### PR TITLE
Use common utility for comparing cluster strings

### DIFF
--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -437,7 +437,7 @@ var AlwaysDiscoverable = func(*IstioEndpoint, *Proxy) bool {
 // DiscoverableFromSameCluster is an EndpointDiscoverabilityPolicy that only allows an endpoint to be discoverable
 // from proxies within the same cluster.
 var DiscoverableFromSameCluster = func(ep *IstioEndpoint, p *Proxy) bool {
-	return ep.Locality.ClusterID == p.Metadata.ClusterID
+	return p.InCluster(ep.Locality.ClusterID)
 }
 
 // ServiceAttributes represents a group of custom attributes of the service.

--- a/pilot/pkg/serviceregistry/kube/controller/serviceexportcache_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/serviceexportcache_test.go
@@ -35,6 +35,7 @@ const (
 	serviceExportName      = "test-svc"
 	serviceExportNamespace = "test-ns"
 	serviceExportPodIP     = "128.0.0.2"
+	testCluster            = "test-cluster"
 )
 
 var serviceExportNamespacedName = types.NamespacedName{
@@ -100,6 +101,7 @@ func newTestServiceExportCache(t *testing.T, stopCh chan struct{}) *serviceExpor
 	c, _ := NewFakeControllerWithOptions(FakeControllerOptions{
 		EnableMCSServiceDiscovery: true,
 		Stop:                      stopCh,
+		ClusterID:                 testCluster,
 	})
 
 	// Create the test service and endpoints.


### PR DESCRIPTION
This is a follow on to https://github.com/istio/istio/pull/32863#discussion_r654679922



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.