### PR TITLE
Cherry Pick Prevent empty revision on install (#26959)

### DIFF
--- a/operator/cmd/mesh/install_test.go
+++ b/operator/cmd/mesh/install_test.go
@@ -1,0 +1,34 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mesh
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/onsi/gomega"
+)
+
+func TestInstallEmptyRevision(t *testing.T) {
+	g := gomega.NewWithT(t)
+	args := []string{"install", "--revision", ""}
+	rootCmd := GetRootCmd(args)
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+
+	err := rootCmd.Execute()
+	g.Expect(err).To(gomega.HaveOccurred())
+}

--- a/releasenotes/notes/26940.yaml
+++ b/releasenotes/notes/26940.yaml
@@ -1,0 +1,16 @@
+apiVersion: release-notes/v2
+
+kind:
+  bug-fix
+
+area:
+  istioctl
+
+issue:
+  - 26940
+
+# releaseNotes is a markdown listing of any user facing changes. This will appear in the
+# release notes.
+releaseNotes:
+  - |
+    **Fixed** Prevent explicitly empty revision flag on install.


### PR DESCRIPTION
Fixes #27810

* reject empty revision

* test empty revision

* Fix duplicate test

* fix test build failures

* register gomega

* move test to unit, prerun

* releasenote

* validate revision as qualified name

* add copyright

* fix note format

* fmt

* remove duplicate import

* gofmt

* remove integ test

* remove install-revision label, as it isn't used.

* Fix spelling and formatting

* fix imports



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.