### PR TITLE
add debug endpoint for multi-network gateways

### DIFF
--- a/pilot/pkg/xds/debug.go
+++ b/pilot/pkg/xds/debug.go
@@ -190,6 +190,7 @@ func (s *DiscoveryServer) AddDebugHandlers(mux *http.ServeMux, enableProfiling b
 
 	s.addDebugHandler(mux, "/debug/inject", "Active inject template", s.InjectTemplateHandler(webhook))
 	s.addDebugHandler(mux, "/debug/mesh", "Active mesh config", s.MeshHandler)
+	s.addDebugHandler(mux, "/debug/networkz", "List cross-network gateways", s.networkz)
 }
 
 func (s *DiscoveryServer) addDebugHandler(mux *http.ServeMux, path string, help string,
@@ -878,4 +879,16 @@ func (s *DiscoveryServer) instancesz(w http.ResponseWriter, req *http.Request) {
 	by, _ := json.MarshalIndent(instances, "", "  ")
 
 	_, _ = w.Write(by)
+}
+
+func (s *DiscoveryServer) networkz(w http.ResponseWriter, req *http.Request) {
+	gws := s.Env.NetworkGateways()
+	by, err := json.MarshalIndent(gws, "", "  ")
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+	}
+	_, err = w.Write(by)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+	}
 }


### PR DESCRIPTION
Responds with 

```json
{
  "network-1": [
    {"Addr": "1.2.3.4", "Port": 15443},
  ]
}
```