### PR TITLE
Do not write namespace configmap for k8s cert provider

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -1157,6 +1157,12 @@ func (s *Server) fetchCARoot() map[string]string {
 	if s.CA == nil {
 		return nil
 	}
+
+	// For Kubernetes CA, we don't distribute it; it is mounted in all pods by Kubernetes.
+	if features.PilotCertProvider.Get() == KubernetesCAProvider {
+		return nil
+	}
+
 	return map[string]string{
 		constants.CACertNamespaceConfigMapDataName: string(s.CA.GetCAKeyCertBundle().GetRootCertPem()),
 	}


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/32023
We have existing test coverage to ensure this mode still works correctly.