### PR TITLE
Add istioctl proxy-config all

### DIFF
--- a/istioctl/cmd/proxyconfig.go
+++ b/istioctl/cmd/proxyconfig.go
@@ -397,18 +397,21 @@ func allConfigCmd() *cobra.Command {
 				}
 			case summaryOutput:
 				var configWriter *configdump.ConfigWriter
-				var err error
 				if len(args) == 1 {
 					podName, podNamespace, err := getPodName(args[0])
 					if err != nil {
 						return err
 					}
 					configWriter, err = setupPodConfigdumpWriter(podName, podNamespace, c.OutOrStdout())
+					if err != nil {
+						return err
+					}
 				} else {
+					var err error
 					configWriter, err = setupFileConfigdumpWriter(configDumpFile, c.OutOrStdout())
-				}
-				if err != nil {
-					return err
+					if err != nil {
+						return err
+					}
 				}
 				return configWriter.PrintFullSummary(
 					configdump.ClusterFilter{

--- a/istioctl/cmd/proxyconfig.go
+++ b/istioctl/cmd/proxyconfig.go
@@ -150,7 +150,7 @@ var (
 	reset             = false
 )
 
-func setupPodConfigdumpWriter(podName, podNamespace string, out io.Writer) (*configdump.ConfigWriter, error) {
+func extractConfigDump(podName, podNamespace string) ([]byte, error) {
 	kubeClient, err := kubeClient(kubeconfig, configContext)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create k8s client: %v", err)
@@ -160,10 +160,18 @@ func setupPodConfigdumpWriter(podName, podNamespace string, out io.Writer) (*con
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute command on %s.%s sidecar: %v", podName, podNamespace, err)
 	}
+	return debug, err
+}
+
+func setupPodConfigdumpWriter(podName, podNamespace string, out io.Writer) (*configdump.ConfigWriter, error) {
+	debug, err := extractConfigDump(podName, podNamespace)
+	if err != nil {
+		return nil, err
+	}
 	return setupConfigdumpEnvoyConfigWriter(debug, out)
 }
 
-func setupFileConfigdumpWriter(filename string, out io.Writer) (*configdump.ConfigWriter, error) {
+func readFile(filename string) ([]byte, error) {
 	file := os.Stdin
 	if filename != "-" {
 		var err error
@@ -177,7 +185,11 @@ func setupFileConfigdumpWriter(filename string, out io.Writer) (*configdump.Conf
 			log.Errorf("failed to close %s: %s", filename, err)
 		}
 	}()
-	data, err := ioutil.ReadAll(file)
+	return ioutil.ReadAll(file)
+}
+
+func setupFileConfigdumpWriter(filename string, out io.Writer) (*configdump.ConfigWriter, error) {
+	data, err := readFile(filename)
 	if err != nil {
 		return nil, err
 	}
@@ -338,6 +350,112 @@ func clusterConfigCmd() *cobra.Command {
 		"Envoy config dump JSON file")
 
 	return clusterConfigCmd
+}
+
+func allConfigCmd() *cobra.Command {
+	allConfigCmd := &cobra.Command{
+		Use:   "all [<type>/]<name>[.<namespace>]",
+		Short: "Retrieves all configuration for the Envoy in the specified pod",
+		Long:  `Retrieve information about all configuration for the Envoy instance in the specified pod.`,
+		Example: `  # Retrieve summary about all configuration for a given pod from Envoy.
+  istioctl proxy-config all <pod-name[.namespace]>
+
+  # Retrieve full cluster dump as JSON
+  istioctl proxy-config all <pod-name[.namespace]> -o json
+
+  # Retrieve cluster summary without using Kubernetes API
+  ssh <user@hostname> 'curl localhost:15000/config_dump' > envoy-config.json
+  istioctl proxy-config all --file envoy-config.json
+`,
+		Aliases: []string{"all", "a"},
+		Args: func(cmd *cobra.Command, args []string) error {
+			if (len(args) == 1) != (configDumpFile == "") {
+				cmd.Println(cmd.UsageString())
+				return fmt.Errorf("all requires pod name or --file parameter")
+			}
+			return nil
+		},
+		RunE: func(c *cobra.Command, args []string) error {
+			switch outputFormat {
+			case jsonOutput:
+				if len(args) == 1 {
+					podName, podNamespace, err := getPodName(args[0])
+					if err != nil {
+						return err
+					}
+					dump, err := extractConfigDump(podName, podNamespace)
+					if err != nil {
+						return err
+					}
+					fmt.Fprintln(c.OutOrStdout(), string(dump))
+				} else {
+					dump, err := readFile(configDumpFile)
+					if err != nil {
+						return err
+					}
+					fmt.Fprintln(c.OutOrStdout(), string(dump))
+				}
+			case summaryOutput:
+				var configWriter *configdump.ConfigWriter
+				var err error
+				if len(args) == 1 {
+					podName, podNamespace, err := getPodName(args[0])
+					if err != nil {
+						return err
+					}
+					configWriter, err = setupPodConfigdumpWriter(podName, podNamespace, c.OutOrStdout())
+				} else {
+					configWriter, err = setupFileConfigdumpWriter(configDumpFile, c.OutOrStdout())
+				}
+				if err != nil {
+					return err
+				}
+				return configWriter.PrintFullSummary(
+					configdump.ClusterFilter{
+						FQDN:      host.Name(fqdn),
+						Port:      port,
+						Subset:    subset,
+						Direction: model.TrafficDirection(direction),
+					},
+					configdump.ListenerFilter{
+						Address: address,
+						Port:    uint32(port),
+						Type:    listenerType,
+						Verbose: verboseProxyConfig,
+					},
+					configdump.RouteFilter{
+						Name:    routeName,
+						Verbose: verboseProxyConfig,
+					},
+				)
+			default:
+				return fmt.Errorf("output format %q not supported", outputFormat)
+			}
+			return nil
+		},
+	}
+
+	allConfigCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", summaryOutput, "Output format: one of json|short")
+	allConfigCmd.PersistentFlags().StringVarP(&configDumpFile, "file", "f", "",
+		"Envoy config dump JSON file")
+	allConfigCmd.PersistentFlags().BoolVar(&verboseProxyConfig, "verbose", true, "Output more information")
+
+	// cluster
+	allConfigCmd.PersistentFlags().StringVar(&fqdn, "fqdn", "", "Filter clusters by substring of Service FQDN field")
+	allConfigCmd.PersistentFlags().StringVar(&direction, "direction", "", "Filter clusters by Direction field")
+	allConfigCmd.PersistentFlags().StringVar(&subset, "subset", "", "Filter clusters by substring of Subset field")
+
+	// applies to cluster and route
+	allConfigCmd.PersistentFlags().IntVar(&port, "port", 0, "Filter clusters and listeners by Port field")
+
+	// Listener
+	allConfigCmd.PersistentFlags().StringVar(&address, "address", "", "Filter listeners by address field")
+	allConfigCmd.PersistentFlags().StringVar(&listenerType, "type", "", "Filter listeners by type field")
+
+	// route
+	allConfigCmd.PersistentFlags().StringVar(&routeName, "name", "", "Filter listeners by route name field")
+
+	return allConfigCmd
 }
 
 func listenerConfigCmd() *cobra.Command {
@@ -804,6 +922,7 @@ func proxyConfig() *cobra.Command {
 	configCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", summaryOutput, "Output format: one of json|short")
 
 	configCmd.AddCommand(clusterConfigCmd())
+	configCmd.AddCommand(allConfigCmd())
 	configCmd.AddCommand(listenerConfigCmd())
 	configCmd.AddCommand(logCmd())
 	configCmd.AddCommand(routeConfigCmd())

--- a/istioctl/pkg/writer/envoy/configdump/configdump.go
+++ b/istioctl/pkg/writer/envoy/configdump/configdump.go
@@ -100,15 +100,15 @@ func (c *ConfigWriter) PrintFullSummary(cf ClusterFilter, lf ListenerFilter, rf 
 	if err := c.PrintClusterSummary(cf); err != nil {
 		return err
 	}
-	c.Stdout.Write([]byte("\n"))
+	_, _ = c.Stdout.Write([]byte("\n"))
 	if err := c.PrintListenerSummary(lf); err != nil {
 		return err
 	}
-	c.Stdout.Write([]byte("\n"))
+	_, _ = c.Stdout.Write([]byte("\n"))
 	if err := c.PrintRouteSummary(rf); err != nil {
 		return err
 	}
-	c.Stdout.Write([]byte("\n"))
+	_, _ = c.Stdout.Write([]byte("\n"))
 	if err := c.PrintSecretSummary(); err != nil {
 		return err
 	}

--- a/istioctl/pkg/writer/envoy/configdump/configdump.go
+++ b/istioctl/pkg/writer/envoy/configdump/configdump.go
@@ -95,3 +95,22 @@ func (c *ConfigWriter) PrintSecretSummary() error {
 	secretWriter := sdscompare.NewSDSWriter(c.Stdout, sdscompare.TABULAR)
 	return secretWriter.PrintSecretItems(secretItems)
 }
+
+func (c *ConfigWriter) PrintFullSummary(cf ClusterFilter, lf ListenerFilter, rf RouteFilter) error {
+	if err := c.PrintClusterSummary(cf); err != nil {
+		return err
+	}
+	c.Stdout.Write([]byte("\n"))
+	if err := c.PrintListenerSummary(lf); err != nil {
+		return err
+	}
+	c.Stdout.Write([]byte("\n"))
+	if err := c.PrintRouteSummary(rf); err != nil {
+		return err
+	}
+	c.Stdout.Write([]byte("\n"))
+	if err := c.PrintSecretSummary(); err != nil {
+		return err
+	}
+	return nil
+}

--- a/istioctl/pkg/writer/envoy/configdump/route.go
+++ b/istioctl/pkg/writer/envoy/configdump/route.go
@@ -51,7 +51,6 @@ func (c *ConfigWriter) PrintRouteSummary(filter RouteFilter) error {
 	if err != nil {
 		return err
 	}
-	fmt.Fprintln(c.Stdout, "NOTE: This output only contains routes loaded via RDS.")
 	if filter.Verbose {
 		fmt.Fprintln(w, "NAME\tDOMAINS\tMATCH\tVIRTUAL SERVICE")
 	} else {

--- a/releasenotes/notes/istioctl-pc-all.yaml
+++ b/releasenotes/notes/istioctl-pc-all.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: istioctl
+issues:
+- 28191
+releaseNotes:
+- |
+  **Added** the `istioctl proxy-config all` command to view the full proxy configuration.


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/28191

Open questions:
* Should we support filters? The behavior is a bit awkward
* Should we instead have kubectl semantics? ie we can do `pc all`, `pc
cluster`, or `pc cluster,listener,secret`. One downside is because these
would not be subcommands we would not have per-command filter flags, so
we have the same awkward flag support as we have here



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.