### PR TITLE
Re-run formatter on all files

### DIFF
--- a/cni/pkg/install-cni/pkg/constants/constants.go
+++ b/cni/pkg/install-cni/pkg/constants/constants.go
@@ -37,7 +37,7 @@ var (
 	HostCNIBinDir         = "/host/opt/cni/bin"
 	SecondaryBinDir       = "/host/secondary-bin-dir"
 	ServiceAccountPath    = "/var/run/secrets/kubernetes.io/serviceaccount"
-	DefaultKubeconfigMode = 0600
+	DefaultKubeconfigMode = 0o600
 
 	// K8s liveness and readiness endpoints
 	LivenessEndpoint  = "/healthz"

--- a/cni/pkg/install-cni/pkg/install/cniconfig.go
+++ b/cni/pkg/install-cni/pkg/install/cniconfig.go
@@ -148,7 +148,7 @@ func writeCNIConfig(ctx context.Context, cniConfig []byte, cfg pluginConfig) (st
 		}
 	}
 
-	if err = file.AtomicWrite(cniConfigFilepath, cniConfig, os.FileMode(0644)); err != nil {
+	if err = file.AtomicWrite(cniConfigFilepath, cniConfig, os.FileMode(0o644)); err != nil {
 		return "", err
 	}
 

--- a/cni/pkg/install-cni/pkg/install/cniconfig_test.go
+++ b/cni/pkg/install-cni/pkg/install/cniconfig_test.go
@@ -109,7 +109,7 @@ func TestGetDefaultCNINetwork(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			if c.fileContents != "" {
-				err = ioutil.WriteFile(filepath.Join(c.dir, c.inFilename), []byte(c.fileContents), 0644)
+				err = ioutil.WriteFile(filepath.Join(c.dir, c.inFilename), []byte(c.fileContents), 0o644)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -287,7 +287,7 @@ func TestGetCNIConfigFilepath(t *testing.T) {
 					if err != nil {
 						t.Fatal(err)
 					}
-					err = ioutil.WriteFile(filepath.Join(tempDir, c.delayedConfName), data, 0644)
+					err = ioutil.WriteFile(filepath.Join(tempDir, c.delayedConfName), data, 0o644)
 					if err != nil {
 						t.Fatal(err)
 					}

--- a/cni/pkg/install-cni/pkg/install/install.go
+++ b/cni/pkg/install-cni/pkg/install/install.go
@@ -109,7 +109,7 @@ func (in *Installer) Cleanup() error {
 			if err != nil {
 				return err
 			}
-			if err = file.AtomicWrite(in.cniConfigFilepath, cniConfig, os.FileMode(0644)); err != nil {
+			if err = file.AtomicWrite(in.cniConfigFilepath, cniConfig, os.FileMode(0o644)); err != nil {
 				return err
 			}
 		} else {

--- a/cni/pkg/install-cni/pkg/install/install_test.go
+++ b/cni/pkg/install-cni/pkg/install/install_test.go
@@ -311,14 +311,14 @@ func TestCleanup(t *testing.T) {
 
 			// Create existing binary files
 			for _, filename := range []string{"istio-cni", "istio-iptables"} {
-				if err := ioutil.WriteFile(filepath.Join(cniBinDir, filename), []byte{1, 2, 3}, 0755); err != nil {
+				if err := ioutil.WriteFile(filepath.Join(cniBinDir, filename), []byte{1, 2, 3}, 0o755); err != nil {
 					t.Fatal(err)
 				}
 			}
 
 			// Create kubeconfig
 			kubeConfigFilePath := filepath.Join(cniNetDir, "kubeconfig")
-			if err := ioutil.WriteFile(kubeConfigFilePath, []byte{1, 2, 3}, 0755); err != nil {
+			if err := ioutil.WriteFile(kubeConfigFilePath, []byte{1, 2, 3}, 0o755); err != nil {
 				t.Fatal(err)
 			}
 

--- a/cni/test/install_cni.go
+++ b/cni/test/install_cni.go
@@ -41,7 +41,7 @@ const (
 	cniConfSubDir    = "/testdata/pre/"
 	k8sSvcAcctSubDir = "/testdata/k8s_svcacct/"
 
-	defaultFileMode = 0644
+	defaultFileMode = 0o644
 
 	cniConfName          = "CNI_CONF_NAME"
 	chainedCNIPluginName = "CHAINED_CNI_PLUGIN"
@@ -147,7 +147,7 @@ func rmCNIConfig(cniConfigFilepath string, t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err = file.AtomicWrite(cniConfigFilepath, cniConfig, os.FileMode(0644)); err != nil {
+	if err = file.AtomicWrite(cniConfigFilepath, cniConfig, os.FileMode(0o644)); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/galley/pkg/config/analysis/msg/generate.main.go
+++ b/galley/pkg/config/analysis/msg/generate.main.go
@@ -27,8 +27,10 @@ import (
 	"github.com/ghodss/yaml"
 )
 
-const codeRegex = `^IST\d\d\d\d$`
-const nameRegex = `^[[:upper:]]\w*$`
+const (
+	codeRegex = `^IST\d\d\d\d$`
+	nameRegex = `^[[:upper:]]\w*$`
+)
 
 // Utility for generating messages.gen.go. Called from gen.go
 func main() {

--- a/istioctl/cmd/workload_test.go
+++ b/istioctl/cmd/workload_test.go
@@ -187,7 +187,7 @@ func TestWorkloadEntryConfigure(t *testing.T) {
 						&v1.Secret{
 							ObjectMeta: metav1.ObjectMeta{Namespace: "bar", Name: "test"},
 							Data: map[string][]byte{
-								"token": []byte{},
+								"token": {},
 							},
 						},
 					),

--- a/operator/cmd/mesh/manifest-generate.go
+++ b/operator/cmd/mesh/manifest-generate.go
@@ -182,7 +182,7 @@ func renderRecursive(manifests name.ManifestMap, installTree helmreconciler.Comp
 		fname := filepath.Join(dirName, componentName) + ".yaml"
 		l.LogAndPrintf("Writing manifest to %s", fname)
 		if !dryRun {
-			if err := ioutil.WriteFile(fname, []byte(ym), 0644); err != nil {
+			if err := ioutil.WriteFile(fname, []byte(ym), 0o644); err != nil {
 				return fmt.Errorf("could not write manifest config; %s", err)
 			}
 		}

--- a/operator/cmd/mesh/operator_test.go
+++ b/operator/cmd/mesh/operator_test.go
@@ -53,7 +53,7 @@ func TestOperatorDump(t *testing.T) {
 
 	if refreshGoldenFiles() {
 		t.Logf("Refreshing golden file for %s", goldenFilepath)
-		if err := ioutil.WriteFile(goldenFilepath, []byte(gotYAML), 0644); err != nil {
+		if err := ioutil.WriteFile(goldenFilepath, []byte(gotYAML), 0o644); err != nil {
 			t.Error(err)
 		}
 	}
@@ -90,7 +90,7 @@ func TestOperatorInit(t *testing.T) {
 
 	if refreshGoldenFiles() {
 		t.Logf("Refreshing golden file for %s", goldenFilepath)
-		if err := ioutil.WriteFile(goldenFilepath, []byte(gotYAML), 0644); err != nil {
+		if err := ioutil.WriteFile(goldenFilepath, []byte(gotYAML), 0o644); err != nil {
 			t.Error(err)
 		}
 	}

--- a/operator/cmd/mesh/profile-dump_test.go
+++ b/operator/cmd/mesh/profile-dump_test.go
@@ -54,7 +54,7 @@ func TestProfileDump(t *testing.T) {
 
 			if refreshGoldenFiles() {
 				t.Logf("Refreshing golden file for %s", outPath)
-				if err := ioutil.WriteFile(outPath, []byte(got), 0644); err != nil {
+				if err := ioutil.WriteFile(outPath, []byte(got), 0o644); err != nil {
 					t.Error(err)
 				}
 			}
@@ -113,7 +113,7 @@ func TestProfileDumpFlags(t *testing.T) {
 
 			if refreshGoldenFiles() {
 				t.Logf("Refreshing golden file for %s", outPath)
-				if err := ioutil.WriteFile(outPath, []byte(got), 0644); err != nil {
+				if err := ioutil.WriteFile(outPath, []byte(got), 0o644); err != nil {
 					t.Error(err)
 				}
 			}

--- a/operator/pkg/apis/istio/fixup_structs/main.go
+++ b/operator/pkg/apis/istio/fixup_structs/main.go
@@ -162,7 +162,7 @@ func main() {
 	}
 
 	fmt.Printf("Writing to output file %s\n", filePath)
-	if err := ioutil.WriteFile(filePath, []byte(strings.Join(out, "\n")), 0644); err != nil {
+	if err := ioutil.WriteFile(filePath, []byte(strings.Join(out, "\n")), 0o644); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}

--- a/operator/pkg/util/httpserver/httpserver.go
+++ b/operator/pkg/util/httpserver/httpserver.go
@@ -62,7 +62,7 @@ func (s *Server) MoveFiles(origin string) ([]string, error) {
 			return []string{}, err
 		}
 		newName := filepath.Join(s.Root, filepath.Base(file))
-		if err := ioutil.WriteFile(newName, data, 0755); err != nil {
+		if err := ioutil.WriteFile(newName, data, 0o755); err != nil {
 			return []string{}, err
 		}
 		tmpFiles[i] = newName

--- a/pilot/pkg/bootstrap/istio_ca.go
+++ b/pilot/pkg/bootstrap/istio_ca.go
@@ -251,12 +251,12 @@ func (s *Server) loadRemoteCACerts(caOpts *caOptions, dir string) error {
 	}
 
 	log.Infof("cacerts Secret found in remote cluster, saving contents to %s", dir)
-	if err := os.MkdirAll(dir, 0700); err != nil {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return err
 	}
 	for key, data := range secret.Data {
 		filename := path.Join(dir, key)
-		if err := ioutil.WriteFile(filename, data, 0600); err != nil {
+		if err := ioutil.WriteFile(filename, data, 0o600); err != nil {
 			return err
 		}
 	}

--- a/pilot/pkg/config/kube/ingress/conversion_test.go
+++ b/pilot/pkg/config/kube/ingress/conversion_test.go
@@ -77,7 +77,7 @@ func TestGoldenConversion(t *testing.T) {
 			output := marshalYaml(t, ordered)
 			goldenFile := fmt.Sprintf("testdata/%s.yaml.golden", tt)
 			if util.Refresh() {
-				if err := ioutil.WriteFile(goldenFile, output, 0644); err != nil {
+				if err := ioutil.WriteFile(goldenFile, output, 0o644); err != nil {
 					t.Fatal(err)
 				}
 			}

--- a/pilot/pkg/config/monitor/file_snapshot_test.go
+++ b/pilot/pkg/config/monitor/file_snapshot_test.go
@@ -140,7 +140,7 @@ func (ts *testState) testSetup(t *testing.T) {
 	}
 
 	for name, content := range ts.ConfigFiles {
-		err = ioutil.WriteFile(filepath.Join(ts.rootPath, name), content, 0600)
+		err = ioutil.WriteFile(filepath.Join(ts.rootPath, name), content, 0o600)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pilot/pkg/xds/eds_test.go
+++ b/pilot/pkg/xds/eds_test.go
@@ -170,7 +170,7 @@ func TestEds(t *testing.T) {
 			t.Error("No clusters in ADS response")
 		}
 		strResponse, _ := json.MarshalIndent(clusters, " ", " ")
-		_ = ioutil.WriteFile(env.IstioOut+"/cdsv2_sidecar.json", strResponse, 0644)
+		_ = ioutil.WriteFile(env.IstioOut+"/cdsv2_sidecar.json", strResponse, 0o644)
 	})
 }
 

--- a/pilot/test/util/diff.go
+++ b/pilot/test/util/diff.go
@@ -72,7 +72,7 @@ func CompareYAML(filename string, t *testing.T) {
 	goldenFile := filename + ".golden"
 	if Refresh() {
 		t.Logf("Refreshing golden file for %s", filename)
-		if err = ioutil.WriteFile(goldenFile, content, 0644); err != nil {
+		if err = ioutil.WriteFile(goldenFile, content, 0o644); err != nil {
 			t.Errorf(err.Error())
 		}
 	}
@@ -110,7 +110,7 @@ func StripVersion(yaml []byte) []byte {
 func RefreshGoldenFile(content []byte, goldenFile string, t *testing.T) {
 	if Refresh() {
 		t.Logf("Refreshing golden file %s", goldenFile)
-		if err := file.AtomicWrite(goldenFile, content, os.FileMode(0644)); err != nil {
+		if err := file.AtomicWrite(goldenFile, content, os.FileMode(0o644)); err != nil {
 			t.Errorf(err.Error())
 		}
 	}

--- a/pilot/tools/debug/pilot_cli.go
+++ b/pilot/tools/debug/pilot_cli.go
@@ -310,7 +310,7 @@ func main() {
 	strResponse, _ := gogoprotomarshal.ToJSONWithIndent(resp, " ")
 	if outputFile == nil || *outputFile == "" {
 		fmt.Printf("%v\n", strResponse)
-	} else if err := ioutil.WriteFile(*outputFile, []byte(strResponse), 0644); err != nil {
+	} else if err := ioutil.WriteFile(*outputFile, []byte(strResponse), 0o644); err != nil {
 		log.Errorf("Cannot write output to file %q", *outputFile)
 	}
 }

--- a/pkg/file/file.go
+++ b/pkg/file/file.go
@@ -95,7 +95,7 @@ func Exists(name string) bool {
 
 const (
 	// PrivateFileMode grants owner to read/write a file.
-	PrivateFileMode = 0600
+	PrivateFileMode = 0o600
 )
 
 // IsDirWriteable checks if dir is writable by writing and removing a file

--- a/pkg/istio-agent/agent_test.go
+++ b/pkg/istio-agent/agent_test.go
@@ -209,7 +209,7 @@ func TestAgent(t *testing.T) {
 		// Handle special edge case where we output certs to /etc/certs, which has magic implicit
 		// reading from file logic
 		dir := "./etc/certs"
-		if err := os.MkdirAll(dir, 0755); err != nil {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
 			t.Fatal(err)
 		}
 		t.Cleanup(func() {
@@ -496,7 +496,7 @@ func (a *AgentTest) Check(expectedSDS ...string) map[string]*xds.AdsTest {
 }
 
 func copyCerts(t *testing.T, dir string) {
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	if err := file.Copy(filepath.Join(env.IstioSrc, "./tests/testdata/certs/pilot/cert-chain.pem"), dir, "cert-chain.pem"); err != nil {

--- a/pkg/kube/util_test.go
+++ b/pkg/kube/util_test.go
@@ -136,7 +136,7 @@ users:
     token: sdsddsd`
 
 	sampleConfig := fmt.Sprintf(template, cluster1Host, cluster2Host)
-	err = ioutil.WriteFile(filePath, []byte(sampleConfig), 0644)
+	err = ioutil.WriteFile(filePath, []byte(sampleConfig), 0o644)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/uds/listener.go
+++ b/pkg/uds/listener.go
@@ -31,7 +31,7 @@ func NewListener(path string) (net.Listener, error) {
 	}
 
 	// Attempt to create the folder in case it doesn't exist
-	if err := os.MkdirAll(filepath.Dir(path), 0750); err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
 		// If we cannot create it, just warn here - we will fail later if there is a real error
 		log.Warnf("Failed to create directory for %v: %v", path, err)
 	}
@@ -46,7 +46,7 @@ func NewListener(path string) (net.Listener, error) {
 	if _, err := os.Stat(path); err != nil {
 		return nil, fmt.Errorf("uds file %q doesn't exist", path)
 	}
-	if err := os.Chmod(path, 0666); err != nil {
+	if err := os.Chmod(path, 0o666); err != nil {
 		return nil, fmt.Errorf("failed to update %q permission", path)
 	}
 

--- a/pkg/wasm/cache.go
+++ b/pkg/wasm/cache.go
@@ -165,7 +165,7 @@ func (c *LocalFileCache) addEntry(key cacheKey, wasmModule []byte, f string) err
 	}
 
 	// Materialize the Wasm module into a local file. Use checksum as name of the module.
-	if err := ioutil.WriteFile(f, wasmModule, 0644); err != nil {
+	if err := ioutil.WriteFile(f, wasmModule, 0o644); err != nil {
 		return err
 	}
 

--- a/pkg/wasm/cache_test.go
+++ b/pkg/wasm/cache_test.go
@@ -145,7 +145,7 @@ func TestWasmCache(t *testing.T) {
 			cache.mux.Lock()
 			for k, m := range c.initialCachedModules {
 				filePath := filepath.Join(tmpDir, m.modulePath)
-				err := ioutil.WriteFile(filePath, []byte("data/\n"), 0644)
+				err := ioutil.WriteFile(filePath, []byte("data/\n"), 0o644)
 				if err != nil {
 					t.Fatalf("failed to write initial wasm module file %v", err)
 				}

--- a/pkg/webhooks/validation/server/server_test.go
+++ b/pkg/webhooks/validation/server/server_test.go
@@ -69,12 +69,12 @@ func createTestWebhook(t testing.TB) (*Webhook, func()) {
 	)
 
 	// cert
-	if err := ioutil.WriteFile(certFile, testcerts.ServerCert, 0644); err != nil { // nolint: vetshadow
+	if err := ioutil.WriteFile(certFile, testcerts.ServerCert, 0o644); err != nil { // nolint: vetshadow
 		cleanup()
 		t.Fatalf("WriteFile(%v) failed: %v", certFile, err)
 	}
 	// key
-	if err := ioutil.WriteFile(keyFile, testcerts.ServerKey, 0644); err != nil { // nolint: vetshadow
+	if err := ioutil.WriteFile(keyFile, testcerts.ServerKey, 0o644); err != nil { // nolint: vetshadow
 		cleanup()
 		t.Fatalf("WriteFile(%v) failed: %v", keyFile, err)
 	}

--- a/samples/extauthz/src/main.go
+++ b/samples/extauthz/src/main.go
@@ -53,8 +53,10 @@ var (
 	denyBody       = fmt.Sprintf("denied by ext_authz for not found header `%s: %s` in the request", checkHeader, allowedValue)
 )
 
-type extAuthzServerV2 struct{}
-type extAuthzServerV3 struct{}
+type (
+	extAuthzServerV2 struct{}
+	extAuthzServerV3 struct{}
+)
 
 // ExtAuthzServer implements the ext_authz v2/v3 gRPC and HTTP check request API.
 type ExtAuthzServer struct {

--- a/security/pkg/credentialfetcher/plugin/gce.go
+++ b/security/pkg/credentialfetcher/plugin/gce.go
@@ -147,7 +147,7 @@ func (p *GCEPlugin) GetPlatformCredential() (string, error) {
 	p.tokenCache = token
 	gcecredLog.Debugf("Got GCE identity token: %d", len(token))
 	tokenbytes := []byte(token)
-	err = ioutil.WriteFile(p.jwtPath, tokenbytes, 0640)
+	err = ioutil.WriteFile(p.jwtPath, tokenbytes, 0o640)
 	if err != nil {
 		gcecredLog.Errorf("Encountered error when writing vm identity token: %v", err)
 		return "", err

--- a/security/pkg/nodeagent/cache/secretcache_test.go
+++ b/security/pkg/nodeagent/cache/secretcache_test.go
@@ -376,7 +376,7 @@ func runFileAgentTest(t *testing.T, sds bool) {
 	// We shouldn't get an pushes; these only happen on changes
 	u.Expect(map[string]int{})
 
-	if err := file.AtomicWrite(sc.existingCertificateFile.CertificatePath, testcerts.RotatedCert, os.FileMode(0644)); err != nil {
+	if err := file.AtomicWrite(sc.existingCertificateFile.CertificatePath, testcerts.RotatedCert, os.FileMode(0o644)); err != nil {
 		t.Fatal(err)
 	}
 	// Expect update callback
@@ -388,7 +388,7 @@ func runFileAgentTest(t *testing.T, sds bool) {
 		PrivateKey:       privateKey,
 	})
 
-	if err := file.AtomicWrite(sc.existingCertificateFile.PrivateKeyPath, testcerts.RotatedKey, os.FileMode(0644)); err != nil {
+	if err := file.AtomicWrite(sc.existingCertificateFile.PrivateKeyPath, testcerts.RotatedKey, os.FileMode(0o644)); err != nil {
 		t.Fatal(err)
 	}
 	// We do NOT expect update callback. We only watch the cert file, since the key and cert must be updated
@@ -401,7 +401,7 @@ func runFileAgentTest(t *testing.T, sds bool) {
 		PrivateKey:       testcerts.RotatedKey,
 	})
 
-	if err := file.AtomicWrite(sc.existingCertificateFile.CaCertificatePath, testcerts.CACert, os.FileMode(0644)); err != nil {
+	if err := file.AtomicWrite(sc.existingCertificateFile.CaCertificatePath, testcerts.CACert, os.FileMode(0o644)); err != nil {
 		t.Fatal(err)
 	}
 	// We expect to get an update notification, and the new root cert to be read

--- a/security/pkg/nodeagent/caclient/providers/citadel/client_test.go
+++ b/security/pkg/nodeagent/caclient/providers/citadel/client_test.go
@@ -117,7 +117,7 @@ func serve(t *testing.T, ca mockCAServer, opts ...grpc.ServerOption) string {
 func TestCitadelClientRotation(t *testing.T) {
 	checkSign := func(t *testing.T, cli security.Client, expectError bool) {
 		t.Helper()
-		resp, err := cli.CSRSign([]byte{01}, 1)
+		resp, err := cli.CSRSign([]byte{0o1}, 1)
 		if expectError != (err != nil) {
 			t.Fatalf("expected error:%v, got error:%v", expectError, err)
 		}
@@ -220,7 +220,7 @@ func TestCitadelClient(t *testing.T) {
 			}
 			t.Cleanup(cli.Close)
 
-			resp, err := cli.CSRSign([]byte{01}, 1)
+			resp, err := cli.CSRSign([]byte{0o1}, 1)
 			if err != nil {
 				if !strings.Contains(err.Error(), tc.expectedErr) {
 					t.Errorf("error (%s) does not match expected error (%s)", err.Error(), tc.expectedErr)
@@ -337,7 +337,7 @@ func TestCitadelClientWithDifferentTypeToken(t *testing.T) {
 					return fmt.Errorf("failed to create ca client: %v", err)
 				}
 				t.Cleanup(cli.Close)
-				resp, err := cli.CSRSign([]byte{01}, 1)
+				resp, err := cli.CSRSign([]byte{0o1}, 1)
 				if err != nil {
 					if !strings.Contains(err.Error(), tc.expectedErr) {
 						return fmt.Errorf("error (%s) does not match expected error (%s)", err.Error(), tc.expectedErr)

--- a/security/pkg/nodeagent/caclient/providers/google/client_test.go
+++ b/security/pkg/nodeagent/caclient/providers/google/client_test.go
@@ -68,7 +68,7 @@ func TestGoogleCAClient(t *testing.T) {
 			t.Errorf("Test case [%s]: failed to create ca client: %v", id, err)
 		}
 
-		resp, err := cli.CSRSign([]byte{01}, 1)
+		resp, err := cli.CSRSign([]byte{0o1}, 1)
 		if err != nil {
 			if err.Error() != tc.expectedErr {
 				t.Errorf("Test case [%s]: error (%s) does not match expected error (%s)", id, err.Error(), tc.expectedErr)

--- a/security/pkg/nodeagent/sds/sdsservice_test.go
+++ b/security/pkg/nodeagent/sds/sdsservice_test.go
@@ -33,12 +33,12 @@ import (
 )
 
 var (
-	fakeRootCert         = []byte{00}
-	fakeCertificateChain = []byte{01}
-	fakePrivateKey       = []byte{02}
+	fakeRootCert         = []byte{0o0}
+	fakeCertificateChain = []byte{0o1}
+	fakePrivateKey       = []byte{0o2}
 
-	fakePushCertificateChain = []byte{03}
-	fakePushPrivateKey       = []byte{04}
+	fakePushCertificateChain = []byte{0o3}
+	fakePushPrivateKey       = []byte{0o4}
 	pushSecret               = &ca2.SecretItem{
 		CertificateChain: fakePushCertificateChain,
 		PrivateKey:       fakePushPrivateKey,

--- a/security/tools/generate_cert/main.go
+++ b/security/tools/generate_cert/main.go
@@ -85,12 +85,12 @@ func checkCmdLine() {
 }
 
 func saveCreds(certPem []byte, privPem []byte) {
-	err := ioutil.WriteFile(*outCert, certPem, 0644)
+	err := ioutil.WriteFile(*outCert, certPem, 0o644)
 	if err != nil {
 		log.Fatalf("Could not write output certificate: %s.", err)
 	}
 
-	err = ioutil.WriteFile(*outPriv, privPem, 0600)
+	err = ioutil.WriteFile(*outPriv, privPem, 0o600)
 	if err != nil {
 		log.Fatalf("Could not write output private key: %s.", err)
 	}

--- a/security/tools/generate_csr/main.go
+++ b/security/tools/generate_csr/main.go
@@ -35,12 +35,12 @@ var (
 )
 
 func saveCreds(csrPem []byte, privPem []byte) {
-	err := ioutil.WriteFile(*outCsr, csrPem, 0644)
+	err := ioutil.WriteFile(*outCsr, csrPem, 0o644)
 	if err != nil {
 		log.Fatalf("Could not write output certificate request: %s.", err)
 	}
 
-	err = ioutil.WriteFile(*outPriv, privPem, 0600)
+	err = ioutil.WriteFile(*outPriv, privPem, 0o600)
 	if err != nil {
 		log.Fatalf("Could not write output private key: %s.", err)
 	}

--- a/tests/integration/security/fuzz/main_test.go
+++ b/tests/integration/security/fuzz/main_test.go
@@ -24,9 +24,7 @@ import (
 	"istio.io/istio/pkg/test/framework/resource"
 )
 
-var (
-	ist istio.Instance
-)
+var ist istio.Instance
 
 func TestMain(m *testing.M) {
 	framework.NewSuite(m).Setup(istio.Setup(&ist, setupConfig)).Run()


### PR DESCRIPTION
I am not sure why these are somehow missed in `format-go`, likely a bug
in the config. Run the formatters manually so future PRs have less
noise.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.