### PR TITLE
Remove incorrect reference to aggregate service account

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -1039,7 +1039,7 @@ roleRef:
   name: istio-reader-clusterrole-istio-system
 subjects:
   - kind: ServiceAccount
-    name: istio-reader-aggregate
+    name: istio-reader-service-account
     namespace: istio-system
 ---
 # Source: istio-discovery/templates/clusterrolebinding.yaml

--- a/manifests/charts/istio-control/istio-discovery/templates/clusterrolebinding.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/clusterrolebinding.yaml
@@ -19,11 +19,7 @@ roleRef:
 {{- end }}
 subjects:
   - kind: ServiceAccount
-{{- if not .Values.global.externalIstiod }}
-    name: istio-reader-aggregate
-{{- else }}
     name: istio-reader-service-account
-{{- end }}
     namespace: {{ .Values.global.istioNamespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
I have no idea how this made it past our multicluster CI jobs... the `ClusterRoleBinding` was pointing to wrong SA so the reader service account should not have had permissions to do anything.

[ ] Configuration Infrastructure
[ ] Docs
[x] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
