### PR TITLE
delta: use discovery.Resource wrapper instead of raw any

### DIFF
--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -165,7 +165,23 @@ func (e *Environment) SetLedger(l ledger.Ledger) {
 }
 
 // Request is an alias for array of marshaled resources.
-type Resources = []*any.Any
+type Resources = []*discovery.Resource
+
+func AnyToUnnamedResources(r []*any.Any) Resources {
+	a := make(Resources, 0, len(r))
+	for _, rr := range r {
+		a = append(a, &discovery.Resource{Resource: rr})
+	}
+	return a
+}
+
+func ResourcesToAny(r Resources) []*any.Any {
+	a := make([]*any.Any, 0, len(r))
+	for _, rr := range r {
+		a = append(a, rr.Resource)
+	}
+	return a
+}
 
 // XdsUpdates include information about the subset of updated resources.
 // See for example EDS incremental updates.

--- a/pilot/pkg/networking/apigen/apigen.go
+++ b/pilot/pkg/networking/apigen/apigen.go
@@ -17,6 +17,7 @@ package apigen
 import (
 	"strings"
 
+	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	gogotypes "github.com/gogo/protobuf/types"
 	golangany "github.com/golang/protobuf/ptypes/any"
 
@@ -56,7 +57,7 @@ type APIGenerator struct{}
 //
 // Names are based on the current resource naming in istiod stores.
 func (g *APIGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource, updates *model.PushRequest) (model.Resources, error) {
-	resp := []*golangany.Any{}
+	resp := model.Resources{}
 
 	// Note: this is the style used by MCP and its config. Pilot is using 'Group/Version/Kind' as the
 	// key, which is similar.
@@ -81,9 +82,12 @@ func (g *APIGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *
 	if w.TypeUrl == collections.IstioMeshV1Alpha1MeshConfig.Resource().GroupVersionKind().String() {
 		meshAny, err := gogotypes.MarshalAny(push.Mesh)
 		if err == nil {
-			resp = append(resp, &golangany.Any{
+			a := &golangany.Any{
 				TypeUrl: meshAny.TypeUrl,
 				Value:   meshAny.Value,
+			}
+			resp = append(resp, &discovery.Resource{
+				Resource: a,
 			})
 		}
 		return resp, nil
@@ -110,9 +114,13 @@ func (g *APIGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *
 		}
 		bany, err := gogotypes.MarshalAny(b)
 		if err == nil {
-			resp = append(resp, &golangany.Any{
+			a := &golangany.Any{
 				TypeUrl: bany.TypeUrl,
 				Value:   bany.Value,
+			}
+			resp = append(resp, &discovery.Resource{
+				Name:     c.Namespace + "/" + c.Name,
+				Resource: a,
 			})
 		} else {
 			log.Warn("Any ", err)
@@ -138,9 +146,13 @@ func (g *APIGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *
 			}
 			bany, err := gogotypes.MarshalAny(b)
 			if err == nil {
-				resp = append(resp, &golangany.Any{
+				a := &golangany.Any{
 					TypeUrl: bany.TypeUrl,
 					Value:   bany.Value,
+				}
+				resp = append(resp, &discovery.Resource{
+					Name:     c.Namespace + "/" + c.Name,
+					Resource: a,
 				})
 			} else {
 				log.Warn("Any ", err)

--- a/pilot/pkg/networking/grpcgen/grpcgen.go
+++ b/pilot/pkg/networking/grpcgen/grpcgen.go
@@ -24,7 +24,7 @@ import (
 	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
-	"github.com/golang/protobuf/ptypes/any"
+	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/util"
@@ -68,8 +68,8 @@ func (g *GrpcConfigGenerator) Generate(proxy *model.Proxy, push *model.PushConte
 // handleLDSApiType handles a LDS request, returning listeners of ApiListener type.
 // The request may include a list of resource names, using the full_hostname[:port] format to select only
 // specific services.
-func (g *GrpcConfigGenerator) BuildListeners(node *model.Proxy, push *model.PushContext, names []string) []*any.Any {
-	resp := []*any.Any{}
+func (g *GrpcConfigGenerator) BuildListeners(node *model.Proxy, push *model.PushContext, names []string) model.Resources {
+	resp := model.Resources{}
 
 	filter := map[string]bool{}
 	for _, name := range names {
@@ -124,7 +124,10 @@ func (g *GrpcConfigGenerator) BuildListeners(node *model.Proxy, push *model.Push
 				ll.ApiListener = &listener.ApiListener{
 					ApiListener: hcmAny,
 				}
-				resp = append(resp, util.MessageToAny(ll))
+				resp = append(resp, &discovery.Resource{
+					Name:     hp,
+					Resource: util.MessageToAny(ll),
+				})
 			}
 		}
 	}
@@ -134,8 +137,8 @@ func (g *GrpcConfigGenerator) BuildListeners(node *model.Proxy, push *model.Push
 
 // Handle a gRPC CDS request, used with the 'ApiListener' style of requests.
 // The main difference is that the request includes Resources.
-func (g *GrpcConfigGenerator) BuildClusters(node *model.Proxy, push *model.PushContext, names []string) []*any.Any {
-	resp := []*any.Any{}
+func (g *GrpcConfigGenerator) BuildClusters(node *model.Proxy, push *model.PushContext, names []string) model.Resources {
+	resp := model.Resources{}
 	// gRPC doesn't currently support any of the APIs - returning just the expected EDS result.
 	// Since the code is relatively strict - we'll add info as needed.
 	for _, n := range names {
@@ -156,7 +159,10 @@ func (g *GrpcConfigGenerator) BuildClusters(node *model.Proxy, push *model.PushC
 				},
 			},
 		}
-		resp = append(resp, util.MessageToAny(rc))
+		resp = append(resp, &discovery.Resource{
+			Name:     n,
+			Resource: util.MessageToAny(rc),
+		})
 	}
 	return resp
 }
@@ -164,8 +170,8 @@ func (g *GrpcConfigGenerator) BuildClusters(node *model.Proxy, push *model.PushC
 // handleSplitRDS supports per-VIP routes, as used by GRPC.
 // This mode is indicated by using names containing full host:port instead of just port.
 // Returns true of the request is of this type.
-func (g *GrpcConfigGenerator) BuildHTTPRoutes(node *model.Proxy, push *model.PushContext, routeNames []string) []*any.Any {
-	resp := []*any.Any{}
+func (g *GrpcConfigGenerator) BuildHTTPRoutes(node *model.Proxy, push *model.PushContext, routeNames []string) model.Resources {
+	resp := model.Resources{}
 
 	// Currently this mode is only used by GRPC, to extract Cluster for the default
 	// route.
@@ -212,7 +218,10 @@ func (g *GrpcConfigGenerator) BuildHTTPRoutes(node *model.Proxy, push *model.Pus
 						},
 					},
 				}
-				resp = append(resp, util.MessageToAny(rc))
+				resp = append(resp, &discovery.Resource{
+					Name:     n,
+					Resource: util.MessageToAny(rc),
+				})
 			}
 		}
 	}

--- a/pilot/pkg/xds/bench_test.go
+++ b/pilot/pkg/xds/bench_test.go
@@ -158,7 +158,7 @@ func TestValidateTelemetry(t *testing.T) {
 	}
 	for _, r := range c {
 		cls := &cluster.Cluster{}
-		if err := r.UnmarshalTo(cls); err != nil {
+		if err := r.GetResource().UnmarshalTo(cls); err != nil {
 			t.Fatal(err)
 		}
 		for _, ff := range cls.Filters {
@@ -305,7 +305,7 @@ func BenchmarkEndpointGeneration(b *testing.B) {
 				}
 				response = endpointDiscoveryResponse(loadAssignments, version, push.LedgerVersion)
 			}
-			logDebug(b, response.GetResources())
+			logDebug(b, model.AnyToUnnamedResources(response.GetResources()))
 		})
 	}
 }
@@ -423,7 +423,7 @@ func logDebug(b *testing.B, m model.Resources) {
 	}
 	bytes := 0
 	for _, r := range m {
-		bytes += len(r.Value)
+		bytes += len(r.GetResource().Value)
 	}
 	b.ReportMetric(float64(bytes)/1000, "kb/msg")
 	b.ReportMetric(float64(len(m)), "resources/msg")

--- a/pilot/pkg/xds/cds.go
+++ b/pilot/pkg/xds/cds.go
@@ -15,6 +15,8 @@
 package xds
 
 import (
+	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pkg/config"
@@ -76,7 +78,10 @@ func (c CdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *m
 	rawClusters := c.Server.ConfigGenerator.BuildClusters(proxy, push)
 	resources := model.Resources{}
 	for _, c := range rawClusters {
-		resources = append(resources, util.MessageToAny(c))
+		resources = append(resources, &discovery.Resource{
+			Name:     c.Name,
+			Resource: util.MessageToAny(c),
+		})
 	}
 	return resources, nil
 }

--- a/pilot/pkg/xds/debug.go
+++ b/pilot/pkg/xds/debug.go
@@ -545,7 +545,7 @@ func (s *DiscoveryServer) configDump(conn *Connection) (*adminapi.ConfigDump, er
 		if len(secrets) > 0 {
 			for _, secretAny := range secrets {
 				secret := &tls.Secret{}
-				if err := secretAny.UnmarshalTo(secret); err != nil {
+				if err := secretAny.GetResource().UnmarshalTo(secret); err != nil {
 					istiolog.Warnf("failed to unmarshal secret: %v", err)
 				}
 				if secret.GetTlsCertificate() != nil {

--- a/pilot/pkg/xds/debuggen.go
+++ b/pilot/pkg/xds/debuggen.go
@@ -22,6 +22,7 @@ import (
 	"net/url"
 	"strconv"
 
+	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"github.com/golang/protobuf/ptypes/any"
 
 	"istio.io/istio/pilot/pkg/model"
@@ -85,7 +86,7 @@ func NewDebugGen(s *DiscoveryServer, systemNamespace string) *DebugGen {
 // Generate XDS debug responses according to the incoming debug request
 func (dg *DebugGen) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource,
 	updates *model.PushRequest) (model.Resources, error) {
-	res := []*any.Any{}
+	res := model.Resources{}
 	var buffer bytes.Buffer
 	if w.ResourceNames == nil {
 		return res, fmt.Errorf("debug type is required")
@@ -116,9 +117,12 @@ func (dg *DebugGen) Generate(proxy *model.Proxy, push *model.PushContext, w *mod
 		buffer.Write(header)
 	}
 	buffer.Write(response.body.Bytes())
-	res = append(res, &any.Any{
-		TypeUrl: TypeDebug,
-		Value:   buffer.Bytes(),
+	res = append(res, &discovery.Resource{
+		Name: resourceName,
+		Resource: &any.Any{
+			TypeUrl: TypeDebug,
+			Value:   buffer.Bytes(),
+		},
 	})
 	return res, nil
 }

--- a/pilot/pkg/xds/delta.go
+++ b/pilot/pkg/xds/delta.go
@@ -19,12 +19,6 @@ import (
 	"fmt"
 	"time"
 
-	cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
-	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
-	endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
-	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
-	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
-	tls "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"github.com/golang/protobuf/jsonpb"
 	"google.golang.org/grpc/codes"
@@ -231,7 +225,7 @@ func (s *DiscoveryServer) receiveDelta(con *Connection) {
 				return
 			}
 			defer s.closeConnection(con)
-			log.Infof("ADS: new connection for node:%s", con.ConID)
+			log.Infof("ADS: new delta connection for node:%s", con.ConID)
 		}
 
 		select {
@@ -426,32 +420,31 @@ func (s *DiscoveryServer) pushDeltaXds(con *Connection, push *model.PushContext,
 	}
 	defer func() { recordPushTime(w.TypeUrl, time.Since(t0)) }()
 
-	deltaResponse := convertResponseToDelta(currentVersion, res)
-	originalResponse := deltaResponse
+	originalNames := extractNames(res)
 	if subscribe != nil {
 		// If subscribe is set, client is requesting specific resources. We should just give it the
 		// new resources it needs, rather than the entire set of known resources.
 		subres := sets.NewSet(subscribe...)
 		filteredResponse := []*discovery.Resource{}
-		for _, r := range deltaResponse {
+		for _, r := range res {
 			if subres.Contains(r.Name) {
 				filteredResponse = append(filteredResponse, r)
 			} else {
 				log.Debugf("ADS:%v SKIP %v", v3.GetShortType(w.TypeUrl), r.Name)
 			}
 		}
-		deltaResponse = filteredResponse
+		res = filteredResponse
 	}
 	resp := &discovery.DeltaDiscoveryResponse{
 		TypeUrl:           w.TypeUrl,
 		SystemVersionInfo: currentVersion,
 		Nonce:             nonce(push.LedgerVersion),
-		Resources:         deltaResponse,
+		Resources:         res,
 	}
 	// We take the set of watched resources and anything not in the response is sent as RemovedResources
 	// This is similar to SotW, but done on the server side instead of the client.
 	cur := sets.NewSet(w.ResourceNames...)
-	cur.Delete(extractNames(originalResponse)...)
+	cur.Delete(originalNames...)
 	resp.RemovedResources = cur.SortedList()
 	if len(resp.RemovedResources) > 0 {
 		log.Infof("ADS:%v REMOVE %v", v3.GetShortType(w.TypeUrl), resp.RemovedResources)
@@ -459,7 +452,7 @@ func (s *DiscoveryServer) pushDeltaXds(con *Connection, push *model.PushContext,
 	if isWildcardTypeURL(w.TypeUrl) {
 		// this is probably a bad idea...
 		con.proxy.Lock()
-		w.ResourceNames = extractNames(originalResponse)
+		w.ResourceNames = originalNames
 		con.proxy.Unlock()
 	}
 
@@ -498,48 +491,6 @@ func newDeltaConnection(peerAddr string, stream DeltaDiscoveryStream) *Connectio
 	}
 }
 
-// just for experimentation
-// TODO: make generator return discovery.Resource; then we don't need to introspect the name
-func convertResponseToDelta(ver string, resources model.Resources) []*discovery.Resource {
-	convert := []*discovery.Resource{}
-	for _, r := range resources {
-		var name string
-		switch r.TypeUrl {
-		case v3.ClusterType:
-			aa := &cluster.Cluster{}
-			_ = r.UnmarshalTo(aa)
-			name = aa.Name
-		case v3.ListenerType:
-			aa := &listener.Listener{}
-			_ = r.UnmarshalTo(aa)
-			name = aa.Name
-		case v3.EndpointType:
-			aa := &endpoint.ClusterLoadAssignment{}
-			_ = r.UnmarshalTo(aa)
-			name = aa.ClusterName
-		case v3.RouteType:
-			aa := &route.RouteConfiguration{}
-			_ = r.UnmarshalTo(aa)
-			name = aa.Name
-		case v3.SecretType:
-			aa := &tls.Secret{}
-			_ = r.UnmarshalTo(aa)
-			name = aa.Name
-		case v3.ExtensionConfigurationType:
-			aa := &core.TypedExtensionConfig{}
-			_ = r.UnmarshalTo(aa)
-			name = aa.Name
-		}
-		c := &discovery.Resource{
-			Name:     name,
-			Version:  ver,
-			Resource: r,
-		}
-		convert = append(convert, c)
-	}
-	return convert
-}
-
 // To satisfy methods that need DiscoveryRequest. Not suitable for real usage
 func deltaToSotwRequest(request *discovery.DeltaDiscoveryRequest) *discovery.DiscoveryRequest {
 	return &discovery.DiscoveryRequest{
@@ -557,14 +508,6 @@ func deltaWatchedResources(existing []string, request *discovery.DeltaDiscoveryR
 	res.Delete(request.ResourceNamesUnsubscribe...)
 	// TODO initial request?
 	return res.SortedList()
-}
-
-func ConvertDeltaToResponse(response []*discovery.Resource) model.Resources {
-	convert := model.Resources{}
-	for _, r := range response {
-		convert = append(convert, r.Resource)
-	}
-	return convert
 }
 
 func extractNames(res []*discovery.Resource) []string {

--- a/pilot/pkg/xds/delta_test.go
+++ b/pilot/pkg/xds/delta_test.go
@@ -20,6 +20,7 @@ import (
 
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 
+	"istio.io/istio/pilot/pkg/model"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
 	"istio.io/istio/pilot/test/xdstest"
 	"istio.io/istio/tests/util/leak"
@@ -45,7 +46,7 @@ func TestDeltaAdsClusterUpdate(t *testing.T) {
 			ResponseNonce:            nonce,
 		})
 		nonce = res.Nonce
-		got := xdstest.MapKeys(xdstest.ExtractLoadAssignments(xdstest.UnmarshalClusterLoadAssignment(t, ConvertDeltaToResponse(res.Resources))))
+		got := xdstest.MapKeys(xdstest.ExtractLoadAssignments(xdstest.UnmarshalClusterLoadAssignment(t, model.ResourcesToAny(res.Resources))))
 		if !reflect.DeepEqual(expect, got) {
 			t.Fatalf("expected clusters %v got %v", expect, got)
 		}

--- a/pilot/pkg/xds/ecds.go
+++ b/pilot/pkg/xds/ecds.go
@@ -15,6 +15,8 @@
 package xds
 
 import (
+	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pkg/config/schema/gvk"
@@ -60,7 +62,10 @@ func (e *EcdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w 
 
 	resources := make(model.Resources, 0, len(ec))
 	for _, c := range ec {
-		resources = append(resources, util.MessageToAny(c))
+		resources = append(resources, &discovery.Resource{
+			Name:     c.Name,
+			Resource: util.MessageToAny(c),
+		})
 	}
 	return resources, nil
 }

--- a/pilot/pkg/xds/eds.go
+++ b/pilot/pkg/xds/eds.go
@@ -358,7 +358,7 @@ func (eds *EdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w
 	if !req.Full {
 		edsUpdatedServices = model.ConfigNamesOfKind(req.ConfigsUpdated, gvk.ServiceEntry)
 	}
-	resources := make([]*any.Any, 0)
+	resources := make(model.Resources, 0)
 	empty := 0
 
 	cached := 0
@@ -387,7 +387,10 @@ func (eds *EdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w
 			if len(l.Endpoints) == 0 {
 				empty++
 			}
-			resource := util.MessageToAny(l)
+			resource := &discovery.Resource{
+				Name:     l.ClusterName,
+				Resource: util.MessageToAny(l),
+			}
 			resources = append(resources, resource)
 			eds.Server.Cache.Add(builder, token, resource)
 		}

--- a/pilot/pkg/xds/gen.go
+++ b/pilot/pkg/xds/gen.go
@@ -120,7 +120,7 @@ func (s *DiscoveryServer) pushXds(con *Connection, push *model.PushContext,
 		TypeUrl:      w.TypeUrl,
 		VersionInfo:  currentVersion,
 		Nonce:        nonce(push.LedgerVersion),
-		Resources:    res,
+		Resources:    model.ResourcesToAny(res),
 	}
 
 	configSize := ResourceSize(res)
@@ -151,7 +151,7 @@ func ResourceSize(r model.Resources) int {
 	// proto.Size, at the expense of slightly under counting.
 	size := 0
 	for _, r := range r {
-		size += len(r.Value)
+		size += len(r.Resource.Value)
 	}
 	return size
 }

--- a/pilot/pkg/xds/lds.go
+++ b/pilot/pkg/xds/lds.go
@@ -15,6 +15,8 @@
 package xds
 
 import (
+	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pkg/config"
@@ -61,7 +63,10 @@ func (l LdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *m
 	listeners := l.Server.ConfigGenerator.BuildListeners(proxy, push)
 	resources := model.Resources{}
 	for _, c := range listeners {
-		resources = append(resources, util.MessageToAny(c))
+		resources = append(resources, &discovery.Resource{
+			Name:     c.Name,
+			Resource: util.MessageToAny(c),
+		})
 	}
 	return resources, nil
 }

--- a/pilot/pkg/xds/nds.go
+++ b/pilot/pkg/xds/nds.go
@@ -15,6 +15,8 @@
 package xds
 
 import (
+	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pkg/config"
@@ -73,6 +75,6 @@ func (n NdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *m
 	if nt == nil {
 		return nil, nil
 	}
-	resources := model.Resources{util.MessageToAny(nt)}
+	resources := model.Resources{&discovery.Resource{Resource: util.MessageToAny(nt)}}
 	return resources, nil
 }

--- a/pilot/pkg/xds/pcds.go
+++ b/pilot/pkg/xds/pcds.go
@@ -15,6 +15,8 @@
 package xds
 
 import (
+	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+
 	mesh "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
@@ -63,5 +65,5 @@ func (e *PcdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w 
 	pc := &mesh.ProxyConfig{
 		CaCertificatesPem: e.TrustBundle.GetTrustBundle(),
 	}
-	return model.Resources{gogo.MessageToAny(pc)}, nil
+	return model.Resources{&discovery.Resource{Resource: gogo.MessageToAny(pc)}}, nil
 }

--- a/pilot/pkg/xds/rds.go
+++ b/pilot/pkg/xds/rds.go
@@ -15,6 +15,8 @@
 package xds
 
 import (
+	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pkg/config"
@@ -64,7 +66,10 @@ func (c RdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *m
 	rawRoutes := c.Server.ConfigGenerator.BuildHTTPRoutes(proxy, push, w.ResourceNames)
 	resources := model.Resources{}
 	for _, c := range rawRoutes {
-		resources = append(resources, util.MessageToAny(c))
+		resources = append(resources, &discovery.Resource{
+			Name:     c.Name,
+			Resource: util.MessageToAny(c),
+		})
 	}
 	return resources, nil
 }

--- a/pilot/pkg/xds/sds.go
+++ b/pilot/pkg/xds/sds.go
@@ -20,7 +20,7 @@ import (
 
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	tls "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
-	"github.com/golang/protobuf/ptypes/any"
+	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
@@ -182,8 +182,8 @@ func (s *SecretGen) Generate(proxy *model.Proxy, push *model.PushContext, w *mod
 	return results, nil
 }
 
-func toEnvoyCaSecret(name string, cert []byte) *any.Any {
-	return util.MessageToAny(&tls.Secret{
+func toEnvoyCaSecret(name string, cert []byte) *discovery.Resource {
+	res := util.MessageToAny(&tls.Secret{
 		Name: name,
 		Type: &tls.Secret_ValidationContext{
 			ValidationContext: &tls.CertificateValidationContext{
@@ -195,10 +195,14 @@ func toEnvoyCaSecret(name string, cert []byte) *any.Any {
 			},
 		},
 	})
+	return &discovery.Resource{
+		Name:     name,
+		Resource: res,
+	}
 }
 
-func toEnvoyKeyCertSecret(name string, key, cert []byte) *any.Any {
-	return util.MessageToAny(&tls.Secret{
+func toEnvoyKeyCertSecret(name string, key, cert []byte) *discovery.Resource {
+	res := util.MessageToAny(&tls.Secret{
 		Name: name,
 		Type: &tls.Secret_TlsCertificate{
 			TlsCertificate: &tls.TlsCertificate{
@@ -215,6 +219,10 @@ func toEnvoyKeyCertSecret(name string, key, cert []byte) *any.Any {
 			},
 		},
 	})
+	return &discovery.Resource{
+		Name:     name,
+		Resource: res,
+	}
 }
 
 func containsAny(mp map[model.ConfigKey]struct{}, keys []model.ConfigKey) bool {

--- a/pilot/pkg/xds/sds_test.go
+++ b/pilot/pkg/xds/sds_test.go
@@ -327,7 +327,7 @@ func TestGenerate(t *testing.T) {
 
 			secrets, _ := gen.Generate(s.SetupProxy(tt.proxy), s.PushContext(),
 				&model.WatchedResource{ResourceNames: tt.resources}, tt.request)
-			raw := xdstest.ExtractTLSSecrets(t, secrets)
+			raw := xdstest.ExtractTLSSecrets(t, model.ResourcesToAny(secrets))
 
 			got := map[string]Expected{}
 			for _, scrt := range raw {

--- a/pilot/pkg/xds/statusgen.go
+++ b/pilot/pkg/xds/statusgen.go
@@ -68,12 +68,15 @@ func NewStatusGen(s *DiscoveryServer) *StatusGen {
 // - NACKs
 // We can also expose ACKS.
 func (sg *StatusGen) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource, updates *model.PushRequest) (model.Resources, error) {
-	res := []*any.Any{}
+	res := model.Resources{}
 
 	switch w.TypeUrl {
 	case TypeURLConnect:
 		for _, v := range sg.Server.Clients() {
-			res = append(res, util.MessageToAny(v.node))
+			res = append(res, &discovery.Resource{
+				Name:     v.node.Id,
+				Resource: util.MessageToAny(v.node),
+			})
 		}
 	case TypeDebugSyncronization:
 		res = sg.debugSyncz()
@@ -101,8 +104,8 @@ func isProxy(con *Connection) bool {
 		con.proxy.Metadata.ProxyConfig != nil
 }
 
-func (sg *StatusGen) debugSyncz() []*any.Any {
-	res := []*any.Any{}
+func (sg *StatusGen) debugSyncz() model.Resources {
+	res := model.Resources{}
 
 	stypes := []string{
 		v3.ListenerType,
@@ -141,7 +144,10 @@ func (sg *StatusGen) debugSyncz() []*any.Any {
 				},
 				XdsConfig: xdsConfigs,
 			}
-			res = append(res, util.MessageToAny(clientConfig))
+			res = append(res, &discovery.Resource{
+				Name:     clientConfig.Node.Id,
+				Resource: util.MessageToAny(clientConfig),
+			})
 		}
 		con.proxy.RUnlock()
 	}
@@ -159,7 +165,7 @@ func debugSyncStatus(wr *model.WatchedResource) status.ConfigStatus {
 	return status.ConfigStatus_STALE
 }
 
-func (sg *StatusGen) debugConfigDump(proxyID string) ([]*any.Any, error) {
+func (sg *StatusGen) debugConfigDump(proxyID string) (model.Resources, error) {
 	conn := sg.Server.getProxyConnection(proxyID)
 	if conn == nil {
 		// This is "like" a 404.  The error is the client's.  However, this endpoint
@@ -172,7 +178,7 @@ func (sg *StatusGen) debugConfigDump(proxyID string) ([]*any.Any, error) {
 		return nil, err
 	}
 
-	return dump.Configs, nil
+	return model.AnyToUnnamedResources(dump.Configs), nil
 }
 
 func (sg *StatusGen) OnConnect(con *Connection) {

--- a/security/pkg/nodeagent/sds/sdsservice.go
+++ b/security/pkg/nodeagent/sds/sdsservice.go
@@ -149,7 +149,10 @@ func (s *sdsservice) generate(resourceNames []string) (model.Resources, error) {
 		}
 
 		res := util.MessageToAny(toEnvoySecret(secret))
-		resources = append(resources, res)
+		resources = append(resources, &discovery.Resource{
+			Name:     resourceName,
+			Resource: res,
+		})
 	}
 	return resources, nil
 }


### PR DESCRIPTION
XDS introduced a `discovery.Resource` wrapper a while back. This is required for delta XDS.

When using delta, we need to populate the `name` field. To do this, we marshaled the XDS response to inspect the name, which is hacky and extremely bad for performance.

Instead, all generators now return this wrapper. For Sotw, we simply unwrap it.

This of course has a performance cost, but IMO its worth it, only ~1% more memory allocated:
```
name                                     old time/op        new time/op        delta
RouteGeneration/gateways-6                     43.4ms ± 1%        43.4ms ± 1%    ~     (p=1.000 n=4+4)
RouteGeneration/gateways-shared-6               175ms ± 5%         171ms ± 3%    ~     (p=0.343 n=4+4)
RouteGeneration/empty-6                         829µs ± 4%         847µs ± 4%    ~     (p=0.343 n=4+4)
RouteGeneration/tls-6                           853µs ± 1%         858µs ± 5%    ~     (p=0.343 n=4+4)
RouteGeneration/telemetry-6                     839µs ± 3%         844µs ± 3%    ~     (p=0.686 n=4+4)
RouteGeneration/virtualservice-6               1.64ms ± 3%        1.61ms ± 1%    ~     (p=0.200 n=4+4)
RouteGeneration/authorizationpolicy-6          6.92µs ± 2%        7.00µs ± 2%    ~     (p=0.343 n=4+4)
RouteGeneration/peerauthentication-6           7.00µs ± 2%        6.86µs ± 3%    ~     (p=0.114 n=4+4)
ClusterGeneration/gateways-6                   10.7ms ± 3%        10.8ms ± 1%    ~     (p=0.886 n=4+4)
ClusterGeneration/gateways-shared-6            10.7ms ± 2%        10.8ms ± 4%    ~     (p=0.686 n=4+4)
ClusterGeneration/empty-6                      6.43ms ± 3%        6.47ms ± 6%    ~     (p=0.886 n=4+4)
ClusterGeneration/tls-6                        6.35ms ± 4%        6.42ms ± 6%    ~     (p=0.486 n=4+4)
ClusterGeneration/telemetry-6                  5.04ms ± 3%        5.08ms ± 2%    ~     (p=0.686 n=4+4)
ClusterGeneration/virtualservice-6             1.06ms ± 4%        1.05ms ± 2%    ~     (p=0.343 n=4+4)
ClusterGeneration/authorizationpolicy-6        43.6µs ± 2%        44.3µs ± 1%    ~     (p=0.114 n=4+4)
ClusterGeneration/peerauthentication-6         43.0µs ± 4%        44.3µs ± 1%  +2.99%  (p=0.029 n=4+4)
ListenerGeneration/gateways-6                  22.0ms ± 0%        21.6ms ± 2%    ~     (p=0.114 n=4+4)
ListenerGeneration/gateways-shared-6           44.4µs ± 3%        44.3µs ± 6%    ~     (p=0.886 n=4+4)
ListenerGeneration/empty-6                     1.36ms ± 4%        1.33ms ± 3%    ~     (p=0.486 n=4+4)
ListenerGeneration/tls-6                       1.30ms ± 2%        1.27ms ± 2%    ~     (p=0.114 n=4+4)
ListenerGeneration/telemetry-6                 1.65ms ± 1%        1.63ms ± 0%    ~     (p=0.800 n=4+1)

name                                     old kb/msg         new kb/msg         delta
RouteGeneration/gateways-6                      2.67k ± 0%         2.67k ± 0%    ~     (all equal)
RouteGeneration/gateways-shared-6               12.6k ± 0%         12.6k ± 0%    ~     (all equal)
RouteGeneration/empty-6                          32.2 ± 0%          32.2 ± 0%    ~     (all equal)
RouteGeneration/tls-6                            32.2 ± 0%          32.2 ± 0%    ~     (all equal)
RouteGeneration/telemetry-6                      32.2 ± 0%          32.2 ± 0%    ~     (all equal)
RouteGeneration/virtualservice-6                 79.8 ± 0%          79.8 ± 0%    ~     (all equal)
RouteGeneration/authorizationpolicy-6            0.33 ± 0%          0.33 ± 0%    ~     (all equal)
RouteGeneration/peerauthentication-6             0.33 ± 0%          0.33 ± 0%    ~     (all equal)
ClusterGeneration/gateways-6                      297 ± 0%           297 ± 0%    ~     (all equal)
ClusterGeneration/gateways-shared-6               297 ± 0%           297 ± 0%    ~     (all equal)
ClusterGeneration/empty-6                         287 ± 0%           287 ± 0%    ~     (all equal)
ClusterGeneration/tls-6                           282 ± 0%           282 ± 0%    ~     (all equal)
ClusterGeneration/telemetry-6                     212 ± 0%           212 ± 0%    ~     (all equal)
ClusterGeneration/virtualservice-6               29.9 ± 0%          29.9 ± 0%    ~     (all equal)
ClusterGeneration/authorizationpolicy-6          1.10 ± 0%          1.10 ± 0%    ~     (all equal)
ClusterGeneration/peerauthentication-6           1.10 ± 0%          1.10 ± 0%    ~     (all equal)
ListenerGeneration/gateways-6                   1.68k ± 0%         1.68k ± 0%    ~     (all equal)
ListenerGeneration/gateways-shared-6             3.06 ± 0%          3.06 ± 0%    ~     (all equal)
ListenerGeneration/empty-6                       15.1 ± 0%          15.1 ± 0%    ~     (all equal)
ListenerGeneration/tls-6                         10.9 ± 0%          10.9 ± 0%    ~     (all equal)
ListenerGeneration/telemetry-6                   33.1 ± 0%          33.1 ± 0%    ~     (all equal)

name                                     old resources/msg  new resources/msg  delta
RouteGeneration/gateways-6                      1.00k ± 0%         1.00k ± 0%    ~     (all equal)
RouteGeneration/gateways-shared-6                2.00 ± 0%          2.00 ± 0%    ~     (all equal)
RouteGeneration/empty-6                          2.00 ± 0%          2.00 ± 0%    ~     (all equal)
RouteGeneration/tls-6                            2.00 ± 0%          2.00 ± 0%    ~     (all equal)
RouteGeneration/telemetry-6                      2.00 ± 0%          2.00 ± 0%    ~     (all equal)
RouteGeneration/virtualservice-6                 1.00 ± 0%          1.00 ± 0%    ~     (all equal)
RouteGeneration/authorizationpolicy-6            1.00 ± 0%          1.00 ± 0%    ~     (all equal)
RouteGeneration/peerauthentication-6             1.00 ± 0%          1.00 ± 0%    ~     (all equal)
ClusterGeneration/gateways-6                    1.00k ± 0%         1.00k ± 0%    ~     (all equal)
ClusterGeneration/gateways-shared-6             1.00k ± 0%         1.00k ± 0%    ~     (all equal)
ClusterGeneration/empty-6                         410 ± 0%           410 ± 0%    ~     (all equal)
ClusterGeneration/tls-6                           410 ± 0%           410 ± 0%    ~     (all equal)
ClusterGeneration/telemetry-6                     410 ± 0%           410 ± 0%    ~     (all equal)
ClusterGeneration/virtualservice-6                104 ± 0%           104 ± 0%    ~     (all equal)
ClusterGeneration/authorizationpolicy-6          6.00 ± 0%          6.00 ± 0%    ~     (all equal)
ClusterGeneration/peerauthentication-6           6.00 ± 0%          6.00 ± 0%    ~     (all equal)
ListenerGeneration/gateways-6                    2.00 ± 0%          2.00 ± 0%    ~     (all equal)
ListenerGeneration/gateways-shared-6             2.00 ± 0%          2.00 ± 0%    ~     (all equal)
ListenerGeneration/empty-6                       6.00 ± 0%          6.00 ± 0%    ~     (all equal)
ListenerGeneration/tls-6                         6.00 ± 0%          6.00 ± 0%    ~     (all equal)
ListenerGeneration/telemetry-6                   6.00 ± 0%          6.00 ± 0%    ~     (all equal)

name                                     old alloc/op       new alloc/op       delta
RouteGeneration/gateways-6                     17.2MB ± 0%        17.4MB ± 0%  +0.74%  (p=0.029 n=4+4)
RouteGeneration/gateways-shared-6              68.0MB ± 0%        68.0MB ± 0%    ~     (p=0.486 n=4+4)
RouteGeneration/empty-6                         617kB ± 0%         617kB ± 0%  +0.04%  (p=0.029 n=4+4)
RouteGeneration/tls-6                           617kB ± 0%         617kB ± 0%  +0.04%  (p=0.029 n=4+4)
RouteGeneration/telemetry-6                     619kB ± 0%         619kB ± 0%  +0.04%  (p=0.029 n=4+4)
RouteGeneration/virtualservice-6                870kB ± 0%         870kB ± 0%    ~     (p=0.200 n=4+4)
RouteGeneration/authorizationpolicy-6          4.34kB ± 0%        4.47kB ± 0%  +2.95%  (p=0.029 n=4+4)
RouteGeneration/peerauthentication-6           4.34kB ± 0%        4.47kB ± 0%  +2.95%  (p=0.029 n=4+4)
ClusterGeneration/gateways-6                   4.66MB ± 0%        4.78MB ± 0%  +2.76%  (p=0.029 n=4+4)
ClusterGeneration/gateways-shared-6            4.66MB ± 0%        4.78MB ± 0%  +2.76%  (p=0.029 n=4+4)
ClusterGeneration/empty-6                      2.78MB ± 0%        2.83MB ± 0%  +1.89%  (p=0.029 n=4+4)
ClusterGeneration/tls-6                        2.77MB ± 0%        2.82MB ± 0%  +1.90%  (p=0.029 n=4+4)
ClusterGeneration/telemetry-6                  2.23MB ± 0%        2.28MB ± 0%  +2.35%  (p=0.029 n=4+4)
ClusterGeneration/virtualservice-6              473kB ± 0%         486kB ± 0%  +2.82%  (p=0.029 n=4+4)
ClusterGeneration/authorizationpolicy-6        20.0kB ± 0%        20.8kB ± 0%  +3.84%  (p=0.029 n=4+4)
ClusterGeneration/peerauthentication-6         20.0kB ± 0%        20.8kB ± 0%  +3.84%  (p=0.029 n=4+4)
ListenerGeneration/gateways-6                  10.1MB ± 0%        10.1MB ± 0%  +0.00%  (p=0.029 n=4+4)
ListenerGeneration/gateways-shared-6           21.3kB ± 0%        21.5kB ± 0%  +1.20%  (p=0.029 n=4+4)
ListenerGeneration/empty-6                      825kB ± 0%         826kB ± 0%  +0.09%  (p=0.029 n=4+4)
ListenerGeneration/tls-6                        782kB ± 0%         783kB ± 0%  +0.10%  (p=0.029 n=4+4)
ListenerGeneration/telemetry-6                  928kB ± 0%         929kB ± 0%    ~     (p=0.400 n=4+1)

name                                     old allocs/op      new allocs/op      delta
RouteGeneration/gateways-6                       212k ± 0%          213k ± 0%  +0.47%  (p=0.029 n=4+4)
RouteGeneration/gateways-shared-6                896k ± 0%          896k ± 0%    ~     (p=0.229 n=4+4)
RouteGeneration/empty-6                         6.31k ± 0%         6.31k ± 0%  +0.04%  (p=0.029 n=4+4)
RouteGeneration/tls-6                           6.31k ± 0%         6.31k ± 0%  +0.03%  (p=0.029 n=4+4)
RouteGeneration/telemetry-6                     6.35k ± 0%         6.35k ± 0%  +0.03%  (p=0.029 n=4+4)
RouteGeneration/virtualservice-6                10.7k ± 0%         10.7k ± 0%  +0.01%  (p=0.029 n=4+4)
RouteGeneration/authorizationpolicy-6            48.0 ± 0%          49.0 ± 0%  +2.08%  (p=0.029 n=4+4)
RouteGeneration/peerauthentication-6             48.0 ± 0%          49.0 ± 0%  +2.08%  (p=0.029 n=4+4)
ClusterGeneration/gateways-6                    76.2k ± 0%         77.2k ± 0%  +1.32%  (p=0.029 n=4+4)
ClusterGeneration/gateways-shared-6             76.2k ± 0%         77.2k ± 0%  +1.32%  (p=0.029 n=4+4)
ClusterGeneration/empty-6                       41.7k ± 0%         42.1k ± 0%  +0.98%  (p=0.029 n=4+4)
ClusterGeneration/tls-6                         41.2k ± 0%         41.6k ± 0%  +1.00%  (p=0.029 n=4+4)
ClusterGeneration/telemetry-6                   35.2k ± 0%         35.7k ± 0%  +1.16%  (p=0.029 n=4+4)
ClusterGeneration/virtualservice-6              7.80k ± 0%         7.91k ± 0%  +1.33%  (p=0.029 n=4+4)
ClusterGeneration/authorizationpolicy-6           334 ± 0%           340 ± 0%  +1.80%  (p=0.029 n=4+4)
ClusterGeneration/peerauthentication-6            334 ± 0%           340 ± 0%  +1.80%  (p=0.029 n=4+4)
ListenerGeneration/gateways-6                    130k ± 0%          130k ± 0%    ~     (p=0.200 n=4+4)
ListenerGeneration/gateways-shared-6              306 ± 0%           308 ± 0%  +0.65%  (p=0.029 n=4+4)
ListenerGeneration/empty-6                      14.6k ± 0%         14.6k ± 0%  +0.04%  (p=0.029 n=4+4)
ListenerGeneration/tls-6                        14.2k ± 0%         14.2k ± 0%  +0.04%  (p=0.029 n=4+4)
ListenerGeneration/telemetry-6                  15.8k ± 0%         15.8k ± 0%    ~     (p=0.400 n=4+1)
```

Unfortunately we cannot make this flag protected to allow SotW users  to get that 1% improvement without having 100s of lines of code which I don't think is worth it.