### PR TITLE
Fix flake in TestController_ServiceWithChangingDiscoveryNamespaces

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -138,6 +138,9 @@ type Options struct {
 
 	// Duration to wait for cache syncs
 	SyncInterval time.Duration
+
+	// If meshConfig.DiscoverySelectors are specified, the DiscoveryNamespacesFilter tracks the namespaces this controller watches.
+	DiscoveryNamespacesFilter filter.DiscoveryNamespacesFilter
 }
 
 func (o Options) GetSyncInterval() time.Duration {
@@ -262,6 +265,9 @@ type Controller struct {
 
 	// Duration to wait for cache syncs
 	syncInterval time.Duration
+
+	// If meshConfig.DiscoverySelectors are specified, the DiscoveryNamespacesFilter tracks the namespaces this controller watches.
+	discoveryNamespacesFilter filter.DiscoveryNamespacesFilter
 }
 
 // NewController creates a new Kubernetes controller
@@ -286,6 +292,7 @@ func NewController(kubeClient kubelib.Client, options Options) *Controller {
 		metrics:                     options.Metrics,
 		syncInterval:                options.GetSyncInterval(),
 		initialized:                 atomic.NewBool(false),
+		discoveryNamespacesFilter:   options.DiscoveryNamespacesFilter,
 	}
 
 	if options.SystemNamespace != "" {
@@ -298,11 +305,13 @@ func NewController(kubeClient kubelib.Client, options Options) *Controller {
 
 	c.nsInformer = kubeClient.KubeInformer().Core().V1().Namespaces()
 
-	discoveryNamespaceFilter := filter.NewDiscoveryNamespacesFilter(c.nsInformer.Lister(), options.MeshWatcher.Mesh().DiscoverySelectors)
+	if c.discoveryNamespacesFilter == nil {
+		c.discoveryNamespacesFilter = filter.NewDiscoveryNamespacesFilter(c.nsInformer.Lister(), options.MeshWatcher.Mesh().DiscoverySelectors)
+	}
 
-	c.initDiscoveryHandlers(kubeClient, options.EndpointMode, options.MeshWatcher, discoveryNamespaceFilter)
+	c.initDiscoveryHandlers(kubeClient, options.EndpointMode, options.MeshWatcher, c.discoveryNamespacesFilter)
 
-	c.serviceInformer = filter.NewFilteredSharedIndexInformer(discoveryNamespaceFilter.Filter, kubeClient.KubeInformer().Core().V1().Services().Informer())
+	c.serviceInformer = filter.NewFilteredSharedIndexInformer(c.discoveryNamespacesFilter.Filter, kubeClient.KubeInformer().Core().V1().Services().Informer())
 	c.serviceLister = listerv1.NewServiceLister(c.serviceInformer.GetIndexer())
 
 	registerHandlers(c.serviceInformer, c.queue, "Services", c.onServiceEvent, nil)
@@ -310,13 +319,13 @@ func NewController(kubeClient kubelib.Client, options Options) *Controller {
 	switch options.EndpointMode {
 	case EndpointsOnly:
 		endpointsInformer := filter.NewFilteredSharedIndexInformer(
-			discoveryNamespaceFilter.Filter,
+			c.discoveryNamespacesFilter.Filter,
 			kubeClient.KubeInformer().Core().V1().Endpoints().Informer(),
 		)
 		c.endpoints = newEndpointsController(c, endpointsInformer)
 	case EndpointSliceOnly:
 		endpointSliceInformer := filter.NewFilteredSharedIndexInformer(
-			discoveryNamespaceFilter.Filter,
+			c.discoveryNamespacesFilter.Filter,
 			kubeClient.KubeInformer().Discovery().V1beta1().EndpointSlices().Informer(),
 		)
 		c.endpoints = newEndpointSliceController(c, endpointSliceInformer)
@@ -327,7 +336,7 @@ func NewController(kubeClient kubelib.Client, options Options) *Controller {
 	c.nodeLister = kubeClient.KubeInformer().Core().V1().Nodes().Lister()
 	registerHandlers(c.nodeInformer, c.queue, "Nodes", c.onNodeEvent, nil)
 
-	podInformer := filter.NewFilteredSharedIndexInformer(discoveryNamespaceFilter.Filter, kubeClient.KubeInformer().Core().V1().Pods().Informer())
+	podInformer := filter.NewFilteredSharedIndexInformer(c.discoveryNamespacesFilter.Filter, kubeClient.KubeInformer().Core().V1().Pods().Informer())
 	c.pods = newPodCache(c, podInformer, func(key string) {
 		item, exists, err := c.endpoints.getInformer().GetIndexer().GetByKey(key)
 		if err != nil {

--- a/pilot/pkg/serviceregistry/kube/controller/fake.go
+++ b/pilot/pkg/serviceregistry/kube/controller/fake.go
@@ -21,6 +21,7 @@ import (
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/serviceregistry/kube/controller/filter"
 	"istio.io/istio/pkg/config/mesh"
 	kubelib "istio.io/istio/pkg/kube"
 )
@@ -126,15 +127,16 @@ func (fx *FakeXdsUpdater) Clear() {
 }
 
 type FakeControllerOptions struct {
-	Client            kubelib.Client
-	NetworksWatcher   mesh.NetworksWatcher
-	MeshWatcher       mesh.Watcher
-	ServiceHandler    func(service *model.Service, event model.Event)
-	Mode              EndpointMode
-	ClusterID         string
-	WatchedNamespaces string
-	DomainSuffix      string
-	XDSUpdater        model.XDSUpdater
+	Client                    kubelib.Client
+	NetworksWatcher           mesh.NetworksWatcher
+	MeshWatcher               mesh.Watcher
+	ServiceHandler            func(service *model.Service, event model.Event)
+	Mode                      EndpointMode
+	ClusterID                 string
+	WatchedNamespaces         string
+	DomainSuffix              string
+	XDSUpdater                model.XDSUpdater
+	DiscoveryNamespacesFilter filter.DiscoveryNamespacesFilter
 
 	// when calling from NewFakeDiscoveryServer, we wait for the aggregate cache to sync. Waiting here can cause deadlock.
 	SkipCacheSyncWait bool
@@ -163,15 +165,16 @@ func NewFakeControllerWithOptions(opts FakeControllerOptions) (*FakeController, 
 	}
 
 	options := Options{
-		WatchedNamespaces: opts.WatchedNamespaces, // default is all namespaces
-		DomainSuffix:      domainSuffix,
-		XDSUpdater:        xdsUpdater,
-		Metrics:           &model.Environment{},
-		NetworksWatcher:   opts.NetworksWatcher,
-		MeshWatcher:       opts.MeshWatcher,
-		EndpointMode:      opts.Mode,
-		ClusterID:         opts.ClusterID,
-		SyncInterval:      time.Microsecond,
+		WatchedNamespaces:         opts.WatchedNamespaces, // default is all namespaces
+		DomainSuffix:              domainSuffix,
+		XDSUpdater:                xdsUpdater,
+		Metrics:                   &model.Environment{},
+		NetworksWatcher:           opts.NetworksWatcher,
+		MeshWatcher:               opts.MeshWatcher,
+		EndpointMode:              opts.Mode,
+		ClusterID:                 opts.ClusterID,
+		SyncInterval:              time.Microsecond,
+		DiscoveryNamespacesFilter: opts.DiscoveryNamespacesFilter,
 	}
 	c := NewController(opts.Client, options)
 	if opts.ServiceHandler != nil {


### PR DESCRIPTION
Fixes #30877

The flake was caused by a race between the discovery namespace event handlers and the assertion of the registry's services. Specifically, [the creation of the test namespaces](https://github.com/istio/istio/blob/d706ab80df4b1742b299b6c38bf80cb967697efc/pilot/pkg/serviceregistry/kube/controller/controller_test.go#L1125-L1127) triggers [this discovery namespace event handler](https://github.com/istio/istio/blob/d706ab80df4b1742b299b6c38bf80cb967697efc/pilot/pkg/serviceregistry/kube/controller/discoverycontrollers.go#L53), which is required for [this assertion](https://github.com/istio/istio/blob/d706ab80df4b1742b299b6c38bf80cb967697efc/pilot/pkg/serviceregistry/kube/controller/controller_test.go#L1171) to pass. On failed runs, debug logs show that the namespace events have not yet been processed at the time of assertion.

To address this I've exposed a `GetMembers()` method on DiscoveryNamespacesFilter, and allow it to be injected into the controller. This allows the test to ensure that the discovery namespace membership has updated (i.e. the event handlers triggered) before asserting that the registry's services have updated.