### PR TITLE
allow specifying additional echo workloads

### DIFF
--- a/pkg/test/framework/components/echo/echoboot/flags.go
+++ b/pkg/test/framework/components/echo/echoboot/flags.go
@@ -1,0 +1,87 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package echoboot
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"io/ioutil"
+
+	"gopkg.in/yaml.v3"
+
+	"istio.io/istio/pkg/test/framework/components/echo"
+	"istio.io/istio/pkg/test/framework/config"
+	"istio.io/istio/pkg/test/util/file"
+)
+
+var additionalConfigs = &configs{}
+
+func init() {
+	flag.Var(additionalConfigs, "istio.test.echo.configs", "The path to a file containing a list of "+
+		"echo.Config in YAML which will be added to the set of echos for every suite.")
+}
+
+// configs wraps a slice of echo.Config to implement the config.Value interface, allowing
+// it to be configured by a flag, or within the test framework config file.
+type configs []echo.Config
+
+var _ config.Value = &configs{}
+
+func (c *configs) String() string {
+	buf := &bytes.Buffer{}
+	for _, cc := range *c {
+		_, _ = fmt.Fprintf(buf, "FQDN:     %s\n", cc.FQDN())
+		_, _ = fmt.Fprintf(buf, "Headless: %v\n", cc.Headless)
+		_, _ = fmt.Fprintf(buf, "VM:       %v\n", cc.DeployAsVM)
+		if cc.DeployAsVM {
+			_, _ = fmt.Fprintf(buf, "VMDistro: %s\n", cc.VMDistro)
+		}
+		if cc.Cluster.Name() != "" {
+			_, _ = fmt.Fprintf(buf, "Cluster:  %s\n", cc.Cluster.Name())
+		}
+	}
+	return buf.String()
+}
+
+func (c *configs) Set(path string) error {
+	path, err := file.NormalizePath(path)
+	if err != nil {
+		return err
+	}
+	yml, err := ioutil.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	out, err := echo.ParseConfigs(yml)
+	if err != nil {
+		return err
+	}
+	*c = out
+	return nil
+}
+
+func (c *configs) SetConfig(m config.Map) error {
+	yml, err := yaml.Marshal(m)
+	if err != nil {
+		return err
+	}
+	out, err := echo.ParseConfigs(yml)
+	if err != nil {
+		return err
+	}
+	*c = out
+	return nil
+}


### PR DESCRIPTION
Allows specifying `--istio.test.echo.configs /path/to/echos.yaml`, which contains input similar to echogen (#32486). The provided `echo.Configs` will be appended as if calling `builder.WithConfig` in the setup for any suite/test. 

This is useful when we want to test against something very specific, that isn't necessarily worth pulling into every CI run, or to add custom CI jobs that test different workloads, without adding logic in the Go code to do so. 

Example:

```yaml
- Service: centosVM
   Namespace: echo
   DeployAsVM: true
   VMDistro: Centos8
``` 

This is also compatible with #32216. The file given to `--istio.test.config` could contain:

```yaml
istio:
  test:
    echo:
      configs:
      - Service: centosVM
         Namespace: echo
         DeployAsVM: true
         VMDistro: Centos8
```

or

```yaml
istio:
  test:
    echo:
      configs: /path/to/separate/file.yaml
```

cc @JimmyCYJ @williamaronli 