### PR TITLE
Refactoring network gateway storage.

### DIFF
--- a/pilot/pkg/model/network.go
+++ b/pilot/pkg/model/network.go
@@ -1,0 +1,144 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"net"
+)
+
+const (
+	noCluster = ""
+)
+
+// NetworkID is the unique identifier for a network.
+type NetworkID string
+
+func (id NetworkID) Equals(other NetworkID) bool {
+	return SameOrEmpty(string(id), string(other))
+}
+
+// ClusterID is the unique identifier for a k8s cluster.
+type ClusterID string
+
+func (id ClusterID) Equals(other ClusterID) bool {
+	return SameOrEmpty(string(id), string(other))
+}
+
+// Gateway is the gateway of a network
+type Gateway struct {
+	// Network is the ID of the network where this Gateway resides.
+	Network NetworkID
+	// Cluster is the ID of the k8s cluster where this Gateway resides.
+	Cluster ClusterID
+	// gateway ip address
+	Addr string
+	// gateway port
+	Port uint32
+}
+
+// Gateways provides information about network Gateway resources throughout the mesh.
+type Gateways interface {
+	// IsMultiNetworkEnabled returns true if one or more Gateways are configured.
+	IsMultiNetworkEnabled() bool
+
+	// All returns all configured Gateway resources in the entire mesh.
+	All() []*Gateway
+
+	// ForNetwork returns all Gateway resources configured for the given network.
+	ForNetwork(network NetworkID) []*Gateway
+
+	// ForNetworkAndCluster returns all Gateway resources configured for the given network and cluster.
+	ForNetworkAndCluster(network NetworkID, cluster ClusterID) []*Gateway
+}
+
+// newGateways creates a new Gateways from the Environment by merging
+// together the MeshNetworks and ServiceRegistry-specific gateways.
+func newGateways(env *Environment) Gateways {
+	// Generate the a snapshot of the state of gateways by merging the contents of
+	// MeshNetworks and the ServiceRegistries.
+	gatewayMap := make(map[NetworkID]map[ClusterID][]*Gateway)
+
+	addGateway := func(gateway *Gateway) {
+		// Get (or create) an entry for the network.
+		gatewaysByCluster := gatewayMap[gateway.Network]
+		if gatewaysByCluster == nil {
+			gatewaysByCluster = make(map[ClusterID][]*Gateway)
+			gatewayMap[gateway.Network] = gatewaysByCluster
+		}
+
+		gatewaysByCluster[gateway.Cluster] = append(gatewaysByCluster[gateway.Cluster], gateway)
+		if gateway.Cluster != noCluster {
+			// Also make sure this gateway appears in the global list of all gateways for the network.
+			gatewaysByCluster[noCluster] = append(gatewaysByCluster[noCluster], gateway)
+		}
+	}
+
+	// First, load gateways from the static MeshNetworks config.
+	meshNetworks := env.Networks()
+	if meshNetworks != nil {
+		for network, networkConf := range meshNetworks.Networks {
+			gws := networkConf.Gateways
+			for _, gw := range gws {
+				if gwIP := net.ParseIP(gw.GetAddress()); gwIP != nil {
+					addGateway(&Gateway{
+						Cluster: noCluster, /* TODO(nmittler): Add Cluster to the API */
+						Network: NetworkID(network),
+						Addr:    gw.GetAddress(),
+						Port:    gw.Port,
+					})
+				}
+			}
+		}
+	}
+
+	// Second, load registry-specific gateways.
+	for _, gateway := range env.NetworkGateways() {
+		// - the internal map of label gateways - these get deleted if the service is deleted, updated if the ip changes etc.
+		// - the computed map from meshNetworks (triggered by reloadNetworkLookup, the ported logic from getGatewayAddresses)
+		addGateway(gateway)
+	}
+
+	return &gatewaysImpl{
+		gateways: gatewayMap,
+	}
+}
+
+type gatewaysImpl struct {
+	gateways map[NetworkID]map[ClusterID][]*Gateway
+}
+
+func (gws *gatewaysImpl) IsMultiNetworkEnabled() bool {
+	return len(gws.gateways) > 0
+}
+
+func (gws *gatewaysImpl) All() []*Gateway {
+	out := make([]*Gateway, 0)
+	for _, byCluster := range gws.gateways {
+		out = append(out, byCluster[noCluster]...)
+	}
+	return out
+}
+
+func (gws *gatewaysImpl) ForNetwork(network NetworkID) []*Gateway {
+	return gws.ForNetworkAndCluster(network, noCluster)
+}
+
+func (gws *gatewaysImpl) ForNetworkAndCluster(network NetworkID, cluster ClusterID) []*Gateway {
+	gatewaysByCluster := gws.gateways[network]
+	if gatewaysByCluster != nil {
+		return gatewaysByCluster[cluster]
+	}
+	return nil
+}

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -17,7 +17,6 @@ package model
 import (
 	"encoding/json"
 	"fmt"
-	"net"
 	"sort"
 	"strconv"
 	"strings"
@@ -203,19 +202,10 @@ type PushContext struct {
 
 	// cache gateways addresses for each network
 	// this is mainly used for kubernetes multi-cluster scenario
-	networksMu      sync.RWMutex
-	networkGateways map[string][]*Gateway
+	gateways Gateways
 
 	initDone        atomic.Bool
 	initializeMutex sync.Mutex
-}
-
-// Gateway is the gateway of a network
-type Gateway struct {
-	// gateway ip address
-	Addr string
-	// gateway port
-	Port uint32
 }
 
 type processedDestRules struct {
@@ -1881,46 +1871,11 @@ func instancesEmpty(m map[int][]*ServiceInstance) bool {
 
 // pre computes gateways for each network
 func (ps *PushContext) initMeshNetworks(env *Environment) {
-	ps.networksMu.Lock()
-	defer ps.networksMu.Unlock()
-	ps.networkGateways = map[string][]*Gateway{}
-
-	// First, use addresses directly specified in meshNetworks
-	meshNetworks := env.Networks()
-	if meshNetworks != nil {
-		for network, networkConf := range meshNetworks.Networks {
-			gws := networkConf.Gateways
-			for _, gw := range gws {
-				if gwIP := net.ParseIP(gw.GetAddress()); gwIP != nil {
-					ps.networkGateways[network] = append(ps.networkGateways[network], &Gateway{gw.GetAddress(), gw.Port})
-				}
-			}
-
-		}
-	}
-
-	// Second, load registry specific gateways.
-	for network, gateways := range env.NetworkGateways() {
-		// - the internal map of label gateways - these get deleted if the service is deleted, updated if the ip changes etc.
-		// - the computed map from meshNetworks (triggered by reloadNetworkLookup, the ported logic from getGatewayAddresses)
-		ps.networkGateways[network] = append(ps.networkGateways[network], gateways...)
-	}
+	ps.gateways = newGateways(env)
 }
 
-func (ps *PushContext) NetworkGateways() map[string][]*Gateway {
-	ps.networksMu.RLock()
-	defer ps.networksMu.RUnlock()
-	return ps.networkGateways
-}
-
-func (ps *PushContext) NetworkGatewaysByNetwork(network string) []*Gateway {
-	ps.networksMu.RLock()
-	defer ps.networksMu.RUnlock()
-	if ps.networkGateways != nil {
-		return ps.networkGateways[network]
-	}
-
-	return nil
+func (ps *PushContext) Gateways() Gateways {
+	return ps.gateways
 }
 
 // BestEffortInferServiceMTLSMode infers the mTLS mode for the service + port from all authentication

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -202,7 +202,7 @@ type PushContext struct {
 
 	// cache gateways addresses for each network
 	// this is mainly used for kubernetes multi-cluster scenario
-	gateways Gateways
+	networkGateways *NetworkGateways
 
 	initDone        atomic.Bool
 	initializeMutex sync.Mutex
@@ -1871,11 +1871,11 @@ func instancesEmpty(m map[int][]*ServiceInstance) bool {
 
 // pre computes gateways for each network
 func (ps *PushContext) initMeshNetworks(env *Environment) {
-	ps.gateways = newGateways(env)
+	ps.networkGateways = newNetworkGateways(env)
 }
 
-func (ps *PushContext) Gateways() Gateways {
-	return ps.gateways
+func (ps *PushContext) NetworkGateways() *NetworkGateways {
+	return ps.networkGateways
 }
 
 // BestEffortInferServiceMTLSMode infers the mTLS mode for the service + port from all authentication

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -727,7 +727,7 @@ func TestInitPushContext(t *testing.T) {
 		// Allow looking into exported fields for parts of push context
 		cmp.AllowUnexported(PushContext{}, exportToDefaults{}, serviceIndex{}, virtualServiceIndex{},
 			destinationRuleIndex{}, gatewayIndex{}, processedDestRules{}, IstioEgressListenerWrapper{}, SidecarScope{},
-			AuthenticationPolicies{}, gatewaysImpl{}),
+			AuthenticationPolicies{}, NetworkGateways{}),
 		// These are not feasible/worth comparing
 		cmpopts.IgnoreTypes(sync.RWMutex{}, localServiceDiscovery{}, FakeStore{}, atomic.Bool{}, sync.Mutex{}),
 		cmpopts.IgnoreInterfaces(struct{ mesh.Holder }{}),
@@ -1719,7 +1719,7 @@ func (l *localServiceDiscovery) GetIstioServiceAccounts(svc *Service, ports []in
 	return nil
 }
 
-func (l *localServiceDiscovery) NetworkGateways() []*Gateway {
+func (l *localServiceDiscovery) NetworkGateways() []*NetworkGateway {
 	// TODO implement fromRegistry logic from kube controller if needed
 	return nil
 }

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -726,7 +726,8 @@ func TestInitPushContext(t *testing.T) {
 	diff := cmp.Diff(old, newPush,
 		// Allow looking into exported fields for parts of push context
 		cmp.AllowUnexported(PushContext{}, exportToDefaults{}, serviceIndex{}, virtualServiceIndex{},
-			destinationRuleIndex{}, gatewayIndex{}, processedDestRules{}, IstioEgressListenerWrapper{}, SidecarScope{}, AuthenticationPolicies{}),
+			destinationRuleIndex{}, gatewayIndex{}, processedDestRules{}, IstioEgressListenerWrapper{}, SidecarScope{},
+			AuthenticationPolicies{}, gatewaysImpl{}),
 		// These are not feasible/worth comparing
 		cmpopts.IgnoreTypes(sync.RWMutex{}, localServiceDiscovery{}, FakeStore{}, atomic.Bool{}, sync.Mutex{}),
 		cmpopts.IgnoreInterfaces(struct{ mesh.Holder }{}),
@@ -1718,7 +1719,7 @@ func (l *localServiceDiscovery) GetIstioServiceAccounts(svc *Service, ports []in
 	return nil
 }
 
-func (l *localServiceDiscovery) NetworkGateways() map[string][]*Gateway {
+func (l *localServiceDiscovery) NetworkGateways() []*Gateway {
 	// TODO implement fromRegistry logic from kube controller if needed
 	return nil
 }

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -42,6 +42,11 @@ import (
 	"istio.io/istio/pkg/config/visibility"
 )
 
+const (
+	// DefaultLoadBalancingWeight is the default weight applied to IstioEndpoint, if not set explicitly.
+	DefaultLoadBalancingWeight = 1
+)
+
 // Service describes an Istio service (e.g., catalog.mystore.com:8080)
 // Each service has a fully qualified domain name (FQDN) and one or more
 // ports where the service is listening for connections. *Optionally*, a
@@ -417,6 +422,14 @@ type IstioEndpoint struct {
 	DiscoverabilityPolicy EndpointDiscoverabilityPolicy `json:"-"`
 }
 
+// GetLoadBalancingWeight returns the LbWeight for this endpoint, or DefaultLoadBalancingWeight if not set.
+func (ep *IstioEndpoint) GetLoadBalancingWeight() uint32 {
+	if ep.LbWeight > 0 {
+		return ep.LbWeight
+	}
+	return DefaultLoadBalancingWeight
+}
+
 // IsDiscoverableFromProxy indicates whether or not this endpoint is discoverable from the given Proxy.
 func (ep *IstioEndpoint) IsDiscoverableFromProxy(p *Proxy) bool {
 	if ep == nil || ep.DiscoverabilityPolicy == nil {
@@ -537,8 +550,8 @@ type ServiceDiscovery interface {
 	// Deprecated - service account tracking moved to XdsServer, incremental.
 	GetIstioServiceAccounts(svc *Service, ports []int) []string
 
-	// NetworkGateways returns a map of network name to Gateways that can be used to access that network.
-	NetworkGateways() map[string][]*Gateway
+	// NetworkGateways returns a list of network gateways that can be used to access endpoints residing in this registry..
+	NetworkGateways() []*Gateway
 }
 
 // GetNames returns port names

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -42,11 +42,6 @@ import (
 	"istio.io/istio/pkg/config/visibility"
 )
 
-const (
-	// DefaultLoadBalancingWeight is the default weight applied to IstioEndpoint, if not set explicitly.
-	DefaultLoadBalancingWeight = 1
-)
-
 // Service describes an Istio service (e.g., catalog.mystore.com:8080)
 // Each service has a fully qualified domain name (FQDN) and one or more
 // ports where the service is listening for connections. *Optionally*, a
@@ -422,14 +417,6 @@ type IstioEndpoint struct {
 	DiscoverabilityPolicy EndpointDiscoverabilityPolicy `json:"-"`
 }
 
-// GetLoadBalancingWeight returns the LbWeight for this endpoint, or DefaultLoadBalancingWeight if not set.
-func (ep *IstioEndpoint) GetLoadBalancingWeight() uint32 {
-	if ep.LbWeight > 0 {
-		return ep.LbWeight
-	}
-	return DefaultLoadBalancingWeight
-}
-
 // IsDiscoverableFromProxy indicates whether or not this endpoint is discoverable from the given Proxy.
 func (ep *IstioEndpoint) IsDiscoverableFromProxy(p *Proxy) bool {
 	if ep == nil || ep.DiscoverabilityPolicy == nil {
@@ -551,7 +538,7 @@ type ServiceDiscovery interface {
 	GetIstioServiceAccounts(svc *Service, ports []int) []string
 
 	// NetworkGateways returns a list of network gateways that can be used to access endpoints residing in this registry..
-	NetworkGateways() []*Gateway
+	NetworkGateways() []*NetworkGateway
 }
 
 // GetNames returns port names

--- a/pilot/pkg/serviceregistry/aggregate/controller.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller.go
@@ -181,8 +181,8 @@ func mergeService(dst, src *model.Service, srcCluster string) {
 }
 
 // NetworkGateways merges the service-based cross-network gateways from each registry.
-func (c *Controller) NetworkGateways() []*model.Gateway {
-	gws := make([]*model.Gateway, 0)
+func (c *Controller) NetworkGateways() []*model.NetworkGateway {
+	var gws []*model.NetworkGateway
 	for _, r := range c.GetRegistries() {
 		gws = append(gws, r.NetworkGateways()...)
 	}

--- a/pilot/pkg/serviceregistry/aggregate/controller.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller.go
@@ -181,16 +181,10 @@ func mergeService(dst, src *model.Service, srcCluster string) {
 }
 
 // NetworkGateways merges the service-based cross-network gateways from each registry.
-func (c *Controller) NetworkGateways() map[string][]*model.Gateway {
-	gws := map[string][]*model.Gateway{}
+func (c *Controller) NetworkGateways() []*model.Gateway {
+	gws := make([]*model.Gateway, 0)
 	for _, r := range c.GetRegistries() {
-		gwMap := r.NetworkGateways()
-		if gwMap == nil {
-			continue
-		}
-		for net, regGws := range gwMap {
-			gws[net] = append(gws[net], regGws...)
-		}
+		gws = append(gws, r.NetworkGateways()...)
 	}
 	return gws
 }

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -254,7 +254,7 @@ type Controller struct {
 	// tracks which services on which ports should act as a gateway for networkForRegistry
 	registryServiceNameGateways map[host.Name]uint32
 	// gateways for each network, indexed by the service that runs them so we clean them up later
-	networkGateways map[host.Name]map[string][]*model.Gateway
+	networkGateways map[host.Name]map[string][]*model.NetworkGateway
 
 	// informerInit is set to true once the controller is running successfully. This ensures we do not
 	// return HasSynced=true before we are running
@@ -279,7 +279,7 @@ func NewController(kubeClient kubelib.Client, options Options) *Controller {
 		workloadInstancesByIP:       make(map[string]*model.WorkloadInstance),
 		workloadInstancesIPsByName:  make(map[string]string),
 		registryServiceNameGateways: make(map[host.Name]uint32),
-		networkGateways:             make(map[host.Name]map[string][]*model.Gateway),
+		networkGateways:             make(map[host.Name]map[string][]*model.NetworkGateway),
 		informerInit:                atomic.NewBool(false),
 		beginSync:                   atomic.NewBool(false),
 		initialSync:                 atomic.NewBool(false),

--- a/pilot/pkg/serviceregistry/kube/controller/network.go
+++ b/pilot/pkg/serviceregistry/kube/controller/network.go
@@ -108,19 +108,19 @@ func (c *Controller) reloadMeshNetworks() {
 	c.ranger = ranger
 }
 
-func (c *Controller) NetworkGateways() map[string][]*model.Gateway {
+func (c *Controller) NetworkGateways() []*model.Gateway {
 	c.RLock()
 	defer c.RUnlock()
 	if c.networkGateways == nil || len(c.networkGateways) == 0 {
 		return nil
 	}
-	gws := map[string][]*model.Gateway{}
+	gws := make([]*model.Gateway, 0)
 	for _, netGws := range c.networkGateways {
 		if netGws == nil {
 			continue
 		}
-		for nw, gw := range netGws {
-			gws[nw] = append(gws[nw], gw...)
+		for _, gw := range netGws {
+			gws = append(gws, gw...)
 		}
 	}
 	return gws
@@ -184,7 +184,12 @@ func (c *Controller) extractGatewaysInner(svc *model.Service) bool {
 		}
 		ips := svc.Attributes.ClusterExternalAddresses[c.Cluster()]
 		for _, ip := range ips {
-			gws = append(gws, &model.Gateway{Addr: ip, Port: gwPort})
+			gws = append(gws, &model.Gateway{
+				Cluster: model.ClusterID(c.Cluster()),
+				Network: model.NetworkID(network),
+				Addr:    ip,
+				Port:    gwPort,
+			})
 		}
 	}
 

--- a/pilot/pkg/serviceregistry/kube/controller/network.go
+++ b/pilot/pkg/serviceregistry/kube/controller/network.go
@@ -108,13 +108,13 @@ func (c *Controller) reloadMeshNetworks() {
 	c.ranger = ranger
 }
 
-func (c *Controller) NetworkGateways() []*model.Gateway {
+func (c *Controller) NetworkGateways() []*model.NetworkGateway {
 	c.RLock()
 	defer c.RUnlock()
 	if c.networkGateways == nil || len(c.networkGateways) == 0 {
 		return nil
 	}
-	gws := make([]*model.Gateway, 0)
+	gws := make([]*model.NetworkGateway, 0)
 	for _, netGws := range c.networkGateways {
 		if netGws == nil {
 			continue
@@ -164,10 +164,10 @@ func (c *Controller) extractGatewaysInner(svc *model.Service) bool {
 	}
 
 	if c.networkGateways[svc.Hostname] == nil {
-		c.networkGateways[svc.Hostname] = map[string][]*model.Gateway{}
+		c.networkGateways[svc.Hostname] = map[string][]*model.NetworkGateway{}
 	}
 
-	gws := make([]*model.Gateway, 0, len(svc.Attributes.ClusterExternalAddresses))
+	gws := make([]*model.NetworkGateway, 0, len(svc.Attributes.ClusterExternalAddresses))
 
 	// TODO(landow) ClusterExternalAddresses doesn't need to get used outside of the kube controller, and spreads
 	// TODO(cont)   logic between ConvertService, extractGatewaysInner, and updateServiceNodePortAddresses.
@@ -184,7 +184,7 @@ func (c *Controller) extractGatewaysInner(svc *model.Service) bool {
 		}
 		ips := svc.Attributes.ClusterExternalAddresses[c.Cluster()]
 		for _, ip := range ips {
-			gws = append(gws, &model.Gateway{
+			gws = append(gws, &model.NetworkGateway{
 				Cluster: model.ClusterID(c.Cluster()),
 				Network: model.NetworkID(network),
 				Addr:    ip,
@@ -196,7 +196,7 @@ func (c *Controller) extractGatewaysInner(svc *model.Service) bool {
 	gwsChanged := len(c.networkGateways[svc.Hostname][network]) != len(gws)
 	if !gwsChanged {
 		// number of gateways are the same, check that their contents are the same
-		found := map[model.Gateway]bool{}
+		found := map[model.NetworkGateway]bool{}
 		for _, gw := range gws {
 			found[*gw] = true
 		}

--- a/pilot/pkg/serviceregistry/memory/discovery.go
+++ b/pilot/pkg/serviceregistry/memory/discovery.go
@@ -37,7 +37,7 @@ type ServiceController struct {
 var _ model.Controller = &ServiceController{}
 
 // Memory does not support workload handlers; everything is done in terms of instances
-func (c *ServiceController) AppendWorkloadHandler(f func(*model.WorkloadInstance, model.Event)) {}
+func (c *ServiceController) AppendWorkloadHandler(func(*model.WorkloadInstance, model.Event)) {}
 
 // AppendServiceHandler appends a service handler to the controller
 func (c *ServiceController) AppendServiceHandler(f func(*model.Service, model.Event)) {
@@ -55,7 +55,7 @@ func (c *ServiceController) HasSynced() bool { return true }
 // ServiceDiscovery is a mock discovery interface
 type ServiceDiscovery struct {
 	services        map[host.Name]*model.Service
-	networkGateways map[string][]*model.Gateway
+	networkGateways []*model.Gateway
 	// EndpointShards table. Key is the fqdn of the service, ':', port
 	instancesByPortNum  map[string][]*model.ServiceInstance
 	instancesByPortName map[string][]*model.ServiceInstance
@@ -96,7 +96,6 @@ func NewServiceDiscovery(services []*model.Service) *ServiceDiscovery {
 		instancesByPortName: map[string][]*model.ServiceInstance{},
 		ip2instance:         map[string][]*model.ServiceInstance{},
 		ip2workloadLabels:   map[string]*labels.Instance{},
-		networkGateways:     map[string][]*model.Gateway{},
 	}
 }
 
@@ -314,7 +313,7 @@ func (sd *ServiceDiscovery) GetProxyWorkloadLabels(proxy *model.Proxy) labels.Co
 }
 
 // GetIstioServiceAccounts gets the Istio service accounts for a service hostname.
-func (sd *ServiceDiscovery) GetIstioServiceAccounts(svc *model.Service, ports []int) []string {
+func (sd *ServiceDiscovery) GetIstioServiceAccounts(svc *model.Service, _ []int) []string {
 	sd.mutex.Lock()
 	defer sd.mutex.Unlock()
 	if svc.Hostname == "world.default.svc.cluster.local" {
@@ -326,10 +325,10 @@ func (sd *ServiceDiscovery) GetIstioServiceAccounts(svc *model.Service, ports []
 	return make([]string, 0)
 }
 
-func (sd *ServiceDiscovery) SetGatewaysForNetwork(nw string, gws ...*model.Gateway) {
-	sd.networkGateways[nw] = gws
+func (sd *ServiceDiscovery) AddGateways(gws ...*model.Gateway) {
+	sd.networkGateways = append(sd.networkGateways, gws...)
 }
 
-func (sd *ServiceDiscovery) NetworkGateways() map[string][]*model.Gateway {
+func (sd *ServiceDiscovery) NetworkGateways() []*model.Gateway {
 	return sd.networkGateways
 }

--- a/pilot/pkg/serviceregistry/memory/discovery.go
+++ b/pilot/pkg/serviceregistry/memory/discovery.go
@@ -55,7 +55,7 @@ func (c *ServiceController) HasSynced() bool { return true }
 // ServiceDiscovery is a mock discovery interface
 type ServiceDiscovery struct {
 	services        map[host.Name]*model.Service
-	networkGateways []*model.Gateway
+	networkGateways []*model.NetworkGateway
 	// EndpointShards table. Key is the fqdn of the service, ':', port
 	instancesByPortNum  map[string][]*model.ServiceInstance
 	instancesByPortName map[string][]*model.ServiceInstance
@@ -325,10 +325,10 @@ func (sd *ServiceDiscovery) GetIstioServiceAccounts(svc *model.Service, _ []int)
 	return make([]string, 0)
 }
 
-func (sd *ServiceDiscovery) AddGateways(gws ...*model.Gateway) {
+func (sd *ServiceDiscovery) AddGateways(gws ...*model.NetworkGateway) {
 	sd.networkGateways = append(sd.networkGateways, gws...)
 }
 
-func (sd *ServiceDiscovery) NetworkGateways() []*model.Gateway {
+func (sd *ServiceDiscovery) NetworkGateways() []*model.NetworkGateway {
 	return sd.networkGateways
 }

--- a/pilot/pkg/serviceregistry/mock/discovery.go
+++ b/pilot/pkg/serviceregistry/mock/discovery.go
@@ -243,9 +243,9 @@ func (sd *ServiceDiscovery) GetIstioServiceAccounts(svc *model.Service, ports []
 	return make([]string, 0)
 }
 
-func (sd *ServiceDiscovery) NetworkGateways() map[string][]*model.Gateway {
+func (sd *ServiceDiscovery) NetworkGateways() []*model.Gateway {
 	// TODO use logic from kube controller if needed
-	return map[string][]*model.Gateway{}
+	return []*model.Gateway{}
 }
 
 type Controller struct{}

--- a/pilot/pkg/serviceregistry/mock/discovery.go
+++ b/pilot/pkg/serviceregistry/mock/discovery.go
@@ -243,9 +243,9 @@ func (sd *ServiceDiscovery) GetIstioServiceAccounts(svc *model.Service, ports []
 	return make([]string, 0)
 }
 
-func (sd *ServiceDiscovery) NetworkGateways() []*model.Gateway {
+func (sd *ServiceDiscovery) NetworkGateways() []*model.NetworkGateway {
 	// TODO use logic from kube controller if needed
-	return []*model.Gateway{}
+	return []*model.NetworkGateway{}
 }
 
 type Controller struct{}

--- a/pilot/pkg/serviceregistry/serviceentry/servicediscovery.go
+++ b/pilot/pkg/serviceregistry/serviceentry/servicediscovery.go
@@ -833,7 +833,7 @@ func (s *ServiceEntryStore) GetIstioServiceAccounts(svc *model.Service, ports []
 	return model.GetServiceAccounts(svc, ports, s)
 }
 
-func (s *ServiceEntryStore) NetworkGateways() map[string][]*model.Gateway {
+func (s *ServiceEntryStore) NetworkGateways() []*model.Gateway {
 	// TODO implement mesh networks loading logic from kube controller if needed
 	return nil
 }

--- a/pilot/pkg/serviceregistry/serviceentry/servicediscovery.go
+++ b/pilot/pkg/serviceregistry/serviceentry/servicediscovery.go
@@ -833,7 +833,7 @@ func (s *ServiceEntryStore) GetIstioServiceAccounts(svc *model.Service, ports []
 	return model.GetServiceAccounts(svc, ports, s)
 }
 
-func (s *ServiceEntryStore) NetworkGateways() []*model.Gateway {
+func (s *ServiceEntryStore) NetworkGateways() []*model.NetworkGateway {
 	// TODO implement mesh networks loading logic from kube controller if needed
 	return nil
 }

--- a/pilot/pkg/xds/debug.go
+++ b/pilot/pkg/xds/debug.go
@@ -692,10 +692,15 @@ type PushContextDebug struct {
 }
 
 // PushContextHandler dumps the current PushContext
-func (s *DiscoveryServer) PushContextHandler(w http.ResponseWriter, req *http.Request) {
+func (s *DiscoveryServer) PushContextHandler(w http.ResponseWriter, _ *http.Request) {
+	gateways := s.globalPushContext().Gateways().All()
+	byNetwork := make(map[string][]*model.Gateway)
+	for _, gateway := range gateways {
+		byNetwork[string(gateway.Network)] = append(byNetwork[string(gateway.Network)], gateway)
+	}
 	push := PushContextDebug{
 		AuthorizationPolicies: s.globalPushContext().AuthzPolicies,
-		NetworkGateways:       s.globalPushContext().NetworkGateways(),
+		NetworkGateways:       byNetwork,
 	}
 
 	writeJSON(w, push)

--- a/pilot/pkg/xds/debug.go
+++ b/pilot/pkg/xds/debug.go
@@ -688,13 +688,13 @@ func (s *DiscoveryServer) PushStatusHandler(w http.ResponseWriter, req *http.Req
 // PushContextDebug holds debug information for push context.
 type PushContextDebug struct {
 	AuthorizationPolicies *model.AuthorizationPolicies
-	NetworkGateways       map[string][]*model.Gateway
+	NetworkGateways       map[string][]*model.NetworkGateway
 }
 
 // PushContextHandler dumps the current PushContext
 func (s *DiscoveryServer) PushContextHandler(w http.ResponseWriter, _ *http.Request) {
-	gateways := s.globalPushContext().Gateways().All()
-	byNetwork := make(map[string][]*model.Gateway)
+	gateways := s.globalPushContext().NetworkGateways().All()
+	byNetwork := make(map[string][]*model.NetworkGateway)
 	for _, gateway := range gateways {
 		byNetwork[string(gateway.Network)] = append(byNetwork[string(gateway.Network)], gateway)
 	}

--- a/pilot/pkg/xds/eds.go
+++ b/pilot/pkg/xds/eds.go
@@ -312,7 +312,7 @@ func (s *DiscoveryServer) generateEndpoints(b EndpointBuilder) *endpoint.Cluster
 
 	// If networks are set (by default they aren't) apply the Split Horizon
 	// EDS filter on the endpoints
-	if b.push.Gateways().IsMultiNetworkEnabled() {
+	if b.push.NetworkGateways().IsMultiNetworkEnabled() {
 		llbOpts = b.EndpointsByNetworkFilter(llbOpts)
 	}
 	if model.IsDNSSrvSubsetKey(b.clusterName) {

--- a/pilot/pkg/xds/eds.go
+++ b/pilot/pkg/xds/eds.go
@@ -312,7 +312,7 @@ func (s *DiscoveryServer) generateEndpoints(b EndpointBuilder) *endpoint.Cluster
 
 	// If networks are set (by default they aren't) apply the Split Horizon
 	// EDS filter on the endpoints
-	if b.MultiNetworkConfigured() {
+	if b.push.Gateways().IsMultiNetworkEnabled() {
 		llbOpts = b.EndpointsByNetworkFilter(llbOpts)
 	}
 	if model.IsDNSSrvSubsetKey(b.clusterName) {

--- a/pilot/pkg/xds/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoint_builder.go
@@ -96,7 +96,7 @@ func NewEndpointBuilder(clusterName string, proxy *model.Proxy, push *model.Push
 		hostname:   hostname,
 		port:       port,
 	}
-	if b.push.Gateways().IsMultiNetworkEnabled() || model.IsDNSSrvSubsetKey(clusterName) {
+	if b.push.NetworkGateways().IsMultiNetworkEnabled() || model.IsDNSSrvSubsetKey(clusterName) {
 		// We only need this for multi-network, or for clusters meant for use with AUTO_PASSTHROUGH
 		// As an optimization, we skip this logic entirely for everything else.
 		b.mtlsChecker = newMtlsChecker(push, port, dr)

--- a/pilot/pkg/xds/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoint_builder.go
@@ -96,7 +96,7 @@ func NewEndpointBuilder(clusterName string, proxy *model.Proxy, push *model.Push
 		hostname:   hostname,
 		port:       port,
 	}
-	if b.MultiNetworkConfigured() || model.IsDNSSrvSubsetKey(clusterName) {
+	if b.push.Gateways().IsMultiNetworkEnabled() || model.IsDNSSrvSubsetKey(clusterName) {
 		// We only need this for multi-network, or for clusters meant for use with AUTO_PASSTHROUGH
 		// As an optimization, we skip this logic entirely for everything else.
 		b.mtlsChecker = newMtlsChecker(push, port, dr)
@@ -132,11 +132,6 @@ func (b EndpointBuilder) Key() string {
 		params = append(params, nv...)
 	}
 	return strings.Join(params, "~")
-}
-
-// MultiNetworkConfigured determines if we have gateways to use for building cross-network endpoints.
-func (b *EndpointBuilder) MultiNetworkConfigured() bool {
-	return b.push.NetworkGateways() != nil && len(b.push.NetworkGateways()) > 0
 }
 
 func (b EndpointBuilder) Cacheable() bool {

--- a/pilot/pkg/xds/ep_filters.go
+++ b/pilot/pkg/xds/ep_filters.go
@@ -36,7 +36,8 @@ func (b *EndpointBuilder) EndpointsByNetworkFilter(endpoints []*LocLbEndpointsAn
 	// calculate the multiples of weight.
 	// It is needed to normalize the LB Weight across different networks.
 	multiples := 1
-	for _, gateways := range b.push.NetworkGateways() {
+	byNetwork := b.gatewaysByNetwork()
+	for _, gateways := range byNetwork {
 		if num := len(gateways); num > 0 {
 			multiples *= num
 		}
@@ -65,7 +66,8 @@ func (b *EndpointBuilder) EndpointsByNetworkFilter(endpoints []*LocLbEndpointsAn
 			epNetwork := istioMetadata(lbEp, "network")
 			// This is a local endpoint or remote network endpoint
 			// but can be accessed directly from local network.
-			if model.SameOrEmpty(b.network, epNetwork) || len(b.push.NetworkGatewaysByNetwork(epNetwork)) == 0 {
+			gatewaysForNetwork := b.push.Gateways().ForNetwork(model.NetworkID(epNetwork))
+			if model.SameOrEmpty(b.network, epNetwork) || len(gatewaysForNetwork) == 0 {
 				// Copy on write.
 				clonedLbEp := proto.Clone(lbEp).(*endpoint.LbEndpoint)
 				clonedLbEp.LoadBalancingWeight = &wrappers.UInt32Value{
@@ -97,7 +99,7 @@ func (b *EndpointBuilder) EndpointsByNetworkFilter(endpoints []*LocLbEndpointsAn
 		// we initiate mTLS automatically to this remote gateway. Split horizon to remote gateway cannot
 		// work with plaintext
 		for network, w := range remoteEps {
-			gateways := b.push.NetworkGatewaysByNetwork(network)
+			gateways := b.push.Gateways().ForNetwork(model.NetworkID(network))
 
 			gatewayNum := len(gateways)
 			weight := w * uint32(multiples/gatewayNum)
@@ -132,6 +134,16 @@ func (b *EndpointBuilder) EndpointsByNetworkFilter(endpoints []*LocLbEndpointsAn
 	}
 
 	return filtered
+}
+
+func (b *EndpointBuilder) gatewaysByNetwork() map[model.NetworkID][]*model.Gateway {
+	gateways := b.push.Gateways().All()
+	byNetwork := make(map[model.NetworkID][]*model.Gateway)
+	for _, gateway := range gateways {
+		networkGateways := append(byNetwork[gateway.Network], gateway)
+		byNetwork[gateway.Network] = networkGateways
+	}
+	return byNetwork
 }
 
 // EndpointsWithMTLSFilter removes all endpoints that do not handle mTLS. This is determined by looking at

--- a/pilot/pkg/xds/ep_filters.go
+++ b/pilot/pkg/xds/ep_filters.go
@@ -66,7 +66,7 @@ func (b *EndpointBuilder) EndpointsByNetworkFilter(endpoints []*LocLbEndpointsAn
 			epNetwork := istioMetadata(lbEp, "network")
 			// This is a local endpoint or remote network endpoint
 			// but can be accessed directly from local network.
-			gatewaysForNetwork := b.push.Gateways().ForNetwork(model.NetworkID(epNetwork))
+			gatewaysForNetwork := b.push.NetworkGateways().ForNetwork(model.NetworkID(epNetwork))
 			if model.SameOrEmpty(b.network, epNetwork) || len(gatewaysForNetwork) == 0 {
 				// Copy on write.
 				clonedLbEp := proto.Clone(lbEp).(*endpoint.LbEndpoint)
@@ -99,7 +99,7 @@ func (b *EndpointBuilder) EndpointsByNetworkFilter(endpoints []*LocLbEndpointsAn
 		// we initiate mTLS automatically to this remote gateway. Split horizon to remote gateway cannot
 		// work with plaintext
 		for network, w := range remoteEps {
-			gateways := b.push.Gateways().ForNetwork(model.NetworkID(network))
+			gateways := b.push.NetworkGateways().ForNetwork(model.NetworkID(network))
 
 			gatewayNum := len(gateways)
 			weight := w * uint32(multiples/gatewayNum)
@@ -136,9 +136,9 @@ func (b *EndpointBuilder) EndpointsByNetworkFilter(endpoints []*LocLbEndpointsAn
 	return filtered
 }
 
-func (b *EndpointBuilder) gatewaysByNetwork() map[model.NetworkID][]*model.Gateway {
-	gateways := b.push.Gateways().All()
-	byNetwork := make(map[model.NetworkID][]*model.Gateway)
+func (b *EndpointBuilder) gatewaysByNetwork() map[model.NetworkID][]*model.NetworkGateway {
+	gateways := b.push.NetworkGateways().All()
+	byNetwork := make(map[model.NetworkID][]*model.NetworkGateway)
 	for _, gateway := range gateways {
 		networkGateways := append(byNetwork[gateway.Network], gateway)
 		byNetwork[gateway.Network] = networkGateways

--- a/pilot/pkg/xds/ep_filters_test.go
+++ b/pilot/pkg/xds/ep_filters_test.go
@@ -488,7 +488,11 @@ func TestEndpointsByNetworkFilter_SkipLBWithHostname(t *testing.T) {
 			},
 		},
 	}}, origServices...))
-	serviceDiscovery.SetGatewaysForNetwork("network2", &model.Gateway{Addr: "aeiou.scooby.do", Port: 80})
+	serviceDiscovery.AddGateways(&model.Gateway{
+		Network: "network2",
+		Addr:    "aeiou.scooby.do",
+		Port:    80,
+	})
 
 	env.ServiceDiscovery = serviceDiscovery
 	env.Init()

--- a/pilot/pkg/xds/ep_filters_test.go
+++ b/pilot/pkg/xds/ep_filters_test.go
@@ -488,7 +488,7 @@ func TestEndpointsByNetworkFilter_SkipLBWithHostname(t *testing.T) {
 			},
 		},
 	}}, origServices...))
-	serviceDiscovery.AddGateways(&model.Gateway{
+	serviceDiscovery.AddGateways(&model.NetworkGateway{
 		Network: "network2",
 		Addr:    "aeiou.scooby.do",
 		Port:    80,

--- a/pilot/pkg/xds/mesh_network_test.go
+++ b/pilot/pkg/xds/mesh_network_test.go
@@ -95,7 +95,7 @@ func TestNetworkGatewayUpdates(t *testing.T) {
 			t.Fatal(err)
 		}
 		if err := retry.Until(func() bool {
-			return len(s.PushContext().Gateways().ForNetwork("network-1")) == 1
+			return len(s.PushContext().NetworkGateways().ForNetwork("network-1")) == 1
 		}); err != nil {
 			t.Fatal("push context did not reinitialize with gateways; xds event may not have been triggred")
 		}

--- a/pilot/pkg/xds/mesh_network_test.go
+++ b/pilot/pkg/xds/mesh_network_test.go
@@ -95,7 +95,7 @@ func TestNetworkGatewayUpdates(t *testing.T) {
 			t.Fatal(err)
 		}
 		if err := retry.Until(func() bool {
-			return len(s.PushContext().NetworkGatewaysByNetwork("network-1")) == 1
+			return len(s.PushContext().Gateways().ForNetwork("network-1")) == 1
 		}); err != nil {
 			t.Fatal("push context did not reinitialize with gateways; xds event may not have been triggred")
 		}


### PR DESCRIPTION
The `PushContext` previously was manually merging `MeshNetworks` with the network gateways provided by the service registries.

Added a `Gateways` structure as an abstraction around the collection of gateways with methods for all current use cases.

Replaced `PushContext` methods with basic access to the `Gateways` object.

Also removed locking around access to `Gateways`. I don't think it's necessary since its already a snapshot in time of the gateways from `MeshNetworks` and the registries.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.