### PR TITLE
Partial cherrypick: Fix various races in push context initialization …

### DIFF
--- a/pilot/pkg/xds/discovery.go
+++ b/pilot/pkg/xds/discovery.go
@@ -266,7 +266,7 @@ func (s *DiscoveryServer) periodicRefreshMetrics(stopCh <-chan struct{}) {
 func (s *DiscoveryServer) Push(req *model.PushRequest) {
 	if !req.Full {
 		req.Push = s.globalPushContext()
-		go s.AdsPushAll(versionInfo(), req)
+		s.AdsPushAll(versionInfo(), req)
 		return
 	}
 	// Reset the status during the push.
@@ -293,7 +293,7 @@ func (s *DiscoveryServer) Push(req *model.PushRequest) {
 	versionMutex.Unlock()
 
 	req.Push = push
-	go s.AdsPushAll(versionLocal, req)
+	s.AdsPushAll(versionLocal, req)
 }
 
 func nonce(noncePrefix string) string {


### PR DESCRIPTION
…(#29872)

concurrent PushContext initialization may lead to storing resulting push
contexts out of order, dropping a later push context. This is fixed by
simply dropping go on AdsPushAll. It doesn't need to be a goroutine
anyways, its not doing any blocking work.

(cherry picked from commit 4eca7f54e79a0585d5c7694851c0e6ad32bde1c9)



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.