### PR TITLE
Fix ADS stream hanging on errors

### DIFF
--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -142,7 +142,15 @@ func isExpectedGRPCError(err error) bool {
 }
 
 func (s *DiscoveryServer) receive(con *Connection, reqChannel chan *discovery.DiscoveryRequest, errP *error) {
-	defer close(reqChannel) // indicates close of the remote side.
+	defer func() {
+		close(reqChannel)
+		// Close the initialized channel, if its not already closed, to prevent blocking the stream
+		select {
+		case <-con.initialized:
+		default:
+			close(con.initialized)
+		}
+	}()
 	firstReq := true
 	for {
 		req, err := con.stream.Recv()


### PR DESCRIPTION
Currently, if we have an error in Recv before initialization completes,
we may hang forever, since we have `<-con.initialized` that blocks. This
fixes this by closing the initialized channel when recieve exits.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.