### PR TITLE
[test-framework] Remove adding duplicate workload to echo workloads on update 

### DIFF
--- a/pkg/test/framework/components/echo/kube/workload_manager.go
+++ b/pkg/test/framework/components/echo/kube/workload_manager.go
@@ -213,9 +213,6 @@ func (m *workloadManager) onPodAddOrUpdate(pod *kubeCore.Pod) error {
 			if newWorkload.IsReady() {
 				workloadReady = newWorkload
 			}
-
-			// Now add the previous workload.
-			newWorkloads = append(newWorkloads, workload)
 			added = true
 		default:
 			// Should never happen.


### PR DESCRIPTION
Fixes #30880. 

#30675 introduced an issue to echo `Restart` where we'd continually add a new workload for the same pod on every pod state change, resulting in 8-9 workloads rather than the expected 1. Removing the line below fixes the issue for my case but I may not understand the intention behind adding the old workload back in

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any changes that may affect Istio users.
