### PR TITLE
Optimize cluster metadata creation

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -137,7 +137,10 @@ func (cb *ClusterBuilder) applyDestinationRule(c *cluster.Cluster, clusterMode C
 
 		maybeApplyEdsConfig(subsetCluster)
 
-		subsetCluster.Metadata = util.AddSubsetToMetadata(clusterMetadata, subset.Name)
+		// Add the DestinationRule+subsets metadata. Metadata here is generated on a per-cluster
+		// basis in buildDefaultCluster, so we can just insert without a copy.
+		subsetCluster.Metadata = util.AddConfigInfoMetadata(subsetCluster.Metadata, destRule.Meta)
+		util.AddSubsetToMetadata(subsetCluster.Metadata, subset.Name)
 		subsetClusters = append(subsetClusters, subsetCluster)
 	}
 	return subsetClusters

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -414,23 +414,18 @@ func AddConfigInfoMetadata(metadata *core.Metadata, config config.Meta) *core.Me
 	return metadata
 }
 
-// AddSubsetToMetadata will build a new core.Metadata struct containing the
-// subset name supplied. This is used for telemetry reporting. A new core.Metadata
-// is created to prevent modification to shared base Metadata across subsets, etc.
-// This should be called after the initial "istio" metadata has been created for the
-// cluster. If the "istio" metadata field is not already defined, the subset information will
-// not be added (to prevent adding this information where not needed).
-func AddSubsetToMetadata(md *core.Metadata, subset string) *core.Metadata {
-	updatedMeta := &core.Metadata{}
-	proto.Merge(updatedMeta, md)
-	if istioMeta, ok := updatedMeta.FilterMetadata[IstioMetadataKey]; ok {
+// AddSubsetToMetadata will insert the subset name supplied. This should be called after the initial
+// "istio" metadata has been created for the cluster. If the "istio" metadata field is not already
+// defined, the subset information will not be added (to prevent adding this information where not
+// needed). This is used for telemetry reporting.
+func AddSubsetToMetadata(md *core.Metadata, subset string) {
+	if istioMeta, ok := md.FilterMetadata[IstioMetadataKey]; ok {
 		istioMeta.Fields["subset"] = &pstruct.Value{
 			Kind: &pstruct.Value_StringValue{
 				StringValue: subset,
 			},
 		}
 	}
-	return updatedMeta
 }
 
 // IsHTTPFilterChain returns true if the filter chain contains a HTTP connection manager filter

--- a/pilot/pkg/networking/util/util_test.go
+++ b/pilot/pkg/networking/util/util_test.go
@@ -591,7 +591,8 @@ func TestAddSubsetToMetadata(t *testing.T) {
 
 	for _, v := range cases {
 		t.Run(v.name, func(tt *testing.T) {
-			got := AddSubsetToMetadata(v.in, v.subset)
+			AddSubsetToMetadata(v.in, v.subset)
+			got := v.in
 			if diff := cmp.Diff(got, v.want, protocmp.Transform()); diff != "" {
 				tt.Errorf("AddSubsetToMetadata(%v, %s) produced incorrect result:\ngot: %v\nwant: %v\nDiff: %s", v.in, v.subset, got, v.want, diff)
 			}


### PR DESCRIPTION
Metadata creation is massive contributor to pilot CPU utilization.
Currently, building the metadata takes ~15% of pilot CPU. An extra ~10%
is also hidden in MarshalToAny, as marshalling it is super slow as well.

A big chunk of this is in AddSubsetToMetadata. This does a proto.Clone
on the existing metadata. This is pretty wasteful, as we are already
creating a full copy of the metadata when we build the cluster.

Instead of a full copy, we can just insert the subset metadata (along
with the initial DR meta).

Results are 20% improvement in CPU.

```
name                     old time/op        new time/op        delta
ClusterGeneration/tls-6        26.7ms ± 2%        21.3ms ± 1%  -20.26%  (p=0.000 n=9+9)

name                     old kb/msg         new kb/msg         delta
ClusterGeneration/tls-6           813 ± 0%           813 ± 0%     ~     (all equal)

name                     old resources/msg  new resources/msg  delta
ClusterGeneration/tls-6         1.21k ± 0%         1.21k ± 0%     ~     (all equal)

name                     old alloc/op       new alloc/op       delta
ClusterGeneration/tls-6        9.63MB ± 0%        8.21MB ± 0%  -14.75%  (p=0.000 n=10+10)

name                     old allocs/op      new allocs/op      delta
ClusterGeneration/tls-6          152k ± 0%          126k ± 0%  -17.36%  (p=0.000 n=10+10)
```



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.