### PR TITLE
Namespacing ClusterRole and ClusterRoleBinding

### DIFF
--- a/samples/addons/prometheus.yaml
+++ b/samples/addons/prometheus.yaml
@@ -299,6 +299,7 @@ metadata:
     release: prometheus
     chart: prometheus-11.16.2
     heritage: Helm
+  namespace: istio-system    
   name: prometheus
 rules:
   - apiGroups:
@@ -341,6 +342,7 @@ metadata:
     release: prometheus
     chart: prometheus-11.16.2
     heritage: Helm
+  namespace: istio-system    
   name: prometheus
 subjects:
   - kind: ServiceAccount


### PR DESCRIPTION
The manifest for Prometheus in ` samples/addons` creates a `ClusterRole` and a `ClusterRoleBinding` (both with the name `prometheus`) which are not namespaced. This creates conflicts with other deployments which, unfortunately, do the same and choose the same name.

This PR namespaces the `ClusterRole` and `ClusterRoleBinding` into `istio-system`.


[x] Configuration Infrastructure
[ ] Docs
[x] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any changes that may affect Istio users.