### PR TITLE
Improve internal-debug and use it in tf Dump commands

### DIFF
--- a/istioctl/cmd/internal-debug.go
+++ b/istioctl/cmd/internal-debug.go
@@ -15,7 +15,6 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"strings"
@@ -23,7 +22,6 @@ import (
 	envoy_corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"github.com/spf13/cobra"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"istio.io/istio/istioctl/pkg/clioptions"
 	"istio.io/istio/istioctl/pkg/multixds"
@@ -32,13 +30,8 @@ import (
 	"istio.io/istio/pkg/kube"
 )
 
-const (
-	istiodServiceName = "istiod"
-	xdsPortName       = "https-dns"
-)
-
 func HandlerForRetrieveDebugList(kubeClient kube.ExtendedClient,
-	centralOpts *clioptions.CentralControlPlaneOptions,
+	centralOpts clioptions.CentralControlPlaneOptions,
 	writer io.Writer) (map[string]*xdsapi.DiscoveryResponse, error) {
 	var namespace, serviceAccount string
 	xdsRequest := xdsapi.DiscoveryRequest{
@@ -70,7 +63,7 @@ func HandlerForDebugErrors(kubeClient kube.ExtendedClient,
 					"edsz?proxyID=istio-ingressgateway")
 
 			case strings.Contains(eString, "404 page not found"):
-				return HandlerForRetrieveDebugList(kubeClient, centralOpts, writer)
+				return HandlerForRetrieveDebugList(kubeClient, *centralOpts, writer)
 
 			case strings.Contains(eString, "querystring parameter 'resource' is required"):
 				return nil, fmt.Errorf("querystring parameter 'resource' is required, e.g. [%s]",
@@ -137,83 +130,33 @@ By default it will use the default serviceAccount from (istio-system) namespace 
 				TypeUrl: v3.DebugType,
 			}
 
-			svc, err := kubeClient.CoreV1().Services(istioNamespace).Get(context.Background(), istiodServiceName, metav1.GetOptions{})
+			xdsResponses, err := multixds.MultiRequestAndProcessXds(internalDebugAllIstiod, &xdsRequest, centralOpts, istioNamespace,
+				namespace, serviceAccount, kubeClient)
 			if err != nil {
-				return fmt.Errorf("please specify %q as %v", "--xds-address", err)
+				return err
 			}
-			podPort := 15012
-			for _, v := range svc.Spec.Ports {
-				if v.Name == xdsPortName {
-					podPort = v.TargetPort.IntValue()
-				}
+			sw := pilot.XdsStatusWriter{
+				Writer:                 c.OutOrStdout(),
+				InternalDebugAllIstiod: internalDebugAllIstiod,
 			}
-
-			labelSelector := centralOpts.XdsPodLabel
-			if labelSelector == "" {
-				labelSelector = "app=istiod"
+			newResponse, err := HandlerForDebugErrors(kubeClient, &centralOpts, c.OutOrStdout(), xdsResponses)
+			if err != nil {
+				return err
 			}
-			podList, podErr := kubeClient.GetIstioPods(context.TODO(), istioNamespace, map[string]string{
-				"labelSelector": labelSelector,
-				"fieldSelector": "status.phase=Running",
-			})
-			if podErr != nil {
-				return podErr
-			}
-			if len(podList) == 0 {
-				return fmt.Errorf("no running Istio pods in %q", istioNamespace)
+			if newResponse != nil {
+				return sw.PrintAll(newResponse)
 			}
 
-			var isNull bool = false
-			var printErr error
-			// Iterate all istiod pods for retrieving debug information
-			for _, pod := range podList {
-				fmt.Println("------------------------------------------------------------------------------")
-				fmt.Println("istioctl x debug for pod: ", pod.Name+"."+pod.Namespace)
-				fmt.Println("------------------------------------------------------------------------------")
-				if centralOpts.Xds == "" {
-					isNull = true
-					f, kcerr := kubeClient.NewPortForwarder(pod.Name, pod.Namespace, "", 0, podPort)
-					if kcerr != nil {
-						return fmt.Errorf("please specify %q as %v", "--xds-address", kcerr)
-					}
-					if ferr := f.Start(); ferr != nil {
-						return fmt.Errorf("please specify %q as %v", "--xds-address", ferr)
-					}
-					centralOpts.Xds = f.Address()
-					defer func() {
-						f.Close()
-						f.WaitForStop()
-					}()
-				}
-
-				xdsResponses, respErr := multixds.AllRequestAndProcessXds(&xdsRequest, &centralOpts, istioNamespace,
-					namespace, serviceAccount, kubeClient)
-				if respErr != nil {
-					return respErr
-				}
-				sw := pilot.XdsStatusWriter{Writer: c.OutOrStdout()}
-				newResponse, hDErr := HandlerForDebugErrors(kubeClient, &centralOpts, c.OutOrStdout(), xdsResponses)
-				if newResponse != nil {
-					return sw.PrintAll(newResponse)
-				}
-				if hDErr != nil {
-					return hDErr
-				}
-				printErr = sw.PrintAll(xdsResponses)
-				if printErr != nil {
-					return printErr
-				}
-				// reset centralOpts.Xds as blank if it's originally null
-				if isNull {
-					centralOpts.Xds = ""
-				}
-			}
-			return nil
+			return sw.PrintAll(xdsResponses)
 		},
 	}
 
 	opts.AttachControlPlaneFlags(debugCommand)
 	centralOpts.AttachControlPlaneFlags(debugCommand)
 	debugCommand.Long += "\n\n" + ExperimentalMsg
+	debugCommand.PersistentFlags().BoolVar(&internalDebugAllIstiod, "all", false,
+		"Send the same request to all instances of Istiod. Only applicable for in-cluster deployment.")
 	return debugCommand
 }
+
+var internalDebugAllIstiod bool

--- a/istioctl/cmd/proxystatus.go
+++ b/istioctl/cmd/proxystatus.go
@@ -202,7 +202,7 @@ Retrieves last sent and last acknowledged xDS sync from Istiod to each Envoy in 
 					ResourceNames: []string{fmt.Sprintf("%s.%s", podName, ns)},
 					TypeUrl:       pilotxds.TypeDebugConfigDump,
 				}
-				xdsResponses, err := multixds.FirstRequestAndProcessXds(&xdsRequest, &centralOpts, istioNamespace, "", "", kubeClient)
+				xdsResponses, err := multixds.FirstRequestAndProcessXds(&xdsRequest, centralOpts, istioNamespace, "", "", kubeClient)
 				if err != nil {
 					return err
 				}
@@ -216,7 +216,7 @@ Retrieves last sent and last acknowledged xDS sync from Istiod to each Envoy in 
 			xdsRequest := xdsapi.DiscoveryRequest{
 				TypeUrl: pilotxds.TypeDebugSyncronization,
 			}
-			xdsResponses, err := multixds.AllRequestAndProcessXds(&xdsRequest, &centralOpts, istioNamespace, "", "", kubeClient)
+			xdsResponses, err := multixds.AllRequestAndProcessXds(&xdsRequest, centralOpts, istioNamespace, "", "", kubeClient)
 			if err != nil {
 				return err
 			}

--- a/istioctl/cmd/version.go
+++ b/istioctl/cmd/version.go
@@ -157,7 +157,7 @@ func xdsRemoteVersionWrapper(opts *clioptions.ControlPlaneOptions, centralOpts *
 		if err != nil {
 			return nil, err
 		}
-		xdsResponse, err := multixds.RequestAndProcessXds(&xdsRequest, centralOpts, istioNamespace, kubeClient)
+		xdsResponse, err := multixds.RequestAndProcessXds(&xdsRequest, *centralOpts, istioNamespace, kubeClient)
 		if err != nil {
 			return nil, err
 		}

--- a/istioctl/pkg/writer/pilot/status.go
+++ b/istioctl/pkg/writer/pilot/status.go
@@ -42,7 +42,8 @@ type writerStatus struct {
 
 // XdsStatusWriter enables printing of sync status using multiple xdsapi.DiscoveryResponse Istiod responses
 type XdsStatusWriter struct {
-	Writer io.Writer
+	Writer                 io.Writer
+	InternalDebugAllIstiod bool
 }
 
 type xdsWriterStatus struct {
@@ -158,8 +159,9 @@ func (s *XdsStatusWriter) PrintAll(statuses map[string]*xdsapi.DiscoveryResponse
 func (s *XdsStatusWriter) setupStatusPrint(drs map[string]*xdsapi.DiscoveryResponse) (*tabwriter.Writer, []*xdsWriterStatus, error) {
 	// Gather the statuses before printing so they may be sorted
 	var fullStatus []*xdsWriterStatus
+	mappedResp := map[string]string{}
 	var w *tabwriter.Writer
-	for _, dr := range drs {
+	for id, dr := range drs {
 		for _, resource := range dr.Resources {
 			switch resource.TypeUrl {
 			case "type.googleapis.com/envoy.service.status.v3.ClientConfig":
@@ -191,11 +193,24 @@ func (s *XdsStatusWriter) setupStatusPrint(drs map[string]*xdsapi.DiscoveryRespo
 				})
 			default:
 				for _, resource := range dr.Resources {
-					s.Writer.Write(resource.Value) // nolint: errcheck
+					if s.InternalDebugAllIstiod {
+						mappedResp[id] = string(resource.Value) + "\n"
+					} else {
+						_, _ = s.Writer.Write(resource.Value)
+						_, _ = s.Writer.Write([]byte("\n"))
+					}
 				}
 				fullStatus = nil
 			}
 		}
+	}
+	if len(mappedResp) > 0 {
+		mresp, err := json.MarshalIndent(mappedResp, "", "  ")
+		if err != nil {
+			return nil, nil, err
+		}
+		_, _ = s.Writer.Write(mresp)
+		_, _ = s.Writer.Write([]byte("\n"))
 	}
 
 	return w, fullStatus, nil

--- a/istioctl/pkg/xds/client.go
+++ b/istioctl/pkg/xds/client.go
@@ -40,7 +40,7 @@ const (
 var tokenAudiences = []string{"istio-ca"}
 
 // GetXdsResponse opens a gRPC connection to opts.xds and waits for a single response
-func GetXdsResponse(dr *xdsapi.DiscoveryRequest, ns string, serviceAccount string, opts *clioptions.CentralControlPlaneOptions,
+func GetXdsResponse(dr *xdsapi.DiscoveryRequest, ns string, serviceAccount string, opts clioptions.CentralControlPlaneOptions,
 	grpcOpts []grpc.DialOption) (*xdsapi.DiscoveryResponse, error) {
 	adscConn, err := adsc.NewWithBackoffPolicy(opts.Xds, &adsc.Config{
 		Meta: model.NodeMetadata{
@@ -70,8 +70,8 @@ func GetXdsResponse(dr *xdsapi.DiscoveryRequest, ns string, serviceAccount strin
 }
 
 // DialOptions constructs gRPC dial options from command line configuration
-func DialOptions(opts *clioptions.CentralControlPlaneOptions,
-	ns string, serviceAccount string, istioNamespace string, kubeClient kube.ExtendedClient) ([]grpc.DialOption, error) {
+func DialOptions(opts clioptions.CentralControlPlaneOptions,
+	ns string, serviceAccount string, kubeClient kube.ExtendedClient) ([]grpc.DialOption, error) {
 	// If we are using the insecure 15010 don't bother getting a token
 	if opts.Plaintext || opts.CertDir != "" {
 		return make([]grpc.DialOption, 0), nil

--- a/pilot/pkg/xds/debug.go
+++ b/pilot/pkg/xds/debug.go
@@ -91,7 +91,7 @@ type AdsClient struct {
 	ConnectionID string              `json:"connectionId"`
 	ConnectedAt  time.Time           `json:"connectedAt"`
 	PeerAddress  string              `json:"address"`
-	Watches      map[string][]string `json:"watches"`
+	Watches      map[string][]string `json:"watches,omitempty"`
 }
 
 // AdsClients is collection of AdsClient connected to this Istiod.

--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -250,7 +250,7 @@ func (i *operatorComponent) Dump(ctx resource.Context) {
 	}
 	kube2.DumpPods(ctx, d, ns)
 	for _, cluster := range ctx.Clusters().Kube() {
-		kube2.DumpDebug(cluster, d, "configz")
+		kube2.DumpDebug(ctx, cluster, d, "configz")
 	}
 }
 

--- a/pkg/test/framework/components/istioctl/istioctl.go
+++ b/pkg/test/framework/components/istioctl/istioctl.go
@@ -43,7 +43,7 @@ type Config struct {
 
 // New returns a new instance of "istioctl".
 func New(ctx resource.Context, cfg Config) (i Instance, err error) {
-	return newKube(ctx, cfg), nil
+	return newKube(ctx, cfg)
 }
 
 // NewOrFail returns a new instance of "istioctl".

--- a/pkg/test/framework/components/istioctl/kube.go
+++ b/pkg/test/framework/components/istioctl/kube.go
@@ -22,29 +22,31 @@ import (
 	"istio.io/istio/istioctl/cmd"
 	"istio.io/istio/pilot/pkg/config/kube/crd"
 	"istio.io/istio/pkg/test"
-	kubecluster "istio.io/istio/pkg/test/framework/components/cluster/kube"
 	"istio.io/istio/pkg/test/framework/resource"
 )
 
 type kubeComponent struct {
-	config  Config
-	id      resource.ID
-	cluster *kubecluster.Cluster
+	config     Config
+	kubeconfig string
 }
 
-func newKube(ctx resource.Context, config Config) Instance {
-	n := &kubeComponent{
-		config:  config,
-		cluster: ctx.Clusters().GetOrDefault(config.Cluster).(*kubecluster.Cluster),
+// Filenamer is an interface to avoid importing kubecluster package, instead build our own interface
+// to extract kube context
+type Filenamer interface {
+	Filename() string
+}
+
+func newKube(ctx resource.Context, config Config) (Instance, error) {
+	fn, ok := ctx.Clusters().GetOrDefault(config.Cluster).(Filenamer)
+	if !ok {
+		return nil, fmt.Errorf("cluster does not support fetching kube config")
 	}
-	n.id = ctx.TrackResource(n)
+	n := &kubeComponent{
+		config:     config,
+		kubeconfig: fn.Filename(),
+	}
 
-	return n
-}
-
-// ID implements resource.Instance
-func (c *kubeComponent) ID() resource.ID {
-	return c.id
+	return n, nil
 }
 
 // Invoke implements WaitForConfigs
@@ -69,7 +71,7 @@ func (c *kubeComponent) WaitForConfigs(defaultNamespace string, configs string) 
 func (c *kubeComponent) Invoke(args []string) (string, string, error) {
 	cmdArgs := append([]string{
 		"--kubeconfig",
-		c.cluster.Filename(),
+		c.kubeconfig,
 	}, args...)
 
 	var out bytes.Buffer


### PR DESCRIPTION
* Support external istiod without XDS Address. If no pod are found for
the revision, we will fetch the URL from the webhook as a fallback
mechanism.
* Improve the output. Currently, we always fetch from all istiods and
then emit some non-json output to distinguish the requests. This is hard
to read/parse in the case we do want all requests, and excessive
verbosity/performance when we only care about one. Instead, expose a
--all flag, off by default. When set, we will query all Istiod's, but
put the response in a structured JSON blob. When unset, we just output
the response from Istiod directly.
* Switch Dumping or configz and ndsz in test framework to use the new
command. This both tests the command and makes tf dumping work for
external Istiod tests. I would also like bug-report to do it, but the PR is pretty
big.
* Some smaller refactorings in the istioctl code to make this PR cleaner



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.