### PR TITLE
pretty print JSON for metricsConfig overrides

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.10.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.10.yaml
@@ -227,7 +227,7 @@ spec:
                       "stat_prefix": "istio"
                     }
                     {{- else }}
-                    {{ toJson .Values.telemetry.v2.prometheus.configOverride.outboundSidecar | indent 18 }}
+                    {{ toPrettyJson .Values.telemetry.v2.prometheus.configOverride.outboundSidecar }}
                     {{- end }}
                 vm_config:
                   vm_id: stats_outbound
@@ -282,7 +282,7 @@ spec:
                       ]
                     }
                     {{- else }}
-                    {{ toJson .Values.telemetry.v2.prometheus.configOverride.inboundSidecar | indent 18 }}
+                    {{ toPrettyJson .Values.telemetry.v2.prometheus.configOverride.inboundSidecar }}
                     {{- end }}
                 vm_config:
                   vm_id: stats_inbound
@@ -329,7 +329,7 @@ spec:
                       "disable_host_header_fallback": true
                     }
                     {{- else }}
-                    {{ toJson .Values.telemetry.v2.prometheus.configOverride.gateway | indent 18 }}
+                    {{ toPrettyJson .Values.telemetry.v2.prometheus.configOverride.gateway }}
                     {{- end }}
                 vm_config:
                   vm_id: stats_outbound
@@ -396,7 +396,7 @@ spec:
                       ]
                     }
                     {{- else }}
-                    {{ toJson .Values.telemetry.v2.prometheus.configOverride.inboundSidecar | indent 18 }}
+                    {{ toPrettyJson .Values.telemetry.v2.prometheus.configOverride.inboundSidecar }}
                     {{- end }}
                 vm_config:
                   vm_id: tcp_stats_inbound
@@ -440,7 +440,7 @@ spec:
                       "stat_prefix": "istio"
                     }
                     {{- else }}
-                    {{ toJson .Values.telemetry.v2.prometheus.configOverride.outboundSidecar | indent 18 }}
+                    {{ toPrettyJson .Values.telemetry.v2.prometheus.configOverride.outboundSidecar }}
                     {{- end }}
                 vm_config:
                   vm_id: tcp_stats_outbound
@@ -484,7 +484,7 @@ spec:
                       "stat_prefix": "istio"
                     }
                     {{- else }}
-                    {{ toJson .Values.telemetry.v2.prometheus.configOverride.gateway | indent 18 }}
+                    {{ toPrettyJson .Values.telemetry.v2.prometheus.configOverride.gateway }}
                     {{- end }}
                 vm_config:
                   vm_id: tcp_stats_outbound
@@ -544,7 +544,7 @@ spec:
                     {{- if not .Values.telemetry.v2.stackdriver.configOverride }}
                     {"access_logging": "{{ .Values.telemetry.v2.stackdriver.outboundAccessLogging }}"}
                     {{- else }}
-                    {{ toJson .Values.telemetry.v2.stackdriver.configOverride | indent 18 }}
+                    {{ toPrettyJson .Values.telemetry.v2.stackdriver.configOverride }}
                     {{- end }}
                 vm_config:
                   vm_id: stackdriver_outbound
@@ -579,7 +579,7 @@ spec:
                     {{- if not .Values.telemetry.v2.stackdriver.configOverride }}
                     {"disable_server_access_logging": {{ not .Values.telemetry.v2.stackdriver.logging }}, "access_logging": "{{ .Values.telemetry.v2.stackdriver.inboundAccessLogging }}", "disable_host_header_fallback": true}
                     {{- else }}
-                    {{ toJson .Values.telemetry.v2.stackdriver.configOverride | indent 18 }}
+                    {{ toPrettyJson .Values.telemetry.v2.stackdriver.configOverride }}
                     {{- end }}
                 vm_config:
                   vm_id: stackdriver_inbound
@@ -613,7 +613,7 @@ spec:
                     {{- if not .Values.telemetry.v2.stackdriver.configOverride }}
                     {"access_logging": "{{ .Values.telemetry.v2.stackdriver.outboundAccessLogging }}", "disable_host_header_fallback": true}
                     {{- else }}
-                    {{ toJson .Values.telemetry.v2.stackdriver.configOverride | indent 18 }}
+                    {{ toPrettyJson .Values.telemetry.v2.stackdriver.configOverride }}
                     {{- end }}
                 vm_config:
                   vm_id: stackdriver_outbound
@@ -660,7 +660,7 @@ spec:
                   {{- if not .Values.telemetry.v2.stackdriver.configOverride }}
                   {"access_logging": "{{ .Values.telemetry.v2.stackdriver.outboundAccessLogging }}"}
                   {{- else }}
-                  {{ toJson .Values.telemetry.v2.stackdriver.configOverride | indent 18 }}
+                  {{ toPrettyJson .Values.telemetry.v2.stackdriver.configOverride }}
                   {{- end }}
               vm_config:
                 vm_id: stackdriver_outbound
@@ -693,7 +693,7 @@ spec:
                   {{- if not .Values.telemetry.v2.stackdriver.configOverride }}
                   {"disable_server_access_logging": {{ not .Values.telemetry.v2.stackdriver.logging }}, "access_logging": "{{ .Values.telemetry.v2.stackdriver.inboundAccessLogging }}"}
                   {{- else }}
-                  {{ toJson .Values.telemetry.v2.stackdriver.configOverride | indent 18 }}
+                  {{ toPrettyJson .Values.telemetry.v2.stackdriver.configOverride }}
                   {{- end }}
               vm_config:
                 vm_id: stackdriver_inbound
@@ -725,7 +725,7 @@ spec:
                   {{- if not .Values.telemetry.v2.stackdriver.configOverride }}
                   {"access_logging": "{{ .Values.telemetry.v2.stackdriver.outboundAccessLogging }}"}
                   {{- else }}
-                  {{ toJson .Values.telemetry.v2.stackdriver.configOverride | indent 18 }}
+                  {{ toPrettyJson .Values.telemetry.v2.stackdriver.configOverride }}
                   {{- end }}
               vm_config:
                 vm_id: stackdriver_outbound

--- a/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.11.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.11.yaml
@@ -227,7 +227,7 @@ spec:
                       "stat_prefix": "istio"
                     }
                     {{- else }}
-                    {{ toJson .Values.telemetry.v2.prometheus.configOverride.outboundSidecar | indent 18 }}
+                    {{ toPrettyJson .Values.telemetry.v2.prometheus.configOverride.outboundSidecar }}
                     {{- end }}
                 vm_config:
                   vm_id: stats_outbound
@@ -282,7 +282,7 @@ spec:
                       ]
                     }
                     {{- else }}
-                    {{ toJson .Values.telemetry.v2.prometheus.configOverride.inboundSidecar | indent 18 }}
+                    {{ toPrettyJson .Values.telemetry.v2.prometheus.configOverride.inboundSidecar }}
                     {{- end }}
                 vm_config:
                   vm_id: stats_inbound
@@ -329,7 +329,7 @@ spec:
                       "disable_host_header_fallback": true
                     }
                     {{- else }}
-                    {{ toJson .Values.telemetry.v2.prometheus.configOverride.gateway | indent 18 }}
+                    {{ toPrettyJson .Values.telemetry.v2.prometheus.configOverride.gateway }}
                     {{- end }}
                 vm_config:
                   vm_id: stats_outbound
@@ -396,7 +396,7 @@ spec:
                       ]
                     }
                     {{- else }}
-                    {{ toJson .Values.telemetry.v2.prometheus.configOverride.inboundSidecar | indent 18 }}
+                    {{ toPrettyJson .Values.telemetry.v2.prometheus.configOverride.inboundSidecar }}
                     {{- end }}
                 vm_config:
                   vm_id: tcp_stats_inbound
@@ -440,7 +440,7 @@ spec:
                       "stat_prefix": "istio"
                     }
                     {{- else }}
-                    {{ toJson .Values.telemetry.v2.prometheus.configOverride.outboundSidecar | indent 18 }}
+                    {{ toPrettyJson .Values.telemetry.v2.prometheus.configOverride.outboundSidecar }}
                     {{- end }}
                 vm_config:
                   vm_id: tcp_stats_outbound
@@ -484,7 +484,7 @@ spec:
                       "stat_prefix": "istio"
                     }
                     {{- else }}
-                    {{ toJson .Values.telemetry.v2.prometheus.configOverride.gateway | indent 18 }}
+                    {{ toPrettyJson .Values.telemetry.v2.prometheus.configOverride.gateway }}
                     {{- end }}
                 vm_config:
                   vm_id: tcp_stats_outbound
@@ -544,7 +544,7 @@ spec:
                     {{- if not .Values.telemetry.v2.stackdriver.configOverride }}
                     {"access_logging": "{{ .Values.telemetry.v2.stackdriver.outboundAccessLogging }}"}
                     {{- else }}
-                    {{ toJson .Values.telemetry.v2.stackdriver.configOverride | indent 18 }}
+                    {{ toPrettyJson .Values.telemetry.v2.stackdriver.configOverride }}
                     {{- end }}
                 vm_config:
                   vm_id: stackdriver_outbound
@@ -579,7 +579,7 @@ spec:
                     {{- if not .Values.telemetry.v2.stackdriver.configOverride }}
                     {"disable_server_access_logging": {{ not .Values.telemetry.v2.stackdriver.logging }}, "access_logging": "{{ .Values.telemetry.v2.stackdriver.inboundAccessLogging }}", "disable_host_header_fallback": true}
                     {{- else }}
-                    {{ toJson .Values.telemetry.v2.stackdriver.configOverride | indent 18 }}
+                    {{ toPrettyJson .Values.telemetry.v2.stackdriver.configOverride }}
                     {{- end }}
                 vm_config:
                   vm_id: stackdriver_inbound
@@ -613,7 +613,7 @@ spec:
                     {{- if not .Values.telemetry.v2.stackdriver.configOverride }}
                     {"access_logging": "{{ .Values.telemetry.v2.stackdriver.outboundAccessLogging }}", "disable_host_header_fallback": true}
                     {{- else }}
-                    {{ toJson .Values.telemetry.v2.stackdriver.configOverride | indent 18 }}
+                    {{ toPrettyJson .Values.telemetry.v2.stackdriver.configOverride }}
                     {{- end }}
                 vm_config:
                   vm_id: stackdriver_outbound
@@ -660,7 +660,7 @@ spec:
                   {{- if not .Values.telemetry.v2.stackdriver.configOverride }}
                   {"access_logging": "{{ .Values.telemetry.v2.stackdriver.outboundAccessLogging }}"}
                   {{- else }}
-                  {{ toJson .Values.telemetry.v2.stackdriver.configOverride | indent 18 }}
+                  {{ toPrettyJson .Values.telemetry.v2.stackdriver.configOverride }}
                   {{- end }}
               vm_config:
                 vm_id: stackdriver_outbound
@@ -693,7 +693,7 @@ spec:
                   {{- if not .Values.telemetry.v2.stackdriver.configOverride }}
                   {"disable_server_access_logging": {{ not .Values.telemetry.v2.stackdriver.logging }}, "access_logging": "{{ .Values.telemetry.v2.stackdriver.inboundAccessLogging }}"}
                   {{- else }}
-                  {{ toJson .Values.telemetry.v2.stackdriver.configOverride | indent 18 }}
+                  {{ toPrettyJson .Values.telemetry.v2.stackdriver.configOverride }}
                   {{- end }}
               vm_config:
                 vm_id: stackdriver_inbound
@@ -725,7 +725,7 @@ spec:
                   {{- if not .Values.telemetry.v2.stackdriver.configOverride }}
                   {"access_logging": "{{ .Values.telemetry.v2.stackdriver.outboundAccessLogging }}"}
                   {{- else }}
-                  {{ toJson .Values.telemetry.v2.stackdriver.configOverride | indent 18 }}
+                  {{ toPrettyJson .Values.telemetry.v2.stackdriver.configOverride }}
                   {{- end }}
               vm_config:
                 vm_id: stackdriver_outbound

--- a/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.9.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.9.yaml
@@ -235,7 +235,7 @@ spec:
                       ]
                     }
                     {{- else }}
-                    {{ toJson .Values.telemetry.v2.prometheus.configOverride.outboundSidecar | indent 18 }}
+                    {{ toPrettyJson .Values.telemetry.v2.prometheus.configOverride.outboundSidecar }}
                     {{- end }}
                 vm_config:
                   vm_id: stats_outbound
@@ -289,7 +289,7 @@ spec:
                       ]
                     }
                     {{- else }}
-                    {{ toJson .Values.telemetry.v2.prometheus.configOverride.inboundSidecar | indent 18 }}
+                    {{ toPrettyJson .Values.telemetry.v2.prometheus.configOverride.inboundSidecar }}
                     {{- end }}
                 vm_config:
                   vm_id: stats_inbound
@@ -344,7 +344,7 @@ spec:
                       ]
                     }
                     {{- else }}
-                    {{ toJson .Values.telemetry.v2.prometheus.configOverride.gateway | indent 18 }}
+                    {{ toPrettyJson .Values.telemetry.v2.prometheus.configOverride.gateway }}
                     {{- end }}
                 vm_config:
                   vm_id: stats_outbound
@@ -411,7 +411,7 @@ spec:
                       ]
                     }
                     {{- else }}
-                    {{ toJson .Values.telemetry.v2.prometheus.configOverride.inboundSidecar | indent 18 }}
+                    {{ toPrettyJson .Values.telemetry.v2.prometheus.configOverride.inboundSidecar }}
                     {{- end }}
                 vm_config:
                   vm_id: tcp_stats_inbound
@@ -463,7 +463,7 @@ spec:
                       ]
                     }
                     {{- else }}
-                    {{ toJson .Values.telemetry.v2.prometheus.configOverride.outboundSidecar | indent 18 }}
+                    {{ toPrettyJson .Values.telemetry.v2.prometheus.configOverride.outboundSidecar }}
                     {{- end }}
                 vm_config:
                   vm_id: tcp_stats_outbound
@@ -515,7 +515,7 @@ spec:
                       ]
                     }
                     {{- else }}
-                    {{ toJson .Values.telemetry.v2.prometheus.configOverride.gateway | indent 18 }}
+                    {{ toPrettyJson .Values.telemetry.v2.prometheus.configOverride.gateway }}
                     {{- end }}
                 vm_config:
                   vm_id: tcp_stats_outbound
@@ -575,7 +575,7 @@ spec:
                     {{- if not .Values.telemetry.v2.stackdriver.configOverride }}
                     {"access_logging": "{{ .Values.telemetry.v2.stackdriver.outboundAccessLogging }}"}
                     {{- else }}
-                    {{ toJson .Values.telemetry.v2.stackdriver.configOverride | indent 18 }}
+                    {{ toPrettyJson .Values.telemetry.v2.stackdriver.configOverride }}
                     {{- end }}
                 vm_config:
                   vm_id: stackdriver_outbound
@@ -610,7 +610,7 @@ spec:
                     {{- if not .Values.telemetry.v2.stackdriver.configOverride }}
                     {"disable_server_access_logging": {{ not .Values.telemetry.v2.stackdriver.logging }}, "access_logging": "{{ .Values.telemetry.v2.stackdriver.inboundAccessLogging }}", "disable_host_header_fallback": true}
                     {{- else }}
-                    {{ toJson .Values.telemetry.v2.stackdriver.configOverride | indent 18 }}
+                    {{ toPrettyJson .Values.telemetry.v2.stackdriver.configOverride }}
                     {{- end }}
                 vm_config:
                   vm_id: stackdriver_inbound
@@ -644,7 +644,7 @@ spec:
                     {{- if not .Values.telemetry.v2.stackdriver.configOverride }}
                     {"access_logging": "{{ .Values.telemetry.v2.stackdriver.outboundAccessLogging }}", "disable_host_header_fallback": true}
                     {{- else }}
-                    {{ toJson .Values.telemetry.v2.stackdriver.configOverride | indent 18 }}
+                    {{ toPrettyJson .Values.telemetry.v2.stackdriver.configOverride }}
                     {{- end }}
                 vm_config:
                   vm_id: stackdriver_outbound
@@ -691,7 +691,7 @@ spec:
                   {{- if not .Values.telemetry.v2.stackdriver.configOverride }}
                   {"access_logging": "{{ .Values.telemetry.v2.stackdriver.outboundAccessLogging }}"}
                   {{- else }}
-                  {{ toJson .Values.telemetry.v2.stackdriver.configOverride | indent 18 }}
+                  {{ toPrettyJson .Values.telemetry.v2.stackdriver.configOverride }}
                   {{- end }}
               vm_config:
                 vm_id: stackdriver_outbound
@@ -724,7 +724,7 @@ spec:
                   {{- if not .Values.telemetry.v2.stackdriver.configOverride }}
                   {"disable_server_access_logging": {{ not .Values.telemetry.v2.stackdriver.logging }}, "access_logging": "{{ .Values.telemetry.v2.stackdriver.inboundAccessLogging }}"}
                   {{- else }}
-                  {{ toJson .Values.telemetry.v2.stackdriver.configOverride | indent 18 }}
+                  {{ toPrettyJson .Values.telemetry.v2.stackdriver.configOverride }}
                   {{- end }}
               vm_config:
                 vm_id: stackdriver_inbound
@@ -756,7 +756,7 @@ spec:
                   {{- if not .Values.telemetry.v2.stackdriver.configOverride }}
                   {"access_logging": "{{ .Values.telemetry.v2.stackdriver.outboundAccessLogging }}"}
                   {{- else }}
-                  {{ toJson .Values.telemetry.v2.stackdriver.configOverride | indent 18 }}
+                  {{ toPrettyJson .Values.telemetry.v2.stackdriver.configOverride }}
                   {{- end }}
               vm_config:
                 vm_id: stackdriver_outbound

--- a/manifests/charts/istiod-remote/templates/telemetryv2_1.10.yaml
+++ b/manifests/charts/istiod-remote/templates/telemetryv2_1.10.yaml
@@ -227,7 +227,7 @@ spec:
                       "stat_prefix": "istio"
                     }
                     {{- else }}
-                    {{ toJson .Values.telemetry.v2.prometheus.configOverride.outboundSidecar | indent 18 }}
+                    {{ toPrettyJson .Values.telemetry.v2.prometheus.configOverride.outboundSidecar }}
                     {{- end }}
                 vm_config:
                   vm_id: stats_outbound
@@ -282,7 +282,7 @@ spec:
                       ]
                     }
                     {{- else }}
-                    {{ toJson .Values.telemetry.v2.prometheus.configOverride.inboundSidecar | indent 18 }}
+                    {{ toPrettyJson .Values.telemetry.v2.prometheus.configOverride.inboundSidecar }}
                     {{- end }}
                 vm_config:
                   vm_id: stats_inbound
@@ -329,7 +329,7 @@ spec:
                       "disable_host_header_fallback": true
                     }
                     {{- else }}
-                    {{ toJson .Values.telemetry.v2.prometheus.configOverride.gateway | indent 18 }}
+                    {{ toPrettyJson .Values.telemetry.v2.prometheus.configOverride.gateway }}
                     {{- end }}
                 vm_config:
                   vm_id: stats_outbound
@@ -396,7 +396,7 @@ spec:
                       ]
                     }
                     {{- else }}
-                    {{ toJson .Values.telemetry.v2.prometheus.configOverride.inboundSidecar | indent 18 }}
+                    {{ toPrettyJson .Values.telemetry.v2.prometheus.configOverride.inboundSidecar }}
                     {{- end }}
                 vm_config:
                   vm_id: tcp_stats_inbound
@@ -440,7 +440,7 @@ spec:
                       "stat_prefix": "istio"
                     }
                     {{- else }}
-                    {{ toJson .Values.telemetry.v2.prometheus.configOverride.outboundSidecar | indent 18 }}
+                    {{ toPrettyJson .Values.telemetry.v2.prometheus.configOverride.outboundSidecar }}
                     {{- end }}
                 vm_config:
                   vm_id: tcp_stats_outbound
@@ -484,7 +484,7 @@ spec:
                       "stat_prefix": "istio"
                     }
                     {{- else }}
-                    {{ toJson .Values.telemetry.v2.prometheus.configOverride.gateway | indent 18 }}
+                    {{ toPrettyJson .Values.telemetry.v2.prometheus.configOverride.gateway }}
                     {{- end }}
                 vm_config:
                   vm_id: tcp_stats_outbound
@@ -544,7 +544,7 @@ spec:
                     {{- if not .Values.telemetry.v2.stackdriver.configOverride }}
                     {"access_logging": "{{ .Values.telemetry.v2.stackdriver.outboundAccessLogging }}"}
                     {{- else }}
-                    {{ toJson .Values.telemetry.v2.stackdriver.configOverride | indent 18 }}
+                    {{ toPrettyJson .Values.telemetry.v2.stackdriver.configOverride }}
                     {{- end }}
                 vm_config:
                   vm_id: stackdriver_outbound
@@ -579,7 +579,7 @@ spec:
                     {{- if not .Values.telemetry.v2.stackdriver.configOverride }}
                     {"disable_server_access_logging": {{ not .Values.telemetry.v2.stackdriver.logging }}, "access_logging": "{{ .Values.telemetry.v2.stackdriver.inboundAccessLogging }}", "disable_host_header_fallback": true}
                     {{- else }}
-                    {{ toJson .Values.telemetry.v2.stackdriver.configOverride | indent 18 }}
+                    {{ toPrettyJson .Values.telemetry.v2.stackdriver.configOverride }}
                     {{- end }}
                 vm_config:
                   vm_id: stackdriver_inbound
@@ -613,7 +613,7 @@ spec:
                     {{- if not .Values.telemetry.v2.stackdriver.configOverride }}
                     {"access_logging": "{{ .Values.telemetry.v2.stackdriver.outboundAccessLogging }}", "disable_host_header_fallback": true}
                     {{- else }}
-                    {{ toJson .Values.telemetry.v2.stackdriver.configOverride | indent 18 }}
+                    {{ toPrettyJson .Values.telemetry.v2.stackdriver.configOverride }}
                     {{- end }}
                 vm_config:
                   vm_id: stackdriver_outbound
@@ -660,7 +660,7 @@ spec:
                   {{- if not .Values.telemetry.v2.stackdriver.configOverride }}
                   {"access_logging": "{{ .Values.telemetry.v2.stackdriver.outboundAccessLogging }}"}
                   {{- else }}
-                  {{ toJson .Values.telemetry.v2.stackdriver.configOverride | indent 18 }}
+                  {{ toPrettyJson .Values.telemetry.v2.stackdriver.configOverride }}
                   {{- end }}
               vm_config:
                 vm_id: stackdriver_outbound
@@ -693,7 +693,7 @@ spec:
                   {{- if not .Values.telemetry.v2.stackdriver.configOverride }}
                   {"disable_server_access_logging": {{ not .Values.telemetry.v2.stackdriver.logging }}, "access_logging": "{{ .Values.telemetry.v2.stackdriver.inboundAccessLogging }}"}
                   {{- else }}
-                  {{ toJson .Values.telemetry.v2.stackdriver.configOverride | indent 18 }}
+                  {{ toPrettyJson .Values.telemetry.v2.stackdriver.configOverride }}
                   {{- end }}
               vm_config:
                 vm_id: stackdriver_inbound
@@ -725,7 +725,7 @@ spec:
                   {{- if not .Values.telemetry.v2.stackdriver.configOverride }}
                   {"access_logging": "{{ .Values.telemetry.v2.stackdriver.outboundAccessLogging }}"}
                   {{- else }}
-                  {{ toJson .Values.telemetry.v2.stackdriver.configOverride | indent 18 }}
+                  {{ toPrettyJson .Values.telemetry.v2.stackdriver.configOverride }}
                   {{- end }}
               vm_config:
                 vm_id: stackdriver_outbound

--- a/manifests/charts/istiod-remote/templates/telemetryv2_1.9.yaml
+++ b/manifests/charts/istiod-remote/templates/telemetryv2_1.9.yaml
@@ -235,7 +235,7 @@ spec:
                       ]
                     }
                     {{- else }}
-                    {{ toJson .Values.telemetry.v2.prometheus.configOverride.outboundSidecar | indent 18 }}
+                    {{ toPrettyJson .Values.telemetry.v2.prometheus.configOverride.outboundSidecar }}
                     {{- end }}
                 vm_config:
                   vm_id: stats_outbound
@@ -289,7 +289,7 @@ spec:
                       ]
                     }
                     {{- else }}
-                    {{ toJson .Values.telemetry.v2.prometheus.configOverride.inboundSidecar | indent 18 }}
+                    {{ toPrettyJson .Values.telemetry.v2.prometheus.configOverride.inboundSidecar }}
                     {{- end }}
                 vm_config:
                   vm_id: stats_inbound
@@ -344,7 +344,7 @@ spec:
                       ]
                     }
                     {{- else }}
-                    {{ toJson .Values.telemetry.v2.prometheus.configOverride.gateway | indent 18 }}
+                    {{ toPrettyJson .Values.telemetry.v2.prometheus.configOverride.gateway }}
                     {{- end }}
                 vm_config:
                   vm_id: stats_outbound
@@ -411,7 +411,7 @@ spec:
                       ]
                     }
                     {{- else }}
-                    {{ toJson .Values.telemetry.v2.prometheus.configOverride.inboundSidecar | indent 18 }}
+                    {{ toPrettyJson .Values.telemetry.v2.prometheus.configOverride.inboundSidecar }}
                     {{- end }}
                 vm_config:
                   vm_id: tcp_stats_inbound
@@ -463,7 +463,7 @@ spec:
                       ]
                     }
                     {{- else }}
-                    {{ toJson .Values.telemetry.v2.prometheus.configOverride.outboundSidecar | indent 18 }}
+                    {{ toPrettyJson .Values.telemetry.v2.prometheus.configOverride.outboundSidecar }}
                     {{- end }}
                 vm_config:
                   vm_id: tcp_stats_outbound
@@ -515,7 +515,7 @@ spec:
                       ]
                     }
                     {{- else }}
-                    {{ toJson .Values.telemetry.v2.prometheus.configOverride.gateway | indent 18 }}
+                    {{ toPrettyJson .Values.telemetry.v2.prometheus.configOverride.gateway }}
                     {{- end }}
                 vm_config:
                   vm_id: tcp_stats_outbound
@@ -575,7 +575,7 @@ spec:
                     {{- if not .Values.telemetry.v2.stackdriver.configOverride }}
                     {"access_logging": "{{ .Values.telemetry.v2.stackdriver.outboundAccessLogging }}"}
                     {{- else }}
-                    {{ toJson .Values.telemetry.v2.stackdriver.configOverride | indent 18 }}
+                    {{ toPrettyJson .Values.telemetry.v2.stackdriver.configOverride }}
                     {{- end }}
                 vm_config:
                   vm_id: stackdriver_outbound
@@ -610,7 +610,7 @@ spec:
                     {{- if not .Values.telemetry.v2.stackdriver.configOverride }}
                     {"disable_server_access_logging": {{ not .Values.telemetry.v2.stackdriver.logging }}, "access_logging": "{{ .Values.telemetry.v2.stackdriver.inboundAccessLogging }}", "disable_host_header_fallback": true}
                     {{- else }}
-                    {{ toJson .Values.telemetry.v2.stackdriver.configOverride | indent 18 }}
+                    {{ toPrettyJson .Values.telemetry.v2.stackdriver.configOverride }}
                     {{- end }}
                 vm_config:
                   vm_id: stackdriver_inbound
@@ -644,7 +644,7 @@ spec:
                     {{- if not .Values.telemetry.v2.stackdriver.configOverride }}
                     {"access_logging": "{{ .Values.telemetry.v2.stackdriver.outboundAccessLogging }}", "disable_host_header_fallback": true}
                     {{- else }}
-                    {{ toJson .Values.telemetry.v2.stackdriver.configOverride | indent 18 }}
+                    {{ toPrettyJson .Values.telemetry.v2.stackdriver.configOverride }}
                     {{- end }}
                 vm_config:
                   vm_id: stackdriver_outbound
@@ -691,7 +691,7 @@ spec:
                   {{- if not .Values.telemetry.v2.stackdriver.configOverride }}
                   {"access_logging": "{{ .Values.telemetry.v2.stackdriver.outboundAccessLogging }}"}
                   {{- else }}
-                  {{ toJson .Values.telemetry.v2.stackdriver.configOverride | indent 18 }}
+                  {{ toPrettyJson .Values.telemetry.v2.stackdriver.configOverride }}
                   {{- end }}
               vm_config:
                 vm_id: stackdriver_outbound
@@ -724,7 +724,7 @@ spec:
                   {{- if not .Values.telemetry.v2.stackdriver.configOverride }}
                   {"disable_server_access_logging": {{ not .Values.telemetry.v2.stackdriver.logging }}, "access_logging": "{{ .Values.telemetry.v2.stackdriver.inboundAccessLogging }}"}
                   {{- else }}
-                  {{ toJson .Values.telemetry.v2.stackdriver.configOverride | indent 18 }}
+                  {{ toPrettyJson .Values.telemetry.v2.stackdriver.configOverride }}
                   {{- end }}
               vm_config:
                 vm_id: stackdriver_inbound
@@ -756,7 +756,7 @@ spec:
                   {{- if not .Values.telemetry.v2.stackdriver.configOverride }}
                   {"access_logging": "{{ .Values.telemetry.v2.stackdriver.outboundAccessLogging }}"}
                   {{- else }}
-                  {{ toJson .Values.telemetry.v2.stackdriver.configOverride | indent 18 }}
+                  {{ toPrettyJson .Values.telemetry.v2.stackdriver.configOverride }}
                   {{- end }}
               vm_config:
                 vm_id: stackdriver_outbound


### PR DESCRIPTION

Pretty print the JSON for the metrics config overrides that we enter. As part of our workflow, we perform a helm-diff by doing a helm dry-run to review changes in configuration to the live cluster state. Since we use these jsons heavily, pretty printing the JSON makes reviewing changes before deploy a lot easier.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[X] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.