### PR TITLE
get more info on echo timeouts

### DIFF
--- a/pkg/test/echo/server/forwarder/instance.go
+++ b/pkg/test/echo/server/forwarder/instance.go
@@ -164,7 +164,10 @@ func (i *Instance) Run(ctx context.Context) (*proto.ForwardEchoResponse, error) 
 				tt += responseTimes[id]
 			}
 		}
-		avgTime := tt / time.Duration(c)
+		var avgTime time.Duration
+		if c > 0 {
+			avgTime = tt / time.Duration(c)
+		}
 		return nil, fmt.Errorf("request set timed out after %v and only %d/%d requests completed (%v avg)", i.timeout, c, i.count, avgTime)
 	}
 

--- a/pkg/test/echo/server/forwarder/instance.go
+++ b/pkg/test/echo/server/forwarder/instance.go
@@ -86,7 +86,7 @@ func New(cfg Config) (*Instance, error) {
 func (i *Instance) Run(ctx context.Context) (*proto.ForwardEchoResponse, error) {
 	g := multierror.Group{}
 	responsesMu := sync.RWMutex{}
-	responses := make([]string, i.count)
+	responses, responseTimes := make([]string, i.count), make([]time.Duration, i.count)
 
 	var throttle *time.Ticker
 
@@ -121,19 +121,23 @@ func (i *Instance) Run(ctx context.Context) (*proto.ForwardEchoResponse, error) 
 		}
 
 		if err := sem.Acquire(ctx, 1); err != nil {
-			return nil, fmt.Errorf("failed acquiring semaphore: %v", err)
+			// this should only occur for a timeout, fallthrough to the ctx.Done() select case
+			break
 		}
 		g.Go(func() error {
 			defer sem.Release(1)
 			if canceled {
 				return fmt.Errorf("request set timed out")
 			}
+			st := time.Now()
 			resp, err := i.p.makeRequest(ctx, &r)
+			rt := time.Since(st)
 			if err != nil {
 				return err
 			}
 			responsesMu.Lock()
 			responses[r.RequestID] = resp
+			responseTimes[r.RequestID] = rt
 			responsesMu.Unlock()
 			return nil
 		})
@@ -152,13 +156,16 @@ func (i *Instance) Run(ctx context.Context) (*proto.ForwardEchoResponse, error) 
 	case <-ctx.Done():
 		responsesMu.RLock()
 		defer responsesMu.RUnlock()
-		c := 0
-		for _, res := range responses {
-			if res != "" {
+		var c int
+		var tt time.Duration
+		for id, res := range responses {
+			if res != "" && responseTimes[id] != 0 {
 				c++
+				tt += responseTimes[id]
 			}
 		}
-		return nil, fmt.Errorf("request set timed out after %v and only %d/%d requests completed", i.timeout, c, i.count)
+		avgTime := tt / time.Duration(c)
+		return nil, fmt.Errorf("request set timed out after %v and only %d/%d requests completed (%v avg)", i.timeout, c, i.count, avgTime)
 	}
 
 	return &proto.ForwardEchoResponse{


### PR DESCRIPTION
When `Count > maxConcurrency`, a timeout will give us `failed acquiring semaphore: context deadline exceeded` if all requests in `Count` haven't at least started. This isn't very useful when trying to tune timeouts for the failing test. 

* Calculate the average response times for each call
* Include the # of requests that were completed even when all requests haven't been enqueued. 