### PR TITLE
Fix high cpu caused by early stop when generating secret

### DIFF
--- a/security/pkg/nodeagent/sds/sdsservice.go
+++ b/security/pkg/nodeagent/sds/sdsservice.go
@@ -109,6 +109,7 @@ func newSDSService(st security.SecretManager, options security.Options) *sdsserv
 	// server in these cases.
 	go func() {
 		b := backoff.NewExponentialBackOff()
+		b.MaxElapsedTime = 0
 		for {
 			_, err := st.GenerateSecret(security.WorkloadKeyCertResourceName)
 			if err == nil {


### PR DESCRIPTION

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ X ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.

The `ExponentialBackOff` has a default 15min's `MaxElapsedTime` which will bring the state to `STOP` after that time. And the use code will enter a nearly infinite loop and cause very high CPU. This change sets the `MaxElapsedTime` to 0 with no-stop semantic.