### PR TITLE
Make revision tags work against older versions

### DIFF
--- a/istioctl/cmd/tag.go
+++ b/istioctl/cmd/tag.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -26,6 +27,9 @@ import (
 	"github.com/spf13/cobra"
 	admit_v1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
@@ -35,11 +39,9 @@ import (
 	"istio.io/istio/galley/pkg/config/analysis/diag"
 	"istio.io/istio/galley/pkg/config/analysis/local"
 	cfgKube "istio.io/istio/galley/pkg/config/source/kube"
-	"istio.io/istio/istioctl/pkg/clioptions"
 	"istio.io/istio/istioctl/pkg/util/formatting"
 	"istio.io/istio/operator/cmd/mesh"
 	"istio.io/istio/operator/pkg/helm"
-	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/config/resource"
 	"istio.io/istio/pkg/config/schema"
 	"istio.io/istio/pkg/kube"
@@ -52,9 +54,6 @@ const (
 	defaultRevisionName         = "default"
 	pilotDiscoveryChart         = "istio-control/istio-discovery"
 	revisionTagTemplateName     = "revision-tags.yaml"
-	// Revision tags require that the target istiod patches ALL webhooks with matching istio.io/rev label,
-	// a behavior that just made it into 1.10 (https://github.com/istio/istio/pull/29583)
-	minRevisionTagIstioVersion = "1.10.0"
 
 	// help strings and long formatted user outputs
 	skipConfirmationFlagHelpStr = `The skipConfirmation determines whether the user is prompted for confirmation.
@@ -82,6 +81,7 @@ type tagWebhookConfig struct {
 	tag                string
 	revision           string
 	remoteInjectionURL string
+	caBundle           string
 }
 
 func tagCommand() *cobra.Command {
@@ -278,19 +278,6 @@ revision tag before removing using the "istioctl x revision tag list" command.
 
 // setTag creates or modifies a revision tag.
 func setTag(ctx context.Context, kubeClient kube.ExtendedClient, tag, revision string, generate bool, w, stderr io.Writer) error {
-	// ensure that the revision is recent enough to patch tag webhooks
-	if !skipConfirmation {
-		sufficient, version, err := versionCheck(revision)
-		if err != nil {
-			return err
-		}
-		if !sufficient {
-			if !confirm(fmt.Sprintf(versionCheckStr, revision, version, minRevisionTagIstioVersion), w) {
-				return nil
-			}
-		}
-	}
-
 	// abort if there exists a revision with the target tag name
 	revWebhookCollisions, err := getWebhooksWithRevision(ctx, kubeClient, tag)
 	if err != nil {
@@ -327,10 +314,6 @@ func setTag(ctx context.Context, kubeClient kube.ExtendedClient, tag, revision s
 	tagWhYAML, err := tagWebhookYAML(tagWhConfig, manifestsPath)
 	if err != nil {
 		return fmt.Errorf("failed to create tag webhook: %v", err)
-	}
-	// custom webhook name specified, change the generated tag webhook configuration
-	if webhookName != "" {
-		tagWhYAML = renameTagWebhookConfiguration(tagWhYAML, tag, webhookName)
 	}
 
 	// Check the newly generated webhook does not conflict with existing ones
@@ -562,10 +545,12 @@ func tagWebhookConfigFromCanonicalWebhook(wh admit_v1.MutatingWebhookConfigurati
 	}
 
 	var injectionURL string
+	var caBundle string
 	found := false
 	for _, w := range wh.Webhooks {
 		if strings.HasSuffix(w.Name, istioInjectionWebhookSuffix) {
 			found = true
+			caBundle = string(w.ClientConfig.CABundle)
 			if w.ClientConfig.URL != nil {
 				injectionURL = *w.ClientConfig.URL
 			} else {
@@ -582,6 +567,7 @@ func tagWebhookConfigFromCanonicalWebhook(wh admit_v1.MutatingWebhookConfigurati
 		tag:                tag,
 		revision:           rev,
 		remoteInjectionURL: injectionURL,
+		caBundle:           caBundle,
 	}, nil
 }
 
@@ -614,7 +600,36 @@ istiodRemote:
 		return "", fmt.Errorf("failed rendering istio-control manifest: %v", err)
 	}
 
-	return tagWebhookYaml, nil
+	// Need to deserialize webhook to change CA bundle
+	// and serialize it back into YAML
+	scheme := runtime.NewScheme()
+	codecFactory := serializer.NewCodecFactory(scheme)
+	deserializer := codecFactory.UniversalDeserializer()
+	serializer := json.NewSerializerWithOptions(
+		json.DefaultMetaFactory, nil, nil, json.SerializerOptions{
+			Yaml:   true,
+			Pretty: true,
+			Strict: true,
+		})
+
+	whObject, _, err := deserializer.Decode([]byte(tagWebhookYaml), nil, &admit_v1.MutatingWebhookConfiguration{})
+	if err != nil {
+		return "", fmt.Errorf("could not decode generated webhook: %w", err)
+	}
+	decodedWh := whObject.(*admit_v1.MutatingWebhookConfiguration)
+	for i := range decodedWh.Webhooks {
+		decodedWh.Webhooks[i].ClientConfig.CABundle = []byte(config.caBundle)
+	}
+	if webhookName != "" {
+		decodedWh.Name = webhookName
+	}
+
+	whBuf := new(bytes.Buffer)
+	if err = serializer.Encode(decodedWh, whBuf); err != nil {
+		return "", err
+	}
+
+	return whBuf.String(), nil
 }
 
 // applyYAML taken from remote_secret.go
@@ -629,11 +644,6 @@ func applyYAML(client kube.ExtendedClient, yamlContent, ns string) error {
 		return fmt.Errorf("failed applying manifest %s: %v", yamlFile, err)
 	}
 	return nil
-}
-
-func renameTagWebhookConfiguration(wh, tag, name string) string {
-	webhookNameStr := fmt.Sprintf("%s-%s", "istio-revision-tag", tag)
-	return strings.ReplaceAll(wh, webhookNameStr, name)
 }
 
 // writeToTempFile taken from remote_secret.go
@@ -661,36 +671,4 @@ func confirm(msg string, w io.Writer) bool {
 	}
 	response = strings.ToUpper(response)
 	return response == "Y" || response == "YES"
-}
-
-// versionCheck returns true if revision tag being created is pointed to a CP version
-// >=1.10 since that's the first version that patches all matching istio.io/rev webhooks
-func versionCheck(rev string) (bool, string, error) {
-	meshInfo, err := getRemoteInfo(clioptions.ControlPlaneOptions{
-		Revision: revision,
-	})
-	if err != nil {
-		if strings.Contains(err.Error(), "no running Istio pods") {
-			// No pods in cluster - assume it is external Istiod and is supported
-			return true, "", nil
-		}
-		return false, "", err
-	}
-	if meshInfo == nil {
-		return false, "", fmt.Errorf("could not retrieve control plane version for revision: %s", rev)
-	}
-	minVersion := model.ParseIstioVersion(minRevisionTagIstioVersion)
-	revVersion := model.ParseIstioVersion((*meshInfo)[0].Info.Version)
-	if minVersion.Compare(revVersion) > 0 {
-		return false, versionToString(revVersion), nil
-	}
-
-	return true, versionToString(revVersion), nil
-}
-
-func versionToString(v *model.IstioVersion) string {
-	if v.Patch != 65535 {
-		return fmt.Sprintf("%d.%d.%d", v.Major, v.Minor, v.Patch)
-	}
-	return fmt.Sprintf("%d.%d", v.Major, v.Minor)
 }

--- a/istioctl/cmd/tag.go
+++ b/istioctl/cmd/tag.go
@@ -65,7 +65,6 @@ overwrite existing revision tags.`
 revision tag, use 'kubectl label namespace <NAMESPACE> istio.io/rev=%s'
 `
 	webhookNameHelpStr = "Name to use for a revision tag's mutating webhook configuration."
-	versionCheckStr    = "Revision %q on version %q, must be at least version %q to patch revision tag webhooks. Continue anyways? (y/N)"
 )
 
 var (

--- a/istioctl/cmd/tag_test.go
+++ b/istioctl/cmd/tag_test.go
@@ -49,6 +49,7 @@ var (
 						Namespace: "default",
 						Name:      "istiod",
 					},
+					CABundle: []byte("ca"),
 				},
 			},
 			{
@@ -58,6 +59,7 @@ var (
 						Namespace: "default",
 						Name:      "istiod",
 					},
+					CABundle: []byte("ca"),
 				},
 			},
 		},
@@ -75,6 +77,7 @@ var (
 						Namespace: "default",
 						Name:      "istiod-revision",
 					},
+					CABundle: []byte("ca"),
 				},
 			},
 			{
@@ -84,6 +87,7 @@ var (
 						Namespace: "default",
 						Name:      "istiod-revision",
 					},
+					CABundle: []byte("ca"),
 				},
 			},
 		},
@@ -99,12 +103,14 @@ var (
 				Name: fmt.Sprintf("namespace.%s", istioInjectionWebhookSuffix),
 				ClientConfig: admit_v1.WebhookClientConfig{
 					URL: &remoteInjectionURL,
+					CABundle: []byte("ca"),
 				},
 			},
 			{
 				Name: fmt.Sprintf("object.%s", istioInjectionWebhookSuffix),
 				ClientConfig: admit_v1.WebhookClientConfig{
 					URL: &remoteInjectionURL,
+					CABundle: []byte("ca"),
 				},
 			},
 		},
@@ -406,6 +412,7 @@ func TestSetTagWebhookCreation(t *testing.T) {
 		tagName     string
 		whURL       string
 		whSVC       string
+		whCA        string
 		numWebhooks int
 	}{
 		{
@@ -414,6 +421,7 @@ func TestSetTagWebhookCreation(t *testing.T) {
 			tagName:     "canary",
 			whURL:       "",
 			whSVC:       "istiod-revision",
+			whCA:        "ca",
 			numWebhooks: 2,
 		},
 		{
@@ -422,6 +430,7 @@ func TestSetTagWebhookCreation(t *testing.T) {
 			tagName:     "canary",
 			whURL:       remoteInjectionURL,
 			whSVC:       "",
+			whCA:        "ca",
 			numWebhooks: 2,
 		},
 		{
@@ -430,6 +439,7 @@ func TestSetTagWebhookCreation(t *testing.T) {
 			tagName:     "canary",
 			whURL:       "",
 			whSVC:       "istiod",
+			whCA:        "ca",
 			numWebhooks: 2,
 		},
 		{
@@ -438,6 +448,7 @@ func TestSetTagWebhookCreation(t *testing.T) {
 			tagName:     "default",
 			whURL:       "",
 			whSVC:       "istiod",
+			whCA:        "ca",
 			numWebhooks: 4,
 		},
 	}
@@ -492,6 +503,11 @@ func TestSetTagWebhookCreation(t *testing.T) {
 				}
 				if *injectionWhConf.URL != tc.whURL {
 					t.Fatalf("expected injection URL %s, got %s", tc.whURL, *injectionWhConf.URL)
+				}
+			}
+			if tc.whCA != "" {
+				if string(injectionWhConf.CABundle) != tc.whCA {
+					t.Fatalf("expected CA bundle %q, got %q", tc.whCA, injectionWhConf.CABundle)
 				}
 			}
 		}

--- a/istioctl/cmd/tag_test.go
+++ b/istioctl/cmd/tag_test.go
@@ -102,14 +102,14 @@ var (
 			{
 				Name: fmt.Sprintf("namespace.%s", istioInjectionWebhookSuffix),
 				ClientConfig: admit_v1.WebhookClientConfig{
-					URL: &remoteInjectionURL,
+					URL:      &remoteInjectionURL,
 					CABundle: []byte("ca"),
 				},
 			},
 			{
 				Name: fmt.Sprintf("object.%s", istioInjectionWebhookSuffix),
 				ClientConfig: admit_v1.WebhookClientConfig{
-					URL: &remoteInjectionURL,
+					URL:      &remoteInjectionURL,
 					CABundle: []byte("ca"),
 				},
 			},


### PR DESCRIPTION
Prior to this PR we relied on the istiod for a given tag's revision to patch the CA bundles into the webhook. This PR makes it so that we use the CA bundle from the revision's webhook when first creating the tag webhook. This makes it so that we can use revision tags against arbitrarily old control planes that may not know how to patch newer webhooks.

The only problem I can think of here is if creating the tag webhook *right after* creating the CP (this could be a part of people's CI pipelines) we may pull out an empty webhook, and if the revision is older than 1.10 it would never get patched in

[ ] Configuration Infrastructure
[ ] Docs
[x] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
