### PR TITLE
cache: drop typesIndex on clearAll

### DIFF
--- a/pilot/pkg/model/xds_cache.go
+++ b/pilot/pkg/model/xds_cache.go
@@ -303,6 +303,7 @@ func (l *lruCache) ClearAll() {
 	defer l.mu.Unlock()
 	l.store.Purge()
 	l.configIndex = map[ConfigKey]sets.Set{}
+	l.typesIndex = map[config.GroupVersionKind]sets.Set{}
 	size(l.store.Len())
 }
 


### PR DESCRIPTION
Not sure if this results in any real bugs, but it feels wrong