### PR TITLE
Fix manifest-generate_test tests flake

### DIFF
--- a/operator/cmd/mesh/manifest-generate_test.go
+++ b/operator/cmd/mesh/manifest-generate_test.go
@@ -60,7 +60,7 @@ var (
 
 	// Snapshot charts are in testdata/manifest-generate/data-snapshot
 	snapshotCharts = func() chartSourceType {
-		d, err := os.MkdirTemp("", "data-snapshot-")
+		d, err := ioutil.TempDir("", "data-snapshot-*")
 		if err != nil {
 			panic(fmt.Errorf("failed to make temp dir: %v", err))
 		}


### PR DESCRIPTION
```bash
➜  istio git:(master) go test ./operator/cmd/mesh
# istio.io/istio/operator/cmd/mesh [istio.io/istio/operator/cmd/mesh.test]
operator/cmd/mesh/manifest-generate_test.go:63:13: undefined: os.MkdirTemp
FAIL    istio.io/istio/operator/cmd/mesh [build failed]
FAIL
```

[X] Test and Release

[X] Does not have any changes that may affect Istio users.
