### PR TITLE
Shadow `log` variable so its consistently used

### DIFF
--- a/pilot/pkg/xds/adstest.go
+++ b/pilot/pkg/xds/adstest.go
@@ -28,7 +28,6 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
 	"istio.io/istio/pkg/test"
-	"istio.io/pkg/log"
 )
 
 func NewAdsTest(t test.Failer, conn *grpc.ClientConn) *AdsTest {

--- a/pilot/pkg/xds/authentication.go
+++ b/pilot/pkg/xds/authentication.go
@@ -62,6 +62,6 @@ func (s *DiscoveryServer) authenticate(ctx context.Context) ([]string, error) {
 		authFailMsgs = append(authFailMsgs, fmt.Sprintf("Authenticator %s: %v", authn.AuthenticatorType(), err))
 	}
 
-	adsLog.Errorf("Failed to authenticate client from %s: %s", peerInfo.Addr.String(), strings.Join(authFailMsgs, "; "))
+	log.Errorf("Failed to authenticate client from %s: %s", peerInfo.Addr.String(), strings.Join(authFailMsgs, "; "))
 	return nil, errors.New("authentication failure")
 }

--- a/pilot/pkg/xds/bench_test.go
+++ b/pilot/pkg/xds/bench_test.go
@@ -45,7 +45,7 @@ import (
 	"istio.io/istio/pkg/spiffe"
 	"istio.io/istio/pkg/test/util/yml"
 	"istio.io/pkg/env"
-	"istio.io/pkg/log"
+	istiolog "istio.io/pkg/log"
 )
 
 // ConfigInput defines inputs passed to the test config templates
@@ -104,11 +104,11 @@ var testCases = []ConfigInput{
 }
 
 func disableLogging() {
-	for _, s := range log.Scopes() {
+	for _, s := range istiolog.Scopes() {
 		if s.Name() == benchmarkScope.Name() {
 			continue
 		}
-		s.SetOutputLevel(log.NoneLevel)
+		s.SetOutputLevel(istiolog.NoneLevel)
 	}
 }
 
@@ -405,7 +405,7 @@ func initPushContext(env *model.Environment, proxy *model.Proxy) {
 
 var debugGeneration = env.RegisterBoolVar("DEBUG_CONFIG_DUMP", false, "if enabled, print a full config dump of the generated config")
 
-var benchmarkScope = log.RegisterScope("benchmark", "", 0)
+var benchmarkScope = istiolog.RegisterScope("benchmark", "", 0)
 
 // Add additional debug info for a test
 func logDebug(b *testing.B, m model.Resources) {

--- a/pilot/pkg/xds/debug.go
+++ b/pilot/pkg/xds/debug.go
@@ -41,7 +41,7 @@ import (
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/collection"
-	"istio.io/pkg/log"
+	istiolog "istio.io/pkg/log"
 )
 
 var indexTmpl = template.Must(template.New("index").Parse(`<html>
@@ -373,7 +373,7 @@ func (s *DiscoveryServer) getResourceVersion(nonce, key string, cache map[string
 	if !ok {
 		lookupResult, err := s.Env.GetLedger().GetPreviousValue(configVersion, key)
 		if err != nil {
-			adsLog.Errorf("Unable to retrieve resource %s at version %s: %v", key, configVersion, err)
+			istiolog.Errorf("Unable to retrieve resource %s at version %s: %v", key, configVersion, err)
 			lookupResult = ""
 		}
 		// update the cache even on an error, because errors will not resolve themselves, and we don't want to
@@ -625,7 +625,7 @@ func (s *DiscoveryServer) configDump(conn *Connection) (*adminapi.ConfigDump, er
 			for _, secretAny := range secrets {
 				secret := &tls.Secret{}
 				if err := ptypes.UnmarshalAny(secretAny, secret); err != nil {
-					log.Warnf("failed to unmarshal secret: %v", err)
+					istiolog.Warnf("failed to unmarshal secret: %v", err)
 				}
 				if secret.GetTlsCertificate() != nil {
 					secret.GetTlsCertificate().PrivateKey = &core.DataSource{
@@ -749,7 +749,7 @@ func (s *DiscoveryServer) Debug(w http.ResponseWriter, req *http.Request) {
 	})
 
 	if err := indexTmpl.Execute(w, deps); err != nil {
-		adsLog.Errorf("Error in rendering index template %v", err)
+		istiolog.Errorf("Error in rendering index template %v", err)
 		w.WriteHeader(500)
 	}
 }

--- a/pilot/pkg/xds/delta.go
+++ b/pilot/pkg/xds/delta.go
@@ -68,16 +68,16 @@ func (s *DiscoveryServer) StreamDeltas(stream DeltaDiscoveryStream) error {
 		return err
 	}
 	if ids != nil {
-		adsLog.Debugf("Authenticated XDS: %v with identity %v", peerAddr, ids)
+		log.Debugf("Authenticated XDS: %v with identity %v", peerAddr, ids)
 	} else {
-		adsLog.Debug("Unauthenticated XDS: ", peerAddr)
+		log.Debug("Unauthenticated XDS: ", peerAddr)
 	}
 
 	// InitContext returns immediately if the context was already initialized.
 	if err = s.globalPushContext().InitContext(s.Env, nil, nil); err != nil {
 		// Error accessing the data - log and close, maybe a different pilot replica
 		// has more luck
-		adsLog.Warnf("Error reading config %v", err)
+		log.Warnf("Error reading config %v", err)
 		return err
 	}
 	con := newDeltaConnection(peerAddr, stream)
@@ -119,7 +119,7 @@ func (s *DiscoveryServer) StreamDeltas(stream DeltaDiscoveryStream) error {
 			}
 			// processRequest is calling pushXXX, accessing common structs with pushConnection.
 			// Adding sync is the second issue to be resolved if we want to save 1/2 of the threads.
-			adsLog.Debugf("Got Delta Request: %+v", req.TypeUrl)
+			log.Debugf("Got Delta Request: %+v", req.TypeUrl)
 			err := s.processDeltaRequest(req, con)
 			if err != nil {
 				return err
@@ -148,7 +148,7 @@ func (s *DiscoveryServer) pushConnectionDelta(con *Connection, pushEv *Event) er
 	}
 
 	if !s.ProxyNeedsPush(con.proxy, pushRequest) {
-		adsLog.Debugf("Skipping push to %v, no updates required", con.ConID)
+		log.Debugf("Skipping push to %v, no updates required", con.ConID)
 		if pushRequest.Full {
 			// Only report for full versions, incremental pushes do not have a new version
 			reportAllEvents(s.StatusReporter, con.ConID, pushRequest.Push.LedgerVersion, nil)
@@ -175,7 +175,7 @@ func (s *DiscoveryServer) pushConnectionDelta(con *Connection, pushEv *Event) er
 			// avoid any scenario where this may deadlock.
 			// This can possibly be removed in the future if we find this never causes issues
 			totalDelayedPushes.With(typeTag.Value(v3.GetMetricType(w.TypeUrl))).Increment()
-			adsLog.Warnf("%s: QUEUE TIMEOUT for node:%s", v3.GetShortType(w.TypeUrl), con.proxy.ID)
+			log.Warnf("%s: QUEUE TIMEOUT for node:%s", v3.GetShortType(w.TypeUrl), con.proxy.ID)
 		}
 		if synced || timeout {
 			// Send the push now
@@ -188,7 +188,7 @@ func (s *DiscoveryServer) pushConnectionDelta(con *Connection, pushEv *Event) er
 			// https://github.com/istio/istio/issues/25685 for details on the performance
 			// impact of sending pushes before Envoy ACKs.
 			totalDelayedPushes.With(typeTag.Value(v3.GetMetricType(w.TypeUrl))).Increment()
-			adsLog.Debugf("%s: QUEUE for node:%s", v3.GetShortType(w.TypeUrl), con.proxy.ID)
+			log.Debugf("%s: QUEUE for node:%s", v3.GetShortType(w.TypeUrl), con.proxy.ID)
 			con.proxy.Lock()
 			con.blockedPushes[w.TypeUrl] = con.blockedPushes[w.TypeUrl].Merge(pushEv.pushRequest)
 			con.proxy.Unlock()
@@ -218,11 +218,11 @@ func (s *DiscoveryServer) receiveDelta(con *Connection, reqChannel chan *discove
 		req, err := con.deltaStream.Recv()
 		if err != nil {
 			if isExpectedGRPCError(err) {
-				adsLog.Infof("ADS: %q %s terminated %v", con.PeerAddr, con.ConID, err)
+				log.Infof("ADS: %q %s terminated %v", con.PeerAddr, con.ConID, err)
 				return
 			}
 			*errP = err
-			adsLog.Errorf("ADS: %q %s terminated with error: %v", con.PeerAddr, con.ConID, err)
+			log.Errorf("ADS: %q %s terminated with error: %v", con.PeerAddr, con.ConID, err)
 			totalXDSInternalErrors.Increment()
 			return
 		}
@@ -238,7 +238,7 @@ func (s *DiscoveryServer) receiveDelta(con *Connection, reqChannel chan *discove
 				*errP = err
 				return
 			}
-			adsLog.Infof("ADS: new connection for node:%s", con.ConID)
+			log.Infof("ADS: new connection for node:%s", con.ConID)
 			defer func() {
 				s.removeCon(con.ConID)
 				if s.StatusGen != nil {
@@ -251,7 +251,7 @@ func (s *DiscoveryServer) receiveDelta(con *Connection, reqChannel chan *discove
 		select {
 		case reqChannel <- req:
 		case <-con.deltaStream.Context().Done():
-			adsLog.Infof("ADS: %q %s terminated with stream closed", con.PeerAddr, con.ConID)
+			log.Infof("ADS: %q %s terminated with stream closed", con.PeerAddr, con.ConID)
 			return
 		}
 	}
@@ -271,7 +271,7 @@ func (conn *Connection) sendDelta(res *discovery.DeltaDiscoveryResponse) error {
 
 	select {
 	case <-t.C:
-		adsLog.Infof("Timeout writing %s", conn.ConID)
+		log.Infof("Timeout writing %s", conn.ConID)
 		xdsResponseWriteTimeouts.Increment()
 		return status.Errorf(codes.DeadlineExceeded, "timeout sending")
 	case err := <-errChan:
@@ -333,7 +333,7 @@ func (s *DiscoveryServer) processDeltaRequest(req *discovery.DeltaDiscoveryReque
 		return nil
 	} else {
 		// we have a blocked push which we will use
-		adsLog.Debugf("%s: DEQUEUE for node:%s", v3.GetShortType(req.TypeUrl), con.proxy.ID)
+		log.Debugf("%s: DEQUEUE for node:%s", v3.GetShortType(req.TypeUrl), con.proxy.ID)
 	}
 
 	push := s.globalPushContext()
@@ -351,7 +351,7 @@ func (s *DiscoveryServer) shouldRespondDelta(con *Connection, request *discovery
 	// will be different from the version sent. But it is fragile to rely on that.
 	if request.ErrorDetail != nil {
 		errCode := codes.Code(request.ErrorDetail.Code)
-		adsLog.Warnf("dADS:%s: ACK ERROR %s %s:%s", stype, con.ConID, errCode.String(), request.ErrorDetail.GetMessage())
+		log.Warnf("dADS:%s: ACK ERROR %s %s:%s", stype, con.ConID, errCode.String(), request.ErrorDetail.GetMessage())
 		incrementXDSRejects(request.TypeUrl, con.proxy.ID, errCode.String())
 		if s.StatusGen != nil {
 			s.StatusGen.OnNack(con.proxy, deltaToSotwRequest(request))
@@ -372,7 +372,7 @@ func (s *DiscoveryServer) shouldRespondDelta(con *Connection, request *discovery
 	// We should always respond with the current resource names.
 	if previousInfo == nil {
 		// TODO: can we distinguish init and reconnect? Do we care?
-		adsLog.Debugf("dADS:%s: INIT/RECONNECT %s %s", stype, con.ConID, request.ResponseNonce)
+		log.Debugf("dADS:%s: INIT/RECONNECT %s %s", stype, con.ConID, request.ResponseNonce)
 		con.proxy.Lock()
 		con.proxy.WatchedResources[request.TypeUrl] = &model.WatchedResource{
 			TypeUrl:       request.TypeUrl,
@@ -387,7 +387,7 @@ func (s *DiscoveryServer) shouldRespondDelta(con *Connection, request *discovery
 	// A nonce becomes stale following a newer nonce being sent to Envoy.
 	// TODO: due to concurrent unsubscribe, this probably doesn't make sense. Do we need any logic here?
 	if request.ResponseNonce != "" && request.ResponseNonce != previousInfo.NonceSent {
-		adsLog.Debugf("dADS:%s: REQ %s Expired nonce received %s, sent %s", stype,
+		log.Debugf("dADS:%s: REQ %s Expired nonce received %s, sent %s", stype,
 			con.ConID, request.ResponseNonce, previousInfo.NonceSent)
 		xdsExpiredNonce.With(typeTag.Value(v3.GetMetricType(request.TypeUrl))).Increment()
 		con.proxy.Lock()
@@ -412,15 +412,15 @@ func (s *DiscoveryServer) shouldRespondDelta(con *Connection, request *discovery
 	newAck := request.ResponseNonce != ""
 	if newAck != oldAck {
 		// Not sure which is better, lets just log if they don't match for now and compare.
-		adsLog.Errorf("dADS:%s: New ACK and old ACK check mismatch: %v vs %v", stype, oldAck, newAck)
+		log.Errorf("dADS:%s: New ACK and old ACK check mismatch: %v vs %v", stype, oldAck, newAck)
 	}
 	// Envoy can send two DiscoveryRequests with same version and nonce
 	// when it detects a new resource. We should respond if they change.
 	if oldAck {
-		adsLog.Debugf("dADS:%s: ACK %s %s", stype, con.ConID, request.ResponseNonce)
+		log.Debugf("dADS:%s: ACK %s %s", stype, con.ConID, request.ResponseNonce)
 		return false
 	}
-	adsLog.Debugf("dADS:%s: RESOURCE CHANGE previous resources: %v, new resources: %v %s %s", stype,
+	log.Debugf("dADS:%s: RESOURCE CHANGE previous resources: %v, new resources: %v %s %s", stype,
 		previousResources, con.proxy.WatchedResources[request.TypeUrl].ResourceNames, con.ConID, request.ResponseNonce)
 
 	return true
@@ -460,7 +460,7 @@ func (s *DiscoveryServer) pushDeltaXds(con *Connection, push *model.PushContext,
 			if subres.Contains(r.Name) {
 				filteredResponse = append(filteredResponse, r)
 			} else {
-				adsLog.Debugf("ADS:%v SKIP %v", v3.GetShortType(w.TypeUrl), r.Name)
+				log.Debugf("ADS:%v SKIP %v", v3.GetShortType(w.TypeUrl), r.Name)
 			}
 		}
 		deltaResponse = filteredResponse
@@ -475,7 +475,7 @@ func (s *DiscoveryServer) pushDeltaXds(con *Connection, push *model.PushContext,
 	cur.Delete(extractNames(originalResponse)...)
 	resp.RemovedResources = cur.SortedList()
 	if len(resp.RemovedResources) > 0 {
-		adsLog.Errorf("ADS:%v REMOVE %v", v3.GetShortType(w.TypeUrl), resp.RemovedResources)
+		log.Errorf("ADS:%v REMOVE %v", v3.GetShortType(w.TypeUrl), resp.RemovedResources)
 	}
 	if isWildcardTypeURL(w.TypeUrl) {
 		// this is probably a bad idea...
@@ -491,12 +491,12 @@ func (s *DiscoveryServer) pushDeltaXds(con *Connection, push *model.PushContext,
 
 	// Some types handle logs inside Generate, skip them here
 	if _, f := SkipLogTypes[w.TypeUrl]; !f {
-		if adsLog.DebugEnabled() {
+		if log.DebugEnabled() {
 			// Add additional information to logs when debug mode enabled
-			adsLog.Infof("%s: PUSH for node:%s resources:%d size:%s nonce:%v version:%v",
+			log.Infof("%s: PUSH for node:%s resources:%d size:%s nonce:%v version:%v",
 				v3.GetShortType(w.TypeUrl), con.proxy.ID, len(res), util.ByteCount(ResourceSize(res)), resp.Nonce, resp.SystemVersionInfo)
 		} else {
-			adsLog.Infof("%s: PUSH for node:%s resources:%d size:%s",
+			log.Infof("%s: PUSH for node:%s resources:%d size:%s",
 				v3.GetShortType(w.TypeUrl), con.proxy.ID, len(res), util.ByteCount(ResourceSize(res)))
 		}
 	}
@@ -594,5 +594,5 @@ func debugRequest(req *discovery.DeltaDiscoveryRequest) {
 		ResponseNonce:            req.ResponseNonce,
 		ErrorDetail:              req.ErrorDetail,
 	})
-	adsLog.Debugf("delta request: %s", debug)
+	log.Debugf("delta request: %s", debug)
 }

--- a/pilot/pkg/xds/deltaadstest.go
+++ b/pilot/pkg/xds/deltaadstest.go
@@ -28,7 +28,6 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
 	"istio.io/istio/pkg/test"
-	"istio.io/pkg/log"
 )
 
 func NewDeltaAdsTest(t test.Failer, conn *grpc.ClientConn) *DeltaAdsTest {

--- a/pilot/pkg/xds/discovery.go
+++ b/pilot/pkg/xds/discovery.go
@@ -234,7 +234,7 @@ var processStartTime = time.Now()
 
 // CachesSynced is called when caches have been synced so that server can accept connections.
 func (s *DiscoveryServer) CachesSynced() {
-	adsLog.Infof("All caches have been synced up in %v, marking server ready", time.Since(processStartTime))
+	log.Infof("All caches have been synced up in %v, marking server ready", time.Since(processStartTime))
 	s.serverReady.Store(true)
 }
 
@@ -285,7 +285,7 @@ func (s *DiscoveryServer) periodicRefreshMetrics(stopCh <-chan struct{}) {
 				push.UpdateMetrics()
 				out, _ := model.LastPushStatus.StatusJSON()
 				if string(out) != "{}" {
-					adsLog.Infof("Push Status: %s", string(out))
+					log.Infof("Push Status: %s", string(out))
 				}
 			}
 			model.LastPushMutex.Unlock()
@@ -319,7 +319,7 @@ func (s *DiscoveryServer) Push(req *model.PushRequest) {
 	}
 
 	initContextTime := time.Since(t0)
-	adsLog.Debugf("InitContext %v for push took %s", versionLocal, initContextTime)
+	log.Debugf("InitContext %v for push took %s", versionLocal, initContextTime)
 
 	versionMutex.Lock()
 	version = versionLocal
@@ -391,7 +391,7 @@ func debounce(ch chan *model.PushRequest, stopCh <-chan struct{}, opts debounceO
 		if eventDelay >= opts.debounceMax || quietTime >= opts.debounceAfter {
 			if req != nil {
 				pushCounter++
-				adsLog.Infof("Push debounce stable[%d] %d: %v since last change, %v since last push, full=%v",
+				log.Infof("Push debounce stable[%d] %d: %v since last change, %v since last push, full=%v",
 					pushCounter, debouncedEvents,
 					quietTime, eventDelay, req.Full)
 
@@ -479,7 +479,7 @@ func doSendPushes(stopCh <-chan struct{}, semaphore chan struct{}, queue *PushQu
 					return
 				case <-closed: // grpc stream was closed
 					doneFunc()
-					adsLog.Infof("Client closed connection %v", client.ConID)
+					log.Infof("Client closed connection %v", client.ConID)
 				}
 			}()
 		}
@@ -495,7 +495,7 @@ func (s *DiscoveryServer) initPushContext(req *model.PushRequest, oldPushContext
 	push.PushVersion = version
 	push.JwtKeyResolver = s.JwtKeyResolver
 	if err := push.InitContext(s.Env, oldPushContext, req); err != nil {
-		adsLog.Errorf("XDS: Failed to update services: %v", err)
+		log.Errorf("XDS: Failed to update services: %v", err)
 		// We can't push if we can't read the data - stick with previous version.
 		pushContextErrors.Increment()
 		return nil, err
@@ -593,7 +593,7 @@ func (s *DiscoveryServer) SendResponse(connections []*Connection, res *discovery
 		go func() {
 			err := con.stream.Send(res)
 			if err != nil {
-				adsLog.Info("Failed to send internal event ", con.ConID, " ", err)
+				log.Info("Failed to send internal event ", con.ConID, " ", err)
 			}
 		}()
 	}

--- a/pilot/pkg/xds/eds.go
+++ b/pilot/pkg/xds/eds.go
@@ -132,7 +132,7 @@ func (s *DiscoveryServer) edsCacheUpdate(clusterID, hostname string, namespace s
 		// unnecessary full push which can become a real problem if a pod is in crashloop and thus endpoints
 		// flip flopping between 1 and 0.
 		s.deleteEndpointShards(clusterID, hostname, namespace)
-		adsLog.Infof("Incremental push, service %s has no endpoints", hostname)
+		log.Infof("Incremental push, service %s has no endpoints", hostname)
 		return false
 	}
 
@@ -142,7 +142,7 @@ func (s *DiscoveryServer) edsCacheUpdate(clusterID, hostname string, namespace s
 	ep, created := s.getOrCreateEndpointShard(hostname, namespace)
 	// If we create a new endpoint shard, that means we have not seen the service earlier. We should do a full push.
 	if created {
-		adsLog.Infof("Full push, new service %s/%s", namespace, hostname)
+		log.Infof("Full push, new service %s/%s", namespace, hostname)
 		fullPush = true
 	}
 
@@ -157,9 +157,9 @@ func (s *DiscoveryServer) edsCacheUpdate(clusterID, hostname string, namespace s
 	ep.mutex.Lock()
 	// For existing endpoints, we need to do full push if service accounts change.
 	if !fullPush && !serviceAccounts.Equals(ep.ServiceAccounts) {
-		adsLog.Debugf("Updating service accounts now, svc %v, before service account %v, after %v",
+		log.Debugf("Updating service accounts now, svc %v, before service account %v, after %v",
 			hostname, ep.ServiceAccounts, serviceAccounts)
-		adsLog.Infof("Full push, service accounts changed, %v", hostname)
+		log.Infof("Full push, service accounts changed, %v", hostname)
 		fullPush = true
 	}
 	ep.Shards[clusterID] = istioEndpoints
@@ -255,7 +255,7 @@ func (s *DiscoveryServer) deleteService(cluster, serviceName, namespace string) 
 func (s *DiscoveryServer) llbEndpointAndOptionsForCluster(b EndpointBuilder) ([]*LocLbEndpointsAndOptions, error) {
 	if b.service == nil {
 		// Shouldn't happen here
-		adsLog.Debugf("can not find the service for cluster %s", b.clusterName)
+		log.Debugf("can not find the service for cluster %s", b.clusterName)
 		return make([]*LocLbEndpointsAndOptions, 0), nil
 	}
 
@@ -267,14 +267,14 @@ func (s *DiscoveryServer) llbEndpointAndOptionsForCluster(b EndpointBuilder) ([]
 	// automatically.
 	// Gateways use EDS for Passthrough cluster. So we should allow Passthrough here.
 	if b.service.Resolution == model.DNSLB {
-		adsLog.Infof("cluster %s in eds cluster, but its resolution now is updated to %v, skipping it.", b.clusterName, b.service.Resolution)
+		log.Infof("cluster %s in eds cluster, but its resolution now is updated to %v, skipping it.", b.clusterName, b.service.Resolution)
 		return nil, fmt.Errorf("cluster %s in eds cluster", b.clusterName)
 	}
 
 	svcPort, f := b.service.Ports.GetByPort(b.port)
 	if !f {
 		// Shouldn't happen here
-		adsLog.Debugf("can not find the service port %d for cluster %s", b.port, b.clusterName)
+		log.Debugf("can not find the service port %d for cluster %s", b.port, b.clusterName)
 		return make([]*LocLbEndpointsAndOptions, 0), nil
 	}
 
@@ -283,7 +283,7 @@ func (s *DiscoveryServer) llbEndpointAndOptionsForCluster(b EndpointBuilder) ([]
 	s.mutex.RUnlock()
 	if !f {
 		// Shouldn't happen here
-		adsLog.Debugf("can not find the endpointShards for cluster %s", b.clusterName)
+		log.Debugf("can not find the endpointShards for cluster %s", b.clusterName)
 		return make([]*LocLbEndpointsAndOptions, 0), nil
 	}
 
@@ -393,10 +393,10 @@ func (eds *EdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w
 		}
 	}
 	if len(edsUpdatedServices) == 0 {
-		adsLog.Infof("EDS: PUSH%s for node:%s resources:%d size:%s empty:%v cached:%v/%v",
+		log.Infof("EDS: PUSH%s for node:%s resources:%d size:%s empty:%v cached:%v/%v",
 			req.PushReason(), proxy.ID, len(resources), util.ByteCount(ResourceSize(resources)), empty, cached, cached+regenerated)
-	} else if adsLog.DebugEnabled() {
-		adsLog.Debugf("EDS: PUSH INC%s for node:%s clusters:%d size:%s empty:%v cached:%v/%v",
+	} else if log.DebugEnabled() {
+		log.Debugf("EDS: PUSH INC%s for node:%s clusters:%d size:%s empty:%v cached:%v/%v",
 			req.PushReason(), proxy.ID, len(resources), util.ByteCount(ResourceSize(resources)), empty, cached, cached+regenerated)
 	}
 	return resources, nil

--- a/pilot/pkg/xds/gen.go
+++ b/pilot/pkg/xds/gen.go
@@ -56,7 +56,7 @@ func init() {
 		Info:      istioversion.Info,
 	})
 	if err != nil {
-		adsLog.Warnf("XDS: Could not serialize control plane id: %v", err)
+		log.Warnf("XDS: Could not serialize control plane id: %v", err)
 	}
 	controlPlane = &corev3.ControlPlane{Identifier: string(byVersion)}
 }
@@ -125,12 +125,12 @@ func (s *DiscoveryServer) pushXds(con *Connection, push *model.PushContext,
 
 	// Some types handle logs inside Generate, skip them here
 	if _, f := SkipLogTypes[w.TypeUrl]; !f {
-		if adsLog.DebugEnabled() {
+		if log.DebugEnabled() {
 			// Add additional information to logs when debug mode enabled
-			adsLog.Infof("%s: PUSH%s for node:%s resources:%d size:%s nonce:%v version:%v",
+			log.Infof("%s: PUSH%s for node:%s resources:%d size:%s nonce:%v version:%v",
 				v3.GetShortType(w.TypeUrl), req.PushReason(), con.proxy.ID, len(res), util.ByteCount(ResourceSize(res)), resp.Nonce, resp.VersionInfo)
 		} else {
-			adsLog.Infof("%s: PUSH%s for node:%s resources:%d size:%s",
+			log.Infof("%s: PUSH%s for node:%s resources:%d size:%s",
 				v3.GetShortType(w.TypeUrl), req.PushReason(), con.proxy.ID, len(res), util.ByteCount(ResourceSize(res)))
 		}
 	}

--- a/pilot/pkg/xds/monitoring.go
+++ b/pilot/pkg/xds/monitoring.go
@@ -196,7 +196,7 @@ func isUnexpectedError(err error) bool {
 
 func recordSendError(xdsType string, conID string, err error) {
 	if isUnexpectedError(err) {
-		adsLog.Warnf("%s: Send failure %s: %v", xdsType, conID, err)
+		log.Warnf("%s: Send failure %s: %v", xdsType, conID, err)
 		// TODO use a single metric with a type tag
 		switch xdsType {
 		case v3.ListenerType:

--- a/pilot/pkg/xds/sds.go
+++ b/pilot/pkg/xds/sds.go
@@ -97,16 +97,16 @@ func (s *SecretGen) proxyAuthorizedForSecret(proxy *model.Proxy, sr SecretResour
 
 func (s *SecretGen) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource, req *model.PushRequest) (model.Resources, error) {
 	if proxy.VerifiedIdentity == nil {
-		adsLog.Warnf("proxy %v is not authorized to receive secrets. Ensure you are connecting over TLS port and are authenticated.", proxy.ID)
+		log.Warnf("proxy %v is not authorized to receive secrets. Ensure you are connecting over TLS port and are authenticated.", proxy.ID)
 		return nil, nil
 	}
 	secrets, err := s.secrets.ForCluster(proxy.Metadata.ClusterID)
 	if err != nil {
-		adsLog.Warnf("proxy %v is from an unknown cluster, cannot retrieve certificates: %v", proxy.ID, err)
+		log.Warnf("proxy %v is from an unknown cluster, cannot retrieve certificates: %v", proxy.ID, err)
 		return nil, nil
 	}
 	if err := secrets.Authorize(proxy.VerifiedIdentity.ServiceAccount, proxy.VerifiedIdentity.Namespace); err != nil {
-		adsLog.Warnf("proxy %v is not authorized to receive secrets: %v", proxy.ID, err)
+		log.Warnf("proxy %v is not authorized to receive secrets: %v", proxy.ID, err)
 		return nil, nil
 	}
 	if req == nil || !needsUpdate(proxy, req.ConfigsUpdated) {
@@ -121,7 +121,7 @@ func (s *SecretGen) Generate(proxy *model.Proxy, push *model.PushContext, w *mod
 	for _, resource := range w.ResourceNames {
 		sr, err := parseResourceName(resource, proxy.ConfigNamespace)
 		if err != nil {
-			adsLog.Warnf("error parsing resource name: %v", err)
+			log.Warnf("error parsing resource name: %v", err)
 			continue
 		}
 
@@ -133,7 +133,7 @@ func (s *SecretGen) Generate(proxy *model.Proxy, push *model.PushContext, w *mod
 		}
 
 		if err := s.proxyAuthorizedForSecret(proxy, sr); err != nil {
-			adsLog.Warnf("requested secret %v not accessible for proxy %v: %v", sr.ResourceName, proxy.ID, err)
+			log.Warnf("requested secret %v not accessible for proxy %v: %v", sr.ResourceName, proxy.ID, err)
 			continue
 		}
 		cachedItem, token, f := s.cache.Get(sr)
@@ -154,7 +154,7 @@ func (s *SecretGen) Generate(proxy *model.Proxy, push *model.PushContext, w *mod
 				results = append(results, res)
 				s.cache.Add(sr, token, res)
 			} else {
-				adsLog.Warnf("failed to fetch ca certificate for %v", sr.ResourceName)
+				log.Warnf("failed to fetch ca certificate for %v", sr.ResourceName)
 			}
 		} else {
 			key, cert := secrets.GetKeyAndCert(sr.Name, sr.Namespace)
@@ -163,11 +163,11 @@ func (s *SecretGen) Generate(proxy *model.Proxy, push *model.PushContext, w *mod
 				results = append(results, res)
 				s.cache.Add(sr, token, res)
 			} else {
-				adsLog.Warnf("failed to fetch key and certificate for %v", sr.ResourceName)
+				log.Warnf("failed to fetch key and certificate for %v", sr.ResourceName)
 			}
 		}
 	}
-	adsLog.Infof("SDS: PUSH for node:%s resources:%d size:%s cached:%v/%v",
+	log.Infof("SDS: PUSH for node:%s resources:%d size:%s cached:%v/%v",
 		proxy.ID, len(results), util.ByteCount(ResourceSize(results)), cached, cached+regenerated)
 	return results, nil
 }

--- a/pilot/pkg/xds/simple.go
+++ b/pilot/pkg/xds/simple.go
@@ -31,7 +31,6 @@ import (
 	"istio.io/istio/pkg/adsc"
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/schema/collections"
-	"istio.io/pkg/log"
 )
 
 // Server represents the XDS serving feature of Istiod (pilot).

--- a/pilot/pkg/xds/statusgen.go
+++ b/pilot/pkg/xds/statusgen.go
@@ -26,7 +26,6 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/util"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
-	"istio.io/pkg/log"
 )
 
 const (


### PR DESCRIPTION
This makes it easier to use the correct scope (ads) by not requiring
developers to remember its supposed to be `adsLog` in this package.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.