### PR TITLE
tools/istio-iptables: allow `dry-run` flag to be used across commands

### DIFF
--- a/tools/istio-clean-iptables/pkg/cmd/root.go
+++ b/tools/istio-clean-iptables/pkg/cmd/root.go
@@ -29,6 +29,12 @@ var rootCmd = &cobra.Command{
 	Use:   "istio-clean-iptables",
 	Short: "Clean up iptables rules for Istio Sidecar",
 	Long:  "Script responsible for cleaning up iptables rules",
+	PreRun: func(cmd *cobra.Command, args []string) {
+		if err := viper.BindPFlag(constants.DryRun, cmd.Flags().Lookup(constants.DryRun)); err != nil {
+			handleError(err)
+		}
+		viper.SetDefault(constants.DryRun, false)
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		cleanup(viper.GetBool(constants.DryRun))
 	},
@@ -40,11 +46,11 @@ func init() {
 	// Replace - with _; so that environment variables are looked up correctly.
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 
+	// https://github.com/spf13/viper/issues/233.
+	// The `dry-run` flag is bound in init() across both `istio-iptables` and `istio-clean-iptables` subcommands and
+	// will be overwritten by the last. Thus, only adding it here while moving its binding to Viper and value
+	// defaulting as part of the command execution.
 	rootCmd.Flags().BoolP(constants.DryRun, "n", false, "Do not call any external dependencies like iptables")
-	if err := viper.BindPFlag(constants.DryRun, rootCmd.Flags().Lookup(constants.DryRun)); err != nil {
-		handleError(err)
-	}
-	viper.SetDefault(constants.DryRun, false)
 }
 
 func GetCommand() *cobra.Command {


### PR DESCRIPTION
The `dry-run` flag is bound in init() across both `istio-iptables` and
`istio-clean-iptables` subcommands and will be overwritten by the last due to
https://github.com/spf13/viper/issues/233. This makes the cleaning up dry run
using e.g. `pilot-agent istio-clean-iptables --dry-run/-n` broken.

Binding the flag to Viper and defaulting it at the last possible moment by
moving it to the `PreRun` hook phase as part of the command execution.

Signed-off-by: Kailun Qin <kailun.qin@intel.com>


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.