### PR TITLE
Fix the order of environment variables for injection

### DIFF
--- a/pkg/kube/inject/inject.go
+++ b/pkg/kube/inject/inject.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"reflect"
+	"sort"
 	"strconv"
 	"strings"
 	"text/template"
@@ -743,9 +744,15 @@ func updateClusterEnvs(container *corev1.Container, newKVs map[string]string) {
 			envVars = append(envVars, env)
 		}
 	}
-	for k, v := range newKVs {
-		envVars = append(envVars, corev1.EnvVar{Name: k, Value: v, ValueFrom: nil})
-	}
 
+	keys := make([]string, 0, len(newKVs))
+	for key := range newKVs {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		val := newKVs[key]
+		envVars = append(envVars, corev1.EnvVar{Name: key, Value: val, ValueFrom: nil})
+	}
 	container.Env = envVars
 }

--- a/pkg/kube/inject/inject_test.go
+++ b/pkg/kube/inject/inject_test.go
@@ -810,3 +810,42 @@ func TestAppendMultusNetwork(t *testing.T) {
 		})
 	}
 }
+
+func Test_updateClusterEnvs(t *testing.T) {
+	type args struct {
+		container *corev1.Container
+		newKVs    map[string]string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *corev1.Container
+	}{
+		{
+			args: args{
+				container: &corev1.Container{},
+				newKVs:    parseInjectEnvs("/inject/net/network1/cluster/cluster1"),
+			},
+			want: &corev1.Container{
+				Env: []corev1.EnvVar{
+					{
+						Name:  "ISTIO_META_CLUSTER_ID",
+						Value: "cluster1",
+					},
+					{
+						Name:  "ISTIO_META_NETWORK",
+						Value: "network1",
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			updateClusterEnvs(tt.args.container, tt.args.newKVs)
+			if !cmp.Equal(tt.args.container.Env, tt.want.Env) {
+				t.Fatalf("updateClusterEnvs got \n%+v, expected \n%+v", tt.args.container.Env, tt.want.Env)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Since the traversal order of the map is unstable, the order of env after injection is unstable, resulting in different results of injecting the same Pod.

[x] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any changes that may affect Istio users.