### PR TITLE
allow specifying test framework flags via config file

### DIFF
--- a/pkg/test/framework/analyzer_runtime.go
+++ b/pkg/test/framework/analyzer_runtime.go
@@ -24,6 +24,7 @@ import (
 
 	"gopkg.in/yaml.v2"
 
+	"istio.io/istio/pkg/test/framework/config"
 	"istio.io/istio/pkg/test/framework/features"
 	"istio.io/istio/pkg/test/framework/label"
 	"istio.io/istio/pkg/test/scopes"
@@ -40,8 +41,8 @@ func init() {
 }
 
 func analyze() bool {
-	if !flag.Parsed() {
-		flag.Parse()
+	if !config.Parsed() {
+		config.Parse()
 	}
 	return analyzeMode
 }
@@ -80,7 +81,7 @@ func dumpAnalysis() {
 	scopes.Framework.Info("\n" + string(marshaled))
 
 	outPath := path.Join(s.RunDir(), fmt.Sprintf("%s_analysis.yaml", analysis.SuiteID))
-	if err := ioutil.WriteFile(outPath, marshaled, 0666); err != nil {
+	if err := ioutil.WriteFile(outPath, marshaled, 0o666); err != nil {
 		scopes.Framework.Errorf("failed writing analysis to file for %s: %v", analysis.SuiteID, err)
 		return
 	}

--- a/pkg/test/framework/components/cluster/clusterboot/factory.go
+++ b/pkg/test/framework/components/cluster/clusterboot/factory.go
@@ -26,6 +26,7 @@ import (
 
 	// imported to trigger registration
 	_ "istio.io/istio/pkg/test/framework/components/cluster/staticvm"
+	"istio.io/istio/pkg/test/framework/config"
 	"istio.io/istio/pkg/test/scopes"
 )
 
@@ -60,8 +61,8 @@ func (a factory) Build() (cluster.Clusters, error) {
 
 	allClusters := make(cluster.Map)
 	var clusters cluster.Clusters
-	for i, config := range a.configs {
-		c, err := buildCluster(config, allClusters)
+	for i, cfg := range a.configs {
+		c, err := buildCluster(cfg, allClusters)
 		if err != nil {
 			errs = multierror.Append(errs, fmt.Errorf("failed building cluster from config %d: %v", i, err))
 			continue
@@ -86,11 +87,11 @@ func (a factory) Build() (cluster.Clusters, error) {
 			errs = multierror.Append(errs, fmt.Errorf("primary %s for %s is of kind %s, primaries must be Kubernetes", primary.Name(), c.Name(), primary.Kind()))
 			continue
 		}
-		if config, ok := allClusters[c.ConfigName()]; !ok {
+		if cfg, ok := allClusters[c.ConfigName()]; !ok {
 			errs = multierror.Append(errs, fmt.Errorf("config %s for %s is not in the topology", c.ConfigName(), c.Name()))
 			continue
-		} else if !validPrimaryOrConfig(config) {
-			errs = multierror.Append(errs, fmt.Errorf("config %s for %s is of kind %s, primaries must be Kubernetes", config.Name(), c.Name(), config.Kind()))
+		} else if !validPrimaryOrConfig(cfg) {
+			errs = multierror.Append(errs, fmt.Errorf("config %s for %s is of kind %s, primaries must be Kubernetes", cfg.Name(), c.Name(), cfg.Kind()))
 			continue
 		}
 	}
@@ -136,7 +137,7 @@ func validConfig(cfg cluster.Config) (cluster.Config, error) {
 		cfg.ConfigClusterName = cfg.PrimaryClusterName
 	}
 	if cfg.Meta == nil {
-		cfg.Meta = cluster.ConfigMeta{}
+		cfg.Meta = config.Map{}
 	}
 	return cfg, nil
 }

--- a/pkg/test/framework/components/cluster/clusterboot/factory_test.go
+++ b/pkg/test/framework/components/cluster/clusterboot/factory_test.go
@@ -21,6 +21,7 @@ import (
 
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/test/framework/components/cluster"
+	"istio.io/istio/pkg/test/framework/config"
 )
 
 func TestBuild(t *testing.T) {
@@ -136,9 +137,9 @@ func TestValidation(t *testing.T) {
 			{Kind: cluster.Fake, Name: "no-primary", ConfigClusterName: "does-not-exist"},
 		},
 		"vm without kube primary": {
-			{Kind: cluster.StaticVM, Name: "vm", Meta: cluster.ConfigMeta{"deployments": []interface{}{
-				cluster.ConfigMeta{
-					"service": "vm", "namespace": "echo", "instances": []cluster.ConfigMeta{{"ip": "1.2.3.4"}},
+			{Kind: cluster.StaticVM, Name: "vm", Meta: config.Map{"deployments": []interface{}{
+				config.Map{
+					"service": "vm", "namespace": "echo", "instances": []config.Map{{"ip": "1.2.3.4"}},
 				},
 			}}},
 		},

--- a/pkg/test/framework/components/cluster/config.go
+++ b/pkg/test/framework/components/cluster/config.go
@@ -15,9 +15,7 @@
 package cluster
 
 import (
-	"fmt"
-
-	"istio.io/istio/pkg/test/scopes"
+	"istio.io/istio/pkg/test/framework/config"
 )
 
 type Kind string
@@ -36,75 +34,5 @@ type Config struct {
 	Network            string     `yaml:"network,omitempty"`
 	PrimaryClusterName string     `yaml:"primaryClusterName,omitempty"`
 	ConfigClusterName  string     `yaml:"configClusterName,omitempty"`
-	Meta               ConfigMeta `yaml:"meta,omitempty"`
-}
-
-type ConfigMeta map[string]interface{}
-
-func (m ConfigMeta) String(key string) string {
-	v, ok := m[key].(string)
-	if !ok {
-		return ""
-	}
-	return v
-}
-
-func (m ConfigMeta) Slice(key string) []ConfigMeta {
-	v, ok := m[key].([]interface{})
-	if !ok {
-		scopes.Framework.Warnf("failed to parse key %q as slice, defaulting to empty", key)
-		return nil
-	}
-	var out []ConfigMeta
-	for i, imeta := range v {
-		meta, ok := toConfigMeta(imeta)
-		if !ok {
-			scopes.Framework.Warnf("failed to parse item %d of %s, defaulting to empty: %v", i, key, imeta)
-			return nil
-		}
-		out = append(out, meta)
-	}
-	return out
-}
-
-func toConfigMeta(orig interface{}) (ConfigMeta, bool) {
-	// keys are strings, easily cast
-	if cfgMeta, ok := orig.(ConfigMeta); ok {
-		return cfgMeta, true
-	}
-	// keys are interface{}, manually change to string keys
-	mapInterface, ok := orig.(map[interface{}]interface{})
-	if !ok {
-		// not a map at all
-		return nil, false
-	}
-	mapString := make(map[string]interface{})
-	for key, value := range mapInterface {
-		mapString[fmt.Sprintf("%v", key)] = value
-	}
-	return mapString, true
-}
-
-func (m ConfigMeta) Bool(key string) *bool {
-	if m[key] == nil {
-		return nil
-	}
-	v, ok := m[key].(bool)
-	if !ok {
-		scopes.Framework.Warnf("failed to parse key of type %T value %q as bool, defaulting to false", m[key], key)
-		return nil
-	}
-	return &v
-}
-
-func (m ConfigMeta) Int(key string) int {
-	if m[key] == nil {
-		return 0
-	}
-	v, ok := m[key].(int)
-	if !ok {
-		scopes.Framework.Warnf("failed to parse key of type %T value %q as int, defaulting to 0", m[key], key)
-		return 0
-	}
-	return v
+	Meta               config.Map `yaml:"meta,omitempty"`
 }

--- a/pkg/test/framework/components/cluster/staticvm/staticvm.go
+++ b/pkg/test/framework/components/cluster/staticvm/staticvm.go
@@ -25,6 +25,7 @@ import (
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/test/framework/components/cluster"
 	"istio.io/istio/pkg/test/framework/components/echo"
+	"istio.io/istio/pkg/test/framework/config"
 	"istio.io/istio/pkg/test/scopes"
 )
 
@@ -68,7 +69,7 @@ func readInstances(cfg cluster.Config) ([]echo.Config, error) {
 	return out, nil
 }
 
-func instanceFromMeta(cfg cluster.ConfigMeta) (echo.Config, error) {
+func instanceFromMeta(cfg config.Map) (echo.Config, error) {
 	svc := cfg.String("service")
 	if svc == "" {
 		return echo.Config{}, errors.New("service must not be empty")

--- a/pkg/test/framework/components/echo/kube/deployment_test.go
+++ b/pkg/test/framework/components/echo/kube/deployment_test.go
@@ -22,6 +22,7 @@ import (
 	"istio.io/istio/pkg/test/framework/components/cluster/clusterboot"
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/echo/common"
+	"istio.io/istio/pkg/test/framework/config"
 	"istio.io/istio/pkg/test/framework/image"
 	"istio.io/istio/pkg/test/framework/resource"
 )
@@ -159,7 +160,7 @@ func TestDeploymentYAML(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			clusters, err := clusterboot.NewFactory().With(cluster.Config{
 				Kind: cluster.Fake, Name: "cluster-0",
-				Meta: cluster.ConfigMeta{"majorVersion": 1, "minorVersion": 16},
+				Meta: config.Map{"majorVersion": 1, "minorVersion": 16},
 			}).Build()
 			if err != nil {
 				t.Fatal(err)
@@ -167,6 +168,9 @@ func TestDeploymentYAML(t *testing.T) {
 			tc.config.Cluster = clusters[0]
 			if err := common.FillInDefaults(nil, &tc.config); err != nil {
 				t.Errorf("failed filling in defaults: %v", err)
+			}
+			if !config.Parsed() {
+				config.Parse()
 			}
 			serviceYAML, err := GenerateService(tc.config)
 			if err != nil {

--- a/pkg/test/framework/components/environment/kube/flags.go
+++ b/pkg/test/framework/components/environment/kube/flags.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"istio.io/istio/pkg/test/env"
+	"istio.io/istio/pkg/test/framework/config"
 	"istio.io/istio/pkg/test/scopes"
 	"istio.io/istio/pkg/test/util/file"
 )
@@ -49,10 +50,10 @@ var (
 )
 
 // NewSettingsFromCommandLine returns Settings obtained from command-line flags.
-// flag.Parse must be called before calling this function.
+// config.Parse must be called before calling this function.
 func NewSettingsFromCommandLine() (*Settings, error) {
-	if !flag.Parsed() {
-		panic("flag.Parse must be called before this function")
+	if !config.Parsed() {
+		panic("config.Parse must be called before this function")
 	}
 
 	s := settingsFromCommandLine.clone()

--- a/pkg/test/framework/components/environment/kube/settings.go
+++ b/pkg/test/framework/components/environment/kube/settings.go
@@ -22,6 +22,7 @@ import (
 
 	istioKube "istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/test/framework/components/cluster"
+	"istio.io/istio/pkg/test/framework/config"
 	"istio.io/istio/pkg/test/scopes"
 	"istio.io/istio/pkg/test/util/file"
 )
@@ -99,7 +100,7 @@ func (s *Settings) clusterConfigsFromFlags() ([]cluster.Config, error) {
 			Name:    fmt.Sprintf("cluster-%d", i),
 			Kind:    cluster.Kubernetes,
 			Network: s.networkTopology[ci],
-			Meta:    cluster.ConfigMeta{"kubeconfig": kc},
+			Meta:    config.Map{"kubeconfig": kc},
 		}
 		if idx, ok := s.controlPlaneTopology[ci]; ok {
 			cfg.PrimaryClusterName = fmt.Sprintf("cluster-%d", idx)
@@ -200,19 +201,19 @@ func replaceKubeconfigs(configs []cluster.Config, kubeconfigs []string) ([]clust
 	}
 	kube := 0
 	out := []cluster.Config{}
-	for _, config := range configs {
-		if config.Kind == cluster.Kubernetes {
+	for _, cfg := range configs {
+		if cfg.Kind == cluster.Kubernetes {
 			if kube >= len(kubeconfigs) {
 				// not enough to cover all clusters in file
-				return nil, fmt.Errorf("istio.test.kube.config should have a kubeconfig for each kube cluster")
+				return nil, fmt.Errorf("istio.test.kube.cfg should have a kubeconfig for each kube cluster")
 			}
-			if config.Meta == nil {
-				config.Meta = cluster.ConfigMeta{}
+			if cfg.Meta == nil {
+				cfg.Meta = config.Map{}
 			}
-			config.Meta["kubeconfig"] = kubeconfigs[kube]
+			cfg.Meta["kubeconfig"] = kubeconfigs[kube]
 		}
 		kube++
-		out = append(out, config)
+		out = append(out, cfg)
 	}
 	if kube < len(kubeconfigs) {
 		return nil, fmt.Errorf("%d kubeconfigs were provided but topolgy has %d kube clusters", len(kubeconfigs), kube)

--- a/pkg/test/framework/config/config.go
+++ b/pkg/test/framework/config/config.go
@@ -1,0 +1,126 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"strings"
+
+	"go.uber.org/atomic"
+	"gopkg.in/yaml.v3"
+
+	"istio.io/istio/pkg/test/scopes"
+	"istio.io/istio/pkg/test/util/file"
+)
+
+const prefix = "istio.test"
+
+var (
+	configFilePath string
+	parsed         atomic.Bool
+)
+
+func init() {
+	flag.StringVar(&configFilePath, "istio.test.config", "", "Path to test framework config file")
+}
+
+type Value interface {
+	flag.Value
+	SetConfig(Map) error
+}
+
+func Parsed() bool {
+	return flag.Parsed() && parsed.Load()
+}
+
+// Parse overrides any unset command line flags beginning with "istio.test" with values provided
+// from a YAML file.
+func Parse() {
+	defer func() {
+		parsed.Store(true)
+	}()
+	if !flag.Parsed() {
+		flag.Parse()
+	}
+	if configFilePath == "" {
+		return
+	}
+
+	cfg, err := readConfig()
+	if err != nil {
+		scopes.Framework.Error(err)
+		return
+	}
+	set := map[string]struct{}{}
+	flag.Visit(func(f *flag.Flag) {
+		set[f.Name] = struct{}{}
+	})
+
+	flag.VisitAll(func(f *flag.Flag) {
+		var err error
+		defer func() {
+			if err != nil {
+				scopes.Framework.Errorf("failed getting %s from config file: %v", f.Name, err)
+			}
+		}()
+
+		// exclude non-istio flags and flags that were set via command line
+		if !strings.HasPrefix(f.Name, prefix) {
+			return
+		}
+		if _, ok := set[f.Name]; ok {
+			return
+		}
+
+		// grab the map containing the last "." separated key
+		keys := strings.Split(f.Name, ".")
+		parentPath, key := keys[:len(keys)-1], keys[len(keys)-1]
+		parent := cfg
+		for _, k := range parentPath {
+			parent = parent.Map(k)
+			if parent == nil {
+				return
+			}
+		}
+
+		// if we have a Map at the last key, and the registered value implements our custom value, parse via Map
+		cfgMap := parent.Map(key)
+		cfgValue, isCfgVal := f.Value.(Value)
+		if isCfgVal && len(cfgMap) > 0 {
+			err = cfgValue.SetConfig(cfgMap)
+		} else if v := parent.String(key); v != "" {
+			// otherwise parse via string (if-set)
+			err = f.Value.Set(v)
+		}
+	})
+}
+
+func readConfig() (Map, error) {
+	path, err := file.NormalizePath(configFilePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed normalizing config file path %q: %v", configFilePath, err)
+	}
+	bytes, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed reading %s: %v", path, err)
+	}
+	cfg := Map{}
+	if err := yaml.Unmarshal(bytes, cfg); err != nil {
+		return nil, fmt.Errorf("failed unmarshalling %s: %v", path, err)
+	}
+	return cfg, nil
+}

--- a/pkg/test/framework/config/map.go
+++ b/pkg/test/framework/config/map.go
@@ -1,0 +1,107 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"fmt"
+
+	"istio.io/istio/pkg/test/scopes"
+)
+
+type Map map[string]interface{}
+
+func (m Map) Map(key string) Map {
+	nested, ok := m[key]
+	if !ok {
+		return nil
+	}
+	out, ok := nested.(Map)
+	if !ok {
+		return nil
+	}
+	return out
+}
+
+func (m Map) String(key string) string {
+	v, ok := m[key]
+	if !ok || v == nil {
+		return ""
+	}
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Sprint(m[key])
+	}
+	return str
+}
+
+func (m Map) Slice(key string) []Map {
+	v, ok := m[key].([]interface{})
+	if !ok {
+		scopes.Framework.Warnf("failed to parse key %q as slice, defaulting to empty", key)
+		return nil
+	}
+	var out []Map
+	for i, imeta := range v {
+		meta, ok := toMap(imeta)
+		if !ok {
+			scopes.Framework.Warnf("failed to parse item %d of %s, defaulting to empty: %v", i, key, imeta)
+			return nil
+		}
+		out = append(out, meta)
+	}
+	return out
+}
+
+func toMap(orig interface{}) (Map, bool) {
+	// keys are strings, easily cast
+	if cfgMeta, ok := orig.(Map); ok {
+		return cfgMeta, true
+	}
+	// keys are interface{}, manually change to string keys
+	mapInterface, ok := orig.(map[interface{}]interface{})
+	if !ok {
+		// not a map at all
+		return nil, false
+	}
+	mapString := make(map[string]interface{})
+	for key, value := range mapInterface {
+		mapString[fmt.Sprintf("%v", key)] = value
+	}
+	return mapString, true
+}
+
+func (m Map) Bool(key string) *bool {
+	if m[key] == nil {
+		return nil
+	}
+	v, ok := m[key].(bool)
+	if !ok {
+		scopes.Framework.Warnf("failed to parse key of type %T value %q as bool, defaulting to false", m[key], key)
+		return nil
+	}
+	return &v
+}
+
+func (m Map) Int(key string) int {
+	if m[key] == nil {
+		return 0
+	}
+	v, ok := m[key].(int)
+	if !ok {
+		scopes.Framework.Warnf("failed to parse key of type %T value %q as int, defaulting to 0", m[key], key)
+		return 0
+	}
+	return v
+}

--- a/pkg/test/framework/image/flags.go
+++ b/pkg/test/framework/image/flags.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"istio.io/istio/pkg/test/env"
+	"istio.io/istio/pkg/test/framework/config"
 )
 
 // Settings we will collect from the command-line.
@@ -29,10 +30,10 @@ var settingsFromCommandLine = &Settings{
 	BitnamiHub: env.BITNAMIHUB.ValueOrDefault("docker.io/bitnami"),
 }
 
-// SettingsFromCommandLine returns Settings obtained from command-line flags. flag.Parse must be called before calling this function.
+// SettingsFromCommandLine returns Settings obtained from command-line flags. config.Parse must be called before calling this function.
 func SettingsFromCommandLine() (*Settings, error) {
-	if !flag.Parsed() {
-		panic("flag.Parse must be called before this function")
+	if !config.Parsed() {
+		panic("config.Parse must be called before this function")
 	}
 
 	s := settingsFromCommandLine.clone()

--- a/pkg/test/framework/resource/flags.go
+++ b/pkg/test/framework/resource/flags.go
@@ -19,16 +19,17 @@ import (
 	"fmt"
 	"os"
 
+	"istio.io/istio/pkg/test/framework/config"
 	"istio.io/istio/pkg/test/framework/label"
 )
 
 var settingsFromCommandLine = DefaultSettings()
 
-// SettingsFromCommandLine returns settings obtained from command-line flags. flag.Parse must be called before
+// SettingsFromCommandLine returns settings obtained from command-line flags. config.Parse must be called before
 // calling this function.
 func SettingsFromCommandLine(testID string) (*Settings, error) {
-	if !flag.Parsed() {
-		panic("flag.Parse must be called before this function")
+	if !config.Parsed() {
+		panic("config.Parse must be called before this function")
 	}
 
 	s := settingsFromCommandLine.Clone()

--- a/pkg/test/framework/resource/version.go
+++ b/pkg/test/framework/resource/version.go
@@ -18,10 +18,26 @@ import (
 	"strings"
 
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/test/framework/config"
 )
+
+var _ config.Value = &RevVerMap{}
 
 // RevVerMap maps installed revisions to their Istio versions.
 type RevVerMap map[string]IstioVersion
+
+func (rv *RevVerMap) SetConfig(m config.Map) error {
+	out := make(RevVerMap)
+	for k := range m {
+		version, err := ParseIstioVersion(m.String(k))
+		if err != nil {
+			return err
+		}
+		out[k] = version
+	}
+	*rv = out
+	return nil
+}
 
 // Set parses IstioVersions from a string flag in the form "a=1.5.6,b=1.9.0,c=1.4".
 func (rv *RevVerMap) Set(value string) error {

--- a/pkg/test/framework/suite.go
+++ b/pkg/test/framework/suite.go
@@ -16,7 +16,6 @@ package framework
 
 import (
 	"errors"
-	"flag"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -34,6 +33,7 @@ import (
 	kubelib "istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/test/framework/components/cluster"
 	"istio.io/istio/pkg/test/framework/components/environment/kube"
+	"istio.io/istio/pkg/test/framework/config"
 	ferrors "istio.io/istio/pkg/test/framework/errors"
 	"istio.io/istio/pkg/test/framework/label"
 	"istio.io/istio/pkg/test/framework/resource"
@@ -508,8 +508,8 @@ func newEnvironment(ctx resource.Context) (resource.Environment, error) {
 
 func getSettings(testID string) (*resource.Settings, error) {
 	// Parse flags and init logging.
-	if !flag.Parsed() {
-		flag.Parse()
+	if !config.Parsed() {
+		config.Parse()
 	}
 
 	return resource.SettingsFromCommandLine(testID)


### PR DESCRIPTION
* any flag beginning with `istio.test` registered via the built-in `flag`package can also be specified by a YAML config file
* by default we allow the `flag.Value` parsing behavior; if the value is `true` in YAML we give that to `value.Set` which in turn does `ParseBool`
* Optionally, whenusing `flag.Var` and a custom type, you can also implement `config.Value`, a superset of `flag.Value`. This means we can allow parsing strings like `0:1,1:1` OR simply reading map values. The `IstioVersions` `RevMap` is an example of this.

A follow will include allowing us to embed the `istio.test.topology` in this larger config file. 

I've tested these changes locally using different combinations. Here is an example that will exercise a simple boolean flag, and one of these more complex map-based flags:

```yaml
istio:
  test:
    analyze: true
    versions:
      rev-a: 1.7.3
      rev-b: 1.8.2
      rev-c: 1.9.0
```
