### PR TITLE
Fix flakes in TestMultiWatcherShouldNotifyHandlers

### DIFF
--- a/pkg/config/mesh/watcher.go
+++ b/pkg/config/mesh/watcher.go
@@ -86,7 +86,11 @@ func NewFileWatcher(fileWatcher filewatcher.FileWatcher, filename string, multiW
 	// Watch the config file for changes and reload if it got modified
 	addFileWatcher(fileWatcher, filename, func() {
 		if multiWatch {
-			meshConfig, _ := ReadMeshConfigData(filename)
+			meshConfig, err := ReadMeshConfigData(filename)
+			if err != nil {
+				log.Warnf("failed to read mesh configuration, using default: %v", err)
+				return
+			}
 			w.HandleMeshConfigData(meshConfig)
 			return
 		}

--- a/pkg/config/mesh/watcher_test.go
+++ b/pkg/config/mesh/watcher_test.go
@@ -15,7 +15,6 @@
 package mesh_test
 
 import (
-	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"

--- a/pkg/config/mesh/watcher_test.go
+++ b/pkg/config/mesh/watcher_test.go
@@ -119,10 +119,6 @@ func writeFile(t testing.TB, path, content string) {
 	}
 }
 
-func closeSilent(c io.Closer) {
-	_ = c.Close()
-}
-
 func removeSilent(path string) {
 	_ = os.RemoveAll(path)
 }

--- a/pkg/config/mesh/watcher_test.go
+++ b/pkg/config/mesh/watcher_test.go
@@ -49,7 +49,6 @@ func watcherShouldNotifyHandlers(t *testing.T, multi bool) {
 	g := NewWithT(t)
 
 	path := newTempFile(t)
-	defer removeSilent(path)
 
 	m := mesh.DefaultMeshConfig()
 	writeMessage(t, path, &m)
@@ -90,11 +89,12 @@ func newWatcher(t testing.TB, filename string, multi bool) mesh.Watcher {
 
 func newTempFile(t testing.TB) string {
 	t.Helper()
-	f, err := ioutil.TempFile("", t.Name())
+
+	f, err := ioutil.TempFile(t.TempDir(), t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer closeSilent(f)
+	t.Cleanup(func() { _ = f.Close() })
 
 	path, err := filepath.Abs(f.Name())
 	if err != nil {
@@ -114,7 +114,7 @@ func writeMessage(t testing.TB, path string, msg proto.Message) {
 
 func writeFile(t testing.TB, path, content string) {
 	t.Helper()
-	if err := ioutil.WriteFile(path, []byte(content), 0666); err != nil {
+	if err := ioutil.WriteFile(path, []byte(content), 0o666); err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
Basically what happens is at the end of the test, the file is removed.
The mesh watcher responds to DELETE events, but we ignore the error that
file is not found and call the handlers again.

Instead, if we cannot process the update, we should just ignore it (as
we did prior to recent changes).

The changes in _test.go are not required, just make things a bit
cleaner.
Fixes https://github.com/istio/istio/issues/32796