### PR TITLE
operator init: make replicas configurable

### DIFF
--- a/manifests/charts/istio-operator/templates/deployment.yaml
+++ b/manifests/charts/istio-operator/templates/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   namespace: {{.Release.Namespace}}
   name: istio-operator{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
 spec:
-  replicas: 1
+  replicas: {{.Values.replicaCount}}
   selector:
     matchLabels:
       name: istio-operator

--- a/manifests/charts/istio-operator/values.yaml
+++ b/manifests/charts/istio-operator/values.yaml
@@ -5,6 +5,11 @@ tag: latest
 # used to pull operator image. Must be set for any cluster configured with private docker registry.
 imagePullSecrets: []
 
+operatorNamespace: istio-operator
+
+# Number of replicas to use for Operator deployment.
+replicaCount: 1
+
 # Used to replace istioNamespace to support operator watch multiple namespaces.
 watchedNamespaces: istio-system
 waitForResourcesTimeout: 300s


### PR DESCRIPTION
To fix https://github.com/istio/istio/issues/32214

You can use helm to configure replicaCount or override values using -f in operator int.
```
$ helm install istio-operator manifests/charts/istio-operator --set replicaCount=3
```