### PR TITLE
eagerly resolve hostname for network gateway in pilot

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -421,4 +421,10 @@ var (
 		20*time.Minute,
 		"The interval for istiod to fetch the jwks_uri for the jwks public key.",
 	).Get()
+
+	ResolveGatewayHostname = env.RegisterBoolVar(
+		"PILOT_RESOLVE_GATEWAY_HOSTNAME",
+		false,
+		"If set, Pilot will eagerly resolve DNS names from meshNetworks gateway addresses or the status.loadBalancer[].hostname field.",
+	).Get()
 )

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -1735,9 +1735,7 @@ func (ps *PushContext) initMeshNetworks(meshNetworks *meshconfig.MeshNetworks) {
 	for nw, nwGateways := range ps.networkGateways {
 		valid := make([]*Gateway, 0, len(nwGateways))
 		for _, gw := range nwGateways {
-			if ip := net.ParseIP(gw.Addr); ip != nil {
-				valid = append(valid, gw)
-			} else if features.ResolveGatewayHostname {
+			if ip := net.ParseIP(gw.Addr); ip == nil && features.ResolveGatewayHostname {
 				ips, err := net.LookupIP(gw.Addr)
 				if err == nil {
 					for _, ip := range ips {
@@ -1745,9 +1743,12 @@ func (ps *PushContext) initMeshNetworks(meshNetworks *meshconfig.MeshNetworks) {
 					}
 				} else {
 					log.Errorf("failed resolving gateway hostname %s: %v", gw.Addr, err)
+					// hostnames are filtered out later
+					valid = append(valid, gw)
 				}
 			} else {
-				log.Errorf("invalid IP address %s in gateway config", gw.Addr)
+				// good IP or hostname - hostnames are filtered out later
+				valid = append(valid, gw)
 			}
 		}
 		ps.networkGateways[nw] = valid

--- a/pilot/pkg/serviceregistry/kube/controller/network.go
+++ b/pilot/pkg/serviceregistry/kube/controller/network.go
@@ -168,9 +168,6 @@ func (c *Controller) extractGatewaysInner(svc *model.Service) bool {
 	}
 
 	gws := make([]*model.Gateway, 0, len(svc.Attributes.ClusterExternalAddresses))
-
-	// TODO(landow) ClusterExternalAddresses doesn't need to get used outside of the kube controller, and spreads
-	// TODO(cont)   logic between ConvertService, extractGatewaysInner, and updateServiceNodePortAddresses.
 	if svc.Attributes.ClusterExternalAddresses != nil {
 		// check if we have node port mappings
 		if svc.Attributes.ClusterExternalPorts != nil {

--- a/pilot/pkg/serviceregistry/memory/discovery.go
+++ b/pilot/pkg/serviceregistry/memory/discovery.go
@@ -331,5 +331,9 @@ func (sd *ServiceDiscovery) SetGatewaysForNetwork(nw string, gws ...*model.Gatew
 }
 
 func (sd *ServiceDiscovery) NetworkGateways() map[string][]*model.Gateway {
-	return sd.networkGateways
+	out := make(map[string][]*model.Gateway, len(sd.networkGateways))
+	for k, v := range sd.networkGateways {
+		out[k] = append([]*model.Gateway{}, v...)
+	}
+	return out
 }

--- a/pilot/pkg/xds/ep_filters_test.go
+++ b/pilot/pkg/xds/ep_filters_test.go
@@ -211,7 +211,7 @@ func TestEndpointsByNetworkFilter(t *testing.T) {
 	}
 }
 
-func TestEndpointsByNetworkFilter_IgnoreHostnameGateways(t *testing.T) {
+func TestEndpointsByNetworkFilter_SkipLBWithHostname(t *testing.T) {
 	//  - 1 IP gateway for network1
 	//  - 1 DNS gateway for network2
 	//  - 1 IP gateway for network3
@@ -227,6 +227,7 @@ func TestEndpointsByNetworkFilter_IgnoreHostnameGateways(t *testing.T) {
 		},
 	}})
 	serviceDiscovery.SetGatewaysForNetwork("network2", &model.Gateway{Addr: "aeiou.scooby.do", Port: 80})
+
 	env.ServiceDiscovery = serviceDiscovery
 
 	// Test endpoints creates:
@@ -256,12 +257,10 @@ func TestEndpointsByNetworkFilter_IgnoreHostnameGateways(t *testing.T) {
 						// 2 local endpoints
 						{address: "10.0.0.1", weight: 1},
 						{address: "10.0.0.2", weight: 1},
-						// non-gateway endpoint to gateway of network2 a its a dns name instead of IP
-						{address: "20.0.0.1", weight: 1},
-						// non-gateway endpoint to network4 since there is no gateway specified
+						// 0 endpoint to gateway of network2 a its a dns name instead of IP
 						{address: "40.0.0.1", weight: 1},
 					},
-					weight: 4,
+					weight: 3,
 				},
 			},
 		},
@@ -293,12 +292,10 @@ func TestEndpointsByNetworkFilter_IgnoreHostnameGateways(t *testing.T) {
 					lbEps: []LbEpInfo{
 						// 1 endpoint to gateway of network1 with weight 2 because it has 2 endpoints
 						{address: "1.1.1.1", weight: 2},
-						// non-gateway endpoint to gateway of network2 a its a dns name instead of IP
-						{address: "20.0.0.1", weight: 1},
-						// non-gateway endpoint to network4 since there is no gateway specified
+						// 0 endpoint to gateway of network2 as its a DNS gateway
 						{address: "40.0.0.1", weight: 1},
 					},
-					weight: 4,
+					weight: 3,
 				},
 			},
 		},
@@ -314,10 +311,9 @@ func TestEndpointsByNetworkFilter_IgnoreHostnameGateways(t *testing.T) {
 						{address: "40.0.0.1", weight: 1},
 						// 1 endpoint to gateway of network1 with weight 2 because it has 2 endpoints
 						{address: "1.1.1.1", weight: 2},
-						// non-gateway endpoint to gateway of network2 a its a dns name instead of IP
-						{address: "20.0.0.1", weight: 1},
+						// 0 endpoint to gateway of network2 as its a dns gateway
 					},
-					weight: 4,
+					weight: 3,
 				},
 			},
 		},

--- a/pilot/pkg/xds/ep_filters_test.go
+++ b/pilot/pkg/xds/ep_filters_test.go
@@ -211,7 +211,7 @@ func TestEndpointsByNetworkFilter(t *testing.T) {
 	}
 }
 
-func TestEndpointsByNetworkFilter_SkipLBWithHostname(t *testing.T) {
+func TestEndpointsByNetworkFilter_IgnoreHostnameGateways(t *testing.T) {
 	//  - 1 IP gateway for network1
 	//  - 1 DNS gateway for network2
 	//  - 1 IP gateway for network3
@@ -227,7 +227,6 @@ func TestEndpointsByNetworkFilter_SkipLBWithHostname(t *testing.T) {
 		},
 	}})
 	serviceDiscovery.SetGatewaysForNetwork("network2", &model.Gateway{Addr: "aeiou.scooby.do", Port: 80})
-
 	env.ServiceDiscovery = serviceDiscovery
 
 	// Test endpoints creates:
@@ -257,10 +256,12 @@ func TestEndpointsByNetworkFilter_SkipLBWithHostname(t *testing.T) {
 						// 2 local endpoints
 						{address: "10.0.0.1", weight: 1},
 						{address: "10.0.0.2", weight: 1},
-						// 0 endpoint to gateway of network2 a its a dns name instead of IP
+						// non-gateway endpoint to gateway of network2 a its a dns name instead of IP
+						{address: "20.0.0.1", weight: 1},
+						// non-gateway endpoint to network4 since there is no gateway specified
 						{address: "40.0.0.1", weight: 1},
 					},
-					weight: 3,
+					weight: 4,
 				},
 			},
 		},
@@ -292,10 +293,12 @@ func TestEndpointsByNetworkFilter_SkipLBWithHostname(t *testing.T) {
 					lbEps: []LbEpInfo{
 						// 1 endpoint to gateway of network1 with weight 2 because it has 2 endpoints
 						{address: "1.1.1.1", weight: 2},
-						// 0 endpoint to gateway of network2 as its a DNS gateway
+						// non-gateway endpoint to gateway of network2 a its a dns name instead of IP
+						{address: "20.0.0.1", weight: 1},
+						// non-gateway endpoint to network4 since there is no gateway specified
 						{address: "40.0.0.1", weight: 1},
 					},
-					weight: 3,
+					weight: 4,
 				},
 			},
 		},
@@ -311,9 +314,10 @@ func TestEndpointsByNetworkFilter_SkipLBWithHostname(t *testing.T) {
 						{address: "40.0.0.1", weight: 1},
 						// 1 endpoint to gateway of network1 with weight 2 because it has 2 endpoints
 						{address: "1.1.1.1", weight: 2},
-						// 0 endpoint to gateway of network2 as its a dns gateway
+						// non-gateway endpoint to gateway of network2 a its a dns name instead of IP
+						{address: "20.0.0.1", weight: 1},
 					},
-					weight: 3,
+					weight: 4,
 				},
 			},
 		},


### PR DESCRIPTION
This is a best-effort fix for https://github.com/istio/istio/issues/29359. Ideally the proxies would be able to resolve a hostname in an EDS cluster, but currently there is no performant way to do that. 

Because this behavior would be unexpected for most users, and could result in serving endpoints based on no-longer-valid DNS resolution it is turned off by default and requires a feature flag. This should only be enabled when you're confident that the IPs backing the hostname won't change. 

DNS will be resolved on each push. 

TODO: this would end up being very useful if we triggeredEDS push when the DNS TTL expires. 