### PR TITLE
add one integration case to check nil label map for iop

### DIFF
--- a/tests/integration/operator/install_test.go
+++ b/tests/integration/operator/install_test.go
@@ -46,6 +46,10 @@ func TestInstallCommandInput(t *testing.T) {
 					command:   []string{"install", "--dry-run", "--revision", "1.8.0"},
 					errString: InvalidRevision,
 				},
+				{
+					command:   []string{"install", "--dry-run", "--set", "values.global.network=network1"},
+					errString: "",
+				},
 			}
 			for _, test := range testCases {
 				_, actualError, _ := istioCtl.Invoke(test.command)


### PR DESCRIPTION
add one integration test to make sure label map is initialized before hand.