### PR TITLE
test framework: move from IstioVersions to Revisions

### DIFF
--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -87,7 +87,7 @@ spec:
 `
 
 	deploymentYAML = `
-{{- $revVerMap := .IstioVersions }}
+{{- $revVerMap := .Revisions }}
 {{- $subsets := .Subsets }}
 {{- $cluster := .Cluster }}
 {{- range $i, $subset := $subsets }}
@@ -474,7 +474,7 @@ func newDeployment(ctx resource.Context, cfg echo.Config) (*deployment, error) {
 		}
 	}
 
-	deploymentYAML, err := generateDeploymentYAML(cfg, nil, ctx.Settings().IstioVersions)
+	deploymentYAML, err := generateDeploymentYAML(cfg, nil, ctx.Settings().Revisions)
 	if err != nil {
 		return nil, fmt.Errorf("failed generating echo deployment YAML for %s/%s: %v",
 			cfg.Namespace.Name(),
@@ -604,7 +604,7 @@ var VMImages = map[echo.VMDistro]string{
 	echo.Centos8:      "app_sidecar_centos_8",
 }
 
-func templateParams(cfg echo.Config, settings *image.Settings, versions resource.RevVerMap) (map[string]interface{}, error) {
+func templateParams(cfg echo.Config, settings *image.Settings, revisions resource.RevVerMap) (map[string]interface{}, error) {
 	if settings == nil {
 		var err error
 		settings, err = image.SettingsFromCommandLine()
@@ -650,8 +650,8 @@ func templateParams(cfg echo.Config, settings *image.Settings, versions resource
 		},
 		"StartupProbe":    supportStartupProbe,
 		"IncludeExtAuthz": cfg.IncludeExtAuthz,
-		"IstioVersions":   versions.TemplateMap(),
-		"IsMultiVersion":  versions.IsMultiVersion(),
+		"Revisions":       revisions.TemplateMap(),
+		"IsMultiVersion":  revisions.IsMultiVersion(),
 	}
 	return params, nil
 }

--- a/pkg/test/framework/components/namespace/kube.go
+++ b/pkg/test/framework/components/namespace/kube.go
@@ -194,7 +194,7 @@ func createNamespaceLabels(ctx resource.Context, cfg *Config) map[string]string 
 	if cfg.Inject {
 		// do not add namespace labels when dealing with multiple revisions since
 		// this disables the necessary object selectors
-		if !ctx.Settings().IstioVersions.IsMultiVersion() {
+		if !ctx.Settings().Revisions.IsMultiVersion() {
 			if cfg.Revision != "" {
 				l[label.IoIstioRev.Name] = cfg.Revision
 			} else {
@@ -204,7 +204,7 @@ func createNamespaceLabels(ctx resource.Context, cfg *Config) map[string]string 
 	} else {
 		// for multiversion environments, disable the entire namespace explicitly
 		// so that object selectors are ignored
-		if ctx.Settings().IstioVersions.IsMultiVersion() {
+		if ctx.Settings().Revisions.IsMultiVersion() {
 			l["istio-injection"] = "disabled"
 		}
 	}

--- a/pkg/test/framework/resource/flags.go
+++ b/pkg/test/framework/resource/flags.go
@@ -52,10 +52,10 @@ func SettingsFromCommandLine(testID string) (*Settings, error) {
 				" -istio.test.deprecation_failure must not be used at the same time")
 	}
 
-	if s.Revision != "" && s.IstioVersions != nil {
+	if s.Revision != "" && s.Revisions != nil {
 		return nil,
-			fmt.Errorf("cannot use --istio.test.revision and --istio.test.versions at the same time," +
-				" --istio.test.versions will take precedence and --istio.test.revision will be ignored")
+			fmt.Errorf("cannot use --istio.test.revision and --istio.test.revisions at the same time," +
+				" --istio.test.revisions will take precedence and --istio.test.revision will be ignored")
 	}
 
 	return s, nil
@@ -96,7 +96,7 @@ func init() {
 	flag.BoolVar(&settingsFromCommandLine.SkipVM, "istio.test.skipVM", settingsFromCommandLine.SkipVM,
 		"Skip VM related parts in all tests.")
 
-	flag.Var(&settingsFromCommandLine.IstioVersions, "istio.test.versions", "Istio CP versions available to the test framework and their corresponding revisions.")
+	flag.Var(&settingsFromCommandLine.Revisions, "istio.test.revisions", "Istio CP revisions available to the test framework and their corresponding versions.")
 }
 
 type arrayFlags []string

--- a/pkg/test/framework/resource/settings.go
+++ b/pkg/test/framework/resource/settings.go
@@ -81,12 +81,13 @@ type Settings struct {
 	// Skip VM related parts for all the tests.
 	SkipVM bool
 
-	// IstioVersions maps the Istio versions that are available to each cluster to their corresponding revisions.
-	// In the future these versions should be automatically deployed to each primary cluster, but for now,
-	// this flag must be used with --istio.test.kube.deploy=false with the versions pre-installed.
-	// The map should be passed in as comma-separated values, such as "rev-a=1.7.3,rev-b=1.8.2,rev-c=1.9.0", and the test framework will
+	// Revisions maps the Istio revisions that are available to each cluster to their corresponding versions.
+	// This flag must be used with --istio.test.kube.deploy=false with the versions pre-installed.
+	// This flag should be passed in as comma-separated values, such as "rev-a=1.7.3,rev-b=1.8.2,rev-c=1.9.0", and the test framework will
 	// spin up pods pointing to these revisions for each echo instance and skip tests accordingly.
-	IstioVersions RevVerMap
+	// To configure it so that an Istio revision is on the latest version simply list the revision name without the version (i.e. "rev-a,rev-b")
+	// If using this flag with --istio.test.revision, this flag will take precedence.
+	Revisions RevVerMap
 }
 
 // RunDir is the name of the dir to output, for this particular run.
@@ -131,6 +132,6 @@ func (s *Settings) String() string {
 	result += fmt.Sprintf("StableNamespaces:  %v\n", s.StableNamespaces)
 	result += fmt.Sprintf("Revision:          %v\n", s.Revision)
 	result += fmt.Sprintf("SkipVM:            %v\n", s.SkipVM)
-	result += fmt.Sprintf("IstioVersions:     %v\n", s.IstioVersions)
+	result += fmt.Sprintf("Revisions:         %v\n", s.Revisions.String())
 	return result
 }

--- a/pkg/test/framework/resource/version.go
+++ b/pkg/test/framework/resource/version.go
@@ -15,6 +15,7 @@
 package resource
 
 import (
+	"fmt"
 	"strings"
 
 	"istio.io/istio/pilot/pkg/model"
@@ -29,28 +30,29 @@ type RevVerMap map[string]IstioVersion
 func (rv *RevVerMap) SetConfig(m config.Map) error {
 	out := make(RevVerMap)
 	for k := range m {
-		version, err := ParseIstioVersion(m.String(k))
-		if err != nil {
-			return err
-		}
-		out[k] = version
+		version := m.String(k)
+		out[k] = IstioVersion(version)
 	}
 	*rv = out
 	return nil
 }
 
-// Set parses IstioVersions from a string flag in the form "a=1.5.6,b=1.9.0,c=1.4".
+// Set parses IstioVersions from a string flag in the form "a=1.5.6,b,c=1.4".
+// If no version is specified for a revision assume latest, represented as ""
 func (rv *RevVerMap) Set(value string) error {
 	m := make(map[string]IstioVersion)
 	rvPairs := strings.Split(value, ",")
-	for _, rvPair := range rvPairs {
-		s := strings.Split(rvPair, "=")
-		rev, ver := s[0], s[1]
-		parsedVer, err := ParseIstioVersion(ver)
-		if err != nil {
-			return err
+	for _, rv := range rvPairs {
+		s := strings.Split(rv, "=")
+		rev := s[0]
+		if len(s) == 1 {
+			m[rev] = ""
+		} else if len(s) == 2 {
+			ver := s[1]
+			m[rev] = IstioVersion(ver)
+		} else {
+			return fmt.Errorf("invalid revision<->version pairing specified: %q", rv)
 		}
-		m[rev] = parsedVer
 	}
 	*rv = m
 	return nil
@@ -60,11 +62,15 @@ func (rv *RevVerMap) String() string {
 	if rv == nil {
 		return ""
 	}
-	var vers []string
-	for _, ver := range *rv {
-		vers = append(vers, string(ver))
+	var rvPairs []string
+	for rev, ver := range *rv {
+		if ver == "" {
+			ver = "latest"
+		}
+		rvPairs = append(rvPairs,
+			fmt.Sprintf("%s=%s", rev, ver))
 	}
-	return strings.Join(vers, ",")
+	return strings.Join(rvPairs, ",")
 }
 
 // Versions returns an ordered list of Istio versions from the given RevVerMap.
@@ -135,9 +141,4 @@ func (v IstioVersions) Minimum() IstioVersion {
 		}
 	}
 	return min
-}
-
-// ParseIstioVersion parses a version string into a IstioVersion.
-func ParseIstioVersion(version string) (IstioVersion, error) {
-	return IstioVersion(version), nil
 }

--- a/pkg/test/framework/resource/version_test.go
+++ b/pkg/test/framework/resource/version_test.go
@@ -49,6 +49,16 @@ func TestCompareIstioVersion(t *testing.T) {
 			IstioVersion("1.3"),
 			1,
 		},
+		{
+			IstioVersion(""),
+			IstioVersion(""),
+			0,
+		},
+		{
+			IstioVersion(""),
+			IstioVersion("1.9"),
+			1,
+		},
 	}
 
 	for _, tc := range tcs {

--- a/pkg/test/framework/test.go
+++ b/pkg/test/framework/test.go
@@ -245,10 +245,10 @@ func (t *testImpl) doRun(ctx *testContext, fn func(ctx TestContext), parallel bo
 	}
 
 	if t.minIstioVersion != "" {
-		if resource.IstioVersion(t.minIstioVersion).Compare(t.ctx.Settings().IstioVersions.Minimum()) > 0 {
+		if resource.IstioVersion(t.minIstioVersion).Compare(t.ctx.Settings().Revisions.Minimum()) > 0 {
 			ctx.Done()
 			t.goTest.Skipf("Skipping %q: running with min Istio version %q, test requires at least %s",
-				t.goTest.Name(), t.ctx.Settings().IstioVersions.Minimum(), t.minIstioVersion)
+				t.goTest.Name(), t.ctx.Settings().Revisions.Minimum(), t.minIstioVersion)
 		}
 	}
 


### PR DESCRIPTION
Should be able to run tests against multiple revisions without specifying versions for those revisions (unspecified revs are assumed to be latest versions). Now, we can express "I want to deploy echoes for revisions `A`, `B` and `C`. `A` and `B` are on 1.9.3 and `C` is on latest" as `--istio.test.revisions A=1.9.3,B=1.9.3,C`.

Renamed from `istio.test.versions` to `istio.test.revisions` since version is just one piece of config associated with a revision, in the future we probably want to pass other things like per-revision config overlays.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any changes that may affect Istio users.
