### PR TITLE
fix post submit failures: security external ca ensure integration tests only run after K8s 1.18

### DIFF
--- a/tests/integration/security/external_ca/main_test.go
+++ b/tests/integration/security/external_ca/main_test.go
@@ -74,6 +74,7 @@ func TestMain(m *testing.M) {
 	// Refer to https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/
 	framework.NewSuite(m).
 		Label(label.CustomSetup).
+		RequireEnvironmentVersion("1.18").
 		Setup(istio.Setup(&inst, setupConfig)).
 		Setup(func(ctx resource.Context) error {
 			return SetupApps(ctx, apps)


### PR DESCRIPTION


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.