### PR TITLE
Fix base templates for shared control plane when remotePilotAddress is a hostname

### DIFF
--- a/manifests/charts/base/templates/endpoints.yaml
+++ b/manifests/charts/base/templates/endpoints.yaml
@@ -1,22 +1,15 @@
 {{- if .Values.global.remotePilotAddress }}
-  {{- if .Values.pilot.enabled }}
+  {{- if regexMatch "^([0-9]*\\.){3}[0-9]*$" .Values.global.remotePilotAddress }}
+# only attempt to create an Endpoint if remotePilotAddress is an IP address
 apiVersion: v1
 kind: Endpoints
 metadata:
+    {{- if .Values.pilot.enabled }}
+  # when istiod is enabled in remote cluster, we can't use istiod service name
   name: istiod-remote
-  namespace: {{ .Release.Namespace }}
-subsets:
-- addresses:
-  - ip: {{ .Values.global.remotePilotAddress }}
-  ports:
-  - port: 15012
-    name: tcp-istiod
-    protocol: TCP
-  {{- else if regexMatch "^([0-9]*\\.){3}[0-9]*$" .Values.global.remotePilotAddress }}
-apiVersion: v1
-kind: Endpoints
-metadata:
+    {{- else }}
   name: istiod
+    {{- end }}
   namespace: {{ .Release.Namespace }}
 subsets:
 - addresses:
@@ -25,6 +18,6 @@ subsets:
   - port: 15012
     name: tcp-istiod
     protocol: TCP
-  {{- end }}
 ---
+  {{- end }}
 {{- end }}

--- a/manifests/charts/base/templates/services.yaml
+++ b/manifests/charts/base/templates/services.yaml
@@ -1,23 +1,13 @@
 {{- if .Values.global.remotePilotAddress }}
+apiVersion: v1
+kind: Service
+metadata:
   {{- if .Values.pilot.enabled }}
-# when istiod is enabled in remote cluster, we can't use istiod service name
-apiVersion: v1
-kind: Service
-metadata:
+  # when istiod is enabled in remote cluster, we can't use istiod service name
   name: istiod-remote
-  namespace: {{ .Release.Namespace }}
-spec:
-  ports:
-  - port: 15012
-    name: tcp-istiod
-    protocol: TCP
-  clusterIP: None
   {{- else }}
-# when istiod isn't enabled in remote cluster, we can use istiod service name
-apiVersion: v1
-kind: Service
-metadata:
   name: istiod
+  {{- end }}
   namespace: {{ .Release.Namespace }}
 spec:
   ports:
@@ -31,7 +21,6 @@ spec:
   {{- else }}
   type: ExternalName
   externalName: {{ .Values.global.remotePilotAddress }}
-  {{- end }}
   {{- end }}
 ---
 {{- end }}

--- a/releasenotes/notes/fix-remotepilotaddress-sharedcontrolplane.yaml
+++ b/releasenotes/notes/fix-remotepilotaddress-sharedcontrolplane.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+releaseNotes:
+- |
+  **Fixed** base templates for services/endpoints to cover cases where remotePilotAddress is a hostname and Istio is being installed in the "shared control plane" topology.


### PR DESCRIPTION
Extends the change in https://github.com/istio/istio/pull/24219 by @linsun to cover cases where remotePilotAddress is a hostname and Istio is being installed in the "shared control plane" topology.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
