### PR TITLE
lookup test only features in test code

### DIFF
--- a/pilot/pkg/features/export_test.go
+++ b/pilot/pkg/features/export_test.go
@@ -15,4 +15,7 @@
 package features
 
 // Only read env variables in tests so that they are not set accidentally in production code.
-var _ = RegisterTestOnlyFeatures
+var _ = (func() interface{} {
+	RegisterTestOnlyFeatures()
+	return nil
+})()

--- a/pilot/pkg/features/export_test.go
+++ b/pilot/pkg/features/export_test.go
@@ -1,0 +1,25 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package features
+
+import "istio.io/pkg/env"
+
+// Only read env variables in tests so that they are not set accidentally in production code.
+var _ = registerTestOnlyFeatures
+
+func registerTestOnlyFeatures() {
+	EnableAdminEndpoints = env.RegisterBoolVar("ENABLE_ADMIN_ENDPOINTS", false,
+		"If this is set to true, dangerous admin endpoins will be exposed on the debug interface.").Get()
+}

--- a/pilot/pkg/features/export_test.go
+++ b/pilot/pkg/features/export_test.go
@@ -14,12 +14,5 @@
 
 package features
 
-import "istio.io/pkg/env"
-
 // Only read env variables in tests so that they are not set accidentally in production code.
-var _ = registerTestOnlyFeatures
-
-func registerTestOnlyFeatures() {
-	EnableAdminEndpoints = env.RegisterBoolVar("ENABLE_ADMIN_ENDPOINTS", false,
-		"If this is set to true, dangerous admin endpoins will be exposed on the debug interface.").Get()
-}
+var _ = RegisterTestOnlyFeatures

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -430,11 +430,25 @@ var (
 	).Get()
 
 	// EnableAdminEndpoints should never be enabled in production code.
-	EnableAdminEndpoints = false
+	EnableAdminEndpoints = env.BoolVar{}
 )
 
 // RegisterTestOnlyFeatures registers features that are only used in tests.
 func RegisterTestOnlyFeatures() {
 	EnableAdminEndpoints = env.RegisterBoolVar("ENABLE_ADMIN_ENDPOINTS", false,
-		"If this is set to true, dangerous admin endpoins will be exposed on the debug interface.").Get()
+		"If this is set to true, dangerous admin endpoins will be exposed on the debug interface.")
+}
+
+type AlwaysFalseVar struct{}
+
+func (v AlwaysFalseVar) Get() bool {
+	return false
+}
+
+func (v AlwaysFalseVar) Type() env.VarType {
+	return env.BOOL
+}
+
+func (v AlwaysFalseVar) Name() string {
+	return ""
 }

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -307,9 +307,6 @@ var (
 	EnableDebugOnHTTP = env.RegisterBoolVar("ENABLE_DEBUG_ON_HTTP", true,
 		"If this is set to false, the debug interface will not be ebabled on Http, recommended for production").Get()
 
-	EnableAdminEndpoints = env.RegisterBoolVar("ENABLE_ADMIN_ENDPOINTS", false,
-		"If this is set to true, dangerous admin endpoins will be exposed on the debug interface. Not recommended for production.").Get()
-
 	XDSAuth = env.RegisterBoolVar("XDS_AUTH", true,
 		"If true, will authenticate XDS clients.").Get()
 
@@ -431,4 +428,7 @@ var (
 			"The enabled behavior matches the behavior without Istio enabled at all; this flag exists only for backwards compatibility. "+
 			"Regardless of this setting, the configuration can be overridden with the Sidecar.Ingress.DefaultEndpoint configuration.",
 	).Get()
+
+	// This should never be enabled in production code.
+	EnableAdminEndpoints = false
 )

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -429,6 +429,6 @@ var (
 			"Regardless of this setting, the configuration can be overridden with the Sidecar.Ingress.DefaultEndpoint configuration.",
 	).Get()
 
-	// This should never be enabled in production code.
+	// EnableAdminEndpoints should never be enabled in production code.
 	EnableAdminEndpoints = false
 )

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -438,17 +438,3 @@ func RegisterTestOnlyFeatures() {
 	EnableAdminEndpoints = env.RegisterBoolVar("ENABLE_ADMIN_ENDPOINTS", false,
 		"If this is set to true, dangerous admin endpoins will be exposed on the debug interface.")
 }
-
-type AlwaysFalseVar struct{}
-
-func (v AlwaysFalseVar) Get() bool {
-	return false
-}
-
-func (v AlwaysFalseVar) Type() env.VarType {
-	return env.BOOL
-}
-
-func (v AlwaysFalseVar) Name() string {
-	return ""
-}

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -432,3 +432,9 @@ var (
 	// EnableAdminEndpoints should never be enabled in production code.
 	EnableAdminEndpoints = false
 )
+
+// RegisterTestOnlyFeatures registers features that are only used in tests.
+func RegisterTestOnlyFeatures() {
+	EnableAdminEndpoints = env.RegisterBoolVar("ENABLE_ADMIN_ENDPOINTS", false,
+		"If this is set to true, dangerous admin endpoins will be exposed on the debug interface.").Get()
+}

--- a/pilot/pkg/xds/debug.go
+++ b/pilot/pkg/xds/debug.go
@@ -156,7 +156,7 @@ func (s *DiscoveryServer) AddDebugHandlers(mux *http.ServeMux, enableProfiling b
 
 	mux.HandleFunc("/debug", s.Debug)
 
-	if features.EnableAdminEndpoints {
+	if features.EnableAdminEndpoints.Get() {
 		s.addDebugHandler(mux, "/debug/force_disconnect", "Disconnects a proxy from this Pilot", s.ForceDisconnect)
 	}
 

--- a/pkg/test/framework/test.go
+++ b/pkg/test/framework/test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	pilotfeatures "istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pkg/test/framework/features"
 	"istio.io/istio/pkg/test/framework/label"
 	"istio.io/istio/pkg/test/scopes"
@@ -117,6 +118,9 @@ type testImpl struct {
 
 // globalCleanupLock defines a global wait group to synchronize cleanup of test suites
 var globalParentLock = new(sync.Map)
+
+// register test only features that Pilot needs.
+var _ = pilotfeatures.RegisterTestOnlyFeatures
 
 // NewTest returns a new test wrapper for running a single test.
 func NewTest(t *testing.T) Test {

--- a/pkg/test/framework/test.go
+++ b/pkg/test/framework/test.go
@@ -120,7 +120,10 @@ type testImpl struct {
 var globalParentLock = new(sync.Map)
 
 // register test only features that Pilot needs.
-var _ = pilotfeatures.RegisterTestOnlyFeatures
+var _ = (func() interface{} {
+	pilotfeatures.RegisterTestOnlyFeatures()
+	return nil
+})()
 
 // NewTest returns a new test wrapper for running a single test.
 func NewTest(t *testing.T) Test {


### PR DESCRIPTION
This PR tries to lookup test "only" features in test code only so that it is not enabled accidentally in production.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any changes that may affect Istio users.
