### PR TITLE
Catch user input error on remote secret creation.

### DIFF
--- a/istioctl/pkg/multicluster/remote_secret_test.go
+++ b/istioctl/pkg/multicluster/remote_secret_test.go
@@ -244,6 +244,23 @@ func TestCreateRemoteSecrets(t *testing.T) {
 			name:       "cluster-foo",
 			want:       "cal-want",
 		},
+		{
+			testName: "fail when non-existing secret name provided",
+			objs:     []runtime.Object{kubeSystemNamespace, sa2, saSecret, saSecret2},
+			config: &api.Config{
+				CurrentContext: testContext,
+				Contexts: map[string]*api.Context{
+					testContext: {Cluster: "cluster"},
+				},
+				Clusters: map[string]*api.Cluster{
+					"cluster": {Server: "server"},
+				},
+			},
+			secretName: "nonexistingSecret",
+			name:       "cluster-foo",
+			want:       "cal-want",
+			wantErrStr: "provided secret does not exist",
+		},
 	}
 
 	for i := range cases {

--- a/releasenotes/notes/30723.yaml
+++ b/releasenotes/notes/30723.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: istioctl
+issue:
+  - 30723
+releaseNotes:
+  - |
+    **Fixed** Fail correctly when `istioctl x create-remote-secret --secret-name` points to a non-existing secret in the remote cluster.


### PR DESCRIPTION
Currently, when there are multiple secrets in the remote service account and the user specifies a non-existing one, it is silently ignored and the first secret is picked up.
This change adds an appropriate error message when this happens.

This is a follow up PR for: https://github.com/istio/istio/pull/30565

[ ] Configuration Infrastructure
[ ] Docs
[x] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[x] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
