### PR TITLE
authn: skip filter peer config when mtls is disabled

### DIFF
--- a/pilot/pkg/security/authn/v1beta1/policy_applier.go
+++ b/pilot/pkg/security/authn/v1beta1/policy_applier.go
@@ -100,6 +100,12 @@ func (a *v1beta1PolicyApplier) setAuthnFilterForPeerAuthn(proxyType model.NodeTy
 	var effectiveMTLSMode model.MutualTLSMode
 	if proxyType == model.SidecarProxy {
 		effectiveMTLSMode = a.getMutualTLSModeForPort(port)
+
+		// Skip authn filter peer config when mtls is disabled.
+		if effectiveMTLSMode == model.MTLSDisable {
+			authnLog.Debugf("AuthnFilter: skip setting peer authn when mtls is disabled")
+			return nil
+		}
 	} else {
 		// this is for gateway with a server whose TLS mode is ISTIO_MUTUAL
 		// this is effectively the same as strict mode. We dont really

--- a/pilot/pkg/security/authn/v1beta1/policy_applier_test.go
+++ b/pilot/pkg/security/authn/v1beta1/policy_applier_test.go
@@ -1378,6 +1378,19 @@ func TestAuthnFilterConfig(t *testing.T) {
 			},
 		},
 		{
+			name: "beta-mtls-disable",
+			peerIn: []*config.Config{
+				{
+					Spec: &v1beta1.PeerAuthentication{
+						Mtls: &v1beta1.PeerAuthentication_MutualTLS{
+							Mode: v1beta1.PeerAuthentication_MutualTLS_DISABLE,
+						},
+					},
+				},
+			},
+			expected: nil,
+		},
+		{
 			name:      "beta-mtls-for-gateway-does-not-respect-mtls-configs",
 			isGateway: true,
 			peerIn: []*config.Config{


### PR DESCRIPTION
This avoids needless `istio_authn` filters to be added with all mtls and
request auth disabled.

Fixes: https://github.com/istio/istio/issues/27057
Related: https://github.com/istio/istio/issues/22602

Signed-off-by: Kailun Qin <kailun.qin@intel.com>

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[x] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
