### PR TITLE
avoid calling kubeclient methods on non kube clusters

### DIFF
--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -135,7 +135,7 @@ type istioctlConfigFiles struct {
 
 func (i *operatorComponent) Ingresses() ingress.Instances {
 	var out ingress.Instances
-	for _, c := range i.ctx.Clusters() {
+	for _, c := range i.ctx.Clusters().Kube() {
 		// call IngressFor in-case initialization is needed.
 		out = append(out, i.IngressFor(c))
 	}

--- a/pkg/test/kube/dump.go
+++ b/pkg/test/kube/dump.go
@@ -55,7 +55,7 @@ func outputPath(workDir string, cluster cluster.Cluster, prefix, suffix string) 
 
 func DumpDeployments(ctx resource.Context, workDir, namespace string) {
 	errG := multierror.Group{}
-	for _, cluster := range ctx.Clusters() {
+	for _, cluster := range ctx.Clusters().Kube() {
 		deps, err := cluster.AppsV1().Deployments(namespace).List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
 			scopes.Framework.Warnf("Error getting deployments: %v", err)


### PR DESCRIPTION
On implementations of our `cluster.Cluster` interface in the test framework, such as `staticvm`, we embed a nil pointer for `kube.ExtendedClient` that we shouldn't interact with. 

Ideally we'd make this transparent via a mock but that comes with it's own problems: 
* How do callers handle empty responses, or "this is a mock" error
* Codegen may be required to generate such a mock/keep it up to date. 

This protects a few places from using the nil client, but our concept that a tf cluster is a place where workloads live is a bit confusing and will probably continue to be violated. 