### PR TITLE
[do not merge] enable mesh config validation in admission webhook

### DIFF
--- a/manifests/charts/base/files/gen-istio-cluster.yaml
+++ b/manifests/charts/base/files/gen-istio-cluster.yaml
@@ -6294,3 +6294,31 @@ webhooks:
     failurePolicy: Ignore
     sideEffects: None
     admissionReviewVersions: ["v1beta1", "v1"]
+  - name: meshconfig-validation.istio.io
+    clientConfig:
+      service:
+        name: istiod
+        namespace: istio-system
+        path: "/validate"
+      caBundle: "" # patched at runtime when the webhook is ready.
+    rules:
+      - operations:
+        - CREATE
+        - UPDATE
+        apiGroups:
+        - ''
+        apiVersions:
+        - '*'
+        resources:
+        - configmaps
+    # Fail open until the validation webhook is ready. The webhook controller
+    # will update this to `Fail` and patch in the `caBundle` when the webhook
+    # endpoint is ready.
+    failurePolicy: Ignore
+    # Use objectSelector to only validate configmap with given label to reduce the number of validation requests.
+    objectSelector:
+      matchLabels:
+        # Use the default revision until the validation webhook is ready. The webhook controller will update this to the correct revision.
+        istio.io/rev: default
+    sideEffects: None
+    admissionReviewVersions: ["v1beta1", "v1"]

--- a/manifests/charts/base/templates/validatingwebhookconfiguration.yaml
+++ b/manifests/charts/base/templates/validatingwebhookconfiguration.yaml
@@ -36,5 +36,37 @@ webhooks:
     failurePolicy: Ignore
     sideEffects: None
     admissionReviewVersions: ["v1beta1", "v1"]
+  - name: meshconfig-validation.istio.io
+    clientConfig:
+      {{- if .Values.base.validationURL }}
+      url: {{ .Values.base.validationURL }}
+      {{- else }}
+      service:
+        name: istiod
+        namespace: {{ .Values.global.istioNamespace }}
+        path: "/validate"
+      {{- end }}
+      caBundle: "" # patched at runtime when the webhook is ready.
+    rules:
+      - operations:
+        - CREATE
+        - UPDATE
+        apiGroups:
+        - ''
+        apiVersions:
+        - '*'
+        resources:
+        - configmaps
+    # Fail open until the validation webhook is ready. The webhook controller
+    # will update this to `Fail` and patch in the `caBundle` when the webhook
+    # endpoint is ready.
+    failurePolicy: Ignore
+    # Use objectSelector to only validate configmap with given label to reduce the number of validation requests.
+    objectSelector:
+      matchLabels:
+        # Use the default revision until the validation webhook is ready. The webhook controller will update this to the correct revision.
+        istio.io/rev: default
+    sideEffects: None
+    admissionReviewVersions: ["v1beta1", "v1"]
 ---
 {{- end }}

--- a/pilot/pkg/bootstrap/validation.go
+++ b/pilot/pkg/bootstrap/validation.go
@@ -43,9 +43,11 @@ func (s *Server) initConfigValidation(args *PilotArgs) error {
 	log.Info("initializing config validator")
 	// always start the validation server
 	params := server.Options{
-		Schemas:      collections.Istio,
-		DomainSuffix: args.RegistryOptions.KubeOptions.DomainSuffix,
-		Mux:          s.httpsMux,
+		Schemas:             collections.Istio,
+		DomainSuffix:        args.RegistryOptions.KubeOptions.DomainSuffix,
+		MeshConfigNamespace: args.Namespace,
+		MeshConfigMapName:   getMeshConfigMapName(args.Revision),
+		Mux:                 s.httpsMux,
 	}
 	whServer, err := server.New(params)
 	if err != nil {
@@ -64,6 +66,7 @@ func (s *Server) initConfigValidation(args *PilotArgs) error {
 
 		o := controller.Options{
 			WatchedNamespace:  args.Namespace,
+			Revision:          args.Revision,
 			CABundleWatcher:   s.istiodCertBundleWatcher,
 			WebhookConfigName: webhookConfigName,
 			ServiceName:       "istiod",

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -1428,7 +1428,7 @@ func IsNegativeDuration(in time.Duration) error {
 	return nil
 }
 
-// ValidateMeshConfig checks that the mesh config is well-formed
+// ValidateMeshConfig checks that the mesh config is well-formed, invalid mesh config will be rejected by validation webhook.
 func ValidateMeshConfig(mesh *meshconfig.MeshConfig) (errs error) {
 	if err := ValidatePort(int(mesh.ProxyListenPort)); err != nil {
 		errs = multierror.Append(errs, multierror.Prefix(err, "invalid proxy listen port:"))
@@ -1461,7 +1461,7 @@ func ValidateMeshConfig(mesh *meshconfig.MeshConfig) (errs error) {
 	}
 
 	if err := validateExtensionProvider(mesh); err != nil {
-		scope.Warnf("found invalid extension provider (can be ignored if the given extension provider is not used): %v", err)
+		errs = multierror.Append(errs, err)
 	}
 
 	return

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -415,6 +415,7 @@ func TestValidateMeshConfig(t *testing.T) {
 			"trustDomainAliases[0]",
 			"trustDomainAliases[1]",
 			"trustDomainAliases[2]",
+			"extension provider default: port number 999999 must be in the range 1..65535",
 		}
 		switch err := err.(type) {
 		case *multierror.Error:

--- a/pkg/webhooks/validation/server/monitoring.go
+++ b/pkg/webhooks/validation/server/monitoring.go
@@ -101,4 +101,6 @@ const (
 	reasonUnknownType          = "unknown_type"
 	reasonCRDConversionError   = "crd_conversion_error"
 	reasonInvalidConfig        = "invalid_resource"
+	reasonInvalidMeshConfig    = "invalid_mesh_config"
+	reasonMeshConfigParseError = "mesh_config_parse_error"
 )


### PR DESCRIPTION
Do not merge, opened for discussions for now.

Currently this works for in-place upgrade but not the canary upgrade. There seems 2 problems in canary upgrade:
1. the validation webhook `istiod-istio-system` always points to the `istiod` service, which may not understand the configmap and always reject it;
2. we cannot reuse the `objectSelector` in the current webhook config if there are 2+ canaries, otherwise the latest installed canary will always override the old ones;

It seems we should create a dedicated (canary-based) validation webhook just for the meshconfig only? (the CRD will still use the current `istiod-istio-system`, no changes to that part)? cc @costinm @howardjohn 

This PR enables the validation webhook for MeshConfig. Note this is not only for the new extension provider field, validation on other fields are now also checked in the validation webhook.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[x] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any changes that may affect Istio users.