### PR TITLE
avoid recursively dumping sibling test contexts

### DIFF
--- a/pkg/test/framework/runtime.go
+++ b/pkg/test/framework/runtime.go
@@ -41,7 +41,11 @@ func newRuntime(s *resource.Settings, fn resource.EnvironmentFactory, labels lab
 
 // Dump state for all allocated resources.
 func (i *runtime) Dump(ctx resource.Context) {
-	i.context.globalScope.dump(ctx)
+	i.context.globalScope.dump(ctx, true)
+}
+
+func (i *runtime) DumpShallow(ctx resource.Context) {
+	i.context.globalScope.dump(ctx, false)
 }
 
 // suiteContext returns the suiteContext.

--- a/pkg/test/framework/scope.go
+++ b/pkg/test/framework/scope.go
@@ -180,7 +180,7 @@ func (s *scope) skipDumping() {
 	s.skipDump = true
 }
 
-func (s *scope) dump(ctx resource.Context) {
+func (s *scope) dump(ctx resource.Context, recursive bool) {
 	s.mu.Lock()
 	skip := s.skipDump
 	s.mu.Unlock()
@@ -193,8 +193,10 @@ func (s *scope) dump(ctx resource.Context) {
 	}()
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	for _, c := range s.children {
-		c.dump(ctx)
+	if recursive {
+		for _, c := range s.children {
+			c.dump(ctx, recursive)
+		}
 	}
 	wg := sync.WaitGroup{}
 	for _, c := range s.resources {

--- a/pkg/test/framework/testcontext.go
+++ b/pkg/test/framework/testcontext.go
@@ -300,7 +300,9 @@ func (c *testContext) Cleanup(fn func()) {
 func (c *testContext) Done() {
 	if c.Failed() && c.Settings().CIMode {
 		scopes.Framework.Debugf("Begin dumping testContext: %q", c.id)
-		rt.Dump(c)
+		// make sure we dump suite-level resources, but don't dump sibling tests or their children
+		rt.DumpShallow(c)
+		c.scope.dump(c, true)
 		scopes.Framework.Debugf("Completed dumping testContext: %q", c.id)
 	}
 


### PR DESCRIPTION
```
2021-06-02T15:49:50.253240Z	debug	tf	Begin dumping testContext: "TestIngress/http"
2021-06-02T15:49:50.253249Z	debug	tf	Done dumping scope: [TestEmptyCluster] (672ns)
2021-06-02T15:49:50.253254Z	debug	tf	Done dumping scope: [TestFileOnly] (212ns)
2021-06-02T15:49:50.253260Z	debug	tf	Done dumping scope: [TestDirectoryWithoutRecursion] (200ns)
2021-06-02T15:49:50.253264Z	debug	tf	Done dumping scope: [TestDirectoryWithRecursion] (362ns)
...
```

The failed test should trigger a suite level dump, but we don't want it to dump the test contexts within the suite except for its own. 