### PR TITLE
pilot: Make JwtKeyResolver non global

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -644,7 +644,6 @@ func (s *Server) waitForShutdown(stop <-chan struct{}) {
 	go func() {
 		<-stop
 		s.fileWatcher.Close()
-		model.GetJwtKeyResolver().Close()
 
 		// Stop gRPC services.  If gRPC services fail to stop in the shutdown duration,
 		// force stop them. This does not happen normally.

--- a/pilot/pkg/model/jwks_resolver_test.go
+++ b/pilot/pkg/model/jwks_resolver_test.go
@@ -29,7 +29,7 @@ import (
 const testRetryInterval = time.Millisecond * 10
 
 func TestResolveJwksURIUsingOpenID(t *testing.T) {
-	r := newJwksResolver(JwtPubKeyEvictionDuration, JwtPubKeyRefreshInterval, JwtPubKeyRefreshIntervalOnFailure, testRetryInterval)
+	r := NewJwksResolver(JwtPubKeyEvictionDuration, JwtPubKeyRefreshInterval, JwtPubKeyRefreshIntervalOnFailure, testRetryInterval)
 	defer r.Close()
 
 	ms, err := test.StartNewServer()
@@ -76,7 +76,7 @@ func TestResolveJwksURIUsingOpenID(t *testing.T) {
 }
 
 func TestGetPublicKey(t *testing.T) {
-	r := newJwksResolver(JwtPubKeyEvictionDuration, JwtPubKeyRefreshInterval, JwtPubKeyRefreshIntervalOnFailure, testRetryInterval)
+	r := NewJwksResolver(JwtPubKeyEvictionDuration, JwtPubKeyRefreshInterval, JwtPubKeyRefreshIntervalOnFailure, testRetryInterval)
 	defer r.Close()
 
 	ms, err := test.StartNewServer()
@@ -117,7 +117,7 @@ func TestGetPublicKey(t *testing.T) {
 }
 
 func TestGetPublicKeyReorderedKey(t *testing.T) {
-	r := newJwksResolver(JwtPubKeyEvictionDuration, testRetryInterval*20, testRetryInterval*10, testRetryInterval)
+	r := NewJwksResolver(JwtPubKeyEvictionDuration, testRetryInterval*20, testRetryInterval*10, testRetryInterval)
 	defer r.Close()
 
 	ms, err := test.StartNewServer()
@@ -232,7 +232,7 @@ func TestGetPublicKeyUsingTLSWithoutCABundles(t *testing.T) {
 }
 
 func TestJwtPubKeyEvictionForNotUsed(t *testing.T) {
-	r := newJwksResolver(
+	r := NewJwksResolver(
 		100*time.Millisecond, /*EvictionDuration*/
 		2*time.Millisecond,   /*RefreshInterval*/
 		2*time.Millisecond,   /*RefreshIntervalOnFailure*/
@@ -260,7 +260,7 @@ func TestJwtPubKeyEvictionForNotUsed(t *testing.T) {
 }
 
 func TestJwtPubKeyEvictionForNotRefreshed(t *testing.T) {
-	r := newJwksResolver(
+	r := NewJwksResolver(
 		100*time.Millisecond, /*EvictionDuration*/
 		10*time.Millisecond,  /*RefreshInterval*/
 		10*time.Millisecond,  /*RefreshIntervalOnFailure*/
@@ -313,7 +313,7 @@ func TestJwtPubKeyEvictionForNotRefreshed(t *testing.T) {
 }
 
 func TestJwtPubKeyLastRefreshedTime(t *testing.T) {
-	r := newJwksResolver(
+	r := NewJwksResolver(
 		JwtPubKeyEvictionDuration,
 		2*time.Millisecond, /*RefreshInterval*/
 		2*time.Millisecond, /*RefreshIntervalOnFailure*/
@@ -333,7 +333,7 @@ func TestJwtPubKeyLastRefreshedTime(t *testing.T) {
 }
 
 func TestJwtPubKeyRefreshWithNetworkError(t *testing.T) {
-	r := newJwksResolver(
+	r := NewJwksResolver(
 		JwtPubKeyEvictionDuration,
 		time.Second, /*RefreshInterval*/
 		time.Second, /*RefreshIntervalOnFailure*/
@@ -357,7 +357,7 @@ func TestJwtPubKeyRefreshWithNetworkError(t *testing.T) {
 func TestJwtRefreshIntervalExponentialBackoff(t *testing.T) {
 	defaultRefreshInterval := 50 * time.Millisecond
 	refreshIntervalOnFail := 2 * time.Millisecond
-	r := newJwksResolver(JwtPubKeyEvictionDuration, defaultRefreshInterval, refreshIntervalOnFail, 1*time.Millisecond)
+	r := NewJwksResolver(JwtPubKeyEvictionDuration, defaultRefreshInterval, refreshIntervalOnFail, 1*time.Millisecond)
 
 	ms := startMockServer(t)
 	defer ms.Stop()
@@ -385,7 +385,7 @@ func TestJwtRefreshIntervalExponentialBackoff(t *testing.T) {
 func TestJwtRefreshIntervalRecoverFromInitialFailOnFirstHit(t *testing.T) {
 	defaultRefreshInterval := 50 * time.Millisecond
 	refreshIntervalOnFail := 2 * time.Millisecond
-	r := newJwksResolver(JwtPubKeyEvictionDuration, defaultRefreshInterval, refreshIntervalOnFail, 1*time.Millisecond)
+	r := NewJwksResolver(JwtPubKeyEvictionDuration, defaultRefreshInterval, refreshIntervalOnFail, 1*time.Millisecond)
 
 	ms := startMockServer(t)
 	defer ms.Stop()
@@ -424,7 +424,7 @@ func TestJwtRefreshIntervalRecoverFromInitialFailOnFirstHit(t *testing.T) {
 func TestJwtRefreshIntervalRecoverFromFail(t *testing.T) {
 	defaultRefreshInterval := 50 * time.Millisecond
 	refreshIntervalOnFail := 2 * time.Millisecond
-	r := newJwksResolver(JwtPubKeyEvictionDuration, defaultRefreshInterval, refreshIntervalOnFail, 1*time.Millisecond)
+	r := NewJwksResolver(JwtPubKeyEvictionDuration, defaultRefreshInterval, refreshIntervalOnFail, 1*time.Millisecond)
 
 	ms := startMockServer(t)
 	defer ms.Stop()
@@ -465,7 +465,8 @@ func getCounterValue(counterName string, t *testing.T) float64 {
 func TestJwtPubKeyMetric(t *testing.T) {
 	defaultRefreshInterval := 50 * time.Millisecond
 	refreshIntervalOnFail := 2 * time.Millisecond
-	r := newJwksResolver(JwtPubKeyEvictionDuration, defaultRefreshInterval, refreshIntervalOnFail, 1*time.Millisecond)
+	r := NewJwksResolver(JwtPubKeyEvictionDuration, defaultRefreshInterval, refreshIntervalOnFail, 1*time.Millisecond)
+	defer r.Close()
 
 	ms := startMockServer(t)
 	defer ms.Stop()

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -201,6 +201,9 @@ type PushContext struct {
 	// LedgerVersion is the version of the configuration ledger
 	LedgerVersion string
 
+	// JwtKeyResolver holds a reference to the JWT key resolver instance.
+	JwtKeyResolver *JwksResolver
+
 	// cache gateways addresses for each network
 	// this is mainly used for kubernetes multi-cluster scenario
 	networksMu      sync.RWMutex

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -46,8 +46,6 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	// TODO(https://github.com/istio/istio/issues/29349) make this not global
-	GetJwtKeyResolver().Close()
 	leak.CheckMain(m)
 }
 

--- a/pilot/pkg/security/authn/v1beta1/policy_applier_test.go
+++ b/pilot/pkg/security/authn/v1beta1/policy_applier_test.go
@@ -533,7 +533,7 @@ func TestJwtFilter(t *testing.T) {
 									JwksSourceSpecifier: &envoy_jwt.JwtProvider_LocalJwks{
 										LocalJwks: &core.DataSource{
 											Specifier: &core.DataSource_InlineString{
-												InlineString: createFakeJwks("http://site.not.exist"),
+												InlineString: model.CreateFakeJwks("http://site.not.exist"),
 											},
 										},
 									},
@@ -684,6 +684,11 @@ func TestJwtFilter(t *testing.T) {
 	}
 
 	push := model.NewPushContext()
+	push.JwtKeyResolver = model.NewJwksResolver(
+		model.JwtPubKeyEvictionDuration, model.JwtPubKeyRefreshInterval,
+		model.JwtPubKeyRefreshIntervalOnFailure, model.JwtPubKeyRetryInterval)
+	defer push.JwtKeyResolver.Close()
+
 	push.ServiceIndex.HostnameAndNamespace[host.Name("jwt-token-issuer.mesh")] = map[string]*model.Service{}
 	push.ServiceIndex.HostnameAndNamespace[host.Name("jwt-token-issuer.mesh")]["mesh"] = &model.Service{
 		Hostname: host.Name("jwt-token-issuer.mesh.svc.cluster.local"),
@@ -929,7 +934,7 @@ func TestConvertToEnvoyJwtConfig(t *testing.T) {
 						JwksSourceSpecifier: &envoy_jwt.JwtProvider_LocalJwks{
 							LocalJwks: &core.DataSource{
 								Specifier: &core.DataSource_InlineString{
-									InlineString: createFakeJwks(""),
+									InlineString: model.CreateFakeJwks(""),
 								},
 							},
 						},
@@ -983,7 +988,7 @@ func TestConvertToEnvoyJwtConfig(t *testing.T) {
 						JwksSourceSpecifier: &envoy_jwt.JwtProvider_LocalJwks{
 							LocalJwks: &core.DataSource{
 								Specifier: &core.DataSource_InlineString{
-									InlineString: createFakeJwks("http://site.not.exist"),
+									InlineString: model.CreateFakeJwks("http://site.not.exist"),
 								},
 							},
 						},
@@ -995,9 +1000,15 @@ func TestConvertToEnvoyJwtConfig(t *testing.T) {
 		},
 	}
 
+	push := &model.PushContext{}
+	push.JwtKeyResolver = model.NewJwksResolver(
+		model.JwtPubKeyEvictionDuration, model.JwtPubKeyRefreshInterval,
+		model.JwtPubKeyRefreshIntervalOnFailure, model.JwtPubKeyRetryInterval)
+	defer push.JwtKeyResolver.Close()
+
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			if got := convertToEnvoyJwtConfig(c.in, &model.PushContext{}); !reflect.DeepEqual(c.expected, got) {
+			if got := convertToEnvoyJwtConfig(c.in, push); !reflect.DeepEqual(c.expected, got) {
 				t.Errorf("got:\n%s\nwanted:\n%s\n", spew.Sdump(got), spew.Sdump(c.expected))
 			}
 		})

--- a/pilot/pkg/xds/fake.go
+++ b/pilot/pkg/xds/fake.go
@@ -108,7 +108,8 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 	// Init with a dummy environment, since we have a circular dependency with the env creation.
 	s := NewDiscoveryServer(&model.Environment{PushContext: model.NewPushContext()}, []string{plugin.AuthzCustom, plugin.Authn, plugin.Authz}, "pilot-123")
 	t.Cleanup(func() {
-		s.Shutdown()
+		s.JwtKeyResolver.Close()
+		s.pushQueue.ShutDown()
 	})
 
 	serviceHandler := func(svc *model.Service, _ model.Event) {

--- a/tests/util/leak/check.go
+++ b/tests/util/leak/check.go
@@ -33,10 +33,7 @@ import (
 var goroutinesToIgnore = []string{
 	// "global" goroutines we always initialize. Maybe we shouldn't always initialize these, but for now every
 	// test fails with these
-	"k8s.io/klog/v2.(*loggingT).flushDaemon", // k8s logging
-	// constantly runs in the background. This can probably be scoped to DiscoveryServer, but isn't today
-	"(*JwksResolver).refresher",
-	"istio.io/pkg/cache.NewTTLWithCallback",       // part of JwksResolver
+	"k8s.io/klog/v2.(*loggingT).flushDaemon",      // k8s logging
 	"go.opencensus.io/stats/view.(*worker).start", // metrics runs on init. Maybe it should be in main()
 
 	// goroutines for test


### PR DESCRIPTION
Currently any test that uses any part of pilot leaks because of this.
Using coding best practices and making this not a global object.

Fixes https://github.com/istio/istio/issues/29349

Signed-off-by: Kailun Qin <kailun.qin@intel.com>



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[x] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any changes that may affect Istio users.