### PR TITLE
Avoid unnecessary sidecarscope calculation

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -867,13 +867,9 @@ func (s *Server) initRegistryEventHandlers() {
 	if s.configController != nil {
 		configHandler := func(old config.Config, curr config.Config, event model.Event) {
 			pushReq := &model.PushRequest{
-				Full: true,
-				ConfigsUpdated: map[model.ConfigKey]struct{}{{
-					Kind:      curr.GroupVersionKind,
-					Name:      curr.Name,
-					Namespace: curr.Namespace,
-				}: {}},
-				Reason: []model.TriggerReason{model.ConfigUpdate},
+				Full:           true,
+				ConfigsUpdated: map[model.ConfigKey]struct{}{model.MakeConfigKeyForConfigUpdate(old, curr): {}},
+				Reason:         []model.TriggerReason{model.ConfigUpdate},
 			}
 			s.XDSServer.ConfigUpdate(pushReq)
 			if event != model.EventDelete {

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -1404,11 +1404,14 @@ func (ps *PushContext) updateSidecarScopes(oldPushContext *PushContext, pushReq 
 		return false
 	}
 
-	ps.sidecarsByNamespace = oldPushContext.sidecarsByNamespace
+	ps.sidecarsByNamespace = make(map[string][]*SidecarScope, len(oldPushContext.sidecarsByNamespace))
 	for ns, sidecars := range oldPushContext.sidecarsByNamespace {
+		ps.sidecarsByNamespace[ns] = make([]*SidecarScope, len(sidecars))
 		for idx, sidecar := range sidecars {
 			if isAffected(sidecar) {
 				ps.sidecarsByNamespace[ns][idx] = ConvertToSidecarScope(ps, sidecar.Config, ns)
+			} else {
+				ps.sidecarsByNamespace[ns][idx] = oldPushContext.sidecarsByNamespace[ns][idx]
 			}
 		}
 	}

--- a/pilot/pkg/xds/fake.go
+++ b/pilot/pkg/xds/fake.go
@@ -188,15 +188,11 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 
 	// Setup config handlers
 	// TODO code re-use from server.go
-	configHandler := func(_, curr config.Config, event model.Event) {
+	configHandler := func(old config.Config, curr config.Config, event model.Event) {
 		pushReq := &model.PushRequest{
-			Full: true,
-			ConfigsUpdated: map[model.ConfigKey]struct{}{{
-				Kind:      curr.GroupVersionKind,
-				Name:      curr.Name,
-				Namespace: curr.Namespace,
-			}: {}},
-			Reason: []model.TriggerReason{model.ConfigUpdate},
+			Full:           true,
+			ConfigsUpdated: map[model.ConfigKey]struct{}{model.MakeConfigKeyForConfigUpdate(old, curr): {}},
+			Reason:         []model.TriggerReason{model.ConfigUpdate},
 		}
 		s.ConfigUpdate(pushReq)
 	}


### PR DESCRIPTION

This PR avoid recalculation of unrelated sidecar scopes which are not affected by the destinationrule or virtualservice updated.
It will significantly reduce the time it takes to do InitContext, especially when facing large scale of services and sidecars scenario. 
In our case (1k sidecars and 100k services), it used to take almost 3m to simply do initSidecarScopes. Now it only takes seconds to do initContext, which is mainly depends on how many sidecarscopes are affected.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[X] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.