### PR TITLE
Remove new validatingwebhookconfiguration for external istiod

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/validatingwebhookconfiguration.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/validatingwebhookconfiguration.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.global.configValidation }}
+{{- if and (not .Values.global.externalIstiod) .Values.global.configValidation }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:


### PR DESCRIPTION

A new revision-aware `ValidatingWebhookConfiguration` resource was recently added to the `istio-control/istio-discovery` charts, at the same time the istiod-remote charts where removed and external control plane changed to use the istio-discovery charts. With both changes merged, validation with an external control plane is currently broken.

```
$ kubectl apply -f samples/helloworld/helloworld-gateway.yaml -n sample --context="${CTX_REMOTE_CLUSTER}"
Error from server (InternalError): error when creating "samples/helloworld/helloworld-gateway.yaml": Internal error occurred: failed calling webhook "validation.istio.io": Post "https://external-f440ce970f6a672b5ae4eddf79834feb-0001.tor01.containers.appdomain.cloud:15017/validate?timeout=10s": x509: certificate signed by unknown authority
```

This PR is fixing external control plane by removing the new VWC in the external-istiod case, making it work like before.

Longer term, we should try to figure out how this VWC, and other revision support, should work with an external control plane (cc @Monkeyanator @howardjohn).


[ ] Configuration Infrastructure
[ ] Docs
[x] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.