### PR TITLE
remove tproxy from traffic shifting test

### DIFF
--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -433,7 +433,7 @@ spec:
 			name:          fmt.Sprintf("shifting-%d", split[0]),
 			toN:           len(split),
 			sourceFilters: []echotest.Filter{noHeadless, noNaked},
-			targetFilters: []echotest.Filter{noHeadless, noExternal},
+			targetFilters: []echotest.Filter{noHeadless, noExternal, noTProxy},
 			templateVars: map[string]interface{}{
 				"split": split,
 			},


### PR DESCRIPTION

Attempts to restore the original number of runs per job of the shifting test so we don't hit the flake (https://github.com/istio/istio/issues/32208) as often.
This doesn't fix the flake and the flake indicates a real bug. 