### PR TITLE
ndsz: handle empty cluster id for headless svc

### DIFF
--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -641,10 +641,16 @@ func (node *Proxy) GetNetworkView() map[string]bool {
 // InNetwork returns true if the proxy is on the given network, or if either
 // the proxy's network or the given network is unspecified ("").
 func (node *Proxy) InNetwork(network string) bool {
-	return node == nil || IsSameNetwork(network, node.Metadata.Network)
+	return node == nil || SameOrEmpty(network, node.Metadata.Network)
 }
 
-func IsSameNetwork(a, b string) bool {
+// InCluster returns true if the proxy is in the given cluster, or if either
+// the proxy's cluster id or the given cluster id is unspecified ("").
+func (node *Proxy) InCluster(cluster string) bool {
+	return node == nil || SameOrEmpty(cluster, node.Metadata.ClusterID)
+}
+
+func SameOrEmpty(a, b string) bool {
 	return a == UnnamedNetwork || b == UnnamedNetwork || a == b
 }
 

--- a/pilot/pkg/xds/ep_filters.go
+++ b/pilot/pkg/xds/ep_filters.go
@@ -65,7 +65,7 @@ func (b *EndpointBuilder) EndpointsByNetworkFilter(endpoints []*LocLbEndpointsAn
 			epNetwork := istioMetadata(lbEp, "network")
 			// This is a local endpoint or remote network endpoint
 			// but can be accessed directly from local network.
-			if model.IsSameNetwork(b.network, epNetwork) || len(b.push.NetworkGatewaysByNetwork(epNetwork)) == 0 {
+			if model.SameOrEmpty(b.network, epNetwork) || len(b.push.NetworkGatewaysByNetwork(epNetwork)) == 0 {
 				// Copy on write.
 				clonedLbEp := proto.Clone(lbEp).(*endpoint.LbEndpoint)
 				clonedLbEp.LoadBalancingWeight = &wrappers.UInt32Value{


### PR DESCRIPTION
If for some reason we misconfigure CLUSTER_ID in some environment (e.g. VMs) we may end up excluding ALL headless services/statefulset info. 