### PR TITLE
istioctl dashboard: improve port-forward error message to mention namespace

### DIFF
--- a/istioctl/pkg/util/handlers/handlers.go
+++ b/istioctl/pkg/util/handlers/handlers.go
@@ -71,7 +71,7 @@ func InferPodInfoFromTypedResource(name, defaultNS string, factory cmdutil.Facto
 	builder.ResourceNames("pods", resname)
 	infos, err := builder.Do().Infos()
 	if err != nil {
-		return "", "", err
+		return "", "", fmt.Errorf("failed retrieving: %v in the %q namespace", err, ns)
 	}
 	if len(infos) != 1 {
 		return "", "", errors.New("expected a resource")

--- a/pkg/kube/portforwarder.go
+++ b/pkg/kube/portforwarder.go
@@ -126,7 +126,7 @@ func newPortForwarder(restConfig *rest.Config, podName, ns, localAddress string,
 	podGet := restClient.Get().Resource("pods").Namespace(ns).Name(podName)
 	obj, err := podGet.Do(context.TODO()).Get()
 	if err != nil {
-		return nil, fmt.Errorf("failed retrieving pod: %v", err)
+		return nil, fmt.Errorf("failed retrieving: %v in the %q namespace", err, ns)
 	}
 	pod, ok := obj.(*v1.Pod)
 	if !ok {


### PR DESCRIPTION
To fix https://github.com/istio/istio/issues/32672

**Before**:
```
$ istioctl d envoy istio-ingressgateway-758d94b574-mpc7x
Error: could not build port forwarder for Envoy sidecar istio-ingressgateway-758d94b574-mpc7x: failed retrieving pod: pods "istio-ingressgateway-758d94b574-mpc7x" not found

$ istioctl d envoy productpage-v1-6b746f74dc-2xdzj.istio-system
Error: failed retrieving: deployments.apps "productpage-v1" not found
```

**After**:
```
$ istioctl d envoy istio-ingressgateway-758d94b574-mpc7x
Error: could not build port forwarder for Envoy sidecar istio-ingressgateway-758d94b574-mpc7x: failed retrieving: pods "istio-ingressgateway-758d94b574-mpc7x" not found in the "default" namespace

$ istioctl d envoy productpage-v1-6b746f74dc-2xdzj.istio-system
Error: failed retrieving: deployments.apps "productpage-v1" not found in the "istio-system" namespace
```