### PR TITLE
Introduce remote secret name parameter for "istioctl x create-remote-secret"

### DIFF
--- a/istioctl/pkg/multicluster/remote_secret.go
+++ b/istioctl/pkg/multicluster/remote_secret.go
@@ -234,13 +234,25 @@ func getServiceAccountSecret(client kube.ExtendedClient, opt RemoteSecretOptions
 		return nil, err
 	}
 
-	if len(serviceAccount.Secrets) != 1 {
-		return nil, fmt.Errorf("wrong number of secrets (%v) in serviceaccount %s/%s",
+	if len(serviceAccount.Secrets) == 0 {
+		return nil, fmt.Errorf("no secret found in the service account: %s", serviceAccount)
+	}
+
+	if len(serviceAccount.Secrets) != 1 && opt.SecretName == "" {
+		return nil, fmt.Errorf("wrong number of secrets (%v) in serviceaccount %s/%s, please use --secret-name to specify one",
 			len(serviceAccount.Secrets), opt.Namespace, opt.ServiceAccountName)
 	}
 
 	secretName := serviceAccount.Secrets[0].Name
 	secretNamespace := serviceAccount.Secrets[0].Namespace
+	for _, secret := range serviceAccount.Secrets {
+		if secret.Name == opt.SecretName {
+			secretName = secret.Name
+			secretNamespace = secret.Namespace
+			break
+		}
+	}
+
 	if secretNamespace == "" {
 		secretNamespace = opt.Namespace
 	}
@@ -459,6 +471,9 @@ type RemoteSecretOptions struct {
 
 	// ServerOverride overrides the server IP/hostname field from the Kubeconfig
 	ServerOverride string
+
+	// SecretName selects a specific secret from the remote service account, if there are multiple
+	SecretName string
 }
 
 func (o *RemoteSecretOptions) addFlags(flagset *pflag.FlagSet) {
@@ -475,6 +490,8 @@ func (o *RemoteSecretOptions) addFlags(flagset *pflag.FlagSet) {
 			"the local cluster will be used.")
 	flagset.StringVar(&o.ServerOverride, "server", "",
 		"The address and port of the Kubernetes API server.")
+	flagset.StringVar(&o.SecretName, "secret-name", "",
+		"The name of the specific secret to use from the service-account. Needed when there are multiple secrets in the service account.")
 	var supportedAuthType []string
 	for _, at := range []RemoteSecretAuthType{RemoteSecretAuthTypeBearerToken, RemoteSecretAuthTypePlugin} {
 		supportedAuthType = append(supportedAuthType, string(at))

--- a/istioctl/pkg/multicluster/remote_secret_test.go
+++ b/istioctl/pkg/multicluster/remote_secret_test.go
@@ -108,7 +108,9 @@ func TestCreateRemoteSecrets(t *testing.T) {
 	defer func() { makeOutputWriterTestHook = prevOutputWriterStub }()
 
 	sa := makeServiceAccount("saSecret")
+	sa2 := makeServiceAccount("saSecret", "saSecret2")
 	saSecret := makeSecret("saSecret", "caData", "token")
+	saSecret2 := makeSecret("saSecret2", "caData", "token")
 	saSecretMissingToken := makeSecret("saSecret", "caData", "")
 	badStartingConfigErrStr := "could not find cluster for context"
 
@@ -116,10 +118,11 @@ func TestCreateRemoteSecrets(t *testing.T) {
 		testName string
 
 		// test input
-		config  *api.Config
-		objs    []runtime.Object
-		name    string
-		secType SecretType
+		config     *api.Config
+		objs       []runtime.Object
+		name       string
+		secType    SecretType
+		secretName string
 
 		// inject errors
 		badStartingConfig bool
@@ -209,6 +212,38 @@ func TestCreateRemoteSecrets(t *testing.T) {
 			secType: "config",
 			want:    "cal-want",
 		},
+		{
+			testName: "failure due to multiple secrets",
+			objs:     []runtime.Object{kubeSystemNamespace, sa2, saSecret, saSecret2},
+			config: &api.Config{
+				CurrentContext: testContext,
+				Contexts: map[string]*api.Context{
+					testContext: {Cluster: "cluster"},
+				},
+				Clusters: map[string]*api.Cluster{
+					"cluster": {Server: "server"},
+				},
+			},
+			name:       "cluster-foo",
+			want:       "cal-want",
+			wantErrStr: "wrong number of secrets (2) in serviceaccount",
+		},
+		{
+			testName: "success when specific secret name provided",
+			objs:     []runtime.Object{kubeSystemNamespace, sa2, saSecret, saSecret2},
+			config: &api.Config{
+				CurrentContext: testContext,
+				Contexts: map[string]*api.Context{
+					testContext: {Cluster: "cluster"},
+				},
+				Clusters: map[string]*api.Cluster{
+					"cluster": {Server: "server"},
+				},
+			},
+			secretName: saSecret.Name,
+			name:       "cluster-foo",
+			want:       "cal-want",
+		},
 	}
 
 	for i := range cases {
@@ -229,7 +264,8 @@ func TestCreateRemoteSecrets(t *testing.T) {
 					Context:    testContext,
 					Kubeconfig: testKubeconfig,
 				},
-				Type: c.secType,
+				Type:       c.secType,
+				SecretName: c.secretName,
 			}
 
 			env := newFakeEnvironmentOrDie(t, c.config, c.objs...)


### PR DESCRIPTION
In certain managed Kubernetes environments, there may be multiple secrets linked to a newly created ServiceAccount by default (i.e. RedHat OpenShift on IBM Cloud). Following the instructions covered [here](https://istio.io/latest/docs/setup/additional-setup/external-controlplane/#set-up-the-control-plane-in-the-external-cluster) in these environments will fail currently with the following error:

```
❯ istioctl x create-remote-secret \
  --context="${CTX_REMOTE_CLUSTER}" \
  --type=config \
  --namespace=external-istiod
error: could not get access token to read resources from local kube-apiserver: wrong number of secrets (2) in serviceaccount external-istiod/istiod-service-account
```

`istioctl x create-remote-secret` command is currently restricted in a way that it cannot succeed if there are more than one secret linked to the `remote` ServiceAccount, which is the base of the credential generation in the current cluster.
This PR eliminates the limitation by introducing a new CLI parameter for the command. The parameter is required only when there are more than one secrets, which means the functionality is meant to be BW compatible.

[ ] Configuration Infrastructure
[ ] Docs
[x] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[x] Security
[ ] Test and Release
[ ] User Experience
[x] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
