### PR TITLE
envoy: refactor envoy agent ownership

### DIFF
--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -20,7 +20,6 @@ import (
 	"net"
 	"os"
 
-	"github.com/gogo/protobuf/types"
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
 
@@ -31,8 +30,6 @@ import (
 	"istio.io/istio/pilot/cmd/pilot-agent/status/ready"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/util/network"
-	"istio.io/istio/pkg/bootstrap"
-	"istio.io/istio/pkg/bootstrap/platform"
 	"istio.io/istio/pkg/cmd"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/envoy"
@@ -125,27 +122,28 @@ var (
 				defer stsServer.Stop()
 			}
 
-			agentOptions := options.NewAgentOptions(proxy)
-			var pilotSAN []string
-			if proxyConfig.ControlPlaneAuthPolicy == meshconfig.AuthenticationPolicy_MUTUAL_TLS {
-				// Obtain Pilot SAN, using DNS.
-				pilotSAN = []string{config.GetPilotSan(proxyConfig.DiscoveryAddress)}
-			}
-			log.Infof("Pilot SAN: %v", pilotSAN)
-
-			agent := istio_agent.NewAgent(proxyConfig, agentOptions, secOpts)
-			// Start in process SDS, dns server, and xds proxy.
-			if err := agent.Start(); err != nil {
-				log.Fatala("Agent start up error", err)
-			}
-
 			// If we are using a custom template file (for control plane proxy, for example), configure this.
 			if templateFile != "" && proxyConfig.CustomConfigFile == "" {
 				proxyConfig.ProxyBootstrapTemplatePath = templateFile
 			}
 
+			envoyOptions := envoy.ProxyConfig{
+				LogLevel:          proxyLogLevel,
+				ComponentLogLevel: proxyComponentLogLevel,
+				LogAsJSON:         loggingOptions.JSONEncoding,
+				NodeIPs:           proxy.IPAddresses,
+				Sidecar:           proxy.Type == model.SidecarProxy,
+				OutlierLogPath:    outlierLogPath,
+			}
+			agentOptions := options.NewAgentOptions(proxy)
+			agent := istio_agent.NewAgent(proxyConfig, agentOptions, secOpts, envoyOptions)
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
+
+			// Start in process SDS, dns server, and xds proxy.
+			if err := agent.Start(ctx); err != nil {
+				log.Fatala("Agent start up error", err)
+			}
 
 			// If a status port was provided, start handling status probes.
 			if proxyConfig.StatusPort > 0 {
@@ -154,45 +152,9 @@ var (
 				}
 			}
 
-			provCert := agent.FindRootCAForXDS()
-			if provCert == "" {
-				// Envoy only supports load from file. If we want to use system certs, use best guess
-				// To be more correct this could lookup all the "well known" paths but this is extremely \
-				// unlikely to run on a non-debian based machine, and if it is it can be explicitly configured
-				provCert = "/etc/ssl/certs/ca-certificates.crt"
-			}
-			node, err := bootstrap.GetNodeMetaData(bootstrap.MetadataOptions{
-				ID:                  proxy.ServiceNode(),
-				Envs:                os.Environ(),
-				Platform:            platform.Discover(),
-				InstanceIPs:         proxy.IPAddresses,
-				StsPort:             stsPort,
-				ProxyConfig:         proxyConfig,
-				ProxyViaAgent:       agentOptions.ProxyXDSViaAgent,
-				PilotSubjectAltName: pilotSAN,
-				OutlierLogPath:      outlierLogPath,
-				PilotCertProvider:   secOpts.PilotCertProvider,
-				ProvCert:            provCert,
-			})
-			if err != nil {
-				log.Error("Failed to extract node metadata: ", err)
-				os.Exit(1)
-			}
-			envoyProxy := envoy.NewProxy(envoy.ProxyConfig{
-				Node:              node,
-				LogLevel:          proxyLogLevel,
-				ComponentLogLevel: proxyComponentLogLevel,
-				LogAsJSON:         loggingOptions.JSONEncoding,
-				NodeIPs:           proxy.IPAddresses,
-				Sidecar:           proxy.Type == model.SidecarProxy,
-			})
-
-			drainDuration, _ := types.DurationFromProto(proxyConfig.TerminationDrainDuration)
-			envoyAgent := envoy.NewAgent(envoyProxy, drainDuration)
 			// On SIGINT or SIGTERM, cancel the context, triggering a graceful shutdown
-			go cmd.WaitSignalFunc(cancel)
-
-			return envoyAgent.Run(ctx)
+			cmd.WaitSignalFunc(cancel)
+			return nil
 		},
 	}
 )

--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -140,11 +140,6 @@ var (
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			// Start in process SDS, dns server, and xds proxy.
-			if err := agent.Start(ctx); err != nil {
-				log.Fatala("Agent start up error", err)
-			}
-
 			// If a status port was provided, start handling status probes.
 			if proxyConfig.StatusPort > 0 {
 				if err := initStatusServer(ctx, proxy, proxyConfig, agent); err != nil {
@@ -153,8 +148,10 @@ var (
 			}
 
 			// On SIGINT or SIGTERM, cancel the context, triggering a graceful shutdown
-			cmd.WaitSignalFunc(cancel)
-			return nil
+			go cmd.WaitSignalFunc(cancel)
+
+			// Start in process SDS, dns server, xds proxy, and Envoy.
+			return agent.Run(ctx)
 		},
 	}
 )

--- a/pilot/cmd/pilot-agent/options/agent.go
+++ b/pilot/cmd/pilot-agent/options/agent.go
@@ -36,6 +36,7 @@ func NewAgentOptions(proxy *model.Proxy) *istioagent.AgentOptions {
 		ProxyType:                proxy.Type,
 		EnableDynamicProxyConfig: enableProxyConfigXdsEnv,
 		ProxyIPAddresses:         proxy.IPAddresses,
+		ServiceNode:              proxy.ServiceNode(),
 	}
 	extractXDSHeadersFromEnv(o)
 	if proxyXDSViaAgent {

--- a/pilot/cmd/pilot-agent/options/security.go
+++ b/pilot/cmd/pilot-agent/options/security.go
@@ -47,6 +47,7 @@ func NewSecurityOptions(proxyConfig *meshconfig.ProxyConfig, stsPort int, tokenM
 		ECCSigAlg:                      eccSigAlgEnv,
 		SecretTTL:                      secretTTLEnv,
 		SecretRotationGracePeriodRatio: secretRotationGracePeriodRatioEnv,
+		STSPort:                        stsPort,
 	}
 
 	o, err := SetupSecurityOptions(proxyConfig, o, jwtPolicy.Get(),

--- a/pkg/envoy/agent.go
+++ b/pkg/envoy/agent.go
@@ -68,7 +68,7 @@ type exitStatus struct {
 }
 
 // Run starts the envoy and waits until it terminates.
-func (a *Agent) Start(ctx context.Context) {
+func (a *Agent) Run(ctx context.Context) {
 	log.Info("Starting proxy agent")
 	go a.runWait(0, a.abortCh)
 

--- a/pkg/envoy/agent.go
+++ b/pkg/envoy/agent.go
@@ -39,7 +39,7 @@ func NewAgent(proxy Proxy, terminationDrainDuration time.Duration) *Agent {
 // Proxy defines command interface for a proxy
 type Proxy interface {
 
-	// Run command for a config, epoch, and abort channel
+	// Run command for an epoch, and abort channel
 	Run(int, <-chan error) error
 
 	// Drains the current epoch.
@@ -68,7 +68,7 @@ type exitStatus struct {
 }
 
 // Run starts the envoy and waits until it terminates.
-func (a *Agent) Run(ctx context.Context) error {
+func (a *Agent) Start(ctx context.Context) {
 	log.Info("Starting proxy agent")
 	go a.runWait(0, a.abortCh)
 
@@ -84,11 +84,9 @@ func (a *Agent) Run(ctx context.Context) error {
 		}
 
 		log.Infof("No more active epochs, terminating")
-		return nil
 	case <-ctx.Done():
 		a.terminate()
 		log.Info("Agent has successfully terminated")
-		return nil
 	}
 }
 

--- a/pkg/envoy/agent_test.go
+++ b/pkg/envoy/agent_test.go
@@ -51,7 +51,7 @@ func TestStartExit(t *testing.T) {
 	done := make(chan struct{})
 	a := NewAgent(TestProxy{}, 0)
 	go func() {
-		_ = a.Run(ctx)
+		a.Run(ctx)
 		done <- struct{}{}
 	}()
 	<-done
@@ -81,7 +81,7 @@ func TestStartDrain(t *testing.T) {
 		return nil
 	}
 	a := NewAgent(TestProxy{run: start, blockChannel: blockChan}, -10*time.Second)
-	go func() { _ = a.Run(ctx) }()
+	go func() { a.Run(ctx) }()
 	<-blockChan
 	cancel()
 	<-blockChan
@@ -104,7 +104,7 @@ func TestStartStop(t *testing.T) {
 		}
 	}
 	a := NewAgent(TestProxy{run: start, cleanup: cleanup}, 0)
-	go func() { _ = a.Run(ctx) }()
+	go func() { a.Run(ctx) }()
 	<-ctx.Done()
 }
 
@@ -124,7 +124,7 @@ func TestRecovery(t *testing.T) {
 		return nil
 	}
 	a := NewAgent(TestProxy{run: start}, 0)
-	go func() { _ = a.Run(ctx) }()
+	go func() { a.Run(ctx) }()
 
 	// make sure we don't try to reconcile twice
 	<-time.After(100 * time.Millisecond)

--- a/pkg/envoy/proxy.go
+++ b/pkg/envoy/proxy.go
@@ -20,20 +20,12 @@ import (
 	"net"
 	"os"
 	"os/exec"
-	"path"
 	"time"
 
 	"github.com/gogo/protobuf/types"
 
-	"istio.io/istio/pilot/pkg/model"
-	"istio.io/istio/pkg/bootstrap"
 	"istio.io/pkg/env"
 	"istio.io/pkg/log"
-)
-
-const (
-	// epochFileTemplate is a template for the root config JSON
-	epochFileTemplate = "envoy-rev%d.json"
 )
 
 type envoy struct {
@@ -41,13 +33,26 @@ type envoy struct {
 	extraArgs []string
 }
 
+// Envoy binary flags
 type ProxyConfig struct {
-	*model.Node
 	LogLevel          string
 	ComponentLogLevel string
 	NodeIPs           []string
 	Sidecar           bool
 	LogAsJSON         bool
+	// TODO: outlier log path configuration belongs to mesh ProxyConfig
+	OutlierLogPath string
+
+	BinaryPath             string
+	ConfigPath             string
+	ConfigCleanup          bool
+	AdminPort              int32
+	DrainDuration          *types.Duration
+	ParentShutdownDuration *types.Duration
+	Concurrency            int32
+
+	// Disables all envoy agent features (for unit testing)
+	TestOnly bool
 }
 
 // NewProxy creates an instance of the proxy control commands
@@ -68,7 +73,7 @@ func NewProxy(cfg ProxyConfig) Proxy {
 }
 
 func (e *envoy) Drain() error {
-	adminPort := uint32(e.Metadata.ProxyConfig.ProxyAdminPort)
+	adminPort := uint32(e.AdminPort)
 
 	err := DrainListeners(adminPort, e.Sidecar)
 	if err != nil {
@@ -85,11 +90,9 @@ func (e *envoy) args(fname string, epoch int, bootstrapConfig string) []string {
 	startupArgs := []string{
 		"-c", fname,
 		"--restart-epoch", fmt.Sprint(epoch),
-		"--drain-time-s", fmt.Sprint(int(convertDuration(e.Metadata.ProxyConfig.DrainDuration) / time.Second)),
+		"--drain-time-s", fmt.Sprint(int(convertDuration(e.DrainDuration) / time.Second)),
 		"--drain-strategy", "immediate", // Clients are notified as soon as the drain process starts.
-		"--parent-shutdown-time-s", fmt.Sprint(int(convertDuration(e.Metadata.ProxyConfig.ParentShutdownDuration) / time.Second)),
-		"--service-cluster", e.Metadata.ProxyConfig.ServiceCluster,
-		"--service-node", e.ID,
+		"--parent-shutdown-time-s", fmt.Sprint(int(convertDuration(e.ParentShutdownDuration) / time.Second)),
 		"--local-address-ip-version", proxyLocalAddressType,
 		"--bootstrap-version", "3",
 		"--disable-hot-restart", // We don't use it, so disable it to simplify Envoy's logic
@@ -116,8 +119,8 @@ func (e *envoy) args(fname string, epoch int, bootstrapConfig string) []string {
 		}
 	}
 
-	if e.Metadata.ProxyConfig.Concurrency.GetValue() > 0 {
-		startupArgs = append(startupArgs, "--concurrency", fmt.Sprint(e.Metadata.ProxyConfig.Concurrency.GetValue()))
+	if e.Concurrency > 0 {
+		startupArgs = append(startupArgs, "--concurrency", fmt.Sprint(e.Concurrency))
 	}
 
 	return startupArgs
@@ -126,31 +129,12 @@ func (e *envoy) args(fname string, epoch int, bootstrapConfig string) []string {
 var istioBootstrapOverrideVar = env.RegisterStringVar("ISTIO_BOOTSTRAP_OVERRIDE", "", "")
 
 func (e *envoy) Run(epoch int, abort <-chan error) error {
-	config := e.Metadata.ProxyConfig
-	var fname string
-	// Note: the cert checking still works, the generated file is updated if certs are changed.
-	// We just don't save the generated file, but use a custom one instead. Pilot will keep
-	// monitoring the certs and restart if the content of the certs changes.
-	if len(config.CustomConfigFile) > 0 {
-		// there is a custom configuration. Don't write our own config - but keep watching the certs.
-		fname = config.CustomConfigFile
-	} else {
-		out, err := bootstrap.New(bootstrap.Config{
-			Node: e.Node,
-		}).CreateFileForEpoch(epoch)
-		if err != nil {
-			log.Error("Failed to generate bootstrap config: ", err)
-			os.Exit(1) // Prevent infinite loop attempting to write the file, let k8s/systemd report
-		}
-		fname = out
-	}
-
 	// spin up a new Envoy process
-	args := e.args(fname, epoch, istioBootstrapOverrideVar.Get())
+	args := e.args(e.ConfigPath, epoch, istioBootstrapOverrideVar.Get())
 	log.Infof("Envoy command: %v", args)
 
 	/* #nosec */
-	cmd := exec.Command(config.BinaryPath, args...)
+	cmd := exec.Command(e.BinaryPath, args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Start(); err != nil {
@@ -174,13 +158,10 @@ func (e *envoy) Run(epoch int, abort <-chan error) error {
 }
 
 func (e *envoy) Cleanup(epoch int) {
-	// should return when use the parameter "--templateFile=/path/xxx.tmpl".
-	if e.Metadata.ProxyConfig.CustomConfigFile != "" {
-		return
-	}
-	filePath := configFile(e.Metadata.ProxyConfig.ConfigPath, epoch)
-	if err := os.Remove(filePath); err != nil {
-		log.Warnf("Failed to delete config file %s for %d, %v", filePath, epoch, err)
+	if e.ConfigCleanup {
+		if err := os.Remove(e.ConfigPath); err != nil {
+			log.Warnf("Failed to delete config file %s for %d, %v", e.ConfigPath, epoch, err)
+		}
 	}
 }
 
@@ -194,10 +175,6 @@ func convertDuration(d *types.Duration) time.Duration {
 		log.Warnf("error converting duration %#v, using 0: %v", d, err)
 	}
 	return dur
-}
-
-func configFile(config string, epoch int) string {
-	return path.Join(config, fmt.Sprintf(epochFileTemplate, epoch))
 }
 
 // isIPv6Proxy check the addresses slice and returns true for a valid IPv6 address

--- a/pkg/envoy/proxy_test.go
+++ b/pkg/envoy/proxy_test.go
@@ -30,17 +30,16 @@ func TestEnvoyArgs(t *testing.T) {
 	proxyConfig.Concurrency = &types.Int32Value{Value: 8}
 
 	cfg := ProxyConfig{
-		Node: &model.Node{
-			ID: "my-node",
-			Metadata: &model.BootstrapNodeMetadata{
-				NodeMetadata: model.NodeMetadata{
-					ProxyConfig: &proxyConfig,
-				},
-			},
-		},
-		LogLevel:          "trace",
-		ComponentLogLevel: "misc:error",
-		NodeIPs:           []string{"10.75.2.9", "192.168.11.18"},
+		LogLevel:               "trace",
+		ComponentLogLevel:      "misc:error",
+		NodeIPs:                []string{"10.75.2.9", "192.168.11.18"},
+		BinaryPath:             proxyConfig.BinaryPath,
+		ConfigPath:             proxyConfig.ConfigPath,
+		ConfigCleanup:          true,
+		AdminPort:              proxyConfig.ProxyAdminPort,
+		DrainDuration:          proxyConfig.DrainDuration,
+		ParentShutdownDuration: proxyConfig.ParentShutdownDuration,
+		Concurrency:            8,
 	}
 
 	test := &envoy{
@@ -60,8 +59,6 @@ func TestEnvoyArgs(t *testing.T) {
 		"--drain-time-s", "45",
 		"--drain-strategy", "immediate",
 		"--parent-shutdown-time-s", "60",
-		"--service-cluster", "my-cluster",
-		"--service-node", "my-node",
 		"--local-address-ip-version", "v4",
 		"--bootstrap-version", "3",
 		"--disable-hot-restart",

--- a/pkg/istio-agent/agent.go
+++ b/pkg/istio-agent/agent.go
@@ -241,7 +241,7 @@ func (a *Agent) initializeEnvoyAgent() error {
 //    For example Google CA
 //
 // 2. Indirect, using istiod: using K8S cert.
-func (a *Agent) Start(ctx context.Context) error {
+func (a *Agent) Run(ctx context.Context) error {
 	var err error
 	a.secretCache, err = a.newSecretManager()
 	if err != nil {
@@ -275,8 +275,10 @@ func (a *Agent) Start(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to start envoy agent: %v", err)
 	}
+
+	// This is a blocking call for graceful termination.
 	if a.envoyAgent != nil {
-		go a.envoyAgent.Run(ctx)
+		a.envoyAgent.Run(ctx)
 	}
 
 	return nil

--- a/pkg/istio-agent/agent.go
+++ b/pkg/istio-agent/agent.go
@@ -197,11 +197,6 @@ func (a *Agent) initializeEnvoyAgent() error {
 		return fmt.Errorf("failed to generate bootstrap metadata: %v", err)
 	}
 
-	// Early exit for unit tests
-	if a.envoyOpts.TestOnly {
-		return nil
-	}
-
 	// Note: the cert checking still works, the generated file is updated if certs are changed.
 	// We just don't save the generated file, but use a custom one instead. Pilot will keep
 	// monitoring the certs and restart if the content of the certs changes.
@@ -271,14 +266,16 @@ func (a *Agent) Run(ctx context.Context) error {
 		}
 	}
 
-	err = a.initializeEnvoyAgent()
-	if err != nil {
-		return fmt.Errorf("failed to start envoy agent: %v", err)
-	}
+	if !a.envoyOpts.TestOnly {
+		err = a.initializeEnvoyAgent()
+		if err != nil {
+			return fmt.Errorf("failed to start envoy agent: %v", err)
+		}
 
-	// This is a blocking call for graceful termination.
-	if a.envoyAgent != nil {
-		a.envoyAgent.Run(ctx)
+		// This is a blocking call for graceful termination.
+		if a.envoyAgent != nil {
+			a.envoyAgent.Run(ctx)
+		}
 	}
 
 	return nil

--- a/pkg/istio-agent/agent.go
+++ b/pkg/istio-agent/agent.go
@@ -15,6 +15,7 @@
 package istioagent
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -22,10 +23,16 @@ import (
 	"path"
 	"strings"
 
+	"github.com/gogo/protobuf/types"
+
 	mesh "istio.io/api/mesh/v1alpha1"
+	"istio.io/istio/pilot/cmd/pilot-agent/config"
 	"istio.io/istio/pilot/pkg/dns"
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/bootstrap"
+	"istio.io/istio/pkg/bootstrap/platform"
 	"istio.io/istio/pkg/config/constants"
+	"istio.io/istio/pkg/envoy"
 	"istio.io/istio/pkg/security"
 	"istio.io/istio/security/pkg/nodeagent/cache"
 	"istio.io/istio/security/pkg/nodeagent/caclient"
@@ -79,8 +86,11 @@ const (
 type Agent struct {
 	proxyConfig *mesh.ProxyConfig
 
-	cfg     *AgentOptions
-	secOpts *security.Options
+	cfg       *AgentOptions
+	secOpts   *security.Options
+	envoyOpts envoy.ProxyConfig
+
+	envoyAgent *envoy.Agent
 
 	sdsServer   *sds.Server
 	secretCache *cache.SecretManagerClient
@@ -114,6 +124,8 @@ type AgentOptions struct {
 	// ProxyDomain is the DNS domain associated with the proxy (assumed
 	// to include the namespace as well) (for local dns resolution)
 	ProxyDomain string
+	// Node identifier used by Envoy
+	ServiceNode string
 
 	// XDSRootCerts is the location of the root CA for the XDS connection. Used for setting platform certs or
 	// using custom roots.
@@ -142,12 +154,84 @@ type AgentOptions struct {
 // NewAgent hosts the functionality for local SDS and XDS. This consists of the local SDS server and
 // associated clients to sign certificates (when not using files), and the local XDS proxy (including
 // health checking for VMs and DNS proxying).
-func NewAgent(proxyConfig *mesh.ProxyConfig, agentOpts *AgentOptions, sopts *security.Options) *Agent {
+func NewAgent(proxyConfig *mesh.ProxyConfig, agentOpts *AgentOptions, sopts *security.Options,
+	eopts envoy.ProxyConfig) *Agent {
 	return &Agent{
 		proxyConfig: proxyConfig,
 		cfg:         agentOpts,
 		secOpts:     sopts,
+		envoyOpts:   eopts,
 	}
+}
+
+func (a *Agent) initializeEnvoyAgent() error {
+	provCert := a.FindRootCAForXDS()
+	if provCert == "" {
+		// Envoy only supports load from file. If we want to use system certs, use best guess
+		// To be more correct this could lookup all the "well known" paths but this is extremely \
+		// unlikely to run on a non-debian based machine, and if it is it can be explicitly configured
+		provCert = "/etc/ssl/certs/ca-certificates.crt"
+	}
+	var pilotSAN []string
+	if a.proxyConfig.ControlPlaneAuthPolicy == mesh.AuthenticationPolicy_MUTUAL_TLS {
+		// Obtain Pilot SAN, using DNS.
+		pilotSAN = []string{config.GetPilotSan(a.proxyConfig.DiscoveryAddress)}
+	}
+	log.Infof("Pilot SAN: %v", pilotSAN)
+
+	var err error
+	node, err := bootstrap.GetNodeMetaData(bootstrap.MetadataOptions{
+		ID:                  a.cfg.ServiceNode,
+		Envs:                os.Environ(),
+		Platform:            platform.Discover(),
+		InstanceIPs:         a.cfg.ProxyIPAddresses,
+		StsPort:             a.secOpts.STSPort,
+		ProxyConfig:         a.proxyConfig,
+		ProxyViaAgent:       a.cfg.ProxyXDSViaAgent,
+		PilotSubjectAltName: pilotSAN,
+		OutlierLogPath:      a.envoyOpts.OutlierLogPath,
+		PilotCertProvider:   a.secOpts.PilotCertProvider,
+		ProvCert:            provCert,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to generate bootstrap metadata: %v", err)
+	}
+
+	// Early exit for unit tests
+	if a.envoyOpts.TestOnly {
+		return nil
+	}
+
+	// Note: the cert checking still works, the generated file is updated if certs are changed.
+	// We just don't save the generated file, but use a custom one instead. Pilot will keep
+	// monitoring the certs and restart if the content of the certs changes.
+	if len(a.proxyConfig.CustomConfigFile) > 0 {
+		// there is a custom configuration. Don't write our own config - but keep watching the certs.
+		a.envoyOpts.ConfigPath = a.proxyConfig.CustomConfigFile
+		a.envoyOpts.ConfigCleanup = false
+	} else {
+		out, err := bootstrap.New(bootstrap.Config{
+			Node: node,
+		}).CreateFileForEpoch(0)
+		if err != nil {
+			return fmt.Errorf("failed to generate bootstrap config: %v", err)
+		}
+		a.envoyOpts.ConfigPath = out
+		a.envoyOpts.ConfigCleanup = true
+	}
+
+	// Back-fill envoy options form proxy config options
+	a.envoyOpts.BinaryPath = a.proxyConfig.BinaryPath
+	a.envoyOpts.AdminPort = a.proxyConfig.ProxyAdminPort
+	a.envoyOpts.DrainDuration = a.proxyConfig.DrainDuration
+	a.envoyOpts.ParentShutdownDuration = a.proxyConfig.ParentShutdownDuration
+	a.envoyOpts.Concurrency = a.proxyConfig.Concurrency.GetValue()
+
+	envoyProxy := envoy.NewProxy(a.envoyOpts)
+
+	drainDuration, _ := types.DurationFromProto(a.proxyConfig.TerminationDrainDuration)
+	a.envoyAgent = envoy.NewAgent(envoyProxy, drainDuration)
+	return nil
 }
 
 // Simplified SDS setup. This is called if and only if user has explicitly mounted a K8S JWT token, and is not
@@ -157,7 +241,7 @@ func NewAgent(proxyConfig *mesh.ProxyConfig, agentOpts *AgentOptions, sopts *sec
 //    For example Google CA
 //
 // 2. Indirect, using istiod: using K8S cert.
-func (a *Agent) Start() error {
+func (a *Agent) Start(ctx context.Context) error {
 	var err error
 	a.secretCache, err = a.newSecretManager()
 	if err != nil {
@@ -186,6 +270,15 @@ func (a *Agent) Start() error {
 			}
 		}
 	}
+
+	err = a.initializeEnvoyAgent()
+	if err != nil {
+		return fmt.Errorf("failed to start envoy agent: %v", err)
+	}
+	if a.envoyAgent != nil {
+		a.envoyAgent.Start(ctx)
+	}
+
 	return nil
 }
 

--- a/pkg/istio-agent/agent.go
+++ b/pkg/istio-agent/agent.go
@@ -276,7 +276,7 @@ func (a *Agent) Start(ctx context.Context) error {
 		return fmt.Errorf("failed to start envoy agent: %v", err)
 	}
 	if a.envoyAgent != nil {
-		a.envoyAgent.Start(ctx)
+		go a.envoyAgent.Run(ctx)
 	}
 
 	return nil

--- a/pkg/istio-agent/agent_test.go
+++ b/pkg/istio-agent/agent_test.go
@@ -384,7 +384,7 @@ func Setup(t *testing.T, opts ...func(a AgentTest) AgentTest) *AgentTest {
 	}
 	a := NewAgent(&resp.ProxyConfig, &resp.AgentConfig, &resp.Security, envoy.ProxyConfig{TestOnly: true})
 	t.Cleanup(a.Close)
-	if err := a.Start(context.Background()); err != nil {
+	if err := a.Run(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	resp.agent = a

--- a/pkg/istio-agent/agent_test.go
+++ b/pkg/istio-agent/agent_test.go
@@ -15,6 +15,7 @@
 package istioagent
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
@@ -40,6 +41,7 @@ import (
 	"istio.io/istio/pilot/test/xdstest"
 	"istio.io/istio/pkg/bootstrap"
 	"istio.io/istio/pkg/config/mesh"
+	"istio.io/istio/pkg/envoy"
 	"istio.io/istio/pkg/file"
 	"istio.io/istio/pkg/security"
 	"istio.io/istio/pkg/spiffe"
@@ -380,9 +382,9 @@ func Setup(t *testing.T, opts ...func(a AgentTest) AgentTest) *AgentTest {
 	for _, opt := range opts {
 		resp = opt(resp)
 	}
-	a := NewAgent(&resp.ProxyConfig, &resp.AgentConfig, &resp.Security)
+	a := NewAgent(&resp.ProxyConfig, &resp.AgentConfig, &resp.Security, envoy.ProxyConfig{TestOnly: true})
 	t.Cleanup(a.Close)
-	if err := a.Start(); err != nil {
+	if err := a.Start(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	resp.agent = a

--- a/pkg/istio-agent/xds_proxy_test.go
+++ b/pkg/istio-agent/xds_proxy_test.go
@@ -45,6 +45,7 @@ import (
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/schema/gvk"
+	"istio.io/istio/pkg/envoy"
 	"istio.io/istio/pkg/security"
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/env"
@@ -217,7 +218,7 @@ func setupXdsProxy(t *testing.T) *XdsProxy {
 	dir := t.TempDir()
 	ia := NewAgent(&proxyConfig, &AgentOptions{
 		XdsUdsPath: filepath.Join(dir, "XDS"),
-	}, secOpts)
+	}, secOpts, envoy.ProxyConfig{TestOnly: true})
 	t.Cleanup(func() {
 		ia.Close()
 	})

--- a/pkg/security/security.go
+++ b/pkg/security/security.go
@@ -140,6 +140,9 @@ type Options struct {
 	// we would refresh 6 minutes before expiration.
 	SecretRotationGracePeriodRatio float64
 
+	// STS port
+	STSPort int
+
 	// authentication provider specific plugins, will exchange the token
 	// For example exchange long lived refresh with access tokens.
 	// Used by the secret fetcher when signing CSRs.


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

Move ownership of envoy agent to istio agent. This allows lifecycle control by the agent.