### PR TITLE
[istioctl] fix panic in revision command without args

### DIFF
--- a/istioctl/cmd/revision.go
+++ b/istioctl/cmd/revision.go
@@ -129,13 +129,13 @@ func revisionDescribeCommand() *cobra.Command {
 		Short: "Show information about a revision, including customizations, " +
 			"istiod version and which pods/gateways are using it.",
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			revArgs.name = args[0]
 			if len(args) == 0 {
 				return fmt.Errorf("revision must be specified")
 			}
 			if len(args) != 1 {
 				return fmt.Errorf("exactly 1 revision should be specified")
 			}
+			revArgs.name = args[0]
 			if !validFormats[revArgs.output] {
 				return fmt.Errorf("unknown format %s. It should be %#v", revArgs.output, validFormats)
 			}


### PR DESCRIPTION
Before this would panic when running `istioctl x revisions describe` without arguments since we were getting `args[0]` before checking length

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[x] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any changes that may affect Istio users.
