### PR TITLE
Add tests for getting tokens for XDS

### DIFF
--- a/pilot/cmd/pilot-agent/config/config.go
+++ b/pilot/cmd/pilot-agent/config/config.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package config
 
 import (
 	"fmt"
@@ -36,7 +36,7 @@ import (
 )
 
 // return proxyConfig and trustDomain
-func constructProxyConfig(role *model.Proxy) (meshconfig.ProxyConfig, error) {
+func ConstructProxyConfig(meshConfigFile, serviceCluster, proxyConfigEnv string, concurrency int, role *model.Proxy) (meshconfig.ProxyConfig, error) {
 	annotations, err := readPodAnnotations()
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -53,7 +53,7 @@ func constructProxyConfig(role *model.Proxy) (meshconfig.ProxyConfig, error) {
 		}
 		fileMeshContents = string(contents)
 	}
-	meshConfig, err := getMeshConfig(fileMeshContents, annotations[annotation.ProxyConfig.Name])
+	meshConfig, err := getMeshConfig(fileMeshContents, annotations[annotation.ProxyConfig.Name], proxyConfigEnv)
 	if err != nil {
 		return meshconfig.ProxyConfig{}, err
 	}
@@ -117,7 +117,7 @@ func determineConcurrencyOption() *types.Int32Value {
 //
 // Merging is done by replacement. Any fields present in the overlay will replace those existing fields, while
 // untouched fields will remain untouched. This means lists will be replaced, not appended to, for example.
-func getMeshConfig(fileOverride, annotationOverride string) (meshconfig.MeshConfig, error) {
+func getMeshConfig(fileOverride, annotationOverride, proxyConfigEnv string) (meshconfig.MeshConfig, error) {
 	mc := mesh.DefaultMeshConfig()
 
 	if fileOverride != "" {
@@ -196,7 +196,7 @@ func applyAnnotations(config meshconfig.ProxyConfig, annos map[string]string) me
 	return config
 }
 
-func getPilotSan(discoveryAddress string) string {
+func GetPilotSan(discoveryAddress string) string {
 	discHost := strings.Split(discoveryAddress, ":")[0]
 	// For local debugging - the discoveryAddress is set to localhost, but the cert issued for normal SA.
 	if discHost == "localhost" {

--- a/pilot/cmd/pilot-agent/config/config_test.go
+++ b/pilot/cmd/pilot-agent/config/config_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package config
 
 import (
 	"reflect"
@@ -121,8 +121,8 @@ proxyStatsMatcher:
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			proxyConfigEnv = tt.environment
-			got, err := getMeshConfig(tt.file, tt.annotation)
+			proxyConfigEnv := tt.environment
+			got, err := getMeshConfig(tt.file, tt.annotation, proxyConfigEnv)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -218,10 +218,27 @@ var (
 			// K8S
 			role.DNSDomain = getDNSDomain(podNamespace, role.DNSDomain)
 			log.WithLabels("ips", role.IPAddresses, "type", role.Type, "id", role.ID, "domain", role.DNSDomain).Info("Proxy role")
-			secOpts, err := secopt.SetupSecurityOptions(proxyConfig, jwtPolicy.Get(), clusterIDVar.Get(),
-				podNamespaceVar.Get(), serviceAccountVar.Get(), caEndpointEnv, caProviderEnv, pilotCertProvider,
-				outputKeyCertToDir, provCert, trustDomainEnv, eccSigAlgEnv, credFetcherTypeEnv, credIdentityProvider,
-				xdsAuthProvider.Get(), fileMountedCertsEnv, pkcs8KeysEnv, secretTTLEnv, secretRotationGracePeriodRatioEnv)
+
+			sop := security.Options{
+				CAEndpoint:                     caEndpointEnv,
+				CAProviderName:                 caProviderEnv,
+				PilotCertProvider:              pilotCertProvider,
+				OutputKeyCertToDir:             outputKeyCertToDir,
+				ProvCert:                       provCert,
+				WorkloadUDSPath:                security.DefaultLocalSDSPath,
+				ClusterID:                      clusterIDVar.Get(),
+				FileMountedCerts:               fileMountedCertsEnv,
+				WorkloadNamespace:              podNamespaceVar.Get(),
+				ServiceAccount:                 serviceAccountVar.Get(),
+				XdsAuthProvider:                xdsAuthProvider.Get(),
+				TrustDomain:                    trustDomainEnv,
+				Pkcs8Keys:                      pkcs8KeysEnv,
+				ECCSigAlg:                      eccSigAlgEnv,
+				SecretTTL:                      secretTTLEnv,
+				SecretRotationGracePeriodRatio: secretRotationGracePeriodRatioEnv,
+			}
+			secOpts, err := secopt.SetupSecurityOptions(proxyConfig, sop, jwtPolicy.Get(),
+				credFetcherTypeEnv, credIdentityProvider)
 			if err != nil {
 				return err
 			}

--- a/pilot/cmd/pilot-agent/security/security.go
+++ b/pilot/cmd/pilot-agent/security/security.go
@@ -1,0 +1,91 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package security
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	meshconfig "istio.io/api/mesh/v1alpha1"
+	securityModel "istio.io/istio/pilot/pkg/security/model"
+	"istio.io/istio/pkg/config/constants"
+	"istio.io/istio/pkg/jwt"
+	"istio.io/istio/pkg/security"
+	"istio.io/istio/security/pkg/credentialfetcher"
+	"istio.io/istio/security/pkg/nodeagent/plugin/providers/google/stsclient"
+	"istio.io/pkg/log"
+)
+
+func SetupSecurityOptions(proxyConfig meshconfig.ProxyConfig, jwtPolicy, clusterIDVar, podNamespaceVar,
+	serviceAccountVar, caEndpointEnv, caProviderEnv, pilotCertProvider, outputKeyCertToDir, provCert, trustDomainEnv,
+	eccSigAlgEnv, credFetcherTypeEnv, credIdentityProvider, xdsAuthProvider string, fileMountedCertsEnv, pkcs8KeysEnv bool,
+	secretTTLEnv time.Duration, secretRotationGracePeriodRatioEnv float64) (security.Options, error) {
+	var jwtPath string
+	if jwtPolicy == jwt.PolicyThirdParty {
+		log.Info("JWT policy is third-party-jwt")
+		jwtPath = constants.TrustworthyJWTPath
+	} else if jwtPolicy == jwt.PolicyFirstParty {
+		log.Info("JWT policy is first-party-jwt")
+		jwtPath = securityModel.K8sSAJwtFileName
+	} else {
+		log.Info("Using existing certs")
+	}
+
+	o := security.Options{
+		CAEndpoint:                     caEndpointEnv,
+		CAProviderName:                 caProviderEnv,
+		PilotCertProvider:              pilotCertProvider,
+		OutputKeyCertToDir:             outputKeyCertToDir,
+		ProvCert:                       provCert,
+		JWTPath:                        jwtPath,
+		WorkloadUDSPath:                security.DefaultLocalSDSPath,
+		ClusterID:                      clusterIDVar,
+		FileMountedCerts:               fileMountedCertsEnv,
+		WorkloadNamespace:              podNamespaceVar,
+		ServiceAccount:                 serviceAccountVar,
+		XdsAuthProvider:                xdsAuthProvider,
+		TrustDomain:                    trustDomainEnv,
+		Pkcs8Keys:                      pkcs8KeysEnv,
+		ECCSigAlg:                      eccSigAlgEnv,
+		SecretTTL:                      secretTTLEnv,
+		SecretRotationGracePeriodRatio: secretRotationGracePeriodRatioEnv,
+	}
+	// If not set explicitly, default to the discovery address.
+	if o.CAEndpoint == "" {
+		o.CAEndpoint = proxyConfig.DiscoveryAddress
+	}
+
+	// TODO (liminw): CredFetcher is a general interface. In 1.7, we limit the use on GCE only because
+	// GCE is the only supported plugin at the moment.
+	if credFetcherTypeEnv == security.GCE {
+		o.CredIdentityProvider = credIdentityProvider
+		credFetcher, err := credentialfetcher.NewCredFetcher(credFetcherTypeEnv, o.TrustDomain, jwtPath, o.CredIdentityProvider)
+		if err != nil {
+			return security.Options{}, fmt.Errorf("failed to create credential fetcher: %v", err)
+		}
+		log.Infof("using credential fetcher of %s type in %s trust domain", credFetcherTypeEnv, o.TrustDomain)
+		o.CredFetcher = credFetcher
+	}
+	// TODO extract this logic out to a plugin
+	if o.CAProviderName == "GoogleCA" || strings.Contains(o.CAEndpoint, "googleapis.com") {
+		o.TokenExchanger = stsclient.NewSecureTokenServiceExchanger(o.CredFetcher, o.TrustDomain)
+	}
+
+	if o.ProvCert != "" && o.FileMountedCerts {
+		return security.Options{}, fmt.Errorf("invalid options: PROV_CERT and FILE_MOUNTED_CERTS are mutually exclusive")
+	}
+	return o, nil
+}

--- a/pilot/cmd/pilot-agent/security/security.go
+++ b/pilot/cmd/pilot-agent/security/security.go
@@ -17,7 +17,6 @@ package security
 import (
 	"fmt"
 	"strings"
-	"time"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	securityModel "istio.io/istio/pilot/pkg/security/model"
@@ -29,10 +28,8 @@ import (
 	"istio.io/pkg/log"
 )
 
-func SetupSecurityOptions(proxyConfig meshconfig.ProxyConfig, jwtPolicy, clusterIDVar, podNamespaceVar,
-	serviceAccountVar, caEndpointEnv, caProviderEnv, pilotCertProvider, outputKeyCertToDir, provCert, trustDomainEnv,
-	eccSigAlgEnv, credFetcherTypeEnv, credIdentityProvider, xdsAuthProvider string, fileMountedCertsEnv, pkcs8KeysEnv bool,
-	secretTTLEnv time.Duration, secretRotationGracePeriodRatioEnv float64) (security.Options, error) {
+func SetupSecurityOptions(proxyConfig meshconfig.ProxyConfig, secOpt security.Options, jwtPolicy,
+	credFetcherTypeEnv, credIdentityProvider string) (security.Options, error) {
 	var jwtPath string
 	if jwtPolicy == jwt.PolicyThirdParty {
 		log.Info("JWT policy is third-party-jwt")
@@ -44,25 +41,9 @@ func SetupSecurityOptions(proxyConfig meshconfig.ProxyConfig, jwtPolicy, cluster
 		log.Info("Using existing certs")
 	}
 
-	o := security.Options{
-		CAEndpoint:                     caEndpointEnv,
-		CAProviderName:                 caProviderEnv,
-		PilotCertProvider:              pilotCertProvider,
-		OutputKeyCertToDir:             outputKeyCertToDir,
-		ProvCert:                       provCert,
-		JWTPath:                        jwtPath,
-		WorkloadUDSPath:                security.DefaultLocalSDSPath,
-		ClusterID:                      clusterIDVar,
-		FileMountedCerts:               fileMountedCertsEnv,
-		WorkloadNamespace:              podNamespaceVar,
-		ServiceAccount:                 serviceAccountVar,
-		XdsAuthProvider:                xdsAuthProvider,
-		TrustDomain:                    trustDomainEnv,
-		Pkcs8Keys:                      pkcs8KeysEnv,
-		ECCSigAlg:                      eccSigAlgEnv,
-		SecretTTL:                      secretTTLEnv,
-		SecretRotationGracePeriodRatio: secretRotationGracePeriodRatioEnv,
-	}
+	o := secOpt
+	o.JWTPath = jwtPath
+
 	// If not set explicitly, default to the discovery address.
 	if o.CAEndpoint == "" {
 		o.CAEndpoint = proxyConfig.DiscoveryAddress

--- a/security/pkg/nodeagent/caclient/credentials_test.go
+++ b/security/pkg/nodeagent/caclient/credentials_test.go
@@ -1,0 +1,125 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package caclient
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+
+	"istio.io/istio/pilot/cmd/pilot-agent/config"
+	secop "istio.io/istio/pilot/cmd/pilot-agent/security"
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/config/constants"
+	"istio.io/istio/pkg/jwt"
+	"istio.io/istio/security/pkg/stsservice"
+	stsmock "istio.io/istio/security/pkg/stsservice/mock"
+	"istio.io/istio/security/pkg/stsservice/tokenmanager/google"
+	"istio.io/istio/security/pkg/stsservice/tokenmanager/google/mock"
+)
+
+// TestGetTokenForXDS tests getting token for XDS.
+// Test case 1: xdsAuthProvider is google.GCPAuthProvider.
+// Test case 2: xdsAuthProvider is empty.
+func TestGetTokenForXDS(t *testing.T) {
+	role := &model.Proxy{}
+	role.Type = model.SidecarProxy
+	meshConfigFile := ""
+	serviceCluster := constants.ServiceClusterName
+	proxyConfigEnv := ""
+	concurrency := 0
+	proxyConfig, err := config.ConstructProxyConfig(meshConfigFile, serviceCluster, proxyConfigEnv, concurrency, role)
+	if err != nil {
+		t.Fatalf("failed to construct proxy config: %v", err)
+	}
+
+	jwtPolicy := jwt.PolicyThirdParty
+	clusterIDVar := ""
+	podNamespaceVar := ""
+	serviceAccountVar := ""
+	caEndpointEnv := ""
+	caProviderEnv := "Citadel"
+	pilotCertProvider := "istiod"
+	outputKeyCertToDir := ""
+	provCert := ""
+	trustDomainEnv := "cluster.local"
+	eccSigAlgEnv := ""
+	credFetcherTypeEnv := ""
+	credIdentityProvider := google.GCEProvider
+	xdsAuthProvider := google.GCPAuthProvider
+	fileMountedCertsEnv := false
+	pkcs8KeysEnv := false
+	secretTTLEnv := 24 * time.Hour
+	secretRotationGracePeriodRatioEnv := 0.5
+	secOpts, err := secop.SetupSecurityOptions(proxyConfig, jwtPolicy, clusterIDVar,
+		podNamespaceVar, serviceAccountVar, caEndpointEnv, caProviderEnv, pilotCertProvider,
+		outputKeyCertToDir, provCert, trustDomainEnv, eccSigAlgEnv, credFetcherTypeEnv, credIdentityProvider,
+		xdsAuthProvider, fileMountedCertsEnv, pkcs8KeysEnv, secretTTLEnv, secretRotationGracePeriodRatioEnv)
+	if err != nil {
+		t.Fatalf("failed to setup security options: %v", err)
+	}
+	jwtPath, err := writeToTempFile(mock.FakeSubjectToken, "jwt-token-*")
+	if err != nil {
+		t.Fatalf("failed to write the JWT token file: %v", err)
+	}
+	secOpts.JWTPath = jwtPath
+	defer os.Remove(jwtPath)
+	// Use a mock token manager because real token exchange requires a working k8s token,
+	// permissions for token exchange, and connection to the token exchange server.
+	tokenManager := stsmock.CreateFakeTokenManager()
+	tokenManager.SetRespStsParam(stsservice.StsResponseParameters{
+		AccessToken:     mock.FakeAccessToken,
+		IssuedTokenType: "urn:ietf:params:oauth:token-type:access_token",
+		TokenType:       "Bearer",
+		ExpiresIn:       60,
+		Scope:           "example.com",
+	})
+	secOpts.TokenManager = tokenManager
+
+	// Case 1: xdsAuthProvider is google.GCPAuthProvider
+	provider := NewXDSTokenProvider(secOpts)
+	token, err := provider.GetToken()
+	if err != nil {
+		t.Errorf("failed to get token: %v", err)
+	}
+	if token != mock.FakeAccessToken {
+		t.Errorf("the access token is unexpected, expect: %v, got: %v", mock.FakeAccessToken, token)
+	}
+	// Case 2: xdsAuthProvider is empty
+	secOpts.XdsAuthProvider = ""
+	provider = NewXDSTokenProvider(secOpts)
+	token, err = provider.GetToken()
+	if err != nil {
+		t.Fatalf("failed to get token: %v", err)
+	}
+	if token != mock.FakeSubjectToken {
+		t.Errorf("token is unexpected, expect: %v, got: %v", mock.FakeSubjectToken, token)
+	}
+}
+
+func writeToTempFile(content, fileNamePrefix string) (string, error) {
+	outFile, err := ioutil.TempFile("", fileNamePrefix)
+	if err != nil {
+		return "", fmt.Errorf("failed creating a temp file: %v", err)
+	}
+	defer func() { _ = outFile.Close() }()
+
+	if _, err := outFile.Write([]byte(content)); err != nil {
+		return "", fmt.Errorf("failed writing to the temp file: %v", err)
+	}
+	return outFile.Name(), nil
+}


### PR DESCRIPTION
Please provide a description for what this PR is for: 
Add tests for getting tokens for XDS
- Test case 1: xdsAuthProvider is google.GCPAuthProvider.
- Test case 2: xdsAuthProvider is empty.
- The tests need to call constructProxyConfig() and setupSecurityOptions() to
  configure the options used by the token provider. Thus,
  constructProxyConfig() and setupSecurityOptions() are refactored such
  that they can be called in tests.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.