### PR TITLE
tf: Avoid not needed wait on stop channel

### DIFF
--- a/pkg/test/framework/components/echo/kube/pod_controller.go
+++ b/pkg/test/framework/components/echo/kube/pod_controller.go
@@ -100,7 +100,6 @@ func (c *podController) Run(stop <-chan struct{}) {
 	go c.informer.Run(stop)
 	cache.WaitForCacheSync(stop, c.HasSynced)
 	go c.q.Run(stop)
-	<-stop
 }
 
 func (c *podController) HasSynced() bool {


### PR DESCRIPTION
Calls are in goroutines. There is no reason to have this function block,
as we don't do anything after stop is closed. So we can save some
goroutines.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.