### PR TITLE
Backport DNS fixes to 1.9

### DIFF
--- a/pilot/pkg/dns/dns.go
+++ b/pilot/pkg/dns/dns.go
@@ -206,8 +206,72 @@ func (h *LocalDNSServer) ServeDNS(proxy *dnsProxy, w dns.ResponseWriter, req *dn
 		// We did not find the host in our internal cache. Query upstream and return the response as is.
 		response = h.queryUpstream(proxy.upstreamClient, req)
 	}
+
+	roundRobinResponse(response)
 	_ = w.WriteMsg(response)
 	log.Debugf("response for hostname %q (found=%v): %v", hostname, hostFound, response)
+}
+
+// Inspired by https://github.com/coredns/coredns/blob/master/plugin/loadbalance/loadbalance.go
+func roundRobinResponse(res *dns.Msg) {
+	if res.Rcode != dns.RcodeSuccess {
+		return
+	}
+
+	if res.Question[0].Qtype == dns.TypeAXFR || res.Question[0].Qtype == dns.TypeIXFR {
+		return
+	}
+
+	res.Answer = roundRobin(res.Answer)
+	res.Ns = roundRobin(res.Ns)
+	res.Extra = roundRobin(res.Extra)
+}
+
+func roundRobin(in []dns.RR) []dns.RR {
+	cname := []dns.RR{}
+	address := []dns.RR{}
+	mx := []dns.RR{}
+	rest := []dns.RR{}
+	for _, r := range in {
+		switch r.Header().Rrtype {
+		case dns.TypeCNAME:
+			cname = append(cname, r)
+		case dns.TypeA, dns.TypeAAAA:
+			address = append(address, r)
+		case dns.TypeMX:
+			mx = append(mx, r)
+		default:
+			rest = append(rest, r)
+		}
+	}
+
+	roundRobinShuffle(address)
+	roundRobinShuffle(mx)
+
+	out := append(cname, rest...)
+	out = append(out, address...)
+	out = append(out, mx...)
+	return out
+}
+
+func roundRobinShuffle(records []dns.RR) {
+	switch l := len(records); l {
+	case 0, 1:
+		break
+	case 2:
+		if dns.Id()%2 == 0 {
+			records[0], records[1] = records[1], records[0]
+		}
+	default:
+		for j := 0; j < l*(int(dns.Id())%4+1); j++ {
+			q := int(dns.Id()) % l
+			p := int(dns.Id()) % l
+			if q == p {
+				p = (p + 1) % l
+			}
+			records[q], records[p] = records[p], records[q]
+		}
+	}
 }
 
 func (h *LocalDNSServer) Close() {

--- a/pilot/pkg/dns/dns.go
+++ b/pilot/pkg/dns/dns.go
@@ -159,7 +159,7 @@ func (h *LocalDNSServer) UpdateLookupTable(nt *nds.NameTable) {
 // ServerDNS is the implementation of DNS interface
 func (h *LocalDNSServer) ServeDNS(proxy *dnsProxy, w dns.ResponseWriter, req *dns.Msg) {
 	var response *dns.Msg
-	log := log.WithLabels("protocol", proxy.protocol)
+	log := log.WithLabels("protocol", proxy.protocol, "edns", req.IsEdns0() != nil)
 	if log.DebugEnabled() {
 		id := uuid.New()
 		log = log.WithLabels("id", id)
@@ -195,21 +195,34 @@ func (h *LocalDNSServer) ServeDNS(proxy *dnsProxy, w dns.ResponseWriter, req *dn
 	if hostFound {
 		response = new(dns.Msg)
 		response.SetReply(req)
+		// We are the authority here, since we control DNS for known hostnames
+		response.Authoritative = true
+		// Even if answers is empty, we still return NOERROR. This matches expected behavior of DNS
+		// servers. NXDOMAIN means we do not know *anything* about the domain; if we set it here then
+		// a client (ie curl, see https://github.com/istio/istio/issues/31250) sending parallel
+		// requests for A and AAAA may get NXDOMAIN for AAAA and treat the entire thing as a NXDOMAIN
 		response.Answer = answers
-		if len(answers) == 0 {
-			// we found the host in our pre-compiled list of known hosts but
-			// there was no valid record for this query type.
-			// so return NXDOMAIN
-			response.Rcode = dns.RcodeNameError
-		}
-	} else {
-		// We did not find the host in our internal cache. Query upstream and return the response as is.
-		response = h.queryUpstream(proxy.upstreamClient, req)
+		// Randomize the responses; this ensures for things like headless services we can do DNS-LB
+		// This matches standard kube-dns behavior. We only do this for cached responses as the
+		// upstream DNS server would already round robin if desired.
+		roundRobinResponse(response)
+		// Truncate response if its too big for the request. In practice, this will only happen with
+		// ~28 headless service replicas. When there are more than that clients need to use eDNS or
+		// TCP (almost every client does this transparently).
+		// In other cases, this is a NOP.
+		response.Truncate(size(proxy.protocol, req))
+		log.Debugf("response for hostname %q (found=true): %v", hostname, response)
+		_ = w.WriteMsg(response)
+		return
 	}
-
-	roundRobinResponse(response)
+	// We did not find the host in our internal cache. Query upstream and return the response as is.
+	response = h.queryUpstream(proxy.upstreamClient, req, log)
+	// Compress the response - we don't know if the incoming response was compressed or not. If it was,
+	// but we don't compress on the outbound, we will run into issues. For example, if the compressed
+	// size is 450 bytes but uncompressed 1000 bytes now we are outside of the non-eDNS UDP size limits
+	response.Truncate(size(proxy.protocol, req))
+	log.Debugf("response for hostname %q (found=false): %v", hostname, response)
 	_ = w.WriteMsg(response)
-	log.Debugf("response for hostname %q (found=%v): %v", hostname, hostFound, response)
 }
 
 // Inspired by https://github.com/coredns/coredns/blob/master/plugin/loadbalance/loadbalance.go
@@ -280,13 +293,15 @@ func (h *LocalDNSServer) Close() {
 }
 
 // TODO: Figure out how to send parallel queries to all nameservers
-func (h *LocalDNSServer) queryUpstream(upstreamClient *dns.Client, req *dns.Msg) *dns.Msg {
+func (h *LocalDNSServer) queryUpstream(upstreamClient *dns.Client, req *dns.Msg, scope *istiolog.Scope) *dns.Msg {
 	var response *dns.Msg
 	for _, upstream := range h.resolvConfServers {
 		cResponse, _, err := upstreamClient.Exchange(req, upstream)
 		if err == nil {
 			response = cResponse
 			break
+		} else {
+			scope.Infof("upstream failure: %v", err)
 		}
 	}
 	if response == nil {
@@ -459,4 +474,28 @@ func cname(host string, targetHost string) []dns.RR {
 	}
 	answer.Target = targetHost
 	return []dns.RR{answer}
+}
+
+// Size returns if buffer size *advertised* in the requests OPT record.
+// Or when the request was over TCP, we return the maximum allowed size of 64K.
+func size(proto string, r *dns.Msg) int {
+	size := uint16(0)
+	if o := r.IsEdns0(); o != nil {
+		size = o.UDPSize()
+	}
+
+	// normalize size
+	size = ednsSize(proto, size)
+	return int(size)
+}
+
+// ednsSize returns a normalized size based on proto.
+func ednsSize(proto string, size uint16) uint16 {
+	if proto == "tcp" {
+		return dns.MaxMsgSize
+	}
+	if size < dns.MinMsgSize {
+		return dns.MinMsgSize
+	}
+	return size
 }

--- a/pilot/pkg/dns/dns_test.go
+++ b/pilot/pkg/dns/dns_test.go
@@ -15,8 +15,10 @@
 package dns
 
 import (
+	"fmt"
 	"net"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -24,72 +26,13 @@ import (
 	"go.uber.org/atomic"
 
 	nds "istio.io/istio/pilot/pkg/proto"
+	"istio.io/istio/pkg/test"
 )
 
-var (
-	testAgentDNSAddr = "127.0.0.1:15053"
-	testAgentDNS     *LocalDNSServer
-	initErr          error
-)
-
-func init() {
-	initErr = initDNS()
-}
-
-func initDNS() error {
-	var err error
-	testAgentDNS, err = NewLocalDNSServer("ns1", "ns1.svc.cluster.local")
-	if err != nil {
-		return err
-	}
-	testAgentDNS.StartDNS()
-	testAgentDNS.searchNamespaces = []string{"ns1.svc.cluster.local", "svc.cluster.local", "cluster.local"}
-	testAgentDNS.UpdateLookupTable(&nds.NameTable{
-		Table: map[string]*nds.NameTable_NameInfo{
-			"www.google.com": {
-				Ips:      []string{"1.1.1.1"},
-				Registry: "External",
-			},
-			"productpage.ns1.svc.cluster.local": {
-				Ips:       []string{"9.9.9.9"},
-				Registry:  "Kubernetes",
-				Namespace: "ns1",
-				Shortname: "productpage",
-			},
-			"example.ns2.svc.cluster.local": {
-				Ips:       []string{"10.10.10.10"},
-				Registry:  "Kubernetes",
-				Namespace: "ns2",
-				Shortname: "example",
-			},
-			"details.ns2.svc.cluster.remote": {
-				Ips:       []string{"11.11.11.11", "12.12.12.12"},
-				Registry:  "Kubernetes",
-				Namespace: "ns2",
-				Shortname: "details",
-			},
-			"ipv6.localhost": {
-				Ips:      []string{"2001:db8:0:0:0:ff00:42:8329"},
-				Registry: "External",
-			},
-			"dual.localhost": {
-				Ips:      []string{"2.2.2.2", "2001:db8:0:0:0:ff00:42:8329"},
-				Registry: "External",
-			},
-			"ipv4.localhost": {
-				Ips:      []string{"2.2.2.2"},
-				Registry: "External",
-			},
-		},
-	})
-	return nil
-}
+var testAgentDNSAddr = "127.0.0.1:15053"
 
 func TestDNS(t *testing.T) {
-	if initErr != nil {
-		t.Fatal(initErr)
-	}
-
+	initDNS(t)
 	testCases := []struct {
 		name                     string
 		host                     string
@@ -98,6 +41,7 @@ func TestDNS(t *testing.T) {
 		expected                 []dns.RR
 		expectResolutionFailure  int
 		expectExternalResolution bool
+		modifyReq                func(msg *dns.Msg)
 	}{
 		{
 			name:     "success: non k8s host in local cache",
@@ -137,10 +81,9 @@ func TestDNS(t *testing.T) {
 				a("productpage.ns1.", []net.IP{net.ParseIP("9.9.9.9").To4()})...),
 		},
 		{
-			name:                    "failure: AAAA query for IPv4 k8s host (name.namespace) with search namespace",
-			host:                    "productpage.ns1.ns1.svc.cluster.local.",
-			queryAAAA:               true,
-			expectResolutionFailure: dns.RcodeNameError,
+			name:      "success: AAAA query for IPv4 k8s host (name.namespace) with search namespace",
+			host:      "productpage.ns1.ns1.svc.cluster.local.",
+			queryAAAA: true,
 		},
 		{
 			name:     "success: k8s host - non local namespace - name.namespace",
@@ -167,14 +110,24 @@ func TestDNS(t *testing.T) {
 			host: "details.ns2.svc.cluster.remote.",
 			id:   2,
 			expected: a("details.ns2.svc.cluster.remote.",
-				[]net.IP{net.ParseIP("12.12.12.12").To4(), net.ParseIP("11.11.11.11").To4()}),
+				[]net.IP{
+					net.ParseIP("13.13.13.13").To4(),
+					net.ParseIP("14.14.14.14").To4(),
+					net.ParseIP("12.12.12.12").To4(),
+					net.ParseIP("11.11.11.11").To4(),
+				}),
 		},
 		{
 			name: "success: remote cluster k8s svc round robin",
 			host: "details.ns2.svc.cluster.remote.",
 			id:   1,
 			expected: a("details.ns2.svc.cluster.remote.",
-				[]net.IP{net.ParseIP("11.11.11.11").To4(), net.ParseIP("12.12.12.12").To4()}),
+				[]net.IP{
+					net.ParseIP("13.13.13.13").To4(),
+					net.ParseIP("14.14.14.14").To4(),
+					net.ParseIP("11.11.11.11").To4(),
+					net.ParseIP("12.12.12.12").To4(),
+				}),
 		},
 		{
 			name:                    "failure: remote cluster k8s svc - same ns and different domain - name.namespace",
@@ -193,15 +146,41 @@ func TestDNS(t *testing.T) {
 			expected:  aaaa("dual.localhost.", []net.IP{net.ParseIP("2001:db8:0:0:0:ff00:42:8329")}),
 		},
 		{
-			name:                    "failure: Error response if only AAAA records exist for typeA",
-			host:                    "ipv6.localhost.",
-			expectResolutionFailure: dns.RcodeNameError,
+			// This is not a NXDOMAIN, but empty response
+			name: "success: Error response if only AAAA records exist for typeA",
+			host: "ipv6.localhost.",
 		},
 		{
-			name:                    "failure: Error response if only A records exist for typeAAAA",
-			host:                    "ipv4.localhost.",
-			queryAAAA:               true,
-			expectResolutionFailure: dns.RcodeNameError,
+			// This is not a NXDOMAIN, but empty response
+			name:      "success: Error response if only A records exist for typeAAAA",
+			host:      "ipv4.localhost.",
+			queryAAAA: true,
+		},
+		{
+			name: "udp: large request",
+			host: "giant.",
+			// Upstream UDP server returns big response, we cannot serve it. Compliant server would truncate it.
+			expectResolutionFailure: dns.RcodeServerFailure,
+		},
+		{
+			name:     "tcp: large request",
+			host:     "giant.",
+			expected: giantResponse,
+		},
+		{
+			name:                    "large request edns",
+			host:                    "giant.",
+			expectResolutionFailure: dns.RcodeSuccess,
+			expected:                giantResponse,
+			modifyReq: func(msg *dns.Msg) {
+				msg.SetEdns0(dns.MaxMsgSize, false)
+			},
+		},
+		{
+			name:                    "large request truncated",
+			host:                    "giant-tc.",
+			expectResolutionFailure: dns.RcodeSuccess,
+			expected:                giantResponse[:29],
 		},
 	}
 
@@ -218,11 +197,15 @@ func TestDNS(t *testing.T) {
 	currentID := atomic.NewInt32(0)
 	oldID := dns.Id
 	dns.Id = func() uint16 {
-		return uint16(currentID.Load())
+		return uint16(currentID.Inc())
 	}
 	defer func() { dns.Id = oldID }()
 	for i := range clients {
 		for _, tt := range testCases {
+			// Test is for explicit network
+			if (strings.HasPrefix(tt.name, "udp") || strings.HasPrefix(tt.name, "tcp")) && !strings.HasPrefix(tt.name, clients[i].Net) {
+				continue
+			}
 			t.Run(clients[i].Net+"-"+tt.name, func(t *testing.T) {
 				m := new(dns.Msg)
 				q := dns.TypeA
@@ -230,12 +213,15 @@ func TestDNS(t *testing.T) {
 					q = dns.TypeAAAA
 				}
 				m.SetQuestion(tt.host, q)
+				if tt.modifyReq != nil {
+					tt.modifyReq(m)
+				}
 				if tt.id != 0 {
 					currentID.Store(int32(tt.id))
 					defer func() { currentID.Store(0) }()
 				}
 				res, _, err := clients[i].Exchange(m, testAgentDNSAddr)
-
+				t.Log("size: ", len(res.Answer))
 				if err != nil {
 					t.Errorf("Failed to resolve query for %s: %v", tt.host, err)
 				} else {
@@ -247,13 +233,14 @@ func TestDNS(t *testing.T) {
 					if tt.expectExternalResolution {
 						// just make sure that the response has a valid DNS response from upstream resolvers
 						if res.Rcode != dns.RcodeSuccess {
-							t.Errorf("upstream dns resolution for %s failed", tt.host)
+							t.Errorf("upstream dns resolution for %s failed: %v", tt.host, res)
 						}
 					} else {
 						if tt.expectResolutionFailure != res.Rcode {
-							t.Errorf("expected resolution failure but it succeeded for %s", tt.host)
+							t.Errorf("expected resolution failure but it succeeded for %s: %v", tt.host, res)
 						}
 						if !equalsDNSrecords(res.Answer, tt.expected) {
+							t.Log(res)
 							t.Errorf("dns responses for %s do not match. \n got %v\nwant %v", tt.host, res.Answer, tt.expected)
 						}
 					}
@@ -261,17 +248,6 @@ func TestDNS(t *testing.T) {
 			})
 		}
 	}
-	testAgentDNS.Close()
-}
-
-// reflect.DeepEqual doesn't seem to work well for dns.RR
-// as the Rdlength field is not updated in the a(), or aaaa() calls.
-// so zero them out before doing reflect.Deepequal
-func equalsDNSrecords(got []dns.RR, want []dns.RR) bool {
-	for i := range got {
-		got[i].Header().Rdlength = 0
-	}
-	return reflect.DeepEqual(got, want)
 }
 
 // Baseline:
@@ -283,31 +259,16 @@ func equalsDNSrecords(got []dns.RR, want []dns.RR) bool {
 //   docker run -v $PWD:$PWD -w $PWD --network host quay.io/ssro/dnsperf dnsperf -p 15053 -d input -c 100 -l 30
 // where `input` contains dns queries to run, such as `echo.default. A`
 func BenchmarkDNS(t *testing.B) {
-	if initErr != nil {
-		t.Fatal(initErr)
-	}
-
+	initDNS(t)
 	t.Run("via-agent-cache-miss", func(b *testing.B) {
 		bench(b, testAgentDNSAddr, "www.bing.com.")
 	})
-	t.ResetTimer()
-	t.Run("public-dns-server", func(b *testing.B) {
-		dnsConfig, err := dns.ClientConfigFromFile("/etc/resolv.conf")
-		if err != nil {
-			b.Fatal(err)
-		}
-
-		bench(b, dnsConfig.Servers[0]+":53", "www.bing.com.")
-	})
-	t.ResetTimer()
 	t.Run("via-agent-cache-hit-fqdn", func(b *testing.B) {
 		bench(b, testAgentDNSAddr, "www.google.com.")
 	})
-	t.ResetTimer()
 	t.Run("via-agent-cache-hit-cname", func(b *testing.B) {
 		bench(b, testAgentDNSAddr, "www.google.com.ns1.svc.cluster.local.")
 	})
-	testAgentDNS.Close()
 }
 
 func bench(t *testing.B, nameserver string, hostname string) {
@@ -353,4 +314,145 @@ func bench(t *testing.B, nameserver string, hostname string) {
 	if errs+nrs > 0 {
 		t.Log("Sent", t.N, "err", errs, "no response", nrs, "nxdomain", nxdomain, "cname redirect", cnames)
 	}
+}
+
+var giantResponse = func() []dns.RR {
+	ips := []net.IP{}
+	for i := 0; i < 64; i++ {
+		ips = append(ips, net.ParseIP(fmt.Sprintf("240.0.0.%d", i)).To4())
+	}
+	return a("aaaaaaaaaaaa.aaaaaa.", ips)
+}()
+
+func makeUpstream(t test.Failer, responses map[string]string) string {
+	mux := dns.NewServeMux()
+	mux.HandleFunc(".", func(resp dns.ResponseWriter, msg *dns.Msg) {
+		answer := new(dns.Msg)
+		answer.SetReply(msg)
+		answer.Rcode = dns.RcodeNameError
+		if err := resp.WriteMsg(answer); err != nil {
+			t.Fatalf("err: %s", err)
+		}
+	})
+	for hn, desiredResp := range responses {
+		mux.HandleFunc(hn, func(resp dns.ResponseWriter, msg *dns.Msg) {
+			answer := dns.Msg{
+				Answer: a(hn, []net.IP{net.ParseIP(desiredResp).To4()}),
+			}
+			answer.SetReply(msg)
+			answer.Rcode = dns.RcodeSuccess
+			if err := resp.WriteMsg(&answer); err != nil {
+				t.Fatalf("err: %s", err)
+			}
+		})
+	}
+	mux.HandleFunc("giant.", func(resp dns.ResponseWriter, msg *dns.Msg) {
+		answer := &dns.Msg{
+			Answer: giantResponse,
+		}
+		answer.SetReply(msg)
+		answer.Rcode = dns.RcodeSuccess
+		if err := resp.WriteMsg(answer); err != nil {
+			t.Fatalf("err: %s", err)
+		}
+	})
+	mux.HandleFunc("giant-tc.", func(resp dns.ResponseWriter, msg *dns.Msg) {
+		answer := &dns.Msg{
+			Answer: giantResponse,
+		}
+		answer.SetReply(msg)
+		answer.Rcode = dns.RcodeSuccess
+		answer.Truncate(size("udp", msg))
+		if err := resp.WriteMsg(answer); err != nil {
+			t.Fatalf("err: %s", err)
+		}
+	})
+	up := make(chan struct{})
+	server := &dns.Server{
+		Addr:              "127.0.0.1:0",
+		Net:               "udp",
+		Handler:           mux,
+		NotifyStartedFunc: func() { close(up) },
+		ReadTimeout:       time.Second,
+		WriteTimeout:      time.Second,
+	}
+	go server.ListenAndServe()
+	<-up
+	t.Cleanup(func() { server.Shutdown() })
+	server.Addr = server.PacketConn.LocalAddr().String()
+
+	// Setup TCP server on same port
+	up = make(chan struct{})
+	tcp := &dns.Server{
+		Addr:              server.Addr,
+		Net:               "tcp",
+		Handler:           mux,
+		NotifyStartedFunc: func() { close(up) },
+	}
+	go tcp.ListenAndServe()
+	<-up
+	t.Cleanup(func() { server.Shutdown() })
+	tcp.Addr = server.PacketConn.LocalAddr().String()
+	return server.Addr
+}
+
+func initDNS(t test.Failer) *LocalDNSServer {
+	srv := makeUpstream(t, map[string]string{"www.bing.com.": "1.1.1.1"})
+	testAgentDNS, err := NewLocalDNSServer("ns1", "ns1.svc.cluster.local")
+	if err != nil {
+		t.Fatal(err)
+	}
+	testAgentDNS.resolvConfServers = []string{srv}
+	testAgentDNS.StartDNS()
+	testAgentDNS.searchNamespaces = []string{"ns1.svc.cluster.local", "svc.cluster.local", "cluster.local"}
+	testAgentDNS.UpdateLookupTable(&nds.NameTable{
+		Table: map[string]*nds.NameTable_NameInfo{
+			"www.google.com": {
+				Ips:      []string{"1.1.1.1"},
+				Registry: "External",
+			},
+			"productpage.ns1.svc.cluster.local": {
+				Ips:       []string{"9.9.9.9"},
+				Registry:  "Kubernetes",
+				Namespace: "ns1",
+				Shortname: "productpage",
+			},
+			"example.ns2.svc.cluster.local": {
+				Ips:       []string{"10.10.10.10"},
+				Registry:  "Kubernetes",
+				Namespace: "ns2",
+				Shortname: "example",
+			},
+			"details.ns2.svc.cluster.remote": {
+				Ips:       []string{"11.11.11.11", "12.12.12.12", "13.13.13.13", "14.14.14.14"},
+				Registry:  "Kubernetes",
+				Namespace: "ns2",
+				Shortname: "details",
+			},
+			"ipv6.localhost": {
+				Ips:      []string{"2001:db8:0:0:0:ff00:42:8329"},
+				Registry: "External",
+			},
+			"dual.localhost": {
+				Ips:      []string{"2.2.2.2", "2001:db8:0:0:0:ff00:42:8329"},
+				Registry: "External",
+			},
+			"ipv4.localhost": {
+				Ips:      []string{"2.2.2.2"},
+				Registry: "External",
+			},
+		},
+	})
+	t.Cleanup(testAgentDNS.Close)
+	return testAgentDNS
+}
+
+// reflect.DeepEqual doesn't seem to work well for dns.RR
+// as the Rdlength field is not updated in the a(), or aaaa() calls.
+// so zero them out before doing reflect.Deepequal
+func equalsDNSrecords(got []dns.RR, want []dns.RR) bool {
+	for i := range got {
+		got[i].Header().Rdlength = 0
+	}
+	return reflect.DeepEqual(got, want)
 }

--- a/pilot/pkg/dns/dns_test.go
+++ b/pilot/pkg/dns/dns_test.go
@@ -32,7 +32,7 @@ import (
 var testAgentDNSAddr = "127.0.0.1:15053"
 
 func TestDNS(t *testing.T) {
-	initDNS(t)
+	srv := initDNS(t)
 	testCases := []struct {
 		name                     string
 		host                     string
@@ -199,7 +199,7 @@ func TestDNS(t *testing.T) {
 	dns.Id = func() uint16 {
 		return uint16(currentID.Inc())
 	}
-	defer func() { dns.Id = oldID }()
+	defer func() { srv.Close(); dns.Id = oldID }()
 	for i := range clients {
 		for _, tt := range testCases {
 			// Test is for explicit network

--- a/pilot/pkg/networking/core/v1alpha3/name_table.go
+++ b/pilot/pkg/networking/core/v1alpha3/name_table.go
@@ -73,6 +73,7 @@ func (configgen *ConfigGeneratorImpl) BuildNameTable(node *model.Proxy, push *mo
 		// IP allocation logic for service entry was unable to allocate an IP.
 		if svcAddress == constants.UnspecifiedIP {
 			// For all k8s headless services, populate the dns table with the endpoint IPs as k8s does.
+			// We return a stable list to the proxy, which will randomize the response in each DNS query.
 			// TODO: Need to have an entry per pod hostname of stateful set but for this, we need to parse
 			// the stateful set object, associate the object with the appropriate kubernetes headless service
 			// and then derive the stable network identities.
@@ -81,6 +82,17 @@ func (configgen *ConfigGeneratorImpl) BuildNameTable(node *model.Proxy, push *mo
 				// TODO: this is used in two places now. Needs to be cached as part of the headless service
 				// object to avoid the costly lookup in the registry code
 				for _, instance := range push.ServiceInstancesByPort(svc, svc.Ports[0].Port, nil) {
+					if instance.Endpoint.Locality.ClusterID != node.Metadata.ClusterID {
+						// We take only cluster-local endpoints. While this seems contradictory to
+						// our logic other parts of the code, where cross-cluster is the default.
+						// However, this only impacts the DNS response. If we were to send all
+						// endpoints, cross network routing would break, as we do passthrough LB and
+						// don't go through the network gateway. While we could, hypothetically, send
+						// "network-local" endpoints, this would still make enabling DNS give vastly
+						// different load balancing than without, so its probably best to filter.
+						// This ends up matching the behavior of Kubernetes DNS.
+						continue
+					}
 					// TODO: should we skip the node's own IP like we do in listener?
 					addressList = append(addressList, instance.Endpoint.Address)
 				}

--- a/releasenotes/notes/dns-round-robin.yaml
+++ b/releasenotes/notes/dns-round-robin.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: feature
+area: networking
+issue: [31064]
+releaseNotes:
+- |
+  **Fixed** an issue with DNS proxying causing StatefulSets addresses to not be load balanced.


### PR DESCRIPTION
* Load balance statefulset DNS response (#31067)
* dns: fix various issues with dns proxy (#31251)

The latter is basically a superset of the first one, just cherrypicked both so they cleanly apply