### PR TITLE
Switch XDS proxy tap to port 15004

### DIFF
--- a/pkg/istio-agent/agent.go
+++ b/pkg/istio-agent/agent.go
@@ -101,7 +101,7 @@ type AgentOptions struct {
 	// ferry Envoy's XDS requests to istiod and responses back to envoy
 	// This flag is temporary until the feature is stabilized.
 	ProxyXDSViaAgent bool
-	// ProxyXDSDebugViaAgent if true will listen on 15009 and forward queries
+	// ProxyXDSDebugViaAgent if true will listen on 15004 and forward queries
 	// to XDS istio.io/debug. (Requires ProxyXDSViaAgent).
 	ProxyXDSDebugViaAgent bool
 	// DNSCapture indicates if the XDS proxy has dns capture enabled or not

--- a/pkg/istio-agent/xds_proxy.go
+++ b/pkg/istio-agent/xds_proxy.go
@@ -826,7 +826,7 @@ func (p *XdsProxy) makeTapHandler() func(w http.ResponseWriter, req *http.Reques
 	}
 }
 
-// initDebugInterface() listens on localhost:15009 for path /debug/...
+// initDebugInterface() listens on localhost:15004 for path /debug/...
 // forwards the paths to Istiod as xDS requests
 // waits for response from Istiod, sends it as JSON
 func (p *XdsProxy) initDebugInterface() error {
@@ -838,7 +838,7 @@ func (p *XdsProxy) initDebugInterface() error {
 	httpMux.HandleFunc("/debug", handler) // For 1.10 Istiod which uses istio.io/debug
 
 	p.httpTapServer = &http.Server{
-		Addr:    "localhost:15009",
+		Addr:    "localhost:15004",
 		Handler: httpMux,
 	}
 

--- a/tests/integration/pilot/piggyback_test.go
+++ b/tests/integration/pilot/piggyback_test.go
@@ -32,7 +32,7 @@ func TestPiggyback(t *testing.T) {
 		RequiresSingleCluster().
 		Run(func(t framework.TestContext) {
 			execCmd := fmt.Sprintf(
-				"kubectl -n %s exec %s -c istio-proxy -- curl localhost:15009/debug/syncz",
+				"kubectl -n %s exec %s -c istio-proxy -- curl localhost:15004/debug/syncz",
 				apps.PodA[0].Config().Namespace.Name(),
 				apps.PodA[0].WorkloadsOrFail(t)[0].PodName())
 			out, err := shell.Execute(false, execCmd)


### PR DESCRIPTION
There are already some usages of port 15009 (for BTS) that may lead to conflict. Switching now to be safe since it hasn't shipped yet



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.