### PR TITLE
Multi inbound cluster route

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -77,7 +77,7 @@ var testMesh = meshconfig.MeshConfig{
 }
 
 func TestHTTPCircuitBreakerThresholds(t *testing.T) {
-	checkClusters := []string{"outbound|8080||*.example.org", "inbound|10001||"}
+	checkClusters := []string{"outbound|8080||*.example.org", "inbound|10001||*.example.org"}
 	settings := []*networking.ConnectionPoolSettings{
 		nil,
 		{
@@ -153,7 +153,7 @@ func TestCommonHttpProtocolOptions(t *testing.T) {
 			clusters:                  8,
 		},
 		{
-			clusterName:               "inbound|10001||",
+			clusterName:               "inbound|10001||*.example.org",
 			useDownStreamProtocol:     false,
 			sniffingEnabledForInbound: false,
 			proxyType:                 model.SidecarProxy,
@@ -167,7 +167,7 @@ func TestCommonHttpProtocolOptions(t *testing.T) {
 			clusters:                  8,
 		},
 		{
-			clusterName:               "inbound|10002||",
+			clusterName:               "inbound|10002||*.example.org",
 			useDownStreamProtocol:     true,
 			sniffingEnabledForInbound: true,
 			proxyType:                 model.SidecarProxy,
@@ -1089,7 +1089,7 @@ func TestStatNamePattern(t *testing.T) {
 		},
 	})
 	g.Expect(xdstest.ExtractCluster("outbound|8080||*.example.org", clusters).AltStatName).To(Equal("*.example.org_default_8080"))
-	g.Expect(xdstest.ExtractCluster("inbound|10001||", clusters).AltStatName).To(Equal("LocalService_*.example.org"))
+	g.Expect(xdstest.ExtractCluster("inbound|10001||*.example.org", clusters).AltStatName).To(Equal("LocalService_*.example.org"))
 }
 
 func TestDuplicateClusters(t *testing.T) {

--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -23,6 +23,7 @@ import (
 	"github.com/golang/protobuf/ptypes"
 
 	networking "istio.io/api/networking/v1alpha3"
+
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/core/v1alpha3/envoyfilter"
@@ -98,7 +99,8 @@ func (configgen *ConfigGeneratorImpl) buildSidecarInboundHTTPRouteConfig(
 		if clusterName != "" {
 			clusterNameForEachHost = clusterName
 		} else {
-			clusterNameForEachHost = model.BuildSubsetKey(model.TrafficDirectionInbound, instance.ServicePort.Name, hostname, instance.ServicePort.Port)
+			clusterNameForEachHost = util.BuildInboundSubsetKey(node, instance.ServicePort.Name,hostname,
+				instance.ServicePort.Port, int(instance.Endpoint.EndpointPort))
 		}
 
 		virtualHosts = append(virtualHosts, &route.VirtualHost{
@@ -111,7 +113,8 @@ func (configgen *ConfigGeneratorImpl) buildSidecarInboundHTTPRouteConfig(
 	}
 
 	if clusterName == "" {
-		clusterName = model.BuildSubsetKey(model.TrafficDirectionInbound, instance.ServicePort.Name, instance.Service.Hostname, instance.ServicePort.Port)
+		clusterName = util.BuildInboundSubsetKey(node, instance.ServicePort.Name, instance.Service.Hostname,
+			instance.ServicePort.Port, int(instance.Endpoint.EndpointPort))
 	}
 	virtualHosts = append(virtualHosts, &route.VirtualHost{
 		Name:    inboundVirtualHostPrefix + strconv.Itoa(instance.ServicePort.Port), // Format: "inbound|http|%d"

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -309,10 +309,11 @@ func (configgen *ConfigGeneratorImpl) buildSidecarInboundListeners(
 
 		portHostnameMap := make(map[int]map[host.Name]bool)
 		for _, instance := range node.ServiceInstances {
-			if _, exist := portHostnameMap[instance.ServicePort.Port]; !exist {
-				portHostnameMap[instance.ServicePort.Port] = make(map[host.Name]bool)
+			port := int(instance.Endpoint.EndpointPort)
+			if _, exist := portHostnameMap[port]; !exist {
+				portHostnameMap[port] = make(map[host.Name]bool)
 			}
-			portHostnameMap[instance.ServicePort.Port][instance.Service.Hostname] = true
+			portHostnameMap[port][instance.Service.Hostname] = true
 		}
 
 		for _, instance := range node.ServiceInstances {
@@ -348,15 +349,15 @@ func (configgen *ConfigGeneratorImpl) buildSidecarInboundListeners(
 				Push:             push,
 			}
 
-			if !portSet[instance.ServicePort.Port] {
-				hosts := make([]host.Name, 0, len(portHostnameMap[instance.ServicePort.Port]))
-				for h := range portHostnameMap[instance.ServicePort.Port] {
+			if !portSet[listenerOpts.port.Port] {
+				hosts := make([]host.Name, 0, len(portHostnameMap[listenerOpts.port.Port]))
+				for h := range portHostnameMap[listenerOpts.port.Port] {
 					hosts = append(hosts, h)
 				}
 				if l := configgen.buildSidecarInboundListenerForPortOrUDS(node, listenerOpts, pluginParams, hosts); l != nil {
 					listeners = append(listeners, l)
 				}
-				portSet[instance.ServicePort.Port] = true
+				portSet[listenerOpts.port.Port] = true
 			}
 		}
 		return listeners

--- a/pilot/pkg/networking/core/v1alpha3/listener_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_builder.go
@@ -21,12 +21,14 @@ import (
 	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	tcp "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
 	envoytype "github.com/envoyproxy/go-control-plane/envoy/type/v3"
-	wellknown "github.com/envoyproxy/go-control-plane/pkg/wellknown"
+	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	golangproto "github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/wrappers"
 
 	networking "istio.io/api/networking/v1alpha3"
+	"istio.io/pkg/log"
+
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	istionetworking "istio.io/istio/pilot/pkg/networking"
@@ -37,7 +39,6 @@ import (
 	xdsfilters "istio.io/istio/pilot/pkg/xds/filters"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/proto"
-	"istio.io/pkg/log"
 )
 
 var dummyServiceInstance = &model.ServiceInstance{
@@ -620,7 +621,7 @@ func buildInboundCatchAllHTTPFilterChains(configgen *ConfigGeneratorImpl, node *
 		}
 		// Construct the actual filter chains for each of the filter chain from the plugin.
 		for _, chain := range allChains {
-			httpOpts := configgen.buildSidecarInboundHTTPListenerOptsForPortOrUDS(node, in, clusterName)
+			httpOpts := configgen.buildSidecarInboundHTTPListenerOptsForPortOrUDS(node, in, clusterName, nil)
 			httpOpts.statPrefix = clusterName
 			connectionManager := buildHTTPConnectionManager(listenerOpts, httpOpts, chain.HTTP)
 

--- a/pilot/pkg/networking/core/v1alpha3/networkfilter_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/networkfilter_test.go
@@ -62,7 +62,7 @@ func TestInboundNetworkFilterStatPrefix(t *testing.T) {
 		{
 			"no pattern",
 			"",
-			"inbound|8888||",
+			"inbound|8888||v0.default.example.org",
 		},
 		{
 			"service only pattern",

--- a/pilot/pkg/networking/core/v1alpha3/peer_authentication_simulation_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/peer_authentication_simulation_test.go
@@ -221,7 +221,7 @@ spec:
 				{
 					Name:   "plaintext on port 8000",
 					Call:   mkCall(8000, simulation.Plaintext),
-					Result: simulation.Result{ClusterMatched: "inbound|8000||"},
+					Result: simulation.Result{ClusterMatched: "inbound|8000||foo.bar"},
 				},
 				{
 					Name: "mtls on port 8000",
@@ -283,7 +283,7 @@ spec:
 				{
 					Name:   "mtls on port 8000",
 					Call:   mkCall(8000, simulation.MTLS),
-					Result: simulation.Result{ClusterMatched: "inbound|8000||"},
+					Result: simulation.Result{ClusterMatched: "inbound|8000||foo.bar"},
 				},
 				{
 					Name:   "plaintext port 9000",
@@ -334,7 +334,7 @@ spec:
 				{
 					Name:   "plaintext on port 8000",
 					Call:   mkCall(8000, simulation.Plaintext),
-					Result: simulation.Result{ClusterMatched: "inbound|8000||"},
+					Result: simulation.Result{ClusterMatched: "inbound|8000||foo.bar"},
 				},
 				{
 					Name: "mtls on port 8000",
@@ -492,18 +492,18 @@ spec:
 				{
 					Name:   "tls on tls port",
 					Call:   mkCall(8080, simulation.MTLS),
-					Result: simulation.Result{ClusterMatched: "inbound|8080||"},
+					Result: simulation.Result{ClusterMatched: "inbound|8080||foo.bar"},
 				},
 				{
 					Name:   "plaintext on plaintext port",
 					Call:   mkCall(9090, simulation.Plaintext),
-					Result: simulation.Result{ClusterMatched: "inbound|9090||"},
+					Result: simulation.Result{ClusterMatched: "inbound|9090||foo.bar"},
 				},
 				{
 					Name: "tls on plaintext port",
 					Call: mkCall(9090, simulation.MTLS),
 					// TLS is fine here; we are not sniffing TLS at all so anything is allowed
-					Result: simulation.Result{ClusterMatched: "inbound|9090||"},
+					Result: simulation.Result{ClusterMatched: "inbound|9090||foo.bar"},
 				},
 			},
 		},
@@ -519,18 +519,18 @@ spec:
 				{
 					Name:   "tls on tls port",
 					Call:   mkCall(8080, simulation.MTLS),
-					Result: simulation.Result{ClusterMatched: "inbound|8080||"},
+					Result: simulation.Result{ClusterMatched: "inbound|8080||foo.bar"},
 				},
 				{
 					Name:   "plaintext on plaintext port",
 					Call:   mkCall(9090, simulation.Plaintext),
-					Result: simulation.Result{ClusterMatched: "inbound|9090||"},
+					Result: simulation.Result{ClusterMatched: "inbound|9090||foo.bar"},
 				},
 				{
 					Name: "tls on plaintext port",
 					Call: mkCall(9090, simulation.MTLS),
 					// TLS is fine here; we are not sniffing TLS at all so anything is allowed
-					Result: simulation.Result{ClusterMatched: "inbound|9090||"},
+					Result: simulation.Result{ClusterMatched: "inbound|9090||foo.bar"},
 				},
 			},
 		},
@@ -575,18 +575,18 @@ spec:
 				{
 					Name:   "tls on tls port",
 					Call:   mkCall(8080, simulation.MTLS),
-					Result: simulation.Result{ClusterMatched: "inbound|8080||"},
+					Result: simulation.Result{ClusterMatched: "inbound|8080||sidecar.default"},
 				},
 				{
 					Name:   "plaintext on plaintext port",
 					Call:   mkCall(9090, simulation.Plaintext),
-					Result: simulation.Result{ClusterMatched: "inbound|9090||"},
+					Result: simulation.Result{ClusterMatched: "inbound|9090||sidecar.default"},
 				},
 				{
 					Name: "tls on plaintext port",
 					Call: mkCall(9090, simulation.MTLS),
 					// TLS is fine here; we are not sniffing TLS at all so anything is allowed
-					Result: simulation.Result{ClusterMatched: "inbound|9090||"},
+					Result: simulation.Result{ClusterMatched: "inbound|9090||sidecar.default"},
 				},
 			},
 		},
@@ -602,7 +602,7 @@ spec:
 				{
 					Name:   "tls on tls port",
 					Call:   mkCall(8080, simulation.MTLS),
-					Result: simulation.Result{ClusterMatched: "inbound|8080||"},
+					Result: simulation.Result{ClusterMatched: "inbound|8080||foo.bar"},
 				},
 				// Despite being defined in the Service, we get no filter chain since its not in Sidecar
 				{

--- a/pilot/pkg/networking/core/v1alpha3/sidecar_simulation_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/sidecar_simulation_test.go
@@ -164,10 +164,10 @@ func TestInboundClusters(t *testing.T) {
 				"inbound|8083||" + string(serviceAlt.Hostname): {"127.0.0.1:8083"},
 			},
 			telemetry: map[string][]string{
-				"inbound|8080||" + string(service.Hostname):    {string(serviceAlt.Hostname), string(service.Hostname)},
-				"inbound|8081||" + string(service.Hostname):    {string(serviceAlt.Hostname), string(service.Hostname)},
-				"inbound|8082||" + string(serviceAlt.Hostname): {string(serviceAlt.Hostname), string(service.Hostname)},
-				"inbound|8083||" + string(serviceAlt.Hostname): {string(serviceAlt.Hostname), string(service.Hostname)},
+				"inbound|8080||" + string(service.Hostname):    {string(service.Hostname)},
+				"inbound|8081||" + string(service.Hostname):    {string(service.Hostname)},
+				"inbound|8082||" + string(serviceAlt.Hostname): {string(serviceAlt.Hostname)},
+				"inbound|8083||" + string(serviceAlt.Hostname): {string(serviceAlt.Hostname)},
 			},
 		},
 		{
@@ -185,10 +185,10 @@ func TestInboundClusters(t *testing.T) {
 				"inbound|8081||" + string(serviceAlt.Hostname): {"127.0.0.1:8081"},
 			},
 			telemetry: map[string][]string{
-				"inbound|8080||" + string(service.Hostname):    {string(serviceAlt.Hostname), string(service.Hostname)},
-				"inbound|8081||" + string(service.Hostname):    {string(serviceAlt.Hostname), string(service.Hostname)},
-				"inbound|8080||" + string(serviceAlt.Hostname): {string(serviceAlt.Hostname), string(service.Hostname)},
-				"inbound|8081||" + string(serviceAlt.Hostname): {string(serviceAlt.Hostname), string(service.Hostname)},
+				"inbound|8080||" + string(service.Hostname):    {string(service.Hostname)},
+				"inbound|8081||" + string(service.Hostname):    {string(service.Hostname)},
+				"inbound|8080||" + string(serviceAlt.Hostname): {string(serviceAlt.Hostname)},
+				"inbound|8081||" + string(serviceAlt.Hostname): {string(serviceAlt.Hostname)},
 			},
 		},
 		{
@@ -344,10 +344,10 @@ func TestInboundClusters(t *testing.T) {
 				"inbound|81||" + string(serviceAlt.Hostname): {"127.0.0.1:8083"},
 			},
 			telemetry: map[string][]string{
-				"inbound|80||" + string(service.Hostname):    {string(serviceAlt.Hostname), string(service.Hostname)},
-				"inbound|80||" + string(serviceAlt.Hostname): {string(serviceAlt.Hostname), string(service.Hostname)},
-				"inbound|81||" + string(service.Hostname):    {string(serviceAlt.Hostname), string(service.Hostname)},
-				"inbound|81||" + string(serviceAlt.Hostname): {string(serviceAlt.Hostname), string(service.Hostname)},
+				"inbound|80||" + string(service.Hostname):    {string(service.Hostname)},
+				"inbound|80||" + string(serviceAlt.Hostname): {string(serviceAlt.Hostname)},
+				"inbound|81||" + string(service.Hostname):    {string(service.Hostname)},
+				"inbound|81||" + string(serviceAlt.Hostname): {string(serviceAlt.Hostname)},
 			},
 		},
 		{
@@ -366,10 +366,10 @@ func TestInboundClusters(t *testing.T) {
 				"inbound|81||" + string(serviceAlt.Hostname): {"127.0.0.1:8081"},
 			},
 			telemetry: map[string][]string{
-				"inbound|80||" + string(service.Hostname):    {string(serviceAlt.Hostname), string(service.Hostname)},
-				"inbound|80||" + string(serviceAlt.Hostname): {string(serviceAlt.Hostname), string(service.Hostname)},
-				"inbound|81||" + string(service.Hostname):    {string(serviceAlt.Hostname), string(service.Hostname)},
-				"inbound|81||" + string(serviceAlt.Hostname): {string(serviceAlt.Hostname), string(service.Hostname)},
+				"inbound|80||" + string(service.Hostname):    {string(service.Hostname)},
+				"inbound|80||" + string(serviceAlt.Hostname): {string(serviceAlt.Hostname)},
+				"inbound|81||" + string(service.Hostname):    {string(service.Hostname)},
+				"inbound|81||" + string(serviceAlt.Hostname): {string(serviceAlt.Hostname)},
 			},
 		},
 		{

--- a/pilot/pkg/networking/core/v1alpha3/sidecar_simulation_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/sidecar_simulation_test.go
@@ -28,6 +28,7 @@ import (
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
+
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/core/v1alpha3"
 	"istio.io/istio/pilot/pkg/networking/util"
@@ -127,10 +128,10 @@ func TestInboundClusters(t *testing.T) {
 			services:  []*model.Service{service},
 			instances: makeInstances(proxy, service, 80, 8080),
 			clusters: map[string][]string{
-				"inbound|8080||": {"127.0.0.1:8080"},
+				"inbound|8080||" + string(service.Hostname): {"127.0.0.1:8080"},
 			},
 			telemetry: map[string][]string{
-				"inbound|8080||": {string(service.Hostname)},
+				"inbound|8080||" + string(service.Hostname): {string(service.Hostname)},
 			},
 		},
 		{
@@ -140,12 +141,12 @@ func TestInboundClusters(t *testing.T) {
 				makeInstances(proxy, service, 80, 8080),
 				makeInstances(proxy, service, 81, 8081)),
 			clusters: map[string][]string{
-				"inbound|8080||": {"127.0.0.1:8080"},
-				"inbound|8081||": {"127.0.0.1:8081"},
+				"inbound|8080||" + string(service.Hostname): {"127.0.0.1:8080"},
+				"inbound|8081||" + string(service.Hostname): {"127.0.0.1:8081"},
 			},
 			telemetry: map[string][]string{
-				"inbound|8080||": {string(service.Hostname)},
-				"inbound|8081||": {string(service.Hostname)},
+				"inbound|8080||" + string(service.Hostname): {string(service.Hostname)},
+				"inbound|8081||" + string(service.Hostname): {string(service.Hostname)},
 			},
 		},
 		{
@@ -157,16 +158,16 @@ func TestInboundClusters(t *testing.T) {
 				makeInstances(proxy, serviceAlt, 80, 8082),
 				makeInstances(proxy, serviceAlt, 81, 8083)),
 			clusters: map[string][]string{
-				"inbound|8080||": {"127.0.0.1:8080"},
-				"inbound|8081||": {"127.0.0.1:8081"},
-				"inbound|8082||": {"127.0.0.1:8082"},
-				"inbound|8083||": {"127.0.0.1:8083"},
+				"inbound|8080||" + string(service.Hostname):    {"127.0.0.1:8080"},
+				"inbound|8081||" + string(service.Hostname):    {"127.0.0.1:8081"},
+				"inbound|8082||" + string(serviceAlt.Hostname): {"127.0.0.1:8082"},
+				"inbound|8083||" + string(serviceAlt.Hostname): {"127.0.0.1:8083"},
 			},
 			telemetry: map[string][]string{
-				"inbound|8080||": {string(service.Hostname)},
-				"inbound|8081||": {string(service.Hostname)},
-				"inbound|8082||": {string(serviceAlt.Hostname)},
-				"inbound|8083||": {string(serviceAlt.Hostname)},
+				"inbound|8080||" + string(service.Hostname):    {string(serviceAlt.Hostname), string(service.Hostname)},
+				"inbound|8081||" + string(service.Hostname):    {string(serviceAlt.Hostname), string(service.Hostname)},
+				"inbound|8082||" + string(serviceAlt.Hostname): {string(serviceAlt.Hostname), string(service.Hostname)},
+				"inbound|8083||" + string(serviceAlt.Hostname): {string(serviceAlt.Hostname), string(service.Hostname)},
 			},
 		},
 		{
@@ -178,12 +179,16 @@ func TestInboundClusters(t *testing.T) {
 				makeInstances(proxy, serviceAlt, 80, 8080),
 				makeInstances(proxy, serviceAlt, 81, 8081)),
 			clusters: map[string][]string{
-				"inbound|8080||": {"127.0.0.1:8080"},
-				"inbound|8081||": {"127.0.0.1:8081"},
+				"inbound|8080||" + string(service.Hostname):    {"127.0.0.1:8080"},
+				"inbound|8080||" + string(serviceAlt.Hostname): {"127.0.0.1:8080"},
+				"inbound|8081||" + string(service.Hostname):    {"127.0.0.1:8081"},
+				"inbound|8081||" + string(serviceAlt.Hostname): {"127.0.0.1:8081"},
 			},
 			telemetry: map[string][]string{
-				"inbound|8080||": {string(serviceAlt.Hostname), string(service.Hostname)},
-				"inbound|8081||": {string(serviceAlt.Hostname), string(service.Hostname)},
+				"inbound|8080||" + string(service.Hostname):    {string(serviceAlt.Hostname), string(service.Hostname)},
+				"inbound|8081||" + string(service.Hostname):    {string(serviceAlt.Hostname), string(service.Hostname)},
+				"inbound|8080||" + string(serviceAlt.Hostname): {string(serviceAlt.Hostname), string(service.Hostname)},
+				"inbound|8081||" + string(serviceAlt.Hostname): {string(serviceAlt.Hostname), string(service.Hostname)},
 			},
 		},
 		{
@@ -202,7 +207,7 @@ func TestInboundClusters(t *testing.T) {
 				},
 			},
 			clusters: map[string][]string{
-				"inbound|80||": {"127.0.0.1:80"},
+				"inbound|80||sidecar.default": {"127.0.0.1:80"},
 			},
 		},
 		{
@@ -221,7 +226,7 @@ func TestInboundClusters(t *testing.T) {
 				},
 			},
 			clusters: map[string][]string{
-				"inbound|80||": {"127.0.0.1:8080"},
+				"inbound|80||sidecar.default": {"127.0.0.1:8080"},
 			},
 		},
 		{
@@ -240,7 +245,7 @@ func TestInboundClusters(t *testing.T) {
 				},
 			},
 			clusters: map[string][]string{
-				"inbound|80||": {"1.2.3.4:8080"},
+				"inbound|80||sidecar.default": {"1.2.3.4:8080"},
 			},
 		},
 		{
@@ -259,7 +264,7 @@ func TestInboundClusters(t *testing.T) {
 				},
 			},
 			clusters: map[string][]string{
-				"inbound|80||": {"/socket"},
+				"inbound|80||sidecar.default": {"/socket"},
 			},
 		},
 		{
@@ -288,8 +293,8 @@ func TestInboundClusters(t *testing.T) {
 				},
 			},
 			clusters: map[string][]string{
-				"inbound|80||": {"127.0.0.1:8080"},
-				"inbound|81||": {"127.0.0.1:8080"},
+				"inbound|80||sidecar.default": {"127.0.0.1:8080"},
+				"inbound|81||sidecar.default": {"127.0.0.1:8080"},
 			},
 		},
 
@@ -300,10 +305,10 @@ func TestInboundClusters(t *testing.T) {
 			services:  []*model.Service{service},
 			instances: makeInstances(proxy180, service, 80, 8080),
 			clusters: map[string][]string{
-				"inbound|80||": {"127.0.0.1:8080"},
+				"inbound|80||" + string(service.Hostname): {"127.0.0.1:8080"},
 			},
 			telemetry: map[string][]string{
-				"inbound|80||": {string(service.Hostname)},
+				"inbound|80||" + string(service.Hostname): {string(service.Hostname)},
 			},
 		},
 		{
@@ -314,12 +319,12 @@ func TestInboundClusters(t *testing.T) {
 				makeInstances(proxy180, service, 80, 8080),
 				makeInstances(proxy180, service, 81, 8081)),
 			clusters: map[string][]string{
-				"inbound|80||": {"127.0.0.1:8080"},
-				"inbound|81||": {"127.0.0.1:8081"},
+				"inbound|80||" + string(service.Hostname): {"127.0.0.1:8080"},
+				"inbound|81||" + string(service.Hostname): {"127.0.0.1:8081"},
 			},
 			telemetry: map[string][]string{
-				"inbound|80||": {string(service.Hostname)},
-				"inbound|81||": {string(service.Hostname)},
+				"inbound|80||" + string(service.Hostname): {string(service.Hostname)},
+				"inbound|81||" + string(service.Hostname): {string(service.Hostname)},
 			},
 		},
 		{
@@ -333,12 +338,16 @@ func TestInboundClusters(t *testing.T) {
 				makeInstances(proxy180, serviceAlt, 81, 8083)),
 			clusters: map[string][]string{
 				// BUG: we are missing 8080 and 8081. This is fixed for 1.8.1+
-				"inbound|80||": {"127.0.0.1:8082"},
-				"inbound|81||": {"127.0.0.1:8083"},
+				"inbound|80||" + string(service.Hostname):    {"127.0.0.1:8080"},
+				"inbound|81||" + string(service.Hostname):    {"127.0.0.1:8081"},
+				"inbound|80||" + string(serviceAlt.Hostname): {"127.0.0.1:8082"},
+				"inbound|81||" + string(serviceAlt.Hostname): {"127.0.0.1:8083"},
 			},
 			telemetry: map[string][]string{
-				"inbound|80||": {string(serviceAlt.Hostname), string(service.Hostname)},
-				"inbound|81||": {string(serviceAlt.Hostname), string(service.Hostname)},
+				"inbound|80||" + string(service.Hostname):    {string(serviceAlt.Hostname), string(service.Hostname)},
+				"inbound|80||" + string(serviceAlt.Hostname): {string(serviceAlt.Hostname), string(service.Hostname)},
+				"inbound|81||" + string(service.Hostname):    {string(serviceAlt.Hostname), string(service.Hostname)},
+				"inbound|81||" + string(serviceAlt.Hostname): {string(serviceAlt.Hostname), string(service.Hostname)},
 			},
 		},
 		{
@@ -351,12 +360,16 @@ func TestInboundClusters(t *testing.T) {
 				makeInstances(proxy180, serviceAlt, 80, 8080),
 				makeInstances(proxy180, serviceAlt, 81, 8081)),
 			clusters: map[string][]string{
-				"inbound|80||": {"127.0.0.1:8080"},
-				"inbound|81||": {"127.0.0.1:8081"},
+				"inbound|80||" + string(service.Hostname):    {"127.0.0.1:8080"},
+				"inbound|80||" + string(serviceAlt.Hostname): {"127.0.0.1:8080"},
+				"inbound|81||" + string(service.Hostname):    {"127.0.0.1:8081"},
+				"inbound|81||" + string(serviceAlt.Hostname): {"127.0.0.1:8081"},
 			},
 			telemetry: map[string][]string{
-				"inbound|80||": {string(serviceAlt.Hostname), string(service.Hostname)},
-				"inbound|81||": {string(serviceAlt.Hostname), string(service.Hostname)},
+				"inbound|80||" + string(service.Hostname):    {string(serviceAlt.Hostname), string(service.Hostname)},
+				"inbound|80||" + string(serviceAlt.Hostname): {string(serviceAlt.Hostname), string(service.Hostname)},
+				"inbound|81||" + string(service.Hostname):    {string(serviceAlt.Hostname), string(service.Hostname)},
+				"inbound|81||" + string(serviceAlt.Hostname): {string(serviceAlt.Hostname), string(service.Hostname)},
 			},
 		},
 		{
@@ -376,7 +389,7 @@ func TestInboundClusters(t *testing.T) {
 				},
 			},
 			clusters: map[string][]string{
-				"inbound|80||": {"127.0.0.1:80"},
+				"inbound|80||sidecar.default": {"127.0.0.1:80"},
 			},
 		},
 		{
@@ -396,7 +409,7 @@ func TestInboundClusters(t *testing.T) {
 				},
 			},
 			clusters: map[string][]string{
-				"inbound|80||": {"127.0.0.1:8080"},
+				"inbound|80||sidecar.default": {"127.0.0.1:8080"},
 			},
 		},
 		{
@@ -416,7 +429,7 @@ func TestInboundClusters(t *testing.T) {
 				},
 			},
 			clusters: map[string][]string{
-				"inbound|80||": {"1.2.3.4:8080"},
+				"inbound|80||sidecar.default": {"1.2.3.4:8080"},
 			},
 		},
 		{
@@ -436,7 +449,7 @@ func TestInboundClusters(t *testing.T) {
 				},
 			},
 			clusters: map[string][]string{
-				"inbound|80||": {"/socket"},
+				"inbound|80||sidecar.default": {"/socket"},
 			},
 		},
 		{
@@ -466,8 +479,8 @@ func TestInboundClusters(t *testing.T) {
 				},
 			},
 			clusters: map[string][]string{
-				"inbound|80||": {"127.0.0.1:8080"},
-				"inbound|81||": {"127.0.0.1:8080"},
+				"inbound|80||sidecar.default": {"127.0.0.1:8080"},
+				"inbound|81||sidecar.default": {"127.0.0.1:8080"},
 			},
 		},
 	}
@@ -530,6 +543,7 @@ func TestInboundClusters(t *testing.T) {
 					Protocol: simulation.HTTP,
 					Address:  "1.2.3.4",
 					CallMode: simulation.CallModeInbound,
+					Headers:  map[string][]string{"Host": {string(hostname)}},
 				}).Matches(t, simulation.Result{
 					ClusterMatched: cname,
 				})
@@ -616,10 +630,10 @@ spec:
 				CallMode: simulation.CallModeInbound,
 			},
 			Disabled: simulation.Result{
-				ClusterMatched: "inbound|70||",
+				ClusterMatched: "inbound|70||foo.bar",
 			},
 			Permissive: simulation.Result{
-				ClusterMatched: "inbound|70||",
+				ClusterMatched: "inbound|70||foo.bar",
 			},
 			Strict: simulation.Result{
 				// Plaintext to strict, should fail
@@ -634,10 +648,10 @@ spec:
 				CallMode: simulation.CallModeInbound,
 			},
 			Disabled: simulation.Result{
-				ClusterMatched: "inbound|70||",
+				ClusterMatched: "inbound|70||foo.bar",
 			},
 			Permissive: simulation.Result{
-				ClusterMatched: "inbound|70||",
+				ClusterMatched: "inbound|70||foo.bar",
 			},
 			Strict: simulation.Result{
 				// Plaintext to strict, should fail
@@ -653,10 +667,10 @@ spec:
 				CallMode: simulation.CallModeInbound,
 			},
 			Disabled: simulation.Result{
-				ClusterMatched: "inbound|70||",
+				ClusterMatched: "inbound|70||foo.bar",
 			},
 			Permissive: simulation.Result{
-				ClusterMatched: "inbound|70||",
+				ClusterMatched: "inbound|70||foo.bar",
 			},
 			Strict: simulation.Result{
 				// TLS, but not mTLS
@@ -672,10 +686,10 @@ spec:
 				CallMode: simulation.CallModeInbound,
 			},
 			Disabled: simulation.Result{
-				ClusterMatched: "inbound|70||",
+				ClusterMatched: "inbound|70||foo.bar",
 			},
 			Permissive: simulation.Result{
-				ClusterMatched: "inbound|70||",
+				ClusterMatched: "inbound|70||foo.bar",
 			},
 			Strict: simulation.Result{
 				// TLS, but not mTLS
@@ -693,13 +707,13 @@ spec:
 			Disabled: simulation.Result{
 				// This is probably a user error, but there is no reason we should block mTLS traffic
 				// we just will not terminate it
-				ClusterMatched: "inbound|70||",
+				ClusterMatched: "inbound|70||foo.bar",
 			},
 			Permissive: simulation.Result{
-				ClusterMatched: "inbound|70||",
+				ClusterMatched: "inbound|70||foo.bar",
 			},
 			Strict: simulation.Result{
-				ClusterMatched: "inbound|70||",
+				ClusterMatched: "inbound|70||foo.bar",
 			},
 		},
 		{
@@ -713,13 +727,13 @@ spec:
 			Disabled: simulation.Result{
 				// This is probably a user error, but there is no reason we should block mTLS traffic
 				// we just will not terminate it
-				ClusterMatched: "inbound|70||",
+				ClusterMatched: "inbound|70||foo.bar",
 			},
 			Permissive: simulation.Result{
-				ClusterMatched: "inbound|70||",
+				ClusterMatched: "inbound|70||foo.bar",
 			},
 			Strict: simulation.Result{
-				ClusterMatched: "inbound|70||",
+				ClusterMatched: "inbound|70||foo.bar",
 			},
 		},
 		{
@@ -731,11 +745,11 @@ spec:
 			},
 			Disabled: simulation.Result{
 				VirtualHostMatched: "inbound|http|80",
-				ClusterMatched:     "inbound|80||",
+				ClusterMatched:     "inbound|80||foo.bar",
 			},
 			Permissive: simulation.Result{
 				VirtualHostMatched: "inbound|http|80",
-				ClusterMatched:     "inbound|80||",
+				ClusterMatched:     "inbound|80||foo.bar",
 			},
 			Strict: simulation.Result{
 				// Plaintext to strict, should fail
@@ -802,11 +816,11 @@ spec:
 			},
 			Permissive: simulation.Result{
 				VirtualHostMatched: "inbound|http|80",
-				ClusterMatched:     "inbound|80||",
+				ClusterMatched:     "inbound|80||foo.bar",
 			},
 			Strict: simulation.Result{
 				VirtualHostMatched: "inbound|http|80",
-				ClusterMatched:     "inbound|80||",
+				ClusterMatched:     "inbound|80||foo.bar",
 			},
 		},
 		{
@@ -838,11 +852,11 @@ spec:
 			},
 			Disabled: simulation.Result{
 				VirtualHostMatched: "inbound|http|81",
-				ClusterMatched:     "inbound|81||",
+				ClusterMatched:     "inbound|81||foo.bar",
 			},
 			Permissive: simulation.Result{
 				VirtualHostMatched: "inbound|http|81",
-				ClusterMatched:     "inbound|81||",
+				ClusterMatched:     "inbound|81||foo.bar",
 			},
 			Strict: simulation.Result{
 				// Plaintext to strict fails
@@ -858,11 +872,11 @@ spec:
 			},
 			Disabled: simulation.Result{
 				VirtualHostMatched: "inbound|http|81",
-				ClusterMatched:     "inbound|81||",
+				ClusterMatched:     "inbound|81||foo.bar",
 			},
 			Permissive: simulation.Result{
 				VirtualHostMatched: "inbound|http|81",
-				ClusterMatched:     "inbound|81||",
+				ClusterMatched:     "inbound|81||foo.bar",
 			},
 			Strict: simulation.Result{
 				// Plaintext to strict fails
@@ -879,13 +893,13 @@ spec:
 			Disabled: simulation.Result{
 				ListenerMatched:    "virtualInbound",
 				FilterChainMatched: "0.0.0.0_81",
-				ClusterMatched:     "inbound|81||",
+				ClusterMatched:     "inbound|81||foo.bar",
 				StrictMatch:        true,
 			},
 			Permissive: simulation.Result{
 				ListenerMatched:    "virtualInbound",
 				FilterChainMatched: "0.0.0.0_81",
-				ClusterMatched:     "inbound|81||",
+				ClusterMatched:     "inbound|81||foo.bar",
 				StrictMatch:        true,
 			},
 			Strict: simulation.Result{
@@ -905,14 +919,14 @@ spec:
 				// Should go through the TCP chains
 				ListenerMatched:    "virtualInbound",
 				FilterChainMatched: "0.0.0.0_81",
-				ClusterMatched:     "inbound|81||",
+				ClusterMatched:     "inbound|81||foo.bar",
 				StrictMatch:        true,
 			},
 			Permissive: simulation.Result{
 				// Should go through the TCP chains
 				ListenerMatched:    "virtualInbound",
 				FilterChainMatched: "0.0.0.0_81",
-				ClusterMatched:     "inbound|81||",
+				ClusterMatched:     "inbound|81||foo.bar",
 				StrictMatch:        true,
 			},
 			Strict: simulation.Result{
@@ -932,14 +946,14 @@ spec:
 				// Should go through the TCP chains
 				ListenerMatched:    "virtualInbound",
 				FilterChainMatched: "0.0.0.0_81",
-				ClusterMatched:     "inbound|81||",
+				ClusterMatched:     "inbound|81||foo.bar",
 				StrictMatch:        true,
 			},
 			Permissive: simulation.Result{
 				// Should go through the TCP chains
 				ListenerMatched:    "virtualInbound",
 				FilterChainMatched: "0.0.0.0_81",
-				ClusterMatched:     "inbound|81||",
+				ClusterMatched:     "inbound|81||foo.bar",
 				StrictMatch:        true,
 			},
 			Strict: simulation.Result{
@@ -958,20 +972,20 @@ spec:
 			Disabled: simulation.Result{
 				// This is probably a user error, but there is no reason we should block mTLS traffic
 				// we just will not terminate it
-				ClusterMatched: "inbound|81||",
+				ClusterMatched: "inbound|81||foo.bar",
 			},
 			Permissive: simulation.Result{
 				// Should go through the TCP chains
 				ListenerMatched:    "virtualInbound",
 				FilterChainMatched: "0.0.0.0_81",
-				ClusterMatched:     "inbound|81||",
+				ClusterMatched:     "inbound|81||foo.bar",
 				StrictMatch:        true,
 			},
 			Strict: simulation.Result{
 				// Should go through the TCP chains
 				ListenerMatched:    "virtualInbound",
 				FilterChainMatched: "0.0.0.0_81",
-				ClusterMatched:     "inbound|81||",
+				ClusterMatched:     "inbound|81||foo.bar",
 				StrictMatch:        true,
 			},
 		},
@@ -986,17 +1000,17 @@ spec:
 			Disabled: simulation.Result{
 				// This is probably a user error, but there is no reason we should block mTLS traffic
 				// we just will not terminate it
-				ClusterMatched: "inbound|81||",
+				ClusterMatched: "inbound|81||foo.bar",
 			},
 			Permissive: simulation.Result{
 				// Should go through the HTTP chains
 				VirtualHostMatched: "inbound|http|81",
-				ClusterMatched:     "inbound|81||",
+				ClusterMatched:     "inbound|81||foo.bar",
 			},
 			Strict: simulation.Result{
 				// Should go through the HTTP chains
 				VirtualHostMatched: "inbound|http|81",
-				ClusterMatched:     "inbound|81||",
+				ClusterMatched:     "inbound|81||foo.bar",
 			},
 		},
 		{

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -291,11 +291,11 @@ func IsIstioVersionGE181(node *model.Proxy) bool {
 func BuildInboundSubsetKey(node *model.Proxy, subsetName string, hostname host.Name, servicePort int, endpointPort int) string {
 	if IsIstioVersionGE181(node) {
 		// On 1.8.1+ Proxies, we use format inbound|endpointPort||. Telemetry no longer requires the hostname
-		return model.BuildSubsetKey(model.TrafficDirectionInbound, "", "", endpointPort)
+		return model.BuildSubsetKey(model.TrafficDirectionInbound, "", hostname, endpointPort)
 	} else if IsIstioVersionGE18(node) {
 		// On 1.8.0 Proxies, we used format inbound|servicePort||. Since changing a cluster name leads to a 503
 		// blip on upgrade, we will support this legacy format.
-		return model.BuildSubsetKey(model.TrafficDirectionInbound, "", "", servicePort)
+		return model.BuildSubsetKey(model.TrafficDirectionInbound, "", hostname, servicePort)
 	}
 	return model.BuildSubsetKey(model.TrafficDirectionInbound, subsetName, hostname, servicePort)
 }


### PR DESCRIPTION
Implement of #30951

[x] Networking

Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any changes that may affect Istio users.


Based on the example in issue, the envoy clusters and configs looks like this:

```
inbound|80||nginx.default.svc.cluster.local::default_priority::max_connections::4294967295
inbound|80||nginx.default.svc.cluster.local::default_priority::max_pending_requests::4294967295
inbound|80||nginx.default.svc.cluster.local::default_priority::max_requests::4294967295
inbound|80||nginx.default.svc.cluster.local::default_priority::max_retries::4294967295
inbound|80||nginx.default.svc.cluster.local::high_priority::max_connections::1024
inbound|80||nginx.default.svc.cluster.local::high_priority::max_pending_requests::1024
inbound|80||nginx.default.svc.cluster.local::high_priority::max_requests::1024
inbound|80||nginx.default.svc.cluster.local::high_priority::max_retries::3
inbound|80||nginx.default.svc.cluster.local::added_via_api::true
inbound|80||nginx.default.svc.cluster.local::127.0.0.1:80::cx_active::0
inbound|80||nginx.default.svc.cluster.local::127.0.0.1:80::cx_connect_fail::0
inbound|80||nginx.default.svc.cluster.local::127.0.0.1:80::cx_total::3
inbound|80||nginx.default.svc.cluster.local::127.0.0.1:80::rq_active::0
inbound|80||nginx.default.svc.cluster.local::127.0.0.1:80::rq_error::0
inbound|80||nginx.default.svc.cluster.local::127.0.0.1:80::rq_success::4
inbound|80||nginx.default.svc.cluster.local::127.0.0.1:80::rq_timeout::0
inbound|80||nginx.default.svc.cluster.local::127.0.0.1:80::rq_total::4
inbound|80||nginx.default.svc.cluster.local::127.0.0.1:80::hostname::
inbound|80||nginx.default.svc.cluster.local::127.0.0.1:80::health_flags::healthy
inbound|80||nginx.default.svc.cluster.local::127.0.0.1:80::weight::1
inbound|80||nginx.default.svc.cluster.local::127.0.0.1:80::region::
inbound|80||nginx.default.svc.cluster.local::127.0.0.1:80::zone::
inbound|80||nginx.default.svc.cluster.local::127.0.0.1:80::sub_zone::
inbound|80||nginx.default.svc.cluster.local::127.0.0.1:80::canary::false
inbound|80||nginx.default.svc.cluster.local::127.0.0.1:80::priority::0
inbound|80||nginx.default.svc.cluster.local::127.0.0.1:80::success_rate::-1.0
inbound|80||nginx.default.svc.cluster.local::127.0.0.1:80::local_origin_success_rate::-1.0
inbound|80||nginx2.default.svc.cluster.local::default_priority::max_connections::4294967295
inbound|80||nginx2.default.svc.cluster.local::default_priority::max_pending_requests::4294967295
inbound|80||nginx2.default.svc.cluster.local::default_priority::max_requests::4294967295
inbound|80||nginx2.default.svc.cluster.local::default_priority::max_retries::4294967295
inbound|80||nginx2.default.svc.cluster.local::high_priority::max_connections::1024
inbound|80||nginx2.default.svc.cluster.local::high_priority::max_pending_requests::1024
inbound|80||nginx2.default.svc.cluster.local::high_priority::max_requests::1024
inbound|80||nginx2.default.svc.cluster.local::high_priority::max_retries::3
inbound|80||nginx2.default.svc.cluster.local::added_via_api::true
inbound|80||nginx2.default.svc.cluster.local::127.0.0.1:80::cx_active::0
inbound|80||nginx2.default.svc.cluster.local::127.0.0.1:80::cx_connect_fail::0
inbound|80||nginx2.default.svc.cluster.local::127.0.0.1:80::cx_total::3
inbound|80||nginx2.default.svc.cluster.local::127.0.0.1:80::rq_active::0
inbound|80||nginx2.default.svc.cluster.local::127.0.0.1:80::rq_error::0
inbound|80||nginx2.default.svc.cluster.local::127.0.0.1:80::rq_success::4
inbound|80||nginx2.default.svc.cluster.local::127.0.0.1:80::rq_timeout::0
inbound|80||nginx2.default.svc.cluster.local::127.0.0.1:80::rq_total::4
inbound|80||nginx2.default.svc.cluster.local::127.0.0.1:80::hostname::
inbound|80||nginx2.default.svc.cluster.local::127.0.0.1:80::health_flags::healthy
inbound|80||nginx2.default.svc.cluster.local::127.0.0.1:80::weight::1
inbound|80||nginx2.default.svc.cluster.local::127.0.0.1:80::region::
inbound|80||nginx2.default.svc.cluster.local::127.0.0.1:80::zone::
inbound|80||nginx2.default.svc.cluster.local::127.0.0.1:80::sub_zone::
inbound|80||nginx2.default.svc.cluster.local::127.0.0.1:80::canary::false
inbound|80||nginx2.default.svc.cluster.local::127.0.0.1:80::priority::0
inbound|80||nginx2.default.svc.cluster.local::127.0.0.1:80::success_rate::-1.0
inbound|80||nginx2.default.svc.cluster.local::127.0.0.1:80::local_origin_success_rate::-1.0
```

```json
{
    "virtual_hosts": [
        {
            "name": "inbound|http|nginx.default.svc.cluster.local|80",
            "domains": [
                "nginx.default.svc.cluster.local",
                "nginx.default.svc.cluster.local:80",
                "nginx",
                "nginx:80",
                "nginx.default.svc",
                "nginx.default.svc:80",
                "nginx.default",
                "nginx.default:80"
            ],
            "routes": [
                {
                    "match": {
                        "prefix": "/"
                    },
                    "route": {
                        "cluster": "inbound|80||nginx.default.svc.cluster.local",
                        "timeout": "0s",
                        "max_stream_duration": {
                            "max_stream_duration": "0s"
                        }
                    },
                    "decorator": {
                        "operation": "nginx.default.svc.cluster.local:80/*"
                    },
                    "name": "default"
                }
            ]
        },
        {
            "name": "inbound|http|nginx2.default.svc.cluster.local|80",
            "domains": [
                "nginx2.default.svc.cluster.local",
                "nginx2.default.svc.cluster.local:80",
                "nginx2",
                "nginx2:80",
                "nginx2.default.svc",
                "nginx2.default.svc:80",
                "nginx2.default",
                "nginx2.default:80"
            ],
            "routes": [
                {
                    "match": {
                        "prefix": "/"
                    },
                    "route": {
                        "cluster": "inbound|80||nginx2.default.svc.cluster.local",
                        "timeout": "0s",
                        "max_stream_duration": {
                            "max_stream_duration": "0s"
                        }
                    },
                    "decorator": {
                        "operation": "nginx2.default.svc.cluster.local:80/*"
                    },
                    "name": "default"
                }
            ]
        },
        {
            "name": "inbound|http|80",
            "domains": [
                "*"
            ],
            "routes": [
                {
                    "match": {
                        "prefix": "/"
                    },
                    "route": {
                        "cluster": "inbound|80||nginx.default.svc.cluster.local",
                        "timeout": "0s",
                        "max_stream_duration": {
                            "max_stream_duration": "0s"
                        }
                    },
                    "decorator": {
                        "operation": "nginx.default.svc.cluster.local:80/*"
                    },
                    "name": "default"
                }
            ]
        }
    ]
}
```


after query with different service name, the final stats will be like this:

```
cluster.inbound|80||nginx.default.svc.cluster.local.upstream_rq_total: 4
cluster.inbound|80||nginx2.default.svc.cluster.local.upstream_rq_total: 4
```