### PR TITLE
pilot: cleanup server to only store kubeClient

### DIFF
--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -305,7 +305,7 @@ func (s *Server) initStatusController(args *PilotArgs, writeStatus bool) {
 				AddRunFunction(func(stop <-chan struct{}) {
 					// Controller should be created for calling the run function every time, so it can
 					// avoid concurrently calling of informer Run() for controller in controller.Start
-					controller := status.NewController(*s.kubeRestConfig, args.Namespace, s.RWConfigStore)
+					controller := status.NewController(s.kubeClient.RESTConfig(), args.Namespace, s.RWConfigStore)
 					s.statusReporter.SetController(controller)
 					controller.Start(stop)
 				}).Run(stop)

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -113,8 +113,7 @@ type Server struct {
 	clusterID   string
 	environment *model.Environment
 
-	kubeRestConfig *rest.Config
-	kubeClient     kubelib.Client
+	kubeClient kubelib.Client
 
 	multicluster      *kubecontroller.Multicluster
 	secretsController *kubesecrets.Multicluster
@@ -532,6 +531,10 @@ func (s *Server) initSDSServer(args *PilotArgs) {
 // This is determined by the presence of a kube registry, which
 // uses in-context k8s, or a config source of type k8s.
 func (s *Server) initKubeClient(args *PilotArgs) error {
+	if s.kubeClient != nil {
+		// Already initialized by startup arguments
+		return nil
+	}
 	hasK8SConfigStore := false
 	if args.RegistryOptions.FileDir == "" {
 		// If file dir is set - config controller will just use file.
@@ -554,9 +557,8 @@ func (s *Server) initKubeClient(args *PilotArgs) error {
 	}
 
 	if hasK8SConfigStore || hasKubeRegistry(args.RegistryOptions.Registries) {
-		var err error
 		// Used by validation
-		s.kubeRestConfig, err = kubelib.DefaultRestConfig(args.RegistryOptions.KubeConfig, "", func(config *rest.Config) {
+		kubeRestConfig, err := kubelib.DefaultRestConfig(args.RegistryOptions.KubeConfig, "", func(config *rest.Config) {
 			config.QPS = args.RegistryOptions.KubeOptions.KubernetesAPIQPS
 			config.Burst = args.RegistryOptions.KubeOptions.KubernetesAPIBurst
 		})
@@ -564,7 +566,7 @@ func (s *Server) initKubeClient(args *PilotArgs) error {
 			return fmt.Errorf("failed creating kube config: %v", err)
 		}
 
-		s.kubeClient, err = kubelib.NewClient(kubelib.NewClientConfigForRestConfig(s.kubeRestConfig))
+		s.kubeClient, err = kubelib.NewClient(kubelib.NewClientConfigForRestConfig(kubeRestConfig))
 		if err != nil {
 			return fmt.Errorf("failed creating kube client: %v", err)
 		}

--- a/pilot/pkg/status/state.go
+++ b/pilot/pkg/status/state.go
@@ -66,7 +66,7 @@ type DistributionController struct {
 	cmInformer      cache.SharedIndexInformer
 }
 
-func NewController(restConfig rest.Config, namespace string, cs model.ConfigStore) *DistributionController {
+func NewController(restConfig *rest.Config, namespace string, cs model.ConfigStore) *DistributionController {
 	c := &DistributionController{
 		CurrentState:    make(map[Resource]map[string]Progress),
 		ObservationTime: make(map[string]time.Time),
@@ -81,12 +81,12 @@ func NewController(restConfig rest.Config, namespace string, cs model.ConfigStor
 	restConfig.QPS = float32(features.StatusQPS)
 	restConfig.Burst = features.StatusBurst
 	var err error
-	if c.dynamicClient, err = dynamic.NewForConfig(&restConfig); err != nil {
+	if c.dynamicClient, err = dynamic.NewForConfig(restConfig); err != nil {
 		scope.Fatalf("Could not connect to kubernetes: %s", err)
 	}
 
 	// configmap informer
-	i := informers.NewSharedInformerFactoryWithOptions(kubernetes.NewForConfigOrDie(&restConfig), 1*time.Minute,
+	i := informers.NewSharedInformerFactoryWithOptions(kubernetes.NewForConfigOrDie(restConfig), 1*time.Minute,
 		informers.WithNamespace(namespace),
 		informers.WithTweakListOptions(func(listOptions *metav1.ListOptions) {
 			listOptions.LabelSelector = labels.Set(map[string]string{labelKey: "true"}).AsSelector().String()


### PR DESCRIPTION
No need to store rest config, it shouldn't be used in 99% of cases and
the one valid use case (different QPS) can just call .RestConfig.

BTW - the pointer change is safe since .RestConfig() already does a
copy.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.