### PR TITLE
do not add validation context for SIMPLE

### DIFF
--- a/pilot/pkg/model/authentication.go
+++ b/pilot/pkg/model/authentication.go
@@ -289,11 +289,6 @@ func (s SdsCertificateConfig) IsKeyCertificate() bool {
 	return s.CertificatePath != "" && s.PrivateKeyPath != ""
 }
 
-// IsValidConfig returns true if this config has valid certs.
-func (s SdsCertificateConfig) IsValidConfig() bool {
-	return s.IsKeyCertificate() || s.IsRootCertificate()
-}
-
 // SdsCertificateConfigFromResourceName converts the provided resource name into a SdsCertificateConfig
 // If the resource name is not valid, false is returned.
 func SdsCertificateConfigFromResourceName(resource string) (SdsCertificateConfig, bool) {

--- a/pilot/pkg/model/authentication.go
+++ b/pilot/pkg/model/authentication.go
@@ -289,6 +289,11 @@ func (s SdsCertificateConfig) IsKeyCertificate() bool {
 	return s.CertificatePath != "" && s.PrivateKeyPath != ""
 }
 
+// IsValidConfig returns true if this config has valid certs.
+func (s SdsCertificateConfig) IsValidConfig() bool {
+	return s.IsKeyCertificate() || s.IsRootCertificate()
+}
+
 // SdsCertificateConfigFromResourceName converts the provided resource name into a SdsCertificateConfig
 // If the resource name is not valid, false is returned.
 func SdsCertificateConfigFromResourceName(resource string) (SdsCertificateConfig, bool) {

--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -483,13 +483,19 @@ func buildGatewayListenerTLSContext(
 		},
 	}
 
+	ctx.RequireClientCertificate = proto.BoolFalse
+	if server.Tls.Mode == networking.ServerTLSSettings_MUTUAL ||
+		server.Tls.Mode == networking.ServerTLSSettings_ISTIO_MUTUAL {
+		ctx.RequireClientCertificate = proto.BoolTrue
+	}
+
 	switch {
 	// If SDS is enabled at gateway, and credential name is specified at gateway config, create
 	// SDS config for gateway to fetch key/cert at gateway agent.
 	case server.Tls.CredentialName != "":
 		authn_model.ApplyCredentialSDSToServerCommonTLSContext(ctx.CommonTlsContext, server.Tls)
 	case server.Tls.Mode == networking.ServerTLSSettings_ISTIO_MUTUAL:
-		authn_model.ApplyToCommonTLSContext(ctx.CommonTlsContext, proxy, server.Tls.SubjectAltNames, []string{})
+		authn_model.ApplyToCommonTLSContext(ctx.CommonTlsContext, proxy, server.Tls.SubjectAltNames, []string{}, ctx.RequireClientCertificate.Value)
 	default:
 		certProxy := &model.Proxy{}
 		certProxy.IstioVersion = proxy.IstioVersion
@@ -497,15 +503,11 @@ func buildGatewayListenerTLSContext(
 		certProxy.Metadata = &model.NodeMetadata{
 			TLSServerCertChain: server.Tls.ServerCertificate,
 			TLSServerKey:       server.Tls.PrivateKey,
-			TLSServerRootCert:  server.Tls.CaCertificates,
 		}
-		authn_model.ApplyToCommonTLSContext(ctx.CommonTlsContext, certProxy, server.Tls.SubjectAltNames, []string{})
-	}
-
-	ctx.RequireClientCertificate = proto.BoolFalse
-	if server.Tls.Mode == networking.ServerTLSSettings_MUTUAL ||
-		server.Tls.Mode == networking.ServerTLSSettings_ISTIO_MUTUAL {
-		ctx.RequireClientCertificate = proto.BoolTrue
+		if server.Tls.Mode == networking.ServerTLSSettings_MUTUAL {
+			certProxy.Metadata.TLSServerRootCert = server.Tls.CaCertificates
+		}
+		authn_model.ApplyToCommonTLSContext(ctx.CommonTlsContext, certProxy, server.Tls.SubjectAltNames, []string{}, ctx.RequireClientCertificate.Value)
 	}
 
 	// Set TLS parameters if they are non-default

--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -483,13 +483,19 @@ func buildGatewayListenerTLSContext(
 		},
 	}
 
+	ctx.RequireClientCertificate = proto.BoolFalse
+	if server.Tls.Mode == networking.ServerTLSSettings_MUTUAL ||
+		server.Tls.Mode == networking.ServerTLSSettings_ISTIO_MUTUAL {
+		ctx.RequireClientCertificate = proto.BoolTrue
+	}
+
 	switch {
 	// If SDS is enabled at gateway, and credential name is specified at gateway config, create
 	// SDS config for gateway to fetch key/cert at gateway agent.
 	case server.Tls.CredentialName != "":
 		authn_model.ApplyCredentialSDSToServerCommonTLSContext(ctx.CommonTlsContext, server.Tls)
 	case server.Tls.Mode == networking.ServerTLSSettings_ISTIO_MUTUAL:
-		authn_model.ApplyToCommonTLSContext(ctx.CommonTlsContext, proxy, server.Tls.SubjectAltNames, []string{})
+		authn_model.ApplyToCommonTLSContext(ctx.CommonTlsContext, proxy, server.Tls.SubjectAltNames, []string{}, ctx.RequireClientCertificate.Value)
 	default:
 		certProxy := &model.Proxy{}
 		certProxy.IstioVersion = proxy.IstioVersion
@@ -500,13 +506,7 @@ func buildGatewayListenerTLSContext(
 			TLSServerRootCert:  server.Tls.CaCertificates,
 		}
 
-		authn_model.ApplyToCommonTLSContext(ctx.CommonTlsContext, certProxy, server.Tls.SubjectAltNames, []string{})
-	}
-
-	ctx.RequireClientCertificate = proto.BoolFalse
-	if server.Tls.Mode == networking.ServerTLSSettings_MUTUAL ||
-		server.Tls.Mode == networking.ServerTLSSettings_ISTIO_MUTUAL {
-		ctx.RequireClientCertificate = proto.BoolTrue
+		authn_model.ApplyToCommonTLSContext(ctx.CommonTlsContext, certProxy, server.Tls.SubjectAltNames, []string{}, ctx.RequireClientCertificate.Value)
 	}
 
 	// Set TLS parameters if they are non-default

--- a/pilot/pkg/networking/core/v1alpha3/gateway_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway_test.go
@@ -147,32 +147,6 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 							},
 						},
 					},
-					ValidationContextType: &auth.CommonTlsContext_CombinedValidationContext{
-						CombinedValidationContext: &auth.CommonTlsContext_CombinedCertificateValidationContext{
-							DefaultValidationContext: &auth.CertificateValidationContext{},
-							ValidationContextSdsSecretConfig: &auth.SdsSecretConfig{
-								Name: "ROOTCA",
-								SdsConfig: &core.ConfigSource{
-									InitialFetchTimeout: ptypes.DurationProto(time.Second * 0),
-									ResourceApiVersion:  core.ApiVersion_V3,
-									ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
-										ApiConfigSource: &core.ApiConfigSource{
-											ApiType:                   core.ApiConfigSource_GRPC,
-											SetNodeOnFirstMessageOnly: true,
-											TransportApiVersion:       core.ApiVersion_V3,
-											GrpcServices: []*core.GrpcService{
-												{
-													TargetSpecifier: &core.GrpcService_EnvoyGrpc_{
-														EnvoyGrpc: &core.GrpcService_EnvoyGrpc{ClusterName: model.SDSClusterName},
-													},
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
 				},
 				RequireClientCertificate: proto.BoolFalse,
 			},
@@ -229,7 +203,7 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 			},
 		},
 		{
-			name: "no credential name key and cert tls SIMPLE with out cacert",
+			name: "no credential name key and cert tls SIMPLE",
 			server: &networking.Server{
 				Hosts: []string{"httpbin.example.com", "bookinfo.example.com"},
 				Tls: &networking.ServerTLSSettings{
@@ -255,71 +229,6 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 											{
 												TargetSpecifier: &core.GrpcService_EnvoyGrpc_{
 													EnvoyGrpc: &core.GrpcService_EnvoyGrpc{ClusterName: model.SDSClusterName},
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-				RequireClientCertificate: proto.BoolFalse,
-			},
-		},
-		{
-			name: "no credential name key and cert tls SIMPLE with cacert",
-			server: &networking.Server{
-				Hosts: []string{"httpbin.example.com", "bookinfo.example.com"},
-				Tls: &networking.ServerTLSSettings{
-					Mode:              networking.ServerTLSSettings_SIMPLE,
-					ServerCertificate: "server-cert.crt",
-					PrivateKey:        "private-key.key",
-					CaCertificates:    "ca-cert.crt",
-				},
-			},
-			result: &auth.DownstreamTlsContext{
-				CommonTlsContext: &auth.CommonTlsContext{
-					AlpnProtocols: util.ALPNHttp,
-					TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{
-						{
-							Name: "file-cert:server-cert.crt~private-key.key",
-							SdsConfig: &core.ConfigSource{
-								ResourceApiVersion: core.ApiVersion_V3,
-								ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
-									ApiConfigSource: &core.ApiConfigSource{
-										ApiType:                   core.ApiConfigSource_GRPC,
-										SetNodeOnFirstMessageOnly: true,
-										TransportApiVersion:       core.ApiVersion_V3,
-										GrpcServices: []*core.GrpcService{
-											{
-												TargetSpecifier: &core.GrpcService_EnvoyGrpc_{
-													EnvoyGrpc: &core.GrpcService_EnvoyGrpc{ClusterName: model.SDSClusterName},
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-					ValidationContextType: &auth.CommonTlsContext_CombinedValidationContext{
-						CombinedValidationContext: &auth.CommonTlsContext_CombinedCertificateValidationContext{
-							DefaultValidationContext: &auth.CertificateValidationContext{},
-							ValidationContextSdsSecretConfig: &auth.SdsSecretConfig{
-								Name: "file-root:ca-cert.crt",
-								SdsConfig: &core.ConfigSource{
-									ResourceApiVersion: core.ApiVersion_V3,
-									ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
-										ApiConfigSource: &core.ApiConfigSource{
-											ApiType:                   core.ApiConfigSource_GRPC,
-											SetNodeOnFirstMessageOnly: true,
-											TransportApiVersion:       core.ApiVersion_V3,
-											GrpcServices: []*core.GrpcService{
-												{
-													TargetSpecifier: &core.GrpcService_EnvoyGrpc_{
-														EnvoyGrpc: &core.GrpcService_EnvoyGrpc{ClusterName: model.SDSClusterName},
-													},
 												},
 											},
 										},

--- a/pilot/pkg/networking/core/v1alpha3/gateway_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway_test.go
@@ -147,6 +147,32 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 							},
 						},
 					},
+					ValidationContextType: &auth.CommonTlsContext_CombinedValidationContext{
+						CombinedValidationContext: &auth.CommonTlsContext_CombinedCertificateValidationContext{
+							DefaultValidationContext: &auth.CertificateValidationContext{},
+							ValidationContextSdsSecretConfig: &auth.SdsSecretConfig{
+								Name: "ROOTCA",
+								SdsConfig: &core.ConfigSource{
+									InitialFetchTimeout: ptypes.DurationProto(time.Second * 0),
+									ResourceApiVersion:  core.ApiVersion_V3,
+									ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
+										ApiConfigSource: &core.ApiConfigSource{
+											ApiType:                   core.ApiConfigSource_GRPC,
+											SetNodeOnFirstMessageOnly: true,
+											TransportApiVersion:       core.ApiVersion_V3,
+											GrpcServices: []*core.GrpcService{
+												{
+													TargetSpecifier: &core.GrpcService_EnvoyGrpc_{
+														EnvoyGrpc: &core.GrpcService_EnvoyGrpc{ClusterName: model.SDSClusterName},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
 				},
 				RequireClientCertificate: proto.BoolFalse,
 			},
@@ -203,7 +229,7 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 			},
 		},
 		{
-			name: "no credential name key and cert tls SIMPLE",
+			name: "no credential name key and cert tls SIMPLE with out cacert",
 			server: &networking.Server{
 				Hosts: []string{"httpbin.example.com", "bookinfo.example.com"},
 				Tls: &networking.ServerTLSSettings{
@@ -229,6 +255,71 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 											{
 												TargetSpecifier: &core.GrpcService_EnvoyGrpc_{
 													EnvoyGrpc: &core.GrpcService_EnvoyGrpc{ClusterName: model.SDSClusterName},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				RequireClientCertificate: proto.BoolFalse,
+			},
+		},
+		{
+			name: "no credential name key and cert tls SIMPLE with cacert",
+			server: &networking.Server{
+				Hosts: []string{"httpbin.example.com", "bookinfo.example.com"},
+				Tls: &networking.ServerTLSSettings{
+					Mode:              networking.ServerTLSSettings_SIMPLE,
+					ServerCertificate: "server-cert.crt",
+					PrivateKey:        "private-key.key",
+					CaCertificates:    "ca-cert.crt",
+				},
+			},
+			result: &auth.DownstreamTlsContext{
+				CommonTlsContext: &auth.CommonTlsContext{
+					AlpnProtocols: util.ALPNHttp,
+					TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{
+						{
+							Name: "file-cert:server-cert.crt~private-key.key",
+							SdsConfig: &core.ConfigSource{
+								ResourceApiVersion: core.ApiVersion_V3,
+								ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
+									ApiConfigSource: &core.ApiConfigSource{
+										ApiType:                   core.ApiConfigSource_GRPC,
+										SetNodeOnFirstMessageOnly: true,
+										TransportApiVersion:       core.ApiVersion_V3,
+										GrpcServices: []*core.GrpcService{
+											{
+												TargetSpecifier: &core.GrpcService_EnvoyGrpc_{
+													EnvoyGrpc: &core.GrpcService_EnvoyGrpc{ClusterName: model.SDSClusterName},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					ValidationContextType: &auth.CommonTlsContext_CombinedValidationContext{
+						CombinedValidationContext: &auth.CommonTlsContext_CombinedCertificateValidationContext{
+							DefaultValidationContext: &auth.CertificateValidationContext{},
+							ValidationContextSdsSecretConfig: &auth.SdsSecretConfig{
+								Name: "file-root:ca-cert.crt",
+								SdsConfig: &core.ConfigSource{
+									ResourceApiVersion: core.ApiVersion_V3,
+									ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
+										ApiConfigSource: &core.ApiConfigSource{
+											ApiType:                   core.ApiConfigSource_GRPC,
+											SetNodeOnFirstMessageOnly: true,
+											TransportApiVersion:       core.ApiVersion_V3,
+											GrpcServices: []*core.GrpcService{
+												{
+													TargetSpecifier: &core.GrpcService_EnvoyGrpc_{
+														EnvoyGrpc: &core.GrpcService_EnvoyGrpc{ClusterName: model.SDSClusterName},
+													},
 												},
 											},
 										},

--- a/pilot/pkg/networking/core/v1alpha3/gateway_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway_test.go
@@ -147,32 +147,6 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 							},
 						},
 					},
-					ValidationContextType: &auth.CommonTlsContext_CombinedValidationContext{
-						CombinedValidationContext: &auth.CommonTlsContext_CombinedCertificateValidationContext{
-							DefaultValidationContext: &auth.CertificateValidationContext{},
-							ValidationContextSdsSecretConfig: &auth.SdsSecretConfig{
-								Name: "ROOTCA",
-								SdsConfig: &core.ConfigSource{
-									InitialFetchTimeout: ptypes.DurationProto(time.Second * 0),
-									ResourceApiVersion:  core.ApiVersion_V3,
-									ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
-										ApiConfigSource: &core.ApiConfigSource{
-											ApiType:                   core.ApiConfigSource_GRPC,
-											SetNodeOnFirstMessageOnly: true,
-											TransportApiVersion:       core.ApiVersion_V3,
-											GrpcServices: []*core.GrpcService{
-												{
-													TargetSpecifier: &core.GrpcService_EnvoyGrpc_{
-														EnvoyGrpc: &core.GrpcService_EnvoyGrpc{ClusterName: model.SDSClusterName},
-													},
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
 				},
 				RequireClientCertificate: proto.BoolFalse,
 			},
@@ -236,7 +210,6 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 					Mode:              networking.ServerTLSSettings_SIMPLE,
 					ServerCertificate: "server-cert.crt",
 					PrivateKey:        "private-key.key",
-					CaCertificates:    "ca-cert.crt",
 				},
 			},
 			result: &auth.DownstreamTlsContext{
@@ -256,31 +229,6 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 											{
 												TargetSpecifier: &core.GrpcService_EnvoyGrpc_{
 													EnvoyGrpc: &core.GrpcService_EnvoyGrpc{ClusterName: model.SDSClusterName},
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-					ValidationContextType: &auth.CommonTlsContext_CombinedValidationContext{
-						CombinedValidationContext: &auth.CommonTlsContext_CombinedCertificateValidationContext{
-							DefaultValidationContext: &auth.CertificateValidationContext{},
-							ValidationContextSdsSecretConfig: &auth.SdsSecretConfig{
-								Name: "file-root:ca-cert.crt",
-								SdsConfig: &core.ConfigSource{
-									ResourceApiVersion: core.ApiVersion_V3,
-									ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
-										ApiConfigSource: &core.ApiConfigSource{
-											ApiType:                   core.ApiConfigSource_GRPC,
-											SetNodeOnFirstMessageOnly: true,
-											TransportApiVersion:       core.ApiVersion_V3,
-											GrpcServices: []*core.GrpcService{
-												{
-													TargetSpecifier: &core.GrpcService_EnvoyGrpc_{
-														EnvoyGrpc: &core.GrpcService_EnvoyGrpc{ClusterName: model.SDSClusterName},
-													},
 												},
 											},
 										},

--- a/pilot/pkg/security/authn/utils/utils.go
+++ b/pilot/pkg/security/authn/utils/utils.go
@@ -91,7 +91,7 @@ func BuildInboundFilterChain(mTLSMode model.MutualTLSMode, node *model.Proxy,
 		CipherSuites:              SupportedCiphers,
 	}
 
-	authn_model.ApplyToCommonTLSContext(ctx.CommonTlsContext, node, []string{} /*subjectAltNames*/, trustDomainAliases)
+	authn_model.ApplyToCommonTLSContext(ctx.CommonTlsContext, node, []string{} /*subjectAltNames*/, trustDomainAliases, ctx.RequireClientCertificate.Value)
 
 	if mTLSMode == model.MTLSStrict {
 		log.Debug("Allow only istio mutual TLS traffic")

--- a/pilot/pkg/security/authn/utils/utils.go
+++ b/pilot/pkg/security/authn/utils/utils.go
@@ -91,7 +91,7 @@ func BuildInboundFilterChain(mTLSMode model.MutualTLSMode, node *model.Proxy,
 		CipherSuites:              SupportedCiphers,
 	}
 
-	authn_model.ApplyToCommonTLSContext(ctx.CommonTlsContext, node, []string{} /*subjectAltNames*/, trustDomainAliases, ctx.RequireClientCertificate.Value)
+	authn_model.ApplyToCommonTLSContext(ctx.CommonTlsContext, node, []string{} /*subjectAltNames*/, trustDomainAliases)
 
 	if mTLSMode == model.MTLSStrict {
 		log.Debug("Allow only istio mutual TLS traffic")

--- a/pilot/pkg/security/model/authentication.go
+++ b/pilot/pkg/security/model/authentication.go
@@ -251,7 +251,7 @@ func appendURIPrefixToTrustDomain(trustDomainAliases []string) []string {
 
 // ApplyToCommonTLSContext completes the commonTlsContext
 func ApplyToCommonTLSContext(tlsContext *tls.CommonTlsContext, proxy *model.Proxy,
-	subjectAltNames []string, trustDomainAliases []string) {
+	subjectAltNames []string, trustDomainAliases []string, validateClient bool) {
 	// These are certs being mounted from within the pod. Rather than reading directly in Envoy,
 	// which does not support rotation, we will serve them over SDS by reading the files.
 	// We should check if these certs have values, if yes we should use them or otherwise fall back to defaults.
@@ -266,13 +266,6 @@ func ApplyToCommonTLSContext(tlsContext *tls.CommonTlsContext, proxy *model.Prox
 	matchSAN := util.StringToExactMatch(subjectAltNames)
 	if len(trustDomainAliases) > 0 {
 		matchSAN = append(matchSAN, util.StringToPrefixMatch(appendURIPrefixToTrustDomain(trustDomainAliases))...)
-	}
-
-	validateClient := true
-	// If file mounted certs are provided, but root certificate is not provided that means it is SIMPLE mode
-	// without cacertificate - We should skip add validate config.
-	if res.IsValidConfig() && !res.IsRootCertificate() {
-		validateClient = false
 	}
 
 	// configure server listeners with SDS.

--- a/pilot/pkg/security/model/authentication.go
+++ b/pilot/pkg/security/model/authentication.go
@@ -251,7 +251,7 @@ func appendURIPrefixToTrustDomain(trustDomainAliases []string) []string {
 
 // ApplyToCommonTLSContext completes the commonTlsContext
 func ApplyToCommonTLSContext(tlsContext *tls.CommonTlsContext, proxy *model.Proxy,
-	subjectAltNames []string, trustDomainAliases []string, validateClient bool) {
+	subjectAltNames []string, trustDomainAliases []string) {
 	// These are certs being mounted from within the pod. Rather than reading directly in Envoy,
 	// which does not support rotation, we will serve them over SDS by reading the files.
 	// We should check if these certs have values, if yes we should use them or otherwise fall back to defaults.
@@ -266,6 +266,13 @@ func ApplyToCommonTLSContext(tlsContext *tls.CommonTlsContext, proxy *model.Prox
 	matchSAN := util.StringToExactMatch(subjectAltNames)
 	if len(trustDomainAliases) > 0 {
 		matchSAN = append(matchSAN, util.StringToPrefixMatch(appendURIPrefixToTrustDomain(trustDomainAliases))...)
+	}
+
+	validateClient := true
+	// If file mounted certs are provided, but root certificate is not provided that means it is SIMPLE mode
+	// without cacertificate - We should skip add validate config.
+	if res.IsValidConfig() && !res.IsRootCertificate() {
+		validateClient = false
 	}
 
 	// configure server listeners with SDS.

--- a/pilot/pkg/security/model/authentication.go
+++ b/pilot/pkg/security/model/authentication.go
@@ -251,7 +251,7 @@ func appendURIPrefixToTrustDomain(trustDomainAliases []string) []string {
 
 // ApplyToCommonTLSContext completes the commonTlsContext
 func ApplyToCommonTLSContext(tlsContext *tls.CommonTlsContext, proxy *model.Proxy,
-	subjectAltNames []string, trustDomainAliases []string) {
+	subjectAltNames []string, trustDomainAliases []string, validateClient bool) {
 	// These are certs being mounted from within the pod. Rather than reading directly in Envoy,
 	// which does not support rotation, we will serve them over SDS by reading the files.
 	// We should check if these certs have values, if yes we should use them or otherwise fall back to defaults.
@@ -269,11 +269,13 @@ func ApplyToCommonTLSContext(tlsContext *tls.CommonTlsContext, proxy *model.Prox
 	}
 
 	// configure server listeners with SDS.
-	tlsContext.ValidationContextType = &tls.CommonTlsContext_CombinedValidationContext{
-		CombinedValidationContext: &tls.CommonTlsContext_CombinedCertificateValidationContext{
-			DefaultValidationContext:         &tls.CertificateValidationContext{MatchSubjectAltNames: matchSAN},
-			ValidationContextSdsSecretConfig: ConstructSdsSecretConfig(model.GetOrDefault(res.GetRootResourceName(), SDSRootResourceName), proxy),
-		},
+	if validateClient {
+		tlsContext.ValidationContextType = &tls.CommonTlsContext_CombinedValidationContext{
+			CombinedValidationContext: &tls.CommonTlsContext_CombinedCertificateValidationContext{
+				DefaultValidationContext:         &tls.CertificateValidationContext{MatchSubjectAltNames: matchSAN},
+				ValidationContextSdsSecretConfig: ConstructSdsSecretConfig(model.GetOrDefault(res.GetRootResourceName(), SDSRootResourceName), proxy),
+			},
+		}
 	}
 	tlsContext.TlsCertificateSdsSecretConfigs = []*tls.SdsSecretConfig{
 		ConstructSdsSecretConfig(model.GetOrDefault(res.GetResourceName(), SDSDefaultResourceName), proxy),

--- a/pilot/pkg/security/model/authentication_test.go
+++ b/pilot/pkg/security/model/authentication_test.go
@@ -138,6 +138,7 @@ func TestApplyToCommonTLSContext(t *testing.T) {
 		name               string
 		node               *model.Proxy
 		trustDomainAliases []string
+		validateClient     bool
 		expected           *auth.CommonTlsContext
 	}{
 		{
@@ -145,6 +146,7 @@ func TestApplyToCommonTLSContext(t *testing.T) {
 			node: &model.Proxy{
 				Metadata: &model.NodeMetadata{},
 			},
+			validateClient: true,
 			expected: &auth.CommonTlsContext{
 				TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{
 					{
@@ -202,6 +204,7 @@ func TestApplyToCommonTLSContext(t *testing.T) {
 			node: &model.Proxy{
 				Metadata: &model.NodeMetadata{},
 			},
+			validateClient:     true,
 			trustDomainAliases: []string{"alias-1.domain", "some-other-alias-1.domain", "alias-2.domain"},
 			expected: &auth.CommonTlsContext{
 				TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{
@@ -268,6 +271,7 @@ func TestApplyToCommonTLSContext(t *testing.T) {
 					TLSServerRootCert:  "servrRootCert",
 				},
 			},
+			validateClient: true,
 			expected: &auth.CommonTlsContext{
 				TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{
 					{
@@ -323,6 +327,7 @@ func TestApplyToCommonTLSContext(t *testing.T) {
 			node: &model.Proxy{
 				Metadata: &model.NodeMetadata{},
 			},
+			validateClient: true,
 			expected: &auth.CommonTlsContext{
 				TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{
 					{
@@ -384,65 +389,7 @@ func TestApplyToCommonTLSContext(t *testing.T) {
 					TLSServerRootCert:  "/custom/path/to/root.pem",
 				},
 			},
-			expected: &auth.CommonTlsContext{
-				TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{
-					{
-						Name: "file-cert:/custom/path/to/cert-chain.pem~/custom-key.pem",
-						SdsConfig: &core.ConfigSource{
-							ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
-								ApiConfigSource: &core.ApiConfigSource{
-									ApiType:                   core.ApiConfigSource_GRPC,
-									SetNodeOnFirstMessageOnly: true,
-									TransportApiVersion:       core.ApiVersion_V3,
-									GrpcServices: []*core.GrpcService{
-										{
-											TargetSpecifier: &core.GrpcService_EnvoyGrpc_{
-												EnvoyGrpc: &core.GrpcService_EnvoyGrpc{ClusterName: SDSClusterName},
-											},
-										},
-									},
-								},
-							},
-							ResourceApiVersion: core.ApiVersion_V3,
-						},
-					},
-				},
-				ValidationContextType: &auth.CommonTlsContext_CombinedValidationContext{
-					CombinedValidationContext: &auth.CommonTlsContext_CombinedCertificateValidationContext{
-						DefaultValidationContext: &auth.CertificateValidationContext{},
-						ValidationContextSdsSecretConfig: &auth.SdsSecretConfig{
-							Name: "file-root:/custom/path/to/root.pem",
-							SdsConfig: &core.ConfigSource{
-								ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
-									ApiConfigSource: &core.ApiConfigSource{
-										ApiType:                   core.ApiConfigSource_GRPC,
-										SetNodeOnFirstMessageOnly: true,
-										TransportApiVersion:       core.ApiVersion_V3,
-										GrpcServices: []*core.GrpcService{
-											{
-												TargetSpecifier: &core.GrpcService_EnvoyGrpc_{
-													EnvoyGrpc: &core.GrpcService_EnvoyGrpc{ClusterName: SDSClusterName},
-												},
-											},
-										},
-									},
-								},
-								ResourceApiVersion: core.ApiVersion_V3,
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "SIMPLE with custom cert paths from proxy node metadata",
-			node: &model.Proxy{
-				Metadata: &model.NodeMetadata{
-					TLSServerCertChain: "/custom/path/to/cert-chain.pem",
-					TLSServerKey:       "/custom-key.pem",
-					TLSServerRootCert:  "/custom/path/to/root.pem",
-				},
-			},
+			validateClient: true,
 			expected: &auth.CommonTlsContext{
 				TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{
 					{
@@ -501,6 +448,7 @@ func TestApplyToCommonTLSContext(t *testing.T) {
 					TLSServerKey:       "/custom-key.pem",
 				},
 			},
+			validateClient: false,
 			expected: &auth.CommonTlsContext{
 				TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{
 					{
@@ -531,7 +479,7 @@ func TestApplyToCommonTLSContext(t *testing.T) {
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			tlsContext := &auth.CommonTlsContext{}
-			ApplyToCommonTLSContext(tlsContext, test.node, []string{}, test.trustDomainAliases)
+			ApplyToCommonTLSContext(tlsContext, test.node, []string{}, test.trustDomainAliases, test.validateClient)
 
 			if !cmp.Equal(tlsContext, test.expected, protocmp.Transform()) {
 				t.Errorf("got(%#v), want(%#v)\n", spew.Sdump(tlsContext), spew.Sdump(test.expected))

--- a/pilot/pkg/security/model/authentication_test.go
+++ b/pilot/pkg/security/model/authentication_test.go
@@ -138,6 +138,7 @@ func TestApplyToCommonTLSContext(t *testing.T) {
 		name               string
 		node               *model.Proxy
 		trustDomainAliases []string
+		validateClient     bool
 		expected           *auth.CommonTlsContext
 	}{
 		{
@@ -145,6 +146,7 @@ func TestApplyToCommonTLSContext(t *testing.T) {
 			node: &model.Proxy{
 				Metadata: &model.NodeMetadata{},
 			},
+			validateClient: true,
 			expected: &auth.CommonTlsContext{
 				TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{
 					{
@@ -202,6 +204,7 @@ func TestApplyToCommonTLSContext(t *testing.T) {
 			node: &model.Proxy{
 				Metadata: &model.NodeMetadata{},
 			},
+			validateClient:     true,
 			trustDomainAliases: []string{"alias-1.domain", "some-other-alias-1.domain", "alias-2.domain"},
 			expected: &auth.CommonTlsContext{
 				TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{
@@ -268,6 +271,7 @@ func TestApplyToCommonTLSContext(t *testing.T) {
 					TLSServerRootCert:  "servrRootCert",
 				},
 			},
+			validateClient: true,
 			expected: &auth.CommonTlsContext{
 				TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{
 					{
@@ -323,6 +327,7 @@ func TestApplyToCommonTLSContext(t *testing.T) {
 			node: &model.Proxy{
 				Metadata: &model.NodeMetadata{},
 			},
+			validateClient: true,
 			expected: &auth.CommonTlsContext{
 				TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{
 					{
@@ -384,6 +389,7 @@ func TestApplyToCommonTLSContext(t *testing.T) {
 					TLSServerRootCert:  "/custom/path/to/root.pem",
 				},
 			},
+			validateClient: true,
 			expected: &auth.CommonTlsContext{
 				TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{
 					{
@@ -434,12 +440,46 @@ func TestApplyToCommonTLSContext(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "SIMPLE with custom cert paths from proxy node metadata",
+			node: &model.Proxy{
+				Metadata: &model.NodeMetadata{
+					TLSServerCertChain: "/custom/path/to/cert-chain.pem",
+					TLSServerKey:       "/custom-key.pem",
+				},
+			},
+			validateClient: false,
+			expected: &auth.CommonTlsContext{
+				TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{
+					{
+						Name: "file-cert:/custom/path/to/cert-chain.pem~/custom-key.pem",
+						SdsConfig: &core.ConfigSource{
+							ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
+								ApiConfigSource: &core.ApiConfigSource{
+									ApiType:                   core.ApiConfigSource_GRPC,
+									SetNodeOnFirstMessageOnly: true,
+									TransportApiVersion:       core.ApiVersion_V3,
+									GrpcServices: []*core.GrpcService{
+										{
+											TargetSpecifier: &core.GrpcService_EnvoyGrpc_{
+												EnvoyGrpc: &core.GrpcService_EnvoyGrpc{ClusterName: SDSClusterName},
+											},
+										},
+									},
+								},
+							},
+							ResourceApiVersion: core.ApiVersion_V3,
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			tlsContext := &auth.CommonTlsContext{}
-			ApplyToCommonTLSContext(tlsContext, test.node, []string{}, test.trustDomainAliases)
+			ApplyToCommonTLSContext(tlsContext, test.node, []string{}, test.trustDomainAliases, test.validateClient)
 
 			if !cmp.Equal(tlsContext, test.expected, protocmp.Transform()) {
 				t.Errorf("got(%#v), want(%#v)\n", spew.Sdump(tlsContext), spew.Sdump(test.expected))


### PR DESCRIPTION
We are currently adding validation context for SIMPLE mode which is not needed if cacerts are not present and is failing if gateway specifies certs via files without caCertificate, as `model.GetRootResourceName` returns `ROOTCA` as cert is not provided and SDS fails to fetch.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any changes that may affect Istio users.
