### PR TITLE
test framework: change signatures and types to encourage shadowing T

### DIFF
--- a/pkg/test/framework/components/echo/echotest/run.go
+++ b/pkg/test/framework/components/echo/echotest/run.go
@@ -20,8 +20,8 @@ import (
 )
 
 type (
-	perDeploymentTest func(ctx framework.TestContext, instances echo.Instances)
-	perInstanceTest   func(ctx framework.TestContext, src echo.Instance, dst echo.Instances)
+	perDeploymentTest func(t framework.TestContext, instances echo.Instances)
+	perInstanceTest   func(t framework.TestContext, src echo.Instance, dst echo.Instances)
 )
 
 // Run will generate nested subtests for every instance in every deployment. The subtests will be nested including

--- a/pkg/test/framework/components/echo/echotest/setup.go
+++ b/pkg/test/framework/components/echo/echotest/setup.go
@@ -28,7 +28,7 @@ import (
 //     cleanup...
 //     b/to_a/from_cluster-1
 //     ...
-func (t *T) Setup(setupFn func(ctx framework.TestContext, src echo.Instances) error) *T {
+func (t *T) Setup(setupFn func(t framework.TestContext, src echo.Instances) error) *T {
 	t.sourceDeploymentSetup = append(t.sourceDeploymentSetup, setupFn)
 	return t
 }
@@ -48,7 +48,7 @@ func (t *T) setup(ctx framework.TestContext, srcInstances echo.Instances) {
 //     cleanup...
 //     a/to_b/from_cluster-2
 //     ...
-func (t *T) SetupForPair(setupFn func(ctx framework.TestContext, src echo.Instances, dst echo.Instances) error) *T {
+func (t *T) SetupForPair(setupFn func(t framework.TestContext, src echo.Instances, dst echo.Instances) error) *T {
 	t.deploymentPairSetup = append(t.deploymentPairSetup, setupFn)
 	return t
 }

--- a/pkg/test/framework/test.go
+++ b/pkg/test/framework/test.go
@@ -45,7 +45,7 @@ type Test interface {
 	// RequiresSingleCluster this a utility that requires the min/max clusters to both = 1.
 	RequiresSingleCluster() Test
 	// Run the test, supplied as a lambda.
-	Run(fn func(ctx TestContext))
+	Run(fn func(t TestContext))
 	// RunParallel runs this test in parallel with other children of the same parent test/suite. Under the hood,
 	// this relies on Go's t.Parallel() and will, therefore, have the same behavior.
 	//
@@ -92,7 +92,7 @@ type Test interface {
 	// Since both T1 and T2 are non-parallel, they are run synchronously: T1 followed by T2. After T1 exits,
 	// T1a and T1b are run asynchronously with each other. After T1a and T1b complete, T2 is then run in the
 	// same way: T2 exits, then T2a and T2b are run asynchronously to completion.
-	RunParallel(fn func(ctx TestContext))
+	RunParallel(fn func(t TestContext))
 }
 
 // Test allows the test author to specify test-related metadata in a fluent-style, before commencing execution.


### PR DESCRIPTION
As #31365  points out, it's easy to run into issues where a subtest calls Fail or other methods on the root/parent test. 

This changes signatures and types that most IDEs would use for auto-complete to make user-defined funcs take `t` instead of `ctx` to help encourage shadowing. 