### PR TITLE
Skip flaky VM test that depends on Kubernetes being slow

### DIFF
--- a/tests/integration/pilot/vm_test.go
+++ b/tests/integration/pilot/vm_test.go
@@ -85,6 +85,7 @@ func TestVmOSPost(t *testing.T) {
 }
 
 func TestVMRegistrationLifecycle(t *testing.T) {
+	t.Skip("https://github.com/istio/istio/issues/33154")
 	framework.
 		NewTest(t).
 		RequiresSingleCluster().


### PR DESCRIPTION
Now that we made some changes to the cluster, the autoscaling is faster
which seems to lead to this failing more often

Tracked in https://github.com/istio/istio/issues/33154



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.