### PR TITLE
Fix helm integration test that uses first-party-jwt

### DIFF
--- a/pkg/test/helm/helm.go
+++ b/pkg/test/helm/helm.go
@@ -38,7 +38,7 @@ func New(kubeConfig, baseWorkDir string) *Helm {
 	}
 }
 
-// InstallChart installs the specified chart with its given name to the given namespace
+// InstallChartWithValues installs the specified chart with its given name to the given namespace
 func (h *Helm) InstallChartWithValues(name, relpath, namespace string, values []string, timeout time.Duration) error {
 	p := filepath.Join(h.baseDir, relpath)
 

--- a/tests/integration/helm/install_test.go
+++ b/tests/integration/helm/install_test.go
@@ -18,7 +18,6 @@ package helm
 import (
 	"fmt"
 	"io/ioutil"
-	"istio.io/istio/tests/util/sanitycheck"
 	"os"
 	"path/filepath"
 	"testing"
@@ -27,6 +26,7 @@ import (
 	kubecluster "istio.io/istio/pkg/test/framework/components/cluster/kube"
 	"istio.io/istio/pkg/test/framework/image"
 	"istio.io/istio/pkg/test/helm"
+	"istio.io/istio/tests/util/sanitycheck"
 )
 
 // TestDefaultInstall tests Istio installation using Helm with default options

--- a/tests/integration/helm/install_test.go
+++ b/tests/integration/helm/install_test.go
@@ -18,6 +18,7 @@ package helm
 import (
 	"fmt"
 	"io/ioutil"
+	"istio.io/istio/tests/util/sanitycheck"
 	"os"
 	"path/filepath"
 	"testing"
@@ -43,6 +44,7 @@ global:
 
 // TestInstallWithFirstPartyJwt tests Istio installation using Helm
 // with first-party-jwt enabled
+// (TODO) remove this test when Istio no longer supports first-party-jwt
 func TestInstallWithFirstPartyJwt(t *testing.T) {
 	overrideValuesStr := `
 global:
@@ -79,12 +81,13 @@ func setupInstallation(overrideValuesStr string) func(t framework.TestContext) {
 		if err := ioutil.WriteFile(overrideValuesFile, []byte(overrideValues), os.ModePerm); err != nil {
 			t.Fatalf("failed to write iop cr file: %v", err)
 		}
-		InstallGatewaysCharts(t, cs, h, "", IstioNamespace, overrideValuesFile)
+		InstallIstio(t, cs, h, "", IstioNamespace, overrideValuesFile)
 
 		VerifyInstallation(t, cs)
 
+		sanitycheck.RunTrafficTest(t, t)
 		t.Cleanup(func() {
-			deleteGatewayCharts(t, h)
+			deleteIstio(t, h, cs)
 		})
 	}
 }

--- a/tests/integration/helm/install_test.go
+++ b/tests/integration/helm/install_test.go
@@ -81,7 +81,7 @@ func setupInstallation(overrideValuesStr string) func(t framework.TestContext) {
 		if err := ioutil.WriteFile(overrideValuesFile, []byte(overrideValues), os.ModePerm); err != nil {
 			t.Fatalf("failed to write iop cr file: %v", err)
 		}
-		InstallIstio(t, cs, h, "", IstioNamespace, overrideValuesFile)
+		InstallIstio(t, cs, h, "", overrideValuesFile)
 
 		VerifyInstallation(t, cs)
 

--- a/tests/integration/helm/main_test.go
+++ b/tests/integration/helm/main_test.go
@@ -19,17 +19,11 @@ import (
 	"testing"
 
 	"istio.io/istio/pkg/test/framework"
-	"istio.io/istio/pkg/test/framework/components/istio"
-	"istio.io/istio/pkg/test/framework/resource"
 )
 
 func TestMain(m *testing.M) {
-	var ist istio.Instance
 	framework.
 		NewSuite(m).
 		RequireSingleCluster().
-		Setup(istio.Setup(&ist, func(ctx resource.Context, cfg *istio.Config) {
-			cfg.DeployHelm = true
-		})).
 		Run()
 }

--- a/tests/integration/helm/upgrade/util.go
+++ b/tests/integration/helm/upgrade/util.go
@@ -137,7 +137,7 @@ func performUpgradeFunc(previousVersion string) func(framework.TestContext) {
 		})
 
 		overrideValuesFile := getValuesOverrides(t, defaultValues, gcrHub, previousVersion)
-		helmtest.InstallIstio(t, cs, h, "", helmtest.IstioNamespace, overrideValuesFile)
+		helmtest.InstallIstio(t, cs, h, "", overrideValuesFile)
 		helmtest.VerifyInstallation(t, cs)
 
 		oldClient, oldServer := sanitycheck.SetupTrafficTest(t, t)

--- a/tests/integration/helm/upgrade/util.go
+++ b/tests/integration/helm/upgrade/util.go
@@ -45,6 +45,7 @@ global:
   hub: %s
   tag: %s
 `
+	tarGzSuffix = ".tar.gz"
 )
 
 // previousChartPath is path of Helm charts for previous Istio deployments.
@@ -137,7 +138,7 @@ func performUpgradeFunc(previousVersion string) func(framework.TestContext) {
 		})
 
 		overrideValuesFile := getValuesOverrides(t, defaultValues, gcrHub, previousVersion)
-		helmtest.InstallIstio(t, cs, h, "", overrideValuesFile)
+		helmtest.InstallIstio(t, cs, h, tarGzSuffix, overrideValuesFile)
 		helmtest.VerifyInstallation(t, cs)
 
 		oldClient, oldServer := sanitycheck.SetupTrafficTest(t, t)

--- a/tests/integration/helm/upgrade/util.go
+++ b/tests/integration/helm/upgrade/util.go
@@ -140,7 +140,7 @@ func installIstio(t framework.TestContext, cs cluster.Cluster,
 		t.Errorf("failed to install istio %s chart", helmtest.DiscoveryChart)
 	}
 
-	helmtest.InstallGatewaysCharts(t, cs, h, helmtest.TarGzSuffix, helmtest.IstioNamespace, overrideValuesFile)
+	helmtest.InstallIstio(t, cs, h, helmtest.TarGzSuffix, helmtest.IstioNamespace, overrideValuesFile)
 }
 
 // performUpgradeFunc returns the provided function necessary to run inside of a integration test

--- a/tests/integration/helm/upgrade/util.go
+++ b/tests/integration/helm/upgrade/util.go
@@ -120,29 +120,6 @@ func getValuesOverrides(ctx framework.TestContext, valuesStr, hub, tag string) s
 	return overrideValuesFile
 }
 
-// installIstio install Istio using Helm charts with the provided
-// override values file and fails the tests on any failures.
-func installIstio(t framework.TestContext, cs cluster.Cluster,
-	h *helm.Helm, overrideValuesFile string) {
-	helmtest.CreateNamespace(t, cs, helmtest.IstioNamespace)
-
-	// Install base chart
-	err := h.InstallChart(helmtest.BaseReleaseName, helmtest.BaseChart+helmtest.TarGzSuffix,
-		helmtest.IstioNamespace, overrideValuesFile, helmtest.Timeout)
-	if err != nil {
-		t.Errorf("failed to install istio %s chart", helmtest.BaseChart)
-	}
-
-	// Install discovery chart
-	err = h.InstallChart(helmtest.IstiodReleaseName, filepath.Join(helmtest.ControlChartsDir, helmtest.DiscoveryChart)+helmtest.TarGzSuffix,
-		helmtest.IstioNamespace, overrideValuesFile, helmtest.Timeout)
-	if err != nil {
-		t.Errorf("failed to install istio %s chart", helmtest.DiscoveryChart)
-	}
-
-	helmtest.InstallIstio(t, cs, h, helmtest.TarGzSuffix, helmtest.IstioNamespace, overrideValuesFile)
-}
-
 // performUpgradeFunc returns the provided function necessary to run inside of a integration test
 // for upgrade capability
 func performUpgradeFunc(previousVersion string) func(framework.TestContext) {
@@ -160,7 +137,7 @@ func performUpgradeFunc(previousVersion string) func(framework.TestContext) {
 		})
 
 		overrideValuesFile := getValuesOverrides(t, defaultValues, gcrHub, previousVersion)
-		installIstio(t, cs, h, overrideValuesFile)
+		helmtest.InstallIstio(t, cs, h, "", helmtest.IstioNamespace, overrideValuesFile)
 		helmtest.VerifyInstallation(t, cs)
 
 		oldClient, oldServer := sanitycheck.SetupTrafficTest(t, t)

--- a/tests/integration/helm/util.go
+++ b/tests/integration/helm/util.go
@@ -18,7 +18,6 @@ package helm
 import (
 	"context"
 	"fmt"
-	"istio.io/istio/pkg/test/framework/components/cluster/kube"
 	"path/filepath"
 	"time"
 
@@ -30,6 +29,7 @@ import (
 	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/cluster"
+	"istio.io/istio/pkg/test/framework/components/cluster/kube"
 	"istio.io/istio/pkg/test/helm"
 	kubetest "istio.io/istio/pkg/test/kube"
 	"istio.io/istio/pkg/test/scopes"

--- a/tests/integration/helm/util.go
+++ b/tests/integration/helm/util.go
@@ -41,7 +41,6 @@ const (
 	IstioNamespace      = "istio-system"
 	ReleasePrefix       = "istio-"
 	BaseChart           = "base"
-	TarGzSuffix         = ".tar.gz"
 	DiscoveryChart      = "istio-discovery"
 	IngressGatewayChart = "istio-ingress"
 	EgressGatewayChart  = "istio-egress"
@@ -62,8 +61,8 @@ var ChartPath = filepath.Join(env.IstioSrc, "manifests/charts")
 // InstallIstio install Istio using Helm charts with the provided
 // override values file and fails the tests on any failures.
 func InstallIstio(t test.Failer, cs cluster.Cluster,
-	h *helm.Helm, suffix, namespace, overrideValuesFile string) {
-	CreateNamespace(t, cs, namespace)
+	h *helm.Helm, suffix, overrideValuesFile string) {
+	CreateNamespace(t, cs, IstioNamespace)
 
 	// Install base chart
 	err := h.InstallChart(BaseReleaseName, BaseChart,
@@ -81,14 +80,14 @@ func InstallIstio(t test.Failer, cs cluster.Cluster,
 
 	// Install ingress gateway chart
 	err = h.InstallChart(IngressReleaseName, filepath.Join(GatewayChartsDir, IngressGatewayChart)+suffix,
-		namespace, overrideValuesFile, Timeout)
+		IstioNamespace, overrideValuesFile, Timeout)
 	if err != nil {
 		t.Fatalf("failed to install istio %s chart", IngressGatewayChart)
 	}
 
 	// Install egress gateway chart
 	err = h.InstallChart(EgressReleaseName, filepath.Join(GatewayChartsDir, EgressGatewayChart)+suffix,
-		namespace, overrideValuesFile, Timeout)
+		IstioNamespace, overrideValuesFile, Timeout)
 	if err != nil {
 		t.Fatalf("failed to install istio %s chart", EgressGatewayChart)
 	}

--- a/tests/integration/helm/util.go
+++ b/tests/integration/helm/util.go
@@ -65,14 +65,14 @@ func InstallIstio(t test.Failer, cs cluster.Cluster,
 	CreateNamespace(t, cs, IstioNamespace)
 
 	// Install base chart
-	err := h.InstallChart(BaseReleaseName, BaseChart,
+	err := h.InstallChart(BaseReleaseName, BaseChart+suffix,
 		IstioNamespace, overrideValuesFile, Timeout)
 	if err != nil {
 		t.Fatalf("failed to install istio %s chart", BaseChart)
 	}
 
 	// Install discovery chart
-	err = h.InstallChart(IstiodReleaseName, filepath.Join(ControlChartsDir, DiscoveryChart),
+	err = h.InstallChart(IstiodReleaseName, filepath.Join(ControlChartsDir, DiscoveryChart)+suffix,
 		IstioNamespace, overrideValuesFile, Timeout)
 	if err != nil {
 		t.Fatalf("failed to install istio %s chart", DiscoveryChart)


### PR DESCRIPTION
Issue: Helm integration tests were always passing in `third-party-jwt` for
the `global.jwtPolicy` field. Fix the integration test to use
`first-party-jwt` when specified by not installing istio with helm in
main_test.go.

TODO: When first-party-jwt is no longer supported we should add back the
test to use the helm package inside of the test framework.


[ ] Configuration Infrastructure
[ ] Docs
[X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any changes that may affect Istio users.