### PR TITLE
gateway: skip duplicate VirtualService matches

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -593,6 +593,8 @@ func buildGatewayNetworkFiltersFromTLSRoutes(node *model.Proxy, push *model.Push
 			networkFilters: buildOutboundAutoPassthroughFilterStack(push, node, port),
 		})
 	} else {
+		tlsSniHosts := map[string]struct{}{} // sni host -> exists
+
 		virtualServices := push.VirtualServicesForGateway(node, gatewayName)
 		for _, v := range virtualServices {
 			vsvc := v.Spec.(*networking.VirtualService)
@@ -612,8 +614,19 @@ func buildGatewayNetworkFiltersFromTLSRoutes(node *model.Proxy, push *model.Push
 			// matches, one for 1.foo.com, another for 2.foo.com, this code will produce duplicate filter
 			// chain matches
 			for _, tls := range vsvc.Tls {
-				for _, match := range tls.Match {
+				for i, match := range tls.Match {
 					if l4SingleMatch(convertTLSMatchToL4Match(match), server, gatewayName) {
+						// Envoy will reject config that has multiple filter chain matches with the same matching rules
+						// To avoid this, we need to make sure we don't have duplicated SNI hosts, which will become
+						// SNI filter chain matches
+						if duplicateSniHosts := model.CheckDuplicates(match.SniHosts, tlsSniHosts); len(duplicateSniHosts) != 0 {
+							log.Debugf(
+								"skipping VirtualService %s rule #%v on server port %d of gateway %s, duplicate SNI host names: %v",
+								v.Meta.Name, i, port.Port, gatewayName, duplicateSniHosts)
+							model.RecordRejectedConfig(gatewayName)
+							continue
+						}
+
 						// the sni hosts in the match will become part of a filter chain match
 						filterChains = append(filterChains, &filterChainOpts{
 							sniHosts:       match.SniHosts,

--- a/pilot/pkg/networking/core/v1alpha3/gateway_simulation_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway_simulation_test.go
@@ -442,8 +442,7 @@ spec:
 			},
 		},
 		simulationTest{
-			name:           "duplicate tls virtual service",
-			skipValidation: true,
+			name: "duplicate tls virtual service",
 			// Create the same virtual service in two namespaces
 			config: `
 apiVersion: networking.istio.io/v1alpha3
@@ -508,12 +507,12 @@ spec:
 `,
 			calls: []simulation.Expect{
 				{
-					// TODO(https://github.com/istio/istio/issues/24638) This is a bug!
-					// We should not have multiple matches, envoy will NACK this
-
 					"call",
 					simulation.Call{Port: 443, Protocol: simulation.HTTP, TLS: simulation.TLS, HostHeader: "mysite.example.com"},
-					simulation.Result{Error: simulation.ErrMultipleFilterChain},
+					simulation.Result{
+						ListenerMatched: "0.0.0.0_443",
+						ClusterMatched:  "outbound|443||mysite.default.svc.cluster.local",
+					},
 				},
 			},
 		},


### PR DESCRIPTION
Duplicate HTTPS virtual services bound to a gateway will lead to envoy
rejections - "multiple filter chains with the same matching rules are defined".

This patch changes the current behavior of no duplication checking on such case
that will eventually fail with a NACK and instead picks only the first one of
the duplicated match rules.

Fixes https://github.com/istio/istio/issues/30321

Signed-off-by: Kailun Qin <kailun.qin@intel.com>

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
