### PR TITLE
Remove quotes around apiVersion and Kind

### DIFF
--- a/galley/testdatasets/validation/dataset.gen.go
+++ b/galley/testdatasets/validation/dataset.gen.go
@@ -937,8 +937,8 @@ func datasetSecurityV1beta1AuthorizationpolicyValidYaml() (*asset, error) {
 	return a, nil
 }
 
-var _datasetSecurityV1beta1PeerauthenticationInvalidYaml = []byte(`apiVersion: "security.istio.io/v1beta1"
-kind: "PeerAuthentication"
+var _datasetSecurityV1beta1PeerauthenticationInvalidYaml = []byte(`apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
 metadata:
   name: invalid-peer-authentication
 spec:
@@ -960,8 +960,8 @@ func datasetSecurityV1beta1PeerauthenticationInvalidYaml() (*asset, error) {
 	return a, nil
 }
 
-var _datasetSecurityV1beta1PeerauthenticationValidYaml = []byte(`apiVersion: "security.istio.io/v1beta1"
-kind: "PeerAuthentication"
+var _datasetSecurityV1beta1PeerauthenticationValidYaml = []byte(`apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
 metadata:
   name: valid-peer-authentication
 spec:
@@ -991,8 +991,8 @@ func datasetSecurityV1beta1PeerauthenticationValidYaml() (*asset, error) {
 	return a, nil
 }
 
-var _datasetSecurityV1beta1RequestauthenticationInvalidYaml = []byte(`apiVersion: "security.istio.io/v1beta1"
-kind: "RequestAuthentication"
+var _datasetSecurityV1beta1RequestauthenticationInvalidYaml = []byte(`apiVersion: security.istio.io/v1beta1
+kind: RequestAuthentication
 metadata:
   name: invalid-request-authentication
 spec:
@@ -1019,8 +1019,8 @@ func datasetSecurityV1beta1RequestauthenticationInvalidYaml() (*asset, error) {
 	return a, nil
 }
 
-var _datasetSecurityV1beta1RequestauthenticationValidYaml = []byte(`apiVersion: "security.istio.io/v1beta1"
-kind: "RequestAuthentication"
+var _datasetSecurityV1beta1RequestauthenticationValidYaml = []byte(`apiVersion: security.istio.io/v1beta1
+kind: RequestAuthentication
 metadata:
   name: valid-request-authentication
 spec:

--- a/galley/testdatasets/validation/dataset/security-v1beta1-PeerAuthentication-invalid.yaml
+++ b/galley/testdatasets/validation/dataset/security-v1beta1-PeerAuthentication-invalid.yaml
@@ -1,5 +1,5 @@
-apiVersion: "security.istio.io/v1beta1"
-kind: "PeerAuthentication"
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
 metadata:
   name: invalid-peer-authentication
 spec:

--- a/galley/testdatasets/validation/dataset/security-v1beta1-PeerAuthentication-valid.yaml
+++ b/galley/testdatasets/validation/dataset/security-v1beta1-PeerAuthentication-valid.yaml
@@ -1,5 +1,5 @@
-apiVersion: "security.istio.io/v1beta1"
-kind: "PeerAuthentication"
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
 metadata:
   name: valid-peer-authentication
 spec:

--- a/galley/testdatasets/validation/dataset/security-v1beta1-RequestAuthentication-invalid.yaml
+++ b/galley/testdatasets/validation/dataset/security-v1beta1-RequestAuthentication-invalid.yaml
@@ -1,5 +1,5 @@
-apiVersion: "security.istio.io/v1beta1"
-kind: "RequestAuthentication"
+apiVersion: security.istio.io/v1beta1
+kind: RequestAuthentication
 metadata:
   name: invalid-request-authentication
 spec:

--- a/galley/testdatasets/validation/dataset/security-v1beta1-RequestAuthentication-valid.yaml
+++ b/galley/testdatasets/validation/dataset/security-v1beta1-RequestAuthentication-valid.yaml
@@ -1,5 +1,5 @@
-apiVersion: "security.istio.io/v1beta1"
-kind: "RequestAuthentication"
+apiVersion: security.istio.io/v1beta1
+kind: RequestAuthentication
 metadata:
   name: valid-request-authentication
 spec:

--- a/pkg/config/schema/metadata.gen.go
+++ b/pkg/config/schema/metadata.gen.go
@@ -84,7 +84,7 @@ collections:
     group: ""
 
   - name: "istio/networking/v1alpha3/destinationrules"
-    kind: "DestinationRule"
+    kind: DestinationRule
     group: "networking.istio.io"
     pilot: true
 
@@ -124,17 +124,17 @@ collections:
     pilot: true
 
   - name: "istio/security/v1beta1/authorizationpolicies"
-    kind: "AuthorizationPolicy"
+    kind: AuthorizationPolicy
     group: "security.istio.io"
     pilot: true
 
   - name: "istio/security/v1beta1/requestauthentications"
-    kind: "RequestAuthentication"
+    kind: RequestAuthentication
     group: "security.istio.io"
     pilot: true
 
   - name: "istio/security/v1beta1/peerauthentications"
-    kind: "PeerAuthentication"
+    kind: PeerAuthentication
     group: "security.istio.io"
     pilot: true
 
@@ -211,7 +211,7 @@ collections:
 
   # Istio CRD collections
   - name: "k8s/networking.istio.io/v1alpha3/destinationrules"
-    kind: "DestinationRule"
+    kind: DestinationRule
     group: "networking.istio.io"
 
   - name: "k8s/networking.istio.io/v1alpha3/envoyfilters"
@@ -243,15 +243,15 @@ collections:
     group: "networking.istio.io"
 
   - name: "k8s/security.istio.io/v1beta1/authorizationpolicies"
-    kind: "AuthorizationPolicy"
+    kind: AuthorizationPolicy
     group: "security.istio.io"
 
   - name: "k8s/security.istio.io/v1beta1/requestauthentications"
-    kind: "RequestAuthentication"
+    kind: RequestAuthentication
     group: "security.istio.io"
 
   - name: "k8s/security.istio.io/v1beta1/peerauthentications"
-    kind: "PeerAuthentication"
+    kind: PeerAuthentication
     group: "security.istio.io"
 
 # The snapshots to generate
@@ -481,7 +481,7 @@ resources:
     statusProto: "istio.meta.v1alpha1.IstioStatus"
     statusProtoPackage: "istio.io/api/meta/v1alpha1"
 
-  - kind: "DestinationRule"
+  - kind: DestinationRule
     plural: "destinationrules"
     group: "networking.istio.io"
     version: "v1alpha3"
@@ -527,7 +527,7 @@ resources:
     protoPackage: "istio.io/api/mesh/v1alpha1"
     description: "describes the networks for the Istio mesh."
 
-  - kind: "AuthorizationPolicy"
+  - kind: AuthorizationPolicy
     plural: "authorizationpolicies"
     group: "security.istio.io"
     version: "v1beta1"
@@ -537,7 +537,7 @@ resources:
     statusProto: "istio.meta.v1alpha1.IstioStatus"
     statusProtoPackage: "istio.io/api/meta/v1alpha1"
 
-  - kind: "RequestAuthentication"
+  - kind: RequestAuthentication
     plural: "requestauthentications"
     group: "security.istio.io"
     version: "v1beta1"
@@ -547,7 +547,7 @@ resources:
     statusProto: "istio.meta.v1alpha1.IstioStatus"
     statusProtoPackage: "istio.io/api/meta/v1alpha1"
 
-  - kind: "PeerAuthentication"
+  - kind: PeerAuthentication
     plural: "peerauthentications"
     group: "security.istio.io"
     version: "v1beta1"

--- a/pkg/config/schema/metadata.yaml
+++ b/pkg/config/schema/metadata.yaml
@@ -29,7 +29,7 @@ collections:
     group: ""
 
   - name: "istio/networking/v1alpha3/destinationrules"
-    kind: "DestinationRule"
+    kind: DestinationRule
     group: "networking.istio.io"
     pilot: true
 
@@ -69,17 +69,17 @@ collections:
     pilot: true
 
   - name: "istio/security/v1beta1/authorizationpolicies"
-    kind: "AuthorizationPolicy"
+    kind: AuthorizationPolicy
     group: "security.istio.io"
     pilot: true
 
   - name: "istio/security/v1beta1/requestauthentications"
-    kind: "RequestAuthentication"
+    kind: RequestAuthentication
     group: "security.istio.io"
     pilot: true
 
   - name: "istio/security/v1beta1/peerauthentications"
-    kind: "PeerAuthentication"
+    kind: PeerAuthentication
     group: "security.istio.io"
     pilot: true
 
@@ -156,7 +156,7 @@ collections:
 
   # Istio CRD collections
   - name: "k8s/networking.istio.io/v1alpha3/destinationrules"
-    kind: "DestinationRule"
+    kind: DestinationRule
     group: "networking.istio.io"
 
   - name: "k8s/networking.istio.io/v1alpha3/envoyfilters"
@@ -188,15 +188,15 @@ collections:
     group: "networking.istio.io"
 
   - name: "k8s/security.istio.io/v1beta1/authorizationpolicies"
-    kind: "AuthorizationPolicy"
+    kind: AuthorizationPolicy
     group: "security.istio.io"
 
   - name: "k8s/security.istio.io/v1beta1/requestauthentications"
-    kind: "RequestAuthentication"
+    kind: RequestAuthentication
     group: "security.istio.io"
 
   - name: "k8s/security.istio.io/v1beta1/peerauthentications"
-    kind: "PeerAuthentication"
+    kind: PeerAuthentication
     group: "security.istio.io"
 
 # The snapshots to generate
@@ -426,7 +426,7 @@ resources:
     statusProto: "istio.meta.v1alpha1.IstioStatus"
     statusProtoPackage: "istio.io/api/meta/v1alpha1"
 
-  - kind: "DestinationRule"
+  - kind: DestinationRule
     plural: "destinationrules"
     group: "networking.istio.io"
     version: "v1alpha3"
@@ -472,7 +472,7 @@ resources:
     protoPackage: "istio.io/api/mesh/v1alpha1"
     description: "describes the networks for the Istio mesh."
 
-  - kind: "AuthorizationPolicy"
+  - kind: AuthorizationPolicy
     plural: "authorizationpolicies"
     group: "security.istio.io"
     version: "v1beta1"
@@ -482,7 +482,7 @@ resources:
     statusProto: "istio.meta.v1alpha1.IstioStatus"
     statusProtoPackage: "istio.io/api/meta/v1alpha1"
 
-  - kind: "RequestAuthentication"
+  - kind: RequestAuthentication
     plural: "requestauthentications"
     group: "security.istio.io"
     version: "v1beta1"
@@ -492,7 +492,7 @@ resources:
     statusProto: "istio.meta.v1alpha1.IstioStatus"
     statusProtoPackage: "istio.io/api/meta/v1alpha1"
 
-  - kind: "PeerAuthentication"
+  - kind: PeerAuthentication
     plural: "peerauthentications"
     group: "security.istio.io"
     version: "v1beta1"

--- a/security/tools/jwt/samples/README.md
+++ b/security/tools/jwt/samples/README.md
@@ -5,8 +5,8 @@ This folder contains sample data to setup end-user authentication with Istio aut
 ## Example end-user authentication policy using the mock jwks.json data
 
 ```yaml
-apiVersion: "security.istio.io/v1beta1"
-kind: "RequestAuthentication"
+apiVersion: security.istio.io/v1beta1
+kind: RequestAuthentication
 metadata:
   name: "jwt-example"
 spec:

--- a/tests/integration/pilot/cni/testdata/global-mtls-on.yaml
+++ b/tests/integration/pilot/cni/testdata/global-mtls-on.yaml
@@ -1,13 +1,13 @@
-apiVersion: "security.istio.io/v1beta1"
-kind: "PeerAuthentication"
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
 metadata:
   name: "default"
 spec:
   mtls:
     mode: STRICT
 ---
-apiVersion: "networking.istio.io/v1alpha3"
-kind: "DestinationRule"
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
 metadata:
   name: "default"
 spec:

--- a/tests/integration/security/ca_custom_root/secure_naming_test.go
+++ b/tests/integration/security/ca_custom_root/secure_naming_test.go
@@ -41,8 +41,8 @@ const (
 	// The length of the example certificate chain.
 	exampleCertChainLength = 3
 
-	defaultIdentityDR = `apiVersion: "networking.istio.io/v1alpha3"
-kind: "DestinationRule"
+	defaultIdentityDR = `apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
 metadata:
   name: "service-b-dr"
 spec:
@@ -53,8 +53,8 @@ spec:
       subjectAltNames:
       - "spiffe://cluster.local/ns/NS/sa/default"
 `
-	correctIdentityDR = `apiVersion: "networking.istio.io/v1alpha3"
-kind: "DestinationRule"
+	correctIdentityDR = `apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
 metadata:
   name: "service-b-dr"
 spec:
@@ -65,8 +65,8 @@ spec:
       subjectAltNames:
       - "spiffe://cluster.local/ns/NS/sa/b"
 `
-	nonExistIdentityDR = `apiVersion: "networking.istio.io/v1alpha3"
-kind: "DestinationRule"
+	nonExistIdentityDR = `apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
 metadata:
   name: "service-b-dr"
 spec:
@@ -77,8 +77,8 @@ spec:
       subjectAltNames:
       - "I-do-not-exist"
 `
-	identityListDR = `apiVersion: "networking.istio.io/v1alpha3"
-kind: "DestinationRule"
+	identityListDR = `apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
 metadata:
   name: "service-b-dr"
 spec:

--- a/tests/integration/security/ca_custom_root/trust_domain_alias_secure_naming_test.go
+++ b/tests/integration/security/ca_custom_root/trust_domain_alias_secure_naming_test.go
@@ -28,16 +28,16 @@ import (
 const (
 	HTTPS  = "https"
 	POLICY = `
-apiVersion: "security.istio.io/v1beta1"
-kind: "PeerAuthentication"
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
 metadata:
   name: "mtls"
 spec:
   mtls:
     mode: STRICT
 ---
-apiVersion: "networking.istio.io/v1alpha3"
-kind: "DestinationRule"
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
 metadata:
   name: "server-naked"
 spec:

--- a/tests/integration/security/ca_custom_root/trust_domain_validation_test.go
+++ b/tests/integration/security/ca_custom_root/trust_domain_validation_test.go
@@ -44,8 +44,8 @@ const (
 	// ports with plaintext: 8090 (http) and 8092 (tcp)
 	// ports with mTLS: 8091 (http), 8093 (tcp) and 9000 (tcp passthrough).
 	policy = `
-apiVersion: "security.istio.io/v1beta1"
-kind: "PeerAuthentication"
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
 metadata:
   name: "mtls"
 spec:

--- a/tests/integration/security/mtls_first_party_jwt/testdata/global-mtls-on-no-dr.yaml
+++ b/tests/integration/security/mtls_first_party_jwt/testdata/global-mtls-on-no-dr.yaml
@@ -1,6 +1,6 @@
 # mTLS is enabled in strict mode without destination rule.
-apiVersion: "security.istio.io/v1beta1"
-kind: "PeerAuthentication"
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
 metadata:
   name: "default"
 spec:

--- a/tests/integration/security/mtls_first_party_jwt/testdata/global-plaintext.yaml
+++ b/tests/integration/security/mtls_first_party_jwt/testdata/global-plaintext.yaml
@@ -1,6 +1,6 @@
 # mTLS is disabled without destination rule.
-apiVersion: "security.istio.io/v1beta1"
-kind: "PeerAuthentication"
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
 metadata:
   name: "default"
 spec:

--- a/tests/integration/security/mtls_healthcheck_test.go
+++ b/tests/integration/security/mtls_healthcheck_test.go
@@ -54,8 +54,8 @@ func runHealthCheckDeployment(t *testing.T, ctx framework.TestContext, ns namesp
 	name string, rewrite bool) {
 	t.Helper()
 	wantSuccess := rewrite
-	policyYAML := fmt.Sprintf(`apiVersion: "security.istio.io/v1beta1"
-kind: "PeerAuthentication"
+	policyYAML := fmt.Sprintf(`apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
 metadata:
   name: "mtls-strict-for-%v"
 spec:

--- a/tests/integration/security/mtlsk8sca/testdata/global-mtls-on-no-dr.yaml
+++ b/tests/integration/security/mtlsk8sca/testdata/global-mtls-on-no-dr.yaml
@@ -1,6 +1,6 @@
 # mTLS is enabled in strict mode without destination rule.
-apiVersion: "security.istio.io/v1beta1"
-kind: "PeerAuthentication"
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
 metadata:
   name: "default"
 spec:

--- a/tests/integration/security/mtlsk8sca/testdata/global-plaintext.yaml
+++ b/tests/integration/security/mtlsk8sca/testdata/global-plaintext.yaml
@@ -1,6 +1,6 @@
 # mTLS is disabled without destination rule.
-apiVersion: "security.istio.io/v1beta1"
-kind: "PeerAuthentication"
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
 metadata:
   name: "default"
 spec:

--- a/tests/integration/security/pass_through_filter_chain_test.go
+++ b/tests/integration/security/pass_through_filter_chain_test.go
@@ -94,7 +94,7 @@ spec:
   mtls:
     mode: DISABLE
 ---
-apiVersion: "security.istio.io/v1beta1"
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: authz

--- a/tests/integration/security/testdata/authz/v1beta1-audit.yaml.tmpl
+++ b/tests/integration/security/testdata/authz/v1beta1-audit.yaml.tmpl
@@ -1,4 +1,4 @@
-apiVersion: "security.istio.io/v1beta1"
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: policy-b-audit
@@ -14,7 +14,7 @@ spec:
         paths: ["/audit"]
 ---
 
-apiVersion: "security.istio.io/v1beta1"
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: policy-b-allow
@@ -30,7 +30,7 @@ spec:
         paths: ["/allow"]
 ---
 
-apiVersion: "security.istio.io/v1beta1"
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: policy-c-audit
@@ -46,7 +46,7 @@ spec:
         paths: ["/audit"]
 ---
 
-apiVersion: "security.istio.io/v1beta1"
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: policy-c-deny
@@ -62,7 +62,7 @@ spec:
         paths: ["/deny"]
 ---
 
-apiVersion: "security.istio.io/v1beta1"
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: policy-d-audit

--- a/tests/integration/security/testdata/authz/v1beta1-conditions.yaml.tmpl
+++ b/tests/integration/security/testdata/authz/v1beta1-conditions.yaml.tmpl
@@ -12,8 +12,8 @@ spec:
   mtls:
     mode: STRICT
 ---
-apiVersion: "networking.istio.io/v1alpha3"
-kind: "DestinationRule"
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
 metadata:
   name: mtls
   namespace: "{{ .NamespaceC }}"

--- a/tests/integration/security/testdata/authz/v1beta1-custom.yaml.tmpl
+++ b/tests/integration/security/testdata/authz/v1beta1-custom.yaml.tmpl
@@ -1,6 +1,6 @@
 # The following policy applies the CUSTOM action with the ext-authz-http provider on workload b for path /custom.
 
-apiVersion: "security.istio.io/v1beta1"
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: policy-b
@@ -20,7 +20,7 @@ spec:
 
 # The following policy applies the CUSTOM action with the ext-authz-grpc provider on workload c for path /custom.
 
-apiVersion: "security.istio.io/v1beta1"
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: policy-c
@@ -40,7 +40,7 @@ spec:
 
 # The following policy applies the CUSTOM action with the ext-authz-http-local provider on workload d for path /custom.
 
-apiVersion: "security.istio.io/v1beta1"
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: policy-d
@@ -60,7 +60,7 @@ spec:
 
 # The following policy applies the CUSTOM action with the ext-authz-grpc-local provider on workload e for path /custom.
 
-apiVersion: "security.istio.io/v1beta1"
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: policy-e
@@ -80,7 +80,7 @@ spec:
 
 # The following policy applies the CUSTOM action with the ext-authz-tcp provider on workload f for port 8092.
 
-apiVersion: "security.istio.io/v1beta1"
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: policy-f-tcp
@@ -101,7 +101,7 @@ spec:
 
 # The following policy applies the CUSTOM action with the ext-authz-http provider on ingress gateway for path /custom.
 
-apiVersion: "security.istio.io/v1beta1"
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: policy-ingress-http

--- a/tests/integration/security/testdata/authz/v1beta1-deny-ns-root.yaml.tmpl
+++ b/tests/integration/security/testdata/authz/v1beta1-deny-ns-root.yaml.tmpl
@@ -1,6 +1,6 @@
 # The following policy denies access to path /global-deny for all workloads
 
-apiVersion: "security.istio.io/v1beta1"
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: policy-deny-ns-root

--- a/tests/integration/security/testdata/authz/v1beta1-deny.yaml.tmpl
+++ b/tests/integration/security/testdata/authz/v1beta1-deny.yaml.tmpl
@@ -1,6 +1,6 @@
 # The following policy denies access to path /deny to workload b
 
-apiVersion: "security.istio.io/v1beta1"
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: policy-b-deny
@@ -18,7 +18,7 @@ spec:
 
 # The following policy denies access to path /allow/admin to workload c
 
-apiVersion: "security.istio.io/v1beta1"
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: policy-c-deny
@@ -36,7 +36,7 @@ spec:
 
 # The following policy allows access to path with prefix "/allow" to workload c
 
-apiVersion: "security.istio.io/v1beta1"
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: policy-c-allow

--- a/tests/integration/security/testdata/authz/v1beta1-egress-gateway.yaml.tmpl
+++ b/tests/integration/security/testdata/authz/v1beta1-egress-gateway.yaml.tmpl
@@ -1,5 +1,5 @@
-apiVersion: "security.istio.io/v1beta1"
-kind: "RequestAuthentication"
+apiVersion: security.istio.io/v1beta1
+kind: RequestAuthentication
 metadata:
   name: "default"
   namespace: "{{ .RootNamespace }}"
@@ -148,8 +148,8 @@ spec:
           add:
             x-egress-test: "handled-by-egress-gateway"
 ---
-apiVersion: "networking.istio.io/v1alpha3"
-kind: "DestinationRule"
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
 metadata:
   name: "test-egress"
   namespace: {{ .Namespace }}

--- a/tests/integration/security/testdata/authz/v1beta1-grpc.yaml.tmpl
+++ b/tests/integration/security/testdata/authz/v1beta1-grpc.yaml.tmpl
@@ -29,7 +29,7 @@ spec:
 # * Disallow c to talk to a since GET, DELETE, and PUT are not supported in gRPC.
 # * Allow d to call any methods of a.
 
-apiVersion: "security.istio.io/v1beta1"
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: a

--- a/tests/integration/security/testdata/authz/v1beta1-jwt.yaml.tmpl
+++ b/tests/integration/security/testdata/authz/v1beta1-jwt.yaml.tmpl
@@ -2,8 +2,8 @@
 
 # The following policy enables JWT authentication on service b.
 
-apiVersion: "security.istio.io/v1beta1"
-kind: "RequestAuthentication"
+apiVersion: security.istio.io/v1beta1
+kind: RequestAuthentication
 metadata:
   name: default
   namespace: {{ .Namespace }}
@@ -21,7 +21,7 @@ spec:
 # - Allow request with any token to access path /tokenAny
 # - Allow request with permission claim of "write" to access path /permission
 
-apiVersion: "security.istio.io/v1beta1"
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: policy-b
@@ -91,7 +91,7 @@ spec:
 
 # The following policy enables JWT authentication on workload d.
 
-apiVersion: "security.istio.io/v1beta1"
+apiVersion: security.istio.io/v1beta1
 kind: RequestAuthentication
 metadata:
   name: request-authn-for-d
@@ -110,7 +110,7 @@ spec:
 # - Allow request with valid JWT token of presenter foo to access path with suffix "/presenter"
 # - Allow request with valid JWT token of audiences bar to access path with suffix "/audiences"
 
-apiVersion: "security.istio.io/v1beta1"
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: policy-d

--- a/tests/integration/security/testdata/authz/v1beta1-mtls.yaml.tmpl
+++ b/tests/integration/security/testdata/authz/v1beta1-mtls.yaml.tmpl
@@ -14,8 +14,8 @@ spec:
   mtls:
     mode: STRICT
 ---
-apiVersion: "networking.istio.io/v1alpha3"
-kind: "DestinationRule"
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
 metadata:
   name: "mtls"
   namespace: "{{ .Namespace }}"
@@ -30,7 +30,7 @@ spec:
 # - Allow workloads of service account a in the same namespace to access path /principal-a
 # - Allow workloads in namespace-2 to access path /namespace-2
 
-apiVersion: "security.istio.io/v1beta1"
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: policy-b

--- a/tests/integration/security/testdata/authz/v1beta1-negative-match.yaml.tmpl
+++ b/tests/integration/security/testdata/authz/v1beta1-negative-match.yaml.tmpl
@@ -1,6 +1,6 @@
 # The following policy denies access to path with prefix "/prefix" except "/prefix/allowlist" to workload b
 
-apiVersion: "security.istio.io/v1beta1"
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: policy-b-deny
@@ -19,7 +19,7 @@ spec:
 
 # The following policy denies access from other namespaces
 
-apiVersion: "security.istio.io/v1beta1"
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: policy-c-same-namespace
@@ -38,7 +38,7 @@ spec:
 # The following policy denies access to workload d if it's not mTLS, in other words,
 # it allows only mTLS traffic to access workload d
 
-apiVersion: "security.istio.io/v1beta1"
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: policy-d-mtls-traffic
@@ -68,8 +68,8 @@ spec:
 
 # The following destination rule enables mTLS in the namespace
 
-apiVersion: "networking.istio.io/v1alpha3"
-kind: "DestinationRule"
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
 metadata:
   name: "mtls"
   namespace: "{{ .Namespace }}"
@@ -83,8 +83,8 @@ spec:
 
 # The following destination rule enables mTLS from namespace 2 to workload b
 
-apiVersion: "networking.istio.io/v1alpha3"
-kind: "DestinationRule"
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
 metadata:
   name: "dr-b"
   namespace: "{{ .Namespace2 }}"
@@ -98,8 +98,8 @@ spec:
 
 # The following destination rule enables mTLS from namespace 2 to workload c
 
-apiVersion: "networking.istio.io/v1alpha3"
-kind: "DestinationRule"
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
 metadata:
   name: "dr-c"
   namespace: "{{ .Namespace2 }}"
@@ -113,8 +113,8 @@ spec:
 
 # The following destination rule disables mTLS from namespace 2 to workload d
 
-apiVersion: "networking.istio.io/v1alpha3"
-kind: "DestinationRule"
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
 metadata:
   name: "dr-d"
   namespace: "{{ .Namespace2 }}"

--- a/tests/integration/security/testdata/authz/v1beta1-path.yaml.tmpl
+++ b/tests/integration/security/testdata/authz/v1beta1-path.yaml.tmpl
@@ -2,7 +2,7 @@
 # * Allow GET requests at path with prefix "/public".
 # * Deny any other requests by default.
 
-apiVersion: "security.istio.io/v1beta1"
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: policy-a

--- a/tests/integration/security/testdata/authz/v1beta1-tcp.yaml.tmpl
+++ b/tests/integration/security/testdata/authz/v1beta1-tcp.yaml.tmpl
@@ -1,6 +1,6 @@
 # The following policy denies request with path "/data" to port 8090 for workload b
 
-apiVersion: "security.istio.io/v1beta1"
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: policy-b-deny
@@ -22,7 +22,7 @@ spec:
 # request to port 8093 with principal suffix matching
 # request to port 8092 with namespace suffix matching
 
-apiVersion: "security.istio.io/v1beta1"
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: policy-c-deny
@@ -52,7 +52,7 @@ spec:
 
 # The following policy denies request from service account a and namespace 2 for workload d
 
-apiVersion: "security.istio.io/v1beta1"
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: policy-d-deny
@@ -72,7 +72,7 @@ spec:
 
 # The following policy denies request with path "/other" for workload e
 
-apiVersion: "security.istio.io/v1beta1"
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: policy-e-deny

--- a/tests/integration/security/testdata/authz/v1beta1-workload-ns-root.yaml.tmpl
+++ b/tests/integration/security/testdata/authz/v1beta1-workload-ns-root.yaml.tmpl
@@ -1,6 +1,6 @@
 # The following policy selects workloads c in all namespaces
 
-apiVersion: "security.istio.io/v1beta1"
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: policy-ns-root-c

--- a/tests/integration/security/testdata/authz/v1beta1-workload-ns1.yaml.tmpl
+++ b/tests/integration/security/testdata/authz/v1beta1-workload-ns1.yaml.tmpl
@@ -1,6 +1,6 @@
 # The following policy selects workload b in namespace 1
 
-apiVersion: "security.istio.io/v1beta1"
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: policy-ns1-b
@@ -17,7 +17,7 @@ spec:
 
 # The following policy selects workload c in namespace 1
 
-apiVersion: "security.istio.io/v1beta1"
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: policy-ns1-c
@@ -34,7 +34,7 @@ spec:
 
 # The following policy selects a non-exist workload in namespace 1
 
-apiVersion: "security.istio.io/v1beta1"
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: policy-ns1-x
@@ -52,7 +52,7 @@ spec:
 
 # The following policy selects all workloads in namespace 1
 
-apiVersion: "security.istio.io/v1beta1"
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: policy-ns1-all

--- a/tests/integration/security/testdata/authz/v1beta1-workload-ns2.yaml.tmpl
+++ b/tests/integration/security/testdata/authz/v1beta1-workload-ns2.yaml.tmpl
@@ -1,6 +1,6 @@
 # The following policy selects workload c in namespace 2
 
-apiVersion: "security.istio.io/v1beta1"
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: policy-ns2-c
@@ -17,7 +17,7 @@ spec:
 
 # The following policy selects all workloads in namespace 2
 
-apiVersion: "security.istio.io/v1beta1"
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: policy-ns2-all

--- a/tests/integration/security/testdata/automtls-partial-sidecar-dr-disable.yaml
+++ b/tests/integration/security/testdata/automtls-partial-sidecar-dr-disable.yaml
@@ -1,5 +1,5 @@
-apiVersion: "security.istio.io/v1beta1"
-kind: "PeerAuthentication"
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
 metadata:
   name: "default"
   annotations:

--- a/tests/integration/security/testdata/automtls-partial-sidecar-dr-mutual.yaml
+++ b/tests/integration/security/testdata/automtls-partial-sidecar-dr-mutual.yaml
@@ -1,5 +1,5 @@
-apiVersion: "security.istio.io/v1beta1"
-kind: "PeerAuthentication"
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
 metadata:
   name: "default"
   annotations:

--- a/tests/integration/security/testdata/automtls-partial-sidecar-dr-no-tls.yaml
+++ b/tests/integration/security/testdata/automtls-partial-sidecar-dr-no-tls.yaml
@@ -1,5 +1,5 @@
-apiVersion: "security.istio.io/v1beta1"
-kind: "PeerAuthentication"
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
 metadata:
   name: "default"
   annotations:

--- a/tests/integration/security/testdata/beta-mtls-automtls.yaml
+++ b/tests/integration/security/testdata/beta-mtls-automtls.yaml
@@ -1,6 +1,6 @@
 # No DR is added for this test. enableAutoMtls is expected on by default.
-apiVersion: "security.istio.io/v1beta1"
-kind: "PeerAuthentication"
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
 metadata:
   name: "default"
   annotations:

--- a/tests/integration/security/testdata/beta-mtls-off.yaml
+++ b/tests/integration/security/testdata/beta-mtls-off.yaml
@@ -1,5 +1,5 @@
-apiVersion: "security.istio.io/v1beta1"
-kind: "PeerAuthentication"
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
 metadata:
   name: "default"
   annotations:
@@ -8,8 +8,8 @@ spec:
   mtls:
     mode: DISABLE
 ---
-apiVersion: "networking.istio.io/v1alpha3"
-kind: "DestinationRule"
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
 metadata:
   name: "default"
   annotations:

--- a/tests/integration/security/testdata/beta-mtls-on.yaml
+++ b/tests/integration/security/testdata/beta-mtls-on.yaml
@@ -1,5 +1,5 @@
-apiVersion: "security.istio.io/v1beta1"
-kind: "PeerAuthentication"
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
 metadata:
   name: "default"
   annotations:
@@ -8,8 +8,8 @@ spec:
   mtls:
     mode: STRICT
 ---
-apiVersion: "networking.istio.io/v1alpha3"
-kind: "DestinationRule"
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
 metadata:
   name: "default"
   annotations:

--- a/tests/integration/security/testdata/beta-mtls-partial-automtls.yaml
+++ b/tests/integration/security/testdata/beta-mtls-partial-automtls.yaml
@@ -1,7 +1,7 @@
 # No DR is added for this test. enableAutoMtls is expected on by default.
 # Workload-level PeerAuthentication will expectedly cause trouble to connect to the corresponding service
-apiVersion: "security.istio.io/v1beta1"
-kind: "PeerAuthentication"
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
 metadata:
   name: "default"
   annotations:
@@ -10,8 +10,8 @@ spec:
   mtls:
     mode: STRICT
 ---
-apiVersion: "security.istio.io/v1beta1"
-kind: "PeerAuthentication"
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
 metadata:
   name: "per-port"
   annotations:

--- a/tests/integration/security/testdata/beta-mtls-permissive.yaml
+++ b/tests/integration/security/testdata/beta-mtls-permissive.yaml
@@ -1,7 +1,7 @@
 # Global PeerAuthentication can be removed for this test, once we remove the (alpha) mesh policy
 # during installation.
-apiVersion: "security.istio.io/v1beta1"
-kind: "PeerAuthentication"
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
 metadata:
   name: "default"
   annotations:
@@ -10,8 +10,8 @@ spec:
   mtls:
     mode: PERMISSIVE
 ---
-apiVersion: "networking.istio.io/v1alpha3"
-kind: "DestinationRule"
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
 metadata:
   name: "default"
   annotations:

--- a/tests/integration/security/testdata/beta-per-port-mtls.yaml
+++ b/tests/integration/security/testdata/beta-per-port-mtls.yaml
@@ -1,5 +1,5 @@
-apiVersion: "security.istio.io/v1beta1"
-kind: "PeerAuthentication"
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
 metadata:
   name: "per-port"
   annotations:
@@ -15,8 +15,8 @@ spec:
     8090:
       mode: STRICT
 ---
-apiVersion: "networking.istio.io/v1alpha3"
-kind: "DestinationRule"
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
 metadata:
   name: "default"
   annotations:

--- a/tests/integration/security/testdata/global-plaintext.yaml
+++ b/tests/integration/security/testdata/global-plaintext.yaml
@@ -1,6 +1,6 @@
 # mTLS is disabled without destination rule.
-apiVersion: "security.istio.io/v1beta1"
-kind: "PeerAuthentication"
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
 metadata:
   name: "default"
   annotations:

--- a/tests/integration/security/testdata/no-peer-authn.yaml
+++ b/tests/integration/security/testdata/no-peer-authn.yaml
@@ -1,5 +1,5 @@
-apiVersion: "networking.istio.io/v1alpha3"
-kind: "DestinationRule"
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
 metadata:
   name: "default"
   annotations:


### PR DESCRIPTION
This is never used in Kubernetes docs. This is bikeshedding, but IMO its
good to have things standardized. I see this same quoting all over the
place because users just copy+paste - we should set a good example.

I will update istio/api as well



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.