### PR TITLE
Implement metrics portion of telemetry API

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -127,7 +127,7 @@ func (configgen *ConfigGeneratorImpl) buildGatewayListeners(builder *ListenerBui
 			bind:       bind,
 			port:       &model.Port{Port: int(port.Number)},
 			bindToPort: true,
-			class:      ListenerClassGateway,
+			class:      istionetworking.ListenerClassGateway,
 		}
 		p := protocol.Parse(port.Protocol)
 		lname := opts.bind + "_" + strconv.Itoa(opts.port.Port)

--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -2585,7 +2585,8 @@ func buildListenerEnvWithVirtualServices(services []*model.Service, virtualServi
 
 func TestAppendListenerFallthroughRouteForCompleteListener(t *testing.T) {
 	push := &model.PushContext{
-		Mesh: &meshconfig.MeshConfig{},
+		Mesh:      &meshconfig.MeshConfig{},
+		Telemetry: &model.Telemetries{},
 	}
 	tests := []struct {
 		name         string
@@ -2658,6 +2659,7 @@ func TestMergeTCPFilterChains(t *testing.T) {
 	push := &model.PushContext{
 		Mesh:        &meshconfig.MeshConfig{},
 		ProxyStatus: map[string]map[string]model.ProxyPushStatus{},
+		Telemetry:   &model.Telemetries{},
 	}
 
 	node := &model.Proxy{

--- a/pilot/pkg/networking/core/v1alpha3/networkfilter_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/networkfilter_test.go
@@ -99,7 +99,8 @@ func TestInboundNetworkFilterStatPrefix(t *testing.T) {
 				},
 			}
 
-			listeners := buildInboundNetworkFilters(env.PushContext, instance, model.BuildInboundSubsetKey(int(instance.Endpoint.EndpointPort)))
+			listeners := buildInboundNetworkFilters(env.PushContext,
+				&model.Proxy{Metadata: &model.NodeMetadata{}}, instance, model.BuildInboundSubsetKey(int(instance.Endpoint.EndpointPort)))
 			tcp := &tcp.TcpProxy{}
 			listeners[0].GetTypedConfig().UnmarshalTo(tcp)
 			if tcp.StatPrefix != tt.expectedStatPrefix {

--- a/pilot/pkg/networking/networking.go
+++ b/pilot/pkg/networking/networking.go
@@ -147,3 +147,13 @@ func (t TunnelType) ToString() string {
 func (t TunnelAbility) SupportH2Tunnel() bool {
 	return (int(t) & int(H2Tunnel)) != 0
 }
+
+// ListenerClass defines the class of the listener
+type ListenerClass int
+
+const (
+	ListenerClassUndefined ListenerClass = iota
+	ListenerClassSidecarInbound
+	ListenerClassSidecarOutbound
+	ListenerClassGateway
+)

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -482,10 +482,6 @@ func MergeAnyWithAny(dst *any.Any, src *any.Any) (*any.Any, error) {
 // BuildLbEndpointMetadata adds metadata values to a lb endpoint
 func BuildLbEndpointMetadata(networkID network.ID, tlsMode, workloadname, namespace string,
 	clusterID cluster.ID, labels labels.Instance) *core.Metadata {
-	if networkID == "" && (tlsMode == "" || tlsMode == model.DisabledTLSModeLabel) && !features.EndpointTelemetryLabel {
-		return nil
-	}
-
 	metadata := &core.Metadata{
 		FilterMetadata: map[string]*pstruct.Struct{},
 	}
@@ -503,23 +499,21 @@ func BuildLbEndpointMetadata(networkID network.ID, tlsMode, workloadname, namesp
 	// server does not have sidecar injected, and request fails to reach server and thus metadata exchange does not happen.
 	// Due to performance concern, telemetry metadata is compressed into a semicolon separted string:
 	// workload-name;namespace;canonical-service-name;canonical-service-revision;cluster-id.
-	if features.EndpointTelemetryLabel {
-		var sb strings.Builder
-		sb.WriteString(workloadname)
-		sb.WriteString(";")
-		sb.WriteString(namespace)
-		sb.WriteString(";")
-		if csn, ok := labels[model.IstioCanonicalServiceLabelName]; ok {
-			sb.WriteString(csn)
-		}
-		sb.WriteString(";")
-		if csr, ok := labels[model.IstioCanonicalServiceRevisionLabelName]; ok {
-			sb.WriteString(csr)
-		}
-		sb.WriteString(";")
-		sb.WriteString(clusterID.String())
-		addIstioEndpointLabel(metadata, "workload", &pstruct.Value{Kind: &pstruct.Value_StringValue{StringValue: sb.String()}})
+	var sb strings.Builder
+	sb.WriteString(workloadname)
+	sb.WriteString(";")
+	sb.WriteString(namespace)
+	sb.WriteString(";")
+	if csn, ok := labels[model.IstioCanonicalServiceLabelName]; ok {
+		sb.WriteString(csn)
 	}
+	sb.WriteString(";")
+	if csr, ok := labels[model.IstioCanonicalServiceRevisionLabelName]; ok {
+		sb.WriteString(csr)
+	}
+	sb.WriteString(";")
+	sb.WriteString(clusterID.String())
+	addIstioEndpointLabel(metadata, "workload", &pstruct.Value{Kind: &pstruct.Value_StringValue{StringValue: sb.String()}})
 
 	return metadata
 }

--- a/pkg/adsc/adsc.go
+++ b/pkg/adsc/adsc.go
@@ -626,11 +626,14 @@ func (a *ADSC) handleLDS(ll []*listener.Listener) {
 			// TODO: extract VIP and RDS or cluster
 			continue
 		}
-		filter := l.FilterChains[len(l.FilterChains)-1].Filters[0]
+		fc := l.FilterChains[len(l.FilterChains)-1]
+		// Find the terminal filter
+		filter := fc.Filters[len(fc.Filters)-1]
 
 		// The actual destination will be the next to the last if the last filter is a passthrough filter
-		if l.FilterChains[len(l.FilterChains)-1].GetName() == util.PassthroughFilterChain {
-			filter = l.FilterChains[len(l.FilterChains)-2].Filters[0]
+		if fc.GetName() == util.PassthroughFilterChain {
+			fc = l.FilterChains[len(l.FilterChains)-2]
+			filter = fc.Filters[len(fc.Filters)-1]
 		}
 
 		switch filter.Name {

--- a/pkg/config/mesh/mesh.go
+++ b/pkg/config/mesh/mesh.go
@@ -104,6 +104,12 @@ func DefaultMeshConfig() meshconfig.MeshConfig {
 		},
 		ExtensionProviders: []*meshconfig.MeshConfig_ExtensionProvider{
 			{
+				Name: "prometheus",
+				Provider: &meshconfig.MeshConfig_ExtensionProvider_Prometheus{
+					Prometheus: &meshconfig.MeshConfig_ExtensionProvider_PrometheusMetricsProvider{},
+				},
+			},
+			{
 				Name: "envoy",
 				Provider: &meshconfig.MeshConfig_ExtensionProvider_EnvoyFileAccessLog{
 					EnvoyFileAccessLog: &meshconfig.MeshConfig_ExtensionProvider_EnvoyFileAccessLogProvider{

--- a/pkg/config/mesh/mesh_test.go
+++ b/pkg/config/mesh/mesh_test.go
@@ -164,12 +164,20 @@ defaultConfig:
 	if len(got.DefaultProviders.GetMetrics()) != 0 {
 		t.Errorf("default providers deep merge failed, got %v", got.DefaultProviders.GetMetrics())
 	}
-	if len(got.ExtensionProviders) != 2 {
-		t.Errorf("extension providers deep merge failed")
+	if !reflect.DeepEqual(getExtensionProviders(got.ExtensionProviders), []string{"prometheus", "envoy", "sd"}) {
+		t.Errorf("extension providers deep merge failed, got %v", getExtensionProviders(got.ExtensionProviders))
 	}
 
 	gotY, err := gogoprotomarshal.ToYAML(got)
 	t.Log("Result: \n", gotY, err)
+}
+
+func getExtensionProviders(eps []*meshconfig.MeshConfig_ExtensionProvider) []string {
+	got := []string{}
+	for _, ep := range eps {
+		got = append(got, ep.Name)
+	}
+	return got
 }
 
 func TestDeepMerge(t *testing.T) {

--- a/tests/integration/telemetry/stats/prometheus/api/stats_wasm_filter_test.go
+++ b/tests/integration/telemetry/stats/prometheus/api/stats_wasm_filter_test.go
@@ -1,0 +1,66 @@
+// +build integ
+// Copyright Istio Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wasm
+
+import (
+	"testing"
+
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/istio"
+	"istio.io/istio/pkg/test/framework/label"
+	"istio.io/istio/pkg/test/framework/resource"
+	common "istio.io/istio/tests/integration/telemetry/stats/prometheus"
+)
+
+// TestTelemetryAPIStats verifies the stats filter could emit expected client and server side
+// metrics when configured with the Telemetry API (with EnvoyFilters disabled)
+// This test focuses on stats filter and metadata exchange filter could work coherently with
+// proxy bootstrap config with Wasm runtime. To avoid flake, it does not verify correctness
+// of metrics, which should be covered by integration test in proxy repo.
+func TestTelemetryAPIStats(t *testing.T) {
+	common.TestStatsFilter(t, "observability.telemetry.stats.prometheus.http.nullvm")
+}
+
+func TestMain(m *testing.M) {
+	framework.NewSuite(m).
+		Label(label.CustomSetup).
+		Setup(istio.Setup(common.GetIstioInstance(), setupConfig)).
+		Setup(func(ctx resource.Context) error {
+			i, err := istio.Get(ctx)
+			if err != nil {
+				return err
+			}
+			return ctx.Config().ApplyYAML(i.Settings().SystemNamespace, `
+apiVersion: telemetry.istio.io/v1alpha1
+kind: Telemetry
+metadata:
+  name: mesh-default
+spec:
+  metrics:
+  - providers:
+    - name: prometheus
+`)
+		}).
+		Setup(common.TestSetup).
+		Run()
+}
+
+func setupConfig(c resource.Context, cfg *istio.Config) {
+	if cfg == nil {
+		return
+	}
+	cfg.Values["telemetry.v2.enabled"] = "false"
+}

--- a/tests/integration/telemetry/stats/prometheus/api/stats_wasm_tcp_filter_test.go
+++ b/tests/integration/telemetry/stats/prometheus/api/stats_wasm_tcp_filter_test.go
@@ -1,0 +1,26 @@
+// +build integ
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wasm
+
+import (
+	"testing"
+
+	common "istio.io/istio/tests/integration/telemetry/stats/prometheus"
+)
+
+func TestTelemetryAPITCPStats(t *testing.T) { // nolint:interfacer
+	common.TestStatsTCPFilter(t, "observability.telemetry.stats.prometheus.tcp")
+}

--- a/tests/integration/telemetry/stats/prometheus/stats.go
+++ b/tests/integration/telemetry/stats/prometheus/stats.go
@@ -111,23 +111,24 @@ func TestStatsFilter(t *testing.T, feature features.Feature) {
 						sourceQuery, destinationQuery, appQuery := buildQuery(sourceCluster)
 						// Query client side metrics
 						if _, err := QueryPrometheus(t, c, sourceQuery, GetPromInstance()); err != nil {
-							t.Logf("prometheus values for istio_requests_total for cluster %v: \n%s", c, util.PromDump(c, promInst, "istio_requests_total"))
+							t.Logf("prometheus values for istio_requests_total for cluster %v: \n%s", c.Name(), util.PromDump(c, promInst, "istio_requests_total"))
 							return err
 						}
 						// Query client side metrics for non-injected server
 						outOfMeshServerQuery := buildOutOfMeshServerQuery(sourceCluster)
 						if _, err := QueryPrometheus(t, c, outOfMeshServerQuery, GetPromInstance()); err != nil {
-							t.Logf("prometheus values for istio_requests_total for cluster %v: \n%s", c, util.PromDump(c, promInst, "istio_requests_total"))
+							t.Logf("prometheus values for istio_requests_total for cluster %v: \n%s", c.Name(), util.PromDump(c, promInst, "istio_requests_total"))
 							return err
 						}
 						// Query server side metrics.
 						if _, err := QueryPrometheus(t, c, destinationQuery, GetPromInstance()); err != nil {
-							t.Logf("prometheus values for istio_requests_total for cluster %v: \n%s", c, util.PromDump(c, promInst, "istio_requests_total"))
+							t.Logf("prometheus values for istio_requests_total for cluster %v: \n%s", c.Name(), util.PromDump(c, promInst, "istio_requests_total"))
 							return err
 						}
 						// This query will continue to increase due to readiness probe; don't wait for it to converge
 						if err := QueryFirstPrometheus(t, c, appQuery, GetPromInstance()); err != nil {
-							t.Logf("prometheus values for istio_echo_http_requests_total for cluster %v: \n%s", c, util.PromDump(c, promInst, "istio_echo_http_requests_total"))
+							t.Logf("prometheus values for istio_echo_http_requests_total for cluster %v: \n%s",
+								c.Name(), util.PromDump(c, promInst, "istio_echo_http_requests_total"))
 							return err
 						}
 


### PR DESCRIPTION
This implements the `metrics` portion of the API. 

Current state:
* Pilot fully generates equivalent stats and mx filters as EnvoyFilters
* None of https://docs.google.com/document/d/1FMvwyoooGeiACf9b7R0A6iJyB6ZuiP7hv5-XDmXtHLo/edit#heading=h.xw1gqgyqs5b is implemented. The changes here are effectively off by default, as everything is skipped when no Telemetry CR is found. For a user to use this, they should first remove all EnvoyFilters, then create Telemetry CR. This is intended to be improved to allow more graceful migrations (see design doc) but out of scope of the initial PR.
* Only prometheus is supported
* Overrides are not supported at all. Only enable/disable of metrics entirely.
* Per-workload configuration is supported. One interesting change here, now that we allow this, is that we need inbound metadata exchange on ALL pods, if any pod has telemetry enabled. We may need to change this to always enable MX unconditionally, since we may not know all configs in the mesh for multicluster; for now we would need to wait until we have a more graceful migration plan in order to do that.
* Basic integration tests added