### PR TITLE
Add ROOT env var

### DIFF
--- a/tools/build-base-images.sh
+++ b/tools/build-base-images.sh
@@ -17,6 +17,10 @@
 # This script runs go tests in a package, but each test is run individually. This helps
 # isolate tests that are improperly depending on global state modification of other tests
 
+WD=$(dirname "$0")
+WD=$(cd "$WD"; pwd)
+ROOT=$(dirname "$WD")
+
 set -ex
 
 # shellcheck source=prow/lib.sh


### PR DESCRIPTION

Fix missing ROOT env var in build-base-images.sh


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any changes that may affect Istio users.