### PR TITLE
No need to apply istio-root-ca-cert configmap to special kubernetes system namespaces.

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/namespacecontroller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/namespacecontroller.go
@@ -16,6 +16,7 @@ package controller
 
 import (
 	"fmt"
+	"istio.io/istio/pkg/kube/inject"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -144,6 +145,13 @@ func (nc *NamespaceController) insertDataForNamespace(ns string) error {
 // On namespace change, update the config map.
 // If terminating, this will be skipped
 func (nc *NamespaceController) namespaceChange(ns *v1.Namespace) error {
+	// skip special kubernetes system namespaces
+	for _, namespace := range inject.IgnoredNamespaces {
+		if ns.Name == namespace {
+			return nil
+		}
+	}
+
 	if ns.Status.Phase != v1.NamespaceTerminating {
 		return nc.insertDataForNamespace(ns.Name)
 	}

--- a/pilot/pkg/serviceregistry/kube/controller/namespacecontroller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/namespacecontroller.go
@@ -16,7 +16,6 @@ package controller
 
 import (
 	"fmt"
-	"istio.io/istio/pkg/kube/inject"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -26,6 +25,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/kube/inject"
 	"istio.io/istio/pkg/queue"
 	"istio.io/istio/security/pkg/k8s"
 )

--- a/pilot/pkg/serviceregistry/kube/controller/namespacecontroller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/namespacecontroller_test.go
@@ -17,6 +17,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"istio.io/istio/pkg/kube/inject"
 	"reflect"
 	"testing"
 	"time"
@@ -51,9 +52,13 @@ func TestNamespaceController(t *testing.T) {
 		t.Fatal(err)
 	}
 	expectConfigMap(t, nc.configmapLister, "foo", newData)
-
 	deleteConfigMap(t, client, "foo")
 	expectConfigMap(t, nc.configmapLister, "foo", testdata)
+
+	for _, namespace := range inject.IgnoredNamespaces {
+		createNamespace(t, client, namespace, testdata)
+		expectConfigMapNotExist(t, nc.configmapLister, namespace)
+	}
 }
 
 func deleteConfigMap(t *testing.T, client kubernetes.Interface, ns string) {
@@ -97,4 +102,19 @@ func expectConfigMap(t *testing.T, client listerv1.ConfigMapLister, ns string, d
 		}
 		return nil
 	}, retry.Timeout(time.Second*2))
+}
+
+func expectConfigMapNotExist(t *testing.T, client listerv1.ConfigMapLister, ns string) {
+	t.Helper()
+	err := retry.Until(func() bool {
+		_, err := client.ConfigMaps(ns).Get(CACertNamespaceConfigMap)
+		if err != nil {
+			return false
+		}
+		return true
+	}, retry.Timeout(time.Second*2))
+
+	if err == nil {
+		t.Fatalf("%s namespace should not have istio-ca-root-cert configmap.", ns)
+	}
 }

--- a/pilot/pkg/serviceregistry/kube/controller/namespacecontroller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/namespacecontroller_test.go
@@ -52,6 +52,7 @@ func TestNamespaceController(t *testing.T) {
 		t.Fatal(err)
 	}
 	expectConfigMap(t, nc.configmapLister, "foo", newData)
+
 	deleteConfigMap(t, client, "foo")
 	expectConfigMap(t, nc.configmapLister, "foo", testdata)
 

--- a/pilot/pkg/serviceregistry/kube/controller/namespacecontroller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/namespacecontroller_test.go
@@ -109,10 +109,7 @@ func expectConfigMapNotExist(t *testing.T, client listerv1.ConfigMapLister, ns s
 	t.Helper()
 	err := retry.Until(func() bool {
 		_, err := client.ConfigMaps(ns).Get(CACertNamespaceConfigMap)
-		if err != nil {
-			return false
-		}
-		return true
+		return err == nil
 	}, retry.Timeout(time.Second*2))
 
 	if err == nil {

--- a/pilot/pkg/serviceregistry/kube/controller/namespacecontroller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/namespacecontroller_test.go
@@ -17,7 +17,6 @@ package controller
 import (
 	"context"
 	"fmt"
-	"istio.io/istio/pkg/kube/inject"
 	"reflect"
 	"testing"
 	"time"
@@ -28,6 +27,7 @@ import (
 	listerv1 "k8s.io/client-go/listers/core/v1"
 
 	"istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/kube/inject"
 	"istio.io/istio/pkg/test/util/retry"
 	"istio.io/istio/security/pkg/k8s"
 )

--- a/pkg/kube/inject/initializer.go
+++ b/pkg/kube/inject/initializer.go
@@ -25,7 +25,7 @@ import (
 	"istio.io/istio/pkg/config/constants"
 )
 
-var ignoredNamespaces = []string{
+var IgnoredNamespaces = []string{
 	constants.KubeSystemNamespace,
 	constants.KubePublicNamespace,
 	constants.KubeNodeLeaseNamespace,

--- a/pkg/kube/inject/inject.go
+++ b/pkg/kube/inject/inject.go
@@ -669,7 +669,7 @@ func IntoObject(injector Injector, sidecarTemplate Templates, valuesConfig strin
 		return nil, err
 	}
 	if patchBytes == nil {
-		if !injectRequired(ignoredNamespaces, &Config{Policy: InjectionPolicyEnabled}, &pod.Spec, pod.ObjectMeta) {
+		if !injectRequired(IgnoredNamespaces, &Config{Policy: InjectionPolicyEnabled}, &pod.Spec, pod.ObjectMeta) {
 			warningHandler(fmt.Sprintf("===> Skipping injection because %q has sidecar injection disabled\n", name))
 			return out, nil
 		}

--- a/pkg/kube/inject/webhook.go
+++ b/pkg/kube/inject/webhook.go
@@ -722,7 +722,7 @@ func (wh *Webhook) inject(ar *kube.AdmissionReview, path string) *kube.Admission
 	log.Debugf("OldObject: %v", string(req.OldObject.Raw))
 
 	wh.mu.RLock()
-	if !injectRequired(ignoredNamespaces, wh.Config, &pod.Spec, pod.ObjectMeta) {
+	if !injectRequired(IgnoredNamespaces, wh.Config, &pod.Spec, pod.ObjectMeta) {
 		log.Infof("Skipping %s/%s due to policy check", pod.ObjectMeta.Namespace, podName)
 		totalSkippedInjections.Increment()
 		wh.mu.RUnlock()

--- a/pkg/kube/inject/webhook_test.go
+++ b/pkg/kube/inject/webhook_test.go
@@ -462,7 +462,7 @@ func TestInjectRequired(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		if got := injectRequired(ignoredNamespaces, c.config, c.podSpec, c.meta); got != c.want {
+		if got := injectRequired(IgnoredNamespaces, c.config, c.podSpec, c.meta); got != c.want {
 			t.Errorf("injectRequired(%v, %v) got %v want %v", c.config, c.meta, got, c.want)
 		}
 	}


### PR DESCRIPTION
We no need to apply `istio-root-ca-cert` configmap to special kubernetes system namespaces, because istio never use these namespaces, such as kube-system, kube-public.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
