### PR TITLE
tf: attempt to speed up resource dump

### DIFF
--- a/pkg/test/framework/scope.go
+++ b/pkg/test/framework/scope.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"reflect"
 	"sync"
+	"time"
 
 	"github.com/hashicorp/go-multierror"
 
@@ -172,14 +173,25 @@ func (s *scope) waitForDone() {
 }
 
 func (s *scope) dump(ctx resource.Context) {
+	st := time.Now()
+	defer func() {
+		scopes.Framework.Infof("Done dumping scope: %s (%v)", s.id, time.Since(st))
+	}()
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for _, c := range s.children {
 		c.dump(ctx)
 	}
+	wg := sync.WaitGroup{}
 	for _, c := range s.resources {
 		if d, ok := c.(resource.Dumper); ok {
-			d.Dump(ctx)
+			d := d
+			wg.Add(1)
+			go func() {
+				d.Dump(ctx)
+				wg.Done()
+			}()
 		}
 	}
+	wg.Wait()
 }


### PR DESCRIPTION
I want to get more info about how much time dumps take, since we're doing it at every level of subtest (there is definitely some level of redundancy here).

Depending on the results. it may make sense to add a `NoDump` option to TestContext. We can use this in `echotest` in the cases where we know there isn't a config change per-cluster, and we can rely on the dump from the next level up. 

This PR: 
* dump every resource in parallel. not sure if this is a good idea – if the Dump impl has it's own concurrency, this may not give us any real gains
* log the time it takes to dump

