### PR TITLE
fix (potential) loopref issues in codebase

### DIFF
--- a/istioctl/pkg/verifier/verifier.go
+++ b/istioctl/pkg/verifier/verifier.go
@@ -394,13 +394,13 @@ func (v *StatusVerifier) injectorFromCluster(revision string) (*admit_v1.Mutatin
 
 	revCount := 0
 	var hookmatch *admit_v1.MutatingWebhookConfiguration
-	for _, hook := range hooks.Items {
+	for i, hook := range hooks.Items {
 		rev := hook.ObjectMeta.GetLabels()[label.IoIstioRev.Name]
 		if rev != "" {
 			revCount++
 			revision = rev
 			if revision == "" || revision == rev {
-				hookmatch = &hook
+				hookmatch = &hooks.Items[i]
 			}
 		}
 	}

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -1428,10 +1428,10 @@ func (ps *PushContext) initSidecarScopes(env *Environment) error {
 	// Currently we expect that it has no workloadSelectors
 	var rootNSConfig *config.Config
 	if ps.Mesh.RootNamespace != "" {
-		for _, sidecarConfig := range sidecarConfigs {
+		for i, sidecarConfig := range sidecarConfigs {
 			if sidecarConfig.Namespace == ps.Mesh.RootNamespace &&
 				sidecarConfig.Spec.(*networking.Sidecar).WorkloadSelector == nil {
-				rootNSConfig = &sidecarConfig
+				rootNSConfig = &sidecarConfigs[i]
 				break
 			}
 		}

--- a/pilot/pkg/serviceregistry/kube/controller/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller_test.go
@@ -1505,8 +1505,8 @@ func updateEndpoints(controller *FakeController, name, namespace string, portNam
 
 	// Update endpoint slice as well
 	esps := make([]discovery.EndpointPort, 0)
-	for _, name := range portNames {
-		esps = append(esps, discovery.EndpointPort{Name: &name, Port: &portNum})
+	for i := range portNames {
+		esps = append(esps, discovery.EndpointPort{Name: &portNames[i], Port: &portNum})
 	}
 	endpointSlice := &discovery.EndpointSlice{
 		ObjectMeta: metaV1.ObjectMeta{

--- a/pkg/test/framework/components/echo/common/call.go
+++ b/pkg/test/framework/components/echo/common/call.go
@@ -194,10 +194,10 @@ func fillInCallOptions(opts *echo.CallOptions) error {
 		} else {
 			// Look up the port.
 			found := false
-			for _, port := range targetPorts {
+			for i, port := range targetPorts {
 				if opts.PortName == port.Name {
 					found = true
-					opts.Port = &port
+					opts.Port = &targetPorts[i]
 					break
 				}
 			}

--- a/tools/bug-report/pkg/cluster/cluster.go
+++ b/tools/bug-report/pkg/cluster/cluster.go
@@ -79,14 +79,14 @@ func GetClusterResources(ctx context.Context, clientset *kubernetes.Clientset) (
 		if err != nil {
 			return nil, err
 		}
-		for _, p := range pods.Items {
+		for i, p := range pods.Items {
 			deployment := getOwnerDeployment(&p, replicasets.Items)
 			for _, c := range p.Spec.Containers {
 				out.insertContainer(ns.Name, deployment, p.Name, c.Name)
 			}
 			out.Labels[PodKey(p.Namespace, p.Name)] = p.Labels
 			out.Annotations[PodKey(p.Namespace, p.Name)] = p.Annotations
-			out.Pod[PodKey(p.Namespace, p.Name)] = &p
+			out.Pod[PodKey(p.Namespace, p.Name)] = &pods.Items[i]
 		}
 	}
 	if len(errs) != 0 {


### PR DESCRIPTION
This PR represents the first step towards upgrading the linter used in this project to be able to detect problematic references to loop variables.  This issue has caused a few known issues recently (example: integration test framework code). As a result, there is a desire to warn when issues potentially arise.

The fixes in this PR were guided by a local run of the linter, upgraded to version 1.40.1 with `exportloopref` enabled.  Output:

```
$ ./common/scripts/lint_go.sh 
INFO [config_reader] Used config file common/config/.golangci.yml 
INFO [lintersdb] Active 19 linters: [deadcode errcheck exportloopref gocritic gofumpt goimports golint gosimple govet ineffassign lll misspell staticcheck structcheck stylecheck typecheck unconvert unparam varcheck] 
INFO [loader] Using build tags: [integ]           
INFO [loader] Go packages loading at mode 575 (compiled_files|deps|files|types_sizes|exports_file|imports|name) took 44.153046079s 
WARN [runner] The linter 'golint' is deprecated (since v1.41.0) due to: The repository of the linter has been archived by the owner.  Replaced by revive. 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 159.789834ms 
INFO [linters context/goanalysis] analyzers took 15m15.629374956s with top 10 stages: buildir: 3m55.180528173s, buildssa: 2m19.159148467s, unconvert: 30.036106224s, goimports: 25.51100774s, unparam: 18.142255374s, fact_deprecated: 15.660858039s, gofumpt: 14.729080742s, nilness: 13.911476186s, gocritic: 13.115293921s, inspect: 10.743149732s 
INFO [runner] Issues before processing: 6600, after processing: 5 
INFO [runner] Processors filtering stat (out/in): max_from_linter: 5/5, sort_results: 5/5, cgo: 6600/6600, skip_files: 4002/6600, max_per_file_from_linter: 5/5, path_shortener: 5/5, severity-rules: 5/5, exclude-rules: 245/3918, path_prefixer: 5/5, filename_unadjuster: 6600/6600, path_prettifier: 6600/6600, autogenerated_exclude: 4002/4002, identifier_marker: 4002/4002, exclude: 3918/4002, source_code: 5/5, skip_dirs: 4002/4002, nolint: 5/245, uniq_by_line: 5/5, diff: 5/5, max_same_issues: 5/5 
INFO [runner] processing took 346.718348ms with stages: nolint: 94.299327ms, exclude-rules: 79.327997ms, identifier_marker: 63.920274ms, path_prettifier: 39.681693ms, autogenerated_exclude: 31.815769ms, skip_files: 18.999061ms, exclude: 9.704118ms, skip_dirs: 7.731984ms, cgo: 642.252µs, filename_unadjuster: 338.572µs, source_code: 246.871µs, uniq_by_line: 3.131µs, max_from_linter: 2.523µs, path_shortener: 2.151µs, max_same_issues: 980ns, max_per_file_from_linter: 766ns, diff: 302ns, severity-rules: 271ns, sort_results: 206ns, path_prefixer: 100ns 
INFO [runner] linters took 59.331258498s with stages: goanalysis_metalinter: 58.984436095s 
tools/bug-report/pkg/cluster/cluster.go:89:44: exporting a pointer for the loop variable p (exportloopref)
                        out.Pod[PodKey(p.Namespace, p.Name)] = &p
                                                                ^
pkg/test/framework/components/echo/common/call.go:200:19: exporting a pointer for the loop variable port (exportloopref)
                                        opts.Port = &port
                                                     ^
istioctl/pkg/verifier/verifier.go:403:18: exporting a pointer for the loop variable hook (exportloopref)
                                hookmatch = &hook
                                             ^
pilot/pkg/model/push_context.go:1434:21: exporting a pointer for the loop variable sidecarConfig (exportloopref)
                                rootNSConfig = &sidecarConfig
                                                ^
pilot/pkg/serviceregistry/kube/controller/controller_test.go:1509:53: exporting a pointer for the loop variable name (exportloopref)
                esps = append(esps, discovery.EndpointPort{Name: &name, Port: &portNum})
                                                                  ^
INFO File cache stats: 1518 entries of total size 10.5MiB 
INFO Memory: 1013 samples, avg is 1271.0MB, max is 3253.9MB 
```

[ X ] Test and Release
[ X ] Developer Infrastructure
[ X ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
