### PR TITLE
Dedup Pushcontext with ServiceDiscovery and IstioConfigStore

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -189,12 +189,6 @@ type PushContext struct {
 	// Mesh configuration for the mesh.
 	Mesh *meshconfig.MeshConfig `json:"-"`
 
-	// Discovery interface for listing services and instances.
-	ServiceDiscovery `json:"-"`
-
-	// Config interface for listing routing rules
-	IstioConfigStore `json:"-"`
-
 	// PushVersion describes the push version this push context was computed for
 	PushVersion string
 
@@ -529,7 +523,6 @@ func init() {
 
 // NewPushContext creates a new PushContext structure to track push status.
 func NewPushContext() *PushContext {
-	// TODO: detect push in progress, don't update status if set
 	return &PushContext{
 		ServiceIndex:            newServiceIndex(),
 		virtualServiceIndex:     newVirtualServiceIndex(),
@@ -955,8 +948,6 @@ func (ps *PushContext) InitContext(env *Environment, oldPushContext *PushContext
 	}
 
 	ps.Mesh = env.Mesh()
-	ps.ServiceDiscovery = env.ServiceDiscovery
-	ps.IstioConfigStore = env.IstioConfigStore
 	ps.LedgerVersion = env.Version()
 
 	// Must be initialized first

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -967,7 +967,7 @@ func (ps *PushContext) InitContext(env *Environment, oldPushContext *PushContext
 	}
 
 	// TODO: only do this when meshnetworks or gateway service changed
-	ps.initMeshNetworks(env.Networks())
+	ps.initMeshNetworks(env)
 
 	ps.clusterLocalHosts = env.ClusterLocal().GetClusterLocalHosts()
 
@@ -1158,7 +1158,7 @@ func (ps *PushContext) initServiceRegistry(env *Environment) error {
 				ps.ServiceIndex.instancesByPort[s] = make(map[int][]*ServiceInstance)
 			}
 			instances := make([]*ServiceInstance, 0)
-			instances = append(instances, ps.InstancesByPort(s, port.Port, nil)...)
+			instances = append(instances, env.InstancesByPort(s, port.Port, nil)...)
 			ps.ServiceIndex.instancesByPort[s][port.Port] = instances
 		}
 
@@ -1742,12 +1742,13 @@ func (ps *PushContext) mergeGateways(proxy *Proxy) *MergedGateway {
 }
 
 // pre computes gateways for each network
-func (ps *PushContext) initMeshNetworks(meshNetworks *meshconfig.MeshNetworks) {
+func (ps *PushContext) initMeshNetworks(env *Environment) {
 	ps.networksMu.Lock()
 	defer ps.networksMu.Unlock()
 	ps.networkGateways = map[string][]*Gateway{}
 
 	// First, use addresses directly specified in meshNetworks
+	meshNetworks := env.Networks()
 	if meshNetworks != nil {
 		for network, networkConf := range meshNetworks.Networks {
 			gws := networkConf.Gateways
@@ -1761,7 +1762,7 @@ func (ps *PushContext) initMeshNetworks(meshNetworks *meshconfig.MeshNetworks) {
 	}
 
 	// Second, load registry specific gateways.
-	for network, gateways := range ps.ServiceDiscovery.NetworkGateways() {
+	for network, gateways := range env.NetworkGateways() {
 		// - the internal map of label gateways - these get deleted if the service is deleted, updated if the ip changes etc.
 		// - the computed map from meshNetworks (triggered by reloadNetworkLookup, the ported logic from getGatewayAddresses)
 		ps.networkGateways[network] = append(ps.networkGateways[network], gateways...)
@@ -1832,9 +1833,7 @@ func (ps *PushContext) ServiceInstancesByPort(svc *Service, port int, labels lab
 			return instances
 		}
 	}
-
-	// Fallback to discovery call.
-	return ps.InstancesByPort(svc, port, labels)
+	return nil
 }
 
 // initKubernetesGateways initializes Kubernetes gateway-api objects

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -578,7 +578,6 @@ func TestSidecarScope(t *testing.T) {
 	ps := NewPushContext()
 	env := &Environment{Watcher: mesh.NewFixedWatcher(&meshconfig.MeshConfig{RootNamespace: "istio-system"})}
 	ps.Mesh = env.Mesh()
-	ps.ServiceDiscovery = env
 	ps.ServiceIndex.HostnameAndNamespace[host.Name("svc1.default.cluster.local")] = map[string]*Service{"default": nil}
 	ps.ServiceIndex.HostnameAndNamespace[host.Name("svc2.nosidecar.cluster.local")] = map[string]*Service{"nosidecar": nil}
 
@@ -668,7 +667,6 @@ func TestBestEffortInferServiceMTLSMode(t *testing.T) {
 	sd := &localServiceDiscovery{}
 	env.ServiceDiscovery = sd
 	ps.Mesh = env.Mesh()
-	ps.ServiceDiscovery = env
 
 	configStore := NewFakeStore()
 
@@ -1200,7 +1198,6 @@ func TestVirtualServiceWithExportTo(t *testing.T) {
 	ps := NewPushContext()
 	env := &Environment{Watcher: mesh.NewFixedWatcher(&meshconfig.MeshConfig{RootNamespace: "zzz"})}
 	ps.Mesh = env.Mesh()
-	ps.ServiceDiscovery = env
 	configStore := NewFakeStore()
 	gatewayName := "default/gateway"
 
@@ -1351,7 +1348,6 @@ func TestInitVirtualService(t *testing.T) {
 	ps := NewPushContext()
 	env := &Environment{Watcher: mesh.NewFixedWatcher(&meshconfig.MeshConfig{RootNamespace: "istio-system"})}
 	ps.Mesh = env.Mesh()
-	ps.ServiceDiscovery = env
 	configStore := NewFakeStore()
 	gatewayName := "ns1/gateway"
 
@@ -1449,7 +1445,6 @@ func TestServiceWithExportTo(t *testing.T) {
 	ps := NewPushContext()
 	env := &Environment{Watcher: mesh.NewFixedWatcher(&meshconfig.MeshConfig{RootNamespace: "zzz"})}
 	ps.Mesh = env.Mesh()
-	ps.ServiceDiscovery = env
 
 	svc1 := &Service{
 		Hostname: "svc1",

--- a/pilot/pkg/networking/apigen/apigen_test.go
+++ b/pilot/pkg/networking/apigen/apigen_test.go
@@ -36,7 +36,7 @@ var (
 )
 
 // Creates an in-process discovery server, using the same code as Istiod, but
-// backed by an in-memory config and endpoint store.
+// backed by an in-memory config and endpoint Store.
 func initDS() *xds.SimpleServer {
 	ds := xds.NewXDS(make(chan struct{}))
 
@@ -56,7 +56,7 @@ func initDS() *xds.SimpleServer {
 // to represent the names. The protocol is based on GRPC resolution of XDS resources.
 func TestAPIGen(t *testing.T) {
 	ds := initDS()
-	ds.DiscoveryServer.Generators["api"] = &apigen.APIGenerator{}
+	ds.DiscoveryServer.Generators["api"] = apigen.NewGenerator(ds.DiscoveryServer.Env.IstioConfigStore)
 	epGen := &xds.EdsGenerator{Server: ds.DiscoveryServer}
 	ds.DiscoveryServer.Generators["api/"+v3.EndpointType] = epGen
 

--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -621,7 +621,7 @@ func (s *DiscoveryServer) updateProxy(proxy *model.Proxy, request *model.PushReq
 }
 
 func (s *DiscoveryServer) computeProxyState(proxy *model.Proxy, request *model.PushRequest) {
-	proxy.SetServiceInstances(s.globalPushContext().ServiceDiscovery)
+	proxy.SetServiceInstances(s.Env.ServiceDiscovery)
 	// Precompute the sidecar scope and merged gateways associated with this proxy.
 	// Saves compute cycles in networking code. Though this might be redundant sometimes, we still
 	// have to compute this because as part of a config change, a new Sidecar could become

--- a/pilot/pkg/xds/discovery.go
+++ b/pilot/pkg/xds/discovery.go
@@ -534,7 +534,7 @@ func (s *DiscoveryServer) initGenerators(env *model.Environment, systemNameSpace
 	s.Generators["grpc/"+v3.RouteType] = s.Generators["grpc"]
 	s.Generators["grpc/"+v3.ClusterType] = s.Generators["grpc"]
 
-	s.Generators["api"] = &apigen.APIGenerator{}
+	s.Generators["api"] = apigen.NewGenerator(env.IstioConfigStore)
 	s.Generators["api/"+v3.EndpointType] = edsGen
 
 	s.Generators["api/"+TypeURLConnect] = s.StatusGen


### PR DESCRIPTION

PushContext should only store intermediate cache for this epic push, but ServiceDiscovery and IstioConfigStore are global interfaces. 

This pr does not change any user-sensitive behavior. 


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.