### PR TITLE
Allow DOCKER_TARGETS as existing env var for build-base-images.sh

### DIFF
--- a/tools/build-base-images.sh
+++ b/tools/build-base-images.sh
@@ -21,7 +21,7 @@ set -ex
 
 HUBS="${HUBS:?specify a space seperated list of hubs}"
 TAG="${TAG:?specify a tag}"
-DOCKER_TARGETS="docker.base docker.distroless docker.app_sidecar_base_debian_9 docker.app_sidecar_base_debian_10 docker.app_sidecar_base_ubuntu_xenial docker.app_sidecar_base_ubuntu_bionic docker.app_sidecar_base_ubuntu_focal docker.app_sidecar_base_centos_7 docker.app_sidecar_base_centos_8"
+DOCKER_TARGETS="${DOCKER_TARGETS:-docker.base docker.distroless docker.app_sidecar_base_debian_9 docker.app_sidecar_base_debian_10 docker.app_sidecar_base_ubuntu_xenial docker.app_sidecar_base_ubuntu_bionic docker.app_sidecar_base_ubuntu_focal docker.app_sidecar_base_centos_7 docker.app_sidecar_base_centos_8}"
 
 # Verify that the specified TAG does not exist for the HUBS/TARGETS
 # Will also fail if user doesn't have authorization to repository, but they shouldn't


### PR DESCRIPTION
For testing purposes, allow a user to specify DOCKER_TARGETS, else use the current as the default.