### PR TITLE
[tf] Add validation to IstioVersion when parsing revisions

### DIFF
--- a/pkg/test/framework/resource/version_test.go
+++ b/pkg/test/framework/resource/version_test.go
@@ -21,49 +21,63 @@ import (
 
 func TestCompareIstioVersion(t *testing.T) {
 	tcs := []struct {
-		a, b   IstioVersion
+		a, b   string
 		result int
 	}{
 		{
-			IstioVersion("1.4"),
-			IstioVersion("1.5"),
+			"1.4",
+			"1.5",
 			-1,
 		},
 		{
-			IstioVersion("1.9.0"),
-			IstioVersion("1.10"),
+			"1.9.0",
+			"1.10",
 			-1,
 		},
 		{
-			IstioVersion("1.8.0"),
-			IstioVersion("1.8.1"),
+			"1.8.0",
+			"1.8.1",
 			-1,
 		},
 		{
-			IstioVersion("1.9.1"),
-			IstioVersion("1.9.1"),
+			"1.9.1",
+			"1.9.1",
 			0,
 		},
 		{
-			IstioVersion("1.12"),
-			IstioVersion("1.3"),
+			"1.12",
+			"1.3",
 			1,
 		},
 		{
-			IstioVersion(""),
-			IstioVersion(""),
+			"",
+			"",
 			0,
 		},
 		{
-			IstioVersion(""),
-			IstioVersion("1.9"),
+			"",
+			"1.9",
+			1,
+		},
+		{
+			// Raw "1.9" refers to latest patch version and should be considered greater than "1.9.0"
+			"1.9",
+			"1.9.0",
 			1,
 		},
 	}
 
 	for _, tc := range tcs {
 		t.Run(fmt.Sprintf("compare version %s->%s", tc.a, tc.b), func(t *testing.T) {
-			r := tc.a.Compare(tc.b)
+			a, err := NewIstioVersion(tc.a)
+			if err != nil {
+				t.Errorf("failed to parse %s as version: %v", tc.a, err)
+			}
+			b, err := NewIstioVersion(tc.b)
+			if err != nil {
+				t.Errorf("failed to parse %s as version: %v", tc.b, err)
+			}
+			r := a.Compare(b)
 			if r != tc.result {
 				t.Errorf("expected %d, got %d", tc.result, r)
 			}

--- a/tests/integration/pilot/common/traffic.go
+++ b/tests/integration/pilot/common/traffic.go
@@ -135,8 +135,8 @@ func (c TrafficTestCase) RunForApps(t framework.TestContext, apps echo.Instances
 				t.SkipNow()
 			}
 			if c.minIstioVersion != "" {
-				if resource.IstioVersion(c.minIstioVersion).
-					Compare(t.Settings().Revisions.Minimum()) > 0 {
+				skipMV := resource.IstioVersion(c.minIstioVersion).Compare(t.Settings().Revisions.Minimum()) > 0
+				if skipMV {
 					t.SkipNow()
 				}
 			}
@@ -195,8 +195,8 @@ func (c TrafficTestCase) Run(t framework.TestContext, namespace string) {
 			t.SkipNow()
 		}
 		if c.minIstioVersion != "" {
-			if resource.IstioVersion(c.minIstioVersion).
-				Compare(t.Settings().Revisions.Minimum()) > 0 {
+			skipMV := resource.IstioVersion(c.minIstioVersion).Compare(t.Settings().Revisions.Minimum()) > 0
+			if skipMV {
 				t.SkipNow()
 			}
 		}


### PR DESCRIPTION
Fails out when passing invalid version in `--istio.test.revisions`.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
