### PR TITLE
improve Equals func performance 

### DIFF
--- a/pilot/pkg/model/config_test.go
+++ b/pilot/pkg/model/config_test.go
@@ -179,6 +179,11 @@ func TestLabelsEquals(t *testing.T) {
 	}{
 		{
 			a: nil,
+			b: nil,
+			want: true,
+		},
+		{
+			a: nil,
 			b: labels.Instance{"a": "b"},
 		},
 		{
@@ -188,6 +193,19 @@ func TestLabelsEquals(t *testing.T) {
 		{
 			a:    labels.Instance{"a": "b"},
 			b:    labels.Instance{"a": "b"},
+			want: true,
+		},
+		{
+			a: labels.Instance{"a": "b"},
+			b: labels.Instance{"a": "b", "c": "d"},
+		},
+		{
+			b: labels.Instance{"a": "b", "c": "d"},
+			a: labels.Instance{"a": "b"},
+		},
+		{
+			b: labels.Instance{"a": "b", "c": "d"},
+			a: labels.Instance{"a": "b", "c": "d"},
 			want: true,
 		},
 	}

--- a/pilot/pkg/model/config_test.go
+++ b/pilot/pkg/model/config_test.go
@@ -178,8 +178,8 @@ func TestLabelsEquals(t *testing.T) {
 		want bool
 	}{
 		{
-			a: nil,
-			b: nil,
+			a:    nil,
+			b:    nil,
 			want: true,
 		},
 		{
@@ -204,8 +204,8 @@ func TestLabelsEquals(t *testing.T) {
 			a: labels.Instance{"a": "b"},
 		},
 		{
-			b: labels.Instance{"a": "b", "c": "d"},
-			a: labels.Instance{"a": "b", "c": "d"},
+			b:    labels.Instance{"a": "b", "c": "d"},
+			a:    labels.Instance{"a": "b", "c": "d"},
 			want: true,
 		},
 	}

--- a/pkg/config/labels/instance.go
+++ b/pkg/config/labels/instance.go
@@ -80,7 +80,10 @@ func (i Instance) Equals(that Instance) bool {
 	if that == nil {
 		return i == nil
 	}
-	return i.SubsetOf(that) && that.SubsetOf(i)
+	if len(i) != len(that) {
+		return false
+	}
+	return i.SubsetOf(that)
 }
 
 // Validate ensures tag is well-formed


### PR DESCRIPTION
Please provide a description for what this PR is for.

1. Add length check for maps with different length, to get result quickly.
2. As length has been checked, and the two maps have the same size, so we only need to check `i.SubsetOf(that)`.

I also add a small example to show the benchmark: https://play.golang.org/p/ZBC5Q9venNY
Run the example in local env, and will get the results:

```
--------- case 1 for length compare ------------
result false, original Equals cost time 233.469785ms
result false, new Equals cost time 162ns
--------- case 2 for one SubsetOf ------------
result true, new Equals 1 cost time 478.357971ms
result true, new Equals 2 cost time 232.908134ms
result true, new Equals 3 cost time 525.778057ms
2021-06-22 00:10:38.98496 +0800 CST m=+3.524822916
```

Case 1 shows two maps with different length, after adding length check, we only need 162ns for `EqualsNew1`, other than 233.469785ms for the original `Equals`.
Case 2 shows two maps with same length, same key & value, we could see `EqualsNew2` with one `SubsetOf` checking, costs almost **half time** of `EqualsNew1`. 
And case 2 also shows that `reflect.DeepEqual` is not a good implement for this situation(maybe the `reflect` is the cause).

---

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[X] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
