### PR TITLE
WIP: Add injectorUserAgent annotation

### DIFF
--- a/istioctl/cmd/kubeinject.go
+++ b/istioctl/cmd/kubeinject.go
@@ -158,7 +158,14 @@ func (e ExternalInjector) Inject(pod *corev1.Pod) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.Post(address, "application/json", bytes.NewBuffer(revBytes))
+
+	req, err := http.NewRequest("POST", address, bytes.NewBuffer(revBytes))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "istioctl/"+version.Info.String())
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
WIP: Add `sidecar.istio.io/injectorUserAgent` to record the user-agent that is injecting the pod.

This can be `kube-apiserver-admission` or `istioctl/x.y.z`.

Choices
1. Add to `sidecar.istio.io/status`
2. Add a label so that it is searchable.

TODO:
Distinguish between istioctl calling webhook and offline injection.

Add tests.