### PR TITLE
Fix process bar output to stderr

### DIFF
--- a/operator/pkg/util/progress/progress_test.go
+++ b/operator/pkg/util/progress/progress_test.go
@@ -22,6 +22,9 @@ import (
 	"istio.io/istio/operator/pkg/name"
 )
 
+// For testing only
+var testWriter *io.Writer
+
 func TestProgressLog(t *testing.T) {
 	buf := bytes.NewBuffer(nil)
 	testBuf := io.Writer(buf)
@@ -37,7 +40,7 @@ func TestProgressLog(t *testing.T) {
 		expected = newExpected
 	}
 
-	p := NewLog()
+	p := NewLogWithWriter(*testWriter)
 	cnp := name.PilotComponentName
 	cnpo := name.UserFacingComponentName(cnp)
 	cnb := name.IstioBaseComponentName


### PR DESCRIPTION
Fix https://github.com/istio/istio/issues/32020
[X] Installation

[X] Does not have any changes that may affect Istio users.

```console
➜  istio git:(fix/process-bar-to-stderr) go run istioctl/cmd/istioctl/main.go install --dry-run -y 2> /dev/null
✔ Istio core installed
✔ Istiod installed
✔ Ingress gateways installed
✔ Installation complete
```