### PR TITLE
Test framework: automatically clean up YAML applied by default

### DIFF
--- a/pkg/test/framework/components/echo/kube/instance.go
+++ b/pkg/test/framework/components/echo/kube/instance.go
@@ -116,13 +116,13 @@ func newInstance(ctx resource.Context, originalCfg echo.Config) (out *instance, 
 	}
 
 	// Apply the service definition to all clusters.
-	if err := ctx.Config().ApplyYAML(cfg.Namespace.Name(), serviceYAML); err != nil {
+	if err := ctx.Config().ApplyYAMLNoCleanup(cfg.Namespace.Name(), serviceYAML); err != nil {
 		return nil, fmt.Errorf("failed deploying echo service %s to clusters: %v",
 			cfg.FQDN(), err)
 	}
 
 	// Deploy the YAML.
-	if err = ctx.Config(c.cluster).ApplyYAML(cfg.Namespace.Name(), deploymentYAML); err != nil {
+	if err = ctx.Config(c.cluster).ApplyYAMLNoCleanup(cfg.Namespace.Name(), deploymentYAML); err != nil {
 		return nil, fmt.Errorf("failed deploying echo %s to cluster %s: %v",
 			cfg.FQDN(), c.cluster.Name(), err)
 	}
@@ -202,7 +202,7 @@ spec:
 
 	// Push the WorkloadGroup for auto-registration
 	if cfg.AutoRegisterVM {
-		if err := ctx.Config(cfg.Cluster).ApplyYAML(cfg.Namespace.Name(), wg); err != nil {
+		if err := ctx.Config(cfg.Cluster).ApplyYAMLNoCleanup(cfg.Namespace.Name(), wg); err != nil {
 			return err
 		}
 	}
@@ -420,7 +420,7 @@ spec:
     version: %s
 `, vmPod.Name, vmPod.Status.PodIP, serviceAccount, cfg.Cluster.NetworkName(), cfg.Service, vmPod.Labels["istio.io/test-vm-version"])
 		// Deploy the workload entry to the primary cluster. We will read WorkloadEntry across clusters.
-		if err := ctx.Config(cfg.Cluster.Primary()).ApplyYAML(cfg.Namespace.Name(), wle); err != nil {
+		if err := ctx.Config(cfg.Cluster.Primary()).ApplyYAMLNoCleanup(cfg.Namespace.Name(), wle); err != nil {
 			return err
 		}
 	}

--- a/pkg/test/framework/config.go
+++ b/pkg/test/framework/config.go
@@ -52,6 +52,7 @@ func (c *configManager) applyYAML(cleanup bool, ns string, yamlText ...string) e
 	}
 
 	for _, cl := range c.clusters {
+		cl := cl
 		if err := cl.ApplyYAMLFiles(ns, yamlFiles...); err != nil {
 			return fmt.Errorf("failed applying YAML to cluster %s: %v", cl.Name(), err)
 		}

--- a/pkg/test/framework/config.go
+++ b/pkg/test/framework/config.go
@@ -40,9 +40,9 @@ func newConfigManager(ctx resource.Context, clusters []resource.Cluster) resourc
 	}
 }
 
-func (c *configManager) ApplyYAML(ns string, yamlText ...string) error {
+func (c *configManager) applyYAML(cleanup bool, ns string, yamlText ...string) error {
 	if len(c.prefix) == 0 {
-		return c.WithFilePrefix("apply").ApplyYAML(ns, yamlText...)
+		return c.WithFilePrefix("apply").(*configManager).applyYAML(cleanup, ns, yamlText...)
 	}
 
 	// Convert the content to files.
@@ -55,13 +55,23 @@ func (c *configManager) ApplyYAML(ns string, yamlText ...string) error {
 		if err := cl.ApplyYAMLFiles(ns, yamlFiles...); err != nil {
 			return fmt.Errorf("failed applying YAML to cluster %s: %v", cl.Name(), err)
 		}
-		c.ctx.Cleanup(func() {
-			if err := cl.DeleteYAMLFiles(ns, yamlFiles...); err != nil {
-				scopes.Framework.Errorf("failed applying YAML from cluster %s: %v", cl.Name(), err)
-			}
-		})
+		if cleanup {
+			c.ctx.Cleanup(func() {
+				if err := cl.DeleteYAMLFiles(ns, yamlFiles...); err != nil {
+					scopes.Framework.Errorf("failed applying YAML from cluster %s: %v", cl.Name(), err)
+				}
+			})
+		}
 	}
 	return nil
+}
+
+func (c *configManager) ApplyYAML(ns string, yamlText ...string) error {
+	return c.applyYAML(true, ns, yamlText...)
+}
+
+func (c *configManager) ApplyYAMLNoCleanup(ns string, yamlText ...string) error {
+	return c.applyYAML(false, ns, yamlText...)
 }
 
 func (c *configManager) ApplyYAMLOrFail(t test.Failer, ns string, yamlText ...string) {

--- a/pkg/test/framework/resource/context.go
+++ b/pkg/test/framework/resource/context.go
@@ -21,16 +21,20 @@ import (
 
 // ConfigManager is an interface for applying/deleting yaml resources.
 type ConfigManager interface {
-	// ApplyYAML applies the given config yaml text via Galley.
+	// ApplyYAML applies the given config yaml text. Applied YAML is automatically deleted when the
+	// test exits.
 	ApplyYAML(ns string, yamlText ...string) error
 
-	// ApplyYAMLOrFail applies the given config yaml text via Galley.
+	// ApplyYAMLNoCleanup applies the given config yaml text.
+	ApplyYAMLNoCleanup(ns string, yamlText ...string) error
+
+	// ApplyYAMLOrFail applies the given config yaml text.
 	ApplyYAMLOrFail(t test.Failer, ns string, yamlText ...string)
 
-	// DeleteYAML deletes the given config yaml text via Galley.
+	// DeleteYAML deletes the given config yaml text.
 	DeleteYAML(ns string, yamlText ...string) error
 
-	// DeleteYAMLOrFail deletes the given config yaml text via Galley.
+	// DeleteYAMLOrFail deletes the given config yaml text.
 	DeleteYAMLOrFail(t test.Failer, ns string, yamlText ...string)
 
 	// WithFilePrefix sets the prefix used for intermediate files.

--- a/tests/integration/pilot/common/traffic.go
+++ b/tests/integration/pilot/common/traffic.go
@@ -64,9 +64,6 @@ func (c TrafficTestCase) Run(ctx framework.TestContext, namespace string) {
 		if len(c.config) > 0 {
 			cfg := yml.MustApplyNamespace(ctx, c.config, namespace)
 			ctx.Config().ApplyYAMLOrFail(ctx, "", cfg)
-			ctx.Cleanup(func() {
-				_ = ctx.Config().DeleteYAML("", cfg)
-			})
 		}
 
 		if c.call != nil && len(c.children) > 0 {

--- a/tests/integration/pilot/istioctl_test.go
+++ b/tests/integration/pilot/istioctl_test.go
@@ -119,9 +119,6 @@ func TestDescribe(t *testing.T) {
 		Run(func(ctx framework.TestContext) {
 			deployment := file.AsStringOrFail(t, "testdata/a.yaml")
 			ctx.Config().ApplyYAMLOrFail(ctx, apps.Namespace.Name(), deployment)
-			ctx.ConditionalCleanup(func() {
-				ctx.Config().DeleteYAML(apps.Namespace.Name(), deployment)
-			})
 
 			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{})
 
@@ -363,12 +360,6 @@ func TestAuthZCheck(t *testing.T) {
 			gwPolicy := file.AsStringOrFail(t, "testdata/authz-b.yaml")
 			ctx.Config().ApplyYAMLOrFail(ctx, apps.Namespace.Name(), appPolicy)
 			ctx.Config().ApplyYAMLOrFail(ctx, i.Settings().SystemNamespace, gwPolicy)
-			ctx.ConditionalCleanup(func() {
-				ctx.Config().DeleteYAML(apps.Namespace.Name(), appPolicy)
-			})
-			ctx.ConditionalCleanup(func() {
-				ctx.Config().DeleteYAML(i.Settings().SystemNamespace, gwPolicy)
-			})
 
 			gwPod, err := i.IngressFor(ctx.Clusters().Default()).PodID(0)
 			if err != nil {

--- a/tests/integration/pilot/locality_test.go
+++ b/tests/integration/pilot/locality_test.go
@@ -182,7 +182,7 @@ func TestLocality(t *testing.T) {
 				ctx.NewSubTest(tt.name).Run(func(ctx framework.TestContext) {
 					hostname := fmt.Sprintf("%s-fake-locality.example.com", strings.ToLower(strings.ReplaceAll(tt.name, "/", "-")))
 					tt.input.Host = hostname
-					applyAndCleanup(ctx, apps.Namespace.Name(), runTemplate(ctx, localityTemplate, tt.input))
+					ctx.Config().ApplyYAMLOrFail(ctx, apps.Namespace.Name(), runTemplate(ctx, localityTemplate, tt.input))
 					sendTrafficOrFail(ctx, apps.PodA[0], hostname, tt.expected)
 				})
 			}
@@ -193,13 +193,6 @@ const sendCount = 50
 
 func expectAllTrafficTo(dest string) map[string]int {
 	return map[string]int{dest: sendCount}
-}
-
-func applyAndCleanup(ctx framework.TestContext, ns string, yaml ...string) {
-	ctx.Config().ApplyYAMLOrFail(ctx, ns, yaml...)
-	ctx.ConditionalCleanup(func() {
-		ctx.Config().DeleteYAML(ns, yaml...)
-	})
 }
 
 func sendTrafficOrFail(ctx framework.TestContext, from echo.Instance, host string, expected map[string]int) {

--- a/tests/integration/pilot/mirror_test.go
+++ b/tests/integration/pilot/mirror_test.go
@@ -142,9 +142,6 @@ func runMirrorTest(t *testing.T, options mirrorTestOptions) {
 					deployment := tmpl.EvaluateOrFail(ctx,
 						file.AsStringOrFail(ctx, "testdata/traffic-mirroring-template.yaml"), vsc)
 					ctx.Config().ApplyYAMLOrFail(ctx, apps.Namespace.Name(), deployment)
-					ctx.ConditionalCleanup(func() {
-						ctx.Config().DeleteYAML(apps.Namespace.Name(), deployment)
-					})
 
 					for _, podA := range apps.PodA {
 						podA := podA

--- a/tests/integration/pilot/multi_version_revision_test.go
+++ b/tests/integration/pilot/multi_version_revision_test.go
@@ -150,7 +150,9 @@ func installRevisionOrFail(ctx framework.TestContext, version string, configs ma
 		ctx.Fatalf("could not read installation config: %v", err)
 	}
 	configs[version] = config
-	ctx.Config().ApplyYAMLOrFail(ctx, i.Settings().SystemNamespace, config)
+	if err := ctx.Config().ApplyYAMLNoCleanup(i.Settings().SystemNamespace, config); err != nil {
+		ctx.Fatal(err)
+	}
 }
 
 // ReadInstallFile reads a tar compress installation file from the embedded

--- a/tests/integration/security/ca_custom_root/secure_naming_test.go
+++ b/tests/integration/security/ca_custom_root/secure_naming_test.go
@@ -186,7 +186,6 @@ func TestSecureNaming(t *testing.T) {
 							Run(func(ctx framework.TestContext) {
 								dr := strings.ReplaceAll(tc.destinationRule, "NS", testNamespace.Name())
 								ctx.Config().ApplyYAMLOrFail(t, testNamespace.Name(), dr)
-								defer ctx.Config().DeleteYAMLOrFail(t, testNamespace.Name(), dr)
 								// Verify mTLS works between a and b
 								callOptions := echo.CallOptions{
 									Target:   bSet[0],

--- a/tests/integration/security/ca_custom_root/trust_domain_alias_secure_naming_test.go
+++ b/tests/integration/security/ca_custom_root/trust_domain_alias_secure_naming_test.go
@@ -74,7 +74,6 @@ func TestTrustDomainAliasSecureNaming(t *testing.T) {
 			testNS := apps.Namespace
 
 			ctx.Config().ApplyYAMLOrFail(ctx, testNS.Name(), POLICY)
-			defer ctx.Config().DeleteYAMLOrFail(ctx, testNS.Name(), POLICY)
 
 			for _, cluster := range ctx.Clusters() {
 				ctx.NewSubTest(fmt.Sprintf("From %s", cluster.Name())).Run(func(ctx framework.TestContext) {

--- a/tests/integration/security/ca_custom_root/trust_domain_validation_test.go
+++ b/tests/integration/security/ca_custom_root/trust_domain_validation_test.go
@@ -99,7 +99,6 @@ func TestTrustDomainValidation(t *testing.T) {
 			testNS := apps.Namespace
 
 			ctx.Config().ApplyYAMLOrFail(ctx, testNS.Name(), fmt.Sprintf(policy, testNS.Name()))
-			defer ctx.Config().DeleteYAMLOrFail(ctx, testNS.Name(), fmt.Sprintf(policy, testNS.Name()))
 
 			trustDomains := map[string]struct {
 				cert string

--- a/tests/integration/security/ecc_signature_algorithm/mtls_strict_test.go
+++ b/tests/integration/security/ecc_signature_algorithm/mtls_strict_test.go
@@ -62,16 +62,10 @@ func TestStrictMTLS(t *testing.T) {
 		Run(func(ctx framework.TestContext) {
 			peerTemplate := tmpl.EvaluateOrFail(ctx, PeerAuthenticationConfig, map[string]string{"AppNamespace": apps.Namespace.Name()})
 			ctx.Config().ApplyYAMLOrFail(ctx, apps.Namespace.Name(), peerTemplate)
-			ctx.ConditionalCleanup(func() {
-				ctx.Config().DeleteYAML(apps.Namespace.Name(), peerTemplate)
-			})
 			util.WaitForConfigWithSleep(ctx, peerTemplate, apps.Namespace)
 
 			drTemplate := tmpl.EvaluateOrFail(ctx, DestinationRuleConfigIstioMutual, map[string]string{"AppNamespace": apps.Namespace.Name()})
 			ctx.Config().ApplyYAMLOrFail(ctx, apps.Namespace.Name(), drTemplate)
-			ctx.ConditionalCleanup(func() {
-				ctx.Config().DeleteYAML(apps.Namespace.Name(), drTemplate)
-			})
 			util.WaitForConfigWithSleep(ctx, drTemplate, apps.Namespace)
 
 			response := apps.Client.CallOrFail(t, echo.CallOptions{

--- a/tests/integration/security/file_mounted_certs/p2p_mtls_test.go
+++ b/tests/integration/security/file_mounted_certs/p2p_mtls_test.go
@@ -52,11 +52,8 @@ func TestClientToServiceTls(t *testing.T) {
 
 			echoClient, echoServer, serviceNamespace := setupEcho(t, ctx)
 
-			bufDestinationRule := createObject(ctx, serviceNamespace.Name(), DestinationRuleConfigMutual)
-			defer ctx.Config().DeleteYAMLOrFail(ctx, serviceNamespace.Name(), bufDestinationRule)
-
-			bufPeerAuthentication := createObject(ctx, "istio-system", PeerAuthenticationConfig)
-			defer ctx.Config().DeleteYAMLOrFail(ctx, "istio-system", bufPeerAuthentication)
+			createObject(ctx, serviceNamespace.Name(), DestinationRuleConfigMutual)
+			createObject(ctx, "istio-system", PeerAuthenticationConfig)
 
 			retry.UntilSuccessOrFail(t, func() error {
 				resp, err := echoClient.Call(echo.CallOptions{
@@ -122,10 +119,9 @@ spec:
 `
 )
 
-func createObject(ctx framework.TestContext, serviceNamespace string, yamlManifest string) string {
+func createObject(ctx framework.TestContext, serviceNamespace string, yamlManifest string) {
 	template := tmpl.EvaluateOrFail(ctx, yamlManifest, map[string]string{"AppNamespace": serviceNamespace})
 	ctx.Config().ApplyYAMLOrFail(ctx, serviceNamespace, template)
-	return template
 }
 
 // setupEcho creates an `istio-fd-sds` namespace and brings up two echo instances server and

--- a/tests/integration/security/filebased_tls_origination/egress_gateway_origination_test.go
+++ b/tests/integration/security/filebased_tls_origination/egress_gateway_origination_test.go
@@ -123,7 +123,6 @@ func TestEgressGatewayTls(t *testing.T) {
 						systemNamespace := namespace.ClaimOrFail(t, ctx, istioCfg.SystemNamespace)
 
 						ctx.Config().ApplyYAMLOrFail(ctx, systemNamespace.Name(), bufDestinationRule.String())
-						defer ctx.Config().DeleteYAMLOrFail(ctx, systemNamespace.Name(), bufDestinationRule.String())
 
 						retry.UntilSuccessOrFail(t, func() error {
 							resp, err := internalClient.Call(echo.CallOptions{

--- a/tests/integration/security/jwt_test.go
+++ b/tests/integration/security/jwt_test.go
@@ -61,7 +61,6 @@ func TestRequestAuthentication(t *testing.T) {
 				file.AsStringOrFail(t, "testdata/requestauthn/f-authn.yaml.tmpl"),
 			)
 			ctx.Config().ApplyYAMLOrFail(t, ns.Name(), jwtPolicies...)
-			defer ctx.Config().DeleteYAMLOrFail(t, ns.Name(), jwtPolicies...)
 
 			aSet := apps.A.Match(echo.Namespace(ns.Name()))
 			bSet := apps.B.Match(echo.Namespace(ns.Name()))
@@ -366,17 +365,13 @@ func TestIngressRequestAuthentication(t *testing.T) {
 				"RootNamespace": istio.GetOrFail(ctx, ctx).Settings().SystemNamespace,
 			}
 
-			applyPolicy := func(filename string, ns namespace.Instance) []string {
+			applyPolicy := func(filename string, ns namespace.Instance) {
 				policy := tmpl.EvaluateAllOrFail(t, namespaceTmpl, file.AsStringOrFail(t, filename))
 				ctx.Config().ApplyYAMLOrFail(t, ns.Name(), policy...)
-				return policy
 			}
 
-			securityPolicies := applyPolicy("testdata/requestauthn/global-jwt.yaml.tmpl", rootNS{})
-			ingressCfgs := applyPolicy("testdata/requestauthn/ingress.yaml.tmpl", ns)
-
-			defer ctx.Config().DeleteYAMLOrFail(t, rootNS{}.Name(), securityPolicies...)
-			defer ctx.Config().DeleteYAMLOrFail(t, ns.Name(), ingressCfgs...)
+			applyPolicy("testdata/requestauthn/global-jwt.yaml.tmpl", rootNS{})
+			applyPolicy("testdata/requestauthn/ingress.yaml.tmpl", ns)
 
 			bSet := apps.B.Match(echo.Namespace(ns.Name()))
 

--- a/tests/integration/security/mtls_healthcheck_test.go
+++ b/tests/integration/security/mtls_healthcheck_test.go
@@ -66,7 +66,6 @@ spec:
     mode: STRICT
 `, name, name)
 	ctx.Config().ApplyYAMLOrFail(t, ns.Name(), policyYAML)
-	defer ctx.Config().DeleteYAMLOrFail(t, ns.Name(), policyYAML)
 
 	var healthcheck echo.Instance
 	cfg := echo.Config{

--- a/tests/integration/security/pass_through_filter_chain_test.go
+++ b/tests/integration/security/pass_through_filter_chain_test.go
@@ -45,7 +45,6 @@ func TestPassThroughFilterChain(t *testing.T) {
 			policies := tmpl.EvaluateAllOrFail(t, args,
 				file.AsStringOrFail(t, "testdata/pass-through-filter-chain.yaml.tmpl"))
 			ctx.Config().ApplyYAMLOrFail(t, ns.Name(), policies...)
-			defer ctx.Config().DeleteYAMLOrFail(t, ns.Name(), policies...)
 
 			for _, cluster := range ctx.Clusters() {
 				a := apps.A.Match(echo.Namespace(ns.Name())).GetOrFail(ctx, echo.InCluster(cluster))

--- a/tests/integration/security/sds_egress/sds_istio_mutual_egress_test.go
+++ b/tests/integration/security/sds_egress/sds_istio_mutual_egress_test.go
@@ -92,7 +92,6 @@ func doIstioMutualTest(
 		With(&client, util.EchoConfig("client", ns, false, nil)).
 		BuildOrFail(ctx)
 	ctx.Config().ApplyYAMLOrFail(ctx, ns.Name(), file.AsStringOrFail(ctx, configPath))
-	defer ctx.Config().DeleteYAMLOrFail(ctx, ns.Name(), file.AsStringOrFail(ctx, configPath))
 
 	// give the configuration a moment to kick in
 	time.Sleep(time.Second * 20)

--- a/tests/integration/security/sds_tls_origination/egress_gateway_origination_test.go
+++ b/tests/integration/security/sds_tls_origination/egress_gateway_origination_test.go
@@ -94,8 +94,8 @@ func TestSimpleTlsOrigination(t *testing.T) {
 			}
 
 			for name, tc := range testCases {
-				t.Run(name, func(t *testing.T) {
-					bufDestinationRule := sdstlsutil.CreateDestinationRule(t, serverNamespace, "SIMPLE", tc.credentialToUse)
+				ctx.NewSubTest(name).Run(func(ctx framework.TestContext) {
+					bufDestinationRule := sdstlsutil.CreateDestinationRule(ctx, serverNamespace, "SIMPLE", tc.credentialToUse)
 
 					// Get namespace for gateway pod.
 					istioCfg := istio.DefaultConfigOrFail(ctx, ctx)
@@ -103,7 +103,7 @@ func TestSimpleTlsOrigination(t *testing.T) {
 
 					ctx.Config().ApplyYAMLOrFail(ctx, systemNS.Name(), bufDestinationRule.String())
 
-					retry.UntilSuccessOrFail(t, func() error {
+					retry.UntilSuccessOrFail(ctx, func() error {
 						resp, err := internalClient.Call(echo.CallOptions{
 							Target:   externalServer,
 							PortName: "http",

--- a/tests/integration/security/sds_tls_origination/egress_gateway_origination_test.go
+++ b/tests/integration/security/sds_tls_origination/egress_gateway_origination_test.go
@@ -102,7 +102,6 @@ func TestSimpleTlsOrigination(t *testing.T) {
 					systemNS := namespace.ClaimOrFail(ctx, ctx, istioCfg.SystemNamespace)
 
 					ctx.Config().ApplyYAMLOrFail(ctx, systemNS.Name(), bufDestinationRule.String())
-					defer ctx.Config().DeleteYAMLOrFail(ctx, systemNS.Name(), bufDestinationRule.String())
 
 					retry.UntilSuccessOrFail(t, func() error {
 						resp, err := internalClient.Call(echo.CallOptions{
@@ -252,7 +251,6 @@ func TestMutualTlsOrigination(t *testing.T) {
 						systemNS := namespace.ClaimOrFail(ctx, ctx, istioCfg.SystemNamespace)
 
 						ctx.Config().ApplyYAMLOrFail(ctx, systemNS.Name(), bufDestinationRule.String())
-						defer ctx.Config().DeleteYAMLOrFail(ctx, systemNS.Name(), bufDestinationRule.String())
 
 						retry.UntilSuccessOrFail(t, func() error {
 							resp, err := internalClient.Call(echo.CallOptions{

--- a/tests/integration/security/sds_tls_origination/util/util.go
+++ b/tests/integration/security/sds_tls_origination/util/util.go
@@ -30,6 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"istio.io/istio/pkg/config/protocol"
+	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/echo/common"
 	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/pkg/test/framework"
@@ -348,14 +349,14 @@ spec:
 )
 
 // Create the DestinationRule for TLS origination at Gateway by reading secret in istio-system namespace.
-func CreateDestinationRule(t *testing.T, serverNamespace namespace.Instance,
+func CreateDestinationRule(t test.Failer, serverNamespace namespace.Instance,
 	destinationRuleMode string, credentialName string) bytes.Buffer {
 
 	destinationRuleToParse := DestinationRuleConfig
 
 	tmpl, err := template.New("DestinationRule").Parse(destinationRuleToParse)
 	if err != nil {
-		t.Errorf("failed to create template: %v", err)
+		t.Fatalf("failed to create template: %v", err)
 	}
 
 	var buf bytes.Buffer

--- a/tests/integration/security/util/reachability/context.go
+++ b/tests/integration/security/util/reachability/context.go
@@ -29,7 +29,6 @@ import (
 	"istio.io/istio/pkg/test/util/retry"
 	"istio.io/istio/tests/integration/security/util"
 	"istio.io/istio/tests/integration/security/util/connection"
-	"istio.io/pkg/log"
 )
 
 // TestCase represents reachability test cases.
@@ -102,14 +101,6 @@ func Run(testCases []TestCase, ctx framework.TestContext, apps *util.EchoDeploym
 			})
 			ctx.NewSubTest("wait for config").Run(func(ctx framework.TestContext) {
 				util.WaitForConfigWithSleep(ctx, policyYAML, c.Namespace)
-			})
-
-			ctx.Cleanup(func() {
-				if err := retry.UntilSuccess(func() error {
-					return ctx.Config().DeleteYAML(c.Namespace.Name(), policyYAML)
-				}); err != nil {
-					log.Errorf("failed to delete configuration: %v", err)
-				}
 			})
 			for _, clients := range []echo.Instances{apps.A, apps.B.Match(echo.Namespace(apps.Namespace1.Name())), apps.Headless, apps.Naked, apps.HeadlessNaked} {
 				for _, client := range clients {

--- a/tests/integration/telemetry/stackdriver/stackdriver_filter_audit_test.go
+++ b/tests/integration/telemetry/stackdriver/stackdriver_filter_audit_test.go
@@ -55,7 +55,6 @@ func TestStackdriverHTTPAuditLogging(t *testing.T) {
 			}
 			policies := tmpl.EvaluateAllOrFail(t, args, file.AsStringOrFail(t, auditPolicyForLogEntry))
 			ctx.Config().ApplyYAMLOrFail(t, ns, policies...)
-			defer ctx.Config().DeleteYAMLOrFail(t, ns, policies...)
 			t.Logf("Audit policy deployed to namespace %v", ns)
 
 			for _, cltInstance := range clt {


### PR DESCRIPTION
This is a superset of https://github.com/istio/istio/pull/30335 and  https://github.com/istio/istio/pull/30336, its slightly smaller if you review those first.

Currently, we have a few cases:
* Test apply YAML, forgets to cleanup
* Test apply YAML, and is force to add extra code to cleanup
* Test apply YAML, and is force to add extra code to cleanup *and* they cleanup wrong (inconsistent cleanup for --nocleanup and cleanup)

All of these are not great.

Instead, this changes the default behavior of ApplyYAML to always clean up. This makes it very hard to shoot yourself in the foot when writing a test, and cleans up the code.

For some use cases where cleanup is explicitly not desired (such as `echo` deployment), a new function to apply without cleanup is added