### PR TITLE
fix(apply): remain nodePorts when apply svc

### DIFF
--- a/operator/pkg/helmreconciler/common.go
+++ b/operator/pkg/helmreconciler/common.go
@@ -164,7 +164,7 @@ func saveNodePorts(current, overlay *unstructured.Unstructured) error {
 	ports, _, _ := unstructured.NestedFieldNoCopy(overlay.Object, "spec", "ports")
 	for _, port := range ports.([]interface{}) {
 		m := port.(map[string]interface{})
-		if nodePortNum, ok := m["nodePort"]; ok && fmt.Sprintf("%v", nodePortNum) == "0" {
+		if nodePortNum, ok := m["nodePort"]; !ok || fmt.Sprintf("%v", nodePortNum) == "0" {
 			if portNum, ok := m["port"]; ok {
 				if v, ok := portMap[fmt.Sprintf("%v", portNum)]; ok {
 					m["nodePort"] = v

--- a/operator/pkg/helmreconciler/testdata/current.yaml
+++ b/operator/pkg/helmreconciler/testdata/current.yaml
@@ -14,5 +14,9 @@ spec:
       protocol: TCP
       port: 443
       nodePort: 9377
+    - name: redis
+      protocol: TCP
+      port: 6379
+      nodePort: 16379
   clusterIP: 10.0.171.239
   type: LoadBalancer

--- a/operator/pkg/helmreconciler/testdata/overlay.yaml
+++ b/operator/pkg/helmreconciler/testdata/overlay.yaml
@@ -14,4 +14,7 @@ spec:
       protocol: TCP
       port: 443
       nodePort: 9379
+    - name: redis
+      protocol: TCP
+      port: 6379
   type: LoadBalancer


### PR DESCRIPTION
Please provide a description for what this PR is for.

- When apply the operator manifest, the svc nodePorts have not been remained.
  
And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ x ] Test and Release
[ ] User Experience
[ x ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ x ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
