### PR TITLE
Deflake TestAddToAndRemoveFromMesh

### DIFF
--- a/tests/integration/pilot/istioctl_test.go
+++ b/tests/integration/pilot/istioctl_test.go
@@ -245,7 +245,7 @@ func TestAddToAndRemoveFromMesh(t *testing.T) {
 					}
 				}
 				return nil
-			}, retry.Delay(time.Second))
+			}, retry.Delay(time.Second), retry.Timeout(time.Minute))
 
 			args = []string{
 				fmt.Sprintf("--namespace=%s", ns.Name()),


### PR DESCRIPTION
Appears to just occasionally take more than 20s to fully terminate the
pod
https://prow.istio.io/view/gs/istio-prow/logs/integ-pilot-k8s-tests_istio_postsubmit/1387950502116855808
as an example



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.