### PR TITLE
convert gateway test to be workload agnostic

### DIFF
--- a/pkg/test/framework/components/echo/echo.go
+++ b/pkg/test/framework/components/echo/echo.go
@@ -73,6 +73,21 @@ type Caller interface {
 	CallWithRetryOrFail(t test.Failer, options CallOptions, retryOptions ...retry.Option) client.ParsedResponses
 }
 
+type Callers []Caller
+
+// Instances returns an Instances if all callers are Instance, otherwise returns nil.
+func (c Callers) Instances() Instances {
+	var out Instances
+	for _, caller := range c {
+		c, ok := caller.(Instance)
+		if !ok {
+			return nil
+		}
+		out = append(out, c)
+	}
+	return out
+}
+
 // Instance is a component that provides access to a deployed echo service.
 type Instance interface {
 	Caller

--- a/pkg/test/framework/components/echo/echo.go
+++ b/pkg/test/framework/components/echo/echo.go
@@ -62,8 +62,21 @@ type Builder interface {
 	BuildOrFail(t test.Failer) Instances
 }
 
+type Caller interface {
+	// Call makes a call from this Instance to a target Instance.
+	Call(options CallOptions) (client.ParsedResponses, error)
+	CallOrFail(t test.Failer, options CallOptions) client.ParsedResponses
+
+	// CallWithRetry is the same as call, except that it will attempt to retry based on the provided
+	// options. If no options are provided, uses defaults.
+	CallWithRetry(options CallOptions, retryOptions ...retry.Option) (client.ParsedResponses, error)
+	CallWithRetryOrFail(t test.Failer, options CallOptions, retryOptions ...retry.Option) client.ParsedResponses
+}
+
 // Instance is a component that provides access to a deployed echo service.
 type Instance interface {
+	Caller
+
 	resource.Resource
 
 	// Config returns the configuration of the Echo instance.
@@ -76,15 +89,6 @@ type Instance interface {
 	// Guarantees at least one workload, if error == nil.
 	Workloads() ([]Workload, error)
 	WorkloadsOrFail(t test.Failer) []Workload
-
-	// Call makes a call from this Instance to a target Instance.
-	Call(options CallOptions) (client.ParsedResponses, error)
-	CallOrFail(t test.Failer, options CallOptions) client.ParsedResponses
-
-	// CallWithRetry is the same as call, except that it will attempt to retry based on the provided
-	// options. If no options are provided, uses defaults.
-	CallWithRetry(options CallOptions, retryOptions ...retry.Option) (client.ParsedResponses, error)
-	CallWithRetryOrFail(t test.Failer, options CallOptions, retryOptions ...retry.Option) client.ParsedResponses
 
 	// Restart restarts the workloads associated with this echo instance
 	Restart() error

--- a/pkg/test/framework/components/echo/echotest/filters.go
+++ b/pkg/test/framework/components/echo/echotest/filters.go
@@ -113,7 +113,7 @@ func isRegularPod(instance echo.Instance) bool {
 
 // SpecialWorkloads includes VMs, external services, naked services, headless, etc.
 func SpecialWorkloads(instances echo.Instances) echo.Instances {
-	return instances.Match(isRegularPod)
+	return instances.Match(echo.Not(isRegularPod))
 }
 
 // Not includes all workloads that don't match the given filter

--- a/pkg/test/framework/components/echo/echotest/filters.go
+++ b/pkg/test/framework/components/echo/echotest/filters.go
@@ -111,6 +111,11 @@ func isRegularPod(instance echo.Instance) bool {
 	return len(c.Subsets) == 1 && !c.IsVM() && !c.IsTProxy() && !c.IsNaked() && !c.IsHeadless()
 }
 
+// SpecialWorkloads includes VMs, external services, naked services, headless, etc.
+func SpecialWorkloads(instances echo.Instances) echo.Instances {
+	return instances.Match(isRegularPod)
+}
+
 // Not includes all workloads that don't match the given filter
 func Not(filter Filter) Filter {
 	return func(instances echo.Instances) echo.Instances {

--- a/pkg/test/framework/components/echo/echotest/filters.go
+++ b/pkg/test/framework/components/echo/echotest/filters.go
@@ -92,8 +92,8 @@ func SingleSimplePodServiceAndAllSpecial(exclude ...echo.Instance) Filter {
 }
 
 func oneRegularPod(instances echo.Instances, exclude echo.Instances) echo.Instances {
-	regularPods := instances.Match(isRegularPod)
-	others := instances.Match(echo.Not(isRegularPod))
+	regularPods := instances.Match(RegularPod)
+	others := instances.Match(echo.Not(RegularPod))
 	for _, exclude := range exclude {
 		regularPods = regularPods.Match(echo.Not(echo.SameDeployment(exclude)))
 	}
@@ -105,15 +105,15 @@ func oneRegularPod(instances echo.Instances, exclude echo.Instances) echo.Instan
 	return append(regularPods, others...)
 }
 
-// TODO put this on echo.Config?
-func isRegularPod(instance echo.Instance) bool {
+// RegularPod matches echos that don't meet any of the following criteria:
+// - VM
+// - Naked
+// - Headless
+// - TProxy
+// - Multi-Subset
+func RegularPod(instance echo.Instance) bool {
 	c := instance.Config()
 	return len(c.Subsets) == 1 && !c.IsVM() && !c.IsTProxy() && !c.IsNaked() && !c.IsHeadless()
-}
-
-// SpecialWorkloads includes VMs, external services, naked services, headless, etc.
-func SpecialWorkloads(instances echo.Instances) echo.Instances {
-	return instances.Match(echo.Not(isRegularPod))
 }
 
 // Not includes all workloads that don't match the given filter

--- a/pkg/test/framework/components/echo/echotest/filters_test.go
+++ b/pkg/test/framework/components/echo/echotest/filters_test.go
@@ -92,17 +92,10 @@ func TestIsRegularPod(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.app.Config().Service, func(t *testing.T) {
-			if got := isRegularPod(tt.app); got != tt.expect {
+			if got := RegularPod(tt.app); got != tt.expect {
 				t.Errorf("got %v expected %v", got, tt.expect)
 			}
 		})
-	}
-}
-
-func TestNoSpecial(t *testing.T) {
-	out := Not(SpecialWorkloads)(all).Services().Services()
-	if diff := cmp.Diff(out, []string{"a", "a", "b", "c"}); diff != "" {
-		t.Fatal(diff)
 	}
 }
 

--- a/pkg/test/framework/components/echo/echotest/filters_test.go
+++ b/pkg/test/framework/components/echo/echotest/filters_test.go
@@ -99,6 +99,13 @@ func TestIsRegularPod(t *testing.T) {
 	}
 }
 
+func TestNoSpecial(t *testing.T) {
+	out := Not(SpecialWorkloads)(all).Services().Services()
+	if diff := cmp.Diff(out, []string{"a", "a", "b", "c"}); diff != "" {
+		t.Fatal(diff)
+	}
+}
+
 func TestIsNaked(t *testing.T) {
 	tests := []struct {
 		app    echo.Instance

--- a/pkg/test/framework/components/echo/echotest/setup.go
+++ b/pkg/test/framework/components/echo/echotest/setup.go
@@ -77,6 +77,7 @@ func (t *T) setupPair(ctx framework.TestContext, src echo.Instances, dsts echo.S
 			ctx.Fatal(err)
 		}
 	}
+	t.setupDst(ctx, dsts.Instances())
 }
 
 func (t *T) SetupForDestination(setupFn dstSetupFn) *T {

--- a/pkg/test/framework/components/echo/echotest/setup.go
+++ b/pkg/test/framework/components/echo/echotest/setup.go
@@ -20,10 +20,9 @@ import (
 )
 
 type (
-	srcSetupFn     func(ctx framework.TestContext, src echo.Instances) error
-	svcPairSetupFn func(ctx framework.TestContext, src echo.Instances, dsts echo.Services) error
+	srcSetupFn     func(ctx framework.TestContext, src echo.Callers) error
+	svcPairSetupFn func(ctx framework.TestContext, src echo.Callers, dsts echo.Services) error
 	dstSetupFn     func(ctx framework.TestContext, dsts echo.Instances) error
-	pairSetupFn    func(ctx framework.TestContext, src, dsts echo.Instances) error
 )
 
 // Setup runs the given function in the source deployment context.
@@ -42,7 +41,7 @@ func (t *T) Setup(setupFn srcSetupFn) *T {
 	return t
 }
 
-func (t *T) setup(ctx framework.TestContext, srcInstances echo.Instances) {
+func (t *T) setup(ctx framework.TestContext, srcInstances echo.Callers) {
 	for _, setupFn := range t.sourceDeploymentSetup {
 		if err := setupFn(ctx, srcInstances); err != nil {
 			ctx.Fatal(err)
@@ -59,13 +58,13 @@ func (t *T) setup(ctx framework.TestContext, srcInstances echo.Instances) {
 //     cleanup...
 //     a/to_b/from_cluster-2
 //     ...
-func (t *T) SetupForPair(setupFn pairSetupFn) *T {
-	return t.SetupForServicePair(func(ctx framework.TestContext, src echo.Instances, dsts echo.Services) error {
+func (t *T) SetupForPair(setupFn func(ctx framework.TestContext, src echo.Callers, dsts echo.Instances) error) *T {
+	return t.SetupForServicePair(func(ctx framework.TestContext, src echo.Callers, dsts echo.Services) error {
 		return setupFn(ctx, src, dsts.Instances())
 	})
 }
 
-// SetupForServicePair works similarly to SetupForPair, but the setup funciton accepts echo.Services, which
+// SetupForServicePair works similarly to SetupForPair, but the setup function accepts echo.Services, which
 // contains instances for multiple services and should be used in combination with RunForN.
 // The length of dsts services will alyas be N.
 func (t *T) SetupForServicePair(setupFn svcPairSetupFn) *T {
@@ -73,7 +72,7 @@ func (t *T) SetupForServicePair(setupFn svcPairSetupFn) *T {
 	return t
 }
 
-func (t *T) setupPair(ctx framework.TestContext, src echo.Instances, dsts echo.Services) {
+func (t *T) setupPair(ctx framework.TestContext, src echo.Callers, dsts echo.Services) {
 	for _, setupFn := range t.deploymentPairSetup {
 		if err := setupFn(ctx, src, dsts); err != nil {
 			ctx.Fatal(err)

--- a/pkg/test/framework/components/echo/echotest/setup.go
+++ b/pkg/test/framework/components/echo/echotest/setup.go
@@ -50,9 +50,8 @@ func (t *T) setup(ctx framework.TestContext, srcInstances echo.Instances) {
 	}
 }
 
-// SetupForPair runs the given function in the source + destination deployment context. The setup function
-// takes an echo.Services. When using Run there will always be 1 destination deployment. When using RunForN,
-// the length will always be N.
+// SetupForPair runs the given function for every source instance in every cluster in combination with every
+// destination service.
 //
 // Example of how long this setup lasts before the given context is cleaned up:
 //     a/to_b/from_cluster-1
@@ -62,10 +61,13 @@ func (t *T) setup(ctx framework.TestContext, srcInstances echo.Instances) {
 //     ...
 func (t *T) SetupForPair(setupFn pairSetupFn) *T {
 	return t.SetupForServicePair(func(ctx framework.TestContext, src echo.Instances, dsts echo.Services) error {
-		return setupFn(ctx, src, dsts[0])
+		return setupFn(ctx, src, dsts.Instances())
 	})
 }
 
+// SetupForServicePair works similarly to SetupForPair, but the setup funciton accepts echo.Services, which
+// contains instances for multiple services and should be used in combination with RunForN.
+// The length of dsts services will alyas be N.
 func (t *T) SetupForServicePair(setupFn svcPairSetupFn) *T {
 	t.deploymentPairSetup = append(t.deploymentPairSetup, setupFn)
 	return t
@@ -80,6 +82,7 @@ func (t *T) setupPair(ctx framework.TestContext, src echo.Instances, dsts echo.S
 	t.setupDst(ctx, dsts.Instances())
 }
 
+// SetupForDestination is run each time the destination Service (but not destination cluser) changes.
 func (t *T) SetupForDestination(setupFn dstSetupFn) *T {
 	t.destinationDeploymentSetup = append(t.destinationDeploymentSetup, setupFn)
 	return t

--- a/pkg/test/framework/components/echo/instances.go
+++ b/pkg/test/framework/components/echo/instances.go
@@ -26,6 +26,15 @@ import (
 // Instances contains the instances created by the builder with methods for filtering
 type Instances []Instance
 
+// Callers is a convenience method to convert Instances into Callers.
+func (i Instances) Callers() Callers {
+	var out Callers
+	for _, instance := range i {
+		out = append(out, instance)
+	}
+	return out
+}
+
 // Clusters returns a list of cluster names that the instances are deployed in
 func (i Instances) Clusters() cluster.Clusters {
 	clusters := map[string]cluster.Cluster{}

--- a/pkg/test/framework/components/istio/helm.go
+++ b/pkg/test/framework/components/istio/helm.go
@@ -82,6 +82,10 @@ func (h *helmComponent) ID() resource.ID {
 	return h.id
 }
 
+func (h *helmComponent) Ingresses() ingress.Instances {
+	panic("implement me")
+}
+
 func (h *helmComponent) IngressFor(cluster cluster.Cluster) ingress.Instance {
 	panic("implement me")
 }

--- a/pkg/test/framework/components/istio/ingress.go
+++ b/pkg/test/framework/components/istio/ingress.go
@@ -164,28 +164,28 @@ func (c *ingressImpl) DiscoveryAddress() net.TCPAddr {
 	return net.TCPAddr{IP: ip, Port: port}
 }
 
-func (c *ingressImpl) CallEcho(options echo.CallOptions) (client.ParsedResponses, error) {
+func (c *ingressImpl) Call(options echo.CallOptions) (client.ParsedResponses, error) {
 	return c.callEcho(options, false)
 }
 
-func (c *ingressImpl) CallEchoOrFail(t test.Failer, options echo.CallOptions) client.ParsedResponses {
+func (c *ingressImpl) CallOrFail(t test.Failer, options echo.CallOptions) client.ParsedResponses {
 	t.Helper()
-	resp, err := c.CallEcho(options)
+	resp, err := c.Call(options)
 	if err != nil {
 		t.Fatal(err)
 	}
 	return resp
 }
 
-func (c *ingressImpl) CallEchoWithRetry(options echo.CallOptions,
+func (c *ingressImpl) CallWithRetry(options echo.CallOptions,
 	retryOptions ...retry.Option) (client.ParsedResponses, error) {
 	return c.callEcho(options, true, retryOptions...)
 }
 
-func (c *ingressImpl) CallEchoWithRetryOrFail(t test.Failer, options echo.CallOptions,
+func (c *ingressImpl) CallWithRetryOrFail(t test.Failer, options echo.CallOptions,
 	retryOptions ...retry.Option) client.ParsedResponses {
 	t.Helper()
-	resp, err := c.CallEchoWithRetry(options, retryOptions...)
+	resp, err := c.CallWithRetry(options, retryOptions...)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/test/framework/components/istio/ingress/interface.go
+++ b/pkg/test/framework/components/istio/ingress/interface.go
@@ -17,14 +17,22 @@ package ingress
 import (
 	"net"
 
-	"istio.io/istio/pkg/test"
-	"istio.io/istio/pkg/test/echo/client"
 	"istio.io/istio/pkg/test/framework/components/echo"
-	"istio.io/istio/pkg/test/util/retry"
 )
+
+type Instances []Instance
+
+func (i Instances) Callers() echo.Callers {
+	var out echo.Callers
+	for _, instance := range i {
+		out = append(out, instance)
+	}
+	return out
+}
 
 // Instance represents a deployed Ingress Gateway instance.
 type Instance interface {
+	echo.Caller
 	// HTTPAddress returns the external HTTP (80) address of the ingress gateway ((or the NodePort address,
 	//	// when in an environment that doesn't support LoadBalancer).
 	HTTPAddress() (string, int)
@@ -40,11 +48,6 @@ type Instance interface {
 	// AddressForPort returns the external address of the ingress gateway (or the NodePort address,
 	// when in an environment that doesn't support LoadBalancer) for the given port.
 	AddressForPort(port int) (string, int)
-	// Call makes a call through ingress using the echo call and response types.
-	Call(options echo.CallOptions) (client.ParsedResponses, error)
-	CallOrFail(t test.Failer, options echo.CallOptions) client.ParsedResponses
-	CallWithRetry(options echo.CallOptions, retryOptions ...retry.Option) (client.ParsedResponses, error)
-	CallWithRetryOrFail(t test.Failer, options echo.CallOptions, retryOptions ...retry.Option) client.ParsedResponses
 
 	// ProxyStats returns proxy stats, or error if failure happens.
 	ProxyStats() (map[string]int, error)

--- a/pkg/test/framework/components/istio/ingress/interface.go
+++ b/pkg/test/framework/components/istio/ingress/interface.go
@@ -40,11 +40,11 @@ type Instance interface {
 	// AddressForPort returns the external address of the ingress gateway (or the NodePort address,
 	// when in an environment that doesn't support LoadBalancer) for the given port.
 	AddressForPort(port int) (string, int)
-	// CallEcho makes a call through ingress using the echo call and response types.
-	CallEcho(options echo.CallOptions) (client.ParsedResponses, error)
-	CallEchoOrFail(t test.Failer, options echo.CallOptions) client.ParsedResponses
-	CallEchoWithRetry(options echo.CallOptions, retryOptions ...retry.Option) (client.ParsedResponses, error)
-	CallEchoWithRetryOrFail(t test.Failer, options echo.CallOptions, retryOptions ...retry.Option) client.ParsedResponses
+	// Call makes a call through ingress using the echo call and response types.
+	Call(options echo.CallOptions) (client.ParsedResponses, error)
+	CallOrFail(t test.Failer, options echo.CallOptions) client.ParsedResponses
+	CallWithRetry(options echo.CallOptions, retryOptions ...retry.Option) (client.ParsedResponses, error)
+	CallWithRetryOrFail(t test.Failer, options echo.CallOptions, retryOptions ...retry.Option) client.ParsedResponses
 
 	// ProxyStats returns proxy stats, or error if failure happens.
 	ProxyStats() (map[string]int, error)

--- a/pkg/test/framework/components/istio/istio.go
+++ b/pkg/test/framework/components/istio/istio.go
@@ -30,6 +30,8 @@ import (
 type Instance interface {
 	resource.Resource
 
+	// Ingresses returns all ingresses for "istio-ingressgateay" in each cluster.
+	Ingresses() ingress.Instances
 	// IngressFor returns an ingress used for reaching workloads in the given cluster.
 	// The ingress's service name will be "istio-ingressgateway" and the istio label will be "ingressgateway".
 	IngressFor(cluster cluster.Cluster) ingress.Instance

--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -134,8 +134,6 @@ type istioctlConfigFiles struct {
 }
 
 func (i *operatorComponent) Ingresses() ingress.Instances {
-	i.mu.Lock()
-	defer i.mu.Unlock()
 	var out ingress.Instances
 	for _, c := range i.ctx.Clusters() {
 		// call IngressFor in-case initialization is needed.

--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -133,6 +133,17 @@ type istioctlConfigFiles struct {
 	remoteOperatorSpec *opAPI.IstioOperatorSpec
 }
 
+func (i *operatorComponent) Ingresses() ingress.Instances {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	var out ingress.Instances
+	for _, c := range i.ctx.Clusters() {
+		// call IngressFor in-case initialization is needed.
+		out = append(out, i.IngressFor(c))
+	}
+	return out
+}
+
 func (i *operatorComponent) IngressFor(cluster cluster.Cluster) ingress.Instance {
 	return i.CustomIngressFor(cluster, defaultIngressServiceName, defaultIngressIstioLabel)
 }

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -628,12 +628,12 @@ func trafficLoopCases(apps *EchoDeployments) []TrafficTestCase {
 
 func gatewayCases() []TrafficTestCase {
 	templateParams := func(protocol protocol.Instance, dests echo.Services) map[string]interface{} {
-		dest, portN, cred := dests[0][0], 80, ""
+		host, dest, portN, cred := "*", dests[0][0], 80, ""
 		if protocol.IsTLS() {
-			portN, cred = 443, "cred"
+			host, portN, cred = dest.Config().FQDN(), 443, "cred"
 		}
 		return map[string]interface{}{
-			"GatewayHost":        "*",
+			"GatewayHost":        host,
 			"GatewayPort":        portN,
 			"GatewayPortName":    strings.ToLower(string(protocol)),
 			"GatewayProtocol":    string(protocol),
@@ -826,7 +826,8 @@ spec:
 								})
 							})),
 				},
-				targetFilters: singleTarget,
+				targetFilters:    singleTarget,
+				workloadAgnostic: true,
 			},
 		)
 	}

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -48,8 +48,13 @@ spec:
   hosts:
   - {{.VirtualServiceHost}}
   http:
+  - route:
+    - destination:
+        host: {{.VirtualServiceHost}}
+        port:
+          number: {{.Port}}
 {{- if .MatchScheme }}
-  - match:
+    match:
     - scheme:
         exact: {{.MatchScheme}}
     headers:
@@ -57,11 +62,6 @@ spec:
         add:
           istio-custom-header: user-defined-value
 {{- end }}
-  - route:
-    - destination:
-        host: {{.VirtualServiceHost}}
-        port:
-          number: {{.Port}}
 ---
 `
 

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -783,7 +783,7 @@ spec:
 	}
 
 	for _, proto := range []protocol.Instance{protocol.HTTP, protocol.HTTPS} {
-		secret := ""
+		proto, secret := proto, ""
 		if proto.IsTLS() {
 			secret = ingressutil.IngressKubeSecretYAML("cred", "{{.IngressNamespace}}", ingressutil.TLS, ingressutil.IngressCredentialA)
 		}

--- a/tests/integration/pilot/common/traffic.go
+++ b/tests/integration/pilot/common/traffic.go
@@ -19,13 +19,12 @@ import (
 	"fmt"
 	"time"
 
-	"istio.io/istio/pkg/test/framework/components/istio/ingress"
-
 	"istio.io/istio/pkg/test"
 	echoclient "istio.io/istio/pkg/test/echo/client"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/echo/echotest"
+	"istio.io/istio/pkg/test/framework/components/istio/ingress"
 	"istio.io/istio/pkg/test/util/retry"
 	"istio.io/istio/pkg/test/util/tmpl"
 	"istio.io/istio/pkg/test/util/yml"

--- a/tests/integration/pilot/ingress_test.go
+++ b/tests/integration/pilot/ingress_test.go
@@ -129,7 +129,7 @@ spec:
 `)
 
 			t.NewSubTest("http").Run(func(t framework.TestContext) {
-				_ = apps.Ingress.CallEchoWithRetryOrFail(t, echo.CallOptions{
+				_ = apps.Ingress.CallWithRetryOrFail(t, echo.CallOptions{
 					Port: &echo.Port{
 						Protocol: protocol.HTTP,
 					},
@@ -142,7 +142,7 @@ spec:
 			})
 			t.NewSubTest("tcp").Run(func(t framework.TestContext) {
 				host, port := apps.Ingress.TCPAddress()
-				_ = apps.Ingress.CallEchoWithRetryOrFail(t, echo.CallOptions{
+				_ = apps.Ingress.CallWithRetryOrFail(t, echo.CallOptions{
 					Port: &echo.Port{
 						Protocol:    protocol.HTTP,
 						ServicePort: port,
@@ -311,7 +311,7 @@ spec:
 			for _, c := range cases {
 				c := c
 				t.NewSubTest(c.name).Run(func(t framework.TestContext) {
-					apps.Ingress.CallEchoWithRetryOrFail(t, c.call, retry.Timeout(time.Minute*2))
+					apps.Ingress.CallWithRetryOrFail(t, c.call, retry.Timeout(time.Minute*2))
 				})
 			}
 
@@ -407,7 +407,7 @@ spec:
 				updatedIngress := fmt.Sprintf(ingressConfigTemplate, updateIngressName, c.ingressClass, c.path, c.path)
 				t.Config().ApplyYAMLOrFail(t, apps.Namespace.Name(), updatedIngress)
 				t.NewSubTest(c.name).Run(func(t framework.TestContext) {
-					apps.Ingress.CallEchoWithRetryOrFail(t, c.call, retry.Timeout(time.Minute))
+					apps.Ingress.CallWithRetryOrFail(t, c.call, retry.Timeout(time.Minute))
 				})
 			}
 		})

--- a/tests/integration/security/jwt_test.go
+++ b/tests/integration/security/jwt_test.go
@@ -296,7 +296,7 @@ func TestRequestAuthentication(t *testing.T) {
 						t.Skip()
 					}
 					echotest.New(t, apps.All).
-						SetupForPair(func(t framework.TestContext, src, dst echo.Instances) error {
+						SetupForDestination(func(t framework.TestContext, dst echo.Instances) error {
 							if c.Config != "" {
 								policy := yml.MustApplyNamespace(t, tmpl.MustEvaluate(
 									file.AsStringOrFail(t, fmt.Sprintf("testdata/requestauthn/%s.yaml.tmpl", c.Config)),
@@ -402,7 +402,7 @@ func TestIngressRequestAuthentication(t *testing.T) {
 				}
 				for _, c := range testCases {
 					echotest.New(t, apps.All).
-						SetupForPair(func(t framework.TestContext, src, dst echo.Instances) error {
+						SetupForDestination(func(t framework.TestContext, dst echo.Instances) error {
 							policy := yml.MustApplyNamespace(t, tmpl.MustEvaluate(
 								file.AsStringOrFail(t, "testdata/requestauthn/ingress.yaml.tmpl"),
 								map[string]string{

--- a/tests/integration/security/pass_through_filter_chain_test.go
+++ b/tests/integration/security/pass_through_filter_chain_test.go
@@ -549,7 +549,7 @@ spec:
 			}}
 			for _, tc := range cases {
 				echotest.New(t, apps.All).
-					SetupForPair(func(t framework.TestContext, src, dst echo.Instances) error {
+					SetupForDestination(func(t framework.TestContext, dst echo.Instances) error {
 						cfg := yml.MustApplyNamespace(t, tmpl.MustEvaluate(
 							tc.config,
 							map[string]string{

--- a/tests/integration/security/sds_ingress/util/util.go
+++ b/tests/integration/security/sds_ingress/util/util.go
@@ -286,7 +286,7 @@ func SendRequestOrFail(ctx framework.TestContext, ing ingress.Instance, host str
 	}
 
 	// Certs occasionally take quite a while to become active in Envoy, so retry for a long time (2min)
-	ing.CallEchoWithRetryOrFail(ctx, opts, retry.Timeout(time.Minute*2))
+	ing.CallWithRetryOrFail(ctx, opts, retry.Timeout(time.Minute*2))
 }
 
 // RotateSecrets deletes kubernetes secrets by name in credNames and creates same secrets using key/cert

--- a/tests/integration/security/sds_tls_origination/egress_gateway_origination_test.go
+++ b/tests/integration/security/sds_tls_origination/egress_gateway_origination_test.go
@@ -88,7 +88,7 @@ func TestSimpleTlsOrigination(t *testing.T) {
 
 			for name, tc := range testCases {
 				echotest.New(t, apps.All).
-					SetupForPair(func(t framework.TestContext, src, dst echo.Instances) error {
+					SetupForDestination(func(t framework.TestContext, dst echo.Instances) error {
 						bufDestinationRule := sdstlsutil.CreateDestinationRule(t, apps.ServerNamespace, "SIMPLE", tc.CredentialToUse)
 
 						// Get namespace for gateway pod.
@@ -231,7 +231,7 @@ func TestMutualTlsOrigination(t *testing.T) {
 
 			for name, tc := range testCases {
 				echotest.New(t, apps.All).
-					SetupForPair(func(t framework.TestContext, src, dst echo.Instances) error {
+					SetupForDestination(func(t framework.TestContext, dst echo.Instances) error {
 						bufDestinationRule := sdstlsutil.CreateDestinationRule(t, apps.ServerNamespace, "MUTUAL", tc.CredentialToUse)
 
 						// Get namespace for gateway pod.

--- a/tests/integration/security/util/authn/authn_util.go
+++ b/tests/integration/security/util/authn/authn_util.go
@@ -99,5 +99,5 @@ func CheckIngressOrFail(ctx framework.TestContext, ingr ingress.Instance, host s
 			fmt.Sprintf("Bearer %s", token),
 		}
 	}
-	ingr.CallEchoWithRetryOrFail(ctx, opts)
+	ingr.CallWithRetryOrFail(ctx, opts)
 }

--- a/tests/integration/security/util/rbac_util/util.go
+++ b/tests/integration/security/util/rbac_util/util.go
@@ -33,10 +33,6 @@ type TestCase struct {
 	ExpectAllowed bool
 	Jwt           string
 	Headers       map[string]string
-	// Indicates whether a test should be run in the multicluster environment.
-	// This is a temporary flag during the converting tests into multicluster supported.
-	// TODO: Remove this flag when all tests support multicluster
-	SkippedForMulticluster bool
 }
 
 func getError(req connection.Checker, expect, actual string) error {

--- a/tests/integration/telemetry/stats/prometheus/nullvm/dashboard_test.go
+++ b/tests/integration/telemetry/stats/prometheus/nullvm/dashboard_test.go
@@ -301,7 +301,7 @@ func setupDashboardTest(done <-chan struct{}) {
 			scopes.Framework.Infof("sending traffic %v", times)
 			for _, ing := range common.GetIngressInstance() {
 				host, port := ing.TCPAddress()
-				_, err := ing.CallEcho(echo.CallOptions{
+				_, err := ing.Call(echo.CallOptions{
 					Port: &echo.Port{
 						Protocol: protocol.HTTP,
 					},
@@ -316,7 +316,7 @@ func setupDashboardTest(done <-chan struct{}) {
 					// These calls are not under tests, the dashboards are, so we can be leniant here
 					log.Warnf("requests failed: %v", err)
 				}
-				_, err = ing.CallEcho(echo.CallOptions{
+				_, err = ing.Call(echo.CallOptions{
 					Port: &echo.Port{
 						Protocol:    protocol.TCP,
 						ServicePort: port,


### PR DESCRIPTION
* add util to echotest to run from Ingress to each configured destination
* convert gatewayCases
  * one test actually hits all destinations
  * one test only hits one destination (pod a, no need to hit VMs)
  * others do not care about workloads
* DRY up some of the logic for TrafficTestCase