### PR TITLE
Add runtime assertions to Pilot

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -432,4 +432,13 @@ var (
 	StripHostPort = env.RegisterBoolVar("ISTIO_GATEWAY_STRIP_HOST_PORT", false,
 		"If enabled, Gateway will remove any port from host/authority header "+
 			"before any processing of request by HTTP filters or routing.").Get()
+
+	// EnableUnsafeAssertions enables runtime checks to test assertions in our code. This should never be enabled in
+	// production; when assertions fail Istio will panic.
+	EnableUnsafeAssertions = env.RegisterBoolVar(
+		"PILOT_ENABLE_UNSAFE_RUNTIME_ASSERTIONS",
+		false,
+		"If enabled, addition runtime asserts will be performed. "+
+			"These checks are both expensive and panic on failure. As a result, this should be used only for testing.",
+	).Get()
 )

--- a/pilot/pkg/model/xds_cache.go
+++ b/pilot/pkg/model/xds_cache.go
@@ -19,7 +19,10 @@ import (
 	"sync"
 
 	"github.com/golang/protobuf/ptypes/any"
+	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/golang-lru/simplelru"
+	"go.uber.org/atomic"
+	"google.golang.org/protobuf/testing/protocmp"
 
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/util/sets"
@@ -99,14 +102,28 @@ type XdsCacheEntry interface {
 	Cacheable() bool
 }
 
+type CacheToken uint64
+
 // XdsCache interface defines a store for caching XDS responses.
 // All operations are thread safe.
 type XdsCache interface {
-	// Add adds the given XdsCacheEntry with the value to the cache.
-	Add(entry XdsCacheEntry, value *any.Any)
+	// Add adds the given XdsCacheEntry with the value to the cache. A token, returned from Get, must
+	// be included or writes will be (silently) dropped. Additionally, if the cache has been
+	// invalided between when a token is fetched from Get and when Add is called, the write will be
+	// dropped. This ensures stale data does not overwrite fresh data when dealing with concurrent
+	// writers.
+	Add(entry XdsCacheEntry, token CacheToken, value *any.Any)
 	// Get retrieves the cached value if it exists. The boolean indicates
 	// whether the entry exists in the cache.
-	Get(entry XdsCacheEntry) (*any.Any, bool)
+	//
+	// A CacheToken is additionally included in the response. This must be used for subsequent writes
+	// to this key. This ensures that if the cache is invalidated between our read and write, we do
+	// not persist stale data.
+	//
+	// Standard usage:
+	// if obj, token, f := cache.Get(key); f { ...do something... }
+	// else { computed := expensive(); cache.Add(key, token, computed); }
+	Get(entry XdsCacheEntry) (*any.Any, CacheToken, bool)
 	// Clear removes the cache entries that are dependent on the configs passed.
 	Clear(map[ConfigKey]struct{})
 	// ClearAll clears the entire cache.
@@ -120,12 +137,15 @@ func NewXdsCache() XdsCache {
 	return &lruCache{
 		store:       newLru(),
 		configIndex: map[ConfigKey]sets.Set{},
+		nextToken:   atomic.NewUint64(0),
 	}
 }
 
 type lruCache struct {
 	store simplelru.LRUCache
-
+	// nextToken stores the next token to use. The content here doesn't matter, we just need a cheap
+	// unique identifier.
+	nextToken   *atomic.Uint64
 	mu          sync.RWMutex
 	configIndex map[ConfigKey]sets.Set
 }
@@ -144,31 +164,90 @@ func newLru() simplelru.LRUCache {
 	return l
 }
 
-func (l *lruCache) Add(entry XdsCacheEntry, value *any.Any) {
+// assertUnchanged checks that a cache entry is not changed. This helps catch bad cache invalidation
+// We should never have a case where we overwrite an existing item with a new change. Instead, when
+// config sources change, Clear/ClearAll should be called. At this point, we may get multiple writes
+// because multiple writers may get cache misses concurrently, but they ought to generate identical
+// configuration. This also checks that our XDS config generation is deterministic, which is a very
+// important property.
+func assertUnchanged(existing *any.Any, replacement *any.Any) {
+	if features.EnableUnsafeAssertions {
+		if existing == nil {
+			// This is a new addition, not an update
+			return
+		}
+		if !cmp.Equal(existing, replacement, protocmp.Transform()) {
+			warning := fmt.Errorf("assertion failed, cache entry changed but not cleared: %v\n%v\n%v",
+				cmp.Diff(existing, replacement, protocmp.Transform()), existing, replacement)
+			panic(warning)
+		}
+	}
+}
+
+func (l *lruCache) Add(entry XdsCacheEntry, token CacheToken, value *any.Any) {
 	if !entry.Cacheable() {
 		return
 	}
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	k := entry.Key()
-	l.store.Add(k, value)
+	cur, f := l.store.Get(k)
+	toWrite := cacheValue{value: value}
+	if f {
+		if token != cur.(cacheValue).token {
+			// entry may be stale, we need to drop it. This can happen when the cache is invalidated
+			// after we call Get.
+			return
+		}
+		// Otherwise, make sure we write the current token again. We don't change the key on writes; the
+		// same token will be used for a value until its invalidated
+		toWrite.token = cur.(cacheValue).token
+	} else {
+		// This is our first time seeing this; this means it was invalidated recently and this is our
+		// first write, or we forgot to call Get before.
+		return
+	}
+	if features.EnableUnsafeAssertions {
+		if toWrite.token == 0 {
+			panic("token cannot be empty. was Get() called before Add()?")
+		}
+		assertUnchanged(cur.(cacheValue).value, value)
+	}
+	l.store.Add(k, toWrite)
 	indexConfig(l.configIndex, entry.Key(), entry)
 	size(l.store.Len())
 }
 
-func (l *lruCache) Get(entry XdsCacheEntry) (*any.Any, bool) {
+type cacheValue struct {
+	value *any.Any
+	token CacheToken
+}
+
+func (l *lruCache) Get(entry XdsCacheEntry) (*any.Any, CacheToken, bool) {
 	if !entry.Cacheable() {
-		return nil, false
+		return nil, 0, false
 	}
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	val, ok := l.store.Get(entry.Key())
+	k := entry.Key()
+	val, ok := l.store.Get(k)
 	if !ok {
 		miss()
-		return nil, false
+		// If the entry is not found at all, this is our first read of it. We will generate and store
+		// a new token. Subsequent writes must include it.
+		tok := CacheToken(l.nextToken.Inc())
+		l.store.Add(k, cacheValue{token: tok})
+		return nil, tok, false
+	}
+	cv := val.(cacheValue)
+	if cv.value == nil {
+		miss()
+		// We have generated a token previously, so return that, but this is still a cache miss as
+		// no value is stored.
+		return nil, cv.token, false
 	}
 	hit()
-	return val.(*any.Any), true
+	return cv.value, cv.token, true
 }
 
 func (l *lruCache) Clear(configs map[ConfigKey]struct{}) {
@@ -208,10 +287,10 @@ type DisabledCache struct{}
 
 var _ XdsCache = &DisabledCache{}
 
-func (d DisabledCache) Add(key XdsCacheEntry, value *any.Any) {}
+func (d DisabledCache) Add(key XdsCacheEntry, token CacheToken, value *any.Any) {}
 
-func (d DisabledCache) Get(XdsCacheEntry) (*any.Any, bool) {
-	return nil, false
+func (d DisabledCache) Get(XdsCacheEntry) (*any.Any, CacheToken, bool) {
+	return nil, 0, false
 }
 
 func (d DisabledCache) Clear(configsUpdated map[ConfigKey]struct{}) {}

--- a/pilot/pkg/xds/eds.go
+++ b/pilot/pkg/xds/eds.go
@@ -22,6 +22,7 @@ import (
 	"github.com/golang/protobuf/ptypes/any"
 
 	networkingapi "istio.io/api/networking/v1alpha3"
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	networking "istio.io/istio/pilot/pkg/networking/core/v1alpha3"
 	"istio.io/istio/pilot/pkg/networking/core/v1alpha3/loadbalancer"
@@ -163,6 +164,18 @@ func (s *DiscoveryServer) edsCacheUpdate(clusterID, hostname string, namespace s
 	}
 	ep.Shards[clusterID] = istioEndpoints
 	ep.ServiceAccounts = serviceAccounts
+	// Clear the cache here. While it would likely be cleared later when we trigger a push, a race
+	// condition is introduced where an XDS response may be generated before the update, but not
+	// completed until after a response after the update. Essentially, we transition from v0 -> v1 ->
+	// v0 -> invalidate -> v1. Reverting a change we pushed violates our contract of monotonically
+	// moving forward in version. In practice, this is pretty rare and self corrects nearly
+	// immediately. However, clearing the cache here has almost no impact on cache performance as we
+	// would clear it shortly after anyways.
+	s.Cache.Clear(map[model.ConfigKey]struct{}{{
+		Kind:      gvk.ServiceEntry,
+		Name:      hostname,
+		Namespace: namespace,
+	}: {}})
 	ep.mutex.Unlock()
 
 	return fullPush
@@ -197,6 +210,12 @@ func (s *DiscoveryServer) deleteEndpointShards(cluster, serviceName, namespace s
 		s.EndpointShardsByService[serviceName][namespace] != nil {
 		s.EndpointShardsByService[serviceName][namespace].mutex.Lock()
 		delete(s.EndpointShardsByService[serviceName][namespace].Shards, cluster)
+		// Clear the cache here to avoid race in cache writes (see edsCacheUpdate for details).
+		s.Cache.Clear(map[model.ConfigKey]struct{}{{
+			Kind:      gvk.ServiceEntry,
+			Name:      serviceName,
+			Namespace: namespace,
+		}: {}})
 		s.EndpointShardsByService[serviceName][namespace].mutex.Unlock()
 	}
 }
@@ -213,6 +232,12 @@ func (s *DiscoveryServer) deleteService(cluster, serviceName, namespace string) 
 		s.EndpointShardsByService[serviceName][namespace].mutex.Lock()
 		delete(s.EndpointShardsByService[serviceName][namespace].Shards, cluster)
 		shards := len(s.EndpointShardsByService[serviceName][namespace].Shards)
+		// Clear the cache here to avoid race in cache writes (see edsCacheUpdate for details).
+		s.Cache.Clear(map[model.ConfigKey]struct{}{{
+			Kind:      gvk.ServiceEntry,
+			Name:      serviceName,
+			Namespace: namespace,
+		}: {}})
 		s.EndpointShardsByService[serviceName][namespace].mutex.Unlock()
 
 		if shards == 0 {
@@ -348,7 +373,8 @@ func (eds *EdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w
 			}
 		}
 		builder := NewEndpointBuilder(clusterName, proxy, push)
-		if marshalledEndpoint, f := eds.Server.Cache.Get(builder); f {
+		if marshalledEndpoint, token, f := eds.Server.Cache.Get(builder); f && !features.EnableUnsafeAssertions {
+			// We skip cache if assertions are enabled, so that the cache will assert our eviction logic is correct
 			resources = append(resources, marshalledEndpoint)
 			cached++
 		} else {
@@ -363,7 +389,7 @@ func (eds *EdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w
 			}
 			resource := util.MessageToAny(l)
 			resources = append(resources, resource)
-			eds.Server.Cache.Add(builder, resource)
+			eds.Server.Cache.Add(builder, token, resource)
 		}
 	}
 	if len(edsUpdatedServices) == 0 {

--- a/pilot/pkg/xds/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoint_builder.go
@@ -242,9 +242,20 @@ func (b *EndpointBuilder) buildLocalityLbEndpointsFromShards(
 	isClusterLocal := b.push.IsClusterLocal(b.service)
 
 	shards.mutex.Lock()
+	// Extract shard keys so we can iterate in order. This ensures a stable EDS output. Since
+	// len(shards) ~= number of remote clusters which isn't too large, doing this sort shouldn't be
+	// too problematic. If it becomes an issue we can cache it in the EndpointShards struct.
+	keys := make([]string, 0, len(shards.Shards))
+	for k := range shards.Shards {
+		keys = append(keys, k)
+	}
+	if len(keys) >= 2 {
+		sort.Strings(keys)
+	}
 	// The shards are updated independently, now need to filter and merge
 	// for this cluster
-	for clusterID, endpoints := range shards.Shards {
+	for _, clusterID := range keys {
+		endpoints := shards.Shards[clusterID]
 		// If the downstream service is configured as cluster-local, only include endpoints that
 		// reside in the same cluster.
 		if isClusterLocal && (clusterID != b.clusterID) {
@@ -280,7 +291,15 @@ func (b *EndpointBuilder) buildLocalityLbEndpointsFromShards(
 	shards.mutex.Unlock()
 
 	locEps := make([]*LocLbEndpointsAndOptions, 0, len(localityEpMap))
-	for _, locLbEps := range localityEpMap {
+	locs := make([]string, 0, len(localityEpMap))
+	for k := range localityEpMap {
+		locs = append(locs, k)
+	}
+	if len(locs) >= 2 {
+		sort.Strings(locs)
+	}
+	for _, k := range locs {
+		locLbEps := localityEpMap[k]
 		var weight uint32
 		for _, ep := range locLbEps.llbEndpoints.LbEndpoints {
 			weight += ep.LoadBalancingWeight.GetValue()

--- a/pilot/pkg/xds/xds_cache_test.go
+++ b/pilot/pkg/xds/xds_cache_test.go
@@ -15,14 +15,20 @@
 package xds
 
 import (
+	"fmt"
+	"math/rand"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/golang/protobuf/ptypes/any"
+	"go.uber.org/atomic"
 
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/gvk"
+	"istio.io/istio/pkg/test/util/retry"
 )
 
 var (
@@ -30,7 +36,48 @@ var (
 	any2 = &any.Any{TypeUrl: "bar"}
 )
 
+// TestXdsCacheToken is a regression test to ensure that we do not write
+func TestXdsCacheToken(t *testing.T) {
+	c := model.NewXdsCache()
+	n := atomic.NewInt32(0)
+	mkv := func(n int32) *any.Any {
+		return &any.Any{TypeUrl: fmt.Sprint(n)}
+	}
+	k := EndpointBuilder{clusterName: "key", service: &model.Service{Hostname: "foo.com"}}
+	work := func() {
+		_, tok, f := c.Get(k)
+		if f {
+			return
+		}
+		v := mkv(n.Load())
+		time.Sleep(time.Millisecond * time.Duration(rand.Intn(100)))
+		c.Add(k, tok, v)
+	}
+	for vals := 0; vals < 5; vals++ {
+		for i := 0; i < 5; i++ {
+			go work()
+		}
+		retry.UntilOrFail(t, func() bool {
+			val, _, f := c.Get(k)
+			return f && val.TypeUrl == fmt.Sprint(n)
+		})
+		n.Inc()
+		c.ClearAll()
+		for i := 0; i < 5; i++ {
+			val, _, f := c.Get(k)
+			if f {
+				t.Log("found unexpected write", val.TypeUrl)
+			}
+			if f && val.TypeUrl != fmt.Sprint(n) {
+				t.Fatalf("got bad write: %v", val.TypeUrl)
+			}
+			time.Sleep(time.Millisecond * time.Duration(rand.Intn(20)))
+		}
+	}
+}
+
 func TestXdsCache(t *testing.T) {
+	features.EnableUnsafeAssertions = false
 	ep1 := EndpointBuilder{
 		clusterName: "outbound|1||foo.com",
 		service:     &model.Service{Hostname: "foo.com"},
@@ -39,41 +86,48 @@ func TestXdsCache(t *testing.T) {
 		clusterName: "outbound|2||foo.com",
 		service:     &model.Service{Hostname: "foo.com"},
 	}
+	addWithToken := func(c model.XdsCache, entry model.XdsCacheEntry, value *any.Any) {
+		_, tok, _ := c.Get(entry)
+		c.Add(entry, tok, value)
+	}
 	t.Run("simple", func(t *testing.T) {
 		c := model.NewXdsCache()
-		c.Add(ep1, any1)
+
+		addWithToken(c, ep1, any1)
 		if !reflect.DeepEqual(c.Keys(), []string{ep1.Key()}) {
 			t.Fatalf("unexpected keys: %v, want %v", c.Keys(), ep1.Key())
 		}
-		if got, _ := c.Get(ep1); got != any1 {
+		if got, _, _ := c.Get(ep1); got != any1 {
 			t.Fatalf("unexpected result: %v, want %v", got, any1)
 		}
-		c.Add(ep1, any2)
-		if got, _ := c.Get(ep1); got != any2 {
+
+		addWithToken(c, ep1, any2)
+		if got, _, _ := c.Get(ep1); got != any2 {
 			t.Fatalf("unexpected result: %v, want %v", got, any2)
 		}
+
 		c.Clear(map[model.ConfigKey]struct{}{{Kind: gvk.ServiceEntry, Name: "foo.com"}: {}})
-		if _, f := c.Get(ep1); f {
+		if _, _, f := c.Get(ep1); f {
 			t.Fatalf("unexpected result, found key when not expected: %v", c.Keys())
 		}
 	})
 
 	t.Run("multiple hostnames", func(t *testing.T) {
 		c := model.NewXdsCache()
-		c.Add(ep1, any1)
-		c.Add(ep2, any2)
+		addWithToken(c, ep1, any1)
+		addWithToken(c, ep2, any2)
 
-		if got, _ := c.Get(ep1); got != any1 {
+		if got, _, _ := c.Get(ep1); got != any1 {
 			t.Fatalf("unexpected result: %v, want %v", got, any1)
 		}
-		if got, _ := c.Get(ep2); got != any2 {
+		if got, _, _ := c.Get(ep2); got != any2 {
 			t.Fatalf("unexpected result: %v, want %v", got, any2)
 		}
 		c.Clear(map[model.ConfigKey]struct{}{{Kind: gvk.ServiceEntry, Name: "foo.com"}: {}})
-		if _, f := c.Get(ep1); f {
+		if _, _, f := c.Get(ep1); f {
 			t.Fatalf("unexpected result, found key when not expected: %v", c.Keys())
 		}
-		if _, f := c.Get(ep2); f {
+		if _, _, f := c.Get(ep2); f {
 			t.Fatalf("unexpected result, found key when not expected: %v", c.Keys())
 		}
 	})
@@ -84,45 +138,66 @@ func TestXdsCache(t *testing.T) {
 		ep1.destinationRule = &config.Config{Meta: config.Meta{Name: "a", Namespace: "b"}}
 		ep2 := ep2
 		ep2.destinationRule = &config.Config{Meta: config.Meta{Name: "b", Namespace: "b"}}
-		c.Add(ep1, any1)
-		c.Add(ep2, any2)
-
-		if got, _ := c.Get(ep1); got != any1 {
+		addWithToken(c, ep1, any1)
+		addWithToken(c, ep2, any2)
+		if got, _, _ := c.Get(ep1); got != any1 {
 			t.Fatalf("unexpected result: %v, want %v", got, any1)
 		}
-		if got, _ := c.Get(ep2); got != any2 {
+		if got, _, _ := c.Get(ep2); got != any2 {
 			t.Fatalf("unexpected result: %v, want %v", got, any2)
 		}
 		c.Clear(map[model.ConfigKey]struct{}{{Kind: gvk.DestinationRule, Name: "a", Namespace: "b"}: {}})
-		if _, f := c.Get(ep1); f {
+		if _, _, f := c.Get(ep1); f {
 			t.Fatalf("unexpected result, found key when not expected: %v", c.Keys())
 		}
-		if got, _ := c.Get(ep2); got != any2 {
+		if got, _, _ := c.Get(ep2); got != any2 {
 			t.Fatalf("unexpected result: %v, want %v", got, any2)
 		}
 		c.Clear(map[model.ConfigKey]struct{}{{Kind: gvk.DestinationRule, Name: "b", Namespace: "b"}: {}})
-		if _, f := c.Get(ep1); f {
+		if _, _, f := c.Get(ep1); f {
 			t.Fatalf("unexpected result, found key when not expected: %v", c.Keys())
 		}
-		if _, f := c.Get(ep2); f {
+		if _, _, f := c.Get(ep2); f {
 			t.Fatalf("unexpected result, found key when not expected: %v", c.Keys())
 		}
 	})
 
 	t.Run("clear all", func(t *testing.T) {
 		c := model.NewXdsCache()
-		c.Add(ep1, any1)
-		c.Add(ep2, any2)
+		addWithToken(c, ep1, any1)
+		addWithToken(c, ep2, any2)
 
 		c.ClearAll()
 		if len(c.Keys()) != 0 {
 			t.Fatalf("expected no keys, got: %v", c.Keys())
 		}
-		if _, f := c.Get(ep1); f {
+		if _, _, f := c.Get(ep1); f {
 			t.Fatalf("unexpected result, found key when not expected: %v", c.Keys())
 		}
-		if _, f := c.Get(ep2); f {
+		if _, _, f := c.Get(ep2); f {
 			t.Fatalf("unexpected result, found key when not expected: %v", c.Keys())
+		}
+	})
+
+	t.Run("write without token", func(t *testing.T) {
+		c := model.NewXdsCache()
+		c.Add(ep1, 0, any1)
+		if len(c.Keys()) != 0 {
+			t.Fatalf("expected no keys, got: %v", c.Keys())
+		}
+	})
+
+	t.Run("write with evicted token", func(t *testing.T) {
+		c := model.NewXdsCache()
+		addWithToken(c, ep1, any1)
+		if len(c.Keys()) != 1 {
+			t.Fatalf("expected 1 keys, got: %v", c.Keys())
+		}
+		_, tok, _ := c.Get(ep1)
+		c.ClearAll()
+		c.Add(ep1, tok, any1)
+		if len(c.Keys()) != 0 {
+			t.Fatalf("expected no keys, got: %v", c.Keys())
 		}
 	})
 }

--- a/pkg/test/kube/dump.go
+++ b/pkg/test/kube/dump.go
@@ -183,15 +183,15 @@ func DumpPodEvents(_ resource.Context, c cluster.Cluster, workDir, namespace str
 	}
 }
 
-// containerRestarted checks if a container has ever restarted
-func containerRestarted(pod corev1.Pod, container string) bool {
+// containerRestarts checks how many times container has ever restarted
+func containerRestarts(pod corev1.Pod, container string) int {
 	for _, cs := range pod.Status.ContainerStatuses {
 		if cs.Name == container {
-			return cs.RestartCount > 0
+			return int(cs.RestartCount)
 		}
 	}
 	// No match - assume that means no restart
-	return false
+	return 0
 }
 
 // DumpPodLogs will dump logs from each container in each of the provided pods
@@ -214,11 +214,11 @@ func DumpPodLogs(_ resource.Context, c cluster.Cluster, workDir, namespace strin
 			}
 
 			// Get previous container logs, if applicable
-			if containerRestarted(pod, container.Name) {
+			if restarts := containerRestarts(pod, container.Name); restarts > 0 {
 				// This is only called if the test failed, so we cannot mark it as "failed" again. Instead, output
 				// a log which will get highlighted in the test logs
 				// TODO proper analysis of restarts to ensure we do not miss crashes when tests still pass.
-				scopes.Framework.Errorf("FAIL: pod %v/%v restarted", pod.Name, pod.Namespace)
+				scopes.Framework.Errorf("FAIL: pod %v/%v restarted %d times", pod.Name, pod.Namespace, restarts)
 				l, err := c.PodLogs(context.TODO(), pod.Name, pod.Namespace, container.Name, true /* previousLog */)
 				if err != nil {
 					scopes.Framework.Warnf("Unable to get previous logs for pod/container: %s/%s/%s", pod.Namespace, pod.Name, container.Name)

--- a/tests/integration/pilot/ingress_test.go
+++ b/tests/integration/pilot/ingress_test.go
@@ -260,7 +260,7 @@ spec:
 
 			ctx.NewSubTest("status").Run(func(ctx framework.TestContext) {
 				if !ctx.Environment().(*kube.Environment).Settings().LoadBalancerSupported {
-					t.Skip("ingress status not supported without load balancer")
+					ctx.Skip("ingress status not supported without load balancer")
 				}
 
 				ip := apps.Ingress.HTTPAddress().IP.String()


### PR DESCRIPTION
This adds assertions that will panic at runtime to pilot. These will be
used only for development and are intended to never be enabled in
production clusters.

The first usage of this, implemented in this PR, is to ensure that our
cache eviction works properly. This is done by disabling the cache when
assertions are enabled, and ensuring all updates are NOP changes.

Motivations:
* Recently had a cache eviction bug that may have been caught by this
* I am hoping to add more caching soon, which I would look to test using
this
* For the Delta XDS work, we need to add logic to detect if a resource
change will impact XDS. This is a perfect usage to test, as we can
assert that our detection logic matches the actual XDS change.
* This found a bunch of bugs in this PR already

In addition, this includes a few fixes:
* Stable endpoint ordering for multicluster
* Ensure we don't have out of order cache writes

I can split these out into another PR if desired, although its helpful to have the test + the fix in the same PR?