### PR TITLE
Update serviceaccounts correctly when service delete or eds update

### DIFF
--- a/pilot/pkg/bootstrap/servicecontroller.go
+++ b/pilot/pkg/bootstrap/servicecontroller.go
@@ -90,7 +90,6 @@ func (s *Server) initKubeRegistry(args *PilotArgs) (err error) {
 		s.istiodCertBundleWatcher,
 		args.Revision,
 		s.fetchCARoot,
-		s.environment,
 		s.environment.ClusterLocal(),
 		s.server)
 

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -389,7 +389,6 @@ func (c *Controller) defaultNetwork() string {
 }
 
 func (c *Controller) Cleanup() error {
-	// TODO(landow) do we need to cleanup other things besides endpoint shards?
 	svcs, err := c.serviceLister.List(klabels.NewSelector())
 	if err != nil {
 		return fmt.Errorf("error listing services for deletion: %v", err)
@@ -397,7 +396,6 @@ func (c *Controller) Cleanup() error {
 	for _, s := range svcs {
 		name := kube.ServiceHostname(s.Name, s.Namespace, c.domainSuffix)
 		c.xdsUpdater.SvcUpdate(c.clusterID, string(name), s.Namespace, model.EventDelete)
-		// TODO(landow) do we need to notify service handlers?
 	}
 	return nil
 }

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -33,7 +33,6 @@ import (
 	"istio.io/istio/pilot/pkg/serviceregistry"
 	"istio.io/istio/pilot/pkg/serviceregistry/aggregate"
 	"istio.io/istio/pilot/pkg/serviceregistry/serviceentry"
-	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/schema/collection"
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/config/schema/gvk"
@@ -78,7 +77,6 @@ type Multicluster struct {
 
 	m                     sync.Mutex // protects remoteKubeControllers
 	remoteKubeControllers map[string]*kubeController
-	networksWatcher       mesh.NetworksWatcher
 	clusterLocal          model.ClusterLocalProvider
 
 	// fetchCaRoot maps the certificate name to the certificate
@@ -103,7 +101,6 @@ func NewMulticluster(
 	caBundleWatcher *keycertbundle.Watcher,
 	revision string,
 	fetchCaRoot func() map[string]string,
-	networksWatcher mesh.NetworksWatcher,
 	clusterLocal model.ClusterLocalProvider,
 	s server.Instance,
 ) *Multicluster {
@@ -118,7 +115,6 @@ func NewMulticluster(
 		fetchCaRoot:           fetchCaRoot,
 		XDSUpdater:            opts.XDSUpdater,
 		remoteKubeControllers: remoteKubeController,
-		networksWatcher:       networksWatcher,
 		clusterLocal:          clusterLocal,
 		secretNamespace:       secretNamespace,
 		syncInterval:          opts.GetSyncInterval(),

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster_test.go
@@ -96,7 +96,7 @@ func Test_KubeSecretController(t *testing.T) {
 			ResyncPeriod: ResyncPeriod,
 			SyncInterval: time.Microsecond,
 			MeshWatcher:  mesh.NewFixedWatcher(&meshconfig.MeshConfig{}),
-		}, mockserviceController, nil, nil, "default", nil, nil, nil, s)
+		}, mockserviceController, nil, nil, "default", nil, nil, s)
 	mc.InitSecretController(stop)
 	cache.WaitForCacheSync(stop, mc.HasSynced)
 	clientset.RunAndWait(stop)

--- a/pilot/pkg/xds/eds.go
+++ b/pilot/pkg/xds/eds.go
@@ -146,7 +146,7 @@ func (s *DiscoveryServer) edsCacheUpdate(clusterID, hostname string, namespace s
 		fullPush = true
 	}
 
-	saUpdated := s.updateServiceAccount(ep, clusterID, hostname, istioEndpoints)
+	saUpdated := s.UpdateServiceAccount(ep, clusterID, hostname, istioEndpoints)
 	// For existing endpoints, we need to do full push if service accounts change.
 	if !fullPush && saUpdated {
 		log.Infof("Full push, service accounts changed, %v", hostname)
@@ -230,7 +230,7 @@ func (s *DiscoveryServer) deleteService(cluster, serviceName, namespace string) 
 		}: {}})
 		epShards.mutex.Unlock()
 
-		s.updateServiceAccount(epShards, cluster, serviceName, nil)
+		s.UpdateServiceAccount(epShards, cluster, serviceName, nil)
 		if shardsLen == 0 {
 			delete(s.EndpointShardsByService[serviceName], namespace)
 		}
@@ -240,8 +240,8 @@ func (s *DiscoveryServer) deleteService(cluster, serviceName, namespace string) 
 	}
 }
 
-// updateServiceAccount updates the service endpoints' sa when service/endpoint event happens.
-func (s *DiscoveryServer) updateServiceAccount(shards *EndpointShards, clusterID, serviceName string, endpoints []*model.IstioEndpoint) bool {
+// UpdateServiceAccount updates the service endpoints' sa when service/endpoint event happens.
+func (s *DiscoveryServer) UpdateServiceAccount(shards *EndpointShards, clusterID, serviceName string, endpoints []*model.IstioEndpoint) bool {
 	oldServiceAccount := shards.ServiceAccounts
 	shards.mutex.Lock()
 	defer shards.mutex.Unlock()

--- a/pilot/pkg/xds/eds.go
+++ b/pilot/pkg/xds/eds.go
@@ -259,7 +259,11 @@ func (s *DiscoveryServer) UpdateServiceAccount(shards *EndpointShards, clusterID
 		}
 	}
 
+	fmt.Printf("old: %v, new %v\n", oldServiceAccount, serviceAccounts)
+
 	if !oldServiceAccount.Equals(serviceAccounts) {
+		fmt.Println("---------updated")
+
 		shards.ServiceAccounts = serviceAccounts
 		log.Debugf("Updating service accounts now, svc %v, before service account %v, after %v",
 			serviceName, oldServiceAccount, serviceAccounts)

--- a/pilot/pkg/xds/eds.go
+++ b/pilot/pkg/xds/eds.go
@@ -258,8 +258,9 @@ func (s *DiscoveryServer) UpdateServiceAccount(shards *EndpointShards, clusterID
 			}
 		}
 	}
-	shards.ServiceAccounts = serviceAccounts
+
 	if !oldServiceAccount.Equals(serviceAccounts) {
+		shards.ServiceAccounts = serviceAccounts
 		log.Debugf("Updating service accounts now, svc %v, before service account %v, after %v",
 			serviceName, oldServiceAccount, serviceAccounts)
 		return true

--- a/pilot/pkg/xds/eds_test.go
+++ b/pilot/pkg/xds/eds_test.go
@@ -471,7 +471,7 @@ func TestUpdateServiceAccount(t *testing.T) {
 			expect: false,
 		},
 		{
-			name:      "deleted one endpoint with duplicate sa",
+			name:      "deleted one endpoint with unique sa",
 			clusterID: "c1",
 			endpoints: []*model.IstioEndpoint{
 				{Address: "10.172.0.1", ServiceAccount: "sa1"},
@@ -479,12 +479,12 @@ func TestUpdateServiceAccount(t *testing.T) {
 			expect: true,
 		},
 		{
-			name:      "deleted one endpoint with unique sa",
+			name:      "deleted one endpoint with duplicate sa",
 			clusterID: "c1",
 			endpoints: []*model.IstioEndpoint{
-				{Address: "10.172.0.2", ServiceAccount: "vsa-vm1"},
+				{Address: "10.172.0.2", ServiceAccount: "sa-vm1"},
 			},
-			expect: true,
+			expect: false,
 		},
 		{
 			name:      "deleted endpoints",


### PR DESCRIPTION
Fix a bug for sa update. Previously we may miss serviceaccount.

This can happen in this scenario. 

There is a hybrid env with multi-clusters, including pods and workload entries. 

Let's say cluster 1: pods all have serviceaccount `sa`, and workloadEntries has `sa-vm1`
              cluster 2: pods all have serviceaccount `sa`, and workloadEntries has `sa-vm2`

1. When workloadEntries in cluster1 are all deleted, then serviceaccounts will be updated to only `sa` and miss `sa-vm2`.

2. When only part of workloadentry of cluster1 deleted,  then serviceaccounts will be updated to only `sa` and miss `sa-vm1` and miss `sa-vm2`. Also this will trigger a full push, which is unneccessary.




[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.