### PR TITLE
Update formatting to be compatible with golangci-lint 1.37.0

### DIFF
--- a/cni/cmd/istio-cni/iptables.go
+++ b/cni/cmd/istio-cni/iptables.go
@@ -26,8 +26,7 @@ import (
 
 var nsSetupProg = "istio-iptables"
 
-type iptables struct {
-}
+type iptables struct{}
 
 func newIPTables() InterceptRuleMgr {
 	return &iptables{}

--- a/cni/cmd/istio-cni/main.go
+++ b/cni/cmd/istio-cni/main.go
@@ -59,9 +59,8 @@ type Kubernetes struct {
 // is passed in on stdin. Your plugin may wish to expose its functionality via
 // runtime args, see CONVENTIONS.md in the CNI spec.
 type PluginConf struct {
-	types.NetConf // You may wish to not nest this type
-	RuntimeConfig *struct {
-		// SampleConfig map[string]interface{} `json:"sample"`
+	types.NetConf           // You may wish to not nest this type
+	RuntimeConfig *struct { // SampleConfig map[string]interface{} `json:"sample"`
 	} `json:"runtimeConfig"`
 
 	// This is the previous result, when called in the context of a chained

--- a/cni/pkg/taint/taint.go
+++ b/cni/pkg/taint/taint.go
@@ -122,7 +122,7 @@ func (ts *Setter) HasReadinessTaint(node *v1.Node) bool {
 	return false
 }
 
-//assumption: order of taint is not important
+// assumption: order of taint is not important
 func (ts *Setter) RemoveReadinessTaint(node *v1.Node) error {
 	ts.mutex.RLock()
 	defer ts.mutex.RUnlock()

--- a/cni/pkg/taint/taintcontroller.go
+++ b/cni/pkg/taint/taintcontroller.go
@@ -72,13 +72,13 @@ func NewTaintSetterController(ts *Setter) (*Controller, error) {
 	return c, nil
 }
 
-//build a listwatch based on the config
-//monitoring on pod with namespace and labelselectors defined in configmap
-//and add store to cache given namespace and labelsalector,
-//return a controller built by listwatch function
-//add : add it to workqueue
-//update: add it to workquueue
-//remove: retaint the node
+// build a listwatch based on the config
+// monitoring on pod with namespace and labelselectors defined in configmap
+// and add store to cache given namespace and labelsalector,
+// return a controller built by listwatch function
+// add : add it to workqueue
+// update: add it to workquueue
+// remove: retaint the node
 func buildPodController(c *Controller, config ConfigSettings, source cache.ListerWatcher) cache.Controller {
 	tempstore, tempcontroller := cache.NewInformer(source, &v1.Pod{}, 0, cache.ResourceEventHandlerFuncs{
 		AddFunc: func(newObj interface{}) {

--- a/istioctl/pkg/validate/validate.go
+++ b/istioctl/pkg/validate/validate.go
@@ -63,8 +63,7 @@ Example resource specifications include:
 	serviceProtocolUDP = "UDP"
 )
 
-type validator struct {
-}
+type validator struct{}
 
 func checkFields(un *unstructured.Unstructured) error {
 	var errs error

--- a/pilot/pkg/networking/apigen/apigen.go
+++ b/pilot/pkg/networking/apigen/apigen.go
@@ -42,8 +42,7 @@ import (
 // Example: networking.istio.io/v1alpha3/VirtualService
 //
 // TODO: we can also add a special marker in the header)
-type APIGenerator struct {
-}
+type APIGenerator struct{}
 
 // TODO: take 'updates' into account, don't send pushes for resources that haven't changed
 // TODO: support WorkloadEntry - to generate endpoints (equivalent with EDS)

--- a/pilot/pkg/networking/grpcgen/grpcgen.go
+++ b/pilot/pkg/networking/grpcgen/grpcgen.go
@@ -49,8 +49,7 @@ import (
 // using the generic structures. "Classical" CDS/LDS/RDS/EDS use separate logic -
 // this is used for the API-based LDS and generic messages.
 
-type GrpcConfigGenerator struct {
-}
+type GrpcConfigGenerator struct{}
 
 func (g *GrpcConfigGenerator) Generate(proxy *model.Proxy, push *model.PushContext,
 	w *model.WatchedResource, updates *model.PushRequest) (model.Resources, error) {

--- a/pilot/pkg/security/authz/model/generator.go
+++ b/pilot/pkg/security/authz/model/generator.go
@@ -30,8 +30,7 @@ type generator interface {
 	principal(key, value string, forTCP bool) (*rbacpb.Principal, error)
 }
 
-type destIPGenerator struct {
-}
+type destIPGenerator struct{}
 
 func (destIPGenerator) permission(_, value string, _ bool) (*rbacpb.Permission, error) {
 	cidrRange, err := matcher.CidrRange(value)
@@ -45,8 +44,7 @@ func (destIPGenerator) principal(_, _ string, _ bool) (*rbacpb.Principal, error)
 	return nil, fmt.Errorf("unimplemented")
 }
 
-type destPortGenerator struct {
-}
+type destPortGenerator struct{}
 
 func (destPortGenerator) permission(_, value string, _ bool) (*rbacpb.Permission, error) {
 	portValue, err := convertToPort(value)
@@ -60,8 +58,7 @@ func (destPortGenerator) principal(_, _ string, _ bool) (*rbacpb.Principal, erro
 	return nil, fmt.Errorf("unimplemented")
 }
 
-type connSNIGenerator struct {
-}
+type connSNIGenerator struct{}
 
 func (connSNIGenerator) permission(_, value string, _ bool) (*rbacpb.Permission, error) {
 	m := matcher.StringMatcher(value)
@@ -72,8 +69,7 @@ func (connSNIGenerator) principal(_, _ string, _ bool) (*rbacpb.Principal, error
 	return nil, fmt.Errorf("unimplemented")
 }
 
-type envoyFilterGenerator struct {
-}
+type envoyFilterGenerator struct{}
 
 func (envoyFilterGenerator) permission(key, value string, _ bool) (*rbacpb.Permission, error) {
 	// Split key of format "experimental.envoy.filters.a.b[c]" to "envoy.filters.a.b" and "c".
@@ -93,8 +89,7 @@ func (envoyFilterGenerator) principal(_, _ string, _ bool) (*rbacpb.Principal, e
 	return nil, fmt.Errorf("unimplemented")
 }
 
-type srcIPGenerator struct {
-}
+type srcIPGenerator struct{}
 
 func (srcIPGenerator) permission(_, _ string, _ bool) (*rbacpb.Permission, error) {
 	return nil, fmt.Errorf("unimplemented")
@@ -108,8 +103,7 @@ func (srcIPGenerator) principal(_, value string, _ bool) (*rbacpb.Principal, err
 	return principalDirectRemoteIP(cidr), nil
 }
 
-type remoteIPGenerator struct {
-}
+type remoteIPGenerator struct{}
 
 func (remoteIPGenerator) permission(_, _ string, _ bool) (*rbacpb.Permission, error) {
 	return nil, fmt.Errorf("unimplemented")
@@ -123,8 +117,7 @@ func (remoteIPGenerator) principal(_, value string, _ bool) (*rbacpb.Principal, 
 	return principalRemoteIP(cidr), nil
 }
 
-type srcNamespaceGenerator struct {
-}
+type srcNamespaceGenerator struct{}
 
 func (srcNamespaceGenerator) permission(_, _ string, _ bool) (*rbacpb.Permission, error) {
 	return nil, fmt.Errorf("unimplemented")
@@ -142,8 +135,7 @@ func (srcNamespaceGenerator) principal(_, value string, forTCP bool) (*rbacpb.Pr
 	return principalMetadata(metadata), nil
 }
 
-type srcPrincipalGenerator struct {
-}
+type srcPrincipalGenerator struct{}
 
 func (srcPrincipalGenerator) permission(_, _ string, _ bool) (*rbacpb.Permission, error) {
 	return nil, fmt.Errorf("unimplemented")
@@ -158,8 +150,7 @@ func (srcPrincipalGenerator) principal(key, value string, forTCP bool) (*rbacpb.
 	return principalMetadata(metadata), nil
 }
 
-type requestPrincipalGenerator struct {
-}
+type requestPrincipalGenerator struct{}
 
 func (requestPrincipalGenerator) permission(_, _ string, _ bool) (*rbacpb.Permission, error) {
 	return nil, fmt.Errorf("unimplemented")
@@ -174,8 +165,7 @@ func (requestPrincipalGenerator) principal(key, value string, forTCP bool) (*rba
 	return principalMetadata(m), nil
 }
 
-type requestAudiencesGenerator struct {
-}
+type requestAudiencesGenerator struct{}
 
 func (requestAudiencesGenerator) permission(key, value string, forTCP bool) (*rbacpb.Permission, error) {
 	return requestPrincipalGenerator{}.permission(key, value, forTCP)
@@ -185,8 +175,7 @@ func (requestAudiencesGenerator) principal(key, value string, forTCP bool) (*rba
 	return requestPrincipalGenerator{}.principal(key, value, forTCP)
 }
 
-type requestPresenterGenerator struct {
-}
+type requestPresenterGenerator struct{}
 
 func (requestPresenterGenerator) permission(key, value string, forTCP bool) (*rbacpb.Permission, error) {
 	return requestPrincipalGenerator{}.permission(key, value, forTCP)
@@ -196,8 +185,7 @@ func (requestPresenterGenerator) principal(key, value string, forTCP bool) (*rba
 	return requestPrincipalGenerator{}.principal(key, value, forTCP)
 }
 
-type requestHeaderGenerator struct {
-}
+type requestHeaderGenerator struct{}
 
 func (requestHeaderGenerator) permission(_, _ string, _ bool) (*rbacpb.Permission, error) {
 	return nil, fmt.Errorf("unimplemented")
@@ -216,8 +204,7 @@ func (requestHeaderGenerator) principal(key, value string, forTCP bool) (*rbacpb
 	return principalHeader(m), nil
 }
 
-type requestClaimGenerator struct {
-}
+type requestClaimGenerator struct{}
 
 func (requestClaimGenerator) permission(_, _ string, _ bool) (*rbacpb.Permission, error) {
 	return nil, fmt.Errorf("unimplemented")
@@ -238,8 +225,7 @@ func (requestClaimGenerator) principal(key, value string, forTCP bool) (*rbacpb.
 	return principalMetadata(m), nil
 }
 
-type hostGenerator struct {
-}
+type hostGenerator struct{}
 
 func (hostGenerator) permission(key, value string, forTCP bool) (*rbacpb.Permission, error) {
 	if forTCP {
@@ -254,8 +240,7 @@ func (hostGenerator) principal(key, value string, forTCP bool) (*rbacpb.Principa
 	return nil, fmt.Errorf("unimplemented")
 }
 
-type pathGenerator struct {
-}
+type pathGenerator struct{}
 
 func (g pathGenerator) permission(key, value string, forTCP bool) (*rbacpb.Permission, error) {
 	if forTCP {
@@ -270,8 +255,7 @@ func (pathGenerator) principal(key, value string, forTCP bool) (*rbacpb.Principa
 	return nil, fmt.Errorf("unimplemented")
 }
 
-type methodGenerator struct {
-}
+type methodGenerator struct{}
 
 func (methodGenerator) permission(key, value string, forTCP bool) (*rbacpb.Permission, error) {
 	if forTCP {

--- a/pilot/pkg/serviceregistry/serviceentry/servicediscovery_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/servicediscovery_test.go
@@ -115,8 +115,7 @@ func waitForEvent(t *testing.T, ch chan Event) Event {
 	}
 }
 
-type channelTerminal struct {
-}
+type channelTerminal struct{}
 
 func initServiceDiscovery() (model.IstioConfigStore, *ServiceEntryStore, chan Event, func()) {
 	return initServiceDiscoveryWithOpts()

--- a/pkg/config/event/router.go
+++ b/pkg/config/event/router.go
@@ -28,8 +28,7 @@ type Router interface {
 }
 
 // emptyRouter
-type emptyRouter struct {
-}
+type emptyRouter struct{}
 
 var _ Router = &emptyRouter{}
 

--- a/pkg/config/resource/serialization_test.go
+++ b/pkg/config/resource/serialization_test.go
@@ -369,8 +369,7 @@ func TestDeserializeAll_Error(t *testing.T) {
 	}
 }
 
-type invalidProto struct {
-}
+type invalidProto struct{}
 
 var (
 	_ proto.Message     = &invalidProto{}

--- a/pkg/config/schema/schema_test.go
+++ b/pkg/config/schema/schema_test.go
@@ -383,8 +383,7 @@ func TestBuild_UnknownTransform(t *testing.T) {
 	g.Expect(err).NotTo(BeNil())
 }
 
-type unknownXformSettings struct {
-}
+type unknownXformSettings struct{}
 
 var _ ast.TransformSettings = &unknownXformSettings{}
 

--- a/pkg/kube/inject/webhook.go
+++ b/pkg/kube/inject/webhook.go
@@ -212,7 +212,7 @@ func (wh *Webhook) Run(stop <-chan struct{}) {
 		select {
 		case <-healthC:
 			content := []byte(`ok`)
-			if err := ioutil.WriteFile(wh.healthCheckFile, content, 0644); err != nil {
+			if err := ioutil.WriteFile(wh.healthCheckFile, content, 0o644); err != nil {
 				log.Errorf("Health check update of %q failed: %v", wh.healthCheckFile, err)
 			}
 		case <-stop:

--- a/pkg/kube/mock_client.go
+++ b/pkg/kube/mock_client.go
@@ -44,8 +44,7 @@ import (
 
 var _ ExtendedClient = MockClient{}
 
-type MockPortForwarder struct {
-}
+type MockPortForwarder struct{}
 
 func (m MockPortForwarder) Start() error {
 	return nil

--- a/pkg/test/echo/server/forwarder/dns.go
+++ b/pkg/test/echo/server/forwarder/dns.go
@@ -25,8 +25,7 @@ import (
 
 var _ protocol = &dnsProtocol{}
 
-type dnsProtocol struct {
-}
+type dnsProtocol struct{}
 
 type dnsRequest struct {
 	hostname  string

--- a/tools/bug-report/pkg/bugreport/bugreport.go
+++ b/tools/bug-report/pkg/bugreport/bugreport.go
@@ -428,13 +428,13 @@ func writeFile(path, text string) {
 		return
 	}
 	mkdirOrExit(path)
-	if err := ioutil.WriteFile(path, []byte(text), 0644); err != nil {
+	if err := ioutil.WriteFile(path, []byte(text), 0o644); err != nil {
 		log.Errorf(err.Error())
 	}
 }
 
 func mkdirOrExit(fpath string) {
-	if err := os.MkdirAll(path.Dir(fpath), 0755); err != nil {
+	if err := os.MkdirAll(path.Dir(fpath), 0o755); err != nil {
 		fmt.Printf("Could not create output directories: %s", err)
 		os.Exit(-1)
 	}

--- a/tools/istio-iptables/pkg/dependencies/implementation.go
+++ b/tools/istio-iptables/pkg/dependencies/implementation.go
@@ -22,8 +22,7 @@ import (
 )
 
 // RealDependencies implementation of interface Dependencies, which is used in production
-type RealDependencies struct {
-}
+type RealDependencies struct{}
 
 func (r *RealDependencies) execute(cmd string, redirectStdout bool, args ...string) error {
 	fmt.Printf("%s %s\n", cmd, strings.Join(args, " "))

--- a/tools/istio-iptables/pkg/dependencies/stub.go
+++ b/tools/istio-iptables/pkg/dependencies/stub.go
@@ -20,8 +20,7 @@ import (
 )
 
 // StdoutStubDependencies implementation of interface Dependencies, which is used for testing
-type StdoutStubDependencies struct {
-}
+type StdoutStubDependencies struct{}
 
 // RunOrFail runs a command and panics, if it fails
 func (s *StdoutStubDependencies) RunOrFail(cmd string, args ...string) {


### PR DESCRIPTION
This is a forward compatible changes that makes our code pass the new
linter, so we can upgrade



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.