### PR TITLE
Remove watchedNamespace

### DIFF
--- a/pilot/cmd/pilot-discovery/main.go
+++ b/pilot/cmd/pilot-discovery/main.go
@@ -22,16 +22,16 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
-	"istio.io/pkg/collateral"
-	"istio.io/pkg/ctrlz"
-	"istio.io/pkg/log"
-	"istio.io/pkg/version"
 
 	"istio.io/istio/pilot/pkg/bootstrap"
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/serviceregistry"
 	"istio.io/istio/pkg/cmd"
 	"istio.io/istio/pkg/config/constants"
+	"istio.io/pkg/collateral"
+	"istio.io/pkg/ctrlz"
+	"istio.io/pkg/log"
+	"istio.io/pkg/version"
 )
 
 var (

--- a/pilot/cmd/pilot-discovery/main.go
+++ b/pilot/cmd/pilot-discovery/main.go
@@ -22,17 +22,16 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"istio.io/pkg/collateral"
+	"istio.io/pkg/ctrlz"
+	"istio.io/pkg/log"
+	"istio.io/pkg/version"
 
 	"istio.io/istio/pilot/pkg/bootstrap"
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/serviceregistry"
 	"istio.io/istio/pkg/cmd"
 	"istio.io/istio/pkg/config/constants"
-	"istio.io/pkg/collateral"
-	"istio.io/pkg/ctrlz"
-	"istio.io/pkg/log"
-	"istio.io/pkg/version"
 )
 
 var (
@@ -128,8 +127,6 @@ func init() {
 	// RegistryOptions Controller options
 	discoveryCmd.PersistentFlags().StringVar(&serverArgs.RegistryOptions.FileDir, "configDir", "",
 		"Directory to watch for updates to config yaml files. If specified, the files will be used as the source of config, rather than a CRD client.")
-	discoveryCmd.PersistentFlags().StringVarP(&serverArgs.RegistryOptions.KubeOptions.WatchedNamespaces, "appNamespace", "a", metav1.NamespaceAll,
-		"Specify the applications namespace list the controller manages, separated by comma; if not set, controller watches all namespaces")
 	discoveryCmd.PersistentFlags().DurationVar(&serverArgs.RegistryOptions.KubeOptions.ResyncPeriod, "resync", 60*time.Second,
 		"Controller resync interval")
 	discoveryCmd.PersistentFlags().StringVar(&serverArgs.RegistryOptions.KubeOptions.DomainSuffix, "domain", constants.DefaultKubernetesDomain,

--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -241,7 +241,6 @@ func (s *Server) initConfigSources(args *PilotArgs) (err error) {
 func (s *Server) initInprocessAnalysisController(args *PilotArgs) error {
 	processingArgs := settings.DefaultArgs()
 	processingArgs.KubeConfig = args.RegistryOptions.KubeConfig
-	processingArgs.WatchedNamespaces = args.RegistryOptions.KubeOptions.WatchedNamespaces
 	processingArgs.EnableConfigAnalysis = true
 	meshSource := mesh.NewInmemoryMeshCfg()
 	meshSource.Set(s.environment.Mesh())

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -209,14 +209,6 @@ func NewServer(args *PilotArgs, initFuncs ...func(*Server)) (*Server, error) {
 	e.TrustBundle = s.workloadTrustBundle
 	s.XDSServer = xds.NewDiscoveryServer(e, args.Plugins, args.PodName, args.Namespace)
 
-	if args.RegistryOptions.KubeOptions.WatchedNamespaces != "" {
-		// Add the control-plane namespace to the list of watched namespaces.
-		args.RegistryOptions.KubeOptions.WatchedNamespaces = fmt.Sprintf("%s,%s",
-			args.RegistryOptions.KubeOptions.WatchedNamespaces,
-			args.Namespace,
-		)
-	}
-
 	// used for both initKubeRegistry and initClusterRegistries
 	if features.EnableEndpointSliceController {
 		args.RegistryOptions.KubeOptions.EndpointMode = kubecontroller.EndpointSliceOnly

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -110,10 +110,8 @@ func incrementEvent(kind, event string) {
 type Options struct {
 	SystemNamespace string
 
-	// Namespace the controller watches. If set to meta_v1.NamespaceAll (""), controller watches all namespaces
-	WatchedNamespaces string
-	ResyncPeriod      time.Duration
-	DomainSuffix      string
+	ResyncPeriod time.Duration
+	DomainSuffix string
 
 	// ClusterID identifies the remote cluster in a multicluster env.
 	ClusterID string

--- a/pilot/pkg/serviceregistry/kube/controller/fake.go
+++ b/pilot/pkg/serviceregistry/kube/controller/fake.go
@@ -165,7 +165,6 @@ func NewFakeControllerWithOptions(opts FakeControllerOptions) (*FakeController, 
 	}
 
 	options := Options{
-		WatchedNamespaces:         opts.WatchedNamespaces, // default is all namespaces
 		DomainSuffix:              domainSuffix,
 		XDSUpdater:                xdsUpdater,
 		Metrics:                   &model.Environment{},

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster_test.go
@@ -35,7 +35,6 @@ import (
 const (
 	testSecretName      = "testSecretName"
 	testSecretNameSpace = "istio-system"
-	WatchedNamespaces   = "istio-system"
 	DomainSuffix        = "fake_domain"
 	ResyncPeriod        = 1 * time.Second
 )
@@ -93,11 +92,10 @@ func Test_KubeSecretController(t *testing.T) {
 		clientset,
 		testSecretNameSpace,
 		Options{
-			WatchedNamespaces: WatchedNamespaces,
-			DomainSuffix:      DomainSuffix,
-			ResyncPeriod:      ResyncPeriod,
-			SyncInterval:      time.Microsecond,
-			MeshWatcher:       mesh.NewFixedWatcher(&meshconfig.MeshConfig{}),
+			DomainSuffix: DomainSuffix,
+			ResyncPeriod: ResyncPeriod,
+			SyncInterval: time.Microsecond,
+			MeshWatcher:  mesh.NewFixedWatcher(&meshconfig.MeshConfig{}),
 		}, mockserviceController, nil, nil, "default", nil, nil, nil, s)
 	mc.InitSecretController(stop)
 	cache.WaitForCacheSync(stop, mc.HasSynced)


### PR DESCRIPTION
Since d89c6a624cfd0962e2ed25238ec671baebda0ca5, this option was not respected.

It seems there is no complain, and maybe we can delete this option. And instead, using the new option `MeshConfig.DiscoverySelectors`


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.