### PR TITLE
Update to focal/debian10

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -19,10 +19,10 @@ ISTIO_GO := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 export ISTIO_GO
 SHELL := /bin/bash -o pipefail
 
-export VERSION ?= 1.10-dev
+export VERSION ?= 1.11-dev
 
 # Base version of Istio image to use
-BASE_VERSION ?= 1.10-dev.4
+BASE_VERSION ?= 1.11-dev.2
 
 export GO111MODULE ?= on
 export GOPROXY ?= https://proxy.golang.org

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -1,6 +1,4 @@
-FROM ubuntu:bionic
-# Base image for debug builds.
-# Built manually uploaded as "istionightly/base_debug"
+FROM ubuntu:focal
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -23,7 +21,6 @@ RUN apt-get update && \
   bsdmainutils \
   net-tools \
   lsof \
-  linux-tools-generic \
   sudo \
   && update-ca-certificates \
   && apt-get upgrade -y \

--- a/docker/Dockerfile.distroless
+++ b/docker/Dockerfile.distroless
@@ -2,7 +2,7 @@
 FROM gcr.io/distroless/static-debian10@sha256:60a7d0c45932b6152b2f7ba561db2f91f58ab14aa90b895c58f72062c768fd77 as distroless_source
 
 # prepare a base dev to modify file contents
-FROM ubuntu:bionic as ubuntu_source
+FROM ubuntu:focal as ubuntu_source
 
 # Modify contents of container
 COPY --from=distroless_source /etc/ /home/etc

--- a/manifests/charts/istio-operator/files/gen-operator.yaml
+++ b/manifests/charts/istio-operator/files/gen-operator.yaml
@@ -181,7 +181,7 @@ spec:
       serviceAccountName: istio-operator
       containers:
         - name: istio-operator
-          image: gcr.io/istio-testing/operator:1.10-dev
+          image: gcr.io/istio-testing/operator:1.11-dev
           command:
           - operator
           - server

--- a/pilot/docker/Dockerfile.proxyv2
+++ b/pilot/docker/Dockerfile.proxyv2
@@ -11,7 +11,7 @@ FROM gcr.io/istio-release/base:${BASE_VERSION} as default
 # This image is a custom built debian9 distroless image with multiarchitecture support.
 # It is built on the base distroless image, with iptables binary and libraries added
 # The source can be found at https://github.com/istio/distroless/tree/iptables
-FROM gcr.io/istio-release/iptables@sha256:8601b3cb13984e375d9a9a85687f23c88bc798e4f2ec9a80cca5e6abda66c6f9 as distroless
+FROM gcr.io/istio-release/iptables@sha256:ce8f9e20081b92300339738e8cf67ed3f83153da8213ff360a772462dba23562 as distroless
 
 # This will build the final image based on either default or distroless from above
 # hadolint ignore=DL3006

--- a/releasenotes/notes/focal-debian10.yaml
+++ b/releasenotes/notes/focal-debian10.yaml
@@ -1,0 +1,11 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+issues:
+- 29326
+
+releaseNotes:
+- |
+  **Updated** the base image versions to be built on `ubuntu:focal` and `debian10` (for distroless).
+- |
+  **Improved** the size of docker images, decreasing each image by up to 50mb. As a result, the `linux-tools-generic` package, as well as dependencies (including `python`) are no longer installed.

--- a/tools/istio-iptables/pkg/dependencies/implementation.go
+++ b/tools/istio-iptables/pkg/dependencies/implementation.go
@@ -101,8 +101,12 @@ func (r *RealDependencies) executeXTables(cmd string, redirectStdout bool, args 
 
 // transformToXTablesErrorMessage returns an updated error message with explicit xtables error hints, if applicable.
 func transformToXTablesErrorMessage(stderr string, err error) string {
-	exitcode := err.(*exec.ExitError).ExitCode()
-
+	ee, ok := err.(*exec.ExitError)
+	if !ok {
+		// Not common, but can happen if file not found error, etc
+		return err.Error()
+	}
+	exitcode := ee.ExitCode()
 	if errtypeStr, ok := exittypeToString[XTablesExittype(exitcode)]; ok {
 		// The original stderr is something like:
 		// `prog_name + prog_vers: error hints`


### PR DESCRIPTION
Update base images to debian10 and ubuntu:focal
Fixes https://github.com/istio/istio/issues/29326
Before trivy shows `Total: 213 (UNKNOWN: 0, LOW: 129, MEDIUM: 84, HIGH:0, CRITICAL: 0)`
After: `Total: 37 (UNKNOWN: 0, LOW: 32, MEDIUM: 5, HIGH: 0, CRITICAL: 0)` (all unfixed upstream)

Base image size 155mb -> 100mb