### PR TITLE
[Test Framework] Adding traffic generation utility

### DIFF
--- a/pkg/test/framework/components/echo/util/traffic/generator.go
+++ b/pkg/test/framework/components/echo/util/traffic/generator.go
@@ -1,0 +1,109 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package traffic
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"istio.io/istio/pkg/test/framework/components/echo"
+)
+
+const (
+	defaultInterval = 1 * time.Second
+)
+
+// Config for a traffic Generator.
+type Config struct {
+	// Source of the traffic.
+	Source echo.Instance
+
+	// Options for generating traffic from the Source to the target.
+	Options echo.CallOptions
+
+	// Interval between successive call operations. If not set, defaults to 1 second.
+	Interval time.Duration
+}
+
+// Generator of traffic between echo instances. Every time interval
+// (as defined by Config.Interval), a grpc request is sent to the source pod,
+// causing it to send a request to the destination echo server. Results are
+// captured for each request for later processing.
+type Generator interface {
+	// Run the Generator and start sending traffic.
+	Run(stop chan struct{})
+
+	// WaitForResult waits for a short while for in-flight requests to complete.
+	// It is expected that the stop channel will be closed in order for this function
+	// to return successfully. Returns the Result, or an error if the wait timed out.
+	WaitForResult(timeout time.Duration) (Result, error)
+}
+
+// NewGenerator returns a new Generator with the given configuration.
+func NewGenerator(cfg Config) Generator {
+	fillInDefaults(&cfg)
+	return &generator{
+		Config:  cfg,
+		stopped: make(chan struct{}),
+	}
+}
+
+var _ Generator = &generator{}
+
+type generator struct {
+	Config
+	result  Result
+	stopped chan struct{}
+}
+
+func (g *generator) Run(stop chan struct{}) {
+	for {
+		t := time.NewTimer(g.Interval)
+		select {
+		case <-stop:
+			t.Stop()
+			close(g.stopped)
+			return
+		case <-t.C:
+			g.result.add(g.Source.Call(g.Options))
+			t.Reset(g.Interval)
+		}
+	}
+}
+
+func (g *generator) WaitForResult(timeout time.Duration) (Result, error) {
+	t := time.NewTimer(timeout)
+	select {
+	case <-g.stopped:
+		t.Stop()
+		if g.result.TotalRequests == 0 {
+			return Result{}, errors.New("no requests completed before stopping the traffic generator")
+		}
+		return g.result, nil
+	case <-t.C:
+		return Result{}, fmt.Errorf("timed out waiting for result")
+	}
+}
+
+func fillInDefaults(cfg *Config) {
+	if cfg.Interval == 0 {
+		cfg.Interval = defaultInterval
+	}
+
+	if cfg.Options.Validator == nil {
+		cfg.Options.Validator = echo.ExpectOK()
+	}
+}

--- a/pkg/test/framework/components/echo/util/traffic/result.go
+++ b/pkg/test/framework/components/echo/util/traffic/result.go
@@ -1,0 +1,60 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package traffic
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+
+	"istio.io/istio/pkg/test/echo/client"
+)
+
+// Result of a traffic generation operation.
+type Result struct {
+	TotalRequests      int
+	SuccessfulRequests int
+	Error              error
+}
+
+func (r Result) String() string {
+	buf := &bytes.Buffer{}
+
+	_, _ = fmt.Fprintf(buf, "TotalRequests:       %d\n", r.TotalRequests)
+	_, _ = fmt.Fprintf(buf, "SuccessfulRequests:  %d\n", r.SuccessfulRequests)
+	_, _ = fmt.Fprintf(buf, "PercentSuccess:      %f\n", r.PercentSuccess())
+	_, _ = fmt.Fprintf(buf, "Errors:              %v\n", r.Error)
+
+	return buf.String()
+}
+
+func (r *Result) add(resp client.ParsedResponses, err error) {
+	count := resp.Len()
+	if count == 0 {
+		count = 1
+	}
+
+	r.TotalRequests += count
+	if err != nil {
+		r.Error = multierror.Append(r.Error, err)
+	} else {
+		r.SuccessfulRequests += count
+	}
+}
+
+func (r Result) PercentSuccess() float64 {
+	return (float64(r.SuccessfulRequests) / float64(r.TotalRequests)) * 100.0
+}

--- a/tests/integration/pilot/revisioned_upgrade_test.go
+++ b/tests/integration/pilot/revisioned_upgrade_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/go-multierror"
 
@@ -26,9 +27,17 @@ import (
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
+	"istio.io/istio/pkg/test/framework/components/echo/util/traffic"
 	"istio.io/istio/pkg/test/framework/components/namespace"
 	kubetest "istio.io/istio/pkg/test/kube"
+	"istio.io/istio/pkg/test/scopes"
 	"istio.io/pkg/log"
+)
+
+const (
+	callInterval     = 200 * time.Millisecond
+	waitTimeout      = 30 * time.Second
+	successThreshold = 95
 )
 
 // TestRevisionedUpgrade tests a revision-based upgrade from the specified versions to current master
@@ -80,7 +89,20 @@ func testUpgradeFromVersion(ctx framework.TestContext, fromVersion string) {
 		},
 	})
 	builder.BuildOrFail(ctx)
-	sendSimpleTrafficOrFail(ctx, revisionedInstance)
+
+	// Create a traffic generator between A and B.
+	g := traffic.NewGenerator(traffic.Config{
+		Source: apps.PodA[0],
+		Options: echo.CallOptions{
+			Target:   apps.PodB[0],
+			PortName: "http",
+		},
+		Interval: callInterval,
+	})
+
+	// Run the traffic generator.
+	stop := make(chan struct{})
+	go g.Run(stop)
 
 	if err := enableDefaultInjection(revisionedNamespace); err != nil {
 		ctx.Fatalf("could not relabel namespace to enable default injection: %v", err)
@@ -103,16 +125,21 @@ func testUpgradeFromVersion(ctx framework.TestContext, fromVersion string) {
 		}
 	}
 
-	sendSimpleTrafficOrFail(ctx, revisionedInstance)
-}
+	// Stop the traffic generator.
+	close(stop)
 
-// sendSimpleTrafficOrFail sends an echo call to the upgrading echo instance
-func sendSimpleTrafficOrFail(ctx framework.TestContext, i echo.Instance) {
-	ctx.Helper()
-	apps.PodA[0].CallWithRetryOrFail(ctx, echo.CallOptions{
-		Target:   i,
-		PortName: "http",
-	})
+	// Get the result.
+	r, err := g.WaitForResult(waitTimeout)
+	if err != nil {
+		ctx.Fatalf("failed waiting for traffic result: %v", err)
+	}
+
+	if r.PercentSuccess() < successThreshold {
+		ctx.Fatalf("percentage of successful calls %f less than threshold %f:\n%s",
+			r.PercentSuccess(), successThreshold, r)
+	}
+
+	scopes.Framework.Infof("traffic test successful!\n%s", r)
 }
 
 // enableDefaultInjection takes a namespaces and relabels it such that it will have a default sidecar injected


### PR DESCRIPTION
This makes it easy to write long-running traffic generation tests.

Also re-working the revisioned upgrade test to use it.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.