### PR TITLE
Various improvements to istio-agent logging

### DIFF
--- a/pilot/cmd/pilot-agent/options/security.go
+++ b/pilot/cmd/pilot-agent/options/security.go
@@ -99,8 +99,12 @@ func SetupSecurityOptions(proxyConfig *meshconfig.ProxyConfig, secOpt *security.
 		log.Infof("using credential fetcher of %s type in %s trust domain", credFetcherTypeEnv, o.TrustDomain)
 		o.CredFetcher = credFetcher
 	}
+	// Default the CA provider where possible
+	if strings.Contains(o.CAEndpoint, "googleapis.com") {
+		o.CAProviderName = security.GoogleCAProvider
+	}
 	// TODO extract this logic out to a plugin
-	if o.CAProviderName == "GoogleCA" || strings.Contains(o.CAEndpoint, "googleapis.com") {
+	if o.CAProviderName == security.GoogleCAProvider {
 		o.TokenExchanger = stsclient.NewSecureTokenServiceExchanger(o.CredFetcher, o.TrustDomain)
 	}
 

--- a/pkg/istio-agent/agent.go
+++ b/pkg/istio-agent/agent.go
@@ -380,9 +380,10 @@ func (a *Agent) newSecretManager() (*cache.SecretManagerClient, error) {
 		return cache.NewSecretManagerClient(nil, a.secOpts)
 	}
 
-	// TODO: this should all be packaged in a plugin, possibly with optional compilation.
 	log.Infof("CA Endpoint %s, provider %s", a.secOpts.CAEndpoint, a.secOpts.CAProviderName)
-	if a.secOpts.CAProviderName == "GoogleCA" || strings.Contains(a.secOpts.CAEndpoint, "googleapis.com") {
+
+	// TODO: this should all be packaged in a plugin, possibly with optional compilation.
+	if a.secOpts.CAProviderName == security.GoogleCAProvider {
 		// Use a plugin to an external CA - this has direct support for the K8S JWT token
 		// This is only used if the proper env variables are injected - otherwise the existing Citadel or Istiod will be
 		// used.

--- a/pkg/security/security.go
+++ b/pkg/security/security.go
@@ -56,6 +56,9 @@ const (
 	// Credential fetcher type
 	GCE  = "GoogleComputeEngine"
 	Mock = "Mock" // testing only
+
+	// GoogleCAProvider uses the Google CA for workload certificate signing
+	GoogleCAProvider = "GoogleCA"
 )
 
 // TODO: For 1.8, make sure MeshConfig is updated with those settings,


### PR DESCRIPTION
These changes should result only in logging changes, no functionality
changes
Example of new logs:
```
info    JWT policy is third-party-jwt
info    stsclient       GKE_CLUSTER_URL is not set, fetched cluster URL from metadata server: "https://container.googleapis.com/v1/..."
info    CA Endpoint ...:443, provider GoogleCA
info    stsserver       Start listening on 127.0.0.1:15009
info    ads     All caches have been synced up in 47.799988ms, marking server ready
info    Opening status port 15020
info    sds     SDS server for workload certificates started, listening on "./etc/istio/proxy/SDS"
info    sds     Start SDS grpc server
info    xdsproxy        Initializing with upstream address "..." and cluster "..."
info    Pilot SAN: [...]
info    starting Http service at 127.0.0.1:15004
info    Starting proxy agent
info    Epoch 0 starting
info    Envoy command: [-c etc/istio/proxy/envoy-rev0.json --restart-epoch 0 --drain-time-s 45 --drain-strategy immediate --parent-shutdown-time-s 60 --local-address-ip-version v4 --bootstrap-version 3 --disable-hot-restart --log-format %Y-%m-%dT%T.%fZ  %l      envoy %n        %v -l warning --component-log-level misc:error]
info    token   Prepared federated token request for aud "identitynamespace:...:https://container.googleapis.com/v1/..."
info    googleca        Cert created with GoogleCA us-central1-c chain length 3
info    cache   generated new workload certificate      latency=204.572712ms ttl=23h59m59.689390416s
info    cache   Root cert has changed, start rotating root cert
info    ads     XDS: Incremental Pushing:0 ConnectedEndpoints:0 Version:
info    cache   returned workload trust anchor from cache       ttl=23h59m59.68907472s
info    token   fetched federated token latency=36.584445ms ttl=3600
info    token   fetched acess token     latency=68.781041ms ttl=3600
info    xdsproxy        connected to upstream XDS server: ...
info    ads     ADS: new connection for node:istio-ingressgateway-5fbc8cc7d7-4kj7r.asm-gw-1
info    cache   returned workload trust anchor from cache       ttl=23h59m59.361699438s
info    ads     ADS: new connection for node:istio-ingressgateway-5fbc8cc7d7-4kj7r.asm-gw-2
info    cache   returned workload certificate from cache        ttl=23h59m59.361400828s
info    sds     SDS: PUSH       resource=ROOTCA
info    sds     SDS: PUSH       resource=default
info    Initialization took 2.888315279s
info    Envoy proxy is ready
```