### PR TITLE
Avoid bad multierror format

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -40,6 +40,7 @@ import (
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/proto"
+	"istio.io/istio/pkg/util/istiomultierror"
 	"istio.io/pkg/log"
 )
 
@@ -53,9 +54,7 @@ func (configgen *ConfigGeneratorImpl) buildGatewayListeners(builder *ListenerBui
 	log.Debugf("buildGatewayListeners: gateways after merging: %v", mergedGateway)
 
 	actualWildcard, _ := getActualWildcardAndLocalHost(builder.node)
-	errs := &multierror.Error{
-		ErrorFormat: util.MultiErrorFormat(),
-	}
+	errs := istiomultierror.New()
 	listeners := make([]*listener.Listener, 0)
 	proxyConfig := builder.node.Metadata.ProxyConfigOrDefault(builder.push.Mesh.DefaultConfig)
 	for port, ms := range mergedGateway.MergedServers {

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -36,7 +36,6 @@ import (
 	"github.com/golang/protobuf/ptypes/duration"
 	pstruct "github.com/golang/protobuf/ptypes/struct"
 	"github.com/golang/protobuf/ptypes/wrappers"
-	"github.com/hashicorp/go-multierror"
 	"google.golang.org/protobuf/types/known/durationpb"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
@@ -677,25 +676,6 @@ func toIPNet(c *core.CidrRange) (*net.IPNet, error) {
 // due to the UNDEFINED in the meshconfig ForwardClientCertDetails
 func MeshConfigToEnvoyForwardClientCertDetails(c meshconfig.Topology_ForwardClientCertDetails) http_conn.HttpConnectionManager_ForwardClientCertDetails {
 	return http_conn.HttpConnectionManager_ForwardClientCertDetails(c - 1)
-}
-
-// MultiErrorFormat provides a format for multierrors. This matches the default format, but if there
-// is only one error we will not expand to multiple lines.
-func MultiErrorFormat() multierror.ErrorFormatFunc {
-	return func(es []error) string {
-		if len(es) == 1 {
-			return es[0].Error()
-		}
-
-		points := make([]string, len(es))
-		for i, err := range es {
-			points[i] = fmt.Sprintf("* %s", err)
-		}
-
-		return fmt.Sprintf(
-			"%d errors occurred:\n\t%s\n\n",
-			len(es), strings.Join(points, "\n\t"))
-	}
 }
 
 // ByteCount returns a human readable byte format

--- a/pilot/pkg/security/authz/builder/logger.go
+++ b/pilot/pkg/security/authz/builder/logger.go
@@ -21,7 +21,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 
 	"istio.io/istio/pilot/pkg/networking/plugin"
-	"istio.io/istio/pilot/pkg/networking/util"
+	"istio.io/istio/pkg/util/istiomultierror"
 	"istio.io/pkg/log"
 )
 
@@ -42,7 +42,7 @@ func (al *AuthzLogger) AppendError(err error) {
 
 func (al *AuthzLogger) Report(in *plugin.InputParams) {
 	if al.errMsg != nil {
-		al.errMsg.ErrorFormat = util.MultiErrorFormat()
+		al.errMsg.ErrorFormat = istiomultierror.MultiErrorFormat()
 		authzLog.Errorf("Processed authorization policy for %s, %s", in.Node.ID, al.errMsg)
 	}
 	if authzLog.DebugEnabled() && len(al.debugMsg) != 0 {

--- a/pkg/test/echo/client/parsedresponse.go
+++ b/pkg/test/echo/client/parsedresponse.go
@@ -26,6 +26,7 @@ import (
 	"istio.io/istio/pkg/test/echo/common/response"
 	"istio.io/istio/pkg/test/echo/proto"
 	"istio.io/istio/pkg/test/framework/components/cluster"
+	"istio.io/istio/pkg/util/istiomultierror"
 )
 
 var (
@@ -108,17 +109,17 @@ func (r ParsedResponses) Len() int {
 	return len(r)
 }
 
-func (r ParsedResponses) Check(check func(int, *ParsedResponse) error) (err error) {
+func (r ParsedResponses) Check(check func(int, *ParsedResponse) error) error {
 	if r.Len() == 0 {
 		return fmt.Errorf("no responses received")
 	}
-
+	err := istiomultierror.New()
 	for i, resp := range r {
 		if e := check(i, resp); e != nil {
 			err = multierror.Append(err, e)
 		}
 	}
-	return
+	return err.ErrorOrNil()
 }
 
 func (r ParsedResponses) CheckOrFail(t test.Failer, check func(int, *ParsedResponse) error) ParsedResponses {

--- a/pkg/test/framework/components/echo/kube/instance.go
+++ b/pkg/test/framework/components/echo/kube/instance.go
@@ -31,6 +31,7 @@ import (
 	"istio.io/istio/pkg/test/framework/components/echo/common"
 	"istio.io/istio/pkg/test/framework/resource"
 	"istio.io/istio/pkg/test/util/retry"
+	"istio.io/istio/pkg/util/istiomultierror"
 )
 
 const (
@@ -209,18 +210,18 @@ func (c *instance) aggregateResponses(opts echo.CallOptions, retry bool, retryOp
 	if err != nil {
 		return nil, err
 	}
-	var aggErr error
+	aggErr := istiomultierror.New()
 	for _, w := range workloads {
 		out, err := common.ForwardEcho(c.cfg.Service, w.(*workload).Client, &opts, retry, retryOptions...)
 		if err != nil {
-			aggErr = multierror.Append(err, aggErr)
+			aggErr = multierror.Append(aggErr, err)
 			continue
 		}
 		for _, r := range out {
 			resps = append(resps, r)
 		}
 	}
-	if aggErr != nil {
+	if aggErr.ErrorOrNil() != nil {
 		return nil, aggErr
 	}
 

--- a/pkg/util/istiomultierror/util.go
+++ b/pkg/util/istiomultierror/util.go
@@ -1,0 +1,47 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package istiomultierror
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+)
+
+// MultiErrorFormat provides a format for multierrors. This matches the default format, but if there
+// is only one error we will not expand to multiple lines.
+func MultiErrorFormat() multierror.ErrorFormatFunc {
+	return func(es []error) string {
+		if len(es) == 1 {
+			return es[0].Error()
+		}
+
+		points := make([]string, len(es))
+		for i, err := range es {
+			points[i] = fmt.Sprintf("* %s", err)
+		}
+
+		return fmt.Sprintf(
+			"%d errors occurred:\n\t%s\n\n",
+			len(es), strings.Join(points, "\n\t"))
+	}
+}
+
+func New() *multierror.Error {
+	return &multierror.Error{
+		ErrorFormat: MultiErrorFormat(),
+	}
+}

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -1023,7 +1023,7 @@ spec:
 				Address:   "b-alt-3",
 				Port:      &echo.Port{ServicePort: 12345, Protocol: protocol.HTTP},
 				Timeout:   time.Millisecond * 100,
-				Validator: echo.ExpectCode("123"),
+				Validator: echo.ExpectOK(),
 			},
 		})
 

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -1023,7 +1023,7 @@ spec:
 				Address:   "b-alt-3",
 				Port:      &echo.Port{ServicePort: 12345, Protocol: protocol.HTTP},
 				Timeout:   time.Millisecond * 100,
-				Validator: echo.ExpectOK(),
+				Validator: echo.ExpectCode("123"),
 			},
 		})
 


### PR DESCRIPTION
Current we get horrible errors like:
```
    traffic.go:180: 1 error occurred:
        	* failed calling a->'://fake.service.local?&protocol=tcp&server=127.0.0.1:0/': call failed from a to dns://fake.service.local?&protocol=tcp&server=127.0.0.1 (using dns): timeout while waiting after 20 attempts, 0/3 successes (last error: 1 error occurred:
        	* unexpected dns response: wanted [], got [1.2.3.4]

        )

```

With this change, it looks instead like:
```
    traffic.go:180: failed calling a->'http://b-alt-3:12345/': call failed from a to http://b-alt-3:12345 (using http): timeout while waiting after 5 attempts, 0/3 successes (last error: expected response code 123, got "200")
```

(different test failure, but same concept)

This is done using `multierror.ErrorFormat`. We used this in a few places, but I refactored it out into a common library so
it can be used by all parts of the code.

The alternative to this would be to just completely fork the multierror
package but I avoided doing that for now.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
