### PR TITLE
[release-1.9] Fix sidecar injector default template config option. (#30353)

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -194,7 +194,6 @@ data:
   # to fine tune it or use it with kube-inject.
   config: |-
     # defaultTemplates defines the default template to use for pods that do not explicitly specify a template
-    # NOTE: this currently only allows a single element
     defaultTemplates: [sidecar]
     policy: enabled
     alwaysInjectSelector:

--- a/manifests/charts/istio-control/istio-discovery/templates/istiod-injector-configmap.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/istiod-injector-configmap.yaml
@@ -21,9 +21,11 @@ data:
   # to fine tune it or use it with kube-inject.
   config: |-
     # defaultTemplates defines the default template to use for pods that do not explicitly specify a template
-    # NOTE: this currently only allows a single element
     {{- if .Values.sidecarInjectorWebhook.defaultTemplates }}
-    defaultTemplates: {{ .Values.sidecarInjectorWebhook.defaultTemplates }}
+    defaultTemplates:
+{{- range .Values.sidecarInjectorWebhook.defaultTemplates}}
+    - {{ . }}
+{{- end }}
     {{- else }}
     defaultTemplates: [sidecar]
     {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -105,10 +105,10 @@ sidecarInjectorWebhook:
   # Templates defines a set of custom injection templates that can be used. For example, defining:
   #
   # templates:
-  #   hello:
-  #    metadata
-  #      labels:
-  #        hello: world
+  #   hello: |
+  #     metadata:
+  #       labels:
+  #         hello: world
   #
   # Then starting a pod with the `inject.istio.io/templates: hello` annotation, will result in the pod
   # being injected with the hello=world labels.
@@ -122,8 +122,8 @@ sidecarInjectorWebhook:
   # For example:
   #
   # templates:
-  #   hello:
-  #     metadata
+  #   hello: |
+  #     metadata:
   #       labels:
   #         hello: world
   #

--- a/manifests/charts/istiod-remote/templates/istiod-injector-configmap.yaml
+++ b/manifests/charts/istiod-remote/templates/istiod-injector-configmap.yaml
@@ -21,9 +21,11 @@ data:
   # to fine tune it or use it with kube-inject.
   config: |-
     # defaultTemplates defines the default template to use for pods that do not explicitly specify a template
-    # NOTE: this currently only allows a single element
     {{- if .Values.sidecarInjectorWebhook.defaultTemplates }}
-    defaultTemplates: {{ .Values.sidecarInjectorWebhook.defaultTemplates }}
+    defaultTemplates:
+{{- range .Values.sidecarInjectorWebhook.defaultTemplates}}
+    - {{ . }}
+{{- end }}
     {{- else }}
     defaultTemplates: [sidecar]
     {{- end }}

--- a/manifests/charts/istiod-remote/values.yaml
+++ b/manifests/charts/istiod-remote/values.yaml
@@ -84,10 +84,10 @@ sidecarInjectorWebhook:
   # Templates defines a set of custom injection templates that can be used. For example, defining:
   #
   # templates:
-  #   hello:
-  #    metadata
-  #      labels:
-  #        hello: world
+  #   hello: |
+  #     metadata:
+  #       labels:
+  #         hello: world
   #
   # Then starting a pod with the `inject.istio.io/templates: hello` annotation, will result in the pod
   # being injected with the hello=world labels.
@@ -100,8 +100,8 @@ sidecarInjectorWebhook:
   # For example:
   #
   # templates:
-  #   hello:
-  #     metadata
+  #   hello: |
+  #     metadata:
   #       labels:
   #         hello: world
   #

--- a/operator/cmd/mesh/manifest-generate_test.go
+++ b/operator/cmd/mesh/manifest-generate_test.go
@@ -918,3 +918,12 @@ func selectorMatches(t *testing.T, selector *metav1.LabelSelector, labels klabel
 	}
 	return s.Matches(labels)
 }
+
+func TestSidecarTemplate(t *testing.T) {
+	runTestGroup(t, testGroup{
+		{
+			desc:       "sidecar_template",
+			diffSelect: "ConfigMap:*:istio-sidecar-injector",
+		},
+	})
+}

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -194,7 +194,6 @@ data:
   # to fine tune it or use it with kube-inject.
   config: |-
     # defaultTemplates defines the default template to use for pods that do not explicitly specify a template
-    # NOTE: this currently only allows a single element
     defaultTemplates: [sidecar]
     policy: enabled
     alwaysInjectSelector:

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-control/istio-discovery/templates/istiod-injector-configmap.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-control/istio-discovery/templates/istiod-injector-configmap.yaml
@@ -21,9 +21,11 @@ data:
   # to fine tune it or use it with kube-inject.
   config: |-
     # defaultTemplates defines the default template to use for pods that do not explicitly specify a template
-    # NOTE: this currently only allows a single element
     {{- if .Values.sidecarInjectorWebhook.defaultTemplates }}
-    defaultTemplates: {{ .Values.sidecarInjectorWebhook.defaultTemplates }}
+    defaultTemplates:
+{{- range .Values.sidecarInjectorWebhook.defaultTemplates}}
+    - {{ . }}
+{{- end }}
     {{- else }}
     defaultTemplates: [sidecar]
     {{- end }}

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-control/istio-discovery/values.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-control/istio-discovery/values.yaml
@@ -105,10 +105,10 @@ sidecarInjectorWebhook:
   # Templates defines a set of custom injection templates that can be used. For example, defining:
   #
   # templates:
-  #   hello:
-  #    metadata
-  #      labels:
-  #        hello: world
+  #   hello: |
+  #     metadata:
+  #       labels:
+  #         hello: world
   #
   # Then starting a pod with the `inject.istio.io/templates: hello` annotation, will result in the pod
   # being injected with the hello=world labels.
@@ -122,8 +122,8 @@ sidecarInjectorWebhook:
   # For example:
   #
   # templates:
-  #   hello:
-  #     metadata
+  #   hello: |
+  #     metadata:
   #       labels:
   #         hello: world
   #

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istiod-remote/files/gen-istiod-remote.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istiod-remote/files/gen-istiod-remote.yaml
@@ -174,7 +174,6 @@ data:
   # to fine tune it or use it with kube-inject.
   config: |-
     # defaultTemplates defines the default template to use for pods that do not explicitly specify a template
-    # NOTE: this currently only allows a single element
     defaultTemplates: [sidecar]
     policy: enabled
     alwaysInjectSelector:

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istiod-remote/templates/istiod-injector-configmap.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istiod-remote/templates/istiod-injector-configmap.yaml
@@ -21,9 +21,11 @@ data:
   # to fine tune it or use it with kube-inject.
   config: |-
     # defaultTemplates defines the default template to use for pods that do not explicitly specify a template
-    # NOTE: this currently only allows a single element
     {{- if .Values.sidecarInjectorWebhook.defaultTemplates }}
-    defaultTemplates: {{ .Values.sidecarInjectorWebhook.defaultTemplates }}
+    defaultTemplates:
+{{- range .Values.sidecarInjectorWebhook.defaultTemplates}}
+    - {{ . }}
+{{- end }}
     {{- else }}
     defaultTemplates: [sidecar]
     {{- end }}

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istiod-remote/values.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istiod-remote/values.yaml
@@ -84,10 +84,10 @@ sidecarInjectorWebhook:
   # Templates defines a set of custom injection templates that can be used. For example, defining:
   #
   # templates:
-  #   hello:
-  #    metadata
-  #      labels:
-  #        hello: world
+  #   hello: |
+  #     metadata:
+  #       labels:
+  #         hello: world
   #
   # Then starting a pod with the `inject.istio.io/templates: hello` annotation, will result in the pod
   # being injected with the hello=world labels.
@@ -100,8 +100,8 @@ sidecarInjectorWebhook:
   # For example:
   #
   # templates:
-  #   hello:
-  #     metadata
+  #   hello: |
+  #     metadata:
   #       labels:
   #         hello: world
   #

--- a/operator/cmd/mesh/testdata/manifest-generate/input/sidecar_template.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/input/sidecar_template.yaml
@@ -1,0 +1,19 @@
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+spec:
+  values:
+    sidecarInjectorWebhook:
+      defaultTemplates: ["sidecar", "credential-volume"]
+      templates:
+        credential-volume: |
+          spec:
+            volumes:
+            - name: application-credentials
+              secret:
+                secretName: secret
+            containers:
+            - name: istio-proxy
+              volumeMounts:
+              - name: application-credentials
+                mountPath: /etc/istio/application-credentials
+                readOnly: true

--- a/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
@@ -4697,7 +4697,6 @@ data:
   # to fine tune it or use it with kube-inject.
   config: |-
     # defaultTemplates defines the default template to use for pods that do not explicitly specify a template
-    # NOTE: this currently only allows a single element
     defaultTemplates: [sidecar]
     policy: enabled
     alwaysInjectSelector:

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.golden.yaml
@@ -958,7 +958,6 @@ data:
   # to fine tune it or use it with kube-inject.
   config: |-
     # defaultTemplates defines the default template to use for pods that do not explicitly specify a template
-    # NOTE: this currently only allows a single element
     defaultTemplates: [sidecar]
     policy: enabled
     alwaysInjectSelector:

--- a/operator/cmd/mesh/testdata/manifest-generate/output/sidecar_template.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/sidecar_template.golden.yaml
@@ -1,32 +1,3 @@
----
-# Source: istiod-remote/templates/configmap.yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: istio
-  namespace: istio-system
-  labels:
-    istio.io/rev: default
-    install.operator.istio.io/owning-resource: unknown
-    operator.istio.io/component: "Pilot"
-    release: istiod-remote
-data:
-
-  # Configuration file for the mesh networks to be used by the Split Horizon EDS.
-  meshNetworks: |-
-    networks: {}
-
-  mesh: |-
-    defaultConfig:
-      discoveryAddress: istiod.istio-system.svc:15012
-      tracing:
-        zipkin:
-          address: zipkin.istio-system:9411
-    enablePrometheusMerge: true
-    rootNamespace: istio-system
-    trustDomain: cluster.local
----
-# Source: istiod-remote/templates/istiod-injector-configmap.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -36,13 +7,20 @@ metadata:
     istio.io/rev: default
     install.operator.istio.io/owning-resource: unknown
     operator.istio.io/component: "Pilot"
-    release: istiod-remote
+    release: istio
 data:
 
   values: |-
     {
       "global": {
+        "arch": {
+          "amd64": 2,
+          "ppc64le": 2,
+          "s390x": 2
+        },
         "caAddress": "",
+        "configValidation": true,
+        "defaultNodeSelector": {},
         "defaultPodDisruptionBudget": {
           "enabled": true
         },
@@ -51,7 +29,8 @@ data:
             "cpu": "10m"
           }
         },
-        "externalIstiod": true,
+        "enabled": true,
+        "externalIstiod": false,
         "hub": "gcr.io/istio-testing",
         "imagePullPolicy": "",
         "imagePullSecrets": [],
@@ -71,6 +50,7 @@ data:
           "clusterName": "",
           "enabled": false
         },
+        "namespace": "istio-system",
         "network": "",
         "omitSidecarInjectorConfigMap": false,
         "oneNamespace": false,
@@ -150,10 +130,16 @@ data:
         "trustDomain": "",
         "useMCP": false
       },
+      "istio_cni": {
+        "enabled": false
+      },
       "revision": "",
       "sidecarInjectorWebhook": {
         "alwaysInjectSelector": [],
-        "defaultTemplates": [],
+        "defaultTemplates": [
+          "sidecar",
+          "credential-volume"
+        ],
         "enableNamespacesByDefault": false,
         "injectedAnnotations": {},
         "neverInjectSelector": [],
@@ -162,7 +148,9 @@ data:
           "enabled": true
         },
         "rewriteAppHTTPProbe": true,
-        "templates": {},
+        "templates": {
+          "credential-volume": "spec:\n  volumes:\n  - name: application-credentials\n    secret:\n      secretName: secret\n  containers:\n  - name: istio-proxy\n    volumeMounts:\n    - name: application-credentials\n      mountPath: /etc/istio/application-credentials\n      readOnly: true\n"
+        },
         "useLegacySelectors": true
       }
     }
@@ -174,7 +162,9 @@ data:
   # to fine tune it or use it with kube-inject.
   config: |-
     # defaultTemplates defines the default template to use for pods that do not explicitly specify a template
-    defaultTemplates: [sidecar]
+    defaultTemplates:
+    - sidecar
+    - credential-volume
     policy: enabled
     alwaysInjectSelector:
       []
@@ -675,40 +665,16 @@ data:
           securityContext:
             fsGroup: 1337
           {{- end }}
+      credential-volume: |
+        spec:
+          volumes:
+          - name: application-credentials
+            secret:
+              secretName: secret
+          containers:
+          - name: istio-proxy
+            volumeMounts:
+            - name: application-credentials
+              mountPath: /etc/istio/application-credentials
+              readOnly: true
 ---
-# Source: istiod-remote/templates/mutatingwebhook.yaml
-apiVersion: admissionregistration.k8s.io/v1beta1
-kind: MutatingWebhookConfiguration
-metadata:
-  name: istio-sidecar-injector
-  labels:
-    istio.io/rev: default
-    install.operator.istio.io/owning-resource: unknown
-    operator.istio.io/component: "Pilot"
-    app: sidecar-injector
-    release: istiod-remote
-webhooks:
-- name: sidecar-injector.istio.io
-  clientConfig:
-    service:
-      name: istiod
-      namespace: istio-system
-      path: "/inject"
-    caBundle: ""
-  sideEffects: None
-  rules:
-  - operations: [ "CREATE" ]
-    apiGroups: [""]
-    apiVersions: ["v1"]
-    resources: ["pods"]
-  failurePolicy: Fail
-  admissionReviewVersions: ["v1beta1", "v1"]
-  namespaceSelector:
-    matchLabels:
-      istio-injection: enabled
-  objectSelector:
-    matchExpressions:
-    - key: "sidecar.istio.io/inject"
-      operator: NotIn
-      values:
-      - "false"

--- a/operator/pkg/apis/istio/v1alpha1/v1alpha1.pb.html
+++ b/operator/pkg/apis/istio/v1alpha1/v1alpha1.pb.html
@@ -3194,10 +3194,10 @@ No
 <p>Templates defines a set of custom injection templates that can be used. For example, defining:</p>
 
 <p>templates:
-  hello:
-   metadata
-     labels:
-       hello: world</p>
+  hello: |
+    metadata:
+      labels:
+        hello: world</p>
 
 <p>Then starting a pod with the <code>inject.istio.io/templates: hello</code> annotation, will result in the pod
 being injected with the hello=world labels.

--- a/operator/pkg/apis/istio/v1alpha1/values_types.pb.go
+++ b/operator/pkg/apis/istio/v1alpha1/values_types.pb.go
@@ -3496,10 +3496,10 @@ type SidecarInjectorConfig struct {
 	// Templates defines a set of custom injection templates that can be used. For example, defining:
 	//
 	// templates:
-	//   hello:
-	//    metadata
-	//      labels:
-	//        hello: world
+	//   hello: |
+	//     metadata:
+	//       labels:
+	//         hello: world
 	//
 	// Then starting a pod with the `inject.istio.io/templates: hello` annotation, will result in the pod
 	// being injected with the hello=world labels.

--- a/operator/pkg/apis/istio/v1alpha1/values_types.proto
+++ b/operator/pkg/apis/istio/v1alpha1/values_types.proto
@@ -971,10 +971,10 @@ message SidecarInjectorConfig {
   // Templates defines a set of custom injection templates that can be used. For example, defining:
   //
   // templates:
-  //   hello:
-  //    metadata
-  //      labels:
-  //        hello: world
+  //   hello: |
+  //     metadata:
+  //       labels:
+  //         hello: world
   //
   // Then starting a pod with the `inject.istio.io/templates: hello` annotation, will result in the pod
   // being injected with the hello=world labels.
@@ -994,8 +994,8 @@ message SidecarInjectorConfig {
   // For example:
 
   // templates:
-  //   hello:
-  //     metadata
+  //   hello: |
+  //     metadata:
   //       labels:
   //         hello: world
 


### PR DESCRIPTION
cherry-pick to fix https://github.com/istio/istio/issues/30402. Also update operator test snapshot and regenerate test golden files.

* Fix sidecar injector default template options.

* add a test for sidecar template

* add test files

* update data snapshot and gen golden file



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.