### PR TITLE
Remove environment variables to disable protocol detection

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -136,18 +136,6 @@ var (
 		false,
 		"Skip validating the peer is from the same trust domain when mTLS is enabled in authentication policy")
 
-	EnableProtocolSniffingForOutbound = env.RegisterBoolVar(
-		"PILOT_ENABLE_PROTOCOL_SNIFFING_FOR_OUTBOUND",
-		true,
-		"If enabled, protocol sniffing will be used for outbound listeners whose port protocol is not specified or unsupported",
-	).Get()
-
-	EnableProtocolSniffingForInbound = env.RegisterBoolVar(
-		"PILOT_ENABLE_PROTOCOL_SNIFFING_FOR_INBOUND",
-		true,
-		"If enabled, protocol sniffing will be used for inbound listeners whose port protocol is not specified or unsupported",
-	).Get()
-
 	EnableWasmTelemetry = env.RegisterBoolVar(
 		"ENABLE_WASM_TELEMETRY",
 		false,

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -137,46 +137,40 @@ func TestHTTPCircuitBreakerThresholds(t *testing.T) {
 
 func TestCommonHttpProtocolOptions(t *testing.T) {
 	cases := []struct {
-		clusterName               string
-		useDownStreamProtocol     bool
-		sniffingEnabledForInbound bool
-		proxyType                 model.NodeType
-		clusters                  int
+		clusterName           string
+		useDownStreamProtocol bool
+		proxyType             model.NodeType
+		clusters              int
 	}{
 		{
-			clusterName:               "outbound|8080||*.example.org",
-			useDownStreamProtocol:     false,
-			sniffingEnabledForInbound: false,
-			proxyType:                 model.SidecarProxy,
-			clusters:                  8,
+			clusterName:           "outbound|8080||*.example.org",
+			useDownStreamProtocol: false,
+			proxyType:             model.SidecarProxy,
+			clusters:              8,
 		},
 		{
-			clusterName:               "inbound|10001||",
-			useDownStreamProtocol:     false,
-			sniffingEnabledForInbound: false,
-			proxyType:                 model.SidecarProxy,
-			clusters:                  8,
+			clusterName:           "inbound|10001||",
+			useDownStreamProtocol: false,
+			proxyType:             model.SidecarProxy,
+			clusters:              8,
 		},
 		{
-			clusterName:               "outbound|9090||*.example.org",
-			useDownStreamProtocol:     true,
-			sniffingEnabledForInbound: false,
-			proxyType:                 model.SidecarProxy,
-			clusters:                  8,
+			clusterName:           "outbound|9090||*.example.org",
+			useDownStreamProtocol: true,
+			proxyType:             model.SidecarProxy,
+			clusters:              8,
 		},
 		{
-			clusterName:               "inbound|10002||",
-			useDownStreamProtocol:     true,
-			sniffingEnabledForInbound: true,
-			proxyType:                 model.SidecarProxy,
-			clusters:                  8,
+			clusterName:           "inbound|10002||",
+			useDownStreamProtocol: true,
+			proxyType:             model.SidecarProxy,
+			clusters:              8,
 		},
 		{
-			clusterName:               "outbound|8080||*.example.org",
-			useDownStreamProtocol:     true,
-			sniffingEnabledForInbound: true,
-			proxyType:                 model.Router,
-			clusters:                  3,
+			clusterName:           "outbound|8080||*.example.org",
+			useDownStreamProtocol: true,
+			proxyType:             model.Router,
+			clusters:              3,
 		},
 	}
 	settings := &networking.ConnectionPoolSettings{
@@ -187,10 +181,6 @@ func TestCommonHttpProtocolOptions(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		defaultValue := features.EnableProtocolSniffingForInbound
-		features.EnableProtocolSniffingForInbound = tc.sniffingEnabledForInbound
-		defer func() { features.EnableProtocolSniffingForInbound = defaultValue }()
-
 		gwClusters := features.FilterGatewayClusterConfig
 		features.FilterGatewayClusterConfig = false
 		defer func() { features.FilterGatewayClusterConfig = gwClusters }()

--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -23,7 +23,6 @@ import (
 	"github.com/golang/protobuf/ptypes"
 
 	networking "istio.io/api/networking/v1alpha3"
-	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/core/v1alpha3/envoyfilter"
 	istio_route "istio.io/istio/pilot/pkg/networking/core/v1alpha3/route"
@@ -122,8 +121,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundHTTPRouteConfig(node *
 	listenerPort := 0
 	useSniffing := false
 	var err error
-	if features.EnableProtocolSniffingForOutbound &&
-		!strings.HasPrefix(routeName, model.UnixAddressPrefix) {
+	if !strings.HasPrefix(routeName, model.UnixAddressPrefix) {
 		index := strings.IndexRune(routeName, ':')
 		if index != -1 {
 			useSniffing = true

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -988,7 +988,6 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundHTTPListenerOptsForPor
 	*listenerMapKey = listenerOpts.bind + ":" + strconv.Itoa(listenerOpts.port.Port)
 
 	var exists bool
-	sniffingEnabled := features.EnableProtocolSniffingForOutbound
 
 	// Have we already generated a listener for this Port based on user
 	// specified listener ports? if so, we should not add any more HTTP
@@ -1016,26 +1015,6 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundHTTPListenerOptsForPor
 		if (*currentListenerEntry).locked {
 			return false, nil
 		}
-
-		if !sniffingEnabled {
-			if listenerOpts.service != nil {
-				if !(*currentListenerEntry).servicePort.Protocol.IsHTTP() {
-					outboundListenerConflict{
-						metric:          model.ProxyStatusConflictOutboundListenerTCPOverHTTP,
-						node:            listenerOpts.proxy,
-						listenerName:    *listenerMapKey,
-						currentServices: (*currentListenerEntry).services,
-						currentProtocol: (*currentListenerEntry).servicePort.Protocol,
-						newHostname:     listenerOpts.service.Hostname,
-						newProtocol:     listenerOpts.port.Protocol,
-					}.addMetric(listenerOpts.push)
-				}
-
-				// Skip building listener for the same http port
-				(*currentListenerEntry).services = append((*currentListenerEntry).services, listenerOpts.service)
-			}
-			return false, nil
-		}
 	}
 
 	listenerProtocol := istionetworking.ModelProtocolToListenerProtocol(listenerOpts.port.Protocol, core.TrafficDirection_OUTBOUND)
@@ -1046,7 +1025,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundHTTPListenerOptsForPor
 		rdsName = listenerOpts.bind // use the UDS as a rds name
 	} else {
 		if listenerProtocol == istionetworking.ListenerProtocolAuto &&
-			sniffingEnabled && listenerOpts.bind != actualWildcard && listenerOpts.service != nil {
+			listenerOpts.bind != actualWildcard && listenerOpts.service != nil {
 			rdsName = string(listenerOpts.service.Hostname) + ":" + strconv.Itoa(listenerOpts.port.Port)
 		} else {
 			rdsName = strconv.Itoa(listenerOpts.port.Port)
@@ -1178,46 +1157,6 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundTCPListenerOptsForPort
 		if (*currentListenerEntry).locked {
 			return false, nil
 		}
-
-		if !features.EnableProtocolSniffingForOutbound {
-			// Check for port collisions between TCP/TLS and HTTP (or unknown). If
-			// configured correctly, TCP/TLS ports may not collide. We'll
-			// need to do additional work to find out if there is a
-			// collision within TCP/TLS.
-			// If the service port was defined as unknown. It will conflict with all other
-			// protocols.
-			if !(*currentListenerEntry).servicePort.Protocol.IsTCP() {
-				// NOTE: While pluginParams.Service can be nil,
-				// this code cannot be reached if Service is nil because a pluginParams.Service can be nil only
-				// for user defined Egress listeners with ports. And these should occur in the API before
-				// the wildcard egress listener. the check for the "locked" bit will eliminate the collision.
-				// User is also not allowed to add duplicate ports in the egress listener
-				var newHostname host.Name
-				if listenerOpts.service != nil {
-					newHostname = listenerOpts.service.Hostname
-				} else {
-					// user defined outbound listener via sidecar API
-					newHostname = "sidecar-config-egress-http-listener"
-				}
-
-				// We have a collision with another TCP port. This can happen
-				// for headless services, or non-k8s services that do not have
-				// a VIP, or when we have two binds on a unix domain socket or
-				// on same IP.  Unfortunately we won't know if this is a real
-				// conflict or not until we process the VirtualServices, etc.
-				// The conflict resolution is done later in this code
-				outboundListenerConflict{
-					metric:          model.ProxyStatusConflictOutboundListenerHTTPOverTCP,
-					node:            listenerOpts.proxy,
-					listenerName:    *listenerMapKey,
-					currentServices: (*currentListenerEntry).services,
-					currentProtocol: (*currentListenerEntry).servicePort.Protocol,
-					newHostname:     newHostname,
-					newProtocol:     listenerOpts.port.Protocol,
-				}.addMetric(listenerOpts.push)
-				return false, nil
-			}
-		}
 	}
 
 	meshGateway := map[string]bool{constants.IstioMeshGateway: true}
@@ -1244,7 +1183,6 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundListenerForPortOrUDS(n
 
 	conflictType := NoConflict
 
-	outboundSniffingEnabled := features.EnableProtocolSniffingForOutbound
 	listenerPortProtocol := listenerOpts.port.Protocol
 	listenerProtocol := istionetworking.ModelProtocolToListenerProtocol(listenerOpts.port.Protocol, core.TrafficDirection_OUTBOUND)
 
@@ -1264,7 +1202,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundListenerForPortOrUDS(n
 			}
 
 			// Check if conflict happens
-			if outboundSniffingEnabled && currentListenerEntry != nil {
+			if currentListenerEntry != nil {
 				// Build HTTP listener. If current listener entry is using HTTP or protocol sniffing,
 				// append the service. Otherwise (TCP), change current listener to use protocol sniffing.
 				if currentListenerEntry.protocol.IsHTTP() {
@@ -1285,25 +1223,23 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundListenerForPortOrUDS(n
 			// Since application protocol filter chain match has been added to the http filter chain, a fall through filter chain will be
 			// appended to the listener later to allow arbitrary egress TCP traffic pass through when its port is conflicted with existing
 			// HTTP services, which can happen when a pod accesses a non registry service.
-			if outboundSniffingEnabled {
-				if listenerOpts.bind == actualWildcard {
-					for _, opt := range opts {
-						if opt.match == nil {
-							opt.match = &listener.FilterChainMatch{}
-						}
-
-						// Support HTTP/1.0, HTTP/1.1 and HTTP/2
-						opt.match.ApplicationProtocols = append(opt.match.ApplicationProtocols, plaintextHTTPALPNs...)
-						opt.match.TransportProtocol = xdsfilters.RawBufferTransportProtocol
+			if listenerOpts.bind == actualWildcard {
+				for _, opt := range opts {
+					if opt.match == nil {
+						opt.match = &listener.FilterChainMatch{}
 					}
 
-					listenerOpts.needHTTPInspector = true
-
-					// if we have a tcp fallthrough filter chain, this is no longer an HTTP listener - it
-					// is instead "unsupported" (auto detected), as we have a TCP and HTTP filter chain with
-					// inspection to route between them
-					listenerPortProtocol = protocol.Unsupported
+					// Support HTTP/1.0, HTTP/1.1 and HTTP/2
+					opt.match.ApplicationProtocols = append(opt.match.ApplicationProtocols, plaintextHTTPALPNs...)
+					opt.match.TransportProtocol = xdsfilters.RawBufferTransportProtocol
 				}
+
+				listenerOpts.needHTTPInspector = true
+
+				// if we have a tcp fallthrough filter chain, this is no longer an HTTP listener - it
+				// is instead "unsupported" (auto detected), as we have a TCP and HTTP filter chain with
+				// inspection to route between them
+				listenerPortProtocol = protocol.Unsupported
 			}
 			listenerOpts.filterChainOpts = opts
 
@@ -1316,7 +1252,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundListenerForPortOrUDS(n
 			}
 
 			// Protocol sniffing for thrift is not supported.
-			if outboundSniffingEnabled && currentListenerEntry != nil {
+			if currentListenerEntry != nil {
 				// We should not ever end up here, but log a line just in case.
 				log.Errorf(
 					"Protocol sniffing is not enabled for thrift, but there was a port collision. Debug info: Node: %v, ListenerEntry: %v",
@@ -1333,7 +1269,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundListenerForPortOrUDS(n
 			}
 
 			// Check if conflict happens
-			if outboundSniffingEnabled && currentListenerEntry != nil {
+			if currentListenerEntry != nil {
 				// Build TCP listener. If current listener entry is using HTTP, add a new TCP filter chain
 				// If current listener is using protocol sniffing, merge the TCP filter chains.
 				if currentListenerEntry.protocol.IsHTTP() {

--- a/pilot/pkg/networking/core/v1alpha3/listener_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_builder.go
@@ -197,10 +197,8 @@ func (lb *ListenerBuilder) aggregateVirtualInboundListener(needTLSForPassThrough
 	// Note: the HTTP inspector should be after TLS inspector.
 	// If TLS inspector sets transport protocol to tls, the http inspector
 	// won't inspect the packet.
-	if features.EnableProtocolSniffingForInbound {
-		lb.virtualInboundListener.ListenerFilters =
-			append(lb.virtualInboundListener.ListenerFilters, buildHTTPInspector(inspectors))
-	}
+	lb.virtualInboundListener.ListenerFilters =
+		append(lb.virtualInboundListener.ListenerFilters, buildHTTPInspector(inspectors))
 
 	timeout := util.GogoDurationToDuration(lb.push.Mesh.GetProtocolDetectionTimeout())
 	if features.InboundProtocolDetectionTimeoutSet {
@@ -359,11 +357,9 @@ func (lb *ListenerBuilder) buildVirtualInboundListener(configgen *ConfigGenerato
 	actualWildcard, _ := getActualWildcardAndLocalHost(lb.node)
 	// add an extra listener that binds to the port that is the recipient of the iptables redirect
 	filterChains, needTLSForPassThroughFilterChain := buildInboundCatchAllNetworkFilterChains(configgen, lb.node, lb.push)
-	if features.EnableProtocolSniffingForInbound {
-		fc, needTLS := buildInboundCatchAllHTTPFilterChains(configgen, lb.node, lb.push)
-		needTLSForPassThroughFilterChain = needTLSForPassThroughFilterChain || needTLS
-		filterChains = append(filterChains, fc...)
-	}
+	fc, needTLS := buildInboundCatchAllHTTPFilterChains(configgen, lb.node, lb.push)
+	needTLSForPassThroughFilterChain = needTLSForPassThroughFilterChain || needTLS
+	filterChains = append(filterChains, fc...)
 	lb.virtualInboundListener = &listener.Listener{
 		Name:             VirtualInboundListenerName,
 		Address:          util.BuildAddress(actualWildcard, ProxyInboundListenPort),

--- a/pilot/pkg/networking/core/v1alpha3/listener_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_builder_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/gogo/protobuf/types"
 
 	networking "istio.io/api/networking/v1alpha3"
-	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/plugin"
 	"istio.io/istio/pilot/pkg/networking/util"
@@ -152,10 +151,6 @@ func prepareListeners(t *testing.T, services []*model.Service, mode model.Traffi
 }
 
 func TestVirtualInboundListenerBuilder(t *testing.T) {
-	defaultValue := features.EnableProtocolSniffingForInbound
-	features.EnableProtocolSniffingForInbound = true
-	defer func() { features.EnableProtocolSniffingForInbound = defaultValue }()
-
 	// prepare
 	t.Helper()
 	listeners := prepareListeners(t, testServices, model.InterceptionRedirect)
@@ -198,9 +193,6 @@ func TestVirtualInboundListenerBuilder(t *testing.T) {
 }
 
 func TestVirtualInboundHasPassthroughClusters(t *testing.T) {
-	defaultValue := features.EnableProtocolSniffingForInbound
-	features.EnableProtocolSniffingForInbound = true
-	defer func() { features.EnableProtocolSniffingForInbound = defaultValue }()
 	// prepare
 	t.Helper()
 	listeners := prepareListeners(t, testServices, model.InterceptionRedirect)

--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -165,10 +165,6 @@ func TestInboundListenerConfig(t *testing.T) {
 }
 
 func TestOutboundListenerConflict_HTTPWithCurrentUnknown(t *testing.T) {
-	defaultValue := features.EnableProtocolSniffingForOutbound
-	features.EnableProtocolSniffingForOutbound = true
-	defer func() { features.EnableProtocolSniffingForOutbound = defaultValue }()
-
 	// The oldest service port is unknown.  We should encounter conflicts when attempting to add the HTTP ports. Purposely
 	// storing the services out of time order to test that it's being sorted properly.
 	testOutboundListenerConflict(t,
@@ -178,10 +174,6 @@ func TestOutboundListenerConflict_HTTPWithCurrentUnknown(t *testing.T) {
 }
 
 func TestOutboundListenerConflict_WellKnowPorts(t *testing.T) {
-	defaultValue := features.EnableProtocolSniffingForOutbound
-	features.EnableProtocolSniffingForOutbound = true
-	defer func() { features.EnableProtocolSniffingForOutbound = defaultValue }()
-
 	// The oldest service port is unknown.  We should encounter conflicts when attempting to add the HTTP ports. Purposely
 	// storing the services out of time order to test that it's being sorted properly.
 	testOutboundListenerConflict(t,
@@ -193,10 +185,6 @@ func TestOutboundListenerConflict_WellKnowPorts(t *testing.T) {
 }
 
 func TestOutboundListenerConflict_TCPWithCurrentUnknown(t *testing.T) {
-	defaultValue := features.EnableProtocolSniffingForOutbound
-	features.EnableProtocolSniffingForOutbound = true
-	defer func() { features.EnableProtocolSniffingForOutbound = defaultValue }()
-
 	// The oldest service port is unknown.  We should encounter conflicts when attempting to add the HTTP ports. Purposely
 	// storing the services out of time order to test that it's being sorted properly.
 	testOutboundListenerConflict(t,
@@ -206,10 +194,6 @@ func TestOutboundListenerConflict_TCPWithCurrentUnknown(t *testing.T) {
 }
 
 func TestOutboundListenerConflict_UnknownWithCurrentTCP(t *testing.T) {
-	defaultValue := features.EnableProtocolSniffingForOutbound
-	features.EnableProtocolSniffingForOutbound = true
-	defer func() { features.EnableProtocolSniffingForOutbound = defaultValue }()
-
 	// The oldest service port is TCP.  We should encounter conflicts when attempting to add the HTTP ports. Purposely
 	// storing the services out of time order to test that it's being sorted properly.
 	testOutboundListenerConflict(t,
@@ -219,10 +203,6 @@ func TestOutboundListenerConflict_UnknownWithCurrentTCP(t *testing.T) {
 }
 
 func TestOutboundListenerConflict_UnknownWithCurrentHTTP(t *testing.T) {
-	defaultValue := features.EnableProtocolSniffingForOutbound
-	features.EnableProtocolSniffingForOutbound = true
-	defer func() { features.EnableProtocolSniffingForOutbound = defaultValue }()
-
 	// The oldest service port is Auto.  We should encounter conflicts when attempting to add the HTTP ports. Purposely
 	// storing the services out of time order to test that it's being sorted properly.
 	testOutboundListenerConflict(t,
@@ -232,10 +212,6 @@ func TestOutboundListenerConflict_UnknownWithCurrentHTTP(t *testing.T) {
 }
 
 func TestOutboundListenerRoute(t *testing.T) {
-	defaultValue := features.EnableProtocolSniffingForOutbound
-	features.EnableProtocolSniffingForOutbound = true
-	defer func() { features.EnableProtocolSniffingForOutbound = defaultValue }()
-
 	testOutboundListenerRoute(t,
 		buildService("test1.com", "1.2.3.4", "unknown", tnow.Add(1*time.Second)),
 		buildService("test2.com", "2.3.4.5", protocol.HTTP, tnow),
@@ -304,24 +280,6 @@ func TestOutboundListenerConfig_WithSidecar(t *testing.T) {
 	}
 	services = append(services, service6)
 	testOutboundListenerConfigWithSidecar(t, services...)
-}
-
-func TestOutboundListenerConflict_HTTPWithCurrentTCP(t *testing.T) {
-	// The oldest service port is TCP.  We should encounter conflicts when attempting to add the HTTP ports. Purposely
-	// storing the services out of time order to test that it's being sorted properly.
-	testOutboundListenerConflictWithSniffingDisabled(t,
-		buildService("test1.com", wildcardIP, protocol.HTTP, tnow.Add(1*time.Second)),
-		buildService("test2.com", wildcardIP, protocol.TCP, tnow),
-		buildService("test3.com", wildcardIP, protocol.HTTP, tnow.Add(2*time.Second)))
-}
-
-func TestOutboundListenerConflict_TCPWithCurrentHTTP(t *testing.T) {
-	// The oldest service port is HTTP.  We should encounter conflicts when attempting to add the TCP ports. Purposely
-	// storing the services out of time order to test that it's being sorted properly.
-	testOutboundListenerConflictWithSniffingDisabled(t,
-		buildService("test1.com", wildcardIP, protocol.TCP, tnow.Add(1*time.Second)),
-		buildService("test2.com", wildcardIP, protocol.HTTP, tnow),
-		buildService("test3.com", wildcardIP, protocol.TCP, tnow.Add(2*time.Second)))
 }
 
 func TestOutboundListenerConflict_TCPWithCurrentTCP(t *testing.T) {
@@ -525,40 +483,6 @@ func TestInboundListenerConfig_HTTP10(t *testing.T) {
 			buildService("test.com", wildcardIP, protocol.HTTP, tnow))
 		testInboundListenerConfigWithSidecarWithoutServicesWithHTTP10Proxy(t, p)
 	}
-}
-
-func TestOutboundListenerConfig_WithDisabledSniffing_WithSidecar(t *testing.T) {
-	defaultValue := features.EnableProtocolSniffingForOutbound
-	features.EnableProtocolSniffingForOutbound = false
-	defer func() { features.EnableProtocolSniffingForOutbound = defaultValue }()
-
-	// Add a service and verify it's config
-	services := []*model.Service{
-		buildService("test1.com", wildcardIP, protocol.HTTP, tnow.Add(1*time.Second)),
-		buildService("test2.com", wildcardIP, protocol.TCP, tnow),
-		buildService("test3.com", wildcardIP, protocol.HTTP, tnow.Add(2*time.Second)),
-	}
-	service4 := &model.Service{
-		CreationTime: tnow.Add(1 * time.Second),
-		Hostname:     host.Name("test4.com"),
-		Address:      wildcardIP,
-		ClusterVIPs:  make(map[string]string),
-		Ports: model.PortList{
-			&model.Port{
-				Name:     "default",
-				Port:     9090,
-				Protocol: protocol.HTTP,
-			},
-		},
-		Resolution: model.Passthrough,
-		Attributes: model.ServiceAttributes{
-			Namespace: "default",
-		},
-	}
-	testOutboundListenerConfigWithSidecarWithSniffingDisabled(t, services...)
-	services = append(services, service4)
-	testOutboundListenerConfigWithSidecarWithCaptureModeNone(t, services...)
-	testOutboundListenerConfigWithSidecarWithUseRemoteAddress(t, services...)
 }
 
 func TestOutboundTlsTrafficWithoutTimeout(t *testing.T) {
@@ -781,33 +705,6 @@ func TestFilterChainMatchFields(t *testing.T) {
 	// If this fails, that means new fields have been added to FilterChainMatch, filterChainMatchEqual function needs to be updated.
 	if e.NumField() != 13 {
 		t.Fatalf("Expected 13 fields, got %v. This means we need to update filterChainMatchEqual implementation", e.NumField())
-	}
-}
-
-func testOutboundListenerConflictWithSniffingDisabled(t *testing.T, services ...*model.Service) {
-	t.Helper()
-
-	defaultValue := features.EnableProtocolSniffingForOutbound
-	features.EnableProtocolSniffingForOutbound = false
-	defer func() { features.EnableProtocolSniffingForOutbound = defaultValue }()
-
-	oldestService := getOldestService(services...)
-
-	p := &fakePlugin{}
-	listeners := buildOutboundListeners(t, p, getProxy(), nil, nil, services...)
-	if len(listeners) != 1 {
-		t.Fatalf("expected %d listeners, found %d", 1, len(listeners))
-	}
-
-	oldestProtocol := oldestService.Ports[0].Protocol
-	if oldestProtocol != protocol.HTTP && isHTTPListener(listeners[0]) {
-		t.Fatal("expected TCP listener, found HTTP")
-	} else if oldestProtocol == protocol.HTTP && !isHTTPListener(listeners[0]) {
-		t.Fatal("expected HTTP listener, found TCP")
-	}
-
-	if len(p.outboundListenerParams) != 1 {
-		t.Fatalf("expected %d listener params, found %d", 1, len(p.outboundListenerParams))
 	}
 }
 

--- a/pilot/pkg/networking/networking.go
+++ b/pilot/pkg/networking/networking.go
@@ -42,24 +42,7 @@ const (
 )
 
 // ModelProtocolToListenerProtocol converts from a config.Protocol to its corresponding plugin.ListenerProtocol
-func ModelProtocolToListenerProtocol(p protocol.Instance,
-	trafficDirection core.TrafficDirection) ListenerProtocol {
-	// If protocol sniffing is not enabled, the default value is TCP
-	if p == protocol.Unsupported {
-		switch trafficDirection {
-		case core.TrafficDirection_INBOUND:
-			if !features.EnableProtocolSniffingForInbound {
-				p = protocol.TCP
-			}
-		case core.TrafficDirection_OUTBOUND:
-			if !features.EnableProtocolSniffingForOutbound {
-				p = protocol.TCP
-			}
-		default:
-			// Should not reach here.
-		}
-	}
-
+func ModelProtocolToListenerProtocol(p protocol.Instance, trafficDirection core.TrafficDirection) ListenerProtocol {
 	switch p {
 	case protocol.HTTP, protocol.HTTP2, protocol.GRPC, protocol.GRPCWeb:
 		return ListenerProtocolHTTP

--- a/pilot/pkg/networking/networking_test.go
+++ b/pilot/pkg/networking/networking_test.go
@@ -19,95 +19,50 @@ import (
 
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 
-	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pkg/config/protocol"
 )
 
 func TestModelProtocolToListenerProtocol(t *testing.T) {
 	tests := []struct {
-		name                       string
-		protocol                   protocol.Instance
-		direction                  core.TrafficDirection
-		sniffingEnabledForInbound  bool
-		sniffingEnabledForOutbound bool
-		want                       ListenerProtocol
+		name      string
+		protocol  protocol.Instance
+		direction core.TrafficDirection
+		want      ListenerProtocol
 	}{
 		{
 			"TCP to TCP",
 			protocol.TCP,
 			core.TrafficDirection_INBOUND,
-			true,
-			true,
 			ListenerProtocolTCP,
 		},
 		{
 			"HTTP to HTTP",
 			protocol.HTTP,
 			core.TrafficDirection_INBOUND,
-			true,
-			true,
 			ListenerProtocolHTTP,
 		},
 		{
 			"MySQL to TCP",
 			protocol.MySQL,
 			core.TrafficDirection_INBOUND,
-			true,
-			true,
 			ListenerProtocolTCP,
 		},
 		{
 			"Inbound unknown to Auto",
 			protocol.Unsupported,
 			core.TrafficDirection_INBOUND,
-			true,
-			true,
 			ListenerProtocolAuto,
 		},
 		{
 			"Outbound unknown to Auto",
 			protocol.Unsupported,
 			core.TrafficDirection_OUTBOUND,
-			true,
-			true,
-			ListenerProtocolAuto,
-		},
-		{
-			"Inbound unknown to TCP",
-			protocol.Unsupported,
-			core.TrafficDirection_INBOUND,
-			false,
-			true,
-			ListenerProtocolTCP,
-		},
-		{
-			"Outbound unknown to Auto (disable sniffing for inbound)",
-			protocol.Unsupported,
-			core.TrafficDirection_OUTBOUND,
-			false,
-			true,
-			ListenerProtocolAuto,
-		},
-		{
-			"Inbound unknown to Auto (disable sniffing for outbound)",
-			protocol.Unsupported,
-			core.TrafficDirection_INBOUND,
-			true,
-			false,
 			ListenerProtocolAuto,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			defaultValue := features.EnableProtocolSniffingForOutbound
-			features.EnableProtocolSniffingForOutbound = tt.sniffingEnabledForOutbound
-			defer func() { features.EnableProtocolSniffingForOutbound = defaultValue }()
-
-			defaultInboundValue := features.EnableProtocolSniffingForInbound
-			features.EnableProtocolSniffingForInbound = tt.sniffingEnabledForInbound
-			defer func() { features.EnableProtocolSniffingForInbound = defaultInboundValue }()
-
 			if got := ModelProtocolToListenerProtocol(tt.protocol, tt.direction); got != tt.want {
 				t.Errorf("ModelProtocolToListenerProtocol() = %v, want %v", got, tt.want)
 			}

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -277,15 +277,15 @@ func IsIstioVersionGE19(node *model.Proxy) bool {
 }
 
 func IsProtocolSniffingEnabledForPort(port *model.Port) bool {
-	return features.EnableProtocolSniffingForOutbound && port.Protocol.IsUnsupported()
+	return port.Protocol.IsUnsupported()
 }
 
 func IsProtocolSniffingEnabledForInboundPort(port *model.Port) bool {
-	return features.EnableProtocolSniffingForInbound && port.Protocol.IsUnsupported()
+	return port.Protocol.IsUnsupported()
 }
 
 func IsProtocolSniffingEnabledForOutboundPort(port *model.Port) bool {
-	return features.EnableProtocolSniffingForOutbound && port.Protocol.IsUnsupported()
+	return port.Protocol.IsUnsupported()
 }
 
 // ConvertLocality converts '/' separated locality string to Locality struct.


### PR DESCRIPTION
After a bit of testing, these flags do not actually work fully -
detection is still enabled. Since we have no testing, no proper API, not
documentation, and no known use cases, seems safe to remove these now.

Put a hold to ensure this gets at least a few approvals first