### PR TITLE
Add telemetry endpoint metadata even when missing workload name

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
@@ -826,18 +826,6 @@ func TestBuildLocalityLbEndpoints(t *testing.T) {
 		},
 	}
 
-	emptyMetadata := &core.Metadata{
-		FilterMetadata: make(map[string]*structpb.Struct),
-	}
-
-	nwMetadata := func(nw string) *core.Metadata {
-		return &core.Metadata{
-			FilterMetadata: map[string]*structpb.Struct{"istio": {Fields: map[string]*structpb.Value{
-				"network": {Kind: &structpb.Value_StringValue{StringValue: nw}},
-			}}},
-		}
-	}
-
 	cases := []struct {
 		name      string
 		mesh      meshconfig.MeshConfig
@@ -854,6 +842,8 @@ func TestBuildLocalityLbEndpoints(t *testing.T) {
 					Endpoint: &model.IstioEndpoint{
 						Address:      "192.168.1.1",
 						EndpointPort: 10001,
+						WorkloadName: "workload-1",
+						Namespace:    "namespace-1",
 						Locality: model.Locality{
 							ClusterID: "cluster-1",
 							Label:     "region1/zone1/subzone1",
@@ -868,6 +858,8 @@ func TestBuildLocalityLbEndpoints(t *testing.T) {
 					Endpoint: &model.IstioEndpoint{
 						Address:      "192.168.1.2",
 						EndpointPort: 10001,
+						WorkloadName: "workload-2",
+						Namespace:    "namespace-2",
 						Locality: model.Locality{
 							ClusterID: "cluster-2",
 							Label:     "region1/zone1/subzone1",
@@ -882,6 +874,8 @@ func TestBuildLocalityLbEndpoints(t *testing.T) {
 					Endpoint: &model.IstioEndpoint{
 						Address:      "192.168.1.3",
 						EndpointPort: 10001,
+						WorkloadName: "workload-3",
+						Namespace:    "namespace-3",
 						Locality: model.Locality{
 							ClusterID: "cluster-3",
 							Label:     "region2/zone1/subzone1",
@@ -896,6 +890,8 @@ func TestBuildLocalityLbEndpoints(t *testing.T) {
 					Endpoint: &model.IstioEndpoint{
 						Address:      "192.168.1.4",
 						EndpointPort: 10001,
+						WorkloadName: "workload-1",
+						Namespace:    "namespace-1",
 						Locality: model.Locality{
 							ClusterID: "cluster-1",
 							Label:     "region1/zone1/subzone1",
@@ -931,7 +927,7 @@ func TestBuildLocalityLbEndpoints(t *testing.T) {
 									},
 								},
 							},
-							Metadata: nwMetadata("nw-0"),
+							Metadata: util.BuildLbEndpointMetadata("nw-0", "", "workload-1", "namespace-1", "cluster-1", map[string]string{}),
 							LoadBalancingWeight: &wrappers.UInt32Value{
 								Value: 30,
 							},
@@ -951,7 +947,7 @@ func TestBuildLocalityLbEndpoints(t *testing.T) {
 									},
 								},
 							},
-							Metadata: nwMetadata("nw-1"),
+							Metadata: util.BuildLbEndpointMetadata("nw-1", "", "workload-2", "namespace-2", "cluster-2", map[string]string{}),
 							LoadBalancingWeight: &wrappers.UInt32Value{
 								Value: 30,
 							},
@@ -983,7 +979,7 @@ func TestBuildLocalityLbEndpoints(t *testing.T) {
 									},
 								},
 							},
-							Metadata: emptyMetadata,
+							Metadata: util.BuildLbEndpointMetadata("", "", "workload-3", "namespace-3", "cluster-3", map[string]string{}),
 							LoadBalancingWeight: &wrappers.UInt32Value{
 								Value: 40,
 							},
@@ -1049,7 +1045,7 @@ func TestBuildLocalityLbEndpoints(t *testing.T) {
 									},
 								},
 							},
-							Metadata: emptyMetadata,
+							Metadata: util.BuildLbEndpointMetadata("", "", "", "", "cluster-1", map[string]string{}),
 							LoadBalancingWeight: &wrappers.UInt32Value{
 								Value: 30,
 							},

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -499,7 +499,7 @@ func MergeAnyWithAny(dst *any.Any, src *any.Any) (*any.Any, error) {
 
 // BuildLbEndpointMetadata adds metadata values to a lb endpoint
 func BuildLbEndpointMetadata(network, tlsMode, workloadname, namespace, clusterID string, labels labels.Instance) *core.Metadata {
-	if network == "" && tlsMode == model.DisabledTLSModeLabel && !shouldAddTelemetryLabel(workloadname) {
+	if network == "" && tlsMode == model.DisabledTLSModeLabel && !shouldAddTelemetryLabel(workloadname, clusterID) {
 		return nil
 	}
 
@@ -524,7 +524,7 @@ func BuildLbEndpointMetadata(network, tlsMode, workloadname, namespace, clusterI
 	// server does not have sidecar injected, and request fails to reach server and thus metadata exchange does not happen.
 	// Due to performance concern, telemetry metadata is compressed into a semicolon separted string:
 	// workload-name;namespace;canonical-service-name;canonical-service-revision.
-	if shouldAddTelemetryLabel(workloadname) {
+	if shouldAddTelemetryLabel(workloadname, clusterID) {
 		var sb strings.Builder
 		sb.WriteString(workloadname)
 		sb.WriteString(";")
@@ -555,8 +555,8 @@ func addIstioEndpointLabel(metadata *core.Metadata, key string, val *pstruct.Val
 	metadata.FilterMetadata[IstioMetadataKey].Fields[key] = val
 }
 
-func shouldAddTelemetryLabel(workloadName string) bool {
-	return features.EndpointTelemetryLabel && (workloadName != "")
+func shouldAddTelemetryLabel(workloadName, clusterID string) bool {
+	return features.EndpointTelemetryLabel && (workloadName != "" || clusterID != "")
 }
 
 // IsAllowAnyOutbound checks if allow_any is enabled for outbound traffic

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -499,7 +499,7 @@ func MergeAnyWithAny(dst *any.Any, src *any.Any) (*any.Any, error) {
 
 // BuildLbEndpointMetadata adds metadata values to a lb endpoint
 func BuildLbEndpointMetadata(network, tlsMode, workloadname, namespace, clusterID string, labels labels.Instance) *core.Metadata {
-	if network == "" && tlsMode == model.DisabledTLSModeLabel && !shouldAddTelemetryLabel(workloadname, clusterID) {
+	if network == "" && (tlsMode == "" || tlsMode == model.DisabledTLSModeLabel) && !features.EndpointTelemetryLabel {
 		return nil
 	}
 
@@ -511,7 +511,7 @@ func BuildLbEndpointMetadata(network, tlsMode, workloadname, namespace, clusterI
 		addIstioEndpointLabel(metadata, "network", &pstruct.Value{Kind: &pstruct.Value_StringValue{StringValue: network}})
 	}
 
-	if tlsMode != "" {
+	if tlsMode != "" && tlsMode != model.DisabledTLSModeLabel {
 		metadata.FilterMetadata[EnvoyTransportSocketMetadataKey] = &pstruct.Struct{
 			Fields: map[string]*pstruct.Value{
 				model.TLSModeLabelShortname: {Kind: &pstruct.Value_StringValue{StringValue: tlsMode}},
@@ -523,8 +523,8 @@ func BuildLbEndpointMetadata(network, tlsMode, workloadname, namespace, clusterI
 	// available at client sidecar, so that telemetry filter could use for metric labels. This is useful for two cases:
 	// server does not have sidecar injected, and request fails to reach server and thus metadata exchange does not happen.
 	// Due to performance concern, telemetry metadata is compressed into a semicolon separted string:
-	// workload-name;namespace;canonical-service-name;canonical-service-revision.
-	if shouldAddTelemetryLabel(workloadname, clusterID) {
+	// workload-name;namespace;canonical-service-name;canonical-service-revision;cluster-id.
+	if features.EndpointTelemetryLabel {
 		var sb strings.Builder
 		sb.WriteString(workloadname)
 		sb.WriteString(";")
@@ -553,10 +553,6 @@ func addIstioEndpointLabel(metadata *core.Metadata, key string, val *pstruct.Val
 	}
 
 	metadata.FilterMetadata[IstioMetadataKey].Fields[key] = val
-}
-
-func shouldAddTelemetryLabel(workloadName, clusterID string) bool {
-	return features.EndpointTelemetryLabel && (workloadName != "" || clusterID != "")
 }
 
 // IsAllowAnyOutbound checks if allow_any is enabled for outbound traffic

--- a/pilot/pkg/networking/util/util_test.go
+++ b/pilot/pkg/networking/util/util_test.go
@@ -1145,7 +1145,19 @@ func TestEndpointMetadata(t *testing.T) {
 			network:      "",
 			workloadName: "",
 			clusterID:    "",
-			want:         nil,
+			want: &core.Metadata{
+				FilterMetadata: map[string]*structpb.Struct{
+					IstioMetadataKey: {
+						Fields: map[string]*structpb.Value{
+							"workload": {
+								Kind: &structpb.Value_StringValue{
+									StringValue: ";;;;",
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 		{
 			name:         "tls mode",
@@ -1160,6 +1172,15 @@ func TestEndpointMetadata(t *testing.T) {
 							model.TLSModeLabelShortname: {
 								Kind: &structpb.Value_StringValue{
 									StringValue: string(model.IstioMutualTLSModeLabel),
+								},
+							},
+						},
+					},
+					IstioMetadataKey: {
+						Fields: map[string]*structpb.Value{
+							"workload": {
+								Kind: &structpb.Value_StringValue{
+									StringValue: ";;;;",
 								},
 							},
 						},
@@ -1189,6 +1210,11 @@ func TestEndpointMetadata(t *testing.T) {
 							"network": {
 								Kind: &structpb.Value_StringValue{
 									StringValue: "network",
+								},
+							},
+							"workload": {
+								Kind: &structpb.Value_StringValue{
+									StringValue: ";;;;",
 								},
 							},
 						},

--- a/pilot/pkg/networking/util/util_test.go
+++ b/pilot/pkg/networking/util/util_test.go
@@ -1270,6 +1270,41 @@ func TestEndpointMetadata(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:         "miss workload name",
+			tlsMode:      string(model.IstioMutualTLSModeLabel),
+			network:      "network",
+			workloadName: "",
+			clusterID:    "cluster",
+			namespace:    "",
+			want: &core.Metadata{
+				FilterMetadata: map[string]*structpb.Struct{
+					EnvoyTransportSocketMetadataKey: {
+						Fields: map[string]*structpb.Value{
+							model.TLSModeLabelShortname: {
+								Kind: &structpb.Value_StringValue{
+									StringValue: string(model.IstioMutualTLSModeLabel),
+								},
+							},
+						},
+					},
+					IstioMetadataKey: {
+						Fields: map[string]*structpb.Value{
+							"network": {
+								Kind: &structpb.Value_StringValue{
+									StringValue: "network",
+								},
+							},
+							"workload": {
+								Kind: &structpb.Value_StringValue{
+									StringValue: ";;;;cluster",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Would be useful in multi cluster multi network environment, to at least indicate the destination cluster when MX does not happen.