### PR TITLE
Istio-agent changes to support Multiple roots for workload mTLS

### DIFF
--- a/pkg/adsc/adsc.go
+++ b/pkg/adsc/adsc.go
@@ -52,7 +52,6 @@ import (
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/security"
-	"istio.io/istio/security/pkg/nodeagent/cache"
 	"istio.io/pkg/log"
 )
 
@@ -318,7 +317,7 @@ func (a *ADSC) tlsConfig() (*tls.Config, error) {
 		serverCABytes, err = ioutil.ReadFile(a.cfg.XDSRootCAFile)
 	} else if a.cfg.SecretManager != nil {
 		// This is a bit crazy - we could just use the file
-		rootCA, err := a.cfg.SecretManager.GenerateSecret(cache.RootCertReqResourceName)
+		rootCA, err := a.cfg.SecretManager.GenerateSecret(security.RootCertReqResourceName)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/adsc/util.go
+++ b/pkg/adsc/util.go
@@ -17,13 +17,13 @@ package adsc
 import (
 	"crypto/tls"
 
-	"istio.io/istio/security/pkg/nodeagent/cache"
+	"istio.io/istio/pkg/security"
 )
 
 func getClientCertFn(config *Config) func(requestInfo *tls.CertificateRequestInfo) (*tls.Certificate, error) {
 	if config.SecretManager != nil {
 		return func(requestInfo *tls.CertificateRequestInfo) (*tls.Certificate, error) {
-			key, err := config.SecretManager.GenerateSecret(cache.WorkloadKeyCertResourceName)
+			key, err := config.SecretManager.GenerateSecret(security.WorkloadKeyCertResourceName)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/istio-agent/agent_test.go
+++ b/pkg/istio-agent/agent_test.go
@@ -47,7 +47,6 @@ import (
 	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/pkg/test/util/retry"
 	"istio.io/istio/security/pkg/credentialfetcher/plugin"
-	"istio.io/istio/security/pkg/nodeagent/cache"
 	camock "istio.io/istio/security/pkg/nodeagent/caclient/providers/mock"
 	"istio.io/istio/security/pkg/nodeagent/test/mock"
 	pkiutil "istio.io/istio/security/pkg/pki/util"
@@ -87,14 +86,14 @@ func TestAgent(t *testing.T) {
 	t.Run("Kubernetes defaults", func(t *testing.T) {
 		// XDS and CA are both using JWT authentication and TLS. Root certificates distributed in
 		// configmap to each namespace.
-		Setup(t).Check(cache.WorkloadKeyCertResourceName, cache.RootCertReqResourceName)
+		Setup(t).Check(security.WorkloadKeyCertResourceName, security.RootCertReqResourceName)
 	})
 	t.Run("RSA", func(t *testing.T) {
 		// All of the other tests use ECC for speed. Here we make sure RSA still works
 		Setup(t, func(a AgentTest) AgentTest {
 			a.Security.ECCSigAlg = ""
 			return a
-		}).Check(cache.WorkloadKeyCertResourceName, cache.RootCertReqResourceName)
+		}).Check(security.WorkloadKeyCertResourceName, security.RootCertReqResourceName)
 	})
 	t.Run("Kubernetes defaults output key and cert", func(t *testing.T) {
 		// same as "Kubernetes defaults", but also output the key and cert. This can be used for tools
@@ -104,13 +103,13 @@ func TestAgent(t *testing.T) {
 			a.Security.OutputKeyCertToDir = dir
 			a.Security.SecretRotationGracePeriodRatio = 1
 			return a
-		}).Check(cache.WorkloadKeyCertResourceName, cache.RootCertReqResourceName)
+		}).Check(security.WorkloadKeyCertResourceName, security.RootCertReqResourceName)
 
 		// Ensure we output the certs
 		checkCertsWritten(t, dir)
 
 		// We rotate immediately, so we expect these files to be constantly updated
-		go sds[cache.WorkloadKeyCertResourceName].DrainResponses()
+		go sds[security.WorkloadKeyCertResourceName].DrainResponses()
 		expectFileChanged(t, filepath.Join(dir, "cert-chain.pem"), filepath.Join(dir, "key.pem"))
 	})
 	t.Run("Kubernetes defaults - output key and cert without SDS", func(t *testing.T) {
@@ -166,7 +165,7 @@ func TestAgent(t *testing.T) {
 			// Ensure we don't try to connect to CA
 			a.CaAuthenticator.Set("", "")
 			return a
-		}).Check(cache.WorkloadKeyCertResourceName, cache.RootCertReqResourceName)
+		}).Check(security.WorkloadKeyCertResourceName, security.RootCertReqResourceName)
 	})
 	t.Run("VMs", func(t *testing.T) {
 		// Bootstrap sets up a short lived JWT token and root certificate. The initial run will fetch
@@ -180,12 +179,12 @@ func TestAgent(t *testing.T) {
 				a.Security.ProvCert = dir
 				return a
 			})
-			a.Check(cache.WorkloadKeyCertResourceName, cache.RootCertReqResourceName)
+			a.Check(security.WorkloadKeyCertResourceName, security.RootCertReqResourceName)
 
 			// Switch out our auth to only allow mTLS. In practice, the real server would allow JWT, but we
 			// don't have a good way to expire JWTs here. Instead, we just deny all JWTs to ensure mTLS is used
 			a.CaAuthenticator.Set("", filepath.Join(dir, "cert-chain.pem"))
-			a.Check(cache.WorkloadKeyCertResourceName, cache.RootCertReqResourceName)
+			a.Check(security.WorkloadKeyCertResourceName, security.RootCertReqResourceName)
 		})
 		t.Run("reboot", func(t *testing.T) {
 			// Switch the JWT to a bogus path, to simulate the VM being rebooted
@@ -198,8 +197,8 @@ func TestAgent(t *testing.T) {
 				return a
 			})
 			// Ensure we can still make requests
-			a.Check(cache.WorkloadKeyCertResourceName, cache.RootCertReqResourceName)
-			a.Check(cache.WorkloadKeyCertResourceName, cache.RootCertReqResourceName)
+			a.Check(security.WorkloadKeyCertResourceName, security.RootCertReqResourceName)
+			a.Check(security.WorkloadKeyCertResourceName, security.RootCertReqResourceName)
 		})
 	})
 	t.Run("VMs to etc/certs", func(t *testing.T) {
@@ -219,13 +218,13 @@ func TestAgent(t *testing.T) {
 			a.Security.SecretRotationGracePeriodRatio = 1
 			return a
 		})
-		sds := a.Check(cache.WorkloadKeyCertResourceName, cache.RootCertReqResourceName)
+		sds := a.Check(security.WorkloadKeyCertResourceName, security.RootCertReqResourceName)
 
 		// Ensure we output the certs
 		checkCertsWritten(t, dir)
 
 		// The provisioning certificates should not be touched
-		go sds[cache.WorkloadKeyCertResourceName].DrainResponses()
+		go sds[security.WorkloadKeyCertResourceName].DrainResponses()
 		expectFileChanged(t, filepath.Join(dir, "cert-chain.pem"), filepath.Join(dir, "key.pem"))
 	})
 	t.Run("VMs provisioned certificates - short lived", func(t *testing.T) {
@@ -243,10 +242,10 @@ func TestAgent(t *testing.T) {
 			a.Security.ProvCert = dir
 			a.Security.SecretRotationGracePeriodRatio = 1
 			return a
-		}).Check(cache.WorkloadKeyCertResourceName, cache.RootCertReqResourceName)
+		}).Check(security.WorkloadKeyCertResourceName, security.RootCertReqResourceName)
 
 		// The provisioning certificates should not be touched
-		go sds[cache.WorkloadKeyCertResourceName].DrainResponses()
+		go sds[security.WorkloadKeyCertResourceName].DrainResponses()
 		expectFileChanged(t, filepath.Join(dir, "cert-chain.pem"), filepath.Join(dir, "key.pem"))
 	})
 	t.Run("VMs provisioned certificates - long lived", func(t *testing.T) {
@@ -263,10 +262,10 @@ func TestAgent(t *testing.T) {
 			a.Security.ProvCert = dir
 			a.Security.SecretRotationGracePeriodRatio = 1
 			return a
-		}).Check(cache.WorkloadKeyCertResourceName, cache.RootCertReqResourceName)
+		}).Check(security.WorkloadKeyCertResourceName, security.RootCertReqResourceName)
 
 		// The provisioning certificates should not be touched
-		go sds[cache.WorkloadKeyCertResourceName].DrainResponses()
+		go sds[security.WorkloadKeyCertResourceName].DrainResponses()
 		expectFileUnchanged(t, filepath.Join(dir, "cert-chain.pem"), filepath.Join(dir, "key.pem"))
 	})
 	t.Run("Token exchange", func(t *testing.T) {
@@ -276,7 +275,7 @@ func TestAgent(t *testing.T) {
 			a.CaAuthenticator.Set("some-token", "")
 			a.Security.TokenExchanger = camock.NewMockTokenExchangeServer(map[string]string{"fake": "some-token"})
 			return a
-		}).Check(cache.WorkloadKeyCertResourceName, cache.RootCertReqResourceName)
+		}).Check(security.WorkloadKeyCertResourceName, security.RootCertReqResourceName)
 	})
 	t.Run("Token exchange with credential fetcher", func(t *testing.T) {
 		// This is used with platform credentials, where the platform provides some underlying
@@ -294,7 +293,7 @@ func TestAgent(t *testing.T) {
 			return a
 		})
 
-		a.Check(cache.WorkloadKeyCertResourceName, cache.RootCertReqResourceName)
+		a.Check(security.WorkloadKeyCertResourceName, security.RootCertReqResourceName)
 	})
 	t.Run("Token exchange with credential fetcher downtime", func(t *testing.T) {
 		// This ensures our pre-warming is resilient to temporary downtime of the CA
@@ -328,7 +327,7 @@ func TestAgent(t *testing.T) {
 			a.CaAuthenticator.Set("some-token", "")
 		}()
 
-		a.Check(cache.WorkloadKeyCertResourceName, cache.RootCertReqResourceName)
+		a.Check(security.WorkloadKeyCertResourceName, security.RootCertReqResourceName)
 	})
 }
 

--- a/pkg/security/security.go
+++ b/pkg/security/security.go
@@ -45,6 +45,14 @@ const (
 	// SystemRootCerts is special case input for root cert configuration to use system root certificates.
 	SystemRootCerts = "SYSTEM"
 
+	// RootCertReqResourceName is resource name of discovery request for root certificate.
+	RootCertReqResourceName = "ROOTCA"
+
+	// WorkloadKeyCertResourceName is the resource name of the discovery request for workload
+	// identity.
+	// TODO: change all the pilot one reference definition here instead.
+	WorkloadKeyCertResourceName = "default"
+
 	// Credential fetcher type
 	GCE  = "GoogleComputeEngine"
 	Mock = "Mock" // testing only

--- a/security/pkg/nodeagent/cache/secretcache.go
+++ b/security/pkg/nodeagent/cache/secretcache.go
@@ -209,6 +209,7 @@ func (sc *SecretManagerClient) CallUpdateCallback(resourceName string) {
 	}
 }
 
+// getCachedSecret: retrieve cached Secret Item (workload-certificate/workload-root) from secretManager client
 func (sc *SecretManagerClient) getCachedSecret(resourceName string) (secret *security.SecretItem) {
 	var rootCertBundle []byte
 	if c := sc.cache.GetWorkload(); c != nil {
@@ -367,13 +368,6 @@ func (sc *SecretManagerClient) generateRootCertFromExistingFile(rootCertPath, re
 		return nil, err
 	}
 
-	now := time.Now()
-	var certExpireTime time.Time
-	if certExpireTime, err = nodeagentutil.ParseCertAndGetExpiryTimestamp(rootCert); err != nil {
-		cacheLog.Errorf("failed to extract expiration time in the root certificate loaded from file: %v", err)
-		return nil, fmt.Errorf("failed to extract expiration time in the root certificate loaded from file: %v", err)
-	}
-
 	// Set the rootCert only if it is workload root cert.
 	if workload {
 		sc.cache.SetRoot(rootCert)
@@ -381,8 +375,6 @@ func (sc *SecretManagerClient) generateRootCertFromExistingFile(rootCertPath, re
 	return &security.SecretItem{
 		ResourceName: resourceName,
 		RootCert:     rootCert,
-		ExpireTime:   certExpireTime,
-		CreatedTime:  now,
 	}, nil
 }
 

--- a/security/pkg/nodeagent/cache/secretcache_test.go
+++ b/security/pkg/nodeagent/cache/secretcache_test.go
@@ -74,7 +74,7 @@ func testWorkloadAgentGenerateSecret(t *testing.T, isUsingPluginProvider bool) {
 	}
 
 	sc := createCache(t, fakeCACli, func(resourceName string) {}, security.Options{})
-	gotSecret, err := sc.GenerateSecret(WorkloadKeyCertResourceName)
+	gotSecret, err := sc.GenerateSecret(security.WorkloadKeyCertResourceName)
 	if err != nil {
 		t.Fatalf("Failed to get secrets: %v", err)
 	}
@@ -83,7 +83,7 @@ func testWorkloadAgentGenerateSecret(t *testing.T, isUsingPluginProvider bool) {
 		t.Errorf("Got unexpected certificate chain #1. Got: %v, want: %v", string(got), string(want))
 	}
 
-	gotSecretRoot, err := sc.GenerateSecret(RootCertReqResourceName)
+	gotSecretRoot, err := sc.GenerateSecret(security.RootCertReqResourceName)
 	if err != nil {
 		t.Fatalf("Failed to get secrets: %v", err)
 	}
@@ -93,7 +93,7 @@ func testWorkloadAgentGenerateSecret(t *testing.T, isUsingPluginProvider bool) {
 	}
 
 	// Try to get secret again, verify secret is not generated.
-	gotSecret, err = sc.GenerateSecret(WorkloadKeyCertResourceName)
+	gotSecret, err = sc.GenerateSecret(security.WorkloadKeyCertResourceName)
 	if err != nil {
 		t.Fatalf("Failed to get secrets: %v", err)
 	}
@@ -104,7 +104,7 @@ func testWorkloadAgentGenerateSecret(t *testing.T, isUsingPluginProvider bool) {
 
 	// Root cert is the last element in the generated certs.
 	want := []byte(fakeCACli.GeneratedCerts[0][2])
-	if got, _ := sc.cache.GetRoot(); !bytes.Equal(got, want) {
+	if got := sc.cache.GetRoot(); !bytes.Equal(got, want) {
 		t.Errorf("Got unexpected root certificate. Got: %v\n want: %v", string(got), string(want))
 	}
 }
@@ -141,6 +141,12 @@ func (u *UpdateTracker) Expect(want map[string]int) {
 	}, retry.Timeout(time.Second*2), retry.Delay(time.Millisecond))
 }
 
+func (u *UpdateTracker) Reset() {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	u.hits = map[string]int{}
+}
+
 func TestWorkloadAgentRefreshSecret(t *testing.T) {
 	cacheLog.SetOutputLevel(log.DebugLevel)
 	fakeCACli, err := mock.NewMockCAClient(time.Millisecond * 200)
@@ -150,20 +156,20 @@ func TestWorkloadAgentRefreshSecret(t *testing.T) {
 	u := NewUpdateTracker(t)
 	sc := createCache(t, fakeCACli, u.Callback, security.Options{})
 
-	_, err = sc.GenerateSecret(WorkloadKeyCertResourceName)
+	_, err = sc.GenerateSecret(security.WorkloadKeyCertResourceName)
 	if err != nil {
 		t.Fatalf("failed to get secrets: %v", err)
 	}
 
 	// First update will trigger root cert immediately, then workload cert once it expires in 200ms
-	u.Expect(map[string]int{WorkloadKeyCertResourceName: 1, RootCertReqResourceName: 1})
+	u.Expect(map[string]int{security.WorkloadKeyCertResourceName: 1, security.RootCertReqResourceName: 1})
 
-	_, err = sc.GenerateSecret(WorkloadKeyCertResourceName)
+	_, err = sc.GenerateSecret(security.WorkloadKeyCertResourceName)
 	if err != nil {
 		t.Fatalf("failed to get secrets: %v", err)
 	}
 
-	u.Expect(map[string]int{WorkloadKeyCertResourceName: 2, RootCertReqResourceName: 1})
+	u.Expect(map[string]int{security.WorkloadKeyCertResourceName: 2, security.RootCertReqResourceName: 1})
 }
 
 // Compare times, with 5s error allowance
@@ -338,8 +344,8 @@ func runFileAgentTest(t *testing.T, sds bool) {
 
 	setupTestDir(t, sc)
 
-	workloadResource := WorkloadKeyCertResourceName
-	rootResource := RootCertReqResourceName
+	workloadResource := security.WorkloadKeyCertResourceName
+	rootResource := security.RootCertReqResourceName
 	if sds {
 		workloadResource = sc.existingCertificateFile.GetResourceName()
 		rootResource = sc.existingCertificateFile.GetRootResourceName()
@@ -478,16 +484,20 @@ func verifySecret(t *testing.T, gotSecret *security.SecretItem, expectedSecret *
 		t.Fatalf("resource name:: expected %s but got %s", expectedSecret.ResourceName,
 			gotSecret.ResourceName)
 	}
-	if !bytes.Equal(expectedSecret.CertificateChain, gotSecret.CertificateChain) {
-		t.Fatalf("cert chain: expected %s but got %s", string(expectedSecret.CertificateChain),
-			string(gotSecret.CertificateChain))
-	}
-	if !bytes.Equal(expectedSecret.PrivateKey, gotSecret.PrivateKey) {
-		t.Fatalf("private key: expected %s but got %s", string(expectedSecret.PrivateKey), string(gotSecret.PrivateKey))
-	}
-	if !bytes.Equal(expectedSecret.RootCert, gotSecret.RootCert) {
-		t.Fatalf("root cert: expected %v but got %v", expectedSecret.RootCert,
-			gotSecret.RootCert)
+	cfg, ok := model.SdsCertificateConfigFromResourceName(expectedSecret.ResourceName)
+	if expectedSecret.ResourceName == security.RootCertReqResourceName || (ok && cfg.IsRootCertificate()) {
+		if !bytes.Equal(expectedSecret.RootCert, gotSecret.RootCert) {
+			t.Fatalf("root cert: expected %v but got %v", expectedSecret.RootCert,
+				gotSecret.RootCert)
+		}
+	} else {
+		if !bytes.Equal(expectedSecret.CertificateChain, gotSecret.CertificateChain) {
+			t.Fatalf("cert chain: expected %s but got %s", string(expectedSecret.CertificateChain),
+				string(gotSecret.CertificateChain))
+		}
+		if !bytes.Equal(expectedSecret.PrivateKey, gotSecret.PrivateKey) {
+			t.Fatalf("private key: expected %s but got %s", string(expectedSecret.PrivateKey), string(gotSecret.PrivateKey))
+		}
 	}
 	if !expectedSecret.ExpireTime.IsZero() && expectedSecret.ExpireTime != gotSecret.ExpireTime {
 		t.Fatalf("expiration: expected %v but got %v",
@@ -531,4 +541,67 @@ func TestConcatCerts(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestProxyConfigAnchors(t *testing.T) {
+	fakeCACli, err := mock.NewMockCAClient(time.Hour)
+	if err != nil {
+		t.Fatalf("Error creating Mock CA client: %v", err)
+	}
+	u := NewUpdateTracker(t)
+
+	sc := createCache(t, fakeCACli, u.Callback, security.Options{})
+	_, err = sc.GenerateSecret(security.WorkloadKeyCertResourceName)
+	if err != nil {
+		t.Errorf("failed to generate certificate for trustAnchor test case")
+	}
+	// Ensure Root cert call back gets invoked once
+	u.Expect(map[string]int{security.RootCertReqResourceName: 1})
+	u.Reset()
+
+	caClientRootCert := []byte(fakeCACli.GeneratedCerts[0][2])
+	// Ensure that contents of the rootCert are correct.
+	checkSecret(t, sc, security.RootCertReqResourceName, security.SecretItem{
+		ResourceName: security.RootCertReqResourceName,
+		RootCert:     caClientRootCert,
+	})
+
+	rootCert, err := ioutil.ReadFile(filepath.Join("./testdata", "root-cert.pem"))
+	if err != nil {
+		t.Fatalf("Error reading the root cert file: %v", err)
+	}
+
+	// Update the proxyConfig with certs
+	sc.UpdateConfigTrustBundle(rootCert)
+
+	// Ensure Callback gets invoked when updating proxyConfig trust bundle
+	u.Expect(map[string]int{security.RootCertReqResourceName: 1})
+	u.Reset()
+
+	// Ensure that contents of the rootCert are correct.
+	checkSecret(t, sc, security.RootCertReqResourceName, security.SecretItem{
+		ResourceName: security.RootCertReqResourceName,
+		RootCert:     sc.mergeConfigTrustBundle(caClientRootCert),
+	})
+
+	// Update the proxyConfig with fakeCaClient certs
+	sc.UpdateConfigTrustBundle(caClientRootCert)
+	setupTestDir(t, sc)
+
+	rootCert, err = ioutil.ReadFile(sc.existingCertificateFile.CaCertificatePath)
+	if err != nil {
+		t.Fatalf("Error reading the root cert file: %v", err)
+	}
+
+	// Check request for workload root-certs merges configuration with ProxyConfig TrustAnchor
+	checkSecret(t, sc, security.RootCertReqResourceName, security.SecretItem{
+		ResourceName: security.RootCertReqResourceName,
+		RootCert:     sc.mergeConfigTrustBundle(rootCert),
+	})
+
+	// Check request for non-workload root-certs doesn't configuration with ProxyConfig TrustAnchor
+	checkSecret(t, sc, sc.existingCertificateFile.GetRootResourceName(), security.SecretItem{
+		ResourceName: sc.existingCertificateFile.GetRootResourceName(),
+		RootCert:     rootCert,
+	})
 }

--- a/security/pkg/nodeagent/sds/sdsservice_test.go
+++ b/security/pkg/nodeagent/sds/sdsservice_test.go
@@ -28,7 +28,6 @@ import (
 	"istio.io/istio/pilot/pkg/xds"
 	"istio.io/istio/pilot/test/xdstest"
 	ca2 "istio.io/istio/pkg/security"
-	"istio.io/istio/security/pkg/nodeagent/cache"
 	"istio.io/istio/tests/util/leak"
 	"istio.io/pkg/log"
 )
@@ -109,9 +108,9 @@ func setupSDS(t *testing.T) *TestServer {
 		PrivateKey:       fakePrivateKey,
 		ResourceName:     testResourceName,
 	})
-	st.Set(cache.RootCertReqResourceName, &ca2.SecretItem{
+	st.Set(ca2.RootCertReqResourceName, &ca2.SecretItem{
 		RootCert:     fakeRootCert,
-		ResourceName: cache.RootCertReqResourceName,
+		ResourceName: ca2.RootCertReqResourceName,
 	})
 
 	opts := ca2.Options{

--- a/security/pkg/pki/util/generate_csr.go
+++ b/security/pkg/pki/util/generate_csr.go
@@ -127,15 +127,3 @@ func AppendRootCerts(pemCert []byte, rootCertFile string) ([]byte, error) {
 	}
 	return rootCerts, nil
 }
-
-func AppendRootCertString(pemCert []byte, rootCert string) ([]byte, error) {
-	var mergedRootCerts []byte
-	if len(pemCert) > 0 {
-		// Copy the input certificate
-		mergedRootCerts = make([]byte, len(pemCert))
-		copy(mergedRootCerts, pemCert)
-		mergedRootCerts = []byte(strings.TrimSuffix(string(mergedRootCerts), "\n") + "\n")
-	}
-	mergedRootCerts = append(mergedRootCerts, []byte(rootCert)...)
-	return mergedRootCerts, nil
-}

--- a/security/pkg/pki/util/generate_csr.go
+++ b/security/pkg/pki/util/generate_csr.go
@@ -127,3 +127,15 @@ func AppendRootCerts(pemCert []byte, rootCertFile string) ([]byte, error) {
 	}
 	return rootCerts, nil
 }
+
+func AppendRootCertString(pemCert []byte, rootCert string) ([]byte, error) {
+	var mergedRootCerts []byte
+	if len(pemCert) > 0 {
+		// Copy the input certificate
+		mergedRootCerts = make([]byte, len(pemCert))
+		copy(mergedRootCerts, pemCert)
+		mergedRootCerts = []byte(strings.TrimSuffix(string(mergedRootCerts), "\n") + "\n")
+	}
+	mergedRootCerts = append(mergedRootCerts, []byte(rootCert)...)
+	return mergedRootCerts, nil
+}

--- a/security/pkg/testing/sdsc/sdsclient.go
+++ b/security/pkg/testing/sdsc/sdsclient.go
@@ -30,7 +30,7 @@ import (
 	"google.golang.org/grpc/metadata"
 
 	authn_model "istio.io/istio/pilot/pkg/security/model"
-	sdscache "istio.io/istio/security/pkg/nodeagent/cache"
+	"istio.io/istio/pkg/security"
 	agent_sds "istio.io/istio/security/pkg/nodeagent/sds"
 	"istio.io/pkg/log"
 )
@@ -134,7 +134,7 @@ func (c *Client) Send() error {
 			Id: "sidecar~127.0.0.1~id2~local",
 		},
 		ResourceNames: []string{
-			sdscache.WorkloadKeyCertResourceName,
+			security.WorkloadKeyCertResourceName,
 		},
 		TypeUrl: agent_sds.SecretTypeV3,
 	})


### PR DESCRIPTION
Adding code to integrate Proxyconfig trust-anchors with existing root-certificates from csr or file based certs.
Part of a larger commit - #30506. Splitting the PR into multiple parts.
Also related to commit - istio/api#1848
Refer to [RFC](https://docs.google.com/document/d/1EFMQZNlyImLP0k0HIyoBINntchqeUq7QQgc9O_jDwZ8/edit#heading=h.io2z16q0yjxj) 

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.