### PR TITLE
pilot: fix TLS headless service requiring unnecessary SNI host

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -1224,7 +1224,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundTCPListenerOptsForPort
 	return true, buildSidecarOutboundTCPTLSFilterChainOpts(listenerOpts.proxy,
 		listenerOpts.push, virtualServices,
 		*destinationCIDR, listenerOpts.service,
-		listenerOpts.port, meshGateway)
+		listenerOpts.bind, listenerOpts.port, meshGateway)
 }
 
 // buildSidecarOutboundListenerForPortOrUDS builds a single listener and

--- a/pilot/pkg/networking/core/v1alpha3/sidecar_simulation_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/sidecar_simulation_test.go
@@ -1090,9 +1090,9 @@ func TestHeadlessServices(t *testing.T) {
 
 		{Address: "1.2.3.4", Port: 82, Protocol: simulation.TCP, HostHeader: "headless.default.svc.cluster.local"},
 
-		// TODO: https://github.com/istio/istio/issues/27677 use short host name
-		{Address: "1.2.3.4", Port: 83, Protocol: simulation.TCP, TLS: simulation.TLS, HostHeader: "headless.default.svc.cluster.local"},
-		{Address: "1.2.3.4", Port: 84, Protocol: simulation.HTTP, TLS: simulation.TLS, HostHeader: "headless.default.svc.cluster.local"},
+		// Use short host name
+		{Address: "1.2.3.4", Port: 83, Protocol: simulation.TCP, TLS: simulation.TLS, HostHeader: "headless.default"},
+		{Address: "1.2.3.4", Port: 84, Protocol: simulation.HTTP, TLS: simulation.TLS, HostHeader: "headless.default"},
 	} {
 		calls = append(calls, simulation.Expect{
 			Name: fmt.Sprintf("%s-%d", call.Protocol, call.Port),

--- a/pilot/pkg/networking/core/v1alpha3/tls.go
+++ b/pilot/pkg/networking/core/v1alpha3/tls.go
@@ -93,7 +93,7 @@ func hashRuntimeTLSMatchPredicates(match *v1alpha3.TLSMatchAttributes) string {
 }
 
 func buildSidecarOutboundTLSFilterChainOpts(node *model.Proxy, push *model.PushContext, destinationCIDR string,
-	service *model.Service, listenPort *model.Port,
+	service *model.Service, bind string, listenPort *model.Port,
 	gateways map[string]bool, configs []config.Config) []*filterChainOpts {
 	if !listenPort.Protocol.IsTLS() {
 		return nil
@@ -175,20 +175,24 @@ func buildSidecarOutboundTLSFilterChainOpts(node *model.Proxy, push *model.PushC
 		if len(push.Mesh.OutboundClusterStatName) != 0 {
 			statPrefix = util.BuildStatPrefix(push.Mesh.OutboundClusterStatName, string(service.Hostname), "", &model.Port{Port: port}, service.Attributes)
 		}
-		// Use the hostname as the SNI value if and only if we do not have a destination VIP or if the destination is a CIDR.
-		// In both cases, the listener will be bound to 0.0.0.0. So SNI match is the only way to distinguish different
-		// target services. If we have a VIP, then we know the destination. There is no need to do a SNI match. It saves us from
-		// having to generate expensive permutations of the host name just like RDS does..
+		// Use the hostname as the SNI value if and only:
+		// 1) if the destination is a CIDR;
+		// 2) or if we have an empty destination VIP (i.e. which we should never get in case some platform adapter improper handlings);
+		// 3) or if the destination is a wildcard destination VIP with the listener bound to the wildcard as well.
+		// In the above cited cases, the listener will be bound to 0.0.0.0. So SNI match is the only way to distinguish different
+		// target services. If we have a VIP, then we know the destination. Or if we do not have an VIP, but have
+		// `PILOT_ENABLE_HEADLESS_SERVICE_POD_LISTENERS` enabled (by default) and applicable to all that's needed, pilot will generate
+		// an outbound listener for each pod in a headless service. There is thus no need to do a SNI match. It saves us from having to
+		// generate expensive permutations of the host name just like RDS does..
 		// NOTE that we cannot have two services with the same VIP as our listener build logic will treat it as a collision and
 		// ignore one of the services.
-		// TODO: https://github.com/istio/istio/issues/27677 reconsider this logic
 		svcListenAddress := service.GetServiceAddressForProxy(node, push)
 		if strings.Contains(svcListenAddress, "/") {
 			// Address is a CIDR, already captured by destinationCIDR parameter.
 			svcListenAddress = ""
 		}
 
-		if len(destinationCIDR) > 0 || len(svcListenAddress) == 0 || svcListenAddress == actualWildcard {
+		if len(destinationCIDR) > 0 || len(svcListenAddress) == 0 || (svcListenAddress == actualWildcard && bind == actualWildcard) {
 			sniHosts = []string{string(service.Hostname)}
 		}
 
@@ -309,7 +313,7 @@ TcpLoop:
 // In the latter case, there is no service associated with this listen port. So we have to account for this
 // missing service throughout this file
 func buildSidecarOutboundTCPTLSFilterChainOpts(node *model.Proxy, push *model.PushContext,
-	configs []config.Config, destinationCIDR string, service *model.Service, listenPort *model.Port,
+	configs []config.Config, destinationCIDR string, service *model.Service, bind string, listenPort *model.Port,
 	gateways map[string]bool) []*filterChainOpts {
 	out := make([]*filterChainOpts, 0)
 	var svcConfigs []config.Config
@@ -320,7 +324,7 @@ func buildSidecarOutboundTCPTLSFilterChainOpts(node *model.Proxy, push *model.Pu
 	}
 
 	out = append(out, buildSidecarOutboundTLSFilterChainOpts(node, push, destinationCIDR, service,
-		listenPort, gateways, svcConfigs)...)
+		bind, listenPort, gateways, svcConfigs)...)
 	out = append(out, buildSidecarOutboundTCPFilterChainOpts(node, push, destinationCIDR, service,
 		listenPort, gateways, svcConfigs)...)
 	return out


### PR DESCRIPTION
TLS statefulsets/headless services with generated listeners bound to specific
endpoint addresses (defaultly enabled by `PILOT_ENABLE_HEADLESS_SERVICE_POD_LISTENERS`)
should not add unnecessary `sniHosts` into TLS matches. The impact is you MUST
call `curl https://svc.ns.svc.cluster.local` and not short names like
`curl https://svc.ns`.

Fixes https://github.com/istio/istio/issues/27677

Signed-off-by: Kailun Qin <kailun.qin@intel.com>

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any changes that may affect Istio users.
