### PR TITLE
tf: shadow t var to avoid using wrong one

### DIFF
--- a/pkg/test/framework/components/istioctl/istioctl.go
+++ b/pkg/test/framework/components/istioctl/istioctl.go
@@ -16,7 +16,6 @@ package istioctl
 
 import (
 	"fmt"
-	"testing"
 
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/framework/components/cluster"
@@ -33,7 +32,7 @@ type Instance interface {
 	Invoke(args []string) (string, string, error)
 
 	// InvokeOrFail calls Invoke and fails tests if it returns en err
-	InvokeOrFail(t *testing.T, args []string) (string, string)
+	InvokeOrFail(t test.Failer, args []string) (string, string)
 }
 
 // Config is structured config for the istioctl component

--- a/pkg/test/framework/components/istioctl/kube.go
+++ b/pkg/test/framework/components/istioctl/kube.go
@@ -18,10 +18,10 @@ import (
 	"bytes"
 	"fmt"
 	"strings"
-	"testing"
 
 	"istio.io/istio/istioctl/cmd"
 	"istio.io/istio/pilot/pkg/config/kube/crd"
+	"istio.io/istio/pkg/test"
 	kubecluster "istio.io/istio/pkg/test/framework/components/cluster/kube"
 	"istio.io/istio/pkg/test/framework/resource"
 )
@@ -82,7 +82,7 @@ func (c *kubeComponent) Invoke(args []string) (string, string, error) {
 }
 
 // InvokeOrFail implements Instance
-func (c *kubeComponent) InvokeOrFail(t *testing.T, args []string) (string, string) {
+func (c *kubeComponent) InvokeOrFail(t test.Failer, args []string) (string, string) {
 	output, stderr, err := c.Invoke(args)
 	if err != nil {
 		t.Logf("Unwanted exception for 'istioctl %s': %v", strings.Join(args, " "), err)

--- a/tests/integration/pilot/analyze_test.go
+++ b/tests/integration/pilot/analyze_test.go
@@ -26,6 +26,7 @@ import (
 	"istio.io/istio/galley/pkg/config/analysis/diag"
 	"istio.io/istio/galley/pkg/config/analysis/msg"
 	"istio.io/istio/istioctl/cmd"
+	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/istioctl"
 	"istio.io/istio/pkg/test/framework/components/namespace"
@@ -48,15 +49,15 @@ func TestEmptyCluster(t *testing.T) {
 	framework.
 		NewTest(t).
 		RequiresSingleCluster().
-		Run(func(ctx framework.TestContext) {
+		Run(func(t framework.TestContext) {
 			g := NewWithT(t)
 
-			ns := namespace.NewOrFail(t, ctx, namespace.Config{
+			ns := namespace.NewOrFail(t, t, namespace.Config{
 				Prefix: "istioctl-analyze",
 				Inject: true,
 			})
 
-			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{})
+			istioCtl := istioctl.NewOrFail(t, t, istioctl.Config{})
 
 			// For a clean istio install with injection enabled, expect no validation errors
 			output, err := istioctlSafe(t, istioCtl, ns.Name(), true)
@@ -69,15 +70,15 @@ func TestFileOnly(t *testing.T) {
 	framework.
 		NewTest(t).
 		RequiresSingleCluster().
-		Run(func(ctx framework.TestContext) {
+		Run(func(t framework.TestContext) {
 			g := NewWithT(t)
 
-			ns := namespace.NewOrFail(t, ctx, namespace.Config{
+			ns := namespace.NewOrFail(t, t, namespace.Config{
 				Prefix: "istioctl-analyze",
 				Inject: true,
 			})
 
-			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{})
+			istioCtl := istioctl.NewOrFail(t, t, istioctl.Config{})
 
 			// Validation error if we have a virtual service with subset not defined.
 			output, err := istioctlSafe(t, istioCtl, ns.Name(), false, virtualServiceFile)
@@ -95,15 +96,15 @@ func TestDirectoryWithoutRecursion(t *testing.T) {
 	framework.
 		NewTest(t).
 		RequiresSingleCluster().
-		Run(func(ctx framework.TestContext) {
+		Run(func(t framework.TestContext) {
 			g := NewWithT(t)
 
-			ns := namespace.NewOrFail(t, ctx, namespace.Config{
+			ns := namespace.NewOrFail(t, t, namespace.Config{
 				Prefix: "istioctl-analyze",
 				Inject: true,
 			})
 
-			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{})
+			istioCtl := istioctl.NewOrFail(t, t, istioctl.Config{})
 
 			// Recursive is false, so we should only analyze
 			// testdata/some-dir/missing-gateway.yaml and get a
@@ -119,15 +120,15 @@ func TestDirectoryWithRecursion(t *testing.T) {
 	framework.
 		NewTest(t).
 		RequiresSingleCluster().
-		Run(func(ctx framework.TestContext) {
+		Run(func(t framework.TestContext) {
 			g := NewWithT(t)
 
-			ns := namespace.NewOrFail(t, ctx, namespace.Config{
+			ns := namespace.NewOrFail(t, t, namespace.Config{
 				Prefix: "istioctl-analyze",
 				Inject: true,
 			})
 
-			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{})
+			istioCtl := istioctl.NewOrFail(t, t, istioctl.Config{})
 
 			// Recursive is true, so we should see two errors (SchemaValidationError and UnknownAnnotation).
 			output, err := istioctlSafe(t, istioCtl, ns.Name(), false, "--recursive=true", dirWithConfig)
@@ -140,15 +141,15 @@ func TestInvalidFileError(t *testing.T) {
 	framework.
 		NewTest(t).
 		RequiresSingleCluster().
-		Run(func(ctx framework.TestContext) {
+		Run(func(t framework.TestContext) {
 			g := NewWithT(t)
 
-			ns := namespace.NewOrFail(t, ctx, namespace.Config{
+			ns := namespace.NewOrFail(t, t, namespace.Config{
 				Prefix: "istioctl-analyze",
 				Inject: true,
 			})
 
-			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{})
+			istioCtl := istioctl.NewOrFail(t, t, istioctl.Config{})
 
 			// Skip the file with invalid extension and produce no errors.
 			output, err := istioctlSafe(t, istioCtl, ns.Name(), false, invalidExtensionFile)
@@ -168,15 +169,15 @@ func TestJsonInputFile(t *testing.T) {
 	framework.
 		NewTest(t).
 		RequiresSingleCluster().
-		Run(func(ctx framework.TestContext) {
+		Run(func(t framework.TestContext) {
 			g := NewWithT(t)
 
-			ns := namespace.NewOrFail(t, ctx, namespace.Config{
+			ns := namespace.NewOrFail(t, t, namespace.Config{
 				Prefix: "istioctl-analyze",
 				Inject: true,
 			})
 
-			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{})
+			istioCtl := istioctl.NewOrFail(t, t, istioctl.Config{})
 
 			// Validation error if we have a gateway with invalid selector.
 			output, err := istioctlSafe(t, istioCtl, ns.Name(), false, jsonGatewayFile)
@@ -189,15 +190,15 @@ func TestJsonOutput(t *testing.T) {
 	framework.
 		NewTest(t).
 		RequiresSingleCluster().
-		Run(func(ctx framework.TestContext) {
+		Run(func(t framework.TestContext) {
 			g := NewWithT(t)
 
-			ns := namespace.NewOrFail(t, ctx, namespace.Config{
+			ns := namespace.NewOrFail(t, t, namespace.Config{
 				Prefix: "istioctl-analyze",
 				Inject: true,
 			})
 
-			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{})
+			istioCtl := istioctl.NewOrFail(t, t, istioctl.Config{})
 
 			testcases := []struct {
 				name     string
@@ -217,7 +218,7 @@ func TestJsonOutput(t *testing.T) {
 			}
 
 			for _, tc := range testcases {
-				ctx.NewSubTest(tc.name).Run(func(ctx framework.TestContext) {
+				t.NewSubTest(tc.name).Run(func(t framework.TestContext) {
 					stdout, _, err := istioctlWithStderr(t, istioCtl, ns.Name(), false, tc.args...)
 					expectJSONMessages(t, g, stdout, tc.messages...)
 					g.Expect(err).To(BeNil())
@@ -230,17 +231,17 @@ func TestKubeOnly(t *testing.T) {
 	framework.
 		NewTest(t).
 		RequiresSingleCluster().
-		Run(func(ctx framework.TestContext) {
+		Run(func(t framework.TestContext) {
 			g := NewWithT(t)
 
-			ns := namespace.NewOrFail(t, ctx, namespace.Config{
+			ns := namespace.NewOrFail(t, t, namespace.Config{
 				Prefix: "istioctl-analyze",
 				Inject: true,
 			})
 
-			applyFileOrFail(ctx, ns.Name(), gatewayFile)
+			applyFileOrFail(t, ns.Name(), gatewayFile)
 
-			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{})
+			istioCtl := istioctl.NewOrFail(t, t, istioctl.Config{})
 
 			// Validation error if we have a gateway with invalid selector.
 			output, err := istioctlSafe(t, istioCtl, ns.Name(), true)
@@ -253,17 +254,17 @@ func TestFileAndKubeCombined(t *testing.T) {
 	framework.
 		NewTest(t).
 		RequiresSingleCluster().
-		Run(func(ctx framework.TestContext) {
+		Run(func(t framework.TestContext) {
 			g := NewWithT(t)
 
-			ns := namespace.NewOrFail(t, ctx, namespace.Config{
+			ns := namespace.NewOrFail(t, t, namespace.Config{
 				Prefix: "istioctl-analyze",
 				Inject: true,
 			})
 
-			applyFileOrFail(ctx, ns.Name(), virtualServiceFile)
+			applyFileOrFail(t, ns.Name(), virtualServiceFile)
 
-			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{})
+			istioCtl := istioctl.NewOrFail(t, t, istioctl.Config{})
 
 			// Simulating applying the destination rule that defines the subset, we should
 			// fix the error and thus see no message
@@ -277,22 +278,22 @@ func TestAllNamespaces(t *testing.T) {
 	framework.
 		NewTest(t).
 		RequiresSingleCluster().
-		Run(func(ctx framework.TestContext) {
+		Run(func(t framework.TestContext) {
 			g := NewWithT(t)
 
-			ns1 := namespace.NewOrFail(t, ctx, namespace.Config{
+			ns1 := namespace.NewOrFail(t, t, namespace.Config{
 				Prefix: "istioctl-analyze-1",
 				Inject: true,
 			})
-			ns2 := namespace.NewOrFail(t, ctx, namespace.Config{
+			ns2 := namespace.NewOrFail(t, t, namespace.Config{
 				Prefix: "istioctl-analyze-2",
 				Inject: true,
 			})
 
-			applyFileOrFail(ctx, ns1.Name(), gatewayFile)
-			applyFileOrFail(ctx, ns2.Name(), gatewayFile)
+			applyFileOrFail(t, ns1.Name(), gatewayFile)
+			applyFileOrFail(t, ns2.Name(), gatewayFile)
 
-			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{})
+			istioCtl := istioctl.NewOrFail(t, t, istioctl.Config{})
 
 			// If we look at one namespace, we should successfully run and see one message (and not anything from any other namespace)
 			output, _ := istioctlSafe(t, istioCtl, ns1.Name(), true)
@@ -321,15 +322,15 @@ func TestTimeout(t *testing.T) {
 	framework.
 		NewTest(t).
 		RequiresSingleCluster().
-		Run(func(ctx framework.TestContext) {
+		Run(func(t framework.TestContext) {
 			g := NewWithT(t)
 
-			ns := namespace.NewOrFail(t, ctx, namespace.Config{
+			ns := namespace.NewOrFail(t, t, namespace.Config{
 				Prefix: "istioctl-analyze",
 				Inject: true,
 			})
 
-			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{})
+			istioCtl := istioctl.NewOrFail(t, t, istioctl.Config{})
 
 			// We should time out immediately.
 			_, err := istioctlSafe(t, istioCtl, ns.Name(), true, "--timeout=0s")
@@ -343,15 +344,15 @@ func TestErrorLine(t *testing.T) {
 		NewTest(t).
 		RequiresSingleCluster().
 		Features("usability.observability.analysis.line-numbers").
-		Run(func(ctx framework.TestContext) {
+		Run(func(t framework.TestContext) {
 			g := NewWithT(t)
 
-			ns := namespace.NewOrFail(t, ctx, namespace.Config{
+			ns := namespace.NewOrFail(t, t, namespace.Config{
 				Prefix: "istioctl-analyze",
 				Inject: true,
 			})
 
-			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{})
+			istioCtl := istioctl.NewOrFail(t, t, istioctl.Config{})
 
 			// Validation error if we have a gateway with invalid selector.
 			output, err := istioctlSafe(t, istioCtl, ns.Name(), true, gatewayFile, virtualServiceFile)
@@ -363,7 +364,7 @@ func TestErrorLine(t *testing.T) {
 }
 
 // Verify the output contains messages of the expected type, in order, followed by boilerplate lines
-func expectMessages(t *testing.T, g *GomegaWithT, outputLines []string, expected ...*diag.MessageType) {
+func expectMessages(t test.Failer, g *GomegaWithT, outputLines []string, expected ...*diag.MessageType) {
 	t.Helper()
 
 	// The boilerplate lines that appear if any issues are found
@@ -380,13 +381,13 @@ func expectMessages(t *testing.T, g *GomegaWithT, outputLines []string, expected
 	}
 }
 
-func expectNoMessages(t *testing.T, g *GomegaWithT, output []string) {
+func expectNoMessages(t test.Failer, g *GomegaWithT, output []string) {
 	t.Helper()
 	g.Expect(output).To(HaveLen(1))
 	g.Expect(output[0]).To(ContainSubstring("No validation issues found when analyzing"))
 }
 
-func expectJSONMessages(t *testing.T, g *GomegaWithT, output string, expected ...*diag.MessageType) {
+func expectJSONMessages(t test.Failer, g *GomegaWithT, output string, expected ...*diag.MessageType) {
 	t.Helper()
 
 	var j []map[string]interface{}
@@ -403,12 +404,12 @@ func expectJSONMessages(t *testing.T, g *GomegaWithT, output string, expected ..
 }
 
 // istioctlSafe calls istioctl analyze with certain flags set. Stdout and Stderr are merged
-func istioctlSafe(t *testing.T, i istioctl.Instance, ns string, useKube bool, extraArgs ...string) ([]string, error) {
+func istioctlSafe(t test.Failer, i istioctl.Instance, ns string, useKube bool, extraArgs ...string) ([]string, error) {
 	output, stderr, err := istioctlWithStderr(t, i, ns, useKube, extraArgs...)
 	return strings.Split(strings.TrimSpace(output+stderr), "\n"), err
 }
 
-func istioctlWithStderr(t *testing.T, i istioctl.Instance, ns string, useKube bool, extraArgs ...string) (string, string, error) {
+func istioctlWithStderr(t test.Failer, i istioctl.Instance, ns string, useKube bool, extraArgs ...string) (string, string, error) {
 	t.Helper()
 
 	args := []string{"analyze"}
@@ -422,12 +423,12 @@ func istioctlWithStderr(t *testing.T, i istioctl.Instance, ns string, useKube bo
 }
 
 // applyFileOrFail applys the given yaml file and deletes it during context cleanup
-func applyFileOrFail(ctx framework.TestContext, ns, filename string) {
-	ctx.Helper()
-	if err := ctx.Clusters().Default().ApplyYAMLFiles(ns, filename); err != nil {
-		ctx.Fatal(err)
+func applyFileOrFail(t framework.TestContext, ns, filename string) {
+	t.Helper()
+	if err := t.Clusters().Default().ApplyYAMLFiles(ns, filename); err != nil {
+		t.Fatal(err)
 	}
-	ctx.ConditionalCleanup(func() {
-		ctx.Clusters().Default().DeleteYAMLFiles(ns, filename)
+	t.ConditionalCleanup(func() {
+		t.Clusters().Default().DeleteYAMLFiles(ns, filename)
 	})
 }

--- a/tests/integration/pilot/cni/cni_test.go
+++ b/tests/integration/pilot/cni/cni_test.go
@@ -43,8 +43,8 @@ components:
      namespace: kube-system
 `
 		})).
-		Setup(func(ctx resource.Context) error {
-			return util.SetupApps(ctx, ist, apps, false)
+		Setup(func(t resource.Context) error {
+			return util.SetupApps(t, ist, apps, false)
 		}).
 		Run()
 }
@@ -57,13 +57,13 @@ components:
 // - Send HTTP/gRPC requests between apps.
 func TestCNIReachability(t *testing.T) {
 	framework.NewTest(t).
-		Run(func(ctx framework.TestContext) {
-			cluster := ctx.Clusters().Default()
+		Run(func(t framework.TestContext) {
+			cluster := t.Clusters().Default()
 			_, err := kube2.WaitUntilPodsAreReady(kube2.NewSinglePodFetch(cluster, "kube-system", "k8s-app=istio-cni-node"))
 			if err != nil {
-				ctx.Fatal(err)
+				t.Fatal(err)
 			}
-			systemNM := istio.ClaimSystemNamespaceOrFail(ctx, ctx)
+			systemNM := istio.ClaimSystemNamespaceOrFail(t, t)
 			testCases := []reachability.TestCase{
 				{
 					ConfigFile: "global-mtls-on.yaml",
@@ -90,6 +90,6 @@ func TestCNIReachability(t *testing.T) {
 					},
 				},
 			}
-			reachability.Run(testCases, ctx, apps)
+			reachability.Run(testCases, t, apps)
 		})
 }

--- a/tests/integration/pilot/common/apps.go
+++ b/tests/integration/pilot/common/apps.go
@@ -114,16 +114,16 @@ func serviceEntryPorts() []echo.Port {
 	return res
 }
 
-func SetupApps(ctx resource.Context, i istio.Instance, apps *EchoDeployments) error {
+func SetupApps(t resource.Context, i istio.Instance, apps *EchoDeployments) error {
 	var err error
-	apps.Namespace, err = namespace.New(ctx, namespace.Config{
+	apps.Namespace, err = namespace.New(t, namespace.Config{
 		Prefix: "echo",
 		Inject: true,
 	})
 	if err != nil {
 		return err
 	}
-	apps.ExternalNamespace, err = namespace.New(ctx, namespace.Config{
+	apps.ExternalNamespace, err = namespace.New(t, namespace.Config{
 		Prefix: "external",
 		Inject: false,
 	})
@@ -131,7 +131,7 @@ func SetupApps(ctx resource.Context, i istio.Instance, apps *EchoDeployments) er
 		return err
 	}
 
-	apps.Ingress = i.IngressFor(ctx.Clusters().Default())
+	apps.Ingress = i.IngressFor(t.Clusters().Default())
 
 	// Headless services don't work with targetPort, set to same port
 	headlessPorts := make([]echo.Port, len(EchoPorts))
@@ -139,8 +139,8 @@ func SetupApps(ctx resource.Context, i istio.Instance, apps *EchoDeployments) er
 		p.ServicePort = p.InstancePort
 		headlessPorts[i] = p
 	}
-	builder := echoboot.NewBuilder(ctx).
-		WithClusters(ctx.Clusters()...).
+	builder := echoboot.NewBuilder(t).
+		WithClusters(t.Clusters()...).
 		WithConfig(echo.Config{
 			Service:           PodASvc,
 			Namespace:         apps.Namespace,
@@ -233,11 +233,11 @@ func SetupApps(ctx resource.Context, i istio.Instance, apps *EchoDeployments) er
 	apps.Headless = echos.Match(echo.Service(HeadlessSvc))
 	apps.Naked = echos.Match(echo.Service(NakedSvc))
 	apps.External = echos.Match(echo.Service(ExternalSvc))
-	if !ctx.Settings().SkipVM {
+	if !t.Settings().SkipVM {
 		apps.VM = echos.Match(echo.Service(VMSvc))
 	}
 
-	if err := ctx.Config().ApplyYAML(apps.Namespace.Name(), `
+	if err := t.Config().ApplyYAML(apps.Namespace.Name(), `
 apiVersion: networking.istio.io/v1alpha3
 kind: Sidecar
 metadata:
@@ -280,7 +280,7 @@ spec:
 	if err != nil {
 		return err
 	}
-	if err := ctx.Config().ApplyYAML(apps.Namespace.Name(), se); err != nil {
+	if err := t.Config().ApplyYAML(apps.Namespace.Name(), se); err != nil {
 		return err
 	}
 	return nil

--- a/tests/integration/pilot/common/traffic.go
+++ b/tests/integration/pilot/common/traffic.go
@@ -54,39 +54,39 @@ type TrafficTestCase struct {
 	skip bool
 }
 
-func (c TrafficTestCase) Run(ctx framework.TestContext, namespace string) {
-	job := func(ctx framework.TestContext) {
+func (c TrafficTestCase) Run(t framework.TestContext, namespace string) {
+	job := func(t framework.TestContext) {
 		if c.skip {
-			ctx.SkipNow()
+			t.SkipNow()
 		}
 		if len(c.config) > 0 {
-			cfg := yml.MustApplyNamespace(ctx, c.config, namespace)
-			ctx.Config().ApplyYAMLOrFail(ctx, "", cfg)
+			cfg := yml.MustApplyNamespace(t, c.config, namespace)
+			t.Config().ApplyYAMLOrFail(t, "", cfg)
 		}
 
 		if c.call != nil && len(c.children) > 0 {
-			ctx.Fatal("TrafficTestCase: must not specify both call and children")
+			t.Fatal("TrafficTestCase: must not specify both call and children")
 		}
 
 		if c.call != nil {
 			// Call the function with a few custom retry options.
-			c.call(ctx, c.opts, retryOptions...)
+			c.call(t, c.opts, retryOptions...)
 		}
 
 		for _, child := range c.children {
-			ctx.NewSubTest(child.name).Run(func(ctx framework.TestContext) {
-				child.call(ctx, child.opts, retryOptions...)
+			t.NewSubTest(child.name).Run(func(t framework.TestContext) {
+				child.call(t, child.opts, retryOptions...)
 			})
 		}
 	}
 	if c.name != "" {
-		ctx.NewSubTest(c.name).Run(job)
+		t.NewSubTest(c.name).Run(job)
 	} else {
-		job(ctx)
+		job(t)
 	}
 }
 
-func RunAllTrafficTests(ctx framework.TestContext, apps *EchoDeployments) {
+func RunAllTrafficTests(t framework.TestContext, apps *EchoDeployments) {
 	cases := map[string][]TrafficTestCase{}
 	cases["virtualservice"] = virtualServiceCases(apps)
 	cases["sniffing"] = protocolSniffingCases(apps)
@@ -97,14 +97,14 @@ func RunAllTrafficTests(ctx framework.TestContext, apps *EchoDeployments) {
 	cases["tls-origination"] = tlsOriginationCases(apps)
 	cases["instanceip"] = instanceIPTests(apps)
 	cases["services"] = serviceCases(apps)
-	if !ctx.Settings().SkipVM {
+	if !t.Settings().SkipVM {
 		cases["vm"] = VMTestCases(apps.VM, apps)
 	}
 	cases["dns"] = DNSTestCases(apps)
 	for name, tts := range cases {
-		ctx.NewSubTest(name).Run(func(ctx framework.TestContext) {
+		t.NewSubTest(name).Run(func(t framework.TestContext) {
 			for _, tt := range tts {
-				tt.Run(ctx, apps.Namespace.Name())
+				tt.Run(t, apps.Namespace.Name())
 			}
 		})
 	}

--- a/tests/integration/pilot/endpointslice/endpointslice_test.go
+++ b/tests/integration/pilot/endpointslice/endpointslice_test.go
@@ -37,15 +37,15 @@ func TestMain(m *testing.M) {
 	framework.
 		NewSuite(m).
 		RequireEnvironmentVersion("1.17").
-		Setup(istio.Setup(&i, func(ctx resource.Context, cfg *istio.Config) {
+		Setup(istio.Setup(&i, func(t resource.Context, cfg *istio.Config) {
 			cfg.ControlPlaneValues = `
 values:
   pilot:
     env:
       PILOT_USE_ENDPOINT_SLICE: "true"`
 		})).
-		Setup(func(ctx resource.Context) error {
-			return common.SetupApps(ctx, i, apps)
+		Setup(func(t resource.Context) error {
+			return common.SetupApps(t, i, apps)
 		}).
 		Run()
 }
@@ -54,7 +54,7 @@ func TestTraffic(t *testing.T) {
 	framework.
 		NewTest(t).
 		Features("traffic.routing", "traffic.reachability", "traffic.shifting").
-		Run(func(ctx framework.TestContext) {
-			common.RunAllTrafficTests(ctx, apps)
+		Run(func(t framework.TestContext) {
+			common.RunAllTrafficTests(t, apps)
 		})
 }

--- a/tests/integration/pilot/gateway_topology/gw_topology_test.go
+++ b/tests/integration/pilot/gateway_topology/gw_topology_test.go
@@ -32,15 +32,15 @@ var (
 func TestMain(m *testing.M) {
 	framework.
 		NewSuite(m).
-		Setup(istio.Setup(&i, func(ctx resource.Context, cfg *istio.Config) {
+		Setup(istio.Setup(&i, func(t resource.Context, cfg *istio.Config) {
 			cfg.ControlPlaneValues = `
 meshConfig:
   defaultConfig:
     gatewayTopology:
       numTrustedProxies: 2`
 		})).
-		Setup(func(ctx resource.Context) error {
-			return common.SetupApps(ctx, i, apps)
+		Setup(func(t resource.Context) error {
+			return common.SetupApps(t, i, apps)
 		}).
 		Run()
 }
@@ -49,20 +49,20 @@ func TestTraffic(t *testing.T) {
 	framework.
 		NewTest(t).
 		Features("traffic.ingress.topology").
-		Run(func(ctx framework.TestContext) {
-			runXFFTrafficTests(ctx, apps)
+		Run(func(t framework.TestContext) {
+			runXFFTrafficTests(t, apps)
 		})
 }
 
-func runXFFTrafficTests(ctx framework.TestContext, apps *common.EchoDeployments) {
+func runXFFTrafficTests(t framework.TestContext, apps *common.EchoDeployments) {
 	cases := map[string][]common.TrafficTestCase{
 		"xff": common.XFFGatewayCase(apps),
 	}
 
 	for name, tts := range cases {
-		ctx.NewSubTest(name).Run(func(ctx framework.TestContext) {
+		t.NewSubTest(name).Run(func(t framework.TestContext) {
 			for _, tt := range tts {
-				tt.Run(ctx, apps.Namespace.Name())
+				tt.Run(t, apps.Namespace.Name())
 			}
 		})
 	}

--- a/tests/integration/pilot/istioctl_test.go
+++ b/tests/integration/pilot/istioctl_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/onsi/gomega"
 
+	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
@@ -65,12 +66,12 @@ Next Step: Add related labels to the deployment to align with Istio's requiremen
 func TestWait(t *testing.T) {
 	framework.NewTest(t).Features("usability.observability.wait").
 		RequiresSingleCluster().
-		Run(func(ctx framework.TestContext) {
-			ns := namespace.NewOrFail(t, ctx, namespace.Config{
+		Run(func(t framework.TestContext) {
+			ns := namespace.NewOrFail(t, t, namespace.Config{
 				Prefix: "default",
 				Inject: true,
 			})
-			ctx.Config().ApplyYAMLOrFail(t, ns.Name(), `
+			t.Config().ApplyYAMLOrFail(t, ns.Name(), `
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
@@ -84,7 +85,7 @@ spec:
     - destination: 
         host: reviews
 `)
-			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{Cluster: ctx.Environment().Clusters()[0]})
+			istioCtl := istioctl.NewOrFail(t, t, istioctl.Config{Cluster: t.Environment().Clusters()[0]})
 			istioCtl.InvokeOrFail(t, []string{"x", "wait", "-v", "VirtualService", "reviews." + ns.Name()})
 		})
 }
@@ -95,10 +96,10 @@ func TestVersion(t *testing.T) {
 	framework.
 		NewTest(t).Features("usability.observability.version").
 		RequiresSingleCluster().
-		Run(func(ctx framework.TestContext) {
+		Run(func(t framework.TestContext) {
 			cfg := i.Settings()
 
-			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{Cluster: ctx.Environment().Clusters()[0]})
+			istioCtl := istioctl.NewOrFail(t, t, istioctl.Config{Cluster: t.Environment().Clusters()[0]})
 			args := []string{"version", "--remote=true", fmt.Sprintf("--istioNamespace=%s", cfg.SystemNamespace)}
 
 			output, _ := istioCtl.InvokeOrFail(t, args)
@@ -109,23 +110,23 @@ func TestVersion(t *testing.T) {
 				return
 			}
 
-			ctx.Fatalf("Did not find control plane version: %v", output)
+			t.Fatalf("Did not find control plane version: %v", output)
 		})
 }
 
 func TestDescribe(t *testing.T) {
 	framework.NewTest(t).Features("usability.observability.describe").
 		RequiresSingleCluster().
-		Run(func(ctx framework.TestContext) {
+		Run(func(t framework.TestContext) {
 			deployment := file.AsStringOrFail(t, "testdata/a.yaml")
-			ctx.Config().ApplyYAMLOrFail(ctx, apps.Namespace.Name(), deployment)
+			t.Config().ApplyYAMLOrFail(t, apps.Namespace.Name(), deployment)
 
-			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{})
+			istioCtl := istioctl.NewOrFail(t, t, istioctl.Config{})
 
 			// When this test passed the namespace through --namespace it was flakey
 			// because istioctl uses a global variable for namespace, and this test may
 			// run in parallel.
-			retry.UntilSuccessOrFail(ctx, func() error {
+			retry.UntilSuccessOrFail(t, func() error {
 				args := []string{
 					"--namespace=dummy",
 					"x", "describe", "svc", fmt.Sprintf("%s.%s", common.PodASvc, apps.Namespace.Name()),
@@ -140,7 +141,7 @@ func TestDescribe(t *testing.T) {
 				return nil
 			}, retry.Timeout(time.Second*5))
 
-			retry.UntilSuccessOrFail(ctx, func() error {
+			retry.UntilSuccessOrFail(t, func() error {
 				podID, err := getPodID(apps.PodA[0])
 				if err != nil {
 					return fmt.Errorf("could not get Pod ID: %v", err)
@@ -179,18 +180,18 @@ func getPodID(i echo.Instance) (string, error) {
 func TestAddToAndRemoveFromMesh(t *testing.T) {
 	framework.NewTest(t).Features("usability.helpers.add-to-mesh", "usability.helpers.remove-from-mesh").
 		RequiresSingleCluster().
-		RunParallel(func(ctx framework.TestContext) {
-			ns := namespace.NewOrFail(t, ctx, namespace.Config{
+		RunParallel(func(t framework.TestContext) {
+			ns := namespace.NewOrFail(t, t, namespace.Config{
 				Prefix: "istioctl-add-to-mesh",
 				Inject: true,
 			})
 
 			var a echo.Instance
-			echoboot.NewBuilder(ctx).
+			echoboot.NewBuilder(t).
 				With(&a, echoConfig(ns, "a")).
-				BuildOrFail(ctx)
+				BuildOrFail(t)
 
-			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{Cluster: ctx.Environment().Clusters()[0]})
+			istioCtl := istioctl.NewOrFail(t, t, istioctl.Config{Cluster: t.Environment().Clusters()[0]})
 
 			var output string
 			var args []string
@@ -206,7 +207,7 @@ func TestAddToAndRemoveFromMesh(t *testing.T) {
 
 			retry.UntilSuccessOrFail(t, func() error {
 				// Wait until the new pod is ready
-				fetch := kubetest.NewPodMustFetch(ctx.Clusters().Default(), ns.Name(), "app=a")
+				fetch := kubetest.NewPodMustFetch(t.Clusters().Default(), ns.Name(), "app=a")
 				pods, err := kubetest.WaitUntilPodsAreReady(fetch)
 				if err != nil {
 					return err
@@ -233,12 +234,12 @@ func TestAddToAndRemoveFromMesh(t *testing.T) {
 func TestProxyConfig(t *testing.T) {
 	framework.NewTest(t).Features("usability.observability.proxy-config").
 		RequiresSingleCluster().
-		Run(func(ctx framework.TestContext) {
-			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{})
+		Run(func(t framework.TestContext) {
+			istioCtl := istioctl.NewOrFail(t, t, istioctl.Config{})
 
 			podID, err := getPodID(apps.PodA[0])
 			if err != nil {
-				ctx.Fatalf("Could not get Pod ID: %v", err)
+				t.Fatalf("Could not get Pod ID: %v", err)
 			}
 
 			var output string
@@ -308,7 +309,7 @@ func TestProxyConfig(t *testing.T) {
 		})
 }
 
-func jsonUnmarshallOrFail(t *testing.T, context, s string) interface{} {
+func jsonUnmarshallOrFail(t test.Failer, context, s string) interface{} {
 	t.Helper()
 	var val interface{}
 
@@ -322,12 +323,12 @@ func jsonUnmarshallOrFail(t *testing.T, context, s string) interface{} {
 func TestProxyStatus(t *testing.T) {
 	framework.NewTest(t).Features("usability.observability.proxy-status").
 		RequiresSingleCluster().
-		Run(func(ctx framework.TestContext) {
-			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{})
+		Run(func(t framework.TestContext) {
+			istioCtl := istioctl.NewOrFail(t, t, istioctl.Config{})
 
 			podID, err := getPodID(apps.PodA[0])
 			if err != nil {
-				ctx.Fatalf("Could not get Pod ID: %v", err)
+				t.Fatalf("Could not get Pod ID: %v", err)
 			}
 
 			var output string
@@ -361,7 +362,7 @@ func TestProxyStatus(t *testing.T) {
 			retry.UntilSuccessOrFail(t, func() error {
 				d := t.TempDir()
 				filename := filepath.Join(d, "ps-configdump.json")
-				cs := ctx.Clusters().Default()
+				cs := t.Clusters().Default()
 				dump, err := cs.EnvoyDo(context.TODO(), podID, apps.Namespace.Name(), "GET", "config_dump", nil)
 				g.Expect(err).ShouldNot(gomega.HaveOccurred())
 				err = ioutil.WriteFile(filename, dump, os.ModePerm)
@@ -378,19 +379,19 @@ func TestProxyStatus(t *testing.T) {
 func TestAuthZCheck(t *testing.T) {
 	framework.NewTest(t).Features("usability.observability.authz-check").
 		RequiresSingleCluster().
-		Run(func(ctx framework.TestContext) {
+		Run(func(t framework.TestContext) {
 			appPolicy := file.AsStringOrFail(t, "testdata/authz-a.yaml")
 			gwPolicy := file.AsStringOrFail(t, "testdata/authz-b.yaml")
-			ctx.Config().ApplyYAMLOrFail(ctx, apps.Namespace.Name(), appPolicy)
-			ctx.Config().ApplyYAMLOrFail(ctx, i.Settings().SystemNamespace, gwPolicy)
+			t.Config().ApplyYAMLOrFail(t, apps.Namespace.Name(), appPolicy)
+			t.Config().ApplyYAMLOrFail(t, i.Settings().SystemNamespace, gwPolicy)
 
-			gwPod, err := i.IngressFor(ctx.Clusters().Default()).PodID(0)
+			gwPod, err := i.IngressFor(t.Clusters().Default()).PodID(0)
 			if err != nil {
-				ctx.Fatalf("Could not get Pod ID: %v", err)
+				t.Fatalf("Could not get Pod ID: %v", err)
 			}
 			appPod, err := getPodID(apps.PodA[0])
 			if err != nil {
-				ctx.Fatalf("Could not get Pod ID: %v", err)
+				t.Fatalf("Could not get Pod ID: %v", err)
 			}
 
 			cases := []struct {
@@ -417,12 +418,12 @@ func TestAuthZCheck(t *testing.T) {
 				},
 			}
 
-			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{Cluster: ctx.Environment().Clusters()[0]})
+			istioCtl := istioctl.NewOrFail(t, t, istioctl.Config{Cluster: t.Environment().Clusters()[0]})
 			for _, c := range cases {
 				args := []string{"experimental", "authz", "check", c.pod}
-				ctx.NewSubTest(c.name).Run(func(ctx framework.TestContext) {
+				t.NewSubTest(c.name).Run(func(t framework.TestContext) {
 					// Verify the output matches the expected text, which is the policies loaded above.
-					retry.UntilSuccessOrFail(ctx, func() error {
+					retry.UntilSuccessOrFail(t, func() error {
 						output, _ := istioCtl.InvokeOrFail(t, args)
 						for _, want := range c.wants {
 							if !want.MatchString(output) {

--- a/tests/integration/pilot/locality_test.go
+++ b/tests/integration/pilot/locality_test.go
@@ -102,7 +102,7 @@ func TestLocality(t *testing.T) {
 		NewTest(t).
 		Features("traffic.locality").
 		RequiresSingleCluster().
-		Run(func(ctx framework.TestContext) {
+		Run(func(t framework.TestContext) {
 			cases := []struct {
 				name     string
 				input    LocalityInput
@@ -180,11 +180,11 @@ func TestLocality(t *testing.T) {
 				},
 			}
 			for _, tt := range cases {
-				ctx.NewSubTest(tt.name).Run(func(ctx framework.TestContext) {
+				t.NewSubTest(tt.name).Run(func(t framework.TestContext) {
 					hostname := fmt.Sprintf("%s-fake-locality.example.com", strings.ToLower(strings.ReplaceAll(tt.name, "/", "-")))
 					tt.input.Host = hostname
-					ctx.Config().ApplyYAMLOrFail(ctx, apps.Namespace.Name(), runTemplate(ctx, localityTemplate, tt.input))
-					sendTrafficOrFail(ctx, apps.PodA[0], hostname, tt.expected)
+					t.Config().ApplyYAMLOrFail(t, apps.Namespace.Name(), runTemplate(t, localityTemplate, tt.input))
+					sendTrafficOrFail(t, apps.PodA[0], hostname, tt.expected)
 				})
 			}
 		})
@@ -196,8 +196,8 @@ func expectAllTrafficTo(dest string) map[string]int {
 	return map[string]int{dest: sendCount}
 }
 
-func sendTrafficOrFail(ctx framework.TestContext, from echo.Instance, host string, expected map[string]int) {
-	ctx.Helper()
+func sendTrafficOrFail(t framework.TestContext, from echo.Instance, host string, expected map[string]int) {
+	t.Helper()
 	headers := http.Header{}
 	headers.Add("Host", host)
 	validator := echo.ValidatorFunc(func(resp client.ParsedResponses, inErr error) error {
@@ -225,7 +225,7 @@ func sendTrafficOrFail(ctx framework.TestContext, from echo.Instance, host strin
 	})
 	// This is a hack to remain infrastructure agnostic when running these tests
 	// We actually call the host set above not the endpoint we pass
-	_ = from.CallWithRetryOrFail(ctx, echo.CallOptions{
+	_ = from.CallWithRetryOrFail(t, echo.CallOptions{
 		Target:    from,
 		PortName:  "http",
 		Headers:   headers,

--- a/tests/integration/pilot/main_test.go
+++ b/tests/integration/pilot/main_test.go
@@ -37,8 +37,8 @@ var (
 	apps = &common.EchoDeployments{}
 )
 
-func supportsCRDv1(ctx resource.Context) bool {
-	for _, cluster := range ctx.Clusters() {
+func supportsCRDv1(t resource.Context) bool {
+	for _, cluster := range t.Clusters() {
 		if !cluster.MinKubeVersion(1, 16) {
 			return false
 		}
@@ -52,19 +52,19 @@ func supportsCRDv1(ctx resource.Context) bool {
 func TestMain(m *testing.M) {
 	framework.
 		NewSuite(m).
-		Setup(func(ctx resource.Context) (err error) {
-			if supportsCRDv1(ctx) {
+		Setup(func(t resource.Context) (err error) {
+			if supportsCRDv1(t) {
 				crd, err := ioutil.ReadFile("testdata/service-apis-crd.yaml")
 				if err != nil {
 					return err
 				}
-				return ctx.Config().ApplyYAMLNoCleanup("", string(crd))
+				return t.Config().ApplyYAMLNoCleanup("", string(crd))
 			}
 			return nil
 		}).
 		Setup(istio.Setup(&i, nil)).
-		Setup(func(ctx resource.Context) error {
-			return common.SetupApps(ctx, i, apps)
+		Setup(func(t resource.Context) error {
+			return common.SetupApps(t, i, apps)
 		}).
 		Run()
 }

--- a/tests/integration/pilot/mirror_test.go
+++ b/tests/integration/pilot/mirror_test.go
@@ -123,9 +123,9 @@ func runMirrorTest(t *testing.T, options mirrorTestOptions) {
 	framework.
 		NewTest(t).
 		Features("traffic.mirroring").
-		Run(func(ctx framework.TestContext) {
+		Run(func(t framework.TestContext) {
 			for _, c := range options.cases {
-				ctx.NewSubTest(c.name).Run(func(ctx framework.TestContext) {
+				t.NewSubTest(c.name).Run(func(t framework.TestContext) {
 					mirrorHost := options.mirrorHost
 					if len(mirrorHost) == 0 {
 						mirrorHost = common.PodCSvc
@@ -137,16 +137,16 @@ func runMirrorTest(t *testing.T, options mirrorTestOptions) {
 						mirrorHost,
 					}
 
-					deployment := tmpl.EvaluateOrFail(ctx,
-						file.AsStringOrFail(ctx, "testdata/traffic-mirroring-template.yaml"), vsc)
-					ctx.Config().ApplyYAMLOrFail(ctx, apps.Namespace.Name(), deployment)
+					deployment := tmpl.EvaluateOrFail(t,
+						file.AsStringOrFail(t, "testdata/traffic-mirroring-template.yaml"), vsc)
+					t.Config().ApplyYAMLOrFail(t, apps.Namespace.Name(), deployment)
 
 					for _, podA := range apps.PodA {
 						podA := podA
-						ctx.NewSubTest(fmt.Sprintf("from %s", podA.Config().Cluster.StableName())).Run(func(ctx framework.TestContext) {
+						t.NewSubTest(fmt.Sprintf("from %s", podA.Config().Cluster.StableName())).Run(func(t framework.TestContext) {
 							for _, proto := range mirrorProtocols {
-								ctx.NewSubTest(string(proto)).Run(func(ctx framework.TestContext) {
-									retry.UntilSuccessOrFail(ctx, func() error {
+								t.NewSubTest(string(proto)).Run(func(t framework.TestContext) {
+									retry.UntilSuccessOrFail(t, func() error {
 										testID := util.RandomString(16)
 										if err := sendTrafficMirror(podA, apps.PodB[0], proto, testID); err != nil {
 											return err

--- a/tests/integration/pilot/multi_version_revision_test.go
+++ b/tests/integration/pilot/multi_version_revision_test.go
@@ -52,33 +52,33 @@ func TestMultiVersionRevision(t *testing.T) {
 	framework.NewTest(t).
 		RequiresSingleCluster().
 		Features("installation.upgrade").
-		Run(func(ctx framework.TestContext) {
-			skipIfK8sVersionUnsupported(ctx)
+		Run(func(t framework.TestContext) {
+			skipIfK8sVersionUnsupported(t)
 
 			// keep these at the latest patch version of each minor version
 			installVersions := []string{NMinusOne, NMinusTwo, NMinusThree, NMinusFour}
 
 			// keep track of applied configurations and clean up after the test
 			configs := make(map[string]string)
-			ctx.ConditionalCleanup(func() {
+			t.ConditionalCleanup(func() {
 				for _, config := range configs {
-					ctx.Config().DeleteYAML("istio-system", config)
+					t.Config().DeleteYAML("istio-system", config)
 				}
 			})
 
 			revisionedNamespaces := []revisionedNamespace{}
 			for _, v := range installVersions {
-				installRevisionOrFail(ctx, v, configs)
+				installRevisionOrFail(t, v, configs)
 
 				// create a namespace pointed to the revisioned control plane we just installed
 				rev := strings.ReplaceAll(v, ".", "-")
-				ns, err := namespace.New(ctx, namespace.Config{
+				ns, err := namespace.New(t, namespace.Config{
 					Prefix:   fmt.Sprintf("revision-%s", rev),
 					Inject:   true,
 					Revision: rev,
 				})
 				if err != nil {
-					ctx.Fatalf("failed to created revisioned namespace: %v", err)
+					t.Fatalf("failed to created revisioned namespace: %v", err)
 				}
 				revisionedNamespaces = append(revisionedNamespaces, revisionedNamespace{
 					revision:  rev,
@@ -88,7 +88,7 @@ func TestMultiVersionRevision(t *testing.T) {
 
 			// create an echo instance in each revisioned namespace, all these echo
 			// instances will be injected with proxies from their respective versions
-			builder := echoboot.NewBuilder(ctx)
+			builder := echoboot.NewBuilder(t)
 
 			for _, ns := range revisionedNamespaces {
 				builder = builder.WithConfig(echo.Config{
@@ -113,17 +113,17 @@ func TestMultiVersionRevision(t *testing.T) {
 					},
 				})
 			}
-			instances := builder.BuildOrFail(ctx)
+			instances := builder.BuildOrFail(t)
 			// add an existing pod from apps to the rotation to avoid an extra deployment
 			instances = append(instances, apps.PodA[0])
 
-			testAllEchoCalls(ctx, instances)
+			testAllEchoCalls(t, instances)
 		})
 }
 
 // testAllEchoCalls takes list of revisioned namespaces and generates list of echo calls covering
 // communication between every pair of namespaces
-func testAllEchoCalls(ctx framework.TestContext, echoInstances []echo.Instance) {
+func testAllEchoCalls(t framework.TestContext, echoInstances []echo.Instance) {
 	trafficTypes := []string{"http", "tcp", "grpc"}
 	for _, source := range echoInstances {
 		for _, dest := range echoInstances {
@@ -131,9 +131,9 @@ func testAllEchoCalls(ctx framework.TestContext, echoInstances []echo.Instance) 
 				continue
 			}
 			for _, trafficType := range trafficTypes {
-				ctx.NewSubTest(fmt.Sprintf("%s-%s->%s", trafficType, source.Config().Service, dest.Config().Service)).
-					Run(func(ctx framework.TestContext) {
-						retry.UntilSuccessOrFail(ctx, func() error {
+				t.NewSubTest(fmt.Sprintf("%s-%s->%s", trafficType, source.Config().Service, dest.Config().Service)).
+					Run(func(t framework.TestContext) {
+						retry.UntilSuccessOrFail(t, func() error {
 							resp, err := source.Call(echo.CallOptions{
 								Target:   dest,
 								PortName: trafficType,
@@ -151,14 +151,14 @@ func testAllEchoCalls(ctx framework.TestContext, echoInstances []echo.Instance) 
 
 // installRevisionOrFail takes an Istio version and installs a revisioned control plane running that version
 // provided istio version must be present in tests/integration/pilot/testdata/upgrade for the installation to succeed
-func installRevisionOrFail(ctx framework.TestContext, version string, configs map[string]string) {
+func installRevisionOrFail(t framework.TestContext, version string, configs map[string]string) {
 	config, err := ReadInstallFile(fmt.Sprintf("%s-install.yaml", version))
 	if err != nil {
-		ctx.Fatalf("could not read installation config: %v", err)
+		t.Fatalf("could not read installation config: %v", err)
 	}
 	configs[version] = config
-	if err := ctx.Config().ApplyYAMLNoCleanup(i.Settings().SystemNamespace, config); err != nil {
-		ctx.Fatal(err)
+	if err := t.Config().ApplyYAMLNoCleanup(i.Settings().SystemNamespace, config); err != nil {
+		t.Fatal(err)
 	}
 }
 
@@ -191,8 +191,8 @@ func ReadInstallFile(f string) (string, error) {
 
 // skipIfK8sVersionUnsupported skips the test if we're running on a k8s version that is not expected to work
 // with any of the revision versions included in the test (i.e. istio 1.7 not supported on k8s 1.15)
-func skipIfK8sVersionUnsupported(ctx framework.TestContext) {
-	if !ctx.Clusters().Default().MinKubeVersion(1, 16) {
-		ctx.Skipf("k8s version not supported for %s (<%s)", ctx.Name(), "1.16")
+func skipIfK8sVersionUnsupported(t framework.TestContext) {
+	if !t.Clusters().Default().MinKubeVersion(1, 16) {
+		t.Skipf("k8s version not supported for %s (<%s)", t.Name(), "1.16")
 	}
 }

--- a/tests/integration/pilot/original_src_addr_test.go
+++ b/tests/integration/pilot/original_src_addr_test.go
@@ -29,23 +29,23 @@ func TestTproxy(t *testing.T) {
 		NewTest(t).
 		Features("traffic.original-source-ip").
 		RequiresSingleCluster().
-		Run(func(ctx framework.TestContext) {
+		Run(func(t framework.TestContext) {
 			workloads, err := apps.PodA[0].Workloads()
 			if err != nil {
 				t.Errorf("failed to get Subsets: %v", err)
 				return
 			}
 			// check the server can see the client's original ip
-			checkOriginalSrcIP(ctx, apps.PodA[0], apps.PodTproxy[0], workloads[0].Address())
+			checkOriginalSrcIP(t, apps.PodA[0], apps.PodTproxy[0], workloads[0].Address())
 		})
 }
 
-func checkOriginalSrcIP(ctx framework.TestContext, src, dest echo.Instance, expected string) {
-	ctx.Helper()
+func checkOriginalSrcIP(t framework.TestContext, src, dest echo.Instance, expected string) {
+	t.Helper()
 	validator := echo.ValidatorFunc(func(resp client.ParsedResponses, inErr error) error {
 		return resp.CheckIP(expected)
 	})
-	_ = src.CallWithRetryOrFail(ctx, echo.CallOptions{
+	_ = src.CallWithRetryOrFail(t, echo.CallOptions{
 		Target:    dest,
 		PortName:  "http",
 		Scheme:    scheme.HTTP,

--- a/tests/integration/pilot/revisioncmd/revision_view_test.go
+++ b/tests/integration/pilot/revisioncmd/revision_view_test.go
@@ -72,20 +72,20 @@ func TestRevisionCommand(t *testing.T) {
 		NewTest(t).
 		RequiresSingleCluster().
 		Features("installation.istioctl.revision_centric_view").
-		Run(func(ctx framework.TestContext) {
-			skipIfUnsupportedKubernetesVersion(ctx)
-			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{})
+		Run(func(t framework.TestContext) {
+			skipIfUnsupportedKubernetesVersion(t)
+			istioCtl := istioctl.NewOrFail(t, t, istioctl.Config{})
 
 			revisions := []string{"stable", "canary"}
 			revResourceMap := map[string]*revisionResource{}
-			builder := echoboot.NewBuilder(ctx)
+			builder := echoboot.NewBuilder(t)
 			for _, rev := range revisions {
 				effectiveRev := rev
 				if rev == "default" {
 					effectiveRev = ""
 				}
 				revResourceMap[rev] = &revisionResource{
-					ns: namespace.NewOrFail(t, ctx, namespace.Config{
+					ns: namespace.NewOrFail(t, t, namespace.Config{
 						Prefix:   fmt.Sprintf("istioctl-rev-%s", rev),
 						Inject:   true,
 						Revision: effectiveRev,
@@ -94,7 +94,7 @@ func TestRevisionCommand(t *testing.T) {
 				builder.With(&revResourceMap[rev].echo,
 					echo.Config{Namespace: revResourceMap[rev].ns})
 			}
-			builder.BuildOrFail(ctx)
+			builder.BuildOrFail(t)
 
 			// Wait some time for things to settle down. This is very
 			// important for gateway pod related tests.
@@ -126,22 +126,22 @@ func TestRevisionCommand(t *testing.T) {
 				},
 			}
 			for _, testCase := range testCases {
-				ctx.NewSubTest(testCase.name).Run(func(sctx framework.TestContext) {
-					testCase.testFunc(sctx, istioCtl, revResourceMap)
+				t.NewSubTest(testCase.name).Run(func(st framework.TestContext) {
+					testCase.testFunc(st, istioCtl, revResourceMap)
 				})
 			}
 		})
 }
 
-func testRevisionListingVerbose(ctx framework.TestContext, istioCtl istioctl.Instance, _ map[string]*revisionResource) {
+func testRevisionListingVerbose(t framework.TestContext, istioCtl istioctl.Instance, _ map[string]*revisionResource) {
 	listVerboseCmd := []string{"x", "revision", "list", "-d", manifestPath, "-v", "-o", "json"}
 	stdout, _, err := istioCtl.Invoke(listVerboseCmd)
 	if err != nil {
-		ctx.Fatalf("unexpected error while invoking istioctl command %v: %v", listVerboseCmd, err)
+		t.Fatalf("unexpected error while invoking istioctl command %v: %v", listVerboseCmd, err)
 	}
 	var revDescriptions map[string]*cmd.RevisionDescription
 	if err = json.Unmarshal([]byte(stdout), &revDescriptions); err != nil {
-		ctx.Fatalf("error while unmarshaling JSON output: %v", err)
+		t.Fatalf("error while unmarshaling JSON output: %v", err)
 	}
 
 	expectedRevisionSet := map[string]bool{"stable": true, "canary": true}
@@ -150,27 +150,27 @@ func testRevisionListingVerbose(ctx framework.TestContext, istioCtl istioctl.Ins
 		actualRevisionSet[rev] = true
 	}
 	if !subsetOf(expectedRevisionSet, actualRevisionSet) {
-		ctx.Fatalf("Some expected revisions are missing from actual. "+
+		t.Fatalf("Some expected revisions are missing from actual. "+
 			"Expected should be subset of actual. Expected: %v, Actual: %v",
 			expectedRevisionSet, actualRevisionSet)
 	}
 
 	for rev, descr := range revDescriptions {
 		if !expectedRevisionSet[rev] {
-			ctx.Logf("revision %s is unexpected. Might be a leftover from some other test. skipping...", rev)
+			t.Logf("revision %s is unexpected. Might be a leftover from some other test. skipping...", rev)
 			continue
 		}
-		verifyRevisionOutput(ctx, descr, rev)
+		verifyRevisionOutput(t, descr, rev)
 	}
 }
 
-func testRevisionDescription(ctx framework.TestContext, istioCtl istioctl.Instance, revResources map[string]*revisionResource) {
+func testRevisionDescription(t framework.TestContext, istioCtl istioctl.Instance, revResources map[string]*revisionResource) {
 	for _, rev := range []string{"stable", "canary"} {
 		descr, err := getDescriptionForRevision(istioCtl, rev)
 		if err != nil || descr == nil {
-			ctx.Fatalf("failed to retrieve description for %s: %v", descr, err)
+			t.Fatalf("failed to retrieve description for %s: %v", descr, err)
 		}
-		verifyRevisionOutput(ctx, descr, rev)
+		verifyRevisionOutput(t, descr, rev)
 		if resources := revResources[rev]; resources != nil {
 			nsName := resources.ns.Name()
 			podsInNamespace := []*cmd.PodFilteredInfo{}
@@ -181,14 +181,14 @@ func testRevisionDescription(ctx framework.TestContext, istioCtl istioctl.Instan
 				MatchLabels: map[string]string{label.IoIstioRev.Name: rev},
 			})
 			if err != nil {
-				ctx.Fatalf("error while creating label selector for pods in namespace: %s, revision: %s",
+				t.Fatalf("error while creating label selector for pods in namespace: %s, revision: %s",
 					nsName, rev)
 			}
-			podsForRev, err := ctx.Clusters().Default().
+			podsForRev, err := t.Clusters().Default().
 				CoreV1().Pods(nsName).
 				List(context.Background(), meta_v1.ListOptions{LabelSelector: labelSelector.String()})
 			if podsForRev == nil || err != nil {
-				ctx.Fatalf("error while getting pods for revision: %s from namespace: %s: %v", rev, nsName, err)
+				t.Fatalf("error while getting pods for revision: %s from namespace: %s: %v", rev, nsName, err)
 			}
 			expectedPodsForRev := map[string]bool{}
 			actualPodsForRev := map[string]bool{}
@@ -200,42 +200,42 @@ func testRevisionDescription(ctx framework.TestContext, istioCtl istioctl.Instan
 				actualPodsForRev[fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)] = true
 			}
 			if !setsMatch(expectedPodsForRev, actualPodsForRev) {
-				ctx.Fatalf("list of pods pointing to %s don't match in namespace %s. Expected: %v, Actual: %v",
+				t.Fatalf("list of pods pointing to %s don't match in namespace %s. Expected: %v, Actual: %v",
 					rev, nsName, expectedPodsForRev, actualPodsForRev)
 			}
 		}
 	}
 }
 
-func testNonExistentRevisionDescription(ctx framework.TestContext, istioCtl istioctl.Instance, _ map[string]*revisionResource) {
+func testNonExistentRevisionDescription(t framework.TestContext, istioCtl istioctl.Instance, _ map[string]*revisionResource) {
 	describeArgs := []string{"x", "revision", "describe", "ghost", "-o", "json", "-v"}
 	_, _, err := istioCtl.Invoke(describeArgs)
 	if err == nil {
-		ctx.Fatalf("expected error for non-existent revision 'ghost', but didn't get it")
+		t.Fatalf("expected error for non-existent revision 'ghost', but didn't get it")
 	}
 }
 
-func testInvalidRevisionFormat(ctx framework.TestContext, istioCtl istioctl.Instance, _ map[string]*revisionResource) {
+func testInvalidRevisionFormat(t framework.TestContext, istioCtl istioctl.Instance, _ map[string]*revisionResource) {
 	describeArgs := []string{"x", "revision", "describe", "$%#@abc", "-o", "json", "-v"}
 	_, _, err := istioCtl.Invoke(describeArgs)
 	if err == nil || !strings.Contains(err.Error(), "invalid revision format") {
-		ctx.Fatalf("expected error message saying revision format is invalid, but got %v", err)
+		t.Fatalf("expected error message saying revision format is invalid, but got %v", err)
 	}
 }
 
-func testInvalidOutputFormat(ctx framework.TestContext, istioCtl istioctl.Instance, _ map[string]*revisionResource) {
+func testInvalidOutputFormat(t framework.TestContext, istioCtl istioctl.Instance, _ map[string]*revisionResource) {
 	type invalidFormatTest struct {
 		name    string
 		command []string
 	}
-	for _, t := range []invalidFormatTest{
+	for _, tt := range []invalidFormatTest{
 		{name: "list", command: []string{"x", "revision", "list", "-o", "mystery"}},
 		{name: "describe", command: []string{"x", "revision", "describe", "canary", "-o", "mystery"}},
 	} {
-		ctx.NewSubTest(t.name).Run(func(sctx framework.TestContext) {
-			_, _, fErr := istioCtl.Invoke(t.command)
+		t.NewSubTest(tt.name).Run(func(st framework.TestContext) {
+			_, _, fErr := istioCtl.Invoke(tt.command)
 			if fErr == nil {
-				ctx.Fatalf("expected error due to invalid format, but got nil")
+				t.Fatalf("expected error due to invalid format, but got nil")
 			}
 		})
 	}
@@ -255,7 +255,7 @@ func getDescriptionForRevision(istioCtl istioctl.Instance, revision string) (*cm
 	return &revDescription, nil
 }
 
-func verifyRevisionOutput(ctx framework.TestContext, descr *cmd.RevisionDescription, rev string) {
+func verifyRevisionOutput(t framework.TestContext, descr *cmd.RevisionDescription, rev string) {
 	expectedTagSet := map[string]bool{}
 	actualTagSet := map[string]bool{}
 	for _, mwh := range descr.Webhooks {
@@ -264,11 +264,11 @@ func verifyRevisionOutput(ctx framework.TestContext, descr *cmd.RevisionDescript
 		}
 	}
 	if !setsMatch(expectedTagSet, actualTagSet) {
-		ctx.Fatalf("tag sets don't match for %s. Expected: %v, Actual:%v", rev, expectedTagSet, actualTagSet)
+		t.Fatalf("tag sets don't match for %s. Expected: %v, Actual:%v", rev, expectedTagSet, actualTagSet)
 	}
 	expectedComponents, ok := expectedComponentsPerRevision[rev]
 	if !ok {
-		ctx.Fatalf("unexpected error. Could not find expected components for %s", rev)
+		t.Fatalf("unexpected error. Could not find expected components for %s", rev)
 	}
 	actualComponents := map[string]bool{}
 	for _, iop := range descr.IstioOperatorCRs {
@@ -277,18 +277,18 @@ func verifyRevisionOutput(ctx framework.TestContext, descr *cmd.RevisionDescript
 		}
 	}
 	if !setsMatch(expectedComponents, actualComponents) {
-		ctx.Fatalf("required component sets don't match for revision %s. Expected: %v, Actual: %v",
+		t.Fatalf("required component sets don't match for revision %s. Expected: %v, Actual: %v",
 			rev, expectedComponents, actualComponents)
 	}
-	verifyComponentPodsForRevision(ctx, "istiod", rev, descr)
-	verifyComponentPodsForRevision(ctx, "ingress-gateway", rev, descr)
-	verifyComponentPodsForRevision(ctx, "egress-gateway", rev, descr)
+	verifyComponentPodsForRevision(t, "istiod", rev, descr)
+	verifyComponentPodsForRevision(t, "ingress-gateway", rev, descr)
+	verifyComponentPodsForRevision(t, "egress-gateway", rev, descr)
 }
 
-func verifyComponentPodsForRevision(ctx framework.TestContext, component, rev string, descr *cmd.RevisionDescription) {
+func verifyComponentPodsForRevision(t framework.TestContext, component, rev string, descr *cmd.RevisionDescription) {
 	opComponent := componentMap[component]
 	if opComponent == "" {
-		ctx.Fatalf("unknown component: %s", component)
+		t.Fatalf("unknown component: %s", component)
 	}
 	labelSelector, err := meta_v1.LabelSelectorAsSelector(&meta_v1.LabelSelector{
 		MatchLabels: map[string]string{
@@ -297,13 +297,13 @@ func verifyComponentPodsForRevision(ctx framework.TestContext, component, rev st
 		},
 	})
 	if err != nil {
-		ctx.Fatalf("unexpected error: failed to create label selector: %v", err)
+		t.Fatalf("unexpected error: failed to create label selector: %v", err)
 	}
-	componentPods, err := ctx.Clusters().Default().
+	componentPods, err := t.Clusters().Default().
 		CoreV1().Pods("").
 		List(context.Background(), meta_v1.ListOptions{LabelSelector: labelSelector.String()})
 	if err != nil {
-		ctx.Fatalf("unexpected error while fetching %s pods for revision %s: %v", component, rev, err)
+		t.Fatalf("unexpected error while fetching %s pods for revision %s: %v", component, rev, err)
 	}
 	expectedComponentPodSet := map[string]bool{}
 	for _, pod := range componentPods.Items {
@@ -327,7 +327,7 @@ func verifyComponentPodsForRevision(ctx framework.TestContext, component, rev st
 	}
 
 	if !setsMatch(expectedComponentPodSet, actualComponentPodSet) {
-		ctx.Fatalf("%s pods are not listed properly. Expected: %v, Actual: %v",
+		t.Fatalf("%s pods are not listed properly. Expected: %v, Actual: %v",
 			component, expectedComponentPodSet, actualComponentPodSet)
 	}
 }
@@ -361,8 +361,8 @@ func subsetOf(a map[string]bool, b map[string]bool) bool {
 //
 // K8s 1.15 - https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#mutatingwebhookconfiguration-v1beta1-admissionregistration-k8s-io
 // K8s 1.16 - https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#mutatingwebhookconfiguration-v1-admissionregistration-k8s-io
-func skipIfUnsupportedKubernetesVersion(ctx framework.TestContext) {
-	if !ctx.Clusters().Default().MinKubeVersion(1, 16) {
-		ctx.Skipf("k8s version not supported for %s (<%s)", ctx.Name(), "1.16")
+func skipIfUnsupportedKubernetesVersion(t framework.TestContext) {
+	if !t.Clusters().Default().MinKubeVersion(1, 16) {
+		t.Skipf("k8s version not supported for %s (<%s)", t.Name(), "1.16")
 	}
 }

--- a/tests/integration/pilot/revisions/revision_tag_test.go
+++ b/tests/integration/pilot/revisions/revision_tag_test.go
@@ -35,7 +35,7 @@ func TestRevisionTags(t *testing.T) {
 	framework.NewTest(t).
 		Features("installation.istioctl.revision_tags").
 		RequiresSingleCluster().
-		Run(func(ctx framework.TestContext) {
+		Run(func(t framework.TestContext) {
 			tcs := []struct {
 				name     string
 				tag      string
@@ -62,52 +62,52 @@ func TestRevisionTags(t *testing.T) {
 				},
 			}
 
-			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{Cluster: ctx.Clusters().Default()})
+			istioCtl := istioctl.NewOrFail(t, t, istioctl.Config{Cluster: t.Clusters().Default()})
 			baseArgs := []string{"experimental", "tag"}
 			for _, tc := range tcs {
-				ctx.NewSubTest(tc.name).Run(func(ctx framework.TestContext) {
+				t.NewSubTest(tc.name).Run(func(t framework.TestContext) {
 					tagSetArgs := append(baseArgs, "set", tc.tag, "--revision", tc.revision)
 					tagSetArgs = append(tagSetArgs, "--manifests", filepath.Join(env.IstioSrc, "manifests"))
 					tagRemoveArgs := append(baseArgs, "remove", tc.tag, "-y")
 
 					_, cmdErr, _ := istioCtl.Invoke(tagSetArgs)
-					ctx.Cleanup(func() {
+					t.Cleanup(func() {
 						_, _, _ = istioCtl.Invoke(tagRemoveArgs)
 					})
 
 					if tc.error == "" && cmdErr != "" {
-						ctx.Fatalf("did not expect error, got %q", cmdErr)
+						t.Fatalf("did not expect error, got %q", cmdErr)
 					}
 					if tc.error != "" {
 						if !strings.Contains(cmdErr, tc.error) {
-							ctx.Fatalf("expected error to contain %q, got %q", tc.error, cmdErr)
+							t.Fatalf("expected error to contain %q, got %q", tc.error, cmdErr)
 						}
 						// found correct error, don't proceed
 						return
 					}
 
 					// build namespace labeled with tag and create echo in that namespace
-					revTagNs := namespace.NewOrFail(t, ctx, namespace.Config{
+					revTagNs := namespace.NewOrFail(t, t, namespace.Config{
 						Prefix:   "rev-tag",
 						Inject:   true,
 						Revision: tc.tag,
 					})
-					echoboot.NewBuilder(ctx).WithConfig(echo.Config{
+					echoboot.NewBuilder(t).WithConfig(echo.Config{
 						Service:   "rev-tag",
 						Namespace: revTagNs,
-					}).BuildOrFail(ctx)
+					}).BuildOrFail(t)
 
-					fetch := kubetest.NewSinglePodFetch(ctx.Clusters().Default(),
+					fetch := kubetest.NewSinglePodFetch(t.Clusters().Default(),
 						revTagNs.Name(),
 						fmt.Sprintf("app=%s", "rev-tag"))
 					pods, err := fetch()
 					if err != nil {
-						ctx.Fatalf("error fetching pods: %v", err)
+						t.Fatalf("error fetching pods: %v", err)
 					}
 
 					injectedRevision := pods[0].GetLabels()[label.IoIstioRev.Name]
 					if injectedRevision != tc.revision {
-						ctx.Fatalf("expected revision tag %q, got %q", tc.revision, injectedRevision)
+						t.Fatalf("expected revision tag %q, got %q", tc.revision, injectedRevision)
 					}
 				})
 			}

--- a/tests/integration/pilot/revisions/revisions_test.go
+++ b/tests/integration/pilot/revisions/revisions_test.go
@@ -57,20 +57,20 @@ components:
 // belong to different control planes.
 func TestMultiRevision(t *testing.T) {
 	framework.NewTest(t).
-		Run(func(ctx framework.TestContext) {
-			stable := namespace.NewOrFail(t, ctx, namespace.Config{
+		Run(func(t framework.TestContext) {
+			stable := namespace.NewOrFail(t, t, namespace.Config{
 				Prefix:   "stable",
 				Inject:   true,
 				Revision: "stable",
 			})
-			canary := namespace.NewOrFail(t, ctx, namespace.Config{
+			canary := namespace.NewOrFail(t, t, namespace.Config{
 				Prefix:   "canary",
 				Inject:   true,
 				Revision: "canary",
 			})
 
 			var client, server echo.Instance
-			echoboot.NewBuilder(ctx).
+			echoboot.NewBuilder(t).
 				With(&client, echo.Config{
 					Service:   "client",
 					Namespace: stable,

--- a/tests/integration/pilot/revisions/uninstall_test.go
+++ b/tests/integration/pilot/revisions/uninstall_test.go
@@ -32,6 +32,7 @@ import (
 	"istio.io/istio/operator/pkg/manifest"
 	"istio.io/istio/operator/pkg/name"
 	"istio.io/istio/operator/pkg/object"
+	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/cluster"
@@ -50,9 +51,9 @@ func TestUninstallByRevision(t *testing.T) {
 	framework.
 		NewTest(t).
 		Features("installation.istioctl.uninstall_revision").
-		Run(func(ctx framework.TestContext) {
-			ctx.NewSubTest("uninstall_revision").Run(func(ctx framework.TestContext) {
-				istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{})
+		Run(func(t framework.TestContext) {
+			t.NewSubTest("uninstall_revision").Run(func(t framework.TestContext) {
+				istioCtl := istioctl.NewOrFail(t, t, istioctl.Config{})
 				uninstallCmd := []string{
 					"x", "uninstall",
 					"--revision=" + stableRevision, "--skip-confirmation",
@@ -61,7 +62,7 @@ func TestUninstallByRevision(t *testing.T) {
 				if err != nil {
 					scopes.Framework.Errorf("failed to uninstall: %v, output: %v", err, out)
 				}
-				cs := ctx.Clusters().Default()
+				cs := t.Clusters().Default()
 				ls := fmt.Sprintf("istio.io/rev=%s", stableRevision)
 				checkCPResourcesUninstalled(t, cs, append(helmreconciler.NamespacedResources, helmreconciler.ClusterCPResources...), ls)
 			})
@@ -72,9 +73,9 @@ func TestUninstallWithSetFlag(t *testing.T) {
 	framework.
 		NewTest(t).
 		Features("installation.istioctl.uninstall_revision").
-		Run(func(ctx framework.TestContext) {
-			ctx.NewSubTest("uninstall_revision").Run(func(ctx framework.TestContext) {
-				istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{})
+		Run(func(t framework.TestContext) {
+			t.NewSubTest("uninstall_revision").Run(func(t framework.TestContext) {
+				istioCtl := istioctl.NewOrFail(t, t, istioctl.Config{})
 				uninstallCmd := []string{
 					"x", "uninstall", "--set",
 					"revision=" + stableRevision, "--skip-confirmation",
@@ -83,7 +84,7 @@ func TestUninstallWithSetFlag(t *testing.T) {
 				if err != nil {
 					scopes.Framework.Errorf("failed to uninstall: %v, output: %v", err, out)
 				}
-				cs := ctx.Clusters().Default()
+				cs := t.Clusters().Default()
 				ls := fmt.Sprintf("istio.io/rev=%s", stableRevision)
 				checkCPResourcesUninstalled(t, cs, append(helmreconciler.NamespacedResources, helmreconciler.ClusterCPResources...), ls)
 			})
@@ -94,12 +95,12 @@ func TestUninstallByManifest(t *testing.T) {
 	framework.
 		NewTest(t).
 		Features("installation.istioctl.uninstall_manifest").
-		Run(func(ctx framework.TestContext) {
-			workDir, err := ctx.CreateTmpDirectory("uninstall-test")
+		Run(func(t framework.TestContext) {
+			workDir, err := t.CreateTmpDirectory("uninstall-test")
 			if err != nil {
 				t.Fatal("failed to create test directory")
 			}
-			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{})
+			istioCtl := istioctl.NewOrFail(t, t, istioctl.Config{})
 			iopFile := filepath.Join(workDir, "iop.yaml")
 			iopYAML := `
 apiVersion: install.istio.io/v1alpha1
@@ -117,7 +118,7 @@ spec:
 				"--filename=" + iopFile, "--skip-confirmation",
 			}
 			istioCtl.InvokeOrFail(t, uninstallCmd)
-			cs := ctx.Clusters().Default()
+			cs := t.Clusters().Default()
 			retry.UntilSuccessOrFail(t, func() error {
 				manifestMap, _, err := manifest.GenManifests([]string{iopFile}, []string{}, true, nil, nil)
 				if err != nil {
@@ -146,21 +147,21 @@ func TestUninstallPurge(t *testing.T) {
 	framework.
 		NewTest(t).
 		Features("installation.istioctl.uninstall_purge").
-		Run(func(ctx framework.TestContext) {
-			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{})
+		Run(func(t framework.TestContext) {
+			istioCtl := istioctl.NewOrFail(t, t, istioctl.Config{})
 			uninstallCmd := []string{
 				"x", "uninstall",
 				"--purge", "--skip-confirmation",
 			}
 			istioCtl.InvokeOrFail(t, uninstallCmd)
-			cs := ctx.Clusters().Default()
+			cs := t.Clusters().Default()
 			checkCPResourcesUninstalled(t, cs, append(helmreconciler.NamespacedResources, helmreconciler.AllClusterResources...),
 				helmreconciler.IstioComponentLabelStr)
 		})
 }
 
 // checkCPResourcesUninstalled is a helper function to check list of gvk resources matched with label are uninstalled
-func checkCPResourcesUninstalled(t *testing.T, cs cluster.Cluster, gvkResources []schema.GroupVersionKind, label string) {
+func checkCPResourcesUninstalled(t test.Failer, cs cluster.Cluster, gvkResources []schema.GroupVersionKind, label string) {
 	retry.UntilSuccessOrFail(t, func() error {
 		for _, gvk := range gvkResources {
 			resources := strings.ToLower(gvk.Kind) + "s"

--- a/tests/integration/pilot/routing_test.go
+++ b/tests/integration/pilot/routing_test.go
@@ -26,7 +26,7 @@ func TestTraffic(t *testing.T) {
 	framework.
 		NewTest(t).
 		Features("traffic.routing", "traffic.reachability", "traffic.shifting").
-		Run(func(ctx framework.TestContext) {
-			common.RunAllTrafficTests(ctx, apps)
+		Run(func(t framework.TestContext) {
+			common.RunAllTrafficTests(t, apps)
 		})
 }

--- a/tests/integration/pilot/validation_test.go
+++ b/tests/integration/pilot/validation_test.go
@@ -68,8 +68,8 @@ func TestValidation(t *testing.T) {
 	framework.NewTest(t).
 		// Limit to Kube environment as we're testing integration of webhook with K8s.
 
-		RunParallel(func(ctx framework.TestContext) {
-			dataset := loadTestData(ctx)
+		RunParallel(func(t framework.TestContext) {
+			dataset := loadTestData(t)
 
 			denied := func(err error) bool {
 				if err == nil {
@@ -84,52 +84,52 @@ func TestValidation(t *testing.T) {
 					strings.Contains(err.Error(), "is invalid")
 			}
 
-			for _, cluster := range ctx.Clusters().Primaries() {
+			for _, cluster := range t.Clusters().Primaries() {
 				for i := range dataset {
 					d := dataset[i]
-					ctx.NewSubTest(string(d)).RunParallel(func(ctx framework.TestContext) {
+					t.NewSubTest(string(d)).RunParallel(func(t framework.TestContext) {
 						if d.isSkipped() {
-							ctx.SkipNow()
+							t.SkipNow()
 							return
 						}
 
 						ym, err := d.load()
 						if err != nil {
-							ctx.Fatalf("Unable to load test data: %v", err)
+							t.Fatalf("Unable to load test data: %v", err)
 						}
 
-						ns := namespace.NewOrFail(t, ctx, namespace.Config{
+						ns := namespace.NewOrFail(t, t, namespace.Config{
 							Prefix: "validation",
 						})
 
-						applyFiles := ctx.WriteYAMLOrFail(ctx, "apply", ym)
+						applyFiles := t.WriteYAMLOrFail(t, "apply", ym)
 						dryRunErr := cluster.ApplyYAMLFilesDryRun(ns.Name(), applyFiles...)
 
 						switch {
 						case dryRunErr != nil && d.isValid():
 							if denied(dryRunErr) {
-								ctx.Fatalf("got unexpected for valid config: %v", dryRunErr)
+								t.Fatalf("got unexpected for valid config: %v", dryRunErr)
 							} else {
-								ctx.Fatalf("got unexpected unknown error for valid config: %v", dryRunErr)
+								t.Fatalf("got unexpected unknown error for valid config: %v", dryRunErr)
 							}
 						case dryRunErr == nil && !d.isValid():
-							ctx.Fatalf("got unexpected success for invalid config")
+							t.Fatalf("got unexpected success for invalid config")
 						case dryRunErr != nil && !d.isValid():
 							if !denied(dryRunErr) {
-								ctx.Fatalf("config request denied for wrong reason: %v", dryRunErr)
+								t.Fatalf("config request denied for wrong reason: %v", dryRunErr)
 							}
 						}
 
 						wetRunErr := cluster.ApplyYAMLFiles(ns.Name(), applyFiles...)
-						ctx.ConditionalCleanup(func() {
+						t.ConditionalCleanup(func() {
 							cluster.DeleteYAMLFiles(ns.Name(), applyFiles...)
 						})
 
 						if dryRunErr != nil && wetRunErr == nil {
-							ctx.Fatalf("dry run returned error, but wet run returned none: %v", dryRunErr)
+							t.Fatalf("dry run returned error, but wet run returned none: %v", dryRunErr)
 						}
 						if dryRunErr == nil && wetRunErr != nil {
-							ctx.Fatalf("wet run returned errors, but dry run returned none: %v", wetRunErr)
+							t.Fatalf("wet run returned errors, but dry run returned none: %v", wetRunErr)
 						}
 					})
 				}
@@ -157,7 +157,7 @@ func TestEnsureNoMissingCRDs(t *testing.T) {
 	// that you need to update validation tests by either adding new/missing test cases, or removing test cases for
 	// types that are no longer supported.
 	framework.NewTest(t).
-		Run(func(ctx framework.TestContext) {
+		Run(func(t framework.TestContext) {
 			ignored := make(map[string]struct{})
 			for _, ig := range ignoredCRDs {
 				ignored[ig] = struct{}{}
@@ -193,21 +193,21 @@ func TestEnsureNoMissingCRDs(t *testing.T) {
 
 			testedValid := make(map[string]struct{})
 			testedInvalid := make(map[string]struct{})
-			for _, te := range loadTestData(ctx) {
+			for _, te := range loadTestData(t) {
 				yamlBatch, err := te.load()
 				yamlParts := yml.SplitString(yamlBatch)
 				for _, yamlPart := range yamlParts {
 					if err != nil {
-						ctx.Fatalf("error loading test data: %v", err)
+						t.Fatalf("error loading test data: %v", err)
 					}
 
 					m := make(map[string]interface{})
 					by, er := yaml.YAMLToJSON([]byte(yamlPart))
 					if er != nil {
-						ctx.Fatalf("error loading test data: %v", er)
+						t.Fatalf("error loading test data: %v", er)
 					}
 					if err = json.Unmarshal(by, &m); err != nil {
-						ctx.Fatalf("error parsing JSON: %v", err)
+						t.Fatalf("error parsing JSON: %v", err)
 					}
 
 					apiVersion := m["apiVersion"].(string)
@@ -228,21 +228,21 @@ func TestEnsureNoMissingCRDs(t *testing.T) {
 				}
 
 				if _, found := testedValid[rec]; !found {
-					ctx.Errorf("CRD does not have a positive validation test: %v", rec)
+					t.Errorf("CRD does not have a positive validation test: %v", rec)
 				}
 				if _, found := testedInvalid[rec]; !found {
-					ctx.Errorf("CRD does not have a negative validation test: %v", rec)
+					t.Errorf("CRD does not have a negative validation test: %v", rec)
 				}
 			}
 
 			for tst := range testedValid {
 				if _, found := recognized[tst]; !found {
-					ctx.Errorf("Unrecognized positive validation test data found: %v", tst)
+					t.Errorf("Unrecognized positive validation test data found: %v", tst)
 				}
 			}
 			for tst := range testedInvalid {
 				if _, found := recognized[tst]; !found {
-					ctx.Errorf("Unrecognized negative validation test data found: %v", tst)
+					t.Errorf("Unrecognized negative validation test data found: %v", tst)
 				}
 			}
 		})

--- a/tests/integration/pilot/vm_test.go
+++ b/tests/integration/pilot/vm_test.go
@@ -50,11 +50,11 @@ func TestVmOSPost(t *testing.T) {
 		NewTest(t).
 		Features("traffic.reachability").
 		Label(label.Postsubmit).
-		Run(func(ctx framework.TestContext) {
-			if ctx.Settings().SkipVM {
-				ctx.Skip("VM tests are disabled")
+		Run(func(t framework.TestContext) {
+			if t.Settings().SkipVM {
+				t.Skip("VM tests are disabled")
 			}
-			b := echoboot.NewBuilder(ctx, ctx.Clusters().Primaries().Default())
+			b := echoboot.NewBuilder(t, t.Clusters().Primaries().Default())
 			images := GetAdditionVMImages()
 			for _, image := range images {
 				b = b.WithConfig(echo.Config{
@@ -66,13 +66,13 @@ func TestVmOSPost(t *testing.T) {
 					Subsets:    []echo.SubsetConfig{{}},
 				})
 			}
-			instances := b.BuildOrFail(ctx)
+			instances := b.BuildOrFail(t)
 
 			for i, image := range images {
 				i, image := i, image
-				ctx.NewSubTest(image).RunParallel(func(ctx framework.TestContext) {
+				t.NewSubTest(image).RunParallel(func(t framework.TestContext) {
 					for _, tt := range common.VMTestCases(echo.Instances{instances[i]}, apps) {
-						tt.Run(ctx, apps.Namespace.Name())
+						tt.Run(t, apps.Namespace.Name())
 					}
 				})
 			}
@@ -84,21 +84,21 @@ func TestVMRegistrationLifecycle(t *testing.T) {
 		NewTest(t).
 		RequiresSingleCluster().
 		Features("vm.autoregistration").
-		Run(func(ctx framework.TestContext) {
-			scaleDeploymentOrFail(ctx, "istiod", i.Settings().SystemNamespace, 2)
-			client := apps.PodA.GetOrFail(ctx, echo.InCluster(ctx.Clusters().Default()))
+		Run(func(t framework.TestContext) {
+			scaleDeploymentOrFail(t, "istiod", i.Settings().SystemNamespace, 2)
+			client := apps.PodA.GetOrFail(t, echo.InCluster(t.Clusters().Default()))
 			// TODO test multi-network (must be shared control plane but on different networks)
 			var autoVM echo.Instance
-			_ = echoboot.NewBuilder(ctx).
+			_ = echoboot.NewBuilder(t).
 				With(&autoVM, echo.Config{
 					Namespace:      apps.Namespace,
 					Service:        "auto-vm",
 					Ports:          common.EchoPorts,
 					DeployAsVM:     true,
 					AutoRegisterVM: true,
-				}).BuildOrFail(ctx)
-			ctx.NewSubTest("initial registration").Run(func(ctx framework.TestContext) {
-				retry.UntilSuccessOrFail(ctx, func() error {
+				}).BuildOrFail(t)
+			t.NewSubTest("initial registration").Run(func(t framework.TestContext) {
+				retry.UntilSuccessOrFail(t, func() error {
 					res, err := client.Call(echo.CallOptions{Target: autoVM, Port: &autoVM.Config().Ports[0]})
 					if err != nil {
 						return err
@@ -106,10 +106,10 @@ func TestVMRegistrationLifecycle(t *testing.T) {
 					return res.CheckOK()
 				}, retry.Timeout(15*time.Second))
 			})
-			ctx.NewSubTest("reconnect reuses WorkloadEntry").Run(func(ctx framework.TestContext) {
+			t.NewSubTest("reconnect reuses WorkloadEntry").Run(func(t framework.TestContext) {
 				// ensure we have two pilot instances, other tests can pass before the second one comes up
-				retry.UntilSuccessOrFail(ctx, func() error {
-					pilotRes, err := ctx.Clusters().Default().CoreV1().Pods(i.Settings().SystemNamespace).
+				retry.UntilSuccessOrFail(t, func() error {
+					pilotRes, err := t.Clusters().Default().CoreV1().Pods(i.Settings().SystemNamespace).
 						List(context.TODO(), metav1.ListOptions{LabelSelector: "istio=pilot"})
 					if err != nil {
 						return err
@@ -121,35 +121,35 @@ func TestVMRegistrationLifecycle(t *testing.T) {
 				}, retry.Timeout(10*time.Second))
 
 				// get the initial workload entry state
-				entries := getWorkloadEntriesOrFail(ctx, autoVM)
+				entries := getWorkloadEntriesOrFail(t, autoVM)
 				if len(entries) != 1 {
-					ctx.Fatalf("expected exactly 1 WorkloadEntry but got %d", len(entries))
+					t.Fatalf("expected exactly 1 WorkloadEntry but got %d", len(entries))
 				}
 				initialWLE := entries[0]
 
 				// keep force-disconnecting until we observe a reconnect to a different istiod instance
 				initialPilot := initialWLE.Annotations[workloadentry.WorkloadControllerAnnotation]
-				disconnectProxy(ctx, initialPilot, autoVM)
-				retry.UntilSuccessOrFail(ctx, func() error {
-					entries := getWorkloadEntriesOrFail(ctx, autoVM)
+				disconnectProxy(t, initialPilot, autoVM)
+				retry.UntilSuccessOrFail(t, func() error {
+					entries := getWorkloadEntriesOrFail(t, autoVM)
 					if len(entries) != 1 || entries[0].UID != initialWLE.UID {
-						ctx.Fatalf("WorkloadEntry was cleaned up unexpectedly")
+						t.Fatalf("WorkloadEntry was cleaned up unexpectedly")
 					}
 
 					currentPilot := entries[0].Annotations[workloadentry.WorkloadControllerAnnotation]
 					if currentPilot == initialPilot || !strings.HasPrefix(currentPilot, "istiod-") {
-						disconnectProxy(ctx, currentPilot, autoVM)
+						disconnectProxy(t, currentPilot, autoVM)
 						return errors.New("expected WorkloadEntry to be updated by other pilot")
 					}
 					return nil
 				}, retry.Delay(5*time.Second))
 			})
-			ctx.NewSubTest("disconnect deletes WorkloadEntry").Run(func(ctx framework.TestContext) {
+			t.NewSubTest("disconnect deletes WorkloadEntry").Run(func(t framework.TestContext) {
 				deployment := fmt.Sprintf("%s-%s", autoVM.Config().Service, "v1")
-				scaleDeploymentOrFail(ctx, deployment, autoVM.Config().Namespace.Name(), 0)
+				scaleDeploymentOrFail(t, deployment, autoVM.Config().Namespace.Name(), 0)
 				// it should take at most just over GracePeriod to cleanup if all pilots are healthy
-				retry.UntilSuccessOrFail(ctx, func() error {
-					if len(getWorkloadEntriesOrFail(ctx, autoVM)) > 0 {
+				retry.UntilSuccessOrFail(t, func() error {
+					if len(getWorkloadEntriesOrFail(t, autoVM)) > 0 {
 						return errors.New("expected 0 WorkloadEntries")
 					}
 					return nil
@@ -158,36 +158,36 @@ func TestVMRegistrationLifecycle(t *testing.T) {
 		})
 }
 
-func disconnectProxy(ctx framework.TestContext, pilot string, instance echo.Instance) {
-	proxyID := strings.Join([]string{instance.WorkloadsOrFail(ctx)[0].PodName(), instance.Config().Namespace.Name()}, ".")
+func disconnectProxy(t framework.TestContext, pilot string, instance echo.Instance) {
+	proxyID := strings.Join([]string{instance.WorkloadsOrFail(t)[0].PodName(), instance.Config().Namespace.Name()}, ".")
 	cmd := "pilot-discovery request GET /debug/force_disconnect?proxyID=" + proxyID
-	stdOut, _, err := ctx.Clusters().Default().
+	stdOut, _, err := t.Clusters().Default().
 		PodExec(pilot, i.Settings().SystemNamespace, "discovery", cmd)
 	if err != nil {
 		scopes.Framework.Warnf("failed to force disconnect %s: %v: %v", proxyID, stdOut, err)
 	}
 }
 
-func scaleDeploymentOrFail(ctx framework.TestContext, name, namespace string, scale int32) {
-	s, err := ctx.Clusters().Default().AppsV1().Deployments(namespace).
+func scaleDeploymentOrFail(t framework.TestContext, name, namespace string, scale int32) {
+	s, err := t.Clusters().Default().AppsV1().Deployments(namespace).
 		GetScale(context.TODO(), name, metav1.GetOptions{})
 	if err != nil {
-		ctx.Fatal(err)
+		t.Fatal(err)
 	}
 	s.Spec.Replicas = scale
-	_, err = ctx.Clusters().Default().AppsV1().Deployments(namespace).
+	_, err = t.Clusters().Default().AppsV1().Deployments(namespace).
 		UpdateScale(context.TODO(), name, s, metav1.UpdateOptions{})
 	if err != nil {
-		ctx.Fatal(err)
+		t.Fatal(err)
 	}
 }
 
-func getWorkloadEntriesOrFail(ctx framework.TestContext, vm echo.Instance) []v1alpha3.WorkloadEntry {
-	res, err := ctx.Clusters().Default().Istio().NetworkingV1alpha3().
+func getWorkloadEntriesOrFail(t framework.TestContext, vm echo.Instance) []v1alpha3.WorkloadEntry {
+	res, err := t.Clusters().Default().Istio().NetworkingV1alpha3().
 		WorkloadEntries(vm.Config().Namespace.Name()).
 		List(context.TODO(), metav1.ListOptions{LabelSelector: "app=" + vm.Config().Service})
 	if err != nil {
-		ctx.Fatal(err)
+		t.Fatal(err)
 	}
 	return res.Items
 }

--- a/tests/integration/pilot/webhook_test.go
+++ b/tests/integration/pilot/webhook_test.go
@@ -36,10 +36,10 @@ const (
 func TestWebhook(t *testing.T) {
 	framework.NewTest(t).
 		RequiresSingleCluster().
-		Run(func(ctx framework.TestContext) {
+		Run(func(t framework.TestContext) {
 			// clear the updated fields and verify istiod updates them
 
-			cluster := ctx.Clusters().Default()
+			cluster := t.Clusters().Default()
 			retry.UntilSuccessOrFail(t, func() error {
 				got, err := getValidatingWebhookConfiguration(cluster, vwcName)
 				if err != nil {


### PR DESCRIPTION
Its incredibly common in our tests to see:
```go
ctx.NewTest().Run(ctx, func() {
   t.Fatal()
}
```

This causes go to panic. They should instead be using ctx.Fatal.

Fixing and preventing all of these cases is hard. Instead, we can just
shadow t so its impossible to make this mistake. I strongly suspect
every new test is copy+pasting previous ones, so if we change all usages
of `ctx` to `t` I doubt more usages will pop up.

I did this only in one tests for now to get early feedback