### PR TITLE
Repair cni resources

### DIFF
--- a/manifests/charts/istio-cni/templates/daemonset.yaml
+++ b/manifests/charts/istio-cni/templates/daemonset.yaml
@@ -113,7 +113,7 @@ spec:
 {{- end }}
 {{ - if .Values.cni.resources }}
           resources:
-{{ toYaml .Values.cni.resources | trim | indent 12 }}
+{{ toYaml .Values.cni.repair.resources | trim | indent 12 }}
 {{ - end }}
           command: ["/opt/cni/bin/istio-cni-repair"]
           env:

--- a/manifests/charts/istio-cni/templates/daemonset.yaml
+++ b/manifests/charts/istio-cni/templates/daemonset.yaml
@@ -65,6 +65,10 @@ spec:
 {{- if or .Values.cni.pullPolicy .Values.global.imagePullPolicy }}
           imagePullPolicy: {{ .Values.cni.pullPolicy | default .Values.global.imagePullPolicy }}
 {{- end }}
+{{ - if .Values.cni.resources }}
+          resources:
+{{ toYaml .Values.cni.resources | trim | indent 12 }}
+{{ - end }}
           livenessProbe:
             httpGet:
               path: /healthz
@@ -107,7 +111,10 @@ spec:
 {{- if or .Values.cni.pullPolicy .Values.global.imagePullPolicy }}
           imagePullPolicy: {{ .Values.cni.pullPolicy | default .Values.global.imagePullPolicy }}
 {{- end }}
-
+{{ - if .Values.cni.resources }}
+          resources:
+{{ toYaml .Values.cni.resources | trim | indent 12 }}
+{{ - end }}
           command: ["/opt/cni/bin/istio-cni-repair"]
           env:
           - name: "REPAIR_NODE-NAME"

--- a/manifests/charts/istio-cni/values.yaml
+++ b/manifests/charts/istio-cni/values.yaml
@@ -32,7 +32,13 @@ cni:
   # Deploy the config files as plugin chain (value "true") or as standalone files in the conf dir (value "false")?
   # Some k8s flavors (e.g. OpenShift) do not support the chain approach, set to false if this is the case
   chained: true
-
+  resources:
+    limits:
+      cpu: 2
+      memory: 4Gi
+    requests:
+      cpu: 4
+      memory: 8Gi
   repair:
     enabled: true
     hub: ""
@@ -45,7 +51,13 @@ cni:
 
     brokenPodLabelKey: "cni.istio.io/uninitialized"
     brokenPodLabelValue: "true"
-
+    resources:
+      limits:
+        cpu: 2
+        memory: 4Gi
+      requests:
+        cpu: 4
+        memory: 8Gi
   # Experimental taint controller for further race condition mitigation
   taint:
     enabled: false


### PR DESCRIPTION
PR lets user to set cpu and memory for cni daemon pods.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ X ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[  ] Does not have any changes that may affect Istio users. 
* Yes
