### PR TITLE
do not register delta xds env var

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -15,7 +15,6 @@
 package features
 
 import (
-	"strconv"
 	"time"
 
 	"github.com/golang/protobuf/ptypes/duration"
@@ -446,9 +445,9 @@ var (
 			"These checks are both expensive and panic on failure. As a result, this should be used only for testing.",
 	).Get()
 
-	DeltaXds = RegisterHiddenBoolVar("ISTIO_DELTA_XDS", false,
+	DeltaXds = env.RegisterBoolVar("ISTIO_DELTA_XDS", false,
 		"If enabled, pilot will only send the delta configs as opposed to the state of the world on a "+
-			"Resource Request").Get()
+			"Resource Request. This feature uses the delta xds api, but does not currently send the actual deltas.").Get()
 
 	EnableLegacyAutoPassthrough = env.RegisterBoolVar(
 		"PILOT_ENABLE_LEGACY_AUTO_PASSTHROUGH",
@@ -492,16 +491,4 @@ var (
 // UnsafeFeaturesEnabled returns true if any unsafe features are enabled.
 func UnsafeFeaturesEnabled() bool {
 	return EnableUnsafeAdminEndpoints || EnableUnsafeAssertions
-}
-
-// RegisterHiddenBoolVar registers a new boolean environment variable that is hidden from documentation.
-func RegisterHiddenBoolVar(name string, defaultValue bool, description string) env.BoolVar {
-	v := env.Var{Name: name, DefaultValue: strconv.FormatBool(defaultValue), Description: description, Type: env.BOOL}
-	env.RegisterVar(v)
-	for _, bv := range env.VarDescriptions() {
-		if bv.Name == v.Name {
-			return env.BoolVar{bv}
-		}
-	}
-	return env.BoolVar{}
 }

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -15,6 +15,8 @@
 package features
 
 import (
+	"os"
+	"strconv"
 	"time"
 
 	"github.com/golang/protobuf/ptypes/duration"
@@ -445,9 +447,9 @@ var (
 			"These checks are both expensive and panic on failure. As a result, this should be used only for testing.",
 	).Get()
 
-	DeltaXds = env.RegisterBoolVar("ISTIO_DELTA_XDS", false,
+	DeltaXds = LookupBoolVar("ISTIO_DELTA_XDS", false,
 		"If enabled, pilot will only send the delta configs as opposed to the state of the world on a "+
-			"Resource Request").Get()
+			"Resource Request")
 
 	EnableLegacyAutoPassthrough = env.RegisterBoolVar(
 		"PILOT_ENABLE_LEGACY_AUTO_PASSTHROUGH",
@@ -491,4 +493,21 @@ var (
 // UnsafeFeaturesEnabled returns true if any unsafe features are enabled.
 func UnsafeFeaturesEnabled() bool {
 	return EnableUnsafeAdminEndpoints || EnableUnsafeAssertions
+}
+
+// LookupBoolVar looks up a new boolean environment variable that is hidden from documentation.
+// nolint
+func LookupBoolVar(name string, defaultValue bool, description string) bool {
+	result, ok := os.LookupEnv(name)
+	if !ok {
+		return defaultValue
+	}
+
+	b, err := strconv.ParseBool(result)
+	if err != nil {
+		log.Warnf("Invalid environment variable value `%s`, expecting true/false, defaulting to %v", result, defaultValue)
+		b = defaultValue
+	}
+
+	return b
 }

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -15,7 +15,6 @@
 package features
 
 import (
-	"os"
 	"strconv"
 	"time"
 
@@ -447,9 +446,9 @@ var (
 			"These checks are both expensive and panic on failure. As a result, this should be used only for testing.",
 	).Get()
 
-	DeltaXds = LookupBoolVar("ISTIO_DELTA_XDS", false,
+	DeltaXds = RegisterHiddenBoolVar("ISTIO_DELTA_XDS", false,
 		"If enabled, pilot will only send the delta configs as opposed to the state of the world on a "+
-			"Resource Request")
+			"Resource Request").Get()
 
 	EnableLegacyAutoPassthrough = env.RegisterBoolVar(
 		"PILOT_ENABLE_LEGACY_AUTO_PASSTHROUGH",
@@ -495,19 +494,14 @@ func UnsafeFeaturesEnabled() bool {
 	return EnableUnsafeAdminEndpoints || EnableUnsafeAssertions
 }
 
-// LookupBoolVar looks up a new boolean environment variable that is hidden from documentation.
-// nolint
-func LookupBoolVar(name string, defaultValue bool, description string) bool {
-	result, ok := os.LookupEnv(name)
-	if !ok {
-		return defaultValue
+// RegisterHiddenBoolVar registers a new boolean environment variable that is hidden from documentation.
+func RegisterHiddenBoolVar(name string, defaultValue bool, description string) env.BoolVar {
+	v := env.Var{Name: name, DefaultValue: strconv.FormatBool(defaultValue), Description: description, Type: env.BOOL}
+	env.RegisterVar(v)
+	for _, bv := range env.VarDescriptions() {
+		if bv.Name == v.Name {
+			return env.BoolVar{bv}
+		}
 	}
-
-	b, err := strconv.ParseBool(result)
-	if err != nil {
-		log.Warnf("Invalid environment variable value `%s`, expecting true/false, defaulting to %v", result, defaultValue)
-		b = defaultValue
-	}
-
-	return b
+	return env.BoolVar{}
 }


### PR DESCRIPTION
Since Delta Xds is not fully implemented, registering this var adding to documentation and people wants to try it and see if it helps their config delivery. Either we should make it clear in the description that it is not ready for use or register it as hidden var so that docs are not generated. This PR moves it to hidden var.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
