### PR TITLE
cleanup enable crd validation feature flag

### DIFF
--- a/pilot/pkg/config/kube/crdclient/client.go
+++ b/pilot/pkg/config/kube/crdclient/client.go
@@ -199,14 +199,6 @@ func (cl *Client) Get(typ config.GroupVersionKind, name, namespace string) *conf
 	if !cl.objectInRevision(cfg) {
 		return nil
 	}
-	if features.EnableCRDValidation {
-		schema, _ := cl.Schemas().FindByGroupVersionKind(typ)
-		if _, err = schema.Resource().ValidateConfig(*cfg); err != nil {
-			handleValidationFailure(cfg, err)
-			return nil
-		}
-
-	}
 	return cfg
 }
 
@@ -280,17 +272,6 @@ func (cl *Client) List(kind config.GroupVersionKind, namespace string) ([]config
 	out := make([]config.Config, 0, len(list))
 	for _, item := range list {
 		cfg := TranslateObject(item, kind, cl.domainSuffix)
-		if features.EnableCRDValidation {
-			schema, _ := cl.Schemas().FindByGroupVersionKind(kind)
-			if _, err = schema.Resource().ValidateConfig(*cfg); err != nil {
-				handleValidationFailure(cfg, err)
-				// DO NOT RETURN ERROR: if a single object is bad, it'll be ignored (with a log message), but
-				// the rest should still be processed.
-				continue
-			}
-
-		}
-
 		if cl.objectInRevision(cfg) {
 			out = append(out, *cfg)
 		}

--- a/pilot/pkg/config/kube/crdclient/metrics.go
+++ b/pilot/pkg/config/kube/crdclient/metrics.go
@@ -15,47 +15,24 @@
 package crdclient
 
 import (
-	"istio.io/istio/pkg/config"
 	"istio.io/pkg/monitoring"
 )
 
 var (
 	typeTag  = monitoring.MustCreateLabel("type")
 	eventTag = monitoring.MustCreateLabel("event")
-	nameTag  = monitoring.MustCreateLabel("name")
 
 	k8sEvents = monitoring.NewSum(
 		"pilot_k8s_cfg_events",
 		"Events from k8s config.",
 		monitoring.WithLabels(typeTag, eventTag),
 	)
-
-	k8sErrors = monitoring.NewGauge(
-		"pilot_k8s_object_errors",
-		"Errors converting k8s CRDs",
-		monitoring.WithLabels(nameTag),
-	)
-
-	k8sTotalErrors = monitoring.NewSum(
-		"pilot_total_k8s_object_errors",
-		"Total Errors converting k8s CRDs",
-	)
 )
 
 func init() {
 	monitoring.MustRegister(k8sEvents)
-	monitoring.MustRegister(k8sErrors)
-	monitoring.MustRegister(k8sTotalErrors)
 }
 
 func incrementEvent(kind, event string) {
 	k8sEvents.With(typeTag.Value(kind), eventTag.Value(event)).Increment()
-}
-
-func handleValidationFailure(obj *config.Config, err error) {
-	key := obj.Namespace + "/" + obj.Name
-	scope.Debugf("CRD validation failed: %s (%v): %v", key, obj.GroupVersionKind, err)
-	k8sErrors.With(nameTag.Value(key)).Record(1)
-
-	k8sTotalErrors.Increment()
 }

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -228,14 +228,6 @@ var (
 			"To ensure proper security, PILOT_ENABLE_XDS_IDENTITY_CHECK=true is required as well.",
 	).Get()
 
-	EnableCRDValidation = env.RegisterBoolVar(
-		"PILOT_ENABLE_CRD_VALIDATION",
-		false,
-		"If enabled, pilot will validate CRDs while retrieving CRDs from kubernetes cache."+
-			"Use this flag to enable validation of CRDs in Pilot, especially in deployments "+
-			"that do not have galley installed.",
-	).Get()
-
 	EnableAnalysis = env.RegisterBoolVar(
 		"PILOT_ENABLE_ANALYSIS",
 		false,


### PR DESCRIPTION
This feature flag is not needed now as validating webhook is part of Istiod it self and can be enabled if CRD validation is needed.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X ] Does not have any changes that may affect Istio users.
