### PR TITLE
Update base image for image scanning issue

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -22,7 +22,7 @@ SHELL := /bin/bash -o pipefail
 export VERSION ?= 1.9-dev
 
 # Base version of Istio image to use
-BASE_VERSION ?= 1.9-dev.4
+BASE_VERSION ?= 1.9-dev.5
 
 export GO111MODULE ?= on
 export GOPROXY ?= https://proxy.golang.org


### PR DESCRIPTION
Update base image. Will need to retest once images are pushed. Blocking the release of 1.9.2