### PR TITLE
Copy cni repair and taint binary to local bin folder.

### DIFF
--- a/cni/deployments/kubernetes/Dockerfile.install-cni
+++ b/cni/deployments/kubernetes/Dockerfile.install-cni
@@ -14,10 +14,10 @@ COPY istio-iptables /opt/cni/bin/
 COPY install-cni /usr/local/bin/
 
 # Copy over the Repair binary
-COPY istio-cni-repair /opt/cni/bin/
+COPY istio-cni-repair /opt/local/bin/
 
 # Copy over the Taint binary
-COPY istio-cni-taint /opt/cni/bin/
+COPY istio-cni-taint /opt/local/bin/
 
 ENV PATH=$PATH:/opt/cni/bin
 WORKDIR /opt/cni/bin

--- a/manifests/charts/istio-cni/templates/daemonset.yaml
+++ b/manifests/charts/istio-cni/templates/daemonset.yaml
@@ -113,7 +113,7 @@ spec:
           imagePullPolicy: {{ .Values.cni.pullPolicy | default .Values.global.imagePullPolicy }}
 {{- end }}
 
-          command: ["/opt/cni/bin/istio-cni-repair"]
+          command: ["/opt/local/bin/istio-cni-repair"]
           env:
           - name: "REPAIR_NODE-NAME"
             valueFrom:
@@ -146,7 +146,7 @@ spec:
 {{- if or .Values.cni.pullPolicy .Values.global.imagePullPolicy }}
           imagePullPolicy: {{ .Values.cni.pullPolicy | default .Values.global.imagePullPolicy }}
 {{- end }}
-          command: ["/opt/cni/bin/istio-cni-taint"]
+          command: ["/opt/local/bin/istio-cni-taint"]
           env:
           - name: "TAINT_RUN-AS-DAEMON"
             value: "true"


### PR DESCRIPTION
Storing istio-cni-repair and istio-cni-taint in `/opt/cni/bin` will make install-cni copy those two binaries into host cni binary folder, which is not necessary. This change copies those two binaries to the same place as install-cni.