### PR TITLE
Make kubernetes.default.svc cluster-local by default.

### DIFF
--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -1535,9 +1535,15 @@ func TestIsClusterLocal(t *testing.T) {
 		expected bool
 	}{
 		{
-			name:     "local by default",
+			name:     "kube-system is local",
 			m:        mesh.DefaultMeshConfig(),
 			host:     "s.kube-system.svc.cluster.local",
+			expected: true,
+		},
+		{
+			name:     "api server local is local",
+			m:        mesh.DefaultMeshConfig(),
+			host:     "kubernetes.default.svc.cluster.local",
 			expected: true,
 		},
 		{
@@ -1553,7 +1559,7 @@ func TestIsClusterLocal(t *testing.T) {
 			expected: false,
 		},
 		{
-			name: "override default",
+			name: "override default namespace",
 			m: meshconfig.MeshConfig{
 				// Remove the cluster-local setting for kube-system.
 				ServiceSettings: []*meshconfig.MeshConfig_ServiceSettings{
@@ -1566,6 +1572,22 @@ func TestIsClusterLocal(t *testing.T) {
 				},
 			},
 			host:     "s.kube-system.svc.cluster.local",
+			expected: false,
+		},
+		{
+			name: "override default service",
+			m: meshconfig.MeshConfig{
+				// Remove the cluster-local setting for kube-system.
+				ServiceSettings: []*meshconfig.MeshConfig_ServiceSettings{
+					{
+						Settings: &meshconfig.MeshConfig_ServiceSettings_Settings{
+							ClusterLocal: false,
+						},
+						Hosts: []string{"kubernetes.default.svc.cluster.local"},
+					},
+				},
+			},
+			host:     "kubernetes.default.svc.cluster.local",
 			expected: false,
 		},
 		{

--- a/releasenotes/notes/api-server-cluster-local.yaml
+++ b/releasenotes/notes/api-server-cluster-local.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: networking
+issue:
+  - 31340
+releaseNotes:
+  - |
+    **Fixed** the Kubernetes API server is now considered to be cluster-local by default. This means that any
+    pod attempting to reach `kubernetes.default.svc` will always be directed to the in-cluster server.


### PR DESCRIPTION


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.