### PR TITLE
Do some code clean up under istioctl

### DIFF
--- a/istioctl/cmd/describe.go
+++ b/istioctl/cmd/describe.go
@@ -177,26 +177,6 @@ func describe() *cobra.Command {
 	return describeCmd
 }
 
-func validatePort(port v1.ServicePort, pod *v1.Pod) []string {
-	retval := []string{}
-
-	// Build list of ports exposed by pod
-	containerPorts := make(map[int]bool)
-	for _, container := range pod.Spec.Containers {
-		for _, port := range container.Ports {
-			containerPorts[int(port.ContainerPort)] = true
-		}
-	}
-
-	// Get port number used by the service port being validated
-	_, err := pilotcontroller.FindPort(pod, &port)
-	if err != nil {
-		retval = append(retval, err.Error())
-	}
-
-	return retval
-}
-
 func servicePortProtocol(name string) protocol.Instance {
 	i := strings.IndexByte(name, '-')
 	if i >= 0 {
@@ -513,10 +493,8 @@ func printService(writer io.Writer, svc v1.Service, pod *v1.Pod) {
 			}
 
 			fmt.Fprintf(writer, "   Port: %s %d/%s targets pod port %d\n", port.Name, port.Port, protocol, nport)
-		}
-		msgs := validatePort(port, pod)
-		for _, msg := range msgs {
-			fmt.Fprintf(writer, "   %s\n", msg)
+		} else {
+			fmt.Fprintf(writer, "   %s\n", err.Error())
 		}
 	}
 }
@@ -1118,8 +1096,6 @@ the configuration objects that affect that service.`,
 }
 
 func describePodServices(writer io.Writer, kubeClient kube.ExtendedClient, configClient istioclient.Interface, pod *v1.Pod, matchingServices []v1.Service, podsLabels []k8s_labels.Set) error { // nolint: lll
-	var err error
-
 	byConfigDump, err := kubeClient.EnvoyDo(context.TODO(), pod.ObjectMeta.Name, pod.ObjectMeta.Namespace, "GET", "config_dump")
 	if err != nil {
 		if ignoreUnmeshed {


### PR DESCRIPTION
Hi there, I was reading the code under istioctl, saw the [validatePort()](https://github.com/istio/istio/blob/fe710ef62f9c1cc8207f4643b48c3def28da7f95/istioctl/cmd/describe.go#L180) is pretty reduplicative with pilotcontroller.FindPort() after some changes and nowhere else is using it now, so I did some code clean up.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.