### PR TITLE
Switch handling of missing routes to send no response instead of empty

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -233,8 +233,12 @@ func buildNameToServiceMapForHTTPRoutes(node *model.Proxy, push *model.PushConte
 func (configgen *ConfigGeneratorImpl) buildGatewayHTTPRouteConfig(node *model.Proxy, push *model.PushContext,
 	routeName string) *route.RouteConfiguration {
 	if node.MergedGateway == nil {
-		log.Debug("buildGatewayRoutes: no gateways for router ", node.ID)
-		return nil
+		log.Warnf("buildGatewayRoutes: no gateways for router ", node.ID)
+		return &route.RouteConfiguration{
+			Name:             routeName,
+			VirtualHosts:     []*route.VirtualHost{},
+			ValidateClusters: proto.BoolFalse,
+		}
 	}
 
 	merged := node.MergedGateway

--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -68,14 +68,8 @@ func (configgen *ConfigGeneratorImpl) BuildHTTPRoutes(node *model.Proxy, push *m
 			rc := configgen.buildGatewayHTTPRouteConfig(node, push, routeName)
 			if rc != nil {
 				rc = envoyfilter.ApplyRouteConfigurationPatches(networking.EnvoyFilter_GATEWAY, node, push, rc)
-			} else {
-				rc = &route.RouteConfiguration{
-					Name:             routeName,
-					VirtualHosts:     []*route.VirtualHost{},
-					ValidateClusters: proto.BoolFalse,
-				}
+				routeConfigurations = append(routeConfigurations, rc)
 			}
-			routeConfigurations = append(routeConfigurations, rc)
 		}
 	}
 	return routeConfigurations


### PR DESCRIPTION
Its common for a route request for a route we do not know about if a
Gateway is recently deleted (due to listener draining).

Pre 1.1, if we missed a route, we closed the ADS connection. This was
obviously wrong, so we introduced a patch to instead make it send a
route back, but with no VHosts defined:
https://github.com/istio/istio/pull/13924.

This seemed to work (and has been around for ~2 years now), but the
behavior isn't quite right. If you send continuous requests to a gateway
then remove the Gateway (triggering listener drain), you will see
requests go to 404 and only later is the connection eventually torn
down. This is because when the listener is removed we will trigger a RDS
push, which will find no route, and thus send an empty route config.
Envoy will treat that as VHosts being removed and start 404ing.

Instead, we should just not respond to the route request. This is
perfectly valid; like EDS, we don't need to respond with all routes. If
Envoy is requesting a route and we don't respond, it will just be
warming. In theory, this may lead to incorrect behavior - if we send
Envoy a listener with route `foo` and then don't have route `foo`, it
would be stuck warming forever rather than 404ing. In practice, the only time we
can not have a route is if its because the configuration is deleted, so
this isn't a concern. The only way this could happen is if we have some
split-brain on LDS and RDS, which could be the result of a bug or a (really) bad
EnvoyFilter patch. In both of these cases, being stuck warming seems
reasonable.

In addition to shutdown, this is also a blocker for
https://github.com/istio/istio/pull/32653. This PR will change the route
names, which ends up having the same 404 issue upon upgrade without this
PR. With this PR, the upgrade is graceful.
