### PR TITLE
Add operator options flag into integration test framework.

### DIFF
--- a/pkg/test/framework/components/istio/config.go
+++ b/pkg/test/framework/components/istio/config.go
@@ -81,6 +81,7 @@ var (
 		DeployEastWestGW:        true,
 		DumpKubernetesManifests: false,
 		IstiodlessRemotes:       false,
+		EnableCNI:               false,
 	}
 )
 
@@ -162,6 +163,9 @@ type Config struct {
 	// IstiodlessRemotes makes remote clusters run without istiod, using webhooks/ca from the primary cluster.
 	// TODO we could set this per-cluster if istiod was smarter about patching remotes.
 	IstiodlessRemotes bool
+
+	// EnableCNI indicates the test should have CNI enabled.
+	EnableCNI bool
 }
 
 func (c *Config) OverridesYAML() string {
@@ -337,6 +341,8 @@ func (c *Config) String() string {
 	result += fmt.Sprintf("DeployHelm:                     %v\n", c.DeployHelm)
 	result += fmt.Sprintf("DumpKubernetesManifests:        %v\n", c.DumpKubernetesManifests)
 	result += fmt.Sprintf("IstiodlessRemotes:              %v\n", c.IstiodlessRemotes)
+	result += fmt.Sprintf("EnableCNI:                      %v\n", c.EnableCNI)
+
 	return result
 }
 

--- a/pkg/test/framework/components/istio/flags.go
+++ b/pkg/test/framework/components/istio/flags.go
@@ -52,4 +52,6 @@ func init() {
 		"Dump generated Istio install manifests in the artifacts directory.")
 	flag.BoolVar(&settingsFromCommandline.IstiodlessRemotes, "istio.test.istio.istiodlessRemotes", settingsFromCommandline.IstiodlessRemotes,
 		"Remote clusters run without istiod, using webhooks/ca from the primary cluster.")
+	flag.BoolVar(&settingsFromCommandline.EnableCNI, "istio.test.istio.enableCNI", settingsFromCommandline.EnableCNI,
+		"Deploy Istio with CNI enabled.")
 }

--- a/pkg/test/framework/components/istio/flags.go
+++ b/pkg/test/framework/components/istio/flags.go
@@ -42,8 +42,6 @@ func init() {
 		"Timeout applied to undeploying Istio from the target Kubernetes environment. Only applies if DeployIstio=true.")
 	flag.StringVar(&settingsFromCommandline.PrimaryClusterIOPFile, "istio.test.kube.helm.iopFile", settingsFromCommandline.PrimaryClusterIOPFile,
 		"IstioOperator spec file. This can be an absolute path or relative to repository root.")
-	flag.StringVar(&helmValues, "istio.test.kube.helm.values", helmValues,
-		"Manual overrides for Helm values file. Only valid when deploying Istio.")
 	flag.BoolVar(&settingsFromCommandline.DeployEastWestGW, "istio.test.kube.deployEastWestGW", settingsFromCommandline.DeployEastWestGW,
 		"Deploy Istio east west gateway into the target Kubernetes environment.")
 	flag.BoolVar(&settingsFromCommandline.DeployHelm, "istio.test.helm.deploy", settingsFromCommandline.DeployHelm,
@@ -52,6 +50,7 @@ func init() {
 		"Dump generated Istio install manifests in the artifacts directory.")
 	flag.BoolVar(&settingsFromCommandline.IstiodlessRemotes, "istio.test.istio.istiodlessRemotes", settingsFromCommandline.IstiodlessRemotes,
 		"Remote clusters run without istiod, using webhooks/ca from the primary cluster.")
-	flag.BoolVar(&settingsFromCommandline.EnableCNI, "istio.test.istio.enableCNI", settingsFromCommandline.EnableCNI,
-		"Deploy Istio with CNI enabled.")
+	flag.StringVar(&operatorOptions, "istio.test.istio.operatorOptions", operatorOptions,
+		`Comma separated operator configuration in addition to the default operator configuration.
+		e.g. components.cni.enabled=true,components.cni.namespace=kube-system`)
 }

--- a/pkg/test/framework/components/istio/flags.go
+++ b/pkg/test/framework/components/istio/flags.go
@@ -42,6 +42,8 @@ func init() {
 		"Timeout applied to undeploying Istio from the target Kubernetes environment. Only applies if DeployIstio=true.")
 	flag.StringVar(&settingsFromCommandline.PrimaryClusterIOPFile, "istio.test.kube.helm.iopFile", settingsFromCommandline.PrimaryClusterIOPFile,
 		"IstioOperator spec file. This can be an absolute path or relative to repository root.")
+	flag.StringVar(&helmValues, "istio.test.kube.helm.values", helmValues,
+		"Manual overrides for Helm values file. Only valid when deploying Istio.")
 	flag.BoolVar(&settingsFromCommandline.DeployEastWestGW, "istio.test.kube.deployEastWestGW", settingsFromCommandline.DeployEastWestGW,
 		"Deploy Istio east west gateway into the target Kubernetes environment.")
 	flag.BoolVar(&settingsFromCommandline.DeployHelm, "istio.test.helm.deploy", settingsFromCommandline.DeployHelm,

--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -647,6 +647,12 @@ func (i *operatorComponent) generateCommonInstallSettings(cfg Config, cluster cl
 			"--set", "values.global.network="+cluster.NetworkName())
 	}
 
+	if cfg.EnableCNI {
+		installSettings = append(installSettings,
+			"--set", "components.cni.namespace=kube-system",
+			"--set", "components.cni.enabled=true")
+	}
+
 	// Include all user-specified values.
 	for k, v := range cfg.Values {
 		installSettings = append(installSettings, "--set", fmt.Sprintf("values.%s=%s", k, v))

--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -647,15 +647,13 @@ func (i *operatorComponent) generateCommonInstallSettings(cfg Config, cluster cl
 			"--set", "values.global.network="+cluster.NetworkName())
 	}
 
-	if cfg.EnableCNI {
-		installSettings = append(installSettings,
-			"--set", "components.cni.namespace=kube-system",
-			"--set", "components.cni.enabled=true")
-	}
-
-	// Include all user-specified values.
+	// Include all user-specified values and configuration options.
 	for k, v := range cfg.Values {
 		installSettings = append(installSettings, "--set", fmt.Sprintf("values.%s=%s", k, v))
+	}
+
+	for k, v := range cfg.OperatorOptions {
+		installSettings = append(installSettings, "--set", fmt.Sprintf("%s=%s", k, v))
 	}
 	return installSettings, nil
 }

--- a/tests/integration/tests.mk
+++ b/tests/integration/tests.mk
@@ -58,6 +58,8 @@ else
 	_INTEGRATION_TEST_FLAGS += --istio.test.kube.config=$(_INTEGRATION_TEST_KUBECONFIG)
 endif
 
+_INTEGRATION_TEST_FLAGS += --helmValues=components.cni.enabled=true,components.cni.namespace=kube-system
+
 test.integration.analyze: test.integration...analyze
 
 test.integration.%.analyze: | $(JUNIT_REPORT) check-go-tag

--- a/tests/integration/tests.mk
+++ b/tests/integration/tests.mk
@@ -58,8 +58,6 @@ else
 	_INTEGRATION_TEST_FLAGS += --istio.test.kube.config=$(_INTEGRATION_TEST_KUBECONFIG)
 endif
 
-_INTEGRATION_TEST_FLAGS += --istio.test.istio.operatorOptions=components.cni.enabled=true,components.cni.namespace=kube-system
-
 test.integration.analyze: test.integration...analyze
 
 test.integration.%.analyze: | $(JUNIT_REPORT) check-go-tag

--- a/tests/integration/tests.mk
+++ b/tests/integration/tests.mk
@@ -58,7 +58,7 @@ else
 	_INTEGRATION_TEST_FLAGS += --istio.test.kube.config=$(_INTEGRATION_TEST_KUBECONFIG)
 endif
 
-_INTEGRATION_TEST_FLAGS += --istio.test.kube.helm.values=components.cni.enabled=true,components.cni.namespace=kube-system
+_INTEGRATION_TEST_FLAGS += --istio.test.istio.operatorOptions=components.cni.enabled=true,components.cni.namespace=kube-system
 
 test.integration.analyze: test.integration...analyze
 

--- a/tests/integration/tests.mk
+++ b/tests/integration/tests.mk
@@ -58,6 +58,8 @@ else
 	_INTEGRATION_TEST_FLAGS += --istio.test.kube.config=$(_INTEGRATION_TEST_KUBECONFIG)
 endif
 
+_INTEGRATION_TEST_FLAGS += --istio.test.istio.enableCNI=true
+
 test.integration.analyze: test.integration...analyze
 
 test.integration.%.analyze: | $(JUNIT_REPORT) check-go-tag

--- a/tests/integration/tests.mk
+++ b/tests/integration/tests.mk
@@ -58,7 +58,7 @@ else
 	_INTEGRATION_TEST_FLAGS += --istio.test.kube.config=$(_INTEGRATION_TEST_KUBECONFIG)
 endif
 
-_INTEGRATION_TEST_FLAGS += --helmValues=components.cni.enabled=true,components.cni.namespace=kube-system
+_INTEGRATION_TEST_FLAGS += --istio.test.kube.helm.values=components.cni.enabled=true,components.cni.namespace=kube-system
 
 test.integration.analyze: test.integration...analyze
 

--- a/tests/integration/tests.mk
+++ b/tests/integration/tests.mk
@@ -58,8 +58,6 @@ else
 	_INTEGRATION_TEST_FLAGS += --istio.test.kube.config=$(_INTEGRATION_TEST_KUBECONFIG)
 endif
 
-_INTEGRATION_TEST_FLAGS += --istio.test.istio.enableCNI=true
-
 test.integration.analyze: test.integration...analyze
 
 test.integration.%.analyze: | $(JUNIT_REPORT) check-go-tag


### PR DESCRIPTION
#31765 I would like to enable a CNI test suite at postsubmit first. If that looks good and not flaky, we can make it at presubmit.