### PR TITLE
Remove appVersion as its not used across all manifests

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/Chart.yaml
+++ b/manifests/charts/istio-control/istio-discovery/Chart.yaml
@@ -1,7 +1,6 @@
 apiVersion: v1
 name: istio-discovery
 version: 1.2.0
-appVersion: 1.2.0
 tillerVersion: ">=2.7.2"
 description: Helm chart for istio control plane
 keywords:

--- a/manifests/charts/istiod-remote/Chart.yaml
+++ b/manifests/charts/istiod-remote/Chart.yaml
@@ -1,7 +1,6 @@
 apiVersion: v1
 name: istiod-remote
 version: 1.1.0
-appVersion: 1.1.0
 tillerVersion: ">=2.7.2"
 description: Helm chart for istio control plane configuration for remote clusters
 keywords:


### PR DESCRIPTION
We should be consistent in our use of `appVersion`. Either use it across each helm charts or not.

This is related to https://github.com/istio/release-builder/pull/535/ as I intend to have the published helm chart versions match the version of Istio (e.g. 1.9.0 final will have "version 1.9.0").

I can also add `appVersion` to all charts as well. But given that we currently do not update charts independently from the version of Istio this is my first suggested route.


[ ] Configuration Infrastructure
[ ] Docs
[X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any changes that may affect Istio users.