### PR TITLE
Optimize route generation by collapsing overlapping routes

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -447,6 +447,9 @@ var (
 	EnableEnvoyFilterMetrics = env.RegisterBoolVar("PILOT_ENVOY_FILTER_STATS", false,
 		"If true, Pilot will collect metrics for envoy filter operations.").Get()
 
+	EnableRouteCollapse = env.RegisterBoolVar("PILOT_ENABLE_ROUTE_COLLAPSE_OPTIMIZATION", true,
+		"If true, Pilot will merge virtual hosts with the same routes into a single virtual host, as an optimization.").Get()
+
 	delayedCloseTimeoutVar = env.RegisterDurationVar(
 		"PILOT_HTTP_DELAYED_CLOSE_TIMEOUT",
 		1*time.Second,

--- a/releasenotes/notes/route-collapse.yaml
+++ b/releasenotes/notes/route-collapse.yaml
@@ -6,3 +6,15 @@ issue:
 releaseNotes:
 - |
   **Optimized** generated routing configuration to merge virtual hosts with the same routing configuration. This improves performance for Virtual Services with multiple hostnames defined.
+
+upgradeNotes:
+- title: EnvoyFilter `match.routeConfiguration.vhost.name` semantics change
+  content: |
+    `EnvoyFilter` matches rely on internal implementation details to match generated XDS segments, which is subject to change at any time.
+
+    In this release, the [virtual host name match](https://istio.io/latest/docs/reference/config/networking/envoy-filter/#EnvoyFilter-RouteConfigurationMatch-VirtualHostMatch) may have different results.
+
+    Previously, each domain name had its own virtual host. As an optimization, multiple domains may use a single virtual host.
+    This means that a Envoy Filter previously matching a specific virtual host may now apply to more domains than in previous releases.
+
+    This optimization may be temporarily disabled by setting PILOT_ENABLE_ROUTE_COLLAPSE_OPTIMIZATION=false on the Istiod deployment.

--- a/releasenotes/notes/route-collapse.yaml
+++ b/releasenotes/notes/route-collapse.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+issue:
+- 28659
+releaseNotes:
+- |
+  **Optimized** generated routing configuration to merge virtual hosts with the same routing configuration. This improves performance for Virtual Services with multiple hostnames defined.

--- a/releasenotes/notes/route-collapse.yaml
+++ b/releasenotes/notes/route-collapse.yaml
@@ -17,4 +17,4 @@ upgradeNotes:
     Previously, each domain name had its own virtual host. As an optimization, multiple domains may use a single virtual host.
     This means that a Envoy Filter previously matching a specific virtual host may now apply to more domains than in previous releases.
 
-    This optimization may be temporarily disabled by setting PILOT_ENABLE_ROUTE_COLLAPSE_OPTIMIZATION=false on the Istiod deployment.
+    This optimization may be temporarily disabled by setting `PILOT_ENABLE_ROUTE_COLLAPSE_OPTIMIZATION=false` on the Istiod deployment.


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/28659
Helps with https://github.com/knative-sandbox/net-istio/issues/630

Benchmarks (I removed ones with no change):
```
name                                   old time/op        new time/op        delta
RouteGeneration/gateways-6                   43.2ms ± 3%        30.3ms ± 3%  -29.79%  (p=0.000 n=10+10)
RouteGeneration/gateways-shared-6             175ms ± 4%          86ms ± 3%  -50.89%  (p=0.000 n=10+10)
RouteGeneration/knative-gateway-6            9.44ms ± 2%        4.02ms ± 1%  -57.41%  (p=0.000 n=10+9)

name                                   old kb/msg         new kb/msg         delta
RouteGeneration/gateways-6                    2.67k ± 0%         1.14k ± 0%  -57.34%  (p=0.000 n=10+10)
RouteGeneration/gateways-shared-6             12.6k ± 0%          4.2k ± 0%  -66.66%  (p=0.000 n=10+10)
RouteGeneration/knative-gateway-6               868 ± 0%           218 ± 0%  -74.91%  (p=0.000 n=10+10)


name                                   old alloc/op       new alloc/op       delta
RouteGeneration/gateways-6                   17.4MB ± 0%        14.2MB ± 0%  -18.09%  (p=0.000 n=9+10)
RouteGeneration/gateways-shared-6            68.0MB ± 0%        45.0MB ± 0%  -33.73%  (p=0.000 n=9+9)
RouteGeneration/knative-gateway-6            3.38MB ± 0%        2.01MB ± 0%  -40.69%  (p=0.000 n=9+10)

name                                   old allocs/op      new allocs/op      delta
RouteGeneration/gateways-6                     213k ± 0%          163k ± 0%  -23.45%  (p=0.000 n=10+10)
RouteGeneration/gateways-shared-6              896k ± 0%          596k ± 0%  -33.47%  (p=0.000 n=9+9)
RouteGeneration/knative-gateway-6             43.6k ± 0%         28.3k ± 0%  -35.02%  (p=0.000 n=10+10)

```

Overall a big reduction in XDS size and CPU/memory usage

```
with virtual service:
  hosts: [a, b]
  route:
  - route1
  - route2

before:
vhost: [a], routes: [route1, route2]
vhost: [b], routes: [route1, route2]

after:
vhost: [a, b], routes: [route1, route2]
```