### PR TITLE
Error produced by forworder.start can't return correctly

### DIFF
--- a/istioctl/cmd/dashboard.go
+++ b/istioctl/cmd/dashboard.go
@@ -418,7 +418,8 @@ func portForward(podName, namespace, flavor, urlFormat, localAddress string, rem
 
 	var err error
 	for _, localPort := range portPrefs {
-		fw, err := client.NewPortForwarder(podName, namespace, localAddress, localPort, remotePort)
+		var fw kube.PortForwarder
+		fw, err = client.NewPortForwarder(podName, namespace, localAddress, localPort, remotePort)
 		if err != nil {
 			return fmt.Errorf("could not build port forwarder for %s: %v", flavor, err)
 		}


### PR DESCRIPTION
The error info produced by fw.Start() can't pass to the outer err because it's been redefined


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[X] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.