### PR TITLE
Fix token exchange error message

### DIFF
--- a/security/pkg/nodeagent/plugin/providers/google/stsclient/stsclient.go
+++ b/security/pkg/nodeagent/plugin/providers/google/stsclient/stsclient.go
@@ -100,7 +100,7 @@ func (p *SecureTokenServiceExchanger) requestWithRetry(reqBytes []byte) ([]byte,
 			return body, err
 		}
 		body, _ := ioutil.ReadAll(resp.Body)
-		lastError = fmt.Errorf("token exchange request failed: status code %v body %v", resp.StatusCode, body)
+		lastError = fmt.Errorf("token exchange request failed: status code %v body %v", resp.StatusCode, string(body))
 		resp.Body.Close()
 		if !retryable(resp.StatusCode) {
 			break


### PR DESCRIPTION

https://github.com/istio/istio/pull/31859 updated the token exchange error message, but didn't convert byte array to string.
The fix is only in master branch https://github.com/istio/istio/pull/32111.
Add similar fix to release 1.10 branch.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[x] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.