### PR TITLE
Update min k8 supported version for Istio 1.9

### DIFF
--- a/istioctl/pkg/install/k8sversion/version.go
+++ b/istioctl/pkg/install/k8sversion/version.go
@@ -29,7 +29,7 @@ import (
 const (
 	// MinK8SVersion is the minimum k8s version required to run this version of Istio
 	// https://istio.io/docs/setup/platform-setup/
-	MinK8SVersion = 16
+	MinK8SVersion = 18
 )
 
 // CheckKubernetesVersion checks if this Istio version is supported in the k8s version

--- a/istioctl/pkg/install/k8sversion/version.go
+++ b/istioctl/pkg/install/k8sversion/version.go
@@ -29,7 +29,7 @@ import (
 const (
 	// MinK8SVersion is the minimum k8s version required to run this version of Istio
 	// https://istio.io/docs/setup/platform-setup/
-	MinK8SVersion = 18
+	MinK8SVersion = 17
 )
 
 // CheckKubernetesVersion checks if this Istio version is supported in the k8s version

--- a/istioctl/pkg/install/k8sversion/version_test.go
+++ b/istioctl/pkg/install/k8sversion/version_test.go
@@ -27,6 +27,11 @@ var (
 		Minor:      "17",
 		GitVersion: "1.17",
 	}
+	version1_8 = &version.Info{
+		Major:      "1",
+		Minor:      "8",
+		GitVersion: "v1.8",
+	}
 	version1_18 = &version.Info{
 		Major:      "1",
 		Minor:      "18",
@@ -79,6 +84,12 @@ func TestExtractKubernetesVersion(t *testing.T) {
 		{
 			version:  version1_17,
 			expected: 17,
+			errMsg:   nil,
+			isValid:  true,
+		},
+		{
+			version:  version1_8,
+			expected: 8,
 			errMsg:   nil,
 			isValid:  true,
 		},

--- a/istioctl/pkg/install/k8sversion/version_test.go
+++ b/istioctl/pkg/install/k8sversion/version_test.go
@@ -22,6 +22,11 @@ import (
 )
 
 var (
+	version1_17 = &version.Info{
+		Major:      "1",
+		Minor:      "17",
+		GitVersion: "1.17",
+	}
 	version1_18 = &version.Info{
 		Major:      "1",
 		Minor:      "18",
@@ -71,6 +76,12 @@ func TestExtractKubernetesVersion(t *testing.T) {
 		errMsg   error
 		isValid  bool
 	}{
+		{
+			version:  version1_17,
+			expected: 17,
+			errMsg:   nil,
+			isValid:  true,
+		},
 		{
 			version:  version1_18,
 			expected: 18,

--- a/istioctl/pkg/install/k8sversion/version_test.go
+++ b/istioctl/pkg/install/k8sversion/version_test.go
@@ -22,25 +22,20 @@ import (
 )
 
 var (
-	version1_16 = &version.Info{
+	version1_18 = &version.Info{
 		Major:      "1",
-		Minor:      "16",
-		GitVersion: "1.16",
-	}
-	version1_17 = &version.Info{
-		Major:      "1",
-		Minor:      "17",
-		GitVersion: "1.17",
-	}
-	version1_8 = &version.Info{
-		Major:      "1",
-		Minor:      "8",
-		GitVersion: "1.8",
+		Minor:      "18",
+		GitVersion: "v1.18.5",
 	}
 	version1_19 = &version.Info{
 		Major:      "1",
 		Minor:      "19",
 		GitVersion: "v1.19.4",
+	}
+	version1_20 = &version.Info{
+		Major:      "1",
+		Minor:      "20",
+		GitVersion: "v1.20.2",
 	}
 	version1_19RC = &version.Info{
 		Major:      "1",
@@ -77,26 +72,20 @@ func TestExtractKubernetesVersion(t *testing.T) {
 		isValid  bool
 	}{
 		{
-			version:  version1_16,
-			expected: 16,
-			errMsg:   nil,
-			isValid:  true,
-		},
-		{
-			version:  version1_17,
-			expected: 17,
-			errMsg:   nil,
-			isValid:  true,
-		},
-		{
-			version:  version1_8,
-			expected: 8,
+			version:  version1_18,
+			expected: 18,
 			errMsg:   nil,
 			isValid:  true,
 		},
 		{
 			version:  version1_19,
 			expected: 19,
+			errMsg:   nil,
+			isValid:  true,
+		},
+		{
+			version:  version1_20,
+			expected: 20,
 			errMsg:   nil,
 			isValid:  true,
 		},

--- a/istioctl/pkg/install/pre-check_test.go
+++ b/istioctl/pkg/install/pre-check_test.go
@@ -38,10 +38,10 @@ type testcase struct {
 }
 
 var (
-	version1_18 = &version.Info{
+	version1_17 = &version.Info{
 		Major:      "1",
-		Minor:      "18",
-		GitVersion: "1.18",
+		Minor:      "17",
+		GitVersion: "1.17",
 	}
 	version1_8 = &version.Info{
 		Major:      "1",
@@ -50,8 +50,8 @@ var (
 	}
 	version1_17GKE = &version.Info{
 		Major:      "1",
-		Minor:      "18+",
-		GitVersion: "v1.18.2-gke.10",
+		Minor:      "17+",
+		GitVersion: "v1.17.7-gke.10",
 	}
 	version1_8GKE = &version.Info{
 		Major:      "1",
@@ -101,21 +101,21 @@ func TestPreCheck(t *testing.T) {
 		},
 		{description: "Invalid Istio System",
 			config: &mockClientExecPreCheckConfig{
-				version:   version1_18,
+				version:   version1_17,
 				namespace: "istio-system",
 			},
 			expectedException: false, // It is fine to precheck an existing namespace; we might be installing canary control plane
 		},
 		{description: "Valid Istio System",
 			config: &mockClientExecPreCheckConfig{
-				version:   version1_18,
+				version:   version1_17,
 				namespace: "test",
 			},
 			expectedException: false,
 		},
 		{description: "Lacking Permission",
 			config: &mockClientExecPreCheckConfig{
-				version:   version1_18,
+				version:   version1_17,
 				namespace: "test",
 				authConfig: &authorizationapi.SelfSubjectAccessReview{
 					Spec: authorizationapi.SelfSubjectAccessReviewSpec{
@@ -133,7 +133,7 @@ func TestPreCheck(t *testing.T) {
 		},
 		{description: "Valid Case",
 			config: &mockClientExecPreCheckConfig{
-				version:   version1_18,
+				version:   version1_17,
 				namespace: "test",
 			},
 		},

--- a/istioctl/pkg/install/pre-check_test.go
+++ b/istioctl/pkg/install/pre-check_test.go
@@ -38,10 +38,10 @@ type testcase struct {
 }
 
 var (
-	version1_17 = &version.Info{
+	version1_18 = &version.Info{
 		Major:      "1",
-		Minor:      "17",
-		GitVersion: "1.17",
+		Minor:      "18",
+		GitVersion: "1.18",
 	}
 	version1_8 = &version.Info{
 		Major:      "1",
@@ -50,8 +50,8 @@ var (
 	}
 	version1_17GKE = &version.Info{
 		Major:      "1",
-		Minor:      "17+",
-		GitVersion: "v1.17.7-gke.10",
+		Minor:      "18+",
+		GitVersion: "v1.18.2-gke.10",
 	}
 	version1_8GKE = &version.Info{
 		Major:      "1",
@@ -101,21 +101,21 @@ func TestPreCheck(t *testing.T) {
 		},
 		{description: "Invalid Istio System",
 			config: &mockClientExecPreCheckConfig{
-				version:   version1_17,
+				version:   version1_18,
 				namespace: "istio-system",
 			},
 			expectedException: false, // It is fine to precheck an existing namespace; we might be installing canary control plane
 		},
 		{description: "Valid Istio System",
 			config: &mockClientExecPreCheckConfig{
-				version:   version1_17,
+				version:   version1_18,
 				namespace: "test",
 			},
 			expectedException: false,
 		},
 		{description: "Lacking Permission",
 			config: &mockClientExecPreCheckConfig{
-				version:   version1_17,
+				version:   version1_18,
 				namespace: "test",
 				authConfig: &authorizationapi.SelfSubjectAccessReview{
 					Spec: authorizationapi.SelfSubjectAccessReviewSpec{
@@ -133,7 +133,7 @@ func TestPreCheck(t *testing.T) {
 		},
 		{description: "Valid Case",
 			config: &mockClientExecPreCheckConfig{
-				version:   version1_17,
+				version:   version1_18,
 				namespace: "test",
 			},
 		},

--- a/releasenotes/notes/min-k8-ver-for-1.9.yaml
+++ b/releasenotes/notes/min-k8-ver-for-1.9.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+issue:
+- 30176
+releaseNotes:
+- |
+  **Added** Istio 1.9 supports kubernetes versions 1.18 to 1.21.

--- a/releasenotes/notes/min-k8-ver-for-1.9.yaml
+++ b/releasenotes/notes/min-k8-ver-for-1.9.yaml
@@ -5,4 +5,4 @@ issue:
 - 30176
 releaseNotes:
 - |
-  **Added** Istio 1.9 supports kubernetes versions 1.17 to 1.20.
+  **Added** Istio 1.9 supports Kubernetes versions 1.17 to 1.20.

--- a/releasenotes/notes/min-k8-ver-for-1.9.yaml
+++ b/releasenotes/notes/min-k8-ver-for-1.9.yaml
@@ -5,4 +5,4 @@ issue:
 - 30176
 releaseNotes:
 - |
-  **Added** Istio 1.9 supports kubernetes versions 1.18 to 1.21.
+  **Added** Istio 1.9 supports kubernetes versions 1.17 to 1.20.


### PR DESCRIPTION
Ref: https://docs.google.com/document/d/14Xfe9V0vv8d7W75c21d-cY2XyK6xvRH0_Kg8j_zfh4Y/edit#

Istio `1.9` supports k8 `1.17` to `1.20` versions.

Previous change:
https://github.com/istio/istio/pull/28814