### PR TITLE
relax istiod signer authority

### DIFF
--- a/manifests/charts/base/files/gen-istio-cluster.yaml
+++ b/manifests/charts/base/files/gen-istio-cluster.yaml
@@ -5768,7 +5768,6 @@ rules:
     resources:
       - "signers"
     resourceNames:
-    - "kubernetes.io/legacy-unknown"
     verbs: ["approve"]
 
   # Used by Istiod to verify the JWT tokens

--- a/manifests/charts/base/files/gen-istio-cluster.yaml
+++ b/manifests/charts/base/files/gen-istio-cluster.yaml
@@ -5767,7 +5767,6 @@ rules:
   - apiGroups: ["certificates.k8s.io"]
     resources:
       - "signers"
-    resourceNames:
     verbs: ["approve"]
 
   # Used by Istiod to verify the JWT tokens

--- a/manifests/charts/base/templates/clusterrole.yaml
+++ b/manifests/charts/base/templates/clusterrole.yaml
@@ -85,7 +85,6 @@ rules:
     resources:
       - "signers"
     resourceNames:
-    - "kubernetes.io/legacy-unknown"
     verbs: ["approve"]
 
   # Used by Istiod to verify the JWT tokens

--- a/manifests/charts/base/templates/clusterrole.yaml
+++ b/manifests/charts/base/templates/clusterrole.yaml
@@ -84,7 +84,6 @@ rules:
   - apiGroups: ["certificates.k8s.io"]
     resources:
       - "signers"
-    resourceNames:
     verbs: ["approve"]
 
   # Used by Istiod to verify the JWT tokens

--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -954,8 +954,6 @@ rules:
   - apiGroups: ["certificates.k8s.io"]
     resources:
       - "signers"
-    resourceNames:
-    - "kubernetes.io/legacy-unknown"
     verbs: ["approve"]
 
   # Used by Istiod to verify the JWT tokens

--- a/manifests/charts/istio-control/istio-discovery/templates/clusterrole.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/clusterrole.yaml
@@ -79,8 +79,6 @@ rules:
   - apiGroups: ["certificates.k8s.io"]
     resources:
       - "signers"
-    resourceNames:
-    - "kubernetes.io/legacy-unknown"
     verbs: ["approve"]
 
   # Used by Istiod to verify the JWT tokens


### PR DESCRIPTION

The reason for this relax is:

1.  clusterrole now supports revision, so it is hard for user to define this via overlay in operator like below:
 ```
apiVersion: install.istio.io/v1alpha1
kind: IstioOperator
spec:
  components:
    base:
      k8s:
        overlays:
          # Amend ClusterRole to add permission for istiod to approve certificate signing by custom signer
          - kind: ClusterRole
            name: istiod-istio-system
            patches:
              - path: rules[-1]
                value: |
                  apiGroups:
                  - certificates.k8s.io
                  resourceNames:
                  # Name of k8s external Signer in this example
                  - example.com/foo
                  resources:
                  - signers
                  verbs:
                  - approve
```
2.  `kubernetes.io/legacy-unknown` is deprecated in k8s 1.19, istio needs to use other signer.
3.   recent cert-manager supports k8s csr, it means we can let user define the signer they want to use. 