### PR TITLE
Add metric for XDS config sizes by namespace and resource type.

### DIFF
--- a/pilot/pkg/xds/gen.go
+++ b/pilot/pkg/xds/gen.go
@@ -123,6 +123,9 @@ func (s *DiscoveryServer) pushXds(con *Connection, push *model.PushContext,
 		Resources:    res,
 	}
 
+	configSize := ResourceSize(res)
+	configSizeBytes.With(typeTag.Value(w.TypeUrl)).Record(float64(configSize))
+
 	if err := con.send(resp); err != nil {
 		recordSendError(w.TypeUrl, con.ConID, err)
 		return err
@@ -133,12 +136,13 @@ func (s *DiscoveryServer) pushXds(con *Connection, push *model.PushContext,
 		if log.DebugEnabled() {
 			// Add additional information to logs when debug mode enabled
 			log.Infof("%s: PUSH%s for node:%s resources:%d size:%s nonce:%v version:%v",
-				v3.GetShortType(w.TypeUrl), req.PushReason(), con.proxy.ID, len(res), util.ByteCount(ResourceSize(res)), resp.Nonce, resp.VersionInfo)
+				v3.GetShortType(w.TypeUrl), req.PushReason(), con.proxy.ID, len(res), util.ByteCount(configSize), resp.Nonce, resp.VersionInfo)
 		} else {
 			log.Infof("%s: PUSH%s for node:%s resources:%d size:%s",
-				v3.GetShortType(w.TypeUrl), req.PushReason(), con.proxy.ID, len(res), util.ByteCount(ResourceSize(res)))
+				v3.GetShortType(w.TypeUrl), req.PushReason(), con.proxy.ID, len(res), util.ByteCount(configSize))
 		}
 	}
+
 	return nil
 }
 

--- a/pilot/pkg/xds/monitoring.go
+++ b/pilot/pkg/xds/monitoring.go
@@ -176,6 +176,17 @@ var (
 	inboundEDSUpdates     = inboundUpdates.With(typeTag.Value("eds"))
 	inboundServiceUpdates = inboundUpdates.With(typeTag.Value("svc"))
 	inboundServiceDeletes = inboundUpdates.With(typeTag.Value("svcdelete"))
+
+	configSizeBytes = monitoring.NewDistribution(
+		"pilot_xds_config_size_bytes",
+		"Distribution of configuration sizes pushed to clients",
+		// Important boundaries: 10K, 1M, 4M, 10M, 40M
+		// 4M default limit for gRPC, 10M config will start to strain system,
+		// 40M is likely upper-bound on config sizes supported.
+		[]float64{1, 10000, 1000000, 4000000, 10000000, 40000000},
+		monitoring.WithLabels(typeTag),
+		monitoring.WithUnit(monitoring.Bytes),
+	)
 )
 
 func recordXDSClients(version string, delta float64) {
@@ -262,5 +273,6 @@ func init() {
 		totalDelayedPushes,
 		totalDelayedPushTimeouts,
 		pilotSDSCertificateErrors,
+		configSizeBytes,
 	)
 }

--- a/releasenotes/notes/istiod-config-size-bytes.yaml
+++ b/releasenotes/notes/istiod-config-size-bytes.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: networking
+releaseNotes:
+- |
+  **Added** new metric for tracking distribution of configuration resource sizes being pushed by istiod.

--- a/releasenotes/notes/istiod-config-size-bytes.yaml
+++ b/releasenotes/notes/istiod-config-size-bytes.yaml
@@ -1,6 +1,8 @@
 apiVersion: release-notes/v2
 kind: feature
 area: networking
+issue:
+  - 31772
 releaseNotes:
 - |
   **Added** new metric for tracking distribution of configuration resource sizes being pushed by istiod.


### PR DESCRIPTION
There is a need to monitor config sizes, particularly as they approach limits. This would allow tracking of p99, etc., for config sizes by resource type.

Example output:

```
pilot_xds_config_size_bytes_bucket{type="type.googleapis.com/envoy.config.listener.v3.Listener",le="1"} 0
pilot_xds_config_size_bytes_bucket{type="type.googleapis.com/envoy.config.listener.v3.Listener",le="10000"} 0
pilot_xds_config_size_bytes_bucket{type="type.googleapis.com/envoy.config.listener.v3.Listener",le="1e+06"} 19
pilot_xds_config_size_bytes_bucket{type="type.googleapis.com/envoy.config.listener.v3.Listener",le="4e+06"} 19
pilot_xds_config_size_bytes_bucket{type="type.googleapis.com/envoy.config.listener.v3.Listener",le="1e+07"} 19
pilot_xds_config_size_bytes_bucket{type="type.googleapis.com/envoy.config.listener.v3.Listener",le="4e+07"} 19
pilot_xds_config_size_bytes_bucket{type="type.googleapis.com/envoy.config.listener.v3.Listener",le="+Inf"} 19
pilot_xds_config_size_bytes_sum{type="type.googleapis.com/envoy.config.listener.v3.Listener"} 1.162747e+06
pilot_xds_config_size_bytes_count{type="type.googleapis.com/envoy.config.listener.v3.Listener"} 19
```

[ X ] Networking
[ X ] Policies and Telemetry
