### PR TITLE
minor xds proxy cleanup

### DIFF
--- a/pilot/pkg/xds/v3/model.go
+++ b/pilot/pkg/xds/v3/model.go
@@ -15,10 +15,15 @@
 package v3
 
 import (
+	"strings"
+
 	"github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 )
 
 const (
+	apiTypePrefix   = "type.googleapis.com/"
+	envoyTypePrefix = apiTypePrefix + "envoy."
+
 	ClusterType                = resource.ClusterType
 	EndpointType               = resource.EndpointType
 	ListenerType               = resource.ListenerType
@@ -26,8 +31,8 @@ const (
 	SecretType                 = resource.SecretType
 	ExtensionConfigurationType = resource.ExtensionConfigType
 
-	NameTableType  = "type.googleapis.com/istio.networking.nds.v1.NameTable"
-	HealthInfoType = "type.googleapis.com/istio.v1.HealthInformation"
+	NameTableType  = apiTypePrefix + "istio.networking.nds.v1.NameTable"
+	HealthInfoType = apiTypePrefix + "istio.v1.HealthInformation"
 )
 
 // GetShortType returns an abbreviated form of a type, useful for logging or human friendly messages
@@ -68,4 +73,9 @@ func GetMetricType(typeURL string) string {
 	default:
 		return typeURL
 	}
+}
+
+// IsEnvoyType checks whether the typeURL is a valid Envoy type.
+func IsEnvoyType(typeURL string) bool {
+	return strings.HasPrefix(typeURL, envoyTypePrefix)
 }

--- a/pkg/istio-agent/xds_proxy_test.go
+++ b/pkg/istio-agent/xds_proxy_test.go
@@ -50,7 +50,6 @@ import (
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/pkg/test/util/retry"
-	"istio.io/pkg/log"
 )
 
 // Validates basic xds proxy flow by proxying one CDS requests end to end.
@@ -369,7 +368,6 @@ func (f *fakeNackCache) Get(string, string, time.Duration) (string, error) {
 func (f *fakeNackCache) Cleanup() {}
 
 func TestECDSWasmConversion(t *testing.T) {
-	proxyLog.SetOutputLevel(log.DebugLevel)
 	node := model.NodeMetadata{
 		Namespace:   "default",
 		InstanceIPs: []string{"1.1.1.1"},


### PR DESCRIPTION
This PR does the following
- Move rewriteAndForward to a go routine for every ECDS update so that does not depend on channels. Might scale better
- Validates typeURL before forwarding to Envoy

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ X] Does not have any changes that may affect Istio users.
