### PR TITLE
Implement new SyncQueue

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -859,7 +859,7 @@ func (s *Server) initRegistryEventHandlers() {
 	s.ServiceController().AppendServiceHandler(serviceHandler)
 
 	if s.configController != nil {
-		configHandler := func(_ config.Config, curr config.Config, event model.Event) {
+		configHandler := func(old config.Config, curr config.Config, event model.Event) {
 			pushReq := &model.PushRequest{
 				Full: true,
 				ConfigsUpdated: map[model.ConfigKey]struct{}{{

--- a/pilot/pkg/config/kube/crdclient/cache_handler.go
+++ b/pilot/pkg/config/kube/crdclient/cache_handler.go
@@ -44,10 +44,6 @@ type cacheHandler struct {
 }
 
 func (h *cacheHandler) onEvent(old interface{}, curr interface{}, event model.Event) error {
-	if err := h.client.checkReadyForEvents(curr); err != nil {
-		return err
-	}
-
 	currItem, ok := curr.(runtime.Object)
 	if !ok {
 		scope.Warnf("New Object can not be converted to runtime Object %v, is type %T", curr, curr)

--- a/pilot/pkg/config/kube/ingress/controller.go
+++ b/pilot/pkg/config/kube/ingress/controller.go
@@ -301,11 +301,14 @@ func (c *controller) HasSynced() bool {
 }
 
 func (c *controller) Run(stop <-chan struct{}) {
-	if !cache.WaitForCacheSync(stop, c.HasSynced) {
-		log.Error("Failed to sync controller cache")
-		return
-	}
-	c.queue.Run(stop)
+	go func() {
+		if !cache.WaitForCacheSync(stop, c.HasSynced) {
+			log.Error("Failed to sync controller cache")
+			return
+		}
+		c.queue.Run(stop)
+	}()
+	<-stop
 }
 
 func (c *controller) Schemas() collection.Schemas {

--- a/pilot/pkg/config/kube/ingressv1/controller.go
+++ b/pilot/pkg/config/kube/ingressv1/controller.go
@@ -256,11 +256,13 @@ func (c *controller) HasSynced() bool {
 }
 
 func (c *controller) Run(stop <-chan struct{}) {
-	if !cache.WaitForCacheSync(stop, c.HasSynced) {
-		log.Error("Failed to sync controller cache")
-		return
-	}
-	c.queue.Run(stop)
+	go func() {
+		if !cache.WaitForCacheSync(stop, c.HasSynced) {
+			log.Error("Failed to sync controller cache")
+			return
+		}
+		c.queue.Run(stop)
+	}()
 	<-stop
 }
 

--- a/pkg/queue/sync.go
+++ b/pkg/queue/sync.go
@@ -1,0 +1,64 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package queue
+
+import "go.uber.org/atomic"
+
+// SyncInstance is a specialized queue.Instance that tracks whether the queue has synced yet
+type SyncInstance interface {
+	Instance
+	// MarkSynced indicates that the queue should be synced. The queue will not be marked synced immediately.
+	// Instead, it will enqueue a task to mark it as synced. This ensures that we complete all pending tasks prior
+	// to marking ourselves as synced.
+	// A boolean indicating whether we have synced is returned as well.
+	MarkSynced() bool
+}
+
+type syncQueue struct {
+	Instance
+	syncState *atomic.Uint32
+}
+
+func (s *syncQueue) MarkSynced() bool {
+	state := s.syncState.Load()
+	switch state {
+	case Synced:
+		return true
+	case Unsynced:
+		s.syncState.Store(Enqueued)
+		s.Push(func() error {
+			s.syncState.Store(Synced)
+			return nil
+		})
+		return false
+	default:
+		return false
+	}
+}
+
+type SyncState = uint32
+
+const (
+	Unsynced SyncState = 0
+	Enqueued SyncState = 1
+	Synced   SyncState = 2
+)
+
+func NewSync(q Instance) SyncInstance {
+	return &syncQueue{
+		Instance:  q,
+		syncState: atomic.NewUint32(Unsynced),
+	}
+}


### PR DESCRIPTION
Investigate alternative to https://github.com/istio/istio/pull/33257

Implement new SyncQueue
This is a wrapper around Queue that handles logic to ensure
syncronization. When we have synced, we trigger MarkSynced which puts a
new Task on the queue to mark the queue as fully synced.
We should move all controllers over to this probably, just did two to
keep it simple
