### PR TITLE
Add Istio user agent to kube-client used in istioctl and other binaries

### DIFF
--- a/cni/cmd/istio-cni-repair/main.go
+++ b/cni/cmd/istio-cni-repair/main.go
@@ -32,9 +32,9 @@ import (
 	"go.uber.org/multierr"
 	client "k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
-	"k8s.io/client-go/tools/clientcmd"
 
 	"istio.io/istio/cni/pkg/repair"
+	"istio.io/istio/pkg/kube"
 	"istio.io/istio/tools/istio-iptables/pkg/constants"
 	"istio.io/pkg/log"
 )
@@ -127,10 +127,7 @@ func parseFlags() (filters *repair.Filters, options *ControllerOptions) {
 
 // Set up Kubernetes client using kubeconfig (or in-cluster config if no file provided)
 func clientSetup() (clientset *client.Clientset, err error) {
-	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
-	configOverrides := &clientcmd.ConfigOverrides{}
-	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
-	config, err := kubeConfig.ClientConfig()
+	config, err := kube.DefaultRestConfig("", "")
 	if err != nil {
 		return
 	}

--- a/cni/cmd/istio-cni-taint/main.go
+++ b/cni/cmd/istio-cni-taint/main.go
@@ -180,7 +180,6 @@ func parseFlags() (options *ControllerOptions) {
 
 // Set up Kubernetes client using kubeconfig (or in-cluster config if no file provided)
 func clientSetup() (clientset *client.Clientset, err error) {
-
 	config, err := kube.DefaultRestConfig("", "")
 	if err != nil {
 		return

--- a/cni/cmd/istio-cni-taint/main.go
+++ b/cni/cmd/istio-cni-taint/main.go
@@ -30,11 +30,11 @@ import (
 	"github.com/spf13/viper"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	client "k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 
 	"istio.io/istio/cni/pkg/taint"
+	"istio.io/istio/pkg/kube"
 	"istio.io/pkg/log"
 )
 
@@ -180,10 +180,8 @@ func parseFlags() (options *ControllerOptions) {
 
 // Set up Kubernetes client using kubeconfig (or in-cluster config if no file provided)
 func clientSetup() (clientset *client.Clientset, err error) {
-	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
-	configOverrides := &clientcmd.ConfigOverrides{}
-	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
-	config, err := kubeConfig.ClientConfig()
+
+	config, err := kube.DefaultRestConfig("", "")
 	if err != nil {
 		return
 	}

--- a/cni/cmd/istio-cni/kubernetes.go
+++ b/cni/cmd/istio-cni/kubernetes.go
@@ -44,7 +44,6 @@ type PodInfo struct {
 
 // newK8sClient returns a Kubernetes client
 func newK8sClient(conf PluginConf) (*kubernetes.Clientset, error) {
-
 	// Some config can be passed in a kubeconfig file
 	kubeconfig := conf.Kubernetes.Kubeconfig
 

--- a/cni/cmd/istio-cni/kubernetes.go
+++ b/cni/cmd/istio-cni/kubernetes.go
@@ -19,11 +19,11 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/cmd/pilot-agent/options"
 	"istio.io/istio/pkg/config/mesh"
+	"istio.io/istio/pkg/kube"
 	"istio.io/pkg/log"
 )
 
@@ -44,16 +44,11 @@ type PodInfo struct {
 
 // newK8sClient returns a Kubernetes client
 func newK8sClient(conf PluginConf) (*kubernetes.Clientset, error) {
+
 	// Some config can be passed in a kubeconfig file
 	kubeconfig := conf.Kubernetes.Kubeconfig
 
-	// Config can be overridden by config passed in explicitly in the network config.
-	configOverrides := &clientcmd.ConfigOverrides{}
-
-	// Use the kubernetes client code to load the kubeconfig file and combine it with the overrides.
-	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-		&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfig},
-		configOverrides).ClientConfig()
+	config, err := kube.DefaultRestConfig(kubeconfig, "")
 	if err != nil {
 		log.Infof("Failed setting up kubernetes client with kubeconfig %s", kubeconfig)
 		return nil, err

--- a/go.mod
+++ b/go.mod
@@ -100,6 +100,8 @@ require (
 	k8s.io/apimachinery v0.21.1
 	k8s.io/cli-runtime v0.21.1
 	k8s.io/client-go v0.21.1
+	k8s.io/klog v1.0.0 // indirect
+	k8s.io/klog/v2 v2.8.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20210527164424-3c818078ee3d
 	k8s.io/kubectl v0.21.1
 	k8s.io/utils v0.0.0-20210527160623-6fdb442a123b

--- a/go.mod
+++ b/go.mod
@@ -100,8 +100,7 @@ require (
 	k8s.io/apimachinery v0.21.1
 	k8s.io/cli-runtime v0.21.1
 	k8s.io/client-go v0.21.1
-	k8s.io/klog v1.0.0 // indirect
-	k8s.io/klog/v2 v2.8.0 // indirect
+	k8s.io/klog/v2 v2.8.0
 	k8s.io/kube-openapi v0.0.0-20210527164424-3c818078ee3d
 	k8s.io/kubectl v0.21.1
 	k8s.io/utils v0.0.0-20210527160623-6fdb442a123b

--- a/istioctl/cmd/analyze.go
+++ b/istioctl/cmd/analyze.go
@@ -181,8 +181,7 @@ func Analyze() *cobra.Command {
 			// If we're using kube, use that as a base source.
 			if useKube {
 				// Set up the kube client
-				config := kube.BuildClientCmd(kubeconfig, configContext)
-				restConfig, err := config.ClientConfig()
+				restConfig, err := kube.DefaultRestConfig(kubeconfig, configContext)
 				if err != nil {
 					return err
 				}

--- a/istioctl/cmd/istioctl/main.go
+++ b/istioctl/cmd/istioctl/main.go
@@ -23,7 +23,6 @@ import (
 
 	// import all known client auth plugins
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
-	"k8s.io/klog/v2"
 
 	"istio.io/istio/istioctl/cmd"
 )
@@ -47,11 +46,9 @@ func main() {
 
 // EnableKlogWithCobra enables klog to work with cobra / pflags.
 // k8s libraries like client-go use klog.
+// TODO(mjog) move this to istio.io/pkg/log package.
 func EnableKlogWithCobra() {
-	klog.InitFlags(nil)
-	goflag.Parse()
-	// just add --v= flag to pflags.
-	gf := goflag.CommandLine.Lookup("v")
+	gf := cmd.KlogVerboseFlag()
 	pflag.CommandLine.AddFlag(pflag.PFlagFromGoFlag(
 		&goflag.Flag{
 			Name:     "vklog",
@@ -59,6 +56,4 @@ func EnableKlogWithCobra() {
 			DefValue: gf.DefValue,
 			Usage:    gf.Usage + ". Like -v flag. ex: --vklog=9",
 		}))
-
-	klog.SetLogger(nil)
 }

--- a/istioctl/cmd/istioctl/main.go
+++ b/istioctl/cmd/istioctl/main.go
@@ -51,6 +51,14 @@ func EnableKlogWithCobra() {
 	klog.InitFlags(nil)
 	goflag.Parse()
 	// just add --v= flag to pflags.
-	pflag.CommandLine.AddGoFlag(goflag.CommandLine.Lookup("v"))
+	gf := goflag.CommandLine.Lookup("v")
+	pflag.CommandLine.AddFlag(pflag.PFlagFromGoFlag(
+		&goflag.Flag{
+			Name:     "vklog",
+			Value:    gf.Value,
+			DefValue: gf.DefValue,
+			Usage:    gf.Usage + ". Like -v flag. ex: --vklog=9",
+		}))
+
 	klog.SetLogger(nil)
 }

--- a/istioctl/cmd/istioctl/main.go
+++ b/istioctl/cmd/istioctl/main.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"os"
 
-	flag "github.com/spf13/pflag"
+	pflag "github.com/spf13/pflag"
 
 	// import all known client auth plugins
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -37,13 +37,20 @@ func main() {
 
 	rootCmd := cmd.GetRootCmd(os.Args[1:])
 
-	klog.InitFlags(nil)
-	goflag.Parse()
-	flag.CommandLine.AddGoFlagSet(goflag.CommandLine)
-	klog.SetLogger(nil)
+	EnableKlogWithCobra()
 
 	if err := rootCmd.Execute(); err != nil {
 		exitCode := cmd.GetExitCode(err)
 		os.Exit(exitCode)
 	}
+}
+
+// EnableKlogWithCobra enables klog to work with cobra / pflags.
+// k8s libraries like client-go use klog.
+func EnableKlogWithCobra() {
+	klog.InitFlags(nil)
+	goflag.Parse()
+	// just add --v= flag to pflags.
+	pflag.CommandLine.AddGoFlag(goflag.CommandLine.Lookup("v"))
+	klog.SetLogger(nil)
 }

--- a/istioctl/cmd/istioctl/main.go
+++ b/istioctl/cmd/istioctl/main.go
@@ -15,11 +15,15 @@
 package main
 
 import (
+	goflag "flag"
 	"fmt"
 	"os"
 
+	flag "github.com/spf13/pflag"
+
 	// import all known client auth plugins
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	"k8s.io/klog/v2"
 
 	"istio.io/istio/istioctl/cmd"
 )
@@ -32,6 +36,11 @@ func main() {
 	}
 
 	rootCmd := cmd.GetRootCmd(os.Args[1:])
+
+	klog.InitFlags(nil)
+	goflag.Parse()
+	flag.CommandLine.AddGoFlagSet(goflag.CommandLine)
+	klog.SetLogger(nil)
 
 	if err := rootCmd.Execute(); err != nil {
 		exitCode := cmd.GetExitCode(err)

--- a/operator/cmd/mesh/shared.go
+++ b/operator/cmd/mesh/shared.go
@@ -24,12 +24,9 @@ import (
 	"sync"
 	"time"
 
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"istio.io/istio/operator/pkg/apis/istio/v1alpha1"
@@ -39,6 +36,7 @@ import (
 	"istio.io/istio/operator/pkg/name"
 	"istio.io/istio/operator/pkg/object"
 	"istio.io/istio/operator/pkg/util/clog"
+	"istio.io/istio/pkg/kube"
 	"istio.io/pkg/log"
 )
 
@@ -123,7 +121,7 @@ func InitK8SRestClient(kubeconfig, kubeContext string) (*rest.Config, *kubernete
 		}
 		return testRestConfig, testK8Interface, nil
 	}
-	restConfig, err := defaultRestConfig(kubeconfig, kubeContext)
+	restConfig, err := kube.DefaultRestConfig(kubeconfig, kubeContext)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -133,48 +131,6 @@ func InitK8SRestClient(kubeconfig, kubeContext string) (*rest.Config, *kubernete
 	}
 
 	return restConfig, clientset, nil
-}
-
-func defaultRestConfig(kubeconfig, kubeContext string) (*rest.Config, error) {
-	config, err := BuildClientConfig(kubeconfig, kubeContext)
-	if err != nil {
-		return nil, err
-	}
-	config.APIPath = "/api"
-	config.GroupVersion = &v1.SchemeGroupVersion
-	config.NegotiatedSerializer = serializer.WithoutConversionCodecFactory{CodecFactory: scheme.Codecs}
-	return config, nil
-}
-
-// BuildClientConfig is a helper function that builds client config from a kubeconfig filepath.
-// It overrides the current context with the one provided (empty to use default).
-//
-// This is a modified version of k8s.io/client-go/tools/clientcmd/BuildConfigFromFlags with the
-// difference that it loads default configs if not running in-cluster.
-func BuildClientConfig(kubeconfig, context string) (*rest.Config, error) {
-	if kubeconfig != "" {
-		info, err := os.Stat(kubeconfig)
-		if err != nil || info.Size() == 0 {
-			// If the specified kubeconfig doesn't exists / empty file / any other error
-			// from file stat, fall back to default
-			kubeconfig = ""
-		}
-	}
-
-	// Config loading rules:
-	// 1. kubeconfig if it not empty string
-	// 2. In cluster config if running in-cluster
-	// 3. Config(s) in KUBECONFIG environment variable
-	// 4. Use $HOME/.kube/config
-	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
-	loadingRules.DefaultClientConfig = &clientcmd.DefaultClientConfig
-	loadingRules.ExplicitPath = kubeconfig
-	configOverrides := &clientcmd.ConfigOverrides{
-		ClusterDefaults: clientcmd.ClusterDefaults,
-		CurrentContext:  context,
-	}
-
-	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides).ClientConfig()
 }
 
 // applyOptions contains the startup options for applying the manifest.

--- a/operator/cmd/mesh/upgrade.go
+++ b/operator/cmd/mesh/upgrade.go
@@ -41,6 +41,7 @@ import (
 	"istio.io/istio/operator/pkg/util"
 	"istio.io/istio/operator/pkg/util/clog"
 	pkgversion "istio.io/istio/operator/pkg/version"
+	"istio.io/istio/pkg/kube"
 	"istio.io/pkg/log"
 )
 
@@ -443,7 +444,7 @@ type ExecClient interface {
 
 // NewClient is the constructor for the client wrapper
 func NewClient(kubeconfig, configContext string) (*Client, error) {
-	config, err := defaultRestConfig(kubeconfig, configContext)
+	config, err := kube.DefaultRestConfig(kubeconfig, configContext)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -391,8 +391,8 @@ func NewExtendedClient(clientConfig clientcmd.ClientConfig, revision string) (Ex
 }
 
 // NewClient creates a Kubernetes client from the given rest config.
-func NewClient(clientConfig clientcmd.ClientConfig) (cl Client, err error) {
-	return NewExtendedClient(clientConfig, "")
+func NewClient(clientConfig clientcmd.ClientConfig) (Client, error) {
+	return newClientInternal(newClientFactory(clientConfig), "")
 }
 
 func (c *client) RESTConfig() *rest.Config {

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -63,7 +63,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/remotecommand"
-	"k8s.io/client-go/transport"
 	"k8s.io/klog/v2"
 	"k8s.io/kubectl/pkg/cmd/apply"
 	kubectlDelete "k8s.io/kubectl/pkg/cmd/delete"
@@ -403,7 +402,7 @@ func DebugWrap(c *rest.Config) {
 		return
 	}
 
-	c.Wrap(transport.DebugWrappers)
+	//c.Wrap(transport.DebugWrappers)
 }
 
 // NewClient creates a Kubernetes client from the given rest config.

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -401,8 +401,6 @@ func DebugWrap(c *rest.Config) {
 	if !klog.V(5).Enabled() {
 		return
 	}
-
-	//c.Wrap(transport.DebugWrappers)
 }
 
 // NewClient creates a Kubernetes client from the given rest config.

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -63,6 +63,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/remotecommand"
+	"k8s.io/client-go/transport"
 	"k8s.io/kubectl/pkg/cmd/apply"
 	kubectlDelete "k8s.io/kubectl/pkg/cmd/delete"
 	"k8s.io/kubectl/pkg/cmd/util"
@@ -387,12 +388,19 @@ func newClientInternal(clientFactory util.Factory, revision string) (*client, er
 // NewExtendedClient creates a Kubernetes client from the given ClientConfig. The "revision" parameter
 // controls the behavior of GetIstioPods, by selecting a specific revision of the control plane.
 func NewExtendedClient(clientConfig clientcmd.ClientConfig, revision string) (ExtendedClient, error) {
+	c, err := clientConfig.ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+	c.Wrap(func(rt http.RoundTripper) http.RoundTripper {
+		return transport.NewDebuggingRoundTripper(rt, transport.DebugCurlCommand, transport.DebugURLTiming, transport.DebugResponseHeaders)
+	})
 	return newClientInternal(newClientFactory(clientConfig), revision)
 }
 
 // NewClient creates a Kubernetes client from the given rest config.
-func NewClient(clientConfig clientcmd.ClientConfig) (Client, error) {
-	return newClientInternal(newClientFactory(clientConfig), "")
+func NewClient(clientConfig clientcmd.ClientConfig) (cl Client, err error) {
+	return NewExtendedClient(clientConfig, "")
 }
 
 func (c *client) RESTConfig() *rest.Config {

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -63,7 +63,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/remotecommand"
-	"k8s.io/klog/v2"
 	"k8s.io/kubectl/pkg/cmd/apply"
 	kubectlDelete "k8s.io/kubectl/pkg/cmd/delete"
 	"k8s.io/kubectl/pkg/cmd/util"
@@ -388,19 +387,7 @@ func newClientInternal(clientFactory util.Factory, revision string) (*client, er
 // NewExtendedClient creates a Kubernetes client from the given ClientConfig. The "revision" parameter
 // controls the behavior of GetIstioPods, by selecting a specific revision of the control plane.
 func NewExtendedClient(clientConfig clientcmd.ClientConfig, revision string) (ExtendedClient, error) {
-	c, err := clientConfig.ClientConfig()
-	if err != nil {
-		return nil, err
-	}
-	DebugWrap(c)
 	return newClientInternal(newClientFactory(clientConfig), revision)
-}
-
-// DebugWrap adds a debug roundtripper.
-func DebugWrap(c *rest.Config) {
-	if !klog.V(5).Enabled() {
-		return
-	}
 }
 
 // NewClient creates a Kubernetes client from the given rest config.

--- a/pkg/kube/util.go
+++ b/pkg/kube/util.go
@@ -21,7 +21,6 @@ import (
 	"strconv"
 	"strings"
 
-	istioversion "istio.io/pkg/version"
 	kubeApiCore "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -32,6 +31,8 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+
+	istioversion "istio.io/pkg/version"
 )
 
 const (

--- a/pkg/kube/util.go
+++ b/pkg/kube/util.go
@@ -53,7 +53,7 @@ func BuildClientConfig(kubeconfig, context string) (*rest.Config, error) {
 //
 // This is a modified version of k8s.io/client-go/tools/clientcmd/BuildConfigFromFlags with the
 // difference that it loads default configs if not running in-cluster.
-func BuildClientCmd(kubeconfig, context string) clientcmd.ClientConfig {
+func BuildClientCmd(kubeconfig, context string, overrides ...func(*clientcmd.ConfigOverrides)) clientcmd.ClientConfig {
 	if kubeconfig != "" {
 		info, err := os.Stat(kubeconfig)
 		if err != nil || info.Size() == 0 {
@@ -74,6 +74,10 @@ func BuildClientCmd(kubeconfig, context string) clientcmd.ClientConfig {
 	configOverrides := &clientcmd.ConfigOverrides{
 		ClusterDefaults: clientcmd.ClusterDefaults,
 		CurrentContext:  context,
+	}
+
+	for _, fn := range overrides {
+		fn(configOverrides)
 	}
 
 	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)

--- a/pkg/kube/util.go
+++ b/pkg/kube/util.go
@@ -27,12 +27,12 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/transport"
 
 	//  allow out of cluster authentication
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/transport"
 
 	istioversion "istio.io/pkg/version"
 )

--- a/pkg/kube/util.go
+++ b/pkg/kube/util.go
@@ -35,10 +35,6 @@ import (
 	istioversion "istio.io/pkg/version"
 )
 
-const (
-	defaultTimeoutDurationStr = "10m"
-)
-
 // BuildClientConfig builds a client rest config from a kubeconfig filepath and context.
 // It overrides the current context with the one provided (empty to use default).
 //
@@ -78,7 +74,6 @@ func BuildClientCmd(kubeconfig, context string) clientcmd.ClientConfig {
 	configOverrides := &clientcmd.ConfigOverrides{
 		ClusterDefaults: clientcmd.ClusterDefaults,
 		CurrentContext:  context,
-		Timeout:         defaultTimeoutDurationStr,
 	}
 
 	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
@@ -94,7 +89,6 @@ func CreateClientset(kubeconfig, context string, fns ...func(*rest.Config)) (*ku
 	for _, fn := range fns {
 		fn(c)
 	}
-
 	return kubernetes.NewForConfig(c)
 }
 

--- a/pkg/kube/util.go
+++ b/pkg/kube/util.go
@@ -21,7 +21,7 @@ import (
 	"strconv"
 	"strings"
 
-	"istio.io/pkg/version"
+	istioversion "istio.io/pkg/version"
 	kubeApiCore "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -121,7 +121,7 @@ func adjustCommand(p string) string {
 // example: pilot-discovery/1.9.5 or istioctl/1.10.0
 // This is a specialized version of rest.DefaultKubernetesUserAgent()
 func IstioUserAgent() string {
-	return adjustCommand(os.Args[0]) + "/" + version.Info.String()
+	return adjustCommand(os.Args[0]) + "/" + istioversion.Info.String()
 }
 
 // SetRestDefaults is a helper function that sets default values for the given rest.Config.

--- a/pkg/kube/util.go
+++ b/pkg/kube/util.go
@@ -34,6 +34,10 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
+const (
+	defaultTimeoutDurationStr = "10m"
+)
+
 // BuildClientConfig builds a client rest config from a kubeconfig filepath and context.
 // It overrides the current context with the one provided (empty to use default).
 //
@@ -69,6 +73,7 @@ func BuildClientCmd(kubeconfig, context string) clientcmd.ClientConfig {
 	configOverrides := &clientcmd.ConfigOverrides{
 		ClusterDefaults: clientcmd.ClusterDefaults,
 		CurrentContext:  context,
+		Timeout:         defaultTimeoutDurationStr,
 	}
 
 	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)

--- a/pkg/kube/util.go
+++ b/pkg/kube/util.go
@@ -101,10 +101,7 @@ func CreateClientset(kubeconfig, context string, fns ...func(*rest.Config)) (*ku
 		fn(c)
 	}
 
-	c.Wrap(func(rt http.RoundTripper) http.RoundTripper {
-		return transport.NewDebuggingRoundTripper(rt, transport.DebugCurlCommand, transport.DebugURLTiming, transport.DebugResponseHeaders)
-	})
-
+	DebugWrap(c)
 	return kubernetes.NewForConfig(c)
 }
 
@@ -137,7 +134,7 @@ func adjustCommand(p string) string {
 // example: pilot-discovery/1.9.5 or istioctl/1.10.0
 // This is a specialized version of rest.DefaultKubernetesUserAgent()
 func IstioUserAgent() string {
-	return adjustCommand(os.Args[0]) + "/" + istioversion.Info.String()
+	return adjustCommand(os.Args[0]) + "/" + istioversion.Info.Version
 }
 
 // SetRestDefaults is a helper function that sets default values for the given rest.Config.
@@ -165,9 +162,6 @@ func SetRestDefaults(config *rest.Config) *rest.Config {
 		config.UserAgent = IstioUserAgent()
 	}
 
-	config.Wrap(func(rt http.RoundTripper) http.RoundTripper {
-		return transport.NewDebuggingRoundTripper(rt, transport.DebugCurlCommand, transport.DebugURLTiming, transport.DebugResponseHeaders)
-	})
 	return config
 }
 

--- a/releasenotes/notes/set-user-agent.yaml
+++ b/releasenotes/notes/set-user-agent.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: feature
+area: istioctl
+issue:
+  - 28231
+
+releaseNotes:
+- |
+  **Fixed** user-agent in all istio binaries to include version.
+  **Added** --vklog option to enable verbose logging in client-go.

--- a/tools/bug-report/pkg/kubeclient/kubeclient.go
+++ b/tools/bug-report/pkg/kubeclient/kubeclient.go
@@ -15,12 +15,13 @@
 package kubeclient
 
 import (
-	"istio.io/istio/pkg/kube"
 	"k8s.io/client-go/kubernetes"
 
 	//  Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/tools/clientcmd"
+
+	"istio.io/istio/pkg/kube"
 )
 
 // New creates a rest.Config qne Clientset from the given kubeconfig path and Context.

--- a/tools/bug-report/pkg/kubeclient/kubeclient.go
+++ b/tools/bug-report/pkg/kubeclient/kubeclient.go
@@ -15,8 +15,7 @@
 package kubeclient
 
 import (
-	"os"
-
+	"istio.io/istio/pkg/kube"
 	"k8s.io/client-go/kubernetes"
 
 	//  Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -24,53 +23,17 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-const (
-	defaultTimeoutDurationStr = "10m"
-)
-
 // New creates a rest.Config qne Clientset from the given kubeconfig path and Context.
 func New(kubeconfig, kubeContext string) (clientcmd.ClientConfig, *kubernetes.Clientset, error) {
-	clientConfig := buildClientConfig(kubeconfig, kubeContext)
+	clientConfig := kube.BuildClientCmd(kubeconfig, kubeContext)
 	restConfig, err := clientConfig.ClientConfig()
 	if err != nil {
 		return nil, nil, err
 	}
-	clientset, err := kubernetes.NewForConfig(restConfig)
+	clientset, err := kubernetes.NewForConfig(kube.SetRestDefaults(restConfig))
 	if err != nil {
 		return nil, nil, err
 	}
 
 	return clientConfig, clientset, nil
-}
-
-// buildClientConfig is a helper function that builds client config from a kubeconfig filepath.
-// It overrides the current Context with the one provided (wantEmpty to use default).
-//
-// This is a modified version of k8s.io/client-go/tools/clientcmd/BuildConfigFromFlags with the
-// difference that it loads default configs if not running in-cluster.
-func buildClientConfig(kubeconfig, context string) clientcmd.ClientConfig {
-	if kubeconfig != "" {
-		info, err := os.Stat(kubeconfig)
-		if err != nil || info.Size() == 0 {
-			// If the specified kubeconfig doesn't exists / wantEmpty file / any other error
-			// from file stat, fall back to default
-			kubeconfig = ""
-		}
-	}
-
-	// Config loading rules:
-	// 1. kubeconfig if it not wantEmpty string
-	// 2. In cluster config if running in-cluster
-	// 3. Config(s) in KUBECONFIG environment variable
-	// 4. Use $HOME/.kube/config
-	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
-	loadingRules.DefaultClientConfig = &clientcmd.DefaultClientConfig
-	loadingRules.ExplicitPath = kubeconfig
-	configOverrides := &clientcmd.ConfigOverrides{
-		ClusterDefaults: clientcmd.ClusterDefaults,
-		CurrentContext:  context,
-		Timeout:         defaultTimeoutDurationStr,
-	}
-
-	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
 }

--- a/tools/bug-report/pkg/kubeclient/kubeclient.go
+++ b/tools/bug-report/pkg/kubeclient/kubeclient.go
@@ -24,9 +24,15 @@ import (
 	"istio.io/istio/pkg/kube"
 )
 
+const (
+	defaultTimeoutDurationStr = "10m"
+)
+
 // New creates a rest.Config qne Clientset from the given kubeconfig path and Context.
 func New(kubeconfig, kubeContext string) (clientcmd.ClientConfig, *kubernetes.Clientset, error) {
-	clientConfig := kube.BuildClientCmd(kubeconfig, kubeContext)
+	clientConfig := kube.BuildClientCmd(kubeconfig, kubeContext, func(co *clientcmd.ConfigOverrides) {
+		co.Timeout = defaultTimeoutDurationStr
+	})
 	restConfig, err := clientConfig.ClientConfig()
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
Add istio-user-agent string to api server calls from istio for auditability.

resolves https://github.com/istio/istio/issues/28231

1.  Use `pkg/version` to generation version string for user-agent.
2. Consolidate multiple paths to build a kubeclient. 
3. Add klog support for client-go. The standard `-v=x` option cannot be used because we use it elsewhere. istioctl renames the option, and makes it a long form option with `--vklog`.

-- 


Following is output with `--vkog=9`. This flag was also added as part of this PR. shows `-H "User-Agent: istioctl/1.11-dev"` 

```console
jog@dev3:~/go/src/istio.io/istio$ ./out/linux_amd64/istioctl version -vklog=9
I0608 07:11:00.050509  250705 loader.go:372] Config loaded from file:  /home/mjog/.kube/config
I0608 07:11:00.051002  250705 loader.go:372] Config loaded from file:  /home/mjog/.kube/config
I0608 07:11:00.052499  250705 round_trippers.go:435] curl -k -v -XGET  -H "Accept: application/json, */*" -H "User-Agent: istioctl/1.11-dev" 'https://34.67.144.238/api/v1/namespaces/istio-system/pods?fieldSelector=status.phase%3DRunning&labelSelector=app%3Distiod&timeout=10m0s'
I0608 07:11:00.180675  250705 round_trippers.go:454] GET https://34.67.144.238/api/v1/namespaces/istio-system/pods?fieldSelector=status.phase%3DRunning&labelSelector=app%3Distiod&timeout=10m0s 200 OK in 128 milliseconds
I0608 07:11:00.180739  250705 round_trippers.go:460] Response Headers:
I0608 07:11:00.180774  250705 round_trippers.go:463]     Cache-Control: no-cache, private
I0608 07:11:00.180805  250705 round_trippers.go:463]     Content-Type: application/json
I0608 07:11:00.180834  250705 round_trippers.go:463]     Date: Tue, 08 Jun 2021 07:11:00 GMT
I0608 07:11:00.180838  250705 round_trippers.go:463]     Audit-Id: 1c8eebbc-0860-4ac0-8f9e-278b54c8bd8c
I0608 07:11:00.213594  250705 request.go:1123] Response Body {...}
```