### PR TITLE
[istioctl] Add generate subcommand and webhookName option to revision tag command

### DIFF
--- a/istioctl/cmd/tag.go
+++ b/istioctl/cmd/tag.go
@@ -261,7 +261,7 @@ func setTag(ctx context.Context, kubeClient kube.ExtendedClient, tag, revision s
 	if err != nil {
 		return err
 	}
-	if len(revWebhookCollisions) > 0 {
+	if !generate && !overwrite && len(revWebhookCollisions) > 0 {
 		return fmt.Errorf("cannot create revision tag %q: found existing control plane revision with same name", tag)
 	}
 

--- a/istioctl/cmd/tag.go
+++ b/istioctl/cmd/tag.go
@@ -111,16 +111,16 @@ func tagSetCommand() *cobra.Command {
 		Long: `Create or modify revision tags. Tag an Istio control plane revision for use with namespace istio.io/rev
 injection labels.`,
 		Example: ` # Create a revision tag from the "1-8-0" revision
-	istioctl x tag set prod --revision 1-8-0
+ istioctl x tag set prod --revision 1-8-0
 
-	# Point namespace "test-ns" at the revision pointed to by the "prod" revision tag
-	kubectl label ns test-ns istio.io/rev=prod
+ # Point namespace "test-ns" at the revision pointed to by the "prod" revision tag
+ kubectl label ns test-ns istio.io/rev=prod
 
-	# Change the revision tag to reference the "1-8-1" revision
-	istioctl x tag set prod --revision 1-8-1 --overwrite
+ # Change the revision tag to reference the "1-8-1" revision
+ istioctl x tag set prod --revision 1-8-1 --overwrite
 
-	# Rollout namespace "test-ns" to update workloads to the "1-8-1" revision
-	kubectl rollout restart deployments -n test-ns
+ # Rollout namespace "test-ns" to update workloads to the "1-8-1" revision
+ kubectl rollout restart deployments -n test-ns
 `,
 		SuggestFor: []string{"create"},
 		Args: func(cmd *cobra.Command, args []string) error {
@@ -159,16 +159,16 @@ func tagGenerateCommand() *cobra.Command {
 		Long: `Create a revision tag and output to the command's stdout. Tag an Istio control plane revision for use with namespace istio.io/rev
 injection labels.`,
 		Example: ` # Create a revision tag from the "1-8-0" revision
-	istioctl x tag generate prod --revision 1-8-0 > tag.yaml
+ istioctl x tag generate prod --revision 1-8-0 > tag.yaml
 
-	# Apply the tag to cluster
-	kubectl apply -f tag.yaml
+ # Apply the tag to cluster
+ kubectl apply -f tag.yaml
 
-	# Point namespace "test-ns" at the revision pointed to by the "prod" revision tag
-	kubectl label ns test-ns istio.io/rev=prod
+ # Point namespace "test-ns" at the revision pointed to by the "prod" revision tag
+ kubectl label ns test-ns istio.io/rev=prod
 
-	# Rollout namespace "test-ns" to update workloads to the "1-8-0" revision
-	kubectl rollout restart deployments -n test-ns
+ # Rollout namespace "test-ns" to update workloads to the "1-8-0" revision
+ kubectl rollout restart deployments -n test-ns
 `,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {

--- a/istioctl/cmd/tag.go
+++ b/istioctl/cmd/tag.go
@@ -51,7 +51,7 @@ overwrite existing revision tags.`
 	tagCreatedStr   = `Revision tag %q created, referencing control plane revision %q. To enable injection using this
 revision tag, use 'kubectl label namespace <NAMESPACE> istio.io/rev=%s'
 `
-	webhookNameHelpStr = "Name to use to for a revision tag's mutating webhook configuration."
+	webhookNameHelpStr = "Name to use for a revision tag's mutating webhook configuration."
 )
 
 var (
@@ -85,12 +85,14 @@ at some later point.
 This allows operators to change which Istio control plane revision should handle injection for a namespace or set of namespaces
 without manual relabeling of the "istio.io/rev" tag.
 `,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			cmd.HelpFunc()(cmd, args)
+		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 0 {
 				return fmt.Errorf("unknown subcommand %q", args[0])
 			}
-
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.HelpFunc()(cmd, args)
 			return nil
 		},
 	}
@@ -122,14 +124,16 @@ injection labels.`,
 	kubectl rollout restart deployments -n test-ns
 `,
 		SuggestFor: []string{"create"},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				return fmt.Errorf("must provide a tag for modification")
 			}
 			if len(args) > 1 {
 				return fmt.Errorf("must provide a single tag for creation")
 			}
-
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := kubeClient(kubeconfig, configContext)
 			if err != nil {
 				return fmt.Errorf("failed to create Kubernetes client: %v", err)
@@ -167,14 +171,16 @@ injection labels.`,
 	# Rollout namespace "test-ns" to update workloads to the "1-8-0" revision
 	kubectl rollout restart deployments -n test-ns
 `,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				return fmt.Errorf("must provide a tag for modification")
 			}
 			if len(args) > 1 {
 				return fmt.Errorf("must provide a single tag for creation")
 			}
-
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := kubeClient(kubeconfig, configContext)
 			if err != nil {
 				return fmt.Errorf("failed to create Kubernetes client: %v", err)
@@ -200,11 +206,13 @@ func tagListCommand() *cobra.Command {
 		Short:   "List existing revision tags",
 		Example: "istioctl x tag list",
 		Aliases: []string{"show"},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 0 {
 				return fmt.Errorf("tag list command does not accept arguments")
 			}
-
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := kubeClient(kubeconfig, configContext)
 			if err != nil {
 				return fmt.Errorf("failed to create Kubernetes client: %v", err)
@@ -230,14 +238,16 @@ revision tag before removing using the "istioctl x tag list" command.
 	istioctl x tag remove prod
 `,
 		Aliases: []string{"delete"},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				return fmt.Errorf("must provide a tag for removal")
 			}
 			if len(args) > 1 {
 				return fmt.Errorf("must provide a single tag for removal")
 			}
-
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := kubeClient(kubeconfig, configContext)
 			if err != nil {
 				return fmt.Errorf("failed to create Kubernetes client: %v", err)

--- a/istioctl/cmd/tag.go
+++ b/istioctl/cmd/tag.go
@@ -60,7 +60,6 @@ var (
 	manifestsPath    = ""
 	overwrite        = false
 	skipConfirmation = false
-	generate         = false
 	webhookName      = ""
 )
 

--- a/istioctl/cmd/tag.go
+++ b/istioctl/cmd/tag.go
@@ -152,8 +152,8 @@ injection labels.`,
 func tagGenerateCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "generate <revision-tag>",
-		Short: "Create or modify revision tags",
-		Long: `Create or modify revision tags. Tag an Istio control plane revision for use with namespace istio.io/rev
+		Short: "Generate configuration for a revision tag to stdout",
+		Long: `Create a revision tag and output to the command's stdout. Tag an Istio control plane revision for use with namespace istio.io/rev
 injection labels.`,
 		Example: ` # Create a revision tag from the "1-8-0" revision
 	istioctl x tag generate prod --revision 1-8-0 > tag.yaml
@@ -164,10 +164,7 @@ injection labels.`,
 	# Point namespace "test-ns" at the revision pointed to by the "prod" revision tag
 	kubectl label ns test-ns istio.io/rev=prod
 
-	# Change the revision tag to reference the "1-8-1" revision
-	istioctl x tag set prod --revision 1-8-1 --overwrite
-
-	# Rollout namespace "test-ns" to update workloads to the "1-8-1" revision
+	# Rollout namespace "test-ns" to update workloads to the "1-8-0" revision
 	kubectl rollout restart deployments -n test-ns
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/istioctl/cmd/tag.go
+++ b/istioctl/cmd/tag.go
@@ -51,6 +51,7 @@ overwrite existing revision tags.`
 	tagCreatedStr   = `Revision tag %q created, referencing control plane revision %q. To enable injection using this
 revision tag, use 'kubectl label namespace <NAMESPACE> istio.io/rev=%s'
 `
+	webhookNameHelpStr = "Name to use to for a revision tag's mutating webhook configuration."
 )
 
 var (
@@ -59,6 +60,8 @@ var (
 	manifestsPath    = ""
 	overwrite        = false
 	skipConfirmation = false
+	generate         = false
+	webhookName      = ""
 )
 
 type tagWebhookConfig struct {
@@ -93,6 +96,7 @@ without manual relabeling of the "istio.io/rev" tag.
 	}
 
 	cmd.AddCommand(tagSetCommand())
+	cmd.AddCommand(tagGenerateCommand())
 	cmd.AddCommand(tagListCommand())
 	cmd.AddCommand(tagRemoveCommand())
 
@@ -131,7 +135,7 @@ injection labels.`,
 				return fmt.Errorf("failed to create Kubernetes client: %v", err)
 			}
 
-			return setTag(context.Background(), client, args[0], revision, cmd.OutOrStdout())
+			return setTag(context.Background(), client, args[0], revision, false, cmd.OutOrStdout())
 		},
 	}
 
@@ -139,6 +143,55 @@ injection labels.`,
 	cmd.PersistentFlags().StringVarP(&manifestsPath, "manifests", "d", "", mesh.ManifestsFlagHelpStr)
 	cmd.PersistentFlags().BoolVarP(&skipConfirmation, "skip-confirmation", "y", false, skipConfirmationFlagHelpStr)
 	cmd.PersistentFlags().StringVarP(&revision, "revision", "r", "", revisionHelpStr)
+	cmd.PersistentFlags().StringVarP(&webhookName, "webhook-name", "", "", webhookNameHelpStr)
+	_ = cmd.MarkPersistentFlagRequired("revision")
+
+	return cmd
+}
+
+func tagGenerateCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "generate <revision-tag>",
+		Short: "Create or modify revision tags",
+		Long: `Create or modify revision tags. Tag an Istio control plane revision for use with namespace istio.io/rev
+injection labels.`,
+		Example: ` # Create a revision tag from the "1-8-0" revision
+	istioctl x tag generate prod --revision 1-8-0 > tag.yaml
+
+	# Apply the tag to cluster
+	kubectl apply -f tag.yaml
+
+	# Point namespace "test-ns" at the revision pointed to by the "prod" revision tag
+	kubectl label ns test-ns istio.io/rev=prod
+
+	# Change the revision tag to reference the "1-8-1" revision
+	istioctl x tag set prod --revision 1-8-1 --overwrite
+
+	# Rollout namespace "test-ns" to update workloads to the "1-8-1" revision
+	kubectl rollout restart deployments -n test-ns
+`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return fmt.Errorf("must provide a tag for modification")
+			}
+			if len(args) > 1 {
+				return fmt.Errorf("must provide a single tag for creation")
+			}
+
+			client, err := kubeClient(kubeconfig, configContext)
+			if err != nil {
+				return fmt.Errorf("failed to create Kubernetes client: %v", err)
+			}
+
+			return setTag(context.Background(), client, args[0], revision, true, cmd.OutOrStdout())
+		},
+	}
+
+	cmd.PersistentFlags().BoolVar(&overwrite, "overwrite", false, overrideHelpStr)
+	cmd.PersistentFlags().StringVarP(&manifestsPath, "manifests", "d", "", mesh.ManifestsFlagHelpStr)
+	cmd.PersistentFlags().BoolVarP(&skipConfirmation, "skip-confirmation", "y", false, skipConfirmationFlagHelpStr)
+	cmd.PersistentFlags().StringVarP(&revision, "revision", "r", "", revisionHelpStr)
+	cmd.PersistentFlags().StringVarP(&webhookName, "webhook-name", "", "", webhookNameHelpStr)
 	_ = cmd.MarkPersistentFlagRequired("revision")
 
 	return cmd
@@ -202,7 +255,7 @@ revision tag before removing using the "istioctl x tag list" command.
 }
 
 // setTag creates or modifies a revision tag.
-func setTag(ctx context.Context, kubeClient kube.ExtendedClient, tag, revision string, w io.Writer) error {
+func setTag(ctx context.Context, kubeClient kube.ExtendedClient, tag, revision string, generate bool, w io.Writer) error {
 	// abort if there exists a revision with the target tag name
 	revWebhookCollisions, err := getWebhooksWithRevision(ctx, kubeClient, tag)
 	if err != nil {
@@ -240,10 +293,21 @@ func setTag(ctx context.Context, kubeClient kube.ExtendedClient, tag, revision s
 	if err != nil {
 		return fmt.Errorf("failed to create tag webhook: %v", err)
 	}
+	// custom webhook name specified, change the generated tag webhook configuration
+	if webhookName != "" {
+		tagWhYAML = renameTagWebhookConfiguration(tagWhYAML, tag, webhookName)
+	}
+	if generate {
+		_, err := w.Write([]byte(tagWhYAML))
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+
 	if err := applyYAML(kubeClient, tagWhYAML, "istio-system"); err != nil {
 		return fmt.Errorf("failed to apply tag webhook MutatingWebhookConfiguration to cluster: %v", err)
 	}
-
 	fmt.Fprintf(w, tagCreatedStr, tag, revision, tag)
 	return nil
 }
@@ -479,6 +543,11 @@ func applyYAML(client kube.ExtendedClient, yamlContent, ns string) error {
 		return fmt.Errorf("failed applying manifest %s: %v", yamlFile, err)
 	}
 	return nil
+}
+
+func renameTagWebhookConfiguration(wh, tag, name string) string {
+	webhookNameStr := fmt.Sprintf("%s-%s", "istio-revision-tag", tag)
+	return strings.ReplaceAll(wh, webhookNameStr, name)
 }
 
 // writeToTempFile taken from remote_secret.go

--- a/istioctl/cmd/tag_test.go
+++ b/istioctl/cmd/tag_test.go
@@ -382,7 +382,7 @@ func TestSetTagErrors(t *testing.T) {
 			mockClient := kube.MockClient{
 				Interface: client,
 			}
-			err := setTag(context.Background(), mockClient, tc.tag, tc.revision, &out)
+			err := setTag(context.Background(), mockClient, tc.tag, tc.revision, false, &out)
 			if tc.error == "" && err != nil {
 				t.Fatalf("expected no error, got %v", err)
 			}


### PR DESCRIPTION
Allows dumping revision tag mutating webhook YAML to stdout with `istioctl tag generate prod --revision 1-8-3`, analogous to `istioctl manifest generate`.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[x] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
