### PR TITLE
Fixes #30868. Added the missing IPv6 rule.

### DIFF
--- a/releasenotes/notes/30868.yaml
+++ b/releasenotes/notes/30868.yaml
@@ -1,0 +1,14 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+
+# issue is a list of GitHub issues resolved in this note.
+issue:
+  - https://github.com/istio/istio/issues/30868
+
+docs:
+ - '[reference] https://istio.io/latest/docs/reference/config/annotations/'
+
+releaseNotes:
+- |
+  **Fixed** an issue where an ipv6 rule was missing when outbound ports were included using the resource annotation 

--- a/releasenotes/notes/30868.yaml
+++ b/releasenotes/notes/30868.yaml
@@ -11,4 +11,4 @@ docs:
 
 releaseNotes:
 - |
-  **Fixed** an issue where an ipv6 rule was missing when outbound ports were included using the resource annotation 
+  **Fixed** an issue where IPv6 iptables rules were incorrect when `includeOutboundPorts` annotations were used.

--- a/tools/istio-iptables/pkg/cmd/run.go
+++ b/tools/istio-iptables/pkg/cmd/run.go
@@ -303,6 +303,13 @@ func (iptConfigurator *IptablesConfigurator) handleInboundIpv6Rules(ipv6RangesEx
 		iptConfigurator.iptables.AppendRuleV6(constants.ISTIOOUTPUT, constants.NAT, "-d", cidr.String(), "-j", constants.RETURN)
 	}
 	// Apply outbound IPv6 inclusions.
+	if iptConfigurator.cfg.OutboundPortsInclude != "" {
+		for _, port := range split(iptConfigurator.cfg.OutboundPortsInclude) {
+			iptConfigurator.iptables.AppendRuleV6(
+				constants.ISTIOOUTPUT, constants.NAT, "-p", constants.TCP, "--dport", port, "-j", constants.ISTIOREDIRECT)
+		}
+	}
+
 	if ipv6RangesInclude.IsWildcard {
 		// Wildcard specified. Redirect all remaining outbound traffic to Envoy.
 		iptConfigurator.iptables.AppendRuleV6(constants.ISTIOOUTPUT, constants.NAT, "-j", constants.ISTIOREDIRECT)

--- a/tools/istio-iptables/pkg/cmd/run.go
+++ b/tools/istio-iptables/pkg/cmd/run.go
@@ -302,7 +302,8 @@ func (iptConfigurator *IptablesConfigurator) handleInboundIpv6Rules(ipv6RangesEx
 	for _, cidr := range ipv6RangesExclude.IPNets {
 		iptConfigurator.iptables.AppendRuleV6(constants.ISTIOOUTPUT, constants.NAT, "-d", cidr.String(), "-j", constants.RETURN)
 	}
-	// Apply outbound IPv6 inclusions.
+
+	// Redirect traffic to Envoy for the included outbound ports
 	if iptConfigurator.cfg.OutboundPortsInclude != "" {
 		for _, port := range split(iptConfigurator.cfg.OutboundPortsInclude) {
 			iptConfigurator.iptables.AppendRuleV6(
@@ -310,6 +311,7 @@ func (iptConfigurator *IptablesConfigurator) handleInboundIpv6Rules(ipv6RangesEx
 		}
 	}
 
+	// Apply outbound IPv6 inclusions.
 	if ipv6RangesInclude.IsWildcard {
 		// Wildcard specified. Redirect all remaining outbound traffic to Envoy.
 		iptConfigurator.iptables.AppendRuleV6(constants.ISTIOOUTPUT, constants.NAT, "-j", constants.ISTIOREDIRECT)


### PR DESCRIPTION
When an application is deployed in the IPv6 cluster with the annotation `traffic.sidecar.istio.io/includeOutboundPorts`, the corresponding IPv6 rule is missing in the ip6tables (as mentioned in issue #30868). This PR addresses this issue by adding the missing IPv6 rule. 


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[X] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.