### PR TITLE
fix(azure bootstrap): handle tags with semicolons or without values

### DIFF
--- a/pkg/bootstrap/platform/azure.go
+++ b/pkg/bootstrap/platform/azure.go
@@ -189,8 +189,13 @@ func (e *azureEnv) azureTags() map[string]string {
 	tags := map[string]string{}
 	if at, ok := e.computeMetadata["tags"]; ok && len(at.(string)) > 0 {
 		for _, tag := range strings.Split(at.(string), ";") {
-			kv := strings.Split(tag, ":")
-			tags[e.prefixName(kv[0])] = kv[1]
+			kv := strings.SplitN(tag, ":", 2)
+			switch len(kv) {
+			case 2:
+				tags[e.prefixName(kv[0])] = kv[1]
+			case 1:
+				tags[e.prefixName(kv[0])] = ""
+			}
 		}
 	}
 	return tags

--- a/pkg/bootstrap/platform/azure.go
+++ b/pkg/bootstrap/platform/azure.go
@@ -187,6 +187,22 @@ func (e *azureEnv) azureName() string {
 // Returns the Azure tags
 func (e *azureEnv) azureTags() map[string]string {
 	tags := map[string]string{}
+	if tl, ok := e.computeMetadata["tagsList"]; ok {
+		tlByte, err := json.Marshal(tl)
+		if err != nil {
+			return tags
+		}
+		var atl []azureTag
+		err = json.Unmarshal(tlByte, &atl)
+		if err != nil {
+			return tags
+		}
+		for _, tag := range atl {
+			tags[e.prefixName(tag.Name)] = tag.Value
+		}
+		return tags
+	}
+	// fall back to tags if tagsList is not available
 	if at, ok := e.computeMetadata["tags"]; ok && len(at.(string)) > 0 {
 		for _, tag := range strings.Split(at.(string), ";") {
 			kv := strings.SplitN(tag, ":", 2)
@@ -220,4 +236,10 @@ func (e *azureEnv) azureVMID() string {
 		return aid.(string)
 	}
 	return ""
+}
+
+// used for simpler JSON parsing
+type azureTag struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
 }

--- a/pkg/bootstrap/platform/azure_test.go
+++ b/pkg/bootstrap/platform/azure_test.go
@@ -28,6 +28,9 @@ const (
 		`"vmId": "13f56399-bd52-4150-9748-7190aae1ff21", "zone": "1"}}`
 	MockMetadataWithValuelessTag = `{"compute": {"location": "centralus", "name": "negasonic", "tags": "Department", ` +
 		`"vmId": "13f56399-bd52-4150-9748-7190aae1ff21", "zone": "1"}}`
+	MockMetadataTagsList = `{"compute": {"location": "centralus", "name": "negasonic", ` +
+		`"tagsList": [{"name": "Department", "value":"IT"}, {"name": "Environment", "value": "Prod"}, {"name": "Role", "value": "WorkerRole; OtherWorker"}], ` +
+		`"vmId": "13f56399-bd52-4150-9748-7190aae1ff21", "zone": "1"}}`
 )
 
 func TestAzureVersionUpdate(t *testing.T) {
@@ -77,6 +80,13 @@ func TestAzureMetadata(t *testing.T) {
 			"handle tags without values", MockMetadataWithValuelessTag,
 			map[string]string{
 				"azure_Department": "", "azure_name": "negasonic", "azure_location": "centralus", "azure_vmId": "13f56399-bd52-4150-9748-7190aae1ff21",
+			},
+		},
+		{
+			"handle tagsList", MockMetadataTagsList,
+			map[string]string{
+				"azure_Department": "IT", "azure_Environment": "Prod", "azure_Role": "WorkerRole; OtherWorker",
+				"azure_name": "negasonic", "azure_location": "centralus", "azure_vmId": "13f56399-bd52-4150-9748-7190aae1ff21",
 			},
 		},
 	}

--- a/pkg/bootstrap/platform/azure_test.go
+++ b/pkg/bootstrap/platform/azure_test.go
@@ -26,6 +26,8 @@ const (
 	MockVersionsTemplate = `{"error": "Bad request. api-version was not specified in the request","newest-versions": ["%s"]}`
 	MockMetadata         = `{"compute": {"location": "centralus", "name": "negasonic", "tags": "Department:IT;Environment:Prod;Role:WorkerRole", ` +
 		`"vmId": "13f56399-bd52-4150-9748-7190aae1ff21", "zone": "1"}}`
+	MockMetadataWithValuelessTag = `{"compute": {"location": "centralus", "name": "negasonic", "tags": "Department", ` +
+		`"vmId": "13f56399-bd52-4150-9748-7190aae1ff21", "zone": "1"}}`
 )
 
 func TestAzureVersionUpdate(t *testing.T) {
@@ -69,6 +71,12 @@ func TestAzureMetadata(t *testing.T) {
 			map[string]string{
 				"azure_Department": "IT", "azure_Environment": "Prod", "azure_Role": "WorkerRole",
 				"azure_name": "negasonic", "azure_location": "centralus", "azure_vmId": "13f56399-bd52-4150-9748-7190aae1ff21",
+			},
+		},
+		{
+			"handle tags without values", MockMetadataWithValuelessTag,
+			map[string]string{
+				"azure_Department": "", "azure_name": "negasonic", "azure_location": "centralus", "azure_vmId": "13f56399-bd52-4150-9748-7190aae1ff21",
 			},
 		},
 	}

--- a/releasenotes/notes/azureTags.yaml
+++ b/releasenotes/notes/azureTags.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: telemetry
+issue:
+- 31176
+releaseNotes:
+- |
+  **Fixed** issue with metadata handling for Azure platform. Support added for
+  tagsList serialization of tags on instance metadata.


### PR DESCRIPTION
As reported in https://github.com/istio/istio/issues/31176, there are situations in which the platform metadata for Azure can lead to Envoy crashes. This PR attempts to improve the handling so as to remove the crashes.

Note: I have no way of verifying behavior on Azure.

Fixes: https://github.com/istio/istio/issues/31176