### PR TITLE
Do not use istio_authn filter when not needed

### DIFF
--- a/pilot/pkg/networking/plugin/authn/authentication.go
+++ b/pilot/pkg/networking/plugin/authn/authentication.go
@@ -43,7 +43,7 @@ func (Plugin) OnOutboundListener(in *plugin.InputParams, mutable *networking.Mut
 		return nil
 	}
 
-	return buildFilter(in, mutable, false)
+	return buildFilter(in, mutable)
 }
 
 // OnInboundListener is called whenever a new listener is added to the LDS output for a given service
@@ -54,29 +54,20 @@ func (Plugin) OnInboundListener(in *plugin.InputParams, mutable *networking.Muta
 		// Only care about sidecar.
 		return nil
 	}
-	return buildFilter(in, mutable, false)
+	return buildFilter(in, mutable)
 }
 
-func buildFilter(in *plugin.InputParams, mutable *networking.MutableObjects, isPassthrough bool) error {
+func buildFilter(in *plugin.InputParams, mutable *networking.MutableObjects) error {
 	ns := in.Node.Metadata.Namespace
 	applier := factory.NewPolicyApplier(in.Push, ns, labels.Collection{in.Node.Metadata.Labels})
-	endpointPort := uint32(0)
-	if in.ServiceInstance != nil {
-		endpointPort = in.ServiceInstance.Endpoint.EndpointPort
-	}
 
 	for i := range mutable.FilterChains {
-		if isPassthrough {
-			// Get the real port from the filter chain match if this is generated for pass through filter chain.
-			endpointPort = mutable.FilterChains[i].FilterChainMatch.GetDestinationPort().GetValue()
-		}
 		if mutable.FilterChains[i].ListenerProtocol == networking.ListenerProtocolHTTP {
 			// Adding Jwt filter and authn filter, if needed.
 			if filter := applier.JwtFilter(); filter != nil {
 				mutable.FilterChains[i].HTTP = append(mutable.FilterChains[i].HTTP, filter)
 			}
-			istioMutualGateway := (in.Node.Type == model.Router) && mutable.FilterChains[i].IstioMutualGateway
-			if filter := applier.AuthNFilter(in.Node.Type, endpointPort, istioMutualGateway); filter != nil {
+			if filter := applier.AuthNFilter(); filter != nil {
 				mutable.FilterChains[i].HTTP = append(mutable.FilterChains[i].HTTP, filter)
 			}
 		}
@@ -92,7 +83,7 @@ func (Plugin) OnInboundPassthrough(in *plugin.InputParams, mutable *networking.M
 		return nil
 	}
 
-	return buildFilter(in, mutable, true)
+	return buildFilter(in, mutable)
 }
 
 func (p Plugin) InboundMTLSConfiguration(in *plugin.InputParams, passthrough bool) []plugin.MTLSSettings {

--- a/pilot/pkg/security/authn/policy_applier.go
+++ b/pilot/pkg/security/authn/policy_applier.go
@@ -34,7 +34,7 @@ type PolicyApplier interface {
 
 	// AuthNFilter returns the (authn) HTTP filter to enforce the underlying authentication policy.
 	// It may return nil, if no authentication is needed.
-	AuthNFilter(proxyType model.NodeType, port uint32, istioMutualGateway bool) *http_conn.HttpFilter
+	AuthNFilter() *http_conn.HttpFilter
 
 	// PortLevelSetting returns port level mTLS settings.
 	PortLevelSetting() map[uint32]*v1beta1.PeerAuthentication_MutualTLS

--- a/pilot/pkg/security/authn/v1beta1/policy_applier.go
+++ b/pilot/pkg/security/authn/v1beta1/policy_applier.go
@@ -174,11 +174,9 @@ func (a *v1beta1PolicyApplier) setAuthnFilterForRequestAuthn(config *authn_filte
 // - If PeerAuthentication is used, it overwrite the settings for peer principal validation and extraction based on the new API.
 // - If RequestAuthentication is used, it overwrite the settings for request principal validation and extraction based on the new API.
 // - If RequestAuthentication is used, principal binding is always set to ORIGIN.
-func (a *v1beta1PolicyApplier) AuthNFilter(proxyType model.NodeType, port uint32, istioMutualGateway bool) *http_conn.HttpFilter {
+func (a *v1beta1PolicyApplier) AuthNFilter() *http_conn.HttpFilter {
 	var filterConfigProto *authn_filter.FilterConfig
 
-	// Override the config with peer authentication, if applicable.
-	filterConfigProto = a.setAuthnFilterForPeerAuthn(proxyType, port, istioMutualGateway, filterConfigProto)
 	// Override the config with request authentication, if applicable.
 	filterConfigProto = a.setAuthnFilterForRequestAuthn(filterConfigProto)
 

--- a/pilot/pkg/security/authn/v1beta1/policy_applier_test.go
+++ b/pilot/pkg/security/authn/v1beta1/policy_applier_test.go
@@ -1035,85 +1035,14 @@ func TestAuthnFilterConfig(t *testing.T) {
 	jwksURI := ms.URL + "/oauth2/v3/certs"
 
 	cases := []struct {
-		name                         string
-		isGateway                    bool
-		gatewayServerUsesIstioMutual bool
-		jwtIn                        []*config.Config
-		peerIn                       []*config.Config
-		expected                     *http_conn.HttpFilter
+		name     string
+		jwtIn    []*config.Config
+		peerIn   []*config.Config
+		expected *http_conn.HttpFilter
 	}{
 		{
-			name: "no-policy",
-			expected: &http_conn.HttpFilter{
-				Name: "istio_authn",
-				ConfigType: &http_conn.HttpFilter_TypedConfig{
-					TypedConfig: pilotutil.MessageToAny(&authn_filter.FilterConfig{
-						Policy: &authn_alpha.Policy{
-							Peers: []*authn_alpha.PeerAuthenticationMethod{
-								{
-									Params: &authn_alpha.PeerAuthenticationMethod_Mtls{
-										Mtls: &authn_alpha.MutualTls{
-											Mode: authn_alpha.MutualTls_PERMISSIVE,
-										},
-									},
-								},
-							},
-						},
-						SkipValidateTrustDomain: true,
-					}),
-				},
-			},
-		},
-		{
-			name:      "no-policy-for-gateway-with-non-istio-mutual-servers",
-			isGateway: true,
-			expected:  nil,
-		},
-		{
-			name:                         "policy-for-gateway-with-istio-mutual-server",
-			isGateway:                    true,
-			gatewayServerUsesIstioMutual: true,
-			expected: &http_conn.HttpFilter{
-				Name: "istio_authn",
-				ConfigType: &http_conn.HttpFilter_TypedConfig{
-					TypedConfig: pilotutil.MessageToAny(&authn_filter.FilterConfig{
-						Policy: &authn_alpha.Policy{
-							Peers: []*authn_alpha.PeerAuthenticationMethod{
-								{
-									Params: &authn_alpha.PeerAuthenticationMethod_Mtls{
-										Mtls: &authn_alpha.MutualTls{
-											Mode: authn_alpha.MutualTls_STRICT,
-										},
-									},
-								},
-							},
-						},
-						SkipValidateTrustDomain: true,
-					}),
-				},
-			},
-		},
-		{
-			name: "no-request-authn-rule-skip-trust-domain",
-			expected: &http_conn.HttpFilter{
-				Name: "istio_authn",
-				ConfigType: &http_conn.HttpFilter_TypedConfig{
-					TypedConfig: pilotutil.MessageToAny(&authn_filter.FilterConfig{
-						Policy: &authn_alpha.Policy{
-							Peers: []*authn_alpha.PeerAuthenticationMethod{
-								{
-									Params: &authn_alpha.PeerAuthenticationMethod_Mtls{
-										Mtls: &authn_alpha.MutualTls{
-											Mode: authn_alpha.MutualTls_PERMISSIVE,
-										},
-									},
-								},
-							},
-						},
-						SkipValidateTrustDomain: true,
-					}),
-				},
-			},
+			name:     "no-policy",
+			expected: nil,
 		},
 		{
 			name: "beta-jwt",
@@ -1133,50 +1062,7 @@ func TestAuthnFilterConfig(t *testing.T) {
 				Name: "istio_authn",
 				ConfigType: &http_conn.HttpFilter_TypedConfig{
 					TypedConfig: pilotutil.MessageToAny(&authn_filter.FilterConfig{
-						Policy: &authn_alpha.Policy{
-							Peers: []*authn_alpha.PeerAuthenticationMethod{
-								{
-									Params: &authn_alpha.PeerAuthenticationMethod_Mtls{
-										Mtls: &authn_alpha.MutualTls{
-											Mode: authn_alpha.MutualTls_PERMISSIVE,
-										},
-									},
-								},
-							},
-							Origins: []*authn_alpha.OriginAuthenticationMethod{
-								{
-									Jwt: &authn_alpha.Jwt{
-										Issuer: "https://secret.foo.com",
-									},
-								},
-							},
-							OriginIsOptional: true,
-							PrincipalBinding: authn_alpha.PrincipalBinding_USE_ORIGIN,
-						},
 						SkipValidateTrustDomain: true,
-					}),
-				},
-			},
-		},
-		{
-			name:      "beta-jwt-for-gateway",
-			isGateway: true,
-			jwtIn: []*config.Config{
-				{
-					Spec: &v1beta1.RequestAuthentication{
-						JwtRules: []*v1beta1.JWTRule{
-							{
-								Issuer:  "https://secret.foo.com",
-								JwksUri: jwksURI,
-							},
-						},
-					},
-				},
-			},
-			expected: &http_conn.HttpFilter{
-				Name: "istio_authn",
-				ConfigType: &http_conn.HttpFilter_TypedConfig{
-					TypedConfig: pilotutil.MessageToAny(&authn_filter.FilterConfig{
 						Policy: &authn_alpha.Policy{
 							Origins: []*authn_alpha.OriginAuthenticationMethod{
 								{
@@ -1188,52 +1074,6 @@ func TestAuthnFilterConfig(t *testing.T) {
 							OriginIsOptional: true,
 							PrincipalBinding: authn_alpha.PrincipalBinding_USE_ORIGIN,
 						},
-						SkipValidateTrustDomain: true,
-					}),
-				},
-			},
-		},
-		{
-			name:                         "beta-jwt-for-gateway-with-istio-mutual",
-			isGateway:                    true,
-			gatewayServerUsesIstioMutual: true,
-			jwtIn: []*config.Config{
-				{
-					Spec: &v1beta1.RequestAuthentication{
-						JwtRules: []*v1beta1.JWTRule{
-							{
-								Issuer:  "https://secret.foo.com",
-								JwksUri: jwksURI,
-							},
-						},
-					},
-				},
-			},
-			expected: &http_conn.HttpFilter{
-				Name: "istio_authn",
-				ConfigType: &http_conn.HttpFilter_TypedConfig{
-					TypedConfig: pilotutil.MessageToAny(&authn_filter.FilterConfig{
-						Policy: &authn_alpha.Policy{
-							Peers: []*authn_alpha.PeerAuthenticationMethod{
-								{
-									Params: &authn_alpha.PeerAuthenticationMethod_Mtls{
-										Mtls: &authn_alpha.MutualTls{
-											Mode: authn_alpha.MutualTls_STRICT,
-										},
-									},
-								},
-							},
-							Origins: []*authn_alpha.OriginAuthenticationMethod{
-								{
-									Jwt: &authn_alpha.Jwt{
-										Issuer: "https://secret.foo.com",
-									},
-								},
-							},
-							OriginIsOptional: true,
-							PrincipalBinding: authn_alpha.PrincipalBinding_USE_ORIGIN,
-						},
-						SkipValidateTrustDomain: true,
 					}),
 				},
 			},
@@ -1269,16 +1109,8 @@ func TestAuthnFilterConfig(t *testing.T) {
 				Name: "istio_authn",
 				ConfigType: &http_conn.HttpFilter_TypedConfig{
 					TypedConfig: pilotutil.MessageToAny(&authn_filter.FilterConfig{
+						SkipValidateTrustDomain: true,
 						Policy: &authn_alpha.Policy{
-							Peers: []*authn_alpha.PeerAuthenticationMethod{
-								{
-									Params: &authn_alpha.PeerAuthenticationMethod_Mtls{
-										Mtls: &authn_alpha.MutualTls{
-											Mode: authn_alpha.MutualTls_PERMISSIVE,
-										},
-									},
-								},
-							},
 							Origins: []*authn_alpha.OriginAuthenticationMethod{
 								{
 									Jwt: &authn_alpha.Jwt{
@@ -1294,7 +1126,6 @@ func TestAuthnFilterConfig(t *testing.T) {
 							OriginIsOptional: true,
 							PrincipalBinding: authn_alpha.PrincipalBinding_USE_ORIGIN,
 						},
-						SkipValidateTrustDomain: true,
 					}),
 				},
 			},
@@ -1330,16 +1161,8 @@ func TestAuthnFilterConfig(t *testing.T) {
 				Name: "istio_authn",
 				ConfigType: &http_conn.HttpFilter_TypedConfig{
 					TypedConfig: pilotutil.MessageToAny(&authn_filter.FilterConfig{
+						SkipValidateTrustDomain: true,
 						Policy: &authn_alpha.Policy{
-							Peers: []*authn_alpha.PeerAuthenticationMethod{
-								{
-									Params: &authn_alpha.PeerAuthenticationMethod_Mtls{
-										Mtls: &authn_alpha.MutualTls{
-											Mode: authn_alpha.MutualTls_PERMISSIVE,
-										},
-									},
-								},
-							},
 							Origins: []*authn_alpha.OriginAuthenticationMethod{
 								{
 									Jwt: &authn_alpha.Jwt{
@@ -1355,7 +1178,6 @@ func TestAuthnFilterConfig(t *testing.T) {
 							OriginIsOptional: true,
 							PrincipalBinding: authn_alpha.PrincipalBinding_USE_ORIGIN,
 						},
-						SkipValidateTrustDomain: true,
 					}),
 				},
 			},
@@ -1371,25 +1193,7 @@ func TestAuthnFilterConfig(t *testing.T) {
 					},
 				},
 			},
-			expected: &http_conn.HttpFilter{
-				Name: "istio_authn",
-				ConfigType: &http_conn.HttpFilter_TypedConfig{
-					TypedConfig: pilotutil.MessageToAny(&authn_filter.FilterConfig{
-						Policy: &authn_alpha.Policy{
-							Peers: []*authn_alpha.PeerAuthenticationMethod{
-								{
-									Params: &authn_alpha.PeerAuthenticationMethod_Mtls{
-										Mtls: &authn_alpha.MutualTls{
-											Mode: authn_alpha.MutualTls_STRICT,
-										},
-									},
-								},
-							},
-						},
-						SkipValidateTrustDomain: true,
-					}),
-				},
-			},
+			expected: nil,
 		},
 		{
 			name: "beta-mtls-disable",
@@ -1398,20 +1202,6 @@ func TestAuthnFilterConfig(t *testing.T) {
 					Spec: &v1beta1.PeerAuthentication{
 						Mtls: &v1beta1.PeerAuthentication_MutualTLS{
 							Mode: v1beta1.PeerAuthentication_MutualTLS_DISABLE,
-						},
-					},
-				},
-			},
-			expected: nil,
-		},
-		{
-			name:      "beta-mtls-for-gateway-does-not-respect-mtls-configs",
-			isGateway: true,
-			peerIn: []*config.Config{
-				{
-					Spec: &v1beta1.PeerAuthentication{
-						Mtls: &v1beta1.PeerAuthentication_MutualTLS{
-							Mode: v1beta1.PeerAuthentication_MutualTLS_STRICT,
 						},
 					},
 				},
@@ -1429,34 +1219,12 @@ func TestAuthnFilterConfig(t *testing.T) {
 					},
 				},
 			},
-			expected: &http_conn.HttpFilter{
-				Name: "istio_authn",
-				ConfigType: &http_conn.HttpFilter_TypedConfig{
-					TypedConfig: pilotutil.MessageToAny(&authn_filter.FilterConfig{
-						Policy: &authn_alpha.Policy{
-							Peers: []*authn_alpha.PeerAuthenticationMethod{
-								{
-									Params: &authn_alpha.PeerAuthenticationMethod_Mtls{
-										Mtls: &authn_alpha.MutualTls{
-											Mode: authn_alpha.MutualTls_STRICT,
-										},
-									},
-								},
-							},
-						},
-						SkipValidateTrustDomain: true,
-					}),
-				},
-			},
+			expected: nil,
 		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			proxyType := model.SidecarProxy
-			if c.isGateway {
-				proxyType = model.Router
-			}
-			got := NewPolicyApplier("root-namespace", c.jwtIn, c.peerIn, &model.PushContext{}).AuthNFilter(proxyType, 80, c.gatewayServerUsesIstioMutual)
+			got := NewPolicyApplier("root-namespace", c.jwtIn, c.peerIn, &model.PushContext{}).AuthNFilter()
 			if !reflect.DeepEqual(c.expected, got) {
 				t.Errorf("got:\n%v\nwanted:\n%v\n", humanReadableAuthnFilterDump(got), humanReadableAuthnFilterDump(c.expected))
 			}

--- a/pilot/pkg/security/authz/builder/testdata/http/allow-full-rule-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/allow-full-rule-out.yaml
@@ -228,69 +228,41 @@ typedConfig:
             ids:
             - orIds:
                 ids:
-                - metadata:
-                    filter: istio_authn
-                    path:
-                    - key: source.principal
-                    value:
-                      stringMatch:
-                        exact: principal
-                - metadata:
-                    filter: istio_authn
-                    path:
-                    - key: source.principal
-                    value:
-                      stringMatch:
-                        prefix: principal-prefix-
-                - metadata:
-                    filter: istio_authn
-                    path:
-                    - key: source.principal
-                    value:
-                      stringMatch:
-                        suffix: -suffix-principal
-                - metadata:
-                    filter: istio_authn
-                    path:
-                    - key: source.principal
-                    value:
-                      stringMatch:
-                        safeRegex:
-                          googleRe2: {}
-                          regex: .+
+                - authenticated:
+                    principalName:
+                      exact: spiffe://principal
+                - authenticated:
+                    principalName:
+                      prefix: spiffe://principal-prefix-
+                - authenticated:
+                    principalName:
+                      safeRegex:
+                        googleRe2: {}
+                        regex: spiffe://.*-suffix-principal
+                - authenticated:
+                    principalName:
+                      safeRegex:
+                        googleRe2: {}
+                        regex: .+
             - notId:
                 orIds:
                   ids:
-                  - metadata:
-                      filter: istio_authn
-                      path:
-                      - key: source.principal
-                      value:
-                        stringMatch:
-                          exact: not-principal
-                  - metadata:
-                      filter: istio_authn
-                      path:
-                      - key: source.principal
-                      value:
-                        stringMatch:
-                          prefix: not-principal-prefix-
-                  - metadata:
-                      filter: istio_authn
-                      path:
-                      - key: source.principal
-                      value:
-                        stringMatch:
-                          suffix: -not-suffix-principal
-                  - metadata:
-                      filter: istio_authn
-                      path:
-                      - key: source.principal
-                      value:
-                        stringMatch:
-                          safeRegex:
-                            googleRe2: {}
-                            regex: .+
+                  - authenticated:
+                      principalName:
+                        exact: spiffe://not-principal
+                  - authenticated:
+                      principalName:
+                        prefix: spiffe://not-principal-prefix-
+                  - authenticated:
+                      principalName:
+                        safeRegex:
+                          googleRe2: {}
+                          regex: spiffe://.*-not-suffix-principal
+                  - authenticated:
+                      principalName:
+                        safeRegex:
+                          googleRe2: {}
+                          regex: .+
             - orIds:
                 ids:
                 - metadata:
@@ -358,81 +330,49 @@ typedConfig:
                             regex: .+
             - orIds:
                 ids:
-                - metadata:
-                    filter: istio_authn
-                    path:
-                    - key: source.principal
-                    value:
-                      stringMatch:
-                        safeRegex:
-                          googleRe2: {}
-                          regex: .*/ns/ns/.*
-                - metadata:
-                    filter: istio_authn
-                    path:
-                    - key: source.principal
-                    value:
-                      stringMatch:
-                        safeRegex:
-                          googleRe2: {}
-                          regex: .*/ns/ns-prefix-.*/.*
-                - metadata:
-                    filter: istio_authn
-                    path:
-                    - key: source.principal
-                    value:
-                      stringMatch:
-                        safeRegex:
-                          googleRe2: {}
-                          regex: .*/ns/.*-ns-suffix/.*
-                - metadata:
-                    filter: istio_authn
-                    path:
-                    - key: source.principal
-                    value:
-                      stringMatch:
-                        safeRegex:
-                          googleRe2: {}
-                          regex: .*/ns/.*/.*
+                - authenticated:
+                    principalName:
+                      safeRegex:
+                        googleRe2: {}
+                        regex: .*/ns/ns/.*
+                - authenticated:
+                    principalName:
+                      safeRegex:
+                        googleRe2: {}
+                        regex: .*/ns/ns-prefix-.*/.*
+                - authenticated:
+                    principalName:
+                      safeRegex:
+                        googleRe2: {}
+                        regex: .*/ns/.*-ns-suffix/.*
+                - authenticated:
+                    principalName:
+                      safeRegex:
+                        googleRe2: {}
+                        regex: .*/ns/.*/.*
             - notId:
                 orIds:
                   ids:
-                  - metadata:
-                      filter: istio_authn
-                      path:
-                      - key: source.principal
-                      value:
-                        stringMatch:
-                          safeRegex:
-                            googleRe2: {}
-                            regex: .*/ns/not-ns/.*
-                  - metadata:
-                      filter: istio_authn
-                      path:
-                      - key: source.principal
-                      value:
-                        stringMatch:
-                          safeRegex:
-                            googleRe2: {}
-                            regex: .*/ns/not-ns-prefix-.*/.*
-                  - metadata:
-                      filter: istio_authn
-                      path:
-                      - key: source.principal
-                      value:
-                        stringMatch:
-                          safeRegex:
-                            googleRe2: {}
-                            regex: .*/ns/.*-not-ns-suffix/.*
-                  - metadata:
-                      filter: istio_authn
-                      path:
-                      - key: source.principal
-                      value:
-                        stringMatch:
-                          safeRegex:
-                            googleRe2: {}
-                            regex: .*/ns/.*/.*
+                  - authenticated:
+                      principalName:
+                        safeRegex:
+                          googleRe2: {}
+                          regex: .*/ns/not-ns/.*
+                  - authenticated:
+                      principalName:
+                        safeRegex:
+                          googleRe2: {}
+                          regex: .*/ns/not-ns-prefix-.*/.*
+                  - authenticated:
+                      principalName:
+                        safeRegex:
+                          googleRe2: {}
+                          regex: .*/ns/.*-not-ns-suffix/.*
+                  - authenticated:
+                      principalName:
+                        safeRegex:
+                          googleRe2: {}
+                          regex: .*/ns/.*/.*
             - orIds:
                 ids:
                 - remoteIp:
@@ -532,146 +472,86 @@ typedConfig:
                       prefixLen: 24
             - orIds:
                 ids:
-                - metadata:
-                    filter: istio_authn
-                    path:
-                    - key: source.principal
-                    value:
-                      stringMatch:
+                - authenticated:
+                    principalName:
+                      safeRegex:
+                        googleRe2: {}
+                        regex: .*/ns/ns/.*
+                - authenticated:
+                    principalName:
+                      safeRegex:
+                        googleRe2: {}
+                        regex: .*/ns/ns-prefix-.*/.*
+                - authenticated:
+                    principalName:
+                      safeRegex:
+                        googleRe2: {}
+                        regex: .*/ns/.*-ns-suffix/.*
+                - authenticated:
+                    principalName:
+                      safeRegex:
+                        googleRe2: {}
+                        regex: .*/ns/.*/.*
+            - notId:
+                orIds:
+                  ids:
+                  - authenticated:
+                      principalName:
                         safeRegex:
                           googleRe2: {}
-                          regex: .*/ns/ns/.*
-                - metadata:
-                    filter: istio_authn
-                    path:
-                    - key: source.principal
-                    value:
-                      stringMatch:
+                          regex: .*/ns/not-ns/.*
+                  - authenticated:
+                      principalName:
                         safeRegex:
                           googleRe2: {}
-                          regex: .*/ns/ns-prefix-.*/.*
-                - metadata:
-                    filter: istio_authn
-                    path:
-                    - key: source.principal
-                    value:
-                      stringMatch:
+                          regex: .*/ns/not-ns-prefix-.*/.*
+                  - authenticated:
+                      principalName:
                         safeRegex:
                           googleRe2: {}
-                          regex: .*/ns/.*-ns-suffix/.*
-                - metadata:
-                    filter: istio_authn
-                    path:
-                    - key: source.principal
-                    value:
-                      stringMatch:
+                          regex: .*/ns/.*-not-ns-suffix/.*
+                  - authenticated:
+                      principalName:
                         safeRegex:
                           googleRe2: {}
                           regex: .*/ns/.*/.*
+            - orIds:
+                ids:
+                - authenticated:
+                    principalName:
+                      exact: spiffe://principal
+                - authenticated:
+                    principalName:
+                      prefix: spiffe://principal-prefix-
+                - authenticated:
+                    principalName:
+                      safeRegex:
+                        googleRe2: {}
+                        regex: spiffe://.*-suffix-principal
+                - authenticated:
+                    principalName:
+                      safeRegex:
+                        googleRe2: {}
+                        regex: .+
             - notId:
                 orIds:
                   ids:
-                  - metadata:
-                      filter: istio_authn
-                      path:
-                      - key: source.principal
-                      value:
-                        stringMatch:
-                          safeRegex:
-                            googleRe2: {}
-                            regex: .*/ns/not-ns/.*
-                  - metadata:
-                      filter: istio_authn
-                      path:
-                      - key: source.principal
-                      value:
-                        stringMatch:
-                          safeRegex:
-                            googleRe2: {}
-                            regex: .*/ns/not-ns-prefix-.*/.*
-                  - metadata:
-                      filter: istio_authn
-                      path:
-                      - key: source.principal
-                      value:
-                        stringMatch:
-                          safeRegex:
-                            googleRe2: {}
-                            regex: .*/ns/.*-not-ns-suffix/.*
-                  - metadata:
-                      filter: istio_authn
-                      path:
-                      - key: source.principal
-                      value:
-                        stringMatch:
-                          safeRegex:
-                            googleRe2: {}
-                            regex: .*/ns/.*/.*
-            - orIds:
-                ids:
-                - metadata:
-                    filter: istio_authn
-                    path:
-                    - key: source.principal
-                    value:
-                      stringMatch:
-                        exact: principal
-                - metadata:
-                    filter: istio_authn
-                    path:
-                    - key: source.principal
-                    value:
-                      stringMatch:
-                        prefix: principal-prefix-
-                - metadata:
-                    filter: istio_authn
-                    path:
-                    - key: source.principal
-                    value:
-                      stringMatch:
-                        suffix: -suffix-principal
-                - metadata:
-                    filter: istio_authn
-                    path:
-                    - key: source.principal
-                    value:
-                      stringMatch:
+                  - authenticated:
+                      principalName:
+                        exact: spiffe://not-principal
+                  - authenticated:
+                      principalName:
+                        prefix: spiffe://not-principal-prefix-
+                  - authenticated:
+                      principalName:
+                        safeRegex:
+                          googleRe2: {}
+                          regex: spiffe://.*-not-suffix-principal
+                  - authenticated:
+                      principalName:
                         safeRegex:
                           googleRe2: {}
                           regex: .+
-            - notId:
-                orIds:
-                  ids:
-                  - metadata:
-                      filter: istio_authn
-                      path:
-                      - key: source.principal
-                      value:
-                        stringMatch:
-                          exact: not-principal
-                  - metadata:
-                      filter: istio_authn
-                      path:
-                      - key: source.principal
-                      value:
-                        stringMatch:
-                          prefix: not-principal-prefix-
-                  - metadata:
-                      filter: istio_authn
-                      path:
-                      - key: source.principal
-                      value:
-                        stringMatch:
-                          suffix: -not-suffix-principal
-                  - metadata:
-                      filter: istio_authn
-                      path:
-                      - key: source.principal
-                      value:
-                        stringMatch:
-                          safeRegex:
-                            googleRe2: {}
-                            regex: .+
             - orIds:
                 ids:
                 - metadata:

--- a/pilot/pkg/security/authz/builder/testdata/http/deny-and-allow-out1.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/deny-and-allow-out1.yaml
@@ -14,11 +14,7 @@ typedConfig:
             ids:
             - orIds:
                 ids:
-                - metadata:
-                    filter: istio_authn
-                    path:
-                    - key: source.principal
-                    value:
-                      stringMatch:
-                        exact: deny
+                - authenticated:
+                    principalName:
+                      exact: spiffe://deny
   shadowRulesStatPrefix: istio_dry_run_allow_

--- a/pilot/pkg/security/authz/builder/testdata/http/deny-and-allow-out2.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/deny-and-allow-out2.yaml
@@ -13,11 +13,7 @@ typedConfig:
             ids:
             - orIds:
                 ids:
-                - metadata:
-                    filter: istio_authn
-                    path:
-                    - key: source.principal
-                    value:
-                      stringMatch:
-                        exact: allow
+                - authenticated:
+                    principalName:
+                      exact: spiffe://allow
   shadowRulesStatPrefix: istio_dry_run_allow_

--- a/pilot/pkg/security/authz/builder/testdata/http/multiple-policies-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/multiple-policies-out.yaml
@@ -73,20 +73,12 @@ typedConfig:
             ids:
             - orIds:
                 ids:
-                - metadata:
-                    filter: istio_authn
-                    path:
-                    - key: source.principal
-                    value:
-                      stringMatch:
-                        exact: principals1
-                - metadata:
-                    filter: istio_authn
-                    path:
-                    - key: source.principal
-                    value:
-                      stringMatch:
-                        exact: principals2
+                - authenticated:
+                    principalName:
+                      exact: spiffe://principals1
+                - authenticated:
+                    principalName:
+                      exact: spiffe://principals2
       ns[foo]-policy[httpbin-6]-rule[0]:
         permissions:
         - andRules:
@@ -121,24 +113,16 @@ typedConfig:
             ids:
             - orIds:
                 ids:
-                - metadata:
-                    filter: istio_authn
-                    path:
-                    - key: source.principal
-                    value:
-                      stringMatch:
-                        safeRegex:
-                          googleRe2: {}
-                          regex: .*/ns/namespaces1/.*
-                - metadata:
-                    filter: istio_authn
-                    path:
-                    - key: source.principal
-                    value:
-                      stringMatch:
-                        safeRegex:
-                          googleRe2: {}
-                          regex: .*/ns/namespaces2/.*
+                - authenticated:
+                    principalName:
+                      safeRegex:
+                        googleRe2: {}
+                        regex: .*/ns/namespaces1/.*
+                - authenticated:
+                    principalName:
+                      safeRegex:
+                        googleRe2: {}
+                        regex: .*/ns/namespaces2/.*
       ns[foo]-policy[httpbin-8]-rule[0]:
         permissions:
         - andRules:

--- a/pilot/pkg/security/authz/builder/testdata/http/simple-policy-multiple-td-aliases-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/simple-policy-multiple-td-aliases-out.yaml
@@ -13,82 +13,42 @@ typedConfig:
             ids:
             - orIds:
                 ids:
-                - metadata:
-                    filter: istio_authn
-                    path:
-                    - key: source.principal
-                    value:
-                      stringMatch:
-                        exact: td1/ns/rule[0]/sa/from[0]-principal[0]
-                - metadata:
-                    filter: istio_authn
-                    path:
-                    - key: source.principal
-                    value:
-                      stringMatch:
-                        exact: cluster.local/ns/rule[0]/sa/from[0]-principal[0]
-                - metadata:
-                    filter: istio_authn
-                    path:
-                    - key: source.principal
-                    value:
-                      stringMatch:
-                        exact: some-td/ns/rule[0]/sa/from[0]-principal[0]
+                - authenticated:
+                    principalName:
+                      exact: spiffe://td1/ns/rule[0]/sa/from[0]-principal[0]
+                - authenticated:
+                    principalName:
+                      exact: spiffe://cluster.local/ns/rule[0]/sa/from[0]-principal[0]
+                - authenticated:
+                    principalName:
+                      exact: spiffe://some-td/ns/rule[0]/sa/from[0]-principal[0]
         - andIds:
             ids:
             - orIds:
                 ids:
-                - metadata:
-                    filter: istio_authn
-                    path:
-                    - key: source.principal
-                    value:
-                      stringMatch:
-                        exact: td1/ns/rule[0]/sa/from[1]-principal[0]
-                - metadata:
-                    filter: istio_authn
-                    path:
-                    - key: source.principal
-                    value:
-                      stringMatch:
-                        exact: cluster.local/ns/rule[0]/sa/from[1]-principal[0]
-                - metadata:
-                    filter: istio_authn
-                    path:
-                    - key: source.principal
-                    value:
-                      stringMatch:
-                        exact: some-td/ns/rule[0]/sa/from[1]-principal[0]
-                - metadata:
-                    filter: istio_authn
-                    path:
-                    - key: source.principal
-                    value:
-                      stringMatch:
-                        exact: td1/ns/rule[0]/sa/from[1]-principal[1]
-                - metadata:
-                    filter: istio_authn
-                    path:
-                    - key: source.principal
-                    value:
-                      stringMatch:
-                        exact: cluster.local/ns/rule[0]/sa/from[1]-principal[1]
-                - metadata:
-                    filter: istio_authn
-                    path:
-                    - key: source.principal
-                    value:
-                      stringMatch:
-                        exact: some-td/ns/rule[0]/sa/from[1]-principal[1]
+                - authenticated:
+                    principalName:
+                      exact: spiffe://td1/ns/rule[0]/sa/from[1]-principal[0]
+                - authenticated:
+                    principalName:
+                      exact: spiffe://cluster.local/ns/rule[0]/sa/from[1]-principal[0]
+                - authenticated:
+                    principalName:
+                      exact: spiffe://some-td/ns/rule[0]/sa/from[1]-principal[0]
+                - authenticated:
+                    principalName:
+                      exact: spiffe://td1/ns/rule[0]/sa/from[1]-principal[1]
+                - authenticated:
+                    principalName:
+                      exact: spiffe://cluster.local/ns/rule[0]/sa/from[1]-principal[1]
+                - authenticated:
+                    principalName:
+                      exact: spiffe://some-td/ns/rule[0]/sa/from[1]-principal[1]
             - orIds:
                 ids:
-                - metadata:
-                    filter: istio_authn
-                    path:
-                    - key: source.principal
-                    value:
-                      stringMatch:
-                        safeRegex:
-                          googleRe2: {}
-                          regex: .*/ns/rule[0]-from[1]-ns[0]/.*
+                - authenticated:
+                    principalName:
+                      safeRegex:
+                        googleRe2: {}
+                        regex: .*/ns/rule[0]-from[1]-ns[0]/.*
   shadowRulesStatPrefix: istio_dry_run_allow_

--- a/pilot/pkg/security/authz/builder/testdata/http/simple-policy-principal-with-wildcard-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/simple-policy-principal-with-wildcard-out.yaml
@@ -13,38 +13,26 @@ typedConfig:
             ids:
             - orIds:
                 ids:
-                - metadata:
-                    filter: istio_authn
-                    path:
-                    - key: source.principal
-                    value:
-                      stringMatch:
-                        safeRegex:
-                          googleRe2: {}
-                          regex: .+
+                - authenticated:
+                    principalName:
+                      safeRegex:
+                        googleRe2: {}
+                        regex: .+
         - andIds:
             ids:
             - orIds:
                 ids:
-                - metadata:
-                    filter: istio_authn
-                    path:
-                    - key: source.principal
-                    value:
-                      stringMatch:
-                        suffix: /ns/foo/sa/rule[0]-from[1]-principal[0]
-                - metadata:
-                    filter: istio_authn
-                    path:
-                    - key: source.principal
-                    value:
-                      stringMatch:
-                        exact: td1/ns/foo/sa/rule[0]-from[1]-principal[1]
-                - metadata:
-                    filter: istio_authn
-                    path:
-                    - key: source.principal
-                    value:
-                      stringMatch:
-                        suffix: bar/ns/foo/sa/rule[0]-from[1]-principal[1]
+                - authenticated:
+                    principalName:
+                      safeRegex:
+                        googleRe2: {}
+                        regex: spiffe://.*/ns/foo/sa/rule[0]-from[1]-principal[0]
+                - authenticated:
+                    principalName:
+                      exact: spiffe://td1/ns/foo/sa/rule[0]-from[1]-principal[1]
+                - authenticated:
+                    principalName:
+                      safeRegex:
+                        googleRe2: {}
+                        regex: spiffe://.*bar/ns/foo/sa/rule[0]-from[1]-principal[1]
   shadowRulesStatPrefix: istio_dry_run_allow_

--- a/pilot/pkg/security/authz/builder/testdata/http/simple-policy-td-aliases-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/simple-policy-td-aliases-out.yaml
@@ -17,63 +17,35 @@ typedConfig:
             ids:
             - orIds:
                 ids:
-                - metadata:
-                    filter: istio_authn
-                    path:
-                    - key: source.principal
-                    value:
-                      stringMatch:
-                        exact: td1/ns/rule[0]/sa/from[0]-principal[0]
-                - metadata:
-                    filter: istio_authn
-                    path:
-                    - key: source.principal
-                    value:
-                      stringMatch:
-                        exact: cluster.local/ns/rule[0]/sa/from[0]-principal[0]
+                - authenticated:
+                    principalName:
+                      exact: spiffe://td1/ns/rule[0]/sa/from[0]-principal[0]
+                - authenticated:
+                    principalName:
+                      exact: spiffe://cluster.local/ns/rule[0]/sa/from[0]-principal[0]
         - andIds:
             ids:
             - orIds:
                 ids:
-                - metadata:
-                    filter: istio_authn
-                    path:
-                    - key: source.principal
-                    value:
-                      stringMatch:
-                        exact: td1/ns/rule[0]/sa/from[1]-principal[0]
-                - metadata:
-                    filter: istio_authn
-                    path:
-                    - key: source.principal
-                    value:
-                      stringMatch:
-                        exact: cluster.local/ns/rule[0]/sa/from[1]-principal[0]
-                - metadata:
-                    filter: istio_authn
-                    path:
-                    - key: source.principal
-                    value:
-                      stringMatch:
-                        exact: td1/ns/rule[0]/sa/from[1]-principal[1]
-                - metadata:
-                    filter: istio_authn
-                    path:
-                    - key: source.principal
-                    value:
-                      stringMatch:
-                        exact: cluster.local/ns/rule[0]/sa/from[1]-principal[1]
+                - authenticated:
+                    principalName:
+                      exact: spiffe://td1/ns/rule[0]/sa/from[1]-principal[0]
+                - authenticated:
+                    principalName:
+                      exact: spiffe://cluster.local/ns/rule[0]/sa/from[1]-principal[0]
+                - authenticated:
+                    principalName:
+                      exact: spiffe://td1/ns/rule[0]/sa/from[1]-principal[1]
+                - authenticated:
+                    principalName:
+                      exact: spiffe://cluster.local/ns/rule[0]/sa/from[1]-principal[1]
             - orIds:
                 ids:
-                - metadata:
-                    filter: istio_authn
-                    path:
-                    - key: source.principal
-                    value:
-                      stringMatch:
-                        safeRegex:
-                          googleRe2: {}
-                          regex: .*/ns/rule[0]-from[1]-ns[0]/.*
+                - authenticated:
+                    principalName:
+                      safeRegex:
+                        googleRe2: {}
+                        regex: .*/ns/rule[0]-from[1]-ns[0]/.*
       ns[foo]-policy[httpbin]-rule[1]:
         permissions:
         - andRules:
@@ -88,18 +60,10 @@ typedConfig:
             ids:
             - orIds:
                 ids:
-                - metadata:
-                    filter: istio_authn
-                    path:
-                    - key: source.principal
-                    value:
-                      stringMatch:
-                        exact: td1/ns/rule[1]/sa/from[0]-principal[0]
-                - metadata:
-                    filter: istio_authn
-                    path:
-                    - key: source.principal
-                    value:
-                      stringMatch:
-                        exact: cluster.local/ns/rule[1]/sa/from[0]-principal[0]
+                - authenticated:
+                    principalName:
+                      exact: spiffe://td1/ns/rule[1]/sa/from[0]-principal[0]
+                - authenticated:
+                    principalName:
+                      exact: spiffe://cluster.local/ns/rule[1]/sa/from[0]-principal[0]
   shadowRulesStatPrefix: istio_dry_run_allow_

--- a/pilot/pkg/security/authz/builder/testdata/http/single-policy-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/single-policy-out.yaml
@@ -86,20 +86,12 @@ typedConfig:
             ids:
             - orIds:
                 ids:
-                - metadata:
-                    filter: istio_authn
-                    path:
-                    - key: source.principal
-                    value:
-                      stringMatch:
-                        exact: rule[0]-from[0]-principal[1]
-                - metadata:
-                    filter: istio_authn
-                    path:
-                    - key: source.principal
-                    value:
-                      stringMatch:
-                        exact: rule[0]-from[0]-principal[2]
+                - authenticated:
+                    principalName:
+                      exact: spiffe://rule[0]-from[0]-principal[1]
+                - authenticated:
+                    principalName:
+                      exact: spiffe://rule[0]-from[0]-principal[2]
             - orIds:
                 ids:
                 - metadata:
@@ -118,24 +110,16 @@ typedConfig:
                         exact: rule[0]-from[0]-requestPrincipal[2]
             - orIds:
                 ids:
-                - metadata:
-                    filter: istio_authn
-                    path:
-                    - key: source.principal
-                    value:
-                      stringMatch:
-                        safeRegex:
-                          googleRe2: {}
-                          regex: .*/ns/rule[0]-from[0]-ns[1]/.*
-                - metadata:
-                    filter: istio_authn
-                    path:
-                    - key: source.principal
-                    value:
-                      stringMatch:
-                        safeRegex:
-                          googleRe2: {}
-                          regex: .*/ns/rule[0]-from[0]-ns[2]/.*
+                - authenticated:
+                    principalName:
+                      safeRegex:
+                        googleRe2: {}
+                        regex: .*/ns/rule[0]-from[0]-ns[1]/.*
+                - authenticated:
+                    principalName:
+                      safeRegex:
+                        googleRe2: {}
+                        regex: .*/ns/rule[0]-from[0]-ns[2]/.*
             - orIds:
                 ids:
                 - remoteIp:
@@ -175,20 +159,12 @@ typedConfig:
             ids:
             - orIds:
                 ids:
-                - metadata:
-                    filter: istio_authn
-                    path:
-                    - key: source.principal
-                    value:
-                      stringMatch:
-                        exact: rule[0]-from[1]-principal[1]
-                - metadata:
-                    filter: istio_authn
-                    path:
-                    - key: source.principal
-                    value:
-                      stringMatch:
-                        exact: rule[0]-from[1]-principal[2]
+                - authenticated:
+                    principalName:
+                      exact: spiffe://rule[0]-from[1]-principal[1]
+                - authenticated:
+                    principalName:
+                      exact: spiffe://rule[0]-from[1]-principal[2]
             - orIds:
                 ids:
                 - metadata:
@@ -207,24 +183,16 @@ typedConfig:
                         exact: rule[0]-from[1]-requestPrincipal[2]
             - orIds:
                 ids:
-                - metadata:
-                    filter: istio_authn
-                    path:
-                    - key: source.principal
-                    value:
-                      stringMatch:
-                        safeRegex:
-                          googleRe2: {}
-                          regex: .*/ns/rule[0]-from[1]-ns[1]/.*
-                - metadata:
-                    filter: istio_authn
-                    path:
-                    - key: source.principal
-                    value:
-                      stringMatch:
-                        safeRegex:
-                          googleRe2: {}
-                          regex: .*/ns/rule[0]-from[1]-ns[2]/.*
+                - authenticated:
+                    principalName:
+                      safeRegex:
+                        googleRe2: {}
+                        regex: .*/ns/rule[0]-from[1]-ns[1]/.*
+                - authenticated:
+                    principalName:
+                      safeRegex:
+                        googleRe2: {}
+                        regex: .*/ns/rule[0]-from[1]-ns[2]/.*
             - orIds:
                 ids:
                 - remoteIp:
@@ -330,20 +298,12 @@ typedConfig:
             ids:
             - orIds:
                 ids:
-                - metadata:
-                    filter: istio_authn
-                    path:
-                    - key: source.principal
-                    value:
-                      stringMatch:
-                        exact: rule[1]-from[0]-principal[1]
-                - metadata:
-                    filter: istio_authn
-                    path:
-                    - key: source.principal
-                    value:
-                      stringMatch:
-                        exact: rule[1]-from[0]-principal[2]
+                - authenticated:
+                    principalName:
+                      exact: spiffe://rule[1]-from[0]-principal[1]
+                - authenticated:
+                    principalName:
+                      exact: spiffe://rule[1]-from[0]-principal[2]
             - orIds:
                 ids:
                 - metadata:
@@ -362,24 +322,16 @@ typedConfig:
                         exact: rule[1]-from[0]-requestPrincipal[2]
             - orIds:
                 ids:
-                - metadata:
-                    filter: istio_authn
-                    path:
-                    - key: source.principal
-                    value:
-                      stringMatch:
-                        safeRegex:
-                          googleRe2: {}
-                          regex: .*/ns/rule[1]-from[0]-ns[1]/.*
-                - metadata:
-                    filter: istio_authn
-                    path:
-                    - key: source.principal
-                    value:
-                      stringMatch:
-                        safeRegex:
-                          googleRe2: {}
-                          regex: .*/ns/rule[1]-from[0]-ns[2]/.*
+                - authenticated:
+                    principalName:
+                      safeRegex:
+                        googleRe2: {}
+                        regex: .*/ns/rule[1]-from[0]-ns[1]/.*
+                - authenticated:
+                    principalName:
+                      safeRegex:
+                        googleRe2: {}
+                        regex: .*/ns/rule[1]-from[0]-ns[2]/.*
             - orIds:
                 ids:
                 - remoteIp:
@@ -400,20 +352,12 @@ typedConfig:
             ids:
             - orIds:
                 ids:
-                - metadata:
-                    filter: istio_authn
-                    path:
-                    - key: source.principal
-                    value:
-                      stringMatch:
-                        exact: rule[1]-from[1]-principal[1]
-                - metadata:
-                    filter: istio_authn
-                    path:
-                    - key: source.principal
-                    value:
-                      stringMatch:
-                        exact: rule[1]-from[1]-principal[2]
+                - authenticated:
+                    principalName:
+                      exact: spiffe://rule[1]-from[1]-principal[1]
+                - authenticated:
+                    principalName:
+                      exact: spiffe://rule[1]-from[1]-principal[2]
             - orIds:
                 ids:
                 - metadata:
@@ -432,24 +376,16 @@ typedConfig:
                         exact: rule[1]-from[1]-requestPrincipal[2]
             - orIds:
                 ids:
-                - metadata:
-                    filter: istio_authn
-                    path:
-                    - key: source.principal
-                    value:
-                      stringMatch:
-                        safeRegex:
-                          googleRe2: {}
-                          regex: .*/ns/rule[1]-from[1]-ns[1]/.*
-                - metadata:
-                    filter: istio_authn
-                    path:
-                    - key: source.principal
-                    value:
-                      stringMatch:
-                        safeRegex:
-                          googleRe2: {}
-                          regex: .*/ns/rule[1]-from[1]-ns[2]/.*
+                - authenticated:
+                    principalName:
+                      safeRegex:
+                        googleRe2: {}
+                        regex: .*/ns/rule[1]-from[1]-ns[1]/.*
+                - authenticated:
+                    principalName:
+                      safeRegex:
+                        googleRe2: {}
+                        regex: .*/ns/rule[1]-from[1]-ns[2]/.*
             - orIds:
                 ids:
                 - remoteIp:

--- a/pilot/pkg/security/authz/builder/testdata/http/td-aliases-source-principal-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/td-aliases-source-principal-out.yaml
@@ -13,45 +13,29 @@ typedConfig:
             ids:
             - orIds:
                 ids:
-                - metadata:
-                    filter: istio_authn
-                    path:
-                    - key: source.principal
-                    value:
-                      stringMatch:
-                        safeRegex:
-                          googleRe2: {}
-                          regex: .*/ns/istio-system/.*
+                - authenticated:
+                    principalName:
+                      safeRegex:
+                        googleRe2: {}
+                        regex: .*/ns/istio-system/.*
             - orIds:
                 ids:
-                - metadata:
-                    filter: istio_authn
-                    path:
-                    - key: source.principal
-                    value:
-                      stringMatch:
-                        safeRegex:
-                          googleRe2: {}
-                          regex: .+
-                - metadata:
-                    filter: istio_authn
-                    path:
-                    - key: source.principal
-                    value:
-                      stringMatch:
-                        suffix: /ns/foo/sa/all-td
-                - metadata:
-                    filter: istio_authn
-                    path:
-                    - key: source.principal
-                    value:
-                      stringMatch:
-                        suffix: -td/ns/foo/sa/prefix-td
-                - metadata:
-                    filter: istio_authn
-                    path:
-                    - key: source.principal
-                    value:
-                      stringMatch:
-                        exact: some-trustdomain/ns/foo/sa/prefix-td
+                - authenticated:
+                    principalName:
+                      safeRegex:
+                        googleRe2: {}
+                        regex: .+
+                - authenticated:
+                    principalName:
+                      safeRegex:
+                        googleRe2: {}
+                        regex: spiffe://.*/ns/foo/sa/all-td
+                - authenticated:
+                    principalName:
+                      safeRegex:
+                        googleRe2: {}
+                        regex: spiffe://.*-td/ns/foo/sa/prefix-td
+                - authenticated:
+                    principalName:
+                      exact: spiffe://some-trustdomain/ns/foo/sa/prefix-td
   shadowRulesStatPrefix: istio_dry_run_allow_

--- a/pilot/pkg/security/authz/model/generator.go
+++ b/pilot/pkg/security/authz/model/generator.go
@@ -123,16 +123,10 @@ func (srcNamespaceGenerator) permission(_, _ string, _ bool) (*rbacpb.Permission
 	return nil, fmt.Errorf("unimplemented")
 }
 
-func (srcNamespaceGenerator) principal(_, value string, forTCP bool) (*rbacpb.Principal, error) {
+func (srcNamespaceGenerator) principal(_, value string, _ bool) (*rbacpb.Principal, error) {
 	v := strings.Replace(value, "*", ".*", -1)
 	m := matcher.StringMatcherRegex(fmt.Sprintf(".*/ns/%s/.*", v))
-	if forTCP {
-		return principalAuthenticated(m), nil
-	}
-	// Proxy doesn't have attrSrcNamespace directly, but the information is encoded in attrSrcPrincipal
-	// with format: cluster.local/ns/{NAMESPACE}/sa/{SERVICE-ACCOUNT}.
-	metadata := matcher.MetadataStringMatcher(sm.AuthnFilterName, attrSrcPrincipal, m)
-	return principalMetadata(metadata), nil
+	return principalAuthenticated(m), nil
 }
 
 type srcPrincipalGenerator struct{}
@@ -141,13 +135,9 @@ func (srcPrincipalGenerator) permission(_, _ string, _ bool) (*rbacpb.Permission
 	return nil, fmt.Errorf("unimplemented")
 }
 
-func (srcPrincipalGenerator) principal(key, value string, forTCP bool) (*rbacpb.Principal, error) {
-	if forTCP {
-		m := matcher.StringMatcherWithPrefix(value, spiffe.URIPrefix)
-		return principalAuthenticated(m), nil
-	}
-	metadata := matcher.MetadataStringMatcher(sm.AuthnFilterName, key, matcher.StringMatcher(value))
-	return principalMetadata(metadata), nil
+func (srcPrincipalGenerator) principal(key, value string, _ bool) (*rbacpb.Principal, error) {
+	m := matcher.StringMatcherWithPrefix(value, spiffe.URIPrefix)
+	return principalAuthenticated(m), nil
 }
 
 type requestPrincipalGenerator struct{}

--- a/pilot/pkg/security/authz/model/generator_test.go
+++ b/pilot/pkg/security/authz/model/generator_test.go
@@ -111,15 +111,11 @@ func TestGenerator(t *testing.T) {
 			g:     srcNamespaceGenerator{},
 			value: "foo",
 			want: yamlPrincipal(t, `
-         metadata:
-          filter: istio_authn
-          path:
-          - key: source.principal
-          value:
-            stringMatch:
-              safeRegex:
-                googleRe2: {}
-                regex: .*/ns/foo/.*`),
+         authenticated:
+          principalName:
+            safeRegex:
+              googleRe2: {}
+              regex: .*/ns/foo/.*`),
 		},
 		{
 			name:   "srcNamespaceGenerator-tcp",
@@ -139,13 +135,9 @@ func TestGenerator(t *testing.T) {
 			key:   "source.principal",
 			value: "foo",
 			want: yamlPrincipal(t, `
-         metadata:
-          filter: istio_authn
-          path:
-          - key: source.principal
-          value:
-            stringMatch:
-              exact: foo`),
+         authenticated:
+          principalName:
+            exact: spiffe://foo`),
 		},
 		{
 			name:   "srcPrincipalGenerator-tcp",


### PR DESCRIPTION
    Currently, we are verifying mTLS attributes using the istio_authn HTTP
    filter. This is already done by the TCP filter. Using the same method
    for TCP simplifies the code (do things one way instead of two), is
    likely slightly more performant, and allows easier usage for non
    istio-proxy Envoy builds.
