### PR TITLE
add log metadata for Xds Generators

### DIFF
--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -164,7 +164,7 @@ func (e *Environment) SetLedger(l ledger.Ledger) {
 	e.ledger = l
 }
 
-// Request is an alias for array of marshaled resources.
+// Resources is an alias for array of marshaled resources.
 type Resources = []*discovery.Resource
 
 func AnyToUnnamedResources(r []*any.Any) Resources {
@@ -187,10 +187,11 @@ func ResourcesToAny(r Resources) []*any.Any {
 // See for example EDS incremental updates.
 type XdsUpdates = map[ConfigKey]struct{}
 
-// GeneratorMetadata has information about generator it self that processors like ads/delta can use.
-type GeneratorMetadata struct {
-	// LogsDetails indicates whether the generator logs details during the generation.
-	LogsDetails bool
+// XdsLogDetails contains additional metadata that is captured by Generators and used by xds processors
+// like Ads and Delta to uniformly log.
+type XdsLogDetails struct {
+	Incremental    bool
+	AdditionalInfo string
 }
 
 // XdsResourceGenerator creates the response for a typeURL DiscoveryRequest. If no generator is associated
@@ -200,17 +201,7 @@ type GeneratorMetadata struct {
 // Note: any errors returned will completely close the XDS stream. Use with caution; typically and empty
 // or no response is preferred.
 type XdsResourceGenerator interface {
-	Generate(proxy *Proxy, push *PushContext, w *WatchedResource, updates *PushRequest) (Resources, error)
-	Metadata() *GeneratorMetadata
-}
-
-// BaseGenerator is the base generator.
-type BaseGenerator struct{}
-
-var baseMetadata = &GeneratorMetadata{false}
-
-func (bg *BaseGenerator) Metadata() *GeneratorMetadata {
-	return baseMetadata
+	Generate(proxy *Proxy, push *PushContext, w *WatchedResource, updates *PushRequest) (Resources, *XdsLogDetails, error)
 }
 
 // Proxy contains information about an specific instance of a proxy (envoy sidecar, gateway,

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -194,6 +194,8 @@ type XdsLogDetails struct {
 	AdditionalInfo string
 }
 
+var DefaultXdsLogDetails XdsLogDetails = XdsLogDetails{}
+
 // XdsResourceGenerator creates the response for a typeURL DiscoveryRequest. If no generator is associated
 // with a Proxy, the default (a networking.core.ConfigGenerator instance) will be used.
 // The server may associate a different generator based on client metadata. Different
@@ -201,7 +203,7 @@ type XdsLogDetails struct {
 // Note: any errors returned will completely close the XDS stream. Use with caution; typically and empty
 // or no response is preferred.
 type XdsResourceGenerator interface {
-	Generate(proxy *Proxy, push *PushContext, w *WatchedResource, updates *PushRequest) (Resources, *XdsLogDetails, error)
+	Generate(proxy *Proxy, push *PushContext, w *WatchedResource, updates *PushRequest) (Resources, XdsLogDetails, error)
 }
 
 // Proxy contains information about an specific instance of a proxy (envoy sidecar, gateway,

--- a/pilot/pkg/networking/apigen/apigen.go
+++ b/pilot/pkg/networking/apigen/apigen.go
@@ -43,8 +43,7 @@ import (
 // Example: networking.istio.io/v1alpha3/VirtualService
 //
 // TODO: we can also add a special marker in the header)
-type APIGenerator struct {
-}
+type APIGenerator struct{}
 
 // TODO: take 'updates' into account, don't send pushes for resources that haven't changed
 // TODO: support WorkloadEntry - to generate endpoints (equivalent with EDS)

--- a/pilot/pkg/networking/apigen/apigen.go
+++ b/pilot/pkg/networking/apigen/apigen.go
@@ -57,7 +57,7 @@ type APIGenerator struct{}
 //
 // Names are based on the current resource naming in istiod stores.
 func (g *APIGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource,
-	updates *model.PushRequest) (model.Resources, *model.XdsLogDetails, error) {
+	updates *model.PushRequest) (model.Resources, model.XdsLogDetails, error) {
 	resp := model.Resources{}
 
 	// Note: this is the style used by MCP and its config. Pilot is using 'Group/Version/Kind' as the
@@ -70,7 +70,7 @@ func (g *APIGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *
 	if len(kind) != 3 {
 		log.Warnf("ADS: Unknown watched resources %s", w.TypeUrl)
 		// Still return an empty response - to not break waiting code. It is fine to not know about some resource.
-		return resp, nil, nil
+		return resp, model.DefaultXdsLogDetails, nil
 	}
 	// TODO: extra validation may be needed - at least logging that a resource
 	// of unknown type was requested. This should not be an error - maybe client asks
@@ -91,7 +91,7 @@ func (g *APIGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *
 				Resource: a,
 			})
 		}
-		return resp, nil, nil
+		return resp, model.DefaultXdsLogDetails, nil
 	}
 
 	// TODO: what is the proper way to handle errors ?
@@ -102,7 +102,7 @@ func (g *APIGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *
 	cfg, err := push.IstioConfigStore.List(rgvk, "")
 	if err != nil {
 		log.Warnf("ADS: Error reading resource %s %v", w.TypeUrl, err)
-		return resp, nil, nil
+		return resp, model.DefaultXdsLogDetails, nil
 	}
 	for _, c := range cfg {
 		// Right now model.Config is not a proto - until we change it, mcp.Resource.
@@ -161,7 +161,7 @@ func (g *APIGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *
 		}
 	}
 
-	return resp, nil, nil
+	return resp, model.DefaultXdsLogDetails, nil
 }
 
 // Convert from model.Config, which has no associated proto, to MCP Resource proto.

--- a/pilot/pkg/networking/apigen/apigen.go
+++ b/pilot/pkg/networking/apigen/apigen.go
@@ -57,7 +57,8 @@ type APIGenerator struct {
 // This provides similar functionality with MCP and :8080/debug/configz.
 //
 // Names are based on the current resource naming in istiod stores.
-func (g *APIGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource, updates *model.PushRequest) (model.Resources, *model.XdsLogDetails, error) {
+func (g *APIGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource,
+	updates *model.PushRequest) (model.Resources, *model.XdsLogDetails, error) {
 	resp := model.Resources{}
 
 	// Note: this is the style used by MCP and its config. Pilot is using 'Group/Version/Kind' as the

--- a/pilot/pkg/networking/grpcgen/grpcgen.go
+++ b/pilot/pkg/networking/grpcgen/grpcgen.go
@@ -49,8 +49,7 @@ import (
 // using the generic structures. "Classical" CDS/LDS/RDS/EDS use separate logic -
 // this is used for the API-based LDS and generic messages.
 
-type GrpcConfigGenerator struct {
-}
+type GrpcConfigGenerator struct{}
 
 func (g *GrpcConfigGenerator) Generate(proxy *model.Proxy, push *model.PushContext,
 	w *model.WatchedResource, updates *model.PushRequest) (model.Resources, *model.XdsLogDetails, error) {

--- a/pilot/pkg/networking/grpcgen/grpcgen.go
+++ b/pilot/pkg/networking/grpcgen/grpcgen.go
@@ -50,21 +50,20 @@ import (
 // this is used for the API-based LDS and generic messages.
 
 type GrpcConfigGenerator struct {
-	model.BaseGenerator
 }
 
 func (g *GrpcConfigGenerator) Generate(proxy *model.Proxy, push *model.PushContext,
-	w *model.WatchedResource, updates *model.PushRequest) (model.Resources, error) {
+	w *model.WatchedResource, updates *model.PushRequest) (model.Resources, *model.XdsLogDetails, error) {
 	switch w.TypeUrl {
 	case v3.ListenerType:
-		return g.BuildListeners(proxy, push, w.ResourceNames), nil
+		return g.BuildListeners(proxy, push, w.ResourceNames), nil, nil
 	case v3.ClusterType:
-		return g.BuildClusters(proxy, push, w.ResourceNames), nil
+		return g.BuildClusters(proxy, push, w.ResourceNames), nil, nil
 	case v3.RouteType:
-		return g.BuildHTTPRoutes(proxy, push, w.ResourceNames), nil
+		return g.BuildHTTPRoutes(proxy, push, w.ResourceNames), nil, nil
 	}
 
-	return nil, nil
+	return nil, nil, nil
 }
 
 // handleLDSApiType handles a LDS request, returning listeners of ApiListener type.

--- a/pilot/pkg/networking/grpcgen/grpcgen.go
+++ b/pilot/pkg/networking/grpcgen/grpcgen.go
@@ -52,17 +52,17 @@ import (
 type GrpcConfigGenerator struct{}
 
 func (g *GrpcConfigGenerator) Generate(proxy *model.Proxy, push *model.PushContext,
-	w *model.WatchedResource, updates *model.PushRequest) (model.Resources, *model.XdsLogDetails, error) {
+	w *model.WatchedResource, updates *model.PushRequest) (model.Resources, model.XdsLogDetails, error) {
 	switch w.TypeUrl {
 	case v3.ListenerType:
-		return g.BuildListeners(proxy, push, w.ResourceNames), nil, nil
+		return g.BuildListeners(proxy, push, w.ResourceNames), model.DefaultXdsLogDetails, nil
 	case v3.ClusterType:
-		return g.BuildClusters(proxy, push, w.ResourceNames), nil, nil
+		return g.BuildClusters(proxy, push, w.ResourceNames), model.DefaultXdsLogDetails, nil
 	case v3.RouteType:
-		return g.BuildHTTPRoutes(proxy, push, w.ResourceNames), nil, nil
+		return g.BuildHTTPRoutes(proxy, push, w.ResourceNames), model.DefaultXdsLogDetails, nil
 	}
 
-	return nil, nil, nil
+	return nil, model.DefaultXdsLogDetails, nil
 }
 
 // handleLDSApiType handles a LDS request, returning listeners of ApiListener type.

--- a/pilot/pkg/xds/bench_test.go
+++ b/pilot/pkg/xds/bench_test.go
@@ -138,7 +138,7 @@ func BenchmarkRouteGeneration(b *testing.B) {
 			b.ResetTimer()
 			var c model.Resources
 			for n := 0; n < b.N; n++ {
-				c, _ = s.Discovery.Generators[v3.RouteType].Generate(proxy, s.PushContext(), &model.WatchedResource{ResourceNames: routeNames}, nil)
+				c, _, _ = s.Discovery.Generators[v3.RouteType].Generate(proxy, s.PushContext(), &model.WatchedResource{ResourceNames: routeNames}, nil)
 				if len(c) == 0 {
 					b.Fatal("Got no routes!")
 				}
@@ -152,7 +152,7 @@ func BenchmarkRouteGeneration(b *testing.B) {
 // update our benchmark doesn't become useless.
 func TestValidateTelemetry(t *testing.T) {
 	s, proxy := setupAndInitializeTest(t, ConfigInput{Name: "telemetry", Services: 1})
-	c, _ := s.Discovery.Generators[v3.ClusterType].Generate(proxy, s.PushContext(), nil, nil)
+	c, _, _ := s.Discovery.Generators[v3.ClusterType].Generate(proxy, s.PushContext(), nil, nil)
 	if len(c) == 0 {
 		t.Fatal("Got no clusters!")
 	}
@@ -178,7 +178,7 @@ func BenchmarkClusterGeneration(b *testing.B) {
 			b.ResetTimer()
 			var c model.Resources
 			for n := 0; n < b.N; n++ {
-				c, _ = s.Discovery.Generators[v3.ClusterType].Generate(proxy, s.PushContext(), nil, nil)
+				c, _, _ = s.Discovery.Generators[v3.ClusterType].Generate(proxy, s.PushContext(), nil, nil)
 				if len(c) == 0 {
 					b.Fatal("Got no clusters!")
 				}
@@ -196,7 +196,7 @@ func BenchmarkListenerGeneration(b *testing.B) {
 			b.ResetTimer()
 			var c model.Resources
 			for n := 0; n < b.N; n++ {
-				c, _ = s.Discovery.Generators[v3.ListenerType].Generate(proxy, s.PushContext(), nil, nil)
+				c, _, _ = s.Discovery.Generators[v3.ListenerType].Generate(proxy, s.PushContext(), nil, nil)
 				if len(c) == 0 {
 					b.Fatal("Got no listeners!")
 				}
@@ -214,7 +214,7 @@ func BenchmarkNameTableGeneration(b *testing.B) {
 			b.ResetTimer()
 			var c model.Resources
 			for n := 0; n < b.N; n++ {
-				c, _ = s.Discovery.Generators[v3.NameTableType].Generate(proxy, s.PushContext(), nil, nil)
+				c, _, _ = s.Discovery.Generators[v3.NameTableType].Generate(proxy, s.PushContext(), nil, nil)
 				if len(c) == 0 && tt.ProxyType != model.Router {
 					b.Fatal("Got no name tables!")
 				}
@@ -257,7 +257,7 @@ func BenchmarkSecretGeneration(b *testing.B) {
 			b.ResetTimer()
 			var c model.Resources
 			for n := 0; n < b.N; n++ {
-				c, _ = gen.Generate(proxy, s.PushContext(), res, &model.PushRequest{Full: true})
+				c, _, _ = gen.Generate(proxy, s.PushContext(), res, &model.PushRequest{Full: true})
 				if len(c) == 0 {
 					b.Fatal("Got no secrets!")
 				}

--- a/pilot/pkg/xds/bootstrapds.go
+++ b/pilot/pkg/xds/bootstrapds.go
@@ -37,7 +37,7 @@ var _ model.XdsResourceGenerator = &BootstrapGenerator{}
 
 // Generate returns a bootstrap discovery response.
 func (e *BootstrapGenerator) Generate(proxy *model.Proxy, _ *model.PushContext, _ *model.WatchedResource,
-	_ *model.PushRequest) (model.Resources, *model.XdsLogDetails, error) {
+	_ *model.PushRequest) (model.Resources, model.XdsLogDetails, error) {
 	// The model.Proxy information is incomplete, re-parse the discovery request.
 	node := bootstrap.ConvertXDSNodeToNode(proxy.XdsNode)
 
@@ -47,7 +47,7 @@ func (e *BootstrapGenerator) Generate(proxy *model.Proxy, _ *model.PushContext, 
 		Node: node,
 	}).WriteTo(templateFile, io.Writer(&buf))
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to generate bootstrap config: %v", err)
+		return nil, model.DefaultXdsLogDetails, fmt.Errorf("failed to generate bootstrap config: %v", err)
 	}
 
 	bs := &bootstrapv3.Bootstrap{}
@@ -58,5 +58,5 @@ func (e *BootstrapGenerator) Generate(proxy *model.Proxy, _ *model.PushContext, 
 		&discovery.Resource{
 			Resource: util.MessageToAny(bs),
 		},
-	}, nil, nil
+	}, model.DefaultXdsLogDetails, nil
 }

--- a/pilot/pkg/xds/bootstrapds.go
+++ b/pilot/pkg/xds/bootstrapds.go
@@ -30,14 +30,13 @@ import (
 
 // Bootstrap generator produces an Envoy bootstrap from node descriptors.
 type BootstrapGenerator struct {
-	model.BaseGenerator
 	Server *DiscoveryServer
 }
 
 var _ model.XdsResourceGenerator = &BootstrapGenerator{}
 
 // Generate returns a bootstrap discovery response.
-func (e *BootstrapGenerator) Generate(proxy *model.Proxy, _ *model.PushContext, _ *model.WatchedResource, _ *model.PushRequest) (model.Resources, error) {
+func (e *BootstrapGenerator) Generate(proxy *model.Proxy, _ *model.PushContext, _ *model.WatchedResource, _ *model.PushRequest) (model.Resources, *model.XdsLogDetails, error) {
 	// The model.Proxy information is incomplete, re-parse the discovery request.
 	node := bootstrap.ConvertXDSNodeToNode(proxy.XdsNode)
 
@@ -47,7 +46,7 @@ func (e *BootstrapGenerator) Generate(proxy *model.Proxy, _ *model.PushContext, 
 		Node: node,
 	}).WriteTo(templateFile, io.Writer(&buf))
 	if err != nil {
-		return nil, fmt.Errorf("failed to generate bootstrap config: %v", err)
+		return nil, nil, fmt.Errorf("failed to generate bootstrap config: %v", err)
 	}
 
 	bs := &bootstrapv3.Bootstrap{}
@@ -58,5 +57,5 @@ func (e *BootstrapGenerator) Generate(proxy *model.Proxy, _ *model.PushContext, 
 		&discovery.Resource{
 			Resource: util.MessageToAny(bs),
 		},
-	}, nil
+	}, nil, nil
 }

--- a/pilot/pkg/xds/bootstrapds.go
+++ b/pilot/pkg/xds/bootstrapds.go
@@ -36,7 +36,8 @@ type BootstrapGenerator struct {
 var _ model.XdsResourceGenerator = &BootstrapGenerator{}
 
 // Generate returns a bootstrap discovery response.
-func (e *BootstrapGenerator) Generate(proxy *model.Proxy, _ *model.PushContext, _ *model.WatchedResource, _ *model.PushRequest) (model.Resources, *model.XdsLogDetails, error) {
+func (e *BootstrapGenerator) Generate(proxy *model.Proxy, _ *model.PushContext, _ *model.WatchedResource,
+	_ *model.PushRequest) (model.Resources, *model.XdsLogDetails, error) {
 	// The model.Proxy information is incomplete, re-parse the discovery request.
 	node := bootstrap.ConvertXDSNodeToNode(proxy.XdsNode)
 

--- a/pilot/pkg/xds/cds.go
+++ b/pilot/pkg/xds/cds.go
@@ -72,9 +72,9 @@ func cdsNeedsPush(req *model.PushRequest, proxy *model.Proxy) bool {
 }
 
 func (c CdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource,
-	req *model.PushRequest) (model.Resources, *model.XdsLogDetails, error) {
+	req *model.PushRequest) (model.Resources, model.XdsLogDetails, error) {
 	if !cdsNeedsPush(req, proxy) {
-		return nil, nil, nil
+		return nil, model.DefaultXdsLogDetails, nil
 	}
 	rawClusters := c.Server.ConfigGenerator.BuildClusters(proxy, push)
 	resources := model.Resources{}
@@ -84,5 +84,5 @@ func (c CdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *m
 			Resource: util.MessageToAny(c),
 		})
 	}
-	return resources, nil, nil
+	return resources, model.DefaultXdsLogDetails, nil
 }

--- a/pilot/pkg/xds/cds.go
+++ b/pilot/pkg/xds/cds.go
@@ -24,7 +24,6 @@ import (
 )
 
 type CdsGenerator struct {
-	model.BaseGenerator
 	Server *DiscoveryServer
 }
 
@@ -72,9 +71,9 @@ func cdsNeedsPush(req *model.PushRequest, proxy *model.Proxy) bool {
 	return false
 }
 
-func (c CdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource, req *model.PushRequest) (model.Resources, error) {
+func (c CdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource, req *model.PushRequest) (model.Resources, *model.XdsLogDetails, error) {
 	if !cdsNeedsPush(req, proxy) {
-		return nil, nil
+		return nil, nil, nil
 	}
 	rawClusters := c.Server.ConfigGenerator.BuildClusters(proxy, push)
 	resources := model.Resources{}
@@ -84,5 +83,5 @@ func (c CdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *m
 			Resource: util.MessageToAny(c),
 		})
 	}
-	return resources, nil
+	return resources, nil, nil
 }

--- a/pilot/pkg/xds/cds.go
+++ b/pilot/pkg/xds/cds.go
@@ -71,7 +71,8 @@ func cdsNeedsPush(req *model.PushRequest, proxy *model.Proxy) bool {
 	return false
 }
 
-func (c CdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource, req *model.PushRequest) (model.Resources, *model.XdsLogDetails, error) {
+func (c CdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource,
+	req *model.PushRequest) (model.Resources, *model.XdsLogDetails, error) {
 	if !cdsNeedsPush(req, proxy) {
 		return nil, nil, nil
 	}

--- a/pilot/pkg/xds/debug.go
+++ b/pilot/pkg/xds/debug.go
@@ -541,7 +541,7 @@ func (s *DiscoveryServer) configDump(conn *Connection) (*adminapi.ConfigDump, er
 
 	secretsDump := &adminapi.SecretsConfigDump{}
 	if s.Generators[v3.SecretType] != nil {
-		secrets, _ := s.Generators[v3.SecretType].Generate(conn.proxy, s.globalPushContext(), conn.Watched(v3.SecretType), nil)
+		secrets, _, _ := s.Generators[v3.SecretType].Generate(conn.proxy, s.globalPushContext(), conn.Watched(v3.SecretType), nil)
 		if len(secrets) > 0 {
 			for _, secretAny := range secrets {
 				secret := &tls.Secret{}
@@ -690,7 +690,7 @@ func (s *DiscoveryServer) Ndsz(w http.ResponseWriter, req *http.Request) {
 	}
 
 	if s.Generators[v3.NameTableType] != nil {
-		nds, _ := s.Generators[v3.NameTableType].Generate(con.proxy, s.globalPushContext(), nil, nil)
+		nds, _, _ := s.Generators[v3.NameTableType].Generate(con.proxy, s.globalPushContext(), nil, nil)
 		if len(nds) == 0 {
 			return
 		}

--- a/pilot/pkg/xds/debuggen.go
+++ b/pilot/pkg/xds/debuggen.go
@@ -85,14 +85,14 @@ func NewDebugGen(s *DiscoveryServer, systemNamespace string) *DebugGen {
 
 // Generate XDS debug responses according to the incoming debug request
 func (dg *DebugGen) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource,
-	updates *model.PushRequest) (model.Resources, *model.XdsLogDetails, error) {
+	updates *model.PushRequest) (model.Resources, model.XdsLogDetails, error) {
 	res := model.Resources{}
 	var buffer bytes.Buffer
 	if w.ResourceNames == nil {
-		return res, nil, fmt.Errorf("debug type is required")
+		return res, model.DefaultXdsLogDetails, fmt.Errorf("debug type is required")
 	}
 	if len(w.ResourceNames) != 1 {
-		return res, nil, fmt.Errorf("only one debug request is allowed")
+		return res, model.DefaultXdsLogDetails, fmt.Errorf("only one debug request is allowed")
 	}
 	resourceName := w.ResourceNames[0]
 	u, _ := url.Parse(resourceName)
@@ -104,7 +104,7 @@ func (dg *DebugGen) Generate(proxy *model.Proxy, push *model.PushContext, w *mod
 			shouldAllow = true
 		}
 		if !shouldAllow {
-			return res, nil, fmt.Errorf("the debug info is not available for current identity: %q", identity)
+			return res, model.DefaultXdsLogDetails, fmt.Errorf("the debug info is not available for current identity: %q", identity)
 		}
 	}
 	debugURL := "/debug/" + resourceName
@@ -124,5 +124,5 @@ func (dg *DebugGen) Generate(proxy *model.Proxy, push *model.PushContext, w *mod
 			Value:   buffer.Bytes(),
 		},
 	})
-	return res, nil, nil
+	return res, model.DefaultXdsLogDetails, nil
 }

--- a/pilot/pkg/xds/debuggen.go
+++ b/pilot/pkg/xds/debuggen.go
@@ -41,7 +41,6 @@ var activeNamespaceDebuggers = map[string]struct{}{
 
 // DebugGen is a Generator for istio debug info
 type DebugGen struct {
-	model.BaseGenerator
 	Server          *DiscoveryServer
 	SystemNamespace string
 	DebugMux        *http.ServeMux
@@ -86,14 +85,14 @@ func NewDebugGen(s *DiscoveryServer, systemNamespace string) *DebugGen {
 
 // Generate XDS debug responses according to the incoming debug request
 func (dg *DebugGen) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource,
-	updates *model.PushRequest) (model.Resources, error) {
+	updates *model.PushRequest) (model.Resources, *model.XdsLogDetails, error) {
 	res := model.Resources{}
 	var buffer bytes.Buffer
 	if w.ResourceNames == nil {
-		return res, fmt.Errorf("debug type is required")
+		return res, nil, fmt.Errorf("debug type is required")
 	}
 	if len(w.ResourceNames) != 1 {
-		return res, fmt.Errorf("only one debug request is allowed")
+		return res, nil, fmt.Errorf("only one debug request is allowed")
 	}
 	resourceName := w.ResourceNames[0]
 	u, _ := url.Parse(resourceName)
@@ -105,7 +104,7 @@ func (dg *DebugGen) Generate(proxy *model.Proxy, push *model.PushContext, w *mod
 			shouldAllow = true
 		}
 		if !shouldAllow {
-			return res, fmt.Errorf("the debug info is not available for current identity: %q", identity)
+			return res, nil, fmt.Errorf("the debug info is not available for current identity: %q", identity)
 		}
 	}
 	debugURL := "/debug/" + resourceName
@@ -125,5 +124,5 @@ func (dg *DebugGen) Generate(proxy *model.Proxy, push *model.PushContext, w *mod
 			Value:   buffer.Bytes(),
 		},
 	})
-	return res, nil
+	return res, nil, nil
 }

--- a/pilot/pkg/xds/delta.go
+++ b/pilot/pkg/xds/delta.go
@@ -492,7 +492,6 @@ func (s *DiscoveryServer) pushDeltaXds(con *Connection, push *model.PushContext,
 			log.Infof("%s: %s for node:%s resources:%d size:%s%s",
 				ptype, v3.GetShortType(w.TypeUrl), con.proxy.ID, len(res), util.ByteCount(ResourceSize(res)), info)
 		}
-
 	}
 	return nil
 }

--- a/pilot/pkg/xds/delta.go
+++ b/pilot/pkg/xds/delta.go
@@ -480,14 +480,13 @@ func (s *DiscoveryServer) pushDeltaXds(con *Connection, push *model.PushContext,
 		info = " " + logdata.AdditionalInfo
 	}
 
-	if log.DebugEnabled() {
+	if log.DebugEnabled() && logdata.Incremental {
+		log.Debugf("%s: %s for node:%s resources:%d size:%s%s",
+			ptype, v3.GetShortType(w.TypeUrl), con.proxy.ID, len(res), util.ByteCount(ResourceSize(res)), info)
+	} else if log.DebugEnabled() {
 		// Add additional information to logs when debug mode enabled
 		log.Infof("%s: %s for node:%s resources:%d size:%s nonce:%v version:%v%s",
 			ptype, v3.GetShortType(w.TypeUrl), con.proxy.ID, len(res), util.ByteCount(ResourceSize(res)), resp.Nonce, resp.SystemVersionInfo, info)
-		if logdata.Incremental {
-			log.Debugf("%s: %s for node:%s resources:%d size:%s%s",
-				ptype, v3.GetShortType(w.TypeUrl), con.proxy.ID, len(res), util.ByteCount(ResourceSize(res)), info)
-		}
 	} else {
 		log.Infof("%s: %s for node:%s resources:%d size:%s%s",
 			ptype, v3.GetShortType(w.TypeUrl), con.proxy.ID, len(res), util.ByteCount(ResourceSize(res)), info)

--- a/pilot/pkg/xds/delta.go
+++ b/pilot/pkg/xds/delta.go
@@ -484,14 +484,13 @@ func (s *DiscoveryServer) pushDeltaXds(con *Connection, push *model.PushContext,
 		// Add additional information to logs when debug mode enabled
 		log.Infof("%s: %s for node:%s resources:%d size:%s nonce:%v version:%v%s",
 			ptype, v3.GetShortType(w.TypeUrl), con.proxy.ID, len(res), util.ByteCount(ResourceSize(res)), resp.Nonce, resp.SystemVersionInfo, info)
-	} else {
-		if logdata.Incremental && log.DebugEnabled() {
+		if logdata.Incremental {
 			log.Debugf("%s: %s for node:%s resources:%d size:%s%s",
 				ptype, v3.GetShortType(w.TypeUrl), con.proxy.ID, len(res), util.ByteCount(ResourceSize(res)), info)
-		} else {
-			log.Infof("%s: %s for node:%s resources:%d size:%s%s",
-				ptype, v3.GetShortType(w.TypeUrl), con.proxy.ID, len(res), util.ByteCount(ResourceSize(res)), info)
 		}
+	} else {
+		log.Infof("%s: %s for node:%s resources:%d size:%s%s",
+			ptype, v3.GetShortType(w.TypeUrl), con.proxy.ID, len(res), util.ByteCount(ResourceSize(res)), info)
 	}
 	return nil
 }

--- a/pilot/pkg/xds/delta.go
+++ b/pilot/pkg/xds/delta.go
@@ -485,8 +485,14 @@ func (s *DiscoveryServer) pushDeltaXds(con *Connection, push *model.PushContext,
 		log.Infof("%s: %s for node:%s resources:%d size:%s nonce:%v version:%v%s",
 			ptype, v3.GetShortType(w.TypeUrl), con.proxy.ID, len(res), util.ByteCount(ResourceSize(res)), resp.Nonce, resp.SystemVersionInfo, info)
 	} else {
-		log.Infof("%s: %s for node:%s resources:%d size:%s%s",
-			ptype, v3.GetShortType(w.TypeUrl), con.proxy.ID, len(res), util.ByteCount(ResourceSize(res)), info)
+		if logdata.Incremental && log.DebugEnabled() {
+			log.Debugf("%s: %s for node:%s resources:%d size:%s%s",
+				ptype, v3.GetShortType(w.TypeUrl), con.proxy.ID, len(res), util.ByteCount(ResourceSize(res)), info)
+		} else {
+			log.Infof("%s: %s for node:%s resources:%d size:%s%s",
+				ptype, v3.GetShortType(w.TypeUrl), con.proxy.ID, len(res), util.ByteCount(ResourceSize(res)), info)
+		}
+
 	}
 	return nil
 }

--- a/pilot/pkg/xds/delta.go
+++ b/pilot/pkg/xds/delta.go
@@ -416,7 +416,7 @@ func (s *DiscoveryServer) pushDeltaXds(con *Connection, push *model.PushContext,
 
 	t0 := time.Now()
 
-	res, err := gen.Generate(con.proxy, push, w, req)
+	res, logdata, err := gen.Generate(con.proxy, push, w, req)
 	if err != nil || res == nil {
 		// If we have nothing to send, report that we got an ACK for this version.
 		if s.StatusReporter != nil {
@@ -471,16 +471,22 @@ func (s *DiscoveryServer) pushDeltaXds(con *Connection, push *model.PushContext,
 		return err
 	}
 
-	// Some types handle logs inside Generate, skip them here.
-	if !gen.Metadata().LogsDetails {
-		if log.DebugEnabled() {
-			// Add additional information to logs when debug mode enabled
-			log.Infof("%s: PUSH for node:%s resources:%d size:%s nonce:%v version:%v",
-				v3.GetShortType(w.TypeUrl), con.proxy.ID, len(res), util.ByteCount(ResourceSize(res)), resp.Nonce, resp.SystemVersionInfo)
-		} else {
-			log.Infof("%s: PUSH for node:%s resources:%d size:%s",
-				v3.GetShortType(w.TypeUrl), con.proxy.ID, len(res), util.ByteCount(ResourceSize(res)))
+	ptype := "PUSH"
+	info := ""
+	if logdata != nil {
+		if logdata.Incremental {
+			ptype = "PUSH INC"
 		}
+		info = logdata.AdditionalInfo
+	}
+
+	if log.DebugEnabled() {
+		// Add additional information to logs when debug mode enabled
+		log.Infof("%s: %s for node:%s resources:%d size:%s nonce:%v version:%v %s",
+			ptype, v3.GetShortType(w.TypeUrl), con.proxy.ID, len(res), util.ByteCount(ResourceSize(res)), resp.Nonce, resp.SystemVersionInfo, info)
+	} else {
+		log.Infof("%s: %s for node:%s resources:%d size:%s %s",
+			ptype, v3.GetShortType(w.TypeUrl), con.proxy.ID, len(res), util.ByteCount(ResourceSize(res)), info)
 	}
 	return nil
 }

--- a/pilot/pkg/xds/delta.go
+++ b/pilot/pkg/xds/delta.go
@@ -473,19 +473,19 @@ func (s *DiscoveryServer) pushDeltaXds(con *Connection, push *model.PushContext,
 
 	ptype := "PUSH"
 	info := ""
-	if logdata != nil {
-		if logdata.Incremental {
-			ptype = "PUSH INC"
-		}
-		info = logdata.AdditionalInfo
+	if logdata.Incremental {
+		ptype = "PUSH INC"
+	}
+	if len(info) > 0 {
+		info = " " + logdata.AdditionalInfo
 	}
 
 	if log.DebugEnabled() {
 		// Add additional information to logs when debug mode enabled
-		log.Infof("%s: %s for node:%s resources:%d size:%s nonce:%v version:%v %s",
+		log.Infof("%s: %s for node:%s resources:%d size:%s nonce:%v version:%v%s",
 			ptype, v3.GetShortType(w.TypeUrl), con.proxy.ID, len(res), util.ByteCount(ResourceSize(res)), resp.Nonce, resp.SystemVersionInfo, info)
 	} else {
-		log.Infof("%s: %s for node:%s resources:%d size:%s %s",
+		log.Infof("%s: %s for node:%s resources:%d size:%s%s",
 			ptype, v3.GetShortType(w.TypeUrl), con.proxy.ID, len(res), util.ByteCount(ResourceSize(res)), info)
 	}
 	return nil

--- a/pilot/pkg/xds/ecds.go
+++ b/pilot/pkg/xds/ecds.go
@@ -52,13 +52,13 @@ func ecdsNeedsPush(req *model.PushRequest) bool {
 
 // Generate returns ECDS resources for a given proxy.
 func (e *EcdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource,
-	req *model.PushRequest) (model.Resources, *model.XdsLogDetails, error) {
+	req *model.PushRequest) (model.Resources, model.XdsLogDetails, error) {
 	if !ecdsNeedsPush(req) {
-		return nil, nil, nil
+		return nil, model.DefaultXdsLogDetails, nil
 	}
 	ec := e.Server.ConfigGenerator.BuildExtensionConfiguration(proxy, push, w.ResourceNames)
 	if ec == nil {
-		return nil, nil, nil
+		return nil, model.DefaultXdsLogDetails, nil
 	}
 
 	resources := make(model.Resources, 0, len(ec))
@@ -68,5 +68,5 @@ func (e *EcdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w 
 			Resource: util.MessageToAny(c),
 		})
 	}
-	return resources, nil, nil
+	return resources, model.DefaultXdsLogDetails, nil
 }

--- a/pilot/pkg/xds/ecds.go
+++ b/pilot/pkg/xds/ecds.go
@@ -51,7 +51,8 @@ func ecdsNeedsPush(req *model.PushRequest) bool {
 }
 
 // Generate returns ECDS resources for a given proxy.
-func (e *EcdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource, req *model.PushRequest) (model.Resources, *model.XdsLogDetails, error) {
+func (e *EcdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource,
+	req *model.PushRequest) (model.Resources, *model.XdsLogDetails, error) {
 	if !ecdsNeedsPush(req) {
 		return nil, nil, nil
 	}

--- a/pilot/pkg/xds/ecds.go
+++ b/pilot/pkg/xds/ecds.go
@@ -24,7 +24,6 @@ import (
 
 // EcdsGenerator generates ECDS configuration.
 type EcdsGenerator struct {
-	model.BaseGenerator
 	Server *DiscoveryServer
 }
 
@@ -52,13 +51,13 @@ func ecdsNeedsPush(req *model.PushRequest) bool {
 }
 
 // Generate returns ECDS resources for a given proxy.
-func (e *EcdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource, req *model.PushRequest) (model.Resources, error) {
+func (e *EcdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource, req *model.PushRequest) (model.Resources, *model.XdsLogDetails, error) {
 	if !ecdsNeedsPush(req) {
-		return nil, nil
+		return nil, nil, nil
 	}
 	ec := e.Server.ConfigGenerator.BuildExtensionConfiguration(proxy, push, w.ResourceNames)
 	if ec == nil {
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	resources := make(model.Resources, 0, len(ec))
@@ -68,5 +67,5 @@ func (e *EcdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w 
 			Resource: util.MessageToAny(c),
 		})
 	}
-	return resources, nil
+	return resources, nil, nil
 }

--- a/pilot/pkg/xds/eds.go
+++ b/pilot/pkg/xds/eds.go
@@ -356,9 +356,9 @@ func edsNeedsPush(updates model.XdsUpdates) bool {
 	return false
 }
 
-func (eds *EdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource, req *model.PushRequest) (model.Resources, error) {
+func (eds *EdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource, req *model.PushRequest) (model.Resources, *model.XdsLogDetails, error) {
 	if !edsNeedsPush(req.ConfigsUpdated) {
-		return nil, nil
+		return nil, nil, nil
 	}
 	var edsUpdatedServices map[string]struct{}
 	if !req.Full {
@@ -401,20 +401,8 @@ func (eds *EdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w
 			eds.Server.Cache.Add(builder, token, resource)
 		}
 	}
-	if len(edsUpdatedServices) == 0 {
-		log.Infof("EDS: PUSH%s for node:%s resources:%d size:%s empty:%v cached:%v/%v",
-			req.PushReason(), proxy.ID, len(resources), util.ByteCount(ResourceSize(resources)), empty, cached, cached+regenerated)
-	} else if log.DebugEnabled() {
-		log.Debugf("EDS: PUSH INC%s for node:%s clusters:%d size:%s empty:%v cached:%v/%v",
-			req.PushReason(), proxy.ID, len(resources), util.ByteCount(ResourceSize(resources)), empty, cached, cached+regenerated)
-	}
-	return resources, nil
-}
-
-var edsGeneratorMetadata = &model.GeneratorMetadata{LogsDetails: true}
-
-func (eds *EdsGenerator) Metadata() *model.GeneratorMetadata {
-	return edsGeneratorMetadata
+	return resources, &model.XdsLogDetails{Incremental: len(edsUpdatedServices) != 0,
+		AdditionalInfo: fmt.Sprintf("empty:%v cached:%v/%v", empty, cached, cached+regenerated)}, nil
 }
 
 func getOutlierDetectionAndLoadBalancerSettings(

--- a/pilot/pkg/xds/eds.go
+++ b/pilot/pkg/xds/eds.go
@@ -357,9 +357,9 @@ func edsNeedsPush(updates model.XdsUpdates) bool {
 }
 
 func (eds *EdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource,
-	req *model.PushRequest) (model.Resources, *model.XdsLogDetails, error) {
+	req *model.PushRequest) (model.Resources, model.XdsLogDetails, error) {
 	if !edsNeedsPush(req.ConfigsUpdated) {
-		return nil, nil, nil
+		return nil, model.DefaultXdsLogDetails, nil
 	}
 	var edsUpdatedServices map[string]struct{}
 	if !req.Full {
@@ -402,7 +402,7 @@ func (eds *EdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w
 			eds.Server.Cache.Add(builder, token, resource)
 		}
 	}
-	return resources, &model.XdsLogDetails{
+	return resources, model.XdsLogDetails{
 		Incremental:    len(edsUpdatedServices) != 0,
 		AdditionalInfo: fmt.Sprintf("empty:%v cached:%v/%v", empty, cached, cached+regenerated),
 	}, nil

--- a/pilot/pkg/xds/eds.go
+++ b/pilot/pkg/xds/eds.go
@@ -356,7 +356,8 @@ func edsNeedsPush(updates model.XdsUpdates) bool {
 	return false
 }
 
-func (eds *EdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource, req *model.PushRequest) (model.Resources, *model.XdsLogDetails, error) {
+func (eds *EdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource,
+	req *model.PushRequest) (model.Resources, *model.XdsLogDetails, error) {
 	if !edsNeedsPush(req.ConfigsUpdated) {
 		return nil, nil, nil
 	}
@@ -401,8 +402,10 @@ func (eds *EdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w
 			eds.Server.Cache.Add(builder, token, resource)
 		}
 	}
-	return resources, &model.XdsLogDetails{Incremental: len(edsUpdatedServices) != 0,
-		AdditionalInfo: fmt.Sprintf("empty:%v cached:%v/%v", empty, cached, cached+regenerated)}, nil
+	return resources, &model.XdsLogDetails{
+		Incremental:    len(edsUpdatedServices) != 0,
+		AdditionalInfo: fmt.Sprintf("empty:%v cached:%v/%v", empty, cached, cached+regenerated),
+	}, nil
 }
 
 func getOutlierDetectionAndLoadBalancerSettings(

--- a/pilot/pkg/xds/lds.go
+++ b/pilot/pkg/xds/lds.go
@@ -24,7 +24,6 @@ import (
 )
 
 type LdsGenerator struct {
-	model.BaseGenerator
 	Server *DiscoveryServer
 }
 
@@ -57,9 +56,9 @@ func ldsNeedsPush(req *model.PushRequest) bool {
 	return false
 }
 
-func (l LdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource, req *model.PushRequest) (model.Resources, error) {
+func (l LdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource, req *model.PushRequest) (model.Resources, *model.XdsLogDetails, error) {
 	if !ldsNeedsPush(req) {
-		return nil, nil
+		return nil, nil, nil
 	}
 	listeners := l.Server.ConfigGenerator.BuildListeners(proxy, push)
 	resources := model.Resources{}
@@ -69,5 +68,5 @@ func (l LdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *m
 			Resource: util.MessageToAny(c),
 		})
 	}
-	return resources, nil
+	return resources, nil, nil
 }

--- a/pilot/pkg/xds/lds.go
+++ b/pilot/pkg/xds/lds.go
@@ -56,7 +56,8 @@ func ldsNeedsPush(req *model.PushRequest) bool {
 	return false
 }
 
-func (l LdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource, req *model.PushRequest) (model.Resources, *model.XdsLogDetails, error) {
+func (l LdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource,
+	req *model.PushRequest) (model.Resources, *model.XdsLogDetails, error) {
 	if !ldsNeedsPush(req) {
 		return nil, nil, nil
 	}

--- a/pilot/pkg/xds/lds.go
+++ b/pilot/pkg/xds/lds.go
@@ -57,9 +57,9 @@ func ldsNeedsPush(req *model.PushRequest) bool {
 }
 
 func (l LdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource,
-	req *model.PushRequest) (model.Resources, *model.XdsLogDetails, error) {
+	req *model.PushRequest) (model.Resources, model.XdsLogDetails, error) {
 	if !ldsNeedsPush(req) {
-		return nil, nil, nil
+		return nil, model.DefaultXdsLogDetails, nil
 	}
 	listeners := l.Server.ConfigGenerator.BuildListeners(proxy, push)
 	resources := model.Resources{}
@@ -69,5 +69,5 @@ func (l LdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *m
 			Resource: util.MessageToAny(c),
 		})
 	}
-	return resources, nil, nil
+	return resources, model.DefaultXdsLogDetails, nil
 }

--- a/pilot/pkg/xds/nds.go
+++ b/pilot/pkg/xds/nds.go
@@ -68,14 +68,14 @@ func ndsNeedsPush(req *model.PushRequest) bool {
 }
 
 func (n NdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource,
-	req *model.PushRequest) (model.Resources, *model.XdsLogDetails, error) {
+	req *model.PushRequest) (model.Resources, model.XdsLogDetails, error) {
 	if !ndsNeedsPush(req) {
-		return nil, nil, nil
+		return nil, model.DefaultXdsLogDetails, nil
 	}
 	nt := n.Server.ConfigGenerator.BuildNameTable(proxy, push)
 	if nt == nil {
-		return nil, nil, nil
+		return nil, model.DefaultXdsLogDetails, nil
 	}
 	resources := model.Resources{&discovery.Resource{Resource: util.MessageToAny(nt)}}
-	return resources, nil, nil
+	return resources, model.DefaultXdsLogDetails, nil
 }

--- a/pilot/pkg/xds/nds.go
+++ b/pilot/pkg/xds/nds.go
@@ -29,7 +29,6 @@ import (
 // the agent will capture all DNS requests and attempt to resolve locally before forwarding to upstream
 // dns servers/
 type NdsGenerator struct {
-	model.BaseGenerator
 	Server *DiscoveryServer
 }
 
@@ -68,14 +67,14 @@ func ndsNeedsPush(req *model.PushRequest) bool {
 	return false
 }
 
-func (n NdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource, req *model.PushRequest) (model.Resources, error) {
+func (n NdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource, req *model.PushRequest) (model.Resources, *model.XdsLogDetails, error) {
 	if !ndsNeedsPush(req) {
-		return nil, nil
+		return nil, nil, nil
 	}
 	nt := n.Server.ConfigGenerator.BuildNameTable(proxy, push)
 	if nt == nil {
-		return nil, nil
+		return nil, nil, nil
 	}
 	resources := model.Resources{&discovery.Resource{Resource: util.MessageToAny(nt)}}
-	return resources, nil
+	return resources, nil, nil
 }

--- a/pilot/pkg/xds/nds.go
+++ b/pilot/pkg/xds/nds.go
@@ -67,7 +67,8 @@ func ndsNeedsPush(req *model.PushRequest) bool {
 	return false
 }
 
-func (n NdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource, req *model.PushRequest) (model.Resources, *model.XdsLogDetails, error) {
+func (n NdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource,
+	req *model.PushRequest) (model.Resources, *model.XdsLogDetails, error) {
 	if !ndsNeedsPush(req) {
 		return nil, nil, nil
 	}

--- a/pilot/pkg/xds/pcds.go
+++ b/pilot/pkg/xds/pcds.go
@@ -55,16 +55,16 @@ func pcdsNeedsPush(req *model.PushRequest) bool {
 
 // Generate returns ProxyConfig protobuf containing TrustBundle for given proxy
 func (e *PcdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource,
-	req *model.PushRequest) (model.Resources, *model.XdsLogDetails, error) {
+	req *model.PushRequest) (model.Resources, model.XdsLogDetails, error) {
 	if !pcdsNeedsPush(req) {
-		return nil, nil, nil
+		return nil, model.DefaultXdsLogDetails, nil
 	}
 	if e.TrustBundle == nil {
-		return nil, nil, nil
+		return nil, model.DefaultXdsLogDetails, nil
 	}
 	// TODO: For now, only TrustBundle updates are pushed. Eventually, this should push entire Proxy Configuration
 	pc := &mesh.ProxyConfig{
 		CaCertificatesPem: e.TrustBundle.GetTrustBundle(),
 	}
-	return model.Resources{&discovery.Resource{Resource: gogo.MessageToAny(pc)}}, nil, nil
+	return model.Resources{&discovery.Resource{Resource: gogo.MessageToAny(pc)}}, model.DefaultXdsLogDetails, nil
 }

--- a/pilot/pkg/xds/pcds.go
+++ b/pilot/pkg/xds/pcds.go
@@ -26,7 +26,6 @@ import (
 
 // ProxyConfigGenerator generates proxy configuration for proxies to consume
 type PcdsGenerator struct {
-	model.BaseGenerator
 	Server      *DiscoveryServer
 	TrustBundle *tb.TrustBundle
 }
@@ -55,16 +54,16 @@ func pcdsNeedsPush(req *model.PushRequest) bool {
 }
 
 // Generate returns ProxyConfig protobuf containing TrustBundle for given proxy
-func (e *PcdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource, req *model.PushRequest) (model.Resources, error) {
+func (e *PcdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource, req *model.PushRequest) (model.Resources, *model.XdsLogDetails, error) {
 	if !pcdsNeedsPush(req) {
-		return nil, nil
+		return nil, nil, nil
 	}
 	if e.TrustBundle == nil {
-		return nil, nil
+		return nil, nil, nil
 	}
 	// TODO: For now, only TrustBundle updates are pushed. Eventually, this should push entire Proxy Configuration
 	pc := &mesh.ProxyConfig{
 		CaCertificatesPem: e.TrustBundle.GetTrustBundle(),
 	}
-	return model.Resources{&discovery.Resource{Resource: gogo.MessageToAny(pc)}}, nil
+	return model.Resources{&discovery.Resource{Resource: gogo.MessageToAny(pc)}}, nil, nil
 }

--- a/pilot/pkg/xds/pcds.go
+++ b/pilot/pkg/xds/pcds.go
@@ -54,7 +54,8 @@ func pcdsNeedsPush(req *model.PushRequest) bool {
 }
 
 // Generate returns ProxyConfig protobuf containing TrustBundle for given proxy
-func (e *PcdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource, req *model.PushRequest) (model.Resources, *model.XdsLogDetails, error) {
+func (e *PcdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource,
+	req *model.PushRequest) (model.Resources, *model.XdsLogDetails, error) {
 	if !pcdsNeedsPush(req) {
 		return nil, nil, nil
 	}

--- a/pilot/pkg/xds/rds.go
+++ b/pilot/pkg/xds/rds.go
@@ -59,7 +59,8 @@ func rdsNeedsPush(req *model.PushRequest) bool {
 	return false
 }
 
-func (c RdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource, req *model.PushRequest) (model.Resources, *model.XdsLogDetails, error) {
+func (c RdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource,
+	req *model.PushRequest) (model.Resources, *model.XdsLogDetails, error) {
 	if !rdsNeedsPush(req) {
 		return nil, nil, nil
 	}

--- a/pilot/pkg/xds/rds.go
+++ b/pilot/pkg/xds/rds.go
@@ -60,9 +60,9 @@ func rdsNeedsPush(req *model.PushRequest) bool {
 }
 
 func (c RdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource,
-	req *model.PushRequest) (model.Resources, *model.XdsLogDetails, error) {
+	req *model.PushRequest) (model.Resources, model.XdsLogDetails, error) {
 	if !rdsNeedsPush(req) {
-		return nil, nil, nil
+		return nil, model.DefaultXdsLogDetails, nil
 	}
 	rawRoutes := c.Server.ConfigGenerator.BuildHTTPRoutes(proxy, push, w.ResourceNames)
 	resources := model.Resources{}
@@ -72,5 +72,5 @@ func (c RdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *m
 			Resource: util.MessageToAny(c),
 		})
 	}
-	return resources, nil, nil
+	return resources, model.DefaultXdsLogDetails, nil
 }

--- a/pilot/pkg/xds/rds.go
+++ b/pilot/pkg/xds/rds.go
@@ -24,7 +24,6 @@ import (
 )
 
 type RdsGenerator struct {
-	model.BaseGenerator
 	Server *DiscoveryServer
 }
 
@@ -60,9 +59,9 @@ func rdsNeedsPush(req *model.PushRequest) bool {
 	return false
 }
 
-func (c RdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource, req *model.PushRequest) (model.Resources, error) {
+func (c RdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource, req *model.PushRequest) (model.Resources, *model.XdsLogDetails, error) {
 	if !rdsNeedsPush(req) {
-		return nil, nil
+		return nil, nil, nil
 	}
 	rawRoutes := c.Server.ConfigGenerator.BuildHTTPRoutes(proxy, push, w.ResourceNames)
 	resources := model.Resources{}
@@ -72,5 +71,5 @@ func (c RdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *m
 			Resource: util.MessageToAny(c),
 		})
 	}
-	return resources, nil
+	return resources, nil, nil
 }

--- a/pilot/pkg/xds/sds.go
+++ b/pilot/pkg/xds/sds.go
@@ -101,22 +101,22 @@ func (s *SecretGen) proxyAuthorizedForSecret(proxy *model.Proxy, sr SecretResour
 	return nil
 }
 
-func (s *SecretGen) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource, req *model.PushRequest) (model.Resources, error) {
+func (s *SecretGen) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource, req *model.PushRequest) (model.Resources, *model.XdsLogDetails, error) {
 	if proxy.VerifiedIdentity == nil {
 		log.Warnf("proxy %v is not authorized to receive secrets. Ensure you are connecting over TLS port and are authenticated.", proxy.ID)
-		return nil, nil
+		return nil, nil, nil
 	}
 	secrets, err := s.secrets.ForCluster(proxy.Metadata.ClusterID)
 	if err != nil {
 		log.Warnf("proxy %v is from an unknown cluster, cannot retrieve certificates: %v", proxy.ID, err)
-		return nil, nil
+		return nil, nil, nil
 	}
 	if err := secrets.Authorize(proxy.VerifiedIdentity.ServiceAccount, proxy.VerifiedIdentity.Namespace); err != nil {
 		log.Warnf("proxy %v is not authorized to receive secrets: %v", proxy.ID, err)
-		return nil, nil
+		return nil, nil, nil
 	}
 	if req == nil || !needsUpdate(proxy, req.ConfigsUpdated) {
-		return nil, nil
+		return nil, nil, nil
 	}
 	var updatedSecrets map[model.ConfigKey]struct{}
 	if !req.Full {
@@ -177,15 +177,7 @@ func (s *SecretGen) Generate(proxy *model.Proxy, push *model.PushContext, w *mod
 			}
 		}
 	}
-	log.Infof("SDS: PUSH for node:%s resources:%d size:%s cached:%v/%v",
-		proxy.ID, len(results), util.ByteCount(ResourceSize(results)), cached, cached+regenerated)
-	return results, nil
-}
-
-var secretGenMetadata = &model.GeneratorMetadata{LogsDetails: true}
-
-func (s *SecretGen) Metadata() *model.GeneratorMetadata {
-	return secretGenMetadata
+	return results, &model.XdsLogDetails{AdditionalInfo: fmt.Sprintf("cached:%v/%v", cached, cached+regenerated)}, nil
 }
 
 func toEnvoyCaSecret(name string, cert []byte) *discovery.Resource {

--- a/pilot/pkg/xds/sds.go
+++ b/pilot/pkg/xds/sds.go
@@ -101,7 +101,8 @@ func (s *SecretGen) proxyAuthorizedForSecret(proxy *model.Proxy, sr SecretResour
 	return nil
 }
 
-func (s *SecretGen) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource, req *model.PushRequest) (model.Resources, *model.XdsLogDetails, error) {
+func (s *SecretGen) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource,
+	req *model.PushRequest) (model.Resources, *model.XdsLogDetails, error) {
 	if proxy.VerifiedIdentity == nil {
 		log.Warnf("proxy %v is not authorized to receive secrets. Ensure you are connecting over TLS port and are authenticated.", proxy.ID)
 		return nil, nil, nil

--- a/pilot/pkg/xds/sds_test.go
+++ b/pilot/pkg/xds/sds_test.go
@@ -325,7 +325,7 @@ func TestGenerate(t *testing.T) {
 
 			gen := s.Discovery.Generators[v3.SecretType]
 
-			secrets, _ := gen.Generate(s.SetupProxy(tt.proxy), s.PushContext(),
+			secrets, _, _ := gen.Generate(s.SetupProxy(tt.proxy), s.PushContext(),
 				&model.WatchedResource{ResourceNames: tt.resources}, tt.request)
 			raw := xdstest.ExtractTLSSecrets(t, model.ResourcesToAny(secrets))
 

--- a/pilot/pkg/xds/statusgen.go
+++ b/pilot/pkg/xds/statusgen.go
@@ -67,7 +67,8 @@ func NewStatusGen(s *DiscoveryServer) *StatusGen {
 // - connection status
 // - NACKs
 // We can also expose ACKS.
-func (sg *StatusGen) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource, updates *model.PushRequest) (model.Resources, *model.XdsLogDetails, error) {
+func (sg *StatusGen) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource,
+	updates *model.PushRequest) (model.Resources, *model.XdsLogDetails, error) {
 	res := model.Resources{}
 
 	switch w.TypeUrl {

--- a/pilot/pkg/xds/statusgen.go
+++ b/pilot/pkg/xds/statusgen.go
@@ -68,7 +68,7 @@ func NewStatusGen(s *DiscoveryServer) *StatusGen {
 // - NACKs
 // We can also expose ACKS.
 func (sg *StatusGen) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource,
-	updates *model.PushRequest) (model.Resources, *model.XdsLogDetails, error) {
+	updates *model.PushRequest) (model.Resources, model.XdsLogDetails, error) {
 	res := model.Resources{}
 
 	switch w.TypeUrl {
@@ -94,7 +94,7 @@ func (sg *StatusGen) Generate(proxy *model.Proxy, push *model.PushContext, w *mo
 			break
 		}
 	}
-	return res, nil, nil
+	return res, model.DefaultXdsLogDetails, nil
 }
 
 // isSidecar ad-hoc method to see if connection represents a sidecar

--- a/pilot/pkg/xds/statusgen.go
+++ b/pilot/pkg/xds/statusgen.go
@@ -51,7 +51,6 @@ const (
 
 // StatusGen is a Generator for XDS status: connections, syncz, configdump
 type StatusGen struct {
-	model.BaseGenerator
 	Server *DiscoveryServer
 
 	// TODO: track last N Nacks and connection events, with 'version' based on timestamp.
@@ -68,7 +67,7 @@ func NewStatusGen(s *DiscoveryServer) *StatusGen {
 // - connection status
 // - NACKs
 // We can also expose ACKS.
-func (sg *StatusGen) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource, updates *model.PushRequest) (model.Resources, error) {
+func (sg *StatusGen) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource, updates *model.PushRequest) (model.Resources, *model.XdsLogDetails, error) {
 	res := model.Resources{}
 
 	switch w.TypeUrl {
@@ -94,7 +93,7 @@ func (sg *StatusGen) Generate(proxy *model.Proxy, push *model.PushContext, w *mo
 			break
 		}
 	}
-	return res, nil
+	return res, nil, nil
 }
 
 // isSidecar ad-hoc method to see if connection represents a sidecar

--- a/pilot/pkg/xds/xdsgen.go
+++ b/pilot/pkg/xds/xdsgen.go
@@ -133,14 +133,13 @@ func (s *DiscoveryServer) pushXds(con *Connection, push *model.PushContext,
 		info = " " + logdata.AdditionalInfo
 	}
 
-	if log.DebugEnabled() {
+	if log.DebugEnabled() && logdata.Incremental {
+		log.Debugf("%s: %s%s for node:%s resources:%d size:%s%s",
+			v3.GetShortType(w.TypeUrl), ptype, req.PushReason(), con.ConID, len(res), util.ByteCount(configSize), info)
+	} else if log.DebugEnabled() {
 		// Add additional information to logs when debug mode enabled
 		log.Infof("%s: %s%s for node:%s resources:%d size:%s nonce:%v version:%v%s",
 			v3.GetShortType(w.TypeUrl), ptype, req.PushReason(), con.ConID, len(res), util.ByteCount(configSize), resp.Nonce, resp.VersionInfo, info)
-		if logdata.Incremental {
-			log.Debugf("%s: %s%s for node:%s resources:%d size:%s%s",
-				v3.GetShortType(w.TypeUrl), ptype, req.PushReason(), con.ConID, len(res), util.ByteCount(configSize), info)
-		}
 	} else {
 		log.Infof("%s: %s%s for node:%s resources:%d size:%s%s",
 			v3.GetShortType(w.TypeUrl), ptype, req.PushReason(), con.ConID, len(res), util.ByteCount(configSize), info)

--- a/pilot/pkg/xds/xdsgen.go
+++ b/pilot/pkg/xds/xdsgen.go
@@ -126,19 +126,19 @@ func (s *DiscoveryServer) pushXds(con *Connection, push *model.PushContext,
 
 	ptype := "PUSH"
 	info := ""
-	if logdata != nil {
-		if logdata.Incremental {
-			ptype = "PUSH INC"
-		}
-		info = logdata.AdditionalInfo
+	if logdata.Incremental {
+		ptype = "PUSH INC"
+	}
+	if len(info) > 0 {
+		info = " " + logdata.AdditionalInfo
 	}
 
 	if log.DebugEnabled() {
 		// Add additional information to logs when debug mode enabled
-		log.Infof("%s: %s%s for node:%s resources:%d size:%s nonce:%v version:%v %s",
+		log.Infof("%s: %s%s for node:%s resources:%d size:%s nonce:%v version:%v%s",
 			v3.GetShortType(w.TypeUrl), ptype, req.PushReason(), con.ConID, len(res), util.ByteCount(configSize), resp.Nonce, resp.VersionInfo, info)
 	} else {
-		log.Infof("%s: %s%s for node:%s resources:%d size:%s %s",
+		log.Infof("%s: %s%s for node:%s resources:%d size:%s%s",
 			v3.GetShortType(w.TypeUrl), ptype, req.PushReason(), con.ConID, len(res), util.ByteCount(configSize), info)
 	}
 

--- a/pilot/pkg/xds/xdsgen.go
+++ b/pilot/pkg/xds/xdsgen.go
@@ -98,7 +98,7 @@ func (s *DiscoveryServer) pushXds(con *Connection, push *model.PushContext,
 
 	t0 := time.Now()
 
-	res, err := gen.Generate(con.proxy, push, w, req)
+	res, logdata, err := gen.Generate(con.proxy, push, w, req)
 	if err != nil || res == nil {
 		// If we have nothing to send, report that we got an ACK for this version.
 		if s.StatusReporter != nil {
@@ -124,16 +124,22 @@ func (s *DiscoveryServer) pushXds(con *Connection, push *model.PushContext,
 		return err
 	}
 
-	// Some types handle logs inside Generate, skip them here
-	if !gen.Metadata().LogsDetails {
-		if log.DebugEnabled() {
-			// Add additional information to logs when debug mode enabled
-			log.Infof("%s: PUSH%s for node:%s resources:%d size:%s nonce:%v version:%v",
-				v3.GetShortType(w.TypeUrl), req.PushReason(), con.ConID, len(res), util.ByteCount(configSize), resp.Nonce, resp.VersionInfo)
-		} else {
-			log.Infof("%s: PUSH%s for node:%s resources:%d size:%s",
-				v3.GetShortType(w.TypeUrl), req.PushReason(), con.ConID, len(res), util.ByteCount(configSize))
+	ptype := "PUSH"
+	info := ""
+	if logdata != nil {
+		if logdata.Incremental {
+			ptype = "PUSH INC"
 		}
+		info = logdata.AdditionalInfo
+	}
+
+	if log.DebugEnabled() {
+		// Add additional information to logs when debug mode enabled
+		log.Infof("%s: %s%s for node:%s resources:%d size:%s nonce:%v version:%v %s",
+			v3.GetShortType(w.TypeUrl), ptype, req.PushReason(), con.ConID, len(res), util.ByteCount(configSize), resp.Nonce, resp.VersionInfo, info)
+	} else {
+		log.Infof("%s: %s%s for node:%s resources:%d size:%s %s",
+			v3.GetShortType(w.TypeUrl), ptype, req.PushReason(), con.ConID, len(res), util.ByteCount(configSize), info)
 	}
 
 	return nil

--- a/pilot/pkg/xds/xdsgen.go
+++ b/pilot/pkg/xds/xdsgen.go
@@ -137,14 +137,13 @@ func (s *DiscoveryServer) pushXds(con *Connection, push *model.PushContext,
 		// Add additional information to logs when debug mode enabled
 		log.Infof("%s: %s%s for node:%s resources:%d size:%s nonce:%v version:%v%s",
 			v3.GetShortType(w.TypeUrl), ptype, req.PushReason(), con.ConID, len(res), util.ByteCount(configSize), resp.Nonce, resp.VersionInfo, info)
-	} else {
-		if logdata.Incremental && log.DebugEnabled() {
+		if logdata.Incremental {
 			log.Debugf("%s: %s%s for node:%s resources:%d size:%s%s",
 				v3.GetShortType(w.TypeUrl), ptype, req.PushReason(), con.ConID, len(res), util.ByteCount(configSize), info)
-		} else {
-			log.Infof("%s: %s%s for node:%s resources:%d size:%s%s",
-				v3.GetShortType(w.TypeUrl), ptype, req.PushReason(), con.ConID, len(res), util.ByteCount(configSize), info)
 		}
+	} else {
+		log.Infof("%s: %s%s for node:%s resources:%d size:%s%s",
+			v3.GetShortType(w.TypeUrl), ptype, req.PushReason(), con.ConID, len(res), util.ByteCount(configSize), info)
 	}
 
 	return nil

--- a/pilot/pkg/xds/xdsgen.go
+++ b/pilot/pkg/xds/xdsgen.go
@@ -138,8 +138,13 @@ func (s *DiscoveryServer) pushXds(con *Connection, push *model.PushContext,
 		log.Infof("%s: %s%s for node:%s resources:%d size:%s nonce:%v version:%v%s",
 			v3.GetShortType(w.TypeUrl), ptype, req.PushReason(), con.ConID, len(res), util.ByteCount(configSize), resp.Nonce, resp.VersionInfo, info)
 	} else {
-		log.Infof("%s: %s%s for node:%s resources:%d size:%s%s",
-			v3.GetShortType(w.TypeUrl), ptype, req.PushReason(), con.ConID, len(res), util.ByteCount(configSize), info)
+		if logdata.Incremental && log.DebugEnabled() {
+			log.Debugf("%s: %s%s for node:%s resources:%d size:%s%s",
+				v3.GetShortType(w.TypeUrl), ptype, req.PushReason(), con.ConID, len(res), util.ByteCount(configSize), info)
+		} else {
+			log.Infof("%s: %s%s for node:%s resources:%d size:%s%s",
+				v3.GetShortType(w.TypeUrl), ptype, req.PushReason(), con.ConID, len(res), util.ByteCount(configSize), info)
+		}
 	}
 
 	return nil

--- a/security/pkg/nodeagent/sds/sdsservice.go
+++ b/security/pkg/nodeagent/sds/sdsservice.go
@@ -155,7 +155,8 @@ func (s *sdsservice) generate(resourceNames []string) (model.Resources, error) {
 
 // Generate implements the XDS Generator interface. This allows the XDS server to dispatch requests
 // for SecretTypeV3 to our server to generate the Envoy response.
-func (s *sdsservice) Generate(_ *model.Proxy, _ *model.PushContext, w *model.WatchedResource, updates *model.PushRequest) (model.Resources, *model.XdsLogDetails, error) {
+func (s *sdsservice) Generate(_ *model.Proxy, _ *model.PushContext, w *model.WatchedResource,
+	updates *model.PushRequest) (model.Resources, *model.XdsLogDetails, error) {
 	// updates.Full indicates we should do a complete push of all updated resources
 	// In practice, all pushes should be incremental (ie, if the `default` cert changes we won't push
 	// all file certs).

--- a/security/pkg/nodeagent/sds/sdsservice.go
+++ b/security/pkg/nodeagent/sds/sdsservice.go
@@ -155,14 +155,14 @@ func (s *sdsservice) generate(resourceNames []string) (model.Resources, error) {
 
 // Generate implements the XDS Generator interface. This allows the XDS server to dispatch requests
 // for SecretTypeV3 to our server to generate the Envoy response.
-func (s *sdsservice) Generate(_ *model.Proxy, _ *model.PushContext, w *model.WatchedResource, updates *model.PushRequest) (model.Resources, error) {
+func (s *sdsservice) Generate(_ *model.Proxy, _ *model.PushContext, w *model.WatchedResource, updates *model.PushRequest) (model.Resources, *model.XdsLogDetails, error) {
 	// updates.Full indicates we should do a complete push of all updated resources
 	// In practice, all pushes should be incremental (ie, if the `default` cert changes we won't push
 	// all file certs).
 	if updates.Full {
 		resp, err := s.generate(w.ResourceNames)
 		pushLog(w.ResourceNames, err)
-		return resp, err
+		return resp, nil, err
 	}
 	names := []string{}
 	watched := sets.NewSet(w.ResourceNames...)
@@ -173,13 +173,7 @@ func (s *sdsservice) Generate(_ *model.Proxy, _ *model.PushContext, w *model.Wat
 	}
 	resp, err := s.generate(names)
 	pushLog(names, err)
-	return resp, err
-}
-
-var sdsGeneratorMetadata = &model.GeneratorMetadata{LogsDetails: true}
-
-func (s *sdsservice) Metadata() *model.GeneratorMetadata {
-	return sdsGeneratorMetadata
+	return resp, nil, err
 }
 
 // register adds the SDS handle to the grpc server

--- a/security/pkg/nodeagent/sds/sdsservice.go
+++ b/security/pkg/nodeagent/sds/sdsservice.go
@@ -156,14 +156,14 @@ func (s *sdsservice) generate(resourceNames []string) (model.Resources, error) {
 // Generate implements the XDS Generator interface. This allows the XDS server to dispatch requests
 // for SecretTypeV3 to our server to generate the Envoy response.
 func (s *sdsservice) Generate(_ *model.Proxy, _ *model.PushContext, w *model.WatchedResource,
-	updates *model.PushRequest) (model.Resources, *model.XdsLogDetails, error) {
+	updates *model.PushRequest) (model.Resources, model.XdsLogDetails, error) {
 	// updates.Full indicates we should do a complete push of all updated resources
 	// In practice, all pushes should be incremental (ie, if the `default` cert changes we won't push
 	// all file certs).
 	if updates.Full {
 		resp, err := s.generate(w.ResourceNames)
 		pushLog(w.ResourceNames, err)
-		return resp, nil, err
+		return resp, model.DefaultXdsLogDetails, err
 	}
 	names := []string{}
 	watched := sets.NewSet(w.ResourceNames...)
@@ -174,7 +174,7 @@ func (s *sdsservice) Generate(_ *model.Proxy, _ *model.PushContext, w *model.Wat
 	}
 	resp, err := s.generate(names)
 	pushLog(names, err)
-	return resp, nil, err
+	return resp, model.DefaultXdsLogDetails, err
 }
 
 // register adds the SDS handle to the grpc server


### PR DESCRIPTION
Moves xds generator logs to central place and individual generators return the metadta

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
