### PR TITLE
Double the timeout to fix the authz dry-run test flaky

### DIFF
--- a/tests/integration/telemetry/stackdriver/stackdriver_filter_dry_run_test.go
+++ b/tests/integration/telemetry/stackdriver/stackdriver_filter_dry_run_test.go
@@ -67,7 +67,7 @@ func testDryRun(t *testing.T, policies []string, cases []dryRunCase) {
 									return err
 								}
 								return verifyAccessLog(t, cltInstance, tc.wantLog)
-							}, retry.Delay(framework.TelemetryRetryDelay), retry.Timeout(framework.TelemetryRetryTimeout))
+							}, retry.Delay(framework.TelemetryRetryDelay), retry.Timeout(framework.TelemetryRetryTimeout*2))
 							if err != nil {
 								return err
 							}

--- a/tests/integration/telemetry/stackdriver/stackdriver_filter_test.go
+++ b/tests/integration/telemetry/stackdriver/stackdriver_filter_test.go
@@ -167,6 +167,7 @@ meshConfig:
 	cfg.Values["global.proxy.tracer"] = "stackdriver"
 	cfg.Values["pilot.traceSampling"] = "100"
 	cfg.Values["telemetry.v2.accessLogPolicy.enabled"] = "true"
+	cfg.Values["global.proxy.componentLogLevel"] = "rbac:debug,wasm:debug"
 
 	// conditionally use a fake metadata server for testing off of GCP
 	if gceInst != nil {


### PR DESCRIPTION
For https://github.com/istio/istio/issues/33243

The `TestStackdriverAuthzDryRun_Allow` wants the `dry-run-allow` policy but a lot of the collected log entries are caused by the `dry-run-deny` policy that is used in the previous test case `TestStackdriverAuthzDryRun_Deny`. 

This seems indicating there are some slowness and delay in the stackdriver log entry update, This PR tries to fix the flaky by doubling the test timeout so that the stackdriver has more time to update the log entries for each test case.
 


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.