### PR TITLE
Profile Diff from Stderr to Stdout

### DIFF
--- a/operator/cmd/mesh/profile-diff.go
+++ b/operator/cmd/mesh/profile-diff.go
@@ -51,6 +51,7 @@ func profileDiffCmd(rootArgs *rootArgs, pfArgs *profileDiffArgs) *cobra.Command 
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SetOut(os.Stdout)
 			return profileDiff(cmd, rootArgs, pfArgs, args)
 		}}
 


### PR DESCRIPTION
Simple change to `profile-diff.go` to set the `outWriter` to `os.Stdout` as opposed to the default `os.Stderr` when not set.

cc @Monkeyanator authored change from `fmt.Println` to `cmd.Println`

fix for #30375 