### PR TITLE
use a single remote secret controller to handle kube client lifecycle

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -28,8 +28,6 @@ import (
 	"sync"
 	"time"
 
-	"istio.io/istio/pkg/kube/secretcontroller"
-
 	middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	prom "github.com/prometheus/client_golang/prometheus"
@@ -66,6 +64,7 @@ import (
 	istiokeepalive "istio.io/istio/pkg/keepalive"
 	kubelib "istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/inject"
+	"istio.io/istio/pkg/kube/secretcontroller"
 	"istio.io/istio/pkg/security"
 	"istio.io/istio/pkg/spiffe"
 	"istio.io/istio/security/pkg/k8s/chiron"

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -300,7 +300,7 @@ func NewServer(args *PilotArgs) (*Server, error) {
 
 	s.initDiscoveryService(args)
 
-	s.initSDSServer(args)
+	s.initSDSServer()
 
 	// Notice that the order of authenticators matters, since at runtime
 	// authenticators are activated sequentially and the first successful attempt
@@ -474,7 +474,7 @@ func (s *Server) WaitUntilCompletion() {
 }
 
 // initSDSServer starts the SDS server
-func (s *Server) initSDSServer(args *PilotArgs) {
+func (s *Server) initSDSServer() {
 	if s.kubeClient != nil {
 		if !features.EnableXDSIdentityCheck {
 			// Make sure we have security

--- a/pilot/pkg/bootstrap/servicecontroller.go
+++ b/pilot/pkg/bootstrap/servicecontroller.go
@@ -124,10 +124,7 @@ func (s *Server) initKubeRegistry(args *PilotArgs) (err error) {
 	s.addTerminatingStartFunc(mc.Run)
 
 	// start remote cluster controllers
-	s.addStartFunc(func(stop <-chan struct{}) error {
-		s.multiclusterSecrets.Run(stop)
-		return nil
-	})
+	s.addTerminatingStartFunc(s.multiclusterSecrets.Run)
 
 	return
 }

--- a/pilot/pkg/bootstrap/servicecontroller.go
+++ b/pilot/pkg/bootstrap/servicecontroller.go
@@ -18,8 +18,6 @@ import (
 	"fmt"
 	"time"
 
-	"istio.io/istio/pkg/kube/secretcontroller"
-
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry"
 	"istio.io/istio/pilot/pkg/serviceregistry/aggregate"
@@ -27,6 +25,7 @@ import (
 	"istio.io/istio/pilot/pkg/serviceregistry/mock"
 	"istio.io/istio/pilot/pkg/serviceregistry/serviceentry"
 	"istio.io/istio/pkg/config/host"
+	"istio.io/istio/pkg/kube/secretcontroller"
 	"istio.io/pkg/log"
 )
 

--- a/pilot/pkg/secrets/kube/secrets_test.go
+++ b/pilot/pkg/secrets/kube/secrets_test.go
@@ -153,9 +153,9 @@ func TestForCluster(t *testing.T) {
 	defer close(stop)
 	localClient := kube.NewFakeClient()
 	remoteClient := kube.NewFakeClient()
-	sc := NewMulticluster(localClient, "local", "", stop)
-	sc.addMemberCluster(remoteClient, "remote")
-	sc.addMemberCluster(remoteClient, "remote2")
+	sc := NewMulticluster(localClient, "local")
+	_ = sc.OnNewCluster(remoteClient, nil, "remote")
+	_ = sc.OnNewCluster(remoteClient, nil, "remote2")
 	cases := []struct {
 		cluster string
 		allowed bool
@@ -182,8 +182,8 @@ func TestAuthorize(t *testing.T) {
 	remoteClient := kube.NewFakeClient()
 	allowIdentities(localClient, "system:serviceaccount:ns-local:sa-allowed")
 	allowIdentities(remoteClient, "system:serviceaccount:ns-remote:sa-allowed")
-	sc := NewMulticluster(localClient, "local", "", stop)
-	sc.addMemberCluster(remoteClient, "remote")
+	sc := NewMulticluster(localClient, "local")
+	_ = sc.OnNewCluster(remoteClient, nil, "remote")
 	cases := []struct {
 		sa      string
 		ns      string
@@ -236,9 +236,12 @@ func TestSecretsControllerMulticluster(t *testing.T) {
 	localClient := kube.NewFakeClient(secretsLocal...)
 	remoteClient := kube.NewFakeClient(secretsRemote...)
 	otherRemoteClient := kube.NewFakeClient()
-	sc := NewMulticluster(localClient, "local", "", stop)
-	sc.addMemberCluster(remoteClient, "remote")
-	sc.addMemberCluster(otherRemoteClient, "other")
+	sc := NewMulticluster(localClient, "local")
+	_ = sc.OnNewCluster(remoteClient, nil, "remote")
+	_ = sc.OnNewCluster(otherRemoteClient, nil, "other")
+	localClient.RunAndWait(stop)
+	remoteClient.RunAndWait(stop)
+	otherRemoteClient.RunAndWait(stop)
 	cases := []struct {
 		name      string
 		namespace string

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -87,8 +87,7 @@ type Multicluster struct {
 	revision     string
 
 	// rootNamespace where we get cluster-access secrets
-	rootNamespace    string
-	secretController *secretcontroller.Controller
+	rootNamespace string
 }
 
 // NewMulticluster initializes data structure to store multicluster information

--- a/pilot/pkg/xds/fake.go
+++ b/pilot/pkg/xds/fake.go
@@ -157,7 +157,7 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 		registries = append(registries, k8s)
 	}
 
-	sc := kubesecrets.NewMulticluster(defaultKubeClient, "", "", stop)
+	sc := kubesecrets.NewMulticluster(defaultKubeClient, "")
 	s.Generators[v3.SecretType] = NewSecretGen(sc, &model.DisabledCache{})
 	defaultKubeClient.RunAndWait(stop)
 


### PR DESCRIPTION
- [X] refactor to use single remote secret controller
- [ ] healthcheck and requeue for unreachable apiserver/any error initializing handlers (could be permissions)
  - this could be more complicated than that... we may actually have to make the HasSynced hiearchy move away from AggregateRegistry and into the secret controller/MulticlusterHandlers.. not sure the best way to handle this yet. 
- [ ] integration tests
---

Part of a fix for https://github.com/istio/istio/issues/30838

The initial fix should allow us to do a quick healthcheck/test request using the newly generated kube client. If the check fails, we don't block `HasSynced`. 

It is easier to accomplish this if everything shares a single remote-secrets controller. The remote secrets controller utilizes a queue, so we can easily retry clusters that aren't ready at first.

For example, if 2 remote secrets exist on startup, the queue looks like this (rightmost item is next to be dequeued):

```
ready, secret2, secret1
```

If an error occurs while processing the remote secret for a cluster, we can tear down anything we've partially set up for the cluster, and requeue the secret to be processed later (possibly with some delay). The processing failure could be due to reachability, a permissions issue while initializing the controllers, or any other error. 

```
secret1, ready, secret2
```

### Old structure:

Before we used 2 separate controllers watching remote secrets, which would each create their own kube clients and manage their lifecycles.

```
remoteSecretController -> k8s client -> auth secrets controller -> RunAndWait (shared server stopCh)
remoteSecretController -> k8s client -> multicluster k8s controller -> RunAndWait (individual stopCh for each cluster)
```

### New Structure

1. a single secrets controller
2. different sub-controllers will share k8s clients for each cluster
3. RunAndWait is called last, by SecretsController, with a per-cluster stopCh to allow gracefully removing a cluster. 

```
                                                         ╭ multicluster k8s controller ╮
remoteSecretController -> k8s client, per-cluster stopCh ┤                             ├-> RunAndWait(per-cluster stop)
                                                         ╰   auth secrets controller   ╯
```