### PR TITLE
fix (prom): disable host header fallback for inbound traffic

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -1345,6 +1345,7 @@ spec:
                     {
                       "debug": "false",
                       "stat_prefix": "istio",
+                      "disable_host_header_fallback": true,
                       "metrics": [
                         {
                           "dimensions": {
@@ -1737,6 +1738,7 @@ spec:
                     {
                       "debug": "false",
                       "stat_prefix": "istio",
+                      "disable_host_header_fallback": true,
                       "metrics": [
                         {
                           "dimensions": {

--- a/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.10.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.10.yaml
@@ -271,6 +271,7 @@ spec:
                     {
                       "debug": "false",
                       "stat_prefix": "istio",
+                      "disable_host_header_fallback": true,
                       "metrics": [
                         {
                           "dimensions": {

--- a/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.11.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.11.yaml
@@ -271,6 +271,7 @@ spec:
                     {
                       "debug": "false",
                       "stat_prefix": "istio",
+                      "disable_host_header_fallback": true,
                       "metrics": [
                         {
                           "dimensions": {

--- a/manifests/charts/istiod-remote/templates/telemetryv2_1.10.yaml
+++ b/manifests/charts/istiod-remote/templates/telemetryv2_1.10.yaml
@@ -271,6 +271,7 @@ spec:
                     {
                       "debug": "false",
                       "stat_prefix": "istio",
+                      "disable_host_header_fallback": true,
                       "metrics": [
                         {
                           "dimensions": {

--- a/manifests/charts/istiod-remote/templates/telemetryv2_1.11.yaml
+++ b/manifests/charts/istiod-remote/templates/telemetryv2_1.11.yaml
@@ -224,7 +224,8 @@ spec:
                     {{- if not .Values.telemetry.v2.prometheus.configOverride.outboundSidecar }}
                     {
                       "debug": "false",
-                      "stat_prefix": "istio"
+                      "stat_prefix": "istio",
+                      "disable_host_header_fallback": true
                     }
                     {{- else }}
                     {{ toJson .Values.telemetry.v2.prometheus.configOverride.outboundSidecar | indent 18 }}

--- a/releasenotes/notes/disable-host-header-fallback.yaml
+++ b/releasenotes/notes/disable-host-header-fallback.yaml
@@ -1,10 +1,19 @@
 apiVersion: release-notes/v2
 kind: bug-fix
 area: telemetry
-docs:
-- https://docs.google.com/document/d/17-ypXfYM6ehdKfr12KSFNUoQzY5QLaEYuhIVlP-wknA/edit#heading=h.xw1gqgyqs5b
 releaseNotes:
 - |
   **Updated** Prometheus telemetry behavior for inbound traffic to disable host header fallback by default. This will
   prevent traffic coming from out-of-mesh locations from potential polluting the `destination_service` dimension in
-  metrics with junk data (and exploding metrics cardinality).
+  metrics with junk data (and exploding metrics cardinality). With this change, it is possible that users relying on
+  host headers for labeling the destination service for inbound traffic from out-of-mesh workloads will see that traffic
+  labeled as `unknown`. The behavior can be restored by modifying Istio configuration to remove the `disable_host_header_fallback: true`
+  configuration.
+upgradeNotes:
+  - title: Host header fallback disabled by default for Prometheus metrics for *all* inbound traffic.
+    content: |
+      Host header fallback for determining values for Prometheus `destination_service` labels has been disabled for all incoming traffic.
+      Previously, this was disabled *only* for traffic arriving at Gateways. If you are relying on host header fallback behavior to properly
+      label the `destination_service` in Prometheus metrics for traffic originating from out-of-mesh workloads, then you will need to update the telemetry
+      configuration to enable host header fallback.
+

--- a/releasenotes/notes/disable-host-header-fallback.yaml
+++ b/releasenotes/notes/disable-host-header-fallback.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: telemetry
+docs:
+- https://docs.google.com/document/d/17-ypXfYM6ehdKfr12KSFNUoQzY5QLaEYuhIVlP-wknA/edit#heading=h.xw1gqgyqs5b
+releaseNotes:
+- |
+  **Updated** Prometheus telemetry behavior for inbound traffic to disable host header fallback by default. This will
+  prevent traffic coming from out-of-mesh locations from potential polluting the `destination_service` dimension in
+  metrics with junk data (and exploding metrics cardinality).


### PR DESCRIPTION
Disables host-header-fallback for inbound traffic. This was approved after discussions in E&T WG.

Relevant doc: https://docs.google.com/document/d/17-ypXfYM6ehdKfr12KSFNUoQzY5QLaEYuhIVlP-wknA/

[ X ] Policies and Telemetry