### PR TITLE
istioctl describe: check UID 1337 for application pods

### DIFF
--- a/istioctl/cmd/describe.go
+++ b/istioctl/cmd/describe.go
@@ -432,7 +432,7 @@ func printPod(writer io.Writer, pod *v1.Pod) {
 		if container.Name != "istio-proxy" {
 			if container.SecurityContext != nil && container.SecurityContext.RunAsUser != nil {
 				if *container.SecurityContext.RunAsUser == UID {
-					fmt.Fprintf(writer, "WARNING: Ensure your pods do not run applications as a user with the user ID (UID) value of 1337\n")
+					fmt.Fprintf(writer, "WARNING: Application pods should not run as user ID (UID) 1337\n")
 				}
 			}
 		}
@@ -468,7 +468,7 @@ func printPod(writer io.Writer, pod *v1.Pod) {
 	// Ref: https://istio.io/latest/docs/ops/deployment/requirements/#pod-requirements
 	if pod.Spec.SecurityContext != nil && pod.Spec.SecurityContext.RunAsUser != nil {
 		if *pod.Spec.SecurityContext.RunAsUser == UID {
-			fmt.Fprintf(writer, "   WARNING: Ensure your pods do not run applications as a user with the user ID (UID) value of 1337\n")
+			fmt.Fprintf(writer, "   WARNING: Application pods should not run as user ID (UID) 1337\n")
 		}
 	}
 

--- a/istioctl/cmd/describe.go
+++ b/istioctl/cmd/describe.go
@@ -418,7 +418,7 @@ func renderMatch(match *v1alpha3.HTTPMatchRequest) string {
 
 func printPod(writer io.Writer, pod *v1.Pod) {
 	ports := []string{}
-	UID := int64(1337)
+	UserID := int64(1337)
 	for _, container := range pod.Spec.Containers {
 		for _, port := range container.Ports {
 			var protocol string
@@ -431,8 +431,8 @@ func printPod(writer io.Writer, pod *v1.Pod) {
 		// Ref: https://istio.io/latest/docs/ops/deployment/requirements/#pod-requirements
 		if container.Name != "istio-proxy" && container.Name != "istio-operator" {
 			if container.SecurityContext != nil && container.SecurityContext.RunAsUser != nil {
-				if *container.SecurityContext.RunAsUser == UID {
-					fmt.Fprintf(writer, "WARNING: Application pods should not run as user ID (UID) 1337\n")
+				if *container.SecurityContext.RunAsUser == UserID {
+					fmt.Fprintf(writer, "WARNING: User ID (UID) 1337 is reserved for the sidecar proxy.\n")
 				}
 			}
 		}
@@ -467,8 +467,8 @@ func printPod(writer io.Writer, pod *v1.Pod) {
 
 	// Ref: https://istio.io/latest/docs/ops/deployment/requirements/#pod-requirements
 	if pod.Spec.SecurityContext != nil && pod.Spec.SecurityContext.RunAsUser != nil {
-		if *pod.Spec.SecurityContext.RunAsUser == UID {
-			fmt.Fprintf(writer, "   WARNING: Application pods should not run as user ID (UID) 1337\n")
+		if *pod.Spec.SecurityContext.RunAsUser == UserID {
+			fmt.Fprintf(writer, "   WARNING: User ID (UID) 1337 is reserved for the sidecar proxy.\n")
 		}
 	}
 

--- a/istioctl/cmd/describe.go
+++ b/istioctl/cmd/describe.go
@@ -429,7 +429,7 @@ func printPod(writer io.Writer, pod *v1.Pod) {
 			ports = append(ports, fmt.Sprintf("%d%s (%s)", port.ContainerPort, protocol, container.Name))
 		}
 		// Ref: https://istio.io/latest/docs/ops/deployment/requirements/#pod-requirements
-		if container.Name != "istio-proxy" {
+		if container.Name != "istio-proxy" && container.Name != "istio-operator" {
 			if container.SecurityContext != nil && container.SecurityContext.RunAsUser != nil {
 				if *container.SecurityContext.RunAsUser == UID {
 					fmt.Fprintf(writer, "WARNING: Application pods should not run as user ID (UID) 1337\n")

--- a/istioctl/cmd/describe.go
+++ b/istioctl/cmd/describe.go
@@ -419,7 +419,6 @@ func renderMatch(match *v1alpha3.HTTPMatchRequest) string {
 func printPod(writer io.Writer, pod *v1.Pod) {
 	ports := []string{}
 	UID := int64(1337)
-	UIDWarnMsg := "   WARN: Ensure your pods do not run applications as a user with the user ID (UID) value of 1337\n"
 	for _, container := range pod.Spec.Containers {
 		for _, port := range container.Ports {
 			var protocol string
@@ -433,7 +432,7 @@ func printPod(writer io.Writer, pod *v1.Pod) {
 		if container.Name != "istio-proxy" {
 			if container.SecurityContext != nil && container.SecurityContext.RunAsUser != nil {
 				if *container.SecurityContext.RunAsUser == UID {
-					fmt.Fprintf(writer, UIDWarnMsg)
+					fmt.Fprintf(writer, "WARNING: Ensure your pods do not run applications as a user with the user ID (UID) value of 1337\n")
 				}
 			}
 		}
@@ -469,7 +468,7 @@ func printPod(writer io.Writer, pod *v1.Pod) {
 	// Ref: https://istio.io/latest/docs/ops/deployment/requirements/#pod-requirements
 	if pod.Spec.SecurityContext != nil && pod.Spec.SecurityContext.RunAsUser != nil {
 		if *pod.Spec.SecurityContext.RunAsUser == UID {
-			fmt.Fprintf(writer, UIDWarnMsg)
+			fmt.Fprintf(writer, "   WARNING: Ensure your pods do not run applications as a user with the user ID (UID) value of 1337\n")
 		}
 	}
 


### PR DESCRIPTION
To fix https://github.com/istio/istio/issues/31874

Update helloworld sample to include container level securityContext and run
```
$ kubectl apply -f samples/helloworld/helloworld.yaml
```

```
$ istioctl x describe pod helloworld-v1-544fc955f5-2fk67
WARNING: Application pods should not run as user ID (UID) 1337\n
Pod: helloworld-v1-544fc955f5-2fk67
   Pod Ports: 5000 (helloworld), 15090 (istio-proxy)
--------------------
Service: helloworld
   Port: http 5000/HTTP targets pod port 5000
```

Update helloworld sample to include pod Level securityContext
```
$ istioctl x describe pod helloworld-v2-5b9c5cc9bc-qvpmn
Pod: helloworld-v2-5b9c5cc9bc-qvpmn
   Pod Ports: 5000 (helloworld), 15090 (istio-proxy)
   WARNING: Application pods should not run as user ID (UID) 1337\n
--------------------
Service: helloworld
   Port: http 5000/HTTP targets pod port 5000
```