### PR TITLE
Log discovery requests when logging at debug level

### DIFF
--- a/istioctl/cmd/proxystatus.go
+++ b/istioctl/cmd/proxystatus.go
@@ -20,7 +20,6 @@ import (
 	"io/ioutil"
 	"os"
 
-	envoy_corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"github.com/spf13/cobra"
 
@@ -201,10 +200,7 @@ Retrieves last sent and last acknowledged xDS sync from Istiod to each Envoy in 
 
 				xdsRequest := xdsapi.DiscoveryRequest{
 					ResourceNames: []string{fmt.Sprintf("%s.%s", podName, ns)},
-					Node: &envoy_corev3.Node{
-						Id: "debug~0.0.0.0~istioctl~cluster.local",
-					},
-					TypeUrl: pilotxds.TypeDebugConfigDump,
+					TypeUrl:       pilotxds.TypeDebugConfigDump,
 				}
 				xdsResponses, err := multixds.FirstRequestAndProcessXds(&xdsRequest, &centralOpts, istioNamespace, "", "", kubeClient)
 				if err != nil {
@@ -218,9 +214,6 @@ Retrieves last sent and last acknowledged xDS sync from Istiod to each Envoy in 
 			}
 
 			xdsRequest := xdsapi.DiscoveryRequest{
-				Node: &envoy_corev3.Node{
-					Id: "debug~0.0.0.0~istioctl~cluster.local",
-				},
 				TypeUrl: pilotxds.TypeDebugSyncronization,
 			}
 			xdsResponses, err := multixds.AllRequestAndProcessXds(&xdsRequest, &centralOpts, istioNamespace, "", "", kubeClient)

--- a/istioctl/cmd/version.go
+++ b/istioctl/cmd/version.go
@@ -151,9 +151,6 @@ istioctl x version --xds-label istio.io/rev=default
 func xdsRemoteVersionWrapper(opts *clioptions.ControlPlaneOptions, centralOpts *clioptions.CentralControlPlaneOptions, outXDS **xdsapi.DiscoveryResponse) func() (*istioVersion.MeshInfo, error) {
 	return func() (*istioVersion.MeshInfo, error) {
 		xdsRequest := xdsapi.DiscoveryRequest{
-			Node: &envoy_corev3.Node{
-				Id: "sidecar~0.0.0.0~debug~cluster.local",
-			},
 			TypeUrl: "istio.io/connections",
 		}
 		kubeClient, err := kubeClientWithRevision(kubeconfig, configContext, opts.Revision)

--- a/pkg/adsc/adsc.go
+++ b/pkg/adsc/adsc.go
@@ -774,6 +774,11 @@ func (a *ADSC) Send(req *discovery.DiscoveryRequest) error {
 		a.sendNodeMeta = false
 	}
 	req.ResponseNonce = time.Now().String()
+	if adscLog.DebugEnabled() {
+		jsonm := &jsonpb.Marshaler{}
+		strReq, _ := jsonm.MarshalToString(req)
+		adscLog.Debugf("Sending Discovery Request to istiod: %s", strReq)
+	}
 	return a.stream.Send(req)
 }
 


### PR DESCRIPTION
I badly needed the ability to see what _istioctl_ was sending when logging at debug level while testing https://github.com/istio/istio/pull/31749

This adds outgoing discovery request logs.  The discovery requests are logged as JSON with `jsonpb` and as such are suitable for being passed to `grpcurl -d @ -plaintext <pilot> envoy.service.discovery.v3.AggregatedDiscoveryService/StreamAggregatedResources`

Note that I was able to determine that some of the fields set by istioctl are overwritten before sending, and I also eliminated those fields.