### PR TITLE
do not set max stream duration

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -398,14 +398,13 @@ func translateRoute(push *model.PushContext, node *model.Proxy, in *networking.H
 			action.Timeout = features.DefaultRequestTimeout
 		}
 
-		// Disable MaxStream duration to let the request timeout/gRPC timeout drive the timeout for request.
-		action.MaxStreamDuration = &route.RouteAction_MaxStreamDuration{MaxStreamDuration: ptypes.DurationProto(0)}
-
 		// Set the GrpcTimeoutHeaderMax so that Envoy respects grpc-timeout header.
 		// Only set if explicit timeout is defined otherwise Envoy will just use grpc-timeout header
 		// instead of disabling the timeout which is Istio's default behavior.
 		if action.Timeout.AsDuration().Nanoseconds() > 0 {
-			action.MaxStreamDuration.GrpcTimeoutHeaderMax = action.Timeout
+			action.MaxStreamDuration = &route.RouteAction_MaxStreamDuration{
+				GrpcTimeoutHeaderMax: action.Timeout,
+			}
 		}
 		out.Action = &route.Route_Route{Route: action}
 

--- a/pilot/pkg/networking/core/v1alpha3/route/route_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route_test.go
@@ -80,8 +80,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		g.Expect(len(routes)).To(gomega.Equal(1))
 		// Validate that when timeout is not specified, we disable it based on default value of flag.
 		g.Expect(routes[0].GetRoute().Timeout.Seconds).To(gomega.Equal(int64(0)))
-		g.Expect(routes[0].GetRoute().MaxStreamDuration.MaxStreamDuration.Seconds).To(gomega.Equal(int64(0)))
-		g.Expect(routes[0].GetRoute().MaxStreamDuration.GrpcTimeoutHeaderMax).To(gomega.BeNil())
+		g.Expect(routes[0].GetRoute().MaxStreamDuration).To(gomega.BeNil())
 	})
 
 	t.Run("for virtual service with changed default timeout", func(t *testing.T) {
@@ -98,7 +97,6 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		g.Expect(len(routes)).To(gomega.Equal(1))
 		// Validate that when timeout is not specified, we send what is set in the timeout flag.
 		g.Expect(routes[0].GetRoute().Timeout.Seconds).To(gomega.Equal(int64(1)))
-		g.Expect(routes[0].GetRoute().MaxStreamDuration.MaxStreamDuration.Seconds).To(gomega.Equal(int64(0)))
 		g.Expect(routes[0].GetRoute().MaxStreamDuration.GrpcTimeoutHeaderMax.Seconds).To(gomega.Equal(int64(1)))
 	})
 
@@ -112,7 +110,6 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		g.Expect(len(routes)).To(gomega.Equal(1))
 		// Validate that when timeout specified, we send the configured timeout to Envoys.
 		g.Expect(routes[0].GetRoute().Timeout.Seconds).To(gomega.Equal(int64(10)))
-		g.Expect(routes[0].GetRoute().MaxStreamDuration.MaxStreamDuration.Seconds).To(gomega.Equal(int64(0)))
 		g.Expect(routes[0].GetRoute().MaxStreamDuration.GrpcTimeoutHeaderMax.Seconds).To(gomega.Equal(int64(10)))
 	})
 
@@ -125,8 +122,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 		g.Expect(len(routes)).To(gomega.Equal(1))
 		g.Expect(routes[0].GetRoute().Timeout.Seconds).To(gomega.Equal(int64(0)))
-		g.Expect(routes[0].GetRoute().MaxStreamDuration.MaxStreamDuration.Seconds).To(gomega.Equal(int64(0)))
-		g.Expect(routes[0].GetRoute().MaxStreamDuration.GrpcTimeoutHeaderMax).To(gomega.BeNil())
+		g.Expect(routes[0].GetRoute().MaxStreamDuration).To(gomega.BeNil())
 	})
 
 	t.Run("for virtual service with catch all route", func(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/31317

Essentially a revert of https://github.com/istio/istio/pull/30885 because now we can not set `max_stream_duration` to 0s as it disables timeouts altogether.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ X] Does not have any changes that may affect Istio users.
