### PR TITLE
Switch inbound clusters to ORIGINAL_DST

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -421,4 +421,14 @@ var (
 		20*time.Minute,
 		"The interval for istiod to fetch the jwks_uri for the jwks public key.",
 	).Get()
+
+	EnableInboundPassthrough = env.RegisterBoolVar(
+		"PILOT_ENABLE_INBOUND_PASSTHROUGH",
+		true,
+		"If enabled, inbound clusters will be configured as ORIGINAL_DST clusters. When disabled, "+
+			"requests are always sent to localhost. The primary implication of this is that when enabled, binding to POD_IP "+
+			"will work while localhost will not; when disable, bind to POD_IP will not work, while localhost will. "+
+			"The enabled behavior matches the behavior without Istio enabled at all; this flag exists only for backwards compatibility. "+
+			"Regardless of this setting, the configuration can be overridden with the Sidecar.Ingress.DefaultEndpoint configuration.",
+	).Get()
 )

--- a/pilot/pkg/model/validation.go
+++ b/pilot/pkg/model/validation.go
@@ -27,8 +27,9 @@ import (
 // UnixAddressPrefix is the prefix used to indicate an address is for a Unix Domain socket. It is used in
 // ServiceEntry.Endpoint.Address message.
 const (
-	UnixAddressPrefix  = "unix://"
-	PodIPAddressPrefix = "0.0.0.0"
+	UnixAddressPrefix      = "unix://"
+	PodIPAddressPrefix     = "0.0.0.0"
+	LocalhostAddressPrefix = "127.0.0.1"
 )
 
 // Validate ensures that the service object is well-defined

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -240,6 +240,9 @@ func (configgen *ConfigGeneratorImpl) buildOutboundSniDnatClusters(proxy *model.
 }
 
 func buildInboundLocalityLbEndpoints(bind string, port uint32) []*endpoint.LocalityLbEndpoints {
+	if bind == "" {
+		return nil
+	}
 	address := util.BuildAddress(bind, port)
 	lbEndpoint := &endpoint.LbEndpoint{
 		HostIdentifier: &endpoint.LbEndpoint_Endpoint{
@@ -294,10 +297,14 @@ func (configgen *ConfigGeneratorImpl) buildInboundClusters(cb *ClusterBuilder, i
 			clustersToBuild[ep] = append(clustersToBuild[ep], instance)
 		}
 
+		bind := actualLocalHost
+		if features.EnableInboundPassthrough {
+			bind = ""
+		}
 		// For each workload port, we will construct a cluster
 		for _, instances := range clustersToBuild {
 			instance := instances[0]
-			localCluster := cb.buildInboundClusterForPortOrUDS(int(instance.Endpoint.EndpointPort), actualLocalHost, instance, instances)
+			localCluster := cb.buildInboundClusterForPortOrUDS(int(instance.Endpoint.EndpointPort), bind, instance, instances)
 			// If inbound cluster match has service, we should see if it matches with any host name across all instances.
 			var hosts []host.Name
 			for _, si := range instances {
@@ -320,25 +327,25 @@ func (configgen *ConfigGeneratorImpl) buildInboundClusters(cb *ClusterBuilder, i
 		// When building an inbound cluster for the ingress listener, we take the defaultEndpoint specified
 		// by the user and parse it into host:port or a unix domain socket
 		// The default endpoint can be 127.0.0.1:port or :port or unix domain socket
-		endpointAddress := actualLocalHost
+		endpointAddress := ""
 		port := 0
-		var err error
-		instanceIPCluster := false
 		if strings.HasPrefix(ingressListener.DefaultEndpoint, model.UnixAddressPrefix) {
 			// this is a UDS endpoint. assign it as is
 			endpointAddress = ingressListener.DefaultEndpoint
-		} else {
+		} else if len(ingressListener.DefaultEndpoint) > 0 {
 			// parse the ip, port. Validation guarantees presence of :
 			parts := strings.Split(ingressListener.DefaultEndpoint, ":")
 			if len(parts) < 2 {
 				continue
 			}
+			var err error
 			if port, err = strconv.Atoi(parts[1]); err != nil {
 				continue
 			}
 			if parts[0] == model.PodIPAddressPrefix {
 				endpointAddress = cb.proxy.IPAddresses[0]
-				instanceIPCluster = true
+			} else if parts[0] == model.LocalhostAddressPrefix {
+				endpointAddress = actualLocalHost
 			}
 		}
 
@@ -352,19 +359,6 @@ func (configgen *ConfigGeneratorImpl) buildInboundClusters(cb *ClusterBuilder, i
 		instance.Endpoint.EndpointPort = uint32(port)
 
 		localCluster := cb.buildInboundClusterForPortOrUDS(int(ingressListener.Port.Number), endpointAddress, instance, nil)
-		if instanceIPCluster {
-			// IPTables will redirect our own traffic back to us if we do not use the "magic" upstream bind
-			// config which will be skipped. This mirrors the "passthrough" clusters.
-			// TODO: consider moving all clusters to use this for consistency.
-			localCluster.UpstreamBindConfig = &core.BindConfig{
-				SourceAddress: &core.SocketAddress{
-					Address: util.InboundPassthroughBindIpv4,
-					PortSpecifier: &core.SocketAddress_PortValue{
-						PortValue: uint32(0),
-					},
-				},
-			}
-		}
 		clusters = cp.conditionallyAppend(clusters, []host.Name{instance.Service.Hostname}, localCluster)
 	}
 
@@ -616,6 +610,8 @@ func applyTrafficPolicy(opts buildClusterOpts) {
 		applyH2Upgrade(opts, connectionPool)
 		applyOutlierDetection(opts.cluster, outlierDetection)
 		applyLoadBalancer(opts.cluster, loadBalancer, opts.port, opts.proxy, opts.mesh)
+	} else if opts.cluster.GetType() == cluster.Cluster_ORIGINAL_DST {
+		opts.cluster.LbPolicy = cluster.Cluster_CLUSTER_PROVIDED
 	}
 
 	if opts.clusterMode != SniDnatClusterMode && opts.direction != model.TrafficDirectionInbound {

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -29,7 +29,6 @@ import (
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/util/gogo"
-	"istio.io/pkg/log"
 )
 
 var defaultDestinationRule = networking.DestinationRule{}
@@ -264,7 +263,6 @@ func (cb *ClusterBuilder) buildInboundClusterForPortOrUDS(clusterPort int, bind 
 	if len(localityLbEndpoints) > 0 {
 		clusterType = cluster.Cluster_STATIC
 	}
-	log.Errorf("howardjohn: %v %v %v %v", clusterPort, bind, len(localityLbEndpoints), clusterType)
 	localCluster := cb.buildDefaultCluster(clusterName, clusterType, localityLbEndpoints,
 		model.TrafficDirectionInbound, instance.ServicePort, instance.Service, allInstance)
 	// If stat name is configured, build the alt statname.
@@ -291,7 +289,7 @@ func (cb *ClusterBuilder) buildInboundClusterForPortOrUDS(clusterPort int, bind 
 		}
 	}
 	if bind != LocalhostAddress && bind != LocalhostIPv6Address {
-		// IPTables will redirect our own traffic to localhost back to us if we do not use the "magic" upstream bind
+		// iptables will redirect our own traffic to localhost back to us if we do not use the "magic" upstream bind
 		// config which will be skipped.
 		localCluster.UpstreamBindConfig = &core.BindConfig{
 			SourceAddress: &core.SocketAddress{

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -2112,6 +2112,13 @@ func getActualWildcardAndLocalHost(node *model.Proxy) (string, string) {
 	return WildcardIPv6Address, LocalhostIPv6Address
 }
 
+func getPassthroughBindIP(node *model.Proxy) string {
+	if node.SupportsIPv4() {
+		return util.InboundPassthroughBindIpv4
+	}
+	return util.InboundPassthroughBindIpv6
+}
+
 // getSidecarInboundBindIP returns the IP that the proxy can bind to along with the sidecar specified port.
 // It looks for an unicast address, if none found, then the default wildcard address is used.
 // This will make the inbound listener bind to instance_ip:port instead of 0.0.0.0:port where applicable.

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -860,9 +860,7 @@ var ValidateSidecar = registerValidateFunc("ValidateSidecar",
 			}
 			portMap[i.Port.Number] = struct{}{}
 
-			if len(i.DefaultEndpoint) == 0 {
-				errs = appendErrors(errs, fmt.Errorf("sidecar: default endpoint must be set for all ingress listeners"))
-			} else {
+			if len(i.DefaultEndpoint) != 0 {
 				if strings.HasPrefix(i.DefaultEndpoint, UnixAddressPrefix) {
 					errs = appendErrors(errs, ValidateUnixAddress(strings.TrimPrefix(i.DefaultEndpoint, UnixAddressPrefix)))
 				} else {

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -5163,7 +5163,7 @@ func TestValidateSidecar(t *testing.T) {
 					Hosts: []string{"*/*"},
 				},
 			},
-		}, false},
+		}, true},
 		{"ingress with invalid default endpoint IP", &networking.Sidecar{
 			Ingress: []*networking.IstioIngressListener{
 				{

--- a/releasenotes/notes/inbound-passthrough.yaml
+++ b/releasenotes/notes/inbound-passthrough.yaml
@@ -1,0 +1,44 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: networking
+issue:
+- 29940
+upradeNotes:
+  title: Inbound Forwarding Configuration
+  content: |
+    The behavior of inbound forwarding will be modified in the near future. While this change is not enabled
+    by default in Istio 1.10, it will can be enabled today by configuring the `PILOT_ENABLE_INBOUND_PASSTHROUGH=true` environment
+    variable in Istiod.
+
+    Previously, requests would be forwarded to `localhost`. This leads to two important differences compared to running applications
+    without Istio:
+
+    * Applications that bind to `localhost` will be exposed to external pods.
+    * Applications that bind to `<POD_IP>` will not be exposed to external pods.
+
+    The latter is a common source of friction when adopting Istio, in particular with stateful services where this is common.
+
+    The new behavior instead forwards the request as is. This matches the behavior a user would see without Istio installed.
+    However, as a result, applications that have come to rely on `localhost` being exposed externally by Istio, may stop working.
+
+    The [check-binds.sh](https://gist.github.com/howardjohn/edcdbe5a85ae2e5ba7809739bd55c566) script can be used to detect what binds your applications are using.
+
+    Regardless of Istio version, the behavior can be explicitly controlled by the `Sidecar`.
+    For example, to configure the 9080 port to explicitly be sent to localhost:
+
+    ```yaml
+    apiVersion: networking.istio.io/v1beta1
+    kind: Sidecar
+    metadata:
+      name: ratings
+    spec:
+      workloadSelector:
+        labels:
+          app: ratings
+      ingress:
+      - port:
+          number: 9080
+          protocol: HTTP
+          name: http
+        defaultEndpoint: 127.0.0.1:9080
+    ```

--- a/releasenotes/notes/inbound-passthrough.yaml
+++ b/releasenotes/notes/inbound-passthrough.yaml
@@ -7,7 +7,7 @@ upradeNotes:
   title: Inbound Forwarding Configuration
   content: |
     The behavior of inbound forwarding will be modified in the near future. While this change is not enabled
-    by default in Istio 1.10, it will can be enabled today by configuring the `PILOT_ENABLE_INBOUND_PASSTHROUGH=true` environment
+    by default in Istio 1.10, it can be enabled today by configuring the `PILOT_ENABLE_INBOUND_PASSTHROUGH=true` environment
     variable in Istiod.
 
     Previously, requests would be forwarded to `localhost`. This leads to two important differences compared to running applications

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -945,7 +945,7 @@ func instanceIPTests(apps *EchoDeployments) []TrafficTestCase {
 			name:           "instance IP without sidecar",
 			disableSidecar: true,
 			port:           "http-instance",
-			code:           503,
+			code:           200,
 		},
 		{
 			name:     "instance IP with wildcard sidecar",
@@ -959,13 +959,19 @@ func instanceIPTests(apps *EchoDeployments) []TrafficTestCase {
 			port:     "http-instance",
 			code:     503,
 		},
+		{
+			name:     "instance IP with empty sidecar",
+			endpoint: "",
+			port:     "http-instance",
+			code:     200,
+		},
 
 		// Localhost bind
 		{
 			name:           "localhost IP without sidecar",
 			disableSidecar: true,
 			port:           "http-localhost",
-			code:           200,
+			code:           503,
 		},
 		{
 			name:     "localhost IP with wildcard sidecar",
@@ -978,6 +984,12 @@ func instanceIPTests(apps *EchoDeployments) []TrafficTestCase {
 			endpoint: "127.0.0.1",
 			port:     "http-localhost",
 			code:     200,
+		},
+		{
+			name:     "localhost IP with empty sidecar",
+			endpoint: "",
+			port:     "http-localhost",
+			code:     503,
 		},
 
 		// Wildcard bind
@@ -996,6 +1008,12 @@ func instanceIPTests(apps *EchoDeployments) []TrafficTestCase {
 		{
 			name:     "wildcard IP with localhost sidecar",
 			endpoint: "127.0.0.1",
+			port:     "http",
+			code:     200,
+		},
+		{
+			name:     "wildcard IP with empty sidecar",
+			endpoint: "",
 			port:     "http",
 			code:     200,
 		},


### PR DESCRIPTION
This implements the design in https://docs.google.com/document/d/1j-5_XpeMTnT9mV_8dbSOeU7rfH-5YNtN_JJFZ2mmQ_w/edit#.

Tl;dr: change inbound cluster from `STATIC` to `ORIGINAL_DST`.

This is intended to be disabled by default in Istio 1.10 most likely. For review/testing, I have it enabled. I will swap it before merge.

Fixes https://github.com/istio/istio/issues/29940