### PR TITLE
renaming validating webhook similar to mutating webhook

### DIFF
--- a/manifests/charts/base/templates/validatingwebhookconfiguration.yaml
+++ b/manifests/charts/base/templates/validatingwebhookconfiguration.yaml
@@ -2,7 +2,11 @@
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: istiod-{{ .Values.global.istioNamespace }}
+{{- if eq .Release.Namespace "istio-system"}}
+  name: istio-sidecar-injector{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
+{{- else }}
+  name: istio-sidecar-injector{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}-{{ .Release.Namespace }}
+{{- end }}
   labels:
     app: istiod
     release: {{ .Release.Name }}


### PR DESCRIPTION
Description

validating webhook name is not following naming convention like mutating webhook

* https://github.com/istio/istio/blob/master/manifests/charts/istiod-remote/templates/mutatingwebhook.yaml 
* https://github.com/istio/istio/blob/47e9ea2c94ccb6c7137bf7e1df644f9e4b7f60f3/manifests/charts/istio-control/istio-discovery/templates/mutatingwebhook.yaml


[ ] Configuration Infrastructure
[ ] Docs
[ X ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.