### PR TITLE
envoy: avoid sending health checks via proxy

### DIFF
--- a/manifests/charts/gateways/istio-egress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-egress/templates/deployment.yaml
@@ -140,7 +140,7 @@ spec:
             failureThreshold: 30
             httpGet:
               path: /healthz/ready
-              port: 15021
+              port: 15020
               scheme: HTTP
             initialDelaySeconds: 1
             periodSeconds: 2

--- a/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
@@ -140,7 +140,7 @@ spec:
             failureThreshold: 30
             httpGet:
               path: /healthz/ready
-              port: 15021
+              port: 15020
               scheme: HTTP
             initialDelaySeconds: 1
             periodSeconds: 2

--- a/manifests/charts/gateways/istio-ingress/values.yaml
+++ b/manifests/charts/gateways/istio-ingress/values.yaml
@@ -12,8 +12,8 @@ gateways:
     # Note that AWS ELB will by default perform health checks on the first port
     # on this list. Setting this to the health check port will ensure that health
     # checks always work. https://github.com/istio/istio/issues/12503
-    - port: 15021
-      targetPort: 15021
+    - port: 15020
+      targetPort: 15020
       name: status-port
       protocol: TCP
     - port: 80

--- a/manifests/charts/istio-control/istio-discovery/files/gateway-injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gateway-injection-template.yaml
@@ -144,7 +144,7 @@ spec:
     readinessProbe:
       httpGet:
         path: /healthz/ready
-        port: 15021
+        port: 15020
       initialDelaySeconds: {{.Values.global.proxy.readinessInitialDelaySeconds }}
       periodSeconds: {{ .Values.global.proxy.readinessPeriodSeconds }}
       timeoutSeconds: 3

--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -266,9 +266,9 @@ data:
             - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` `*` }}"
             - "-d"
           {{- if excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}
-            - "15090,15021,{{ excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}"
+            - "15090,{{excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}"
           {{- else }}
-            - "15090,15021"
+            - "15090,15020"
           {{- end }}
             {{ if or (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/includeOutboundPorts`) (ne (valueOrDefault .Values.global.proxy.includeOutboundPorts "") "") -}}
             - "-q"
@@ -528,7 +528,7 @@ data:
             readinessProbe:
               httpGet:
                 path: /healthz/ready
-                port: 15021
+                port: 15020
               initialDelaySeconds: {{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/initialDelaySeconds` .Values.global.proxy.readinessInitialDelaySeconds }}
               periodSeconds: {{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/periodSeconds` .Values.global.proxy.readinessPeriodSeconds }}
               timeoutSeconds: 3
@@ -846,7 +846,7 @@ data:
             readinessProbe:
               httpGet:
                 path: /healthz/ready
-                port: 15021
+                port: 15020
               initialDelaySeconds: {{.Values.global.proxy.readinessInitialDelaySeconds }}
               periodSeconds: {{ .Values.global.proxy.readinessPeriodSeconds }}
               timeoutSeconds: 3

--- a/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
@@ -61,9 +61,9 @@ spec:
     - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` `*` }}"
     - "-d"
   {{- if excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}
-    - "15090,15021,{{ excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}"
+    - "15090,{{excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}"
   {{- else }}
-    - "15090,15021"
+    - "15090,15020"
   {{- end }}
     {{ if or (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/includeOutboundPorts`) (ne (valueOrDefault .Values.global.proxy.includeOutboundPorts "") "") -}}
     - "-q"
@@ -323,7 +323,7 @@ spec:
     readinessProbe:
       httpGet:
         path: /healthz/ready
-        port: 15021
+        port: 15020
       initialDelaySeconds: {{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/initialDelaySeconds` .Values.global.proxy.readinessInitialDelaySeconds }}
       periodSeconds: {{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/periodSeconds` .Values.global.proxy.readinessPeriodSeconds }}
       timeoutSeconds: 3

--- a/manifests/charts/istiod-remote/files/gateway-injection-template.yaml
+++ b/manifests/charts/istiod-remote/files/gateway-injection-template.yaml
@@ -144,7 +144,7 @@ spec:
     readinessProbe:
       httpGet:
         path: /healthz/ready
-        port: 15021
+        port: 15020
       initialDelaySeconds: {{.Values.global.proxy.readinessInitialDelaySeconds }}
       periodSeconds: {{ .Values.global.proxy.readinessPeriodSeconds }}
       timeoutSeconds: 3

--- a/manifests/charts/istiod-remote/files/gen-istiod-remote.yaml
+++ b/manifests/charts/istiod-remote/files/gen-istiod-remote.yaml
@@ -246,9 +246,9 @@ data:
             - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` `*` }}"
             - "-d"
           {{- if excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}
-            - "15090,15021,{{ excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}"
+            - "15090,{{excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}"
           {{- else }}
-            - "15090,15021"
+            - "15090,15020"
           {{- end }}
             {{ if or (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/includeOutboundPorts`) (ne (valueOrDefault .Values.global.proxy.includeOutboundPorts "") "") -}}
             - "-q"
@@ -508,7 +508,7 @@ data:
             readinessProbe:
               httpGet:
                 path: /healthz/ready
-                port: 15021
+                port: 15020
               initialDelaySeconds: {{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/initialDelaySeconds` .Values.global.proxy.readinessInitialDelaySeconds }}
               periodSeconds: {{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/periodSeconds` .Values.global.proxy.readinessPeriodSeconds }}
               timeoutSeconds: 3
@@ -826,7 +826,7 @@ data:
             readinessProbe:
               httpGet:
                 path: /healthz/ready
-                port: 15021
+                port: 15020
               initialDelaySeconds: {{.Values.global.proxy.readinessInitialDelaySeconds }}
               periodSeconds: {{ .Values.global.proxy.readinessPeriodSeconds }}
               timeoutSeconds: 3

--- a/manifests/charts/istiod-remote/files/injection-template.yaml
+++ b/manifests/charts/istiod-remote/files/injection-template.yaml
@@ -61,9 +61,9 @@ spec:
     - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` `*` }}"
     - "-d"
   {{- if excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}
-    - "15090,15021,{{ excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}"
+    - "15090,{{excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}"
   {{- else }}
-    - "15090,15021"
+    - "15090,15020"
   {{- end }}
     {{ if or (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/includeOutboundPorts`) (ne (valueOrDefault .Values.global.proxy.includeOutboundPorts "") "") -}}
     - "-q"
@@ -323,7 +323,7 @@ spec:
     readinessProbe:
       httpGet:
         path: /healthz/ready
-        port: 15021
+        port: 15020
       initialDelaySeconds: {{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/initialDelaySeconds` .Values.global.proxy.readinessInitialDelaySeconds }}
       periodSeconds: {{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/periodSeconds` .Values.global.proxy.readinessPeriodSeconds }}
       timeoutSeconds: 3

--- a/manifests/profiles/demo.yaml
+++ b/manifests/profiles/demo.yaml
@@ -27,8 +27,8 @@ spec:
             # Note that AWS ELB will by default perform health checks on the first port
             # on this list. Setting this to the health check port will ensure that health
             # checks always work. https://github.com/istio/istio/issues/12503
-            - port: 15021
-              targetPort: 15021
+            - port: 15020
+              targetPort: 15020
               name: status-port
             - port: 80
               targetPort: 8080

--- a/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
@@ -116,7 +116,7 @@ spec:
           failureThreshold: 30
           httpGet:
             path: /healthz/ready
-            port: 15021
+            port: 15020
           initialDelaySeconds: 1
           periodSeconds: 2
           timeoutSeconds: 3
@@ -166,7 +166,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 15090,15021,15020
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/auth.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/auth.yaml.injected
@@ -116,7 +116,7 @@ spec:
           failureThreshold: 30
           httpGet:
             path: /healthz/ready
-            port: 15021
+            port: 15020
           initialDelaySeconds: 1
           periodSeconds: 2
           timeoutSeconds: 3
@@ -166,7 +166,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 15090,15021,15020
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
@@ -110,7 +110,7 @@ spec:
               failureThreshold: 30
               httpGet:
                 path: /healthz/ready
-                port: 15021
+                port: 15020
               initialDelaySeconds: 1
               periodSeconds: 2
               timeoutSeconds: 3
@@ -160,7 +160,7 @@ spec:
             - -b
             - '*'
             - -d
-            - 15090,15021,15020
+            - 15090,15020
             image: gcr.io/istio-testing/proxyv2:latest
             name: istio-init
             resources:

--- a/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
@@ -114,7 +114,7 @@ spec:
           failureThreshold: 30
           httpGet:
             path: /healthz/ready
-            port: 15021
+            port: 15020
           initialDelaySeconds: 1
           periodSeconds: 2
           timeoutSeconds: 3
@@ -164,7 +164,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 15090,15021,15020
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/deploymentconfig-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/deploymentconfig-multi.yaml.injected
@@ -129,7 +129,7 @@ items:
             failureThreshold: 30
             httpGet:
               path: /healthz/ready
-              port: 15021
+              port: 15020
             initialDelaySeconds: 1
             periodSeconds: 2
             timeoutSeconds: 3
@@ -179,7 +179,7 @@ items:
           - -b
           - '*'
           - -d
-          - 15090,15021,15020
+          - 15090,15020
           image: gcr.io/istio-testing/proxyv2:latest
           name: istio-init
           resources:

--- a/pkg/kube/inject/testdata/inject/deploymentconfig-with-canonical-service-label.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/deploymentconfig-with-canonical-service-label.yaml.injected
@@ -114,7 +114,7 @@ spec:
           failureThreshold: 30
           httpGet:
             path: /healthz/ready
-            port: 15021
+            port: 15020
           initialDelaySeconds: 1
           periodSeconds: 2
           timeoutSeconds: 3
@@ -164,7 +164,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 15090,15021,15020
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/deploymentconfig.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/deploymentconfig.yaml.injected
@@ -114,7 +114,7 @@ spec:
           failureThreshold: 30
           httpGet:
             path: /healthz/ready
-            port: 15021
+            port: 15020
           initialDelaySeconds: 1
           periodSeconds: 2
           timeoutSeconds: 3
@@ -164,7 +164,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 15090,15021,15020
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/enable-core-dump-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/enable-core-dump-annotation.yaml.injected
@@ -120,7 +120,7 @@ spec:
           failureThreshold: 30
           httpGet:
             path: /healthz/ready
-            port: 15021
+            port: 15020
           initialDelaySeconds: 1
           periodSeconds: 2
           timeoutSeconds: 3
@@ -170,7 +170,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 15090,15021,15020
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
@@ -116,7 +116,7 @@ spec:
           failureThreshold: 30
           httpGet:
             path: /healthz/ready
-            port: 15021
+            port: 15020
           initialDelaySeconds: 1
           periodSeconds: 2
           timeoutSeconds: 3
@@ -166,7 +166,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 15090,15021,15020
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/explicit-security-context.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/explicit-security-context.yaml.injected
@@ -107,7 +107,7 @@ spec:
           failureThreshold: 30
           httpGet:
             path: /healthz/ready
-            port: 15021
+            port: 15020
           initialDelaySeconds: 1
           periodSeconds: 2
           timeoutSeconds: 3
@@ -157,7 +157,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 15090,15021,15020
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
@@ -116,7 +116,7 @@ spec:
           failureThreshold: 30
           httpGet:
             path: /healthz/ready
-            port: 15021
+            port: 15020
           initialDelaySeconds: 1
           periodSeconds: 2
           timeoutSeconds: 3
@@ -166,7 +166,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 15090,15021,15020
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/frontend.yaml.injected
@@ -133,7 +133,7 @@ spec:
           failureThreshold: 30
           httpGet:
             path: /healthz/ready
-            port: 15021
+            port: 15020
           initialDelaySeconds: 1
           periodSeconds: 2
           timeoutSeconds: 3
@@ -183,7 +183,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 15090,15021,15020
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
@@ -117,7 +117,7 @@ spec:
           failureThreshold: 30
           httpGet:
             path: /healthz/ready
-            port: 15021
+            port: 15020
           initialDelaySeconds: 1
           periodSeconds: 2
           timeoutSeconds: 3
@@ -167,7 +167,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 15090,15021,15020
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/hello-cncf-networks.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-cncf-networks.yaml.injected
@@ -121,7 +121,7 @@ spec:
           failureThreshold: 30
           httpGet:
             path: /healthz/ready
-            port: 15021
+            port: 15020
           initialDelaySeconds: 1
           periodSeconds: 2
           timeoutSeconds: 3
@@ -171,7 +171,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 15090,15021,15020
+        - 15090,15020
         - --run-validation
         - --skip-rule-apply
         image: gcr.io/istio-testing/proxyv2:latest

--- a/pkg/kube/inject/testdata/inject/hello-existing-cncf-networks-json.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-existing-cncf-networks-json.yaml.injected
@@ -124,7 +124,7 @@ spec:
           failureThreshold: 30
           httpGet:
             path: /healthz/ready
-            port: 15021
+            port: 15020
           initialDelaySeconds: 1
           periodSeconds: 2
           timeoutSeconds: 3
@@ -174,7 +174,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 15090,15021,15020
+        - 15090,15020
         - --run-validation
         - --skip-rule-apply
         image: gcr.io/istio-testing/proxyv2:latest

--- a/pkg/kube/inject/testdata/inject/hello-existing-cncf-networks.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-existing-cncf-networks.yaml.injected
@@ -124,7 +124,7 @@ spec:
           failureThreshold: 30
           httpGet:
             path: /healthz/ready
-            port: 15021
+            port: 15020
           initialDelaySeconds: 1
           periodSeconds: 2
           timeoutSeconds: 3
@@ -174,7 +174,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 15090,15021,15020
+        - 15090,15020
         - --run-validation
         - --skip-rule-apply
         image: gcr.io/istio-testing/proxyv2:latest

--- a/pkg/kube/inject/testdata/inject/hello-image-pull-secret.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-image-pull-secret.yaml.injected
@@ -116,7 +116,7 @@ spec:
           failureThreshold: 30
           httpGet:
             path: /healthz/ready
-            port: 15021
+            port: 15020
           initialDelaySeconds: 1
           periodSeconds: 2
           timeoutSeconds: 3
@@ -168,7 +168,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 15090,15021,15020
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/hello-image-secrets-in-values.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-image-secrets-in-values.yaml.injected
@@ -116,7 +116,7 @@ spec:
           failureThreshold: 30
           httpGet:
             path: /healthz/ready
-            port: 15021
+            port: 15020
           initialDelaySeconds: 1
           periodSeconds: 2
           timeoutSeconds: 3
@@ -168,7 +168,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 15090,15021,15020
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/hello-mount-mtls-certs.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-mount-mtls-certs.yaml.injected
@@ -116,7 +116,7 @@ spec:
           failureThreshold: 30
           httpGet:
             path: /healthz/ready
-            port: 15021
+            port: 15020
           initialDelaySeconds: 1
           periodSeconds: 2
           timeoutSeconds: 3
@@ -169,7 +169,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 15090,15021,15020
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/hello-mtls-not-ready.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-mtls-not-ready.yaml.injected
@@ -116,7 +116,7 @@ spec:
           failureThreshold: 30
           httpGet:
             path: /healthz/ready
-            port: 15021
+            port: 15020
           initialDelaySeconds: 1
           periodSeconds: 2
           timeoutSeconds: 3
@@ -166,7 +166,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 15090,15021,15020
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
@@ -118,7 +118,7 @@ spec:
           failureThreshold: 30
           httpGet:
             path: /healthz/ready
-            port: 15021
+            port: 15020
           initialDelaySeconds: 1
           periodSeconds: 2
           timeoutSeconds: 3
@@ -168,7 +168,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 15090,15021,15020
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:
@@ -350,7 +350,7 @@ spec:
           failureThreshold: 30
           httpGet:
             path: /healthz/ready
-            port: 15021
+            port: 15020
           initialDelaySeconds: 1
           periodSeconds: 2
           timeoutSeconds: 3
@@ -400,7 +400,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 15090,15021,15020
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/hello-multiple-image-secrets.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-multiple-image-secrets.yaml.injected
@@ -116,7 +116,7 @@ spec:
           failureThreshold: 30
           httpGet:
             path: /healthz/ready
-            port: 15021
+            port: 15020
           initialDelaySeconds: 1
           periodSeconds: 2
           timeoutSeconds: 3
@@ -169,7 +169,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 15090,15021,15020
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/hello-namespace.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-namespace.yaml.injected
@@ -117,7 +117,7 @@ spec:
           failureThreshold: 30
           httpGet:
             path: /healthz/ready
-            port: 15021
+            port: 15020
           initialDelaySeconds: 1
           periodSeconds: 2
           timeoutSeconds: 3
@@ -167,7 +167,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 15090,15021,15020
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
@@ -117,7 +117,7 @@ spec:
           failureThreshold: 30
           httpGet:
             path: /healthz/ready
-            port: 15021
+            port: 15020
           initialDelaySeconds: 1
           periodSeconds: 2
           timeoutSeconds: 3
@@ -167,7 +167,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 15090,15021,15020
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Never
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/hello-no-seccontext.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-no-seccontext.yaml.injected
@@ -116,7 +116,7 @@ spec:
           failureThreshold: 30
           httpGet:
             path: /healthz/ready
-            port: 15021
+            port: 15020
           initialDelaySeconds: 1
           periodSeconds: 2
           timeoutSeconds: 3
@@ -166,7 +166,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 15090,15021,15020
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.injected
@@ -121,7 +121,7 @@ spec:
           failureThreshold: 30
           httpGet:
             path: /healthz/ready
-            port: 15021
+            port: 15020
           initialDelaySeconds: 1
           periodSeconds: 2
           timeoutSeconds: 3
@@ -200,7 +200,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 15090,15021,15020
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/hello-probes-proxyHoldApplication-ProxyConfig.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-probes-proxyHoldApplication-ProxyConfig.yaml.injected
@@ -121,7 +121,7 @@ spec:
           failureThreshold: 30
           httpGet:
             path: /healthz/ready
-            port: 15021
+            port: 15020
           initialDelaySeconds: 1
           periodSeconds: 2
           timeoutSeconds: 3
@@ -200,7 +200,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 15090,15021,15020
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/hello-probes-with-flag-set-in-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-probes-with-flag-set-in-annotation.yaml.injected
@@ -144,7 +144,7 @@ spec:
           failureThreshold: 30
           httpGet:
             path: /healthz/ready
-            port: 15021
+            port: 15020
           initialDelaySeconds: 1
           periodSeconds: 2
           timeoutSeconds: 3
@@ -194,7 +194,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 15090,15021,15020
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/hello-probes-with-flag-unset-in-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-probes-with-flag-unset-in-annotation.yaml.injected
@@ -139,7 +139,7 @@ spec:
           failureThreshold: 30
           httpGet:
             path: /healthz/ready
-            port: 15021
+            port: 15020
           initialDelaySeconds: 1
           periodSeconds: 2
           timeoutSeconds: 3
@@ -189,7 +189,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 15090,15021,15020
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/hello-probes.proxyHoldsApplication.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-probes.proxyHoldsApplication.yaml.injected
@@ -117,7 +117,7 @@ spec:
           failureThreshold: 30
           httpGet:
             path: /healthz/ready
-            port: 15021
+            port: 15020
           initialDelaySeconds: 1
           periodSeconds: 2
           timeoutSeconds: 3
@@ -196,7 +196,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 15090,15021,15020
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/hello-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-probes.yaml.injected
@@ -140,7 +140,7 @@ spec:
           failureThreshold: 30
           httpGet:
             path: /healthz/ready
-            port: 15021
+            port: 15020
           initialDelaySeconds: 1
           periodSeconds: 2
           timeoutSeconds: 3
@@ -190,7 +190,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 15090,15021,15020
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
@@ -120,7 +120,7 @@ spec:
           failureThreshold: 30
           httpGet:
             path: /healthz/ready
-            port: 15021
+            port: 15020
           initialDelaySeconds: 1
           periodSeconds: 2
           timeoutSeconds: 3
@@ -170,7 +170,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 15090,15021,15020
+        - 15090,15020
         image: docker.io/istio/proxy2_debug:unittest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/hello-readiness.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-readiness.yaml.injected
@@ -122,7 +122,7 @@ spec:
           failureThreshold: 30
           httpGet:
             path: /healthz/ready
-            port: 15021
+            port: 15020
           initialDelaySeconds: 1
           periodSeconds: 2
           timeoutSeconds: 3
@@ -172,7 +172,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 15090,15021,15020
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/hello-template-in-values.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-template-in-values.yaml.injected
@@ -116,7 +116,7 @@ spec:
           failureThreshold: 30
           httpGet:
             path: /healthz/ready
-            port: 15021
+            port: 15020
           initialDelaySeconds: 1
           periodSeconds: 2
           timeoutSeconds: 3
@@ -166,7 +166,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 15090,15021,15020
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
@@ -116,7 +116,7 @@ spec:
           failureThreshold: 30
           httpGet:
             path: /healthz/ready
-            port: 15021
+            port: 15020
           initialDelaySeconds: 1
           periodSeconds: 2
           timeoutSeconds: 3
@@ -168,7 +168,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 15090,15021,15020
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/hello.proxyHoldsApplication.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello.proxyHoldsApplication.yaml.injected
@@ -116,7 +116,7 @@ spec:
           failureThreshold: 30
           httpGet:
             path: /healthz/ready
-            port: 15021
+            port: 15020
           initialDelaySeconds: 1
           periodSeconds: 2
           timeoutSeconds: 3
@@ -172,7 +172,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 15090,15021,15020
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/hello.yaml.cni.injected
+++ b/pkg/kube/inject/testdata/inject/hello.yaml.cni.injected
@@ -123,7 +123,7 @@ spec:
           failureThreshold: 30
           httpGet:
             path: /healthz/ready
-            port: 15021
+            port: 15020
           initialDelaySeconds: 1
           periodSeconds: 2
           timeoutSeconds: 3
@@ -173,7 +173,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 15090,15021,15020
+        - 15090,15020
         - --run-validation
         - --skip-rule-apply
         image: gcr.io/istio-testing/proxyv2:latest

--- a/pkg/kube/inject/testdata/inject/hello.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello.yaml.injected
@@ -116,7 +116,7 @@ spec:
           failureThreshold: 30
           httpGet:
             path: /healthz/ready
-            port: 15021
+            port: 15020
           initialDelaySeconds: 1
           periodSeconds: 2
           timeoutSeconds: 3
@@ -166,7 +166,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 15090,15021,15020
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/https-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/https-probes.yaml.injected
@@ -141,7 +141,7 @@ spec:
           failureThreshold: 30
           httpGet:
             path: /healthz/ready
-            port: 15021
+            port: 15020
           initialDelaySeconds: 1
           periodSeconds: 2
           timeoutSeconds: 3
@@ -191,7 +191,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 15090,15021,15020
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/job.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/job.yaml.injected
@@ -108,7 +108,7 @@ spec:
           failureThreshold: 30
           httpGet:
             path: /healthz/ready
-            port: 15021
+            port: 15020
           initialDelaySeconds: 1
           periodSeconds: 2
           timeoutSeconds: 3
@@ -158,7 +158,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 15090,15021,15020
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml.injected
@@ -120,7 +120,7 @@ spec:
           failureThreshold: 300
           httpGet:
             path: /healthz/ready
-            port: 15021
+            port: 15020
           initialDelaySeconds: 100
           periodSeconds: 200
           timeoutSeconds: 3
@@ -170,7 +170,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 15090,15021,123
+        - 15090,123
         - -k
         - net1
         image: gcr.io/istio-testing/proxyv2:latest

--- a/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml.injected
@@ -120,7 +120,7 @@ spec:
           failureThreshold: 30
           httpGet:
             path: /healthz/ready
-            port: 15021
+            port: 15020
           initialDelaySeconds: 1
           periodSeconds: 2
           timeoutSeconds: 3
@@ -170,7 +170,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 15090,15021,15020
+        - 15090,15020
         - -k
         - net1,net2
         image: gcr.io/istio-testing/proxyv2:latest

--- a/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
@@ -134,7 +134,7 @@ items:
             failureThreshold: 30
             httpGet:
               path: /healthz/ready
-              port: 15021
+              port: 15020
             initialDelaySeconds: 1
             periodSeconds: 2
             timeoutSeconds: 3
@@ -184,7 +184,7 @@ items:
           - -b
           - '*'
           - -d
-          - 15090,15021,15020
+          - 15090,15020
           image: gcr.io/istio-testing/proxyv2:latest
           name: istio-init
           resources:

--- a/pkg/kube/inject/testdata/inject/list.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/list.yaml.injected
@@ -120,7 +120,7 @@ items:
             failureThreshold: 30
             httpGet:
               path: /healthz/ready
-              port: 15021
+              port: 15020
             initialDelaySeconds: 1
             periodSeconds: 2
             timeoutSeconds: 3
@@ -170,7 +170,7 @@ items:
           - -b
           - '*'
           - -d
-          - 15090,15021,15020
+          - 15090,15020
           image: gcr.io/istio-testing/proxyv2:latest
           name: istio-init
           resources:
@@ -351,7 +351,7 @@ items:
             failureThreshold: 30
             httpGet:
               path: /healthz/ready
-              port: 15021
+              port: 15020
             initialDelaySeconds: 1
             periodSeconds: 2
             timeoutSeconds: 3
@@ -401,7 +401,7 @@ items:
           - -b
           - '*'
           - -d
-          - 15090,15021,15020
+          - 15090,15020
           image: gcr.io/istio-testing/proxyv2:latest
           name: istio-init
           resources:

--- a/pkg/kube/inject/testdata/inject/multi-container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/multi-container.yaml.injected
@@ -116,7 +116,7 @@ spec:
           failureThreshold: 30
           httpGet:
             path: /healthz/ready
-            port: 15021
+            port: 15020
           initialDelaySeconds: 1
           periodSeconds: 2
           timeoutSeconds: 3
@@ -166,7 +166,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 15090,15021,15020
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
@@ -116,7 +116,7 @@ spec:
           failureThreshold: 30
           httpGet:
             path: /healthz/ready
-            port: 15021
+            port: 15020
           initialDelaySeconds: 1
           periodSeconds: 2
           timeoutSeconds: 3
@@ -180,7 +180,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 15090,15021,15020
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/multiple-templates.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/multiple-templates.yaml.injected
@@ -112,7 +112,7 @@ spec:
           failureThreshold: 30
           httpGet:
             path: /healthz/ready
-            port: 15021
+            port: 15020
           initialDelaySeconds: 1
           periodSeconds: 2
           timeoutSeconds: 3
@@ -162,7 +162,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 15090,15021,15020
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/named_port.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/named_port.yaml.injected
@@ -122,7 +122,7 @@ spec:
           failureThreshold: 30
           httpGet:
             path: /healthz/ready
-            port: 15021
+            port: 15020
           initialDelaySeconds: 1
           periodSeconds: 2
           timeoutSeconds: 3
@@ -172,7 +172,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 15090,15021,15020
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/one_container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/one_container.yaml.injected
@@ -126,7 +126,7 @@ spec:
           failureThreshold: 30
           httpGet:
             path: /healthz/ready
-            port: 15021
+            port: 15020
           initialDelaySeconds: 1
           periodSeconds: 2
           timeoutSeconds: 3
@@ -176,7 +176,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 15090,15021,15020
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/only-proxy-container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/only-proxy-container.yaml.injected
@@ -102,7 +102,7 @@ spec:
           failureThreshold: 30
           httpGet:
             path: /healthz/ready
-            port: 15021
+            port: 15020
           initialDelaySeconds: 1
           periodSeconds: 2
           timeoutSeconds: 3
@@ -152,7 +152,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 15090,15021,15020
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/pod.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/pod.yaml.injected
@@ -102,7 +102,7 @@ spec:
       failureThreshold: 30
       httpGet:
         path: /healthz/ready
-        port: 15021
+        port: 15020
       initialDelaySeconds: 1
       periodSeconds: 2
       timeoutSeconds: 3
@@ -152,7 +152,7 @@ spec:
     - -b
     - '*'
     - -d
-    - 15090,15021,15020
+    - 15090,15020
     image: gcr.io/istio-testing/proxyv2:latest
     name: istio-init
     resources:

--- a/pkg/kube/inject/testdata/inject/proxy-override-args.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/proxy-override-args.yaml.injected
@@ -101,7 +101,7 @@ spec:
           failureThreshold: 30
           httpGet:
             path: /healthz/ready
-            port: 15021
+            port: 15020
           initialDelaySeconds: 1
           periodSeconds: 2
           timeoutSeconds: 3
@@ -151,7 +151,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 15090,15021,15020
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/proxy-override.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/proxy-override.yaml.injected
@@ -122,7 +122,7 @@ spec:
           failureThreshold: 30
           httpGet:
             path: /healthz/ready
-            port: 15021
+            port: 15020
           initialDelaySeconds: 1
           periodSeconds: 2
           timeoutSeconds: 3

--- a/pkg/kube/inject/testdata/inject/ready_live.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/ready_live.yaml.injected
@@ -140,7 +140,7 @@ spec:
           failureThreshold: 30
           httpGet:
             path: /healthz/ready
-            port: 15021
+            port: 15020
           initialDelaySeconds: 1
           periodSeconds: 2
           timeoutSeconds: 3
@@ -190,7 +190,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 15090,15021,15020
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/ready_only.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/ready_only.yaml.injected
@@ -122,7 +122,7 @@ spec:
           failureThreshold: 30
           httpGet:
             path: /healthz/ready
-            port: 15021
+            port: 15020
           initialDelaySeconds: 1
           periodSeconds: 2
           timeoutSeconds: 3
@@ -172,7 +172,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 15090,15021,15020
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
@@ -111,7 +111,7 @@ spec:
           failureThreshold: 30
           httpGet:
             path: /healthz/ready
-            port: 15021
+            port: 15020
           initialDelaySeconds: 1
           periodSeconds: 2
           timeoutSeconds: 3
@@ -161,7 +161,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 15090,15021,15020
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
@@ -110,7 +110,7 @@ spec:
           failureThreshold: 30
           httpGet:
             path: /healthz/ready
-            port: 15021
+            port: 15020
           initialDelaySeconds: 1
           periodSeconds: 2
           timeoutSeconds: 3
@@ -160,7 +160,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 15090,15021,15020
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/resource_annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/resource_annotations.yaml.injected
@@ -119,7 +119,7 @@ spec:
           failureThreshold: 30
           httpGet:
             path: /healthz/ready
-            port: 15021
+            port: 15020
           initialDelaySeconds: 1
           periodSeconds: 2
           timeoutSeconds: 3
@@ -169,7 +169,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 15090,15021,15020
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/startup_live.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/startup_live.yaml.injected
@@ -140,7 +140,7 @@ spec:
           failureThreshold: 30
           httpGet:
             path: /healthz/ready
-            port: 15021
+            port: 15020
           initialDelaySeconds: 1
           periodSeconds: 2
           timeoutSeconds: 3
@@ -190,7 +190,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 15090,15021,15020
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/startup_only.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/startup_only.yaml.injected
@@ -122,7 +122,7 @@ spec:
           failureThreshold: 30
           httpGet:
             path: /healthz/ready
-            port: 15021
+            port: 15020
           initialDelaySeconds: 1
           periodSeconds: 2
           timeoutSeconds: 3
@@ -172,7 +172,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 15090,15021,15020
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/startup_ready_live.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/startup_ready_live.yaml.injected
@@ -148,7 +148,7 @@ spec:
           failureThreshold: 30
           httpGet:
             path: /healthz/ready
-            port: 15021
+            port: 15020
           initialDelaySeconds: 1
           periodSeconds: 2
           timeoutSeconds: 3
@@ -198,7 +198,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 15090,15021,15020
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
@@ -119,7 +119,7 @@ spec:
           failureThreshold: 30
           httpGet:
             path: /healthz/ready
-            port: 15021
+            port: 15020
           initialDelaySeconds: 1
           periodSeconds: 2
           timeoutSeconds: 3
@@ -169,7 +169,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 15090,15021,15020
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/status_annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/status_annotations.yaml.injected
@@ -120,7 +120,7 @@ spec:
           failureThreshold: 300
           httpGet:
             path: /healthz/ready
-            port: 15021
+            port: 15020
           initialDelaySeconds: 100
           periodSeconds: 200
           timeoutSeconds: 3
@@ -170,7 +170,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 15090,15021,123
+        - 15090,123
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/status_annotations_zeroport.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/status_annotations_zeroport.yaml.injected
@@ -162,7 +162,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 15090,15021
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/status_params.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/status_params.yaml.injected
@@ -112,7 +112,7 @@ spec:
           failureThreshold: 300
           httpGet:
             path: /healthz/ready
-            port: 15021
+            port: 15020
           initialDelaySeconds: 100
           periodSeconds: 200
           timeoutSeconds: 3
@@ -162,7 +162,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 15090,15021,123
+        - 15090,123
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
@@ -119,7 +119,7 @@ spec:
           failureThreshold: 30
           httpGet:
             path: /healthz/ready
-            port: 15021
+            port: 15020
           initialDelaySeconds: 1
           periodSeconds: 2
           timeoutSeconds: 3
@@ -169,7 +169,7 @@ spec:
         - -b
         - ""
         - -d
-        - 15090,15021,4,5,6,15020
+        - 15090,4,5,6,15020
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
@@ -119,7 +119,7 @@ spec:
           failureThreshold: 30
           httpGet:
             path: /healthz/ready
-            port: 15021
+            port: 15020
           initialDelaySeconds: 1
           periodSeconds: 2
           timeoutSeconds: 3
@@ -169,7 +169,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 15090,15021,4,5,6,15020
+        - 15090,4,5,6,15020
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
@@ -126,7 +126,7 @@ spec:
           failureThreshold: 30
           httpGet:
             path: /healthz/ready
-            port: 15021
+            port: 15020
           initialDelaySeconds: 1
           periodSeconds: 2
           timeoutSeconds: 3
@@ -172,7 +172,7 @@ spec:
         - -b
         - 1,2,3
         - -d
-        - 15090,15021,4,5,6,15020
+        - 15090,4,5,6,15020
         - -o
         - 7,8,9
         env:

--- a/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
@@ -112,7 +112,7 @@ spec:
           failureThreshold: 30
           httpGet:
             path: /healthz/ready
-            port: 15021
+            port: 15020
           initialDelaySeconds: 1
           periodSeconds: 2
           timeoutSeconds: 3
@@ -162,7 +162,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 15090,15021,15020
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
@@ -154,7 +154,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 15090,15021,4,5,6
+        - 15090,4,5,6
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/two_container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/two_container.yaml.injected
@@ -131,7 +131,7 @@ spec:
           failureThreshold: 30
           httpGet:
             path: /healthz/ready
-            port: 15021
+            port: 15020
           initialDelaySeconds: 1
           periodSeconds: 2
           timeoutSeconds: 3
@@ -181,7 +181,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 15090,15021,15020
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/user-volume.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/user-volume.yaml.injected
@@ -121,7 +121,7 @@ spec:
           failureThreshold: 30
           httpGet:
             path: /healthz/ready
-            port: 15021
+            port: 15020
           initialDelaySeconds: 1
           periodSeconds: 2
           timeoutSeconds: 3
@@ -176,7 +176,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 15090,15021,15020
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/tools/packaging/common/envoy_bootstrap.json
+++ b/tools/packaging/common/envoy_bootstrap.json
@@ -186,28 +186,6 @@
         }
       },
       {
-        "name": "agent",
-        "type": "STATIC",
-        "connect_timeout": "0.250s",
-        "lb_policy": "ROUND_ROBIN",
-        "load_assignment": {
-          "cluster_name": "agent",
-          "endpoints": [{
-            "lb_endpoints": [{
-              "endpoint": {
-                "address":{
-                  "socket_address": {
-                    "protocol": "TCP",
-                    "address": "{{ .localhost }}",
-                    "port_value": 15020
-                  }
-                }
-              }
-            }]
-          }]
-        }
-      },
-      {
         "name": "sds-grpc",
         "type": "STATIC",
         "http2_protocol_options": {},
@@ -511,55 +489,6 @@
           }
         ]
       },
-      {
-        "address": {
-          "socket_address": {
-            "protocol": "TCP",
-            "address": "{{ .wildcard }}",
-            "port_value": 15021
-          }
-        },
-        "filter_chains": [
-          {
-            "filters": [
-              {
-                "name": "envoy.filters.network.http_connection_manager",
-                "typed_config": {
-                  "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
-                  "codec_type": "AUTO",
-                  "stat_prefix": "agent",
-                  "route_config": {
-                    "virtual_hosts": [
-                      {
-                        "name": "backend",
-                        "domains": [
-                          "*"
-                        ],
-                        "routes": [
-                          {
-                            "match": {
-                              "prefix": "/healthz/ready"
-                            },
-                            "route": {
-                              "cluster": "agent"
-                            }
-                          }
-                        ]
-                      }
-                    ]
-                  },
-                  "http_filters": [{
-                    "name": "envoy.filters.http.router",
-                    "typed_config": {
-                      "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
-                    }
-                  }]
-                }
-              }
-            ]
-          }
-        ]
-      }
     ]
   }
   {{- if .zipkin }}


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

It is unnecessary to route health checks via a static listener on envoy. The agent already checks that the listener has started (warmed and worker accepting), so it does not add any value on top. Moreover, it complicates the set-up making it difficult to run two agents/envoys on one VM.




[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.