### PR TITLE
Add configurable RSA key size for Istiod TLS key cert generation

### DIFF
--- a/releasenotes/notes/istiod-tls-rsa-key-size.yaml
+++ b/releasenotes/notes/istiod-tls-rsa-key-size.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: security
+releaseNotes:
+- |
+  **Added** capability to support Istiod TLS key cert generation with specified RSA key size. The RSA key size will be used when configured through the ISTIOD_TLS_RSA_KEY_SIZE env variable.

--- a/security/pkg/pki/ca/ca.go
+++ b/security/pkg/pki/ca/ca.go
@@ -50,9 +50,6 @@ const (
 	PrivateKeyFile = "key.pem"
 	// RootCertFile is the ID/name for the CA root certificate file.
 	RootCertFile = "root-cert.pem"
-
-	// The standard key size to use when generating an RSA private key
-	rsaKeySize = 2048
 )
 
 var pkiCaLog = log.RegisterScope("pkica", "Citadel CA log", 0)
@@ -327,19 +324,15 @@ func (ca *IstioCA) GetCAKeyCertBundle() *util.KeyCertBundle {
 
 // GenKeyCert generates a certificate signed by the CA,
 // returns the certificate chain and the private key.
-func (ca *IstioCA) GenKeyCert(hostnames []string, certTTL time.Duration, checkLifetime bool) ([]byte, []byte, error) {
-	opts := util.CertOptions{
-		RSAKeySize: rsaKeySize,
-	}
-
+func (ca *IstioCA) GenKeyCert(opts *util.CertOptions, hostnames []string, certTTL time.Duration, checkLifetime bool) ([]byte, []byte, error) {
 	// use the type of private key the CA uses to generate an intermediate CA of that type (e.g. CA cert using RSA will
 	// cause intermediate CAs using RSA to be generated)
 	_, signingKey, _, _ := ca.keyCertBundle.GetAll()
-	if util.IsSupportedECPrivateKey(signingKey) {
+	if util.IsSupportedECPrivateKey(*signingKey) {
 		opts.ECSigAlg = util.EcdsaSigAlg
 	}
 
-	csrPEM, privPEM, err := util.GenCSR(opts)
+	csrPEM, privPEM, err := util.GenCSR(*opts)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/security/pkg/pki/ca/ca_test.go
+++ b/security/pkg/pki/ca/ca_test.go
@@ -643,7 +643,10 @@ func TestGenKeyCert(t *testing.T) {
 			t.Fatalf("failed to create a plugged-cert CA.")
 		}
 
-		certPEM, privPEM, err := ca.GenKeyCert([]string{"host1", "host2"}, tc.certLifetime, tc.checkCertLifetime)
+		opts := &util.CertOptions{
+			RSAKeySize: rsaKeySize,
+		}
+		certPEM, privPEM, err := ca.GenKeyCert(opts, []string{"host1", "host2"}, tc.certLifetime, tc.checkCertLifetime)
 		if err != nil {
 			if tc.expectedError == "" {
 				t.Fatalf("[%s] Unexpected error: %v", id, err)

--- a/security/pkg/pki/util/crypto.go
+++ b/security/pkg/pki/util/crypto.go
@@ -101,8 +101,8 @@ func GetRSAKeySize(privKey crypto.PrivateKey) (int, error) {
 }
 
 // IsSupportedECPrivateKey is a predicate returning true if the private key is EC based
-func IsSupportedECPrivateKey(privKey *crypto.PrivateKey) bool {
-	switch (*privKey).(type) {
+func IsSupportedECPrivateKey(privKey crypto.PrivateKey) bool {
+	switch privKey.(type) {
 	// this should agree with var SupportedECSignatureAlgorithms
 	case *ecdsa.PrivateKey:
 		return true

--- a/security/pkg/pki/util/crypto_test.go
+++ b/security/pkg/pki/util/crypto_test.go
@@ -337,7 +337,7 @@ func TestIsSupportedECPrivateKey(t *testing.T) {
 	}
 
 	for id, tc := range cases {
-		if IsSupportedECPrivateKey(&tc.key) != tc.isSupported {
+		if IsSupportedECPrivateKey(tc.key) != tc.isSupported {
 			t.Errorf("%s: does not match expected support level for EC signature algorithms", id)
 		}
 	}


### PR DESCRIPTION
Currently, the Istiod TLS key cert using RSA are generated with a hardcoded key
size of 2048 bits. Users should be able to configure with another different key
size that is qualified.

Signed-off-by: Kailun Qin <kailun.qin@intel.com>

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[x] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
