### PR TITLE
Add version guard in Istiod telemetry filter config for 1.9+ proxies

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -43,6 +43,7 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	istionetworking "istio.io/istio/pilot/pkg/networking"
 	"istio.io/istio/pilot/pkg/networking/plugin"
+	"istio.io/istio/pilot/pkg/networking/plugin/metadataexchange"
 	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pilot/pkg/serviceregistry"
 	xdsfilters "istio.io/istio/pilot/pkg/xds/filters"
@@ -238,6 +239,10 @@ func init() {
 func (configgen *ConfigGeneratorImpl) BuildListeners(node *model.Proxy,
 	push *model.PushContext) []*listener.Listener {
 	builder := NewListenerBuilder(node, push)
+
+	if util.IsIstioVersionGE19(node) {
+		configgen.Plugins = append(configgen.Plugins, metadataexchange.NewPlugin())
+	}
 
 	switch node.Type {
 	case model.SidecarProxy:

--- a/pilot/pkg/networking/networking.go
+++ b/pilot/pkg/networking/networking.go
@@ -15,11 +15,13 @@
 package networking
 
 import (
+	cluster1 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	http_conn "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	thrift_proxy "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/thrift_proxy/v3"
 	tls "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
+	_ "google.golang.org/genproto/googleapis/bigtable/admin/cluster/v1"
 
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pkg/config/protocol"
@@ -118,6 +120,9 @@ type MutableObjects struct {
 
 	// FilterChains is the set of filter chains that will be attached to Listener.
 	FilterChains []FilterChain
+
+	// Cluster is the set of clusters that will be attached to Cluster.
+	Clusters []cluster1.Cluster
 }
 
 const (

--- a/pilot/pkg/networking/plugin/authn/authentication.go
+++ b/pilot/pkg/networking/plugin/authn/authentication.go
@@ -34,6 +34,10 @@ var (
 // Plugin implements Istio mTLS auth
 type Plugin struct{}
 
+func (p Plugin) OnOutboundCluster(mutable *networking.MutableObjects) error {
+	panic("implement me")
+}
+
 // NewPlugin returns an instance of the authn plugin
 func NewPlugin() plugin.Plugin {
 	return Plugin{}

--- a/pilot/pkg/networking/plugin/authz/authorization.go
+++ b/pilot/pkg/networking/plugin/authz/authorization.go
@@ -42,6 +42,10 @@ type Plugin struct {
 	actionType ActionType
 }
 
+func (p Plugin) OnOutboundCluster(mutable *networking.MutableObjects) error {
+	panic("implement me")
+}
+
 // NewPlugin returns an instance of the authorization plugin
 func NewPlugin(actionType ActionType) plugin.Plugin {
 	return Plugin{actionType: actionType}

--- a/pilot/pkg/networking/plugin/metadataexchange/metadataexchange.go
+++ b/pilot/pkg/networking/plugin/metadataexchange/metadataexchange.go
@@ -49,6 +49,10 @@ func (p Plugin) OnOutboundListener(in *plugin.InputParams, mutable *networking.M
 	return buildFilter(in, mutable)
 }
 
+func (p Plugin) OnOutboundCluster(mutable *networking.MutableObjects) error {
+	return buildClusterFilter(mutable)
+}
+
 // OnInboundPassthrough is called whenever a new passthrough filter chain is added to the LDS output.
 // Can be used to add additional filters.
 func (p Plugin) OnInboundPassthrough(in *plugin.InputParams, mutable *networking.MutableObjects) error {
@@ -70,6 +74,13 @@ func buildFilter(in *plugin.InputParams, mutable *networking.MutableObjects) err
 			mutable.FilterChains[i].ListenerProtocol == networking.ListenerProtocolTCP {
 			mutable.FilterChains[i].TCP = append(mutable.FilterChains[i].TCP, xdsfilters.TCPMx)
 		}
+	}
+	return nil
+}
+
+func buildClusterFilter(mutable *networking.MutableObjects) error {
+	for i := range mutable.Clusters {
+		mutable.Clusters[i].Filters = append(mutable.Clusters[i].Filters, xdsfilters.TCPMxClusterFilter)
 	}
 	return nil
 }

--- a/pilot/pkg/networking/plugin/plugin.go
+++ b/pilot/pkg/networking/plugin/plugin.go
@@ -55,6 +55,8 @@ type Plugin interface {
 	// Can be used to add additional filters on the outbound path.
 	OnOutboundListener(in *InputParams, mutable *istionetworking.MutableObjects) error
 
+	OnOutboundCluster(mutable *istionetworking.MutableObjects) error
+
 	// OnInboundListener is called whenever a new listener is added to the LDS output for a given service
 	// Can be used to add additional filters.
 	OnInboundListener(in *InputParams, mutable *istionetworking.MutableObjects) error

--- a/pilot/pkg/xds/filters/filters.go
+++ b/pilot/pkg/xds/filters/filters.go
@@ -16,6 +16,7 @@ package filters
 
 import (
 	udpa "github.com/cncf/udpa/go/udpa/type/v1"
+	cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	cors "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/cors/v3"
@@ -151,6 +152,19 @@ var (
 					}},
 			},
 		})},
+	}
+
+	TCPMxClusterFilter = &cluster.Filter{
+		Name: MxFilterName,
+		TypedConfig: util.MessageToAny(&udpa.TypedStruct{
+			TypeUrl: "type.googleapis.com/envoy.tcp.metadataexchange.config.MetadataExchange",
+			Value: &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"protocol": {
+						Kind: &structpb.Value_StringValue{StringValue: "istio-peer-exchange"},
+					}},
+			},
+		}),
 	}
 
 	HTTPMx = buildHTTPMxFilter()


### PR DESCRIPTION
Please provide a description for what this PR is for.

https://github.com/istio/istio/issues/28410
Only triggering Istiod telemetry filter config for proxy version >= 1.9

Tested locally:
- Installed istio 1.8.2
- Build 1.9 istioctl, and install istio 1.9
- Check the istio-ingressgateway istio-proxy container image is `gcr.io/istio-testing/proxyv2:1.9-dev` and checked the config_dump, there is no duplicate filters being inserted.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
