### PR TITLE
istioctl crashed at retrieveListenerAddress 

### DIFF
--- a/istioctl/pkg/writer/envoy/configdump/listener.go
+++ b/istioctl/pkg/writer/envoy/configdump/listener.go
@@ -104,7 +104,17 @@ func retrieveListenerType(l *listener.Listener) string {
 }
 
 func retrieveListenerAddress(l *listener.Listener) string {
-	return l.Address.GetSocketAddress().Address
+	sockAddr := l.Address.GetSocketAddress()
+	if nil != sockAddr {
+		return sockAddr.Address
+	}
+
+	pipe := l.Address.GetPipe()
+	if nil != pipe {
+		return pipe.Path
+	}
+
+	return ""
 }
 
 func retrieveListenerPort(l *listener.Listener) uint32 {

--- a/istioctl/pkg/writer/envoy/configdump/listener.go
+++ b/istioctl/pkg/writer/envoy/configdump/listener.go
@@ -105,12 +105,12 @@ func retrieveListenerType(l *listener.Listener) string {
 
 func retrieveListenerAddress(l *listener.Listener) string {
 	sockAddr := l.Address.GetSocketAddress()
-	if nil != sockAddr {
+	if sockAddr != nil {
 		return sockAddr.Address
 	}
 
 	pipe := l.Address.GetPipe()
-	if nil != pipe {
+	if pipe != nil {
 		return pipe.Path
 	}
 

--- a/istioctl/pkg/writer/envoy/configdump/listener_test.go
+++ b/istioctl/pkg/writer/envoy/configdump/listener_test.go
@@ -137,6 +137,22 @@ func TestListenerFilter_Verify(t *testing.T) {
 			},
 			expect: true,
 		},
+		{
+			desc: "listener-pipe",
+			inFilter: &ListenerFilter{
+				Address: "",
+				Port:    0,
+				Type:    "",
+			},
+			inListener: &listener.Listener{
+				Address: &v3.Address{
+					Address: &v3.Address_Pipe{
+						Pipe: &v3.Pipe{Path: "unix:///dev/shm/uds.socket"},
+					},
+				},
+			},
+			expect: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
**ISSUE:** 
  https://github.com/istio/istio/issues/33432
  istioctl crashed when retrieving the listener config which is listening on an unix domain socket
  100% percent re-produciable
**Root cause:**
  retrieveListenerAddress call the GetSocketAddress() by default which would return nil in this case
  and further reference would crash the code
**Solution:**
  add GetPipe() to the logic to handle difference listeners
**Unit-test:**
  issue cannot be re-produced with this fix following the re-producing procedure

before fix 
```
$ istioctl pc listeners python-6db574dd4d-6trft.uds
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0x2608c0f]

goroutine 1 [running]:
istio.io/istio/istioctl/pkg/writer/envoy/configdump.retrieveListenerAddress(...)
        istio.io/istio/istioctl/pkg/writer/envoy/configdump/listener.go:107
istio.io/istio/istioctl/pkg/writer/envoy/configdump.(*ConfigWriter).PrintListenerSummary(0xc0004e9830, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0)
        istio.io/istio/istioctl/pkg/writer/envoy/configdump/listener.go:151 +0x32f
istio.io/istio/istioctl/cmd.listenerConfigCmd.func2(0xc0013b8780, 0xc00041b300, 0x1, 0x1, 0x0, 0x0)
        istio.io/istio/istioctl/cmd/proxyconfig.go:526 +0x333
github.com/spf13/cobra.(*Command).execute(0xc0013b8780, 0xc00041b2a0, 0x1, 0x1, 0xc0013b8780, 0xc00041b2a0)
        github.com/spf13/cobra@v1.1.3/command.go:852 +0x472
github.com/spf13/cobra.(*Command).ExecuteC(0xc000d3f900, 0x3, 0x3, 0xc000d3f900)
        github.com/spf13/cobra@v1.1.3/command.go:960 +0x375
github.com/spf13/cobra.(*Command).Execute(...)
        github.com/spf13/cobra@v1.1.3/command.go:897
main.main()
        istio.io/istio/istioctl/cmd/istioctl/main.go:36 +0x12b
```
after fix
```
$ out/linux_amd64/istioctl pc listeners python-6db574dd4d-6trft.uds
ADDRESS             PORT  MATCH                                                                                                       DESTINATION
/dev/shm/out.socket 0     ALL                                                                                                         Route: unix:///dev/shm/out.socket
0.0.0.0             15001 ALL                                                                                                         PassthroughCluster
0.0.0.0             15001 Addr: *:15001                                                                                               Non-HTTP/Non-TCP
0.0.0.0             15006 Addr: *:15006                                                                                               Non-HTTP/Non-TCP
0.0.0.0             15006 Trans: tls; App: istio-http/1.0,istio-http/1.1,istio-h2; Addr: 0.0.0.0/0                                    InboundPassthroughClusterIpv4
0.0.0.0             15006 Trans: raw_buffer; App: HTTP; Addr: 0.0.0.0/0                                                               InboundPassthroughClusterIpv4
0.0.0.0             15006 Trans: tls; App: TCP TLS; Addr: 0.0.0.0/0                                                                   InboundPassthroughClusterIpv4
0.0.0.0             15006 Trans: raw_buffer; Addr: 0.0.0.0/0                                                                          InboundPassthroughClusterIpv4
0.0.0.0             15006 Trans: tls; Addr: 0.0.0.0/0                                                                                 InboundPassthroughClusterIpv4
0.0.0.0             15006 Trans: tls; App: istio,istio-peer-exchange,istio-http/1.0,istio-http/1.1,istio-h2; Addr: 10.88.0.67/32:9999 Cluster: inbound|9999||
0.0.0.0             15006 Trans: raw_buffer; Addr: 10.88.0.67/32:9999                                                                 Cluster: inbound|9999||
0.0.0.0             15021 ALL                                                                                                         Inline Route: /healthz/ready*
0.0.0.0             15090 ALL                                                                                                         Inline Route: /stats/prometheus*
```

refer to issue https://github.com/istio/istio/issues/33432


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[X] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.