### PR TITLE
Fix local address for ipv6 probes

### DIFF
--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -66,7 +66,7 @@ const (
 
 var (
 	UpstreamLocalAddressIPv4 = &net.TCPAddr{IP: net.ParseIP("127.0.0.6")}
-	UpstreamLocalAddressIPv6 = &net.TCPAddr{IP: net.ParseIP("[::6]")}
+	UpstreamLocalAddressIPv6 = &net.TCPAddr{IP: net.ParseIP("::6")}
 )
 
 var PrometheusScrapingConfig = env.RegisterStringVar("ISTIO_PROMETHEUS_ANNOTATIONS", "", "")


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/32760

What happens:
* IP silently parses wrong, causing us to use default LocalAddr
* Without ::6 address, our requests go through iptables
* In the test, we set mTLS strict mode. This causes health check
failures. If the test does not complete before the failureThreshold is
reached, the test fails since the pods are "not ready"
