### PR TITLE
invert if condition revision check for readability

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -25,7 +25,7 @@ spec:
       maxUnavailable: {{ .Values.pilot.rollingMaxUnavailable }}
   selector:
     matchLabels:
-      {{- if ne .Values.revision ""}}
+      {{- if ne .Values.revision "" }}
       app: istiod
       istio.io/rev: {{ .Values.revision | default "default" }}
       {{- else }}
@@ -39,10 +39,10 @@ spec:
         install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
         sidecar.istio.io/inject: "false"
         operator.istio.io/component: "Pilot"
-        {{- if eq .Values.revision ""}}
-        istio: pilot
-        {{- else }}
+        {{- if ne .Values.revision "" }}
         istio: istiod
+        {{- else }}
+        istio: pilot
         {{- end }}
       annotations:
         {{- if .Values.meshConfig.enablePrometheusMerge }}

--- a/manifests/charts/istio-control/istio-discovery/templates/poddisruptionbudget.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/poddisruptionbudget.yaml
@@ -16,7 +16,7 @@ spec:
   selector:
     matchLabels:
       app: istiod
-      {{- if ne .Values.revision ""}}
+      {{- if ne .Values.revision "" }}
       istio.io/rev: {{ .Values.revision }}
       {{- else }}
       istio: pilot

--- a/manifests/charts/istio-control/istio-discovery/templates/service.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/service.yaml
@@ -27,7 +27,7 @@ spec:
       protocol: TCP
   selector:
     app: istiod
-    {{- if ne .Values.revision ""}}
+    {{- if ne .Values.revision "" }}
     istio.io/rev: {{ .Values.revision }}
     {{- else }}
     # Label used by the 'default' service. For versioned deployments we match with app and version.


### PR DESCRIPTION
This is a cosmetic change. Inverting the only instance of `{{- if eq .Values.revision "" }}` to match with the other instances of `{{- if ne .Values.revision "" }}`. Shaves off unnecessary cognitive burden when I revisit charts and inspect `.Values.revision` decision flows

[ ] Configuration Infrastructure
[ ] Docs
[X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any changes that may affect Istio users.
