### PR TITLE
Fix race condition in mesh config update

### DIFF
--- a/pkg/config/mesh/kubemesh/watcher.go
+++ b/pkg/config/mesh/kubemesh/watcher.go
@@ -44,6 +44,8 @@ func NewConfigMapWatcher(client kube.Client, namespace, name, key, extraConfig s
 			log.Warnf("failed to read mesh config from ConfigMap: %v", err)
 			return
 		}
+		w.Mutex.Lock()
+		defer w.Mutex.Unlock()
 		w.HandleMeshConfig(meshConfig)
 	})
 

--- a/pkg/config/mesh/kubemesh/watcher.go
+++ b/pkg/config/mesh/kubemesh/watcher.go
@@ -44,8 +44,6 @@ func NewConfigMapWatcher(client kube.Client, namespace, name, key, extraConfig s
 			log.Warnf("failed to read mesh config from ConfigMap: %v", err)
 			return
 		}
-		w.Mutex.Lock()
-		defer w.Mutex.Unlock()
 		w.HandleMeshConfig(meshConfig)
 	})
 

--- a/pkg/config/mesh/watcher.go
+++ b/pkg/config/mesh/watcher.go
@@ -44,7 +44,7 @@ type Watcher interface {
 var _ Watcher = &InternalWatcher{}
 
 type InternalWatcher struct {
-	mutux    sync.Mutex
+	mutex    sync.Mutex
 	handlers []func()
 	// Current merged mesh config
 	MeshConfig *meshconfig.MeshConfig
@@ -93,16 +93,16 @@ func (w *InternalWatcher) Mesh() *meshconfig.MeshConfig {
 
 // AddMeshHandler registers a callback handler for changes to the mesh config.
 func (w *InternalWatcher) AddMeshHandler(h func()) {
-	w.mutux.Lock()
-	defer w.mutux.Unlock()
+	w.mutex.Lock()
+	defer w.mutex.Unlock()
 	w.handlers = append(w.handlers, h)
 }
 
 // HandleMeshConfigData keeps track of the standard mesh config. These are merged with the user
 // mesh config, but takes precedence.
 func (w *InternalWatcher) HandleMeshConfigData(yaml string) {
-	w.mutux.Lock()
-	defer w.mutux.Unlock()
+	w.mutex.Lock()
+	defer w.mutex.Unlock()
 	w.revMeshConfig = yaml
 	merged := w.merged()
 	w.handleMeshConfigInternal(merged)
@@ -111,8 +111,8 @@ func (w *InternalWatcher) HandleMeshConfigData(yaml string) {
 // HandleUserMeshConfig keeps track of user mesh config overrides. These are merged with the standard
 // mesh config, which takes precedence.
 func (w *InternalWatcher) HandleUserMeshConfig(yaml string) {
-	w.mutux.Lock()
-	defer w.mutux.Unlock()
+	w.mutex.Lock()
+	defer w.mutex.Unlock()
 	w.userMeshConfig = yaml
 	merged := w.merged()
 	w.handleMeshConfigInternal(merged)
@@ -143,8 +143,8 @@ func (w *InternalWatcher) merged() *meshconfig.MeshConfig {
 // HandleMeshConfig calls all handlers for a given mesh configuration update. This must be called
 // with a lock on w.Mutex, or updates may be applied out of order.
 func (w *InternalWatcher) HandleMeshConfig(meshConfig *meshconfig.MeshConfig) {
-	w.mutux.Lock()
-	defer w.mutux.Unlock()
+	w.mutex.Lock()
+	defer w.mutex.Unlock()
 	w.handleMeshConfigInternal(meshConfig)
 }
 


### PR DESCRIPTION
Out of order updates may cause the callback to run out of order,
persisting an older version

Example test failure:
https://prow.istio.io/view/gs/istio-prow/logs/unit-tests_istio_postsubmit/1379065239072411648

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
