### PR TITLE
authz-plugin: get trust domain from MeshConfig to build filters

### DIFF
--- a/pilot/pkg/networking/plugin/authz/authorization.go
+++ b/pilot/pkg/networking/plugin/authz/authorization.go
@@ -23,7 +23,6 @@ import (
 	"istio.io/istio/pilot/pkg/networking/plugin"
 	"istio.io/istio/pilot/pkg/security/authz/builder"
 	"istio.io/istio/pilot/pkg/security/trustdomain"
-	"istio.io/istio/pkg/spiffe"
 	"istio.io/pkg/log"
 )
 
@@ -79,9 +78,8 @@ func (p Plugin) buildFilter(in *plugin.InputParams, mutable *networking.MutableO
 		return
 	}
 
-	// TODO: Get trust domain from MeshConfig instead.
-	// https://github.com/istio/istio/issues/17873
-	tdBundle := trustdomain.NewBundle(spiffe.GetTrustDomain(), in.Push.Mesh.TrustDomainAliases)
+	meshConfig := in.Push.Mesh
+	tdBundle := trustdomain.NewBundle(meshConfig.TrustDomain, meshConfig.TrustDomainAliases)
 	option := builder.Option{
 		IsCustomBuilder: p.actionType == Custom,
 		Logger:          &builder.AuthzLogger{},


### PR DESCRIPTION
MeshConfig is already populated into the push context and passed to authz-plugin
callbacks as inputs. We can simply get trust domains from it instead to build
filters.

Signed-off-by: Kailun Qin <kailun.qin@intel.com>

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[x] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any changes that may affect Istio users.
