### PR TITLE
Deflake sync timeout test

### DIFF
--- a/pkg/kube/secretcontroller/secretcontroller_test.go
+++ b/pkg/kube/secretcontroller/secretcontroller_test.go
@@ -122,12 +122,7 @@ func Test_SecretController(t *testing.T) {
 	})
 	c := StartSecretController(clientset, addCallback, updateCallback, deleteCallback, secretNamespace, time.Microsecond, stopCh)
 	t.Run("sync timeout", func(t *testing.T) {
-		retry.UntilSuccessOrFail(t, func() error {
-			if !c.HasSynced() {
-				return fmt.Errorf("expected secretcontroller synctimeout to expire")
-			}
-			return nil
-		}, retry.Timeout(50*time.Millisecond))
+		retry.UntilOrFail(t, c.HasSynced, retry.Timeout(2*time.Second))
 	})
 	kube.WaitForCacheSyncInterval(stopCh, time.Microsecond, c.informer.HasSynced)
 	clientset.RunAndWait(stopCh)


### PR DESCRIPTION
Example failure:
https://prow.istio.io/view/gs/istio-prow/logs/unit-tests_istio_postsubmit/1384370286442319872

50ms seems too short to be reliable



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.