### PR TITLE
Fix analyzer IST137 description

### DIFF
--- a/galley/pkg/config/analysis/msg/messages.gen.go
+++ b/galley/pkg/config/analysis/msg/messages.gen.go
@@ -142,7 +142,7 @@ var (
 	AlphaAnnotation = diag.NewMessageType(diag.Info, "IST0136", "Annotation %q is part of an alpha-phase feature and may be incompletely supported.")
 
 	// DeploymentConflictingPorts defines a diag.MessageType for message "DeploymentConflictingPorts".
-	// Description: Two services selecting the same workload with same target port are MUST refer to the same port.
+	// Description: Two services selecting the same workload with the same targetPort MUST refer to the same port.
 	DeploymentConflictingPorts = diag.NewMessageType(diag.Warning, "IST0137", "This deployment %s is associated with multiple services %v using targetPort %q but different ports: %v.")
 
 	// GatewayDuplicateCertificate defines a diag.MessageType for message "GatewayDuplicateCertificate".

--- a/galley/pkg/config/analysis/msg/messages.yaml
+++ b/galley/pkg/config/analysis/msg/messages.yaml
@@ -375,7 +375,7 @@ messages:
   - name: "DeploymentConflictingPorts"
     code: IST0137
     level: Warning
-    description: "Two services selecting the same workload with same target port are MUST refer to the same port."
+    description: "Two services selecting the same workload with the same targetPort MUST refer to the same port."
     template: "This deployment %s is associated with multiple services %v using targetPort %q but different ports: %v."
     args:
       - name: deployment


### PR DESCRIPTION
For https://github.com/istio/istio.io/pull/9239#issuecomment-805977238

> As an aside, the text at https://github.com/istio/istio/blob/master/galley/pkg/config/analysis/msg/messages.yaml#L378 should probably be updated for grammar and name.
>
> Today: description: "Two services selecting the same workload with same target port are MUST refer to the same port."
> Maybe: description: "Two services selecting the same workload with the same targetPort MUST refer to the same port."



[X] User Experience

[X] Does not have any changes that may affect Istio users.

/cc @ericvn 