### PR TITLE
don't block on RunAndWait in secretcontroller queue

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -308,6 +308,9 @@ var (
 		"If enabled, Kubernetes services with selectors will select workload entries with matching labels. "+
 			"It is safe to disable it if you are quite sure you don't need this feature").Get()
 
+	RemoteClusterTimeout = env.RegisterDurationVar("PILOT_REMOTE_CLUSTER_TIMEOUT", 30*time.Second,
+		"The amount of time we give for remote clusters' service registries to sync before marking pilot ready.").Get()
+
 	InjectionWebhookConfigName = env.RegisterStringVar("INJECTION_WEBHOOK_CONFIG_NAME", "istio-sidecar-injector",
 		"Name of the mutatingwebhookconfiguration to patch, if istioctl is not used.")
 

--- a/pilot/pkg/secrets/kube/secrets.go
+++ b/pilot/pkg/secrets/kube/secrets.go
@@ -97,6 +97,10 @@ func toUser(serviceAccount, namespace string) string {
 
 const cacheTTL = time.Minute
 
+func (s *SecretsController) HasSynced() bool {
+	return s.secrets.Informer().HasSynced()
+}
+
 // clearExpiredCache iterates through the cache and removes all expired entries. Should be called with mutex held.
 func (s *SecretsController) clearExpiredCache() {
 	for k, v := range s.authorizationCache {

--- a/pilot/pkg/secrets/kube/secrets_test.go
+++ b/pilot/pkg/secrets/kube/secrets_test.go
@@ -153,7 +153,7 @@ func TestForCluster(t *testing.T) {
 	defer close(stop)
 	localClient := kube.NewFakeClient()
 	remoteClient := kube.NewFakeClient()
-	sc := NewMulticluster(localClient, "local", "", stop)
+	sc := NewMulticluster(localClient, "local", "")
 	sc.addMemberCluster(remoteClient, "remote")
 	sc.addMemberCluster(remoteClient, "remote2")
 	cases := []struct {
@@ -182,7 +182,7 @@ func TestAuthorize(t *testing.T) {
 	remoteClient := kube.NewFakeClient()
 	allowIdentities(localClient, "system:serviceaccount:ns-local:sa-allowed")
 	allowIdentities(remoteClient, "system:serviceaccount:ns-remote:sa-allowed")
-	sc := NewMulticluster(localClient, "local", "", stop)
+	sc := NewMulticluster(localClient, "local", "")
 	sc.addMemberCluster(remoteClient, "remote")
 	cases := []struct {
 		sa      string
@@ -236,7 +236,7 @@ func TestSecretsControllerMulticluster(t *testing.T) {
 	localClient := kube.NewFakeClient(secretsLocal...)
 	remoteClient := kube.NewFakeClient(secretsRemote...)
 	otherRemoteClient := kube.NewFakeClient()
-	sc := NewMulticluster(localClient, "local", "", stop)
+	sc := NewMulticluster(localClient, "local", "")
 	sc.addMemberCluster(remoteClient, "remote")
 	sc.addMemberCluster(otherRemoteClient, "other")
 	cases := []struct {

--- a/pilot/pkg/xds/fake.go
+++ b/pilot/pkg/xds/fake.go
@@ -157,7 +157,7 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 		registries = append(registries, k8s)
 	}
 
-	sc := kubesecrets.NewMulticluster(defaultKubeClient, "", "", stop)
+	sc := kubesecrets.NewMulticluster(defaultKubeClient, "", "")
 	s.Generators[v3.SecretType] = NewSecretGen(sc, &model.DisabledCache{})
 	defaultKubeClient.RunAndWait(stop)
 


### PR DESCRIPTION
A smaller fix related to #30838 - the final fix will likely involve centralizing where we start RunAndWait, but this is a smaller step forward. 



The remote secret controller uses a signal placed on the queue after all the clusters we have remote secrets for at start are queued up:

https://github.com/istio/istio/blob/88a2bfb3bd8e0010229ee66befc4e56b326c2a3a/pkg/kube/secretcontroller/secretcontroller.go#L174-L173

The callbacks for adding secrets are run synchronously. The callback for the kube secrets controller runs `RunAndWait` on the kube client synchronously. This blocks the remote secrets controller queue from hitting it's initial sync marker. Any failure in reaching the remote clusters will block readiness. 


