### PR TITLE
refactor echo.Builder to allow multiple clusters

### DIFF
--- a/pkg/test/framework/components/echo/echo.go
+++ b/pkg/test/framework/components/echo/echo.go
@@ -47,6 +47,14 @@ type Builder interface {
 	// pointer will be updated to point at the new Instance.
 	With(i *Instance, cfg Config) Builder
 
+	// WithConfig mimics the behavior of With, but does not allow passing a reference
+	// and returns an echoboot builder rather than a generic echo builder.
+	// TODO rename this to With, and the old method to WithInstance
+	WithConfig(cfg Config) Builder
+
+	// WithClusters will cause subsequent With or WithConfig calls to be applied to the given clusters.
+	WithClusters(...resource.Cluster) Builder
+
 	// Build and initialize all Echo Instances. Upon returning, the Instance pointers
 	// are assigned and all Instances are ready to communicate with each other.
 	Build() (Instances, error)

--- a/pkg/test/framework/components/echo/echoboot/echoboot.go
+++ b/pkg/test/framework/components/echo/echoboot/echoboot.go
@@ -21,37 +21,21 @@ import (
 	"istio.io/istio/pkg/test/framework/resource"
 )
 
+var _ echo.Builder = builder{}
+
 // NewBuilder for Echo Instances.
-func NewBuilder(ctx resource.Context, clusters ...resource.Cluster) Builder {
+func NewBuilder(ctx resource.Context, clusters ...resource.Cluster) echo.Builder {
 	return builder{
 		kubeBuilder: kube.NewBuilder(ctx),
 	}.WithClusters(clusters...)
 }
-
-// Builder is a superset of echo.Builder, which allows deploying the same echo configuration across clusters.
-type Builder interface {
-	echo.Builder
-
-	// With is the legacy version of WithConfig.
-	With(i *echo.Instance, cfg echo.Config) echo.Builder
-
-	// WithConfig mimics the behavior of With, but does not allow passing a reference
-	// and returns an echoboot builder rather than a generic echo builder.
-	// TODO rename this to With, and the old method to WithInstance
-	WithConfig(cfg echo.Config) Builder
-
-	// WithClusters will cause subsequent With or WithConfig calls to be applied to the given clusters.
-	WithClusters(...resource.Cluster) Builder
-}
-
-var _ Builder = builder{}
 
 type builder struct {
 	clusters    resource.Clusters
 	kubeBuilder echo.Builder
 }
 
-func (b builder) WithConfig(cfg echo.Config) Builder {
+func (b builder) WithConfig(cfg echo.Config) echo.Builder {
 	return b.With(nil, cfg).(builder)
 }
 
@@ -85,7 +69,7 @@ func (b builder) With(i *echo.Instance, cfg echo.Config) echo.Builder {
 }
 
 // WithClusters will cause subsequent With calls to be applied to the given clusters.
-func (b builder) WithClusters(clusters ...resource.Cluster) Builder {
+func (b builder) WithClusters(clusters ...resource.Cluster) echo.Builder {
 	next := b
 	next.clusters = clusters
 	return next

--- a/pkg/test/framework/components/echo/echoboot/echoboot.go
+++ b/pkg/test/framework/components/echo/echoboot/echoboot.go
@@ -1,26 +1,80 @@
-// Copyright Istio Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package echoboot
 
 import (
+	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/echo/kube"
 	"istio.io/istio/pkg/test/framework/resource"
+	"istio.io/istio/pkg/test/scopes"
 )
 
 // NewBuilder for Echo Instances.
-func NewBuilder(ctx resource.Context) echo.Builder {
-	return kube.NewBuilder(ctx)
+func NewBuilder(ctx resource.Context, clusters ...resource.Cluster) Builder {
+	return builder{
+		kubeBuilder: kube.NewBuilder(ctx),
+	}.WithClusters(clusters...)
+}
+
+// Builder is a superset of echo.Builder, which allows deploying the same echo configuration accross clusters.
+type Builder interface {
+	echo.Builder
+
+	// WithClusters deploys to the given clusters all configs provided to With, that don't specify a cluster.
+	// If WithClusters is called multiple times it will replace the set of clusters for which subsequent With
+	// calls are applied to.
+	WithClusters(...resource.Cluster) Builder
+}
+
+var _ Builder = builder{}
+
+type builder struct {
+	clusters    resource.Clusters
+	kubeBuilder echo.Builder
+}
+
+// With adds a new Echo configuration to the Builder. When a cluster is provided in the Config, it will only be applied
+// to that cluster, otherwise the Config is applied to all WithClusters. Once built, if being built for a sngle cluster,
+// the instance pointer will be updated to point at the new Instance.
+func (b builder) With(i *echo.Instance, cfg echo.Config) echo.Builder {
+	if len(b.clusters) == 0 && cfg.Cluster == nil {
+		scopes.Framework.Warnf("echo config %s has no cluster and builder has no WithClusters", cfg.Service)
+		return b
+	}
+
+	// Per-config cluster override
+	if cfg.Cluster != nil {
+		b.kubeBuilder = b.kubeBuilder.With(i, cfg)
+		return b
+	}
+
+	// WithClusters
+	// only provide the ref for a single cluster
+	var ref *echo.Instance
+	if len(b.clusters) == 1 {
+		ref = i
+	}
+	// provide a config for each cluster to the kubeBuilder
+	for _, cluster := range b.clusters {
+		// TODO add a mechanism to allow "claiming" a config, and not providing it to other clusters
+		clusterCfg := cfg
+		clusterCfg.Cluster = cluster
+		b.kubeBuilder.With(ref, clusterCfg)
+	}
+
+	return b
+}
+
+// WithClusters will cause subsequent With calls to be applied to the given clusters.
+func (b builder) WithClusters(clusters ...resource.Cluster) Builder {
+	next := b
+	next.clusters = clusters
+	return next
+}
+
+func (b builder) Build() (echo.Instances, error) {
+	return b.kubeBuilder.Build()
+}
+
+func (b builder) BuildOrFail(t test.Failer) echo.Instances {
+	return b.kubeBuilder.BuildOrFail(t)
 }

--- a/pkg/test/framework/components/echo/echoboot/echoboot.go
+++ b/pkg/test/framework/components/echo/echoboot/echoboot.go
@@ -1,3 +1,18 @@
+// +build integ
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package echoboot
 
 import (

--- a/pkg/test/framework/components/echo/echoboot/echoboot.go
+++ b/pkg/test/framework/components/echo/echoboot/echoboot.go
@@ -1,4 +1,3 @@
-// +build integ
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,7 +28,7 @@ func NewBuilder(ctx resource.Context, clusters ...resource.Cluster) Builder {
 	}.WithClusters(clusters...)
 }
 
-// Builder is a superset of echo.Builder, which allows deploying the same echo configuration accross clusters.
+// Builder is a superset of echo.Builder, which allows deploying the same echo configuration across clusters.
 type Builder interface {
 	echo.Builder
 

--- a/pkg/test/framework/components/echo/echoboot/echoboot.go
+++ b/pkg/test/framework/components/echo/echoboot/echoboot.go
@@ -34,9 +34,6 @@ type Builder interface {
 	echo.Builder
 
 	// With is the legacy version of WithConfig.
-	//
-	// Deprecated: in the process of being replaced by WithConfig. Rather than relying on an instance
-	// reference, query the result echo.Instances given by Build/BuildOrFail using matchers.
 	With(i *echo.Instance, cfg echo.Config) echo.Builder
 
 	// WithConfig mimics the behavior of With, but does not allow passing a reference

--- a/pkg/test/framework/components/echo/echoboot/echoboot.go
+++ b/pkg/test/framework/components/echo/echoboot/echoboot.go
@@ -5,7 +5,6 @@ import (
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/echo/kube"
 	"istio.io/istio/pkg/test/framework/resource"
-	"istio.io/istio/pkg/test/scopes"
 )
 
 // NewBuilder for Echo Instances.
@@ -19,9 +18,18 @@ func NewBuilder(ctx resource.Context, clusters ...resource.Cluster) Builder {
 type Builder interface {
 	echo.Builder
 
-	// WithClusters deploys to the given clusters all configs provided to With, that don't specify a cluster.
-	// If WithClusters is called multiple times it will replace the set of clusters for which subsequent With
-	// calls are applied to.
+	// With is the legacy version of WithConfig.
+	//
+	// Deprecated: in the process of being replaced by WithConfig. Rather than relying on an instance
+	// reference, query the result echo.Instances given by Build/BuildOrFail using matchers.
+	With(i *echo.Instance, cfg echo.Config) echo.Builder
+
+	// WithConfig mimics the behavior of With, but does not allow passing a reference
+	// and returns an echoboot builder rather than a generic echo builder.
+	// TODO rename this to With, and the old method to WithInstance
+	WithConfig(cfg echo.Config) Builder
+
+	// WithClusters will cause subsequent With or WithConfig calls to be applied to the given clusters.
 	WithClusters(...resource.Cluster) Builder
 }
 
@@ -32,17 +40,18 @@ type builder struct {
 	kubeBuilder echo.Builder
 }
 
+func (b builder) WithConfig(cfg echo.Config) Builder {
+	return b.With(nil, cfg).(builder)
+}
+
 // With adds a new Echo configuration to the Builder. When a cluster is provided in the Config, it will only be applied
 // to that cluster, otherwise the Config is applied to all WithClusters. Once built, if being built for a sngle cluster,
 // the instance pointer will be updated to point at the new Instance.
 func (b builder) With(i *echo.Instance, cfg echo.Config) echo.Builder {
-	if len(b.clusters) == 0 && cfg.Cluster == nil {
-		scopes.Framework.Warnf("echo config %s has no cluster and builder has no WithClusters", cfg.Service)
-		return b
-	}
+	// TODO support for other kinds of cluster
 
-	// Per-config cluster override
-	if cfg.Cluster != nil {
+	// Per-config cluster override, or no WithClusters provided
+	if cfg.Cluster != nil || len(b.clusters) == 0 {
 		b.kubeBuilder = b.kubeBuilder.With(i, cfg)
 		return b
 	}

--- a/pkg/test/framework/components/echo/kube/builder.go
+++ b/pkg/test/framework/components/echo/kube/builder.go
@@ -50,6 +50,14 @@ func (b *builder) With(i *echo.Instance, cfg echo.Config) echo.Builder {
 	return b
 }
 
+func (b *builder) WithConfig(cfg echo.Config) echo.Builder {
+	return b.With(nil, cfg)
+}
+
+func (b *builder) WithClusters(_ ...resource.Cluster) echo.Builder {
+	panic("WithClusters is not supported directly on kube echo.Builder")
+}
+
 func (b *builder) Build() (echo.Instances, error) {
 	t0 := time.Now()
 	instances, err := b.newInstances()

--- a/tests/integration/multicluster/helper.go
+++ b/tests/integration/multicluster/helper.go
@@ -90,11 +90,12 @@ func SetupApps(appCtx *AppContext) resource.SetupFn {
 			echoLbCfg := newEchoConfig("echolb", appCtx.Namespace, cluster)
 			echoLbCfg.Subsets = append(echoLbCfg.Subsets, echo.SubsetConfig{Version: "v2"})
 
-			builder.With(nil, echoLbCfg)
-			builder.With(nil, newEchoConfig("local", appCtx.LocalNamespace, cluster))
+			builder = builder.
+				WithConfig(echoLbCfg).
+				WithConfig(newEchoConfig("local", appCtx.LocalNamespace, cluster))
 			for i := 0; i < uniqSvcPerCluster; i++ {
 				svcName := fmt.Sprintf("echo-%d-%d", cluster.Index(), i)
-				builder = builder.With(nil, newEchoConfig(svcName, appCtx.Namespace, cluster))
+				builder = builder.WithConfig(newEchoConfig(svcName, appCtx.Namespace, cluster))
 			}
 		}
 		echos, err := builder.Build()

--- a/tests/integration/pilot/common/apps.go
+++ b/tests/integration/pilot/common/apps.go
@@ -138,99 +138,89 @@ func SetupApps(ctx resource.Context, i istio.Instance, apps *EchoDeployments) er
 		p.ServicePort = p.InstancePort
 		headlessPorts[i] = p
 	}
-	builder := echoboot.NewBuilder(ctx)
-	for _, c := range ctx.Environment().Clusters() {
-		builder.
-			With(nil, echo.Config{
-				Service:           PodASvc,
-				Namespace:         apps.Namespace,
-				Ports:             EchoPorts,
-				Subsets:           []echo.SubsetConfig{{}},
-				Locality:          "region.zone.subzone",
-				Cluster:           c,
-				WorkloadOnlyPorts: WorkloadPorts,
-			}).
-			With(nil, echo.Config{
-				Service:           PodBSvc,
-				Namespace:         apps.Namespace,
-				Ports:             EchoPorts,
-				Subsets:           []echo.SubsetConfig{{}},
-				Cluster:           c,
-				WorkloadOnlyPorts: WorkloadPorts,
-			}).
-			With(nil, echo.Config{
-				Service:           PodCSvc,
-				Namespace:         apps.Namespace,
-				Ports:             EchoPorts,
-				Subsets:           []echo.SubsetConfig{{}},
-				Cluster:           c,
-				WorkloadOnlyPorts: WorkloadPorts,
-			}).
-			With(nil, echo.Config{
-				Service:           HeadlessSvc,
-				Headless:          true,
-				Namespace:         apps.Namespace,
-				Ports:             headlessPorts,
-				Subsets:           []echo.SubsetConfig{{}},
-				Cluster:           c,
-				WorkloadOnlyPorts: WorkloadPorts,
-			}).
-			With(nil, echo.Config{
-				Service:   NakedSvc,
-				Namespace: apps.Namespace,
-				Ports:     EchoPorts,
-				Subsets: []echo.SubsetConfig{
-					{
-						Annotations: map[echo.Annotation]*echo.AnnotationValue{
-							echo.SidecarInject: {
-								Value: strconv.FormatBool(false)},
-						},
+	builder := echoboot.NewBuilder(ctx).
+		WithClusters(ctx.Clusters()...).
+		WithConfig(echo.Config{
+			Service:           PodASvc,
+			Namespace:         apps.Namespace,
+			Ports:             EchoPorts,
+			Subsets:           []echo.SubsetConfig{{}},
+			Locality:          "region.zone.subzone",
+			WorkloadOnlyPorts: WorkloadPorts,
+		}).
+		WithConfig(echo.Config{
+			Service:           PodBSvc,
+			Namespace:         apps.Namespace,
+			Ports:             EchoPorts,
+			Subsets:           []echo.SubsetConfig{{}},
+			WorkloadOnlyPorts: WorkloadPorts,
+		}).
+		WithConfig(echo.Config{
+			Service:           PodCSvc,
+			Namespace:         apps.Namespace,
+			Ports:             EchoPorts,
+			Subsets:           []echo.SubsetConfig{{}},
+			WorkloadOnlyPorts: WorkloadPorts,
+		}).
+		WithConfig(echo.Config{
+			Service:           HeadlessSvc,
+			Headless:          true,
+			Namespace:         apps.Namespace,
+			Ports:             headlessPorts,
+			Subsets:           []echo.SubsetConfig{{}},
+			WorkloadOnlyPorts: WorkloadPorts,
+		}).
+		WithConfig(echo.Config{
+			Service:   NakedSvc,
+			Namespace: apps.Namespace,
+			Ports:     EchoPorts,
+			Subsets: []echo.SubsetConfig{
+				{
+					Annotations: map[echo.Annotation]*echo.AnnotationValue{
+						echo.SidecarInject: {
+							Value: strconv.FormatBool(false)},
 					},
 				},
-				Cluster:           c,
-				WorkloadOnlyPorts: WorkloadPorts,
-			}).
-			With(nil, echo.Config{
-				Service:           ExternalSvc,
-				Namespace:         apps.ExternalNamespace,
-				DefaultHostHeader: externalHostname,
-				Ports:             EchoPorts,
-				Subsets: []echo.SubsetConfig{
-					{
-						Annotations: map[echo.Annotation]*echo.AnnotationValue{
-							echo.SidecarInject: {
-								Value: strconv.FormatBool(false)},
-						},
+			},
+			WorkloadOnlyPorts: WorkloadPorts,
+		}).
+		WithConfig(echo.Config{
+			Service:           ExternalSvc,
+			Namespace:         apps.ExternalNamespace,
+			DefaultHostHeader: externalHostname,
+			Ports:             EchoPorts,
+			Subsets: []echo.SubsetConfig{
+				{
+					Annotations: map[echo.Annotation]*echo.AnnotationValue{
+						echo.SidecarInject: {
+							Value: strconv.FormatBool(false)},
 					},
 				},
-				Cluster:           c,
-				WorkloadOnlyPorts: WorkloadPorts,
-			}).
-			With(nil, echo.Config{
-				Service:   PodTproxySvc,
-				Namespace: apps.Namespace,
-				Ports:     EchoPorts,
-				Subsets: []echo.SubsetConfig{{
-					Annotations: echo.NewAnnotations().Set(echo.SidecarInterceptionMode, "TPROXY"),
-				}},
-				Cluster:           c,
-				WorkloadOnlyPorts: WorkloadPorts,
-			})
-	}
+			},
+			WorkloadOnlyPorts: WorkloadPorts,
+		}).
+		WithConfig(echo.Config{
+			Service:   PodTproxySvc,
+			Namespace: apps.Namespace,
+			Ports:     EchoPorts,
+			Subsets: []echo.SubsetConfig{{
+				Annotations: echo.NewAnnotations().Set(echo.SidecarInterceptionMode, "TPROXY"),
+			}},
+			WorkloadOnlyPorts: WorkloadPorts,
+		})
 	if !ctx.Settings().SkipVM {
 		// It only makes sense to deploy echo VMs on a primary cluster.
-		for _, cluster := range ctx.Clusters().Primaries() {
-			builder.With(nil, echo.Config{
+		// TODO in the future non-kube Cluster types will support VMs
+		builder = builder.WithClusters(ctx.Clusters().Primaries()...).
+			WithConfig(echo.Config{
 				Service:           VMSvc,
 				Namespace:         apps.Namespace,
 				Ports:             EchoPorts,
 				DeployAsVM:        true,
 				AutoRegisterVM:    true,
 				Subsets:           []echo.SubsetConfig{{}},
-				Cluster:           cluster,
 				WorkloadOnlyPorts: WorkloadPorts,
 			})
-		}
 	}
 
 	echos, err := builder.Build()

--- a/tests/integration/pilot/vm_test.go
+++ b/tests/integration/pilot/vm_test.go
@@ -52,19 +52,17 @@ func TestVmOSPost(t *testing.T) {
 		Run(func(ctx framework.TestContext) {
 			b := echoboot.NewBuilder(ctx)
 			images := GetAdditionVMImages()
-			instances := make([]echo.Instance, len(images))
-			for i, image := range images {
-				b = b.With(&instances[i], echo.Config{
+			for _, image := range images {
+				b = b.WithConfig(echo.Config{
 					Service:    "vm-" + strings.ReplaceAll(image, "_", "-"),
 					Namespace:  apps.Namespace,
 					Ports:      common.EchoPorts,
 					DeployAsVM: true,
 					VMImage:    image,
 					Subsets:    []echo.SubsetConfig{{}},
-					Cluster:    ctx.Clusters().Default(),
 				})
 			}
-			b.BuildOrFail(ctx)
+			instances := b.BuildOrFail(ctx)
 
 			for i, image := range images {
 				i, image := i, image

--- a/tests/integration/security/authorization_test.go
+++ b/tests/integration/security/authorization_test.go
@@ -516,7 +516,7 @@ func TestAuthorization_IngressGateway(t *testing.T) {
 
 			var b echo.Instance
 			echoboot.NewBuilder(ctx).
-				With(&b, util.EchoConfig("b", ns, false, nil, nil)).
+				With(&b, util.EchoConfig("b", ns, false, nil)).
 				BuildOrFail(t)
 
 			ingr := ist.IngressFor(ctx.Clusters().Default())
@@ -648,7 +648,7 @@ func TestAuthorization_EgressGateway(t *testing.T) {
 
 			var a, b, c echo.Instance
 			echoboot.NewBuilder(ctx).
-				With(&a, util.EchoConfig("a", ns, false, nil, nil)).
+				With(&a, util.EchoConfig("a", ns, false, nil)).
 				With(&b, echo.Config{
 					Service:   "b",
 					Namespace: ns,
@@ -661,7 +661,7 @@ func TestAuthorization_EgressGateway(t *testing.T) {
 						},
 					},
 				}).
-				With(&c, util.EchoConfig("c", ns, false, nil, nil)).
+				With(&c, util.EchoConfig("c", ns, false, nil)).
 				BuildOrFail(t)
 
 			args := map[string]string{
@@ -858,7 +858,7 @@ func TestAuthorization_TCP(t *testing.T) {
 				},
 			}
 			echoboot.NewBuilder(ctx).
-				With(&x, util.EchoConfig("x", ns2, false, nil, nil)).
+				With(&x, util.EchoConfig("x", ns2, false, nil)).
 				With(&a, echo.Config{
 					Subsets:        []echo.SubsetConfig{{}},
 					Namespace:      ns,
@@ -1102,10 +1102,10 @@ func TestAuthorization_GRPC(t *testing.T) {
 			})
 			var a, b, c, d echo.Instance
 			echoboot.NewBuilder(ctx).
-				With(&a, util.EchoConfig("a", ns, false, nil, nil)).
-				With(&b, util.EchoConfig("b", ns, false, nil, nil)).
-				With(&c, util.EchoConfig("c", ns, false, nil, nil)).
-				With(&d, util.EchoConfig("d", ns, false, nil, nil)).
+				With(&a, util.EchoConfig("a", ns, false, nil)).
+				With(&b, util.EchoConfig("b", ns, false, nil)).
+				With(&c, util.EchoConfig("c", ns, false, nil)).
+				With(&d, util.EchoConfig("d", ns, false, nil)).
 				BuildOrFail(t)
 
 			cases := []rbacUtil.TestCase{
@@ -1229,10 +1229,10 @@ func TestAuthorization_Audit(t *testing.T) {
 
 			var a, b, c, d echo.Instance
 			echoboot.NewBuilder(ctx).
-				With(&a, util.EchoConfig("a", ns, false, nil, nil)).
-				With(&b, util.EchoConfig("b", ns, false, nil, nil)).
-				With(&c, util.EchoConfig("c", ns, false, nil, nil)).
-				With(&d, util.EchoConfig("d", ns, false, nil, nil)).
+				With(&a, util.EchoConfig("a", ns, false, nil)).
+				With(&b, util.EchoConfig("b", ns, false, nil)).
+				With(&c, util.EchoConfig("c", ns, false, nil)).
+				With(&d, util.EchoConfig("d", ns, false, nil)).
 				BuildOrFail(t)
 
 			newTestCase := func(target echo.Instance, path string, expectAllowed bool) rbacUtil.TestCase {
@@ -1325,7 +1325,7 @@ func TestAuthorization_Custom(t *testing.T) {
 
 			var a, b, c, d, e, f, x echo.Instance
 			echoConfig := func(name string, includeExtAuthz bool) echo.Config {
-				cfg := util.EchoConfig(name, ns, false, nil, nil)
+				cfg := util.EchoConfig(name, ns, false, nil)
 				cfg.IncludeExtAuthz = includeExtAuthz
 				cfg.Ports = ports
 				return cfg

--- a/tests/integration/security/sds_egress/sds_istio_mutual_egress_test.go
+++ b/tests/integration/security/sds_egress/sds_istio_mutual_egress_test.go
@@ -89,7 +89,7 @@ func doIstioMutualTest(
 	ctx framework.TestContext, ns namespace.Instance, configPath, expectedResp string) {
 	var client echo.Instance
 	echoboot.NewBuilder(ctx).
-		With(&client, util.EchoConfig("client", ns, false, nil, nil)).
+		With(&client, util.EchoConfig("client", ns, false, nil)).
 		BuildOrFail(ctx)
 	ctx.Config().ApplyYAMLOrFail(ctx, ns.Name(), file.AsStringOrFail(ctx, configPath))
 	defer ctx.Config().DeleteYAMLOrFail(ctx, ns.Name(), file.AsStringOrFail(ctx, configPath))

--- a/tests/integration/security/util/framework.go
+++ b/tests/integration/security/util/framework.go
@@ -60,7 +60,7 @@ type EchoDeployments struct {
 	All              echo.Instances
 }
 
-func EchoConfig(name string, ns namespace.Instance, headless bool, annos echo.Annotations, cluster resource.Cluster) echo.Config {
+func EchoConfig(name string, ns namespace.Instance, headless bool, annos echo.Annotations) echo.Config {
 	out := echo.Config{
 		Service:        name,
 		Namespace:      ns,
@@ -119,7 +119,6 @@ func EchoConfig(name string, ns namespace.Instance, headless bool, annos echo.An
 				Protocol: protocol.HTTPS,
 			},
 		},
-		Cluster: cluster,
 	}
 
 	// for headless service with selector, the port and target port must be equal
@@ -155,45 +154,48 @@ func SetupApps(ctx resource.Context, i istio.Instance, apps *EchoDeployments, bu
 	if err != nil {
 		return err
 	}
-	builder := echoboot.NewBuilder(ctx)
-	for _, cluster := range ctx.Clusters() {
-		// Multi-version specific setup
-		multiVersionCfg := EchoConfig(MultiversionSvc, apps.Namespace1, false, nil, cluster)
-		multiVersionCfg.Subsets = []echo.SubsetConfig{
-			// Istio deployment, with sidecar.
-			{
-				Version: "vistio",
-			},
-			// Legacy deployment subset, does not have sidecar injected.
-			{
-				Version:     "vlegacy",
-				Annotations: echo.NewAnnotations().SetBool(echo.SidecarInject, false),
-			},
-		}
-		builder.
-			With(nil, EchoConfig(ASvc, apps.Namespace1, false, nil, cluster)).
-			With(nil, EchoConfig(BSvc, apps.Namespace1, false, nil, cluster)).
-			With(nil, EchoConfig(CSvc, apps.Namespace1, false, nil, cluster)).
-			With(nil, EchoConfig(DSvc, apps.Namespace1, false, nil, cluster)).
-			With(nil, EchoConfig(ESvc, apps.Namespace1, false, nil, cluster)).
-			With(nil, EchoConfig(FSvc, apps.Namespace1, false, nil, cluster)).
-			With(nil, multiVersionCfg).
-			With(nil, EchoConfig(NakedSvc, apps.Namespace1, false, echo.NewAnnotations().
-				SetBool(echo.SidecarInject, false), cluster)).
-			With(nil, EchoConfig(BSvc, apps.Namespace2, false, nil, cluster)).
-			With(nil, EchoConfig(CSvc, apps.Namespace2, false, nil, cluster)).
-			With(nil, EchoConfig(CSvc, apps.Namespace3, false, nil, cluster))
-	}
-	for _, cluster := range ctx.Clusters().Primaries() {
-		// VM specific setup
-		vmCfg := EchoConfig(VMSvc, apps.Namespace1, false, nil, cluster)
-		// for test cases that have `buildVM` off, vm will function like a regular pod
-		vmCfg.DeployAsVM = buildVM
-		builder.With(nil, vmCfg)
-		builder.With(nil, EchoConfig(HeadlessSvc, apps.Namespace1, true, nil, cluster))
-		builder.With(nil, EchoConfig(HeadlessNakedSvc, apps.Namespace1, true, echo.NewAnnotations().
-			SetBool(echo.SidecarInject, false), cluster))
-	}
+
+	builder := echoboot.NewBuilder(ctx).
+		WithClusters(ctx.Clusters()...).
+		WithConfig(EchoConfig(ASvc, apps.Namespace1, false, nil)).
+		WithConfig(EchoConfig(BSvc, apps.Namespace1, false, nil)).
+		WithConfig(EchoConfig(CSvc, apps.Namespace1, false, nil)).
+		WithConfig(EchoConfig(DSvc, apps.Namespace1, false, nil)).
+		WithConfig(EchoConfig(ESvc, apps.Namespace1, false, nil)).
+		WithConfig(EchoConfig(FSvc, apps.Namespace1, false, nil)).
+		WithConfig(func() echo.Config {
+			// Multi-version specific setup
+			multiVersionCfg := EchoConfig(MultiversionSvc, apps.Namespace1, false, nil)
+			multiVersionCfg.Subsets = []echo.SubsetConfig{
+				// Istio deployment, with sidecar.
+				{
+					Version: "vistio",
+				},
+				// Legacy deployment subset, does not have sidecar injected.
+				{
+					Version:     "vlegacy",
+					Annotations: echo.NewAnnotations().SetBool(echo.SidecarInject, false),
+				},
+			}
+			return multiVersionCfg
+		}()).
+		WithConfig(EchoConfig(NakedSvc, apps.Namespace1, false, echo.NewAnnotations().
+			SetBool(echo.SidecarInject, false))).
+		WithConfig(EchoConfig(BSvc, apps.Namespace2, false, nil)).
+		WithConfig(EchoConfig(CSvc, apps.Namespace2, false, nil)).
+		WithConfig(EchoConfig(CSvc, apps.Namespace3, false, nil)).
+		WithClusters(ctx.Clusters().Primaries()...).
+		WithConfig(func() echo.Config {
+			// VM specific setup
+			vmCfg := EchoConfig(VMSvc, apps.Namespace1, false, nil)
+			// for test cases that have `buildVM` off, vm will function like a regular pod
+			vmCfg.DeployAsVM = buildVM
+			return vmCfg
+		}()).
+		WithConfig(EchoConfig(HeadlessSvc, apps.Namespace1, true, nil)).
+		WithConfig(EchoConfig(HeadlessNakedSvc, apps.Namespace1, true, echo.NewAnnotations().
+			SetBool(echo.SidecarInject, false)))
+
 	echos, err := builder.Build()
 	if err != nil {
 		return err

--- a/tests/integration/telemetry/stackdriver/stackdriver_filter_test.go
+++ b/tests/integration/telemetry/stackdriver/stackdriver_filter_test.go
@@ -207,7 +207,7 @@ func testSetup(ctx resource.Context) (err error) {
 	for _, cls := range ctx.Clusters() {
 		clName := cls.Name()
 		builder.
-			With(nil, echo.Config{
+			WithConfig(echo.Config{
 				Service:   fmt.Sprintf("clt-%s", clName),
 				Cluster:   cls,
 				Namespace: getEchoNamespaceInstance(),
@@ -220,7 +220,7 @@ func testSetup(ctx resource.Context) (err error) {
 						},
 					},
 				}}).
-			With(nil, echo.Config{
+			WithConfig(echo.Config{
 				Service:   "srv",
 				Cluster:   cls,
 				Namespace: getEchoNamespaceInstance(),
@@ -252,8 +252,7 @@ func testSetup(ctx resource.Context) (err error) {
 							},
 						},
 					},
-				}}).
-			Build()
+				}})
 	}
 	echos, err := builder.Build()
 	if err != nil {

--- a/tests/integration/telemetry/stats/prometheus/customizemetrics/customize_metrics_test.go
+++ b/tests/integration/telemetry/stats/prometheus/customizemetrics/customize_metrics_test.go
@@ -105,36 +105,32 @@ func testSetup(ctx resource.Context) (err error) {
 	if err != nil {
 		return
 	}
-	var echos echo.Instances
-	for _, c := range ctx.Clusters() {
-		echos, err = echoboot.NewBuilder(ctx).
-			With(nil, echo.Config{
-				Service:   "client",
-				Namespace: appNsInst,
-				Cluster:   c,
-				Ports:     nil,
-				Subsets:   []echo.SubsetConfig{{}},
-			}).
-			With(nil, echo.Config{
-				Service:   "server",
-				Namespace: appNsInst,
-				Cluster:   c,
-				Subsets:   []echo.SubsetConfig{{}},
-				Ports: []echo.Port{
-					{
-						Name:         "http",
-						Protocol:     protocol.HTTP,
-						InstancePort: 8090,
-					},
-					{
-						Name:         "grpc",
-						Protocol:     protocol.GRPC,
-						InstancePort: 7070,
-					},
+	echos, err := echoboot.NewBuilder(ctx).
+		WithClusters(ctx.Clusters()...).
+		WithConfig(echo.Config{
+			Service:   "client",
+			Namespace: appNsInst,
+			Ports:     nil,
+			Subsets:   []echo.SubsetConfig{{}},
+		}).
+		WithConfig(echo.Config{
+			Service:   "server",
+			Namespace: appNsInst,
+			Subsets:   []echo.SubsetConfig{{}},
+			Ports: []echo.Port{
+				{
+					Name:         "http",
+					Protocol:     protocol.HTTP,
+					InstancePort: 8090,
 				},
-			}).
-			Build()
-	}
+				{
+					Name:         "grpc",
+					Protocol:     protocol.GRPC,
+					InstancePort: 7070,
+				},
+			},
+		}).
+		Build()
 	if err != nil {
 		return err
 	}

--- a/tests/integration/telemetry/stats/prometheus/stats.go
+++ b/tests/integration/telemetry/stats/prometheus/stats.go
@@ -179,65 +179,60 @@ func TestSetup(ctx resource.Context) (err error) {
 	}
 
 	builder := echoboot.NewBuilder(ctx)
-	for _, c := range ctx.Clusters() {
-		builder.
-			With(nil, echo.Config{
-				Service:   "client",
-				Namespace: appNsInst,
-				Cluster:   c,
-				Ports:     nil,
-				Subsets:   []echo.SubsetConfig{{}},
-			}).
-			With(nil, echo.Config{
-				Service:   "server",
-				Namespace: appNsInst,
-				Cluster:   c,
-				Subsets:   []echo.SubsetConfig{{}},
-				Ports: []echo.Port{
-					{
-						Name:         "http",
-						Protocol:     protocol.HTTP,
-						InstancePort: 8090,
-					},
-					{
-						Name:     "tcp",
-						Protocol: protocol.TCP,
-						// We use a port > 1024 to not require root
-						InstancePort: 9000,
-						ServicePort:  9000,
-					},
+	builder.
+		WithConfig(echo.Config{
+			Service:   "client",
+			Namespace: appNsInst,
+			Ports:     nil,
+			Subsets:   []echo.SubsetConfig{{}},
+		}).
+		WithConfig(echo.Config{
+			Service:   "server",
+			Namespace: appNsInst,
+			Subsets:   []echo.SubsetConfig{{}},
+			Ports: []echo.Port{
+				{
+					Name:         "http",
+					Protocol:     protocol.HTTP,
+					InstancePort: 8090,
 				},
-			}).
-			With(nil, echo.Config{
-				Service:   "server-no-sidecar",
-				Namespace: appNsInst,
-				Cluster:   c,
-				Subsets: []echo.SubsetConfig{
-					{
-						Annotations: map[echo.Annotation]*echo.AnnotationValue{
-							echo.SidecarInject: {
-								Value: strconv.FormatBool(false),
-							},
+				{
+					Name:     "tcp",
+					Protocol: protocol.TCP,
+					// We use a port > 1024 to not require root
+					InstancePort: 9000,
+					ServicePort:  9000,
+				},
+			},
+		}).
+		WithConfig(echo.Config{
+			Service:   "server-no-sidecar",
+			Namespace: appNsInst,
+			Subsets: []echo.SubsetConfig{
+				{
+					Annotations: map[echo.Annotation]*echo.AnnotationValue{
+						echo.SidecarInject: {
+							Value: strconv.FormatBool(false),
 						},
 					},
 				},
-				Ports: []echo.Port{
-					{
-						Name:         "http",
-						Protocol:     protocol.HTTP,
-						InstancePort: 8090,
-					},
-					{
-						Name:     "tcp",
-						Protocol: protocol.TCP,
-						// We use a port > 1024 to not require root
-						InstancePort: 9000,
-						ServicePort:  9000,
-					},
+			},
+			Ports: []echo.Port{
+				{
+					Name:         "http",
+					Protocol:     protocol.HTTP,
+					InstancePort: 8090,
 				},
-			}).
-			Build()
-
+				{
+					Name:     "tcp",
+					Protocol: protocol.TCP,
+					// We use a port > 1024 to not require root
+					InstancePort: 9000,
+					ServicePort:  9000,
+				},
+			},
+		})
+	for _, c := range ctx.Clusters() {
 		ingr = append(ingr, ist.IngressFor(c))
 	}
 	echos, err := builder.Build()

--- a/tests/integration/telemetry/tracing/tracing.go
+++ b/tests/integration/telemetry/tracing/tracing.go
@@ -71,14 +71,14 @@ func TestSetup(ctx resource.Context) (err error) {
 	for _, c := range ctx.Clusters() {
 		clName := c.Name()
 		builder = builder.
-			With(nil, echo.Config{
+			WithConfig(echo.Config{
 				Service:   fmt.Sprintf("client-%s", clName),
 				Namespace: appNsInst,
 				Cluster:   c,
 				Ports:     nil,
 				Subsets:   []echo.SubsetConfig{{}},
 			}).
-			With(nil, echo.Config{
+			WithConfig(echo.Config{
 				Service:   "server",
 				Namespace: appNsInst,
 				Cluster:   c,


### PR DESCRIPTION
Additional changes to go along with #30092.

- This will allow us to swap out echo deployment strategies based on cluster type. 
- Also removes the need for looping/duplicating echo.Configs per-cluster (for services identical across clusters). 
- _May_ reduce telemetry test times, there were multiple places that called `Build` on echobuilder more than once. 