### PR TITLE
ext-authz: fix to set the proper timeout for gRPC case

### DIFF
--- a/pilot/pkg/security/authz/builder/extauthz.go
+++ b/pilot/pkg/security/authz/builder/extauthz.go
@@ -303,6 +303,7 @@ func generateGRPCConfig(cluster string, failOpen bool, status *envoytypev3.HttpS
 				Authority:   authority,
 			},
 		},
+		Timeout: &duration.Duration{Seconds: 600},
 	}
 	http := &extauthzhttp.ExtAuthz{
 		StatusOnError:    status,

--- a/pilot/pkg/security/authz/builder/testdata/action-custom-HTTP-for-TCP-filter-out2.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/action-custom-HTTP-for-TCP-filter-out2.yaml
@@ -13,5 +13,6 @@ typedConfig:
     envoyGrpc:
       authority: outbound_.9000_._.my-custom-ext-authz.foo.svc.cluster.local
       clusterName: outbound|9000||my-custom-ext-authz.foo.svc.cluster.local
+    timeout: 600s
   statPrefix: tcp.
   transportApiVersion: V3

--- a/pilot/pkg/security/authz/builder/testdata/action-custom-grpc-provider-out2.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/action-custom-grpc-provider-out2.yaml
@@ -13,6 +13,7 @@ typedConfig:
     envoyGrpc:
       authority: outbound_.9000_._.my-custom-ext-authz.foo.svc.cluster.local
       clusterName: outbound|9000||my-custom-ext-authz.foo.svc.cluster.local
+    timeout: 600s
   statusOnError:
     code: Forbidden
   transportApiVersion: V3


### PR DESCRIPTION
This match the same timeout we had set for HTTP.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[x] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any changes that may affect Istio users.