### PR TITLE
Improvements to tag command

### DIFF
--- a/istioctl/cmd/tag_test.go
+++ b/istioctl/cmd/tag_test.go
@@ -383,7 +383,7 @@ func TestSetTagErrors(t *testing.T) {
 				Interface: client,
 			}
 			skipConfirmation = true
-			err := setTag(context.Background(), mockClient, tc.tag, tc.revision, false, &out)
+			err := setTag(context.Background(), mockClient, tc.tag, tc.revision, false, &out, nil)
 			if tc.error == "" && err != nil {
 				t.Fatalf("expected no error, got %v", err)
 			}


### PR DESCRIPTION
* Allow external control plane to bypass in-cluster Istiod pod check
* Add check to ensure we don't have overlapping webhooks. For example:

```
$ grun ./istioctl/cmd/istioctl x revision tag generate istio-1611 --revision istio-1611
Error: creating tag would conflict:
Error [IST0139] (MutatingWebhookConfiguration istio-revision-tag-istio-1611 ) Webhook overlaps with others: [istio-sidecar-injector-istio-1611/sidecar-injector.istio.io]. This may cause injection to occur twice.
```
