### PR TITLE
Fix flaky TestDNS case

### DIFF
--- a/pilot/pkg/dns/dns_test.go
+++ b/pilot/pkg/dns/dns_test.go
@@ -199,6 +199,7 @@ func TestDNS(t *testing.T) {
 		{
 			Timeout: 3 * time.Second,
 			Net:     "udp",
+			UDPSize: 65535,
 		},
 		{
 			Timeout: 3 * time.Second,


### PR DESCRIPTION
DNS resolve error could happen in UDP protocol with error:

=== RUN   TestDNS/udp-success:_non_k8s_host_not_in_local_cache
       dns_test.go:221: Failed to resolve query for www.bing.com.: dns: overflowing header size

This change increases the UDP receive buffer size.
 
[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
