### PR TITLE
[release-1.9] set MaxEjectionTime to BaseEjectionTime if it is greater than 300s 

### DIFF
--- a/releasenotes/notes/30181.yaml
+++ b/releasenotes/notes/30181.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: networking
+issue:
+  - 30181
+releaseNotes:
+  - |
+    **Fixed** a bug when baseEjectionTime is greater than 300s, envoy will send a NACK to cds .

--- a/tests/integration/pilot/locality_test.go
+++ b/tests/integration/pilot/locality_test.go
@@ -73,7 +73,7 @@ spec:
 {{.LocalitySetting | indent 8 }}
     outlierDetection:
       interval: 1s
-      baseEjectionTime: 3m
+      baseEjectionTime: 10m # if baseEjectionTime > default maxEjectionTime(300s), the maxEjectionTime will be upgraded
       maxEjectionPercent: 100`
 
 type LocalityInput struct {


### PR DESCRIPTION
cherry-pick #30602

fix: #30648

