### PR TITLE
Improve format of `istioctl pc r` with multiple domains

### DIFF
--- a/istioctl/pkg/writer/envoy/configdump/route.go
+++ b/istioctl/pkg/writer/envoy/configdump/route.go
@@ -94,21 +94,19 @@ func describeRouteDomains(domains []string) string {
 	}
 
 	// Return the shortest non-numeric domain.  Count of domains seems uninteresting.
-	candidate := domains[0]
-	for _, domain := range domains {
-		if len(domain) == 0 {
-			continue
-		}
-		firstChar := domain[0]
-		if firstChar >= '1' && firstChar <= '9' {
-			continue
-		}
-		if len(domain) < len(candidate) {
-			candidate = domain
+	max := 2
+	withoutPort := make([]string, 0, len(domains))
+	for _, d := range domains {
+		if !strings.Contains(d, ":") {
+			withoutPort = append(withoutPort, d)
 		}
 	}
-
-	return candidate
+	visible := withoutPort[:max]
+	ret := strings.Join(visible, ", ")
+	if len(withoutPort) > max {
+		return fmt.Sprintf("%s + %d more...", ret, len(withoutPort)-max)
+	}
+	return ret
 }
 
 func describeManagement(metadata *envoy_config_core_v3.Metadata) string {


### PR DESCRIPTION
The `+ x more...` format is stolen from kubectl

BEFORE
```
NAME                                DOMAINS                    MATCH                  VIRTUAL SERVICE
http.80                             hello.default              /*                     hello-ingress.default
http.80                             hello.default              /*                     hello-ingress.default
http.80                             other.bar                  /*                     echo.default
http.8081                           hello-private.default      /*                     hello-private-ingress.default
http.8081                           hello-private.default      /*                     hello-private-ingress.default
http.8081                           hello.default              /*                     hello-ingress.default
http.8081                           hello.default              /*                     hello-ingress.default
https.443.https.gateway.default     d.35.184.249.94.nip.io     /productpage           a.default
https.443.https.gateway.default     d.35.184.249.94.nip.io     /productpage/2         a.default
                                    *                          /healthz/ready*
                                    *                          /stats/prometheus*
```

AFTER
```
NAME                                DOMAINS                                                              MATCH                  VIRTUAL SERVICE
http.80                             hello.default, hello.default.172.17.255.155.sslip.io + 2 more...     /*                     hello-ingress.default
http.80                             hello.default, hello.default.172.17.255.155.sslip.io + 2 more...     /*                     hello-ingress.default
http.80                             howardjohn.default, other.bar                                        /*                     echo.default
http.8081                           hello-private.default, hello-private.default.svc + 1 more...         /*                     hello-private-ingress.default
http.8081                           hello-private.default, hello-private.default.svc + 1 more...         /*                     hello-private-ingress.default
http.8081                           hello.default, hello.default.172.17.255.155.sslip.io + 2 more...     /*                     hello-ingress.default
http.8081                           hello.default, hello.default.172.17.255.155.sslip.io + 2 more...     /*                     hello-ingress.default
https.443.https.gateway.default     d.35.184.249.94.nip.io, e.35.184.249.94.nip.io + 4 more...           /productpage           a.default
https.443.https.gateway.default     d.35.184.249.94.nip.io, e.35.184.249.94.nip.io + 4 more...           /productpage/2         a.default
                                    *                                                                    /healthz/ready*
                                    *                                                                    /stats/prometheus*
```