### PR TITLE
echo app: call timeout applies to entire set of requests

### DIFF
--- a/pkg/test/echo/server/forwarder/instance.go
+++ b/pkg/test/echo/server/forwarder/instance.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
@@ -84,6 +85,7 @@ func New(cfg Config) (*Instance, error) {
 // Run the forwarder and collect the responses.
 func (i *Instance) Run(ctx context.Context) (*proto.ForwardEchoResponse, error) {
 	g := multierror.Group{}
+	responsesMu := sync.RWMutex{}
 	responses := make([]string, i.count)
 
 	var throttle *time.Ticker
@@ -93,6 +95,14 @@ func (i *Instance) Run(ctx context.Context) (*proto.ForwardEchoResponse, error) 
 		fwLog.Debugf("Sleeping %v between requests", sleepTime)
 		throttle = time.NewTicker(sleepTime)
 	}
+
+	// make the timeout apply to the entire set of requests
+	ctx, cancel := context.WithTimeout(ctx, i.timeout)
+	var canceled bool
+	defer func() {
+		cancel()
+		canceled = true
+	}()
 
 	sem := semaphore.NewWeighted(maxConcurrency)
 	for reqIndex := 0; reqIndex < i.count; reqIndex++ {
@@ -115,17 +125,40 @@ func (i *Instance) Run(ctx context.Context) (*proto.ForwardEchoResponse, error) 
 		}
 		g.Go(func() error {
 			defer sem.Release(1)
+			if canceled {
+				return fmt.Errorf("request set timed out")
+			}
 			resp, err := i.p.makeRequest(ctx, &r)
 			if err != nil {
 				return err
 			}
+			responsesMu.Lock()
 			responses[r.RequestID] = resp
+			responsesMu.Unlock()
 			return nil
 		})
 	}
 
-	if err := g.Wait(); err != nil {
-		return nil, fmt.Errorf("%d/%d requests had errors; first error: %v", err.Len(), i.count, err.Errors[0])
+	requestsDone := make(chan *multierror.Error)
+	go func() {
+		requestsDone <- g.Wait()
+	}()
+
+	select {
+	case err := <-requestsDone:
+		if err != nil {
+			return nil, fmt.Errorf("%d/%d requests had errors; first error: %v", err.Len(), i.count, err.Errors[0])
+		}
+	case <-ctx.Done():
+		responsesMu.RLock()
+		defer responsesMu.RUnlock()
+		c := 0
+		for _, res := range responses {
+			if res != "" {
+				c++
+			}
+		}
+		return nil, fmt.Errorf("request set timed out after %v and only %d/%d requests completed", i.timeout, c, i.count)
 	}
 
 	return &proto.ForwardEchoResponse{


### PR DESCRIPTION
When making a call with echo app, the user can specify the # of requests as well as a timeout via CallOptions:

```go
echo.CallOptions{
  Timeout: 5*time.Second,
  Count: 50,
}
```

The current semantics are that _each_ of the 50 calls can take up to 5 seconds. 

In the echo forwarder, we make up to 20 concurrent requests:

https://github.com/istio/istio/blob/3f324e45a17d27e8660930cacfffeef2ea0de3e9/pkg/test/echo/server/forwarder/instance.go#L33

So for 50 requests, that timeout after 5 seconds each, the first set of 20 take 5 seconds, the second set of 20 takes 5 seconds, then the final set of 10 takes 5 seconds giving a total of 15 seconds. 

To allow a failure to occur while providing ample time for us to retry and converge on 3 sets of requests all succeeding, we should enforce this timeout at the _request set_ level which is easier to understand and predict, versus what we do today with at the _request_ level which requires understanding the maxConcurrency of requests. 