### PR TITLE
Cherry-pick dry-run observability support in 1.10

### DIFF
--- a/pilot/pkg/security/authz/builder/extauthz.go
+++ b/pilot/pkg/security/authz/builder/extauthz.go
@@ -354,7 +354,7 @@ func generateFilterMatcher(name string) *envoy_type_matcher_v3.MetadataMatcher {
 		Path: []*envoy_type_matcher_v3.MetadataMatcher_PathSegment{
 			{
 				Segment: &envoy_type_matcher_v3.MetadataMatcher_PathSegment_Key{
-					Key: "shadow_effective_policy_id",
+					Key: authzmodel.RBACExtAuthzShadowRulesStatPrefix + authzmodel.RBACShadowEffectivePolicyID,
 				},
 			},
 		},

--- a/pilot/pkg/security/authz/builder/testdata/http/custom-grpc-provider-no-namespace-out1.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/custom-grpc-provider-no-namespace-out1.yaml
@@ -30,3 +30,4 @@ typedConfig:
         - andIds:
             ids:
             - any: true
+  shadowRulesStatPrefix: istio_ext_authz_

--- a/pilot/pkg/security/authz/builder/testdata/http/custom-grpc-provider-no-namespace-out2.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/custom-grpc-provider-no-namespace-out2.yaml
@@ -5,7 +5,7 @@ typedConfig:
   filterEnabledMetadata:
     filter: envoy.filters.http.rbac
     path:
-    - key: shadow_effective_policy_id
+    - key: istio_ext_authz_shadow_effective_policy_id
     value:
       stringMatch:
         prefix: istio-ext-authz

--- a/pilot/pkg/security/authz/builder/testdata/http/custom-grpc-provider-out1.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/custom-grpc-provider-out1.yaml
@@ -30,3 +30,4 @@ typedConfig:
         - andIds:
             ids:
             - any: true
+  shadowRulesStatPrefix: istio_ext_authz_

--- a/pilot/pkg/security/authz/builder/testdata/http/custom-grpc-provider-out2.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/custom-grpc-provider-out2.yaml
@@ -5,7 +5,7 @@ typedConfig:
   filterEnabledMetadata:
     filter: envoy.filters.http.rbac
     path:
-    - key: shadow_effective_policy_id
+    - key: istio_ext_authz_shadow_effective_policy_id
     value:
       stringMatch:
         prefix: istio-ext-authz

--- a/pilot/pkg/security/authz/builder/testdata/http/custom-http-provider-out1.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/custom-http-provider-out1.yaml
@@ -30,3 +30,4 @@ typedConfig:
         - andIds:
             ids:
             - any: true
+  shadowRulesStatPrefix: istio_ext_authz_

--- a/pilot/pkg/security/authz/builder/testdata/http/custom-http-provider-out2.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/custom-http-provider-out2.yaml
@@ -5,7 +5,7 @@ typedConfig:
   filterEnabledMetadata:
     filter: envoy.filters.http.rbac
     path:
-    - key: shadow_effective_policy_id
+    - key: istio_ext_authz_shadow_effective_policy_id
     value:
       stringMatch:
         prefix: istio-ext-authz

--- a/pilot/pkg/security/authz/builder/testdata/tcp/custom-both-http-tcp-out1.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/tcp/custom-both-http-tcp-out1.yaml
@@ -97,4 +97,5 @@ typedConfig:
                   - directRemoteIp:
                       addressPrefix: 9.0.0.1
                       prefixLen: 32
+  shadowRulesStatPrefix: istio_ext_authz_
   statPrefix: tcp.

--- a/pilot/pkg/security/authz/builder/testdata/tcp/custom-both-http-tcp-out2.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/tcp/custom-both-http-tcp-out2.yaml
@@ -5,7 +5,7 @@ typedConfig:
   filterEnabledMetadata:
     filter: envoy.filters.network.rbac
     path:
-    - key: shadow_effective_policy_id
+    - key: istio_ext_authz_shadow_effective_policy_id
     value:
       stringMatch:
         prefix: istio-ext-authz

--- a/pilot/pkg/security/authz/model/model.go
+++ b/pilot/pkg/security/authz/model/model.go
@@ -29,8 +29,13 @@ const (
 	RBACHTTPFilterName = "envoy.filters.http.rbac"
 
 	// RBACTCPFilterName is the name of the RBAC network filter in envoy.
-	RBACTCPFilterName       = "envoy.filters.network.rbac"
-	RBACTCPFilterStatPrefix = "tcp."
+	RBACTCPFilterName                 = "envoy.filters.network.rbac"
+	RBACTCPFilterStatPrefix           = "tcp."
+	RBACShadowEngineResult            = "shadow_engine_result"
+	RBACShadowEffectivePolicyID       = "shadow_effective_policy_id"
+	RBACShadowRulesAllowStatPrefix    = "istio_dry_run_allow_"
+	RBACShadowRulesDenyStatPrefix     = "istio_dry_run_deny_"
+	RBACExtAuthzShadowRulesStatPrefix = "istio_ext_authz_"
 
 	attrRequestHeader    = "request.headers"             // header name is surrounded by brackets, e.g. "request.headers[User-Agent]".
 	attrSrcIP            = "source.ip"                   // supports both single ip and cidr, e.g. "10.1.2.3" or "10.1.0.0/16".

--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -50,6 +50,8 @@ const (
 	// required stats are used by readiness checks.
 	requiredEnvoyStatsMatcherInclusionPrefixes = "cluster_manager,listener_manager,server,cluster.xds-grpc,wasm"
 
+	rbacEnvoyStatsMatcherInclusionSuffix = "rbac.allowed,rbac.denied,shadow_allowed,shadow_denied"
+
 	// Prefixes of V2 metrics.
 	// "reporter" prefix is for istio standard metrics.
 	// "component" suffix is for istio_build metric.
@@ -223,7 +225,8 @@ func getStatsOptions(meta *model.BootstrapNodeMetadata) []option.Instance {
 	return []option.Instance{
 		option.EnvoyStatsMatcherInclusionPrefix(parseOption(meta.StatsInclusionPrefixes,
 			requiredEnvoyStatsMatcherInclusionPrefixes, proxyConfigPrefixes)),
-		option.EnvoyStatsMatcherInclusionSuffix(parseOption(meta.StatsInclusionSuffixes, "", proxyConfigSuffixes)),
+		option.EnvoyStatsMatcherInclusionSuffix(parseOption(meta.StatsInclusionSuffixes,
+			rbacEnvoyStatsMatcherInclusionSuffix, proxyConfigSuffixes)),
 		option.EnvoyStatsMatcherInclusionRegexp(parseOption(meta.StatsInclusionRegexps, "", proxyConfigRegexps)),
 		option.EnvoyExtraStatTags(extraStatTags),
 	}

--- a/pkg/bootstrap/instance_test.go
+++ b/pkg/bootstrap/instance_test.go
@@ -485,6 +485,11 @@ func checkStatsMatcher(t *testing.T, got, want *bootstrap.Bootstrap, stats stats
 	} else {
 		stats.prefixes = v2Prefixes + stats.prefixes + "," + requiredEnvoyStatsMatcherInclusionPrefixes + v2Suffix
 	}
+	if stats.suffixes == "" {
+		stats.suffixes = rbacEnvoyStatsMatcherInclusionSuffix
+	} else {
+		stats.suffixes += "," + rbacEnvoyStatsMatcherInclusionSuffix
+	}
 
 	if err := gsm.Validate(); err != nil {
 		t.Fatalf("Generated invalid matcher: %v", err)

--- a/pkg/bootstrap/testdata/all_golden.json
+++ b/pkg/bootstrap/testdata/all_golden.json
@@ -194,6 +194,18 @@
       {
         "regex": "(wasm_filter\\.(.+?)\\.)",
         "tag_name": "wasm_filter"
+      },
+      {
+        "tag_name": "authz_enforce_result",
+        "regex": "rbac(\\.(allowed|denied))"
+      },
+      {
+        "tag_name": "authz_dry_run_action",
+        "regex": "(\\.istio_dry_run_(allow|deny)_)"
+      },
+      {
+        "tag_name": "authz_dry_run_result",
+        "regex": "(\\.shadow_(allowed|denied))"
       }
     ],
     "stats_matcher": {
@@ -216,6 +228,18 @@
           },
           {
           "prefix": "wasm"
+          },
+          {
+          "suffix": "rbac.allowed"
+          },
+          {
+          "suffix": "rbac.denied"
+          },
+          {
+          "suffix": "shadow_allowed"
+          },
+          {
+          "suffix": "shadow_denied"
           },
           {
           "prefix": "component"

--- a/pkg/bootstrap/testdata/auth_golden.json
+++ b/pkg/bootstrap/testdata/auth_golden.json
@@ -194,6 +194,18 @@
       {
         "regex": "(wasm_filter\\.(.+?)\\.)",
         "tag_name": "wasm_filter"
+      },
+      {
+        "tag_name": "authz_enforce_result",
+        "regex": "rbac(\\.(allowed|denied))"
+      },
+      {
+        "tag_name": "authz_dry_run_action",
+        "regex": "(\\.istio_dry_run_(allow|deny)_)"
+      },
+      {
+        "tag_name": "authz_dry_run_result",
+        "regex": "(\\.shadow_(allowed|denied))"
       }
     ],
     "stats_matcher": {
@@ -216,6 +228,18 @@
           },
           {
           "prefix": "wasm"
+          },
+          {
+          "suffix": "rbac.allowed"
+          },
+          {
+          "suffix": "rbac.denied"
+          },
+          {
+          "suffix": "shadow_allowed"
+          },
+          {
+          "suffix": "shadow_denied"
           },
           {
           "prefix": "component"

--- a/pkg/bootstrap/testdata/authsds_golden.json
+++ b/pkg/bootstrap/testdata/authsds_golden.json
@@ -194,6 +194,18 @@
       {
         "regex": "(wasm_filter\\.(.+?)\\.)",
         "tag_name": "wasm_filter"
+      },
+      {
+        "tag_name": "authz_enforce_result",
+        "regex": "rbac(\\.(allowed|denied))"
+      },
+      {
+        "tag_name": "authz_dry_run_action",
+        "regex": "(\\.istio_dry_run_(allow|deny)_)"
+      },
+      {
+        "tag_name": "authz_dry_run_result",
+        "regex": "(\\.shadow_(allowed|denied))"
       }
     ],
     "stats_matcher": {
@@ -216,6 +228,18 @@
           },
           {
           "prefix": "wasm"
+          },
+          {
+          "suffix": "rbac.allowed"
+          },
+          {
+          "suffix": "rbac.denied"
+          },
+          {
+          "suffix": "shadow_allowed"
+          },
+          {
+          "suffix": "shadow_denied"
           },
           {
           "prefix": "component"

--- a/pkg/bootstrap/testdata/default_golden.json
+++ b/pkg/bootstrap/testdata/default_golden.json
@@ -194,6 +194,18 @@
       {
         "regex": "(wasm_filter\\.(.+?)\\.)",
         "tag_name": "wasm_filter"
+      },
+      {
+        "tag_name": "authz_enforce_result",
+        "regex": "rbac(\\.(allowed|denied))"
+      },
+      {
+        "tag_name": "authz_dry_run_action",
+        "regex": "(\\.istio_dry_run_(allow|deny)_)"
+      },
+      {
+        "tag_name": "authz_dry_run_result",
+        "regex": "(\\.shadow_(allowed|denied))"
       }
     ],
     "stats_matcher": {
@@ -216,6 +228,18 @@
           },
           {
           "prefix": "wasm"
+          },
+          {
+          "suffix": "rbac.allowed"
+          },
+          {
+          "suffix": "rbac.denied"
+          },
+          {
+          "suffix": "shadow_allowed"
+          },
+          {
+          "suffix": "shadow_denied"
           },
           {
           "prefix": "component"

--- a/pkg/bootstrap/testdata/running_golden.json
+++ b/pkg/bootstrap/testdata/running_golden.json
@@ -199,6 +199,18 @@
       {
         "regex": "(wasm_filter\\.(.+?)\\.)",
         "tag_name": "wasm_filter"
+      },
+      {
+        "tag_name": "authz_enforce_result",
+        "regex": "rbac(\\.(allowed|denied))"
+      },
+      {
+        "tag_name": "authz_dry_run_action",
+        "regex": "(\\.istio_dry_run_(allow|deny)_)"
+      },
+      {
+        "tag_name": "authz_dry_run_result",
+        "regex": "(\\.shadow_(allowed|denied))"
       }
     ],
     "stats_matcher": {
@@ -221,6 +233,18 @@
           },
           {
           "prefix": "wasm"
+          },
+          {
+          "suffix": "rbac.allowed"
+          },
+          {
+          "suffix": "rbac.denied"
+          },
+          {
+          "suffix": "shadow_allowed"
+          },
+          {
+          "suffix": "shadow_denied"
           },
           {
           "prefix": "component"

--- a/pkg/bootstrap/testdata/runningsds_golden.json
+++ b/pkg/bootstrap/testdata/runningsds_golden.json
@@ -199,6 +199,18 @@
       {
         "regex": "(wasm_filter\\.(.+?)\\.)",
         "tag_name": "wasm_filter"
+      },
+      {
+        "tag_name": "authz_enforce_result",
+        "regex": "rbac(\\.(allowed|denied))"
+      },
+      {
+        "tag_name": "authz_dry_run_action",
+        "regex": "(\\.istio_dry_run_(allow|deny)_)"
+      },
+      {
+        "tag_name": "authz_dry_run_result",
+        "regex": "(\\.shadow_(allowed|denied))"
       }
     ],
     "stats_matcher": {
@@ -221,6 +233,18 @@
           },
           {
           "prefix": "wasm"
+          },
+          {
+          "suffix": "rbac.allowed"
+          },
+          {
+          "suffix": "rbac.denied"
+          },
+          {
+          "suffix": "shadow_allowed"
+          },
+          {
+          "suffix": "shadow_denied"
           },
           {
           "prefix": "component"

--- a/pkg/bootstrap/testdata/stats_inclusion_golden.json
+++ b/pkg/bootstrap/testdata/stats_inclusion_golden.json
@@ -206,6 +206,18 @@
       {
         "regex": "(wasm_filter\\.(.+?)\\.)",
         "tag_name": "wasm_filter"
+      },
+      {
+        "tag_name": "authz_enforce_result",
+        "regex": "rbac(\\.(allowed|denied))"
+      },
+      {
+        "tag_name": "authz_dry_run_action",
+        "regex": "(\\.istio_dry_run_(allow|deny)_)"
+      },
+      {
+        "tag_name": "authz_dry_run_result",
+        "regex": "(\\.shadow_(allowed|denied))"
       }
     ],
     "stats_matcher": {
@@ -228,6 +240,18 @@
           },
           {
           "prefix": "wasm"
+          },
+          {
+          "suffix": "rbac.allowed"
+          },
+          {
+          "suffix": "rbac.denied"
+          },
+          {
+          "suffix": "shadow_allowed"
+          },
+          {
+          "suffix": "shadow_denied"
           },
           {
           "safe_regex": {"google_re2":{}, "regex":"http.[0-9]*\\.[0-9]*\\.[0-9]*\\.[0-9]*_8080.downstream_rq_time"}

--- a/pkg/bootstrap/testdata/tracing_datadog_golden.json
+++ b/pkg/bootstrap/testdata/tracing_datadog_golden.json
@@ -194,6 +194,18 @@
       {
         "regex": "(wasm_filter\\.(.+?)\\.)",
         "tag_name": "wasm_filter"
+      },
+      {
+        "tag_name": "authz_enforce_result",
+        "regex": "rbac(\\.(allowed|denied))"
+      },
+      {
+        "tag_name": "authz_dry_run_action",
+        "regex": "(\\.istio_dry_run_(allow|deny)_)"
+      },
+      {
+        "tag_name": "authz_dry_run_result",
+        "regex": "(\\.shadow_(allowed|denied))"
       }
     ],
     "stats_matcher": {
@@ -216,6 +228,18 @@
           },
           {
           "prefix": "wasm"
+          },
+          {
+          "suffix": "rbac.allowed"
+          },
+          {
+          "suffix": "rbac.denied"
+          },
+          {
+          "suffix": "shadow_allowed"
+          },
+          {
+          "suffix": "shadow_denied"
           },
           {
           "prefix": "component"

--- a/pkg/bootstrap/testdata/tracing_lightstep_golden.json
+++ b/pkg/bootstrap/testdata/tracing_lightstep_golden.json
@@ -194,6 +194,18 @@
       {
         "regex": "(wasm_filter\\.(.+?)\\.)",
         "tag_name": "wasm_filter"
+      },
+      {
+        "tag_name": "authz_enforce_result",
+        "regex": "rbac(\\.(allowed|denied))"
+      },
+      {
+        "tag_name": "authz_dry_run_action",
+        "regex": "(\\.istio_dry_run_(allow|deny)_)"
+      },
+      {
+        "tag_name": "authz_dry_run_result",
+        "regex": "(\\.shadow_(allowed|denied))"
       }
     ],
     "stats_matcher": {
@@ -216,6 +228,18 @@
           },
           {
           "prefix": "wasm"
+          },
+          {
+          "suffix": "rbac.allowed"
+          },
+          {
+          "suffix": "rbac.denied"
+          },
+          {
+          "suffix": "shadow_allowed"
+          },
+          {
+          "suffix": "shadow_denied"
           },
           {
           "prefix": "component"

--- a/pkg/bootstrap/testdata/tracing_opencensusagent_golden.json
+++ b/pkg/bootstrap/testdata/tracing_opencensusagent_golden.json
@@ -194,6 +194,18 @@
       {
         "regex": "(wasm_filter\\.(.+?)\\.)",
         "tag_name": "wasm_filter"
+      },
+      {
+        "tag_name": "authz_enforce_result",
+        "regex": "rbac(\\.(allowed|denied))"
+      },
+      {
+        "tag_name": "authz_dry_run_action",
+        "regex": "(\\.istio_dry_run_(allow|deny)_)"
+      },
+      {
+        "tag_name": "authz_dry_run_result",
+        "regex": "(\\.shadow_(allowed|denied))"
       }
     ],
     "stats_matcher": {
@@ -216,6 +228,18 @@
           },
           {
           "prefix": "wasm"
+          },
+          {
+          "suffix": "rbac.allowed"
+          },
+          {
+          "suffix": "rbac.denied"
+          },
+          {
+          "suffix": "shadow_allowed"
+          },
+          {
+          "suffix": "shadow_denied"
           },
           {
           "prefix": "component"

--- a/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
+++ b/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
@@ -194,6 +194,18 @@
       {
         "regex": "(wasm_filter\\.(.+?)\\.)",
         "tag_name": "wasm_filter"
+      },
+      {
+        "tag_name": "authz_enforce_result",
+        "regex": "rbac(\\.(allowed|denied))"
+      },
+      {
+        "tag_name": "authz_dry_run_action",
+        "regex": "(\\.istio_dry_run_(allow|deny)_)"
+      },
+      {
+        "tag_name": "authz_dry_run_result",
+        "regex": "(\\.shadow_(allowed|denied))"
       }
     ],
     "stats_matcher": {
@@ -216,6 +228,18 @@
           },
           {
           "prefix": "wasm"
+          },
+          {
+          "suffix": "rbac.allowed"
+          },
+          {
+          "suffix": "rbac.denied"
+          },
+          {
+          "suffix": "shadow_allowed"
+          },
+          {
+          "suffix": "shadow_denied"
           },
           {
           "prefix": "component"

--- a/pkg/bootstrap/testdata/tracing_tls_custom_sni_golden.json
+++ b/pkg/bootstrap/testdata/tracing_tls_custom_sni_golden.json
@@ -194,6 +194,18 @@
       {
         "regex": "(wasm_filter\\.(.+?)\\.)",
         "tag_name": "wasm_filter"
+      },
+      {
+        "tag_name": "authz_enforce_result",
+        "regex": "rbac(\\.(allowed|denied))"
+      },
+      {
+        "tag_name": "authz_dry_run_action",
+        "regex": "(\\.istio_dry_run_(allow|deny)_)"
+      },
+      {
+        "tag_name": "authz_dry_run_result",
+        "regex": "(\\.shadow_(allowed|denied))"
       }
     ],
     "stats_matcher": {
@@ -216,6 +228,18 @@
           },
           {
           "prefix": "wasm"
+          },
+          {
+          "suffix": "rbac.allowed"
+          },
+          {
+          "suffix": "rbac.denied"
+          },
+          {
+          "suffix": "shadow_allowed"
+          },
+          {
+          "suffix": "shadow_denied"
           },
           {
           "prefix": "component"

--- a/pkg/bootstrap/testdata/tracing_tls_golden.json
+++ b/pkg/bootstrap/testdata/tracing_tls_golden.json
@@ -194,6 +194,18 @@
       {
         "regex": "(wasm_filter\\.(.+?)\\.)",
         "tag_name": "wasm_filter"
+      },
+      {
+        "tag_name": "authz_enforce_result",
+        "regex": "rbac(\\.(allowed|denied))"
+      },
+      {
+        "tag_name": "authz_dry_run_action",
+        "regex": "(\\.istio_dry_run_(allow|deny)_)"
+      },
+      {
+        "tag_name": "authz_dry_run_result",
+        "regex": "(\\.shadow_(allowed|denied))"
       }
     ],
     "stats_matcher": {
@@ -216,6 +228,18 @@
           },
           {
           "prefix": "wasm"
+          },
+          {
+          "suffix": "rbac.allowed"
+          },
+          {
+          "suffix": "rbac.denied"
+          },
+          {
+          "suffix": "shadow_allowed"
+          },
+          {
+          "suffix": "shadow_denied"
           },
           {
           "prefix": "component"

--- a/pkg/bootstrap/testdata/tracing_zipkin_golden.json
+++ b/pkg/bootstrap/testdata/tracing_zipkin_golden.json
@@ -194,6 +194,18 @@
       {
         "regex": "(wasm_filter\\.(.+?)\\.)",
         "tag_name": "wasm_filter"
+      },
+      {
+        "tag_name": "authz_enforce_result",
+        "regex": "rbac(\\.(allowed|denied))"
+      },
+      {
+        "tag_name": "authz_dry_run_action",
+        "regex": "(\\.istio_dry_run_(allow|deny)_)"
+      },
+      {
+        "tag_name": "authz_dry_run_result",
+        "regex": "(\\.shadow_(allowed|denied))"
       }
     ],
     "stats_matcher": {
@@ -216,6 +228,18 @@
           },
           {
           "prefix": "wasm"
+          },
+          {
+          "suffix": "rbac.allowed"
+          },
+          {
+          "suffix": "rbac.denied"
+          },
+          {
+          "suffix": "shadow_allowed"
+          },
+          {
+          "suffix": "shadow_denied"
           },
           {
           "prefix": "component"

--- a/pkg/bootstrap/testdata/xdsproxy_golden.json
+++ b/pkg/bootstrap/testdata/xdsproxy_golden.json
@@ -194,6 +194,18 @@
       {
         "regex": "(wasm_filter\\.(.+?)\\.)",
         "tag_name": "wasm_filter"
+      },
+      {
+        "tag_name": "authz_enforce_result",
+        "regex": "rbac(\\.(allowed|denied))"
+      },
+      {
+        "tag_name": "authz_dry_run_action",
+        "regex": "(\\.istio_dry_run_(allow|deny)_)"
+      },
+      {
+        "tag_name": "authz_dry_run_result",
+        "regex": "(\\.shadow_(allowed|denied))"
       }
     ],
     "stats_matcher": {
@@ -216,6 +228,18 @@
           },
           {
           "prefix": "wasm"
+          },
+          {
+          "suffix": "rbac.allowed"
+          },
+          {
+          "suffix": "rbac.denied"
+          },
+          {
+          "suffix": "shadow_allowed"
+          },
+          {
+          "suffix": "shadow_denied"
           },
           {
           "prefix": "component"

--- a/tools/packaging/common/envoy_bootstrap.json
+++ b/tools/packaging/common/envoy_bootstrap.json
@@ -99,6 +99,18 @@
       {
         "regex": "(wasm_filter\\.(.+?)\\.)",
         "tag_name": "wasm_filter"
+      },
+      {
+        "tag_name": "authz_enforce_result",
+        "regex": "rbac(\\.(allowed|denied))"
+      },
+      {
+        "tag_name": "authz_dry_run_action",
+        "regex": "(\\.istio_dry_run_(allow|deny)_)"
+      },
+      {
+        "tag_name": "authz_dry_run_result",
+        "regex": "(\\.shadow_(allowed|denied))"
       }
     ],
     "stats_matcher": {


### PR DESCRIPTION
Cherry-pick https://github.com/istio/istio/pull/32011

The API and feature is already in 1.10, this is a follow-up PR for better observability in master. This is the exact change in master, I will send a follow-up PR for release-note only.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[x] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any changes that may affect Istio users.