### PR TITLE
Added the proxy information to the call that builds the inbound cluster name.

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -341,7 +341,7 @@ func (configgen *ConfigGeneratorImpl) buildInboundClusters(cb *ClusterBuilder, i
 		instance.Endpoint.ServicePortName = listenPort.Name
 		instance.Endpoint.EndpointPort = uint32(port)
 
-		localCluster := cb.buildInboundClusterForPortOrUDS(nil, int(ingressListener.Port.Number), endpointAddress, instance, nil)
+		localCluster := cb.buildInboundClusterForPortOrUDS(cb.proxy, int(ingressListener.Port.Number), endpointAddress, instance, nil)
 		if instanceIPCluster {
 			// IPTables will redirect our own traffic back to us if we do not use the "magic" upstream bind
 			// config which will be skipped. This mirrors the "passthrough" clusters.


### PR DESCRIPTION
This PR fixes an issue in which the inbound cluster name is constructed incorrectly. This issue appears when the control plane is updated from some version < 1.8.0 to some version > 1.8.0 and there is a Sidecar resource specified.

Specifically the configuration generated for a version of istio-proxy < 1.8.0, the inbound route refers to a cluster with the name `inbound|8088|http2|<svc>.<namespace>`. The name of the inbound cluster that the route should be referring to is actually `inbound|8088||` (due to a change made in Istio 1.8.0). This configuration causes these older `istio-proxy` containers to fail to forward the requests to the service container and instead return a `503 NR`.

This change ensures that the `buildInboundClusterForPortOrUDS` has the `istio-proxy` version information it needs to correctly build the inbound clusters when a Sidecar resource is specified.


[x] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.