### PR TITLE
Change variable "retryDelay" into  "RetryDelay" to stay the same in (tests/integration/helm/util.go)

### DIFF
--- a/samples/bookinfo/README.md
+++ b/samples/bookinfo/README.md
@@ -85,7 +85,7 @@ $ kubectl exec -it "$(kubectl get pod -l app=ratings -o jsonpath='{.items[0].met
 <title>Simple Bookstore App</title>
 ```
 
-You can also test it by hitting productpage in the browser.
+You can also test it by hitting producpage in the browser.
 
 ```bash
 http://192.168.39.116:31395/productpage

--- a/samples/bookinfo/README.md
+++ b/samples/bookinfo/README.md
@@ -85,7 +85,7 @@ $ kubectl exec -it "$(kubectl get pod -l app=ratings -o jsonpath='{.items[0].met
 <title>Simple Bookstore App</title>
 ```
 
-You can also test it by hitting producpage in the browser.
+You can also test it by hitting productpage in the browser.
 
 ```bash
 http://192.168.39.116:31395/productpage

--- a/tests/integration/helm/util.go
+++ b/tests/integration/helm/util.go
@@ -50,7 +50,7 @@ const (
 	EgressReleaseName   = EgressGatewayChart
 	ControlChartsDir    = "istio-control"
 	GatewayChartsDir    = "gateways"
-	retryDelay          = 2 * time.Second
+	RetryDelay          = 2 * time.Second
 	RetryTimeOut        = 5 * time.Minute
 	Timeout             = 2 * time.Minute
 )
@@ -169,6 +169,6 @@ func VerifyInstallation(ctx framework.TestContext, cs cluster.Cluster) {
 			return fmt.Errorf("istio egress gateway pod is not ready: %v", err)
 		}
 		return nil
-	}, retry.Timeout(RetryTimeOut), retry.Delay(retryDelay))
+	}, retry.Timeout(RetryTimeOut), retry.Delay(RetryDelay))
 	scopes.Framework.Infof("=== succeeded ===")
 }


### PR DESCRIPTION


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[X ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.

Before:
const (
	IstioNamespace      = "istio-system"
	ReleasePrefix       = "istio-"
	BaseChart           = "base"
	DiscoveryChart      = "istio-discovery"
	IngressGatewayChart = "istio-ingress"
	EgressGatewayChart  = "istio-egress"
	BaseReleaseName     = ReleasePrefix + BaseChart
	IstiodReleaseName   = "istiod"
	IngressReleaseName  = IngressGatewayChart
	EgressReleaseName   = EgressGatewayChart
	ControlChartsDir    = "istio-control"
	GatewayChartsDir    = "gateways"
	retryDelay          = 2 * time.Second
	RetryTimeOut        = 5 * time.Minute
	Timeout             = 2 * time.Minute
)


After:
const (
	IstioNamespace      = "istio-system"
	ReleasePrefix       = "istio-"
	BaseChart           = "base"
	DiscoveryChart      = "istio-discovery"
	IngressGatewayChart = "istio-ingress"
	EgressGatewayChart  = "istio-egress"
	BaseReleaseName     = ReleasePrefix + BaseChart
	IstiodReleaseName   = "istiod"
	IngressReleaseName  = IngressGatewayChart
	EgressReleaseName   = EgressGatewayChart
	ControlChartsDir    = "istio-control"
	GatewayChartsDir    = "gateways"
	RetryDelay          = 2 * time.Second
	RetryTimeOut        = 5 * time.Minute
	Timeout             = 2 * time.Minute
)