### PR TITLE
optimize cluster patch

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -184,9 +184,11 @@ type clusterPatcher struct {
 }
 
 func (p clusterPatcher) conditionallyAppend(l []*cluster.Cluster, clusters ...*cluster.Cluster) []*cluster.Cluster {
+	cpw, serviceMap, subsetMap, portMap := envoyfilter.GenerateMatchMap(p.pctx, p.efw)
 	for _, c := range clusters {
-		if envoyfilter.ShouldKeepCluster(p.pctx, p.efw, c) {
-			l = append(l, envoyfilter.ApplyClusterMerge(p.pctx, p.efw, c))
+		result, shouldKeep := envoyfilter.ApplyClusterMergeOrRemove(c, cpw, serviceMap, subsetMap, portMap)
+		if shouldKeep {
+			l = append(l, result)
 		}
 	}
 	return l

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -184,9 +184,9 @@ type clusterPatcher struct {
 }
 
 func (p clusterPatcher) conditionallyAppend(l []*cluster.Cluster, clusters ...*cluster.Cluster) []*cluster.Cluster {
-	cpw, serviceMap, subsetMap, portMap := envoyfilter.GenerateMatchMap(p.pctx, p.efw)
+	cpw, serviceMap, subsetMap, portMap := envoyfilter.GenerateEnvoyFilterMatchMap(p.pctx, p.efw)
 	for _, c := range clusters {
-		result, shouldKeep := envoyfilter.ApplyClusterMergeOrRemove(c, cpw, serviceMap, subsetMap, portMap)
+		result, shouldKeep := envoyfilter.ApplyClusterPatches(c, cpw, serviceMap, subsetMap, portMap)
 		if shouldKeep {
 			l = append(l, result)
 		}

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/cluster_patch.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/cluster_patch.go
@@ -36,7 +36,10 @@ const (
 	Port        = "port"
 )
 
-func GenerateMatchMap(pctx networking.EnvoyFilter_PatchContext, efw *model.EnvoyFilterWrapper) (cpw map[string][]*model.EnvoyFilterConfigPatchWrapper, serviceMap map[string][]*model.EnvoyFilterConfigPatchWrapper, subsetMap map[string][]*model.EnvoyFilterConfigPatchWrapper, portMap map[string][]*model.EnvoyFilterConfigPatchWrapper) {
+func GenerateMatchMap(pctx networking.EnvoyFilter_PatchContext, efw *model.EnvoyFilterWrapper) (cpw map[string][]*model.EnvoyFilterConfigPatchWrapper,
+	serviceMap map[string][]*model.EnvoyFilterConfigPatchWrapper,
+	subsetMap map[string][]*model.EnvoyFilterConfigPatchWrapper,
+	portMap map[string][]*model.EnvoyFilterConfigPatchWrapper) {
 
 	cpw = make(map[string][]*model.EnvoyFilterConfigPatchWrapper)
 	serviceMap = make(map[string][]*model.EnvoyFilterConfigPatchWrapper)

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/cluster_patch.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/cluster_patch.go
@@ -36,11 +36,12 @@ const (
 	Port        = "port"
 )
 
-func GenerateMatchMap(pctx networking.EnvoyFilter_PatchContext, efw *model.EnvoyFilterWrapper) (map[string][]*model.EnvoyFilterConfigPatchWrapper, map[string][]*model.EnvoyFilterConfigPatchWrapper, map[string][]*model.EnvoyFilterConfigPatchWrapper, map[string][]*model.EnvoyFilterConfigPatchWrapper) {
-	cpw := make(map[string][]*model.EnvoyFilterConfigPatchWrapper)
-	serviceMap := make(map[string][]*model.EnvoyFilterConfigPatchWrapper)
-	subsetMap := make(map[string][]*model.EnvoyFilterConfigPatchWrapper)
-	portMap := make(map[string][]*model.EnvoyFilterConfigPatchWrapper)
+func GenerateMatchMap(pctx networking.EnvoyFilter_PatchContext, efw *model.EnvoyFilterWrapper) (cpw map[string][]*model.EnvoyFilterConfigPatchWrapper, serviceMap map[string][]*model.EnvoyFilterConfigPatchWrapper, subsetMap map[string][]*model.EnvoyFilterConfigPatchWrapper, portMap map[string][]*model.EnvoyFilterConfigPatchWrapper) {
+
+	cpw = make(map[string][]*model.EnvoyFilterConfigPatchWrapper)
+	serviceMap = make(map[string][]*model.EnvoyFilterConfigPatchWrapper)
+	subsetMap = make(map[string][]*model.EnvoyFilterConfigPatchWrapper)
+	portMap = make(map[string][]*model.EnvoyFilterConfigPatchWrapper)
 	if efw == nil {
 		return cpw, serviceMap, subsetMap, portMap
 	}
@@ -95,7 +96,10 @@ func GenerateMatchMap(pctx networking.EnvoyFilter_PatchContext, efw *model.Envoy
 	return cpw, serviceMap, subsetMap, portMap
 }
 
-func ApplyClusterMergeOrRemove(c *cluster.Cluster, cpw, serviceMap, subsetMap, portMap map[string][]*model.EnvoyFilterConfigPatchWrapper) (out *cluster.Cluster, shouldKeep bool) {
+func ApplyClusterMergeOrRemove(c *cluster.Cluster, cpw map[string][]*model.EnvoyFilterConfigPatchWrapper,
+	serviceMap map[string][]*model.EnvoyFilterConfigPatchWrapper,
+	subsetMap map[string][]*model.EnvoyFilterConfigPatchWrapper,
+	portMap map[string][]*model.EnvoyFilterConfigPatchWrapper) (out *cluster.Cluster, shouldKeep bool) {
 	defer runtime.HandleCrash(func(interface{}) {
 		log.Errorf("clusters patch caused panic, so the patches did not take effect")
 	})

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/cluster_patch.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/cluster_patch.go
@@ -41,6 +41,9 @@ func GenerateMatchMap(pctx networking.EnvoyFilter_PatchContext, efw *model.Envoy
 	serviceMap = make(map[string][]*model.EnvoyFilterConfigPatchWrapper)
 	subsetMap = make(map[string][]*model.EnvoyFilterConfigPatchWrapper)
 	portMap = make(map[string][]*model.EnvoyFilterConfigPatchWrapper)
+	if efw == nil {
+		return cpw, serviceMap, subsetMap, portMap
+	}
 	for _, cp := range efw.Patches[networking.EnvoyFilter_CLUSTER] {
 		if cp.Operation != networking.EnvoyFilter_Patch_REMOVE &&
 			cp.Operation != networking.EnvoyFilter_Patch_MERGE {

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/cluster_patch.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/cluster_patch.go
@@ -41,7 +41,8 @@ const (
 // serviceMap is the map that envoyFilters specify the service or not
 // subsetMap is the map that envoyFilters specify the subset or not
 // portMap is the map that envoyFilters specify the port or not
-func GenerateEnvoyFilterMatchMap(pctx networking.EnvoyFilter_PatchContext, efw *model.EnvoyFilterWrapper) (cpw map[string][]*model.EnvoyFilterConfigPatchWrapper,
+func GenerateEnvoyFilterMatchMap(pctx networking.EnvoyFilter_PatchContext,
+	efw *model.EnvoyFilterWrapper) (cpw map[string][]*model.EnvoyFilterConfigPatchWrapper,
 	serviceMap map[string][]*model.EnvoyFilterConfigPatchWrapper,
 	subsetMap map[string][]*model.EnvoyFilterConfigPatchWrapper,
 	portMap map[string][]*model.EnvoyFilterConfigPatchWrapper) {

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/cluster_patch.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/cluster_patch.go
@@ -36,11 +36,11 @@ const (
 	Port        = "port"
 )
 
-func GenerateMatchMap(pctx networking.EnvoyFilter_PatchContext, efw *model.EnvoyFilterWrapper) (cpw, serviceMap, subsetMap, portMap map[string][]*model.EnvoyFilterConfigPatchWrapper) {
-	cpw = make(map[string][]*model.EnvoyFilterConfigPatchWrapper)
-	serviceMap = make(map[string][]*model.EnvoyFilterConfigPatchWrapper)
-	subsetMap = make(map[string][]*model.EnvoyFilterConfigPatchWrapper)
-	portMap = make(map[string][]*model.EnvoyFilterConfigPatchWrapper)
+func GenerateMatchMap(pctx networking.EnvoyFilter_PatchContext, efw *model.EnvoyFilterWrapper) (map[string][]*model.EnvoyFilterConfigPatchWrapper, map[string][]*model.EnvoyFilterConfigPatchWrapper, map[string][]*model.EnvoyFilterConfigPatchWrapper, map[string][]*model.EnvoyFilterConfigPatchWrapper) {
+	cpw := make(map[string][]*model.EnvoyFilterConfigPatchWrapper)
+	serviceMap := make(map[string][]*model.EnvoyFilterConfigPatchWrapper)
+	subsetMap := make(map[string][]*model.EnvoyFilterConfigPatchWrapper)
+	portMap := make(map[string][]*model.EnvoyFilterConfigPatchWrapper)
 	if efw == nil {
 		return cpw, serviceMap, subsetMap, portMap
 	}
@@ -152,16 +152,18 @@ func mergeOrRemove(cluster *cluster.Cluster, cp *model.EnvoyFilterConfigPatchWra
 	if clusterMatch(cluster, cp) {
 		if cp.Operation == networking.EnvoyFilter_Patch_REMOVE {
 			return nil, false
-		} else {
-			proto.Merge(cluster, cp.Value)
 		}
+		proto.Merge(cluster, cp.Value)
 	}
 	return cluster, true
 }
 
-func findMinMatchMap(Name string, serviceMap, subsetMap, portMap map[string][]*model.EnvoyFilterConfigPatchWrapper) (string, []*model.EnvoyFilterConfigPatchWrapper) {
+func findMinMatchMap(name string,
+	serviceMap map[string][]*model.EnvoyFilterConfigPatchWrapper,
+	subsetMap map[string][]*model.EnvoyFilterConfigPatchWrapper,
+	portMap map[string][]*model.EnvoyFilterConfigPatchWrapper) (string, []*model.EnvoyFilterConfigPatchWrapper) {
 
-	_, subset, hostname, port := model.ParseSubsetKey(Name)
+	_, subset, hostname, port := model.ParseSubsetKey(name)
 
 	serviceMapLen := len(serviceMap[string(hostname)]) + len(serviceMap[MergeAny])
 	subsetMapLen := len(subsetMap[subset]) + len(subsetMap[MergeAny])

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/cluster_patch_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/cluster_patch_test.go
@@ -293,9 +293,9 @@ func TestClusterPatching(t *testing.T) {
 			efw := push.EnvoyFilters(tc.proxy)
 			output := []*cluster.Cluster{}
 
-			cpw, serviceMap, subsetMap, portMap := GenerateMatchMap(tc.patchContext, efw)
+			cpw, serviceMap, subsetMap, portMap := GenerateEnvoyFilterMatchMap(tc.patchContext, efw)
 			for _, c := range tc.input {
-				result, shouldKeep := ApplyClusterMergeOrRemove(c, cpw, serviceMap, subsetMap, portMap)
+				result, shouldKeep := ApplyClusterPatches(c, cpw, serviceMap, subsetMap, portMap)
 				if shouldKeep {
 					output = append(output, result)
 				}
@@ -381,9 +381,9 @@ func TestBatchClusterPatching(t *testing.T) {
 			efw := push.EnvoyFilters(tc.proxy)
 			output := []*cluster.Cluster{}
 
-			cpw, serviceMap, subsetMap, portMap := GenerateMatchMap(tc.patchContext, efw)
+			cpw, serviceMap, subsetMap, portMap := GenerateEnvoyFilterMatchMap(tc.patchContext, efw)
 			for _, c := range tc.input {
-				result, shouldKeep := ApplyClusterMergeOrRemove(c, cpw, serviceMap, subsetMap, portMap)
+				result, shouldKeep := ApplyClusterPatches(c, cpw, serviceMap, subsetMap, portMap)
 				if shouldKeep {
 					output = append(output, result)
 				}


### PR DESCRIPTION
**What this PR does**
Now the logic of *cluster patch* is double loop nesting, which means the algorithm complexity is O(n^2). When the scale of envoyfilters and clusters becomes larger and larger, the performance is getting worse and the latency is getting longer.  
This PR is trying to optimize the performance of the *cluster patch*. The main idea is to find the min match envoyfilter map for each cluster, which makes the algorithm complexity become close to O(n). I have made the test case which has 10000 filters and 10000 clusters. The latency is reduced by almost 20 times. Of course the performance is related to the size of match data. The worst case is the same as the  double loop nesting.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[X] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.