### PR TITLE
merge the ResolveJwksURI into refresh() function

### DIFF
--- a/pilot/pkg/model/authentication.go
+++ b/pilot/pkg/model/authentication.go
@@ -110,9 +110,6 @@ func initAuthenticationPolicies(env *Environment) (*AuthenticationPolicies, erro
 
 func (policy *AuthenticationPolicies) addRequestAuthentication(configs []config.Config) {
 	for _, config := range configs {
-		reqPolicy := config.Spec.(*v1beta1.RequestAuthentication)
-		// Follow OIDC discovery to resolve JwksURI if need to.
-		GetJwtKeyResolver().ResolveJwksURI(reqPolicy)
 		policy.requestAuthentications[config.Namespace] =
 			append(policy.requestAuthentications[config.Namespace], config)
 	}

--- a/pilot/pkg/model/authentication_test.go
+++ b/pilot/pkg/model/authentication_test.go
@@ -607,8 +607,6 @@ func TestGetPoliciesForWorkloadWithJwksResolver(t *testing.T) {
 		t.Fatal("failed to start a mock server")
 	}
 
-	mockCertURL := ms.URL + "/oauth2/v3/certs"
-
 	policies := getTestAuthenticationPolicies(createNonTrivialRequestAuthnTestConfigs(ms.URL), t)
 
 	cases := []struct {
@@ -631,8 +629,7 @@ func TestGetPoliciesForWorkloadWithJwksResolver(t *testing.T) {
 					Spec: &securityBeta.RequestAuthentication{
 						JwtRules: []*securityBeta.JWTRule{
 							{
-								Issuer:  ms.URL,
-								JwksUri: mockCertURL,
+								Issuer: ms.URL,
 							},
 						},
 					},
@@ -653,8 +650,7 @@ func TestGetPoliciesForWorkloadWithJwksResolver(t *testing.T) {
 					Spec: &securityBeta.RequestAuthentication{
 						JwtRules: []*securityBeta.JWTRule{
 							{
-								Issuer:  ms.URL,
-								JwksUri: mockCertURL,
+								Issuer: ms.URL,
 							},
 						},
 					},
@@ -673,8 +669,7 @@ func TestGetPoliciesForWorkloadWithJwksResolver(t *testing.T) {
 						},
 						JwtRules: []*securityBeta.JWTRule{
 							{
-								Issuer:  ms.URL,
-								JwksUri: mockCertURL,
+								Issuer: ms.URL,
 							},
 							{
 								Issuer: "bad-issuer",
@@ -723,8 +718,7 @@ func TestGetPoliciesForWorkloadWithJwksResolver(t *testing.T) {
 					Spec: &securityBeta.RequestAuthentication{
 						JwtRules: []*securityBeta.JWTRule{
 							{
-								Issuer:  ms.URL,
-								JwksUri: mockCertURL,
+								Issuer: ms.URL,
 							},
 						},
 					},
@@ -743,8 +737,7 @@ func TestGetPoliciesForWorkloadWithJwksResolver(t *testing.T) {
 						},
 						JwtRules: []*securityBeta.JWTRule{
 							{
-								Issuer:  ms.URL,
-								JwksUri: mockCertURL,
+								Issuer: ms.URL,
 							},
 							{
 								Issuer: "bad-issuer",

--- a/pilot/pkg/model/jwks_resolver.go
+++ b/pilot/pkg/model/jwks_resolver.go
@@ -338,17 +338,21 @@ func (r *JwksResolver) getRemoteContentWithRetry(uri string, retry int) ([]byte,
 
 func (r *JwksResolver) refresher() {
 	// Wake up once in a while and refresh stale items.
+	r.mu.Lock()
 	r.refreshTicker = time.NewTicker(r.refreshInterval)
+	r.mu.Unlock()
 	for {
 		select {
 		case <-r.refreshTicker.C:
 			useDefault := r.refresh()
+			r.mu.Lock()
 			r.refreshTicker.Stop()
 			if useDefault {
 				r.refreshTicker = time.NewTicker(r.refreshDefaultInterval)
 			} else {
 				r.refreshTicker = time.NewTicker(r.refreshInterval)
 			}
+			r.mu.Unlock()
 		case <-closeChan:
 			r.refreshTicker.Stop()
 			return

--- a/pilot/pkg/model/jwks_resolver.go
+++ b/pilot/pkg/model/jwks_resolver.go
@@ -18,6 +18,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -220,6 +221,8 @@ func newJwksResolverWithCABundlePaths(
 	return ret
 }
 
+var errEmptyPubKeyFoundInCache = errors.New("empty public key found in cache")
+
 // GetPublicKey gets JWT public key and cache the key for future use.
 func (r *JwksResolver) GetPublicKey(issuer string, jwksURI string) (string, error) {
 	now := time.Now()
@@ -229,6 +232,9 @@ func (r *JwksResolver) GetPublicKey(issuer string, jwksURI string) (string, erro
 		// Update cached key's last used time.
 		e.lastUsedTime = now
 		r.keyEntries.Store(key, e)
+		if e.pubKey == "" {
+			return e.pubKey, errEmptyPubKeyFoundInCache
+		}
 		return e.pubKey, nil
 	}
 

--- a/pilot/pkg/model/jwks_resolver.go
+++ b/pilot/pkg/model/jwks_resolver.go
@@ -30,6 +30,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/pkg/monitoring"
 )
 
@@ -46,9 +47,6 @@ const (
 	// Cached item will be removed from the cache if it hasn't been used longer than JwtPubKeyEvictionDuration or if pilot
 	// has failed to refresh it for more than JwtPubKeyEvictionDuration.
 	JwtPubKeyEvictionDuration = 24 * 7 * time.Hour
-
-	// JwtPubKeyRefreshInterval is the running interval of JWT pubKey refresh job on default.
-	JwtPubKeyRefreshInterval = time.Minute * 20
 
 	// JwtPubKeyRefreshIntervalOnFailure is the running interval of JWT pubKey refresh job on failure.
 	JwtPubKeyRefreshIntervalOnFailure = time.Minute

--- a/pilot/pkg/model/jwks_resolver.go
+++ b/pilot/pkg/model/jwks_resolver.go
@@ -425,12 +425,6 @@ func (r *JwksResolver) refresh() time.Duration {
 	// Wait for all go routine to complete.
 	wg.Wait()
 
-	if hasErrors {
-		r.refreshInterval = r.refreshIntervalOnFailure
-	} else {
-		r.refreshInterval = r.refreshDefaultInterval
-	}
-
 	if hasChange {
 		atomic.AddUint64(&r.refreshJobKeyChangedCount, 1)
 		// Push public key changes to sidecars.

--- a/pilot/pkg/model/jwks_resolver.go
+++ b/pilot/pkg/model/jwks_resolver.go
@@ -29,8 +29,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"istio.io/api/security/v1beta1"
-	"istio.io/pkg/cache"
 	"istio.io/pkg/monitoring"
 )
 
@@ -43,21 +41,16 @@ const (
 	// OpenID Discovery web request timeout.
 	jwksHTTPTimeOutInSec = 5
 
-	// JwksURI Cache expiration time duration, individual cached JwksURI item will be removed
-	// from cache after its duration expires.
-	jwksURICacheExpiration = time.Hour * 24
-
-	// JwksURI Cache eviction time duration, cache eviction is done on a periodic basis,
-	// jwksURICacheEviction specifies the frequency at which eviction activities take place.
-	jwksURICacheEviction = time.Minute * 30
-
 	// JwtPubKeyEvictionDuration is the life duration for cached item.
 	// Cached item will be removed from the cache if it hasn't been used longer than JwtPubKeyEvictionDuration or if pilot
 	// has failed to refresh it for more than JwtPubKeyEvictionDuration.
 	JwtPubKeyEvictionDuration = 24 * 7 * time.Hour
 
-	// JwtPubKeyRefreshInterval is the running interval of JWT pubKey refresh job.
+	// JwtPubKeyRefreshInterval is the running interval of JWT pubKey refresh job on default.
 	JwtPubKeyRefreshInterval = time.Minute * 20
+
+	// JwtPubKeyRefreshIntervalOnFailure is the running interval of JWT pubKey refresh job on failure.
+	JwtPubKeyRefreshIntervalOnFailure = time.Minute
 
 	// JwtPubKeyRetryInterval is the retry interval between the attempt to retry getting the remote
 	// content from network.
@@ -106,16 +99,19 @@ type jwtPubKeyEntry struct {
 	lastUsedTime time.Time
 }
 
+// jwtKey is a key in the JwksResolver keyEntries map.
+type jwtKey struct {
+	jwksURI string
+	issuer  string
+}
+
 // JwksResolver is resolver for jwksURI and jwt public key.
 type JwksResolver struct {
-	// cache for jwksURI.
-	JwksURICache cache.ExpiringCache
-
 	// Callback function to invoke when detecting jwt public key change.
 	PushFunc func()
 
 	// cache for JWT public key.
-	// map key is jwksURI, map value is jwtPubKeyEntry.
+	// map key is jwtKey, map value is jwtPubKeyEntry.
 	keyEntries sync.Map
 
 	secureHTTPClient *http.Client
@@ -127,6 +123,12 @@ type JwksResolver struct {
 
 	// Refresher job running interval.
 	refreshInterval time.Duration
+
+	// Refresher job running interval on failure.
+	refreshIntervalOnFailure time.Duration
+
+	// Refresher job default running interval without failure.
+	refreshDefaultInterval time.Duration
 
 	retryInterval time.Duration
 
@@ -141,11 +143,12 @@ func init() {
 	monitoring.MustRegister(networkFetchSuccessCounter, networkFetchFailCounter)
 }
 
-// NewJwksResolver creates new instance of JwksResolver.
-func NewJwksResolver(evictionDuration, refreshInterval, retryInterval time.Duration) *JwksResolver {
+// newJwksResolver creates new instance of JwksResolver.
+func newJwksResolver(evictionDuration, refreshDefaultInterval, refreshIntervalOnFailure, retryInterval time.Duration) *JwksResolver {
 	return newJwksResolverWithCABundlePaths(
 		evictionDuration,
-		refreshInterval,
+		refreshDefaultInterval,
+		refreshIntervalOnFailure,
 		retryInterval,
 		[]string{jwksExtraRootCABundlePath},
 	)
@@ -154,17 +157,24 @@ func NewJwksResolver(evictionDuration, refreshInterval, retryInterval time.Durat
 // GetJwtKeyResolver lazy-creates JwtKeyResolver resolves JWT public key and JwksURI.
 func GetJwtKeyResolver() *JwksResolver {
 	jwtKeyResolverOnce.Do(func() {
-		jwtKeyResolver = NewJwksResolver(JwtPubKeyEvictionDuration, JwtPubKeyRefreshInterval, JwtPubKeyRetryInterval)
+		jwtKeyResolver = newJwksResolver(JwtPubKeyEvictionDuration, JwtPubKeyRefreshInterval, JwtPubKeyRefreshIntervalOnFailure, JwtPubKeyRetryInterval)
 	})
 	return jwtKeyResolver
 }
 
-func newJwksResolverWithCABundlePaths(evictionDuration, refreshInterval, retryInterval time.Duration, caBundlePaths []string) *JwksResolver {
+func newJwksResolverWithCABundlePaths(
+	evictionDuration,
+	refreshDefaultInterval,
+	refreshIntervalOnFailure,
+	retryInterval time.Duration,
+	caBundlePaths []string,
+) *JwksResolver {
 	ret := &JwksResolver{
-		JwksURICache:     cache.NewTTL(jwksURICacheExpiration, jwksURICacheEviction),
-		evictionDuration: evictionDuration,
-		refreshInterval:  refreshInterval,
-		retryInterval:    retryInterval,
+		evictionDuration:         evictionDuration,
+		refreshInterval:          refreshDefaultInterval,
+		refreshDefaultInterval:   refreshDefaultInterval,
+		refreshIntervalOnFailure: refreshIntervalOnFailure,
+		retryInterval:            retryInterval,
 		httpClient: &http.Client{
 			Timeout: jwksHTTPTimeOutInSec * time.Second,
 			Transport: &http.Transport{
@@ -207,31 +217,28 @@ func newJwksResolverWithCABundlePaths(evictionDuration, refreshInterval, retryIn
 	return ret
 }
 
-// ResolveJwksURI sets jwks_uri through openID discovery if it's not set in request authentication policy.
-func (r *JwksResolver) ResolveJwksURI(policy *v1beta1.RequestAuthentication) {
-	for _, rule := range policy.JwtRules {
-		if rule.JwksUri == "" && rule.Jwks == "" {
-			if uri, err := r.resolveJwksURIUsingOpenID(rule.Issuer); err == nil {
-				rule.JwksUri = uri
-			} else {
-				log.Warnf("Failed to get jwks_uri for issuer %q: %v", rule.Issuer, err)
-			}
-		}
-	}
-}
-
 // GetPublicKey gets JWT public key and cache the key for future use.
-func (r *JwksResolver) GetPublicKey(jwksURI string) (string, error) {
+func (r *JwksResolver) GetPublicKey(issuer string, jwksURI string) (string, error) {
 	now := time.Now()
-	if val, found := r.keyEntries.Load(jwksURI); found {
+	key := jwtKey{issuer: issuer, jwksURI: jwksURI}
+	if val, found := r.keyEntries.Load(key); found {
 		e := val.(jwtPubKeyEntry)
 		// Update cached key's last used time.
 		e.lastUsedTime = now
-		r.keyEntries.Store(jwksURI, e)
+		r.keyEntries.Store(key, e)
 		return e.pubKey, nil
 	}
 
-	// Fetch key if it's not cached.
+	if jwksURI == "" {
+		// Fetch the jwks URI if it is not hardcoded on config.
+		var err error
+		jwksURI, err = r.resolveJwksURIUsingOpenID(issuer)
+		if err != nil {
+			log.Errorf("Failed to jwks URI from %q: %v", issuer, err)
+			return "", err
+		}
+	}
+
 	resp, err := r.getRemoteContentWithRetry(jwksURI, networkFetchRetryCountOnMainFlow)
 	if err != nil {
 		log.Errorf("Failed to fetch public key from %q: %v", jwksURI, err)
@@ -239,7 +246,7 @@ func (r *JwksResolver) GetPublicKey(jwksURI string) (string, error) {
 	}
 
 	pubKey := string(resp)
-	r.keyEntries.Store(jwksURI, jwtPubKeyEntry{
+	r.keyEntries.Store(key, jwtPubKeyEntry{
 		pubKey:            pubKey,
 		lastRefreshedTime: now,
 		lastUsedTime:      now,
@@ -248,13 +255,8 @@ func (r *JwksResolver) GetPublicKey(jwksURI string) (string, error) {
 	return pubKey, nil
 }
 
-// Resolve jwks_uri through openID discovery and cache the jwks_uri for future use.
+// Resolve jwks_uri through openID discovery.
 func (r *JwksResolver) resolveJwksURIUsingOpenID(issuer string) (string, error) {
-	// Set policyJwt.JwksUri if the JwksUri could be found in cache.
-	if uri, found := r.JwksURICache.Get(issuer); found {
-		return uri.(string), nil
-	}
-
 	// Try to get jwks_uri through OpenID Discovery.
 	body, err := r.getRemoteContentWithRetry(issuer+openIDDiscoveryCfgURLSuffix, networkFetchRetryCountOnMainFlow)
 	if err != nil {
@@ -270,9 +272,6 @@ func (r *JwksResolver) resolveJwksURIUsingOpenID(issuer string) (string, error) 
 	if !ok {
 		return "", fmt.Errorf("invalid jwks_uri %v in openID discovery configuration", data["jwks_uri"])
 	}
-
-	// Set JwksUri in cache.
-	r.JwksURICache.Set(issuer, jwksURI)
 
 	return jwksURI, nil
 }
@@ -340,7 +339,12 @@ func (r *JwksResolver) refresher() {
 	for {
 		select {
 		case <-r.refreshTicker.C:
-			r.refresh()
+			refreshInterval := r.refresh()
+			// update refresh interval on change.
+			if r.refreshInterval != refreshInterval {
+				r.refreshTicker.Stop()
+				r.refreshTicker = time.NewTicker(refreshInterval)
+			}
 		case <-closeChan:
 			r.refreshTicker.Stop()
 			return
@@ -348,13 +352,14 @@ func (r *JwksResolver) refresher() {
 	}
 }
 
-func (r *JwksResolver) refresh() {
+func (r *JwksResolver) refresh() time.Duration {
 	var wg sync.WaitGroup
 	hasChange := false
+	hasErrors := false
 
 	r.keyEntries.Range(func(key interface{}, value interface{}) bool {
 		now := time.Now()
-		jwksURI := key.(string)
+		k := key.(jwtKey)
 		e := value.(jwtPubKeyEntry)
 
 		// Remove cached item for either of the following 2 situations
@@ -364,8 +369,8 @@ func (r *JwksResolver) refresh() {
 		// with no success refresh for too much time.
 		if now.Sub(e.lastUsedTime) >= r.evictionDuration || now.Sub(e.lastRefreshedTime) >= r.evictionDuration {
 			log.Infof("Removed cached JWT public key (lastRefreshed: %s, lastUsed: %s) from %q",
-				e.lastRefreshedTime, e.lastUsedTime, jwksURI)
-			r.keyEntries.Delete(jwksURI)
+				e.lastRefreshedTime, e.lastUsedTime, k.issuer)
+			r.keyEntries.Delete(k)
 			return true
 		}
 
@@ -377,21 +382,34 @@ func (r *JwksResolver) refresh() {
 		go func() {
 			// Decrement the counter when the goroutine completes.
 			defer wg.Done()
+			jwksURI := k.jwksURI
+			if jwksURI == "" {
+				var err error
+				jwksURI, err = r.resolveJwksURIUsingOpenID(k.issuer)
+				if err != nil {
+					hasErrors = true
+					log.Errorf("Failed to resolve Jwks from issuer %q: %v", k.issuer, err)
+					atomic.AddUint64(&r.refreshJobFetchFailedCount, 1)
+					return
+				}
+			}
 
 			resp, err := r.getRemoteContentWithRetry(jwksURI, networkFetchRetryCountOnRefreshFlow)
 			if err != nil {
+				hasErrors = true
 				log.Errorf("Failed to refresh JWT public key from %q: %v", jwksURI, err)
 				atomic.AddUint64(&r.refreshJobFetchFailedCount, 1)
 				return
 			}
 			newPubKey := string(resp)
-			r.keyEntries.Store(jwksURI, jwtPubKeyEntry{
+			r.keyEntries.Store(k, jwtPubKeyEntry{
 				pubKey:            newPubKey,
 				lastRefreshedTime: now,            // update the lastRefreshedTime if we get a success response from the network.
 				lastUsedTime:      e.lastUsedTime, // keep original lastUsedTime.
 			})
 			isNewKey, err := compareJWKSResponse(oldPubKey, newPubKey)
 			if err != nil {
+				hasErrors = true
 				log.Errorf("Failed to refresh JWT public key from %q: %v", jwksURI, err)
 				return
 			}
@@ -407,6 +425,12 @@ func (r *JwksResolver) refresh() {
 	// Wait for all go routine to complete.
 	wg.Wait()
 
+	if hasErrors {
+		r.refreshInterval = r.refreshIntervalOnFailure
+	} else {
+		r.refreshInterval = r.refreshDefaultInterval
+	}
+
 	if hasChange {
 		atomic.AddUint64(&r.refreshJobKeyChangedCount, 1)
 		// Push public key changes to sidecars.
@@ -414,9 +438,13 @@ func (r *JwksResolver) refresh() {
 			r.PushFunc()
 		}
 	}
+	if hasErrors {
+		return r.refreshIntervalOnFailure
+	}
+	return r.refreshDefaultInterval
 }
 
-// Shut down the refresher job.
+// Close will shut down the refresher job.
 // TODO: may need to figure out the right place to call this function.
 // (right now calls it from initDiscoveryService in pkg/bootstrap/server.go).
 func (r *JwksResolver) Close() {

--- a/pilot/pkg/model/jwks_resolver_test.go
+++ b/pilot/pkg/model/jwks_resolver_test.go
@@ -16,14 +16,12 @@ package model
 
 import (
 	"fmt"
-	"reflect"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"go.opencensus.io/stats/view"
 
-	"istio.io/api/security/v1beta1"
 	"istio.io/istio/pilot/pkg/model/test"
 	"istio.io/istio/pkg/test/util/retry"
 )
@@ -31,7 +29,7 @@ import (
 const testRetryInterval = time.Millisecond * 10
 
 func TestResolveJwksURIUsingOpenID(t *testing.T) {
-	r := NewJwksResolver(JwtPubKeyEvictionDuration, JwtPubKeyRefreshInterval, testRetryInterval)
+	r := newJwksResolver(JwtPubKeyEvictionDuration, JwtPubKeyRefreshInterval, JwtPubKeyRefreshIntervalOnFailure, testRetryInterval)
 	defer r.Close()
 
 	ms, err := test.StartNewServer()
@@ -70,116 +68,18 @@ func TestResolveJwksURIUsingOpenID(t *testing.T) {
 				c.in, c.expectedJwksURI, jwksURI)
 		}
 	}
+	jwksURI, err := r.resolveJwksURIUsingOpenID("http://xyz")
+	t.Logf("jwks: %s, err: %s", jwksURI, err)
+	t.Logf("%v", r.keyEntries)
 
-	// Verify mock openID discovery http://localhost:9999/.well-known/openid-configuration was only called once because of the cache.
-	if got, want := ms.OpenIDHitNum, uint64(1); got != want {
+	// Verify mock openID discovery http://localhost:9999/.well-known/openid-configuration was called twice.
+	if got, want := ms.OpenIDHitNum, uint64(2); got != want {
 		t.Errorf("Mock OpenID discovery Hit number => expected %d but got %d", want, got)
 	}
 }
 
-func TestResolveJwksURI(t *testing.T) {
-	r := NewJwksResolver(JwtPubKeyEvictionDuration, JwtPubKeyRefreshInterval, testRetryInterval)
-	defer r.Close()
-
-	ms, err := test.StartNewServer()
-	defer ms.Stop()
-	if err != nil {
-		t.Fatal("failed to start a mock server")
-	}
-
-	mockCertURL := ms.URL + "/oauth2/v3/certs"
-
-	cases := []struct {
-		name     string
-		in       *v1beta1.RequestAuthentication
-		expected []string
-	}{
-		{
-			name: "single jwt",
-			in: &v1beta1.RequestAuthentication{
-				JwtRules: []*v1beta1.JWTRule{
-					{
-						Issuer: ms.URL,
-					},
-				},
-			},
-			expected: []string{mockCertURL},
-		},
-		{
-			name: "duplicate single jwt",
-			in: &v1beta1.RequestAuthentication{
-				JwtRules: []*v1beta1.JWTRule{
-					{
-						Issuer: ms.URL,
-					},
-					{
-						Issuer: ms.URL,
-					},
-				},
-			},
-			expected: []string{mockCertURL, mockCertURL},
-		},
-		{
-			name: "bad one",
-			in: &v1beta1.RequestAuthentication{
-				JwtRules: []*v1beta1.JWTRule{
-					{
-						Issuer: "bad-one",
-					},
-					{
-						Issuer: ms.URL,
-					},
-				},
-			},
-			expected: []string{"", mockCertURL},
-		},
-		{
-			name: "JwksURI provided",
-			in: &v1beta1.RequestAuthentication{
-				JwtRules: []*v1beta1.JWTRule{
-					{
-						Issuer:  "jwks URI provided",
-						JwksUri: "example.com",
-					},
-					{
-						Issuer: ms.URL,
-					},
-				},
-			},
-			expected: []string{"example.com", mockCertURL},
-		},
-		{
-			name: "Jwks provided",
-			in: &v1beta1.RequestAuthentication{
-				JwtRules: []*v1beta1.JWTRule{
-					{
-						Issuer: "jwks provided",
-						Jwks:   "deadbeef",
-					},
-					{
-						Issuer: ms.URL,
-					},
-				},
-			},
-			expected: []string{"", mockCertURL},
-		},
-	}
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			r.ResolveJwksURI(c.in)
-			got := make([]string, 0, len(c.in.JwtRules))
-			for _, rule := range c.in.JwtRules {
-				got = append(got, rule.JwksUri)
-			}
-			if !reflect.DeepEqual(c.expected, got) {
-				t.Errorf("want %v, got %v", c.expected, c.in)
-			}
-		})
-	}
-}
-
 func TestGetPublicKey(t *testing.T) {
-	r := NewJwksResolver(JwtPubKeyEvictionDuration, JwtPubKeyRefreshInterval, testRetryInterval)
+	r := newJwksResolver(JwtPubKeyEvictionDuration, JwtPubKeyRefreshInterval, JwtPubKeyRefreshIntervalOnFailure, testRetryInterval)
 	defer r.Close()
 
 	ms, err := test.StartNewServer()
@@ -191,25 +91,25 @@ func TestGetPublicKey(t *testing.T) {
 	mockCertURL := ms.URL + "/oauth2/v3/certs"
 
 	cases := []struct {
-		in                string
+		in                []string
 		expectedJwtPubkey string
 	}{
 		{
-			in:                mockCertURL,
+			in:                []string{"testIssuer", mockCertURL},
 			expectedJwtPubkey: test.JwtPubKey1,
 		},
 		{
-			in:                mockCertURL, // Send two same request, mock server is expected to hit only once because of the cache.
+			in:                []string{"testIssuer", mockCertURL}, // Send two same request, mock server is expected to hit only once because of the cache.
 			expectedJwtPubkey: test.JwtPubKey1,
 		},
 	}
 	for _, c := range cases {
-		pk, err := r.GetPublicKey(c.in)
+		pk, err := r.GetPublicKey(c.in[0], c.in[1])
 		if err != nil {
-			t.Errorf("GetPublicKey(%+v) fails: expected no error, got (%v)", c.in, err)
+			t.Errorf("GetPublicKey(\"\", %+v) fails: expected no error, got (%v)", c.in, err)
 		}
 		if c.expectedJwtPubkey != pk {
-			t.Errorf("GetPublicKey(%+v): expected (%s), got (%s)", c.in, c.expectedJwtPubkey, pk)
+			t.Errorf("GetPublicKey(\"\", %+v): expected (%s), got (%s)", c.in, c.expectedJwtPubkey, pk)
 		}
 	}
 
@@ -220,7 +120,7 @@ func TestGetPublicKey(t *testing.T) {
 }
 
 func TestGetPublicKeyReorderedKey(t *testing.T) {
-	r := NewJwksResolver(JwtPubKeyEvictionDuration, testRetryInterval*20, testRetryInterval)
+	r := newJwksResolver(JwtPubKeyEvictionDuration, testRetryInterval*20, testRetryInterval*10, testRetryInterval)
 	defer r.Close()
 
 	ms, err := test.StartNewServer()
@@ -233,37 +133,37 @@ func TestGetPublicKeyReorderedKey(t *testing.T) {
 	mockCertURL := ms.URL + "/oauth2/v3/certs"
 
 	cases := []struct {
-		in                string
+		in                []string
 		expectedJwtPubkey string
 	}{
 		{
-			in:                mockCertURL,
+			in:                []string{"", mockCertURL},
 			expectedJwtPubkey: test.JwtPubKey1,
 		},
 		{
-			in:                mockCertURL, // Send two same request, mock server is expected to hit only once because of the cache.
+			in:                []string{"", mockCertURL}, // Send two same request, mock server is expected to hit only once because of the cache.
 			expectedJwtPubkey: test.JwtPubKey1Reordered,
 		},
 	}
 	for _, c := range cases {
-		pk, err := r.GetPublicKey(c.in)
+		pk, err := r.GetPublicKey(c.in[0], c.in[1])
 		if err != nil {
-			t.Errorf("GetPublicKey(%+v) fails: expected no error, got (%v)", c.in, err)
+			t.Errorf("GetPublicKey(\"\", %+v) fails: expected no error, got (%v)", c.in, err)
 		}
 		if c.expectedJwtPubkey != pk {
-			t.Errorf("GetPublicKey(%+v): expected (%s), got (%s)", c.in, c.expectedJwtPubkey, pk)
+			t.Errorf("GetPublicKey(\"\", %+v): expected (%s), got (%s)", c.in, c.expectedJwtPubkey, pk)
 		}
 		r.refresh()
 	}
 
-	// Verify mock server http://localhost:9999/oauth2/v3/certs was only called once because of the cache.
+	// Verify refresh job key changed count is zero.
 	if got, want := r.refreshJobKeyChangedCount, uint64(0); got != want {
 		t.Errorf("JWKs Resolver Refreshed Key Count => expected %d but got %d", want, got)
 	}
 }
 
 func TestGetPublicKeyUsingTLS(t *testing.T) {
-	r := newJwksResolverWithCABundlePaths(JwtPubKeyEvictionDuration, JwtPubKeyRefreshInterval, testRetryInterval, []string{"./test/testcert/cert.pem"})
+	r := newJwksResolverWithCABundlePaths(JwtPubKeyEvictionDuration, JwtPubKeyRefreshInterval, JwtPubKeyRefreshIntervalOnFailure, testRetryInterval, []string{"./test/testcert/cert.pem"})
 	defer r.Close()
 
 	ms, err := test.StartNewTLSServer("./test/testcert/cert.pem", "./test/testcert/key.pem")
@@ -273,17 +173,23 @@ func TestGetPublicKeyUsingTLS(t *testing.T) {
 	}
 
 	mockCertURL := ms.URL + "/oauth2/v3/certs"
-	pk, err := r.GetPublicKey(mockCertURL)
+	pk, err := r.GetPublicKey("", mockCertURL)
 	if err != nil {
-		t.Errorf("GetPublicKey(%+v) fails: expected no error, got (%v)", mockCertURL, err)
+		t.Errorf("GetPublicKey(\"\", %+v) fails: expected no error, got (%v)", mockCertURL, err)
 	}
 	if test.JwtPubKey1 != pk {
-		t.Errorf("GetPublicKey(%+v): expected (%s), got (%s)", mockCertURL, test.JwtPubKey1, pk)
+		t.Errorf("GetPublicKey(\"\", %+v): expected (%s), got (%s)", mockCertURL, test.JwtPubKey1, pk)
 	}
 }
 
 func TestGetPublicKeyUsingTLSBadCert(t *testing.T) {
-	r := newJwksResolverWithCABundlePaths(JwtPubKeyEvictionDuration, JwtPubKeyRefreshInterval, testRetryInterval, []string{"./test/testcert/cert2.pem"})
+	r := newJwksResolverWithCABundlePaths(
+		JwtPubKeyEvictionDuration,
+		JwtPubKeyRefreshInterval,
+		testRetryInterval,
+		JwtPubKeyRefreshIntervalOnFailure,
+		[]string{"./test/testcert/cert2.pem"},
+	)
 	defer r.Close()
 
 	ms, err := test.StartNewTLSServer("./test/testcert/cert.pem", "./test/testcert/key.pem")
@@ -293,14 +199,20 @@ func TestGetPublicKeyUsingTLSBadCert(t *testing.T) {
 	}
 
 	mockCertURL := ms.URL + "/oauth2/v3/certs"
-	_, err = r.GetPublicKey(mockCertURL)
+	_, err = r.GetPublicKey("", mockCertURL)
 	if err == nil {
-		t.Errorf("GetPublicKey(%+v) did not fail: expected bad certificate error, got no error", mockCertURL)
+		t.Errorf("GetPublicKey(\"\", %+v) did not fail: expected bad certificate error, got no error", mockCertURL)
 	}
 }
 
 func TestGetPublicKeyUsingTLSWithoutCABundles(t *testing.T) {
-	r := newJwksResolverWithCABundlePaths(JwtPubKeyEvictionDuration, JwtPubKeyRefreshInterval, testRetryInterval, []string{})
+	r := newJwksResolverWithCABundlePaths(
+		JwtPubKeyEvictionDuration,
+		JwtPubKeyRefreshInterval,
+		testRetryInterval,
+		JwtPubKeyRefreshIntervalOnFailure,
+		[]string{},
+	)
 	defer r.Close()
 
 	ms, err := test.StartNewTLSServer("./test/testcert/cert.pem", "./test/testcert/key.pem")
@@ -310,14 +222,19 @@ func TestGetPublicKeyUsingTLSWithoutCABundles(t *testing.T) {
 	}
 
 	mockCertURL := ms.URL + "/oauth2/v3/certs"
-	_, err = r.GetPublicKey(mockCertURL)
+	_, err = r.GetPublicKey("", mockCertURL)
 	if err == nil {
-		t.Errorf("GetPublicKey(%+v) did not fail: expected https unsupported error, got no error", mockCertURL)
+		t.Errorf("GetPublicKey(\"\", %+v) did not fail: expected https unsupported error, got no error", mockCertURL)
 	}
 }
 
 func TestJwtPubKeyEvictionForNotUsed(t *testing.T) {
-	r := NewJwksResolver(100*time.Millisecond /*EvictionDuration*/, 2*time.Millisecond /*RefreshInterval*/, testRetryInterval)
+	r := newJwksResolver(
+		100*time.Millisecond, /*EvictionDuration*/
+		2*time.Millisecond,   /*RefreshInterval*/
+		2*time.Millisecond,   /*RefreshIntervalOnFailure*/
+		testRetryInterval,
+	)
 	defer r.Close()
 
 	ms := startMockServer(t)
@@ -328,10 +245,11 @@ func TestJwtPubKeyEvictionForNotUsed(t *testing.T) {
 	verifyKeyRefresh(t, r, ms, test.JwtPubKey2)
 
 	// Wait until unused keys are evicted.
-	mockCertURL := ms.URL + "/oauth2/v3/certs"
+	key := jwtKey{jwksURI: ms.URL + "/oauth2/v3/certs", issuer: "istio-test"}
+
 	retry.UntilSuccessOrFail(t, func() error {
 		// Verify the public key is evicted.
-		if _, found := r.keyEntries.Load(mockCertURL); found {
+		if _, found := r.keyEntries.Load(key); found {
 			return fmt.Errorf("public key is not evicted")
 		}
 		return nil
@@ -339,7 +257,12 @@ func TestJwtPubKeyEvictionForNotUsed(t *testing.T) {
 }
 
 func TestJwtPubKeyEvictionForNotRefreshed(t *testing.T) {
-	r := NewJwksResolver(100*time.Millisecond /*EvictionDuration*/, 10*time.Millisecond /*RefreshInterval*/, testRetryInterval /*RetryInterval*/)
+	r := newJwksResolver(
+		100*time.Millisecond, /*EvictionDuration*/
+		10*time.Millisecond,  /*RefreshInterval*/
+		10*time.Millisecond,  /*RefreshIntervalOnFailure*/
+		testRetryInterval,    /*RetryInterval*/
+	)
 	defer r.Close()
 
 	ms := startMockServer(t)
@@ -350,13 +273,13 @@ func TestJwtPubKeyEvictionForNotRefreshed(t *testing.T) {
 
 	mockCertURL := ms.URL + "/oauth2/v3/certs"
 
-	pk, err := r.GetPublicKey(mockCertURL)
+	pk, err := r.GetPublicKey("", mockCertURL)
 	if err != nil {
-		t.Fatalf("GetPublicKey(%+v) fails: expected no error, got (%v)", mockCertURL, err)
+		t.Fatalf("GetPublicKey(\"\", %+v) fails: expected no error, got (%v)", mockCertURL, err)
 	}
 	// Mock server returns JwtPubKey1 for first call.
 	if test.JwtPubKey1 != pk {
-		t.Fatalf("GetPublicKey(%+v): expected (%s), got (%s)", mockCertURL, test.JwtPubKey1, pk)
+		t.Fatalf("GetPublicKey(\"\", %+v): expected (%s), got (%s)", mockCertURL, test.JwtPubKey1, pk)
 	}
 
 	// Keep getting the public key to change the lastUsedTime of the public key.
@@ -368,7 +291,7 @@ func TestJwtPubKeyEvictionForNotRefreshed(t *testing.T) {
 			case <-done:
 				return
 			case <-c.C:
-				_, _ = r.GetPublicKey(mockCertURL)
+				_, _ = r.GetPublicKey(mockCertURL, "")
 			}
 		}
 	}()
@@ -378,16 +301,21 @@ func TestJwtPubKeyEvictionForNotRefreshed(t *testing.T) {
 
 	// Verify the cached public key is removed after failed to refresh longer than the eviction duration.
 	retry.UntilSuccessOrFail(t, func() error {
-		_, err = r.GetPublicKey(mockCertURL)
+		_, err = r.GetPublicKey(mockCertURL, "")
 		if err == nil {
-			return fmt.Errorf("getPublicKey(%+v) fails: expected error, got no error", mockCertURL)
+			return fmt.Errorf("getPublicKey(\"\", %+v) fails: expected error, got no error", mockCertURL)
 		}
 		return nil
 	})
 }
 
 func TestJwtPubKeyLastRefreshedTime(t *testing.T) {
-	r := NewJwksResolver(JwtPubKeyEvictionDuration, 2*time.Millisecond /*RefreshInterval*/, testRetryInterval /*RetryInterval*/)
+	r := newJwksResolver(
+		JwtPubKeyEvictionDuration,
+		2*time.Millisecond, /*RefreshInterval*/
+		2*time.Millisecond, /*RefreshIntervalOnFailure*/
+		testRetryInterval,  /*RetryInterval*/
+	)
 	defer r.Close()
 
 	ms := startMockServer(t)
@@ -402,7 +330,12 @@ func TestJwtPubKeyLastRefreshedTime(t *testing.T) {
 }
 
 func TestJwtPubKeyRefreshWithNetworkError(t *testing.T) {
-	r := NewJwksResolver(JwtPubKeyEvictionDuration, time.Second /*RefreshInterval*/, testRetryInterval)
+	r := newJwksResolver(
+		JwtPubKeyEvictionDuration,
+		time.Second, /*RefreshInterval*/
+		time.Second, /*RefreshIntervalOnFailure*/
+		testRetryInterval,
+	)
 	defer r.Close()
 
 	ms := startMockServer(t)
@@ -418,6 +351,56 @@ func TestJwtPubKeyRefreshWithNetworkError(t *testing.T) {
 	verifyKeyLastRefreshedTime(t, r, ms, false /* wantChanged */)
 }
 
+func TestJwtRefreshIntervalOnFailureAndResetToDefault(t *testing.T) {
+	r := newJwksResolver(
+		JwtPubKeyEvictionDuration,
+		100*time.Millisecond, /*RefreshInterval*/
+		2*time.Millisecond,   /*RefreshIntervalOnFailure*/
+		testRetryInterval,
+	)
+	defer r.Close()
+
+	ms := startMockServer(t)
+	defer ms.Stop()
+
+	// Configures the mock server to return error after the first request.
+	ms.ReturnErrorAfterFirstNumHits = 2
+	ms.ReturnSuccessAfterFirstNumHits = 20
+
+	mockCertURL := ms.URL + "/oauth2/v3/certs"
+	_, err := r.GetPublicKey("", mockCertURL)
+	if err != nil {
+		t.Fatalf("GetPublicKey(\"\", %+v) fails: expected no error, got (%v)", mockCertURL, err)
+	}
+
+	// note that calling refresh has the side effect that it does hit the mockserver and hence we will already do the 2nd hit.
+	refreshInverval := r.refresh()
+	if refreshInverval != r.refreshDefaultInterval {
+		t.Errorf("first test on refresh interval failed, expected: %s, got: %s", r.refreshDefaultInterval, refreshInverval)
+	}
+
+	// sleep a bit more than the default refresh interval so we are expected to operate the refresh in failure mode.
+	time.Sleep(r.refreshDefaultInterval + 1*time.Millisecond)
+	refreshInverval = r.refresh()
+	if refreshInverval != r.refreshIntervalOnFailure {
+		t.Errorf("2nd test on refresh interval failed, expected: %s, got: %s", r.refreshIntervalOnFailure, refreshInverval)
+	}
+
+	// sleep long enough to get back to the default interval. Note that the refreshs also consume some time.
+	time.Sleep(20 * r.refreshIntervalOnFailure)
+	refreshInverval = r.refresh()
+	if refreshInverval != r.refreshDefaultInterval {
+		t.Errorf("3rd test on refresh interval failed, expected: %s, got: %s", r.refreshDefaultInterval, refreshInverval)
+	}
+
+	// test after two more default refresh intervals and expect that we are still on the default interval.
+	time.Sleep(2 * r.refreshDefaultInterval)
+	refreshInverval = r.refresh()
+	if refreshInverval != r.refreshDefaultInterval {
+		t.Errorf("4th test on refresh interval failed, expected: %s, got: %s", r.refreshDefaultInterval, refreshInverval)
+	}
+}
+
 func getCounterValue(counterName string, t *testing.T) float64 {
 	counterValue := 0.0
 	if data, err := view.RetrieveData(counterName); err == nil {
@@ -431,7 +414,12 @@ func getCounterValue(counterName string, t *testing.T) float64 {
 }
 
 func TestJwtPubKeyMetric(t *testing.T) {
-	r := NewJwksResolver(JwtPubKeyEvictionDuration, JwtPubKeyRefreshInterval, testRetryInterval)
+	r := newJwksResolver(
+		JwtPubKeyEvictionDuration,
+		JwtPubKeyRefreshInterval,
+		JwtPubKeyRefreshIntervalOnFailure,
+		testRetryInterval,
+	)
 	defer r.Close()
 
 	ms, err := test.StartNewServer()
@@ -446,22 +434,22 @@ func TestJwtPubKeyMetric(t *testing.T) {
 
 	mockCertURL := ms.URL + "/oauth2/v3/certs"
 	cases := []struct {
-		in                string
+		in                []string
 		expectedJwtPubkey string
 	}{
 		{
-			in:                mockCertURL,
+			in:                []string{"", mockCertURL},
 			expectedJwtPubkey: "",
 		},
 		{
-			in:                mockCertURL,
+			in:                []string{"", mockCertURL},
 			expectedJwtPubkey: test.JwtPubKey1,
 		},
 	}
 	for _, c := range cases {
-		pk, _ := r.GetPublicKey(c.in)
+		pk, _ := r.GetPublicKey(c.in[0], c.in[1])
 		if c.expectedJwtPubkey != pk {
-			t.Errorf("GetPublicKey(%+v): expected (%s), got (%s)", c.in, c.expectedJwtPubkey, pk)
+			t.Errorf("GetPublicKey(\"\", %+v): expected (%s), got (%s)", c.in, c.expectedJwtPubkey, pk)
 		}
 	}
 
@@ -489,13 +477,13 @@ func verifyKeyRefresh(t *testing.T, r *JwksResolver, ms *test.MockOpenIDDiscover
 	t.Helper()
 	mockCertURL := ms.URL + "/oauth2/v3/certs"
 
-	pk, err := r.GetPublicKey(mockCertURL)
+	pk, err := r.GetPublicKey("", mockCertURL)
 	if err != nil {
-		t.Fatalf("GetPublicKey(%+v) fails: expected no error, got (%v)", mockCertURL, err)
+		t.Fatalf("GetPublicKey(\"\", %+v) fails: expected no error, got (%v)", mockCertURL, err)
 	}
 	// Mock server returns JwtPubKey1 for first call.
 	if test.JwtPubKey1 != pk {
-		t.Fatalf("GetPublicKey(%+v): expected (%s), got (%s)", mockCertURL, test.JwtPubKey1, pk)
+		t.Fatalf("GetPublicKey(\"\", %+v): expected (%s), got (%s)", mockCertURL, test.JwtPubKey1, pk)
 	}
 
 	// Wait until refresh job at least finished once.
@@ -506,30 +494,31 @@ func verifyKeyRefresh(t *testing.T, r *JwksResolver, ms *test.MockOpenIDDiscover
 		}
 		return fmt.Errorf("refresher failed to run")
 	})
-	pk, err = r.GetPublicKey(mockCertURL)
+	pk, err = r.GetPublicKey("", mockCertURL)
 	if err != nil {
-		t.Fatalf("GetPublicKey(%+v) fails: expected no error, got (%v)", mockCertURL, err)
+		t.Fatalf("GetPublicKey(\"\", %+v) fails: expected no error, got (%v)", mockCertURL, err)
 	}
 	if expectedJwtPubkey != pk {
-		t.Fatalf("GetPublicKey(%+v): expected (%s), got (%s)", mockCertURL, expectedJwtPubkey, pk)
+		t.Fatalf("GetPublicKey(\"\", %+v): expected (%s), got (%s)", mockCertURL, expectedJwtPubkey, pk)
 	}
 }
 
 func verifyKeyLastRefreshedTime(t *testing.T, r *JwksResolver, ms *test.MockOpenIDDiscoveryServer, wantChanged bool) {
 	t.Helper()
 	mockCertURL := ms.URL + "/oauth2/v3/certs"
+	key := jwtKey{jwksURI: mockCertURL}
 
-	e, found := r.keyEntries.Load(mockCertURL)
+	e, found := r.keyEntries.Load(key)
 	if !found {
-		t.Fatalf("No cached public key for %s", mockCertURL)
+		t.Fatalf("No cached public key for %+v", key)
 	}
 	oldRefreshedTime := e.(jwtPubKeyEntry).lastRefreshedTime
 
 	time.Sleep(200 * time.Millisecond)
 
-	e, found = r.keyEntries.Load(mockCertURL)
+	e, found = r.keyEntries.Load(key)
 	if !found {
-		t.Fatalf("No cached public key for %s", mockCertURL)
+		t.Fatalf("No cached public key for %+v", key)
 	}
 	newRefreshedTime := e.(jwtPubKeyEntry).lastRefreshedTime
 

--- a/pilot/pkg/model/jwks_resolver_test.go
+++ b/pilot/pkg/model/jwks_resolver_test.go
@@ -390,7 +390,7 @@ func TestJwtRefreshIntervalRecoverFromInitialFailOnFirstHit(t *testing.T) {
 	ms := startMockServer(t)
 	defer ms.Stop()
 
-	// Configures the mock server to return error after the first request.
+	// Configures the mock server to return error for the first request 3 requests.
 	ms.ReturnErrorForFirstNumHits = 3
 
 	mockCertURL := ms.URL + "/oauth2/v3/certs"
@@ -399,12 +399,9 @@ func TestJwtRefreshIntervalRecoverFromInitialFailOnFirstHit(t *testing.T) {
 		t.Fatalf("GetPublicKey(%q, %+v) fails: expected error, got no error: (%v)", pk, mockCertURL, err)
 	}
 
-	time.Sleep(1 * time.Millisecond)
+	time.Sleep(150 * time.Millisecond)
 	r.Close()
 
-	// Note(Marco) only to illustrate the current issue...
-	// We should be in failure mode and expect refresh interval on fail but we do not because
-	// only on successful jwk lookup in r.GetPublicKey we add key to cache. Hence we are still in defaultRefreshInterval...
 	i := 0
 	r.keyEntries.Range(func(_ interface{}, _ interface{}) bool {
 		i++
@@ -416,8 +413,8 @@ func TestJwtRefreshIntervalRecoverFromInitialFailOnFirstHit(t *testing.T) {
 		t.Errorf("expected entries in cache: %d , got %d", expectedEntries, i)
 	}
 
-	if r.refreshInterval != refreshIntervalOnFail {
-		t.Errorf("expected refreshIntervalOnFail: %v , got %v", refreshIntervalOnFail, r.refreshInterval)
+	if r.refreshInterval != defaultRefreshInterval {
+		t.Errorf("expected refreshInterval to be refreshDefaultInterval: %v, got %v", defaultRefreshInterval, r.refreshInterval)
 	}
 }
 

--- a/pilot/pkg/model/jwks_resolver_test.go
+++ b/pilot/pkg/model/jwks_resolver_test.go
@@ -49,7 +49,7 @@ func TestResolveJwksURIUsingOpenID(t *testing.T) {
 			expectedJwksURI: mockCertURL,
 		},
 		{
-			in:              ms.URL, // Send two same request, mock server is expected to hit only once because of the cache.
+			in:              ms.URL, // Send two same request, mock server is expected to hit twice.
 			expectedJwksURI: mockCertURL,
 		},
 		{
@@ -68,9 +68,6 @@ func TestResolveJwksURIUsingOpenID(t *testing.T) {
 				c.in, c.expectedJwksURI, jwksURI)
 		}
 	}
-	jwksURI, err := r.resolveJwksURIUsingOpenID("http://xyz")
-	t.Logf("jwks: %s, err: %s", jwksURI, err)
-	t.Logf("%v", r.keyEntries)
 
 	// Verify mock openID discovery http://localhost:9999/.well-known/openid-configuration was called twice.
 	if got, want := ms.OpenIDHitNum, uint64(2); got != want {
@@ -355,7 +352,7 @@ func TestJwtRefreshIntervalOnFailureAndResetToDefault(t *testing.T) {
 	r := newJwksResolver(
 		JwtPubKeyEvictionDuration,
 		100*time.Millisecond, /*RefreshInterval*/
-		2*time.Millisecond,   /*RefreshIntervalOnFailure*/
+		10*time.Millisecond,  /*RefreshIntervalOnFailure*/
 		testRetryInterval,
 	)
 	defer r.Close()

--- a/pilot/pkg/model/jwks_resolver_test.go
+++ b/pilot/pkg/model/jwks_resolver_test.go
@@ -390,7 +390,7 @@ func TestJwtRefreshIntervalRecoverFromInitialFailOnFirstHit(t *testing.T) {
 	ms := startMockServer(t)
 	defer ms.Stop()
 
-	// Configures the mock server to return error for the first request 3 requests.
+	// Configures the mock server to return error for the first 3 requests.
 	ms.ReturnErrorForFirstNumHits = 3
 
 	mockCertURL := ms.URL + "/oauth2/v3/certs"

--- a/pilot/pkg/model/jwks_resolver_test.go
+++ b/pilot/pkg/model/jwks_resolver_test.go
@@ -160,7 +160,13 @@ func TestGetPublicKeyReorderedKey(t *testing.T) {
 }
 
 func TestGetPublicKeyUsingTLS(t *testing.T) {
-	r := newJwksResolverWithCABundlePaths(JwtPubKeyEvictionDuration, JwtPubKeyRefreshInterval, JwtPubKeyRefreshIntervalOnFailure, testRetryInterval, []string{"./test/testcert/cert.pem"})
+	r := newJwksResolverWithCABundlePaths(
+		JwtPubKeyEvictionDuration,
+		JwtPubKeyRefreshInterval,
+		JwtPubKeyRefreshIntervalOnFailure,
+		testRetryInterval,
+		[]string{"./test/testcert/cert.pem"},
+	)
 	defer r.Close()
 
 	ms, err := test.StartNewTLSServer("./test/testcert/cert.pem", "./test/testcert/key.pem")

--- a/pilot/pkg/model/test/mockopenidserver.go
+++ b/pilot/pkg/model/test/mockopenidserver.go
@@ -85,7 +85,7 @@ type MockOpenIDDiscoveryServer struct {
 	ReturnErrorAfterFirstNumHits uint64
 
 	// The mock server will start to return a successful response after the first number of hits for public key,
-	// this is used to simulate network errors and test the refresh logic in jwks resolver. Note the idea is to\
+	// this is used to simulate network errors and test the refresh logic in jwks resolver. Note the idea is to
 	// use this in combination with ReturnErrorAfterFirstNumHits to simulate something like this:
 	// { success, success, error, error, success, success }
 	ReturnSuccessAfterFirstNumHits uint64

--- a/pilot/pkg/model/test/mockopenidserver.go
+++ b/pilot/pkg/model/test/mockopenidserver.go
@@ -84,6 +84,12 @@ type MockOpenIDDiscoveryServer struct {
 	// this is used to simulate network errors and test the refresh logic in jwks resolver.
 	ReturnErrorAfterFirstNumHits uint64
 
+	// The mock server will start to return a successful response after the first number of hits for public key,
+	// this is used to simulate network errors and test the refresh logic in jwks resolver. Note the idea is to\
+	// use this in combination with ReturnErrorAfterFirstNumHits to simulate something like this:
+	// { success, success, error, error, success, success }
+	ReturnSuccessAfterFirstNumHits uint64
+
 	// The mock server will start to return an error after the first number of hits for public key,
 	// this is used to simulate network errors and test the refresh logic in jwks resolver.
 	ReturnReorderedKeyAfterFirstNumHits uint64
@@ -209,6 +215,12 @@ func (ms *MockOpenIDDiscoveryServer) openIDCfg(w http.ResponseWriter, req *http.
 
 func (ms *MockOpenIDDiscoveryServer) jwtPubKey(w http.ResponseWriter, req *http.Request) {
 	atomic.AddUint64(&ms.PubKeyHitNum, 1)
+
+	if ms.ReturnSuccessAfterFirstNumHits > 0 && atomic.LoadUint64(&ms.PubKeyHitNum) >= ms.ReturnSuccessAfterFirstNumHits {
+		fmt.Fprintf(w, "%v", JwtPubKey1)
+		return
+	}
+
 	if ms.ReturnErrorAfterFirstNumHits != 0 && atomic.LoadUint64(&ms.PubKeyHitNum) > ms.ReturnErrorAfterFirstNumHits {
 		w.WriteHeader(http.StatusForbidden)
 		fmt.Fprintf(w, "Mock server configured to return error after %d hits", ms.ReturnErrorAfterFirstNumHits)

--- a/pilot/pkg/security/authn/v1beta1/policy_applier.go
+++ b/pilot/pkg/security/authn/v1beta1/policy_applier.go
@@ -259,9 +259,9 @@ func convertToEnvoyJwtConfig(jwtRules []*v1beta1.JWTRule) *envoy_jwt.JwtAuthenti
 		jwtPubKey := jwtRule.Jwks
 		if jwtPubKey == "" {
 			var err error
-			jwtPubKey, err = model.GetJwtKeyResolver().GetPublicKey(jwtRule.JwksUri)
+			jwtPubKey, err = model.GetJwtKeyResolver().GetPublicKey(jwtRule.Issuer, jwtRule.JwksUri)
 			if err != nil {
-				log.Errorf("Failed to fetch jwt public key from %q: %s", jwtRule.JwksUri, err)
+				log.Errorf("Failed to fetch jwt public key from issuer %q, jwks uri %q: %s", jwtRule.Issuer, jwtRule.JwksUri, err)
 				// This is a temporary workaround to reject a request with JWT token by using a fake jwks when istiod failed to fetch it.
 				// TODO(xulingqing): Find a better way to reject the request without using the fake jwks.
 				jwtPubKey = createFakeJwks(jwtRule.JwksUri)

--- a/pilot/pkg/security/authn/v1beta1/policy_applier_test.go
+++ b/pilot/pkg/security/authn/v1beta1/policy_applier_test.go
@@ -266,7 +266,7 @@ func TestJwtFilter(t *testing.T) {
 									JwksSourceSpecifier: &envoy_jwt.JwtProvider_LocalJwks{
 										LocalJwks: &core.DataSource{
 											Specifier: &core.DataSource_InlineString{
-												InlineString: test.JwtPubKey1,
+												InlineString: test.JwtPubKey2,
 											},
 										},
 									},

--- a/releasenotes/notes/30261.yaml
+++ b/releasenotes/notes/30261.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: security
+issue:
+- 30261
+releaseNotes:
+- |
+  **Added**  Periodically resolve jwks_uri.

--- a/releasenotes/notes/30261.yaml
+++ b/releasenotes/notes/30261.yaml
@@ -5,4 +5,4 @@ issue:
 - 30261
 releaseNotes:
 - |
-  **Added**  Periodically resolve jwks_uri.
+  **Added**   `istiod` JWT public key refresh job will now retry the failed fetch of the `jwks_uri` with exponential backoff.


### PR DESCRIPTION
As suggested by @yangminzhu this PR merges the ResolveJwksURI to the refresh() function. Fixes #30261 

[x] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[x] Policies and Telemetry
[x] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure

Pull Request Attributes

Please check any characteristics that apply to this pull request.

[x] Does not have any changes that may affect Istio users.
