### PR TITLE
fix dns resolve for service entry with multi addresses

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/name_table.go
+++ b/pilot/pkg/networking/core/v1alpha3/name_table.go
@@ -119,6 +119,10 @@ func (configgen *ConfigGeneratorImpl) BuildNameTable(node *model.Proxy, push *mo
 			nameInfo.Namespace = svc.Attributes.Namespace
 			nameInfo.Shortname = svc.Attributes.Name
 		}
+
+		if ni, ok := out.Table[string(svc.Hostname)]; ok {
+			nameInfo.Ips = append(nameInfo.Ips, ni.Ips...)
+		}
 		out.Table[string(svc.Hostname)] = nameInfo
 	}
 	return out


### PR DESCRIPTION

dns resolve for service entry with multi addresses only get the last address.
For example, create a service entry as below.

```yaml
apiVersion: networking.istio.io/v1beta1
kind: ServiceEntry
metadata:
  name: all-tcp-external
  namespace: istio-demo
spec:
  addresses:
  - 192.168.0.204/32
  - 192.168.0.231/32
  hosts:
  - www.example.com
  location: MESH_EXTERNAL
  ports:
  - name: http
    number: 80
```

And try to dig `www.example.com` in a pod with sidecar injected, will only get the last address(192.168.0.231 in this example).

```bash
[root@debian-77dc9c5f4f-nscvz /]# dig www.example.com

; <<>> DiG 9.11.4-P2-RedHat-9.11.4-26.P2.el7_9.5 <<>> www.example.com
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 54996
;; flags: qr aa rd; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0
;; WARNING: recursion requested but not available

;; QUESTION SECTION:
;www.example.com.		IN	A

;; ANSWER SECTION:
www.example.com.	30	IN	A	192.168.0.231

;; Query time: 0 msec
;; SERVER: 10.96.0.10#53(10.96.0.10)
;; WHEN: Thu Jun 10 14:06:59 UTC 2021
;; MSG SIZE  rcvd: 64
```

we know pilot-discovery converts service entry with multi addresses to multi services.
`pilot/pkg/serviceregistry/serviceentry/conversion.go:buildServices`

```go
func buildServices(hostAddresses []*HostAddress, namespace string, ports model.PortList, location networking.ServiceEntry_Location,
	resolution model.Resolution, exportTo map[visibility.Instance]bool, selectors map[string]string, saccounts []string,
	ctime time.Time, labels map[string]string) []*model.Service {
	out := make([]*model.Service, 0, len(hostAddresses))
	for _, ha := range hostAddresses {
		out = append(out, &model.Service{
			CreationTime: ctime,
			MeshExternal: location == networking.ServiceEntry_MESH_EXTERNAL,
			Hostname:     host.Name(ha.host),
			Address:      ha.address,
...
		})
	}
	return out
}
```

So in `BuildNameTable` when responding xds messages to sidecar, it stores the `nameInfo` to `out.Table[string(svc.Hostname)]` without checking whether `svc.Hostname` is exist in `out.Table` or not.

Thus will cause the `out.Table` only contains the last address of service entry, and name resolve on sidecar will only get the last address.
`pilot/pkg/networking/core/v1alpha3/name_table.go:BuildNameTable`

```go
func (configgen *ConfigGeneratorImpl) BuildNameTable(node *model.Proxy, push *model.PushContext) *nds.NameTable {
...
	out := &nds.NameTable{
		Table: map[string]*nds.NameTable_NameInfo{},
	}
	for _, svc := range push.Services(node) {
...
		nameInfo := &nds.NameTable_NameInfo{
			Ips:      addressList,
			Registry: svc.Attributes.ServiceRegistry,
		}
		if svc.Attributes.ServiceRegistry == string(serviceregistry.Kubernetes) {
			// The agent will take care of resolving a, a.ns, a.ns.svc, etc.
			// No need to provide a DNS entry for each variant.
			nameInfo.Namespace = svc.Attributes.Namespace
			nameInfo.Shortname = svc.Attributes.Name
		}
		out.Table[string(svc.Hostname)] = nameInfo
```

This PR will append the Ips of prev `nameInfo` in `out.Table` with the same `svc.Hostname` to the current `nameInfo`, and dig will get all IP addresses for host of service entry.

```bash
[root@debian-77dc9c5f4f-nscvz /]# dig www.example.com

; <<>> DiG 9.11.4-P2-RedHat-9.11.4-26.P2.el7_9.5 <<>> www.example.com
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 58814
;; flags: qr aa rd; QUERY: 1, ANSWER: 2, AUTHORITY: 0, ADDITIONAL: 0
;; WARNING: recursion requested but not available

;; QUESTION SECTION:
;www.example.com.		IN	A

;; ANSWER SECTION:
www.example.com.	30	IN	A	192.168.0.231
www.example.com.	30	IN	A	192.168.0.204

;; Query time: 0 msec
;; SERVER: 10.96.0.10#53(10.96.0.10)
;; WHEN: Thu Jun 10 14:33:48 UTC 2021
;; MSG SIZE  rcvd: 95
```



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.