### PR TITLE
[release-1.9] Add ECDS interception and Wasm conversion into xds proxy. (#30086)

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -410,4 +410,8 @@ var (
 	StatusMaxWorkers = env.RegisterIntVar("PILOT_STATUS_MAX_WORKERS", 100, "The maximum number of workers"+
 		" Pilot will use to keep configuration status up to date.  Smaller numbers will result in higher status latency, "+
 		"but larger numbers may impact CPU in high scale environments.")
+
+	WasmRemoteLoadConversion = env.RegisterBoolVar("ISTIO_AGENT_ENABLE_WASM_REMOTE_LOAD_CONVERSION", true,
+		"If enabled, Istio agent will intercept ECDS resource update, downloads Wasm module, "+
+			"and replaces Wasm module remote load with downloaded local module file.").Get()
 )

--- a/pilot/pkg/xds/testdata/ecds.yaml
+++ b/pilot/pkg/xds/testdata/ecds.yaml
@@ -17,4 +17,7 @@ spec:
           value:
             config:
               vm_config:
-                vm_id: vm
+                code:
+                  remote:
+                    http_uri:
+                      uri: https://test-url

--- a/pkg/config/constants/constants.go
+++ b/pkg/config/constants/constants.go
@@ -42,6 +42,9 @@ const (
 	// ConfigPathDir config directory for storing envoy json config files.
 	ConfigPathDir = "./etc/istio/proxy"
 
+	// IstioDataDir is the directory to store binary data such as envoy core dump, profile, and downloaded Wasm modules.
+	IstioDataDir = "/var/lib/istio/data"
+
 	// BinaryPathFilename envoy binary location
 	BinaryPathFilename = "/usr/local/bin/envoy"
 

--- a/pkg/istio-agent/xds_proxy.go
+++ b/pkg/istio-agent/xds_proxy.go
@@ -32,6 +32,7 @@ import (
 
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"github.com/golang/protobuf/ptypes"
+	"go.uber.org/atomic"
 	"golang.org/x/oauth2"
 	google_rpc "google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc"
@@ -44,6 +45,7 @@ import (
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/cmd/pilot-agent/status/ready"
 	"istio.io/istio/pilot/pkg/dns"
+	"istio.io/istio/pilot/pkg/features"
 	nds "istio.io/istio/pilot/pkg/proto"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
 	"istio.io/istio/pkg/config/constants"
@@ -51,6 +53,7 @@ import (
 	"istio.io/istio/pkg/istio-agent/metrics"
 	"istio.io/istio/pkg/mcp/status"
 	"istio.io/istio/pkg/uds"
+	"istio.io/istio/pkg/wasm"
 	"istio.io/istio/security/pkg/nodeagent/caclient"
 	"istio.io/pkg/log"
 )
@@ -85,6 +88,18 @@ type XdsProxy struct {
 	connected      *ProxyConnection
 	initialRequest *discovery.DiscoveryRequest
 	connectedMutex sync.RWMutex
+
+	// Wasm cache and ecds channel are used to replace wasm remote load with local file.
+	wasmCache      wasm.Cache
+	ecdsUpdateChan chan *discovery.DiscoveryResponse
+	// ecds version and nonce uses atomic only to prevent race in testing.
+	// In reality there should not be race as istiod will only have one
+	// in flight update for each type of resource.
+	// TODO(bianpengyuan): this relies on the fact that istiod versions all ECDS resources
+	// the same in a update response. This needs update to support per resource versioning,
+	// in case istiod changes its behavior, or a different ECDS server is used.
+	ecdsLastAckVersion atomic.String
+	ecdsLastNonce      atomic.String
 }
 
 var proxyLog = log.RegisterScope("xdsproxy", "XDS Proxy in Istio Agent", 0)
@@ -112,6 +127,8 @@ func initXdsProxy(ia *Agent) (*XdsProxy, error) {
 		healthChecker:  health.NewWorkloadHealthChecker(ia.proxyConfig.ReadinessProbe, envoyProbe),
 		xdsHeaders:     ia.cfg.XDSHeaders,
 		xdsUdsPath:     ia.cfg.XdsUdsPath,
+		wasmCache:      wasm.NewLocalFileCache(constants.IstioDataDir, wasm.DefaultWasmModulePurgeInteval, wasm.DefaultWasmModuleExpiry),
+		ecdsUpdateChan: make(chan *discovery.DiscoveryResponse, 10),
 	}
 
 	proxyLog.Infof("Initializing with upstream address %q and cluster %q", proxy.istiodAddress, proxy.clusterID)
@@ -294,6 +311,11 @@ func (p *XdsProxy) HandleUpstream(ctx context.Context, con *ProxyConnection, xds
 	go p.handleUpstreamRequest(ctx, con)
 	go p.handleUpstreamResponse(con)
 
+	if features.WasmRemoteLoadConversion {
+		// Handle ECDS update asynchronously for Wasm config rewriting, since it might need to download Wasm modules.
+		go p.handleUpstreamECDSResponse(con)
+	}
+
 	for {
 		select {
 		case err := <-con.upstreamError:
@@ -331,6 +353,12 @@ func (p *XdsProxy) handleUpstreamRequest(ctx context.Context, con *ProxyConnecti
 		case req := <-con.requestsChan:
 			proxyLog.Debugf("request for type url %s", req.TypeUrl)
 			metrics.XdsProxyRequests.Increment()
+			if req.TypeUrl == v3.ExtensionConfigurationType {
+				if req.VersionInfo != "" {
+					p.ecdsLastAckVersion.Store(req.VersionInfo)
+				}
+				p.ecdsLastNonce.Store(req.ResponseNonce)
+			}
 			if err := sendUpstreamWithTimeout(ctx, con.upstream, req); err != nil {
 				proxyLog.Errorf("upstream send error for type url %s: %v", req.TypeUrl, err)
 				con.upstreamError <- err
@@ -367,20 +395,69 @@ func (p *XdsProxy) handleUpstreamResponse(con *ProxyConnection) {
 					TypeUrl:       v3.NameTableType,
 					ResponseNonce: resp.Nonce,
 				}
-			default:
-				// TODO: Validate the known type urls before forwarding them to Envoy.
-				if err := sendDownstreamWithTimeout(con.downstream, resp); err != nil {
-					proxyLog.Errorf("downstream send error: %v", err)
-					// we cannot return partial error and hope to restart just the downstream
-					// as we are blindly proxying req/responses. For now, the best course of action
-					// is to terminate upstream connection as well and restart afresh.
-					con.downstreamError <- err
-					return
+			case v3.ExtensionConfigurationType:
+				if features.WasmRemoteLoadConversion {
+					// If Wasm remote load conversion feature is enabled, push ECDS update into
+					// conversion channel.
+					p.ecdsUpdateChan <- resp
+				} else {
+					// Otherwise, forward ECDS resource update directly to Envoy.
+					forwardToEnvoy(con, resp)
 				}
+			default:
+				forwardToEnvoy(con, resp)
 			}
 		case <-con.stopChan:
 			return
 		}
+	}
+}
+
+func (p *XdsProxy) handleUpstreamECDSResponse(con *ProxyConnection) {
+	// TODO(bianpengyuan): Add metrics about ecds handling.
+	for {
+		select {
+		case resp := <-p.ecdsUpdateChan:
+			sendNack := wasm.MaybeConvertWasmExtensionConfig(resp.Resources, p.wasmCache)
+			if sendNack {
+				con.requestsChan <- &discovery.DiscoveryRequest{
+					VersionInfo:   p.ecdsLastAckVersion.Load(),
+					TypeUrl:       v3.ExtensionConfigurationType,
+					ResponseNonce: resp.Nonce,
+					ErrorDetail: &google_rpc.Status{
+						// TODO(bianpengyuan): make error message more informative.
+						Message: "failed to fetch wasm module",
+					},
+				}
+				return
+			}
+			proxyLog.Debugf("forward ECDS resources %+v", resp.Resources)
+			forwardToEnvoy(con, resp)
+
+		case <-con.stopChan:
+			return
+		}
+	}
+}
+
+func forwardToEnvoy(con *ProxyConnection, resp *discovery.DiscoveryResponse) {
+	// TODO: Validate the known type urls before forwarding them to Envoy.
+	if err := sendDownstreamWithTimeout(con.downstream, resp); err != nil {
+		select {
+		case con.downstreamError <- err:
+			// we cannot return partial error and hope to restart just the downstream
+			// as we are blindly proxying req/responses. For now, the best course of action
+			// is to terminate upstream connection as well and restart afresh.
+			proxyLog.Errorf("downstream send error: %v", err)
+		default:
+			// Do not block on downstream error channel push, this could happen when forward
+			// is triggered from a separated goroutine (e.g. ECDS processing go routine) while
+			// downstream connection has already been teared down and no receiver is available
+			// for downstream error channel.
+			proxyLog.Debugf("downstream error channel full, but get downstream send error: %v", err)
+		}
+
+		return
 	}
 }
 
@@ -390,6 +467,7 @@ func (p *XdsProxy) DeltaAggregatedResources(server discovery.AggregatedDiscovery
 
 func (p *XdsProxy) close() {
 	close(p.stopChan)
+	p.wasmCache.Cleanup()
 	if p.downstreamGrpcServer != nil {
 		p.downstreamGrpcServer.Stop()
 	}

--- a/pkg/istio-agent/xds_proxy_test.go
+++ b/pkg/istio-agent/xds_proxy_test.go
@@ -16,7 +16,9 @@ package istioagent
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io/ioutil"
 	"net"
 	"path"
 	"path/filepath"
@@ -24,16 +26,21 @@ import (
 	"time"
 
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	wasm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/wasm/v3"
+	wasmv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/wasm/v3"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	"github.com/golang/protobuf/ptypes"
 	google_rpc "google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/test/bufconn"
+	"google.golang.org/protobuf/proto"
 
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/model/status"
+	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pilot/pkg/xds"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
 	"istio.io/istio/pkg/config"
@@ -43,6 +50,7 @@ import (
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/pkg/test/util/retry"
+	"istio.io/pkg/log"
 )
 
 // Validates basic xds proxy flow by proxying one CDS requests end to end.
@@ -344,6 +352,135 @@ func TestXdsProxyReconnects(t *testing.T) {
 		downstream = stream(t, conn)
 		sendDownstream(t, downstream)
 	})
+}
+
+type fakeAckCache struct{}
+
+func (f *fakeAckCache) Get(string, string, time.Duration) (string, error) {
+	return "test", nil
+}
+func (f *fakeAckCache) Cleanup() {}
+
+type fakeNackCache struct{}
+
+func (f *fakeNackCache) Get(string, string, time.Duration) (string, error) {
+	return "", errors.New("errror")
+}
+func (f *fakeNackCache) Cleanup() {}
+
+func TestECDSWasmConversion(t *testing.T) {
+	proxyLog.SetOutputLevel(log.DebugLevel)
+	node := model.NodeMetadata{
+		Namespace:   "default",
+		InstanceIPs: []string{"1.1.1.1"},
+	}
+	proxy := setupXdsProxy(t)
+
+	// Reset wasm cache to a fake ACK cache.
+	proxy.wasmCache.Cleanup()
+	proxy.wasmCache = &fakeAckCache{}
+
+	// Initialize discovery server with an ECDS resource.
+	ef, err := ioutil.ReadFile(path.Join(env.IstioSrc, "pilot/pkg/xds/testdata/ecds.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	f := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{
+		ConfigString: string(ef),
+	})
+	setDialOptions(proxy, f.Listener)
+	conn := setupDownstreamConnection(t, proxy)
+	downstream := stream(t, conn)
+
+	// Send first request, wasm module async fetch should work fine and
+	// downstream should receive a local file based wasm extension config.
+	err = downstream.Send(&discovery.DiscoveryRequest{
+		TypeUrl:       v3.ExtensionConfigurationType,
+		ResourceNames: []string{"extension-config"},
+		Node: &core.Node{
+			Id:       "sidecar~1.1.1.1~debug~cluster.local",
+			Metadata: node.ToStruct(),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify that the request received has been rewritten to local file.
+	gotResp, err := downstream.Recv()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(gotResp.Resources) != 1 {
+		t.Errorf("xds proxy ecds wasm conversion number of received resource got %v want 1", len(gotResp.Resources))
+	}
+	gotEcdsConfig := &core.TypedExtensionConfig{}
+	if err := ptypes.UnmarshalAny(gotResp.Resources[0], gotEcdsConfig); err != nil {
+		t.Fatalf("wasm config conversion output %v failed to unmarshal", gotResp.Resources[0])
+	}
+	wasm := &wasm.Wasm{
+		Config: &wasmv3.PluginConfig{
+			Vm: &wasmv3.PluginConfig_VmConfig{
+				VmConfig: &wasmv3.VmConfig{
+
+					Code: &core.AsyncDataSource{Specifier: &core.AsyncDataSource_Local{
+						Local: &core.DataSource{
+							Specifier: &core.DataSource_Filename{
+								Filename: "test",
+							},
+						},
+					}},
+				},
+			},
+		},
+	}
+	wantEcdsConfig := &core.TypedExtensionConfig{
+		Name:        "extension-config",
+		TypedConfig: util.MessageToAny(wasm),
+	}
+
+	if !proto.Equal(gotEcdsConfig, wantEcdsConfig) {
+		t.Errorf("xds proxy wasm config conversion got %v want %v", gotEcdsConfig, wantEcdsConfig)
+	}
+	v1 := proxy.ecdsLastAckVersion
+	n1 := proxy.ecdsLastNonce
+
+	// reset wasm cache to a NACK cache, and recreate xds server as well to simulate a version bump
+	proxy.wasmCache = &fakeNackCache{}
+	f = xds.NewFakeDiscoveryServer(t, xds.FakeOptions{
+		ConfigString: string(ef),
+	})
+	setDialOptions(proxy, f.Listener)
+	conn = setupDownstreamConnection(t, proxy)
+	downstream = stream(t, conn)
+
+	// send request again, this time a nack should be returned from the xds proxy due to NACK wasm cache.
+	err = downstream.Send(&discovery.DiscoveryRequest{
+		VersionInfo:   gotResp.VersionInfo,
+		TypeUrl:       v3.ExtensionConfigurationType,
+		ResourceNames: []string{"extension-config"},
+		Node: &core.Node{
+			Id:       "sidecar~1.1.1.1~debug~cluster.local",
+			Metadata: node.ToStruct(),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait until nonce was updated, which represents an ACK/NACK has been received.
+	retry.UntilSuccessOrFail(t, func() error {
+		if proxy.ecdsLastNonce.Load() == n1.Load() {
+			return errors.New("last process nonce has not been updated. no ecds ack/nack is received yet")
+		}
+		return nil
+	}, retry.Timeout(time.Second), retry.Delay(time.Millisecond))
+
+	// Verify that the last ack version remains the same, which represents the latest DiscoveryRequest is a NACK.
+	v2 := proxy.ecdsLastAckVersion
+	if v1.Load() == v2.Load() {
+		t.Errorf("last ack ecds request was updated. expect it to remain the same which represents a nack for ecds update")
+	}
 }
 
 func stream(t *testing.T, conn *grpc.ClientConn) discovery.AggregatedDiscoveryService_StreamAggregatedResourcesClient {

--- a/pkg/wasm/cache.go
+++ b/pkg/wasm/cache.go
@@ -41,6 +41,7 @@ const (
 // TODO(bianpengyuan): add metrics to the wasm package.
 type Cache interface {
 	Get(url, checksum string, timeout time.Duration) (string, error)
+	Cleanup()
 }
 
 // LocalFileCache for downloaded Wasm modules. Currently it stores the Wasm module as local file.
@@ -141,6 +142,11 @@ func (c *LocalFileCache) Get(downloadURL, checksum string, timeout time.Duration
 	default:
 		return "", fmt.Errorf("unsupported Wasm module downloading URL scheme: %v", url.Scheme)
 	}
+}
+
+// Cleanup closes background Wasm module purge routine.
+func (c *LocalFileCache) Cleanup() {
+	close(c.stopChan)
 }
 
 func (c *LocalFileCache) addEntry(key cacheKey, wasmModule []byte, f string) error {

--- a/pkg/wasm/convert.go
+++ b/pkg/wasm/convert.go
@@ -1,0 +1,151 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wasm
+
+import (
+	"sync"
+	"time"
+
+	udpa "github.com/cncf/udpa/go/udpa/type/v1"
+	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	wasm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/wasm/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/conversion"
+	"github.com/golang/protobuf/ptypes"
+	"github.com/golang/protobuf/ptypes/any"
+	"go.uber.org/atomic"
+)
+
+const (
+	apiTypePrefix      = "type.googleapis.com/"
+	typedStructType    = apiTypePrefix + "udpa.type.v1.TypedStruct"
+	wasmHTTPFilterType = apiTypePrefix + "envoy.extensions.filters.http.wasm.v3.Wasm"
+)
+
+// MaybeConvertWasmExtensionConfig converts any presence of module remote download to local file.
+// It downloads the Wasm module and stores the module locally in the file system.
+func MaybeConvertWasmExtensionConfig(resources []*any.Any, cache Cache) bool {
+	var wg sync.WaitGroup
+	numResources := len(resources)
+	wg.Add(numResources)
+	sendNack := atomic.NewBool(false)
+
+	for i := 0; i < numResources; i++ {
+		go func(i int) {
+			defer wg.Done()
+
+			newExtensionConfig, nack := convert(resources[i], cache)
+			if nack {
+				sendNack.Store(true)
+				return
+			}
+			resources[i] = newExtensionConfig
+		}(i)
+	}
+
+	wg.Wait()
+	return sendNack.Load()
+}
+
+func convert(resource *any.Any, cache Cache) (newExtensionConfig *any.Any, sendNack bool) {
+	ec := &core.TypedExtensionConfig{}
+	newExtensionConfig = resource
+	sendNack = false
+	if err := ptypes.UnmarshalAny(resource, ec); err != nil {
+		wasmLog.Debugf("failed to unmarshal extension config resource: %v", err)
+		return
+	}
+
+	// Currently Wasm filter can only be configured using typed struct via EnvoyFilter.
+	wasmLog.Debugf("original extension config resource %+v", ec)
+	if ec.GetTypedConfig() == nil && ec.GetTypedConfig().TypeUrl != typedStructType {
+		wasmLog.Debugf("cannot find typed struct in %+v", ec)
+		return
+	}
+	wasmStruct := &udpa.TypedStruct{}
+	wasmTypedConfig := ec.GetTypedConfig()
+	if err := ptypes.UnmarshalAny(wasmTypedConfig, wasmStruct); err != nil {
+		wasmLog.Debugf("failed to unmarshal typed config for wasm filter: %v", err)
+		return
+	}
+
+	if wasmStruct.TypeUrl != wasmHTTPFilterType {
+		wasmLog.Debugf("typed extension config %+v does not contain wasm http filter", wasmStruct)
+		return
+	}
+
+	wasmHTTPFilterConfig := &wasm.Wasm{}
+	if err := conversion.StructToMessage(wasmStruct.Value, wasmHTTPFilterConfig); err != nil {
+		wasmLog.Debugf("failed to convert extension config struct %+v to Wasm HTTP filter", wasmStruct)
+		return
+	}
+
+	if wasmHTTPFilterConfig.Config.GetVmConfig().GetCode().GetRemote() == nil {
+		wasmLog.Debugf("no remote load found in Wasm HTTP filter %+v", wasmHTTPFilterConfig)
+		return
+	}
+
+	// Wasm plugin configuration has remote load. From this point, any failure should result as a Nack,
+	// unless the plugin is marked as fail open.
+	failOpen := wasmHTTPFilterConfig.Config.GetFailOpen()
+	sendNack = !failOpen
+
+	vm := wasmHTTPFilterConfig.Config.GetVmConfig()
+	remote := vm.GetCode().GetRemote()
+	httpURI := remote.GetHttpUri()
+	if httpURI == nil {
+		wasmLog.Errorf("wasm remote fetch %+v does not have httpUri specified", remote)
+		return
+	}
+	timeout := time.Duration(0)
+	if remote.GetHttpUri().Timeout != nil {
+		timeout = remote.GetHttpUri().Timeout.AsDuration()
+	}
+	f, err := cache.Get(httpURI.GetUri(), remote.GetSha256(), timeout)
+	if err != nil {
+		wasmLog.Errorf("cannot fetch Wasm module %v: %v", remote.GetHttpUri().GetUri(), err)
+		return
+	}
+
+	// Rewrite remote fetch to local file.
+	vm.Code = &core.AsyncDataSource{
+		Specifier: &core.AsyncDataSource_Local{
+			Local: &core.DataSource{
+				Specifier: &core.DataSource_Filename{
+					Filename: f,
+				},
+			},
+		},
+	}
+
+	wasmTypedConfig, err = ptypes.MarshalAny(wasmHTTPFilterConfig)
+	if err != nil {
+		wasmLog.Errorf("failed to marshal new wasm HTTP filter %+v to protobuf Any: %v", wasmHTTPFilterConfig, err)
+		return
+	}
+	ec.TypedConfig = wasmTypedConfig
+	wasmLog.Debugf("new extension config resource %+v", ec)
+
+	nec, err := ptypes.MarshalAny(ec)
+	if err != nil {
+		wasmLog.Errorf("failed to marshal new extension config resource: %v", err)
+		return
+	}
+
+	// At this point, we are certain that wasm module has been downloaded and config is rewritten.
+	// ECDS has been rewritten successfully and should not nack.
+	newExtensionConfig = nec
+	sendNack = false
+	return
+}

--- a/pkg/wasm/convert_test.go
+++ b/pkg/wasm/convert_test.go
@@ -1,0 +1,292 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wasm
+
+import (
+	"errors"
+	"net/url"
+	"testing"
+	"time"
+
+	udpa "github.com/cncf/udpa/go/udpa/type/v1"
+	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	wasm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/wasm/v3"
+	v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/wasm/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/conversion"
+	"github.com/golang/protobuf/ptypes"
+	"github.com/golang/protobuf/ptypes/any"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"istio.io/istio/pilot/pkg/networking/util"
+)
+
+type mockCache struct{}
+
+func (c *mockCache) Get(downloadURL, checksum string, timeout time.Duration) (string, error) {
+	url, _ := url.Parse(downloadURL)
+	query := url.Query()
+
+	module := query.Get("module")
+	errMsg := query.Get("error")
+	var err error
+	if errMsg != "" {
+		err = errors.New(errMsg)
+	}
+
+	return module, err
+}
+func (c *mockCache) Cleanup() {}
+
+func TestWasmConvert(t *testing.T) {
+	cases := []struct {
+		name       string
+		input      []*core.TypedExtensionConfig
+		wantOutput []*core.TypedExtensionConfig
+		wantNack   bool
+	}{
+		{
+			name: "remote load success",
+			input: []*core.TypedExtensionConfig{
+				extensionConfigMap["remote-load-success"],
+			},
+			wantOutput: []*core.TypedExtensionConfig{
+				extensionConfigMap["remote-load-success-local-file"],
+			},
+			wantNack: false,
+		},
+		{
+			name: "remote load fail",
+			input: []*core.TypedExtensionConfig{
+				extensionConfigMap["remote-load-fail"],
+			},
+			wantOutput: []*core.TypedExtensionConfig{
+				extensionConfigMap["remote-load-fail"],
+			},
+			wantNack: true,
+		},
+		{
+			name: "mix",
+			input: []*core.TypedExtensionConfig{
+				extensionConfigMap["remote-load-fail"],
+				extensionConfigMap["remote-load-success"],
+			},
+			wantOutput: []*core.TypedExtensionConfig{
+				extensionConfigMap["remote-load-fail"],
+				extensionConfigMap["remote-load-success-local-file"],
+			},
+			wantNack: true,
+		},
+		{
+			name: "remote load fail open",
+			input: []*core.TypedExtensionConfig{
+				extensionConfigMap["remote-load-fail-open"],
+			},
+			wantOutput: []*core.TypedExtensionConfig{
+				extensionConfigMap["remote-load-fail-open"],
+			},
+			wantNack: false,
+		},
+		{
+			name: "no typed struct",
+			input: []*core.TypedExtensionConfig{
+				extensionConfigMap["empty"],
+			},
+			wantOutput: []*core.TypedExtensionConfig{
+				extensionConfigMap["empty"],
+			},
+			wantNack: false,
+		},
+		{
+			name: "no wasm",
+			input: []*core.TypedExtensionConfig{
+				extensionConfigMap["no-wasm"],
+			},
+			wantOutput: []*core.TypedExtensionConfig{
+				extensionConfigMap["no-wasm"],
+			},
+			wantNack: false,
+		},
+		{
+			name: "no remote load",
+			input: []*core.TypedExtensionConfig{
+				extensionConfigMap["no-remote-load"],
+			},
+			wantOutput: []*core.TypedExtensionConfig{
+				extensionConfigMap["no-remote-load"],
+			},
+			wantNack: false,
+		},
+		{
+			name: "no uri",
+			input: []*core.TypedExtensionConfig{
+				extensionConfigMap["no-http-uri"],
+			},
+			wantOutput: []*core.TypedExtensionConfig{
+				extensionConfigMap["no-http-uri"],
+			},
+			wantNack: true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			gotOutput := make([]*any.Any, 0, len(c.input))
+			for _, i := range c.input {
+				gotOutput = append(gotOutput, util.MessageToAny(i))
+			}
+			gotNack := MaybeConvertWasmExtensionConfig(gotOutput, &mockCache{})
+			if len(gotOutput) != len(c.wantOutput) {
+				t.Fatalf("wasm config conversion number of configuration got %v want %v", len(gotOutput), len(c.wantOutput))
+			}
+			for i, output := range gotOutput {
+				ec := &core.TypedExtensionConfig{}
+				if err := ptypes.UnmarshalAny(output, ec); err != nil {
+					t.Errorf("wasm config conversion output %v failed to unmarshal", output)
+					continue
+				}
+				if !proto.Equal(ec, c.wantOutput[i]) {
+					t.Errorf("wasm config conversion output index %d got %v want %v", i, ec, c.wantOutput[i])
+				}
+			}
+			if gotNack != c.wantNack {
+				t.Errorf("wasm config conversion send nack got %v wamt %v", gotNack, c.wantNack)
+			}
+		})
+	}
+}
+
+func buildTypedStructExtensionConfig(name string, wasm *wasm.Wasm) *core.TypedExtensionConfig {
+	ws, _ := conversion.MessageToStruct(wasm)
+	return &core.TypedExtensionConfig{
+		Name: name,
+		TypedConfig: util.MessageToAny(
+			&udpa.TypedStruct{
+				TypeUrl: wasmHTTPFilterType,
+				Value:   ws,
+			},
+		),
+	}
+}
+
+func buildWasmExtensionConfig(name string, wasm *wasm.Wasm) *core.TypedExtensionConfig {
+	return &core.TypedExtensionConfig{
+		Name:        name,
+		TypedConfig: util.MessageToAny(wasm),
+	}
+}
+
+var extensionConfigMap = map[string]*core.TypedExtensionConfig{
+	"empty": {
+		Name: "empty",
+		TypedConfig: util.MessageToAny(
+			&structpb.Struct{},
+		),
+	},
+	"no-wasm": {
+		Name: "no-wasm",
+		TypedConfig: util.MessageToAny(
+			&udpa.TypedStruct{TypeUrl: apiTypePrefix + "sometype"},
+		),
+	},
+	"no-remote-load": buildTypedStructExtensionConfig("no-remote-load", &wasm.Wasm{
+		Config: &v3.PluginConfig{
+			Vm: &v3.PluginConfig_VmConfig{
+				VmConfig: &v3.VmConfig{
+					Runtime: "envoy.wasm.runtime.null",
+					Code: &core.AsyncDataSource{Specifier: &core.AsyncDataSource_Local{
+						Local: &core.DataSource{
+							Specifier: &core.DataSource_InlineString{
+								InlineString: "envoy.wasm.metadata_exchange",
+							},
+						},
+					}},
+				},
+			},
+		},
+	}),
+	"no-http-uri": buildTypedStructExtensionConfig("no-remote-load", &wasm.Wasm{
+		Config: &v3.PluginConfig{
+			Vm: &v3.PluginConfig_VmConfig{
+				VmConfig: &v3.VmConfig{
+					Code: &core.AsyncDataSource{Specifier: &core.AsyncDataSource_Remote{
+						Remote: &core.RemoteDataSource{},
+					}},
+				},
+			},
+		},
+	}),
+	"remote-load-success": buildTypedStructExtensionConfig("remote-load-success", &wasm.Wasm{
+		Config: &v3.PluginConfig{
+			Vm: &v3.PluginConfig_VmConfig{
+				VmConfig: &v3.VmConfig{
+					Code: &core.AsyncDataSource{Specifier: &core.AsyncDataSource_Remote{
+						Remote: &core.RemoteDataSource{
+							HttpUri: &core.HttpUri{
+								Uri: "http://test?module=test.wasm",
+							},
+						},
+					}},
+				},
+			},
+		},
+	}),
+	"remote-load-success-local-file": buildWasmExtensionConfig("remote-load-success", &wasm.Wasm{
+		Config: &v3.PluginConfig{
+			Vm: &v3.PluginConfig_VmConfig{
+				VmConfig: &v3.VmConfig{
+					Code: &core.AsyncDataSource{Specifier: &core.AsyncDataSource_Local{
+						Local: &core.DataSource{
+							Specifier: &core.DataSource_Filename{
+								Filename: "test.wasm",
+							},
+						},
+					}},
+				},
+			},
+		},
+	}),
+	"remote-load-fail": buildTypedStructExtensionConfig("remote-load-fail", &wasm.Wasm{
+		Config: &v3.PluginConfig{
+			Vm: &v3.PluginConfig_VmConfig{
+				VmConfig: &v3.VmConfig{
+					Code: &core.AsyncDataSource{Specifier: &core.AsyncDataSource_Remote{
+						Remote: &core.RemoteDataSource{
+							HttpUri: &core.HttpUri{
+								Uri: "http://test?module=test.wasm&error=download-error",
+							},
+						},
+					}},
+				},
+			},
+		},
+	}),
+	"remote-load-fail-open": buildTypedStructExtensionConfig("remote-load-fail", &wasm.Wasm{
+		Config: &v3.PluginConfig{
+			Vm: &v3.PluginConfig_VmConfig{
+				VmConfig: &v3.VmConfig{
+					Code: &core.AsyncDataSource{Specifier: &core.AsyncDataSource_Remote{
+						Remote: &core.RemoteDataSource{
+							HttpUri: &core.HttpUri{
+								Uri: "http://test?module=test.wasm&error=download-error",
+							},
+						},
+					}},
+				},
+			},
+			FailOpen: true,
+		},
+	}),
+}

--- a/releasenotes/notes/reliable-wasm-remote-load.yaml
+++ b/releasenotes/notes/reliable-wasm-remote-load.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: feature
+area: extension
+issue:
+  - 29989
+
+releaseNotes:
+- |
+  **Added** Reliable Wasm module remote load with istio-agent.


### PR DESCRIPTION
Manual cherry-pick of https://github.com/istio/istio/issues/30235

* Add ECDS interception and Wasm conversion into xds proxy.

* update

* file path

* fix race in test

* clean up

* do not block on downstream error channel

* add a release note.

* add feature flag for Wasm remote load conversion.

* update

* update



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.