### PR TITLE
[release-1.10] Fix helm integration test that uses first-party-jwt (#32159)

### DIFF
--- a/pkg/test/helm/helm.go
+++ b/pkg/test/helm/helm.go
@@ -38,7 +38,7 @@ func New(kubeConfig, baseWorkDir string) *Helm {
 	}
 }
 
-// InstallChart installs the specified chart with its given name to the given namespace
+// InstallChartWithValues installs the specified chart with its given name to the given namespace
 func (h *Helm) InstallChartWithValues(name, relpath, namespace string, values []string, timeout time.Duration) error {
 	p := filepath.Join(h.baseDir, relpath)
 

--- a/tests/integration/helm/install_test.go
+++ b/tests/integration/helm/install_test.go
@@ -26,6 +26,7 @@ import (
 	kubecluster "istio.io/istio/pkg/test/framework/components/cluster/kube"
 	"istio.io/istio/pkg/test/framework/image"
 	"istio.io/istio/pkg/test/helm"
+	"istio.io/istio/tests/util/sanitycheck"
 )
 
 // TestDefaultInstall tests Istio installation using Helm with default options
@@ -43,6 +44,7 @@ global:
 
 // TestInstallWithFirstPartyJwt tests Istio installation using Helm
 // with first-party-jwt enabled
+// (TODO) remove this test when Istio no longer supports first-party-jwt
 func TestInstallWithFirstPartyJwt(t *testing.T) {
 	overrideValuesStr := `
 global:
@@ -76,12 +78,13 @@ func setupInstallation(overrideValuesStr string) func(t framework.TestContext) {
 		if err := ioutil.WriteFile(overrideValuesFile, []byte(overrideValues), os.ModePerm); err != nil {
 			t.Fatalf("failed to write iop cr file: %v", err)
 		}
-		InstallGatewaysCharts(t, cs, h, "", IstioNamespace, overrideValuesFile)
+		InstallIstio(t, cs, h, "", overrideValuesFile)
 
 		VerifyInstallation(t, cs)
 
+		sanitycheck.RunTrafficTest(t, t)
 		t.Cleanup(func() {
-			deleteGatewayCharts(t, h)
+			deleteIstio(t, h, cs)
 		})
 	}
 }

--- a/tests/integration/helm/main_test.go
+++ b/tests/integration/helm/main_test.go
@@ -19,17 +19,11 @@ import (
 	"testing"
 
 	"istio.io/istio/pkg/test/framework"
-	"istio.io/istio/pkg/test/framework/components/istio"
-	"istio.io/istio/pkg/test/framework/resource"
 )
 
 func TestMain(m *testing.M) {
-	var ist istio.Instance
 	framework.
 		NewSuite(m).
 		RequireSingleCluster().
-		Setup(istio.Setup(&ist, func(ctx resource.Context, cfg *istio.Config) {
-			cfg.DeployHelm = true
-		})).
 		Run()
 }

--- a/tests/integration/helm/upgrade/util.go
+++ b/tests/integration/helm/upgrade/util.go
@@ -45,6 +45,7 @@ global:
   hub: %s
   tag: %s
 `
+	tarGzSuffix = ".tar.gz"
 )
 
 // previousChartPath is path of Helm charts for previous Istio deployments.
@@ -120,29 +121,6 @@ func getValuesOverrides(ctx framework.TestContext, valuesStr, hub, tag string) s
 	return overrideValuesFile
 }
 
-// installIstio install Istio using Helm charts with the provided
-// override values file and fails the tests on any failures.
-func installIstio(t framework.TestContext, cs cluster.Cluster,
-	h *helm.Helm, overrideValuesFile string) {
-	helmtest.CreateNamespace(t, cs, helmtest.IstioNamespace)
-
-	// Install base chart
-	err := h.InstallChart(helmtest.BaseReleaseName, helmtest.BaseChart+helmtest.TarGzSuffix,
-		helmtest.IstioNamespace, overrideValuesFile, helmtest.Timeout)
-	if err != nil {
-		t.Errorf("failed to install istio %s chart", helmtest.BaseChart)
-	}
-
-	// Install discovery chart
-	err = h.InstallChart(helmtest.IstiodReleaseName, filepath.Join(helmtest.ControlChartsDir, helmtest.DiscoveryChart)+helmtest.TarGzSuffix,
-		helmtest.IstioNamespace, overrideValuesFile, helmtest.Timeout)
-	if err != nil {
-		t.Errorf("failed to install istio %s chart", helmtest.DiscoveryChart)
-	}
-
-	helmtest.InstallGatewaysCharts(t, cs, h, helmtest.TarGzSuffix, helmtest.IstioNamespace, overrideValuesFile)
-}
-
 // performUpgradeFunc returns the provided function necessary to run inside of a integration test
 // for upgrade capability
 func performUpgradeFunc(previousVersion string) func(framework.TestContext) {
@@ -160,7 +138,7 @@ func performUpgradeFunc(previousVersion string) func(framework.TestContext) {
 		})
 
 		overrideValuesFile := getValuesOverrides(t, defaultValues, gcrHub, previousVersion)
-		installIstio(t, cs, h, overrideValuesFile)
+		helmtest.InstallIstio(t, cs, h, tarGzSuffix, overrideValuesFile)
 		helmtest.VerifyInstallation(t, cs)
 
 		oldClient, oldServer := sanitycheck.SetupTrafficTest(t, t)

--- a/tests/integration/helm/util.go
+++ b/tests/integration/helm/util.go
@@ -29,6 +29,7 @@ import (
 	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/cluster"
+	"istio.io/istio/pkg/test/framework/components/cluster/kube"
 	"istio.io/istio/pkg/test/helm"
 	kubetest "istio.io/istio/pkg/test/kube"
 	"istio.io/istio/pkg/test/scopes"
@@ -40,7 +41,6 @@ const (
 	IstioNamespace      = "istio-system"
 	ReleasePrefix       = "istio-"
 	BaseChart           = "base"
-	TarGzSuffix         = ".tar.gz"
 	DiscoveryChart      = "istio-discovery"
 	IngressGatewayChart = "istio-ingress"
 	EgressGatewayChart  = "istio-egress"
@@ -58,22 +58,36 @@ const (
 // ChartPath is path of local Helm charts used for testing.
 var ChartPath = filepath.Join(env.IstioSrc, "manifests/charts")
 
-// InstallGatewaysCharts install Istio using Helm charts with the provided
+// InstallIstio install Istio using Helm charts with the provided
 // override values file and fails the tests on any failures.
-func InstallGatewaysCharts(t test.Failer, cs cluster.Cluster,
-	h *helm.Helm, suffix, namespace, overrideValuesFile string) {
-	CreateNamespace(t, cs, namespace)
+func InstallIstio(t test.Failer, cs cluster.Cluster,
+	h *helm.Helm, suffix, overrideValuesFile string) {
+	CreateNamespace(t, cs, IstioNamespace)
+
+	// Install base chart
+	err := h.InstallChart(BaseReleaseName, BaseChart+suffix,
+		IstioNamespace, overrideValuesFile, Timeout)
+	if err != nil {
+		t.Fatalf("failed to install istio %s chart", BaseChart)
+	}
+
+	// Install discovery chart
+	err = h.InstallChart(IstiodReleaseName, filepath.Join(ControlChartsDir, DiscoveryChart)+suffix,
+		IstioNamespace, overrideValuesFile, Timeout)
+	if err != nil {
+		t.Fatalf("failed to install istio %s chart", DiscoveryChart)
+	}
 
 	// Install ingress gateway chart
-	err := h.InstallChart(IngressReleaseName, filepath.Join(GatewayChartsDir, IngressGatewayChart)+suffix,
-		namespace, overrideValuesFile, Timeout)
+	err = h.InstallChart(IngressReleaseName, filepath.Join(GatewayChartsDir, IngressGatewayChart)+suffix,
+		IstioNamespace, overrideValuesFile, Timeout)
 	if err != nil {
 		t.Fatalf("failed to install istio %s chart", IngressGatewayChart)
 	}
 
 	// Install egress gateway chart
 	err = h.InstallChart(EgressReleaseName, filepath.Join(GatewayChartsDir, EgressGatewayChart)+suffix,
-		namespace, overrideValuesFile, Timeout)
+		IstioNamespace, overrideValuesFile, Timeout)
 	if err != nil {
 		t.Fatalf("failed to install istio %s chart", EgressGatewayChart)
 	}
@@ -93,14 +107,26 @@ func CreateNamespace(t test.Failer, cs cluster.Cluster, namespace string) {
 	}
 }
 
-// deleteGatewayCharts deletes installed Istio Helm charts and resources
-func deleteGatewayCharts(t framework.TestContext, h *helm.Helm) {
+// deleteIstio deletes installed Istio Helm charts and resources
+func deleteIstio(t framework.TestContext, h *helm.Helm, cs *kube.Cluster) {
 	scopes.Framework.Infof("cleaning up resources")
 	if err := h.DeleteChart(EgressReleaseName, IstioNamespace); err != nil {
 		t.Errorf("failed to delete %s release", EgressReleaseName)
 	}
 	if err := h.DeleteChart(IngressReleaseName, IstioNamespace); err != nil {
 		t.Errorf("failed to delete %s release", IngressReleaseName)
+	}
+	if err := h.DeleteChart(IstiodReleaseName, IstioNamespace); err != nil {
+		t.Errorf("failed to delete %s release", IngressReleaseName)
+	}
+	if err := h.DeleteChart(BaseReleaseName, IstioNamespace); err != nil {
+		t.Errorf("failed to delete %s release", BaseReleaseName)
+	}
+	if err := cs.CoreV1().Namespaces().Delete(context.TODO(), IstioNamespace, metav1.DeleteOptions{}); err != nil {
+		t.Errorf("failed to delete istio namespace: %v", err)
+	}
+	if err := kubetest.WaitForNamespaceDeletion(cs, IstioNamespace, retry.Timeout(RetryTimeOut)); err != nil {
+		t.Errorf("wating for istio namespace to be deleted: %v", err)
 	}
 }
 


### PR DESCRIPTION
Cherry-pick of 54ba14c99b705694d2ec36ec7f9cfe52f6afdf1e from https://github.com/istio/istio/pull/32159

Issue: Helm integration tests were always passing in third-party-jwt for
the global.jwtPolicy field. Fix the integration test to use
first-party-jwt when specified by not installing istio with helm in
main_test.go.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any changes that may affect Istio users.