### PR TITLE
trustbundle: refactoring code that fetches CA roots when CA is not ru…

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -1175,8 +1175,6 @@ func (s *Server) initMeshHandlers() {
 }
 
 func (s *Server) addIstioCAToTrustBundle(args *PilotArgs) error {
-	// TODO: unify with CreateIstioCA instead of mirroring it
-
 	var err error
 	if s.CA != nil {
 		// If IstioCA is setup, derive trustAnchor directly from CA
@@ -1190,52 +1188,6 @@ func (s *Server) addIstioCAToTrustBundle(args *PilotArgs) error {
 			return err
 		}
 		return nil
-	}
-
-	// If CA is not running, derive root certificates from the configured CA secrets
-	signingKeyFile := path.Join(LocalCertDir.Get(), "ca-key.pem")
-	if _, err := os.Stat(signingKeyFile); err != nil && s.kubeClient != nil {
-		// Fetch self signed certificates
-		caSecret, err := s.kubeClient.CoreV1().Secrets(args.Namespace).
-			Get(context.TODO(), ca.CASecret, metav1.GetOptions{})
-		if err != nil {
-			log.Errorf("unable to retrieve self signed CA secret: %v", err)
-			return err
-		}
-		rootCertBytes, ok := caSecret.Data[ca.RootCertID]
-		if !ok {
-			rootCertBytes = caSecret.Data[ca.CaCertID]
-		}
-		err = s.workloadTrustBundle.UpdateTrustAnchor(&tb.TrustAnchorUpdate{
-			TrustAnchorConfig: tb.TrustAnchorConfig{Certs: []string{string(rootCertBytes)}},
-			Source:            tb.SourceIstioCA,
-		})
-		if err != nil {
-			log.Errorf("unable to update trustbundle with self signed CA root: %v", err)
-			return err
-		}
-	} else {
-		// If NOT self signed certificates
-		rootCertFile := path.Join(LocalCertDir.Get(), "root-cert.pem")
-		if _, err := os.Stat(rootCertFile); err != nil {
-			rootCertFile = path.Join(LocalCertDir.Get(), "ca-cert.pem")
-		}
-		certBytes, err := ioutil.ReadFile(rootCertFile)
-		if err != nil {
-			if s.kubeClient != nil {
-				return err
-			}
-			// TODO: accommodation for unit tests. needs to be removed
-			return nil
-		}
-		err = s.workloadTrustBundle.UpdateTrustAnchor(&tb.TrustAnchorUpdate{
-			TrustAnchorConfig: tb.TrustAnchorConfig{Certs: []string{string(certBytes)}},
-			Source:            tb.SourceIstioCA,
-		})
-		if err != nil {
-			log.Errorf("unable to update trustbundle with plugin CA root: %v", err)
-			return err
-		}
 	}
 	return nil
 }


### PR DESCRIPTION
Refactor previous commit: Don't attempt to get CA root certs if CA is not running. Need to find better way to do this.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
