### PR TITLE
istioctl pc all: remove duplicate alias

### DIFF
--- a/istioctl/cmd/proxyconfig.go
+++ b/istioctl/cmd/proxyconfig.go
@@ -363,11 +363,14 @@ func allConfigCmd() *cobra.Command {
   # Retrieve full cluster dump as JSON
   istioctl proxy-config all <pod-name[.namespace]> -o json
 
+  # Retrieve full cluster dump with short syntax
+  istioctl pc a <pod-name[.namespace]>
+
   # Retrieve cluster summary without using Kubernetes API
   ssh <user@hostname> 'curl localhost:15000/config_dump' > envoy-config.json
   istioctl proxy-config all --file envoy-config.json
 `,
-		Aliases: []string{"all", "a"},
+		Aliases: []string{"a"},
 		Args: func(cmd *cobra.Command, args []string) error {
 			if (len(args) == 1) != (configDumpFile == "") {
 				cmd.Println(cmd.UsageString())


### PR DESCRIPTION
Minor fix for duplicate alias added in https://github.com/istio/istio/pull/30934

Before:
```
$ istioctl pc all
Usage:
  istioctl proxy-config all [<type>/]<name>[.<namespace>] [flags]

Aliases:
  all, all, a
```