### PR TITLE
Fix CONNTRACK issues for UDP iptables

### DIFF
--- a/tools/istio-iptables/pkg/cmd/run.go
+++ b/tools/istio-iptables/pkg/cmd/run.go
@@ -626,11 +626,36 @@ func HandleDNSUDP(
 		case DeleteOps:
 			ext.RunQuietlyAndIgnore(cmd, raw...)
 		}
+
+		table := constants.RAW
+		raw = []string{
+			"-t", table, opsStr, chain,
+			"-p", "udp", "--dport", "53", "-m", "owner", "--uid-owner", uid,
+			"-j", constants.CT, "--zone", "1",
+		}
+		switch ops {
+		case AppendOps:
+			iptables.AppendRuleV4(chain, table, raw[paramIdxRaw:]...)
+		case DeleteOps:
+			ext.RunQuietlyAndIgnore(cmd, raw...)
+		}
 	}
 	for _, gid := range split(proxyGID) {
 		raw = []string{
 			"-t", table, opsStr, chain,
 			"-p", "udp", "--dport", "53", "-m", "owner", "--gid-owner", gid, "-j", constants.RETURN,
+		}
+		switch ops {
+		case AppendOps:
+			iptables.AppendRuleV4(chain, table, raw[paramIdxRaw:]...)
+		case DeleteOps:
+			ext.RunQuietlyAndIgnore(cmd, raw...)
+		}
+		table := constants.RAW
+		raw = []string{
+			"-t", table, opsStr, chain,
+			"-p", "udp", "--dport", "53", "-m", "owner", "--gid-owner", gid,
+			"-j", constants.CT, "--zone", "1",
 		}
 		switch ops {
 		case AppendOps:
@@ -667,6 +692,18 @@ func HandleDNSUDP(
 				"-t", table, opsStr, chain,
 				"-p", "udp", "--dport", "53", "-d", s + "/32",
 				"-j", constants.REDIRECT, "--to-port", constants.IstioAgentDNSListenerPort,
+			}
+			switch ops {
+			case AppendOps:
+				iptables.AppendRuleV4(chain, table, raw[paramIdxRaw:]...)
+			case DeleteOps:
+				ext.RunQuietlyAndIgnore(cmd, raw...)
+			}
+			table := constants.RAW
+			raw = []string{
+				"-t", table, opsStr, chain,
+				"-p", "udp", "--dport", "53", "-d", s + "/32",
+				"-j", constants.CT, "--zone", "2",
 			}
 			switch ops {
 			case AppendOps:

--- a/tools/istio-iptables/pkg/constants/constants.go
+++ b/tools/istio-iptables/pkg/constants/constants.go
@@ -20,6 +20,7 @@ import "time"
 const (
 	MANGLE = "mangle"
 	NAT    = "nat"
+	RAW    = "raw"
 	FILTER = "filter"
 )
 
@@ -51,6 +52,7 @@ const (
 	REJECT   = "REJECT"
 	REDIRECT = "REDIRECT"
 	MARK     = "MARK"
+	CT       = "CT"
 )
 
 // iptables chains


### PR DESCRIPTION
iptables redirection is essentially "cached" by conntrack. This works ok
for TCP, but for UDP this means we are not routing on a per-packet basis
like we require for the DNS proxy. See
https://serverfault.com/questions/741104/iptables-redirect-works-only-for-first-packet/741108#741108.

This means if we happen to re-use a 4 tuple, we may accidentally bypass
the proxy and go directly upstream, giving unexpected results.

This PR adds a new "conntrack zone" for each part of the process. The
request from app <-> proxy is in "zone 1" and proxy <-> upstream is in
"zone 2".

Fixes https://github.com/istio/istio/issues/33469