### PR TITLE
cleanup set workload labels

### DIFF
--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -819,6 +819,19 @@ func (node *Proxy) SetServiceInstances(serviceDiscovery ServiceDiscovery) {
 	node.ServiceInstances = instances
 }
 
+// SetWorkloadLabels will set the node.Metadata.Labels only when it is nil.
+func (node *Proxy) SetWorkloadLabels(env *Environment) {
+	// First get the workload labels from node meta
+	if len(node.Metadata.Labels) > 0 {
+		return
+	}
+	// Fallback to calling GetProxyWorkloadLabels
+	l := env.GetProxyWorkloadLabels(node)
+	if len(l) > 0 {
+		node.Metadata.Labels = l[0]
+	}
+}
+
 // DiscoverIPVersions discovers the IP Versions supported by Proxy based on its IP addresses.
 func (node *Proxy) DiscoverIPVersions() {
 	for i := 0; i < len(node.IPAddresses); i++ {

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -819,20 +819,6 @@ func (node *Proxy) SetServiceInstances(serviceDiscovery ServiceDiscovery) {
 	node.ServiceInstances = instances
 }
 
-// SetWorkloadLabels will set the node.Metadata.Labels only when it is nil.
-func (node *Proxy) SetWorkloadLabels(env *Environment) {
-	// First get the workload labels from node meta
-	if len(node.Metadata.Labels) > 0 {
-		return
-	}
-
-	// Fallback to calling GetProxyWorkloadLabels
-	l := env.GetProxyWorkloadLabels(node)
-	if len(l) > 0 {
-		node.Metadata.Labels = l[0]
-	}
-}
-
 // DiscoverIPVersions discovers the IP Versions supported by Proxy based on its IP addresses.
 func (node *Proxy) DiscoverIPVersions() {
 	for i := 0; i < len(node.IPAddresses); i++ {

--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -554,6 +554,9 @@ func (s *DiscoveryServer) initProxyMetadata(node *core.Node) (*model.Proxy, erro
 	if err != nil {
 		return nil, err
 	}
+	if len(meta.Labels) == 0 {
+		log.Warnf("proxy %s does not have labels in metadata, some functionality might not work properly", node.Id)
+	}
 	proxy, err := model.ParseServiceNodeWithMetadata(node.Id, meta)
 	if err != nil {
 		return nil, err
@@ -573,7 +576,6 @@ func (s *DiscoveryServer) initializeProxy(node *core.Node, con *Connection) erro
 	if err := s.WorkloadEntryController.RegisterWorkload(proxy, con.Connect); err != nil {
 		return err
 	}
-
 	s.computeProxyState(proxy, nil)
 
 	// Get the locality from the proxy's service instances.
@@ -621,7 +623,6 @@ func (s *DiscoveryServer) updateProxy(proxy *model.Proxy, request *model.PushReq
 
 func (s *DiscoveryServer) computeProxyState(proxy *model.Proxy, request *model.PushRequest) {
 	proxy.SetServiceInstances(s.Env.ServiceDiscovery)
-	proxy.SetWorkloadLabels(s.Env)
 	// Precompute the sidecar scope and merged gateways associated with this proxy.
 	// Saves compute cycles in networking code. Though this might be redundant sometimes, we still
 	// have to compute this because as part of a config change, a new Sidecar could become

--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -554,9 +554,6 @@ func (s *DiscoveryServer) initProxyMetadata(node *core.Node) (*model.Proxy, erro
 	if err != nil {
 		return nil, err
 	}
-	if len(meta.Labels) == 0 {
-		log.Warnf("proxy %s does not have labels in metadata, some functionality might not work properly", node.Id)
-	}
 	proxy, err := model.ParseServiceNodeWithMetadata(node.Id, meta)
 	if err != nil {
 		return nil, err

--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -574,7 +574,6 @@ func (s *DiscoveryServer) initializeProxy(node *core.Node, con *Connection) erro
 		return err
 	}
 
-	proxy.SetWorkloadLabels(s.Env)
 	s.computeProxyState(proxy, nil)
 
 	// Get the locality from the proxy's service instances.
@@ -622,6 +621,7 @@ func (s *DiscoveryServer) updateProxy(proxy *model.Proxy, request *model.PushReq
 
 func (s *DiscoveryServer) computeProxyState(proxy *model.Proxy, request *model.PushRequest) {
 	proxy.SetServiceInstances(s.Env.ServiceDiscovery)
+	proxy.SetWorkloadLabels(s.Env)
 	// Precompute the sidecar scope and merged gateways associated with this proxy.
 	// Saves compute cycles in networking code. Though this might be redundant sometimes, we still
 	// have to compute this because as part of a config change, a new Sidecar could become

--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -619,6 +619,7 @@ func (s *DiscoveryServer) updateProxy(proxy *model.Proxy, request *model.PushReq
 }
 
 func (s *DiscoveryServer) computeProxyState(proxy *model.Proxy, request *model.PushRequest) {
+	proxy.SetWorkloadLabels(s.Env)
 	proxy.SetServiceInstances(s.Env.ServiceDiscovery)
 	// Precompute the sidecar scope and merged gateways associated with this proxy.
 	// Saves compute cycles in networking code. Though this might be redundant sometimes, we still

--- a/pilot/pkg/xds/lds_test.go
+++ b/pilot/pkg/xds/lds_test.go
@@ -296,7 +296,11 @@ func TestLDSEnvoyFilterWithWorkloadSelector(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
-			adsc := s.Connect(&model.Proxy{ConfigNamespace: "consumerns", Metadata: &model.NodeMetadata{Labels: test.labels}, IPAddresses: []string{test.ip}}, nil, watchAll)
+			adsc := s.Connect(&model.Proxy{
+				ConfigNamespace: "consumerns",
+				Metadata:        &model.NodeMetadata{Labels: test.labels},
+				IPAddresses:     []string{test.ip},
+			}, nil, watchAll)
 
 			// Expect 1 HTTP listeners for 8081
 			if len(adsc.GetHTTPListeners()) != 1 {


### PR DESCRIPTION
If proxy bootstrap does not provide labels in metadata(happens for noninjected proxies) and by that time pod connects to istiod if the pod is not available in istiod pod cache, we never set work load labels later -and any sidecar that is applied to it with workload selector does not work

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
