### PR TITLE
Add monitoring for clusters known to istiod

### DIFF
--- a/pilot/pkg/secrets/kube/multicluster.go
+++ b/pilot/pkg/secrets/kube/multicluster.go
@@ -41,7 +41,7 @@ var (
 	clusterType = monitoring.MustCreateLabel("cluster_type")
 
 	clustersCount = monitoring.NewGauge(
-		"istiod_managed_clusters_total",
+		"istiod_managed_clusters",
 		"Number of clusters managed by istiod",
 		monitoring.WithLabels(clusterType),
 	)

--- a/pkg/kube/secretcontroller/secretcontroller.go
+++ b/pkg/kube/secretcontroller/secretcontroller.go
@@ -50,17 +50,11 @@ const (
 
 func init() {
 	monitoring.MustRegister(timeouts)
-	monitoring.MustRegister(remoteClustersCount)
 }
 
 var timeouts = monitoring.NewSum(
 	"remote_cluster_sync_timeouts_total",
 	"Number of times remote clusters took too long to sync, causing slow startup that excludes remote clusters.",
-)
-
-var remoteClustersCount = monitoring.NewGauge(
-	"istiod_remote_clusters_total",
-	"Number of remote clusters monitored by istiod",
 )
 
 // newClientCallback prototype for the add secret callback function.
@@ -124,7 +118,6 @@ type ClusterStore struct {
 // newClustersStore initializes data struct to store clusters information
 func newClustersStore() *ClusterStore {
 	remoteClusters := make(map[string]*Cluster)
-	remoteClustersCount.Record(0)
 	return &ClusterStore{
 		remoteClusters: remoteClusters,
 	}
@@ -421,7 +414,6 @@ func (c *Controller) addMemberCluster(secretName string, s *corev1.Secret) {
 	}
 
 	log.Infof("Number of remote clusters: %d", c.cs.Len())
-	remoteClustersCount.Record(float64(c.cs.Len()))
 }
 
 func (c *Controller) deleteMemberCluster(secretName string) {
@@ -429,7 +421,6 @@ func (c *Controller) deleteMemberCluster(secretName string) {
 	defer func() {
 		c.cs.Unlock()
 		log.Infof("Number of remote clusters: %d", len(c.cs.remoteClusters))
-		remoteClustersCount.Record(float64(len(c.cs.remoteClusters)))
 	}()
 	for clusterID, cluster := range c.cs.remoteClusters {
 		if cluster.secretName == secretName {

--- a/releasenotes/notes/istiod-cluster-metric.yaml
+++ b/releasenotes/notes/istiod-cluster-metric.yaml
@@ -3,5 +3,5 @@ kind: feature
 area: telemetry
 releaseNotes:
 - |
-  **Added** a new metric (`istiod_managed_clusters_total`) to `istiod` to track the number of clusters managed by an
+  **Added** a new metric (`istiod_managed_clusters`) to `istiod` to track the number of clusters managed by an
   `istiod` instance.

--- a/releasenotes/notes/istiod-cluster-metric.yaml
+++ b/releasenotes/notes/istiod-cluster-metric.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: feature
+area: telemetry
+releaseNotes:
+- |
+  **Added** a new metric (`istiod_managed_clusters_total`) to `istiod` to track the number of clusters managed by an
+  `istiod` instance.


### PR DESCRIPTION
This PR adds a new gauge to `istiod`. The gauge monitors the number of total clusters known to `istiod`, dimensioned by `cluster_type` ([`local`, `remote`]).

This PR is intended to provide insight into MC scenarios beyond the workload logs (that also monitor these scenarios). At the moment, no counters are kept for failures to initialize remote clusters, etc.  Depending on reviewer taste, that can follow or be added to this PR.

[ X ] Networking
[ X ] Policies and Telemetry
