### PR TITLE
Allow specifying a reason for annotation deprecation

### DIFF
--- a/galley/pkg/config/analysis/analyzers/annotations/annotations.go
+++ b/galley/pkg/config/analysis/analyzers/annotations/annotations.go
@@ -92,10 +92,16 @@ outer:
 		}
 
 		if annotationDef.Deprecated {
-			m := msg.NewDeprecatedAnnotation(r, ann, deprecationExtraMessages[annotationDef.Name])
-			util.AddLineNumber(r, ann, m)
+			if _, f := r.Metadata.Labels[annotation.SidecarInject.Name]; f && ann == annotation.SidecarInject.Name {
+				// Skip to avoid noise; the user has the deprecated annotation but they also have the replacement
+				// This means they are likely aware its deprecated, but are keeping both variants around for maximum
+				// compatibility
+			} else {
+				m := msg.NewDeprecatedAnnotation(r, ann, deprecationExtraMessages[annotationDef.Name])
+				util.AddLineNumber(r, ann, m)
 
-			ctx.Report(collectionType, m)
+				ctx.Report(collectionType, m)
+			}
 		}
 
 		// If the annotation def attaches to Any, exit early

--- a/galley/pkg/config/analysis/analyzers/annotations/annotations.go
+++ b/galley/pkg/config/analysis/analyzers/annotations/annotations.go
@@ -66,6 +66,10 @@ func (fa *K8sAnalyzer) Analyze(ctx analysis.Context) {
 	})
 }
 
+var deprecationExtraMessages = map[string]string{
+	annotation.SidecarInject.Name: ` in favor of the "sidecar.istio.io/inject" label`,
+}
+
 func (*K8sAnalyzer) allowAnnotations(r *resource.Instance, ctx analysis.Context, kind string, collectionType collection.Name) {
 	if len(r.Metadata.Annotations) == 0 {
 		return
@@ -88,7 +92,7 @@ outer:
 		}
 
 		if annotationDef.Deprecated {
-			m := msg.NewDeprecatedAnnotation(r, ann)
+			m := msg.NewDeprecatedAnnotation(r, ann, deprecationExtraMessages[annotationDef.Name])
 			util.AddLineNumber(r, ann, m)
 
 			ctx.Report(collectionType, m)

--- a/galley/pkg/config/analysis/msg/messages.gen.go
+++ b/galley/pkg/config/analysis/msg/messages.gen.go
@@ -135,7 +135,7 @@ var (
 
 	// DeprecatedAnnotation defines a diag.MessageType for message "DeprecatedAnnotation".
 	// Description: A resource is using a deprecated Istio annotation.
-	DeprecatedAnnotation = diag.NewMessageType(diag.Info, "IST0135", "Annotation %q has been deprecated and may not work in future Istio versions.")
+	DeprecatedAnnotation = diag.NewMessageType(diag.Info, "IST0135", "Annotation %q has been deprecated%s and may not work in future Istio versions.")
 
 	// AlphaAnnotation defines a diag.MessageType for message "AlphaAnnotation".
 	// Description: An Istio annotation may not be suitable for production.
@@ -541,11 +541,12 @@ func NewServiceEntryAddressesRequired(r *resource.Instance) diag.Message {
 }
 
 // NewDeprecatedAnnotation returns a new diag.Message based on DeprecatedAnnotation.
-func NewDeprecatedAnnotation(r *resource.Instance, annotation string) diag.Message {
+func NewDeprecatedAnnotation(r *resource.Instance, annotation string, extra string) diag.Message {
 	return diag.NewMessage(
 		DeprecatedAnnotation,
 		r,
 		annotation,
+		extra,
 	)
 }
 

--- a/galley/pkg/config/analysis/msg/messages.yaml
+++ b/galley/pkg/config/analysis/msg/messages.yaml
@@ -358,9 +358,11 @@ messages:
     code: IST0135
     level: Info
     description: "A resource is using a deprecated Istio annotation."
-    template: "Annotation %q has been deprecated and may not work in future Istio versions."
+    template: "Annotation %q has been deprecated%s and may not work in future Istio versions."
     args:
       - name: annotation
+        type: string
+      - name: extra
         type: string
 
   - name: "AlphaAnnotation"


### PR DESCRIPTION
This assists https://github.com/istio/api/pull/1997

Example:
```
Info [IST0135] (Pod shell-74bc57ff88-ptb6d.default) Annotation "sidecar.istio.io/discoveryAddress" has been deprecated and may not work in future Istio versions.
Info [IST0135] (Pod shell-74bc57ff88-ptb6d.default) Annotation "sidecar.istio.io/inject" has been deprecated in favor of the "sidecar.istio.io/inject" label and may not work in future Istio versions.
```

This has been replaced with a label of the same name. The label is
strictly more powerful since selection is done in Kubernetes, rather
than in Istio.

See
https://preliminary.istio.io/latest/docs/setup/additional-setup/sidecar-injection/#controlling-the-injection-policy
