### PR TITLE
envoy: simplify bootstrap generation

### DIFF
--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -413,6 +413,18 @@ func (s *NodeMetaProxyConfig) UnmarshalJSON(data []byte) error {
 	return gogojsonpb.Unmarshal(bytes.NewReader(data), pc)
 }
 
+// Node is a typed version of Envoy node with metadata.
+type Node struct {
+	// ID of the Envoy node
+	ID string
+	// Metadata is the typed node metadata
+	Metadata *BootstrapNodeMetadata
+	// RawMetadata is the untyped node metadata
+	RawMetadata map[string]interface{}
+	// Locality from Envoy bootstrap
+	Locality *core.Locality
+}
+
 // BootstrapNodeMetadata is a superset of NodeMetadata, intended to model the entirety of the node metadata
 // we configure in the Envoy bootstrap. This is split out from NodeMetadata to explicitly segment the parameters
 // that are consumed by Pilot from the parameters used only as part of the bootstrap. Fields used by bootstrap only

--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -471,11 +471,9 @@ func GetNodeMetaData(id string, envs []string, plat platform.Environment, nodeIP
 	}
 
 	var l *core.Locality
-	if meta.Labels[model.LocalityLabel] == "" {
+	if meta.Labels[model.LocalityLabel] == "" && plat != nil {
 		// The locality string was not set, try to get locality from platform
-		if plat != nil {
-			l = plat.Locality()
-		}
+		l = plat.Locality()
 	} else {
 		localityString := model.GetLocalityLabelOrDefault(meta.Labels[model.LocalityLabel], "")
 		l = util.ConvertLocality(localityString)

--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -58,13 +58,8 @@ const (
 
 // Config for creating a bootstrap file.
 type Config struct {
-	Node                string
-	Proxy               *meshAPI.ProxyConfig
-	PlatEnv             platform.Environment
+	*model.Node
 	PilotSubjectAltName []string
-	LocalEnv            []string
-	NodeIPs             []string
-	STSPort             int
 	ProxyViaAgent       bool
 	OutlierLogPath      string
 	PilotCertProvider   string
@@ -76,16 +71,8 @@ type Config struct {
 func (cfg Config) toTemplateParams() (map[string]interface{}, error) {
 	opts := make([]option.Instance, 0)
 
-	// Fill in default config values.
-	if cfg.PlatEnv == nil {
-		cfg.PlatEnv = platform.Discover()
-	}
-
-	// Remove duplicates from the node IPs.
-	cfg.NodeIPs = removeDuplicates(cfg.NodeIPs)
-
 	opts = append(opts,
-		option.NodeID(cfg.Node),
+		option.NodeID(cfg.ID),
 		option.PilotSubjectAltName(cfg.PilotSubjectAltName),
 		option.ProxyViaAgent(cfg.ProxyViaAgent),
 		option.PilotCertProvider(cfg.PilotCertProvider),
@@ -93,25 +80,24 @@ func (cfg Config) toTemplateParams() (map[string]interface{}, error) {
 		option.ProvCert(cfg.ProvCert),
 		option.DiscoveryHost(cfg.DiscoveryHost))
 
-	if cfg.STSPort > 0 {
-		opts = append(opts,
-			option.STSEnabled(true),
-			option.STSPort(cfg.STSPort))
-		md := cfg.PlatEnv.Metadata()
-		if projectID, found := md[platform.GCPProject]; found {
-			opts = append(opts, option.GCPProjectID(projectID))
+	if cfg.Metadata.StsPort != "" {
+		stsPort, err := strconv.Atoi(cfg.Metadata.StsPort)
+		if err == nil && stsPort > 0 {
+			opts = append(opts,
+				option.STSEnabled(true),
+				option.STSPort(stsPort))
+			md := cfg.Metadata.PlatformMetadata
+			if projectID, found := md[platform.GCPProject]; found {
+				opts = append(opts, option.GCPProjectID(projectID))
+			}
 		}
 	}
 
 	// Support passing extra info from node environment as metadata
-	meta, rawMeta, err := getNodeMetaData(cfg.LocalEnv, cfg.PlatEnv, cfg.NodeIPs, cfg.STSPort, cfg.Proxy)
-	if err != nil {
-		return nil, err
-	}
-	opts = append(opts, getNodeMetadataOptions(meta, rawMeta, cfg.PlatEnv, cfg.Proxy)...)
+	opts = append(opts, getNodeMetadataOptions(cfg.Node)...)
 
 	// Check if nodeIP carries IPv4 or IPv6 and set up proxy accordingly
-	if isIPv6Proxy(cfg.NodeIPs) {
+	if isIPv6Proxy(cfg.Metadata.InstanceIPs) {
 		opts = append(opts,
 			option.Localhost(option.LocalhostIPv6),
 			option.Wildcard(option.WildcardIPv6),
@@ -123,7 +109,7 @@ func (cfg Config) toTemplateParams() (map[string]interface{}, error) {
 			option.DNSLookupFamily(option.DNSLookupFamilyIPv4))
 	}
 
-	proxyOpts, err := getProxyConfigOptions(cfg.Proxy, meta)
+	proxyOpts, err := getProxyConfigOptions(cfg.Metadata)
 	if err != nil {
 		return nil, err
 	}
@@ -187,7 +173,9 @@ var DefaultStatTags = []string{
 	"destination_canonical_revision",
 }
 
-func getStatsOptions(meta *model.BootstrapNodeMetadata, nodeIPs []string, config *meshAPI.ProxyConfig) []option.Instance {
+func getStatsOptions(meta *model.BootstrapNodeMetadata) []option.Instance {
+	nodeIPs := meta.InstanceIPs
+	config := meta.ProxyConfig
 	parseOption := func(metaOption string, required string, proxyConfigOption []string) []string {
 		var inclusionOption []string
 		if len(metaOption) > 0 {
@@ -244,31 +232,23 @@ func lightstepAccessTokenFile(config string) string {
 	return path.Join(config, lightstepAccessTokenBase)
 }
 
-func getNodeMetadataOptions(meta *model.BootstrapNodeMetadata, rawMeta map[string]interface{},
-	platEnv platform.Environment, config *meshAPI.ProxyConfig) []option.Instance {
+func getNodeMetadataOptions(node *model.Node) []option.Instance {
 	// Add locality options.
-	opts := getLocalityOptions(meta, platEnv)
+	opts := getLocalityOptions(node.Locality)
 
-	opts = append(opts, getStatsOptions(meta, meta.InstanceIPs, config)...)
+	opts = append(opts, getStatsOptions(node.Metadata)...)
 
-	opts = append(opts, option.NodeMetadata(meta, rawMeta))
+	opts = append(opts, option.NodeMetadata(node.Metadata, node.RawMetadata))
 	return opts
 }
 
-func getLocalityOptions(meta *model.BootstrapNodeMetadata, platEnv platform.Environment) []option.Instance {
-	var l *core.Locality
-	if meta.Labels[model.LocalityLabel] == "" {
-		l = platEnv.Locality()
-		// The locality string was not set, try to get locality from platform
-	} else {
-		localityString := model.GetLocalityLabelOrDefault(meta.Labels[model.LocalityLabel], "")
-		l = util.ConvertLocality(localityString)
-	}
-
+func getLocalityOptions(l *core.Locality) []option.Instance {
 	return []option.Instance{option.Region(l.Region), option.Zone(l.Zone), option.SubZone(l.SubZone)}
 }
 
-func getProxyConfigOptions(config *meshAPI.ProxyConfig, metadata *model.BootstrapNodeMetadata) ([]option.Instance, error) {
+func getProxyConfigOptions(metadata *model.BootstrapNodeMetadata) ([]option.Instance, error) {
+	config := metadata.ProxyConfig
+
 	// Add a few misc options.
 	opts := make([]option.Instance, 0)
 
@@ -429,12 +409,12 @@ func extractAttributesMetadata(envVars []string, plat platform.Environment, meta
 	}
 }
 
-// getNodeMetaData function uses an environment variable contract
+// GetNodeMetaData function uses an environment variable contract
 // ISTIO_METAJSON_* env variables contain json_string in the value.
 // 					The name of variable is ignored.
 // ISTIO_META_* env variables are passed thru
-func getNodeMetaData(envs []string, plat platform.Environment, nodeIPs []string, stsPort int,
-	pc *meshAPI.ProxyConfig) (*model.BootstrapNodeMetadata, map[string]interface{}, error) {
+func GetNodeMetaData(id string, envs []string, plat platform.Environment, nodeIPs []string, stsPort int,
+	pc *meshAPI.ProxyConfig) (*model.Node, error) {
 	meta := &model.BootstrapNodeMetadata{}
 	untypedMeta := map[string]interface{}{}
 
@@ -451,16 +431,16 @@ func getNodeMetaData(envs []string, plat platform.Environment, nodeIPs []string,
 
 	j, err := json.Marshal(untypedMeta)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	if err := json.Unmarshal(j, meta); err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	extractAttributesMetadata(envs, plat, meta)
 
 	// Support multiple network interfaces, removing duplicates.
-	meta.InstanceIPs = nodeIPs
+	meta.InstanceIPs = removeDuplicates(nodeIPs)
 
 	// Add STS port into node metadata if it is not 0. This is read by envoy telemetry filters
 	if stsPort != 0 {
@@ -490,7 +470,23 @@ func getNodeMetaData(envs []string, plat platform.Environment, nodeIPs []string,
 		}
 	}
 
-	return meta, untypedMeta, nil
+	var l *core.Locality
+	if meta.Labels[model.LocalityLabel] == "" {
+		// The locality string was not set, try to get locality from platform
+		if plat != nil {
+			l = plat.Locality()
+		}
+	} else {
+		localityString := model.GetLocalityLabelOrDefault(meta.Labels[model.LocalityLabel], "")
+		l = util.ConvertLocality(localityString)
+	}
+
+	return &model.Node{
+		ID:          id,
+		Metadata:    meta,
+		RawMetadata: untypedMeta,
+		Locality:    l,
+	}, nil
 }
 
 // Extracts instance labels for the platform into model.NodeMetadata.Labels

--- a/pkg/bootstrap/config_test.go
+++ b/pkg/bootstrap/config_test.go
@@ -84,12 +84,12 @@ func TestGetNodeMetaData(t *testing.T) {
 	os.Setenv(IstioMetaPrefix+"OWNER", inputOwner)
 	os.Setenv(IstioMetaPrefix+"WORKLOAD_NAME", inputWorkloadName)
 
-	meta, rawMeta, err := getNodeMetaData(os.Environ(), nil, nil, 0, nil)
+	node, err := GetNodeMetaData("test", os.Environ(), nil, nil, 0, nil)
 
 	g := NewWithT(t)
 	g.Expect(err).Should(BeNil())
-	g.Expect(meta.Owner).To(Equal(expectOwner))
-	g.Expect(meta.WorkloadName).To(Equal(expectWorkloadName))
-	g.Expect(rawMeta["OWNER"]).To(Equal(expectOwner))
-	g.Expect(rawMeta["WORKLOAD_NAME"]).To(Equal(expectWorkloadName))
+	g.Expect(node.Metadata.Owner).To(Equal(expectOwner))
+	g.Expect(node.Metadata.WorkloadName).To(Equal(expectWorkloadName))
+	g.Expect(node.RawMetadata["OWNER"]).To(Equal(expectOwner))
+	g.Expect(node.RawMetadata["WORKLOAD_NAME"]).To(Equal(expectWorkloadName))
 }

--- a/pkg/bootstrap/instance.go
+++ b/pkg/bootstrap/instance.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"text/template"
 
-	meshAPI "istio.io/api/mesh/v1alpha1"
+	"istio.io/istio/pilot/pkg/model"
 	"istio.io/pkg/env"
 	"istio.io/pkg/log"
 )
@@ -90,7 +90,7 @@ func toJSON(i interface{}) string {
 }
 
 // getEffectiveTemplatePath gets the template file that should be used for bootstrap
-func getEffectiveTemplatePath(pc *meshAPI.ProxyConfig) string {
+func getEffectiveTemplatePath(pc *model.NodeMetaProxyConfig) string {
 	var templateFilePath string
 	switch {
 	case pc.CustomConfigFile != "":
@@ -109,13 +109,13 @@ func getEffectiveTemplatePath(pc *meshAPI.ProxyConfig) string {
 
 func (i *instance) CreateFileForEpoch(epoch int) (string, error) {
 	// Create the output file.
-	if err := os.MkdirAll(i.Proxy.ConfigPath, 0700); err != nil {
+	if err := os.MkdirAll(i.Metadata.ProxyConfig.ConfigPath, 0700); err != nil {
 		return "", err
 	}
 
-	templateFile := getEffectiveTemplatePath(i.Proxy)
+	templateFile := getEffectiveTemplatePath(i.Metadata.ProxyConfig)
 
-	outputFilePath := configFile(i.Proxy.ConfigPath, templateFile, epoch)
+	outputFilePath := configFile(i.Metadata.ProxyConfig.ConfigPath, templateFile, epoch)
 	outputFile, err := os.Create(outputFilePath)
 	if err != nil {
 		return "", err

--- a/pkg/bootstrap/option/instances.go
+++ b/pkg/bootstrap/option/instances.go
@@ -37,7 +37,7 @@ const (
 	DNSLookupFamilyIPv6 DNSLookupFamilyValue = "AUTO"
 )
 
-func ProxyConfig(value *meshAPI.ProxyConfig) Instance {
+func ProxyConfig(value *model.NodeMetaProxyConfig) Instance {
 	return newOption("config", value)
 }
 

--- a/pkg/bootstrap/option/instances_test.go
+++ b/pkg/bootstrap/option/instances_test.go
@@ -39,8 +39,8 @@ func TestOptions(t *testing.T) {
 		{
 			testName: "proxy config",
 			key:      "config",
-			option:   option.ProxyConfig(&meshAPI.ProxyConfig{DiscoveryAddress: "fake"}),
-			expected: &meshAPI.ProxyConfig{DiscoveryAddress: "fake"},
+			option:   option.ProxyConfig(&model.NodeMetaProxyConfig{DiscoveryAddress: "fake"}),
+			expected: &model.NodeMetaProxyConfig{DiscoveryAddress: "fake"},
 		},
 		{
 			testName: "pilotSAN",


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

Simple refactor to converge on bootstrap generation that is driven by node structure.
This allows portable bootstrap generator that can be run outside the pod.