### PR TITLE
test framework: support hostname loadbalancer in ingress

### DIFF
--- a/pkg/test/framework/components/istio/ingress.go
+++ b/pkg/test/framework/components/istio/ingress.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"strconv"
 	"time"
 
 	"istio.io/istio/pkg/config/protocol"
@@ -93,7 +94,7 @@ type ingressImpl struct {
 
 // getAddressInner returns the external address for the given port. When we don't have support for LoadBalancer,
 // the returned net.Addr will have the externally reachable NodePort address and port.
-func (c *ingressImpl) getAddressInner(port int) (net.TCPAddr, error) {
+func (c *ingressImpl) getAddressInner(port int) (string, int, error) {
 	attempts := 0
 	addr, err := retry.Do(func() (result interface{}, completed bool, err error) {
 		attempts++
@@ -105,40 +106,62 @@ func (c *ingressImpl) getAddressInner(port int) (net.TCPAddr, error) {
 		}
 		return
 	}, getAddressTimeout, getAddressDelay)
-	if addr != nil {
-		return addr.(net.TCPAddr), err
+	if err != nil {
+		return "", 0, err
 	}
-	return net.TCPAddr{}, err
+
+	switch v := addr.(type) {
+	case string:
+		host, portStr, err := net.SplitHostPort(v)
+		if err != nil {
+			return "", 0, err
+		}
+		mappedPort, err := strconv.Atoi(portStr)
+		if err != nil {
+			return "", 0, err
+		}
+		return host, mappedPort, nil
+	case net.TCPAddr:
+		return v.IP.String(), v.Port, nil
+	}
+
+	return "", 0, fmt.Errorf("failed to get address for port %v", port)
 }
 
-// AddressForPort returns the externally reachable address of the component for the given port.
-func (c *ingressImpl) AddressForPort(port int) net.TCPAddr {
-	address, err := c.getAddressInner(port)
+// AddressForPort returns the externally reachable host and port of the component for the given port.
+func (c *ingressImpl) AddressForPort(port int) (string, int) {
+	host, port, err := c.getAddressInner(port)
 	if err != nil {
 		scopes.Framework.Error(err)
-		return net.TCPAddr{}
+		return "", 0
 	}
-	return address
+	return host, port
 }
 
-// HTTPAddress returns the externally reachable HTTP address (80) of the component.
-func (c *ingressImpl) HTTPAddress() net.TCPAddr {
+// HTTPAddress returns the externally reachable HTTP host and port (80) of the component.
+func (c *ingressImpl) HTTPAddress() (string, int) {
 	return c.AddressForPort(80)
 }
 
-// TCPAddress returns the externally reachable TCP address (31400) of the component.
-func (c *ingressImpl) TCPAddress() net.TCPAddr {
+// TCPAddress returns the externally reachable TCP host and port (31400) of the component.
+func (c *ingressImpl) TCPAddress() (string, int) {
 	return c.AddressForPort(31400)
 }
 
-// HTTPSAddress returns the externally reachable TCP address (443) of the component.
-func (c *ingressImpl) HTTPSAddress() net.TCPAddr {
+// HTTPSAddress returns the externally reachable TCP host and port (443) of the component.
+func (c *ingressImpl) HTTPSAddress() (string, int) {
 	return c.AddressForPort(443)
 }
 
 // DiscoveryAddress returns the externally reachable discovery address (15012) of the component.
 func (c *ingressImpl) DiscoveryAddress() net.TCPAddr {
-	return c.AddressForPort(discoveryPort)
+	host, port := c.AddressForPort(discoveryPort)
+	ip := net.ParseIP(host)
+	if ip.String() == "<nil>" {
+		// TODO support hostname based discovery address
+		return net.TCPAddr{}
+	}
+	return net.TCPAddr{IP: ip, Port: port}
 }
 
 func (c *ingressImpl) CallEcho(options echo.CallOptions) (client.ParsedResponses, error) {
@@ -173,27 +196,35 @@ func (c *ingressImpl) callEcho(options echo.CallOptions, retry bool, retryOption
 	if options.Port == nil || options.Port.Protocol == "" {
 		return nil, fmt.Errorf("must provide protocol")
 	}
-	var addr net.TCPAddr
+	var (
+		addr string
+		port int
+	)
 	if options.Port.ServicePort == 0 {
 		// Default port based on protocol
 		switch options.Port.Protocol {
 		case protocol.HTTP:
-			addr = c.HTTPAddress()
+			addr, port = c.HTTPAddress()
 		case protocol.HTTPS:
-			addr = c.HTTPSAddress()
+			addr, port = c.HTTPSAddress()
 		case protocol.TCP:
-			addr = c.TCPAddress()
+			addr, port = c.TCPAddress()
 		default:
 			return nil, fmt.Errorf("protocol %v not supported, provide explicit port", options.Port.Protocol)
 		}
 	} else {
-		addr = c.AddressForPort(options.Port.ServicePort)
+		addr, port = c.AddressForPort(options.Port.ServicePort)
 	}
+
+	if addr == "" || port == 0 {
+		scopes.Framework.Warnf("failed to get host and port for %s/%d", options.Port.Protocol, options.Port.ServicePort)
+	}
+
 	// Even if they set ServicePort, when load balancer is disabled, we may need to switch to NodePort, so replace it.
-	options.Port.ServicePort = addr.Port
+	options.Port.ServicePort = port
 	if len(options.Address) == 0 {
 		// Default address based on port
-		options.Address = addr.IP.String()
+		options.Address = addr
 	}
 	if options.Headers == nil {
 		options.Headers = map[string][]string{}

--- a/pkg/test/framework/components/istio/ingress/interface.go
+++ b/pkg/test/framework/components/istio/ingress/interface.go
@@ -27,19 +27,19 @@ import (
 type Instance interface {
 	// HTTPAddress returns the external HTTP (80) address of the ingress gateway ((or the NodePort address,
 	//	// when in an environment that doesn't support LoadBalancer).
-	HTTPAddress() net.TCPAddr
+	HTTPAddress() (string, int)
 	// HTTPSAddress returns the external HTTPS (443) address of the ingress gateway (or the NodePort address,
 	//	// when in an environment that doesn't support LoadBalancer).
-	HTTPSAddress() net.TCPAddr
+	HTTPSAddress() (string, int)
 	// TCPAddress returns the external TCP (31400) address of the ingress gateway (or the NodePort address,
 	// when in an environment that doesn't support LoadBalancer).
-	TCPAddress() net.TCPAddr
+	TCPAddress() (string, int)
 	// DiscoveryAddress returns the external XDS (!5012) address on the ingress gateway (or the NodePort address,
 	// when in an evnironment that doesn't support LoadBalancer).
 	DiscoveryAddress() net.TCPAddr
 	// AddressForPort returns the external address of the ingress gateway (or the NodePort address,
 	// when in an environment that doesn't support LoadBalancer) for the given port.
-	AddressForPort(port int) net.TCPAddr
+	AddressForPort(port int) (string, int)
 	// CallEcho makes a call through ingress using the echo call and response types.
 	CallEcho(options echo.CallOptions) (client.ParsedResponses, error)
 	CallEchoOrFail(t test.Failer, options echo.CallOptions) client.ParsedResponses

--- a/pkg/test/framework/components/istio/util.go
+++ b/pkg/test/framework/components/istio/util.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"strconv"
 	"time"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -149,12 +150,17 @@ func getRemoteServiceAddress(s *kube.Settings, cluster cluster.Cluster, ns, labe
 		return nil, false, err
 	}
 
-	if len(svc.Status.LoadBalancer.Ingress) == 0 || svc.Status.LoadBalancer.Ingress[0].IP == "" {
-		return nil, false, fmt.Errorf("service %s is not available yet: %s/%s", svcName, svc.Namespace, svc.Name)
+	if len(svc.Status.LoadBalancer.Ingress) == 0 {
+		return nil, false, fmt.Errorf("service %s/%s is not available yet: no ingress", svc.Namespace, svc.Name)
 	}
-
-	ip := svc.Status.LoadBalancer.Ingress[0].IP
-	return net.TCPAddr{IP: net.ParseIP(ip), Port: port}, true, nil
+	ingr := svc.Status.LoadBalancer.Ingress[0]
+	if ingr.IP == "" && ingr.Hostname == "" {
+		return nil, false, fmt.Errorf("service %s/%s is not available yet: no ingress", svc.Namespace, svc.Name)
+	}
+	if ingr.IP != "" {
+		return net.TCPAddr{IP: net.ParseIP(ingr.IP), Port: port}, true, nil
+	}
+	return net.JoinHostPort(ingr.Hostname, strconv.Itoa(port)), true, nil
 }
 
 func (i *operatorComponent) isExternalControlPlane() bool {

--- a/pkg/test/framework/components/opentelemetry/kube.go
+++ b/pkg/test/framework/components/opentelemetry/kube.go
@@ -17,6 +17,7 @@ package opentelemetry
 import (
 	"fmt"
 	"io/ioutil"
+	"net"
 	"strings"
 
 	"istio.io/istio/pkg/test/env"
@@ -167,7 +168,12 @@ func newCollector(ctx resource.Context, c Config) (*otel, error) {
 		return nil, err
 	}
 
-	ingressDomain := fmt.Sprintf("%s.nip.io", c.IngressAddr.IP.String())
+	isIP := net.ParseIP(c.IngressAddr).String() != "<nil>"
+	ingressDomain := c.IngressAddr
+	if isIP {
+		ingressDomain = fmt.Sprintf("%s.nip.io", c.IngressAddr)
+	}
+
 	err = installServiceEntry(ctx, istioCfg.TelemetryNamespace, ingressDomain)
 	if err != nil {
 		return nil, err

--- a/pkg/test/framework/components/opentelemetry/opentelemetry-collector.go
+++ b/pkg/test/framework/components/opentelemetry/opentelemetry-collector.go
@@ -15,7 +15,6 @@
 package opentelemetry
 
 import (
-	"net"
 	"testing"
 
 	"istio.io/istio/pkg/test/framework/components/cluster"
@@ -29,7 +28,7 @@ type Config struct {
 	Cluster cluster.Cluster
 
 	// HTTP Address of ingress gateway of the cluster to be used to install open telemetry collector in.
-	IngressAddr net.TCPAddr
+	IngressAddr string
 }
 
 // Instance represents a opencensus collector deployment on kubernetes.

--- a/pkg/test/framework/components/zipkin/kube.go
+++ b/pkg/test/framework/components/zipkin/kube.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"path/filepath"
 	"sort"
@@ -212,7 +213,12 @@ func newKube(ctx resource.Context, cfgIn Config) (Instance, error) {
 	c.forwarder = forwarder
 	scopes.Framework.Debugf("initialized zipkin port forwarder: %v", forwarder.Address())
 
-	ingressDomain := fmt.Sprintf("%s.nip.io", cfgIn.IngressAddr.IP.String())
+	isIP := net.ParseIP(cfgIn.IngressAddr).String() != "<nil>"
+	ingressDomain := cfgIn.IngressAddr
+	if isIP {
+		ingressDomain = fmt.Sprintf("%s.nip.io", cfgIn.IngressAddr)
+	}
+
 	c.address = fmt.Sprintf("http://tracing.%s", ingressDomain)
 	scopes.Framework.Debugf("Zipkin address: %s ", c.address)
 	err = installServiceEntry(ctx, cfg.TelemetryNamespace, ingressDomain)

--- a/pkg/test/framework/components/zipkin/zipkin.go
+++ b/pkg/test/framework/components/zipkin/zipkin.go
@@ -15,7 +15,6 @@
 package zipkin
 
 import (
-	"net"
 	"testing"
 
 	"istio.io/istio/pkg/test/framework/components/cluster"
@@ -36,7 +35,7 @@ type Config struct {
 	Cluster cluster.Cluster
 
 	// HTTP Address of ingress gateway of the cluster to be used to install zipkin in.
-	IngressAddr net.TCPAddr
+	IngressAddr string
 }
 
 // Span represents a single span, which includes span attributes for verification

--- a/tests/integration/telemetry/stats/prometheus/nullvm/dashboard_test.go
+++ b/tests/integration/telemetry/stats/prometheus/nullvm/dashboard_test.go
@@ -300,7 +300,7 @@ func setupDashboardTest(done <-chan struct{}) {
 			times++
 			scopes.Framework.Infof("sending traffic %v", times)
 			for _, ing := range common.GetIngressInstance() {
-				tcpAddr := ing.TCPAddress()
+				host, port := ing.TCPAddress()
 				_, err := ing.CallEcho(echo.CallOptions{
 					Port: &echo.Port{
 						Protocol: protocol.HTTP,
@@ -319,9 +319,9 @@ func setupDashboardTest(done <-chan struct{}) {
 				_, err = ing.CallEcho(echo.CallOptions{
 					Port: &echo.Port{
 						Protocol:    protocol.TCP,
-						ServicePort: tcpAddr.Port,
+						ServicePort: port,
 					},
-					Address: tcpAddr.IP.String(),
+					Address: host,
 					Path:    fmt.Sprintf("/echo-%s", common.GetAppNamespace().Name()),
 					Headers: map[string][]string{
 						"Host": {"server"},

--- a/tests/integration/telemetry/tracing/opencensusagent/tracing_test.go
+++ b/tests/integration/telemetry/tracing/opencensusagent/tracing_test.go
@@ -92,6 +92,7 @@ meshConfig:
 }
 
 func testSetup(ctx resource.Context) (err error) {
-	_, err = opentelemetry.New(ctx, opentelemetry.Config{IngressAddr: tracing.GetIngressInstance().HTTPAddress()})
+	addr, _ := tracing.GetIngressInstance().HTTPAddress()
+	_, err = opentelemetry.New(ctx, opentelemetry.Config{IngressAddr: addr})
 	return
 }

--- a/tests/integration/telemetry/tracing/tracing.go
+++ b/tests/integration/telemetry/tracing/tracing.go
@@ -106,7 +106,8 @@ func TestSetup(ctx resource.Context) (err error) {
 	client = echos.Match(echo.ServicePrefix("client"))
 	server = echos.Match(echo.Service("server"))
 	ingInst = ist.IngressFor(ctx.Clusters().Default())
-	zipkinInst, err = zipkin.New(ctx, zipkin.Config{Cluster: ctx.Clusters().Default(), IngressAddr: ingInst.HTTPAddress()})
+	addr, _ := ingInst.HTTPAddress()
+	zipkinInst, err = zipkin.New(ctx, zipkin.Config{Cluster: ctx.Clusters().Default(), IngressAddr: addr})
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
In environments such as AWS, `LoadBalancer` may be supported, but never set `LoadBalancer[0].IP` – instead it sets `Hostname`. 

Our framework should be robust to handle testing in such environments. 

We will also want to handle this for multicluster, this PR isn't concerned with that for now. 