### PR TITLE
[1.10] Fix regression when using custom transport_socket envoyfilter (#33386)

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/cluster_patch.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/cluster_patch.go
@@ -59,7 +59,9 @@ func ApplyClusterMerge(pctx networking.EnvoyFilter_PatchContext, efw *model.Envo
 }
 
 // Test if the patch contains a config for TransportSocket
-func mergeTransportSocketCluster(c *cluster.Cluster, cp *model.EnvoyFilterConfigPatchWrapper) (bool, error) {
+// Returns a boolean indicating if the merge was handled by this function; if false, it should still be called
+// outside of this function.
+func mergeTransportSocketCluster(c *cluster.Cluster, cp *model.EnvoyFilterConfigPatchWrapper) (merged bool, err error) {
 	cpValueCast, okCpCast := (cp.Value).(*cluster.Cluster)
 	if !okCpCast {
 		return false, fmt.Errorf("cast of cp.Value failed: %v", okCpCast)
@@ -76,9 +78,19 @@ func mergeTransportSocketCluster(c *cluster.Cluster, cp *model.EnvoyFilterConfig
 				break
 			}
 		}
+		if tsmPatch == nil && len(c.GetTransportSocketMatches()) > 0 {
+			// If we merged we would get both a transport_socket and transport_socket_matches which is not valid
+			// Drop the filter, but indicate that we handled the merge so that the outer function does not try
+			// to merge it again
+			return true, nil
+		}
 	} else if cpValueCast.GetTransportSocket() != nil && c.GetTransportSocket() != nil {
 		if cpValueCast.GetTransportSocket().Name == c.GetTransportSocket().Name {
 			tsmPatch = c.GetTransportSocket()
+		} else {
+			// There is a name mismatch, so we cannot do a deep merge. Instead just replace the transport socket
+			c.TransportSocket = cpValueCast.TransportSocket
+			return true, nil
 		}
 	}
 

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/cluster_patch_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/cluster_patch_test.go
@@ -17,6 +17,7 @@ package envoyfilter
 import (
 	"testing"
 
+	udpa "github.com/cncf/udpa/go/udpa/type/v1"
 	cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	tls "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
@@ -241,6 +242,11 @@ func TestClusterPatching(t *testing.T) {
 			ApplyTo: networking.EnvoyFilter_CLUSTER,
 			Match: &networking.EnvoyFilter_EnvoyConfigObjectMatch{
 				Context: networking.EnvoyFilter_SIDECAR_OUTBOUND,
+				ObjectTypes: &networking.EnvoyFilter_EnvoyConfigObjectMatch_Cluster{
+					Cluster: &networking.EnvoyFilter_ClusterMatch{
+						PortNumber: 443,
+					},
+				},
 			},
 			Patch: &networking.EnvoyFilter_Patch{
 				Operation: networking.EnvoyFilter_Patch_MERGE,
@@ -254,11 +260,33 @@ func TestClusterPatching(t *testing.T) {
 								"tls_minimum_protocol_version":"TLSv1_3"}}}}}`),
 			},
 		},
+		// Patch custom TLS type
+		{
+			ApplyTo: networking.EnvoyFilter_CLUSTER,
+			Match: &networking.EnvoyFilter_EnvoyConfigObjectMatch{
+				Context: networking.EnvoyFilter_SIDECAR_OUTBOUND,
+				ObjectTypes: &networking.EnvoyFilter_EnvoyConfigObjectMatch_Cluster{
+					Cluster: &networking.EnvoyFilter_ClusterMatch{
+						PortNumber: 7777,
+					},
+				},
+			},
+			Patch: &networking.EnvoyFilter_Patch{
+				Operation: networking.EnvoyFilter_Patch_MERGE,
+				Value: buildPatchStruct(`
+					{"transport_socket":{
+						"name":"transport_sockets.alts",
+						"typed_config":{
+							"@type":"type.googleapis.com/udpa.type.v1.TypedStruct",
+              "type_url": "type.googleapis.com/envoy.extensions.transport_sockets.alts.v3.Alts",
+							"value":{"handshaker_service":"1.2.3.4"}}}}`),
+			},
+		},
 	}
 
 	sidecarOutboundIn := []*cluster.Cluster{
 		{
-			Name:            "cluster1",
+			Name:            "outbound|443||cluster1",
 			DnsLookupFamily: cluster.Cluster_V4_ONLY,
 			LbPolicy:        cluster.Cluster_ROUND_ROBIN,
 			TransportSocketMatches: []*cluster.Cluster_TransportSocketMatch{
@@ -285,14 +313,14 @@ func TestClusterPatching(t *testing.T) {
 			},
 		},
 		{
-			Name: "cluster2",
+			Name: "outbound|443||cluster2",
 			Http2ProtocolOptions: &core.Http2ProtocolOptions{
 				AllowConnect:  true,
 				AllowMetadata: true,
 			}, LbPolicy: cluster.Cluster_MAGLEV,
 		},
 		{
-			Name:            "cluster3",
+			Name:            "outbound|443||cluster3",
 			DnsLookupFamily: cluster.Cluster_V4_ONLY,
 			LbPolicy:        cluster.Cluster_ROUND_ROBIN,
 			TransportSocket: &core.TransportSocket{
@@ -313,11 +341,63 @@ func TestClusterPatching(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name: "outbound|7777||custom-tls-addition",
+		},
+		{
+			Name:            "outbound|7777||custom-tls-replacement",
+			DnsLookupFamily: cluster.Cluster_V4_ONLY,
+			LbPolicy:        cluster.Cluster_ROUND_ROBIN,
+			TransportSocket: &core.TransportSocket{
+				Name: "envoy.transport_sockets.tls",
+				ConfigType: &core.TransportSocket_TypedConfig{
+					TypedConfig: util.MessageToAny(&tls.UpstreamTlsContext{
+						CommonTlsContext: &tls.CommonTlsContext{
+							TlsParams: &tls.TlsParameters{
+								EcdhCurves:                []string{"X25519"},
+								TlsMinimumProtocolVersion: tls.TlsParameters_TLSv1_1,
+							},
+							TlsCertificateCertificateProviderInstance: &tls.CommonTlsContext_CertificateProviderInstance{
+								InstanceName:    "instance",
+								CertificateName: "certificate",
+							},
+						},
+					}),
+				},
+			},
+		},
+		{
+			Name:            "outbound|7777||custom-tls-replacement-tsm",
+			DnsLookupFamily: cluster.Cluster_V4_ONLY,
+			LbPolicy:        cluster.Cluster_ROUND_ROBIN,
+			TransportSocketMatches: []*cluster.Cluster_TransportSocketMatch{
+				{
+					Name: "tlsMode-istio",
+					TransportSocket: &core.TransportSocket{
+						Name: "envoy.transport_sockets.tls",
+						ConfigType: &core.TransportSocket_TypedConfig{
+							TypedConfig: util.MessageToAny(&tls.UpstreamTlsContext{
+								CommonTlsContext: &tls.CommonTlsContext{
+									TlsParams: &tls.TlsParameters{
+										EcdhCurves:                []string{"X25519"},
+										TlsMinimumProtocolVersion: tls.TlsParameters_TLSv1_1,
+									},
+									TlsCertificateCertificateProviderInstance: &tls.CommonTlsContext_CertificateProviderInstance{
+										InstanceName:    "instance",
+										CertificateName: "certificate",
+									},
+								},
+							}),
+						},
+					},
+				},
+			},
+		},
 	}
 
 	sidecarOutboundOut := []*cluster.Cluster{
 		{
-			Name:            "cluster1",
+			Name:            "outbound|443||cluster1",
 			DnsLookupFamily: cluster.Cluster_V6_ONLY,
 			LbPolicy:        cluster.Cluster_RING_HASH,
 			TransportSocketMatches: []*cluster.Cluster_TransportSocketMatch{
@@ -344,7 +424,7 @@ func TestClusterPatching(t *testing.T) {
 			},
 		},
 		{
-			Name: "cluster2",
+			Name: "outbound|443||cluster2",
 			Http2ProtocolOptions: &core.Http2ProtocolOptions{
 				AllowConnect:  true,
 				AllowMetadata: true,
@@ -365,7 +445,7 @@ func TestClusterPatching(t *testing.T) {
 			},
 		},
 		{
-			Name:            "cluster3",
+			Name:            "outbound|443||cluster3",
 			DnsLookupFamily: cluster.Cluster_V6_ONLY,
 			LbPolicy:        cluster.Cluster_RING_HASH,
 			TransportSocket: &core.TransportSocket{
@@ -384,6 +464,61 @@ func TestClusterPatching(t *testing.T) {
 							},
 						},
 					}),
+				},
+			},
+		},
+		{
+			Name:            "outbound|7777||custom-tls-addition",
+			DnsLookupFamily: cluster.Cluster_V6_ONLY,
+			LbPolicy:        cluster.Cluster_RING_HASH,
+			TransportSocket: &core.TransportSocket{
+				Name: "transport_sockets.alts",
+				ConfigType: &core.TransportSocket_TypedConfig{
+					TypedConfig: util.MessageToAny(&udpa.TypedStruct{
+						TypeUrl: "type.googleapis.com/envoy.extensions.transport_sockets.alts.v3.Alts",
+						Value:   buildGolangPatchStruct(`{"handshaker_service":"1.2.3.4"}`),
+					}),
+				},
+			},
+		},
+		{
+			Name:            "outbound|7777||custom-tls-replacement",
+			DnsLookupFamily: cluster.Cluster_V6_ONLY,
+			LbPolicy:        cluster.Cluster_RING_HASH,
+			TransportSocket: &core.TransportSocket{
+				Name: "transport_sockets.alts",
+				ConfigType: &core.TransportSocket_TypedConfig{
+					TypedConfig: util.MessageToAny(&udpa.TypedStruct{
+						TypeUrl: "type.googleapis.com/envoy.extensions.transport_sockets.alts.v3.Alts",
+						Value:   buildGolangPatchStruct(`{"handshaker_service":"1.2.3.4"}`),
+					}),
+				},
+			},
+		},
+		{
+			Name:            "outbound|7777||custom-tls-replacement-tsm",
+			DnsLookupFamily: cluster.Cluster_V6_ONLY,
+			LbPolicy:        cluster.Cluster_RING_HASH,
+			TransportSocketMatches: []*cluster.Cluster_TransportSocketMatch{
+				{
+					Name: "tlsMode-istio",
+					TransportSocket: &core.TransportSocket{
+						Name: "envoy.transport_sockets.tls",
+						ConfigType: &core.TransportSocket_TypedConfig{
+							TypedConfig: util.MessageToAny(&tls.UpstreamTlsContext{
+								CommonTlsContext: &tls.CommonTlsContext{
+									TlsParams: &tls.TlsParameters{
+										EcdhCurves:                []string{"X25519"},
+										TlsMinimumProtocolVersion: tls.TlsParameters_TLSv1_1,
+									},
+									TlsCertificateCertificateProviderInstance: &tls.CommonTlsContext_CertificateProviderInstance{
+										InstanceName:    "instance",
+										CertificateName: "certificate",
+									},
+								},
+							}),
+						},
+					},
 				},
 			},
 		},

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch.go
@@ -181,12 +181,12 @@ func doFilterChainOperation(patchContext networking.EnvoyFilter_PatchContext,
 			return
 		} else if cp.Operation == networking.EnvoyFilter_Patch_MERGE {
 
-			ret, err := mergeTransportSocketListener(fc, cp)
+			merged, err := mergeTransportSocketListener(fc, cp)
 			if err != nil {
 				log.Debugf("merge of transport socket failed for listener: %v", err)
 				continue
 			}
-			if !ret {
+			if !merged {
 				proto.Merge(fc, cp.Value)
 			}
 		}
@@ -195,7 +195,9 @@ func doFilterChainOperation(patchContext networking.EnvoyFilter_PatchContext,
 }
 
 // Test if the patch contains a config for TransportSocket
-func mergeTransportSocketListener(fc *xdslistener.FilterChain, cp *model.EnvoyFilterConfigPatchWrapper) (bool, error) {
+// Returns a boolean indicating if the merge was handled by this function; if false, it should still be called
+// outside of this function.
+func mergeTransportSocketListener(fc *xdslistener.FilterChain, cp *model.EnvoyFilterConfigPatchWrapper) (merged bool, err error) {
 	cpValueCast, okCpCast := (cp.Value).(*xdslistener.FilterChain)
 	if !okCpCast {
 		return false, fmt.Errorf("cast of cp.Value failed: %v", okCpCast)
@@ -204,6 +206,10 @@ func mergeTransportSocketListener(fc *xdslistener.FilterChain, cp *model.EnvoyFi
 	// Test if the patch contains a config for TransportSocket
 	applyPatch := false
 	if cpValueCast.GetTransportSocket() != nil {
+		if fc.GetTransportSocket() == nil {
+			// There is no existing filter chain, we will add it outside this function; report back that we did not merge.
+			return false, nil
+		}
 		// Test if the listener contains a config for TransportSocket
 		applyPatch = fc.GetTransportSocket() != nil && cpValueCast.GetTransportSocket().Name == fc.GetTransportSocket().Name
 	} else {
@@ -226,8 +232,8 @@ func mergeTransportSocketListener(fc *xdslistener.FilterChain, cp *model.EnvoyFi
 			proto.Merge(dstListener, retVal)
 		}
 	}
-	// Default: we won't call proto.Merge() if the patch is transportSocket and the listener isn't
-	return true, nil
+	// If we already applied the patch, we skip proto.Merge() in the outer function
+	return applyPatch, nil
 }
 
 func doNetworkFilterListOperation(patchContext networking.EnvoyFilter_PatchContext,

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch_test.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"testing"
 
+	udpa "github.com/cncf/udpa/go/udpa/type/v1"
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	fault "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/fault/v3"
@@ -31,6 +32,7 @@ import (
 	"github.com/gogo/protobuf/types"
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/proto"
+	structpb "github.com/golang/protobuf/ptypes/struct"
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/protobuf/testing/protocmp"
@@ -78,6 +80,13 @@ func buildEnvoyFilterConfigStore(configPatches []*networking.EnvoyFilter_EnvoyCo
 
 func buildPatchStruct(config string) *types.Struct {
 	val := &types.Struct{}
+	_ = jsonpb.Unmarshal(strings.NewReader(config), val)
+	return val
+}
+
+// nolint: unparam
+func buildGolangPatchStruct(config string) *structpb.Struct {
+	val := &structpb.Struct{}
 	_ = jsonpb.Unmarshal(strings.NewReader(config), val)
 	return val
 }
@@ -632,11 +641,8 @@ func TestApplyListenerPatches(t *testing.T) {
 				Context: networking.EnvoyFilter_SIDECAR_OUTBOUND,
 				ObjectTypes: &networking.EnvoyFilter_EnvoyConfigObjectMatch_Listener{
 					Listener: &networking.EnvoyFilter_ListenerMatch{
-						FilterChain: &networking.EnvoyFilter_ListenerMatch_FilterChainMatch{
-							Filter: &networking.EnvoyFilter_ListenerMatch_FilterMatch{
-								Name: "envoy.transport_sockets.tls",
-							},
-						},
+						PortNumber:  12345,
+						FilterChain: &networking.EnvoyFilter_ListenerMatch_FilterChainMatch{TransportProtocol: "tls"},
 					},
 				},
 			},
@@ -651,6 +657,50 @@ func TestApplyListenerPatches(t *testing.T) {
 								"tls_params":{
 									"tls_maximum_protocol_version":"TLSv1_3",
 									"tls_minimum_protocol_version":"TLSv1_2"}}}}}`),
+			},
+		},
+		// Patch custom TLS type
+		{
+			ApplyTo: networking.EnvoyFilter_FILTER_CHAIN,
+			Match: &networking.EnvoyFilter_EnvoyConfigObjectMatch{
+				Context: networking.EnvoyFilter_SIDECAR_OUTBOUND,
+				ObjectTypes: &networking.EnvoyFilter_EnvoyConfigObjectMatch_Listener{
+					Listener: &networking.EnvoyFilter_ListenerMatch{
+						PortNumber: 7777,
+					},
+				},
+			},
+			Patch: &networking.EnvoyFilter_Patch{
+				Operation: networking.EnvoyFilter_Patch_MERGE,
+				Value: buildPatchStruct(`
+					{"transport_socket":{
+						"name":"transport_sockets.alts",
+						"typed_config":{
+							"@type":"type.googleapis.com/udpa.type.v1.TypedStruct",
+              "type_url": "type.googleapis.com/envoy.extensions.transport_sockets.alts.v3.Alts",
+							"value":{"handshaker_service":"1.2.3.4"}}}}`),
+			},
+		},
+		// Patch custom TLS type to a FC without TLS already set
+		{
+			ApplyTo: networking.EnvoyFilter_FILTER_CHAIN,
+			Match: &networking.EnvoyFilter_EnvoyConfigObjectMatch{
+				Context: networking.EnvoyFilter_SIDECAR_OUTBOUND,
+				ObjectTypes: &networking.EnvoyFilter_EnvoyConfigObjectMatch_Listener{
+					Listener: &networking.EnvoyFilter_ListenerMatch{
+						PortNumber: 7778,
+					},
+				},
+			},
+			Patch: &networking.EnvoyFilter_Patch{
+				Operation: networking.EnvoyFilter_Patch_MERGE,
+				Value: buildPatchStruct(`
+					{"transport_socket":{
+						"name":"transport_sockets.alts",
+						"typed_config":{
+							"@type":"type.googleapis.com/udpa.type.v1.TypedStruct",
+              "type_url": "type.googleapis.com/envoy.extensions.transport_sockets.alts.v3.Alts",
+							"value":{"handshaker_service":"1.2.3.4"}}}}`),
 			},
 		},
 		{
@@ -829,6 +879,50 @@ func TestApplyListenerPatches(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name: "custom-tls-replacement",
+			Address: &core.Address{
+				Address: &core.Address_SocketAddress{
+					SocketAddress: &core.SocketAddress{
+						PortSpecifier: &core.SocketAddress_PortValue{
+							PortValue: 7777,
+						},
+					},
+				},
+			},
+			FilterChains: []*listener.FilterChain{
+				{
+					TransportSocket: &core.TransportSocket{
+						Name: "envoy.transport_sockets.tls",
+						ConfigType: &core.TransportSocket_TypedConfig{
+							TypedConfig: util.MessageToAny(&tls.DownstreamTlsContext{
+								CommonTlsContext: &tls.CommonTlsContext{
+									TlsParams: &tls.TlsParameters{},
+								},
+							}),
+						},
+					},
+					Filters: []*listener.Filter{{Name: "filter"}},
+				},
+			},
+		},
+		{
+			Name: "custom-tls-addition",
+			Address: &core.Address{
+				Address: &core.Address_SocketAddress{
+					SocketAddress: &core.SocketAddress{
+						PortSpecifier: &core.SocketAddress_PortValue{
+							PortValue: 7778,
+						},
+					},
+				},
+			},
+			FilterChains: []*listener.FilterChain{
+				{
+					Filters: []*listener.Filter{{Name: "filter"}},
+				},
+			},
+		},
 	}
 
 	sidecarOutboundOut := []*listener.Listener{
@@ -995,6 +1089,58 @@ func TestApplyListenerPatches(t *testing.T) {
 							},
 						},
 					},
+				},
+			},
+		},
+		{
+			Name: "custom-tls-replacement",
+			Address: &core.Address{
+				Address: &core.Address_SocketAddress{
+					SocketAddress: &core.SocketAddress{
+						PortSpecifier: &core.SocketAddress_PortValue{
+							PortValue: 7777,
+						},
+					},
+				},
+			},
+			FilterChains: []*listener.FilterChain{
+				{
+					TransportSocket: &core.TransportSocket{
+						Name: "transport_sockets.alts",
+						ConfigType: &core.TransportSocket_TypedConfig{
+							TypedConfig: util.MessageToAny(&udpa.TypedStruct{
+								TypeUrl: "type.googleapis.com/envoy.extensions.transport_sockets.alts.v3.Alts",
+								Value:   buildGolangPatchStruct(`{"handshaker_service":"1.2.3.4"}`),
+							}),
+						},
+					},
+					Filters: []*listener.Filter{{Name: "filter"}},
+				},
+			},
+		},
+		{
+			Name: "custom-tls-addition",
+			Address: &core.Address{
+				Address: &core.Address_SocketAddress{
+					SocketAddress: &core.SocketAddress{
+						PortSpecifier: &core.SocketAddress_PortValue{
+							PortValue: 7778,
+						},
+					},
+				},
+			},
+			FilterChains: []*listener.FilterChain{
+				{
+					TransportSocket: &core.TransportSocket{
+						Name: "transport_sockets.alts",
+						ConfigType: &core.TransportSocket_TypedConfig{
+							TypedConfig: util.MessageToAny(&udpa.TypedStruct{
+								TypeUrl: "type.googleapis.com/envoy.extensions.transport_sockets.alts.v3.Alts",
+								Value:   buildGolangPatchStruct(`{"handshaker_service":"1.2.3.4"}`),
+							}),
+						},
+					},
+					Filters: []*listener.Filter{{Name: "filter"}},
 				},
 			},
 		},

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -737,6 +737,11 @@ var ValidateEnvoyFilter = registerValidateFunc("ValidateEnvoyFilter",
 					listenerMatch := cp.Match.GetListener()
 					if listenerMatch.FilterChain != nil {
 						if listenerMatch.FilterChain.Filter != nil {
+							if cp.ApplyTo == networking.EnvoyFilter_LISTENER || cp.ApplyTo == networking.EnvoyFilter_FILTER_CHAIN {
+								// This would be an error but is a warning for backwards compatibility
+								errs = appendValidation(errs, WrapWarning(
+									fmt.Errorf("Envoy filter: filter match has no effect when used with %v", cp.ApplyTo))) // nolint: golint,stylecheck
+							}
 							// filter names are required if network filter matches are being made
 							if listenerMatch.FilterChain.Filter.Name == "" {
 								errs = appendValidation(errs, fmt.Errorf("Envoy filter: filter match has no name to match on")) // nolint: golint,stylecheck

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -3447,7 +3447,7 @@ func TestValidateEnvoyFilter(t *testing.T) {
 		{name: "listener with invalid filter match", in: &networking.EnvoyFilter{
 			ConfigPatches: []*networking.EnvoyFilter_EnvoyConfigObjectPatch{
 				{
-					ApplyTo: networking.EnvoyFilter_LISTENER,
+					ApplyTo: networking.EnvoyFilter_NETWORK_FILTER,
 					Match: &networking.EnvoyFilter_EnvoyConfigObjectMatch{
 						ObjectTypes: &networking.EnvoyFilter_EnvoyConfigObjectMatch_Listener{
 							Listener: &networking.EnvoyFilter_ListenerMatch{
@@ -3467,7 +3467,7 @@ func TestValidateEnvoyFilter(t *testing.T) {
 		{name: "listener with sub filter match and invalid applyTo", in: &networking.EnvoyFilter{
 			ConfigPatches: []*networking.EnvoyFilter_EnvoyConfigObjectPatch{
 				{
-					ApplyTo: networking.EnvoyFilter_LISTENER,
+					ApplyTo: networking.EnvoyFilter_NETWORK_FILTER,
 					Match: &networking.EnvoyFilter_EnvoyConfigObjectMatch{
 						ObjectTypes: &networking.EnvoyFilter_EnvoyConfigObjectMatch_Listener{
 							Listener: &networking.EnvoyFilter_ListenerMatch{

--- a/releasenotes/notes/ef-tls-regression.yaml
+++ b/releasenotes/notes/ef-tls-regression.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issues:
+- 33385
+releaseNotes:
+- |
+  **Fixed** an issue causing Envoy Filters that merge the `transport_socket` field and have a custom transport socket name to be ignored.


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/33409

* Fix regression when using custom transport_socket envoyfilter

Fixes https://github.com/istio/istio/issues/33385

* do not patch TSM

* test and lint

* lint

* More comments

(cherry picked from commit 97d8df38eb725dc8acaaa9fceb714968d32dfe54)



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.