### PR TITLE
Add a few checks for ECDS type

### DIFF
--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -455,7 +455,7 @@ func shouldUnsubscribe(request *discovery.DiscoveryRequest) bool {
 // resource names.
 func isWildcardTypeURL(typeURL string) bool {
 	switch typeURL {
-	case v3.SecretType, v3.EndpointType, v3.RouteType:
+	case v3.SecretType, v3.EndpointType, v3.RouteType, v3.ExtensionConfigurationType:
 		// By XDS spec, these are not wildcard
 		return false
 	case v3.ClusterType, v3.ListenerType:

--- a/pilot/pkg/xds/v3/model.go
+++ b/pilot/pkg/xds/v3/model.go
@@ -56,6 +56,8 @@ func GetShortType(typeURL string) string {
 		return "NDS"
 	case ProxyConfigType:
 		return "PCDS"
+	case ExtensionConfigurationType:
+		return "ECDS"
 	default:
 		return typeURL
 	}
@@ -78,6 +80,8 @@ func GetMetricType(typeURL string) string {
 		return "nds"
 	case ProxyConfigType:
 		return "pcds"
+	case ExtensionConfigurationType:
+		return "ecds"
 	default:
 		return typeURL
 	}

--- a/tests/integration/telemetry/stats/prometheus/wasm/bad_wasm_filter_test.go
+++ b/tests/integration/telemetry/stats/prometheus/wasm/bad_wasm_filter_test.go
@@ -16,12 +16,10 @@
 package wasm
 
 import (
-	"fmt"
 	"io/ioutil"
 	"testing"
 	"time"
 
-	resource "istio.io/istio/pilot/pkg/xds/v3"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/util/retry"
@@ -74,7 +72,7 @@ func TestBadWasmRemoteLoad(t *testing.T) {
 			// Verify that istiod has a stats about rejected ECDS update
 			// pilot_total_xds_rejects{type="type.googleapis.com/envoy.config.core.v3.TypedExtensionConfig"}
 			retry.UntilSuccessOrFail(t, func() error {
-				q := fmt.Sprintf("pilot_total_xds_rejects{type=\"%v\"}", resource.ExtensionConfigurationType)
+				q := "pilot_total_xds_rejects{type=\"ecds\"}"
 				c := cltInstance.Config().Cluster
 				if _, err := common.QueryPrometheus(t, c, q, common.GetPromInstance()); err != nil {
 					t.Logf("prometheus values for pilot_total_xds_rejects for cluster %v: \n%s",


### PR DESCRIPTION
* Use short name in log and metrics
* Correctly identify it as a non-wildcard type. This alows us to fully
drop the type if envoy unsubscribes, instead of constantly pushing empty
responses to it.
