### PR TITLE
Hide error message when running test outside of CI

### DIFF
--- a/pkg/test/util/file/file.go
+++ b/pkg/test/util/file/file.go
@@ -57,6 +57,9 @@ func AsStringOrFail(t test.Failer, filename string) string {
 
 // NormalizePath expands the homedir (~) and returns an error if the file doesn't exist.
 func NormalizePath(originalPath string) (string, error) {
+	if originalPath == "" {
+		return "", nil
+	}
 	// trim leading/trailing spaces from the path and if it uses the homedir ~, expand it.
 	var err error
 	out := strings.TrimSpace(originalPath)


### PR DESCRIPTION
We attempt to normalize `$ARTIFACTS` which is not there locally. I think
we can just make the function not fail for unset input



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.