### PR TITLE
TestReachability: assert we actually send mtls when expected

### DIFF
--- a/pkg/test/echo/client/client.go
+++ b/pkg/test/echo/client/client.go
@@ -98,5 +98,5 @@ func (c *Instance) ForwardEcho(ctx context.Context, request *proto.ForwardEchoRe
 		return nil, err
 	}
 
-	return ParseForwardedResponse(resp), nil
+	return ParseForwardedResponse(request, resp), nil
 }

--- a/pkg/test/echo/client/parsedresponse.go
+++ b/pkg/test/echo/client/parsedresponse.go
@@ -189,9 +189,9 @@ func (r ParsedResponses) CheckMTLSForHTTP() error {
 		_, f1 := response.RawResponse["X-Forwarded-Client-Cert"]
 		_, f2 := response.RawResponse["x-forwarded-client-cert"] // grpc has different casing
 		if f1 || f2 {
-			return fmt.Errorf("response[%d] X-Forwarded-Client-Cert expected but not found: %v", i, response)
+			return nil
 		}
-		return nil
+		return fmt.Errorf("response[%d] X-Forwarded-Client-Cert expected but not found: %v", i, response)
 	})
 }
 

--- a/pkg/test/echo/client/parsedresponse.go
+++ b/pkg/test/echo/client/parsedresponse.go
@@ -188,7 +188,7 @@ func (r ParsedResponses) CheckMTLSForHTTP() error {
 		}
 		_, f1 := response.RawResponse["X-Forwarded-Client-Cert"]
 		_, f2 := response.RawResponse["x-forwarded-client-cert"] // grpc has different casing
-		if !f1 && !f2 {
+		if f1 || f2 {
 			return fmt.Errorf("response[%d] X-Forwarded-Client-Cert expected but not found: %v", i, response)
 		}
 		return nil

--- a/pkg/test/echo/client/parsedresponse.go
+++ b/pkg/test/echo/client/parsedresponse.go
@@ -176,9 +176,9 @@ func (r ParsedResponses) CheckHostOrFail(t test.Failer, expected string) ParsedR
 	return r
 }
 
-// CheckMTLS asserts that mutual TLS was used.
+// CheckMTLSForHTTP asserts that mutual TLS was used.
 // Note: this only is detectable for *successful* HTTP based traffic. Other types will always pass
-func (r ParsedResponses) CheckMTLS() error {
+func (r ParsedResponses) CheckMTLSForHTTP() error {
 	return r.Check(func(i int, response *ParsedResponse) error {
 		if !strings.HasPrefix(response.RequestURL, "http://") &&
 			!strings.HasPrefix(response.RequestURL, "grpc://") &&

--- a/pkg/test/framework/components/echo/common/call.go
+++ b/pkg/test/framework/components/echo/common/call.go
@@ -130,7 +130,7 @@ func CallEcho(opts *echo.CallOptions, retry bool, retryOptions ...retry.Option) 
 		if err != nil {
 			return nil, err
 		}
-		resp := client.ParseForwardedResponse(ret)
+		resp := client.ParseForwardedResponse(req, ret)
 		return resp, nil
 	}
 	return callInternal("TestRunner", opts, send, retry, retryOptions...)

--- a/tests/integration/pilot/cni/cni_test.go
+++ b/tests/integration/pilot/cni/cni_test.go
@@ -88,6 +88,17 @@ func TestCNIReachability(t *testing.T) {
 						// If one of the two endpoints is naked, expect failure.
 						return !apps.Naked.Contains(src) && !apps.Naked.Contains(opts.Target)
 					},
+					ExpectMTLS: func(src echo.Instance, opts echo.CallOptions) bool {
+						if apps.IsNaked(src) || apps.IsNaked(opts.Target) {
+							// If one of the two endpoints is naked, we don't send mTLS
+							return false
+						}
+						if apps.IsHeadless(opts.Target) && opts.Target == src {
+							// pod calling its own pod IP will not be intercepted
+							return false
+						}
+						return true
+					},
 				},
 			}
 			reachability.Run(testCases, ctx, apps)

--- a/tests/integration/security/mtlsk8sca/strict_test.go
+++ b/tests/integration/security/mtlsk8sca/strict_test.go
@@ -58,6 +58,17 @@ func TestMtlsStrictK8sCA(t *testing.T) {
 						// If source is naked, and destination is not, expect failure.
 						return !(apps.IsNaked(src) && !apps.IsNaked(opts.Target))
 					},
+					ExpectMTLS: func(src echo.Instance, opts echo.CallOptions) bool {
+						if apps.IsNaked(src) || apps.IsNaked(opts.Target) {
+							// If one of the two endpoints is naked, we don't send mTLS
+							return false
+						}
+						if apps.IsHeadless(opts.Target) && opts.Target == src {
+							// pod calling its own pod IP will not be intercepted
+							return false
+						}
+						return true
+					},
 				},
 				{
 					ConfigFile: "global-plaintext.yaml",
@@ -73,6 +84,9 @@ func TestMtlsStrictK8sCA(t *testing.T) {
 					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
 						// When mTLS is disabled, all traffic should work.
 						return true
+					},
+					ExpectMTLS: func(src echo.Instance, opts echo.CallOptions) bool {
+						return false
 					},
 				},
 			}

--- a/tests/integration/security/reachability_test.go
+++ b/tests/integration/security/reachability_test.go
@@ -38,14 +38,29 @@ func TestReachability(t *testing.T) {
 		Features("security.reachability").
 		Run(func(ctx framework.TestContext) {
 			systemNM := istio.ClaimSystemNamespaceOrFail(ctx, ctx)
-
+			// mtlsOnExpect defines our expectations for when mTLS is expected when its enabled
+			mtlsOnExpect := func(src echo.Instance, opts echo.CallOptions) bool {
+				if apps.IsNaked(src) || apps.IsNaked(opts.Target) {
+					// If one of the two endpoints is naked, we don't send mTLS
+					return false
+				}
+				if apps.IsHeadless(opts.Target) && opts.Target == src {
+					// pod calling its own pod IP will not be intercepted
+					return false
+				}
+				return true
+			}
+			Always := func(src echo.Instance, opts echo.CallOptions) bool {
+				return true
+			}
+			Never := func(src echo.Instance, opts echo.CallOptions) bool {
+				return false
+			}
 			testCases := []reachability.TestCase{
 				{
 					ConfigFile: "beta-mtls-on.yaml",
 					Namespace:  systemNM,
-					Include: func(src echo.Instance, opts echo.CallOptions) bool {
-						return true
-					},
+					Include:    Always,
 					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
 						if apps.IsNaked(src) && apps.IsNaked(opts.Target) {
 							// naked->naked should always succeed.
@@ -54,6 +69,7 @@ func TestReachability(t *testing.T) {
 						// If one of the two endpoints is naked, expect failure.
 						return !apps.IsNaked(src) && !apps.IsNaked(opts.Target)
 					},
+					ExpectMTLS: mtlsOnExpect,
 				},
 				{
 					ConfigFile: "beta-mtls-permissive.yaml",
@@ -62,30 +78,23 @@ func TestReachability(t *testing.T) {
 						// Exclude calls to naked since we are applying ISTIO_MUTUAL
 						return !apps.IsNaked(opts.Target)
 					},
-					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
-						return true
-					},
+					ExpectSuccess: Always,
+					ExpectMTLS:    mtlsOnExpect,
 				},
 				{
-					ConfigFile: "beta-mtls-off.yaml",
-					Namespace:  systemNM,
-					Include: func(src echo.Instance, opts echo.CallOptions) bool {
-						return true
-					},
-					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
-						return true
-					},
+					ConfigFile:             "beta-mtls-off.yaml",
+					Namespace:              systemNM,
+					Include:                Always,
+					ExpectSuccess:          Always,
+					ExpectMTLS:             Never,
 					SkippedForMulticluster: true,
 				},
 				{
-					ConfigFile: "plaintext-to-permissive.yaml",
-					Namespace:  systemNM,
-					Include: func(src echo.Instance, opts echo.CallOptions) bool {
-						return true
-					},
-					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
-						return true
-					},
+					ConfigFile:             "plaintext-to-permissive.yaml",
+					Namespace:              systemNM,
+					Include:                Always,
+					ExpectSuccess:          Always,
+					ExpectMTLS:             Never,
 					SkippedForMulticluster: true,
 				},
 				{
@@ -98,14 +107,13 @@ func TestReachability(t *testing.T) {
 					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
 						return opts.PortName != "http"
 					},
+					ExpectMTLS:             Never,
 					SkippedForMulticluster: true,
 				},
 				{
 					ConfigFile: "beta-mtls-automtls.yaml",
 					Namespace:  apps.Namespace1,
-					Include: func(src echo.Instance, opts echo.CallOptions) bool {
-						return true
-					},
+					Include:    Always,
 					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
 						// autoMtls doesn't work for client that doesn't have proxy, unless target doesn't
 						// have proxy neither.
@@ -114,13 +122,12 @@ func TestReachability(t *testing.T) {
 						}
 						return true
 					},
+					ExpectMTLS: mtlsOnExpect,
 				},
 				{
 					ConfigFile: "beta-mtls-partial-automtls.yaml",
 					Namespace:  apps.Namespace1,
-					Include: func(src echo.Instance, opts echo.CallOptions) bool {
-						return true
-					},
+					Include:    Always,
 					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
 						// autoMtls doesn't work for client that doesn't have proxy, unless target doesn't
 						// have proxy or have mTLS disabled
@@ -131,22 +138,14 @@ func TestReachability(t *testing.T) {
 						// will fail on all ports on b, except http port.
 						return !apps.B.Contains(opts.Target) || opts.PortName == "http"
 					},
+					ExpectMTLS: mtlsOnExpect,
 				},
 				{
-					ConfigFile: "global-plaintext.yaml",
-					Namespace:  systemNM,
-					Include: func(src echo.Instance, opts echo.CallOptions) bool {
-						// Exclude calls to the headless TCP port.
-						if apps.IsHeadless(opts.Target) && opts.PortName == "tcp" {
-							return false
-						}
-
-						return true
-					},
-					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
-						// When mTLS is disabled, all traffic should work.
-						return true
-					},
+					ConfigFile:             "global-plaintext.yaml",
+					Namespace:              systemNM,
+					Include:                Always,
+					ExpectSuccess:          Always,
+					ExpectMTLS:             Never,
 					SkippedForMulticluster: true,
 				},
 				// --------start of auto mtls partial test cases ---------------
@@ -171,8 +170,9 @@ func TestReachability(t *testing.T) {
 						// We only need one pair.
 						return apps.A.Contains(src) && apps.Multiversion.Contains(opts.Target)
 					},
-					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
-						return true
+					ExpectSuccess: Always,
+					ExpectMTLS: func(src echo.Instance, opts echo.CallOptions) bool {
+						return opts.Path == "/vistio"
 					},
 				},
 				{
@@ -198,6 +198,7 @@ func TestReachability(t *testing.T) {
 						// Only the request to legacy one succeeds as we disable mtls explicitly.
 						return opts.Path == "/vlegacy"
 					},
+					ExpectMTLS: Never,
 				},
 				{
 					ConfigFile: "automtls-partial-sidecar-dr-mutual.yaml",
@@ -220,6 +221,9 @@ func TestReachability(t *testing.T) {
 					},
 					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
 						// Only the request to vistio one succeeds as we enable mtls explicitly.
+						return opts.Path == "/vistio"
+					},
+					ExpectMTLS: func(src echo.Instance, opts echo.CallOptions) bool {
 						return opts.Path == "/vistio"
 					},
 				},

--- a/tests/integration/security/util/connection/checker.go
+++ b/tests/integration/security/util/connection/checker.go
@@ -17,7 +17,6 @@ package connection
 
 import (
 	"fmt"
-	"time"
 
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/echo/common/scheme"
@@ -32,6 +31,7 @@ type Checker struct {
 	DestClusters  cluster.Clusters
 	Options       echo.CallOptions
 	ExpectSuccess bool
+	ExpectMTLS    bool
 }
 
 // Check whether the target endpoint is reachable from the source.
@@ -52,6 +52,14 @@ func (c *Checker) Check() error {
 				return err
 			}
 		}
+		if c.ExpectMTLS {
+			err := results.CheckMTLS()
+			gotMtls := err == nil
+			if gotMtls != c.ExpectMTLS {
+				return fmt.Errorf("%s to %s:%s using %s: expected mtls=%v, got mtls=%v",
+					c.From.Config().Service, c.Options.Target.Config().Service, c.Options.PortName, c.Options.Scheme, c.ExpectMTLS, gotMtls)
+			}
+		}
 		return nil
 	}
 
@@ -64,7 +72,7 @@ func (c *Checker) Check() error {
 }
 
 func (c *Checker) CheckOrFail(t test.Failer) {
-	if err := retry.UntilSuccess(c.Check, retry.Delay(time.Millisecond*100)); err != nil {
+	if err := retry.UntilSuccess(c.Check, echo.DefaultCallRetryOptions()...); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/tests/integration/security/util/connection/checker.go
+++ b/tests/integration/security/util/connection/checker.go
@@ -53,7 +53,7 @@ func (c *Checker) Check() error {
 			}
 		}
 		if c.ExpectMTLS {
-			err := results.CheckMTLS()
+			err := results.CheckMTLSForHTTP()
 			gotMtls := err == nil
 			if gotMtls != c.ExpectMTLS {
 				return fmt.Errorf("%s to %s:%s using %s: expected mtls=%v, got mtls=%v",

--- a/tests/integration/security/util/reachability/context.go
+++ b/tests/integration/security/util/reachability/context.go
@@ -52,6 +52,9 @@ type TestCase struct {
 	// Indicates whether the test should expect a successful response.
 	ExpectSuccess func(src echo.Instance, opts echo.CallOptions) bool
 
+	// Indicates whether the test should expect a MTLS response.
+	ExpectMTLS func(src echo.Instance, opts echo.CallOptions) bool
+
 	// Indicates whether a test should be run in the multicluster environment.
 	// This is a temporary flag during the converting tests into multicluster supported.
 	// TODO: Remove this flag when all tests support multicluster
@@ -179,7 +182,7 @@ func Run(testCases []TestCase, ctx framework.TestContext, apps *util.EchoDeploym
 
 								if c.Include(src, opts) {
 									expectSuccess := c.ExpectSuccess(src, opts)
-
+									expectMTLS := c.ExpectMTLS(src, opts)
 									tpe := "positive"
 									if !expectSuccess {
 										tpe = "negative"
@@ -202,6 +205,7 @@ func Run(testCases []TestCase, ctx framework.TestContext, apps *util.EchoDeploym
 												DestClusters:  destClusters,
 												Options:       opts,
 												ExpectSuccess: expectSuccess,
+												ExpectMTLS:    expectMTLS,
 											}
 											checker.CheckOrFail(ctx)
 										})


### PR DESCRIPTION
Currently, our tests check only if traffic succeeds or fails. That is great, but it still leaves a lot of coverage missing. For example, auto mtls could send plaintext in permissive mode and we wouldn't catch it.

This just adds more coverage. No bugs were detected in this, so it is just test code changing. This will help with another PR I am working on that does change the real mTLS code.