### PR TITLE
[release-1.9] test framework: *echotest.T for enumerating subtests

### DIFF
--- a/pkg/test/framework/components/echo/config.go
+++ b/pkg/test/framework/components/echo/config.go
@@ -155,6 +155,18 @@ func (c Config) HostHeader() string {
 	return c.FQDN()
 }
 
+func (c Config) IsHeadless() bool {
+	return c.Headless
+}
+
+func (c Config) IsNaked() bool {
+	return len(c.Subsets) > 0 && c.Subsets[0].Annotations != nil && !c.Subsets[0].Annotations.GetBool(SidecarInject)
+}
+
+func (c Config) IsVM() bool {
+	return c.DeployAsVM
+}
+
 // DeepCopy creates a clone of IstioEndpoint.
 func (c Config) DeepCopy() Config {
 	newc := c
@@ -163,6 +175,10 @@ func (c Config) DeepCopy() Config {
 	newc.Cluster = c.Cluster
 	newc.Namespace = c.Namespace
 	return newc
+}
+
+func (c Config) IsExternal() bool {
+	return c.HostHeader() != c.FQDN()
 }
 
 func copyInternal(v interface{}) interface{} {

--- a/pkg/test/framework/components/echo/echotest/echotest.go
+++ b/pkg/test/framework/components/echo/echotest/echotest.go
@@ -1,0 +1,42 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package echotest
+
+import (
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/echo"
+)
+
+// T enumerates subtests given a set of workloads as echo.Instances.
+type T struct {
+	// rootCtx is the top level test context to generate subtests from and should only be referenced from RunX methods.
+	rootCtx framework.TestContext
+
+	sources      echo.Instances
+	destinations echo.Instances
+
+	destinationFilters []combinationFilter
+
+	sourceDeploymentSetup []func(ctx framework.TestContext, src echo.Instances) error
+	deploymentPairSetup   []func(ctx framework.TestContext, src, dst echo.Instances) error
+}
+
+// New creates a *T using the given applications as sources and destinations for each subtest.
+func New(ctx framework.TestContext, instances echo.Instances) *T {
+	s, d := make(echo.Instances, len(instances)), make(echo.Instances, len(instances))
+	copy(s, instances)
+	copy(d, instances)
+	return &T{rootCtx: ctx, sources: s, destinations: d}
+}

--- a/pkg/test/framework/components/echo/echotest/fake.go
+++ b/pkg/test/framework/components/echo/echotest/fake.go
@@ -1,0 +1,95 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package echotest
+
+import (
+	"fmt"
+
+	"istio.io/istio/pkg/test"
+	"istio.io/istio/pkg/test/echo/client"
+	"istio.io/istio/pkg/test/framework/components/echo"
+	"istio.io/istio/pkg/test/framework/components/echo/common"
+	"istio.io/istio/pkg/test/framework/components/namespace"
+	"istio.io/istio/pkg/test/framework/resource"
+	"istio.io/istio/pkg/test/util/retry"
+)
+
+var _ echo.Instance = fakeInstance{}
+
+func instanceKey(i echo.Instance) string {
+	return fmt.Sprintf("%s.%s.%s", i.Config().Service, i.Config().Namespace.Name(), i.Config().Cluster.Name())
+}
+
+// fakeInstance wraps echo.Config for test-framework internals tests where we don't actually make calls
+type fakeInstance echo.Config
+
+func (f fakeInstance) ID() resource.ID {
+	panic("implement me")
+}
+
+func (f fakeInstance) Config() echo.Config {
+	cfg := echo.Config(f)
+	_ = common.FillInDefaults(nil, &cfg)
+	return cfg
+}
+
+func (f fakeInstance) Address() string {
+	panic("implement me")
+}
+
+func (f fakeInstance) Workloads() ([]echo.Workload, error) {
+	panic("implement me")
+}
+
+func (f fakeInstance) WorkloadsOrFail(t test.Failer) []echo.Workload {
+	panic("implement me")
+}
+
+func (f fakeInstance) Call(options echo.CallOptions) (client.ParsedResponses, error) {
+	panic("implement me")
+}
+
+func (f fakeInstance) CallOrFail(t test.Failer, options echo.CallOptions) client.ParsedResponses {
+	panic("implement me")
+}
+
+func (f fakeInstance) CallWithRetry(options echo.CallOptions, retryOptions ...retry.Option) (client.ParsedResponses, error) {
+	panic("implement me")
+}
+
+func (f fakeInstance) CallWithRetryOrFail(t test.Failer, options echo.CallOptions, retryOptions ...retry.Option) client.ParsedResponses {
+	panic("implement me")
+}
+
+func (f fakeInstance) Restart() error {
+	panic("implement me")
+}
+
+var _ namespace.Instance = fakeNamespace("")
+
+// fakeNamespace allows matching echo.Configs against a namespace.Instance
+type fakeNamespace string
+
+func (f fakeNamespace) Name() string {
+	return string(f)
+}
+
+func (f fakeNamespace) SetLabel(key, value string) error {
+	panic("cannot interact with fake namespace, should not be exposed outside of staticvm")
+}
+
+func (f fakeNamespace) RemoveLabel(key string) error {
+	panic("cannot interact with fake namespace, should not be exposed outside of staticvm")
+}

--- a/pkg/test/framework/components/echo/echotest/filters.go
+++ b/pkg/test/framework/components/echo/echotest/filters.go
@@ -1,0 +1,138 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package echotest
+
+import "istio.io/istio/pkg/test/framework/components/echo"
+
+type (
+	simpleFilter      func(echo.Instances) echo.Instances
+	combinationFilter func(from echo.Instance, to echo.Instances) echo.Instances
+)
+
+// From applies each of the filter functions in order to allow removing workloads from the set of clients.
+// Example:
+//     echotest.New(t, apps).
+//       From(echotest.SingleSimplePodBasedService, echotest.NoExternalServices).
+//       Run()
+func (t *T) From(filters ...simpleFilter) *T {
+	for _, filter := range filters {
+		t.sources = filter(t.sources)
+	}
+	return t
+}
+
+// To applies each of the filter functions in order to allow removing workloads from the set of destinations.
+// Example:
+//     echotest.New(t, apps).
+//       To(echotest.SingleSimplePodBasedService).
+//       Run()
+func (t *T) To(filters ...simpleFilter) *T {
+	for _, filter := range filters {
+		t.destinations = filter(t.destinations)
+	}
+	return t
+}
+
+// ConditionallyTo appends the given filters which are executed per test. Destination filters may need
+// to change behavior based on the client. For example, naked services can't be reached cross-network, so
+// the client matters.
+// Example:
+//     echotest.New(t, apps).
+//       ConditionallyTo(echotest.ReachableDestinations).
+//       Run()
+func (t *T) ConditionallyTo(filters ...combinationFilter) *T {
+	t.destinationFilters = append(t.destinationFilters, filters...)
+	return t
+}
+
+func (t *T) applyCombinationFilters(from echo.Instance, to echo.Instances) echo.Instances {
+	for _, filter := range t.destinationFilters {
+		to = filter(from, to)
+	}
+	return to
+}
+
+// SingleSimplePodBasedService finds the first Pod deployment that has a sidecar and doesn't use a headless service and removes all
+// other "regular" pods that aren't part of the same Service. Pods that are part of the same Service but are in a
+// different cluster or revision will still be included.
+func SingleSimplePodBasedService(instances echo.Instances) echo.Instances {
+	return oneRegularPod(instances)
+}
+
+// NoExternalServices filters out external services which are based on
+func NoExternalServices(instances echo.Instances) echo.Instances {
+	return instances.Match(echo.IsExternal().Negate())
+}
+
+func oneRegularPod(instances echo.Instances) echo.Instances {
+	regularPods := instances.Match(isRegularPod)
+	others := instances.Match(echo.Not(isRegularPod))
+	if len(regularPods) == 0 {
+		return others
+	}
+	regularPods = regularPods.Match(echo.SameDeployment(regularPods[0]))
+	// TODO will the re-ordering end up breaking something or making other filters hard to predict?
+	return append(regularPods, others...)
+}
+
+// TODO put this on echo.Config?
+func isRegularPod(instance echo.Instance) bool {
+	c := instance.Config()
+	return !c.IsVM() && len(c.Subsets) == 1 && !c.IsNaked() && !c.IsHeadless()
+}
+
+// ReachableDestinations filters out known-unreachable destinations given a source.
+// - from a naked pod, we can't reach cross-network endpoints or VMs
+// - we can't reach cross-cluster headless endpoints
+// - from an injected Pod, only non-naked cross-network endpoints are reachable
+var ReachableDestinations combinationFilter = func(from echo.Instance, to echo.Instances) echo.Instances {
+	return to.Match(fromNaked(from).
+		And(fromVM(from)).
+		And(toSameNetworkNaked(from)).
+		And(toInClusterHeadless(from)))
+}
+
+func toInClusterHeadless(from echo.Instance) echo.Matcher {
+	excluded := echo.IsHeadless().
+		And(echo.Not(echo.InCluster(from.Config().Cluster)))
+	return excluded.Negate()
+}
+
+// toSameNetworkNaked filters out naked instances that aren't on the same network.
+// While External services are considered "naked", we won't see 500s due to different loadbalancing.
+func toSameNetworkNaked(from echo.Instance) echo.Matcher {
+	srcNw := from.Config().Cluster.NetworkName()
+	excluded := echo.IsNaked().
+		// TODO we probably don't actually reach all external, but for now maintaining what the tests did
+		And(echo.Not(echo.IsExternal())).
+		And(echo.Not(echo.InNetwork(srcNw)))
+	return excluded.Negate()
+}
+
+// fromVM filters out external services
+func fromVM(from echo.Instance) echo.Matcher {
+	if !from.Config().IsVM() {
+		return echo.Any
+	}
+	return echo.IsExternal().Negate()
+}
+
+// fromNaked filters out all virtual machines and any instance that isn't on the same network
+func fromNaked(from echo.Instance) echo.Matcher {
+	if !from.Config().IsNaked() {
+		return echo.Any
+	}
+	return echo.InNetwork(from.Config().Cluster.NetworkName()).And(echo.IsVirtualMachine().Negate())
+}

--- a/pkg/test/framework/components/echo/echotest/filters_test.go
+++ b/pkg/test/framework/components/echo/echotest/filters_test.go
@@ -1,0 +1,195 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package echotest
+
+import (
+	"strconv"
+	"testing"
+
+	"istio.io/istio/pkg/test/framework/components/cluster"
+	"istio.io/istio/pkg/test/framework/components/echo"
+)
+
+var (
+	// TODO set this up with echobuilder/cluster builder in Fake mode
+
+	// 2 clusters on 2 networks
+	cls1 = &cluster.FakeCluster{Topology: cluster.Topology{ClusterName: "cls1", Network: "n1"}}
+	cls2 = &cluster.FakeCluster{Topology: cluster.Topology{ClusterName: "cls2", Network: "n2"}}
+
+	// simple pod
+	a1 = fakeInstance{Cluster: cls1, Namespace: fakeNamespace("echo"), Service: "a"}
+	a2 = fakeInstance{Cluster: cls2, Namespace: fakeNamespace("echo"), Service: "a"}
+	// simple pod with different svc
+	b1 = fakeInstance{Cluster: cls1, Namespace: fakeNamespace("echo"), Service: "b"}
+	b2 = fakeInstance{Cluster: cls2, Namespace: fakeNamespace("echo"), Service: "b"}
+	// another simple pod with different svc
+	c1 = fakeInstance{Cluster: cls1, Namespace: fakeNamespace("echo"), Service: "c"}
+	c2 = fakeInstance{Cluster: cls2, Namespace: fakeNamespace("echo"), Service: "c"}
+	// simple pod with a different namespace
+	aNs1 = fakeInstance{Cluster: cls1, Namespace: fakeNamespace("echo2"), Service: "a"}
+	aNs2 = fakeInstance{Cluster: cls2, Namespace: fakeNamespace("echo2"), Service: "a"}
+	// virtual machine
+	vm1 = fakeInstance{Cluster: cls1, Namespace: fakeNamespace("echo"), Service: "vm", DeployAsVM: true}
+	vm2 = fakeInstance{Cluster: cls2, Namespace: fakeNamespace("echo"), Service: "vm", DeployAsVM: true}
+	// headless
+	headless1 = fakeInstance{Cluster: cls1, Namespace: fakeNamespace("echo"), Service: "headless", Headless: true}
+	headless2 = fakeInstance{Cluster: cls2, Namespace: fakeNamespace("echo"), Service: "headless", Headless: true}
+	// naked pod (uninjected)
+	naked1 = fakeInstance{Cluster: cls1, Namespace: fakeNamespace("echo"), Service: "naked", Subsets: []echo.SubsetConfig{{
+		Annotations: echo.NewAnnotations().SetBool(echo.SidecarInject, false),
+	}}}
+	naked2 = fakeInstance{Cluster: cls2, Namespace: fakeNamespace("echo"), Service: "naked", Subsets: []echo.SubsetConfig{{
+		Annotations: echo.NewAnnotations().SetBool(echo.SidecarInject, false),
+	}}}
+	// external svc
+	external1 = fakeInstance{
+		Cluster: cls1, Namespace: fakeNamespace("echo"), Service: "external", DefaultHostHeader: "external.com", Subsets: []echo.SubsetConfig{{
+			Annotations: map[echo.Annotation]*echo.AnnotationValue{echo.SidecarInject: {Value: strconv.FormatBool(false)}},
+		}},
+	}
+	external2 = fakeInstance{
+		Cluster: cls2, Namespace: fakeNamespace("echo"), Service: "external", DefaultHostHeader: "external.com", Subsets: []echo.SubsetConfig{{
+			Annotations: map[echo.Annotation]*echo.AnnotationValue{echo.SidecarInject: {Value: strconv.FormatBool(false)}},
+		}},
+	}
+
+	all = echo.Instances{a1, a2, b1, b2, c1, c2, aNs1, aNs2, vm1, vm2, headless1, headless2, naked1, naked2, external1, external2}
+)
+
+func TestIsRegularPod(t *testing.T) {
+	tests := []struct {
+		app    echo.Instance
+		expect bool
+	}{
+		{app: a1, expect: true},
+		{app: b1, expect: true},
+		{app: vm1, expect: false},
+		{app: naked1, expect: false},
+		{app: external1, expect: false},
+		{app: headless1, expect: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.app.Config().Service, func(t *testing.T) {
+			if got := isRegularPod(tt.app); got != tt.expect {
+				t.Errorf("got %v expected %v", got, tt.expect)
+			}
+		})
+	}
+}
+
+func TestIsNaked(t *testing.T) {
+	tests := []struct {
+		app    echo.Instance
+		expect bool
+	}{
+		{app: a1, expect: false},
+		{app: headless1, expect: false},
+		{app: naked1, expect: true},
+		{app: external1, expect: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.app.Config().Service, func(t *testing.T) {
+			if got := tt.app.Config().IsNaked(); got != tt.expect {
+				t.Errorf("got %v expected %v", got, tt.expect)
+			}
+		})
+	}
+}
+
+func TestFilters(t *testing.T) {
+	tests := map[string]struct {
+		filter func(echo.Instances) echo.Instances
+		expect echo.Instances
+	}{
+		"OneRegularPod": {
+			filter: SingleSimplePodBasedService,
+			expect: echo.Instances{
+				// keep all instances of this pod-based service
+				a1, a2,
+				// keep the special cases
+				vm1, vm2,
+				headless1, headless2,
+				naked1, naked2,
+				external1, external2,
+			},
+		},
+		"ReachableDestinations from pod": {
+			filter: func(instances echo.Instances) echo.Instances {
+				return ReachableDestinations(a1, instances)
+			},
+			expect: echo.Instances{
+				// all instances
+				a1, a2, aNs1, aNs2, b1, b2, c1, c2, vm1, vm2, external1, external2,
+				// only same network/cluster
+				headless1, naked1,
+			},
+		},
+		"ReachableDestinations from naked": {
+			filter: func(instances echo.Instances) echo.Instances {
+				return ReachableDestinations(naked1, instances)
+			},
+			expect: echo.Instances{
+				// only same network/cluster, no VMs
+				a1, aNs1, b1, c1, headless1, naked1, external1,
+			},
+		},
+		"ReachableDestinations from vm": {
+			filter: func(instances echo.Instances) echo.Instances {
+				return ReachableDestinations(vm1, instances)
+			},
+			expect: echo.Instances{
+				// all pods/vms, no external
+				a1, a2, aNs1, aNs2, b1, b2, c1, c2, vm1, vm2,
+				// only same network/cluster
+				headless1, naked1,
+			},
+		},
+	}
+	for n, tc := range tests {
+		n, tc := n, tc
+		t.Run(n, func(t *testing.T) {
+			compare(t, tc.filter(all), tc.expect)
+		})
+	}
+}
+
+func compare(t *testing.T, got echo.Instances, want echo.Instances) {
+	if len(got) != len(want) {
+		t.Errorf("got %d instnaces but expected %d", len(got), len(want))
+	}
+	expected := map[string]struct{}{}
+	for _, i := range want {
+		expected[instanceKey(i)] = struct{}{}
+	}
+	unexpected := map[string]struct{}{}
+	for _, i := range all {
+		k := instanceKey(i)
+		if _, ok := expected[k]; !ok {
+			unexpected[k] = struct{}{}
+		}
+	}
+	for _, i := range got {
+		k := instanceKey(i)
+		// just remove the items rather than looping over expected, if anythings left we missed it
+		delete(expected, k)
+		if _, ok := unexpected[k]; ok {
+			t.Errorf("expected %s to be filtered out", k)
+		}
+	}
+	if len(expected) > 0 {
+		t.Errorf("did not include %v", expected)
+	}
+}

--- a/pkg/test/framework/components/echo/echotest/run.go
+++ b/pkg/test/framework/components/echo/echotest/run.go
@@ -1,0 +1,80 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package echotest
+
+import (
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/echo"
+)
+
+type (
+	perDeploymentTest func(ctx framework.TestContext, instances echo.Instances)
+	perInstanceTest   func(ctx framework.TestContext, src echo.Instance, dst echo.Instances)
+)
+
+// Run will generate nested subtests for every instance in every deployment. The subtests will be nested including
+// the source service, source cluster and destination deployment. Example: `a/to_b/from_cluster-0`
+func (t *T) Run(testFn perInstanceTest) {
+	t.fromEachDeployment(t.rootCtx, func(ctx framework.TestContext, srcInstances echo.Instances) {
+		t.setup(ctx, srcInstances)
+		t.toEachDeployment(ctx, func(ctx framework.TestContext, dstInstances echo.Instances) {
+			t.setupPair(ctx, srcInstances, dstInstances)
+			t.fromEachCluster(ctx, srcInstances, dstInstances, testFn)
+		})
+	})
+}
+
+// fromEachDeployment enumerates subtests for deployment with the structure <src>
+// Intended to be used in combination with other helpers to enumerate subtests for destinations.
+func (t *T) fromEachDeployment(ctx framework.TestContext, testFn perDeploymentTest) {
+	for _, src := range t.sources.Deployments() {
+		src := src
+		ctx.NewSubTestf("%s", src[0].Config().Service).Run(func(ctx framework.TestContext) {
+			testFn(ctx, src)
+		})
+	}
+}
+
+// toEachDeployment enumerates subtests for every deployment as a destination, adding /to_<dst> to the parent test.
+// Intended to be used in combination with other helpers which enumerates the subtests and chooses the srcInstnace.
+func (t *T) toEachDeployment(ctx framework.TestContext, testFn perDeploymentTest) {
+	for _, dst := range t.destinations.Deployments() {
+		dst := dst
+		ctx.NewSubTestf("to %s", dst[0].Config().Service).Run(func(ctx framework.TestContext) {
+			testFn(ctx, dst)
+		})
+	}
+}
+
+func (t *T) fromEachCluster(ctx framework.TestContext, src, dst echo.Instances, testFn perInstanceTest) {
+	for _, srcInstance := range src {
+		srcInstance := srcInstance
+		filteredDst := t.applyCombinationFilters(srcInstance, dst)
+		if len(filteredDst) == 0 {
+			// this only happens due to conditional filters and when an entire deployment is filtered we should be noisy
+			ctx.Skipf("cases from %s in %s with %s as destination are removed by filters ",
+				srcInstance.Config().Service, srcInstance.Config().Cluster.StableName(), dst[0].Config().Service)
+			continue
+		}
+		if len(ctx.Clusters()) == 1 && len(src) == 1 {
+			testFn(ctx, srcInstance, filteredDst)
+		} else {
+			ctx.NewSubTestf("from %s", srcInstance.Config().Cluster.StableName()).Run(func(ctx framework.TestContext) {
+				testFn(ctx, srcInstance, filteredDst)
+			})
+		}
+
+	}
+}

--- a/pkg/test/framework/components/echo/echotest/setup.go
+++ b/pkg/test/framework/components/echo/echotest/setup.go
@@ -1,0 +1,62 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package echotest
+
+import (
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/echo"
+)
+
+// Setup runs the given function in the source deployment context. For example, given apps a, b, and c in 2 clusters,
+// these tests would all run before the the context is cleaned up:
+//     a/to_b/from_cluster-1
+//     a/to_b/from_cluster-2
+//     a/to_c/from_cluster-1
+//     a/to_c/from_cluster-2
+//     cleanup...
+//     b/to_a/from_cluster-1
+//     ...
+func (t *T) Setup(setupFn func(ctx framework.TestContext, src echo.Instances) error) *T {
+	t.sourceDeploymentSetup = append(t.sourceDeploymentSetup, setupFn)
+	return t
+}
+
+func (t *T) setup(ctx framework.TestContext, srcInstances echo.Instances) {
+	for _, setupFn := range t.sourceDeploymentSetup {
+		if err := setupFn(ctx, srcInstances); err != nil {
+			ctx.Fatal(err)
+		}
+	}
+}
+
+// SetupForPair runs the given function in the source + destination deployment context. For example, given apps a, b,
+// and c in 2 clusters, these tests would all run before the the context is cleaned up:
+//     a/to_b/from_cluster-1
+//     a/to_b/from_cluster-2
+//     cleanup...
+//     a/to_b/from_cluster-2
+//     ...
+func (t *T) SetupForPair(setupFn func(ctx framework.TestContext, src echo.Instances, dst echo.Instances) error) *T {
+	t.deploymentPairSetup = append(t.deploymentPairSetup, setupFn)
+	return t
+}
+
+func (t *T) setupPair(ctx framework.TestContext, src echo.Instances, dst echo.Instances) {
+	for _, setupFn := range t.deploymentPairSetup {
+		if err := setupFn(ctx, src, dst); err != nil {
+			ctx.Fatal(err)
+		}
+	}
+}

--- a/pkg/test/framework/testcontext.go
+++ b/pkg/test/framework/testcontext.go
@@ -44,6 +44,7 @@ type TestContext interface {
 	//
 	// If this TestContext was not created by a Test or if that Test is not running, this method will panic.
 	NewSubTest(name string) Test
+	NewSubTestf(format string, a ...interface{}) Test
 
 	// WorkDir allocated for this test.
 	WorkDir() string
@@ -85,8 +86,10 @@ type TestContext interface {
 	Skipped() bool
 }
 
-var _ TestContext = &testContext{}
-var _ test.Failer = &testContext{}
+var (
+	_ TestContext = &testContext{}
+	_ test.Failer = &testContext{}
+)
 
 // testContext for the currently executing test.
 type testContext struct {
@@ -278,6 +281,10 @@ func (c *testContext) NewSubTest(name string) Test {
 		s:             c.test.s,
 		featureLabels: c.test.featureLabels,
 	}
+}
+
+func (c *testContext) NewSubTestf(format string, a ...interface{}) Test {
+	return c.NewSubTest(fmt.Sprintf(format, a...))
 }
 
 func (c *testContext) WhenDone(fn func() error) {


### PR DESCRIPTION

cherry-pick of #31373 

fixes #31498 

this will help us keep coverage high as new tests are added without as much manual backporting/conversion