### PR TITLE
Remove default caBundle value from Chart

### DIFF
--- a/manifests/charts/base/files/gen-istio-cluster.yaml
+++ b/manifests/charts/base/files/gen-istio-cluster.yaml
@@ -5935,7 +5935,6 @@ webhooks:
         name: istiod
         namespace: istio-system
         path: "/validate"
-      caBundle: "" # patched at runtime when the webhook is ready.
     rules:
       - operations:
         - CREATE

--- a/manifests/charts/base/templates/validatingwebhookconfiguration.yaml
+++ b/manifests/charts/base/templates/validatingwebhookconfiguration.yaml
@@ -18,7 +18,6 @@ webhooks:
         namespace: {{ .Values.global.istioNamespace }}
         path: "/validate"
       {{- end }}
-      caBundle: "" # patched at runtime when the webhook is ready.
     rules:
       - operations:
         - CREATE

--- a/releasenotes/notes/837475-caBundle.yaml
+++ b/releasenotes/notes/837475-caBundle.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+issue:
+  - 33052
+releaseNotes:
+  - |
+    **Fixed** Removing caBundle default value from Chart to allow a GitOps approach


### PR DESCRIPTION
Fix #33052 

When using a GitOps approach where all generated files from `istioctl manifest generate -f .. -rev ..` are pushed to Git, keeping an empty string will trigger some infinite loop between Flux (for example) and the webhook in charge of setting the caBundle value.

By removing the key from the manifest, Flux (or any CD tool), won't "watch" this key and it will be set in the cluster.

[ ] Configuration Infrastructure
[ ] Docs
[X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
