### PR TITLE
use test framework imagepullsecret in testcustomgateway

### DIFF
--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -28,11 +28,9 @@ import (
 
 	"github.com/Masterminds/sprig/v3"
 	"github.com/hashicorp/go-multierror"
-	"gopkg.in/yaml.v3"
 	kubeCore "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/kubernetes"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
@@ -617,17 +615,9 @@ func templateParams(cfg echo.Config, settings *image.Settings, versions resource
 	if cfg.Namespace != nil {
 		namespace = cfg.Namespace.Name()
 	}
-	imagePullSecret := ""
-	if settings.ImagePullSecret != "" {
-		data, err := ioutil.ReadFile(settings.ImagePullSecret)
-		if err != nil {
-			return nil, err
-		}
-		secret := unstructured.Unstructured{Object: map[string]interface{}{}}
-		if err := yaml.Unmarshal(data, secret.Object); err != nil {
-			return nil, err
-		}
-		imagePullSecret = secret.GetName()
+	imagePullSecret, err := settings.ImagePullSecretName()
+	if err != nil {
+		return nil, err
 	}
 	params := map[string]interface{}{
 		"Hub":                settings.Hub,

--- a/pkg/test/framework/image/settings.go
+++ b/pkg/test/framework/image/settings.go
@@ -18,11 +18,10 @@ import (
 	"fmt"
 	"io/ioutil"
 
-	"istio.io/istio/pkg/test"
-
 	"gopkg.in/yaml.v3"
-
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"istio.io/istio/pkg/test"
 )
 
 const (

--- a/tests/integration/pilot/ingress_test.go
+++ b/tests/integration/pilot/ingress_test.go
@@ -23,10 +23,6 @@ import (
 	"testing"
 	"time"
 
-	"istio.io/istio/pkg/test/util/tmpl"
-
-	"istio.io/istio/pkg/test/framework/image"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8s "sigs.k8s.io/gateway-api/apis/v1alpha1"
 
@@ -39,9 +35,11 @@ import (
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/environment/kube"
 	"istio.io/istio/pkg/test/framework/components/namespace"
+	"istio.io/istio/pkg/test/framework/image"
 	"istio.io/istio/pkg/test/helm"
 	kubetest "istio.io/istio/pkg/test/kube"
 	"istio.io/istio/pkg/test/util/retry"
+	"istio.io/istio/pkg/test/util/tmpl"
 	helmtest "istio.io/istio/tests/integration/helm"
 	ingressutil "istio.io/istio/tests/integration/security/sds_ingress/util"
 )

--- a/tests/integration/pilot/ingress_test.go
+++ b/tests/integration/pilot/ingress_test.go
@@ -23,6 +23,10 @@ import (
 	"testing"
 	"time"
 
+	"istio.io/istio/pkg/test/util/tmpl"
+
+	"istio.io/istio/pkg/test/framework/image"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8s "sigs.k8s.io/gateway-api/apis/v1alpha1"
 
@@ -413,8 +417,15 @@ func TestCustomGateway(t *testing.T) {
 			if len(t.Settings().Revision) > 0 {
 				injectLabel = fmt.Sprintf(`istio.io/rev: "%v"`, t.Settings().Revision)
 			}
+
+			templateParams := map[string]string{
+				"imagePullSecret": image.PullSecretNameOrFail(t),
+				"injectLabel":     injectLabel,
+				"host":            apps.PodA[0].Config().FQDN(),
+			}
+
 			t.NewSubTest("minimal").Run(func(t framework.TestContext) {
-				t.Config().ApplyYAMLOrFail(t, gatewayNs.Name(), fmt.Sprintf(`apiVersion: v1
+				t.Config().ApplyYAMLOrFail(t, gatewayNs.Name(), tmpl.MustEvaluate(`apiVersion: v1
 kind: Service
 metadata:
   name: custom-gateway
@@ -441,8 +452,12 @@ spec:
         inject.istio.io/templates: gateway
       labels:
         istio: custom
-        %v
+        {{ .injectLabel }}
     spec:
+      {{- if ne .imagePullSecret "" }}
+      imagePullSecrets:
+      - name: {{ .imagePullSecret }}
+      {{- end }}
       containers:
       - name: istio-proxy
         image: auto
@@ -474,10 +489,10 @@ spec:
   http:
   - route:
     - destination:
-        host: %s
+        host: {{ .host }}
         port:
           number: 80
-`, injectLabel, apps.PodA[0].Config().FQDN()))
+`, templateParams))
 				cs := t.Clusters().Default().(*kubecluster.Cluster)
 				retry.UntilSuccessOrFail(t, func() error {
 					_, err := kubetest.CheckPodsAreReady(kubetest.NewPodFetch(cs, gatewayNs.Name(), "istio=custom"))


### PR DESCRIPTION
Allows (partially) running this test in environments where images are in a protected registry. 

I began to convert the helm test as well, but the options were: modify the templates, somehow patch the generated kube yaml. Neither seemed great (although it makes me wonder if our templates _should_ include the ability to set `imagePullSecrets`?)