### PR TITLE
Align revision tags with injection changes

### DIFF
--- a/istioctl/cmd/tag.go
+++ b/istioctl/cmd/tag.go
@@ -37,6 +37,7 @@ const (
 	// TODO(Monkeyanator) move into istio/api
 	istioTagLabel               = "istio.io/tag"
 	istioInjectionWebhookSuffix = "sidecar-injector.istio.io"
+	defaultRevisionName         = "default"
 	pilotDiscoveryChart         = "istio-control/istio-discovery"
 	chartsPath                  = "" // use compiled in charts for tag webhook gen
 	revisionTagTemplateName     = "revision-tags.yaml"
@@ -402,6 +403,11 @@ func tagWebhookConfigFromCanonicalWebhook(wh admit_v1.MutatingWebhookConfigurati
 	if err != nil {
 		return nil, err
 	}
+	// if the revision is "default", render templates with an empty revision
+	if rev == defaultRevisionName {
+		rev = ""
+	}
+
 	var injectionURL string
 	found := false
 	for _, w := range wh.Webhooks {
@@ -438,7 +444,7 @@ func tagWebhookYAML(config *tagWebhookConfig, chartPath string) (string, error) 
 	}
 
 	values := fmt.Sprintf(`
-revision: %s
+revision: %q
 revisionTags:
   - %s
 

--- a/istioctl/cmd/tag.go
+++ b/istioctl/cmd/tag.go
@@ -35,11 +35,11 @@ import (
 
 const (
 	// TODO(Monkeyanator) move into istio/api
-	istioTagLabel             = "istio.io/tag"
-	istioInjectionWebhookName = "sidecar-injector.istio.io"
-	pilotDiscoveryChart       = "istio-control/istio-discovery"
-	chartsPath                = "" // use compiled in charts for tag webhook gen
-	revisionTagTemplateName   = "revision-tags.yaml"
+	istioTagLabel               = "istio.io/tag"
+	istioInjectionWebhookSuffix = "sidecar-injector.istio.io"
+	pilotDiscoveryChart         = "istio-control/istio-discovery"
+	chartsPath                  = "" // use compiled in charts for tag webhook gen
+	revisionTagTemplateName     = "revision-tags.yaml"
 
 	// help strings and long formatted user outputs
 	skipConfirmationFlagHelpStr = `The skipConfirmation determines whether the user is prompted for confirmation.
@@ -405,13 +405,14 @@ func tagWebhookConfigFromCanonicalWebhook(wh admit_v1.MutatingWebhookConfigurati
 	var injectionURL string
 	found := false
 	for _, w := range wh.Webhooks {
-		if w.Name == istioInjectionWebhookName {
+		if strings.HasSuffix(w.Name, istioInjectionWebhookSuffix) {
 			found = true
 			if w.ClientConfig.URL != nil {
 				injectionURL = *w.ClientConfig.URL
 			} else {
 				injectionURL = ""
 			}
+			break
 		}
 	}
 	if !found {

--- a/istioctl/cmd/tag_test.go
+++ b/istioctl/cmd/tag_test.go
@@ -36,6 +36,32 @@ import (
 )
 
 var (
+	defaultRevisionCanonicalWebhook = admit_v1.MutatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "istio-sidecar-injector",
+			Labels: map[string]string{label.IoIstioRev.Name: "default"},
+		},
+		Webhooks: []admit_v1.MutatingWebhook{
+			{
+				Name: fmt.Sprintf("namespace.%s", istioInjectionWebhookSuffix),
+				ClientConfig: admit_v1.WebhookClientConfig{
+					Service: &admit_v1.ServiceReference{
+						Namespace: "default",
+						Name:      "istiod",
+					},
+				},
+			},
+			{
+				Name: fmt.Sprintf("object.%s", istioInjectionWebhookSuffix),
+				ClientConfig: admit_v1.WebhookClientConfig{
+					Service: &admit_v1.ServiceReference{
+						Namespace: "default",
+						Name:      "istiod",
+					},
+				},
+			},
+		},
+	}
 	revisionCanonicalWebhook = admit_v1.MutatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "istio-sidecar-injector-revision",
@@ -393,6 +419,13 @@ func TestSetTagWebhookCreation(t *testing.T) {
 			tagName: "canary",
 			whURL:   remoteInjectionURL,
 			whSVC:   "",
+		},
+		{
+			name:    "webhook-pointing-to-default-revision",
+			webhook: defaultRevisionCanonicalWebhook,
+			tagName: "canary",
+			whURL:   "",
+			whSVC:   "istiod",
 		},
 	}
 	scheme := runtime.NewScheme()

--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -915,6 +915,11 @@ spec:
       name: cpu
       targetAverageUtilization: 80
 ---
+# Source: istio-discovery/templates/revision-tags.yaml
+# Adapted from istio-discovery/templates/mutatingwebhook.yaml
+# Removed paths for legacy and default selectors since a revision tag
+# is inherently created from a specific revision
+---
 # Source: istio-discovery/templates/telemetryv2_1.10.yaml
 # Note: metadata exchange filter is wasm enabled only in sidecars.
 apiVersion: networking.istio.io/v1alpha3

--- a/manifests/charts/istio-control/istio-discovery/templates/revision-tags.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/revision-tags.yaml
@@ -46,7 +46,7 @@ webhooks:
     - key: istio.io/rev
       operator: In
       values:
-      - "{{ $.Values.tagName }}"
+      - "{{ $tagName }}"
     - key: istio-injection
       operator: DoesNotExist
   objectSelector:
@@ -71,5 +71,5 @@ webhooks:
     - key: istio.io/rev
       operator: In
       values:
-      - "{{ $.Values.tagName }}"
+      - "{{ $tagName }}"
 {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/templates/revision-tags.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/revision-tags.yaml
@@ -1,63 +1,75 @@
+# Adapted from istio-discovery/templates/mutatingwebhook.yaml
+# Removed paths for legacy and default selectors since a revision tag
+# is inherently created from a specific revision
+{{- define "core" }}
+- name: {{.Prefix}}sidecar-injector.istio.io
+  clientConfig:
+    {{- if .Values.istiodRemote.injectionURL }}
+    url: {{ .Values.istiodRemote.injectionURL }}
+    {{- else }}
+    service:
+      name: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
+      namespace: {{ .Release.Namespace }}
+      path: "/inject"
+    {{- end }}
+    caBundle: ""
+  sideEffects: None
+  rules:
+    - operations: [ "CREATE" ]
+      apiGroups: [""]
+      apiVersions: ["v1"]
+      resources: ["pods"]
+  failurePolicy: Fail
+  admissionReviewVersions: ["v1beta1", "v1"]
+{{- end }}
+
 {{- range $tagName := $.Values.revisionTags }}
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
 {{- if eq $.Release.Namespace "istio-system"}}
   name: istio-revision-tag-{{ $tagName }}
-{{ else }}
+{{- else }}
   name: istio-revision-tag-{{ $tagName }}-{{ $.Release.Namespace }}
 {{- end }}
   labels:
-    istio.io/rev: {{ $.Values.revision | default "default" }}
     istio.io/tag: {{ $tagName }}
+    istio.io/rev: {{ $.Values.revision | default "default" }}
     install.operator.istio.io/owning-resource: {{ $.Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: sidecar-injector
     release: {{ $.Release.Name }}
 webhooks:
-  - name: sidecar-injector.istio.io
-    clientConfig:
-      {{- if $.Values.istiodRemote.injectionURL }}
-      url: {{ $.Values.istiodRemote.injectionURL }}
-      {{- else }}
-      service:
-        name: istiod{{- if not (eq $.Values.revision "") }}-{{ $.Values.revision }}{{- end }}
-        namespace: {{ $.Release.Namespace }}
-        path: "/inject"
-      {{- end }}
-      caBundle: ""
-    sideEffects: None
-    rules:
-      - operations: [ "CREATE" ]
-        apiGroups: [""]
-        apiVersions: ["v1"]
-        resources: ["pods"]
-    failurePolicy: Fail
-    admissionReviewVersions: ["v1beta1", "v1"]
-    namespaceSelector:
-      matchExpressions:
-      - key: istio-injection
-        operator: DoesNotExist
-      - key: istio.io/rev
-        operator: In
-        values:
-        - {{ $tagName }}
-{{- if $.Values.sidecarInjectorWebhook.objectSelector.enabled }}
-    objectSelector:
-{{- if $.Values.sidecarInjectorWebhook.objectSelector.autoInject }}
-      matchExpressions:
-      - key: "sidecar.istio.io/inject"
-        operator: NotIn
-        values:
-        - "false"
-{{- else }}
-      matchExpressions:
-      - key: "sidecar.istio.io/inject"
-        operator: DoesNotExist
-      - key: istio.io/rev
-        operator: In
-        values:
-        - {{ $tagName }}
-{{- end }}
-{{- end }}
+{{- include "core" (mergeOverwrite (deepCopy $) (dict "Prefix" "namespace.") ) }}
+  namespaceSelector:
+    matchExpressions:
+    - key: istio.io/rev
+      operator: In
+      values:
+      - "{{ $.Values.tagName }}"
+    - key: istio-injection
+      operator: DoesNotExist
+  objectSelector:
+    matchExpressions:
+    - key: sidecar.istio.io/inject
+      operator: NotIn
+      values:
+      - "false"
+{{- include "core" (mergeOverwrite (deepCopy $) (dict "Prefix" "object.") ) }}
+  namespaceSelector:
+    matchExpressions:
+    - key: istio.io/rev
+      operator: DoesNotExist
+    - key: istio-injection
+      operator: DoesNotExist
+  objectSelector:
+    matchExpressions:
+    - key: sidecar.istio.io/inject
+      operator: NotIn
+      values:
+      - "false"
+    - key: istio.io/rev
+      operator: In
+      values:
+      - "{{ $.Values.tagName }}"
 {{- end }}


### PR DESCRIPTION
Fixes #30392. Puts the revision tag template in line with the recent changes to injection behavior from #30013. Also fixes bug that prevented users from pointing a revision tag at the `default` revision

[ ] Configuration Infrastructure
[ ] Docs
[x] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any changes that may affect Istio users.
