### PR TITLE
initial Apache SkyWalking tracer support

### DIFF
--- a/istioctl/cmd/dashboard.go
+++ b/istioctl/cmd/dashboard.go
@@ -370,8 +370,8 @@ func skywalkingDashCmd() *cobra.Command {
 	var opts clioptions.ControlPlaneOptions
 	cmd := &cobra.Command{
 		Use:   "skywalking",
-		Short: "Open SKyWalking UI",
-		Long:  "Open SkyWalking UI on Istio",
+		Short: "Open SkyWalking UI",
+		Long:  "Open the Istio dashboard in the SkyWalking UI",
 		Example: `  istioctl dashboard skywalking
 
   # with short syntax

--- a/istioctl/cmd/dashboard.go
+++ b/istioctl/cmd/dashboard.go
@@ -365,6 +365,42 @@ func controlZDashCmd() *cobra.Command {
 	return cmd
 }
 
+// port-forward to SkyWalking UI on istio-system
+func skywalkingDashCmd() *cobra.Command {
+	var opts clioptions.ControlPlaneOptions
+	cmd := &cobra.Command{
+		Use:   "skywalking",
+		Short: "Open SKyWalking UI",
+		Long:  "Open SkyWalking UI on Istio",
+		Example: `  istioctl dashboard skywalking
+
+  # with short syntax
+  istioctl dash skywalking
+  istioctl d skywalking`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := kubeClientWithRevision(kubeconfig, configContext, opts.Revision)
+			if err != nil {
+				return fmt.Errorf("failed to create k8s client: %v", err)
+			}
+
+			pl, err := client.PodsForSelector(context.TODO(), addonNamespace, "app=skywalking-ui")
+			if err != nil {
+				return fmt.Errorf("not able to locate SkyWalking UI pod: %v", err)
+			}
+
+			if len(pl.Items) < 1 {
+				return errors.New("no SkyWalking UI pods found")
+			}
+
+			// only use the first pod in the list
+			return portForward(pl.Items[0].Name, addonNamespace, "SkyWalking",
+				"http://%s", bindAddress, 8080, client, cmd.OutOrStdout(), browser)
+		},
+	}
+
+	return cmd
+}
+
 // portForward first tries to forward localhost:remotePort to podName:remotePort, falls back to dynamic local port
 func portForward(podName, namespace, flavor, urlFormat, localAddress string, remotePort int,
 	client kube.ExtendedClient, writer io.Writer, browser bool) error {
@@ -472,6 +508,7 @@ func dashboard() *cobra.Command {
 	dashboardCmd.AddCommand(grafanaDashCmd())
 	dashboardCmd.AddCommand(jaegerDashCmd())
 	dashboardCmd.AddCommand(zipkinDashCmd())
+	dashboardCmd.AddCommand(skywalkingDashCmd())
 
 	envoy := envoyDashCmd()
 	envoy.PersistentFlags().StringVarP(&labelSelector, "selector", "l", "", "Label selector")

--- a/pilot/docker/Dockerfile.proxyv2
+++ b/pilot/docker/Dockerfile.proxyv2
@@ -30,7 +30,7 @@ COPY gcp_envoy_bootstrap.json /var/lib/istio/envoy/gcp_envoy_bootstrap_tmpl.json
 # Install Envoy.
 COPY $SIDECAR /usr/local/bin/$SIDECAR
 
-# Environment variable indicating the exact proxy sha - for debugging or version-specific configs 
+# Environment variable indicating the exact proxy sha - for debugging or version-specific configs
 ENV ISTIO_META_ISTIO_PROXY_SHA $proxy_version
 # Environment variable indicating the exact build, for debugging
 ENV ISTIO_META_ISTIO_VERSION $istio_version

--- a/pilot/docker/Dockerfile.proxyv2
+++ b/pilot/docker/Dockerfile.proxyv2
@@ -30,7 +30,7 @@ COPY gcp_envoy_bootstrap.json /var/lib/istio/envoy/gcp_envoy_bootstrap_tmpl.json
 # Install Envoy.
 COPY $SIDECAR /usr/local/bin/$SIDECAR
 
-# Environment variable indicating the exact proxy sha - for debugging or version-specific configs
+# Environment variable indicating the exact proxy sha - for debugging or version-specific configs 
 ENV ISTIO_META_ISTIO_PROXY_SHA $proxy_version
 # Environment variable indicating the exact build, for debugging
 ENV ISTIO_META_ISTIO_VERSION $istio_version

--- a/pilot/pkg/networking/core/v1alpha3/tracing.go
+++ b/pilot/pkg/networking/core/v1alpha3/tracing.go
@@ -149,6 +149,21 @@ func configureFromProviderConfig(pushCtx *model.PushContext, meta *model.NodeMet
 			return anypb.New(oc)
 		})
 
+	case *meshconfig.MeshConfig_ExtensionProvider_Skywalking:
+		return buildHCMTracing(pushCtx, providerCfg.Name, provider.Skywalking.Service, provider.Skywalking.Port, 0, func(clusterName string) (*anypb.Any, error) {
+			s := &tracingcfg.SkyWalkingConfig{
+				GrpcService: &envoy_config_core_v3.GrpcService{
+					TargetSpecifier: &envoy_config_core_v3.GrpcService_EnvoyGrpc_{
+						EnvoyGrpc: &envoy_config_core_v3.GrpcService_EnvoyGrpc{
+							ClusterName: clusterName,
+						},
+					},
+				},
+			}
+
+			return anypb.New(s)
+		})
+
 	case *meshconfig.MeshConfig_ExtensionProvider_Stackdriver:
 		return buildHCMTracingOpenCensus(providerCfg.Name, provider.Stackdriver.MaxTagLength, func() (*anypb.Any, error) {
 			proj, ok := meta.PlatformMetadata[platform.GCPProject]

--- a/pilot/pkg/networking/core/v1alpha3/tracing_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/tracing_test.go
@@ -384,7 +384,6 @@ func fakeZipkinProvider(expectClusterName, expectProviderName string) *tracingcf
 		Name:       expectProviderName,
 		ConfigType: &tracingcfg.Tracing_Http_TypedConfig{TypedConfig: fakeZipkinAny},
 	}
-
 }
 
 func fakeSkywalkingProvider(expectClusterName, expectProviderName string) *tracingcfg.Tracing_Http {

--- a/pilot/pkg/networking/core/v1alpha3/tracing_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/tracing_test.go
@@ -17,6 +17,7 @@ package v1alpha3
 import (
 	"testing"
 
+	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	tracingcfg "github.com/envoyproxy/go-control-plane/envoy/config/trace/v3"
 	hpb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	tracing "github.com/envoyproxy/go-control-plane/envoy/type/tracing/v3"
@@ -33,9 +34,12 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 )
 
-func TestConfigureTracing(t *testing.T) {
+func TestZipkinConfigureTracing(t *testing.T) {
+	clusterName := "testcluster"
+	providerName := "foo"
+
 	clusterLookupFn = func(push *model.PushContext, service string, port int) (hostname string, cluster string, err error) {
-		return "testhost", "testcluster", nil
+		return "testhost", clusterName, nil
 	}
 	defer func() {
 		clusterLookupFn = extensionproviders.LookupCluster
@@ -55,14 +59,14 @@ func TestConfigureTracing(t *testing.T) {
 		{
 			name:   "only telemetry api (no provider)",
 			inSpec: fakeTracingSpecNoProvider(99.999, false),
-			opts:   fakeOptsOnlyTelemetryAPI(),
+			opts:   fakeOptsOnlyZipkinTelemetryAPI(),
 			want:   fakeTracingConfigNoProvider(99.999, 0, append(defaultTracingTags(), fakeEnvTag)),
 		},
 		{
 			name:   "only telemetry api (with provider)",
-			inSpec: fakeTracingSpec(fakeProviders([]string{"foo"}), 99.999, false),
-			opts:   fakeOptsOnlyTelemetryAPI(),
-			want:   fakeTracingConfig(fakeZipkinProvider, 99.999, 256, append(defaultTracingTags(), fakeEnvTag)),
+			inSpec: fakeTracingSpec(fakeProviders([]string{providerName}), 99.999, false),
+			opts:   fakeOptsOnlyZipkinTelemetryAPI(),
+			want:   fakeTracingConfig(fakeZipkinProvider(clusterName, providerName), 99.999, 256, append(defaultTracingTags(), fakeEnvTag)),
 		},
 		{
 			name:   "both tracing enabled (no provider)",
@@ -78,15 +82,15 @@ func TestConfigureTracing(t *testing.T) {
 		},
 		{
 			name:   "both tracing enabled (with provider)",
-			inSpec: fakeTracingSpec(fakeProviders([]string{"foo"}), 99.999, false),
+			inSpec: fakeTracingSpec(fakeProviders([]string{providerName}), 99.999, false),
 			opts:   fakeOptsMeshAndTelemetryAPI(true /* enable tracing */),
-			want:   fakeTracingConfig(fakeZipkinProvider, 99.999, 256, append(defaultTracingTags(), fakeEnvTag)),
+			want:   fakeTracingConfig(fakeZipkinProvider(clusterName, providerName), 99.999, 256, append(defaultTracingTags(), fakeEnvTag)),
 		},
 		{
 			name:   "both tracing disabled (with provider)",
-			inSpec: fakeTracingSpec(fakeProviders([]string{"foo"}), 99.999, false),
+			inSpec: fakeTracingSpec(fakeProviders([]string{providerName}), 99.999, false),
 			opts:   fakeOptsMeshAndTelemetryAPI(false /* no enable tracing */),
-			want:   fakeTracingConfig(fakeZipkinProvider, 99.999, 256, append(defaultTracingTags(), fakeEnvTag)),
+			want:   fakeTracingConfig(fakeZipkinProvider(clusterName, providerName), 99.999, 256, append(defaultTracingTags(), fakeEnvTag)),
 		},
 	}
 
@@ -98,6 +102,40 @@ func TestConfigureTracing(t *testing.T) {
 				t.Errorf("configureTracing returned unexpected diff (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestSkywalkingTracingConfigure(t *testing.T) {
+	clusterName := "testcluster"
+	providerName := "foo"
+
+	clusterLookupFn = func(push *model.PushContext, service string, port int) (hostname string, cluster string, err error) {
+		return "testhost", clusterName, nil
+	}
+	defer func() {
+		clusterLookupFn = extensionproviders.LookupCluster
+	}()
+
+	testcases := []struct {
+		name     string
+		spec     *tpb.Telemetry
+		opts     buildListenerOpts
+		expected *hpb.HttpConnectionManager_Tracing
+	}{
+		{
+			name:     "basic config",
+			spec:     fakeTracingSpec(fakeProviders([]string{providerName}), 99.999, false),
+			opts:     fakeOptsOnlySkywalkingTelemetryAPI(),
+			expected: fakeTracingConfig(fakeSkywalkingProvider(clusterName, providerName), 99.999, 0, append(defaultTracingTags(), fakeEnvTag)),
+		},
+	}
+
+	for _, tc := range testcases {
+		hcm := &hpb.HttpConnectionManager{}
+		configureTracingFromSpec(tc.spec, tc.opts, hcm)
+		if diff := cmp.Diff(tc.expected, hcm.Tracing, protocmp.Transform()); diff != "" {
+			t.Errorf("configureTracing returned unexpected diff (-want +got):\n%s", diff)
+		}
 	}
 }
 
@@ -167,7 +205,7 @@ func fakeOptsNoTelemetryAPI() buildListenerOpts {
 	return opts
 }
 
-func fakeOptsOnlyTelemetryAPI() buildListenerOpts {
+func fakeOptsOnlyZipkinTelemetryAPI() buildListenerOpts {
 	var opts buildListenerOpts
 	opts.push = &model.PushContext{
 		Mesh: &meshconfig.MeshConfig{
@@ -230,6 +268,32 @@ func fakeOptsMeshAndTelemetryAPI(enableTracing bool) buildListenerOpts {
 					},
 				},
 			},
+		},
+	}
+
+	return opts
+}
+
+func fakeOptsOnlySkywalkingTelemetryAPI() buildListenerOpts {
+	var opts buildListenerOpts
+	opts.push = &model.PushContext{
+		Mesh: &meshconfig.MeshConfig{
+			ExtensionProviders: []*meshconfig.MeshConfig_ExtensionProvider{
+				{
+					Name: "foo",
+					Provider: &meshconfig.MeshConfig_ExtensionProvider_Skywalking{
+						Skywalking: &meshconfig.MeshConfig_ExtensionProvider_SkyWalkingTracingProvider{
+							Service: "skywalking-oap.istio-system.svc.cluster.local",
+							Port:    11800,
+						},
+					},
+				},
+			},
+		},
+	}
+	opts.proxy = &model.Proxy{
+		Metadata: &model.NodeMetadata{
+			ProxyConfig: &model.NodeMetaProxyConfig{},
 		},
 	}
 
@@ -307,17 +371,35 @@ var fakeEnvTag = &tracing.CustomTag{
 	},
 }
 
-var fakeZipkinProviderConfig = &tracingcfg.ZipkinConfig{
-	CollectorCluster:         "testcluster",
-	CollectorEndpoint:        "/api/v2/spans",
-	CollectorEndpointVersion: tracingcfg.ZipkinConfig_HTTP_JSON,
-	TraceId_128Bit:           true,
-	SharedSpanContext:        wrapperspb.Bool(false),
+func fakeZipkinProvider(expectClusterName, expectProviderName string) *tracingcfg.Tracing_Http {
+	fakeZipkinProviderConfig := &tracingcfg.ZipkinConfig{
+		CollectorCluster:         expectClusterName,
+		CollectorEndpoint:        "/api/v2/spans",
+		CollectorEndpointVersion: tracingcfg.ZipkinConfig_HTTP_JSON,
+		TraceId_128Bit:           true,
+		SharedSpanContext:        wrapperspb.Bool(false),
+	}
+	fakeZipkinAny, _ := anypb.New(fakeZipkinProviderConfig)
+	return &tracingcfg.Tracing_Http{
+		Name:       expectProviderName,
+		ConfigType: &tracingcfg.Tracing_Http_TypedConfig{TypedConfig: fakeZipkinAny},
+	}
+
 }
 
-var fakeZipkinAny, _ = anypb.New(fakeZipkinProviderConfig)
-
-var fakeZipkinProvider = &tracingcfg.Tracing_Http{
-	Name:       "foo",
-	ConfigType: &tracingcfg.Tracing_Http_TypedConfig{TypedConfig: fakeZipkinAny},
+func fakeSkywalkingProvider(expectClusterName, expectProviderName string) *tracingcfg.Tracing_Http {
+	fakeSkywalkingProviderConfig := &tracingcfg.SkyWalkingConfig{
+		GrpcService: &envoy_config_core_v3.GrpcService{
+			TargetSpecifier: &envoy_config_core_v3.GrpcService_EnvoyGrpc_{
+				EnvoyGrpc: &envoy_config_core_v3.GrpcService_EnvoyGrpc{
+					ClusterName: expectClusterName,
+				},
+			},
+		},
+	}
+	fakeSkywalkingAny, _ := anypb.New(fakeSkywalkingProviderConfig)
+	return &tracingcfg.Tracing_Http{
+		Name:       expectProviderName,
+		ConfigType: &tracingcfg.Tracing_Http_TypedConfig{TypedConfig: fakeSkywalkingAny},
+	}
 }

--- a/pkg/config/validation/extensionprovider.go
+++ b/pkg/config/validation/extensionprovider.go
@@ -154,6 +154,19 @@ func validateExtensionProviderTracingOpenCensusAgent(config *meshconfig.MeshConf
 	return
 }
 
+func validateExtensionProviderTracingSkyWalking(config *meshconfig.MeshConfig_ExtensionProvider_SkyWalkingTracingProvider) (errs error) {
+	if config == nil {
+		return fmt.Errorf("nil TracingSkyWalkingProvider")
+	}
+	if err := validateExtensionProviderService(config.Service); err != nil {
+		errs = appendErrors(errs, err)
+	}
+	if err := ValidatePort(int(config.Port)); err != nil {
+		errs = appendErrors(errs, fmt.Errorf("invalid service port: %v", err))
+	}
+	return
+}
+
 func validateExtensionProvider(config *meshconfig.MeshConfig) (errs error) {
 	definedProviders := map[string]struct{}{}
 	for _, c := range config.ExtensionProviders {
@@ -181,6 +194,8 @@ func validateExtensionProvider(config *meshconfig.MeshConfig) (errs error) {
 			currentErrs = appendErrors(currentErrs, validateExtensionProviderTracingDatadog(provider.Datadog))
 		case *meshconfig.MeshConfig_ExtensionProvider_Opencensus:
 			currentErrs = appendErrors(currentErrs, validateExtensionProviderTracingOpenCensusAgent(provider.Opencensus))
+		case *meshconfig.MeshConfig_ExtensionProvider_Skywalking:
+			currentErrs = appendErrors(currentErrs, validateExtensionProviderTracingSkyWalking(provider.Skywalking))
 		default:
 			currentErrs = appendErrors(currentErrs, fmt.Errorf("unsupported provider: %v", provider))
 		}

--- a/releasenotes/notes/32588.yaml
+++ b/releasenotes/notes/32588.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: feature
+area: telemetry
+
+issue:
+- https://github.com/istio/istio/pull/32588
+
+releaseNotes:
+- |
+  **Added** Introduced to deliver Apache SkyWalking tracer configuration to envoy.

--- a/releasenotes/notes/32588.yaml
+++ b/releasenotes/notes/32588.yaml
@@ -7,4 +7,4 @@ issue:
 
 releaseNotes:
 - |
-  **Added** Introduced to deliver Apache SkyWalking tracer configuration to envoy.
+  **Added** support for [Apache SkyWalking](https://skywalking.apache.org/) tracer. Now you can run the `istioctl dashboard skywalking` command to view skywalking dashboard UI.


### PR DESCRIPTION
This PR introduces initial Apache SkyWalking support. This PR depends on istio-proxy which includes these fixes (https://github.com/envoyproxy/envoy/pull/16203, https://github.com/envoyproxy/envoy/pull/16264).

<img width="1426" alt="Screen Shot 2021-05-02 at 21 02 46" src="https://user-images.githubusercontent.com/17607122/116821051-2d27a280-abb3-11eb-94e2-2e50e5bdb297.png">

<img width="1431" alt="Screen Shot 2021-05-02 at 21 03 10" src="https://user-images.githubusercontent.com/17607122/116821047-28fb8500-abb3-11eb-81ca-246fa5fc2a4f.png">


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[x] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
