### PR TITLE
Fixes for validation webhook controller

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/validatingwebhookconfiguration.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/validatingwebhookconfiguration.yaml
@@ -2,7 +2,7 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: istio{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}-{{ .Values.global.istioNamespace }}
+  name: istio-validator{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}-{{ .Values.global.istioNamespace }}
   labels:
     app: istiod
     release: {{ .Release.Name }}

--- a/manifests/charts/istio-control/istio-discovery/templates/validatingwebhookconfiguration.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/validatingwebhookconfiguration.yaml
@@ -2,11 +2,7 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-{{- if eq .Release.Namespace "istio-system"}}
-  name: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-{{- else }}
-  name: istio{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}-{{ .Release.Namespace }}
-{{- end }}
+  name: istio{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}-{{ .Values.global.istioNamespace }}
   labels:
     app: istiod
     release: {{ .Release.Name }}

--- a/pilot/pkg/bootstrap/validation.go
+++ b/pilot/pkg/bootstrap/validation.go
@@ -15,6 +15,7 @@
 package bootstrap
 
 import (
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/webhooks/validation/controller"
 	"istio.io/istio/pkg/webhooks/validation/server"
@@ -43,7 +44,7 @@ func (s *Server) initConfigValidation(args *PilotArgs) error {
 		return nil
 	})
 
-	if s.kubeClient != nil {
+	if features.ValidationWebhookConfigName != "" && s.kubeClient != nil {
 		s.addStartFunc(func(stop <-chan struct{}) error {
 			log.Infof("Starting validation controller")
 			go controller.NewValidatingWebhookController(

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -322,6 +322,9 @@ var (
 	InjectionWebhookConfigName = env.RegisterStringVar("INJECTION_WEBHOOK_CONFIG_NAME", "istio-sidecar-injector",
 		"Name of the mutatingwebhookconfiguration to patch, if istioctl is not used.").Get()
 
+	ValidationWebhookConfigName = env.RegisterStringVar("VALIDATION_WEBHOOK_CONFIG_NAME", "istio-istio-system",
+		"Name of the validatingwebhookconfiguration to patch. Empty will skip using cluster admin to patch.").Get()
+
 	SpiffeBundleEndpoints = env.RegisterStringVar("SPIFFE_BUNDLE_ENDPOINTS", "",
 		"The SPIFFE bundle trust domain to endpoint mappings. Istiod retrieves the root certificate from each SPIFFE "+
 			"bundle endpoint and uses it to verify client certifiates from that trust domain. The endpoint must be "+

--- a/pkg/webhooks/validation/controller/controller.go
+++ b/pkg/webhooks/validation/controller/controller.go
@@ -444,7 +444,7 @@ func (c *Controller) updateValidatingWebhookConfiguration(webhookName string, ca
 }
 
 func (o *Options) validatingWebhookName() string {
-	name := "istio"
+	name := "istio-validator"
 	if o.Revision != "default" {
 		name = fmt.Sprintf("%s-%s", name, o.Revision)
 	}

--- a/pkg/webhooks/validation/controller/controller.go
+++ b/pkg/webhooks/validation/controller/controller.go
@@ -444,13 +444,11 @@ func (c *Controller) updateValidatingWebhookConfiguration(webhookName string, ca
 }
 
 func (o *Options) validatingWebhookName() string {
-	name := "istiod"
+	name := "istio"
 	if o.Revision != "default" {
 		name = fmt.Sprintf("%s-%s", name, o.Revision)
 	}
-	if o.WatchedNamespace != "istio-system" {
-		name = fmt.Sprintf("%s-%s", name, o.WatchedNamespace)
-	}
+	name = fmt.Sprintf("%s-%s", name, o.WatchedNamespace)
 	return name
 }
 

--- a/pkg/webhooks/validation/controller/controller_test.go
+++ b/pkg/webhooks/validation/controller/controller_test.go
@@ -164,7 +164,7 @@ const (
 	revision  = "revision"
 )
 
-var webhookName = fmt.Sprintf("%s-%s", istiod, namespace)
+var webhookName = fmt.Sprintf("istio-validator-revision-%s", namespace)
 
 func createTestController(t *testing.T) *fakeController {
 	fakeClient := kube.NewFakeClient()

--- a/pkg/webhooks/validation/controller/controller_test.go
+++ b/pkg/webhooks/validation/controller/controller_test.go
@@ -49,7 +49,7 @@ var (
 			Kind:       "ValidatingWebhookConfiguration",
 		},
 		ObjectMeta: kubeApiMeta.ObjectMeta{
-			Name: istiod,
+			Name: webhookName,
 			Labels: map[string]string{
 				label.IoIstioRev.Name: revision,
 			},
@@ -159,10 +159,12 @@ type fakeController struct {
 }
 
 const (
+	istiod    = "istio-revision"
 	namespace = "istio-system"
-	istiod    = "istiod-revision"
 	revision  = "revision"
 )
+
+var webhookName = fmt.Sprintf("%s-%s", istiod, namespace)
 
 func createTestController(t *testing.T) *fakeController {
 	fakeClient := kube.NewFakeClient()
@@ -217,7 +219,7 @@ func TestGreenfield(t *testing.T) {
 	_ = c.configStore.Add(unpatchedWebhookConfig)
 
 	reconcileHelper(t, c)
-	g.Expect(c.ValidatingWebhookConfigurations().Get(context.TODO(), istiod, kubeApiMeta.GetOptions{})).
+	g.Expect(c.ValidatingWebhookConfigurations().Get(context.TODO(), webhookName, kubeApiMeta.GetOptions{})).
 		Should(Equal(webhookConfigWithCABundleIgnore), "no config update when endpoint not present")
 
 	// verify the webhook isn't updated if invalid config is accepted.
@@ -225,7 +227,7 @@ func TestGreenfield(t *testing.T) {
 		return true, &v1alpha3.Gateway{}, nil
 	})
 	reconcileHelper(t, c)
-	g.Expect(c.ValidatingWebhookConfigurations().Get(context.TODO(), istiod, kubeApiMeta.GetOptions{})).
+	g.Expect(c.ValidatingWebhookConfigurations().Get(context.TODO(), webhookName, kubeApiMeta.GetOptions{})).
 		Should(Equal(webhookConfigWithCABundleIgnore), "no config update when endpoint invalid config is accepted")
 
 	// verify the webhook is updated after the controller can confirm invalid config is rejected.
@@ -233,7 +235,7 @@ func TestGreenfield(t *testing.T) {
 		return true, &v1alpha3.Gateway{}, kubeErrors.NewInternalError(errors.New("unknown error"))
 	})
 	reconcileHelper(t, c)
-	g.Expect(c.ValidatingWebhookConfigurations().Get(context.TODO(), istiod, kubeApiMeta.GetOptions{})).
+	g.Expect(c.ValidatingWebhookConfigurations().Get(context.TODO(), webhookName, kubeApiMeta.GetOptions{})).
 		Should(Equal(webhookConfigWithCABundleIgnore),
 			"no config update when endpoint invalid config is rejected for an unknown reason")
 
@@ -243,7 +245,7 @@ func TestGreenfield(t *testing.T) {
 	})
 	reconcileHelper(t, c)
 	g.Expect(c.Actions()[2].Matches("update", "validatingwebhookconfigurations")).Should(BeTrue())
-	g.Expect(c.ValidatingWebhookConfigurations().Get(context.TODO(), istiod, kubeApiMeta.GetOptions{})).
+	g.Expect(c.ValidatingWebhookConfigurations().Get(context.TODO(), webhookName, kubeApiMeta.GetOptions{})).
 		Should(Equal(webhookConfigWithCABundleFail),
 			"istiod config created when endpoint is ready and invalid config is denied")
 }
@@ -258,7 +260,7 @@ func TestCABundleChange(t *testing.T) {
 		return true, &v1alpha3.Gateway{}, kubeErrors.NewInternalError(errors.New(deniedRequestMessageFragment))
 	})
 	reconcileHelper(t, c)
-	g.Expect(c.ValidatingWebhookConfigurations().Get(context.TODO(), istiod, kubeApiMeta.GetOptions{})).
+	g.Expect(c.ValidatingWebhookConfigurations().Get(context.TODO(), webhookName, kubeApiMeta.GetOptions{})).
 		Should(Equal(webhookConfigWithCABundleFail), "istiod config created when endpoint is ready")
 	// keep test store and tracker in-sync
 	_ = c.configStore.Add(webhookConfigWithCABundleFail)
@@ -273,7 +275,7 @@ func TestCABundleChange(t *testing.T) {
 	webhookConfigAfterCAUpdate.Webhooks[1].ClientConfig.CABundle = caBundle1
 
 	reconcileHelper(t, c)
-	g.Expect(c.ValidatingWebhookConfigurations().Get(context.TODO(), istiod, kubeApiMeta.GetOptions{})).
+	g.Expect(c.ValidatingWebhookConfigurations().Get(context.TODO(), webhookName, kubeApiMeta.GetOptions{})).
 		Should(Equal(webhookConfigAfterCAUpdate), "webhook should change after cert change")
 	// keep test store and tracker in-sync
 	_ = c.configStore.Update(webhookConfigAfterCAUpdate)

--- a/tests/integration/pilot/webhook_test.go
+++ b/tests/integration/pilot/webhook_test.go
@@ -32,17 +32,18 @@ import (
 	"istio.io/istio/pkg/test/util/retry"
 )
 
-var vwcName = "istiod"
+var vwcName = "istio"
 
 func TestWebhook(t *testing.T) {
 	framework.NewTest(t).
 		RequiresSingleCluster().
 		Run(func(t framework.TestContext) {
-			// clear the updated fields and verify istiod updates them
-
 			if t.Settings().Revisions.Default() != "" {
 				vwcName = fmt.Sprintf("%s-%s", vwcName, t.Settings().Revisions.Default())
 			}
+			vwcName += "-istio-system"
+
+			// clear the updated fields and verify istiod updates them
 			cluster := t.Clusters().Default()
 			retry.UntilSuccessOrFail(t, func() error {
 				got, err := getValidatingWebhookConfiguration(cluster, vwcName)

--- a/tests/integration/pilot/webhook_test.go
+++ b/tests/integration/pilot/webhook_test.go
@@ -32,7 +32,7 @@ import (
 	"istio.io/istio/pkg/test/util/retry"
 )
 
-var vwcName = "istio"
+var vwcName = "istio-validator"
 
 func TestWebhook(t *testing.T) {
 	framework.NewTest(t).


### PR DESCRIPTION
[Related](https://github.com/istio/istio/pull/33288) 

#33044 removed the `VALIDATION_WEBHOOK_CONFIG_NAME` environment variable which is still used to disable webhook patching in the external control plane docs, this adds it back. That PR also targeted the wrong (deprecated) webhook when using non-"istio-system" namespace.

[ ] Configuration Infrastructure
[ ] Docs
[x] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
