### PR TITLE
Add Traffic Verification to Helm Install Test

### DIFF
--- a/tests/integration/helm/install_test.go
+++ b/tests/integration/helm/install_test.go
@@ -26,6 +26,7 @@ import (
 	kubecluster "istio.io/istio/pkg/test/framework/components/cluster/kube"
 	"istio.io/istio/pkg/test/framework/image"
 	"istio.io/istio/pkg/test/helm"
+	"istio.io/istio/tests/util/sanitycheck"
 )
 
 // TestDefaultInstall tests Istio installation using Helm with default options
@@ -57,6 +58,9 @@ global:
 			InstallGatewaysCharts(t, cs, h, "", IstioNamespace, overrideValuesFile)
 
 			VerifyInstallation(ctx, cs)
+
+			client, server := sanitycheck.SetupTrafficTest(t, ctx)
+			sanitycheck.RunTrafficTestClientServer(t, client, server)
 
 			t.Cleanup(func() {
 				deleteGatewayCharts(t, h)


### PR DESCRIPTION
The current helm install verification test was not checking network traffic after installation.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any changes that may affect Istio users.
