### PR TITLE
[tf] Pass context to namespace when creating with stableNamespaces

### DIFF
--- a/pkg/test/framework/components/namespace/kube.go
+++ b/pkg/test/framework/components/namespace/kube.go
@@ -117,7 +117,7 @@ func claimKube(ctx resource.Context, nsConfig *Config) (Instance, error) {
 			}
 		}
 	}
-	return &kubeNamespace{prefix: nsConfig.Prefix, name: nsConfig.Prefix}, nil
+	return &kubeNamespace{prefix: nsConfig.Prefix, name: nsConfig.Prefix, ctx: ctx}, nil
 }
 
 // setNamespaceLabel labels a namespace with the given key, value pair


### PR DESCRIPTION
Before we'd panic when using `SetLabel` on namespace running with `--istio.test.stableNamespaces`

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
