### PR TITLE
add timeout for remote clusters to become ready

### DIFF
--- a/pilot/pkg/bootstrap/servicecontroller.go
+++ b/pilot/pkg/bootstrap/servicecontroller.go
@@ -24,6 +24,7 @@ import (
 	"istio.io/istio/pilot/pkg/serviceregistry/mock"
 	"istio.io/istio/pilot/pkg/serviceregistry/serviceentry"
 	"istio.io/istio/pkg/config/host"
+	"istio.io/istio/pkg/kube/secretcontroller"
 	"istio.io/pkg/log"
 )
 
@@ -99,10 +100,15 @@ func (s *Server) initKubeRegistry(args *PilotArgs) (err error) {
 		s.server)
 
 	// initialize the "main" cluster registry before starting controllers for remote clusters
-	if err := mc.AddMemberCluster(s.kubeClient, args.RegistryOptions.KubeOptions.ClusterID); err != nil {
-		log.Errorf("failed initializing registry for %s: %v", args.RegistryOptions.KubeOptions.ClusterID, err)
-		return err
-	}
+	s.addStartFunc(func(stop <-chan struct{}) error {
+		if err := mc.AddMemberCluster(args.RegistryOptions.KubeOptions.ClusterID, &secretcontroller.Cluster{
+			Client: s.kubeClient,
+			Stop:   stop,
+		}); err != nil {
+			return fmt.Errorf("failed initializing registry for %s: %v", args.RegistryOptions.KubeOptions.ClusterID, err)
+		}
+		return nil
+	})
 
 	// Start the multicluster controller and wait for it to shutdown before exiting the server.
 	s.addTerminatingStartFunc(mc.Run)

--- a/pilot/pkg/config/kube/crdclient/client.go
+++ b/pilot/pkg/config/kube/crdclient/client.go
@@ -314,7 +314,7 @@ func knownCRDs(ctx context.Context, crdClient apiextensionsclient.Interface) (ma
 			return nil, err
 		}
 		var err error
-		res, err = crdClient.ApiextensionsV1().CustomResourceDefinitions().List(context.TODO(), metav1.ListOptions{})
+		res, err = crdClient.ApiextensionsV1().CustomResourceDefinitions().List(ctx, metav1.ListOptions{})
 		if err == nil {
 			break
 		}

--- a/pilot/pkg/config/kube/crdclient/client.go
+++ b/pilot/pkg/config/kube/crdclient/client.go
@@ -149,10 +149,10 @@ func New(client kube.Client, revision, domainSuffix string) (model.ConfigStoreCa
 	if features.EnableServiceApis {
 		schemas = collections.PilotServiceApi
 	}
-	return NewForSchemas(client, revision, domainSuffix, schemas)
+	return NewForSchemas(context.Background(), client, revision, domainSuffix, schemas)
 }
 
-func NewForSchemas(client kube.Client, revision, domainSuffix string, schemas collection.Schemas) (model.ConfigStoreCache, error) {
+func NewForSchemas(ctx context.Context, client kube.Client, revision, domainSuffix string, schemas collection.Schemas) (model.ConfigStoreCache, error) {
 	out := &Client{
 		domainSuffix:     domainSuffix,
 		schemas:          schemas,
@@ -162,7 +162,10 @@ func NewForSchemas(client kube.Client, revision, domainSuffix string, schemas co
 		istioClient:      client.Istio(),
 		gatewayAPIClient: client.GatewayAPI(),
 	}
-	known := knownCRDs(client.Ext())
+	known, err := knownCRDs(ctx, client.Ext())
+	if err != nil {
+		return nil, err
+	}
 	for _, s := range out.schemas.All() {
 		// From the spec: "Its name MUST be in the format <.spec.name>.<.spec.group>."
 		name := fmt.Sprintf("%s.%s", s.Resource().Plural(), s.Resource().Group())
@@ -302,11 +305,14 @@ func (cl *Client) objectInRevision(o *config.Config) bool {
 }
 
 // knownCRDs returns all CRDs present in the cluster, with retries
-func knownCRDs(crdClient apiextensionsclient.Interface) map[string]struct{} {
+func knownCRDs(ctx context.Context, crdClient apiextensionsclient.Interface) (map[string]struct{}, error) {
 	delay := time.Second
 	maxDelay := time.Minute
 	var res *crd.CustomResourceDefinitionList
 	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		var err error
 		res, err = crdClient.ApiextensionsV1().CustomResourceDefinitions().List(context.TODO(), metav1.ListOptions{})
 		if err == nil {
@@ -324,7 +330,7 @@ func knownCRDs(crdClient apiextensionsclient.Interface) map[string]struct{} {
 	for _, r := range res.Items {
 		mp[r.Name] = struct{}{}
 	}
-	return mp
+	return mp, nil
 }
 
 func TranslateObject(r runtime.Object, gvk config.GroupVersionKind, domainSuffix string) *config.Config {

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -343,6 +343,12 @@ var (
 		"The timeout to send the XDS configuration to proxies. After this timeout is reached, Pilot will discard that push.",
 	).Get()
 
+	RemoteClusterTimeout = env.RegisterDurationVar(
+		"PILOT_REMOTE_CLUSTER_TIMEOUT",
+		30*time.Second,
+		"After this timeout expires, pilot can become ready without syncing data from clusters added via remote-secrets.",
+	).Get()
+
 	EndpointTelemetryLabel = env.RegisterBoolVar("PILOT_ENDPOINT_TELEMETRY_LABEL", true,
 		"If true, pilot will add telemetry related metadata to Endpoint resource, which will be consumed by telemetry filter.",
 	).Get()

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -346,7 +346,8 @@ var (
 	RemoteClusterTimeout = env.RegisterDurationVar(
 		"PILOT_REMOTE_CLUSTER_TIMEOUT",
 		30*time.Second,
-		"After this timeout expires, pilot can become ready without syncing data from clusters added via remote-secrets.",
+		"After this timeout expires, pilot can become ready without syncing data from clusters added via remote-secrets. "+
+			"Setting the timeout to 0 disables this behavior.",
 	).Get()
 
 	EndpointTelemetryLabel = env.RegisterBoolVar("PILOT_ENDPOINT_TELEMETRY_LABEL", true,

--- a/pilot/pkg/secrets/kube/multicluster.go
+++ b/pilot/pkg/secrets/kube/multicluster.go
@@ -45,8 +45,8 @@ func NewMulticluster(client kube.Client, localCluster, secretNamespace string, s
 	// Add the local cluster
 	m.addMemberCluster(client, localCluster)
 	sc := secretcontroller.StartSecretController(client,
-		func(c kube.Client, k string) error { m.addMemberCluster(c, k); return nil },
-		func(c kube.Client, k string) error { m.updateMemberCluster(c, k); return nil },
+		func(c kube.Client, _ chan struct{}, k string) error { m.addMemberCluster(c, k); return nil },
+		func(c kube.Client, _ chan struct{}, k string) error { m.updateMemberCluster(c, k); return nil },
 		func(k string) error { m.deleteMemberCluster(k); return nil },
 		secretNamespace,
 		time.Millisecond*100,

--- a/pilot/pkg/secrets/kube/multicluster.go
+++ b/pilot/pkg/secrets/kube/multicluster.go
@@ -45,8 +45,8 @@ func NewMulticluster(client kube.Client, localCluster, secretNamespace string, s
 	// Add the local cluster
 	m.addMemberCluster(client, localCluster)
 	sc := secretcontroller.StartSecretController(client,
-		func(c kube.Client, _ chan struct{}, k string) error { m.addMemberCluster(c, k); return nil },
-		func(c kube.Client, _ chan struct{}, k string) error { m.updateMemberCluster(c, k); return nil },
+		func(k string, c *secretcontroller.Cluster) error { m.addMemberCluster(c.Client, k); return nil },
+		func(k string, c *secretcontroller.Cluster) error { m.updateMemberCluster(c.Client, k); return nil },
 		func(k string) error { m.deleteMemberCluster(k); return nil },
 		secretNamespace,
 		time.Millisecond*100,
@@ -61,7 +61,6 @@ func (m *Multicluster) addMemberCluster(clients kube.Client, key string) {
 	m.m.Lock()
 	m.remoteKubeControllers[key] = sc
 	m.m.Unlock()
-	clients.RunAndWait(m.stop)
 }
 
 func (m *Multicluster) updateMemberCluster(clients kube.Client, key string) {

--- a/pilot/pkg/secrets/kube/secrets_test.go
+++ b/pilot/pkg/secrets/kube/secrets_test.go
@@ -244,7 +244,7 @@ func TestSecretsControllerMulticluster(t *testing.T) {
 	localClient.RunAndWait(stop)
 	remoteClient.RunAndWait(stop)
 	otherRemoteClient.RunAndWait(stop)
-	
+
 	cases := []struct {
 		name      string
 		namespace string

--- a/pilot/pkg/secrets/kube/secrets_test.go
+++ b/pilot/pkg/secrets/kube/secrets_test.go
@@ -239,6 +239,12 @@ func TestSecretsControllerMulticluster(t *testing.T) {
 	sc := NewMulticluster(localClient, "local", "", stop)
 	sc.addMemberCluster(remoteClient, "remote")
 	sc.addMemberCluster(otherRemoteClient, "other")
+
+	// normally the remote secrets controller would start these
+	localClient.RunAndWait(stop)
+	remoteClient.RunAndWait(stop)
+	otherRemoteClient.RunAndWait(stop)
+	
 	cases := []struct {
 		name      string
 		namespace string

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -142,6 +142,9 @@ type Options struct {
 	// Duration to wait for cache syncs
 	SyncInterval time.Duration
 
+	// SyncTimeout, if set, causes HasSynced to be returned when marked true.
+	SyncTimeout *atomic.Bool
+
 	// If meshConfig.DiscoverySelectors are specified, the DiscoveryNamespacesFilter tracks the namespaces this controller watches.
 	DiscoveryNamespacesFilter filter.DiscoveryNamespacesFilter
 }
@@ -261,11 +264,14 @@ type Controller struct {
 	// gateways for each network, indexed by the service that runs them so we clean them up later
 	networkGateways map[host.Name]map[string][]*model.Gateway
 
-	once sync.Once
-	// initialized is set to true once the controller is running successfully. This ensures we do not
+	// informerInit is set to true once the controller is running successfully. This ensures we do not
 	// return HasSynced=true before we are running
-	initialized *atomic.Bool
-
+	informerInit *atomic.Bool
+	// initialSync is set to true after performing an initial in-order processing of all objects.
+	initialSync *atomic.Bool
+	// syncTimeout, if non-nil, will short-circuit HasSynced to be true for remote clusters to avoid blocking istiod startup
+	// during communication failures
+	syncTimeout *atomic.Bool
 	// Duration to wait for cache syncs
 	syncInterval time.Duration
 
@@ -294,7 +300,9 @@ func NewController(kubeClient kubelib.Client, options Options) *Controller {
 		networksWatcher:             options.NetworksWatcher,
 		metrics:                     options.Metrics,
 		syncInterval:                options.GetSyncInterval(),
-		initialized:                 atomic.NewBool(false),
+		informerInit:                atomic.NewBool(false),
+		initialSync:                 atomic.NewBool(false),
+		syncTimeout:                 options.SyncTimeout,
 		discoveryNamespacesFilter:   options.DiscoveryNamespacesFilter,
 	}
 
@@ -596,7 +604,15 @@ func tryGetLatestObject(informer filter.FilteredSharedIndexInformer, obj interfa
 
 // HasSynced returns true after the initial state synchronization
 func (c *Controller) HasSynced() bool {
-	if !c.initialized.Load() {
+	if c.syncTimeout != nil && c.syncTimeout.Load() {
+		return true
+	}
+	return c.informersSynced() && c.initialSync.Load()
+}
+
+func (c *Controller) informersSynced() bool {
+	if !c.informerInit.Load() {
+		// registration/Run of informers hasn't occurred yet
 		return false
 	}
 	if (c.systemNsInformer != nil && !c.systemNsInformer.HasSynced()) ||
@@ -606,14 +622,6 @@ func (c *Controller) HasSynced() bool {
 		!c.nodeInformer.HasSynced() {
 		return false
 	}
-
-	// after informer caches sync the first time, process resources in order
-	c.once.Do(func() {
-		if err := c.SyncAll(); err != nil {
-			log.Errorf("one or more errors force-syncing resources: %v", err)
-		}
-	})
-
 	return true
 }
 
@@ -679,8 +687,14 @@ func (c *Controller) Run(stop <-chan struct{}) {
 	if c.systemNsInformer != nil {
 		go c.systemNsInformer.Run(stop)
 	}
-	c.initialized.Store(true)
-	kubelib.WaitForCacheSyncInterval(stop, c.syncInterval, c.HasSynced)
+	c.informerInit.Store(true)
+	kubelib.WaitForCacheSyncInterval(stop, c.syncInterval, c.informersSynced)
+	// after informer caches sync the first time, process resources in order
+	if err := c.SyncAll(); err != nil {
+		log.Errorf("one or more errors force-syncing resources: %v", err)
+	}
+	c.initialSync.Store(true)
+	// after the in-order sync we can start processing the queue
 	c.queue.Run(stop)
 	log.Infof("Controller terminated")
 }

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -351,7 +351,9 @@ func createConfigStore(client kubelib.Client, revision string, opts Options) (mo
 	workloadEntriesSchemas := collection.NewSchemasBuilder().
 		MustAdd(collections.IstioNetworkingV1Alpha3Workloadentries).
 		Build()
-	return crdclient.NewForSchemas(client, revision, opts.DomainSuffix, workloadEntriesSchemas)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	return crdclient.NewForSchemas(ctx, client, revision, opts.DomainSuffix, workloadEntriesSchemas)
 }
 
 func (m *Multicluster) updateHandler(svc *model.Service) {

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -55,7 +55,6 @@ var (
 
 type kubeController struct {
 	*Controller
-	stopCh             chan struct{}
 	workloadEntryStore *serviceentry.ServiceEntryStore
 }
 
@@ -168,7 +167,7 @@ func (m *Multicluster) close() (err error) {
 // AddMemberCluster is passed to the secret controller as a callback to be called
 // when a remote cluster is added.  This function needs to set up all the handlers
 // to watch for resources being added, deleted or changed on remote clusters.
-func (m *Multicluster) AddMemberCluster(client kubelib.Client, clusterID string) error {
+func (m *Multicluster) AddMemberCluster(client kubelib.Client, clusterStopCh chan struct{}, clusterID string) error {
 	m.m.Lock()
 
 	if m.closing {
@@ -177,7 +176,6 @@ func (m *Multicluster) AddMemberCluster(client kubelib.Client, clusterID string)
 	}
 
 	// clusterStopCh is a channel that will be closed when this cluster removed.
-	clusterStopCh := make(chan struct{})
 	options := m.opts
 	options.ClusterID = clusterID
 
@@ -186,7 +184,6 @@ func (m *Multicluster) AddMemberCluster(client kubelib.Client, clusterID string)
 	m.serviceController.AddRegistry(kubeRegistry)
 	m.remoteKubeControllers[clusterID] = &kubeController{
 		Controller: kubeRegistry,
-		stopCh:     clusterStopCh,
 	}
 	// localCluster may also be the "config" cluster, in an external-istiod setup.
 	localCluster := m.opts.ClusterID == clusterID
@@ -310,11 +307,11 @@ func (m *Multicluster) AddMemberCluster(client kubelib.Client, clusterID string)
 	return nil
 }
 
-func (m *Multicluster) UpdateMemberCluster(clients kubelib.Client, clusterID string) error {
+func (m *Multicluster) UpdateMemberCluster(clients kubelib.Client, stop chan struct{}, clusterID string) error {
 	if err := m.DeleteMemberCluster(clusterID); err != nil {
 		return err
 	}
-	return m.AddMemberCluster(clients, clusterID)
+	return m.AddMemberCluster(clients, stop, clusterID)
 }
 
 // DeleteMemberCluster is passed to the secret controller as a callback to be called
@@ -335,7 +332,6 @@ func (m *Multicluster) DeleteMemberCluster(clusterID string) error {
 	if kc.workloadEntryStore != nil {
 		m.serviceController.DeleteRegistry(clusterID, serviceregistry.External)
 	}
-	close(m.remoteKubeControllers[clusterID].stopCh)
 	delete(m.remoteKubeControllers, clusterID)
 	if m.XDSUpdater != nil {
 		m.XDSUpdater.ConfigUpdate(&model.PushRequest{Full: true})

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -167,7 +167,7 @@ func (m *Multicluster) close() (err error) {
 // AddMemberCluster is passed to the secret controller as a callback to be called
 // when a remote cluster is added.  This function needs to set up all the handlers
 // to watch for resources being added, deleted or changed on remote clusters.
-func (m *Multicluster) AddMemberCluster(client kubelib.Client, clusterStopCh chan struct{}, clusterID string) error {
+func (m *Multicluster) AddMemberCluster(clusterID string, rc *secretcontroller.Cluster) error {
 	m.m.Lock()
 
 	if m.closing {
@@ -175,9 +175,14 @@ func (m *Multicluster) AddMemberCluster(client kubelib.Client, clusterStopCh cha
 		return fmt.Errorf("failed adding member cluster %s: server shutting down", clusterID)
 	}
 
+	client := rc.Client
+	clusterStopCh := rc.Stop
+
 	// clusterStopCh is a channel that will be closed when this cluster removed.
 	options := m.opts
 	options.ClusterID = clusterID
+	// the aggregate registry's HasSynced will use the k8s controller's HasSynced, so we reference the same timeout
+	options.SyncTimeout = rc.SyncTimeout
 
 	log.Infof("Initializing Kubernetes service registry %q", options.ClusterID)
 	kubeRegistry := NewController(client, options)
@@ -221,11 +226,13 @@ func (m *Multicluster) AddMemberCluster(client kubelib.Client, clusterStopCh cha
 		}
 	}
 
-	// TODO only create namespace controller and cert patch for remote clusters (no way to tell currently)
+	// TODO make the aggregate controller keep clusters tied to their individual stop channels
 	if m.serviceController.Running() {
 		// if serviceController isn't running, it will start its members when it is started
 		go kubeRegistry.Run(clusterStopCh)
 	}
+
+	// TODO only create namespace controller and cert patch for remote clusters (no way to tell currently)
 	if m.fetchCaRoot != nil && m.fetchCaRoot() != nil && (features.ExternalIstiod || localCluster) {
 		// Block server exit on graceful termination of the leader controller.
 		m.s.RunComponentAsyncAndWait(func(_ <-chan struct{}) error {
@@ -303,15 +310,14 @@ func (m *Multicluster) AddMemberCluster(client kubelib.Client, clusterStopCh cha
 		})
 	}
 
-	client.RunAndWait(clusterStopCh)
 	return nil
 }
 
-func (m *Multicluster) UpdateMemberCluster(clients kubelib.Client, stop chan struct{}, clusterID string) error {
+func (m *Multicluster) UpdateMemberCluster(clusterID string, rc *secretcontroller.Cluster) error {
 	if err := m.DeleteMemberCluster(clusterID); err != nil {
 		return err
 	}
-	return m.AddMemberCluster(clients, stop, clusterID)
+	return m.AddMemberCluster(clusterID, rc)
 }
 
 // DeleteMemberCluster is passed to the secret controller as a callback to be called

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -221,7 +221,7 @@ func (m *Multicluster) AddMemberCluster(clusterID string, rc *secretcontroller.C
 				m.remoteKubeControllers[clusterID].workloadEntryStore.AppendWorkloadHandler(kubeRegistry.WorkloadInstanceHandler)
 				go configStore.Run(clusterStopCh)
 			} else {
-				log.Errorf("failed creating config configStore for cluster %s: %v", clusterID, err)
+				return fmt.Errorf("failed creating config configStore for cluster %s: %v", clusterID, err)
 			}
 		}
 	}

--- a/pkg/kube/secretcontroller/secretcontroller.go
+++ b/pkg/kube/secretcontroller/secretcontroller.go
@@ -24,8 +24,6 @@ import (
 	"sync"
 	"time"
 
-	"istio.io/pkg/monitoring"
-
 	"go.uber.org/atomic"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -41,6 +39,7 @@ import (
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pkg/kube"
 	"istio.io/pkg/log"
+	"istio.io/pkg/monitoring"
 )
 
 const (

--- a/pkg/kube/secretcontroller/secretcontroller.go
+++ b/pkg/kube/secretcontroller/secretcontroller.go
@@ -414,7 +414,7 @@ func (c *Controller) deleteMemberCluster(secretName string) {
 					clusterID, secretName, err)
 			}
 			close(cluster.stop)
-			c.cs.Delete(clusterID)
+			delete(c.cs.remoteClusters, clusterID)
 		}
 	}
 }

--- a/pkg/kube/secretcontroller/secretcontroller.go
+++ b/pkg/kube/secretcontroller/secretcontroller.go
@@ -53,7 +53,7 @@ func init() {
 }
 
 var timeouts = monitoring.NewSum(
-	"remote_cluster_sync_timeouts",
+	"remote_cluster_sync_timeouts_total",
 	"Number of times remote clusters took too long to sync, causing slow startup that excludes remote clusters.",
 )
 

--- a/pkg/kube/secretcontroller/secretcontroller.go
+++ b/pkg/kube/secretcontroller/secretcontroller.go
@@ -56,7 +56,6 @@ type removeClientCallback func(clusterID string) error
 // Controller is the controller implementation for Secret resources
 type Controller struct {
 	kubeclientset kubernetes.Interface
-	configCluster string
 	namespace     string
 	queue         workqueue.RateLimitingInterface
 	informer      cache.SharedIndexInformer
@@ -244,12 +243,11 @@ func (c *Controller) HasSynced() bool {
 	}
 	c.cs.RLock()
 	defer c.cs.RUnlock()
-	for clusterID, cluster := range c.cs.remoteClusters {
-		if c.remoteSyncTimeout.Load() && clusterID != c.configCluster {
-			continue
-		}
+	if c.remoteSyncTimeout.Load() {
+		return true
+	}
+	for _, cluster := range c.cs.remoteClusters {
 		if !cluster.HasSynced() {
-			// TODO timeout
 			return false
 		}
 	}

--- a/pkg/kube/secretcontroller/secretcontroller.go
+++ b/pkg/kube/secretcontroller/secretcontroller.go
@@ -232,9 +232,11 @@ func (c *Controller) Run(stopCh <-chan struct{}) {
 	}
 	// all secret events before this signal must be processed before we're marked "ready"
 	c.queue.Add(initialSyncSignal)
-	time.AfterFunc(features.RemoteClusterTimeout, func() {
-		c.remoteSyncTimeout.Store(true)
-	})
+	if features.RemoteClusterTimeout != 0 {
+		time.AfterFunc(features.RemoteClusterTimeout, func() {
+			c.remoteSyncTimeout.Store(true)
+		})
+	}
 	go wait.Until(c.runWorker, 5*time.Second, stopCh)
 	<-stopCh
 	c.close()

--- a/pkg/kube/secretcontroller/secretcontroller_test.go
+++ b/pkg/kube/secretcontroller/secretcontroller_test.go
@@ -52,14 +52,14 @@ var (
 	deleted string
 )
 
-func addCallback(_ kube.Client, id string) error {
+func addCallback(_ kube.Client, _ chan struct{}, id string) error {
 	mu.Lock()
 	defer mu.Unlock()
 	added = id
 	return nil
 }
 
-func updateCallback(_ kube.Client, id string) error {
+func updateCallback(_ kube.Client, _ chan struct{}, id string) error {
 	mu.Lock()
 	defer mu.Unlock()
 	updated = id

--- a/pkg/kube/secretcontroller/secretcontroller_test.go
+++ b/pkg/kube/secretcontroller/secretcontroller_test.go
@@ -52,14 +52,14 @@ var (
 	deleted string
 )
 
-func addCallback(_ kube.Client, _ chan struct{}, id string) error {
+func addCallback(id string, _ *Cluster) error {
 	mu.Lock()
 	defer mu.Unlock()
 	added = id
 	return nil
 }
 
-func updateCallback(_ kube.Client, _ chan struct{}, id string) error {
+func updateCallback(id string, _ *Cluster) error {
 	mu.Lock()
 	defer mu.Unlock()
 	updated = id

--- a/pkg/kube/secretcontroller/secretcontroller_test.go
+++ b/pkg/kube/secretcontroller/secretcontroller_test.go
@@ -21,15 +21,13 @@ import (
 	"testing"
 	"time"
 
-	"istio.io/istio/pkg/test/util/retry"
-
-	"istio.io/istio/pilot/pkg/features"
-
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/test/util/retry"
 )
 
 const secretNamespace string = "istio-system"

--- a/pkg/test/framework/components/cluster/cluster.go
+++ b/pkg/test/framework/components/cluster/cluster.go
@@ -81,6 +81,13 @@ func (c Clusters) Primaries(excluded ...Cluster) Clusters {
 	}, exclude(excluded...))
 }
 
+// Exclude returns all clusters not given as input.
+func (c Clusters) Exclude(excluded ...Cluster) Clusters {
+	return c.filterClusters(func(cc Cluster) bool {
+		return true
+	}, exclude(excluded...))
+}
+
 // Configs returns the subset that are config clusters.
 func (c Clusters) Configs(excluded ...Cluster) Clusters {
 	return c.filterClusters(func(cc Cluster) bool {

--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -706,7 +706,7 @@ func (i *operatorComponent) configureDirectAPIServerAccess(ctx resource.Context,
 func (i *operatorComponent) configureDirectAPIServiceAccessForCluster(ctx resource.Context, cfg Config,
 	cluster cluster.Cluster) error {
 	// Create a secret.
-	secret, err := createRemoteSecret(ctx, cluster, cfg)
+	secret, err := CreateRemoteSecret(ctx, cluster, cfg)
 	if err != nil {
 		return fmt.Errorf("failed creating remote secret for cluster %s: %v", cluster.Name(), err)
 	}
@@ -721,7 +721,7 @@ func (i *operatorComponent) configureDirectAPIServiceAccessForCluster(ctx resour
 	return nil
 }
 
-func createRemoteSecret(ctx resource.Context, cluster cluster.Cluster, cfg Config) (string, error) {
+func CreateRemoteSecret(ctx resource.Context, cluster cluster.Cluster, cfg Config, opts ...string) (string, error) {
 	istioCtl, err := istioctl.New(ctx, istioctl.Config{
 		Cluster: cluster,
 	})
@@ -734,6 +734,7 @@ func createRemoteSecret(ctx resource.Context, cluster cluster.Cluster, cfg Confi
 		"--namespace", cfg.SystemNamespace,
 		"--manifests", filepath.Join(testenv.IstioSrc, "manifests"),
 	}
+	cmd = append(cmd, opts...)
 
 	scopes.Framework.Infof("Creating remote secret for cluster cluster %s %v", cluster.Name(), cmd)
 	out, _, err := istioCtl.Invoke(cmd)

--- a/releasenotes/notes/30838.yaml
+++ b/releasenotes/notes/30838.yaml
@@ -7,5 +7,5 @@ issue:
 releaseNotes:
 - |
   **Fixed** istiod never becoming ready when it fails to read resources from clusters configured via remote secrets.
-  After a timeout configured by `PILOT_REMOTE_CLUSTER_TIMEOUT` (default 30s), istiod will become ready startup without
+  After a timeout configured by `PILOT_REMOTE_CLUSTER_TIMEOUT` (default 30s), istiod will become ready without
   syncing remote clusters. The stat `remote_cluster_sync_timeouts` will be incremented when this occurs.

--- a/releasenotes/notes/30838.yaml
+++ b/releasenotes/notes/30838.yaml
@@ -1,0 +1,11 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: networking
+issue:
+  - 30838
+
+releaseNotes:
+- |
+  **Fixed** istiod never becoming ready when it fails to read resources from clusters configured via remote secrets.
+  After a timeout configured by `PILOT_REMOTE_CLUSTER_TIMEOUT` (default 30s), istiod will become ready startup without
+  syncing remote clusters. The stat `remote_cluster_sync_timeouts` will be incremented when this occurs.

--- a/tests/integration/iop-integration-test-defaults.yaml
+++ b/tests/integration/iop-integration-test-defaults.yaml
@@ -56,6 +56,7 @@ spec:
       env:
         UNSAFE_ENABLE_ADMIN_ENDPOINTS: true
         PILOT_ENABLE_CROSS_CLUSTER_WORKLOAD_ENTRY: true
+        PILOT_REMOTE_CLUSTER_TIMEOUT: 15s
 
     gateways:
       istio-ingressgateway:

--- a/tests/integration/pilot/multicluster_test.go
+++ b/tests/integration/pilot/multicluster_test.go
@@ -123,8 +123,8 @@ func TestBadRemoteSecret(t *testing.T) {
 
 			// intentionally not doing this with subtests since it would be pretty slow
 			for name, opts := range map[string][]string{
-				"unreachable server": {"--server", "https://255.255.255.255"},
-				"no permissions":     {"--service-account", "istio-reader-no-perms"},
+				"unreachable server": {"--name", "unreachable", "--server", "https://255.255.255.255"},
+				"no permissions":     {"--name", "no-permissions", "--service-account", "istio-reader-no-perms"},
 			} {
 				secret, err := istio.CreateRemoteSecret(t, remote, i.Settings(), opts...)
 				if err != nil {

--- a/tests/integration/pilot/multicluster_test.go
+++ b/tests/integration/pilot/multicluster_test.go
@@ -20,16 +20,20 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/go-multierror"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pkg/test/echo/common/scheme"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/cluster"
 	"istio.io/istio/pkg/test/framework/components/echo"
+	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/scopes"
+	"istio.io/istio/pkg/test/util/retry"
 	"istio.io/istio/pkg/util/gogoprotomarshal"
 )
 
@@ -91,6 +95,73 @@ serviceSettings:
 		})
 }
 
+func TestBadRemoteSecret(t *testing.T) {
+	framework.NewTest(t).
+		RequiresMinClusters(2).
+		Features(
+			// TODO tracking topologies as feature labels doesn't make sense
+			"installation.multicluster.multimaster",
+			"installation.multicluster.remote",
+		).
+		Run(func(t framework.TestContext) {
+			// we don't need to test this per-cluster
+			primary := t.Clusters().Configs()[0]
+			// it doesn't matter if the other cluster is a primary/remote/etc.
+			remote := t.Clusters().Exclude(primary)[0]
+
+			if _, err := remote.Config().CoreV1().ServiceAccounts(i.Settings().SystemNamespace).Create(context.TODO(), &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{Name: "istio-reader-no-perms", Namespace: i.Settings().SystemNamespace},
+			}, metav1.CreateOptions{}); err != nil {
+				t.Fatal(err)
+			}
+
+			// intentionally not doing this with subtests since it would be pretty slow
+			for name, opts := range map[string][]string{
+				"unreachable server": {"--server", "https://255.255.255.255"},
+				"no permissions":     {"--service-account", "istio-reader-no-perms"},
+			} {
+				secret, err := istio.CreateRemoteSecret(t, remote, i.Settings(), opts...)
+				if err != nil {
+					t.Fatalf("failed generating secret with %s: %v", name, err)
+				}
+				t.Config().ApplyYAMLOrFail(t, i.Settings().SystemNamespace, secret)
+			}
+
+			deps, err := primary.AppsV1().
+				Deployments(i.Settings().SystemNamespace).List(context.TODO(), metav1.ListOptions{LabelSelector: "app=istiod"})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			pods := primary.CoreV1().Pods(i.Settings().SystemNamespace)
+			podMeta := deps.Items[0].Spec.Template.ObjectMeta
+			podMeta.Name = "istiod-bad-secrets-test"
+			_, err = pods.Create(context.TODO(), &corev1.Pod{
+				ObjectMeta: podMeta,
+				Spec:       deps.Items[0].Spec.Template.Spec,
+			}, metav1.CreateOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() {
+				if err := pods.Delete(context.TODO(), podMeta.Name, metav1.DeleteOptions{}); err != nil {
+					t.Logf("error cleaning up %s: %v", podMeta.Name, err)
+				}
+			})
+			retry.UntilSuccessOrFail(t, func() error {
+				pod, err := pods.Get(context.TODO(), podMeta.Name, metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+				status := pod.Status.ContainerStatuses
+				if len(status) < 1 || !status[0].Ready {
+					return fmt.Errorf("%s not ready", podMeta.Name)
+				}
+				return nil
+			}, retry.Timeout(time.Minute), retry.Delay(time.Second))
+		})
+}
+
 func patchMeshConfig(t framework.TestContext, clusters cluster.Clusters, patch string) {
 	errG := multierror.Group{}
 	origCfg := map[string]string{}
@@ -103,7 +174,7 @@ func patchMeshConfig(t framework.TestContext, clusters cluster.Clusters, patch s
 	for _, c := range clusters.Kube() {
 		c := c
 		errG.Go(func() error {
-			cm, err := c.CoreV1().ConfigMaps(i.Settings().SystemNamespace).Get(context.TODO(), cmName, v1.GetOptions{})
+			cm, err := c.CoreV1().ConfigMaps(i.Settings().SystemNamespace).Get(context.TODO(), cmName, metav1.GetOptions{})
 			if err != nil {
 				return err
 			}
@@ -125,7 +196,7 @@ func patchMeshConfig(t framework.TestContext, clusters cluster.Clusters, patch s
 			if err != nil {
 				return err
 			}
-			_, err = c.CoreV1().ConfigMaps(i.Settings().SystemNamespace).Update(context.TODO(), cm, v1.UpdateOptions{})
+			_, err = c.CoreV1().ConfigMaps(i.Settings().SystemNamespace).Update(context.TODO(), cm, metav1.UpdateOptions{})
 			if err != nil {
 				return err
 			}
@@ -141,12 +212,12 @@ func patchMeshConfig(t framework.TestContext, clusters cluster.Clusters, patch s
 			cn, mcYaml := cn, mcYaml
 			c := clusters.GetByName(cn)
 			errG.Go(func() error {
-				cm, err := c.CoreV1().ConfigMaps(i.Settings().SystemNamespace).Get(context.TODO(), cmName, v1.GetOptions{})
+				cm, err := c.CoreV1().ConfigMaps(i.Settings().SystemNamespace).Get(context.TODO(), cmName, metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
 				cm.Data["mesh"] = mcYaml
-				_, err = c.CoreV1().ConfigMaps(i.Settings().SystemNamespace).Update(context.TODO(), cm, v1.UpdateOptions{})
+				_, err = c.CoreV1().ConfigMaps(i.Settings().SystemNamespace).Update(context.TODO(), cm, metav1.UpdateOptions{})
 				return err
 			})
 		}


### PR DESCRIPTION
initial fix for #30838 

[doc](https://docs.google.com/document/d/1eS72Ozu_tREk3Zw5PTrPA8oGeAMis1VwvkgTgLgUr7g/edit?usp=sharing&resourcekey=0-0OnlRQXkFqL09ZXyqMhpog)

* General `secretcontroller` refactor
  * duplicated code in Update/Add path
  * util methods for concurrent access to cluster store
  * update/add share a type
  * callbacks take a struct with: client, stop channel, timeout bool ptr
* `secretcontroller` now manages stop channels for each cluster, and calls RunAndWait
  * we were calling RunAndWait synchronously, inside of callbacks, which blocked startup without getting to HasSynced
* `secretcontroller` exposes `HasSynced`
  * requires us to _attempt_ to process the secrets local to the cluster
  * makes sure `RunAndWait` has allowed caches to sync for remote clusters created so-far
  * ignores remote cluster syncs after a timeout
* `kube/controller` readiness refactor:
  * When created via secretcontroller, it will reference the secretcontroller's timeout. 
  * `HasSynced` returns `true` if `(timeout != nil && timeoutExpired) || SyncAll has completed)`
  * `SyncAll` is run after informers are synced, then we start processing the queue (decoupled from `HasSynced`)