### PR TITLE
Adding configurable knob for multiple TrustAnchor support

### DIFF
--- a/pilot/cmd/pilot-agent/options/agent.go
+++ b/pilot/cmd/pilot-agent/options/agent.go
@@ -28,12 +28,13 @@ const xdsHeaderPrefix = "XDS_HEADER_"
 
 func NewAgentOptions(proxy *model.Proxy) *istioagent.AgentOptions {
 	o := &istioagent.AgentOptions{
-		XDSRootCerts: xdsRootCA,
-		CARootCerts:  caRootCA,
-		XDSHeaders:   map[string]string{},
-		XdsUdsPath:   constants.DefaultXdsUdsPath,
-		IsIPv6:       proxy.SupportsIPv6(),
-		ProxyType:    proxy.Type,
+		XDSRootCerts:             xdsRootCA,
+		CARootCerts:              caRootCA,
+		XDSHeaders:               map[string]string{},
+		XdsUdsPath:               constants.DefaultXdsUdsPath,
+		IsIPv6:                   proxy.SupportsIPv6(),
+		ProxyType:                proxy.Type,
+		EnableDynamicProxyConfig: enableProxyConfigXdsEnv,
 	}
 	extractXDSHeadersFromEnv(o)
 	if proxyXDSViaAgent {

--- a/pilot/cmd/pilot-agent/options/options.go
+++ b/pilot/cmd/pilot-agent/options/options.go
@@ -84,4 +84,8 @@ var (
 	// This is a copy of the env var in the init code.
 	dnsCaptureByAgent = env.RegisterBoolVar("ISTIO_META_DNS_CAPTURE", false,
 		"If set to true, enable the capture of outgoing DNS packets on port 53, redirecting to istio-agent on :15053").Get()
+
+	// Ability of istio-agent to retrieve proxyConfig via XDS for dynamic configuration updates
+	enableProxyConfigXdsEnv = env.RegisterBoolVar("PROXY_CONFIG_XDS_AGENT", false,
+		"If set to true, agent retrieves dynamic proxy-config updates via xds channel").Get()
 )

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -1203,6 +1203,10 @@ func (s *Server) addIstioCAToTrustBundle(args *PilotArgs) error {
 func (s *Server) initWorkloadTrustBundle(args *PilotArgs) error {
 	var err error
 
+	if !features.MultiRootMesh.Get() {
+		return nil
+	}
+
 	s.workloadTrustBundle.UpdateCb(func() {
 		pushReq := &model.PushRequest{
 			Full:   true,

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -427,6 +427,8 @@ var (
 
 	SharedMeshConfig = env.RegisterStringVar("SHARED_MESH_CONFIG", "",
 		"Additional config map to load for shared MeshConfig settings. The standard mesh config will take precedence.").Get()
+	MultiRootMesh = env.RegisterBoolVar("ISTIO_MULTIROOT_MESH", false,
+		"If enabled, mesh will support certificates signed by more than one trustAnchor for ISTIO_MUTUAL mTLS")
 )
 
 // UnsafeFeaturesEnabled returns true if any unsafe features are enabled.

--- a/pilot/pkg/xds/pcds.go
+++ b/pilot/pkg/xds/pcds.go
@@ -16,6 +16,7 @@ package xds
 
 import (
 	mesh "istio.io/api/mesh/v1alpha1"
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	tb "istio.io/istio/pilot/pkg/trustbundle"
 	"istio.io/istio/pkg/util/gogo"
@@ -30,6 +31,10 @@ type PcdsGenerator struct {
 var _ model.XdsResourceGenerator = &PcdsGenerator{}
 
 func pcdsNeedsPush(req *model.PushRequest) bool {
+	if !features.MultiRootMesh.Get() {
+		return false
+	}
+
 	if req == nil {
 		return true
 	}

--- a/pkg/istio-agent/agent.go
+++ b/pkg/istio-agent/agent.go
@@ -128,6 +128,9 @@ type AgentOptions struct {
 
 	// Path to local UDS to communicate with Envoy
 	XdsUdsPath string
+
+	// Ability to retrieve ProxyConfig dynamically through XDS
+	EnableDynamicProxyConfig bool
 }
 
 // NewAgent hosts the functionality for local SDS and XDS. This consists of the local SDS server and

--- a/pkg/istio-agent/xds_proxy.go
+++ b/pkg/istio-agent/xds_proxy.go
@@ -148,7 +148,7 @@ func initXdsProxy(ia *Agent) (*XdsProxy, error) {
 			return nil
 		}
 	}
-	if ia.secretCache != nil {
+	if ia.cfg.EnableDynamicProxyConfig && ia.secretCache != nil {
 		proxy.handlers[v3.ProxyConfigType] = func(resp *discovery.DiscoveryResponse) error {
 			if len(resp.Resources) == 0 {
 				return fmt.Errorf("empty response")

--- a/tests/integration/security/ca_custom_root/main_test.go
+++ b/tests/integration/security/ca_custom_root/main_test.go
@@ -332,6 +332,9 @@ func setupConfig(_ resource.Context, cfg *istio.Config) {
 
 	cfgYaml := tmpl.MustEvaluate(`
 values:
+  pilot:
+    env:
+      ISTIO_MULTIROOT_MESH: true
   meshConfig:
     trustDomainAliases: [some-other, trust-domain-foo]
     caCertificates:

--- a/tests/integration/security/ca_custom_root/main_test.go
+++ b/tests/integration/security/ca_custom_root/main_test.go
@@ -336,6 +336,9 @@ values:
     env:
       ISTIO_MULTIROOT_MESH: true
   meshConfig:
+    defaultConfig:
+      proxyMetadata:
+        PROXY_CONFIG_XDS_AGENT: "true"
     trustDomainAliases: [some-other, trust-domain-foo]
     caCertificates:
     - pem: |


### PR DESCRIPTION
Adding configurable knob for multiple TrustAnchor support.
Related to https://github.com/istio/istio/issues/31662

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
