### PR TITLE
Update download scripts to support 1.10 as specified version

### DIFF
--- a/release/downloadIstioCandidate.sh
+++ b/release/downloadIstioCandidate.sh
@@ -103,13 +103,12 @@ without_arch() {
 }
 
 # Istio 1.6 and above support arch
-ARCH_SUPPORTED=$(echo "$ISTIO_VERSION" | awk -F'.' '{print $1"."$2}' )
 # Istio 1.5 and below do not have arch support
-ARCH_UNSUPPORTED="1.5"
+ARCH_SUPPORTED="1.6"
 
 if [ "${OS}" = "Linux" ] ; then
-  # This checks if 1.6 <= 1.5 or 1.4 <= 1.5
-  if [ "$(expr "${ARCH_SUPPORTED}" \<= "${ARCH_UNSUPPORTED}")" -eq 1 ]; then
+  # This checks if ISTIO_VERSION is less than ARCH_SUPPORTED (version-sort's before it)
+  if [ "$(printf '%s\n%s' "${ARCH_SUPPORTED}" "${ISTIO_VERSION}" | sort --version-sort | head -n 1)" = "${ISTIO_VERSION}" ]; then
     without_arch
   else
     with_arch

--- a/release/downloadIstioCtl.sh
+++ b/release/downloadIstioCtl.sh
@@ -49,7 +49,7 @@ if [ "${TARGET_ARCH}" ]; then
     LOCAL_ARCH=${TARGET_ARCH}
 fi
 
-case "${LOCAL_ARCH}" in 
+case "${LOCAL_ARCH}" in
   x86_64)
     ISTIO_ARCH=amd64
     ;;
@@ -99,13 +99,12 @@ without_arch() {
 }
 
 # Istio 1.6 and above support arch
-ARCH_SUPPORTED=$(echo "$ISTIO_VERSION" | awk -F'.' '{print $1"."$2}' )
 # Istio 1.5 and below do not have arch support
-ARCH_UNSUPPORTED="1.5"
+ARCH_SUPPORTED="1.6"
 
 if [ "${OS}" = "Linux" ] ; then
-  # This checks if 1.6 <= 1.5 or 1.4 <= 1.5
-  if [ "$(expr "${ARCH_SUPPORTED}" \<= "${ARCH_UNSUPPORTED}")" -eq 1 ]; then
+  # This checks if ISTIO_VERSION is less than ARCH_SUPPORTED (version-sort's before it)
+  if [ "$(printf '%s\n%s' "${ARCH_SUPPORTED}" "${ISTIO_VERSION}" | sort --version-sort | head -n 1)" = "${ISTIO_VERSION}" ]; then
     without_arch
   else
     with_arch


### PR DESCRIPTION

The downloads scripts use architecture starting with 1.6. The current download scripts don't support 1.10...

I'm not able to test the script in Linux.

Fixes: #32194


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any changes that may affect Istio users.