### PR TITLE
add connections debug interface

### DIFF
--- a/pilot/pkg/xds/debug.go
+++ b/pilot/pkg/xds/debug.go
@@ -96,6 +96,7 @@ type AdsClient struct {
 
 // AdsClients is collection of AdsClient connected to this Istiod.
 type AdsClients struct {
+	Total     int         `json:"totalClients"`
 	Connected []AdsClient `json:"clients"`
 }
 
@@ -180,6 +181,7 @@ func (s *DiscoveryServer) AddDebugHandlers(mux *http.ServeMux, enableProfiling b
 	s.addDebugHandler(mux, "/debug/config_dump", "ConfigDump in the form of the Envoy admin config dump API for passed in proxyID", s.ConfigDump)
 	s.addDebugHandler(mux, "/debug/push_status", "Last PushContext Details", s.PushStatusHandler)
 	s.addDebugHandler(mux, "/debug/pushcontext", "Debug support for current push context", s.PushContextHandler)
+	s.addDebugHandler(mux, "/debug/connections", "Info about the connected XDS clients", s.ConnectionsHandler)
 
 	s.addDebugHandler(mux, "/debug/inject", "Active inject template", s.InjectTemplateHandler(webhook))
 	s.addDebugHandler(mux, "/debug/mesh", "Active mesh config", s.MeshHandler)
@@ -458,6 +460,29 @@ func (s *DiscoveryServer) Authorizationz(w http.ResponseWriter, req *http.Reques
 		AuthorizationPolicies: s.globalPushContext().AuthzPolicies,
 	}
 	if b, err := json.MarshalIndent(info, "  ", "  "); err == nil {
+		_, _ = w.Write(b)
+	}
+}
+
+// ConnectionsHandler implements interface for displaying current connections.
+// It is mapped to /debug/connections.
+func (s *DiscoveryServer) ConnectionsHandler(w http.ResponseWriter, req *http.Request) {
+	_ = req.ParseForm()
+	w.Header().Add("Content-Type", "application/json")
+
+	adsClients := &AdsClients{}
+	connections := s.Clients()
+	adsClients.Total = len(connections)
+
+	for _, c := range connections {
+		adsClient := AdsClient{
+			ConnectionID: c.ConID,
+			ConnectedAt:  c.Connect,
+			PeerAddress:  c.PeerAddr,
+		}
+		adsClients.Connected = append(adsClients.Connected, adsClient)
+	}
+	if b, err := json.MarshalIndent(adsClients, "  ", "  "); err == nil {
 		_, _ = w.Write(b)
 	}
 }

--- a/pilot/pkg/xds/debug.go
+++ b/pilot/pkg/xds/debug.go
@@ -499,6 +499,8 @@ func (s *DiscoveryServer) adsz(w http.ResponseWriter, req *http.Request) {
 	}
 
 	adsClients := &AdsClients{}
+	connections := s.Clients()
+	adsClients.Total = len(connections)
 	for _, c := range s.Clients() {
 		adsClient := AdsClient{
 			ConnectionID: c.ConID,

--- a/releasenotes/notes/31075.yaml
+++ b/releasenotes/notes/31075.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: networking
+issue:
+  - 31075
+releaseNotes:
+  - |
+    **Added** /debug/connections debug interface to list the current connected clients.


### PR DESCRIPTION
Currently /adsz interface provides the list of clients along with watches. But it takes a lot of time to load and this is a quick way to get the current connections list

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
