### PR TITLE
Clean up pilot-agent start up error message.

### DIFF
--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -134,9 +134,9 @@ var (
 			log.Infof("Pilot SAN: %v", pilotSAN)
 
 			agent := istio_agent.NewAgent(proxyConfig, agentOptions, secOpts)
-			// Start in process SDS.
+			// Start in process SDS, dns server, and xds proxy.
 			if err := agent.Start(); err != nil {
-				log.Fatala("Failed to start in-process SDS", err)
+				log.Fatala("Agent start up error", err)
 			}
 
 			// If we are using a custom template file (for control plane proxy, for example), configure this.

--- a/pkg/istio-agent/agent.go
+++ b/pkg/istio-agent/agent.go
@@ -155,12 +155,12 @@ func (a *Agent) Start() error {
 	var err error
 	a.secretCache, err = a.newSecretManager()
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to start workload secret manager %v", err)
 	}
 
 	a.sdsServer, err = sds.NewServer(a.secOpts, a.secretCache)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to start local sds server %v", err)
 	}
 	a.secretCache.SetUpdateCallback(a.sdsServer.UpdateCallback)
 


### PR DESCRIPTION
agent start up function not only starts up sds, but also xds proxy and dns server.