### PR TITLE
Improve error msg of istioctl x precheck

### DIFF
--- a/istioctl/cmd/precheck.go
+++ b/istioctl/cmd/precheck.go
@@ -227,7 +227,7 @@ func checkCanCreateResources(c kube.ExtendedClient, namespace, group, version, n
 func checkServerVersion(cli kube.ExtendedClient) (diag.Messages, error) {
 	v, err := cli.GetKubernetesVersion()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get the Kubernetes version: %v", err)
 	}
 	compatible, err := k8sversion.CheckKubernetesVersion(v)
 	if err != nil {


### PR DESCRIPTION
Closes #32119
Improve error message when istioctl x precheck could not connect to K8s cluster.
Suggest reviewer: @howardjohn

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[X] User Experience
[ ] Developer Infrastructure
