### PR TITLE
Consolidate componentLogLevel into one field

### DIFF
--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -174,13 +174,14 @@ func init() {
 	// DEPRECATED. Flags for proxy configuration
 	proxyCmd.PersistentFlags().StringVar(&serviceCluster, "serviceCluster", constants.ServiceClusterName, "Service cluster")
 	// Log levels are provided by the library https://github.com/gabime/spdlog, used by Envoy.
-	proxyCmd.PersistentFlags().StringVar(&proxyLogLevel, "proxyLogLevel", "warning",
-		fmt.Sprintf("The log level used to start the Envoy proxy (choose from {%s, %s, %s, %s, %s, %s, %s})",
+	proxyCmd.PersistentFlags().StringVar(&proxyLogLevel, "proxyLogLevel", "warning,misc:error",
+		fmt.Sprintf("The log level used to start the Envoy proxy (choose from {%s, %s, %s, %s, %s, %s, %s})."+
+			"Level may also include one or more scopes, such as 'info,misc:error,upstream:debug'",
 			"trace", "debug", "info", "warning", "error", "critical", "off"))
 	proxyCmd.PersistentFlags().IntVar(&concurrency, "concurrency", 0, "number of worker threads to run")
 	// See https://www.envoyproxy.io/docs/envoy/latest/operations/cli#cmdoption-component-log-level
-	proxyCmd.PersistentFlags().StringVar(&proxyComponentLogLevel, "proxyComponentLogLevel", "misc:error",
-		"The component log level used to start the Envoy proxy")
+	proxyCmd.PersistentFlags().StringVar(&proxyComponentLogLevel, "proxyComponentLogLevel", "",
+		"The component log level used to start the Envoy proxy. Deprecated, use proxyLogLevel instead")
 	proxyCmd.PersistentFlags().StringVar(&templateFile, "templateFile", "",
 		"Go template bootstrap config")
 	proxyCmd.PersistentFlags().StringVar(&outlierLogPath, "outlierLogPath", "",

--- a/pkg/envoy/proxy_test.go
+++ b/pkg/envoy/proxy_test.go
@@ -73,4 +73,28 @@ func TestEnvoyArgs(t *testing.T) {
 	}
 }
 
-// TestEnvoyRun is no longer used - we are now using v2 bootstrap API.
+func TestSplitComponentLog(t *testing.T) {
+	cases := []struct {
+		input      string
+		log        string
+		components []string
+	}{
+		{"info", "info", nil},
+		// A bit odd, but istio logging behaves this way so might as well be consistent
+		{"info,warn", "warn", nil},
+		{"info,misc:warn", "info", []string{"misc:warn"}},
+		{"misc:warn,info", "info", []string{"misc:warn"}},
+		{"misc:warn,info,upstream:debug", "info", []string{"misc:warn", "upstream:debug"}},
+	}
+	for _, tt := range cases {
+		t.Run(tt.input, func(t *testing.T) {
+			l, c := splitComponentLog(tt.input)
+			if l != tt.log {
+				t.Errorf("expected log level %v, got %v", tt.log, l)
+			}
+			if !reflect.DeepEqual(c, tt.components) {
+				t.Errorf("expected component log level %v, got %v", tt.components, c)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This preserves the existing field, but allows expressing all of the same
options in LogLevel. Then we can just not promote componentLogLevel to
beta
