### PR TITLE
Revert "Add test for consistent hash"

### DIFF
--- a/pkg/test/framework/components/echo/cmd/echogen/testdata/golden.yaml
+++ b/pkg/test/framework/components/echo/cmd/echogen/testdata/golden.yaml
@@ -64,7 +64,6 @@ spec:
         prometheus.io/scrape: "true"
       labels:
         app: a
-        test.istio.io/class: standard
         version: v1
     spec:
       containers:

--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -121,7 +121,6 @@ spec:
       labels:
         app: {{ $.Service }}
         version: {{ $subset.Version }}
-        test.istio.io/class: {{ $.Class }}
 {{- if $.Compatibility }}
         istio.io/rev: {{ $revision }}
 {{- end }}
@@ -671,7 +670,6 @@ func templateParams(cfg echo.Config, imgSettings *image.Settings, settings *reso
 		"IncludeExtAuthz": cfg.IncludeExtAuthz,
 		"Revisions":       settings.Revisions.TemplateMap(),
 		"Compatibility":   settings.Compatibility,
-		"Class":           getConfigClass(cfg),
 	}
 	return params, nil
 }
@@ -708,7 +706,6 @@ spec:
   metadata:
     labels:
       app: {{.name}}
-      test.istio.io/class: {{ .class }}
   template:
     serviceAccount: {{.serviceaccount}}
     network: "{{.network}}"
@@ -726,7 +723,6 @@ spec:
 		"namespace":      cfg.Namespace.Name(),
 		"serviceaccount": serviceAccount(cfg),
 		"network":        cfg.Cluster.NetworkName(),
-		"class":          getConfigClass(cfg),
 	})
 
 	// Push the WorkloadGroup for auto-registration
@@ -842,25 +838,6 @@ spec:
 	}
 
 	return nil
-}
-
-func getConfigClass(cfg echo.Config) string {
-	if cfg.IsProxylessGRPC() {
-		return "proxyless"
-	} else if cfg.IsVM() {
-		return "vm"
-	} else if cfg.IsTProxy() {
-		return "tproxy"
-	} else if cfg.IsNaked() {
-		return "naked"
-	} else if cfg.IsExternal() {
-		return "external"
-	} else if cfg.IsStatefulSet() {
-		return "statefulset"
-	} else if cfg.IsHeadless() {
-		return "headless"
-	}
-	return "standard"
 }
 
 func patchProxyConfigFile(file string, overrides string) error {

--- a/pkg/test/framework/components/echo/kube/testdata/basic.yaml
+++ b/pkg/test/framework/components/echo/kube/testdata/basic.yaml
@@ -31,7 +31,6 @@ spec:
       labels:
         app: foo
         version: bar
-        test.istio.io/class: standard
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "15014"

--- a/pkg/test/framework/components/echo/kube/testdata/healthcheck-rewrite.yaml
+++ b/pkg/test/framework/components/echo/kube/testdata/healthcheck-rewrite.yaml
@@ -31,7 +31,6 @@ spec:
       labels:
         app: healthcheck
         version: v1
-        test.istio.io/class: standard
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "15014"

--- a/pkg/test/framework/components/echo/kube/testdata/multiple-istio-versions.yaml
+++ b/pkg/test/framework/components/echo/kube/testdata/multiple-istio-versions.yaml
@@ -31,7 +31,6 @@ spec:
       labels:
         app: foo
         version: bar
-        test.istio.io/class: standard
         istio.io/rev: rev-a
       annotations:
         prometheus.io/scrape: "true"
@@ -113,7 +112,6 @@ spec:
       labels:
         app: foo
         version: bar
-        test.istio.io/class: standard
         istio.io/rev: rev-b
       annotations:
         prometheus.io/scrape: "true"

--- a/pkg/test/framework/components/echo/kube/testdata/multiversion.yaml
+++ b/pkg/test/framework/components/echo/kube/testdata/multiversion.yaml
@@ -34,7 +34,6 @@ spec:
       labels:
         app: multiversion
         version: v-istio
-        test.istio.io/class: standard
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "15014"
@@ -118,7 +117,6 @@ spec:
       labels:
         app: multiversion
         version: v-legacy
-        test.istio.io/class: standard
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "15014"

--- a/pkg/test/framework/components/echo/kube/testdata/two-workloads-one-nosidecar.yaml
+++ b/pkg/test/framework/components/echo/kube/testdata/two-workloads-one-nosidecar.yaml
@@ -31,7 +31,6 @@ spec:
       labels:
         app: foo
         version: v1
-        test.istio.io/class: standard
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "15014"
@@ -112,7 +111,6 @@ spec:
       labels:
         app: foo
         version: nosidecar
-        test.istio.io/class: standard
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "15014"

--- a/tests/integration/pilot/common/traffic.go
+++ b/tests/integration/pilot/common/traffic.go
@@ -242,7 +242,6 @@ func RunAllTrafficTests(t framework.TestContext, i istio.Instance, apps *EchoDep
 	cases["tls-origination"] = tlsOriginationCases(apps)
 	cases["instanceip"] = instanceIPTests(apps)
 	cases["services"] = serviceCases(apps)
-	cases["consistent-hash"] = consistentHashCases(apps)
 	cases["use-client-protocol"] = useClientProtocolCases(apps)
 	if !t.Settings().SkipVM {
 		cases["vm"] = VMTestCases(apps.VM, apps)


### PR DESCRIPTION
Reverts istio/istio#33477

Revert the mostly failing test, in lieu of fixing the test. If the fix PR gets merged, this revert PR can be closed.