### PR TITLE
Capture all mTLS traffic in permissive mode

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -132,7 +132,8 @@ var (
 	// properly use a HTTP or TCP listener
 	plaintextHTTPALPNs  = []string{"http/1.0", "http/1.1", "h2c"}
 	mtlsHTTPALPNs       = []string{"istio-http/1.0", "istio-http/1.1", "istio-h2"}
-	legacyMtlsHTTPALPNs = []string{"istio", "istio-http/1.0", "istio-http/1.1", "istio-h2"}
+
+	allIstioMtlsALPNs = []string{"istio", "istio-peer-exchange", "istio-http/1.0", "istio-http/1.1", "istio-h2"}
 
 	mtlsTCPWithMxcALPNs = []string{"istio-peer-exchange", "istio"}
 
@@ -183,7 +184,7 @@ var (
 	inboundPermissiveHTTPFilterChainMatchWithMxcOptions = []FilterChainMatchOptions{
 		{
 			// HTTP over MTLS
-			ApplicationProtocols: legacyMtlsHTTPALPNs,
+			ApplicationProtocols: allIstioMtlsALPNs,
 			TransportProtocol:    xdsfilters.TLSTransportProtocol,
 			Protocol:             istionetworking.ListenerProtocolHTTP,
 			MTLS:                 true,
@@ -198,7 +199,7 @@ var (
 	inboundPermissiveTCPFilterChainMatchWithMxcOptions = []FilterChainMatchOptions{
 		{
 			// MTLS
-			ApplicationProtocols: mtlsTCPWithMxcALPNs,
+			ApplicationProtocols: allIstioMtlsALPNs,
 			TransportProtocol:    xdsfilters.TLSTransportProtocol,
 			Protocol:             istionetworking.ListenerProtocolTCP,
 			MTLS:                 true,

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -130,8 +130,8 @@ var (
 	// These are sniffed by the HTTP Inspector in the outbound listener
 	// We need to forward these ALPNs to upstream so that the upstream can
 	// properly use a HTTP or TCP listener
-	plaintextHTTPALPNs  = []string{"http/1.0", "http/1.1", "h2c"}
-	mtlsHTTPALPNs       = []string{"istio-http/1.0", "istio-http/1.1", "istio-h2"}
+	plaintextHTTPALPNs = []string{"http/1.0", "http/1.1", "h2c"}
+	mtlsHTTPALPNs      = []string{"istio-http/1.0", "istio-http/1.1", "istio-h2"}
 
 	allIstioMtlsALPNs = []string{"istio", "istio-peer-exchange", "istio-http/1.0", "istio-http/1.1", "istio-h2"}
 


### PR DESCRIPTION
Currently, our ALPN matching logic is not complete. As a result,
requests that come in with the wrong ALPN will be forwarded to the
application.

This changes our filter chains such that in permissive mode, Istio mTLS
traffic is *always* captured by a filter chain that will terminate the
TLS. Note that the traffic may not be valid - for example, raw TCP on a
filter chain with HCM, but we will fail at the Envoy level rather than
in the users application.
