### PR TITLE
shifting test: use 2 pods when vms are disabled

### DIFF
--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -78,7 +78,7 @@ spec:
 	}{gateway, host, port})
 }
 
-func virtualServiceCases() []TrafficTestCase {
+func virtualServiceCases(skipVM bool) []TrafficTestCase {
 	var cases []TrafficTestCase
 	// Send the same call from all different clusters
 
@@ -392,15 +392,21 @@ spec:
 		cases[i] = tc
 	}
 
-	splits := [][3]int{
+	splits := [][]int{
 		{50, 25, 25},
 		{80, 10, 10},
+	}
+	if skipVM {
+		splits = [][]int{
+			{50, 50},
+			{80, 20},
+		}
 	}
 	for _, split := range splits {
 		split := split
 		cases = append(cases, TrafficTestCase{
 			name:          fmt.Sprintf("shifting-%d", split[0]),
-			toN:           3,
+			toN:           len(split),
 			sourceFilters: []echotest.Filter{noHeadless, noNaked},
 			targetFilters: []echotest.Filter{noHeadless, noExternal},
 			config: fmt.Sprintf(`

--- a/tests/integration/pilot/common/traffic.go
+++ b/tests/integration/pilot/common/traffic.go
@@ -201,7 +201,7 @@ func (c TrafficTestCase) Run(t framework.TestContext, namespace string) {
 
 func RunAllTrafficTests(t framework.TestContext, apps *EchoDeployments) {
 	cases := map[string][]TrafficTestCase{}
-	cases["virtualservice"] = virtualServiceCases()
+	cases["virtualservice"] = virtualServiceCases(t.Settings().SkipVM)
 	cases["sniffing"] = protocolSniffingCases()
 	cases["selfcall"] = selfCallsCases(apps)
 	cases["serverfirst"] = serverFirstTestCases(apps)


### PR DESCRIPTION
prevent test failures in `--skipVM` mode