### PR TITLE
Make installer create istiod service if none detected for revisioned install

### DIFF
--- a/operator/cmd/mesh/install.go
+++ b/operator/cmd/mesh/install.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"istio.io/api/label"
 	"istio.io/api/operator/v1alpha1"
 	"istio.io/istio/istioctl/pkg/clioptions"
 	"istio.io/istio/istioctl/pkg/install/k8sversion"
@@ -433,6 +434,14 @@ revision: "%s"
 
 	// Rename the generated service from `istiod-<revision>` to `istiod`
 	svc.Name = "istiod"
+
+	// Do not remove this service when the associated revision is removed
+	delete(svc.Labels, label.IoIstioRev.Name)
+
+	// Change selectors such that the `istiod` service selects istiod instances from all revisions
+	svc.Spec.Selector = map[string]string{
+		"app": "istiod",
+	}
 	_, err = cs.CoreV1().Services(istioNs).Create(context.TODO(), svc, metav1.CreateOptions{})
 	if err != nil {
 		return err

--- a/operator/cmd/mesh/install.go
+++ b/operator/cmd/mesh/install.go
@@ -406,9 +406,13 @@ revision: "%s"
 	deserializer := codecFactory.UniversalDeserializer
 
 	svcObject, _, err := deserializer().Decode([]byte(serviceYAML), nil, &corev1.Service{})
+	if err != nil {
+		return fmt.Errorf("failed deserializing generated manifest")
+	}
+
 	svc, ok := svcObject.(*corev1.Service)
 	if !ok {
-		return fmt.Errorf("failed deserializing manifest as service")
+		return fmt.Errorf("failed casting deserialized manifest as service")
 	}
 
 	// Rename the generated service from `istiod-<revision>` to `istiod`

--- a/operator/cmd/mesh/install.go
+++ b/operator/cmd/mesh/install.go
@@ -195,7 +195,7 @@ func runApplyCmd(cmd *cobra.Command, rootArgs *rootArgs, iArgs *installArgs, log
 		if requiresIstiodServiceCreation(clientset, name.IstioDefaultNamespace) {
 			if err := createIstiodService(clientset, name.IstioDefaultNamespace, iArgs.revision); err != nil {
 				const canaryUpgradeDoc = "https://istio.io/latest/docs/setup/upgrade/canary/"
-				warning := fmt.Sprintf("Validation cannot function without an istiod service but the installer failed" +
+				warning := fmt.Sprintf("Validation cannot function without an istiod service but the installer failed"+
 					" to create one. Please consider creating the istiod service manually as outlined in the canary upgrade documentation (%s).", canaryUpgradeDoc)
 				fmt.Fprintln(cmd.OutOrStderr(), warning)
 			}

--- a/operator/cmd/mesh/install.go
+++ b/operator/cmd/mesh/install.go
@@ -192,7 +192,7 @@ func runApplyCmd(cmd *cobra.Command, rootArgs *rootArgs, iArgs *installArgs, log
 	// Workaround for broken validation with revisions (https://github.com/istio/istio/issues/28880)
 	// TODO(Monkeyanator) remove once we have a nicer solution
 	if iArgs.revision != "" {
-		if !requiresIstiodServiceCreation(clientset, name.IstioDefaultNamespace) {
+		if requiresIstiodServiceCreation(clientset, name.IstioDefaultNamespace) {
 			if err := createIstiodService(clientset, name.IstioDefaultNamespace, iArgs.revision); err != nil {
 				warning := "Did not find existing istiod service and failed to create one."
 				fmt.Fprintln(cmd.OutOrStderr(), warning)
@@ -376,7 +376,6 @@ func requiresIstiodServiceCreation(cs kubernetes.Interface, istioNs string) bool
 		vwh, err := cs.AdmissionregistrationV1().ValidatingWebhookConfigurations().Get(
 			context.TODO(), fmt.Sprintf("istiod-%s", name.IstioDefaultNamespace), metav1.GetOptions{})
 		if err != nil {
-			fmt.Printf("oops: %v", err)
 			return false
 		}
 		// Second: if it doesn't, are there webhooks in the VWHC referencing it? If so,

--- a/operator/cmd/mesh/install.go
+++ b/operator/cmd/mesh/install.go
@@ -407,9 +407,9 @@ func createIstiodService(cs kubernetes.Interface, istioNs string) error {
 		return fmt.Errorf("failed running Helm renderer: %v", err)
 	}
 
-	values := fmt.Sprintf(`
+	values := `
 revision: ""
-`)
+`
 
 	serviceYAML, err := r.RenderManifestFiltered(values, func(tmplName string) bool {
 		return strings.Contains(tmplName, serviceTemplateName)

--- a/operator/cmd/mesh/install.go
+++ b/operator/cmd/mesh/install.go
@@ -17,7 +17,6 @@ package mesh
 import (
 	"context"
 	"fmt"
-	"istio.io/istio/pkg/url"
 	"os"
 	"sort"
 	"strings"
@@ -54,6 +53,7 @@ import (
 	operatorVer "istio.io/istio/operator/version"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/url"
 	"istio.io/pkg/log"
 )
 

--- a/operator/cmd/mesh/install.go
+++ b/operator/cmd/mesh/install.go
@@ -17,6 +17,7 @@ package mesh
 import (
 	"context"
 	"fmt"
+	"istio.io/istio/pkg/url"
 	"os"
 	"sort"
 	"strings"
@@ -195,9 +196,8 @@ func runApplyCmd(cmd *cobra.Command, rootArgs *rootArgs, iArgs *installArgs, log
 	if iArgs.revision != "" {
 		if requiresIstiodServiceCreation(clientset, name.IstioDefaultNamespace) {
 			if err := createIstiodService(clientset, name.IstioDefaultNamespace); err != nil {
-				const canaryUpgradeDoc = "https://istio.io/latest/docs/setup/upgrade/canary/"
 				warning := fmt.Sprintf("Validation cannot function without an istiod service but the installer failed"+
-					" to create one. Please consider creating the istiod service manually as outlined in the canary upgrade documentation (%s).", canaryUpgradeDoc)
+					" to create one. Please consider creating the istiod service manually as outlined in the canary upgrade documentation (%s).", url.CanaryUpgradeURL)
 				fmt.Fprintln(cmd.OutOrStderr(), warning)
 			}
 		}

--- a/operator/cmd/mesh/uninstall.go
+++ b/operator/cmd/mesh/uninstall.go
@@ -105,7 +105,7 @@ func UninstallCmd(logOpts *log.Options) *cobra.Command {
   istioctl x uninstall --purge`,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if uiArgs.revision == "" && manifest.GetValueForSetFlag(uiArgs.set, "revision") == "" && uiArgs.filename == "" && !uiArgs.purge {
-				return fmt.Errorf("at least one of the --revision(or --set revision=<revision>), --filename or --purge flags must be set")
+				return fmt.Errorf("at least one of the --revision (or --set revision=<revision>), --filename or --purge flags must be set")
 			}
 			if len(args) > 0 {
 				return fmt.Errorf("istioctl uninstall does not take arguments")
@@ -126,7 +126,7 @@ func uninstall(cmd *cobra.Command, rootArgs *rootArgs, uiArgs *uninstallArgs, lo
 	if err := configLogs(logOpts); err != nil {
 		return fmt.Errorf("could not configure logs: %s", err)
 	}
-	restConfig, _, client, err := K8sConfig(uiArgs.kubeConfigPath, uiArgs.context)
+	restConfig, clientset, client, err := K8sConfig(uiArgs.kubeConfigPath, uiArgs.context)
 	if err != nil {
 		return err
 	}
@@ -161,6 +161,11 @@ func uninstall(cmd *cobra.Command, rootArgs *rootArgs, uiArgs *uninstallArgs, lo
 			return fmt.Errorf("failed to delete control plane resources by revision: %v", err)
 		}
 		opts.ProgressLog.SetState(progress.StateUninstallComplete)
+
+		// If we're removing the default revision, add `istiod` service so we don't break existing revisions
+		if uiArgs.revision == "default" {
+			_ = createIstiodService(clientset, name.IstioDefaultNamespace)
+		}
 		return nil
 	}
 	manifestMap, iop, err := manifest.GenManifests([]string{uiArgs.filename},

--- a/pkg/url/url.go
+++ b/pkg/url/url.go
@@ -33,6 +33,9 @@ var (
 	// BaseURL for istio.io
 	BaseURL = "https://istio.io/"
 
+	// CanaryUpgradeURL is documentation for performing canary upgrades.
+	CanaryUpgradeURL = fmt.Sprintf("%s%s", DocsURL, "setup/upgrade/canary/")
+
 	// DocsVersion is a documentation version for istio.io
 	// This will build version as v1.6, v1.7, v1.8
 	DocsVersion = fmt.Sprintf("%s%s", "v", baseVersion)

--- a/releasenotes/notes/revision-install-create-istiod-service.yaml
+++ b/releasenotes/notes/revision-install-create-istiod-service.yaml
@@ -4,5 +4,5 @@ area: installation
 releaseNotes:
   - |
     **Fixed** a bug resulting in broken resource validation when a fresh Istio installation specified a revision. Note that
-    this fix applies only when using the `istioctl` installation method, the manual steps documented at
-    https://istio.io/latest/docs/setup/upgrade/canary/ are still required if Helm or the in-cluster operator.
+    this fix applies only when using the `istioctl` installation method, the manual steps from the [canary upgrade documentation](https://istio.io/latest/docs/setup/upgrade/canary/)
+    are still required if using Helm or the in-cluster operator.

--- a/releasenotes/notes/revision-install-create-istiod-service.yaml
+++ b/releasenotes/notes/revision-install-create-istiod-service.yaml
@@ -3,5 +3,6 @@ kind: bug-fix
 area: installation
 releaseNotes:
   - |
-    **Fixed** a bug resulting in broken resource validation when a fresh Istio installation specified a revision. Please
-    note that subsequent revisioned installations still require manual creation of the istiod service as described in the canary upgrade documentation.
+    **Fixed** a bug resulting in broken resource validation when a fresh Istio installation specified a revision. Note that
+    this fix applies only when using the `istioctl` installation method, the manual steps documented at
+    https://istio.io/latest/docs/setup/upgrade/canary/ are still required if Helm or the in-cluster operator.

--- a/releasenotes/notes/revision-install-create-istiod-service.yaml
+++ b/releasenotes/notes/revision-install-create-istiod-service.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+releaseNotes:
+  - |
+    **Fixed** a bug resulting in broken resource validation when a fresh Istio installation specified a revision. Please
+    note that subsequent revisioned installations still require manual creation of the istiod service as described in the canary upgrade documentation.


### PR DESCRIPTION
Lets users do `istioctl install --revision blah` without extra steps

When installing with a revision and there's no istiod service in the cluster go ahead and create the `istiod` service. Not sure how to make this work well with external istiod (shouldn't _break_ things but would create istiod service when not necessary IIUC).

Workaround is best effort so we warn but don't fail out.

[ ] Configuration Infrastructure
[ ] Docs
[x] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
