### PR TITLE
Manual cherry-pick global DestinationRule …

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -410,6 +410,12 @@ var (
 		"If enabled, Envoy will be configured to prevent traffic directly the the inbound/outbound "+
 			"ports (15001/15006). This prevents traffic loops. This option will be removed, and considered always enabled, in 1.9.").Get()
 
+	EnableDestinationRuleInheritance = env.RegisterBoolVar(
+		"PILOT_ENABLE_DESTINATION_RULE_INHERITANCE",
+		false,
+		"If set, workload specific DestinationRules will inherit configurations settings from mesh and namespace level rules",
+	).Get()
+
 	StatusMaxWorkers = env.RegisterIntVar("PILOT_STATUS_MAX_WORKERS", 100, "The maximum number of workers"+
 		" Pilot will use to keep configuration status up to date.  Smaller numbers will result in higher status latency, "+
 		"but larger numbers may impact CPU in high scale environments.")

--- a/releasenotes/notes/merge-dr.yaml
+++ b/releasenotes/notes/merge-dr.yaml
@@ -1,0 +1,26 @@
+apiVersion: release-notes/v2
+
+# This YAML file describes the format for specifying a release notes entry for Istio.
+# This should be filled in for all user facing changes.
+
+# kind describes the type of change that this represents.
+# Valid Values are:
+# - bug-fix -- Used to specify that this change represents a bug fix.
+# - security-fix -- Used to specify that this change represents a security fix.
+# - feature -- Used to specify a new feature that has been added.
+# - test -- Used to describe additional testing added. This file is optional for
+#   tests, but included for completeness.
+kind: feature
+
+area: traffic-management
+
+# issue is a list of GitHub issues resolved in this note.
+# If issue is not in the current repo, specify its full URL instead.
+issue: 
+- 29525
+
+# releaseNotes is a markdown listing of any user facing changes. This will appear in the
+# release notes.
+releaseNotes:
+- |
+  **Added** support for DestinationRule inheritance for mesh/namespace level rules. Enable feature with `PILOT_ENABLE_DESTINATION_RULE_INHERITANCE` environment variable.


### PR DESCRIPTION
resolves https://github.com/istio/istio/issues/30657

* add feature flag for destination rules inheritance

* implement destination rule inheritance during push context init

* unit tests for destination rule inheritance

* update validation logic for inherited destination rules

* added release note

* unset feature flag after test completes

* allow TLS contexts, don't allow exportTo field

* use proto.Merge to simplify

* use correct proto.Merge package, special logic for TLS context merging

* don't allow portlevelsettings in global DR

* more unit tests

* handle Service DRs exported to other namespaces

* feature flag rename



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.