### PR TITLE
add additional logging for cache sync

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -793,11 +793,7 @@ func (s *Server) addTerminatingStartFunc(fn server.Component) {
 
 func (s *Server) waitForCacheSync(stop <-chan struct{}) bool {
 	log.Info("Waiting for caches to be synced")
-	start := time.Now()
-	if !cache.WaitForCacheSync(stop, func() bool {
-		// log which controller is not synced if sync takes more than 5 mins.
-		return s.cachesSynced(time.Since(start) > 5*time.Minute)
-	}) {
+	if !cache.WaitForCacheSync(stop, s.cachesSynced) {
 		log.Errorf("Failed waiting for cache sync")
 		return false
 	}
@@ -818,29 +814,17 @@ func (s *Server) waitForCacheSync(stop <-chan struct{}) bool {
 }
 
 // cachesSynced checks whether caches have been synced.
-func (s *Server) cachesSynced(debug bool) bool {
+func (s *Server) cachesSynced() bool {
 	if s.secretsController != nil && !s.secretsController.HasSynced() {
-		if debug {
-			log.Debug("secret controller has not yet synced up")
-		}
 		return false
 	}
 	if s.multicluster != nil && !s.multicluster.HasSynced() {
-		if debug {
-			log.Debug("multi cluster has not yet synced up")
-		}
 		return false
 	}
 	if !s.ServiceController().HasSynced() {
-		if debug {
-			log.Debug("service controller has not yet synced up")
-		}
 		return false
 	}
 	if !s.configController.HasSynced() {
-		if debug {
-			log.Debug("service controller has not yet synced up")
-		}
 		return false
 	}
 	return true

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -801,7 +801,7 @@ func (s *Server) waitForCacheSync(stop <-chan struct{}) bool {
 	log.Infof("All controller caches have been synced up in %v", time.Since(start))
 
 	// At this point, we know that all update events of the initial state-of-the-world have been
-	// received.We wait to ensure we have committed at least this many updates. This avoids a race
+	// received. We wait to ensure we have committed at least this many updates. This avoids a race
 	// condition where we are marked ready prior to updating the push context, leading to incomplete
 	// pushes.
 	expected := s.XDSServer.InboundUpdates.Load()
@@ -817,7 +817,7 @@ func (s *Server) waitForCacheSync(stop <-chan struct{}) bool {
 func (s *Server) pushContextReady(expected int64) bool {
 	committed := s.XDSServer.CommittedUpdates.Load()
 	if committed < expected {
-		log.Infof("Waiting for pushcontext to process inbound updates, inbound: %v, committed : %v", expected, committed)
+		log.Debugf("Waiting for pushcontext to process inbound updates, inbound: %v, committed : %v", expected, committed)
 		return false
 	}
 	return true

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -792,24 +792,34 @@ func (s *Server) addTerminatingStartFunc(fn server.Component) {
 }
 
 func (s *Server) waitForCacheSync(stop <-chan struct{}) bool {
+	start := time.Now()
 	log.Info("Waiting for caches to be synced")
 	if !cache.WaitForCacheSync(stop, s.cachesSynced) {
 		log.Errorf("Failed waiting for cache sync")
 		return false
 	}
+	log.Infof("All controller caches have been synced up in %v", time.Since(start))
+
 	// At this point, we know that all update events of the initial state-of-the-world have been
-	// received. Capture how many updates there are
-	expected := s.XDSServer.InboundUpdates.Load()
-	// Now, we wait to ensure we have committed at least this many updates. This avoids a race
+	// received.We wait to ensure we have committed at least this many updates. This avoids a race
 	// condition where we are marked ready prior to updating the push context, leading to incomplete
 	// pushes.
-	if !cache.WaitForCacheSync(stop, func() bool {
-		return s.XDSServer.CommittedUpdates.Load() >= expected
-	}) {
+	if !cache.WaitForCacheSync(stop, s.pushContextReady) {
 		log.Errorf("Failed waiting for push context initialization")
 		return false
 	}
 
+	return true
+}
+
+// pushContextReady indicates whether pushcontext has processed all inbound config updates.
+func (s *Server) pushContextReady() bool {
+	expected := s.XDSServer.InboundUpdates.Load()
+	committed := s.XDSServer.CommittedUpdates.Load()
+	if committed < expected {
+		log.Infof("Waiting for pushcontext to process inbound updates, inbound: %v, committed : %v", expected, committed)
+		return false
+	}
 	return true
 }
 

--- a/pilot/pkg/serviceregistry/aggregate/controller.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller.go
@@ -289,6 +289,7 @@ func (c *Controller) Running() bool {
 func (c *Controller) HasSynced() bool {
 	for _, r := range c.GetRegistries() {
 		if !r.HasSynced() {
+			log.Debugf("registry %s is syncing", r.Cluster())
 			return false
 		}
 	}

--- a/pkg/kube/secretcontroller/secretcontroller.go
+++ b/pkg/kube/secretcontroller/secretcontroller.go
@@ -224,7 +224,7 @@ func (c *Controller) Run(stopCh <-chan struct{}) {
 
 	go c.informer.Run(stopCh)
 
-	if !cache.WaitForCacheSync(stopCh, c.informer.HasSynced) {
+	if !kube.WaitForCacheSyncInterval(stopCh, c.syncInterval, c.informer.HasSynced) {
 		log.Error("Failed to sync secret controller cache")
 		return
 	}


### PR DESCRIPTION
We are seeing cache sync taking more than 1 hour in some clusters. It is not clear which controller is taking time. This PR tries to add log lines to capture that information.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
