### PR TITLE
Update build_base_images to only build one image, tag push others,

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -185,6 +185,9 @@ ifeq ($(HUB),)
   $(error "HUB cannot be empty")
 endif
 
+# For dockerx builds, allow HUBS which is a space seperated list of hubs. Default to HUB.
+HUBS ?= $(HUB)
+
 # If tag not explicitly set in users' .istiorc.mk or command line, default to the git sha.
 TAG ?= $(shell git rev-parse --verify HEAD)
 ifeq ($(TAG),)

--- a/tools/build-base-images.sh
+++ b/tools/build-base-images.sh
@@ -19,7 +19,7 @@
 
 set -ex
 
-HUBS="${HUBS:?specify a comma seperated list of hubs}"
+HUBS="${HUBS:?specify a space seperated list of hubs}"
 TAG="${TAG:?specify a tag}"
 
 # For multi architecture building:
@@ -29,21 +29,4 @@ TAG="${TAG:?specify a tag}"
 # * export DOCKER_ARCHITECTURES="linux/amd64,linux/arm64"
 # Note: if you already have a container builder before running the qemu setup you will need to restart them
 
-index=0
-DOCKER_TARGETS="docker.base docker.distroless docker.app_sidecar_base_debian_9 docker.app_sidecar_base_debian_10 docker.app_sidecar_base_ubuntu_xenial docker.app_sidecar_base_ubuntu_bionic docker.app_sidecar_base_ubuntu_focal docker.app_sidecar_base_centos_7 docker.app_sidecar_base_centos_8"
-
-for hub in ${HUBS//,/ }  # Iterate over comma seperated hubs
-do
- if (( index == 0 )) ; then # For first HUB, build and push the images
-    hubBuilt=${hub}
-    HUB=${hub} BUILDX_BAKE_EXTRA_OPTIONS="--no-cache --pull" DOCKER_TARGETS=${DOCKER_TARGETS} make dockerx.pushx
-  else
-    for target in ${DOCKER_TARGETS// / } # For successive HUBs, iterate of the images, retagging for the HUB and pushing
-    do
-      image=${target#*.}
-      docker tag "${hubBuilt}"/"${image}":"${TAG}" "${hub}"/"${image}":"${TAG}"
-      docker push "${hub}"/"${image}":"${TAG}"
-    done
-  fi
-  ((index=index+1))
-done
+BUILDX_BAKE_EXTRA_OPTIONS="--no-cache --pull" DOCKER_TARGETS="docker.base docker.distroless docker.app_sidecar_base_debian_9 docker.app_sidecar_base_debian_10 docker.app_sidecar_base_ubuntu_xenial docker.app_sidecar_base_ubuntu_bionic docker.app_sidecar_base_ubuntu_focal docker.app_sidecar_base_centos_7 docker.app_sidecar_base_centos_8" make dockerx.pushx

--- a/tools/build-base-images.sh
+++ b/tools/build-base-images.sh
@@ -29,7 +29,21 @@ TAG="${TAG:?specify a tag}"
 # * export DOCKER_ARCHITECTURES="linux/amd64,linux/arm64"
 # Note: if you already have a container builder before running the qemu setup you will need to restart them
 
-for hub in ${HUBS//,/ }
+index=0
+DOCKER_TARGETS="docker.base docker.distroless docker.app_sidecar_base_debian_9 docker.app_sidecar_base_debian_10 docker.app_sidecar_base_ubuntu_xenial docker.app_sidecar_base_ubuntu_bionic docker.app_sidecar_base_ubuntu_focal docker.app_sidecar_base_centos_7 docker.app_sidecar_base_centos_8"
+
+for hub in ${HUBS//,/ }  # Iterate over comma seperated hubs
 do
-  HUB=${hub} BUILDX_BAKE_EXTRA_OPTIONS="--no-cache --pull" DOCKER_TARGETS="docker.base docker.distroless docker.app_sidecar_base_debian_9 docker.app_sidecar_base_debian_10 docker.app_sidecar_base_ubuntu_xenial docker.app_sidecar_base_ubuntu_bionic docker.app_sidecar_base_ubuntu_focal docker.app_sidecar_base_centos_7 docker.app_sidecar_base_centos_8" make dockerx.pushx
+ if (( index == 0 )) ; then # For first HUB, build and push the images
+    hubBuilt=${hub}
+    HUB=${hub} BUILDX_BAKE_EXTRA_OPTIONS="--no-cache --pull" DOCKER_TARGETS=${DOCKER_TARGETS} make dockerx.pushx
+  else
+    for target in ${DOCKER_TARGETS// / } # For successive HUBs, iterate of the images, retagging for the HUB and pushing
+    do
+      image=${target#*.}
+      docker tag "${hubBuilt}"/"${image}":"${TAG}" "${hub}"/"${image}":"${TAG}"
+      docker push "${hub}"/"${image}":"${TAG}"
+    done
+  fi
+  ((index=index+1))
 done

--- a/tools/buildx-gen.sh
+++ b/tools/buildx-gen.sh
@@ -87,11 +87,19 @@ for file in "$@"; do
       VM_IMAGE_VERSION="${split[-1]}"
     fi
 
+    # Create a list of tags by iterating over HUBs
+    tags=""
+    for hub in ${HUBS};
+    do
+      tags=${tags}"\"${hub}/${image}:${tag}\", "
+    done
+    tags="${tags%, *}" # remove training ', '
+
     cat <<EOF >> "${config}"
 target "$image-$variant" {
     context = "${out}/${file}"
     dockerfile = "Dockerfile.$image"
-    tags = ["${HUB}/${image}:${tag}"]
+    tags = [${tags}]
     platforms = [$(to_platform_list "${image}" "${DOCKER_ARCHITECTURES}")]
     args = {
       BASE_VERSION = "${BASE_VERSION}"

--- a/tools/istio-docker.mk
+++ b/tools/istio-docker.mk
@@ -228,7 +228,7 @@ dockerx: DOCKER_RULE?=mkdir -p $(DOCKERX_BUILD_TOP)/$@ && cp -rp $^ $(DOCKERX_BU
 dockerx: RENAME_TEMPLATE?=mkdir -p $(DOCKERX_BUILD_TOP)/$@ && cp $(ECHO_DOCKER)/$(VM_OS_DOCKERFILE_TEMPLATE) $(DOCKERX_BUILD_TOP)/$@/Dockerfile$(suffix $@)
 dockerx: docker | $(ISTIO_DOCKER_TAR)
 dockerx:
-	HUB=$(HUB) \
+	HUBS="$(HUBS)" \
 		TAG=$(TAG) \
 		PROXY_REPO_SHA=$(PROXY_REPO_SHA) \
 		VERSION=$(VERSION) \


### PR DESCRIPTION
The prior PR iterated over the comma separated hubs, and built and pushed each set of images. This could result in different images across the hubs.

This PR will build and push the first HUBs images, and for successive Hubs, retag the images using the new HUB and then push. This will result in matching images across the HUBs.