### PR TITLE
Filter out some redundant domains in istioctl

### DIFF
--- a/istioctl/pkg/writer/envoy/configdump/route.go
+++ b/istioctl/pkg/writer/envoy/configdump/route.go
@@ -103,12 +103,11 @@ func describeRouteDomains(domains []string) string {
 		}
 	}
 	withoutPort = unexpandDomains(withoutPort)
-	visible := withoutPort[:max]
-	ret := strings.Join(visible, ", ")
 	if len(withoutPort) > max {
+		ret := strings.Join(withoutPort[:max], ", ")
 		return fmt.Sprintf("%s + %d more...", ret, len(withoutPort)-max)
 	}
-	return ret
+	return strings.Join(withoutPort, ", ")
 }
 
 func unexpandDomains(domains []string) []string {


### PR DESCRIPTION
Before:
```
NAME                                                          DOMAINS                                                                                                MATCH                  VIRTUAL SERVICE
                                                              *                                                                                                      /healthz/ready*  
                                                              *                                                                                                      /stats/prometheus*
InboundPassthroughClusterIpv6                                 *                                                                                                      /*               
inbound|9087||                                                *                                                                                                      /*               
InboundPassthroughClusterIpv4                                 *                                                                                                      /*               
kube-dns.kube-system.svc.cluster.local:9153                   kube-dns.kube-system.svc.cluster.local, kube-dns.kube-system + 2 more...                               /*               
inbound|9087||                                                *                                                                                                      /*               
istio-ingressgateway.istio-system.svc.cluster.local:15021     istio-ingressgateway.istio-system.svc.cluster.local, istio-ingressgateway.istio-system + 2 more...     /*               
InboundPassthroughClusterIpv6                                 *                                                                                                      /*               
80                                                            istio-ingressgateway.istio-system.svc.cluster.local, istio-ingressgateway.istio-system + 2 more...     /*               
90                                                            mynginx.ext, 1.2.3.5                                                                                   /*               
8888                                                          mynginx.ext, 1.2.3.5                                                                                   /*               
9087                                                          shell.default.svc.cluster.local, shell + 3 more...                                                     /*               
15010                                                         istiod.istio-system.svc.cluster.local, istiod.istio-system + 2 more...                                 /*               
15014                                                         istiod.istio-system.svc.cluster.local, istiod.istio-system + 2 more...                                 /*               
InboundPassthroughClusterIpv4                                 *                                                                                                      /*               

```
After:
```
build complete
NAME                                                          DOMAINS                                             MATCH                  VIRTUAL SERVICE
                                                              *                                                   /healthz/ready*
                                                              *                                                   /stats/prometheus*
InboundPassthroughClusterIpv6                                 *                                                   /*
inbound|9087||                                                *                                                   /*
InboundPassthroughClusterIpv4                                 *                                                   /*
kube-dns.kube-system.svc.cluster.local:9153                   kube-dns.kube-system, 10.96.0.10                    /*
inbound|9087||                                                *                                                   /*
istio-ingressgateway.istio-system.svc.cluster.local:15021     istio-ingressgateway.istio-system, 10.96.237.16     /*
InboundPassthroughClusterIpv6                                 *                                                   /*
80                                                            istio-ingressgateway.istio-system, 10.96.237.16     /*
90                                                            mynginx.ext, 1.2.3.5                                /*
8888                                                          mynginx.ext, 1.2.3.5                                /*
9087                                                          shell, shell.default + 1 more...                    /*
15010                                                         istiod.istio-system, 10.96.62.184                   /*
15014                                                         istiod.istio-system, 10.96.62.184                   /*
InboundPassthroughClusterIpv4                                 *                                                   /*
```