### PR TITLE
Avoid high-probability hash collisions, use md5 instead of crc32

### DIFF
--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -106,7 +106,7 @@ type SidecarScope struct {
 	// Set of known configs this sidecar depends on.
 	// This field will be used to determine the config/resource scope
 	// which means which config changes will affect the proxies within this scope.
-	configDependencies map[uint32]struct{}
+	configDependencies map[uint64]struct{}
 
 	// The namespace to treat as the administrative root namespace for
 	// Istio configuration.
@@ -187,7 +187,7 @@ func DefaultSidecarScopeForNamespace(ps *PushContext, configNamespace string) *S
 		services:           defaultEgressListener.services,
 		destinationRules:   make(map[host.Name]*config.Config),
 		servicesByHostname: make(map[host.Name]*Service, len(defaultEgressListener.services)),
-		configDependencies: make(map[uint32]struct{}),
+		configDependencies: make(map[uint64]struct{}),
 		RootNamespace:      ps.Mesh.RootNamespace,
 		Version:            ps.PushVersion,
 	}
@@ -250,7 +250,7 @@ func ConvertToSidecarScope(ps *PushContext, sidecarConfig *config.Config, config
 		Name:               sidecarConfig.Name,
 		Namespace:          configNamespace,
 		Sidecar:            sidecar,
-		configDependencies: make(map[uint32]struct{}),
+		configDependencies: make(map[uint64]struct{}),
 		RootNamespace:      ps.Mesh.RootNamespace,
 		Version:            ps.PushVersion,
 	}
@@ -539,7 +539,7 @@ func (sc *SidecarScope) AddConfigDependencies(dependencies ...ConfigKey) {
 		return
 	}
 	if sc.configDependencies == nil {
-		sc.configDependencies = make(map[uint32]struct{})
+		sc.configDependencies = make(map[uint64]struct{})
 	}
 
 	for _, config := range dependencies {


### PR DESCRIPTION
It may not be suitable to use crc32 in this scenario

``` shell
$ cat ./main.go 
package main

import (
	"fmt"
	"hash/crc32"
)

func main() {
	a := crc32.ChecksumIEEE([]byte("xxx-c294f5b1"))
	b := crc32.ChecksumIEEE([]byte("xxx-fc26498f"))
	fmt.Println(a == b, a, b)
}

$ go run ./main.go  
true 2816933872 2816933872

```

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
