### PR TITLE
a deep hidden bug for command `istioctl analysis -A`

### DIFF
--- a/galley/pkg/config/processing/snapshotter/analyzingdistributor.go
+++ b/galley/pkg/config/processing/snapshotter/analyzingdistributor.go
@@ -154,6 +154,7 @@ func (d *AnalyzingDistributor) analyzeAndDistribute(cancelCh chan struct{}, name
 	ctx := &context{
 		sn:                 d.getCombinedSnapshot(),
 		cancelCh:           cancelCh,
+		isCancel:           false,
 		collectionReporter: d.s.CollectionReporter,
 	}
 
@@ -239,6 +240,7 @@ FilterMessages:
 type context struct {
 	sn                 *Snapshot
 	cancelCh           chan struct{}
+	isCancel           bool
 	messages           diag.Messages
 	collectionReporter CollectionReporterFn
 }
@@ -272,8 +274,9 @@ func (c *context) ForEach(col collection.Name, fn analysis.IteratorFn) {
 func (c *context) Canceled() bool {
 	select {
 	case <-c.cancelCh:
-		return true
+		c.isCancel = true
+		return c.isCancel
 	default:
-		return false
+		return c.isCancel
 	}
 }


### PR DESCRIPTION
PR Description: 
 When I execute command `istioctl analysis -A`,  I found that the analyzers may not be completed every time, then trigger the StatusUpdater update and finish the analysis reporter building if there are several goroutines to do analysis work. 

reference source code:
[analyzingdistributor.go L#139](https://github.com/istio/istio/blob/3e057db1331d14a4d276c8a15f3eb20c588daae9/galley/pkg/config/processing/snapshotter/analyzingdistributor.go#L139)
[analyzingdistributor.go L#165](https://github.com/istio/istio/blob/3e057db1331d14a4d276c8a15f3eb20c588daae9/galley/pkg/config/processing/snapshotter/analyzingdistributor.go#L165)
[analyzer.go L#54](https://github.com/istio/istio/blob/3e057db1331d14a4d276c8a15f3eb20c588daae9/galley/pkg/config/analysis/analyzer.go#L54)


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[x] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
