### PR TITLE
dynamically set Lease Duration for operator

### DIFF
--- a/operator/cmd/operator/server.go
+++ b/operator/cmd/operator/server.go
@@ -106,22 +106,6 @@ func getRenewDeadline() *time.Duration {
 	return &duration
 }
 
-// getLeaseDuration returns the lease duration, duration for waiting to force acquire leadership.
-func getLeaseDuration() *time.Duration {
-	ddl, found := os.LookupEnv("LEASE_DURATION")
-	// default duration in controller-runtime package
-	df := time.Second * 15
-	if !found {
-		return &df
-	}
-	duration, err := time.ParseDuration(ddl)
-	if err != nil {
-		log.Errorf("failed to parse leaseDuration: %v, use default value", err)
-		return &df
-	}
-	return &duration
-}
-
 func run() {
 	watchNS, err := getWatchNamespace()
 	if err != nil {
@@ -133,9 +117,9 @@ func run() {
 		log.Warn("Leader election namespace not set. Leader election is disabled. NOT APPROPRIATE FOR PRODUCTION USE!")
 	}
 
-	// TODO renewDeadline cannot be greater than leaseDuration
+	// renewDeadline cannot be greater than leaseDuration
 	renewDeadline := getRenewDeadline()
-	leaseDuration := getLeaseDuration()
+	leaseDuration := time.Duration(renewDeadline.Nanoseconds() * 2)
 
 	// Get a config to talk to the apiserver
 	cfg, err := config.GetConfig()
@@ -158,7 +142,7 @@ func run() {
 			LeaderElection:          leaderElectionEnabled,
 			LeaderElectionNamespace: leaderElectionNS,
 			LeaderElectionID:        leaderElectionID,
-			LeaseDuration:           leaseDuration,
+			LeaseDuration:           &leaseDuration,
 			RenewDeadline:           renewDeadline,
 		}
 	} else {
@@ -169,7 +153,7 @@ func run() {
 			LeaderElection:          leaderElectionEnabled,
 			LeaderElectionNamespace: leaderElectionNS,
 			LeaderElectionID:        leaderElectionID,
-			LeaseDuration:           leaseDuration,
+			LeaseDuration:           &leaseDuration,
 			RenewDeadline:           renewDeadline,
 		}
 	}

--- a/releasenotes/notes/27509-lease-duration.yaml
+++ b/releasenotes/notes/27509-lease-duration.yaml
@@ -5,4 +5,4 @@ issue:
   - 27509
 releaseNotes:
   - |
-    **Fixed** allow custom configuration of LEASE_DURATION for istio operator manager.
+    **Fixed** ensure lease duration is always larger than the user configured `RENEW_DEADLINE` for Istio operator manager.

--- a/releasenotes/notes/27509-lease-duration.yaml
+++ b/releasenotes/notes/27509-lease-duration.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+issue:
+  - 27509
+releaseNotes:
+  - |
+    **Fixed** allow custom configuration of LEASE_DURATION for istio operator manager.


### PR DESCRIPTION

The RENEW_DEADLINE is configuable but the leaseDuration limits the renewDeadline.

If RENEW_DEADLINE is set to 30s, the following error occurs when the operator pod tries to start.

```
2021-04-09T18:45:44.565506Z	info	installer	Controller added
2021-04-09T18:45:44.565541Z	info	Starting the Cmd.
2021-04-09T18:45:44.565767Z	fatal	Manager exited non-zero: leaseDuration must be greater than renewDeadline
```

It seems like the leaseDuration defaults to 15s

resolves: https://github.com/istio/istio/issues/27509


[ ] Configuration Infrastructure
[ ] Docs
[ X ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.