### PR TITLE
istioctl analyze: display dir or file name when it is provided

### DIFF
--- a/istioctl/cmd/analyze.go
+++ b/istioctl/cmd/analyze.go
@@ -236,11 +236,11 @@ func Analyze() *cobra.Command {
 			if len(outputMessages) == 0 {
 				if parseErrors == 0 {
 					if len(readers) > 0 {
-						fileOrDir := filepath.Dir(readers[0].Name)
-						if len(readers) == 1 {
-							fileOrDir = readers[0].Name
+						var files []string
+						for _, r := range readers {
+							files = append(files, r.Name)
 						}
-						fmt.Fprintf(cmd.ErrOrStderr(), "\u2714 No validation issues found when analyzing %s.\n", fileOrDir)
+						fmt.Fprintf(cmd.ErrOrStderr(), "\u2714 No validation issues found when analyzing %s.\n", strings.Join(files, "\n"))
 					} else {
 						fmt.Fprintf(cmd.ErrOrStderr(), "\u2714 No validation issues found when analyzing %s.\n", analyzeTargetAsString())
 					}

--- a/istioctl/cmd/analyze.go
+++ b/istioctl/cmd/analyze.go
@@ -235,7 +235,15 @@ func Analyze() *cobra.Command {
 			// An extra message on success
 			if len(outputMessages) == 0 {
 				if parseErrors == 0 {
-					fmt.Fprintf(cmd.ErrOrStderr(), "\u2714 No validation issues found when analyzing %s.\n", analyzeTargetAsString())
+					if len(readers) > 0 {
+						fileOrDir := filepath.Dir(readers[0].Name)
+						if len(readers) == 1 {
+							fileOrDir = readers[0].Name
+						}
+						fmt.Fprintf(cmd.ErrOrStderr(), "\u2714 No validation issues found when analyzing %s.\n", fileOrDir)
+					} else {
+						fmt.Fprintf(cmd.ErrOrStderr(), "\u2714 No validation issues found when analyzing %s.\n", analyzeTargetAsString())
+					}
 				} else {
 					fileOrFiles := "files"
 					if parseErrors == 1 {


### PR DESCRIPTION
To fix https://github.com/istio/istio/issues/30865

Before:
```
$ istioctl analyze samples/bookinfo/platform/kube/

✔ No validation issues found when analyzing namespace: default.
```

After:

When filename is provided
```
$ istioctl analyze samples/bookinfo/platform/kube/bookinfo-ingress.yaml

✔ No validation issues found when analyzing samples/bookinfo/platform/kube/bookinfo-ingress.yaml.
```