### PR TITLE
Do not cleanup service-apis CRD

### DIFF
--- a/tests/integration/pilot/main_test.go
+++ b/tests/integration/pilot/main_test.go
@@ -58,7 +58,7 @@ func TestMain(m *testing.M) {
 				if err != nil {
 					return err
 				}
-				return ctx.Config().ApplyYAML("", string(crd))
+				return ctx.Config().ApplyYAMLNoCleanup("", string(crd))
 			}
 			return nil
 		}).


### PR DESCRIPTION
This fixes a regression from a previous PR. We should not cleanup the
CRD, as it leaves Istio in a semi-broken state and may break existing
clusters. This should be treated at the same level as istio deployment
and not be removed with --nocleanup



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.