### PR TITLE
External CA: Adding e2e integration tests to interoperate with external CA using K8s CSR API

### DIFF
--- a/pkg/test/framework/features/features.yaml
+++ b/pkg/test/framework/features/features.yaml
@@ -62,6 +62,8 @@ features:
       remove-from-mesh:
   # features that allow users to secure their services and service mesh.
   security:
+    externalca:
+      reachability:
     peer:
       secure-naming:
       trust-domain-validation:

--- a/tests/integration/security/external_ca/basic_reachability.go
+++ b/tests/integration/security/external_ca/basic_reachability.go
@@ -1,0 +1,77 @@
+// +build integ
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package externalca
+
+import (
+	"fmt"
+	"testing"
+
+	"istio.io/istio/pkg/test/echo/common/scheme"
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/echo"
+	"istio.io/istio/pkg/test/framework/components/istio"
+	"istio.io/istio/pkg/test/framework/components/namespace"
+	"istio.io/istio/tests/integration/security/util"
+	"istio.io/istio/tests/integration/security/util/connection"
+)
+
+// TestReachability verifies:
+// (a) Different workloads after getting their certificates signed by the K8s CA are successfully able to communicate with each other
+func TestReachability(t *testing.T) {
+	framework.NewTest(t).
+		Features("security.externalca.reachability").
+		Run(func(ctx framework.TestContext) {
+			/* Test cases cannot be run in multi-cluster environments when using per cluster K8s CA Signers. Revisit this when
+			 * (a) Test environment can be modified to deploy external-signer common to all clusters in multi-cluster environment OR
+			 * (b) When trust-bundle for workload ISTIO_MUTUAL mtls can be explicitly configured PER Istio Trust Domain
+			 */
+			if ctx.Clusters().IsMulticluster() {
+				ctx.Skip()
+			}
+			istioCfg := istio.DefaultConfigOrFail(t, ctx)
+			testNamespace := apps.Namespace
+			namespace.ClaimOrFail(t, ctx, istioCfg.SystemNamespace)
+			callCount := 1
+			if ctx.Clusters().IsMulticluster() {
+				// so we can validate all clusters are hit
+				callCount = util.CallsPerCluster * len(ctx.Clusters())
+			}
+			bSet := apps.B.Match(echo.Namespace(testNamespace.Name()))
+			for _, cluster := range ctx.Clusters() {
+				ctx.NewSubTest(fmt.Sprintf("From %s", cluster.Name())).Run(func(ctx framework.TestContext) {
+					a := apps.A.Match(echo.InCluster(cluster)).Match(echo.Namespace(testNamespace.Name()))[0]
+					ctx.NewSubTest("Basic reachability with external ca").
+						Run(func(ctx framework.TestContext) {
+							// Verify mTLS works between a and b
+							callOptions := echo.CallOptions{
+								Target:   bSet[0],
+								PortName: "http",
+								Scheme:   scheme.HTTP,
+								Count:    callCount,
+							}
+							checker := connection.Checker{
+								From:          a,
+								Options:       callOptions,
+								ExpectSuccess: true,
+								DestClusters:  bSet.Clusters(),
+							}
+							checker.CheckOrFail(ctx)
+						})
+
+				})
+			}
+		})
+}

--- a/tests/integration/security/external_ca/main_test.go
+++ b/tests/integration/security/external_ca/main_test.go
@@ -1,0 +1,103 @@
+// +build integ
+//  Copyright Istio Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package externalca
+
+import (
+	"testing"
+
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/echo"
+	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
+	"istio.io/istio/pkg/test/framework/components/istio"
+	"istio.io/istio/pkg/test/framework/components/namespace"
+	"istio.io/istio/pkg/test/framework/label"
+	"istio.io/istio/pkg/test/framework/resource"
+	"istio.io/istio/tests/integration/security/util"
+)
+
+const (
+	ASvc = "a"
+	BSvc = "b"
+)
+
+type EchoDeployments struct {
+	Namespace namespace.Instance
+	// workloads for TestSecureNaming
+	A, B echo.Instances
+}
+
+var (
+	inst istio.Instance
+	apps = &EchoDeployments{}
+)
+
+func SetupApps(ctx resource.Context, apps *EchoDeployments) error {
+	var err error
+	apps.Namespace, err = namespace.New(ctx, namespace.Config{
+		Prefix: "test-ns",
+		Inject: true,
+	})
+	if err != nil {
+		return err
+	}
+
+	builder := echoboot.NewBuilder(ctx)
+	builder.
+		WithClusters(ctx.Clusters()...).
+		WithConfig(util.EchoConfig(ASvc, apps.Namespace, false, nil)).
+		WithConfig(util.EchoConfig(BSvc, apps.Namespace, false, nil))
+
+	echos, err := builder.Build()
+	if err != nil {
+		return err
+	}
+	apps.A = echos.Match(echo.Service(ASvc))
+	apps.B = echos.Match(echo.Service(BSvc))
+	return nil
+}
+
+func TestMain(m *testing.M) {
+	// Integration test for testing interoperability with external CA's that are integrated with K8s CSR API
+	// Refer to https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/
+	framework.NewSuite(m).
+		Label(label.CustomSetup).
+		Setup(istio.Setup(&inst, setupConfig)).
+		Setup(func(ctx resource.Context) error {
+			return SetupApps(ctx, apps)
+		}).
+		Run()
+}
+
+func setupConfig(_ resource.Context, cfg *istio.Config) {
+	if cfg == nil {
+		return
+	}
+
+	// TODO: Replace K8s legacy signer by deploying external signer common to all clusters with a known root
+	cfg.ControlPlaneValues = `
+components:
+  pilot:
+    k8s:
+      env:
+      - name: EXTERNAL_CA
+        value: ISTIOD_RA_KUBERNETES_API
+      - name: K8S_SIGNER
+        value: kubernetes.io/legacy-unknown
+values:
+  meshConfig:
+    trustDomainAliases: [some-other, trust-domain-foo]
+`
+}


### PR DESCRIPTION
Related to issue [#27418](https://github.com/istio/istio/issues/27606) - effort to promote feature from pre-alpha to beta

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.