### PR TITLE
Attempt to deflake instanceip test

### DIFF
--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -1243,8 +1243,6 @@ func instanceIPTests(apps *EchoDeployments) []TrafficTestCase {
 			ipCase := ipCase
 			client := client
 			destination := apps.PodB[0]
-			// so we can validate all clusters are hit
-			callCount := callsPerCluster * len(apps.PodB)
 			var config string
 			if !ipCase.disableSidecar {
 				config = fmt.Sprintf(`
@@ -1275,7 +1273,6 @@ spec:
 						Target:    destination,
 						PortName:  ipCase.port,
 						Scheme:    scheme.HTTP,
-						Count:     callCount,
 						Timeout:   time.Second * 5,
 						Validator: echo.ExpectCode(fmt.Sprint(ipCase.code)),
 					},


### PR DESCRIPTION
Without this, for the negative cases we make 135 calls (5 calls * 3
cluster * 3 retries in envoy * converge(3)). This seems to just end up
overloading the test and we end up with timeouts



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.