### PR TITLE
Add support to istiod to notice cacerts changes

### DIFF
--- a/pilot/pkg/bootstrap/certcontroller.go
+++ b/pilot/pkg/bootstrap/certcontroller.go
@@ -184,7 +184,7 @@ func (s *Server) watchRootCertAndGenKeyCert(stop <-chan struct{}) {
 	}
 }
 
-// updatePluggedinRootCertAndGenKeyCert generates new dns certs and notifies keycertbundle
+// updatePluggedinRootCertAndGenKeyCert when intermediate CA is updated, it generates new dns certs and notifies keycertbundle about the changes
 func (s *Server) updatePluggedinRootCertAndGenKeyCert() error {
 	caBundle := s.CA.GetCAKeyCertBundle().GetRootCertPem()
 	certChain, keyPEM, err := s.CA.GenKeyCert(s.dnsNames, SelfSignedCACertTTL.Get(), false)

--- a/pilot/pkg/bootstrap/certcontroller.go
+++ b/pilot/pkg/bootstrap/certcontroller.go
@@ -103,35 +103,18 @@ func (s *Server) initCertController(args *PilotArgs) error {
 //
 // TODO: If the discovery address in mesh.yaml is set to port 15012 (XDS-with-DNS-certs) and the name
 // matches the k8s namespace, failure to start DNS server is a fatal error.
-func (s *Server) initDNSCerts(hostname, customHost, namespace string) error {
+func (s *Server) initDNSCerts(hostname, namespace string) error {
 	// Name in the Istiod cert - support the old service names as well.
 	// validate hostname contains namespace
 	parts := strings.Split(hostname, ".")
 	hostnamePrefix := parts[0]
 
-	// append custom hostname if there is any
-	names := []string{hostname}
-	if customHost != "" && customHost != hostname {
-		log.Infof("Adding custom hostname %s", customHost)
-		names = append(names, customHost)
-	}
-
-	// The first is the recommended one, also used by Apiserver for webhooks.
-	// add a few known hostnames
-	for _, altName := range []string{"istiod", "istiod-remote", "istio-pilot"} {
-		name := fmt.Sprintf("%v.%v.svc", altName, namespace)
-		if name == hostname || name == customHost {
-			continue
-		}
-		names = append(names, name)
-	}
-
 	var certChain, keyPEM, caBundle []byte
 	var err error
 	if features.PilotCertProvider == constants.CertProviderKubernetes {
-		log.Infof("Generating K8S-signed cert for %v", names)
+		log.Infof("Generating K8S-signed cert for %v", s.dnsNames)
 		certChain, keyPEM, _, err = chiron.GenKeyCertK8sCA(s.kubeClient,
-			strings.Join(names, ","), hostnamePrefix+".csr.secret", namespace, defaultCACertPath, "", true)
+			strings.Join(s.dnsNames, ","), hostnamePrefix+".csr.secret", namespace, defaultCACertPath, "", true)
 		if err != nil {
 			return fmt.Errorf("failed generating key and cert by kubernetes: %v", err)
 		}
@@ -140,11 +123,11 @@ func (s *Server) initDNSCerts(hostname, customHost, namespace string) error {
 			return fmt.Errorf("failed reading %s: %v", defaultCACertPath, err)
 		}
 	} else if features.PilotCertProvider == constants.CertProviderIstiod {
-		certChain, keyPEM, err = s.CA.GenKeyCert(names, SelfSignedCACertTTL.Get(), false)
+		certChain, keyPEM, err = s.CA.GenKeyCert(s.dnsNames, SelfSignedCACertTTL.Get(), false)
 		if err != nil {
 			return fmt.Errorf("failed generating istiod key cert %v", err)
 		}
-		log.Infof("Generating istiod-signed cert for %v:\n %s", names, certChain)
+		log.Infof("Generating istiod-signed cert for %v:\n %s", s.dnsNames, certChain)
 
 		signingKeyFile := path.Join(LocalCertDir.Get(), ca.CAPrivateKeyFile)
 		// check if signing key file exists the cert dir
@@ -154,7 +137,7 @@ func (s *Server) initDNSCerts(hostname, customHost, namespace string) error {
 			s.addStartFunc(func(stop <-chan struct{}) error {
 				go func() {
 					// regenerate istiod key cert when root cert changes.
-					s.watchRootCertAndGenKeyCert(names, stop)
+					s.watchRootCertAndGenKeyCert(stop)
 				}()
 				return nil
 			})
@@ -179,7 +162,7 @@ func (s *Server) initDNSCerts(hostname, customHost, namespace string) error {
 }
 
 // TODO(hzxuzonghu): support async notification instead of polling the CA root cert.
-func (s *Server) watchRootCertAndGenKeyCert(names []string, stop <-chan struct{}) {
+func (s *Server) watchRootCertAndGenKeyCert(stop <-chan struct{}) {
 	caBundle := s.CA.GetCAKeyCertBundle().GetRootCertPem()
 	for {
 		select {
@@ -189,7 +172,7 @@ func (s *Server) watchRootCertAndGenKeyCert(names []string, stop <-chan struct{}
 			newRootCert := s.CA.GetCAKeyCertBundle().GetRootCertPem()
 			if !bytes.Equal(caBundle, newRootCert) {
 				caBundle = newRootCert
-				certChain, keyPEM, err := s.CA.GenKeyCert(names, SelfSignedCACertTTL.Get(), false)
+				certChain, keyPEM, err := s.CA.GenKeyCert(s.dnsNames, SelfSignedCACertTTL.Get(), false)
 				if err != nil {
 					log.Errorf("failed generating istiod key cert %v", err)
 				} else {
@@ -199,6 +182,18 @@ func (s *Server) watchRootCertAndGenKeyCert(names []string, stop <-chan struct{}
 			}
 		}
 	}
+}
+
+// updatePluggedinRootCertAndGenKeyCert generates new dns certs and notifies keycertbundle
+func (s *Server) updatePluggedinRootCertAndGenKeyCert() error {
+	caBundle := s.CA.GetCAKeyCertBundle().GetRootCertPem()
+	certChain, keyPEM, err := s.CA.GenKeyCert(s.dnsNames, SelfSignedCACertTTL.Get(), false)
+	if err != nil {
+		return err
+	}
+
+	s.istiodCertBundleWatcher.SetAndNotify(keyPEM, certChain, caBundle)
+	return nil
 }
 
 // initCertificateWatches sets up watches for the plugin dns certs.

--- a/pilot/pkg/bootstrap/istio_ca.go
+++ b/pilot/pkg/bootstrap/istio_ca.go
@@ -304,8 +304,8 @@ func handleEvent(s *Server) {
 		return
 	}
 
-	err = s.CA.GetCAKeyCertBundle().UpdateNewPluggedInCACerts(
-		path.Join(LocalCertDir.Get(), "/ca-cert.pem"),
+	err = s.CA.GetCAKeyCertBundle().UpdateVerifiedKeyCertBundleFromFile(
+		path.Join(LocalCertDir.Get(), "ca-cert.pem"),
 		path.Join(LocalCertDir.Get(), "ca-key.pem"),
 		path.Join(LocalCertDir.Get(), "cert-chain.pem"),
 		path.Join(LocalCertDir.Get(), "root-cert.pem"))
@@ -447,7 +447,7 @@ func (s *Server) createIstioCA(client corev1.CoreV1Interface, opts *caOptions) (
 		return nil, fmt.Errorf("failed to create an istiod CA: %v", err)
 	}
 
-	if features.EnableAvoidRestartIstiod {
+	if features.AutoReloadPluginCerts {
 		s.initCACertsWatcher()
 	}
 

--- a/pilot/pkg/bootstrap/istio_ca.go
+++ b/pilot/pkg/bootstrap/istio_ca.go
@@ -443,14 +443,14 @@ func (s *Server) createIstioCA(client corev1.CoreV1Interface, opts *caOptions) (
 		if err != nil {
 			return nil, fmt.Errorf("failed to create an istiod CA: %v", err)
 		}
+
+		if features.AutoReloadPluginCerts {
+			s.initCACertsWatcher()
+		}
 	}
 	istioCA, err := ca.NewIstioCA(caOpts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create an istiod CA: %v", err)
-	}
-
-	if features.AutoReloadPluginCerts {
-		s.initCACertsWatcher()
 	}
 
 	// TODO: provide an endpoint returning all the roots. SDS can only pull a single root in current impl.

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -155,8 +155,6 @@ type Server struct {
 
 	// certWatcher watches the certificates for changes and triggers a notification to Istiod.
 	cacertsWatcher *fsnotify.Watcher
-	cacertsMap     map[string]bool
-	cacertsMutex   sync.RWMutex
 	dnsNames       []string
 
 	certController *chiron.WebhookController

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -29,6 +29,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/fsnotify/fsnotify"
 	prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	prom "github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/net/http2"
@@ -151,6 +152,10 @@ type Server struct {
 
 	// fileWatcher used to watch mesh config, networks and certificates.
 	fileWatcher filewatcher.FileWatcher
+
+	// certWatcher watches the certificates for changes and triggers a notification to Istiod.
+	cacertsWatcher *fsnotify.Watcher
+	dnsNames       []string
 
 	certController *chiron.WebhookController
 	CA             *ca.IstioCA
@@ -930,6 +935,25 @@ func (s *Server) initIstiodCertLoader() error {
 func (s *Server) initIstiodCerts(args *PilotArgs, host string) error {
 	// Skip all certificates
 	var err error
+
+	// Append custom hostname if there is any
+	customHost := features.IstiodServiceCustomHost
+	s.dnsNames = []string{host}
+	if customHost != "" && customHost != host {
+		log.Infof("Adding custom hostname %s", customHost)
+		s.dnsNames = append(s.dnsNames, customHost)
+	}
+
+	// The first is the recommended one, also used by Apiserver for webhooks.
+	// add a few known hostnames
+	for _, altName := range []string{"istiod", "istiod-remote", "istio-pilot"} {
+		name := fmt.Sprintf("%v.%v.svc", altName, args.Namespace)
+		if name == host || name == customHost {
+			continue
+		}
+		s.dnsNames = append(s.dnsNames, name)
+	}
+
 	if hasCustomTLSCerts(args.ServerOptions.TLSOptions) {
 		// Use the DNS certificate provided via args.
 		err = s.initCertificateWatches(args.ServerOptions.TLSOptions)
@@ -943,13 +967,13 @@ func (s *Server) initIstiodCerts(args *PilotArgs, host string) error {
 		return nil
 	} else if s.EnableCA() && features.PilotCertProvider == constants.CertProviderIstiod {
 		log.Infof("initializing Istiod DNS certificates host: %s, custom host: %s", host, features.IstiodServiceCustomHost)
-		err = s.initDNSCerts(host, features.IstiodServiceCustomHost, args.Namespace)
+		err = s.initDNSCerts(host, args.Namespace)
 		if err == nil {
 			err = s.initIstiodCertLoader()
 		}
 	} else if features.PilotCertProvider == constants.CertProviderKubernetes {
 		log.Infof("initializing Istiod DNS certificates host: %s, custom host: %s", host, features.IstiodServiceCustomHost)
-		err = s.initDNSCerts(host, features.IstiodServiceCustomHost, args.Namespace)
+		err = s.initDNSCerts(host, args.Namespace)
 		if err == nil {
 			err = s.initIstiodCertLoader()
 		}

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -92,13 +92,6 @@ const (
 	watchDebounceDelay = 100 * time.Millisecond
 )
 
-const ( // CACerts file operation states
-	create  = 0
-	write   = 1
-	remove  = 2
-	invalid = 3
-)
-
 func init() {
 	// Disable gRPC tracing. It has performance impacts (See https://github.com/grpc/grpc-go/issues/695)
 	grpc.EnableTracing = false
@@ -162,7 +155,7 @@ type Server struct {
 
 	// certWatcher watches the certificates for changes and triggers a notification to Istiod.
 	cacertsWatcher *fsnotify.Watcher
-	cacertsMap     map[string]uint8
+	cacertsMap     map[string]bool
 	cacertsMutex   sync.RWMutex
 	dnsNames       []string
 

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -507,6 +507,11 @@ var (
 		"If true, routes will use the target port of the gateway service in the route name, not the service port.").Get()
 
 	CertSignerDomain = env.RegisterStringVar("CERT_SIGNER_DOMAIN", "", "The cert signer domain info").Get()
+	EnableAvoidRestartIstiod = env.RegisterBoolVar(
+		"PILOT_ENABLE_AVOID_RESTART_ISTIOD",
+		false,
+		"If enabled, if user introduces new intermediate plug-in CA, user need not to restart isitod to pick up certs."+
+			"Istiod picks newly added intermediate plug-in CA certs and updates it").Get()
 )
 
 // UnsafeFeaturesEnabled returns true if any unsafe features are enabled.

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -507,8 +507,9 @@ var (
 		"If true, routes will use the target port of the gateway service in the route name, not the service port.").Get()
 
 	CertSignerDomain = env.RegisterStringVar("CERT_SIGNER_DOMAIN", "", "The cert signer domain info").Get()
-	EnableAvoidRestartIstiod = env.RegisterBoolVar(
-		"PILOT_ENABLE_AVOID_RESTART_ISTIOD",
+
+	AutoReloadPluginCerts = env.RegisterBoolVar(
+		"PILOT_AUTO_RELOAD_PLUGIN_CERTS",
 		false,
 		"If enabled, if user introduces new intermediate plug-in CA, user need not to restart isitod to pick up certs."+
 			"Istiod picks newly added intermediate plug-in CA certs and updates it").Get()

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -509,10 +509,10 @@ var (
 	CertSignerDomain = env.RegisterStringVar("CERT_SIGNER_DOMAIN", "", "The cert signer domain info").Get()
 
 	AutoReloadPluginCerts = env.RegisterBoolVar(
-		"PILOT_AUTO_RELOAD_PLUGIN_CERTS",
+		"AUTO_RELOAD_PLUGIN_CERTS",
 		false,
 		"If enabled, if user introduces new intermediate plug-in CA, user need not to restart isitod to pick up certs."+
-			"Istiod picks newly added intermediate plug-in CA certs and updates it").Get()
+			"Istiod picks newly added intermediate plug-in CA certs and updates it. Plug-in new Root-CA not supported.").Get()
 )
 
 // UnsafeFeaturesEnabled returns true if any unsafe features are enabled.

--- a/releasenotes/notes/31522.yaml
+++ b/releasenotes/notes/31522.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: security
+issue:
+  - 31522
+releaseNotes:
+  - |
+    **Added** support to istiod to notice cacerts file changes.

--- a/releasenotes/notes/31522.yaml
+++ b/releasenotes/notes/31522.yaml
@@ -5,4 +5,4 @@ issue:
   - 31522
 releaseNotes:
   - |
-    **Added** support to istiod to notice cacerts file changes.
+    **Added** support to istiod to notice cacerts file changes via the `AUTO_RELOAD_PLUGIN_CERTS` env var.

--- a/security/pkg/pki/util/keycertbundle.go
+++ b/security/pkg/pki/util/keycertbundle.go
@@ -204,8 +204,8 @@ func (b *KeyCertBundle) CertOptions() (*CertOptions, error) {
 	return opts, nil
 }
 
-// UpdateNewPluggedInCACerts Verifies and updates KeyCertBundle with new certs
-func (b *KeyCertBundle) UpdateNewPluggedInCACerts(certFile, privKeyFile, certChainFile, rootCertFile string) error {
+// UpdateVerifiedKeyCertBundleFromFile Verifies and updates KeyCertBundle with new certs
+func (b *KeyCertBundle) UpdateVerifiedKeyCertBundleFromFile(certFile, privKeyFile, certChainFile, rootCertFile string) error {
 	certBytes, err := ioutil.ReadFile(certFile)
 	if err != nil {
 		return err

--- a/security/pkg/pki/util/keycertbundle.go
+++ b/security/pkg/pki/util/keycertbundle.go
@@ -204,6 +204,35 @@ func (b *KeyCertBundle) CertOptions() (*CertOptions, error) {
 	return opts, nil
 }
 
+// UpdateNewPluggedInCACerts Verifies and updates KeyCertBundle with new certs
+func (b *KeyCertBundle) UpdateNewPluggedInCACerts(certFile, privKeyFile, certChainFile, rootCertFile string) error {
+	certBytes, err := ioutil.ReadFile(certFile)
+	if err != nil {
+		return err
+	}
+	privKeyBytes, err := ioutil.ReadFile(privKeyFile)
+	if err != nil {
+		return err
+	}
+	certChainBytes := []byte{}
+	if len(certChainFile) != 0 {
+		if certChainBytes, err = ioutil.ReadFile(certChainFile); err != nil {
+			return err
+		}
+	}
+	rootCertBytes, err := ioutil.ReadFile(rootCertFile)
+	if err != nil {
+		return err
+	}
+
+	err = b.VerifyAndSetAll(certBytes, privKeyBytes, certChainBytes, rootCertBytes)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // ExtractRootCertExpiryTimestamp returns the unix timestamp when the root becomes expires.
 func (b *KeyCertBundle) ExtractRootCertExpiryTimestamp() (float64, error) {
 	return extractCertExpiryTimestamp("root cert", b.GetRootCertPem())


### PR DESCRIPTION
Istiod picks plugged in cacerts while bootstrap. After that, if user deletes and add new set of secrets, istiod has to restart.
This PR avoids necessity of restating istiod. File watcher added at /etc/cacerts directory to observe cacerts files changes (ca-cert.pem, ca-key.pem, root-cert.pem, cert-chain.pem). If new files are created, watcher notifies an event and istiod updates key certs bundle and generates new DNS certs.

Detailed discussion about this feature is discussed [here](https://github.com/istio/istio/issues/30947).
Note: This PR currently supports only intermediate-CA. I am working on new ROOT-CA support as well.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[] Does not have any changes that may affect Istio users.
