### PR TITLE
fix health check logic when initial check is failure

### DIFF
--- a/pkg/istio-agent/health/health_check_test.go
+++ b/pkg/istio-agent/health/health_check_test.go
@@ -52,7 +52,8 @@ func TestWorkloadHealthChecker_PerformApplicationHealthCheck(t *testing.T) {
 
 		quitChan := make(chan struct{})
 
-		expectedTCPEvents := [6]*ProbeEvent{
+		expectedTCPEvents := [7]*ProbeEvent{
+			{Healthy: false},
 			{Healthy: true},
 			{Healthy: false},
 			{Healthy: true},
@@ -60,7 +61,7 @@ func TestWorkloadHealthChecker_PerformApplicationHealthCheck(t *testing.T) {
 			{Healthy: true},
 			{Healthy: false},
 		}
-		tcpHealthStatuses := [6]bool{true, false, true, false, true, false}
+		tcpHealthStatuses := [7]bool{false, true, false, true, false, true, false}
 
 		cont := make(chan struct{}, 6)
 		// wait for go-ahead for state change
@@ -87,7 +88,7 @@ func TestWorkloadHealthChecker_PerformApplicationHealthCheck(t *testing.T) {
 
 		eventNum := atomic.NewInt32(0)
 		go tcpHealthChecker.PerformApplicationHealthCheck(func(event *ProbeEvent) {
-			if eventNum.Load() >= 6 {
+			if eventNum.Load() >= 7 {
 				return
 			}
 			if event.Healthy != expectedTCPEvents[eventNum.Load()].Healthy {


### PR DESCRIPTION
when initial health check is failure, we will never send the event out.    This PR will fix the problem.