### PR TITLE
[istioctl] add version check to tag set command

### DIFF
--- a/istioctl/cmd/tag.go
+++ b/istioctl/cmd/tag.go
@@ -43,7 +43,9 @@ const (
 	defaultRevisionName         = "default"
 	pilotDiscoveryChart         = "istio-control/istio-discovery"
 	revisionTagTemplateName     = "revision-tags.yaml"
-	minRevisionTagIstioVersion  = "1.10"
+	// Revision tags require that the target istiod patches ALL webhooks with matching istio.io/rev label,
+	// a behavior that just made it into 1.10 (https://github.com/istio/istio/pull/29583)
+	minRevisionTagIstioVersion = "1.10"
 
 	// help strings and long formatted user outputs
 	skipConfirmationFlagHelpStr = `The skipConfirmation determines whether the user is prompted for confirmation.

--- a/istioctl/cmd/tag_test.go
+++ b/istioctl/cmd/tag_test.go
@@ -382,6 +382,7 @@ func TestSetTagErrors(t *testing.T) {
 			mockClient := kube.MockClient{
 				Interface: client,
 			}
+			skipConfirmation = true
 			err := setTag(context.Background(), mockClient, tc.tag, tc.revision, false, &out)
 			if tc.error == "" && err != nil {
 				t.Fatalf("expected no error, got %v", err)

--- a/tests/integration/pilot/revisions/revision_tag_test.go
+++ b/tests/integration/pilot/revisions/revision_tag_test.go
@@ -66,7 +66,7 @@ func TestRevisionTags(t *testing.T) {
 			baseArgs := []string{"experimental", "tag"}
 			for _, tc := range tcs {
 				t.NewSubTest(tc.name).Run(func(t framework.TestContext) {
-					tagSetArgs := append(baseArgs, "set", tc.tag, "--revision", tc.revision)
+					tagSetArgs := append(baseArgs, "set", tc.tag, "--revision", tc.revision, "--skip-confirmation")
 					tagSetArgs = append(tagSetArgs, "--manifests", filepath.Join(env.IstioSrc, "manifests"))
 					tagRemoveArgs := append(baseArgs, "remove", tc.tag, "-y")
 


### PR DESCRIPTION
Fixes #30701, makes it so that users are prompted for confirmation when creating a revision tag pointed to a revision that's too old to patch it

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[x] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any changes that may affect Istio users.
