### PR TITLE
shifting test: use only available splits

### DIFF
--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -409,7 +409,10 @@ spec:
 			toN:           len(split),
 			sourceFilters: []echotest.Filter{noHeadless, noNaked},
 			targetFilters: []echotest.Filter{noHeadless, noExternal},
-			config: fmt.Sprintf(`
+			templateVars: map[string]interface{}{
+				"split": split,
+			},
+			config: `
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
@@ -419,16 +422,12 @@ spec:
     - {{ ( index .dstSvcs 0) }}
   http:
   - route:
+{{- range $idx, $svc }}
     - destination:
-        host: {{ ( index .dstSvcs 0) }}
-      weight: %d
-    - destination:
-        host: {{ ( index .dstSvcs 1) }}
-      weight: %d
-    - destination:
-        host: {{ ( index .dstSvcs 2) }}
-      weight: %d
-`, split[0], split[1], split[2]),
+        host: {{ $svc }}
+      weight: {{ ( index .split $idx ) }}
+{{- end }}
+`,
 			validate: func(src echo.Instance, dests echo.Services) echo.Validator {
 				return echo.And(
 					echo.ExpectOK(),

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -413,6 +413,7 @@ spec:
 				"split": split,
 			},
 			config: `
+{{ $split := .split }} 
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
@@ -422,10 +423,10 @@ spec:
     - {{ ( index .dstSvcs 0) }}
   http:
   - route:
-{{- range $idx, $svc }}
+{{- range $idx, $svc := .dstSvcs }}
     - destination:
         host: {{ $svc }}
-      weight: {{ ( index .split $idx ) }}
+      weight: {{ ( index $split $idx ) }}
 {{- end }}
 `,
 			validate: func(src echo.Instance, dests echo.Services) echo.Validator {

--- a/tests/integration/pilot/common/traffic.go
+++ b/tests/integration/pilot/common/traffic.go
@@ -70,6 +70,8 @@ type TrafficTestCase struct {
 	sourceFilters []echotest.Filter
 	// targetFilters allows adding additional filtering for workload agnostic cases to test using fewer targets
 	targetFilters []echotest.Filter
+	// vars given to the config template
+	templateVars map[string]interface{}
 }
 
 func (c TrafficTestCase) RunForApps(t framework.TestContext, apps echo.Instances, namespace string) {
@@ -88,19 +90,20 @@ func (c TrafficTestCase) RunForApps(t framework.TestContext, apps echo.Instances
 	job := func(t framework.TestContext) {
 		echoT := echotest.New(t, apps).
 			SetupForServicePair(func(t framework.TestContext, src echo.Instances, dsts echo.Services) error {
-				cfg := yml.MustApplyNamespace(t, tmpl.MustEvaluate(
-					c.config,
-					map[string]interface{}{
-						"src":    src,
-						"srcSvc": src[0].Config().Service,
-						// tests that use simple Run only need the first
-						"dst":    dsts[0],
-						"dstSvc": dsts[0][0].Config().Service,
-						// tests that use RunForN need all destination deployments
-						"dsts":    dsts,
-						"dstSvcs": dsts.Services(),
-					},
-				), namespace)
+				tmplData := map[string]interface{}{
+					"src":    src,
+					"srcSvc": src[0].Config().Service,
+					// tests that use simple Run only need the first
+					"dst":    dsts[0],
+					"dstSvc": dsts[0][0].Config().Service,
+					// tests that use RunForN need all destination deployments
+					"dsts":    dsts,
+					"dstSvcs": dsts.Services(),
+				}
+				for k, v := range c.templateVars {
+					tmplData[k] = v
+				}
+				cfg := yml.MustApplyNamespace(t, tmpl.MustEvaluate(c.config, tmplData), namespace)
 				return t.Config().ApplyYAML("", cfg)
 			}).
 			WithDefaultFilters().

--- a/tests/integration/pilot/vm_test.go
+++ b/tests/integration/pilot/vm_test.go
@@ -85,6 +85,9 @@ func TestVMRegistrationLifecycle(t *testing.T) {
 		RequiresSingleCluster().
 		Features("vm.autoregistration").
 		Run(func(t framework.TestContext) {
+			if t.Settings().SkipVM {
+				t.Skip()
+			}
 			scaleDeploymentOrFail(t, "istiod", i.Settings().SystemNamespace, 2)
 			client := apps.PodA.GetOrFail(t, echo.InCluster(t.Clusters().Default()))
 			// TODO test multi-network (must be shared control plane but on different networks)


### PR DESCRIPTION
#31937 introduced a panic when `--istio.test.skipVM` is used – this includes logic to use available splits inside the template