### PR TITLE
support http proxy from an echo forwarder

### DIFF
--- a/pkg/test/echo/server/forwarder/protocol.go
+++ b/pkg/test/echo/server/forwarder/protocol.go
@@ -147,6 +147,7 @@ func newProtocol(cfg Config) (protocol, error) {
 					IdleConnTimeout: time.Second,
 					TLSClientConfig: tlsConfig,
 					DialContext:     httpDialContext,
+					Proxy:           http.ProxyFromEnvironment,
 				},
 				Timeout: timeout,
 			},


### PR DESCRIPTION
Setting `HTTP_PROXY` or `HTTPS_PROXY` will allow the test runner to use the proxy on requests via ingress. gRPC lib should handle these already, so ForwardEcho calls should work. 