### PR TITLE
add istio.test.echo.requestTimeout flag

### DIFF
--- a/pkg/test/echo/common/util.go
+++ b/pkg/test/echo/common/util.go
@@ -15,16 +15,23 @@
 package common
 
 import (
+	"flag"
 	"net/http"
 	"time"
 
 	"istio.io/istio/pkg/test/echo/proto"
 )
 
+func init() {
+	flag.DurationVar(&DefaultRequestTimeout, "istio.test.echo.requestTimeout", DefaultRequestTimeout,
+		"Specifies the timeout for individual ForwardEcho calls.")
+}
+
+var DefaultRequestTimeout = 5 * time.Second
+
 const (
-	ConnectionTimeout     = 2 * time.Second
-	DefaultRequestTimeout = 5 * time.Second
-	DefaultCount          = 1
+	ConnectionTimeout = 2 * time.Second
+	DefaultCount      = 1
 )
 
 // FillInDefaults fills in the timeout and count if not specified in the given message.

--- a/pkg/test/framework/components/echo/flags.go
+++ b/pkg/test/framework/components/echo/flags.go
@@ -29,7 +29,7 @@ var (
 // init registers the command-line flags that we can exposed for "go test".
 func init() {
 	flag.DurationVar(&callTimeout, "istio.test.echo.callTimeout", callTimeout,
-		"Specifies the default timeout used when retrying calls to the Echo service")
+		"Specifies the default total timeout used when retrying calls to the Echo service")
 	flag.DurationVar(&callDelay, "istio.test.echo.callDelay", callDelay,
 		"Specifies the default delay between successive retry attempts when calling the Echo service")
 }


### PR DESCRIPTION
Adds a flag --istio.test.echo.requestTimeout that applies for individual ForwardEcho calls (applies to all calls in the ForwardEcho, which may be > 1). 

Effectively we have

```
while totalTime < --istio.test.echo.callTimeout {
  success := sendRequest{{timeout: --istio.test.echo.requestTimeout})
  if success { break }
}
```