### PR TITLE
inject network label on pods based on env value

### DIFF
--- a/pkg/kube/inject/inject_test.go
+++ b/pkg/kube/inject/inject_test.go
@@ -60,6 +60,7 @@ func TestInjection(t *testing.T) {
 			setFlags: []string{
 				"components.cni.enabled=true",
 				"values.istio_cni.chained=true",
+				"values.global.network=network1",
 			},
 		},
 		{

--- a/pkg/kube/inject/testdata/inject/hello.yaml.cni.injected
+++ b/pkg/kube/inject/testdata/inject/hello.yaml.cni.injected
@@ -31,6 +31,7 @@ spec:
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest
         tier: backend
+        topology.istio.io/network: network1
         track: stable
     spec:
       containers:
@@ -109,6 +110,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_NETWORK
+          value: network1
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-proxy
         ports:

--- a/pkg/kube/inject/webhook.go
+++ b/pkg/kube/inject/webhook.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 
 	"istio.io/api/annotation"
+	"istio.io/api/label"
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	opconfig "istio.io/istio/operator/pkg/apis/istio/v1alpha1"
 	"istio.io/istio/pilot/cmd/pilot-agent/status"
@@ -590,6 +591,9 @@ func postProcessPod(pod *corev1.Pod, injectedPod corev1.Pod, req InjectionParame
 }
 
 func applyMetadata(pod *corev1.Pod, injectedPodData corev1.Pod, req InjectionParameters) {
+	if nw, ok := req.proxyEnvs["ISTIO_META_NETWORK"]; ok {
+		pod.Labels[label.TopologyNetwork.Name] = nw
+	}
 	// Add all additional injected annotations. These are overridden if needed
 	pod.Annotations[annotation.SidecarStatus.Name] = getInjectionStatus(injectedPodData.Spec)
 


### PR DESCRIPTION
fixes https://github.com/istio/istio/issues/30376

The namespace label is a catch-all that hides this in integration tests #28126 and 1.8+ users, so it was not noticed to be missing when https://github.com/istio/istio/pull/28800 deleted it (see changes to webhook.go, permalink not working)