### PR TITLE
dns: add individual pod endpoints cross cluster also

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/name_table.go
+++ b/pilot/pkg/networking/core/v1alpha3/name_table.go
@@ -79,7 +79,7 @@ func (configgen *ConfigGeneratorImpl) BuildNameTable(node *model.Proxy, push *mo
 				svc.Resolution == model.Passthrough && len(svc.Ports) > 0 {
 				for _, instance := range push.ServiceInstancesByPort(svc, svc.Ports[0].Port, nil) {
 					// Add individual addresses even for cross cluster.
-					if instance.Endpoint.SubDomain != "" {
+					if instance.Endpoint.SubDomain != "" && instance.Endpoint.Network == node.Metadata.Network {
 						// Follow k8s pods dns naming convention of "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>"
 						// i.e. "mysql-0.mysql.default.svc.cluster.local".
 						parts := strings.SplitN(string(svc.Hostname), ".", 2)


### PR DESCRIPTION
With this https://github.com/istio/istio/pull/31067 we are skipping cross cluster endpoints. However for individual pod endpoints for stateful sets we do not need load balancing and we need to add it even for cross cluster
[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ X] Does not have any changes that may affect Istio users.
