### PR TITLE
Enable HttpsRedirect for Kubernetes Ingresses with TLS

### DIFF
--- a/pilot/pkg/config/kube/ingress/testdata/overlay.yaml.golden
+++ b/pilot/pkg/config/kube/ingress/testdata/overlay.yaml.golden
@@ -14,6 +14,7 @@ spec:
       name: http-80-ingress-foo-ns
       number: 80
       protocol: HTTP
+    tls: {}
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
@@ -31,6 +32,7 @@ spec:
       name: http-80-ingress-foo2-ns
       number: 80
       protocol: HTTP
+    tls: {}
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService

--- a/pilot/pkg/config/kube/ingress/testdata/simple.yaml.golden
+++ b/pilot/pkg/config/kube/ingress/testdata/simple.yaml.golden
@@ -14,6 +14,7 @@ spec:
       name: http-80-ingress-foo-ns
       number: 80
       protocol: HTTP
+    tls: {}
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService

--- a/pilot/pkg/config/kube/ingress/testdata/tls-no-secret.yaml.golden
+++ b/pilot/pkg/config/kube/ingress/testdata/tls-no-secret.yaml.golden
@@ -36,4 +36,5 @@ spec:
       name: http-80-ingress-tls-bar
       number: 80
       protocol: HTTP
+    tls: {}
 ---

--- a/pilot/pkg/config/kube/ingress/testdata/tls.yaml.golden
+++ b/pilot/pkg/config/kube/ingress/testdata/tls.yaml.golden
@@ -45,4 +45,6 @@ spec:
       name: http-80-ingress-tls-bar
       number: 80
       protocol: HTTP
+    tls:
+      httpsRedirect: true
 ---

--- a/pilot/pkg/config/kube/ingressv1/conversion.go
+++ b/pilot/pkg/config/kube/ingressv1/conversion.go
@@ -76,11 +76,14 @@ func ConvertIngressV1alpha3(ingress knetworking.Ingress, mesh *meshconfig.MeshCo
 	gateway := &networking.Gateway{}
 	gateway.Selector = getIngressGatewaySelector(mesh.IngressSelector, mesh.IngressService)
 
+	httpsRedirect := false
+
 	for i, tls := range ingress.Spec.TLS {
 		if tls.SecretName == "" {
 			log.Infof("invalid ingress rule %s:%s for hosts %q, no secretName defined", ingress.Namespace, ingress.Name, tls.Hosts)
 			continue
 		}
+		httpsRedirect = true
 		// TODO validation when multiple wildcard tls secrets are given
 		if len(tls.Hosts) == 0 {
 			tls.Hosts = []string{"*"}
@@ -107,6 +110,9 @@ func ConvertIngressV1alpha3(ingress knetworking.Ingress, mesh *meshconfig.MeshCo
 			Name:     fmt.Sprintf("http-80-ingress-%s-%s", ingress.Name, ingress.Namespace),
 		},
 		Hosts: []string{"*"},
+		Tls: &networking.ServerTLSSettings{
+			HttpsRedirect:  httpsRedirect,
+		},
 	})
 
 	gatewayConfig := config.Config{

--- a/pilot/pkg/config/kube/ingressv1/testdata/overlay.yaml.golden
+++ b/pilot/pkg/config/kube/ingressv1/testdata/overlay.yaml.golden
@@ -14,6 +14,7 @@ spec:
       name: http-80-ingress-foo-ns
       number: 80
       protocol: HTTP
+    tls: {}
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
@@ -31,6 +32,7 @@ spec:
       name: http-80-ingress-foo2-ns
       number: 80
       protocol: HTTP
+    tls: {}
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService

--- a/pilot/pkg/config/kube/ingressv1/testdata/simple.yaml.golden
+++ b/pilot/pkg/config/kube/ingressv1/testdata/simple.yaml.golden
@@ -14,6 +14,7 @@ spec:
       name: http-80-ingress-foo-ns
       number: 80
       protocol: HTTP
+    tls: {}
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService

--- a/pilot/pkg/config/kube/ingressv1/testdata/tls-no-secret.yaml.golden
+++ b/pilot/pkg/config/kube/ingressv1/testdata/tls-no-secret.yaml.golden
@@ -36,4 +36,5 @@ spec:
       name: http-80-ingress-tls-bar
       number: 80
       protocol: HTTP
+    tls: {}
 ---

--- a/pilot/pkg/config/kube/ingressv1/testdata/tls.yaml.golden
+++ b/pilot/pkg/config/kube/ingressv1/testdata/tls.yaml.golden
@@ -45,4 +45,6 @@ spec:
       name: http-80-ingress-tls-bar
       number: 80
       protocol: HTTP
+    tls:
+      httpsRedirect: true
 ---


### PR DESCRIPTION



Note: initial PR title was:

> Add `gateway.istio.io/httpsRedirect` annotation to `Ingress` to set Gateway's httpsRedirect

[ ] Configuration Infrastructure
[x] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any changes that may affect Istio users.
