### PR TITLE
Allow running echogen test outside of makefile

### DIFF
--- a/pkg/test/framework/components/echo/cmd/echogen/echogen_test.go
+++ b/pkg/test/framework/components/echo/cmd/echogen/echogen_test.go
@@ -39,6 +39,8 @@ func TestGenerate(t *testing.T) {
 			_ = f.Value.Set("testtag")
 		case "istio.test.hub":
 			_ = f.Value.Set("testhub")
+		case "istio.test.pullpolicy":
+			_ = f.Value.Set("IfNotPresent")
 		}
 	})
 	out := bytes.NewBuffer([]byte{})


### PR DESCRIPTION
Previously this depended on an env var set in the makefile to generate
the intended result of the golden file