### PR TITLE
Add more logs to install-cni.

### DIFF
--- a/cni/pkg/install-cni/cmd/root.go
+++ b/cni/pkg/install-cni/cmd/root.go
@@ -39,6 +39,7 @@ var rootCmd = &cobra.Command{
 		if cfg, err = constructConfig(); err != nil {
 			return
 		}
+		log.Infof("install cni with configuration: \n%+v", cfg)
 
 		isReady := install.StartServer()
 

--- a/cni/pkg/install-cni/pkg/config/config.go
+++ b/cni/pkg/install-cni/pkg/config/config.go
@@ -14,6 +14,11 @@
 
 package config
 
+import (
+	"fmt"
+	"strings"
+)
+
 // Config struct defines the Istio CNI installation options
 type Config struct {
 	CNINetDir        string
@@ -37,4 +42,28 @@ type Config struct {
 
 	UpdateCNIBinaries bool
 	SkipCNIBinaries   []string
+}
+
+func (c *Config) String() string {
+	var b strings.Builder
+	b.WriteString("CNINetDir: " + c.CNINetDir + "\n")
+	b.WriteString("MountedCNINetDir: " + c.MountedCNINetDir + "\n")
+	b.WriteString("CNIConfName: " + c.CNIConfName + "\n")
+	b.WriteString("ChainedCNIPlugin: " + fmt.Sprint(c.ChainedCNIPlugin) + "\n")
+	b.WriteString("CNINetworkConfigFile: " + c.CNINetworkConfigFile + "\n")
+	b.WriteString("CNINetworkConfig: " + c.CNINetworkConfig + "\n")
+
+	b.WriteString("LogLevel: " + c.LogLevel + "\n")
+	b.WriteString("KubeconfigFilename: " + c.KubeconfigFilename + "\n")
+	b.WriteString("KubeconfigMode: " + fmt.Sprintf("%#o", c.KubeconfigMode) + "\n")
+	b.WriteString("KubeCAFile: " + c.KubeCAFile + "\n")
+	b.WriteString("SkipTLSVerify: " + fmt.Sprint(c.SkipTLSVerify) + "\n")
+
+	b.WriteString("K8sServiceProtocol: " + c.K8sServiceProtocol + "\n")
+	b.WriteString("K8sServiceHost: " + c.K8sServiceHost + "\n")
+	b.WriteString("K8sServicePort: " + fmt.Sprint(c.K8sServicePort) + "\n")
+	b.WriteString("K8sNodeName: " + c.K8sNodeName + "\n")
+	b.WriteString("UpdateCNIBinaries: " + fmt.Sprint(c.UpdateCNIBinaries) + "\n")
+	b.WriteString("SkipCNIBinaries: " + fmt.Sprint(c.SkipCNIBinaries) + "\n")
+	return b.String()
 }

--- a/cni/pkg/install-cni/pkg/install/kubeconfig.go
+++ b/cni/pkg/install-cni/pkg/install/kubeconfig.go
@@ -15,6 +15,7 @@
 package install
 
 import (
+	"bytes"
 	"encoding/base64"
 	"fmt"
 	"io/ioutil"
@@ -27,6 +28,7 @@ import (
 	"istio.io/istio/cni/pkg/install-cni/pkg/config"
 	"istio.io/istio/cni/pkg/install-cni/pkg/constants"
 	"istio.io/istio/pkg/file"
+	"istio.io/pkg/log"
 )
 
 const kubeconfigTemplate = `# Kubeconfig file for Istio CNI plugin.
@@ -75,12 +77,12 @@ func createKubeconfigFile(cfg *config.Config, saToken string) (kubeconfigFilepat
 	}
 
 	protocol := cfg.K8sServiceProtocol
-	if len(protocol) == 0 {
+	if protocol == "" {
 		protocol = "https"
 	}
 
 	caFile := cfg.KubeCAFile
-	if len(caFile) == 0 {
+	if caFile == "" {
 		caFile = constants.ServiceAccountPath + "/ca.crt"
 	}
 
@@ -108,40 +110,23 @@ func createKubeconfigFile(cfg *config.Config, saToken string) (kubeconfigFilepat
 		TLSConfig:                 tlsConfig,
 	}
 
-	var tmpFile *os.File
-	tmpFile, err = ioutil.TempFile(cfg.MountedCNINetDir, cfg.KubeconfigFilename+".tmp.")
-	if err != nil {
-		return
-	}
-	defer func() {
-		if file.Exists(tmpFile.Name()) {
-			if rmErr := os.Remove(tmpFile.Name()); rmErr != nil {
-				if err != nil {
-					err = errors.Wrap(err, rmErr.Error())
-				} else {
-					err = rmErr
-				}
-			}
-		}
-	}()
-
-	if err = os.Chmod(tmpFile.Name(), os.FileMode(cfg.KubeconfigMode)); err != nil {
-		return
+	var kcbb bytes.Buffer
+	if err := tpl.Execute(&kcbb, fields); err != nil {
+		return "", err
 	}
 
-	if err = tpl.Execute(tmpFile, fields); err != nil {
-		if closeErr := tmpFile.Close(); closeErr != nil {
-			err = errors.Wrap(err, closeErr.Error())
-		}
-		return
+	var kcbbToPrint bytes.Buffer
+	fields.ServiceAccountToken = "<redacted>"
+	if !cfg.SkipTLSVerify {
+		fields.TLSConfig = fmt.Sprintf("certificate-authority-data: <CA cert from %s>", caFile)
 	}
-
-	if err = tmpFile.Close(); err != nil {
-		return
+	if err := tpl.Execute(&kcbbToPrint, fields); err != nil {
+		return "", err
 	}
 
 	kubeconfigFilepath = filepath.Join(cfg.MountedCNINetDir, cfg.KubeconfigFilename)
-	if err = os.Rename(tmpFile.Name(), kubeconfigFilepath); err != nil {
+	log.Infof("write kubeconfig file %s with: \n%+v", kubeconfigFilepath, kcbbToPrint.String())
+	if err = os.WriteFile(kubeconfigFilepath, kcbb.Bytes(), os.FileMode(cfg.KubeconfigMode)); err != nil {
 		return "", err
 	}
 

--- a/cni/pkg/install-cni/pkg/install/kubeconfig.go
+++ b/cni/pkg/install-cni/pkg/install/kubeconfig.go
@@ -126,7 +126,7 @@ func createKubeconfigFile(cfg *config.Config, saToken string) (kubeconfigFilepat
 
 	kubeconfigFilepath = filepath.Join(cfg.MountedCNINetDir, cfg.KubeconfigFilename)
 	log.Infof("write kubeconfig file %s with: \n%+v", kubeconfigFilepath, kcbbToPrint.String())
-	if err = os.WriteFile(kubeconfigFilepath, kcbb.Bytes(), os.FileMode(cfg.KubeconfigMode)); err != nil {
+	if err = file.AtomicWrite(kubeconfigFilepath, kcbb.Bytes(), os.FileMode(cfg.KubeconfigMode)); err != nil {
 		return "", err
 	}
 


### PR DESCRIPTION
Add a bit more logs into install-cni, including logging for the initial configuration and the generated kubeconfig. Also simplify the kubeconfig generation, there is no need to write to a temp file for template execution. 