### PR TITLE
manifests: generate intended YAML for openCensusAgent

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/configmap.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/configmap.yaml
@@ -44,8 +44,8 @@
           maxNumberOfMessageEvents: {{ $.Values.global.tracer.stackdriver.maxNumberOfMessageEvents | default "200" }}
         {{- end }}
       {{- else if eq .Values.global.proxy.tracer "openCensusAgent" }}
-      {{- /* Fill in openCensusAgent configuration from meshConfig so it isn't overwritten below */ -}}
-        {{ toYaml $.Values.meshConfig.defaultConfig.tracing }}
+      {{/* Fill in openCensusAgent configuration from meshConfig so it isn't overwritten below */}}
+{{ toYaml $.Values.meshConfig.defaultConfig.tracing | indent 8 }}
       {{- end }}
       {{- if .Values.global.remotePilotAddress }}
          {{- if .Values.pilot.enabled }}

--- a/manifests/charts/istiod-remote/templates/configmap.yaml
+++ b/manifests/charts/istiod-remote/templates/configmap.yaml
@@ -44,8 +44,8 @@
           maxNumberOfMessageEvents: {{ $.Values.global.tracer.stackdriver.maxNumberOfMessageEvents | default "200" }}
         {{- end }}
       {{- else if eq .Values.global.proxy.tracer "openCensusAgent" }}
-      {{- /* Fill in openCensusAgent configuration from meshConfig so it isn't overwritten below */ -}}
-        {{ toYaml $.Values.meshConfig.defaultConfig.tracing }}
+      {{/* Fill in openCensusAgent configuration from meshConfig so it isn't overwritten below */}}
+{{ toYaml $.Values.meshConfig.defaultConfig.tracing | indent 8 }}
       {{- end }}
       {{- if .Values.global.remotePilotAddress }}
          {{- if .Values.pilot.enabled }}


### PR DESCRIPTION
This fixes up two templating issues when configuring openCensusAgent as
the tracer:
1) when toYaml renders a multiline string on an indented line, only the
   first line is indented properly.
2) trimming whitespace from comments is unnecessary and may lead to
   unintended removal of significant whitespace.

Change-Id: Ie7ac6789c2da3ca9adb761d2cbc78bdfcbcd5587



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.