### PR TITLE
Allow, with warning, users using first-party-jwt with Kubernetes 1.21+

### DIFF
--- a/security/pkg/server/ca/authenticate/kubeauth/kube_jwt.go
+++ b/security/pkg/server/ca/authenticate/kubeauth/kube_jwt.go
@@ -19,9 +19,9 @@ import (
 
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/metadata"
-	"istio.io/istio/pkg/jwt"
 	"k8s.io/client-go/kubernetes"
 
+	"istio.io/istio/pkg/jwt"
 	"istio.io/istio/pkg/security"
 	"istio.io/istio/security/pkg/k8s/tokenreview"
 	"istio.io/istio/security/pkg/server/ca/authenticate"

--- a/security/pkg/server/ca/authenticate/kubeauth/kube_jwt.go
+++ b/security/pkg/server/ca/authenticate/kubeauth/kube_jwt.go
@@ -19,12 +19,14 @@ import (
 
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/metadata"
+	"istio.io/istio/pkg/jwt"
 	"k8s.io/client-go/kubernetes"
 
 	"istio.io/istio/pkg/security"
 	"istio.io/istio/security/pkg/k8s/tokenreview"
 	"istio.io/istio/security/pkg/server/ca/authenticate"
 	"istio.io/istio/security/pkg/util"
+	"istio.io/pkg/log"
 )
 
 const (
@@ -68,6 +70,8 @@ func (a *KubeJWTAuthenticator) AuthenticatorType() string {
 	return KubeJWTAuthenticatorType
 }
 
+const DefaultKubernetesAudience = "kubernetes.default.svc"
+
 // Authenticate authenticates the call using the K8s JWT from the context.
 // The returned Caller.Identities is in SPIFFE format.
 func (a *KubeJWTAuthenticator) Authenticate(ctx context.Context) (*security.Caller, error) {
@@ -92,6 +96,20 @@ func (a *KubeJWTAuthenticator) Authenticate(ctx context.Context) (*security.Call
 	// tolerate the unbound tokens.
 	if !util.IsK8SUnbound(targetJWT) || security.Require3PToken.Get() {
 		aud = security.TokenAudiences
+		if tokenAud, _ := util.ExtractJwtAud(targetJWT); len(tokenAud) == 1 && tokenAud[0] == DefaultKubernetesAudience {
+			if a.jwtPolicy == jwt.PolicyFirstParty && !security.Require3PToken.Get() {
+				// For backwards compatibility, if first-party-jwt is used and they don't require 3p, allow it but warn
+				// This is intended to support first-party-jwt on Kubernetes 1.21+, where BoundServiceAccountTokenVolume
+				// became default and started setting an audience to DefaultKubernetesAudience.
+				// Users should disable first-party-jwt, but we don't want to break them on upgrade
+				log.Warnf("Insecure first-party-jwt option used to validate token; use third-party-jwt")
+				aud = nil
+			} else {
+				log.Warnf("Received token with aud %q, but expected %q. BoundServiceAccountTokenVolume, "+
+					"default in Kubernetes 1.21+, is not compatible with first-party-jwt",
+					DefaultKubernetesAudience, aud)
+			}
+		}
 		// TODO: check the audience from token, no need to call
 		// apiserver if audience is not matching. This may also
 		// handle older apiservers that don't check audience.

--- a/tests/integration/helm/install_test.go
+++ b/tests/integration/helm/install_test.go
@@ -55,9 +55,6 @@ global:
 		NewTest(t).
 		Features("installation.helm.firstpartyjwt.install").
 		Run(func(t framework.TestContext) {
-			if !t.Clusters().Default().MaxKubeVersion(20) { // All JWT are third party in 1.21+ (BoundServiceAccountTokenVolume)
-				t.Skip("first-party-jwt is not supported")
-			}
 			setupInstallation(overrideValuesStr)(t)
 		})
 }

--- a/tests/integration/security/mtls_first_party_jwt/main_test.go
+++ b/tests/integration/security/mtls_first_party_jwt/main_test.go
@@ -34,7 +34,6 @@ func TestMain(m *testing.M) {
 	framework.
 		NewSuite(m).
 		Label(label.CustomSetup).
-		RequireMaxVersion(20). // All JWT are third party in 1.21+ (BoundServiceAccountTokenVolume)
 		Setup(istio.Setup(&inst, setupConfig)).
 		Setup(func(ctx resource.Context) error {
 			// TODO: due to issue https://github.com/istio/istio/issues/25286,


### PR DESCRIPTION
For https://github.com/istio/istio/issues/31964
Just add a warning to give users a hint.

This also cleans up a dead field.