### PR TITLE
make virtual service tests workload agnostic

### DIFF
--- a/pkg/test/framework/components/echo/echotest/echotest.go
+++ b/pkg/test/framework/components/echo/echotest/echotest.go
@@ -27,7 +27,7 @@ type T struct {
 	sources      echo.Instances
 	destinations echo.Instances
 
-	destinationFilters []combinationFilter
+	destinationFilters []CombinationFilter
 
 	sourceDeploymentSetup []func(ctx framework.TestContext, src echo.Instances) error
 	deploymentPairSetup   []func(ctx framework.TestContext, src, dst echo.Instances) error

--- a/pkg/test/framework/components/echo/echotest/filters.go
+++ b/pkg/test/framework/components/echo/echotest/filters.go
@@ -17,8 +17,8 @@ package echotest
 import "istio.io/istio/pkg/test/framework/components/echo"
 
 type (
-	simpleFilter      func(echo.Instances) echo.Instances
-	combinationFilter func(from echo.Instance, to echo.Instances) echo.Instances
+	SimpleFilter      func(echo.Instances) echo.Instances
+	CombinationFilter func(from echo.Instance, to echo.Instances) echo.Instances
 )
 
 // From applies each of the filter functions in order to allow removing workloads from the set of clients.
@@ -26,7 +26,7 @@ type (
 //     echotest.New(t, apps).
 //       From(echotest.SingleSimplePodBasedService, echotest.NoExternalServices).
 //       Run()
-func (t *T) From(filters ...simpleFilter) *T {
+func (t *T) From(filters ...SimpleFilter) *T {
 	for _, filter := range filters {
 		t.sources = filter(t.sources)
 	}
@@ -38,7 +38,7 @@ func (t *T) From(filters ...simpleFilter) *T {
 //     echotest.New(t, apps).
 //       To(echotest.SingleSimplePodBasedService).
 //       Run()
-func (t *T) To(filters ...simpleFilter) *T {
+func (t *T) To(filters ...SimpleFilter) *T {
 	for _, filter := range filters {
 		t.destinations = filter(t.destinations)
 	}
@@ -52,7 +52,7 @@ func (t *T) To(filters ...simpleFilter) *T {
 //     echotest.New(t, apps).
 //       ConditionallyTo(echotest.ReachableDestinations).
 //       Run()
-func (t *T) ConditionallyTo(filters ...combinationFilter) *T {
+func (t *T) ConditionallyTo(filters ...CombinationFilter) *T {
 	t.destinationFilters = append(t.destinationFilters, filters...)
 	return t
 }
@@ -97,7 +97,7 @@ func isRegularPod(instance echo.Instance) bool {
 // - from a naked pod, we can't reach cross-network endpoints or VMs
 // - we can't reach cross-cluster headless endpoints
 // - from an injected Pod, only non-naked cross-network endpoints are reachable
-var ReachableDestinations combinationFilter = func(from echo.Instance, to echo.Instances) echo.Instances {
+var ReachableDestinations CombinationFilter = func(from echo.Instance, to echo.Instances) echo.Instances {
 	return to.Match(fromNaked(from).
 		And(fromVM(from)).
 		And(toSameNetworkNaked(from)).

--- a/pkg/test/framework/components/echo/echotest/filters.go
+++ b/pkg/test/framework/components/echo/echotest/filters.go
@@ -115,9 +115,10 @@ func isRegularPod(instance echo.Instance) bool {
 func Not(filter SimpleFilter) SimpleFilter {
 	return func(instances echo.Instances) echo.Instances {
 		filtered := filter(instances)
-		return instances.Match(func(instance echo.Instance) bool {
+		inverted := instances.Match(func(instance echo.Instance) bool {
 			return !filtered.Contains(instance)
 		})
+		return inverted
 	}
 }
 
@@ -128,7 +129,7 @@ func VirtualMachines(instances echo.Instances) echo.Instances {
 
 // ExternalServices includes services that are based on naked pods with a custom DefaultHostHeader
 func ExternalServices(instances echo.Instances) echo.Instances {
-	return instances.Match(echo.Not(echo.IsExternal()))
+	return instances.Match(echo.IsExternal())
 }
 
 // ReachableDestinations filters out known-unreachable destinations given a source.

--- a/pkg/test/framework/components/echo/echotest/filters_test.go
+++ b/pkg/test/framework/components/echo/echotest/filters_test.go
@@ -24,8 +24,6 @@ import (
 	"istio.io/istio/pkg/test/framework/components/cluster"
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/resource"
-	"istio.io/istio/pkg/test/scopes"
-	"istio.io/pkg/log"
 )
 
 var (
@@ -36,37 +34,37 @@ var (
 	cls2 = &cluster.FakeCluster{Topology: cluster.Topology{ClusterName: "cls2", Network: "n2", Index: 1, ClusterKind: cluster.Fake}}
 
 	// simple pod
-	a1 = fakeInstance{Cluster: cls1, Namespace: fakeNamespace("echo"), Service: "a"}
-	a2 = fakeInstance{Cluster: cls2, Namespace: fakeNamespace("echo"), Service: "a"}
+	a1 = &fakeInstance{Cluster: cls1, Namespace: fakeNamespace("echo"), Service: "a"}
+	a2 = &fakeInstance{Cluster: cls2, Namespace: fakeNamespace("echo"), Service: "a"}
 	// simple pod with different svc
-	b1 = fakeInstance{Cluster: cls1, Namespace: fakeNamespace("echo"), Service: "b"}
-	b2 = fakeInstance{Cluster: cls2, Namespace: fakeNamespace("echo"), Service: "b"}
+	b1 = &fakeInstance{Cluster: cls1, Namespace: fakeNamespace("echo"), Service: "b"}
+	b2 = &fakeInstance{Cluster: cls2, Namespace: fakeNamespace("echo"), Service: "b"}
 	// another simple pod with different svc
-	c1 = fakeInstance{Cluster: cls1, Namespace: fakeNamespace("echo"), Service: "c"}
-	c2 = fakeInstance{Cluster: cls2, Namespace: fakeNamespace("echo"), Service: "c"}
+	c1 = &fakeInstance{Cluster: cls1, Namespace: fakeNamespace("echo"), Service: "c"}
+	c2 = &fakeInstance{Cluster: cls2, Namespace: fakeNamespace("echo"), Service: "c"}
 	// simple pod with a different namespace
-	aNs1 = fakeInstance{Cluster: cls1, Namespace: fakeNamespace("echo2"), Service: "a"}
-	aNs2 = fakeInstance{Cluster: cls2, Namespace: fakeNamespace("echo2"), Service: "a"}
+	aNs1 = &fakeInstance{Cluster: cls1, Namespace: fakeNamespace("echo2"), Service: "a"}
+	aNs2 = &fakeInstance{Cluster: cls2, Namespace: fakeNamespace("echo2"), Service: "a"}
 	// virtual machine
-	vm1 = fakeInstance{Cluster: cls1, Namespace: fakeNamespace("echo"), Service: "vm", DeployAsVM: true}
-	vm2 = fakeInstance{Cluster: cls2, Namespace: fakeNamespace("echo"), Service: "vm", DeployAsVM: true}
+	vm1 = &fakeInstance{Cluster: cls1, Namespace: fakeNamespace("echo"), Service: "vm", DeployAsVM: true}
+	vm2 = &fakeInstance{Cluster: cls2, Namespace: fakeNamespace("echo"), Service: "vm", DeployAsVM: true}
 	// headless
-	headless1 = fakeInstance{Cluster: cls1, Namespace: fakeNamespace("echo"), Service: "headless", Headless: true}
-	headless2 = fakeInstance{Cluster: cls2, Namespace: fakeNamespace("echo"), Service: "headless", Headless: true}
+	headless1 = &fakeInstance{Cluster: cls1, Namespace: fakeNamespace("echo"), Service: "headless", Headless: true}
+	headless2 = &fakeInstance{Cluster: cls2, Namespace: fakeNamespace("echo"), Service: "headless", Headless: true}
 	// naked pod (uninjected)
-	naked1 = fakeInstance{Cluster: cls1, Namespace: fakeNamespace("echo"), Service: "naked", Subsets: []echo.SubsetConfig{{
+	naked1 = &fakeInstance{Cluster: cls1, Namespace: fakeNamespace("echo"), Service: "naked", Subsets: []echo.SubsetConfig{{
 		Annotations: echo.NewAnnotations().SetBool(echo.SidecarInject, false),
 	}}}
-	naked2 = fakeInstance{Cluster: cls2, Namespace: fakeNamespace("echo"), Service: "naked", Subsets: []echo.SubsetConfig{{
+	naked2 = &fakeInstance{Cluster: cls2, Namespace: fakeNamespace("echo"), Service: "naked", Subsets: []echo.SubsetConfig{{
 		Annotations: echo.NewAnnotations().SetBool(echo.SidecarInject, false),
 	}}}
 	// external svc
-	external1 = fakeInstance{
+	external1 = &fakeInstance{
 		Cluster: cls1, Namespace: fakeNamespace("echo"), Service: "external", DefaultHostHeader: "external.com", Subsets: []echo.SubsetConfig{{
 			Annotations: map[echo.Annotation]*echo.AnnotationValue{echo.SidecarInject: {Value: strconv.FormatBool(false)}},
 		}},
 	}
-	external2 = fakeInstance{
+	external2 = &fakeInstance{
 		Cluster: cls2, Namespace: fakeNamespace("echo"), Service: "external", DefaultHostHeader: "external.com", Subsets: []echo.SubsetConfig{{
 			Annotations: map[echo.Annotation]*echo.AnnotationValue{echo.SidecarInject: {Value: strconv.FormatBool(false)}},
 		}},
@@ -179,9 +177,6 @@ func TestFilters(t *testing.T) {
 func TestDefaultFilters(t *testing.T) {
 	// source svc/cluster -> dest services -> number of subtests (should == num clusters)
 	testTopology := map[string]map[string]int{}
-
-	oldLevel := scopes.Framework.GetOutputLevel()
-	scopes.Framework.SetOutputLevel(log.NoneLevel)
 	framework.NewTest(t).Run(func(t framework.TestContext) {
 		New(t, all).
 			WithDefaultFilters().
@@ -195,8 +190,6 @@ func TestDefaultFilters(t *testing.T) {
 				testTopology[srcKey][dstKey]++
 			})
 	})
-	scopes.Framework.SetOutputLevel(oldLevel)
-
 	if diff := cmp.Diff(testTopology, map[string]map[string]int{
 		"a.echo.svc.cluster.local": {
 			"b.echo.svc.cluster.local":        2,

--- a/pkg/test/framework/components/echo/echotest/filters_test.go
+++ b/pkg/test/framework/components/echo/echotest/filters_test.go
@@ -18,6 +18,14 @@ import (
 	"strconv"
 	"testing"
 
+	"istio.io/istio/pkg/test/scopes"
+	"istio.io/pkg/log"
+
+	"github.com/google/go-cmp/cmp"
+
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/resource"
+
 	"istio.io/istio/pkg/test/framework/components/cluster"
 	"istio.io/istio/pkg/test/framework/components/echo"
 )
@@ -26,8 +34,8 @@ var (
 	// TODO set this up with echobuilder/cluster builder in Fake mode
 
 	// 2 clusters on 2 networks
-	cls1 = &cluster.FakeCluster{Topology: cluster.Topology{ClusterName: "cls1", Network: "n1"}}
-	cls2 = &cluster.FakeCluster{Topology: cluster.Topology{ClusterName: "cls2", Network: "n2"}}
+	cls1 = &cluster.FakeCluster{Topology: cluster.Topology{ClusterName: "cls1", Network: "n1", Index: 0, ClusterKind: cluster.Fake}}
+	cls2 = &cluster.FakeCluster{Topology: cluster.Topology{ClusterName: "cls2", Network: "n2", Index: 1, ClusterKind: cluster.Fake}}
 
 	// simple pod
 	a1 = fakeInstance{Cluster: cls1, Namespace: fakeNamespace("echo"), Service: "a"}
@@ -68,6 +76,10 @@ var (
 
 	all = echo.Instances{a1, a2, b1, b2, c1, c2, aNs1, aNs2, vm1, vm2, headless1, headless2, naked1, naked2, external1, external2}
 )
+
+func TestMain(m *testing.M) {
+	framework.NewSuite(m).EnvironmentFactory(resource.NilEnvironmentFactory).Run()
+}
 
 func TestIsRegularPod(t *testing.T) {
 	tests := []struct {
@@ -114,8 +126,8 @@ func TestFilters(t *testing.T) {
 		filter func(echo.Instances) echo.Instances
 		expect echo.Instances
 	}{
-		"OneRegularPod": {
-			filter: SingleSimplePodBasedService,
+		"SingleSimplePodServiceAndAllSpecial": {
+			filter: SingleSimplePodServiceAndAllSpecial(),
 			expect: echo.Instances{
 				// keep all instances of this pod-based service
 				a1, a2,
@@ -163,6 +175,59 @@ func TestFilters(t *testing.T) {
 		t.Run(n, func(t *testing.T) {
 			compare(t, tc.filter(all), tc.expect)
 		})
+	}
+}
+
+func TestDefaultFilters(t *testing.T) {
+	// source svc/cluster -> dest services -> number of subtests (should == num clusters)
+	testTopology := map[string]map[string]int{}
+
+	oldLevel := scopes.Framework.GetOutputLevel()
+	scopes.Framework.SetOutputLevel(log.NoneLevel)
+	framework.NewTest(t).Run(func(t framework.TestContext) {
+		New(t, all).
+			WithDefaultFilters().
+			Run(func(ctx framework.TestContext, src echo.Instance, dst echo.Instances) {
+				// TODO if the destinations would change based on which cluster then add cluster to srCkey
+				srcKey := src.Config().FQDN()
+				dstKey := dst[0].Config().FQDN()
+				if testTopology[srcKey] == nil {
+					testTopology[srcKey] = map[string]int{}
+				}
+				testTopology[srcKey][dstKey]++
+			})
+	})
+	scopes.Framework.SetOutputLevel(oldLevel)
+
+	if diff := cmp.Diff(testTopology, map[string]map[string]int{
+		"a.echo.svc.cluster.local": {
+			"b.echo.svc.cluster.local":        2,
+			"external.echo.svc.cluster.local": 2,
+			"headless.echo.svc.cluster.local": 2,
+			"naked.echo.svc.cluster.local":    2,
+			"vm.echo.svc.cluster.local":       2,
+		},
+		"headless.echo.svc.cluster.local": {
+			"b.echo.svc.cluster.local":        2,
+			"external.echo.svc.cluster.local": 2,
+			"headless.echo.svc.cluster.local": 2,
+			"naked.echo.svc.cluster.local":    2,
+			"vm.echo.svc.cluster.local":       2,
+		},
+		"naked.echo.svc.cluster.local": {
+			"b.echo.svc.cluster.local":        2,
+			"external.echo.svc.cluster.local": 2,
+			"headless.echo.svc.cluster.local": 2,
+			"naked.echo.svc.cluster.local":    2,
+		},
+		"vm.echo.svc.cluster.local": {
+			"b.echo.svc.cluster.local":        2,
+			"headless.echo.svc.cluster.local": 2,
+			"naked.echo.svc.cluster.local":    2,
+			"vm.echo.svc.cluster.local":       2,
+		},
+	}); diff != "" {
+		t.Errorf(diff)
 	}
 }
 

--- a/pkg/test/framework/components/echo/echotest/filters_test.go
+++ b/pkg/test/framework/components/echo/echotest/filters_test.go
@@ -18,16 +18,14 @@ import (
 	"strconv"
 	"testing"
 
-	"istio.io/istio/pkg/test/scopes"
-	"istio.io/pkg/log"
-
 	"github.com/google/go-cmp/cmp"
 
 	"istio.io/istio/pkg/test/framework"
-	"istio.io/istio/pkg/test/framework/resource"
-
 	"istio.io/istio/pkg/test/framework/components/cluster"
 	"istio.io/istio/pkg/test/framework/components/echo"
+	"istio.io/istio/pkg/test/framework/resource"
+	"istio.io/istio/pkg/test/scopes"
+	"istio.io/pkg/log"
 )
 
 var (

--- a/pkg/test/framework/suite.go
+++ b/pkg/test/framework/suite.go
@@ -406,7 +406,7 @@ func (s *suiteImpl) writeOutput() {
 		if err != nil {
 			log.Errorf("failed writing test suite outcome to yaml: %s", err)
 		}
-		err = ioutil.WriteFile(path.Join(artifactsPath, out.Name+".yaml"), outbytes, 0644)
+		err = ioutil.WriteFile(path.Join(artifactsPath, out.Name+".yaml"), outbytes, 0o644)
 		if err != nil {
 			log.Errorf("failed writing test suite outcome to file: %s", err)
 		}

--- a/pkg/test/framework/testcontext.go
+++ b/pkg/test/framework/testcontext.go
@@ -201,6 +201,9 @@ func (c *testContext) Environment() resource.Environment {
 }
 
 func (c *testContext) Clusters() cluster.Clusters {
+	if c == nil || c.Environment() == nil {
+		return nil
+	}
 	return c.Environment().Clusters()
 }
 

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -24,14 +24,13 @@ import (
 	"strings"
 	"time"
 
-	"istio.io/istio/pkg/test/framework/components/echo/echotest"
-
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/test"
 	echoclient "istio.io/istio/pkg/test/echo/client"
 	"istio.io/istio/pkg/test/echo/common/scheme"
 	epb "istio.io/istio/pkg/test/echo/proto"
 	"istio.io/istio/pkg/test/framework/components/echo"
+	"istio.io/istio/pkg/test/framework/components/echo/echotest"
 	"istio.io/istio/pkg/test/util/retry"
 	"istio.io/istio/pkg/test/util/tmpl"
 )

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -24,6 +24,8 @@ import (
 	"strings"
 	"time"
 
+	"istio.io/istio/pkg/test/framework/components/echo/echotest"
+
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/test"
 	echoclient "istio.io/istio/pkg/test/echo/client"
@@ -210,6 +212,8 @@ spec:
 		},
 		TrafficTestCase{
 			name: "cors",
+			// TODO https://github.com/istio/istio/issues/31532
+			targetFilters: []echotest.SimpleFilter{echotest.Not(echotest.VirtualMachines)},
 			config: `
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -298,6 +298,7 @@ spec:
 					},
 				},
 			},
+			workloadAgnostic: true,
 		},
 	)
 

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -389,6 +389,15 @@ spec:
 		}
 	}
 
+	// reduce the total # of subtests that don't give valuable coverage
+	for _, tc := range cases {
+		noNakedHeadless := func(instances echo.Instances) echo.Instances {
+			return instances.Match(echo.Not(echo.IsNaked()).And(echo.Not(echo.IsHeadless())))
+		}
+		tc.sourceFilters = append(tc.sourceFilters, noNakedHeadless)
+		tc.targetFilters = append(tc.targetFilters, noNakedHeadless)
+	}
+
 	return cases
 }
 

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -390,7 +390,7 @@ spec:
 		}
 	}
 
-	// reduce the total # of subtests that don't give valuable coverage
+	// reduce the total # of subtests that don't give valuable coverage or just don't work
 	for i, tc := range cases {
 		noNakedHeadless := func(instances echo.Instances) echo.Instances {
 			return instances.Match(echo.Not(echo.IsNaked()).And(echo.Not(echo.IsHeadless())))

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -390,12 +390,13 @@ spec:
 	}
 
 	// reduce the total # of subtests that don't give valuable coverage
-	for _, tc := range cases {
+	for i, tc := range cases {
 		noNakedHeadless := func(instances echo.Instances) echo.Instances {
 			return instances.Match(echo.Not(echo.IsNaked()).And(echo.Not(echo.IsHeadless())))
 		}
 		tc.sourceFilters = append(tc.sourceFilters, noNakedHeadless)
 		tc.targetFilters = append(tc.targetFilters, noNakedHeadless)
+		cases[i] = tc
 	}
 
 	return cases

--- a/tests/integration/pilot/common/traffic.go
+++ b/tests/integration/pilot/common/traffic.go
@@ -93,13 +93,13 @@ func (c TrafficTestCase) RunForApps(t framework.TestContext, apps echo.Instances
 
 	echotest.New(t, apps).
 		SetupForPair(func(t framework.TestContext, src, dst echo.Instances) error {
-			cfg := tmpl.MustEvaluate(
-				yml.MustApplyNamespace(t, c.config, namespace),
-				map[string]echo.Instances{
+			cfg := yml.MustApplyNamespace(t, tmpl.MustEvaluate(
+				c.config,
+				map[string]interface{}{
 					"src": src,
 					"dst": dst,
 				},
-			)
+			), namespace)
 			return t.Config().ApplyYAML("", cfg)
 		}).
 		From(append(defaulltSourceFilters, c.sourceFilters...)...).

--- a/tests/integration/pilot/common/traffic.go
+++ b/tests/integration/pilot/common/traffic.go
@@ -69,12 +69,6 @@ type TrafficTestCase struct {
 	targetFilters []echotest.SimpleFilter
 }
 
-var (
-	// TODO move to echotest?
-	defaultSourceFilters = []echotest.SimpleFilter{echotest.SingleSimplePodBasedService, echotest.NoExternalServices}
-	defaultTargetFilters = []echotest.SimpleFilter{echotest.SingleSimplePodBasedService}
-)
-
 func (c TrafficTestCase) RunForApps(t framework.TestContext, apps echo.Instances, namespace string) {
 	if c.opts.Target != nil {
 		t.Fatal("TrafficTestCase.RunForApps: opts.Target must not be specified")
@@ -100,9 +94,9 @@ func (c TrafficTestCase) RunForApps(t framework.TestContext, apps echo.Instances
 				), namespace)
 				return t.Config().ApplyYAML("", cfg)
 			}).
-			From(append(defaultSourceFilters, c.sourceFilters...)...).
-			ConditionallyTo(echotest.ReachableDestinations).
-			To(append(defaultTargetFilters, c.targetFilters...)...).
+			WithDefaultFilters().
+			From(c.sourceFilters...).
+			To(c.targetFilters...).
 			Run(func(t framework.TestContext, src echo.Instance, dest echo.Instances) {
 				if c.skip {
 					t.SkipNow()

--- a/tests/integration/pilot/common/traffic.go
+++ b/tests/integration/pilot/common/traffic.go
@@ -76,9 +76,6 @@ var (
 )
 
 func (c TrafficTestCase) RunForApps(t framework.TestContext, apps echo.Instances, namespace string) {
-	if c.skip {
-		t.SkipNow()
-	}
 	if c.opts.Target != nil {
 		t.Fatal("TrafficTestCase.RunForApps: opts.Target must not be specified")
 	}
@@ -91,39 +88,50 @@ func (c TrafficTestCase) RunForApps(t framework.TestContext, apps echo.Instances
 		t.Fatal("TrafficTestCase: must not specify both opts and children")
 	}
 
-	echotest.New(t, apps).
-		SetupForPair(func(t framework.TestContext, src, dst echo.Instances) error {
-			cfg := yml.MustApplyNamespace(t, tmpl.MustEvaluate(
-				c.config,
-				map[string]interface{}{
-					"src": src,
-					"dst": dst,
-				},
-			), namespace)
-			return t.Config().ApplyYAML("", cfg)
-		}).
-		From(append(defaulltSourceFilters, c.sourceFilters...)...).
-		ConditionallyTo(echotest.ReachableDestinations).
-		To(append(defaulltTargetFilters, c.targetFilters...)...).
-		Run(func(t framework.TestContext, src echo.Instance, dest echo.Instances) {
-			buildOpts := func(options echo.CallOptions) echo.CallOptions {
-				opts := options
-				opts.Target = dest[0]
-				if c.validate != nil {
-					opts.Validator = c.validate(src, dest)
+	job := func(t framework.TestContext) {
+		echotest.New(t, apps).
+			SetupForPair(func(t framework.TestContext, src, dst echo.Instances) error {
+				cfg := yml.MustApplyNamespace(t, tmpl.MustEvaluate(
+					c.config,
+					map[string]interface{}{
+						"src": src,
+						"dst": dst,
+					},
+				), namespace)
+				return t.Config().ApplyYAML("", cfg)
+			}).
+			From(append(defaulltSourceFilters, c.sourceFilters...)...).
+			ConditionallyTo(echotest.ReachableDestinations).
+			To(append(defaulltTargetFilters, c.targetFilters...)...).
+			Run(func(t framework.TestContext, src echo.Instance, dest echo.Instances) {
+				if c.skip {
+					t.SkipNow()
 				}
-				opts.Count = callsPerCluster * len(dest)
-				return opts
-			}
-			if optsSpecified {
-				src.CallWithRetryOrFail(t, buildOpts(c.opts), retryOptions...)
-			}
-			for _, child := range c.children {
-				t.NewSubTest(child.name).Run(func(t framework.TestContext) {
-					src.CallWithRetryOrFail(t, buildOpts(child.opts), retryOptions...)
-				})
-			}
-		})
+				buildOpts := func(options echo.CallOptions) echo.CallOptions {
+					opts := options
+					opts.Target = dest[0]
+					if c.validate != nil {
+						opts.Validator = c.validate(src, dest)
+					}
+					opts.Count = callsPerCluster * len(dest)
+					return opts
+				}
+				if optsSpecified {
+					src.CallWithRetryOrFail(t, buildOpts(c.opts), retryOptions...)
+				}
+				for _, child := range c.children {
+					t.NewSubTest(child.name).Run(func(t framework.TestContext) {
+						src.CallWithRetryOrFail(t, buildOpts(child.opts), retryOptions...)
+					})
+				}
+			})
+	}
+
+	if c.name != "" {
+		t.NewSubTest(c.name).Run(job)
+	} else {
+		job(t)
+	}
 }
 
 func (c TrafficTestCase) Run(t framework.TestContext, namespace string) {

--- a/tests/integration/pilot/common/traffic.go
+++ b/tests/integration/pilot/common/traffic.go
@@ -71,8 +71,8 @@ type TrafficTestCase struct {
 
 var (
 	// TODO move to echotest?
-	defaulltSourceFilters = []echotest.SimpleFilter{echotest.SingleSimplePodBasedService, echotest.NoExternalServices}
-	defaulltTargetFilters = []echotest.SimpleFilter{echotest.SingleSimplePodBasedService}
+	defaultSourceFilters = []echotest.SimpleFilter{echotest.SingleSimplePodBasedService, echotest.NoExternalServices}
+	defaultTargetFilters = []echotest.SimpleFilter{echotest.SingleSimplePodBasedService}
 )
 
 func (c TrafficTestCase) RunForApps(t framework.TestContext, apps echo.Instances, namespace string) {
@@ -100,9 +100,9 @@ func (c TrafficTestCase) RunForApps(t framework.TestContext, apps echo.Instances
 				), namespace)
 				return t.Config().ApplyYAML("", cfg)
 			}).
-			From(append(defaulltSourceFilters, c.sourceFilters...)...).
+			From(append(defaultSourceFilters, c.sourceFilters...)...).
 			ConditionallyTo(echotest.ReachableDestinations).
-			To(append(defaulltTargetFilters, c.targetFilters...)...).
+			To(append(defaultTargetFilters, c.targetFilters...)...).
 			Run(func(t framework.TestContext, src echo.Instance, dest echo.Instances) {
 				if c.skip {
 					t.SkipNow()


### PR DESCRIPTION
- [x] use templated config
- [x] remove Call/Target/Count
- [x] trim down the # of sources/destinations
- [x] debug duplicate top level tests (virtualservice/a#01/...)