### PR TITLE
istioctl proxy-config command support pod-name auto-completion

### DIFF
--- a/istioctl/cmd/proxyconfig.go
+++ b/istioctl/cmd/proxyconfig.go
@@ -20,13 +20,13 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"os"
 	"regexp"
 	"strings"
 
 	"github.com/ghodss/yaml"
 	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"istio.io/istio/istioctl/pkg/util/handlers"
 	"istio.io/istio/istioctl/pkg/writer/envoy/clusters"

--- a/istioctl/cmd/proxyconfig.go
+++ b/istioctl/cmd/proxyconfig.go
@@ -1022,7 +1022,8 @@ func getPodsNameInDefaultNamespace(toComplete string) ([]string, error) {
 	}
 
 	ctx := context.Background()
-	podList, err := kubeClient.CoreV1().Pods(defaultNamespace).List(ctx, metav1.ListOptions{})
+	ns := handlers.HandleNamespace(namespace, defaultNamespace)
+	podList, err := kubeClient.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/istioctl/cmd/root.go
+++ b/istioctl/cmd/root.go
@@ -161,7 +161,7 @@ func GetRootCmd(args []string) *cobra.Command {
 		Long: `Istio configuration command line utility for service operators to
 debug and diagnose their Istio mesh.
 `,
-		PersistentPreRunE: configureLogging,
+		PersistentPreRunE:      configureLogging,
 		BashCompletionFunction: bashCompletionFunc,
 	}
 

--- a/istioctl/cmd/root.go
+++ b/istioctl/cmd/root.go
@@ -38,29 +38,6 @@ import (
 	"istio.io/pkg/log"
 )
 
-const (
-	bashCompletionFunc = `__istioctl_get_resource_pod()
-{
-    local template
-    template="${2:-"{{ range .items  }}{{ .metadata.name }} {{ end }}"}"
-    local kubectl_out
-    if kubectl_out=$(__kubectl_debug_out "kubectl get $(__kubectl_override_flags) -o template --template=\"${template}\" \"pods\""); then
-        COMPREPLY+=( $( compgen -W "${kubectl_out[*]}" -- "$cur" ) )
-    fi
-}
-
-__istioctl_custom_func() {
-    case ${last_command} in
-        istioctl_proxy-config_*)
-            __istioctl_get_resource_pod
-            return
-            ;;
-        *)
-            ;;
-    esac
-}`
-)
-
 // CommandParseError distinguishes an error parsing istioctl CLI arguments from an error processing
 type CommandParseError struct {
 	e error
@@ -161,8 +138,7 @@ func GetRootCmd(args []string) *cobra.Command {
 		Long: `Istio configuration command line utility for service operators to
 debug and diagnose their Istio mesh.
 `,
-		PersistentPreRunE:      configureLogging,
-		BashCompletionFunction: bashCompletionFunc,
+		PersistentPreRunE: configureLogging,
 	}
 
 	rootCmd.SetArgs(args)


### PR DESCRIPTION
Please provide a description for what this PR is for.

When auto-completion is enabled, istioctl could auto complete most command, this is convenient.
However, for `istioctl proxyconfig` command, it wants users to fill in pod-name, but this command could not auto complete pod names in current namespace, so users have to use kubectl to get pods name first, then copy and paste to fill in istioctl command.

`istioctl proxy-config <clusters|listeners|routes|endpoints|bootstrap|log|secret> <pod-name[.namespace]>`

This is a little burdensome. This PR will add func to custom `istioctl proxy-config * ` to auto fill in pods name in current namespace, and will helps a lot.

```bash
$ istioctl proxy-config route <tab><tab>
debian-77dc9c5f4f-nscvz                      nginx-74f5bd857c-7dvkp                       spring-cloud-consul-school-7759b8ffcc-f22q2
$ kubectl get pods
NAME                                          READY   STATUS    RESTARTS   AGE
debian-77dc9c5f4f-nscvz                       2/2     Running   0          2d22h
nginx-74f5bd857c-7dvkp                        2/2     Running   0          2d22h
spring-cloud-consul-school-7759b8ffcc-f22q2   2/2     Running   0          21d
```
---
And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[X] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
