### PR TITLE
enable previously disabled VM tests

### DIFF
--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -882,6 +882,10 @@ func protocolSniffingCases(apps *EchoDeployments) []TrafficTestCase {
 					// Need a sidecar to connect to VMs
 					continue
 				}
+				if apps.VM.Contains(client) && apps.External.Contains(destination) {
+					// VM won't resolve external DNS
+					continue
+				}
 
 				type protocolCase struct {
 					// The port we call

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -883,7 +883,7 @@ func protocolSniffingCases(apps *EchoDeployments) []TrafficTestCase {
 					continue
 				}
 				if apps.VM.Contains(client) && apps.External.Contains(destination) {
-					// VM won't resolve external DNS
+					// TODO VM won't resolve DNS in ServiceEntry https://github.com/istio/istio/issues/27154
 					continue
 				}
 

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -854,8 +854,7 @@ func selfCallsCases(apps *EchoDeployments) []TrafficTestCase {
 // Todo merge with security TestReachability code
 func protocolSniffingCases(apps *EchoDeployments) []TrafficTestCase {
 	cases := []TrafficTestCase{}
-	// TODO add VMs to clients when DNS works for VMs. Blocked by https://github.com/istio/istio/issues/27154
-	for _, clients := range []echo.Instances{apps.PodA, apps.Naked, apps.Headless} {
+	for _, clients := range []echo.Instances{apps.PodA, apps.Naked, apps.Headless, apps.VM} {
 		for _, client := range clients {
 			destinationSets := []echo.Instances{
 				apps.PodA,
@@ -875,8 +874,8 @@ func protocolSniffingCases(apps *EchoDeployments) []TrafficTestCase {
 				destinations := destinations
 				// grabbing the 0th assumes all echos in destinations have the same service name
 				destination := destinations[0]
-				if (apps.Headless.Contains(client) || apps.Headless.Contains(destination)) && len(apps.Headless) > 1 {
-					// TODO(landow) fix DNS issues with multicluster/VMs/headless
+				if apps.Headless.Contains(destination) && len(apps.Headless) > 1 {
+					// TODO(landow) incompatibilities with multicluster & headless
 					continue
 				}
 				if apps.Naked.Contains(client) && apps.VM.Contains(destination) {

--- a/tests/integration/pilot/vm_test.go
+++ b/tests/integration/pilot/vm_test.go
@@ -46,7 +46,6 @@ func GetAdditionVMImages() []string {
 func TestVmOSPost(t *testing.T) {
 	framework.
 		NewTest(t).
-		RequiresSingleCluster(). // TODO(landow) fix DNS issues with multicluster/VMs/headless
 		Features("traffic.reachability").
 		Label(label.Postsubmit).
 		Run(func(ctx framework.TestContext) {

--- a/tests/integration/pilot/vm_test.go
+++ b/tests/integration/pilot/vm_test.go
@@ -52,7 +52,7 @@ func TestVmOSPost(t *testing.T) {
 			if ctx.Settings().SkipVM {
 				ctx.Skip("VM tests are disabled")
 			}
-			b := echoboot.NewBuilder(ctx)
+			b := echoboot.NewBuilder(ctx, ctx.Clusters().Primaries().Default())
 			images := GetAdditionVMImages()
 			for _, image := range images {
 				b = b.WithConfig(echo.Config{


### PR DESCRIPTION
The TODOs to enable these tests have been around a while, could have been enabled a while ago. 

- sniffing from VM to k8s
- VM os tests in multicluster mode