### PR TITLE
support embedding topolgoy in istio.test.config

### DIFF
--- a/pkg/test/framework/components/echo/echoboot/flags.go
+++ b/pkg/test/framework/components/echo/echoboot/flags.go
@@ -73,7 +73,7 @@ func (c *configs) Set(path string) error {
 	return nil
 }
 
-func (c *configs) SetConfig(m config.Map) error {
+func (c *configs) SetConfig(m interface{}) error {
 	yml, err := yaml.Marshal(m)
 	if err != nil {
 		return err

--- a/pkg/test/framework/components/environment/kube/flags.go
+++ b/pkg/test/framework/components/environment/kube/flags.go
@@ -17,12 +17,16 @@ package kube
 import (
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
 
+	"gopkg.in/yaml.v3"
+
 	"istio.io/istio/pkg/test/env"
+	"istio.io/istio/pkg/test/framework/components/cluster"
 	"istio.io/istio/pkg/test/framework/config"
 	"istio.io/istio/pkg/test/scopes"
 	"istio.io/istio/pkg/test/util/file"
@@ -46,7 +50,7 @@ var (
 	// hold configTopology from command line to parse later
 	configTopology string
 	// file defining all types of topology
-	topologyFile string
+	clusterConfigs configsVal
 )
 
 // NewSettingsFromCommandLine returns Settings obtained from command-line flags.
@@ -215,6 +219,48 @@ func parseClusterIndex(index string) (clusterIndex, error) {
 	return clusterIndex(ci), nil
 }
 
+// configsVal implements config.Value to allow setting the path as a flag or embedding the topology content
+// in the overal test framework config
+type configsVal []cluster.Config
+
+func (c *configsVal) String() string {
+	return fmt.Sprint(*c)
+}
+
+func (c *configsVal) Set(s string) error {
+	filename, err := file.NormalizePath(s)
+	if err != nil {
+		return err
+	}
+	topologyBytes, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return err
+	}
+	configs := []cluster.Config{}
+	if err := yaml.Unmarshal(topologyBytes, &configs); err != nil {
+		return fmt.Errorf("failed to parse %s: %v", s, err)
+	}
+	*c = configs
+	scopes.Framework.Infof("Using clusterConfigs file: %v.", s)
+	return nil
+}
+
+func (c *configsVal) SetConfig(m interface{}) error {
+	bytes, err := yaml.Marshal(m)
+	if err != nil {
+		return err
+	}
+	configs := []cluster.Config{}
+	if err := yaml.Unmarshal(bytes, &configs); err != nil {
+		return fmt.Errorf("failed to reparse: %v", err)
+	}
+	*c = configs
+	scopes.Framework.Infof("Using topology from test framework config file.")
+	return nil
+}
+
+var _ config.Value = &configsVal{}
+
 // init registers the command-line flags that we can exposed for "go test".
 func init() {
 	flag.StringVar(&kubeConfigs, "istio.test.kube.config", "",
@@ -239,7 +285,7 @@ func init() {
 		"", "Specifies the mapping for each cluster to the cluster hosting its config. The value is a "+
 			"comma-separated list of the form <clusterIndex>:<configClusterIndex>, where the indexes refer to the order in which "+
 			"a given cluster appears in the 'istio.test.kube.config' flag. If not specified, the default is every cluster maps to itself(e.g. 0:0,1:1,...).")
-	flag.StringVar(&topologyFile, "istio.test.kube.topology", "", "The path to a JSON file that defines control plane,"+
+	flag.Var(&clusterConfigs, "istio.test.kube.topology", "The path to a JSON file that defines control plane,"+
 		" network, and config cluster topology. The JSON document should be an array of objects that contain the keys \"control_plane_index\","+
 		" \"network_id\" and \"config_index\" with all integer values. If control_plane_index is omitted, the index of the array item is used."+
 		"If network_id is omitted, 0 will be used. If config_index is omitted, control_plane_index will be used.")

--- a/pkg/test/framework/components/environment/kube/settings.go
+++ b/pkg/test/framework/components/environment/kube/settings.go
@@ -16,15 +16,11 @@ package kube
 
 import (
 	"fmt"
-	"io/ioutil"
-
-	"gopkg.in/yaml.v3"
 
 	istioKube "istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/test/framework/components/cluster"
 	"istio.io/istio/pkg/test/framework/config"
 	"istio.io/istio/pkg/test/scopes"
-	"istio.io/istio/pkg/test/util/file"
 )
 
 // clusterIndex is the index of a cluster within the KubeConfig or topology file entries
@@ -70,9 +66,9 @@ func (s *Settings) clone() *Settings {
 	return &c
 }
 
-func (s *Settings) clusterConfigs() (configs []cluster.Config, err error) {
-	if topologyFile == "" {
-		// no file, build directly from provided kubeconfigs and topology flag maps
+func (s *Settings) clusterConfigs() ([]cluster.Config, error) {
+	if len(clusterConfigs) == 0 {
+		// not loaded from file file, build directly from provided kubeconfigs and topology flag maps
 		return s.clusterConfigsFromFlags()
 	}
 
@@ -114,57 +110,44 @@ func (s *Settings) clusterConfigsFromFlags() ([]cluster.Config, error) {
 }
 
 func (s *Settings) clusterConfigsFromFile() ([]cluster.Config, error) {
-	scopes.Framework.Infof("Using configs file: %v.", topologyFile)
-	filename, err := file.NormalizePath(topologyFile)
-	if err != nil {
-		return nil, err
-	}
-	topologyBytes, err := ioutil.ReadFile(filename)
-	if err != nil {
-		return nil, err
-	}
-	configs := []cluster.Config{}
-	if err := yaml.Unmarshal(topologyBytes, &configs); err != nil {
-		return nil, fmt.Errorf("failed to parse %s: %v", topologyFile, err)
-	}
-
 	// Allow kubeconfig flag to override file
-	configs, err = replaceKubeconfigs(configs, s.KubeConfig)
+	var err error
+	clusterConfigs, err = replaceKubeconfigs(clusterConfigs, s.KubeConfig)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := s.validateTopologyFlags(len(configs)); err != nil {
+	if err := s.validateTopologyFlags(len(clusterConfigs)); err != nil {
 		return nil, err
 	}
 
-	// Apply configs overrides from flags, if specified.
+	// Apply clusterConfigs overrides from flags, if specified.
 	if s.controlPlaneTopology != nil && len(s.controlPlaneTopology) > 0 {
-		if len(s.controlPlaneTopology) != len(configs) {
-			return nil, fmt.Errorf("istio.test.kube.controlPlaneTopology has %d entries but there are %d clusters", len(controlPlaneTopology), len(configs))
+		if len(s.controlPlaneTopology) != len(clusterConfigs) {
+			return nil, fmt.Errorf("istio.test.kube.controlPlaneTopology has %d entries but there are %d clusters", len(controlPlaneTopology), len(clusterConfigs))
 		}
 		for src, dst := range s.controlPlaneTopology {
-			configs[src].PrimaryClusterName = configs[dst].Name
+			clusterConfigs[src].PrimaryClusterName = clusterConfigs[dst].Name
 		}
 	}
 	if s.configTopology != nil {
-		if len(s.configTopology) != len(configs) {
-			return nil, fmt.Errorf("istio.test.kube.configTopology has %d entries but there are %d clusters", len(controlPlaneTopology), len(configs))
+		if len(s.configTopology) != len(clusterConfigs) {
+			return nil, fmt.Errorf("istio.test.kube.configTopology has %d entries but there are %d clusters", len(controlPlaneTopology), len(clusterConfigs))
 		}
 		for src, dst := range s.controlPlaneTopology {
-			configs[src].ConfigClusterName = configs[dst].Name
+			clusterConfigs[src].ConfigClusterName = clusterConfigs[dst].Name
 		}
 	}
 	if s.networkTopology != nil {
-		if len(s.networkTopology) != len(configs) {
-			return nil, fmt.Errorf("istio.test.kube.networkTopology has %d entries but there are %d clusters", len(controlPlaneTopology), len(configs))
+		if len(s.networkTopology) != len(clusterConfigs) {
+			return nil, fmt.Errorf("istio.test.kube.networkTopology has %d entries but there are %d clusters", len(controlPlaneTopology), len(clusterConfigs))
 		}
 		for src, network := range s.networkTopology {
-			configs[src].ConfigClusterName = network
+			clusterConfigs[src].ConfigClusterName = network
 		}
 	}
 
-	return configs, nil
+	return clusterConfigs, nil
 }
 
 func (s *Settings) validateTopologyFlags(nClusters int) error {

--- a/pkg/test/framework/config/map.go
+++ b/pkg/test/framework/config/map.go
@@ -49,7 +49,6 @@ func (m Map) String(key string) string {
 func (m Map) Slice(key string) []Map {
 	v, ok := m[key].([]interface{})
 	if !ok {
-		scopes.Framework.Warnf("failed to parse key %q as slice, defaulting to empty", key)
 		return nil
 	}
 	var out []Map

--- a/pkg/test/framework/resource/version.go
+++ b/pkg/test/framework/resource/version.go
@@ -27,7 +27,11 @@ var _ config.Value = &RevVerMap{}
 // RevVerMap maps installed revisions to their Istio versions.
 type RevVerMap map[string]IstioVersion
 
-func (rv *RevVerMap) SetConfig(m config.Map) error {
+func (rv *RevVerMap) SetConfig(mi interface{}) error {
+	m, ok := mi.(config.Map)
+	if !ok {
+		return fmt.Errorf("revisions map: expected map but got slice")
+	}
 	out := make(RevVerMap)
 	for k := range m {
 		version := m.String(k)


### PR DESCRIPTION
The last change required to configure pretty much any test framework flag completely in one file. I can run the tests with multiple clusters, and istiodless remotes via: `go test ./tests/integration/pilot/... --istio.test.config ~/test-config.yaml` + the following config file:

```yaml
istio:
  test:
    istio:
      istiodlessRemotes: true
    kube:
      topology:
      - kind: Kubernetes
        clusterName: primary
        meta:
          kubeconfig: ~/kubeconf/cluster-1.yaml
      - kind: Kubernetes
        clusterName: remote
        primaryClusterName: primary
        meta:
          kubeconfig: ~/kubeconf/cluster-2.yaml
          fakeVM: false
```

If I have several sets of clusters for manual testing, I could just store the `topology` bit in separate files (e.g. `aws.yaml`, `gke.yaml`) then provide the path instead:


```yaml
istio:
  test:
    kube:
      topology: ~/topologies/aws.yaml
```