### PR TITLE
allow stable namespaces to be created/claimed in parallel

### DIFF
--- a/pkg/test/framework/components/namespace/kube.go
+++ b/pkg/test/framework/components/namespace/kube.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	kubeApiCore "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	kubeApiMeta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -106,7 +107,7 @@ func claimKube(ctx resource.Context, nsConfig *Config) (Instance, error) {
 					Name:   nsConfig.Prefix,
 					Labels: createNamespaceLabels(nsConfig),
 				},
-			}, kubeApiMeta.CreateOptions{}); err != nil {
+			}, kubeApiMeta.CreateOptions{}); err != nil && !errors.IsAlreadyExists(err) {
 				return nil, err
 			}
 		}


### PR DESCRIPTION
When running TestValidation with stable namespaces enabled:

1. both tests read the NS, see it doesn't exist
2. since it doesn't exist they both try to create it
3. one will succeed and one with fail out

This PR lets the failing one succeed if the error was due to the create succeeding on another thread. 