### PR TITLE
authn: default peer authn to a PERMISSIVE is none effective exists

### DIFF
--- a/pilot/pkg/security/authn/v1beta1/policy_applier.go
+++ b/pilot/pkg/security/authn/v1beta1/policy_applier.go
@@ -382,16 +382,10 @@ func convertToEnvoyJwtConfig(jwtRules []*v1beta1.JWTRule, push *model.PushContex
 }
 
 func (a *v1beta1PolicyApplier) PortLevelSetting() map[uint32]*v1beta1.PeerAuthentication_MutualTLS {
-	if a.consolidatedPeerPolicy != nil {
-		return a.consolidatedPeerPolicy.PortLevelMtls
-	}
-	return nil
+	return a.consolidatedPeerPolicy.PortLevelMtls
 }
 
 func (a *v1beta1PolicyApplier) getMutualTLSModeForPort(endpointPort uint32) model.MutualTLSMode {
-	if a.consolidatedPeerPolicy == nil {
-		return model.MTLSPermissive
-	}
 	if a.consolidatedPeerPolicy.PortLevelMtls != nil {
 		if portMtls, ok := a.consolidatedPeerPolicy.PortLevelMtls[endpointPort]; ok {
 			return getMutualTLSMode(portMtls)

--- a/pilot/pkg/security/authn/v1beta1/policy_applier_test.go
+++ b/pilot/pkg/security/authn/v1beta1/policy_applier_test.go
@@ -1743,7 +1743,11 @@ func TestComposePeerAuthentication(t *testing.T) {
 		{
 			name:    "no config",
 			configs: []*config.Config{},
-			want:    nil,
+			want: &v1beta1.PeerAuthentication{
+				Mtls: &v1beta1.PeerAuthentication_MutualTLS{
+					Mode: v1beta1.PeerAuthentication_MutualTLS_PERMISSIVE,
+				},
+			},
 		},
 		{
 			name: "mesh only",
@@ -1802,7 +1806,7 @@ func TestComposePeerAuthentication(t *testing.T) {
 			},
 		},
 		{
-			name: "ignore non-empty selector in root namespace",
+			name: "return non-empty selector in root namespace with default",
 			configs: []*config.Config{
 				{
 					Meta: config.Meta{
@@ -1821,7 +1825,11 @@ func TestComposePeerAuthentication(t *testing.T) {
 					},
 				},
 			},
-			want: nil,
+			want: &v1beta1.PeerAuthentication{
+				Mtls: &v1beta1.PeerAuthentication_MutualTLS{
+					Mode: v1beta1.PeerAuthentication_MutualTLS_PERMISSIVE,
+				},
+			},
 		},
 		{
 			name: "workload vs namespace config",

--- a/pilot/pkg/security/authn/v1beta1/policy_applier_test.go
+++ b/pilot/pkg/security/authn/v1beta1/policy_applier_test.go
@@ -1806,7 +1806,7 @@ func TestComposePeerAuthentication(t *testing.T) {
 			},
 		},
 		{
-			name: "return non-empty selector in root namespace with default",
+			name: "ignore non-empty selector in root namespace",
 			configs: []*config.Config{
 				{
 					Meta: config.Meta{

--- a/tests/integration/security/reachability_test.go
+++ b/tests/integration/security/reachability_test.go
@@ -141,6 +141,16 @@ func TestReachability(t *testing.T) {
 					ExpectMTLS: mtlsOnExpect,
 				},
 				{
+					ConfigFile: "no-peer-authn.yaml",
+					Namespace:  systemNM,
+					Include: func(src echo.Instance, opts echo.CallOptions) bool {
+						// Exclude calls to naked since we are applying ISTIO_MUTUAL
+						return !apps.IsNaked(opts.Target)
+					},
+					ExpectSuccess: Always, // No PeerAuthN should default to a PERMISSIVE.
+					ExpectMTLS:    mtlsOnExpect,
+				},
+				{
 					ConfigFile:             "global-plaintext.yaml",
 					Namespace:              systemNM,
 					Include:                Always,

--- a/tests/integration/security/testdata/beta-mtls-permissive.yaml
+++ b/tests/integration/security/testdata/beta-mtls-permissive.yaml
@@ -1,3 +1,15 @@
+# Global PeerAuthentication can be removed for this test, once we remove the (alpha) mesh policy
+# during installation.
+apiVersion: "security.istio.io/v1beta1"
+kind: "PeerAuthentication"
+metadata:
+  name: "default"
+  annotations:
+    test-suite: "beta-mtls-permissive"
+spec:
+  mtls:
+    mode: PERMISSIVE
+---
 apiVersion: "networking.istio.io/v1alpha3"
 kind: "DestinationRule"
 metadata:

--- a/tests/integration/security/testdata/beta-mtls-permissive.yaml
+++ b/tests/integration/security/testdata/beta-mtls-permissive.yaml
@@ -1,15 +1,3 @@
-# Global PeerAuthentication can be removed for this test, once we remove the (alpha) mesh policy
-# during installation.
-apiVersion: "security.istio.io/v1beta1"
-kind: "PeerAuthentication"
-metadata:
-  name: "default"
-  annotations:
-    test-suite: "beta-mtls-permissive"
-spec:
-  mtls:
-    mode: PERMISSIVE
----
 apiVersion: "networking.istio.io/v1alpha3"
 kind: "DestinationRule"
 metadata:

--- a/tests/integration/security/testdata/no-peer-authn.yaml
+++ b/tests/integration/security/testdata/no-peer-authn.yaml
@@ -1,0 +1,11 @@
+apiVersion: "networking.istio.io/v1alpha3"
+kind: "DestinationRule"
+metadata:
+  name: "default"
+  annotations:
+    test-suite: "no-peer-authn"
+spec:
+  host: "*.local"
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL


### PR DESCRIPTION
Previously, `composePeerAuthentication` returns nil which can be used to
indicate no applicable (beta) policy exist in order to trigger fallback to
alpha policy if the input config list is empty. This can be simplified as we've
deprecated alpha policy.

This patch defaults the peer authn to a PERMISSIVE if no effective config input.
It helps clarify the behavior when no beta peer authn policy applied.

Related: https://github.com/istio/istio/issues/22602

Signed-off-by: Kailun Qin <kailun.qin@intel.com>

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[x] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any changes that may affect Istio users.
