### PR TITLE
Fix outdated setting in flag help of set in istioctl

### DIFF
--- a/operator/cmd/mesh/root.go
+++ b/operator/cmd/mesh/root.go
@@ -28,7 +28,7 @@ import (
 var (
 	baseVersion    = binversion.OperatorVersionString
 	setFlagHelpStr = `Override an IstioOperator value, e.g. to choose a profile
-(--set profile=demo), enable or disable components (--set components.policy.enabled=true), or override Istio
+(--set profile=demo), enable or disable components (--set components.cni.enabled=true), or override Istio
 settings (--set meshConfig.enableTracing=true). See documentation for more info:` + url.IstioOperatorSpec
 	// ManifestsFlagHelpStr is the command line description for --manifests
 	ManifestsFlagHelpStr = `Specify a path to a directory of charts and profiles


### PR DESCRIPTION
Since the `Policy` field of `IstioComponentSetSpec` is removed in current version, fix outdated setting in help flag of set in istioctl.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
