### PR TITLE
don't block istiod readiness on remote clusters

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -835,6 +835,9 @@ func (s *Server) waitForCacheSync(stop <-chan struct{}) bool {
 
 // cachesSynced checks whether caches have been synced.
 func (s *Server) cachesSynced() bool {
+	if s.multicluster != nil && !s.multicluster.HasSynced() {
+		return false
+	}
 	if !s.ServiceController().HasSynced() {
 		return false
 	}

--- a/pilot/pkg/bootstrap/servicecontroller.go
+++ b/pilot/pkg/bootstrap/servicecontroller.go
@@ -35,7 +35,7 @@ func (s *Server) ServiceController() *aggregate.Controller {
 func (s *Server) initServiceControllers(args *PilotArgs) error {
 	serviceControllers := s.ServiceController()
 
-	s.serviceEntryStore = serviceentry.NewServiceDiscovery(s.configController, s.environment.IstioConfigStore, s.XDSServer)
+	s.serviceEntryStore = serviceentry.NewServiceDiscovery(s.clusterID, s.configController, s.environment.IstioConfigStore, s.XDSServer)
 	serviceControllers.AddRegistry(s.serviceEntryStore)
 
 	registered := make(map[serviceregistry.ProviderID]bool)

--- a/pilot/pkg/config/aggregate/config.go
+++ b/pilot/pkg/config/aggregate/config.go
@@ -180,6 +180,16 @@ func (cr *storeCache) HasSynced() bool {
 	return true
 }
 
+func (cr *storeCache) SyncErr() error {
+	var errs error
+	for _, cache := range cr.caches {
+		if err := cache.SyncErr(); err != nil {
+			errs = multierror.Append(errs, err)
+		}
+	}
+	return errs
+}
+
 func (cr *storeCache) RegisterEventHandler(kind config.GroupVersionKind, handler func(config.Config, config.Config, model.Event)) {
 	for _, cache := range cr.caches {
 		if _, exists := cache.Schemas().FindByGroupVersionKind(kind); exists {

--- a/pilot/pkg/config/kube/crdclient/client.go
+++ b/pilot/pkg/config/kube/crdclient/client.go
@@ -28,9 +28,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/hashicorp/go-multierror"
-
 	jsonmerge "github.com/evanphx/json-patch/v5"
+	"github.com/hashicorp/go-multierror"
 	"gomodules.xyz/jsonpatch/v2"
 	crd "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"

--- a/pilot/pkg/config/kube/gateway/controller.go
+++ b/pilot/pkg/config/kube/gateway/controller.go
@@ -209,3 +209,8 @@ func (c controller) Run(stop <-chan struct{}) {
 func (c controller) HasSynced() bool {
 	return c.cache.HasSynced()
 }
+
+func (c *controller) SyncErr() error {
+	// TODO implement if needed
+	return nil
+}

--- a/pilot/pkg/config/kube/ingress/controller.go
+++ b/pilot/pkg/config/kube/ingress/controller.go
@@ -288,6 +288,11 @@ func (c *controller) HasSynced() bool {
 		(c.classes == nil || c.classes.Informer().HasSynced())
 }
 
+func (c *controller) SyncErr() error {
+	// TODO implement if needed
+	return nil
+}
+
 func (c *controller) Run(stop <-chan struct{}) {
 	go func() {
 		cache.WaitForCacheSync(stop, c.HasSynced)

--- a/pilot/pkg/config/kube/ingressv1/controller.go
+++ b/pilot/pkg/config/kube/ingressv1/controller.go
@@ -242,6 +242,11 @@ func (c *controller) HasSynced() bool {
 		(c.classes == nil || c.classes.Informer().HasSynced())
 }
 
+func (c *controller) SyncErr() error {
+	// TODO implement if needed
+	return nil
+}
+
 func (c *controller) Run(stop <-chan struct{}) {
 	go func() {
 		cache.WaitForCacheSync(stop, c.HasSynced)

--- a/pilot/pkg/config/memory/controller.go
+++ b/pilot/pkg/config/memory/controller.go
@@ -59,6 +59,10 @@ func (c *controller) HasSynced() bool {
 	return true
 }
 
+func (c *controller) SyncErr() error {
+	return nil
+}
+
 func (c *controller) Run(stop <-chan struct{}) {
 	c.monitor.Run(stop)
 }

--- a/pilot/pkg/model/config.go
+++ b/pilot/pkg/model/config.go
@@ -166,6 +166,8 @@ type ConfigStoreCache interface {
 
 	// HasSynced returns true after initial cache synchronization is complete
 	HasSynced() bool
+
+	SyncErr() error
 }
 
 // IstioConfigStore is a specialized interface to access config store using

--- a/pilot/pkg/networking/core/v1alpha3/fake.go
+++ b/pilot/pkg/networking/core/v1alpha3/fake.go
@@ -76,7 +76,8 @@ type TestOptions struct {
 	PushContextLock *sync.RWMutex
 
 	// If set, we will not run immediately, allowing adding event handlers, etc prior to start.
-	SkipRun bool
+	SkipRun   bool
+	ClusterID string
 }
 
 type ConfigGenTest struct {
@@ -114,7 +115,7 @@ func NewConfigGenTest(t test.Failer, opts TestOptions) *ConfigGenTest {
 	}
 
 	serviceDiscovery := aggregate.NewController(aggregate.Options{})
-	se := serviceentry.NewServiceDiscovery(configController, model.MakeIstioStore(configStore), &FakeXdsUpdater{})
+	se := serviceentry.NewServiceDiscovery(opts.ClusterID, configController, model.MakeIstioStore(configStore), &FakeXdsUpdater{})
 	// TODO allow passing in registry, for k8s, mem reigstry
 	serviceDiscovery.AddRegistry(se)
 	msd := memregistry.NewServiceDiscovery(opts.Services)

--- a/pilot/pkg/serviceregistry/aggregate/controller.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller.go
@@ -286,6 +286,7 @@ func (c *Controller) Running() bool {
 // HasSynced returns true when all registries have synced
 func (c *Controller) HasSynced() bool {
 	for _, r := range c.GetRegistries() {
+		// the readiness of multicluster registries are handled elsewhere
 		if r.Cluster() != c.configCluster {
 			continue
 		}

--- a/pilot/pkg/serviceregistry/aggregate/controller.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller.go
@@ -87,8 +87,8 @@ func (c *Controller) DeleteRegistry(clusterID string, providerID serviceregistry
 	log.Infof("Registry for the cluster %s has been deleted.", clusterID)
 }
 
-// getAllRegistries returns a copy of all registries
-func (c *Controller) getAllRegistries() []serviceregistry.Instance {
+// GetAllRegistries returns a copy of all registries
+func (c *Controller) GetAllRegistries() []serviceregistry.Instance {
 	c.storeLock.RLock()
 	defer c.storeLock.RUnlock()
 
@@ -282,7 +282,7 @@ func (c *Controller) GetProxyWorkloadLabels(proxy *model.Proxy) labels.Collectio
 
 // Run starts all the controllers
 func (c *Controller) Run(stop <-chan struct{}) {
-	for _, r := range c.getAllRegistries() {
+	for _, r := range c.GetAllRegistries() {
 		go r.Run(stop)
 	}
 	c.running.Store(true)

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -221,7 +221,7 @@ func (m *Multicluster) AddMemberCluster(client kubelib.Client, clusterID string)
 			// TODO only do this for non-remotes, can't guarantee CRDs in remotes (depends on https://github.com/istio/istio/pull/29824)
 			if configStore, err := createConfigStore(client, m.revision, options); err == nil {
 				m.remoteKubeControllers[clusterID].configStore = configStore
-				m.remoteKubeControllers[clusterID].workloadEntryStore = serviceentry.NewServiceDiscovery(
+				m.remoteKubeControllers[clusterID].workloadEntryStore = serviceentry.NewServiceDiscovery(clusterID,
 					configStore, model.MakeIstioStore(configStore), options.XDSUpdater, serviceentry.DisableServiceEntryProcessing())
 				m.serviceController.AddRegistry(m.remoteKubeControllers[clusterID].workloadEntryStore)
 				// Services can select WorkloadEntry from the same cluster. We only duplicate the Service to configure kube-dns.

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -22,13 +22,10 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-multierror"
-
-	"k8s.io/client-go/tools/cache"
-
 	"go.uber.org/atomic"
-
 	"golang.org/x/sync/errgroup"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
 
 	"istio.io/istio/pilot/pkg/config/kube/crdclient"
 	"istio.io/istio/pilot/pkg/features"

--- a/pilot/pkg/serviceregistry/serviceentry/servicediscovery.go
+++ b/pilot/pkg/serviceregistry/serviceentry/servicediscovery.go
@@ -67,6 +67,7 @@ type configKey struct {
 type ServiceEntryStore struct { // nolint:golint
 	XdsUpdater model.XDSUpdater
 	store      model.IstioConfigStore
+	clusterID  string
 
 	storeMutex sync.RWMutex
 
@@ -97,6 +98,7 @@ func DisableServiceEntryProcessing() ServiceDiscoveryOption {
 
 // NewServiceDiscovery creates a new ServiceEntry discovery service
 func NewServiceDiscovery(
+	clusterID string,
 	configController model.ConfigStoreCache,
 	store model.IstioConfigStore,
 	xdsUpdater model.XDSUpdater,
@@ -105,6 +107,7 @@ func NewServiceDiscovery(
 	s := &ServiceEntryStore{
 		XdsUpdater:                 xdsUpdater,
 		store:                      store,
+		clusterID:                  clusterID,
 		ip2instance:                map[string][]*model.ServiceInstance{},
 		instances:                  map[instancesKey]map[configKey][]*model.ServiceInstance{},
 		workloadInstancesByIP:      map[string]*model.WorkloadInstance{},
@@ -460,9 +463,7 @@ func (s *ServiceEntryStore) Provider() serviceregistry.ProviderID {
 }
 
 func (s *ServiceEntryStore) Cluster() string {
-	// DO NOT ASSIGN CLUSTER ID to non-k8s registries. This will prevent service entries with multiple
-	// VIPs or CIDR ranges in the address field
-	return ""
+	return s.clusterID
 }
 
 // AppendServiceHandler adds service resource event handler. Service Entries does not use these handlers.

--- a/pilot/pkg/serviceregistry/serviceentry/servicediscovery_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/servicediscovery_test.go
@@ -135,7 +135,7 @@ func initServiceDiscoveryWithOpts(opts ...ServiceDiscoveryOption) (model.IstioCo
 	}
 
 	istioStore := model.MakeIstioStore(configController)
-	serviceController := NewServiceDiscovery(configController, istioStore, xdsUpdater, opts...)
+	serviceController := NewServiceDiscovery("", configController, istioStore, xdsUpdater, opts...)
 	return istioStore, serviceController, eventch, func() {
 		stop <- channelTerminal{}
 	}

--- a/pilot/pkg/serviceregistry/serviceregistry_test.go
+++ b/pilot/pkg/serviceregistry/serviceregistry_test.go
@@ -142,7 +142,7 @@ func setupTest(t *testing.T) (
 	go configController.Run(stop)
 
 	istioStore := model.MakeIstioStore(configController)
-	se := serviceentry.NewServiceDiscovery(configController, istioStore, xdsUpdater)
+	se := serviceentry.NewServiceDiscovery("", configController, istioStore, xdsUpdater)
 	client.RunAndWait(stop)
 
 	kc.AppendWorkloadHandler(se.WorkloadInstanceHandler)

--- a/pilot/pkg/xds/fake.go
+++ b/pilot/pkg/xds/fake.go
@@ -167,6 +167,7 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 	defaultKubeClient.RunAndWait(stop)
 
 	cg := v1alpha3.NewConfigGenTest(t, v1alpha3.TestOptions{
+		ClusterID:           defaultKubeController.Cluster(),
 		Configs:             opts.Configs,
 		ConfigString:        opts.ConfigString,
 		ConfigTemplateInput: opts.ConfigTemplateInput,

--- a/pilot/pkg/xds/simple.go
+++ b/pilot/pkg/xds/simple.go
@@ -107,7 +107,7 @@ func NewXDS(stop chan struct{}) *SimpleServer {
 	// Endpoints/Clusters - using the config store for ServiceEntries
 	serviceControllers := aggregate.NewController(aggregate.Options{})
 
-	serviceEntryStore := serviceentry.NewServiceDiscovery(configController, s.MemoryConfigStore, ds)
+	serviceEntryStore := serviceentry.NewServiceDiscovery("", configController, s.MemoryConfigStore, ds)
 	serviceEntryRegistry := serviceregistry.Simple{
 		ProviderID:       "External",
 		Controller:       serviceEntryStore,

--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -251,6 +251,7 @@ func (i *operatorComponent) Dump(ctx resource.Context) {
 	kube2.DumpPods(ctx, d, ns)
 	for _, cluster := range ctx.Clusters().Kube() {
 		kube2.DumpDebug(cluster, d, "configz")
+		kube2.DumpDebug(cluster, d, "clusterz")
 	}
 }
 


### PR DESCRIPTION
alternative to #31768 

We want to avoid starting a new istiod instance when it can't reach remote clusters due to transient errors.
We also want to avoid persistent errors connecting to other clusters from stopping any istiod's from coming up. 

To compromise, components that read from remote clusters should expose both: `HasSynced` and an additional function `SyncErr`

While waiting for remote cluster controllers to sync, we will block istiod's readiness. `SyncErr` lets us know if `HasSynced` is returning `false` due to an error rather than us just taking a while to sync. 

After a timeout, if we find an error, we allow the server to ready, assuming the error is persistent.
If there is no error after the timeout, we assume the startup is slow. 


Istiod will _not_ ready if any controllers for the local/config cluster fail to flip `HasSynced` to `true`. 


---

This approach has tradeoffs: it leaves istiods that have endpoints for remote clusters whose API servers are no longer reachable, allowing new ones to come up with inconsistent endpoints _eventually_. 

Somehow we need to either get rid of the old istiods or have them drop the endpoints, if we consider API server reachability to be tied with the endpoints' health. 

