### PR TITLE
Support proxy concurrency over-rides for gateway deployment

### DIFF
--- a/manifests/charts/gateways/istio-egress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-egress/templates/deployment.yaml
@@ -107,6 +107,8 @@ spec:
           args:
           - proxy
           - router
+          - --concurrency
+          - 0
           - --domain
           - $(POD_NAMESPACE).svc.{{ .Values.global.proxy.clusterDomain }}
         {{- if .Values.global.proxy.logLevel }}

--- a/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
@@ -107,6 +107,8 @@ spec:
           args:
           - proxy
           - router
+          - --concurrency
+          - 0
           - --domain
           - $(POD_NAMESPACE).svc.{{ .Values.global.proxy.clusterDomain }}
         {{- if .Values.global.proxy.logLevel }}

--- a/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
@@ -5239,6 +5239,8 @@ spec:
           args:
           - proxy
           - router
+          - --concurrency
+          - 0
           - --domain
           - $(POD_NAMESPACE).svc.cluster.local
           - --proxyLogLevel=warning
@@ -5491,6 +5493,8 @@ spec:
           args:
           - proxy
           - router
+          - --concurrency
+          - 0
           - --domain
           - $(POD_NAMESPACE).svc.cluster.local
           - --proxyLogLevel=warning

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_values.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_values.golden.yaml
@@ -65,6 +65,8 @@ spec:
           args:
           - proxy
           - router
+          - --concurrency
+          - 0
           - --domain
           - $(POD_NAMESPACE).svc.cluster.local
           - --proxyLogLevel=warning

--- a/operator/cmd/mesh/testdata/manifest-generate/output/helm_values_enablement.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/helm_values_enablement.golden.yaml
@@ -61,6 +61,8 @@ spec:
           args:
           - proxy
           - router
+          - --concurrency
+          - 0
           - --domain
           - $(POD_NAMESPACE).svc.cluster.local
           - --proxyLogLevel=warning

--- a/operator/cmd/mesh/testdata/manifest-generate/output/ingressgateway_k8s_settings.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/ingressgateway_k8s_settings.golden.yaml
@@ -76,6 +76,8 @@ spec:
       - args:
         - proxy
         - router
+        - --concurrency
+        - 0
         - --domain
         - $(POD_NAMESPACE).svc.cluster.local
         - --proxyLogLevel=warning
@@ -322,6 +324,8 @@ spec:
           args:
           - proxy
           - router
+          - --concurrency
+          - 0
           - --domain
           - $(POD_NAMESPACE).svc.cluster.local
           - --proxyLogLevel=warning


### PR DESCRIPTION
Current upstream ref #29374 covers controlling
concurrency using flag instead
of using global values proxyconfig or Meshconfig,
e.g. error
unknown field "concurrency" in v1alpha1.MeshConfig/ProxyConfig

However, PR #29380 adds function determineConcurrencyOption
to determine correct setting for side car based on cpu, mem
requests.

It also adds cpu/mem in in/egress injection templates.
But nodetype router is always set to 0 (meaning use all cpus).

However, user should have capability to over-ride number of threads
on need basis/tunings.

Hence, exposing --concurrency flag for gateway template
so that user can still over-ride number of threads for router.

e.g.set concurrency=20
patches:
- path: spec.template.spec.containers.[name:istio-proxy].args.[3]
  value: 20

via operator using k8s.patches; defaults to 0 always.

Signed-off-by: Aliasgar Ginwala <aginwala@ebay.com>

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
