### PR TITLE
Fix Wasm reliable remote load release notes.

### DIFF
--- a/releasenotes/README.md
+++ b/releasenotes/README.md
@@ -66,6 +66,7 @@ This field describes the area of Istio that the note affects. Valid values inclu
 * traffic-management
 * security
 * telemetry
+* extensibility
 * installation
 * istioctl
 * documentation

--- a/releasenotes/notes/reliable-wasm-remote-load.yaml
+++ b/releasenotes/notes/reliable-wasm-remote-load.yaml
@@ -1,6 +1,6 @@
 apiVersion: release-notes/v2
 kind: feature
-area: extension
+area: extensibility
 issue:
   - 29989
 


### PR DESCRIPTION
Corresponding to https://github.com/istio/tools/pull/1445 which adds extensibility to release notes template.