### PR TITLE
Make istio.io/rev=default inject for default revision

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -1986,6 +1986,66 @@ metadata:
     app: sidecar-injector
     release: istio
 webhooks:
+- name: rev.namespace.sidecar-injector.istio.io
+  clientConfig:
+    service:
+      name: istiod
+      namespace: istio-system
+      path: "/inject"
+    caBundle: ""
+  sideEffects: None
+  rules:
+  - operations: [ "CREATE" ]
+    apiGroups: [""]
+    apiVersions: ["v1"]
+    resources: ["pods"]
+  failurePolicy: Fail
+  admissionReviewVersions: ["v1beta1", "v1"]
+  namespaceSelector:
+    matchExpressions:
+    - key: istio.io/rev
+      operator: In
+      values:
+      - "default"
+    - key: istio-injection
+      operator: DoesNotExist
+  objectSelector:
+    matchExpressions:
+    - key: sidecar.istio.io/inject
+      operator: NotIn
+      values:
+      - "false"
+- name: rev.object.sidecar-injector.istio.io
+  clientConfig:
+    service:
+      name: istiod
+      namespace: istio-system
+      path: "/inject"
+    caBundle: ""
+  sideEffects: None
+  rules:
+  - operations: [ "CREATE" ]
+    apiGroups: [""]
+    apiVersions: ["v1"]
+    resources: ["pods"]
+  failurePolicy: Fail
+  admissionReviewVersions: ["v1beta1", "v1"]
+  namespaceSelector:
+    matchExpressions:
+    - key: istio.io/rev
+      operator: DoesNotExist
+    - key: istio-injection
+      operator: DoesNotExist
+  objectSelector:
+    matchExpressions:
+    - key: sidecar.istio.io/inject
+      operator: NotIn
+      values:
+      - "false"
+    - key: istio.io/rev
+      operator: In
+      values:
+      - "default"
 - name: namespace.sidecar-injector.istio.io
   clientConfig:
     service:

--- a/manifests/charts/istio-control/istio-discovery/templates/mutatingwebhook.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/mutatingwebhook.yaml
@@ -92,18 +92,21 @@ webhooks:
   {{- end }}
 {{- else }}
 
-{{- /* Set up the selectors. First section is for revision, rest is for "default" revision */}}
-{{- if .Values.revision }}
+  {{- /* Set up the selectors. First section is for revision, rest is for "default" revision */}}
 
 {{- /* Case 1: namespace selector matches, and object doesn't disable */}}
 {{- /* Note: if both revision and legacy selector, we give precedence to the legacy one */}}
-{{- include "core" (mergeOverwrite (deepCopy .) (dict "Prefix" "namespace.") ) }}
+{{- include "core" (mergeOverwrite (deepCopy .) (dict "Prefix" "rev.namespace.") ) }}
   namespaceSelector:
     matchExpressions:
     - key: istio.io/rev
       operator: In
       values:
+      {{- if (eq .Values.revision "") }}
+      - "default"
+      {{- else }}
       - "{{ .Values.revision }}"
+      {{- end }}
     - key: istio-injection
       operator: DoesNotExist
   objectSelector:
@@ -114,7 +117,7 @@ webhooks:
       - "false"
 
 {{- /* Case 2: No namespace selector, but object selects our revision (and doesn't disable) */}}
-{{- include "core" (mergeOverwrite (deepCopy .) (dict "Prefix" "object.") ) }}
+{{- include "core" (mergeOverwrite (deepCopy .) (dict "Prefix" "rev.object.") ) }}
   namespaceSelector:
     matchExpressions:
     - key: istio.io/rev
@@ -130,10 +133,15 @@ webhooks:
     - key: istio.io/rev
       operator: In
       values:
+      {{- if (eq .Values.revision "") }}
+      - "default"
+      {{- else }}
       - "{{ .Values.revision }}"
+      {{- end }}
 
-{{- else }}
-{{- /* "default" revision */}}
+
+{{- /* Webhooks for default revision */}}
+{{- if (eq .Values.revision "") }}
 
 {{- /* Case 1: Namespace selector enabled, and object selector is not injected */}}
 {{- include "core" (mergeOverwrite (deepCopy .) (dict "Prefix" "namespace.") ) }}

--- a/manifests/charts/istiod-remote/files/gen-istiod-remote.yaml
+++ b/manifests/charts/istiod-remote/files/gen-istiod-remote.yaml
@@ -927,6 +927,66 @@ metadata:
     app: sidecar-injector
     release: istiod-remote
 webhooks:
+- name: rev.namespace.sidecar-injector.istio.io
+  clientConfig:
+    service:
+      name: istiod
+      namespace: istio-system
+      path: "/inject"
+    caBundle: ""
+  sideEffects: None
+  rules:
+  - operations: [ "CREATE" ]
+    apiGroups: [""]
+    apiVersions: ["v1"]
+    resources: ["pods"]
+  failurePolicy: Fail
+  admissionReviewVersions: ["v1beta1", "v1"]
+  namespaceSelector:
+    matchExpressions:
+    - key: istio.io/rev
+      operator: In
+      values:
+      - "default"
+    - key: istio-injection
+      operator: DoesNotExist
+  objectSelector:
+    matchExpressions:
+    - key: sidecar.istio.io/inject
+      operator: NotIn
+      values:
+      - "false"
+- name: rev.object.sidecar-injector.istio.io
+  clientConfig:
+    service:
+      name: istiod
+      namespace: istio-system
+      path: "/inject"
+    caBundle: ""
+  sideEffects: None
+  rules:
+  - operations: [ "CREATE" ]
+    apiGroups: [""]
+    apiVersions: ["v1"]
+    resources: ["pods"]
+  failurePolicy: Fail
+  admissionReviewVersions: ["v1beta1", "v1"]
+  namespaceSelector:
+    matchExpressions:
+    - key: istio.io/rev
+      operator: DoesNotExist
+    - key: istio-injection
+      operator: DoesNotExist
+  objectSelector:
+    matchExpressions:
+    - key: sidecar.istio.io/inject
+      operator: NotIn
+      values:
+      - "false"
+    - key: istio.io/rev
+      operator: In
+      values:
+      - "default"
 - name: namespace.sidecar-injector.istio.io
   clientConfig:
     service:

--- a/manifests/charts/istiod-remote/templates/mutatingwebhook.yaml
+++ b/manifests/charts/istiod-remote/templates/mutatingwebhook.yaml
@@ -92,18 +92,21 @@ webhooks:
   {{- end }}
 {{- else }}
 
-{{- /* Set up the selectors. First section is for revision, rest is for "default" revision */}}
-{{- if .Values.revision }}
+  {{- /* Set up the selectors. First section is for revision, rest is for "default" revision */}}
 
 {{- /* Case 1: namespace selector matches, and object doesn't disable */}}
 {{- /* Note: if both revision and legacy selector, we give precedence to the legacy one */}}
-{{- include "core" (mergeOverwrite (deepCopy .) (dict "Prefix" "namespace.") ) }}
+{{- include "core" (mergeOverwrite (deepCopy .) (dict "Prefix" "rev.namespace.") ) }}
   namespaceSelector:
     matchExpressions:
     - key: istio.io/rev
       operator: In
       values:
+      {{- if (eq .Values.revision "") }}
+      - "default"
+      {{- else }}
       - "{{ .Values.revision }}"
+      {{- end }}
     - key: istio-injection
       operator: DoesNotExist
   objectSelector:
@@ -114,7 +117,7 @@ webhooks:
       - "false"
 
 {{- /* Case 2: No namespace selector, but object selects our revision (and doesn't disable) */}}
-{{- include "core" (mergeOverwrite (deepCopy .) (dict "Prefix" "object.") ) }}
+{{- include "core" (mergeOverwrite (deepCopy .) (dict "Prefix" "rev.object.") ) }}
   namespaceSelector:
     matchExpressions:
     - key: istio.io/rev
@@ -130,10 +133,15 @@ webhooks:
     - key: istio.io/rev
       operator: In
       values:
+      {{- if (eq .Values.revision "") }}
+      - "default"
+      {{- else }}
       - "{{ .Values.revision }}"
+      {{- end }}
 
-{{- else }}
-{{- /* "default" revision */}}
+
+{{- /* Webhooks for default revision */}}
+{{- if (eq .Values.revision "") }}
 
 {{- /* Case 1: Namespace selector enabled, and object selector is not injected */}}
 {{- include "core" (mergeOverwrite (deepCopy .) (dict "Prefix" "namespace.") ) }}

--- a/releasenotes/notes/add-default-revision-webhook.yaml
+++ b/releasenotes/notes/add-default-revision-webhook.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+releaseNotes:
+  - |
+    **Updated** non-revisioned installs to target the label `istio.io/rev=default` for injection in addition to the
+    existing default injection labels `istio-injection=enabled` and `sidecar.istio.io/inject=true`.


### PR DESCRIPTION
Makes it so that labeling namespace or workload `istio.io/rev=default` will result in injection for a non-revisioned install, blocker for https://github.com/istio/istio.io/pull/9192

[ ] Configuration Infrastructure
[ ] Docs
[x] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
