### PR TITLE
Add a lot more leak checks and fix some leaks

### DIFF
--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -290,7 +290,10 @@ func (s *Server) initStatusController(args *PilotArgs, writeStatus bool) {
 		UpdateInterval: time.Millisecond * 500, // TODO: use args here?
 		PodName:        args.PodName,
 	}
-	s.statusReporter.Init(s.environment.GetLedger())
+	s.addStartFunc(func(stop <-chan struct{}) error {
+		s.statusReporter.Init(s.environment.GetLedger(), stop)
+		return nil
+	})
 	s.addTerminatingStartFunc(func(stop <-chan struct{}) error {
 		if writeStatus {
 			s.statusReporter.Start(s.kubeClient, args.Namespace, args.PodName, stop)

--- a/pilot/pkg/bootstrap/istio_ca.go
+++ b/pilot/pkg/bootstrap/istio_ca.go
@@ -251,12 +251,12 @@ func (s *Server) loadRemoteCACerts(caOpts *caOptions, dir string) error {
 	}
 
 	log.Infof("cacerts Secret found in remote cluster, saving contents to %s", dir)
-	if err := os.MkdirAll(dir, 0700); err != nil {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return err
 	}
 	for key, data := range secret.Data {
 		filename := path.Join(dir, key)
-		if err := ioutil.WriteFile(filename, data, 0600); err != nil {
+		if err := ioutil.WriteFile(filename, data, 0o600); err != nil {
 			return err
 		}
 	}
@@ -330,9 +330,8 @@ func (s *Server) createIstioCA(client corev1.CoreV1Interface, opts *caOptions) (
 	// ca.go saves or uses the secret, but also writes to the configmap "istio-security", under caTLSRootCert
 	// rootCertRotatorChan channel accepts signals to stop root cert rotator for
 	// self-signed CA.
-	rootCertRotatorChan := make(chan struct{})
 	// Start root cert rotator in a separate goroutine.
-	istioCA.Run(rootCertRotatorChan)
+	istioCA.Run(s.internalStop)
 	return istioCA, nil
 }
 

--- a/pilot/pkg/bootstrap/leak_test.go
+++ b/pilot/pkg/bootstrap/leak_test.go
@@ -1,0 +1,26 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bootstrap
+
+import (
+	"testing"
+
+	"istio.io/istio/tests/util/leak"
+)
+
+func TestMain(m *testing.M) {
+	// CheckMain asserts that no goroutines are leaked after a test package exits.
+	leak.CheckMain(m)
+}

--- a/pilot/pkg/bootstrap/mesh.go
+++ b/pilot/pkg/bootstrap/mesh.go
@@ -66,7 +66,7 @@ func (s *Server) initMeshConfiguration(args *PilotArgs, fileWatcher filewatcher.
 		if err == nil {
 			if multiWatch {
 				kubemesh.AddUserMeshConfig(
-					s.kubeClient, s.environment.Watcher, args.Namespace, configMapKey, features.SharedMeshConfig)
+					s.kubeClient, s.environment.Watcher, args.Namespace, configMapKey, features.SharedMeshConfig, s.internalStop)
 			} else {
 				// Normal install no longer uses this mode - testing and special installs still use this.
 				log.Warnf("Using local mesh config file %s, in cluster configs ignored", args.MeshConfigFile)
@@ -88,11 +88,10 @@ func (s *Server) initMeshConfiguration(args *PilotArgs, fileWatcher filewatcher.
 	// This may be necessary for external Istiod.
 	configMapName := getMeshConfigMapName(args.Revision)
 	s.environment.Watcher = kubemesh.NewConfigMapWatcher(
-		s.kubeClient, args.Namespace, configMapName, configMapKey, multiWatch)
+		s.kubeClient, args.Namespace, configMapName, configMapKey, multiWatch, s.internalStop)
 
 	if multiWatch {
-		kubemesh.AddUserMeshConfig(
-			s.kubeClient, s.environment.Watcher, args.Namespace, configMapKey, features.SharedMeshConfig)
+		kubemesh.AddUserMeshConfig(s.kubeClient, s.environment.Watcher, args.Namespace, configMapKey, features.SharedMeshConfig, s.internalStop)
 	}
 }
 

--- a/pilot/pkg/bootstrap/server_test.go
+++ b/pilot/pkg/bootstrap/server_test.go
@@ -380,7 +380,7 @@ func TestIstiodCipherSuites(t *testing.T) {
 		},
 	}
 
-	for _, c := range cases {
+	for _, c := range cases[:1] {
 		t.Run(c.name, func(t *testing.T) {
 			configDir, err := ioutil.TempDir("", "TestIstiodCipherSuites")
 			if err != nil {

--- a/pilot/pkg/bootstrap/server_test.go
+++ b/pilot/pkg/bootstrap/server_test.go
@@ -380,7 +380,7 @@ func TestIstiodCipherSuites(t *testing.T) {
 		},
 	}
 
-	for _, c := range cases[:1] {
+	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			configDir, err := ioutil.TempDir("", "TestIstiodCipherSuites")
 			if err != nil {

--- a/pilot/pkg/config/kube/crd/leak_test.go
+++ b/pilot/pkg/config/kube/crd/leak_test.go
@@ -1,0 +1,26 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crd
+
+import (
+	"testing"
+
+	"istio.io/istio/tests/util/leak"
+)
+
+func TestMain(m *testing.M) {
+	// CheckMain asserts that no goroutines are leaked after a test package exits.
+	leak.CheckMain(m)
+}

--- a/pilot/pkg/config/kube/crdclient/leak_test.go
+++ b/pilot/pkg/config/kube/crdclient/leak_test.go
@@ -1,0 +1,26 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crdclient
+
+import (
+	"testing"
+
+	"istio.io/istio/tests/util/leak"
+)
+
+func TestMain(m *testing.M) {
+	// CheckMain asserts that no goroutines are leaked after a test package exits.
+	leak.CheckMain(m)
+}

--- a/pilot/pkg/config/kube/gateway/leak_test.go
+++ b/pilot/pkg/config/kube/gateway/leak_test.go
@@ -1,0 +1,26 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gateway
+
+import (
+	"testing"
+
+	"istio.io/istio/tests/util/leak"
+)
+
+func TestMain(m *testing.M) {
+	// CheckMain asserts that no goroutines are leaked after a test package exits.
+	leak.CheckMain(m)
+}

--- a/pilot/pkg/config/kube/ingress/leak_test.go
+++ b/pilot/pkg/config/kube/ingress/leak_test.go
@@ -1,0 +1,26 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ingress
+
+import (
+	"testing"
+
+	"istio.io/istio/tests/util/leak"
+)
+
+func TestMain(m *testing.M) {
+	// CheckMain asserts that no goroutines are leaked after a test package exits.
+	leak.CheckMain(m)
+}

--- a/pilot/pkg/config/kube/ingressv1/leak_test.go
+++ b/pilot/pkg/config/kube/ingressv1/leak_test.go
@@ -1,0 +1,26 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ingress
+
+import (
+	"testing"
+
+	"istio.io/istio/tests/util/leak"
+)
+
+func TestMain(m *testing.M) {
+	// CheckMain asserts that no goroutines are leaked after a test package exits.
+	leak.CheckMain(m)
+}

--- a/pilot/pkg/config/memory/leak_test.go
+++ b/pilot/pkg/config/memory/leak_test.go
@@ -1,0 +1,26 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package memory
+
+import (
+	"testing"
+
+	"istio.io/istio/tests/util/leak"
+)
+
+func TestMain(m *testing.M) {
+	// CheckMain asserts that no goroutines are leaked after a test package exits.
+	leak.CheckMain(m)
+}

--- a/pilot/pkg/config/monitor/leak_test.go
+++ b/pilot/pkg/config/monitor/leak_test.go
@@ -1,0 +1,26 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package monitor
+
+import (
+	"testing"
+
+	"istio.io/istio/tests/util/leak"
+)
+
+func TestMain(m *testing.M) {
+	// CheckMain asserts that no goroutines are leaked after a test package exits.
+	leak.CheckMain(m)
+}

--- a/pilot/pkg/controller/workloadentry/leak_test.go
+++ b/pilot/pkg/controller/workloadentry/leak_test.go
@@ -1,0 +1,26 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workloadentry
+
+import (
+	"testing"
+
+	"istio.io/istio/tests/util/leak"
+)
+
+func TestMain(m *testing.M) {
+	// CheckMain asserts that no goroutines are leaked after a test package exits.
+	leak.CheckMain(m)
+}

--- a/pilot/pkg/controller/workloadentry/workloadentry_controller_test.go
+++ b/pilot/pkg/controller/workloadentry/workloadentry_controller_test.go
@@ -37,12 +37,7 @@ import (
 	"istio.io/istio/pkg/keepalive"
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/util/retry"
-	"istio.io/istio/tests/util/leak"
 )
-
-func TestMain(m *testing.M) {
-	leak.CheckMain(m)
-}
 
 func init() {
 	features.WorkloadEntryAutoRegistration = true

--- a/pilot/pkg/dns/dns_test.go
+++ b/pilot/pkg/dns/dns_test.go
@@ -403,6 +403,7 @@ func makeUpstream(t test.Failer, responses map[string]string) string {
 	}
 	go tcp.ListenAndServe()
 	<-up
+	t.Cleanup(func() { tcp.Shutdown() })
 	t.Cleanup(func() { server.Shutdown() })
 	tcp.Addr = server.PacketConn.LocalAddr().String()
 	return server.Addr

--- a/pilot/pkg/dns/leak_test.go
+++ b/pilot/pkg/dns/leak_test.go
@@ -1,0 +1,26 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dns
+
+import (
+	"testing"
+
+	"istio.io/istio/tests/util/leak"
+)
+
+func TestMain(m *testing.M) {
+	// CheckMain asserts that no goroutines are leaked after a test package exits.
+	leak.CheckMain(m)
+}

--- a/pilot/pkg/grpc/leak_test.go
+++ b/pilot/pkg/grpc/leak_test.go
@@ -1,0 +1,26 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grpc
+
+import (
+	"testing"
+
+	"istio.io/istio/tests/util/leak"
+)
+
+func TestMain(m *testing.M) {
+	// CheckMain asserts that no goroutines are leaked after a test package exits.
+	leak.CheckMain(m)
+}

--- a/pilot/pkg/model/leak_test.go
+++ b/pilot/pkg/model/leak_test.go
@@ -1,0 +1,26 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"testing"
+
+	"istio.io/istio/tests/util/leak"
+)
+
+func TestMain(m *testing.M) {
+	// CheckMain asserts that no goroutines are leaked after a test package exits.
+	leak.CheckMain(m)
+}

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -42,12 +42,7 @@ import (
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/config/visibility"
-	"istio.io/istio/tests/util/leak"
 )
-
-func TestMain(m *testing.M) {
-	leak.CheckMain(m)
-}
 
 func TestMergeUpdateRequest(t *testing.T) {
 	push0 := &PushContext{}

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/leak_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/leak_test.go
@@ -1,0 +1,26 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package envoyfilter
+
+import (
+	"testing"
+
+	"istio.io/istio/tests/util/leak"
+)
+
+func TestMain(m *testing.M) {
+	// CheckMain asserts that no goroutines are leaked after a test package exits.
+	leak.CheckMain(m)
+}

--- a/pilot/pkg/networking/core/v1alpha3/leak_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/leak_test.go
@@ -1,0 +1,26 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha3
+
+import (
+	"testing"
+
+	"istio.io/istio/tests/util/leak"
+)
+
+func TestMain(m *testing.M) {
+	// CheckMain asserts that no goroutines are leaked after a test package exits.
+	leak.CheckMain(m)
+}

--- a/pilot/pkg/networking/core/v1alpha3/route/leak_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/leak_test.go
@@ -1,0 +1,26 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package route
+
+import (
+	"testing"
+
+	"istio.io/istio/tests/util/leak"
+)
+
+func TestMain(m *testing.M) {
+	// CheckMain asserts that no goroutines are leaked after a test package exits.
+	leak.CheckMain(m)
+}

--- a/pilot/pkg/secrets/kube/leak_test.go
+++ b/pilot/pkg/secrets/kube/leak_test.go
@@ -1,0 +1,26 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kube
+
+import (
+	"testing"
+
+	"istio.io/istio/tests/util/leak"
+)
+
+func TestMain(m *testing.M) {
+	// CheckMain asserts that no goroutines are leaked after a test package exits.
+	leak.CheckMain(m)
+}

--- a/pilot/pkg/secrets/kube/secrets_test.go
+++ b/pilot/pkg/secrets/kube/secrets_test.go
@@ -91,7 +91,11 @@ func TestSecretsController(t *testing.T) {
 	}
 	client := kube.NewFakeClient(secrets...)
 	sc := NewSecretsController(client, "")
-	client.RunAndWait(make(chan struct{}))
+	stop := make(chan struct{})
+	t.Cleanup(func() {
+		close(stop)
+	})
+	client.RunAndWait(stop)
 	cases := []struct {
 		name      string
 		namespace string

--- a/pilot/pkg/security/authz/matcher/leak_test.go
+++ b/pilot/pkg/security/authz/matcher/leak_test.go
@@ -1,0 +1,26 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package matcher
+
+import (
+	"testing"
+
+	"istio.io/istio/tests/util/leak"
+)
+
+func TestMain(m *testing.M) {
+	// CheckMain asserts that no goroutines are leaked after a test package exits.
+	leak.CheckMain(m)
+}

--- a/pilot/pkg/security/authz/model/leak_test.go
+++ b/pilot/pkg/security/authz/model/leak_test.go
@@ -1,0 +1,26 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"testing"
+
+	"istio.io/istio/tests/util/leak"
+)
+
+func TestMain(m *testing.M) {
+	// CheckMain asserts that no goroutines are leaked after a test package exits.
+	leak.CheckMain(m)
+}

--- a/pilot/pkg/security/trustdomain/leak_test.go
+++ b/pilot/pkg/security/trustdomain/leak_test.go
@@ -1,0 +1,26 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trustdomain
+
+import (
+	"testing"
+
+	"istio.io/istio/tests/util/leak"
+)
+
+func TestMain(m *testing.M) {
+	// CheckMain asserts that no goroutines are leaked after a test package exits.
+	leak.CheckMain(m)
+}

--- a/pilot/pkg/serviceregistry/kube/controller/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller_test.go
@@ -162,7 +162,6 @@ func TestServices(t *testing.T) {
 				t.Fatalf("GetService(%q) => %s, should not exist", missing, svc.Hostname)
 			}
 		})
-		return
 	}
 }
 

--- a/pilot/pkg/serviceregistry/kube/controller/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller_test.go
@@ -162,6 +162,7 @@ func TestServices(t *testing.T) {
 				t.Fatalf("GetService(%q) => %s, should not exist", missing, svc.Hostname)
 			}
 		})
+		return
 	}
 }
 

--- a/pilot/pkg/serviceregistry/kube/controller/fake.go
+++ b/pilot/pkg/serviceregistry/kube/controller/fake.go
@@ -180,6 +180,9 @@ func NewFakeControllerWithOptions(opts FakeControllerOptions) (*FakeController, 
 		c.AppendServiceHandler(opts.ServiceHandler)
 	}
 	c.stop = opts.Stop
+	if c.stop == nil {
+		c.stop = make(chan struct{})
+	}
 	// Run in initiation to prevent calling each test
 	// TODO: fix it, so we can remove `stop` channel
 	go c.Run(c.stop)

--- a/pilot/pkg/serviceregistry/kube/controller/leak_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/leak_test.go
@@ -1,0 +1,26 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"testing"
+
+	"istio.io/istio/tests/util/leak"
+)
+
+func TestMain(m *testing.M) {
+	// CheckMain asserts that no goroutines are leaked after a test package exits.
+	leak.CheckMain(m)
+}

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 	"time"
 
-	"istio.io/istio/pkg/test/util/retry"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
@@ -30,6 +29,7 @@ import (
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/secretcontroller"
+	"istio.io/istio/pkg/test/util/retry"
 )
 
 const (
@@ -74,7 +74,7 @@ func verifyControllers(t *testing.T, m *Multicluster, expectedControllerCount in
 		m.m.Lock()
 		defer m.m.Unlock()
 		return len(m.remoteKubeControllers) == expectedControllerCount
-	}, retry.Message(timeoutName), retry.Delay(time.Millisecond * 10), retry.Timeout(time.Second * 5))
+	}, retry.Message(timeoutName), retry.Delay(time.Millisecond*10), retry.Timeout(time.Second*5))
 }
 
 func Test_KubeSecretController(t *testing.T) {

--- a/pilot/pkg/serviceregistry/kube/controller/namespacecontroller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/namespacecontroller_test.go
@@ -39,6 +39,9 @@ func TestNamespaceController(t *testing.T) {
 	}, client)
 	nc.configmapLister = client.KubeInformer().Core().V1().ConfigMaps().Lister()
 	stop := make(chan struct{})
+	t.Cleanup(func() {
+		close(stop)
+	})
 	client.RunAndWait(stop)
 	nc.Run(stop)
 

--- a/pilot/pkg/serviceregistry/kube/leak_test.go
+++ b/pilot/pkg/serviceregistry/kube/leak_test.go
@@ -1,0 +1,26 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kube
+
+import (
+	"testing"
+
+	"istio.io/istio/tests/util/leak"
+)
+
+func TestMain(m *testing.M) {
+	// CheckMain asserts that no goroutines are leaked after a test package exits.
+	leak.CheckMain(m)
+}

--- a/pilot/pkg/serviceregistry/leak_test.go
+++ b/pilot/pkg/serviceregistry/leak_test.go
@@ -1,0 +1,26 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package serviceregistry
+
+import (
+	"testing"
+
+	"istio.io/istio/tests/util/leak"
+)
+
+func TestMain(m *testing.M) {
+	// CheckMain asserts that no goroutines are leaked after a test package exits.
+	leak.CheckMain(m)
+}

--- a/pilot/pkg/serviceregistry/serviceentry/leak_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/leak_test.go
@@ -1,0 +1,26 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package serviceentry
+
+import (
+	"testing"
+
+	"istio.io/istio/tests/util/leak"
+)
+
+func TestMain(m *testing.M) {
+	// CheckMain asserts that no goroutines are leaked after a test package exits.
+	leak.CheckMain(m)
+}

--- a/pilot/pkg/status/leak_test.go
+++ b/pilot/pkg/status/leak_test.go
@@ -1,0 +1,26 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package status
+
+import (
+	"testing"
+
+	"istio.io/istio/tests/util/leak"
+)
+
+func TestMain(m *testing.M) {
+	// CheckMain asserts that no goroutines are leaked after a test package exits.
+	leak.CheckMain(m)
+}

--- a/pilot/pkg/status/resourcelock_test.go
+++ b/pilot/pkg/status/resourcelock_test.go
@@ -21,13 +21,7 @@ import (
 
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-
-	"istio.io/istio/tests/util/leak"
 )
-
-func TestMain(m *testing.M) {
-	leak.CheckMain(m)
-}
 
 func TestResourceLock_Lock(t *testing.T) {
 	g := NewGomegaWithT(t)

--- a/pilot/pkg/trustbundle/leak_test.go
+++ b/pilot/pkg/trustbundle/leak_test.go
@@ -1,0 +1,26 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trustbundle
+
+import (
+	"testing"
+
+	"istio.io/istio/tests/util/leak"
+)
+
+func TestMain(m *testing.M) {
+	// CheckMain asserts that no goroutines are leaked after a test package exits.
+	leak.CheckMain(m)
+}

--- a/pilot/pkg/trustbundle/trustbundle_test.go
+++ b/pilot/pkg/trustbundle/trustbundle_test.go
@@ -271,6 +271,7 @@ func TestAddMeshConfigUpdate(t *testing.T) {
 		t.Fatalf("failed to get SystemCertPool: %v", err)
 	}
 	stop := make(chan struct{})
+	t.Cleanup(func() { close(stop) })
 
 	// Mock response from TLS Spiffe Server
 	validHandler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {

--- a/pilot/pkg/util/runtime/leak_test.go
+++ b/pilot/pkg/util/runtime/leak_test.go
@@ -1,0 +1,26 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"testing"
+
+	"istio.io/istio/tests/util/leak"
+)
+
+func TestMain(m *testing.M) {
+	// CheckMain asserts that no goroutines are leaked after a test package exits.
+	leak.CheckMain(m)
+}

--- a/pilot/pkg/xds/ads_test.go
+++ b/pilot/pkg/xds/ads_test.go
@@ -36,7 +36,6 @@ import (
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/test/util/retry"
-	"istio.io/istio/tests/util/leak"
 )
 
 const (
@@ -44,12 +43,7 @@ const (
 	routeB = "https.443.https.my-gateway.testns"
 )
 
-func TestMain(m *testing.M) {
-	leak.CheckMain(m)
-}
-
 func TestStatusEvents(t *testing.T) {
-	leak.Check(t)
 	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
 
 	ads := s.Connect(
@@ -120,7 +114,6 @@ func TestAdsUnsubscribe(t *testing.T) {
 
 // Regression for envoy restart and overlapping connections
 func TestAdsReconnect(t *testing.T) {
-	leak.Check(t)
 	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
 	ads := s.ConnectADS().WithType(v3.ClusterType)
 	ads.RequestResponseAck(nil)
@@ -139,7 +132,6 @@ func TestAdsReconnect(t *testing.T) {
 
 // Regression for connection with a bad ID
 func TestAdsBadId(t *testing.T) {
-	leak.Check(t)
 	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
 	ads := s.ConnectADS().WithID("").WithType(v3.ClusterType)
 	xds.AdsPushAll(s.Discovery)
@@ -177,7 +169,6 @@ func TestAdsClusterUpdate(t *testing.T) {
 
 // nolint: lll
 func TestAdsPushScoping(t *testing.T) {
-	leak.Check(t)
 	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
 
 	const (

--- a/pilot/pkg/xds/debug_test.go
+++ b/pilot/pkg/xds/debug_test.go
@@ -27,11 +27,9 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/xds"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
-	"istio.io/istio/tests/util/leak"
 )
 
 func TestSyncz(t *testing.T) {
-	leak.Check(t)
 	t.Run("return the sent and ack status of adsClient connections", func(t *testing.T) {
 		s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
 		ads := s.ConnectADS()
@@ -133,7 +131,6 @@ func verifySyncStatus(t *testing.T, s *xds.DiscoveryServer, nodeID string, wantS
 }
 
 func TestConfigDump(t *testing.T) {
-	leak.Check(t)
 	tests := []struct {
 		name     string
 		wantCode int
@@ -204,7 +201,6 @@ func getConfigDump(t *testing.T, s *xds.DiscoveryServer, proxyID string, wantCod
 }
 
 func TestDebugHandlers(t *testing.T) {
-	leak.Check(t)
 	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
 	req, err := http.NewRequest("GET", "/debug", nil)
 	if err != nil {

--- a/pilot/pkg/xds/delta_test.go
+++ b/pilot/pkg/xds/delta_test.go
@@ -23,11 +23,9 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
 	"istio.io/istio/pilot/test/xdstest"
-	"istio.io/istio/tests/util/leak"
 )
 
 func TestDeltaAds(t *testing.T) {
-	leak.Check(t)
 	s := NewFakeDiscoveryServer(t, FakeOptions{})
 	ads := s.ConnectDeltaADS().WithType(v3.ClusterType)
 	ads.RequestResponseAck(nil)

--- a/pilot/pkg/xds/discovery_test.go
+++ b/pilot/pkg/xds/discovery_test.go
@@ -30,7 +30,6 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
 	"istio.io/istio/pkg/test/util/retry"
-	"istio.io/istio/tests/util/leak"
 )
 
 func createProxies(n int) []*Connection {
@@ -60,7 +59,6 @@ func wgDoneOrTimeout(wg *sync.WaitGroup, timeout time.Duration) bool {
 }
 
 func TestSendPushesManyPushes(t *testing.T) {
-	leak.Check(t)
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 
@@ -111,7 +109,6 @@ func TestSendPushesManyPushes(t *testing.T) {
 }
 
 func TestSendPushesSinglePush(t *testing.T) {
-	leak.Check(t)
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 
@@ -183,7 +180,6 @@ func (h *fakeStream) Context() context.Context {
 }
 
 func TestDebounce(t *testing.T) {
-	leak.Check(t)
 	// This test tests the timeout and debouncing of config updates
 	// If it is flaking, DebounceAfter may need to be increased, or the code refactored to mock time.
 	// For now, this seems to work well
@@ -331,7 +327,6 @@ func TestDebounce(t *testing.T) {
 }
 
 func TestShouldRespond(t *testing.T) {
-	leak.Check(t)
 	tests := []struct {
 		name       string
 		connection *Connection

--- a/pilot/pkg/xds/leak_test.go
+++ b/pilot/pkg/xds/leak_test.go
@@ -1,0 +1,26 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package xds
+
+import (
+	"testing"
+
+	"istio.io/istio/tests/util/leak"
+)
+
+func TestMain(m *testing.M) {
+	// CheckMain asserts that no goroutines are leaked after a test package exits.
+	leak.CheckMain(m)
+}

--- a/pilot/pkg/xds/pushqueue_test.go
+++ b/pilot/pkg/xds/pushqueue_test.go
@@ -26,7 +26,6 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/gvk"
-	"istio.io/istio/tests/util/leak"
 )
 
 // Helper function to remove an item or timeout and return nil if there are no pending pushes
@@ -76,7 +75,6 @@ func ExpectDequeue(t *testing.T, p *PushQueue, expected *Connection) {
 }
 
 func TestProxyQueue(t *testing.T) {
-	leak.Check(t)
 	proxies := make([]*Connection, 0, 100)
 	for p := 0; p < 100; p++ {
 		proxies = append(proxies, &Connection{ConID: fmt.Sprintf("proxy-%d", p)})

--- a/pilot/test/mock/config.go
+++ b/pilot/test/mock/config.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"go.uber.org/atomic"
-	"istio.io/istio/pkg/test/util/retry"
 
 	networking "istio.io/api/networking/v1alpha3"
 	authz "istio.io/api/security/v1beta1"
@@ -32,6 +31,7 @@ import (
 	"istio.io/istio/pkg/config/schema/collection"
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/test/config"
+	"istio.io/istio/pkg/test/util/retry"
 	"istio.io/pkg/log"
 )
 

--- a/pilot/test/mock/config.go
+++ b/pilot/test/mock/config.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"go.uber.org/atomic"
+	"istio.io/istio/pkg/test/util/retry"
 
 	networking "istio.io/api/networking/v1alpha3"
 	authz "istio.io/api/security/v1beta1"
@@ -30,7 +31,6 @@ import (
 	config2 "istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/collection"
 	"istio.io/istio/pkg/config/schema/collections"
-	pkgtest "istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/config"
 	"istio.io/pkg/log"
 )
@@ -349,9 +349,9 @@ func CheckCacheEvents(store model.ConfigStore, cache model.ConfigStoreCache, nam
 	CheckMapInvariant(store, t, namespace, n)
 
 	log.Infof("Waiting till all events are received")
-	pkgtest.NewEventualOpts(500*time.Millisecond, 60*time.Second).Eventually(t, "receive events", func() bool {
+	retry.UntilOrFail(t, func() bool {
 		return added.Load() == n64 && deleted.Load() == n64
-	})
+	}, retry.Message("receive events"), retry.Delay(time.Millisecond*500), retry.Timeout(time.Minute))
 }
 
 // CheckCacheFreshness validates operational invariants of a cache
@@ -439,7 +439,7 @@ func CheckCacheSync(store model.ConfigStore, cache model.ConfigStoreCache, names
 	stop := make(chan struct{})
 	defer close(stop)
 	go cache.Run(stop)
-	pkgtest.Eventually(t, "HasSynced", cache.HasSynced)
+	retry.UntilOrFail(t, cache.HasSynced, retry.Message("HasSynced"))
 	os, _ := cache.List(mockGvk, namespace)
 	if len(os) != n {
 		t.Errorf("cache.List => Got %d, expected %d", len(os), n)
@@ -453,11 +453,11 @@ func CheckCacheSync(store model.ConfigStore, cache model.ConfigStoreCache, names
 	}
 
 	// check again in the controller cache
-	pkgtest.Eventually(t, "no elements in cache", func() bool {
+	retry.UntilOrFail(t, func() bool {
 		os, _ = cache.List(mockGvk, namespace)
 		log.Infof("cache.List => Got %d, expected %d", len(os), 0)
 		return len(os) == 0
-	})
+	}, retry.Message("no elements in cache"))
 
 	// now add through the controller
 	for i := 0; i < n; i++ {
@@ -467,13 +467,13 @@ func CheckCacheSync(store model.ConfigStore, cache model.ConfigStoreCache, names
 	}
 
 	// check directly through the client
-	pkgtest.Eventually(t, "cache and backing store match", func() bool {
+	retry.UntilOrFail(t, func() bool {
 		cs, _ := cache.List(mockGvk, namespace)
 		os, _ := store.List(mockGvk, namespace)
 		log.Infof("cache.List => Got %d, expected %d", len(cs), n)
 		log.Infof("store.List => Got %d, expected %d", len(os), n)
 		return len(os) == n && len(cs) == n
-	})
+	}, retry.Message("cache and backing store match"))
 
 	// remove elements directly through the client
 	for i := 0; i < n; i++ {

--- a/pkg/config/mesh/kubemesh/leak_test.go
+++ b/pkg/config/mesh/kubemesh/leak_test.go
@@ -1,0 +1,26 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubemesh
+
+import (
+	"testing"
+
+	"istio.io/istio/tests/util/leak"
+)
+
+func TestMain(m *testing.M) {
+	// CheckMain asserts that no goroutines are leaked after a test package exits.
+	leak.CheckMain(m)
+}

--- a/pkg/config/mesh/kubemesh/watcher_test.go
+++ b/pkg/config/mesh/kubemesh/watcher_test.go
@@ -29,6 +29,7 @@ import (
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/util/retry"
 )
 
@@ -65,16 +66,18 @@ func TestExtraConfigmap(t *testing.T) {
 	cmUserinvalid := makeConfigMapWithName(extraCmName, "1", map[string]string{
 		key: "ingressClass: 1",
 	})
-	setup := func() (corev1.ConfigMapInterface, mesh.Watcher) {
+	setup := func(t test.Failer) (corev1.ConfigMapInterface, mesh.Watcher) {
 		client := kube.NewFakeClient()
 		cms := client.Kube().CoreV1().ConfigMaps(namespace)
-		w := NewConfigMapWatcher(client, namespace, name, key, true)
-		AddUserMeshConfig(client, w, namespace, key, extraCmName)
+		stop := make(chan struct{})
+		t.Cleanup(func() { close(stop) })
+		w := NewConfigMapWatcher(client, namespace, name, key, true, stop)
+		AddUserMeshConfig(client, w, namespace, key, extraCmName, stop)
 		return cms, w
 	}
 
 	t.Run("core first", func(t *testing.T) {
-		cms, w := setup()
+		cms, w := setup(t)
 		if _, err := cms.Create(context.Background(), cmCore, metav1.CreateOptions{}); err != nil {
 			t.Fatal(err)
 		}
@@ -84,7 +87,7 @@ func TestExtraConfigmap(t *testing.T) {
 		retry.UntilOrFail(t, func() bool { return w.Mesh().GetIngressClass() == "core" }, retry.Delay(time.Millisecond), retry.Timeout(time.Second))
 	})
 	t.Run("user first", func(t *testing.T) {
-		cms, w := setup()
+		cms, w := setup(t)
 		if _, err := cms.Create(context.Background(), cmUser, metav1.CreateOptions{}); err != nil {
 			t.Fatal(err)
 		}
@@ -94,21 +97,21 @@ func TestExtraConfigmap(t *testing.T) {
 		retry.UntilOrFail(t, func() bool { return w.Mesh().GetIngressClass() == "core" }, retry.Delay(time.Millisecond), retry.Timeout(time.Second))
 	})
 	t.Run("only user", func(t *testing.T) {
-		cms, w := setup()
+		cms, w := setup(t)
 		if _, err := cms.Create(context.Background(), cmUser, metav1.CreateOptions{}); err != nil {
 			t.Fatal(err)
 		}
 		retry.UntilOrFail(t, func() bool { return w.Mesh().GetIngressClass() == "user" }, retry.Delay(time.Millisecond), retry.Timeout(time.Second))
 	})
 	t.Run("only core", func(t *testing.T) {
-		cms, w := setup()
+		cms, w := setup(t)
 		if _, err := cms.Create(context.Background(), cmCore, metav1.CreateOptions{}); err != nil {
 			t.Fatal(err)
 		}
 		retry.UntilOrFail(t, func() bool { return w.Mesh().GetIngressClass() == "core" }, retry.Delay(time.Millisecond), retry.Timeout(time.Second))
 	})
 	t.Run("invalid user config", func(t *testing.T) {
-		cms, w := setup()
+		cms, w := setup(t)
 		if _, err := cms.Create(context.Background(), cmCore, metav1.CreateOptions{}); err != nil {
 			t.Fatal(err)
 		}
@@ -138,7 +141,9 @@ func TestNewConfigMapWatcher(t *testing.T) {
 
 	client := kube.NewFakeClient()
 	cms := client.Kube().CoreV1().ConfigMaps(namespace)
-	w := NewConfigMapWatcher(client, namespace, name, key, false)
+	stop := make(chan struct{})
+	t.Cleanup(func() { close(stop) })
+	w := NewConfigMapWatcher(client, namespace, name, key, false, stop)
 
 	defaultMesh := mesh.DefaultMeshConfig()
 

--- a/pkg/istio-agent/health/health_probers_test.go
+++ b/pkg/istio-agent/health/health_probers_test.go
@@ -25,12 +25,7 @@ import (
 	"time"
 
 	"istio.io/api/networking/v1alpha3"
-	"istio.io/istio/tests/util/leak"
 )
-
-func TestMain(m *testing.M) {
-	leak.CheckMain(m)
-}
 
 func TestHttpProber(t *testing.T) {
 	tests := []struct {

--- a/pkg/istio-agent/health/leak_test.go
+++ b/pkg/istio-agent/health/leak_test.go
@@ -1,0 +1,26 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package health
+
+import (
+	"testing"
+
+	"istio.io/istio/tests/util/leak"
+)
+
+func TestMain(m *testing.M) {
+	// CheckMain asserts that no goroutines are leaked after a test package exits.
+	leak.CheckMain(m)
+}

--- a/pkg/kube/configmapwatcher/configmapwatcher.go
+++ b/pkg/kube/configmapwatcher/configmapwatcher.go
@@ -105,7 +105,9 @@ func (c *Controller) Run(stop <-chan struct{}) {
 
 	// Trigger initial callback.
 	c.queue.Add(struct{}{})
-	wait.Until(c.runWorker, time.Second, stop)
+
+	go wait.Until(c.runWorker, time.Second, stop)
+	<-stop
 }
 
 // HasSynced returns whether the underlying cache has synced and the callback has been called at least once.

--- a/pkg/wasm/cache_test.go
+++ b/pkg/wasm/cache_test.go
@@ -24,13 +24,7 @@ import (
 	"strings"
 	"testing"
 	"time"
-
-	"istio.io/istio/tests/util/leak"
 )
-
-func TestMain(m *testing.M) {
-	leak.CheckMain(m)
-}
 
 func TestWasmCache(t *testing.T) {
 	var tsNumRequest int
@@ -145,7 +139,7 @@ func TestWasmCache(t *testing.T) {
 			cache.mux.Lock()
 			for k, m := range c.initialCachedModules {
 				filePath := filepath.Join(tmpDir, m.modulePath)
-				err := ioutil.WriteFile(filePath, []byte("data/\n"), 0644)
+				err := ioutil.WriteFile(filePath, []byte("data/\n"), 0o644)
 				if err != nil {
 					t.Fatalf("failed to write initial wasm module file %v", err)
 				}

--- a/pkg/wasm/leak_test.go
+++ b/pkg/wasm/leak_test.go
@@ -1,0 +1,26 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wasm
+
+import (
+	"testing"
+
+	"istio.io/istio/tests/util/leak"
+)
+
+func TestMain(m *testing.M) {
+	// CheckMain asserts that no goroutines are leaked after a test package exits.
+	leak.CheckMain(m)
+}

--- a/security/pkg/credentialfetcher/plugin/gce_test.go
+++ b/security/pkg/credentialfetcher/plugin/gce_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/google/uuid"
 
 	"istio.io/istio/pkg/test/util/retry"
-	"istio.io/istio/tests/util/leak"
 )
 
 var (
@@ -305,8 +304,4 @@ func TestTokenRotationJob(t *testing.T) {
 			p.Stop()
 		})
 	}
-}
-
-func TestMain(m *testing.M) {
-	leak.CheckMain(m)
 }

--- a/security/pkg/credentialfetcher/plugin/leak_test.go
+++ b/security/pkg/credentialfetcher/plugin/leak_test.go
@@ -1,0 +1,26 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugin
+
+import (
+	"testing"
+
+	"istio.io/istio/tests/util/leak"
+)
+
+func TestMain(m *testing.M) {
+	// CheckMain asserts that no goroutines are leaked after a test package exits.
+	leak.CheckMain(m)
+}

--- a/security/pkg/nodeagent/cache/leak_test.go
+++ b/security/pkg/nodeagent/cache/leak_test.go
@@ -1,0 +1,26 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"testing"
+
+	"istio.io/istio/tests/util/leak"
+)
+
+func TestMain(m *testing.M) {
+	// CheckMain asserts that no goroutines are leaked after a test package exits.
+	leak.CheckMain(m)
+}

--- a/security/pkg/nodeagent/cache/secretcache_test.go
+++ b/security/pkg/nodeagent/cache/secretcache_test.go
@@ -32,13 +32,8 @@ import (
 	"istio.io/istio/pkg/test/util/retry"
 	"istio.io/istio/pkg/testcerts"
 	"istio.io/istio/security/pkg/nodeagent/caclient/providers/mock"
-	"istio.io/istio/tests/util/leak"
 	"istio.io/pkg/log"
 )
-
-func TestMain(m *testing.M) {
-	leak.CheckMain(m)
-}
 
 func TestWorkloadAgentGenerateSecret(t *testing.T) {
 	t.Run("plugin", func(t *testing.T) {
@@ -376,7 +371,7 @@ func runFileAgentTest(t *testing.T, sds bool) {
 	// We shouldn't get an pushes; these only happen on changes
 	u.Expect(map[string]int{})
 
-	if err := file.AtomicWrite(sc.existingCertificateFile.CertificatePath, testcerts.RotatedCert, os.FileMode(0644)); err != nil {
+	if err := file.AtomicWrite(sc.existingCertificateFile.CertificatePath, testcerts.RotatedCert, os.FileMode(0o644)); err != nil {
 		t.Fatal(err)
 	}
 	// Expect update callback
@@ -388,7 +383,7 @@ func runFileAgentTest(t *testing.T, sds bool) {
 		PrivateKey:       privateKey,
 	})
 
-	if err := file.AtomicWrite(sc.existingCertificateFile.PrivateKeyPath, testcerts.RotatedKey, os.FileMode(0644)); err != nil {
+	if err := file.AtomicWrite(sc.existingCertificateFile.PrivateKeyPath, testcerts.RotatedKey, os.FileMode(0o644)); err != nil {
 		t.Fatal(err)
 	}
 	// We do NOT expect update callback. We only watch the cert file, since the key and cert must be updated
@@ -401,7 +396,7 @@ func runFileAgentTest(t *testing.T, sds bool) {
 		PrivateKey:       testcerts.RotatedKey,
 	})
 
-	if err := file.AtomicWrite(sc.existingCertificateFile.CaCertificatePath, testcerts.CACert, os.FileMode(0644)); err != nil {
+	if err := file.AtomicWrite(sc.existingCertificateFile.CaCertificatePath, testcerts.CACert, os.FileMode(0o644)); err != nil {
 		t.Fatal(err)
 	}
 	// We expect to get an update notification, and the new root cert to be read

--- a/security/pkg/nodeagent/caclient/providers/citadel/client_test.go
+++ b/security/pkg/nodeagent/caclient/providers/citadel/client_test.go
@@ -42,7 +42,6 @@ import (
 	"istio.io/istio/security/pkg/monitoring"
 	"istio.io/istio/security/pkg/nodeagent/util"
 	ca2 "istio.io/istio/security/pkg/server/ca"
-	"istio.io/istio/tests/util/leak"
 )
 
 const (
@@ -117,7 +116,7 @@ func serve(t *testing.T, ca mockCAServer, opts ...grpc.ServerOption) string {
 func TestCitadelClientRotation(t *testing.T) {
 	checkSign := func(t *testing.T, cli security.Client, expectError bool) {
 		t.Helper()
-		resp, err := cli.CSRSign([]byte{01}, 1)
+		resp, err := cli.CSRSign([]byte{0o1}, 1)
 		if expectError != (err != nil) {
 			t.Fatalf("expected error:%v, got error:%v", expectError, err)
 		}
@@ -220,7 +219,7 @@ func TestCitadelClient(t *testing.T) {
 			}
 			t.Cleanup(cli.Close)
 
-			resp, err := cli.CSRSign([]byte{01}, 1)
+			resp, err := cli.CSRSign([]byte{0o1}, 1)
 			if err != nil {
 				if !strings.Contains(err.Error(), tc.expectedErr) {
 					t.Errorf("error (%s) does not match expected error (%s)", err.Error(), tc.expectedErr)
@@ -337,7 +336,7 @@ func TestCitadelClientWithDifferentTypeToken(t *testing.T) {
 					return fmt.Errorf("failed to create ca client: %v", err)
 				}
 				t.Cleanup(cli.Close)
-				resp, err := cli.CSRSign([]byte{01}, 1)
+				resp, err := cli.CSRSign([]byte{0o1}, 1)
 				if err != nil {
 					if !strings.Contains(err.Error(), tc.expectedErr) {
 						return fmt.Errorf("error (%s) does not match expected error (%s)", err.Error(), tc.expectedErr)
@@ -356,8 +355,4 @@ func TestCitadelClientWithDifferentTypeToken(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestMain(m *testing.M) {
-	leak.CheckMain(m)
 }

--- a/security/pkg/nodeagent/caclient/providers/citadel/leak_test.go
+++ b/security/pkg/nodeagent/caclient/providers/citadel/leak_test.go
@@ -1,0 +1,26 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package citadel
+
+import (
+	"testing"
+
+	"istio.io/istio/tests/util/leak"
+)
+
+func TestMain(m *testing.M) {
+	// CheckMain asserts that no goroutines are leaked after a test package exits.
+	leak.CheckMain(m)
+}

--- a/security/pkg/nodeagent/caclient/providers/citadel/leak_test.go
+++ b/security/pkg/nodeagent/caclient/providers/citadel/leak_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package citadel
+package caclient
 
 import (
 	"testing"

--- a/security/pkg/nodeagent/plugin/providers/google/stsclient/leak_test.go
+++ b/security/pkg/nodeagent/plugin/providers/google/stsclient/leak_test.go
@@ -1,0 +1,26 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stsclient
+
+import (
+	"testing"
+
+	"istio.io/istio/tests/util/leak"
+)
+
+func TestMain(m *testing.M) {
+	// CheckMain asserts that no goroutines are leaked after a test package exits.
+	leak.CheckMain(m)
+}

--- a/security/pkg/nodeagent/plugin/providers/google/stsclient/stsclient_test.go
+++ b/security/pkg/nodeagent/plugin/providers/google/stsclient/stsclient_test.go
@@ -24,7 +24,6 @@ import (
 	"istio.io/istio/security/pkg/monitoring"
 	"istio.io/istio/security/pkg/nodeagent/util"
 	"istio.io/istio/security/pkg/stsservice/tokenmanager/google/mock"
-	"istio.io/istio/tests/util/leak"
 )
 
 func TestGetFederatedToken(t *testing.T) {
@@ -85,8 +84,4 @@ func TestGetFederatedToken(t *testing.T) {
 			return nil
 		}, retry.Timeout(time.Second*5))
 	})
-}
-
-func TestMain(m *testing.M) {
-	leak.CheckMain(m)
 }

--- a/security/pkg/nodeagent/sds/leak_test.go
+++ b/security/pkg/nodeagent/sds/leak_test.go
@@ -1,0 +1,26 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sds
+
+import (
+	"testing"
+
+	"istio.io/istio/tests/util/leak"
+)
+
+func TestMain(m *testing.M) {
+	// CheckMain asserts that no goroutines are leaked after a test package exits.
+	leak.CheckMain(m)
+}

--- a/security/pkg/nodeagent/sds/sdsservice_test.go
+++ b/security/pkg/nodeagent/sds/sdsservice_test.go
@@ -28,17 +28,16 @@ import (
 	"istio.io/istio/pilot/pkg/xds"
 	"istio.io/istio/pilot/test/xdstest"
 	ca2 "istio.io/istio/pkg/security"
-	"istio.io/istio/tests/util/leak"
 	"istio.io/pkg/log"
 )
 
 var (
-	fakeRootCert         = []byte{00}
-	fakeCertificateChain = []byte{01}
-	fakePrivateKey       = []byte{02}
+	fakeRootCert         = []byte{0o0}
+	fakeCertificateChain = []byte{0o1}
+	fakePrivateKey       = []byte{0o2}
 
-	fakePushCertificateChain = []byte{03}
-	fakePushPrivateKey       = []byte{04}
+	fakePushCertificateChain = []byte{0o3}
+	fakePushPrivateKey       = []byte{0o4}
 	pushSecret               = &ca2.SecretItem{
 		CertificateChain: fakePushCertificateChain,
 		PrivateKey:       fakePushPrivateKey,
@@ -47,10 +46,6 @@ var (
 	testResourceName = "default"
 	rootResourceName = "ROOTCA"
 )
-
-func TestMain(m *testing.M) {
-	leak.CheckMain(m)
-}
 
 type TestServer struct {
 	t       *testing.T

--- a/tests/util/leak/check.go
+++ b/tests/util/leak/check.go
@@ -139,7 +139,7 @@ func Check(t TestingTB) {
 //       leak.CheckMain(m)
 //   }
 // Failures here are scoped to the package, not a specific test. To determine the source of the failure,
-// you can use the tool `./tools/go-ordered-test.sh ./my/package`. This runs each test individually.
+// you can use the tool `go test -exec $PWD/tools/go-ordered-test ./my/package`. This runs each test individually.
 // If there are some tests that are leaky, you the Check method can be used on individual tests.
 func CheckMain(m TestingM) {
 	exitCode := m.Run()

--- a/tests/util/leak/check.go
+++ b/tests/util/leak/check.go
@@ -105,6 +105,7 @@ func check(filter func(in []*goroutine) []*goroutine) error {
 // Cleanup's called in the test happen first.
 // Any existing goroutines before the test starts are filtered out. This ensures a single test failing doesn't
 // cause all future tests to fail. However, it is still possible another test influences the result when t.Parallel is used.
+// Where possible, CheckMain is preferred.
 func Check(t TestingTB) {
 	existingRaw, err := interestingGoroutines()
 	if err != nil {


### PR DESCRIPTION
First, move all leak check main to dedicate files. This makes it much easier to see which ones have leak check enabled, and also avoids accidentally deleting the check when its in a random spot in some file. Can also search for all packages without leak checker enable with: `find pilot -type d '!' -exec test -e "{}/leak_test.go" \; -exec bash -c 'echo  "$(ls {} | grep test.go | wc -l) {}"' \; | sort -n`

Next, add the leak check to a lot of important packages and fix a lot of leaks. All of these are about just not stopping properly/