### PR TITLE
Do not cleanup remote secret

### DIFF
--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -715,7 +715,7 @@ func (i *operatorComponent) configureDirectAPIServiceAccessForCluster(ctx resour
 		// giving 0 clusters to ctx.Config() means using all clusters
 		return nil
 	}
-	if err := ctx.Config(clusters...).ApplyYAML(cfg.SystemNamespace, secret); err != nil {
+	if err := ctx.Config(clusters...).ApplyYAMLNoCleanup(cfg.SystemNamespace, secret); err != nil {
 		return fmt.Errorf("failed applying remote secret to clusters: %v", err)
 	}
 	return nil


### PR DESCRIPTION
Without this, its impossible to run local tests as the secret is removed
after the first run, and subsequent installs fail due to longstanding
bugs in the webhook logic.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.