### PR TITLE
Fix broken release notes in 1.10 only

### DIFF
--- a/releasenotes/notes/19300.yaml
+++ b/releasenotes/notes/19300.yaml
@@ -1,6 +1,6 @@
 apiVersion: release-notes/v2
 kind: feature
-area: cni
+area: traffic-management
 issue:
   - 19300
 

--- a/releasenotes/notes/30067.yaml
+++ b/releasenotes/notes/30067.yaml
@@ -1,6 +1,6 @@
 apiVersion: release-notes/v2
 kind: bug-fix
-area: networking
+area: traffic-management
 issue:
 - 30067
 releaseNotes:

--- a/releasenotes/notes/30683.yaml
+++ b/releasenotes/notes/30683.yaml
@@ -1,6 +1,6 @@
 apiVersion: release-notes/v2
 kind: bug-fix
-area: networking
+area: traffic-management
 issue:
   - 30683
 releaseNotes:

--- a/releasenotes/notes/31075.yaml
+++ b/releasenotes/notes/31075.yaml
@@ -1,6 +1,6 @@
 apiVersion: release-notes/v2
 kind: feature
-area: networking
+area: traffic-management
 issue:
   - 31075
 releaseNotes:

--- a/releasenotes/notes/31186.yaml
+++ b/releasenotes/notes/31186.yaml
@@ -1,6 +1,6 @@
 apiVersion: release-notes/v2
 kind: bug-fix
-area: environments
+area: istioctl
 issue:
   - 31186
 releaseNotes:

--- a/releasenotes/notes/31403.yaml
+++ b/releasenotes/notes/31403.yaml
@@ -1,9 +1,9 @@
 apiVersion: release-notes/v2
 kind: feature
-area: networking
+area: traffic-management
 issue:
   - 31403
 
 releaseNotes:
 - |
-  **Updated** istio-proxy drain notification strategy to immediate from gradual. 
+  **Updated** istio-proxy drain notification strategy to immediate from gradual.

--- a/releasenotes/notes/31573.yaml
+++ b/releasenotes/notes/31573.yaml
@@ -1,6 +1,6 @@
 apiVersion: release-notes/v2
 kind: bug-fix
-area: EnvoyFilter
+area: traffic-management
 issue:
   - 31573
 releaseNotes:

--- a/releasenotes/notes/31779.yaml
+++ b/releasenotes/notes/31779.yaml
@@ -1,6 +1,6 @@
 apiVersion: release-notes/v2
 kind: feature
-area: network
+area: traffic-management
 issue:
   - 31779
 releaseNotes:

--- a/releasenotes/notes/31797.yaml
+++ b/releasenotes/notes/31797.yaml
@@ -1,6 +1,6 @@
 apiVersion: release-notes/v2
-kind: enhancement
-area: environments
+kind: feature
+area: installation
 issue:
 - 31732
 releaseNotes:

--- a/releasenotes/notes/31853.yaml
+++ b/releasenotes/notes/31853.yaml
@@ -1,7 +1,6 @@
 apiVersion: release-notes/v2
 kind: feature
-area: networking
-issue:
+area: traffic-management
 releaseNotes:
 - |
   **Added** metrics for istiod informer errors.

--- a/releasenotes/notes/auto-mtls-passthrough.yaml
+++ b/releasenotes/notes/auto-mtls-passthrough.yaml
@@ -1,6 +1,6 @@
 apiVersion: release-notes/v2
 kind: bug-fix
-area: networking
+area: traffic-management
 issue:
 - 23494
 releaseNotes:

--- a/releasenotes/notes/inbound-passthrough.yaml
+++ b/releasenotes/notes/inbound-passthrough.yaml
@@ -1,6 +1,6 @@
 apiVersion: release-notes/v2
 kind: bug-fix
-area: networking
+area: traffic-management
 issue:
 - 29940
 upgradeNotes:

--- a/releasenotes/notes/inbound-patch.yaml
+++ b/releasenotes/notes/inbound-patch.yaml
@@ -1,6 +1,6 @@
 apiVersion: release-notes/v2
-kind: bug-fix 
-area: networking
+kind: bug-fix
+area: traffic-management
 releaseNotes:
 - |
   **Fixed** a bug where Envoy filter with service match is not working for inbound clusters.

--- a/releasenotes/notes/pilot-discovery-scoped-namespaces.yaml
+++ b/releasenotes/notes/pilot-discovery-scoped-namespaces.yaml
@@ -13,14 +13,3 @@ releaseNotes:
 - |
   **Added** Specify `meshConfig.discoverySelectors` to dynamically restrict the set of namespaces for Services, Pods, and Endpoints that istiod processes when pushing xDS updates to improve performance on the data plane.
 
-# upgradeNotes is a markdown listing of any changes that will affect the upgrade
-# process. This will appear in the release notes.
-upgradeNotes:
-
-# docs is a list of related docs to the change.
-docs:
-
-
-# securityNotes is a markdown listing of any changes related to the security of
-# Istio.
-securityNotes:

--- a/releasenotes/notes/revision-tag-command.yaml
+++ b/releasenotes/notes/revision-tag-command.yaml
@@ -1,7 +1,6 @@
 apiVersion: release-notes/v2
 kind: feature
 area: installation
-issue:
 releaseNotes:
   - |
     **Added** `istioctl experimental revision tag` command group. Revision tags act as aliases for

--- a/releasenotes/notes/scope-push-by-sidecar-changes.yaml
+++ b/releasenotes/notes/scope-push-by-sidecar-changes.yaml
@@ -1,6 +1,6 @@
 apiVersion: release-notes/v2
 kind: feature
-area: networking
+area: traffic-management
 releaseNotes:
 - |
   **Improved** the full push scoping by adding `Sidecar` config to sidecarScopeKnownConfigTypes.

--- a/releasenotes/notes/vm-cleanup-iptables.yaml
+++ b/releasenotes/notes/vm-cleanup-iptables.yaml
@@ -1,6 +1,6 @@
 apiVersion: release-notes/v2
 kind: bug-fix
-area: networking
+area: traffic-management
 issue:
 - 29556
 releaseNotes:

--- a/releasenotes/notes/vs-ineffective-warning.yaml
+++ b/releasenotes/notes/vs-ineffective-warning.yaml
@@ -1,6 +1,6 @@
 apiVersion: release-notes/v2
 kind: feature
-area: networking
+area: traffic-management
 issue:
   - 31525
 releaseNotes:


### PR DESCRIPTION
This fixes several release notes in 1.10 that don't match the schema.

@istio/release-managers-1-10 this should be all of the release notes that got missed in the generation. 