### PR TITLE
build converted service cache in service entry store

### DIFF
--- a/pilot/pkg/serviceregistry/serviceentry/servicediscovery.go
+++ b/pilot/pkg/serviceregistry/serviceentry/servicediscovery.go
@@ -498,9 +498,8 @@ func (s *ServiceEntryStore) GetService(hostname host.Name) (*model.Service, erro
 	if !s.processServiceEntry {
 		return nil, nil
 	}
-	s.storeMutex.RLock()
-	defer s.storeMutex.RUnlock()
-	for _, service := range s.services {
+	services, _ := s.Services()
+	for _, service := range services {
 		if service.Hostname == hostname {
 			return service, nil
 		}

--- a/pilot/pkg/serviceregistry/serviceentry/servicediscovery_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/servicediscovery_test.go
@@ -143,6 +143,7 @@ func initServiceDiscoveryWithOpts(opts ...ServiceDiscoveryOption) (model.IstioCo
 
 func TestServiceDiscoveryServices(t *testing.T) {
 	store, sd, _, stopFn := initServiceDiscovery()
+	sd.refreshIndexes.Store(true)
 	defer stopFn()
 
 	expectedServices := []*model.Service{
@@ -168,6 +169,7 @@ func TestServiceDiscoveryGetService(t *testing.T) {
 	hostDNE := "does.not.exist.local"
 
 	store, sd, _, stopFn := initServiceDiscovery()
+	sd.refreshIndexes.Store(true)
 	defer stopFn()
 
 	createConfigs([]*config.Config{httpDNS, tcpStatic}, store, t)

--- a/security/pkg/nodeagent/cache/secretcache.go
+++ b/security/pkg/nodeagent/cache/secretcache.go
@@ -333,7 +333,7 @@ func (sc *SecretManagerClient) addFileWatcher(file string, resourceName string) 
 	// File is not being watched, start watching now and trigger key push.
 	cacheLog.Infof("adding watcher for file certificate %s", file)
 	if err := sc.certWatcher.Add(file); err != nil {
-		cacheLog.Errorf("%v: error adding watcher for file, retrying watches [%s] %v", resourceName, file, err)
+		cacheLog.Errorf("%v: error adding watcher for file, skipping watches [%s] %v", resourceName, file, err)
 		numFileWatcherFailures.Increment()
 		return
 	}

--- a/security/pkg/nodeagent/cache/secretcache.go
+++ b/security/pkg/nodeagent/cache/secretcache.go
@@ -333,7 +333,7 @@ func (sc *SecretManagerClient) addFileWatcher(file string, resourceName string) 
 	// File is not being watched, start watching now and trigger key push.
 	cacheLog.Infof("adding watcher for file certificate %s", file)
 	if err := sc.certWatcher.Add(file); err != nil {
-		cacheLog.Errorf("%v: error adding watcher for file, skipping watches [%s] %v", resourceName, file, err)
+		cacheLog.Errorf("%v: error adding watcher for file, retrying watches [%s] %v", resourceName, file, err)
 		numFileWatcherFailures.Increment()
 		return
 	}


### PR DESCRIPTION
Currently we already store services of service entry's that have wortload selectors. This PR stores all services (pointing to the same services in workload selector and additional services as well) to avoid reconversion when Services() and GetService() is called.
[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X ] Does not have any changes that may affect Istio users.
