### PR TITLE
do not start secret controller twice

### DIFF
--- a/pilot/pkg/bootstrap/servicecontroller.go
+++ b/pilot/pkg/bootstrap/servicecontroller.go
@@ -17,6 +17,7 @@ package bootstrap
 import (
 	"fmt"
 
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry"
 	"istio.io/istio/pilot/pkg/serviceregistry/aggregate"
@@ -113,10 +114,13 @@ func (s *Server) initKubeRegistry(args *PilotArgs) (err error) {
 	s.addTerminatingStartFunc(mc.Run)
 
 	// start remote cluster controllers
-	s.addStartFunc(func(stop <-chan struct{}) error {
-		mc.InitSecretController(stop)
-		return nil
-	})
+	// If XDS Identity check is enabled, we already start secret controller - see initSDSServer in server.go.
+	if !features.EnableXDSIdentityCheck {
+		s.addStartFunc(func(stop <-chan struct{}) error {
+			mc.InitSecretController(stop)
+			return nil
+		})
+	}
 
 	s.multicluster = mc
 	return


### PR DESCRIPTION
We are seeing cluster being processed twice

2021-06-02T05:26:52.348109Z	info	Processing add: mesh-canary/istio-remote-secret-canary-sam-processing00002
2021-06-02T05:26:52.348272Z	info	Processing add: mesh-canary/istio-remote-secret-canary-sam-processing00002
2021-06-02T05:26:52.444865Z	info	Adding cluster sam-processing00002 from secret mesh-canary/istio-remote-secret-canary-sam-processing00002
2021-06-02T05:26:52.444874Z	info	Adding cluster sam-processing00002 from secret mesh-canary/istio-remote-secret-canary-sam-processing00002

If we disable `PILOT_ENABLE_XDS_IDENTITY_CHECK` - the problem goes away

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
