### PR TITLE
[Test Framework] Fix panic if echo creation fails

### DIFF
--- a/pkg/test/framework/components/echo/kube/instance.go
+++ b/pkg/test/framework/components/echo/kube/instance.go
@@ -62,7 +62,6 @@ func newInstance(ctx resource.Context, originalCfg echo.Config) (out *instance, 
 		ctx:     ctx,
 		cluster: cfg.Cluster,
 	}
-	c.id = ctx.TrackResource(c)
 
 	// Deploy echo to the cluster
 	c.deployment, err = newDeployment(ctx, cfg)
@@ -75,6 +74,10 @@ func newInstance(ctx resource.Context, originalCfg echo.Config) (out *instance, 
 	if err != nil {
 		return nil, err
 	}
+
+	// Now that we have the successfully created the workload manager, track this resource so
+	// that it will be closed when it goes out of scope.
+	c.id = ctx.TrackResource(c)
 
 	// Now retrieve the service information to find the ClusterIP
 	s, err := c.cluster.CoreV1().Services(cfg.Namespace.Name()).Get(context.TODO(), cfg.Service, metav1.GetOptions{})


### PR DESCRIPTION
This fixes a panic that will occur if echo creation fails before the workload manager is created.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.