### PR TITLE
Allow slash characters in env variable values passed to injector #31732

### DIFF
--- a/pkg/kube/inject/webhook_test.go
+++ b/pkg/kube/inject/webhook_test.go
@@ -1148,6 +1148,48 @@ func TestParseInjectEnvs(t *testing.T) {
 			in:   "/inject/cluster/cluster1/network",
 			want: map[string]string{"ISTIO_META_CLUSTER_ID": "cluster1"},
 		},
+		{
+			name: "key-with-values-contain-slashes",
+			in:   "/inject/:ENV:cluster=cluster2:ENV:rootpage=/foo/bar",
+			want: map[string]string{"ISTIO_META_CLUSTER_ID": "cluster2", "ROOTPAGE": "/foo/bar"},
+		},
+		{
+			// this is to test the path not following :ENV: format, the
+			// path will be considered using slash as separator
+			name: "no-predefined-kv-with-values-contain-ENV-separator",
+			in:   "/inject/rootpage1/value1/rootpage2/:ENV:abcd=efgh",
+			want: map[string]string{"ROOTPAGE1": "value1", "ROOTPAGE2": ":ENV:abcd=efgh"},
+		},
+		{
+			// this is to test the path following :ENV: format, but two variables
+			// do not have correct format, thus they will be ignored. Eg. :ENV:=abb
+			// :ENV:=, these two are not correct variables.
+			name: "no-predefined-kv-with-values-contain-ENV-separator-invalid-format",
+			in:   "/inject/:ENV:rootpage1=efgh:ENV:=abb:ENV:=",
+			want: map[string]string{"ROOTPAGE1": "efgh"},
+		},
+		{
+			// this is to test that the path is an url encoded string, still using
+			// slash as separators
+			name: "no-predefined-kv-with-mixed-values",
+			in: func() string {
+				req, _ := http.NewRequest("GET",
+					"%2Finject%2Frootpage1%2Ffoo%2Frootpage2%2Fbar", nil)
+				return req.URL.Path
+			}(),
+			want: map[string]string{"ROOTPAGE1": "foo", "ROOTPAGE2": "bar"},
+		},
+		{
+			// this is to test that the path is an url encoded string and :ENV: as separator
+			// eg. /inject/:ENV:rootpage1=/foo/bar:ENV:rootpage2=/bar/toe but url encoded.
+			name: "no-predefined-kv-with-slashes",
+			in: func() string {
+				req, _ := http.NewRequest("GET",
+					"%2Finject%2F%3AENV%3Arootpage1%3D%2Ffoo%2Fbar%3AENV%3Arootpage2%3D%2Fbar%2Ftoe", nil)
+				return req.URL.Path
+			}(),
+			want: map[string]string{"ROOTPAGE1": "/foo/bar", "ROOTPAGE2": "/bar/toe"},
+		},
 	}
 
 	for _, tc := range cases {

--- a/releasenotes/notes/31797.yaml
+++ b/releasenotes/notes/31797.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: enhancement
+area: environments
+issue:
+- 31732
+releaseNotes:
+- |
+  **Added** support for slash characters in environment variables on injectionURL


### PR DESCRIPTION
The parseInjectEnvs() function in webhook.go uses / characters to separate
keys and values for environment variables passed through the injector webhook
URL path. This doesn't work if the value of an env variable includes slash
characters. For example, it's not possible to set an environment variable like:
FOO_LOCATION=/path/to/foo.

This should be possible and is also needed in the external control plane
multicluster configuration if the remote cluster name includes / characters.

Perhaps this could be fixed by accepting values that are urlencoded
(e.g., "/inject/FOO_LOCATION/%2Fpath%2Fto%2Ffoo") or some similar encoding.

This PR checks each value, if there are encoded slashes, then it will
replace the encoded slash with actual slash.

Signed-off-by: litong01 <litong01@us.ibm.com>



[ ] Configuration Infrastructure
[ ] Docs
[X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.