### PR TITLE
do not build auto MTLS settings for SIMPLE

### DIFF
--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -606,6 +606,10 @@ type NodeMetadata struct {
 	Raw map[string]interface{} `json:"-"`
 }
 
+func (m *NodeMetadata) HasConfiguredCerts() bool {
+	return m.TLSClientRootCert != "" || m.TLSServerRootCert != ""
+}
+
 // ProxyConfigOrDefault is a helper function to get the ProxyConfig from metadata, or fallback to a default
 // This is useful as the logic should check for proxy config from proxy first and then defer to mesh wide defaults
 // if not present.

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -606,10 +606,6 @@ type NodeMetadata struct {
 	Raw map[string]interface{} `json:"-"`
 }
 
-func (m *NodeMetadata) HasConfiguredCerts() bool {
-	return m.TLSClientRootCert != "" || m.TLSServerRootCert != ""
-}
-
 // ProxyConfigOrDefault is a helper function to get the ProxyConfig from metadata, or fallback to a default
 // This is useful as the logic should check for proxy config from proxy first and then defer to mesh wide defaults
 // if not present.

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -927,6 +927,30 @@ func TestBuildAutoMtlsSettings(t *testing.T) {
 			},
 			autoDetected,
 		},
+		{
+			"Simple TLS",
+			&networking.ClientTLSSettings{
+				Mode:              networking.ClientTLSSettings_SIMPLE,
+				PrivateKey:        "/custom/key.pem",
+				ClientCertificate: "/custom/chain.pem",
+				CaCertificates:    "/custom/root.pem",
+			},
+			[]string{"custom.foo.com"},
+			"custom.foo.com",
+			&model.Proxy{Metadata: &model.NodeMetadata{
+				TLSClientCertChain: "/custom/meta/chain.pem",
+				TLSClientKey:       "/custom/meta/key.pem",
+				TLSClientRootCert:  "/custom/meta/root.pem",
+			}},
+			false, false, model.MTLSUnknown,
+			&networking.ClientTLSSettings{
+				Mode:              networking.ClientTLSSettings_SIMPLE,
+				PrivateKey:        "/custom/key.pem",
+				ClientCertificate: "/custom/chain.pem",
+				CaCertificates:    "/custom/root.pem",
+			},
+			userSupplied,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
For user specified SIMPLE and DISABLE TLS mode we should not try to build mutual tls settings.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
