### PR TITLE
add stats and tracing support for dry-run policy

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/tracing.go
+++ b/pilot/pkg/networking/core/v1alpha3/tracing.go
@@ -24,6 +24,7 @@ import (
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	tracingcfg "github.com/envoyproxy/go-control-plane/envoy/config/trace/v3"
 	hpb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	envoy_type_metadata_v3 "github.com/envoyproxy/go-control-plane/envoy/type/metadata/v3"
 	tracing "github.com/envoyproxy/go-control-plane/envoy/type/tracing/v3"
 	xdstype "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	"github.com/golang/protobuf/ptypes/wrappers"
@@ -35,6 +36,7 @@ import (
 	"istio.io/istio/pilot/pkg/extensionproviders"
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
+	authz_model "istio.io/istio/pilot/pkg/security/authz/model"
 	"istio.io/istio/pkg/bootstrap/platform"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/pkg/log"
@@ -315,8 +317,37 @@ func convert(ctxs []meshconfig.MeshConfig_ExtensionProvider_OpenCensusAgentTraci
 	return converted
 }
 
+func dryRunPolicyTraceTag(name, key string) *tracing.CustomTag {
+	return &tracing.CustomTag{
+		Tag: name,
+		Type: &tracing.CustomTag_Metadata_{
+			Metadata: &tracing.CustomTag_Metadata{
+				Kind: &envoy_type_metadata_v3.MetadataKind{
+					Kind: &envoy_type_metadata_v3.MetadataKind_Request_{
+						Request: &envoy_type_metadata_v3.MetadataKind_Request{},
+					},
+				},
+				MetadataKey: &envoy_type_metadata_v3.MetadataKey{
+					Key: authz_model.RBACHTTPFilterName,
+					Path: []*envoy_type_metadata_v3.MetadataKey_PathSegment{
+						{
+							Segment: &envoy_type_metadata_v3.MetadataKey_PathSegment_Key{
+								Key: key,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
 func defaultTags() []*tracing.CustomTag {
 	return []*tracing.CustomTag{
+		dryRunPolicyTraceTag("istio.authorization.dry_run.allow_policy.name", authz_model.RBACShadowRulesAllowStatPrefix+authz_model.RBACShadowEffectivePolicyID),
+		dryRunPolicyTraceTag("istio.authorization.dry_run.allow_policy.result", authz_model.RBACShadowRulesAllowStatPrefix+authz_model.RBACShadowEngineResult),
+		dryRunPolicyTraceTag("istio.authorization.dry_run.deny_policy.name", authz_model.RBACShadowRulesDenyStatPrefix+authz_model.RBACShadowEffectivePolicyID),
+		dryRunPolicyTraceTag("istio.authorization.dry_run.deny_policy.result", authz_model.RBACShadowRulesDenyStatPrefix+authz_model.RBACShadowEngineResult),
 		{
 			Tag: "istio.canonical_revision",
 			Type: &tracing.CustomTag_Environment_{

--- a/pilot/pkg/networking/core/v1alpha3/tracing.go
+++ b/pilot/pkg/networking/core/v1alpha3/tracing.go
@@ -318,6 +318,8 @@ func convert(ctxs []meshconfig.MeshConfig_ExtensionProvider_OpenCensusAgentTraci
 }
 
 func dryRunPolicyTraceTag(name, key string) *tracing.CustomTag {
+	// The tag will not be populated when not used as there is no default value set for the tag.
+	// See https://www.envoyproxy.io/docs/envoy/v1.17.1/configuration/http/http_filters/rbac_filter#dynamic-metadata.
 	return &tracing.CustomTag{
 		Tag: name,
 		Type: &tracing.CustomTag_Metadata_{

--- a/pilot/pkg/security/authz/builder/extauthz.go
+++ b/pilot/pkg/security/authz/builder/extauthz.go
@@ -354,7 +354,7 @@ func generateFilterMatcher(name string) *envoy_type_matcher_v3.MetadataMatcher {
 		Path: []*envoy_type_matcher_v3.MetadataMatcher_PathSegment{
 			{
 				Segment: &envoy_type_matcher_v3.MetadataMatcher_PathSegment_Key{
-					Key: "shadow_effective_policy_id",
+					Key: authzmodel.RBACExtAuthzShadowRulesStatPrefix + authzmodel.RBACShadowEffectivePolicyID,
 				},
 			},
 		},

--- a/pilot/pkg/security/authz/builder/testdata/http/custom-grpc-provider-no-namespace-out1.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/custom-grpc-provider-no-namespace-out1.yaml
@@ -30,3 +30,4 @@ typedConfig:
         - andIds:
             ids:
             - any: true
+  shadowRulesStatPrefix: istio_ext_authz_

--- a/pilot/pkg/security/authz/builder/testdata/http/custom-grpc-provider-no-namespace-out2.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/custom-grpc-provider-no-namespace-out2.yaml
@@ -5,7 +5,7 @@ typedConfig:
   filterEnabledMetadata:
     filter: envoy.filters.http.rbac
     path:
-    - key: shadow_effective_policy_id
+    - key: istio_ext_authz_shadow_effective_policy_id
     value:
       stringMatch:
         prefix: istio-ext-authz

--- a/pilot/pkg/security/authz/builder/testdata/http/custom-grpc-provider-out1.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/custom-grpc-provider-out1.yaml
@@ -30,3 +30,4 @@ typedConfig:
         - andIds:
             ids:
             - any: true
+  shadowRulesStatPrefix: istio_ext_authz_

--- a/pilot/pkg/security/authz/builder/testdata/http/custom-grpc-provider-out2.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/custom-grpc-provider-out2.yaml
@@ -5,7 +5,7 @@ typedConfig:
   filterEnabledMetadata:
     filter: envoy.filters.http.rbac
     path:
-    - key: shadow_effective_policy_id
+    - key: istio_ext_authz_shadow_effective_policy_id
     value:
       stringMatch:
         prefix: istio-ext-authz

--- a/pilot/pkg/security/authz/builder/testdata/http/custom-http-provider-out1.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/custom-http-provider-out1.yaml
@@ -30,3 +30,4 @@ typedConfig:
         - andIds:
             ids:
             - any: true
+  shadowRulesStatPrefix: istio_ext_authz_

--- a/pilot/pkg/security/authz/builder/testdata/http/custom-http-provider-out2.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/custom-http-provider-out2.yaml
@@ -5,7 +5,7 @@ typedConfig:
   filterEnabledMetadata:
     filter: envoy.filters.http.rbac
     path:
-    - key: shadow_effective_policy_id
+    - key: istio_ext_authz_shadow_effective_policy_id
     value:
       stringMatch:
         prefix: istio-ext-authz

--- a/pilot/pkg/security/authz/builder/testdata/tcp/custom-both-http-tcp-out1.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/tcp/custom-both-http-tcp-out1.yaml
@@ -97,4 +97,5 @@ typedConfig:
                   - directRemoteIp:
                       addressPrefix: 9.0.0.1
                       prefixLen: 32
+  shadowRulesStatPrefix: istio_ext_authz_
   statPrefix: tcp.

--- a/pilot/pkg/security/authz/builder/testdata/tcp/custom-both-http-tcp-out2.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/tcp/custom-both-http-tcp-out2.yaml
@@ -5,7 +5,7 @@ typedConfig:
   filterEnabledMetadata:
     filter: envoy.filters.network.rbac
     path:
-    - key: shadow_effective_policy_id
+    - key: istio_ext_authz_shadow_effective_policy_id
     value:
       stringMatch:
         prefix: istio-ext-authz

--- a/pilot/pkg/security/authz/model/model.go
+++ b/pilot/pkg/security/authz/model/model.go
@@ -29,8 +29,13 @@ const (
 	RBACHTTPFilterName = "envoy.filters.http.rbac"
 
 	// RBACTCPFilterName is the name of the RBAC network filter in envoy.
-	RBACTCPFilterName       = "envoy.filters.network.rbac"
-	RBACTCPFilterStatPrefix = "tcp."
+	RBACTCPFilterName                 = "envoy.filters.network.rbac"
+	RBACTCPFilterStatPrefix           = "tcp."
+	RBACShadowEngineResult            = "shadow_engine_result"
+	RBACShadowEffectivePolicyID       = "shadow_effective_policy_id"
+	RBACShadowRulesAllowStatPrefix    = "istio_dry_run_allow_"
+	RBACShadowRulesDenyStatPrefix     = "istio_dry_run_deny_"
+	RBACExtAuthzShadowRulesStatPrefix = "istio_ext_authz_"
 
 	attrRequestHeader    = "request.headers"             // header name is surrounded by brackets, e.g. "request.headers[User-Agent]".
 	attrSrcIP            = "source.ip"                   // supports both single ip and cidr, e.g. "10.1.2.3" or "10.1.0.0/16".

--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -50,6 +50,8 @@ const (
 	// required stats are used by readiness checks.
 	requiredEnvoyStatsMatcherInclusionPrefixes = "cluster_manager,listener_manager,server,cluster.xds-grpc,wasm"
 
+	rbacEnvoyStatsMatcherInclusionSuffix = "allowed,denied"
+
 	// Prefixes of V2 metrics.
 	// "reporter" prefix is for istio standard metrics.
 	// "component" suffix is for istio_build metric.
@@ -223,7 +225,8 @@ func getStatsOptions(meta *model.BootstrapNodeMetadata) []option.Instance {
 	return []option.Instance{
 		option.EnvoyStatsMatcherInclusionPrefix(parseOption(meta.StatsInclusionPrefixes,
 			requiredEnvoyStatsMatcherInclusionPrefixes, proxyConfigPrefixes)),
-		option.EnvoyStatsMatcherInclusionSuffix(parseOption(meta.StatsInclusionSuffixes, "", proxyConfigSuffixes)),
+		option.EnvoyStatsMatcherInclusionSuffix(parseOption(meta.StatsInclusionSuffixes,
+			rbacEnvoyStatsMatcherInclusionSuffix, proxyConfigSuffixes)),
 		option.EnvoyStatsMatcherInclusionRegexp(parseOption(meta.StatsInclusionRegexps, "", proxyConfigRegexps)),
 		option.EnvoyExtraStatTags(extraStatTags),
 	}

--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -50,7 +50,7 @@ const (
 	// required stats are used by readiness checks.
 	requiredEnvoyStatsMatcherInclusionPrefixes = "cluster_manager,listener_manager,server,cluster.xds-grpc,wasm"
 
-	rbacEnvoyStatsMatcherInclusionSuffix = "allowed,denied"
+	rbacEnvoyStatsMatcherInclusionSuffix = "rbac.allowed,rbac.denied,shadow_allowed,shadow_denied"
 
 	// Prefixes of V2 metrics.
 	// "reporter" prefix is for istio standard metrics.

--- a/pkg/bootstrap/instance_test.go
+++ b/pkg/bootstrap/instance_test.go
@@ -485,6 +485,11 @@ func checkStatsMatcher(t *testing.T, got, want *bootstrap.Bootstrap, stats stats
 	} else {
 		stats.prefixes = v2Prefixes + stats.prefixes + "," + requiredEnvoyStatsMatcherInclusionPrefixes + v2Suffix
 	}
+	if stats.suffixes == "" {
+		stats.suffixes = "allowed,denied"
+	} else {
+		stats.suffixes += ",allowed,denied"
+	}
 
 	if err := gsm.Validate(); err != nil {
 		t.Fatalf("Generated invalid matcher: %v", err)

--- a/pkg/bootstrap/instance_test.go
+++ b/pkg/bootstrap/instance_test.go
@@ -486,9 +486,9 @@ func checkStatsMatcher(t *testing.T, got, want *bootstrap.Bootstrap, stats stats
 		stats.prefixes = v2Prefixes + stats.prefixes + "," + requiredEnvoyStatsMatcherInclusionPrefixes + v2Suffix
 	}
 	if stats.suffixes == "" {
-		stats.suffixes = "rbac.allowed,rbac.denied,shadow_allowed,shadow_denied"
+		stats.suffixes = rbacEnvoyStatsMatcherInclusionSuffix
 	} else {
-		stats.suffixes += ",rbac.allowed,rbac.denied,shadow_allowed,shadow_denied"
+		stats.suffixes += "," + rbacEnvoyStatsMatcherInclusionSuffix
 	}
 
 	if err := gsm.Validate(); err != nil {

--- a/pkg/bootstrap/instance_test.go
+++ b/pkg/bootstrap/instance_test.go
@@ -486,9 +486,9 @@ func checkStatsMatcher(t *testing.T, got, want *bootstrap.Bootstrap, stats stats
 		stats.prefixes = v2Prefixes + stats.prefixes + "," + requiredEnvoyStatsMatcherInclusionPrefixes + v2Suffix
 	}
 	if stats.suffixes == "" {
-		stats.suffixes = "allowed,denied"
+		stats.suffixes = "rbac.allowed,rbac.denied,shadow_allowed,shadow_denied"
 	} else {
-		stats.suffixes += ",allowed,denied"
+		stats.suffixes += ",rbac.allowed,rbac.denied,shadow_allowed,shadow_denied"
 	}
 
 	if err := gsm.Validate(); err != nil {

--- a/pkg/bootstrap/testdata/all_golden.json
+++ b/pkg/bootstrap/testdata/all_golden.json
@@ -230,10 +230,16 @@
           "prefix": "wasm"
           },
           {
-          "suffix": "allowed"
+          "suffix": "rbac.allowed"
           },
           {
-          "suffix": "denied"
+          "suffix": "rbac.denied"
+          },
+          {
+          "suffix": "shadow_allowed"
+          },
+          {
+          "suffix": "shadow_denied"
           },
           {
           "prefix": "component"

--- a/pkg/bootstrap/testdata/all_golden.json
+++ b/pkg/bootstrap/testdata/all_golden.json
@@ -197,7 +197,7 @@
       },
       {
         "tag_name": "authz_enforce_result",
-        "regex": "(\\.(allowed|denied))"
+        "regex": "rbac(\\.(allowed|denied))"
       },
       {
         "tag_name": "authz_dry_run_action",

--- a/pkg/bootstrap/testdata/all_golden.json
+++ b/pkg/bootstrap/testdata/all_golden.json
@@ -194,6 +194,18 @@
       {
         "regex": "(wasm_filter\\.(.+?)\\.)",
         "tag_name": "wasm_filter"
+      },
+      {
+        "tag_name": "authz_enforce_result",
+        "regex": "(\\.(allowed|denied))"
+      },
+      {
+        "tag_name": "authz_dry_run_action",
+        "regex": "(\\.istio_dry_run_(allow|deny)_)"
+      },
+      {
+        "tag_name": "authz_dry_run_result",
+        "regex": "(\\.shadow_(allowed|denied))"
       }
     ],
     "stats_matcher": {
@@ -216,6 +228,12 @@
           },
           {
           "prefix": "wasm"
+          },
+          {
+          "suffix": "allowed"
+          },
+          {
+          "suffix": "denied"
           },
           {
           "prefix": "component"

--- a/pkg/bootstrap/testdata/auth_golden.json
+++ b/pkg/bootstrap/testdata/auth_golden.json
@@ -230,10 +230,16 @@
           "prefix": "wasm"
           },
           {
-          "suffix": "allowed"
+          "suffix": "rbac.allowed"
           },
           {
-          "suffix": "denied"
+          "suffix": "rbac.denied"
+          },
+          {
+          "suffix": "shadow_allowed"
+          },
+          {
+          "suffix": "shadow_denied"
           },
           {
           "prefix": "component"

--- a/pkg/bootstrap/testdata/auth_golden.json
+++ b/pkg/bootstrap/testdata/auth_golden.json
@@ -197,7 +197,7 @@
       },
       {
         "tag_name": "authz_enforce_result",
-        "regex": "(\\.(allowed|denied))"
+        "regex": "rbac(\\.(allowed|denied))"
       },
       {
         "tag_name": "authz_dry_run_action",

--- a/pkg/bootstrap/testdata/auth_golden.json
+++ b/pkg/bootstrap/testdata/auth_golden.json
@@ -194,6 +194,18 @@
       {
         "regex": "(wasm_filter\\.(.+?)\\.)",
         "tag_name": "wasm_filter"
+      },
+      {
+        "tag_name": "authz_enforce_result",
+        "regex": "(\\.(allowed|denied))"
+      },
+      {
+        "tag_name": "authz_dry_run_action",
+        "regex": "(\\.istio_dry_run_(allow|deny)_)"
+      },
+      {
+        "tag_name": "authz_dry_run_result",
+        "regex": "(\\.shadow_(allowed|denied))"
       }
     ],
     "stats_matcher": {
@@ -216,6 +228,12 @@
           },
           {
           "prefix": "wasm"
+          },
+          {
+          "suffix": "allowed"
+          },
+          {
+          "suffix": "denied"
           },
           {
           "prefix": "component"

--- a/pkg/bootstrap/testdata/authsds_golden.json
+++ b/pkg/bootstrap/testdata/authsds_golden.json
@@ -230,10 +230,16 @@
           "prefix": "wasm"
           },
           {
-          "suffix": "allowed"
+          "suffix": "rbac.allowed"
           },
           {
-          "suffix": "denied"
+          "suffix": "rbac.denied"
+          },
+          {
+          "suffix": "shadow_allowed"
+          },
+          {
+          "suffix": "shadow_denied"
           },
           {
           "prefix": "component"

--- a/pkg/bootstrap/testdata/authsds_golden.json
+++ b/pkg/bootstrap/testdata/authsds_golden.json
@@ -197,7 +197,7 @@
       },
       {
         "tag_name": "authz_enforce_result",
-        "regex": "(\\.(allowed|denied))"
+        "regex": "rbac(\\.(allowed|denied))"
       },
       {
         "tag_name": "authz_dry_run_action",

--- a/pkg/bootstrap/testdata/authsds_golden.json
+++ b/pkg/bootstrap/testdata/authsds_golden.json
@@ -194,6 +194,18 @@
       {
         "regex": "(wasm_filter\\.(.+?)\\.)",
         "tag_name": "wasm_filter"
+      },
+      {
+        "tag_name": "authz_enforce_result",
+        "regex": "(\\.(allowed|denied))"
+      },
+      {
+        "tag_name": "authz_dry_run_action",
+        "regex": "(\\.istio_dry_run_(allow|deny)_)"
+      },
+      {
+        "tag_name": "authz_dry_run_result",
+        "regex": "(\\.shadow_(allowed|denied))"
       }
     ],
     "stats_matcher": {
@@ -216,6 +228,12 @@
           },
           {
           "prefix": "wasm"
+          },
+          {
+          "suffix": "allowed"
+          },
+          {
+          "suffix": "denied"
           },
           {
           "prefix": "component"

--- a/pkg/bootstrap/testdata/default_golden.json
+++ b/pkg/bootstrap/testdata/default_golden.json
@@ -230,10 +230,16 @@
           "prefix": "wasm"
           },
           {
-          "suffix": "allowed"
+          "suffix": "rbac.allowed"
           },
           {
-          "suffix": "denied"
+          "suffix": "rbac.denied"
+          },
+          {
+          "suffix": "shadow_allowed"
+          },
+          {
+          "suffix": "shadow_denied"
           },
           {
           "prefix": "component"

--- a/pkg/bootstrap/testdata/default_golden.json
+++ b/pkg/bootstrap/testdata/default_golden.json
@@ -197,7 +197,7 @@
       },
       {
         "tag_name": "authz_enforce_result",
-        "regex": "(\\.(allowed|denied))"
+        "regex": "rbac(\\.(allowed|denied))"
       },
       {
         "tag_name": "authz_dry_run_action",

--- a/pkg/bootstrap/testdata/default_golden.json
+++ b/pkg/bootstrap/testdata/default_golden.json
@@ -194,6 +194,18 @@
       {
         "regex": "(wasm_filter\\.(.+?)\\.)",
         "tag_name": "wasm_filter"
+      },
+      {
+        "tag_name": "authz_enforce_result",
+        "regex": "(\\.(allowed|denied))"
+      },
+      {
+        "tag_name": "authz_dry_run_action",
+        "regex": "(\\.istio_dry_run_(allow|deny)_)"
+      },
+      {
+        "tag_name": "authz_dry_run_result",
+        "regex": "(\\.shadow_(allowed|denied))"
       }
     ],
     "stats_matcher": {
@@ -216,6 +228,12 @@
           },
           {
           "prefix": "wasm"
+          },
+          {
+          "suffix": "allowed"
+          },
+          {
+          "suffix": "denied"
           },
           {
           "prefix": "component"

--- a/pkg/bootstrap/testdata/running_golden.json
+++ b/pkg/bootstrap/testdata/running_golden.json
@@ -202,7 +202,7 @@
       },
       {
         "tag_name": "authz_enforce_result",
-        "regex": "(\\.(allowed|denied))"
+        "regex": "rbac(\\.(allowed|denied))"
       },
       {
         "tag_name": "authz_dry_run_action",

--- a/pkg/bootstrap/testdata/running_golden.json
+++ b/pkg/bootstrap/testdata/running_golden.json
@@ -235,10 +235,16 @@
           "prefix": "wasm"
           },
           {
-          "suffix": "allowed"
+          "suffix": "rbac.allowed"
           },
           {
-          "suffix": "denied"
+          "suffix": "rbac.denied"
+          },
+          {
+          "suffix": "shadow_allowed"
+          },
+          {
+          "suffix": "shadow_denied"
           },
           {
           "prefix": "component"

--- a/pkg/bootstrap/testdata/running_golden.json
+++ b/pkg/bootstrap/testdata/running_golden.json
@@ -199,6 +199,18 @@
       {
         "regex": "(wasm_filter\\.(.+?)\\.)",
         "tag_name": "wasm_filter"
+      },
+      {
+        "tag_name": "authz_enforce_result",
+        "regex": "(\\.(allowed|denied))"
+      },
+      {
+        "tag_name": "authz_dry_run_action",
+        "regex": "(\\.istio_dry_run_(allow|deny)_)"
+      },
+      {
+        "tag_name": "authz_dry_run_result",
+        "regex": "(\\.shadow_(allowed|denied))"
       }
     ],
     "stats_matcher": {
@@ -221,6 +233,12 @@
           },
           {
           "prefix": "wasm"
+          },
+          {
+          "suffix": "allowed"
+          },
+          {
+          "suffix": "denied"
           },
           {
           "prefix": "component"

--- a/pkg/bootstrap/testdata/runningsds_golden.json
+++ b/pkg/bootstrap/testdata/runningsds_golden.json
@@ -202,7 +202,7 @@
       },
       {
         "tag_name": "authz_enforce_result",
-        "regex": "(\\.(allowed|denied))"
+        "regex": "rbac(\\.(allowed|denied))"
       },
       {
         "tag_name": "authz_dry_run_action",

--- a/pkg/bootstrap/testdata/runningsds_golden.json
+++ b/pkg/bootstrap/testdata/runningsds_golden.json
@@ -235,10 +235,16 @@
           "prefix": "wasm"
           },
           {
-          "suffix": "allowed"
+          "suffix": "rbac.allowed"
           },
           {
-          "suffix": "denied"
+          "suffix": "rbac.denied"
+          },
+          {
+          "suffix": "shadow_allowed"
+          },
+          {
+          "suffix": "shadow_denied"
           },
           {
           "prefix": "component"

--- a/pkg/bootstrap/testdata/runningsds_golden.json
+++ b/pkg/bootstrap/testdata/runningsds_golden.json
@@ -199,6 +199,18 @@
       {
         "regex": "(wasm_filter\\.(.+?)\\.)",
         "tag_name": "wasm_filter"
+      },
+      {
+        "tag_name": "authz_enforce_result",
+        "regex": "(\\.(allowed|denied))"
+      },
+      {
+        "tag_name": "authz_dry_run_action",
+        "regex": "(\\.istio_dry_run_(allow|deny)_)"
+      },
+      {
+        "tag_name": "authz_dry_run_result",
+        "regex": "(\\.shadow_(allowed|denied))"
       }
     ],
     "stats_matcher": {
@@ -221,6 +233,12 @@
           },
           {
           "prefix": "wasm"
+          },
+          {
+          "suffix": "allowed"
+          },
+          {
+          "suffix": "denied"
           },
           {
           "prefix": "component"

--- a/pkg/bootstrap/testdata/stats_inclusion_golden.json
+++ b/pkg/bootstrap/testdata/stats_inclusion_golden.json
@@ -242,10 +242,16 @@
           "prefix": "wasm"
           },
           {
-          "suffix": "allowed"
+          "suffix": "rbac.allowed"
           },
           {
-          "suffix": "denied"
+          "suffix": "rbac.denied"
+          },
+          {
+          "suffix": "shadow_allowed"
+          },
+          {
+          "suffix": "shadow_denied"
           },
           {
           "safe_regex": {"google_re2":{}, "regex":"http.[0-9]*\\.[0-9]*\\.[0-9]*\\.[0-9]*_8080.downstream_rq_time"}

--- a/pkg/bootstrap/testdata/stats_inclusion_golden.json
+++ b/pkg/bootstrap/testdata/stats_inclusion_golden.json
@@ -206,6 +206,18 @@
       {
         "regex": "(wasm_filter\\.(.+?)\\.)",
         "tag_name": "wasm_filter"
+      },
+      {
+        "tag_name": "authz_enforce_result",
+        "regex": "(\\.(allowed|denied))"
+      },
+      {
+        "tag_name": "authz_dry_run_action",
+        "regex": "(\\.istio_dry_run_(allow|deny)_)"
+      },
+      {
+        "tag_name": "authz_dry_run_result",
+        "regex": "(\\.shadow_(allowed|denied))"
       }
     ],
     "stats_matcher": {
@@ -228,6 +240,12 @@
           },
           {
           "prefix": "wasm"
+          },
+          {
+          "suffix": "allowed"
+          },
+          {
+          "suffix": "denied"
           },
           {
           "safe_regex": {"google_re2":{}, "regex":"http.[0-9]*\\.[0-9]*\\.[0-9]*\\.[0-9]*_8080.downstream_rq_time"}

--- a/pkg/bootstrap/testdata/stats_inclusion_golden.json
+++ b/pkg/bootstrap/testdata/stats_inclusion_golden.json
@@ -209,7 +209,7 @@
       },
       {
         "tag_name": "authz_enforce_result",
-        "regex": "(\\.(allowed|denied))"
+        "regex": "rbac(\\.(allowed|denied))"
       },
       {
         "tag_name": "authz_dry_run_action",

--- a/pkg/bootstrap/testdata/tracing_datadog_golden.json
+++ b/pkg/bootstrap/testdata/tracing_datadog_golden.json
@@ -230,10 +230,16 @@
           "prefix": "wasm"
           },
           {
-          "suffix": "allowed"
+          "suffix": "rbac.allowed"
           },
           {
-          "suffix": "denied"
+          "suffix": "rbac.denied"
+          },
+          {
+          "suffix": "shadow_allowed"
+          },
+          {
+          "suffix": "shadow_denied"
           },
           {
           "prefix": "component"

--- a/pkg/bootstrap/testdata/tracing_datadog_golden.json
+++ b/pkg/bootstrap/testdata/tracing_datadog_golden.json
@@ -197,7 +197,7 @@
       },
       {
         "tag_name": "authz_enforce_result",
-        "regex": "(\\.(allowed|denied))"
+        "regex": "rbac(\\.(allowed|denied))"
       },
       {
         "tag_name": "authz_dry_run_action",

--- a/pkg/bootstrap/testdata/tracing_datadog_golden.json
+++ b/pkg/bootstrap/testdata/tracing_datadog_golden.json
@@ -194,6 +194,18 @@
       {
         "regex": "(wasm_filter\\.(.+?)\\.)",
         "tag_name": "wasm_filter"
+      },
+      {
+        "tag_name": "authz_enforce_result",
+        "regex": "(\\.(allowed|denied))"
+      },
+      {
+        "tag_name": "authz_dry_run_action",
+        "regex": "(\\.istio_dry_run_(allow|deny)_)"
+      },
+      {
+        "tag_name": "authz_dry_run_result",
+        "regex": "(\\.shadow_(allowed|denied))"
       }
     ],
     "stats_matcher": {
@@ -216,6 +228,12 @@
           },
           {
           "prefix": "wasm"
+          },
+          {
+          "suffix": "allowed"
+          },
+          {
+          "suffix": "denied"
           },
           {
           "prefix": "component"

--- a/pkg/bootstrap/testdata/tracing_lightstep_golden.json
+++ b/pkg/bootstrap/testdata/tracing_lightstep_golden.json
@@ -230,10 +230,16 @@
           "prefix": "wasm"
           },
           {
-          "suffix": "allowed"
+          "suffix": "rbac.allowed"
           },
           {
-          "suffix": "denied"
+          "suffix": "rbac.denied"
+          },
+          {
+          "suffix": "shadow_allowed"
+          },
+          {
+          "suffix": "shadow_denied"
           },
           {
           "prefix": "component"

--- a/pkg/bootstrap/testdata/tracing_lightstep_golden.json
+++ b/pkg/bootstrap/testdata/tracing_lightstep_golden.json
@@ -197,7 +197,7 @@
       },
       {
         "tag_name": "authz_enforce_result",
-        "regex": "(\\.(allowed|denied))"
+        "regex": "rbac(\\.(allowed|denied))"
       },
       {
         "tag_name": "authz_dry_run_action",

--- a/pkg/bootstrap/testdata/tracing_lightstep_golden.json
+++ b/pkg/bootstrap/testdata/tracing_lightstep_golden.json
@@ -194,6 +194,18 @@
       {
         "regex": "(wasm_filter\\.(.+?)\\.)",
         "tag_name": "wasm_filter"
+      },
+      {
+        "tag_name": "authz_enforce_result",
+        "regex": "(\\.(allowed|denied))"
+      },
+      {
+        "tag_name": "authz_dry_run_action",
+        "regex": "(\\.istio_dry_run_(allow|deny)_)"
+      },
+      {
+        "tag_name": "authz_dry_run_result",
+        "regex": "(\\.shadow_(allowed|denied))"
       }
     ],
     "stats_matcher": {
@@ -216,6 +228,12 @@
           },
           {
           "prefix": "wasm"
+          },
+          {
+          "suffix": "allowed"
+          },
+          {
+          "suffix": "denied"
           },
           {
           "prefix": "component"

--- a/pkg/bootstrap/testdata/tracing_opencensusagent_golden.json
+++ b/pkg/bootstrap/testdata/tracing_opencensusagent_golden.json
@@ -230,10 +230,16 @@
           "prefix": "wasm"
           },
           {
-          "suffix": "allowed"
+          "suffix": "rbac.allowed"
           },
           {
-          "suffix": "denied"
+          "suffix": "rbac.denied"
+          },
+          {
+          "suffix": "shadow_allowed"
+          },
+          {
+          "suffix": "shadow_denied"
           },
           {
           "prefix": "component"

--- a/pkg/bootstrap/testdata/tracing_opencensusagent_golden.json
+++ b/pkg/bootstrap/testdata/tracing_opencensusagent_golden.json
@@ -197,7 +197,7 @@
       },
       {
         "tag_name": "authz_enforce_result",
-        "regex": "(\\.(allowed|denied))"
+        "regex": "rbac(\\.(allowed|denied))"
       },
       {
         "tag_name": "authz_dry_run_action",

--- a/pkg/bootstrap/testdata/tracing_opencensusagent_golden.json
+++ b/pkg/bootstrap/testdata/tracing_opencensusagent_golden.json
@@ -194,6 +194,18 @@
       {
         "regex": "(wasm_filter\\.(.+?)\\.)",
         "tag_name": "wasm_filter"
+      },
+      {
+        "tag_name": "authz_enforce_result",
+        "regex": "(\\.(allowed|denied))"
+      },
+      {
+        "tag_name": "authz_dry_run_action",
+        "regex": "(\\.istio_dry_run_(allow|deny)_)"
+      },
+      {
+        "tag_name": "authz_dry_run_result",
+        "regex": "(\\.shadow_(allowed|denied))"
       }
     ],
     "stats_matcher": {
@@ -216,6 +228,12 @@
           },
           {
           "prefix": "wasm"
+          },
+          {
+          "suffix": "allowed"
+          },
+          {
+          "suffix": "denied"
           },
           {
           "prefix": "component"

--- a/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
+++ b/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
@@ -230,10 +230,16 @@
           "prefix": "wasm"
           },
           {
-          "suffix": "allowed"
+          "suffix": "rbac.allowed"
           },
           {
-          "suffix": "denied"
+          "suffix": "rbac.denied"
+          },
+          {
+          "suffix": "shadow_allowed"
+          },
+          {
+          "suffix": "shadow_denied"
           },
           {
           "prefix": "component"

--- a/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
+++ b/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
@@ -197,7 +197,7 @@
       },
       {
         "tag_name": "authz_enforce_result",
-        "regex": "(\\.(allowed|denied))"
+        "regex": "rbac(\\.(allowed|denied))"
       },
       {
         "tag_name": "authz_dry_run_action",

--- a/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
+++ b/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
@@ -194,6 +194,18 @@
       {
         "regex": "(wasm_filter\\.(.+?)\\.)",
         "tag_name": "wasm_filter"
+      },
+      {
+        "tag_name": "authz_enforce_result",
+        "regex": "(\\.(allowed|denied))"
+      },
+      {
+        "tag_name": "authz_dry_run_action",
+        "regex": "(\\.istio_dry_run_(allow|deny)_)"
+      },
+      {
+        "tag_name": "authz_dry_run_result",
+        "regex": "(\\.shadow_(allowed|denied))"
       }
     ],
     "stats_matcher": {
@@ -216,6 +228,12 @@
           },
           {
           "prefix": "wasm"
+          },
+          {
+          "suffix": "allowed"
+          },
+          {
+          "suffix": "denied"
           },
           {
           "prefix": "component"

--- a/pkg/bootstrap/testdata/tracing_tls_custom_sni_golden.json
+++ b/pkg/bootstrap/testdata/tracing_tls_custom_sni_golden.json
@@ -230,10 +230,16 @@
           "prefix": "wasm"
           },
           {
-          "suffix": "allowed"
+          "suffix": "rbac.allowed"
           },
           {
-          "suffix": "denied"
+          "suffix": "rbac.denied"
+          },
+          {
+          "suffix": "shadow_allowed"
+          },
+          {
+          "suffix": "shadow_denied"
           },
           {
           "prefix": "component"

--- a/pkg/bootstrap/testdata/tracing_tls_custom_sni_golden.json
+++ b/pkg/bootstrap/testdata/tracing_tls_custom_sni_golden.json
@@ -197,7 +197,7 @@
       },
       {
         "tag_name": "authz_enforce_result",
-        "regex": "(\\.(allowed|denied))"
+        "regex": "rbac(\\.(allowed|denied))"
       },
       {
         "tag_name": "authz_dry_run_action",

--- a/pkg/bootstrap/testdata/tracing_tls_custom_sni_golden.json
+++ b/pkg/bootstrap/testdata/tracing_tls_custom_sni_golden.json
@@ -194,6 +194,18 @@
       {
         "regex": "(wasm_filter\\.(.+?)\\.)",
         "tag_name": "wasm_filter"
+      },
+      {
+        "tag_name": "authz_enforce_result",
+        "regex": "(\\.(allowed|denied))"
+      },
+      {
+        "tag_name": "authz_dry_run_action",
+        "regex": "(\\.istio_dry_run_(allow|deny)_)"
+      },
+      {
+        "tag_name": "authz_dry_run_result",
+        "regex": "(\\.shadow_(allowed|denied))"
       }
     ],
     "stats_matcher": {
@@ -216,6 +228,12 @@
           },
           {
           "prefix": "wasm"
+          },
+          {
+          "suffix": "allowed"
+          },
+          {
+          "suffix": "denied"
           },
           {
           "prefix": "component"

--- a/pkg/bootstrap/testdata/tracing_tls_golden.json
+++ b/pkg/bootstrap/testdata/tracing_tls_golden.json
@@ -230,10 +230,16 @@
           "prefix": "wasm"
           },
           {
-          "suffix": "allowed"
+          "suffix": "rbac.allowed"
           },
           {
-          "suffix": "denied"
+          "suffix": "rbac.denied"
+          },
+          {
+          "suffix": "shadow_allowed"
+          },
+          {
+          "suffix": "shadow_denied"
           },
           {
           "prefix": "component"

--- a/pkg/bootstrap/testdata/tracing_tls_golden.json
+++ b/pkg/bootstrap/testdata/tracing_tls_golden.json
@@ -197,7 +197,7 @@
       },
       {
         "tag_name": "authz_enforce_result",
-        "regex": "(\\.(allowed|denied))"
+        "regex": "rbac(\\.(allowed|denied))"
       },
       {
         "tag_name": "authz_dry_run_action",

--- a/pkg/bootstrap/testdata/tracing_tls_golden.json
+++ b/pkg/bootstrap/testdata/tracing_tls_golden.json
@@ -194,6 +194,18 @@
       {
         "regex": "(wasm_filter\\.(.+?)\\.)",
         "tag_name": "wasm_filter"
+      },
+      {
+        "tag_name": "authz_enforce_result",
+        "regex": "(\\.(allowed|denied))"
+      },
+      {
+        "tag_name": "authz_dry_run_action",
+        "regex": "(\\.istio_dry_run_(allow|deny)_)"
+      },
+      {
+        "tag_name": "authz_dry_run_result",
+        "regex": "(\\.shadow_(allowed|denied))"
       }
     ],
     "stats_matcher": {
@@ -216,6 +228,12 @@
           },
           {
           "prefix": "wasm"
+          },
+          {
+          "suffix": "allowed"
+          },
+          {
+          "suffix": "denied"
           },
           {
           "prefix": "component"

--- a/pkg/bootstrap/testdata/tracing_zipkin_golden.json
+++ b/pkg/bootstrap/testdata/tracing_zipkin_golden.json
@@ -230,10 +230,16 @@
           "prefix": "wasm"
           },
           {
-          "suffix": "allowed"
+          "suffix": "rbac.allowed"
           },
           {
-          "suffix": "denied"
+          "suffix": "rbac.denied"
+          },
+          {
+          "suffix": "shadow_allowed"
+          },
+          {
+          "suffix": "shadow_denied"
           },
           {
           "prefix": "component"

--- a/pkg/bootstrap/testdata/tracing_zipkin_golden.json
+++ b/pkg/bootstrap/testdata/tracing_zipkin_golden.json
@@ -197,7 +197,7 @@
       },
       {
         "tag_name": "authz_enforce_result",
-        "regex": "(\\.(allowed|denied))"
+        "regex": "rbac(\\.(allowed|denied))"
       },
       {
         "tag_name": "authz_dry_run_action",

--- a/pkg/bootstrap/testdata/tracing_zipkin_golden.json
+++ b/pkg/bootstrap/testdata/tracing_zipkin_golden.json
@@ -194,6 +194,18 @@
       {
         "regex": "(wasm_filter\\.(.+?)\\.)",
         "tag_name": "wasm_filter"
+      },
+      {
+        "tag_name": "authz_enforce_result",
+        "regex": "(\\.(allowed|denied))"
+      },
+      {
+        "tag_name": "authz_dry_run_action",
+        "regex": "(\\.istio_dry_run_(allow|deny)_)"
+      },
+      {
+        "tag_name": "authz_dry_run_result",
+        "regex": "(\\.shadow_(allowed|denied))"
       }
     ],
     "stats_matcher": {
@@ -216,6 +228,12 @@
           },
           {
           "prefix": "wasm"
+          },
+          {
+          "suffix": "allowed"
+          },
+          {
+          "suffix": "denied"
           },
           {
           "prefix": "component"

--- a/pkg/bootstrap/testdata/xdsproxy_golden.json
+++ b/pkg/bootstrap/testdata/xdsproxy_golden.json
@@ -230,10 +230,16 @@
           "prefix": "wasm"
           },
           {
-          "suffix": "allowed"
+          "suffix": "rbac.allowed"
           },
           {
-          "suffix": "denied"
+          "suffix": "rbac.denied"
+          },
+          {
+          "suffix": "shadow_allowed"
+          },
+          {
+          "suffix": "shadow_denied"
           },
           {
           "prefix": "component"

--- a/pkg/bootstrap/testdata/xdsproxy_golden.json
+++ b/pkg/bootstrap/testdata/xdsproxy_golden.json
@@ -197,7 +197,7 @@
       },
       {
         "tag_name": "authz_enforce_result",
-        "regex": "(\\.(allowed|denied))"
+        "regex": "rbac(\\.(allowed|denied))"
       },
       {
         "tag_name": "authz_dry_run_action",

--- a/pkg/bootstrap/testdata/xdsproxy_golden.json
+++ b/pkg/bootstrap/testdata/xdsproxy_golden.json
@@ -194,6 +194,18 @@
       {
         "regex": "(wasm_filter\\.(.+?)\\.)",
         "tag_name": "wasm_filter"
+      },
+      {
+        "tag_name": "authz_enforce_result",
+        "regex": "(\\.(allowed|denied))"
+      },
+      {
+        "tag_name": "authz_dry_run_action",
+        "regex": "(\\.istio_dry_run_(allow|deny)_)"
+      },
+      {
+        "tag_name": "authz_dry_run_result",
+        "regex": "(\\.shadow_(allowed|denied))"
       }
     ],
     "stats_matcher": {
@@ -216,6 +228,12 @@
           },
           {
           "prefix": "wasm"
+          },
+          {
+          "suffix": "allowed"
+          },
+          {
+          "suffix": "denied"
           },
           {
           "prefix": "component"

--- a/tools/packaging/common/envoy_bootstrap.json
+++ b/tools/packaging/common/envoy_bootstrap.json
@@ -99,6 +99,18 @@
       {
         "regex": "(wasm_filter\\.(.+?)\\.)",
         "tag_name": "wasm_filter"
+      },
+      {
+        "tag_name": "authz_enforce_result",
+        "regex": "(\\.(allowed|denied))"
+      },
+      {
+        "tag_name": "authz_dry_run_action",
+        "regex": "(\\.istio_dry_run_(allow|deny)_)"
+      },
+      {
+        "tag_name": "authz_dry_run_result",
+        "regex": "(\\.shadow_(allowed|denied))"
       }
     ],
     "stats_matcher": {

--- a/tools/packaging/common/envoy_bootstrap.json
+++ b/tools/packaging/common/envoy_bootstrap.json
@@ -102,7 +102,7 @@
       },
       {
         "tag_name": "authz_enforce_result",
-        "regex": "(\\.(allowed|denied))"
+        "regex": "rbac(\\.(allowed|denied))"
       },
       {
         "tag_name": "authz_dry_run_action",


### PR DESCRIPTION
This PR allows users to view the dry-run results in tracing and stats.

There are 3 main changes in the PR:
1. In tracing.go, added 4 new custom trace tags for dry run policies
2. In authz, updated to use a different stat prefix in the ext-authz so that it won't affect the dry run stats
3. In envoy_bootstrap.json and bootstrap/config.go: added 3 new tag extractors for authz policies and also include the rbac stats with suffix match  `allowed,denied`

Example Prometheus Stats, we will document the tags are not stable and should only be used for debugging for now:
```
# TYPE envoy_http_inbound_0_0_0_0_80_rbac counter
envoy_http_inbound_0_0_0_0_80_rbac{authz_enforce_result="allowed"} 0
envoy_http_inbound_0_0_0_0_80_rbac{authz_enforce_result="denied"} 0
envoy_http_inbound_0_0_0_0_80_rbac{authz_dry_run_action="allow",authz_dry_run_result="allowed"} 2
envoy_http_inbound_0_0_0_0_80_rbac{authz_dry_run_action="allow",authz_dry_run_result="denied"} 1
envoy_http_inbound_0_0_0_0_80_rbac{authz_dry_run_action="deny",authz_dry_run_result="allowed"} 1
envoy_http_inbound_0_0_0_0_80_rbac{authz_dry_run_action="deny",authz_dry_run_result="denied"} 2
```

Limitations:
1. There will be 2 separate stats for `allow` and `deny` policies due to we are using 2 RBAC filters for deny and allow. Currently the stackdriver filter will automatically merge it to a single stat for better usability, but this is not done for other tracing/stat provider. we can look into improving this later.
2. The existing tag extractor seems already broken (not extracting the `inbound_0_0_0_0_80` part: ), this should be fixed separately, see https://github.com/istio/istio/issues/32025.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[x] Policies and Telemetry
[x] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any changes that may affect Istio users.