### PR TITLE
Add vm as server workload to pass through filter chain security integration tests 

### DIFF
--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -375,6 +375,20 @@ spec:
              --bind-localhost={{ $p.Port }} \
 {{- end }}
 {{- end }}
+{{- range $i, $p := $.WorkloadOnlyPorts }}
+{{- if eq .Protocol "TCP" }}
+             --tcp \
+{{- else }}
+             --port \
+{{- end }}
+             "{{ $p.Port }}" \
+{{- if $p.TLS }}
+             --tls={{ $p.Port }} \
+{{- end }}
+{{- if $p.ServerFirst }}
+             --server-first={{ $p.Port }} \
+{{- end }}
+{{- end }}
              --crt=/var/lib/istio/cert.crt \
              --key=/var/lib/istio/cert.key
         env:

--- a/tests/integration/security/pass_through_filter_chain_test.go
+++ b/tests/integration/security/pass_through_filter_chain_test.go
@@ -614,14 +614,17 @@ spec:
 						echotest.Not(func(instances echo.Instances) echo.Instances { return instances.Match(echo.IsNaked()) }),
 						echotest.Not(func(instances echo.Instances) echo.Instances { return instances.Match(echo.IsExternal()) }),
 						echotest.Not(func(instances echo.Instances) echo.Instances { return instances.Match(util.IsMultiversion()) }),
-						// TODO(JimmyCYJ): WorkloadOnlyPorts are missing in the VM deployment configuration yaml.
-						echotest.Not(func(instances echo.Instances) echo.Instances { return instances.Match(echo.IsVirtualMachine()) }),
 						func(instances echo.Instances) echo.Instances { return instances.Match(echo.Namespace(ns.Name())) },
 					).
 					Run(func(t framework.TestContext, src echo.Instance, dest echo.Instances) {
 						clusterName := src.Config().Cluster.StableName()
 						if dest[0].Config().Cluster.StableName() != clusterName {
 							// The workaround for mTLS does not work on cross cluster traffic.
+							t.Skip()
+						}
+						if src.Config().Service == dest[0].Config().Service {
+							// The workaround for mTLS does not work on a workload calling itself.
+							// Skip vm->vm requests.
 							t.Skip()
 						}
 						nameSuffix := "mtls"


### PR DESCRIPTION

This is a followup PR of https://github.com/istio/istio/pull/31663

- Fix missing `WorkloadOnlyPorts` in VM deployment 
- Add VM as server workload to the [security/pass_through_filter_chain_test.go](https://github.com/istio/istio/blob/master/tests/integration/security/pass_through_filter_chain_test.go)


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any changes that may affect Istio users.