### PR TITLE
Intitialize revMeshConfig in FileWatcher

### DIFF
--- a/pkg/config/mesh/mesh.go
+++ b/pkg/config/mesh/mesh.go
@@ -220,12 +220,12 @@ func ReadMeshConfig(filename string) (*meshconfig.MeshConfig, error) {
 }
 
 // ReadMeshConfigData gets mesh configuration yaml from a config file
-func ReadMeshConfigData(filename string) string {
+func ReadMeshConfigData(filename string) (string, error) {
 	yaml, err := ioutil.ReadFile(filename)
 	if err != nil {
-		return ""
+		return "", multierror.Prefix(err, "cannot read mesh config file")
 	}
-	return string(yaml)
+	return string(yaml), nil
 }
 
 // ResolveHostsInNetworksConfig will go through the Gateways addresses for all

--- a/pkg/config/mesh/watcher.go
+++ b/pkg/config/mesh/watcher.go
@@ -68,19 +68,25 @@ func NewFixedWatcher(mesh *meshconfig.MeshConfig) Watcher {
 // NewFileWatcher creates a new Watcher for changes to the given mesh config file. Returns an error
 // if the given file does not exist or failed during parsing.
 func NewFileWatcher(fileWatcher filewatcher.FileWatcher, filename string, multiWatch bool) (Watcher, error) {
-	meshConfig, err := ReadMeshConfig(filename)
+	meshConfigYaml, err := ReadMeshConfigData(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	meshConfig, err := ApplyMeshConfigDefaults(meshConfigYaml)
 	if err != nil {
 		return nil, err
 	}
 
 	w := &InternalWatcher{
 		MeshConfig: meshConfig,
+		revMeshConfig: meshConfigYaml,
 	}
 
 	// Watch the config file for changes and reload if it got modified
 	addFileWatcher(fileWatcher, filename, func() {
 		if multiWatch {
-			meshConfig := ReadMeshConfigData(filename)
+			meshConfig, _ := ReadMeshConfigData(filename)
 			w.HandleMeshConfigData(meshConfig)
 			return
 		}


### PR DESCRIPTION
Please provide a description for what this PR is for.

Currently, the revision mesh config in a mounted file is not merged with the user config until after its first update. This fixes that.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
