### PR TITLE
Drop echo default timeout

### DIFF
--- a/pkg/test/echo/common/util.go
+++ b/pkg/test/echo/common/util.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	ConnectionTimeout     = 2 * time.Second
-	DefaultRequestTimeout = 15 * time.Second
+	DefaultRequestTimeout = 5 * time.Second
 	DefaultCount          = 1
 )
 

--- a/pkg/test/framework/components/echo/call.go
+++ b/pkg/test/framework/components/echo/call.go
@@ -58,7 +58,7 @@ type CallOptions struct {
 	// If no Host header is provided, a default will be chosen for the target service endpoint.
 	Headers http.Header
 
-	// Timeout used for each individual request. Must be > 0, otherwise 30 seconds is used.
+	// Timeout used for each individual request. Must be > 0, otherwise 5 seconds is used.
 	Timeout time.Duration
 
 	// Message to be sent if this is a GRPC request


### PR DESCRIPTION
I've seen some cases of test flakes where I think what happens is we hang for 15s on a bad connection and then we hit our total timeout too soon. If we had justretried earlier, we would have succeeded. 15s is super high anyways - even 5s is quite high