### PR TITLE
fix envoy process exit bug

### DIFF
--- a/pkg/envoy/agent.go
+++ b/pkg/envoy/agent.go
@@ -89,6 +89,12 @@ func (a *Agent) Run(ctx context.Context) {
 		log.Infof("No more active epochs, terminating")
 	case <-ctx.Done():
 		a.terminate()
+		status := <-a.statusCh
+		if status.err == errAbort {
+			log.Infof("Epoch %d aborted normally", status.epoch)
+		} else {
+			log.Warnf("Epoch %d aborted abnormally", status.epoch)
+		}
 		log.Info("Agent has successfully terminated")
 	}
 }


### PR DESCRIPTION
Running istio(pilot-agent and envoy) on virtual machine, when systemctl stop istio, the istio-pilot process is terminated, but the envoy process is still running.

(There is another fix about systemd #33040 )

`envoy.Agent` in istio-agent send `errAbort` to `a.abortCh`.

```go
func (a *Agent) terminate() {
	log.Infof("Agent draining Proxy")
	e := a.proxy.Drain()
	if e != nil {
		log.Warnf("Error in invoking drain listeners endpoint %v", e)
	}
	log.Infof("Graceful termination period is %v, starting...", a.terminationDrainDuration)
	time.Sleep(a.terminationDrainDuration)
	log.Infof("Graceful termination period complete, terminating remaining proxies.")
	a.abortCh <- errAbort         //<--- sending errAbort to abortCh
	log.Warnf("Aborted all epochs")
}
```

And expect envoy goroutine in istio-agent to kill envoy process when receiving err from abort.

```go
func (e *envoy) Run(epoch int, abort <-chan error) error {
..
	select {
	case err := <-abort:     //<---- receive abort err in envoy gorouting
		log.Warnf("Aborting epoch %d", epoch)
		if errKill := cmd.Process.Kill(); errKill != nil {
			log.Warnf("killing epoch %d caused an error %v", epoch, errKill)
		}
		return err
	case err := <-done:
		return err
	}
```

However, the main envoy.Agent returns immediately without waiting envoy goroutine. This may causes the envoy process is still running.

```go
// Run starts the envoy and waits until it terminates.
func (a *Agent) Run(ctx context.Context) {
	log.Info("Starting proxy agent")
	go a.runWait(0, a.abortCh)

	select {
	case status := <-a.statusCh:
..
	case <-ctx.Done():
		a.terminate()
		log.Info("Agent has successfully terminated")      //<---here returns immediately without waiting for a.runWait(0, a.abortCh)
	}
}
```



[X] Networking



Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.