### PR TITLE
Fix returnStatusToPool

### DIFF
--- a/galley/pkg/config/source/kube/apiserver/status/status.go
+++ b/galley/pkg/config/source/kube/apiserver/status/status.go
@@ -63,6 +63,8 @@ func returnStatusToPool(s *status) {
 	s.observedVersion = ""
 	s.desiredStatus = nil
 	s.desiredStatusVersion = ""
+	s.next = nil
+	statusPool.Put(s)
 }
 
 func (r *status) setObserved(v resource.Version, status interface{}) bool {


### PR DESCRIPTION
https://github.com/istio/istio/blob/5f5cd773bbcedfb91ae1030211c08d49a9a7d67b/galley/pkg/config/source/kube/apiserver/status/status.go#L48-L66

``` diff
var statusPool = sync.Pool{
	New: func() interface{} {
		return &status{}
	},
}
func getStatusFromPool(k key) *status {
	st := statusPool.Get().(*status)
	st.key = k
	return st
}
func returnStatusToPool(s *status) {
	s.key = key{}
	s.observedStatus = nil
	s.observedVersion = ""
	s.desiredStatus = nil
	s.desiredStatusVersion = ""
+++	s.next = nil
+++	statusPool.Put(s)
}
```

Obtained from the statusPool will not be returned after use.  this PR adds the logic.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[x] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any changes that may affect Istio users.
