### PR TITLE
[release-1.9] wait for pod deletion before echo is ready

### DIFF
--- a/pkg/kube/util.go
+++ b/pkg/kube/util.go
@@ -129,6 +129,9 @@ func SetRestDefaults(config *rest.Config) *rest.Config {
 
 // CheckPodReady returns nil if the given pod and all of its containers are ready.
 func CheckPodReady(pod *kubeApiCore.Pod) error {
+	if pod.ObjectMeta.DeletionTimestamp != nil {
+		return fmt.Errorf("pod not ready, being deleted")
+	}
 	switch pod.Status.Phase {
 	case kubeApiCore.PodSucceeded:
 		return nil

--- a/pkg/test/kube/util.go
+++ b/pkg/test/kube/util.go
@@ -95,6 +95,10 @@ func CheckPodsAreReady(fetchFunc PodFetchFunc) ([]kubeApiCore.Pod, error) {
 		return nil, err
 	}
 
+	if len(fetched) == 0 {
+		return nil, fmt.Errorf("fetched 0 pods")
+	}
+
 	for i, p := range fetched {
 		msg := "Ready"
 		if e := istioKube.CheckPodReady(&p); e != nil {


### PR DESCRIPTION
When running multiple suites with `--istio.test.stableNamespace` where each suite shares a namespace prefix (e.g. `echo`) and deployment names (e.g. `client` and `server`), echo's deployer will see Pods that are currently Ready but in a Terminating state and stop waiting for the new echo pods to be ready.

In master this is fixed with #30675 but we don't have an equiv in 1.9. 