### PR TITLE
Make inbound TLS cipher suites configurable

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -24,6 +24,16 @@ import (
 	"istio.io/pkg/env"
 )
 
+const (
+	// DefaultInboundCiphers for server side TLS configuration.
+	DefaultInboundCiphers string = "ECDHE-ECDSA-AES256-GCM-SHA384," +
+		"ECDHE-RSA-AES256-GCM-SHA384," +
+		"ECDHE-ECDSA-AES128-GCM-SHA256," +
+		"ECDHE-RSA-AES128-GCM-SHA256," +
+		"AES256-GCM-SHA384," +
+		"AES128-GCM-SHA256"
+)
+
 var (
 	MaxConcurrentStreams = env.RegisterIntVar(
 		"ISTIO_GPRC_MAXSTREAMS",
@@ -422,6 +432,9 @@ var (
 		"If enabled, addition runtime asserts will be performed. "+
 			"These checks are both expensive and panic on failure. As a result, this should be used only for testing.",
 	).Get()
+
+	TLSInboundCipherSuites = env.RegisterStringVar("TLS_INBOUND_CIPHER_SUITES", DefaultInboundCiphers,
+		"The cipher suites for inbound TLS connections, delimited by comma.").Get()
 )
 
 // UnsafeFeaturesEnabled returns true if any unsafe features are enabled.

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -38,25 +38,27 @@ const (
 		"ECDHE-RSA-AES128-GCM-SHA256," +
 		"ECDHE-ECDSA-AES256-GCM-SHA384," +
 		"ECDHE-RSA-AES256-GCM-SHA384"
-
-	// AllowedInboundCiphers for server side TLS configuration.
-	// The list is based on the Envoy BoringSSL FIPS cipher list on
-	// https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/common.proto.html.
-	AllowedInboundCiphers string = "ECDHE-ECDSA-AES128-GCM-SHA256," +
-		"ECDHE-RSA-AES128-GCM-SHA256," +
-		"ECDHE-ECDSA-AES128-SHA," +
-		"ECDHE-RSA-AES128-SHA," +
-		"AES128-GCM-SHA256," +
-		"AES128-SHA," +
-		"ECDHE-ECDSA-AES256-GCM-SHA384," +
-		"ECDHE-RSA-AES256-GCM-SHA384," +
-		"ECDHE-ECDSA-AES256-SHA," +
-		"ECDHE-RSA-AES256-SHA," +
-		"AES256-GCM-SHA384," +
-		"AES256-SHA"
 )
 
 var (
+	// AllowedInboundCiphers for server side TLS configuration.
+	// The list is based on the Envoy BoringSSL FIPS cipher list on
+	// https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/common.proto.html.
+	AllowedInboundCiphers = []string{
+		"ECDHE-ECDSA-AES128-GCM-SHA256",
+		"ECDHE-RSA-AES128-GCM-SHA256",
+		"ECDHE-ECDSA-AES128-SHA",
+		"ECDHE-RSA-AES128-SHA",
+		"AES128-GCM-SHA256",
+		"AES128-SHA",
+		"ECDHE-ECDSA-AES256-GCM-SHA384",
+		"ECDHE-RSA-AES256-GCM-SHA384",
+		"ECDHE-ECDSA-AES256-SHA",
+		"ECDHE-RSA-AES256-SHA",
+		"AES256-GCM-SHA384",
+		"AES256-SHA",
+	}
+
 	MaxConcurrentStreams = env.RegisterIntVar(
 		"ISTIO_GPRC_MAXSTREAMS",
 		100000,

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -26,12 +26,34 @@ import (
 
 const (
 	// DefaultInboundCiphers for server side TLS configuration.
-	DefaultInboundCiphers string = "ECDHE-ECDSA-AES256-GCM-SHA384," +
-		"ECDHE-RSA-AES256-GCM-SHA384," +
-		"ECDHE-ECDSA-AES128-GCM-SHA256," +
+	// The list is based on the "RESTRICTED" profile from
+	// https://cloud.google.com/load-balancing/docs/ssl-policies-concepts
+	// and the Envoy BoringSSL FIPS cipher list on
+	// https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/common.proto.html.
+	// The order matters: first one on the server list that's also supported
+	// by the client is used for the connection.
+	// Note that AES128 is preferred over AES256 since both ciphers are on
+	// the "RESTRICTED" profile and AES128 is less CPU-intensive.
+	DefaultInboundCiphers string = "ECDHE-ECDSA-AES128-GCM-SHA256," +
 		"ECDHE-RSA-AES128-GCM-SHA256," +
+		"ECDHE-ECDSA-AES256-GCM-SHA384," +
+		"ECDHE-RSA-AES256-GCM-SHA384"
+
+	// AllowedInboundCiphers for server side TLS configuration.
+	// The list is based on the Envoy BoringSSL FIPS cipher list on
+	// https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/common.proto.html.
+	AllowedInboundCiphers string = "ECDHE-ECDSA-AES128-GCM-SHA256," +
+		"ECDHE-RSA-AES128-GCM-SHA256," +
+		"ECDHE-ECDSA-AES128-SHA," +
+		"ECDHE-RSA-AES128-SHA," +
+		"AES128-GCM-SHA256," +
+		"AES128-SHA," +
+		"ECDHE-ECDSA-AES256-GCM-SHA384," +
+		"ECDHE-RSA-AES256-GCM-SHA384," +
+		"ECDHE-ECDSA-AES256-SHA," +
+		"ECDHE-RSA-AES256-SHA," +
 		"AES256-GCM-SHA384," +
-		"AES128-GCM-SHA256"
+		"AES256-SHA"
 )
 
 var (

--- a/pilot/pkg/security/authn/utils/utils.go
+++ b/pilot/pkg/security/authn/utils/utils.go
@@ -79,17 +79,13 @@ func BuildInboundFilterChain(mTLSMode model.MutualTLSMode, node *model.Proxy,
 		}
 	}
 
-	allowedCiphers := []string{}
-	for _, c := range strings.Split(features.AllowedInboundCiphers, ",") {
-		allowedCiphers = append(allowedCiphers, strings.TrimSpace(c))
-	}
 	defaultCiphers := []string{}
 	for _, c := range strings.Split(features.DefaultInboundCiphers, ",") {
 		defaultCiphers = append(defaultCiphers, strings.TrimSpace(c))
 	}
 	ciphers := []string{}
 	for _, c := range strings.Split(features.TLSInboundCipherSuites, ",") {
-		if err := checkCipher(c, allowedCiphers); err != nil {
+		if err := checkCipher(c, features.AllowedInboundCiphers); err != nil {
 			log.Warnf("checking cipher %v returns an error: %v", err)
 		} else {
 			ciphers = append(ciphers, strings.TrimSpace(c))

--- a/pilot/pkg/security/authn/utils/utils_test.go
+++ b/pilot/pkg/security/authn/utils/utils_test.go
@@ -24,8 +24,8 @@ import (
 	"github.com/golang/protobuf/ptypes"
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/protobuf/testing/protocmp"
-	"istio.io/istio/pilot/pkg/features"
 
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking"
 	authn_model "istio.io/istio/pilot/pkg/security/model"
@@ -34,10 +34,10 @@ import (
 )
 
 const (
+	// The list of ciphers in tlsInboundCiphers1 are only used to test that
+	// the Envoy config generated is as expected.
 	tlsInboundCiphers1 string = "ECDHE-ECDSA-AES256-GCM-SHA384," +
-		"ECDHE-RSA-AES256-GCM-SHA384," +
-		"ECDHE-ECDSA-AES128-GCM-SHA256," +
-		"ECDHE-RSA-AES128-GCM-SHA256"
+		"ECDHE-RSA-AES256-GCM-SHA384"
 )
 
 func TestBuildInboundFilterChain(t *testing.T) {
@@ -144,12 +144,10 @@ func TestBuildInboundFilterChain(t *testing.T) {
 							TlsParams: &auth.TlsParameters{
 								TlsMinimumProtocolVersion: auth.TlsParameters_TLSv1_2,
 								CipherSuites: []string{
-									"ECDHE-ECDSA-AES256-GCM-SHA384",
-									"ECDHE-RSA-AES256-GCM-SHA384",
 									"ECDHE-ECDSA-AES128-GCM-SHA256",
 									"ECDHE-RSA-AES128-GCM-SHA256",
-									"AES256-GCM-SHA384",
-									"AES128-GCM-SHA256",
+									"ECDHE-ECDSA-AES256-GCM-SHA384",
+									"ECDHE-RSA-AES256-GCM-SHA384",
 								},
 							},
 						},
@@ -227,8 +225,6 @@ func TestBuildInboundFilterChain(t *testing.T) {
 								CipherSuites: []string{
 									"ECDHE-ECDSA-AES256-GCM-SHA384",
 									"ECDHE-RSA-AES256-GCM-SHA384",
-									"ECDHE-ECDSA-AES128-GCM-SHA256",
-									"ECDHE-RSA-AES128-GCM-SHA256",
 								},
 							},
 						},
@@ -307,12 +303,10 @@ func TestBuildInboundFilterChain(t *testing.T) {
 							TlsParams: &auth.TlsParameters{
 								TlsMinimumProtocolVersion: auth.TlsParameters_TLSv1_2,
 								CipherSuites: []string{
-									"ECDHE-ECDSA-AES256-GCM-SHA384",
-									"ECDHE-RSA-AES256-GCM-SHA384",
 									"ECDHE-ECDSA-AES128-GCM-SHA256",
 									"ECDHE-RSA-AES128-GCM-SHA256",
-									"AES256-GCM-SHA384",
-									"AES128-GCM-SHA256",
+									"ECDHE-ECDSA-AES256-GCM-SHA384",
+									"ECDHE-RSA-AES256-GCM-SHA384",
 								},
 							},
 						},

--- a/pilot/pkg/security/authn/v1beta1/policy_applier_test.go
+++ b/pilot/pkg/security/authn/v1beta1/policy_applier_test.go
@@ -1494,12 +1494,10 @@ func TestOnInboundFilterChain(t *testing.T) {
 			TlsParams: &tls.TlsParameters{
 				TlsMinimumProtocolVersion: tls.TlsParameters_TLSv1_2,
 				CipherSuites: []string{
-					"ECDHE-ECDSA-AES256-GCM-SHA384",
-					"ECDHE-RSA-AES256-GCM-SHA384",
 					"ECDHE-ECDSA-AES128-GCM-SHA256",
 					"ECDHE-RSA-AES128-GCM-SHA256",
-					"AES256-GCM-SHA384",
-					"AES128-GCM-SHA256",
+					"ECDHE-ECDSA-AES256-GCM-SHA384",
+					"ECDHE-RSA-AES256-GCM-SHA384",
 				},
 			},
 		},

--- a/releasenotes/notes/31380.yaml
+++ b/releasenotes/notes/31380.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: security
+issue:
+- 31380
+releaseNotes:
+- |
+  **Added** the support of configuring the cipher suites for inbound TLS connections.


### PR DESCRIPTION
Please provide a description for what this PR is for: https://github.com/istio/istio/issues/31380

In current implementation, inbound TLS cipher suites are hard-coded. This PR adds an option to configure inbound TLS cipher suites. With this PR, if you want to enforce stricter cipher suites for stronger security on the inbound server side, you can configure through the TLS_INBOUND_CIPHER_SUITES option.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.