### PR TITLE
Improve retry timeouts

### DIFF
--- a/pkg/test/util/retry/retry.go
+++ b/pkg/test/util/retry/retry.go
@@ -145,16 +145,18 @@ func Do(fn RetriableFunc, options ...Option) (interface{}, error) {
 	}
 
 	successes := 0
+	attempts := 0
 	var lasterr error
 	to := time.After(cfg.timeout)
 	for {
 		select {
 		case <-to:
-			return nil, fmt.Errorf("timeout while waiting (last error: %v)", lasterr)
+			return nil, fmt.Errorf("timeout while waiting after %d attempts (last error: %v)", attempts, lasterr)
 		default:
 		}
 
 		result, completed, err := fn()
+		attempts++
 		if completed {
 			if err == nil {
 				successes++
@@ -174,6 +176,11 @@ func Do(fn RetriableFunc, options ...Option) (interface{}, error) {
 			lasterr = err
 		}
 
-		<-time.After(cfg.delay)
+		select {
+		case <-to:
+			return nil, fmt.Errorf("timeout while waiting after %d attempts (last error: %v)", attempts, lasterr)
+		case <-time.After(cfg.delay):
+		}
+
 	}
 }


### PR DESCRIPTION
* Record number of attempts. This helps show if we actually attempted
many times and it failed, or we just tried 1x but it was really slow
* Make timeout more reliable by pre-empting the Delay if the timeout
occurs during the delay.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.