### PR TITLE
Use generated label variables

### DIFF
--- a/galley/pkg/config/analysis/analyzers/injection/injection.go
+++ b/galley/pkg/config/analysis/analyzers/injection/injection.go
@@ -38,8 +38,8 @@ var _ analysis.Analyzer = &Analyzer{}
 // We assume that enablement is via an istio-injection=enabled or istio.io/rev namespace label
 // In theory, there can be alternatives using Mutatingwebhookconfiguration, but they're very uncommon
 // See https://istio.io/docs/ops/troubleshooting/injection/ for more info.
-const (
-	RevisionInjectionLabelName = label.IstioRev
+var (
+	RevisionInjectionLabelName = label.IoIstioRev.Name
 )
 
 // Metadata implements Analyzer

--- a/istioctl/cmd/injector-list.go
+++ b/istioctl/cmd/injector-list.go
@@ -177,7 +177,7 @@ func printHooks(writer io.Writer, namespaces []v1.Namespace, hooks []admit_v1.Mu
 	w := new(tabwriter.Writer).Init(writer, 0, 8, 1, ' ', 0)
 	fmt.Fprintln(w, "NAMESPACES\tINJECTOR-HOOK\tISTIO-REVISION\tSIDECAR-IMAGE")
 	for _, hook := range hooks {
-		revision := hook.ObjectMeta.GetLabels()[label.IstioRev]
+		revision := hook.ObjectMeta.GetLabels()[label.IoIstioRev.Name]
 		namespaces := getMatchingNamespaces(&hook, namespaces)
 		if len(namespaces) == 0 {
 			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", "DOES NOT AUTOINJECT", hook.Name, revision, injectedImages[revision])
@@ -209,9 +209,9 @@ func getInjector(namespace *v1.Namespace, hooks []admit_v1.MutatingWebhookConfig
 func getInjectedRevision(namespace *v1.Namespace, hooks []admit_v1.MutatingWebhookConfiguration) string {
 	injector := getInjector(namespace, hooks)
 	if injector != nil {
-		return injector.ObjectMeta.GetLabels()[label.IstioRev]
+		return injector.ObjectMeta.GetLabels()[label.IoIstioRev.Name]
 	}
-	newRev := namespace.ObjectMeta.GetLabels()[label.IstioRev]
+	newRev := namespace.ObjectMeta.GetLabels()[label.IoIstioRev.Name]
 	oldLabel, ok := namespace.ObjectMeta.GetLabels()[analyzer_util.InjectionLabelName]
 	// If there is no istio-injection=disabled and no istio.io/rev, the namespace isn't injected
 	if newRev == "" && (ok && oldLabel == "disabled" || !ok) {
@@ -263,7 +263,7 @@ func getInjectedImages(ctx context.Context, client kube.ExtendedClient) (map[str
 	retval := map[string]string{}
 
 	// All configs in all namespaces that are Istio revisioned
-	configMaps, err := client.CoreV1().ConfigMaps("").List(ctx, metav1.ListOptions{LabelSelector: label.IstioRev})
+	configMaps, err := client.CoreV1().ConfigMaps("").List(ctx, metav1.ListOptions{LabelSelector: label.IoIstioRev.Name})
 	if err != nil {
 		return retval, err
 	}
@@ -271,7 +271,7 @@ func getInjectedImages(ctx context.Context, client kube.ExtendedClient) (map[str
 	for _, configMap := range configMaps.Items {
 		image := injection.GetIstioProxyImage(&configMap)
 		if image != "" {
-			retval[configMap.ObjectMeta.GetLabels()[label.IstioRev]] = image
+			retval[configMap.ObjectMeta.GetLabels()[label.IoIstioRev.Name]] = image
 		}
 	}
 
@@ -282,7 +282,7 @@ func getInjectedImages(ctx context.Context, client kube.ExtendedClient) (map[str
 func podCountByRevision(pods []v1.Pod, expectedRevision string) map[string]revisionCount {
 	retval := map[string]revisionCount{}
 	for _, pod := range pods {
-		revision := pod.ObjectMeta.GetLabels()[label.IstioRev]
+		revision := pod.ObjectMeta.GetLabels()[label.IoIstioRev.Name]
 		revisionLabel := revision
 		if revision == "" {
 			revisionLabel = "<non-Istio>"

--- a/istioctl/cmd/tag.go
+++ b/istioctl/cmd/tag.go
@@ -334,7 +334,7 @@ func getWebhooksWithTag(ctx context.Context, client kubernetes.Interface, tag st
 // this retrieves the webhook created at revision installation rather than tag webhooks
 func getWebhooksWithRevision(ctx context.Context, client kubernetes.Interface, rev string) ([]admit_v1.MutatingWebhookConfiguration, error) {
 	webhooks, err := client.AdmissionregistrationV1().MutatingWebhookConfigurations().List(ctx, metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("%s=%s,!%s", label.IstioRev, rev, istioTagLabel),
+		LabelSelector: fmt.Sprintf("%s=%s,!%s", label.IoIstioRev.Name, rev, istioTagLabel),
 	})
 	if err != nil {
 		return nil, err
@@ -345,7 +345,7 @@ func getWebhooksWithRevision(ctx context.Context, client kubernetes.Interface, r
 // getNamespacesWithTag retrieves all namespaces pointed at the given tag.
 func getNamespacesWithTag(ctx context.Context, client kubernetes.Interface, tag string) ([]string, error) {
 	namespaces, err := client.CoreV1().Namespaces().List(ctx, metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("%s=%s", label.IstioRev, tag),
+		LabelSelector: fmt.Sprintf("%s=%s", label.IoIstioRev.Name, tag),
 	})
 	if err != nil {
 		return nil, err
@@ -368,7 +368,7 @@ func getWebhookName(wh admit_v1.MutatingWebhookConfiguration) (string, error) {
 
 // getRevision extracts tag target revision from webhook object.
 func getWebhookRevision(wh admit_v1.MutatingWebhookConfiguration) (string, error) {
-	if tagName, ok := wh.ObjectMeta.Labels[label.IstioRev]; ok {
+	if tagName, ok := wh.ObjectMeta.Labels[label.IoIstioRev.Name]; ok {
 		return tagName, nil
 	}
 	return "", fmt.Errorf("could not extract tag revision from webhook")

--- a/istioctl/cmd/tag_test.go
+++ b/istioctl/cmd/tag_test.go
@@ -40,7 +40,7 @@ var (
 	revisionCanonicalWebhook = admit_v1.MutatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "istio-sidecar-injector-revision",
-			Labels: map[string]string{label.IstioRev: "revision"},
+			Labels: map[string]string{label.IoIstioRev.Name: "revision"},
 		},
 		Webhooks: []admit_v1.MutatingWebhook{
 			{
@@ -58,7 +58,7 @@ var (
 	revisionCanonicalWebhookRemote = admit_v1.MutatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "istio-sidecar-injector-revision",
-			Labels: map[string]string{label.IstioRev: "revision"},
+			Labels: map[string]string{label.IoIstioRev.Name: "revision"},
 		},
 		Webhooks: []admit_v1.MutatingWebhook{
 			{
@@ -89,7 +89,7 @@ func TestTagList(t *testing.T) {
 							Name: "istio-revision-tag-sample",
 							Labels: map[string]string{
 								istioTagLabel:                         "sample",
-								label.IstioRev:                        "sample-revision",
+								label.IoIstioRev.Name:                 "sample-revision",
 								helmreconciler.IstioComponentLabelStr: "Pilot",
 							},
 						},
@@ -108,7 +108,7 @@ func TestTagList(t *testing.T) {
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:   "istio-revision-test",
-							Labels: map[string]string{label.IstioRev: "test"},
+							Labels: map[string]string{label.IoIstioRev.Name: "test"},
 						},
 					},
 				},
@@ -126,8 +126,8 @@ func TestTagList(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "istio-revision-test",
 							Labels: map[string]string{
-								label.IstioRev: "revision",
-								istioTagLabel:  "test",
+								label.IoIstioRev.Name: "revision",
+								istioTagLabel:         "test",
 							},
 						},
 					},
@@ -138,7 +138,7 @@ func TestTagList(t *testing.T) {
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:   "dependent",
-							Labels: map[string]string{label.IstioRev: "test"},
+							Labels: map[string]string{label.IoIstioRev.Name: "test"},
 						},
 					},
 				},
@@ -267,7 +267,7 @@ func TestRemoveTag(t *testing.T) {
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:   "dependent",
-							Labels: map[string]string{label.IstioRev: "match"},
+							Labels: map[string]string{label.IoIstioRev.Name: "match"},
 						},
 					},
 				},
@@ -366,7 +366,7 @@ func TestSetTagWebhookCreation(t *testing.T) {
 				Operator: metav1.LabelSelectorOpDoesNotExist,
 			},
 			{
-				Key:      label.IstioRev,
+				Key:      label.IoIstioRev.Name,
 				Operator: metav1.LabelSelectorOpIn,
 				Values:   []string{"canary"},
 			},

--- a/istioctl/pkg/verifier/verifier.go
+++ b/istioctl/pkg/verifier/verifier.go
@@ -149,7 +149,7 @@ func (v *StatusVerifier) getRevision() (string, error) {
 		return "", fmt.Errorf("failed to fetch istiod pod, error: %v", err)
 	}
 	for _, pod := range pods.Items {
-		rev := pod.ObjectMeta.GetLabels()[label.IstioRev]
+		rev := pod.ObjectMeta.GetLabels()[label.IoIstioRev.Name]
 		revCount++
 		if rev == "default" {
 			continue
@@ -370,7 +370,7 @@ func (v *StatusVerifier) injectorFromCluster(revision string) (*admit_v1.Mutatin
 	revCount := 0
 	var hookmatch *admit_v1.MutatingWebhookConfiguration
 	for _, hook := range hooks.Items {
-		rev := hook.ObjectMeta.GetLabels()[label.IstioRev]
+		rev := hook.ObjectMeta.GetLabels()[label.IoIstioRev.Name]
 		if rev != "" {
 			revCount++
 			revision = rev

--- a/operator/cmd/mesh/shared.go
+++ b/operator/cmd/mesh/shared.go
@@ -259,7 +259,7 @@ func createNamespace(cs kubernetes.Interface, namespace string, network string) 
 				},
 			}}
 			if network != "" {
-				ns.Labels[label.IstioNetwork] = network
+				ns.Labels[label.TopologyNetwork.Name] = network
 			}
 			_, err := cs.CoreV1().Namespaces().Create(context.TODO(), ns, v12.CreateOptions{})
 			if err != nil {

--- a/operator/pkg/helmreconciler/prune.go
+++ b/operator/pkg/helmreconciler/prune.go
@@ -186,7 +186,7 @@ func (h *HelmReconciler) GetPrunedResources(revision string, includeClusterResou
 	var usList []*unstructured.UnstructuredList
 	labels := make(map[string]string)
 	if revision != "" {
-		labels[label.IstioRev] = revision
+		labels[label.IoIstioRev.Name] = revision
 	}
 	if componentName != "" {
 		labels[IstioComponentLabelStr] = componentName
@@ -249,7 +249,7 @@ func (h *HelmReconciler) DeleteControlPlaneByManifests(manifestMap name.Manifest
 	}
 	cpManifestMap := make(name.ManifestMap)
 	if revision != "" {
-		labels[label.IstioRev] = revision
+		labels[label.IoIstioRev.Name] = revision
 	}
 	if !includeClusterResources {
 		// only delete istiod resources if revision is empty and --purge flag is not true.

--- a/operator/pkg/helmreconciler/reconciler.go
+++ b/operator/pkg/helmreconciler/reconciler.go
@@ -392,7 +392,7 @@ func (h *HelmReconciler) getCoreOwnerLabels() (map[string]string, error) {
 	if revision == "" {
 		revision = "default"
 	}
-	labels[label.IstioRev] = revision
+	labels[label.IoIstioRev.Name] = revision
 
 	return labels, nil
 }
@@ -516,7 +516,7 @@ func (h *HelmReconciler) createNamespace(namespace string, network string) error
 				},
 			}}
 			if network != "" {
-				ns.Labels[label.IstioNetwork] = network
+				ns.Labels[label.TopologyNetwork.Name] = network
 			}
 			_, err := h.clientSet.CoreV1().Namespaces().Create(context.TODO(), ns, metav1.CreateOptions{})
 			if err != nil {

--- a/pilot/pkg/config/kube/crdclient/client.go
+++ b/pilot/pkg/config/kube/crdclient/client.go
@@ -300,7 +300,7 @@ func (cl *Client) List(kind config.GroupVersionKind, namespace string) ([]config
 }
 
 func (cl *Client) objectInRevision(o *config.Config) bool {
-	configEnv, f := o.Labels[label.IstioRev]
+	configEnv, f := o.Labels[label.IoIstioRev.Name]
 	if !f {
 		// This is a global object, and always included
 		return true

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -620,7 +620,7 @@ func (s *Service) GetServiceAddressForProxy(node *Proxy, push *PushContext) stri
 // and apply custom transport socket matchers here.
 func GetTLSModeFromEndpointLabels(labels map[string]string) string {
 	if labels != nil {
-		if val, exists := labels[label.TLSMode]; exists {
+		if val, exists := labels[label.SecurityTlsMode.Name]; exists {
 			return val
 		}
 	}

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -708,7 +708,7 @@ func (c *Controller) getPodLocality(pod *v1.Pod) string {
 
 	region := getLabelValue(nodeMeta, NodeRegionLabel, NodeRegionLabelGA)
 	zone := getLabelValue(nodeMeta, NodeZoneLabel, NodeZoneLabelGA)
-	subzone := getLabelValue(nodeMeta, label.IstioSubZone, "")
+	subzone := getLabelValue(nodeMeta, label.TopologySubzone.Name, "")
 
 	if region == "" && zone == "" && subzone == "" {
 		return ""
@@ -1004,7 +1004,7 @@ func (c *Controller) onNamespaceEvent(obj interface{}, ev model.Event) error {
 			log.Warnf("Namespace watch getting wrong type in event: %T", obj)
 			return nil
 		}
-		nw = ns.Labels[label.IstioNetwork]
+		nw = ns.Labels[label.TopologyNetwork.Name]
 	}
 	c.Lock()
 	oldDefaultNetwork := c.network

--- a/pilot/pkg/serviceregistry/kube/controller/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller_test.go
@@ -198,8 +198,8 @@ func TestController_GetPodLocality(t *testing.T) {
 			name: "should return correct az for given address",
 			pods: []*coreV1.Pod{pod1, pod2},
 			nodes: []*coreV1.Node{
-				generateNode("node1", map[string]string{NodeZoneLabel: "zone1", NodeRegionLabel: "region1", label.IstioSubZone: "subzone1"}),
-				generateNode("node2", map[string]string{NodeZoneLabel: "zone2", NodeRegionLabel: "region2", label.IstioSubZone: "subzone2"}),
+				generateNode("node1", map[string]string{NodeZoneLabel: "zone1", NodeRegionLabel: "region1", label.TopologySubzone.Name: "subzone1"}),
+				generateNode("node2", map[string]string{NodeZoneLabel: "zone2", NodeRegionLabel: "region2", label.TopologySubzone.Name: "subzone2"}),
 			},
 			wantAZ: map[*coreV1.Pod]string{
 				pod1: "region1/zone1/subzone1",
@@ -261,8 +261,8 @@ func TestController_GetPodLocality(t *testing.T) {
 			name: "should return correct az if node has only subzone label",
 			pods: []*coreV1.Pod{pod1, pod2},
 			nodes: []*coreV1.Node{
-				generateNode("node1", map[string]string{label.IstioSubZone: "subzone1"}),
-				generateNode("node2", map[string]string{label.IstioSubZone: "subzone2"}),
+				generateNode("node1", map[string]string{label.TopologySubzone.Name: "subzone1"}),
+				generateNode("node2", map[string]string{label.TopologySubzone.Name: "subzone2"}),
 			},
 			wantAZ: map[*coreV1.Pod]string{
 				pod1: "//subzone1",
@@ -273,7 +273,7 @@ func TestController_GetPodLocality(t *testing.T) {
 			name: "should return correct az for given address",
 			pods: []*coreV1.Pod{podOverride},
 			nodes: []*coreV1.Node{
-				generateNode("node1", map[string]string{NodeZoneLabel: "zone1", NodeRegionLabel: "region1", label.IstioSubZone: "subzone1"}),
+				generateNode("node1", map[string]string{NodeZoneLabel: "zone1", NodeRegionLabel: "region1", label.TopologySubzone.Name: "subzone1"}),
 			},
 			wantAZ: map[*coreV1.Pod]string{
 				podOverride: "regionOverride/zoneOverride/subzoneOverride",
@@ -393,8 +393,8 @@ func TestGetProxyServiceInstances(t *testing.T) {
 				Metadata: &model.NodeMetadata{ServiceAccount: "account",
 					ClusterID: clusterID,
 					Labels: map[string]string{
-						"app":         "prod-app",
-						label.TLSMode: "mutual",
+						"app":                      "prod-app",
+						label.SecurityTlsMode.Name: "mutual",
 					}},
 			})
 
@@ -416,11 +416,11 @@ func TestGetProxyServiceInstances(t *testing.T) {
 				ServicePort: &model.Port{Name: "tcp-port", Port: 8080, Protocol: protocol.TCP},
 				Endpoint: &model.IstioEndpoint{
 					Labels: labels.Instance{
-						"app":              "prod-app",
-						label.TLSMode:      "mutual",
-						NodeRegionLabelGA:  "r",
-						NodeZoneLabelGA:    "z",
-						label.IstioCluster: clusterID,
+						"app":                      "prod-app",
+						label.SecurityTlsMode.Name: "mutual",
+						NodeRegionLabelGA:          "r",
+						NodeZoneLabelGA:            "z",
+						label.TopologyCluster.Name: clusterID,
 					},
 					ServiceAccount:  "account",
 					Address:         "1.1.1.1",
@@ -442,7 +442,7 @@ func TestGetProxyServiceInstances(t *testing.T) {
 
 			// Test that we first look up instances by Proxy pod
 
-			node := generateNode("node1", map[string]string{NodeZoneLabel: "zone1", NodeRegionLabel: "region1", label.IstioSubZone: "subzone1"})
+			node := generateNode("node1", map[string]string{NodeZoneLabel: "zone1", NodeRegionLabel: "region1", label.TopologySubzone.Name: "subzone1"})
 			addNodes(t, controller, node)
 
 			// 1. pod without `istio-locality` label, get locality from node label.
@@ -488,11 +488,11 @@ func TestGetProxyServiceInstances(t *testing.T) {
 						ClusterID: clusterID,
 					},
 					Labels: labels.Instance{
-						"app":              "prod-app",
-						NodeRegionLabelGA:  "region1",
-						NodeZoneLabelGA:    "zone1",
-						label.IstioSubZone: "subzone1",
-						label.IstioCluster: clusterID,
+						"app":                      "prod-app",
+						NodeRegionLabelGA:          "region1",
+						NodeZoneLabelGA:            "zone1",
+						label.TopologySubzone.Name: "subzone1",
+						label.TopologyCluster.Name: clusterID,
 					},
 					ServiceAccount: "spiffe://cluster.local/ns/nsa/sa/svcaccount",
 					TLSMode:        model.DisabledTLSModeLabel,
@@ -550,11 +550,11 @@ func TestGetProxyServiceInstances(t *testing.T) {
 						ClusterID: clusterID,
 					},
 					Labels: labels.Instance{
-						"app":              "prod-app",
-						"istio-locality":   "region.zone",
-						NodeRegionLabelGA:  "region",
-						NodeZoneLabelGA:    "zone",
-						label.IstioCluster: clusterID,
+						"app":                      "prod-app",
+						"istio-locality":           "region.zone",
+						NodeRegionLabelGA:          "region",
+						NodeZoneLabelGA:            "zone",
+						label.TopologyCluster.Name: clusterID,
 					},
 					ServiceAccount: "spiffe://cluster.local/ns/nsa/sa/svcaccount",
 					TLSMode:        model.DisabledTLSModeLabel,
@@ -1447,7 +1447,7 @@ func TestEndpointUpdateBeforePodUpdate(t *testing.T) {
 			controller, fx := NewFakeControllerWithOptions(FakeControllerOptions{Mode: mode})
 			// Setup kube caches
 			defer controller.Stop()
-			addNodes(t, controller, generateNode("node1", map[string]string{NodeZoneLabel: "zone1", NodeRegionLabel: "region1", label.IstioSubZone: "subzone1"}))
+			addNodes(t, controller, generateNode("node1", map[string]string{NodeZoneLabel: "zone1", NodeRegionLabel: "region1", label.TopologySubzone.Name: "subzone1"}))
 			// Setup help functions to make the test more explicit
 			addPod := func(name, ip string) {
 				pod := generatePod(ip, name, "nsA", name, "node1", map[string]string{"app": "prod-app"}, map[string]string{})
@@ -1604,7 +1604,7 @@ func TestWorkloadInstanceHandlerMultipleEndpoints(t *testing.T) {
 	pod2 := generatePod("172.0.1.2", "pod2", "nsA", "", "node1", map[string]string{"app": "prod-app"}, map[string]string{})
 	pods := []*coreV1.Pod{pod1, pod2}
 	nodes := []*coreV1.Node{
-		generateNode("node1", map[string]string{NodeZoneLabel: "zone1", NodeRegionLabel: "region1", label.IstioSubZone: "subzone1"}),
+		generateNode("node1", map[string]string{NodeZoneLabel: "zone1", NodeRegionLabel: "region1", label.TopologySubzone.Name: "subzone1"}),
 	}
 	addNodes(t, controller, nodes...)
 	addPods(t, controller, fx, pods...)

--- a/pilot/pkg/serviceregistry/kube/controller/endpoint_builder.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpoint_builder.go
@@ -92,7 +92,7 @@ func augmentLabels(in labels.Instance, clusterID, locality string) labels.Instan
 		out[k] = v
 	}
 
-	// Don't need to add label.IstioNetwork, since that's already added by injection.
+	// Don't need to add label.TopologyNetwork.Name, since that's already added by injection.
 	region, zone, subzone := model.SplitLocalityLabel(locality)
 	if len(region) > 0 {
 		out[NodeRegionLabelGA] = region
@@ -101,10 +101,10 @@ func augmentLabels(in labels.Instance, clusterID, locality string) labels.Instan
 		out[NodeZoneLabelGA] = zone
 	}
 	if len(subzone) > 0 {
-		out[label.IstioSubZone] = subzone
+		out[label.TopologySubzone.Name] = subzone
 	}
 	if len(clusterID) > 0 {
-		out[label.IstioCluster] = clusterID
+		out[label.TopologyCluster.Name] = clusterID
 	}
 	return out
 }
@@ -150,7 +150,7 @@ func (b *EndpointBuilder) endpointNetwork(endpointIP string) string {
 	}
 
 	// If not using cidr-lookup, or non of the given ranges contain the address, use the pod-label
-	if nw := b.labels[label.IstioNetwork]; nw != "" {
+	if nw := b.labels[label.TopologyNetwork.Name]; nw != "" {
 		return nw
 	}
 

--- a/pilot/pkg/serviceregistry/kube/controller/endpoint_builder_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpoint_builder_test.go
@@ -46,13 +46,13 @@ func TestNewEndpointBuilderTopologyLabels(t *testing.T) {
 				locality: "myregion",
 			},
 			podLabels: labels.Instance{
-				"k1":               "v1",
-				label.IstioNetwork: "mynetwork",
+				"k1":                       "v1",
+				label.TopologyNetwork.Name: "mynetwork",
 			},
 			expected: labels.Instance{
-				"k1":               "v1",
-				NodeRegionLabelGA:  "myregion",
-				label.IstioNetwork: "mynetwork",
+				"k1":                       "v1",
+				NodeRegionLabelGA:          "myregion",
+				label.TopologyNetwork.Name: "mynetwork",
 			},
 		},
 		{
@@ -61,14 +61,14 @@ func TestNewEndpointBuilderTopologyLabels(t *testing.T) {
 				locality: "myregion/myzone",
 			},
 			podLabels: labels.Instance{
-				"k1":               "v1",
-				label.IstioNetwork: "mynetwork",
+				"k1":                       "v1",
+				label.TopologyNetwork.Name: "mynetwork",
 			},
 			expected: labels.Instance{
-				"k1":               "v1",
-				NodeRegionLabelGA:  "myregion",
-				NodeZoneLabelGA:    "myzone",
-				label.IstioNetwork: "mynetwork",
+				"k1":                       "v1",
+				NodeRegionLabelGA:          "myregion",
+				NodeZoneLabelGA:            "myzone",
+				label.TopologyNetwork.Name: "mynetwork",
 			},
 		},
 		{
@@ -78,16 +78,16 @@ func TestNewEndpointBuilderTopologyLabels(t *testing.T) {
 				cluster:  "mycluster",
 			},
 			podLabels: labels.Instance{
-				"k1":               "v1",
-				label.IstioNetwork: "mynetwork",
+				"k1":                       "v1",
+				label.TopologyNetwork.Name: "mynetwork",
 			},
 			expected: labels.Instance{
-				"k1":               "v1",
-				NodeRegionLabelGA:  "myregion",
-				NodeZoneLabelGA:    "myzone",
-				label.IstioSubZone: "mysubzone",
-				label.IstioCluster: "mycluster",
-				label.IstioNetwork: "mynetwork",
+				"k1":                       "v1",
+				NodeRegionLabelGA:          "myregion",
+				NodeZoneLabelGA:            "myzone",
+				label.TopologySubzone.Name: "mysubzone",
+				label.TopologyCluster.Name: "mycluster",
+				label.TopologyNetwork.Name: "mynetwork",
 			},
 		},
 	}
@@ -130,8 +130,8 @@ func TestNewEndpointBuilderFromMetadataTopologyLabels(t *testing.T) {
 			proxy: &model.Proxy{
 				Metadata: &model.NodeMetadata{
 					Labels: labels.Instance{
-						"k1":               "v1",
-						label.IstioNetwork: "mynetwork",
+						"k1":                       "v1",
+						label.TopologyNetwork.Name: "mynetwork",
 					},
 				},
 				Locality: &core.Locality{
@@ -139,9 +139,9 @@ func TestNewEndpointBuilderFromMetadataTopologyLabels(t *testing.T) {
 				},
 			},
 			expected: labels.Instance{
-				"k1":               "v1",
-				NodeRegionLabelGA:  "myregion",
-				label.IstioNetwork: "mynetwork",
+				"k1":                       "v1",
+				NodeRegionLabelGA:          "myregion",
+				label.TopologyNetwork.Name: "mynetwork",
 			},
 		},
 		{
@@ -150,8 +150,8 @@ func TestNewEndpointBuilderFromMetadataTopologyLabels(t *testing.T) {
 			proxy: &model.Proxy{
 				Metadata: &model.NodeMetadata{
 					Labels: labels.Instance{
-						"k1":               "v1",
-						label.IstioNetwork: "mynetwork",
+						"k1":                       "v1",
+						label.TopologyNetwork.Name: "mynetwork",
 					},
 				},
 				Locality: &core.Locality{
@@ -160,10 +160,10 @@ func TestNewEndpointBuilderFromMetadataTopologyLabels(t *testing.T) {
 				},
 			},
 			expected: labels.Instance{
-				"k1":               "v1",
-				NodeRegionLabelGA:  "myregion",
-				NodeZoneLabelGA:    "myzone",
-				label.IstioNetwork: "mynetwork",
+				"k1":                       "v1",
+				NodeRegionLabelGA:          "myregion",
+				NodeZoneLabelGA:            "myzone",
+				label.TopologyNetwork.Name: "mynetwork",
 			},
 		},
 		{
@@ -174,8 +174,8 @@ func TestNewEndpointBuilderFromMetadataTopologyLabels(t *testing.T) {
 			proxy: &model.Proxy{
 				Metadata: &model.NodeMetadata{
 					Labels: labels.Instance{
-						"k1":               "v1",
-						label.IstioNetwork: "mynetwork",
+						"k1":                       "v1",
+						label.TopologyNetwork.Name: "mynetwork",
 					},
 				},
 				Locality: &core.Locality{
@@ -185,12 +185,12 @@ func TestNewEndpointBuilderFromMetadataTopologyLabels(t *testing.T) {
 				},
 			},
 			expected: labels.Instance{
-				"k1":               "v1",
-				NodeRegionLabelGA:  "myregion",
-				NodeZoneLabelGA:    "myzone",
-				label.IstioSubZone: "mysubzone",
-				label.IstioCluster: "mycluster",
-				label.IstioNetwork: "mynetwork",
+				"k1":                       "v1",
+				NodeRegionLabelGA:          "myregion",
+				NodeZoneLabelGA:            "myzone",
+				label.TopologySubzone.Name: "mysubzone",
+				label.TopologyCluster.Name: "mycluster",
+				label.TopologyNetwork.Name: "mynetwork",
 			},
 		},
 	}

--- a/pilot/pkg/serviceregistry/kube/controller/endpointslice.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpointslice.go
@@ -285,8 +285,8 @@ func getLocalityFromTopology(topology map[string]string) string {
 	if _, f := topology[NodeZoneLabelGA]; f {
 		locality += "/" + topology[NodeZoneLabelGA]
 	}
-	if _, f := topology[label.IstioSubZone]; f {
-		locality += "/" + topology[label.IstioSubZone]
+	if _, f := topology[label.TopologySubzone.Name]; f {
+		locality += "/" + topology[label.TopologySubzone.Name]
 	}
 	return locality
 }

--- a/pilot/pkg/serviceregistry/kube/controller/endpointslice_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpointslice_test.go
@@ -38,9 +38,9 @@ func TestGetLocalityFromTopology(t *testing.T) {
 		{
 			"all standard kubernetes labels and Istio custom labels",
 			map[string]string{
-				NodeRegionLabelGA:  "region",
-				NodeZoneLabelGA:    "zone",
-				label.IstioSubZone: "subzone",
+				NodeRegionLabelGA:          "region",
+				NodeZoneLabelGA:            "zone",
+				label.TopologySubzone.Name: "subzone",
 			},
 			"region/zone/subzone",
 		},

--- a/pilot/pkg/serviceregistry/kube/controller/network.go
+++ b/pilot/pkg/serviceregistry/kube/controller/network.go
@@ -210,7 +210,7 @@ func (c *Controller) extractGatewaysInner(svc *model.Service) bool {
 // Zero values are returned if the service is not a cross-network gateway.
 func (c *Controller) getGatewayDetails(svc *model.Service) (uint32, string) {
 	// label based gateways
-	if nw := svc.Attributes.Labels[label.IstioNetwork]; nw != "" {
+	if nw := svc.Attributes.Labels[label.TopologyNetwork.Name]; nw != "" {
 		if gwPortStr := svc.Attributes.Labels[IstioGatewayPortLabel]; gwPortStr != "" {
 			if gwPort, err := strconv.Atoi(gwPortStr); err == nil {
 				return uint32(gwPort), nw

--- a/pilot/pkg/serviceregistry/serviceentry/conversion.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion.go
@@ -339,7 +339,7 @@ func getTLSModeFromWorkloadEntry(wle *networking.WorkloadEntry) string {
 	// * Use security.istio.io/tlsMode if its present
 	// * If not, set TLS mode if ServiceAccount is specified
 	tlsMode := model.DisabledTLSModeLabel
-	if val, exists := wle.Labels[label.TLSMode]; exists {
+	if val, exists := wle.Labels[label.SecurityTlsMode.Name]; exists {
 		tlsMode = val
 	} else if wle.ServiceAccount != "" {
 		tlsMode = model.IstioMutualTLSModeLabel

--- a/pilot/pkg/serviceregistry/serviceentry/conversion_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion_test.go
@@ -88,12 +88,12 @@ var httpStatic = &config.Config{
 			{
 				Address: "2.2.2.2",
 				Ports:   map[string]uint32{"http-port": 7080, "http-alt-port": 18080},
-				Labels:  map[string]string{label.TLSMode: model.IstioMutualTLSModeLabel},
+				Labels:  map[string]string{label.SecurityTlsMode.Name: model.IstioMutualTLSModeLabel},
 			},
 			{
 				Address: "3.3.3.3",
 				Ports:   map[string]uint32{"http-port": 1080},
-				Labels:  map[string]string{label.TLSMode: model.IstioMutualTLSModeLabel},
+				Labels:  map[string]string{label.SecurityTlsMode.Name: model.IstioMutualTLSModeLabel},
 			},
 			{
 				Address: "4.4.4.4",
@@ -136,7 +136,7 @@ var httpDNSnoEndpoints = &config.Config{
 		Name:              "httpDNSnoEndpoints",
 		Namespace:         "httpDNSnoEndpoints",
 		CreationTimestamp: GlobalTime,
-		Labels:            map[string]string{label.TLSMode: model.IstioMutualTLSModeLabel},
+		Labels:            map[string]string{label.SecurityTlsMode.Name: model.IstioMutualTLSModeLabel},
 	},
 	Spec: &networking.ServiceEntry{
 		Hosts: []string{"google.com", "www.wikipedia.org"},
@@ -172,7 +172,7 @@ var httpDNS = &config.Config{
 		Name:              "httpDNS",
 		Namespace:         "httpDNS",
 		CreationTimestamp: GlobalTime,
-		Labels:            map[string]string{label.TLSMode: model.IstioMutualTLSModeLabel},
+		Labels:            map[string]string{label.SecurityTlsMode.Name: model.IstioMutualTLSModeLabel},
 	},
 	Spec: &networking.ServiceEntry{
 		Hosts: []string{"*.google.com"},
@@ -184,16 +184,16 @@ var httpDNS = &config.Config{
 			{
 				Address: "us.google.com",
 				Ports:   map[string]uint32{"http-port": 7080, "http-alt-port": 18080},
-				Labels:  map[string]string{label.TLSMode: model.IstioMutualTLSModeLabel},
+				Labels:  map[string]string{label.SecurityTlsMode.Name: model.IstioMutualTLSModeLabel},
 			},
 			{
 				Address: "uk.google.com",
 				Ports:   map[string]uint32{"http-port": 1080},
-				Labels:  map[string]string{label.TLSMode: model.IstioMutualTLSModeLabel},
+				Labels:  map[string]string{label.SecurityTlsMode.Name: model.IstioMutualTLSModeLabel},
 			},
 			{
 				Address: "de.google.com",
-				Labels:  map[string]string{"foo": "bar", label.TLSMode: model.IstioMutualTLSModeLabel},
+				Labels:  map[string]string{"foo": "bar", label.SecurityTlsMode.Name: model.IstioMutualTLSModeLabel},
 			},
 		},
 		Location:   networking.ServiceEntry_MESH_EXTERNAL,
@@ -207,7 +207,7 @@ var tcpDNS = &config.Config{
 		Name:              "tcpDNS",
 		Namespace:         "tcpDNS",
 		CreationTimestamp: GlobalTime,
-		Labels:            map[string]string{label.TLSMode: model.IstioMutualTLSModeLabel},
+		Labels:            map[string]string{label.SecurityTlsMode.Name: model.IstioMutualTLSModeLabel},
 	},
 	Spec: &networking.ServiceEntry{
 		Hosts: []string{"tcpdns.com"},
@@ -217,11 +217,11 @@ var tcpDNS = &config.Config{
 		Endpoints: []*networking.WorkloadEntry{
 			{
 				Address: "lon.google.com",
-				Labels:  map[string]string{label.TLSMode: model.IstioMutualTLSModeLabel},
+				Labels:  map[string]string{label.SecurityTlsMode.Name: model.IstioMutualTLSModeLabel},
 			},
 			{
 				Address: "in.google.com",
-				Labels:  map[string]string{label.TLSMode: model.IstioMutualTLSModeLabel},
+				Labels:  map[string]string{label.SecurityTlsMode.Name: model.IstioMutualTLSModeLabel},
 			},
 		},
 		Location:   networking.ServiceEntry_MESH_EXTERNAL,
@@ -235,7 +235,7 @@ var tcpStatic = &config.Config{
 		Name:              "tcpStatic",
 		Namespace:         "tcpStatic",
 		CreationTimestamp: GlobalTime,
-		Labels:            map[string]string{label.TLSMode: model.IstioMutualTLSModeLabel},
+		Labels:            map[string]string{label.SecurityTlsMode.Name: model.IstioMutualTLSModeLabel},
 	},
 	Spec: &networking.ServiceEntry{
 		Hosts:     []string{"tcpstatic.com"},
@@ -246,11 +246,11 @@ var tcpStatic = &config.Config{
 		Endpoints: []*networking.WorkloadEntry{
 			{
 				Address: "1.1.1.1",
-				Labels:  map[string]string{label.TLSMode: model.IstioMutualTLSModeLabel},
+				Labels:  map[string]string{label.SecurityTlsMode.Name: model.IstioMutualTLSModeLabel},
 			},
 			{
 				Address: "2.2.2.2",
-				Labels:  map[string]string{label.TLSMode: model.IstioMutualTLSModeLabel},
+				Labels:  map[string]string{label.SecurityTlsMode.Name: model.IstioMutualTLSModeLabel},
 			},
 		},
 		Location:   networking.ServiceEntry_MESH_EXTERNAL,
@@ -264,7 +264,7 @@ var httpNoneInternal = &config.Config{
 		Name:              "httpNoneInternal",
 		Namespace:         "httpNoneInternal",
 		CreationTimestamp: GlobalTime,
-		Labels:            map[string]string{label.TLSMode: model.IstioMutualTLSModeLabel},
+		Labels:            map[string]string{label.SecurityTlsMode.Name: model.IstioMutualTLSModeLabel},
 	},
 	Spec: &networking.ServiceEntry{
 		Hosts: []string{"*.google.com"},
@@ -283,7 +283,7 @@ var tcpNoneInternal = &config.Config{
 		Name:              "tcpNoneInternal",
 		Namespace:         "tcpNoneInternal",
 		CreationTimestamp: GlobalTime,
-		Labels:            map[string]string{label.TLSMode: model.IstioMutualTLSModeLabel},
+		Labels:            map[string]string{label.SecurityTlsMode.Name: model.IstioMutualTLSModeLabel},
 	},
 	Spec: &networking.ServiceEntry{
 		Hosts:     []string{"tcpinternal.com"},
@@ -302,7 +302,7 @@ var multiAddrInternal = &config.Config{
 		Name:              "multiAddrInternal",
 		Namespace:         "multiAddrInternal",
 		CreationTimestamp: GlobalTime,
-		Labels:            map[string]string{label.TLSMode: model.IstioMutualTLSModeLabel},
+		Labels:            map[string]string{label.SecurityTlsMode.Name: model.IstioMutualTLSModeLabel},
 	},
 	Spec: &networking.ServiceEntry{
 		Hosts:     []string{"tcp1.com", "tcp2.com"},
@@ -321,7 +321,7 @@ var udsLocal = &config.Config{
 		Name:              "udsLocal",
 		Namespace:         "udsLocal",
 		CreationTimestamp: GlobalTime,
-		Labels:            map[string]string{label.TLSMode: model.IstioMutualTLSModeLabel},
+		Labels:            map[string]string{label.SecurityTlsMode.Name: model.IstioMutualTLSModeLabel},
 	},
 	Spec: &networking.ServiceEntry{
 		Hosts: []string{"uds.cluster.local"},
@@ -329,7 +329,7 @@ var udsLocal = &config.Config{
 			{Number: 6553, Name: "grpc-1", Protocol: "grpc"},
 		},
 		Endpoints: []*networking.WorkloadEntry{
-			{Address: "unix:///test/sock", Labels: map[string]string{label.TLSMode: model.IstioMutualTLSModeLabel}},
+			{Address: "unix:///test/sock", Labels: map[string]string{label.SecurityTlsMode.Name: model.IstioMutualTLSModeLabel}},
 		},
 		Resolution: networking.ServiceEntry_STATIC,
 	},
@@ -342,7 +342,7 @@ var selectorDNS = &config.Config{
 		Name:              "selector",
 		Namespace:         "selector",
 		CreationTimestamp: GlobalTime,
-		Labels:            map[string]string{label.TLSMode: model.IstioMutualTLSModeLabel},
+		Labels:            map[string]string{label.SecurityTlsMode.Name: model.IstioMutualTLSModeLabel},
 	},
 	Spec: &networking.ServiceEntry{
 		Hosts: []string{"selector.com"},
@@ -364,7 +364,7 @@ var selector = &config.Config{
 		Name:              "selector",
 		Namespace:         "selector",
 		CreationTimestamp: GlobalTime,
-		Labels:            map[string]string{label.TLSMode: model.IstioMutualTLSModeLabel},
+		Labels:            map[string]string{label.SecurityTlsMode.Name: model.IstioMutualTLSModeLabel},
 	},
 	Spec: &networking.ServiceEntry{
 		Hosts: []string{"selector.com"},
@@ -386,7 +386,7 @@ var dnsSelector = &config.Config{
 		Name:              "dns-selector",
 		Namespace:         "dns-selector",
 		CreationTimestamp: GlobalTime,
-		Labels:            map[string]string{label.TLSMode: model.IstioMutualTLSModeLabel},
+		Labels:            map[string]string{label.SecurityTlsMode.Name: model.IstioMutualTLSModeLabel},
 	},
 	Spec: &networking.ServiceEntry{
 		Hosts: []string{"dns.selector.com"},
@@ -491,7 +491,7 @@ func makeInstance(cfg *config.Config, address string, port int,
 		if svcLabels == nil {
 			svcLabels = map[string]string{}
 		}
-		svcLabels[label.TLSMode] = model.IstioMutualTLSModeLabel
+		svcLabels[label.SecurityTlsMode.Name] = model.IstioMutualTLSModeLabel
 	}
 	return &model.ServiceInstance{
 		Service: svc,

--- a/pilot/pkg/serviceregistry/serviceentry/servicediscovery_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/servicediscovery_test.go
@@ -418,7 +418,7 @@ func TestServiceDiscoveryServiceUpdate(t *testing.T) {
 			se.Endpoints = []*networking.WorkloadEntry{
 				{
 					Address: "lon.google.com",
-					Labels:  map[string]string{label.TLSMode: model.IstioMutualTLSModeLabel},
+					Labels:  map[string]string{label.SecurityTlsMode.Name: model.IstioMutualTLSModeLabel},
 				},
 			}
 			return &c
@@ -1018,7 +1018,7 @@ func TestServicesDiff(t *testing.T) {
 			Name:              "httpDNS",
 			Namespace:         "httpDNS",
 			CreationTimestamp: GlobalTime,
-			Labels:            map[string]string{label.TLSMode: model.IstioMutualTLSModeLabel},
+			Labels:            map[string]string{label.SecurityTlsMode.Name: model.IstioMutualTLSModeLabel},
 		},
 		Spec: &networking.ServiceEntry{
 			Hosts: []string{"*.google.com", "*.mail.com"},
@@ -1030,16 +1030,16 @@ func TestServicesDiff(t *testing.T) {
 				{
 					Address: "us.google.com",
 					Ports:   map[string]uint32{"http-port": 7080, "http-alt-port": 18080},
-					Labels:  map[string]string{label.TLSMode: model.IstioMutualTLSModeLabel},
+					Labels:  map[string]string{label.SecurityTlsMode.Name: model.IstioMutualTLSModeLabel},
 				},
 				{
 					Address: "uk.google.com",
 					Ports:   map[string]uint32{"http-port": 1080},
-					Labels:  map[string]string{label.TLSMode: model.IstioMutualTLSModeLabel},
+					Labels:  map[string]string{label.SecurityTlsMode.Name: model.IstioMutualTLSModeLabel},
 				},
 				{
 					Address: "de.google.com",
-					Labels:  map[string]string{"foo": "bar", label.TLSMode: model.IstioMutualTLSModeLabel},
+					Labels:  map[string]string{"foo": "bar", label.SecurityTlsMode.Name: model.IstioMutualTLSModeLabel},
 				},
 			},
 			Location:   networking.ServiceEntry_MESH_EXTERNAL,
@@ -1064,7 +1064,7 @@ func TestServicesDiff(t *testing.T) {
 		endpoints = append(endpoints, se.Endpoints...)
 		endpoints = append(endpoints, &networking.WorkloadEntry{
 			Address: "in.google.com",
-			Labels:  map[string]string{"foo": "bar", label.TLSMode: model.IstioMutualTLSModeLabel},
+			Labels:  map[string]string{"foo": "bar", label.SecurityTlsMode.Name: model.IstioMutualTLSModeLabel},
 		})
 		se.Endpoints = endpoints
 		return &c

--- a/pilot/pkg/xds/mesh_network_test.go
+++ b/pilot/pkg/xds/mesh_network_test.go
@@ -46,7 +46,7 @@ func TestNetworkGatewayUpdates(t *testing.T) {
 		name: "app", namespace: "pod",
 		ip: "10.10.10.10", port: 8080,
 		metaNetwork: "network-1",
-		labels:      map[string]string{label.IstioNetwork: "network-1"},
+		labels:      map[string]string{label.TopologyNetwork.Name: "network-1"},
 	}
 	vm := &workload{
 		kind: VirtualMachine,
@@ -81,7 +81,7 @@ func TestNetworkGatewayUpdates(t *testing.T) {
 				Name:      "istio-ingressgateway",
 				Namespace: "istio-system",
 				Labels: map[string]string{
-					label.IstioNetwork: "network-1",
+					label.TopologyNetwork.Name: "network-1",
 				},
 			},
 			Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
@@ -122,7 +122,7 @@ func TestMeshNetworking(t *testing.T) {
 					Name:      "istio-ingressgateway",
 					Namespace: "istio-system",
 					Labels: map[string]string{
-						label.IstioNetwork: "network-2",
+						label.TopologyNetwork.Name: "network-2",
 					},
 				},
 				Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
@@ -149,7 +149,7 @@ func TestMeshNetworking(t *testing.T) {
 					Name:      "istio-ingressgateway",
 					Namespace: "istio-system",
 					Labels: map[string]string{
-						label.IstioNetwork: "network-2",
+						label.TopologyNetwork.Name: "network-2",
 					},
 				},
 				Spec: corev1.ServiceSpec{
@@ -178,7 +178,7 @@ func TestMeshNetworking(t *testing.T) {
 						Namespace:   "istio-system",
 						Annotations: map[string]string{kube.NodeSelectorAnnotation: "{}"},
 						Labels: map[string]string{
-							label.IstioNetwork: "network-2",
+							label.TopologyNetwork.Name: "network-2",
 							// set the label here to test it = expectation doesn't change since we map back to that via NodePort
 							controller.IstioGatewayPortLabel: "443",
 						},
@@ -231,7 +231,7 @@ func TestMeshNetworking(t *testing.T) {
 						name: "labeled", namespace: "pod",
 						ip: "10.10.10.20", port: 9090,
 						metaNetwork: "network-2", clusterID: "cluster-2",
-						labels: map[string]string{label.IstioNetwork: "network-2"},
+						labels: map[string]string{label.TopologyNetwork.Name: "network-2"},
 					}
 					vm := &workload{
 						kind: VirtualMachine,
@@ -429,8 +429,8 @@ func (w *workload) buildPodService() []runtime.Object {
 	baseMeta := metav1.ObjectMeta{
 		Name: w.name,
 		Labels: labels.Instance{
-			"app":         w.name,
-			label.TLSMode: model.IstioMutualTLSModeLabel,
+			"app":                      w.name,
+			label.SecurityTlsMode.Name: model.IstioMutualTLSModeLabel,
 		},
 		Namespace: w.namespace,
 	}

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -650,9 +650,9 @@ func (c *client) GetIstioPods(ctx context.Context, namespace string, params map[
 	if c.revision != "" {
 		labelSelector, ok := params["labelSelector"]
 		if ok {
-			params["labelSelector"] = fmt.Sprintf("%s,%s=%s", labelSelector, label.IstioRev, c.revision)
+			params["labelSelector"] = fmt.Sprintf("%s,%s=%s", labelSelector, label.IoIstioRev.Name, c.revision)
 		} else {
-			params["labelSelector"] = fmt.Sprintf("%s=%s", label.IstioRev, c.revision)
+			params["labelSelector"] = fmt.Sprintf("%s=%s", label.IoIstioRev.Name, c.revision)
 		}
 	}
 

--- a/pkg/kube/inject/inject.go
+++ b/pkg/kube/inject/inject.go
@@ -310,7 +310,7 @@ func RunTemplate(params InjectionParameters) (mergedPod *corev1.Pod, templatePod
 		network = params.proxyEnvs["ISTIO_META_NETWORK"]
 	}
 	// explicit label takes highest precedence
-	if n, ok := metadata.Labels[label.IstioNetwork]; ok {
+	if n, ok := metadata.Labels[label.TopologyNetwork.Name]; ok {
 		network = n
 	}
 

--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -735,7 +735,7 @@ func deployCACerts(workDir string, env *kube.Environment, cfg Config) error {
 		// Create the system namespace.
 		var nsLabels map[string]string
 		if env.IsMultinetwork() {
-			nsLabels = map[string]string{label.IstioNetwork: cluster.NetworkName()}
+			nsLabels = map[string]string{label.TopologyNetwork.Name: cluster.NetworkName()}
 		}
 		if _, err := cluster.CoreV1().Namespaces().Create(context.TODO(), &kubeApiCore.Namespace{
 			ObjectMeta: kubeApiMeta.ObjectMeta{

--- a/pkg/test/framework/components/namespace/kube.go
+++ b/pkg/test/framework/components/namespace/kube.go
@@ -175,7 +175,7 @@ func createNamespaceLabels(cfg *Config) map[string]string {
 	l["istio-testing"] = "istio-test"
 	if cfg.Inject {
 		if cfg.Revision != "" {
-			l[label.IstioRev] = cfg.Revision
+			l[label.IoIstioRev.Name] = cfg.Revision
 		} else {
 			l["istio-injection"] = "enabled"
 		}

--- a/pkg/webhooks/webhookpatch.go
+++ b/pkg/webhooks/webhookpatch.go
@@ -87,7 +87,7 @@ func (w *WebhookCertPatcher) runWebhookController(stopChan <-chan struct{}) {
 		"mutatingwebhookconfigurations",
 		"",
 		func(options *metav1.ListOptions) {
-			options.LabelSelector = fmt.Sprintf("%s=%s", label.IstioRev, w.revision)
+			options.LabelSelector = fmt.Sprintf("%s=%s", label.IoIstioRev.Name, w.revision)
 		})
 
 	_, c := cache.NewInformer(
@@ -159,7 +159,7 @@ func (w *WebhookCertPatcher) patchMutatingWebhookConfig(
 		return err
 	}
 	// prevents a race condition between multiple istiods when the revision is changed or modified
-	v, ok := config.Labels[label.IstioRev]
+	v, ok := config.Labels[label.IoIstioRev.Name]
 	if v != w.revision || !ok {
 		return errWrongRevision
 	}

--- a/pkg/webhooks/webhookpatch_test.go
+++ b/pkg/webhooks/webhookpatch_test.go
@@ -30,8 +30,8 @@ import (
 func TestMutatingWebhookPatch(t *testing.T) {
 	testRevision := "test-revision"
 	wrongRevision := "wrong-revision"
-	testRevisionLabel := map[string]string{label.IstioRev: testRevision}
-	wrongRevisionLabel := map[string]string{label.IstioRev: wrongRevision}
+	testRevisionLabel := map[string]string{label.IoIstioRev.Name: testRevision}
+	wrongRevisionLabel := map[string]string{label.IoIstioRev.Name: wrongRevision}
 	ts := []struct {
 		name        string
 		configs     admissionregistrationv1beta1.MutatingWebhookConfigurationList


### PR DESCRIPTION
We recently added auto-generation of labels in istio.io/api. This changes istio/istio to use the new generated label variables. We will follow this up by removal of the old variables from the API repo.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.