### PR TITLE
lds: cidr equality only checks significant bits

### DIFF
--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -656,7 +656,6 @@ func CidrRangeSliceEqual(a, b []*core.CidrRange) bool {
 		if err != nil {
 			return false
 		}
-		fmt.Println(netA, netB)
 		if netA.IP.String() != netB.IP.String() {
 			return false
 		}

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -648,12 +648,29 @@ func CidrRangeSliceEqual(a, b []*core.CidrRange) bool {
 	}
 
 	for i := range a {
-		if a[i].GetAddressPrefix() != b[i].GetAddressPrefix() || a[i].GetPrefixLen().GetValue() != b[i].GetPrefixLen().GetValue() {
+		netA, err := toIPNet(a[i])
+		if err != nil {
+			return false
+		}
+		netB, err := toIPNet(b[i])
+		if err != nil {
+			return false
+		}
+		fmt.Println(netA, netB)
+		if netA.IP.String() != netB.IP.String() {
 			return false
 		}
 	}
 
 	return true
+}
+
+func toIPNet(c *core.CidrRange) (*net.IPNet, error) {
+	_, cA, err := net.ParseCIDR(c.AddressPrefix + "/" + strconv.Itoa(int(c.PrefixLen.GetValue())))
+	if err != nil {
+		log.Errorf("failed to parse CidrRange %v as IPNet: %v", c, err)
+	}
+	return cA, err
 }
 
 // meshconfig ForwardClientCertDetails and the Envoy config enum are off by 1

--- a/pilot/pkg/networking/util/util_test.go
+++ b/pilot/pkg/networking/util/util_test.go
@@ -1057,6 +1057,26 @@ func TestCidrRangeSliceEqual(t *testing.T) {
 			true,
 		},
 		{
+			"equal cidr with different insignificant bits",
+			[]*core.CidrRange{
+				{
+					AddressPrefix: "1.2.3.4",
+					PrefixLen: &wrappers.UInt32Value{
+						Value: 24,
+					},
+				},
+			},
+			[]*core.CidrRange{
+				{
+					AddressPrefix: "1.2.3.5",
+					PrefixLen: &wrappers.UInt32Value{
+						Value: 24,
+					},
+				},
+			},
+			true,
+		},
+		{
 			"unequal cidr address prefix mismatch",
 			[]*core.CidrRange{
 				{


### PR DESCRIPTION
Partially solves https://github.com/istio/istio/issues/29197. The specific case laid out there has CIDRs that have a different prefix, but the prefix length only includes equal parts.

This will make sure we accurately detect conflicting filter chains. 


