### PR TITLE
add delimit for status report of distribution

### DIFF
--- a/pilot/pkg/status/reporter.go
+++ b/pilot/pkg/status/reporter.go
@@ -34,6 +34,11 @@ import (
 	"istio.io/pkg/ledger"
 )
 
+func GenStatusReporterMapKey(conID string, distributionType xds.EventType) string {
+	key := conID + "~" + distributionType
+	return key
+}
+
 func NewIstioContext(stop <-chan struct{}) context.Context {
 	ctx, cancel := context.WithCancel(context.Background())
 	go func() {
@@ -276,7 +281,7 @@ type distributionEvent struct {
 }
 
 func (r *Reporter) QueryLastNonce(conID string, distributionType xds.EventType) (noncePrefix string) {
-	key := conID + distributionType
+	key := GenStatusReporterMapKey(conID, distributionType)
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	return r.status[key]
@@ -311,7 +316,7 @@ func (r *Reporter) readFromEventQueue() {
 func (r *Reporter) processEvent(conID string, distributionType xds.EventType, nonce string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	key := conID + distributionType // TODO: delimit?
+	key := GenStatusReporterMapKey(conID, distributionType)
 	r.deleteKeyFromReverseMap(key)
 	var version string
 	if len(nonce) > 12 {
@@ -345,7 +350,7 @@ func (r *Reporter) RegisterDisconnect(conID string, types []xds.EventType) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	for _, xdsType := range types {
-		key := conID + xdsType // TODO: delimit?
+		key := GenStatusReporterMapKey(conID, xdsType)
 		r.deleteKeyFromReverseMap(key)
 		delete(r.status, key)
 	}

--- a/pilot/pkg/status/reporter_test.go
+++ b/pilot/pkg/status/reporter_test.go
@@ -36,14 +36,14 @@ func TestStatusMaps(t *testing.T) {
 	r.processEvent("conD", typ, "d")
 	RegisterTestingT(t)
 	x := struct{}{}
-	Expect(r.status).To(Equal(map[string]string{"conA": "a", "conB": "a", "conC": "c", "conD": "d"}))
-	Expect(r.reverseStatus).To(Equal(map[string]map[string]struct{}{"a": {"conA": x, "conB": x}, "c": {"conC": x}, "d": {"conD": x}}))
+	Expect(r.status).To(Equal(map[string]string{"conA~": "a", "conB~": "a", "conC~": "c", "conD~": "d"}))
+	Expect(r.reverseStatus).To(Equal(map[string]map[string]struct{}{"a": {"conA~": x, "conB~": x}, "c": {"conC~": x}, "d": {"conD~": x}}))
 	r.processEvent("conA", typ, "d")
-	Expect(r.status).To(Equal(map[string]string{"conA": "d", "conB": "a", "conC": "c", "conD": "d"}))
-	Expect(r.reverseStatus).To(Equal(map[string]map[string]struct{}{"a": {"conB": x}, "c": {"conC": x}, "d": {"conD": x, "conA": x}}))
+	Expect(r.status).To(Equal(map[string]string{"conA~": "d", "conB~": "a", "conC~": "c", "conD~": "d"}))
+	Expect(r.reverseStatus).To(Equal(map[string]map[string]struct{}{"a": {"conB~": x}, "c": {"conC~": x}, "d": {"conD~": x, "conA~": x}}))
 	r.RegisterDisconnect("conA", []xds.EventType{typ})
-	Expect(r.status).To(Equal(map[string]string{"conB": "a", "conC": "c", "conD": "d"}))
-	Expect(r.reverseStatus).To(Equal(map[string]map[string]struct{}{"a": {"conB": x}, "c": {"conC": x}, "d": {"conD": x}}))
+	Expect(r.status).To(Equal(map[string]string{"conB~": "a", "conC~": "c", "conD~": "d"}))
+	Expect(r.reverseStatus).To(Equal(map[string]map[string]struct{}{"a": {"conB~": x}, "c": {"conC~": x}, "d": {"conD~": x}}))
 }
 
 func initReporterWithoutStarting() (out Reporter) {


### PR DESCRIPTION
I think it's very necessary that there should be a delimiter for status reporter map between connection ID and distribution. Not just for unique identifier of status map, but also the distinguishing key. 

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[x] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
