### PR TITLE
Fix vs/gateway/dr event handler been registered twice

### DIFF
--- a/pilot/pkg/config/kube/gateway/controller.go
+++ b/pilot/pkg/config/kube/gateway/controller.go
@@ -154,9 +154,7 @@ func (c controller) Delete(typ config.GroupVersionKind, name, namespace string, 
 }
 
 func (c controller) RegisterEventHandler(typ config.GroupVersionKind, handler func(config.Config, config.Config, model.Event)) {
-	c.cache.RegisterEventHandler(typ, func(prev, cur config.Config, event model.Event) {
-		handler(prev, cur, event)
-	})
+	// do nothing as c.cache has been registered
 }
 
 func (c controller) Run(stop <-chan struct{}) {


### PR DESCRIPTION
k8s gateway controller actually contains the crd cache, but it is also added to istio config store. So for vs/gw/dr , there are 2 duplicate handlers registered