### PR TITLE
Make bin/retry.sh only use TTY if parent has TTY

### DIFF
--- a/bin/retry.sh
+++ b/bin/retry.sh
@@ -25,6 +25,14 @@ function fail {
   exit 1
 }
 
+function isatty() {
+ if [ -t 1 ] ; then
+   return 0
+  else
+   return 1
+  fi
+}
+
 function retry {
   local tmpFile
   tmpFile=$(mktemp)
@@ -36,7 +44,13 @@ function retry {
   local max=5
   while true; do
     unset SHELL # Don't let environment control which shell to use
-    script --flush --quiet --return "${tmpFile}" --command "${*}"
+    if isatty; then
+      script --flush --quiet --return "${tmpFile}" --command "${*}"
+    else
+      # if we aren't a TTY, run directly as script will always run with a tty, which may output content that
+      # we cannot display
+      set -o pipefail; "$@" 2>&1 | tee "${tmpFile}"
+    fi
     # shellcheck disable=SC2181
     if [[ $? == 0 ]]; then
       break


### PR DESCRIPTION
Otherwise in CI we try to output things that don't work. Now we get a
TTY IFF the caller has one
I think I finally got this right...