### PR TITLE
Shadow t *testing.T with framework.TestContext in security tests

### DIFF
--- a/tests/integration/security/ca_custom_root/multi_root_test.go
+++ b/tests/integration/security/ca_custom_root/multi_root_test.go
@@ -28,25 +28,25 @@ import (
 func TestMultiRootSetup(t *testing.T) {
 	framework.NewTest(t).
 		Features("security.peer.multiple-root").
-		Run(func(ctx framework.TestContext) {
+		Run(func(t framework.TestContext) {
 			// TODO: remove the skip when https://github.com/istio/istio/issues/28798 is fixed
-			if ctx.Clusters().IsMulticluster() {
-				ctx.Skip()
+			if t.Clusters().IsMulticluster() {
+				t.Skip()
 			}
 			testNS := apps.Namespace
 
-			ctx.Config().ApplyYAMLOrFail(ctx, testNS.Name(), POLICY)
+			t.Config().ApplyYAMLOrFail(t, testNS.Name(), POLICY)
 
-			for _, cluster := range ctx.Clusters() {
-				ctx.NewSubTest(fmt.Sprintf("From %s", cluster.StableName())).Run(func(ctx framework.TestContext) {
+			for _, cluster := range t.Clusters() {
+				t.NewSubTest(fmt.Sprintf("From %s", cluster.StableName())).Run(func(t framework.TestContext) {
 					verify := func(ctx framework.TestContext, src echo.Instance, dest echo.Instance, s scheme.Instance, success bool) {
 						want := "success"
 						if !success {
 							want = "fail"
 						}
 						name := fmt.Sprintf("server:%s[%s]", dest.Config().Service, want)
-						ctx.NewSubTest(name).Run(func(ctx framework.TestContext) {
-							ctx.Helper()
+						ctx.NewSubTest(name).Run(func(t framework.TestContext) {
+							t.Helper()
 							opt := echo.CallOptions{
 								Target:   dest,
 								PortName: HTTPS,
@@ -57,14 +57,14 @@ func TestMultiRootSetup(t *testing.T) {
 								From:          src,
 								Options:       opt,
 								ExpectSuccess: success,
-								DestClusters:  ctx.Clusters(),
+								DestClusters:  t.Clusters(),
 							}
-							checker.CheckOrFail(ctx)
+							checker.CheckOrFail(t)
 						})
 					}
 
-					client := apps.Client.GetOrFail(ctx, echo.InCluster(cluster))
-					serverNakedFooAlt := apps.ServerNakedFooAlt.GetOrFail(ctx, echo.InCluster(cluster))
+					client := apps.Client.GetOrFail(t, echo.InCluster(cluster))
+					serverNakedFooAlt := apps.ServerNakedFooAlt.GetOrFail(t, echo.InCluster(cluster))
 					cases := []struct {
 						src    echo.Instance
 						dest   echo.Instance
@@ -78,7 +78,7 @@ func TestMultiRootSetup(t *testing.T) {
 					}
 
 					for _, tc := range cases {
-						verify(ctx, tc.src, tc.dest, scheme.HTTP, tc.expect)
+						verify(t, tc.src, tc.dest, scheme.HTTP, tc.expect)
 					}
 				})
 			}

--- a/tests/integration/security/ca_custom_root/secure_naming_test.go
+++ b/tests/integration/security/ca_custom_root/secure_naming_test.go
@@ -103,31 +103,31 @@ spec:
 func TestSecureNaming(t *testing.T) {
 	framework.NewTest(t).
 		Features("security.peer.secure-naming").
-		Run(func(ctx framework.TestContext) {
+		Run(func(t framework.TestContext) {
 			// TODO: remove the skip when https://github.com/istio/istio/issues/28798 is fixed
-			if ctx.Clusters().IsMulticluster() {
-				ctx.Skip()
+			if t.Clusters().IsMulticluster() {
+				t.Skip()
 			}
-			istioCfg := istio.DefaultConfigOrFail(t, ctx)
+			istioCfg := istio.DefaultConfigOrFail(t, t)
 			testNamespace := apps.Namespace
-			namespace.ClaimOrFail(t, ctx, istioCfg.SystemNamespace)
+			namespace.ClaimOrFail(t, t, istioCfg.SystemNamespace)
 			// Check that the CA certificate in the configmap of each namespace is as expected, which
 			// is used for data plane to control plane TLS authentication.
 			retry.UntilSuccessOrFail(t, func() error {
-				return checkCACert(ctx, t, testNamespace)
+				return checkCACert(t, testNamespace)
 			}, retry.Delay(time.Second), retry.Timeout(10*time.Second))
 
 			callCount := 1
-			if ctx.Clusters().IsMulticluster() {
+			if t.Clusters().IsMulticluster() {
 				// so we can validate all clusters are hit
-				callCount = util.CallsPerCluster * len(ctx.Clusters())
+				callCount = util.CallsPerCluster * len(t.Clusters())
 			}
 			bSet := apps.B.Match(echo.Namespace(testNamespace.Name()))
-			for _, cluster := range ctx.Clusters() {
-				ctx.NewSubTest(fmt.Sprintf("From %s", cluster.StableName())).Run(func(ctx framework.TestContext) {
+			for _, cluster := range t.Clusters() {
+				t.NewSubTest(fmt.Sprintf("From %s", cluster.StableName())).Run(func(t framework.TestContext) {
 					a := apps.A.Match(echo.InCluster(cluster)).Match(echo.Namespace(testNamespace.Name()))[0]
-					ctx.NewSubTest("mTLS cert validation with plugin CA").
-						Run(func(ctx framework.TestContext) {
+					t.NewSubTest("mTLS cert validation with plugin CA").
+						Run(func(t framework.TestContext) {
 							// Verify that the certificate issued to the sidecar is as expected.
 							connectTarget := fmt.Sprintf("b.%s:80", testNamespace.Name())
 							out, err := cert.DumpCertFromSidecar(testNamespace, "app=a", "istio-proxy",
@@ -151,7 +151,7 @@ func TestSecureNaming(t *testing.T) {
 								ExpectSuccess: true,
 								DestClusters:  bSet.Clusters(),
 							}
-							checker.CheckOrFail(ctx)
+							checker.CheckOrFail(t)
 						})
 
 					secureNamingTestCases := []struct {
@@ -181,10 +181,10 @@ func TestSecureNaming(t *testing.T) {
 						},
 					}
 					for _, tc := range secureNamingTestCases {
-						ctx.NewSubTest(tc.name).
-							Run(func(ctx framework.TestContext) {
+						t.NewSubTest(tc.name).
+							Run(func(t framework.TestContext) {
 								dr := strings.ReplaceAll(tc.destinationRule, "NS", testNamespace.Name())
-								ctx.Config().ApplyYAMLOrFail(t, testNamespace.Name(), dr)
+								t.Config().ApplyYAMLOrFail(t, testNamespace.Name(), dr)
 								// Verify mTLS works between a and b
 								callOptions := echo.CallOptions{
 									Target:   bSet[0],
@@ -200,7 +200,7 @@ func TestSecureNaming(t *testing.T) {
 								}
 								if err := retry.UntilSuccess(
 									checker.Check, retry.Delay(time.Second), retry.Timeout(15*time.Second), retry.Converge(5)); err != nil {
-									ctx.Fatal(err)
+									t.Fatal(err)
 								}
 							})
 					}
@@ -209,7 +209,7 @@ func TestSecureNaming(t *testing.T) {
 		})
 }
 
-func verifyCertificatesWithPluginCA(t *testing.T, dump string) {
+func verifyCertificatesWithPluginCA(t framework.TestContext, dump string) {
 	certExp := regexp.MustCompile("(?sU)-----BEGIN CERTIFICATE-----(.+)-----END CERTIFICATE-----")
 	certs := certExp.FindAll([]byte(dump), -1)
 	// Verify that the certificate chain length is as expected
@@ -233,9 +233,9 @@ func verifyCertificatesWithPluginCA(t *testing.T, dump string) {
 	t.Log("the CA certificate is as expected")
 }
 
-func checkCACert(testCtx framework.TestContext, t *testing.T, testNamespace namespace.Instance) error {
+func checkCACert(t framework.TestContext, testNamespace namespace.Instance) error {
 	configMapName := "istio-ca-root-cert"
-	cm, err := testCtx.Clusters().Default().CoreV1().ConfigMaps(testNamespace.Name()).Get(context.TODO(), configMapName,
+	cm, err := t.Clusters().Default().CoreV1().ConfigMaps(testNamespace.Name()).Get(context.TODO(), configMapName,
 		kubeApiMeta.GetOptions{})
 	if err != nil {
 		return err

--- a/tests/integration/security/ca_custom_root/trust_domain_alias_secure_naming_test.go
+++ b/tests/integration/security/ca_custom_root/trust_domain_alias_secure_naming_test.go
@@ -66,25 +66,25 @@ spec:
 func TestTrustDomainAliasSecureNaming(t *testing.T) {
 	framework.NewTest(t).
 		Features("security.peer.trust-domain-alias-secure-naming").
-		Run(func(ctx framework.TestContext) {
+		Run(func(t framework.TestContext) {
 			// TODO: remove the skip when https://github.com/istio/istio/issues/28798 is fixed
-			if ctx.Clusters().IsMulticluster() {
-				ctx.Skip()
+			if t.Clusters().IsMulticluster() {
+				t.Skip()
 			}
 			testNS := apps.Namespace
 
-			ctx.Config().ApplyYAMLOrFail(ctx, testNS.Name(), POLICY)
+			t.Config().ApplyYAMLOrFail(t, testNS.Name(), POLICY)
 
-			for _, cluster := range ctx.Clusters() {
-				ctx.NewSubTest(fmt.Sprintf("From %s", cluster.StableName())).Run(func(ctx framework.TestContext) {
+			for _, cluster := range t.Clusters() {
+				t.NewSubTest(fmt.Sprintf("From %s", cluster.StableName())).Run(func(t framework.TestContext) {
 					verify := func(ctx framework.TestContext, src echo.Instance, dest echo.Instance, s scheme.Instance, success bool) {
 						want := "success"
 						if !success {
 							want = "fail"
 						}
 						name := fmt.Sprintf("server:%s[%s]", dest.Config().Service, want)
-						ctx.NewSubTest(name).Run(func(ctx framework.TestContext) {
-							ctx.Helper()
+						ctx.NewSubTest(name).Run(func(t framework.TestContext) {
+							t.Helper()
 							opt := echo.CallOptions{
 								Target:   dest,
 								PortName: HTTPS,
@@ -95,15 +95,15 @@ func TestTrustDomainAliasSecureNaming(t *testing.T) {
 								From:          src,
 								Options:       opt,
 								ExpectSuccess: success,
-								DestClusters:  ctx.Clusters(),
+								DestClusters:  t.Clusters(),
 							}
-							checker.CheckOrFail(ctx)
+							checker.CheckOrFail(t)
 						})
 					}
 
-					client := apps.Client.GetOrFail(ctx, echo.InCluster(cluster))
-					serverNakedFoo := apps.ServerNakedFoo.GetOrFail(ctx, echo.InCluster(cluster))
-					serverNakedBar := apps.ServerNakedBar.GetOrFail(ctx, echo.InCluster(cluster))
+					client := apps.Client.GetOrFail(t, echo.InCluster(cluster))
+					serverNakedFoo := apps.ServerNakedFoo.GetOrFail(t, echo.InCluster(cluster))
+					serverNakedBar := apps.ServerNakedBar.GetOrFail(t, echo.InCluster(cluster))
 					cases := []struct {
 						src    echo.Instance
 						dest   echo.Instance
@@ -122,7 +122,7 @@ func TestTrustDomainAliasSecureNaming(t *testing.T) {
 					}
 
 					for _, tc := range cases {
-						verify(ctx, tc.src, tc.dest, scheme.HTTP, tc.expect)
+						verify(t, tc.src, tc.dest, scheme.HTTP, tc.expect)
 					}
 				})
 			}

--- a/tests/integration/security/chiron/dns_cert_test.go
+++ b/tests/integration/security/chiron/dns_cert_test.go
@@ -93,75 +93,75 @@ ksOPXgK63Oot7wxQOuG5BX1v1yQ=
 func TestDNSCertificate(t *testing.T) {
 	framework.NewTest(t).
 		Features("security.control-plane.k8s-certs.dns-certificate").
-		Run(func(ctx framework.TestContext) {
+		Run(func(t framework.TestContext) {
 			var galleySecret, galleySecret2, sidecarInjectorSecret, sidecarInjectorSecret2 *corev1.Secret
-			istio.DefaultConfigOrFail(t, ctx)
-			cluster := ctx.Clusters().Default()
+			istio.DefaultConfigOrFail(t, t)
+			cluster := t.Clusters().Default()
 			istioNs := inst.Settings().IstioNamespace
 
 			// Test that DNS certificates have been generated.
-			ctx.NewSubTest("generateDNSCertificates").
-				Run(func(ctx framework.TestContext) {
-					ctx.Log("check that DNS certificates have been generated ...")
-					galleySecret = kube2.WaitForSecretToExistOrFail(ctx, cluster, istioNs, galleySecretName, secretWaitTime)
-					sidecarInjectorSecret = kube2.WaitForSecretToExistOrFail(ctx, cluster, istioNs, sidecarInjectorSecretName, secretWaitTime)
-					ctx.Log(`checking Galley DNS certificate is valid`)
-					secret.ExamineDNSSecretOrFail(ctx, galleySecret, galleyDNSName)
-					ctx.Log(`checking Sidecar Injector DNS certificate is valid`)
-					secret.ExamineDNSSecretOrFail(ctx, sidecarInjectorSecret, sidecarInjectorDNSName)
+			t.NewSubTest("generateDNSCertificates").
+				Run(func(t framework.TestContext) {
+					t.Log("check that DNS certificates have been generated ...")
+					galleySecret = kube2.WaitForSecretToExistOrFail(t, cluster, istioNs, galleySecretName, secretWaitTime)
+					sidecarInjectorSecret = kube2.WaitForSecretToExistOrFail(t, cluster, istioNs, sidecarInjectorSecretName, secretWaitTime)
+					t.Log(`checking Galley DNS certificate is valid`)
+					secret.ExamineDNSSecretOrFail(t, galleySecret, galleyDNSName)
+					t.Log(`checking Sidecar Injector DNS certificate is valid`)
+					secret.ExamineDNSSecretOrFail(t, sidecarInjectorSecret, sidecarInjectorDNSName)
 				})
 
 			// Test certificate regeneration: if a DNS certificate is deleted, Chiron will regenerate it.
-			ctx.NewSubTest("regenerateDNSCertificates").
-				Run(func(ctx framework.TestContext) {
+			t.NewSubTest("regenerateDNSCertificates").
+				Run(func(t framework.TestContext) {
 					_ = deleteSecret(cluster, istioNs, galleySecretName)
 					_ = deleteSecret(cluster, istioNs, sidecarInjectorSecretName)
 					// Sleep 5 seconds for the certificate regeneration to take place.
-					ctx.Log(`sleep 5 seconds for the certificate regeneration to take place ...`)
+					t.Log(`sleep 5 seconds for the certificate regeneration to take place ...`)
 					time.Sleep(5 * time.Second)
-					galleySecret = kube2.WaitForSecretToExistOrFail(ctx, cluster, istioNs, galleySecretName, secretWaitTime)
-					sidecarInjectorSecret = kube2.WaitForSecretToExistOrFail(ctx, cluster, istioNs, sidecarInjectorSecretName, secretWaitTime)
-					ctx.Log(`checking regenerated Galley DNS certificate is valid`)
-					secret.ExamineDNSSecretOrFail(ctx, galleySecret, galleyDNSName)
-					ctx.Log(`checking regenerated Sidecar Injector DNS certificate is valid`)
-					secret.ExamineDNSSecretOrFail(ctx, sidecarInjectorSecret, sidecarInjectorDNSName)
+					galleySecret = kube2.WaitForSecretToExistOrFail(t, cluster, istioNs, galleySecretName, secretWaitTime)
+					sidecarInjectorSecret = kube2.WaitForSecretToExistOrFail(t, cluster, istioNs, sidecarInjectorSecretName, secretWaitTime)
+					t.Log(`checking regenerated Galley DNS certificate is valid`)
+					secret.ExamineDNSSecretOrFail(t, galleySecret, galleyDNSName)
+					t.Log(`checking regenerated Sidecar Injector DNS certificate is valid`)
+					secret.ExamineDNSSecretOrFail(t, sidecarInjectorSecret, sidecarInjectorDNSName)
 				})
 
 			// Test certificate rotation: when the CA certificate is updated, certificates will be rotated.
-			ctx.NewSubTest("rotateDNSCertificatesWhenCAUpdated").
-				Run(func(ctx framework.TestContext) {
+			t.NewSubTest("rotateDNSCertificatesWhenCAUpdated").
+				Run(func(t framework.TestContext) {
 					galleySecret.Data[controller.RootCertID] = []byte(caCertUpdated)
 					if _, err := cluster.CoreV1().Secrets(istioNs).Update(context.TODO(), galleySecret, metav1.UpdateOptions{}); err != nil {
-						ctx.Fatalf("failed to update secret (%s:%s), error: %s", istioNs, galleySecret.Name, err)
+						t.Fatalf("failed to update secret (%s:%s), error: %s", istioNs, galleySecret.Name, err)
 					}
 					// Sleep 5 seconds for the certificate rotation to take place.
-					ctx.Log(`sleep 5 seconds for certificate rotation to take place ...`)
+					t.Log(`sleep 5 seconds for certificate rotation to take place ...`)
 					time.Sleep(5 * time.Second)
-					galleySecret2 = kube2.WaitForSecretToExistOrFail(ctx, cluster, istioNs, galleySecretName, secretWaitTime)
-					ctx.Log(`checking rotated Galley DNS certificate is valid`)
-					secret.ExamineDNSSecretOrFail(ctx, galleySecret2, galleyDNSName)
+					galleySecret2 = kube2.WaitForSecretToExistOrFail(t, cluster, istioNs, galleySecretName, secretWaitTime)
+					t.Log(`checking rotated Galley DNS certificate is valid`)
+					secret.ExamineDNSSecretOrFail(t, galleySecret2, galleyDNSName)
 					if bytes.Equal(galleySecret2.Data[controller.CertChainID], galleySecret.Data[controller.CertChainID]) {
-						ctx.Errorf("the rotated cert should be different from the original cert (%v, %v)",
+						t.Errorf("the rotated cert should be different from the original cert (%v, %v)",
 							string(galleySecret2.Data[controller.CertChainID]), string(galleySecret.Data[controller.CertChainID]))
 					}
 				})
 
 			// Test certificate rotation: when a certificate is expired, the certificate will be rotated.
-			ctx.NewSubTest("rotateDNSCertificatesWhenCertExpired").
-				Run(func(ctx framework.TestContext) {
+			t.NewSubTest("rotateDNSCertificatesWhenCertExpired").
+				Run(func(t framework.TestContext) {
 					sidecarInjectorSecret.Data[controller.CertChainID] = []byte(certExpired)
 					if _, err := cluster.CoreV1().Secrets(istioNs).Update(context.TODO(), sidecarInjectorSecret, metav1.UpdateOptions{}); err != nil {
-						ctx.Fatalf("failed to update secret (%s:%s), error: %s", istioNs, sidecarInjectorSecret.Name, err)
+						t.Fatalf("failed to update secret (%s:%s), error: %s", istioNs, sidecarInjectorSecret.Name, err)
 					}
 					// Sleep 5 seconds for the certificate rotation to take place.
-					ctx.Log(`sleep 5 seconds for expired certificate rotation to take place ...`)
+					t.Log(`sleep 5 seconds for expired certificate rotation to take place ...`)
 					time.Sleep(5 * time.Second)
-					sidecarInjectorSecret2 = kube2.WaitForSecretToExistOrFail(ctx, cluster, istioNs, sidecarInjectorSecretName, secretWaitTime)
-					ctx.Log(`checking rotated Sidecar Injector DNS certificate is valid`)
-					secret.ExamineDNSSecretOrFail(ctx, sidecarInjectorSecret2, sidecarInjectorDNSName)
+					sidecarInjectorSecret2 = kube2.WaitForSecretToExistOrFail(t, cluster, istioNs, sidecarInjectorSecretName, secretWaitTime)
+					t.Log(`checking rotated Sidecar Injector DNS certificate is valid`)
+					secret.ExamineDNSSecretOrFail(t, sidecarInjectorSecret2, sidecarInjectorDNSName)
 					if bytes.Equal(sidecarInjectorSecret2.Data[controller.CertChainID],
 						sidecarInjectorSecret.Data[controller.CertChainID]) {
-						ctx.Errorf("the rotated cert should be different from the original cert (%v, %v)",
+						t.Errorf("the rotated cert should be different from the original cert (%v, %v)",
 							string(sidecarInjectorSecret2.Data[controller.CertChainID]),
 							string(sidecarInjectorSecret.Data[controller.CertChainID]))
 					}

--- a/tests/integration/security/file_mounted_certs/p2p_mtls_test.go
+++ b/tests/integration/security/file_mounted_certs/p2p_mtls_test.go
@@ -48,11 +48,11 @@ const (
 func TestClientToServiceTls(t *testing.T) {
 	framework.NewTest(t).
 		Features("security.peer.file-mounted-certs").
-		Run(func(ctx framework.TestContext) {
-			echoClient, echoServer, serviceNamespace := setupEcho(t, ctx)
+		Run(func(t framework.TestContext) {
+			echoClient, echoServer, serviceNamespace := setupEcho(t, t)
 
-			createObject(ctx, serviceNamespace.Name(), DestinationRuleConfigMutual)
-			createObject(ctx, "istio-system", PeerAuthenticationConfig)
+			createObject(t, serviceNamespace.Name(), DestinationRuleConfigMutual)
+			createObject(t, "istio-system", PeerAuthenticationConfig)
 
 			retry.UntilSuccessOrFail(t, func() error {
 				resp, err := echoClient.Call(echo.CallOptions{
@@ -124,7 +124,7 @@ func createObject(ctx framework.TestContext, serviceNamespace string, yamlManife
 
 // setupEcho creates an `istio-fd-sds` namespace and brings up two echo instances server and
 // client in that namespace.
-func setupEcho(t *testing.T, ctx resource.Context) (echo.Instance, echo.Instance, namespace.Instance) {
+func setupEcho(t framework.TestContext, ctx resource.Context) (echo.Instance, echo.Instance, namespace.Instance) {
 	appsNamespace := namespace.NewOrFail(t, ctx, namespace.Config{
 		Prefix: "istio-fd-sds",
 		Inject: true,

--- a/tests/integration/security/filebased_tls_origination/egress_gateway_origination_test.go
+++ b/tests/integration/security/filebased_tls_origination/egress_gateway_origination_test.go
@@ -28,6 +28,7 @@ import (
 	envoyAdmin "github.com/envoyproxy/go-control-plane/envoy/admin/v3"
 
 	"istio.io/istio/pkg/config/protocol"
+	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/echo/common"
 	"istio.io/istio/pkg/test/echo/common/response"
 	"istio.io/istio/pkg/test/env"
@@ -41,7 +42,7 @@ import (
 	"istio.io/istio/pkg/test/util/structpath"
 )
 
-func mustReadCert(t *testing.T, f string) string {
+func mustReadCert(t framework.TestContext, f string) string {
 	b, err := ioutil.ReadFile(path.Join(env.IstioSrc, "tests/testdata/certs/dns", f))
 	if err != nil {
 		t.Fatalf("failed to read %v: %v", f, err)
@@ -56,8 +57,8 @@ func mustReadCert(t *testing.T, f string) string {
 func TestEgressGatewayTls(t *testing.T) {
 	framework.NewTest(t).
 		Features("security.egress.tls.filebased").
-		Run(func(ctx framework.TestContext) {
-			internalClient, externalServer, _, serviceNamespace := setupEcho(t, ctx)
+		Run(func(t framework.TestContext) {
+			internalClient, externalServer, _, serviceNamespace := setupEcho(t, t)
 			// Set up Host Name
 			host := "server." + serviceNamespace.Name() + ".svc.cluster.local"
 
@@ -114,14 +115,14 @@ func TestEgressGatewayTls(t *testing.T) {
 			}
 
 			for name, tc := range testCases {
-				ctx.NewSubTest(name).
-					Run(func(ctx framework.TestContext) {
+				t.NewSubTest(name).
+					Run(func(t framework.TestContext) {
 						bufDestinationRule := createDestinationRule(t, serviceNamespace, tc.destinationRuleMode, tc.fakeRootCert)
 
-						istioCfg := istio.DefaultConfigOrFail(t, ctx)
-						systemNamespace := namespace.ClaimOrFail(t, ctx, istioCfg.SystemNamespace)
+						istioCfg := istio.DefaultConfigOrFail(t, t)
+						systemNamespace := namespace.ClaimOrFail(t, t, istioCfg.SystemNamespace)
 
-						ctx.Config().ApplyYAMLOrFail(ctx, systemNamespace.Name(), bufDestinationRule.String())
+						t.Config().ApplyYAMLOrFail(t, systemNamespace.Name(), bufDestinationRule.String())
 
 						retry.UntilSuccessOrFail(t, func() error {
 							resp, err := internalClient.Call(echo.CallOptions{
@@ -209,7 +210,7 @@ spec:
 `
 )
 
-func createDestinationRule(t *testing.T, serviceNamespace namespace.Instance,
+func createDestinationRule(t framework.TestContext, serviceNamespace namespace.Instance,
 	destinationRuleMode string, fakeRootCert bool) bytes.Buffer {
 	var destinationRuleToParse string
 	var rootCertPathToUse string
@@ -245,7 +246,7 @@ func createDestinationRule(t *testing.T, serviceNamespace namespace.Instance,
 // is applied to only allow egress traffic to service namespace such that when client to server calls are made
 // we are able to simulate "external" traffic by going outside this namespace. Egress Gateway is set up in the
 // service namespace to handle egress for "external" calls.
-func setupEcho(t *testing.T, ctx resource.Context) (echo.Instance, echo.Instance, namespace.Instance, namespace.Instance) {
+func setupEcho(t framework.TestContext, ctx resource.Context) (echo.Instance, echo.Instance, namespace.Instance, namespace.Instance) {
 	appsNamespace := namespace.NewOrFail(t, ctx, namespace.Config{
 		Prefix: "app",
 		Inject: true,
@@ -388,7 +389,7 @@ spec:
 `
 )
 
-func createGateway(t *testing.T, ctx resource.Context, appsNamespace namespace.Instance, serviceNamespace namespace.Instance) {
+func createGateway(t test.Failer, ctx resource.Context, appsNamespace namespace.Instance, serviceNamespace namespace.Instance) {
 	tmplGateway, err := template.New("Gateway").Parse(Gateway)
 	if err != nil {
 		t.Fatalf("failed to create template: %v", err)

--- a/tests/integration/security/mtls_first_party_jwt/strict_test.go
+++ b/tests/integration/security/mtls_first_party_jwt/strict_test.go
@@ -34,8 +34,8 @@ import (
 func TestMtlsStrictK8sCA(t *testing.T) {
 	framework.NewTest(t).
 		Features("security.control-plane.k8s-certs.jwt").
-		Run(func(ctx framework.TestContext) {
-			systemNM := istio.ClaimSystemNamespaceOrFail(ctx, ctx)
+		Run(func(t framework.TestContext) {
+			systemNM := istio.ClaimSystemNamespaceOrFail(t, t)
 			testCases := []reachability.TestCase{
 				{
 					ConfigFile: "global-mtls-on-no-dr.yaml",
@@ -89,6 +89,6 @@ func TestMtlsStrictK8sCA(t *testing.T) {
 					},
 				},
 			}
-			reachability.Run(testCases, ctx, apps)
+			reachability.Run(testCases, t, apps)
 		})
 }

--- a/tests/integration/security/mtlsk8sca/strict_test.go
+++ b/tests/integration/security/mtlsk8sca/strict_test.go
@@ -34,8 +34,8 @@ import (
 func TestMtlsStrictK8sCA(t *testing.T) {
 	framework.NewTest(t).
 		Features("security.control-plane.k8s-certs.k8sca").
-		Run(func(ctx framework.TestContext) {
-			systemNM := istio.ClaimSystemNamespaceOrFail(ctx, ctx)
+		Run(func(t framework.TestContext) {
+			systemNM := istio.ClaimSystemNamespaceOrFail(t, t)
 
 			testCases := []reachability.TestCase{
 				{
@@ -90,6 +90,6 @@ func TestMtlsStrictK8sCA(t *testing.T) {
 					},
 				},
 			}
-			reachability.Run(testCases, ctx, apps)
+			reachability.Run(testCases, t, apps)
 		})
 }

--- a/tests/integration/security/pass_through_filter_chain_test.go
+++ b/tests/integration/security/pass_through_filter_chain_test.go
@@ -35,7 +35,7 @@ func TestPassThroughFilterChain(t *testing.T) {
 	framework.
 		NewTest(t).
 		Features("security.filterchain").
-		Run(func(ctx framework.TestContext) {
+		Run(func(t framework.TestContext) {
 			ns := apps.Namespace1
 			type expect struct {
 				port   int
@@ -281,15 +281,15 @@ spec:
 				},
 			}
 
-			for _, cluster := range ctx.Clusters() {
-				client := apps.Naked.Match(echo.InCluster(cluster)).GetOrFail(ctx, echo.Namespace(ns.Name()))
-				destination := apps.A.Match(echo.Namespace(ns.Name())).GetOrFail(ctx, echo.InCluster(cluster))
-				from := getWorkload(client, ctx)
-				destWorkload := getWorkload(destination, ctx).Address()
+			for _, cluster := range t.Clusters() {
+				client := apps.Naked.Match(echo.InCluster(cluster)).GetOrFail(t, echo.Namespace(ns.Name()))
+				destination := apps.A.Match(echo.Namespace(ns.Name())).GetOrFail(t, echo.InCluster(cluster))
+				from := getWorkload(client, t)
+				destWorkload := getWorkload(destination, t).Address()
 				for _, tc := range cases {
-					ctx.NewSubTest(fmt.Sprintf("In %s/%v", cluster.StableName(), tc.name)).Run(func(ctx framework.TestContext) {
-						ctx.Config().ApplyYAMLOrFail(ctx, ns.Name(), tc.config)
-						util.WaitForConfig(ctx, tc.config, ns)
+					t.NewSubTest(fmt.Sprintf("In %s/%v", cluster.StableName(), tc.name)).Run(func(t framework.TestContext) {
+						t.Config().ApplyYAMLOrFail(t, ns.Name(), tc.config)
+						util.WaitForConfig(t, tc.config, ns)
 						for _, expect := range tc.expected {
 							name := fmt.Sprintf("port %d[%t]", expect.port, expect.want)
 
@@ -305,8 +305,8 @@ spec:
 									},
 								},
 							}
-							ctx.NewSubTest(name).Run(func(ctx framework.TestContext) {
-								retry.UntilSuccessOrFail(ctx, func() error {
+							t.NewSubTest(name).Run(func(t framework.TestContext) {
+								retry.UntilSuccessOrFail(t, func() error {
 									responses, err := from.ForwardEcho(context.TODO(), request)
 									if expect.want {
 										if err != nil {

--- a/tests/integration/security/reachability_test.go
+++ b/tests/integration/security/reachability_test.go
@@ -36,8 +36,8 @@ import (
 func TestReachability(t *testing.T) {
 	framework.NewTest(t).
 		Features("security.reachability").
-		Run(func(ctx framework.TestContext) {
-			systemNM := istio.ClaimSystemNamespaceOrFail(ctx, ctx)
+		Run(func(t framework.TestContext) {
+			systemNM := istio.ClaimSystemNamespaceOrFail(t, t)
 			// mtlsOnExpect defines our expectations for when mTLS is expected when its enabled
 			mtlsOnExpect := func(src echo.Instance, opts echo.CallOptions) bool {
 				if apps.IsNaked(src) || apps.IsNaked(opts.Target) {
@@ -261,6 +261,6 @@ func TestReachability(t *testing.T) {
 				},
 				// ----- end of automtls partial test suites -----
 			}
-			reachability.Run(testCases, ctx, apps)
+			reachability.Run(testCases, t, apps)
 		})
 }

--- a/tests/integration/security/sds_egress/sds_istio_mutual_egress_test.go
+++ b/tests/integration/security/sds_egress/sds_istio_mutual_egress_test.go
@@ -52,15 +52,15 @@ func TestSdsEgressGatewayIstioMutual(t *testing.T) {
 	t.Skip("https://github.com/istio/istio/issues/17933")
 	framework.NewTest(t).
 		Features("security.egress.mtls.sds").
-		Run(func(ctx framework.TestContext) {
-			istioCfg := istio.DefaultConfigOrFail(t, ctx)
+		Run(func(t framework.TestContext) {
+			istioCfg := istio.DefaultConfigOrFail(t, t)
 
-			namespace.ClaimOrFail(t, ctx, istioCfg.SystemNamespace)
-			ns := namespace.NewOrFail(t, ctx, namespace.Config{
+			namespace.ClaimOrFail(t, t, istioCfg.SystemNamespace)
+			ns := namespace.NewOrFail(t, t, namespace.Config{
 				Prefix: "sds-egress-gateway-workload",
 				Inject: true,
 			})
-			applySetupConfig(ctx, ns)
+			applySetupConfig(t, ns)
 
 			testCases := map[string]struct {
 				configPath string
@@ -77,9 +77,9 @@ func TestSdsEgressGatewayIstioMutual(t *testing.T) {
 			}
 
 			for name, tc := range testCases {
-				ctx.NewSubTest(name).
-					Run(func(ctx framework.TestContext) {
-						doIstioMutualTest(ctx, ns, tc.configPath, tc.response)
+				t.NewSubTest(name).
+					Run(func(t framework.TestContext) {
+						doIstioMutualTest(t, ns, tc.configPath, tc.response)
 					})
 			}
 		})

--- a/tests/integration/security/sds_ingress/util/util.go
+++ b/tests/integration/security/sds_ingress/util/util.go
@@ -432,8 +432,8 @@ func RunTestMultiMtlsGateways(ctx framework.TestContext, inst istio.Instance, ns
 	callType := Mtls
 
 	for _, h := range tests {
-		ctx.NewSubTest(h.Host).Run(func(ctx framework.TestContext) {
-			SendRequestOrFail(ctx, ing, h.Host, h.CredentialName, callType, tlsContext,
+		ctx.NewSubTest(h.Host).Run(func(t framework.TestContext) {
+			SendRequestOrFail(t, ing, h.Host, h.CredentialName, callType, tlsContext,
 				ExpectedResponse{ResponseCode: 200, ErrorMessage: ""})
 		})
 	}
@@ -464,8 +464,8 @@ func RunTestMultiTLSGateways(ctx framework.TestContext, inst istio.Instance, ns 
 	callType := TLS
 
 	for _, h := range tests {
-		ctx.NewSubTest(h.Host).Run(func(ctx framework.TestContext) {
-			SendRequestOrFail(ctx, ing, h.Host, h.CredentialName, callType, tlsContext,
+		ctx.NewSubTest(h.Host).Run(func(t framework.TestContext) {
+			SendRequestOrFail(t, ing, h.Host, h.CredentialName, callType, tlsContext,
 				ExpectedResponse{ResponseCode: 200, ErrorMessage: ""})
 		})
 	}

--- a/tests/integration/security/sds_ingress_k8sca/main_test.go
+++ b/tests/integration/security/sds_ingress_k8sca/main_test.go
@@ -60,8 +60,8 @@ func TestMtlsGatewaysK8sca(t *testing.T) {
 	framework.
 		NewTest(t).
 		Features("security.ingress.mtls.gateway").
-		Run(func(ctx framework.TestContext) {
-			util.RunTestMultiMtlsGateways(ctx, inst, ns)
+		Run(func(t framework.TestContext) {
+			util.RunTestMultiMtlsGateways(t, inst, ns)
 		})
 }
 
@@ -69,7 +69,7 @@ func TestTlsGatewaysK8sca(t *testing.T) {
 	framework.
 		NewTest(t).
 		Features("security.ingress.tls.gateway.K8sca").
-		Run(func(ctx framework.TestContext) {
-			util.RunTestMultiTLSGateways(ctx, inst, ns)
+		Run(func(t framework.TestContext) {
+			util.RunTestMultiTLSGateways(t, inst, ns)
 		})
 }

--- a/tests/integration/security/util/rbac_util/util.go
+++ b/tests/integration/security/util/rbac_util/util.go
@@ -122,13 +122,13 @@ func RunRBACTest(ctx framework.TestContext, cases []TestCase) {
 			tc.Request.Options.PortName,
 			tc.Request.Options.Path,
 			want)
-		ctx.NewSubTest(testName).Run(func(ctx framework.TestContext) {
+		ctx.NewSubTest(testName).Run(func(t framework.TestContext) {
 			// Current source ip based authz test cases are not required in multicluster setup
 			// because cross-network traffic will lose the origin source ip info
-			if strings.Contains(testName, "source-ip") && ctx.Clusters().IsMulticluster() {
-				ctx.Skip()
+			if strings.Contains(testName, "source-ip") && t.Clusters().IsMulticluster() {
+				t.Skip()
 			}
-			retry.UntilSuccessOrFail(ctx, tc.CheckRBACRequest,
+			retry.UntilSuccessOrFail(t, tc.CheckRBACRequest,
 				retry.Delay(250*time.Millisecond), retry.Timeout(30*time.Second))
 		})
 	}


### PR DESCRIPTION
Shadows `t *testing.T` with `t framework.TestContext` in security tests. Refactors helpers to either take (1) `test.Failer` if `t.Error` and `t.Log` not used or (2) `framework.TestContext` if they are.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
