### PR TITLE
Cleanup domain suffix handling

### DIFF
--- a/pilot/pkg/bootstrap/server_test.go
+++ b/pilot/pkg/bootstrap/server_test.go
@@ -247,7 +247,7 @@ func TestNewServer(t *testing.T) {
 				s.WaitUntilCompletion()
 			}()
 
-			g.Expect(s.environment.GetDomainSuffix()).To(Equal(c.expectedDomain))
+			g.Expect(s.environment.DomainSuffix).To(Equal(c.expectedDomain))
 		})
 	}
 }

--- a/pilot/pkg/model/cluster_local.go
+++ b/pilot/pkg/model/cluster_local.go
@@ -75,7 +75,7 @@ func (c *clusterLocalProvider) GetClusterLocalHosts() ClusterLocalHosts {
 
 func (c *clusterLocalProvider) onMeshUpdated(e *Environment) {
 	// Create the default list of cluster-local hosts.
-	domainSuffix := e.GetDomainSuffix()
+	domainSuffix := e.DomainSuffix
 	defaultClusterLocalHosts := make([]host.Name, 0)
 	for _, n := range defaultClusterLocalNamespaces {
 		defaultClusterLocalHosts = append(defaultClusterLocalHosts, host.Name("*."+n+".svc."+domainSuffix))

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -86,13 +86,6 @@ type Environment struct {
 	clusterLocalServices ClusterLocalProvider
 }
 
-func (e *Environment) GetDomainSuffix() string {
-	if len(e.DomainSuffix) > 0 {
-		return e.DomainSuffix
-	}
-	return constants.DefaultKubernetesDomain
-}
-
 func (e *Environment) Mesh() *meshconfig.MeshConfig {
 	if e != nil && e.Watcher != nil {
 		return e.Watcher.Mesh()
@@ -148,7 +141,14 @@ func (e *Environment) Version() string {
 	return ""
 }
 
+// Init initializes the Environment for use.
 func (e *Environment) Init() {
+	// Use a default DomainSuffix, if none was provided.
+	if len(e.DomainSuffix) == 0 {
+		e.DomainSuffix = constants.DefaultKubernetesDomain
+	}
+
+	// Create the cluster-local service registry.
 	e.clusterLocalServices = NewClusterLocalProvider(e)
 }
 


### PR DESCRIPTION
We've added an Init() method to Environment. Adding the defaulting of DomainSuffix there to avoid the need for a duplicate method.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.