### PR TITLE
istioctl upgrade: update tar url  based on os and arch

### DIFF
--- a/operator/cmd/mesh/upgrade.go
+++ b/operator/cmd/mesh/upgrade.go
@@ -60,7 +60,7 @@ const (
 		"    kubectl apply -f < (istioctl kube-inject -f <original application deployment yaml>)"
 
 	// releaseURLPathTemplate is used to construct a download URL for a tar at a given version.
-	releaseURLPathTemplate = "https://github.com/istio/istio/releases/download/%s/istio-%s-%s.tar.gz"
+	releaseURLPathTemplate = "https://github.com/istio/istio/releases/download/%s/istio-%s-%s"
 )
 
 type upgradeArgs struct {
@@ -262,11 +262,23 @@ func upgrade(rootArgs *rootArgs, args *upgradeArgs, l clog.Logger) (err error) {
 
 // releaseURLFromVersion generates default installation url from version number.
 func releaseURLFromVersion(version string) string {
-	osArch := "osx"
-	if runtime.GOOS == "linux" {
-		osArch = runtime.GOOS + "-" + runtime.GOARCH
-	}
+	osArch := platformBasedTar()
 	return fmt.Sprintf(releaseURLPathTemplate, version, version, osArch)
+}
+
+func platformBasedTar() (tarExtension string) {
+	defaultExtension := "osx.tar.gz"
+	switch runtime.GOOS {
+	case "linux":
+		tarExtension = runtime.GOOS + "-" + runtime.GOARCH + ".tar.gz"
+	case "windows":
+		tarExtension = runtime.GOOS + ".zip"
+	case "darwin":
+		tarExtension = defaultExtension
+	default:
+		tarExtension = defaultExtension
+	}
+	return tarExtension
 }
 
 // checkUpgradeIOPS checks the upgrade eligibility by comparing the current IOPS with the target IOPS

--- a/operator/cmd/mesh/upgrade.go
+++ b/operator/cmd/mesh/upgrade.go
@@ -262,11 +262,9 @@ func upgrade(rootArgs *rootArgs, args *upgradeArgs, l clog.Logger) (err error) {
 
 // releaseURLFromVersion generates default installation url from version number.
 func releaseURLFromVersion(version string) string {
-	var osArch string
+	osArch := "osx"
 	if runtime.GOOS == "linux" {
 		osArch = runtime.GOOS + "-" + runtime.GOARCH
-	} else {
-		osArch = "osx"
 	}
 	return fmt.Sprintf(releaseURLPathTemplate, version, version, osArch)
 }

--- a/operator/cmd/mesh/upgrade.go
+++ b/operator/cmd/mesh/upgrade.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"runtime"
 	"strings"
 	"time"
 
@@ -58,9 +59,8 @@ const (
 		"If you’re using manual injection, you can upgrade the sidecar by executing:\n" +
 		"    kubectl apply -f < (istioctl kube-inject -f <original application deployment yaml>)"
 
-	// releaseURLPathTemplate is used to construct a download URL for a tar at a given version. The osx tar is
-	// used because it's stable between 1.5->1.6 and only the profiles are used, not binaries.
-	releaseURLPathTemplate = "https://github.com/istio/istio/releases/download/%s/istio-%s-osx.tar.gz"
+	// releaseURLPathTemplate is used to construct a download URL for a tar at a given version.
+	releaseURLPathTemplate = "https://github.com/istio/istio/releases/download/%s/istio-%s-%s.tar.gz"
 )
 
 type upgradeArgs struct {
@@ -262,7 +262,13 @@ func upgrade(rootArgs *rootArgs, args *upgradeArgs, l clog.Logger) (err error) {
 
 // releaseURLFromVersion generates default installation url from version number.
 func releaseURLFromVersion(version string) string {
-	return fmt.Sprintf(releaseURLPathTemplate, version, version)
+	var osArch string
+	if runtime.GOOS == "linux" {
+		osArch = runtime.GOOS + "-" + runtime.GOARCH
+	} else {
+		osArch = "osx"
+	}
+	return fmt.Sprintf(releaseURLPathTemplate, version, version, osArch)
 }
 
 // checkUpgradeIOPS checks the upgrade eligibility by comparing the current IOPS with the target IOPS


### PR DESCRIPTION
Part of  https://github.com/istio/istio/issues/31411 fix.

The upgrade should look into specific URL tar based on os and arch. currently it's using osx tar because of 1.5 to 1.6 compatibility. But as the 1.5 and 1.6 are EOL. we can dynamically build tar url for release greater than 1.8.
 
