### PR TITLE
rate-limit invalid config retries

### DIFF
--- a/pkg/webhooks/validation/controller/controller.go
+++ b/pkg/webhooks/validation/controller/controller.go
@@ -49,8 +49,7 @@ import (
 )
 
 var (
-	scope             = log.RegisterScope("validationController", "validation webhook controller", 0)
-	dryRunCreationReq = &reconcileRequest{"retry dry-run creation of invalid config"}
+	scope = log.RegisterScope("validationController", "validation webhook controller", 0)
 )
 
 type Options struct {
@@ -202,7 +201,7 @@ func newController(
 	c := &Controller{
 		o:      o,
 		client: client,
-		queue:  workqueue.NewRateLimitingQueue(workqueue.DefaultItemBasedRateLimiter()),
+		queue:  workqueue.NewRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(1*time.Second, 1*time.Minute)),
 	}
 
 	c.webhookInformer = client.KubeInformer().Admissionregistration().V1().ValidatingWebhookConfigurations()
@@ -261,7 +260,7 @@ func (c *Controller) processNextWorkItem() (cont bool) {
 		return false
 	}
 
-	if err := c.reconcileRequest(req); err != nil {
+	if retry, err := c.reconcileRequest(req); retry || err != nil {
 		c.queue.AddRateLimited(obj)
 		utilruntime.HandleError(err)
 	} else {
@@ -271,13 +270,15 @@ func (c *Controller) processNextWorkItem() (cont bool) {
 }
 
 // reconcile the desired state with the kube-apiserver.
-func (c *Controller) reconcileRequest(req *reconcileRequest) error {
+// the returned results indicate if the reconciliation should be retried and/or
+// if there was an error.
+func (c *Controller) reconcileRequest(req *reconcileRequest) (bool, error) {
 	// Stop early if webhook is not present, rather than attempting (and failing) to reconcile permanently
 	// If the webhook is later added a new reconciliation request will trigger it to update
 	_, err := c.webhookInformer.Lister().Get(c.o.WebhookConfigName)
 	if err != nil && kubeErrors.IsNotFound(err) {
 		scope.Infof("Skip patching webhook, webhook not found")
-		return nil
+		return false, nil
 	}
 
 	scope.Infof("Reconcile(enter): %v", req)
@@ -293,16 +294,15 @@ func (c *Controller) reconcileRequest(req *reconcileRequest) error {
 		scope.Errorf("Failed to load CA bundle: %v", err)
 		reportValidationConfigLoadError(err.(*configError).Reason())
 		// no point in retrying unless cert file changes.
-		return nil
+		return !ready, nil
 	}
-	return c.updateValidatingWebhookConfiguration(caBundle, failurePolicy)
+	return !ready, c.updateValidatingWebhookConfiguration(caBundle, failurePolicy)
 }
 
 func (c *Controller) readyForFailClose() bool {
 	if !c.dryRunOfInvalidConfigRejected {
 		if rejected, reason := c.isDryRunOfInvalidConfigRejected(); !rejected {
 			scope.Infof("Not ready to switch validation to fail-closed: %v", reason)
-			c.queue.AddRateLimited(dryRunCreationReq)
 			return false
 		}
 		scope.Info("Endpoint successfully rejected invalid config. Switching to fail-close.")

--- a/pkg/webhooks/validation/controller/controller.go
+++ b/pkg/webhooks/validation/controller/controller.go
@@ -49,8 +49,8 @@ import (
 )
 
 var (
-	scope             = log.RegisterScope("validationController", "validation webhook controller", 0)
-	dryRunCreationReq = &reconcileRequest{"retry dry-run creation of invalid config"}
+	scope          = log.RegisterScope("validationController", "validation webhook controller", 0)
+	retryReconcile = &reconcileRequest{"retry reconcile loop"}
 )
 
 type Options struct {
@@ -262,6 +262,10 @@ func (c *Controller) processNextWorkItem() (cont bool) {
 	}
 
 	if retry, err := c.reconcileRequest(req); retry || err != nil {
+		if retry {
+			c.queue.AddRateLimited(retryReconcile)
+			return true
+		}
 		c.queue.AddRateLimited(obj)
 		utilruntime.HandleError(err)
 	} else {

--- a/pkg/webhooks/validation/controller/controller.go
+++ b/pkg/webhooks/validation/controller/controller.go
@@ -48,7 +48,10 @@ import (
 	"istio.io/pkg/log"
 )
 
-var scope = log.RegisterScope("validationController", "validation webhook controller", 0)
+var (
+	scope             = log.RegisterScope("validationController", "validation webhook controller", 0)
+	dryRunCreationReq = &reconcileRequest{"retry dry-run creation of invalid config"}
+)
 
 type Options struct {
 	// Istio system namespace where istiod resides.

--- a/pkg/webhooks/validation/controller/controller.go
+++ b/pkg/webhooks/validation/controller/controller.go
@@ -48,9 +48,7 @@ import (
 	"istio.io/pkg/log"
 )
 
-var (
-	scope = log.RegisterScope("validationController", "validation webhook controller", 0)
-)
+var scope = log.RegisterScope("validationController", "validation webhook controller", 0)
 
 type Options struct {
 	// Istio system namespace where istiod resides.

--- a/pkg/webhooks/validation/controller/controller_test.go
+++ b/pkg/webhooks/validation/controller/controller_test.go
@@ -196,7 +196,7 @@ func reconcileHelper(t *testing.T, c *fakeController) {
 	t.Helper()
 
 	c.ClearActions()
-	if err := c.reconcileRequest(&reconcileRequest{"test"}); err != nil {
+	if _, err := c.reconcileRequest(&reconcileRequest{"test"}); err != nil {
 		t.Fatalf("unexpected reconciliation error: %v", err)
 	}
 }

--- a/releasenotes/notes/validating-webhook-reconcile-change.yaml
+++ b/releasenotes/notes/validating-webhook-reconcile-change.yaml
@@ -5,6 +5,6 @@ issue:
 - 32210
 releaseNotes:
 - |
-  **Updated** reconciliation logic in the validation webhook controller to rate-limit
+  **Fixed** reconciliation logic in the validation webhook controller to rate-limit
   the retries in the loop. This should drastically reduce churn (and generated logs)
   in cases of misconfiguration.

--- a/releasenotes/notes/validating-webhook-reconcile-change.yaml
+++ b/releasenotes/notes/validating-webhook-reconcile-change.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+- 32210
+releaseNotes:
+- |
+  **Updated** reconciliation logic in the validation webhook controller to rate-limit
+  the retries in the loop. This should drastically reduce churn (and generated logs)
+  in cases of misconfiguration.


### PR DESCRIPTION
When recently looking at some customer logs, I noticed an extremely high-frequency of reconcile log messages for the validatingwebhookcontroller.  This PR represents an attempt to limit address that issue by rate-limiting retries for fail-closed loops and establish a new rate limiter with a `1s` base (with max of `1m`) (original was `1ms` -> `1000s`).

[ x ] Networking
[ x ] Policies and Telemetry
[ X ] User Experience
