### PR TITLE
envoy filter metrics does not have name populated correctly

### DIFF
--- a/pilot/pkg/model/envoyfilter.go
+++ b/pilot/pkg/model/envoyfilter.go
@@ -85,6 +85,8 @@ func convertToEnvoyFilterWrapper(local *config.Config) *EnvoyFilterWrapper {
 			continue
 		}
 		cpw := &EnvoyFilterConfigPatchWrapper{
+			Name:      local.Name,
+			Namespace: local.Namespace,
 			ApplyTo:   cp.ApplyTo,
 			Match:     cp.Match,
 			Operation: cp.Patch.Operation,

--- a/pilot/pkg/model/envoyfilter.go
+++ b/pilot/pkg/model/envoyfilter.go
@@ -46,6 +46,8 @@ type EnvoyFilterConfigPatchWrapper struct {
 	// regex match, but as an optimization we can reduce this to a prefix match for common cases.
 	// If this is set, ProxyVersionRegex is ignored.
 	ProxyPrefixMatch string
+	Name             string
+	Namespace        string
 }
 
 // wellKnownVersions defines a mapping of well known regex matches to prefix matches
@@ -165,4 +167,11 @@ func (efw *EnvoyFilterWrapper) Key() string {
 		return ""
 	}
 	return efw.Namespace + "/" + efw.Name
+}
+
+func (cpw *EnvoyFilterConfigPatchWrapper) Key() string {
+	if cpw == nil {
+		return ""
+	}
+	return cpw.Namespace + "/" + cpw.Name
 }

--- a/pilot/pkg/model/envoyfilter_test.go
+++ b/pilot/pkg/model/envoyfilter_test.go
@@ -114,3 +114,22 @@ func TestEnvoyFilterMatch(t *testing.T) {
 		}
 	}
 }
+
+func TestConvertEnvoyFilter(t *testing.T) {
+	cfilter := convertToEnvoyFilterWrapper(&config.Config{
+		Meta: config.Meta{Name: "test", Namespace: "testns"},
+		Spec: &networking.EnvoyFilter{
+			ConfigPatches: []*networking.EnvoyFilter_EnvoyConfigObjectPatch{
+				{
+					Patch: &networking.EnvoyFilter_Patch{},
+					Match: &networking.EnvoyFilter_EnvoyConfigObjectMatch{
+						Proxy: &networking.EnvoyFilter_ProxyMatch{ProxyVersion: `foobar`},
+					},
+				},
+			},
+		},
+	})
+	if cfilter.Name != "test" && cfilter.Namespace != "testns" {
+		t.Errorf("expected name %s got %s and namespace %s got %s", "test", cfilter.Name, "testns", cfilter.Namespace)
+	}
+}

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -1674,6 +1674,8 @@ func (ps *PushContext) EnvoyFilters(proxy *Proxy) *EnvoyFilterWrapper {
 				}
 				for _, cp := range cps {
 					if proxyMatch(proxy, cp) {
+						cp.Name = efw.Name
+						cp.Namespace = efw.Namespace
 						out.Patches[applyTo] = append(out.Patches[applyTo], cp)
 					}
 				}

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -1674,8 +1674,6 @@ func (ps *PushContext) EnvoyFilters(proxy *Proxy) *EnvoyFilterWrapper {
 				}
 				for _, cp := range cps {
 					if proxyMatch(proxy, cp) {
-						cp.Name = efw.Name
-						cp.Namespace = efw.Namespace
 						out.Patches[applyTo] = append(out.Patches[applyTo], cp)
 					}
 				}

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -83,7 +83,6 @@ func (configgen *ConfigGeneratorImpl) BuildClusters(proxy *model.Proxy, push *mo
 		// Add a blackhole and passthrough cluster for catching traffic to unresolved routes
 		clusters = outboundPatcher.conditionallyAppend(clusters, nil, cb.buildBlackHoleCluster(), cb.buildDefaultPassthroughCluster())
 		clusters = append(clusters, outboundPatcher.insertedClusters()...)
-		outboundPatcher.incrementFilterMetrics()
 
 		// Setup inbound clusters
 		inboundPatcher := clusterPatcher{efw: envoyFilterPatches, pctx: networking.EnvoyFilter_SIDECAR_INBOUND}
@@ -91,7 +90,6 @@ func (configgen *ConfigGeneratorImpl) BuildClusters(proxy *model.Proxy, push *mo
 		// Pass through clusters for inbound traffic. These cluster bind loopback-ish src address to access node local service.
 		clusters = inboundPatcher.conditionallyAppend(clusters, nil, cb.buildInboundPassthroughClusters()...)
 		clusters = append(clusters, inboundPatcher.insertedClusters()...)
-		inboundPatcher.incrementFilterMetrics()
 	default: // Gateways
 		patcher := clusterPatcher{efw: envoyFilterPatches, pctx: networking.EnvoyFilter_GATEWAY}
 		clusters = append(clusters, configgen.buildOutboundClusters(cb, patcher)...)
@@ -101,7 +99,6 @@ func (configgen *ConfigGeneratorImpl) BuildClusters(proxy *model.Proxy, push *mo
 			clusters = append(clusters, configgen.buildOutboundSniDnatClusters(proxy, push, patcher)...)
 		}
 		clusters = append(clusters, patcher.insertedClusters()...)
-		patcher.incrementFilterMetrics()
 	}
 
 	return cb.normalizeClusters(clusters)
@@ -147,9 +144,8 @@ func (configgen *ConfigGeneratorImpl) buildOutboundClusters(cb *ClusterBuilder, 
 }
 
 type clusterPatcher struct {
-	efw            *model.EnvoyFilterWrapper
-	pctx           networking.EnvoyFilter_PatchContext
-	patchesApplied int
+	efw  *model.EnvoyFilterWrapper
+	pctx networking.EnvoyFilter_PatchContext
 }
 
 func (p clusterPatcher) conditionallyAppend(l []*cluster.Cluster, hosts []host.Name, clusters ...*cluster.Cluster) []*cluster.Cluster {
@@ -157,16 +153,10 @@ func (p clusterPatcher) conditionallyAppend(l []*cluster.Cluster, hosts []host.N
 		return append(l, clusters...)
 	}
 	var pc *cluster.Cluster
-	applied := false
 	for _, c := range clusters {
 		if envoyfilter.ShouldKeepCluster(p.pctx, p.efw, c, hosts) {
-			pc, applied = envoyfilter.ApplyClusterMerge(p.pctx, p.efw, c, hosts)
+			pc = envoyfilter.ApplyClusterMerge(p.pctx, p.efw, c, hosts)
 			l = append(l, pc)
-		} else {
-			applied = true // Remove patch is applied.
-		}
-		if applied {
-			p.patchesApplied++
 		}
 	}
 	return l
@@ -174,16 +164,6 @@ func (p clusterPatcher) conditionallyAppend(l []*cluster.Cluster, hosts []host.N
 
 func (p clusterPatcher) insertedClusters() []*cluster.Cluster {
 	return envoyfilter.InsertedClusters(p.pctx, p.efw)
-}
-
-func (p clusterPatcher) incrementFilterMetrics() {
-	if p.efw != nil {
-		if len(p.efw.Patches[networking.EnvoyFilter_CLUSTER]) != p.patchesApplied {
-			envoyfilter.RecordEnvoyFilterMetric(p.efw.Key(), envoyfilter.Cluster, false,
-				float64(len(p.efw.Patches[networking.EnvoyFilter_CLUSTER])-p.patchesApplied))
-		}
-		envoyfilter.RecordEnvoyFilterMetric(p.efw.Key(), envoyfilter.Cluster, true, float64(p.patchesApplied))
-	}
 }
 
 func (p clusterPatcher) hasPatches() bool {

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/cluster_patch_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/cluster_patch_test.go
@@ -480,7 +480,7 @@ func TestClusterPatching(t *testing.T) {
 			output := []*cluster.Cluster{}
 			for _, c := range tc.input {
 				if ShouldKeepCluster(tc.patchContext, efw, c, []host.Name{host.Name(tc.host)}) {
-					pc, _ := ApplyClusterMerge(tc.patchContext, efw, c, []host.Name{host.Name(tc.host)})
+					pc := ApplyClusterMerge(tc.patchContext, efw, c, []host.Name{host.Name(tc.host)})
 					output = append(output, pc)
 				}
 			}


### PR DESCRIPTION
The name tag of envoy filter metrics is not populated correctly as we merge all the matching filters in to a single EnvoyFilterWrapper and that does not have name/namespace populated. This PR fixes it by populating the patch with the name/namespace and uses it to increment metrics.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
