### PR TITLE
Workaround conflicting port mapping in Gateway

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -44,6 +44,17 @@ import (
 	"istio.io/pkg/log"
 )
 
+// DisableGatewayPortTranslationLabel is a label on Service that declares that, for that particular
+// service, we should not translate Gateway ports to target ports. For example, if I have a Service
+// on port 80 with target port 8080, with the label. Gateways on port 80 would *not* match. Instead,
+// only Gateways on port 8080 would be used. This prevents ambiguities when there are multiple
+// Services on port 80 referring to different target ports. Long term, this will be replaced by
+// Gateways directly referencing a Service, rather than label selectors. Warning: this label is
+// intended solely for as a workaround for Knative's Istio integration, and not intended for any
+// other usage. It can, and will, be removed immediately after the new direct reference is ready for
+// use.
+const DisableGatewayPortTranslationLabel = "experimental.istio.io/disable-gateway-port-translation"
+
 func (configgen *ConfigGeneratorImpl) buildGatewayListeners(builder *ListenerBuilder) *ListenerBuilder {
 	if builder.node.MergedGateway == nil {
 		log.Debugf("buildGatewayListeners: no gateways for router %v", builder.node.ID)
@@ -61,7 +72,15 @@ func (configgen *ConfigGeneratorImpl) buildGatewayListeners(builder *ListenerBui
 		servers := ms.Servers
 		var si *model.ServiceInstance
 		services := make(map[host.Name]struct{}, len(builder.node.ServiceInstances))
+		foundDirectPortTranslation := false
 		for _, w := range builder.node.ServiceInstances {
+			_, directPortTranslation := w.Service.Attributes.Labels[DisableGatewayPortTranslationLabel]
+			if directPortTranslation {
+				if w.Endpoint.EndpointPort == port.Number {
+					foundDirectPortTranslation = true
+				}
+				continue
+			}
 			if w.ServicePort.Port == int(port.Number) {
 				if si == nil {
 					si = w
@@ -69,14 +88,19 @@ func (configgen *ConfigGeneratorImpl) buildGatewayListeners(builder *ListenerBui
 				services[w.Service.Hostname] = struct{}{}
 			}
 		}
-		if len(services) != 1 {
+		if len(services) == 0 && foundDirectPortTranslation {
+			log.Debugf("buildGatewayListeners: using direct port mapping due to disable label for %v",
+				port.Number)
+		} else if len(services) != 1 {
 			log.Warnf("buildGatewayListeners: found %d services on port %d: %v",
 				len(services), port.Number, services)
 		}
+
 		// if we found a ServiceInstance with matching ServicePort, listen on TargetPort
 		if si != nil && si.Endpoint != nil {
 			port.Number = si.Endpoint.EndpointPort
 		}
+
 		if builder.node.Metadata.UnprivilegedPod != "" && port.Number < 1024 {
 			log.Warnf("buildGatewayListeners: skipping privileged gateway port %d for node %s as it is an unprivileged pod",
 				port.Number, builder.node.ID)

--- a/pilot/pkg/serviceregistry/serviceentry/conversion.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion.go
@@ -194,13 +194,13 @@ func convertServices(cfg config.Config) []*model.Service {
 	}
 
 	out = append(out, buildServices(hostAddresses, cfg.Namespace, svcPorts, serviceEntry.Location, resolution,
-		exportTo, labelSelectors, serviceEntry.SubjectAltNames, creationTime)...)
+		exportTo, labelSelectors, serviceEntry.SubjectAltNames, creationTime, cfg.Labels)...)
 	return out
 }
 
 func buildServices(hostAddresses []*HostAddress, namespace string, ports model.PortList, location networking.ServiceEntry_Location,
 	resolution model.Resolution, exportTo map[visibility.Instance]bool, selectors map[string]string, saccounts []string,
-	ctime time.Time) []*model.Service {
+	ctime time.Time, labels map[string]string) []*model.Service {
 	out := make([]*model.Service, 0, len(hostAddresses))
 	for _, ha := range hostAddresses {
 		out = append(out, &model.Service{
@@ -214,6 +214,7 @@ func buildServices(hostAddresses []*HostAddress, namespace string, ports model.P
 				ServiceRegistry: string(serviceregistry.External),
 				Name:            ha.host,
 				Namespace:       namespace,
+				Labels:          labels,
 				ExportTo:        exportTo,
 				LabelSelectors:  selectors,
 			},

--- a/pilot/pkg/serviceregistry/serviceentry/conversion_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion_test.go
@@ -138,7 +138,6 @@ var httpDNSnoEndpoints = &config.Config{
 		Name:              "httpDNSnoEndpoints",
 		Namespace:         "httpDNSnoEndpoints",
 		CreationTimestamp: GlobalTime,
-		Labels:            map[string]string{label.SecurityTlsMode.Name: model.IstioMutualTLSModeLabel},
 	},
 	Spec: &networking.ServiceEntry{
 		Hosts: []string{"google.com", "www.wikipedia.org"},
@@ -174,7 +173,6 @@ var httpDNS = &config.Config{
 		Name:              "httpDNS",
 		Namespace:         "httpDNS",
 		CreationTimestamp: GlobalTime,
-		Labels:            map[string]string{label.SecurityTlsMode.Name: model.IstioMutualTLSModeLabel},
 	},
 	Spec: &networking.ServiceEntry{
 		Hosts: []string{"*.google.com"},
@@ -209,7 +207,6 @@ var tcpDNS = &config.Config{
 		Name:              "tcpDNS",
 		Namespace:         "tcpDNS",
 		CreationTimestamp: GlobalTime,
-		Labels:            map[string]string{label.SecurityTlsMode.Name: model.IstioMutualTLSModeLabel},
 	},
 	Spec: &networking.ServiceEntry{
 		Hosts: []string{"tcpdns.com"},
@@ -237,7 +234,6 @@ var tcpStatic = &config.Config{
 		Name:              "tcpStatic",
 		Namespace:         "tcpStatic",
 		CreationTimestamp: GlobalTime,
-		Labels:            map[string]string{label.SecurityTlsMode.Name: model.IstioMutualTLSModeLabel},
 	},
 	Spec: &networking.ServiceEntry{
 		Hosts:     []string{"tcpstatic.com"},
@@ -266,7 +262,6 @@ var httpNoneInternal = &config.Config{
 		Name:              "httpNoneInternal",
 		Namespace:         "httpNoneInternal",
 		CreationTimestamp: GlobalTime,
-		Labels:            map[string]string{label.SecurityTlsMode.Name: model.IstioMutualTLSModeLabel},
 	},
 	Spec: &networking.ServiceEntry{
 		Hosts: []string{"*.google.com"},
@@ -285,7 +280,6 @@ var tcpNoneInternal = &config.Config{
 		Name:              "tcpNoneInternal",
 		Namespace:         "tcpNoneInternal",
 		CreationTimestamp: GlobalTime,
-		Labels:            map[string]string{label.SecurityTlsMode.Name: model.IstioMutualTLSModeLabel},
 	},
 	Spec: &networking.ServiceEntry{
 		Hosts:     []string{"tcpinternal.com"},
@@ -304,7 +298,6 @@ var multiAddrInternal = &config.Config{
 		Name:              "multiAddrInternal",
 		Namespace:         "multiAddrInternal",
 		CreationTimestamp: GlobalTime,
-		Labels:            map[string]string{label.SecurityTlsMode.Name: model.IstioMutualTLSModeLabel},
 	},
 	Spec: &networking.ServiceEntry{
 		Hosts:     []string{"tcp1.com", "tcp2.com"},
@@ -344,7 +337,6 @@ var selectorDNS = &config.Config{
 		Name:              "selector",
 		Namespace:         "selector",
 		CreationTimestamp: GlobalTime,
-		Labels:            map[string]string{label.SecurityTlsMode.Name: model.IstioMutualTLSModeLabel},
 	},
 	Spec: &networking.ServiceEntry{
 		Hosts: []string{"selector.com"},
@@ -366,7 +358,6 @@ var selector = &config.Config{
 		Name:              "selector",
 		Namespace:         "selector",
 		CreationTimestamp: GlobalTime,
-		Labels:            map[string]string{label.SecurityTlsMode.Name: model.IstioMutualTLSModeLabel},
 	},
 	Spec: &networking.ServiceEntry{
 		Hosts: []string{"selector.com"},


### PR DESCRIPTION
This is intended to be a minimal, backport-able change to allow Knative to work; currently Istio+Knative is extremely fragile and breaks under situations when Services are created out of order.

The long term solution is in https://github.com/istio/istio/pull/32653, but will take many months to be adopted.

The tl;dr is that we add an explicit label on the service and then we no longer try to translate the Gateway port to a targetPort for that service. This avoids the ambiguity that Knative has as shown in the test. Without the change, the test will result in a NACK.
cc @arturenault 