### PR TITLE
Fix dashboard controlz could not port forward to istiod pod

### DIFF
--- a/istioctl/cmd/dashboard.go
+++ b/istioctl/cmd/dashboard.go
@@ -304,6 +304,9 @@ func controlZDashCmd() *cobra.Command {
 		Example: `  # Open ControlZ web UI for the istiod-123-456.istio-system pod
   istioctl dashboard controlz istiod-123-456.istio-system
 
+  # Open ControlZ web UI for the istiod-56dd66799-jfdvs pod in a custom namespace
+  istioctl dashboard controlz istiod-123-456 -n custom-ns
+
   # Open ControlZ web UI for any Istiod pod
   istioctl dashboard controlz deployment/istiod.istio-system
 

--- a/istioctl/cmd/dashboard.go
+++ b/istioctl/cmd/dashboard.go
@@ -329,7 +329,7 @@ func controlZDashCmd() *cobra.Command {
 
 			var podName, ns string
 			if labelSelector != "" {
-				pl, err := client.PodsForSelector(context.TODO(), handlers.HandleNamespace(namespace, defaultNamespace), labelSelector)
+				pl, err := client.PodsForSelector(context.TODO(), handlers.HandleNamespace(addonNamespace, defaultNamespace), labelSelector)
 				if err != nil {
 					return fmt.Errorf("not able to locate pod with selector %s: %v", labelSelector, err)
 				}
@@ -347,7 +347,7 @@ func controlZDashCmd() *cobra.Command {
 				ns = pl.Items[0].Namespace
 			} else {
 				podName, ns, err = handlers.InferPodInfoFromTypedResource(args[0],
-					handlers.HandleNamespace(namespace, defaultNamespace),
+					handlers.HandleNamespace(addonNamespace, defaultNamespace),
 					client.UtilFactory())
 				if err != nil {
 					return err
@@ -477,6 +477,8 @@ func dashboard() *cobra.Command {
 	controlz := controlZDashCmd()
 	controlz.PersistentFlags().IntVar(&controlZport, "ctrlz_port", 9876, "ControlZ port")
 	controlz.PersistentFlags().StringVarP(&labelSelector, "selector", "l", "", "Label selector")
+	controlz.PersistentFlags().StringVarP(&addonNamespace, "namespace", "n", istioNamespace,
+		"Namespace where the addon is running, if not specified, istio-system would be used")
 	dashboardCmd.AddCommand(controlz)
 
 	return dashboardCmd

--- a/istioctl/cmd/dashboard_test.go
+++ b/istioctl/cmd/dashboard_test.go
@@ -107,6 +107,11 @@ func TestDashboard(t *testing.T) {
 			args:           strings.Split("-n test dashboard", " "),
 			expectedRegexp: regexp.MustCompile("Access to Istio web UIs"),
 		},
+		{ // case 16
+			args:           strings.Split("dashboard controlz --browser=false pod-123456-7890 -n istio-system", " "),
+			expectedRegexp: regexp.MustCompile(".*http://localhost:3456"),
+			wantException:  false,
+		},
 	}
 
 	for i, c := range cases {

--- a/releasenotes/notes/30208.yaml
+++ b/releasenotes/notes/30208.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: istioctl
+issue:
+  - 30208
+
+releaseNotes:
+  - |
+    **Fixed** dashboard controlz could not port forward to istiod pod.


### PR DESCRIPTION
To fix https://github.com/istio/istio/issues/30208

Before:
```
[istio-1.9.0-beta.1]$ k get po -n istio-system
NAME                                    READY   STATUS    RESTARTS   AGE
istio-ingressgateway-5787d6946b-jxfsg   1/1     Running   0          4m
istiod-56dd66799-jfdvs                  1/1     Running   0          5m
```
```
[istio-1.9.0-beta.1]$ ./bin/istioctl dashboard controlz istiod-56dd66799-jfdvs -n istio-system
Error: could not build port forwarder for ControlZ istiod-56dd66799-jfdvs: failed retrieving pod: pods "istiod-56dd66799-jfdvs" not found
```

After:
```
[istio-master] ./out/linux_amd64/istioctl dashboard controlz istiod-56dd66799-jfdvs -n istio-system
http://localhost:9876
```