### PR TITLE
Adding TrustBundle package + Integration Hooks into Istiod

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -1212,7 +1212,7 @@ func (s *Server) initWorkloadTrustBundle() {
 			Reason: []model.TriggerReason{model.GlobalUpdate},
 		})
 	})
-
+	tb.SetGlobalTrustBundle(s.workloadTrustBundle)
 	// MeshConfig: Add initial roots and callback
 	s.workloadTrustBundle.AddMeshConfigUpdate(s.environment.Mesh())
 	s.environment.AddMeshHandler(func() {
@@ -1222,10 +1222,10 @@ func (s *Server) initWorkloadTrustBundle() {
 	// IstioCA: Implicitly add roots corresponding to CA
 	if s.CA != nil {
 		rootCerts := []string{string(s.CA.GetCAKeyCertBundle().GetRootCertPem())}
-		err = s.workloadTrustBundle.UpdateTrustAnchor(&tb.TrustAnchorUpdate{TrustAnchorConfig: tb.TrustAnchorConfig{
-			Source: tb.SourceIstioCA,
-			Certs:  rootCerts,
-		}})
+		err = s.workloadTrustBundle.UpdateTrustAnchor(&tb.TrustAnchorUpdate{
+			TrustAnchorConfig: tb.TrustAnchorConfig{Certs: rootCerts},
+			Source:            tb.SourceIstioCA,
+		})
 		if err != nil {
 			log.Errorf("fatal: unable to add CA root as trustAnchor")
 		}
@@ -1235,10 +1235,10 @@ func (s *Server) initWorkloadTrustBundle() {
 	if s.RA != nil {
 		// Implicitly add the Istio RA certificates to the Workload Trust Bundle
 		rootCerts := []string{string(s.RA.GetCAKeyCertBundle().GetRootCertPem())}
-		err = s.workloadTrustBundle.UpdateTrustAnchor(&tb.TrustAnchorUpdate{TrustAnchorConfig: tb.TrustAnchorConfig{
-			Source: tb.SourceIstioRA,
-			Certs:  rootCerts,
-		}})
+		err = s.workloadTrustBundle.UpdateTrustAnchor(&tb.TrustAnchorUpdate{
+			TrustAnchorConfig: tb.TrustAnchorConfig{Certs: rootCerts},
+			Source:            tb.SourceIstioRA,
+		})
 		if err != nil {
 			log.Errorf("fatal: unable to add RA root as trustAnchor")
 		}

--- a/pilot/pkg/trustbundle/trustbundle.go
+++ b/pilot/pkg/trustbundle/trustbundle.go
@@ -50,7 +50,6 @@ const (
 	SourceIstioCA Source = iota
 	SourceMeshConfig
 	SourceIstioRA
-	// SOURCE_SPIFFE_ENDPOINT
 )
 
 func checkSameCerts(certs1 []string, certs2 []string) bool {
@@ -72,7 +71,6 @@ func NewTrustBundle() *TrustBundle {
 			SourceIstioCA:    {Certs: []string{}},
 			SourceMeshConfig: {Certs: []string{}},
 			SourceIstioRA:    {Certs: []string{}},
-			// SOURCE_SPIFFE_ENDPOINT:        &TrustAnchorConfig{source: SOURCE_SPIFFE_ENDPOINT, certs: []string{}},
 		},
 		mergedCerts: []string{},
 		updatecb:    nil,

--- a/pilot/pkg/trustbundle/trustbundle.go
+++ b/pilot/pkg/trustbundle/trustbundle.go
@@ -1,0 +1,181 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package trustbundle
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"strings"
+	"sync"
+
+	meshconfig "istio.io/api/mesh/v1alpha1"
+	"istio.io/pkg/log"
+)
+
+// source is all possible sources of MeshConfig
+type Source int
+
+type TrustAnchorConfig struct {
+	Source Source
+	Certs  []string
+}
+
+type TrustAnchorUpdate struct {
+	TrustAnchorConfig
+}
+
+type TrustBundle struct {
+	sourceConfig map[Source]TrustAnchorConfig
+	mutex        sync.RWMutex
+	mergedCerts  []string
+	updatecb     func()
+}
+
+var (
+	trustBundleLog = log.RegisterScope("trustBundle", "Workload mTLS trust bundle logs", 0)
+
+	// GlobalWorkloadTrustbundle Needed to interface with XDS
+	GlobalWorkloadTrustbundle *TrustBundle = nil
+)
+
+const (
+	SourceIstioCA Source = iota
+	SourceMeshConfig
+	SourceIstioRA
+	// SOURCE_SPIFFE_ENDPOINT
+	UpdateChannelLen = 10
+)
+
+func checkSameCerts(certs1 []string, certs2 []string) bool {
+	if len(certs1) != len(certs2) {
+		return false
+	}
+	for i := range certs1 {
+		if certs1[i] != certs2[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func NewTrustBundle(updatecb func()) *TrustBundle {
+	tb := &TrustBundle{
+		sourceConfig: map[Source]TrustAnchorConfig{
+			SourceIstioCA:    {Source: SourceIstioCA, Certs: []string{}},
+			SourceMeshConfig: {Source: SourceMeshConfig, Certs: []string{}},
+			SourceIstioRA:    {Source: SourceIstioRA, Certs: []string{}},
+			// SOURCE_SPIFFE_ENDPOINT:        &TrustAnchorConfig{source: SOURCE_SPIFFE_ENDPOINT, certs: []string{}},
+		},
+		mergedCerts: []string{},
+		updatecb:    updatecb,
+	}
+
+	GlobalWorkloadTrustbundle = tb
+	return tb
+}
+
+// GetTrustBundle : Retrieves all the trustAnchors for current Spiffee Trust Domain
+func (tb *TrustBundle) GetTrustBundle() []string {
+	tb.mutex.RLock()
+	defer tb.mutex.RUnlock()
+	trustedCerts := make([]string, len(tb.mergedCerts))
+	copy(trustedCerts, tb.mergedCerts)
+	return trustedCerts
+}
+
+func (tb *TrustBundle) verifyTrustAnchor(trustAnchor string) error {
+	block, _ := pem.Decode([]byte(trustAnchor))
+	if block == nil {
+		return fmt.Errorf("failed to decode pem certificate")
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return fmt.Errorf("failed to parse X.509 certificate")
+	}
+	if !cert.IsCA {
+		return fmt.Errorf("certificate is not a CA certificate")
+	}
+	return nil
+}
+
+func (tb *TrustBundle) mergeInternal() {
+	var ok bool
+	mergeCerts := []string{}
+	certMap := make(map[string]bool)
+
+	tb.mutex.Lock()
+	defer tb.mutex.Unlock()
+
+	for _, configSource := range tb.sourceConfig {
+		for _, cert := range configSource.Certs {
+			if _, ok = certMap[cert]; !ok {
+				certMap[cert] = true
+				mergeCerts = append(mergeCerts, cert)
+			}
+		}
+	}
+	tb.mergedCerts = mergeCerts
+}
+
+// External Function to merge a TrustAnchor config with the existing TrustBundle
+// Should only be one writer
+func (tb *TrustBundle) UpdateTrustAnchor(anchorConfig *TrustAnchorUpdate) error {
+	var ok bool
+	var err error
+
+	cachedConfig, ok := tb.sourceConfig[anchorConfig.Source]
+	if !ok {
+		return fmt.Errorf("invalid source of TrustBundle configuration %v", anchorConfig.Source)
+	}
+
+	// Check if anything needs to be changed at all
+	if checkSameCerts(anchorConfig.Certs, cachedConfig.Certs) {
+		trustBundleLog.Infof("no change to trustAnchor configuration after recent update")
+		return nil
+	}
+
+	for _, cert := range anchorConfig.Certs {
+		err = tb.verifyTrustAnchor(cert)
+		if err != nil {
+			return err
+		}
+	}
+	tb.sourceConfig[anchorConfig.TrustAnchorConfig.Source] = anchorConfig.TrustAnchorConfig
+	tb.mergeInternal()
+
+	trustBundleLog.Debugf("updating Source %v with certs %v",
+		anchorConfig.TrustAnchorConfig.Source,
+		strings.Join(anchorConfig.TrustAnchorConfig.Certs, "\n\n"))
+
+	tb.updatecb()
+	return nil
+}
+
+// AddMeshConfigUpdate : Update trustAnchor configurations from meshConfig
+func (tb *TrustBundle) AddMeshConfigUpdate(cfg *meshconfig.MeshConfig) {
+	if cfg != nil {
+		certs := []string{}
+		for _, pemCert := range cfg.GetCaCertificates() {
+			certs = append(certs, pemCert.GetPem())
+		}
+		err := tb.UpdateTrustAnchor(&TrustAnchorUpdate{TrustAnchorConfig{
+			Source: SourceMeshConfig,
+			Certs:  certs,
+		}})
+		if err != nil {
+			trustBundleLog.Errorf("failed to update meshConfig trustAnchors because %v")
+		}
+	}
+}

--- a/pilot/pkg/trustbundle/trustbundle_test.go
+++ b/pilot/pkg/trustbundle/trustbundle_test.go
@@ -1,0 +1,135 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trustbundle
+
+import (
+	"io/ioutil"
+	"path"
+	"sort"
+	"testing"
+
+	"istio.io/istio/pkg/test/env"
+)
+
+func readCertFromFile(filename string) string {
+	csrBytes, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return ""
+	}
+	return string(csrBytes)
+}
+
+var testCerts map[string]string = map[string]string{
+	"MalformedCert":      "Malformed",
+	"RootCACert":         readCertFromFile(path.Join(env.IstioSrc, "samples/certs", "root-cert.pem")),
+	"NonCaCert":          readCertFromFile(path.Join(env.IstioSrc, "samples/certs", "workload-bar-cert.pem")),
+	"IntermediateCACert": readCertFromFile(path.Join(env.IstioSrc, "samples/certs", "ca-cert.pem")),
+}
+
+func TestCheckSameCerts(t *testing.T) {
+	if checkSameCerts([]string{"a", "b"}, []string{}) {
+		t.Errorf("cert check test case 1 failed")
+	}
+	if checkSameCerts([]string{"a", "b"}, []string{"b"}) {
+		t.Errorf("cert check test case 2 failed")
+	}
+	if !checkSameCerts([]string{"a", "b", "c"}, []string{"a", "b", "c"}) {
+		t.Errorf("cert check test case 3 failed")
+	}
+}
+
+func TestVerifyTrustAnchor(t *testing.T) {
+	testCases := []struct {
+		errExp bool
+		cert   string
+	}{
+		{
+			cert:   testCerts["RootCACert"],
+			errExp: false,
+		},
+		{
+			cert:   testCerts["MalformedCert"],
+			errExp: true,
+		},
+		{
+			cert:   testCerts["NonCaCert"],
+			errExp: true,
+		},
+		{
+			cert:   testCerts["IntermediateCACert"],
+			errExp: false,
+		},
+	}
+	for i, tc := range testCases {
+		err := NewTrustBundle(func() {}).verifyTrustAnchor(tc.cert)
+		if tc.errExp && err == nil {
+			t.Errorf("test case %v failed. Expected Error but got none", i)
+		} else if !tc.errExp && err != nil {
+			t.Errorf("test case %v failed. Expected no error but got %v", i, err)
+		}
+	}
+}
+
+func TestUpdateTrustAnchor(t *testing.T) {
+	var cbCounter int = 0
+	tb := NewTrustBundle(func() { cbCounter++ })
+	var trustedCerts []string
+
+	// Add First Cert update
+	tb.UpdateTrustAnchor(&TrustAnchorUpdate{TrustAnchorConfig{Source: SourceMeshConfig, Certs: []string{testCerts["RootCACert"]}}})
+	trustedCerts = tb.GetTrustBundle()
+	if !checkSameCerts(trustedCerts, []string{testCerts["RootCACert"]}) || cbCounter != 1 {
+		t.Errorf("Basic trustbundle update test failed. Callback value is %v", cbCounter)
+	}
+
+	// Add Second Cert update
+	// ensure intermediate CA certs accepted, it replaces the first completely, and lib dedupes duplicate cert
+	tb.UpdateTrustAnchor(&TrustAnchorUpdate{TrustAnchorConfig{
+		Source: SourceMeshConfig,
+		Certs:  []string{testCerts["IntermediateCACert"], testCerts["IntermediateCACert"]},
+	}})
+	trustedCerts = tb.GetTrustBundle()
+	if !checkSameCerts(trustedCerts, []string{testCerts["IntermediateCACert"]}) || cbCounter != 2 {
+		t.Errorf("trustbundle intermediate cert update test failed. Callback value is %v", cbCounter)
+	}
+
+	// Try adding one more cert to a different source
+	// Ensure both certs are not present
+	tb.UpdateTrustAnchor(&TrustAnchorUpdate{TrustAnchorConfig{Source: SourceIstioCA, Certs: []string{testCerts["RootCACert"]}}})
+	trustedCerts = tb.GetTrustBundle()
+	sort.Strings(trustedCerts)
+	result := []string{testCerts["IntermediateCACert"], testCerts["RootCACert"]}
+	sort.Strings(result)
+	if !checkSameCerts(trustedCerts, result) || cbCounter != 3 {
+		t.Errorf("multicert update failed. Callback value is %v", cbCounter)
+	}
+
+	// Try added same cert again. Ensure cb doesn't increment
+	tb.UpdateTrustAnchor(&TrustAnchorUpdate{TrustAnchorConfig{Source: SourceIstioCA, Certs: []string{testCerts["RootCACert"]}}})
+	trustedCerts = tb.GetTrustBundle()
+	sort.Strings(trustedCerts)
+	if !checkSameCerts(trustedCerts, result) || cbCounter != 3 {
+		t.Errorf("duplicate multicert update failed. Callback value is %v", cbCounter)
+	}
+
+	// Try added one good cert, one bogus Cert
+	// Verify Update should not go through and no change to cb
+	tb.UpdateTrustAnchor(&TrustAnchorUpdate{TrustAnchorConfig{Source: SourceIstioCA, Certs: []string{testCerts["Malformed"]}}})
+	trustedCerts = tb.GetTrustBundle()
+	sort.Strings(trustedCerts)
+	if !checkSameCerts(trustedCerts, result) || cbCounter != 3 {
+		t.Errorf("bad cert update failed. Callback value is %v", cbCounter)
+	}
+}

--- a/pilot/pkg/trustbundle/trustbundle_test.go
+++ b/pilot/pkg/trustbundle/trustbundle_test.go
@@ -38,15 +38,6 @@ var (
 	intermediateCACert string = readCertFromFile(path.Join(env.IstioSrc, "samples/certs", "ca-cert.pem"))
 )
 
-func TestSetGlobalWorkloadTrustBundle(t *testing.T) {
-	tb := NewTrustBundle(func() {})
-	SetGlobalTrustBundle(tb)
-	g := GetGlobalTrustBundle()
-	if tb != g {
-		t.Errorf("global trustbundle test failed! ")
-	}
-}
-
 func TestCheckSameCerts(t *testing.T) {
 	testCases := []struct {
 		certs1  []string
@@ -100,7 +91,7 @@ func TestVerifyTrustAnchor(t *testing.T) {
 		},
 	}
 	for i, tc := range testCases {
-		err := NewTrustBundle(func() {}).verifyTrustAnchor(tc.cert)
+		err := verifyTrustAnchor(tc.cert)
 		if tc.errExp && err == nil {
 			t.Errorf("test case %v failed. Expected Error but got none", i)
 		} else if !tc.errExp && err != nil {
@@ -111,7 +102,9 @@ func TestVerifyTrustAnchor(t *testing.T) {
 
 func TestUpdateTrustAnchor(t *testing.T) {
 	var cbCounter int = 0
-	tb := NewTrustBundle(func() { cbCounter++ })
+	tb := NewTrustBundle()
+	tb.UpdateCb(func() { cbCounter++ })
+
 	var trustedCerts []string
 	var err error
 


### PR DESCRIPTION
Adding code to accumulate all the configured and implicit trust anchors of the mesh in one location.
Part of a larger commit - https://github.com/istio/istio/pull/30506. Splitting the PR into multiple parts.
Also related to commit - https://github.com/istio/api/pull/1848
Refer to [RFC](https://docs.google.com/document/d/1EFMQZNlyImLP0k0HIyoBINntchqeUq7QQgc9O_jDwZ8/edit#heading=h.io2z16q0yjxj)


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.