### PR TITLE
echotest: include namespace in subtest when service exists in multiple

### DIFF
--- a/pkg/test/framework/components/cluster/staticvm/namespace.go
+++ b/pkg/test/framework/components/cluster/staticvm/namespace.go
@@ -25,6 +25,10 @@ func (f fakeNamespace) Name() string {
 	return string(f)
 }
 
+func (f fakeNamespace) Prefix() string {
+	return string(f)
+}
+
 func (f fakeNamespace) SetLabel(key, value string) error {
 	panic("cannot interact with fake namespace, should not be exposed outside of staticvm")
 }

--- a/pkg/test/framework/components/echo/echotest/fake.go
+++ b/pkg/test/framework/components/echo/echotest/fake.go
@@ -86,6 +86,10 @@ func (f fakeNamespace) Name() string {
 	return string(f)
 }
 
+func (f fakeNamespace) Prefix() string {
+	return string(f)
+}
+
 func (f fakeNamespace) SetLabel(key, value string) error {
 	panic("cannot interact with fake namespace, should not be exposed outside of staticvm")
 }

--- a/pkg/test/framework/components/echo/echotest/run.go
+++ b/pkg/test/framework/components/echo/echotest/run.go
@@ -104,7 +104,7 @@ func (t *T) fromEachDeployment(ctx framework.TestContext, testFn perDeploymentTe
 		src := src
 		subtestName := src[0].Config().Service
 		if duplicateShortnames {
-			subtestName = src[0].Config().FQDN()
+			subtestName += "." + src[0].Config().Namespace.Prefix()
 		}
 		ctx.NewSubTest(subtestName).Run(func(ctx framework.TestContext) {
 			testFn(ctx, src)

--- a/pkg/test/framework/components/namespace/kube.go
+++ b/pkg/test/framework/components/namespace/kube.go
@@ -42,9 +42,10 @@ var (
 
 // kubeNamespace represents a Kubernetes namespace. It is tracked as a resource.
 type kubeNamespace struct {
-	id   resource.ID
-	name string
-	ctx  resource.Context
+	id     resource.ID
+	name   string
+	prefix string
+	ctx    resource.Context
 }
 
 func (n *kubeNamespace) Dump(ctx resource.Context) {
@@ -68,6 +69,10 @@ var (
 
 func (n *kubeNamespace) Name() string {
 	return n.name
+}
+
+func (n *kubeNamespace) Prefix() string {
+	return n.prefix
 }
 
 func (n *kubeNamespace) SetLabel(key, value string) error {
@@ -111,7 +116,7 @@ func claimKube(ctx resource.Context, nsConfig *Config) (Instance, error) {
 			}
 		}
 	}
-	return &kubeNamespace{name: nsConfig.Prefix}, nil
+	return &kubeNamespace{prefix: nsConfig.Prefix, name: nsConfig.Prefix}, nil
 }
 
 // setNamespaceLabel labels a namespace with the given key, value pair
@@ -152,8 +157,9 @@ func newKube(ctx resource.Context, nsConfig *Config) (Instance, error) {
 
 	ns := fmt.Sprintf("%s-%d-%d", nsConfig.Prefix, nsid, r)
 	n := &kubeNamespace{
-		name: ns,
-		ctx:  ctx,
+		name:   ns,
+		prefix: nsConfig.Prefix,
+		ctx:    ctx,
 	}
 	id := ctx.TrackResource(n)
 	n.id = id

--- a/pkg/test/framework/components/namespace/namespace.go
+++ b/pkg/test/framework/components/namespace/namespace.go
@@ -36,6 +36,7 @@ type Instance interface {
 	Name() string
 	SetLabel(key, value string) error
 	RemoveLabel(key string) error
+	Prefix() string
 }
 
 // Claim an existing namespace in all clusters, or create a new one if doesn't exist.

--- a/tests/integration/security/authorization_test.go
+++ b/tests/integration/security/authorization_test.go
@@ -56,6 +56,10 @@ func (i rootNS) Name() string {
 	return i.rootNamespace
 }
 
+func (i rootNS) Prefix() string {
+	return i.rootNamespace
+}
+
 func (i rootNS) SetLabel(key, value string) error {
 	return nil
 }


### PR DESCRIPTION
The security tests deal with multiple namespaces often. The tests look like duplicates, but should be listed distinctly. 