### PR TITLE
Allow gateway-api to function without Kubernetes RBAC

### DIFF
--- a/pilot/pkg/model/gateway_test.go
+++ b/pilot/pkg/model/gateway_test.go
@@ -134,7 +134,7 @@ func TestMergeGateways(t *testing.T) {
 			for _, c := range tt.gwConfig {
 				instances = append(instances, gatewayWithInstances{c, true, nil})
 			}
-			mgw := MergeGateways(instances)
+			mgw := MergeGateways(instances, &Proxy{})
 			if len(mgw.MergedServers) != tt.mergedServersNum {
 				t.Errorf("Incorrect number of merged servers. Expected: %v Got: %d", tt.mergedServersNum, len(mgw.MergedServers))
 			}

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -1773,7 +1773,7 @@ func (ps *PushContext) mergeGateways(proxy *Proxy) *MergedGateway {
 		return nil
 	}
 
-	return MergeGateways(gatewayInstances)
+	return MergeGateways(gatewayInstances, proxy)
 }
 
 // GatewayContext contains a minimal subset of push context functionality to be exposed to GatewayAPIControllers

--- a/pilot/pkg/xds/sds.go
+++ b/pilot/pkg/xds/sds.go
@@ -93,28 +93,64 @@ func needsUpdate(proxy *model.Proxy, updates model.XdsUpdates) bool {
 	return false
 }
 
-// Currently only same namespace is allowed. In the future this will be expanded.
-func (s *SecretGen) proxyAuthorizedForSecret(proxy *model.Proxy, sr SecretResource) error {
-	if proxy.ConfigNamespace != sr.Namespace {
-		return fmt.Errorf("SDS is currently only supporting accessing secret within the same namespace. Secret namespace %q does not match proxy namespace %q",
-			sr.Namespace, proxy.ConfigNamespace)
+func parseResources(names []string, proxy *model.Proxy) []SecretResource {
+	res := make([]SecretResource, 0, len(names))
+	for _, resource := range names {
+		sr, err := parseResourceName(resource, proxy.VerifiedIdentity.Namespace, string(proxy.Metadata.ClusterID))
+		if err != nil {
+			pilotSDSCertificateErrors.Increment()
+			log.Warnf("error parsing resource name: %v", err)
+			continue
+		}
+		if proxy.VerifiedIdentity.Namespace != sr.Namespace {
+			pilotSDSCertificateErrors.Increment()
+			log.Warnf("requested secret %v not accessible for proxy %v: SDS is currently only supporting accessing secret within the same namespace. "+
+				"Secret namespace %q does not match proxy namespace %q",
+				sr.ResourceName, proxy.ID, err, sr.Namespace, proxy.VerifiedIdentity.Namespace)
+			continue
+		}
+		res = append(res, sr)
 	}
-	return nil
+	return res
+}
+
+type AuthorizationMode int
+
+const (
+	// OnlyLocalCertificateReferences indicates that all certificates requested come from Gateways that
+	// are in the same namespace as the proxy.
+	// For the new gateway-api, this is *always* the case. This allows deploying a gateway without any roles,
+	// while still allowing SDS access.
+	// For the old API, its still possible to hit this if we happen to only have Gateways in the proxy namespace.
+	// In this case, we get a small performance improvement.
+	OnlyLocalCertificateReferences AuthorizationMode = iota
+	// CrossNamespaceCertificateReferences indicates we have a cross namespace certificate reference.
+	// Note that the Secret still needs to be in the same namespace as the proxy, but it may only be referenced by a
+	// Gateway in another namespace.
+	// Because we check the Secret namespace already, it may be a bit overkill to check authorization here at all
+	// (since any pods in the namespace can already mount the Secret), but it does improve the security posture a bit
+	// by disallowing someone with an identity in a namespace to access ANY secret in the namespace (such as citadel private key)
+	// if the identity doesn't already have Kubernetes RBAC permission to access it.
+	CrossNamespaceCertificateReferences
+)
+
+func getAuthorizationMode(resources []SecretResource, proxy *model.Proxy) AuthorizationMode {
+	if proxy.MergedGateway == nil {
+		return CrossNamespaceCertificateReferences
+	}
+	verifiedCertificateReferences := proxy.MergedGateway.VerifiedCertificateReferences
+	for _, r := range resources {
+		if !verifiedCertificateReferences.Contains(r.Name) {
+			return CrossNamespaceCertificateReferences
+		}
+	}
+	return OnlyLocalCertificateReferences
 }
 
 func (s *SecretGen) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource,
 	req *model.PushRequest) (model.Resources, model.XdsLogDetails, error) {
 	if proxy.VerifiedIdentity == nil {
 		log.Warnf("proxy %v is not authorized to receive secrets. Ensure you are connecting over TLS port and are authenticated.", proxy.ID)
-		return nil, model.DefaultXdsLogDetails, nil
-	}
-	secrets, err := s.secrets.ForCluster(proxy.Metadata.ClusterID)
-	if err != nil {
-		log.Warnf("proxy %v is from an unknown cluster, cannot retrieve certificates: %v", proxy.ID, err)
-		return nil, model.DefaultXdsLogDetails, nil
-	}
-	if err := secrets.Authorize(proxy.VerifiedIdentity.ServiceAccount, proxy.VerifiedIdentity.Namespace); err != nil {
-		log.Warnf("proxy %v is not authorized to receive secrets: %v", proxy.ID, err)
 		return nil, model.DefaultXdsLogDetails, nil
 	}
 	if req == nil || !needsUpdate(proxy, req.ConfigsUpdated) {
@@ -124,16 +160,29 @@ func (s *SecretGen) Generate(proxy *model.Proxy, push *model.PushContext, w *mod
 	if !req.Full {
 		updatedSecrets = model.ConfigsOfKind(req.ConfigsUpdated, gvk.Secret)
 	}
+
+	// TODO: For the new gateway-api, we should always search the config namespace and stop reading across all clusters
+	secrets, err := s.secrets.ForCluster(proxy.Metadata.ClusterID)
+	if err != nil {
+		log.Warnf("proxy %v is from an unknown cluster, cannot retrieve certificates: %v", proxy.ID, err)
+		pilotSDSCertificateErrors.Increment()
+		return nil, model.DefaultXdsLogDetails, nil
+	}
+
+	resources := parseResources(w.ResourceNames, proxy)
+	authMode := getAuthorizationMode(resources, proxy)
+	if authMode != OnlyLocalCertificateReferences {
+		if err := secrets.Authorize(proxy.VerifiedIdentity.ServiceAccount, proxy.VerifiedIdentity.Namespace); err != nil {
+			log.Warnf("proxy %v is not authorized to receive secrets: %v", proxy.ID, err)
+			pilotSDSCertificateErrors.Increment()
+			return nil, model.DefaultXdsLogDetails, nil
+		}
+	}
+
 	results := model.Resources{}
 	cached, regenerated := 0, 0
-	for _, resource := range w.ResourceNames {
-		sr, err := parseResourceName(resource, proxy.ConfigNamespace, string(proxy.Metadata.ClusterID))
-		if err != nil {
-			pilotSDSCertificateErrors.Increment()
-			log.Warnf("error parsing resource name: %v", err)
-			continue
-		}
 
+	for _, sr := range resources {
 		if updatedSecrets != nil {
 			if !containsAny(updatedSecrets, relatedConfigs(model.ConfigKey{Kind: gvk.Secret, Name: sr.Name, Namespace: sr.Namespace})) {
 				// This is an incremental update, filter out secrets that are not updated.
@@ -141,11 +190,6 @@ func (s *SecretGen) Generate(proxy *model.Proxy, push *model.PushContext, w *mod
 			}
 		}
 
-		if err := s.proxyAuthorizedForSecret(proxy, sr); err != nil {
-			pilotSDSCertificateErrors.Increment()
-			log.Warnf("requested secret %v not accessible for proxy %v: %v", sr.ResourceName, proxy.ID, err)
-			continue
-		}
 		cachedItem, f := s.cache.Get(sr)
 		if f && !features.EnableUnsafeAssertions {
 			// If it is in the Cache, add it and continue

--- a/pilot/pkg/xds/sds_test.go
+++ b/pilot/pkg/xds/sds_test.go
@@ -143,7 +143,7 @@ func TestGenerate(t *testing.T) {
 	}{
 		{
 			name:      "simple",
-			proxy:     &model.Proxy{VerifiedIdentity: &spiffe.Identity{Namespace: "istio-system"}, Type: model.Router, ConfigNamespace: "istio-system"},
+			proxy:     &model.Proxy{VerifiedIdentity: &spiffe.Identity{Namespace: "istio-system"}, Type: model.Router},
 			resources: []string{"kubernetes://generic"},
 			request:   &model.PushRequest{Full: true},
 			expect: map[string]Expected{
@@ -155,28 +155,21 @@ func TestGenerate(t *testing.T) {
 		},
 		{
 			name:      "sidecar",
-			proxy:     &model.Proxy{VerifiedIdentity: &spiffe.Identity{Namespace: "istio-system"}, ConfigNamespace: "istio-system"},
-			resources: []string{"kubernetes://generic"},
-			request:   &model.PushRequest{Full: true},
-			expect:    map[string]Expected{},
-		},
-		{
-			name:      "mismatched namespace",
-			proxy:     &model.Proxy{VerifiedIdentity: &spiffe.Identity{Namespace: "istio-system"}, Type: model.Router},
+			proxy:     &model.Proxy{VerifiedIdentity: &spiffe.Identity{Namespace: "istio-system"}},
 			resources: []string{"kubernetes://generic"},
 			request:   &model.PushRequest{Full: true},
 			expect:    map[string]Expected{},
 		},
 		{
 			name:      "unauthenticated",
-			proxy:     &model.Proxy{Type: model.Router, ConfigNamespace: "istio-system"},
+			proxy:     &model.Proxy{Type: model.Router},
 			resources: []string{"kubernetes://generic"},
 			request:   &model.PushRequest{Full: true},
 			expect:    map[string]Expected{},
 		},
 		{
 			name:      "multiple",
-			proxy:     &model.Proxy{VerifiedIdentity: &spiffe.Identity{Namespace: "istio-system"}, Type: model.Router, ConfigNamespace: "istio-system"},
+			proxy:     &model.Proxy{VerifiedIdentity: &spiffe.Identity{Namespace: "istio-system"}, Type: model.Router},
 			resources: allResources,
 			request:   &model.PushRequest{Full: true},
 			expect: map[string]Expected{
@@ -202,7 +195,7 @@ func TestGenerate(t *testing.T) {
 		},
 		{
 			name:      "full push with updates",
-			proxy:     &model.Proxy{VerifiedIdentity: &spiffe.Identity{Namespace: "istio-system"}, Type: model.Router, ConfigNamespace: "istio-system"},
+			proxy:     &model.Proxy{VerifiedIdentity: &spiffe.Identity{Namespace: "istio-system"}, Type: model.Router},
 			resources: []string{"kubernetes://generic", "kubernetes://generic-mtls", "kubernetes://generic-mtls-cacert"},
 			request: &model.PushRequest{Full: true, ConfigsUpdated: map[model.ConfigKey]struct{}{
 				{Name: "generic-mtls", Namespace: "istio-system", Kind: gvk.Secret}: {},
@@ -223,7 +216,7 @@ func TestGenerate(t *testing.T) {
 		},
 		{
 			name:      "incremental push with updates",
-			proxy:     &model.Proxy{VerifiedIdentity: &spiffe.Identity{Namespace: "istio-system"}, Type: model.Router, ConfigNamespace: "istio-system"},
+			proxy:     &model.Proxy{VerifiedIdentity: &spiffe.Identity{Namespace: "istio-system"}, Type: model.Router},
 			resources: allResources,
 			request: &model.PushRequest{Full: false, ConfigsUpdated: map[model.ConfigKey]struct{}{
 				{Name: "generic", Namespace: "istio-system", Kind: gvk.Secret}: {},
@@ -237,7 +230,7 @@ func TestGenerate(t *testing.T) {
 		},
 		{
 			name:      "incremental push with updates - mtls",
-			proxy:     &model.Proxy{VerifiedIdentity: &spiffe.Identity{Namespace: "istio-system"}, Type: model.Router, ConfigNamespace: "istio-system"},
+			proxy:     &model.Proxy{VerifiedIdentity: &spiffe.Identity{Namespace: "istio-system"}, Type: model.Router},
 			resources: allResources,
 			request: &model.PushRequest{Full: false, ConfigsUpdated: map[model.ConfigKey]struct{}{
 				{Name: "generic-mtls", Namespace: "istio-system", Kind: gvk.Secret}: {},
@@ -254,7 +247,7 @@ func TestGenerate(t *testing.T) {
 		},
 		{
 			name:      "incremental push with updates - mtls split",
-			proxy:     &model.Proxy{VerifiedIdentity: &spiffe.Identity{Namespace: "istio-system"}, Type: model.Router, ConfigNamespace: "istio-system"},
+			proxy:     &model.Proxy{VerifiedIdentity: &spiffe.Identity{Namespace: "istio-system"}, Type: model.Router},
 			resources: allResources,
 			request: &model.PushRequest{Full: false, ConfigsUpdated: map[model.ConfigKey]struct{}{
 				{Name: "generic-mtls-split", Namespace: "istio-system", Kind: gvk.Secret}: {},
@@ -271,7 +264,7 @@ func TestGenerate(t *testing.T) {
 		},
 		{
 			name:      "incremental push with updates - mtls split ca update",
-			proxy:     &model.Proxy{VerifiedIdentity: &spiffe.Identity{Namespace: "istio-system"}, Type: model.Router, ConfigNamespace: "istio-system"},
+			proxy:     &model.Proxy{VerifiedIdentity: &spiffe.Identity{Namespace: "istio-system"}, Type: model.Router},
 			resources: allResources,
 			request: &model.PushRequest{Full: false, ConfigsUpdated: map[model.ConfigKey]struct{}{
 				{Name: "generic-mtls-split-cacert", Namespace: "istio-system", Kind: gvk.Secret}: {},
@@ -289,7 +282,7 @@ func TestGenerate(t *testing.T) {
 		{
 			// If an unknown resource is request, we return all the ones we do know about
 			name:      "unknown",
-			proxy:     &model.Proxy{VerifiedIdentity: &spiffe.Identity{Namespace: "istio-system"}, Type: model.Router, ConfigNamespace: "istio-system"},
+			proxy:     &model.Proxy{VerifiedIdentity: &spiffe.Identity{Namespace: "istio-system"}, Type: model.Router},
 			resources: []string{"kubernetes://generic", "foo://invalid", "kubernetes://not-found"},
 			request:   &model.PushRequest{Full: true},
 			expect: map[string]Expected{
@@ -302,7 +295,7 @@ func TestGenerate(t *testing.T) {
 		{
 			// proxy without authorization
 			name:      "unauthorized",
-			proxy:     &model.Proxy{VerifiedIdentity: &spiffe.Identity{Namespace: "istio-system"}, Type: model.Router, ConfigNamespace: "istio-system"},
+			proxy:     &model.Proxy{VerifiedIdentity: &spiffe.Identity{Namespace: "istio-system"}, Type: model.Router},
 			resources: []string{"kubernetes://generic"},
 			request:   &model.PushRequest{Full: true},
 			// Should get a response, but it will be empty


### PR DESCRIPTION
This implements most of
https://docs.google.com/document/d/1gDhj058q2PKKI9SWpxE23ExEXdOkLiueT8JA_oEJ8Mo/edit#heading=h.bmkc9oooxqbj

Another PR will try to figure out the multicluster change
I tried to capture context in the comments in the code