### PR TITLE
Fix DNS search namespaces with existing trailing dot

### DIFF
--- a/pilot/pkg/dns/dns.go
+++ b/pilot/pkg/dns/dns.go
@@ -343,8 +343,11 @@ func (table *LookupTable) buildDNSAnswers(altHosts map[string]struct{}, ipv4 []n
 			// do sequential dns resolution, starting with the first search namespace)
 
 			// host h already ends with a .
-			// search namespace does not. So we append one in the end
-			expandedHost := strings.ToLower(h + searchNamespaces[0] + ".")
+			// search namespace might not. So we append one in the end if needed
+			expandedHost := strings.ToLower(h + searchNamespaces[0])
+			if !strings.HasSuffix(searchNamespaces[0], ".") {
+				expandedHost += "."
+			}
 			// make sure this is not a proper hostname
 			// if host is productpage, and search namespace is ns1.svc.cluster.local
 			// then the expanded host productpage.ns1.svc.cluster.local is a valid hostname


### PR DESCRIPTION
Example debian GCE VM:
```
$ cat /etc/resolv.conf
domain c.project-id.internal
search c.project-id.internal. google.internal.
nameserver 169.254.169.254
```

In our code, we were appending the search namespace a dot, so we get
`c.project-id.internal..` which doesn't match. As a result, if a VM and
Service had the same name, the VM took precedence unexpectedly.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.