### PR TITLE
Don't expect istio-system to have an injection label

### DIFF
--- a/galley/pkg/config/analysis/analyzers/injection/injection.go
+++ b/galley/pkg/config/analysis/analyzers/injection/injection.go
@@ -25,6 +25,7 @@ import (
 	"istio.io/istio/galley/pkg/config/analysis"
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/util"
 	"istio.io/istio/galley/pkg/config/analysis/msg"
+	"istio.io/istio/pilot/pkg/serviceregistry/kube/controller"
 	"istio.io/istio/pkg/config/resource"
 	"istio.io/istio/pkg/config/schema/collection"
 	"istio.io/istio/pkg/config/schema/collections"
@@ -59,6 +60,10 @@ func (a *Analyzer) Analyze(c analysis.Context) {
 	injectedNamespaces := make(map[string]bool)
 
 	c.ForEach(collections.K8SCoreV1Namespaces.Name(), func(r *resource.Instance) bool {
+		if r.Metadata.FullName.Namespace == controller.IstioNamespace {
+			return true
+		}
+
 		ns := r.Metadata.FullName.String()
 		if util.IsSystemNamespace(resource.Namespace(ns)) {
 			return true

--- a/galley/pkg/config/analysis/analyzers/util/config.go
+++ b/galley/pkg/config/analysis/analyzers/util/config.go
@@ -33,14 +33,12 @@ var (
 		constants.KubePublicNamespace,
 		constants.KubeNodeLeaseNamespace,
 		constants.LocalPathStorageNamespace,
-
-		controller.IstioNamespace,
 	}
 )
 
 // IsSystemNamespace returns true for system namespaces
 func IsSystemNamespace(ns resource.Namespace) bool {
-	return IsIncluded(SystemNamespaces, ns.String())
+	return IsIncluded(SystemNamespaces, ns.String()) || ns.String() == controller.IstioNamespace
 }
 
 // IsIstioControlPlane returns true for resources that are part of the Istio control plane

--- a/galley/pkg/config/analysis/analyzers/util/config.go
+++ b/galley/pkg/config/analysis/analyzers/util/config.go
@@ -15,7 +15,6 @@
 package util
 
 import (
-	"istio.io/istio/pilot/pkg/serviceregistry/kube/controller"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/resource"
 )
@@ -38,7 +37,7 @@ var (
 
 // IsSystemNamespace returns true for system namespaces
 func IsSystemNamespace(ns resource.Namespace) bool {
-	return IsIncluded(SystemNamespaces, ns.String()) || ns.String() == controller.IstioNamespace
+	return IsIncluded(SystemNamespaces, ns.String())
 }
 
 // IsIstioControlPlane returns true for resources that are part of the Istio control plane

--- a/galley/pkg/config/analysis/analyzers/util/config.go
+++ b/galley/pkg/config/analysis/analyzers/util/config.go
@@ -15,6 +15,7 @@
 package util
 
 import (
+	"istio.io/istio/pilot/pkg/serviceregistry/kube/controller"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/resource"
 )
@@ -32,6 +33,8 @@ var (
 		constants.KubePublicNamespace,
 		constants.KubeNodeLeaseNamespace,
 		constants.LocalPathStorageNamespace,
+
+		controller.IstioNamespace,
 	}
 )
 


### PR DESCRIPTION
~~Resolves https://github.com/istio/istio/issues/30874~~
Starts work on https://github.com/istio/istio/issues/30874 by skipping _istio-system_ when checking for injection labels.

Because _istio-system_ does not have an injection label, yet also doesn't run user workloads, don't expect it to have an `istio-injection` label.