### PR TITLE
change kubeclient get call to lister call in namespace controller

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/namespacecontroller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/namespacecontroller.go
@@ -15,13 +15,13 @@
 package controller
 
 import (
-	"context"
 	"fmt"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	listerv1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 
 	"istio.io/istio/pkg/kube"
@@ -49,6 +49,8 @@ type NamespaceController struct {
 	queue              queue.Instance
 	namespacesInformer cache.SharedInformer
 	configMapInformer  cache.SharedInformer
+	namespaceLister    listerv1.NamespaceLister
+	configmapLister    listerv1.ConfigMapLister
 }
 
 // NewNamespaceController returns a pointer to a newly constructed NamespaceController instance.
@@ -60,6 +62,10 @@ func NewNamespaceController(data func() map[string]string, kubeClient kube.Clien
 	}
 
 	c.configMapInformer = kubeClient.KubeInformer().Core().V1().ConfigMaps().Informer()
+	c.configmapLister = kubeClient.KubeInformer().Core().V1().ConfigMaps().Lister()
+	c.namespacesInformer = kubeClient.KubeInformer().Core().V1().Namespaces().Informer()
+	c.namespaceLister = kubeClient.KubeInformer().Core().V1().Namespaces().Lister()
+
 	c.configMapInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		UpdateFunc: func(_, obj interface{}) {
 			cm, err := convertToConfigMap(obj)
@@ -84,7 +90,7 @@ func NewNamespaceController(data func() map[string]string, kubeClient kube.Clien
 				return
 			}
 			c.queue.Push(func() error {
-				ns, err := kubeClient.CoreV1().Namespaces().Get(context.TODO(), cm.Namespace, metav1.GetOptions{})
+				ns, err := c.namespaceLister.Get(cm.Namespace)
 				if err != nil {
 					return err
 				}
@@ -98,7 +104,6 @@ func NewNamespaceController(data func() map[string]string, kubeClient kube.Clien
 		},
 	})
 
-	c.namespacesInformer = kubeClient.KubeInformer().Core().V1().Namespaces().Informer()
 	c.namespacesInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			c.queue.Push(func() error {
@@ -131,7 +136,7 @@ func (nc *NamespaceController) insertDataForNamespace(ns string) error {
 		Namespace: ns,
 		Labels:    configMapLabel,
 	}
-	return k8s.InsertDataToConfigMap(nc.client, meta, nc.getData())
+	return k8s.InsertDataToConfigMap(nc.client, nc.configmapLister, meta, nc.getData())
 }
 
 // On namespace change, update the config map.

--- a/pilot/pkg/serviceregistry/kube/controller/namespacecontroller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/namespacecontroller_test.go
@@ -36,7 +36,7 @@ func TestNamespaceController(t *testing.T) {
 	nc := NewNamespaceController(func() map[string]string {
 		return testdata
 	}, client)
-
+	nc.configmapLister = client.KubeInformer().Core().V1().ConfigMaps().Lister()
 	stop := make(chan struct{})
 	client.RunAndWait(stop)
 	nc.Run(stop)
@@ -45,7 +45,8 @@ func TestNamespaceController(t *testing.T) {
 	expectConfigMap(t, client, "foo", testdata)
 
 	newData := map[string]string{"key": "value", "foo": "bar"}
-	if err := k8s.InsertDataToConfigMap(client.CoreV1(), metav1.ObjectMeta{Name: CACertNamespaceConfigMap, Namespace: "foo"}, newData); err != nil {
+	if err := k8s.InsertDataToConfigMap(client.CoreV1(), nc.configmapLister,
+		metav1.ObjectMeta{Name: CACertNamespaceConfigMap, Namespace: "foo"}, newData); err != nil {
 		t.Fatal(err)
 	}
 	expectConfigMap(t, client, "foo", newData)
@@ -56,6 +57,10 @@ func TestNamespaceController(t *testing.T) {
 
 func deleteConfigMap(t *testing.T, client kubernetes.Interface, ns string) {
 	t.Helper()
+	_, err := client.CoreV1().ConfigMaps(ns).Get(context.TODO(), CACertNamespaceConfigMap, metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
 	if err := client.CoreV1().ConfigMaps(ns).Delete(context.TODO(), CACertNamespaceConfigMap, metav1.DeleteOptions{}); err != nil {
 		t.Fatal(err)
 	}

--- a/security/pkg/k8s/configutil.go
+++ b/security/pkg/k8s/configutil.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	listerv1 "k8s.io/client-go/listers/core/v1"
 )
 
 // InsertDataToConfigMap inserts a data to a configmap in a namespace.
@@ -30,8 +31,8 @@ import (
 // value: the value of the data to insert.
 // configName: the name of the configmap.
 // dataName: the name of the data in the configmap.
-func InsertDataToConfigMap(client corev1.ConfigMapsGetter, meta metav1.ObjectMeta, data map[string]string) error {
-	configmap, err := client.ConfigMaps(meta.Namespace).Get(context.TODO(), meta.Name, metav1.GetOptions{})
+func InsertDataToConfigMap(client corev1.ConfigMapsGetter, lister listerv1.ConfigMapLister, meta metav1.ObjectMeta, data map[string]string) error {
+	configmap, err := lister.ConfigMaps(meta.Namespace).Get(meta.Name)
 	if err != nil && !errors.IsNotFound(err) {
 		return fmt.Errorf("error when getting configmap %v: %v", meta.Name, err)
 	}


### PR DESCRIPTION
Please provide a description for what this PR is for.
We are deploying istio in very large cluster, I reviewed current Istio code, and trying to see if there is unnecessary call to apiserver, and the only finding is in namespace controller istiod is getting namespace and configmap from apiserver directly even though the lister is there available in the code.
Our large cluster have around 15000 namespace now, and this PR change the kube client get to lister get to avoid thousands of get calls for namespaces and thousands of get calls for configmap.
And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[X] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any changes that may affect Istio users.
