### PR TITLE
Enhance the namespace isolation of services in buildGatewayHTTPRouteConfig.

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -62,7 +62,6 @@ type serviceIndex struct {
 
 	// HostnameAndNamespace has all services, indexed by hostname then namespace.
 	HostnameAndNamespace map[host.Name]map[string]*Service `json:"-"`
-	Hostname             map[host.Name]*Service            `json:"-"`
 
 	// ClusterVIPs contains a map of service and its cluster addresses. It is stored here
 	// to avoid locking each service for every proxy during push.
@@ -80,7 +79,6 @@ func newServiceIndex() serviceIndex {
 		privateByNamespace:   map[string][]*Service{},
 		exportedToNamespace:  map[string][]*Service{},
 		HostnameAndNamespace: map[host.Name]map[string]*Service{},
-		Hostname:             map[host.Name]*Service{},
 		ClusterVIPs:          map[*Service]map[string]string{},
 		instancesByPort:      map[*Service]map[int][]*ServiceInstance{},
 	}
@@ -1095,7 +1093,6 @@ func (ps *PushContext) initServiceRegistry(env *Environment) error {
 			ps.ServiceIndex.HostnameAndNamespace[s.Hostname] = map[string]*Service{}
 		}
 		ps.ServiceIndex.HostnameAndNamespace[s.Hostname][s.Attributes.Namespace] = s
-		ps.ServiceIndex.Hostname[s.Hostname] = s
 
 		ns := s.Attributes.Namespace
 		if len(s.Attributes.ExportTo) == 0 {

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -684,8 +684,8 @@ func (ps *PushContext) ServiceForHostname(proxy *Proxy, hostname host.Name) *Ser
 	return nil
 }
 
-// IsServiceExportTo returns true if the input service is visible to the given namespace.
-func (ps *PushContext) IsServiceExportTo(service *Service, namespace string) bool {
+// IsServiceVisible returns true if the input service is visible to the given namespace.
+func (ps *PushContext) IsServiceVisible(service *Service, namespace string) bool {
 	if service == nil {
 		return false
 	}

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -697,24 +697,11 @@ func (ps *PushContext) IsServiceExportTo(service *Service, namespace string) boo
 		} else if ps.exportToDefaults.service[visibility.Public] {
 			return true
 		}
-	} else {
-		if service.Attributes.ExportTo[visibility.Public] {
-			return true
-		} else if service.Attributes.ExportTo[visibility.None] {
-			return false
-		} else {
-			// . or other namespaces
-			for exportTo := range service.Attributes.ExportTo {
-				if exportTo == visibility.Private && ns == namespace {
-					return true
-				} else if string(exportTo) == namespace {
-					return true
-				}
-			}
-		}
 	}
 
-	return false
+	return service.Attributes.ExportTo[visibility.Public] ||
+		(service.Attributes.ExportTo[visibility.Private] && ns == namespace) ||
+		service.Attributes.ExportTo[visibility.Instance(namespace)]
 }
 
 // VirtualServicesForGateway lists all virtual services bound to the specified gateways

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -339,7 +339,7 @@ func TestServiceIndex(t *testing.T) {
 	g.Expect(serviceNames(si.privateByNamespace["test1"])).To(Equal([]string{"svc-private"}))
 }
 
-func TestIsServiceExportTo(t *testing.T) {
+func TestIsServiceVisible(t *testing.T) {
 	targetNamespace := "foo"
 	cases := []struct {
 		name        string
@@ -348,7 +348,7 @@ func TestIsServiceExportTo(t *testing.T) {
 		expect      bool
 	}{
 		{
-			name: "service has no exportTo map with global private",
+			name: "service whose namespace is foo has no exportTo map with global private",
 			pushContext: &PushContext{
 				exportToDefaults: exportToDefaults{
 					service: map[visibility.Instance]bool{
@@ -364,7 +364,7 @@ func TestIsServiceExportTo(t *testing.T) {
 			expect: true,
 		},
 		{
-			name: "service has no exportTo map with global private",
+			name: "service whose namespace is bar has no exportTo map with global private",
 			pushContext: &PushContext{
 				exportToDefaults: exportToDefaults{
 					service: map[visibility.Instance]bool{
@@ -380,7 +380,7 @@ func TestIsServiceExportTo(t *testing.T) {
 			expect: false,
 		},
 		{
-			name: "service has no exportTo map with global public",
+			name: "service whose namespace is bar has no exportTo map with global public",
 			pushContext: &PushContext{
 				exportToDefaults: exportToDefaults{
 					service: map[visibility.Instance]bool{
@@ -396,7 +396,7 @@ func TestIsServiceExportTo(t *testing.T) {
 			expect: true,
 		},
 		{
-			name:        "service has exportTo map with private",
+			name:        "service whose namespace is foo has exportTo map with private",
 			pushContext: &PushContext{},
 			service: &Service{
 				Attributes: ServiceAttributes{
@@ -409,7 +409,7 @@ func TestIsServiceExportTo(t *testing.T) {
 			expect: true,
 		},
 		{
-			name:        "service has exportTo map with private",
+			name:        "service whose namespace is bar has exportTo map with private",
 			pushContext: &PushContext{},
 			service: &Service{
 				Attributes: ServiceAttributes{
@@ -422,7 +422,7 @@ func TestIsServiceExportTo(t *testing.T) {
 			expect: false,
 		},
 		{
-			name:        "service has exportTo map with public",
+			name:        "service whose namespace is bar has exportTo map with public",
 			pushContext: &PushContext{},
 			service: &Service{
 				Attributes: ServiceAttributes{
@@ -435,7 +435,7 @@ func TestIsServiceExportTo(t *testing.T) {
 			expect: true,
 		},
 		{
-			name:        "service has exportTo map with specific namespace",
+			name:        "service whose namespace is bar has exportTo map with specific namespace foo",
 			pushContext: &PushContext{},
 			service: &Service{
 				Attributes: ServiceAttributes{
@@ -448,7 +448,7 @@ func TestIsServiceExportTo(t *testing.T) {
 			expect: true,
 		},
 		{
-			name:        "service has exportTo map with specific namespace",
+			name:        "service whose namespace is bar has exportTo map with specific namespace baz",
 			pushContext: &PushContext{},
 			service: &Service{
 				Attributes: ServiceAttributes{
@@ -464,7 +464,7 @@ func TestIsServiceExportTo(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			isVisible := c.pushContext.IsServiceExportTo(c.service, targetNamespace)
+			isVisible := c.pushContext.IsServiceVisible(c.service, targetNamespace)
 
 			g := NewWithT(t)
 			g.Expect(isVisible).To(Equal(c.expect))

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -327,7 +327,6 @@ func TestServiceIndex(t *testing.T) {
 	g.Expect(si.instancesByPort).To(HaveLen(5))
 	g.Expect(si.ClusterVIPs).To(HaveLen(5))
 	g.Expect(si.HostnameAndNamespace).To(HaveLen(5))
-	g.Expect(si.Hostname).To(HaveLen(5))
 
 	// Should just have "namespace"
 	g.Expect(si.exportedToNamespace).To(HaveLen(1))

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -339,7 +339,7 @@ func TestServiceIndex(t *testing.T) {
 	g.Expect(serviceNames(si.privateByNamespace["test1"])).To(Equal([]string{"svc-private"}))
 }
 
-func TestIsServiceExportToProxy(t *testing.T) {
+func TestIsServiceExportTo(t *testing.T) {
 	targetNamespace := "foo"
 	cases := []struct {
 		name        string

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -342,11 +342,11 @@ func TestServiceIndex(t *testing.T) {
 func TestIsServiceExportToProxy(t *testing.T) {
 	targetNamespace := "foo"
 	cases := []struct {
-		name string
+		name        string
 		pushContext *PushContext
-		service *Service
-		expect bool
-	} {
+		service     *Service
+		expect      bool
+	}{
 		{
 			name: "service has no exportTo map with global private",
 			pushContext: &PushContext{
@@ -396,7 +396,7 @@ func TestIsServiceExportToProxy(t *testing.T) {
 			expect: true,
 		},
 		{
-			name: "service has exportTo map with private",
+			name:        "service has exportTo map with private",
 			pushContext: &PushContext{},
 			service: &Service{
 				Attributes: ServiceAttributes{
@@ -409,7 +409,7 @@ func TestIsServiceExportToProxy(t *testing.T) {
 			expect: true,
 		},
 		{
-			name: "service has exportTo map with private",
+			name:        "service has exportTo map with private",
 			pushContext: &PushContext{},
 			service: &Service{
 				Attributes: ServiceAttributes{
@@ -422,7 +422,7 @@ func TestIsServiceExportToProxy(t *testing.T) {
 			expect: false,
 		},
 		{
-			name: "service has exportTo map with public",
+			name:        "service has exportTo map with public",
 			pushContext: &PushContext{},
 			service: &Service{
 				Attributes: ServiceAttributes{
@@ -435,7 +435,7 @@ func TestIsServiceExportToProxy(t *testing.T) {
 			expect: true,
 		},
 		{
-			name: "service has exportTo map with specific namespace",
+			name:        "service has exportTo map with specific namespace",
 			pushContext: &PushContext{},
 			service: &Service{
 				Attributes: ServiceAttributes{
@@ -448,7 +448,7 @@ func TestIsServiceExportToProxy(t *testing.T) {
 			expect: true,
 		},
 		{
-			name: "service has exportTo map with specific namespace",
+			name:        "service has exportTo map with specific namespace",
 			pushContext: &PushContext{},
 			service: &Service{
 				Attributes: ServiceAttributes{

--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -201,7 +201,7 @@ func buildNameToServiceMapForHTTPRoutes(node *model.Proxy, push *model.PushConte
 		s, exist := push.ServiceIndex.HostnameAndNamespace[hostname][virtualService.Namespace]
 		if exist {
 			// We should check whether the selected service is visible to the proxy node.
-			if push.IsServiceExportTo(s, node.ConfigNamespace) {
+			if push.IsServiceVisible(s, node.ConfigNamespace) {
 				service = s
 			}
 		}

--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -185,7 +185,7 @@ func (configgen *ConfigGeneratorImpl) buildGatewayListeners(builder *ListenerBui
 	return builder
 }
 
-func buildNameToServiceMapForHttpRoutes(push *model.PushContext,
+func buildNameToServiceMapForHTTPRoutes(push *model.PushContext,
 	virtualService config.Config) map[host.Name]*model.Service {
 
 	vs := virtualService.Spec.(*networking.VirtualService)
@@ -293,7 +293,7 @@ func (configgen *ConfigGeneratorImpl) buildGatewayHTTPRouteConfig(node *model.Pr
 			}
 
 			// Make sure we can obtain services which are visible to this virtualService as much as possible.
-			nameToServiceMap := buildNameToServiceMapForHttpRoutes(push, virtualService)
+			nameToServiceMap := buildNameToServiceMapForHTTPRoutes(push, virtualService)
 
 			var routes []*route.Route
 			var exists bool

--- a/pilot/pkg/networking/core/v1alpha3/gateway_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway_test.go
@@ -1602,7 +1602,7 @@ func TestBuildNameToServiceMapForHttpRoutes(t *testing.T) {
 	}
 
 	cg := NewConfigGenTest(t, TestOptions{
-		Configs: []config.Config{virtualService},
+		Configs:  []config.Config{virtualService},
 		Services: []*pilot_model.Service{fooServiceInTestNamespace, barServiceInDefaultNamespace, bazServiceInDefaultNamespace},
 	})
 	proxy := &pilot_model.Proxy{

--- a/pilot/pkg/networking/core/v1alpha3/gateway_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway_test.go
@@ -1606,7 +1606,7 @@ func TestBuildNameToServiceMapForHttpRoutes(t *testing.T) {
 	push.ServiceIndex.HostnameAndNamespace[barHostName] = map[string]*pilot_model.Service{}
 	push.ServiceIndex.HostnameAndNamespace[barHostName]["test"] = barServiceInTestNamespace
 
-	nameToServiceMap := buildNameToServiceMapForHttpRoutes(push, virtualService)
+	nameToServiceMap := buildNameToServiceMapForHTTPRoutes(push, virtualService)
 
 	if len(nameToServiceMap) != 2 {
 		t.Errorf("The length of nameToServiceMap is wrong.")


### PR DESCRIPTION
Suppose there are services with the same hostname but in different namespaces, and these services are only visible to the namespace where they are located. When we are building a cluster key from the Destination in HTTPRoute, in order to comply with the visibility specified by the ExportTo attribute of the Service, we need to obtain a service with the same namespace as the VirtualService from PushConext. 

However, the current code just gets the service directly based on the hostname, without considering the issue of visibility.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
