### PR TITLE
Add configz to tf dump

### DIFF
--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -216,6 +216,9 @@ func (i *operatorComponent) Dump(ctx resource.Context) {
 		return
 	}
 	kube2.DumpPods(ctx, d, ns)
+	for _, cluster := range ctx.Clusters() {
+		kube2.DumpDebug(cluster, d, "configz")
+	}
 }
 
 // saveManifestForCleanup will ensure we delete the given yaml from the given cluster during cleanup.

--- a/pkg/test/kube/dump.go
+++ b/pkg/test/kube/dump.go
@@ -259,6 +259,24 @@ func checkIfVM(pod corev1.Pod) bool {
 	return false
 }
 
+func DumpDebug(c resource.Cluster, workDir string, endpoint string) {
+	cp, istiod, err := getControlPlane(c)
+	if err != nil {
+		scopes.Framework.Warnf("failed dumping %q: %v", endpoint, err)
+		return
+	}
+	outPath := outputPath(workDir, c, istiod, endpoint)
+	out, err := dumpDebug(cp, istiod, fmt.Sprintf("/debug/%s", endpoint))
+	if err != nil {
+		scopes.Framework.Warnf("failed dumping %q: %v", endpoint, err)
+		return
+	}
+	if err := ioutil.WriteFile(outPath, []byte(out), 0644); err != nil {
+		scopes.Framework.Warnf("failed dumping %q: %v", endpoint, err)
+		return
+	}
+}
+
 func DumpNdsz(_ resource.Context, c resource.Cluster, workDir string, _ string, pods ...corev1.Pod) {
 	cp, istiod, err := getControlPlane(c)
 	if err != nil {


### PR DESCRIPTION
Just ran into a case where stale config broke a test. This would make it simple to spot.