### PR TITLE
Disable require_strict_1xx_and_204_response_headers runtime config

### DIFF
--- a/pkg/bootstrap/testdata/all_golden.json
+++ b/pkg/bootstrap/testdata/all_golden.json
@@ -12,7 +12,7 @@
               "name": "deprecation",
               "static_layer": {
                   "envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst": true,
-                  "envoy.reloadable_features.strict_1xx_and_204_response_headers": false,
+                  "envoy.reloadable_features.require_strict_1xx_and_204_response_headers": false,
                   "re2.max_program_size.error_level": 1024
               }
           },

--- a/pkg/bootstrap/testdata/auth_golden.json
+++ b/pkg/bootstrap/testdata/auth_golden.json
@@ -12,7 +12,7 @@
               "name": "deprecation",
               "static_layer": {
                   "envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst": true,
-                  "envoy.reloadable_features.strict_1xx_and_204_response_headers": false,
+                  "envoy.reloadable_features.require_strict_1xx_and_204_response_headers": false,
                   "re2.max_program_size.error_level": 1024
               }
           },

--- a/pkg/bootstrap/testdata/authsds_golden.json
+++ b/pkg/bootstrap/testdata/authsds_golden.json
@@ -12,7 +12,7 @@
               "name": "deprecation",
               "static_layer": {
                   "envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst": true,
-                  "envoy.reloadable_features.strict_1xx_and_204_response_headers": false,
+                  "envoy.reloadable_features.require_strict_1xx_and_204_response_headers": false,
                   "re2.max_program_size.error_level": 1024
               }
           },

--- a/pkg/bootstrap/testdata/default_golden.json
+++ b/pkg/bootstrap/testdata/default_golden.json
@@ -12,7 +12,7 @@
               "name": "deprecation",
               "static_layer": {
                   "envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst": true,
-                  "envoy.reloadable_features.strict_1xx_and_204_response_headers": false,
+                  "envoy.reloadable_features.require_strict_1xx_and_204_response_headers": false,
                   "re2.max_program_size.error_level": 1024
               }
           },

--- a/pkg/bootstrap/testdata/running_golden.json
+++ b/pkg/bootstrap/testdata/running_golden.json
@@ -17,7 +17,7 @@
               "name": "deprecation",
               "static_layer": {
                   "envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst": true,
-                  "envoy.reloadable_features.strict_1xx_and_204_response_headers": false,
+                  "envoy.reloadable_features.require_strict_1xx_and_204_response_headers": false,
                   "re2.max_program_size.error_level": 1024
               }
           },

--- a/pkg/bootstrap/testdata/runningsds_golden.json
+++ b/pkg/bootstrap/testdata/runningsds_golden.json
@@ -17,7 +17,7 @@
               "name": "deprecation",
               "static_layer": {
                   "envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst": true,
-                  "envoy.reloadable_features.strict_1xx_and_204_response_headers": false,
+                  "envoy.reloadable_features.require_strict_1xx_and_204_response_headers": false,
                   "re2.max_program_size.error_level": 1024
               }
           },

--- a/pkg/bootstrap/testdata/stats_inclusion_golden.json
+++ b/pkg/bootstrap/testdata/stats_inclusion_golden.json
@@ -12,7 +12,7 @@
               "name": "deprecation",
               "static_layer": {
                   "envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst": true,
-                  "envoy.reloadable_features.strict_1xx_and_204_response_headers": false,
+                  "envoy.reloadable_features.require_strict_1xx_and_204_response_headers": false,
                   "re2.max_program_size.error_level": 1024
               }
           },

--- a/pkg/bootstrap/testdata/tracing_datadog_golden.json
+++ b/pkg/bootstrap/testdata/tracing_datadog_golden.json
@@ -12,7 +12,7 @@
               "name": "deprecation",
               "static_layer": {
                   "envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst": true,
-                  "envoy.reloadable_features.strict_1xx_and_204_response_headers": false,
+                  "envoy.reloadable_features.require_strict_1xx_and_204_response_headers": false,
                   "re2.max_program_size.error_level": 1024
               }
           },

--- a/pkg/bootstrap/testdata/tracing_lightstep_golden.json
+++ b/pkg/bootstrap/testdata/tracing_lightstep_golden.json
@@ -12,7 +12,7 @@
               "name": "deprecation",
               "static_layer": {
                   "envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst": true,
-                  "envoy.reloadable_features.strict_1xx_and_204_response_headers": false,
+                  "envoy.reloadable_features.require_strict_1xx_and_204_response_headers": false,
                   "re2.max_program_size.error_level": 1024
               }
           },

--- a/pkg/bootstrap/testdata/tracing_opencensusagent_golden.json
+++ b/pkg/bootstrap/testdata/tracing_opencensusagent_golden.json
@@ -12,7 +12,7 @@
               "name": "deprecation",
               "static_layer": {
                   "envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst": true,
-                  "envoy.reloadable_features.strict_1xx_and_204_response_headers": false,
+                  "envoy.reloadable_features.require_strict_1xx_and_204_response_headers": false,
                   "re2.max_program_size.error_level": 1024
               }
           },

--- a/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
+++ b/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
@@ -12,7 +12,7 @@
               "name": "deprecation",
               "static_layer": {
                   "envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst": true,
-                  "envoy.reloadable_features.strict_1xx_and_204_response_headers": false,
+                  "envoy.reloadable_features.require_strict_1xx_and_204_response_headers": false,
                   "re2.max_program_size.error_level": 1024
               }
           },

--- a/pkg/bootstrap/testdata/tracing_tls_custom_sni_golden.json
+++ b/pkg/bootstrap/testdata/tracing_tls_custom_sni_golden.json
@@ -12,7 +12,7 @@
               "name": "deprecation",
               "static_layer": {
                   "envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst": true,
-                  "envoy.reloadable_features.strict_1xx_and_204_response_headers": false,
+                  "envoy.reloadable_features.require_strict_1xx_and_204_response_headers": false,
                   "re2.max_program_size.error_level": 1024
               }
           },

--- a/pkg/bootstrap/testdata/tracing_tls_golden.json
+++ b/pkg/bootstrap/testdata/tracing_tls_golden.json
@@ -12,7 +12,7 @@
               "name": "deprecation",
               "static_layer": {
                   "envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst": true,
-                  "envoy.reloadable_features.strict_1xx_and_204_response_headers": false,
+                  "envoy.reloadable_features.require_strict_1xx_and_204_response_headers": false,
                   "re2.max_program_size.error_level": 1024
               }
           },

--- a/pkg/bootstrap/testdata/tracing_zipkin_golden.json
+++ b/pkg/bootstrap/testdata/tracing_zipkin_golden.json
@@ -12,7 +12,7 @@
               "name": "deprecation",
               "static_layer": {
                   "envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst": true,
-                  "envoy.reloadable_features.strict_1xx_and_204_response_headers": false,
+                  "envoy.reloadable_features.require_strict_1xx_and_204_response_headers": false,
                   "re2.max_program_size.error_level": 1024
               }
           },

--- a/pkg/bootstrap/testdata/xdsproxy_golden.json
+++ b/pkg/bootstrap/testdata/xdsproxy_golden.json
@@ -12,7 +12,7 @@
               "name": "deprecation",
               "static_layer": {
                   "envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst": true,
-                  "envoy.reloadable_features.strict_1xx_and_204_response_headers": false,
+                  "envoy.reloadable_features.require_strict_1xx_and_204_response_headers": false,
                   "re2.max_program_size.error_level": 1024
               }
           },

--- a/releasenotes/notes/strict_1xx_204_fix.yaml
+++ b/releasenotes/notes/strict_1xx_204_fix.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: networking
+releaseNotes:
+  - |
+    **Fixed** an issue causing proxies to send `Transfer-Encoding` headers with `1xx` and `204` responses.

--- a/tools/packaging/common/envoy_bootstrap.json
+++ b/tools/packaging/common/envoy_bootstrap.json
@@ -27,7 +27,7 @@
               "name": "deprecation",
               "static_layer": {
                   "envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst": true,
-                  "envoy.reloadable_features.strict_1xx_and_204_response_headers": false,
+                  "envoy.reloadable_features.require_strict_1xx_and_204_response_headers": false,
                   "re2.max_program_size.error_level": 1024
               }
           },


### PR DESCRIPTION
fixes #32021

[https://github.com/envoyproxy/envoy/pull/15880](https://github.com/envoyproxy/envoy/pull/15880
) split strict_1xx_and_204_response_headers into two configs, one for `send_strict...` and one for `require_strict...`. 

In our case, we want to send the compliant response headers (so we don't break people like [here](https://github.com/istio/istio/issues/32127)) but accept non-compliant responses (so we don't break people like we did [here](https://github.com/istio/istio/issues/29427)). Both flags default to true so just setting `requite_strict...=false` should do the trick

Also won't run into upgrade issues since older versions can send non-compliant responses to newer proxies with this change without newer proxies caring

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
