### PR TITLE
Add exit return code if existing manifest found

### DIFF
--- a/tools/build-base-images.sh
+++ b/tools/build-base-images.sh
@@ -32,7 +32,7 @@ for hub in ${HUBS}
 do
   for image in ${DOCKER_TARGETS#docker.}  # assume the image name is the target without the leading docker.
   do
-    docker manifest inspect "$hub"/"$image":"$TAG" && exit  # will exit if it finds the manifest
+    docker manifest inspect "$hub"/"$image":"$TAG" && exit 1 # will exit if it finds the manifest
   done
 done
 set -e


### PR DESCRIPTION
Add a return code to the exit so we can test in the release-builder code if there was a failure due to an existing image.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any changes that may affect Istio users.