### PR TITLE
traffic simulation: add false positive support

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -608,9 +608,6 @@ func buildGatewayNetworkFiltersFromTLSRoutes(node *model.Proxy, push *model.Push
 			}
 
 			// For every matching TLS block, generate a filter chain with sni match
-			// TODO: Bug..if there is a single virtual service with *.foo.com, and multiple TLS block
-			// matches, one for 1.foo.com, another for 2.foo.com, this code will produce duplicate filter
-			// chain matches
 			for _, tls := range vsvc.Tls {
 				for _, match := range tls.Match {
 					if l4SingleMatch(convertTLSMatchToL4Match(match), server, gatewayName) {

--- a/pkg/config/host/name.go
+++ b/pkg/config/host/name.go
@@ -85,6 +85,10 @@ func (n Name) SubsetOf(o Name) bool {
 	return n == o
 }
 
+func (n Name) SameAs(o Name) bool {
+	return n == o
+}
+
 func (n Name) IsWildCarded() bool {
 	return len(n) > 0 && n[0] == '*'
 }


### PR DESCRIPTION
traffic simulation: add false positive support

Envoy is able to handle multiple configured filter chains w/ SNI wildcards,
which the current XDS traffic simulation flow considers as an error and
fails with a NACK.

This patch:
* extends the XDS traffic simulation flow with a false positive check support
  for `multiple filter chain matched` error on `server_names`;
* adds a new test for gateway using `single virtual service with multiple TLS
  match blocks`;
* removes confusing comments related to filter chain generation with SNI
  match specified in TLS match blocks.

Signed-off-by: Kailun Qin <kailun.qin@intel.com>

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
