### PR TITLE
autoregistration: allow bootstrap node to override locality

### DIFF
--- a/pilot/pkg/controller/workloadentry/workloadentry_controller.go
+++ b/pilot/pkg/controller/workloadentry/workloadentry_controller.go
@@ -619,6 +619,8 @@ func workloadEntryFromGroup(name string, proxy *model.Proxy, groupCfg *config.Co
 	if proxy.Metadata.Network != "" {
 		entry.Network = proxy.Metadata.Network
 	}
+	// proxy.Locality is unset when auto registration takes place, because its
+	// state is not fully initialized. Therefore, we check the bootstrap node.
 	if proxy.XdsNode.Locality != nil {
 		entry.Locality = util.LocalityToString(proxy.XdsNode.Locality)
 	}

--- a/pilot/pkg/controller/workloadentry/workloadentry_controller.go
+++ b/pilot/pkg/controller/workloadentry/workloadentry_controller.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff"
-	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	"github.com/gogo/protobuf/types"
 	"golang.org/x/time/rate"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -253,7 +252,7 @@ func setConnectMeta(c *config.Config, controller string, conTime time.Time) {
 	delete(c.Annotations, DisconnectedAtAnnotation)
 }
 
-func (c *Controller) RegisterWorkload(proxy *model.Proxy, node *core.Node, conTime time.Time) error {
+func (c *Controller) RegisterWorkload(proxy *model.Proxy, conTime time.Time) error {
 	if !features.WorkloadEntryAutoRegistration || c == nil {
 		return nil
 	}
@@ -267,14 +266,14 @@ func (c *Controller) RegisterWorkload(proxy *model.Proxy, node *core.Node, conTi
 	c.adsConnections[makeProxyKey(proxy)]++
 	c.mutex.Unlock()
 
-	if err := c.registerWorkload(entryName, proxy, node, conTime); err != nil {
+	if err := c.registerWorkload(entryName, proxy, conTime); err != nil {
 		log.Errorf(err)
 		return err
 	}
 	return nil
 }
 
-func (c *Controller) registerWorkload(entryName string, proxy *model.Proxy, node *core.Node, conTime time.Time) error {
+func (c *Controller) registerWorkload(entryName string, proxy *model.Proxy, conTime time.Time) error {
 	wle := c.store.Get(gvk.WorkloadEntry, entryName, proxy.Metadata.Namespace)
 	if wle != nil {
 		lastConTime, _ := time.Parse(timeFormat, wle.Annotations[ConnectedAtAnnotation])
@@ -302,7 +301,7 @@ func (c *Controller) registerWorkload(entryName string, proxy *model.Proxy, node
 		return fmt.Errorf("auto-registration WorkloadEntry of %v failed: cannot find WorkloadGroup %s/%s",
 			proxy.ID, proxy.Metadata.Namespace, proxy.Metadata.AutoRegisterGroup)
 	}
-	entry := workloadEntryFromGroup(entryName, proxy, node, groupCfg)
+	entry := workloadEntryFromGroup(entryName, proxy, groupCfg)
 	setConnectMeta(entry, c.instanceID, conTime)
 	_, err := c.store.Create(*entry)
 	if err != nil {
@@ -599,7 +598,7 @@ func mergeLabels(labels ...map[string]string) map[string]string {
 
 var workloadGroupIsController = true
 
-func workloadEntryFromGroup(name string, proxy *model.Proxy, node *core.Node, groupCfg *config.Config) *config.Config {
+func workloadEntryFromGroup(name string, proxy *model.Proxy, groupCfg *config.Config) *config.Config {
 	group := groupCfg.Spec.(*v1alpha3.WorkloadGroup)
 	entry := group.Template.DeepCopy()
 	entry.Address = proxy.IPAddresses[0]
@@ -620,8 +619,8 @@ func workloadEntryFromGroup(name string, proxy *model.Proxy, node *core.Node, gr
 	if proxy.Metadata.Network != "" {
 		entry.Network = proxy.Metadata.Network
 	}
-	if node.Locality != nil {
-		entry.Locality = util.LocalityToString(node.Locality)
+	if proxy.XdsNode.Locality != nil {
+		entry.Locality = util.LocalityToString(proxy.XdsNode.Locality)
 	}
 	if proxy.Metadata.ProxyConfig != nil && proxy.Metadata.ProxyConfig.ReadinessProbe != nil {
 		annotations[status.WorkloadEntryHealthCheckAnnotation] = "true"

--- a/pilot/pkg/controller/workloadentry/workloadentry_controller_test.go
+++ b/pilot/pkg/controller/workloadentry/workloadentry_controller_test.go
@@ -85,8 +85,6 @@ func TestNonAutoregisteredWorkloads(t *testing.T) {
 	go c.Run(stop)
 	defer close(stop)
 
-	n := core.Node{}
-
 	cases := map[string]*model.Proxy{
 		"missing group":      {IPAddresses: []string{"1.2.3.4"}, Metadata: &model.NodeMetadata{Namespace: wgA.Namespace}},
 		"missing ip":         {Metadata: &model.NodeMetadata{Namespace: wgA.Namespace, AutoRegisterGroup: wgA.Name}},
@@ -97,7 +95,7 @@ func TestNonAutoregisteredWorkloads(t *testing.T) {
 	for name, tc := range cases {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
-			c.RegisterWorkload(tc, &n, time.Now())
+			c.RegisterWorkload(tc, time.Now())
 			items, err := store.List(gvk.WorkloadEntry, model.NamespaceAll)
 			if err != nil {
 				t.Fatalf("failed listing WorkloadEntry: %v", err)
@@ -125,23 +123,28 @@ func TestAutoregistrationLifecycle(t *testing.T) {
 	go c1.Run(stop1)
 	go c2.Run(stop2)
 
-	p := fakeProxy("1.2.3.4", wgA, "nw1")
-	p2 := fakeProxy("1.2.3.4", wgA, "nw2")
-	p3 := fakeProxy("1.2.3.5", wgA, "nw1")
-
 	n := fakeNode("reg1", "zone1", "subzone1")
+
+	p := fakeProxy("1.2.3.4", wgA, "nw1")
+	p.XdsNode = n
+
+	p2 := fakeProxy("1.2.3.4", wgA, "nw2")
+	p2.XdsNode = n
+
+	p3 := fakeProxy("1.2.3.5", wgA, "nw1")
+	p3.XdsNode = n
 
 	// allows associating a Register call with Unregister
 	var origConnTime time.Time
 
 	t.Run("initial registration", func(t *testing.T) {
 		// simply make sure the entry exists after connecting
-		c1.RegisterWorkload(p, n, time.Now())
+		c1.RegisterWorkload(p, time.Now())
 		checkEntryOrFail(t, store, wgA, p, n, c1.instanceID)
 	})
 	t.Run("multinetwork same ip", func(t *testing.T) {
 		// make sure we don't overrwrite a similar entry for a different network
-		c2.RegisterWorkload(p2, n, time.Now())
+		c2.RegisterWorkload(p2, time.Now())
 		checkEntryOrFail(t, store, wgA, p, n, c1.instanceID)
 		checkEntryOrFail(t, store, wgA, p2, n, c2.instanceID)
 	})
@@ -153,12 +156,12 @@ func TestAutoregistrationLifecycle(t *testing.T) {
 			checkEntryOrFail(t, store, wgA, p, n, "")
 			// reconnect, ensure entry is there with the same instance id
 			origConnTime = time.Now()
-			c1.RegisterWorkload(p, n, origConnTime)
+			c1.RegisterWorkload(p, origConnTime)
 			checkEntryOrFail(t, store, wgA, p, n, c1.instanceID)
 		})
 		t.Run("same instance: connect before disconnect ", func(t *testing.T) {
 			// reconnect, ensure entry is there with the same instance id
-			c1.RegisterWorkload(p, n, origConnTime.Add(10*time.Millisecond))
+			c1.RegisterWorkload(p, origConnTime.Add(10*time.Millisecond))
 			// disconnect (associated with original connect, not the reconnect)
 			// make sure entry is still there with disconnect meta
 			c1.QueueUnregisterWorkload(p, origConnTime)
@@ -172,7 +175,7 @@ func TestAutoregistrationLifecycle(t *testing.T) {
 			checkEntryOrFail(t, store, wgA, p, n, "")
 			// reconnect, ensure entry is there with the new instance id
 			origConnTime = time.Now()
-			c2.RegisterWorkload(p, n, origConnTime)
+			c2.RegisterWorkload(p, origConnTime)
 			checkEntryOrFail(t, store, wgA, p, n, c2.instanceID)
 		})
 	})
@@ -184,7 +187,7 @@ func TestAutoregistrationLifecycle(t *testing.T) {
 		})
 		// reconnect
 		origConnTime = time.Now()
-		c1.RegisterWorkload(p, n, origConnTime)
+		c1.RegisterWorkload(p, origConnTime)
 		checkEntryOrFail(t, store, wgA, p, n, c1.instanceID)
 	})
 	t.Run("garbage collected if pilot stops after disconnect", func(t *testing.T) {
@@ -201,7 +204,7 @@ func TestAutoregistrationLifecycle(t *testing.T) {
 
 	t.Run("garbage collected if pilot and workload stops simultaneously before pilot can do anything", func(t *testing.T) {
 		// simulate p3 has been registered long before
-		c2.RegisterWorkload(p3, n, time.Now().Add(-2*maxConnAge))
+		c2.RegisterWorkload(p3, time.Now().Add(-2*maxConnAge))
 
 		// keep silent to simulate the scenario
 
@@ -223,8 +226,8 @@ func TestUpdateHealthCondition(t *testing.T) {
 	go ig.Run(stop)
 	go ig2.Run(stop)
 	p := fakeProxy("1.2.3.4", wgA, "litNw")
-	n := fakeNode("reg1", "zone1", "subzone1")
-	ig.RegisterWorkload(p, n, time.Now())
+	p.XdsNode = fakeNode("reg1", "zone1", "subzone1")
+	ig.RegisterWorkload(p, time.Now())
 	t.Run("auto registered healthy health", func(t *testing.T) {
 		ig.QueueWorkloadEntryHealth(p, HealthEvent{
 			Healthy: true,
@@ -266,7 +269,7 @@ func TestWorkloadEntryFromGroup(t *testing.T) {
 		},
 	}
 	proxy := fakeProxy("10.0.0.1", group, "nw1")
-	node := fakeNode("rgn2", "zone2", "subzone2")
+	proxy.XdsNode = fakeNode("rgn2", "zone2", "subzone2")
 
 	wantLabels := map[string]string{
 		"app":   "a",   // from WorkloadEntry template
@@ -305,7 +308,7 @@ func TestWorkloadEntryFromGroup(t *testing.T) {
 		},
 	}
 
-	got := workloadEntryFromGroup("test-we", proxy, node, &group)
+	got := workloadEntryFromGroup("test-we", proxy, &group)
 	if diff := cmp.Diff(got, &want); diff != "" {
 		t.Errorf(diff)
 	}

--- a/pilot/pkg/controller/workloadentry/workloadentry_controller_test.go
+++ b/pilot/pkg/controller/workloadentry/workloadentry_controller_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/go-multierror"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,6 +32,7 @@ import (
 	"istio.io/istio/pilot/pkg/config/memory"
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/config/schema/gvk"
@@ -55,6 +57,8 @@ var (
 		Template: &v1alpha3.WorkloadEntry{
 			Ports:          map[string]uint32{"http": 80},
 			Labels:         map[string]string{"app": "a"},
+			Network:        "nw0",
+			Locality:       "reg0/zone0/subzone0",
 			Weight:         1,
 			ServiceAccount: "sa-a",
 		},
@@ -123,30 +127,32 @@ func TestAutoregistrationLifecycle(t *testing.T) {
 	p2 := fakeProxy("1.2.3.4", wgA, "nw2")
 	p3 := fakeProxy("1.2.3.5", wgA, "nw1")
 
+	n := fakeNode("reg1", "zone1", "subzone1")
+
 	// allows associating a Register call with Unregister
 	var origConnTime time.Time
 
 	t.Run("initial registration", func(t *testing.T) {
 		// simply make sure the entry exists after connecting
 		c1.RegisterWorkload(p, time.Now())
-		checkEntryOrFail(t, store, wgA, p, c1.instanceID)
+		checkEntryOrFail(t, store, wgA, p, n, c1.instanceID)
 	})
 	t.Run("multinetwork same ip", func(t *testing.T) {
 		// make sure we don't overrwrite a similar entry for a different network
 		c2.RegisterWorkload(p2, time.Now())
-		checkEntryOrFail(t, store, wgA, p, c1.instanceID)
-		checkEntryOrFail(t, store, wgA, p2, c2.instanceID)
+		checkEntryOrFail(t, store, wgA, p, n, c1.instanceID)
+		checkEntryOrFail(t, store, wgA, p2, n, c2.instanceID)
 	})
 	t.Run("fast reconnect", func(t *testing.T) {
 		t.Run("same instance", func(t *testing.T) {
 			// disconnect, make sure entry is still there with disconnect meta
 			c1.QueueUnregisterWorkload(p, time.Now())
 			time.Sleep(features.WorkloadEntryCleanupGracePeriod / 2)
-			checkEntryOrFail(t, store, wgA, p, "")
+			checkEntryOrFail(t, store, wgA, p, n, "")
 			// reconnect, ensure entry is there with the same instance id
 			origConnTime = time.Now()
 			c1.RegisterWorkload(p, origConnTime)
-			checkEntryOrFail(t, store, wgA, p, c1.instanceID)
+			checkEntryOrFail(t, store, wgA, p, n, c1.instanceID)
 		})
 		t.Run("same instance: connect before disconnect ", func(t *testing.T) {
 			// reconnect, ensure entry is there with the same instance id
@@ -155,17 +161,17 @@ func TestAutoregistrationLifecycle(t *testing.T) {
 			// make sure entry is still there with disconnect meta
 			c1.QueueUnregisterWorkload(p, origConnTime)
 			time.Sleep(features.WorkloadEntryCleanupGracePeriod / 2)
-			checkEntryOrFail(t, store, wgA, p, c1.instanceID)
+			checkEntryOrFail(t, store, wgA, p, n, c1.instanceID)
 		})
 		t.Run("different instance", func(t *testing.T) {
 			// disconnect, make sure entry is still there with disconnect metadata
 			c1.QueueUnregisterWorkload(p, time.Now())
 			time.Sleep(features.WorkloadEntryCleanupGracePeriod / 2)
-			checkEntryOrFail(t, store, wgA, p, "")
+			checkEntryOrFail(t, store, wgA, p, n, "")
 			// reconnect, ensure entry is there with the new instance id
 			origConnTime = time.Now()
 			c2.RegisterWorkload(p, origConnTime)
-			checkEntryOrFail(t, store, wgA, p, c2.instanceID)
+			checkEntryOrFail(t, store, wgA, p, n, c2.instanceID)
 		})
 	})
 	t.Run("slow reconnect", func(t *testing.T) {
@@ -177,7 +183,7 @@ func TestAutoregistrationLifecycle(t *testing.T) {
 		// reconnect
 		origConnTime = time.Now()
 		c1.RegisterWorkload(p, origConnTime)
-		checkEntryOrFail(t, store, wgA, p, c1.instanceID)
+		checkEntryOrFail(t, store, wgA, p, n, c1.instanceID)
 	})
 	t.Run("garbage collected if pilot stops after disconnect", func(t *testing.T) {
 		// disconnect, kill the cleanup queue from the first controller
@@ -250,11 +256,14 @@ func TestWorkloadEntryFromGroup(t *testing.T) {
 				Ports:          map[string]uint32{"http": 80},
 				Labels:         map[string]string{"app": "a"},
 				Weight:         1,
+				Network:        "nw0",
+				Locality:       "rgn1/zone1/subzone1",
 				ServiceAccount: "sa-a",
 			},
 		},
 	}
 	proxy := fakeProxy("10.0.0.1", group, "nw1")
+	node := fakeNode("rgn2", "zone2", "subzone2")
 
 	wantLabels := map[string]string{
 		"app":   "a",   // from WorkloadEntry template
@@ -287,12 +296,13 @@ func TestWorkloadEntryFromGroup(t *testing.T) {
 			},
 			Labels:         wantLabels,
 			Network:        "nw1",
+			Locality:       "rgn2/zone2/subzone2",
 			Weight:         1,
 			ServiceAccount: "sa-a",
 		},
 	}
 
-	got := workloadEntryFromGroup("test-we", proxy, &group)
+	got := workloadEntryFromGroup("test-we", proxy, node, &group)
 	if diff := cmp.Diff(got, &want); diff != "" {
 		t.Errorf(diff)
 	}
@@ -323,6 +333,7 @@ func checkEntry(
 	store model.ConfigStoreCache,
 	wg config.Config,
 	proxy *model.Proxy,
+	node *core.Node,
 	connectedTo string,
 ) (err error) {
 	name := wg.Name + "-" + proxy.IPAddresses[0]
@@ -354,6 +365,14 @@ func checkEntry(
 		if we.Network != tmpl.Template.Network {
 			err = multierror.Append(fmt.Errorf("entry has network %s; expected to match group template network %s", we.Network, tmpl.Template.Network))
 		}
+	}
+
+	loc := tmpl.Template.Locality
+	if node.Locality != nil {
+		loc = util.LocalityToString(node.Locality)
+	}
+	if we.Locality != loc {
+		err = multierror.Append(fmt.Errorf("entry has locality %s; expected %s", we.Locality, loc))
 	}
 
 	// check controller annotations
@@ -394,9 +413,10 @@ func checkEntryOrFail(
 	store model.ConfigStoreCache,
 	wg config.Config,
 	proxy *model.Proxy,
+	node *core.Node,
 	connectedTo string,
 ) {
-	if err := checkEntry(store, wg, proxy, connectedTo); err != nil {
+	if err := checkEntry(store, wg, proxy, node, connectedTo); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -455,6 +475,16 @@ func fakeProxy(ip string, wg config.Config, nw string) *model.Proxy {
 			Namespace:         wg.Namespace,
 			Network:           nw,
 			Labels:            map[string]string{"merge": "me"},
+		},
+	}
+}
+
+func fakeNode(r, z, sz string) *core.Node {
+	return &core.Node{
+		Locality: &core.Locality{
+			Region:  r,
+			Zone:    z,
+			SubZone: sz,
 		},
 	}
 }

--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -568,7 +568,7 @@ func (s *DiscoveryServer) initializeProxy(node *core.Node, con *Connection) erro
 	proxy := con.proxy
 	// this should be done before we look for service instances, but after we load metadata
 	// TODO fix check in kubecontroller treat echo VMs like there isn't a pod
-	if err := s.WorkloadEntryController.RegisterWorkload(proxy, node, con.Connect); err != nil {
+	if err := s.WorkloadEntryController.RegisterWorkload(proxy, con.Connect); err != nil {
 		return err
 	}
 

--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -568,7 +568,7 @@ func (s *DiscoveryServer) initializeProxy(node *core.Node, con *Connection) erro
 	proxy := con.proxy
 	// this should be done before we look for service instances, but after we load metadata
 	// TODO fix check in kubecontroller treat echo VMs like there isn't a pod
-	if err := s.WorkloadEntryController.RegisterWorkload(proxy, con.Connect); err != nil {
+	if err := s.WorkloadEntryController.RegisterWorkload(proxy, node, con.Connect); err != nil {
 		return err
 	}
 

--- a/releasenotes/notes/autoregistered-workload-entry-locality.yaml
+++ b/releasenotes/notes/autoregistered-workload-entry-locality.yaml
@@ -1,0 +1,15 @@
+apiVersion: release-notes/v2
+
+kind: feature
+
+area: traffic-management
+
+issue:
+- https://github.com/istio/istio/pull/33426
+- 33426
+
+releaseNotes:
+- |
+  **Added** support for overriding the locality of the WorkloadGroup template in
+  auto registered WorkloadEntries. Locality overrides can be passed in through
+  Envoy bootstrap configuration.


### PR DESCRIPTION
During testing of VM autoregistration, we discovered that it is not
possible to override the WorkloadGroup template's locality from the
bootstrap node locality. The core issue is that istiod initializes the
proxy struct from the bootstrap node before passing it to the
autoregistration controller; however, the node's locality is not set on
the proxy at that time. This is fixed by passing the bootstrap node
along to autoregistration code in addition to the proxy.

Change-Id: Id9b1d2f0cc5d2cf9416670c26b0a490d302ea039
Reviewed-on: https://gerrit.musta.ch/c/public/istio/+/1391
Reviewed-by: Weibo He <weibo.he@airbnb.com>
Reviewed-by: Jungho Ahn <jungho.ahn@airbnb.com>



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.

@hzxuzhonghu @howardjohn @stevenctl 