### PR TITLE
Match inbound cluster logic in prober

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -416,6 +416,10 @@ data:
                   - wait
           {{- end }}
             env:
+            {{- if eq (env "PILOT_ENABLE_INBOUND_PASSTHROUGH" "true") "false" }}
+            - name: REWRITE_PROBE_LEGACY_LOCALHOST_DESTINATION
+              value: "true"
+            {{- end }}
             - name: JWT_POLICY
               value: {{ .Values.global.jwtPolicy }}
             - name: PILOT_CERT_PROVIDER

--- a/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
@@ -211,6 +211,10 @@ spec:
           - wait
   {{- end }}
     env:
+    {{- if eq (env "PILOT_ENABLE_INBOUND_PASSTHROUGH" "true") "false" }}
+    - name: REWRITE_PROBE_LEGACY_LOCALHOST_DESTINATION
+      value: "true"
+    {{- end }}
     - name: JWT_POLICY
       value: {{ .Values.global.jwtPolicy }}
     - name: PILOT_CERT_PROVIDER

--- a/manifests/charts/istiod-remote/files/gen-istiod-remote.yaml
+++ b/manifests/charts/istiod-remote/files/gen-istiod-remote.yaml
@@ -396,6 +396,10 @@ data:
                   - wait
           {{- end }}
             env:
+            {{- if eq (env "PILOT_ENABLE_INBOUND_PASSTHROUGH" "true") "false" }}
+            - name: REWRITE_PROBE_LEGACY_LOCALHOST_DESTINATION
+              value: "true"
+            {{- end }}
             - name: JWT_POLICY
               value: {{ .Values.global.jwtPolicy }}
             - name: PILOT_CERT_PROVIDER

--- a/manifests/charts/istiod-remote/files/injection-template.yaml
+++ b/manifests/charts/istiod-remote/files/injection-template.yaml
@@ -211,6 +211,10 @@ spec:
           - wait
   {{- end }}
     env:
+    {{- if eq (env "PILOT_ENABLE_INBOUND_PASSTHROUGH" "true") "false" }}
+    - name: REWRITE_PROBE_LEGACY_LOCALHOST_DESTINATION
+      value: "true"
+    {{- end }}
     - name: JWT_POLICY
       value: {{ .Values.global.jwtPolicy }}
     - name: PILOT_CERT_PROVIDER

--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -375,7 +375,7 @@ func initStatusServer(ctx context.Context, proxyIPv6 bool, proxyConfig meshconfi
 	prober := kubeAppProberNameVar.Get()
 	statusServer, err := status.NewServer(status.Config{
 		IPv6:           proxyIPv6,
-		PodIp:          instanceIPVar.Get(),
+		PodIP:          instanceIPVar.Get(),
 		AdminPort:      uint16(proxyConfig.ProxyAdminPort),
 		StatusPort:     uint16(proxyConfig.StatusPort),
 		KubeAppProbers: prober,

--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -372,13 +372,10 @@ func extractXDSHeadersFromEnv(config *istio_agent.AgentConfig) {
 }
 
 func initStatusServer(ctx context.Context, proxyIPv6 bool, proxyConfig meshconfig.ProxyConfig) error {
-	localHostAddr := localHostIPv4
-	if proxyIPv6 {
-		localHostAddr = localHostIPv6
-	}
 	prober := kubeAppProberNameVar.Get()
 	statusServer, err := status.NewServer(status.Config{
-		LocalHostAddr:  localHostAddr,
+		IPv6:           proxyIPv6,
+		PodIp:          instanceIPVar.Get(),
 		AdminPort:      uint16(proxyConfig.ProxyAdminPort),
 		StatusPort:     uint16(proxyConfig.StatusPort),
 		KubeAppProbers: prober,

--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -59,6 +59,14 @@ const (
 	// indicates that httpbin container liveness prober port is 8080 and probing path is /hello.
 	// This environment variable should never be set manually.
 	KubeAppProberEnvName = "ISTIO_KUBE_APP_PROBERS"
+
+	localHostIPv4 = "127.0.0.1"
+	localHostIPv6 = "[::1]"
+)
+
+var (
+	upstreamLocalAddressIPv4 = &net.TCPAddr{IP: net.ParseIP("127.0.0.6")}
+	upstreamLocalAddressIPv6 = &net.TCPAddr{IP: net.ParseIP("[::6]")}
 )
 
 var PrometheusScrapingConfig = env.RegisterStringVar("ISTIO_PROMETHEUS_ANNOTATIONS", "", "")
@@ -67,6 +75,9 @@ var (
 	appProberPattern = regexp.MustCompile(`^/app-health/[^/]+/(livez|readyz|startupz)$`)
 
 	promRegistry *prometheus.Registry
+
+	legacyLocalhostProbeDestination = env.RegisterBoolVar("REWRITE_PROBE_LEGACY_LOCALHOST_DESTINATION", false,
+		"If enabled, readiness probes will be sent to 'localhost'. Otherwise, they will be sent to the Pod's IP, matching Kubernetes' behavior.")
 )
 
 // KubeAppProbers holds the information about a Kubernetes pod prober.
@@ -83,24 +94,26 @@ type Prober struct {
 
 // Config for the status server.
 type Config struct {
-	LocalHostAddr string
+	PodIp string
 	// KubeAppProbers is a json with Kubernetes application prober config encoded.
 	KubeAppProbers string
 	NodeType       model.NodeType
 	StatusPort     uint16
 	AdminPort      uint16
+	IPv6           bool
 }
 
 // Server provides an endpoint for handling status probes.
 type Server struct {
-	ready               *ready.Probe
-	prometheus          *PrometheusScrapeConfiguration
-	mutex               sync.RWMutex
-	appKubeProbers      KubeAppProbers
-	appProbeClient      map[string]*http.Client
-	statusPort          uint16
-	lastProbeSuccessful bool
-	envoyStatsPort      int
+	ready                 *ready.Probe
+	prometheus            *PrometheusScrapeConfiguration
+	mutex                 sync.RWMutex
+	appProbersDestination string
+	appKubeProbers        KubeAppProbers
+	appProbeClient        map[string]*http.Client
+	statusPort            uint16
+	lastProbeSuccessful   bool
+	envoyStatsPort        int
 }
 
 func init() {
@@ -120,13 +133,21 @@ func init() {
 
 // NewServer creates a new status server.
 func NewServer(config Config) (*Server, error) {
+	localhost := localHostIPv4
+	if config.IPv6 {
+		localhost = localHostIPv6
+	}
 	s := &Server{
 		statusPort: config.StatusPort,
 		ready: &ready.Probe{
-			LocalHostAddr: config.LocalHostAddr,
+			LocalHostAddr: localhost,
 			AdminPort:     config.AdminPort,
 		},
-		envoyStatsPort: 15090,
+		appProbersDestination: config.PodIp,
+		envoyStatsPort:        15090,
+	}
+	if legacyLocalhostProbeDestination.Get() {
+		s.appProbersDestination = "localhost"
 	}
 
 	// Enable prometheus server if its configured and a sidecar
@@ -173,6 +194,13 @@ func NewServer(config Config) (*Server, error) {
 		if prober.HTTPGet.Port.Type != intstr.Int {
 			return nil, fmt.Errorf("invalid prober config for %v, the port must be int type", path)
 		}
+		localAddr := upstreamLocalAddressIPv4
+		if config.IPv6 {
+			localAddr = upstreamLocalAddressIPv6
+		}
+		d := &net.Dialer{
+			LocalAddr: localAddr,
+		}
 		// Construct a http client and cache it in order to reuse the connection.
 		s.appProbeClient[path] = &http.Client{
 			Timeout: time.Duration(prober.TimeoutSeconds) * time.Second,
@@ -180,6 +208,7 @@ func NewServer(config Config) (*Server, error) {
 			// https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
 			Transport: &http.Transport{
 				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+				DialContext:     d.DialContext,
 			},
 		}
 	}
@@ -485,9 +514,9 @@ func (s *Server) handleAppProbe(w http.ResponseWriter, req *http.Request) {
 	}
 	var url string
 	if prober.HTTPGet.Scheme == apimirror.URISchemeHTTPS {
-		url = fmt.Sprintf("https://localhost:%v%s", prober.HTTPGet.Port.IntValue(), proberPath)
+		url = fmt.Sprintf("https://%s:%v%s", s.appProbersDestination, prober.HTTPGet.Port.IntValue(), proberPath)
 	} else {
-		url = fmt.Sprintf("http://localhost:%v%s", prober.HTTPGet.Port.IntValue(), proberPath)
+		url = fmt.Sprintf("http://%s:%v%s", s.appProbersDestination, prober.HTTPGet.Port.IntValue(), proberPath)
 	}
 	appReq, err := http.NewRequest("GET", url, nil)
 	if err != nil {

--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -94,7 +94,9 @@ type Prober struct {
 
 // Config for the status server.
 type Config struct {
-	PodIp string
+	// Ip of the pod. Note: this is only applicable for Kubernetes pods and should only be used for
+	// the prober.
+	PodIP string
 	// KubeAppProbers is a json with Kubernetes application prober config encoded.
 	KubeAppProbers string
 	NodeType       model.NodeType
@@ -143,7 +145,7 @@ func NewServer(config Config) (*Server, error) {
 			LocalHostAddr: localhost,
 			AdminPort:     config.AdminPort,
 		},
-		appProbersDestination: config.PodIp,
+		appProbersDestination: config.PodIP,
 		envoyStatsPort:        15090,
 	}
 	if legacyLocalhostProbeDestination.Get() {


### PR DESCRIPTION
Design doc:
https://docs.google.com/document/d/1j-5_XpeMTnT9mV_8dbSOeU7rfH-5YNtN_JJFZ2mmQ_w/edit

Currently, k8s sends readiness probes to <POD_IP>. We in turn forward
them to `localhost`. This is not great, since it means applications that
bind to the POD_IP will not work.

We have avoided changing this because of backwards compatibility.
However, with the design above, we are moving forward with this.

This PR makes it so we send to POD_IP by default, but respect the pilot
env var to control this behavior. We need to bind to local addres
127.0.0.6 to avoid our requests going through envoy.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.