### PR TITLE
wait for secrets cache sync

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -116,7 +116,8 @@ type Server struct {
 	kubeRestConfig *rest.Config
 	kubeClient     kubelib.Client
 
-	multicluster *kubecontroller.Multicluster
+	multicluster      *kubecontroller.Multicluster
+	secretsController *kubesecrets.Multicluster
 
 	configController  model.ConfigStoreCache
 	ConfigStores      []model.ConfigStoreCache
@@ -496,22 +497,25 @@ func (s *Server) initSDSServer(args *PilotArgs) {
 			// Make sure we have security
 			log.Warnf("skipping Kubernetes credential reader; PILOT_ENABLE_XDS_IDENTITY_CHECK must be set to true for this feature.")
 		} else {
-			// TODO move this to a startup function and pass stop
-			sc := kubesecrets.NewMulticluster(s.kubeClient, s.clusterID, args.RegistryOptions.ClusterRegistriesNamespace, make(chan struct{}))
-			sc.AddEventHandler(func(name, namespace string) {
-				s.XDSServer.ConfigUpdate(&model.PushRequest{
-					Full: false,
-					ConfigsUpdated: map[model.ConfigKey]struct{}{
-						{
-							Kind:      gvk.Secret,
-							Name:      name,
-							Namespace: namespace,
-						}: {},
-					},
-					Reason: []model.TriggerReason{model.SecretTrigger},
+			s.addStartFunc(func(stop <-chan struct{}) error {
+				sc := kubesecrets.NewMulticluster(s.kubeClient, s.clusterID, args.RegistryOptions.ClusterRegistriesNamespace, stop)
+				sc.AddEventHandler(func(name, namespace string) {
+					s.XDSServer.ConfigUpdate(&model.PushRequest{
+						Full: false,
+						ConfigsUpdated: map[model.ConfigKey]struct{}{
+							{
+								Kind:      gvk.Secret,
+								Name:      name,
+								Namespace: namespace,
+							}: {},
+						},
+						Reason: []model.TriggerReason{model.SecretTrigger},
+					})
 				})
+				s.XDSServer.Generators[v3.SecretType] = xds.NewSecretGen(sc, s.XDSServer.Cache)
+				s.secretsController = sc
+				return nil
 			})
-			s.XDSServer.Generators[v3.SecretType] = xds.NewSecretGen(sc, s.XDSServer.Cache)
 		}
 	}
 }
@@ -818,6 +822,9 @@ func (s *Server) waitForCacheSync(stop <-chan struct{}) bool {
 
 // cachesSynced checks whether caches have been synced.
 func (s *Server) cachesSynced() bool {
+	if s.secretsController != nil && !s.secretsController.HasSynced() {
+		return false
+	}
 	if s.multicluster != nil && !s.multicluster.HasSynced() {
 		return false
 	}

--- a/pilot/pkg/secrets/kube/multicluster.go
+++ b/pilot/pkg/secrets/kube/multicluster.go
@@ -31,12 +31,12 @@ type Multicluster struct {
 	m                     sync.Mutex // protects remoteKubeControllers
 	secretController      *secretcontroller.Controller
 	localCluster          string
-	stop                  chan struct{}
+	stop                  <-chan struct{}
 }
 
 var _ secrets.MulticlusterController = &Multicluster{}
 
-func NewMulticluster(client kube.Client, localCluster, secretNamespace string, stop chan struct{}) *Multicluster {
+func NewMulticluster(client kube.Client, localCluster, secretNamespace string, stop <-chan struct{}) *Multicluster {
 	m := &Multicluster{
 		remoteKubeControllers: map[string]*SecretsController{},
 		localCluster:          localCluster,
@@ -53,6 +53,10 @@ func NewMulticluster(client kube.Client, localCluster, secretNamespace string, s
 		stop)
 	m.secretController = sc
 	return m
+}
+
+func (m *Multicluster) HasSynced() bool {
+	return m.secretController.HasSynced()
 }
 
 func (m *Multicluster) addMemberCluster(clients kube.Client, key string) {


### PR DESCRIPTION
For https://github.com/istio/istio/issues/32662

Eventually I'd like to refactor this such that:


```
              remote secrets controller
                          /\
                    client, stop
                         /  \
              k8s svc reg    secrets controller
```

1. To share a single k8s client, stop channel for the entire cluster
2. The remote secrets controller can be the one stop shop for checking if informers are synced (as long as we're checking _after_ registering informers)

With that structure, if we add more per-cluster components, we don't have to keep expanding our `cachesSynced` check. 