### PR TITLE
Warn service entry which has more than one host specified  simultaneously with address and https port

### DIFF
--- a/pilot/pkg/serviceregistry/serviceentry/conversion.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion.go
@@ -202,7 +202,7 @@ func convertServices(cfg config.Config) []*model.Service {
 						Ports:        svcPorts,
 						Resolution:   resolution,
 						Attributes: model.ServiceAttributes{
-							ServiceRegistry: string(serviceregistry.External),
+							ServiceRegistry: serviceregistry.External,
 							Name:            hostname,
 							Namespace:       cfg.Namespace,
 							ExportTo:        exportTo,
@@ -221,7 +221,7 @@ func convertServices(cfg config.Config) []*model.Service {
 				Ports:        svcPorts,
 				Resolution:   resolution,
 				Attributes: model.ServiceAttributes{
-					ServiceRegistry: string(serviceregistry.External),
+					ServiceRegistry: serviceregistry.External,
 					Name:            hostname,
 					Namespace:       cfg.Namespace,
 					ExportTo:        exportTo,

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -2483,8 +2483,9 @@ var ValidateServiceEntry = registerValidateFunc("ValidateServiceEntry",
 					}
 				}
 				if hasTCPPort && len(serviceEntry.Hosts) > 1 {
-					errs = appendValidation(errs,
-						fmt.Errorf("service entry can not have more than one host specified when address and tcp port set simultaneously"))
+					// TODO: prevent this invalid setting, maybe in 1.11+
+					errs = appendValidation(errs, WrapWarning(fmt.Errorf("service entry can not have more than one host specified "+
+						"simultaneously with address and tcp port")))
 				}
 			}
 		default:

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -3680,7 +3680,7 @@ func TestValidateServiceEntries(t *testing.T) {
 		},
 
 		{
-			name: "discovery type DNS, one host set with IP address and tcp port",
+			name: "discovery type DNS, one host set with IP address and https port",
 			in: networking.ServiceEntry{
 				Hosts:     []string{"httpbin.org"},
 				Addresses: []string{"10.10.10.10"},
@@ -3696,7 +3696,7 @@ func TestValidateServiceEntries(t *testing.T) {
 		},
 
 		{
-			name: "discovery type DNS, multi hosts set with IP address and tcp port",
+			name: "discovery type DNS, multi hosts set with IP address and https port",
 			in: networking.ServiceEntry{
 				Hosts:     []string{"httpbin.org", "wikipedia.org"},
 				Addresses: []string{"10.10.10.10"},

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -3681,6 +3681,38 @@ func TestValidateServiceEntries(t *testing.T) {
 		},
 
 		{
+			name: "discovery type DNS, one host set with IP address and tcp port",
+			in: networking.ServiceEntry{
+				Hosts:     []string{"httpbin.org"},
+				Addresses: []string{"10.10.10.10"},
+				Ports: []*networking.Port{
+					{Number: 80, Protocol: "http", Name: "http-valid1"},
+					{Number: 8080, Protocol: "http", Name: "http-valid2"},
+					{Number: 443, Protocol: "https", Name: "https"},
+				},
+				Resolution: networking.ServiceEntry_DNS,
+			},
+			valid:   true,
+			warning: false,
+		},
+
+		{
+			name: "discovery type DNS, multi hosts set with IP address and tcp port",
+			in: networking.ServiceEntry{
+				Hosts:     []string{"httpbin.org", "wikipedia.org"},
+				Addresses: []string{"10.10.10.10"},
+				Ports: []*networking.Port{
+					{Number: 80, Protocol: "http", Name: "http-valid1"},
+					{Number: 8080, Protocol: "http", Name: "http-valid2"},
+					{Number: 443, Protocol: "https", Name: "https"},
+				},
+				Resolution: networking.ServiceEntry_DNS,
+			},
+			valid:   true,
+			warning: true,
+		},
+
+		{
 			name: "discovery type DNS, IP address set",
 			in: networking.ServiceEntry{
 				Hosts:     []string{"*.google.com"},
@@ -3696,7 +3728,7 @@ func TestValidateServiceEntries(t *testing.T) {
 				Resolution: networking.ServiceEntry_DNS,
 			},
 			valid:   true,
-			warning: true,
+			warning: false,
 		},
 
 		{

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -28,7 +28,6 @@ import (
 	networking "istio.io/api/networking/v1alpha3"
 	security_beta "istio.io/api/security/v1beta1"
 	api "istio.io/api/type/v1beta1"
-
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/constants"


### PR DESCRIPTION

Warn during validation and ignore the address for dns resolution serviceentry .

Fix: #30771


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.