### PR TITLE
Add role arn annotation on service account 

### DIFF
--- a/manifests/charts/gateways/istio-ingress/templates/serviceaccount.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/serviceaccount.yaml
@@ -10,6 +10,10 @@ imagePullSecrets:
 metadata:
   name: {{ $gateway.name | default "istio-ingressgateway" }}-service-account
   namespace: {{ .Release.Namespace }}
+  {{- if $gateway.serviceAccountRoleArn }}
+  annotations:
+    eks.amazonaws.com/role-arn: "{{ $gateway.serviceAccountRoleArn }}"
+  {{- end }}
   labels:
 {{ $gateway.labels | toYaml | trim | indent 4 }}
     release: {{ .Release.Name }}

--- a/manifests/charts/gateways/istio-ingress/templates/serviceaccount.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/serviceaccount.yaml
@@ -10,9 +10,11 @@ imagePullSecrets:
 metadata:
   name: {{ $gateway.name | default "istio-ingressgateway" }}-service-account
   namespace: {{ .Release.Namespace }}
-  {{- if $gateway.serviceAccountRoleArn }}
+  {{- if $gateway.serviceAccountAnnotations }}
   annotations:
-    eks.amazonaws.com/role-arn: "{{ $gateway.serviceAccountRoleArn }}"
+    {{- range $key, $val := $gateway.serviceAccountAnnotations }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
   {{- end }}
   labels:
 {{ $gateway.labels | toYaml | trim | indent 4 }}

--- a/manifests/charts/gateways/istio-ingress/values.yaml
+++ b/manifests/charts/gateways/istio-ingress/values.yaml
@@ -47,7 +47,7 @@ gateways:
     loadBalancerIP: ""
     loadBalancerSourceRanges: []
     serviceAnnotations: {}
-    serviceAccountRoleArn: ""
+    serviceAccountAnnotations: {}
 
     # Enable cross-cluster access using SNI matching
     zvpn:

--- a/manifests/charts/gateways/istio-ingress/values.yaml
+++ b/manifests/charts/gateways/istio-ingress/values.yaml
@@ -47,6 +47,7 @@ gateways:
     loadBalancerIP: ""
     loadBalancerSourceRanges: []
     serviceAnnotations: {}
+    serviceAccountRoleArn: ""
 
     # Enable cross-cluster access using SNI matching
     zvpn:


### PR DESCRIPTION
Add role arn annotation on service account to handle permission through role instead of iam role on worker node

In a AWS EKS context, we need to give permissions in order to allow istio to provision load balancer. The standard way is to give permission on the worker nodes.
This PR allow to give permission through a role, bind on the service account. It's a more fine grained security.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.