### PR TITLE
tools/istio-clean-iptables: clean up all DNS UDP rules

### DIFF
--- a/tools/istio-clean-iptables/pkg/cmd/cleanup.go
+++ b/tools/istio-clean-iptables/pkg/cmd/cleanup.go
@@ -39,19 +39,19 @@ func removeOldChains(cfg *config.Config, ext dep.Dependencies, cmd string) {
 	// Remove the old DNS UDP rules
 	if dnsCaptureByAgent {
 		for _, uid := range split(cfg.ProxyUID) {
-			ext.RunQuietlyAndIgnore(
-				cmd, "-t", constants.NAT, "-D", constants.OUTPUT, "-p", constants.UDP, "--dport", "53", "-m", "owner", "--uid-owner", uid, "-j", constants.RETURN)
+			ext.RunQuietlyAndIgnore(cmd, "-t", constants.NAT, "-D", constants.OUTPUT, "-p", constants.UDP,
+				"--dport", "53", "-m", "owner", "--uid-owner", uid, "-j", constants.RETURN)
 		}
 		for _, gid := range split(cfg.ProxyGID) {
-			ext.RunQuietlyAndIgnore(
-				cmd, "-t", constants.NAT, "-D", constants.OUTPUT, "-p", constants.UDP, "--dport", "53", "-m", "owner", "--uid-owner", gid, "-j", constants.RETURN)
+			ext.RunQuietlyAndIgnore(cmd, "-t", constants.NAT, "-D", constants.OUTPUT, "-p", constants.UDP,
+				"--dport", "53", "-m", "owner", "--uid-owner", gid, "-j", constants.RETURN)
 		}
 
-		ext.RunQuietlyAndIgnore(
-			cmd, "-t", constants.NAT, "-D", constants.OUTPUT, "-p", constants.UDP, "--dport", "53", "-j", "DNAT", "--to-destination", "127.0.0.1:"+constants.IstioAgentDNSListenerPort)
+		ext.RunQuietlyAndIgnore(cmd, "-t", constants.NAT, "-D", constants.OUTPUT, "-p", constants.UDP,
+			"--dport", "53", "-j", "DNAT", "--to-destination", "127.0.0.1:"+constants.IstioAgentDNSListenerPort)
 
-		ext.RunQuietlyAndIgnore(
-			cmd, "-t", constants.NAT, "-D", constants.POSTROUTING, "-p", constants.UDP, "--dport", constants.IstioAgentDNSListenerPort, "-j", "SNAT", "--to-source", "127.0.0.1")
+		ext.RunQuietlyAndIgnore(cmd, "-t", constants.NAT, "-D", constants.POSTROUTING, "-p", constants.UDP,
+			"--dport", constants.IstioAgentDNSListenerPort, "-j", "SNAT", "--to-source", "127.0.0.1")
 	}
 
 	// Flush and delete the istio chains from NAT table.

--- a/tools/istio-clean-iptables/pkg/cmd/cleanup.go
+++ b/tools/istio-clean-iptables/pkg/cmd/cleanup.go
@@ -39,7 +39,7 @@ func removeOldChains(cfg *config.Config, ext dep.Dependencies, cmd string) {
 	redirectDNS := cfg.RedirectDNS
 	// Remove the old DNS UDP rules
 	if redirectDNS {
-		common.HandleDnsUdp(common.DeleteOps, builder.NewIptablesBuilder(), ext, cmd, cfg.ProxyUID, cfg.ProxyGID, cfg.DNSServersV4)
+		common.HandleDNSUDP(common.DeleteOps, builder.NewIptablesBuilder(), ext, cmd, cfg.ProxyUID, cfg.ProxyGID, cfg.DNSServersV4)
 	}
 
 	// Flush and delete the istio chains from NAT table.

--- a/tools/istio-clean-iptables/pkg/cmd/root.go
+++ b/tools/istio-clean-iptables/pkg/cmd/root.go
@@ -16,13 +16,23 @@ package cmd
 
 import (
 	"os"
+	"os/user"
 	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
+	"istio.io/istio/tools/istio-clean-iptables/pkg/config"
 	"istio.io/istio/tools/istio-iptables/pkg/constants"
+	"istio.io/pkg/env"
 	"istio.io/pkg/log"
+)
+
+var (
+	envoyUserVar = env.RegisterStringVar(constants.EnvoyUser, "istio-proxy", "Envoy proxy username")
+	// Enable interception of DNS.
+	dnsCaptureByAgent = env.RegisterBoolVar("ISTIO_META_DNS_CAPTURE", false,
+		"If set to true, enable the capture of outgoing DNS packets on port 53, redirecting to istio-agent on :15053").Get()
 )
 
 var rootCmd = &cobra.Command{
@@ -36,8 +46,48 @@ var rootCmd = &cobra.Command{
 		viper.SetDefault(constants.DryRun, false)
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		cleanup(viper.GetBool(constants.DryRun))
+		cfg := constructConfig()
+		cleanup(cfg)
 	},
+}
+
+func bindProxyFlags(cmd *cobra.Command, args []string) {
+	if err := viper.BindPFlag(constants.ProxyUID, cmd.Flags().Lookup(constants.ProxyUID)); err != nil {
+		handleError(err)
+	}
+	viper.SetDefault(constants.ProxyUID, "")
+
+	if err := viper.BindPFlag(constants.ProxyGID, cmd.Flags().Lookup(constants.ProxyGID)); err != nil {
+		handleError(err)
+	}
+	viper.SetDefault(constants.ProxyGID, "")
+}
+
+func constructConfig() *config.Config {
+	cfg := &config.Config{
+		DryRun:   viper.GetBool(constants.DryRun),
+		ProxyUID: viper.GetString(constants.ProxyUID),
+		ProxyGID: viper.GetString(constants.ProxyGID),
+	}
+
+	// TODO: Make this more configurable, maybe with an allowlist of users to be captured for output instead of a denylist.
+	if cfg.ProxyUID == "" {
+		usr, err := user.Lookup(envoyUserVar.Get())
+		var userID string
+		// Default to the UID of ENVOY_USER
+		if err != nil {
+			userID = constants.DefaultProxyUID
+		} else {
+			userID = usr.Uid
+		}
+		cfg.ProxyUID = userID
+	}
+	// For TPROXY as its uid and gid are same.
+	if cfg.ProxyGID == "" {
+		cfg.ProxyGID = cfg.ProxyUID
+	}
+
+	return cfg
 }
 
 func init() {
@@ -51,6 +101,14 @@ func init() {
 	// will be overwritten by the last. Thus, only adding it here while moving its binding to Viper and value
 	// defaulting as part of the command execution.
 	rootCmd.Flags().BoolP(constants.DryRun, "n", false, "Do not call any external dependencies like iptables")
+
+	// https://github.com/spf13/viper/issues/233.
+	rootCmd.Flags().StringP(constants.ProxyUID, "u", "",
+		"Specify the UID of the user for which the redirection is not applied. Typically, this is the UID of the proxy container")
+
+	// https://github.com/spf13/viper/issues/233.
+	rootCmd.Flags().StringP(constants.ProxyGID, "g", "",
+		"Specify the GID of the user for which the redirection is not applied. (same default value as -u param)")
 }
 
 func GetCommand() *cobra.Command {

--- a/tools/istio-clean-iptables/pkg/cmd/root.go
+++ b/tools/istio-clean-iptables/pkg/cmd/root.go
@@ -20,10 +20,9 @@ import (
 	"os/user"
 	"strings"
 
+	"github.com/miekg/dns"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-
-	"github.com/miekg/dns"
 
 	"istio.io/istio/tools/istio-clean-iptables/pkg/config"
 	common "istio.io/istio/tools/istio-iptables/pkg/cmd"

--- a/tools/istio-clean-iptables/pkg/config/config.go
+++ b/tools/istio-clean-iptables/pkg/config/config.go
@@ -1,0 +1,46 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"istio.io/pkg/log"
+)
+
+// Command line options
+// nolint: maligned
+type Config struct {
+	DryRun   bool   `json:"DRY_RUN"`
+	ProxyUID string `json:"PROXY_UID"`
+	ProxyGID string `json:"PROXY_GID"`
+}
+
+func (c *Config) String() string {
+	output, err := json.MarshalIndent(c, "", "\t")
+	if err != nil {
+		log.Fatalf("Unable to marshal config object: %v", err)
+	}
+	return string(output)
+}
+
+func (c *Config) Print() {
+	fmt.Println("Variables:")
+	fmt.Println("----------")
+	fmt.Printf("PROXY_UID=%s\n", c.ProxyUID)
+	fmt.Printf("PROXY_GID=%s\n", c.ProxyGID)
+	fmt.Println("")
+}

--- a/tools/istio-clean-iptables/pkg/config/config.go
+++ b/tools/istio-clean-iptables/pkg/config/config.go
@@ -24,9 +24,12 @@ import (
 // Command line options
 // nolint: maligned
 type Config struct {
-	DryRun   bool   `json:"DRY_RUN"`
-	ProxyUID string `json:"PROXY_UID"`
-	ProxyGID string `json:"PROXY_GID"`
+	DryRun       bool     `json:"DRY_RUN"`
+	ProxyUID     string   `json:"PROXY_UID"`
+	ProxyGID     string   `json:"PROXY_GID"`
+	RedirectDNS  bool     `json:"REDIRECT_DNS"`
+	DNSServersV4 []string `json:"DNS_SERVERS_V4"`
+	DNSServersV6 []string `json:"DNS_SERVERS_V6"`
 }
 
 func (c *Config) String() string {
@@ -42,5 +45,7 @@ func (c *Config) Print() {
 	fmt.Println("----------")
 	fmt.Printf("PROXY_UID=%s\n", c.ProxyUID)
 	fmt.Printf("PROXY_GID=%s\n", c.ProxyGID)
+	fmt.Printf("DNS_CAPTURE=%t\n", c.RedirectDNS)
+	fmt.Printf("DNS_SERVERS=%s,%s\n", c.DNSServersV4, c.DNSServersV6)
 	fmt.Println("")
 }

--- a/tools/istio-iptables/pkg/cmd/root.go
+++ b/tools/istio-iptables/pkg/cmd/root.go
@@ -165,6 +165,18 @@ func handleErrorWithCode(err error, code int) {
 	os.Exit(code)
 }
 
+func bindProxyFlags(cmd *cobra.Command, args []string) {
+	if err := viper.BindPFlag(constants.ProxyUID, cmd.Flags().Lookup(constants.ProxyUID)); err != nil {
+		handleError(err)
+	}
+	viper.SetDefault(constants.ProxyUID, "")
+
+	if err := viper.BindPFlag(constants.ProxyGID, cmd.Flags().Lookup(constants.ProxyGID)); err != nil {
+		handleError(err)
+	}
+	viper.SetDefault(constants.ProxyGID, "")
+}
+
 func init() {
 	// Read in all environment variables
 	viper.AutomaticEnv()
@@ -195,19 +207,13 @@ func init() {
 	}
 	viper.SetDefault(constants.InboundTunnelPort, inboundTunnelPort)
 
+	// https://github.com/spf13/viper/issues/233.
 	rootCmd.Flags().StringP(constants.ProxyUID, "u", "",
 		"Specify the UID of the user for which the redirection is not applied. Typically, this is the UID of the proxy container")
-	if err := viper.BindPFlag(constants.ProxyUID, rootCmd.Flags().Lookup(constants.ProxyUID)); err != nil {
-		handleError(err)
-	}
-	viper.SetDefault(constants.ProxyUID, "")
 
+	// https://github.com/spf13/viper/issues/233.
 	rootCmd.Flags().StringP(constants.ProxyGID, "g", "",
 		"Specify the GID of the user for which the redirection is not applied. (same default value as -u param)")
-	if err := viper.BindPFlag(constants.ProxyGID, rootCmd.Flags().Lookup(constants.ProxyGID)); err != nil {
-		handleError(err)
-	}
-	viper.SetDefault(constants.ProxyGID, "")
 
 	rootCmd.Flags().StringP(constants.InboundInterceptionMode, "m", "",
 		"The mode used to redirect inbound connections to Envoy, either \"REDIRECT\" or \"TPROXY\"")

--- a/tools/istio-iptables/pkg/cmd/root.go
+++ b/tools/istio-iptables/pkg/cmd/root.go
@@ -131,7 +131,7 @@ func constructConfig() *config.Config {
 		if err != nil {
 			panic(fmt.Sprintf("failed to load /etc/resolv.conf: %v", err))
 		}
-		cfg.DNSServersV4, cfg.DNSServersV6 = splitV4V6(dnsConfig.Servers)
+		cfg.DNSServersV4, cfg.DNSServersV6 = SplitV4V6(dnsConfig.Servers)
 	}
 	return cfg
 }

--- a/tools/istio-iptables/pkg/cmd/root.go
+++ b/tools/istio-iptables/pkg/cmd/root.go
@@ -42,15 +42,10 @@ var (
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "istio-iptables",
-	Short: "Set up iptables rules for Istio Sidecar",
-	Long:  "istio-iptables is responsible for setting up port forwarding for Istio Sidecar.",
-	PreRun: func(cmd *cobra.Command, args []string) {
-		if err := viper.BindPFlag(constants.DryRun, cmd.Flags().Lookup(constants.DryRun)); err != nil {
-			handleError(err)
-		}
-		viper.SetDefault(constants.DryRun, false)
-	},
+	Use:    "istio-iptables",
+	Short:  "Set up iptables rules for Istio Sidecar",
+	Long:   "istio-iptables is responsible for setting up port forwarding for Istio Sidecar.",
+	PreRun: bindFlags,
 	Run: func(cmd *cobra.Command, args []string) {
 		cfg := constructConfig()
 		var ext dep.Dependencies
@@ -165,19 +160,9 @@ func handleErrorWithCode(err error, code int) {
 	os.Exit(code)
 }
 
-func bindProxyFlags(cmd *cobra.Command, args []string) {
-	if err := viper.BindPFlag(constants.ProxyUID, cmd.Flags().Lookup(constants.ProxyUID)); err != nil {
-		handleError(err)
-	}
-	viper.SetDefault(constants.ProxyUID, "")
-
-	if err := viper.BindPFlag(constants.ProxyGID, cmd.Flags().Lookup(constants.ProxyGID)); err != nil {
-		handleError(err)
-	}
-	viper.SetDefault(constants.ProxyGID, "")
-}
-
-func init() {
+// https://github.com/spf13/viper/issues/233.
+// Any viper mutation and binding should be placed in `PreRun` since they should be dynamically bound to the subcommand being executed.
+func bindFlags(cmd *cobra.Command, args []string) {
 	// Read in all environment variables
 	viper.AutomaticEnv()
 	// Replace - with _; so that environment variables are looked up correctly.
@@ -187,147 +172,180 @@ func init() {
 	inboundPort := "15006"
 	inboundTunnelPort := "15008"
 
-	rootCmd.Flags().StringP(constants.EnvoyPort, "p", "", "Specify the envoy port to which redirect all TCP traffic (default $ENVOY_PORT = 15001)")
-	if err := viper.BindPFlag(constants.EnvoyPort, rootCmd.Flags().Lookup(constants.EnvoyPort)); err != nil {
+	if err := viper.BindPFlag(constants.EnvoyPort, cmd.Flags().Lookup(constants.EnvoyPort)); err != nil {
 		handleError(err)
 	}
 	viper.SetDefault(constants.EnvoyPort, envoyPort)
 
-	rootCmd.Flags().StringP(constants.InboundCapturePort, "z", "",
-		"Port to which all inbound TCP traffic to the pod/VM should be redirected to (default $INBOUND_CAPTURE_PORT = 15006)")
-	if err := viper.BindPFlag(constants.InboundCapturePort, rootCmd.Flags().Lookup(constants.InboundCapturePort)); err != nil {
+	if err := viper.BindPFlag(constants.InboundCapturePort, cmd.Flags().Lookup(constants.InboundCapturePort)); err != nil {
 		handleError(err)
 	}
 	viper.SetDefault(constants.InboundCapturePort, inboundPort)
 
-	rootCmd.Flags().StringP(constants.InboundTunnelPort, "e", "",
-		"Specify the istio tunnel port for inbound tcp traffic (default $INBOUND_TUNNEL_PORT = 15008)")
-	if err := viper.BindPFlag(constants.InboundTunnelPort, rootCmd.Flags().Lookup(constants.InboundTunnelPort)); err != nil {
+	if err := viper.BindPFlag(constants.InboundTunnelPort, cmd.Flags().Lookup(constants.InboundTunnelPort)); err != nil {
 		handleError(err)
 	}
 	viper.SetDefault(constants.InboundTunnelPort, inboundTunnelPort)
 
-	// https://github.com/spf13/viper/issues/233.
+	if err := viper.BindPFlag(constants.ProxyUID, cmd.Flags().Lookup(constants.ProxyUID)); err != nil {
+		handleError(err)
+	}
+	viper.SetDefault(constants.ProxyUID, "")
+
+	if err := viper.BindPFlag(constants.ProxyGID, cmd.Flags().Lookup(constants.ProxyGID)); err != nil {
+		handleError(err)
+	}
+	viper.SetDefault(constants.ProxyGID, "")
+
+	if err := viper.BindPFlag(constants.InboundInterceptionMode, cmd.Flags().Lookup(constants.InboundInterceptionMode)); err != nil {
+		handleError(err)
+	}
+	viper.SetDefault(constants.InboundInterceptionMode, "")
+
+	if err := viper.BindPFlag(constants.InboundPorts, cmd.Flags().Lookup(constants.InboundPorts)); err != nil {
+		handleError(err)
+	}
+	viper.SetDefault(constants.InboundPorts, "")
+
+	if err := viper.BindPFlag(constants.LocalExcludePorts, cmd.Flags().Lookup(constants.LocalExcludePorts)); err != nil {
+		handleError(err)
+	}
+	viper.SetDefault(constants.LocalExcludePorts, "")
+
+	if err := viper.BindPFlag(constants.ServiceCidr, cmd.Flags().Lookup(constants.ServiceCidr)); err != nil {
+		handleError(err)
+	}
+	viper.SetDefault(constants.ServiceCidr, "")
+
+	if err := viper.BindPFlag(constants.ServiceExcludeCidr, cmd.Flags().Lookup(constants.ServiceExcludeCidr)); err != nil {
+		handleError(err)
+	}
+	viper.SetDefault(constants.ServiceExcludeCidr, "")
+
+	if err := viper.BindPFlag(constants.OutboundPorts, cmd.Flags().Lookup(constants.OutboundPorts)); err != nil {
+		handleError(err)
+	}
+	viper.SetDefault(constants.OutboundPorts, "")
+
+	if err := viper.BindPFlag(constants.LocalOutboundPortsExclude, cmd.Flags().Lookup(constants.LocalOutboundPortsExclude)); err != nil {
+		handleError(err)
+	}
+	viper.SetDefault(constants.LocalOutboundPortsExclude, "")
+
+	if err := viper.BindPFlag(constants.KubeVirtInterfaces, cmd.Flags().Lookup(constants.KubeVirtInterfaces)); err != nil {
+		handleError(err)
+	}
+	viper.SetDefault(constants.KubeVirtInterfaces, "")
+
+	if err := viper.BindPFlag(constants.InboundTProxyMark, cmd.Flags().Lookup(constants.InboundTProxyMark)); err != nil {
+		handleError(err)
+	}
+	viper.SetDefault(constants.InboundTProxyMark, "1337")
+
+	if err := viper.BindPFlag(constants.InboundTProxyRouteTable, cmd.Flags().Lookup(constants.InboundTProxyRouteTable)); err != nil {
+		handleError(err)
+	}
+	viper.SetDefault(constants.InboundTProxyRouteTable, "133")
+
+	if err := viper.BindPFlag(constants.DryRun, cmd.Flags().Lookup(constants.DryRun)); err != nil {
+		handleError(err)
+	}
+	viper.SetDefault(constants.DryRun, false)
+
+	if err := viper.BindPFlag(constants.RestoreFormat, cmd.Flags().Lookup(constants.RestoreFormat)); err != nil {
+		handleError(err)
+	}
+	viper.SetDefault(constants.RestoreFormat, true)
+
+	if err := viper.BindPFlag(constants.IptablesProbePort, cmd.Flags().Lookup(constants.IptablesProbePort)); err != nil {
+		handleError(err)
+	}
+	viper.SetDefault(constants.IptablesProbePort, strconv.Itoa(constants.DefaultIptablesProbePort))
+
+	if err := viper.BindPFlag(constants.ProbeTimeout, cmd.Flags().Lookup(constants.ProbeTimeout)); err != nil {
+		handleError(err)
+	}
+	viper.SetDefault(constants.ProbeTimeout, constants.DefaultProbeTimeout)
+
+	if err := viper.BindPFlag(constants.SkipRuleApply, cmd.Flags().Lookup(constants.SkipRuleApply)); err != nil {
+		handleError(err)
+	}
+	viper.SetDefault(constants.SkipRuleApply, false)
+
+	if err := viper.BindPFlag(constants.RunValidation, cmd.Flags().Lookup(constants.RunValidation)); err != nil {
+		handleError(err)
+	}
+	viper.SetDefault(constants.RunValidation, false)
+
+	if err := viper.BindPFlag(constants.RedirectDNS, cmd.Flags().Lookup(constants.RedirectDNS)); err != nil {
+		handleError(err)
+	}
+	viper.SetDefault(constants.RedirectDNS, dnsCaptureByAgent)
+}
+
+// https://github.com/spf13/viper/issues/233.
+// Only adding flags in `init()` while moving its binding to Viper and value defaulting as part of the command execution.
+// Otherwise, the flag with the same name shared across subcommands will be overwritten by the last.
+func init() {
+	rootCmd.Flags().StringP(constants.EnvoyPort, "p", "", "Specify the envoy port to which redirect all TCP traffic (default $ENVOY_PORT = 15001)")
+
+	rootCmd.Flags().StringP(constants.InboundCapturePort, "z", "",
+		"Port to which all inbound TCP traffic to the pod/VM should be redirected to (default $INBOUND_CAPTURE_PORT = 15006)")
+
+	rootCmd.Flags().StringP(constants.InboundTunnelPort, "e", "",
+		"Specify the istio tunnel port for inbound tcp traffic (default $INBOUND_TUNNEL_PORT = 15008)")
+
 	rootCmd.Flags().StringP(constants.ProxyUID, "u", "",
 		"Specify the UID of the user for which the redirection is not applied. Typically, this is the UID of the proxy container")
 
-	// https://github.com/spf13/viper/issues/233.
 	rootCmd.Flags().StringP(constants.ProxyGID, "g", "",
 		"Specify the GID of the user for which the redirection is not applied. (same default value as -u param)")
 
 	rootCmd.Flags().StringP(constants.InboundInterceptionMode, "m", "",
 		"The mode used to redirect inbound connections to Envoy, either \"REDIRECT\" or \"TPROXY\"")
-	if err := viper.BindPFlag(constants.InboundInterceptionMode, rootCmd.Flags().Lookup(constants.InboundInterceptionMode)); err != nil {
-		handleError(err)
-	}
-	viper.SetDefault(constants.InboundInterceptionMode, "")
 
 	rootCmd.Flags().StringP(constants.InboundPorts, "b", "",
 		"Comma separated list of inbound ports for which traffic is to be redirected to Envoy (optional). "+
 			"The wildcard character \"*\" can be used to configure redirection for all ports. An empty list will disable")
-	if err := viper.BindPFlag(constants.InboundPorts, rootCmd.Flags().Lookup(constants.InboundPorts)); err != nil {
-		handleError(err)
-	}
-	viper.SetDefault(constants.InboundPorts, "")
 
 	rootCmd.Flags().StringP(constants.LocalExcludePorts, "d", "",
 		"Comma separated list of inbound ports to be excluded from redirection to Envoy (optional). "+
 			"Only applies  when all inbound traffic (i.e. \"*\") is being redirected (default to $ISTIO_LOCAL_EXCLUDE_PORTS)")
-	if err := viper.BindPFlag(constants.LocalExcludePorts, rootCmd.Flags().Lookup(constants.LocalExcludePorts)); err != nil {
-		handleError(err)
-	}
-	viper.SetDefault(constants.LocalExcludePorts, "")
 
 	rootCmd.Flags().StringP(constants.ServiceCidr, "i", "",
 		"Comma separated list of IP ranges in CIDR form to redirect to envoy (optional). "+
 			"The wildcard character \"*\" can be used to redirect all outbound traffic. An empty list will disable all outbound")
-	if err := viper.BindPFlag(constants.ServiceCidr, rootCmd.Flags().Lookup(constants.ServiceCidr)); err != nil {
-		handleError(err)
-	}
-	viper.SetDefault(constants.ServiceCidr, "")
 
 	rootCmd.Flags().StringP(constants.ServiceExcludeCidr, "x", "",
 		"Comma separated list of IP ranges in CIDR form to be excluded from redirection. "+
 			"Only applies when all  outbound traffic (i.e. \"*\") is being redirected (default to $ISTIO_SERVICE_EXCLUDE_CIDR)")
-	if err := viper.BindPFlag(constants.ServiceExcludeCidr, rootCmd.Flags().Lookup(constants.ServiceExcludeCidr)); err != nil {
-		handleError(err)
-	}
-	viper.SetDefault(constants.ServiceExcludeCidr, "")
 
 	rootCmd.Flags().StringP(constants.OutboundPorts, "q", "",
 		"Comma separated list of outbound ports to be explicitly included for redirection to Envoy")
-	if err := viper.BindPFlag(constants.OutboundPorts, rootCmd.Flags().Lookup(constants.OutboundPorts)); err != nil {
-		handleError(err)
-	}
-	viper.SetDefault(constants.OutboundPorts, "")
 
 	rootCmd.Flags().StringP(constants.LocalOutboundPortsExclude, "o", "",
 		"Comma separated list of outbound ports to be excluded from redirection to Envoy")
-	if err := viper.BindPFlag(constants.LocalOutboundPortsExclude, rootCmd.Flags().Lookup(constants.LocalOutboundPortsExclude)); err != nil {
-		handleError(err)
-	}
-	viper.SetDefault(constants.LocalOutboundPortsExclude, "")
 
 	rootCmd.Flags().StringP(constants.KubeVirtInterfaces, "k", "",
 		"Comma separated list of virtual interfaces whose inbound traffic (from VM) will be treated as outbound")
-	if err := viper.BindPFlag(constants.KubeVirtInterfaces, rootCmd.Flags().Lookup(constants.KubeVirtInterfaces)); err != nil {
-		handleError(err)
-	}
-	viper.SetDefault(constants.KubeVirtInterfaces, "")
 
 	rootCmd.Flags().StringP(constants.InboundTProxyMark, "t", "", "")
-	if err := viper.BindPFlag(constants.InboundTProxyMark, rootCmd.Flags().Lookup(constants.InboundTProxyMark)); err != nil {
-		handleError(err)
-	}
-	viper.SetDefault(constants.InboundTProxyMark, "1337")
 
 	rootCmd.Flags().StringP(constants.InboundTProxyRouteTable, "r", "", "")
-	if err := viper.BindPFlag(constants.InboundTProxyRouteTable, rootCmd.Flags().Lookup(constants.InboundTProxyRouteTable)); err != nil {
-		handleError(err)
-	}
-	viper.SetDefault(constants.InboundTProxyRouteTable, "133")
 
-	// https://github.com/spf13/viper/issues/233.
-	// The `dry-run` flag is bound in init() across both `istio-iptables` and `istio-clean-iptables` subcommands and
-	// will be overwritten by the last. Thus, only adding it here while moving its binding to Viper and value
-	// defaulting as part of the command execution.
 	rootCmd.Flags().BoolP(constants.DryRun, "n", false, "Do not call any external dependencies like iptables")
 
 	rootCmd.Flags().BoolP(constants.RestoreFormat, "f", true, "Print iptables rules in iptables-restore interpretable format")
-	if err := viper.BindPFlag(constants.RestoreFormat, rootCmd.Flags().Lookup(constants.RestoreFormat)); err != nil {
-		handleError(err)
-	}
-	viper.SetDefault(constants.RestoreFormat, true)
 
 	rootCmd.Flags().String(constants.IptablesProbePort, strconv.Itoa(constants.DefaultIptablesProbePort), "set listen port for failure detection")
-	if err := viper.BindPFlag(constants.IptablesProbePort, rootCmd.Flags().Lookup(constants.IptablesProbePort)); err != nil {
-		handleError(err)
-	}
-	viper.SetDefault(constants.IptablesProbePort, strconv.Itoa(constants.DefaultIptablesProbePort))
 
 	rootCmd.Flags().Duration(constants.ProbeTimeout, constants.DefaultProbeTimeout, "failure detection timeout")
-	if err := viper.BindPFlag(constants.ProbeTimeout, rootCmd.Flags().Lookup(constants.ProbeTimeout)); err != nil {
-		handleError(err)
-	}
-	viper.SetDefault(constants.ProbeTimeout, constants.DefaultProbeTimeout)
 
 	rootCmd.Flags().Bool(constants.SkipRuleApply, false, "Skip iptables apply")
-	if err := viper.BindPFlag(constants.SkipRuleApply, rootCmd.Flags().Lookup(constants.SkipRuleApply)); err != nil {
-		handleError(err)
-	}
-	viper.SetDefault(constants.SkipRuleApply, false)
 
 	rootCmd.Flags().Bool(constants.RunValidation, false, "Validate iptables")
-	if err := viper.BindPFlag(constants.RunValidation, rootCmd.Flags().Lookup(constants.RunValidation)); err != nil {
-		handleError(err)
-	}
-	viper.SetDefault(constants.RunValidation, false)
 
 	rootCmd.Flags().Bool(constants.RedirectDNS, dnsCaptureByAgent, "Enable capture of dns traffic by istio-agent")
-	if err := viper.BindPFlag(constants.RedirectDNS, rootCmd.Flags().Lookup(constants.RedirectDNS)); err != nil {
-		handleError(err)
-	}
-	viper.SetDefault(constants.RedirectDNS, dnsCaptureByAgent)
 }
 
 func GetCommand() *cobra.Command {

--- a/tools/istio-iptables/pkg/cmd/run.go
+++ b/tools/istio-iptables/pkg/cmd/run.go
@@ -28,6 +28,20 @@ import (
 	dep "istio.io/istio/tools/istio-iptables/pkg/dependencies"
 )
 
+type Ops int
+
+const (
+	// AppendOps performs append operations of rules
+	AppendOps Ops = iota
+	// DeleteOps performs delete operations of rules
+	DeleteOps
+)
+
+var opsToString = map[Ops]string{
+	AppendOps: "-A",
+	DeleteOps: "-D",
+}
+
 type IptablesConfigurator struct {
 	iptables *builder.IptablesBuilderImpl
 	// TODO(abhide): Fix dep.Dependencies with better interface
@@ -339,7 +353,7 @@ func (iptConfigurator *IptablesConfigurator) shortCircuitKubeInternalInterface()
 	}
 }
 
-func splitV4V6(ips []string) (ipv4 []string, ipv6 []string) {
+func SplitV4V6(ips []string) (ipv4 []string, ipv6 []string) {
 	for _, i := range ips {
 		parsed := net.ParseIP(i)
 		if parsed.To4() != nil {
@@ -525,29 +539,9 @@ func (iptConfigurator *IptablesConfigurator) run() {
 	}
 
 	if redirectDNS {
-		// Make sure that upstream DNS requests from agent/envoy dont get captured.
-		// TODO: add ip6 as well
-		for _, uid := range split(iptConfigurator.cfg.ProxyUID) {
-			iptConfigurator.iptables.AppendRuleV4(constants.OUTPUT, constants.NAT,
-				"-p", "udp", "--dport", "53", "-m", "owner", "--uid-owner", uid, "-j", constants.RETURN)
-		}
-		for _, gid := range split(iptConfigurator.cfg.ProxyGID) {
-			iptConfigurator.iptables.AppendRuleV4(constants.OUTPUT, constants.NAT,
-				"-p", "udp", "--dport", "53", "-m", "owner", "--gid-owner", gid, "-j", constants.RETURN)
-		}
-
-		// redirect all TCP dns traffic on port 53 to the agent on port 15053 for all servers
-		// in etc/resolv.conf
-		// We avoid redirecting all IP ranges to avoid infinite loops when there are local DNS proxies
-		// such as: app -> istio dns server -> dnsmasq -> upstream
-		// This ensures that we do not get requests from dnsmasq sent back to the agent dns server in a loop.
-		// Note: If a user somehow configured etc/resolv.conf to point to dnsmasq and server X, and dnsmasq also
-		// pointed to server X, this would not work. However, the assumption is that is not a common case.
-		for _, s := range iptConfigurator.cfg.DNSServersV4 {
-			iptConfigurator.iptables.AppendRuleV4(constants.OUTPUT, constants.NAT,
-				"-p", "udp", "--dport", "53", "-d", s+"/32",
-				"-j", constants.REDIRECT, "--to-port", constants.IstioAgentDNSListenerPort)
-		}
+		HandleDnsUdp(
+			AppendOps, iptConfigurator.iptables, iptConfigurator.ext, "",
+			iptConfigurator.cfg.ProxyUID, iptConfigurator.cfg.ProxyGID, iptConfigurator.cfg.DNSServersV4)
 	}
 
 	if iptConfigurator.cfg.InboundInterceptionMode == constants.TPROXY {
@@ -562,6 +556,60 @@ func (iptConfigurator *IptablesConfigurator) run() {
 			"-p", constants.TCP, "-m", "mark", "--mark", iptConfigurator.cfg.InboundTProxyMark, "-j", constants.RETURN)
 	}
 	iptConfigurator.executeCommands()
+}
+
+// HandleDnsUdp is a helper function to tackle with DNS UDP specific operations.
+// This helps the creation logic of DNS UDP rules in sync with the deletion.
+func HandleDnsUdp(
+	ops Ops, iptables *builder.IptablesBuilderImpl, ext dep.Dependencies,
+	cmd, proxyUID, proxyGID string, dnsServersV4 []string) {
+	const paramIdxRaw = 5
+	var raw []string
+	opsStr := opsToString[ops]
+	table := constants.NAT
+	chain := constants.OUTPUT
+
+	// Make sure that upstream DNS requests from agent/envoy dont get captured.
+	// TODO: add ip6 as well
+	for _, uid := range split(proxyUID) {
+		raw = []string{cmd, "-t", table, opsStr, chain,
+			"-p", "udp", "--dport", "53", "-m", "owner", "--uid-owner", uid, "-j", constants.RETURN}
+		switch ops {
+		case AppendOps:
+			iptables.AppendRuleV4(chain, table, raw[paramIdxRaw:]...)
+		case DeleteOps:
+			ext.RunQuietlyAndIgnore(cmd, raw...)
+		}
+	}
+	for _, gid := range split(proxyGID) {
+		raw = []string{cmd, "-t", table, opsStr, chain,
+			"-p", "udp", "--dport", "53", "-m", "owner", "--gid-owner", gid, "-j", constants.RETURN}
+		switch ops {
+		case AppendOps:
+			iptables.AppendRuleV4(chain, table, raw[paramIdxRaw:]...)
+		case DeleteOps:
+			ext.RunQuietlyAndIgnore(cmd, raw...)
+		}
+	}
+
+	// redirect all TCP dns traffic on port 53 to the agent on port 15053 for all servers
+	// in etc/resolv.conf
+	// We avoid redirecting all IP ranges to avoid infinite loops when there are local DNS proxies
+	// such as: app -> istio dns server -> dnsmasq -> upstream
+	// This ensures that we do not get requests from dnsmasq sent back to the agent dns server in a loop.
+	// Note: If a user somehow configured etc/resolv.conf to point to dnsmasq and server X, and dnsmasq also
+	// pointed to server X, this would not work. However, the assumption is that is not a common case.
+	for _, s := range dnsServersV4 {
+		raw = []string{cmd, "-t", table, opsStr, chain,
+			"-p", "udp", "--dport", "53", "-d", s + "/32",
+			"-j", constants.REDIRECT, "--to-port", constants.IstioAgentDNSListenerPort}
+		switch ops {
+		case AppendOps:
+			iptables.AppendRuleV4(chain, table, raw[paramIdxRaw:]...)
+		case DeleteOps:
+			ext.RunQuietlyAndIgnore(cmd, raw...)
+		}
+	}
 }
 
 func (iptConfigurator *IptablesConfigurator) handleOutboundPortsInclude() {

--- a/tools/istio-iptables/pkg/cmd/run_test.go
+++ b/tools/istio-iptables/pkg/cmd/run_test.go
@@ -676,7 +676,7 @@ func TestHandleInboundPortsIncludeWithWildcardInboundPortsAndTproxy(t *testing.T
 }
 
 func TestHandleInboundIpv4RulesWithUidGid(t *testing.T) {
-	cfg := constructConfig()
+	cfg := constructTestConfig()
 	cfg.DryRun = true
 	cfg.RedirectDNS = true
 	cfg.DNSServersV4 = []string{"127.0.0.53"}
@@ -723,7 +723,7 @@ func TestHandleInboundIpv4RulesWithUidGid(t *testing.T) {
 }
 
 func TestGenerateEmptyV6ConfigOnV4OnlyEnv(t *testing.T) {
-	cfg := constructConfig()
+	cfg := constructTestConfig()
 	cfg.DryRun = true
 	cfg.RedirectDNS = true
 	iptConfigurator := NewIptablesConfigurator(cfg, &dep.StdoutStubDependencies{})


### PR DESCRIPTION
This patch adds the support of cleaning up all DNS UDP rules in iptables tools,
by reusing the same logic on creation. This helps prevent them from being out
of sync. 

To allow multiple flags with the same name to be used across different
subcommands, this patch also moves all viper mutation and binding to `PreRun`
as part of the command execution so that no overwritten will take place.

Fixes https://github.com/istio/istio/issues/30674

Signed-off-by: Kailun Qin <kailun.qin@intel.com>

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
