### PR TITLE
Add serviceAccountRoleArn in service account gateway 

### DIFF
--- a/manifests/charts/gateways/istio-ingress/templates/serviceaccount.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/serviceaccount.yaml
@@ -10,6 +10,10 @@ imagePullSecrets:
 metadata:
   name: {{ $gateway.name | default "istio-ingressgateway" }}-service-account
   namespace: {{ .Release.Namespace }}
+  {{ - if $gateway.serviceAccountRoleArn }}
+  annotations:
+    eks.amazonaws.com/role-arn: "{{ $gateway.serviceAccountRoleArn }}"
+  {{ - end }}
   labels:
 {{ $gateway.labels | toYaml | trim | indent 4 }}
     release: {{ .Release.Name }}

--- a/manifests/charts/gateways/istio-ingress/values.yaml
+++ b/manifests/charts/gateways/istio-ingress/values.yaml
@@ -48,6 +48,9 @@ gateways:
     loadBalancerSourceRanges: []
     serviceAnnotations: {}
 
+    # link service account to aws iam role for LB permissions
+    serviceAccountRoleArn: ""
+
     # Enable cross-cluster access using SNI matching
     zvpn:
       enabled: false


### PR DESCRIPTION
Add serviceAccountRoleArn in service account gateway to link service account to aws iam role for LB permissions.

The goal of this PR is to grant iam permission to the service account through role arn instead of iam permission on worker nodes.


[ ] Configuration Infrastructure
[ ] Docs
[X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[ ] Test and Release
[ ] User Experience
[X] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
