### PR TITLE
istioctl verify-install: add revision shortcut

### DIFF
--- a/istioctl/pkg/clioptions/control_plane.go
+++ b/istioctl/pkg/clioptions/control_plane.go
@@ -25,6 +25,6 @@ type ControlPlaneOptions struct {
 // AttachControlPlaneFlags attaches control-plane flags to a Cobra command.
 // (Currently just --revision)
 func (o *ControlPlaneOptions) AttachControlPlaneFlags(cmd *cobra.Command) {
-	cmd.PersistentFlags().StringVar(&o.Revision, "revision", "",
+	cmd.PersistentFlags().StringVarP(&o.Revision, "revision", "r", "",
 		"Control plane revision")
 }

--- a/istioctl/pkg/install/verify.go
+++ b/istioctl/pkg/install/verify.go
@@ -63,7 +63,10 @@ istioctl experimental precheck.
   istioctl verify-install -f $HOME/istio.yaml
 
   # Verify the deployment matches the Istio Operator deployment definition
-  istioctl verify-install --revision <canary>`,
+  istioctl verify-install --revision <canary>
+
+  # Verify the installation of specific revision
+  istioctl verify-install -r 1-9-0`,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(filenames) > 0 && opts.Revision != "" {
 				cmd.Println(cmd.UsageString())


### PR DESCRIPTION
Before:
```
$ istioctl verify-install -r 1-10-0
Error: unknown shorthand flag: 'r' in -r
```

After:
```
$ istioctl verify-install -r 1-10-0
✔ ClusterRole: istiod-istio-system.istio-system checked successfully
✔ ClusterRole: istio-reader-istio-system.istio-system checked successfully
...
Checked 12 custom resource definitions
Checked 2 Istio Deployments
✔ Istio is installed and verified successfully
```