### PR TITLE
Bind localhost to virtualOutbound listener 

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/listener_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_builder.go
@@ -383,12 +383,12 @@ func (lb *ListenerBuilder) buildVirtualOutboundListener(configgen *ConfigGenerat
 
 	filterChains := buildOutboundCatchAllNetworkFilterChains(configgen, lb.node, lb.push)
 
-	actualWildcard, _ := getActualWildcardAndLocalHost(lb.node)
+	_, actualLocalHost := getActualWildcardAndLocalHost(lb.node)
 
 	// add an extra listener that binds to the port that is the recipient of the iptables redirect
 	ipTablesListener := &listener.Listener{
 		Name:             VirtualOutboundListenerName,
-		Address:          util.BuildAddress(actualWildcard, uint32(lb.push.Mesh.ProxyListenPort)),
+		Address:          util.BuildAddress(actualLocalHost, uint32(lb.push.Mesh.ProxyListenPort)),
 		Transparent:      isTransparentProxy,
 		UseOriginalDst:   proto.BoolTrue,
 		FilterChains:     filterChains,

--- a/pilot/pkg/xds/xds_test.go
+++ b/pilot/pkg/xds/xds_test.go
@@ -263,7 +263,7 @@ func TestSidecarListeners(t *testing.T) {
 			Exists("{.resources[?(@.address.socketAddress.portValue==15001)]}").
 			Select("{.resources[?(@.address.socketAddress.portValue==15001)]}").
 			Equals("virtualOutbound", "{.name}").
-			Equals("0.0.0.0", "{.address.socketAddress.address}").
+			Equals("127.0.0.1", "{.address.socketAddress.address}").
 			Equals(wellknown.TCPProxy, "{.filterChains[1].filters[0].name}").
 			Equals("PassthroughCluster", "{.filterChains[1].filters[0].typedConfig.cluster}").
 			Equals("PassthroughCluster", "{.filterChains[1].filters[0].typedConfig.statPrefix}").


### PR DESCRIPTION
There is no reason to allow external access.

Note: for virtualInbound listener, we could not set localhost or podIP.