### PR TITLE
Fixes sidecar graceful shutdown issue in the IPv6 environment

### DIFF
--- a/pkg/envoy/admin.go
+++ b/pkg/envoy/admin.go
@@ -78,7 +78,7 @@ func GetConfigDump(adminPort uint32) (*envoyAdmin.ConfigDump, error) {
 }
 
 func doEnvoyGet(path string, adminPort uint32) (*bytes.Buffer, error) {
-	requestURL := fmt.Sprintf("http://127.0.0.1:%d/%s", adminPort, path)
+	requestURL := fmt.Sprintf("http://localhost:%d/%s", adminPort, path)
 	buffer, err := doHTTPGet(requestURL)
 	if err != nil {
 		return nil, err
@@ -87,7 +87,7 @@ func doEnvoyGet(path string, adminPort uint32) (*bytes.Buffer, error) {
 }
 
 func doEnvoyPost(path, contentType, body string, adminPort uint32) (*bytes.Buffer, error) {
-	requestURL := fmt.Sprintf("http://127.0.0.1:%d/%s", adminPort, path)
+	requestURL := fmt.Sprintf("http://localhost:%d/%s", adminPort, path)
 	buffer, err := doHTTPPost(requestURL, contentType, body)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
When Istio is installed in the IPv6 environment, graceful shutdown of the sidecar fails. It skips the terminationDrainDuration period and terminates immediately. This is because the pilot-agent invokes Envoy (admin path) on the IPv4 address (127.0.0.1:15000) when Envoy is actually listening on the IPv6 address ([::1]:15000). This PR addresses this minor issue.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[X] User Experience
[X] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.