### PR TITLE
fix cluster check for ingress test

### DIFF
--- a/pkg/test/echo/client/parsedresponse.go
+++ b/pkg/test/echo/client/parsedresponse.go
@@ -230,7 +230,6 @@ func (r ParsedResponses) clusterDistribution() map[string]int {
 // This can be used in combination with echo.Instances.Clusters(), for example:
 //     echoA[0].CallOrFail(t, ...).CheckReachedClusters(echoB.Clusters())
 func (r ParsedResponses) CheckReachedClusters(clusters cluster.Clusters) error {
-	clusters = clusters.Kube()
 	hits := r.clusterDistribution()
 	exp := map[string]struct{}{}
 	for _, expCluster := range clusters {
@@ -251,7 +250,6 @@ func (r ParsedResponses) CheckReachedClusters(clusters cluster.Clusters) error {
 // For example, with 100 requests and 20 percent error, each cluster must given received 20±4 responses. Only the passed
 // in clusters will be validated.
 func (r ParsedResponses) CheckEqualClusterTraffic(clusters cluster.Clusters, precisionPct int) error {
-	clusters = clusters.Kube()
 	clusterHits := r.clusterDistribution()
 	expected := len(r) / len(clusters)
 	precision := int(float32(expected) * (float32(precisionPct) / 100))

--- a/tests/integration/pilot/ingress_test.go
+++ b/tests/integration/pilot/ingress_test.go
@@ -285,7 +285,7 @@ spec:
 				t.Fatal(err)
 			}
 
-			validator := echo.And(echo.ExpectOK(), echo.ExpectReachedClusters(t.Clusters()))
+			validator := echo.And(echo.ExpectOK(), echo.ExpectReachedClusters(apps.PodB.Clusters()))
 			count := 1
 			if t.Clusters().IsMulticluster() {
 				count = 2 * len(t.Clusters())


### PR DESCRIPTION
This reverts commit 94758b7ed491b5557e7c4fec056836a3a5ca619e and uses more appropriate filtering logic, only checking the correct _app_'s clusters. 