### PR TITLE
support: XDS_SEND_TIMEOUT on pilot-agent

### DIFF
--- a/pkg/istio-agent/xds_proxy.go
+++ b/pkg/istio-agent/xds_proxy.go
@@ -56,6 +56,7 @@ import (
 	"istio.io/istio/pkg/wasm"
 	"istio.io/istio/security/pkg/nodeagent/caclient"
 	"istio.io/istio/security/pkg/pki/util"
+	"istio.io/pkg/env"
 	"istio.io/pkg/log"
 )
 
@@ -66,18 +67,11 @@ const (
 )
 
 var (
-	sendTimeout = 5 * time.Second // default upstream send timeout.
+	sendTimeout = env.RegisterDurationVar("XDS_SEND_TIMEOUT",
+		5*time.Second,
+		"The timeout to send the XDS configuration to proxies. After this timeout is reached, XDSProxy will discard that push.").
+		Get()
 )
-
-func init() {
-	timeout := os.Getenv("XDS_SEND_TIMEOUT")
-	if timeout != "" {
-		d, _ := time.ParseDuration(timeout)
-		if d >= time.Millisecond {
-			sendTimeout = d
-		}
-	}
-}
 
 type ResponseHandler func(resp *discovery.DiscoveryResponse) error
 

--- a/pkg/istio-agent/xds_proxy.go
+++ b/pkg/istio-agent/xds_proxy.go
@@ -66,12 +66,10 @@ const (
 	defaultInitialWindowSize           = 1024 * 1024 // default gRPC ConnWindowSize
 )
 
-var (
-	sendTimeout = env.RegisterDurationVar("XDS_SEND_TIMEOUT",
-		5*time.Second,
-		"The timeout to send the XDS configuration to proxies. After this timeout is reached, XDSProxy will discard that push.").
-		Get()
-)
+var sendTimeout = env.RegisterDurationVar("XDS_SEND_TIMEOUT",
+	5*time.Second,
+	"The timeout to send the XDS configuration to proxies. After this timeout is reached, XDSProxy will discard that push.").
+	Get()
 
 type ResponseHandler func(resp *discovery.DiscoveryResponse) error
 

--- a/pkg/istio-agent/xds_proxy.go
+++ b/pkg/istio-agent/xds_proxy.go
@@ -61,10 +61,23 @@ import (
 
 const (
 	defaultClientMaxReceiveMessageSize = math.MaxInt32
-	defaultInitialConnWindowSize       = 1024 * 1024     // default gRPC InitialWindowSize
-	defaultInitialWindowSize           = 1024 * 1024     // default gRPC ConnWindowSize
-	sendTimeout                        = 5 * time.Second // default upstream send timeout.
+	defaultInitialConnWindowSize       = 1024 * 1024 // default gRPC InitialWindowSize
+	defaultInitialWindowSize           = 1024 * 1024 // default gRPC ConnWindowSize
 )
+
+var (
+	sendTimeout = 5 * time.Second // default upstream send timeout.
+)
+
+func init() {
+	timeout := os.Getenv("XDS_SEND_TIMEOUT")
+	if timeout != "" {
+		d, _ := time.ParseDuration(timeout)
+		if d >= time.Millisecond {
+			sendTimeout = d
+		}
+	}
+}
 
 type ResponseHandler func(resp *discovery.DiscoveryResponse) error
 

--- a/pkg/istio-agent/xds_proxy.go
+++ b/pkg/istio-agent/xds_proxy.go
@@ -68,7 +68,7 @@ const (
 
 var sendTimeout = env.RegisterDurationVar("XDS_SEND_TIMEOUT",
 	5*time.Second,
-	"The timeout to send the XDS configuration to proxies. After this timeout is reached, XDSProxy will discard that push.").
+	"The timeout to send the XDS configuration to proxies. After this timeout is reached, XDSProxy will discard that push. The default timeout is 5s. Valid time units are 'ns', 'us', 'ms', 's', 'm', 'h'").
 	Get()
 
 type ResponseHandler func(resp *discovery.DiscoveryResponse) error

--- a/pkg/istio-agent/xds_proxy.go
+++ b/pkg/istio-agent/xds_proxy.go
@@ -68,7 +68,9 @@ const (
 
 var sendTimeout = env.RegisterDurationVar("XDS_SEND_TIMEOUT",
 	5*time.Second,
-	"The timeout to send the XDS configuration to proxies. After this timeout is reached, XDSProxy will discard that push. The default timeout is 5s. Valid time units are 'ns', 'us', 'ms', 's', 'm', 'h'").
+	"The timeout to send the XDS configuration to proxies. "+
+		"After this timeout is reached, XDSProxy will discard that push. "+
+		"The default timeout is 5s. Valid time units are 'ns', 'us', 'ms', 's', 'm', 'h'").
 	Get()
 
 type ResponseHandler func(resp *discovery.DiscoveryResponse) error

--- a/releasenotes/notes/31167.yaml
+++ b/releasenotes/notes/31167.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: feature
+area: networking
+issue:
+  - 31141
+releaseNotes:
+- |
+   **Added** An environment variable XDS_SEND_TIMEOUT for config the timeout of xdsproxy.
+   The default timeout is 5s. Valid time units are "ns", "us", "ms", "s", "m", "h".

--- a/releasenotes/notes/31167.yaml
+++ b/releasenotes/notes/31167.yaml
@@ -5,5 +5,5 @@ issue:
   - 31141
 releaseNotes:
 - |
-   **Added** An environment variable XDS_SEND_TIMEOUT for config the timeout of xdsproxy.
+   **Added** an environment variable `XDS_SEND_TIMEOUT` for configuring the timeout of xdsproxy.
    The default timeout is 5s. Valid time units are "ns", "us", "ms", "s", "m", "h".

--- a/releasenotes/notes/31167.yaml
+++ b/releasenotes/notes/31167.yaml
@@ -6,4 +6,4 @@ issue:
 releaseNotes:
 - |
    **Added** an environment variable `XDS_SEND_TIMEOUT` for configuring the timeout of xdsproxy.
-   The default timeout is 5s. Valid time units are "ns", "us", "ms", "s", "m", "h".
+   


### PR DESCRIPTION
Signed-off-by: cocotyty <cocotyty@sina.com>


https://github.com/istio/istio/issues/31141

Currently the pilot-agent xds_proxy default sendTimeout is 5 seconds. 

Pilot can set this value  by PILOT_XDS_SEND_TIMEOUT. 

In large scale cluster , ingressgateway may receive lots of resources , so it can be timeout frequently.

Maybe we can provide a envrionment value to set the `sendTimeout`.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.