### PR TITLE
rename: x istiod log to admin log

### DIFF
--- a/istioctl/cmd/admin.go
+++ b/istioctl/cmd/admin.go
@@ -1,0 +1,45 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func adminCmd() *cobra.Command {
+	adminCmd := &cobra.Command{
+		Use:   "admin",
+		Short: "Manage control plane (istiod) configuration",
+		Long:  "A group of commands used to manage istiod configuration",
+		Example: `  # Retrieve information about istiod configuration.
+  istioctl admin log`,
+		Aliases: []string{"istiod"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.HelpFunc()(cmd, args)
+			if len(args) != 0 {
+				return fmt.Errorf("unknown subcommand %q", args[0])
+			}
+			return nil
+		},
+	}
+
+	istiodLog := istiodLogCmd()
+	adminCmd.AddCommand(istiodLog)
+	adminCmd.PersistentFlags().StringVarP(&istiodLabelSelector, "selector", "l", "app=istiod", "label selector")
+
+	return adminCmd
+}

--- a/istioctl/cmd/istiodconfig.go
+++ b/istioctl/cmd/istiodconfig.go
@@ -371,16 +371,16 @@ func istiodLogCmd() *cobra.Command {
 		Short: "Manage istiod logging.",
 		Long:  "Retrieve or update logging levels of istiod components.",
 		Example: `  # Retrieve information about istiod logging levels.
-  istioctl experimental istiod log
+  istioctl admin log
 
   # Retrieve information about istiod logging levels on a specific control plane pod.
-  istioctl experimental istiod l istiod-5c868d8bdd-pmvgg
+  istioctl admin l istiod-5c868d8bdd-pmvgg
 
   # Update levels of the specified loggers.
-  istioctl x istiod log --level ads:debug,authorization:debug
+  istioctl admin log --level ads:debug,authorization:debug
 
   # Reset levels of all the loggers to default value (info).
-  istioctl x istiod log -r
+  istioctl admin log -r
 `,
 		Aliases: []string{"l"},
 		Args: func(logCmd *cobra.Command, args []string) error {
@@ -465,28 +465,4 @@ func istiodLogCmd() *cobra.Command {
 	logCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o",
 		outputFormat, "Output format: one of json|short")
 	return logCmd
-}
-
-func istiodConfig() *cobra.Command {
-	istiodConfigCmd := &cobra.Command{
-		Use:   "istiod",
-		Short: "Manage control plane (istiod) configuration",
-		Long:  "A group of commands used to manage istiod configuration",
-		Example: `  # Retrieve information about istiod configuration.
-  istioctl experimental istiod log`,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			cmd.HelpFunc()(cmd, args)
-			if len(args) != 0 {
-				return fmt.Errorf("unknown subcommand %q", args[0])
-			}
-
-			return nil
-		},
-	}
-
-	istiodLog := istiodLogCmd()
-	istiodConfigCmd.AddCommand(istiodLog)
-	istiodConfigCmd.PersistentFlags().StringVarP(&istiodLabelSelector, "selector", "l", "app=istiod", "label selector")
-
-	return istiodConfigCmd
 }

--- a/istioctl/cmd/istiodconfig_test.go
+++ b/istioctl/cmd/istiodconfig_test.go
@@ -31,37 +31,33 @@ func TestCtlPlaneConfig(t *testing.T) {
 
 	cases := []execTestCase{
 		{
-			args:           strings.Split("experimental istiod", " "),
+			args:           strings.Split("admin", " "),
 			expectedString: "Manage istiod logging",
 		},
 		{
-			args:           strings.Split("x istiod", " "),
-			expectedString: "Manage istiod logging",
-		},
-		{
-			args:           strings.Split("x istiod log -l app=invalid", " "),
+			args:           strings.Split("admin log -l app=invalid", " "),
 			expectedString: "no pods found",
 			wantException:  true,
 		},
 		{
-			args:           strings.Split("x istiod log", " "),
+			args:           strings.Split("admin log", " "),
 			expectedString: "no pods found",
 			wantException:  true,
 		},
 		{
 			execClientConfig: istiodConfigMap,
-			args:             strings.Split("x istiod log istiod-7b69ff6f8c-fvjvw --level invalid", " "),
+			args:             strings.Split("admin log istiod-7b69ff6f8c-fvjvw --level invalid", " "),
 			expectedString:   "pattern invalid did not match",
 			wantException:    true,
 		},
 		{
 			execClientConfig: istiodConfigMap,
-			args:             strings.Split("x istiod log istiod-7b69ff6f8c-fvjvw --stack-trace-level invalid", " "),
+			args:             strings.Split("admin log istiod-7b69ff6f8c-fvjvw --stack-trace-level invalid", " "),
 			expectedString:   "pattern invalid did not match",
 			wantException:    true,
 		},
 		{
-			args:           strings.Split("x istiod log --reset --level invalid", " "),
+			args:           strings.Split("admin log --reset --level invalid", " "),
 			expectedString: "--level cannot be combined with --reset",
 			wantException:  true,
 		},

--- a/istioctl/cmd/root.go
+++ b/istioctl/cmd/root.go
@@ -208,7 +208,7 @@ debug and diagnose their Istio mesh.
 
 	rootCmd.AddCommand(experimentalCmd)
 	rootCmd.AddCommand(proxyConfig())
-	experimentalCmd.AddCommand(istiodConfig())
+	rootCmd.AddCommand(adminCmd())
 	experimentalCmd.AddCommand(injectorCommand())
 	experimentalCmd.AddCommand(tagCommand())
 


### PR DESCRIPTION
> istioctl x istiod log must become istioctl admin log or istioctl admin x log

Keeping `admin` as a separate command will be useful when we will have separate control plane and data plane commands (`istioctl admin proxy-status` and `istioctl proxy-status`).

Part of https://github.com/istio/istio/issues/29153

More details: https://docs.google.com/document/d/1raZOoeYz3APZdQRlJlFA-zgfmEJu2YLaGa4_3KwbNRs/edit#