### PR TITLE
revert to use deprecated values for timeouts

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -548,8 +548,9 @@ func buildCatchAllVirtualHost(node *model.Proxy) *route.VirtualHost {
 		routeAction := &route.RouteAction{
 			ClusterSpecifier: &route.RouteAction_Cluster{Cluster: egressCluster},
 			// Disable timeout instead of assuming some defaults.
-			Timeout:           notimeout,
-			MaxStreamDuration: &route.RouteAction_MaxStreamDuration{MaxStreamDuration: notimeout},
+			Timeout: notimeout,
+			// Use deprecated value for now as the replacement MaxStreamDuration has some regressions.
+			MaxGrpcTimeout: notimeout,
 		}
 
 		return &route.VirtualHost{

--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -550,6 +550,7 @@ func buildCatchAllVirtualHost(node *model.Proxy) *route.VirtualHost {
 			// Disable timeout instead of assuming some defaults.
 			Timeout: notimeout,
 			// Use deprecated value for now as the replacement MaxStreamDuration has some regressions.
+			// nolint: staticcheck
 			MaxGrpcTimeout: notimeout,
 		}
 

--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -405,6 +405,7 @@ func translateRoute(push *model.PushContext, node *model.Proxy, in *networking.H
 		}
 		action.Timeout = d
 		// Use deprecated value for now as the replacement MaxStreamDuration has some regressions.
+		// nolint: staticcheck
 		action.MaxGrpcTimeout = d
 		out.Action = &route.Route_Route{Route: action}
 

--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -404,6 +404,7 @@ func translateRoute(push *model.PushContext, node *model.Proxy, in *networking.H
 			d = features.DefaultRequestTimeout
 		}
 		action.Timeout = d
+		// Use deprecated value for now as the replacement MaxStreamDuration has some regressions.
 		action.MaxGrpcTimeout = d
 		out.Action = &route.Route_Route{Route: action}
 

--- a/pilot/pkg/networking/core/v1alpha3/route/route_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route_test.go
@@ -97,8 +97,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		g.Expect(len(routes)).To(gomega.Equal(1))
 		// Validate that when timeout is not specified, we send what is set in the timeout flag.
 		g.Expect(routes[0].GetRoute().Timeout.Seconds).To(gomega.Equal(int64(1)))
-		g.Expect(routes[0].GetRoute().MaxStreamDuration.MaxStreamDuration).To(gomega.BeNil())
-		g.Expect(routes[0].GetRoute().MaxStreamDuration.GrpcTimeoutHeaderMax.Seconds).To(gomega.Equal(int64(1)))
+		g.Expect(routes[0].GetRoute().MaxGrpcTimeout.Seconds).To(gomega.Equal(int64(1)))
 	})
 
 	t.Run("for virtual service with timeout", func(t *testing.T) {
@@ -111,8 +110,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		g.Expect(len(routes)).To(gomega.Equal(1))
 		// Validate that when timeout specified, we send the configured timeout to Envoys.
 		g.Expect(routes[0].GetRoute().Timeout.Seconds).To(gomega.Equal(int64(10)))
-		g.Expect(routes[0].GetRoute().MaxStreamDuration.MaxStreamDuration).To(gomega.BeNil())
-		g.Expect(routes[0].GetRoute().MaxStreamDuration.GrpcTimeoutHeaderMax.Seconds).To(gomega.Equal(int64(10)))
+		g.Expect(routes[0].GetRoute().MaxGrpcTimeout.Seconds).To(gomega.Equal(int64(10)))
 	})
 
 	t.Run("for virtual service with disabled timeout", func(t *testing.T) {

--- a/pilot/pkg/networking/core/v1alpha3/route/route_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route_test.go
@@ -80,7 +80,8 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		g.Expect(len(routes)).To(gomega.Equal(1))
 		// Validate that when timeout is not specified, we disable it based on default value of flag.
 		g.Expect(routes[0].GetRoute().Timeout.Seconds).To(gomega.Equal(int64(0)))
-		g.Expect(routes[0].GetRoute().MaxStreamDuration).To(gomega.BeNil())
+		// nolint: staticcheck
+		g.Expect(routes[0].GetRoute().MaxGrpcTimeout.Seconds).To(gomega.Equal(int64(0)))
 	})
 
 	t.Run("for virtual service with changed default timeout", func(t *testing.T) {
@@ -97,6 +98,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		g.Expect(len(routes)).To(gomega.Equal(1))
 		// Validate that when timeout is not specified, we send what is set in the timeout flag.
 		g.Expect(routes[0].GetRoute().Timeout.Seconds).To(gomega.Equal(int64(1)))
+		// nolint: staticcheck
 		g.Expect(routes[0].GetRoute().MaxGrpcTimeout.Seconds).To(gomega.Equal(int64(1)))
 	})
 
@@ -110,6 +112,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		g.Expect(len(routes)).To(gomega.Equal(1))
 		// Validate that when timeout specified, we send the configured timeout to Envoys.
 		g.Expect(routes[0].GetRoute().Timeout.Seconds).To(gomega.Equal(int64(10)))
+		// nolint: staticcheck
 		g.Expect(routes[0].GetRoute().MaxGrpcTimeout.Seconds).To(gomega.Equal(int64(10)))
 	})
 
@@ -122,7 +125,8 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 		g.Expect(len(routes)).To(gomega.Equal(1))
 		g.Expect(routes[0].GetRoute().Timeout.Seconds).To(gomega.Equal(int64(0)))
-		g.Expect(routes[0].GetRoute().MaxStreamDuration).To(gomega.BeNil())
+		// nolint: staticcheck
+		g.Expect(routes[0].GetRoute().MaxGrpcTimeout.Seconds).To(gomega.Equal(int64(0)))
 	})
 
 	t.Run("for virtual service with catch all route", func(t *testing.T) {


### PR DESCRIPTION
Envoy's new timeout fields have multiple issues like timeouts not being honoured and wrong return codes etc. They are planning to revisit the design and implement it properly. So in the mean time, I am reverting to use deprecated fields (old  behaviour that we used to have) so that we can fix at our side till Envoy figures out the solution.

See https://github.com/envoyproxy/envoy/pull/16131 for more details.

Fixes https://github.com/istio/istio/issues/31317
https://github.com/istio/istio/issues/31616

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any changes that may affect Istio users.
