### PR TITLE
Fix Istio installation with samples/operator/pilot-k8s.yaml

### DIFF
--- a/operator/samples/pilot-k8s.yaml
+++ b/operator/samples/pilot-k8s.yaml
@@ -11,11 +11,3 @@ spec:
         hpaSpec:
           maxReplicas: 10 # ... default 5
           minReplicas: 2  # ... default 1
-        nodeSelector:
-          master: "true"
-        tolerations:
-        - key: dedicated
-          operator: Exists
-          effect: NoSchedule
-        - key: CriticalAddonsOnly
-          operator: Exists


### PR DESCRIPTION
To fix https://github.com/istio/istio/issues/32504

After:
```
$ istioctl install -f operator/samples/pilot-k8s.yaml  -y
✔ Istio core installed                                                                                                      
✔ Istiod installed                                                                                                          
✔ Ingress gateways installed                                                                                                
✔ Installation complete
```

```
$ kubectl get pod -n istio-system
NAME                                    READY   STATUS    RESTARTS   AGE
istio-ingressgateway-5c98cbbd99-jhqvp   1/1     Running   0          49s
istiod-6d5757696c-cf7bj                 1/1     Running   0          87s
istiod-6d5757696c-szdqv                 1/1     Running   0          103s
```