### PR TITLE
WIP: Adding Grpc metrics and debug

### DIFF
--- a/pilot/pkg/bootstrap/monitoring.go
+++ b/pilot/pkg/bootstrap/monitoring.go
@@ -23,6 +23,7 @@ import (
 	ocprom "contrib.go.opencensus.io/exporter/prometheus"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opencensus.io/stats/view"
+	"go.opencensus.io/zpages"
 
 	"istio.io/pkg/log"
 	"istio.io/pkg/monitoring"
@@ -63,6 +64,8 @@ func addMonitor(mux *http.ServeMux) error {
 			log.Errorf("Unable to write version string: %v", err)
 		}
 	})
+
+	zpages.Handle(mux, "/debug")
 
 	return nil
 }

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -34,6 +34,7 @@ import (
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/admin"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/reflection"
 	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -760,6 +761,8 @@ func (s *Server) initSecureDiscoveryService(args *PilotArgs) error {
 	s.secureGrpcServer = grpc.NewServer(opts...)
 	s.XDSServer.Register(s.secureGrpcServer)
 	reflection.Register(s.secureGrpcServer)
+
+	admin.Register(s.secureGrpcServer)
 
 	s.addStartFunc(func(stop <-chan struct{}) error {
 		go func() {

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -713,6 +713,9 @@ func (s *Server) initGrpcServer(options *istiokeepalive.Options) {
 	s.grpcServer = grpc.NewServer(grpcOptions...)
 	s.XDSServer.Register(s.grpcServer)
 	reflection.Register(s.grpcServer)
+	if features.GRPCDebug {
+		admin.Register(s.grpcServer)
+	}
 }
 
 // initialize secureGRPCServer.
@@ -761,8 +764,9 @@ func (s *Server) initSecureDiscoveryService(args *PilotArgs) error {
 	s.secureGrpcServer = grpc.NewServer(opts...)
 	s.XDSServer.Register(s.secureGrpcServer)
 	reflection.Register(s.secureGrpcServer)
-
-	admin.Register(s.secureGrpcServer)
+	if features.GRPCDebug {
+		admin.Register(s.secureGrpcServer)
+	}
 
 	s.addStartFunc(func(stop <-chan struct{}) error {
 		go func() {

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -469,6 +469,9 @@ var (
 	// New behavior (true): we create listener 0.0.0.0_8080 and route http.8080. This has no conflicts; routes are 1:1 with listener.
 	UseTargetPortForGatewayRoutes = env.RegisterBoolVar("PILOT_USE_TARGET_PORT_FOR_GATEWAY_ROUTES", true,
 		"If true, routes will use the target port of the gateway service in the route name, not the service port.").Get()
+
+	// For development/debugging - provides access to channelz internals for Istiod.
+	GRPCDebug = env.RegisterBoolVar("GRPC_DEBUG", false, "Enable gRPC debug interface").Get()
 )
 
 // UnsafeFeaturesEnabled returns true if any unsafe features are enabled.

--- a/pkg/istio-agent/xds_proxy.go
+++ b/pkg/istio-agent/xds_proxy.go
@@ -41,6 +41,7 @@ import (
 	"go.uber.org/atomic"
 	google_rpc "google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/admin"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/keepalive"
@@ -577,6 +578,7 @@ func (p *XdsProxy) initDownstreamServer() error {
 	grpcs := grpc.NewServer(istiogrpc.ServerOptions(istiokeepalive.DefaultOption())...)
 	discovery.RegisterAggregatedDiscoveryServiceServer(grpcs, p)
 	reflection.Register(grpcs)
+	admin.Register(grpcs)
 	p.downstreamGrpcServer = grpcs
 	p.downstreamListener = l
 	return nil


### PR DESCRIPTION
gRPC provides a number of useful debug tools - admin allows checking the internal channels, zpages provide 
traces and metrics for the specific workload ( including the agent ). Also when aggregated the metrics will
follow the typical pattern/naming expected for gRPC - including messages sent in streaming connections, etc.

We are using OC already, so not a new dependency.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
