### PR TITLE
Expose DNS config from agent

### DIFF
--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -27,7 +27,6 @@ import (
 	"istio.io/istio/pilot/cmd/pilot-agent/config"
 	"istio.io/istio/pilot/cmd/pilot-agent/options"
 	"istio.io/istio/pilot/cmd/pilot-agent/status"
-	"istio.io/istio/pilot/cmd/pilot-agent/status/ready"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/util/network"
 	"istio.io/istio/pkg/cmd"
@@ -204,8 +203,8 @@ func init() {
 }
 
 func initStatusServer(ctx context.Context, proxy *model.Proxy, proxyConfig *meshconfig.ProxyConfig,
-	envoyPrometheusPort int, probes ...ready.Prober) error {
-	o := options.NewStatusServerOptions(proxy, proxyConfig, probes...)
+	envoyPrometheusPort int, agent *istio_agent.Agent) error {
+	o := options.NewStatusServerOptions(proxy, proxyConfig, agent)
 	o.EnvoyPrometheusPort = envoyPrometheusPort
 	o.Context = ctx
 	statusServer, err := status.NewServer(*o)

--- a/pilot/cmd/pilot-agent/options/statusserver.go
+++ b/pilot/cmd/pilot-agent/options/statusserver.go
@@ -19,9 +19,10 @@ import (
 	"istio.io/istio/pilot/cmd/pilot-agent/status"
 	"istio.io/istio/pilot/cmd/pilot-agent/status/ready"
 	"istio.io/istio/pilot/pkg/model"
+	istio_agent "istio.io/istio/pkg/istio-agent"
 )
 
-func NewStatusServerOptions(proxy *model.Proxy, proxyConfig *meshconfig.ProxyConfig, probes ...ready.Prober) *status.Options {
+func NewStatusServerOptions(proxy *model.Proxy, proxyConfig *meshconfig.ProxyConfig, agent *istio_agent.Agent) *status.Options {
 	return &status.Options{
 		IPv6:           IsIPv6Proxy(proxy.IPAddresses),
 		PodIP:          InstanceIPVar.Get(),
@@ -29,6 +30,7 @@ func NewStatusServerOptions(proxy *model.Proxy, proxyConfig *meshconfig.ProxyCon
 		StatusPort:     uint16(proxyConfig.StatusPort),
 		KubeAppProbers: kubeAppProberNameVar.Get(),
 		NodeType:       proxy.Type,
-		Probes:         probes,
+		Probes:         []ready.Prober{agent},
+		FetchDNS:       agent.GetDNSTable,
 	}
 }

--- a/pkg/istio-agent/agent.go
+++ b/pkg/istio-agent/agent.go
@@ -37,6 +37,7 @@ import (
 	"istio.io/istio/pilot/cmd/pilot-agent/config"
 	"istio.io/istio/pilot/pkg/dns"
 	"istio.io/istio/pilot/pkg/model"
+	nds "istio.io/istio/pilot/pkg/proto"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
 	"istio.io/istio/pkg/bootstrap"
 	"istio.io/istio/pkg/bootstrap/platform"
@@ -435,6 +436,13 @@ func (a *Agent) Check() (err error) {
 		if !a.localDNSServer.IsReady() {
 			return errors.New("istio DNS capture is turned ON and DNS lookup table is not ready yet")
 		}
+	}
+	return nil
+}
+
+func (a *Agent) GetDNSTable() *nds.NameTable {
+	if a.localDNSServer != nil {
+		return a.localDNSServer.NameTable()
 	}
 	return nil
 }


### PR DESCRIPTION
We currently can get it from pilot but its nice to have it on both sides for different cases.

Opening early for feedback, needs some work

Open questions:
* How can we/should we expose this in `istioctl pc dns`?
* Should we expose `nds.NameTable` or internal `LookupTable`? Probably NameTable, but I didn't implement that here