### PR TITLE
test proxyless gRPC with echo

### DIFF
--- a/pilot/pkg/util/sets/string.go
+++ b/pilot/pkg/util/sets/string.go
@@ -77,8 +77,8 @@ func (s Set) Difference(s2 Set) Set {
 // For example:
 // s = {a1, a2, a3}
 // s2 = {a1, a2, a3, a4, a5}
-// s.Difference(s2) = {a3}
-// s2.Difference(s) = {a4, a5}
+// s.SupersetOf(s2) = false
+// s2.SupersetOf(s) = true
 func (s Set) SupersetOf(s2 Set) bool {
 	return len(s2.Difference(s)) == 0
 }

--- a/pilot/pkg/util/sets/string.go
+++ b/pilot/pkg/util/sets/string.go
@@ -41,6 +41,22 @@ func (s Set) Delete(items ...string) Set {
 	return s
 }
 
+// Union returns a set of objects that are in both s and s2
+// For example:
+// s = {a1, a2, a3}
+// s2 = {a1, a2, a4, a5}
+// s.Union(s2) = {a1, a2}
+// s2.Union(s) = {a1, a2}
+func (s Set) Union(s2 Set) Set {
+	result := NewSet()
+	for key := range s {
+		if _, exist := s2[key]; exist {
+			result.Insert(key)
+		}
+	}
+	return result
+}
+
 // Difference returns a set of objects that are not in s2
 // For example:
 // s = {a1, a2, a3}
@@ -55,6 +71,16 @@ func (s Set) Difference(s2 Set) Set {
 		}
 	}
 	return result
+}
+
+// SupersetOf returns true if s contains all elements of s2
+// For example:
+// s = {a1, a2, a3}
+// s2 = {a1, a2, a3, a4, a5}
+// s.Difference(s2) = {a3}
+// s2.Difference(s) = {a4, a5}
+func (s Set) SupersetOf(s2 Set) bool {
+	return len(s2.Difference(s)) == 0
 }
 
 // UnsortedList returns the slice with contents in random order.

--- a/pilot/pkg/util/sets/string_test.go
+++ b/pilot/pkg/util/sets/string_test.go
@@ -77,6 +77,10 @@ func TestSupersetOf(t *testing.T) {
 	if !s1.SupersetOf(s2) {
 		t.Errorf("%v should be superset of %v", s1.SortedList(), s2.SortedList())
 	}
+
+	if !NewSet().SupersetOf(NewSet()) {
+		t.Errorf("%v should be superset of empty set", s1.SortedList())
+	}
 }
 
 func TestEquals(t *testing.T) {

--- a/pilot/pkg/util/sets/string_test.go
+++ b/pilot/pkg/util/sets/string_test.go
@@ -14,7 +14,10 @@
 
 package sets
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+)
 
 func TestNewSet(t *testing.T) {
 	elements := []string{"a", "b", "c"}
@@ -78,7 +81,9 @@ func TestSupersetOf(t *testing.T) {
 		t.Errorf("%v should be superset of %v", s1.SortedList(), s2.SortedList())
 	}
 
-	if !NewSet().SupersetOf(NewSet()) {
+	s3 := NewSet()
+	if !NewSet().SupersetOf(s3) {
+		fmt.Printf("%q\n", s3.SortedList()[0])
 		t.Errorf("%v should be superset of empty set", s1.SortedList())
 	}
 }

--- a/pilot/pkg/util/sets/string_test.go
+++ b/pilot/pkg/util/sets/string_test.go
@@ -31,6 +31,21 @@ func TestNewSet(t *testing.T) {
 	}
 }
 
+func TestUnion(t *testing.T) {
+	elements := []string{"a", "b", "c", "d"}
+	elements2 := []string{"a", "b", "e"}
+	want := NewSet("a", "b")
+	for _, sets := range [][]Set{
+		{NewSet(elements...), NewSet(elements2...)},
+		{NewSet(elements2...), NewSet(elements...)},
+	} {
+		s1, s2 := sets[0], sets[1]
+		if got := s1.Union(s2); !got.Equals(want) {
+			t.Errorf("expected %v; got %v", want, got)
+		}
+	}
+}
+
 func TestDifference(t *testing.T) {
 	elements := []string{"a", "b", "c", "d"}
 	s1 := NewSet(elements...)
@@ -49,6 +64,18 @@ func TestDifference(t *testing.T) {
 	}
 	if _, exist := d["d"]; !exist {
 		t.Errorf("d is not in %v", d)
+	}
+}
+
+func TestSupersetOf(t *testing.T) {
+	elements := []string{"a", "b", "c", "d"}
+	s1 := NewSet(elements...)
+
+	elements2 := []string{"a", "b"}
+	s2 := NewSet(elements2...)
+
+	if !s1.SupersetOf(s2) {
+		t.Errorf("%v should be superset of %v", s1.SortedList(), s2.SortedList())
 	}
 }
 

--- a/pkg/test/echo/cmd/client/main.go
+++ b/pkg/test/echo/cmd/client/main.go
@@ -26,6 +26,9 @@ import (
 
 	"github.com/spf13/cobra"
 
+	// To install the xds resolvers and balancers.
+	_ "google.golang.org/grpc/xds"
+
 	"istio.io/istio/pkg/cmd"
 	"istio.io/istio/pkg/test/echo/common"
 	"istio.io/istio/pkg/test/echo/proto"

--- a/pkg/test/echo/cmd/server/main.go
+++ b/pkg/test/echo/cmd/server/main.go
@@ -22,6 +22,9 @@ import (
 
 	"github.com/spf13/cobra"
 
+	// To install the xds resolvers and balancers.
+	_ "google.golang.org/grpc/xds"
+
 	"istio.io/istio/pkg/cmd"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/test/echo/common"

--- a/pkg/test/echo/common/scheme/scheme.go
+++ b/pkg/test/echo/common/scheme/scheme.go
@@ -21,6 +21,7 @@ const (
 	HTTP      Instance = "http"
 	HTTPS     Instance = "https"
 	GRPC      Instance = "grpc"
+	XDS       Instance = "xds"
 	WebSocket Instance = "ws"
 	TCP       Instance = "tcp"
 	DNS       Instance = "dns"

--- a/pkg/test/echo/server/forwarder/protocol.go
+++ b/pkg/test/echo/server/forwarder/protocol.go
@@ -207,7 +207,7 @@ func newProtocol(cfg Config) (protocol, error) {
 			}
 		}
 		return proto, nil
-	case scheme.GRPC:
+	case scheme.GRPC, scheme.XDS:
 		// grpc-go sets incorrect authority header
 		authority := headers.Get(hostHeader)
 
@@ -217,8 +217,11 @@ func newProtocol(cfg Config) (protocol, error) {
 			security = grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))
 		}
 
-		// Strip off the scheme from the address.
-		address := rawURL[len(urlScheme+"://"):]
+		// Strip off the scheme from the address (for regular gRPC).
+		address := rawURL
+		if urlScheme == string(scheme.GRPC) {
+			address = rawURL[len(urlScheme+"://"):]
+		}
 
 		// Connect to the GRPC server.
 		ctx, cancel := context.WithTimeout(context.Background(), common.ConnectionTimeout)

--- a/pkg/test/framework/components/echo/annotations.go
+++ b/pkg/test/framework/components/echo/annotations.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"istio.io/api/annotation"
+	"istio.io/istio/pkg/kube/inject"
 )
 
 type AnnotationType string
@@ -45,6 +46,7 @@ var (
 	SidecarIncludeInboundPorts     = workloadAnnotation(annotation.SidecarTrafficIncludeInboundPorts.Name, "")
 	SidecarIncludeOutboundIPRanges = workloadAnnotation(annotation.SidecarTrafficIncludeOutboundIPRanges.Name, "")
 	SidecarProxyConfig             = workloadAnnotation(annotation.ProxyConfig.Name, "")
+	SidecarInjectTemplates         = workloadAnnotation(inject.TemplatesAnnotation, "")
 )
 
 type AnnotationValue struct {

--- a/pkg/test/framework/components/echo/common/call.go
+++ b/pkg/test/framework/components/echo/common/call.go
@@ -53,6 +53,8 @@ func callInternal(srcName string, opts *echo.CallOptions, send sendFunc,
 		targetURL = fmt.Sprintf("%s://%s", string(opts.Scheme), opts.Address)
 	case scheme.TCP:
 		targetURL = fmt.Sprintf("%s://%s", string(opts.Scheme), addressAndPort)
+	case scheme.XDS:
+		targetURL = fmt.Sprintf("%s:///%s", string(opts.Scheme), addressAndPort)
 	default:
 		targetURL = fmt.Sprintf("%s://%s%s", string(opts.Scheme), addressAndPort, opts.Path)
 	}

--- a/pkg/test/framework/components/echo/config.go
+++ b/pkg/test/framework/components/echo/config.go
@@ -187,6 +187,11 @@ func (c Config) IsNaked() bool {
 	return len(c.Subsets) > 0 && c.Subsets[0].Annotations != nil && !c.Subsets[0].Annotations.GetBool(SidecarInject)
 }
 
+func (c Config) IsProxylessGRPC() bool {
+	// TODO make these check if any subset has a matching annotation
+	return len(c.Subsets) > 0 && c.Subsets[0].Annotations != nil && c.Subsets[0].Annotations.Get(SidecarInjectTemplates) == "grpc"
+}
+
 func (c Config) IsTProxy() bool {
 	// TODO this could be HasCustomInjectionMode
 	return len(c.Subsets) > 0 && c.Subsets[0].Annotations != nil && c.Subsets[0].Annotations.Get(SidecarInterceptionMode) == "TPROXY"

--- a/pkg/test/framework/components/echo/echoboot/echoboot.go
+++ b/pkg/test/framework/components/echo/echoboot/echoboot.go
@@ -126,7 +126,7 @@ func (b builder) With(i *echo.Instance, cfg echo.Config) echo.Builder {
 		}
 		if !b.validateTemplates(perClusterConfig, c) {
 			if c.Kind() == cluster.Kubernetes {
-				scopes.Framework.Warnf("%s does not contain injection templates for %s; skipping deployment", perClusterConfig.FQDN())
+				scopes.Framework.Warnf("%s does not contain injection templates for %s; skipping deployment", c.Name(), perClusterConfig.FQDN())
 			}
 			continue
 		}
@@ -344,9 +344,11 @@ func (b builder) validateTemplates(config echo.Config, c cluster.Cluster) bool {
 	for _, subset := range config.Subsets {
 		expected.Insert(parseList(subset.Annotations.Get(echo.SidecarInjectTemplates))...)
 	}
+	scopes.Framework.Infof("expect %v", expected.SortedList())
 	if b.templates == nil || b.templates[c.Name()] == nil {
 		return len(expected) == 0
 	}
+	scopes.Framework.Infof("got %v", b.templates[c.Name()].SortedList())
 
 	return b.templates[c.Name()].SupersetOf(expected)
 }

--- a/pkg/test/framework/components/echo/echoboot/echoboot.go
+++ b/pkg/test/framework/components/echo/echoboot/echoboot.go
@@ -15,13 +15,18 @@
 package echoboot
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"sync"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/go-multierror"
+	"gopkg.in/yaml.v3"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"istio.io/istio/pilot/pkg/util/sets"
+	"istio.io/istio/pkg/kube/inject"
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/framework/components/cluster"
 	"istio.io/istio/pkg/test/framework/components/echo"
@@ -30,6 +35,7 @@ import (
 
 	// force registraton of factory func
 	_ "istio.io/istio/pkg/test/framework/components/echo/staticvm"
+	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/framework/resource"
 	"istio.io/istio/pkg/test/scopes"
@@ -43,12 +49,20 @@ func NewBuilder(ctx resource.Context, clusters ...cluster.Cluster) echo.Builder 
 	if len(clusters) == 0 {
 		clusters = cluster.Clusters{ctx.Clusters().Default()}
 	}
-	return builder{
+	b := builder{
 		ctx:        ctx,
 		configs:    map[cluster.Kind][]echo.Config{},
 		refs:       map[cluster.Kind][]*echo.Instance{},
 		namespaces: map[string]namespace.Instance{},
-	}.WithClusters(clusters...)
+	}
+	templates, err := b.injectionTemplates()
+	if err != nil {
+		// deal with this when we call Build() to avoid making the NewBuilder signature unwieldy
+		b.errs = multierror.Append(b.errs, err)
+	}
+	b.templates = templates
+
+	return b.WithClusters(clusters...)
 }
 
 type builder struct {
@@ -67,6 +81,8 @@ type builder struct {
 	// namespaces caches namespaces by their prefix; used for converting Static namespace from configs into actual
 	// namesapces
 	namespaces map[string]namespace.Instance
+	// the set of injection templates for each cluster
+	templates map[string]sets.Set
 	// errs contains a multierror for failed validation during With calls
 	errs error
 }
@@ -104,21 +120,30 @@ func (b builder) With(i *echo.Instance, cfg echo.Config) echo.Builder {
 			b.errs = multierror.Append(b.errs, fmt.Errorf("attembed to deploy to %s but it does not implement echo.Cluster", c.Name()))
 			continue
 		}
-		if perClusterConfig, ok := ec.CanDeploy(cfg); ok {
-			var ref *echo.Instance
-			if idx == 0 {
-				// ref only applies to the first cluster deployed to
-				// refs shouldn't be used when deploying to multiple targetClusters
-				// TODO: should we just panic if a ref is passed in a multi-cluster context?
-				ref = i
-			}
-			perClusterConfig = perClusterConfig.DeepCopy()
-			k := ec.Kind()
-			perClusterConfig.Cluster = ec
-			b.configs[k] = append(b.configs[k], perClusterConfig)
-			b.refs[k] = append(b.refs[k], ref)
-			deployedTo++
+		perClusterConfig, ok := ec.CanDeploy(cfg)
+		if !ok {
+			continue
 		}
+		if !b.validateTemplates(perClusterConfig) {
+			if c.Kind() == cluster.Kubernetes {
+				scopes.Framework.Warnf("%s does not contain injection templates for %s; skipping deployment", perClusterConfig.FQDN())
+			}
+			continue
+		}
+
+		var ref *echo.Instance
+		if idx == 0 {
+			// ref only applies to the first cluster deployed to
+			// refs shouldn't be used when deploying to multiple targetClusters
+			// TODO: should we just panic if a ref is passed in a multi-cluster context?
+			ref = i
+		}
+		perClusterConfig = perClusterConfig.DeepCopy()
+		k := ec.Kind()
+		perClusterConfig.Cluster = ec
+		b.configs[k] = append(b.configs[k], perClusterConfig)
+		b.refs[k] = append(b.refs[k], ref)
+		deployedTo++
 	}
 
 	// If we didn't deploy VMs, but we don't care about VMs, we can ignore this.
@@ -139,6 +164,43 @@ func (b builder) WithClusters(clusters ...cluster.Cluster) echo.Builder {
 
 func (b builder) Build() (out echo.Instances, err error) {
 	return build(b)
+}
+
+// injectionTemplates lists the set of templates for each Kube cluster
+func (b builder) injectionTemplates() (map[string]sets.Set, error) {
+	i, err := istio.Get(b.ctx)
+	if err != nil {
+		return nil, err
+	}
+	ns := i.Settings().SystemNamespace
+
+	out := map[string]sets.Set{}
+	for _, c := range b.ctx.Clusters().Kube() {
+		out[c.Name()] = sets.NewSet()
+		// TODO find a place to read revision(s) and avoid listing
+		cms, err := c.CoreV1().ConfigMaps(ns).List(context.TODO(), metav1.ListOptions{})
+		if err != nil {
+			return nil, err
+		}
+
+		// collect all the templates from this cluster
+		for _, item := range cms.Items {
+			if !strings.HasPrefix(item.Name, "istio-sidecar-injector") {
+				continue
+			}
+			data := &inject.Config{}
+			if err := yaml.Unmarshal([]byte(item.Data["config"]), data); err != nil {
+				return nil, fmt.Errorf("failed parsing injection cm in %s: %v", c.Name(), err)
+			}
+			if data.Templates != nil {
+				for name := range data.Templates {
+					out[c.Name()].Insert(name)
+				}
+			}
+		}
+	}
+
+	return out, nil
 }
 
 // build inner allows assigning to b (assignment to receiver would be ineffective)
@@ -274,4 +336,25 @@ func (b builder) BuildOrFail(t test.Failer) echo.Instances {
 		t.Fatal(err)
 	}
 	return out
+}
+
+// validateTemplates given a Config with the Cluster populated, returns true if the cluster contains all templates
+// specified by inject.istio.io/templates
+func (b builder) validateTemplates(perClusterConfig echo.Config) bool {
+	expected := sets.NewSet()
+	for _, subset := range perClusterConfig.Subsets {
+		expected.Insert(parseList(subset.Annotations.Get(echo.SidecarInjectTemplates))...)
+	}
+	if b.templates == nil || b.templates[perClusterConfig.Cluster.Name()] == nil {
+		return len(expected) == 0
+	}
+	return b.templates[perClusterConfig.Cluster.Name()].SupersetOf(expected)
+}
+
+func parseList(s string) []string {
+	items := strings.Split(s, ",")
+	for i := range items {
+		items[i] = strings.TrimSpace(items[i])
+	}
+	return items
 }

--- a/pkg/test/framework/components/echo/echoboot/echoboot.go
+++ b/pkg/test/framework/components/echo/echoboot/echoboot.go
@@ -344,16 +344,17 @@ func (b builder) validateTemplates(config echo.Config, c cluster.Cluster) bool {
 	for _, subset := range config.Subsets {
 		expected.Insert(parseList(subset.Annotations.Get(echo.SidecarInjectTemplates))...)
 	}
-	scopes.Framework.Infof("expect %v", expected.SortedList())
 	if b.templates == nil || b.templates[c.Name()] == nil {
 		return len(expected) == 0
 	}
-	scopes.Framework.Infof("got %v", b.templates[c.Name()].SortedList())
 
 	return b.templates[c.Name()].SupersetOf(expected)
 }
 
 func parseList(s string) []string {
+	if len(strings.TrimSpace(s)) == 0 {
+		return nil
+	}
 	items := strings.Split(s, ",")
 	for i := range items {
 		items[i] = strings.TrimSpace(items[i])

--- a/pkg/test/framework/components/echo/echoboot/echoboot.go
+++ b/pkg/test/framework/components/echo/echoboot/echoboot.go
@@ -20,6 +20,8 @@ import (
 	"strings"
 	"sync"
 
+	"istio.io/pkg/log"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/go-multierror"
 	"gopkg.in/yaml.v3"
@@ -345,9 +347,12 @@ func (b builder) validateTemplates(perClusterConfig echo.Config) bool {
 	for _, subset := range perClusterConfig.Subsets {
 		expected.Insert(parseList(subset.Annotations.Get(echo.SidecarInjectTemplates))...)
 	}
+	log.Info("expect %v", expected.SortedList())
 	if b.templates == nil || b.templates[perClusterConfig.Cluster.Name()] == nil {
 		return len(expected) == 0
 	}
+	log.Info("got %v", b.templates[perClusterConfig.Cluster.Name()].SortedList())
+
 	return b.templates[perClusterConfig.Cluster.Name()].SupersetOf(expected)
 }
 

--- a/pkg/test/framework/components/echo/echotest/filters.go
+++ b/pkg/test/framework/components/echo/echotest/filters.go
@@ -113,7 +113,7 @@ func oneRegularPod(instances echo.Instances, exclude echo.Instances) echo.Instan
 // - Multi-Subset
 func RegularPod(instance echo.Instance) bool {
 	c := instance.Config()
-	return len(c.Subsets) == 1 && !c.IsVM() && !c.IsTProxy() && !c.IsNaked() && !c.IsHeadless() && !c.IsStatefulSet()
+	return len(c.Subsets) == 1 && !c.IsVM() && !c.IsTProxy() && !c.IsNaked() && !c.IsHeadless() && !c.IsStatefulSet() && !c.IsProxylessGRPC()
 }
 
 // Not includes all workloads that don't match the given filter

--- a/pkg/test/framework/components/echo/instances.go
+++ b/pkg/test/framework/components/echo/instances.go
@@ -154,6 +154,13 @@ func IsHeadless() Matcher {
 	}
 }
 
+// IsProxylessGRPC matches instances that are Pods with a SidecarInjectTemplate annotation equal to grpc.
+func IsProxylessGRPC() Matcher {
+	return func(i Instance) bool {
+		return i.Config().IsProxylessGRPC()
+	}
+}
+
 // Match filters instances that matcher the given Matcher
 func (i Instances) Match(matches Matcher) Instances {
 	out := make(Instances, 0)

--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -142,7 +142,10 @@ spec:
       - name: {{ $.ImagePullSecret }}
 {{- end }}
       containers:
-{{- if ne ($subset.Annotations.GetByName "sidecar.istio.io/inject") "false" }}
+{{- if and
+  (ne ($subset.Annotations.GetByName "sidecar.istio.io/inject") "false")
+  (ne ($subset.Annotations.GetByName "inject.istio.io/templates") "grpc")
+}}
       - name: istio-proxy
         image: auto
         securityContext: # to allow core dumps

--- a/pkg/test/framework/components/echo/kube/instance.go
+++ b/pkg/test/framework/components/echo/kube/instance.go
@@ -26,6 +26,7 @@ import (
 
 	"istio.io/istio/pkg/test"
 	appEcho "istio.io/istio/pkg/test/echo/client"
+	"istio.io/istio/pkg/test/echo/common/scheme"
 	"istio.io/istio/pkg/test/framework/components/cluster"
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/echo/common"
@@ -205,6 +206,12 @@ func (c *instance) Restart() error {
 
 // aggregateResponses forwards an echo request from all workloads belonging to this echo instance and aggregates the results.
 func (c *instance) aggregateResponses(opts echo.CallOptions, retry bool, retryOptions ...retry.Option) (appEcho.ParsedResponses, error) {
+	// TODO put this somewhere else, or require users explicitly set the protocol
+	if c.Config().IsProxylessGRPC() && opts.Scheme == scheme.GRPC {
+		// for gRPC calls, use XDS resolver
+		opts.Scheme = scheme.XDS
+	}
+
 	resps := make([]*appEcho.ParsedResponse, 0)
 	workloads, err := c.Workloads()
 	if err != nil {

--- a/pkg/test/framework/components/echo/kube/util.go
+++ b/pkg/test/framework/components/echo/kube/util.go
@@ -63,7 +63,8 @@ func workloadHasSidecar(cfg echo.Config, podName string) bool {
 	// Match workload first.
 	for _, w := range cfg.Subsets {
 		if strings.HasPrefix(podName, fmt.Sprintf("%v-%v", cfg.Service, w.Version)) {
-			return w.Annotations.GetBool(echo.SidecarInject)
+			return w.Annotations.GetBool(echo.SidecarInject) &&
+				w.Annotations.Get(echo.SidecarInjectTemplates) != "grpc"
 		}
 	}
 	return true

--- a/tests/integration/iop-integration-test-defaults.yaml
+++ b/tests/integration/iop-integration-test-defaults.yaml
@@ -45,6 +45,69 @@ spec:
       - name: istio-egressgateway
         enabled: true
   values:
+    sidecarInjectorWebhook:
+      templates:
+        grpc: |
+          spec:
+            initContainers:
+            - name: grpc-bootstrap-init
+              image: busybox:1.28
+              volumeMounts:
+              - mountPath: /var/lib/grpc/data/
+                name: grpc-io-proxyless-bootstrap
+              env:
+              - name: INSTANCE_IP
+                valueFrom:
+                  fieldRef:
+                    fieldPath: status.podIP
+              - name: POD_NAME
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.name
+              - name: POD_NAMESPACE
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.namespace
+              command:
+              - sh
+              - "-c"
+              - |-
+                  NODE_ID="sidecar~${INSTANCE_IP}~${POD_NAME}.${POD_NAMESPACE}~cluster.local"
+                  echo '
+                  {
+                    "xds_servers": [
+                      {
+                        "server_uri": "dns:///istiod.istio-system.svc:15010",
+                        "channel_creds": [{"type": "insecure"}],
+                        "server_features" : ["xds_v3"]
+                      }
+                    ],
+                    "node": {
+                      "id": "'${NODE_ID}'",
+                      "metadata": {
+                        "GENERATOR": "grpc"
+                      }
+                    }
+                  }' > /var/lib/grpc/data/bootstrap.json
+            containers:
+          {{- range $index, $container := .Spec.Containers }}
+            - name: {{ $container.Name }}
+              env:
+                - name: GRPC_XDS_EXPERIMENTAL_V3_SUPPORT
+                  value: "true"
+                - name: GRPC_XDS_BOOTSTRAP
+                  value: /var/lib/grpc/data/bootstrap.json
+                - name: GRPC_GO_LOG_VERBOSITY_LEVEL 
+                  value: "99"
+                - name: GRPC_GO_LOG_SEVERITY_LEVEL
+                  value: info 
+              volumeMounts:
+                - mountPath: /var/lib/grpc/data/
+                  name: grpc-io-proxyless-bootstrap
+            {{- end}}
+            volumes:
+            - name: grpc-io-proxyless-bootstrap
+              emptyDir: {}
     global:
       proxy:
         resources:

--- a/tests/integration/pilot/common/apps.go
+++ b/tests/integration/pilot/common/apps.go
@@ -50,6 +50,8 @@ type EchoDeployments struct {
 	Headless echo.Instances
 	// StatefulSet echo app to be used by tests
 	StatefulSet echo.Instances
+	// ProxylessGRPC echo app to be used by tests
+	ProxylessGRPC echo.Instances
 	// Echo app to be used by tests, with no sidecar injected
 	Naked echo.Instances
 	// A virtual machine echo app (only deployed to one cluster)
@@ -62,15 +64,16 @@ type EchoDeployments struct {
 }
 
 const (
-	PodASvc        = "a"
-	PodBSvc        = "b"
-	PodCSvc        = "c"
-	PodTproxySvc   = "tproxy"
-	VMSvc          = "vm"
-	HeadlessSvc    = "headless"
-	StatefulSetSvc = "statefulset"
-	NakedSvc       = "naked"
-	ExternalSvc    = "external"
+	PodASvc          = "a"
+	PodBSvc          = "b"
+	PodCSvc          = "c"
+	PodTproxySvc     = "tproxy"
+	VMSvc            = "vm"
+	HeadlessSvc      = "headless"
+	StatefulSetSvc   = "statefulset"
+	ProxylessGRPCSvc = "proxyless-grpc"
+	NakedSvc         = "naked"
+	ExternalSvc      = "external"
 
 	externalHostname = "fake.external.com"
 )
@@ -213,6 +216,26 @@ func SetupApps(t resource.Context, i istio.Instance, apps *EchoDeployments) erro
 			WorkloadOnlyPorts: common.WorkloadPorts,
 		})
 
+	if !t.Clusters().IsMulticluster() {
+		builder = builder.
+			// TODO when agent handles secure control-plane connection for grpc-less, deploy to "remote" clusters
+			WithConfig(echo.Config{
+				Service:   ProxylessGRPCSvc,
+				Namespace: apps.Namespace,
+				Ports:     common.EchoPorts,
+				Subsets: []echo.SubsetConfig{
+					{
+						Annotations: map[echo.Annotation]*echo.AnnotationValue{
+							echo.SidecarInjectTemplates: {
+								Value: "grpc",
+							},
+						},
+					},
+				},
+				WorkloadOnlyPorts: common.WorkloadPorts,
+			})
+	}
+
 	echos, err := builder.Build()
 	if err != nil {
 		return err
@@ -226,6 +249,7 @@ func SetupApps(t resource.Context, i istio.Instance, apps *EchoDeployments) erro
 	apps.StatefulSet = echos.Match(echo.Service(StatefulSetSvc))
 	apps.Naked = echos.Match(echo.Service(NakedSvc))
 	apps.External = echos.Match(echo.Service(ExternalSvc))
+	apps.ProxylessGRPC = echos.Match(echo.Service(ProxylessGRPCSvc))
 	if !t.Settings().SkipVM {
 		apps.VM = echos.Match(echo.Service(VMSvc))
 	}

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -464,9 +464,9 @@ spec:
 	noHeadless := echotest.FilterMatch(echo.Not(echo.IsHeadless()))
 	noExternal := echotest.FilterMatch(echo.Not(echo.IsExternal()))
 	for i, tc := range cases {
-
-		tc.sourceFilters = append(tc.sourceFilters, noNaked, noHeadless)
-		tc.targetFilters = append(tc.targetFilters, noNaked, noHeadless)
+		// TODO include proxyless as different features become supported
+		tc.sourceFilters = append(tc.sourceFilters, noNaked, noHeadless, noProxyless)
+		tc.targetFilters = append(tc.targetFilters, noNaked, noHeadless, noProxyless)
 		cases[i] = tc
 	}
 
@@ -485,8 +485,8 @@ spec:
 		cases = append(cases, TrafficTestCase{
 			name:          fmt.Sprintf("shifting-%d", split[0]),
 			toN:           len(split),
-			sourceFilters: []echotest.Filter{noHeadless, noNaked},
-			targetFilters: []echotest.Filter{noHeadless, noExternal},
+			sourceFilters: []echotest.Filter{noHeadless, noNaked, noProxyless},
+			targetFilters: []echotest.Filter{noHeadless, noExternal, noProxyless},
 			templateVars: func(_ echo.Callers, _ echo.Instances) map[string]interface{} {
 				return map[string]interface{}{
 					"split": split,
@@ -1170,22 +1170,11 @@ func flatten(clients ...[]echo.Instance) []echo.Instance {
 
 // selfCallsCases checks that pods can call themselves
 func selfCallsCases() []TrafficTestCase {
-	sourceFilters := []echotest.Filter{
-		echotest.Not(echotest.ExternalServices),
-		echotest.Not(echotest.FilterMatch(echo.IsNaked())),
-		echotest.Not(echotest.FilterMatch(echo.IsHeadless())),
-	}
-	comboFilters := []echotest.CombinationFilter{func(from echo.Instance, to echo.Instances) echo.Instances {
-		return to.Match(echo.FQDN(from.Config().FQDN()))
-	}}
-
-	return []TrafficTestCase{
+	cases := []TrafficTestCase{
 		// Calls to the Service will go through envoy outbound and inbound, so we get envoy headers added
 		{
 			name:             "to service",
 			workloadAgnostic: true,
-			sourceFilters:    sourceFilters,
-			comboFilters:     comboFilters,
 			opts: echo.CallOptions{
 				Count:     1,
 				PortName:  "http",
@@ -1196,8 +1185,6 @@ func selfCallsCases() []TrafficTestCase {
 		{
 			name:             "to localhost",
 			workloadAgnostic: true,
-			sourceFilters:    sourceFilters,
-			comboFilters:     comboFilters,
 			setupOpts: func(_ echo.Caller, _ echo.Instances, opts *echo.CallOptions) {
 				// the framework will try to set this when enumerating test cases
 				opts.Target = nil
@@ -1214,8 +1201,6 @@ func selfCallsCases() []TrafficTestCase {
 		{
 			name:             "to podIP",
 			workloadAgnostic: true,
-			sourceFilters:    sourceFilters,
-			comboFilters:     comboFilters,
 			setupOpts: func(srcCaller echo.Caller, _ echo.Instances, opts *echo.CallOptions) {
 				src := srcCaller.(echo.Instance)
 				workloads, _ := src.Workloads()
@@ -1231,6 +1216,21 @@ func selfCallsCases() []TrafficTestCase {
 			},
 		},
 	}
+	for i, tc := range cases {
+		// proxyless doesn't get valuable coverage here
+		tc.sourceFilters = []echotest.Filter{
+			echotest.Not(echotest.ExternalServices),
+			echotest.Not(echotest.FilterMatch(echo.IsNaked())),
+			echotest.Not(echotest.FilterMatch(echo.IsHeadless())),
+			noProxyless,
+		}
+		tc.comboFilters = []echotest.CombinationFilter{func(from echo.Instance, to echo.Instances) echo.Instances {
+			return to.Match(echo.FQDN(from.Config().FQDN()))
+		}}
+		cases[i] = tc
+	}
+
+	return cases
 }
 
 // Todo merge with security TestReachability code
@@ -1274,6 +1274,17 @@ func protocolSniffingCases() []TrafficTestCase {
 					echo.ExpectOK(),
 					echo.ExpectHost(dst[0].Config().HostHeader()))
 			},
+			comboFilters: func() []echotest.CombinationFilter {
+				if call.scheme != scheme.GRPC {
+					return []echotest.CombinationFilter{func(from echo.Instance, to echo.Instances) echo.Instances {
+						if from.Config().IsProxylessGRPC() && to.ContainsMatch(echo.IsVirtualMachine()) {
+							return nil
+						}
+						return to
+					}}
+				}
+				return nil
+			}(),
 			workloadAgnostic: true,
 		})
 	}
@@ -1410,6 +1421,14 @@ spec:
 				})
 		}
 	}
+
+	for _, tc := range cases {
+		// proxyless doesn't get valuable coverage here
+		noProxyless := echotest.FilterMatch(echo.Not(echo.IsProxylessGRPC()))
+		tc.sourceFilters = append(tc.sourceFilters, noProxyless)
+		tc.targetFilters = append(tc.targetFilters, noProxyless)
+	}
+
 	return cases
 }
 

--- a/tests/integration/pilot/common/traffic.go
+++ b/tests/integration/pilot/common/traffic.go
@@ -87,6 +87,8 @@ type TrafficTestCase struct {
 	minIstioVersion string
 }
 
+var noProxyless = echotest.Not(echotest.FilterMatch(echo.IsProxylessGRPC()))
+
 func (c TrafficTestCase) RunForApps(t framework.TestContext, apps echo.Instances, namespace string) {
 	if c.opts.Target != nil {
 		t.Fatal("TrafficTestCase.RunForApps: opts.Target must not be specified")
@@ -127,7 +129,8 @@ func (c TrafficTestCase) RunForApps(t framework.TestContext, apps echo.Instances
 			}).
 			WithDefaultFilters().
 			From(c.sourceFilters...).
-			To(c.targetFilters...).
+			// TODO mainly testing proxyless features as a client for now
+			To(append(c.targetFilters, noProxyless)...).
 			ConditionallyTo(c.comboFilters...)
 
 		doTest := func(t framework.TestContext, src echo.Caller, dsts echo.Services) {


### PR DESCRIPTION
* Modifications to the `echo` forwarder app to support proxyless gRPC
* Test-only inject template pointing to istiod insecure (15010)
* Test framework will automatically swap `grpc://` with `xds:///` when the forwarder is a proxyless gRPC client
* Actually use a proxyless grpc app in our common set of apps (workload agnostic tests will automatically try to utilize)
* Skip several tests that aren't compatible


The main test that actually benefits here is `sniffing` which really acts as a reachability test. This PR mostly serves to lay groundwork for future tests/enhancements to proxyless gRPC support. 

Not 100% if we want to merge as-is or wait till we decide on how we want to handle some of the proxyless features (bootstrap with agent vs. custom injector etc). 