### PR TITLE
Consistently only dump in CIMode

### DIFF
--- a/pkg/test/framework/testcontext.go
+++ b/pkg/test/framework/testcontext.go
@@ -283,7 +283,7 @@ func (c *testContext) Cleanup(fn func()) {
 }
 
 func (c *testContext) Done() {
-	if c.Failed() {
+	if c.Failed() && c.Settings().CIMode {
 		scopes.Framework.Debugf("Begin dumping testContext: %q", c.id)
 		rt.Dump(c)
 		scopes.Framework.Debugf("Completed dumping testContext: %q", c.id)


### PR DESCRIPTION
Currently, we only dump in CIMode in another place. Sothis makes it
consistent. I thought about making it always dump, but this seems better
since usually local devs don't care about the dump and it just slows
things down.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.