### PR TITLE
enable node on first message only for 1.10 proxies

### DIFF
--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -276,6 +276,12 @@ func IsIstioVersionGE19(node *model.Proxy) bool {
 		node.IstioVersion.Compare(&model.IstioVersion{Major: 1, Minor: 9, Patch: -1}) >= 0
 }
 
+// IsIstioVersionGE110 checks whether the given Istio version is greater than or equals 1.9.
+func IsIstioVersionGE110(node *model.Proxy) bool {
+	return node == nil || node.IstioVersion == nil ||
+		node.IstioVersion.Compare(&model.IstioVersion{Major: 1, Minor: 10, Patch: -1}) >= 0
+}
+
 func IsProtocolSniffingEnabledForPort(port *model.Port) bool {
 	return features.EnableProtocolSniffingForOutbound && port.Protocol.IsUnsupported()
 }

--- a/pilot/pkg/security/model/authentication.go
+++ b/pilot/pkg/security/model/authentication.go
@@ -184,13 +184,13 @@ func ConstructSdsSecretConfig(name string, node *model.Proxy) *tls.SdsSecretConf
 	}
 
 	if name == SDSDefaultResourceName {
-		if util.IsIstioVersionGE19(node) {
+		if util.IsIstioVersionGE110(node) {
 			return defaultSDSConfig
 		}
 		return legacyDefaultSDSConfig
 	}
 	if name == SDSRootResourceName {
-		if util.IsIstioVersionGE19(node) {
+		if util.IsIstioVersionGE110(node) {
 			return rootSDSConfig
 		}
 		return legacyRootSDSConfig
@@ -216,7 +216,7 @@ func ConstructSdsSecretConfig(name string, node *model.Proxy) *tls.SdsSecretConf
 		},
 	}
 
-	if util.IsIstioVersionGE19(node) {
+	if util.IsIstioVersionGE110(node) {
 		cfg.SdsConfig.GetApiConfigSource().SetNodeOnFirstMessageOnly = true
 	}
 	return cfg


### PR DESCRIPTION
We enabled this in 1.10 bootstrap for ADS. For SDS we are checking 1.9 - It is better to be consistent and check for 1.10 for SDS also

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ X] Does not have any changes that may affect Istio users.
