### PR TITLE
Add --dry-run flag supported for uninstall command

### DIFF
--- a/operator/cmd/mesh/uninstall.go
+++ b/operator/cmd/mesh/uninstall.go
@@ -116,6 +116,7 @@ func UninstallCmd(logOpts *log.Options) *cobra.Command {
 			return uninstall(cmd, rootArgs, uiArgs, logOpts)
 		},
 	}
+	addFlags(uicmd, rootArgs)
 	addUninstallFlags(uicmd, uiArgs)
 	return uicmd
 }

--- a/releasenotes/notes/32513.yaml
+++ b/releasenotes/notes/32513.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: istioctl
+issue:
+  - 32513
+releaseNotes:
+  - |
+    **Added** `--dry-run` flag for `istioctl x uninstall`.


### PR DESCRIPTION
Fixes: https://github.com/istio/istio/issues/32513
[X] Installation

[X] Does not have any changes that may affect Istio users.

Uninstall logs:

```console
➜  istio git:(feature/uninstall-dry-run-flag) k x uninstall -y --dry-run --purge

Not deleting object HorizontalPodAutoscaler:istio-system:istio-ingressgateway because of dry run.
Not deleting object HorizontalPodAutoscaler:istio-system:istiod because of dry run.
Not deleting object PodDisruptionBudget:istio-system:istio-ingressgateway because of dry run.
Not deleting object PodDisruptionBudget:istio-system:istiod because of dry run.
Not deleting object Deployment:istio-system:istio-ingressgateway because of dry run.
Not deleting object Deployment:istio-system:istiod because of dry run.
Not deleting object Service:istio-system:istio-ingressgateway because of dry run.
Not deleting object Service:istio-system:istiod because of dry run.
Not deleting object ConfigMap:istio-system:istio because of dry run.
Not deleting object ConfigMap:istio-system:istio-sidecar-injector because of dry run.
Not deleting object Pod:istio-system:istio-ingressgateway-6f7567cc64-s4tdc because of dry run.
Not deleting object Pod:istio-system:istiod-85ff87cc84-pd7dw because of dry run.
Not deleting object ServiceAccount:istio-system:istio-ingressgateway-service-account because of dry run.
Not deleting object ServiceAccount:istio-system:istio-reader-service-account because of dry run.
Not deleting object ServiceAccount:istio-system:istiod-service-account because of dry run.
Not deleting object RoleBinding:istio-system:istio-ingressgateway-sds because of dry run.
Not deleting object RoleBinding:istio-system:istiod-istio-system because of dry run.
Not deleting object Role:istio-system:istio-ingressgateway-sds because of dry run.
Not deleting object Role:istio-system:istiod-istio-system because of dry run.
Not deleting object EnvoyFilter:istio-system:metadata-exchange-1.6 because of dry run.
Not deleting object EnvoyFilter:istio-system:metadata-exchange-1.7 because of dry run.
Not deleting object EnvoyFilter:istio-system:metadata-exchange-1.8 because of dry run.
Not deleting object EnvoyFilter:istio-system:stats-filter-1.6 because of dry run.
Not deleting object EnvoyFilter:istio-system:stats-filter-1.7 because of dry run.
Not deleting object EnvoyFilter:istio-system:stats-filter-1.8 because of dry run.
Not deleting object EnvoyFilter:istio-system:tcp-metadata-exchange-1.6 because of dry run.
Not deleting object EnvoyFilter:istio-system:tcp-metadata-exchange-1.7 because of dry run.
Not deleting object EnvoyFilter:istio-system:tcp-metadata-exchange-1.8 because of dry run.
Not deleting object EnvoyFilter:istio-system:tcp-stats-filter-1.6 because of dry run.
Not deleting object EnvoyFilter:istio-system:tcp-stats-filter-1.7 because of dry run.
Not deleting object EnvoyFilter:istio-system:tcp-stats-filter-1.8 because of dry run.
Not deleting object MutatingWebhookConfiguration::istio-sidecar-injector because of dry run.
Not deleting object ValidatingWebhookConfiguration::istiod-istio-system because of dry run.
Not deleting object ClusterRole::istio-reader-istio-system because of dry run.
Not deleting object ClusterRole::istiod-istio-system because of dry run.
Not deleting object ClusterRoleBinding::istio-reader-istio-system because of dry run.
Not deleting object ClusterRoleBinding::istiod-istio-system because of dry run.
Not deleting object MutatingWebhookConfiguration::istio-sidecar-injector because of dry run.
Not deleting object ValidatingWebhookConfiguration::istiod-istio-system because of dry run.
Not deleting object CustomResourceDefinition::authorizationpolicies.security.istio.io because of dry run.
Not deleting object CustomResourceDefinition::destinationrules.networking.istio.io because of dry run.
Not deleting object CustomResourceDefinition::envoyfilters.networking.istio.io because of dry run.
Not deleting object CustomResourceDefinition::gateways.networking.istio.io because of dry run.
Not deleting object CustomResourceDefinition::istiooperators.install.istio.io because of dry run.
Not deleting object CustomResourceDefinition::peerauthentications.security.istio.io because of dry run.
Not deleting object CustomResourceDefinition::requestauthentications.security.istio.io because of dry run.
Not deleting object CustomResourceDefinition::serviceentries.networking.istio.io because of dry run.
Not deleting object CustomResourceDefinition::sidecars.networking.istio.io because of dry run.
Not deleting object CustomResourceDefinition::virtualservices.networking.istio.io because of dry run.
Not deleting object CustomResourceDefinition::workloadentries.networking.istio.io because of dry run.
Not deleting object CustomResourceDefinition::workloadgroups.networking.istio.io because of dry run.
Not deleting object CustomResourceDefinition::authorizationpolicies.security.istio.io because of dry run.
Not deleting object CustomResourceDefinition::destinationrules.networking.istio.io because of dry run.
Not deleting object CustomResourceDefinition::envoyfilters.networking.istio.io because of dry run.
Not deleting object CustomResourceDefinition::gateways.networking.istio.io because of dry run.
Not deleting object CustomResourceDefinition::istiooperators.install.istio.io because of dry run.
Not deleting object CustomResourceDefinition::peerauthentications.security.istio.io because of dry run.
Not deleting object CustomResourceDefinition::requestauthentications.security.istio.io because of dry run.
Not deleting object CustomResourceDefinition::serviceentries.networking.istio.io because of dry run.
Not deleting object CustomResourceDefinition::sidecars.networking.istio.io because of dry run.
Not deleting object CustomResourceDefinition::virtualservices.networking.istio.io because of dry run.
Not deleting object CustomResourceDefinition::workloadentries.networking.istio.io because of dry run.
Not deleting object CustomResourceDefinition::workloadgroups.networking.istio.io because of dry run.
✔ Uninstall complete         
```