### PR TITLE
Make consistent hash test only run in single network

### DIFF
--- a/tests/integration/pilot/common/traffic.go
+++ b/tests/integration/pilot/common/traffic.go
@@ -242,7 +242,11 @@ func RunAllTrafficTests(t framework.TestContext, i istio.Instance, apps *EchoDep
 	cases["tls-origination"] = tlsOriginationCases(apps)
 	cases["instanceip"] = instanceIPTests(apps)
 	cases["services"] = serviceCases(apps)
-	cases["consistent-hash"] = consistentHashCases(apps)
+	if len(t.Clusters().ByNetwork()) == 1 {
+		// Consistent hashing does not work for multinetwork. The first request will consistently go to a
+		// gateway, but that gateway will tcp_proxy it to a random pod.
+		cases["consistent-hash"] = consistentHashCases(apps)
+	}
 	cases["use-client-protocol"] = useClientProtocolCases(apps)
 	if !t.Settings().SkipVM {
 		cases["vm"] = VMTestCases(apps.VM, apps)


### PR DESCRIPTION
Smaller version of https://github.com/istio/istio/pull/33510