### PR TITLE
fix xds proxy logs

### DIFF
--- a/pkg/istio-agent/xds_proxy_test.go
+++ b/pkg/istio-agent/xds_proxy_test.go
@@ -551,3 +551,10 @@ func setupDownstreamConnectionUDS(t test.Failer, path string) *grpc.ClientConn {
 func setupDownstreamConnection(t *testing.T, proxy *XdsProxy) *grpc.ClientConn {
 	return setupDownstreamConnectionUDS(t, proxy.xdsUdsPath)
 }
+
+func TestIsExpectedGRPCError(t *testing.T) {
+	err := errors.New("code = Internal desc = stream terminated by RST_STREAM with error code: NO_ERROR")
+	if got := isExpectedGRPCError(err); !got {
+		t.Fatalf("expected true, got %v", got)
+	}
+}


### PR DESCRIPTION
We are still seeing this stream terminated by RST_STREAM with error code: NO_ERROR in logs. Figured out that is is in a gRPC status but a regular error. So added message check.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any changes that may affect Istio users.
