### PR TITLE
fix labels

### DIFF
--- a/pilot/tools/debug/pilot_cli.go
+++ b/pilot/tools/debug/pilot_cli.go
@@ -233,7 +233,7 @@ func portForwardPilot(kubeConfig, pilotURL string) (*os.Process, string, error) 
 		return nil, "", err
 	}
 	for _, pod := range pods.Items {
-		if app, ok := pod.ObjectMeta.Labels["istio"]; ok && app == "istiod" {
+		if app, ok := pod.ObjectMeta.Labels["app"]; ok && app == "istiod" {
 			podName = pod.Name
 		}
 	}


### PR DESCRIPTION
Signed-off-by: zackzhangkai <zhangkaiamm@gmail.com>



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.


Lower version, such as istio 1.6.10, the labels is ` app=istiod, istio=istiod`. 
But the latest version, the labels changed to ` app=istiod,istio=pilot`. 

So we should use `app=istiod` instead to be compliant with different versions.