### PR TITLE
[release-1.9] add a timeout for remote cluster readiness

### DIFF
--- a/pilot/pkg/bootstrap/servicecontroller.go
+++ b/pilot/pkg/bootstrap/servicecontroller.go
@@ -24,6 +24,7 @@ import (
 	"istio.io/istio/pilot/pkg/serviceregistry/mock"
 	"istio.io/istio/pilot/pkg/serviceregistry/serviceentry"
 	"istio.io/istio/pkg/config/host"
+	"istio.io/istio/pkg/kube/secretcontroller"
 	"istio.io/pkg/log"
 )
 
@@ -93,10 +94,15 @@ func (s *Server) initKubeRegistry(args *PilotArgs) (err error) {
 		s.environment)
 
 	// initialize the "main" cluster registry before starting controllers for remote clusters
-	if err := mc.AddMemberCluster(s.kubeClient, args.RegistryOptions.KubeOptions.ClusterID); err != nil {
-		log.Errorf("failed initializing registry for %s: %v", args.RegistryOptions.KubeOptions.ClusterID, err)
-		return err
-	}
+	s.addStartFunc(func(stop <-chan struct{}) error {
+		if err := mc.AddMemberCluster(args.RegistryOptions.KubeOptions.ClusterID, &secretcontroller.Cluster{
+			Client: s.kubeClient,
+			Stop:   stop,
+		}); err != nil {
+			return fmt.Errorf("failed initializing registry for %s: %v", args.RegistryOptions.KubeOptions.ClusterID, err)
+		}
+		return nil
+	})
 
 	// start remote cluster controllers
 	s.addStartFunc(func(stop <-chan struct{}) error {

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -375,6 +375,12 @@ var (
 		"The timeout to send the XDS configuration to proxies. After this timeout is reached, Pilot will discard that push.",
 	).Get()
 
+	RemoteClusterTimeout = env.RegisterDurationVar(
+		"PILOT_REMOTE_CLUSTER_TIMEOUT",
+		30*time.Second,
+		"After this timeout expires, pilot can become ready without syncing data from clusters added via remote-secrets.",
+	).Get()
+
 	EndpointTelemetryLabel = env.RegisterBoolVar("PILOT_ENDPOINT_TELEMETRY_LABEL", true,
 		"If true, pilot will add telemetry related metadata to Endpoint resource, which will be consumed by telemetry filter.",
 	).Get()

--- a/pilot/pkg/secrets/kube/multicluster.go
+++ b/pilot/pkg/secrets/kube/multicluster.go
@@ -45,8 +45,8 @@ func NewMulticluster(client kube.Client, localCluster, secretNamespace string, s
 	// Add the local cluster
 	m.addMemberCluster(client, localCluster)
 	sc := secretcontroller.StartSecretController(client,
-		func(c kube.Client, k string) error { m.addMemberCluster(c, k); return nil },
-		func(c kube.Client, k string) error { m.updateMemberCluster(c, k); return nil },
+		func(k string, c *secretcontroller.Cluster) error { m.addMemberCluster(c.Client, k); return nil },
+		func(k string, c *secretcontroller.Cluster) error { m.updateMemberCluster(c.Client, k); return nil },
 		func(k string) error { m.deleteMemberCluster(k); return nil },
 		secretNamespace,
 		time.Millisecond*100,
@@ -61,7 +61,6 @@ func (m *Multicluster) addMemberCluster(clients kube.Client, key string) {
 	m.m.Lock()
 	m.remoteKubeControllers[key] = sc
 	m.m.Unlock()
-	clients.RunAndWait(m.stop)
 }
 
 func (m *Multicluster) updateMemberCluster(clients kube.Client, key string) {

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -137,6 +137,9 @@ type Options struct {
 
 	// Duration to wait for cache syncs
 	SyncInterval time.Duration
+
+	// SyncTimeout, if set, causes HasSynced to be returned when marked true.
+	SyncTimeout *atomic.Bool
 }
 
 func (o Options) GetSyncInterval() time.Duration {
@@ -252,11 +255,14 @@ type Controller struct {
 	// gateways for each network, indexed by the service that runs them so we clean them up later
 	networkGateways map[host.Name]map[string][]*model.Gateway
 
-	once sync.Once
-	// initialized is set to true once the controller is running successfully. This ensures we do not
+	// informerInit is set to true once the controller is running successfully. This ensures we do not
 	// return HasSynced=true before we are running
-	initialized *atomic.Bool
-
+	informerInit *atomic.Bool
+	// initialSync is set to true after performing an initial in-order processing of all objects.
+	initialSync *atomic.Bool
+	// syncTimeout, if non-nil, will short-circuit HasSynced to be true for remote clusters to avoid blocking istiod startup
+	// during communication failures
+	syncTimeout *atomic.Bool
 	// Duration to wait for cache syncs
 	syncInterval time.Duration
 }
@@ -282,7 +288,9 @@ func NewController(kubeClient kubelib.Client, options Options) *Controller {
 		networksWatcher:             options.NetworksWatcher,
 		metrics:                     options.Metrics,
 		syncInterval:                options.GetSyncInterval(),
-		initialized:                 atomic.NewBool(false),
+		informerInit:                atomic.NewBool(false),
+		initialSync:                 atomic.NewBool(false),
+		syncTimeout:                 options.SyncTimeout,
 	}
 
 	if options.SystemNamespace != "" {
@@ -569,7 +577,15 @@ func tryGetLatestObject(informer cache.SharedIndexInformer, obj interface{}) int
 
 // HasSynced returns true after the initial state synchronization
 func (c *Controller) HasSynced() bool {
-	if !c.initialized.Load() {
+	if c.syncTimeout != nil && c.syncTimeout.Load() {
+		return true
+	}
+	return c.informersSynced() && c.initialSync.Load()
+}
+
+func (c *Controller) informersSynced() bool {
+	if !c.informerInit.Load() {
+		// registration/Run of informers hasn't occurred yet
 		return false
 	}
 	if (c.nsInformer != nil && !c.nsInformer.HasSynced()) ||
@@ -579,14 +595,6 @@ func (c *Controller) HasSynced() bool {
 		!c.nodeInformer.HasSynced() {
 		return false
 	}
-
-	// after informer caches sync the first time, process resources in order
-	c.once.Do(func() {
-		if err := c.SyncAll(); err != nil {
-			log.Errorf("one or more errors force-syncing resources: %v", err)
-		}
-	})
-
 	return true
 }
 
@@ -652,8 +660,14 @@ func (c *Controller) Run(stop <-chan struct{}) {
 	if c.nsInformer != nil {
 		go c.nsInformer.Run(stop)
 	}
-	c.initialized.Store(true)
-	kubelib.WaitForCacheSyncInterval(stop, c.syncInterval, c.HasSynced)
+	c.informerInit.Store(true)
+	kubelib.WaitForCacheSyncInterval(stop, c.syncInterval, c.informersSynced)
+	// after informer caches sync the first time, process resources in order
+	if err := c.SyncAll(); err != nil {
+		log.Errorf("one or more errors force-syncing resources: %v", err)
+	}
+	c.initialSync.Store(true)
+	// after the in-order sync we can start processing the queue
 	c.queue.Run(stop)
 	log.Infof("Controller terminated")
 }

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -15,6 +15,7 @@
 package controller
 
 import (
+	"fmt"
 	"strings"
 	"sync"
 	"time"
@@ -52,7 +53,6 @@ var (
 
 type kubeController struct {
 	*Controller
-	stopCh             chan struct{}
 	workloadEntryStore *serviceentry.ServiceEntryStore
 }
 
@@ -128,19 +128,23 @@ func NewMulticluster(
 // AddMemberCluster is passed to the secret controller as a callback to be called
 // when a remote cluster is added.  This function needs to set up all the handlers
 // to watch for resources being added, deleted or changed on remote clusters.
-func (m *Multicluster) AddMemberCluster(client kubelib.Client, clusterID string) error {
-	// stopCh to stop controller created here when cluster removed.
-	stopCh := make(chan struct{})
+func (m *Multicluster) AddMemberCluster(clusterID string, rc *secretcontroller.Cluster) error {
 	m.m.Lock()
+
+	client := rc.Client
+	clusterStopCh := rc.Stop
+
+	// clusterStopCh is a channel that will be closed when this cluster removed.
 	options := m.opts
 	options.ClusterID = clusterID
+	// the aggregate registry's HasSynced will use the k8s controller's HasSynced, so we reference the same timeout
+	options.SyncTimeout = rc.SyncTimeout
 
 	log.Infof("Initializing Kubernetes service registry %q", options.ClusterID)
 	kubeRegistry := NewController(client, options)
 	m.serviceController.AddRegistry(kubeRegistry)
 	m.remoteKubeControllers[clusterID] = &kubeController{
 		Controller: kubeRegistry,
-		stopCh:     stopCh,
 	}
 	// localCluster may also be the "config" cluster, in an external-istiod setup.
 	localCluster := m.opts.ClusterID == clusterID
@@ -170,7 +174,7 @@ func (m *Multicluster) AddMemberCluster(client kubelib.Client, clusterID string)
 				m.serviceController.AddRegistry(m.remoteKubeControllers[clusterID].workloadEntryStore)
 				// Services can select WorkloadEntry from the same cluster. We only duplicate the Service to configure kube-dns.
 				m.remoteKubeControllers[clusterID].workloadEntryStore.AppendWorkloadHandler(kubeRegistry.WorkloadInstanceHandler)
-				go configStore.Run(stopCh)
+				go configStore.Run(clusterStopCh)
 			} else {
 				log.Errorf("failed creating config configStore for cluster %s: %v", clusterID, err)
 			}
@@ -180,7 +184,7 @@ func (m *Multicluster) AddMemberCluster(client kubelib.Client, clusterID string)
 	// TODO only create namespace controller and cert patch for remote clusters (no way to tell currently)
 	if m.serviceController.Running() {
 		// if serviceController isn't running, it will start its members when it is started
-		go kubeRegistry.Run(stopCh)
+		go kubeRegistry.Run(clusterStopCh)
 	}
 	if m.fetchCaRoot != nil && m.fetchCaRoot() != nil && (features.ExternalIstiod || localCluster) {
 		log.Infof("joining leader-election for %s in %s", leaderelection.NamespaceController, options.SystemNamespace)
@@ -194,9 +198,9 @@ func (m *Multicluster) AddMemberCluster(client kubelib.Client, clusterID string)
 				// Note: stop here should be the overall pilot stop, NOT the leader election stop. We are
 				// basically lazy loading the informer, if we stop it when we lose the lock we will never
 				// recreate it again.
-				client.RunAndWait(stopCh)
+				client.RunAndWait(clusterStopCh)
 				nc.Run(leaderStop)
-			}).Run(stopCh)
+			}).Run(clusterStopCh)
 	}
 
 	// The local cluster has this patching set-up elsewhere. We may eventually want to move it here.
@@ -211,7 +215,7 @@ func (m *Multicluster) AddMemberCluster(client kubelib.Client, clusterID string)
 			if err != nil {
 				log.Errorf("could not initialize webhook cert patcher: %v", err)
 			} else {
-				patcher.Run(stopCh)
+				patcher.Run(clusterStopCh)
 			}
 		}
 		// Patch validation webhook cert
@@ -220,27 +224,25 @@ func (m *Multicluster) AddMemberCluster(client kubelib.Client, clusterID string)
 			validationWebhookController := webhooks.CreateValidationWebhookController(client, webhookConfigName,
 				m.secretNamespace, m.caBundlePath, true)
 			if validationWebhookController != nil {
-				go validationWebhookController.Start(stopCh)
+				go validationWebhookController.Start(clusterStopCh)
 			}
 		}
 	}
 
-	client.RunAndWait(stopCh)
 	return nil
 }
 
-func (m *Multicluster) UpdateMemberCluster(clients kubelib.Client, clusterID string) error {
+func (m *Multicluster) UpdateMemberCluster(clusterID string, rc *secretcontroller.Cluster) error {
 	if err := m.DeleteMemberCluster(clusterID); err != nil {
 		return err
 	}
-	return m.AddMemberCluster(clients, clusterID)
+	return m.AddMemberCluster(clusterID, rc)
 }
 
 // DeleteMemberCluster is passed to the secret controller as a callback to be called
 // when a remote cluster is deleted.  Also must clear the cache so remote resources
 // are removed.
 func (m *Multicluster) DeleteMemberCluster(clusterID string) error {
-
 	m.m.Lock()
 	defer m.m.Unlock()
 	m.serviceController.DeleteRegistry(clusterID, serviceregistry.Kubernetes)
@@ -255,7 +257,6 @@ func (m *Multicluster) DeleteMemberCluster(clusterID string) error {
 	if kc.workloadEntryStore != nil {
 		m.serviceController.DeleteRegistry(clusterID, serviceregistry.External)
 	}
-	close(m.remoteKubeControllers[clusterID].stopCh)
 	delete(m.remoteKubeControllers, clusterID)
 	if m.XDSUpdater != nil {
 		m.XDSUpdater.ConfigUpdate(&model.PushRequest{Full: true})

--- a/pkg/kube/secretcontroller/secretcontroller_test.go
+++ b/pkg/kube/secretcontroller/secretcontroller_test.go
@@ -52,14 +52,14 @@ var (
 	deleted string
 )
 
-func addCallback(_ kube.Client, id string) error {
+func addCallback(id string, _ *Cluster) error {
 	mu.Lock()
 	defer mu.Unlock()
 	added = id
 	return nil
 }
 
-func updateCallback(_ kube.Client, id string) error {
+func updateCallback(id string, _ *Cluster) error {
 	mu.Lock()
 	defer mu.Unlock()
 	updated = id


### PR DESCRIPTION
#### change:

Adds a simple timeout (default 30s) after which we ignore whether remote clusters have synced. This is a 1.9 only fix for #30838 

Changes are primarily to: k8s service registry, k8s secret controller:
* after 30s, remote clusters' controllers will mark themselves ready no matter what
* `RunAndWait` is called in the background, which makes us rely on calling `HasSynced` on the individual informers; previously we were calling it in the callbacks for remote secret creation, which would block the queue forever.
* Added `HasSynced` to the k8s secret controller, since it previously relied on `RunAndWait` to ensure caches synced. 

---

#### manual testing:

- [x] Test: With remote secret with an unusable IP
  - Result: istiod becomes ready after the timeout
- [X] Test: With `CROSS_CLUSTER_WORKLOAD_ENTRY` enabled, and removed WorkloadEntry permissions on `istio-reader-istio-system`:
  - Result: istiod immediately readies; this means we're relying on eventual consistency for these endpoints which should be fine
- [X] Test: removed k8s resource permissions in `istio-reader-istio-system`:
  - Result: istiod becomes ready after the timeout
- [X] Test: invalid service account token
  - Result:  istiod becomes ready after the timeout