### PR TITLE
Remove meshconfig/injector configmap mount

### DIFF
--- a/galley/pkg/server/components/processing.go
+++ b/galley/pkg/server/components/processing.go
@@ -63,7 +63,8 @@ func (p *Processing) Start() (err error) {
 	if p.args.MeshSource != nil {
 		mesh = p.args.MeshSource
 	} else {
-		if mesh, err = meshcfgNewFS(p.args.MeshConfigFile); err != nil {
+		mesh, err = meshcfgNewFS(p.args.MeshConfigFile)
+		if err != nil {
 			return
 		}
 	}

--- a/galley/pkg/server/components/processing.go
+++ b/galley/pkg/server/components/processing.go
@@ -60,8 +60,12 @@ func (p *Processing) Start() (err error) {
 	var src event.Source
 	var updater snapshotter.StatusUpdater
 
-	if mesh, err = meshcfgNewFS(p.args.MeshConfigFile); err != nil {
-		return
+	if p.args.MeshSource != nil {
+		mesh = p.args.MeshSource
+	} else {
+		if mesh, err = meshcfgNewFS(p.args.MeshConfigFile); err != nil {
+			return
+		}
 	}
 
 	m := schema.MustGet()

--- a/galley/pkg/server/settings/args.go
+++ b/galley/pkg/server/settings/args.go
@@ -23,6 +23,7 @@ import (
 
 	"istio.io/istio/galley/pkg/config/util/kuberesource"
 	"istio.io/istio/pkg/config/constants"
+	"istio.io/istio/pkg/config/event"
 	"istio.io/istio/pkg/config/schema/snapshots"
 )
 
@@ -48,6 +49,7 @@ type Args struct { // nolint:maligned
 
 	// MeshConfigFile is the path for mesh config
 	MeshConfigFile string
+	MeshSource     event.Source
 
 	// DNS Domain suffix to use while constructing Ingress based resources.
 	DomainSuffix string

--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -1082,8 +1082,6 @@ spec:
               drop:
               - ALL
           volumeMounts:
-          - name: config-volume
-            mountPath: /etc/istio/config
           - name: istio-token
             mountPath: /var/run/secrets/tokens
             readOnly: true
@@ -1094,9 +1092,6 @@ spec:
             readOnly: true
           - name: istio-kubeconfig
             mountPath: /var/run/secrets/remote
-            readOnly: true
-          - name: inject
-            mountPath: /var/lib/istio/inject
             readOnly: true
       volumes:
       # Technically not needed on this pod - but it helps debugging/testing SDS
@@ -1120,13 +1115,6 @@ spec:
         secret:
           secretName: istio-kubeconfig
           optional: true
-      # Optional - image should have
-      - name: inject
-        configMap:
-          name: istio-sidecar-injector
-      - name: config-volume
-        configMap:
-          name: istio
 ---
 # Source: istio-discovery/templates/autoscale.yaml
 apiVersion: autoscaling/v2beta1

--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -168,8 +168,6 @@ spec:
               drop:
               - ALL
           volumeMounts:
-          - name: config-volume
-            mountPath: /etc/istio/config
           {{- if eq .Values.global.jwtPolicy "third-party-jwt" }}
           - name: istio-token
             mountPath: /var/run/secrets/tokens
@@ -182,9 +180,6 @@ spec:
             readOnly: true
           - name: istio-kubeconfig
             mountPath: /var/run/secrets/remote
-            readOnly: true
-          - name: inject
-            mountPath: /var/lib/istio/inject
             readOnly: true
           {{- if .Values.pilot.jwksResolverExtraRootCA }}
           - name: extracacerts
@@ -214,13 +209,6 @@ spec:
         secret:
           secretName: istio-kubeconfig
           optional: true
-      # Optional - image should have
-      - name: inject
-        configMap:
-          name: istio-sidecar-injector{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-      - name: config-volume
-        configMap:
-          name: istio{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.pilot.jwksResolverExtraRootCA }}
       - name: extracacerts
         configMap:

--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
+	"istio.io/istio/galley/pkg/config/mesh"
 	"istio.io/istio/galley/pkg/server/components"
 	"istio.io/istio/galley/pkg/server/settings"
 	configaggregate "istio.io/istio/pilot/pkg/config/aggregate"
@@ -241,8 +242,12 @@ func (s *Server) initInprocessAnalysisController(args *PilotArgs) error {
 	processingArgs := settings.DefaultArgs()
 	processingArgs.KubeConfig = args.RegistryOptions.KubeConfig
 	processingArgs.WatchedNamespaces = args.RegistryOptions.KubeOptions.WatchedNamespaces
-	processingArgs.MeshConfigFile = args.MeshConfigFile
 	processingArgs.EnableConfigAnalysis = true
+	meshSource := mesh.NewInmemoryMeshCfg()
+	s.environment.Watcher.AddMeshHandler(func() {
+		meshSource.Set(s.environment.Mesh())
+	})
+	processingArgs.MeshSource = meshSource
 
 	processing := components.NewProcessing(processingArgs)
 

--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -244,6 +244,7 @@ func (s *Server) initInprocessAnalysisController(args *PilotArgs) error {
 	processingArgs.WatchedNamespaces = args.RegistryOptions.KubeOptions.WatchedNamespaces
 	processingArgs.EnableConfigAnalysis = true
 	meshSource := mesh.NewInmemoryMeshCfg()
+	meshSource.Set(s.environment.Mesh())
 	s.environment.Watcher.AddMeshHandler(func() {
 		meshSource.Set(s.environment.Mesh())
 	})


### PR DESCRIPTION
We have had code to read these from configmap for a while. This makes us use that. The benefit is that the configmap watch updates immediately instead of 1-2 minutes later, and works well in external istiod.

As part of this, update galley code to also read from the s.environment mesh config. In practice, this mesh config is never actually used. In theory it feeds analyzers, but only one uses it, and that one doesn't run in cluster.