### PR TITLE
test framework: dont apply remote secret for self

### DIFF
--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -706,7 +706,12 @@ func (i *operatorComponent) configureDirectAPIServiceAccessForCluster(ctx resour
 	if err != nil {
 		return fmt.Errorf("failed creating remote secret for cluster %s: %v", cluster.Name(), err)
 	}
-	if err := ctx.Config(ctx.Clusters().Primaries(cluster)...).ApplyYAML(cfg.SystemNamespace, secret); err != nil {
+	clusters := ctx.Clusters().Primaries(cluster)
+	if len(clusters) == 0 {
+		// giving 0 clusters to ctx.Config() means using all clusters
+		return nil
+	}
+	if err := ctx.Config(clusters...).ApplyYAML(cfg.SystemNamespace, secret); err != nil {
 		return fmt.Errorf("failed applying remote secret to clusters: %v", err)
 	}
 	return nil


### PR DESCRIPTION
This shouldn't affect CI, but when running the test framework in multicluster mode, with only 1 primary cluster, we will apply the remote secret for the local primary-cluster. 

This can cause kube service registry issues. The following log also occurs:

```
2021-03-18T20:16:21.258530Z	error	klog	error retrieving resource lock istio-system/istio-namespace-controller-election: configmaps "istio-namespace-controller-election" is forbidden: User "system:serviceaccount:istio-system:istio-reader-service-account" cannot get resource "configmaps" in API group "" in the namespace "istio-system"
```