### PR TITLE
Add option to enable legacy cluster name

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -183,6 +183,12 @@ var (
 		"Protocol detection timeout for inbound listener",
 	).Lookup()
 
+	LegacyClusterName = env.RegisterBoolVar(
+		"PILOT_ENABLE_LEGACY_INBOUND_CLUSTER_NAME",
+		false,
+		"Enable the legacy inbound cluster format (inbound|port|port-name|hostname). This option will be removed soon.",
+	).Get()
+
 	EnableHeadlessService = env.RegisterBoolVar(
 		"PILOT_ENABLE_HEADLESS_SERVICE_POD_LISTENERS",
 		true,

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -268,7 +268,6 @@ type ClusterInstances struct {
 }
 
 func (configgen *ConfigGeneratorImpl) buildInboundClusters(cb *ClusterBuilder, instances []*model.ServiceInstance, cp clusterPatcher) []*cluster.Cluster {
-
 	clusters := make([]*cluster.Cluster, 0)
 
 	// The inbound clusters for a node depends on whether the node has a SidecarScope with inbound listeners
@@ -299,7 +298,7 @@ func (configgen *ConfigGeneratorImpl) buildInboundClusters(cb *ClusterBuilder, i
 			// The first instance will be used as the "primary" instance; this means if we have an conflicts between
 			// Services the first one wins
 			ep := instance.ServicePort.Port
-			if util.IsIstioVersionGE181(cb.proxy) {
+			if util.IsIstioVersionGE181(cb.proxy) && !features.LegacyClusterName {
 				// Istio 1.8.1+ switched to keying on EndpointPort. We need both logics in place to support smooth upgrade from 1.8.0 to 1.8.x
 				ep = int(instance.Endpoint.EndpointPort)
 			}
@@ -307,7 +306,7 @@ func (configgen *ConfigGeneratorImpl) buildInboundClusters(cb *ClusterBuilder, i
 		}
 
 		// For each workload port, we will construct a cluster
-		if !util.IsIstioVersionGE18(cb.proxy) {
+		if !util.IsIstioVersionGE18(cb.proxy) || features.LegacyClusterName {
 			// For 1.7 clusters, we used an old cluster format
 			for _, instances := range clustersToBuild {
 				for _, instance := range instances {

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -280,6 +280,9 @@ func IsIstioVersionGE181(node *model.Proxy) bool {
 }
 
 func BuildInboundSubsetKey(node *model.Proxy, subsetName string, hostname host.Name, servicePort int, endpointPort int) string {
+	if features.LegacyClusterName {
+		return model.BuildSubsetKey(model.TrafficDirectionInbound, subsetName, hostname, servicePort)
+	}
 	if IsIstioVersionGE181(node) {
 		// On 1.8.1+ Proxies, we use format inbound|endpointPort||. Telemetry no longer requires the hostname
 		return model.BuildSubsetKey(model.TrafficDirectionInbound, "", "", endpointPort)


### PR DESCRIPTION
We have had some users that are complaining about the backwards
incompatible changes in 1.8 to the cluster name format. Technically, the
cluster name is an implementation detail for most users. However, some
users are using envoy native telemetry, which includes the cluster name.

The intent of this change is to give users some time to adopt Istio 1.8
first, *then* deal with the migration to the new cluster format.
Currently, the two are coupled so its hard to accomplish this.

Essentially, this makes the condition of the old cluster format to apply
to all proxy versions below 1.8, OR if the new option is set.

The same tests that are testing the 1.7 proxies apply here, so they are
copied and give the same coverage.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.