### PR TITLE
Add ability to define externalIPs

### DIFF
--- a/manifests/charts/gateways/istio-ingress/templates/service.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/service.yaml
@@ -16,6 +16,12 @@ metadata:
     install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "IngressGateways"
 spec:
+{{- if $gateway.externalIPs }}
+  externalIPs:
+    {{- range $gateway.externalIPs }}
+    - {{ . | quote }}
+    {{- end }}
+{{- end }}
 {{- if $gateway.loadBalancerIP }}
   loadBalancerIP: "{{ $gateway.loadBalancerIP }}"
 {{- end }}

--- a/manifests/charts/gateways/istio-ingress/values.yaml
+++ b/manifests/charts/gateways/istio-ingress/values.yaml
@@ -44,6 +44,7 @@ gateways:
         cpu: 2000m
         memory: 1024Mi
 
+    externalIPs: []
     loadBalancerIP: ""
     loadBalancerSourceRanges: []
     serviceAnnotations: {}


### PR DESCRIPTION
This PR adds the ability to define externalIPs for the ingress gateway services, so that they can be used with NodePort instead of LoadBalancer type.

And to help us figure out who should review this PR, please put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure

Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
