### PR TITLE
Fix TestEDS flake

### DIFF
--- a/pilot/pkg/xds/eds_test.go
+++ b/pilot/pkg/xds/eds_test.go
@@ -27,11 +27,11 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
 	endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+	uatomic "go.uber.org/atomic"
 
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking"
@@ -117,19 +117,23 @@ func TestIncrementalPush(t *testing.T) {
 }
 
 func TestEds(t *testing.T) {
-	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{ConfigString: mustReadFile(t, "tests/testdata/config/destination-rule-locality.yaml")})
-	addUdsEndpoint(s)
+	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{
+		ConfigString: mustReadFile(t, "tests/testdata/config/destination-rule-locality.yaml"),
+		DiscoveryServerModifier: func(s *xds.DiscoveryServer) {
+			addUdsEndpoint(s)
 
-	// enable locality load balancing and add relevant endpoints in order to test
-	addLocalityEndpoints(s, "locality.cluster.local")
-	addLocalityEndpoints(s, "locality-no-outlier-detection.cluster.local")
+			// enable locality load balancing and add relevant endpoints in order to test
+			addLocalityEndpoints(s, "locality.cluster.local")
+			addLocalityEndpoints(s, "locality-no-outlier-detection.cluster.local")
 
-	// Add the test ads clients to list of service instances in order to test the context dependent locality coloring.
-	addTestClientEndpoints(s)
+			// Add the test ads clients to list of service instances in order to test the context dependent locality coloring.
+			addTestClientEndpoints(s)
 
-	s.Discovery.MemRegistry.AddHTTPService(edsIncSvc, edsIncVip, 8080)
-	s.Discovery.MemRegistry.SetEndpoints(edsIncSvc, "",
-		newEndpointWithAccount("127.0.0.1", "hello-sa", "v1"))
+			s.MemRegistry.AddHTTPService(edsIncSvc, edsIncVip, 8080)
+			s.MemRegistry.SetEndpoints(edsIncSvc, "",
+				newEndpointWithAccount("127.0.0.1", "hello-sa", "v1"))
+		},
+	})
 
 	adscConn := s.Connect(&model.Proxy{IPAddresses: []string{"10.10.10.10"}}, nil, watchAll)
 	adscConn2 := s.Connect(&model.Proxy{IPAddresses: []string{"10.10.10.11"}}, nil, watchAll)
@@ -153,11 +157,11 @@ func TestEds(t *testing.T) {
 		edsUpdates(s, adscConn, t)
 	})
 	t.Run("MultipleRequest", func(t *testing.T) {
-		multipleRequest(s, false, 20, 5, 5*time.Second, nil, t)
+		multipleRequest(s, false, 20, 5, 25*time.Second, nil, t)
 	})
 	// 5 pushes for 100 clients, using EDS incremental only.
 	t.Run("MultipleRequestIncremental", func(t *testing.T) {
-		multipleRequest(s, true, 20, 5, 5*time.Second, nil, t)
+		multipleRequest(s, true, 20, 5, 25*time.Second, nil, t)
 	})
 	t.Run("CDSSave", func(t *testing.T) {
 		// Moved from cds_test, using new client
@@ -224,7 +228,7 @@ func TestNoTunnelServerEndpointEds(t *testing.T) {
 	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
 
 	// Add the test ads clients to list of service instances in order to test the context dependent locality coloring.
-	addTestClientEndpoints(s)
+	addTestClientEndpoints(s.Discovery)
 
 	s.Discovery.MemRegistry.AddHTTPService(edsIncSvc, edsIncVip, 8080)
 	s.Discovery.MemRegistry.SetEndpoints(edsIncSvc, "",
@@ -433,8 +437,8 @@ func fullPush(s *xds.FakeDiscoveryServer) {
 	s.Discovery.Push(&model.PushRequest{Full: true})
 }
 
-func addTestClientEndpoints(server *xds.FakeDiscoveryServer) {
-	server.Discovery.MemRegistry.AddService("test-1.default", &model.Service{
+func addTestClientEndpoints(server *xds.DiscoveryServer) {
+	server.MemRegistry.AddService("test-1.default", &model.Service{
 		Hostname: "test-1.default",
 		Ports: model.PortList{
 			{
@@ -444,7 +448,7 @@ func addTestClientEndpoints(server *xds.FakeDiscoveryServer) {
 			},
 		},
 	})
-	server.Discovery.MemRegistry.AddInstance("test-1.default", &model.ServiceInstance{
+	server.MemRegistry.AddInstance("test-1.default", &model.ServiceInstance{
 		Endpoint: &model.IstioEndpoint{
 			Address:         "10.10.10.10",
 			ServicePortName: "http",
@@ -457,7 +461,7 @@ func addTestClientEndpoints(server *xds.FakeDiscoveryServer) {
 			Protocol: protocol.HTTP,
 		},
 	})
-	server.Discovery.MemRegistry.AddInstance("test-1.default", &model.ServiceInstance{
+	server.MemRegistry.AddInstance("test-1.default", &model.ServiceInstance{
 		Endpoint: &model.IstioEndpoint{
 			Address:         "10.10.10.11",
 			ServicePortName: "http",
@@ -654,11 +658,11 @@ func edsUpdateInc(s *xds.FakeDiscoveryServer, adsc *adsc.ADSC, t *testing.T) {
 	s.Discovery.MemRegistry.SetEndpoints(edsIncSvc, "",
 		newEndpointWithAccount("127.0.0.2", "hello-sa", "v1"))
 
-	upd, err := adsc.Wait(5 * time.Second)
+	upd, err := adsc.Wait(5*time.Second, v3.EndpointType)
 	if err != nil {
 		t.Fatal("Incremental push failed", err)
 	}
-	if !reflect.DeepEqual(upd, []string{v3.EndpointType}) {
+	if contains(upd, v3.ClusterType) {
 		t.Fatal("Expecting EDS only update, got", upd)
 	}
 
@@ -734,8 +738,8 @@ func multipleRequest(s *xds.FakeDiscoveryServer, inc bool, nclients,
 	n := nclients
 	wg.Add(n)
 	wgConnect.Add(n)
-	rcvPush := int32(0)
-	rcvClients := int32(0)
+	rcvPush := uatomic.NewInt32(0)
+	rcvClients := uatomic.NewInt32(0)
 	for i := 0; i < n; i++ {
 		current := i
 		go func(id int) {
@@ -774,7 +778,7 @@ func multipleRequest(s *xds.FakeDiscoveryServer, inc bool, nclients,
 				}
 			}
 
-			atomic.AddInt32(&rcvPush, 1)
+			rcvPush.Inc()
 			if err != nil {
 				log.Println("Recv failed", err, id)
 				errChan <- fmt.Errorf("failed to receive a response in 15 s %v %v",
@@ -783,7 +787,7 @@ func multipleRequest(s *xds.FakeDiscoveryServer, inc bool, nclients,
 			}
 
 			log.Println("Received all pushes ", id)
-			atomic.AddInt32(&rcvClients, 1)
+			rcvClients.Inc()
 
 			adscConn.Close()
 		}(current)
@@ -814,7 +818,7 @@ func multipleRequest(s *xds.FakeDiscoveryServer, inc bool, nclients,
 
 	ok = waitTimeout(wg, to)
 	if !ok {
-		t.Errorf("Failed to receive all responses %d %d", rcvClients, rcvPush)
+		t.Errorf("Failed to receive all responses %d %d", rcvClients.Load(), rcvPush.Load())
 		buf := make([]byte, 1<<16)
 		runtime.Stack(buf, true)
 		fmt.Printf("%s", buf)
@@ -844,8 +848,8 @@ func waitTimeout(wg *sync.WaitGroup, timeout time.Duration) bool {
 
 const udsPath = "/var/run/test/socket"
 
-func addUdsEndpoint(s *xds.FakeDiscoveryServer) {
-	s.Discovery.MemRegistry.AddService("localuds.cluster.local", &model.Service{
+func addUdsEndpoint(s *xds.DiscoveryServer) {
+	s.MemRegistry.AddService("localuds.cluster.local", &model.Service{
 		Hostname: "localuds.cluster.local",
 		Ports: model.PortList{
 			{
@@ -857,7 +861,7 @@ func addUdsEndpoint(s *xds.FakeDiscoveryServer) {
 		MeshExternal: true,
 		Resolution:   model.ClientSideLB,
 	})
-	s.Discovery.MemRegistry.AddInstance("localuds.cluster.local", &model.ServiceInstance{
+	s.MemRegistry.AddInstance("localuds.cluster.local", &model.ServiceInstance{
 		Endpoint: &model.IstioEndpoint{
 			Address:         udsPath,
 			EndpointPort:    0,
@@ -876,11 +880,11 @@ func addUdsEndpoint(s *xds.FakeDiscoveryServer) {
 		Full:   true,
 		Reason: []model.TriggerReason{model.ConfigUpdate},
 	}
-	s.Discovery.ConfigUpdate(pushReq)
+	s.ConfigUpdate(pushReq)
 }
 
-func addLocalityEndpoints(server *xds.FakeDiscoveryServer, hostname host.Name) {
-	server.Discovery.MemRegistry.AddService(hostname, &model.Service{
+func addLocalityEndpoints(server *xds.DiscoveryServer, hostname host.Name) {
+	server.MemRegistry.AddService(hostname, &model.Service{
 		Hostname: hostname,
 		Ports: model.PortList{
 			{
@@ -900,7 +904,7 @@ func addLocalityEndpoints(server *xds.FakeDiscoveryServer, hostname host.Name) {
 		"region2/zone2/subzone2",
 	}
 	for i, locality := range localities {
-		server.Discovery.MemRegistry.AddInstance(hostname, &model.ServiceInstance{
+		server.MemRegistry.AddInstance(hostname, &model.ServiceInstance{
 			Endpoint: &model.IstioEndpoint{
 				Address:         fmt.Sprintf("10.0.0.%v", i),
 				EndpointPort:    80,

--- a/pilot/pkg/xds/fake.go
+++ b/pilot/pkg/xds/fake.go
@@ -76,6 +76,9 @@ type FakeOptions struct {
 	MeshConfig      *meshconfig.MeshConfig
 	NetworksWatcher mesh.NetworksWatcher
 
+	// Callback to modify the server before it is started
+	DiscoveryServerModifier func(s *DiscoveryServer)
+
 	// Time to debounce
 	// By default, set to 0s to speed up tests
 	DebounceTime time.Duration
@@ -226,6 +229,10 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 		k8s.AppendWorkloadHandler(cg.ServiceEntryRegistry.WorkloadInstanceHandler)
 	}
 	s.WorkloadEntryController = workloadentry.NewController(cg.Store(), "test", keepalive.Infinity)
+
+	if opts.DiscoveryServerModifier != nil {
+		opts.DiscoveryServerModifier(s)
+	}
 
 	// Start in memory gRPC listener
 	buffer := 1024 * 1024


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/30364

The bug is in the test code - we create a new service, but we do not
wait for it to be propogated. Instead of adding retry loop, just make
sure the service is created before we start the test



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.