### PR TITLE
test framework: make kubeconfig path in topology file more robust

### DIFF
--- a/pkg/test/framework/components/cluster/kube/factory.go
+++ b/pkg/test/framework/components/cluster/kube/factory.go
@@ -21,6 +21,7 @@ import (
 
 	istioKube "istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/test/framework/components/cluster"
+	"istio.io/istio/pkg/test/util/file"
 )
 
 const (
@@ -39,6 +40,11 @@ func buildKube(origCfg cluster.Config, topology cluster.Topology) (cluster.Clust
 	}
 
 	kubeconfigPath := cfg.Meta.String(kubeconfigMetaKey)
+	kubeconfigPath, err = file.NormalizePath(kubeconfigPath)
+	if err != nil {
+		return nil, err
+	}
+
 	client, err := buildClient(kubeconfigPath)
 	if err != nil {
 		return nil, err

--- a/pkg/test/framework/components/environment/kube/flags.go
+++ b/pkg/test/framework/components/environment/kube/flags.go
@@ -22,10 +22,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/mitchellh/go-homedir"
-
 	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/pkg/test/scopes"
+	"istio.io/istio/pkg/test/util/file"
 )
 
 const (
@@ -104,7 +103,7 @@ func getKubeConfigsFromEnvironment() ([]string, error) {
 	}
 	if len(out) == 0 {
 		scopes.Framework.Info("Environment variable KUBECONFIG unspecified, defaultiing to ~/.kube/config.")
-		normalizedDefaultKubeConfig, err := normalizeFile(defaultKubeConfig)
+		normalizedDefaultKubeConfig, err := file.NormalizePath(defaultKubeConfig)
 		if err != nil {
 			return nil, fmt.Errorf("error normalizing default kube config file %s: %v",
 				defaultKubeConfig, err)
@@ -125,7 +124,7 @@ func parseKubeConfigs(value, separator string) ([]string, error) {
 		f := strings.TrimSpace(f)
 		if len(f) != 0 {
 			var err error
-			if f, err = normalizeFile(f); err != nil {
+			if f, err = file.NormalizePath(f); err != nil {
 				return nil, err
 			}
 			out = append(out, f)
@@ -213,23 +212,6 @@ func parseClusterIndex(index string) (clusterIndex, error) {
 		return 0, fmt.Errorf("failed parsing cluster index: %s", index)
 	}
 	return clusterIndex(ci), nil
-}
-
-func normalizeFile(originalPath string) (string, error) {
-	// trim leading/trailing spaces from the path and if it uses the homedir ~, expand it.
-	var err error
-	out := strings.TrimSpace(originalPath)
-	out, err = homedir.Expand(out)
-	if err != nil {
-		return "", err
-	}
-
-	// Verify that the file exists.
-	if _, err := os.Stat(out); os.IsNotExist(err) {
-		return "", fmt.Errorf("failed normalizing file %s: %v", originalPath, err)
-	}
-
-	return out, nil
 }
 
 // init registers the command-line flags that we can exposed for "go test".

--- a/pkg/test/framework/components/environment/kube/settings.go
+++ b/pkg/test/framework/components/environment/kube/settings.go
@@ -23,6 +23,7 @@ import (
 	istioKube "istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/test/framework/components/cluster"
 	"istio.io/istio/pkg/test/scopes"
+	"istio.io/istio/pkg/test/util/file"
 )
 
 // clusterIndex is the index of a cluster within the KubeConfig or topology file entries
@@ -113,7 +114,7 @@ func (s *Settings) clusterConfigsFromFlags() ([]cluster.Config, error) {
 
 func (s *Settings) clusterConfigsFromFile() ([]cluster.Config, error) {
 	scopes.Framework.Infof("Using configs file: %v.", topologyFile)
-	filename, err := normalizeFile(topologyFile)
+	filename, err := file.NormalizePath(topologyFile)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Without this change, if you specify multiple clusters that use '~' instead of an absolute path, we end up using `~/.kube/config` for every cluster, which will break the tests and possibly a cluster that shouldn't be touched. 

- Allow homedir via `~`
- Fail out if file isn't found