### PR TITLE
Disable envoy hot restart

### DIFF
--- a/pkg/envoy/proxy.go
+++ b/pkg/envoy/proxy.go
@@ -117,7 +117,6 @@ func (e *envoy) args(fname string, epoch int, bootstrapConfig string) []string {
 		"--service-node", e.Node,
 		"--local-address-ip-version", proxyLocalAddressType,
 		"--bootstrap-version", "3",
-		"--use-dynamic-base-id", // Ensure we don't conflict with other Envoys in the same process namespace
 		"--disable-hot-restart", // We don't use it, so disable it to simplify Envoy's logic
 	}
 	if e.ProxyConfig.LogAsJSON {

--- a/pkg/envoy/proxy.go
+++ b/pkg/envoy/proxy.go
@@ -117,6 +117,8 @@ func (e *envoy) args(fname string, epoch int, bootstrapConfig string) []string {
 		"--service-node", e.Node,
 		"--local-address-ip-version", proxyLocalAddressType,
 		"--bootstrap-version", "3",
+		"--use-dynamic-base-id", // Ensure we don't conflict with other Envoys in the same process namespace
+		"--disable-hot-restart", // We don't use it, so disable it to simplify Envoy's logic
 	}
 	if e.ProxyConfig.LogAsJSON {
 		startupArgs = append(startupArgs,

--- a/pkg/envoy/proxy_test.go
+++ b/pkg/envoy/proxy_test.go
@@ -56,7 +56,6 @@ func TestEnvoyArgs(t *testing.T) {
 		"--service-node", "my-node",
 		"--local-address-ip-version", "v4",
 		"--bootstrap-version", "3",
-		"--use-dynamic-base-id",
 		"--disable-hot-restart",
 		"--log-format", "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n\t%v",
 		"-l", "trace",

--- a/pkg/envoy/proxy_test.go
+++ b/pkg/envoy/proxy_test.go
@@ -56,6 +56,8 @@ func TestEnvoyArgs(t *testing.T) {
 		"--service-node", "my-node",
 		"--local-address-ip-version", "v4",
 		"--bootstrap-version", "3",
+		"--use-dynamic-base-id",
+		"--disable-hot-restart",
 		"--log-format", "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n\t%v",
 		"-l", "trace",
 		"--component-log-level", "misc:error",


### PR DESCRIPTION
Part of https://github.com/istio/istio/issues/31138

This is generally to simplify running multiple Envoy's on one pod. It
may have the side effect of reducing the work Envoy needs to do by
disablnig hot restart. It also drops privileges required by Envoy (write
access to /dev/shm).

We don't use hot restart today. A user with custom fork might, in which
case they can either comment these two lines out or send a PR upstream
to make this opt-in. Until then, I think we can just hard disable it as
I believe no users are using this without a fork.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.