### PR TITLE
Address UDP DNS issues due to conntrack

### DIFF
--- a/tools/istio-iptables/pkg/cmd/run.go
+++ b/tools/istio-iptables/pkg/cmd/run.go
@@ -676,6 +676,131 @@ func HandleDNSUDP(
 			}
 		}
 	}
+	// Split UDP DNS traffic to separate conntrack zones
+	addConntrackZoneDNSUDP(ops, iptables, ext, cmd, proxyUID, proxyGID, dnsServersV4, captureAllDNS)
+}
+
+// addConntrackZoneDNSUDP is a helper function to add iptables rules to split DNS traffic
+// in two separate conntrack zones to avoid issues with UDP conntrack race conditions.
+// Traffic that goes from istio to DNS servers and vice versa are zone 1 and traffic from
+// DNS client to istio and vice versa goes to zone 2
+func addConntrackZoneDNSUDP(
+	ops Ops, iptables *builder.IptablesBuilderImpl, ext dep.Dependencies,
+	cmd, proxyUID, proxyGID string, dnsServersV4 []string, captureAllDNS bool) {
+	const paramIdxRaw = 4
+	var raw []string
+	opsStr := opsToString[ops]
+	table := constants.RAW
+	chainOUTPUT := constants.OUTPUT
+	chainPREROUTING := constants.PREROUTING
+
+	// TODO: add ip6 as well
+	for _, uid := range split(proxyUID) {
+		// Packets with dst port 53 from istio to zone 1. These are Istio calls to upstream resolvers
+		raw = []string{
+			"-t", table, opsStr, chainOUTPUT,
+			"-p", "udp", "--dport", "53", "-m", "owner", "--uid-owner", uid, "-j", constants.CT, "--zone", "1",
+		}
+		switch ops {
+		case AppendOps:
+			iptables.AppendRuleV4(chainOUTPUT, table, raw[paramIdxRaw:]...)
+		case DeleteOps:
+			ext.RunQuietlyAndIgnore(cmd, raw...)
+		}
+		// Packets with src port 15053 from istio to zone 2. These are Istio response packets to application clients
+		raw = []string{
+			"-t", table, opsStr, chainOUTPUT,
+			"-p", "udp", "--sport", "15053", "-m", "owner", "--uid-owner", uid, "-j", constants.CT, "--zone", "2",
+		}
+		switch ops {
+		case AppendOps:
+			iptables.AppendRuleV4(chainOUTPUT, table, raw[paramIdxRaw:]...)
+		case DeleteOps:
+			ext.RunQuietlyAndIgnore(cmd, raw...)
+		}
+	}
+	for _, gid := range split(proxyGID) {
+		// Packets with dst port 53 from istio to zone 1. These are Istio calls to upstream resolvers
+		raw = []string{
+			"-t", table, opsStr, chainOUTPUT,
+			"-p", "udp", "--dport", "53", "-m", "owner", "--gid-owner", gid, "-j", constants.CT, "--zone", "1",
+		}
+		switch ops {
+		case AppendOps:
+			iptables.AppendRuleV4(chainOUTPUT, table, raw[paramIdxRaw:]...)
+		case DeleteOps:
+			ext.RunQuietlyAndIgnore(cmd, raw...)
+		}
+		// Packets with src port 15053 from istio to zone 2. These are Istio response packets to application clients
+		raw = []string{
+			"-t", table, opsStr, chainOUTPUT,
+			"-p", "udp", "--sport", "15053", "-m", "owner", "--gid-owner", gid, "-j", constants.CT, "--zone", "2",
+		}
+		switch ops {
+		case AppendOps:
+			iptables.AppendRuleV4(chainOUTPUT, table, raw[paramIdxRaw:]...)
+		case DeleteOps:
+			ext.RunQuietlyAndIgnore(cmd, raw...)
+		}
+
+	}
+
+	if captureAllDNS {
+		// Not specifying destination address is useful for the CNI case where pod DNS server address cannot be decided.
+
+		// Mark all UDP dns traffic with dst port 53 as zone 2. These are application client packets towards DNS resolvers.
+		raw = []string{
+			"-t", table, opsStr, chainOUTPUT,
+			"-p", "udp", "--dport", "53",
+			"-j", constants.CT, "--zone", "2",
+		}
+		switch ops {
+		case AppendOps:
+			iptables.AppendRuleV4(chainOUTPUT, table, raw[paramIdxRaw:]...)
+		case DeleteOps:
+			ext.RunQuietlyAndIgnore(cmd, raw...)
+		}
+		// Mark all UDP dns traffic with src port 53 as zone 1. These are response packets from the DNS resolvers.
+		raw = []string{
+			"-t", table, opsStr, chainPREROUTING,
+			"-p", "udp", "--sport", "53",
+			"-j", constants.CT, "--zone", "1",
+		}
+		switch ops {
+		case AppendOps:
+			iptables.AppendRuleV4(chainPREROUTING, table, raw[paramIdxRaw:]...)
+		case DeleteOps:
+			ext.RunQuietlyAndIgnore(cmd, raw...)
+		}
+	} else {
+		// Go through all DNS servers in etc/resolv.conf and mark the packets based on these destination addresses.
+		for _, s := range dnsServersV4 {
+			// Mark all UDP dns traffic with dst port 53 as zone 2. These are application client packets towards DNS resolvers.
+			raw = []string{
+				"-t", table, opsStr, chainOUTPUT,
+				"-p", "udp", "--dport", "53", "-d", s + "/32",
+				"-j", constants.CT, "--zone", "2",
+			}
+			switch ops {
+			case AppendOps:
+				iptables.AppendRuleV4(chainOUTPUT, table, raw[paramIdxRaw:]...)
+			case DeleteOps:
+				ext.RunQuietlyAndIgnore(cmd, raw...)
+			}
+			// Mark all UDP dns traffic with src port 53 as zone 1. These are response packets from the DNS resolvers.
+			raw = []string{
+				"-t", table, opsStr, chainPREROUTING,
+				"-p", "udp", "--sport", "53", "-d", s + "/32",
+				"-j", constants.CT, "--zone", "1",
+			}
+			switch ops {
+			case AppendOps:
+				iptables.AppendRuleV4(chainPREROUTING, table, raw[paramIdxRaw:]...)
+			case DeleteOps:
+				ext.RunQuietlyAndIgnore(cmd, raw...)
+			}
+		}
+	}
 }
 
 func (iptConfigurator *IptablesConfigurator) handleOutboundPortsInclude() {

--- a/tools/istio-iptables/pkg/cmd/run_test.go
+++ b/tools/istio-iptables/pkg/cmd/run_test.go
@@ -159,6 +159,16 @@ func TestRulesWithIpRange(t *testing.T) {
 		"iptables -t nat -A OUTPUT -p udp --dport 53 -m owner --gid-owner 1 -j RETURN",
 		"iptables -t nat -A OUTPUT -p udp --dport 53 -m owner --gid-owner 2 -j RETURN",
 		"iptables -t nat -A OUTPUT -p udp --dport 53 -d 127.0.0.53/32 -j REDIRECT --to-port 15053",
+		"iptables -t raw -A OUTPUT -p udp --dport 53 -m owner --uid-owner 3 -j CT --zone 1",
+		"iptables -t raw -A OUTPUT -p udp --sport 15053 -m owner --uid-owner 3 -j CT --zone 2",
+		"iptables -t raw -A OUTPUT -p udp --dport 53 -m owner --uid-owner 4 -j CT --zone 1",
+		"iptables -t raw -A OUTPUT -p udp --sport 15053 -m owner --uid-owner 4 -j CT --zone 2",
+		"iptables -t raw -A OUTPUT -p udp --dport 53 -m owner --gid-owner 1 -j CT --zone 1",
+		"iptables -t raw -A OUTPUT -p udp --sport 15053 -m owner --gid-owner 1 -j CT --zone 2",
+		"iptables -t raw -A OUTPUT -p udp --dport 53 -m owner --gid-owner 2 -j CT --zone 1",
+		"iptables -t raw -A OUTPUT -p udp --sport 15053 -m owner --gid-owner 2 -j CT --zone 2",
+		"iptables -t raw -A OUTPUT -p udp --dport 53 -d 127.0.0.53/32 -j CT --zone 2",
+		"iptables -t raw -A PREROUTING -p udp --sport 53 -d 127.0.0.53/32 -j CT --zone 1",
 	}
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("Output mismatch. Expected: \n%#v ; Actual: \n%#v", expected, actual)
@@ -214,6 +224,12 @@ func TestRulesWithTproxy(t *testing.T) {
 		"iptables -t nat -A OUTPUT -p udp --dport 53 -m owner --uid-owner 1337 -j RETURN",
 		"iptables -t nat -A OUTPUT -p udp --dport 53 -m owner --gid-owner 1337 -j RETURN",
 		"iptables -t nat -A OUTPUT -p udp --dport 53 -d 127.0.0.53/32 -j REDIRECT --to-port 15053",
+		"iptables -t raw -A OUTPUT -p udp --dport 53 -m owner --uid-owner 1337 -j CT --zone 1",
+		"iptables -t raw -A OUTPUT -p udp --sport 15053 -m owner --uid-owner 1337 -j CT --zone 2",
+		"iptables -t raw -A OUTPUT -p udp --dport 53 -m owner --gid-owner 1337 -j CT --zone 1",
+		"iptables -t raw -A OUTPUT -p udp --sport 15053 -m owner --gid-owner 1337 -j CT --zone 2",
+		"iptables -t raw -A OUTPUT -p udp --dport 53 -d 127.0.0.53/32 -j CT --zone 2",
+		"iptables -t raw -A PREROUTING -p udp --sport 53 -d 127.0.0.53/32 -j CT --zone 1",
 		"iptables -t mangle -A PREROUTING -p tcp -m mark --mark 1337 -j CONNMARK --save-mark",
 		"iptables -t mangle -A OUTPUT -p tcp -o lo -m mark --mark 1337 -j RETURN",
 		"iptables -t mangle -A OUTPUT ! -d 127.0.0.1/32 -p tcp -o lo -m owner --uid-owner 1337 -j MARK --set-mark 1338",
@@ -758,6 +774,16 @@ func TestHandleInboundIpv4RulesWithUidGid(t *testing.T) {
 		"iptables -t nat -A OUTPUT -p udp --dport 53 -m owner --gid-owner 1 -j RETURN",
 		"iptables -t nat -A OUTPUT -p udp --dport 53 -m owner --gid-owner 2 -j RETURN",
 		"iptables -t nat -A OUTPUT -p udp --dport 53 -d 127.0.0.53/32 -j REDIRECT --to-port 15053",
+		"iptables -t raw -A OUTPUT -p udp --dport 53 -m owner --uid-owner 3 -j CT --zone 1",
+		"iptables -t raw -A OUTPUT -p udp --sport 15053 -m owner --uid-owner 3 -j CT --zone 2",
+		"iptables -t raw -A OUTPUT -p udp --dport 53 -m owner --uid-owner 4 -j CT --zone 1",
+		"iptables -t raw -A OUTPUT -p udp --sport 15053 -m owner --uid-owner 4 -j CT --zone 2",
+		"iptables -t raw -A OUTPUT -p udp --dport 53 -m owner --gid-owner 1 -j CT --zone 1",
+		"iptables -t raw -A OUTPUT -p udp --sport 15053 -m owner --gid-owner 1 -j CT --zone 2",
+		"iptables -t raw -A OUTPUT -p udp --dport 53 -m owner --gid-owner 2 -j CT --zone 1",
+		"iptables -t raw -A OUTPUT -p udp --sport 15053 -m owner --gid-owner 2 -j CT --zone 2",
+		"iptables -t raw -A OUTPUT -p udp --dport 53 -d 127.0.0.53/32 -j CT --zone 2",
+		"iptables -t raw -A PREROUTING -p udp --sport 53 -d 127.0.0.53/32 -j CT --zone 1",
 	}
 
 	if !reflect.DeepEqual(actual, expected) {
@@ -842,6 +868,16 @@ func TestRulesWithLoopbackIpInOutboundIpRanges(t *testing.T) {
 		"iptables -t nat -A OUTPUT -p udp --dport 53 -m owner --gid-owner 1 -j RETURN",
 		"iptables -t nat -A OUTPUT -p udp --dport 53 -m owner --gid-owner 2 -j RETURN",
 		"iptables -t nat -A OUTPUT -p udp --dport 53 -d 127.0.0.53/32 -j REDIRECT --to-port 15053",
+		"iptables -t raw -A OUTPUT -p udp --dport 53 -m owner --uid-owner 3 -j CT --zone 1",
+		"iptables -t raw -A OUTPUT -p udp --sport 15053 -m owner --uid-owner 3 -j CT --zone 2",
+		"iptables -t raw -A OUTPUT -p udp --dport 53 -m owner --uid-owner 4 -j CT --zone 1",
+		"iptables -t raw -A OUTPUT -p udp --sport 15053 -m owner --uid-owner 4 -j CT --zone 2",
+		"iptables -t raw -A OUTPUT -p udp --dport 53 -m owner --gid-owner 1 -j CT --zone 1",
+		"iptables -t raw -A OUTPUT -p udp --sport 15053 -m owner --gid-owner 1 -j CT --zone 2",
+		"iptables -t raw -A OUTPUT -p udp --dport 53 -m owner --gid-owner 2 -j CT --zone 1",
+		"iptables -t raw -A OUTPUT -p udp --sport 15053 -m owner --gid-owner 2 -j CT --zone 2",
+		"iptables -t raw -A OUTPUT -p udp --dport 53 -d 127.0.0.53/32 -j CT --zone 2",
+		"iptables -t raw -A PREROUTING -p udp --sport 53 -d 127.0.0.53/32 -j CT --zone 1",
 	}
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("Output mismatch. Expected: \n%#v ; Actual: \n%#v", expected, actual)

--- a/tools/istio-iptables/pkg/constants/constants.go
+++ b/tools/istio-iptables/pkg/constants/constants.go
@@ -21,6 +21,7 @@ const (
 	MANGLE = "mangle"
 	NAT    = "nat"
 	FILTER = "filter"
+	RAW    = "raw"
 )
 
 // Built-in iptables chains
@@ -51,6 +52,7 @@ const (
 	REJECT   = "REJECT"
 	REDIRECT = "REDIRECT"
 	MARK     = "MARK"
+	CT       = "CT"
 )
 
 // iptables chains


### PR DESCRIPTION
The problem this PR tries to solve is described in https://github.com/istio/istio/issues/33469

In cases where an application does a lot of DNS UDP requests, we have cases where a UDP requests picks a source port that is already defined inside the conntrack tables and its packet is routed directly to the DNS resolvers.
That makes the new packet to be also routed directly to DNS resolvers without traversing the NAT iptables and hence the REDIRECT rules to send it to the local Istio DNS port.
This way we get DNS resolution errors.

The fix that implements this commit is to use separate conntrack zones for different flows. One flow will be the communication with the application, and the other will be the communication with DNS resolver.
More specific zone 2 will be UDP DNS packets that are coming from the application and return to it. Zone 1 will be UDP DNS packets that are coming from istio and going to DNS resolvers and vice versa.
Here is a picture to help you understand how the packets are classified in each conntrack zone
![conntrack](https://user-images.githubusercontent.com/1355590/122952227-2f6dd800-d37e-11eb-8e01-ea58849eb1d8.jpg)




[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.