### PR TITLE
Refine logic on FindRootCAForXX

### DIFF
--- a/pkg/security/security.go
+++ b/pkg/security/security.go
@@ -40,9 +40,6 @@ const (
 	// DefaultRootCertFilePath is the well-known path for an existing root certificate file
 	DefaultRootCertFilePath = "./etc/certs/root-cert.pem"
 
-	// SystemRootCerts is special case input for root cert configuration to use system root certificates.
-	SystemRootCerts = "SYSTEM"
-
 	// RootCertReqResourceName is resource name of discovery request for root certificate.
 	RootCertReqResourceName = "ROOTCA"
 


### PR DESCRIPTION
* Remove duplicated code on finding root CA in istio-agent
* Make the well-known cert location a const

Signed-off-by: Ruoyu.Ying <ruoyu.ying@intel.com>


Found some duplicated code in istio-agent. So made some enhancement on that.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[x] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.