### PR TITLE
kube-inject improvements

### DIFF
--- a/tests/integration/pilot/istioctl_test.go
+++ b/tests/integration/pilot/istioctl_test.go
@@ -525,7 +525,7 @@ func TestKubeInject(t *testing.T) {
 		Run(func(t framework.TestContext) {
 			istioCtl := istioctl.NewOrFail(t, t, istioctl.Config{})
 			var output string
-			args := []string{"kube-inject", "-f", "testdata/hello.yaml"}
+			args := []string{"kube-inject", "-f", "testdata/hello.yaml", "--revision=" + t.Settings().Revision}
 			output, _ = istioCtl.InvokeOrFail(t, args)
 			if !strings.Contains(output, "istio-proxy") {
 				t.Fatal("istio-proxy has not been injected")


### PR DESCRIPTION
* When no pods available, fail instead of hanging forever. Example:
```
$ istioctl kube-inject -f ~/kube/apps/httpbin.yaml
Error: no pods matching selector "app=istiod,istio=pilot" found in namespace "istio-system"
```
* Allow --revision=default
* Make integration test respect revision flag
