### PR TITLE
Make sds_tls_origination suite work under multiversion tests

### DIFF
--- a/tests/integration/security/sds_tls_origination/egress_gateway_origination_test.go
+++ b/tests/integration/security/sds_tls_origination/egress_gateway_origination_test.go
@@ -17,7 +17,6 @@ package sdstlsorigination
 
 import (
 	"fmt"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -37,7 +36,7 @@ import (
 func TestSimpleTlsOrigination(t *testing.T) {
 	framework.NewTest(t).
 		Features("security.egress.tls.sds").
-		Run(func(ctx framework.TestContext) {
+		Run(func(t framework.TestContext) {
 			var (
 				credName        = "tls-credential-cacert"
 				fakeCredName    = "fake-tls-credential-cacert"
@@ -51,34 +50,34 @@ func TestSimpleTlsOrigination(t *testing.T) {
 				CaCert: sdstlsutil.FakeRoot,
 			}
 			// Add kubernetes secret to provision key/cert for gateway.
-			sdstlsutil.CreateKubeSecret(ctx, []string{credName}, "SIMPLE", credentialA, false)
-			defer ingressutil.DeleteKubeSecret(ctx, []string{credName})
+			sdstlsutil.CreateKubeSecret(t, []string{credName}, "SIMPLE", credentialA, false)
+			defer ingressutil.DeleteKubeSecret(t, []string{credName})
 
 			// Add kubernetes secret to provision key/cert for gateway.
-			sdstlsutil.CreateKubeSecret(ctx, []string{fakeCredName}, "SIMPLE", CredentialB, false)
-			defer ingressutil.DeleteKubeSecret(ctx, []string{fakeCredName})
+			sdstlsutil.CreateKubeSecret(t, []string{fakeCredName}, "SIMPLE", CredentialB, false)
+			defer ingressutil.DeleteKubeSecret(t, []string{fakeCredName})
 
-			internalClient, externalServer, _, serverNamespace := sdstlsutil.SetupEcho(t, ctx)
+			internalClient, externalServer, _, serverNamespace := sdstlsutil.SetupEcho(t, t)
 
 			// Set up Host Namespace
 			host := "server." + serverNamespace.Name() + ".svc.cluster.local"
 
 			testCases := map[string]struct {
-				response        []string
+				response        string
 				credentialToUse string
 				gateway         bool // true if the request is expected to be routed through gateway
 			}{
 				// Use CA certificate stored as k8s secret with the same issuing CA as server's CA.
 				// This root certificate can validate the server cert presented by the echoboot server instance.
 				"Simple TLS with Correct Root Cert": {
-					response:        []string{response.StatusCodeOK},
+					response:        response.StatusCodeOK,
 					credentialToUse: strings.TrimSuffix(credName, "-cacert"),
 					gateway:         true,
 				},
 				// Use CA certificate stored as k8s secret with different issuing CA as server's CA.
 				// This root certificate cannot validate the server cert presented by the echoboot server instance.
 				"Simple TLS with Fake Root Cert": {
-					response:        []string{response.StatusCodeUnavailable},
+					response:        response.StatusCodeUnavailable,
 					credentialToUse: strings.TrimSuffix(fakeCredName, "-cacert"),
 					gateway:         false,
 				},
@@ -86,23 +85,23 @@ func TestSimpleTlsOrigination(t *testing.T) {
 				// Set up an UpstreamCluster with a CredentialName when secret doesn't even exist in istio-system ns.
 				// Secret fetching error at Gateway, results in a 503 response.
 				"Simple TLS with credentialName set when the underlying secret doesn't exist": {
-					response:        []string{response.StatusCodeUnavailable},
+					response:        response.StatusCodeUnavailable,
 					credentialToUse: strings.TrimSuffix(credNameMissing, "-cacert"),
 					gateway:         false,
 				},
 			}
 
 			for name, tc := range testCases {
-				ctx.NewSubTest(name).Run(func(ctx framework.TestContext) {
-					bufDestinationRule := sdstlsutil.CreateDestinationRule(ctx, serverNamespace, "SIMPLE", tc.credentialToUse)
+				t.NewSubTest(name).Run(func(t framework.TestContext) {
+					bufDestinationRule := sdstlsutil.CreateDestinationRule(t, serverNamespace, "SIMPLE", tc.credentialToUse)
 
 					// Get namespace for gateway pod.
-					istioCfg := istio.DefaultConfigOrFail(ctx, ctx)
-					systemNS := namespace.ClaimOrFail(ctx, ctx, istioCfg.SystemNamespace)
+					istioCfg := istio.DefaultConfigOrFail(t, t)
+					systemNS := namespace.ClaimOrFail(t, t, istioCfg.SystemNamespace)
 
-					ctx.Config(ctx.Clusters().Default()).ApplyYAMLOrFail(ctx, systemNS.Name(), bufDestinationRule.String())
+					t.Config(t.Clusters().Default()).ApplyYAMLOrFail(t, systemNS.Name(), bufDestinationRule.String())
 
-					retry.UntilSuccessOrFail(ctx, func() error {
+					retry.UntilSuccessOrFail(t, func() error {
 						resp, err := internalClient.Call(echo.CallOptions{
 							Target:   externalServer,
 							PortName: "http",
@@ -113,12 +112,10 @@ func TestSimpleTlsOrigination(t *testing.T) {
 						if err != nil {
 							return fmt.Errorf("request failed: %v", err)
 						}
-						codes := make([]string, 0, len(resp))
 						for _, r := range resp {
-							codes = append(codes, r.Code)
-						}
-						if !reflect.DeepEqual(codes, tc.response) {
-							return fmt.Errorf("got codes %q, expected %q", codes, tc.response)
+							if r.Code != tc.response {
+								return fmt.Errorf("got code %s, expected %s", r.Code, tc.response)
+							}
 						}
 						for _, r := range resp {
 							if _, f := r.RawResponse["Handled-By-Egress-Gateway"]; tc.gateway && !f {
@@ -137,7 +134,7 @@ func TestSimpleTlsOrigination(t *testing.T) {
 func TestMutualTlsOrigination(t *testing.T) {
 	framework.NewTest(t).
 		Features("security.egress.mtls.sds").
-		Run(func(ctx framework.TestContext) {
+		Run(func(t framework.TestContext) {
 			var (
 				credNameGeneric    = "mtls-credential-generic"
 				credNameNotGeneric = "mtls-credential-not-generic"
@@ -175,28 +172,28 @@ func TestMutualTlsOrigination(t *testing.T) {
 				CaCert:     sdstlsutil.MustReadCert(t, "root-cert.pem"),
 			}
 			// Add kubernetes secret to provision key/cert for gateway.
-			sdstlsutil.CreateKubeSecret(ctx, []string{credNameGeneric}, "MUTUAL", credentialAGeneric, false)
-			defer ingressutil.DeleteKubeSecret(ctx, []string{credNameGeneric})
+			sdstlsutil.CreateKubeSecret(t, []string{credNameGeneric}, "MUTUAL", credentialAGeneric, false)
+			defer ingressutil.DeleteKubeSecret(t, []string{credNameGeneric})
 
-			sdstlsutil.CreateKubeSecret(ctx, []string{credNameNotGeneric}, "MUTUAL", credentialANonGeneric, true)
-			defer ingressutil.DeleteKubeSecret(ctx, []string{credNameNotGeneric})
+			sdstlsutil.CreateKubeSecret(t, []string{credNameNotGeneric}, "MUTUAL", credentialANonGeneric, true)
+			defer ingressutil.DeleteKubeSecret(t, []string{credNameNotGeneric})
 
-			sdstlsutil.CreateKubeSecret(ctx, []string{fakeCredNameA}, "MUTUAL", credentialBCert, false)
-			defer ingressutil.DeleteKubeSecret(ctx, []string{fakeCredNameA})
+			sdstlsutil.CreateKubeSecret(t, []string{fakeCredNameA}, "MUTUAL", credentialBCert, false)
+			defer ingressutil.DeleteKubeSecret(t, []string{fakeCredNameA})
 
-			sdstlsutil.CreateKubeSecret(ctx, []string{fakeCredNameB}, "MUTUAL", credentialBCertAndKey, false)
-			defer ingressutil.DeleteKubeSecret(ctx, []string{fakeCredNameB})
+			sdstlsutil.CreateKubeSecret(t, []string{fakeCredNameB}, "MUTUAL", credentialBCertAndKey, false)
+			defer ingressutil.DeleteKubeSecret(t, []string{fakeCredNameB})
 
-			sdstlsutil.CreateKubeSecret(ctx, []string{simpleCredName}, "SIMPLE", credentialASimple, false)
-			defer ingressutil.DeleteKubeSecret(ctx, []string{simpleCredName})
+			sdstlsutil.CreateKubeSecret(t, []string{simpleCredName}, "SIMPLE", credentialASimple, false)
+			defer ingressutil.DeleteKubeSecret(t, []string{simpleCredName})
 
-			internalClient, externalServer, _, serverNamespace := sdstlsutil.SetupEcho(t, ctx)
+			internalClient, externalServer, _, serverNamespace := sdstlsutil.SetupEcho(t, t)
 
 			// Set up Host Namespace
 			host := "server." + serverNamespace.Name() + ".svc.cluster.local"
 
 			testCases := map[string]struct {
-				response        []string
+				response        string
 				credentialToUse string
 				gateway         bool // true if the request is expected to be routed through gateway
 			}{
@@ -204,7 +201,7 @@ func TestMutualTlsOrigination(t *testing.T) {
 				// This root certificate can validate the server cert presented by the echoboot server instance and server CA can
 				// validate the client cert. Secret is of type generic.
 				"MUTUAL TLS with correct root cert and client certs and generic secret type": {
-					response:        []string{response.StatusCodeOK},
+					response:        response.StatusCodeOK,
 					credentialToUse: strings.TrimSuffix(credNameGeneric, "-cacert"),
 					gateway:         true,
 				},
@@ -212,7 +209,7 @@ func TestMutualTlsOrigination(t *testing.T) {
 				// This root certificate can validate the server cert presented by the echoboot server instance and server CA can
 				// validate the client cert. Secret is not of type generic.
 				"MUTUAL TLS with correct root cert and client certs and non generic secret type": {
-					response:        []string{response.StatusCodeOK},
+					response:        response.StatusCodeOK,
 					credentialToUse: strings.TrimSuffix(credNameNotGeneric, "-cacert"),
 					gateway:         true,
 				},
@@ -220,7 +217,7 @@ func TestMutualTlsOrigination(t *testing.T) {
 				// This root certificate can validate the server cert presented by the echoboot server instance and server CA
 				// cannot validate the client cert. Returns 503 response as TLS handshake fails.
 				"MUTUAL TLS with correct root cert but invalid client cert": {
-					response:        []string{response.StatusCodeUnavailable},
+					response:        response.StatusCodeUnavailable,
 					credentialToUse: strings.TrimSuffix(fakeCredNameA, "-cacert"),
 					gateway:         false,
 				},
@@ -228,27 +225,27 @@ func TestMutualTlsOrigination(t *testing.T) {
 				// Set up an UpstreamCluster with a CredentialName when secret doesn't even exist in istio-system ns.
 				// Secret fetching error at Gateway, results in a 503 response.
 				"MUTUAL TLS with credentialName set when the underlying secret doesn't exist": {
-					response:        []string{response.StatusCodeUnavailable},
+					response:        response.StatusCodeUnavailable,
 					credentialToUse: strings.TrimSuffix(credNameMissing, "-cacert"),
 					gateway:         false,
 				},
 				"MUTUAL TLS with correct root cert but no client certs": {
-					response:        []string{response.StatusCodeUnavailable},
+					response:        response.StatusCodeUnavailable,
 					credentialToUse: strings.TrimSuffix(simpleCredName, "-cacert"),
 					gateway:         false,
 				},
 			}
 
 			for name, tc := range testCases {
-				ctx.NewSubTest(name).
-					Run(func(ctx framework.TestContext) {
+				t.NewSubTest(name).
+					Run(func(t framework.TestContext) {
 						bufDestinationRule := sdstlsutil.CreateDestinationRule(t, serverNamespace, "MUTUAL", tc.credentialToUse)
 
 						// Get namespace for gateway pod.
-						istioCfg := istio.DefaultConfigOrFail(t, ctx)
-						systemNS := namespace.ClaimOrFail(ctx, ctx, istioCfg.SystemNamespace)
+						istioCfg := istio.DefaultConfigOrFail(t, t)
+						systemNS := namespace.ClaimOrFail(t, t, istioCfg.SystemNamespace)
 
-						ctx.Config(ctx.Clusters().Default()).ApplyYAMLOrFail(ctx, systemNS.Name(), bufDestinationRule.String())
+						t.Config(t.Clusters().Default()).ApplyYAMLOrFail(t, systemNS.Name(), bufDestinationRule.String())
 
 						retry.UntilSuccessOrFail(t, func() error {
 							resp, err := internalClient.Call(echo.CallOptions{
@@ -261,12 +258,10 @@ func TestMutualTlsOrigination(t *testing.T) {
 							if err != nil {
 								return fmt.Errorf("request failed: %v", err)
 							}
-							codes := make([]string, 0, len(resp))
 							for _, r := range resp {
-								codes = append(codes, r.Code)
-							}
-							if !reflect.DeepEqual(codes, tc.response) {
-								return fmt.Errorf("got codes %q, expected %q", codes, tc.response)
+								if r.Code != tc.response {
+									return fmt.Errorf("got code %s, expected %s", r.Code, tc.response)
+								}
 							}
 							for _, r := range resp {
 								if _, f := r.RawResponse["Handled-By-Egress-Gateway"]; tc.gateway && !f {

--- a/tests/integration/security/sds_tls_origination/util/util.go
+++ b/tests/integration/security/sds_tls_origination/util/util.go
@@ -22,7 +22,6 @@ import (
 	"html/template"
 	"io/ioutil"
 	"path"
-	"testing"
 	"time"
 
 	envoyAdmin "github.com/envoyproxy/go-control-plane/envoy/admin/v3"
@@ -43,7 +42,7 @@ import (
 	"istio.io/istio/pkg/test/util/structpath"
 )
 
-func MustReadCert(t *testing.T, f string) string {
+func MustReadCert(t test.Failer, f string) string {
 	b, err := ioutil.ReadFile(path.Join(env.IstioSrc, "tests/testdata/certs/dns", f))
 	if err != nil {
 		t.Fatalf("failed to read %v: %v", f, err)
@@ -153,7 +152,7 @@ func createSecret(credentialType string, cn, ns string, ic TLSCredential, isNotG
 // SetupEcho creates two namespaces client and server. It also brings up two echo instances server and
 // client in respective namespaces. HTTP and HTTPS port on the server echo are set up. Egress Gateway is set up in the
 // service namespace to handle egress for "external" calls.
-func SetupEcho(t *testing.T, ctx resource.Context) (echo.Instance, echo.Instance, namespace.Instance, namespace.Instance) {
+func SetupEcho(t test.Failer, ctx resource.Context) (echo.Instance, echo.Instance, namespace.Instance, namespace.Instance) {
 	clientNamespace := namespace.NewOrFail(t, ctx, namespace.Config{
 		Prefix: "client",
 		Inject: true,
@@ -299,7 +298,7 @@ spec:
 // We want to test out TLS origination at Gateway, to do so traffic from client in client namespace is first
 // routed to egress-gateway service in istio-system namespace and then from egress-gateway to server in server namespace.
 // TLS origination at Gateway happens using DestinationRule with CredentialName reading k8s secret at the gateway proxy.
-func createGateway(t *testing.T, ctx resource.Context, clientNamespace namespace.Instance, serverNamespace namespace.Instance) {
+func createGateway(t test.Failer, ctx resource.Context, clientNamespace namespace.Instance, serverNamespace namespace.Instance) {
 	tmplGateway, err := template.New("Gateway").Parse(Gateway)
 	if err != nil {
 		t.Fatalf("failed to create template: %v", err)


### PR DESCRIPTION
Changes sds_tls_origination so that it checks response codes for each echo response. Also shadow `testing.T` with `framework.TestContext`.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any changes that may affect Istio users.
