### PR TITLE
istio-agent: add checks for XDS root CA existence

### DIFF
--- a/pkg/istio-agent/xds_proxy.go
+++ b/pkg/istio-agent/xds_proxy.go
@@ -662,9 +662,13 @@ func (p *XdsProxy) getTLSDialOption(agent *Agent) (grpc.DialOption, error) {
 
 func (p *XdsProxy) getRootCertificate(agent *Agent) (*x509.CertPool, error) {
 	var certPool *x509.CertPool
-	var err error
 	var rootCert []byte
-	xdsCACertPath := agent.FindRootCAForXDS()
+
+	xdsCACertPath, err := agent.FindRootCAForXDS()
+	if err != nil {
+		return nil, fmt.Errorf("failed to find root CA cert for XDS: %v", err)
+	}
+
 	if xdsCACertPath != "" {
 		rootCert, err = ioutil.ReadFile(xdsCACertPath)
 		if err != nil {


### PR DESCRIPTION
Adding additional checks for the existence of root CA certs for the XDS
connection. This helps XDS initialization to fail early, instead of obscure
envoy errors.

Signed-off-by: Kailun Qin <kailun.qin@intel.com>

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[x] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
