### PR TITLE
Properly validate header operations and allow host header modification

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -409,10 +409,14 @@ func translateRoute(push *model.PushContext, node *model.Proxy, in *networking.H
 		}
 		out.Action = &route.Route_Route{Route: action}
 
-		if rewrite := in.Rewrite; rewrite != nil {
-			action.PrefixRewrite = rewrite.Uri
+		action.PrefixRewrite = in.Rewrite.GetUri()
+		authority := operations.authority
+		if in.Rewrite.GetAuthority() != "" {
+			authority = in.Rewrite.GetAuthority()
+		}
+		if authority != "" {
 			action.HostRewriteSpecifier = &route.RouteAction_HostRewriteLiteral{
-				HostRewriteLiteral: rewrite.Authority,
+				HostRewriteLiteral: authority,
 			}
 		}
 
@@ -543,12 +547,20 @@ func (b SortHeaderValueOption) Swap(i, j int) {
 }
 
 // translateAppendHeaders translates headers
-func translateAppendHeaders(headers map[string]string, appendFlag bool) []*core.HeaderValueOption {
+func translateAppendHeaders(headers map[string]string, appendFlag bool) ([]*core.HeaderValueOption, string) {
 	if len(headers) == 0 {
-		return nil
+		return nil, ""
 	}
+	authority := ""
 	headerValueOptionList := make([]*core.HeaderValueOption, 0, len(headers))
 	for key, value := range headers {
+		if isAuthorityHeader(key) {
+			// If there are multiple, last one wins; validation will reject
+			authority = value
+		}
+		if isInternalHeader(key) {
+			continue
+		}
 		headerValueOptionList = append(headerValueOptionList, &core.HeaderValueOption{
 			Header: &core.HeaderValue{
 				Key:   key,
@@ -558,7 +570,7 @@ func translateAppendHeaders(headers map[string]string, appendFlag bool) []*core.
 		})
 	}
 	sort.Stable(SortHeaderValueOption(headerValueOptionList))
-	return headerValueOptionList
+	return headerValueOptionList, authority
 }
 
 type headersOperations struct {
@@ -566,6 +578,28 @@ type headersOperations struct {
 	responseHeadersToAdd    []*core.HeaderValueOption
 	requestHeadersToRemove  []string
 	responseHeadersToRemove []string
+	authority               string
+}
+
+// isInternalHeader returns true if a header refers to an internal value that cannot be modified by Envoy
+func isInternalHeader(headerKey string) bool {
+	return strings.HasPrefix(headerKey, ":") || strings.EqualFold(headerKey, "host")
+}
+
+// isAuthorityHeader returns true if a header refers to the authority header
+func isAuthorityHeader(headerKey string) bool {
+	return strings.EqualFold(headerKey, ":authority") || strings.EqualFold(headerKey, "host")
+}
+
+func dropInternal(keys []string) []string {
+	result := make([]string, 0, len(keys))
+	for _, k := range keys {
+		if isInternalHeader(k) {
+			continue
+		}
+		result = append(result, k)
+	}
+	return result
 }
 
 // translateHeadersOperations translates headers operations
@@ -573,17 +607,25 @@ func translateHeadersOperations(headers *networking.Headers) headersOperations {
 	req := headers.GetRequest()
 	resp := headers.GetResponse()
 
-	requestHeadersToAdd := translateAppendHeaders(req.GetSet(), false)
-	requestHeadersToAdd = append(requestHeadersToAdd, translateAppendHeaders(req.GetAdd(), true)...)
+	requestHeadersToAdd, setAuthority := translateAppendHeaders(req.GetSet(), false)
+	reqAdd, addAuthority := translateAppendHeaders(req.GetAdd(), true)
+	requestHeadersToAdd = append(requestHeadersToAdd, reqAdd...)
 
-	responseHeadersToAdd := translateAppendHeaders(resp.GetSet(), false)
-	responseHeadersToAdd = append(responseHeadersToAdd, translateAppendHeaders(resp.GetAdd(), true)...)
+	responseHeadersToAdd, _ := translateAppendHeaders(resp.GetSet(), false)
+	respAdd, _ := translateAppendHeaders(resp.GetAdd(), true)
+	responseHeadersToAdd = append(responseHeadersToAdd, respAdd...)
 
+	auth := addAuthority
+	if setAuthority != "" {
+		// If authority is set in 'add' and 'set', pick the one from 'set'
+		auth = setAuthority
+	}
 	return headersOperations{
 		requestHeadersToAdd:     requestHeadersToAdd,
 		responseHeadersToAdd:    responseHeadersToAdd,
-		requestHeadersToRemove:  append([]string{}, req.GetRemove()...), // copy slice
-		responseHeadersToRemove: append([]string{}, resp.GetRemove()...),
+		requestHeadersToRemove:  dropInternal(req.GetRemove()),
+		responseHeadersToRemove: dropInternal(resp.GetRemove()),
+		authority:               auth,
 	}
 }
 

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -2575,6 +2575,40 @@ func TestValidateVirtualService(t *testing.T) {
 				}},
 			}},
 		}, valid: true, warning: true},
+		{name: "set authority", in: &networking.VirtualService{
+			Hosts: []string{"foo.bar"},
+			Http: []*networking.HTTPRoute{{
+				Headers: &networking.Headers{
+					Request: &networking.Headers_HeaderOperations{Set: map[string]string{":authority": "foo"}},
+				},
+				Route: []*networking.HTTPRouteDestination{{
+					Destination: &networking.Destination{Host: "foo.baz"},
+				}},
+			}},
+		}, valid: true, warning: false},
+		{name: "set authority in destination", in: &networking.VirtualService{
+			Hosts: []string{"foo.bar"},
+			Http: []*networking.HTTPRoute{{
+				Route: []*networking.HTTPRouteDestination{{
+					Destination: &networking.Destination{Host: "foo.baz"},
+					Headers: &networking.Headers{
+						Request: &networking.Headers_HeaderOperations{Set: map[string]string{":authority": "foo"}},
+					},
+				}},
+			}},
+		}, valid: false, warning: false},
+		{name: "set authority in rewrite and header", in: &networking.VirtualService{
+			Hosts: []string{"foo.bar"},
+			Http: []*networking.HTTPRoute{{
+				Headers: &networking.Headers{
+					Request: &networking.Headers_HeaderOperations{Set: map[string]string{":authority": "foo"}},
+				},
+				Rewrite: &networking.HTTPRewrite{Authority: "bar"},
+				Route: []*networking.HTTPRouteDestination{{
+					Destination: &networking.Destination{Host: "foo.baz"},
+				}},
+			}},
+		}, valid: false, warning: false},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/config/validation/virtualservice.go
+++ b/pkg/config/validation/virtualservice.go
@@ -17,6 +17,7 @@ package validation
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/features"
@@ -56,26 +57,26 @@ func validateHTTPRoute(http *networking.HTTPRoute, delegate bool) (errs Validati
 
 	// header manipulation
 	for name, val := range http.Headers.GetRequest().GetAdd() {
-		errs = appendValidation(errs, ValidateHTTPHeaderName(name))
+		errs = appendValidation(errs, ValidateHTTPHeaderWithAuthorityOperationName(name))
 		errs = appendValidation(errs, ValidateHTTPHeaderValue(val))
 	}
 	for name, val := range http.Headers.GetRequest().GetSet() {
-		errs = appendValidation(errs, ValidateHTTPHeaderName(name))
+		errs = appendValidation(errs, ValidateHTTPHeaderWithAuthorityOperationName(name))
 		errs = appendValidation(errs, ValidateHTTPHeaderValue(val))
 	}
 	for _, name := range http.Headers.GetRequest().GetRemove() {
-		errs = appendValidation(errs, ValidateHTTPHeaderName(name))
+		errs = appendValidation(errs, ValidateHTTPHeaderOperationName(name))
 	}
 	for name, val := range http.Headers.GetResponse().GetAdd() {
-		errs = appendValidation(errs, ValidateHTTPHeaderName(name))
+		errs = appendValidation(errs, ValidateHTTPHeaderOperationName(name))
 		errs = appendValidation(errs, ValidateHTTPHeaderValue(val))
 	}
 	for name, val := range http.Headers.GetResponse().GetSet() {
-		errs = appendValidation(errs, ValidateHTTPHeaderName(name))
+		errs = appendValidation(errs, ValidateHTTPHeaderOperationName(name))
 		errs = appendValidation(errs, ValidateHTTPHeaderValue(val))
 	}
 	for _, name := range http.Headers.GetResponse().GetRemove() {
-		errs = appendValidation(errs, ValidateHTTPHeaderName(name))
+		errs = appendValidation(errs, ValidateHTTPHeaderOperationName(name))
 	}
 
 	errs = appendValidation(errs, validateCORSPolicy(http.CorsPolicy))
@@ -98,12 +99,37 @@ func validateHTTPRoute(http *networking.HTTPRoute, delegate bool) (errs Validati
 	errs = appendValidation(errs, validateHTTPRedirect(http.Redirect))
 	errs = appendValidation(errs, validateHTTPRetry(http.Retries))
 	errs = appendValidation(errs, validateHTTPRewrite(http.Rewrite))
+	errs = appendValidation(errs, validateAuthorityRewrite(http.Rewrite, http.Headers))
 	errs = appendValidation(errs, validateHTTPRouteDestinations(http.Route))
 	if http.Timeout != nil {
 		errs = appendValidation(errs, ValidateDurationGogo(http.Timeout))
 	}
 
 	return
+}
+
+// validateAuthorityRewrite ensures we only attempt rewrite authority in a single place.
+func validateAuthorityRewrite(rewrite *networking.HTTPRewrite, headers *networking.Headers) error {
+	current := rewrite.GetAuthority()
+	for k, v := range headers.GetRequest().GetSet() {
+		if !isAuthorityHeader(k) {
+			continue
+		}
+		if current != "" {
+			return fmt.Errorf("authority header cannot be set multiple times: have %q, attempting to set %q", current, v)
+		}
+		current = v
+	}
+	for k, v := range headers.GetRequest().GetAdd() {
+		if !isAuthorityHeader(k) {
+			continue
+		}
+		if current != "" {
+			return fmt.Errorf("authority header cannot be set multiple times: have %q, attempting to set %q", current, v)
+		}
+		current = v
+	}
+	return nil
 }
 
 func validateHTTPRouteMatchRequest(http *networking.HTTPRoute, routeType HTTPRouteType) (errs error) {
@@ -240,4 +266,14 @@ func containRegexMatch(config *networking.StringMatch) bool {
 		return true
 	}
 	return false
+}
+
+// isInternalHeader returns true if a header refers to an internal value that cannot be modified by Envoy
+func isInternalHeader(headerKey string) bool {
+	return strings.HasPrefix(headerKey, ":") || strings.EqualFold(headerKey, "host")
+}
+
+// isAuthorityHeader returns true if a header refers to the authority header
+func isAuthorityHeader(headerKey string) bool {
+	return strings.EqualFold(headerKey, ":authority") || strings.EqualFold(headerKey, "host")
 }


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/31844

Envoy will reject header options for `Host` or `:`-prefixed. This adds
validation to our webhook to capture these. Additionally, it allows
setting `host` or `:authority` specifically, by internally transforming
it to a `authorityRewrite`.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.