### PR TITLE
Add analyzer for webhook issues

### DIFF
--- a/galley/pkg/config/analysis/analyzers/all.go
+++ b/galley/pkg/config/analysis/analyzers/all.go
@@ -29,6 +29,7 @@ import (
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/serviceentry"
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/sidecar"
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/virtualservice"
+	"istio.io/istio/galley/pkg/config/analysis/analyzers/webhook"
 )
 
 // All returns all analyzers
@@ -56,6 +57,7 @@ func All() []analysis.Analyzer {
 		&virtualservice.MatchesAnalyzer{},
 		&destinationrule.CaCertificateAnalyzer{},
 		&serviceentry.ProtocolAdressesAnalyzer{},
+		&webhook.Analyzer{},
 	}
 
 	analyzers = append(analyzers, schema.AllValidationAnalyzers()...)

--- a/galley/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_test.go
@@ -37,6 +37,7 @@ import (
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/serviceentry"
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/sidecar"
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/virtualservice"
+	"istio.io/istio/galley/pkg/config/analysis/analyzers/webhook"
 	"istio.io/istio/galley/pkg/config/analysis/diag"
 	"istio.io/istio/galley/pkg/config/analysis/local"
 	"istio.io/istio/galley/pkg/config/analysis/msg"
@@ -457,6 +458,18 @@ var testGrid = []testCase{
 			{msg.GatewayDuplicateCertificate, "Gateway gateway-02-test-01.istio-system"},
 			{msg.GatewayDuplicateCertificate, "Gateway gateway-01-test-02.istio-system"},
 			{msg.GatewayDuplicateCertificate, "Gateway gateway-01-test-03.default"},
+		},
+	},
+	{
+		name: "webook",
+		inputFiles: []string{
+			"testdata/webhook.yaml",
+		},
+		analyzer: &webhook.Analyzer{},
+		expected: []message{
+			{msg.InvalidWebhook, "MutatingWebhookConfiguration istio-sidecar-injector-missing-overlap"},
+			{msg.InvalidWebhook, "MutatingWebhookConfiguration istio-sidecar-injector-missing-overlap"},
+			{msg.InvalidWebhook, "MutatingWebhookConfiguration istio-sidecar-injector-overlap"},
 		},
 	},
 }

--- a/galley/pkg/config/analysis/analyzers/testdata/webhook.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/webhook.yaml
@@ -1,0 +1,38 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: istio-sidecar-injector-missing-overlap
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: fake
+      namespace: istio-system
+  name: sidecar-injector.istio.io
+  namespaceSelector:
+    matchLabels:
+      istio-injection: enabled
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: istio-sidecar-injector-overlap
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: istiod
+      namespace: istio-system
+  name: sidecar-injector.istio.io
+  namespaceSelector:
+    matchLabels:
+      istio-injection: enabled
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: istiod
+  namespace: istio-system
+spec: {}

--- a/galley/pkg/config/analysis/analyzers/webhook/webhook.go
+++ b/galley/pkg/config/analysis/analyzers/webhook/webhook.go
@@ -1,3 +1,17 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package webhook
 
 import (

--- a/galley/pkg/config/analysis/analyzers/webhook/webhook.go
+++ b/galley/pkg/config/analysis/analyzers/webhook/webhook.go
@@ -142,21 +142,25 @@ func extractRevisions(wh *v1.MutatingWebhookConfiguration) []string {
 		revs.Insert(r)
 	}
 	for _, webhook := range wh.Webhooks {
-		if r, f := webhook.NamespaceSelector.MatchLabels[label.IoIstioRev.Name]; f {
-			revs.Insert(r)
+		if webhook.NamespaceSelector != nil {
+			if r, f := webhook.NamespaceSelector.MatchLabels[label.IoIstioRev.Name]; f {
+				revs.Insert(r)
+			}
 		}
-		if r, f := webhook.ObjectSelector.MatchLabels[label.IoIstioRev.Name]; f {
-			revs.Insert(r)
-		}
-
 		for _, ls := range webhook.NamespaceSelector.MatchExpressions {
 			if ls.Key == label.IoIstioRev.Name {
 				revs.Insert(ls.Values...)
 			}
 		}
-		for _, ls := range webhook.ObjectSelector.MatchExpressions {
-			if ls.Key == label.IoIstioRev.Name {
-				revs.Insert(ls.Values...)
+		if webhook.ObjectSelector != nil {
+			if r, f := webhook.ObjectSelector.MatchLabels[label.IoIstioRev.Name]; f {
+				revs.Insert(r)
+			}
+
+			for _, ls := range webhook.ObjectSelector.MatchExpressions {
+				if ls.Key == label.IoIstioRev.Name {
+					revs.Insert(ls.Values...)
+				}
 			}
 		}
 	}

--- a/galley/pkg/config/analysis/analyzers/webhook/webhook.go
+++ b/galley/pkg/config/analysis/analyzers/webhook/webhook.go
@@ -135,7 +135,7 @@ func (a *Analyzer) Analyze(context analysis.Context) {
 				resource.LocalName(wh.ClientConfig.Service.Name))
 			if !context.Exists(serviceCol, fname) {
 				context.Report(webhookCol, msg.NewInvalidWebhook(resources[fmt.Sprintf("%v/%v", name, wh.Name)],
-					fmt.Sprintf("Webhook refers to a service that does not exist: %v.", fname)))
+					fmt.Sprintf("Injector refers to a control plane service that does not exist: %v.", fname)))
 			}
 		}
 	}

--- a/galley/pkg/config/analysis/analyzers/webhook/webhook.go
+++ b/galley/pkg/config/analysis/analyzers/webhook/webhook.go
@@ -192,23 +192,3 @@ func selectorMatches(selector *metav1.LabelSelector, labels klabels.Set) bool {
 	}
 	return s.Matches(labels)
 }
-
-//
-//func (a *Analyzer) analyzeProtocolAddresses(resource *resource.Instance, context analysis.Context) {
-//	se := resource.Message.(*v1alpha3.ServiceEntry)
-//
-//	if se.Addresses == nil {
-//		for index, port := range se.Ports {
-//			if port.Protocol == "" || port.Protocol == "TCP" {
-//				message := msg.NewServiceEntryAddressesRequired(resource)
-//
-//				if line, ok := util.ErrorLine(resource, fmt.Sprintf(util.ServiceEntryPort, index)); ok {
-//					message.Line = line
-//				}
-//
-//				context.Report(collections.IstioNetworkingV1Alpha3Serviceentries.Name(), message)
-//			}
-//		}
-//	}
-//}
-//

--- a/galley/pkg/config/analysis/analyzers/webhook/webhook.go
+++ b/galley/pkg/config/analysis/analyzers/webhook/webhook.go
@@ -1,0 +1,50 @@
+package webhook
+
+import (
+	"istio.io/pkg/log"
+
+	"istio.io/istio/galley/pkg/config/analysis"
+	"istio.io/istio/pkg/config/resource"
+	"istio.io/istio/pkg/config/schema/collection"
+	"istio.io/istio/pkg/config/schema/collections"
+)
+
+type Analyzer struct{}
+
+var _ analysis.Analyzer = &Analyzer{}
+
+func (a *Analyzer) Metadata() analysis.Metadata {
+	return analysis.Metadata{
+		Name:        "webhook.Analyzer",
+		Description: "Checks the validity of Istio webhooks",
+		Inputs: collection.Names{
+			collections.K8SAdmissionregistrationK8SIoV1Mutatingwebhookconfigurations.Name(),
+		},
+	}
+}
+
+func (a *Analyzer) Analyze(context analysis.Context) {
+	context.ForEach(collections.K8SAdmissionregistrationK8SIoV1Mutatingwebhookconfigurations.Name(), func(resource *resource.Instance) bool {
+		log.Errorf("howardjohn: analyzed %v", resource.Metadata.FullName)
+		return true
+	})
+}
+//
+//func (a *Analyzer) analyzeProtocolAddresses(resource *resource.Instance, context analysis.Context) {
+//	se := resource.Message.(*v1alpha3.ServiceEntry)
+//
+//	if se.Addresses == nil {
+//		for index, port := range se.Ports {
+//			if port.Protocol == "" || port.Protocol == "TCP" {
+//				message := msg.NewServiceEntryAddressesRequired(resource)
+//
+//				if line, ok := util.ErrorLine(resource, fmt.Sprintf(util.ServiceEntryPort, index)); ok {
+//					message.Line = line
+//				}
+//
+//				context.Report(collections.IstioNetworkingV1Alpha3Serviceentries.Name(), message)
+//			}
+//		}
+//	}
+//}
+//

--- a/galley/pkg/config/analysis/analyzers/webhook/webhook.go
+++ b/galley/pkg/config/analysis/analyzers/webhook/webhook.go
@@ -1,12 +1,25 @@
 package webhook
 
 import (
-	"istio.io/pkg/log"
+	"fmt"
+	"strings"
 
+	v1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	klabels "k8s.io/apimachinery/pkg/labels"
+
+	"istio.io/api/label"
 	"istio.io/istio/galley/pkg/config/analysis"
+	"istio.io/istio/galley/pkg/config/analysis/msg"
+	"istio.io/istio/pilot/pkg/util/sets"
 	"istio.io/istio/pkg/config/resource"
 	"istio.io/istio/pkg/config/schema/collection"
 	"istio.io/istio/pkg/config/schema/collections"
+)
+
+var (
+	webhookCol = collections.K8SAdmissionregistrationK8SIoV1Mutatingwebhookconfigurations.Name()
+	serviceCol = collections.K8SCoreV1Services.Name()
 )
 
 type Analyzer struct{}
@@ -18,17 +31,150 @@ func (a *Analyzer) Metadata() analysis.Metadata {
 		Name:        "webhook.Analyzer",
 		Description: "Checks the validity of Istio webhooks",
 		Inputs: collection.Names{
-			collections.K8SAdmissionregistrationK8SIoV1Mutatingwebhookconfigurations.Name(),
+			webhookCol,
+			serviceCol,
 		},
 	}
 }
 
+func getNamespaceLabels() []klabels.Set {
+	return []klabels.Set{
+		{},
+		{"istio-injection": "enabled"},
+		{"istio-injection": "disabled"},
+	}
+}
+
+func getObjectLabels() []klabels.Set {
+	return []klabels.Set{
+		{},
+		{"sidecar.istio.io/inject": "true"},
+		{"sidecar.istio.io/inject": "false"},
+	}
+}
+
 func (a *Analyzer) Analyze(context analysis.Context) {
-	context.ForEach(collections.K8SAdmissionregistrationK8SIoV1Mutatingwebhookconfigurations.Name(), func(resource *resource.Instance) bool {
-		log.Errorf("howardjohn: analyzed %v", resource.Metadata.FullName)
+	// First, extract and index all webhooks we found
+	webhooks := map[string][]v1.MutatingWebhook{}
+	resources := map[string]*resource.Instance{}
+	revisions := sets.NewSet()
+	context.ForEach(webhookCol, func(resource *resource.Instance) bool {
+		wh := resource.Message.(*v1.MutatingWebhookConfiguration)
+		revs := extractRevisions(wh)
+		if len(revs) == 0 && !isIstioWebhook(wh) {
+			return true
+		}
+		webhooks[resource.Metadata.FullName.String()] = wh.Webhooks
+		for _, h := range wh.Webhooks {
+			resources[fmt.Sprintf("%v/%v", resource.Metadata.FullName.String(), h.Name)] = resource
+		}
+		revisions.Insert(revs...)
 		return true
 	})
+
+	// Set up all relevant namespace and object selector permutations
+	namespaceLabels := getNamespaceLabels()
+	for rev := range revisions {
+		for _, base := range getNamespaceLabels() {
+			base[label.IoIstioRev.Name] = rev
+			namespaceLabels = append(namespaceLabels, base)
+		}
+	}
+	objectLabels := getObjectLabels()
+	for rev := range revisions {
+		for _, base := range getObjectLabels() {
+			base[label.IoIstioRev.Name] = rev
+			objectLabels = append(objectLabels, base)
+		}
+	}
+
+	// For each permutation, we check which webhooks it matches. It must match exactly 0 or 1!
+	for _, nl := range namespaceLabels {
+		for _, ol := range objectLabels {
+			matches := sets.NewSet()
+			for name, whs := range webhooks {
+				for _, wh := range whs {
+					if selectorMatches(wh.NamespaceSelector, nl) && selectorMatches(wh.ObjectSelector, ol) {
+						matches.Insert(fmt.Sprintf("%v/%v", name, wh.Name))
+					}
+				}
+			}
+			if len(matches) > 1 {
+				for match := range matches {
+					others := matches.Difference(sets.NewSet(match))
+					context.Report(webhookCol, msg.NewInvalidWebhook(resources[match],
+						fmt.Sprintf("Webhook overlaps with others: %v. This may cause injection to occur twice.", others.UnsortedList())))
+				}
+			}
+		}
+	}
+
+	// Next, check service references
+	for name, whs := range webhooks {
+		for _, wh := range whs {
+			if wh.ClientConfig.Service == nil {
+				// it is an url, skip it
+				continue
+			}
+			fname := resource.NewFullName(
+				resource.Namespace(wh.ClientConfig.Service.Namespace),
+				resource.LocalName(wh.ClientConfig.Service.Name))
+			if !context.Exists(serviceCol, fname) {
+				context.Report(webhookCol, msg.NewInvalidWebhook(resources[fmt.Sprintf("%v/%v", name, wh.Name)],
+					fmt.Sprintf("Webhook refers to a service that does not exist: %v.", fname)))
+			}
+		}
+	}
 }
+
+func isIstioWebhook(wh *v1.MutatingWebhookConfiguration) bool {
+	for _, w := range wh.Webhooks {
+		if strings.HasSuffix(w.Name, "istio.io") {
+			return true
+		}
+	}
+	return false
+}
+
+func extractRevisions(wh *v1.MutatingWebhookConfiguration) []string {
+	revs := sets.NewSet()
+	if r, f := wh.Labels[label.IoIstioRev.Name]; f {
+		revs.Insert(r)
+	}
+	for _, webhook := range wh.Webhooks {
+		if r, f := webhook.NamespaceSelector.MatchLabels[label.IoIstioRev.Name]; f {
+			revs.Insert(r)
+		}
+		if r, f := webhook.ObjectSelector.MatchLabels[label.IoIstioRev.Name]; f {
+			revs.Insert(r)
+		}
+
+		for _, ls := range webhook.NamespaceSelector.MatchExpressions {
+			if ls.Key == label.IoIstioRev.Name {
+				revs.Insert(ls.Values...)
+			}
+		}
+		for _, ls := range webhook.ObjectSelector.MatchExpressions {
+			if ls.Key == label.IoIstioRev.Name {
+				revs.Insert(ls.Values...)
+			}
+		}
+	}
+	return revs.UnsortedList()
+}
+
+func selectorMatches(selector *metav1.LabelSelector, labels klabels.Set) bool {
+	// From webhook spec: "Default to the empty LabelSelector, which matches everything."
+	if selector == nil {
+		return true
+	}
+	s, err := metav1.LabelSelectorAsSelector(selector)
+	if err != nil {
+		return false
+	}
+	return s.Matches(labels)
+}
+
 //
 //func (a *Analyzer) analyzeProtocolAddresses(resource *resource.Instance, context analysis.Context) {
 //	se := resource.Message.(*v1alpha3.ServiceEntry)

--- a/galley/pkg/config/analysis/msg/messages.gen.go
+++ b/galley/pkg/config/analysis/msg/messages.gen.go
@@ -150,7 +150,7 @@ var (
 	GatewayDuplicateCertificate = diag.NewMessageType(diag.Warning, "IST0138", "Duplicate certificate in multiple gateways %v may cause 404s if clients re-use HTTP2 connections.")
 
 	// InvalidWebhook defines a diag.MessageType for message "InvalidWebhook".
-	// Description: Webhook is invalid
+	// Description: Webhook is invalid or references a control plane service that does not exist.
 	InvalidWebhook = diag.NewMessageType(diag.Error, "IST0139", "%v")
 )
 

--- a/galley/pkg/config/analysis/msg/messages.gen.go
+++ b/galley/pkg/config/analysis/msg/messages.gen.go
@@ -148,6 +148,10 @@ var (
 	// GatewayDuplicateCertificate defines a diag.MessageType for message "GatewayDuplicateCertificate".
 	// Description: Duplicate certificate in multiple gateways may cause 404s if clients re-use HTTP2 connections.
 	GatewayDuplicateCertificate = diag.NewMessageType(diag.Warning, "IST0138", "Duplicate certificate in multiple gateways %v may cause 404s if clients re-use HTTP2 connections.")
+
+	// InvalidWebhook defines a diag.MessageType for message "InvalidWebhook".
+	// Description: Webhook is invalid
+	InvalidWebhook = diag.NewMessageType(diag.Error, "IST0139", "%v")
 )
 
 // All returns a list of all known message types.
@@ -188,6 +192,7 @@ func All() []*diag.MessageType {
 		AlphaAnnotation,
 		DeploymentConflictingPorts,
 		GatewayDuplicateCertificate,
+		InvalidWebhook,
 	}
 }
 
@@ -541,5 +546,14 @@ func NewGatewayDuplicateCertificate(r *resource.Instance, gateways []string) dia
 		GatewayDuplicateCertificate,
 		r,
 		gateways,
+	)
+}
+
+// NewInvalidWebhook returns a new diag.Message based on InvalidWebhook.
+func NewInvalidWebhook(r *resource.Instance, error string) diag.Message {
+	return diag.NewMessage(
+		InvalidWebhook,
+		r,
+		error,
 	)
 }

--- a/galley/pkg/config/analysis/msg/messages.yaml
+++ b/galley/pkg/config/analysis/msg/messages.yaml
@@ -400,7 +400,7 @@ messages:
   - name: "InvalidWebhook"
     code: IST0139
     level: Error
-    description: "Webhook is invalid"
+    description: "Webhook is invalid or references a control plane service that does not exist."
     template: "%v"
     args:
       - name: error

--- a/galley/pkg/config/analysis/msg/messages.yaml
+++ b/galley/pkg/config/analysis/msg/messages.yaml
@@ -396,3 +396,12 @@ messages:
     args:
       - name: gateways
         type: "[]string"
+
+  - name: "InvalidWebhook"
+    code: IST0139
+    level: Error
+    description: "Webhook is invalid"
+    template: "%v"
+    args:
+      - name: error
+        type: string

--- a/pkg/config/schema/collections/collections.gen.go
+++ b/pkg/config/schema/collections/collections.gen.go
@@ -7,6 +7,7 @@ package collections
 import (
 	"reflect"
 
+	k8sioapiadmissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	k8sioapiappsv1 "k8s.io/api/apps/v1"
 	k8sioapicorev1 "k8s.io/api/core/v1"
 	k8sioapiextensionsv1beta1 "k8s.io/api/extensions/v1beta1"
@@ -268,6 +269,26 @@ var (
 			ProtoPackage: "istio.io/api/security/v1beta1", StatusPackage: "istio.io/api/meta/v1alpha1",
 			ClusterScoped: false,
 			ValidateProto: validation.ValidateRequestAuthentication,
+		}.MustBuild(),
+	}.MustBuild()
+
+	// K8SAdmissionregistrationK8SIoV1Mutatingwebhookconfigurations describes
+	// the collection
+	// k8s/admissionregistration.k8s.io/v1/mutatingwebhookconfigurations
+	K8SAdmissionregistrationK8SIoV1Mutatingwebhookconfigurations = collection.Builder{
+		Name:         "k8s/admissionregistration.k8s.io/v1/mutatingwebhookconfigurations",
+		VariableName: "K8SAdmissionregistrationK8SIoV1Mutatingwebhookconfigurations",
+		Disabled:     false,
+		Resource: resource.Builder{
+			Group:         "admissionregistration.k8s.io",
+			Kind:          "MutatingWebhookConfiguration",
+			Plural:        "MutatingWebhookConfigurations",
+			Version:       "v1",
+			Proto:         "k8s.io.api.admissionregistration.v1.MutatingWebhookConfiguration",
+			ReflectType:   reflect.TypeOf(&k8sioapiadmissionregistrationv1.MutatingWebhookConfiguration{}).Elem(),
+			ProtoPackage:  "k8s.io/api/admissionregistration/v1",
+			ClusterScoped: false,
+			ValidateProto: validation.EmptyValidate,
 		}.MustBuild(),
 	}.MustBuild()
 
@@ -791,6 +812,7 @@ var (
 		MustAdd(IstioSecurityV1Beta1Authorizationpolicies).
 		MustAdd(IstioSecurityV1Beta1Peerauthentications).
 		MustAdd(IstioSecurityV1Beta1Requestauthentications).
+		MustAdd(K8SAdmissionregistrationK8SIoV1Mutatingwebhookconfigurations).
 		MustAdd(K8SApiextensionsK8SIoV1Customresourcedefinitions).
 		MustAdd(K8SAppsV1Deployments).
 		MustAdd(K8SCoreV1Configmaps).
@@ -839,6 +861,7 @@ var (
 
 	// Kube contains only kubernetes collections.
 	Kube = collection.NewSchemasBuilder().
+		MustAdd(K8SAdmissionregistrationK8SIoV1Mutatingwebhookconfigurations).
 		MustAdd(K8SApiextensionsK8SIoV1Customresourcedefinitions).
 		MustAdd(K8SAppsV1Deployments).
 		MustAdd(K8SCoreV1Configmaps).

--- a/pkg/config/schema/gvk/resources.gen.go
+++ b/pkg/config/schema/gvk/resources.gen.go
@@ -23,6 +23,7 @@ var (
 	Ingress = config.GroupVersionKind{Group: "extensions", Version: "v1beta1", Kind: "Ingress"}
 	MeshConfig = config.GroupVersionKind{Group: "", Version: "v1alpha1", Kind: "MeshConfig"}
 	MeshNetworks = config.GroupVersionKind{Group: "", Version: "v1alpha1", Kind: "MeshNetworks"}
+	MutatingWebhookConfiguration = config.GroupVersionKind{Group: "admissionregistration.k8s.io", Version: "v1", Kind: "MutatingWebhookConfiguration"}
 	Namespace = config.GroupVersionKind{Group: "", Version: "v1", Kind: "Namespace"}
 	Node = config.GroupVersionKind{Group: "", Version: "v1", Kind: "Node"}
 	PeerAuthentication = config.GroupVersionKind{Group: "security.istio.io", Version: "v1beta1", Kind: "PeerAuthentication"}

--- a/pkg/config/schema/metadata.gen.go
+++ b/pkg/config/schema/metadata.gen.go
@@ -145,6 +145,10 @@ collections:
     kind: "CustomResourceDefinition"
     group: "apiextensions.k8s.io"
 
+  - name: "k8s/admissionregistration.k8s.io/v1/mutatingwebhookconfigurations"
+    kind: "MutatingWebhookConfiguration"
+    group: "admissionregistration.k8s.io"
+
   - name: "k8s/apps/v1/deployments"
     kind: "Deployment"
     group: "apps"
@@ -285,6 +289,7 @@ snapshots:
       - "istio/networking/v1alpha3/virtualservices"
       - "istio/security/v1beta1/authorizationpolicies"
       - "k8s/apiextensions.k8s.io/v1/customresourcedefinitions"
+      - "k8s/admissionregistration.k8s.io/v1/mutatingwebhookconfigurations"
       - "k8s/apps/v1/deployments"
       - "k8s/core/v1/namespaces"
       - "k8s/core/v1/pods"
@@ -301,6 +306,13 @@ resources:
     version: "v1"
     proto: "k8s.io.apiextensions_apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinition"
     protoPackage: "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+
+  - kind: "MutatingWebhookConfiguration"
+    plural: "MutatingWebhookConfigurations"
+    group: "admissionregistration.k8s.io"
+    version: "v1"
+    proto: "k8s.io.api.admissionregistration.v1.MutatingWebhookConfiguration"
+    protoPackage: "k8s.io/api/admissionregistration/v1"
 
   - kind: "Deployment"
     plural: "Deployments"
@@ -551,6 +563,7 @@ transforms:
   - type: direct
     mapping:
       "k8s/apiextensions.k8s.io/v1/customresourcedefinitions": "k8s/apiextensions.k8s.io/v1/customresourcedefinitions"
+      "k8s/admissionregistration.k8s.io/v1/mutatingwebhookconfigurations": "k8s/admissionregistration.k8s.io/v1/mutatingwebhookconfigurations"
       "k8s/networking.istio.io/v1alpha3/destinationrules": "istio/networking/v1alpha3/destinationrules"
       "k8s/networking.istio.io/v1alpha3/envoyfilters": "istio/networking/v1alpha3/envoyfilters"
       "k8s/networking.istio.io/v1alpha3/gateways": "istio/networking/v1alpha3/gateways"

--- a/pkg/config/schema/metadata.yaml
+++ b/pkg/config/schema/metadata.yaml
@@ -90,6 +90,10 @@ collections:
     kind: "CustomResourceDefinition"
     group: "apiextensions.k8s.io"
 
+  - name: "k8s/admissionregistration.k8s.io/v1/mutatingwebhookconfigurations"
+    kind: "MutatingWebhookConfiguration"
+    group: "admissionregistration.k8s.io"
+
   - name: "k8s/apps/v1/deployments"
     kind: "Deployment"
     group: "apps"
@@ -230,6 +234,7 @@ snapshots:
       - "istio/networking/v1alpha3/virtualservices"
       - "istio/security/v1beta1/authorizationpolicies"
       - "k8s/apiextensions.k8s.io/v1/customresourcedefinitions"
+      - "k8s/admissionregistration.k8s.io/v1/mutatingwebhookconfigurations"
       - "k8s/apps/v1/deployments"
       - "k8s/core/v1/namespaces"
       - "k8s/core/v1/pods"
@@ -246,6 +251,13 @@ resources:
     version: "v1"
     proto: "k8s.io.apiextensions_apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinition"
     protoPackage: "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+
+  - kind: "MutatingWebhookConfiguration"
+    plural: "MutatingWebhookConfigurations"
+    group: "admissionregistration.k8s.io"
+    version: "v1"
+    proto: "k8s.io.api.admissionregistration.v1.MutatingWebhookConfiguration"
+    protoPackage: "k8s.io/api/admissionregistration/v1"
 
   - kind: "Deployment"
     plural: "Deployments"
@@ -496,6 +508,7 @@ transforms:
   - type: direct
     mapping:
       "k8s/apiextensions.k8s.io/v1/customresourcedefinitions": "k8s/apiextensions.k8s.io/v1/customresourcedefinitions"
+      "k8s/admissionregistration.k8s.io/v1/mutatingwebhookconfigurations": "k8s/admissionregistration.k8s.io/v1/mutatingwebhookconfigurations"
       "k8s/networking.istio.io/v1alpha3/destinationrules": "istio/networking/v1alpha3/destinationrules"
       "k8s/networking.istio.io/v1alpha3/envoyfilters": "istio/networking/v1alpha3/envoyfilters"
       "k8s/networking.istio.io/v1alpha3/gateways": "istio/networking/v1alpha3/gateways"

--- a/releasenotes/notes/webhook-analyzer.yaml
+++ b/releasenotes/notes/webhook-analyzer.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: istioctl
+releaseNotes:
+- |
+  **Added** a new analyzer for invalid webhook configurations.

--- a/tests/integration/pilot/validation_test.go
+++ b/tests/integration/pilot/validation_test.go
@@ -147,6 +147,7 @@ var ignoredCRDs = []string{
 	"/v1/Service",
 	"/v1/ConfigMap",
 	"apiextensions.k8s.io/v1/CustomResourceDefinition",
+	"admissionregistration.k8s.io/v1/MutatingWebhookConfiguration",
 	"apps/v1/Deployment",
 	"extensions/v1beta1/Ingress",
 }


### PR DESCRIPTION
This adds an analyzer for mutating webhooks. This checks 2 things:
* referenced Services exist. This is important if someone partially deletes a revision or otherwise misconfigures the webhooks
* Webhooks do not overlap. This could occur if someone set things up incorrectly (setting multiple revisions as "auto inject", etc)

There is a lot of extra stuff to add reading webhooks to the analyzer; today it doesn't read them at all.