### PR TITLE
feat:check the k8s version before installing istio by operator

### DIFF
--- a/operator/cmd/mesh/operator-init.go
+++ b/operator/cmd/mesh/operator-init.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"istio.io/api/operator/v1alpha1"
+	"istio.io/istio/istioctl/pkg/install/k8sversion"
 	iopv1alpha1 "istio.io/istio/operator/pkg/apis/istio/v1alpha1"
 	"istio.io/istio/operator/pkg/name"
 	"istio.io/istio/operator/pkg/translate"
@@ -84,6 +85,9 @@ func operatorInit(args *rootArgs, oiArgs *operatorInitArgs, l clog.Logger) {
 
 	restConfig, clientset, client, err := K8sConfig(oiArgs.kubeConfigPath, oiArgs.context)
 	if err != nil {
+		l.LogAndFatal(err)
+	}
+	if err := k8sversion.IsK8VersionSupported(clientset, l); err != nil {
 		l.LogAndFatal(err)
 	}
 	// Error here likely indicates Deployment is missing. If some other K8s error, we will hit it again later.


### PR DESCRIPTION
[ ] Configuration Infrastructure
[ ] Docs
[x] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[x] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.

see
```
[root@mesh-dev-10-20-11-180 istio-1.10.0]# istioctl operator init
Operator controller is already installed in istio-operator namespace.
Upgrading operator controller in namespace: istio-operator using image: docker.io/istio/operator:1.10.0
Operator controller will watch namespaces: istio-system
- Processing resources for Istio operator.                                                                                                       2021-06-01T12:02:29.509703Z	error	installer	failed to verify CRD creation; the server could not find the requested resource
✘ Istio operator encountered an error: failed to wait for resource: failed to verify CRD creation: the server could not find the requested resource
failed to wait for resource: failed to verify CRD creation: the server could not find the requested resource
```
we should check the version of istio, the installation of operator and istioctl should be consistent, and the version of k8s must be checked.

see
```
[root@mesh-dev-10-20-11-180 istio-1.10.0]# istioctl install
The Kubernetes version v1.14.8 is not supported by Istio 1.10.0. The minimum supported Kubernetes version is 1.17.
Proceeding with the installation, but you might experience problems. See https://istio.io/latest/docs/setup/platform-setup/ for a list of supported versions.

Detected that your cluster does not support third party JWT authentication. Falling back to less secure first party JWT. See https://istio.io/v1.10/docs/ops/best-practices/security/#configure-third-party-service-account-tokens for details.
! values.global.jwtPolicy is deprecated; use Values.global.jwtPolicy=third-party-jwt. See http://istio.io/latest/docs/ops/best-practices/security/#configure-third-party-service-account-tokens for more information instead
```


