### PR TITLE
remove debounce logic from secret watcher

### DIFF
--- a/security/pkg/nodeagent/cache/secretcache.go
+++ b/security/pkg/nodeagent/cache/secretcache.go
@@ -626,7 +626,7 @@ func (sc *SecretManagerClient) handleFileWatch() {
 			sc.certMutex.RUnlock()
 			// Trigger callbacks for all resources referencing this file. This is practically always
 			// a single resource.
-			cacheLog.Infof("event for file certificate %s : %s", event.Name, event.Op.String())
+			cacheLog.Infof("event for file certificate %s : %s, pushing to proxy", event.Name, event.Op.String())
 			for k := range resources {
 				if k.Filename == event.Name {
 					sc.CallUpdateCallback(k.ResourceName)

--- a/security/pkg/nodeagent/cache/secretcache.go
+++ b/security/pkg/nodeagent/cache/secretcache.go
@@ -610,27 +610,8 @@ func (sc *SecretManagerClient) registerSecret(item security.SecretItem) {
 }
 
 func (sc *SecretManagerClient) handleFileWatch() {
-	var timerC <-chan time.Time
-	events := make(map[string]fsnotify.Event)
-
 	for {
 		select {
-		case <-timerC:
-			timerC = nil
-			for resource, event := range events {
-				cacheLog.Infof("file certificate %s changed with event %s, pushing to proxy", resource, event.Op.String())
-				sc.certMutex.RLock()
-				resources := sc.fileCerts
-				sc.certMutex.RUnlock()
-				// Trigger callbacks for all resources referencing this file. This is practically always
-				// a single resource.
-				for k := range resources {
-					if k.Filename == resource {
-						sc.CallUpdateCallback(k.ResourceName)
-					}
-				}
-			}
-			events = make(map[string]fsnotify.Event)
 		case event, ok := <-sc.certWatcher.Events:
 			// Channel is closed.
 			if !ok {
@@ -640,14 +621,16 @@ func (sc *SecretManagerClient) handleFileWatch() {
 			if !(isWrite(event) || isRemove(event) || isCreate(event)) {
 				continue
 			}
-			// Typically inotify notifies about file change after the event i.e. write is complete. It only
-			// does some housekeeping tasks after the event is generated. However in some cases, multiple events
-			// are triggered in quick succession - to handle that case we debounce here.
-			// Use a timer to debounce watch updates
-			cacheLog.Infof("event for file certificate %s : %s, debouncing ", event.Name, event.Op.String())
-			if timerC == nil {
-				timerC = time.After(100 * time.Millisecond) // TODO: Make this configurable if needed.
-				events[event.Name] = event
+			sc.certMutex.RLock()
+			resources := sc.fileCerts
+			sc.certMutex.RUnlock()
+			// Trigger callbacks for all resources referencing this file. This is practically always
+			// a single resource.
+			cacheLog.Infof("event for file certificate %s : %s", event.Name, event.Op.String())
+			for k := range resources {
+				if k.Filename == event.Name {
+					sc.CallUpdateCallback(k.ResourceName)
+				}
 			}
 		case err, ok := <-sc.certWatcher.Errors:
 			// Channel is closed.


### PR DESCRIPTION
Because of this debounce logic we are seeing some events are missed (probably a race condition in debouncer) . I think debouncer is strictly not needed here because inotify will trigger write event after write is actually complete and we are checking for write events already.
[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
