### PR TITLE
support config istiod server tls cipher suites

### DIFF
--- a/pilot/cmd/pilot-discovery/main.go
+++ b/pilot/cmd/pilot-discovery/main.go
@@ -17,6 +17,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -62,6 +63,9 @@ var (
 		},
 		RunE: func(c *cobra.Command, args []string) error {
 			cmd.PrintFlags(c.Flags())
+			if err := ValidateFlags(serverArgs); err != nil {
+				return err
+			}
 
 			// Create the stop channel for all of the servers.
 			stop := make(chan struct{})
@@ -154,6 +158,11 @@ func init() {
 		"File containing the x509 Server Certificate")
 	discoveryCmd.PersistentFlags().StringVar(&serverArgs.ServerOptions.TLSOptions.KeyFile, "tlsKeyFile", "",
 		"File containing the x509 private key matching --tlsCertFile")
+	discoveryCmd.PersistentFlags().StringSliceVar(&serverArgs.ServerOptions.TLSOptions.TLSCipherSuites, "tls-cipher-suites", nil,
+		"Comma-separated list of cipher suites for the server. "+
+			"If omitted, the default Go cipher suites will be used. \n"+
+			"Preferred values: "+strings.Join(secureTLSCipherNames(), ", ")+". \n"+
+			"Insecure values: "+strings.Join(insecureTLSCipherNames(), ", ")+".")
 
 	discoveryCmd.PersistentFlags().Float32Var(&serverArgs.RegistryOptions.KubeOptions.KubernetesAPIQPS, "kubernetesApiQPS", 80.0,
 		"Maximum QPS when communicating with the kubernetes API")

--- a/pilot/cmd/pilot-discovery/options.go
+++ b/pilot/cmd/pilot-discovery/options.go
@@ -1,3 +1,17 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/pilot/cmd/pilot-discovery/options.go
+++ b/pilot/cmd/pilot-discovery/options.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"crypto/tls"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"istio.io/istio/pilot/pkg/bootstrap"
+)
+
+// insecureTLSCipherNames returns a list of cipher suite names implemented by crypto/tls
+// which have security issues.
+func insecureTLSCipherNames() []string {
+	cipherKeys := sets.NewString()
+	for _, cipher := range tls.InsecureCipherSuites() {
+		cipherKeys.Insert(cipher.Name)
+	}
+	return cipherKeys.List()
+}
+
+// secureTLSCipherNames returns a list of cipher suite names implemented by crypto/tls.
+func secureTLSCipherNames() []string {
+	cipherKeys := sets.NewString()
+	for _, cipher := range tls.CipherSuites() {
+		cipherKeys.Insert(cipher.Name)
+	}
+	return cipherKeys.List()
+}
+
+func ValidateFlags(serverArgs *bootstrap.PilotArgs) error {
+	if serverArgs == nil {
+		return nil
+	}
+	_, err := bootstrap.TLSCipherSuites(serverArgs.ServerOptions.TLSOptions.TLSCipherSuites)
+	// TODO: add validation for other flags
+
+	return err
+}

--- a/pilot/pkg/bootstrap/options.go
+++ b/pilot/pkg/bootstrap/options.go
@@ -176,7 +176,7 @@ func TLSCipherSuites(cipherNames []string) ([]uint16, error) {
 	for _, cipher := range cipherNames {
 		intValue, ok := possibleCiphers[cipher]
 		if !ok {
-			return nil, fmt.Errorf("Cipher suite %s not supported or doesn't exist", cipher)
+			return nil, fmt.Errorf("cipher suite %s not supported or doesn't exist", cipher)
 		}
 		ciphersIntSlice = append(ciphersIntSlice, intValue)
 	}

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -179,6 +179,7 @@ type Server struct {
 
 // NewServer creates a new Server instance based on the provided arguments.
 func NewServer(args *PilotArgs) (*Server, error) {
+
 	e := &model.Environment{
 		PushContext:  model.NewPushContext(),
 		DomainSuffix: args.RegistryOptions.KubeOptions.DomainSuffix,
@@ -709,7 +710,6 @@ func (s *Server) initSecureDiscoveryService(args *PilotArgs) error {
 		return nil
 	}
 	log.Info("initializing secure discovery service")
-	cipherSuites, _ := TLSCipherSuites(args.ServerOptions.TLSOptions.TLSCipherSuites)
 	cfg := &tls.Config{
 		GetCertificate: s.getIstiodCertificate,
 		ClientAuth:     tls.VerifyClientCertIfGiven,
@@ -722,7 +722,7 @@ func (s *Server) initSecureDiscoveryService(args *PilotArgs) error {
 			return err
 		},
 		MinVersion:   tls.VersionTLS12,
-		CipherSuites: cipherSuites,
+		CipherSuites: args.ServerOptions.TLSOptions.CipherSuits,
 	}
 
 	tlsCreds := credentials.NewTLS(cfg)

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -709,7 +709,7 @@ func (s *Server) initSecureDiscoveryService(args *PilotArgs) error {
 		return nil
 	}
 	log.Info("initializing secure discovery service")
-
+	cipherSuites, _ := TLSCipherSuites(args.ServerOptions.TLSOptions.TLSCipherSuites)
 	cfg := &tls.Config{
 		GetCertificate: s.getIstiodCertificate,
 		ClientAuth:     tls.VerifyClientCertIfGiven,
@@ -721,6 +721,8 @@ func (s *Server) initSecureDiscoveryService(args *PilotArgs) error {
 			}
 			return err
 		},
+		MinVersion:   tls.VersionTLS12,
+		CipherSuites: cipherSuites,
 	}
 
 	tlsCreds := credentials.NewTLS(cfg)

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -179,7 +179,6 @@ type Server struct {
 
 // NewServer creates a new Server instance based on the provided arguments.
 func NewServer(args *PilotArgs) (*Server, error) {
-
 	e := &model.Environment{
 		PushContext:  model.NewPushContext(),
 		DomainSuffix: args.RegistryOptions.KubeOptions.DomainSuffix,

--- a/pilot/pkg/bootstrap/webhook.go
+++ b/pilot/pkg/bootstrap/webhook.go
@@ -41,11 +41,14 @@ func (s *Server) initSecureWebhookServer(args *PilotArgs) {
 	log.Info("initializing secure webhook server for istiod webhooks")
 	// create the https server for hosting the k8s injectionWebhook handlers.
 	s.httpsMux = http.NewServeMux()
+	cipherSuites, _ := TLSCipherSuites(args.ServerOptions.TLSOptions.TLSCipherSuites)
 	s.httpsServer = &http.Server{
 		Addr:    args.ServerOptions.HTTPSAddr,
 		Handler: s.httpsMux,
 		TLSConfig: &tls.Config{
 			GetCertificate: s.getIstiodCertificate,
+			MinVersion:     tls.VersionTLS12,
+			CipherSuites:   cipherSuites,
 		},
 	}
 

--- a/pilot/pkg/bootstrap/webhook.go
+++ b/pilot/pkg/bootstrap/webhook.go
@@ -16,6 +16,7 @@ package bootstrap
 
 import (
 	"crypto/tls"
+	"fmt"
 	"net/http"
 	"net/url"
 	"time"
@@ -31,8 +32,9 @@ const (
 // If https address is off the injection handlers will be registered on the main http endpoint, with
 // TLS handled by a proxy/gateway in front of Istiod.
 func (s *Server) initSecureWebhookServer(args *PilotArgs) {
+	fmt.Println(args.ServerOptions.HTTPSAddr)
 	// create the https server for hosting the k8s injectionWebhook handlers.
-	if s.kubeClient == nil || args.ServerOptions.HTTPSAddr == "" {
+	if args.ServerOptions.HTTPSAddr == "" {
 		s.httpsMux = s.httpMux
 		log.Info("HTTPS port is disabled, multiplexing webhooks on the httpAddr ", args.ServerOptions.HTTPAddr)
 		return

--- a/pilot/pkg/bootstrap/webhook.go
+++ b/pilot/pkg/bootstrap/webhook.go
@@ -41,14 +41,13 @@ func (s *Server) initSecureWebhookServer(args *PilotArgs) {
 	log.Info("initializing secure webhook server for istiod webhooks")
 	// create the https server for hosting the k8s injectionWebhook handlers.
 	s.httpsMux = http.NewServeMux()
-	cipherSuites, _ := TLSCipherSuites(args.ServerOptions.TLSOptions.TLSCipherSuites)
 	s.httpsServer = &http.Server{
 		Addr:    args.ServerOptions.HTTPSAddr,
 		Handler: s.httpsMux,
 		TLSConfig: &tls.Config{
 			GetCertificate: s.getIstiodCertificate,
 			MinVersion:     tls.VersionTLS12,
-			CipherSuites:   cipherSuites,
+			CipherSuites:   args.ServerOptions.TLSOptions.CipherSuits,
 		},
 	}
 


### PR DESCRIPTION
### Context

Sometimes it is not allowed to support tls1.0/tls1.1 and also not allowed to use some cipher suites in production env.  So in this pr, I make cipher suites of istiod TLS server configurable.