### PR TITLE
Fixed #31185 Show changes to be made in the cluster before applying

### DIFF
--- a/operator/cmd/mesh/install.go
+++ b/operator/cmd/mesh/install.go
@@ -254,7 +254,8 @@ func InstallManifests(iop *v1alpha12.IstioOperator, force bool, dryRun bool, res
 		if err != nil {
 			return iop, err
 		}
-		fmt.Println(result)
+		// Display the results to the user
+		l.Print(result)
 	}
 	return iop, saveIOPToCluster(reconciler, iopStr)
 }

--- a/operator/cmd/mesh/install_test.go
+++ b/operator/cmd/mesh/install_test.go
@@ -1,0 +1,173 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mesh
+
+import (
+	"strings"
+	"testing"
+
+	"istio.io/istio/operator/pkg/object"
+)
+
+func TestManifestFromString(t *testing.T) {
+	tests := []struct {
+		desc         string
+		given        string
+		mustContains []string
+		expectErr    bool
+	}{
+		{
+			desc: "with enabled component",
+			given: `---
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+metadata:
+  namespace: istio-system
+spec:
+  components:
+    ingressGateways:
+    - name: istio-ingressgateway
+      enabled: true`,
+			mustContains: []string{
+				"name: istio-ingressgateway-service-account",
+				"name: istio-ingressgateway",
+			},
+			expectErr: false,
+		},
+		{
+			desc: "with no enabled component",
+			given: `---
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+metadata:
+  namespace: istio-system
+spec:
+  components:
+    pilot:
+      k8s:
+        podDisruptionBudget:
+          maxUnavailable: 2`,
+			mustContains: []string{""},
+			expectErr:    false,
+		},
+		{
+			desc: "invalid spec",
+			given: `---
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: invalid-virtual-service
+spec:
+  http`,
+			mustContains: []string{""},
+			expectErr:    true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			got, err := ManifestFromString(tt.given)
+			if !tt.expectErr {
+				if err != nil {
+					t.Errorf("Expect no errors but got one %v", err)
+				} else {
+					for _, mcs := range tt.mustContains {
+						if !strings.Contains(got, mcs) {
+							t.Errorf("Results must contain %s, but is not found in the results", mcs)
+						}
+					}
+				}
+			} else if err == nil {
+				t.Errorf("Expected error but did not get any")
+			}
+		})
+	}
+}
+
+func TestShowDifferences(t *testing.T) {
+	getK8sObj := func(content string) *object.K8sObject {
+		obj, err := object.ParseYAMLToK8sObject([]byte(content))
+		if err != nil {
+			t.Fatal(err)
+		}
+		return obj
+	}
+	testInput1 := `---
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+metadata:
+  namespace: istio-operator-test
+  name: test-operator
+spec:
+  values:
+    global:
+      logging:
+        level: "default:info"
+  components:
+    ingressGateways:
+    - name: istio-ingressgateway
+      enabled: true`
+	testInput2 := `---
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+metadata:
+  namespace: istio-operator-test
+  name: test-operator
+spec:
+  values:
+    global:
+      logging:
+        level: "default:error"
+  components:
+    ingressGateways:
+    - name: istio-ingressgateway
+      enabled: true`
+	tests := []struct {
+		name         string
+		diff1        string
+		diff2        string
+		mustContains []string
+	}{
+		{
+			name:  "different inputs",
+			diff1: testInput1,
+			diff2: testInput2,
+			mustContains: []string{
+				"-        level: default:info",
+				"+        level: default:error",
+			},
+		},
+		{
+			name:         "same inputs",
+			diff1:        testInput1,
+			diff2:        testInput1,
+			mustContains: []string{""},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := showDifferences(getK8sObj(tt.diff1).UnstructuredObject(),
+				getK8sObj(tt.diff2).UnstructuredObject())
+			if err != nil {
+				t.Errorf("Expected no error but got error %v", err)
+			} else {
+				for _, mcs := range tt.mustContains {
+					if !strings.Contains(result, mcs) {
+						t.Errorf("Results must contain %s, but is not found in the results", mcs)
+					}
+				}
+			}
+		})
+	}
+}

--- a/operator/pkg/helmreconciler/apply.go
+++ b/operator/pkg/helmreconciler/apply.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	errors2 "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
@@ -243,7 +244,7 @@ func (h *HelmReconciler) GetObject(iop *v1alpha12.IstioOperator) (*unstructured.
 	err := h.client.Get(context.TODO(), objectKey, receiver)
 
 	switch {
-	case errors2.IsNotFound(err):
+	case errors2.IsNotFound(err) || meta.IsNoMatchError(err):
 		return nil, nil
 	case err == nil:
 		return receiver, nil

--- a/releasenotes/notes/31185.yaml
+++ b/releasenotes/notes/31185.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+issue:
+- 31185
+releaseNotes:
+- |
+  **Fixed** Show changes that will be made in the cluster before applying in istioctl
+


### PR DESCRIPTION
Currently there is no way to see what might be changed to istio system.
With this fix, one can simply use --dry-run flag available in `install`
command to see what will be changed. The istioctl output will display
istio configuration changes and manifest changes.

Signed-off-by: Tong Li <litong01@us.ibm.com>



[ ] Configuration Infrastructure
[ ] Docs
[X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.