### PR TITLE
Temporarily disable CI dumping

### DIFF
--- a/tests/integration/tests.mk
+++ b/tests/integration/tests.mk
@@ -8,7 +8,9 @@ _INTEGRATION_TEST_FLAGS ?= $(INTEGRATION_TEST_FLAGS)
 
 # $(CI) specifies that the test is running in a CI system. This enables CI specific logging.
 ifneq ($(CI),)
-	_INTEGRATION_TEST_FLAGS += --istio.test.ci
+# TODO(https://github.com/istio/istio/issues/32985) re-enable dumping
+# This is disabled as dumping leads to massive IO and we want to investigate if removal will improve things
+#	_INTEGRATION_TEST_FLAGS += --istio.test.ci
 	_INTEGRATION_TEST_FLAGS += --istio.test.pullpolicy=IfNotPresent
 endif
 


### PR DESCRIPTION
This is to see if it improves our IO usage on our nodes, or if its not
the root cause. Currently we are hitting over 120mb/s writes which is
leading to massive IO throttling

This of course will make debugging test failures ~impossible so we should merge only for a day or 2 and revert