### PR TITLE
Block CheckPodsAreReady until there are pods

### DIFF
--- a/pkg/test/kube/util.go
+++ b/pkg/test/kube/util.go
@@ -95,6 +95,10 @@ func CheckPodsAreReady(fetchFunc PodFetchFunc) ([]kubeApiCore.Pod, error) {
 		return nil, err
 	}
 
+	if len(fetched) == 0 {
+		return nil, fmt.Errorf("no pods fetched")
+	}
+
 	for i, p := range fetched {
 		msg := "Ready"
 		if e := istioKube.CheckPodReadyOrComplete(&p); e != nil {


### PR DESCRIPTION
This prevents a race condition where no pods are started yet - we should
wait until there is at least one pod AND the pods are ready



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.