### PR TITLE
Create prefix matches for wildcard SPIFFE URI SANs in TLS validation context

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -737,7 +737,7 @@ func (cb *ClusterBuilder) buildUpstreamClusterTLSContext(opts *buildClusterOpts,
 
 		tlsContext.CommonTlsContext.ValidationContextType = &auth.CommonTlsContext_CombinedValidationContext{
 			CombinedValidationContext: &auth.CommonTlsContext_CombinedCertificateValidationContext{
-				DefaultValidationContext:         &auth.CertificateValidationContext{MatchSubjectAltNames: util.StringToExactMatch(tls.SubjectAltNames)},
+				DefaultValidationContext:         &auth.CertificateValidationContext{MatchSubjectAltNames: authn_model.SANToMatch(tls.SubjectAltNames)},
 				ValidationContextSdsSecretConfig: authn_model.ConstructSdsSecretConfig(authn_model.SDSRootResourceName, proxy),
 			},
 		}
@@ -781,7 +781,7 @@ func (cb *ClusterBuilder) buildUpstreamClusterTLSContext(opts *buildClusterOpts,
 			} else {
 				tlsContext.CommonTlsContext.ValidationContextType = &auth.CommonTlsContext_CombinedValidationContext{
 					CombinedValidationContext: &auth.CommonTlsContext_CombinedCertificateValidationContext{
-						DefaultValidationContext:         &auth.CertificateValidationContext{MatchSubjectAltNames: util.StringToExactMatch(tls.SubjectAltNames)},
+						DefaultValidationContext:         &auth.CertificateValidationContext{MatchSubjectAltNames: authn_model.SANToMatch(tls.SubjectAltNames)},
 						ValidationContextSdsSecretConfig: authn_model.ConstructSdsSecretConfig(res.GetRootResourceName(), proxy),
 					},
 				}
@@ -827,7 +827,7 @@ func (cb *ClusterBuilder) buildUpstreamClusterTLSContext(opts *buildClusterOpts,
 			} else {
 				tlsContext.CommonTlsContext.ValidationContextType = &auth.CommonTlsContext_CombinedValidationContext{
 					CombinedValidationContext: &auth.CommonTlsContext_CombinedCertificateValidationContext{
-						DefaultValidationContext:         &auth.CertificateValidationContext{MatchSubjectAltNames: util.StringToExactMatch(tls.SubjectAltNames)},
+						DefaultValidationContext:         &auth.CertificateValidationContext{MatchSubjectAltNames: authn_model.SANToMatch(tls.SubjectAltNames)},
 						ValidationContextSdsSecretConfig: authn_model.ConstructSdsSecretConfig(res.GetRootResourceName(), proxy),
 					},
 				}

--- a/pkg/spiffe/spiffe.go
+++ b/pkg/spiffe/spiffe.go
@@ -63,7 +63,7 @@ type Identity struct {
 }
 
 func ParseIdentity(s string) (Identity, error) {
-	if !strings.HasPrefix(s, URIPrefix) {
+	if !HasSpiffePrefix(s) {
 		return Identity{}, fmt.Errorf("identity is not a spiffe format: %v", s)
 	}
 	split := strings.Split(s[URIPrefixLen:], "/")
@@ -78,6 +78,10 @@ func ParseIdentity(s string) (Identity, error) {
 		Namespace:      split[2],
 		ServiceAccount: split[4],
 	}, nil
+}
+
+func HasSpiffePrefix(s string) bool {
+	return strings.HasPrefix(s, URIPrefix)
 }
 
 func (i Identity) String() string {

--- a/releasenotes/notes/spiffe-uri-san-wildcard.yaml
+++ b/releasenotes/notes/spiffe-uri-san-wildcard.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+
+releaseNotes:
+- |
+  **Added** support for SPIFFE URI subject alternative names that end with valid wildcards in TLS validation context. This allows users to specify `subjectAltNames` in SPIFFE URI format that end in wildcards (e.g., "spiffe://cluster.domain/*") for `TLSSettings`.


### PR DESCRIPTION
This helps with cases e.g. SPIFFE where users would like to trust the entire
trust domain by setting wildcards SANs like "spiffe://cluster.domain/*".

Signed-off-by: Kailun Qin <kailun.qin@intel.com>

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[x] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
