### PR TITLE
Change the drain strategy to immediate

### DIFF
--- a/pkg/envoy/proxy.go
+++ b/pkg/envoy/proxy.go
@@ -112,6 +112,7 @@ func (e *envoy) args(fname string, epoch int, bootstrapConfig string) []string {
 		"-c", fname,
 		"--restart-epoch", fmt.Sprint(epoch),
 		"--drain-time-s", fmt.Sprint(int(convertDuration(e.Config.DrainDuration) / time.Second)),
+		"--drain-strategy", "immediate", // Clients are notified as soon as the drain process starts.
 		"--parent-shutdown-time-s", fmt.Sprint(int(convertDuration(e.Config.ParentShutdownDuration) / time.Second)),
 		"--service-cluster", e.Config.ServiceCluster,
 		"--service-node", e.Node,

--- a/pkg/envoy/proxy_test.go
+++ b/pkg/envoy/proxy_test.go
@@ -51,6 +51,7 @@ func TestEnvoyArgs(t *testing.T) {
 		"-c", "test.json",
 		"--restart-epoch", "5",
 		"--drain-time-s", "45",
+		"--drain-strategy", "immediate",
 		"--parent-shutdown-time-s", "60",
 		"--service-cluster", "my-cluster",
 		"--service-node", "my-node",

--- a/releasenotes/notes/31403.yaml
+++ b/releasenotes/notes/31403.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: feature
+area: networking
+issue:
+  - 31403
+
+releaseNotes:
+- |
+  **Updated** istio-proxy drain notification strategy to immediate from gradual. 


### PR DESCRIPTION
resolves https://github.com/istio/istio/issues/31403

During drain Envoy notifies clients using GO-AWAY or connection:close (or other protocol specific methods).
The default is to gradually notify clients, this changes it to immediately notify clients.

The drain duration is unaffected, just that clients have more time to gracefully react to impending termination. 