### PR TITLE
fix: helmchart istiod - add ports defined on service to deployment

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/Chart.yaml
+++ b/manifests/charts/istio-control/istio-discovery/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: istio-discovery
-version: 1.2.0
+version: 1.2.1
 tillerVersion: ">=2.7.2"
 description: Helm chart for istio control plane
 keywords:

--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -95,8 +95,16 @@ spec:
             protocol: TCP
           - containerPort: 15010
             protocol: TCP
+            name: grpc-xds # plaintext
+          - containerPort: 15012
+            protocol: TCP
+            name: https-dns # mTLS with k8s-signed cert
+          - containerPort: 15014
+            protocol: TCP
+            name: http-monitoring # prometheus stats
           - containerPort: 15017
             protocol: TCP
+            name: https-webhook # validation and injection
           readinessProbe:
             httpGet:
               path: /ready


### PR DESCRIPTION
This adds the missing ports that the istiod Service expects on the pods to the Deployment spec.  


[X] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.