### PR TITLE
Support for both distroless and default base image for install-cni

### DIFF
--- a/cni/deployments/kubernetes/Dockerfile.install-cni
+++ b/cni/deployments/kubernetes/Dockerfile.install-cni
@@ -7,6 +7,11 @@ ARG BASE_VERSION=latest
 # The following section is used as base image if BASE_DISTRIBUTION=default
 FROM gcr.io/istio-release/base:${BASE_VERSION} as default
 
+# The following section is used as base image if BASE_DISTRIBUTION=distroless
+FROM gcr.io/istio-release/distroless:${BASE_VERSION} as distroless
+
+FROM ${BASE_DISTRIBUTION}
+
 LABEL description="Istio CNI plugin installer."
 
 COPY istio-cni /opt/cni/bin/

--- a/cni/deployments/kubernetes/Dockerfile.install-cni
+++ b/cni/deployments/kubernetes/Dockerfile.install-cni
@@ -10,6 +10,8 @@ FROM gcr.io/istio-release/base:${BASE_VERSION} as default
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
 FROM gcr.io/istio-release/distroless:${BASE_VERSION} as distroless
 
+# This will build the final image based on either default or distroless from above
+# hadolint ignore=DL3006
 FROM ${BASE_DISTRIBUTION}
 
 LABEL description="Istio CNI plugin installer."


### PR DESCRIPTION
Added support for both 
distroless : gcr.io/istio-release/distroless
and 
default : gcr.io/istio-release/base
base image for install-cni