### PR TITLE
Merge profile before diff'ing

### DIFF
--- a/operator/cmd/mesh/profile-diff.go
+++ b/operator/cmd/mesh/profile-diff.go
@@ -37,7 +37,7 @@ func addProfileDiffFlags(cmd *cobra.Command, args *profileDiffArgs) {
 
 func profileDiffCmd(rootArgs *rootArgs, pfArgs *profileDiffArgs) *cobra.Command {
 	return &cobra.Command{
-		Use:   "diff <file1.yaml> <file2.yaml>",
+		Use:   "diff <profile|file1.yaml> <profile|file2.yaml>",
 		Short: "Diffs two Istio configuration profiles",
 		Long:  "The diff subcommand displays the differences between two Istio configuration profiles.",
 		Example: `  # Profile diff by providing yaml files

--- a/operator/cmd/mesh/profile-diff.go
+++ b/operator/cmd/mesh/profile-diff.go
@@ -20,8 +20,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"istio.io/istio/operator/pkg/helm"
+	"istio.io/istio/operator/pkg/manifest"
 	"istio.io/istio/operator/pkg/util"
+	"istio.io/istio/operator/pkg/util/clog"
 )
 
 type profileDiffArgs struct {
@@ -60,12 +61,15 @@ func profileDiffCmd(rootArgs *rootArgs, pfArgs *profileDiffArgs) *cobra.Command 
 func profileDiff(cmd *cobra.Command, rootArgs *rootArgs, pfArgs *profileDiffArgs, args []string) error {
 	initLogsOrExit(rootArgs)
 
-	a, err := helm.ReadProfileYAML(args[0], pfArgs.manifestsPath)
+	l := clog.NewConsoleLogger(os.Stdout, os.Stderr, nil)
+	setFlags := []string{fmt.Sprintf("installPackagePath=%s", pfArgs.manifestsPath)}
+
+	a, _, err := manifest.GenIOPFromProfile(args[0], "", setFlags, true, true, nil, l)
 	if err != nil {
 		return fmt.Errorf("could not read %q: %v", args[0], err)
 	}
 
-	b, err := helm.ReadProfileYAML(args[1], pfArgs.manifestsPath)
+	b, _, err := manifest.GenIOPFromProfile(args[1], "", setFlags, true, true, nil, l)
 	if err != nil {
 		return fmt.Errorf("could not read %q: %v", args[1], err)
 	}

--- a/operator/cmd/mesh/profile-diff.go
+++ b/operator/cmd/mesh/profile-diff.go
@@ -79,7 +79,10 @@ func profileDiff(cmd *cobra.Command, rootArgs *rootArgs, pfArgs *profileDiffArgs
 		cmd.Println("Profiles are identical")
 	} else {
 		cmd.Printf("The difference between profiles:\n%s", diff)
-		os.Exit(1)
+		// The command was a success, but we return an error so that the process will
+		// exit with 1.  We don't want to tell the user there was an error because there wasn't.
+		cmd.SilenceErrors = true
+		return fmt.Errorf("dummy")
 	}
 
 	return nil

--- a/operator/cmd/mesh/profile-diff_test.go
+++ b/operator/cmd/mesh/profile-diff_test.go
@@ -1,0 +1,95 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mesh
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"istio.io/istio/pilot/test/util"
+)
+
+type profileDiffTestcase struct {
+	args           string
+	shouldFail     bool
+	expectedString string // String output is expected to contain
+	goldenFilename string // Expected output stored in golden file
+}
+
+func TestProfileDiff(t *testing.T) {
+	cases := []profileDiffTestcase{
+		{
+			args:       "profile diff demo default --unknown-flag",
+			shouldFail: true,
+		},
+		{
+			args:       "profile diff demo",
+			shouldFail: true,
+		},
+		{
+			args:       "profile diff",
+			shouldFail: true,
+		},
+		{
+			args:           fmt.Sprintf("profile diff default default --manifests %s", snapshotCharts),
+			expectedString: "Profiles are identical",
+		},
+		{
+			args:           fmt.Sprintf("profile diff demo demo --manifests %s", snapshotCharts),
+			expectedString: "Profiles are identical",
+		},
+		{
+			args:           fmt.Sprintf("profile diff openshift openshift --manifests %s", snapshotCharts),
+			expectedString: "Profiles are identical",
+		},
+		// TODO diff non-identical profiles (default and demo; default and openshift)
+		// and use golden file to hold the expect difference.
+		// Currently we don't do that because profileDiff() calls os.Exit(1) which
+		// ends the Go test.
+	}
+
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("case %d %q", i, c.args), func(t *testing.T) {
+			verifyProfileDiffCommandCaseOutput(t, c)
+		})
+	}
+}
+
+func verifyProfileDiffCommandCaseOutput(t *testing.T, c profileDiffTestcase) {
+	t.Helper()
+
+	output, fErr := runCommand(c.args)
+	// Note that 'output' doesn't capture stderr
+
+	if c.expectedString != "" && !strings.Contains(output, c.expectedString) {
+		t.Fatalf("Output didn't match for 'istioctl %s'\n got %v\nwant: %v", c.args, output, c.expectedString)
+	}
+
+	if c.goldenFilename != "" {
+		util.CompareContent([]byte(output), c.goldenFilename, t)
+	}
+
+	if c.shouldFail {
+		if fErr == nil {
+			t.Fatalf("Command should have failed for 'istioctl %s', didn't get one, output was %q",
+				c.args, output)
+		}
+	} else {
+		if fErr != nil {
+			t.Fatalf("Command should not have failed for 'istioctl %s': %v", c.args, fErr)
+		}
+	}
+}


### PR DESCRIPTION
Resolves https://github.com/istio/istio/issues/30112

@ostromart @istio/wg-environments-maintainers This subcommand has no unit tests that I could find.

I could easily implement a brittle test that looks for specific output, but I didn't originate this code and lack good ideas for how to make a unit test that doesn't break every time we twiddle with the profiles.  Can someone from Environments comment on the feasibility of testing this?  Or write a unit test?  I was nervous about my implementation of the `--manifests` option, which is needed in Master but not in official releases.  Ideally a unit test would make sure fixes work in both Master (with `--manifests`) and releases (without).

It might be possible to make an integration or doc test if unit testing is too hard.

cc @frankbu 