### PR TITLE
OIDC JWT authenticator

### DIFF
--- a/pilot/pkg/bootstrap/istio_ca.go
+++ b/pilot/pkg/bootstrap/istio_ca.go
@@ -31,6 +31,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 
+	"istio.io/api/security/v1beta1"
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/serviceregistry/kube/controller"
 	"istio.io/istio/pkg/config/constants"
@@ -209,7 +210,8 @@ func (s *Server) RunCA(grpc *grpc.Server, ca caserver.CertificateAuthority, opts
 		k8sInCluster.Get() == "" { // not running in cluster - in cluster use direct call to apiserver
 		// Add a custom authenticator using standard JWT validation, if not running in K8S
 		// When running inside K8S - we can use the built-in validator, which also check pod removal (invalidation).
-		oidcAuth, err := authenticate.NewJwtAuthenticator(iss, opts.TrustDomain, aud)
+		jwtRule := v1beta1.JWTRule{Issuer: iss, Audiences: []string{aud}}
+		oidcAuth, err := authenticate.NewJwtAuthenticator(&jwtRule, opts.TrustDomain)
 		if err == nil {
 			caServer.Authenticators = append(caServer.Authenticators, oidcAuth)
 			log.Info("Using out-of-cluster JWT authentication")

--- a/pilot/pkg/bootstrap/options.go
+++ b/pilot/pkg/bootstrap/options.go
@@ -61,6 +61,7 @@ type PilotArgs struct {
 	Plugins            []string
 	KeepaliveOptions   *keepalive.Options
 	ShutdownDuration   time.Duration
+	JwtRule            string
 }
 
 // DiscoveryServerOptions contains options for create a new discovery server instance.
@@ -108,6 +109,8 @@ type TLSOptions struct {
 
 var PodNamespaceVar = env.RegisterStringVar("POD_NAMESPACE", constants.IstioSystemNamespace, "")
 var podNameVar = env.RegisterStringVar("POD_NAME", "", "")
+var jwtRuleVar = env.RegisterStringVar("JWT_RULE", "",
+	"The JWT rule used by istiod authentication")
 
 // RevisionVar is the value of the Istio control plane revision, e.g. "canary",
 // and is the value used by the "istio.io/rev" label.
@@ -140,6 +143,7 @@ func (p *PilotArgs) applyDefaults() {
 	p.Namespace = PodNamespaceVar.Get()
 	p.PodName = podNameVar.Get()
 	p.Revision = RevisionVar.Get()
+	p.JwtRule = jwtRuleVar.Get()
 	p.KeepaliveOptions = keepalive.DefaultOption()
 	p.RegistryOptions.DistributionTrackingEnabled = features.EnableDistributionTracking
 	p.RegistryOptions.DistributionCacheRetention = features.DistributionHistoryRetention

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -313,17 +313,17 @@ func NewServer(args *PilotArgs) (*Server, error) {
 		&authenticate.ClientCertAuthenticator{},
 		kubeauth.NewKubeJWTAuthenticator(s.kubeClient, s.clusterID, s.multicluster.GetRemoteKubeClient, spiffe.GetTrustDomain(), features.JwtPolicy.Get()),
 	}
-	if features.XDSAuth {
-		if args.JwtRule != "" {
-			jwtAuthn, err := initOIDC(args, s.environment.Mesh().TrustDomain)
-			if err != nil {
-				return nil, fmt.Errorf("error initializing OIDC: %v", err)
-			}
-			if jwtAuthn == nil {
-				return nil, fmt.Errorf("JWT authenticator is nil")
-			}
-			authenticators = append(authenticators, jwtAuthn)
+	if args.JwtRule != "" {
+		jwtAuthn, err := initOIDC(args, s.environment.Mesh().TrustDomain)
+		if err != nil {
+			return nil, fmt.Errorf("error initializing OIDC: %v", err)
 		}
+		if jwtAuthn == nil {
+			return nil, fmt.Errorf("JWT authenticator is nil")
+		}
+		authenticators = append(authenticators, jwtAuthn)
+	}
+	if features.XDSAuth {
 		s.XDSServer.Authenticators = authenticators
 	}
 	caOpts.Authenticators = authenticators

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -313,17 +313,7 @@ func NewServer(args *PilotArgs) (*Server, error) {
 		&authenticate.ClientCertAuthenticator{},
 		kubeauth.NewKubeJWTAuthenticator(s.kubeClient, s.clusterID, s.multicluster.GetRemoteKubeClient, spiffe.GetTrustDomain(), features.JwtPolicy.Get()),
 	}
-
-	caOpts.Authenticators = authenticators
 	if features.XDSAuth {
-		authenticators := []security.Authenticator{
-			&authenticate.ClientCertAuthenticator{},
-		}
-		// To be compatible with the flow in which k8s JWT is forwarded to istiod,
-		// the NewKubeJWTAuthenticator is included as an istiod authenticator.
-		// If the k8s JWT is not used, only the OIDC JWT authenticator is needed.
-		authenticators = append(authenticators, kubeauth.NewKubeJWTAuthenticator(s.kubeClient, s.clusterID,
-			s.multicluster.GetRemoteKubeClient, spiffe.GetTrustDomain(), features.JwtPolicy.Get()))
 		if args.JwtRule != "" {
 			jwtAuthn, err := initOIDC(args, s.environment.Mesh().TrustDomain)
 			if err != nil {
@@ -336,6 +326,7 @@ func NewServer(args *PilotArgs) (*Server, error) {
 		}
 		s.XDSServer.Authenticators = authenticators
 	}
+	caOpts.Authenticators = authenticators
 
 	// Start CA or RA server. This should be called after CA and Istiod certs have been created.
 	s.startCA(caOpts)

--- a/releasenotes/notes/30294.yaml
+++ b/releasenotes/notes/30294.yaml
@@ -5,4 +5,4 @@ issue:
 - 30295
 releaseNotes:
 - |
-  **Added** OIDC JWT authenticator that supports both JWKS-URI and OIDC discovery. The OIDC JWT authenticator can be configured through the JWT_RULE env variable and when configured, it will be used as an istiod authenticator.
+  **Added** OIDC JWT authenticator that supports both JWKS-URI and OIDC discovery. The OIDC JWT authenticator will be used when configured through the JWT_RULE env variable.

--- a/releasenotes/notes/30294.yaml
+++ b/releasenotes/notes/30294.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: security
+issue:
+- 30295
+releaseNotes:
+- |
+  **Added** OIDC JWT authenticator that supports both JWKS-URI and OIDC discovery. The OIDC JWT authenticator can be configured through the JWT_RULE env variable and when configured, it will be used as an istiod authenticator.

--- a/security/pkg/server/ca/authenticate/oidc.go
+++ b/security/pkg/server/ca/authenticate/oidc.go
@@ -19,8 +19,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/coreos/go-oidc"
+	oidc "github.com/coreos/go-oidc"
 
+	"istio.io/api/security/v1beta1"
 	"istio.io/istio/pkg/security"
 )
 
@@ -29,9 +30,9 @@ const (
 )
 
 type JwtAuthenticator struct {
-	provider    *oidc.Provider
-	verifier    *oidc.IDTokenVerifier
 	trustDomain string
+	audiences   []string
+	verifier    *oidc.IDTokenVerifier
 }
 
 var _ security.Authenticator = &JwtAuthenticator{}
@@ -39,16 +40,30 @@ var _ security.Authenticator = &JwtAuthenticator{}
 // newJwtAuthenticator is used when running istiod outside of a cluster, to validate the tokens using OIDC
 // K8S is created with --service-account-issuer, service-account-signing-key-file and service-account-api-audiences
 // which enable OIDC.
-func NewJwtAuthenticator(iss string, trustDomain, audience string) (*JwtAuthenticator, error) {
-	provider, err := oidc.NewProvider(context.Background(), iss)
-	if err != nil {
-		return nil, fmt.Errorf("running in cluster with K8S tokens, but failed to initialize %s %s", iss, err)
+func NewJwtAuthenticator(jwtRule *v1beta1.JWTRule, trustDomain string) (*JwtAuthenticator, error) {
+	issuer := jwtRule.GetIssuer()
+	jwksURL := jwtRule.GetJwksUri()
+	// The key of a JWT issuer may change, so the key may need to be updated.
+	// Based on https://godoc.org/github.com/coreos/go-oidc#NewRemoteKeySet,
+	// the oidc library handles caching and cache invalidation. Thus, the verifier
+	// is only created once in the constructor.
+	var verifier *oidc.IDTokenVerifier
+	if len(jwksURL) == 0 {
+		// OIDC discovery is used if jwksURL is not set.
+		provider, err := oidc.NewProvider(context.Background(), issuer)
+		// OIDC discovery may fail, e.g. http request for the OIDC server may fail.
+		if err != nil {
+			return nil, fmt.Errorf("failed at creating an OIDC provider for %v: %v", issuer, err)
+		}
+		verifier = provider.Verifier(&oidc.Config{SkipClientIDCheck: true})
+	} else {
+		keySet := oidc.NewRemoteKeySet(context.Background(), jwksURL)
+		verifier = oidc.NewVerifier(issuer, keySet, &oidc.Config{SkipClientIDCheck: true})
 	}
-
 	return &JwtAuthenticator{
 		trustDomain: trustDomain,
-		provider:    provider,
-		verifier:    provider.Verifier(&oidc.Config{ClientID: audience}),
+		verifier:    verifier,
+		audiences:   jwtRule.Audiences,
 	}, nil
 }
 
@@ -59,16 +74,16 @@ func (j *JwtAuthenticator) Authenticate(ctx context.Context) (*security.Caller, 
 		return nil, fmt.Errorf("ID token extraction error: %v", err)
 	}
 
-	idToken, err := j.verifier.Verify(context.Background(), bearerToken)
+	idToken, err := j.verifier.Verify(ctx, bearerToken)
 	if err != nil {
-		return nil, fmt.Errorf("failed to verify the ID token (error %v)", err)
+		return nil, fmt.Errorf("failed to verify the JWT token (error %v)", err)
 	}
 
-	// for GCP-issued JWT, the service account is in the "email" field
 	sa := &JwtPayload{}
-
+	// "aud" for trust domain, "sub" has "system:serviceaccount:$namespace:$serviceaccount".
+	// in future trust domain may use another field as a standard is defined.
 	if err := idToken.Claims(&sa); err != nil {
-		return nil, fmt.Errorf("failed to extract email field from ID token: %v", err)
+		return nil, fmt.Errorf("failed to extract claims from ID token: %v", err)
 	}
 	if !strings.HasPrefix(sa.Sub, "system:serviceaccount") {
 		return nil, fmt.Errorf("invalid sub %v", sa.Sub)
@@ -76,11 +91,27 @@ func (j *JwtAuthenticator) Authenticate(ctx context.Context) (*security.Caller, 
 	parts := strings.Split(sa.Sub, ":")
 	ns := parts[2]
 	ksa := parts[3]
+	if !checkAudience(sa.Aud, j.audiences) {
+		return nil, fmt.Errorf("invalid audiences %v", sa.Aud)
+	}
 
 	return &security.Caller{
 		AuthSource: security.AuthSourceIDToken,
 		Identities: []string{fmt.Sprintf(IdentityTemplate, j.trustDomain, ns, ksa)},
 	}, nil
+}
+
+// checkAudience() returns true if the audiences to check are in
+// the expected audiences. Otherwise, return false.
+func checkAudience(audToCheck []string, audExpected []string) bool {
+	for _, a := range audToCheck {
+		for _, b := range audExpected {
+			if a == b {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 type JwtPayload struct {

--- a/security/pkg/server/ca/authenticate/oidc_test.go
+++ b/security/pkg/server/ca/authenticate/oidc_test.go
@@ -1,0 +1,246 @@
+// Copyright 2020 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package authenticate
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strconv"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc/metadata"
+	jose "gopkg.in/square/go-jose.v2"
+
+	"istio.io/api/security/v1beta1"
+	"istio.io/istio/pkg/security"
+)
+
+const (
+	bearerTokenPrefix = "Bearer "
+)
+
+type jwksServer struct {
+	key jose.JSONWebKeySet
+	t   *testing.T
+}
+
+func (k *jwksServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if err := json.NewEncoder(w).Encode(k.key); err != nil {
+		k.t.Fatalf("failed to encode the jwks: %v", err)
+	}
+}
+
+func TestNewJwtAuthenticator(t *testing.T) {
+	tests := []struct {
+		name      string
+		expectErr bool
+		jwtRule   string
+	}{
+		{
+			name:      "jwt rule with jwks_uri",
+			expectErr: false,
+			jwtRule:   `{"issuer": "foo", "jwks_uri": "baz", "audiences": ["aud1", "aud2"]}`,
+		},
+		{
+			name: "jwt rule with OIDC config expected to fail",
+			// "foo/.well-known/openid-configuration" is expected to fail
+			expectErr: true,
+			jwtRule:   `{"issuer": "foo", "audiences": ["aud1", "aud2"]}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			jwtRule := v1beta1.JWTRule{}
+			err := json.Unmarshal([]byte(tt.jwtRule), &jwtRule)
+			if err != nil {
+				t.Fatalf("failed at unmarshal the jwt rule (%v), err: %v",
+					tt.jwtRule, err)
+			}
+			_, err = NewJwtAuthenticator(&jwtRule, "domain-foo")
+			gotErr := err != nil
+			if gotErr != tt.expectErr {
+				t.Errorf("expect error is %v while actual error is %v", tt.expectErr, gotErr)
+			}
+		})
+	}
+}
+
+func TestCheckAudience(t *testing.T) {
+	tests := []struct {
+		name        string
+		expectRet   bool
+		audToCheck  []string
+		audExpected []string
+	}{
+		{
+			name:        "audience is in the expected set",
+			expectRet:   true,
+			audToCheck:  []string{"aud1"},
+			audExpected: []string{"aud1", "aud2"},
+		},
+		{
+			name:        "audience is NOT in the expected set",
+			expectRet:   false,
+			audToCheck:  []string{"aud3"},
+			audExpected: []string{"aud1", "aud2"},
+		},
+		{
+			name:        "one of the audiences is in the expected set",
+			expectRet:   true,
+			audToCheck:  []string{"aud1", "aud3"},
+			audExpected: []string{"aud1", "aud2"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ret := checkAudience(tt.audToCheck, tt.audExpected)
+			if ret != tt.expectRet {
+				t.Errorf("expected return is %v while actual return is %v", tt.expectRet, ret)
+			}
+		})
+	}
+}
+
+func TestOIDCAuthenticate(t *testing.T) {
+	// Create a JWKS server
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 512)
+	if err != nil {
+		t.Fatalf("failed to generate a private key: %v", err)
+	}
+	key := jose.JSONWebKey{Algorithm: string(jose.RS256), Key: rsaKey}
+	keySet := jose.JSONWebKeySet{}
+	keySet.Keys = append(keySet.Keys, key.Public())
+	server := httptest.NewServer(&jwksServer{key: keySet})
+	defer server.Close()
+
+	// Create a JWT authenticator
+	jwtRuleStr := `{"issuer": "` + server.URL + `", "jwks_uri": "` + server.URL + `", "audiences": ["baz.svc.id.goog"]}`
+	jwtRule := v1beta1.JWTRule{}
+	err = json.Unmarshal([]byte(jwtRuleStr), &jwtRule)
+	if err != nil {
+		t.Fatalf("failed at unmarshal jwt rule")
+	}
+	authenticator, err := NewJwtAuthenticator(&jwtRule, "baz.svc.id.goog")
+	if err != nil {
+		t.Fatalf("failed to create the JWT authenticator: %v", err)
+	}
+
+	// Create a valid JWT token
+	expStr := strconv.FormatInt(time.Now().Add(time.Hour).Unix(), 10)
+	claims := `{"iss": "` + server.URL + `", "aud": ["baz.svc.id.goog"], "sub": "system:serviceaccount:bar:foo", "exp": ` + expStr + `}`
+	token, err := generateJWT(&key, []byte(claims))
+	if err != nil {
+		t.Fatalf("failed to generate JWT: %v", err)
+	}
+	// Create an expired JWT token
+	expiredStr := strconv.FormatInt(time.Now().Add(-time.Hour).Unix(), 10)
+	expiredClaims := `{"iss": "` + server.URL + `", "aud": ["baz.svc.id.goog"], "sub": "system:serviceaccount:bar:foo", "exp": ` + expiredStr + `}`
+	expiredToken, err := generateJWT(&key, []byte(expiredClaims))
+	if err != nil {
+		t.Fatalf("failed to generate an expired JWT: %v", err)
+	}
+	// Create a JWT token with wrong audience
+	claimsWrongAudience := `{"iss": "` + server.URL + `", "aud": ["wrong-audience"], "sub": "system:serviceaccount:bar:foo", "exp": ` + expStr + `}`
+	tokenWrongAudience, err := generateJWT(&key, []byte(claimsWrongAudience))
+	if err != nil {
+		t.Fatalf("failed to generate JWT: %v", err)
+	}
+	// Create a JWT token with invalid subject, which is not prefixed with "system:serviceaccount"
+	claimsWrongSubject := `{"iss": "` + server.URL + `", "aud": ["baz.svc.id.goog"], "sub": "bar:foo", "exp": ` + expStr + `}`
+	tokenInvalidSubject, err := generateJWT(&key, []byte(claimsWrongSubject))
+	if err != nil {
+		t.Fatalf("failed to generate JWT: %v", err)
+	}
+
+	tests := map[string]struct {
+		token      string
+		expectErr  bool
+		expectedID string
+	}{
+		"No bearer token": {
+			expectErr: true,
+		},
+		"Valid token": {
+			token:      token,
+			expectErr:  false,
+			expectedID: fmt.Sprintf(IdentityTemplate, "baz.svc.id.goog", "bar", "foo"),
+		},
+		"Expired token": {
+			token:     expiredToken,
+			expectErr: true,
+		},
+		"Token with wrong audience": {
+			token:     tokenWrongAudience,
+			expectErr: true,
+		},
+		"Token with invalid subject": {
+			token:     tokenInvalidSubject,
+			expectErr: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+			md := metadata.MD{}
+			if tc.token != "" {
+				token := bearerTokenPrefix + tc.token
+				md.Append("authorization", token)
+			}
+			ctx = metadata.NewIncomingContext(ctx, md)
+
+			actualCaller, err := authenticator.Authenticate(ctx)
+			gotErr := err != nil
+			if gotErr != tc.expectErr {
+				t.Errorf("gotErr (%v) whereas expectErr (%v)", gotErr, tc.expectErr)
+			}
+			if gotErr {
+				return
+			}
+			expectedCaller := &security.Caller{
+				AuthSource: security.AuthSourceIDToken,
+				Identities: []string{tc.expectedID},
+			}
+			if !reflect.DeepEqual(actualCaller, expectedCaller) {
+				t.Errorf("%v: unexpected caller (want %v but got %v)", name, expectedCaller, actualCaller)
+			}
+		})
+	}
+}
+
+func generateJWT(key *jose.JSONWebKey, claims []byte) (string, error) {
+	signer, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.SignatureAlgorithm(key.Algorithm),
+		Key: key}, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create a signer: %v", err)
+	}
+	signature, err := signer.Sign(claims)
+	if err != nil {
+		return "", fmt.Errorf("failed to sign claims: %v", err)
+	}
+	jwt, err := signature.CompactSerialize()
+	if err != nil {
+		return "", fmt.Errorf("failed to serialize the JWT: %v", err)
+	}
+	return jwt, nil
+}


### PR DESCRIPTION
Please provide a description for what this PR is for: https://github.com/istio/istio/issues/30295
- Implement an OIDC JWT authenticator that supports both JWKS-URI and OIDC discovery. The OIDC JWT authenticator can be configured through the JWT_RULE env variable and when configured, it will be used as an istiod authenticator.
- Add tests for the OIDC JWT authenticator.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.