### PR TITLE
Fix GetRegistries race

### DIFF
--- a/pilot/pkg/serviceregistry/aggregate/controller.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller.go
@@ -89,7 +89,10 @@ func (c *Controller) GetRegistries() []serviceregistry.Instance {
 	c.storeLock.RLock()
 	defer c.storeLock.RUnlock()
 
-	return c.registries
+	// copy registries to prevent race.
+	out := make([]serviceregistry.Instance, len(c.registries))
+	copy(out, c.registries)
+	return out
 }
 
 // GetRegistryIndex returns the index of a registry

--- a/pilot/pkg/serviceregistry/aggregate/controller.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller.go
@@ -89,9 +89,11 @@ func (c *Controller) GetRegistries() []serviceregistry.Instance {
 	c.storeLock.RLock()
 	defer c.storeLock.RUnlock()
 
-	// copy registries to prevent race.
+	// copy registries to prevent race, no need to deep copy here.
 	out := make([]serviceregistry.Instance, len(c.registries))
-	copy(out, c.registries)
+	for i := range c.registries {
+		out[i] = c.registries[i]
+	}
 	return out
 }
 


### PR DESCRIPTION
Previously, returning slice could conflict with dynamic update.