### PR TITLE
Scope full push raised by Sidecar config changes

### DIFF
--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -631,6 +631,8 @@ const (
 	Router NodeType = "router"
 )
 
+var NodeTypes = [...]NodeType{SidecarProxy, Router}
+
 // IsApplicationNodeType verifies that the NodeType is one of the declared constants in the model
 func IsApplicationNodeType(nType NodeType) bool {
 	switch nType {

--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -38,12 +38,12 @@ var (
 		gvk.ServiceEntry:    {},
 		gvk.VirtualService:  {},
 		gvk.DestinationRule: {},
+		gvk.Sidecar:         {},
 	}
 
 	// clusterScopedConfigTypes includes configs when they are in root namespace,
 	// they will be applied to all namespaces within the cluster.
 	clusterScopedConfigTypes = map[config.GroupVersionKind]struct{}{
-		gvk.Sidecar:               {},
 		gvk.EnvoyFilter:           {},
 		gvk.AuthorizationPolicy:   {},
 		gvk.RequestAuthentication: {},
@@ -268,6 +268,12 @@ func ConvertToSidecarScope(ps *PushContext, sidecarConfig *config.Config, config
 		RootNamespace:      ps.Mesh.RootNamespace,
 		Version:            ps.PushVersion,
 	}
+
+	out.AddConfigDependencies(ConfigKey{
+		sidecarConfig.GroupVersionKind,
+		sidecarConfig.Name,
+		sidecarConfig.Namespace,
+	})
 
 	out.EgressListeners = make([]*IstioEgressListenerWrapper, 0)
 	egressConfigs := sidecar.Egress

--- a/pilot/pkg/xds/ads_common.go
+++ b/pilot/pkg/xds/ads_common.go
@@ -20,7 +20,7 @@ import (
 	"istio.io/istio/pkg/config/schema/gvk"
 )
 
-// configKindAffectedProxyTypes contains known config types which will affect certain node types.
+// configKindAffectedProxyTypes contains known config types which may affect certain node types.
 var configKindAffectedProxyTypes = map[config.GroupVersionKind][]model.NodeType{
 	gvk.Gateway: {model.Router},
 	gvk.Secret:  {model.Router},

--- a/pilot/pkg/xds/ads_test.go
+++ b/pilot/pkg/xds/ads_test.go
@@ -392,13 +392,16 @@ func TestAdsPushScoping(t *testing.T) {
 		Spec: sc,
 	}
 	notMatchedScc := config.Config{
-		Meta: config.Meta{GroupVersionKind: gvk.Sidecar,
-			Name: "notMatchedSc", Namespace: model.IstioDefaultConfigNamespace},
+		Meta: config.Meta{
+			GroupVersionKind: gvk.Sidecar,
+			Name:             "notMatchedSc", Namespace: model.IstioDefaultConfigNamespace,
+		},
 		Spec: &networking.Sidecar{
 			WorkloadSelector: &networking.WorkloadSelector{
 				Labels: map[string]string{"notMatched": "notMatched"},
 			},
-		}}
+		},
+	}
 	if _, err := s.Store().Create(scc); err != nil {
 		t.Fatal(err)
 	}

--- a/releasenotes/notes/scope-push-by-sidecar-changes.yaml
+++ b/releasenotes/notes/scope-push-by-sidecar-changes.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: networking
+releaseNotes:
+- |
+  **Improved** the full push scoping by adding `Sidecar` config to sidecarScopeKnownConfigTypes.


### PR DESCRIPTION


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ * ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.



I think we can consider Sidecar as `sidecarScopeKnownConfigTypes` rather than `clusterScopedConfigTypes`. And then only full-push raised by relevant Sidecar changes will be performed towards our proxies.
We can add the `kind+name+ns` of Sidecar config itself to `configDependencies` while `ConvertToSidecarScope`.