### PR TITLE
Support proxy inbound listen port configuration through mesh config.

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -71,12 +71,6 @@ const (
 	AutoOverAuto
 )
 
-const (
-	// ProxyInboundListenPort is the port on which all inbound traffic to the pod/vm will be captured to
-	// TODO: allow configuration through mesh config
-	ProxyInboundListenPort = 15006
-)
-
 // MutableListener represents a listener that is being built.
 type MutableListener struct {
 	istionetworking.MutableObjects

--- a/pilot/pkg/networking/core/v1alpha3/listener_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_builder.go
@@ -412,7 +412,7 @@ func (lb *ListenerBuilder) buildVirtualInboundListener(configgen *ConfigGenerato
 	filterChains, passthroughInspector := buildInboundCatchAllFilterChains(configgen, lb.node, lb.push)
 	lb.virtualInboundListener = &listener.Listener{
 		Name:             model.VirtualInboundListenerName,
-		Address:          util.BuildAddress(actualWildcard, ProxyInboundListenPort),
+		Address:          util.BuildAddress(actualWildcard, uint32(lb.push.Mesh.ProxyInboundListenPort)),
 		Transparent:      isTransparentProxy,
 		UseOriginalDst:   proto.BoolTrue,
 		TrafficDirection: core.TrafficDirection_INBOUND,
@@ -534,7 +534,7 @@ func buildInboundCatchAllFilterChains(configgen *ConfigGeneratorImpl,
 	filterChains = append(filterChains, &listener.FilterChain{
 		Name: model.VirtualInboundBlackholeFilterChainName,
 		FilterChainMatch: &listener.FilterChainMatch{
-			DestinationPort: &wrappers.UInt32Value{Value: ProxyInboundListenPort},
+			DestinationPort: &wrappers.UInt32Value{Value: uint32(push.Mesh.ProxyInboundListenPort)},
 		},
 		Filters: []*listener.Filter{{
 			Name: wellknown.TCPProxy,

--- a/pkg/config/mesh/mesh.go
+++ b/pkg/config/mesh/mesh.go
@@ -91,6 +91,7 @@ func DefaultMeshConfig() meshconfig.MeshConfig {
 
 		RootNamespace:                  constants.IstioSystemNamespace,
 		ProxyListenPort:                15001,
+		ProxyInboundListenPort:         15006,
 		ConnectTimeout:                 types.DurationProto(10 * time.Second),
 		DefaultServiceExportTo:         []string{"*"},
 		DefaultVirtualServiceExportTo:  []string{"*"},

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -1434,6 +1434,10 @@ func ValidateMeshConfig(mesh *meshconfig.MeshConfig) (errs error) {
 		errs = multierror.Append(errs, multierror.Prefix(err, "invalid proxy listen port:"))
 	}
 
+	if err := ValidatePort(int(mesh.ProxyInboundListenPort)); err != nil {
+		errs = multierror.Append(errs, multierror.Prefix(err, "invalid proxy inbound listen port:"))
+	}
+
 	if err := ValidateConnectTimeout(mesh.ConnectTimeout); err != nil {
 		errs = multierror.Append(errs, multierror.Prefix(err, "invalid connect timeout:"))
 	}

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -378,11 +378,12 @@ func TestValidateMeshConfig(t *testing.T) {
 	}
 
 	invalid := meshconfig.MeshConfig{
-		ProxyListenPort:    0,
-		ConnectTimeout:     types.DurationProto(-1 * time.Second),
-		DefaultConfig:      &meshconfig.ProxyConfig{},
-		TrustDomain:        "",
-		TrustDomainAliases: []string{"a.$b", "a/b", ""},
+		ProxyListenPort:        0,
+		ProxyInboundListenPort: 0,
+		ConnectTimeout:         types.DurationProto(-1 * time.Second),
+		DefaultConfig:          &meshconfig.ProxyConfig{},
+		TrustDomain:            "",
+		TrustDomainAliases:     []string{"a.$b", "a/b", ""},
 		ExtensionProviders: []*meshconfig.MeshConfig_ExtensionProvider{
 			{
 				Name: "default",
@@ -402,6 +403,7 @@ func TestValidateMeshConfig(t *testing.T) {
 	} else {
 		wantErrors := []string{
 			"invalid proxy listen port",
+			"invalid proxy inbound listen port",
 			"invalid connect timeout",
 			"invalid protocol detection timeout: duration: nil Duration",
 			"config path must be set",


### PR DESCRIPTION

Support proxy inbound listen port configuration through mesh config.

Ref: https://github.com/istio/api/pull/1979


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.