### PR TITLE
Adding MCS service discovery

### DIFF
--- a/manifests/charts/base/files/gen-istio-cluster.yaml
+++ b/manifests/charts/base/files/gen-istio-cluster.yaml
@@ -5837,6 +5837,9 @@ rules:
   - apiGroups: ["authorization.k8s.io"]
     resources: ["subjectaccessreviews"]
     verbs: ["create"]
+  - apiGroups: ["multicluster.x-k8s.io"]
+    resources: ["serviceexports"]
+    verbs: ["get", "watch", "list"]
 ---
 # Source: base/templates/clusterrolebinding.yaml
 # -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-

--- a/manifests/charts/base/templates/clusterrole.yaml
+++ b/manifests/charts/base/templates/clusterrole.yaml
@@ -154,6 +154,9 @@ rules:
   - apiGroups: ["authorization.k8s.io"]
     resources: ["subjectaccessreviews"]
     verbs: ["create"]
+  - apiGroups: ["multicluster.x-k8s.io"]
+    resources: ["serviceexports"]
+    verbs: ["get", "watch", "list"]
 {{- if or .Values.global.externalIstiod }}
   - apiGroups: [""]
     resources: ["configmaps"]

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -222,6 +222,8 @@ func NewServer(args *PilotArgs, initFuncs ...func(*Server)) (*Server, error) {
 		args.RegistryOptions.KubeOptions.EndpointMode = kubecontroller.EndpointsOnly
 	}
 
+	args.RegistryOptions.KubeOptions.EnableMCSServiceDiscovery = features.EnableMCSServiceDiscovery
+
 	prometheus.EnableHandlingTimeHistogram()
 
 	// Apply the arguments to the configuration.

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -222,11 +222,17 @@ var (
 			"Currently this is mutual exclusive - either Endpoints or EndpointSlices will be used",
 	).Get()
 
-	EnableMCSServiceExport = env.RegisterBoolVar(
-		"PILOT_ENABLE_MCS_SERVICEEXPORT",
+	EnableMCSAutoExport = env.RegisterBoolVar(
+		"ENABLE_MCS_AUTOEXPORT",
 		false,
-		"If enabled, Pilot will generate MCS ServiceExport objects for every non cluster-local service in the cluster",
+		"If enabled, istiod will automatically generate MCS ServiceExport objects for each "+
+			"service in each cluster. Services defined to be cluster-local in MeshConfig are excluded.",
 	).Get()
+
+	EnableMCSServiceDiscovery = env.RegisterBoolVar("ENABLE_MCS_SERVICE_DISCOVERY", false,
+		"If enabled, istiod will enable Kubernetes MCS service discovery mode. In this mode, service endpoints "+
+			"in a cluster will only discoverable within the same cluster unless explicitly exported "+
+			"(via the ServiceExport CR).").Get()
 
 	EnableAnalysis = env.RegisterBoolVar(
 		"PILOT_ENABLE_ANALYSIS",

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -406,6 +406,10 @@ func (cb *ClusterBuilder) buildLocalityLbEndpoints(proxyNetworkView map[string]b
 		if isClusterLocal && (cb.proxy.Metadata.ClusterID != instance.Endpoint.Locality.ClusterID) {
 			continue
 		}
+		// TODO(nmittler): Consider merging discoverability policy with cluster-local
+		if !instance.Endpoint.IsDiscoverableFromProxy(cb.proxy) {
+			continue
+		}
 		addr := util.BuildAddress(instance.Endpoint.Address, instance.Endpoint.EndpointPort)
 		ep := &endpoint.LbEndpoint{
 			HostIdentifier: &endpoint.LbEndpoint_Endpoint{

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	klabels "k8s.io/apimachinery/pkg/labels"
-	"k8s.io/client-go/kubernetes"
+	"k8s.io/apimachinery/pkg/types"
 	listerv1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 
@@ -138,6 +138,9 @@ type Options struct {
 	// SyncTimeout, if set, causes HasSynced to be returned when marked true.
 	SyncTimeout *atomic.Bool
 
+	// EnableMCSServiceDiscovery if set, configures endpoint discoverability based on Kubernetes MCS resources.
+	EnableMCSServiceDiscovery bool
+
 	// If meshConfig.DiscoverySelectors are specified, the DiscoveryNamespacesFilter tracks the namespaces this controller watches.
 	DiscoveryNamespacesFilter filter.DiscoveryNamespacesFilter
 }
@@ -194,7 +197,9 @@ var _ controllerInterface = &Controller{}
 // Controller is a collection of synchronized resource watchers
 // Caches are thread-safe
 type Controller struct {
-	client kubernetes.Interface
+	opts Options
+
+	client kubelib.Client
 
 	queue queue.Instance
 
@@ -212,13 +217,8 @@ type Controller struct {
 	nodeInformer cache.SharedIndexInformer
 	nodeLister   listerv1.NodeLister
 
-	pods *PodCache
-
-	metrics         model.Metrics
-	networksWatcher mesh.NetworksWatcher
-	xdsUpdater      model.XDSUpdater
-	domainSuffix    string
-	clusterID       string
+	exports serviceExportCache
+	pods    *PodCache
 
 	serviceHandlers  []func(*model.Service, model.Event)
 	workloadHandlers []func(*model.WorkloadInstance, model.Event)
@@ -263,26 +263,15 @@ type Controller struct {
 	beginSync *atomic.Bool
 	// initialSync is set to true after performing an initial in-order processing of all objects.
 	initialSync *atomic.Bool
-	// syncTimeout signals that the registry should mark itself synced even if informers haven't been processed yet.
-	// The timeout may be controlled by a different component than the kube controller.
-	syncTimeout *atomic.Bool
-	// Duration to wait for cache syncs
-	syncInterval time.Duration
-
-	// If meshConfig.DiscoverySelectors are specified, the DiscoveryNamespacesFilter tracks the namespaces this controller watches.
-	discoveryNamespacesFilter filter.DiscoveryNamespacesFilter
-	systemNamespace           string
 }
 
 // NewController creates a new Kubernetes controller
 // Created by bootstrap and multicluster (see secretcontroller).
 func NewController(kubeClient kubelib.Client, options Options) *Controller {
 	c := &Controller{
-		domainSuffix:                options.DomainSuffix,
-		client:                      kubeClient.Kube(),
+		opts:                        options,
+		client:                      kubeClient,
 		queue:                       queue.NewQueue(1 * time.Second),
-		clusterID:                   options.ClusterID,
-		xdsUpdater:                  options.XDSUpdater,
 		servicesMap:                 make(map[host.Name]*model.Service),
 		nodeSelectorsForServices:    make(map[host.Name]labels.Instance),
 		nodeInfoMap:                 make(map[string]kubernetesNode),
@@ -291,37 +280,31 @@ func NewController(kubeClient kubelib.Client, options Options) *Controller {
 		workloadInstancesIPsByName:  make(map[string]string),
 		registryServiceNameGateways: make(map[host.Name]uint32),
 		networkGateways:             make(map[host.Name]map[string][]*model.Gateway),
-		networksWatcher:             options.NetworksWatcher,
-		metrics:                     options.Metrics,
-		syncInterval:                options.GetSyncInterval(),
 		informerInit:                atomic.NewBool(false),
 		beginSync:                   atomic.NewBool(false),
 		initialSync:                 atomic.NewBool(false),
-		syncTimeout:                 options.SyncTimeout,
-		discoveryNamespacesFilter:   options.DiscoveryNamespacesFilter,
-		systemNamespace:             options.SystemNamespace,
 	}
 	c.nsInformer = kubeClient.KubeInformer().Core().V1().Namespaces().Informer()
 	c.nsLister = kubeClient.KubeInformer().Core().V1().Namespaces().Lister()
-	if c.systemNamespace != "" {
+	if c.opts.SystemNamespace != "" {
 		nsInformer := filter.NewFilteredSharedIndexInformer(func(obj interface{}) bool {
 			ns, ok := obj.(*v1.Namespace)
 			if !ok {
 				log.Warnf("Namespace watch getting wrong type in event: %T", obj)
 				return false
 			}
-			return ns.Name == c.systemNamespace
+			return ns.Name == c.opts.SystemNamespace
 		}, c.nsInformer)
 		c.registerHandlers(nsInformer, "Namespaces", c.onSystemNamespaceEvent, nil)
 	}
 
-	if c.discoveryNamespacesFilter == nil {
-		c.discoveryNamespacesFilter = filter.NewDiscoveryNamespacesFilter(c.nsLister, options.MeshWatcher.Mesh().DiscoverySelectors)
+	if c.opts.DiscoveryNamespacesFilter == nil {
+		c.opts.DiscoveryNamespacesFilter = filter.NewDiscoveryNamespacesFilter(c.nsLister, options.MeshWatcher.Mesh().DiscoverySelectors)
 	}
 
-	c.initDiscoveryHandlers(kubeClient, options.EndpointMode, options.MeshWatcher, c.discoveryNamespacesFilter)
+	c.initDiscoveryHandlers(kubeClient, options.EndpointMode, options.MeshWatcher, c.opts.DiscoveryNamespacesFilter)
 
-	c.serviceInformer = filter.NewFilteredSharedIndexInformer(c.discoveryNamespacesFilter.Filter, kubeClient.KubeInformer().Core().V1().Services().Informer())
+	c.serviceInformer = filter.NewFilteredSharedIndexInformer(c.opts.DiscoveryNamespacesFilter.Filter, kubeClient.KubeInformer().Core().V1().Services().Informer())
 	c.serviceLister = listerv1.NewServiceLister(c.serviceInformer.GetIndexer())
 
 	c.registerHandlers(c.serviceInformer, "Services", c.onServiceEvent, nil)
@@ -329,13 +312,13 @@ func NewController(kubeClient kubelib.Client, options Options) *Controller {
 	switch options.EndpointMode {
 	case EndpointsOnly:
 		endpointsInformer := filter.NewFilteredSharedIndexInformer(
-			c.discoveryNamespacesFilter.Filter,
+			c.opts.DiscoveryNamespacesFilter.Filter,
 			kubeClient.KubeInformer().Core().V1().Endpoints().Informer(),
 		)
 		c.endpoints = newEndpointsController(c, endpointsInformer)
 	case EndpointSliceOnly:
 		endpointSliceInformer := filter.NewFilteredSharedIndexInformer(
-			c.discoveryNamespacesFilter.Filter,
+			c.opts.DiscoveryNamespacesFilter.Filter,
 			kubeClient.KubeInformer().Discovery().V1beta1().EndpointSlices().Informer(),
 		)
 		c.endpoints = newEndpointSliceController(c, endpointSliceInformer)
@@ -346,7 +329,7 @@ func NewController(kubeClient kubelib.Client, options Options) *Controller {
 	c.nodeLister = kubeClient.KubeInformer().Core().V1().Nodes().Lister()
 	c.registerHandlers(c.nodeInformer, "Nodes", c.onNodeEvent, nil)
 
-	podInformer := filter.NewFilteredSharedIndexInformer(c.discoveryNamespacesFilter.Filter, kubeClient.KubeInformer().Core().V1().Pods().Informer())
+	podInformer := filter.NewFilteredSharedIndexInformer(c.opts.DiscoveryNamespacesFilter.Filter, kubeClient.KubeInformer().Core().V1().Pods().Informer())
 	c.pods = newPodCache(c, podInformer, func(key string) {
 		item, exists, err := c.endpoints.getInformer().GetIndexer().GetByKey(key)
 		if err != nil {
@@ -365,6 +348,8 @@ func NewController(kubeClient kubelib.Client, options Options) *Controller {
 	})
 	c.registerHandlers(c.pods.informer, "Pods", c.pods.onEvent, nil)
 
+	c.exports = newServiceExportCache(c)
+
 	return c
 }
 
@@ -373,7 +358,14 @@ func (c *Controller) Provider() serviceregistry.ProviderID {
 }
 
 func (c *Controller) Cluster() string {
-	return c.clusterID
+	return c.opts.ClusterID
+}
+
+func (c *Controller) discoverabilityPolicyForService(name types.NamespacedName) model.EndpointDiscoverabilityPolicy {
+	if c.exports.isExported(name) {
+		return model.AlwaysDiscoverable
+	}
+	return model.DiscoverableFromSameCluster
 }
 
 func (c *Controller) cidrRanger() cidranger.Ranger {
@@ -397,8 +389,8 @@ func (c *Controller) Cleanup() error {
 		return fmt.Errorf("error listing services for deletion: %v", err)
 	}
 	for _, s := range svcs {
-		name := kube.ServiceHostname(s.Name, s.Namespace, c.domainSuffix)
-		c.xdsUpdater.SvcUpdate(c.clusterID, string(name), s.Namespace, model.EventDelete)
+		name := kube.ServiceHostname(s.Name, s.Namespace, c.opts.DomainSuffix)
+		c.opts.XDSUpdater.SvcUpdate(c.Cluster(), string(name), s.Namespace, model.EventDelete)
 	}
 	return nil
 }
@@ -412,7 +404,7 @@ func (c *Controller) onServiceEvent(curr interface{}, event model.Event) error {
 
 	log.Debugf("Handle event %s for service %s in namespace %s", event, svc.Name, svc.Namespace)
 
-	svcConv := kube.ConvertService(*svc, c.domainSuffix, c.clusterID)
+	svcConv := kube.ConvertService(*svc, c.opts.DomainSuffix, c.Cluster())
 	switch event {
 	case model.EventDelete:
 		c.Lock()
@@ -449,32 +441,35 @@ func (c *Controller) onServiceEvent(curr interface{}, event model.Event) error {
 
 		if needsFullPush {
 			// networks are different, we need to update all eds endpoints
-			c.xdsUpdater.ConfigUpdate(&model.PushRequest{Full: true, Reason: []model.TriggerReason{model.NetworksTrigger}})
+			c.opts.XDSUpdater.ConfigUpdate(&model.PushRequest{Full: true, Reason: []model.TriggerReason{model.NetworksTrigger}})
 		}
 	}
 
 	// We also need to update when the Service changes. For Kubernetes, a service change will result in Endpoint updates,
 	// but workload entries will also need to be updated.
 	if event == model.EventAdd || event == model.EventUpdate {
-		// Build IstioEndpoints
-		endpoints := c.endpoints.buildIstioEndpointsWithService(svc.Name, svc.Namespace, svcConv.Hostname)
-		if features.EnableK8SServiceSelectWorkloadEntries {
-			fep := c.collectWorkloadInstanceEndpoints(svcConv)
-			endpoints = append(endpoints, fep...)
-		}
-
+		endpoints := c.buildEndpointsForService(svcConv)
 		if len(endpoints) > 0 {
-			c.xdsUpdater.EDSCacheUpdate(c.clusterID, string(svcConv.Hostname), svc.Namespace, endpoints)
+			c.opts.XDSUpdater.EDSCacheUpdate(c.Cluster(), string(svcConv.Hostname), svc.Namespace, endpoints)
 		}
 	}
 
-	c.xdsUpdater.SvcUpdate(c.clusterID, string(svcConv.Hostname), svc.Namespace, event)
+	c.opts.XDSUpdater.SvcUpdate(c.Cluster(), string(svcConv.Hostname), svc.Namespace, event)
 	// Notify service handlers.
 	for _, f := range c.serviceHandlers {
 		f(svcConv, event)
 	}
 
 	return nil
+}
+
+func (c *Controller) buildEndpointsForService(svc *model.Service) []*model.IstioEndpoint {
+	endpoints := c.endpoints.buildIstioEndpointsWithService(svc.Attributes.Name, svc.Attributes.Namespace, svc.Hostname)
+	if features.EnableK8SServiceSelectWorkloadEntries {
+		fep := c.collectWorkloadInstanceEndpoints(svc)
+		endpoints = append(endpoints, fep...)
+	}
+	return endpoints
 }
 
 func (c *Controller) onNodeEvent(obj interface{}, event model.Event) error {
@@ -522,7 +517,7 @@ func (c *Controller) onNodeEvent(obj interface{}, event model.Event) error {
 
 	// update all related services
 	if updatedNeeded && c.updateServiceNodePortAddresses() {
-		c.xdsUpdater.ConfigUpdate(&model.PushRequest{
+		c.opts.XDSUpdater.ConfigUpdate(&model.PushRequest{
 			Full: true,
 		})
 	}
@@ -541,7 +536,7 @@ func (c *Controller) registerHandlers(
 		return handler(obj, event)
 	}
 	if informer, ok := informer.(cache.SharedInformer); ok {
-		_ = informer.SetWatchErrorHandler(informermetric.ErrorHandlerForCluster(c.clusterID))
+		_ = informer.SetWatchErrorHandler(informermetric.ErrorHandlerForCluster(c.Cluster()))
 	}
 	informer.AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
@@ -602,7 +597,7 @@ func tryGetLatestObject(informer filter.FilteredSharedIndexInformer, obj interfa
 
 // HasSynced returns true after the initial state synchronization
 func (c *Controller) HasSynced() bool {
-	return (c.syncTimeout != nil && c.syncTimeout.Load()) || c.initialSync.Load()
+	return (c.opts.SyncTimeout != nil && c.opts.SyncTimeout.Load()) || c.initialSync.Load()
 }
 
 func (c *Controller) informersSynced() bool {
@@ -614,7 +609,8 @@ func (c *Controller) informersSynced() bool {
 		!c.serviceInformer.HasSynced() ||
 		!c.endpoints.HasSynced() ||
 		!c.pods.informer.HasSynced() ||
-		!c.nodeInformer.HasSynced() {
+		!c.nodeInformer.HasSynced() ||
+		!c.exports.HasSynced() {
 		return false
 	}
 	return true
@@ -629,7 +625,7 @@ func (c *Controller) SyncAll() error {
 	var err *multierror.Error
 
 	if c.nsLister != nil {
-		sysNs, _ := c.nsLister.Get(c.systemNamespace)
+		sysNs, _ := c.nsLister.Get(c.opts.SystemNamespace)
 		if sysNs != nil {
 			err = multierror.Append(err, c.onSystemNamespaceEvent(sysNs, model.EventAdd))
 		}
@@ -675,14 +671,14 @@ func (c *Controller) syncEndpoints() error {
 
 // Run all controllers until a signal is received
 func (c *Controller) Run(stop <-chan struct{}) {
-	if c.networksWatcher != nil {
-		c.networksWatcher.AddNetworksHandler(c.reloadNetworkLookup)
+	if c.opts.NetworksWatcher != nil {
+		c.opts.NetworksWatcher.AddNetworksHandler(c.reloadNetworkLookup)
 		c.reloadMeshNetworks()
 		c.reloadNetworkGateways()
 	}
 	c.informerInit.Store(true)
 
-	kubelib.WaitForCacheSyncInterval(stop, c.syncInterval, c.informersSynced)
+	kubelib.WaitForCacheSyncInterval(stop, c.opts.GetSyncInterval(), c.informersSynced)
 	// after informer caches sync the first time, process resources in order
 	if err := c.SyncAll(); err != nil {
 		log.Errorf("one or more errors force-syncing resources: %v", err)
@@ -897,7 +893,7 @@ func (c *Controller) GetProxyServiceInstances(proxy *model.Proxy) []*model.Servi
 			// we don't want to use this block for our test "VM" which is actually a Pod.
 
 			if !c.isControllerForProxy(proxy) {
-				log.Errorf("proxy is in cluster %v, but controller is for cluster %v", proxy.Metadata.ClusterID, c.clusterID)
+				log.Errorf("proxy is in cluster %v, but controller is for cluster %v", proxy.Metadata.ClusterID, c.Cluster())
 				return nil
 			}
 
@@ -927,8 +923,8 @@ func (c *Controller) GetProxyServiceInstances(proxy *model.Proxy) []*model.Servi
 	}
 
 	// TODO: This could not happen, remove?
-	if c.metrics != nil {
-		c.metrics.AddMetric(model.ProxyStatusNoService, proxy.ID, proxy.ID, "")
+	if c.opts.Metrics != nil {
+		c.opts.Metrics.AddMetric(model.ProxyStatusNoService, proxy.ID, proxy.ID, "")
 	} else {
 		log.Infof("Missing metrics env, empty list of services for pod %s", proxy.ID)
 	}
@@ -948,7 +944,7 @@ func (c *Controller) hydrateWorkloadInstance(si *model.WorkloadInstance) []*mode
 		for _, k8sSvc := range k8sServices {
 			var service *model.Service
 			c.RLock()
-			service = c.servicesMap[kube.ServiceHostname(k8sSvc.Name, k8sSvc.Namespace, c.domainSuffix)]
+			service = c.servicesMap[kube.ServiceHostname(k8sSvc.Name, k8sSvc.Namespace, c.opts.DomainSuffix)]
 			c.RUnlock()
 			// Note that this cannot be an external service because k8s external services do not have label selectors.
 			if service == nil || service.Resolution != model.ClientSideLB {
@@ -1006,7 +1002,7 @@ func (c *Controller) WorkloadInstanceHandler(si *model.WorkloadInstance, event m
 		for _, k8sSvc := range k8sServices {
 			var service *model.Service
 			c.RLock()
-			service = c.servicesMap[kube.ServiceHostname(k8sSvc.Name, k8sSvc.Namespace, c.domainSuffix)]
+			service = c.servicesMap[kube.ServiceHostname(k8sSvc.Name, k8sSvc.Namespace, c.opts.DomainSuffix)]
 			c.RUnlock()
 			// Note that this cannot be an external service because k8s external services do not have label selectors.
 			if service == nil || service.Resolution != model.ClientSideLB {
@@ -1029,7 +1025,7 @@ func (c *Controller) WorkloadInstanceHandler(si *model.WorkloadInstance, event m
 				}
 			}
 			// fire off eds update
-			c.xdsUpdater.EDSUpdate(c.clusterID, string(service.Hostname), service.Attributes.Namespace, endpoints)
+			c.opts.XDSUpdater.EDSUpdate(c.Cluster(), string(service.Hostname), service.Attributes.Namespace, endpoints)
 		}
 	}
 }
@@ -1062,7 +1058,7 @@ func (c *Controller) onSystemNamespaceEvent(obj interface{}, ev model.Event) err
 // isControllerForProxy should be used for proxies assumed to be in the kube cluster for this controller. Workload Entries
 // may not necessarily pass this check, but we still want to allow kube services to select workload instances.
 func (c *Controller) isControllerForProxy(proxy *model.Proxy) bool {
-	return proxy.Metadata.ClusterID == "" || proxy.Metadata.ClusterID == c.clusterID
+	return proxy.Metadata.ClusterID == "" || proxy.Metadata.ClusterID == c.Cluster()
 }
 
 // getProxyServiceInstancesFromMetadata retrieves ServiceInstances using proxy Metadata rather than
@@ -1074,7 +1070,7 @@ func (c *Controller) getProxyServiceInstancesFromMetadata(proxy *model.Proxy) ([
 	}
 
 	if !c.isControllerForProxy(proxy) {
-		return nil, fmt.Errorf("proxy is in cluster %v, but controller is for cluster %v", proxy.Metadata.ClusterID, c.clusterID)
+		return nil, fmt.Errorf("proxy is in cluster %v, but controller is for cluster %v", proxy.Metadata.ClusterID, c.Cluster())
 	}
 
 	// Create a pod with just the information needed to find the associated Services
@@ -1096,13 +1092,15 @@ func (c *Controller) getProxyServiceInstancesFromMetadata(proxy *model.Proxy) ([
 
 	out := make([]*model.ServiceInstance, 0)
 	for _, svc := range services {
-		hostname := kube.ServiceHostname(svc.Name, svc.Namespace, c.domainSuffix)
+		hostname := kube.ServiceHostname(svc.Name, svc.Namespace, c.opts.DomainSuffix)
 		c.RLock()
 		modelService, f := c.servicesMap[hostname]
 		c.RUnlock()
 		if !f {
 			return nil, fmt.Errorf("failed to find model service for %v", hostname)
 		}
+
+		discoverabilityPolicy := c.discoverabilityPolicyForService(namespacedNameForService(modelService))
 
 		tps := make(map[model.Port]*model.Port)
 		for _, port := range svc.Spec.Ports {
@@ -1142,7 +1140,7 @@ func (c *Controller) getProxyServiceInstancesFromMetadata(proxy *model.Proxy) ([
 				out = append(out, &model.ServiceInstance{
 					Service:     modelService,
 					ServicePort: svcPort,
-					Endpoint:    epBuilder.buildIstioEndpoint(ip, int32(tp.Port), svcPort.Name),
+					Endpoint:    epBuilder.buildIstioEndpoint(ip, int32(tp.Port), svcPort.Name, discoverabilityPolicy),
 				})
 			}
 		}
@@ -1154,7 +1152,7 @@ func (c *Controller) getProxyServiceInstancesByPod(pod *v1.Pod,
 	service *v1.Service, proxy *model.Proxy) []*model.ServiceInstance {
 	out := make([]*model.ServiceInstance, 0)
 
-	hostname := kube.ServiceHostname(service.Name, service.Namespace, c.domainSuffix)
+	hostname := kube.ServiceHostname(service.Name, service.Namespace, c.opts.DomainSuffix)
 	c.RLock()
 	svc := c.servicesMap[hostname]
 	c.RUnlock()
@@ -1162,6 +1160,8 @@ func (c *Controller) getProxyServiceInstancesByPod(pod *v1.Pod,
 	if svc == nil {
 		return out
 	}
+
+	discoverabilityPolicy := c.discoverabilityPolicyForService(namespacedNameForService(svc))
 
 	tps := make(map[model.Port]*model.Port)
 	for _, port := range service.Spec.Ports {
@@ -1191,7 +1191,7 @@ func (c *Controller) getProxyServiceInstancesByPod(pod *v1.Pod,
 	for tp, svcPort := range tps {
 		// consider multiple IP scenarios
 		for _, ip := range proxy.IPAddresses {
-			istioEndpoint := builder.buildIstioEndpoint(ip, int32(tp.Port), svcPort.Name)
+			istioEndpoint := builder.buildIstioEndpoint(ip, int32(tp.Port), svcPort.Name, discoverabilityPolicy)
 			out = append(out, &model.ServiceInstance{
 				Service:     svc,
 				ServicePort: svcPort,

--- a/pilot/pkg/serviceregistry/kube/controller/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller_test.go
@@ -442,6 +442,8 @@ func TestGetProxyServiceInstances(t *testing.T) {
 			if len(metaServices) != 1 {
 				t.Fatalf("expected 1 instance, got %v", len(metaServices))
 			}
+			// Remove the discoverability function so that it's ignored by DeepEqual.
+			clearDiscoverabilityPolicy(metaServices[0].Endpoint)
 			if !reflect.DeepEqual(expected, metaServices[0]) {
 				t.Fatalf("expected instance %v, got %v", expected, metaServices[0])
 			}
@@ -512,6 +514,7 @@ func TestGetProxyServiceInstances(t *testing.T) {
 			if len(podServices) != 1 {
 				t.Fatalf("expected 1 instance, got %v", len(podServices))
 			}
+			clearDiscoverabilityPolicy(podServices[0].Endpoint)
 			if !reflect.DeepEqual(expected, podServices[0]) {
 				t.Fatalf("expected instance %v, got %v", expected, podServices[0])
 			}
@@ -577,6 +580,7 @@ func TestGetProxyServiceInstances(t *testing.T) {
 			if len(podServices) != 1 {
 				t.Fatalf("expected 1 instance, got %v", len(podServices))
 			}
+			clearDiscoverabilityPolicy(podServices[0].Endpoint)
 			if !reflect.DeepEqual(expected, podServices[0]) {
 				t.Fatalf("expected instance %v, got %v", expected, podServices[0])
 			}
@@ -1815,8 +1819,9 @@ func TestEndpointUpdate(t *testing.T) {
 			if ev == nil {
 				t.Fatalf("Timeout xds push")
 			}
-			if ev.ID != string(kube.ServiceHostname("svc1", "nsa", controller.domainSuffix)) {
-				t.Errorf("Expect service %s updated, but got %s", kube.ServiceHostname("svc1", "nsa", controller.domainSuffix), ev.ID)
+			if ev.ID != string(kube.ServiceHostname("svc1", "nsa", controller.opts.DomainSuffix)) {
+				t.Errorf("Expect service %s updated, but got %s",
+					kube.ServiceHostname("svc1", "nsa", controller.opts.DomainSuffix), ev.ID)
 			}
 		})
 	}
@@ -2100,5 +2105,11 @@ func TestKubeEndpointsControllerOnEvent(t *testing.T) {
 				t.Errorf("unexpected error: %v", err)
 			}
 		})
+	}
+}
+
+func clearDiscoverabilityPolicy(ep *model.IstioEndpoint) {
+	if ep != nil {
+		ep.DiscoverabilityPolicy = nil
 	}
 }

--- a/pilot/pkg/serviceregistry/kube/controller/endpoint_builder.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpoint_builder.go
@@ -123,24 +123,26 @@ func augmentLabels(in labels.Instance, clusterID, locality string) labels.Instan
 func (b *EndpointBuilder) buildIstioEndpoint(
 	endpointAddress string,
 	endpointPort int32,
-	svcPortName string) *model.IstioEndpoint {
+	svcPortName string,
+	discoverabilityPolicy model.EndpointDiscoverabilityPolicy) *model.IstioEndpoint {
 	if b == nil {
 		return nil
 	}
 
 	return &model.IstioEndpoint{
-		Labels:          b.labels,
-		ServiceAccount:  b.serviceAccount,
-		Locality:        b.locality,
-		TLSMode:         b.tlsMode,
-		Address:         endpointAddress,
-		EndpointPort:    uint32(endpointPort),
-		ServicePortName: svcPortName,
-		Network:         b.endpointNetwork(endpointAddress),
-		WorkloadName:    b.workloadName,
-		Namespace:       b.namespace,
-		HostName:        b.hostname,
-		SubDomain:       b.subDomain,
+		Labels:                b.labels,
+		ServiceAccount:        b.serviceAccount,
+		Locality:              b.locality,
+		TLSMode:               b.tlsMode,
+		Address:               endpointAddress,
+		EndpointPort:          uint32(endpointPort),
+		ServicePortName:       svcPortName,
+		Network:               b.endpointNetwork(endpointAddress),
+		WorkloadName:          b.workloadName,
+		Namespace:             b.namespace,
+		HostName:              b.hostname,
+		SubDomain:             b.subDomain,
+		DiscoverabilityPolicy: discoverabilityPolicy,
 	}
 }
 

--- a/pilot/pkg/serviceregistry/kube/controller/endpointcontroller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpointcontroller.go
@@ -67,8 +67,8 @@ func processEndpointEvent(c *Controller, epc kubeEndpointsController, name strin
 		if svc, _ := c.serviceLister.Services(namespace).Get(name); svc != nil {
 			// if the service is headless service, trigger a full push.
 			if svc.Spec.ClusterIP == v1.ClusterIPNone {
-				hostname := kube.ServiceHostname(svc.Name, svc.Namespace, c.domainSuffix)
-				c.xdsUpdater.ConfigUpdate(&model.PushRequest{
+				hostname := kube.ServiceHostname(svc.Name, svc.Namespace, c.opts.DomainSuffix)
+				c.opts.XDSUpdater.ConfigUpdate(&model.PushRequest{
 					Full: true,
 					// TODO: extend and set service instance type, so no need to re-init push context
 					ConfigsUpdated: map[model.ConfigKey]struct{}{{
@@ -109,7 +109,7 @@ func updateEDS(c *Controller, epc kubeEndpointsController, ep interface{}, event
 		}
 	}
 
-	c.xdsUpdater.EDSUpdate(c.clusterID, string(host), ns, endpoints)
+	c.opts.XDSUpdater.EDSUpdate(c.Cluster(), string(host), ns, endpoints)
 }
 
 // getPod fetches a pod by name or IP address.
@@ -138,8 +138,8 @@ func (c *Controller) registerEndpointResync(ep *metav1.ObjectMeta, ip string, ho
 	// This might happen because PodCache is eventually consistent.
 	log.Debugf("Endpoint without pod %s %s.%s", ip, ep.Name, ep.Namespace)
 	endpointsWithNoPods.Increment()
-	if c.metrics != nil {
-		c.metrics.AddMetric(model.EndpointNoPod, string(host), "", ip)
+	if c.opts.Metrics != nil {
+		c.opts.Metrics.AddMetric(model.EndpointNoPod, string(host), "", ip)
 	}
 	// Tell pod cache we want to queue the endpoint event when this pod arrives.
 	epkey := kube.KeyFunc(ep.Name, ep.Namespace)

--- a/pilot/pkg/serviceregistry/kube/controller/endpoints.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpoints.go
@@ -18,6 +18,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	klabels "k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	listerv1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 
@@ -63,7 +64,7 @@ func (e *endpointsController) GetProxyServiceInstances(c *Controller, proxy *mod
 func endpointServiceInstances(c *Controller, endpoints *v1.Endpoints, proxy *model.Proxy) []*model.ServiceInstance {
 	out := make([]*model.ServiceInstance, 0)
 
-	hostname := kube.ServiceHostname(endpoints.Name, endpoints.Namespace, c.domainSuffix)
+	hostname := kube.ServiceHostname(endpoints.Name, endpoints.Namespace, c.opts.DomainSuffix)
 	c.RLock()
 	svc := c.servicesMap[hostname]
 	c.RUnlock()
@@ -71,6 +72,8 @@ func endpointServiceInstances(c *Controller, endpoints *v1.Endpoints, proxy *mod
 	if svc != nil {
 		pod := c.pods.getPodByProxy(proxy)
 		builder := NewEndpointBuilder(c, pod)
+
+		discoverabilityPolicy := c.discoverabilityPolicyForService(namespacedNameForService(svc))
 
 		for _, ss := range endpoints.Subsets {
 			for _, port := range ss.Ports {
@@ -82,7 +85,7 @@ func endpointServiceInstances(c *Controller, endpoints *v1.Endpoints, proxy *mod
 				// consider multiple IP scenarios
 				for _, ip := range proxy.IPAddresses {
 					if hasProxyIP(ss.Addresses, ip) || hasProxyIP(ss.NotReadyAddresses, ip) {
-						istioEndpoint := builder.buildIstioEndpoint(ip, port.Port, svcPort.Name)
+						istioEndpoint := builder.buildIstioEndpoint(ip, port.Port, svcPort.Name, discoverabilityPolicy)
 						out = append(out, &model.ServiceInstance{
 							Endpoint:    istioEndpoint,
 							ServicePort: svcPort,
@@ -91,8 +94,8 @@ func endpointServiceInstances(c *Controller, endpoints *v1.Endpoints, proxy *mod
 					}
 
 					if hasProxyIP(ss.NotReadyAddresses, ip) {
-						if c.metrics != nil {
-							c.metrics.AddMetric(model.ProxyStatusEndpointNotReady, proxy.ID, proxy.ID, "")
+						if c.opts.Metrics != nil {
+							c.opts.Metrics.AddMetric(model.ProxyStatusEndpointNotReady, proxy.ID, proxy.ID, "")
 						}
 					}
 				}
@@ -112,6 +115,8 @@ func (e *endpointsController) InstancesByPort(c *Controller, svc *model.Service,
 	if !exists {
 		return nil
 	}
+
+	discoverabilityPolicy := c.discoverabilityPolicyForService(namespacedNameForService(svc))
 
 	// Locate all ports in the actual service
 	svcPort, exists := svc.Ports.GetByPort(reqSvcPort)
@@ -140,7 +145,7 @@ func (e *endpointsController) InstancesByPort(c *Controller, svc *model.Service,
 			for _, port := range ss.Ports {
 				if port.Name == "" || // 'name optional if single port is defined'
 					svcPort.Name == port.Name {
-					istioEndpoint := builder.buildIstioEndpoint(ea.IP, port.Port, svcPort.Name)
+					istioEndpoint := builder.buildIstioEndpoint(ea.IP, port.Port, svcPort.Name, discoverabilityPolicy)
 					out = append(out, &model.ServiceInstance{
 						Endpoint:    istioEndpoint,
 						ServicePort: svcPort,
@@ -189,6 +194,12 @@ func (e *endpointsController) forgetEndpoint(endpoint interface{}) {
 func (e *endpointsController) buildIstioEndpoints(endpoint interface{}, host host.Name) []*model.IstioEndpoint {
 	endpoints := make([]*model.IstioEndpoint, 0)
 	ep := endpoint.(*v1.Endpoints)
+
+	discoverabilityPolicy := e.c.discoverabilityPolicyForService(types.NamespacedName{
+		Namespace: ep.Namespace,
+		Name:      ep.Name,
+	})
+
 	for _, ss := range ep.Subsets {
 		for _, ea := range ss.Addresses {
 			pod, expectedPod := getPod(e.c, ea.IP, &metav1.ObjectMeta{Name: ep.Name, Namespace: ep.Namespace}, ea.TargetRef, host)
@@ -199,7 +210,7 @@ func (e *endpointsController) buildIstioEndpoints(endpoint interface{}, host hos
 
 			// EDS and ServiceEntry use name for service port - ADS will need to map to numbers.
 			for _, port := range ss.Ports {
-				istioEndpoint := builder.buildIstioEndpoint(ea.IP, port.Port, port.Name)
+				istioEndpoint := builder.buildIstioEndpoint(ea.IP, port.Port, port.Name, discoverabilityPolicy)
 				endpoints = append(endpoints, istioEndpoint)
 			}
 		}
@@ -219,7 +230,7 @@ func (e *endpointsController) buildIstioEndpointsWithService(name, namespace str
 
 func (e *endpointsController) getServiceInfo(ep interface{}) (host.Name, string, string) {
 	endpoint := ep.(*v1.Endpoints)
-	return kube.ServiceHostname(endpoint.Name, endpoint.Namespace, e.c.domainSuffix), endpoint.Name, endpoint.Namespace
+	return kube.ServiceHostname(endpoint.Name, endpoint.Namespace, e.c.opts.DomainSuffix), endpoint.Name, endpoint.Namespace
 }
 
 // endpointsEqual returns true if the two endpoints are the same in aspects Pilot cares about

--- a/pilot/pkg/serviceregistry/kube/controller/fake.go
+++ b/pilot/pkg/serviceregistry/kube/controller/fake.go
@@ -86,7 +86,13 @@ func (fx *FakeXdsUpdater) EDSUpdate(_, hostname string, _ string, entry []*model
 	}
 }
 
-func (fx *FakeXdsUpdater) EDSCacheUpdate(_, _, _ string, entry []*model.IstioEndpoint) {
+func (fx *FakeXdsUpdater) EDSCacheUpdate(_, hostname, _ string, entry []*model.IstioEndpoint) {
+	if len(entry) > 0 {
+		select {
+		case fx.Events <- FakeXdsEvent{Type: "eds cache", ID: hostname, Endpoints: entry}:
+		default:
+		}
+	}
 }
 
 // SvcUpdate is called when a service port mapping definition is updated.
@@ -137,6 +143,7 @@ type FakeControllerOptions struct {
 	DomainSuffix              string
 	XDSUpdater                model.XDSUpdater
 	DiscoveryNamespacesFilter filter.DiscoveryNamespacesFilter
+	EnableMCSServiceDiscovery bool
 
 	// when calling from NewFakeDiscoveryServer, we wait for the aggregate cache to sync. Waiting here can cause deadlock.
 	SkipCacheSyncWait bool
@@ -174,6 +181,7 @@ func NewFakeControllerWithOptions(opts FakeControllerOptions) (*FakeController, 
 		ClusterID:                 opts.ClusterID,
 		SyncInterval:              time.Microsecond,
 		DiscoveryNamespacesFilter: opts.DiscoveryNamespacesFilter,
+		EnableMCSServiceDiscovery: opts.EnableMCSServiceDiscovery,
 	}
 	c := NewController(opts.Client, options)
 	if opts.ServiceHandler != nil {

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -262,7 +262,7 @@ func (m *Multicluster) AddMemberCluster(clusterID string, rc *secretcontroller.C
 
 	// setting up the serviceexport controller if and only if it is turned on in the meshconfig.
 	// TODO(nmittler): Need a better solution. Leader election doesn't take into account locality.
-	if features.EnableMCSServiceExport {
+	if features.EnableMCSAutoExport {
 		log.Infof("joining leader-election for %s in %s on cluster %s",
 			leaderelection.ServiceExportController, options.SystemNamespace, options.ClusterID)
 		// Block server exit on graceful termination of the leader controller.

--- a/pilot/pkg/serviceregistry/kube/controller/pod.go
+++ b/pilot/pkg/serviceregistry/kube/controller/pod.go
@@ -168,7 +168,7 @@ func (pc *PodCache) onEvent(curr interface{}, ev model.Event) error {
 		}
 		// fire instance handles for workload
 		for _, handler := range pc.c.workloadHandlers {
-			ep := NewEndpointBuilder(pc.c, pod).buildIstioEndpoint(ip, 0, "")
+			ep := NewEndpointBuilder(pc.c, pod).buildIstioEndpoint(ip, 0, "", model.AlwaysDiscoverable)
 			handler(&model.WorkloadInstance{
 				Name:      pod.Name,
 				Namespace: pod.Namespace,
@@ -246,8 +246,8 @@ func (pc *PodCache) endpointDeleted(key string, ip string) {
 }
 
 func (pc *PodCache) proxyUpdates(ip string) {
-	if pc.c != nil && pc.c.xdsUpdater != nil {
-		pc.c.xdsUpdater.ProxyUpdate(pc.c.clusterID, ip)
+	if pc.c != nil && pc.c.opts.XDSUpdater != nil {
+		pc.c.opts.XDSUpdater.ProxyUpdate(pc.c.Cluster(), ip)
 	}
 }
 

--- a/pilot/pkg/serviceregistry/kube/controller/serviceexportcache.go
+++ b/pilot/pkg/serviceregistry/kube/controller/serviceexportcache.go
@@ -1,0 +1,123 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/cache"
+	mcsCore "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
+	mcsLister "sigs.k8s.io/mcs-api/pkg/client/listers/apis/v1alpha1"
+
+	"istio.io/istio/pilot/pkg/model"
+	kubesr "istio.io/istio/pilot/pkg/serviceregistry/kube"
+	"istio.io/istio/pkg/config/host"
+)
+
+// serviceExportCache provides export state for all services in the cluster.
+type serviceExportCache interface {
+	isExported(name types.NamespacedName) bool
+	HasSynced() bool
+}
+
+// newServiceExportCache creates a new serviceExportCache that observes the given cluster.
+func newServiceExportCache(c *Controller) serviceExportCache {
+	if c.opts.EnableMCSServiceDiscovery {
+		informer := c.client.MCSApisInformer().Multicluster().V1alpha1().ServiceExports().Informer()
+		sec := &serviceExportCacheImpl{
+			Controller: c,
+			informer:   informer,
+			lister:     mcsLister.NewServiceExportLister(informer.GetIndexer()),
+		}
+
+		// Register callbacks for ServiceImport events.
+		c.registerHandlers(informer, "ServiceExports", sec.onEvent, nil)
+		return sec
+	}
+
+	// MCS Service discovery is disabled. Use a placeholder cache.
+	return disabledServiceExportCache{}
+}
+
+// serviceExportCache reads ServiceExport resources for a single cluster.
+type serviceExportCacheImpl struct {
+	*Controller
+	informer cache.SharedIndexInformer
+	lister   mcsLister.ServiceExportLister
+}
+
+func (ec *serviceExportCacheImpl) onEvent(obj interface{}, event model.Event) error {
+	se, ok := obj.(*mcsCore.ServiceExport)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			return fmt.Errorf("couldn't get object from tombstone %#v", obj)
+		}
+		se, ok = tombstone.Obj.(*mcsCore.ServiceExport)
+		if !ok {
+			return fmt.Errorf("tombstone contained object that is not a ServiceExport %#v", obj)
+		}
+	}
+
+	switch event {
+	case model.EventAdd, model.EventDelete:
+		ec.updateXDS(se)
+	default:
+		// Don't care about updates.
+	}
+	return nil
+}
+
+func (ec *serviceExportCacheImpl) updateXDS(se *mcsCore.ServiceExport) {
+	hostname := ec.getHostname(se)
+	svc, err := ec.GetService(hostname)
+	if err != nil {
+		// The service doesn't exist - nothing to update.
+		return
+	}
+
+	// Update the endpoint cache for this cluster and push an update.
+	endpoints := ec.buildEndpointsForService(svc)
+	if len(endpoints) > 0 {
+		ec.opts.XDSUpdater.EDSUpdate(ec.Cluster(), string(hostname), se.Namespace, endpoints)
+	}
+}
+
+func (ec *serviceExportCacheImpl) isExported(name types.NamespacedName) bool {
+	_, err := ec.lister.ServiceExports(name.Namespace).Get(name.Name)
+	return err == nil
+}
+
+func (ec *serviceExportCacheImpl) HasSynced() bool {
+	return ec.informer.HasSynced()
+}
+
+func (ec *serviceExportCacheImpl) getHostname(se *mcsCore.ServiceExport) host.Name {
+	return kubesr.ServiceHostname(se.Name, se.Namespace, ec.opts.DomainSuffix)
+}
+
+type disabledServiceExportCache struct{}
+
+var _ serviceExportCache = disabledServiceExportCache{}
+
+func (c disabledServiceExportCache) isExported(types.NamespacedName) bool {
+	// When disabled, assume all services are exported (default Istio behavior).
+	return true
+}
+
+func (c disabledServiceExportCache) HasSynced() bool {
+	return true
+}

--- a/pilot/pkg/serviceregistry/kube/controller/serviceexportcache_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/serviceexportcache_test.go
@@ -1,0 +1,240 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
+
+	"istio.io/api/label"
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/test/util/retry"
+)
+
+const (
+	serviceExportName      = "test-svc"
+	serviceExportNamespace = "test-ns"
+	serviceExportPodIP     = "128.0.0.2"
+)
+
+var serviceExportNamespacedName = types.NamespacedName{
+	Namespace: serviceExportNamespace,
+	Name:      serviceExportName,
+}
+
+func TestServiceNotExported(t *testing.T) {
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	// Create and run the controller.
+	ec := newTestServiceExportCache(t, stopCh)
+
+	// Check that the endpoint is cluster-local
+	ec.checkServiceInstances(t, false)
+}
+
+func TestServiceExported(t *testing.T) {
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	// Create and run the controller.
+	ec := newTestServiceExportCache(t, stopCh)
+
+	// Export the service.
+	ec.export(t)
+
+	// Check that the endpoint is mesh-wide
+	ec.checkServiceInstances(t, true)
+}
+
+func TestServiceUnexported(t *testing.T) {
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	// Create and run the controller.
+	ec := newTestServiceExportCache(t, stopCh)
+
+	// Export the service and then unexport it immediately.
+	ec.export(t)
+	ec.unExport(t)
+
+	// Check that the endpoint is cluster-local
+	ec.checkServiceInstances(t, false)
+}
+
+func newServiceExport() *v1alpha1.ServiceExport {
+	return &v1alpha1.ServiceExport{
+		TypeMeta: v12.TypeMeta{
+			Kind:       "ServiceExport",
+			APIVersion: "multicluster.x-k8s.io/v1alpha1",
+		},
+		ObjectMeta: v12.ObjectMeta{
+			Name:      serviceExportName,
+			Namespace: serviceExportNamespace,
+		},
+	}
+}
+
+func newTestServiceExportCache(t *testing.T, stopCh chan struct{}) *serviceExportCacheImpl {
+	t.Helper()
+	c, _ := NewFakeControllerWithOptions(FakeControllerOptions{
+		EnableMCSServiceDiscovery: true,
+		Stop:                      stopCh,
+	})
+
+	// Create the test service and endpoints.
+	createService(c, serviceExportName, serviceExportNamespace, map[string]string{},
+		[]int32{8080}, map[string]string{"app": "prod-app"}, t)
+	createEndpoints(c, serviceExportName, serviceExportNamespace, []string{"tcp-port"}, []string{"128.0.0.2"}, nil, t)
+
+	ec := c.exports.(*serviceExportCacheImpl)
+
+	// Wait for the resources to be processed by the controller.
+	retry.UntilOrFail(t, func() bool {
+		inst := ec.getProxyServiceInstances()
+		return len(inst) == 1 && inst[0].Service != nil && inst[0].Endpoint != nil
+	}, retry.Timeout(2*time.Second))
+
+	return ec
+}
+
+func (ec *serviceExportCacheImpl) export(t *testing.T) {
+	t.Helper()
+
+	_, _ = ec.client.MCSApis().MulticlusterV1alpha1().ServiceExports(serviceExportNamespace).Create(
+		context.TODO(),
+		newServiceExport(),
+		v12.CreateOptions{})
+
+	// Wait for the export to be processed by the controller.
+	retry.UntilOrFail(t, func() bool {
+		return ec.isExported(serviceExportNamespacedName)
+	}, retry.Timeout(2*time.Second))
+
+	// Wait for the XDS event.
+	ec.waitForXDS(t, true)
+}
+
+func (ec *serviceExportCacheImpl) unExport(t *testing.T) {
+	t.Helper()
+
+	_ = ec.client.MCSApis().MulticlusterV1alpha1().ServiceExports(serviceExportNamespace).Delete(
+		context.TODO(),
+		serviceExportName,
+		v12.DeleteOptions{})
+
+	// Wait for the delete to be processed by the controller.
+	retry.UntilOrFail(t, func() bool {
+		return !ec.isExported(serviceExportNamespacedName)
+	}, retry.Timeout(2*time.Second))
+
+	// Wait for the XDS event.
+	ec.waitForXDS(t, false)
+}
+
+func (ec *serviceExportCacheImpl) waitForXDS(t *testing.T, expectMeshWide bool) {
+	t.Helper()
+	retry.UntilSuccessOrFail(t, func() error {
+		event := ec.opts.XDSUpdater.(*FakeXdsUpdater).Wait("eds")
+		if event == nil {
+			return errors.New("failed waiting for XDS event")
+		}
+		if len(event.Endpoints) != 1 {
+			return fmt.Errorf("waitForXDS failed: expected 1 endpoint, but found %v", event.Endpoints)
+		}
+		ep := event.Endpoints[0]
+		return ec.expectDiscoverable(ep, expectMeshWide)
+	}, retry.Timeout(2*time.Second))
+}
+
+func (ec *serviceExportCacheImpl) expectNotExported(t *testing.T) {
+	t.Helper()
+	if ec.isExported(serviceExportNamespacedName) {
+		t.Fatalf("endpoint was unexpectedly discoverable from proxy")
+	}
+}
+
+func (ec *serviceExportCacheImpl) expectExported(t *testing.T) {
+	t.Helper()
+	if !ec.isExported(serviceExportNamespacedName) {
+		t.Fatalf("endpoint was not discoverable from proxy")
+	}
+}
+
+func (ec *serviceExportCacheImpl) getProxyServiceInstances() []*model.ServiceInstance {
+	return ec.GetProxyServiceInstances(&model.Proxy{
+		Type:            model.SidecarProxy,
+		IPAddresses:     []string{serviceExportPodIP},
+		Locality:        &core.Locality{Region: "r", Zone: "z"},
+		ConfigNamespace: serviceExportNamespace,
+		Metadata: &model.NodeMetadata{
+			ServiceAccount: "account",
+			ClusterID:      ec.Cluster(),
+			Labels: map[string]string{
+				"app":                      "prod-app",
+				label.SecurityTlsMode.Name: "mutual",
+			},
+		},
+	})
+}
+
+func (ec *serviceExportCacheImpl) checkServiceInstances(t *testing.T, meshWide bool) {
+	t.Helper()
+	inst := ec.getProxyServiceInstances()
+	if len(inst) != 1 {
+		t.Fatalf("expected 1 ServiceInstance, found %d", len(inst))
+	}
+	ep := inst[0].Endpoint
+	if err := ec.expectDiscoverable(ep, meshWide); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func (ec *serviceExportCacheImpl) expectDiscoverable(ep *model.IstioEndpoint, expectMeshWide bool) error {
+	// All endpoints should be discoverable from within the same cluster.
+	if !ep.IsDiscoverableFromProxy(&model.Proxy{
+		Metadata: &model.NodeMetadata{
+			ClusterID: ec.Cluster(),
+		},
+	}) {
+		return fmt.Errorf("endpoint was not discoverable in the same cluster")
+	}
+
+	// Check if this endpoint is discoverable from another cluster.
+	meshWide := ep.IsDiscoverableFromProxy(&model.Proxy{
+		Metadata: &model.NodeMetadata{
+			ClusterID: "some-other-cluster",
+		},
+	})
+
+	if expectMeshWide {
+		if !meshWide {
+			return fmt.Errorf("endpoint was not discoverable mesh-wide")
+		}
+	} else {
+		if meshWide {
+			return fmt.Errorf("endpoint was discoverable mesh-wide")
+		}
+	}
+	return nil
+}

--- a/pilot/pkg/serviceregistry/kube/controller/util.go
+++ b/pilot/pkg/serviceregistry/kube/controller/util.go
@@ -22,6 +22,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	klabels "k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	listerv1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
@@ -214,4 +215,11 @@ func convertToService(obj interface{}) (*v1.Service, error) {
 		}
 	}
 	return cm, nil
+}
+
+func namespacedNameForService(svc *model.Service) types.NamespacedName {
+	return types.NamespacedName{
+		Namespace: svc.Attributes.Namespace,
+		Name:      svc.Attributes.Name,
+	}
 }

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -460,6 +460,7 @@ func (c *client) RunAndWait(stop <-chan struct{}) {
 	c.metadataInformer.Start(stop)
 	c.istioInformer.Start(stop)
 	c.gatewayapiInformer.Start(stop)
+	c.mcsapisInformers.Start(stop)
 	if c.fastSync {
 		// WaitForCacheSync will virtually never be synced on the first call, as its called immediately after Start()
 		// This triggers a 100ms delay per call, which is often called 2-3 times in a test, delaying tests.
@@ -469,6 +470,7 @@ func (c *client) RunAndWait(stop <-chan struct{}) {
 		fastWaitForCacheSyncDynamic(stop, c.metadataInformer)
 		fastWaitForCacheSync(stop, c.istioInformer)
 		fastWaitForCacheSync(stop, c.gatewayapiInformer)
+		fastWaitForCacheSync(stop, c.mcsapisInformers)
 		_ = wait.PollImmediate(time.Microsecond*100, wait.ForeverTestTimeout, func() (bool, error) {
 			select {
 			case <-stop:
@@ -486,6 +488,7 @@ func (c *client) RunAndWait(stop <-chan struct{}) {
 		c.metadataInformer.WaitForCacheSync(stop)
 		c.istioInformer.WaitForCacheSync(stop)
 		c.gatewayapiInformer.WaitForCacheSync(stop)
+		c.mcsapisInformers.WaitForCacheSync(stop)
 	}
 }
 

--- a/pkg/test/echo/server/instance.go
+++ b/pkg/test/echo/server/instance.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strings"
 	"sync"
 	"sync/atomic"
 
@@ -48,6 +49,22 @@ type Config struct {
 	IstioVersion          string
 }
 
+func (c Config) String() string {
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("Ports:                 %v\n", c.Ports))
+	b.WriteString(fmt.Sprintf("BindIPPortsMap:        %v\n", c.BindIPPortsMap))
+	b.WriteString(fmt.Sprintf("BindLocalhostPortsMap: %v\n", c.BindLocalhostPortsMap))
+	b.WriteString(fmt.Sprintf("Metrics:               %v\n", c.Metrics))
+	b.WriteString(fmt.Sprintf("TLSCert:               %v\n", c.TLSCert))
+	b.WriteString(fmt.Sprintf("TLSKey:                %v\n", c.TLSKey))
+	b.WriteString(fmt.Sprintf("Version:               %v\n", c.Version))
+	b.WriteString(fmt.Sprintf("UDSServer:             %v\n", c.UDSServer))
+	b.WriteString(fmt.Sprintf("Cluster:               %v\n", c.Cluster))
+	b.WriteString(fmt.Sprintf("IstioVersion:          %v\n", c.IstioVersion))
+
+	return b.String()
+}
+
 var _ io.Closer = &Instance{}
 
 // Instance of the Echo server.
@@ -61,6 +78,7 @@ type Instance struct {
 
 // New creates a new server instance.
 func New(config Config) *Instance {
+	log.Infof("Creating Server with config:\n%s", config)
 	config.Dialer = config.Dialer.FillInDefaults()
 
 	return &Instance{

--- a/pkg/test/framework/components/echo/kube/instance.go
+++ b/pkg/test/framework/components/echo/kube/instance.go
@@ -219,7 +219,10 @@ func (c *instance) aggregateResponses(opts echo.CallOptions, retry bool, retryOp
 	}
 	aggErr := istiomultierror.New()
 	for _, w := range workloads {
-		out, err := common.ForwardEcho(c.cfg.Service, w.(*workload).Client, &opts, retry, retryOptions...)
+		clusterName := w.(*workload).cluster.Name()
+		serviceName := fmt.Sprintf("%s (cluster=%s)", c.cfg.Service, clusterName)
+
+		out, err := common.ForwardEcho(serviceName, w.(*workload).Client, &opts, retry, retryOptions...)
 		if err != nil {
 			aggErr = multierror.Append(aggErr, err)
 			continue

--- a/pkg/test/framework/components/environment/kube/flags.go
+++ b/pkg/test/framework/components/environment/kube/flags.go
@@ -166,7 +166,7 @@ func parseClusterTopology(topology string) (clusterTopology, error) {
 	}
 	out := make(clusterTopology)
 
-	values := strings.Split(configTopology, ",")
+	values := strings.Split(topology, ",")
 	for _, v := range values {
 		parts := strings.Split(v, ":")
 		if len(parts) != 2 {

--- a/pkg/test/framework/features/features.yaml
+++ b/pkg/test/framework/features/features.yaml
@@ -49,7 +49,8 @@ features:
       envoy:
     original-source-ip:
     mcs:
-      serviceexport:
+      autoexport:
+      servicediscovery:
   usability:
     observability:
       describe:

--- a/releasenotes/notes/mcs-service-discovery.yaml
+++ b/releasenotes/notes/mcs-service-discovery.yaml
@@ -1,0 +1,15 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+issue:
+  - 29384
+releaseNotes:
+  - |
+    **Added** experimental support for controlling service endpoint discoverability with Kubernetes Multi-Cluster
+    Services (MCS). This feature is off by default, but can be enabled by setting the
+    `ENABLE_MCS_SERVICE_DISCOVERY` flag in Istio. When enabled, Istio will make service endpoints
+    only discoverable from within the same cluster by default. To make the service endpoints within a cluster
+    discoverable throughout the mesh, a `ServiceExport` CR must be created within the same cluster as the service
+    endpoints. this process can be automated by enabling the Istio flag `ENABLE_MCS_AUTOEXPORT`. With this enabled,
+    Istio will automatically create `ServiceExport` in all clusters for each service.
+

--- a/tests/integration/pilot/mcs/autoexport/autoexport_test.go
+++ b/tests/integration/pilot/mcs/autoexport/autoexport_test.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package mcs
+package autoexport
 
 import (
 	"context"
@@ -53,7 +53,7 @@ func TestMain(m *testing.M) {
 		Label(label.CustomSetup).
 		RequireMinVersion(17).
 		Setup(func(ctx resource.Context) error {
-			crd, err := ioutil.ReadFile("../testdata/mcs-serviceexport-crd.yaml")
+			crd, err := ioutil.ReadFile("../../testdata/mcs-serviceexport-crd.yaml")
 			if err != nil {
 				return err
 			}
@@ -64,7 +64,7 @@ func TestMain(m *testing.M) {
 values:
   pilot:
     env:
-      PILOT_ENABLE_MCS_SERVICEEXPORT: "true"`
+      ENABLE_MCS_AUTOEXPORT: "true"`
 		})).
 		Setup(func(ctx resource.Context) error {
 			// Create a new namespace in each cluster.
@@ -90,9 +90,9 @@ values:
 		Run()
 }
 
-func TestServiceExports(t *testing.T) {
+func TestAutoExport(t *testing.T) {
 	framework.NewTest(t).
-		Features("traffic.mcs.serviceexport").
+		Features("traffic.mcs.autoexport").
 		RequiresSingleCluster().
 		Run(func(ctx framework.TestContext) {
 			// Verify that ServiceExport is created automatically for services.

--- a/tests/integration/pilot/mcs/discoverability/discoverability_test.go
+++ b/tests/integration/pilot/mcs/discoverability/discoverability_test.go
@@ -1,0 +1,268 @@
+// +build integ
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package discoverability
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"sync"
+	"testing"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
+
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/cluster"
+	"istio.io/istio/pkg/test/framework/components/echo"
+	"istio.io/istio/pkg/test/framework/components/echo/common"
+	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
+	"istio.io/istio/pkg/test/framework/components/echo/echotest"
+	"istio.io/istio/pkg/test/framework/components/istio"
+	"istio.io/istio/pkg/test/framework/components/namespace"
+	"istio.io/istio/pkg/test/framework/label"
+	"istio.io/istio/pkg/test/framework/resource"
+	"istio.io/istio/pkg/test/scopes"
+	"istio.io/istio/pkg/test/util/retry"
+)
+
+const (
+	serviceA = "svc-a"
+	serviceB = "svc-b"
+)
+
+var (
+	i      istio.Instance
+	testNS string
+	echos  echo.Instances
+
+	retryTimeout = retry.Timeout(1 * time.Minute)
+)
+
+func TestMain(m *testing.M) {
+	framework.
+		NewSuite(m).
+		Label(label.CustomSetup).
+		RequireMinVersion(17).
+		RequireMinClusters(2).
+		Setup(installServiceExportCRD).
+		Setup(istio.Setup(&i, enableMCSServiceDiscovery)).
+		Setup(deployEchos).
+		Run()
+}
+
+func TestClusterLocal(t *testing.T) {
+	framework.NewTest(t).
+		Features("traffic.mcs.servicediscovery").
+		Run(func(t framework.TestContext) {
+			// Don't export service B in any cluster. All requests should stay in-cluster.
+
+			sendTrafficBetweenAllClusters(t, func(t framework.TestContext, src echo.Instance, dst echo.Instances) {
+				// Ensure that all requests stay in the same cluster
+				expectedClusters := cluster.Clusters{src.Config().Cluster}
+				checkClustersReached(t, src, dst[0], expectedClusters)
+			})
+		})
+}
+
+func TestMeshWide(t *testing.T) {
+	framework.NewTest(t).
+		Features("traffic.mcs.servicediscovery").
+		Run(func(t framework.TestContext) {
+			// Export service B in all clusters.
+			createAndCleanupServiceExport(t, serviceB, t.Clusters())
+
+			sendTrafficBetweenAllClusters(t, func(t framework.TestContext, src echo.Instance, dst echo.Instances) {
+				// Ensure that all destination clusters are reached.
+				expectedClusters := dst.Clusters()
+				checkClustersReached(t, src, dst[0], expectedClusters)
+			})
+		})
+}
+
+func TestServiceExportedInOneCluster(t *testing.T) {
+	framework.NewTest(t).
+		Features("traffic.mcs.servicediscovery").
+		Run(func(t framework.TestContext) {
+			// Get all the clusters where service B resides.
+			bClusters := echos.Match(echo.Service(serviceB)).Clusters()
+
+			// Test exporting service B exclusively in each cluster.
+			for _, exportCluster := range bClusters {
+				exportCluster := exportCluster
+				t.NewSubTestf("b exported in %s", exportCluster.StableName()).
+					Run(func(t framework.TestContext) {
+						// Export service B in the export cluster.
+						createAndCleanupServiceExport(t, serviceB, cluster.Clusters{exportCluster})
+
+						sendTrafficBetweenAllClusters(t, func(t framework.TestContext, src echo.Instance, dst echo.Instances) {
+							// Since we're exporting only the endpoints in the exportCluster, depending
+							// on where we call service B from, we'll reach a different set of endpoints.
+							// If we're calling from exportCluster, it will be the same as cluster-local
+							// (i.e. we'll only reach endpoints in exportCluster). From all other clusters,
+							// we should reach endpoints in that cluster AND exportCluster.
+							expectedClusters := cluster.Clusters{exportCluster}
+							if src.Config().Cluster.Name() != exportCluster.Name() {
+								expectedClusters = append(expectedClusters, src.Config().Cluster)
+							}
+							checkClustersReached(t, src, dst[0], expectedClusters)
+						})
+					})
+			}
+		})
+}
+
+func installServiceExportCRD(t resource.Context) error {
+	crd, err := ioutil.ReadFile("../../testdata/mcs-serviceexport-crd.yaml")
+	if err != nil {
+		return err
+	}
+	return t.Config().ApplyYAMLNoCleanup("", string(crd))
+}
+
+func enableMCSServiceDiscovery(_ resource.Context, cfg *istio.Config) {
+	cfg.ControlPlaneValues = `
+values:
+  pilot:
+    env:
+      ENABLE_MCS_SERVICE_DISCOVERY: "true"`
+}
+
+func deployEchos(t resource.Context) error {
+	// Create a new namespace in each cluster.
+	ns, err := namespace.New(t, namespace.Config{
+		Prefix: "mcs",
+		Inject: true,
+	})
+	if err != nil {
+		return err
+	}
+	testNS = ns.Name()
+
+	// TODO(https://github.com/istio/istio/issues/33526)
+	// To avoid a multi-network bug with MCS, we'll only deploy our workloads on the same network
+	clusters := findClustersOnTheSameNetwork(t)
+
+	// Create echo instances in each cluster.
+	echos, err = echoboot.NewBuilder(t).
+		WithClusters(clusters...).
+		WithConfig(echo.Config{
+			Service:   serviceA,
+			Namespace: ns,
+			Ports:     common.EchoPorts,
+		}).
+		WithConfig(echo.Config{
+			Service:   serviceB,
+			Namespace: ns,
+			Ports:     common.EchoPorts,
+		}).Build()
+	return err
+}
+
+func findClustersOnTheSameNetwork(t resource.Context) cluster.Clusters {
+	networkMap := t.Clusters().ByNetwork()
+	var out cluster.Clusters
+	// Pick the network with the most clusters.
+	for _, clusters := range networkMap {
+		if len(clusters) > len(out) {
+			out = clusters
+		}
+	}
+	return out
+}
+
+func sendTrafficBetweenAllClusters(
+	t framework.TestContext,
+	fn func(t framework.TestContext, src echo.Instance, dst echo.Instances)) {
+	t.Helper()
+	echotest.New(t, echos).
+		WithDefaultFilters().
+		From(echotest.FilterMatch(echo.Service(serviceA))).
+		To(echotest.FilterMatch(echo.Service(serviceB))).
+		Run(fn)
+}
+
+func newServiceExport(service string) *v1alpha1.ServiceExport {
+	return &v1alpha1.ServiceExport{
+		TypeMeta: v12.TypeMeta{
+			Kind:       "ServiceExport",
+			APIVersion: "multicluster.x-k8s.io/v1alpha1",
+		},
+		ObjectMeta: v12.ObjectMeta{
+			Name:      service,
+			Namespace: testNS,
+		},
+	}
+}
+
+func checkClustersReached(t framework.TestContext, src, dest echo.Instance, clusters cluster.Clusters) {
+	t.Helper()
+	src.CallWithRetryOrFail(t, echo.CallOptions{
+		Target:    dest,
+		Count:     50,
+		PortName:  "http",
+		Validator: echo.And(echo.ExpectOK(), echo.ExpectReachedClusters(clusters)),
+	}, retryTimeout)
+}
+
+func createAndCleanupServiceExport(t framework.TestContext, service string, clusters cluster.Clusters) {
+	t.Helper()
+	serviceExport := newServiceExport(service)
+
+	// Create the ServiceExports in each cluster concurrently.
+	g := errgroup.Group{}
+	for _, c := range clusters {
+		c := c
+		g.Go(func() error {
+			_, err := c.MCSApis().MulticlusterV1alpha1().ServiceExports(testNS).Create(context.TODO(),
+				serviceExport, v12.CreateOptions{})
+			if err != nil {
+				return fmt.Errorf("failed creating ServiceExport %s/%s in cluster %s: %v",
+					testNS, serviceB, c.Name(), err)
+			}
+
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Add a cleanup that will delete the ServiceExports in each cluster concurrently.
+	t.Cleanup(func() {
+		wg := sync.WaitGroup{}
+		for _, c := range clusters {
+			c := c
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+
+				err := c.MCSApis().MulticlusterV1alpha1().ServiceExports(testNS).Delete(context.TODO(),
+					serviceExport.Name, v12.DeleteOptions{})
+				if err != nil {
+					scopes.Framework.Warnf("failed deleting ServiceExport %s/%s in cluster %s: %v",
+						testNS, serviceB, c.Name(), err)
+					return
+				}
+			}()
+		}
+
+		wg.Wait()
+	})
+}


### PR DESCRIPTION
This introduces a ClusterSet structure that stores cluster names
and their associated kube clients. The Multicluster object
adds/removes clusters to the ClusterSet.

The new mcs.DiscoverabilityController observes the ClusterSet events.
When a cluster is added, the controller will observe ServiceExport
events on that cluster.

Fixes #29384

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.