### PR TITLE
Cleanup tests depending on ordering

### DIFF
--- a/cni/cmd/istio-cni/main_test.go
+++ b/cni/cmd/istio-cni/main_test.go
@@ -133,7 +133,9 @@ func mockgetK8sPodInfo(client *kubernetes.Clientset, podName, podNamespace strin
 func resetGlobalTestVariables() {
 	getKubePodInfoCalled = false
 	nsenterFuncCalled = false
-
+	testInitContainers = map[string]struct{}{
+		"foo-init": {},
+	}
 	testContainers = []string{"mockContainer"}
 	testLabels = map[string]string{}
 	testAnnotations = map[string]string{}

--- a/operator/cmd/mesh/profile-dump_test.go
+++ b/operator/cmd/mesh/profile-dump_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestProfileDump(t *testing.T) {
-	testDataDir = filepath.Join(operatorRootDir, "cmd/mesh/testdata/profile-dump")
+	testDataDir := filepath.Join(operatorRootDir, "cmd/mesh/testdata/profile-dump")
 	tests := []struct {
 		desc       string
 		configPath string
@@ -85,7 +85,7 @@ func runProfileDump(profilePath, configPath string, chartSource chartSourceType,
 }
 
 func TestProfileDumpFlags(t *testing.T) {
-	testDataDir = filepath.Join(operatorRootDir, "cmd/mesh/testdata/profile-dump")
+	testDataDir := filepath.Join(operatorRootDir, "cmd/mesh/testdata/profile-dump")
 	tests := []struct {
 		desc       string
 		configPath string

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
@@ -798,7 +798,8 @@ func TestBuildDefaultCluster(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			cg := NewConfigGenTest(t, TestOptions{MeshConfig: &testMesh})
+			mesh := testMesh()
+			cg := NewConfigGenTest(t, TestOptions{MeshConfig: &mesh})
 			cb := NewClusterBuilder(cg.SetupProxy(nil), cg.PushContext())
 			service := &model.Service{
 				Ports: model.PortList{
@@ -849,7 +850,7 @@ func TestBuildLocalityLbEndpoints(t *testing.T) {
 	}{
 		{
 			name: "basics",
-			mesh: testMesh,
+			mesh: testMesh(),
 			instances: []*model.ServiceInstance{
 				{
 					Service:     service,
@@ -1005,7 +1006,7 @@ func TestBuildLocalityLbEndpoints(t *testing.T) {
 		},
 		{
 			name: "cluster local",
-			mesh: withClusterLocalHosts(testMesh, "*.example.org"),
+			mesh: withClusterLocalHosts(testMesh(), "*.example.org"),
 			instances: []*model.ServiceInstance{
 				{
 					Service:     service,

--- a/pilot/pkg/networking/core/v1alpha3/gateway_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway_test.go
@@ -1396,6 +1396,10 @@ func TestGatewayHTTPRouteConfig(t *testing.T) {
 	}
 
 	StripHostPort := []bool{false, true}
+	oldValue := features.StripHostPort
+	t.Cleanup(func() {
+		features.StripHostPort = oldValue
+	})
 	for _, value := range StripHostPort {
 		features.StripHostPort = value
 		for _, tt := range cases {


### PR DESCRIPTION
Tests in go shouldn't depend on order they are run, as it breaks when
they are moved, run alone, or with -shuffle. This fixes a few occurances

See https://github.com/istio/istio/issues/33382



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.