### PR TITLE
broken tracing test checks networks instead of hardcoded name

### DIFF
--- a/tests/integration/telemetry/tracing/zipkin/clienttracing/client_tracing_test.go
+++ b/tests/integration/telemetry/tracing/zipkin/clienttracing/client_tracing_test.go
@@ -43,32 +43,32 @@ func TestClientTracing(t *testing.T) {
 
 			for _, cl := range ctx.Clusters() {
 				clName := cl.Name()
-				if clName == "cluster-3" || clName == "cluster-4" {
-					// TODO: Skipping cluster-3 and cluster-4 as per https://github.com/istio/istio/issues/28890
-					continue
-				}
-				t.Logf("Verifying for cluster %s", clName)
-				retry.UntilSuccessOrFail(t, func() error {
-					// Send test traffic with a trace header.
-					id := uuid.NewV4().String()
-					extraHeader := map[string][]string{
-						tracing.TraceHeader: {id},
+				t.Run(clName, func(t *testing.T) {
+					if cl.NetworkName() != ctx.Clusters().Default().NetworkName() {
+						t.Skip("tracing fails on cross-network client; see https://github.com/istio/istio/issues/28890")
 					}
-					err := tracing.SendTraffic(t, extraHeader, cl)
-					if err != nil {
-						return fmt.Errorf("cannot send traffic from cluster %s: %v", clName, err)
-					}
-					traces, err := tracing.GetZipkinInstance().QueryTraces(100,
-						fmt.Sprintf("server.%s.svc.cluster.local:80/*", appNsInst.Name()), "")
-					if err != nil {
-						return fmt.Errorf("cannot get traces from zipkin: %v", err)
-					}
-					if !tracing.VerifyEchoTraces(t, appNsInst.Name(), clName, traces) {
-						return errors.New("cannot find expected traces")
-					}
-					return nil
-
-				}, retry.Delay(3*time.Second), retry.Timeout(80*time.Second))
+					t.Logf("Verifying for cluster %s", clName)
+					retry.UntilSuccessOrFail(t, func() error {
+						// Send test traffic with a trace header.
+						id := uuid.NewV4().String()
+						extraHeader := map[string][]string{
+							tracing.TraceHeader: {id},
+						}
+						err := tracing.SendTraffic(t, extraHeader, cl)
+						if err != nil {
+							return fmt.Errorf("cannot send traffic from cluster %s: %v", clName, err)
+						}
+						traces, err := tracing.GetZipkinInstance().QueryTraces(100,
+							fmt.Sprintf("server.%s.svc.cluster.local:80/*", appNsInst.Name()), "")
+						if err != nil {
+							return fmt.Errorf("cannot get traces from zipkin: %v", err)
+						}
+						if !tracing.VerifyEchoTraces(t, appNsInst.Name(), clName, traces) {
+							return errors.New("cannot find expected traces")
+						}
+						return nil
+					}, retry.Delay(3*time.Second), retry.Timeout(80*time.Second))
+				})
 			}
 		})
 }


### PR DESCRIPTION
we skipped some tests by hardcoding cluster name checks: https://github.com/istio/istio/issues/28890 

this should skip them properly, but we should see if the actual fix is possible to backport