### PR TITLE
handle unset network

### DIFF
--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -580,6 +580,38 @@ func (m NodeMetadata) ProxyConfigOrDefault(def *meshconfig.ProxyConfig) *meshcon
 	return def
 }
 
+// UnnamedNetwork is the default network that proxies in the mesh
+// get when they don't request a specific network view.
+const UnnamedNetwork = ""
+
+// GetNetworkView returns the networks that the proxy requested.
+// When sending EDS/CDS-with-dns-endpoints, Pilot will only send
+// endpoints corresponding to the networks that the proxy wants to see.
+// If not set, we assume that the proxy wants to see endpoints in any network.
+func (node *Proxy) GetNetworkView() map[string]bool {
+	if node == nil || len(node.Metadata.RequestedNetworkView) == 0 {
+		return nil
+	}
+
+	nmap := make(map[string]bool)
+	for _, n := range node.Metadata.RequestedNetworkView {
+		nmap[n] = true
+	}
+	nmap[UnnamedNetwork] = true
+
+	return nmap
+}
+
+// InNetwork returns true if the proxy is on the given network, or if either
+// the proxy's network or the given network is unspecified ("").
+func (node *Proxy) InNetwork(network string) bool {
+	return node == nil || SameNetwork(network, node.Metadata.Network)
+}
+
+func SameNetwork(a, b string) bool {
+	return a == UnnamedNetwork || b == UnnamedNetwork || a == b
+}
+
 func (m *BootstrapNodeMetadata) UnmarshalJSON(data []byte) error {
 	// Create a new type from the target type to avoid recursion.
 	type BootstrapNodeMetadata2 BootstrapNodeMetadata
@@ -806,28 +838,6 @@ func (node *Proxy) SupportsIPv4() bool {
 // SupportsIPv6 returns true if proxy supports IPv6 addresses.
 func (node *Proxy) SupportsIPv6() bool {
 	return node.ipv6Support
-}
-
-// UnnamedNetwork is the default network that proxies in the mesh
-// get when they don't request a specific network view.
-const UnnamedNetwork = ""
-
-// GetNetworkView returns the networks that the proxy requested.
-// When sending EDS/CDS-with-dns-endpoints, Pilot will only send
-// endpoints corresponding to the networks that the proxy wants to see.
-// If not set, we assume that the proxy wants to see endpoints in any network.
-func GetNetworkView(node *Proxy) map[string]bool {
-	if node == nil || len(node.Metadata.RequestedNetworkView) == 0 {
-		return nil
-	}
-
-	nmap := make(map[string]bool)
-	for _, n := range node.Metadata.RequestedNetworkView {
-		nmap[n] = true
-	}
-	nmap[UnnamedNetwork] = true
-
-	return nmap
 }
 
 // ParseMetadata parses the opaque Metadata from an Envoy Node into string key-value pairs.

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -605,10 +605,10 @@ func (node *Proxy) GetNetworkView() map[string]bool {
 // InNetwork returns true if the proxy is on the given network, or if either
 // the proxy's network or the given network is unspecified ("").
 func (node *Proxy) InNetwork(network string) bool {
-	return node == nil || SameNetwork(network, node.Metadata.Network)
+	return node == nil || IsSameNetwork(network, node.Metadata.Network)
 }
 
-func SameNetwork(a, b string) bool {
+func IsSameNetwork(a, b string) bool {
 	return a == UnnamedNetwork || b == UnnamedNetwork || a == b
 }
 

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -114,7 +114,7 @@ func (configgen *ConfigGeneratorImpl) BuildClusters(proxy *model.Proxy, push *mo
 
 func (configgen *ConfigGeneratorImpl) buildOutboundClusters(cb *ClusterBuilder, cp clusterPatcher) []*cluster.Cluster {
 	clusters := make([]*cluster.Cluster, 0)
-	networkView := model.GetNetworkView(cb.proxy)
+	networkView := cb.proxy.GetNetworkView()
 
 	var services []*model.Service
 	if features.FilterGatewayClusterConfig && cb.proxy.Type == model.Router {
@@ -204,7 +204,7 @@ func (configgen *ConfigGeneratorImpl) buildOutboundSniDnatClusters(proxy *model.
 	clusters := make([]*cluster.Cluster, 0)
 	cb := NewClusterBuilder(proxy, push)
 
-	networkView := model.GetNetworkView(proxy)
+	networkView := proxy.GetNetworkView()
 
 	for _, service := range push.Services(proxy) {
 		if service.MeshExternal {

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
@@ -807,7 +807,7 @@ func TestBuildDefaultCluster(t *testing.T) {
 			}
 			defaultCluster := cb.buildDefaultCluster(tt.clusterName, tt.discovery, tt.endpoints, tt.direction, servicePort, service, nil)
 			if defaultCluster != nil {
-				_ = cb.applyDestinationRule(defaultCluster, DefaultClusterMode, service, servicePort, model.GetNetworkView(cb.proxy))
+				_ = cb.applyDestinationRule(defaultCluster, DefaultClusterMode, service, servicePort, cb.proxy.GetNetworkView())
 			}
 
 			if diff := cmp.Diff(defaultCluster.build(), tt.expectedCluster, protocmp.Transform()); diff != "" {

--- a/pilot/pkg/networking/core/v1alpha3/name_table.go
+++ b/pilot/pkg/networking/core/v1alpha3/name_table.go
@@ -79,7 +79,7 @@ func (configgen *ConfigGeneratorImpl) BuildNameTable(node *model.Proxy, push *mo
 				svc.Resolution == model.Passthrough && len(svc.Ports) > 0 {
 				for _, instance := range push.ServiceInstancesByPort(svc, svc.Ports[0].Port, nil) {
 					// Add individual addresses even for cross cluster.
-					if instance.Endpoint.SubDomain != "" && instance.Endpoint.Network == node.Metadata.Network {
+					if instance.Endpoint.SubDomain != "" && node.InNetwork(instance.Endpoint.Network) {
 						// Follow k8s pods dns naming convention of "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>"
 						// i.e. "mysql-0.mysql.default.svc.cluster.local".
 						parts := strings.SplitN(string(svc.Hostname), ".", 2)

--- a/pilot/pkg/xds/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoint_builder.go
@@ -82,7 +82,7 @@ func NewEndpointBuilder(clusterName string, proxy *model.Proxy, push *model.Push
 	b := EndpointBuilder{
 		clusterName:     clusterName,
 		network:         proxy.Metadata.Network,
-		networkView:     model.GetNetworkView(proxy),
+		networkView:     proxy.GetNetworkView(),
 		clusterID:       proxy.Metadata.ClusterID,
 		locality:        proxy.Locality,
 		service:         svc,

--- a/pilot/pkg/xds/ep_filters.go
+++ b/pilot/pkg/xds/ep_filters.go
@@ -65,7 +65,7 @@ func (b *EndpointBuilder) EndpointsByNetworkFilter(endpoints []*LocLbEndpointsAn
 			epNetwork := istioMetadata(lbEp, "network")
 			// This is a local endpoint or remote network endpoint
 			// but can be accessed directly from local network.
-			if epNetwork == b.network || len(b.push.NetworkGatewaysByNetwork(epNetwork)) == 0 {
+			if model.SameNetwork(b.network, epNetwork) || len(b.push.NetworkGatewaysByNetwork(epNetwork)) == 0 {
 				// Copy on write.
 				clonedLbEp := proto.Clone(lbEp).(*endpoint.LbEndpoint)
 				clonedLbEp.LoadBalancingWeight = &wrappers.UInt32Value{

--- a/pilot/pkg/xds/ep_filters.go
+++ b/pilot/pkg/xds/ep_filters.go
@@ -65,7 +65,7 @@ func (b *EndpointBuilder) EndpointsByNetworkFilter(endpoints []*LocLbEndpointsAn
 			epNetwork := istioMetadata(lbEp, "network")
 			// This is a local endpoint or remote network endpoint
 			// but can be accessed directly from local network.
-			if model.SameNetwork(b.network, epNetwork) || len(b.push.NetworkGatewaysByNetwork(epNetwork)) == 0 {
+			if model.IsSameNetwork(b.network, epNetwork) || len(b.push.NetworkGatewaysByNetwork(epNetwork)) == 0 {
 				// Copy on write.
 				clonedLbEp := proto.Clone(lbEp).(*endpoint.LbEndpoint)
 				clonedLbEp.LoadBalancingWeight = &wrappers.UInt32Value{


### PR DESCRIPTION
A few small future-proofing changes to better handle the unset ("") network value

* the change to name_table is probably required
* change to ep_filters will probably never matter, since we don't get a NetworkGatewaysByNetwork for `""` 
* added utils to wrap up this logic
* moved GetNetworkView() to be an instance method. This is mostly aesthetic. We could cache it on the Node or NodeMetadata if it gets called a lot. 