### PR TITLE
short path check for SubsetOf

### DIFF
--- a/pkg/config/labels/collection.go
+++ b/pkg/config/labels/collection.go
@@ -18,7 +18,7 @@ package labels
 // collection of labels
 type Collection []Instance
 
-// HasSubsetOf returns true if the input labels are a super set of one labels in a
+// HasSubsetOf returns true if the input labels are a superset of one labels in a
 // collection or if the tag collection is empty
 func (c Collection) HasSubsetOf(that Instance) bool {
 	if len(c) == 0 {
@@ -36,7 +36,7 @@ func (c Collection) HasSubsetOf(that Instance) bool {
 	return false
 }
 
-// IsSupersetOf returns true if the input labels are a subset set of any set of labels in a
+// IsSupersetOf returns true if the input labels are a subset of any set of labels in a
 // collection
 func (c Collection) IsSupersetOf(that Instance) bool {
 	if len(c) == 0 {

--- a/pkg/config/labels/instance.go
+++ b/pkg/config/labels/instance.go
@@ -56,6 +56,14 @@ type Instance map[string]string
 
 // SubsetOf is true if the label has identical values for the keys
 func (i Instance) SubsetOf(that Instance) bool {
+	if len(i) == 0 {
+		return true
+	}
+
+	if len(that) == 0 || len(that) < len(i) {
+		return false
+	}
+
 	for k, v := range i {
 		if that[k] != v {
 			return false

--- a/pkg/config/labels/instance_test.go
+++ b/pkg/config/labels/instance_test.go
@@ -23,6 +23,7 @@ import (
 func TestInstance(t *testing.T) {
 	a := labels.Instance{"app": "a"}
 	a1 := labels.Instance{"app": "a", "prod": "env"}
+	a2 := labels.Instance{"app": "b", "prod": "env"}
 
 	if !labels.Instance(nil).SubsetOf(a) {
 		t.Errorf("nil.SubsetOf({a}) => Got false")
@@ -34,6 +35,14 @@ func TestInstance(t *testing.T) {
 
 	if a1.SubsetOf(a) {
 		t.Errorf("%v.SubsetOf(%v) => Got true", a1, a)
+	}
+
+	if !a.SubsetOf(a1) {
+		t.Errorf("%v.SubsetOf(%v) => Got false", a, a1)
+	}
+
+	if a.SubsetOf(a2) {
+		t.Errorf("%v.SubsetOf(%v) => Got true", a, a2)
 	}
 }
 


### PR DESCRIPTION

Add short path check for `SubsetOf`, mainly for cases when `len(that) < len(i)`, to avoid meaningless map iteration.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[X] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.