### PR TITLE
optimize cluster patch

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -184,9 +184,11 @@ type clusterPatcher struct {
 }
 
 func (p clusterPatcher) conditionallyAppend(l []*cluster.Cluster, clusters ...*cluster.Cluster) []*cluster.Cluster {
+	cpw, serviceMap, subsetMap, portMap := envoyfilter.GenerateMatchMap(p.pctx, p.efw)
 	for _, c := range clusters {
-		if envoyfilter.ShouldKeepCluster(p.pctx, p.efw, c) {
-			l = append(l, envoyfilter.ApplyClusterMerge(p.pctx, p.efw, c))
+		result, shouldKeep := envoyfilter.ApplyClusterMergeOrRemove(c, cpw, serviceMap, subsetMap, portMap)
+		if shouldKeep {
+			l = append(l, result)
 		}
 	}
 	return l

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/cluster_patch.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/cluster_patch.go
@@ -15,6 +15,8 @@
 package envoyfilter
 
 import (
+	"strconv"
+
 	cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	"github.com/golang/protobuf/proto"
 
@@ -25,39 +27,166 @@ import (
 	"istio.io/pkg/log"
 )
 
-func ApplyClusterMerge(pctx networking.EnvoyFilter_PatchContext, efw *model.EnvoyFilterWrapper, c *cluster.Cluster) (out *cluster.Cluster) {
-	defer runtime.HandleCrash(runtime.LogPanic, func(interface{}) {
-		log.Errorf("clusters patch caused panic, so the patches did not take effect")
-	})
-	// In case the patches cause panic, use the clusters generated before to reduce the influence.
-	out = c
-	if efw == nil {
-		return
-	}
+const (
+	RemovePatch = "-"
+	MergeAny    = "*"
+	MergeOne    = "+"
+	Service     = "service"
+	Subset      = "subset"
+	Port        = "port"
+)
+
+func GenerateMatchMap(pctx networking.EnvoyFilter_PatchContext, efw *model.EnvoyFilterWrapper) (cpw, serviceMap, subsetMap, portMap map[string][]*model.EnvoyFilterConfigPatchWrapper) {
+	cpw = make(map[string][]*model.EnvoyFilterConfigPatchWrapper)
+	serviceMap = make(map[string][]*model.EnvoyFilterConfigPatchWrapper)
+	subsetMap = make(map[string][]*model.EnvoyFilterConfigPatchWrapper)
+	portMap = make(map[string][]*model.EnvoyFilterConfigPatchWrapper)
 	for _, cp := range efw.Patches[networking.EnvoyFilter_CLUSTER] {
-		if cp.Operation != networking.EnvoyFilter_Patch_MERGE {
+		if cp.Operation != networking.EnvoyFilter_Patch_REMOVE &&
+			cp.Operation != networking.EnvoyFilter_Patch_MERGE {
 			continue
 		}
-		if commonConditionMatch(pctx, cp) && clusterMatch(c, cp) {
+		if !commonConditionMatch(pctx, cp) {
+			continue
+		}
+
+		if cp.Match.GetCluster() == nil {
+			if cp.Operation == networking.EnvoyFilter_Patch_REMOVE {
+				cpw[RemovePatch] = append(cpw[RemovePatch], cp)
+				continue
+			}
+			cpw[MergeAny] = append(cpw[MergeAny], cp)
+			continue
+		}
+		if cp.Match.GetCluster().Name != "" {
+			if cp.Operation == networking.EnvoyFilter_Patch_REMOVE {
+				cpw[cp.Match.GetCluster().Name+RemovePatch] = append(cpw[cp.Match.GetCluster().Name+RemovePatch], cp)
+				continue
+			}
+			cpw[cp.Match.GetCluster().Name+MergeOne] = append(cpw[cp.Match.GetCluster().Name+MergeOne], cp)
+			continue
+		}
+
+		service := cp.Match.GetCluster().Service
+		subset := cp.Match.GetCluster().Subset
+		port := cp.Match.GetCluster().PortNumber
+
+		if service != "" {
+			serviceMap[service] = append(serviceMap[service], cp)
+		} else {
+			serviceMap[MergeAny] = append(serviceMap[MergeAny], cp)
+		}
+
+		if subset != "" {
+			subsetMap[subset] = append(subsetMap[subset], cp)
+		} else {
+			subsetMap[MergeAny] = append(subsetMap[MergeAny], cp)
+		}
+
+		if port != 0 {
+			portMap[strconv.Itoa(int(port))] = append(portMap[strconv.Itoa(int(port))], cp)
+		} else {
+			portMap[MergeAny] = append(portMap[MergeAny], cp)
+		}
+	}
+	return cpw, serviceMap, subsetMap, portMap
+}
+
+func ApplyClusterMergeOrRemove(c *cluster.Cluster, cpw, serviceMap, subsetMap, portMap map[string][]*model.EnvoyFilterConfigPatchWrapper) (*cluster.Cluster, bool) {
+	shouldKeep := true
+	if len(cpw[RemovePatch]) > 0 || len(cpw[c.Name+RemovePatch]) > 0 {
+		c = nil
+		shouldKeep = false
+		return nil, shouldKeep
+	}
+	if len(cpw[MergeAny]) > 0 {
+		for _, cp := range cpw[MergeAny] {
 			proto.Merge(c, cp.Value)
 		}
 	}
-	return c
+	if len(cpw[c.Name+MergeOne]) > 0 {
+		for _, cp := range cpw[c.Name+MergeOne] {
+			proto.Merge(c, cp.Value)
+		}
+	}
+	key, minMatchMap := findMinMatchMap(c.Name, serviceMap, subsetMap, portMap)
+
+	switch key {
+	case Service:
+		for _, cp := range minMatchMap {
+			c, shouldKeep = mergeOrRemove(c, cp)
+		}
+		for _, cp := range serviceMap[MergeAny] {
+			c, shouldKeep = mergeOrRemove(c, cp)
+		}
+
+	case Subset:
+		for _, cp := range minMatchMap {
+			c, shouldKeep = mergeOrRemove(c, cp)
+		}
+		for _, cp := range subsetMap[MergeAny] {
+			c, shouldKeep = mergeOrRemove(c, cp)
+		}
+
+	case Port:
+		for _, cp := range minMatchMap {
+			c, shouldKeep = mergeOrRemove(c, cp)
+		}
+		for _, cp := range portMap[MergeAny] {
+			c, shouldKeep = mergeOrRemove(c, cp)
+		}
+	default:
+		//do nothing
+	}
+	return c, shouldKeep
 }
 
-func ShouldKeepCluster(pctx networking.EnvoyFilter_PatchContext, efw *model.EnvoyFilterWrapper, c *cluster.Cluster) bool {
-	if efw == nil {
-		return true
+func mergeOrRemove(cluster *cluster.Cluster, cp *model.EnvoyFilterConfigPatchWrapper) (*cluster.Cluster, bool) {
+	if clusterMatch(cluster, cp) {
+		if cp.Operation == networking.EnvoyFilter_Patch_REMOVE {
+			return nil, false
+		} else {
+			proto.Merge(cluster, cp.Value)
+		}
 	}
-	for _, cp := range efw.Patches[networking.EnvoyFilter_CLUSTER] {
-		if cp.Operation != networking.EnvoyFilter_Patch_REMOVE {
+	return cluster, true
+}
+
+func findMinMatchMap(Name string, serviceMap, subsetMap, portMap map[string][]*model.EnvoyFilterConfigPatchWrapper) (string, []*model.EnvoyFilterConfigPatchWrapper) {
+
+	_, subset, hostname, port := model.ParseSubsetKey(Name)
+
+	serviceMapLen := len(serviceMap[string(hostname)]) + len(serviceMap[MergeAny])
+	subsetMapLen := len(subsetMap[subset]) + len(subsetMap[MergeAny])
+	portMapLen := len(portMap[strconv.Itoa(port)]) + len(portMap[MergeAny])
+
+	if serviceMapLen == 0 && subsetMapLen == 0 && portMapLen == 0 {
+		return "", nil
+	}
+	var intArr = []int{serviceMapLen, subsetMapLen, portMapLen}
+	minVal := intArr[0]
+	minValIndex := 0
+	for i := 1; i < len(intArr); i++ {
+		if minVal == 0 {
+			minVal = intArr[i]
+			minValIndex = i
 			continue
 		}
-		if commonConditionMatch(pctx, cp) && clusterMatch(c, cp) {
-			return false
+		if minVal > intArr[i] && intArr[i] != 0 {
+			minVal = intArr[i]
+			minValIndex = i
 		}
 	}
-	return true
+	switch minValIndex {
+	case 0:
+		return Service, serviceMap[string(hostname)]
+	case 1:
+		return Subset, subsetMap[subset]
+	case 2:
+		return Port, portMap[strconv.Itoa(port)]
+	default:
+		return "", nil
+	}
 }
 
 func InsertedClusters(pctx networking.EnvoyFilter_PatchContext, efw *model.EnvoyFilterWrapper) []*cluster.Cluster {


### PR DESCRIPTION
**What this PR does**
Now the logic of *cluster patch* is double loop nesting, which means the algorithm complexity is O(n^2). When the scale of envoyfilters and clusters becomes larger and larger, the performance is getting worse and the latency is getting longer.  
This PR is trying to optimize the performance of the *cluster patch*. The main idea is to find the min match envoyfilter map for each cluster, which makes the algorithm complexity become close to O(n). I have made the test case which has 10000 filters and 10000 clusters. The latency is reduced by almost 20 times. Of course the performance is related to the size of match data. The worst case is the same as the  double loop nesting.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[X] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.