### PR TITLE
Fix security/pkg/nodeagent/sds/Server.initWorkloadSdsService

### DIFF
--- a/security/pkg/nodeagent/sds/server.go
+++ b/security/pkg/nodeagent/sds/server.go
@@ -95,16 +95,16 @@ func (s *Server) initWorkloadSdsService(options *security.Options) {
 		for i := 0; i < maxRetryTimes; i++ {
 			serverOk := true
 			setUpUdsOK := true
-			if s.grpcWorkloadListener != nil {
-				if err = s.grpcWorkloadServer.Serve(s.grpcWorkloadListener); err != nil {
-					sdsServiceLog.Errorf("SDS grpc server for workload proxies failed to start: %v", err)
-					serverOk = false
-				}
-			}
 			if s.grpcWorkloadListener == nil {
 				if s.grpcWorkloadListener, err = uds.NewListener(options.WorkloadUDSPath); err != nil {
 					sdsServiceLog.Errorf("SDS grpc server for workload proxies failed to set up UDS: %v", err)
 					setUpUdsOK = false
+				}
+			}
+			if s.grpcWorkloadListener != nil {
+				if err = s.grpcWorkloadServer.Serve(s.grpcWorkloadListener); err != nil {
+					sdsServiceLog.Errorf("SDS grpc server for workload proxies failed to start: %v", err)
+					serverOk = false
 				}
 			}
 			if serverOk && setUpUdsOK {


### PR DESCRIPTION
Fix backoff last time, even if listen succeeds, the service will not start.



[x] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any changes that may affect Istio users.