### PR TITLE
Fix empty revision for precheck

### DIFF
--- a/istioctl/pkg/install/pre-check.go
+++ b/istioctl/pkg/install/pre-check.go
@@ -347,7 +347,11 @@ func NewPrecheckCommand() *cobra.Command {
 				matched := false
 				for _, install := range installs {
 					if !specific || targetNamespace == install.namespace && targetRevision == install.revision {
-						c.Printf("Istio Revision %q already installed in namespace %q\n", install.revision, install.namespace)
+						revision := install.revision
+						if revision == "" {
+							revision = "default"
+						}
+						c.Printf("%q revision of Istio is already installed in %q namespace \n", revision, install.namespace)
 					}
 					if targetNamespace == install.namespace && targetRevision == install.revision {
 						matched = true

--- a/istioctl/pkg/install/pre-check.go
+++ b/istioctl/pkg/install/pre-check.go
@@ -351,7 +351,7 @@ func NewPrecheckCommand() *cobra.Command {
 						if revision == "" {
 							revision = "default"
 						}
-						c.Printf("%q revision of Istio is already installed in %q namespace \n", revision, install.namespace)
+						c.Printf("%q revision of Istio is already installed in %q namespace\n", revision, install.namespace)
 					}
 					if targetNamespace == install.namespace && targetRevision == install.revision {
 						matched = true


### PR DESCRIPTION
To fix https://github.com/istio/istio/issues/30300

Before:
```
[istio-1.9.0-beta.0]$ ./bin/istioctl x precheck
Istio Revision "" already installed in namespace "istio-system"
```
After:
Install Istio without revision.
```
[istio-1.9.0-beta.0]$ ./bin/istioctl install --set values.global.jwtPolicy=first-party-jwt

[istio-master]$ ./out/linux_amd64/istioctl x precheck
"default" revision of Istio is already installed in "istio-system" namespace
```

Install Istio with revision `1-9-beta`
```
[istio-1.9.0-beta.0]$ ./bin/istioctl install -r 1-9-beta --set values.global.jwtPolicy=first-party-jwt

[istio-1.9.0-beta.0]$ ./out/linux_amd64/istioctl x precheck
"1-9-beta" revision of Istio is already installed in "istio-system" namespace
```