### PR TITLE
Completely disable tracing in proxies if tracing is disabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ export BUILD_WITH_CONTAINER ?= 0
 
 ifeq ($(BUILD_WITH_CONTAINER),1)
 
-# An export free of arugments in a Makefile places all variables in the Makefile into the
+# An export free of arguments in a Makefile places all variables in the Makefile into the
 # environment. This is needed to allow overrides from Makefile.overrides.mk.
 export
 

--- a/go.mod
+++ b/go.mod
@@ -118,3 +118,5 @@ require (
 
 // Pending https://github.com/kubernetes/kube-openapi/pull/220
 replace k8s.io/kube-openapi => github.com/howardjohn/kube-openapi v0.0.0-20210104181841-c0b40d2cb1c8
+
+replace istio.io/api => github.com/nacx/api v0.0.0-20210310223803-6b9d5a2c467d

--- a/go.sum
+++ b/go.sum
@@ -676,6 +676,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f h1:KUppIJq7/+SVif2QVs3tOP0zanoHgBEVAwHxUSIzRqU=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
+github.com/nacx/api v0.0.0-20210310223803-6b9d5a2c467d h1:ECrgZQf7wsqxpqMg4KYqw01JjgEFqJ/ODqVxy58Sb0c=
+github.com/nacx/api v0.0.0-20210310223803-6b9d5a2c467d/go.mod h1:nsSFw1LIMmGL7r/+6fJI6FxeG/UGlLxRK8bkojIvBVs=
 github.com/natefinch/lumberjack v2.0.0+incompatible h1:4QJd3OLAMgj7ph+yZTuX13Ld4UpgHp07nNdFX7mqFfM=
 github.com/natefinch/lumberjack v2.0.0+incompatible/go.mod h1:Wi9p2TTF5DG5oU+6YfsmYQpsTIOm0B1VNzQg9Mw6nPk=
 github.com/nats-io/jwt v0.3.0/go.mod h1:fRYCDE99xlTsqUzISS1Bi75UBJ6ljOJQOAAu5VglpSg=
@@ -1391,7 +1393,6 @@ google.golang.org/grpc v1.26.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.27.1/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.28.0/go.mod h1:rpkK4SK4GF4Ach/+MFLZUBavHOvF2JJB5uozKKal+60=
-google.golang.org/grpc v1.28.1/go.mod h1:rpkK4SK4GF4Ach/+MFLZUBavHOvF2JJB5uozKKal+60=
 google.golang.org/grpc v1.29.1/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3IjizoKk=
 google.golang.org/grpc v1.30.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
 google.golang.org/grpc v1.31.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
@@ -1470,9 +1471,6 @@ honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.5 h1:nI5egYTGJakVyOryqLs1cQO5dO0ksin5XXs2pspk75k=
 honnef.co/go/tools v0.0.1-2020.1.5/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
-istio.io/api v0.0.0-20210131044048-bfeb10697307/go.mod h1:fnENIXK5mEYv7Acq1AE8bSEvba9kG2dltqEzsaCw7ys=
-istio.io/api v0.0.0-20210305035442-003b5cf6f68d h1:ApLqckaE/XH3dWx7jtbtKxYD3b0NTH0UsLigFlkVflg=
-istio.io/api v0.0.0-20210305035442-003b5cf6f68d/go.mod h1:nsSFw1LIMmGL7r/+6fJI6FxeG/UGlLxRK8bkojIvBVs=
 istio.io/client-go v0.0.0-20210218000043-b598dd019200 h1:9M2ZxIeSilnH03pFVovgxbm2RFL/J5mASQzlbHAvgJs=
 istio.io/client-go v0.0.0-20210218000043-b598dd019200/go.mod h1:gmwBYzvw0UEaguyZG6E9mYv4HXGr1V9MChouM0tj5KQ=
 istio.io/gogo-genproto v0.0.0-20210113155706-4daf5697332f/go.mod h1:6BwTZRNbWS570wHX/uR1Wqk5e0157TofTAUMzT7N4+s=

--- a/pilot/cmd/pilot-agent/config/config_test.go
+++ b/pilot/cmd/pilot-agent/config/config_test.go
@@ -20,8 +20,8 @@ import (
 	"time"
 
 	"github.com/gogo/protobuf/types"
-
 	meshconfig "istio.io/api/mesh/v1alpha1"
+
 	"istio.io/istio/pkg/config/mesh"
 )
 
@@ -32,18 +32,22 @@ defaultConfig:
   controlPlaneAuthPolicy: NONE
   proxyMetadata:
     SOME: setting
-  drainDuration: 1s`
+  drainDuration: 1s
+  enableTracing: false`
 	proxyOverride := `discoveryAddress: foo:123
 proxyMetadata:
   SOME: setting
 drainDuration: 1s
-controlPlaneAuthPolicy: NONE`
+controlPlaneAuthPolicy: NONE
+enableTracing: false`
 	overridesExpected := func() meshconfig.ProxyConfig {
 		m := mesh.DefaultProxyConfig()
 		m.DiscoveryAddress = "foo:123"
 		m.ProxyMetadata = map[string]string{"SOME": "setting"}
 		m.DrainDuration = types.DurationProto(time.Second)
 		m.ControlPlaneAuthPolicy = meshconfig.AuthenticationPolicy_NONE
+		m.EnableTracing = false
+		m.Tracing = nil
 		return m
 	}()
 	cases := []struct {


### PR DESCRIPTION
Even when tracing is disabled globally in the mesh configuration, the sidecar proxies still have some default tracing configuration in the Envoy bootstrap config. They also have the following tracing static cluster:
```json
{
  "name": "zipkin",
  "type": "STRICT_DNS",
  "connect_timeout": "1s",
  "dns_refresh_rate": "30s",
  "dns_lookup_family": "V4_ONLY",
  "load_assignment": {
   "cluster_name": "zipkin",
   "endpoints": [
    {
     "lb_endpoints": [
      {
       "endpoint": {
        "address": {
         "socket_address": {
          "address": "zipkin.istio-system",
          "port_value": 9411
         }
        }
       }
      }
     ]
    }
   ]
  },
  "respect_dns_ttl": true
}
```
Having this default cluster, even when tracing is disabled, causes Envoy to [periodically send DNS requests](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/service_discovery#arch-overview-service-discovery-types-strict-dns) to resolve the zipkin address, but those requests are unnecessary if tracing is disabled and zipkin is not even deployed.

This pull request introduces a way of properly disabling tracing at the proxy level in order to eliminate those unnecessary DNS requests.

This PR depends on: https://github.com/istio/api/pull/1908

The first commit in the PR is the relevant one; the second one is just to accommodate the changes needed to upgrade to a more recent version of the Istio API.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
