### PR TITLE
[release-1.9] Add integration tests for Wasm module remote load (#30241)

### DIFF
--- a/pkg/test/framework/features/features.yaml
+++ b/pkg/test/framework/features/features.yaml
@@ -115,6 +115,8 @@ features:
       plugin-cert:
   # features which allow extending or deep integrations with istio and other products
   extensibility:
+    wasm:
+      remote-load:
   # features releated to the lifecycle of istio installations
   installation:
     istioctl:

--- a/tests/integration/telemetry/stats/prometheus/customizemetrics/customize_metrics_test.go
+++ b/tests/integration/telemetry/stats/prometheus/customizemetrics/customize_metrics_test.go
@@ -16,13 +16,16 @@
 package customizemetrics
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"path"
 	"strings"
 	"testing"
 	"time"
 
 	"istio.io/istio/pkg/config/protocol"
+	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
@@ -32,6 +35,7 @@ import (
 	"istio.io/istio/pkg/test/framework/label"
 	"istio.io/istio/pkg/test/framework/resource"
 	"istio.io/istio/pkg/test/util/retry"
+	"istio.io/istio/pkg/test/util/tmpl"
 	util "istio.io/istio/tests/integration/telemetry"
 	common "istio.io/istio/tests/integration/telemetry/stats/prometheus"
 )
@@ -52,6 +56,8 @@ const (
 func TestCustomizeMetrics(t *testing.T) {
 	framework.NewTest(t).
 		Features("observability.telemetry.stats.prometheus.customize-metric").
+		Features("observability.telemetry.request-classification").
+		Features("extensibility.wasm.remote-load").
 		Run(func(ctx framework.TestContext) {
 			httpDestinationQuery := buildQuery(httpProtocol)
 			grpcDestinationQuery := buildQuery(grpcProtocol)
@@ -60,7 +66,7 @@ func TestCustomizeMetrics(t *testing.T) {
 			httpChecked := false
 			retry.UntilSuccessOrFail(t, func() error {
 				if err := sendTraffic(t); err != nil {
-					t.Errorf("failed to send traffic")
+					t.Log("failed to send traffic")
 					return err
 				}
 				var err error
@@ -169,11 +175,32 @@ values:
 }
 
 func setupEnvoyFilter(ctx resource.Context) error {
+	proxyDepFile := path.Join(env.IstioSrc, "istio.deps")
+	depJSON, err := ioutil.ReadFile(proxyDepFile)
+	if err != nil {
+		return err
+	}
+	var deps []interface{}
+	if err := json.Unmarshal(depJSON, &deps); err != nil {
+		return err
+	}
+	proxySHA := ""
+	for _, d := range deps {
+		if dm, ok := d.(map[string]interface{}); ok && dm["repoName"].(string) == "proxy" {
+			proxySHA = dm["lastStableSHA"].(string)
+		}
+	}
 	content, err := ioutil.ReadFile("testdata/attributegen_envoy_filter.yaml")
 	if err != nil {
 		return err
 	}
-	if err := ctx.Config().ApplyYAML(appNsInst.Name(), string(content)); err != nil {
+	con, err := tmpl.Evaluate(string(content), map[string]interface{}{
+		"ProxySHA": proxySHA,
+	})
+	if err != nil {
+		return err
+	}
+	if err := ctx.Config().ApplyYAML(appNsInst.Name(), con); err != nil {
 		return err
 	}
 

--- a/tests/integration/telemetry/stats/prometheus/customizemetrics/testdata/attributegen_envoy_filter.yaml
+++ b/tests/integration/telemetry/stats/prometheus/customizemetrics/testdata/attributegen_envoy_filter.yaml
@@ -20,6 +20,27 @@ spec:
         operation: INSERT_BEFORE
         value:
           name: istio.attributegen
+          config_discovery:
+            config_source:
+              ads: {}
+            type_urls: [ "type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm"]
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: istio-attributegen-filter-config
+spec:
+  workloadSelector:
+    labels:
+      app: server
+  configPatches:
+    - applyTo: EXTENSION_CONFIG
+      match:
+        context: SIDECAR_INBOUND
+      patch:
+        operation: ADD
+        value:
+          name: istio.attributegen
           typed_config:
             "@type": type.googleapis.com/udpa.type.v1.TypedStruct
             type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
@@ -56,6 +77,9 @@ spec:
                       }]
                     }
                 vm_config:
-                  runtime: envoy.wasm.runtime.null
+                  runtime: envoy.wasm.runtime.v8
                   code:
-                    local: { inline_string: "envoy.wasm.attributegen" }
+                    remote:
+                      http_uri:
+                        uri: https://storage.googleapis.com/istio-build/proxy/attributegen-{{ .ProxySHA }}.wasm
+                        timeout: 10s

--- a/tests/integration/telemetry/stats/prometheus/stats.go
+++ b/tests/integration/telemetry/stats/prometheus/stats.go
@@ -251,9 +251,10 @@ func TestSetup(ctx resource.Context) (err error) {
 // SendTraffic makes a client call to the "server" service on the http port.
 func SendTraffic(cltInstance echo.Instance) error {
 	_, err := cltInstance.Call(echo.CallOptions{
-		Target:   server[0],
-		PortName: "http",
-		Count:    util.RequestCountMultipler * len(server),
+		Target:    server[0],
+		PortName:  "http",
+		Count:     util.RequestCountMultipler * len(server),
+		Validator: echo.ExpectOK(),
 	})
 	if err != nil {
 		return err

--- a/tests/integration/telemetry/stats/prometheus/wasm/bad_wasm_filter_test.go
+++ b/tests/integration/telemetry/stats/prometheus/wasm/bad_wasm_filter_test.go
@@ -1,0 +1,96 @@
+// +build integ
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wasm
+
+import (
+	"fmt"
+	"io/ioutil"
+	"testing"
+	"time"
+
+	resource "istio.io/istio/pilot/pkg/xds/v3"
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/util/retry"
+	util "istio.io/istio/tests/integration/telemetry"
+	common "istio.io/istio/tests/integration/telemetry/stats/prometheus"
+)
+
+// TestBadWasmRemoteLoad tests that bad Wasm remote load configuration won't affect service.
+// The test will set up an echo client and server, test echo ping works fine. Then apply a
+// Wasm filter which has a bad URL link, which will result as module download failure. After that,
+// verifies that echo ping could still work. The test also verifies that metrics are properly
+// recorded for module downloading failure and nack on ECDS update.
+func TestBadWasmRemoteLoad(t *testing.T) {
+	framework.NewTest(t).
+		Features("extensibility.wasm.remote-load").
+		Run(func(ctx framework.TestContext) {
+			// Test bad wasm remote load in only one cluster.
+			// There is no need to repeat the same testing logic in several different clusters.
+			cltInstance := common.GetClientInstances()[0]
+			// Verify that echo server could return 200
+			retry.UntilSuccessOrFail(t, func() error {
+				if err := common.SendTraffic(cltInstance); err != nil {
+					return err
+				}
+				return nil
+			}, retry.Delay(1*time.Millisecond), retry.Timeout(5*time.Second))
+			t.Log("echo server returns OK, apply bad wasm remote load filter.")
+
+			// Apply bad filter config
+			content, err := ioutil.ReadFile("testdata/bad-filter.yaml")
+			if err != nil {
+				t.Fatal(err)
+			}
+			ctx.Config().ApplyYAMLInClusterOrFail(t, cltInstance.Config().Cluster, common.GetAppNamespace().Name(), string(content))
+
+			// Wait until there is agent metrics for wasm download failure
+			retry.UntilSuccessOrFail(t, func() error {
+				q := "istio_agent_wasm_remote_fetch_count{result=\"download_failure\"}"
+				c := cltInstance.Config().Cluster
+				if _, err := common.QueryPrometheus(t, c, q, common.GetPromInstance()); err != nil {
+					t.Logf("prometheus values for istio_agent_wasm_remote_fetch_count for cluster %v: \n%s",
+						c, util.PromDump(c, common.GetPromInstance(), "istio_agent_wasm_remote_fetch_count"))
+					return err
+				}
+				return nil
+			}, retry.Delay(1*time.Second), retry.Timeout(80*time.Second))
+
+			t.Log("got istio_agent_wasm_remote_fetch_count metric in prometheus, bad wasm filter is applied, send request to echo server again.")
+
+			// Verify that istiod has a stats about rejected ECDS update
+			// pilot_total_xds_rejects{type="type.googleapis.com/envoy.config.core.v3.TypedExtensionConfig"}
+			retry.UntilSuccessOrFail(t, func() error {
+				q := fmt.Sprintf("pilot_total_xds_rejects{type=\"%v\"}", resource.ExtensionConfigurationType)
+				c := cltInstance.Config().Cluster
+				if _, err := common.QueryPrometheus(t, c, q, common.GetPromInstance()); err != nil {
+					t.Logf("prometheus values for pilot_total_xds_rejects for cluster %v: \n%s",
+						c, util.PromDump(c, common.GetPromInstance(), "pilot_total_xds_rejects"))
+					return err
+				}
+				return nil
+			}, retry.Delay(1*time.Second), retry.Timeout(80*time.Second))
+
+			// Verify that echo server could still return 200
+			retry.UntilSuccessOrFail(t, func() error {
+				if err := common.SendTraffic(cltInstance); err != nil {
+					return err
+				}
+				return nil
+			}, retry.Delay(1*time.Millisecond), retry.Timeout(5*time.Second))
+
+			t.Log("echo server still returns ok after bad wasm filter is applied.")
+		})
+}

--- a/tests/integration/telemetry/stats/prometheus/wasm/testdata/bad-filter.yaml
+++ b/tests/integration/telemetry/stats/prometheus/wasm/testdata/bad-filter.yaml
@@ -1,0 +1,55 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: bad-filter
+spec:
+  configPatches:
+  - applyTo: HTTP_FILTER
+    match:
+      context: ANY
+      listener:
+        filterChain:
+          filter:
+            name: envoy.http_connection_manager
+            subFilter:
+              name: "envoy.filters.http.router"
+    patch:
+      operation: INSERT_BEFORE
+      value:
+        name: bad-filter
+        config_discovery:
+          config_source:
+            ads: {}
+            initial_fetch_timeout: 0s # wait indefinitely to prevent filter chain being disabled
+          type_urls: [ "type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm"]
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: bad-filter-config
+spec:
+  configPatches:
+  - applyTo: EXTENSION_CONFIG
+    match:
+      context: ANY
+    patch:
+      operation: ADD
+      value:
+        name: bad-filter
+        typed_config:
+          "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+          type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+          value:
+            config:
+              vm_config:
+                vm_id: bad_vm
+                runtime: envoy.wasm.runtime.v8
+                code:
+                  remote:
+                    http_uri:
+                      uri: https://bad-url.wasm
+                      timeout: 10s
+              configuration:
+                '@type': type.googleapis.com/google.protobuf.StringValue
+                value: |
+                  {}


### PR DESCRIPTION
* Convert customize metrics to use remote load.

* lint

* feature label

* fix

* fix build

* fix

* make bad wasm remote load test single cluster

* fix



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.