### PR TITLE
check if in.Rewrite is nil

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -409,9 +409,11 @@ func translateRoute(push *model.PushContext, node *model.Proxy, in *networking.H
 		action.MaxGrpcTimeout = d
 		out.Action = &route.Route_Route{Route: action}
 
-		action.PrefixRewrite = in.Rewrite.GetUri()
-		if in.Rewrite.GetAuthority() != "" {
-			authority = in.Rewrite.GetAuthority()
+		if in.Rewrite != nil {
+			action.PrefixRewrite = in.Rewrite.GetUri()
+			if in.Rewrite.GetAuthority() != "" {
+				authority = in.Rewrite.GetAuthority()
+			}
 		}
 		if authority != "" {
 			action.HostRewriteSpecifier = &route.RouteAction_HostRewriteLiteral{


### PR DESCRIPTION

It is better to check if `in.Rewrite` is nil, to avoid unnecessary function calls when no rewrite rules.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[X] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.