### PR TITLE
istioctl verify-install: fix empty revision

### DIFF
--- a/istioctl/pkg/verifier/verifier.go
+++ b/istioctl/pkg/verifier/verifier.go
@@ -139,6 +139,7 @@ func (v *StatusVerifier) verifyInstallIOPRevision() error {
 
 func (v *StatusVerifier) getRevision() (string, error) {
 	var revision string
+	var revs string
 	revCount := 0
 	kubeClient, err := v.createClient()
 	if err != nil {
@@ -156,7 +157,12 @@ func (v *StatusVerifier) getRevision() (string, error) {
 		}
 		revision = rev
 	}
-	v.logger.LogAndPrintf("%d Istio control planes detected, checking --revision %q only", revCount, revision)
+	if revision == "" {
+		revs = "default"
+	} else {
+		revs = revision
+	}
+	v.logger.LogAndPrintf("%d Istio control planes detected, checking --revision %q only", revCount, revs)
 	return revision, nil
 }
 


### PR DESCRIPTION
To fix https://github.com/istio/istio/issues/30612

Before:
```
[istio-1.9.0-rc.0]$ istioctl verify-install
1 Istio control planes detected, checking --revision "" only
✔ ClusterRole: istiod-istio-system.istio-system checked successfully
✔ ClusterRole: istio-reader-istio-system.istio-system checked successfully
```

After:
```
[istio-master]$ ./out/linux_amd64/istioctl verify-install
1 Istio control planes detected, checking --revision "default" only
✔ HorizontalPodAutoscaler: istio-ingressgateway.istio-system checked successfully
✔ Deployment: istio-ingressgateway.istio-system checked successfully
```

```
[istio-master]$ istioctl install -r 1-10-0

[istio-master]$ ./out/linux_amd64/istioctl verify-install
1 Istio control planes detected, checking --revision "1-10-0" only
✔ ClusterRole: istiod-istio-system.istio-system checked successfully
✔ ClusterRole: istio-reader-istio-system.istio-system checked successfully
```