### PR TITLE
allow security tests to run against real VMs

### DIFF
--- a/pkg/test/framework/components/echo/common/config.go
+++ b/pkg/test/framework/components/echo/common/config.go
@@ -33,7 +33,7 @@ const (
 	defaultDomain    = constants.DefaultKubernetesDomain
 )
 
-func FillInDefaults(c *echo.Config) {
+func FillInDefaults(ctx resource.Context, c *echo.Config) (err error) {
 	if c.Service == "" {
 		c.Service = defaultService
 	}
@@ -60,10 +60,6 @@ func FillInDefaults(c *echo.Config) {
 			c.Subsets[i].Version = c.Version
 		}
 	}
-}
-
-func FillInKubeDefaults(ctx resource.Context, c *echo.Config) (err error) {
-	FillInDefaults(c)
 	AddPortIfMissing(c, protocol.GRPC)
 	// If no namespace was provided, use the default.
 	if c.Namespace == nil && ctx != nil {

--- a/pkg/test/framework/components/echo/instances.go
+++ b/pkg/test/framework/components/echo/instances.go
@@ -77,13 +77,6 @@ func InCluster(c cluster.Cluster) Matcher {
 	}
 }
 
-// WithPrimary matches instances who are in a cluster that uses the given cluster as a Primary.
-func WithPrimary(c cluster.Cluster) Matcher {
-	return func(i Instance) bool {
-		return c.Name() == i.Config().Cluster.Primary().Name()
-	}
-}
-
 
 // InNetwork matches instances deployed in the given network.
 func InNetwork(n string) Matcher {

--- a/pkg/test/framework/components/echo/instances.go
+++ b/pkg/test/framework/components/echo/instances.go
@@ -84,7 +84,6 @@ func WithPrimary(c cluster.Cluster) Matcher {
 	}
 }
 
-
 // InNetwork matches instances deployed in the given network.
 func InNetwork(n string) Matcher {
 	return func(i Instance) bool {

--- a/pkg/test/framework/components/echo/instances.go
+++ b/pkg/test/framework/components/echo/instances.go
@@ -77,6 +77,14 @@ func InCluster(c cluster.Cluster) Matcher {
 	}
 }
 
+// WithPrimary matches instances who are in a cluster that uses the given cluster as a Primary.
+func WithPrimary(c cluster.Cluster) Matcher {
+	return func(i Instance) bool {
+		return c.Name() == i.Config().Cluster.Primary().Name()
+	}
+}
+
+
 // InNetwork matches instances deployed in the given network.
 func InNetwork(n string) Matcher {
 	return func(i Instance) bool {

--- a/pkg/test/framework/components/echo/instances.go
+++ b/pkg/test/framework/components/echo/instances.go
@@ -77,13 +77,6 @@ func InCluster(c cluster.Cluster) Matcher {
 	}
 }
 
-// WithPrimary matches instances who are in a cluster that uses the given cluster as a Primary.
-func WithPrimary(c cluster.Cluster) Matcher {
-	return func(i Instance) bool {
-		return c.Name() == i.Config().Cluster.Primary().Name()
-	}
-}
-
 // InNetwork matches instances deployed in the given network.
 func InNetwork(n string) Matcher {
 	return func(i Instance) bool {

--- a/pkg/test/framework/components/echo/instances.go
+++ b/pkg/test/framework/components/echo/instances.go
@@ -77,6 +77,13 @@ func InCluster(c cluster.Cluster) Matcher {
 	}
 }
 
+// WithPrimary matches instances who are in a cluster that uses the given cluster as a Primary.
+func WithPrimary(c cluster.Cluster) Matcher {
+	return func(i Instance) bool {
+		return c.Name() == i.Config().Cluster.Primary().Name()
+	}
+}
+
 
 // InNetwork matches instances deployed in the given network.
 func InNetwork(n string) Matcher {

--- a/pkg/test/framework/components/echo/kube/deployment_test.go
+++ b/pkg/test/framework/components/echo/kube/deployment_test.go
@@ -143,7 +143,7 @@ func TestDeploymentYAML(t *testing.T) {
 				t.Fatal(err)
 			}
 			tc.config.Cluster = clusters[0]
-			if err := common.FillInKubeDefaults(nil, &tc.config); err != nil {
+			if err := common.FillInDefaults(nil, &tc.config); err != nil {
 				t.Errorf("failed filling in defaults: %v", err)
 			}
 			serviceYAML, err := GenerateService(tc.config)

--- a/pkg/test/framework/components/echo/kube/instance.go
+++ b/pkg/test/framework/components/echo/kube/instance.go
@@ -75,10 +75,6 @@ type instance struct {
 
 func newInstance(ctx resource.Context, originalCfg echo.Config) (out *instance, err error) {
 	cfg := originalCfg.DeepCopy()
-	if err = common.FillInKubeDefaults(ctx, &cfg); err != nil {
-		return nil, err
-	}
-
 	if !cfg.Cluster.IsPrimary() && cfg.DeployAsVM {
 		return nil, fmt.Errorf("cannot deploy %s as VM on non-primary %s", cfg.Service, cfg.Cluster.Name())
 	}

--- a/tests/integration/security/util/reachability/context.go
+++ b/tests/integration/security/util/reachability/context.go
@@ -108,10 +108,16 @@ func Run(testCases []TestCase, ctx framework.TestContext, apps *util.EchoDeploym
 						client.Config().Service, client.Config().Cluster.Name())).Run(func(ctx framework.TestContext) {
 						aSet := apps.A
 						bSet := apps.B
-						// TODO: check why 503 is received for global-plaintext.yaml (https://github.com/istio/istio/issues/28766)
+						vmSet := apps.VM
+
 						if c.ConfigFile == "global-plaintext.yaml" {
+							// TODO: cross-network traffic fails because istiod can't filter endpoints set to non-mTLS via PeerAuthentication
+							// TODO (cont): setting callCount to 1 seems to avoid this somehow See https://github.com/istio/istio/issues/28798
 							aSet = apps.A.Match(echo.InCluster(client.Config().Cluster))
 							bSet = apps.B.Match(echo.InCluster(client.Config().Cluster))
+							if len(vmSet) > 0 {
+								vmSet = vmSet[:1]
+							}
 						}
 						destinationSets := []echo.Instances{
 							aSet,
@@ -122,8 +128,7 @@ func Run(testCases []TestCase, ctx framework.TestContext, apps *util.EchoDeploym
 							apps.Multiversion.Match(echo.InCluster(client.Config().Cluster)),
 							// only hit same cluster naked services
 							apps.Naked.Match(echo.InCluster(client.Config().Cluster)),
-							// we should hit VMs anywhere
-							apps.VM,
+							vmSet,
 							// only hit same cluster headless services
 							apps.HeadlessNaked.Match(echo.InCluster(client.Config().Cluster)),
 						}

--- a/tests/integration/security/util/reachability/context.go
+++ b/tests/integration/security/util/reachability/context.go
@@ -122,8 +122,8 @@ func Run(testCases []TestCase, ctx framework.TestContext, apps *util.EchoDeploym
 							apps.Multiversion.Match(echo.InCluster(client.Config().Cluster)),
 							// only hit same cluster naked services
 							apps.Naked.Match(echo.InCluster(client.Config().Cluster)),
-							// only hit same cluster vm services
-							apps.VM.Match(echo.InCluster(client.Config().Cluster)),
+							// we should hit VMs anywhere
+							apps.VM.Match(echo.WithPrimary(client.Config().Cluster.Primary())),
 							// only hit same cluster headless services
 							apps.HeadlessNaked.Match(echo.InCluster(client.Config().Cluster)),
 						}

--- a/tests/integration/security/util/reachability/context.go
+++ b/tests/integration/security/util/reachability/context.go
@@ -123,7 +123,7 @@ func Run(testCases []TestCase, ctx framework.TestContext, apps *util.EchoDeploym
 							// only hit same cluster naked services
 							apps.Naked.Match(echo.InCluster(client.Config().Cluster)),
 							// we should hit VMs anywhere
-							apps.VM,
+							apps.VM.Match(echo.WithPrimary(client.Config().Cluster.Primary())),
 							// only hit same cluster headless services
 							apps.HeadlessNaked.Match(echo.InCluster(client.Config().Cluster)),
 						}

--- a/tests/integration/security/util/reachability/context.go
+++ b/tests/integration/security/util/reachability/context.go
@@ -123,7 +123,7 @@ func Run(testCases []TestCase, ctx framework.TestContext, apps *util.EchoDeploym
 							// only hit same cluster naked services
 							apps.Naked.Match(echo.InCluster(client.Config().Cluster)),
 							// we should hit VMs anywhere
-							apps.VM.Match(echo.WithPrimary(client.Config().Cluster.Primary())),
+							apps.VM,
 							// only hit same cluster headless services
 							apps.HeadlessNaked.Match(echo.InCluster(client.Config().Cluster)),
 						}


### PR DESCRIPTION
- FillInDefaults needs to be the same for all echo configs, that way the Ports match no batter which cluster. 
- Since the VM is not in the same "cluster" as the pods, we shouldn't filter it out in security tests 
  - leaving the "is primary" match for now