### PR TITLE
Preserve tty when running under `bin/retry.sh`

### DIFF
--- a/bin/retry.sh
+++ b/bin/retry.sh
@@ -35,6 +35,7 @@ function retry {
   local n=1
   local max=5
   while true; do
+    unset SHELL # Don't let environment control which shell to use
     script --flush --quiet --return "${tmpFile}" --command "${*}"
     # shellcheck disable=SC2181
     if [[ $? == 0 ]]; then

--- a/bin/retry.sh
+++ b/bin/retry.sh
@@ -26,19 +26,22 @@ function fail {
 }
 
 function retry {
+  local tmpFile
+  tmpFile=$(mktemp)
+  trap 'rm -f "${tmpFile}"' EXIT
+
   local failureRegex="$1"
   shift
   local n=1
   local max=5
   while true; do
-    exec 5>&1
-    out="$(set -o pipefail; "$@" 2>&1 | tee /dev/fd/5)"
+    script --flush --quiet --return "${tmpFile}" --command "${*}"
     # shellcheck disable=SC2181
     if [[ $? == 0 ]]; then
       break
     fi
-    if ! grep "${failureRegex}" <<< "${out}"; then
-      fail "Unexpected failure: ${out}"
+    if ! grep -q "${failureRegex}" "${tmpFile}"; then
+      fail "Unexpected failure: $(cat tmpFile)"
     fi
     if [[ $n -lt $max ]]; then
       ((n++))


### PR DESCRIPTION
This makes output nicer as commands are run with a tty so we can get
interactive mode for buildx, etc
