### PR TITLE
do not read empty file on retry.sh error

### DIFF
--- a/bin/retry.sh
+++ b/bin/retry.sh
@@ -42,7 +42,7 @@ function retry {
       break
     fi
     if ! grep -q "${failureRegex}" "${tmpFile}"; then
-      fail "Unexpected failure: $(cat tmpFile)"
+      fail "Unexpected failure"
     fi
     if [[ $n -lt $max ]]; then
       ((n++))


### PR DESCRIPTION
The error is already output to stdout/stderr, so no need to output it
again - and the file doesn't exist in error cases anyways so its not
useful to attempt it.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.