### PR TITLE
pilot-discovery: remove superfluous response.WriteHeader call in debug

### DIFF
--- a/pilot/pkg/xds/debug.go
+++ b/pilot/pkg/xds/debug.go
@@ -719,7 +719,6 @@ func (s *DiscoveryServer) Debug(w http.ResponseWriter, req *http.Request) {
 		adsLog.Errorf("Error in rendering index template %v", err)
 		w.WriteHeader(500)
 	}
-	w.WriteHeader(200)
 }
 
 // Ndsz implements a status and debug interface for NDS.


### PR DESCRIPTION
If response.WriteHeader is not called explicitly, the first call to
response.Write will trigger an implicit WriteHeader(http.StatusOK).

A WriteHeader is implicitly triggered in the index template execution for debug
endpoints. The explicit call at the end of `/debug` handler is redundant and can
thus be removed.

The status code is checked in `TestDebugHandlers` unit test.

Fixes https://github.com/istio/istio/issues/30785

Signed-off-by: Kailun Qin <kailun.qin@intel.com>

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
