### PR TITLE
optimize GetDeployMetaFromPod

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/endpoint_builder.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpoint_builder.go
@@ -47,7 +47,7 @@ type EndpointBuilder struct {
 }
 
 func NewEndpointBuilder(c controllerInterface, pod *v1.Pod) *EndpointBuilder {
-	locality, sa, wn, namespace, hostname, subdomain := "", "", "", "", "", ""
+	locality, sa, namespace, hostname, subdomain := "", "", "", "", ""
 	var podLabels labels.Instance
 	if pod != nil {
 		locality = c.getPodLocality(pod)
@@ -63,9 +63,6 @@ func NewEndpointBuilder(c controllerInterface, pod *v1.Pod) *EndpointBuilder {
 		}
 	}
 	dm, _ := kubeUtil.GetDeployMetaFromPod(pod)
-	if dm != nil {
-		wn = dm.Name
-	}
 
 	return &EndpointBuilder{
 		controller:     c,
@@ -76,7 +73,7 @@ func NewEndpointBuilder(c controllerInterface, pod *v1.Pod) *EndpointBuilder {
 			ClusterID: c.Cluster(),
 		},
 		tlsMode:      kube.PodTLSMode(pod),
-		workloadName: wn,
+		workloadName: dm.Name,
 		namespace:    namespace,
 		hostname:     hostname,
 		subDomain:    subdomain,

--- a/pkg/kube/inject/inject.go
+++ b/pkg/kube/inject/inject.go
@@ -86,8 +86,8 @@ const (
 // SidecarTemplateData is the data object to which the templated
 // version of `SidecarInjectionSpec` is applied.
 type SidecarTemplateData struct {
-	TypeMeta       *metav1.TypeMeta
-	DeploymentMeta *metav1.ObjectMeta
+	TypeMeta       metav1.TypeMeta
+	DeploymentMeta metav1.ObjectMeta
 	ObjectMeta     metav1.ObjectMeta
 	Spec           corev1.PodSpec
 	ProxyConfig    *meshconfig.ProxyConfig
@@ -551,10 +551,10 @@ func IntoObject(injector Injector, sidecarTemplate Templates, valuesConfig strin
 	revision string, meshconfig *meshconfig.MeshConfig, in runtime.Object, warningHandler func(string)) (interface{}, error) {
 	out := in.DeepCopyObject()
 
-	var deploymentMetadata *metav1.ObjectMeta
+	var deploymentMetadata metav1.ObjectMeta
 	var metadata *metav1.ObjectMeta
 	var podSpec *corev1.PodSpec
-	var typeMeta *metav1.TypeMeta
+	var typeMeta metav1.TypeMeta
 
 	// Handle Lists
 	if list, ok := out.(*corev1.List); ok {
@@ -586,29 +586,29 @@ func IntoObject(injector Injector, sidecarTemplate Templates, valuesConfig strin
 	switch v := out.(type) {
 	case *batch.CronJob:
 		job := v
-		typeMeta = &job.TypeMeta
+		typeMeta = job.TypeMeta
 		metadata = &job.Spec.JobTemplate.ObjectMeta
-		deploymentMetadata = &job.ObjectMeta
+		deploymentMetadata = job.ObjectMeta
 		podSpec = &job.Spec.JobTemplate.Spec.Template.Spec
 	case *corev1.Pod:
 		pod := v
-		typeMeta = &pod.TypeMeta
+		typeMeta = pod.TypeMeta
 		metadata = &pod.ObjectMeta
-		deploymentMetadata = &pod.ObjectMeta
+		deploymentMetadata = pod.ObjectMeta
 		podSpec = &pod.Spec
 	case *appsv1.Deployment: // Added to be explicit about the most expected case
 		deploy := v
-		typeMeta = &deploy.TypeMeta
-		deploymentMetadata = &deploy.ObjectMeta
+		typeMeta = deploy.TypeMeta
+		deploymentMetadata = deploy.ObjectMeta
 		metadata = &deploy.Spec.Template.ObjectMeta
 		podSpec = &deploy.Spec.Template.Spec
 	default:
 		// `in` is a pointer to an Object. Dereference it.
 		outValue := reflect.ValueOf(out).Elem()
 
-		typeMeta = outValue.FieldByName("TypeMeta").Addr().Interface().(*metav1.TypeMeta)
+		typeMeta = outValue.FieldByName("TypeMeta").Interface().(metav1.TypeMeta)
 
-		deploymentMetadata = outValue.FieldByName("ObjectMeta").Addr().Interface().(*metav1.ObjectMeta)
+		deploymentMetadata = outValue.FieldByName("ObjectMeta").Interface().(metav1.ObjectMeta)
 
 		templateValue := outValue.FieldByName("Spec").FieldByName("Template")
 		// `Template` is defined as a pointer in some older API

--- a/pkg/kube/inject/webhook.go
+++ b/pkg/kube/inject/webhook.go
@@ -273,8 +273,8 @@ func toAdmissionResponse(err error) *kube.AdmissionResponse {
 
 type InjectionParameters struct {
 	pod                 *corev1.Pod
-	deployMeta          *metav1.ObjectMeta
-	typeMeta            *metav1.TypeMeta
+	deployMeta          metav1.ObjectMeta
+	typeMeta            metav1.TypeMeta
 	templates           Templates
 	defaultTemplate     []string
 	aliases             map[string][]string

--- a/pkg/kube/util.go
+++ b/pkg/kube/util.go
@@ -164,16 +164,17 @@ func CheckPodReady(pod *kubeApiCore.Pod) error {
 }
 
 // GetDeployMetaFromPod heuristically derives deployment metadata from the pod spec.
-func GetDeployMetaFromPod(pod *kubeApiCore.Pod) (*metav1.ObjectMeta, *metav1.TypeMeta) {
+func GetDeployMetaFromPod(pod *kubeApiCore.Pod) (metav1.ObjectMeta, metav1.TypeMeta) {
 	if pod == nil {
-		return nil, nil
+		return metav1.ObjectMeta{}, metav1.TypeMeta{}
 	}
 	// try to capture more useful namespace/name info for deployments, etc.
 	// TODO(dougreid): expand to enable lookup of OWNERs recursively a la kubernetesenv
-	deployMeta := pod.ObjectMeta.DeepCopy()
-	deployMeta.Namespace = pod.ObjectMeta.Namespace
+	deployMeta := pod.ObjectMeta
+	deployMeta.ManagedFields = nil
+	deployMeta.OwnerReferences = nil
 
-	typeMetadata := &metav1.TypeMeta{
+	typeMetadata := metav1.TypeMeta{
 		Kind:       "Pod",
 		APIVersion: "v1",
 	}


### PR DESCRIPTION


From go pprof analysis, the metadata deepCopy has so much memory allocation.
