### PR TITLE
add crash recover to CNI plugin

### DIFF
--- a/cni/cmd/istio-cni/main.go
+++ b/cni/cmd/istio-cni/main.go
@@ -123,16 +123,18 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 	// a proper error to the runtime.
 	defer func() {
 		if e := recover(); e != nil {
-			msg := fmt.Sprintf("istio-cni panicked during ADD: %s", e)
+			msg := fmt.Sprintf("istio-cni panicked during cmdAdd: %v", e)
+			log.Errorf(msg)
 			if err != nil {
 				// If we're recovering and there was also an error, then we need to
 				// present both.
-				msg = fmt.Sprintf("%s: error=%s", msg, err)
+				msg = fmt.Sprintf("%s: %v", msg, err)
+				log.Errorf(msg)
 			}
 			err = fmt.Errorf(msg)
 		}
 		if err != nil {
-			log.Errorf("Final result of istio-cni ADD was an error.")
+			log.Errorf("istio-cni cmdAdd error: %v", err)
 		}
 	}()
 
@@ -275,33 +277,8 @@ func cmdGet(args *skel.CmdArgs) error {
 }
 
 // cmdDel is called for DELETE requests
-func cmdDel(args *skel.CmdArgs) (err error) {
-	// Defer a panic recover, so that in case we panic we can still return
-	// a proper error to the runtime.
-	defer func() {
-		if e := recover(); e != nil {
-			msg := fmt.Sprintf("istio-cni panicked during DELETE: %s", e)
-			if err != nil {
-				// If we're recovering and there was also an error, then we need to
-				// present both.
-				msg = fmt.Sprintf("%s: error=%s", msg, err)
-			}
-			err = fmt.Errorf(msg)
-		}
-		if err != nil {
-			log.Errorf("Final result of istio-cni DELETE was an error.")
-		}
-	}()
-
-	log.Info("istio-cni cmdDel parsing config")
-	conf, err := parseConfig(args.StdinData)
-	if err != nil {
-		return err
-	}
-	_ = conf
-
-	// Do your delete here
-
+func cmdDel(args *skel.CmdArgs) error {
+	// nothing to cleanup for istio-cni
 	return nil
 }
 

--- a/cni/cmd/istio-cni/main.go
+++ b/cni/cmd/istio-cni/main.go
@@ -124,12 +124,10 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 	defer func() {
 		if e := recover(); e != nil {
 			msg := fmt.Sprintf("istio-cni panicked during cmdAdd: %v", e)
-			log.Errorf(msg)
 			if err != nil {
 				// If we're recovering and there was also an error, then we need to
 				// present both.
 				msg = fmt.Sprintf("%s: %v", msg, err)
-				log.Errorf(msg)
 			}
 			err = fmt.Errorf(msg)
 		}

--- a/cni/cmd/istio-cni/main_test.go
+++ b/cni/cmd/istio-cni/main_test.go
@@ -428,20 +428,6 @@ func TestCmdAddNoPrevResult(t *testing.T) {
 	testCmdAddWithStdinData(t, confNoPrevResult)
 }
 
-func TestCmdDel(t *testing.T) {
-	cniConf := fmt.Sprintf(conf, currentVersion, ifname, sandboxDirectory)
-	args := testSetArgs(cniConf)
-
-	err := cmdDel(args)
-	if err != nil {
-		t.Fatalf("failed with error: %v", err)
-	}
-}
-
-func TestCmdDelInvalidVersion(t *testing.T) {
-	testCmdInvalidVersion(t, cmdDel)
-}
-
 func MockInterceptRuleMgrCtor() InterceptRuleMgr {
 	return NewMockInterceptRuleMgr()
 }

--- a/releasenotes/notes/33145.yaml
+++ b/releasenotes/notes/33145.yaml
@@ -1,8 +1,0 @@
-apiVersion: release-notes/v2
-kind: bug-fix
-area: installation
-issue:
-  - 33137
-releaseNotes:
-  - |
-    **Fixed** the CNI plugin has no crash recover.

--- a/releasenotes/notes/33145.yaml
+++ b/releasenotes/notes/33145.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+issue:
+  - 33137
+releaseNotes:
+  - |
+    **Fixed** the CNI plugin has no crash recover.


### PR DESCRIPTION
This PR is to add the crash revocer like Calico for CNI plugin. The PR is to fix the issue #33137. 
[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure

[x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
