### PR TITLE
fix stats filter test: shadow var for goroutine

### DIFF
--- a/tests/integration/telemetry/stats/prometheus/stats.go
+++ b/tests/integration/telemetry/stats/prometheus/stats.go
@@ -83,6 +83,7 @@ func TestStatsFilter(t *testing.T, feature features.Feature) {
 		Run(func(ctx framework.TestContext) {
 			g, _ := errgroup.WithContext(context.Background())
 			for _, cltInstance := range client {
+				cltInstance := cltInstance
 				g.Go(func() error {
 					err := retry.UntilSuccess(func() error {
 						if err := SendTraffic(cltInstance); err != nil {


### PR DESCRIPTION
it's possible this could fix the flakes we see