### PR TITLE
cni: remove workarounds of adding excludeInboundPorts

### DIFF
--- a/cni/cmd/istio-cni/redirect.go
+++ b/cni/cmd/istio-cni/redirect.go
@@ -117,19 +117,6 @@ func splitPorts(portsString string) []string {
 	return strings.Split(portsString, ",")
 }
 
-func dedupPorts(ports []string) []string {
-	dedup := make(map[string]bool)
-	keys := []string{}
-
-	for _, port := range ports {
-		if !dedup[port] {
-			dedup[port] = true
-			keys = append(keys, port)
-		}
-	}
-	return keys
-}
-
 func parsePort(portStr string) (uint16, error) {
 	port, err := strconv.ParseUint(strings.TrimSpace(portStr), 10, 16)
 	if err != nil {
@@ -240,14 +227,6 @@ func NewRedirect(pi *PodInfo) (*Redirect, error) {
 			"excludeOutboundPorts", isFound, valErr)
 		return nil, valErr
 	}
-	// Add 15090 to sync with non-cni injection template
-	// TODO: Revert below once https://github.com/istio/istio/pull/23037 or its follow up is merged.
-	redir.excludeInboundPorts = strings.TrimSpace(redir.excludeInboundPorts)
-	if len(redir.excludeInboundPorts) > 0 && redir.excludeInboundPorts[len(redir.excludeInboundPorts)-1] != ',' {
-		redir.excludeInboundPorts += ","
-	}
-	redir.excludeInboundPorts += "15020,15021,15090"
-	redir.excludeInboundPorts = strings.Join(dedupPorts(splitPorts(redir.excludeInboundPorts)), ",")
 	isFound, redir.kubevirtInterfaces, valErr = getAnnotationOrDefault("kubevirtInterfaces", pi.Annotations)
 	if valErr != nil {
 		log.Errorf("Annotation value error for value %s; annotationFound = %t: %v",


### PR DESCRIPTION
These were previously used as workarounds to simulate what non-cni template
injector does on specific ports, to avoid them being captured. With the
`excludeInboundPorts` being added by default into the injection templates,
these can be done via the annotations specified and propagated to webhook so
that the workarouds can be removed.

Signed-off-by: Kailun Qin <kailun.qin@intel.com>

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
