### PR TITLE
add documentation url to analysis messages

### DIFF
--- a/galley/pkg/config/analysis/msg/generate.main.go
+++ b/galley/pkg/config/analysis/msg/generate.main.go
@@ -176,6 +176,7 @@ type message struct {
 	Level       string `json:"level"`
 	Description string `json:"description"`
 	Template    string `json:"template"`
+	Url         string `json:"url"`
 	Args        []arg  `json:"args"`
 }
 

--- a/galley/pkg/config/analysis/msg/messages.yaml
+++ b/galley/pkg/config/analysis/msg/messages.yaml
@@ -6,6 +6,7 @@ messages:
     level: Error
     description: "There was an internal error in the toolchain. This is almost always a bug in the implementation."
     template: "Internal error: %v"
+    url: "https://istio.io/latest/docs/reference/config/analysis/ist0001/"
     args:
       - name: detail
         type: string
@@ -15,6 +16,7 @@ messages:
     level: Warning
     description: "A feature that the configuration is depending on is now deprecated."
     template: "Deprecated: %s"
+    url: "https://istio.io/latest/docs/reference/config/analysis/ist0002/"
     args:
       - name: detail
         type: string
@@ -24,6 +26,7 @@ messages:
     level: Error
     description: "A resource being referenced does not exist."
     template: "Referenced %s not found: %q"
+    url: "https://istio.io/latest/docs/reference/config/analysis/ist0101/"
     args:
       - name: reftype
         type: string
@@ -35,6 +38,7 @@ messages:
     level: Info
     description: "A namespace is not enabled for Istio injection."
     template: "The namespace is not enabled for Istio injection. Run 'kubectl label namespace %s istio-injection=enabled' to enable it, or 'kubectl label namespace %s istio-injection=disabled' to explicitly mark it as not needing injection."
+    url: "https://istio.io/latest/docs/reference/config/analysis/ist0102/"
     args:
       - name: namespace
         type: string
@@ -46,6 +50,7 @@ messages:
     level: Warning
     description: "A pod is missing the Istio proxy."
     template: "The pod is missing the Istio proxy. This can often be resolved by restarting or redeploying the workload."
+    url: "https://istio.io/latest/docs/reference/config/analysis/ist0103/"
     args:
 
   - name: "GatewayPortNotOnWorkload"
@@ -53,6 +58,7 @@ messages:
     level: Warning
     description: "Unhandled gateway port"
     template: "The gateway refers to a port that is not exposed on the workload (pod selector %s; port %d)"
+    url: "https://istio.io/latest/docs/reference/config/analysis/ist0104/"
     args:
       - name: selector
         type: string
@@ -64,6 +70,7 @@ messages:
     level: Warning
     description: "The image of the Istio proxy running on the pod does not match the image defined in the injection configuration."
     template: "The image of the Istio proxy running on the pod does not match the image defined in the injection configuration (pod image: %s; injection configuration image: %s). This often happens after upgrading the Istio control-plane and can be fixed by redeploying the pod."
+    url: "https://istio.io/latest/docs/reference/config/analysis/ist0105/"
     args:
       - name: proxyImage
         type: string
@@ -75,6 +82,7 @@ messages:
     level: Error
     description: "The resource has a schema validation error."
     template: "Schema validation error: %v"
+    url: "https://istio.io/latest/docs/reference/config/analysis/ist0106/"
     args:
       - name: err
         type: error
@@ -84,6 +92,7 @@ messages:
     level: Warning
     description: "An Istio annotation is applied to the wrong kind of resource."
     template: "Misplaced annotation: %s can only be applied to %s"
+    url: "https://istio.io/latest/docs/reference/config/analysis/ist0107/"
     args:
       - name: annotation
         type: string
@@ -95,6 +104,7 @@ messages:
     level: Warning
     description: "An Istio annotation is not recognized for any kind of resource"
     template: "Unknown annotation: %s"
+    url: "https://istio.io/latest/docs/reference/config/analysis/ist0108/"
     args:
       - name: annotation
         type: string
@@ -104,6 +114,7 @@ messages:
     level: Error
     description: "Conflicting hosts on VirtualServices associated with mesh gateway"
     template: "The VirtualServices %s associated with mesh gateway define the same host %s which can lead to undefined behavior. This can be fixed by merging the conflicting VirtualServices into a single resource."
+    url: "https://istio.io/latest/docs/reference/config/analysis/ist0109/"
     args:
       - name: virtualServices
         type: string
@@ -115,6 +126,7 @@ messages:
     level: Error
     description: "A Sidecar resource selects the same workloads as another Sidecar resource"
     template: "The Sidecars %v in namespace %q select the same workload pod %q, which can lead to undefined behavior."
+    url: "https://istio.io/latest/docs/reference/config/analysis/ist0110/"
     args:
       - name: conflictingSidecars
         type: "[]string"
@@ -128,6 +140,7 @@ messages:
     level: Error
     description: "More than one sidecar resource in a namespace has no workload selector"
     template: "The Sidecars %v in namespace %q have no workload selector, which can lead to undefined behavior."
+    url: "https://istio.io/latest/docs/reference/config/analysis/ist0111/"
     args:
       - name: conflictingSidecars
         type: "[]string"
@@ -139,6 +152,7 @@ messages:
     level: Error
     description: "A VirtualService routes to a service with more than one port exposed, but does not specify which to use."
     template: "This VirtualService routes to a service %q that exposes multiple ports %v. Specifying a port in the destination is required to disambiguate."
+    url: "https://istio.io/latest/docs/reference/config/analysis/ist0112/"
     args:
       - name: destHost
         type: string
@@ -150,6 +164,7 @@ messages:
     level: Error
     description: "A DestinationRule and Policy are in conflict with regards to mTLS."
     template: "A DestinationRule and Policy are in conflict with regards to mTLS for host %s. The DestinationRule %q specifies that mTLS must be %t but the Policy object %q specifies %s."
+    url: "https://istio.io/latest/docs/reference/config/analysis/ist0113/"
     args:
       - name: host
         type: string
@@ -170,6 +185,7 @@ messages:
     level: Warning
     description: "The resulting pods of a service mesh deployment can't be associated with multiple services using the same port but different protocols."
     template: "This deployment %s is associated with multiple services using port %d but different protocols: %v"
+    url: "https://istio.io/latest/docs/reference/config/analysis/ist0116/"
     args:
       - name: deployment
         type: string
@@ -183,12 +199,14 @@ messages:
     level: Warning
     description: "The resulting pods of a service mesh deployment must be associated with at least one service."
     template: "No service associated with this deployment. Service mesh deployments must be associated with a service."
+    url: "https://istio.io/latest/docs/reference/config/analysis/ist0117/"
 
   - name: "PortNameIsNotUnderNamingConvention"
     code: IST0118
     level: Info
     description: "Port name is not under naming convention. Protocol detection is applied to the port."
     template: "Port name %s (port: %d, targetPort: %s) doesn't follow the naming convention of Istio port."
+    url: "https://istio.io/latest/docs/reference/config/analysis/ist0118/"
     args:
       - name: portName
         type: string
@@ -202,6 +220,7 @@ messages:
     level: Warning
     description: "Authentication policy with JWT targets Service with invalid port specification."
     template: "Authentication policy with JWT targets Service with invalid port specification (port: %d, name: %s, protocol: %s, targetPort: %s)."
+    url: "https://istio.io/latest/docs/reference/config/analysis/ist0119/"
     args:
       - name: port
         type: int
@@ -220,6 +239,7 @@ messages:
     level: Warning
     description: "Invalid Regex"
     template: "Field %q regular expression invalid: %q (%s)"
+    url: "https://istio.io/latest/docs/reference/config/analysis/ist0122/"
     args:
       - name: where
         type: string
@@ -233,6 +253,7 @@ messages:
     level: Warning
     description: "A namespace has both new and legacy injection labels"
     template: "The namespace has both new and legacy injection labels. Run 'kubectl label namespace %s istio.io/rev-' or 'kubectl label namespace %s istio-injection-'"
+    url: "https://istio.io/latest/docs/reference/config/analysis/ist0123/"
     args:
       - name: namespace
         type: string
@@ -244,6 +265,7 @@ messages:
     level: Warning
     description: "An Istio annotation that is not valid"
     template: "Invalid annotation %s: %s"
+    url: "https://istio.io/latest/docs/reference/config/analysis/ist0125/"
     args:
       - name: annotation
         type: string
@@ -266,6 +288,7 @@ messages:
     level: Warning
     description: "There aren't workloads matching the resource labels"
     template: "No matching workloads for this resource with the following labels: %s"
+    url: "https://istio.io/latest/docs/reference/config/analysis/ist0127/"
     args:
       - name: labels
         type: string
@@ -275,6 +298,7 @@ messages:
     level: Error
     description: "No caCertificates are set in DestinationRule, this results in no verification of presented server certificate."
     template: "DestinationRule %s in namespace %s has TLS mode set to %s but no caCertificates are set to validate server identity for host: %s"
+    url: "https://istio.io/latest/docs/reference/config/analysis/ist0128/"
     args:
       - name: destinationrule
         type: string
@@ -290,6 +314,7 @@ messages:
     level: Warning
     description: "No caCertificates are set in DestinationRule, this results in no verification of presented server certificate for traffic to a given port."
     template: "DestinationRule %s in namespace %s has TLS mode set to %s but no caCertificates are set to validate server identity for host: %s at port %s"
+    url: "https://istio.io/latest/docs/reference/config/analysis/ist0129/"
     args:
       - name: destinationrule
         type: string
@@ -307,6 +332,7 @@ messages:
     level: Warning
     description: "A VirtualService rule will never be used because a previous rule uses the same match."
     template: "VirtualService rule %v not used (%s)."
+    url: "https://istio.io/latest/docs/reference/config/analysis/ist0130/"
     args:
       - name: ruleno
         type: string
@@ -318,6 +344,7 @@ messages:
     level: Info
     description: "A VirtualService rule match duplicates a match in a previous rule."
     template: "VirtualService rule %v match %v is not used (duplicates a match in rule %v)."
+    url: "https://istio.io/latest/docs/reference/config/analysis/ist0131/"
     args:
       - name: ruleno
         type: string
@@ -331,6 +358,7 @@ messages:
     level: Warning
     description: "Host defined in VirtualService not found in Gateway."
     template: "one or more host %v defined in VirtualService %s not found in Gateway %s."
+    url: "https://istio.io/latest/docs/reference/config/analysis/ist0132/"
     args:
       - name: host
         type: "[]string"
@@ -353,12 +381,14 @@ messages:
     level: Warning
     description: "Virtual IP addresses are required for ports serving TCP (or unset) protocol"
     template: "ServiceEntry addresses are required for this protocol."
+    url: "https://istio.io/latest/docs/reference/config/analysis/ist0134/"
 
   - name: "DeprecatedAnnotation"
     code: IST0135
     level: Info
     description: "A resource is using a deprecated Istio annotation."
     template: "Annotation %q has been deprecated%s and may not work in future Istio versions."
+    url: "https://istio.io/latest/docs/reference/config/analysis/ist0135/"
     args:
       - name: annotation
         type: string
@@ -370,6 +400,7 @@ messages:
     level: Info
     description: "An Istio annotation may not be suitable for production."
     template: "Annotation %q is part of an alpha-phase feature and may be incompletely supported."
+    url: "https://istio.io/latest/docs/reference/config/analysis/ist0136/"
     args:
       - name: annotation
         type: string
@@ -379,6 +410,7 @@ messages:
     level: Warning
     description: "Two services selecting the same workload with the same targetPort MUST refer to the same port."
     template: "This deployment %s is associated with multiple services %v using targetPort %q but different ports: %v."
+    url: "https://istio.io/latest/docs/reference/config/analysis/ist0137/"
     args:
       - name: deployment
         type: string
@@ -446,6 +478,7 @@ messages:
     level: Error
     description: "A port exposed in a Service is bound to a localhost address"
     template: "Port %v is exposed in a Service but listens on localhost. It will not be exposed to other pods."
+    url: "https://istio.io/latest/docs/reference/config/analysis/ist0143/"
     args:
       - name: port
         type: string

--- a/galley/pkg/config/analysis/msg/messages.yaml
+++ b/galley/pkg/config/analysis/msg/messages.yaml
@@ -488,6 +488,7 @@ messages:
     level: Warning
     description: "Application pods should not run as user ID (UID) 1337"
     template: "User ID (UID) 1337 is reserved for the sidecar proxy."
+    url: "https://istio.io/latest/docs/reference/config/analysis/ist0144/"
 
   - name: "ConflictingGateways"
     code: IST0145


### PR DESCRIPTION
This PR is to add the documentation url from istio.io to messages.yaml. The next step I'll do is to convert the current message structures using Analysis message api.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[x] User Experience
[x] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
