### PR TITLE
remove tlsv2 env var

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -358,9 +358,6 @@ var (
 		"If true, Istiod will set the pod fsGroup to 1337 on injection. This is required for Kubernetes 1.18 and older "+
 			`(see https://github.com/kubernetes/kubernetes/issues/57923 for details) unless JWT_POLICY is "first-party-jwt".`).Get()
 
-	EnableTLSv2OnInboundPath = env.RegisterBoolVar("PILOT_SIDECAR_ENABLE_INBOUND_TLS_V2", true,
-		"If true, Pilot will set the TLS version on server side as TLSv1_2 and also enforce strong cipher suites").Get()
-
 	XdsPushSendTimeout = env.RegisterDurationVar(
 		"PILOT_XDS_SEND_TIMEOUT",
 		5*time.Second,

--- a/pilot/pkg/security/authn/utils/utils.go
+++ b/pilot/pkg/security/authn/utils/utils.go
@@ -18,7 +18,6 @@ import (
 	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	tls "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 
-	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking"
 	"istio.io/istio/pilot/pkg/networking/util"
@@ -86,12 +85,10 @@ func BuildInboundFilterChain(mTLSMode model.MutualTLSMode, node *model.Proxy,
 		}
 	}
 
-	if features.EnableTLSv2OnInboundPath {
-		// Set Minimum TLS version to match the default client version and allowed strong cipher suites for sidecars.
-		ctx.CommonTlsContext.TlsParams = &tls.TlsParameters{
-			TlsMinimumProtocolVersion: tls.TlsParameters_TLSv1_2,
-			CipherSuites:              SupportedCiphers,
-		}
+	// Set Minimum TLS version to match the default client version and allowed strong cipher suites for sidecars.
+	ctx.CommonTlsContext.TlsParams = &tls.TlsParameters{
+		TlsMinimumProtocolVersion: tls.TlsParameters_TLSv1_2,
+		CipherSuites:              SupportedCiphers,
 	}
 
 	authn_model.ApplyToCommonTLSContext(ctx.CommonTlsContext, node, []string{} /*subjectAltNames*/, trustDomainAliases)

--- a/pilot/pkg/security/authn/utils/utils_test.go
+++ b/pilot/pkg/security/authn/utils/utils_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/protobuf/testing/protocmp"
 
-	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking"
 	authn_model "istio.io/istio/pilot/pkg/security/model"
@@ -39,7 +38,6 @@ func TestBuildInboundFilterChain(t *testing.T) {
 		node             *model.Proxy
 		listenerProtocol networking.ListenerProtocol
 		trustDomains     []string
-		tlsV2Enabled     bool
 	}
 	tests := []struct {
 		name string
@@ -54,7 +52,6 @@ func TestBuildInboundFilterChain(t *testing.T) {
 					Metadata: &model.NodeMetadata{},
 				},
 				listenerProtocol: networking.ListenerProtocolAuto,
-				tlsV2Enabled:     false,
 			},
 			want: []networking.FilterChain{{}},
 		},
@@ -66,7 +63,6 @@ func TestBuildInboundFilterChain(t *testing.T) {
 					Metadata: &model.NodeMetadata{},
 				},
 				listenerProtocol: networking.ListenerProtocolAuto,
-				tlsV2Enabled:     false,
 			},
 			want: []networking.FilterChain{{}},
 		},
@@ -78,7 +74,6 @@ func TestBuildInboundFilterChain(t *testing.T) {
 					Metadata: &model.NodeMetadata{},
 				},
 				listenerProtocol: networking.ListenerProtocolHTTP,
-				tlsV2Enabled:     true,
 			},
 			want: []networking.FilterChain{
 				{
@@ -160,7 +155,6 @@ func TestBuildInboundFilterChain(t *testing.T) {
 				},
 				listenerProtocol: networking.ListenerProtocolTCP,
 				trustDomains:     []string{"cluster.local"},
-				tlsV2Enabled:     true,
 			},
 			want: []networking.FilterChain{
 				{
@@ -235,87 +229,9 @@ func TestBuildInboundFilterChain(t *testing.T) {
 				},
 			},
 		},
-		{
-			name: "MTLSStrict using SDS with local trust domain and TLSv2 feature disabled",
-			args: args{
-				mTLSMode: model.MTLSStrict,
-				node: &model.Proxy{
-					Metadata: &model.NodeMetadata{},
-				},
-				listenerProtocol: networking.ListenerProtocolHTTP,
-				trustDomains:     []string{"cluster.local"},
-				tlsV2Enabled:     false,
-			},
-			want: []networking.FilterChain{
-				{
-					TLSContext: &auth.DownstreamTlsContext{
-						CommonTlsContext: &auth.CommonTlsContext{
-							TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{
-								{
-									Name: "default",
-									SdsConfig: &core.ConfigSource{
-										InitialFetchTimeout: ptypes.DurationProto(0 * time.Second),
-										ResourceApiVersion:  core.ApiVersion_V3,
-										ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
-											ApiConfigSource: &core.ApiConfigSource{
-												ApiType:                   core.ApiConfigSource_GRPC,
-												SetNodeOnFirstMessageOnly: true,
-												TransportApiVersion:       core.ApiVersion_V3,
-												GrpcServices: []*core.GrpcService{
-													{
-														TargetSpecifier: &core.GrpcService_EnvoyGrpc_{
-															EnvoyGrpc: &core.GrpcService_EnvoyGrpc{ClusterName: authn_model.SDSClusterName},
-														},
-													},
-												},
-											},
-										},
-									},
-								},
-							},
-							ValidationContextType: &auth.CommonTlsContext_CombinedValidationContext{
-								CombinedValidationContext: &auth.CommonTlsContext_CombinedCertificateValidationContext{
-									DefaultValidationContext: &auth.CertificateValidationContext{MatchSubjectAltNames: []*matcher.StringMatcher{
-										{MatchPattern: &matcher.StringMatcher_Prefix{Prefix: spiffe.URIPrefix + spiffe.GetTrustDomain() + "/"}},
-									}},
-									ValidationContextSdsSecretConfig: &auth.SdsSecretConfig{
-										Name: "ROOTCA",
-										SdsConfig: &core.ConfigSource{
-											InitialFetchTimeout: ptypes.DurationProto(0 * time.Second),
-											ResourceApiVersion:  core.ApiVersion_V3,
-											ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
-												ApiConfigSource: &core.ApiConfigSource{
-													ApiType:                   core.ApiConfigSource_GRPC,
-													SetNodeOnFirstMessageOnly: true,
-													TransportApiVersion:       core.ApiVersion_V3,
-													GrpcServices: []*core.GrpcService{
-														{
-															TargetSpecifier: &core.GrpcService_EnvoyGrpc_{
-																EnvoyGrpc: &core.GrpcService_EnvoyGrpc{ClusterName: authn_model.SDSClusterName},
-															},
-														},
-													},
-												},
-											},
-										},
-									},
-								},
-							},
-							AlpnProtocols: []string{"h2", "http/1.1"},
-						},
-						RequireClientCertificate: protovalue.BoolTrue,
-					},
-				},
-			},
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			defaultValue := features.EnableTLSv2OnInboundPath
-			features.EnableTLSv2OnInboundPath = tt.args.tlsV2Enabled
-			defer func() {
-				features.EnableTLSv2OnInboundPath = defaultValue
-			}()
 			got := BuildInboundFilterChain(tt.args.mTLSMode, tt.args.node, tt.args.listenerProtocol, tt.args.trustDomains)
 			if diff := cmp.Diff(got, tt.want, protocmp.Transform()); diff != "" {
 				t.Errorf("BuildInboundFilterChain() = %v", diff)


### PR DESCRIPTION
This has been there for couple of releases and no one complained. Moreover we now have a way to override with Envoy filters if needed. So removing this.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ X] Does not have any changes that may affect Istio users.
