### PR TITLE
Fix TestXdsProxyHealthCheck test flakes

### DIFF
--- a/pilot/pkg/config/memory/controller.go
+++ b/pilot/pkg/config/memory/controller.go
@@ -118,7 +118,7 @@ func (c *controller) Patch(orig config.Config, patchFn config.PatchFunc) (newRev
 	default:
 		return "", fmt.Errorf("unsupported merge type: %s", typ)
 	}
-	if newRevision, err = c.configStore.Update(cfg); err == nil {
+	if newRevision, err = c.configStore.Patch(cfg, patchFn); err == nil {
 		c.monitor.ScheduleProcessEvent(ConfigEvent{
 			old:    orig,
 			config: cfg,

--- a/pilot/pkg/serviceregistry/serviceentry/servicediscovery_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/servicediscovery_test.go
@@ -229,7 +229,6 @@ func TestServiceDiscoveryServiceUpdate(t *testing.T) {
 	// httpStaticOverlayUpdatedNop is the same as httpStaticOverlayUpdated but with a NOP change
 	httpStaticOverlayUpdatedNop := func() *config.Config {
 		c := httpStaticOverlayUpdated.DeepCopy()
-		c.ResourceVersion = "foo"
 		return &c
 	}()
 

--- a/pkg/istio-agent/xds_proxy.go
+++ b/pkg/istio-agent/xds_proxy.go
@@ -310,11 +310,6 @@ func (p *XdsProxy) handleStream(downstream adsStream) error {
 	// Handle downstream xds
 	initialRequestsSent := false
 	go func() {
-		// Send initial request
-		p.connectedMutex.RLock()
-		initialRequest := p.initialRequest
-		p.connectedMutex.RUnlock()
-
 		for {
 			// From Envoy
 			req, err := downstream.Recv()
@@ -338,9 +333,12 @@ func (p *XdsProxy) handleStream(downstream adsStream) error {
 					}
 				}
 				// Fire of a configured initial request, if there is one
+				p.connectedMutex.RLock()
+				initialRequest := p.initialRequest
 				if initialRequest != nil {
 					con.requestsChan <- initialRequest
 				}
+				p.connectedMutex.RUnlock()
 				initialRequestsSent = true
 			}
 		}


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/30510

This consists of two bugs, one impacting tests only and the other real:
* A race between access and write of initialRequest. Before we may hit
this sequence:
  * Read initial request version 1
  * Set and immediately send version 2
  * Send version 1
Now we have consistent locking so we are always sending the latest
version

* Update the in-memory store to reject updates where resource version is
not set properly. This avoids races where an update occurs at the same
time as a patch and reverts a change. This matches Kubernetes behavior,
and thus is a test-only bug, as the memory store is only used for tests.
