### PR TITLE
IST0143 - Fix `in by` to be `in`

### DIFF
--- a/galley/pkg/config/analysis/msg/messages.gen.go
+++ b/galley/pkg/config/analysis/msg/messages.gen.go
@@ -166,7 +166,7 @@ var (
 	UnsupportedKubernetesVersion = diag.NewMessageType(diag.Error, "IST0142", "The Kubernetes Version %q is lower than the minimum version: %v")
 
 	// LocalhostListener defines a diag.MessageType for message "LocalhostListener".
-	// Description: A port exposed in by a Service is bound to a localhost address
+	// Description: A port exposed in a Service is bound to a localhost address
 	LocalhostListener = diag.NewMessageType(diag.Error, "IST0143", "Port %v is exposed in a Service but listens on localhost. It will not be exposed to other pods.")
 )
 

--- a/galley/pkg/config/analysis/msg/messages.yaml
+++ b/galley/pkg/config/analysis/msg/messages.yaml
@@ -442,7 +442,7 @@ messages:
   - name: "LocalhostListener"
     code: IST0143
     level: Error
-    description: "A port exposed in by a Service is bound to a localhost address"
+    description: "A port exposed in a Service is bound to a localhost address"
     template: "Port %v is exposed in a Service but listens on localhost. It will not be exposed to other pods."
     args:
       - name: port


### PR DESCRIPTION

IST0143 has: "A port exposed in by a Service is bound to a localhost address". Reword to "A port exposed in a Service is bound to a localhost address"

I went with the `in` wording used on the next line, but wonder if we should use `by` instead.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any changes that may affect Istio users.