### PR TITLE
ext-authz: return error for invalid extension provider only when it is being used

### DIFF
--- a/pilot/pkg/security/authz/builder/builder.go
+++ b/pilot/pkg/security/authz/builder/builder.go
@@ -72,13 +72,9 @@ func New(trustDomainBundle trustdomain.Bundle, in *plugin.InputParams, option Op
 		if len(policies.Custom) == 0 {
 			return nil
 		}
-		extAuthzExtensions, err := processExtensionProvider(in)
-		if err != nil {
-			option.Logger.AppendError(err)
-		}
 		return &Builder{
 			customPolicies:    policies.Custom,
-			extensions:        extAuthzExtensions,
+			extensions:        processExtensionProvider(in),
 			trustDomainBundle: trustDomainBundle,
 			option:            option,
 		}

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -1383,7 +1383,7 @@ func ValidateMeshConfig(mesh *meshconfig.MeshConfig) (errs error) {
 	}
 
 	if err := validateExtensionProvider(mesh); err != nil {
-		errs = multierror.Append(errs, err)
+		scope.Warnf("found invalid extension provider (can be ignored if the given extension provider is not used): %v", err)
 	}
 
 	return

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -415,7 +415,6 @@ func TestValidateMeshConfig(t *testing.T) {
 			"trustDomainAliases[0]",
 			"trustDomainAliases[1]",
 			"trustDomainAliases[2]",
-			"invalid extension provider default: port number 999999",
 		}
 		switch err := err.(type) {
 		case *multierror.Error:


### PR DESCRIPTION
Fixes #30824 

If some extension provider is not used by any authz policy, it should not cause errors even if it might be invalid.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[x] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any changes that may affect Istio users.