### PR TITLE
Fix inbound TLS v2 settings

### DIFF
--- a/pilot/pkg/security/authn/utils/utils.go
+++ b/pilot/pkg/security/authn/utils/utils.go
@@ -86,15 +86,14 @@ func BuildInboundFilterChain(mTLSMode model.MutualTLSMode, sdsUdsPath string, no
 			},
 			RequireClientCertificate: protovalue.BoolTrue,
 		}
+	}
 
-		if features.EnableTLSv2OnInboundPath {
-			// Set Minimum TLS version to match the default client version and allowed strong cipher suites for sidecars.
-			ctx.CommonTlsContext.TlsParams = &tls.TlsParameters{
-				TlsMinimumProtocolVersion: tls.TlsParameters_TLSv1_2,
-				CipherSuites:              SupportedCiphers,
-			}
+	if features.EnableTLSv2OnInboundPath {
+		// Set Minimum TLS version to match the default client version and allowed strong cipher suites for sidecars.
+		ctx.CommonTlsContext.TlsParams = &tls.TlsParameters{
+			TlsMinimumProtocolVersion: tls.TlsParameters_TLSv1_2,
+			CipherSuites:              SupportedCiphers,
 		}
-
 	}
 
 	authn_model.ApplyToCommonTLSContext(ctx.CommonTlsContext, node, sdsUdsPath, []string{} /*subjectAltNames*/, trustDomainAliases)

--- a/pilot/pkg/security/authn/utils/utils_test.go
+++ b/pilot/pkg/security/authn/utils/utils_test.go
@@ -161,7 +161,7 @@ func TestBuildInboundFilterChain(t *testing.T) {
 				node: &model.Proxy{
 					Metadata: &model.NodeMetadata{},
 				},
-				listenerProtocol: networking.ListenerProtocolHTTP,
+				listenerProtocol: networking.ListenerProtocolTCP,
 				trustDomains:     []string{"cluster.local"},
 				tlsV2Enabled:     true,
 			},
@@ -220,7 +220,7 @@ func TestBuildInboundFilterChain(t *testing.T) {
 									},
 								},
 							},
-							AlpnProtocols: []string{"h2", "http/1.1"},
+							AlpnProtocols: []string{"istio-peer-exchange", "h2", "http/1.1"},
 							TlsParams: &auth.TlsParameters{
 								TlsMinimumProtocolVersion: auth.TlsParameters_TLSv1_2,
 								CipherSuites: []string{

--- a/pilot/pkg/security/authn/v1beta1/policy_applier_test.go
+++ b/pilot/pkg/security/authn/v1beta1/policy_applier_test.go
@@ -1339,6 +1339,17 @@ func TestOnInboundFilterChain(t *testing.T) {
 				},
 			},
 			AlpnProtocols: []string{"istio-peer-exchange", "h2", "http/1.1"},
+			TlsParams: &tls.TlsParameters{
+				TlsMinimumProtocolVersion: tls.TlsParameters_TLSv1_2,
+				CipherSuites: []string{
+					"ECDHE-ECDSA-AES256-GCM-SHA384",
+					"ECDHE-RSA-AES256-GCM-SHA384",
+					"ECDHE-ECDSA-AES128-GCM-SHA256",
+					"ECDHE-RSA-AES128-GCM-SHA256",
+					"AES256-GCM-SHA384",
+					"AES128-GCM-SHA256",
+				},
+			},
 		},
 		RequireClientCertificate: protovalue.BoolTrue,
 	}
@@ -1348,7 +1359,6 @@ func TestOnInboundFilterChain(t *testing.T) {
 			TLSContext: tlsContext,
 		},
 	}
-
 	// Two filter chains, one for mtls traffic within the mesh, one for plain text traffic.
 	expectedPermissive := []networking.FilterChain{
 		{

--- a/releasenotes/notes/tls-inbound-all-protocols.yaml
+++ b/releasenotes/notes/tls-inbound-all-protocols.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: security
+releaseNotes:
+- |
+  **Fixed** an issue the TLS minimum version to be set to v1.2 only on HTTP ports. This option is now applied to all ports.

--- a/releasenotes/notes/tls-inbound-all-protocols.yaml
+++ b/releasenotes/notes/tls-inbound-all-protocols.yaml
@@ -3,4 +3,4 @@ kind: bug-fix
 area: security
 releaseNotes:
 - |
-  **Fixed** an issue the TLS minimum version to be set to v1.2 only on HTTP ports. This option is now applied to all ports.
+  **Fixed** an issue where the TLSv2 version was enforced only on HTTP ports. This option is now applied to all ports.


### PR DESCRIPTION
Currently, its accidentally inside the "if protocol == HTTP" clause. I
am pretty sure its intended to be outside of it, so it applies to all
protocol types.
