### PR TITLE
fix defaulting remote cluster values

### DIFF
--- a/pkg/test/framework/components/istio/config.go
+++ b/pkg/test/framework/components/istio/config.go
@@ -135,7 +135,7 @@ type Config struct {
 
 	// Override values specifically for the ICP crd
 	// This is mostly required for cases where --set cannot be used
-	// These values are only applied to config clusters
+	// These values are only applied to remote config clusters
 	// Default value will be ControlPlaneValues if no remote values provided
 	ConfigClusterValues string
 

--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -958,6 +958,10 @@ func createIstioctlConfigFile(workDir string, cfg Config) (istioctlConfigFiles, 
 	}
 
 	// Generate the istioctl config file for remote cluster
+	if cfg.RemoteClusterValues == "" {
+		cfg.RemoteClusterValues = cfg.ControlPlaneValues
+	}
+
 	configFiles.remoteIopFile = filepath.Join(workDir, "remote.yaml")
 	if configFiles.remoteOperatorSpec, err = initIOPFile(cfg, configFiles.remoteIopFile, cfg.RemoteClusterValues); err != nil {
 		return configFiles, err

--- a/tests/integration/security/ecc_signature_algorithm/main_test.go
+++ b/tests/integration/security/ecc_signature_algorithm/main_test.go
@@ -62,7 +62,6 @@ values:
       proxyMetadata:
         ECC_SIGNATURE_ALGORITHM: "ECDSA"
 `
-	cfg.RemoteClusterValues = cfg.ControlPlaneValues
 }
 
 func SetupApps(ctx resource.Context, apps *EchoDeployments) error {


### PR DESCRIPTION
The comment on RemoteClusterValues is:
```
	// Default value will be ControlPlaneValues if no remote values provided
```

But at some point it seems that defaulting was removed. This brings it back. fixes #30592 and fixes #30587 