### PR TITLE
embed on Windows uses forward slash

### DIFF
--- a/operator/pkg/helm/helm.go
+++ b/operator/pkg/helm/helm.go
@@ -63,7 +63,7 @@ type TemplateRenderer interface {
 // The format of helmBaseDir and profile strings determines the type of helm renderer returned (compiled-in, file,
 // HTTP etc.)
 func NewHelmRenderer(operatorDataDir, helmSubdir, componentName, namespace string) TemplateRenderer {
-	dir := filepath.Join(ChartsSubdirName, helmSubdir)
+	dir := strings.Join([]string{ChartsSubdirName, helmSubdir}, "/")
 	return NewGenericRenderer(manifests.BuiltinOrDir(operatorDataDir), dir, componentName, namespace)
 }
 

--- a/operator/pkg/helm/renderer.go
+++ b/operator/pkg/helm/renderer.go
@@ -137,7 +137,7 @@ func builtinProfileToFilename(name string) string {
 }
 
 func LoadValues(profileName string, chartsDir string) (string, error) {
-	path := filepath.Join(profilesRoot, builtinProfileToFilename(profileName))
+	path := strings.Join([]string{profilesRoot, builtinProfileToFilename(profileName)}, "/")
 	by, err := fs.ReadFile(manifests.BuiltinOrDir(chartsDir), path)
 	if err != nil {
 		return "", err
@@ -163,9 +163,9 @@ func readProfiles(chartsDir string) (map[string]bool, error) {
 
 // stripPrefix removes the the given prefix from prefix.
 func stripPrefix(path, prefix string) string {
-	pl := len(strings.Split(prefix, string(filepath.Separator)))
-	pv := strings.Split(path, string(filepath.Separator))
-	return strings.Join(pv[pl:], string(filepath.Separator))
+	pl := len(strings.Split(prefix, "/"))
+	pv := strings.Split(path, "/")
+	return strings.Join(pv[pl:], "/")
 }
 
 // list all the profiles.


### PR DESCRIPTION
Attempting to replace the use of the os.FileSeparator with `/` as embed continues to use `/` even on Windows.

Fixes #32380. 

This gets me by a number of errors.

[x] Configuration Infrastructure
[ ] Docs
[x] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any changes that may affect Istio users.