### PR TITLE
Refactor status resource queue to allow reuse

### DIFF
--- a/pilot/pkg/status/report.go
+++ b/pilot/pkg/status/report.go
@@ -58,9 +58,10 @@ func ResourceFromString(s string) *Resource {
 // TODO: maybe replace with a kubernetes resource identifier, if that's a thing
 type Resource struct {
 	schema.GroupVersionResource
-	Namespace  string
-	Name       string
-	Generation string
+	Namespace       string
+	Name            string
+	Generation      string
+	ResourceVersion string
 }
 
 func (r Resource) String() string {
@@ -75,16 +76,27 @@ func (r *Resource) ToModelKey() string {
 		r.Name, r.Namespace)
 }
 
-func ResourceFromModelConfig(c config.Config) *Resource {
+func ResourceFromModelConfig(c config.Config) Resource {
 	gvr := GVKtoGVR(c.GroupVersionKind)
 	if gvr == nil {
-		return nil
+		return Resource{}
 	}
-	return &Resource{
+	return Resource{
 		GroupVersionResource: *gvr,
 		Namespace:            c.Namespace,
 		Name:                 c.Name,
 		Generation:           strconv.FormatInt(c.Generation, 10),
+		ResourceVersion:      c.ResourceVersion,
+	}
+}
+
+func ResourceToModelConfig(c Resource) config.Meta {
+	gvk := GVRtoGVK(c.GroupVersionResource)
+	return config.Meta{
+		GroupVersionKind: gvk,
+		Namespace:        c.Namespace,
+		Name:             c.Name,
+		ResourceVersion:  c.ResourceVersion,
 	}
 }
 
@@ -98,4 +110,12 @@ func GVKtoGVR(in config.GroupVersionKind) *schema.GroupVersionResource {
 		Version:  in.Version,
 		Resource: found.Resource().Plural(),
 	}
+}
+
+func GVRtoGVK(in schema.GroupVersionResource) config.GroupVersionKind {
+	found, ok := collections.All.FindByGroupVersionResource(in)
+	if !ok {
+		return config.GroupVersionKind{}
+	}
+	return found.Resource().GroupVersionKind()
 }

--- a/pilot/pkg/status/reporter.go
+++ b/pilot/pkg/status/reporter.go
@@ -219,14 +219,14 @@ func (r *Reporter) removeCompletedResource(completedResources []Resource) {
 func (r *Reporter) AddInProgressResource(res config.Config) {
 	tryLedgerPut(r.ledger, res)
 	myRes := ResourceFromModelConfig(res)
-	if myRes == nil {
+	if myRes == (Resource{}) {
 		scope.Errorf("Unable to locate schema for %v, will not update status.", res)
 		return
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.inProgressResources[myRes.ToModelKey()] = &inProgressEntry{
-		Resource:            *myRes,
+		Resource:            myRes,
 		completedIterations: 0,
 	}
 }

--- a/pilot/pkg/status/reporter_test.go
+++ b/pilot/pkg/status/reporter_test.go
@@ -91,7 +91,7 @@ func TestBuildReport(t *testing.T) {
 	for _, res := range resources {
 		// Set Group Version and GroupVersionKind to real world values from VS
 		res.GroupVersionKind = col.GroupVersionKind()
-		myResources = append(myResources, *ResourceFromModelConfig(*res))
+		myResources = append(myResources, ResourceFromModelConfig(*res))
 		// Add each resource to our ledger for tracking history
 		// mark each of our resources as in flight so they are included in the report.
 		r.AddInProgressResource(*res)

--- a/pilot/pkg/status/resourcelock_test.go
+++ b/pilot/pkg/status/resourcelock_test.go
@@ -52,7 +52,7 @@ func TestResourceLock_Lock(t *testing.T) {
 	var runCount int32
 	x := make(chan struct{})
 	y := make(chan struct{})
-	workers := NewWorkerPool(func(resource *Resource, progress *Progress) {
+	workers := NewProgressWorkerPool(func(resource Resource, progress Progress) {
 		x <- struct{}{}
 		atomic.AddInt32(&runCount, 1)
 		y <- struct{}{}

--- a/pilot/pkg/status/state.go
+++ b/pilot/pkg/status/state.go
@@ -105,8 +105,8 @@ func (c *DistributionController) Start(stop <-chan struct{}) {
 	ctx := NewIstioContext(stop)
 	go c.cmInformer.Run(ctx.Done())
 
-	c.workers = NewWorkerPool(func(resource *Resource, progress *Progress) {
-		c.writeStatus(*resource, *progress)
+	c.workers = NewProgressWorkerPool(func(resource Resource, progress Progress) {
+		c.writeStatus(resource, progress)
 	}, uint(features.StatusMaxWorkers.Get()))
 	c.workers.Run(ctx)
 
@@ -223,7 +223,7 @@ func (c *DistributionController) queueWriteStatus(config Resource, state Progres
 
 func (c *DistributionController) configDeleted(res config.Config) {
 	r := ResourceFromModelConfig(res)
-	c.workers.Delete(*r)
+	c.workers.Delete(r)
 }
 
 func GetTypedStatus(in interface{}) (out *v1alpha1.IstioStatus, err error) {


### PR DESCRIPTION
Will be used for gateway controller as part of
https://docs.google.com/document/d/1wgYnCnypxYMc_nGPZsLr7JIqTe727TwKiNopPkrJ2-k/edit#

This changes to allow different types as the input, and stop using
pointers everywhere when we don't need to, to avoid excessive heap
allocations and un-ergonomic usage
