### PR TITLE
Fix probe header

### DIFF
--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -551,7 +551,7 @@ func (s *Server) handleAppProbe(w http.ResponseWriter, req *http.Request) {
 			// Probe has specific host header override; honor it
 			appReq.Host = h.Value
 		} else {
-			appReq.Header.Set(h.Name, h.Value)
+			appReq.Header.Add(h.Name, h.Value)
 		}
 	}
 

--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -546,12 +546,19 @@ func (s *Server) handleAppProbe(w http.ResponseWriter, req *http.Request) {
 		appReq.Header[name] = newValues
 	}
 
-	for _, h := range prober.HTTPGet.HTTPHeaders {
-		if h.Name == "Host" || h.Name == ":authority" {
-			// Probe has specific host header override; honor it
-			appReq.Host = h.Value
-		} else {
-			appReq.Header.Add(h.Name, h.Value)
+	// If there are custom HTTPHeaders, it will override the forwarding header
+	if headers := prober.HTTPGet.HTTPHeaders; len(headers) != 0 {
+		for _, h := range headers {
+			delete(appReq.Header, h.Name)
+		}
+		for _, h := range headers {
+			if h.Name == "Host" || h.Name == ":authority" {
+				// Probe has specific host header override; honor it
+				appReq.Host = h.Value
+				appReq.Header.Set(h.Name, h.Value)
+			} else {
+				appReq.Header.Add(h.Name, h.Value)
+			}
 		}
 	}
 

--- a/pilot/cmd/pilot-agent/status/server_test.go
+++ b/pilot/cmd/pilot-agent/status/server_test.go
@@ -24,6 +24,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"os/signal"
+	"reflect"
 	"strconv"
 	"strings"
 	"syscall"
@@ -550,6 +551,154 @@ func TestHttpsAppProbe(t *testing.T) {
 		if resp.StatusCode != tc.statusCode {
 			t.Errorf("[%v] unexpected status code, want = %v, got = %v", tc.probePath, tc.statusCode, resp.StatusCode)
 		}
+	}
+}
+
+func TestProbeHeader(t *testing.T) {
+	headerChecker := func(t *testing.T, header http.Header) net.Listener {
+		listener, err := net.Listen("tcp", ":0")
+		if err != nil {
+			t.Fatalf("failed to allocate unused port %v", err)
+		}
+		go http.Serve(listener, http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			r.Header.Del("User-Agent")
+			r.Header.Del("Accept-Encoding")
+			if !reflect.DeepEqual(r.Header, header) {
+				t.Errorf("unexpected header, want = %v, got = %v", header, r.Header)
+				http.Error(rw, "", http.StatusBadRequest)
+				return
+			}
+			http.Error(rw, "", http.StatusOK)
+		}))
+		return listener
+	}
+
+	testCases := []struct {
+		name          string
+		originHeaders http.Header
+		proxyHeaders  []apimirror.HTTPHeader
+		want          http.Header
+	}{
+		{
+			name: "Only Origin",
+			originHeaders: http.Header{
+				testHeader: []string{testHeaderValue},
+			},
+			proxyHeaders: []apimirror.HTTPHeader{},
+			want: http.Header{
+				testHeader: []string{testHeaderValue},
+			},
+		},
+		{
+			name: "Only Origin, has multiple values",
+			originHeaders: http.Header{
+				testHeader: []string{testHeaderValue, testHeaderValue},
+			},
+			proxyHeaders: []apimirror.HTTPHeader{},
+			want: http.Header{
+				testHeader: []string{testHeaderValue, testHeaderValue},
+			},
+		},
+		{
+			name:          "Only Proxy",
+			originHeaders: http.Header{},
+			proxyHeaders: []apimirror.HTTPHeader{
+				{
+					Name:  testHeader,
+					Value: testHeaderValue,
+				},
+			},
+			want: http.Header{
+				testHeader: []string{testHeaderValue},
+			},
+		},
+		{
+			name:          "Only Proxy, has multiple values",
+			originHeaders: http.Header{},
+			proxyHeaders: []apimirror.HTTPHeader{
+				{
+					Name:  testHeader,
+					Value: testHeaderValue,
+				},
+				{
+					Name:  testHeader,
+					Value: testHeaderValue,
+				},
+			},
+			want: http.Header{
+				testHeader: []string{testHeaderValue, testHeaderValue},
+			},
+		},
+		{
+			name: "Proxy overwrites Origin",
+			originHeaders: http.Header{
+				testHeader: []string{testHeaderValue, testHeaderValue},
+			},
+			proxyHeaders: []apimirror.HTTPHeader{
+				{
+					Name:  testHeader,
+					Value: testHeaderValue + "Over",
+				},
+			},
+			want: http.Header{
+				testHeader: []string{testHeaderValue + "Over"},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := headerChecker(t, tc.want)
+			defer svc.Close()
+			probePath := "/app-health/hello-world/livez"
+			appAddress := svc.Addr().(*net.TCPAddr)
+			appProber, err := json.Marshal(KubeAppProbers{
+				probePath: &Prober{
+					HTTPGet: &apimirror.HTTPGetAction{
+						Port:        intstr.IntOrString{IntVal: int32(appAddress.Port)},
+						Host:        appAddress.IP.String(),
+						Path:        "/header",
+						HTTPHeaders: tc.proxyHeaders,
+					},
+				},
+			})
+			if err != nil {
+				t.Fatalf("invalid app probers")
+			}
+			config := Options{
+				StatusPort:     0,
+				KubeAppProbers: string(appProber),
+			}
+			// Starts the pilot agent status server.
+			server, err := NewServer(config)
+			if err != nil {
+				t.Fatal("failed to create status server: ", err)
+			}
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			go server.Run(ctx)
+
+			var statusPort uint16
+			for statusPort == 0 {
+				server.mutex.RLock()
+				statusPort = server.statusPort
+				server.mutex.RUnlock()
+			}
+
+			client := http.Client{}
+			req, err := http.NewRequest("GET", fmt.Sprintf("http://localhost:%v%s", statusPort, probePath), nil)
+			if err != nil {
+				t.Fatal("failed to create request: ", err)
+			}
+			req.Header = tc.originHeaders
+			resp, err := client.Do(req)
+			if err != nil {
+				t.Fatal("request failed: ", err)
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				t.Errorf("unexpected status code, want = %v, got = %v", http.StatusOK, resp.StatusCode)
+			}
+		})
 	}
 }
 

--- a/pkg/kube/apimirror/probe.go
+++ b/pkg/kube/apimirror/probe.go
@@ -37,7 +37,7 @@ type HTTPGetAction struct {
 	// Defaults to HTTP.
 	// +optional
 	Scheme URIScheme `json:"scheme,omitempty" protobuf:"bytes,4,opt,name=scheme,casttype=URIScheme"`
-	// Custom headers to set in the request.
+	// Custom headers to set in the request. HTTP allows repeated headers.
 	// +optional
 	HTTPHeaders []HTTPHeader `json:"httpHeaders,omitempty" protobuf:"bytes,5,rep,name=httpHeaders"`
 }


### PR DESCRIPTION
Revert "Fix allows repeated headers (#31866)"
Revert "Avoid duplicate HTTP headers for istio-proxy probe requests (#28537)"
Fix #23504

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any changes that may affect Istio users.
