### PR TITLE
Make iptables wait for the xtables lock

### DIFF
--- a/tools/istio-clean-iptables/pkg/cmd/cleanup.go
+++ b/tools/istio-clean-iptables/pkg/cmd/cleanup.go
@@ -24,17 +24,27 @@ import (
 
 func flushAndDeleteChains(ext dep.Dependencies, cmd string, table string, chains []string) {
 	for _, chain := range chains {
-		ext.RunQuietlyAndIgnore(cmd, "-t", table, "-F", chain)
-		ext.RunQuietlyAndIgnore(cmd, "-t", table, "-X", chain)
+		ext.RunQuietlyAndIgnore(cmd, "-w", constants.IptablesWaitSecondsArg, "-t", table, "-F", chain)
+		ext.RunQuietlyAndIgnore(cmd, "-w", constants.IptablesWaitSecondsArg, "-t", table, "-X", chain)
 	}
 }
 
 func removeOldChains(cfg *config.Config, ext dep.Dependencies, cmd string) {
 	// Remove the old TCP rules
 	for _, table := range []string{constants.NAT, constants.MANGLE} {
-		ext.RunQuietlyAndIgnore(cmd, "-t", table, "-D", constants.PREROUTING, "-p", constants.TCP, "-j", constants.ISTIOINBOUND)
+		ext.RunQuietlyAndIgnore(cmd,
+			"-w", constants.IptablesWaitSecondsArg,
+			"-t", table,
+			"-D", constants.PREROUTING,
+			"-p", constants.TCP,
+			"-j", constants.ISTIOINBOUND)
 	}
-	ext.RunQuietlyAndIgnore(cmd, "-t", constants.NAT, "-D", constants.OUTPUT, "-p", constants.TCP, "-j", constants.ISTIOOUTPUT)
+	ext.RunQuietlyAndIgnore(cmd,
+		"-w", constants.IptablesWaitSecondsArg,
+		"-t", constants.NAT,
+		"-D", constants.OUTPUT,
+		"-p", constants.TCP,
+		"-j", constants.ISTIOOUTPUT)
 
 	redirectDNS := cfg.RedirectDNS
 	// Remove the old DNS UDP rules

--- a/tools/istio-iptables/pkg/builder/iptables_builder_impl.go
+++ b/tools/istio-iptables/pkg/builder/iptables_builder_impl.go
@@ -94,14 +94,14 @@ func (rb *IptablesBuilderImpl) buildRules(command string, rules []*Rule) [][]str
 		if _, present := chainTableLookupMap[chainTable]; !present {
 			// Ignore chain creation for built-in chains for iptables
 			if _, present := constants.BuiltInChainsMap[r.chain]; !present {
-				cmd := []string{command, "-t", r.table, "-N", r.chain}
+				cmd := []string{command, "-w", constants.IptablesWaitSecondsArg, "-t", r.table, "-N", r.chain}
 				output = append(output, cmd)
 				chainTableLookupMap[chainTable] = struct{}{}
 			}
 		}
 	}
 	for _, r := range rules {
-		cmd := append([]string{command, "-t", r.table}, r.params...)
+		cmd := append([]string{command, "-w", constants.IptablesWaitSecondsArg, "-t", r.table}, r.params...)
 		output = append(output, cmd)
 	}
 	return output

--- a/tools/istio-iptables/pkg/builder/iptables_builder_test.go
+++ b/tools/istio-iptables/pkg/builder/iptables_builder_test.go
@@ -49,8 +49,8 @@ func TestBuildV4InsertSingleRule(t *testing.T) {
 	}
 	actual := iptables.BuildV4()
 	expected := [][]string{
-		{"iptables", "-t", "table", "-N", "chain"},
-		{"iptables", "-t", "table", "-I", "chain", "2", "-f", "foo", "-b", "bar"},
+		{"iptables", "-w", "10", "-t", "table", "-N", "chain"},
+		{"iptables", "-w", "10", "-t", "table", "-I", "chain", "2", "-f", "foo", "-b", "bar"},
 	}
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("Actual and expected output mismatch; but instead got Actual: %#v ; Expected: %#v", actual, expected)
@@ -70,8 +70,8 @@ func TestBuildV4AppendSingleRule(t *testing.T) {
 	}
 	actual := iptables.BuildV4()
 	expected := [][]string{
-		{"iptables", "-t", "table", "-N", "chain"},
-		{"iptables", "-t", "table", "-A", "chain", "-f", "foo", "-b", "bar"},
+		{"iptables", "-w", "10", "-t", "table", "-N", "chain"},
+		{"iptables", "-w", "10", "-t", "table", "-A", "chain", "-f", "foo", "-b", "bar"},
 	}
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("Actual and expected output mismatch; but instead got Actual: %#v ; Expected: %#v", actual, expected)
@@ -93,10 +93,10 @@ func TestBuildV4AppendMultipleRules(t *testing.T) {
 	}
 	actual := iptables.BuildV4()
 	expected := [][]string{
-		{"iptables", "-t", "table", "-N", "chain"},
-		{"iptables", "-t", "table", "-A", "chain", "-f", "foo", "-b", "bar"},
-		{"iptables", "-t", "table", "-A", "chain", "-f", "fu", "-b", "bar"},
-		{"iptables", "-t", "table", "-A", "chain", "-f", "foo", "-b", "baz"},
+		{"iptables", "-w", "10", "-t", "table", "-N", "chain"},
+		{"iptables", "-w", "10", "-t", "table", "-A", "chain", "-f", "foo", "-b", "bar"},
+		{"iptables", "-w", "10", "-t", "table", "-A", "chain", "-f", "fu", "-b", "bar"},
+		{"iptables", "-w", "10", "-t", "table", "-A", "chain", "-f", "foo", "-b", "baz"},
 	}
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("Actual and expected output mismatch; but instead got Actual: %#v ; Expected: %#v", actual, expected)
@@ -118,10 +118,10 @@ func TestBuildV4InsertMultipleRules(t *testing.T) {
 	}
 	actual := iptables.BuildV4()
 	expected := [][]string{
-		{"iptables", "-t", "table", "-N", "chain"},
-		{"iptables", "-t", "table", "-I", "chain", "1", "-f", "foo", "-b", "bar"},
-		{"iptables", "-t", "table", "-I", "chain", "2", "-f", "foo", "-b", "baaz"},
-		{"iptables", "-t", "table", "-I", "chain", "3", "-f", "foo", "-b", "baz"},
+		{"iptables", "-w", "10", "-t", "table", "-N", "chain"},
+		{"iptables", "-w", "10", "-t", "table", "-I", "chain", "1", "-f", "foo", "-b", "bar"},
+		{"iptables", "-w", "10", "-t", "table", "-I", "chain", "2", "-f", "foo", "-b", "baaz"},
+		{"iptables", "-w", "10", "-t", "table", "-I", "chain", "3", "-f", "foo", "-b", "baz"},
 	}
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("Actual and expected output mismatch; but instead got Actual: %#v ; Expected: %#v", actual, expected)
@@ -143,10 +143,10 @@ func TestBuildV4AppendInsertMultipleRules(t *testing.T) {
 	}
 	actual := iptables.BuildV4()
 	expected := [][]string{
-		{"iptables", "-t", "table", "-N", "chain"},
-		{"iptables", "-t", "table", "-A", "chain", "-f", "foo", "-b", "bar"},
-		{"iptables", "-t", "table", "-I", "chain", "2", "-f", "foo", "-b", "bar"},
-		{"iptables", "-t", "table", "-A", "chain", "-f", "foo", "-b", "baz"},
+		{"iptables", "-w", "10", "-t", "table", "-N", "chain"},
+		{"iptables", "-w", "10", "-t", "table", "-A", "chain", "-f", "foo", "-b", "bar"},
+		{"iptables", "-w", "10", "-t", "table", "-I", "chain", "2", "-f", "foo", "-b", "bar"},
+		{"iptables", "-w", "10", "-t", "table", "-A", "chain", "-f", "foo", "-b", "baz"},
 	}
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("Actual and expected output mismatch; but instead got Actual: %#v ; Expected: %#v", actual, expected)
@@ -166,8 +166,8 @@ func TestBuildV6InsertSingleRule(t *testing.T) {
 	}
 	actual := iptables.BuildV6()
 	expected := [][]string{
-		{"ip6tables", "-t", "table", "-N", "chain"},
-		{"ip6tables", "-t", "table", "-I", "chain", "2", "-f", "foo", "-b", "bar"},
+		{"ip6tables", "-w", "10", "-t", "table", "-N", "chain"},
+		{"ip6tables", "-w", "10", "-t", "table", "-I", "chain", "2", "-f", "foo", "-b", "bar"},
 	}
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("Actual and expected output mismatch; but instead got Actual: %#v ; Expected: %#v", actual, expected)
@@ -187,8 +187,8 @@ func TestBuildV6AppendSingleRule(t *testing.T) {
 	}
 	actual := iptables.BuildV6()
 	expected := [][]string{
-		{"ip6tables", "-t", "table", "-N", "chain"},
-		{"ip6tables", "-t", "table", "-A", "chain", "-f", "foo", "-b", "bar"},
+		{"ip6tables", "-w", "10", "-t", "table", "-N", "chain"},
+		{"ip6tables", "-w", "10", "-t", "table", "-A", "chain", "-f", "foo", "-b", "bar"},
 	}
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("Actual and expected output mismatch; but instead got Actual: %#v ; Expected: %#v", actual, expected)
@@ -210,10 +210,10 @@ func TestBuildV6AppendMultipleRules(t *testing.T) {
 	}
 	actual := iptables.BuildV6()
 	expected := [][]string{
-		{"ip6tables", "-t", "table", "-N", "chain"},
-		{"ip6tables", "-t", "table", "-A", "chain", "-f", "foo", "-b", "bar"},
-		{"ip6tables", "-t", "table", "-A", "chain", "-f", "fu", "-b", "bar"},
-		{"ip6tables", "-t", "table", "-A", "chain", "-f", "foo", "-b", "baz"},
+		{"ip6tables", "-w", "10", "-t", "table", "-N", "chain"},
+		{"ip6tables", "-w", "10", "-t", "table", "-A", "chain", "-f", "foo", "-b", "bar"},
+		{"ip6tables", "-w", "10", "-t", "table", "-A", "chain", "-f", "fu", "-b", "bar"},
+		{"ip6tables", "-w", "10", "-t", "table", "-A", "chain", "-f", "foo", "-b", "baz"},
 	}
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("Actual and expected output mismatch; but instead got Actual: %#v ; Expected: %#v", actual, expected)
@@ -235,10 +235,10 @@ func TestBuildV6InsertMultipleRules(t *testing.T) {
 	}
 	actual := iptables.BuildV6()
 	expected := [][]string{
-		{"ip6tables", "-t", "table", "-N", "chain"},
-		{"ip6tables", "-t", "table", "-I", "chain", "1", "-f", "foo", "-b", "bar"},
-		{"ip6tables", "-t", "table", "-I", "chain", "2", "-f", "foo", "-b", "baaz"},
-		{"ip6tables", "-t", "table", "-I", "chain", "3", "-f", "foo", "-b", "baz"},
+		{"ip6tables", "-w", "10", "-t", "table", "-N", "chain"},
+		{"ip6tables", "-w", "10", "-t", "table", "-I", "chain", "1", "-f", "foo", "-b", "bar"},
+		{"ip6tables", "-w", "10", "-t", "table", "-I", "chain", "2", "-f", "foo", "-b", "baaz"},
+		{"ip6tables", "-w", "10", "-t", "table", "-I", "chain", "3", "-f", "foo", "-b", "baz"},
 	}
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("Actual and expected output mismatch; but instead got Actual: %#v ; Expected: %#v", actual, expected)
@@ -260,10 +260,10 @@ func TestBuildV6InsertAppendMultipleRules(t *testing.T) {
 	}
 	actual := iptables.BuildV6()
 	expected := [][]string{
-		{"ip6tables", "-t", "table", "-N", "chain"},
-		{"ip6tables", "-t", "table", "-A", "chain", "-f", "foo", "-b", "bar"},
-		{"ip6tables", "-t", "table", "-I", "chain", "2", "-f", "foo", "-b", "bar"},
-		{"ip6tables", "-t", "table", "-I", "chain", "1", "-f", "foo", "-b", "bar"},
+		{"ip6tables", "-w", "10", "-t", "table", "-N", "chain"},
+		{"ip6tables", "-w", "10", "-t", "table", "-A", "chain", "-f", "foo", "-b", "bar"},
+		{"ip6tables", "-w", "10", "-t", "table", "-I", "chain", "2", "-f", "foo", "-b", "bar"},
+		{"ip6tables", "-w", "10", "-t", "table", "-I", "chain", "1", "-f", "foo", "-b", "bar"},
 	}
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("Actual and expected output mismatch; but instead got Actual: %#v ; Expected: %#v", actual, expected)
@@ -287,17 +287,17 @@ func TestBuildV4V6MultipleRulesWithNewChain(t *testing.T) {
 	actualV4 := iptables.BuildV4()
 	actualV6 := iptables.BuildV6()
 	expectedV6 := [][]string{
-		{"ip6tables", "-t", "table", "-N", "chain"},
-		{"ip6tables", "-t", "table", "-A", "chain", "-f", "foo", "-b", "bar"},
-		{"ip6tables", "-t", "table", "-I", "chain", "2", "-f", "foo", "-b", "bar"},
-		{"ip6tables", "-t", "table", "-I", "chain", "1", "-f", "foo", "-b", "bar"},
+		{"ip6tables", "-w", "10", "-t", "table", "-N", "chain"},
+		{"ip6tables", "-w", "10", "-t", "table", "-A", "chain", "-f", "foo", "-b", "bar"},
+		{"ip6tables", "-w", "10", "-t", "table", "-I", "chain", "2", "-f", "foo", "-b", "bar"},
+		{"ip6tables", "-w", "10", "-t", "table", "-I", "chain", "1", "-f", "foo", "-b", "bar"},
 	}
 	expectedV4 := [][]string{
-		{"iptables", "-t", "table", "-N", "chain"},
-		{"iptables", "-t", "table", "-A", "chain", "-f", "foo", "-b", "bar"},
-		{"iptables", "-t", "table", "-I", "chain", "2", "-f", "foo", "-b", "bar"},
-		{"iptables", "-t", "table", "-A", "chain", "-f", "foo", "-b", "baz"},
-		{"iptables", "-t", "nat", "-A", "PREROUTING", "-f", "foo", "-b", "bar"},
+		{"iptables", "-w", "10", "-t", "table", "-N", "chain"},
+		{"iptables", "-w", "10", "-t", "table", "-A", "chain", "-f", "foo", "-b", "bar"},
+		{"iptables", "-w", "10", "-t", "table", "-I", "chain", "2", "-f", "foo", "-b", "bar"},
+		{"iptables", "-w", "10", "-t", "table", "-A", "chain", "-f", "foo", "-b", "baz"},
+		{"iptables", "-w", "10", "-t", "nat", "-A", "PREROUTING", "-f", "foo", "-b", "bar"},
 	}
 	if !reflect.DeepEqual(actualV4, expectedV4) {
 		t.Errorf("Actual and expected output mismatch; but instead got Actual: %#v ; Expected: %#v", actualV4, expectedV4)

--- a/tools/istio-iptables/pkg/cmd/run.go
+++ b/tools/istio-iptables/pkg/cmd/run.go
@@ -670,7 +670,7 @@ func (iptConfigurator *IptablesConfigurator) executeIptablesRestoreCommand(isIpv
 		return err
 	}
 	// --noflush to prevent flushing/deleting previous contents from table
-	iptConfigurator.ext.RunOrFail(cmd, "--noflush", rulesFile.Name())
+	iptConfigurator.ext.RunOrFail(cmd, "-w", constants.IptablesWaitSecondsArg, "--noflush", rulesFile.Name())
 	return nil
 }
 

--- a/tools/istio-iptables/pkg/cmd/run_test.go
+++ b/tools/istio-iptables/pkg/cmd/run_test.go
@@ -57,8 +57,8 @@ func TestShortCircuitInternalIterface(t *testing.T) {
 	iptConfigurator.shortCircuitKubeInternalInterface()
 	actual := FormatIptablesCommands(iptConfigurator.iptables.BuildV6())
 	expected := []string{
-		"ip6tables -t nat -I PREROUTING 1 -i eth0 -j RETURN",
-		"ip6tables -t nat -I PREROUTING 1 -i eth1 -j RETURN",
+		"ip6tables -w 10 -t nat -I PREROUTING 1 -i eth0 -j RETURN",
+		"ip6tables -w 10 -t nat -I PREROUTING 1 -i eth1 -j RETURN",
 	}
 
 	if !reflect.DeepEqual(actual, expected) {
@@ -70,8 +70,8 @@ func TestShortCircuitInternalIterface(t *testing.T) {
 	iptConfigurator.shortCircuitKubeInternalInterface()
 	actual = FormatIptablesCommands(iptConfigurator.iptables.BuildV4())
 	expected = []string{
-		"iptables -t nat -I PREROUTING 1 -i eth0 -j RETURN",
-		"iptables -t nat -I PREROUTING 1 -i eth1 -j RETURN",
+		"iptables -w 10 -t nat -I PREROUTING 1 -i eth0 -j RETURN",
+		"iptables -w 10 -t nat -I PREROUTING 1 -i eth1 -j RETURN",
 	}
 
 	if !reflect.DeepEqual(actual, expected) {
@@ -92,22 +92,22 @@ func TestHandleInboundIpv6RulesWithEmptyInboundPorts(t *testing.T) {
 	iptConfigurator.handleInboundIpv6Rules(ipv6Range, ipv6Range)
 	actual := FormatIptablesCommands(iptConfigurator.iptables.BuildV6())
 	expected := []string{
-		"ip6tables -t nat -N ISTIO_INBOUND",
-		"ip6tables -t nat -N ISTIO_REDIRECT",
-		"ip6tables -t nat -N ISTIO_IN_REDIRECT",
-		"ip6tables -t nat -N ISTIO_OUTPUT",
-		"ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN",
-		"ip6tables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001",
-		"ip6tables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006",
-		"ip6tables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT",
-		"ip6tables -t nat -A ISTIO_OUTPUT -o lo -s ::6/128 -j RETURN",
-		"ip6tables -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT",
-		"ip6tables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 1337 -j RETURN",
-		"ip6tables -t nat -A ISTIO_OUTPUT -m owner --uid-owner 1337 -j RETURN",
-		"ip6tables -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -m owner --gid-owner 1337 -j ISTIO_IN_REDIRECT",
-		"ip6tables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --gid-owner 1337 -j RETURN",
-		"ip6tables -t nat -A ISTIO_OUTPUT -m owner --gid-owner 1337 -j RETURN",
-		"ip6tables -t nat -A ISTIO_OUTPUT -d ::1/128 -j RETURN",
+		"ip6tables -w 10 -t nat -N ISTIO_INBOUND",
+		"ip6tables -w 10 -t nat -N ISTIO_REDIRECT",
+		"ip6tables -w 10 -t nat -N ISTIO_IN_REDIRECT",
+		"ip6tables -w 10 -t nat -N ISTIO_OUTPUT",
+		"ip6tables -w 10 -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN",
+		"ip6tables -w 10 -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001",
+		"ip6tables -w 10 -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006",
+		"ip6tables -w 10 -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT",
+		"ip6tables -w 10 -t nat -A ISTIO_OUTPUT -o lo -s ::6/128 -j RETURN",
+		"ip6tables -w 10 -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT",
+		"ip6tables -w 10 -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 1337 -j RETURN",
+		"ip6tables -w 10 -t nat -A ISTIO_OUTPUT -m owner --uid-owner 1337 -j RETURN",
+		"ip6tables -w 10 -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -m owner --gid-owner 1337 -j ISTIO_IN_REDIRECT",
+		"ip6tables -w 10 -t nat -A ISTIO_OUTPUT -o lo -m owner ! --gid-owner 1337 -j RETURN",
+		"ip6tables -w 10 -t nat -A ISTIO_OUTPUT -m owner --gid-owner 1337 -j RETURN",
+		"ip6tables -w 10 -t nat -A ISTIO_OUTPUT -d ::1/128 -j RETURN",
 	}
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("Output mismatch.\nExpected: %#v\nActual: %#v", expected, actual)
@@ -128,37 +128,37 @@ func TestRulesWithIpRange(t *testing.T) {
 	iptConfigurator.run()
 	actual := FormatIptablesCommands(iptConfigurator.iptables.BuildV4())
 	expected := []string{
-		"iptables -t nat -N ISTIO_INBOUND",
-		"iptables -t nat -N ISTIO_REDIRECT",
-		"iptables -t nat -N ISTIO_IN_REDIRECT",
-		"iptables -t nat -N ISTIO_OUTPUT",
-		"iptables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN",
-		"iptables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001",
-		"iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006",
-		"iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT",
-		"iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN",
-		"iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -p tcp ! --dport 53 -m owner --uid-owner 3 -j ISTIO_IN_REDIRECT",
-		"iptables -t nat -A ISTIO_OUTPUT -o lo -p tcp ! --dport 53 -m owner ! --uid-owner 3 -j RETURN",
-		"iptables -t nat -A ISTIO_OUTPUT -m owner --uid-owner 3 -j RETURN",
-		"iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -p tcp ! --dport 53 -m owner --uid-owner 4 -j ISTIO_IN_REDIRECT",
-		"iptables -t nat -A ISTIO_OUTPUT -o lo -p tcp ! --dport 53 -m owner ! --uid-owner 4 -j RETURN",
-		"iptables -t nat -A ISTIO_OUTPUT -m owner --uid-owner 4 -j RETURN",
-		"iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --gid-owner 1 -j ISTIO_IN_REDIRECT",
-		"iptables -t nat -A ISTIO_OUTPUT -o lo -p tcp ! --dport 53 -m owner ! --gid-owner 1 -j RETURN",
-		"iptables -t nat -A ISTIO_OUTPUT -m owner --gid-owner 1 -j RETURN",
-		"iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --gid-owner 2 -j ISTIO_IN_REDIRECT",
-		"iptables -t nat -A ISTIO_OUTPUT -o lo -p tcp ! --dport 53 -m owner ! --gid-owner 2 -j RETURN",
-		"iptables -t nat -A ISTIO_OUTPUT -m owner --gid-owner 2 -j RETURN",
-		"iptables -t nat -A ISTIO_OUTPUT -p tcp --dport 53 -d 127.0.0.53/32 -j REDIRECT --to-ports 15053",
-		"iptables -t nat -A ISTIO_OUTPUT -d 127.0.0.1/32 -j RETURN",
-		"iptables -t nat -A ISTIO_OUTPUT -d 1.1.0.0/16 -j RETURN",
-		"iptables -t nat -A ISTIO_OUTPUT -d 9.9.0.0/16 -j ISTIO_REDIRECT",
-		"iptables -t nat -A ISTIO_OUTPUT -j RETURN",
-		"iptables -t nat -A OUTPUT -p udp --dport 53 -m owner --uid-owner 3 -j RETURN",
-		"iptables -t nat -A OUTPUT -p udp --dport 53 -m owner --uid-owner 4 -j RETURN",
-		"iptables -t nat -A OUTPUT -p udp --dport 53 -m owner --gid-owner 1 -j RETURN",
-		"iptables -t nat -A OUTPUT -p udp --dport 53 -m owner --gid-owner 2 -j RETURN",
-		"iptables -t nat -A OUTPUT -p udp --dport 53 -d 127.0.0.53/32 -j REDIRECT --to-port 15053",
+		"iptables -w 10 -t nat -N ISTIO_INBOUND",
+		"iptables -w 10 -t nat -N ISTIO_REDIRECT",
+		"iptables -w 10 -t nat -N ISTIO_IN_REDIRECT",
+		"iptables -w 10 -t nat -N ISTIO_OUTPUT",
+		"iptables -w 10 -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN",
+		"iptables -w 10 -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001",
+		"iptables -w 10 -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006",
+		"iptables -w 10 -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT",
+		"iptables -w 10 -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN",
+		"iptables -w 10 -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -p tcp ! --dport 53 -m owner --uid-owner 3 -j ISTIO_IN_REDIRECT",
+		"iptables -w 10 -t nat -A ISTIO_OUTPUT -o lo -p tcp ! --dport 53 -m owner ! --uid-owner 3 -j RETURN",
+		"iptables -w 10 -t nat -A ISTIO_OUTPUT -m owner --uid-owner 3 -j RETURN",
+		"iptables -w 10 -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -p tcp ! --dport 53 -m owner --uid-owner 4 -j ISTIO_IN_REDIRECT",
+		"iptables -w 10 -t nat -A ISTIO_OUTPUT -o lo -p tcp ! --dport 53 -m owner ! --uid-owner 4 -j RETURN",
+		"iptables -w 10 -t nat -A ISTIO_OUTPUT -m owner --uid-owner 4 -j RETURN",
+		"iptables -w 10 -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --gid-owner 1 -j ISTIO_IN_REDIRECT",
+		"iptables -w 10 -t nat -A ISTIO_OUTPUT -o lo -p tcp ! --dport 53 -m owner ! --gid-owner 1 -j RETURN",
+		"iptables -w 10 -t nat -A ISTIO_OUTPUT -m owner --gid-owner 1 -j RETURN",
+		"iptables -w 10 -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --gid-owner 2 -j ISTIO_IN_REDIRECT",
+		"iptables -w 10 -t nat -A ISTIO_OUTPUT -o lo -p tcp ! --dport 53 -m owner ! --gid-owner 2 -j RETURN",
+		"iptables -w 10 -t nat -A ISTIO_OUTPUT -m owner --gid-owner 2 -j RETURN",
+		"iptables -w 10 -t nat -A ISTIO_OUTPUT -p tcp --dport 53 -d 127.0.0.53/32 -j REDIRECT --to-ports 15053",
+		"iptables -w 10 -t nat -A ISTIO_OUTPUT -d 127.0.0.1/32 -j RETURN",
+		"iptables -w 10 -t nat -A ISTIO_OUTPUT -d 1.1.0.0/16 -j RETURN",
+		"iptables -w 10 -t nat -A ISTIO_OUTPUT -d 9.9.0.0/16 -j ISTIO_REDIRECT",
+		"iptables -w 10 -t nat -A ISTIO_OUTPUT -j RETURN",
+		"iptables -w 10 -t nat -A OUTPUT -p udp --dport 53 -m owner --uid-owner 3 -j RETURN",
+		"iptables -w 10 -t nat -A OUTPUT -p udp --dport 53 -m owner --uid-owner 4 -j RETURN",
+		"iptables -w 10 -t nat -A OUTPUT -p udp --dport 53 -m owner --gid-owner 1 -j RETURN",
+		"iptables -w 10 -t nat -A OUTPUT -p udp --dport 53 -m owner --gid-owner 2 -j RETURN",
+		"iptables -w 10 -t nat -A OUTPUT -p udp --dport 53 -d 127.0.0.53/32 -j REDIRECT --to-port 15053",
 	}
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("Output mismatch. Expected: \n%#v ; Actual: \n%#v", expected, actual)
@@ -181,42 +181,42 @@ func TestRulesWithTproxy(t *testing.T) {
 	iptConfigurator.run()
 	actual := FormatIptablesCommands(iptConfigurator.iptables.BuildV4())
 	expected := []string{
-		"iptables -t nat -N ISTIO_INBOUND",
-		"iptables -t nat -N ISTIO_REDIRECT",
-		"iptables -t nat -N ISTIO_IN_REDIRECT",
-		"iptables -t mangle -N ISTIO_DIVERT",
-		"iptables -t mangle -N ISTIO_TPROXY",
-		"iptables -t mangle -N ISTIO_INBOUND",
-		"iptables -t nat -N ISTIO_OUTPUT",
-		"iptables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN",
-		"iptables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001",
-		"iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006",
-		"iptables -t mangle -A ISTIO_DIVERT -j MARK --set-mark 1337",
-		"iptables -t mangle -A ISTIO_DIVERT -j ACCEPT",
-		"iptables -t mangle -A ISTIO_TPROXY ! -d 127.0.0.1/32 -p tcp -j TPROXY --tproxy-mark 1337/0xffffffff --on-port 15006",
-		"iptables -t mangle -A PREROUTING -p tcp -j ISTIO_INBOUND",
-		"iptables -t mangle -A ISTIO_INBOUND -p tcp --dport 22 -j RETURN",
-		"iptables -t mangle -A ISTIO_INBOUND -p tcp -m conntrack --ctstate RELATED,ESTABLISHED -j ISTIO_DIVERT",
-		"iptables -t mangle -A ISTIO_INBOUND -p tcp -j ISTIO_TPROXY",
-		"iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT",
-		"iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN",
-		"iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -p tcp ! --dport 53 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT",
-		"iptables -t nat -A ISTIO_OUTPUT -o lo -p tcp ! --dport 53 -m owner ! --uid-owner 1337 -j RETURN",
-		"iptables -t nat -A ISTIO_OUTPUT -m owner --uid-owner 1337 -j RETURN",
-		"iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --gid-owner 1337 -j ISTIO_IN_REDIRECT",
-		"iptables -t nat -A ISTIO_OUTPUT -o lo -p tcp ! --dport 53 -m owner ! --gid-owner 1337 -j RETURN",
-		"iptables -t nat -A ISTIO_OUTPUT -m owner --gid-owner 1337 -j RETURN",
-		"iptables -t nat -A ISTIO_OUTPUT -p tcp --dport 53 -d 127.0.0.53/32 -j REDIRECT --to-ports 15053",
-		"iptables -t nat -A ISTIO_OUTPUT -d 127.0.0.1/32 -j RETURN",
-		"iptables -t nat -A ISTIO_OUTPUT -d 1.1.0.0/16 -j RETURN",
-		"iptables -t nat -A ISTIO_OUTPUT -d 9.9.0.0/16 -j ISTIO_REDIRECT",
-		"iptables -t nat -A ISTIO_OUTPUT -j RETURN",
-		"iptables -t nat -A OUTPUT -p udp --dport 53 -m owner --uid-owner 1337 -j RETURN",
-		"iptables -t nat -A OUTPUT -p udp --dport 53 -m owner --gid-owner 1337 -j RETURN",
-		"iptables -t nat -A OUTPUT -p udp --dport 53 -d 127.0.0.53/32 -j REDIRECT --to-port 15053",
-		"iptables -t mangle -A PREROUTING -p tcp -m mark --mark 1337 -j CONNMARK --save-mark",
-		"iptables -t mangle -A OUTPUT -p tcp -m connmark --mark 1337 -j CONNMARK --restore-mark",
-		"iptables -t mangle -I ISTIO_INBOUND 1 -p tcp -m mark --mark 1337 -j RETURN",
+		"iptables -w 10 -t nat -N ISTIO_INBOUND",
+		"iptables -w 10 -t nat -N ISTIO_REDIRECT",
+		"iptables -w 10 -t nat -N ISTIO_IN_REDIRECT",
+		"iptables -w 10 -t mangle -N ISTIO_DIVERT",
+		"iptables -w 10 -t mangle -N ISTIO_TPROXY",
+		"iptables -w 10 -t mangle -N ISTIO_INBOUND",
+		"iptables -w 10 -t nat -N ISTIO_OUTPUT",
+		"iptables -w 10 -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN",
+		"iptables -w 10 -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001",
+		"iptables -w 10 -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006",
+		"iptables -w 10 -t mangle -A ISTIO_DIVERT -j MARK --set-mark 1337",
+		"iptables -w 10 -t mangle -A ISTIO_DIVERT -j ACCEPT",
+		"iptables -w 10 -t mangle -A ISTIO_TPROXY ! -d 127.0.0.1/32 -p tcp -j TPROXY --tproxy-mark 1337/0xffffffff --on-port 15006",
+		"iptables -w 10 -t mangle -A PREROUTING -p tcp -j ISTIO_INBOUND",
+		"iptables -w 10 -t mangle -A ISTIO_INBOUND -p tcp --dport 22 -j RETURN",
+		"iptables -w 10 -t mangle -A ISTIO_INBOUND -p tcp -m conntrack --ctstate RELATED,ESTABLISHED -j ISTIO_DIVERT",
+		"iptables -w 10 -t mangle -A ISTIO_INBOUND -p tcp -j ISTIO_TPROXY",
+		"iptables -w 10 -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT",
+		"iptables -w 10 -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN",
+		"iptables -w 10 -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -p tcp ! --dport 53 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT",
+		"iptables -w 10 -t nat -A ISTIO_OUTPUT -o lo -p tcp ! --dport 53 -m owner ! --uid-owner 1337 -j RETURN",
+		"iptables -w 10 -t nat -A ISTIO_OUTPUT -m owner --uid-owner 1337 -j RETURN",
+		"iptables -w 10 -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --gid-owner 1337 -j ISTIO_IN_REDIRECT",
+		"iptables -w 10 -t nat -A ISTIO_OUTPUT -o lo -p tcp ! --dport 53 -m owner ! --gid-owner 1337 -j RETURN",
+		"iptables -w 10 -t nat -A ISTIO_OUTPUT -m owner --gid-owner 1337 -j RETURN",
+		"iptables -w 10 -t nat -A ISTIO_OUTPUT -p tcp --dport 53 -d 127.0.0.53/32 -j REDIRECT --to-ports 15053",
+		"iptables -w 10 -t nat -A ISTIO_OUTPUT -d 127.0.0.1/32 -j RETURN",
+		"iptables -w 10 -t nat -A ISTIO_OUTPUT -d 1.1.0.0/16 -j RETURN",
+		"iptables -w 10 -t nat -A ISTIO_OUTPUT -d 9.9.0.0/16 -j ISTIO_REDIRECT",
+		"iptables -w 10 -t nat -A ISTIO_OUTPUT -j RETURN",
+		"iptables -w 10 -t nat -A OUTPUT -p udp --dport 53 -m owner --uid-owner 1337 -j RETURN",
+		"iptables -w 10 -t nat -A OUTPUT -p udp --dport 53 -m owner --gid-owner 1337 -j RETURN",
+		"iptables -w 10 -t nat -A OUTPUT -p udp --dport 53 -d 127.0.0.53/32 -j REDIRECT --to-port 15053",
+		"iptables -w 10 -t mangle -A PREROUTING -p tcp -m mark --mark 1337 -j CONNMARK --save-mark",
+		"iptables -w 10 -t mangle -A OUTPUT -p tcp -m connmark --mark 1337 -j CONNMARK --restore-mark",
+		"iptables -w 10 -t mangle -I ISTIO_INBOUND 1 -p tcp -m mark --mark 1337 -j RETURN",
 	}
 
 	if !reflect.DeepEqual(actual, expected) {
@@ -237,25 +237,25 @@ func TestHandleInboundIpv6RulesWithInboundPorts(t *testing.T) {
 	iptConfigurator.handleInboundIpv6Rules(ipv6Range, ipv6Range)
 	actual := FormatIptablesCommands(iptConfigurator.iptables.BuildV6())
 	expected := []string{
-		"ip6tables -t nat -N ISTIO_INBOUND",
-		"ip6tables -t nat -N ISTIO_REDIRECT",
-		"ip6tables -t nat -N ISTIO_IN_REDIRECT",
-		"ip6tables -t nat -N ISTIO_OUTPUT",
-		"ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN",
-		"ip6tables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001",
-		"ip6tables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006",
-		"ip6tables -t nat -A PREROUTING -p tcp -j ISTIO_INBOUND",
-		"ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 4000 -j ISTIO_IN_REDIRECT",
-		"ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 5000 -j ISTIO_IN_REDIRECT",
-		"ip6tables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT",
-		"ip6tables -t nat -A ISTIO_OUTPUT -o lo -s ::6/128 -j RETURN",
-		"ip6tables -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT",
-		"ip6tables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 1337 -j RETURN",
-		"ip6tables -t nat -A ISTIO_OUTPUT -m owner --uid-owner 1337 -j RETURN",
-		"ip6tables -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -m owner --gid-owner 1337 -j ISTIO_IN_REDIRECT",
-		"ip6tables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --gid-owner 1337 -j RETURN",
-		"ip6tables -t nat -A ISTIO_OUTPUT -m owner --gid-owner 1337 -j RETURN",
-		"ip6tables -t nat -A ISTIO_OUTPUT -d ::1/128 -j RETURN",
+		"ip6tables -w 10 -t nat -N ISTIO_INBOUND",
+		"ip6tables -w 10 -t nat -N ISTIO_REDIRECT",
+		"ip6tables -w 10 -t nat -N ISTIO_IN_REDIRECT",
+		"ip6tables -w 10 -t nat -N ISTIO_OUTPUT",
+		"ip6tables -w 10 -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN",
+		"ip6tables -w 10 -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001",
+		"ip6tables -w 10 -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006",
+		"ip6tables -w 10 -t nat -A PREROUTING -p tcp -j ISTIO_INBOUND",
+		"ip6tables -w 10 -t nat -A ISTIO_INBOUND -p tcp --dport 4000 -j ISTIO_IN_REDIRECT",
+		"ip6tables -w 10 -t nat -A ISTIO_INBOUND -p tcp --dport 5000 -j ISTIO_IN_REDIRECT",
+		"ip6tables -w 10 -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT",
+		"ip6tables -w 10 -t nat -A ISTIO_OUTPUT -o lo -s ::6/128 -j RETURN",
+		"ip6tables -w 10 -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT",
+		"ip6tables -w 10 -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 1337 -j RETURN",
+		"ip6tables -w 10 -t nat -A ISTIO_OUTPUT -m owner --uid-owner 1337 -j RETURN",
+		"ip6tables -w 10 -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -m owner --gid-owner 1337 -j ISTIO_IN_REDIRECT",
+		"ip6tables -w 10 -t nat -A ISTIO_OUTPUT -o lo -m owner ! --gid-owner 1337 -j RETURN",
+		"ip6tables -w 10 -t nat -A ISTIO_OUTPUT -m owner --gid-owner 1337 -j RETURN",
+		"ip6tables -w 10 -t nat -A ISTIO_OUTPUT -d ::1/128 -j RETURN",
 	}
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("Output mismatch. Expected: %#v ; Actual: %#v", expected, actual)
@@ -276,28 +276,28 @@ func TestHandleInboundIpv6RulesWithWildcardRanges(t *testing.T) {
 	iptConfigurator.handleInboundIpv6Rules(ipv6Range, ipv6Range)
 	actual := FormatIptablesCommands(iptConfigurator.iptables.BuildV6())
 	expected := []string{
-		"ip6tables -t nat -N ISTIO_INBOUND",
-		"ip6tables -t nat -N ISTIO_REDIRECT",
-		"ip6tables -t nat -N ISTIO_IN_REDIRECT",
-		"ip6tables -t nat -N ISTIO_OUTPUT",
-		"ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN",
-		"ip6tables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001",
-		"ip6tables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006",
-		"ip6tables -t nat -A PREROUTING -p tcp -j ISTIO_INBOUND",
-		"ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 4000 -j ISTIO_IN_REDIRECT",
-		"ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 5000 -j ISTIO_IN_REDIRECT",
-		"ip6tables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT",
-		"ip6tables -t nat -A ISTIO_OUTPUT -o lo -s ::6/128 -j RETURN",
-		"ip6tables -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT",
-		"ip6tables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 1337 -j RETURN",
-		"ip6tables -t nat -A ISTIO_OUTPUT -m owner --uid-owner 1337 -j RETURN",
-		"ip6tables -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -m owner --gid-owner 1337 -j ISTIO_IN_REDIRECT",
-		"ip6tables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --gid-owner 1337 -j RETURN",
-		"ip6tables -t nat -A ISTIO_OUTPUT -m owner --gid-owner 1337 -j RETURN",
-		"ip6tables -t nat -A ISTIO_OUTPUT -d ::1/128 -j RETURN",
-		"ip6tables -t nat -A ISTIO_OUTPUT -j ISTIO_REDIRECT",
-		"ip6tables -t nat -I PREROUTING 1 -i eth0 -j RETURN",
-		"ip6tables -t nat -I PREROUTING 1 -i eth1 -j RETURN",
+		"ip6tables -w 10 -t nat -N ISTIO_INBOUND",
+		"ip6tables -w 10 -t nat -N ISTIO_REDIRECT",
+		"ip6tables -w 10 -t nat -N ISTIO_IN_REDIRECT",
+		"ip6tables -w 10 -t nat -N ISTIO_OUTPUT",
+		"ip6tables -w 10 -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN",
+		"ip6tables -w 10 -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001",
+		"ip6tables -w 10 -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006",
+		"ip6tables -w 10 -t nat -A PREROUTING -p tcp -j ISTIO_INBOUND",
+		"ip6tables -w 10 -t nat -A ISTIO_INBOUND -p tcp --dport 4000 -j ISTIO_IN_REDIRECT",
+		"ip6tables -w 10 -t nat -A ISTIO_INBOUND -p tcp --dport 5000 -j ISTIO_IN_REDIRECT",
+		"ip6tables -w 10 -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT",
+		"ip6tables -w 10 -t nat -A ISTIO_OUTPUT -o lo -s ::6/128 -j RETURN",
+		"ip6tables -w 10 -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT",
+		"ip6tables -w 10 -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 1337 -j RETURN",
+		"ip6tables -w 10 -t nat -A ISTIO_OUTPUT -m owner --uid-owner 1337 -j RETURN",
+		"ip6tables -w 10 -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -m owner --gid-owner 1337 -j ISTIO_IN_REDIRECT",
+		"ip6tables -w 10 -t nat -A ISTIO_OUTPUT -o lo -m owner ! --gid-owner 1337 -j RETURN",
+		"ip6tables -w 10 -t nat -A ISTIO_OUTPUT -m owner --gid-owner 1337 -j RETURN",
+		"ip6tables -w 10 -t nat -A ISTIO_OUTPUT -d ::1/128 -j RETURN",
+		"ip6tables -w 10 -t nat -A ISTIO_OUTPUT -j ISTIO_REDIRECT",
+		"ip6tables -w 10 -t nat -I PREROUTING 1 -i eth0 -j RETURN",
+		"ip6tables -w 10 -t nat -I PREROUTING 1 -i eth1 -j RETURN",
 	}
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("Output mismatch.\nExpected: %#v\nActual: %#v", expected, actual)
@@ -320,30 +320,30 @@ func TestHandleInboundIpv6RulesWithIpNets(t *testing.T) {
 	iptConfigurator.handleInboundIpv6Rules(ipv6Range, ipv6Range)
 	actual := FormatIptablesCommands(iptConfigurator.iptables.BuildV6())
 	expected := []string{
-		"ip6tables -t nat -N ISTIO_INBOUND",
-		"ip6tables -t nat -N ISTIO_REDIRECT",
-		"ip6tables -t nat -N ISTIO_IN_REDIRECT",
-		"ip6tables -t nat -N ISTIO_OUTPUT",
-		"ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN",
-		"ip6tables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001",
-		"ip6tables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006",
-		"ip6tables -t nat -A PREROUTING -p tcp -j ISTIO_INBOUND",
-		"ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 4000 -j ISTIO_IN_REDIRECT",
-		"ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 5000 -j ISTIO_IN_REDIRECT",
-		"ip6tables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT",
-		"ip6tables -t nat -A ISTIO_OUTPUT -o lo -s ::6/128 -j RETURN",
-		"ip6tables -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT",
-		"ip6tables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 1337 -j RETURN",
-		"ip6tables -t nat -A ISTIO_OUTPUT -m owner --uid-owner 1337 -j RETURN",
-		"ip6tables -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -m owner --gid-owner 1337 -j ISTIO_IN_REDIRECT",
-		"ip6tables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --gid-owner 1337 -j RETURN",
-		"ip6tables -t nat -A ISTIO_OUTPUT -m owner --gid-owner 1337 -j RETURN",
-		"ip6tables -t nat -A ISTIO_OUTPUT -d ::1/128 -j RETURN",
-		"ip6tables -t nat -A ISTIO_OUTPUT -d 10.0.0.0/8 -j RETURN",
-		"ip6tables -t nat -I PREROUTING 1 -i eth0 -d 10.0.0.0/8 -j ISTIO_REDIRECT",
-		"ip6tables -t nat -I PREROUTING 1 -i eth1 -d 10.0.0.0/8 -j ISTIO_REDIRECT",
-		"ip6tables -t nat -A ISTIO_OUTPUT -d 10.0.0.0/8 -j ISTIO_REDIRECT",
-		"ip6tables -t nat -A ISTIO_OUTPUT -j RETURN",
+		"ip6tables -w 10 -t nat -N ISTIO_INBOUND",
+		"ip6tables -w 10 -t nat -N ISTIO_REDIRECT",
+		"ip6tables -w 10 -t nat -N ISTIO_IN_REDIRECT",
+		"ip6tables -w 10 -t nat -N ISTIO_OUTPUT",
+		"ip6tables -w 10 -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN",
+		"ip6tables -w 10 -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001",
+		"ip6tables -w 10 -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006",
+		"ip6tables -w 10 -t nat -A PREROUTING -p tcp -j ISTIO_INBOUND",
+		"ip6tables -w 10 -t nat -A ISTIO_INBOUND -p tcp --dport 4000 -j ISTIO_IN_REDIRECT",
+		"ip6tables -w 10 -t nat -A ISTIO_INBOUND -p tcp --dport 5000 -j ISTIO_IN_REDIRECT",
+		"ip6tables -w 10 -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT",
+		"ip6tables -w 10 -t nat -A ISTIO_OUTPUT -o lo -s ::6/128 -j RETURN",
+		"ip6tables -w 10 -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT",
+		"ip6tables -w 10 -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 1337 -j RETURN",
+		"ip6tables -w 10 -t nat -A ISTIO_OUTPUT -m owner --uid-owner 1337 -j RETURN",
+		"ip6tables -w 10 -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -m owner --gid-owner 1337 -j ISTIO_IN_REDIRECT",
+		"ip6tables -w 10 -t nat -A ISTIO_OUTPUT -o lo -m owner ! --gid-owner 1337 -j RETURN",
+		"ip6tables -w 10 -t nat -A ISTIO_OUTPUT -m owner --gid-owner 1337 -j RETURN",
+		"ip6tables -w 10 -t nat -A ISTIO_OUTPUT -d ::1/128 -j RETURN",
+		"ip6tables -w 10 -t nat -A ISTIO_OUTPUT -d 10.0.0.0/8 -j RETURN",
+		"ip6tables -w 10 -t nat -I PREROUTING 1 -i eth0 -d 10.0.0.0/8 -j ISTIO_REDIRECT",
+		"ip6tables -w 10 -t nat -I PREROUTING 1 -i eth1 -d 10.0.0.0/8 -j ISTIO_REDIRECT",
+		"ip6tables -w 10 -t nat -A ISTIO_OUTPUT -d 10.0.0.0/8 -j ISTIO_REDIRECT",
+		"ip6tables -w 10 -t nat -A ISTIO_OUTPUT -j RETURN",
 	}
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("Output mismatch.\nExpected: %#v\nActual: %#v", expected, actual)
@@ -368,36 +368,36 @@ func TestHandleInboundIpv6RulesWithUidGid(t *testing.T) {
 	iptConfigurator.handleInboundIpv6Rules(ipv6Range, ipv6Range)
 	actual := FormatIptablesCommands(iptConfigurator.iptables.BuildV6())
 	expected := []string{
-		"ip6tables -t nat -N ISTIO_INBOUND",
-		"ip6tables -t nat -N ISTIO_REDIRECT",
-		"ip6tables -t nat -N ISTIO_IN_REDIRECT",
-		"ip6tables -t nat -N ISTIO_OUTPUT",
-		"ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN",
-		"ip6tables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001",
-		"ip6tables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006",
-		"ip6tables -t nat -A PREROUTING -p tcp -j ISTIO_INBOUND",
-		"ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 4000 -j ISTIO_IN_REDIRECT",
-		"ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 5000 -j ISTIO_IN_REDIRECT",
-		"ip6tables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT",
-		"ip6tables -t nat -A ISTIO_OUTPUT -o lo -s ::6/128 -j RETURN",
-		"ip6tables -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -m owner --uid-owner 3 -j ISTIO_IN_REDIRECT",
-		"ip6tables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 3 -j RETURN",
-		"ip6tables -t nat -A ISTIO_OUTPUT -m owner --uid-owner 3 -j RETURN",
-		"ip6tables -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -m owner --uid-owner 4 -j ISTIO_IN_REDIRECT",
-		"ip6tables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 4 -j RETURN",
-		"ip6tables -t nat -A ISTIO_OUTPUT -m owner --uid-owner 4 -j RETURN",
-		"ip6tables -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -m owner --gid-owner 1 -j ISTIO_IN_REDIRECT",
-		"ip6tables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --gid-owner 1 -j RETURN",
-		"ip6tables -t nat -A ISTIO_OUTPUT -m owner --gid-owner 1 -j RETURN",
-		"ip6tables -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -m owner --gid-owner 2 -j ISTIO_IN_REDIRECT",
-		"ip6tables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --gid-owner 2 -j RETURN",
-		"ip6tables -t nat -A ISTIO_OUTPUT -m owner --gid-owner 2 -j RETURN",
-		"ip6tables -t nat -A ISTIO_OUTPUT -d ::1/128 -j RETURN",
-		"ip6tables -t nat -A ISTIO_OUTPUT -d 10.0.0.0/8 -j RETURN",
-		"ip6tables -t nat -I PREROUTING 1 -i eth0 -d 10.0.0.0/8 -j ISTIO_REDIRECT",
-		"ip6tables -t nat -I PREROUTING 1 -i eth1 -d 10.0.0.0/8 -j ISTIO_REDIRECT",
-		"ip6tables -t nat -A ISTIO_OUTPUT -d 10.0.0.0/8 -j ISTIO_REDIRECT",
-		"ip6tables -t nat -A ISTIO_OUTPUT -j RETURN",
+		"ip6tables -w 10 -t nat -N ISTIO_INBOUND",
+		"ip6tables -w 10 -t nat -N ISTIO_REDIRECT",
+		"ip6tables -w 10 -t nat -N ISTIO_IN_REDIRECT",
+		"ip6tables -w 10 -t nat -N ISTIO_OUTPUT",
+		"ip6tables -w 10 -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN",
+		"ip6tables -w 10 -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001",
+		"ip6tables -w 10 -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006",
+		"ip6tables -w 10 -t nat -A PREROUTING -p tcp -j ISTIO_INBOUND",
+		"ip6tables -w 10 -t nat -A ISTIO_INBOUND -p tcp --dport 4000 -j ISTIO_IN_REDIRECT",
+		"ip6tables -w 10 -t nat -A ISTIO_INBOUND -p tcp --dport 5000 -j ISTIO_IN_REDIRECT",
+		"ip6tables -w 10 -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT",
+		"ip6tables -w 10 -t nat -A ISTIO_OUTPUT -o lo -s ::6/128 -j RETURN",
+		"ip6tables -w 10 -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -m owner --uid-owner 3 -j ISTIO_IN_REDIRECT",
+		"ip6tables -w 10 -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 3 -j RETURN",
+		"ip6tables -w 10 -t nat -A ISTIO_OUTPUT -m owner --uid-owner 3 -j RETURN",
+		"ip6tables -w 10 -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -m owner --uid-owner 4 -j ISTIO_IN_REDIRECT",
+		"ip6tables -w 10 -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 4 -j RETURN",
+		"ip6tables -w 10 -t nat -A ISTIO_OUTPUT -m owner --uid-owner 4 -j RETURN",
+		"ip6tables -w 10 -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -m owner --gid-owner 1 -j ISTIO_IN_REDIRECT",
+		"ip6tables -w 10 -t nat -A ISTIO_OUTPUT -o lo -m owner ! --gid-owner 1 -j RETURN",
+		"ip6tables -w 10 -t nat -A ISTIO_OUTPUT -m owner --gid-owner 1 -j RETURN",
+		"ip6tables -w 10 -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -m owner --gid-owner 2 -j ISTIO_IN_REDIRECT",
+		"ip6tables -w 10 -t nat -A ISTIO_OUTPUT -o lo -m owner ! --gid-owner 2 -j RETURN",
+		"ip6tables -w 10 -t nat -A ISTIO_OUTPUT -m owner --gid-owner 2 -j RETURN",
+		"ip6tables -w 10 -t nat -A ISTIO_OUTPUT -d ::1/128 -j RETURN",
+		"ip6tables -w 10 -t nat -A ISTIO_OUTPUT -d 10.0.0.0/8 -j RETURN",
+		"ip6tables -w 10 -t nat -I PREROUTING 1 -i eth0 -d 10.0.0.0/8 -j ISTIO_REDIRECT",
+		"ip6tables -w 10 -t nat -I PREROUTING 1 -i eth1 -d 10.0.0.0/8 -j ISTIO_REDIRECT",
+		"ip6tables -w 10 -t nat -A ISTIO_OUTPUT -d 10.0.0.0/8 -j ISTIO_REDIRECT",
+		"ip6tables -w 10 -t nat -A ISTIO_OUTPUT -j RETURN",
 	}
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("Output mismatch.\nExpected: %#v\nActual: %#v", expected, actual)
@@ -415,8 +415,8 @@ func TestHandleInboundIpv4RulesWithWildCard(t *testing.T) {
 	iptConfigurator.handleInboundIpv4Rules(ipv4Range)
 	actual := FormatIptablesCommands(iptConfigurator.iptables.BuildV4())
 	expected := []string{
-		"iptables -t nat -N ISTIO_OUTPUT",
-		"iptables -t nat -A ISTIO_OUTPUT -j ISTIO_REDIRECT",
+		"iptables -w 10 -t nat -N ISTIO_OUTPUT",
+		"iptables -w 10 -t nat -A ISTIO_OUTPUT -j ISTIO_REDIRECT",
 	}
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("Output mismatch.\nExpected: %#v\nActual: %#v", expected, actual)
@@ -435,10 +435,10 @@ func TestHandleInboundIpv4RulesWithWildcardWithKubeVirtInterfaces(t *testing.T) 
 	iptConfigurator.handleInboundIpv4Rules(ipv4Range)
 	actual := FormatIptablesCommands(iptConfigurator.iptables.BuildV4())
 	expected := []string{
-		"iptables -t nat -N ISTIO_OUTPUT",
-		"iptables -t nat -A ISTIO_OUTPUT -j ISTIO_REDIRECT",
-		"iptables -t nat -I PREROUTING 1 -i eth1 -j ISTIO_REDIRECT",
-		"iptables -t nat -I PREROUTING 1 -i eth2 -j ISTIO_REDIRECT",
+		"iptables -w 10 -t nat -N ISTIO_OUTPUT",
+		"iptables -w 10 -t nat -A ISTIO_OUTPUT -j ISTIO_REDIRECT",
+		"iptables -w 10 -t nat -I PREROUTING 1 -i eth1 -j ISTIO_REDIRECT",
+		"iptables -w 10 -t nat -I PREROUTING 1 -i eth2 -j ISTIO_REDIRECT",
 	}
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("Output mismatch.\nExpected: %#v\nActual: %#v", expected, actual)
@@ -457,9 +457,9 @@ func TestHandleInboundIpv4RulesWithIpNets(t *testing.T) {
 	iptConfigurator.handleInboundIpv4Rules(ipv4Range)
 	actual := FormatIptablesCommands(iptConfigurator.iptables.BuildV4())
 	expected := []string{
-		"iptables -t nat -N ISTIO_OUTPUT",
-		"iptables -t nat -A ISTIO_OUTPUT -d 10.0.0.0/8 -j ISTIO_REDIRECT",
-		"iptables -t nat -A ISTIO_OUTPUT -j RETURN",
+		"iptables -w 10 -t nat -N ISTIO_OUTPUT",
+		"iptables -w 10 -t nat -A ISTIO_OUTPUT -d 10.0.0.0/8 -j ISTIO_REDIRECT",
+		"iptables -w 10 -t nat -A ISTIO_OUTPUT -j RETURN",
 	}
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("Output mismatch.\nExpected: %#v\nActual: %#v", expected, actual)
@@ -479,11 +479,11 @@ func TestHandleInboundIpv4RulesWithIpNetsWithKubeVirtInterfaces(t *testing.T) {
 	iptConfigurator.handleInboundIpv4Rules(ipv4Range)
 	actual := FormatIptablesCommands(iptConfigurator.iptables.BuildV4())
 	expected := []string{
-		"iptables -t nat -N ISTIO_OUTPUT",
-		"iptables -t nat -I PREROUTING 1 -i eth1 -d 10.0.0.0/8 -j ISTIO_REDIRECT",
-		"iptables -t nat -I PREROUTING 1 -i eth2 -d 10.0.0.0/8 -j ISTIO_REDIRECT",
-		"iptables -t nat -A ISTIO_OUTPUT -d 10.0.0.0/8 -j ISTIO_REDIRECT",
-		"iptables -t nat -A ISTIO_OUTPUT -j RETURN",
+		"iptables -w 10 -t nat -N ISTIO_OUTPUT",
+		"iptables -w 10 -t nat -I PREROUTING 1 -i eth1 -d 10.0.0.0/8 -j ISTIO_REDIRECT",
+		"iptables -w 10 -t nat -I PREROUTING 1 -i eth2 -d 10.0.0.0/8 -j ISTIO_REDIRECT",
+		"iptables -w 10 -t nat -A ISTIO_OUTPUT -d 10.0.0.0/8 -j ISTIO_REDIRECT",
+		"iptables -w 10 -t nat -A ISTIO_OUTPUT -j RETURN",
 	}
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("Output mismatch.\nExpected: %#v\nActual: %#v", expected, actual)
@@ -581,10 +581,10 @@ func TestHandleInboundPortsIncludeWithInboundPorts(t *testing.T) {
 		t.Errorf("Expected ip6Rules to be empty; instead got %#v", ip6Rules)
 	}
 	expectedIpv4Rules := []string{
-		"iptables -t nat -N ISTIO_INBOUND",
-		"iptables -t nat -A PREROUTING -p tcp -j ISTIO_INBOUND",
-		"iptables -t nat -A ISTIO_INBOUND -p tcp --dport 32000 -j ISTIO_IN_REDIRECT",
-		"iptables -t nat -A ISTIO_INBOUND -p tcp --dport 31000 -j ISTIO_IN_REDIRECT",
+		"iptables -w 10 -t nat -N ISTIO_INBOUND",
+		"iptables -w 10 -t nat -A PREROUTING -p tcp -j ISTIO_INBOUND",
+		"iptables -w 10 -t nat -A ISTIO_INBOUND -p tcp --dport 32000 -j ISTIO_IN_REDIRECT",
+		"iptables -w 10 -t nat -A ISTIO_INBOUND -p tcp --dport 31000 -j ISTIO_IN_REDIRECT",
 	}
 	if !reflect.DeepEqual(ip4Rules, expectedIpv4Rules) {
 		t.Errorf("Output mismatch\nExpected: %#v\nActual: %#v", expectedIpv4Rules, ip4Rules)
@@ -604,10 +604,10 @@ func TestHandleInboundPortsIncludeWithWildcardInboundPorts(t *testing.T) {
 		t.Errorf("Expected ip6Rules to be empty; instead got %#v", ip6Rules)
 	}
 	expectedIpv4Rules := []string{
-		"iptables -t nat -N ISTIO_INBOUND",
-		"iptables -t nat -A PREROUTING -p tcp -j ISTIO_INBOUND",
-		"iptables -t nat -A ISTIO_INBOUND -p tcp --dport 22 -j RETURN",
-		"iptables -t nat -A ISTIO_INBOUND -p tcp -j ISTIO_IN_REDIRECT",
+		"iptables -w 10 -t nat -N ISTIO_INBOUND",
+		"iptables -w 10 -t nat -A PREROUTING -p tcp -j ISTIO_INBOUND",
+		"iptables -w 10 -t nat -A ISTIO_INBOUND -p tcp --dport 22 -j RETURN",
+		"iptables -w 10 -t nat -A ISTIO_INBOUND -p tcp -j ISTIO_IN_REDIRECT",
 	}
 	if !reflect.DeepEqual(ip4Rules, expectedIpv4Rules) {
 		t.Errorf("Output mismatch\nExpected: %#v\nActual: %#v", expectedIpv4Rules, ip4Rules)
@@ -628,17 +628,17 @@ func TestHandleInboundPortsIncludeWithInboundPortsAndTproxy(t *testing.T) {
 		t.Errorf("Expected ip6Rules to be empty; instead got %#v", ip6Rules)
 	}
 	expectedIpv4Rules := []string{
-		"iptables -t mangle -N ISTIO_DIVERT",
-		"iptables -t mangle -N ISTIO_TPROXY",
-		"iptables -t mangle -N ISTIO_INBOUND",
-		"iptables -t mangle -A ISTIO_DIVERT -j MARK --set-mark 1337",
-		"iptables -t mangle -A ISTIO_DIVERT -j ACCEPT",
-		"iptables -t mangle -A ISTIO_TPROXY ! -d 127.0.0.1/32 -p tcp -j TPROXY --tproxy-mark 1337/0xffffffff --on-port 15006",
-		"iptables -t mangle -A PREROUTING -p tcp -j ISTIO_INBOUND",
-		"iptables -t mangle -A ISTIO_INBOUND -p tcp --dport 32000 -m conntrack --ctstate RELATED,ESTABLISHED -j ISTIO_DIVERT",
-		"iptables -t mangle -A ISTIO_INBOUND -p tcp --dport 32000 -j ISTIO_TPROXY",
-		"iptables -t mangle -A ISTIO_INBOUND -p tcp --dport 31000 -m conntrack --ctstate RELATED,ESTABLISHED -j ISTIO_DIVERT",
-		"iptables -t mangle -A ISTIO_INBOUND -p tcp --dport 31000 -j ISTIO_TPROXY",
+		"iptables -w 10 -t mangle -N ISTIO_DIVERT",
+		"iptables -w 10 -t mangle -N ISTIO_TPROXY",
+		"iptables -w 10 -t mangle -N ISTIO_INBOUND",
+		"iptables -w 10 -t mangle -A ISTIO_DIVERT -j MARK --set-mark 1337",
+		"iptables -w 10 -t mangle -A ISTIO_DIVERT -j ACCEPT",
+		"iptables -w 10 -t mangle -A ISTIO_TPROXY ! -d 127.0.0.1/32 -p tcp -j TPROXY --tproxy-mark 1337/0xffffffff --on-port 15006",
+		"iptables -w 10 -t mangle -A PREROUTING -p tcp -j ISTIO_INBOUND",
+		"iptables -w 10 -t mangle -A ISTIO_INBOUND -p tcp --dport 32000 -m conntrack --ctstate RELATED,ESTABLISHED -j ISTIO_DIVERT",
+		"iptables -w 10 -t mangle -A ISTIO_INBOUND -p tcp --dport 32000 -j ISTIO_TPROXY",
+		"iptables -w 10 -t mangle -A ISTIO_INBOUND -p tcp --dport 31000 -m conntrack --ctstate RELATED,ESTABLISHED -j ISTIO_DIVERT",
+		"iptables -w 10 -t mangle -A ISTIO_INBOUND -p tcp --dport 31000 -j ISTIO_TPROXY",
 	}
 	if !reflect.DeepEqual(ip4Rules, expectedIpv4Rules) {
 		t.Errorf("Output mismatch\nExpected: %#v\nActual: %#v", expectedIpv4Rules, ip4Rules)
@@ -659,16 +659,16 @@ func TestHandleInboundPortsIncludeWithWildcardInboundPortsAndTproxy(t *testing.T
 		t.Errorf("Expected ip6Rules to be empty; instead got %#v", ip6Rules)
 	}
 	expectedIpv4Rules := []string{
-		"iptables -t mangle -N ISTIO_DIVERT",
-		"iptables -t mangle -N ISTIO_TPROXY",
-		"iptables -t mangle -N ISTIO_INBOUND",
-		"iptables -t mangle -A ISTIO_DIVERT -j MARK --set-mark 1337",
-		"iptables -t mangle -A ISTIO_DIVERT -j ACCEPT",
-		"iptables -t mangle -A ISTIO_TPROXY ! -d 127.0.0.1/32 -p tcp -j TPROXY --tproxy-mark 1337/0xffffffff --on-port 15006",
-		"iptables -t mangle -A PREROUTING -p tcp -j ISTIO_INBOUND",
-		"iptables -t mangle -A ISTIO_INBOUND -p tcp --dport 22 -j RETURN",
-		"iptables -t mangle -A ISTIO_INBOUND -p tcp -m conntrack --ctstate RELATED,ESTABLISHED -j ISTIO_DIVERT",
-		"iptables -t mangle -A ISTIO_INBOUND -p tcp -j ISTIO_TPROXY",
+		"iptables -w 10 -t mangle -N ISTIO_DIVERT",
+		"iptables -w 10 -t mangle -N ISTIO_TPROXY",
+		"iptables -w 10 -t mangle -N ISTIO_INBOUND",
+		"iptables -w 10 -t mangle -A ISTIO_DIVERT -j MARK --set-mark 1337",
+		"iptables -w 10 -t mangle -A ISTIO_DIVERT -j ACCEPT",
+		"iptables -w 10 -t mangle -A ISTIO_TPROXY ! -d 127.0.0.1/32 -p tcp -j TPROXY --tproxy-mark 1337/0xffffffff --on-port 15006",
+		"iptables -w 10 -t mangle -A PREROUTING -p tcp -j ISTIO_INBOUND",
+		"iptables -w 10 -t mangle -A ISTIO_INBOUND -p tcp --dport 22 -j RETURN",
+		"iptables -w 10 -t mangle -A ISTIO_INBOUND -p tcp -m conntrack --ctstate RELATED,ESTABLISHED -j ISTIO_DIVERT",
+		"iptables -w 10 -t mangle -A ISTIO_INBOUND -p tcp -j ISTIO_TPROXY",
 	}
 	if !reflect.DeepEqual(ip4Rules, expectedIpv4Rules) {
 		t.Errorf("Output mismatch\nExpected: %#v\nActual: %#v", expectedIpv4Rules, ip4Rules)
@@ -687,34 +687,34 @@ func TestHandleInboundIpv4RulesWithUidGid(t *testing.T) {
 	iptConfigurator.run()
 	actual := FormatIptablesCommands(iptConfigurator.iptables.BuildV4())
 	expected := []string{
-		"iptables -t nat -N ISTIO_INBOUND",
-		"iptables -t nat -N ISTIO_REDIRECT",
-		"iptables -t nat -N ISTIO_IN_REDIRECT",
-		"iptables -t nat -N ISTIO_OUTPUT",
-		"iptables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN",
-		"iptables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001",
-		"iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006",
-		"iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT",
-		"iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN",
-		"iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -p tcp ! --dport 53 -m owner --uid-owner 3 -j ISTIO_IN_REDIRECT",
-		"iptables -t nat -A ISTIO_OUTPUT -o lo -p tcp ! --dport 53 -m owner ! --uid-owner 3 -j RETURN",
-		"iptables -t nat -A ISTIO_OUTPUT -m owner --uid-owner 3 -j RETURN",
-		"iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -p tcp ! --dport 53 -m owner --uid-owner 4 -j ISTIO_IN_REDIRECT",
-		"iptables -t nat -A ISTIO_OUTPUT -o lo -p tcp ! --dport 53 -m owner ! --uid-owner 4 -j RETURN",
-		"iptables -t nat -A ISTIO_OUTPUT -m owner --uid-owner 4 -j RETURN",
-		"iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --gid-owner 1 -j ISTIO_IN_REDIRECT",
-		"iptables -t nat -A ISTIO_OUTPUT -o lo -p tcp ! --dport 53 -m owner ! --gid-owner 1 -j RETURN",
-		"iptables -t nat -A ISTIO_OUTPUT -m owner --gid-owner 1 -j RETURN",
-		"iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --gid-owner 2 -j ISTIO_IN_REDIRECT",
-		"iptables -t nat -A ISTIO_OUTPUT -o lo -p tcp ! --dport 53 -m owner ! --gid-owner 2 -j RETURN",
-		"iptables -t nat -A ISTIO_OUTPUT -m owner --gid-owner 2 -j RETURN",
-		"iptables -t nat -A ISTIO_OUTPUT -p tcp --dport 53 -d 127.0.0.53/32 -j REDIRECT --to-ports 15053",
-		"iptables -t nat -A ISTIO_OUTPUT -d 127.0.0.1/32 -j RETURN",
-		"iptables -t nat -A OUTPUT -p udp --dport 53 -m owner --uid-owner 3 -j RETURN",
-		"iptables -t nat -A OUTPUT -p udp --dport 53 -m owner --uid-owner 4 -j RETURN",
-		"iptables -t nat -A OUTPUT -p udp --dport 53 -m owner --gid-owner 1 -j RETURN",
-		"iptables -t nat -A OUTPUT -p udp --dport 53 -m owner --gid-owner 2 -j RETURN",
-		"iptables -t nat -A OUTPUT -p udp --dport 53 -d 127.0.0.53/32 -j REDIRECT --to-port 15053",
+		"iptables -w 10 -t nat -N ISTIO_INBOUND",
+		"iptables -w 10 -t nat -N ISTIO_REDIRECT",
+		"iptables -w 10 -t nat -N ISTIO_IN_REDIRECT",
+		"iptables -w 10 -t nat -N ISTIO_OUTPUT",
+		"iptables -w 10 -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN",
+		"iptables -w 10 -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001",
+		"iptables -w 10 -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006",
+		"iptables -w 10 -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT",
+		"iptables -w 10 -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN",
+		"iptables -w 10 -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -p tcp ! --dport 53 -m owner --uid-owner 3 -j ISTIO_IN_REDIRECT",
+		"iptables -w 10 -t nat -A ISTIO_OUTPUT -o lo -p tcp ! --dport 53 -m owner ! --uid-owner 3 -j RETURN",
+		"iptables -w 10 -t nat -A ISTIO_OUTPUT -m owner --uid-owner 3 -j RETURN",
+		"iptables -w 10 -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -p tcp ! --dport 53 -m owner --uid-owner 4 -j ISTIO_IN_REDIRECT",
+		"iptables -w 10 -t nat -A ISTIO_OUTPUT -o lo -p tcp ! --dport 53 -m owner ! --uid-owner 4 -j RETURN",
+		"iptables -w 10 -t nat -A ISTIO_OUTPUT -m owner --uid-owner 4 -j RETURN",
+		"iptables -w 10 -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --gid-owner 1 -j ISTIO_IN_REDIRECT",
+		"iptables -w 10 -t nat -A ISTIO_OUTPUT -o lo -p tcp ! --dport 53 -m owner ! --gid-owner 1 -j RETURN",
+		"iptables -w 10 -t nat -A ISTIO_OUTPUT -m owner --gid-owner 1 -j RETURN",
+		"iptables -w 10 -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --gid-owner 2 -j ISTIO_IN_REDIRECT",
+		"iptables -w 10 -t nat -A ISTIO_OUTPUT -o lo -p tcp ! --dport 53 -m owner ! --gid-owner 2 -j RETURN",
+		"iptables -w 10 -t nat -A ISTIO_OUTPUT -m owner --gid-owner 2 -j RETURN",
+		"iptables -w 10 -t nat -A ISTIO_OUTPUT -p tcp --dport 53 -d 127.0.0.53/32 -j REDIRECT --to-ports 15053",
+		"iptables -w 10 -t nat -A ISTIO_OUTPUT -d 127.0.0.1/32 -j RETURN",
+		"iptables -w 10 -t nat -A OUTPUT -p udp --dport 53 -m owner --uid-owner 3 -j RETURN",
+		"iptables -w 10 -t nat -A OUTPUT -p udp --dport 53 -m owner --uid-owner 4 -j RETURN",
+		"iptables -w 10 -t nat -A OUTPUT -p udp --dport 53 -m owner --gid-owner 1 -j RETURN",
+		"iptables -w 10 -t nat -A OUTPUT -p udp --dport 53 -m owner --gid-owner 2 -j RETURN",
+		"iptables -w 10 -t nat -A OUTPUT -p udp --dport 53 -d 127.0.0.53/32 -j REDIRECT --to-port 15053",
 	}
 
 	if !reflect.DeepEqual(actual, expected) {
@@ -751,9 +751,9 @@ func TestHandleOutboundPortsIncludeWithOutboundPorts(t *testing.T) {
 		t.Errorf("Expected ip6Rules to be empty; instead got %#v", ip6Rules)
 	}
 	expectedIpv4Rules := []string{
-		"iptables -t nat -N ISTIO_OUTPUT",
-		"iptables -t nat -A ISTIO_OUTPUT -p tcp --dport 32000 -j ISTIO_REDIRECT",
-		"iptables -t nat -A ISTIO_OUTPUT -p tcp --dport 31000 -j ISTIO_REDIRECT",
+		"iptables -w 10 -t nat -N ISTIO_OUTPUT",
+		"iptables -w 10 -t nat -A ISTIO_OUTPUT -p tcp --dport 32000 -j ISTIO_REDIRECT",
+		"iptables -w 10 -t nat -A ISTIO_OUTPUT -p tcp --dport 31000 -j ISTIO_REDIRECT",
 	}
 	if !reflect.DeepEqual(ip4Rules, expectedIpv4Rules) {
 		t.Errorf("Output mismatch\nExpected: %#v\nActual: %#v", expectedIpv4Rules, ip4Rules)
@@ -773,32 +773,32 @@ func TestRulesWithLoopbackIpInOutboundIpRanges(t *testing.T) {
 	iptConfigurator.run()
 	actual := FormatIptablesCommands(iptConfigurator.iptables.BuildV4())
 	expected := []string{
-		"iptables -t nat -N ISTIO_INBOUND",
-		"iptables -t nat -N ISTIO_REDIRECT",
-		"iptables -t nat -N ISTIO_IN_REDIRECT",
-		"iptables -t nat -N ISTIO_OUTPUT",
-		"iptables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN",
-		"iptables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001",
-		"iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006",
-		"iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT",
-		"iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN",
-		"iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -p tcp ! --dport 53 -m owner --uid-owner 3 -j ISTIO_IN_REDIRECT",
-		"iptables -t nat -A ISTIO_OUTPUT -m owner --uid-owner 3 -j RETURN",
-		"iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -p tcp ! --dport 53 -m owner --uid-owner 4 -j ISTIO_IN_REDIRECT",
-		"iptables -t nat -A ISTIO_OUTPUT -m owner --uid-owner 4 -j RETURN",
-		"iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --gid-owner 1 -j ISTIO_IN_REDIRECT",
-		"iptables -t nat -A ISTIO_OUTPUT -m owner --gid-owner 1 -j RETURN",
-		"iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --gid-owner 2 -j ISTIO_IN_REDIRECT",
-		"iptables -t nat -A ISTIO_OUTPUT -m owner --gid-owner 2 -j RETURN",
-		"iptables -t nat -A ISTIO_OUTPUT -p tcp --dport 53 -d 127.0.0.53/32 -j REDIRECT --to-ports 15053",
-		"iptables -t nat -A ISTIO_OUTPUT -d 127.0.0.1/32 -j RETURN",
-		"iptables -t nat -A ISTIO_OUTPUT -d 127.1.2.3/32 -j ISTIO_REDIRECT",
-		"iptables -t nat -A ISTIO_OUTPUT -j RETURN",
-		"iptables -t nat -A OUTPUT -p udp --dport 53 -m owner --uid-owner 3 -j RETURN",
-		"iptables -t nat -A OUTPUT -p udp --dport 53 -m owner --uid-owner 4 -j RETURN",
-		"iptables -t nat -A OUTPUT -p udp --dport 53 -m owner --gid-owner 1 -j RETURN",
-		"iptables -t nat -A OUTPUT -p udp --dport 53 -m owner --gid-owner 2 -j RETURN",
-		"iptables -t nat -A OUTPUT -p udp --dport 53 -d 127.0.0.53/32 -j REDIRECT --to-port 15053",
+		"iptables -w 10 -t nat -N ISTIO_INBOUND",
+		"iptables -w 10 -t nat -N ISTIO_REDIRECT",
+		"iptables -w 10 -t nat -N ISTIO_IN_REDIRECT",
+		"iptables -w 10 -t nat -N ISTIO_OUTPUT",
+		"iptables -w 10 -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN",
+		"iptables -w 10 -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001",
+		"iptables -w 10 -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006",
+		"iptables -w 10 -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT",
+		"iptables -w 10 -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN",
+		"iptables -w 10 -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -p tcp ! --dport 53 -m owner --uid-owner 3 -j ISTIO_IN_REDIRECT",
+		"iptables -w 10 -t nat -A ISTIO_OUTPUT -m owner --uid-owner 3 -j RETURN",
+		"iptables -w 10 -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -p tcp ! --dport 53 -m owner --uid-owner 4 -j ISTIO_IN_REDIRECT",
+		"iptables -w 10 -t nat -A ISTIO_OUTPUT -m owner --uid-owner 4 -j RETURN",
+		"iptables -w 10 -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --gid-owner 1 -j ISTIO_IN_REDIRECT",
+		"iptables -w 10 -t nat -A ISTIO_OUTPUT -m owner --gid-owner 1 -j RETURN",
+		"iptables -w 10 -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --gid-owner 2 -j ISTIO_IN_REDIRECT",
+		"iptables -w 10 -t nat -A ISTIO_OUTPUT -m owner --gid-owner 2 -j RETURN",
+		"iptables -w 10 -t nat -A ISTIO_OUTPUT -p tcp --dport 53 -d 127.0.0.53/32 -j REDIRECT --to-ports 15053",
+		"iptables -w 10 -t nat -A ISTIO_OUTPUT -d 127.0.0.1/32 -j RETURN",
+		"iptables -w 10 -t nat -A ISTIO_OUTPUT -d 127.1.2.3/32 -j ISTIO_REDIRECT",
+		"iptables -w 10 -t nat -A ISTIO_OUTPUT -j RETURN",
+		"iptables -w 10 -t nat -A OUTPUT -p udp --dport 53 -m owner --uid-owner 3 -j RETURN",
+		"iptables -w 10 -t nat -A OUTPUT -p udp --dport 53 -m owner --uid-owner 4 -j RETURN",
+		"iptables -w 10 -t nat -A OUTPUT -p udp --dport 53 -m owner --gid-owner 1 -j RETURN",
+		"iptables -w 10 -t nat -A OUTPUT -p udp --dport 53 -m owner --gid-owner 2 -j RETURN",
+		"iptables -w 10 -t nat -A OUTPUT -p udp --dport 53 -d 127.0.0.53/32 -j REDIRECT --to-port 15053",
 	}
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("Output mismatch. Expected: \n%#v ; Actual: \n%#v", expected, actual)

--- a/tools/istio-iptables/pkg/constants/constants.go
+++ b/tools/istio-iptables/pkg/constants/constants.go
@@ -131,3 +131,8 @@ const (
 const (
 	IstioAgentDNSListenerPort = "15053"
 )
+
+const (
+	// argument to pass to iptables --wait
+	IptablesWaitSecondsArg = "10"
+)


### PR DESCRIPTION
By default, the iptables command fails if the xtables lock is held
by another process. Using the -w flag allows iptables to wait for
the lock to be released.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
