### PR TITLE
increase dns timeouts

### DIFF
--- a/pilot/pkg/dns/proxy.go
+++ b/pilot/pkg/dns/proxy.go
@@ -16,6 +16,7 @@ package dns
 
 import (
 	"net"
+	"time"
 
 	"github.com/miekg/dns"
 )
@@ -36,7 +37,10 @@ func newDNSProxy(protocol string, resolver *LocalDNSServer) (*dnsProxy, error) {
 		serveMux: dns.NewServeMux(),
 		server:   &dns.Server{},
 		upstreamClient: &dns.Client{
-			Net: protocol,
+			Net:          protocol,
+			DialTimeout:  5 * time.Second,
+			ReadTimeout:  5 * time.Second,
+			WriteTimeout: 5 * time.Second,
 		},
 		protocol: protocol,
 		resolver: resolver,


### PR DESCRIPTION
Some times we are seeing 	

`upstream failure: read udp 10.110.244.222:54257->172.20.0.10:53: i/o timeout	protocol=udp edns=false`

in a busy pod. This PR increases the timeouts. Even though the client documentation https://github.com/miekg/dns/blob/40060b4a4b85b14867003343f64bfd5cd64ea256/client.go#L39 says it is disabled if it is not set, it enforcing 2s timeout https://github.com/miekg/dns/blob/40060b4a4b85b14867003343f64bfd5cd64ea256/client.go#L73

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
