### PR TITLE
fix: script parameter error under macos

### DIFF
--- a/bin/retry.sh
+++ b/bin/retry.sh
@@ -45,7 +45,11 @@ function retry {
   while true; do
     unset SHELL # Don't let environment control which shell to use
     if isatty; then
-      script --flush --quiet --return "${tmpFile}" --command "${*}"
+      if [ "$(uname)" == "Darwin" ]; then
+        script -q -r "${tmpFile}" "${*}"
+      else
+        script --flush --quiet --return "${tmpFile}" --command "${*}"
+      fi
     else
       # if we aren't a TTY, run directly as script will always run with a tty, which may output content that
       # we cannot display


### PR DESCRIPTION
Signed-off-by: shaowenchen <mail@chenshaowen.com>


An error occurs while I compile the project under macos 11.2.3 (20D91).

```bash
BUILD_WITH_CONTAINER=0 make clean 
```

```bash
BUILD_WITH_CONTAINER=0 make init 

ISTIO_OUT=/Users/shaowenchen/Code/github/istio/out/darwin_amd64 ISTIO_BIN=/Users/shaowenchen/.gvm/pkgsets/go1.16/global/bin GOOS_LOCAL=darwin bin/retry.sh SSL_ERROR_SYSCALL bin/init.sh
script: illegal option -- -
usage: script [-adkpqr] [-t time] [file [command ...]]
Unexpected failure
make: *** [/Users/shaowenchen/Code/github/istio/out/darwin_amd64/istio_is_init] Error 1
```

It should use `script -q -r file cmd` of `script --flush --quiet --return file --command cmd` under macos.


[X] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.