### PR TITLE
[release-1.9] Manual cherrypick of #31323 #31331 #31343

### DIFF
--- a/tools/build-base-images.sh
+++ b/tools/build-base-images.sh
@@ -21,6 +21,21 @@ set -ex
 
 HUBS="${HUBS:?specify a space seperated list of hubs}"
 TAG="${TAG:?specify a tag}"
+DOCKER_TARGETS="${DOCKER_TARGETS:-docker.base docker.distroless docker.app_sidecar_base_debian_9 docker.app_sidecar_base_debian_10 docker.app_sidecar_base_ubuntu_xenial docker.app_sidecar_base_ubuntu_bionic docker.app_sidecar_base_ubuntu_focal docker.app_sidecar_base_centos_7 docker.app_sidecar_base_centos_8}"
+
+# Verify that the specified TAG does not exist for the HUBS/TARGETS
+# Will also fail if user doesn't have authorization to repository, but they shouldn't
+# be able to push if no authorization.
+# What other errors might happen that would be ignored ?
+set +e
+for hub in ${HUBS}
+do
+  for image in ${DOCKER_TARGETS#docker.}  # assume the image name is the target without the leading docker.
+  do
+    docker manifest inspect "$hub"/"$image":"$TAG" && exit 1 # will exit if it finds the manifest
+  done
+done
+set -e
 
 # For multi architecture building:
 # See https://medium.com/@artur.klauser/building-multi-architecture-docker-images-with-buildx-27d80f7e2408 for more info
@@ -29,4 +44,4 @@ TAG="${TAG:?specify a tag}"
 # * export DOCKER_ARCHITECTURES="linux/amd64,linux/arm64"
 # Note: if you already have a container builder before running the qemu setup you will need to restart them
 
-BUILDX_BAKE_EXTRA_OPTIONS="--no-cache --pull" DOCKER_TARGETS="docker.base docker.distroless docker.app_sidecar_base_debian_9 docker.app_sidecar_base_debian_10 docker.app_sidecar_base_ubuntu_xenial docker.app_sidecar_base_ubuntu_bionic docker.app_sidecar_base_ubuntu_focal docker.app_sidecar_base_centos_7 docker.app_sidecar_base_centos_8" make dockerx.pushx
+BUILDX_BAKE_EXTRA_OPTIONS="--no-cache --pull" DOCKER_TARGETS="${DOCKER_TARGETS}" make dockerx.pushx


### PR DESCRIPTION
This is a manual cherrypick of #31323 #31331 #31343. Those PRs, but two more cherrypicked earlier make up the changes to tools/build-base-images.sh so that it can be called during a release-builder build to actually create new base images.

This PR along with a forthcoming cherry-pick of the release builder PR combine so that when a new release build is being done, and the base images contain a vulnerability, the automation should create a new base image using this script, and then a PR will be created containing the required update to have the new image be used. The RM should see the build failed, merge the new PR containing the image name update, and be able to kick off another build which should pass, removing the need to find someone who can build a new set of base images.

Please check any characteristics that apply to this pull request. 

[x] Does not have any changes that may affect Istio users.
