### PR TITLE
update dry-run metric prefix and also add e2e tests

### DIFF
--- a/pilot/pkg/security/authz/builder/testdata/http/allow-empty-rule-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/allow-empty-rule-out.yaml
@@ -12,4 +12,4 @@ typedConfig:
         - andIds:
             ids:
             - any: true
-  shadowRulesStatPrefix: istio_dry_run_
+  shadowRulesStatPrefix: istio_dry_run_allow_

--- a/pilot/pkg/security/authz/builder/testdata/http/allow-full-rule-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/allow-full-rule-out.yaml
@@ -1053,4 +1053,4 @@ typedConfig:
                               safeRegex:
                                 googleRe2: {}
                                 regex: .+
-  shadowRulesStatPrefix: istio_dry_run_
+  shadowRulesStatPrefix: istio_dry_run_allow_

--- a/pilot/pkg/security/authz/builder/testdata/http/allow-nil-rule-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/allow-nil-rule-out.yaml
@@ -10,4 +10,4 @@ typedConfig:
         principals:
         - notId:
             any: true
-  shadowRulesStatPrefix: istio_dry_run_
+  shadowRulesStatPrefix: istio_dry_run_allow_

--- a/pilot/pkg/security/authz/builder/testdata/http/allow-path-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/allow-path-out.yaml
@@ -44,4 +44,4 @@ typedConfig:
         - andIds:
             ids:
             - any: true
-  shadowRulesStatPrefix: istio_dry_run_
+  shadowRulesStatPrefix: istio_dry_run_allow_

--- a/pilot/pkg/security/authz/builder/testdata/http/audit-full-rule-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/audit-full-rule-out.yaml
@@ -13,4 +13,4 @@ typedConfig:
         - andIds:
             ids:
             - any: true
-  shadowRulesStatPrefix: istio_dry_run_
+  shadowRulesStatPrefix: istio_dry_run_allow_

--- a/pilot/pkg/security/authz/builder/testdata/http/deny-and-allow-out1.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/deny-and-allow-out1.yaml
@@ -21,4 +21,4 @@ typedConfig:
                     value:
                       stringMatch:
                         exact: deny
-  shadowRulesStatPrefix: istio_dry_run_
+  shadowRulesStatPrefix: istio_dry_run_allow_

--- a/pilot/pkg/security/authz/builder/testdata/http/deny-and-allow-out2.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/deny-and-allow-out2.yaml
@@ -20,4 +20,4 @@ typedConfig:
                     value:
                       stringMatch:
                         exact: allow
-  shadowRulesStatPrefix: istio_dry_run_
+  shadowRulesStatPrefix: istio_dry_run_allow_

--- a/pilot/pkg/security/authz/builder/testdata/http/deny-empty-rule-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/deny-empty-rule-out.yaml
@@ -13,4 +13,4 @@ typedConfig:
         - andIds:
             ids:
             - any: true
-  shadowRulesStatPrefix: istio_dry_run_
+  shadowRulesStatPrefix: istio_dry_run_allow_

--- a/pilot/pkg/security/authz/builder/testdata/http/dry-run-allow-and-deny-out1.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/dry-run-allow-and-deny-out1.yaml
@@ -17,4 +17,4 @@ typedConfig:
         - andIds:
             ids:
             - any: true
-  shadowRulesStatPrefix: istio_dry_run_
+  shadowRulesStatPrefix: istio_dry_run_deny_

--- a/pilot/pkg/security/authz/builder/testdata/http/dry-run-allow-and-deny-out2.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/dry-run-allow-and-deny-out2.yaml
@@ -16,4 +16,4 @@ typedConfig:
         - andIds:
             ids:
             - any: true
-  shadowRulesStatPrefix: istio_dry_run_
+  shadowRulesStatPrefix: istio_dry_run_allow_

--- a/pilot/pkg/security/authz/builder/testdata/http/dry-run-allow-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/dry-run-allow-out.yaml
@@ -16,4 +16,4 @@ typedConfig:
         - andIds:
             ids:
             - any: true
-  shadowRulesStatPrefix: istio_dry_run_
+  shadowRulesStatPrefix: istio_dry_run_allow_

--- a/pilot/pkg/security/authz/builder/testdata/http/dry-run-mix-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/dry-run-mix-out.yaml
@@ -31,4 +31,4 @@ typedConfig:
         - andIds:
             ids:
             - any: true
-  shadowRulesStatPrefix: istio_dry_run_
+  shadowRulesStatPrefix: istio_dry_run_allow_

--- a/pilot/pkg/security/authz/builder/testdata/http/multiple-policies-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/multiple-policies-out.yaml
@@ -171,4 +171,4 @@ typedConfig:
                 - header:
                     exactMatch: abc2
                     name: X-abc
-  shadowRulesStatPrefix: istio_dry_run_
+  shadowRulesStatPrefix: istio_dry_run_allow_

--- a/pilot/pkg/security/authz/builder/testdata/http/simple-policy-multiple-td-aliases-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/simple-policy-multiple-td-aliases-out.yaml
@@ -91,4 +91,4 @@ typedConfig:
                         safeRegex:
                           googleRe2: {}
                           regex: .*/ns/rule[0]-from[1]-ns[0]/.*
-  shadowRulesStatPrefix: istio_dry_run_
+  shadowRulesStatPrefix: istio_dry_run_allow_

--- a/pilot/pkg/security/authz/builder/testdata/http/simple-policy-principal-with-wildcard-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/simple-policy-principal-with-wildcard-out.yaml
@@ -47,4 +47,4 @@ typedConfig:
                     value:
                       stringMatch:
                         suffix: bar/ns/foo/sa/rule[0]-from[1]-principal[1]
-  shadowRulesStatPrefix: istio_dry_run_
+  shadowRulesStatPrefix: istio_dry_run_allow_

--- a/pilot/pkg/security/authz/builder/testdata/http/simple-policy-td-aliases-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/simple-policy-td-aliases-out.yaml
@@ -102,4 +102,4 @@ typedConfig:
                     value:
                       stringMatch:
                         exact: cluster.local/ns/rule[1]/sa/from[0]-principal[0]
-  shadowRulesStatPrefix: istio_dry_run_
+  shadowRulesStatPrefix: istio_dry_run_allow_

--- a/pilot/pkg/security/authz/builder/testdata/http/single-policy-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/single-policy-out.yaml
@@ -466,4 +466,4 @@ typedConfig:
                 - directRemoteIp:
                     addressPrefix: 192.1.1.2
                     prefixLen: 32
-  shadowRulesStatPrefix: istio_dry_run_
+  shadowRulesStatPrefix: istio_dry_run_allow_

--- a/pilot/pkg/security/authz/builder/testdata/http/td-aliases-source-principal-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/td-aliases-source-principal-out.yaml
@@ -54,4 +54,4 @@ typedConfig:
                     value:
                       stringMatch:
                         exact: some-trustdomain/ns/foo/sa/prefix-td
-  shadowRulesStatPrefix: istio_dry_run_
+  shadowRulesStatPrefix: istio_dry_run_allow_

--- a/pilot/pkg/security/authz/builder/testdata/tcp/allow-both-http-tcp-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/tcp/allow-both-http-tcp-out.yaml
@@ -20,5 +20,5 @@ typedConfig:
                       safeRegex:
                         googleRe2: {}
                         regex: .*/ns/ns-1/.*
-  shadowRulesStatPrefix: istio_dry_run_
+  shadowRulesStatPrefix: istio_dry_run_allow_
   statPrefix: tcp.

--- a/pilot/pkg/security/authz/builder/testdata/tcp/allow-only-http-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/tcp/allow-only-http-out.yaml
@@ -2,5 +2,5 @@ name: envoy.filters.network.rbac
 typedConfig:
   '@type': type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC
   rules: {}
-  shadowRulesStatPrefix: istio_dry_run_
+  shadowRulesStatPrefix: istio_dry_run_allow_
   statPrefix: tcp.

--- a/pilot/pkg/security/authz/builder/testdata/tcp/audit-both-http-tcp-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/tcp/audit-both-http-tcp-out.yaml
@@ -160,5 +160,5 @@ typedConfig:
                   - authenticated:
                       principalName:
                         exact: spiffe://not-principal
-  shadowRulesStatPrefix: istio_dry_run_
+  shadowRulesStatPrefix: istio_dry_run_allow_
   statPrefix: tcp.

--- a/pilot/pkg/security/authz/builder/testdata/tcp/deny-both-http-tcp-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/tcp/deny-both-http-tcp-out.yaml
@@ -362,5 +362,5 @@ typedConfig:
                         safeRegex:
                           googleRe2: {}
                           regex: .+
-  shadowRulesStatPrefix: istio_dry_run_
+  shadowRulesStatPrefix: istio_dry_run_allow_
   statPrefix: tcp.

--- a/pilot/pkg/security/authz/builder/testdata/tcp/dry-run-mix-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/tcp/dry-run-mix-out.yaml
@@ -27,5 +27,5 @@ typedConfig:
         - andIds:
             ids:
             - any: true
-  shadowRulesStatPrefix: istio_dry_run_
+  shadowRulesStatPrefix: istio_dry_run_allow_
   statPrefix: tcp.

--- a/pilot/pkg/security/authz/model/model.go
+++ b/pilot/pkg/security/authz/model/model.go
@@ -29,9 +29,8 @@ const (
 	RBACHTTPFilterName = "envoy.filters.http.rbac"
 
 	// RBACTCPFilterName is the name of the RBAC network filter in envoy.
-	RBACTCPFilterName         = "envoy.filters.network.rbac"
-	RBACTCPFilterStatPrefix   = "tcp."
-	RBACShadowRulesStatPrefix = "istio_dry_run_"
+	RBACTCPFilterName       = "envoy.filters.network.rbac"
+	RBACTCPFilterStatPrefix = "tcp."
 
 	attrRequestHeader    = "request.headers"             // header name is surrounded by brackets, e.g. "request.headers[User-Agent]".
 	attrSrcIP            = "source.ip"                   // supports both single ip and cidr, e.g. "10.1.2.3" or "10.1.0.0/16".

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -182,8 +182,16 @@ func checkDryRunAnnotation(cfg config.Config, allowed bool) error {
 		if !allowed {
 			return fmt.Errorf("%s/%s has unsupported annotation %s, please remove the annotation", cfg.Namespace, cfg.Name, annotation.IoIstioDryRun.Name)
 		}
-		if _, err := strconv.ParseBool(val); err != nil {
-			return fmt.Errorf("%s/%s has annotation %s with invalid value (%s): %v", cfg.Namespace, cfg.Name, annotation.IoIstioDryRun.Name, val, err)
+		if spec, ok := cfg.Spec.(*security_beta.AuthorizationPolicy); ok {
+			switch spec.Action {
+			case security_beta.AuthorizationPolicy_ALLOW, security_beta.AuthorizationPolicy_DENY:
+				if _, err := strconv.ParseBool(val); err != nil {
+					return fmt.Errorf("%s/%s has annotation %s with invalid value (%s): %v", cfg.Namespace, cfg.Name, annotation.IoIstioDryRun.Name, val, err)
+				}
+			default:
+				return fmt.Errorf("the annotation %s currently only supports action ALLOW/DENY, found action %v in %s/%s",
+					annotation.IoIstioDryRun.Name, spec.Action, cfg.Namespace, cfg.Name)
+			}
 		}
 	}
 	return nil

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -4332,10 +4332,43 @@ func TestValidateAuthorizationPolicy(t *testing.T) {
 			valid: true,
 		},
 		{
-			name:        "dry-run-invalid",
+			name:        "dry-run-valid-allow",
+			annotations: map[string]string{"istio.io/dry-run": "true"},
+			in: &security_beta.AuthorizationPolicy{
+				Action: security_beta.AuthorizationPolicy_ALLOW,
+			},
+			valid: true,
+		},
+		{
+			name:        "dry-run-valid-deny",
+			annotations: map[string]string{"istio.io/dry-run": "false"},
+			in: &security_beta.AuthorizationPolicy{
+				Action: security_beta.AuthorizationPolicy_DENY,
+				Rules:  []*security_beta.Rule{{}},
+			},
+			valid: true,
+		},
+		{
+			name:        "dry-run-invalid-value",
 			annotations: map[string]string{"istio.io/dry-run": "foo"},
 			in: &security_beta.AuthorizationPolicy{
 				Action: security_beta.AuthorizationPolicy_ALLOW,
+			},
+			valid: false,
+		},
+		{
+			name:        "dry-run-invalid-action-custom",
+			annotations: map[string]string{"istio.io/dry-run": "true"},
+			in: &security_beta.AuthorizationPolicy{
+				Action: security_beta.AuthorizationPolicy_CUSTOM,
+			},
+			valid: false,
+		},
+		{
+			name:        "dry-run-invalid-action-audit",
+			annotations: map[string]string{"istio.io/dry-run": "true"},
+			in: &security_beta.AuthorizationPolicy{
+				Action: security_beta.AuthorizationPolicy_AUDIT,
 			},
 			valid: false,
 		},

--- a/tests/integration/telemetry/stackdriver/stackdriver_filter_dry_run_test.go
+++ b/tests/integration/telemetry/stackdriver/stackdriver_filter_dry_run_test.go
@@ -20,10 +20,11 @@ import (
 	"testing"
 
 	"golang.org/x/sync/errgroup"
+
 	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/stackdriver"
 	telemetrypkg "istio.io/istio/pkg/test/framework/components/telemetry"
-	"istio.io/istio/pkg/test/scopes"
 	"istio.io/istio/pkg/test/util/file"
 	"istio.io/istio/pkg/test/util/retry"
 	"istio.io/istio/pkg/test/util/tmpl"
@@ -32,8 +33,10 @@ import (
 )
 
 const (
-	dryRunServerLogEntry      = "testdata/security_authz_dry_run/server_access_log.json.tmpl"
-	dryRunAuthorizationPolicy = "testdata/security_authz_dry_run/authorization_policy.yaml.tmpl"
+	dryRunServerLogEntry         = "testdata/security_authz_dry_run/server_access_log.json.tmpl"
+	dryRunTCPServerLogEntry      = "testdata/security_authz_dry_run/tcp_server_access_log.json.tmpl"
+	dryRunAuthorizationPolicy    = "testdata/security_authz_dry_run/authorization_policy.yaml.tmpl"
+	dryRunTCPAuthorizationPolicy = "testdata/security_authz_dry_run/tcp_authorization_policy.yaml.tmpl"
 )
 
 // TestStackdriverAuthzDryRun verifies that stackdriver WASM filter exports dry-run metrics with expected labels.
@@ -41,11 +44,7 @@ func TestStackdriverAuthzDryRun(t *testing.T) {
 	framework.NewTest(t).
 		Features("observability.telemetry.stackdriver").
 		Run(func(ctx framework.TestContext) {
-			ns := getEchoNamespaceInstance()
-			policies := tmpl.EvaluateAllOrFail(t, map[string]string{"Namespace": ns.Name()}, file.AsStringOrFail(t, dryRunAuthorizationPolicy))
-			ctx.Config().ApplyYAMLOrFail(t, ns.Name(), policies...)
-			util.WaitForConfig(ctx, policies[0], ns)
-
+			createDryRunPolicy(t, ctx, dryRunAuthorizationPolicy)
 			g, _ := errgroup.WithContext(context.Background())
 			for _, cltInstance := range clt {
 				cltInstance := cltInstance
@@ -54,14 +53,7 @@ func TestStackdriverAuthzDryRun(t *testing.T) {
 						if err := sendTraffic(t, cltInstance); err != nil {
 							return err
 						}
-						clName := cltInstance.Config().Cluster.Name()
-						trustDomain := telemetry.GetTrustDomain(cltInstance.Config().Cluster, ist.Settings().SystemNamespace)
-						scopes.Framework.Infof("Validating for cluster %s", clName)
-						if err := validateLogs(t, dryRunServerLogEntry, clName, trustDomain, stackdriver.ServerAccessLog); err != nil {
-							return err
-						}
-						t.Logf("logs validated")
-						return nil
+						return verifyAccessLog(t, cltInstance, dryRunServerLogEntry)
 					}, retry.Delay(telemetrypkg.RetryDelay), retry.Timeout(telemetrypkg.RetryTimeout))
 					if err != nil {
 						return err
@@ -73,4 +65,54 @@ func TestStackdriverAuthzDryRun(t *testing.T) {
 				t.Fatalf("test failed: %v", err)
 			}
 		})
+}
+
+// TestTCPStackdriverAuthzDryRun verifies that stackdriver TCP filter works.
+func TestTCPStackdriverAuthzDryRun(t *testing.T) {
+	framework.NewTest(t).
+		Features("observability.telemetry.stackdriver").
+		Run(func(ctx framework.TestContext) {
+			createDryRunPolicy(t, ctx, dryRunTCPAuthorizationPolicy)
+			g, _ := errgroup.WithContext(context.Background())
+			for _, cltInstance := range clt {
+				cltInstance := cltInstance
+				g.Go(func() error {
+					err := retry.UntilSuccess(func() error {
+						_, err := cltInstance.Call(echo.CallOptions{
+							Target:   srv[0],
+							PortName: "tcp",
+							Count:    telemetry.RequestCountMultipler * len(srv),
+						})
+						if err != nil {
+							return err
+						}
+						return verifyAccessLog(t, cltInstance, dryRunTCPServerLogEntry)
+					}, retry.Delay(telemetrypkg.RetryDelay), retry.Timeout(telemetrypkg.RetryTimeout))
+					if err != nil {
+						return err
+					}
+					return nil
+				})
+			}
+			if err := g.Wait(); err != nil {
+				t.Fatalf("test failed: %v", err)
+			}
+		})
+}
+
+func createDryRunPolicy(t *testing.T, ctx framework.TestContext, authz string) {
+	ns := getEchoNamespaceInstance()
+	policies := tmpl.EvaluateAllOrFail(t, map[string]string{"Namespace": ns.Name()}, file.AsStringOrFail(t, authz))
+	ctx.Config().ApplyYAMLOrFail(t, ns.Name(), policies...)
+	util.WaitForConfig(ctx, policies[0], ns)
+}
+
+func verifyAccessLog(t *testing.T, cltInstance echo.Instance, wantLog string) error {
+	t.Logf("Validating for cluster %v", cltInstance.Config().Cluster)
+	clName := cltInstance.Config().Cluster.Name()
+	trustDomain := telemetry.GetTrustDomain(cltInstance.Config().Cluster, ist.Settings().SystemNamespace)
+	if err := validateLogs(t, wantLog, clName, trustDomain, stackdriver.ServerAccessLog); err != nil {
+		return err
+	}
+	return nil
 }

--- a/tests/integration/telemetry/stackdriver/stackdriver_filter_dry_run_test.go
+++ b/tests/integration/telemetry/stackdriver/stackdriver_filter_dry_run_test.go
@@ -39,7 +39,7 @@ const (
 	dryRunTCPAuthorizationPolicy = "testdata/security_authz_dry_run/tcp_authorization_policy.yaml.tmpl"
 )
 
-// TestStackdriverAuthzDryRun verifies that stackdriver WASM filter exports dry-run metrics with expected labels.
+// TestStackdriverAuthzDryRun verifies that stackdriver WASM filter exports dry-run logs with expected labels for HTTP traffic.
 func TestStackdriverAuthzDryRun(t *testing.T) {
 	framework.NewTest(t).
 		Features("observability.telemetry.stackdriver").
@@ -67,7 +67,7 @@ func TestStackdriverAuthzDryRun(t *testing.T) {
 		})
 }
 
-// TestTCPStackdriverAuthzDryRun verifies that stackdriver TCP filter works.
+// TestTCPStackdriverAuthzDryRun verifies that stackdriver WASM filter exports dry-run logs with expected labels for TCP traffic.
 func TestTCPStackdriverAuthzDryRun(t *testing.T) {
 	framework.NewTest(t).
 		Features("observability.telemetry.stackdriver").

--- a/tests/integration/telemetry/stackdriver/stackdriver_filter_dry_run_test.go
+++ b/tests/integration/telemetry/stackdriver/stackdriver_filter_dry_run_test.go
@@ -1,0 +1,76 @@
+// +build integ
+// Copyright Istio Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stackdriver
+
+import (
+	"context"
+	"testing"
+
+	"golang.org/x/sync/errgroup"
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/stackdriver"
+	telemetrypkg "istio.io/istio/pkg/test/framework/components/telemetry"
+	"istio.io/istio/pkg/test/scopes"
+	"istio.io/istio/pkg/test/util/file"
+	"istio.io/istio/pkg/test/util/retry"
+	"istio.io/istio/pkg/test/util/tmpl"
+	"istio.io/istio/tests/integration/security/util"
+	"istio.io/istio/tests/integration/telemetry"
+)
+
+const (
+	dryRunServerLogEntry      = "testdata/security_authz_dry_run/server_access_log.json.tmpl"
+	dryRunAuthorizationPolicy = "testdata/security_authz_dry_run/authorization_policy.yaml.tmpl"
+)
+
+// TestStackdriverAuthzDryRun verifies that stackdriver WASM filter exports dry-run metrics with expected labels.
+func TestStackdriverAuthzDryRun(t *testing.T) {
+	framework.NewTest(t).
+		Features("observability.telemetry.stackdriver").
+		Run(func(ctx framework.TestContext) {
+			ns := getEchoNamespaceInstance()
+			policies := tmpl.EvaluateAllOrFail(t, map[string]string{"Namespace": ns.Name()}, file.AsStringOrFail(t, dryRunAuthorizationPolicy))
+			ctx.Config().ApplyYAMLOrFail(t, ns.Name(), policies...)
+			util.WaitForConfig(ctx, policies[0], ns)
+
+			g, _ := errgroup.WithContext(context.Background())
+			for _, cltInstance := range clt {
+				cltInstance := cltInstance
+				g.Go(func() error {
+					err := retry.UntilSuccess(func() error {
+						if err := sendTraffic(t, cltInstance); err != nil {
+							return err
+						}
+						clName := cltInstance.Config().Cluster.Name()
+						trustDomain := telemetry.GetTrustDomain(cltInstance.Config().Cluster, ist.Settings().SystemNamespace)
+						scopes.Framework.Infof("Validating for cluster %s", clName)
+						if err := validateLogs(t, dryRunServerLogEntry, clName, trustDomain, stackdriver.ServerAccessLog); err != nil {
+							return err
+						}
+						t.Logf("logs validated")
+						return nil
+					}, retry.Delay(telemetrypkg.RetryDelay), retry.Timeout(telemetrypkg.RetryTimeout))
+					if err != nil {
+						return err
+					}
+					return nil
+				})
+			}
+			if err := g.Wait(); err != nil {
+				t.Fatalf("test failed: %v", err)
+			}
+		})
+}

--- a/tests/integration/telemetry/stackdriver/testdata/security_authz_dry_run/authorization_policy.yaml.tmpl
+++ b/tests/integration/telemetry/stackdriver/testdata/security_authz_dry_run/authorization_policy.yaml.tmpl
@@ -1,0 +1,27 @@
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  namespace: "{{ .Namespace }}"
+  name: "dry-run-deny"
+  annotations:
+    "istio.io/dry-run": "true"
+spec:
+  action: DENY
+  rules:
+  - to:
+    - operation:
+        methods: ["POST"]
+---
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  namespace: "{{ .Namespace }}"
+  name: "dry-run-allow"
+  annotations:
+    "istio.io/dry-run": "true"
+spec:
+  action: ALLOW
+  rules:
+  - to:
+    - operation:
+        methods: ["POST"]

--- a/tests/integration/telemetry/stackdriver/testdata/security_authz_dry_run/server_access_log.json.tmpl
+++ b/tests/integration/telemetry/stackdriver/testdata/security_authz_dry_run/server_access_log.json.tmpl
@@ -1,0 +1,38 @@
+{
+    "http_request": {
+        "request_method": "POST",
+        "request_url": "http://srv.{{ .EchoNamespace }}.svc.cluster.local/proto.EchoTestService/Echo",
+        "protocol": "grpc",
+        "status": "200"
+    },
+    "labels": {
+        "destination_app": "srv",
+        "destination_canonical_revision": "v1",
+        "destination_canonical_service": "srv",
+        "destination_namespace": "{{ .EchoNamespace }}",
+        "destination_principal": "spiffe://{{ .TrustDomain }}/ns/{{ .EchoNamespace }}/sa/default",
+        "destination_service_host": "srv.{{ .EchoNamespace }}.svc.cluster.local",
+        "destination_service_name": "srv",
+        "destination_version": "v1",
+        "destination_workload": "srv-v1",
+        "mesh_uid": "proj-test-mesh",
+        "response_flag": "-",
+        "service_authentication_policy": "MUTUAL_TLS",
+        "source_app": "clt-{{ .ClusterName }}",
+        "source_canonical_revision": "v1",
+        "source_canonical_service": "clt-{{ .ClusterName }}",
+        "source_namespace": "{{ .EchoNamespace }}",
+        "source_principal": "spiffe://{{ .TrustDomain }}/ns/{{ .EchoNamespace }}/sa/default",
+        "source_version": "v1",
+        "source_workload": "clt-{{ .ClusterName }}-v1",
+        "protocol": "grpc",
+        "log_sampled": "true",
+        "upstream_cluster": "inbound|7070||",
+        "route_name": "default",
+        "requested_server_name": "outbound_.7070_._.srv.{{ .EchoNamespace }}.svc.cluster.local",
+        "response_details": "via_upstream",
+        "dry_run_result": "AuthzDenied",
+        "dry_run_policy_name": "{{ .EchoNamespace }}.dry-run-deny",
+        "dry_run_policy_rule": "0"
+    }
+}

--- a/tests/integration/telemetry/stackdriver/testdata/security_authz_dry_run/tcp_authorization_policy.yaml.tmpl
+++ b/tests/integration/telemetry/stackdriver/testdata/security_authz_dry_run/tcp_authorization_policy.yaml.tmpl
@@ -1,0 +1,27 @@
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  namespace: "{{ .Namespace }}"
+  name: "dry-run-deny"
+  annotations:
+    "istio.io/dry-run": "true"
+spec:
+  action: DENY
+  rules:
+  - from:
+    - source:
+        principals: ["none"]
+---
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  namespace: "{{ .Namespace }}"
+  name: "dry-run-allow"
+  annotations:
+    "istio.io/dry-run": "true"
+spec:
+  action: ALLOW
+  rules:
+  - from:
+    - source:
+        principals: ["*"]

--- a/tests/integration/telemetry/stackdriver/testdata/security_authz_dry_run/tcp_server_access_log.json.tmpl
+++ b/tests/integration/telemetry/stackdriver/testdata/security_authz_dry_run/tcp_server_access_log.json.tmpl
@@ -1,0 +1,32 @@
+{
+    "text_payload": "clt-{{ .ClusterName }} --> srv",
+    "labels": {
+        "destination_app": "srv",
+        "destination_canonical_revision": "v1",
+        "destination_canonical_service": "srv",
+        "destination_namespace": "{{ .EchoNamespace }}",
+        "destination_principal": "spiffe://{{ .TrustDomain }}/ns/{{ .EchoNamespace }}/sa/default",
+        "destination_service_host": "srv.{{ .EchoNamespace }}.svc.cluster.local",
+        "destination_service_name": "srv",
+        "destination_version": "v1",
+        "destination_workload": "srv-v1",
+        "destination_port": "9000",
+        "mesh_uid": "proj-test-mesh",
+        "response_flag": "-",
+        "service_authentication_policy": "MUTUAL_TLS",
+        "source_app": "clt-{{ .ClusterName }}",
+        "source_canonical_revision": "v1",
+        "source_canonical_service": "clt-{{ .ClusterName }}",
+        "source_namespace": "{{ .EchoNamespace }}",
+        "source_principal": "spiffe://{{ .TrustDomain }}/ns/{{ .EchoNamespace }}/sa/default",
+        "source_version": "v1",
+        "source_workload": "clt-{{ .ClusterName }}-v1",
+        "protocol": "tcp",
+        "log_sampled": "false",
+        "requested_server_name": "outbound_.9090_._.srv.{{ .EchoNamespace }}.svc.cluster.local",
+        "upstream_cluster": "inbound|9000||"
+        "dry_run_result": "AuthzAllowed",
+        "dry_run_policy_name": "{{ .EchoNamespace }}.dry-run-allow",
+        "dry_run_policy_rule": "0"
+    }
+}

--- a/tests/integration/telemetry/stackdriver/testdata/security_authz_dry_run/tcp_server_access_log.json.tmpl
+++ b/tests/integration/telemetry/stackdriver/testdata/security_authz_dry_run/tcp_server_access_log.json.tmpl
@@ -24,7 +24,7 @@
         "protocol": "tcp",
         "log_sampled": "false",
         "requested_server_name": "outbound_.9090_._.srv.{{ .EchoNamespace }}.svc.cluster.local",
-        "upstream_cluster": "inbound|9000||"
+        "upstream_cluster": "inbound|9000||",
         "dry_run_result": "AuthzAllowed",
         "dry_run_policy_name": "{{ .EchoNamespace }}.dry-run-allow",
         "dry_run_policy_rule": "0"


### PR DESCRIPTION
This PR updates to use the correct metric prefix for dry-run results and also add e2e tests with stackdriver.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[x] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any changes that may affect Istio users.