### PR TITLE
use a deterministic cluster name for subtests

### DIFF
--- a/pkg/test/framework/components/cluster/cluster.go
+++ b/pkg/test/framework/components/cluster/cluster.go
@@ -142,8 +142,14 @@ type Cluster interface {
 	fmt.Stringer
 	kube.ExtendedClient
 
-	// Name of this cluster
+	// Name of this cluster. Use for interacting with the cluster or validation against clusters.
+	// Use StableName instead of Name when creating subtests.
 	Name() string
+
+	// StableName gives a deterministic name for the cluster. Use this for test/subtest names to
+	// allow test grid to compare runs, even when the underlying cluster names are dynamic.
+	// Use Name for validation/interaction with the actual cluster.
+	StableName() string
 
 	// Kind of cluster
 	Kind() Kind

--- a/pkg/test/framework/components/cluster/clusterboot/factory_test.go
+++ b/pkg/test/framework/components/cluster/clusterboot/factory_test.go
@@ -52,6 +52,7 @@ func TestBuild(t *testing.T) {
 					PrimaryClusterName: "auto-fill-primary",
 					// The config cluster should match the primary cluster when not specified
 					ConfigClusterName: "auto-fill-primary",
+					Index:             1,
 				},
 			},
 		},
@@ -64,6 +65,7 @@ func TestBuild(t *testing.T) {
 					ClusterKind:        cluster.Fake,
 					PrimaryClusterName: "external-istiod",
 					ConfigClusterName:  "remote-config",
+					Index:              2,
 				},
 			},
 		},
@@ -82,6 +84,7 @@ func TestBuild(t *testing.T) {
 					// Explicitly specified in config, should be copied exactly
 					PrimaryClusterName: "external-istiod",
 					ConfigClusterName:  "remote-config",
+					Index:              3,
 				},
 			},
 		},

--- a/pkg/test/framework/components/cluster/topology.go
+++ b/pkg/test/framework/components/cluster/topology.go
@@ -32,7 +32,7 @@ func NewTopology(config Config, allClusters Map) Topology {
 		PrimaryClusterName: config.PrimaryClusterName,
 		ConfigClusterName:  config.ConfigClusterName,
 		AllClusters:        allClusters,
-		index:              len(allClusters),
+		Index:              len(allClusters),
 	}
 }
 
@@ -44,7 +44,7 @@ type Topology struct {
 	Network            string
 	PrimaryClusterName string
 	ConfigClusterName  string
-	index              int
+	Index              int
 	// AllClusters should contain all AllClusters in the context
 	AllClusters Map
 }
@@ -82,7 +82,7 @@ func (c Topology) StableName() string {
 		prefix = string(c.Kind())
 	}
 
-	return fmt.Sprintf("%s-%d", prefix, c.index)
+	return fmt.Sprintf("%s-%d", prefix, c.Index)
 }
 
 func (c Topology) Kind() Kind {

--- a/pkg/test/framework/components/cluster/topology.go
+++ b/pkg/test/framework/components/cluster/topology.go
@@ -32,6 +32,7 @@ func NewTopology(config Config, allClusters Map) Topology {
 		PrimaryClusterName: config.PrimaryClusterName,
 		ConfigClusterName:  config.ConfigClusterName,
 		AllClusters:        allClusters,
+		index:              len(allClusters),
 	}
 }
 
@@ -43,6 +44,7 @@ type Topology struct {
 	Network            string
 	PrimaryClusterName string
 	ConfigClusterName  string
+	index              int
 	// AllClusters should contain all AllClusters in the context
 	AllClusters Map
 }
@@ -55,6 +57,32 @@ func (c Topology) NetworkName() string {
 // Name provides the ClusterName this cluster used by Istio.
 func (c Topology) Name() string {
 	return c.ClusterName
+}
+
+// StableName provides a name used for testcase names. Deterministic, so testgrid
+// can be consistent when the underlying cluster names are dynamic.
+func (c Topology) StableName() string {
+	var prefix string
+	switch c.Kind() {
+	case Kubernetes:
+		if c.IsPrimary() {
+			if c.IsConfig() {
+				prefix = "primary"
+			} else {
+				prefix = "externalistiod"
+			}
+		} else if c.IsRemote() {
+			if c.IsConfig() {
+				prefix = "config"
+			} else {
+				prefix = "remote"
+			}
+		}
+	default:
+		prefix = string(c.Kind())
+	}
+
+	return fmt.Sprintf("%s-%d", prefix, c.index)
 }
 
 func (c Topology) Kind() Kind {
@@ -136,6 +164,7 @@ func (c Topology) String() string {
 	buf := &bytes.Buffer{}
 
 	_, _ = fmt.Fprintf(buf, "Name:               %s\n", c.Name())
+	_, _ = fmt.Fprintf(buf, "StableName:         %s\n", c.StableName())
 	_, _ = fmt.Fprintf(buf, "Kind:               %s\n", c.Kind())
 	_, _ = fmt.Fprintf(buf, "PrimaryCluster:     %s\n", c.Primary().Name())
 	_, _ = fmt.Fprintf(buf, "ConfigCluster:      %s\n", c.Config().Name())

--- a/tests/integration/multicluster/cluster_local.go
+++ b/tests/integration/multicluster/cluster_local.go
@@ -33,7 +33,7 @@ func ClusterLocalTest(t *testing.T, apps AppContext, features ...features.Featur
 			ctx.NewSubTest("respect-cluster-local-config").Run(func(ctx framework.TestContext) {
 				for _, c := range ctx.Clusters() {
 					c := c
-					ctx.NewSubTest(c.Name()).
+					ctx.NewSubTest(c.StableName()).
 						Label(label.Multicluster).
 						Run(func(ctx framework.TestContext) {
 							local := apps.LocalEchos.GetOrFail(ctx, echo.InCluster(c))

--- a/tests/integration/multicluster/helper.go
+++ b/tests/integration/multicluster/helper.go
@@ -95,7 +95,7 @@ func SetupApps(appCtx *AppContext) resource.SetupFn {
 				WithConfig(echoLbCfg).
 				WithConfig(newEchoConfig("local", appCtx.LocalNamespace, cluster))
 			for i := 0; i < uniqSvcPerCluster; i++ {
-				svcName := fmt.Sprintf("echo-%s-%d", cluster.Name(), i)
+				svcName := fmt.Sprintf("echo-%s-%d", cluster.StableName(), i)
 				builder = builder.WithConfig(newEchoConfig(svcName, appCtx.Namespace, cluster))
 			}
 		}

--- a/tests/integration/multicluster/loadbalancing.go
+++ b/tests/integration/multicluster/loadbalancing.go
@@ -36,7 +36,7 @@ func LoadbalancingTest(t *testing.T, apps AppContext, features ...features.Featu
 				Run(func(ctx framework.TestContext) {
 					for _, src := range apps.LBEchos {
 						src := src
-						ctx.NewSubTest(fmt.Sprintf("from %s", src.Config().Cluster.Name())).
+						ctx.NewSubTest(fmt.Sprintf("from %s", src.Config().Cluster.StableName())).
 							Run(func(ctx framework.TestContext) {
 								srcNetwork := src.Config().Cluster.NetworkName()
 								callOrFail(ctx, src, apps.LBEchos[0],

--- a/tests/integration/multicluster/telemetry.go
+++ b/tests/integration/multicluster/telemetry.go
@@ -39,9 +39,9 @@ func TelemetryTest(t *testing.T, apps AppContext, features ...features.Feature) 
 						for _, dest := range ctx.Clusters() {
 							src, dest := src, dest
 							subTestName := fmt.Sprintf("%s->%s://%s:%s%s",
-								src.Name(),
+								src.StableName(),
 								"http",
-								dest.Name(),
+								dest.StableName(),
 								"http",
 								"/")
 

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -348,7 +348,7 @@ spec:
 		for _, split := range splits {
 			split := split
 			cases = append(cases, TrafficTestCase{
-				name: fmt.Sprintf("shifting-%d from %s", split["b"], podA.Config().Cluster.Name()),
+				name: fmt.Sprintf("shifting-%d from %s", split["b"], podA.Config().Cluster.StableName()),
 				config: fmt.Sprintf(`
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
@@ -444,7 +444,7 @@ spec:
 			e := e
 
 			tc.children = append(tc.children, TrafficCall{
-				name: fmt.Sprintf("%s: %s", c.Config().Cluster.Name(), e.alpn),
+				name: fmt.Sprintf("%s: %s", c.Config().Cluster.StableName(), e.alpn),
 				opts: echo.CallOptions{
 					Port:      &echo.Port{ServicePort: e.port, Protocol: protocol.HTTP},
 					Address:   apps.External[0].Address(),
@@ -910,7 +910,7 @@ func protocolSniffingCases(apps *EchoDeployments) []TrafficTestCase {
 					cases = append(cases, TrafficTestCase{
 						// TODO(https://github.com/istio/istio/issues/26798) enable sniffing tcp
 						skip: call.scheme == scheme.TCP,
-						name: fmt.Sprintf("%v %v->%v from %s", call.port, client.Config().Service, destination.Config().Service, client.Config().Cluster.Name()),
+						name: fmt.Sprintf("%v %v->%v from %s", call.port, client.Config().Service, destination.Config().Service, client.Config().Cluster.StableName()),
 						call: client.CallWithRetryOrFail,
 						opts: echo.CallOptions{
 							Target:   destination,
@@ -1214,7 +1214,7 @@ func VMTestCases(vms echo.Instances, apps *EchoDeployments) []TrafficTestCase {
 	for _, c := range testCases {
 		c := c
 		cases = append(cases, TrafficTestCase{
-			name: fmt.Sprintf("%s from %s", c.name, c.from.Config().Cluster.Name()),
+			name: fmt.Sprintf("%s from %s", c.name, c.from.Config().Cluster.StableName()),
 			call: c.from.CallWithRetryOrFail,
 			opts: echo.CallOptions{
 				// assume that all echos in `to` only differ in which cluster they're deployed in

--- a/tests/integration/pilot/mirror_test.go
+++ b/tests/integration/pilot/mirror_test.go
@@ -143,7 +143,7 @@ func runMirrorTest(t *testing.T, options mirrorTestOptions) {
 
 					for _, podA := range apps.PodA {
 						podA := podA
-						ctx.NewSubTest(fmt.Sprintf("from %s", podA.Config().Cluster.Name())).Run(func(ctx framework.TestContext) {
+						ctx.NewSubTest(fmt.Sprintf("from %s", podA.Config().Cluster.StableName())).Run(func(ctx framework.TestContext) {
 							for _, proto := range mirrorProtocols {
 								ctx.NewSubTest(string(proto)).Run(func(ctx framework.TestContext) {
 									retry.UntilSuccessOrFail(ctx, func() error {

--- a/tests/integration/security/authorization_test.go
+++ b/tests/integration/security/authorization_test.go
@@ -84,7 +84,7 @@ func TestAuthorization_mTLS(t *testing.T) {
 
 			ctx.Config().ApplyYAMLOrFail(t, apps.Namespace1.Name(), policies...)
 			for _, cluster := range ctx.Clusters() {
-				ctx.NewSubTest(fmt.Sprintf("From %s", cluster.Name())).Run(func(ctx framework.TestContext) {
+				ctx.NewSubTest(fmt.Sprintf("From %s", cluster.StableName())).Run(func(ctx framework.TestContext) {
 					a := apps.A.Match(echo.InCluster(cluster).And(echo.Namespace(apps.Namespace1.Name())))
 					c := apps.C.Match(echo.InCluster(cluster).And(echo.Namespace(apps.Namespace2.Name())))
 					newTestCase := func(from echo.Instance, path string, expectAllowed bool) rbacUtil.TestCase {
@@ -135,7 +135,7 @@ func TestAuthorization_JWT(t *testing.T) {
 				file.AsStringOrFail(t, "testdata/authz/v1beta1-jwt.yaml.tmpl"))
 			ctx.Config().ApplyYAMLOrFail(t, ns.Name(), policies...)
 			for _, srcCluster := range ctx.Clusters() {
-				ctx.NewSubTest(fmt.Sprintf("From %s", srcCluster.Name())).Run(func(ctx framework.TestContext) {
+				ctx.NewSubTest(fmt.Sprintf("From %s", srcCluster.StableName())).Run(func(ctx framework.TestContext) {
 					a := apps.A.Match(echo.InCluster(srcCluster).And(echo.Namespace(ns.Name())))
 					callCount := 1
 					b := apps.B.Match(echo.Namespace(ns.Name()))
@@ -246,7 +246,7 @@ func TestAuthorization_WorkloadSelector(t *testing.T) {
 			applyPolicy("testdata/authz/v1beta1-workload-ns2.yaml.tmpl", ns2)
 			applyPolicy("testdata/authz/v1beta1-workload-ns-root.yaml.tmpl", rootns)
 			for _, srcCluster := range ctx.Clusters() {
-				ctx.NewSubTest(fmt.Sprintf("From %s", srcCluster.Name())).Run(func(ctx framework.TestContext) {
+				ctx.NewSubTest(fmt.Sprintf("From %s", srcCluster.StableName())).Run(func(ctx framework.TestContext) {
 					a := apps.A.Match(echo.InCluster(srcCluster).And(echo.Namespace(apps.Namespace1.Name())))
 					bInNS1 := apps.B.Match(echo.Namespace(apps.Namespace1.Name()))
 					cInNS1 := apps.C.Match(echo.Namespace(apps.Namespace1.Name()))
@@ -338,7 +338,7 @@ func TestAuthorization_Deny(t *testing.T) {
 				callCount = util.CallsPerCluster * len(ctx.Clusters())
 			}
 			for _, srcCluster := range ctx.Clusters() {
-				ctx.NewSubTest(fmt.Sprintf("From %s", srcCluster.Name())).Run(func(ctx framework.TestContext) {
+				ctx.NewSubTest(fmt.Sprintf("From %s", srcCluster.StableName())).Run(func(ctx framework.TestContext) {
 					a := apps.A.Match(echo.InCluster(srcCluster).And(echo.Namespace(apps.Namespace1.Name())))
 					b := apps.B.Match(echo.Namespace(apps.Namespace1.Name()))
 					c := apps.C.Match(echo.Namespace(apps.Namespace1.Name()))
@@ -414,7 +414,7 @@ func TestAuthorization_NegativeMatch(t *testing.T) {
 				callCount = util.CallsPerCluster * len(ctx.Clusters())
 			}
 			for _, srcCluster := range ctx.Clusters() {
-				ctx.NewSubTest(fmt.Sprintf("From %s", srcCluster.Name())).Run(func(ctx framework.TestContext) {
+				ctx.NewSubTest(fmt.Sprintf("From %s", srcCluster.StableName())).Run(func(ctx framework.TestContext) {
 					srcA := apps.A.Match(echo.InCluster(srcCluster).And(echo.Namespace(apps.Namespace1.Name())))
 					srcBInNS2 := apps.B.Match(echo.InCluster(srcCluster).And(echo.Namespace(apps.Namespace2.Name())))
 					destB := apps.B.Match(echo.Namespace(apps.Namespace1.Name()))
@@ -961,7 +961,7 @@ func TestAuthorization_Conditions(t *testing.T) {
 			IPC = IPC[:lengthC-1]
 			portC := 8090
 			for i := 0; i < len(ctx.Clusters()); i++ {
-				ctx.NewSubTest(fmt.Sprintf("IpA IpB IpC in %s", ctx.Clusters()[i].Name())).Run(func(ctx framework.TestContext) {
+				ctx.NewSubTest(fmt.Sprintf("IpA IpB IpC in %s", ctx.Clusters()[i].StableName())).Run(func(ctx framework.TestContext) {
 					podAWithIPA := apps.A.Match(echo.InCluster(ctx.Clusters()[i])).Match(echo.Namespace(nsA.Name()))[0]
 					podBWithIPB := apps.B.Match(echo.InCluster(ctx.Clusters()[i])).Match(echo.Namespace(nsB.Name()))[0]
 
@@ -979,7 +979,7 @@ func TestAuthorization_Conditions(t *testing.T) {
 					ctx.Config().ApplyYAMLOrFail(t, "", policies...)
 
 					for _, srcCluster := range ctx.Clusters() {
-						ctx.NewSubTest(fmt.Sprintf("From %s", srcCluster.Name())).Run(func(ctx framework.TestContext) {
+						ctx.NewSubTest(fmt.Sprintf("From %s", srcCluster.StableName())).Run(func(ctx framework.TestContext) {
 							a := apps.A.Match(echo.InCluster(srcCluster).And(echo.Namespace(nsA.Name())))
 							b := apps.B.Match(echo.InCluster(srcCluster).And(echo.Namespace(nsB.Name())))
 							callCount := 1
@@ -1148,7 +1148,7 @@ func TestAuthorization_Path(t *testing.T) {
 				file.AsStringOrFail(t, "testdata/authz/v1beta1-path.yaml.tmpl"))
 			ctx.Config().ApplyYAMLOrFail(t, ns.Name(), policies...)
 			for _, srcCluster := range ctx.Clusters() {
-				ctx.NewSubTest(fmt.Sprintf("In %s", srcCluster.Name())).Run(func(ctx framework.TestContext) {
+				ctx.NewSubTest(fmt.Sprintf("In %s", srcCluster.StableName())).Run(func(ctx framework.TestContext) {
 					b := apps.B.GetOrFail(ctx, echo.InCluster(srcCluster).And(echo.Namespace(ns.Name())))
 					a := apps.A.Match(echo.Namespace(ns.Name()))
 					callCount := 1

--- a/tests/integration/security/ca_custom_root/secure_naming_test.go
+++ b/tests/integration/security/ca_custom_root/secure_naming_test.go
@@ -124,7 +124,7 @@ func TestSecureNaming(t *testing.T) {
 			}
 			bSet := apps.B.Match(echo.Namespace(testNamespace.Name()))
 			for _, cluster := range ctx.Clusters() {
-				ctx.NewSubTest(fmt.Sprintf("From %s", cluster.Name())).Run(func(ctx framework.TestContext) {
+				ctx.NewSubTest(fmt.Sprintf("From %s", cluster.StableName())).Run(func(ctx framework.TestContext) {
 					a := apps.A.Match(echo.InCluster(cluster)).Match(echo.Namespace(testNamespace.Name()))[0]
 					ctx.NewSubTest("mTLS cert validation with plugin CA").
 						Run(func(ctx framework.TestContext) {

--- a/tests/integration/security/ca_custom_root/trust_domain_alias_secure_naming_test.go
+++ b/tests/integration/security/ca_custom_root/trust_domain_alias_secure_naming_test.go
@@ -76,7 +76,7 @@ func TestTrustDomainAliasSecureNaming(t *testing.T) {
 			ctx.Config().ApplyYAMLOrFail(ctx, testNS.Name(), POLICY)
 
 			for _, cluster := range ctx.Clusters() {
-				ctx.NewSubTest(fmt.Sprintf("From %s", cluster.Name())).Run(func(ctx framework.TestContext) {
+				ctx.NewSubTest(fmt.Sprintf("From %s", cluster.StableName())).Run(func(ctx framework.TestContext) {
 					verify := func(ctx framework.TestContext, src echo.Instance, dest echo.Instance, s scheme.Instance, success bool) {
 						want := "success"
 						if !success {

--- a/tests/integration/security/external_ca/basic_reachability.go
+++ b/tests/integration/security/external_ca/basic_reachability.go
@@ -51,7 +51,7 @@ func TestReachability(t *testing.T) {
 			}
 			bSet := apps.B.Match(echo.Namespace(testNamespace.Name()))
 			for _, cluster := range ctx.Clusters() {
-				ctx.NewSubTest(fmt.Sprintf("From %s", cluster.Name())).Run(func(ctx framework.TestContext) {
+				ctx.NewSubTest(fmt.Sprintf("From %s", cluster.StableName())).Run(func(ctx framework.TestContext) {
 					a := apps.A.Match(echo.InCluster(cluster)).Match(echo.Namespace(testNamespace.Name()))[0]
 					ctx.NewSubTest("Basic reachability with external ca").
 						Run(func(ctx framework.TestContext) {

--- a/tests/integration/security/jwt_test.go
+++ b/tests/integration/security/jwt_test.go
@@ -76,7 +76,7 @@ func TestRequestAuthentication(t *testing.T) {
 			}
 
 			for _, cluster := range ctx.Clusters() {
-				ctx.NewSubTest(fmt.Sprintf("From %s", cluster.Name())).Run(func(ctx framework.TestContext) {
+				ctx.NewSubTest(fmt.Sprintf("From %s", cluster.StableName())).Run(func(ctx framework.TestContext) {
 					a := apps.A.Match(echo.InCluster(cluster).And(echo.Namespace(apps.Namespace1.Name())))
 					b := apps.B.Match(echo.InCluster(cluster).And(echo.Namespace(apps.Namespace1.Name())))
 					testCases := []authn.TestCase{
@@ -382,7 +382,7 @@ func TestIngressRequestAuthentication(t *testing.T) {
 			}
 
 			for _, cluster := range ctx.Clusters() {
-				ctx.NewSubTest(fmt.Sprintf("In %s", cluster.Name())).Run(func(ctx framework.TestContext) {
+				ctx.NewSubTest(fmt.Sprintf("In %s", cluster.StableName())).Run(func(ctx framework.TestContext) {
 					a := apps.A.Match(echo.InCluster(cluster).And(echo.Namespace(apps.Namespace1.Name())))
 					// These test cases verify in-mesh traffic doesn't need tokens.
 					testCases := []authn.TestCase{

--- a/tests/integration/security/pass_through_filter_chain_test.go
+++ b/tests/integration/security/pass_through_filter_chain_test.go
@@ -222,7 +222,7 @@ func TestPassThroughFilterChain(t *testing.T) {
 						want:   true,
 					},
 				}
-				ctx.NewSubTest(fmt.Sprintf("In %s", cluster.Name())).Run(func(ctx framework.TestContext) {
+				ctx.NewSubTest(fmt.Sprintf("In %s", cluster.StableName())).Run(func(ctx framework.TestContext) {
 					for _, tc := range cases {
 						name := fmt.Sprintf("A->%s:%d[%t]", tc.target.Config().Service, tc.port, tc.want)
 						a := apps.A.Match(echo.InCluster(cluster)).GetOrFail(ctx, echo.Namespace(ns.Name()))

--- a/tests/integration/security/util/reachability/context.go
+++ b/tests/integration/security/util/reachability/context.go
@@ -105,7 +105,7 @@ func Run(testCases []TestCase, ctx framework.TestContext, apps *util.EchoDeploym
 			for _, clients := range []echo.Instances{apps.A, apps.B.Match(echo.Namespace(apps.Namespace1.Name())), apps.Headless, apps.Naked, apps.HeadlessNaked} {
 				for _, client := range clients {
 					ctx.NewSubTest(fmt.Sprintf("%s in %s",
-						client.Config().Service, client.Config().Cluster.Name())).Run(func(ctx framework.TestContext) {
+						client.Config().Service, client.Config().Cluster.StableName())).Run(func(ctx framework.TestContext) {
 						aSet := apps.A
 						bSet := apps.B
 						// TODO: check why 503 is received for global-plaintext.yaml (https://github.com/istio/istio/issues/28766)

--- a/tests/integration/telemetry/stackdriver/stackdriver_filter_audit_test.go
+++ b/tests/integration/telemetry/stackdriver/stackdriver_filter_audit_test.go
@@ -58,7 +58,7 @@ func TestStackdriverHTTPAuditLogging(t *testing.T) {
 			t.Logf("Audit policy deployed to namespace %v", ns)
 
 			for _, cltInstance := range clt {
-				scopes.Framework.Infof("Validating Audit policy and Telemetry for Cluster %v", cltInstance.Config().Cluster.Name())
+				scopes.Framework.Infof("Validating Audit policy and Telemetry for Cluster %v", cltInstance.Config().Cluster.StableName())
 				g.Go(func() error {
 					err := retry.UntilSuccess(func() error {
 						if err := sendTrafficForAudit(t, cltInstance); err != nil {

--- a/tests/integration/telemetry/stackdriver/stackdriver_filter_test.go
+++ b/tests/integration/telemetry/stackdriver/stackdriver_filter_test.go
@@ -203,7 +203,7 @@ func testSetup(ctx resource.Context) (err error) {
 
 	builder := echoboot.NewBuilder(ctx)
 	for _, cls := range ctx.Clusters() {
-		clName := cls.StableName()
+		clName := cls.Name()
 		builder.
 			WithConfig(echo.Config{
 				Service:   fmt.Sprintf("clt-%s", clName),

--- a/tests/integration/telemetry/stackdriver/stackdriver_filter_test.go
+++ b/tests/integration/telemetry/stackdriver/stackdriver_filter_test.go
@@ -203,7 +203,7 @@ func testSetup(ctx resource.Context) (err error) {
 
 	builder := echoboot.NewBuilder(ctx)
 	for _, cls := range ctx.Clusters() {
-		clName := cls.Name()
+		clName := cls.StableName()
 		builder.
 			WithConfig(echo.Config{
 				Service:   fmt.Sprintf("clt-%s", clName),

--- a/tests/integration/telemetry/tracing/opencensusagent/tracing_test.go
+++ b/tests/integration/telemetry/tracing/opencensusagent/tracing_test.go
@@ -43,7 +43,7 @@ func TestProxyTracing(t *testing.T) {
 			// TODO fix tracing tests in multi-network https://github.com/istio/istio/issues/28890
 			for _, cluster := range ctx.Clusters().ByNetwork()[ctx.Clusters().Default().NetworkName()] {
 				cluster := cluster
-				ctx.NewSubTest(cluster.Name()).Run(func(ctx framework.TestContext) {
+				ctx.NewSubTest(cluster.StableName()).Run(func(ctx framework.TestContext) {
 					retry.UntilSuccessOrFail(t, func() error {
 						err := tracing.SendTraffic(ctx, nil, cluster)
 						if err != nil {

--- a/tests/integration/telemetry/tracing/tracing.go
+++ b/tests/integration/telemetry/tracing/tracing.go
@@ -70,7 +70,7 @@ func TestSetup(ctx resource.Context) (err error) {
 	}
 	builder := echoboot.NewBuilder(ctx)
 	for _, c := range ctx.Clusters() {
-		clName := c.StableName()
+		clName := c.Name()
 		builder = builder.
 			WithConfig(echo.Config{
 				Service:   fmt.Sprintf("client-%s", clName),

--- a/tests/integration/telemetry/tracing/tracing.go
+++ b/tests/integration/telemetry/tracing/tracing.go
@@ -70,7 +70,7 @@ func TestSetup(ctx resource.Context) (err error) {
 	}
 	builder := echoboot.NewBuilder(ctx)
 	for _, c := range ctx.Clusters() {
-		clName := c.Name()
+		clName := c.StableName()
 		builder = builder.
 			WithConfig(echo.Config{
 				Service:   fmt.Sprintf("client-%s", clName),

--- a/tests/integration/telemetry/tracing/zipkin/clienttracing/client_tracing_test.go
+++ b/tests/integration/telemetry/tracing/zipkin/clienttracing/client_tracing_test.go
@@ -43,7 +43,7 @@ func TestClientTracing(t *testing.T) {
 			// TODO fix tracing tests in multi-network https://github.com/istio/istio/issues/28890
 			for _, cluster := range ctx.Clusters().ByNetwork()[ctx.Clusters().Default().NetworkName()] {
 				cluster := cluster
-				ctx.NewSubTest(cluster.Name()).Run(func(ctx framework.TestContext) {
+				ctx.NewSubTest(cluster.StableName()).Run(func(ctx framework.TestContext) {
 					retry.UntilSuccessOrFail(ctx, func() error {
 						// Send test traffic with a trace header.
 						id := uuid.NewV4().String()

--- a/tests/integration/telemetry/tracing/zipkin/servertracing/tracing_test.go
+++ b/tests/integration/telemetry/tracing/zipkin/servertracing/tracing_test.go
@@ -41,7 +41,7 @@ func TestProxyTracing(t *testing.T) {
 			appNsInst := tracing.GetAppNamespace()
 			// TODO fix tracing tests in multi-network https://github.com/istio/istio/issues/28890
 			for _, cluster := range ctx.Clusters().ByNetwork()[ctx.Clusters().Default().NetworkName()] {
-				t.Run(cluster.Name(), func(t *testing.T) {
+				t.Run(cluster.StableName(), func(t *testing.T) {
 					retry.UntilSuccessOrFail(ctx, func() error {
 						err := tracing.SendTraffic(ctx, nil, cluster)
 						if err != nil {


### PR DESCRIPTION
If the underlying cluster names given to the test framework are dynamic (for example, using a pool of non-kind Kubernetes clusters), test grid won't be able to see that certain tests are actually the same since we include the cluster name in the test/subtest names. 

We generate the name using a combination of: 
- the order in which the cluster was added (for uniqueness)
- whether the cluster is a primary, remote, remoteconfig or externalistiod cluster
- if it is a non-kube cluster, simply use the cluster's Kind

examples:

- StaticVM-0
- primary-1
- remote-2
- primary-2

Unfortunately this prevents having very descriptive names like `cross-network-primary`. The network name may also be dynamic. We will log the real name next to the stable name in the "Built cluster" log message.