### PR TITLE
Add createNamespace flag to istio-operator Helm chart

### DIFF
--- a/manifests/charts/istio-operator/templates/namespace.yaml
+++ b/manifests/charts/istio-operator/templates/namespace.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.createNamespace }}
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -6,3 +7,4 @@ metadata:
     istio-operator-managed: Reconcile
     istio-injection: disabled
 ---
+{{- end }}

--- a/manifests/charts/istio-operator/values.yaml
+++ b/manifests/charts/istio-operator/values.yaml
@@ -27,3 +27,5 @@ operator:
       cpu: 50m
       memory: 128Mi
 
+# Flag to create (or not) operator's namespace
+createNamespace: true


### PR DESCRIPTION
Performing a canary release of istio-operator using Helm fails when the original deployment was installed with Helm too as its namespace is already created. To reproduce it:
```bash
helm install -n istio-system --create-namespace istio-operator-1-9-0 manifests/charts/istio-operator --set revision=1-9-0
# This would fail
helm install -n istio-system --create-namespace istio-operator-1-9-1 manifests/charts/istio-operator --set revision=1-9-1
```
I'd like to suggest adding a new flag _createNamespace_ to the Helm chart:
```bash
helm install -n istio-system --create-namespace istio-operator-1-9-1 manifests/charts/istio-operator --set revision=1-9-1 --set createNamespace=false
```

[ ] Configuration Infrastructure
[ ] Docs
[X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any changes that may affect Istio users.
