### PR TITLE
remove unnecessary setting for original dst

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -790,16 +790,6 @@ func applyLoadBalancer(c *cluster.Cluster, lb *networking.LoadBalancerSettings, 
 	// Use locality lb settings from load balancer settings if present, else use mesh wide locality lb settings
 	applyLocalityLBSetting(proxy.Locality, c, localityLbSetting)
 
-	// The following order is important. If cluster type has been identified as Original DST since Resolution is PassThrough,
-	// and port is named as redis-xxx we end up creating a cluster with type Original DST and LbPolicy as MAGLEV which would be
-	// rejected by Envoy.
-
-	// Original destination service discovery must be used with the original destination load balancer.
-	if c.GetType() == cluster.Cluster_ORIGINAL_DST {
-		c.LbPolicy = cluster.Cluster_CLUSTER_PROVIDED
-		return
-	}
-
 	// Redis protocol must be defaulted with MAGLEV to benefit from client side sharding.
 	if features.EnableRedisFilter && port != nil && port.Protocol == protocol.Redis {
 		c.LbPolicy = cluster.Cluster_MAGLEV

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -1800,12 +1800,7 @@ func TestApplyLoadBalancer(t *testing.T) {
 		expectedLocalityWeightedConfig bool
 	}{
 		{
-			name:             "lb = nil ORIGINAL_DST discovery type",
-			discoveryType:    cluster.Cluster_ORIGINAL_DST,
-			expectedLbPolicy: cluster.Cluster_CLUSTER_PROVIDED,
-		},
-		{
-			name:             "lb = nil redis protocol",
+			name:             "redis protocol",
 			discoveryType:    cluster.Cluster_EDS,
 			port:             &model.Port{Protocol: protocol.Redis},
 			expectedLbPolicy: cluster.Cluster_MAGLEV,


### PR DESCRIPTION
For original DST cluster, we already handle it in applyTrafficPolicy. This is not needed now

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X ] Does not have any changes that may affect Istio users.
