### PR TITLE
istioctl: Use *mesh config* to find istiod XDS

### DIFF
--- a/istioctl/cmd/add-to-mesh.go
+++ b/istioctl/cmd/add-to-mesh.go
@@ -294,7 +294,7 @@ func setupParameters(sidecarTemplate *inject.Templates, valuesConfig *string, re
 			return nil, err
 		}
 	} else {
-		if meshConfig, err = getMeshConfigFromConfigMap(kubeconfig, "add-to-mesh", revision); err != nil {
+		if meshConfig, err = getMeshConfigFromConfigMap(kubeconfig, revision); err != nil {
 			return nil, err
 		}
 	}

--- a/istioctl/cmd/config.go
+++ b/istioctl/cmd/config.go
@@ -31,7 +31,7 @@ import (
 var settableFlags = map[string]interface{}{
 	"istioNamespace":      env.RegisterStringVar("ISTIOCTL_ISTIONAMESPACE", controller.IstioNamespace, "The istioctl --istioNamespace override"),
 	"xds-address":         env.RegisterStringVar("ISTIOCTL_XDS_ADDRESS", "", "The istioctl --xds-address override"),
-	"xds-port":            env.RegisterIntVar("ISTIOCTL_XDS_PORT", 15012, "The istioctl --xds-port override"),
+	"xds-port":            env.RegisterIntVar("ISTIOCTL_XDS_PORT", 0, "The istioctl --xds-port override"),
 	"authority":           env.RegisterStringVar("ISTIOCTL_AUTHORITY", "", "The istioctl --authority override"),
 	"cert-dir":            env.RegisterStringVar("ISTIOCTL_CERT_DIR", "", "The istioctl --cert-dir override"),
 	"insecure":            env.RegisterBoolVar("ISTIOCTL_INSECURE", false, "The istioctl --insecure override"),

--- a/istioctl/cmd/config_test.go
+++ b/istioctl/cmd/config_test.go
@@ -38,7 +38,7 @@ istioNamespace          istio-system     default
 plaintext                                default
 prefer-experimental                      default
 xds-address                              default
-xds-port                15012            default
+xds-port                                 default
 `,
 			wantException: false,
 		},

--- a/istioctl/cmd/root.go
+++ b/istioctl/cmd/root.go
@@ -125,7 +125,6 @@ func ConfigAndEnvProcessing() error {
 
 func init() {
 	viper.SetDefault("istioNamespace", controller.IstioNamespace)
-	viper.SetDefault("xds-port", 15012)
 }
 
 // GetRootCmd returns the root of the cobra command-tree.

--- a/istioctl/pkg/clioptions/istioconfig.go
+++ b/istioctl/pkg/clioptions/istioconfig.go
@@ -1,0 +1,59 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clioptions
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	meshconfig "istio.io/api/mesh/v1alpha1"
+
+	"istio.io/istio/pkg/config/mesh"
+	"istio.io/istio/pkg/kube"
+	"istio.io/pkg/version"
+)
+
+func GetMeshConfigFromConfigMap(client kube.Client, istioNamespace, revision string) (*meshconfig.MeshConfig, error) {
+	defaultMeshConfigMapName := "istio"
+	configMapKey := "mesh"
+
+	meshConfigMapName := defaultMeshConfigMapName
+	if revision != "" {
+		meshConfigMapName = fmt.Sprintf("%s-%s", defaultMeshConfigMapName, revision)
+	}
+	meshConfigMap, err := client.CoreV1().ConfigMaps(istioNamespace).Get(context.TODO(), meshConfigMapName, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf(`could not read valid configmap %q from namespace %q: %v
+Use --meshConfigFile or run with -i <istioSystemNamespace> and ensure configmap %q exists`,
+			meshConfigMapName, istioNamespace, err, defaultMeshConfigMapName)
+	}
+
+	// values in the data are strings, while proto might use a
+	// different data type.  therefore, we have to get a value by a
+	// key
+	configYaml, exists := meshConfigMap.Data[configMapKey]
+	if !exists {
+		return nil, fmt.Errorf("missing configuration map key %q", configMapKey)
+	}
+	cfg, err := mesh.ApplyMeshConfigDefaults(configYaml)
+	if err != nil {
+		err = multierror.Append(err, fmt.Errorf("istioctl version %s cannot parse mesh config.",
+			version.Info.Version))
+	}
+	return cfg, err
+}

--- a/istioctl/pkg/clioptions/istioconfig.go
+++ b/istioctl/pkg/clioptions/istioconfig.go
@@ -22,7 +22,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
-
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/kube"
 	"istio.io/pkg/version"
@@ -52,7 +51,7 @@ Use --meshConfigFile or run with -i <istioSystemNamespace> and ensure configmap 
 	}
 	cfg, err := mesh.ApplyMeshConfigDefaults(configYaml)
 	if err != nil {
-		err = multierror.Append(err, fmt.Errorf("istioctl version %s cannot parse mesh config.",
+		err = multierror.Append(err, fmt.Errorf("istioctl version %s cannot parse mesh config",
 			version.Info.Version))
 	}
 	return cfg, err

--- a/releasenotes/notes/22274.yaml
+++ b/releasenotes/notes/22274.yaml
@@ -6,5 +6,5 @@ issue:
 
 releaseNotes:
 - |
-  **Added** `istioctl experimental proxy-status` will find istiod using meshConfig if neither --xds-address nor --xds-port is supplied
+  **Added** The `istioctl experimental proxy-status` command will find istiod using meshConfig if neither `--xds-address` nor `--xds-port` is supplied
 

--- a/releasenotes/notes/22274.yaml
+++ b/releasenotes/notes/22274.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: feature
+area: istioctl
+issue:
+  - 22274
+
+releaseNotes:
+- |
+  **Added** `istioctl experimental proxy-status` will find istiod using meshConfig if neither --xds-address nor --xds-port is supplied
+

--- a/tests/integration/pilot/istioctl_test.go
+++ b/tests/integration/pilot/istioctl_test.go
@@ -373,6 +373,62 @@ func TestProxyStatus(t *testing.T) {
 		})
 }
 
+// Tests istioctl x proxy-status [<pod>]
+func TestXdsProxyStatus(t *testing.T) {
+	framework.NewTest(t).Features("usability.observability.proxy-status").
+		RequiresSingleCluster().
+		Run(func(ctx framework.TestContext) {
+			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{})
+
+			podID, err := getPodID(apps.PodA[0])
+			if err != nil {
+				ctx.Fatalf("Could not get Pod ID: %v", err)
+			}
+
+			var output string
+			var args []string
+			g := gomega.NewWithT(t)
+
+			args = []string{"experimenta", "proxy-status"}
+			output, _ = istioCtl.InvokeOrFail(t, args)
+			// Just verify pod A is known to Pilot; implicitly this verifies that
+			// the printing code printed it.
+			g.Expect(output).To(gomega.ContainSubstring(fmt.Sprintf("%s.%s", podID, apps.Namespace.Name())))
+
+			expectSubstrings := func(have string, wants ...string) error {
+				for _, want := range wants {
+					if !strings.Contains(have, want) {
+						return fmt.Errorf("substring %q not found; have %q", want, have)
+					}
+				}
+				return nil
+			}
+
+			retry.UntilSuccessOrFail(t, func() error {
+				args = []string{
+					"experimenta", "proxy-status", fmt.Sprintf("%s.%s", podID, apps.Namespace.Name()),
+				}
+				output, _ = istioCtl.InvokeOrFail(t, args)
+				return expectSubstrings(output, "Clusters Match", "Listeners Match", "Routes Match")
+			})
+
+			// test the --file param
+			retry.UntilSuccessOrFail(t, func() error {
+				filename := "ps-configdump.json"
+				cs := ctx.Clusters().Default()
+				dump, err := cs.EnvoyDo(context.TODO(), podID, apps.Namespace.Name(), "GET", "config_dump", nil)
+				g.Expect(err).ShouldNot(gomega.HaveOccurred())
+				err = ioutil.WriteFile(filename, dump, os.ModePerm)
+				g.Expect(err).ShouldNot(gomega.HaveOccurred())
+				args = []string{
+					"proxy-status", fmt.Sprintf("%s.%s", podID, apps.Namespace.Name()), "--file", filename,
+				}
+				output, _ = istioCtl.InvokeOrFail(t, args)
+				return expectSubstrings(output, "Clusters Match", "Listeners Match", "Routes Match")
+			})
+		})
+}
+
 func TestAuthZCheck(t *testing.T) {
 	framework.NewTest(t).Features("usability.observability.authz-check").
 		RequiresSingleCluster().

--- a/tests/integration/pilot/istioctl_test.go
+++ b/tests/integration/pilot/istioctl_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
@@ -406,7 +407,7 @@ func TestXdsProxyStatus(t *testing.T) {
 
 			retry.UntilSuccessOrFail(t, func() error {
 				args = []string{
-					"experimenta", "proxy-status", fmt.Sprintf("%s.%s", podID, apps.Namespace.Name()),
+					"experimental", "proxy-status", fmt.Sprintf("%s.%s", podID, apps.Namespace.Name()),
 				}
 				output, _ = istioCtl.InvokeOrFail(t, args)
 				return expectSubstrings(output, "Clusters Match", "Listeners Match", "Routes Match")
@@ -414,7 +415,7 @@ func TestXdsProxyStatus(t *testing.T) {
 
 			// test the --file param
 			retry.UntilSuccessOrFail(t, func() error {
-				filename := "ps-configdump.json"
+				filename := filepath.Join(t.TempDir(), "ps-configdump.json")
 				cs := ctx.Clusters().Default()
 				dump, err := cs.EnvoyDo(context.TODO(), podID, apps.Namespace.Name(), "GET", "config_dump", nil)
 				g.Expect(err).ShouldNot(gomega.HaveOccurred())

--- a/tests/integration/pilot/istioctl_test.go
+++ b/tests/integration/pilot/istioctl_test.go
@@ -389,7 +389,7 @@ func TestXdsProxyStatus(t *testing.T) {
 			var args []string
 			g := gomega.NewWithT(t)
 
-			args = []string{"experimenta", "proxy-status"}
+			args = []string{"experimental", "proxy-status"}
 			output, _ = istioCtl.InvokeOrFail(t, args)
 			// Just verify pod A is known to Pilot; implicitly this verifies that
 			// the printing code printed it.


### PR DESCRIPTION
(Part of the work for https://github.com/istio/istio/issues/22274 )

Experimental implementation used for `istioctl experimental proxy-status` only.

If the user does supplies neither `--xds-port 15012` (self-hosted control plane) nor `--xds-address mycloud.com:port` (external control plane), _istioctl_ will use values in the injector config to default those flags.

Note: If the user is canarying they still need to set `--revision` at this time.

This should make things much easier for users with >1 mesh on >1 cluster.

This sets up some of the work needed before we merge the `x proxy-status` and non-experimental `proxy-status`.