### PR TITLE
make reached clusters check only consider actual clusters

### DIFF
--- a/pkg/test/echo/client/parsedresponse.go
+++ b/pkg/test/echo/client/parsedresponse.go
@@ -230,6 +230,7 @@ func (r ParsedResponses) clusterDistribution() map[string]int {
 // This can be used in combination with echo.Instances.Clusters(), for example:
 //     echoA[0].CallOrFail(t, ...).CheckReachedClusters(echoB.Clusters())
 func (r ParsedResponses) CheckReachedClusters(clusters cluster.Clusters) error {
+	clusters = clusters.Kube()
 	hits := r.clusterDistribution()
 	exp := map[string]struct{}{}
 	for _, expCluster := range clusters {
@@ -250,6 +251,7 @@ func (r ParsedResponses) CheckReachedClusters(clusters cluster.Clusters) error {
 // For example, with 100 requests and 20 percent error, each cluster must given received 20±4 responses. Only the passed
 // in clusters will be validated.
 func (r ParsedResponses) CheckEqualClusterTraffic(clusters cluster.Clusters, precisionPct int) error {
+	clusters = clusters.Kube()
 	clusterHits := r.clusterDistribution()
 	expected := len(r) / len(clusters)
 	precision := int(float32(expected) * (float32(precisionPct) / 100))


### PR DESCRIPTION
We use "Cluster" to abstract anywhere we deploy to, but the things we deploy to consider themselves as being "attached" to one of the k8s clusters – this is what's validated in these checks. 