### PR TITLE
Add info about unset istio-injection

### DIFF
--- a/galley/pkg/config/analysis/analyzers/injection/injection.go
+++ b/galley/pkg/config/analysis/analyzers/injection/injection.go
@@ -71,7 +71,7 @@ func (a *Analyzer) Analyze(c analysis.Context) {
 			// TODO: if Istio is installed with sidecarInjectorWebhook.enableNamespacesByDefault=true
 			// (in the istio-sidecar-injector configmap), we need to reverse this logic and treat this as an injected namespace
 
-			m := msg.NewNamespaceNotInjected(r, ns, ns)
+			m := msg.NewNamespaceNotInjected(r, ns, ns, ns)
 
 			if line, ok := util.ErrorLine(r, fmt.Sprintf(util.MetadataName)); ok {
 				m.Line = line

--- a/galley/pkg/config/analysis/msg/messages.gen.go
+++ b/galley/pkg/config/analysis/msg/messages.gen.go
@@ -23,7 +23,7 @@ var (
 
 	// NamespaceNotInjected defines a diag.MessageType for message "NamespaceNotInjected".
 	// Description: A namespace is not enabled for Istio injection.
-	NamespaceNotInjected = diag.NewMessageType(diag.Info, "IST0102", "The namespace is not enabled for Istio injection. Run 'kubectl label namespace %s istio-injection=enabled' to enable it, or 'kubectl label namespace %s istio-injection=disabled' to explicitly mark it as not needing injection.")
+	NamespaceNotInjected = diag.NewMessageType(diag.Info, "IST0102", "The namespace is not enabled for Istio injection. Run 'kubectl label namespace %s istio-injection=enabled' to enable it, or 'kubectl label namespace %s istio-injection=disabled' to explicitly mark it as not needing injection. You can also unset 'istio-injection' by running 'kubectl label namespace %s istio-injection-'")
 
 	// PodMissingProxy defines a diag.MessageType for message "PodMissingProxy".
 	// Description: A pod is missing the Istio proxy.
@@ -220,12 +220,13 @@ func NewReferencedResourceNotFound(r *resource.Instance, reftype string, refval 
 }
 
 // NewNamespaceNotInjected returns a new diag.Message based on NamespaceNotInjected.
-func NewNamespaceNotInjected(r *resource.Instance, namespace string, namespace2 string) diag.Message {
+func NewNamespaceNotInjected(r *resource.Instance, namespace string, namespace2 string, namespace3 string) diag.Message {
 	return diag.NewMessage(
 		NamespaceNotInjected,
 		r,
 		namespace,
 		namespace2,
+		namespace3,
 	)
 }
 

--- a/galley/pkg/config/analysis/msg/messages.yaml
+++ b/galley/pkg/config/analysis/msg/messages.yaml
@@ -34,11 +34,13 @@ messages:
     code: IST0102
     level: Info
     description: "A namespace is not enabled for Istio injection."
-    template: "The namespace is not enabled for Istio injection. Run 'kubectl label namespace %s istio-injection=enabled' to enable it, or 'kubectl label namespace %s istio-injection=disabled' to explicitly mark it as not needing injection."
+    template: "The namespace is not enabled for Istio injection. Run 'kubectl label namespace %s istio-injection=enabled' to enable it, or 'kubectl label namespace %s istio-injection=disabled' to explicitly mark it as not needing injection. You can also unset 'istio-injection' by running 'kubectl label namespace %s istio-injection-'"
     args:
       - name: namespace
         type: string
       - name: namespace2
+        type: string
+      - name: namespace3
         type: string
 
   - name: "PodMissingProxy"


### PR DESCRIPTION
To fix https://github.com/istio/istio/issues/30874


```
$ istioctl analyze -A
Info [IST0102] (Namespace default) The namespace is not enabled for Istio injection. Run 'kubectl label namespace default istio-injection=enabled' to enable it, or 'kubectl label namespace default istio-injection=disabled' to explicitly mark it as not needing injection.
You can also unset 'istio-injection' by running 'kubectl label namespace default istio-injection-'
Info [IST0102] (Namespace istio-system) The namespace is not enabled for Istio injection. Run 'kubectl label namespace istio-system istio-injection=enabled' to enable it, or 'kubectl label namespace istio-system istio-injection=disabled' to explicitly mark it as not needing injection.
You can also unset 'istio-injection' by running 'kubectl label namespace istio-system istio-injection-'
```