### PR TITLE
Support regex matching of HTTP headers in AuthorizationPolicy

### DIFF
--- a/pilot/pkg/security/authz/builder/testdata/all-fields-in.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/all-fields-in.yaml
@@ -35,6 +35,8 @@ spec:
         - key: "request.headers[X-header]"
           values: ["header", "header-prefix-*", "*-suffix-header", "*"]
           notValues: ["not-header", "not-header-prefix-*", "*-not-suffix-header", "*"]
+        - key: "request.regex.headers[X-header-regex]"
+          values: ["some.*value"]
         - key: "source.ip"
           values: ["10.10.10.10", "192.168.10.0/24"]
           notValues: ["90.10.10.10", "90.168.10.0/24"]

--- a/pilot/pkg/security/authz/builder/testdata/all-fields-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/all-fields-out.yaml
@@ -498,6 +498,13 @@ typedConfig:
                       presentMatch: true
             - orIds:
                 ids:
+                - header:
+                    name: X-header-regex
+                    safeRegexMatch:
+                      googleRe2: {}
+                      regex: some.*value
+            - orIds:
+                ids:
                 - directRemoteIp:
                     addressPrefix: 10.10.10.10
                     prefixLen: 32

--- a/pilot/pkg/security/authz/matcher/header.go
+++ b/pilot/pkg/security/authz/matcher/header.go
@@ -63,3 +63,16 @@ func PathMatcher(path string) *matcherpb.PathMatcher {
 		},
 	}
 }
+
+// HeaderMatcherRegex converts a key, value string pair to a corresponding SafeRegex HeaderMatcher.
+func HeaderMatcherRegex(k, v string) *routepb.HeaderMatcher {
+	return &routepb.HeaderMatcher{
+		Name: k,
+		HeaderMatchSpecifier: &routepb.HeaderMatcher_SafeRegexMatch{
+			SafeRegexMatch: &matcherpb.RegexMatcher{
+				EngineType: &matcherpb.RegexMatcher_GoogleRe2{GoogleRe2: &matcherpb.RegexMatcher_GoogleRE2{}},
+				Regex:      v,
+			},
+		},
+	}
+}

--- a/pilot/pkg/security/authz/model/generator.go
+++ b/pilot/pkg/security/authz/model/generator.go
@@ -204,6 +204,25 @@ func (requestHeaderGenerator) principal(key, value string, forTCP bool) (*rbacpb
 	return principalHeader(m), nil
 }
 
+type requestRegexHeaderGenerator struct{}
+
+func (requestRegexHeaderGenerator) permission(_, _ string, _ bool) (*rbacpb.Permission, error) {
+	return nil, fmt.Errorf("unimplemented")
+}
+
+func (requestRegexHeaderGenerator) principal(key, value string, forTCP bool) (*rbacpb.Principal, error) {
+	if forTCP {
+		return nil, fmt.Errorf("%q is HTTP only", key)
+	}
+
+	header, err := extractNameInBrackets(strings.TrimPrefix(key, attrRequestRegexHeader))
+	if err != nil {
+		return nil, err
+	}
+	m := matcher.HeaderMatcherRegex(header, value)
+	return principalHeader(m), nil
+}
+
 type requestClaimGenerator struct{}
 
 func (requestClaimGenerator) permission(_, _ string, _ bool) (*rbacpb.Permission, error) {

--- a/pilot/pkg/security/authz/model/generator_test.go
+++ b/pilot/pkg/security/authz/model/generator_test.go
@@ -211,6 +211,18 @@ func TestGenerator(t *testing.T) {
           name: x-foo`),
 		},
 		{
+			name:  "requestRegexHeaderGenerator",
+			g:     requestRegexHeaderGenerator{},
+			key:   "request.regex.headers[x-foo]",
+			value: "foo-[0-9]",
+			want: yamlPrincipal(t, `
+         header:
+          name: x-foo
+          safeRegexMatch:
+            googleRe2: {}
+            regex: foo-[0-9]`),
+		},
+		{
 			name:  "requestClaimGenerator",
 			g:     requestClaimGenerator{},
 			key:   "request.auth.claims[bar]",
@@ -281,12 +293,12 @@ func TestGenerator(t *testing.T) {
 			if _, ok := tc.want.(*rbacpb.Permission); ok {
 				got, err = tc.g.permission(tc.key, tc.value, tc.forTCP)
 				if err != nil {
-					t.Errorf("both permission and principal returned error")
+					t.Errorf("both permission and principal returned error: %v", err)
 				}
 			} else {
 				got, err = tc.g.principal(tc.key, tc.value, tc.forTCP)
 				if err != nil {
-					t.Errorf("both permission and principal returned error")
+					t.Errorf("both permission and principal returned error: %v", err)
 				}
 			}
 			if diff := cmp.Diff(got, tc.want, protocmp.Transform()); diff != "" {

--- a/pilot/pkg/security/authz/model/model.go
+++ b/pilot/pkg/security/authz/model/model.go
@@ -46,6 +46,8 @@ const (
 	attrConnSNI          = "connection.sni"              // server name indication, e.g. "www.example.com".
 	attrEnvoyFilter      = "experimental.envoy.filters." // an experimental attribute for checking Envoy Metadata directly.
 
+	attrRequestRegexHeader = "request.regex.headers" // header name is surrounded by brackets, e.g. "request.regex.headers[User-Agent]".
+
 	// Internal names used to generate corresponding Envoy matcher.
 	methodHeader = ":method"
 	pathMatcher  = "path-matcher"
@@ -105,6 +107,8 @@ func New(r *authzpb.Rule) (*Model, error) {
 			basePrincipal.appendLast(requestPresenterGenerator{}, k, when.Values, when.NotValues)
 		case strings.HasPrefix(k, attrRequestHeader):
 			basePrincipal.appendLast(requestHeaderGenerator{}, k, when.Values, when.NotValues)
+		case strings.HasPrefix(k, attrRequestRegexHeader):
+			basePrincipal.appendLast(requestRegexHeaderGenerator{}, k, when.Values, when.NotValues)
 		case strings.HasPrefix(k, attrRequestClaims):
 			basePrincipal.appendLast(requestClaimGenerator{}, k, when.Values, when.NotValues)
 		default:

--- a/pkg/config/security/security.go
+++ b/pkg/config/security/security.go
@@ -35,23 +35,24 @@ type JwksInfo struct {
 }
 
 const (
-	attrRequestHeader    = "request.headers"        // header name is surrounded by brackets, e.g. "request.headers[User-Agent]".
-	attrSrcIP            = "source.ip"              // supports both single ip and cidr, e.g. "10.1.2.3" or "10.1.0.0/16".
-	attrRemoteIP         = "remote.ip"              // original client ip determined from x-forwarded-for or proxy protocol.
-	attrSrcNamespace     = "source.namespace"       // e.g. "default".
-	attrSrcPrincipal     = "source.principal"       // source identity, e,g, "cluster.local/ns/default/sa/productpage".
-	attrRequestPrincipal = "request.auth.principal" // authenticated principal of the request.
-	attrRequestAudiences = "request.auth.audiences" // intended audience(s) for this authentication information.
-	attrRequestPresenter = "request.auth.presenter" // authorized presenter of the credential.
-	attrRequestClaims    = "request.auth.claims"    // claim name is surrounded by brackets, e.g. "request.auth.claims[iss]".
-	attrDestIP           = "destination.ip"         // supports both single ip and cidr, e.g. "10.1.2.3" or "10.1.0.0/16".
-	attrDestPort         = "destination.port"       // must be in the range [0, 65535].
-	attrDestLabel        = "destination.labels"     // label name is surrounded by brackets, e.g. "destination.labels[version]".
-	attrDestName         = "destination.name"       // short service name, e.g. "productpage".
-	attrDestNamespace    = "destination.namespace"  // e.g. "default".
-	attrDestUser         = "destination.user"       // service account, e.g. "bookinfo-productpage".
-	attrConnSNI          = "connection.sni"         // server name indication, e.g. "www.example.com".
-	attrExperimental     = "experimental.envoy.filters."
+	attrRequestHeader      = "request.headers"        // header name is surrounded by brackets, e.g. "request.headers[User-Agent]".
+	attrRequestHeaderRegex = "request.regex.headers"  // header regex is surrounded by brackets, e.g. "request.regex.headers[User-Agent]".
+	attrSrcIP              = "source.ip"              // supports both single ip and cidr, e.g. "10.1.2.3" or "10.1.0.0/16".
+	attrRemoteIP           = "remote.ip"              // original client ip determined from x-forwarded-for or proxy protocol.
+	attrSrcNamespace       = "source.namespace"       // e.g. "default".
+	attrSrcPrincipal       = "source.principal"       // source identity, e,g, "cluster.local/ns/default/sa/productpage".
+	attrRequestPrincipal   = "request.auth.principal" // authenticated principal of the request.
+	attrRequestAudiences   = "request.auth.audiences" // intended audience(s) for this authentication information.
+	attrRequestPresenter   = "request.auth.presenter" // authorized presenter of the credential.
+	attrRequestClaims      = "request.auth.claims"    // claim name is surrounded by brackets, e.g. "request.auth.claims[iss]".
+	attrDestIP             = "destination.ip"         // supports both single ip and cidr, e.g. "10.1.2.3" or "10.1.0.0/16".
+	attrDestPort           = "destination.port"       // must be in the range [0, 65535].
+	attrDestLabel          = "destination.labels"     // label name is surrounded by brackets, e.g. "destination.labels[version]".
+	attrDestName           = "destination.name"       // short service name, e.g. "productpage".
+	attrDestNamespace      = "destination.namespace"  // e.g. "default".
+	attrDestUser           = "destination.user"       // service account, e.g. "bookinfo-productpage".
+	attrConnSNI            = "connection.sni"         // server name indication, e.g. "www.example.com".
+	attrExperimental       = "experimental.envoy.filters."
 )
 
 // ParseJwksURI parses the input URI and returns the corresponding hostname, port, and whether SSL is used.
@@ -103,6 +104,8 @@ func ValidateAttribute(key string, values []string) error {
 	}
 	switch {
 	case hasPrefix(key, attrRequestHeader):
+		return validateMapKey(key)
+	case hasPrefix(key, attrRequestHeaderRegex):
 		return validateMapKey(key)
 	case isEqual(key, attrSrcIP):
 		return ValidateIPs(values)

--- a/pkg/config/security/security_test.go
+++ b/pkg/config/security/security_test.go
@@ -108,6 +108,16 @@ func TestValidateCondition(t *testing.T) {
 			wantError: true,
 		},
 		{
+			key:       "request.regex.headers[]",
+			values:    []string{"some.*value"},
+			wantError: true,
+		},
+		{
+			key:       "request.regex.headers[X-header-regex]",
+			values:    []string{"some.*value"},
+			wantError: false,
+		},
+		{
 			key:    "source.ip",
 			values: []string{"1.2.3.4", "5.6.7.0/24"},
 		},

--- a/releasenotes/notes/authz-regex-header.yaml
+++ b/releasenotes/notes/authz-regex-header.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: feature
+area: security
+releaseNotes:
+- |
+  **Added** request.regex.headers condition for authorization policies.  This
+  allows matching HTTP headers against a regex.

--- a/tests/integration/security/authorization_test.go
+++ b/tests/integration/security/authorization_test.go
@@ -1014,6 +1014,15 @@ func TestAuthorization_Conditions(t *testing.T) {
 								newTestCase(a[0], "/request-headers-notValues-bar", map[string]string{"x-foo": "foo"}, true),
 								newTestCase(a[0], "/request-headers-notValues-bar", map[string]string{"x-foo": "bar"}, false),
 
+								newTestCase(a[0], "/request-regex-headers", map[string]string{"x-foo": "foo-01"}, true),
+								newTestCase(b[0], "/request-regex-headers", map[string]string{"x-foo": "foo-99"}, true),
+								newTestCase(a[0], "/request-regex-headers", map[string]string{"x-foo": "bar-01"}, false),
+								newTestCase(b[0], "/request-regex-headers", map[string]string{"x-foo": "bar-99"}, false),
+								newTestCase(a[0], "/request-regex-headers", nil, false),
+								newTestCase(b[0], "/request-regex-headers", nil, false),
+								newTestCase(a[0], "/request-regex-headers-notValues-bar", map[string]string{"x-foo": "foo-00"}, true),
+								newTestCase(a[0], "/request-regex-headers-notValues-bar", map[string]string{"x-foo": "bar-00"}, false),
+
 								newTestCase(a[0], "/source-ip-a", nil, true),
 								newTestCase(b[0], "/source-ip-a", nil, false),
 								newTestCase(a[0], "/source-ip-b", nil, false),

--- a/tests/integration/security/testdata/authz/v1beta1-conditions.yaml.tmpl
+++ b/tests/integration/security/testdata/authz/v1beta1-conditions.yaml.tmpl
@@ -67,6 +67,42 @@ spec:
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
+  name: condition-request-regex-headers
+  namespace: "{{ .NamespaceC }}"
+spec:
+  selector:
+    matchLabels:
+      app: c
+  rules:
+  - to:
+    - operation:
+        paths: ["/request-regex-headers"]
+    when:
+    - key: request.regex.headers[x-foo]
+      values: ["foo-[0-9]+"]
+---
+
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: condition-request-regex-headers-notvalues
+  namespace: "{{ .NamespaceC }}"
+spec:
+  selector:
+    matchLabels:
+      app: c
+  rules:
+  - to:
+    - operation:
+        paths: ["/request-regex-headers-notValues-bar"]
+    when:
+    - key: request.regex.headers[x-foo]
+      notValues: ["bar-[0-9]+"]
+---
+
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
   name: condition-source-ip
   namespace: "{{ .NamespaceC }}"
 spec:


### PR DESCRIPTION
This adds support for a `request.regex.headers` condition in authz
policies.  It works like the existing `request.headers` condition, but
supports regex values via Envoy's SafeRegexMatch using Google’s RE2
regex engine.  The engine is designed to complete execution in linear
time as well as limit the amount of memory used.




[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[x] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.