### PR TITLE
Allow multiple istio.test.skips

### DIFF
--- a/pkg/test/framework/resource/flags.go
+++ b/pkg/test/framework/resource/flags.go
@@ -71,7 +71,7 @@ func init() {
 	flag.StringVar(&settingsFromCommandLine.SelectorString, "istio.test.select", settingsFromCommandLine.SelectorString,
 		"Comma separated list of labels for selecting tests to run (e.g. 'foo,+bar-baz').")
 
-	flag.StringVar(&settingsFromCommandLine.SkipString, "istio.test.skip", settingsFromCommandLine.SkipString,
+	flag.Var(&settingsFromCommandLine.SkipString, "istio.test.skip",
 		"Skip tests matching the regular expression. This follows the semantics of -test.run.")
 
 	flag.IntVar(&settingsFromCommandLine.Retries, "istio.test.retries", settingsFromCommandLine.Retries,
@@ -88,4 +88,15 @@ func init() {
 
 	flag.BoolVar(&settingsFromCommandLine.SkipVM, "istio.test.skipVM", settingsFromCommandLine.SkipVM,
 		"Skip VM related parts in all tests.")
+}
+
+type arrayFlags []string
+
+func (i *arrayFlags) String() string {
+	return fmt.Sprint([]string(*i))
+}
+
+func (i *arrayFlags) Set(value string) error {
+	*i = append(*i, value)
+	return nil
 }

--- a/pkg/test/framework/resource/matcher.go
+++ b/pkg/test/framework/resource/matcher.go
@@ -20,45 +20,57 @@ import (
 	"strings"
 )
 
+// testFilter is a regex matcher on a test. It is split by / following go subtest format
+type testFilter []*regexp.Regexp
+
 type Matcher struct {
-	filter []*regexp.Regexp
+	filters []testFilter
 }
 
-// Matcher reimplements the logic of Go's -test.run. The code is mostly directly copied from Go's
-// source.
-func NewMatcher(regex string) (*Matcher, error) {
-	if regex == "" {
-		return &Matcher{}, nil
-	}
-	filter := splitRegexp(regex)
-	for i, s := range filter {
-		filter[i] = rewrite(s)
-	}
-	rxs := []*regexp.Regexp{}
-	for _, f := range filter {
-		r, err := regexp.Compile(f)
-		if err != nil {
-			return nil, err
+// NewMatcher reimplements the logic of Go's -test.run. The code is mostly directly copied from Go's source.
+func NewMatcher(regexs []string) (*Matcher, error) {
+	filters := []testFilter{}
+	for _, regex := range regexs {
+		filter := splitRegexp(regex)
+		for i, s := range filter {
+			filter[i] = rewrite(s)
 		}
-		rxs = append(rxs, r)
+		rxs := []*regexp.Regexp{}
+		for _, f := range filter {
+			r, err := regexp.Compile(f)
+			if err != nil {
+				return nil, err
+			}
+			rxs = append(rxs, r)
+		}
+		filters = append(filters, rxs)
 	}
-	return &Matcher{filter: rxs}, nil
+	return &Matcher{filters: filters}, nil
 }
 
 func (m *Matcher) MatchTest(testName string) bool {
-	if len(m.filter) == 0 {
+	for _, f := range m.filters {
+		if matchSingle(f, testName) {
+			return true
+		}
+	}
+	return false
+}
+
+func matchSingle(filter testFilter, testName string) bool {
+	if len(filter) == 0 {
 		// No regex defined, we default to NOT matching. This ensures our default skips nothing
 		return false
 	}
 	elem := strings.Split(testName, "/")
-	if len(m.filter) > len(elem) {
+	if len(filter) > len(elem) {
 		return false
 	}
 	for i, s := range elem {
-		if i >= len(m.filter) {
+		if i >= len(filter) {
 			break
 		}
-		if !m.filter[i].MatchString(s) {
+		if !filter[i].MatchString(s) {
 			return false
 		}
 	}

--- a/pkg/test/framework/resource/matcher_test.go
+++ b/pkg/test/framework/resource/matcher_test.go
@@ -19,38 +19,44 @@ import "testing"
 func TestMatcher(t *testing.T) {
 	cases := []struct {
 		name      string
-		input     string
+		input     []string
 		matches   []string
 		nomatches []string
 	}{
 		{
 			name:      "empty",
-			input:     "",
+			input:     []string{},
 			matches:   []string{},
 			nomatches: []string{"", "foo", "foo/bar", ".*"},
 		},
 		{
 			name:      "single",
-			input:     "Foo",
+			input:     []string{"Foo"},
 			matches:   []string{"TestFoo", "TestMyFooBar", "TestFoo/TestBar"},
 			nomatches: []string{"baz", "baz/foo", "TestBar/TestFoo"},
 		},
 		{
 			name:      "double",
-			input:     "Foo/Bar",
+			input:     []string{"Foo/Bar"},
 			matches:   []string{"TestFoo/TestBar", "TestFoo/TestBar/TestBaz"},
 			nomatches: []string{"TestFoo", "TestBar", "TestMyFooBar"},
 		},
 		{
 			name:    "space",
-			input:   "TestFoo/with space",
+			input:   []string{"TestFoo/with space"},
 			matches: []string{"TestFoo/with_space"},
 		},
 		{
 			name:      "regex",
-			input:     "Foo/.*/Baz",
+			input:     []string{"Foo/.*/Baz"},
 			matches:   []string{"TestFoo/something/TestBaz"},
 			nomatches: []string{"TestFoo", "TestFoo/TestBaz", "TestFoo/something/TestBar"},
+		},
+		{
+			name:      "multiple",
+			input:     []string{"TestFoo/subset", "TestBar"},
+			matches:   []string{"TestBar", "TestBar/subtest", "TestFoo/subset"},
+			nomatches: []string{"TestFoo/something/subset", "TestFoo/something", "TestFoo", "TestFoo/TestBar"},
 		},
 	}
 	for _, tt := range cases {

--- a/pkg/test/framework/resource/settings.go
+++ b/pkg/test/framework/resource/settings.go
@@ -64,7 +64,7 @@ type Settings struct {
 	// -test.run flag, which only supports positive match. If an entire package is meant to be
 	// excluded, it can be filtered with `go list` and explicitly passing the list of desired
 	// packages. For example: `go test $(go list ./... | grep -v bad-package)`.
-	SkipString  string
+	SkipString  arrayFlags
 	SkipMatcher *Matcher
 
 	// The label selector, in parsed form.


### PR DESCRIPTION
Otherwise its impossible to skip subtests sanely.

Instead of `--skip'TestFoo|TestBar'` we can do `--skip 'TestFoo' --skip 'TestBar/subtest'` and not skip the entire TestBar.

This is not possible with the current regex match



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.