### PR TITLE
fix nil error

### DIFF
--- a/samples/extauthz/src/main.go
+++ b/samples/extauthz/src/main.go
@@ -73,7 +73,7 @@ func (s *extAuthzServerV2) Check(ctx context.Context, request *authv2.CheckReque
 		request.GetAttributes().GetRequest().GetHttp().GetHost(),
 		request.GetAttributes().GetRequest().GetHttp().GetPath(),
 		request.GetAttributes())
-	if allowedValue == request.GetAttributes().GetRequest().GetHttp().GetHeaders()[checkHeader] || strings.HasSuffix(request.GetAttributes().Source.Principal, "/sa/" + *serviceAccount) {
+	if allowedValue == request.GetAttributes().GetRequest().GetHttp().GetHeaders()[checkHeader] || (request.GetAttributes().Source != nil && strings.HasSuffix(request.GetAttributes().Source.Principal, "/sa/"+*serviceAccount)) {
 		log.Printf("[gRPCv2][allowed]: %s", l)
 		return &authv2.CheckResponse{
 			HttpResponse: &authv2.CheckResponse_OkResponse{
@@ -118,7 +118,7 @@ func (s *extAuthzServerV3) Check(ctx context.Context, request *authv3.CheckReque
 		request.GetAttributes().GetRequest().GetHttp().GetHost(),
 		request.GetAttributes().GetRequest().GetHttp().GetPath(),
 		request.GetAttributes())
-	if allowedValue == request.GetAttributes().GetRequest().GetHttp().GetHeaders()[checkHeader]  || strings.HasSuffix(request.GetAttributes().Source.Principal, "/sa/" + *serviceAccount) {
+	if allowedValue == request.GetAttributes().GetRequest().GetHttp().GetHeaders()[checkHeader] || (request.GetAttributes().Source != nil && strings.HasSuffix(request.GetAttributes().Source.Principal, "/sa/"+*serviceAccount)) {
 		log.Printf("[gRPCv3][allowed]: %s", l)
 		return &authv3.CheckResponse{
 			HttpResponse: &authv3.CheckResponse_OkResponse{


### PR DESCRIPTION
Signed-off-by: zackzhangkai <zhangkaiamm@gmail.com>



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.



Fix the sample code. 

```bash
[root@jump src]# pwd
/tmp/istio/samples/extauthz/src

[root@jump src]# go test
2021/03/17 08:12:19 Starting HTTP server at 127.0.0.1:36064
2021/03/17 08:12:19 Starting gRPC server at 127.0.0.1:33706
2021/03/17 08:12:19 [HTTP][allowed]: GET localhost:36064/check, headers: map[Accept-Encoding:[gzip] User-Agent:[Go-http-client/1.1] X-Ext-Authz:[allow]]
2021/03/17 08:12:19 [HTTP][denied]: GET localhost:36064/check, headers: map[Accept-Encoding:[gzip] User-Agent:[Go-http-client/1.1] X-Ext-Authz:[deny]]
2021/03/17 08:12:19 [gRPCv3][allowed]: localhost/check, attributes: request:{http:{headers:{key:"x-ext-authz" value:"allow"} path:"/check" host:"localhost"}}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x50 pc=0xa9ad08]

goroutine 114 [running]:
istio.io/istio/samples/extauthz/src.(*extAuthzServerV3).Check(0x11ec138, 0xd14160, 0xc0000fc390, 0xc0000fc3c0, 0x11ec138, 0xc0000fc390, 0xc000230ba0)
	/tmp/istio/samples/extauthz/src/main.go:121 +0x848
github.com/envoyproxy/go-control-plane/envoy/service/auth/v3._Authorization_Check_Handler(0xb2c440, 0x11ec138, 0xd14160, 0xc0000fc390, 0xc0001a02a0, 0x0, 0xd14160, 0xc0000fc390, 0xc0001a60f0, 0x2e)
	/root/go/pkg/mod/github.com/envoyproxy/go-control-plane@v0.9.7/envoy/service/auth/v3/external_auth.pb.go:638 +0x214
google.golang.org/grpc.(*Server).processUnaryRPC(0xc00046fc00, 0xd199f8, 0xc000103500, 0xc0001de000, 0xc0002887b0, 0x11a20e0, 0x0, 0x0, 0x0)
	/root/go/pkg/mod/google.golang.org/grpc@v1.33.1/server.go:1210 +0x52b
google.golang.org/grpc.(*Server).handleStream(0xc00046fc00, 0xd199f8, 0xc000103500, 0xc0001de000, 0x0)
	/root/go/pkg/mod/google.golang.org/grpc@v1.33.1/server.go:1533 +0xd0c
google.golang.org/grpc.(*Server).serveStreams.func1.2(0xc00042c8e0, 0xc00046fc00, 0xd199f8, 0xc000103500, 0xc0001de000)
	/root/go/pkg/mod/google.golang.org/grpc@v1.33.1/server.go:871 +0xab
created by google.golang.org/grpc.(*Server).serveStreams.func1
	/root/go/pkg/mod/google.golang.org/grpc@v1.33.1/server.go:869 +0x1fd
exit status 2
FAIL	istio.io/istio/samples/extauthz/src	0.023s
```