### PR TITLE
Moving trustbundle library after CA initializaton

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -241,7 +241,6 @@ func NewServer(args *PilotArgs) (*Server, error) {
 
 	s.initMeshNetworks(args, s.fileWatcher)
 	s.initMeshHandlers()
-	s.initWorkloadTrustBundle()
 
 	// Options based on the current 'defaults' in istio.
 	caOpts := &caOptions{
@@ -263,6 +262,9 @@ func NewServer(args *PilotArgs) (*Server, error) {
 	if err := s.initControllers(args); err != nil {
 		return nil, err
 	}
+
+	// Initialize workloadTrustBundle after CA has been initialized
+	s.initWorkloadTrustBundle()
 
 	// Parse and validate Istiod Address.
 	istiodHost, _, err := e.GetDiscoveryAddress()


### PR DESCRIPTION
Moving trustbundle library after CA initializaton


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.