### PR TITLE
Skip tests broken in 1.22

### DIFF
--- a/tests/integration/helm/upgrade/main_test.go
+++ b/tests/integration/helm/upgrade/main_test.go
@@ -24,6 +24,8 @@ import (
 func TestMain(m *testing.M) {
 	framework.
 		NewSuite(m).
+		// Kubernetes 1.22 drops support for a number of legacy resources, so we cannot install the old versions
+		RequireMaxVersion(21).
 		RequireSingleCluster().
 		Run()
 }

--- a/tests/integration/pilot/multi_version_revision_test.go
+++ b/tests/integration/pilot/multi_version_revision_test.go
@@ -199,4 +199,8 @@ func skipIfK8sVersionUnsupported(t framework.TestContext) {
 	if !t.Clusters().Default().MinKubeVersion(16) {
 		t.Skipf("k8s version not supported for %s (<%s)", t.Name(), "1.16")
 	}
+	// Kubernetes 1.22 drops support for a number of legacy resources, so we cannot install the old versions
+	if !t.Clusters().Default().MaxKubeVersion(21) {
+		t.Skipf("k8s version not supported for %s (>%s)", t.Name(), "1.21")
+	}
 }

--- a/tests/integration/pilot/revisioned_upgrade_test.go
+++ b/tests/integration/pilot/revisioned_upgrade_test.go
@@ -48,6 +48,10 @@ func TestRevisionedUpgrade(t *testing.T) {
 		Label(label.CustomSetup).
 		Features("installation.upgrade").
 		Run(func(t framework.TestContext) {
+			// Kubernetes 1.22 drops support for a number of legacy resources, so we cannot install the old versions
+			if !t.Clusters().Default().MaxKubeVersion(21) {
+				t.Skipf("k8s version not supported for %s (>%s)", t.Name(), "1.21")
+			}
 			versions := []string{NMinusOne, NMinusTwo, NMinusThree, NMinusFour}
 			for _, v := range versions {
 				t.NewSubTest(fmt.Sprintf("%s->master", v)).Run(func(t framework.TestContext) {

--- a/tests/integration/security/chiron/main_test.go
+++ b/tests/integration/security/chiron/main_test.go
@@ -31,6 +31,8 @@ func TestMain(m *testing.M) {
 	// TODO (lei-tang): investigate whether this test can be moved to integration/security.
 	framework.NewSuite(m).
 		Label(label.CustomSetup).
+		// https://github.com/istio/istio/issues/22161. 1.22 drops support for legacy-unknown signer
+		RequireMaxVersion(21).
 		Setup(istio.Setup(&inst, setupConfig)).
 		Run()
 }

--- a/tests/integration/security/external_ca/main_test.go
+++ b/tests/integration/security/external_ca/main_test.go
@@ -75,6 +75,8 @@ func TestMain(m *testing.M) {
 	framework.NewSuite(m).
 		Label(label.CustomSetup).
 		RequireMinVersion(18).
+		// https://github.com/istio/istio/issues/22161. 1.22 drops support for legacy-unknown signer
+		RequireMaxVersion(21).
 		Setup(istio.Setup(&inst, setupConfig)).
 		Setup(func(ctx resource.Context) error {
 			return SetupApps(ctx, apps)

--- a/tests/integration/security/mtlsk8sca/main_test.go
+++ b/tests/integration/security/mtlsk8sca/main_test.go
@@ -35,6 +35,8 @@ func TestMain(m *testing.M) {
 		NewSuite(m).
 		RequireSingleCluster().
 		Label(label.CustomSetup).
+		// https://github.com/istio/istio/issues/22161. 1.22 drops support for legacy-unknown signer
+		RequireMaxVersion(21).
 		Setup(istio.Setup(&inst, setupConfig)).
 		Setup(func(ctx resource.Context) error {
 			// TODO: due to issue https://github.com/istio/istio/issues/25286,

--- a/tests/integration/security/sds_ingress_k8sca/main_test.go
+++ b/tests/integration/security/sds_ingress_k8sca/main_test.go
@@ -35,6 +35,8 @@ func TestMain(m *testing.M) {
 	framework.
 		NewSuite(m).
 		RequireSingleCluster().
+		// https://github.com/istio/istio/issues/22161. 1.22 drops support for legacy-unknown signer
+		RequireMaxVersion(21).
 		Setup(istio.Setup(&inst, setupConfig)).
 		Setup(func(ctx resource.Context) (err error) {
 			// Skip VM as eastwest gateway is disabled.


### PR DESCRIPTION
* Ingress old API version was removed, bump it up one versions we can
* legacy-unknown signer is removed. This disables 4 test suites. THESE
FEATURES ARE BROKEN - it is not just a testing issue.
* Upgrade tests are broken on 1.22, so disabled. This is not a big deal
right now, but when we update presubmit to 1.22 it likely will be.

I have tagged everyone that has features they worked on broken.

Fixes https://github.com/istio/istio/issues/33475