### PR TITLE
injector: define empty template var

### DIFF
--- a/pkg/kube/inject/inject.go
+++ b/pkg/kube/inject/inject.go
@@ -86,14 +86,15 @@ const (
 // SidecarTemplateData is the data object to which the templated
 // version of `SidecarInjectionSpec` is applied.
 type SidecarTemplateData struct {
-	TypeMeta       *metav1.TypeMeta
-	DeploymentMeta *metav1.ObjectMeta
-	ObjectMeta     metav1.ObjectMeta
-	Spec           corev1.PodSpec
-	ProxyConfig    *meshconfig.ProxyConfig
-	MeshConfig     *meshconfig.MeshConfig
-	Values         map[string]interface{}
-	Revision       string
+	TypeMeta             *metav1.TypeMeta
+	DeploymentMeta       *metav1.ObjectMeta
+	ObjectMeta           metav1.ObjectMeta
+	Spec                 corev1.PodSpec
+	ProxyConfig          *meshconfig.ProxyConfig
+	MeshConfig           *meshconfig.MeshConfig
+	Values               map[string]interface{}
+	Revision             string
+	EstimatedConcurrency int
 }
 
 type (


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

Non-functional backport of https://github.com/istio/istio/pull/32928 to prevent breakage of 1.11 injector configmap on 1.10.