### PR TITLE
[release-1.9] Make test framework version-aware (#31150)

### DIFF
--- a/pkg/test/framework/analyzer.go
+++ b/pkg/test/framework/analyzer.go
@@ -32,15 +32,16 @@ import (
 type commonAnalyzer struct {
 	labels                  label.Set
 	minCusters, maxClusters int
-	skip                    string
+	minIstioVersion, skip   string
 }
 
 func newCommonAnalyzer() commonAnalyzer {
 	return commonAnalyzer{
-		labels:      label.NewSet(),
-		skip:        "",
-		minCusters:  1,
-		maxClusters: -1,
+		labels:          label.NewSet(),
+		skip:            "",
+		minIstioVersion: "",
+		minCusters:      1,
+		maxClusters:     -1,
 	}
 }
 
@@ -197,6 +198,11 @@ func (t *testAnalyzer) RequiresMinClusters(minClusters int) Test {
 
 func (t *testAnalyzer) RequiresMaxClusters(maxClusters int) Test {
 	t.maxClusters = maxClusters
+	return t
+}
+
+func (t *testAnalyzer) RequireIstioVersion(version string) Test {
+	t.minIstioVersion = version
 	return t
 }
 

--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -89,13 +89,19 @@ spec:
 `
 
 	deploymentYAML = `
+{{- $revVerMap := .IstioVersions }}
 {{- $subsets := .Subsets }}
 {{- $cluster := .Cluster }}
 {{- range $i, $subset := $subsets }}
+{{- range $revision, $version := $revVerMap }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+{{- if $.IsMultiVersion }}
+  name: {{ $.Service }}-{{ $subset.Version }}-{{ $revision }}
+{{- else }}
   name: {{ $.Service }}-{{ $subset.Version }}
+{{- end }}
 spec:
   replicas: 1
   selector:
@@ -110,6 +116,9 @@ spec:
       labels:
         app: {{ $.Service }}
         version: {{ $subset.Version }}
+{{- if $.IsMultiVersion }}
+        istio.io/rev: {{ $revision }}
+{{- end }}
 {{- if ne $.Locality "" }}
         istio-locality: {{ $.Locality }}
 {{- end }}
@@ -228,9 +237,10 @@ spec:
       - configMap:
           name: {{ $.Service }}-certs
         name: custom-certs
-{{- end}}
+{{- end }}
 ---
-{{- end}}
+{{- end }}
+{{- end }}
 {{- if .TLSSettings }}
 apiVersion: v1
 kind: ConfigMap
@@ -438,7 +448,7 @@ func newDeployment(ctx resource.Context, cfg echo.Config) (*deployment, error) {
 		}
 	}
 
-	deploymentYAML, err := generateDeploymentYAML(cfg, nil)
+	deploymentYAML, err := generateDeploymentYAML(cfg, nil, ctx.Settings().IstioVersions)
 	if err != nil {
 		return nil, fmt.Errorf("failed generating echo deployment YAML for %s/%s",
 			cfg.Namespace.Name(),
@@ -535,8 +545,8 @@ spec:
 `, name, podIP, sa, network, service, version)
 }
 
-func generateDeploymentYAML(cfg echo.Config, settings *image.Settings) (string, error) {
-	params, err := templateParams(cfg, settings)
+func generateDeploymentYAML(cfg echo.Config, settings *image.Settings, versions resource.RevVerMap) (string, error) {
+	params, err := templateParams(cfg, settings, versions)
 	if err != nil {
 		return "", err
 	}
@@ -550,7 +560,7 @@ func generateDeploymentYAML(cfg echo.Config, settings *image.Settings) (string, 
 }
 
 func GenerateService(cfg echo.Config) (string, error) {
-	params, err := templateParams(cfg, nil)
+	params, err := templateParams(cfg, nil, resource.RevVerMap{})
 	if err != nil {
 		return "", err
 	}
@@ -560,7 +570,7 @@ func GenerateService(cfg echo.Config) (string, error) {
 
 const DefaultVMImage = "app_sidecar_ubuntu_bionic"
 
-func templateParams(cfg echo.Config, settings *image.Settings) (map[string]interface{}, error) {
+func templateParams(cfg echo.Config, settings *image.Settings, versions resource.RevVerMap) (map[string]interface{}, error) {
 	if settings == nil {
 		var err error
 		settings, err = image.SettingsFromCommandLine()
@@ -614,6 +624,8 @@ func templateParams(cfg echo.Config, settings *image.Settings) (map[string]inter
 		},
 		"StartupProbe":    supportStartupProbe,
 		"IncludeExtAuthz": cfg.IncludeExtAuthz,
+		"IstioVersions":   versions.TemplateMap(),
+		"IsMultiVersion":  versions.IsMultiVersion(),
 	}
 	return params, nil
 }

--- a/pkg/test/framework/components/echo/kube/deployment_test.go
+++ b/pkg/test/framework/components/echo/kube/deployment_test.go
@@ -23,6 +23,7 @@ import (
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/echo/common"
 	"istio.io/istio/pkg/test/framework/image"
+	"istio.io/istio/pkg/test/framework/resource"
 )
 
 var (
@@ -153,7 +154,7 @@ func TestDeploymentYAML(t *testing.T) {
 			if err != nil {
 				t.Errorf("failed to generate service %v", err)
 			}
-			deploymentYAML, err := generateDeploymentYAML(tc.config, settings)
+			deploymentYAML, err := generateDeploymentYAML(tc.config, settings, resource.RevVerMap{})
 			if err != nil {
 				t.Errorf("failed to generate deployment %v", err)
 			}

--- a/pkg/test/framework/resource/flags.go
+++ b/pkg/test/framework/resource/flags.go
@@ -53,6 +53,12 @@ func SettingsFromCommandLine(testID string) (*Settings, error) {
 				" -istio.test.deprecation_failure must not be used at the same time")
 	}
 
+	if s.Revision != "" && s.IstioVersions != nil {
+		return nil,
+			fmt.Errorf("cannot use --istio.test.revision and --istio.test.versions at the same time," +
+				" --istio.test.versions will take precedence and --istio.test.revision will be ignored")
+	}
+
 	return s, nil
 }
 
@@ -90,6 +96,8 @@ func init() {
 
 	flag.BoolVar(&settingsFromCommandLine.SkipVM, "istio.test.skipVM", settingsFromCommandLine.SkipVM,
 		"Skip VM related parts in all tests.")
+
+	flag.Var(&settingsFromCommandLine.IstioVersions, "istio.test.versions", "Istio CP versions available to the test framework and their corresponding revisions.")
 }
 
 type arrayFlags []string

--- a/pkg/test/framework/resource/settings.go
+++ b/pkg/test/framework/resource/settings.go
@@ -80,6 +80,13 @@ type Settings struct {
 
 	// Skip VM related parts for all the tests.
 	SkipVM bool
+
+	// IstioVersions maps the Istio versions that are available to each cluster to their corresponding revisions.
+	// In the future these versions should be automatically deployed to each primary cluster, but for now,
+	// this flag must be used with --istio.test.kube.deploy=false with the versions pre-installed.
+	// The map should be passed in as comma-separated values, such as "rev-a=1.7.3,rev-b=1.8.2,rev-c=1.9.0", and the test framework will
+	// spin up pods pointing to these revisions for each echo instance and skip tests accordingly.
+	IstioVersions RevVerMap
 }
 
 // RunDir is the name of the dir to output, for this particular run.
@@ -124,5 +131,6 @@ func (s *Settings) String() string {
 	result += fmt.Sprintf("StableNamespaces:  %v\n", s.StableNamespaces)
 	result += fmt.Sprintf("Revision:          %v\n", s.Revision)
 	result += fmt.Sprintf("SkipVM:            %v\n", s.SkipVM)
+	result += fmt.Sprintf("IstioVersions:     %v\n", s.IstioVersions)
 	return result
 }

--- a/pkg/test/framework/resource/version.go
+++ b/pkg/test/framework/resource/version.go
@@ -1,0 +1,127 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resource
+
+import (
+	"strings"
+
+	"istio.io/istio/pilot/pkg/model"
+)
+
+// RevVerMap maps installed revisions to their Istio versions.
+type RevVerMap map[string]IstioVersion
+
+// Set parses IstioVersions from a string flag in the form "a=1.5.6,b=1.9.0,c=1.4".
+func (rv *RevVerMap) Set(value string) error {
+	m := make(map[string]IstioVersion)
+	rvPairs := strings.Split(value, ",")
+	for _, rvPair := range rvPairs {
+		s := strings.Split(rvPair, "=")
+		rev, ver := s[0], s[1]
+		parsedVer, err := ParseIstioVersion(ver)
+		if err != nil {
+			return err
+		}
+		m[rev] = parsedVer
+	}
+	*rv = m
+	return nil
+}
+
+func (rv *RevVerMap) String() string {
+	if rv == nil {
+		return ""
+	}
+	var vers []string
+	for _, ver := range *rv {
+		vers = append(vers, string(ver))
+	}
+	return strings.Join(vers, ",")
+}
+
+// Versions returns an ordered list of Istio versions from the given RevVerMap.
+func (rv *RevVerMap) Versions() IstioVersions {
+	if rv == nil {
+		return nil
+	}
+	var vers []IstioVersion
+	for _, v := range *rv {
+		vers = append(vers, v)
+	}
+	return vers
+}
+
+// Minimum returns the minimum version from the revision-version mapping.
+func (rv *RevVerMap) Minimum() IstioVersion {
+	return rv.Versions().Minimum()
+}
+
+// IsMultiVersion returns whether the associated IstioVersions have multiple specified versions.
+func (rv *RevVerMap) IsMultiVersion() bool {
+	return rv != nil && len(*rv) > 0
+}
+
+// TemplateMap creates a map of revisions and versions suitable for templating.
+func (rv *RevVerMap) TemplateMap() map[string]string {
+	if rv == nil {
+		return nil
+	}
+	templateMap := make(map[string]string)
+	if len(*rv) == 0 {
+		// if there are no entries, generate a dummy value so that we don't render
+		// deployment template with empty loop
+		templateMap[""] = ""
+		return templateMap
+	}
+	for r, v := range *rv {
+		templateMap[r] = string(v)
+	}
+	return templateMap
+}
+
+// IstioVersion is an Istio version running within a cluster.
+type IstioVersion string
+
+// IstioVersions represents a collection of Istio versions running in a cluster.
+type IstioVersions []IstioVersion
+
+// Compare compares two Istio versions. Returns -1 if version "v" is less than "other", 0 if the same,
+// and 1 if "v" is greater than "other".
+func (v IstioVersion) Compare(other IstioVersion) int {
+	ver := model.ParseIstioVersion(string(v))
+	otherVer := model.ParseIstioVersion(string(other))
+	return ver.Compare(otherVer)
+}
+
+// Minimum returns the minimum from a set of IstioVersions
+// returns empty value if no versions.
+func (v IstioVersions) Minimum() IstioVersion {
+	if len(v) == 0 {
+		return ""
+	}
+	min := v[0]
+	for i := 1; i < len(v); i++ {
+		ver := v[i]
+		if ver.Compare(min) > 1 {
+			min = ver
+		}
+	}
+	return min
+}
+
+// ParseIstioVersion parses a version string into a IstioVersion.
+func ParseIstioVersion(version string) (IstioVersion, error) {
+	return IstioVersion(version), nil
+}

--- a/pkg/test/framework/resource/version_test.go
+++ b/pkg/test/framework/resource/version_test.go
@@ -1,0 +1,101 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resource
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestCompareIstioVersion(t *testing.T) {
+	tcs := []struct {
+		a, b   IstioVersion
+		result int
+	}{
+		{
+			IstioVersion("1.4"),
+			IstioVersion("1.5"),
+			-1,
+		},
+		{
+			IstioVersion("1.9.0"),
+			IstioVersion("1.10"),
+			-1,
+		},
+		{
+			IstioVersion("1.8.0"),
+			IstioVersion("1.8.1"),
+			-1,
+		},
+		{
+			IstioVersion("1.9.1"),
+			IstioVersion("1.9.1"),
+			0,
+		},
+		{
+			IstioVersion("1.12"),
+			IstioVersion("1.3"),
+			1,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(fmt.Sprintf("compare version %s->%s", tc.a, tc.b), func(t *testing.T) {
+			r := tc.a.Compare(tc.b)
+			if r != tc.result {
+				t.Errorf("expected %d, got %d", tc.result, r)
+			}
+		})
+	}
+}
+
+func TestMinimumIstioVersion(t *testing.T) {
+	tcs := []struct {
+		name     string
+		versions IstioVersions
+		result   IstioVersion
+	}{
+		{
+			"two versions",
+			IstioVersions([]IstioVersion{
+				"1.4", "1.5",
+			}),
+			IstioVersion("1.4"),
+		},
+		{
+			"three versions",
+			IstioVersions([]IstioVersion{
+				"1.9", "1.13", "1.10",
+			}),
+			IstioVersion("1.9"),
+		},
+		{
+			"single version",
+			IstioVersions([]IstioVersion{
+				"1.9",
+			}),
+			IstioVersion("1.9"),
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			min := tc.versions.Minimum()
+			if min != tc.result {
+				t.Errorf("expected %v, got %v", tc.result, min)
+			}
+		})
+	}
+}

--- a/pkg/test/framework/test.go
+++ b/pkg/test/framework/test.go
@@ -22,6 +22,7 @@ import (
 
 	"istio.io/istio/pkg/test/framework/features"
 	"istio.io/istio/pkg/test/framework/label"
+	"istio.io/istio/pkg/test/framework/resource"
 	"istio.io/istio/pkg/test/scopes"
 	"istio.io/pkg/log"
 )
@@ -32,6 +33,9 @@ type Test interface {
 	// Label applies the given labels to this test.
 	Features(feats ...features.Feature) Test
 	NotImplementedYet(features ...features.Feature) Test
+	// RequireIstioVersion ensures that all installed versions of Istio are at least the
+	// required version for the annotated test to pass
+	RequireIstioVersion(version string) Test
 	// RequiresMinClusters ensures that the current environment contains at least the expected number of clusters.
 	// Otherwise it stops test execution and skips the test.
 	RequiresMinClusters(minClusters int) Test
@@ -104,6 +108,7 @@ type testImpl struct {
 	s                   *suiteContext
 	requiredMinClusters int
 	requiredMaxClusters int
+	minIstioVersion     string
 
 	ctx *testContext
 
@@ -173,6 +178,11 @@ func (t *testImpl) RequiresSingleCluster() Test {
 	return t.RequiresMaxClusters(1).RequiresMinClusters(1)
 }
 
+func (t *testImpl) RequireIstioVersion(version string) Test {
+	t.minIstioVersion = version
+	return t
+}
+
 func (t *testImpl) Run(fn func(ctx TestContext)) {
 	t.runInternal(fn, false)
 }
@@ -229,6 +239,14 @@ func (t *testImpl) doRun(ctx *testContext, fn func(ctx TestContext), parallel bo
 		t.goTest.Skipf("Skipping %q: number of clusters %d is above required max %d",
 			t.goTest.Name(), len(t.s.Environment().Clusters()), t.requiredMaxClusters)
 		return
+	}
+
+	if t.minIstioVersion != "" {
+		if resource.IstioVersion(t.minIstioVersion).Compare(t.ctx.Settings().IstioVersions.Minimum()) > 0 {
+			ctx.Done()
+			t.goTest.Skipf("Skipping %q: running with min Istio version %q, test requires at least %s",
+				t.goTest.Name(), t.ctx.Settings().IstioVersions.Minimum(), t.minIstioVersion)
+		}
 	}
 
 	start := time.Now()


### PR DESCRIPTION
Backport of [https://github.com/istio/istio/pull/31150](https://github.com/istio/istio/pull/31150)

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any changes that may affect Istio users.
