### PR TITLE
Ability to tap into istio-agent to route debug messages to istiod

### DIFF
--- a/pilot/cmd/pilot-agent/options/agent.go
+++ b/pilot/cmd/pilot-agent/options/agent.go
@@ -28,12 +28,13 @@ const xdsHeaderPrefix = "XDS_HEADER_"
 
 func NewAgentOptions(proxy *model.Proxy) *istioagent.AgentOptions {
 	o := &istioagent.AgentOptions{
-		XDSRootCerts: xdsRootCA,
-		CARootCerts:  caRootCA,
-		XDSHeaders:   map[string]string{},
-		XdsUdsPath:   constants.DefaultXdsUdsPath,
-		IsIPv6:       proxy.SupportsIPv6(),
-		ProxyType:    proxy.Type,
+		XDSRootCerts:  xdsRootCA,
+		CARootCerts:   caRootCA,
+		XDSHeaders:    map[string]string{},
+		XdsUdsPath:    constants.DefaultXdsUdsPath,
+		XdsUdsTapPath: constants.DefaultXdsUdsTapPath,
+		IsIPv6:        proxy.SupportsIPv6(),
+		ProxyType:     proxy.Type,
 	}
 	extractXDSHeadersFromEnv(o)
 	if proxyXDSViaAgent {

--- a/pkg/config/constants/constants.go
+++ b/pkg/config/constants/constants.go
@@ -108,6 +108,9 @@ const (
 	// DefaultXdsUdsPath is the path used for XDS communication between istio-agent and proxy
 	DefaultXdsUdsPath = "./etc/istio/proxy/XDS"
 
+	// DefaultXdsUdsTapPath is the path used for XDS communication between debug tools piggybacking on the istio-agent
+	DefaultXdsUdsTapPath = "./etc/istio/proxy/xDS-tap"
+
 	// DefaultServiceAccountName is the default service account to use for remote cluster access.
 	DefaultServiceAccountName = "istio-reader-service-account"
 

--- a/pkg/istio-agent/agent.go
+++ b/pkg/istio-agent/agent.go
@@ -127,6 +127,9 @@ type AgentOptions struct {
 
 	// Path to local UDS to communicate with Envoy
 	XdsUdsPath string
+
+	// Path to the local UDS tap, for debug tools to communicate with Istiod
+	XdsUdsTapPath string
 }
 
 // NewAgent hosts the functionality for local SDS and XDS. This consists of the local SDS server and

--- a/pkg/istio-agent/agent_test.go
+++ b/pkg/istio-agent/agent_test.go
@@ -374,6 +374,7 @@ func Setup(t *testing.T, opts ...func(a AgentTest) AgentTest) *AgentTest {
 		CARootCerts:      rootCert,
 		XDSRootCerts:     rootCert,
 		XdsUdsPath:       filepath.Join(d, "XDS"),
+		XdsUdsTapPath:    filepath.Join(d, "xDS-tap"),
 	}
 	// Run through opts again to apply settings
 	for _, opt := range opts {

--- a/pkg/istio-agent/xds_proxy_test.go
+++ b/pkg/istio-agent/xds_proxy_test.go
@@ -214,7 +214,8 @@ func setupXdsProxy(t *testing.T) *XdsProxy {
 	}
 	dir := t.TempDir()
 	ia := NewAgent(&proxyConfig, &AgentOptions{
-		XdsUdsPath: filepath.Join(dir, "XDS"),
+		XdsUdsPath:    filepath.Join(dir, "XDS"),
+		XdsUdsTapPath: filepath.Join(dir, "xDS-tap"),
 	}, secOpts)
 	t.Cleanup(func() {
 		ia.Close()


### PR DESCRIPTION
This is the next step for https://github.com/istio/istio/issues/22274

This PR causes the sidecar agent to create a special file _/etc/istio/proxy/xDS-tap_

In the future, we will add either a separate binary or subcommand to istio-agent that will invoke that file via GRPC.

I have been testing this on my Mac, using a sleeping script instead of a real Envoy.  I have been testing it like this:

```
cat > /tmp/connreq7.json <<EOM
{
  "node": {"id": "sidecar~1.1.1.1~debug~cluster.local", "metadata": {"NAMESPACE": "default", "GENERATOR": "event", "ISTIO_VERSION": "1.9.1"}},
  "typeUrl": "istio.io/debug/syncz"
}
EOM
```

Then

```
(cat /tmp/connreq7.json; sleep 2) |  grpcurl -d @ -plaintext -unix ~/go/src/istio.io/istio/etc/istio/proxy/xDS-tap envoy.service.discovery.v3.AggregatedDiscoveryService/StreamAggregatedResources
```

It works for me.

The data I send to GRPC is almost the same as what is sent now by `istioctl x proxy-status`, except I had to add `"NAMESPACE": "default"`.  This is because Istiod rejects requests by an existing pod for another namespace.

@howardjohn @therealmitchconnors Does this match your expectations?  The code was less than I thought it would be.  The only thing I can think of adding to it is a way to disable it.