### PR TITLE
Update Install Script to use atom feed and reliably obtain latest

### DIFF
--- a/release/downloadIstioCandidate.sh
+++ b/release/downloadIstioCandidate.sh
@@ -36,10 +36,10 @@ fi
 
 # Determine the latest Istio version by version number ignoring alpha, beta, and rc versions.
 if [ "x${ISTIO_VERSION}" = "x" ] ; then
-  ISTIO_VERSION="$(curl -sL https://github.com/istio/istio/releases | \
-                  grep -o 'releases/[0-9]*.[0-9]*.[0-9]*/' | sort --version-sort | \
-                  tail -1 | awk -F'/' '{ print $2}')"
-  ISTIO_VERSION="${ISTIO_VERSION##*/}"
+  response="$(curl -sL https://github.com/istio/istio/releases.atom)"
+  ISTIO_VERSION="$(echo "$response" | grep '<link' | grep 'tag' | grep '[0-9]\-rc'| sort --reverse --version-sort | head -1)"
+  ISTIO_VERSION="${ISTIO_VERSION##*tag/}"
+  ISTIO_VERSION="${ISTIO_VERSION%%\"*}"
 fi
 
 LOCAL_ARCH=$(uname -m)

--- a/release/downloadIstioCtl.sh
+++ b/release/downloadIstioCtl.sh
@@ -33,10 +33,10 @@ fi
 
 # Determine the latest Istio version by version number ignoring alpha, beta, and rc versions.
 if [ "x${ISTIO_VERSION}" = "x" ] ; then
-  ISTIO_VERSION="$(curl -sL https://github.com/istio/istio/releases | \
-                  grep -o 'releases/[0-9]*.[0-9]*.[0-9]*/' | sort --version-sort | \
-                  tail -1 | awk -F'/' '{ print $2}')"
-  ISTIO_VERSION="${ISTIO_VERSION##*/}"
+  response="$(curl -sL https://github.com/istio/istio/releases.atom)"
+  ISTIO_VERSION="$(echo "$response" | grep '<link' | grep 'tag' | grep -v '[0-9]\-' | sort --reverse --version-sort | head -1)"
+  ISTIO_VERSION="${ISTIO_VERSION##*tag/}"
+  ISTIO_VERSION="${ISTIO_VERSION%%\"*}"
 fi
 
 if [ "x${ISTIO_VERSION}" = "x" ] ; then


### PR DESCRIPTION
Previously I provided the current solution to  bypass the API throttling by parsing the HTML. Within that PR (https://github.com/istio/istio/pull/23469) there was a debate about stability in the endpoint, especially given that Github could change the markup from underneath it, etc.

This pull request addresses some of those concerns by providing a more stable endpoint via Github's atom feed.  This pull request also contains updated the logic to achieve the following:

- Reliably grab the latest stable in `downloadIstioCtl.sh`
- Correcting a bug in `downloadIstioCandidate.sh` where it does not download a release candidate. Now it will if one exists in the atom feed.



[ ] Configuration Infrastructure
[ ] Docs
[x] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.