### PR TITLE
minor improvements to istio cni

### DIFF
--- a/cni/pkg/taint/taintcontroller.go
+++ b/cni/pkg/taint/taintcontroller.go
@@ -68,16 +68,16 @@ func NewTaintSetterController(ts *Setter) (*Controller, error) {
 	}
 	nodeListWatch := cache.NewFilteredListWatchFromClient(c.clientset.CoreV1().RESTClient(), "nodes", metav1.NamespaceAll, func(options *metav1.ListOptions) {
 	})
-	c.nodeStore, c.nodeController = buildNodeControler(c, nodeListWatch)
+	c.nodeStore, c.nodeController = buildNodeController(c, nodeListWatch)
 	return c, nil
 }
 
 // build a listwatch based on the config
-// monitoring on pod with namespace and labelselectors defined in configmap
-// and add store to cache given namespace and labelsalector,
+// monitoring on pod with namespace and label-selectors defined in configmap
+// and add store to cache given namespace and label-selector,
 // return a controller built by listwatch function
 // add : add it to workqueue
-// update: add it to workquueue
+// update: add it to workqueue
 // remove: retaint the node
 func buildPodController(c *Controller, config ConfigSettings, source cache.ListerWatcher) cache.Controller {
 	tempstore, tempcontroller := cache.NewInformer(source, &v1.Pod{}, 0, cache.ResourceEventHandlerFuncs{
@@ -103,7 +103,7 @@ func buildPodController(c *Controller, config ConfigSettings, source cache.Liste
 	return tempcontroller
 }
 
-func buildNodeControler(c *Controller, nodeListWatch cache.ListerWatcher) (cache.Store, cache.Controller) {
+func buildNodeController(c *Controller, nodeListWatch cache.ListerWatcher) (cache.Store, cache.Controller) {
 	store, controller := cache.NewInformer(nodeListWatch, &v1.Node{}, 0, cache.ResourceEventHandlerFuncs{
 		AddFunc: func(newObj interface{}) {
 			_, ok := newObj.(*v1.Node)
@@ -185,17 +185,20 @@ func (tc *Controller) Run(stopCh <-chan struct{}) {
 
 func (tc *Controller) processNextPod() bool {
 	errorHandler := func(obj interface{}, pod *v1.Pod, err error) {
+		podName := fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
 		if err == nil {
-			log.Debugf("Removing %s/%s from work queue", pod.Namespace, pod.Name)
+			log.Debugf("Removing %s from work queue", podName)
 			tc.podWorkQueue.Forget(obj)
-		} else if tc.podWorkQueue.NumRequeues(obj) < 50 {
-			log.Errorf("Error: %s", err.Error())
-			log.Infof("Re-adding %s/%s to work queue", pod.Namespace, pod.Name)
-			tc.podWorkQueue.AddRateLimited(obj)
 		} else {
-			log.Infof("Requeue limit reached, removing %s/%s", pod.Namespace, pod.Name)
-			tc.podWorkQueue.Forget(obj)
-			runtime.HandleError(err)
+			log.Errorf("Error while processing pod %s: %s", podName, err.Error())
+			if tc.podWorkQueue.NumRequeues(obj) < 50 {
+				log.Infof("Re-adding %s to work queue", podName)
+				tc.podWorkQueue.AddRateLimited(obj)
+			} else {
+				log.Infof("Requeue limit reached, removing %s", podName)
+				tc.podWorkQueue.Forget(obj)
+				runtime.HandleError(err)
+			}
 		}
 	}
 	obj, quit := tc.podWorkQueue.Get()
@@ -219,7 +222,7 @@ func (tc *Controller) processNextPod() bool {
 		err := tc.processReadyPod(pod)
 		errorHandler(obj, pod, err)
 	} else {
-		err := tc.processUnReadyPod(pod)
+		err := tc.processUnreadyPod(pod)
 		errorHandler(obj, pod, err)
 	}
 	// Return true to let the loop process the next item
@@ -288,7 +291,7 @@ func (tc Controller) processReadyPod(pod *v1.Pod) error {
 }
 
 // if pod is unready, it should be tainted
-func (tc Controller) processUnReadyPod(pod *v1.Pod) error {
+func (tc Controller) processUnreadyPod(pod *v1.Pod) error {
 	node, err := tc.getNodeByPod(pod)
 	if err != nil {
 		return fmt.Errorf("cannot get node by  %s in namespace %s : %s", pod.Name, pod.Namespace, err)

--- a/cni/pkg/taint/taintcontroller_test.go
+++ b/cni/pkg/taint/taintcontroller_test.go
@@ -54,7 +54,7 @@ func newMockTaintSetterController(ts *Setter,
 		tempcontroller := buildPodController(c, config, podSource)
 		c.podController = append(c.podController, tempcontroller)
 	}
-	c.nodeStore, c.nodeController = buildNodeControler(c, nodeSource)
+	c.nodeStore, c.nodeController = buildNodeController(c, nodeSource)
 	return c, sourcer
 }
 

--- a/manifests/charts/istio-cni/templates/clusterrole.yaml
+++ b/manifests/charts/istio-cni/templates/clusterrole.yaml
@@ -24,6 +24,9 @@ metadata:
   labels:
     app: istio-cni
     release: {{ .Release.Name }}
+    istio.io/rev: {{ .Values.revision | default "default" }}
+    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
+    operator.istio.io/component: "Cni"
 rules:
 - apiGroups: [""]
   resources: ["pods"]
@@ -41,6 +44,9 @@ metadata:
   labels:
     app: istio-cni
     release: {{ .Release.Name }}
+    istio.io/rev: {{ .Values.revision | default "default" }}
+    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
+    operator.istio.io/component: "Cni"
 rules:
   - apiGroups: [""]
     resources: ["pods"]

--- a/manifests/charts/istio-cni/templates/clusterrolebinding.yaml
+++ b/manifests/charts/istio-cni/templates/clusterrolebinding.yaml
@@ -24,6 +24,9 @@ metadata:
   name: istio-cni-repair-rolebinding
   labels:
     k8s-app: istio-cni-repair
+    istio.io/rev: {{ .Values.revision | default "default" }}
+    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
+    operator.istio.io/component: "Cni"
 subjects:
 - kind: ServiceAccount
   name: istio-cni
@@ -40,6 +43,10 @@ kind: RoleBinding
 metadata:
   name: istio-cni-psp
   namespace: {{ .Release.Namespace }}
+  labels:
+    istio.io/rev: {{ .Values.revision | default "default" }}
+    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
+    operator.istio.io/component: "Cni"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -50,13 +57,16 @@ subjects:
   namespace: {{ .Release.Namespace }}
 {{- end }}
 ---
-  {{- if .Values.cni.taint.enabled }}
+{{- if .Values.cni.taint.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: istio-cni-taint-rolebinding
   labels:
     k8s-app: istio-cni-taint
+    istio.io/rev: {{ .Values.revision | default "default" }}
+    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
+    operator.istio.io/component: "Cni"
 subjects:
   - kind: ServiceAccount
     name: istio-cni
@@ -65,4 +75,4 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: istio-cni-taint-role
-  {{- end }}
+{{- end }}

--- a/manifests/charts/istio-cni/templates/configmap-cni.yaml
+++ b/manifests/charts/istio-cni/templates/configmap-cni.yaml
@@ -30,13 +30,16 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: "istio-cni-taint-configmap"
-  namespace: "kube-system"
+  namespace: {{ .Release.Namespace }}
   labels:
     app: istio-cni
     release: {{ .Release.Name }}
+    istio.io/rev: {{ .Values.revision | default "default" }}
+    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
+    operator.istio.io/component: "Cni"
 data:
   config: |
         - name: istio-cni
           selector: k8s-app=istio-cni-node
-          namespace: kube-system
+          namespace: {{ .Release.Namespace }}
   {{- end }}

--- a/manifests/charts/istio-cni/templates/daemonset.yaml
+++ b/manifests/charts/istio-cni/templates/daemonset.yaml
@@ -148,7 +148,7 @@ spec:
           - name: "TAINT_CONFIGMAP-NAME"
             value: "istio-cni-taint-configmap"
           - name: "TAINT_CONFIGMAP-NAMESPACE"
-            value: "kube-system"
+            value: {{ .Release.Namespace | quote }}
 {{- end }}
       volumes:
         # Used to install CNI.


### PR DESCRIPTION
Please provide a description of what this PR is for.
This PR adds some minor improvements to istio-cni-taint-controller

i) Logging of errors when processing istio cni pods from the workqueue
ii) Consistent usage of namespace
iii) Adding standard labels to the istio cni taint controller manifests

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
