### PR TITLE
Adding nodeSelector and tolerations options in istiod deployment

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -214,4 +214,12 @@ spec:
         configMap:
           name: pilot-jwks-extra-cacerts{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- end }}
+  {{- if .Values.pilot.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.pilot.nodeSelector | indent 8 }}
+  {{- end }}
+  {{- if .Values.pilot.tolerations }}
+      tolerations:
+{{ toYaml .Values.pilot.tolerations | indent 8 }}
+  {{- end }}
 ---

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -33,6 +33,7 @@ pilot:
   enableProtocolSniffingForInbound: true
 
   nodeSelector: {}
+  tolerations: []
   podAnnotations: {}
 
   # You can use jwksResolverExtraRootCA to provide a root certificate


### PR DESCRIPTION
Provide option to specify `nodeSelector` and `tolerations` for istiod deployment.

`nodeSelector` is already present in [values.yaml](https://github.com/istio/istio/blob/master/manifests/charts/istio-control/istio-discovery/values.yaml#L35) but the corresponding template is not in deployment template.

[ ] Configuration Infrastructure
[ ] Docs
[X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any changes that may affect Istio users.
