### PR TITLE
Rewrite gateway server port to service port.

### DIFF
--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -1527,6 +1527,135 @@ func TestServiceWithExportTo(t *testing.T) {
 	}
 }
 
+func TestMergeGatewayServerPort(t *testing.T) {
+	cases := []struct {
+		name        string
+		gateways    []config.Config
+		services    []*ServiceInstance
+		wantedPorts map[uint32]struct{}
+	}{
+		{
+			name: "rewrite",
+			gateways: []config.Config{
+				makeConfig("foo", "not-default", "foo.bar.com", "name1", "http", 7, "ingressgateway", ""),
+				makeConfig("foo", "not-default", "foo.bar.com", "name2", "http", 8, "ingressgateway", ""),
+			},
+			services: []*ServiceInstance{
+				{
+					Endpoint:    &IstioEndpoint{EndpointPort: 7},
+					ServicePort: &Port{Port: 8},
+				},
+			},
+			wantedPorts: map[uint32]struct{}{8: {}},
+		},
+		{
+			name: "skip rewrite: no dup",
+			gateways: []config.Config{
+				makeConfig("foo", "not-default", "foo.bar.com", "name1", "http", 7, "ingressgateway", ""),
+			},
+			services: []*ServiceInstance{
+				{
+					Endpoint:    &IstioEndpoint{EndpointPort: 7},
+					ServicePort: &Port{Port: 8},
+				},
+			},
+			wantedPorts: map[uint32]struct{}{7: {}},
+		},
+		{
+			name: "skip rewrite: ambiguous gateway port",
+			gateways: []config.Config{
+				makeConfig("foo", "not-default", "foo.bar.com", "name1", "http", 7, "ingressgateway", ""),
+				makeConfig("foo", "not-default", "foo.bar.com", "name2", "http", 8, "ingressgateway", ""),
+			},
+			services: []*ServiceInstance{
+				{
+					Endpoint:    &IstioEndpoint{EndpointPort: 7},
+					ServicePort: &Port{Port: 8},
+				},
+				{
+					Endpoint:    &IstioEndpoint{EndpointPort: 6},
+					ServicePort: &Port{Port: 7},
+				},
+			},
+			wantedPorts: map[uint32]struct{}{8: {}, 7: {}},
+		},
+		{
+			name: "skip rewrite: no dup + ambiguous gateway port",
+			gateways: []config.Config{
+				makeConfig("foo", "not-default", "foo.bar.com", "name1", "http", 7, "ingressgateway", ""),
+				makeConfig("foo", "not-default", "foo.bar.com", "name2", "http", 8, "ingressgateway", ""),
+			},
+			services: []*ServiceInstance{
+				{
+					Endpoint:    &IstioEndpoint{EndpointPort: 8},
+					ServicePort: &Port{Port: 8},
+				},
+				{
+					Endpoint:    &IstioEndpoint{EndpointPort: 7},
+					ServicePort: &Port{Port: 7},
+				},
+			},
+			wantedPorts: map[uint32]struct{}{7: {}, 8: {}},
+		},
+		{
+			name: "skip rewrite: target port with multiple service port",
+			gateways: []config.Config{
+				makeConfig("foo", "not-default", "foo.bar.com", "name1", "http", 7, "ingressgateway", ""),
+			},
+			services: []*ServiceInstance{
+				{
+					Endpoint:    &IstioEndpoint{EndpointPort: 7},
+					ServicePort: &Port{Port: 8},
+				},
+				{
+					Endpoint:    &IstioEndpoint{EndpointPort: 7},
+					ServicePort: &Port{Port: 9},
+				},
+			},
+			wantedPorts: map[uint32]struct{}{7: {}},
+		},
+		{
+			name: "skip rewrite: svc port with multiple target ports",
+			gateways: []config.Config{
+				makeConfig("foo", "not-default", "foo.bar.com", "name1", "http", 8, "ingressgateway", ""),
+				makeConfig("foo", "not-default", "foo.bar.com", "name2", "http", 7, "ingressgateway", ""),
+			},
+			services: []*ServiceInstance{
+				{
+					Endpoint:    &IstioEndpoint{EndpointPort: 9},
+					ServicePort: &Port{Port: 8},
+				},
+				{
+					Endpoint:    &IstioEndpoint{EndpointPort: 7},
+					ServicePort: &Port{Port: 8},
+				},
+			},
+			wantedPorts: map[uint32]struct{}{8: {}, 7: {}},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			proxy := &Proxy{
+				Metadata:         &NodeMetadata{Labels: map[string]string{"istio": "ingressgateway"}},
+				ServiceInstances: c.services,
+			}
+			pc := &PushContext{
+				gatewayIndex: gatewayIndex{all: c.gateways},
+			}
+			mg := pc.mergeGateways(proxy)
+			if len(mg.MergedServers) != len(c.wantedPorts) {
+				t.Errorf("number of servers want %v got %v", c.wantedPorts, mg.MergedServers)
+			}
+			for p := range mg.MergedServers {
+				if _, ok := c.wantedPorts[p.Number]; !ok {
+					t.Errorf("server port want %v got %v", c.wantedPorts, p)
+					break
+				}
+			}
+		})
+	}
+}
+
 var _ ServiceDiscovery = &localServiceDiscovery{}
 
 // MockDiscovery is an in-memory ServiceDiscover with mock services

--- a/pilot/pkg/networking/core/v1alpha3/fake.go
+++ b/pilot/pkg/networking/core/v1alpha3/fake.go
@@ -223,8 +223,8 @@ func (f *ConfigGenTest) SetupProxy(p *model.Proxy) *model.Proxy {
 	// Initialize data structures
 	pc := f.PushContext()
 	p.SetSidecarScope(pc)
-	p.SetGatewaysForProxy(pc)
 	p.SetServiceInstances(f.env.ServiceDiscovery)
+	p.SetGatewaysForProxy(pc)
 	p.DiscoverIPVersions()
 	return p
 }


### PR DESCRIPTION
Another fix attempt for #29291, which should only rewrite gateway server port if

* GW server port is unambiguously a target port (i.e. there is no service port using the same port number)
* There is only one service port mapped to this target port, which the gateway server port will be rewritten to.
* There is only one target port mapped to the rewritten service port (i.e. there is no ambiguity later on when generating listener with target port)
* Another gateway server is defined to listen on the service port, thus without rewriting, duplicated listeners will be generated.

This change makes sure that it only fixes the case where duplicated listeners are guaranteed to be generated, but not affects existing use cases which depend on using target port as gateway server port.