### PR TITLE
fix(typo): typo in object group and kind

### DIFF
--- a/operator/pkg/object/objects.go
+++ b/operator/pkg/object/objects.go
@@ -444,11 +444,11 @@ func DefaultObjectOrder() func(o *K8sObject) int {
 			return 4
 
 			// Pods might need configmap or secrets - avoid backoff by creating them first
-		case gk == "/ConfigMap" || gk == "/Secrets":
+		case gk == "/ConfigMap" || gk == "/Secret":
 			return 100
 
 			// Create the pods after we've created other things they might be waiting for
-		case gk == "extensions/Deployment" || gk == "app/Deployment":
+		case gk == "extensions/Deployment" || gk == "apps/Deployment":
 			return 1000
 
 			// Autoscalers typically act on a deployment


### PR DESCRIPTION
in the function object.DefaultObjectOrder():

- the group kind of Secret should be `/Secret` instead of `/Secrets`
- the group kind of Deployment should be `apps/Deployment` instead of  `app/Deployment`

And to help us figure out who should review this PR, please put an X in all the areas that this PR affects.

- [x] Installation


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

- [x] Does not have any changes that may affect Istio users.