### PR TITLE
remove xds proxy periodic disconnect warning logs

### DIFF
--- a/pkg/istio-agent/xds_proxy.go
+++ b/pkg/istio-agent/xds_proxy.go
@@ -489,6 +489,9 @@ func isExpectedGRPCError(err error) bool {
 	if s.Code() == codes.Unavailable && (s.Message() == "client disconnected" || s.Message() == "transport is closing") {
 		return true
 	}
+	if s.Code() == codes.Internal && (s.Message() == "stream terminated by RST_STREAM with error code: NO_ERROR") {
+		return true
+	}
 	return false
 }
 


### PR DESCRIPTION
xds_proxy logs the following warning for every 30 mins when istiod disconnects it
upstream terminated with unexpected error rpc error: code = Internal desc = stream terminated by RST_STREAM with error code: NO_ERROR
That is not useful. This PR handles that case.
[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X ] Does not have any changes that may affect Istio users.
