### PR TITLE
selectively skip dumping at subscopes with no additional setup

### DIFF
--- a/pkg/test/framework/components/echo/echotest/run.go
+++ b/pkg/test/framework/components/echo/echotest/run.go
@@ -190,6 +190,8 @@ func (t *T) fromEachWorkloadCluster(ctx framework.TestContext, src echo.Instance
 			testFn(ctx, srcInstance)
 		} else {
 			ctx.NewSubTestf("from %s", srcInstance.Config().Cluster.StableName()).Run(func(ctx framework.TestContext) {
+				// assumes we don't change config from cluster to cluster
+				ctx.SkipDumping()
 				testFn(ctx, srcInstance)
 			})
 		}

--- a/pkg/test/framework/scope.go
+++ b/pkg/test/framework/scope.go
@@ -42,6 +42,8 @@ type scope struct {
 
 	closeChan chan struct{}
 
+	skipDump bool
+
 	// Mutex to lock changes to resources, children, and closers that can be done concurrently
 	mu sync.Mutex
 }
@@ -173,6 +175,9 @@ func (s *scope) waitForDone() {
 }
 
 func (s *scope) dump(ctx resource.Context) {
+	if s.skipDump {
+		return
+	}
 	st := time.Now()
 	defer func() {
 		scopes.Framework.Infof("Done dumping scope: %s (%v)", s.id, time.Since(st))

--- a/pkg/test/framework/scope.go
+++ b/pkg/test/framework/scope.go
@@ -174,10 +174,18 @@ func (s *scope) waitForDone() {
 	<-s.closeChan
 }
 
+func (s *scope) skipDumping() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.skipDump = true
+}
+
 func (s *scope) dump(ctx resource.Context) {
+	s.mu.Lock()
 	if s.skipDump {
 		return
 	}
+	s.mu.Unlock()
 	st := time.Now()
 	defer func() {
 		scopes.Framework.Infof("Done dumping scope: %s (%v)", s.id, time.Since(st))

--- a/pkg/test/framework/testcontext.go
+++ b/pkg/test/framework/testcontext.go
@@ -55,6 +55,7 @@ type TestContext interface {
 	// CreateTmpDirectoryOrFail creates a new temporary directory with the given prefix in the workdir, or fails the test.
 	CreateTmpDirectoryOrFail(prefix string) string
 
+	// SkipDumping will skip dumping debug logs/configs/etc for this scope only (child scopes are not skipped).
 	SkipDumping()
 
 	// Done should be called when this context is no longer needed. It triggers the asynchronous cleanup of any
@@ -242,7 +243,7 @@ func (c *testContext) CreateTmpDirectory(prefix string) (string, error) {
 }
 
 func (c *testContext) SkipDumping() {
-	c.scope.skipDump = true
+	c.scope.skipDumping()
 }
 
 func (c *testContext) Config(clusters ...cluster.Cluster) resource.ConfigManager {

--- a/pkg/test/framework/testcontext.go
+++ b/pkg/test/framework/testcontext.go
@@ -55,6 +55,8 @@ type TestContext interface {
 	// CreateTmpDirectoryOrFail creates a new temporary directory with the given prefix in the workdir, or fails the test.
 	CreateTmpDirectoryOrFail(prefix string) string
 
+	SkipDumping()
+
 	// Done should be called when this context is no longer needed. It triggers the asynchronous cleanup of any
 	// allocated resources.
 	Done()
@@ -237,6 +239,10 @@ func (c *testContext) CreateTmpDirectory(prefix string) (string, error) {
 	}
 
 	return dir, err
+}
+
+func (c *testContext) SkipDumping() {
+	c.scope.skipDump = true
 }
 
 func (c *testContext) Config(clusters ...cluster.Cluster) resource.ConfigManager {


### PR DESCRIPTION
Related to https://github.com/istio/istio/issues/33034

We dump duplicate debug info, which is quite large, at each scope. For deeply nested subtests this gets big quick. If we're confident the setup doesn't change, we can just rely on the larger/later dump that comes from parent scopes. 

* Added `SkipDumping` to `TestContext` to disable dumping at a scope. 
* Automatically call `SkipDumping` in `echotest` when none of the `SetupX` methods are called. 

For now we only get benefit for echotest compliant tests. Other tests can either convert to echotest, or take the riskier approach of calling `SkipDumping` themselves in the right places. 