### PR TITLE
Make kubernetes.default.svc cluster-local by default. (#31347)

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -40,6 +40,7 @@ import (
 
 var (
 	defaultClusterLocalNamespaces = []string{"kube-system"}
+	defaultClusterLocalServices   = []string{"kubernetes.default.svc"}
 )
 
 // Metrics is an interface for capturing metrics on a per-node basis.
@@ -1724,6 +1725,9 @@ func (ps *PushContext) initClusterLocalHosts(e *Environment) {
 	for _, n := range defaultClusterLocalNamespaces {
 		defaultClusterLocalHosts = append(defaultClusterLocalHosts, host.Name("*."+n+".svc."+domainSuffix))
 	}
+	for _, s := range defaultClusterLocalServices {
+		defaultClusterLocalHosts = append(defaultClusterLocalHosts, host.Name(s+"."+domainSuffix))
+	}
 
 	if discoveryHost, _, err := e.GetDiscoveryAddress(); err != nil {
 		log.Errorf("failed to make discoveryAddress cluster-local: %v", err)
@@ -1745,9 +1749,13 @@ func (ps *PushContext) initClusterLocalHosts(e *Environment) {
 			// Remove defaults if specified to be non-cluster-local.
 			for _, h := range serviceSettings.Hosts {
 				for i, defaultClusterLocalHost := range defaultClusterLocalHosts {
-					if len(defaultClusterLocalHost) > 0 && strings.HasSuffix(h, string(defaultClusterLocalHost[1:])) {
-						// This default was explicitly overridden, so remove it.
-						defaultClusterLocalHosts[i] = ""
+					if len(defaultClusterLocalHost) > 0 {
+						if h == string(defaultClusterLocalHost) ||
+							(defaultClusterLocalHost.IsWildCarded() &&
+								strings.HasSuffix(h, string(defaultClusterLocalHost[1:]))) {
+							// This default was explicitly overridden, so remove it.
+							defaultClusterLocalHosts[i] = ""
+						}
 					}
 				}
 			}

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -1392,9 +1392,15 @@ func TestIsClusterLocal(t *testing.T) {
 		expected bool
 	}{
 		{
-			name:     "local by default",
+			name:     "kube-system is local",
 			m:        mesh.DefaultMeshConfig(),
 			host:     "s.kube-system.svc.cluster.local",
+			expected: true,
+		},
+		{
+			name:     "api server local is local",
+			m:        mesh.DefaultMeshConfig(),
+			host:     "kubernetes.default.svc.cluster.local",
 			expected: true,
 		},
 		{
@@ -1410,7 +1416,7 @@ func TestIsClusterLocal(t *testing.T) {
 			expected: false,
 		},
 		{
-			name: "override default",
+			name: "override default namespace",
 			m: meshconfig.MeshConfig{
 				// Remove the cluster-local setting for kube-system.
 				ServiceSettings: []*meshconfig.MeshConfig_ServiceSettings{
@@ -1423,6 +1429,22 @@ func TestIsClusterLocal(t *testing.T) {
 				},
 			},
 			host:     "s.kube-system.svc.cluster.local",
+			expected: false,
+		},
+		{
+			name: "override default service",
+			m: meshconfig.MeshConfig{
+				// Remove the cluster-local setting for kube-system.
+				ServiceSettings: []*meshconfig.MeshConfig_ServiceSettings{
+					{
+						Settings: &meshconfig.MeshConfig_ServiceSettings_Settings{
+							ClusterLocal: false,
+						},
+						Hosts: []string{"kubernetes.default.svc.cluster.local"},
+					},
+				},
+			},
+			host:     "kubernetes.default.svc.cluster.local",
 			expected: false,
 		},
 		{

--- a/releasenotes/notes/api-server-cluster-local.yaml
+++ b/releasenotes/notes/api-server-cluster-local.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: networking
+issue:
+  - 31340
+releaseNotes:
+  - |
+    **Fixed** the Kubernetes API server is now considered to be cluster-local by default. This means that any
+    pod attempting to reach `kubernetes.default.svc` will always be directed to the in-cluster server.


### PR DESCRIPTION
Fixes #31367



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.