### PR TITLE
Do not write namespace configmap for k8s cert provider (#32052)

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -1156,6 +1156,12 @@ func (s *Server) fetchCARoot() map[string]string {
 	if s.CA == nil {
 		return nil
 	}
+
+	// For Kubernetes CA, we don't distribute it; it is mounted in all pods by Kubernetes.
+	if features.PilotCertProvider.Get() == KubernetesCAProvider {
+		return nil
+	}
+
 	return map[string]string{
 		constants.CACertNamespaceConfigMapDataName: string(s.CA.GetCAKeyCertBundle().GetRootCertPem()),
 	}


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/32023

(cherry picked from commit 439c0ab15027113a70f8076e4c399bcb77532746)



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.