### PR TITLE
Implement Wasm API

### DIFF
--- a/galley/testdatasets/validation/dataset/extensions-v1alpha1-WasmPlugin-invalid.yaml
+++ b/galley/testdatasets/validation/dataset/extensions-v1alpha1-WasmPlugin-invalid.yaml
@@ -1,0 +1,7 @@
+apiVersion: extensions.istio.io/v1alpha1
+kind: WasmPlugin
+metadata:
+  name: invalid
+spec:
+  url: ftp://domain.com/module.wasm
+  sha256: test

--- a/galley/testdatasets/validation/dataset/extensions-v1alpha1-WasmPlugin-valid.yaml
+++ b/galley/testdatasets/validation/dataset/extensions-v1alpha1-WasmPlugin-valid.yaml
@@ -1,0 +1,15 @@
+apiVersion: extensions.istio.io/v1alpha1
+kind: WasmPlugin
+metadata:
+  name: valid
+spec:
+  selector:
+    matchLabels:
+      istio: ingressgateway
+  url: oci://private-registry:5000/openid-connect/openid:latest
+  imagePullPolicy: IfNotPresent
+  imagePullSecret: private-registry-pull-secret
+  phase: AUTHN
+  pluginConfig:
+    openid_server: authn
+    openid_realm: ingress

--- a/manifests/charts/default/templates/validatingwebhook.yaml
+++ b/manifests/charts/default/templates/validatingwebhook.yaml
@@ -30,6 +30,7 @@ webhooks:
           - security.istio.io
           - networking.istio.io
           - telemetry.istio.io
+          - extensions.istio.io
         apiVersions:
           - "*"
         resources:

--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -1222,7 +1222,7 @@ rules:
   # istio configuration
   # removing CRD permissions can break older versions of Istio running alongside this control plane (https://github.com/istio/istio/issues/29382)
   # please proceed with caution
-  - apiGroups: ["config.istio.io", "security.istio.io", "networking.istio.io", "authentication.istio.io", "rbac.istio.io", "telemetry.istio.io"]
+  - apiGroups: ["config.istio.io", "security.istio.io", "networking.istio.io", "authentication.istio.io", "rbac.istio.io", "telemetry.istio.io", "extensions.istio.io"]
     verbs: ["get", "watch", "list"]
     resources: ["*"]
   - apiGroups: ["networking.istio.io"]

--- a/manifests/charts/istio-control/istio-discovery/templates/clusterrole.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/clusterrole.yaml
@@ -19,11 +19,11 @@ rules:
   # istio configuration
   # removing CRD permissions can break older versions of Istio running alongside this control plane (https://github.com/istio/istio/issues/29382)
   # please proceed with caution
-  - apiGroups: ["config.istio.io", "security.istio.io", "networking.istio.io", "authentication.istio.io", "rbac.istio.io", "telemetry.istio.io"]
+  - apiGroups: ["config.istio.io", "security.istio.io", "networking.istio.io", "authentication.istio.io", "rbac.istio.io", "telemetry.istio.io", "extensions.istio.io"]
     verbs: ["get", "watch", "list"]
     resources: ["*"]
 {{- if .Values.global.istiod.enableAnalysis }}
-  - apiGroups: ["config.istio.io", "security.istio.io", "networking.istio.io", "authentication.istio.io", "rbac.istio.io", "telemetry.istio.io"]
+  - apiGroups: ["config.istio.io", "security.istio.io", "networking.istio.io", "authentication.istio.io", "rbac.istio.io", "telemetry.istio.io", "extensions.istio.io"]
     verbs: ["update"]
     # TODO: should be on just */status but wildcard is not supported
     resources: ["*"]

--- a/manifests/charts/istio-control/istio-discovery/templates/validatingwebhookconfiguration.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/validatingwebhookconfiguration.yaml
@@ -31,6 +31,7 @@ webhooks:
           - security.istio.io
           - networking.istio.io
           - telemetry.istio.io
+          - extensions.istio.io
         apiVersions:
           - "*"
         resources:

--- a/manifests/charts/istiod-remote/templates/clusterrole.yaml
+++ b/manifests/charts/istiod-remote/templates/clusterrole.yaml
@@ -20,11 +20,11 @@ rules:
   # istio configuration
   # removing CRD permissions can break older versions of Istio running alongside this control plane (https://github.com/istio/istio/issues/29382)
   # please proceed with caution
-  - apiGroups: ["config.istio.io", "security.istio.io", "networking.istio.io", "authentication.istio.io", "rbac.istio.io", "telemetry.istio.io"]
+  - apiGroups: ["config.istio.io", "security.istio.io", "networking.istio.io", "authentication.istio.io", "rbac.istio.io", "telemetry.istio.io", "extensions.istio.io"]
     verbs: ["get", "watch", "list"]
     resources: ["*"]
 {{- if .Values.global.istiod.enableAnalysis }}
-  - apiGroups: ["config.istio.io", "security.istio.io", "networking.istio.io", "authentication.istio.io", "rbac.istio.io", "telemetry.istio.io"]
+  - apiGroups: ["config.istio.io", "security.istio.io", "networking.istio.io", "authentication.istio.io", "rbac.istio.io", "telemetry.istio.io", "extensions.istio.io"]
     verbs: ["update"]
     # TODO: should be on just */status but wildcard is not supported
     resources: ["*"]

--- a/manifests/charts/istiod-remote/templates/validatingwebhookconfiguration.yaml
+++ b/manifests/charts/istiod-remote/templates/validatingwebhookconfiguration.yaml
@@ -32,6 +32,7 @@ webhooks:
           - security.istio.io
           - networking.istio.io
           - telemetry.istio.io
+          - extensions.istio.io
         apiVersions:
           - "*"
         resources:

--- a/pilot/pkg/config/kube/crdclient/gen/main.go
+++ b/pilot/pkg/config/kube/crdclient/gen/main.go
@@ -80,6 +80,7 @@ var (
 		"istio.io/api/telemetry/v1alpha1":       "telemetryv1alpha1",
 		"sigs.k8s.io/gateway-api/apis/v1alpha2": "gatewayv1alpha2",
 		"istio.io/api/meta/v1alpha1":            "metav1alpha1",
+		"istio.io/api/extensions/v1alpha1":      "extensionsv1alpha1",
 	}
 	// Mapping from istio/api path import to client go import path
 	clientGoImport = map[string]string{
@@ -87,6 +88,7 @@ var (
 		"istio.io/api/security/v1beta1":         "clientsecurityv1beta1",
 		"istio.io/api/telemetry/v1alpha1":       "clienttelemetryv1alpha1",
 		"sigs.k8s.io/gateway-api/apis/v1alpha2": "gatewayv1alpha2",
+		"istio.io/api/extensions/v1alpha1":      "clientextensionsv1alpha1",
 	}
 	// Translates an api import path to the top level path in client-go
 	clientGoAccessPath = map[string]string{
@@ -94,6 +96,7 @@ var (
 		"istio.io/api/security/v1beta1":         "SecurityV1beta1",
 		"istio.io/api/telemetry/v1alpha1":       "TelemetryV1alpha1",
 		"sigs.k8s.io/gateway-api/apis/v1alpha2": "GatewayV1alpha2",
+		"istio.io/api/extensions/v1alpha1":      "ExtensionsV1alpha1",
 	}
 	// Translates a plural type name to the type path in client-go
 	// TODO: can we automatically derive this? I don't think we can, its internal to the kubegen
@@ -115,6 +118,7 @@ var (
 		"tlsroutes":              "TLSRoutes",
 		"referencepolicies":      "ReferencePolicies",
 		"telemetries":            "Telemetries",
+		"wasmplugins":            "WasmPlugins",
 	}
 )
 

--- a/pilot/pkg/config/kube/crdclient/gen/types.go.tmpl
+++ b/pilot/pkg/config/kube/crdclient/gen/types.go.tmpl
@@ -35,9 +35,11 @@ import (
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/collections"
 
+	extensionsv1alpha1 "istio.io/api/extensions/v1alpha1"
 	networkingv1alpha3 "istio.io/api/networking/v1alpha3"
 	securityv1beta1 "istio.io/api/security/v1beta1"
 	telemetryv1alpha1 "istio.io/api/telemetry/v1alpha1"
+	clientextensionsv1alpha1 "istio.io/client-go/pkg/apis/extensions/v1alpha1"
 	clientnetworkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	clientsecurityv1beta1 "istio.io/client-go/pkg/apis/security/v1beta1"
 	clienttelemetryv1alpha1 "istio.io/client-go/pkg/apis/telemetry/v1alpha1"

--- a/pilot/pkg/config/kube/crdclient/types.gen.go
+++ b/pilot/pkg/config/kube/crdclient/types.gen.go
@@ -35,9 +35,11 @@ import (
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/collections"
 
+	extensionsv1alpha1 "istio.io/api/extensions/v1alpha1"
 	networkingv1alpha3 "istio.io/api/networking/v1alpha3"
 	securityv1beta1 "istio.io/api/security/v1beta1"
 	telemetryv1alpha1 "istio.io/api/telemetry/v1alpha1"
+	clientextensionsv1alpha1 "istio.io/client-go/pkg/apis/extensions/v1alpha1"
 	clientnetworkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	clientsecurityv1beta1 "istio.io/client-go/pkg/apis/security/v1beta1"
 	clienttelemetryv1alpha1 "istio.io/client-go/pkg/apis/telemetry/v1alpha1"
@@ -47,6 +49,11 @@ import (
 
 func create(ic versionedclient.Interface, sc gatewayapiclient.Interface, cfg config.Config, objMeta metav1.ObjectMeta) (metav1.Object, error) {
 	switch cfg.GroupVersionKind {
+	case collections.IstioExtensionsV1Alpha1Wasmplugins.Resource().GroupVersionKind():
+		return ic.ExtensionsV1alpha1().WasmPlugins(cfg.Namespace).Create(context.TODO(), &clientextensionsv1alpha1.WasmPlugin{
+			ObjectMeta: objMeta,
+			Spec:       *(cfg.Spec.(*extensionsv1alpha1.WasmPlugin)),
+		}, metav1.CreateOptions{})
 	case collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind():
 		return ic.NetworkingV1alpha3().DestinationRules(cfg.Namespace).Create(context.TODO(), &clientnetworkingv1alpha3.DestinationRule{
 			ObjectMeta: objMeta,
@@ -144,6 +151,11 @@ func create(ic versionedclient.Interface, sc gatewayapiclient.Interface, cfg con
 
 func update(ic versionedclient.Interface, sc gatewayapiclient.Interface, cfg config.Config, objMeta metav1.ObjectMeta) (metav1.Object, error) {
 	switch cfg.GroupVersionKind {
+	case collections.IstioExtensionsV1Alpha1Wasmplugins.Resource().GroupVersionKind():
+		return ic.ExtensionsV1alpha1().WasmPlugins(cfg.Namespace).Update(context.TODO(), &clientextensionsv1alpha1.WasmPlugin{
+			ObjectMeta: objMeta,
+			Spec:       *(cfg.Spec.(*extensionsv1alpha1.WasmPlugin)),
+		}, metav1.UpdateOptions{})
 	case collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind():
 		return ic.NetworkingV1alpha3().DestinationRules(cfg.Namespace).Update(context.TODO(), &clientnetworkingv1alpha3.DestinationRule{
 			ObjectMeta: objMeta,
@@ -241,6 +253,12 @@ func update(ic versionedclient.Interface, sc gatewayapiclient.Interface, cfg con
 
 func updateStatus(ic versionedclient.Interface, sc gatewayapiclient.Interface, cfg config.Config, objMeta metav1.ObjectMeta) (metav1.Object, error) {
 	switch cfg.GroupVersionKind {
+
+	case collections.IstioExtensionsV1Alpha1Wasmplugins.Resource().GroupVersionKind():
+		return ic.ExtensionsV1alpha1().WasmPlugins(cfg.Namespace).UpdateStatus(context.TODO(), &clientextensionsv1alpha1.WasmPlugin{
+			ObjectMeta: objMeta,
+			Status:     *(cfg.Status.(*metav1alpha1.IstioStatus)),
+		}, metav1.UpdateOptions{})
 
 	case collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind():
 		return ic.NetworkingV1alpha3().DestinationRules(cfg.Namespace).UpdateStatus(context.TODO(), &clientnetworkingv1alpha3.DestinationRule{
@@ -354,6 +372,21 @@ func patch(ic versionedclient.Interface, sc gatewayapiclient.Interface, orig con
 	}
 	// TODO support setting field manager
 	switch orig.GroupVersionKind {
+	case collections.IstioExtensionsV1Alpha1Wasmplugins.Resource().GroupVersionKind():
+		oldRes := &clientextensionsv1alpha1.WasmPlugin{
+			ObjectMeta: origMeta,
+			Spec:       *(orig.Spec.(*extensionsv1alpha1.WasmPlugin)),
+		}
+		modRes := &clientextensionsv1alpha1.WasmPlugin{
+			ObjectMeta: modMeta,
+			Spec:       *(mod.Spec.(*extensionsv1alpha1.WasmPlugin)),
+		}
+		patchBytes, err := genPatchBytes(oldRes, modRes, typ)
+		if err != nil {
+			return nil, err
+		}
+		return ic.ExtensionsV1alpha1().WasmPlugins(orig.Namespace).
+			Patch(context.TODO(), orig.Name, typ, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
 	case collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind():
 		oldRes := &clientnetworkingv1alpha3.DestinationRule{
 			ObjectMeta: origMeta,
@@ -635,6 +668,8 @@ func delete(ic versionedclient.Interface, sc gatewayapiclient.Interface, typ con
 		deleteOptions.Preconditions = &metav1.Preconditions{ResourceVersion: resourceVersion}
 	}
 	switch typ {
+	case collections.IstioExtensionsV1Alpha1Wasmplugins.Resource().GroupVersionKind():
+		return ic.ExtensionsV1alpha1().WasmPlugins(namespace).Delete(context.TODO(), name, deleteOptions)
 	case collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind():
 		return ic.NetworkingV1alpha3().DestinationRules(namespace).Delete(context.TODO(), name, deleteOptions)
 	case collections.IstioNetworkingV1Alpha3Envoyfilters.Resource().GroupVersionKind():
@@ -677,6 +712,25 @@ func delete(ic versionedclient.Interface, sc gatewayapiclient.Interface, typ con
 }
 
 var translationMap = map[config.GroupVersionKind]func(r runtime.Object) *config.Config{
+	collections.IstioExtensionsV1Alpha1Wasmplugins.Resource().GroupVersionKind(): func(r runtime.Object) *config.Config {
+		obj := r.(*clientextensionsv1alpha1.WasmPlugin)
+		return &config.Config{
+			Meta: config.Meta{
+				GroupVersionKind:  collections.IstioExtensionsV1Alpha1Wasmplugins.Resource().GroupVersionKind(),
+				Name:              obj.Name,
+				Namespace:         obj.Namespace,
+				Labels:            obj.Labels,
+				Annotations:       obj.Annotations,
+				ResourceVersion:   obj.ResourceVersion,
+				CreationTimestamp: obj.CreationTimestamp.Time,
+				OwnerReferences:   obj.OwnerReferences,
+				UID:               string(obj.UID),
+				Generation:        obj.Generation,
+			},
+			Spec:   &obj.Spec,
+			Status: &obj.Status,
+		}
+	},
 	collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind(): func(r runtime.Object) *config.Config {
 		obj := r.(*clientnetworkingv1alpha3.DestinationRule)
 		return &config.Config{

--- a/pilot/pkg/model/extensions.go
+++ b/pilot/pkg/model/extensions.go
@@ -22,14 +22,14 @@ import (
 	envoy_extensions_filters_http_wasm_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/wasm/v3"
 	envoy_extensions_wasm_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/wasm/v3"
 	"github.com/gogo/protobuf/types"
-	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/any"
-	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
 
 	extensions "istio.io/api/extensions/v1alpha1"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/util/gogo"
+	"istio.io/istio/pkg/util/gogoprotomarshal"
 )
 
 const (
@@ -42,7 +42,7 @@ type WasmPluginWrapper struct {
 	Name      string
 	Namespace string
 
-	ExtensionConfiguration *envoy_extensions_filters_http_wasm_v3.Wasm
+	ExtensionConfiguration *envoy_config_core_v3.TypedExtensionConfig
 }
 
 func convertToWasmPluginWrapper(plugin *config.Config) *WasmPluginWrapper {
@@ -54,13 +54,13 @@ func convertToWasmPluginWrapper(plugin *config.Config) *WasmPluginWrapper {
 
 	cfg := &any.Any{}
 	if wasmPlugin.PluginConfig != nil && len(wasmPlugin.PluginConfig.Fields) > 0 {
-		cfgJSON, err := protojson.Marshal(proto.MessageV2(wasmPlugin.PluginConfig))
+		cfgJSON, err := gogoprotomarshal.ToJSON(wasmPlugin.PluginConfig)
 		if err != nil {
 			log.Warnf("wasmplugin %v/%v discarded due to json marshaling error: %s", plugin.Namespace, plugin.Name, err)
 			return nil
 		}
 		cfg = gogo.MessageToAny(&types.StringValue{
-			Value: string(cfgJSON),
+			Value: cfgJSON,
 		})
 	}
 	var datasource *envoy_config_core_v3.AsyncDataSource
@@ -108,22 +108,31 @@ func convertToWasmPluginWrapper(plugin *config.Config) *WasmPluginWrapper {
 			},
 		}
 	}
-	return &WasmPluginWrapper{
-		Name:       plugin.Name,
-		Namespace:  plugin.Namespace,
-		WasmPlugin: *wasmPlugin,
-		ExtensionConfiguration: &envoy_extensions_filters_http_wasm_v3.Wasm{
-			Config: &envoy_extensions_wasm_v3.PluginConfig{
-				Name:          plugin.Name,
-				RootId:        wasmPlugin.PluginName,
-				Configuration: cfg,
-				Vm: &envoy_extensions_wasm_v3.PluginConfig_VmConfig{
-					VmConfig: &envoy_extensions_wasm_v3.VmConfig{
-						Runtime: defaultRuntime,
-						Code:    datasource,
-					},
+	typedConfig, err := anypb.New(&envoy_extensions_filters_http_wasm_v3.Wasm{
+		Config: &envoy_extensions_wasm_v3.PluginConfig{
+			Name:          plugin.Name,
+			RootId:        wasmPlugin.PluginName,
+			Configuration: cfg,
+			Vm: &envoy_extensions_wasm_v3.PluginConfig_VmConfig{
+				VmConfig: &envoy_extensions_wasm_v3.VmConfig{
+					Runtime: defaultRuntime,
+					Code:    datasource,
 				},
 			},
 		},
+	})
+	if err != nil {
+		log.Warnf("wasmplugin %s/%s failed to marshal to TypedExtensionConfig: %s", plugin.Namespace, plugin.Name, err)
+		return nil
+	}
+	ec := &envoy_config_core_v3.TypedExtensionConfig{
+		Name:        plugin.Name,
+		TypedConfig: typedConfig,
+	}
+	return &WasmPluginWrapper{
+		Name:                   plugin.Name,
+		Namespace:              plugin.Namespace,
+		WasmPlugin:             *wasmPlugin,
+		ExtensionConfiguration: ec,
 	}
 }

--- a/pilot/pkg/model/extensions.go
+++ b/pilot/pkg/model/extensions.go
@@ -15,6 +15,7 @@ package model
 
 import (
 	"net/url"
+	"strings"
 	"time"
 
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -57,6 +58,7 @@ func convertToWasmPluginWrapper(plugin *config.Config) *WasmPluginWrapper {
 		var sha256 string
 		u, err := url.Parse(wasmPlugin.Url)
 		if err != nil {
+			log.Warnf("wasmplugin %v/%v discarded due to failure to parse URL: %s", plugin.Namespace, plugin.Name, err)
 			return nil
 		}
 		if wasmPlugin.XSha256 == nil {
@@ -75,8 +77,7 @@ func convertToWasmPluginWrapper(plugin *config.Config) *WasmPluginWrapper {
 				Specifier: &envoy_config_core_v3.AsyncDataSource_Local{
 					Local: &envoy_config_core_v3.DataSource{
 						Specifier: &envoy_config_core_v3.DataSource_Filename{
-							// remove 'file://' prefix
-							Filename: wasmPlugin.Url[7:],
+							Filename: strings.TrimPrefix(wasmPlugin.Url, "file://"),
 						},
 					},
 				},

--- a/pilot/pkg/model/extensions.go
+++ b/pilot/pkg/model/extensions.go
@@ -1,0 +1,121 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package model
+
+import (
+	"net/url"
+	"time"
+
+	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	envoy_extensions_filters_http_wasm_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/wasm/v3"
+	envoy_extensions_wasm_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/wasm/v3"
+	"github.com/gogo/protobuf/types"
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes/any"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/durationpb"
+
+	extensions "istio.io/api/extensions/v1alpha1"
+	"istio.io/istio/pkg/config"
+	"istio.io/istio/pkg/util/gogo"
+)
+
+const (
+	defaultRuntime = "envoy.wasm.runtime.v8"
+)
+
+type WasmPluginWrapper struct {
+	extensions.WasmPlugin
+
+	Name      string
+	Namespace string
+
+	ExtensionConfiguration *envoy_extensions_filters_http_wasm_v3.Wasm
+}
+
+func convertToWasmPluginWrapper(plugin *config.Config) *WasmPluginWrapper {
+	if wasmPlugin, ok := plugin.Spec.(*extensions.WasmPlugin); ok {
+		cfg := &any.Any{}
+		if wasmPlugin.PluginConfig != nil && len(wasmPlugin.PluginConfig.Fields) > 0 {
+			cfgJSON, _ := protojson.Marshal(proto.MessageV2(wasmPlugin.PluginConfig))
+			cfg = gogo.MessageToAny(&types.StringValue{
+				Value: string(cfgJSON),
+			})
+		}
+		var datasource *envoy_config_core_v3.AsyncDataSource
+		var sha256 string
+		u, err := url.Parse(wasmPlugin.Url)
+		if err != nil {
+			return nil
+		}
+		if wasmPlugin.XSha256 == nil {
+			if u.Scheme == "http" || u.Scheme == "https" {
+				// SHA256 is required for .wasm deployments fetched from HTTP/HTTPS URLs
+				return nil
+			}
+			// field is required, so we're setting a string for unmarshaling to not fail
+			// on the agent side. this will never reach envoy
+			sha256 = "nil"
+		} else {
+			sha256 = wasmPlugin.GetSha256()
+		}
+		if u.Scheme == "file" {
+			datasource = &envoy_config_core_v3.AsyncDataSource{
+				Specifier: &envoy_config_core_v3.AsyncDataSource_Local{
+					Local: &envoy_config_core_v3.DataSource{
+						Specifier: &envoy_config_core_v3.DataSource_Filename{
+							// remove 'file://' prefix
+							Filename: wasmPlugin.Url[7:],
+						},
+					},
+				},
+			}
+		} else {
+			datasource = &envoy_config_core_v3.AsyncDataSource{
+				Specifier: &envoy_config_core_v3.AsyncDataSource_Remote{
+					Remote: &envoy_config_core_v3.RemoteDataSource{
+						HttpUri: &envoy_config_core_v3.HttpUri{
+							Uri:     wasmPlugin.Url,
+							Timeout: durationpb.New(30 * time.Second),
+							HttpUpstreamType: &envoy_config_core_v3.HttpUri_Cluster{
+								// this will be fetched by the agent anyway, so no need for a cluster
+								Cluster: "_",
+							},
+						},
+						Sha256: sha256,
+					},
+				},
+			}
+		}
+		return &WasmPluginWrapper{
+			Name:       plugin.Name,
+			Namespace:  plugin.Namespace,
+			WasmPlugin: *wasmPlugin,
+			ExtensionConfiguration: &envoy_extensions_filters_http_wasm_v3.Wasm{
+				Config: &envoy_extensions_wasm_v3.PluginConfig{
+					Name:          plugin.Name,
+					RootId:        wasmPlugin.PluginName,
+					Configuration: cfg,
+					Vm: &envoy_extensions_wasm_v3.PluginConfig_VmConfig{
+						VmConfig: &envoy_extensions_wasm_v3.VmConfig{
+							Runtime: defaultRuntime,
+							Code:    datasource,
+						},
+					},
+				},
+			},
+		}
+	}
+	return nil
+}

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -17,6 +17,7 @@ package model
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"sort"
 	"strconv"
 	"strings"
@@ -25,6 +26,7 @@ import (
 
 	"go.uber.org/atomic"
 
+	extensions "istio.io/api/extensions/v1alpha1"
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/features"
@@ -203,6 +205,9 @@ type PushContext struct {
 
 	// envoy filters for each namespace including global config namespace
 	envoyFiltersByNamespace map[string][]*EnvoyFilterWrapper
+
+	// wasm plugins for each namespace including global config namespace
+	wasmPluginsByNamespace map[string][]*WasmPluginWrapper
 
 	// AuthnPolicies contains Authn policies by namespace.
 	AuthnPolicies *AuthenticationPolicies `json:"-"`
@@ -1117,6 +1122,10 @@ func (ps *PushContext) createNewContext(env *Environment) error {
 		return err
 	}
 
+	if err := ps.initWasmPlugins(env); err != nil {
+		return err
+	}
+
 	if err := ps.initEnvoyFilters(env); err != nil {
 		return err
 	}
@@ -1137,7 +1146,8 @@ func (ps *PushContext) updateContext(
 	oldPushContext *PushContext,
 	pushReq *PushRequest) error {
 	var servicesChanged, virtualServicesChanged, destinationRulesChanged, gatewayChanged,
-		authnChanged, authzChanged, envoyFiltersChanged, sidecarsChanged, telemetryChanged, gatewayAPIChanged bool
+		authnChanged, authzChanged, envoyFiltersChanged, sidecarsChanged, telemetryChanged, gatewayAPIChanged,
+		wasmPluginsChanged bool
 
 	for conf := range pushReq.ConfigsUpdated {
 		switch conf.Kind {
@@ -1151,6 +1161,8 @@ func (ps *PushContext) updateContext(
 			gatewayChanged = true
 		case gvk.Sidecar:
 			sidecarsChanged = true
+		case gvk.WasmPlugin:
+			wasmPluginsChanged = true
 		case gvk.EnvoyFilter:
 			envoyFiltersChanged = true
 		case gvk.AuthorizationPolicy:
@@ -1225,6 +1237,14 @@ func (ps *PushContext) updateContext(
 		}
 	} else {
 		ps.Telemetry = oldPushContext.Telemetry
+	}
+
+	if wasmPluginsChanged {
+		if err := ps.initWasmPlugins(env); err != nil {
+			return err
+		}
+	} else {
+		ps.wasmPluginsByNamespace = oldPushContext.wasmPluginsByNamespace
 	}
 
 	if envoyFiltersChanged {
@@ -1688,6 +1708,88 @@ func (ps *PushContext) initTelemetry(env *Environment) (err error) {
 		return
 	}
 	return
+}
+
+// pre computes WasmPlugins per namespace
+func (ps *PushContext) initWasmPlugins(env *Environment) error {
+	wasmplugins, err := env.List(gvk.WasmPlugin, NamespaceAll)
+	if err != nil {
+		return err
+	}
+
+	sortConfigByCreationTime(wasmplugins)
+	ps.wasmPluginsByNamespace = map[string][]*WasmPluginWrapper{}
+	for _, plugin := range wasmplugins {
+		if ps.wasmPluginsByNamespace[plugin.Namespace] == nil {
+			ps.wasmPluginsByNamespace[plugin.Namespace] = []*WasmPluginWrapper{}
+		}
+		if pluginWrapper := convertToWasmPluginWrapper(&plugin); pluginWrapper != nil {
+			ps.wasmPluginsByNamespace[plugin.Namespace] = append(ps.wasmPluginsByNamespace[plugin.Namespace], pluginWrapper)
+		}
+	}
+
+	return nil
+}
+
+// WasmPlugins return the WasmPluginWrappers of a proxy
+func (ps *PushContext) WasmPlugins(proxy *Proxy) map[extensions.PluginPhase][]*WasmPluginWrapper {
+	if proxy == nil {
+		return nil
+	}
+	matchedPlugins := make(map[extensions.PluginPhase][]*WasmPluginWrapper)
+	// First get all the extension configs from the config root namespace
+	// and then add the ones from proxy's own namespace
+	if ps.Mesh.RootNamespace != "" {
+		// if there is no workload selector, the config applies to all workloads
+		// if there is a workload selector, check for matching workload labels
+		for _, plugin := range ps.wasmPluginsByNamespace[ps.Mesh.RootNamespace] {
+			var workloadLabels labels.Collection
+			if proxy.Metadata != nil && len(proxy.Metadata.Labels) > 0 {
+				workloadLabels = labels.Collection{proxy.Metadata.Labels}
+			}
+			if plugin.Selector == nil || workloadLabels.IsSupersetOf(plugin.Selector.MatchLabels) {
+				matchedPlugins[plugin.Phase] = append(matchedPlugins[plugin.Phase], plugin)
+			}
+		}
+	}
+
+	// To prevent duplicate extensions in case root namespace equals proxy's namespace
+	if proxy.ConfigNamespace != ps.Mesh.RootNamespace {
+		for _, plugin := range ps.wasmPluginsByNamespace[proxy.ConfigNamespace] {
+			var workloadLabels labels.Collection
+			if proxy.Metadata != nil && len(proxy.Metadata.Labels) > 0 {
+				workloadLabels = labels.Collection{proxy.Metadata.Labels}
+			}
+			if plugin.Selector == nil || workloadLabels.IsSupersetOf(plugin.Selector.MatchLabels) {
+				matchedPlugins[plugin.Phase] = append(matchedPlugins[plugin.Phase], plugin)
+			}
+		}
+	}
+
+	// sort slices by priority
+	for i, slice := range matchedPlugins {
+		sort.SliceStable(slice, func(i, j int) bool {
+			iPriority := int64(math.MinInt64)
+			if prio := slice[i].Priority; prio != nil {
+				iPriority = prio.Value
+			}
+			jPriority := int64(math.MinInt64)
+			if prio := slice[j].Priority; prio != nil {
+				jPriority = prio.Value
+			}
+			// if priority is the same, in order to still have a
+			// deterministic ordering, we sort based on name + url
+			if iPriority == jPriority {
+				in := slice[i].Name + slice[i].Url
+				jn := slice[j].Name + slice[j].Url
+				return in < jn
+			}
+			return iPriority > jPriority
+		})
+		matchedPlugins[i] = slice
+	}
+
+	return matchedPlugins
 }
 
 // pre computes envoy filters per namespace

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -1777,13 +1777,6 @@ func (ps *PushContext) WasmPlugins(proxy *Proxy) map[extensions.PluginPhase][]*W
 			if prio := slice[j].Priority; prio != nil {
 				jPriority = prio.Value
 			}
-			// if priority is the same, in order to still have a
-			// deterministic ordering, we sort based on name + url
-			if iPriority == jPriority {
-				in := slice[i].Name + slice[i].Url
-				jn := slice[j].Name + slice[j].Url
-				return in < jn
-			}
 			return iPriority > jPriority
 		})
 		matchedPlugins[i] = slice

--- a/pilot/pkg/networking/core/v1alpha3/extension/wasmplugin.go
+++ b/pilot/pkg/networking/core/v1alpha3/extension/wasmplugin.go
@@ -125,7 +125,7 @@ func popAppend(list []*hcm_filter.HttpFilter,
 
 func toEnvoyHTTPFilter(wasmPlugin *model.WasmPluginWrapper) *hcm_filter.HttpFilter {
 	return &hcm_filter.HttpFilter{
-		Name: wasmPlugin.Name,
+		Name: wasmPlugin.Namespace + "." + wasmPlugin.Name,
 		ConfigType: &hcm_filter.HttpFilter_ConfigDiscovery{
 			ConfigDiscovery: &envoy_config_core_v3.ExtensionConfigSource{
 				ConfigSource: defaultConfigSource,
@@ -149,7 +149,7 @@ func InsertedExtensionConfigurations(
 	}
 	for _, list := range wasmPlugins {
 		for _, p := range list {
-			if _, ok := hasName[p.Name]; !ok {
+			if _, ok := hasName[p.Namespace+"."+p.Name]; !ok {
 				continue
 			}
 			result = append(result, proto.Clone(p.ExtensionConfiguration).(*envoy_config_core_v3.TypedExtensionConfig))

--- a/pilot/pkg/networking/core/v1alpha3/extension/wasmplugin.go
+++ b/pilot/pkg/networking/core/v1alpha3/extension/wasmplugin.go
@@ -87,8 +87,9 @@ func injectExtensions(filterChain []*hcm_filter.HttpFilter, exts map[extensions.
 	// append all remaining extensions at the end (router is not yet in the chain so this is correct)
 	newHTTPFilters = popAppend(newHTTPFilters, extMap, extensions.PluginPhase_AUTHN)
 	newHTTPFilters = popAppend(newHTTPFilters, extMap, extensions.PluginPhase_AUTHZ)
-	// TODO: stats are currently injected using EnvoyFilter, we should migrate them to
-	// WasmPlugin (with phase: stats and priority: -maxInt) so this becomes effective
+	// TODO: stats are currently injected using EnvoyFilter, but they're about to be migrated to
+	// native code (see https://github.com/istio/istio/pull/33583). When that's done, we can properly
+	// implement the STATS phase here
 	newHTTPFilters = popAppend(newHTTPFilters, extMap, extensions.PluginPhase_STATS)
 	newHTTPFilters = popAppend(newHTTPFilters, extMap, extensions.PluginPhase_UNSPECIFIED_PHASE)
 	return newHTTPFilters

--- a/pilot/pkg/networking/core/v1alpha3/extension/wasmplugin.go
+++ b/pilot/pkg/networking/core/v1alpha3/extension/wasmplugin.go
@@ -38,7 +38,7 @@ var defaultConfigSource = &envoy_config_core_v3.ConfigSource{
 		Ads: &envoy_config_core_v3.AggregatedConfigSource{},
 	},
 	ResourceApiVersion:  envoy_config_core_v3.ApiVersion_V3,
-	InitialFetchTimeout: &durationpb.Duration{Seconds: 30},
+	InitialFetchTimeout: &durationpb.Duration{Seconds: 0},
 }
 
 // AddWasmPluginsToMutableObjects adds WasmPlugins to HTTP filterChains

--- a/pilot/pkg/networking/core/v1alpha3/extension/wasmplugin.go
+++ b/pilot/pkg/networking/core/v1alpha3/extension/wasmplugin.go
@@ -1,0 +1,149 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extension
+
+import (
+	udpa "github.com/cncf/udpa/go/udpa/type/v1"
+	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	hcm_filter "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/conversion"
+	"google.golang.org/protobuf/proto"
+
+	extensions "istio.io/api/extensions/v1alpha1"
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/networking"
+	"istio.io/istio/pilot/pkg/networking/util"
+	authzmodel "istio.io/istio/pilot/pkg/security/authz/model"
+	securitymodel "istio.io/istio/pilot/pkg/security/model"
+)
+
+const (
+	wasmFilterType = "envoy.extensions.filters.http.wasm.v3.Wasm"
+)
+
+var defaultConfigSource = &envoy_config_core_v3.ConfigSource{
+	ConfigSourceSpecifier: &envoy_config_core_v3.ConfigSource_Ads{
+		Ads: &envoy_config_core_v3.AggregatedConfigSource{},
+	},
+	ResourceApiVersion: envoy_config_core_v3.ApiVersion_V3,
+}
+
+// AddWasmPluginsToMutableObjects adds WasmPlugins to HTTP filterChains
+// Note that the slices in the map must already be ordered by plugin
+// priority! This will be the case for maps returned by PushContext.WasmPlugin()
+func AddWasmPluginsToMutableObjects(
+	mutable *networking.MutableObjects,
+	extensionsMap map[extensions.PluginPhase][]*model.WasmPluginWrapper,
+) {
+	if mutable == nil {
+		return
+	}
+
+	for fcIndex, fc := range mutable.FilterChains {
+		// we currently only support HTTP
+		if fc.ListenerProtocol != networking.ListenerProtocolHTTP {
+			continue
+		}
+		mutable.FilterChains[fcIndex].HTTP = injectExtensions(fc.HTTP, extensionsMap)
+	}
+}
+
+func injectExtensions(filterChain []*hcm_filter.HttpFilter, exts map[extensions.PluginPhase][]*model.WasmPluginWrapper) []*hcm_filter.HttpFilter {
+	// copy map as we'll manipulate it in the loop
+	extMap := make(map[extensions.PluginPhase][]*model.WasmPluginWrapper)
+	for phase, list := range exts {
+		extMap[phase] = []*model.WasmPluginWrapper{}
+		extMap[phase] = append(extMap[phase], list...)
+	}
+	newHTTPFilters := make([]*hcm_filter.HttpFilter, 0)
+	for _, httpFilter := range filterChain {
+		switch httpFilter.Name {
+		case securitymodel.EnvoyJwtFilterName:
+			newHTTPFilters = popAppend(newHTTPFilters, extMap, extensions.PluginPhase_AUTHN)
+			newHTTPFilters = append(newHTTPFilters, httpFilter)
+		case securitymodel.AuthnFilterName:
+			newHTTPFilters = popAppend(newHTTPFilters, extMap, extensions.PluginPhase_AUTHN)
+			newHTTPFilters = append(newHTTPFilters, httpFilter)
+		case authzmodel.RBACHTTPFilterName:
+			newHTTPFilters = popAppend(newHTTPFilters, extMap, extensions.PluginPhase_AUTHN)
+			newHTTPFilters = popAppend(newHTTPFilters, extMap, extensions.PluginPhase_AUTHZ)
+			newHTTPFilters = append(newHTTPFilters, httpFilter)
+		default:
+			newHTTPFilters = append(newHTTPFilters, httpFilter)
+		}
+	}
+	// append all remaining extensions at the end (router is not yet in the chain so this is correct)
+	newHTTPFilters = popAppend(newHTTPFilters, extMap, extensions.PluginPhase_AUTHN)
+	newHTTPFilters = popAppend(newHTTPFilters, extMap, extensions.PluginPhase_AUTHZ)
+	// TODO: stats are currently injected using EnvoyFilter, we should migrate them to
+	// WasmPlugin (with phase: stats and priority: -maxInt) so this becomes effective
+	newHTTPFilters = popAppend(newHTTPFilters, extMap, extensions.PluginPhase_STATS)
+	newHTTPFilters = popAppend(newHTTPFilters, extMap, extensions.PluginPhase_UNSPECIFIED_PHASE)
+	return newHTTPFilters
+}
+
+func popAppend(list []*hcm_filter.HttpFilter,
+	filterMap map[extensions.PluginPhase][]*model.WasmPluginWrapper,
+	phase extensions.PluginPhase) []*hcm_filter.HttpFilter {
+	for _, ext := range filterMap[phase] {
+		if filter := toEnvoyHTTPFilter(ext); filter != nil {
+			list = append(list, filter)
+		}
+	}
+	filterMap[phase] = []*model.WasmPluginWrapper{}
+	return list
+}
+
+func toEnvoyHTTPFilter(wasmPlugin *model.WasmPluginWrapper) *hcm_filter.HttpFilter {
+	return &hcm_filter.HttpFilter{
+		Name: wasmPlugin.Name,
+		ConfigType: &hcm_filter.HttpFilter_ConfigDiscovery{
+			ConfigDiscovery: &envoy_config_core_v3.ExtensionConfigSource{
+				ConfigSource: defaultConfigSource,
+				TypeUrls:     []string{wasmFilterType},
+			},
+		},
+	}
+}
+
+// InsertedExtensionConfigurations returns extension configurations added via EnvoyFilter.
+func InsertedExtensionConfigurations(
+	wasmPlugins map[extensions.PluginPhase][]*model.WasmPluginWrapper,
+	names []string) []*envoy_config_core_v3.TypedExtensionConfig {
+	result := make([]*envoy_config_core_v3.TypedExtensionConfig, 0)
+	if len(wasmPlugins) == 0 {
+		return result
+	}
+	hasName := make(map[string]bool)
+	for _, n := range names {
+		hasName[n] = true
+	}
+	for _, list := range wasmPlugins {
+		for _, p := range list {
+			ws, _ := conversion.MessageToStruct(p.ExtensionConfiguration)
+			ec := &envoy_config_core_v3.TypedExtensionConfig{
+				Name: p.Name,
+				TypedConfig: util.MessageToAny(&udpa.TypedStruct{
+					TypeUrl: "type.googleapis.com/" + wasmFilterType,
+					Value:   ws,
+				}),
+			}
+			if _, ok := hasName[ec.GetName()]; ok {
+				result = append(result, proto.Clone(ec).(*envoy_config_core_v3.TypedExtensionConfig))
+			}
+		}
+	}
+	return result
+}

--- a/pilot/pkg/networking/core/v1alpha3/extension/wasmplugin_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/extension/wasmplugin_test.go
@@ -201,7 +201,7 @@ func TestInsertedExtensionConfigurations(t *testing.T) {
 					someAuthZFilter,
 				},
 			},
-			names: []string{someAuthNFilter.Name},
+			names: []string{someAuthNFilter.Namespace + "." + someAuthNFilter.Name},
 			expectedECs: []*envoy_config_core_v3.TypedExtensionConfig{
 				someAuthNFilter.ExtensionConfiguration,
 			},

--- a/pilot/pkg/networking/core/v1alpha3/extension/wasmplugin_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/extension/wasmplugin_test.go
@@ -1,0 +1,144 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extension
+
+import (
+	"testing"
+
+	http_conn "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	"github.com/gogo/protobuf/types"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/testing/protocmp"
+
+	extensions "istio.io/api/extensions/v1alpha1"
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/networking"
+	authzmodel "istio.io/istio/pilot/pkg/security/authz/model"
+	securitymodel "istio.io/istio/pilot/pkg/security/model"
+)
+
+var (
+	istioAuthN = &http_conn.HttpFilter{
+		Name: securitymodel.AuthnFilterName,
+	}
+	istioAuthZ = &http_conn.HttpFilter{
+		Name: authzmodel.RBACHTTPFilterName,
+	}
+	someAuthNFilter = &model.WasmPluginWrapper{
+		Name: "someAuthNFilter",
+		WasmPlugin: extensions.WasmPlugin{
+			Priority: &types.Int64Value{Value: 1},
+		},
+	}
+	someImportantAuthNFilter = &model.WasmPluginWrapper{
+		Name: "someImportantAuthNFilter",
+		WasmPlugin: extensions.WasmPlugin{
+			Priority: &types.Int64Value{Value: 1000},
+		},
+	}
+	someAuthZFilter = &model.WasmPluginWrapper{
+		Name: "someAuthZFilter",
+		WasmPlugin: extensions.WasmPlugin{
+			Priority: &types.Int64Value{Value: 1000},
+		},
+	}
+)
+
+func TestAddWasmPluginsToMutableObjects(t *testing.T) {
+	testCases := []struct {
+		name           string
+		filterChains   []networking.FilterChain
+		extensions     map[extensions.PluginPhase][]*model.WasmPluginWrapper
+		expectedResult []networking.FilterChain
+	}{
+		{
+			name:           "empty",
+			filterChains:   []networking.FilterChain{},
+			extensions:     map[extensions.PluginPhase][]*model.WasmPluginWrapper{},
+			expectedResult: []networking.FilterChain{},
+		},
+		{
+			name: "authN",
+			filterChains: []networking.FilterChain{
+				{
+					ListenerProtocol: networking.ListenerProtocolHTTP,
+					HTTP: []*http_conn.HttpFilter{
+						istioAuthN,
+					},
+				},
+			},
+			extensions: map[extensions.PluginPhase][]*model.WasmPluginWrapper{
+				extensions.PluginPhase_AUTHN: {
+					someImportantAuthNFilter,
+					someAuthNFilter,
+				},
+			},
+			expectedResult: []networking.FilterChain{
+				{
+					ListenerProtocol: networking.ListenerProtocolHTTP,
+					HTTP: []*http_conn.HttpFilter{
+						toEnvoyHTTPFilter(someImportantAuthNFilter),
+						toEnvoyHTTPFilter(someAuthNFilter),
+						istioAuthN,
+					},
+				},
+			},
+		},
+		{
+			name: "authZ",
+			filterChains: []networking.FilterChain{
+				{
+					ListenerProtocol: networking.ListenerProtocolHTTP,
+					HTTP: []*http_conn.HttpFilter{
+						istioAuthN,
+						istioAuthZ,
+					},
+				},
+			},
+			extensions: map[extensions.PluginPhase][]*model.WasmPluginWrapper{
+				extensions.PluginPhase_AUTHN: {
+					someImportantAuthNFilter,
+					someAuthNFilter,
+				},
+				extensions.PluginPhase_AUTHZ: {
+					someAuthZFilter,
+				},
+			},
+			expectedResult: []networking.FilterChain{
+				{
+					ListenerProtocol: networking.ListenerProtocolHTTP,
+					HTTP: []*http_conn.HttpFilter{
+						toEnvoyHTTPFilter(someImportantAuthNFilter),
+						toEnvoyHTTPFilter(someAuthNFilter),
+						istioAuthN,
+						toEnvoyHTTPFilter(someAuthZFilter),
+						istioAuthZ,
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mut := &networking.MutableObjects{
+				FilterChains: tc.filterChains,
+			}
+			AddWasmPluginsToMutableObjects(mut, tc.extensions)
+			if diff := cmp.Diff(tc.expectedResult, mut.FilterChains, protocmp.Transform()); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}

--- a/pilot/pkg/networking/core/v1alpha3/extension/wasmplugin_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/extension/wasmplugin_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/gogo/protobuf/types"
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/protobuf/testing/protocmp"
-	"google.golang.org/protobuf/types/known/anypb"
 
 	extensions "istio.io/api/extensions/v1alpha1"
 	"istio.io/istio/pilot/pkg/model"
@@ -204,7 +203,7 @@ func TestInsertedExtensionConfigurations(t *testing.T) {
 			},
 			names: []string{someAuthNFilter.Name},
 			expectedECs: []*envoy_config_core_v3.TypedExtensionConfig{
-				getTypedConfig(someAuthNFilter),
+				someAuthNFilter.ExtensionConfiguration,
 			},
 		},
 	}
@@ -215,13 +214,5 @@ func TestInsertedExtensionConfigurations(t *testing.T) {
 				t.Fatal(diff)
 			}
 		})
-	}
-}
-
-func getTypedConfig(wasmPlugin *model.WasmPluginWrapper) *envoy_config_core_v3.TypedExtensionConfig {
-	any, _ := anypb.New(wasmPlugin.ExtensionConfiguration)
-	return &envoy_config_core_v3.TypedExtensionConfig{
-		Name:        wasmPlugin.Name,
-		TypedConfig: any,
 	}
 }

--- a/pilot/pkg/networking/core/v1alpha3/extension_config_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/extension_config_builder.go
@@ -19,6 +19,7 @@ import (
 
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/core/v1alpha3/envoyfilter"
+	"istio.io/istio/pilot/pkg/networking/core/v1alpha3/extension"
 )
 
 // BuildExtensionConfiguration returns the list of extension configuration for the given proxy and list of names.
@@ -26,5 +27,8 @@ import (
 func (configgen *ConfigGeneratorImpl) BuildExtensionConfiguration(
 	proxy *model.Proxy, push *model.PushContext, extensionConfigNames []string) []*core.TypedExtensionConfig {
 	envoyFilterPatches := push.EnvoyFilters(proxy)
-	return envoyfilter.InsertedExtensionConfigurations(envoyFilterPatches, extensionConfigNames)
+	extensions := envoyfilter.InsertedExtensionConfigurations(envoyFilterPatches, extensionConfigNames)
+	wasmPlugins := push.WasmPlugins(proxy)
+	extensions = append(extensions, extension.InsertedExtensionConfigurations(wasmPlugins, extensionConfigNames)...)
+	return extensions
 }

--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -35,6 +35,7 @@ import (
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	istionetworking "istio.io/istio/pilot/pkg/networking"
+	"istio.io/istio/pilot/pkg/networking/core/v1alpha3/extension"
 	istio_route "istio.io/istio/pilot/pkg/networking/core/v1alpha3/route"
 	"istio.io/istio/pilot/pkg/networking/plugin"
 	"istio.io/istio/pilot/pkg/networking/util"
@@ -152,6 +153,7 @@ func (configgen *ConfigGeneratorImpl) buildGatewayListeners(builder *ListenerBui
 					log.Warn("generateListenerAndFilterChains: failed to build listener for gateway: ", err.Error())
 				}
 			}
+			extension.AddWasmPluginsToMutableObjects(&mutable.MutableObjects, builder.push.WasmPlugins(builder.node))
 		}
 	}
 	listeners := make([]*listener.Listener, 0)

--- a/pilot/pkg/networking/core/v1alpha3/listener_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_builder.go
@@ -622,6 +622,7 @@ func (configgen *ConfigGeneratorImpl) buildInboundFilterchains(in *plugin.InputP
 			}
 		}
 	}
+	// only inject WasmPlugins for Sidecar inbound listeners and routers outbound listeners
 	if in.Node.Type == model.SidecarProxy {
 		extension.AddWasmPluginsToMutableObjects(mutable, in.Push.WasmPlugins(in.Node))
 	}

--- a/pilot/pkg/networking/core/v1alpha3/listener_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_builder.go
@@ -31,6 +31,7 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	istionetworking "istio.io/istio/pilot/pkg/networking"
 	"istio.io/istio/pilot/pkg/networking/core/v1alpha3/envoyfilter"
+	"istio.io/istio/pilot/pkg/networking/core/v1alpha3/extension"
 	istio_route "istio.io/istio/pilot/pkg/networking/core/v1alpha3/route"
 	"istio.io/istio/pilot/pkg/networking/plugin"
 	"istio.io/istio/pilot/pkg/networking/util"
@@ -620,6 +621,9 @@ func (configgen *ConfigGeneratorImpl) buildInboundFilterchains(in *plugin.InputP
 				log.Errorf("Build inbound filter chains error: %v", err)
 			}
 		}
+	}
+	if in.Node.Type == model.SidecarProxy {
+		extension.AddWasmPluginsToMutableObjects(mutable, in.Push.WasmPlugins(in.Node))
 	}
 	// Merge the results back into our struct
 	for i, fc := range mutable.FilterChains {

--- a/pilot/pkg/xds/ecds.go
+++ b/pilot/pkg/xds/ecds.go
@@ -41,9 +41,12 @@ func ecdsNeedsPush(req *model.PushRequest) bool {
 	if len(req.ConfigsUpdated) == 0 {
 		return true
 	}
-	// Only push if config updates is triggered by EnvoyFilter.
+	// Only push if config updates is triggered by EnvoyFilter or WasmPlugin.
 	for config := range req.ConfigsUpdated {
-		if config.Kind == gvk.EnvoyFilter {
+		switch config.Kind {
+		case gvk.EnvoyFilter:
+			return true
+		case gvk.WasmPlugin:
 			return true
 		}
 	}

--- a/pkg/config/schema/collections/collections.agent.gen.go
+++ b/pkg/config/schema/collections/collections.agent.gen.go
@@ -7,6 +7,7 @@ package collections
 import (
 	"reflect"
 
+	istioioapiextensionsv1alpha1 "istio.io/api/extensions/v1alpha1"
 	istioioapimeshv1alpha1 "istio.io/api/mesh/v1alpha1"
 	istioioapimetav1alpha1 "istio.io/api/meta/v1alpha1"
 	istioioapinetworkingv1alpha3 "istio.io/api/networking/v1alpha3"
@@ -18,6 +19,25 @@ import (
 )
 
 var (
+
+	// IstioExtensionsV1Alpha1Wasmplugins describes the collection
+	// istio/extensions/v1alpha1/wasmplugins
+	IstioExtensionsV1Alpha1Wasmplugins = collection.Builder{
+		Name:         "istio/extensions/v1alpha1/wasmplugins",
+		VariableName: "IstioExtensionsV1Alpha1Wasmplugins",
+		Disabled:     false,
+		Resource: resource.Builder{
+			Group:   "extensions.istio.io",
+			Kind:    "WasmPlugin",
+			Plural:  "wasmplugins",
+			Version: "v1alpha1",
+			Proto:   "istio.extensions.v1alpha1.WasmPlugin", StatusProto: "istio.meta.v1alpha1.IstioStatus",
+			ReflectType: reflect.TypeOf(&istioioapiextensionsv1alpha1.WasmPlugin{}).Elem(), StatusType: reflect.TypeOf(&istioioapimetav1alpha1.IstioStatus{}).Elem(),
+			ProtoPackage: "istio.io/api/extensions/v1alpha1", StatusPackage: "istio.io/api/meta/v1alpha1",
+			ClusterScoped: false,
+			ValidateProto: validation.ValidateWasmPlugin,
+		}.MustBuild(),
+	}.MustBuild()
 
 	// IstioMeshV1Alpha1MeshConfig describes the collection
 	// istio/mesh/v1alpha1/MeshConfig
@@ -287,6 +307,7 @@ var (
 
 	// All contains all collections in the system.
 	All = collection.NewSchemasBuilder().
+		MustAdd(IstioExtensionsV1Alpha1Wasmplugins).
 		MustAdd(IstioMeshV1Alpha1MeshConfig).
 		MustAdd(IstioMeshV1Alpha1MeshNetworks).
 		MustAdd(IstioNetworkingV1Alpha3Destinationrules).
@@ -305,6 +326,7 @@ var (
 
 	// Istio contains only Istio collections.
 	Istio = collection.NewSchemasBuilder().
+		MustAdd(IstioExtensionsV1Alpha1Wasmplugins).
 		MustAdd(IstioMeshV1Alpha1MeshConfig).
 		MustAdd(IstioMeshV1Alpha1MeshNetworks).
 		MustAdd(IstioNetworkingV1Alpha3Destinationrules).
@@ -327,6 +349,7 @@ var (
 
 	// Pilot contains only collections used by Pilot.
 	Pilot = collection.NewSchemasBuilder().
+		MustAdd(IstioExtensionsV1Alpha1Wasmplugins).
 		MustAdd(IstioNetworkingV1Alpha3Destinationrules).
 		MustAdd(IstioNetworkingV1Alpha3Envoyfilters).
 		MustAdd(IstioNetworkingV1Alpha3Gateways).
@@ -343,6 +366,7 @@ var (
 
 	// PilotGatewayAPI contains only collections used by Pilot, including experimental Service Api.
 	PilotGatewayAPI = collection.NewSchemasBuilder().
+			MustAdd(IstioExtensionsV1Alpha1Wasmplugins).
 			MustAdd(IstioNetworkingV1Alpha3Destinationrules).
 			MustAdd(IstioNetworkingV1Alpha3Envoyfilters).
 			MustAdd(IstioNetworkingV1Alpha3Gateways).

--- a/pkg/config/schema/collections/collections.gen.go
+++ b/pkg/config/schema/collections/collections.gen.go
@@ -14,6 +14,7 @@ import (
 	k8sioapiextensionsapiserverpkgapisapiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	sigsk8siogatewayapiapisv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
+	istioioapiextensionsv1alpha1 "istio.io/api/extensions/v1alpha1"
 	istioioapimeshv1alpha1 "istio.io/api/mesh/v1alpha1"
 	istioioapimetav1alpha1 "istio.io/api/meta/v1alpha1"
 	istioioapinetworkingv1alpha3 "istio.io/api/networking/v1alpha3"
@@ -25,6 +26,25 @@ import (
 )
 
 var (
+
+	// IstioExtensionsV1Alpha1Wasmplugins describes the collection
+	// istio/extensions/v1alpha1/wasmplugins
+	IstioExtensionsV1Alpha1Wasmplugins = collection.Builder{
+		Name:         "istio/extensions/v1alpha1/wasmplugins",
+		VariableName: "IstioExtensionsV1Alpha1Wasmplugins",
+		Disabled:     false,
+		Resource: resource.Builder{
+			Group:   "extensions.istio.io",
+			Kind:    "WasmPlugin",
+			Plural:  "wasmplugins",
+			Version: "v1alpha1",
+			Proto:   "istio.extensions.v1alpha1.WasmPlugin", StatusProto: "istio.meta.v1alpha1.IstioStatus",
+			ReflectType: reflect.TypeOf(&istioioapiextensionsv1alpha1.WasmPlugin{}).Elem(), StatusType: reflect.TypeOf(&istioioapimetav1alpha1.IstioStatus{}).Elem(),
+			ProtoPackage: "istio.io/api/extensions/v1alpha1", StatusPackage: "istio.io/api/meta/v1alpha1",
+			ClusterScoped: false,
+			ValidateProto: validation.ValidateWasmPlugin,
+		}.MustBuild(),
+	}.MustBuild()
 
 	// IstioMeshV1Alpha1MeshConfig describes the collection
 	// istio/mesh/v1alpha1/MeshConfig
@@ -475,6 +495,25 @@ var (
 		}.MustBuild(),
 	}.MustBuild()
 
+	// K8SExtensionsIstioIoV1Alpha1Wasmplugins describes the collection
+	// k8s/extensions.istio.io/v1alpha1/wasmplugins
+	K8SExtensionsIstioIoV1Alpha1Wasmplugins = collection.Builder{
+		Name:         "k8s/extensions.istio.io/v1alpha1/wasmplugins",
+		VariableName: "K8SExtensionsIstioIoV1Alpha1Wasmplugins",
+		Disabled:     false,
+		Resource: resource.Builder{
+			Group:   "extensions.istio.io",
+			Kind:    "WasmPlugin",
+			Plural:  "wasmplugins",
+			Version: "v1alpha1",
+			Proto:   "istio.extensions.v1alpha1.WasmPlugin", StatusProto: "istio.meta.v1alpha1.IstioStatus",
+			ReflectType: reflect.TypeOf(&istioioapiextensionsv1alpha1.WasmPlugin{}).Elem(), StatusType: reflect.TypeOf(&istioioapimetav1alpha1.IstioStatus{}).Elem(),
+			ProtoPackage: "istio.io/api/extensions/v1alpha1", StatusPackage: "istio.io/api/meta/v1alpha1",
+			ClusterScoped: false,
+			ValidateProto: validation.ValidateWasmPlugin,
+		}.MustBuild(),
+	}.MustBuild()
+
 	// K8SExtensionsV1Beta1Ingresses describes the collection
 	// k8s/extensions/v1beta1/ingresses
 	K8SExtensionsV1Beta1Ingresses = collection.Builder{
@@ -838,6 +877,7 @@ var (
 
 	// All contains all collections in the system.
 	All = collection.NewSchemasBuilder().
+		MustAdd(IstioExtensionsV1Alpha1Wasmplugins).
 		MustAdd(IstioMeshV1Alpha1MeshConfig).
 		MustAdd(IstioMeshV1Alpha1MeshNetworks).
 		MustAdd(IstioNetworkingV1Alpha3Destinationrules).
@@ -862,6 +902,7 @@ var (
 		MustAdd(K8SCoreV1Pods).
 		MustAdd(K8SCoreV1Secrets).
 		MustAdd(K8SCoreV1Services).
+		MustAdd(K8SExtensionsIstioIoV1Alpha1Wasmplugins).
 		MustAdd(K8SExtensionsV1Beta1Ingresses).
 		MustAdd(K8SGatewayApiV1Alpha2Gatewayclasses).
 		MustAdd(K8SGatewayApiV1Alpha2Gateways).
@@ -885,6 +926,7 @@ var (
 
 	// Istio contains only Istio collections.
 	Istio = collection.NewSchemasBuilder().
+		MustAdd(IstioExtensionsV1Alpha1Wasmplugins).
 		MustAdd(IstioMeshV1Alpha1MeshConfig).
 		MustAdd(IstioMeshV1Alpha1MeshNetworks).
 		MustAdd(IstioNetworkingV1Alpha3Destinationrules).
@@ -913,6 +955,7 @@ var (
 		MustAdd(K8SCoreV1Pods).
 		MustAdd(K8SCoreV1Secrets).
 		MustAdd(K8SCoreV1Services).
+		MustAdd(K8SExtensionsIstioIoV1Alpha1Wasmplugins).
 		MustAdd(K8SExtensionsV1Beta1Ingresses).
 		MustAdd(K8SGatewayApiV1Alpha2Gatewayclasses).
 		MustAdd(K8SGatewayApiV1Alpha2Gateways).
@@ -936,6 +979,7 @@ var (
 
 	// Pilot contains only collections used by Pilot.
 	Pilot = collection.NewSchemasBuilder().
+		MustAdd(IstioExtensionsV1Alpha1Wasmplugins).
 		MustAdd(IstioNetworkingV1Alpha3Destinationrules).
 		MustAdd(IstioNetworkingV1Alpha3Envoyfilters).
 		MustAdd(IstioNetworkingV1Alpha3Gateways).
@@ -952,6 +996,7 @@ var (
 
 	// PilotGatewayAPI contains only collections used by Pilot, including experimental Service Api.
 	PilotGatewayAPI = collection.NewSchemasBuilder().
+			MustAdd(IstioExtensionsV1Alpha1Wasmplugins).
 			MustAdd(IstioNetworkingV1Alpha3Destinationrules).
 			MustAdd(IstioNetworkingV1Alpha3Envoyfilters).
 			MustAdd(IstioNetworkingV1Alpha3Gateways).

--- a/pkg/config/schema/fuzz_test.go
+++ b/pkg/config/schema/fuzz_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 
 	authentication "istio.io/api/authentication/v1alpha1"
+	extensions "istio.io/api/extensions/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
 	security "istio.io/api/security/v1beta1"
 	telemetry "istio.io/api/telemetry/v1alpha1"
@@ -186,6 +187,18 @@ func fixProtoFuzzer(codecs serializer.CodecFactory) []interface{} {
 		},
 		func(t *telemetry.MetricSelector, c fuzz.Continue) {
 			*t = telemetry.MetricSelector{}
+		},
+		func(t *extensions.WasmPlugin, c fuzz.Continue) {
+			if c.RandBool() {
+				*t = extensions.WasmPlugin{
+					XSha256: nil,
+				}
+			} else {
+				*t = extensions.WasmPlugin{
+					XSha256: &extensions.WasmPlugin_Sha256{Sha256: ""},
+				}
+			}
+			c.Fuzz(t)
 		},
 	}
 }

--- a/pkg/config/schema/gvk/resources.gen.go
+++ b/pkg/config/schema/gvk/resources.gen.go
@@ -38,6 +38,7 @@ var (
 	TLSRoute = config.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Kind: "TLSRoute"}
 	Telemetry = config.GroupVersionKind{Group: "telemetry.istio.io", Version: "v1alpha1", Kind: "Telemetry"}
 	VirtualService = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1alpha3", Kind: "VirtualService"}
+	WasmPlugin = config.GroupVersionKind{Group: "extensions.istio.io", Version: "v1alpha1", Kind: "WasmPlugin"}
 	WorkloadEntry = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1alpha3", Kind: "WorkloadEntry"}
 	WorkloadGroup = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1alpha3", Kind: "WorkloadGroup"}
 )

--- a/pkg/config/schema/metadata.gen.go
+++ b/pkg/config/schema/metadata.gen.go
@@ -75,6 +75,11 @@ var _metadataYaml = []byte(`# Copyright 2019 Istio Authors
 # The total set of collections, both Istio (i.e. MCP) and K8s (API Server/K8s).
 collections:
   ## Istio collections
+  - name: "istio/extensions/v1alpha1/wasmplugins"
+    kind: "WasmPlugin"
+    group: "extensions.istio.io"
+    pilot: true
+
   - name: "istio/mesh/v1alpha1/MeshConfig"
     kind: "MeshConfig"
     group: ""
@@ -215,6 +220,10 @@ collections:
     group: "gateway.networking.k8s.io"
 
   # Istio CRD collections
+  - name: "k8s/extensions.istio.io/v1alpha1/wasmplugins"
+    kind: WasmPlugin
+    group: "extensions.istio.io"
+
   - name: "k8s/networking.istio.io/v1alpha3/destinationrules"
     kind: DestinationRule
     group: "networking.istio.io"
@@ -269,6 +278,7 @@ snapshots:
   - name: "default"
     strategy: debounce
     collections:
+      - "istio/extensions/v1alpha1/wasmplugins"
       - "istio/mesh/v1alpha1/MeshConfig"
       - "istio/networking/v1alpha3/destinationrules"
       - "istio/networking/v1alpha3/envoyfilters"
@@ -576,12 +586,23 @@ resources:
     statusProto: "istio.meta.v1alpha1.IstioStatus"
     statusProtoPackage: "istio.io/api/meta/v1alpha1"
 
+  - kind: "WasmPlugin"
+    plural: "wasmplugins"
+    group: "extensions.istio.io"
+    version: "v1alpha1"
+    proto: "istio.extensions.v1alpha1.WasmPlugin"
+    protoPackage: "istio.io/api/extensions/v1alpha1"
+    description: ""
+    statusProto: "istio.meta.v1alpha1.IstioStatus"
+    statusProtoPackage: "istio.io/api/meta/v1alpha1"
+
 # Transform specific configurations
 transforms:
   - type: direct
     mapping:
       "k8s/apiextensions.k8s.io/v1/customresourcedefinitions": "k8s/apiextensions.k8s.io/v1/customresourcedefinitions"
       "k8s/admissionregistration.k8s.io/v1/mutatingwebhookconfigurations": "k8s/admissionregistration.k8s.io/v1/mutatingwebhookconfigurations"
+      "k8s/extensions.istio.io/v1alpha1/wasmplugins": "istio/extensions/v1alpha1/wasmplugins"
       "k8s/networking.istio.io/v1alpha3/destinationrules": "istio/networking/v1alpha3/destinationrules"
       "k8s/networking.istio.io/v1alpha3/envoyfilters": "istio/networking/v1alpha3/envoyfilters"
       "k8s/networking.istio.io/v1alpha3/gateways": "istio/networking/v1alpha3/gateways"

--- a/pkg/config/schema/metadata.yaml
+++ b/pkg/config/schema/metadata.yaml
@@ -20,6 +20,11 @@
 # The total set of collections, both Istio (i.e. MCP) and K8s (API Server/K8s).
 collections:
   ## Istio collections
+  - name: "istio/extensions/v1alpha1/wasmplugins"
+    kind: "WasmPlugin"
+    group: "extensions.istio.io"
+    pilot: true
+
   - name: "istio/mesh/v1alpha1/MeshConfig"
     kind: "MeshConfig"
     group: ""
@@ -160,6 +165,10 @@ collections:
     group: "gateway.networking.k8s.io"
 
   # Istio CRD collections
+  - name: "k8s/extensions.istio.io/v1alpha1/wasmplugins"
+    kind: WasmPlugin
+    group: "extensions.istio.io"
+
   - name: "k8s/networking.istio.io/v1alpha3/destinationrules"
     kind: DestinationRule
     group: "networking.istio.io"
@@ -214,6 +223,7 @@ snapshots:
   - name: "default"
     strategy: debounce
     collections:
+      - "istio/extensions/v1alpha1/wasmplugins"
       - "istio/mesh/v1alpha1/MeshConfig"
       - "istio/networking/v1alpha3/destinationrules"
       - "istio/networking/v1alpha3/envoyfilters"
@@ -521,12 +531,23 @@ resources:
     statusProto: "istio.meta.v1alpha1.IstioStatus"
     statusProtoPackage: "istio.io/api/meta/v1alpha1"
 
+  - kind: "WasmPlugin"
+    plural: "wasmplugins"
+    group: "extensions.istio.io"
+    version: "v1alpha1"
+    proto: "istio.extensions.v1alpha1.WasmPlugin"
+    protoPackage: "istio.io/api/extensions/v1alpha1"
+    description: ""
+    statusProto: "istio.meta.v1alpha1.IstioStatus"
+    statusProtoPackage: "istio.io/api/meta/v1alpha1"
+
 # Transform specific configurations
 transforms:
   - type: direct
     mapping:
       "k8s/apiextensions.k8s.io/v1/customresourcedefinitions": "k8s/apiextensions.k8s.io/v1/customresourcedefinitions"
       "k8s/admissionregistration.k8s.io/v1/mutatingwebhookconfigurations": "k8s/admissionregistration.k8s.io/v1/mutatingwebhookconfigurations"
+      "k8s/extensions.istio.io/v1alpha1/wasmplugins": "istio/extensions/v1alpha1/wasmplugins"
       "k8s/networking.istio.io/v1alpha3/destinationrules": "istio/networking/v1alpha3/destinationrules"
       "k8s/networking.istio.io/v1alpha3/envoyfilters": "istio/networking/v1alpha3/envoyfilters"
       "k8s/networking.istio.io/v1alpha3/gateways": "istio/networking/v1alpha3/gateways"

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -3485,7 +3485,7 @@ var ValidateWasmPlugin = registerValidateFunc("ValidateWasmPlugin",
 	func(cfg config.Config) (Warning, error) {
 		spec, ok := cfg.Spec.(*extensions.WasmPlugin)
 		if !ok {
-			return nil, fmt.Errorf("cannot cast to service entry")
+			return nil, fmt.Errorf("cannot cast to wasmplugin")
 		}
 
 		errs := Validation{}

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -3517,18 +3517,14 @@ func validateWasmPluginURL(pluginURL string) error {
 
 func validateWasmPluginSHA(plugin *extensions.WasmPlugin) error {
 	if plugin.XSha256 == nil {
-		if strings.HasPrefix(plugin.Url, "http") {
-			return fmt.Errorf("sha256 field must be set when fetching .wasm module from HTTP(s) URL")
-		}
 		return nil
 	}
 	if len(plugin.GetSha256()) != 64 {
 		return fmt.Errorf("sha256 field must be 64 characters long")
 	}
-	validCharacters := "0123456789abcdef"
-	for _, char := range plugin.GetSha256() {
-		if !strings.ContainsRune(validCharacters, char) {
-			return fmt.Errorf("sha256 field must be alphanumeric: %s", plugin.GetSha256())
+	for _, r := range plugin.GetSha256() {
+		if !('a' <= r && r <= 'z' || '0' <= r && r <= '9') {
+			return fmt.Errorf("sha256 field must match [a-z0-9]{64} pattern")
 		}
 	}
 	return nil

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -3523,8 +3523,8 @@ func validateWasmPluginSHA(plugin *extensions.WasmPlugin) error {
 		return fmt.Errorf("sha256 field must be 64 characters long")
 	}
 	for _, r := range plugin.GetSha256() {
-		if !('a' <= r && r <= 'z' || '0' <= r && r <= '9') {
-			return fmt.Errorf("sha256 field must match [a-z0-9]{64} pattern")
+		if !('a' <= r && r <= 'f' || '0' <= r && r <= '9') {
+			return fmt.Errorf("sha256 field must match [a-f0-9]{64} pattern")
 		}
 	}
 	return nil

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
 	"path"
 	"regexp"
 	"strconv"
@@ -38,6 +39,7 @@ import (
 	"google.golang.org/protobuf/types/descriptorpb"
 
 	"istio.io/api/annotation"
+	extensions "istio.io/api/extensions/v1alpha1"
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
 	security_beta "istio.io/api/security/v1beta1"
@@ -3473,6 +3475,60 @@ func validateTelemetryProviders(providers []*telemetry.ProviderRef) error {
 	for _, p := range providers {
 		if p == nil || p.Name == "" {
 			return fmt.Errorf("providers.name may not be empty")
+		}
+	}
+	return nil
+}
+
+// ValidateWasmPlugin validates a WasmPlugin.
+var ValidateWasmPlugin = registerValidateFunc("ValidateWasmPlugin",
+	func(cfg config.Config) (Warning, error) {
+		spec, ok := cfg.Spec.(*extensions.WasmPlugin)
+		if !ok {
+			return nil, fmt.Errorf("cannot cast to service entry")
+		}
+
+		errs := Validation{}
+		errs = appendValidation(errs,
+			validateWorkloadSelector(spec.Selector),
+			validateWasmPluginURL(spec.Url),
+			validateWasmPluginSHA(spec),
+		)
+		return errs.Unwrap()
+	})
+
+func validateWasmPluginURL(pluginURL string) error {
+	if pluginURL == "" {
+		return fmt.Errorf("url field needs to be set")
+	}
+	validSchemes := map[string]bool{
+		"": true, "file": true, "http": true, "https": true, "oci": true,
+	}
+
+	u, err := url.Parse(pluginURL)
+	if err != nil {
+		return fmt.Errorf("failed to parse url: %s", err)
+	}
+	if _, found := validSchemes[u.Scheme]; !found {
+		return fmt.Errorf("url contains unsupported scheme: %s", u.Scheme)
+	}
+	return nil
+}
+
+func validateWasmPluginSHA(plugin *extensions.WasmPlugin) error {
+	if plugin.XSha256 == nil {
+		if strings.HasPrefix(plugin.Url, "http") {
+			return fmt.Errorf("sha256 field must be set when fetching .wasm module from HTTP(s) URL")
+		}
+		return nil
+	}
+	if len(plugin.GetSha256()) != 64 {
+		return fmt.Errorf("sha256 field must be 64 characters long")
+	}
+	validCharacters := "0123456789abcdef"
+	for _, char := range plugin.GetSha256() {
+		if !strings.ContainsRune(validCharacters, char) {
+			return fmt.Errorf("sha256 field must be alphanumeric: %s", plugin.GetSha256())
 		}
 	}
 	return nil

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -6698,6 +6698,13 @@ func TestValidateWasmPlugin(t *testing.T) {
 			"valid http",
 			&extensions.WasmPlugin{
 				Url: "http://test.com/test",
+			},
+			"", "",
+		},
+		{
+			"valid http w/ sha",
+			&extensions.WasmPlugin{
+				Url: "http://test.com/test",
 				XSha256: &extensions.WasmPlugin_Sha256{
 					Sha256: "01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b",
 				},
@@ -6725,7 +6732,24 @@ func TestValidateWasmPlugin(t *testing.T) {
 			"sha256 field must be 64 characters long", "",
 		},
 		{
+			"invalid sha characters",
+			&extensions.WasmPlugin{
+				Url: "http://test.com/test",
+				XSha256: &extensions.WasmPlugin_Sha256{
+					Sha256: "01Ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b",
+				},
+			},
+			"sha256 field must match [a-z0-9]{64} pattern", "",
+		},
+		{
 			"valid oci",
+			&extensions.WasmPlugin{
+				Url: "oci://test.com/test",
+			},
+			"", "",
+		},
+		{
+			"valid oci no scheme",
 			&extensions.WasmPlugin{
 				Url: "test.com/test",
 			},

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gogo/protobuf/types"
 	"github.com/hashicorp/go-multierror"
 
+	extensions "istio.io/api/extensions/v1alpha1"
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
 	security_beta "istio.io/api/security/v1beta1"
@@ -6666,6 +6667,74 @@ func TestValidateTelemetry(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			warn, err := ValidateTelemetry(config.Config{
+				Meta: config.Meta{
+					Name:      someName,
+					Namespace: someNamespace,
+				},
+				Spec: tt.in,
+			})
+			checkValidationMessage(t, warn, err, tt.warning, tt.out)
+		})
+	}
+}
+
+func TestValidateWasmPlugin(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      proto.Message
+		out     string
+		warning string
+	}{
+		{"empty", &extensions.WasmPlugin{}, "url field needs to be set", ""},
+		{"invalid message", &networking.Server{}, "cannot cast", ""},
+		{
+			"wrong scheme",
+			&extensions.WasmPlugin{
+				Url: "ftp://test.com/test",
+			},
+			"unsupported scheme", "",
+		},
+		{
+			"valid http",
+			&extensions.WasmPlugin{
+				Url: "http://test.com/test",
+				XSha256: &extensions.WasmPlugin_Sha256{
+					Sha256: "01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b",
+				},
+			},
+			"", "",
+		},
+		{
+			"short sha",
+			&extensions.WasmPlugin{
+				Url: "http://test.com/test",
+				XSha256: &extensions.WasmPlugin_Sha256{
+					Sha256: "01ba47",
+				},
+			},
+			"sha256 field must be 64 characters long", "",
+		},
+		{
+			"invalid sha",
+			&extensions.WasmPlugin{
+				Url: "http://test.com/test",
+				XSha256: &extensions.WasmPlugin_Sha256{
+					Sha256: "test",
+				},
+			},
+			"sha256 field must be 64 characters long", "",
+		},
+		{
+			"valid oci",
+			&extensions.WasmPlugin{
+				Url: "test.com/test",
+			},
+			"", "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			warn, err := ValidateWasmPlugin(config.Config{
 				Meta: config.Meta{
 					Name:      someName,
 					Namespace: someNamespace,

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -6739,7 +6739,7 @@ func TestValidateWasmPlugin(t *testing.T) {
 					Sha256: "01Ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b",
 				},
 			},
-			"sha256 field must match [a-z0-9]{64} pattern", "",
+			"sha256 field must match [a-f0-9]{64} pattern", "",
 		},
 		{
 			"valid oci",

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -76,6 +76,7 @@ import (
 	mcsapisInformer "sigs.k8s.io/mcs-api/pkg/client/informers/externalversions"
 
 	"istio.io/api/label"
+	clientextensions "istio.io/client-go/pkg/apis/extensions/v1alpha1"
 	clientnetworkingalpha "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	clientnetworkingbeta "istio.io/client-go/pkg/apis/networking/v1beta1"
 	clientsecurity "istio.io/client-go/pkg/apis/security/v1beta1"
@@ -1050,6 +1051,7 @@ var IstioScheme = func() *runtime.Scheme {
 	utilruntime.Must(clientnetworkingbeta.AddToScheme(scheme))
 	utilruntime.Must(clientsecurity.AddToScheme(scheme))
 	utilruntime.Must(clienttelemetry.AddToScheme(scheme))
+	utilruntime.Must(clientextensions.AddToScheme(scheme))
 	utilruntime.Must(gatewayapi.AddToScheme(scheme))
 	utilruntime.Must(mcsapi.AddToScheme(scheme))
 	return scheme

--- a/pkg/wasm/convert.go
+++ b/pkg/wasm/convert.go
@@ -110,7 +110,7 @@ func convert(resource *any.Any, cache Cache) (newExtensionConfig *any.Any, sendN
 
 	wasmHTTPFilterConfig := &wasm.Wasm{}
 	// Wasm filter can be configured using typed struct and Wasm filter type
-	wasmLog.Infof("original extension config resource %+v", ec)
+	wasmLog.Debugf("original extension config resource %+v", ec)
 	if ec.GetTypedConfig() != nil && ec.GetTypedConfig().TypeUrl == wasmHTTPFilterType {
 		err := ec.GetTypedConfig().UnmarshalTo(wasmHTTPFilterConfig)
 		if err != nil {

--- a/pkg/wasm/convert.go
+++ b/pkg/wasm/convert.go
@@ -108,29 +108,36 @@ func convert(resource *any.Any, cache Cache) (newExtensionConfig *any.Any, sendN
 		return
 	}
 
-	// Currently Wasm filter can only be configured using typed struct via EnvoyFilter.
-	wasmLog.Debugf("original extension config resource %+v", ec)
-	if ec.GetTypedConfig() == nil && ec.GetTypedConfig().TypeUrl != typedStructType {
+	wasmHTTPFilterConfig := &wasm.Wasm{}
+	// Wasm filter can be configured using typed struct and Wasm filter type
+	wasmLog.Infof("original extension config resource %+v", ec)
+	if ec.GetTypedConfig() != nil && ec.GetTypedConfig().TypeUrl == wasmHTTPFilterType {
+		err := ec.GetTypedConfig().UnmarshalTo(wasmHTTPFilterConfig)
+		if err != nil {
+			wasmLog.Debugf("failed to unmarshal extension config resource into Wasm HTTP filter: %v", err)
+			return
+		}
+	} else if ec.GetTypedConfig() == nil || ec.GetTypedConfig().TypeUrl != typedStructType {
 		wasmLog.Debugf("cannot find typed struct in %+v", ec)
 		return
-	}
-	wasmStruct := &udpa.TypedStruct{}
-	wasmTypedConfig := ec.GetTypedConfig()
-	// nolint: staticcheck
-	if err := ptypes.UnmarshalAny(wasmTypedConfig, wasmStruct); err != nil {
-		wasmLog.Debugf("failed to unmarshal typed config for wasm filter: %v", err)
-		return
-	}
+	} else {
+		wasmStruct := &udpa.TypedStruct{}
+		wasmTypedConfig := ec.GetTypedConfig()
+		// nolint: staticcheck
+		if err := ptypes.UnmarshalAny(wasmTypedConfig, wasmStruct); err != nil {
+			wasmLog.Debugf("failed to unmarshal typed config for wasm filter: %v", err)
+			return
+		}
 
-	if wasmStruct.TypeUrl != wasmHTTPFilterType {
-		wasmLog.Debugf("typed extension config %+v does not contain wasm http filter", wasmStruct)
-		return
-	}
+		if wasmStruct.TypeUrl != wasmHTTPFilterType {
+			wasmLog.Debugf("typed extension config %+v does not contain wasm http filter", wasmStruct)
+			return
+		}
 
-	wasmHTTPFilterConfig := &wasm.Wasm{}
-	if err := conversion.StructToMessage(wasmStruct.Value, wasmHTTPFilterConfig); err != nil {
-		wasmLog.Debugf("failed to convert extension config struct %+v to Wasm HTTP filter", wasmStruct)
-		return
+		if err := conversion.StructToMessage(wasmStruct.Value, wasmHTTPFilterConfig); err != nil {
+			wasmLog.Debugf("failed to convert extension config struct %+v to Wasm HTTP filter", wasmStruct)
+			return
+		}
 	}
 
 	if wasmHTTPFilterConfig.Config.GetVmConfig().GetCode().GetRemote() == nil {
@@ -178,7 +185,7 @@ func convert(resource *any.Any, cache Cache) (newExtensionConfig *any.Any, sendN
 		},
 	}
 
-	wasmTypedConfig, err = anypb.New(wasmHTTPFilterConfig)
+	wasmTypedConfig, err := anypb.New(wasmHTTPFilterConfig)
 	if err != nil {
 		status = marshalFailure
 		wasmLog.Errorf("failed to marshal new wasm HTTP filter %+v to protobuf Any: %v", wasmHTTPFilterConfig, err)

--- a/pkg/wasm/convert.go
+++ b/pkg/wasm/convert.go
@@ -152,6 +152,10 @@ func convert(resource *any.Any, cache Cache) (newExtensionConfig *any.Any, sendN
 		wasmLog.Errorf("wasm remote fetch %+v does not have httpUri specified", remote)
 		return
 	}
+	// checksum sent by istiod can be "nil" if not set by user - magic value used to avoid unmarshaling errors
+	if remote.Sha256 == "nil" {
+		remote.Sha256 = ""
+	}
 	timeout := time.Duration(0)
 	if remote.GetHttpUri().Timeout != nil {
 		timeout = remote.GetHttpUri().Timeout.AsDuration()

--- a/releasenotes/notes/wasmplugin.yaml
+++ b/releasenotes/notes/wasmplugin.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: feature
+area: telemetry
+issue: []
+releaseNotes:
+  - |
+    **Added** support for Istio WasmPlugin API

--- a/releasenotes/notes/wasmplugin.yaml
+++ b/releasenotes/notes/wasmplugin.yaml
@@ -1,6 +1,6 @@
 apiVersion: release-notes/v2
 kind: feature
-area: telemetry
+area: extensibility
 issue: []
 releaseNotes:
   - |

--- a/tests/integration/telemetry/stats/prometheus/wasm/bad_wasm_filter_test.go
+++ b/tests/integration/telemetry/stats/prometheus/wasm/bad_wasm_filter_test.go
@@ -92,7 +92,7 @@ func TestBadWasmRemoteLoad(t *testing.T) {
 					return err
 				}
 				return nil
-			}, retry.Delay(1*time.Millisecond), retry.Timeout(5*time.Second))
+			}, retry.Delay(1*time.Millisecond), retry.Timeout(10*time.Second))
 
 			t.Log("echo server still returns ok after bad wasm filter is applied.")
 		})

--- a/tests/integration/telemetry/stats/prometheus/wasm/testdata/bad-filter.yaml
+++ b/tests/integration/telemetry/stats/prometheus/wasm/testdata/bad-filter.yaml
@@ -1,55 +1,7 @@
-apiVersion: networking.istio.io/v1alpha3
-kind: EnvoyFilter
-metadata:
-  name: bad-filter
-spec:
-  configPatches:
-  - applyTo: HTTP_FILTER
-    match:
-      context: ANY
-      listener:
-        filterChain:
-          filter:
-            name: envoy.http_connection_manager
-            subFilter:
-              name: "envoy.filters.http.router"
-    patch:
-      operation: INSERT_BEFORE
-      value:
-        name: bad-filter
-        config_discovery:
-          config_source:
-            ads: {}
-            initial_fetch_timeout: 0s # wait indefinitely to prevent filter chain being disabled
-          type_urls: [ "type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm"]
----
-apiVersion: networking.istio.io/v1alpha3
-kind: EnvoyFilter
+apiVersion: extensions.istio.io/v1alpha1
+kind: WasmPlugin
 metadata:
   name: bad-filter-config
 spec:
-  configPatches:
-  - applyTo: EXTENSION_CONFIG
-    match:
-      context: ANY
-    patch:
-      operation: ADD
-      value:
-        name: bad-filter
-        typed_config:
-          "@type": type.googleapis.com/udpa.type.v1.TypedStruct
-          type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
-          value:
-            config:
-              vm_config:
-                vm_id: bad_vm
-                runtime: envoy.wasm.runtime.v8
-                code:
-                  remote:
-                    http_uri:
-                      uri: https://bad-url.wasm
-                      timeout: 10s
-              configuration:
-                '@type': type.googleapis.com/google.protobuf.StringValue
-                value: |
-                  {}
+  url: https://bad-url.wasm
+  sha256: f2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2


### PR DESCRIPTION
This is the implementation of the API introduced in https://github.com/istio/api/pull/1940.

What works:
- reading of WasmPlugin CRD, pushing updates through ECDS
- deploying filters hosted on HTTP(S) servers or present locally in the proxy container
- fetching OCI containers (as soon as https://github.com/istio/istio/pull/34430 is merged)
- phase+priority


What's missing:
- image pull secrets
- signature verification

these two will be added later

@mandarjog @douglas-reid @bianpengyuan @jwendell