### PR TITLE
Add logging to distinguish pushes from requests

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -307,7 +307,18 @@ type PushRequest struct {
 	// There should only be multiple reasons if the push request is the result of two distinct triggers, rather than
 	// classifying a single trigger as having multiple reasons.
 	Reason []TriggerReason
+
+	// PushType declares the type of push this is. Support values are currently PushTypeRequest, for
+	// responses to XDS requests, and PushTypePush for Istiod-originated pushes.
+	PushType PushType
 }
+
+type PushType string
+
+const (
+	PushTypeRequest PushType = "request"
+	PushTypePush    PushType = "push"
+)
 
 type TriggerReason string
 

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -316,8 +316,8 @@ type PushRequest struct {
 type PushType string
 
 const (
-	PushTypeRequest PushType = "request"
-	PushTypePush    PushType = "push"
+	PushTypeRequest PushType = " for request"
+	PushTypePush    PushType = ""
 )
 
 type TriggerReason string

--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -228,6 +228,7 @@ func (s *DiscoveryServer) processRequest(req *discovery.DiscoveryRequest, con *C
 
 	push := s.globalPushContext()
 
+	request.PushType = model.PushTypeRequest
 	return s.pushXds(con, push, versionInfo(), con.Watched(req.TypeUrl), request)
 }
 

--- a/pilot/pkg/xds/eds.go
+++ b/pilot/pkg/xds/eds.go
@@ -366,12 +366,16 @@ func (eds *EdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w
 			eds.Server.Cache.Add(builder, resource)
 		}
 	}
+	typeMessage := ""
+	if req.PushType == model.PushTypeRequest {
+		typeMessage = " for request"
+	}
 	if len(edsUpdatedServices) == 0 {
-		adsLog.Infof("EDS: PUSH for node:%s resources:%d size:%s empty:%v cached:%v/%v",
-			proxy.ID, len(resources), util.ByteCount(ResourceSize(resources)), empty, cached, cached+regenerated)
+		adsLog.Infof("EDS: PUSH%s for node:%s resources:%d size:%s empty:%v cached:%v/%v",
+			typeMessage, proxy.ID, len(resources), util.ByteCount(ResourceSize(resources)), empty, cached, cached+regenerated)
 	} else if adsLog.DebugEnabled() {
-		adsLog.Debugf("EDS: PUSH INC for node:%s clusters:%d size:%s empty:%vcached:%v/%v",
-			proxy.ID, len(resources), util.ByteCount(ResourceSize(resources)), empty, cached, cached+regenerated)
+		adsLog.Debugf("EDS: PUSH INC%s for node:%s clusters:%d size:%s empty:%v cached:%v/%v",
+			typeMessage, proxy.ID, len(resources), util.ByteCount(ResourceSize(resources)), empty, cached, cached+regenerated)
 	}
 	return resources, nil
 }

--- a/pilot/pkg/xds/eds.go
+++ b/pilot/pkg/xds/eds.go
@@ -366,16 +366,12 @@ func (eds *EdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w
 			eds.Server.Cache.Add(builder, resource)
 		}
 	}
-	typeMessage := ""
-	if req.PushType == model.PushTypeRequest {
-		typeMessage = " for request"
-	}
 	if len(edsUpdatedServices) == 0 {
 		adsLog.Infof("EDS: PUSH%s for node:%s resources:%d size:%s empty:%v cached:%v/%v",
-			typeMessage, proxy.ID, len(resources), util.ByteCount(ResourceSize(resources)), empty, cached, cached+regenerated)
+			req.PushType, proxy.ID, len(resources), util.ByteCount(ResourceSize(resources)), empty, cached, cached+regenerated)
 	} else if adsLog.DebugEnabled() {
 		adsLog.Debugf("EDS: PUSH INC%s for node:%s clusters:%d size:%s empty:%v cached:%v/%v",
-			typeMessage, proxy.ID, len(resources), util.ByteCount(ResourceSize(resources)), empty, cached, cached+regenerated)
+			req.PushType, proxy.ID, len(resources), util.ByteCount(ResourceSize(resources)), empty, cached, cached+regenerated)
 	}
 	return resources, nil
 }

--- a/pilot/pkg/xds/gen.go
+++ b/pilot/pkg/xds/gen.go
@@ -124,13 +124,17 @@ func (s *DiscoveryServer) pushXds(con *Connection, push *model.PushContext,
 
 	// Some types handle logs inside Generate, skip them here
 	if _, f := SkipLogTypes[w.TypeUrl]; !f {
+		typeMessage := ""
+		if req.PushType == model.PushTypeRequest {
+			typeMessage = " for request"
+		}
 		if adsLog.DebugEnabled() {
 			// Add additional information to logs when debug mode enabled
-			adsLog.Infof("%s: PUSH for node:%s resources:%d size:%s nonce:%v version:%v",
-				v3.GetShortType(w.TypeUrl), con.proxy.ID, len(res), util.ByteCount(ResourceSize(res)), resp.Nonce, resp.VersionInfo)
+			adsLog.Infof("%s: PUSH%s for node:%s resources:%d size:%s nonce:%v version:%v",
+				v3.GetShortType(w.TypeUrl), typeMessage, con.proxy.ID, len(res), util.ByteCount(ResourceSize(res)), resp.Nonce, resp.VersionInfo)
 		} else {
-			adsLog.Infof("%s: PUSH for node:%s resources:%d size:%s",
-				v3.GetShortType(w.TypeUrl), con.proxy.ID, len(res), util.ByteCount(ResourceSize(res)))
+			adsLog.Infof("%s: PUSH%s for node:%s resources:%d size:%s",
+				v3.GetShortType(w.TypeUrl), typeMessage, con.proxy.ID, len(res), util.ByteCount(ResourceSize(res)))
 		}
 	}
 	return nil

--- a/pilot/pkg/xds/gen.go
+++ b/pilot/pkg/xds/gen.go
@@ -124,17 +124,13 @@ func (s *DiscoveryServer) pushXds(con *Connection, push *model.PushContext,
 
 	// Some types handle logs inside Generate, skip them here
 	if _, f := SkipLogTypes[w.TypeUrl]; !f {
-		typeMessage := ""
-		if req.PushType == model.PushTypeRequest {
-			typeMessage = " for request"
-		}
 		if adsLog.DebugEnabled() {
 			// Add additional information to logs when debug mode enabled
 			adsLog.Infof("%s: PUSH%s for node:%s resources:%d size:%s nonce:%v version:%v",
-				v3.GetShortType(w.TypeUrl), typeMessage, con.proxy.ID, len(res), util.ByteCount(ResourceSize(res)), resp.Nonce, resp.VersionInfo)
+				v3.GetShortType(w.TypeUrl), req.PushType, con.proxy.ID, len(res), util.ByteCount(ResourceSize(res)), resp.Nonce, resp.VersionInfo)
 		} else {
 			adsLog.Infof("%s: PUSH%s for node:%s resources:%d size:%s",
-				v3.GetShortType(w.TypeUrl), typeMessage, con.proxy.ID, len(res), util.ByteCount(ResourceSize(res)))
+				v3.GetShortType(w.TypeUrl), req.PushType, con.proxy.ID, len(res), util.ByteCount(ResourceSize(res)))
 		}
 	}
 	return nil


### PR DESCRIPTION
Currently, both a request from envoy and a push due to update logs
`PUSH ...`. This makes it hard to tell *why* we pushed.

This makes it so that pushes in response to requests add `PUSH for
request`.

Example:
```
2021-02-19T23:51:41.555516Z     info    ads     ADS: new connection for node:sidecar~10.0.0.14~.~.svc.cluster.local-1
2021-02-19T23:51:41.556925Z     info    ads     CDS: PUSH for request for node:. resources:21 size:13.4kB
2021-02-19T23:51:41.564607Z     info    ads     EDS: PUSH for request for node:. resources:17 size:3.2kB empty:7 cached:0/17
2021-02-19T23:51:41.610006Z     info    ads     LDS: PUSH for request for node:. resources:18 size:56.2kB
2021-02-19T23:51:41.629489Z     info    ads     RDS: PUSH for request for node:. resources:8 size:5.3kB
2021-02-19T23:51:46.942349Z     info    ads     XDS: Pushing:2021-02-19T15:51:46-08:00/2 Services:6 ConnectedEndpoints:1  Version:2021-02-19T15:51:46-08:00/2
2021-02-19T23:51:46.942981Z     info    ads     CDS: PUSH for node:. resources:20 size:12.7kB
2021-02-19T23:51:46.943041Z     info    ads     EDS: PUSH for node:. resources:17 size:2.9kB empty:1 cached:16/17
2021-02-19T23:51:46.943810Z     info    ads     LDS: PUSH for node:. resources:17 size:52.7kB
2021-02-19T23:51:46.944199Z     info    ads     RDS: PUSH for node:. resources:8 size:4.8kB
2021-02-19T23:51:46.955465Z     info    ads     EDS: PUSH for request for node:. resources:16 size:2.8kB empty:0 cached:16/16
```

See the last 2 EDS pushes - here we can spot that we push EDS our selves, then additionally get an EDS request (as a result of the CDS push).
