### PR TITLE
fix(ingress-controller): align prefix generation.

### DIFF
--- a/pilot/pkg/config/kube/ingress/conversion.go
+++ b/pilot/pkg/config/kube/ingress/conversion.go
@@ -321,7 +321,7 @@ func createFallbackStringMatch(s string) *networking.StringMatch {
 	}
 	if strings.HasSuffix(s, "/*") {
 		return &networking.StringMatch{
-			MatchType: &networking.StringMatch_Prefix{Prefix: strings.TrimSuffix(s, "/*")},
+			MatchType: &networking.StringMatch_Prefix{Prefix: strings.TrimSuffix(s, "*")},
 		}
 	}
 

--- a/pilot/pkg/config/kube/ingressv1/conversion.go
+++ b/pilot/pkg/config/kube/ingressv1/conversion.go
@@ -325,7 +325,7 @@ func createFallbackStringMatch(s string) *networking.StringMatch {
 	}
 	if strings.HasSuffix(s, "/*") {
 		return &networking.StringMatch{
-			MatchType: &networking.StringMatch_Prefix{Prefix: strings.TrimSuffix(s, "/*")},
+			MatchType: &networking.StringMatch_Prefix{Prefix: strings.TrimSuffix(s, "*")},
 		}
 	}
 


### PR DESCRIPTION
This PR aligns the prefix generation to adhere to the note posted in the [Ingress Path types docs](https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types) and in the code at https://github.com/istio/istio/blob/978f43519deddcb3e3fb2d0d4d56810b30692dca/pilot/pkg/config/kube/ingress/conversion.go#L164 and https://github.com/istio/istio/blob/978f43519deddcb3e3fb2d0d4d56810b30692dca/pilot/pkg/config/kube/ingressv1/conversion.go#L164.

>Note: If the last element of the path is a substring of the last element in request path, it is not a match (for example: /foo/bar matches/foo/bar/baz, but does not match /foo/barbaz).

Edit: Though now that I'm mulling it over, it may be intentional so that the Envoy-based prefix functionality can be used... 


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[X] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.