### PR TITLE
Add CLI option to pilot-agent for exec mode

### DIFF
--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"os/exec"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
@@ -89,68 +90,7 @@ var (
 		RunE: func(c *cobra.Command, args []string) error {
 			cmd.PrintFlags(c.Flags())
 			log.Infof("Version %s", version.Info.String())
-
-			proxy, err := initProxy(args)
-			if err != nil {
-				return err
-			}
-			proxyConfig, err := config.ConstructProxyConfig(meshConfigFile, serviceCluster, options.ProxyConfigEnv, concurrency, proxy)
-			if err != nil {
-				return fmt.Errorf("failed to get proxy config: %v", err)
-			}
-			if out, err := gogoprotomarshal.ToYAML(proxyConfig); err != nil {
-				log.Infof("Failed to serialize to YAML: %v", err)
-			} else {
-				log.Infof("Effective config: %s", out)
-			}
-
-			secOpts, err := options.NewSecurityOptions(proxyConfig, stsPort, tokenManagerPlugin)
-			if err != nil {
-				return err
-			}
-
-			// If security token service (STS) port is not zero, start STS server and
-			// listen on STS port for STS requests. For STS, see
-			// https://tools.ietf.org/html/draft-ietf-oauth-token-exchange-16.
-			// STS is used for stackdriver or other Envoy services using google gRPC.
-			if stsPort > 0 {
-				stsServer, err := initStsServer(proxy, secOpts.TokenManager)
-				if err != nil {
-					return err
-				}
-				defer stsServer.Stop()
-			}
-
-			// If we are using a custom template file (for control plane proxy, for example), configure this.
-			if templateFile != "" && proxyConfig.CustomConfigFile == "" {
-				proxyConfig.ProxyBootstrapTemplatePath = templateFile
-			}
-
-			envoyOptions := envoy.ProxyConfig{
-				LogLevel:          proxyLogLevel,
-				ComponentLogLevel: proxyComponentLogLevel,
-				LogAsJSON:         loggingOptions.JSONEncoding,
-				NodeIPs:           proxy.IPAddresses,
-				Sidecar:           proxy.Type == model.SidecarProxy,
-				OutlierLogPath:    outlierLogPath,
-			}
-			agentOptions := options.NewAgentOptions(proxy, proxyConfig)
-			agent := istio_agent.NewAgent(proxyConfig, agentOptions, secOpts, envoyOptions)
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-
-			// If a status port was provided, start handling status probes.
-			if proxyConfig.StatusPort > 0 {
-				if err := initStatusServer(ctx, proxy, proxyConfig, agentOptions.EnvoyPrometheusPort, agent); err != nil {
-					return err
-				}
-			}
-
-			// On SIGINT or SIGTERM, cancel the context, triggering a graceful shutdown
-			go cmd.WaitSignalFunc(cancel)
-
-			// Start in process SDS, dns server, xds proxy, and Envoy.
-			wait, err := agent.Run(ctx)
+			wait, err := initAgent(args)
 			if err != nil {
 				return err
 			}
@@ -158,7 +98,37 @@ var (
 			return nil
 		},
 	}
+
+	execCmd = newExecCommand()
 )
+
+func newExecCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "exec -- COMMAND [args...]",
+		Short: "Execute a command in pilot-agent",
+		FParseErrWhitelist: cobra.FParseErrWhitelist{
+			// Allow unknown flags for backward-compatibility.
+			UnknownFlags: true,
+		},
+		PersistentPreRunE: configureLogging,
+		RunE: func(c *cobra.Command, args []string) error {
+			// In exec mode, only "sidecar" NodeType is supported.
+			wait, err := initAgent([]string{})
+			if err != nil {
+				return err
+			}
+			cmd := exec.Command(args[0], args[1:]...)
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Start(); err != nil {
+				return fmt.Errorf("failed to execute command: %v", err)
+			}
+			// For no-proxy mode, wait for SIGTERM for a graceful shutdown.
+			wait()
+			return nil
+		},
+	}
+}
 
 func init() {
 	proxyCmd.PersistentFlags().StringVar(&dnsDomain, "domain", "",
@@ -192,6 +162,7 @@ func init() {
 	cmd.AddFlags(rootCmd)
 
 	rootCmd.AddCommand(proxyCmd)
+	rootCmd.AddCommand(execCmd)
 	rootCmd.AddCommand(version.CobraCommand())
 	rootCmd.AddCommand(iptables.GetCommand())
 	rootCmd.AddCommand(cleaniptables.GetCommand())
@@ -229,6 +200,74 @@ func initStsServer(proxy *model.Proxy, tokenManager security.TokenManager) (*sts
 		return nil, err
 	}
 	return stsServer, nil
+}
+
+func initAgent(args []string) (func(), error) {
+	proxy, err := initProxy(args)
+	if err != nil {
+		return nil, err
+	}
+	proxyConfig, err := config.ConstructProxyConfig(meshConfigFile, serviceCluster, options.ProxyConfigEnv, concurrency, proxy)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get proxy config: %v", err)
+	}
+	if out, err := gogoprotomarshal.ToYAML(proxyConfig); err != nil {
+		log.Infof("Failed to serialize to YAML: %v", err)
+	} else {
+		log.Infof("Effective config: %s", out)
+	}
+
+	secOpts, err := options.NewSecurityOptions(proxyConfig, stsPort, tokenManagerPlugin)
+	if err != nil {
+		return nil, err
+	}
+
+	// If security token service (STS) port is not zero, start STS server and
+	// listen on STS port for STS requests. For STS, see
+	// https://tools.ietf.org/html/draft-ietf-oauth-token-exchange-16.
+	// STS is used for stackdriver or other Envoy services using google gRPC.
+	if stsPort > 0 {
+		stsServer, err := initStsServer(proxy, secOpts.TokenManager)
+		if err != nil {
+			return nil, err
+		}
+		defer stsServer.Stop()
+	}
+
+	// If we are using a custom template file (for control plane proxy, for example), configure this.
+	if templateFile != "" && proxyConfig.CustomConfigFile == "" {
+		proxyConfig.ProxyBootstrapTemplatePath = templateFile
+	}
+
+	envoyOptions := envoy.ProxyConfig{
+		LogLevel:          proxyLogLevel,
+		ComponentLogLevel: proxyComponentLogLevel,
+		LogAsJSON:         loggingOptions.JSONEncoding,
+		NodeIPs:           proxy.IPAddresses,
+		Sidecar:           proxy.Type == model.SidecarProxy,
+		OutlierLogPath:    outlierLogPath,
+	}
+	agentOptions := options.NewAgentOptions(proxy, proxyConfig)
+	agent := istio_agent.NewAgent(proxyConfig, agentOptions, secOpts, envoyOptions)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// If a status port was provided, start handling status probes.
+	if proxyConfig.StatusPort > 0 {
+		if err := initStatusServer(ctx, proxy, proxyConfig, agentOptions.EnvoyPrometheusPort, agent); err != nil {
+			return nil, err
+		}
+	}
+
+	// On SIGINT or SIGTERM, cancel the context, triggering a graceful shutdown
+	go cmd.WaitSignalFunc(cancel)
+
+	// Start in process SDS, dns server, xds proxy, and Envoy.
+	wait, err := agent.Run(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return wait, nil
 }
 
 func getDNSDomain(podNamespace, domain string) string {

--- a/pkg/istio-agent/agent_test.go
+++ b/pkg/istio-agent/agent_test.go
@@ -34,6 +34,7 @@ import (
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/xds"

--- a/releasenotes/notes/pilot-proxy-exec-mode.yaml
+++ b/releasenotes/notes/pilot-proxy-exec-mode.yaml
@@ -1,0 +1,12 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+issue:
+  - 28791
+releaseNotes:
+  - |
+    **Added** `pilot-agent exec -- COMMAND [args...]` command. Start a custom
+    command with/without envoy proxy. Rely on the previously added env
+    `DISABLE_ENVOY` to control whether to start envoy proxy. The agent will
+    be responsible for the cert generation/rotation and gRPC bootstrap file
+    generation.


### PR DESCRIPTION
Add support to start a custom command/app in pilot-agent.
The custom app can run with/without envoy proxy.
To be consistent, rely on the previously added environment
variable to control whether to enable envoy proxy.

Issue: https://github.com/istio/istio/issues/28791



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[X] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.