### PR TITLE
use correct yaml package to read image pull secret

### DIFF
--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -103,7 +103,7 @@ spec:
 {{- end }}
 {{- if $.ImagePullSecret }}
       imagePullSecrets:
-      - {{ $.ImagePullSecret }}
+      - name: {{ $.ImagePullSecret }}
 {{- end }}
       containers:
 {{- if $.IncludeExtAuthz }}

--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -267,7 +267,7 @@ spec:
       automountServiceAccountToken: false
       {{- if $.ImagePullSecret }}
       imagePullSecrets:
-      - {{ $.ImagePullSecret }}
+      - name: {{ $.ImagePullSecret }}
       {{- end }}
       containers:
       - name: istio-proxy

--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -22,7 +22,7 @@ import (
 	"text/template"
 
 	"github.com/Masterminds/sprig/v3"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"istio.io/istio/pkg/test/framework/components/echo"

--- a/pkg/test/framework/components/echo/kube/deployment_test.go
+++ b/pkg/test/framework/components/echo/kube/deployment_test.go
@@ -29,9 +29,10 @@ import (
 
 var (
 	settings = &image.Settings{
-		Hub:        "testing.hub",
-		Tag:        "latest",
-		PullPolicy: "Always",
+		Hub:             "testing.hub",
+		Tag:             "latest",
+		PullPolicy:      "Always",
+		ImagePullSecret: "testdata/secret.yaml",
 	}
 )
 

--- a/pkg/test/framework/components/echo/kube/testdata/basic.yaml
+++ b/pkg/test/framework/components/echo/kube/testdata/basic.yaml
@@ -33,7 +33,7 @@ spec:
         prometheus.io/port: "15014"
     spec:
       imagePullSecrets:
-      - myregistrykey
+      - name: myregistrykey
       containers:
       - name: app
         image: testing.hub/app:latest

--- a/pkg/test/framework/components/echo/kube/testdata/basic.yaml
+++ b/pkg/test/framework/components/echo/kube/testdata/basic.yaml
@@ -32,6 +32,8 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: "15014"
     spec:
+      imagePullSecrets:
+      - myregistrykey
       containers:
       - name: app
         image: testing.hub/app:latest

--- a/pkg/test/framework/components/echo/kube/testdata/healthcheck-rewrite.yaml
+++ b/pkg/test/framework/components/echo/kube/testdata/healthcheck-rewrite.yaml
@@ -33,6 +33,8 @@ spec:
         prometheus.io/port: "15014"
         sidecar.istio.io/rewriteAppHTTPProbers: "true"
     spec:
+      imagePullSecrets:
+      - myregistrykey
       containers:
       - name: app
         image: testing.hub/app:latest

--- a/pkg/test/framework/components/echo/kube/testdata/healthcheck-rewrite.yaml
+++ b/pkg/test/framework/components/echo/kube/testdata/healthcheck-rewrite.yaml
@@ -34,7 +34,7 @@ spec:
         sidecar.istio.io/rewriteAppHTTPProbers: "true"
     spec:
       imagePullSecrets:
-      - myregistrykey
+      - name: myregistrykey
       containers:
       - name: app
         image: testing.hub/app:latest

--- a/pkg/test/framework/components/echo/kube/testdata/multiversion.yaml
+++ b/pkg/test/framework/components/echo/kube/testdata/multiversion.yaml
@@ -38,6 +38,8 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: "15014"
     spec:
+      imagePullSecrets:
+      - myregistrykey
       containers:
       - name: app
         image: testing.hub/app:latest
@@ -111,6 +113,8 @@ spec:
         prometheus.io/port: "15014"
         sidecar.istio.io/inject: "false"
     spec:
+      imagePullSecrets:
+      - myregistrykey
       containers:
       - name: app
         image: testing.hub/app:latest

--- a/pkg/test/framework/components/echo/kube/testdata/multiversion.yaml
+++ b/pkg/test/framework/components/echo/kube/testdata/multiversion.yaml
@@ -39,7 +39,7 @@ spec:
         prometheus.io/port: "15014"
     spec:
       imagePullSecrets:
-      - myregistrykey
+      - name: myregistrykey
       containers:
       - name: app
         image: testing.hub/app:latest
@@ -114,7 +114,7 @@ spec:
         sidecar.istio.io/inject: "false"
     spec:
       imagePullSecrets:
-      - myregistrykey
+      - name: myregistrykey
       containers:
       - name: app
         image: testing.hub/app:latest

--- a/pkg/test/framework/components/echo/kube/testdata/secret.yaml
+++ b/pkg/test/framework/components/echo/kube/testdata/secret.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: myregistrykey

--- a/pkg/test/framework/components/echo/kube/testdata/two-workloads-one-nosidecar.yaml
+++ b/pkg/test/framework/components/echo/kube/testdata/two-workloads-one-nosidecar.yaml
@@ -33,7 +33,7 @@ spec:
         prometheus.io/port: "15014"
     spec:
       imagePullSecrets:
-      - myregistrykey
+      - name: myregistrykey
       containers:
       - name: app
         image: testing.hub/app:latest
@@ -102,7 +102,7 @@ spec:
         sidecar.istio.io/inject: "false"
     spec:
       imagePullSecrets:
-      - myregistrykey
+      - name: myregistrykey
       containers:
       - name: app
         image: testing.hub/app:latest

--- a/pkg/test/framework/components/echo/kube/testdata/two-workloads-one-nosidecar.yaml
+++ b/pkg/test/framework/components/echo/kube/testdata/two-workloads-one-nosidecar.yaml
@@ -32,6 +32,8 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: "15014"
     spec:
+      imagePullSecrets:
+      - myregistrykey
       containers:
       - name: app
         image: testing.hub/app:latest
@@ -99,6 +101,8 @@ spec:
         prometheus.io/port: "15014"
         sidecar.istio.io/inject: "false"
     spec:
+      imagePullSecrets:
+      - myregistrykey
       containers:
       - name: app
         image: testing.hub/app:latest


### PR DESCRIPTION
v2 gives `map[interface{}]interface{}` and unstructured needs `map[string]interface{}` which is given by v3

actually tested this time

fixes #30455 