### PR TITLE
Enable the ecc_signature_algorithm test

### DIFF
--- a/pkg/test/framework/components/istioctl/istioctl.go
+++ b/pkg/test/framework/components/istioctl/istioctl.go
@@ -30,6 +30,8 @@ type Instance interface {
 
 	// InvokeOrFail calls Invoke and fails tests if it returns en err
 	InvokeOrFail(t *testing.T, args []string) (string, string)
+
+	// WaitForConfigs will wait until all passed in config has been distributed
 	WaitForConfigs(defaultNamespace string, configs string) error
 }
 

--- a/pkg/test/framework/components/istioctl/istioctl.go
+++ b/pkg/test/framework/components/istioctl/istioctl.go
@@ -30,6 +30,7 @@ type Instance interface {
 
 	// InvokeOrFail calls Invoke and fails tests if it returns en err
 	InvokeOrFail(t *testing.T, args []string) (string, string)
+	WaitForConfigs(defaultNamespace string, configs string) error
 }
 
 // Config is structured config for the istioctl component

--- a/pkg/test/framework/components/istioctl/kube.go
+++ b/pkg/test/framework/components/istioctl/kube.go
@@ -16,10 +16,12 @@ package istioctl
 
 import (
 	"bytes"
+	"fmt"
 	"strings"
 	"testing"
 
 	"istio.io/istio/istioctl/cmd"
+	"istio.io/istio/pilot/pkg/config/kube/crd"
 
 	"istio.io/istio/pkg/test/framework/components/environment/kube"
 	"istio.io/istio/pkg/test/framework/resource"
@@ -44,6 +46,23 @@ func newKube(ctx resource.Context, config Config) Instance {
 // ID implements resource.Instance
 func (c *kubeComponent) ID() resource.ID {
 	return c.id
+}
+
+func (c *kubeComponent) WaitForConfigs(defaultNamespace string, configs string) error {
+	cfgs, _, err := crd.ParseInputs(configs)
+	if err != nil {
+		return fmt.Errorf("failed to parse input: %v", err)
+	}
+	for _, cfg := range cfgs {
+		ns := cfg.Namespace
+		if ns == "" {
+			ns = defaultNamespace
+		}
+		if _, _, err := c.Invoke([]string{"x", "wait", cfg.GroupVersionKind.Kind, cfg.Name + "." + ns}); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // Invoke implements Instance

--- a/tests/integration/framework/example_test.go
+++ b/tests/integration/framework/example_test.go
@@ -1,3 +1,4 @@
+// +build integ
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/framework/framework_test.go
+++ b/tests/integration/framework/framework_test.go
@@ -1,3 +1,4 @@
+// +build integ
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/galley/analyze_test.go
+++ b/tests/integration/galley/analyze_test.go
@@ -1,3 +1,4 @@
+// +build integ
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/galley/main_test.go
+++ b/tests/integration/galley/main_test.go
@@ -1,3 +1,4 @@
+// +build integ
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/galley/namespace_test.go
+++ b/tests/integration/galley/namespace_test.go
@@ -1,3 +1,4 @@
+// +build integ
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/galley/validation_test.go
+++ b/tests/integration/galley/validation_test.go
@@ -1,3 +1,4 @@
+// +build integ
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/galley/webhook_test.go
+++ b/tests/integration/galley/webhook_test.go
@@ -1,3 +1,4 @@
+// +build integ
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/mixer/check_test.go
+++ b/tests/integration/mixer/check_test.go
@@ -1,3 +1,4 @@
+// +build integ
 //  Copyright Istio Authors
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/mixer/envoy/logs/accesslog_test.go
+++ b/tests/integration/mixer/envoy/logs/accesslog_test.go
@@ -1,3 +1,4 @@
+// +build integ
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/mixer/envoy/metrics/new_metric_test.go
+++ b/tests/integration/mixer/envoy/metrics/new_metric_test.go
@@ -1,3 +1,4 @@
+// +build integ
 //  Copyright Istio Authors
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/mixer/envoy/metrics/scenarios_test.go
+++ b/tests/integration/mixer/envoy/metrics/scenarios_test.go
@@ -1,3 +1,4 @@
+// +build integ
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/mixer/main_test.go
+++ b/tests/integration/mixer/main_test.go
@@ -1,3 +1,4 @@
+// +build integ
 //  Copyright Istio Authors
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/mixer/outboundtrafficpolicy/traffic_allow_any_test.go
+++ b/tests/integration/mixer/outboundtrafficpolicy/traffic_allow_any_test.go
@@ -1,3 +1,4 @@
+// +build integ
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/mixer/outboundtrafficpolicy/traffic_registry_only_test.go
+++ b/tests/integration/mixer/outboundtrafficpolicy/traffic_registry_only_test.go
@@ -1,3 +1,4 @@
+// +build integ
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/mixer/outboundtrafficpolicy/traffic_test.go
+++ b/tests/integration/mixer/outboundtrafficpolicy/traffic_test.go
@@ -1,3 +1,4 @@
+// +build integ
 // Copyright Istio Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/mixer/policy/ratelimiting_test.go
+++ b/tests/integration/mixer/policy/ratelimiting_test.go
@@ -1,3 +1,4 @@
+// +build integ
 //  Copyright Istio Authors
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/mixer/report_test.go
+++ b/tests/integration/mixer/report_test.go
@@ -1,3 +1,4 @@
+// +build integ
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/mixer/telemetry/logs/accesslog_test.go
+++ b/tests/integration/mixer/telemetry/logs/accesslog_test.go
@@ -1,3 +1,4 @@
+// +build integ
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/mixer/telemetry/metrics/new_metric_test.go
+++ b/tests/integration/mixer/telemetry/metrics/new_metric_test.go
@@ -1,3 +1,4 @@
+// +build integ
 //  Copyright Istio Authors
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/mixer/telemetry/metrics/scenarios_test.go
+++ b/tests/integration/mixer/telemetry/metrics/scenarios_test.go
@@ -1,3 +1,4 @@
+// +build integ
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/multicluster/centralistio/main_test.go
+++ b/tests/integration/multicluster/centralistio/main_test.go
@@ -1,3 +1,4 @@
+// +build integ
 //  Copyright Istio Authors
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/multicluster/multimaster/main_test.go
+++ b/tests/integration/multicluster/multimaster/main_test.go
@@ -1,3 +1,4 @@
+// +build integ
 //  Copyright Istio Authors
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/multicluster/remote/main_test.go
+++ b/tests/integration/multicluster/remote/main_test.go
@@ -1,3 +1,4 @@
+// +build integ
 //  Copyright Istio Authors
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/operator/main_test.go
+++ b/tests/integration/operator/main_test.go
@@ -1,3 +1,4 @@
+// +build integ
 //  Copyright Istio Authors
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/operator/switch_cr_test.go
+++ b/tests/integration/operator/switch_cr_test.go
@@ -1,3 +1,4 @@
+// +build integ
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/pilot/analysis/analysis_test.go
+++ b/tests/integration/pilot/analysis/analysis_test.go
@@ -1,3 +1,4 @@
+// +build integ
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/pilot/analysis/main_test.go
+++ b/tests/integration/pilot/analysis/main_test.go
@@ -1,3 +1,4 @@
+// +build integ
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/pilot/cni/cni_test.go
+++ b/tests/integration/pilot/cni/cni_test.go
@@ -1,3 +1,4 @@
+// +build integ
 //  Copyright Istio Authors
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/pilot/ingress/ingress_test.go
+++ b/tests/integration/pilot/ingress/ingress_test.go
@@ -1,3 +1,4 @@
+// +build integ
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/pilot/istioctl_test.go
+++ b/tests/integration/pilot/istioctl_test.go
@@ -1,3 +1,4 @@
+// +build integ
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/pilot/locality/distribute_test.go
+++ b/tests/integration/pilot/locality/distribute_test.go
@@ -1,3 +1,4 @@
+// +build integ
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/pilot/locality/failover_test.go
+++ b/tests/integration/pilot/locality/failover_test.go
@@ -1,3 +1,4 @@
+// +build integ
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/pilot/locality/main_test.go
+++ b/tests/integration/pilot/locality/main_test.go
@@ -1,3 +1,4 @@
+// +build integ
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/pilot/locality/prioritized_test.go
+++ b/tests/integration/pilot/locality/prioritized_test.go
@@ -1,3 +1,4 @@
+// +build integ
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/pilot/main_test.go
+++ b/tests/integration/pilot/main_test.go
@@ -1,3 +1,4 @@
+// +build integ
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/pilot/mirror_test.go
+++ b/tests/integration/pilot/mirror_test.go
@@ -1,3 +1,4 @@
+// +build integ
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/pilot/revisions/revisions_test.go
+++ b/tests/integration/pilot/revisions/revisions_test.go
@@ -1,3 +1,4 @@
+// +build integ
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/pilot/revisions/uninstall_test.go
+++ b/tests/integration/pilot/revisions/uninstall_test.go
@@ -1,3 +1,4 @@
+// +build integ
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/pilot/routing_test.go
+++ b/tests/integration/pilot/routing_test.go
@@ -1,3 +1,4 @@
+// +build integ
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/pilot/vm/main_test.go
+++ b/tests/integration/pilot/vm/main_test.go
@@ -1,3 +1,4 @@
+// +build integ
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/pilot/vm/vm_test.go
+++ b/tests/integration/pilot/vm/vm_test.go
@@ -1,3 +1,4 @@
+// +build integ
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/pilot/vm/vm_traffic_shifting_test.go
+++ b/tests/integration/pilot/vm/vm_traffic_shifting_test.go
@@ -1,18 +1,17 @@
-/*
- * // Copyright Istio Authors
- * //
- * // Licensed under the Apache License, Version 2.0 (the "License");
- * // you may not use this file except in compliance with the License.
- * // You may obtain a copy of the License at
- * //
- * //     http://www.apache.org/licenses/LICENSE-2.0
- * //
- * // Unless required by applicable law or agreed to in writing, software
- * // distributed under the License is distributed on an "AS IS" BASIS,
- * // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * // See the License for the specific language governing permissions and
- * // limitations under the License.
- */
+// +build integ
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package vm
 

--- a/tests/integration/security/authorization_test.go
+++ b/tests/integration/security/authorization_test.go
@@ -1,3 +1,4 @@
+// +build integ
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/security/ca_custom_root/main_test.go
+++ b/tests/integration/security/ca_custom_root/main_test.go
@@ -1,3 +1,4 @@
+// +build integ
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/security/ca_custom_root/secure_naming_test.go
+++ b/tests/integration/security/ca_custom_root/secure_naming_test.go
@@ -1,3 +1,4 @@
+// +build integ
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/security/ca_custom_root/trust_domain_validation_test.go
+++ b/tests/integration/security/ca_custom_root/trust_domain_validation_test.go
@@ -1,3 +1,4 @@
+// +build integ
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/security/cert_provision_prometheus/cert_provision_prometheus_test.go
+++ b/tests/integration/security/cert_provision_prometheus/cert_provision_prometheus_test.go
@@ -1,3 +1,4 @@
+// +build integ
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/security/chiron/dns_cert_test.go
+++ b/tests/integration/security/chiron/dns_cert_test.go
@@ -1,3 +1,4 @@
+// +build integ
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/security/chiron/main_test.go
+++ b/tests/integration/security/chiron/main_test.go
@@ -1,3 +1,4 @@
+// +build integ
 //  Copyright Istio Authors
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/security/ecc_signature_algorithm/main_test.go
+++ b/tests/integration/security/ecc_signature_algorithm/main_test.go
@@ -1,3 +1,4 @@
+// +build integ
 //  Copyright Istio Authors
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/security/ecc_signature_algorithm/main_test.go
+++ b/tests/integration/security/ecc_signature_algorithm/main_test.go
@@ -1,4 +1,3 @@
-// +build integ
 //  Copyright Istio Authors
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/security/ecc_signature_algorithm/main_test.go
+++ b/tests/integration/security/ecc_signature_algorithm/main_test.go
@@ -77,12 +77,12 @@ func SetupApps(ctx resource.Context, apps *EchoDeployments) error {
 	builder := echoboot.NewBuilder(ctx)
 	for _, cluster := range ctx.Clusters() {
 		builder.
-			With(nil, echo.Config{
+			With(&apps.Client, echo.Config{
 				Namespace: apps.Namespace,
 				Service:   "client",
 				Cluster:   cluster,
 			}).
-			With(nil, echo.Config{
+			With(&apps.Server, echo.Config{
 				Subsets:        []echo.SubsetConfig{{}},
 				Namespace:      apps.Namespace,
 				Service:        "server",
@@ -98,16 +98,8 @@ func SetupApps(ctx resource.Context, apps *EchoDeployments) error {
 				Cluster: cluster,
 			})
 	}
-	echoes, err := builder.Build()
-	if err != nil {
-		return err
-	}
-	apps.Client, err = echoes.Get(echo.Service("client"))
-	if err != nil {
-		return err
-	}
+	err = builder.Build()
 
-	apps.Server, err = echoes.Get(echo.Service("server"))
 	if err != nil {
 		return err
 	}

--- a/tests/integration/security/ecc_signature_algorithm/main_test.go
+++ b/tests/integration/security/ecc_signature_algorithm/main_test.go
@@ -51,7 +51,7 @@ func TestMain(m *testing.M) {
 		Run()
 }
 
-func setupConfig(_ resource.Context, cfg *istio.Config) {
+func setupConfig(cfg *istio.Config) {
 	if cfg == nil {
 		return
 	}

--- a/tests/integration/security/ecc_signature_algorithm/mtls_strict_test.go
+++ b/tests/integration/security/ecc_signature_algorithm/mtls_strict_test.go
@@ -1,3 +1,4 @@
+// +build integ
 //  Copyright Istio Authors
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/security/ecc_signature_algorithm/mtls_strict_test.go
+++ b/tests/integration/security/ecc_signature_algorithm/mtls_strict_test.go
@@ -65,14 +65,14 @@ func TestStrictMTLS(t *testing.T) {
 			ctx.WhenDone(func() error {
 				return ctx.Config().DeleteYAML(apps.Namespace.Name(), peerTemplate)
 			})
-			util.WaitForConfigWithSleep(ctx, peerTemplate, apps.Namespace)
+			util.WaitForConfigWithSleep(ctx, "mtls-strict", peerTemplate, apps.Namespace)
 
 			drTemplate := tmpl.EvaluateOrFail(ctx, DestinationRuleConfigIstioMutual, map[string]string{"AppNamespace": apps.Namespace.Name()})
 			ctx.Config().ApplyYAMLOrFail(ctx, apps.Namespace.Name(), drTemplate)
 			ctx.WhenDone(func() error {
 				return ctx.Config().DeleteYAML(apps.Namespace.Name(), drTemplate)
 			})
-			util.WaitForConfigWithSleep(ctx, drTemplate, apps.Namespace)
+			util.WaitForConfigWithSleep(ctx, "mtls-strict", drTemplate, apps.Namespace)
 
 			response := apps.Client.CallOrFail(t, echo.CallOptions{
 				Target:   apps.Server,

--- a/tests/integration/security/ecc_signature_algorithm/mtls_strict_test.go
+++ b/tests/integration/security/ecc_signature_algorithm/mtls_strict_test.go
@@ -1,4 +1,3 @@
-// +build integ
 //  Copyright Istio Authors
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/security/filebased_tls_origination/destination_rule_tls_test.go
+++ b/tests/integration/security/filebased_tls_origination/destination_rule_tls_test.go
@@ -1,3 +1,4 @@
+// +build integ
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/security/filebased_tls_origination/egress_gateway_origination_test.go
+++ b/tests/integration/security/filebased_tls_origination/egress_gateway_origination_test.go
@@ -1,3 +1,4 @@
+// +build integ
 //  Copyright Istio Authors
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/security/filebased_tls_origination/main_test.go
+++ b/tests/integration/security/filebased_tls_origination/main_test.go
@@ -1,3 +1,4 @@
+// +build integ
 //  Copyright Istio Authors
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/security/jwt_test.go
+++ b/tests/integration/security/jwt_test.go
@@ -1,3 +1,4 @@
+// +build integ
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/security/main_test.go
+++ b/tests/integration/security/main_test.go
@@ -1,3 +1,4 @@
+// +build integ
 //  Copyright Istio Authors
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/security/mtls_first_party_jwt/main_test.go
+++ b/tests/integration/security/mtls_first_party_jwt/main_test.go
@@ -1,3 +1,4 @@
+// +build integ
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/security/mtls_first_party_jwt/strict_test.go
+++ b/tests/integration/security/mtls_first_party_jwt/strict_test.go
@@ -1,3 +1,4 @@
+// +build integ
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/security/mtls_healthcheck_test.go
+++ b/tests/integration/security/mtls_healthcheck_test.go
@@ -1,3 +1,4 @@
+// +build integ
 //  Copyright Istio Authors
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/security/mtlsk8sca/main_test.go
+++ b/tests/integration/security/mtlsk8sca/main_test.go
@@ -1,3 +1,4 @@
+// +build integ
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/security/mtlsk8sca/strict_test.go
+++ b/tests/integration/security/mtlsk8sca/strict_test.go
@@ -1,3 +1,4 @@
+// +build integ
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/security/pass_through_filter_chain_test.go
+++ b/tests/integration/security/pass_through_filter_chain_test.go
@@ -1,3 +1,4 @@
+// +build integ
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/security/reachability_test.go
+++ b/tests/integration/security/reachability_test.go
@@ -1,3 +1,4 @@
+// +build integ
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/security/sds_egress/main_test.go
+++ b/tests/integration/security/sds_egress/main_test.go
@@ -1,3 +1,4 @@
+// +build integ
 //  Copyright Istio Authors
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/security/sds_egress/sds_istio_mutual_egress_test.go
+++ b/tests/integration/security/sds_egress/sds_istio_mutual_egress_test.go
@@ -1,3 +1,4 @@
+// +build integ
 //  Copyright Istio Authors
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/security/sds_ingress/ingress_test.go
+++ b/tests/integration/security/sds_ingress/ingress_test.go
@@ -1,3 +1,4 @@
+// +build integ
 //  Copyright Istio Authors
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/security/sds_ingress_k8sca/main_test.go
+++ b/tests/integration/security/sds_ingress_k8sca/main_test.go
@@ -1,3 +1,4 @@
+// +build integ
 //  Copyright Istio Authors
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/security/sds_tls_origination/egress_gateway_origination_test.go
+++ b/tests/integration/security/sds_tls_origination/egress_gateway_origination_test.go
@@ -1,3 +1,4 @@
+// +build integ
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/security/sds_tls_origination/main_test.go
+++ b/tests/integration/security/sds_tls_origination/main_test.go
@@ -1,3 +1,4 @@
+// +build integ
 //  Copyright Istio Authors
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/security/sds_vault_flow/main_test.go
+++ b/tests/integration/security/sds_vault_flow/main_test.go
@@ -1,3 +1,4 @@
+// +build integ
 //  Copyright Istio Authors
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/security/sds_vault_flow/sds_vault_flow_test.go
+++ b/tests/integration/security/sds_vault_flow/sds_vault_flow_test.go
@@ -1,3 +1,4 @@
+// +build integ
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/security/util/framework.go
+++ b/tests/integration/security/util/framework.go
@@ -62,7 +62,7 @@ func EchoConfig(name string, ns namespace.Instance, headless bool, annos echo.An
 	return out
 }
 
-func WaitForConfigWithSleep(ctx framework.TestContext, testName, configs string, namespace namespace.Instance) {
+func WaitForConfigWithSleep(ctx framework.TestContext, configs string, namespace namespace.Instance) {
 	ik := istioctl.NewOrFail(ctx, ctx, istioctl.Config{})
 	t0 := time.Now()
 	if err := ik.WaitForConfigs(namespace.Name(), configs); err != nil {
@@ -76,7 +76,7 @@ func WaitForConfigWithSleep(ctx framework.TestContext, testName, configs string,
 	// to work around this, we will temporarily make sure we are always sleeping at least 10s, even if istioctl wait is faster.
 	// This allows us to debug istioctl wait, while still ensuring tests are stable
 	sleep := time.Second*10 - time.Since(t0)
-	ctx.Logf("[%s] [%v] Wait for additional %v config propagate to endpoints...", testName, time.Now(), sleep)
+	//ctx.Logf("[%s] [%v] Wait for additional %v config propagate to endpoints...", testName, time.Now(), sleep)
 	time.Sleep(sleep)
-	ctx.Logf("[%s] [%v] Finish waiting. Continue testing.", testName, time.Now())
+	//ctx.Logf("[%s] [%v] Finish waiting. Continue testing.", testName, time.Now())
 }

--- a/tests/integration/security/util/framework.go
+++ b/tests/integration/security/util/framework.go
@@ -62,7 +62,7 @@ func EchoConfig(name string, ns namespace.Instance, headless bool, annos echo.An
 	return out
 }
 
-func WaitForConfigWithSleep(ctx framework.TestContext, configs string, namespace namespace.Instance) {
+func WaitForConfigWithSleep(ctx framework.TestContext, testName, configs string, namespace namespace.Instance) {
 	ik := istioctl.NewOrFail(ctx, ctx, istioctl.Config{})
 	t0 := time.Now()
 	if err := ik.WaitForConfigs(namespace.Name(), configs); err != nil {
@@ -76,7 +76,7 @@ func WaitForConfigWithSleep(ctx framework.TestContext, configs string, namespace
 	// to work around this, we will temporarily make sure we are always sleeping at least 10s, even if istioctl wait is faster.
 	// This allows us to debug istioctl wait, while still ensuring tests are stable
 	sleep := time.Second*10 - time.Since(t0)
-	//ctx.Logf("[%s] [%v] Wait for additional %v config propagate to endpoints...", testName, time.Now(), sleep)
+	ctx.Logf("[%s] [%v] Wait for additional %v config propagate to endpoints...", testName, time.Now(), sleep)
 	time.Sleep(sleep)
-	//ctx.Logf("[%s] [%v] Finish waiting. Continue testing.", testName, time.Now())
+	ctx.Logf("[%s] [%v] Finish waiting. Continue testing.", testName, time.Now())
 }

--- a/tests/integration/security/webhook/webhook_test.go
+++ b/tests/integration/security/webhook/webhook_test.go
@@ -1,3 +1,4 @@
+// +build integ
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/telemetry/dashboard_test.go
+++ b/tests/integration/telemetry/dashboard_test.go
@@ -1,3 +1,4 @@
+// +build integ
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/telemetry/main_test.go
+++ b/tests/integration/telemetry/main_test.go
@@ -1,3 +1,4 @@
+// +build integ
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/telemetry/outboundtrafficpolicy/traffic_allow_any_test.go
+++ b/tests/integration/telemetry/outboundtrafficpolicy/traffic_allow_any_test.go
@@ -1,3 +1,4 @@
+// +build integ
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/telemetry/outboundtrafficpolicy/traffic_registry_only_test.go
+++ b/tests/integration/telemetry/outboundtrafficpolicy/traffic_registry_only_test.go
@@ -1,3 +1,4 @@
+// +build integ
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/telemetry/outboundtrafficpolicy/traffic_test.go
+++ b/tests/integration/telemetry/outboundtrafficpolicy/traffic_test.go
@@ -1,3 +1,4 @@
+// +build integ
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/telemetry/requestclassification/requestclassification_test.go
+++ b/tests/integration/telemetry/requestclassification/requestclassification_test.go
@@ -1,3 +1,4 @@
+// +build integ
 // Copyright Istio Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/telemetry/stackdriver/stackdriver_filter_test.go
+++ b/tests/integration/telemetry/stackdriver/stackdriver_filter_test.go
@@ -1,3 +1,4 @@
+// +build integ
 // Copyright Istio Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/telemetry/stackdriver/stackdriver_tcp_filter_test.go
+++ b/tests/integration/telemetry/stackdriver/stackdriver_tcp_filter_test.go
@@ -1,3 +1,4 @@
+// +build integ
 // Copyright Istio Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/telemetry/stackdriver/vm/main_test.go
+++ b/tests/integration/telemetry/stackdriver/vm/main_test.go
@@ -1,3 +1,4 @@
+// +build integ
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/telemetry/stackdriver/vm/vm_test.go
+++ b/tests/integration/telemetry/stackdriver/vm/vm_test.go
@@ -1,3 +1,4 @@
+// +build integ
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/telemetry/stats/prometheus/http/nullvm/stats_filter_test.go
+++ b/tests/integration/telemetry/stats/prometheus/http/nullvm/stats_filter_test.go
@@ -1,3 +1,4 @@
+// +build integ
 // Copyright Istio Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/telemetry/stats/prometheus/http/wasm/stats_wasm_filter_test.go
+++ b/tests/integration/telemetry/stats/prometheus/http/wasm/stats_wasm_filter_test.go
@@ -1,3 +1,4 @@
+// +build integ
 // Copyright Istio Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/telemetry/stats/prometheus/istioctl/istioctl_metrics_test.go
+++ b/tests/integration/telemetry/stats/prometheus/istioctl/istioctl_metrics_test.go
@@ -1,3 +1,4 @@
+// +build integ
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/telemetry/stats/prometheus/tcp/stats_tcp_filter_test.go
+++ b/tests/integration/telemetry/stats/prometheus/tcp/stats_tcp_filter_test.go
@@ -1,3 +1,4 @@
+// +build integ
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/telemetry/tracing/clienttracing/client_tracing_test.go
+++ b/tests/integration/telemetry/tracing/clienttracing/client_tracing_test.go
@@ -1,3 +1,4 @@
+// +build integ
 // Copyright Istio Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/telemetry/tracing/servertracing/tracing_test.go
+++ b/tests/integration/telemetry/tracing/servertracing/tracing_test.go
@@ -1,3 +1,4 @@
+// +build integ
 // Copyright Istio Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/tests.mk
+++ b/tests/integration/tests.mk
@@ -67,13 +67,13 @@ endif
 test.integration.analyze: test.integration...analyze
 
 test.integration.%.analyze: | $(JUNIT_REPORT)
-	$(GO) test -p 1 ${T} ./tests/integration/$(subst .,/,$*)/... -timeout 30m \
+	$(GO) test -p 1 -tags=integ ${T} ./tests/integration/$(subst .,/,$*)/... -timeout 30m \
 	--istio.test.analyze \
 	2>&1 | tee >($(JUNIT_REPORT) > $(JUNIT_OUT))
 
 # Generate integration test targets for kubernetes environment.
 test.integration.%.kube: | $(JUNIT_REPORT)
-	$(GO) test -p 1 ${T} ./tests/integration/$(subst .,/,$*)/... -timeout 30m \
+	$(GO) test -p 1 -tags=integ ${T} ./tests/integration/$(subst .,/,$*)/... -timeout 30m \
 	${_INTEGRATION_TEST_FLAGS} \
 	2>&1 | tee >($(JUNIT_REPORT) > $(JUNIT_OUT))
 
@@ -82,7 +82,7 @@ test.integration...local:
 
 # Generate presubmit integration test targets for each component in kubernetes environment
 test.integration.%.kube.presubmit: | $(JUNIT_REPORT)
-	PATH=${PATH}:${ISTIO_OUT} $(GO) test -p 1 ${T} ./tests/integration/$(subst .,/,$*)/... -timeout 30m \
+	PATH=${PATH}:${ISTIO_OUT} $(GO) test -p 1 -tags=integ ${T} ./tests/integration/$(subst .,/,$*)/... -timeout 30m \
 	${_INTEGRATION_TEST_FLAGS} ${_INTEGRATION_TEST_SELECT_FLAGS} \
 	2>&1 | tee >($(JUNIT_REPORT) > $(JUNIT_OUT))
 
@@ -90,14 +90,14 @@ test.integration.%.kube.presubmit: | $(JUNIT_REPORT)
 # Presubmit integration tests targeting Kubernetes environment.
 .PHONY: test.integration.kube.presubmit
 test.integration.kube.presubmit: | $(JUNIT_REPORT)
-	PATH=${PATH}:${ISTIO_OUT} $(GO) test -p 1 ${T} $(shell go list ./tests/integration/... | grep -v /qualification | grep -v /examples) -timeout 30m \
+	PATH=${PATH}:${ISTIO_OUT} $(GO) test -p 1 -tags=integ  ${T} $(shell go list ./tests/integration/... | grep -v /qualification | grep -v /examples) -timeout 30m \
 	${_INTEGRATION_TEST_FLAGS} ${_INTEGRATION_TEST_SELECT_FLAGS} \
 	2>&1 | tee >($(JUNIT_REPORT) > $(JUNIT_OUT))
 
 # Defines a target to run a minimal reachability testing basic traffic
 .PHONY: test.integration.kube.reachability
 test.integration.kube.reachability: | $(JUNIT_REPORT)
-	PATH=${PATH}:${ISTIO_OUT} $(GO) test -p 1 ${T} ./tests/integration/security/ -timeout 30m \
+	PATH=${PATH}:${ISTIO_OUT} $(GO) test -p 1 -tags=integ ${T} ./tests/integration/security/ -timeout 30m -tags=integ \
 	${_INTEGRATION_TEST_FLAGS} \
 	--test.run=TestReachability \
 	2>&1 | tee >($(JUNIT_REPORT) > $(JUNIT_OUT))


### PR DESCRIPTION
Saw the test was disabled cause it was tagged with "integ" whereas others were not. Don't know if it was intentional or not. Just passing in the tag didn't work so tried to stitch together a solution by copying some code from newer releases.

Feel free to close this if it is intentional, :)

It affects:

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [x] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure