### PR TITLE
ca: separate self-signed debug mode without K8s from plugged cert mode

### DIFF
--- a/pilot/pkg/bootstrap/istio_ca.go
+++ b/pilot/pkg/bootstrap/istio_ca.go
@@ -140,25 +140,10 @@ var (
 )
 
 // EnableCA returns whether CA functionality is enabled in istiod.
-// The logic of this function is from the logic of whether running CA
-// in RunCA(). The reason for moving this logic from RunCA into EnableCA() is
-// to have a central consistent endpoint to get whether CA functionality is
+// This is a central consistent endpoint to get whether CA functionality is
 // enabled in istiod. EnableCA() is called in multiple places.
 func (s *Server) EnableCA() bool {
-	if !features.EnableCAServer {
-		return false
-	}
-	// Log if we're using self-signed certs without K8S, in debug mode
-	if s.kubeClient == nil {
-		// Without K8S the user needs to have the private key in a local file.
-		// If that is missing - we'll generate an in-memory root for testing, and warn.
-		signingKeyFile := path.Join(LocalCertDir.Get(), "ca-key.pem")
-		if _, err := os.Stat(signingKeyFile); err != nil {
-			log.Warnf("Will use in-memory root CA, no K8S access and no ca key file %s", signingKeyFile)
-		}
-	}
-
-	return true
+	return features.EnableCAServer
 }
 
 // RunCA will start the cert signing GRPC service on an existing server.
@@ -166,14 +151,6 @@ func (s *Server) EnableCA() bool {
 // is mounted. If it is missing - for example old versions of K8S that don't support such tokens -
 // we will not start the cert-signing server, since pods will have no way to authenticate.
 func (s *Server) RunCA(grpc *grpc.Server, ca caserver.CertificateAuthority, opts *caOptions) {
-	if !s.EnableCA() {
-		return
-	}
-	if ca == nil {
-		// When the CA to run is nil, return
-		log.Warn("the CA to run is nil")
-		return
-	}
 	iss := trustedIssuer.Get()
 	aud := audience.Get()
 
@@ -288,14 +265,13 @@ func (s *Server) loadRemoteCACerts(caOpts *caOptions, dir string) error {
 
 // createIstioCA initializes the Istio CA signing functionality.
 // - for 'plugged in', uses ./etc/cacert directory, mounted from 'cacerts' secret in k8s.
-//   Inside, the key/cert are 'ca-key.pem' and 'ca-cert.pem'. The root cert signing the intermeidate is root-cert.pem,
+//   Inside, the key/cert are 'ca-key.pem' and 'ca-cert.pem'. The root cert signing the intermediate is root-cert.pem,
 //   which may contain multiple roots. A 'cert-chain.pem' file has the full cert chain.
 func (s *Server) createIstioCA(client corev1.CoreV1Interface, opts *caOptions) (*ca.IstioCA, error) {
 	var caOpts *ca.IstioCAOptions
 	var err error
 
 	// In pods, this is the optional 'cacerts' Secret.
-	// TODO: also check for key.pem ( for interop )
 	signingKeyFile := path.Join(LocalCertDir.Get(), "ca-key.pem")
 
 	// If not found, will default to ca-cert.pem. May contain multiple roots.
@@ -305,30 +281,37 @@ func (s *Server) createIstioCA(client corev1.CoreV1Interface, opts *caOptions) (
 		// In Istiod, it is possible to provide one via "cacerts" secret in both cases, for consistency.
 		rootCertFile = ""
 	}
-	if _, err := os.Stat(signingKeyFile); err != nil && client != nil {
+	if _, err := os.Stat(signingKeyFile); err != nil {
 		// The user-provided certs are missing - create a self-signed cert.
-		log.Info("Use self-signed certificate as the CA certificate")
-		// Abort after 20 minutes.
-		ctx, cancel := context.WithTimeout(context.Background(), time.Minute*20)
-		defer cancel()
-		// rootCertFile will be added to "ca-cert.pem".
-		// readSigningCertOnly set to false - it doesn't seem to be used in Citadel, nor do we have a way
-		// to set it only for one job.
-		caOpts, err = ca.NewSelfSignedIstioCAOptions(ctx,
-			selfSignedRootCertGracePeriodPercentile.Get(), SelfSignedCACertTTL.Get(),
-			selfSignedRootCertCheckInterval.Get(), workloadCertTTL.Get(),
-			maxWorkloadCertTTL.Get(), opts.TrustDomain, true,
-			opts.Namespace, -1, client, rootCertFile,
-			enableJitterForRootCertRotator.Get(), caRSAKeySize.Get())
+		if client != nil {
+			log.Info("Use self-signed certificate as the CA certificate")
+
+			// Abort after 20 minutes.
+			ctx, cancel := context.WithTimeout(context.Background(), time.Minute*20)
+			defer cancel()
+			// rootCertFile will be added to "ca-cert.pem".
+			// readSigningCertOnly set to false - it doesn't seem to be used in Citadel, nor do we have a way
+			// to set it only for one job.
+			caOpts, err = ca.NewSelfSignedIstioCAOptions(ctx,
+				selfSignedRootCertGracePeriodPercentile.Get(), SelfSignedCACertTTL.Get(),
+				selfSignedRootCertCheckInterval.Get(), workloadCertTTL.Get(),
+				maxWorkloadCertTTL.Get(), opts.TrustDomain, true,
+				opts.Namespace, -1, client, rootCertFile,
+				enableJitterForRootCertRotator.Get(), caRSAKeySize.Get())
+		} else {
+			log.Warnf(
+				"Use local self-signed CA certificate for testing. Will use in-memory root CA, no K8S access and no ca key file %s",
+				signingKeyFile)
+
+			caOpts, err = ca.NewSelfSignedDebugIstioCAOptions(rootCertFile, SelfSignedCACertTTL.Get(),
+				workloadCertTTL.Get(), maxWorkloadCertTTL.Get(), opts.TrustDomain, caRSAKeySize.Get())
+		}
 		if err != nil {
 			return nil, fmt.Errorf("failed to create a self-signed istiod CA: %v", err)
 		}
 	} else {
-		if err == nil {
-			log.Info("Use local CA certificate")
-		} else {
-			log.Info("Use local self-signed CA certificate")
-		}
+		log.Info("Use local CA certificate")
+
 		// The cert corresponding to the key, self-signed or chain.
 		// rootCertFile will be added at the end, if present, to form 'rootCerts'.
 		signingCertFile := path.Join(LocalCertDir.Get(), "ca-cert.pem")


### PR DESCRIPTION
Currently, the self generating key cert for testing or local (i.e., debug mode)
in non-K8s run are produced within the logic of plugged cert mode of Istio CA,
with the CA being considered as the `plugged` type too. This is not reasonable
and somewhat leads to confusions.

This patch separates the logic to create key cert and IstioCAOptions of Istio CA
in debug mode (using in-memory root CA, no K8S access and no ca key file) into
`NewSelfSignedDebugIstioCAOptions` and removes some unnecessary checks.

Signed-off-by: Kailun Qin <kailun.qin@intel.com>

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[x] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
