### PR TITLE
Fix namespace creation in operator

### DIFF
--- a/operator/cmd/mesh/shared.go
+++ b/operator/cmd/mesh/shared.go
@@ -16,7 +16,6 @@
 package mesh
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -26,8 +25,6 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
-	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -35,7 +32,6 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"istio.io/api/label"
 	"istio.io/istio/operator/pkg/apis/istio/v1alpha1"
 	"istio.io/istio/operator/pkg/cache"
 	"istio.io/istio/operator/pkg/helmreconciler"
@@ -244,30 +240,7 @@ func getCRAndNamespaceFromFile(filePath string, l clog.Logger) (customResource s
 
 // createNamespace creates a namespace using the given k8s interface.
 func createNamespace(cs kubernetes.Interface, namespace string, network string) error {
-	if namespace == "" {
-		// Setup default namespace
-		namespace = istioDefaultNamespace
-	}
-	// check if the namespace already exists. If yes, do nothing. If no, create a new one.
-	_, err := cs.CoreV1().Namespaces().Get(context.TODO(), namespace, v12.GetOptions{})
-	if err != nil {
-		if errors.IsNotFound(err) {
-			ns := &v1.Namespace{ObjectMeta: v12.ObjectMeta{
-				Name: namespace,
-			}}
-			if network != "" {
-				ns.Labels[label.TopologyNetwork.Name] = network
-			}
-			_, err := cs.CoreV1().Namespaces().Create(context.TODO(), ns, v12.CreateOptions{})
-			if err != nil {
-				return fmt.Errorf("failed to create namespace %v: %v", namespace, err)
-			}
-		} else {
-			return fmt.Errorf("failed to check if namespace %v exists: %v", namespace, err)
-		}
-	}
-
-	return nil
+	return helmreconciler.CreateNamespace(cs, namespace, network)
 }
 
 // saveIOPToCluster saves the state in an IOP CR in the cluster.


### PR DESCRIPTION
A previous PR attempted to remove the istio-injection label to the
operator namespace creation. However, the code was duplicated, so it
missed part of it. This reconciles the two methods and removes the
duplication.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.