### PR TITLE
Remove init polling task in bug-report

### DIFF
--- a/tools/bug-report/pkg/bugreport/bugreport.go
+++ b/tools/bug-report/pkg/bugreport/bugreport.go
@@ -101,6 +101,7 @@ var (
 )
 
 func runBugReportCommand(_ *cobra.Command, logOpts *log.Options) error {
+	kubectlcmd.ReportRunningTasks()
 	if err := configLogs(logOpts); err != nil {
 		return err
 	}

--- a/tools/bug-report/pkg/kubectlcmd/kubectlcmd.go
+++ b/tools/bug-report/pkg/kubectlcmd/kubectlcmd.go
@@ -53,7 +53,7 @@ var (
 	runningTasksTicker = time.NewTicker(reportInterval)
 )
 
-func init() {
+func ReportRunningTasks() {
 	go func() {
 		time.Sleep(reportInterval)
 		for range runningTasksTicker.C {


### PR DESCRIPTION
This avoids running this accidentally when something (istioctl) just
imports the package



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.