### PR TITLE
Add service account to base with aggregate permissions

### DIFF
--- a/istioctl/pkg/multicluster/remote_secret.go
+++ b/istioctl/pkg/multicluster/remote_secret.go
@@ -304,7 +304,7 @@ func createServiceAccount(client kube.ExtendedClient, opt RemoteSecretOptions) e
 	baseRenderer := helm.NewHelmRenderer(opt.ManifestsPath, "base", "Base", opt.Namespace)
 	discoveryRenderer := helm.NewHelmRenderer(opt.ManifestsPath, "istio-control/istio-discovery", "Pilot", opt.Namespace)
 
-	baseTemplates := []string {"reader-serviceaccount.yaml"}
+	baseTemplates := []string{"reader-serviceaccount.yaml"}
 	discoveryTemplates := []string{"clusterrole.yaml", "clusterrolebinding.yaml"}
 
 	if err := baseRenderer.Run(); err != nil {

--- a/istioctl/pkg/multicluster/remote_secret_test.go
+++ b/istioctl/pkg/multicluster/remote_secret_test.go
@@ -457,12 +457,12 @@ func TestGenerateServiceAccount(t *testing.T) {
 		t.Fatalf("could not parse k8s objects from generated YAML: %v", err)
 	}
 
-	_ = mustFindObject(t, objs, "istio-reader-service-account", "ServiceAccount")
-	_ = mustFindObject(t, objs, "istio-reader-clusterrole-istio-system", "ClusterRole")
-	_ = mustFindObject(t, objs, "istio-reader-clusterrole-istio-system", "ClusterRoleBinding")
+	mustFindObject(t, objs, "istio-reader-service-account", "ServiceAccount")
+	mustFindObject(t, objs, "istio-reader-clusterrole-istio-system", "ClusterRole")
+	mustFindObject(t, objs, "istio-reader-clusterrole-istio-system", "ClusterRoleBinding")
 }
 
-func mustFindObject(t test.Failer, objs object.K8sObjects, name, kind string) object.K8sObject {
+func mustFindObject(t test.Failer, objs object.K8sObjects, name, kind string) {
 	t.Helper()
 	var obj *object.K8sObject
 	for _, o := range objs {
@@ -473,9 +473,7 @@ func mustFindObject(t test.Failer, objs object.K8sObjects, name, kind string) ob
 	}
 	if obj == nil {
 		t.Fatalf("expected %v/%v", name, kind)
-		return object.K8sObject{}
 	}
-	return *obj
 }
 
 func TestGetClusterServerFromKubeconfig(t *testing.T) {

--- a/manifests/charts/base/files/gen-istio-cluster.yaml
+++ b/manifests/charts/base/files/gen-istio-cluster.yaml
@@ -6028,12 +6028,12 @@ spec:
 
 ---
 # Source: base/templates/reader-serviceaccount.yaml
-# This service account aggregates the permissions for the revisions in a given cluster
+# This service account aggregates reader permissions for the revisions in a given cluster
 # Should be used for remote secret creation.
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: istio-reader-aggregate
+  name: istio-reader-service-account
   namespace: istio-system
   labels:
     app: istio-reader
@@ -6045,16 +6045,6 @@ metadata:
 # THIS IS A LEGACY CHART HERE FOR BACKCOMPAT
 # UPDATED CHART AT manifests/charts/istio-control/istio-discovery
 # -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: istio-reader-service-account
-  namespace: istio-system
-  labels:
-    app: istio-reader
-    release: istio
----
-# Source: base/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/manifests/charts/base/files/gen-istio-cluster.yaml
+++ b/manifests/charts/base/files/gen-istio-cluster.yaml
@@ -6027,6 +6027,18 @@ spec:
 ---
 
 ---
+# Source: base/templates/reader-serviceaccount.yaml
+# This service account aggregates the permissions for the revisions in a given cluster
+# Should be used for remote secret creation.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: istio-reader-aggregate
+  namespace: istio-system
+  labels:
+    app: istio-reader
+    release: istio
+---
 # Source: base/templates/serviceaccount.yaml
 # -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 # DO NOT EDIT!

--- a/manifests/charts/base/templates/reader-serviceaccount.yaml
+++ b/manifests/charts/base/templates/reader-serviceaccount.yaml
@@ -1,0 +1,16 @@
+# This service account aggregates the permissions for the revisions in a given cluster
+# Should be used for remote secret creation.
+apiVersion: v1
+kind: ServiceAccount
+{{- if .Values.global.imagePullSecrets }}
+imagePullSecrets:
+{{- range .Values.global.imagePullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- end }}
+metadata:
+  name: istio-reader-aggregate
+  namespace: {{ .Values.global.istioNamespace }}
+  labels:
+    app: istio-reader
+    release: {{ .Release.Name }}

--- a/manifests/charts/base/templates/reader-serviceaccount.yaml
+++ b/manifests/charts/base/templates/reader-serviceaccount.yaml
@@ -1,15 +1,15 @@
-# This service account aggregates the permissions for the revisions in a given cluster
+# This service account aggregates reader permissions for the revisions in a given cluster
 # Should be used for remote secret creation.
 apiVersion: v1
 kind: ServiceAccount
-{{- if .Values.global.imagePullSecrets }}
+  {{- if .Values.global.imagePullSecrets }}
 imagePullSecrets:
-{{- range .Values.global.imagePullSecrets }}
+  {{- range .Values.global.imagePullSecrets }}
   - name: {{ . }}
-{{- end }}
-{{- end }}
+    {{- end }}
+    {{- end }}
 metadata:
-  name: istio-reader-aggregate
+  name: istio-reader-service-account
   namespace: {{ .Values.global.istioNamespace }}
   labels:
     app: istio-reader

--- a/manifests/charts/base/templates/serviceaccount.yaml
+++ b/manifests/charts/base/templates/serviceaccount.yaml
@@ -5,21 +5,6 @@
 # -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 apiVersion: v1
 kind: ServiceAccount
-{{- if .Values.global.imagePullSecrets }}
-imagePullSecrets:
-{{- range .Values.global.imagePullSecrets }}
-  - name: {{ . }}
-{{- end }}
-{{- end }}
-metadata:
-  name: istio-reader-service-account
-  namespace: {{ .Values.global.istioNamespace }}
-  labels:
-    app: istio-reader
-    release: {{ .Release.Name }}
----
-apiVersion: v1
-kind: ServiceAccount
   {{- if .Values.global.imagePullSecrets }}
 imagePullSecrets:
   {{- range .Values.global.imagePullSecrets }}
@@ -32,4 +17,3 @@ metadata:
   labels:
     app: istiod
     release: {{ .Release.Name }}
----

--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -911,7 +911,7 @@ data:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: istiod-cr-istio-system
+  name: istiod-clusterrole-istio-system
   labels:
     app: istiod
     release: istio
@@ -1074,7 +1074,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: istiod-cr-istio-system
+  name: istiod-clusterrole-istio-system
 subjects:
   - kind: ServiceAccount
     name: istiod

--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -1067,7 +1067,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istiod-cr-istio-system
+  name: istiod-clusterrole-istio-system
   labels:
     app: istiod
     release: istio

--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -921,7 +921,7 @@ data:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: istiod-cristio-system
+  name: istiod-cr-istio-system
   labels:
     app: istiod
     release: istio
@@ -1021,7 +1021,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: istio-reader-cr
+  name: istio-reader-cr-istio-system
   labels:
     app: istio-reader
     release: istio
@@ -1060,14 +1060,14 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istio-reader-cr
+  name: istio-reader-cr-istio-system
   labels:
     app: istio-reader
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: istio-reader-cr
+  name: istio-reader-cr-istio-system
 subjects:
   - kind: ServiceAccount
     name: istio-reader
@@ -1077,14 +1077,14 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istiod-cristio-system
+  name: istiod-cr-istio-system
   labels:
     app: istiod
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: istiod-cristio-system
+  name: istiod-cr-istio-system
 subjects:
   - kind: ServiceAccount
     name: istiod

--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -1011,7 +1011,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: istio-reader-cr-istio-system
+  name: istio-reader-clusterrole-istio-system
   labels:
     app: istio-reader
     release: istio
@@ -1050,14 +1050,14 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istio-reader-cr-istio-system
+  name: istio-reader-clusterrole-istio-system
   labels:
     app: istio-reader
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: istio-reader-cr-istio-system
+  name: istio-reader-clusterrole-istio-system
 subjects:
   - kind: ServiceAccount
     name: istio-reader-aggregate

--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -23,16 +23,6 @@ spec:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: istio-reader
-  namespace: istio-system
-  labels:
-    app: istio-reader
-    release: istio
----
-# Source: istio-discovery/templates/serviceaccount.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
   name: istiod
   namespace: istio-system
   labels:
@@ -1070,7 +1060,7 @@ roleRef:
   name: istio-reader-cr-istio-system
 subjects:
   - kind: ServiceAccount
-    name: istio-reader
+    name: istio-reader-aggregate
     namespace: istio-system
 ---
 # Source: istio-discovery/templates/clusterrolebinding.yaml

--- a/manifests/charts/istio-control/istio-discovery/templates/clusterrole.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/clusterrole.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: istiod-cr{{- if not (eq .Values.revision "")}}-{{ .Values.revision }}{{- end }}{{ .Release.Namespace }}
+  name: istiod-cr{{- if not (eq .Values.revision "")}}-{{ .Values.revision }}{{- end }}-{{ .Release.Namespace }}
   labels:
     app: istiod
     release: {{ .Release.Name }}
@@ -115,7 +115,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: istio-reader-cr{{- if not (eq .Values.revision "")}}-{{ .Values.revision }}{{- end }}
+  name: istio-reader-cr{{- if not (eq .Values.revision "")}}-{{ .Values.revision }}{{- end }}-{{ .Release.Namespace }}
   labels:
     app: istio-reader
     release: {{ .Release.Name }}

--- a/manifests/charts/istio-control/istio-discovery/templates/clusterrole.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/clusterrole.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: istiod-cr{{- if not (eq .Values.revision "")}}-{{ .Values.revision }}{{- end }}-{{ .Release.Namespace }}
+  name: istiod-clusterrole{{- if not (eq .Values.revision "")}}-{{ .Values.revision }}{{- end }}-{{ .Release.Namespace }}
   labels:
     app: istiod
     release: {{ .Release.Name }}

--- a/manifests/charts/istio-control/istio-discovery/templates/clusterrole.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/clusterrole.yaml
@@ -115,7 +115,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: istio-reader-cr{{- if not (eq .Values.revision "")}}-{{ .Values.revision }}{{- end }}-{{ .Release.Namespace }}
+  name: istio-reader-clusterrole{{- if not (eq .Values.revision "")}}-{{ .Values.revision }}{{- end }}-{{ .Release.Namespace }}
   labels:
     app: istio-reader
     release: {{ .Release.Name }}

--- a/manifests/charts/istio-control/istio-discovery/templates/clusterrolebinding.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/clusterrolebinding.yaml
@@ -1,14 +1,14 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istio-reader-cr{{- if not (eq .Values.revision "")}}-{{ .Values.revision }}{{- end }}
+  name: istio-reader-cr{{- if not (eq .Values.revision "")}}-{{ .Values.revision }}{{- end }}-{{ .Release.Namespace }}
   labels:
     app: istio-reader
     release: {{ .Release.Name }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: istio-reader-cr{{- if not (eq .Values.revision "")}}-{{ .Values.revision }}{{- end }}
+  name: istio-reader-cr{{- if not (eq .Values.revision "")}}-{{ .Values.revision }}{{- end }}-{{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
     name: istio-reader{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
@@ -17,14 +17,14 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istiod-cr{{- if not (eq .Values.revision "")}}-{{ .Values.revision }}{{- end }}{{ .Release.Namespace }}
+  name: istiod-cr{{- if not (eq .Values.revision "")}}-{{ .Values.revision }}{{- end }}-{{ .Release.Namespace }}
   labels:
     app: istiod
     release: {{ .Release.Name }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: istiod-cr{{- if not (eq .Values.revision "")}}-{{ .Values.revision }}{{- end }}{{ .Release.Namespace }}
+  name: istiod-cr{{- if not (eq .Values.revision "")}}-{{ .Values.revision }}{{- end }}-{{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
     name: istiod{{- if not (eq .Values.revision "")}}-{{ .Values.revision }}{{- end }}

--- a/manifests/charts/istio-control/istio-discovery/templates/clusterrolebinding.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/clusterrolebinding.yaml
@@ -11,7 +11,7 @@ roleRef:
   name: istio-reader-cr{{- if not (eq .Values.revision "")}}-{{ .Values.revision }}{{- end }}-{{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
-    name: istio-reader{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
+    name: istio-reader-aggregate
     namespace: {{ .Values.global.istioNamespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/charts/istio-control/istio-discovery/templates/clusterrolebinding.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/clusterrolebinding.yaml
@@ -17,7 +17,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istiod-cr{{- if not (eq .Values.revision "")}}-{{ .Values.revision }}{{- end }}-{{ .Release.Namespace }}
+  name: istiod-clusterrole{{- if not (eq .Values.revision "")}}-{{ .Values.revision }}{{- end }}-{{ .Release.Namespace }}
   labels:
     app: istiod
     release: {{ .Release.Name }}

--- a/manifests/charts/istio-control/istio-discovery/templates/clusterrolebinding.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/clusterrolebinding.yaml
@@ -24,7 +24,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: istiod-cr{{- if not (eq .Values.revision "")}}-{{ .Values.revision }}{{- end }}-{{ .Release.Namespace }}
+  name: istiod-clusterrole{{- if not (eq .Values.revision "")}}-{{ .Values.revision }}{{- end }}-{{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
     name: istiod{{- if not (eq .Values.revision "")}}-{{ .Values.revision }}{{- end }}

--- a/manifests/charts/istio-control/istio-discovery/templates/clusterrolebinding.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/clusterrolebinding.yaml
@@ -1,14 +1,14 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istio-reader-cr{{- if not (eq .Values.revision "")}}-{{ .Values.revision }}{{- end }}-{{ .Release.Namespace }}
+  name: istio-reader-clusterrole{{- if not (eq .Values.revision "")}}-{{ .Values.revision }}{{- end }}-{{ .Release.Namespace }}
   labels:
     app: istio-reader
     release: {{ .Release.Name }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: istio-reader-cr{{- if not (eq .Values.revision "")}}-{{ .Values.revision }}{{- end }}-{{ .Release.Namespace }}
+  name: istio-reader-clusterrole{{- if not (eq .Values.revision "")}}-{{ .Values.revision }}{{- end }}-{{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
     name: istio-reader-aggregate

--- a/manifests/charts/istio-control/istio-discovery/templates/serviceaccount.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/serviceaccount.yaml
@@ -1,20 +1,5 @@
 apiVersion: v1
 kind: ServiceAccount
-{{- if .Values.global.imagePullSecrets }}
-imagePullSecrets:
-{{- range .Values.global.imagePullSecrets }}
-  - name: {{ . }}
-{{- end }}
-{{- end }}
-metadata:
-  name: istio-reader{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  namespace: {{ .Values.global.istioNamespace }}
-  labels:
-    app: istio-reader
-    release: {{ .Release.Name }}
----
-apiVersion: v1
-kind: ServiceAccount
   {{- if .Values.global.imagePullSecrets }}
 imagePullSecrets:
   {{- range .Values.global.imagePullSecrets }}

--- a/pkg/config/constants/constants.go
+++ b/pkg/config/constants/constants.go
@@ -109,7 +109,7 @@ const (
 	DefaultXdsUdsPath = "./etc/istio/proxy/XDS"
 
 	// DefaultServiceAccountName is the default service account to use for remote cluster access.
-	DefaultServiceAccountName = "istio-reader-aggregate"
+	DefaultServiceAccountName = "istio-reader-service-account"
 
 	// DefaultConfigServiceAccountName is the default service account to use for external Istiod cluster access.
 	DefaultConfigServiceAccountName = "istiod-service-account"

--- a/pkg/config/constants/constants.go
+++ b/pkg/config/constants/constants.go
@@ -109,7 +109,7 @@ const (
 	DefaultXdsUdsPath = "./etc/istio/proxy/XDS"
 
 	// DefaultServiceAccountName is the default service account to use for remote cluster access.
-	DefaultServiceAccountName = "istio-reader-service-account"
+	DefaultServiceAccountName = "istio-reader-aggregate"
 
 	// DefaultConfigServiceAccountName is the default service account to use for external Istiod cluster access.
 	DefaultConfigServiceAccountName = "istiod-service-account"


### PR DESCRIPTION
Adds `istio-reader-aggregate` service account to base that has aggregate perms for all revisions running in cluster, should be used when creating remote secret.

Changes create remote secret command to render service account, cluster roles, and role bindings from updated charts

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
