### PR TITLE
fix envoy filter service match for inbound clusters

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -302,7 +302,11 @@ func (configgen *ConfigGeneratorImpl) buildInboundClusters(cb *ClusterBuilder, i
 		for _, instances := range clustersToBuild {
 			instance := instances[0]
 			localCluster := cb.buildInboundClusterForPortOrUDS(cb.proxy, int(instance.Endpoint.EndpointPort), actualLocalHost, instance, instances)
-			clusters = cp.conditionallyAppend(clusters, instance.Service.Hostname, localCluster)
+			// If inbound cluster match has service, we should see if it matches with any host name across all instances
+			// and merge the filter.
+			for _, si := range instances {
+				clusters = cp.conditionallyAppend(clusters, si.Service.Hostname, localCluster)
+			}
 		}
 		return clusters
 	}

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -100,20 +100,20 @@ func (configgen *ConfigGeneratorImpl) BuildClusters(proxy *model.Proxy, push *mo
 		outboundPatcher := clusterPatcher{envoyFilterPatches, networking.EnvoyFilter_SIDECAR_OUTBOUND}
 		clusters = append(clusters, configgen.buildOutboundClusters(cb, outboundPatcher)...)
 		// Add a blackhole and passthrough cluster for catching traffic to unresolved routes
-		clusters = outboundPatcher.conditionallyAppend(clusters, "", cb.buildBlackHoleCluster(), cb.buildDefaultPassthroughCluster())
+		clusters = outboundPatcher.conditionallyAppend(clusters, nil, cb.buildBlackHoleCluster(), cb.buildDefaultPassthroughCluster())
 		clusters = append(clusters, outboundPatcher.insertedClusters()...)
 
 		// Setup inbound clusters
 		inboundPatcher := clusterPatcher{envoyFilterPatches, networking.EnvoyFilter_SIDECAR_INBOUND}
 		clusters = append(clusters, configgen.buildInboundClusters(cb, instances, inboundPatcher)...)
 		// Pass through clusters for inbound traffic. These cluster bind loopback-ish src address to access node local service.
-		clusters = inboundPatcher.conditionallyAppend(clusters, "", cb.buildInboundPassthroughClusters()...)
+		clusters = inboundPatcher.conditionallyAppend(clusters, nil, cb.buildInboundPassthroughClusters()...)
 		clusters = append(clusters, inboundPatcher.insertedClusters()...)
 	default: // Gateways
 		patcher := clusterPatcher{envoyFilterPatches, networking.EnvoyFilter_GATEWAY}
 		clusters = append(clusters, configgen.buildOutboundClusters(cb, patcher)...)
 		// Gateways do not require the default passthrough cluster as they do not have original dst listeners.
-		clusters = patcher.conditionallyAppend(clusters, "", cb.buildBlackHoleCluster())
+		clusters = patcher.conditionallyAppend(clusters, nil, cb.buildBlackHoleCluster())
 		if proxy.Type == model.Router && proxy.GetRouterMode() == model.SniDnatRouter {
 			clusters = append(clusters, configgen.buildOutboundSniDnatClusters(proxy, push, patcher)...)
 		}
@@ -175,8 +175,8 @@ func (configgen *ConfigGeneratorImpl) buildOutboundClusters(cb *ClusterBuilder, 
 
 			subsetClusters := cb.applyDestinationRule(defaultCluster, DefaultClusterMode, service, port, networkView)
 
-			clusters = cp.conditionallyAppend(clusters, "", defaultCluster)
-			clusters = cp.conditionallyAppend(clusters, "", subsetClusters...)
+			clusters = cp.conditionallyAppend(clusters, nil, defaultCluster)
+			clusters = cp.conditionallyAppend(clusters, nil, subsetClusters...)
 		}
 	}
 
@@ -190,10 +190,10 @@ type clusterPatcher struct {
 	pctx networking.EnvoyFilter_PatchContext
 }
 
-func (p clusterPatcher) conditionallyAppend(l []*cluster.Cluster, host host.Name, clusters ...*cluster.Cluster) []*cluster.Cluster {
+func (p clusterPatcher) conditionallyAppend(l []*cluster.Cluster, hosts []host.Name, clusters ...*cluster.Cluster) []*cluster.Cluster {
 	for _, c := range clusters {
-		if envoyfilter.ShouldKeepCluster(p.pctx, p.efw, c, host) {
-			l = append(l, envoyfilter.ApplyClusterMerge(p.pctx, p.efw, c, host))
+		if envoyfilter.ShouldKeepCluster(p.pctx, p.efw, c, hosts) {
+			l = append(l, envoyfilter.ApplyClusterMerge(p.pctx, p.efw, c, hosts))
 		}
 	}
 	return l
@@ -231,8 +231,8 @@ func (configgen *ConfigGeneratorImpl) buildOutboundSniDnatClusters(proxy *model.
 				continue
 			}
 			subsetClusters := cb.applyDestinationRule(defaultCluster, SniDnatClusterMode, service, port, networkView)
-			clusters = cp.conditionallyAppend(clusters, "", defaultCluster)
-			clusters = cp.conditionallyAppend(clusters, "", subsetClusters...)
+			clusters = cp.conditionallyAppend(clusters, nil, defaultCluster)
+			clusters = cp.conditionallyAppend(clusters, nil, subsetClusters...)
 		}
 	}
 
@@ -302,11 +302,12 @@ func (configgen *ConfigGeneratorImpl) buildInboundClusters(cb *ClusterBuilder, i
 		for _, instances := range clustersToBuild {
 			instance := instances[0]
 			localCluster := cb.buildInboundClusterForPortOrUDS(cb.proxy, int(instance.Endpoint.EndpointPort), actualLocalHost, instance, instances)
-			// If inbound cluster match has service, we should see if it matches with any host name across all instances
-			// and merge the filter.
+			// If inbound cluster match has service, we should see if it matches with any host name across all instances.
+			var hosts []host.Name
 			for _, si := range instances {
-				clusters = cp.conditionallyAppend(clusters, si.Service.Hostname, localCluster)
+				hosts = append(hosts, si.Service.Hostname)
 			}
+			clusters = cp.conditionallyAppend(clusters, hosts, localCluster)
 		}
 		return clusters
 	}
@@ -368,7 +369,7 @@ func (configgen *ConfigGeneratorImpl) buildInboundClusters(cb *ClusterBuilder, i
 				},
 			}
 		}
-		clusters = cp.conditionallyAppend(clusters, instance.Service.Hostname, localCluster)
+		clusters = cp.conditionallyAppend(clusters, []host.Name{instance.Service.Hostname}, localCluster)
 	}
 
 	return clusters

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/cluster_patch.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/cluster_patch.go
@@ -29,7 +29,7 @@ import (
 	"istio.io/pkg/log"
 )
 
-func ApplyClusterMerge(pctx networking.EnvoyFilter_PatchContext, efw *model.EnvoyFilterWrapper, c *cluster.Cluster) (out *cluster.Cluster) {
+func ApplyClusterMerge(pctx networking.EnvoyFilter_PatchContext, efw *model.EnvoyFilterWrapper, c *cluster.Cluster, host host.Name) (out *cluster.Cluster) {
 	defer runtime.HandleCrash(runtime.LogPanic, func(interface{}) {
 		log.Errorf("clusters patch caused panic, so the patches did not take effect")
 	})
@@ -42,7 +42,7 @@ func ApplyClusterMerge(pctx networking.EnvoyFilter_PatchContext, efw *model.Envo
 		if cp.Operation != networking.EnvoyFilter_Patch_MERGE {
 			continue
 		}
-		if commonConditionMatch(pctx, cp) && clusterMatch(c, cp) {
+		if commonConditionMatch(pctx, cp) && clusterMatch(c, cp, host) {
 
 			ret, err := mergeTransportSocketCluster(c, cp)
 			if err != nil {
@@ -102,7 +102,7 @@ func mergeTransportSocketCluster(c *cluster.Cluster, cp *model.EnvoyFilterConfig
 	return false, nil
 }
 
-func ShouldKeepCluster(pctx networking.EnvoyFilter_PatchContext, efw *model.EnvoyFilterWrapper, c *cluster.Cluster) bool {
+func ShouldKeepCluster(pctx networking.EnvoyFilter_PatchContext, efw *model.EnvoyFilterWrapper, c *cluster.Cluster, host host.Name) bool {
 	if efw == nil {
 		return true
 	}
@@ -110,7 +110,7 @@ func ShouldKeepCluster(pctx networking.EnvoyFilter_PatchContext, efw *model.Envo
 		if cp.Operation != networking.EnvoyFilter_Patch_REMOVE {
 			continue
 		}
-		if commonConditionMatch(pctx, cp) && clusterMatch(c, cp) {
+		if commonConditionMatch(pctx, cp) && clusterMatch(c, cp, host) {
 			return false
 		}
 	}
@@ -133,7 +133,7 @@ func InsertedClusters(pctx networking.EnvoyFilter_PatchContext, efw *model.Envoy
 	return result
 }
 
-func clusterMatch(cluster *cluster.Cluster, cp *model.EnvoyFilterConfigPatchWrapper) bool {
+func clusterMatch(cluster *cluster.Cluster, cp *model.EnvoyFilterConfigPatchWrapper, service host.Name) bool {
 	cMatch := cp.Match.GetCluster()
 	if cMatch == nil {
 		return true
@@ -143,13 +143,19 @@ func clusterMatch(cluster *cluster.Cluster, cp *model.EnvoyFilterConfigPatchWrap
 		return cMatch.Name == cluster.Name
 	}
 
-	_, subset, hostname, port := model.ParseSubsetKey(cluster.Name)
+	direction, subset, hostname, port := model.ParseSubsetKey(cluster.Name)
+
+	hostMatch := hostname
+	// For inbound clusters, host parsed from subset key will be empty. Use the passed in service name.
+	if direction == model.TrafficDirectionInbound && len(service) > 0 {
+		hostMatch = service
+	}
 
 	if cMatch.Subset != "" && cMatch.Subset != subset {
 		return false
 	}
 
-	if cMatch.Service != "" && host.Name(cMatch.Service) != hostname {
+	if cMatch.Service != "" && host.Name(cMatch.Service) != hostMatch {
 		return false
 	}
 

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/cluster_patch.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/cluster_patch.go
@@ -29,6 +29,7 @@ import (
 	"istio.io/pkg/log"
 )
 
+// ApplyClusterMerge processes the MERGE operation and merges the supplied configuration to the matched clusters.
 func ApplyClusterMerge(pctx networking.EnvoyFilter_PatchContext, efw *model.EnvoyFilterWrapper, c *cluster.Cluster, host host.Name) (out *cluster.Cluster) {
 	defer runtime.HandleCrash(runtime.LogPanic, func(interface{}) {
 		log.Errorf("clusters patch caused panic, so the patches did not take effect")
@@ -102,6 +103,7 @@ func mergeTransportSocketCluster(c *cluster.Cluster, cp *model.EnvoyFilterConfig
 	return false, nil
 }
 
+// ShouldKeepCluster checks if there is a REMOVE patch on the cluster, returns false if there is on so that it is removed.
 func ShouldKeepCluster(pctx networking.EnvoyFilter_PatchContext, efw *model.EnvoyFilterWrapper, c *cluster.Cluster, host host.Name) bool {
 	if efw == nil {
 		return true
@@ -117,6 +119,7 @@ func ShouldKeepCluster(pctx networking.EnvoyFilter_PatchContext, efw *model.Envo
 	return true
 }
 
+// InsertedClusters collects all clusters that are added via ADD operation and match the patch context.
 func InsertedClusters(pctx networking.EnvoyFilter_PatchContext, efw *model.EnvoyFilterWrapper) []*cluster.Cluster {
 	if efw == nil {
 		return nil

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/cluster_patch_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/cluster_patch_test.go
@@ -149,7 +149,7 @@ func Test_clusterMatch(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := clusterMatch(tt.args.cluster, &model.EnvoyFilterConfigPatchWrapper{Match: tt.args.matchCondition}, tt.args.host); got != tt.want {
+			if got := clusterMatch(tt.args.cluster, &model.EnvoyFilterConfigPatchWrapper{Match: tt.args.matchCondition}, []host.Name{tt.args.host}); got != tt.want {
 				t.Errorf("clusterMatch() = %v, want %v", got, tt.want)
 			}
 		})
@@ -479,8 +479,8 @@ func TestClusterPatching(t *testing.T) {
 			efw := push.EnvoyFilters(tc.proxy)
 			output := []*cluster.Cluster{}
 			for _, c := range tc.input {
-				if ShouldKeepCluster(tc.patchContext, efw, c, host.Name(tc.host)) {
-					output = append(output, ApplyClusterMerge(tc.patchContext, efw, c, host.Name(tc.host)))
+				if ShouldKeepCluster(tc.patchContext, efw, c, []host.Name{host.Name(tc.host)}) {
+					output = append(output, ApplyClusterMerge(tc.patchContext, efw, c, []host.Name{host.Name(tc.host)}))
 				}
 			}
 			output = append(output, InsertedClusters(tc.patchContext, efw)...)

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/cluster_patch_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/cluster_patch_test.go
@@ -105,10 +105,10 @@ func Test_clusterMatch(t *testing.T) {
 						},
 					},
 				},
-				cluster: &cluster.Cluster{Name: "inbond|80||"},
+				cluster: &cluster.Cluster{Name: "inbound|80||"},
 				host:    "foo.bar",
 			},
-			want: false,
+			want: true,
 		},
 		{
 			name: "port mismatch",

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/cluster_patch_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/cluster_patch_test.go
@@ -27,6 +27,7 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pilot/pkg/serviceregistry/memory"
+	"istio.io/istio/pkg/config/host"
 )
 
 func Test_clusterMatch(t *testing.T) {
@@ -35,6 +36,7 @@ func Test_clusterMatch(t *testing.T) {
 		cluster        *cluster.Cluster
 		matchCondition *networking.EnvoyFilter_EnvoyConfigObjectMatch
 		operation      networking.EnvoyFilter_Patch_Operation
+		host           host.Name
 	}
 	tests := []struct {
 		name string
@@ -92,6 +94,23 @@ func Test_clusterMatch(t *testing.T) {
 			want: false,
 		},
 		{
+			name: "service name match for inbound cluster",
+			args: args{
+				proxy:     &model.Proxy{Type: model.SidecarProxy},
+				operation: networking.EnvoyFilter_Patch_MERGE,
+				matchCondition: &networking.EnvoyFilter_EnvoyConfigObjectMatch{
+					ObjectTypes: &networking.EnvoyFilter_EnvoyConfigObjectMatch_Cluster{
+						Cluster: &networking.EnvoyFilter_ClusterMatch{
+							Service: "foo.bar",
+						},
+					},
+				},
+				cluster: &cluster.Cluster{Name: "inbond|80||"},
+				host:    "foo.bar",
+			},
+			want: false,
+		},
+		{
 			name: "port mismatch",
 			args: args{
 				proxy:     &model.Proxy{Type: model.SidecarProxy},
@@ -130,7 +149,7 @@ func Test_clusterMatch(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := clusterMatch(tt.args.cluster, &model.EnvoyFilterConfigPatchWrapper{Match: tt.args.matchCondition}); got != tt.want {
+			if got := clusterMatch(tt.args.cluster, &model.EnvoyFilterConfigPatchWrapper{Match: tt.args.matchCondition}, tt.args.host); got != tt.want {
 				t.Errorf("clusterMatch() = %v, want %v", got, tt.want)
 			}
 		})
@@ -182,6 +201,21 @@ func TestClusterPatching(t *testing.T) {
 				},
 			},
 			Patch: &networking.EnvoyFilter_Patch{Operation: networking.EnvoyFilter_Patch_REMOVE},
+		},
+		{
+			ApplyTo: networking.EnvoyFilter_CLUSTER,
+			Match: &networking.EnvoyFilter_EnvoyConfigObjectMatch{
+				Context: networking.EnvoyFilter_SIDECAR_INBOUND,
+				ObjectTypes: &networking.EnvoyFilter_EnvoyConfigObjectMatch_Cluster{
+					Cluster: &networking.EnvoyFilter_ClusterMatch{
+						Service: "service.servicens",
+					},
+				},
+			},
+			Patch: &networking.EnvoyFilter_Patch{
+				Operation: networking.EnvoyFilter_Patch_MERGE,
+				Value:     buildPatchStruct(`{"protocol_selection":"USE_DOWNSTREAM_PROTOCOL"}`),
+			},
 		},
 		{
 			ApplyTo: networking.EnvoyFilter_CLUSTER,
@@ -365,6 +399,13 @@ func TestClusterPatching(t *testing.T) {
 		{Name: "cluster1", DnsLookupFamily: cluster.Cluster_V6_ONLY, LbPolicy: cluster.Cluster_RING_HASH},
 	}
 
+	sidecarInboundServiceIn := []*cluster.Cluster{
+		{Name: "inbound|7443||", DnsLookupFamily: cluster.Cluster_V4_ONLY, LbPolicy: cluster.Cluster_ROUND_ROBIN},
+	}
+	sidecarInboundServiceOut := []*cluster.Cluster{
+		{Name: "inbound|7443||", ProtocolSelection: cluster.Cluster_USE_DOWNSTREAM_PROTOCOL, DnsLookupFamily: cluster.Cluster_V6_ONLY, LbPolicy: cluster.Cluster_RING_HASH},
+	}
+
 	gatewayInput := []*cluster.Cluster{
 		{Name: "cluster1", DnsLookupFamily: cluster.Cluster_V4_ONLY, LbPolicy: cluster.Cluster_ROUND_ROBIN},
 		{
@@ -391,6 +432,7 @@ func TestClusterPatching(t *testing.T) {
 		name         string
 		input        []*cluster.Cluster
 		proxy        *model.Proxy
+		host         string
 		patchContext networking.EnvoyFilter_PatchContext
 		output       []*cluster.Cluster
 	}{
@@ -407,6 +449,14 @@ func TestClusterPatching(t *testing.T) {
 			patchContext: networking.EnvoyFilter_SIDECAR_INBOUND,
 			proxy:        &model.Proxy{Type: model.SidecarProxy, ConfigNamespace: "not-default"},
 			output:       sidecarInboundOut,
+		},
+		{
+			name:         "sidecar inbound cluster patch with service name",
+			input:        sidecarInboundServiceIn,
+			patchContext: networking.EnvoyFilter_SIDECAR_INBOUND,
+			proxy:        &model.Proxy{Type: model.SidecarProxy, ConfigNamespace: "not-default"},
+			host:         "service.servicens",
+			output:       sidecarInboundServiceOut,
 		},
 		{
 			name:         "gateway cds patch",
@@ -426,8 +476,8 @@ func TestClusterPatching(t *testing.T) {
 			efw := push.EnvoyFilters(tc.proxy)
 			output := []*cluster.Cluster{}
 			for _, c := range tc.input {
-				if ShouldKeepCluster(tc.patchContext, efw, c) {
-					output = append(output, ApplyClusterMerge(tc.patchContext, efw, c))
+				if ShouldKeepCluster(tc.patchContext, efw, c, host.Name(tc.host)) {
+					output = append(output, ApplyClusterMerge(tc.patchContext, efw, c, host.Name(tc.host)))
 				}
 			}
 			output = append(output, InsertedClusters(tc.patchContext, efw)...)

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/cluster_patch_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/cluster_patch_test.go
@@ -403,7 +403,10 @@ func TestClusterPatching(t *testing.T) {
 		{Name: "inbound|7443||", DnsLookupFamily: cluster.Cluster_V4_ONLY, LbPolicy: cluster.Cluster_ROUND_ROBIN},
 	}
 	sidecarInboundServiceOut := []*cluster.Cluster{
-		{Name: "inbound|7443||", ProtocolSelection: cluster.Cluster_USE_DOWNSTREAM_PROTOCOL, DnsLookupFamily: cluster.Cluster_V6_ONLY, LbPolicy: cluster.Cluster_RING_HASH},
+		{
+			Name: "inbound|7443||", ProtocolSelection: cluster.Cluster_USE_DOWNSTREAM_PROTOCOL,
+			DnsLookupFamily: cluster.Cluster_V6_ONLY, LbPolicy: cluster.Cluster_RING_HASH,
+		},
 	}
 
 	gatewayInput := []*cluster.Cluster{

--- a/releasenotes/notes/inbound-patch.yaml
+++ b/releasenotes/notes/inbound-patch.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: bug-fix 
+area: networking
+releaseNotes:
+- |
+  **Fixed** a bug where Envoy filter with service match is not working for inbound clusters.
+


### PR DESCRIPTION
After we renamed the inbound clusters not to have host name in it, the service match stopped working because we are trying to get host name from cluster name which is not available. This PR fixes that.
[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
