### PR TITLE
Adds template option for gateway lifecycles to ingress/egress helm charts

### DIFF
--- a/manifests/charts/gateways/istio-egress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-egress/templates/deployment.yaml
@@ -88,6 +88,10 @@ spec:
 {{- end }}
       containers:
         - name: istio-proxy
+{{- if .Values.global.istioproxy.lifecycle }}
+          lifecycle:
+{{ toYaml .Values.global.istioproxy.lifecycle | indent 11 }}
+{{- end }}
 {{- if contains "/" .Values.global.proxy.image }}
           image: "{{ .Values.global.proxy.image }}"
 {{- else }}

--- a/manifests/charts/gateways/istio-egress/values.yaml
+++ b/manifests/charts/gateways/istio-egress/values.yaml
@@ -172,6 +172,11 @@ global:
   imagePullSecrets: []
   # - private-registry-key
 
+  # Lifecycle for istio-proxy container; allows you to add preStop/postStop for
+  # istio-proxy container for istio-egressgateway.
+  istioproxy:
+    lifecycle: {}
+
   # To output all istio components logs in json format by adding --log_as_json argument to each container argument
   logAsJson: false
 

--- a/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
@@ -88,6 +88,10 @@ spec:
 {{- end }}
       containers:
         - name: istio-proxy
+{{- if .Values.global.istioproxy.lifecycle }}
+          lifecycle:
+{{ toYaml .Values.global.istioproxy.lifecycle | indent 11 }}
+{{- end }}
 {{- if contains "/" .Values.global.proxy.image }}
           image: "{{ .Values.global.proxy.image }}"
 {{- else }}

--- a/manifests/charts/gateways/istio-ingress/values.yaml
+++ b/manifests/charts/gateways/istio-ingress/values.yaml
@@ -185,6 +185,11 @@ global:
   imagePullSecrets: []
   # - private-registry-key
 
+  # Lifecycle for istio-proxy container; allows you to add preStop/postStop for
+  # istio-proxy container for istio-ingressgateway.
+  istioproxy:
+    lifecycle: {}
+
   # To output all istio components logs in json format by adding --log_as_json argument to each container argument
   logAsJson: false
 


### PR DESCRIPTION
Adds an option to the helm charts for ingress/egress gateways that allows a lifecycle definition to be added to the containers.

[ ] Configuration Infrastructure
[ ] Docs
[ X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ X] Does not have any changes that may affect Istio users.
