### PR TITLE
Do not panic on invalid Gateway config

### DIFF
--- a/pilot/pkg/model/gateway.go
+++ b/pilot/pkg/model/gateway.go
@@ -114,6 +114,12 @@ func MergeGateways(gateways ...config.Config) *MergedGateway {
 					snames.Insert(s.Name)
 				}
 			}
+			if s.Port == nil {
+				// Should be rejected in validation, this is an extra check
+				log.Debugf("invalid server without port: %q", gatewayName)
+				RecordRejectedConfig(gatewayName)
+				continue
+			}
 			sanitizeServerHostNamespace(s, gatewayConfig.Namespace)
 			gatewayNameForServer[s] = gatewayName
 			log.Debugf("MergeGateways: gateway %q processing server %s :%v", gatewayName, s.Name, s.Hosts)


### PR DESCRIPTION
Saw a user fail to validate, we should not panic but ignore the config.
