### PR TITLE
fix envoy process leak when systemd stop istio

### DIFF
--- a/tools/packaging/common/istio-start.sh
+++ b/tools/packaging/common/istio-start.sh
@@ -134,5 +134,5 @@ else
 currentLimit=$(ulimit -n)
 
 # Will run: ${ISTIO_BIN_BASE}/envoy -c $ENVOY_CFG --restart-epoch 0 --drain-time-s 2 --parent-shutdown-time-s 3 --service-cluster $SVC --service-node 'sidecar~${ISTIO_SVC_IP}~${POD_NAME}.${NS}.svc.cluster.local~${NS}.svc.cluster.local' $ISTIO_DEBUG >${ISTIO_LOG_DIR}/istio.log" istio-proxy
-exec su -s /bin/bash -c "ulimit -n ${currentLimit}; INSTANCE_IP=${ISTIO_SVC_IP} POD_NAME=${POD_NAME} POD_NAMESPACE=${NS} exec ${ISTIO_BIN_BASE}/pilot-agent proxy ${ISTIO_AGENT_FLAGS_ARRAY[*]} 2> ${ISTIO_LOG_DIR}/istio.err.log > ${ISTIO_LOG_DIR}/istio.log" ${EXEC_USER}
+exec sudo -E -u ${EXEC_USER} -s /bin/bash -c "ulimit -n ${currentLimit}; INSTANCE_IP=${ISTIO_SVC_IP} POD_NAME=${POD_NAME} POD_NAMESPACE=${NS} exec ${ISTIO_BIN_BASE}/pilot-agent proxy ${ISTIO_AGENT_FLAGS_ARRAY[*]} 2> ${ISTIO_LOG_DIR}/istio.err.log > ${ISTIO_LOG_DIR}/istio.log"
 fi

--- a/tools/packaging/common/istio.service
+++ b/tools/packaging/common/istio.service
@@ -8,6 +8,7 @@ ExecStopPost=/usr/local/bin/istio-start.sh clean
 Restart=always
 StartLimitInterval=0
 RestartSec=10
+KillMode=mixed
 
 [Install]
 WantedBy=multi-user.target

--- a/tools/packaging/common/istio.service
+++ b/tools/packaging/common/istio.service
@@ -9,6 +9,7 @@ Restart=always
 StartLimitInterval=0
 RestartSec=10
 KillMode=mixed
+TimeoutStopSec=30s
 
 [Install]
 WantedBy=multi-user.target

--- a/tools/packaging/packaging.mk
+++ b/tools/packaging/packaging.mk
@@ -81,6 +81,7 @@ rpm/fpm:
 		--description "Istio Sidecar" \
 		--depends iproute \
 		--depends iptables \
+		--depends sudo \
 		$(SIDECAR_FILES)
 
 # Centos 7 compatible RPM
@@ -97,6 +98,7 @@ rpm-7/fpm:
 		--description "Istio Sidecar" \
 		--depends iproute \
 		--depends iptables \
+		--depends sudo \
 		$(SIDECAR_CENTOS_7_FILES)
 
 # Package the sidecar deb file.
@@ -113,6 +115,7 @@ deb/fpm:
 		--description "Istio Sidecar" \
 		--depends iproute2 \
 		--depends iptables \
+		--depends sudo \
 		$(SIDECAR_FILES)
 
 ${ISTIO_OUT_LINUX}/release/istio.deb:


### PR DESCRIPTION

virtual machine OS:  Ubuntu 20.04.1 LTS
istio version: 1.10.0

Running istio(pilot-agent and envoy) on virtual machine, when `systemctl stop istio`, the `istio-pilot` process is terminated,  but the envoy process is still there. I have to kill the envoy process by kill, otherwise `systemctl start istio` will failed as the old envoy process still listens on the port.

How to reproduce this bug:

1. install istio on virtual machine according to [Virtual Machine Installation](https://istio.io/latest/docs/setup/install/virtual-machine/)
2. ensure the istio-pilot and envoy process is running
3. run `systemctl stop isto`, and will find that the istio-pilot process is terminated, but the envoy process is still there, and it's farther process is pid 1 now.


```bash
# ps -ef|grep istio
istio-p+  108661       1  0 20:24 ?        00:00:00 /lib/systemd/systemd --user
istio-p+  108662  108661  0 20:24 ?        00:00:00 (sd-pam)
istio-p+  108674       1  0 20:24 ?        00:00:00 /usr/local/bin/envoy -c etc/istio/proxy/envoy-rev0.json --restart-epoch 0 --drain-time-s 45 --drain-strategy immediate --parent-shutdown-time-s 60 --service-cluster istio-proxy --service-node sidecar~192.168.0.204~cilium-1.istio-demo~istio-demo.svc.cluster.local --local-address-ip-version v4 --bootstrap-version 3 --disable-hot-restart --log-format %Y-%m-%dT%T.%fZ?%l?envoy %n?%v -l warning --component-log-level misc:error --concurrency 2
```

Here is `/var/log/istio/isto.log`.

```txt
2021-05-23T12:24:37.145539Z	info	cache	returned workload certificate from cache	ttl=23h59m58.854464634s
2021-05-23T12:24:37.145749Z	info	sds	SDS: PUSH	resource=default
2021-05-23T12:24:49.823967Z	info	Agent draining Proxy
2021-05-23T12:24:49.823979Z	info	Status server has successfully terminated
2021-05-23T12:24:49.825257Z	error	accept tcp [::]:15020: use of closed network connection
2021-05-23T12:24:49.825789Z	info	Graceful termination period is 5s, starting...
```

`Graceful termination period complete` is not printed. As `a.terminationDrainDuration` is 5 seconds by default, the pilot-agent process is killed by someone before the time reached.

```go
func (a *Agent) terminate() {
	log.Infof("Agent draining Proxy")
	e := a.proxy.Drain()
	if e != nil {
		log.Warnf("Error in invoking drain listeners endpoint %v", e)
	}
	log.Infof("Graceful termination period is %v, starting...", a.terminationDrainDuration)
	time.Sleep(a.terminationDrainDuration)
	log.Infof("Graceful termination period complete, terminating remaining proxies.")
	a.abortCh <- errAbort
	log.Warnf("Aborted all epochs")
}
```

The systemctl stop costs 2 seconds.

```
# time systemctl stop istio

real	0m2.080s
user	0m0.005s
sys	0m0.000s
```

This is because the `su` command [waits for 2 second for the child](https://github.com/karelzak/util-linux/blob/master/login-utils/su-common.c#L602), then it will kill the child process, just as we see above.

So it is better to change `su` to `sudo` which has no such limit.

Also the  `KillMode` should be changed from the default `control-group` to `mixed`, which will prevent systemd from killing all processes, according to [systemd.kill ref](https://manpages.ubuntu.com/manpages/xenial/man5/systemd.kill.5.html)


[X] Installation


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
