### PR TITLE
fix typo from DefaultWasmModulePurgeInteval to DefaultWasmModulePurgeInterval

### DIFF
--- a/pkg/istio-agent/xds_proxy.go
+++ b/pkg/istio-agent/xds_proxy.go
@@ -145,7 +145,7 @@ func initXdsProxy(ia *Agent) (*XdsProxy, error) {
 		healthChecker:  health.NewWorkloadHealthChecker(ia.proxyConfig.ReadinessProbe, envoyProbe, ia.cfg.ProxyIPAddresses, ia.cfg.IsIPv6),
 		xdsHeaders:     ia.cfg.XDSHeaders,
 		xdsUdsPath:     ia.cfg.XdsUdsPath,
-		wasmCache:      wasm.NewLocalFileCache(constants.IstioDataDir, wasm.DefaultWasmModulePurgeInteval, wasm.DefaultWasmModuleExpiry),
+		wasmCache:      wasm.NewLocalFileCache(constants.IstioDataDir, wasm.DefaultWasmModulePurgeInterval, wasm.DefaultWasmModuleExpiry),
 		proxyAddresses: ia.cfg.ProxyIPAddresses,
 	}
 

--- a/pkg/wasm/cache.go
+++ b/pkg/wasm/cache.go
@@ -31,8 +31,8 @@ import (
 var wasmLog = log.RegisterScope("wasm", "", 0)
 
 const (
-	// DefaultWasmModulePurgeInteval is the default interval for periodic stale Wasm module clean up.
-	DefaultWasmModulePurgeInteval = 10 * time.Minute
+	// DefaultWasmModulePurgeInterval is the default interval for periodic stale Wasm module clean up.
+	DefaultWasmModulePurgeInterval = 10 * time.Minute
 
 	// DefaultWasmModuleExpiry is the default duration for least recently touched Wasm module to become stale.
 	DefaultWasmModuleExpiry = 24 * time.Hour

--- a/pkg/wasm/cache_test.go
+++ b/pkg/wasm/cache_test.go
@@ -51,7 +51,7 @@ func TestWasmCache(t *testing.T) {
 			name:                 "cache miss",
 			initialCachedModules: map[cacheKey]cacheEntry{},
 			fetchURL:             ts.URL,
-			purgeInterval:        DefaultWasmModulePurgeInteval,
+			purgeInterval:        DefaultWasmModulePurgeInterval,
 			wasmModuleExpiry:     DefaultWasmModuleExpiry,
 			checksum:             dataCheckSum,
 			wantFileName:         fmt.Sprintf("%x.wasm", dataCheckSum),
@@ -63,7 +63,7 @@ func TestWasmCache(t *testing.T) {
 				{downloadURL: ts.URL, checksum: fmt.Sprintf("%x", sha256.Sum256([]byte("cachehit\n")))}: {modulePath: "test.wasm"},
 			},
 			fetchURL:         ts.URL,
-			purgeInterval:    DefaultWasmModulePurgeInteval,
+			purgeInterval:    DefaultWasmModulePurgeInterval,
 			wasmModuleExpiry: DefaultWasmModuleExpiry,
 			checksum:         sha256.Sum256([]byte("cachehit\n")),
 			wantFileName:     "test.wasm",
@@ -73,7 +73,7 @@ func TestWasmCache(t *testing.T) {
 			name:                 "invalid scheme",
 			initialCachedModules: map[cacheKey]cacheEntry{},
 			fetchURL:             "oci://abc",
-			purgeInterval:        DefaultWasmModulePurgeInteval,
+			purgeInterval:        DefaultWasmModulePurgeInterval,
 			wasmModuleExpiry:     DefaultWasmModuleExpiry,
 			checksum:             dataCheckSum,
 			wantFileName:         fmt.Sprintf("%x.wasm", dataCheckSum),
@@ -84,7 +84,7 @@ func TestWasmCache(t *testing.T) {
 			name:                 "download failure",
 			initialCachedModules: map[cacheKey]cacheEntry{},
 			fetchURL:             "https://dummyurl",
-			purgeInterval:        DefaultWasmModulePurgeInteval,
+			purgeInterval:        DefaultWasmModulePurgeInterval,
 			wasmModuleExpiry:     DefaultWasmModuleExpiry,
 			wantErrorMsgPrefix:   "wasm module download failed, last error: Get \"https://dummyurl\"",
 			wantServerReqNum:     0,
@@ -94,7 +94,7 @@ func TestWasmCache(t *testing.T) {
 			name:                 "wrong checksum",
 			initialCachedModules: map[cacheKey]cacheEntry{},
 			fetchURL:             ts.URL,
-			purgeInterval:        DefaultWasmModulePurgeInteval,
+			purgeInterval:        DefaultWasmModulePurgeInterval,
 			wasmModuleExpiry:     DefaultWasmModuleExpiry,
 			checksum:             sha256.Sum256([]byte("wrongchecksum\n")),
 			wantErrorMsgPrefix:   fmt.Sprintf("module downloaded from %v has checksum %x, which does not match", ts.URL, dataCheckSum),
@@ -108,7 +108,7 @@ func TestWasmCache(t *testing.T) {
 				{downloadURL: ts.URL, checksum: fmt.Sprintf("%x", dataCheckSum)}: {modulePath: fmt.Sprintf("%x.wasm", dataCheckSum)},
 			},
 			fetchURL:           ts.URL + "/different-url",
-			purgeInterval:      DefaultWasmModulePurgeInteval,
+			purgeInterval:      DefaultWasmModulePurgeInterval,
 			wasmModuleExpiry:   DefaultWasmModuleExpiry,
 			checksum:           dataCheckSum,
 			wantErrorMsgPrefix: fmt.Sprintf("module downloaded from %v/different-url has checksum", ts.URL),
@@ -185,7 +185,7 @@ func TestWasmCache(t *testing.T) {
 
 func TestWasmCacheMissChecksum(t *testing.T) {
 	tmpDir := t.TempDir()
-	cache := NewLocalFileCache(tmpDir, DefaultWasmModulePurgeInteval, DefaultWasmModuleExpiry)
+	cache := NewLocalFileCache(tmpDir, DefaultWasmModulePurgeInterval, DefaultWasmModuleExpiry)
 	defer close(cache.stopChan)
 
 	gotNumRequest := 0


### PR DESCRIPTION
Signed-off-by: gy95 <1015105054@qq.com>



- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [x] User Experience
- [ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.