### PR TITLE
Fix downloading Istio version greater than 1.9

### DIFF
--- a/release/downloadIstioCandidate.sh
+++ b/release/downloadIstioCandidate.sh
@@ -103,11 +103,7 @@ without_arch() {
 }
 
 # Istio 1.6 and above support arch
-ARCH_SUPPORTED=$(echo "$ISTIO_VERSION" | awk  '{ ARCH_SUPPORTED=substr($0, 1, 4); print ARCH_SUPPORTED; }' )
-# If the verion contains dot at the end, remove it eg: (1.10, 1.11, 1.9., 1.8.)
-if [[ $ARCH_SUPPORTED == *. ]]; then
-  ARCH_SUPPORTED=$(echo "$ARCH_SUPPORTED" | sed 's/.$//' )
-fi
+ARCH_SUPPORTED=$(echo "$ISTIO_VERSION" | awk -F'.' '{print $1"."$2}' )
 # Istio 1.5 and below do not have arch support
 ARCH_UNSUPPORTED="1.5"
 

--- a/release/downloadIstioCandidate.sh
+++ b/release/downloadIstioCandidate.sh
@@ -103,7 +103,11 @@ without_arch() {
 }
 
 # Istio 1.6 and above support arch
-ARCH_SUPPORTED=$(echo "$ISTIO_VERSION" | awk  '{ ARCH_SUPPORTED=substr($0, 1, 3); print ARCH_SUPPORTED; }' )
+ARCH_SUPPORTED=$(echo "$ISTIO_VERSION" | awk  '{ ARCH_SUPPORTED=substr($0, 1, 4); print ARCH_SUPPORTED; }' )
+# If the verion contains dot at the end, remove it eg: (1.10, 1.11, 1.9., 1.8.)
+if [[ $ARCH_SUPPORTED == *. ]]; then
+  ARCH_SUPPORTED=$(echo "$ARCH_SUPPORTED" | sed 's/.$//' )
+fi
 # Istio 1.5 and below do not have arch support
 ARCH_UNSUPPORTED="1.5"
 

--- a/release/downloadIstioCtl.sh
+++ b/release/downloadIstioCtl.sh
@@ -99,11 +99,7 @@ without_arch() {
 }
 
 # Istio 1.6 and above support arch
-ARCH_SUPPORTED=$(echo "$ISTIO_VERSION" | awk  '{ ARCH_SUPPORTED=substr($0, 1, 4); print ARCH_SUPPORTED; }' )
-# If the verion contains dot at the end, remove it eg: (1.10, 1.11, 1.9., 1.8.)
-if [[ $ARCH_SUPPORTED == *. ]]; then
-  ARCH_SUPPORTED=$(echo "$ARCH_SUPPORTED" | sed 's/.$//' )
-fi
+ARCH_SUPPORTED=$(echo "$ISTIO_VERSION" | awk -F'.' '{print $1"."$2}' )
 # Istio 1.5 and below do not have arch support
 ARCH_UNSUPPORTED="1.5"
 

--- a/release/downloadIstioCtl.sh
+++ b/release/downloadIstioCtl.sh
@@ -99,7 +99,11 @@ without_arch() {
 }
 
 # Istio 1.6 and above support arch
-ARCH_SUPPORTED=$(echo "$ISTIO_VERSION" | awk  '{ ARCH_SUPPORTED=substr($0, 1, 3); print ARCH_SUPPORTED; }' )
+ARCH_SUPPORTED=$(echo "$ISTIO_VERSION" | awk  '{ ARCH_SUPPORTED=substr($0, 1, 4); print ARCH_SUPPORTED; }' )
+# If the verion contains dot at the end, remove it eg: (1.10, 1.11, 1.9., 1.8.)
+if [[ $ARCH_SUPPORTED == *. ]]; then
+  ARCH_SUPPORTED=$(echo "$ARCH_SUPPORTED" | sed 's/.$//' )
+fi
 # Istio 1.5 and below do not have arch support
 ARCH_UNSUPPORTED="1.5"
 


### PR DESCRIPTION
To fix https://github.com/istio/istio/issues/32194

We use to trim the first 3 characters from the Istio version eg: `1.9.0-alpha.0 > 1.9`, but if the version is greater than 1.9 eg: `1.10.0-alpha.0 > 1.1` which breaks the download script. We should split with dot and consider the first 2 values. 

