### PR TITLE
Properly chown certs in docker build

### DIFF
--- a/tools/istio-docker.mk
+++ b/tools/istio-docker.mk
@@ -53,7 +53,7 @@ $(foreach FILE,$(DOCKER_FILES_FROM_ISTIO_OUT_LINUX), \
 $(ISTIO_DOCKER)/certs:
 	mkdir -p $(ISTIO_DOCKER)
 	cp -a tests/testdata/certs $(ISTIO_DOCKER)/.
-	chmod o+r $(ISTIO_DOCKER)/certs
+	chmod -R o+r $(ISTIO_DOCKER)/certs
 
 # tell make which files are copied from the source tree and generate rules to copy them to the proper location:
 # TODO(sdake)                      $(NODE_AGENT_TEST_FILES) $(GRAFANA_FILES)


### PR DESCRIPTION
It was just making the folder readable - we need the whole folder. This
is just testing certs, so we don't care about security here to need
strict isolation



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.