### PR TITLE
pilot: dump proxy version option

### DIFF
--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -154,6 +154,27 @@ var (
 			return agent.Run(ctx)
 		},
 	}
+
+	dumpProxyVersionCmd = &cobra.Command{
+		Use:               "version",
+		Short:             "Dump envoy proxy version",
+		PersistentPreRunE: configureLogging,
+		RunE: func(c *cobra.Command, args []string) error {
+			proxy, err := initProxy(args)
+			if err != nil {
+				return err
+			}
+			proxyConfig, err := config.ConstructProxyConfig(meshConfigFile, serviceCluster, options.ProxyConfigEnv, concurrency, proxy)
+			if err != nil {
+				return fmt.Errorf("failed to get proxy config: %v", err)
+			}
+			p := envoy.NewProxy(envoy.ProxyConfig{BinaryPath: proxyConfig.BinaryPath})
+			if err := p.DumpVersion(); err != nil {
+				return err
+			}
+			return nil
+		},
+	}
 )
 
 func init() {
@@ -196,6 +217,8 @@ func init() {
 		Section: "pilot-agent CLI",
 		Manual:  "Istio Pilot Agent",
 	}))
+
+	proxyCmd.AddCommand(dumpProxyVersionCmd)
 }
 
 func initStatusServer(ctx context.Context, proxy *model.Proxy, proxyConfig *meshconfig.ProxyConfig,

--- a/pkg/envoy/agent.go
+++ b/pkg/envoy/agent.go
@@ -47,6 +47,9 @@ type Proxy interface {
 
 	// Cleanup command for an epoch
 	Cleanup(int)
+
+	// Show current version of proxy
+	DumpVersion() error
 }
 
 type Agent struct {

--- a/pkg/envoy/proxy.go
+++ b/pkg/envoy/proxy.go
@@ -82,6 +82,15 @@ func (e *envoy) Drain() error {
 	return err
 }
 
+func (e *envoy) DumpVersion() error {
+	cmd := exec.Command(e.BinaryPath, "--version")
+	cmd.Stdout = os.Stdout
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (e *envoy) args(fname string, epoch int, bootstrapConfig string) []string {
 	proxyLocalAddressType := "v4"
 	if isIPv6Proxy(e.NodeIPs) {


### PR DESCRIPTION
Signed-off-by: Rei Shimizu <rei@tetrate.io>

This PR adds to dump proxy version for pilot-agent to check whether version of envoy is bundled on pilot-agent container for debugging. It is assumed to be used like

```
docker run ${HUB}/proxyv2:${TAG} proxy version
``` 

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[x] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
