### PR TITLE
Fix runaway ingress status errors

### DIFF
--- a/pilot/pkg/config/kube/ingress/status.go
+++ b/pilot/pkg/config/kube/ingress/status.go
@@ -46,10 +46,6 @@ type StatusSyncer struct {
 	meshHolder mesh.Holder
 	client     kubernetes.Interface
 
-	// Name of service (istio-ingressgateway default) to find the IP
-	ingressService  string
-	ingressSelector string
-
 	queue              queue.Instance
 	ingressLister      listerv1beta1.IngressLister
 	podLister          listerv1.PodLister
@@ -73,7 +69,7 @@ func NewStatusSyncer(meshHolder mesh.Holder, client kubelib.Client) *StatusSynce
 	}
 
 	// queue requires a time duration for a retry delay after a handler error
-	q := queue.NewQueue(1 * time.Second)
+	q := queue.NewQueue(5 * time.Second)
 
 	return &StatusSyncer{
 		meshHolder:         meshHolder,
@@ -84,14 +80,15 @@ func NewStatusSyncer(meshHolder mesh.Holder, client kubelib.Client) *StatusSynce
 		nodeLister:         client.KubeInformer().Core().V1().Nodes().Lister(),
 		ingressClassLister: ingressClassLister,
 		queue:              q,
-		ingressService:     meshHolder.Mesh().IngressService,
-		ingressSelector:    meshHolder.Mesh().IngressSelector,
 	}
 }
 
 func (s *StatusSyncer) onEvent() error {
 	addrs, err := s.runningAddresses(ingressNamespace)
 	if err != nil {
+		if kerrors.IsNotFound(err) {
+			return nil
+		}
 		return err
 	}
 
@@ -161,9 +158,11 @@ func (s *StatusSyncer) updateStatus(status []coreV1.LoadBalancerIngress) error {
 // where the ingress controller is currently running
 func (s *StatusSyncer) runningAddresses(ingressNs string) ([]string, error) {
 	addrs := make([]string, 0)
+	ingressService := s.meshHolder.Mesh().IngressService
+	ingressSelector := s.meshHolder.Mesh().IngressSelector
 
-	if s.ingressService != "" {
-		svc, err := s.serviceLister.Services(ingressNs).Get(s.ingressService)
+	if ingressService != "" {
+		svc, err := s.serviceLister.Services(ingressNs).Get(ingressService)
 		if err != nil {
 			return nil, err
 		}
@@ -186,7 +185,7 @@ func (s *StatusSyncer) runningAddresses(ingressNs string) ([]string, error) {
 	}
 
 	// get all pods acting as ingress gateways
-	igSelector := getIngressGatewaySelector(s.ingressSelector, s.ingressService)
+	igSelector := getIngressGatewaySelector(ingressSelector, ingressService)
 	igPods, err := s.podLister.Pods(ingressNamespace).List(labels.SelectorFromSet(igSelector))
 	if err != nil {
 		return nil, err

--- a/pilot/pkg/config/kube/ingress/status_test.go
+++ b/pilot/pkg/config/kube/ingress/status_test.go
@@ -102,9 +102,9 @@ func setupFake(t *testing.T, client kubelib.Client) {
 	}
 }
 
-func fakeMeshHolder() mesh.Holder {
+func fakeMeshHolder(ingressService string) mesh.Holder {
 	config := mesh.DefaultMeshConfig()
-	config.IngressService = "istio-ingress"
+	config.IngressService = ingressService
 	return mesh.NewFixedWatcher(&config)
 }
 
@@ -115,7 +115,7 @@ func makeStatusSyncer(t *testing.T) *StatusSyncer {
 
 	client := kubelib.NewFakeClient()
 	setupFake(t, client)
-	sync := NewStatusSyncer(fakeMeshHolder(), client)
+	sync := NewStatusSyncer(fakeMeshHolder("istio-ingress"), client)
 	stop := make(chan struct{})
 	client.RunAndWait(stop)
 	t.Cleanup(func() {
@@ -156,7 +156,7 @@ func testRunningAddressesWithService(t *testing.T) {
 
 func testRunningAddressesWithHostname(t *testing.T) {
 	syncer := makeStatusSyncer(t)
-	syncer.ingressService = "istio-ingress-hostname"
+	syncer.meshHolder = fakeMeshHolder("istio-ingress-hostname")
 
 	address, err := syncer.runningAddresses(testNamespace)
 	if err != nil {
@@ -171,7 +171,7 @@ func testRunningAddressesWithHostname(t *testing.T) {
 func TestRunningAddressesWithPod(t *testing.T) {
 	ingressNamespace = "istio-system" // it is set in real pilot on newController.
 	syncer := makeStatusSyncer(t)
-	syncer.ingressService = ""
+	syncer.meshHolder = fakeMeshHolder("")
 
 	address, err := syncer.runningAddresses(ingressNamespace)
 	if err != nil {

--- a/pilot/pkg/config/kube/ingressv1/status.go
+++ b/pilot/pkg/config/kube/ingressv1/status.go
@@ -46,10 +46,6 @@ type StatusSyncer struct {
 	meshHolder mesh.Holder
 	client     kubernetes.Interface
 
-	// Name of service (istio-ingressgateway default) to find the IP
-	ingressService  string
-	ingressSelector string
-
 	queue              queue.Instance
 	ingressLister      ingresslister.IngressLister
 	podLister          listerv1.PodLister
@@ -67,7 +63,7 @@ func (s *StatusSyncer) Run(stopCh <-chan struct{}) {
 // NewStatusSyncer creates a new instance
 func NewStatusSyncer(meshHolder mesh.Holder, client kubelib.Client) *StatusSyncer {
 	// queue requires a time duration for a retry delay after a handler error
-	q := queue.NewQueue(1 * time.Second)
+	q := queue.NewQueue(5 * time.Second)
 
 	return &StatusSyncer{
 		meshHolder:         meshHolder,
@@ -78,14 +74,15 @@ func NewStatusSyncer(meshHolder mesh.Holder, client kubelib.Client) *StatusSynce
 		nodeLister:         client.KubeInformer().Core().V1().Nodes().Lister(),
 		ingressClassLister: client.KubeInformer().Networking().V1().IngressClasses().Lister(),
 		queue:              q,
-		ingressService:     meshHolder.Mesh().IngressService,
-		ingressSelector:    meshHolder.Mesh().IngressSelector,
 	}
 }
 
 func (s *StatusSyncer) onEvent() error {
 	addrs, err := s.runningAddresses(ingressNamespace)
 	if err != nil {
+		if kerrors.IsNotFound(err) {
+			return nil
+		}
 		return err
 	}
 
@@ -155,9 +152,11 @@ func (s *StatusSyncer) updateStatus(status []coreV1.LoadBalancerIngress) error {
 // where the ingress controller is currently running
 func (s *StatusSyncer) runningAddresses(ingressNs string) ([]string, error) {
 	addrs := make([]string, 0)
+	ingressService := s.meshHolder.Mesh().IngressService
+	ingressSelector := s.meshHolder.Mesh().IngressSelector
 
-	if s.ingressService != "" {
-		svc, err := s.serviceLister.Services(ingressNs).Get(s.ingressService)
+	if ingressService != "" {
+		svc, err := s.serviceLister.Services(ingressNs).Get(ingressService)
 		if err != nil {
 			return nil, err
 		}
@@ -180,7 +179,7 @@ func (s *StatusSyncer) runningAddresses(ingressNs string) ([]string, error) {
 	}
 
 	// get all pods acting as ingress gateways
-	igSelector := getIngressGatewaySelector(s.ingressSelector, s.ingressService)
+	igSelector := getIngressGatewaySelector(ingressSelector, ingressService)
 	igPods, err := s.podLister.Pods(ingressNamespace).List(labels.SelectorFromSet(igSelector))
 	if err != nil {
 		return nil, err

--- a/pilot/pkg/config/kube/ingressv1/status_test.go
+++ b/pilot/pkg/config/kube/ingressv1/status_test.go
@@ -102,9 +102,9 @@ func setupFake(t *testing.T, client kubelib.Client) {
 	}
 }
 
-func fakeMeshHolder() mesh.Holder {
+func fakeMeshHolder(ingressService string) mesh.Holder {
 	config := mesh.DefaultMeshConfig()
-	config.IngressService = "istio-ingress"
+	config.IngressService = ingressService
 	return mesh.NewFixedWatcher(&config)
 }
 
@@ -115,7 +115,7 @@ func makeStatusSyncer(t *testing.T) *StatusSyncer {
 
 	client := kubelib.NewFakeClient()
 	setupFake(t, client)
-	sync := NewStatusSyncer(fakeMeshHolder(), client)
+	sync := NewStatusSyncer(fakeMeshHolder("istio-ingress"), client)
 	stop := make(chan struct{})
 	client.RunAndWait(stop)
 	t.Cleanup(func() {
@@ -156,7 +156,7 @@ func testRunningAddressesWithService(t *testing.T) {
 
 func testRunningAddressesWithHostname(t *testing.T) {
 	syncer := makeStatusSyncer(t)
-	syncer.ingressService = "istio-ingress-hostname"
+	syncer.meshHolder = fakeMeshHolder("istio-ingress-hostname")
 
 	address, err := syncer.runningAddresses(testNamespace)
 	if err != nil {
@@ -171,7 +171,7 @@ func testRunningAddressesWithHostname(t *testing.T) {
 func TestRunningAddressesWithPod(t *testing.T) {
 	ingressNamespace = "istio-system" // it is set in real pilot on newController.
 	syncer := makeStatusSyncer(t)
-	syncer.ingressService = ""
+	syncer.meshHolder = fakeMeshHolder("")
 
 	address, err := syncer.runningAddresses(ingressNamespace)
 	if err != nil {

--- a/releasenotes/notes/31336.yaml
+++ b/releasenotes/notes/31336.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug
+area: networking
+issue:
+  - 31336
+releaseNotes:
+  - |
+    **Fixed** a bug causing runaway logs in `istiod` after disabling the default ingress controller.


### PR DESCRIPTION
Fixes #31336, probably want to cherry-pick back through 1.8

Still unclear to me how there could be 2000-18000 logs per minute with the queue rate limiting the errors without multiple status controller queues, which there don't seem to be from goroutine dump

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
