### PR TITLE
Add example of add to list by overlays patches

### DIFF
--- a/operator/README.md
+++ b/operator/README.md
@@ -392,6 +392,15 @@ spec:
             value: "60m" # OVERRIDDEN
           - path: spec.template.spec.containers.[name:discovery].ports.[containerPort:8080].containerPort
             value: 8090 # OVERRIDDEN
+          - path: 'spec.template.spec.volumes[100]' #push to the list
+            value:
+              configMap:
+                name: my-config-map
+              name: my-volume-name
+          - path: 'spec.template.spec.containers[0].volumeMounts[100]'
+            value:
+              mountPath: /mnt/path1
+              name: my-volume-name
         - kind: Service
           name: istio-pilot
           patches:


### PR DESCRIPTION
Hi,

docs missing example of push to the lists by overlays patches, this PR fix this issue.


[ ] Configuration Infrastructure
[x] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any changes that may affect Istio users.
