### PR TITLE
Make revision tag `default` inject for default selectors

### DIFF
--- a/istioctl/cmd/tag.go
+++ b/istioctl/cmd/tag.go
@@ -45,7 +45,7 @@ const (
 	revisionTagTemplateName     = "revision-tags.yaml"
 	// Revision tags require that the target istiod patches ALL webhooks with matching istio.io/rev label,
 	// a behavior that just made it into 1.10 (https://github.com/istio/istio/pull/29583)
-	minRevisionTagIstioVersion = "1.10"
+	minRevisionTagIstioVersion = "1.10.0"
 
 	// help strings and long formatted user outputs
 	skipConfirmationFlagHelpStr = `The skipConfirmation determines whether the user is prompted for confirmation.
@@ -276,7 +276,9 @@ func setTag(ctx context.Context, kubeClient kube.ExtendedClient, tag, revision s
 			return err
 		}
 		if !sufficient {
-			confirm(fmt.Sprintf(versionCheckStr, revision, version, minRevisionTagIstioVersion), w)
+			if !confirm(fmt.Sprintf(versionCheckStr, revision, version, minRevisionTagIstioVersion), w) {
+				return nil
+			}
 		}
 	}
 

--- a/istioctl/cmd/tag_test.go
+++ b/istioctl/cmd/tag_test.go
@@ -401,32 +401,44 @@ func TestSetTagErrors(t *testing.T) {
 
 func TestSetTagWebhookCreation(t *testing.T) {
 	tcs := []struct {
-		name    string
-		webhook admit_v1.MutatingWebhookConfiguration
-		tagName string
-		whURL   string
-		whSVC   string
+		name        string
+		webhook     admit_v1.MutatingWebhookConfiguration
+		tagName     string
+		whURL       string
+		whSVC       string
+		numWebhooks int
 	}{
 		{
-			name:    "webhook-pointing-to-service",
-			webhook: revisionCanonicalWebhook,
-			tagName: "canary",
-			whURL:   "",
-			whSVC:   "istiod-revision",
+			name:        "webhook-pointing-to-service",
+			webhook:     revisionCanonicalWebhook,
+			tagName:     "canary",
+			whURL:       "",
+			whSVC:       "istiod-revision",
+			numWebhooks: 2,
 		},
 		{
-			name:    "webhook-pointing-to-url",
-			webhook: revisionCanonicalWebhookRemote,
-			tagName: "canary",
-			whURL:   remoteInjectionURL,
-			whSVC:   "",
+			name:        "webhook-pointing-to-url",
+			webhook:     revisionCanonicalWebhookRemote,
+			tagName:     "canary",
+			whURL:       remoteInjectionURL,
+			whSVC:       "",
+			numWebhooks: 2,
 		},
 		{
-			name:    "webhook-pointing-to-default-revision",
-			webhook: defaultRevisionCanonicalWebhook,
-			tagName: "canary",
-			whURL:   "",
-			whSVC:   "istiod",
+			name:        "webhook-pointing-to-default-revision",
+			webhook:     defaultRevisionCanonicalWebhook,
+			tagName:     "canary",
+			whURL:       "",
+			whSVC:       "istiod",
+			numWebhooks: 2,
+		},
+		{
+			name:        "webhook-pointing-to-default-revision",
+			webhook:     defaultRevisionCanonicalWebhook,
+			tagName:     "default",
+			whURL:       "",
+			whSVC:       "istiod",
+			numWebhooks: 4,
 		},
 	}
 	scheme := runtime.NewScheme()
@@ -451,8 +463,9 @@ func TestSetTagWebhookCreation(t *testing.T) {
 		wh := whObject.(*admit_v1.MutatingWebhookConfiguration)
 
 		// expect both namespace.sidecar-injector.istio.io and object.sidecar-injector.istio.io webhooks
-		if len(wh.Webhooks) != 2 {
-			t.Errorf("expected 1 webhook in MutatingWebhookConfiguration, found %d", len(wh.Webhooks))
+		if len(wh.Webhooks) != tc.numWebhooks {
+			t.Errorf("expected %d webhook(s) in MutatingWebhookConfiguration, found %d",
+				tc.numWebhooks, len(wh.Webhooks))
 		}
 		tag, exists := wh.ObjectMeta.Labels[istioTagLabel]
 		if !exists {

--- a/manifests/charts/istio-control/istio-discovery/templates/revision-tags.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/revision-tags.yaml
@@ -40,36 +40,74 @@ metadata:
     app: sidecar-injector
     release: {{ $.Release.Name }}
 webhooks:
+{{- include "core" (mergeOverwrite (deepCopy $) (dict "Prefix" "rev.namespace.") ) }}
+  namespaceSelector:
+    matchExpressions:
+    - key: istio.io/rev
+      operator: In
+      values:
+      - "{{ $tagName }}"
+    - key: istio-injection
+      operator: DoesNotExist
+  objectSelector:
+    matchExpressions:
+    - key: sidecar.istio.io/inject
+      operator: NotIn
+      values:
+      - "false"
+{{- include "core" (mergeOverwrite (deepCopy $) (dict "Prefix" "rev.object.") ) }}
+  namespaceSelector:
+    matchExpressions:
+    - key: istio.io/rev
+      operator: DoesNotExist
+    - key: istio-injection
+      operator: DoesNotExist
+  objectSelector:
+    matchExpressions:
+    - key: sidecar.istio.io/inject
+      operator: NotIn
+      values:
+      - "false"
+    - key: istio.io/rev
+      operator: In
+      values:
+      - "{{ $tagName }}"
+
+{{- /* When the tag is "default" we want to create webhooks for the default revision */}}
+{{- /* These webhooks should be kept in sync with istio-discovery/templates/mutatingwebhook.yaml */}}
+{{- if (eq $tagName "default") }}
+
+{{- /* Case 1: Namespace selector enabled, and object selector is not injected */}}
 {{- include "core" (mergeOverwrite (deepCopy $) (dict "Prefix" "namespace.") ) }}
   namespaceSelector:
     matchExpressions:
-    - key: istio.io/rev
+    - key: istio-injection
       operator: In
       values:
-      - "{{ $tagName }}"
-    - key: istio-injection
-      operator: DoesNotExist
+      - enabled
   objectSelector:
     matchExpressions:
     - key: sidecar.istio.io/inject
       operator: NotIn
       values:
       - "false"
+
+{{- /* Case 2: no namespace label, but object selector is enabled (and revision label is not, which has priority) */}}
 {{- include "core" (mergeOverwrite (deepCopy $) (dict "Prefix" "object.") ) }}
   namespaceSelector:
     matchExpressions:
-    - key: istio.io/rev
-      operator: DoesNotExist
     - key: istio-injection
+      operator: DoesNotExist
+    - key: istio.io/rev
       operator: DoesNotExist
   objectSelector:
     matchExpressions:
     - key: sidecar.istio.io/inject
-      operator: NotIn
-      values:
-      - "false"
-    - key: istio.io/rev
       operator: In
       values:
-      - "{{ $tagName }}"
+      - "true"
+    - key: istio.io/rev
+      operator: DoesNotExist
+
+{{- end }}
 {{- end }}


### PR DESCRIPTION
Makes it so that creating revision tag `default` will inject for namespace labels `istio-injection=enabled` and workload labels `sidecar.istio.io/inject` in addition to `istio.io/rev=default`.

[ ] Configuration Infrastructure
[ ] Docs
[x] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any changes that may affect Istio users.
