### PR TITLE
Fix: istioctl dashboard envoy does not default namespace

### DIFF
--- a/istioctl/cmd/dashboard.go
+++ b/istioctl/cmd/dashboard.go
@@ -45,6 +45,8 @@ var (
 	labelSelector = ""
 
 	addonNamespace = ""
+
+	envoyDashNs = ""
 )
 
 // port-forward to Istio System Prometheus; open browser
@@ -261,7 +263,7 @@ func envoyDashCmd() *cobra.Command {
 
 			var podName, ns string
 			if labelSelector != "" {
-				pl, err := client.PodsForSelector(context.TODO(), handlers.HandleNamespace(addonNamespace, defaultNamespace), labelSelector)
+				pl, err := client.PodsForSelector(context.TODO(), handlers.HandleNamespace(envoyDashNs, defaultNamespace), labelSelector)
 				if err != nil {
 					return fmt.Errorf("not able to locate pod with selector %s: %v", labelSelector, err)
 				}
@@ -279,7 +281,7 @@ func envoyDashCmd() *cobra.Command {
 				ns = pl.Items[0].Namespace
 			} else {
 				podName, ns, err = handlers.InferPodInfoFromTypedResource(args[0],
-					handlers.HandleNamespace(addonNamespace, defaultNamespace),
+					handlers.HandleNamespace(envoyDashNs, defaultNamespace),
 					client.UtilFactory())
 				if err != nil {
 					return err
@@ -475,7 +477,7 @@ func dashboard() *cobra.Command {
 
 	envoy := envoyDashCmd()
 	envoy.PersistentFlags().StringVarP(&labelSelector, "selector", "l", "", "Label selector")
-	envoy.PersistentFlags().StringVarP(&addonNamespace, "namespace", "n", istioNamespace,
+	envoy.PersistentFlags().StringVarP(&envoyDashNs, "namespace", "n", defaultNamespace,
 		"Namespace where the addon is running, if not specified, istio-system would be used")
 	dashboardCmd.AddCommand(envoy)
 


### PR DESCRIPTION
To fix https://github.com/istio/istio/issues/32600

The current default was `istio-system` which was aligned according to other addon components eg: Kiali, Jaeger. But as envoy dashboard can work for both core components as well as other pods, defaulting to the `default` namespace is more appropriate.

In default namespace.
```
$ istioctl dashboard envoy deployment/productpage-v1
http://localhost:15000

$ istioctl dashboard envoy deployment/productpage-v1.default
http://localhost:15000

$ istioctl dashboard envoy deployment/productpage-v1 -n default
http://localhost:15000
```
In another namespace.
```
$ istioctl d envoy istio-ingressgateway-758d94b574-mpc7x
Error: could not build port forwarder for Envoy sidecar istio-ingressgateway-758d94b574-mpc7x: failed retrieving pod: pods "istio-ingressgateway-758d94b574-mpc7x" not found

$ istioctl d envoy istio-ingressgateway-758d94b574-mpc7x.istio-system
http://localhost:15000

$ istioctl d envoy istio-ingressgateway-758d94b574-mpc7x -n istio-system
http://localhost:15000
```