### PR TITLE
enable cross cluster workloadentry reading by default

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -361,7 +361,7 @@ var (
 	WorkloadEntryHealthChecks = env.RegisterBoolVar("PILOT_ENABLE_WORKLOAD_ENTRY_HEALTHCHECKS", true,
 		"Enables automatic health checks of WorkloadEntries based on the config provided in the associated WorkloadGroup").Get()
 
-	WorkloadEntryCrossCluster = env.RegisterBoolVar("PILOT_ENABLE_CROSS_CLUSTER_WORKLOAD_ENTRY", false,
+	WorkloadEntryCrossCluster = env.RegisterBoolVar("PILOT_ENABLE_CROSS_CLUSTER_WORKLOAD_ENTRY", true,
 		"If enabled, pilot will read WorkloadEntry from other clusters, selectable by Services in that cluster.").Get()
 
 	EnableFlowControl = env.RegisterBoolVar(

--- a/releasenotes/notes/x-cluster-wle.yaml
+++ b/releasenotes/notes/x-cluster-wle.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: networking
+releaseNotes:
+- |
+  **Promoted** `PILOT_ENABLE_CROSS_CLUSTER_WORKLOAD_ENTRY` to be enabled by default, allowing Pilot to read `WorkloadEntry`
+  resources across clusters without the need to duplicate them in each primary cluster. This is required to use VM
+  auto-registration alongside multi-primary multi-cluster.

--- a/tests/integration/iop-integration-test-defaults.yaml
+++ b/tests/integration/iop-integration-test-defaults.yaml
@@ -55,7 +55,6 @@ spec:
     pilot:
       env:
         UNSAFE_ENABLE_ADMIN_ENDPOINTS: true
-        PILOT_ENABLE_CROSS_CLUSTER_WORKLOAD_ENTRY: true
 
     gateways:
       istio-ingressgateway:


### PR DESCRIPTION
cc @istio/release-managers-1-10 

I want to propose enabling this by default in 1.10+

Reasons for:
* We have strong coverage in integration tests
* I'm aware of users trying this out (at least Google customers)

Reasons against:
* Requires a permission for `istio-reader` introduced in 1.9, and we need to make sure upgrades are safe. 