### PR TITLE
Allow server to wait for multicluster components

### DIFF
--- a/pilot/pkg/bootstrap/server_test.go
+++ b/pilot/pkg/bootstrap/server_test.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"istio.io/istio/pilot/pkg/features"
+	"istio.io/istio/pilot/pkg/server"
 	"istio.io/istio/pilot/pkg/serviceregistry"
 	kubecontroller "istio.io/istio/pilot/pkg/serviceregistry/kube/controller"
 	"istio.io/istio/pkg/config/constants"
@@ -110,6 +111,7 @@ func TestReloadIstiodCert(t *testing.T) {
 	stop := make(chan struct{})
 	s := &Server{
 		fileWatcher: filewatcher.NewWatcher(),
+		server:      server.New(),
 	}
 
 	defer func() {
@@ -138,15 +140,12 @@ func TestReloadIstiodCert(t *testing.T) {
 	}
 
 	// setup cert watches.
-	err = s.initCertificateWatches(tlsOptions)
-	for _, fn := range s.startFuncs {
-		if err := fn(stop); err != nil {
-			t.Fatalf("Could not invoke startFuncs: %v", err)
-		}
+	if err = s.initCertificateWatches(tlsOptions); err != nil {
+		t.Fatalf("initCertificateWatches failed: %v", err)
 	}
 
-	if err != nil {
-		t.Fatalf("initCertificateWatches failed: %v", err)
+	if err = s.server.Start(stop); err != nil {
+		t.Fatalf("Could not invoke startFuncs: %v", err)
 	}
 
 	// Validate that the certs are loaded.

--- a/pilot/pkg/server/instance.go
+++ b/pilot/pkg/server/instance.go
@@ -1,0 +1,155 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"sync"
+
+	"istio.io/pkg/log"
+)
+
+type Component func(stop <-chan struct{}) error
+
+// Instance is a server that is composed a number of Component tasks.
+type Instance interface {
+	// Start this Server. Any components that were already added
+	// will be run immediately. If any error is returned,
+	// Start will terminate and return the error immediately.
+	//
+	// Once all startup components have been run, starts a polling
+	// loop to continue monitoring for new components and returns nil.
+	Start(stop <-chan struct{}) error
+
+	// RunComponent adds the given component to the server's run queue.
+	RunComponent(t Component)
+
+	// RunComponentAsync runs the given component asynchronously.
+	RunComponentAsync(t Component)
+
+	// RunComponentAsync runs the given component asynchronously. When
+	// the serer Instance is shutting down, it will wait for the component
+	// to complete before exiting.
+	// Note: this is best effort; a process can die at any time.
+	RunComponentAsyncAndWait(t Component)
+
+	// Wait for this server Instance to shutdown.
+	Wait()
+}
+
+var _ Instance = &instance{}
+
+// New creates a new server Instance.
+func New() Instance {
+	return &instance{
+		done:       make(chan struct{}),
+		components: make(chan Component, 1000), // should be enough?
+	}
+}
+
+type instance struct {
+	components chan Component
+	done       chan struct{}
+
+	// requiredTerminations keeps track of tasks that should block instance exit
+	// if they are not stopped. This allows important cleanup tasks to be completed.
+	// Note: this is still best effort; a process can die at any time.
+	requiredTerminations sync.WaitGroup
+}
+
+func (i *instance) Start(stop <-chan struct{}) error {
+	shutdown := func() {
+		close(i.done)
+	}
+
+	// First, drain all startup tasks and immediately return if any fail.
+	for startupDone := false; !startupDone; {
+		select {
+		case next := <-i.components:
+			if err := next(stop); err != nil {
+				// Startup error: terminate and return the error.
+				shutdown()
+				return err
+			}
+		default:
+			// We've drained all of the initial tasks.
+			// Break out of the loop and run asynchronously.
+			startupDone = true
+		}
+	}
+
+	// Start the run loop to continue tasks added after the instance is started.
+	go func() {
+		for {
+			select {
+			case <-stop:
+				// Wait for any tasks that are required for termination.
+				i.requiredTerminations.Wait()
+
+				// Indicate that this instance is not terminated.
+				shutdown()
+				return
+			case next := <-i.components:
+				if err := next(stop); err != nil {
+					logComponentError(err)
+				}
+			}
+		}
+	}()
+
+	return nil
+}
+
+func (i *instance) RunComponent(t Component) {
+	select {
+	case <-i.done:
+		log.Warnf("attempting to run a new component after the server was shutdown")
+	default:
+		i.components <- t
+	}
+}
+
+func (i *instance) RunComponentAsync(task Component) {
+	i.RunComponent(func(stop <-chan struct{}) error {
+		go func() {
+			err := task(stop)
+			if err != nil {
+				logComponentError(err)
+			}
+		}()
+		return nil
+	})
+}
+
+func (i *instance) RunComponentAsyncAndWait(task Component) {
+	i.RunComponent(func(stop <-chan struct{}) error {
+		i.requiredTerminations.Add(1)
+		go func() {
+			err := task(stop)
+			if err != nil {
+				logComponentError(err)
+			}
+			i.requiredTerminations.Done()
+		}()
+		return nil
+	})
+}
+
+func (i *instance) Wait() {
+	<-i.done
+}
+
+func logComponentError(err error) {
+	log.Errorf("failure in server component: %v", err)
+}

--- a/pilot/pkg/server/instance_test.go
+++ b/pilot/pkg/server/instance_test.go
@@ -1,0 +1,167 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	"go.uber.org/atomic"
+
+	"istio.io/istio/pilot/pkg/server"
+)
+
+func TestStartWithError(t *testing.T) {
+	g := NewWithT(t)
+
+	inst := server.New()
+	expected := errors.New("fake")
+	inst.RunComponent(func(stop <-chan struct{}) error {
+		return expected
+	})
+
+	stop := newReclosableChannel()
+	t.Cleanup(stop.Close)
+	g.Expect(inst.Start(stop.c)).To(Equal(expected))
+}
+
+func TestStartWithNoError(t *testing.T) {
+	g := NewWithT(t)
+
+	inst := server.New()
+	c := newFakeComponent(0)
+	inst.RunComponent(c.Run)
+
+	stop := newReclosableChannel()
+	t.Cleanup(stop.Close)
+	g.Expect(inst.Start(stop.c)).To(BeNil())
+	g.Expect(c.started.Load()).To(BeTrue())
+}
+
+func TestRunComponentsAfterStart(t *testing.T) {
+	longDuration := 10 * time.Second
+	shortDuration := 1 * time.Second
+	cases := []struct {
+		name  string
+		c     *fakeComponent
+		async bool
+		wait  bool
+	}{
+		{
+			name: "RunComponent",
+			// Use a large duration - it will not complete before the end of the test.
+			// This is used to verify that we don't wait for it while shutting down.
+			c:     newFakeComponent(longDuration),
+			async: false,
+			wait:  false,
+		},
+		{
+			name: "RunComponentAsync",
+			// Use a large duration - it will not complete before the end of the test.
+			// This is used to verify that we don't wait for it while shutting down.
+			c:     newFakeComponent(longDuration),
+			async: true,
+			wait:  false,
+		},
+		{
+			name:  "RunComponentAsyncAndWait",
+			c:     newFakeComponent(shortDuration),
+			async: true,
+			wait:  true,
+		},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			stop := newReclosableChannel()
+			t.Cleanup(stop.Close)
+			inst := server.New()
+			g.Expect(inst.Start(stop.c)).To(BeNil())
+
+			go func() {
+				component := c.c.Run
+				if c.async {
+					if c.wait {
+						inst.RunComponentAsyncAndWait(component)
+					} else {
+						inst.RunComponentAsync(component)
+					}
+				} else {
+					inst.RunComponent(component)
+				}
+			}()
+
+			// Ensure that the component is started.
+			g.Eventually(func() bool {
+				return c.c.started.Load()
+			}).Should(BeTrue())
+
+			// Stop before the tasks end.
+			stop.Close()
+			if c.wait {
+				// Add a little buffer to the task duration.
+				totalWaitTime := shortDuration + (1 * time.Second)
+				g.Eventually(func() bool {
+					return c.c.completed.Load()
+				}, totalWaitTime).Should(BeTrue())
+			} else {
+				g.Expect(c.c.completed.Load()).Should(BeFalse())
+			}
+		})
+	}
+}
+
+type reclosableChannel struct {
+	c      chan struct{}
+	closed bool
+}
+
+func newReclosableChannel() *reclosableChannel {
+	return &reclosableChannel{
+		c: make(chan struct{}),
+	}
+}
+
+func (c *reclosableChannel) Close() {
+	if !c.closed {
+		c.closed = true
+		close(c.c)
+	}
+}
+
+type fakeComponent struct {
+	started   *atomic.Bool
+	completed *atomic.Bool
+	d         time.Duration
+}
+
+func newFakeComponent(d time.Duration) *fakeComponent {
+	return &fakeComponent{
+		started:   atomic.NewBool(false),
+		completed: atomic.NewBool(false),
+		d:         d,
+	}
+}
+
+func (c *fakeComponent) Run(_ <-chan struct{}) error {
+	c.started.Store(true)
+	time.Sleep(c.d)
+	c.completed.Store(true)
+	return nil
+}

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -15,16 +15,20 @@
 package controller
 
 import (
+	"context"
+	"fmt"
 	"strings"
 	"sync"
 	"time"
 
+	"golang.org/x/sync/errgroup"
 	"k8s.io/client-go/kubernetes"
 
 	"istio.io/istio/pilot/pkg/config/kube/crdclient"
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/leaderelection"
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/server"
 	"istio.io/istio/pilot/pkg/serviceregistry"
 	"istio.io/istio/pilot/pkg/serviceregistry/aggregate"
 	"istio.io/istio/pilot/pkg/serviceregistry/serviceentry"
@@ -65,7 +69,9 @@ type Multicluster struct {
 	opts Options
 
 	// client for reading remote-secrets to initialize multicluster registries
-	client kubernetes.Interface
+	client  kubernetes.Interface
+	s       server.Instance
+	closing bool
 
 	serviceController *aggregate.Controller
 	serviceEntryStore *serviceentry.ServiceEntryStore
@@ -99,6 +105,7 @@ func NewMulticluster(
 	revision string,
 	fetchCaRoot func() map[string]string,
 	networksWatcher mesh.NetworksWatcher,
+	s server.Instance,
 ) *Multicluster {
 	remoteKubeController := make(map[string]*kubeController)
 	if opts.ResyncPeriod == 0 {
@@ -120,18 +127,53 @@ func NewMulticluster(
 		secretNamespace:       secretNamespace,
 		syncInterval:          opts.GetSyncInterval(),
 		client:                kc,
+		s:                     s,
 	}
 
 	return mc
+}
+
+func (m *Multicluster) Run(stopCh <-chan struct{}) error {
+	// Wait for server shutdown.
+	<-stopCh
+	return m.close()
+}
+
+func (m *Multicluster) close() (err error) {
+	m.m.Lock()
+	m.closing = true
+
+	// Gather all of the member clusters.
+	var clusterIDs []string
+	for clusterID := range m.remoteKubeControllers {
+		clusterIDs = append(clusterIDs, clusterID)
+	}
+	m.m.Unlock()
+
+	// Remove all of the clusters.
+	g, _ := errgroup.WithContext(context.Background())
+	for _, clusterID := range clusterIDs {
+		g.Go(func() error {
+			return m.DeleteMemberCluster(clusterID)
+		})
+	}
+	err = g.Wait()
+	return
 }
 
 // AddMemberCluster is passed to the secret controller as a callback to be called
 // when a remote cluster is added.  This function needs to set up all the handlers
 // to watch for resources being added, deleted or changed on remote clusters.
 func (m *Multicluster) AddMemberCluster(client kubelib.Client, clusterID string) error {
-	// stopCh to stop controller created here when cluster removed.
-	stopCh := make(chan struct{})
 	m.m.Lock()
+
+	if m.closing {
+		m.m.Unlock()
+		return fmt.Errorf("failed adding member cluster %s: server shutting down", clusterID)
+	}
+
+	// clusterStopCh is a channel that will be closed when this cluster removed.
+	clusterStopCh := make(chan struct{})
 	options := m.opts
 	options.ClusterID = clusterID
 
@@ -140,7 +182,7 @@ func (m *Multicluster) AddMemberCluster(client kubelib.Client, clusterID string)
 	m.serviceController.AddRegistry(kubeRegistry)
 	m.remoteKubeControllers[clusterID] = &kubeController{
 		Controller: kubeRegistry,
-		stopCh:     stopCh,
+		stopCh:     clusterStopCh,
 	}
 	// localCluster may also be the "config" cluster, in an external-istiod setup.
 	localCluster := m.opts.ClusterID == clusterID
@@ -170,7 +212,7 @@ func (m *Multicluster) AddMemberCluster(client kubelib.Client, clusterID string)
 				m.serviceController.AddRegistry(m.remoteKubeControllers[clusterID].workloadEntryStore)
 				// Services can select WorkloadEntry from the same cluster. We only duplicate the Service to configure kube-dns.
 				m.remoteKubeControllers[clusterID].workloadEntryStore.AppendWorkloadHandler(kubeRegistry.WorkloadInstanceHandler)
-				go configStore.Run(stopCh)
+				go configStore.Run(clusterStopCh)
 			} else {
 				log.Errorf("failed creating config configStore for cluster %s: %v", clusterID, err)
 			}
@@ -180,23 +222,27 @@ func (m *Multicluster) AddMemberCluster(client kubelib.Client, clusterID string)
 	// TODO only create namespace controller and cert patch for remote clusters (no way to tell currently)
 	if m.serviceController.Running() {
 		// if serviceController isn't running, it will start its members when it is started
-		go kubeRegistry.Run(stopCh)
+		go kubeRegistry.Run(clusterStopCh)
 	}
 	if m.fetchCaRoot != nil && m.fetchCaRoot() != nil && (features.ExternalIstiod || localCluster) {
-		log.Infof("joining leader-election for %s in %s", leaderelection.NamespaceController, options.SystemNamespace)
-		go leaderelection.
-			NewLeaderElection(options.SystemNamespace, m.serverID, leaderelection.NamespaceController, client.Kube()).
-			AddRunFunction(func(leaderStop <-chan struct{}) {
-				log.Infof("starting namespace controller for cluster %s", clusterID)
-				nc := NewNamespaceController(m.fetchCaRoot, client)
-				// Start informers again. This fixes the case where informers for namespace do not start,
-				// as we create them only after acquiring the leader lock
-				// Note: stop here should be the overall pilot stop, NOT the leader election stop. We are
-				// basically lazy loading the informer, if we stop it when we lose the lock we will never
-				// recreate it again.
-				client.RunAndWait(stopCh)
-				nc.Run(leaderStop)
-			}).Run(stopCh)
+		// Block server exit on graceful termination of the leader controller.
+		m.s.RunComponentAsyncAndWait(func(_ <-chan struct{}) error {
+			log.Infof("joining leader-election for %s in %s", leaderelection.NamespaceController, options.SystemNamespace)
+			leaderelection.
+				NewLeaderElection(options.SystemNamespace, m.serverID, leaderelection.NamespaceController, client.Kube()).
+				AddRunFunction(func(leaderStop <-chan struct{}) {
+					log.Infof("starting namespace controller for cluster %s", clusterID)
+					nc := NewNamespaceController(m.fetchCaRoot, client)
+					// Start informers again. This fixes the case where informers for namespace do not start,
+					// as we create them only after acquiring the leader lock
+					// Note: stop here should be the overall pilot stop, NOT the leader election stop. We are
+					// basically lazy loading the informer, if we stop it when we lose the lock we will never
+					// recreate it again.
+					client.RunAndWait(clusterStopCh)
+					nc.Run(leaderStop)
+				}).Run(clusterStopCh)
+			return nil
+		})
 	}
 
 	// The local cluster has this patching set-up elsewhere. We may eventually want to move it here.
@@ -211,7 +257,7 @@ func (m *Multicluster) AddMemberCluster(client kubelib.Client, clusterID string)
 			if err != nil {
 				log.Errorf("could not initialize webhook cert patcher: %v", err)
 			} else {
-				patcher.Run(stopCh)
+				patcher.Run(clusterStopCh)
 			}
 		}
 		// Patch validation webhook cert
@@ -220,12 +266,12 @@ func (m *Multicluster) AddMemberCluster(client kubelib.Client, clusterID string)
 			validationWebhookController := webhooks.CreateValidationWebhookController(client, webhookConfigName,
 				m.secretNamespace, m.caBundlePath)
 			if validationWebhookController != nil {
-				go validationWebhookController.Start(stopCh)
+				go validationWebhookController.Start(clusterStopCh)
 			}
 		}
 	}
 
-	client.RunAndWait(stopCh)
+	client.RunAndWait(clusterStopCh)
 	return nil
 }
 

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster_test.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
+	"istio.io/istio/pilot/pkg/server"
 	"istio.io/istio/pilot/pkg/serviceregistry/aggregate"
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/kube"
@@ -86,6 +87,7 @@ func Test_KubeSecretController(t *testing.T) {
 	t.Cleanup(func() {
 		close(stop)
 	})
+	s := server.New()
 	mc := NewMulticluster(
 		"pilot-abc-123",
 		clientset,
@@ -96,10 +98,14 @@ func Test_KubeSecretController(t *testing.T) {
 			ResyncPeriod:      ResyncPeriod,
 			SyncInterval:      time.Microsecond,
 			MeshWatcher:       mesh.NewFixedWatcher(&meshconfig.MeshConfig{}),
-		}, mockserviceController, nil, "", "default", nil, nil)
+		}, mockserviceController, nil, "", "default", nil, nil, s)
 	mc.InitSecretController(stop)
 	cache.WaitForCacheSync(stop, mc.HasSynced)
 	clientset.RunAndWait(stop)
+	_ = s.Start(stop)
+	go func() {
+		_ = mc.Run(stop)
+	}()
 
 	// Create the multicluster secret. Sleep to allow created remote
 	// controller to start and callback add function to be called.


### PR DESCRIPTION
Server has a `addTerminatingStartFunc` method that is used to wait for gracefully shutdown of an elected k8s leader. Without this, shutting down the process could result in no leader being elected for 30-60s. This method is only accessible to the bootstrap package, however.

This PR refactors the server so that leader components dynamically created by the multicluster processing can also hook into the same shutdown logic.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.