### PR TITLE
Highlight warning messages before upgrading control plan cluster

### DIFF
--- a/operator/cmd/mesh/install.go
+++ b/operator/cmd/mesh/install.go
@@ -293,7 +293,8 @@ func DetectIstioVersionDiff(cmd *cobra.Command, tag string, ns string, kubeClien
 		if icpTag != "" && tag != icpTag && revision != "" {
 			if icpTag > tag {
 				cmd.Printf("%s Istio is being upgraded from %s -> %s.\n"+
-					"%s Before upgrading, you may wish to use 'istioctl analyze' to check for IST0002 and IST0135 deprecation warnings.\n", warnMarker, icpTag, tag, warnMarker)
+					"%s Before upgrading, you may wish to use 'istioctl analyze' to check for"+
+					"IST0002 and IST0135 deprecation warnings.\n", warnMarker, icpTag, tag, warnMarker)
 			} else {
 				cmd.Printf("%s Istio is being downgraded from %s -> %s.", warnMarker, icpTag, tag)
 			}

--- a/operator/cmd/mesh/install.go
+++ b/operator/cmd/mesh/install.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -252,6 +253,7 @@ func savedIOPName(iop *v1alpha12.IstioOperator) string {
 // DetectIstioVersionDiff will show warning if istioctl version and control plane version are different
 // nolint: interfacer
 func DetectIstioVersionDiff(cmd *cobra.Command, tag string, ns string, kubeClient kube.ExtendedClient, setFlags []string) error {
+	warnMarker := color.New(color.FgYellow).Add(color.Italic).Sprint("WARNING:")
 	icps, err := kubeClient.GetIstioVersions(context.TODO(), ns)
 	if err != nil {
 		return err
@@ -284,16 +286,16 @@ func DetectIstioVersionDiff(cmd *cobra.Command, tag string, ns string, kubeClien
 			} else {
 				msg = "An older"
 			}
-			cmd.Printf("! Istio control planes installed: %s.\n"+
-				"! "+msg+" installed version of Istio has been detected. Running this command will overwrite it.\n", strings.Join(icpTags, ", "))
+			cmd.Printf("%s Istio control planes installed: %s.\n"+
+				"%s "+msg+" installed version of Istio has been detected. Running this command will overwrite it.\n", warnMarker, strings.Join(icpTags, ", "), warnMarker)
 		}
 		// when the revision is passed
 		if icpTag != "" && tag != icpTag && revision != "" {
 			if icpTag > tag {
-				cmd.Printf("! Istio is being upgraded from %s -> %s.\n"+
-					"! Before upgrading, you may wish to use 'istioctl analyze' to check for IST0002 and IST0135 deprecation warnings.\n", icpTag, tag)
+				cmd.Printf("%s Istio is being upgraded from %s -> %s.\n"+
+					"%s Before upgrading, you may wish to use 'istioctl analyze' to check for IST0002 and IST0135 deprecation warnings.\n", warnMarker, icpTag, tag, warnMarker)
 			} else {
-				cmd.Printf("! Istio is being downgraded from %s -> %s.", icpTag, tag)
+				cmd.Printf("%s Istio is being downgraded from %s -> %s.", warnMarker, icpTag, tag)
 			}
 		}
 	}


### PR DESCRIPTION
To fix https://github.com/istio/istio/issues/32384

Without revision:
```
$ istioctl install
WARNING: Istio control planes installed: 1.9.2.
WARNING: An older installed version of Istio has been detected. Running this command will overwrite it.
This will install the Istio 1.10.0  profile with ["Istio core" "Istiod" "Ingress gateways"] components into the cluster. Proceed? (y/N)
```
With revision:
```
$ istioctl install -r 1-10-0
WARNING: Istio is being upgraded from 1.9.2 -> 1.10.0.
WARNING: Before upgrading, you may wish to use 'istioctl analyze' to check for IST0002 and IST0135 deprecation warnings.
This will install the Istio 1.10.0  profile with ["Istio core" "Istiod" "Ingress gateways"] components into the cluster. Proceed? (y/N)
```