### PR TITLE
Handle wrapper value properly for DisableSpanReporting

### DIFF
--- a/pilot/pkg/model/telemetry.go
+++ b/pilot/pkg/model/telemetry.go
@@ -136,13 +136,11 @@ func shallowMergeTracing(parent, child *tpb.Telemetry) *tpb.Telemetry {
 		mergedTracing.CustomTags = childTracing.CustomTags
 	}
 
-	// TODO: use wrapper in API to allow inheritance of disablement ?
-	if childTracing.GetDisableSpanReporting() != mergedTracing.GetDisableSpanReporting() {
+	if childTracing.GetDisableSpanReporting() != nil {
 		mergedTracing.DisableSpanReporting = childTracing.DisableSpanReporting
 	}
 
-	// TODO: use wrapper in API to allow 0-valued override
-	if childTracing.RandomSamplingPercentage != nil {
+	if childTracing.GetRandomSamplingPercentage() != nil {
 		mergedTracing.RandomSamplingPercentage = childTracing.RandomSamplingPercentage
 	}
 

--- a/pilot/pkg/model/telemetry_test.go
+++ b/pilot/pkg/model/telemetry_test.go
@@ -51,7 +51,7 @@ func TestTelemetries_EffectiveTelemetry(t *testing.T) {
 		},
 		Tracing: []*tpb.Tracing{
 			{
-				RandomSamplingPercentage: &types.DoubleValue{Value: 77.77},
+				RandomSamplingPercentage: &types.DoubleValue{Value: 0.0},
 			},
 		},
 	}
@@ -160,8 +160,8 @@ func TestTelemetries_EffectiveTelemetry(t *testing.T) {
 								Name: "zipkin",
 							},
 						},
-						RandomSamplingPercentage: &types.DoubleValue{Value: 77.77},
-						// no disableSpanReporting because the missing value overrides
+						DisableSpanReporting:     &types.BoolValue{Value: true},
+						RandomSamplingPercentage: &types.DoubleValue{Value: 0.0},
 					},
 				},
 			},


### PR DESCRIPTION
Prior PR cleaned up the random sampling percentage; this PR handles it for disable span reporting as well.  With this PR, a user overriding the parent disable/enable choice will have to do so explicitly.

[ X ] Policies and Telemetry
