### PR TITLE
Add warning for mismatch injector versions

### DIFF
--- a/istioctl/cmd/kubeinject.go
+++ b/istioctl/cmd/kubeinject.go
@@ -104,7 +104,7 @@ func getValuesFromConfigMap(kubeconfig string) (string, error) {
 func readInjectConfigFile(f []byte) (inject.Templates, error) {
 	var injectConfig inject.Config
 	err := yaml.Unmarshal(f, &injectConfig)
-	if err != nil || len(injectConfig.Templates) == 0 && len(injectConfig.Template) == 0 {
+	if err != nil || len(injectConfig.Templates) == 0 {
 		// This must be a direct template, instead of an inject.Config. We support both formats
 		return map[string]string{inject.SidecarTemplateName: string(f)}, nil
 	}
@@ -305,8 +305,8 @@ kube-inject on deployments to get the most up-to-date changes.
 
 			if emitTemplate {
 				cfg := inject.Config{
-					Policy:   inject.InjectionPolicyEnabled,
-					Template: sidecarTemplate[inject.SidecarTemplateName],
+					Policy:    inject.InjectionPolicyEnabled,
+					Templates: sidecarTemplate,
 				}
 				out, err := yaml.Marshal(&cfg)
 				if err != nil {

--- a/istioctl/cmd/testdata/inject-config.yaml
+++ b/istioctl/cmd/testdata/inject-config.yaml
@@ -1,8 +1,9 @@
-template: |-
-  spec:
-    initContainers:
-    - name: istio-init
-      image: docker.io/istio/proxy_init:unittest-{{.Values.global.suffix}}
-    containers:
-    - name: istio-proxy
-      image: docker.io/istio/proxy_debug:unittest
+templates:
+  sidecar: |-
+    spec:
+      initContainers:
+      - name: istio-init
+        image: docker.io/istio/proxy_init:unittest-{{.Values.global.suffix}}
+      containers:
+      - name: istio-proxy
+        image: docker.io/istio/proxy_debug:unittest

--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -200,6 +200,7 @@ data:
     neverInjectSelector:
       []
     injectedAnnotations:
+    template: "{{ Template_Version_And_Istio_Version_Mismatched_Check_Installation }}"
     templates:
       sidecar: |
         {{- $containers := list }}

--- a/manifests/charts/istio-control/istio-discovery/templates/istiod-injector-configmap.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/istiod-injector-configmap.yaml
@@ -32,6 +32,11 @@ data:
       {{- range $key, $val := .Values.sidecarInjectorWebhook.injectedAnnotations }}
       "{{ $key }}": "{{ $val }}"
       {{- end }}
+    {{- /* If someone ends up with this new template, but an older Istiod image, they will attempt to render this template
+         which will fail with "Pod injection failed: template: inject:1: function "Istio_1_9_Required_Template_And_Version_Mismatched" not defined".
+         This should make it obvious that their installation is broken.
+     */}}
+    template: {{ `{{ Template_Version_And_Istio_Version_Mismatched_Check_Installation }}` | quote }}
     templates:
 {{- if not (hasKey .Values.sidecarInjectorWebhook.templates "sidecar") }}
       sidecar: |

--- a/manifests/charts/istiod-remote/files/gen-istiod-remote.yaml
+++ b/manifests/charts/istiod-remote/files/gen-istiod-remote.yaml
@@ -180,6 +180,7 @@ data:
     neverInjectSelector:
       []
     injectedAnnotations:
+    template: "{{ Template_Version_And_Istio_Version_Mismatched_Check_Installation }}"
     templates:
       sidecar: |
         {{- $containers := list }}

--- a/manifests/charts/istiod-remote/templates/istiod-injector-configmap.yaml
+++ b/manifests/charts/istiod-remote/templates/istiod-injector-configmap.yaml
@@ -32,6 +32,11 @@ data:
       {{- range $key, $val := .Values.sidecarInjectorWebhook.injectedAnnotations }}
       "{{ $key }}": "{{ $val }}"
       {{- end }}
+    {{- /* If someone ends up with this new template, but an older Istiod image, they will attempt to render this template
+         which will fail with "Pod injection failed: template: inject:1: function "Istio_1_9_Required_Template_And_Version_Mismatched" not defined".
+         This should make it obvious that their installation is broken.
+     */}}
+    template: {{ `{{ Template_Version_And_Istio_Version_Mismatched_Check_Installation }}` | quote }}
     templates:
 {{- if not (hasKey .Values.sidecarInjectorWebhook.templates "sidecar") }}
       sidecar: |

--- a/pkg/kube/inject/webhook.go
+++ b/pkg/kube/inject/webhook.go
@@ -26,7 +26,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ghodss/yaml"
 	"gomodules.xyz/jsonpatch/v3"
 	kubeApiAdmissionv1 "k8s.io/api/admission/v1"
 	kubeApiAdmissionv1beta1 "k8s.io/api/admission/v1beta1"
@@ -752,16 +751,6 @@ func applyOverlay(target *corev1.Pod, overlayJSON []byte) (*corev1.Pod, error) {
 		return nil, fmt.Errorf("unmarshal patched pod: %v", err)
 	}
 	return &pod, nil
-}
-
-func mergeInjectedConfig(req *corev1.Pod, injected []byte) (*corev1.Pod, error) {
-	// The template is yaml, StrategicMergePatch expects JSON
-	injectedJSON, err := yaml.YAMLToJSON(injected)
-	if err != nil {
-		return nil, fmt.Errorf("yaml to json: %v", err)
-	}
-
-	return applyOverlay(req, injectedJSON)
 }
 
 func (wh *Webhook) inject(ar *kube.AdmissionReview, path string) *kube.AdmissionResponse {


### PR DESCRIPTION
We have seen some reports of users have mismatched Istiod and injection templates. This is not valid, nor has it ever been valid. This makes this much easier to debug.

This fixes both directions of mismatch:

* Old istiod, new template: It will hard fail to parse the template
* New Istiod, old template: It will *warn* due to empty template. I was a bit scared to fail, but maybe we should
