### PR TITLE
Prevent meaningless enqueue before SyncAll

### DIFF
--- a/pilot/pkg/config/kube/crdclient/cache_handler.go
+++ b/pilot/pkg/config/kube/crdclient/cache_handler.go
@@ -88,7 +88,7 @@ func createCacheHandler(cl *Client, schema collection.Schema, i informers.Generi
 	i.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			incrementEvent(kind, "add")
-			if !cl.beginInitialSync.Load() {
+			if !cl.beginSync.Load() {
 				return
 			}
 			cl.queue.Push(func() error {
@@ -98,7 +98,7 @@ func createCacheHandler(cl *Client, schema collection.Schema, i informers.Generi
 		UpdateFunc: func(old, cur interface{}) {
 			if !reflect.DeepEqual(old, cur) {
 				incrementEvent(kind, "update")
-				if !cl.beginInitialSync.Load() {
+				if !cl.beginSync.Load() {
 					return
 				}
 				cl.queue.Push(func() error {
@@ -110,7 +110,7 @@ func createCacheHandler(cl *Client, schema collection.Schema, i informers.Generi
 		},
 		DeleteFunc: func(obj interface{}) {
 			incrementEvent(kind, "delete")
-			if !cl.beginInitialSync.Load() {
+			if !cl.beginSync.Load() {
 				return
 			}
 			cl.queue.Push(func() error {

--- a/pilot/pkg/config/kube/crdclient/client.go
+++ b/pilot/pkg/config/kube/crdclient/client.go
@@ -87,6 +87,8 @@ type Client struct {
 	// The gateway-api client we will use to access objects
 	gatewayAPIClient gatewayapiclient.Interface
 
+	// beginInitialSync is set to true after SyncAll is called.
+	beginInitialSync *atomic.Bool
 	// initialSync is set to true after performing an initial processing of all objects.
 	initialSync *atomic.Bool
 }
@@ -110,6 +112,7 @@ func NewForSchemas(ctx context.Context, client kube.Client, revision, domainSuff
 		kinds:            map[config.GroupVersionKind]*cacheHandler{},
 		istioClient:      client.Istio(),
 		gatewayAPIClient: client.GatewayAPI(),
+		beginInitialSync: atomic.NewBool(false),
 		initialSync:      atomic.NewBool(false),
 	}
 
@@ -204,6 +207,7 @@ func (cl *Client) HasSynced() bool {
 
 // SyncAll syncs all the objects during bootstrap to make the configs updated to caches
 func (cl *Client) SyncAll() {
+	cl.beginInitialSync.Store(true)
 	wg := sync.WaitGroup{}
 	for _, h := range cl.kinds {
 		if len(h.handlers) == 0 {

--- a/pilot/pkg/config/kube/crdclient/client.go
+++ b/pilot/pkg/config/kube/crdclient/client.go
@@ -87,8 +87,8 @@ type Client struct {
 	// The gateway-api client we will use to access objects
 	gatewayAPIClient gatewayapiclient.Interface
 
-	// beginInitialSync is set to true after SyncAll is called.
-	beginInitialSync *atomic.Bool
+	// beginSync is set to true when calling SyncAll, it indicates the controller has began sync resources.
+	beginSync *atomic.Bool
 	// initialSync is set to true after performing an initial processing of all objects.
 	initialSync *atomic.Bool
 }
@@ -112,7 +112,7 @@ func NewForSchemas(ctx context.Context, client kube.Client, revision, domainSuff
 		kinds:            map[config.GroupVersionKind]*cacheHandler{},
 		istioClient:      client.Istio(),
 		gatewayAPIClient: client.GatewayAPI(),
-		beginInitialSync: atomic.NewBool(false),
+		beginSync:        atomic.NewBool(false),
 		initialSync:      atomic.NewBool(false),
 	}
 
@@ -207,7 +207,7 @@ func (cl *Client) HasSynced() bool {
 
 // SyncAll syncs all the objects during bootstrap to make the configs updated to caches
 func (cl *Client) SyncAll() {
-	cl.beginInitialSync.Store(true)
+	cl.beginSync.Store(true)
 	wg := sync.WaitGroup{}
 	for _, h := range cl.kinds {
 		if len(h.handlers) == 0 {

--- a/pilot/pkg/serviceregistry/kube/controller/sync.go
+++ b/pilot/pkg/serviceregistry/kube/controller/sync.go
@@ -1,0 +1,39 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import "go.uber.org/atomic"
+
+var SyncAllKinds = map[string]struct{}{
+	"Services":      {},
+	"Nodes":         {},
+	"Pods":          {},
+	"Endpoints":     {},
+	"EndpointSlice": {},
+}
+
+func isSyncAllKind(kind string) bool {
+	if _, ok := SyncAllKinds[kind]; ok {
+		return true
+	}
+	return false
+}
+
+func shouldEnqueue(kind string, beginSync *atomic.Bool) bool {
+	if isSyncAllKind(kind) && !beginSync.Load() {
+		return false
+	}
+	return true
+}


### PR DESCRIPTION

this is the second half, based on #33247 to simplify review.
Prevent task enqueue before we SyncAll, this is to prevent double handling resources during bootstrap. 

In my test env, the istio ready time before is
```
2021-06-03T12:05:00.134841Z     error   ====waitForCacheSync: committed 28181, expected 24816
2021-06-03T12:05:00.134877Z     info    ads     All caches have been synced up in 31.57432894s, marking server ready
```
with this patch: 
```
2021-06-03T12:13:19.954575Z     error   ====waitForCacheSync: committed 18512, expected 18512
2021-06-03T12:13:19.954612Z     info    ads     All caches have been synced up in 22.187328946s, marking server ready
```



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.