### PR TITLE
Add support for contains operator for authz header matcher

### DIFF
--- a/pilot/pkg/security/authz/matcher/header.go
+++ b/pilot/pkg/security/authz/matcher/header.go
@@ -32,6 +32,13 @@ func HeaderMatcher(k, v string) *routepb.HeaderMatcher {
 				PresentMatch: true,
 			},
 		}
+	} else if strings.HasPrefix(v, "*") && strings.HasSuffix(v, "*") {
+		return &routepb.HeaderMatcher{
+			Name: k,
+			HeaderMatchSpecifier: &routepb.HeaderMatcher_ContainsMatch{
+				ContainsMatch: v[1 : len(v)-1],
+			},
+		}
 	} else if strings.HasPrefix(v, "*") {
 		return &routepb.HeaderMatcher{
 			Name: k,

--- a/pilot/pkg/security/authz/matcher/header.go
+++ b/pilot/pkg/security/authz/matcher/header.go
@@ -36,7 +36,7 @@ func HeaderMatcher(k, v string) *routepb.HeaderMatcher {
 		return &routepb.HeaderMatcher{
 			Name: k,
 			HeaderMatchSpecifier: &routepb.HeaderMatcher_ContainsMatch{
-				ContainsMatch: v[1 : len(v)-1],
+				ContainsMatch: v[1:len(v)-1],
 			},
 		}
 	} else if strings.HasPrefix(v, "*") {

--- a/pilot/pkg/security/authz/matcher/header.go
+++ b/pilot/pkg/security/authz/matcher/header.go
@@ -36,7 +36,7 @@ func HeaderMatcher(k, v string) *routepb.HeaderMatcher {
 		return &routepb.HeaderMatcher{
 			Name: k,
 			HeaderMatchSpecifier: &routepb.HeaderMatcher_ContainsMatch{
-				ContainsMatch: v[1:len(v)-1],
+				ContainsMatch: v[1 : len(v)-1],
 			},
 		}
 	} else if strings.HasPrefix(v, "*") {

--- a/pilot/pkg/security/authz/matcher/header_test.go
+++ b/pilot/pkg/security/authz/matcher/header_test.go
@@ -44,11 +44,22 @@ func TestHeaderMatcher(t *testing.T) {
 		{
 			Name: "suffix match",
 			K:    ":path",
-			V:    "*/productpage*",
+			V:    "*/productpage",
 			Expect: &routepb.HeaderMatcher{
 				Name: ":path",
 				HeaderMatchSpecifier: &routepb.HeaderMatcher_SuffixMatch{
-					SuffixMatch: "/productpage*",
+					SuffixMatch: "/productpage",
+				},
+			},
+		},
+		{
+			Name: "contains match",
+			K:    ":path",
+			V:    "*/productpage*",
+			Expect: &routepb.HeaderMatcher{
+				Name: ":path",
+				HeaderMatchSpecifier: &routepb.HeaderMatcher_ContainsMatch{
+					ContainsMatch: "/productpage",
 				},
 			},
 		},

--- a/releasenotes/notes/32173.yaml
+++ b/releasenotes/notes/32173.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: enhancement
+area: security
+issue:
+- 32173
+releaseNotes:
+- |
+  **Added** support for contains match for authorization header matching


### PR DESCRIPTION
closes #32173




[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.