### PR TITLE
Fix change in ads log format

### DIFF
--- a/pilot/pkg/xds/delta.go
+++ b/pilot/pkg/xds/delta.go
@@ -483,8 +483,8 @@ func (s *DiscoveryServer) pushDeltaXds(con *Connection, push *model.PushContext,
 	switch {
 	case logdata.Incremental:
 		if log.DebugEnabled() {
-			log.Debugf("%s: %s for node:%s resources:%d size:%s%s",
-				ptype, v3.GetShortType(w.TypeUrl), con.proxy.ID, len(res), util.ByteCount(ResourceSize(res)), info)
+			log.Debugf("%s: %s%s for node:%s resources:%d size:%s%s",
+				v3.GetShortType(w.TypeUrl), ptype, req.PushReason(), con.ConID, len(res), util.ByteCount(configSize), info)
 		}
 	default:
 		debug := ""
@@ -492,8 +492,8 @@ func (s *DiscoveryServer) pushDeltaXds(con *Connection, push *model.PushContext,
 			// Add additional information to logs when debug mode enabled.
 			debug = " nonce:" + resp.Nonce + " version:%" + resp.SystemVersionInfo
 		}
-		log.Infof("%s: %s for node:%s resources:%d size:%v%s%s", ptype, v3.GetShortType(w.TypeUrl), con.proxy.ID,
-			len(res), util.ByteCount(ResourceSize(res)), debug, info)
+		log.Infof("%s: %s for node:%s resources:%d size:%v%s%s", v3.GetShortType(w.TypeUrl), ptype, con.proxy.ID, len(res),
+			util.ByteCount(ResourceSize(res)), info, debug)
 	}
 
 	return nil

--- a/pilot/pkg/xds/xdsgen.go
+++ b/pilot/pkg/xds/xdsgen.go
@@ -145,7 +145,7 @@ func (s *DiscoveryServer) pushXds(con *Connection, push *model.PushContext,
 			// Add additional information to logs when debug mode enabled.
 			debug = " nonce:" + resp.Nonce + " version:%" + resp.VersionInfo
 		}
-		log.Infof("%s: %s for node:%s resources:%d size:%v%s%s", ptype, v3.GetShortType(w.TypeUrl), con.proxy.ID, len(res),
+		log.Infof("%s: %s for node:%s resources:%d size:%v%s%s", v3.GetShortType(w.TypeUrl), ptype, con.proxy.ID, len(res),
 			util.ByteCount(ResourceSize(res)), info, debug)
 	}
 


### PR DESCRIPTION
Switch from `PUSH: CDS for ...` back to `CDS: PUSH for ...`. This
restores the old behavior we have had since 1.0.

This log is commonly parsed so I don't really want to break it, I think
it was an accidental change anyhow



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.