### PR TITLE
skip bad remote secret when istiod is not in cluster

### DIFF
--- a/tests/integration/pilot/multicluster_test.go
+++ b/tests/integration/pilot/multicluster_test.go
@@ -104,8 +104,12 @@ func TestBadRemoteSecret(t *testing.T) {
 			"installation.multicluster.remote",
 		).
 		Run(func(t framework.TestContext) {
+			if len(t.Clusters().Primaries()) == 0 {
+				t.Skip("no primary cluster in framework (most likely only remote-config)")
+			}
+
 			// we don't need to test this per-cluster
-			primary := t.Clusters().Configs()[0]
+			primary := t.Clusters().Primaries()[0]
 			// it doesn't matter if the other cluster is a primary/remote/etc.
 			remote := t.Clusters().Exclude(primary)[0]
 
@@ -142,6 +146,9 @@ func TestBadRemoteSecret(t *testing.T) {
 				Deployments(ns).List(context.TODO(), metav1.ListOptions{LabelSelector: "app=istiod"})
 			if err != nil {
 				t.Fatal(err)
+			}
+			if len(deps.Items) == 0 {
+				t.Skip("no deployments with label app=istiod")
 			}
 			pods := primary.CoreV1().Pods(ns)
 			podMeta := deps.Items[0].Spec.Template.ObjectMeta


### PR DESCRIPTION
When testing external istiod, or running tests in any scenario where the test framework can/should not interact with istiod, we can ignore this test. 