### PR TITLE
Improve merging of proxy config proxyMetadata

### DIFF
--- a/pilot/cmd/pilot-agent/config/config_test.go
+++ b/pilot/cmd/pilot-agent/config/config_test.go
@@ -107,7 +107,7 @@ proxyStatsMatcher:
 			expect: func() meshconfig.ProxyConfig {
 				m := mesh.DefaultProxyConfig()
 				m.DiscoveryAddress = "annotation:123"
-				m.ProxyMetadata = map[string]string{"ANNOTATION": "something"}
+				m.ProxyMetadata = map[string]string{"ANNOTATION": "something", "SOME": "setting"}
 				m.DrainDuration = types.DurationProto(5 * time.Second)
 				m.ExtraStatTags = []string{"b"}
 				m.ProxyStatsMatcher = &meshconfig.ProxyConfig_ProxyStatsMatcher{}

--- a/pkg/config/mesh/mesh_test.go
+++ b/pkg/config/mesh/mesh_test.go
@@ -52,6 +52,48 @@ func TestApplyProxyConfig(t *testing.T) {
 			t.Fatalf("expected drainDuration: 5s, got %q", mc.DefaultConfig.DrainDuration.Seconds)
 		}
 	})
+
+	t.Run("apply proxy metadata", func(t *testing.T) {
+		config := mesh.DefaultMeshConfig()
+		config.DefaultConfig.ProxyMetadata = map[string]string{
+			"merged":  "original",
+			"default": "foo",
+		}
+		mc, err := mesh.ApplyProxyConfig(`proxyMetadata: {"merged":"override","override":"bar"}`, config)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Ensure we didn't modify the passed in mesh config
+		if !reflect.DeepEqual(mc.DefaultConfig.ProxyMetadata, map[string]string{
+
+			"merged":   "override",
+			"default":  "foo",
+			"override": "bar",
+		}) {
+			t.Fatalf("unexpected proxy metadata: %+v", mc.DefaultConfig.ProxyMetadata)
+		}
+	})
+	t.Run("apply proxy metadata to mesh config", func(t *testing.T) {
+		config := mesh.DefaultMeshConfig()
+		config.DefaultConfig.ProxyMetadata = map[string]string{
+			"merged":  "original",
+			"default": "foo",
+		}
+		mc, err := mesh.ApplyMeshConfig(`defaultConfig:
+  proxyMetadata: {"merged":"override","override":"bar"}`, config)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Ensure we didn't modify the passed in mesh config
+		if !reflect.DeepEqual(mc.DefaultConfig.ProxyMetadata, map[string]string{
+
+			"merged":   "override",
+			"default":  "foo",
+			"override": "bar",
+		}) {
+			t.Fatalf("unexpected proxy metadata: %+v", mc.DefaultConfig.ProxyMetadata)
+		}
+	})
 }
 
 func TestDefaultProxyConfig(t *testing.T) {

--- a/releasenotes/notes/pc-merge-metadata.yaml
+++ b/releasenotes/notes/pc-merge-metadata.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+releaseNotes:
+- |
+  **Improved** the `meshConfig.defaultConfig.proxyMetadata` field to do a deep megre when overriden, rather than replacing all values.

--- a/releasenotes/notes/pc-merge-metadata.yaml
+++ b/releasenotes/notes/pc-merge-metadata.yaml
@@ -3,4 +3,4 @@ kind: feature
 area: installation
 releaseNotes:
 - |
-  **Improved** the `meshConfig.defaultConfig.proxyMetadata` field to do a deep megre when overriden, rather than replacing all values.
+  **Improved** the `meshConfig.defaultConfig.proxyMetadata` field to do a deep merge when overriden, rather than replacing all values.


### PR DESCRIPTION
This is useful for pod annotation overrides and for
shared_user_mesh_config. Basically if the top level sets a proxy
metadata, which may be for critical fields like CA_ADDRESS, anyone below
it will override them completely which will often lead to breakages.

This allows a deeper merge



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.