### PR TITLE
CA: simplify sign interfaces by passing a cert opts struct

### DIFF
--- a/security/pkg/pki/ca/ca.go
+++ b/security/pkg/pki/ca/ca.go
@@ -303,13 +303,13 @@ func (ca *IstioCA) Run(stopChan chan struct{}) {
 
 // Sign takes a PEM-encoded CSR and cert opts, and returns a signed certificate.
 // TODO(myidpt): Add error code to identify the Sign error types.
-func (ca *IstioCA) Sign(csrPEM []byte, certOpts *CertOpts) (
+func (ca *IstioCA) Sign(csrPEM []byte, certOpts CertOpts) (
 	[]byte, error) {
 	return ca.sign(csrPEM, certOpts.SubjectIDs, certOpts.TTL, true, certOpts.ForCA)
 }
 
 // SignWithCertChain is similar to Sign but returns the leaf cert and the entire cert chain.
-func (ca *IstioCA) SignWithCertChain(csrPEM []byte, certOpts *CertOpts) (
+func (ca *IstioCA) SignWithCertChain(csrPEM []byte, certOpts CertOpts) (
 	[]byte, error) {
 	return ca.signWithCertChain(csrPEM, certOpts.SubjectIDs, certOpts.TTL, true, certOpts.ForCA)
 }

--- a/security/pkg/pki/ca/ca.go
+++ b/security/pkg/pki/ca/ca.go
@@ -75,15 +75,6 @@ type CertOpts struct {
 	ForCA bool
 }
 
-// NewCertOpts creates new cert options based on the given inputs.
-func NewCertOpts(subjectIDs []string, ttl time.Duration, forCA bool) *CertOpts {
-	return &CertOpts{
-		subjectIDs,
-		ttl,
-		forCA,
-	}
-}
-
 const (
 	// selfSignedCA means the Istio CA uses a self signed certificate.
 	selfSignedCA caTypes = iota

--- a/security/pkg/pki/ca/ca_test.go
+++ b/security/pkg/pki/ca/ca_test.go
@@ -374,7 +374,7 @@ func TestSignCSRForWorkload(t *testing.T) {
 		}
 
 		requestedTTL := 30 * time.Minute
-		caCertOpts := &CertOpts{
+		caCertOpts := CertOpts{
 			SubjectIDs: []string{subjectID},
 			TTL:        requestedTTL,
 			ForCA:      false,
@@ -452,7 +452,7 @@ func TestSignCSRForCA(t *testing.T) {
 		}
 
 		requestedTTL := 30 * 24 * time.Hour
-		caCertOpts := &CertOpts{
+		caCertOpts := CertOpts{
 			SubjectIDs: []string{subjectID},
 			TTL:        requestedTTL,
 			ForCA:      true,
@@ -528,7 +528,7 @@ func TestSignCSRTTLError(t *testing.T) {
 			t.Errorf("%s: createCA error: %v", id, err)
 		}
 
-		caCertOpts := &CertOpts{
+		caCertOpts := CertOpts{
 			SubjectIDs: []string{subjectID},
 			TTL:        3 * time.Hour,
 			ForCA:      false,
@@ -607,7 +607,7 @@ func TestSignWithCertChain(t *testing.T) {
 		t.Error(err)
 	}
 
-	caCertOpts := &CertOpts{
+	caCertOpts := CertOpts{
 		SubjectIDs: []string{"localhost"},
 		TTL:        time.Hour,
 		ForCA:      false,

--- a/security/pkg/pki/ca/ca_test.go
+++ b/security/pkg/pki/ca/ca_test.go
@@ -374,7 +374,12 @@ func TestSignCSRForWorkload(t *testing.T) {
 		}
 
 		requestedTTL := 30 * time.Minute
-		certPEM, signErr := ca.Sign(csrPEM, NewCertOpts([]string{subjectID}, requestedTTL, false))
+		caCertOpts := &CertOpts{
+			SubjectIDs: []string{subjectID},
+			TTL:        requestedTTL,
+			ForCA:      false,
+		}
+		certPEM, signErr := ca.Sign(csrPEM, caCertOpts)
 		if signErr != nil {
 			t.Errorf("%s: Sign error: %v", id, err)
 		}
@@ -447,7 +452,12 @@ func TestSignCSRForCA(t *testing.T) {
 		}
 
 		requestedTTL := 30 * 24 * time.Hour
-		certPEM, signErr := ca.Sign(csrPEM, NewCertOpts([]string{subjectID}, requestedTTL, true))
+		caCertOpts := &CertOpts{
+			SubjectIDs: []string{subjectID},
+			TTL:        requestedTTL,
+			ForCA:      true,
+		}
+		certPEM, signErr := ca.Sign(csrPEM, caCertOpts)
 		if signErr != nil {
 			t.Errorf("%s: Sign error: %v", id, err)
 		}
@@ -518,8 +528,12 @@ func TestSignCSRTTLError(t *testing.T) {
 			t.Errorf("%s: createCA error: %v", id, err)
 		}
 
-		ttl := 3 * time.Hour
-		cert, signErr := ca.Sign(csrPEM, NewCertOpts([]string{subjectID}, ttl, false))
+		caCertOpts := &CertOpts{
+			SubjectIDs: []string{subjectID},
+			TTL:        3 * time.Hour,
+			ForCA:      false,
+		}
+		cert, signErr := ca.Sign(csrPEM, caCertOpts)
 		if cert != nil {
 			t.Errorf("%s: Expected null cert be obtained a non-null cert.", id)
 		}
@@ -593,7 +607,12 @@ func TestSignWithCertChain(t *testing.T) {
 		t.Error(err)
 	}
 
-	certPEM, signErr := ca.SignWithCertChain(csrPEM, NewCertOpts([]string{"localhost"}, time.Hour, false))
+	caCertOpts := &CertOpts{
+		SubjectIDs: []string{"localhost"},
+		TTL:        time.Hour,
+		ForCA:      false,
+	}
+	certPEM, signErr := ca.SignWithCertChain(csrPEM, caCertOpts)
 	if signErr != nil {
 		t.Error(err)
 	}

--- a/security/pkg/pki/ca/ca_test.go
+++ b/security/pkg/pki/ca/ca_test.go
@@ -374,7 +374,7 @@ func TestSignCSRForWorkload(t *testing.T) {
 		}
 
 		requestedTTL := 30 * time.Minute
-		certPEM, signErr := ca.Sign(csrPEM, []string{subjectID}, requestedTTL, false)
+		certPEM, signErr := ca.Sign(csrPEM, NewCertOpts([]string{subjectID}, requestedTTL, false))
 		if signErr != nil {
 			t.Errorf("%s: Sign error: %v", id, err)
 		}
@@ -447,7 +447,7 @@ func TestSignCSRForCA(t *testing.T) {
 		}
 
 		requestedTTL := 30 * 24 * time.Hour
-		certPEM, signErr := ca.Sign(csrPEM, []string{subjectID}, requestedTTL, true)
+		certPEM, signErr := ca.Sign(csrPEM, NewCertOpts([]string{subjectID}, requestedTTL, true))
 		if signErr != nil {
 			t.Errorf("%s: Sign error: %v", id, err)
 		}
@@ -519,8 +519,7 @@ func TestSignCSRTTLError(t *testing.T) {
 		}
 
 		ttl := 3 * time.Hour
-
-		cert, signErr := ca.Sign(csrPEM, []string{subjectID}, ttl, false)
+		cert, signErr := ca.Sign(csrPEM, NewCertOpts([]string{subjectID}, ttl, false))
 		if cert != nil {
 			t.Errorf("%s: Expected null cert be obtained a non-null cert.", id)
 		}
@@ -594,7 +593,7 @@ func TestSignWithCertChain(t *testing.T) {
 		t.Error(err)
 	}
 
-	certPEM, signErr := ca.SignWithCertChain(csrPEM, []string{"localhost"}, time.Hour, false)
+	certPEM, signErr := ca.SignWithCertChain(csrPEM, NewCertOpts([]string{"localhost"}, time.Hour, false))
 	if signErr != nil {
 		t.Error(err)
 	}

--- a/security/pkg/pki/ca/mock/fakeca.go
+++ b/security/pkg/pki/ca/mock/fakeca.go
@@ -29,7 +29,7 @@ type FakeCA struct {
 }
 
 // Sign returns the SignErr if SignErr is not nil, otherwise, it returns SignedCert.
-func (ca *FakeCA) Sign(csr []byte, certOpts *ca.CertOpts) ([]byte, error) {
+func (ca *FakeCA) Sign(csr []byte, certOpts ca.CertOpts) ([]byte, error) {
 	ca.ReceivedIDs = certOpts.SubjectIDs
 	if ca.SignErr != nil {
 		return nil, ca.SignErr
@@ -38,7 +38,7 @@ func (ca *FakeCA) Sign(csr []byte, certOpts *ca.CertOpts) ([]byte, error) {
 }
 
 // SignWithCertChain returns the SignErr if SignErr is not nil, otherwise, it returns SignedCert and the cert chain.
-func (ca *FakeCA) SignWithCertChain(csr []byte, certOpts *ca.CertOpts) ([]byte, error) {
+func (ca *FakeCA) SignWithCertChain(csr []byte, certOpts ca.CertOpts) ([]byte, error) {
 	if ca.SignErr != nil {
 		return nil, ca.SignErr
 	}

--- a/security/pkg/pki/ca/mock/fakeca.go
+++ b/security/pkg/pki/ca/mock/fakeca.go
@@ -15,8 +15,7 @@
 package mock
 
 import (
-	"time"
-
+	"istio.io/istio/security/pkg/pki/ca"
 	caerror "istio.io/istio/security/pkg/pki/error"
 	"istio.io/istio/security/pkg/pki/util"
 )
@@ -30,8 +29,8 @@ type FakeCA struct {
 }
 
 // Sign returns the SignErr if SignErr is not nil, otherwise, it returns SignedCert.
-func (ca *FakeCA) Sign(csr []byte, identities []string, lifetime time.Duration, forCA bool) ([]byte, error) {
-	ca.ReceivedIDs = identities
+func (ca *FakeCA) Sign(csr []byte, certOpts *ca.CertOpts) ([]byte, error) {
+	ca.ReceivedIDs = certOpts.SubjectIDs
 	if ca.SignErr != nil {
 		return nil, ca.SignErr
 	}
@@ -39,7 +38,7 @@ func (ca *FakeCA) Sign(csr []byte, identities []string, lifetime time.Duration, 
 }
 
 // SignWithCertChain returns the SignErr if SignErr is not nil, otherwise, it returns SignedCert and the cert chain.
-func (ca *FakeCA) SignWithCertChain(csr []byte, identities []string, lifetime time.Duration, forCA bool) ([]byte, error) {
+func (ca *FakeCA) SignWithCertChain(csr []byte, certOpts *ca.CertOpts) ([]byte, error) {
 	if ca.SignErr != nil {
 		return nil, ca.SignErr
 	}

--- a/security/pkg/pki/ra/k8s_ra.go
+++ b/security/pkg/pki/ra/k8s_ra.go
@@ -16,12 +16,12 @@ package ra
 
 import (
 	"fmt"
-	"time"
 
 	cert "k8s.io/api/certificates/v1beta1"
 	certclient "k8s.io/client-go/kubernetes/typed/certificates/v1beta1"
 
 	"istio.io/istio/security/pkg/k8s/chiron"
+	"istio.io/istio/security/pkg/pki/ca"
 	raerror "istio.io/istio/security/pkg/pki/error"
 	"istio.io/istio/security/pkg/pki/util"
 )
@@ -66,9 +66,9 @@ func (r *KubernetesRA) kubernetesSign(csrPEM []byte, csrName string, caCertFile 
 	return certChain, err
 }
 
-// Sign takes a PEM-encoded CSR, subject IDs and lifetime, and returns a certificate signed by k8s CA.
-func (r *KubernetesRA) Sign(csrPEM []byte, subjectIDs []string, requestedLifetime time.Duration, forCA bool) ([]byte, error) {
-	_, err := preSign(r.raOpts, csrPEM, subjectIDs, requestedLifetime, forCA)
+// Sign takes a PEM-encoded CSR and cert opts, and returns a certificate signed by k8s CA.
+func (r *KubernetesRA) Sign(csrPEM []byte, certOpts *ca.CertOpts) ([]byte, error) {
+	_, err := preSign(r.raOpts, csrPEM, certOpts.SubjectIDs, certOpts.TTL, certOpts.ForCA)
 	if err != nil {
 		return nil, err
 	}
@@ -77,8 +77,8 @@ func (r *KubernetesRA) Sign(csrPEM []byte, subjectIDs []string, requestedLifetim
 }
 
 // SignWithCertChain is similar to Sign but returns the leaf cert and the entire cert chain.
-func (r *KubernetesRA) SignWithCertChain(csrPEM []byte, subjectIDs []string, ttl time.Duration, forCA bool) ([]byte, error) {
-	cert, err := r.Sign(csrPEM, subjectIDs, ttl, forCA)
+func (r *KubernetesRA) SignWithCertChain(csrPEM []byte, certOpts *ca.CertOpts) ([]byte, error) {
+	cert, err := r.Sign(csrPEM, certOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/security/pkg/pki/ra/k8s_ra.go
+++ b/security/pkg/pki/ra/k8s_ra.go
@@ -67,7 +67,7 @@ func (r *KubernetesRA) kubernetesSign(csrPEM []byte, csrName string, caCertFile 
 }
 
 // Sign takes a PEM-encoded CSR and cert opts, and returns a certificate signed by k8s CA.
-func (r *KubernetesRA) Sign(csrPEM []byte, certOpts *ca.CertOpts) ([]byte, error) {
+func (r *KubernetesRA) Sign(csrPEM []byte, certOpts ca.CertOpts) ([]byte, error) {
 	_, err := preSign(r.raOpts, csrPEM, certOpts.SubjectIDs, certOpts.TTL, certOpts.ForCA)
 	if err != nil {
 		return nil, err
@@ -77,7 +77,7 @@ func (r *KubernetesRA) Sign(csrPEM []byte, certOpts *ca.CertOpts) ([]byte, error
 }
 
 // SignWithCertChain is similar to Sign but returns the leaf cert and the entire cert chain.
-func (r *KubernetesRA) SignWithCertChain(csrPEM []byte, certOpts *ca.CertOpts) ([]byte, error) {
+func (r *KubernetesRA) SignWithCertChain(csrPEM []byte, certOpts ca.CertOpts) ([]byte, error) {
 	cert, err := r.Sign(csrPEM, certOpts)
 	if err != nil {
 		return nil, err

--- a/security/pkg/server/ca/server.go
+++ b/security/pkg/server/ca/server.go
@@ -37,9 +37,9 @@ var serverCaLog = log.RegisterScope("serverca", "Citadel server log", 0)
 // CertificateAuthority contains methods to be supported by a CA.
 type CertificateAuthority interface {
 	// Sign generates a certificate for a workload or CA, from the given CSR and cert opts.
-	Sign(csrPEM []byte, opt *ca.CertOpts) ([]byte, error)
+	Sign(csrPEM []byte, opts ca.CertOpts) ([]byte, error)
 	// SignWithCertChain is similar to Sign but returns the leaf cert and the entire cert chain.
-	SignWithCertChain(csrPEM []byte, opt *ca.CertOpts) ([]byte, error)
+	SignWithCertChain(csrPEM []byte, opts ca.CertOpts) ([]byte, error)
 	// GetCAKeyCertBundle returns the KeyCertBundle used by CA.
 	GetCAKeyCertBundle() *util.KeyCertBundle
 }
@@ -80,7 +80,7 @@ func (s *Server) CreateCertificate(ctx context.Context, request *pb.IstioCertifi
 	// TODO: Call authorizer.
 
 	_, _, certChainBytes, rootCertBytes := s.ca.GetCAKeyCertBundle().GetAll()
-	certOpts := &ca.CertOpts{
+	certOpts := ca.CertOpts{
 		SubjectIDs: caller.Identities,
 		TTL:        time.Duration(request.ValidityDuration) * time.Second,
 		ForCA:      false,

--- a/security/pkg/server/ca/server.go
+++ b/security/pkg/server/ca/server.go
@@ -26,6 +26,7 @@ import (
 
 	pb "istio.io/api/security/v1alpha1"
 	"istio.io/istio/pkg/security"
+	"istio.io/istio/security/pkg/pki/ca"
 	caerror "istio.io/istio/security/pkg/pki/error"
 	"istio.io/istio/security/pkg/pki/util"
 	"istio.io/pkg/log"
@@ -35,11 +36,10 @@ var serverCaLog = log.RegisterScope("serverca", "Citadel server log", 0)
 
 // CertificateAuthority contains methods to be supported by a CA.
 type CertificateAuthority interface {
-	// Sign generates a certificate for a workload or CA, from the given CSR and TTL.
-	// TODO(myidpt): simplify this interface and pass a struct with cert field values instead.
-	Sign(csrPEM []byte, subjectIDs []string, ttl time.Duration, forCA bool) ([]byte, error)
+	// Sign generates a certificate for a workload or CA, from the given CSR and cert opts.
+	Sign(csrPEM []byte, opt *ca.CertOpts) ([]byte, error)
 	// SignWithCertChain is similar to Sign but returns the leaf cert and the entire cert chain.
-	SignWithCertChain(csrPEM []byte, subjectIDs []string, ttl time.Duration, forCA bool) ([]byte, error)
+	SignWithCertChain(csrPEM []byte, opt *ca.CertOpts) ([]byte, error)
 	// GetCAKeyCertBundle returns the KeyCertBundle used by CA.
 	GetCAKeyCertBundle() *util.KeyCertBundle
 }
@@ -80,8 +80,8 @@ func (s *Server) CreateCertificate(ctx context.Context, request *pb.IstioCertifi
 	// TODO: Call authorizer.
 
 	_, _, certChainBytes, rootCertBytes := s.ca.GetCAKeyCertBundle().GetAll()
-	cert, signErr := s.ca.Sign(
-		[]byte(request.Csr), caller.Identities, time.Duration(request.ValidityDuration)*time.Second, false)
+	certOpts := ca.NewCertOpts(caller.Identities, time.Duration(request.ValidityDuration)*time.Second, false)
+	cert, signErr := s.ca.Sign([]byte(request.Csr), certOpts)
 	if signErr != nil {
 		serverCaLog.Errorf("CSR signing error (%v)", signErr.Error())
 		s.monitoring.GetCertSignError(signErr.(*caerror.Error).ErrorType()).Increment()

--- a/security/pkg/server/ca/server.go
+++ b/security/pkg/server/ca/server.go
@@ -80,7 +80,11 @@ func (s *Server) CreateCertificate(ctx context.Context, request *pb.IstioCertifi
 	// TODO: Call authorizer.
 
 	_, _, certChainBytes, rootCertBytes := s.ca.GetCAKeyCertBundle().GetAll()
-	certOpts := ca.NewCertOpts(caller.Identities, time.Duration(request.ValidityDuration)*time.Second, false)
+	certOpts := &ca.CertOpts{
+		SubjectIDs: caller.Identities,
+		TTL:        time.Duration(request.ValidityDuration) * time.Second,
+		ForCA:      false,
+	}
 	cert, signErr := s.ca.Sign([]byte(request.Csr), certOpts)
 	if signErr != nil {
 		serverCaLog.Errorf("CSR signing error (%v)", signErr.Error())


### PR DESCRIPTION
This patch proposes to simplify `Sign*` interfaces of `CertificateAuthority` by
passing a struct with cert field values instead. This may also help with further
extensions of the input options applied by the certificate generation.

Signed-off-by: Kailun Qin <kailun.qin@intel.com>

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[x] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any changes that may affect Istio users.
