### PR TITLE
Prevent stale cache

### DIFF
--- a/pilot/pkg/model/xds_cache.go
+++ b/pilot/pkg/model/xds_cache.go
@@ -22,7 +22,6 @@ import (
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/golang-lru/simplelru"
-	"go.uber.org/atomic"
 	"google.golang.org/protobuf/testing/protocmp"
 
 	"istio.io/istio/pilot/pkg/features"
@@ -122,23 +121,14 @@ type CacheToken uint64
 // XdsCache interface defines a store for caching XDS responses.
 // All operations are thread safe.
 type XdsCache interface {
-	// Add adds the given XdsCacheEntry with the value to the cache. A token, returned from Get, must
-	// be included or writes will be (silently) dropped. Additionally, if the cache has been
-	// invalided between when a token is fetched from Get and when Add is called, the write will be
-	// dropped. This ensures stale data does not overwrite fresh data when dealing with concurrent
+	// Add adds the given XdsCacheEntry with the value for the given pushContext to the cache.
+	// If the cache has been updated to a newer push context, the write will be dropped silently.
+	// This ensures stale data does not overwrite fresh data when dealing with concurrent
 	// writers.
-	Add(entry XdsCacheEntry, token CacheToken, value *discovery.Resource)
+	Add(entry XdsCacheEntry, pushRequest *PushRequest, value *discovery.Resource)
 	// Get retrieves the cached value if it exists. The boolean indicates
 	// whether the entry exists in the cache.
-	//
-	// A CacheToken is additionally included in the response. This must be used for subsequent writes
-	// to this key. This ensures that if the cache is invalidated between our read and write, we do
-	// not persist stale data.
-	//
-	// Standard usage:
-	// if obj, token, f := cache.Get(key); f { ...do something... }
-	// else { computed := expensive(); cache.Add(key, token, computed); }
-	Get(entry XdsCacheEntry) (*discovery.Resource, CacheToken, bool)
+	Get(entry XdsCacheEntry) (*discovery.Resource, bool)
 	// Clear removes the cache entries that are dependent on the configs passed.
 	Clear(map[ConfigKey]struct{})
 	// ClearAll clears the entire cache.
@@ -156,7 +146,6 @@ func NewXdsCache() XdsCache {
 		store:            newLru(),
 		configIndex:      map[ConfigKey]sets.Set{},
 		typesIndex:       map[config.GroupVersionKind]sets.Set{},
-		nextToken:        atomic.NewUint64(0),
 	}
 }
 
@@ -167,16 +156,15 @@ func NewLenientXdsCache() XdsCache {
 		store:            newLru(),
 		configIndex:      map[ConfigKey]sets.Set{},
 		typesIndex:       map[config.GroupVersionKind]sets.Set{},
-		nextToken:        atomic.NewUint64(0),
 	}
 }
 
 type lruCache struct {
 	enableAssertions bool
 	store            simplelru.LRUCache
-	// nextToken stores the next token to use. The content here doesn't matter, we just need a cheap
-	// unique identifier.
-	nextToken   *atomic.Uint64
+	// token stores the latest token of the store, used to prevent stale data overwrite.
+	// It is refreshed when Clear or ClearAll are called
+	token       CacheToken
 	mu          sync.RWMutex
 	configIndex map[ConfigKey]sets.Set
 	typesIndex  map[config.GroupVersionKind]sets.Set
@@ -222,36 +210,39 @@ func (l *lruCache) assertUnchanged(key string, existing *discovery.Resource, rep
 	}
 }
 
-func (l *lruCache) Add(entry XdsCacheEntry, token CacheToken, value *discovery.Resource) {
-	if !entry.Cacheable() {
+func (l *lruCache) Add(entry XdsCacheEntry, pushReq *PushRequest, value *discovery.Resource) {
+	if !entry.Cacheable() || pushReq == nil {
 		return
 	}
+	// Start unset
+	if pushReq.Start.Equal(time.Time{}) {
+		panic("token cannot be empty!")
+	}
+	// TODO: It will not overflow until year 2262
+	token := CacheToken(pushReq.Start.UnixNano())
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	k := entry.Key()
 	cur, f := l.store.Get(k)
-	toWrite := cacheValue{value: value}
 	if f {
-		if token != cur.(cacheValue).token {
+		// This is the stale or same resource
+		if token <= cur.(cacheValue).token || token <= l.token {
 			// entry may be stale, we need to drop it. This can happen when the cache is invalidated
 			// after we call Get.
 			return
 		}
-		// Otherwise, make sure we write the current token again. We don't change the key on writes; the
-		// same token will be used for a value until its invalidated
-		toWrite.token = cur.(cacheValue).token
-	} else {
-		// This is our first time seeing this; this means it was invalidated recently and this is our
-		// first write, or we forgot to call Get before.
+		if l.enableAssertions {
+			l.assertUnchanged(k, cur.(cacheValue).value, value)
+		}
+	}
+
+	if token < l.token {
 		return
 	}
-	if l.enableAssertions {
-		if toWrite.token == 0 {
-			panic("token cannot be empty. was Get() called before Add()?")
-		}
-		l.assertUnchanged(k, cur.(cacheValue).value, value)
-	}
+
+	toWrite := cacheValue{value: value, token: token}
 	l.store.Add(k, toWrite)
+	l.token = token
 	indexConfig(l.configIndex, k, entry)
 	indexType(l.typesIndex, k, entry)
 	size(l.store.Len())
@@ -262,9 +253,9 @@ type cacheValue struct {
 	token CacheToken
 }
 
-func (l *lruCache) Get(entry XdsCacheEntry) (*discovery.Resource, CacheToken, bool) {
+func (l *lruCache) Get(entry XdsCacheEntry) (*discovery.Resource, bool) {
 	if !entry.Cacheable() {
-		return nil, 0, false
+		return nil, false
 	}
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -272,28 +263,21 @@ func (l *lruCache) Get(entry XdsCacheEntry) (*discovery.Resource, CacheToken, bo
 	val, ok := l.store.Get(k)
 	if !ok {
 		miss()
-		// If the entry is not found at all, this is our first read of it. We will generate and store
-		// a new token. Subsequent writes must include it.
-		tok := CacheToken(l.nextToken.Inc())
-		l.store.Add(k, cacheValue{token: tok})
-		indexConfig(l.configIndex, k, entry)
-		indexType(l.typesIndex, k, entry)
-		return nil, tok, false
+		return nil, false
 	}
 	cv := val.(cacheValue)
 	if cv.value == nil {
 		miss()
-		// We have generated a token previously, so return that, but this is still a cache miss as
-		// no value is stored.
-		return nil, cv.token, false
+		return nil, false
 	}
 	hit()
-	return cv.value, cv.token, true
+	return cv.value, true
 }
 
 func (l *lruCache) Clear(configs map[ConfigKey]struct{}) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
+	l.token = CacheToken(time.Now().UnixNano())
 	for ckey := range configs {
 		referenced := l.configIndex[ckey]
 		delete(l.configIndex, ckey)
@@ -312,6 +296,7 @@ func (l *lruCache) Clear(configs map[ConfigKey]struct{}) {
 func (l *lruCache) ClearAll() {
 	l.mu.Lock()
 	defer l.mu.Unlock()
+	l.token = CacheToken(time.Now().UnixNano())
 	l.store.Purge()
 	l.configIndex = map[ConfigKey]sets.Set{}
 	l.typesIndex = map[config.GroupVersionKind]sets.Set{}
@@ -350,10 +335,10 @@ type DisabledCache struct{}
 
 var _ XdsCache = &DisabledCache{}
 
-func (d DisabledCache) Add(key XdsCacheEntry, token CacheToken, value *discovery.Resource) {}
+func (d DisabledCache) Add(key XdsCacheEntry, pushReq *PushRequest, value *discovery.Resource) {}
 
-func (d DisabledCache) Get(XdsCacheEntry) (*discovery.Resource, CacheToken, bool) {
-	return nil, 0, false
+func (d DisabledCache) Get(XdsCacheEntry) (*discovery.Resource, bool) {
+	return nil, false
 }
 
 func (d DisabledCache) Clear(configsUpdated map[ConfigKey]struct{}) {}

--- a/pilot/pkg/model/xds_cache.go
+++ b/pilot/pkg/model/xds_cache.go
@@ -211,14 +211,10 @@ func (l *lruCache) assertUnchanged(key string, existing *discovery.Resource, rep
 }
 
 func (l *lruCache) Add(entry XdsCacheEntry, pushReq *PushRequest, value *discovery.Resource) {
-	if !entry.Cacheable() || pushReq == nil {
+	if !entry.Cacheable() || pushReq == nil || pushReq.Start.Equal(time.Time{}) {
 		return
 	}
-	// Start unset
-	if pushReq.Start.Equal(time.Time{}) {
-		panic("token cannot be empty!")
-	}
-	// TODO: It will not overflow until year 2262
+	// It will not overflow until year 2262
 	token := CacheToken(pushReq.Start.UnixNano())
 	l.mu.Lock()
 	defer l.mu.Unlock()

--- a/pilot/pkg/model/xds_cache.go
+++ b/pilot/pkg/model/xds_cache.go
@@ -221,8 +221,8 @@ func (l *lruCache) Add(entry XdsCacheEntry, pushReq *PushRequest, value *discove
 	k := entry.Key()
 	cur, f := l.store.Get(k)
 	if f {
-		// This is the stale or same resource
-		if token <= cur.(cacheValue).token || token <= l.token {
+		// This is the stale resource
+		if token < cur.(cacheValue).token || token < l.token {
 			// entry may be stale, we need to drop it. This can happen when the cache is invalidated
 			// after we call Get.
 			return

--- a/pilot/pkg/networking/core/configgen.go
+++ b/pilot/pkg/networking/core/configgen.go
@@ -35,7 +35,7 @@ type ConfigGenerator interface {
 	BuildListeners(node *model.Proxy, push *model.PushContext) []*listener.Listener
 
 	// BuildClusters returns the list of clusters for the given proxy. This is the CDS output
-	BuildClusters(node *model.Proxy, push *model.PushContext) ([]*discovery.Resource, model.XdsLogDetails)
+	BuildClusters(node *model.Proxy, req *model.PushRequest) ([]*discovery.Resource, model.XdsLogDetails)
 
 	// BuildHTTPRoutes returns the list of HTTP routes for the given proxy. This is the RDS output
 	BuildHTTPRoutes(node *model.Proxy, push *model.PushContext, routeNames []string) []*route.RouteConfiguration

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -71,11 +71,11 @@ func getDefaultCircuitBreakerThresholds() *cluster.CircuitBreakers_Thresholds {
 // For outbound: Cluster for each service/subset hostname or cidr with SNI set to service hostname
 // Cluster type based on resolution
 // For inbound (sidecar only): Cluster for each inbound endpoint port and for each service port
-func (configgen *ConfigGeneratorImpl) BuildClusters(proxy *model.Proxy, push *model.PushContext) ([]*discovery.Resource, model.XdsLogDetails) {
+func (configgen *ConfigGeneratorImpl) BuildClusters(proxy *model.Proxy, req *model.PushRequest) ([]*discovery.Resource, model.XdsLogDetails) {
 	clusters := make([]*cluster.Cluster, 0)
 	resources := model.Resources{}
-	envoyFilterPatches := push.EnvoyFilters(proxy)
-	cb := NewClusterBuilder(proxy, push, configgen.Cache)
+	envoyFilterPatches := req.Push.EnvoyFilters(proxy)
+	cb := NewClusterBuilder(proxy, req, configgen.Cache)
 	instances := proxy.ServiceInstances
 	cacheStats := cacheStats{}
 	switch proxy.Type {
@@ -103,7 +103,7 @@ func (configgen *ConfigGeneratorImpl) BuildClusters(proxy *model.Proxy, push *mo
 		// Gateways do not require the default passthrough cluster as they do not have original dst listeners.
 		clusters = patcher.conditionallyAppend(clusters, nil, cb.buildBlackHoleCluster())
 		if proxy.Type == model.Router && proxy.MergedGateway != nil && proxy.MergedGateway.ContainsAutoPassthroughGateways {
-			clusters = append(clusters, configgen.buildOutboundSniDnatClusters(proxy, push, patcher)...)
+			clusters = append(clusters, configgen.buildOutboundSniDnatClusters(proxy, req, patcher)...)
 		}
 		clusters = append(clusters, patcher.insertedClusters()...)
 	}
@@ -140,8 +140,8 @@ func buildClusterKey(service *model.Service, port *model.Port, cb *ClusterBuilde
 		clusterName:     clusterName,
 		service:         service,
 		networkView:     cb.proxy.GetNetworkView(),
-		pushVersion:     cb.push.PushVersion,
-		destinationRule: cb.push.DestinationRule(cb.proxy, service),
+		pushVersion:     cb.req.Push.PushVersion,
+		destinationRule: cb.req.Push.DestinationRule(cb.proxy, service),
 		locality:        cb.proxy.Locality,
 		proxySidecar:    cb.proxy.Type == model.SidecarProxy,
 		http2:           port.Protocol.IsHTTP2(),
@@ -156,9 +156,9 @@ func (configgen *ConfigGeneratorImpl) buildOutboundClusters(cb *ClusterBuilder, 
 	hit, miss := 0, 0
 	var services []*model.Service
 	if features.FilterGatewayClusterConfig && cb.proxy.Type == model.Router {
-		services = cb.push.GatewayServices(cb.proxy)
+		services = cb.req.Push.GatewayServices(cb.proxy)
 	} else {
-		services = cb.push.Services(cb.proxy)
+		services = cb.req.Push.Services(cb.proxy)
 	}
 	for _, service := range services {
 		for _, port := range service.Ports {
@@ -166,7 +166,7 @@ func (configgen *ConfigGeneratorImpl) buildOutboundClusters(cb *ClusterBuilder, 
 				continue
 			}
 			clusterKey := buildClusterKey(service, port, cb)
-			cached, tokens, allFound := cb.getAllCachedSubsetClusters(*clusterKey)
+			cached, allFound := cb.getAllCachedSubsetClusters(*clusterKey)
 			if allFound && !features.EnableUnsafeAssertions {
 				hit += len(cached)
 				resources = append(resources, cached...)
@@ -186,8 +186,8 @@ func (configgen *ConfigGeneratorImpl) buildOutboundClusters(cb *ClusterBuilder, 
 				continue
 			}
 			// If stat name is configured, build the alternate stats name.
-			if len(cb.push.Mesh.OutboundClusterStatName) != 0 {
-				defaultCluster.cluster.AltStatName = util.BuildStatPrefix(cb.push.Mesh.OutboundClusterStatName, string(service.Hostname), "", port, service.Attributes)
+			if len(cb.req.Push.Mesh.OutboundClusterStatName) != 0 {
+				defaultCluster.cluster.AltStatName = util.BuildStatPrefix(cb.req.Push.Mesh.OutboundClusterStatName, string(service.Hostname), "", port, service.Attributes)
 			}
 
 			subsetClusters := cb.applyDestinationRule(defaultCluster, DefaultClusterMode, service, port, clusterKey.networkView, clusterKey.destinationRule)
@@ -195,7 +195,7 @@ func (configgen *ConfigGeneratorImpl) buildOutboundClusters(cb *ClusterBuilder, 
 			if patched := cp.applyResource(nil, defaultCluster.build()); patched != nil {
 				resources = append(resources, patched)
 				if features.EnableCDSCaching {
-					cb.cache.Add(clusterKey, tokens[clusterKey.clusterName], patched)
+					cb.cache.Add(clusterKey, cb.req, patched)
 				}
 			}
 			for _, ss := range subsetClusters {
@@ -204,7 +204,7 @@ func (configgen *ConfigGeneratorImpl) buildOutboundClusters(cb *ClusterBuilder, 
 					nk.clusterName = ss.Name
 					resources = append(resources, patched)
 					if features.EnableCDSCaching {
-						cb.cache.Add(&nk, tokens[ss.Name], patched)
+						cb.cache.Add(&nk, cb.req, patched)
 					}
 				}
 			}
@@ -257,14 +257,14 @@ func (p clusterPatcher) hasPatches() bool {
 // SniDnat clusters do not have any TLS setting, as they simply forward traffic to upstream
 // All SniDnat clusters are internal services in the mesh.
 // TODO enable cache - there is no blockers here, skipped to simplify the original caching implementation
-func (configgen *ConfigGeneratorImpl) buildOutboundSniDnatClusters(proxy *model.Proxy, push *model.PushContext,
+func (configgen *ConfigGeneratorImpl) buildOutboundSniDnatClusters(proxy *model.Proxy, req *model.PushRequest,
 	cp clusterPatcher) []*cluster.Cluster {
 	clusters := make([]*cluster.Cluster, 0)
-	cb := NewClusterBuilder(proxy, push, nil)
+	cb := NewClusterBuilder(proxy, req, nil)
 
 	networkView := proxy.GetNetworkView()
 
-	for _, service := range push.Services(proxy) {
+	for _, service := range req.Push.Services(proxy) {
 		if service.MeshExternal {
 			continue
 		}
@@ -282,7 +282,7 @@ func (configgen *ConfigGeneratorImpl) buildOutboundSniDnatClusters(proxy *model.
 			if defaultCluster == nil {
 				continue
 			}
-			destRule := cb.push.DestinationRule(cb.proxy, service)
+			destRule := cb.req.Push.DestinationRule(cb.proxy, service)
 			subsetClusters := cb.applyDestinationRule(defaultCluster, SniDnatClusterMode, service, port, networkView, destRule)
 			clusters = cp.conditionallyAppend(clusters, nil, defaultCluster.build())
 			clusters = cp.conditionallyAppend(clusters, nil, subsetClusters...)

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
@@ -275,10 +275,10 @@ func TestApplyDestinationRule(t *testing.T) {
 				Services:       []*model.Service{tt.service},
 			})
 			cg.MemRegistry.WantGetProxyServiceInstances = instances
-			cb := NewClusterBuilder(cg.SetupProxy(nil), cg.PushContext(), nil)
+			cb := NewClusterBuilder(cg.SetupProxy(nil), &model.PushRequest{Push: cg.PushContext()}, nil)
 
 			ec := NewMutableCluster(tt.cluster)
-			destRule := cb.push.DestinationRule(cb.proxy, tt.service)
+			destRule := cb.req.Push.DestinationRule(cb.proxy, tt.service)
 			subsetClusters := cb.applyDestinationRule(ec, tt.clusterMode, tt.service, tt.port, tt.networkView, destRule)
 			if len(subsetClusters) != len(tt.expectedSubsetClusters) {
 				t.Errorf("Unexpected subset clusters want %v, got %v", len(tt.expectedSubsetClusters), len(subsetClusters))
@@ -805,7 +805,7 @@ func TestBuildDefaultCluster(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			mesh := testMesh()
 			cg := NewConfigGenTest(t, TestOptions{MeshConfig: &mesh})
-			cb := NewClusterBuilder(cg.SetupProxy(nil), cg.PushContext(), nil)
+			cb := NewClusterBuilder(cg.SetupProxy(nil), &model.PushRequest{Push: cg.PushContext()}, nil)
 			service := &model.Service{
 				Ports: model.PortList{
 					servicePort,
@@ -1221,7 +1221,7 @@ func TestBuildLocalityLbEndpoints(t *testing.T) {
 				Instances:  tt.instances,
 			})
 
-			cb := NewClusterBuilder(cg.SetupProxy(proxy), cg.PushContext(), nil)
+			cb := NewClusterBuilder(cg.SetupProxy(proxy), &model.PushRequest{Push: cg.PushContext()}, nil)
 			nv := map[network.ID]bool{
 				"nw-0":               true,
 				"nw-1":               true,
@@ -1267,7 +1267,7 @@ func TestBuildPassthroughClusters(t *testing.T) {
 			proxy := &model.Proxy{IPAddresses: tt.ips}
 			cg := NewConfigGenTest(t, TestOptions{})
 
-			cb := NewClusterBuilder(cg.SetupProxy(proxy), cg.PushContext(), nil)
+			cb := NewClusterBuilder(cg.SetupProxy(proxy), &model.PushRequest{Push: cg.PushContext()}, nil)
 			clusters := cb.buildInboundPassthroughClusters()
 
 			var hasIpv4, hasIpv6 bool
@@ -1488,7 +1488,7 @@ func TestApplyUpstreamTLSSettings(t *testing.T) {
 	push := model.NewPushContext()
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			cb := NewClusterBuilder(proxy, push, model.DisabledCache{})
+			cb := NewClusterBuilder(proxy, &model.PushRequest{Push: push}, model.DisabledCache{})
 			opts := &buildClusterOpts{
 				mutable: NewMutableCluster(&cluster.Cluster{
 					ClusterDiscoveryType: &cluster.Cluster_Type{Type: test.discoveryType},

--- a/pilot/pkg/networking/core/v1alpha3/fake.go
+++ b/pilot/pkg/networking/core/v1alpha3/fake.go
@@ -237,7 +237,7 @@ func (f *ConfigGenTest) Listeners(p *model.Proxy) []*listener.Listener {
 }
 
 func (f *ConfigGenTest) Clusters(p *model.Proxy) []*cluster.Cluster {
-	raw, _ := f.ConfigGen.BuildClusters(p, f.PushContext())
+	raw, _ := f.ConfigGen.BuildClusters(p, &model.PushRequest{Push: f.PushContext()})
 	res := make([]*cluster.Cluster, 0, len(raw))
 	for _, r := range raw {
 		c := &cluster.Cluster{}

--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -209,10 +209,11 @@ func (s *DiscoveryServer) processRequest(req *discovery.DiscoveryRequest, con *C
 	shouldRespond := s.shouldRespond(con, req)
 
 	var request *model.PushRequest
+	push := s.globalPushContext()
 	if shouldRespond {
 		// This is a request, trigger a full push for this type. Override the blocked push (if it exists),
 		// as this full push is guaranteed to be a superset of what we would have pushed from the blocked push.
-		request = &model.PushRequest{Full: true}
+		request = &model.PushRequest{Full: true, Push: push}
 	} else {
 		// Check if we have a blocked push. If this was an ACK, we will send it.
 		// Either way we remove the blocked push as we will send a push.
@@ -231,7 +232,6 @@ func (s *DiscoveryServer) processRequest(req *discovery.DiscoveryRequest, con *C
 		}
 	}
 
-	push := s.globalPushContext()
 	request.Reason = append(request.Reason, model.ProxyRequest)
 	return s.pushXds(con, push, versionInfo(), con.Watched(req.TypeUrl), request)
 }

--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -201,7 +201,7 @@ func (s *DiscoveryServer) processRequest(req *discovery.DiscoveryRequest, con *C
 	if strings.HasPrefix(req.TypeUrl, v3.DebugType) {
 		return s.pushXds(con, s.globalPushContext(), versionInfo(), &model.WatchedResource{
 			TypeUrl: req.TypeUrl, ResourceNames: req.ResourceNames,
-		}, &model.PushRequest{Full: true})
+		}, &model.PushRequest{Full: true, Start: time.Now()})
 	}
 	if s.StatusReporter != nil {
 		s.StatusReporter.RegisterEvent(con.ConID, req.TypeUrl, req.ResponseNonce)
@@ -232,6 +232,7 @@ func (s *DiscoveryServer) processRequest(req *discovery.DiscoveryRequest, con *C
 	}
 
 	push := s.globalPushContext()
+	request.Start = time.Now()
 	request.Reason = append(request.Reason, model.ProxyRequest)
 	return s.pushXds(con, push, versionInfo(), con.Watched(req.TypeUrl), request)
 }

--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -201,7 +201,7 @@ func (s *DiscoveryServer) processRequest(req *discovery.DiscoveryRequest, con *C
 	if strings.HasPrefix(req.TypeUrl, v3.DebugType) {
 		return s.pushXds(con, s.globalPushContext(), versionInfo(), &model.WatchedResource{
 			TypeUrl: req.TypeUrl, ResourceNames: req.ResourceNames,
-		}, &model.PushRequest{Full: true, Start: time.Now()})
+		}, &model.PushRequest{Full: true})
 	}
 	if s.StatusReporter != nil {
 		s.StatusReporter.RegisterEvent(con.ConID, req.TypeUrl, req.ResponseNonce)
@@ -232,7 +232,6 @@ func (s *DiscoveryServer) processRequest(req *discovery.DiscoveryRequest, con *C
 	}
 
 	push := s.globalPushContext()
-	request.Start = time.Now()
 	request.Reason = append(request.Reason, model.ProxyRequest)
 	return s.pushXds(con, push, versionInfo(), con.Watched(req.TypeUrl), request)
 }

--- a/pilot/pkg/xds/bench_test.go
+++ b/pilot/pkg/xds/bench_test.go
@@ -166,7 +166,7 @@ func BenchmarkRouteGeneration(b *testing.B) {
 // update our benchmark doesn't become useless.
 func TestValidateTelemetry(t *testing.T) {
 	s, proxy := setupAndInitializeTest(t, ConfigInput{Name: "telemetry", Services: 1})
-	c, _, _ := s.Discovery.Generators[v3.ClusterType].Generate(proxy, s.PushContext(), nil, nil)
+	c, _, _ := s.Discovery.Generators[v3.ClusterType].Generate(proxy, s.PushContext(), nil, &model.PushRequest{Full: true, Push: s.PushContext()})
 	if len(c) == 0 {
 		t.Fatal("Got no clusters!")
 	}
@@ -192,7 +192,7 @@ func BenchmarkClusterGeneration(b *testing.B) {
 			b.ResetTimer()
 			var c model.Resources
 			for n := 0; n < b.N; n++ {
-				c, _, _ = s.Discovery.Generators[v3.ClusterType].Generate(proxy, s.PushContext(), nil, nil)
+				c, _, _ = s.Discovery.Generators[v3.ClusterType].Generate(proxy, s.PushContext(), nil, &model.PushRequest{Push: s.PushContext()})
 				if len(c) == 0 {
 					b.Fatal("Got no clusters!")
 				}

--- a/pilot/pkg/xds/cds.go
+++ b/pilot/pkg/xds/cds.go
@@ -73,6 +73,6 @@ func (c CdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *m
 	if !cdsNeedsPush(req, proxy) {
 		return nil, model.DefaultXdsLogDetails, nil
 	}
-	clusters, logs := c.Server.ConfigGenerator.BuildClusters(proxy, push)
+	clusters, logs := c.Server.ConfigGenerator.BuildClusters(proxy, req)
 	return clusters, logs, nil
 }

--- a/pilot/pkg/xds/debug.go
+++ b/pilot/pkg/xds/debug.go
@@ -560,7 +560,7 @@ func (s *DiscoveryServer) ConfigDump(w http.ResponseWriter, req *http.Request) {
 // It is used in debugging to create a consistent object for comparison between Envoy and Pilot outputs
 func (s *DiscoveryServer) configDump(conn *Connection) (*adminapi.ConfigDump, error) {
 	dynamicActiveClusters := make([]*adminapi.ClustersConfigDump_DynamicCluster, 0)
-	clusters, _ := s.ConfigGenerator.BuildClusters(conn.proxy, s.globalPushContext())
+	clusters, _ := s.ConfigGenerator.BuildClusters(conn.proxy, &model.PushRequest{Push: s.globalPushContext()})
 
 	for _, cs := range clusters {
 		dynamicActiveClusters = append(dynamicActiveClusters, &adminapi.ClustersConfigDump_DynamicCluster{Cluster: cs.Resource})

--- a/pilot/pkg/xds/delta.go
+++ b/pilot/pkg/xds/delta.go
@@ -285,11 +285,12 @@ func (s *DiscoveryServer) processDeltaRequest(req *discovery.DeltaDiscoveryReque
 	}
 	shouldRespond := s.shouldRespondDelta(con, req)
 	var request *model.PushRequest
+	push := s.globalPushContext()
 	if shouldRespond {
 		debugRequest(req)
 		// This is a request, trigger a full push for this type. Override the blocked push (if it exists),
 		// as this full push is guaranteed to be a superset of what we would have pushed from the blocked push.
-		request = &model.PushRequest{Full: true}
+		request = &model.PushRequest{Full: true, Push: push}
 	} else {
 		// Check if we have a blocked push. If this was an ACK, we will send it.
 		// Either way we remove the blocked push as we will send a push.
@@ -308,7 +309,6 @@ func (s *DiscoveryServer) processDeltaRequest(req *discovery.DeltaDiscoveryReque
 		}
 	}
 
-	push := s.globalPushContext()
 	return s.pushDeltaXds(con, push, versionInfo(), con.Watched(req.TypeUrl), req.ResourceNamesSubscribe, request)
 }
 

--- a/pilot/pkg/xds/delta.go
+++ b/pilot/pkg/xds/delta.go
@@ -278,7 +278,7 @@ func (s *DiscoveryServer) processDeltaRequest(req *discovery.DeltaDiscoveryReque
 	if strings.HasPrefix(req.TypeUrl, v3.DebugType) {
 		return s.pushXds(con, s.globalPushContext(), versionInfo(), &model.WatchedResource{
 			TypeUrl: req.TypeUrl, ResourceNames: req.ResourceNamesSubscribe,
-		}, &model.PushRequest{Full: true})
+		}, &model.PushRequest{Full: true, Start: time.Now()})
 	}
 	if s.StatusReporter != nil {
 		s.StatusReporter.RegisterEvent(con.ConID, req.TypeUrl, req.ResponseNonce)
@@ -310,6 +310,7 @@ func (s *DiscoveryServer) processDeltaRequest(req *discovery.DeltaDiscoveryReque
 	}
 
 	push := s.globalPushContext()
+	request.Start = time.Now()
 	return s.pushDeltaXds(con, push, versionInfo(), con.Watched(req.TypeUrl), req.ResourceNamesSubscribe, request)
 }
 

--- a/pilot/pkg/xds/delta.go
+++ b/pilot/pkg/xds/delta.go
@@ -278,13 +278,12 @@ func (s *DiscoveryServer) processDeltaRequest(req *discovery.DeltaDiscoveryReque
 	if strings.HasPrefix(req.TypeUrl, v3.DebugType) {
 		return s.pushXds(con, s.globalPushContext(), versionInfo(), &model.WatchedResource{
 			TypeUrl: req.TypeUrl, ResourceNames: req.ResourceNamesSubscribe,
-		}, &model.PushRequest{Full: true, Start: time.Now()})
+		}, &model.PushRequest{Full: true})
 	}
 	if s.StatusReporter != nil {
 		s.StatusReporter.RegisterEvent(con.ConID, req.TypeUrl, req.ResponseNonce)
 	}
 	shouldRespond := s.shouldRespondDelta(con, req)
-
 	var request *model.PushRequest
 	if shouldRespond {
 		debugRequest(req)
@@ -310,7 +309,6 @@ func (s *DiscoveryServer) processDeltaRequest(req *discovery.DeltaDiscoveryReque
 	}
 
 	push := s.globalPushContext()
-	request.Start = time.Now()
 	return s.pushDeltaXds(con, push, versionInfo(), con.Watched(req.TypeUrl), req.ResourceNamesSubscribe, request)
 }
 

--- a/pilot/pkg/xds/eds.go
+++ b/pilot/pkg/xds/eds.go
@@ -397,7 +397,7 @@ func (eds *EdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w
 			}
 		}
 		builder := NewEndpointBuilder(clusterName, proxy, push)
-		if marshalledEndpoint, token, f := eds.Server.Cache.Get(builder); f && !features.EnableUnsafeAssertions {
+		if marshalledEndpoint, f := eds.Server.Cache.Get(builder); f && !features.EnableUnsafeAssertions {
 			// We skip cache if assertions are enabled, so that the cache will assert our eviction logic is correct
 			resources = append(resources, marshalledEndpoint)
 			cached++
@@ -416,7 +416,7 @@ func (eds *EdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w
 				Resource: util.MessageToAny(l),
 			}
 			resources = append(resources, resource)
-			eds.Server.Cache.Add(builder, token, resource)
+			eds.Server.Cache.Add(builder, req, resource)
 		}
 	}
 	return resources, model.XdsLogDetails{

--- a/pilot/pkg/xds/sds.go
+++ b/pilot/pkg/xds/sds.go
@@ -146,7 +146,7 @@ func (s *SecretGen) Generate(proxy *model.Proxy, push *model.PushContext, w *mod
 			log.Warnf("requested secret %v not accessible for proxy %v: %v", sr.ResourceName, proxy.ID, err)
 			continue
 		}
-		cachedItem, token, f := s.cache.Get(sr)
+		cachedItem, f := s.cache.Get(sr)
 		if f && !features.EnableUnsafeAssertions {
 			// If it is in the Cache, add it and continue
 			// We skip cache if assertions are enabled, so that the cache will assert our eviction logic is correct
@@ -162,7 +162,7 @@ func (s *SecretGen) Generate(proxy *model.Proxy, push *model.PushContext, w *mod
 			if secret != nil {
 				res := toEnvoyCaSecret(sr.ResourceName, secret)
 				results = append(results, res)
-				s.cache.Add(sr, token, res)
+				s.cache.Add(sr, req, res)
 			} else {
 				pilotSDSCertificateErrors.Increment()
 				log.Warnf("failed to fetch ca certificate for %v", sr.ResourceName)
@@ -172,7 +172,7 @@ func (s *SecretGen) Generate(proxy *model.Proxy, push *model.PushContext, w *mod
 			if key != nil && cert != nil {
 				res := toEnvoyKeyCertSecret(sr.ResourceName, key, cert)
 				results = append(results, res)
-				s.cache.Add(sr, token, res)
+				s.cache.Add(sr, req, res)
 			} else {
 				pilotSDSCertificateErrors.Increment()
 				log.Warnf("failed to fetch key and certificate for %v", sr.ResourceName)

--- a/pilot/pkg/xds/sds_test.go
+++ b/pilot/pkg/xds/sds_test.go
@@ -17,6 +17,7 @@ package xds
 import (
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
@@ -327,7 +328,7 @@ func TestGenerate(t *testing.T) {
 			cc.Fake.Unlock()
 
 			gen := s.Discovery.Generators[v3.SecretType]
-
+			tt.request.Start = time.Now()
 			secrets, _, _ := gen.Generate(s.SetupProxy(tt.proxy), s.PushContext(),
 				&model.WatchedResource{ResourceNames: tt.resources}, tt.request)
 			raw := xdstest.ExtractTLSSecrets(t, model.ResourcesToAny(secrets))
@@ -360,7 +361,7 @@ func TestCaching(t *testing.T) {
 	})
 	gen := s.Discovery.Generators[v3.SecretType]
 
-	fullPush := &model.PushRequest{Full: true}
+	fullPush := &model.PushRequest{Full: true, Start: time.Now()}
 	istiosystem := &model.Proxy{VerifiedIdentity: &spiffe.Identity{Namespace: "istio-system"}, Type: model.Router, ConfigNamespace: "istio-system"}
 	otherNamespace := &model.Proxy{VerifiedIdentity: &spiffe.Identity{Namespace: "other-namespace"}, Type: model.Router, ConfigNamespace: "other-namespace"}
 

--- a/pilot/pkg/xds/xds_cache_test.go
+++ b/pilot/pkg/xds/xds_cache_test.go
@@ -44,31 +44,30 @@ func TestXdsCacheToken(t *testing.T) {
 		return &discovery.Resource{Resource: &any.Any{TypeUrl: fmt.Sprint(n)}}
 	}
 	k := EndpointBuilder{clusterName: "key", service: &model.Service{Hostname: "foo.com"}}
-	work := func() {
-		_, tok, f := c.Get(k)
-		if f {
-			return
-		}
-		v := mkv(n.Load())
+	work := func(start time.Time, n int32) {
+		v := mkv(n)
 		time.Sleep(time.Millisecond * time.Duration(rand.Intn(100)))
-		c.Add(k, tok, v)
+		req := &model.PushRequest{Start: start}
+		c.Add(k, req, v)
 	}
+	// 5 round of xds push
 	for vals := 0; vals < 5; vals++ {
+		c.ClearAll()
+		n.Inc()
+		start := time.Now()
 		for i := 0; i < 5; i++ {
-			go work()
+			go work(start, n.Load())
 		}
 		retry.UntilOrFail(t, func() bool {
-			val, _, f := c.Get(k)
-			return f && val.Resource.TypeUrl == fmt.Sprint(n)
+			val, f := c.Get(k)
+			return f && val.Resource.TypeUrl == fmt.Sprint(n.Load())
 		})
-		n.Inc()
-		c.ClearAll()
 		for i := 0; i < 5; i++ {
-			val, _, f := c.Get(k)
-			if f {
-				t.Log("found unexpected write", val.Resource.TypeUrl)
+			val, f := c.Get(k)
+			if !f {
+				t.Fatalf("no cache found")
 			}
-			if f && val.Resource.TypeUrl != fmt.Sprint(n) {
+			if f && val.Resource.TypeUrl != fmt.Sprint(n.Load()) {
 				t.Fatalf("got bad write: %v", val.Resource.TypeUrl)
 			}
 			time.Sleep(time.Millisecond * time.Duration(rand.Intn(20)))
@@ -85,135 +84,170 @@ func TestXdsCache(t *testing.T) {
 		clusterName: "outbound|2||foo.com",
 		service:     &model.Service{Hostname: "foo.com"},
 	}
-	addWithToken := func(c model.XdsCache, entry model.XdsCacheEntry, value *discovery.Resource) {
-		_, tok, _ := c.Get(entry)
-		c.Add(entry, tok, value)
-	}
 	t.Run("simple", func(t *testing.T) {
 		c := model.NewLenientXdsCache()
-
-		addWithToken(c, ep1, any1)
+		c.Add(ep1, &model.PushRequest{Start: time.Now()}, any1)
 		if !reflect.DeepEqual(c.Keys(), []string{ep1.Key()}) {
 			t.Fatalf("unexpected keys: %v, want %v", c.Keys(), ep1.Key())
 		}
-		if got, _, _ := c.Get(ep1); got != any1 {
+		if got, _ := c.Get(ep1); got != any1 {
 			t.Fatalf("unexpected result: %v, want %v", got, any1)
 		}
-
-		addWithToken(c, ep1, any2)
-		if got, _, _ := c.Get(ep1); got != any2 {
+		c.Add(ep1, &model.PushRequest{Start: time.Now()}, any2)
+		if got, _ := c.Get(ep1); got != any2 {
 			t.Fatalf("unexpected result: %v, want %v", got, any2)
 		}
 
 		c.Clear(map[model.ConfigKey]struct{}{{Kind: gvk.ServiceEntry, Name: "foo.com"}: {}})
-		if _, _, f := c.Get(ep1); f {
+		if _, f := c.Get(ep1); f {
 			t.Fatalf("unexpected result, found key when not expected: %v", c.Keys())
 		}
 	})
 
 	t.Run("multiple hostnames", func(t *testing.T) {
 		c := model.NewLenientXdsCache()
-		addWithToken(c, ep1, any1)
-		addWithToken(c, ep2, any2)
+		start := time.Now()
+		c.Add(ep1, &model.PushRequest{Start: start}, any1)
+		c.Add(ep2, &model.PushRequest{Start: start}, any2)
 
-		if got, _, _ := c.Get(ep1); got != any1 {
+		if got, _ := c.Get(ep1); got != any1 {
 			t.Fatalf("unexpected result: %v, want %v", got, any1)
 		}
-		if got, _, _ := c.Get(ep2); got != any2 {
+		if got, _ := c.Get(ep2); got != any2 {
 			t.Fatalf("unexpected result: %v, want %v", got, any2)
 		}
 		c.Clear(map[model.ConfigKey]struct{}{{Kind: gvk.ServiceEntry, Name: "foo.com"}: {}})
-		if _, _, f := c.Get(ep1); f {
+		if _, f := c.Get(ep1); f {
 			t.Fatalf("unexpected result, found key when not expected: %v", c.Keys())
 		}
-		if _, _, f := c.Get(ep2); f {
+		if _, f := c.Get(ep2); f {
 			t.Fatalf("unexpected result, found key when not expected: %v", c.Keys())
 		}
 	})
 
 	t.Run("multiple destinationRules", func(t *testing.T) {
 		c := model.NewLenientXdsCache()
+
 		ep1 := ep1
 		ep1.destinationRule = &config.Config{Meta: config.Meta{Name: "a", Namespace: "b"}}
 		ep2 := ep2
 		ep2.destinationRule = &config.Config{Meta: config.Meta{Name: "b", Namespace: "b"}}
-		addWithToken(c, ep1, any1)
-		addWithToken(c, ep2, any2)
-		if got, _, _ := c.Get(ep1); got != any1 {
+		start := time.Now()
+		c.Add(ep1, &model.PushRequest{Start: start}, any1)
+		c.Add(ep2, &model.PushRequest{Start: start}, any2)
+		if got, _ := c.Get(ep1); got != any1 {
 			t.Fatalf("unexpected result: %v, want %v", got, any1)
 		}
-		if got, _, _ := c.Get(ep2); got != any2 {
+		if got, _ := c.Get(ep2); got != any2 {
 			t.Fatalf("unexpected result: %v, want %v", got, any2)
 		}
 		c.Clear(map[model.ConfigKey]struct{}{{Kind: gvk.DestinationRule, Name: "a", Namespace: "b"}: {}})
-		if _, _, f := c.Get(ep1); f {
+		if _, f := c.Get(ep1); f {
 			t.Fatalf("unexpected result, found key when not expected: %v", c.Keys())
 		}
-		if got, _, _ := c.Get(ep2); got != any2 {
+		if got, _ := c.Get(ep2); got != any2 {
 			t.Fatalf("unexpected result: %v, want %v", got, any2)
 		}
 		c.Clear(map[model.ConfigKey]struct{}{{Kind: gvk.DestinationRule, Name: "b", Namespace: "b"}: {}})
-		if _, _, f := c.Get(ep1); f {
+		if _, f := c.Get(ep1); f {
 			t.Fatalf("unexpected result, found key when not expected: %v", c.Keys())
 		}
-		if _, _, f := c.Get(ep2); f {
+		if _, f := c.Get(ep2); f {
 			t.Fatalf("unexpected result, found key when not expected: %v", c.Keys())
 		}
 	})
 
 	t.Run("clear all", func(t *testing.T) {
 		c := model.NewLenientXdsCache()
-		addWithToken(c, ep1, any1)
-		addWithToken(c, ep2, any2)
+		start := time.Now()
+		c.Add(ep1, &model.PushRequest{Start: start}, any1)
+		c.Add(ep2, &model.PushRequest{Start: start}, any2)
 
 		c.ClearAll()
 		if len(c.Keys()) != 0 {
 			t.Fatalf("expected no keys, got: %v", c.Keys())
 		}
-		if _, _, f := c.Get(ep1); f {
+		if _, f := c.Get(ep1); f {
 			t.Fatalf("unexpected result, found key when not expected: %v", c.Keys())
 		}
-		if _, _, f := c.Get(ep2); f {
+		if _, f := c.Get(ep2); f {
 			t.Fatalf("unexpected result, found key when not expected: %v", c.Keys())
 		}
 	})
 
 	t.Run("dependent type clears all", func(t *testing.T) {
 		c := model.NewLenientXdsCache()
-		addWithToken(c, ep1, any1)
-		addWithToken(c, ep2, any2)
+		start := time.Now()
+		c.Add(ep1, &model.PushRequest{Start: start}, any1)
+		c.Add(ep2, &model.PushRequest{Start: start}, any2)
 
 		c.Clear(map[model.ConfigKey]struct{}{{Kind: gvk.PeerAuthentication}: {}})
 		if len(c.Keys()) != 0 {
 			t.Fatalf("expected no keys, got: %v", c.Keys())
 		}
-		if _, _, f := c.Get(ep1); f {
+		if _, f := c.Get(ep1); f {
 			t.Fatalf("unexpected result, found key when not expected: %v", c.Keys())
 		}
-		if _, _, f := c.Get(ep2); f {
+		if _, f := c.Get(ep2); f {
 			t.Fatalf("unexpected result, found key when not expected: %v", c.Keys())
 		}
 	})
 
-	t.Run("write without token", func(t *testing.T) {
+	t.Run("write without token causes panic", func(t *testing.T) {
 		c := model.NewLenientXdsCache()
-		c.Add(ep1, 0, any1)
-		if len(c.Keys()) != 0 {
-			t.Fatalf("expected no keys, got: %v", c.Keys())
-		}
+		defer func() {
+			ret := recover()
+			if ret == nil {
+				t.Fatalf("expected no keys, got: %v", c.Keys())
+			}
+		}()
+		c.Add(ep1, &model.PushRequest{}, any1)
 	})
 
 	t.Run("write with evicted token", func(t *testing.T) {
 		c := model.NewLenientXdsCache()
-		addWithToken(c, ep1, any1)
+		t1 := time.Now()
+		t2 := t1.Add(1 * time.Nanosecond)
+		c.Add(ep1, &model.PushRequest{Start: t2}, any1)
+		c.Add(ep1, &model.PushRequest{Start: t1}, any2)
 		if len(c.Keys()) != 1 {
 			t.Fatalf("expected 1 keys, got: %v", c.Keys())
 		}
-		_, tok, _ := c.Get(ep1)
+		if got, _ := c.Get(ep1); got != any1 {
+			t.Fatalf("unexpected result: %v, want %v", got, any1)
+		}
+	})
+
+	t.Run("write with expired token", func(t *testing.T) {
+		c := model.NewLenientXdsCache()
+		t1 := time.Now()
+		t2 := t1.Add(-1 * time.Nanosecond)
+
+		c.Add(ep1, &model.PushRequest{Start: t1}, any1)
 		c.ClearAll()
-		c.Add(ep1, tok, any1)
-		if len(c.Keys()) != 0 {
-			t.Fatalf("expected no keys, got: %v", c.Keys())
+		// prevented, this is stale token
+		c.Add(ep1, &model.PushRequest{Start: t2}, any2)
+		if got, _ := c.Get(ep1); got != nil {
+			t.Fatalf("expected no cache, but got %v", got)
+		}
+	})
+
+	t.Run("disallow write with stale token after clear", func(t *testing.T) {
+		c := model.NewLenientXdsCache()
+		t1 := time.Now()
+
+		c.Add(ep1, &model.PushRequest{Start: t1}, any1)
+		c.ClearAll()
+		// prevented, this can be stale data after `disallowCacheSameToken`
+		c.Add(ep1, &model.PushRequest{Start: t1}, any2)
+		if got, _ := c.Get(ep1); got != nil {
+			t.Fatalf("expected no cache, but got %v", got)
+		}
+
+		// cache with newer token
+		c.Add(ep1, &model.PushRequest{Start: time.Now()}, any1)
+		if got, _ := c.Get(ep1); got != any1 {
+			t.Fatalf("unexpected result: %v, want %v", got, any1)
 		}
 	})
 }

--- a/pilot/pkg/xds/xds_cache_test.go
+++ b/pilot/pkg/xds/xds_cache_test.go
@@ -193,15 +193,12 @@ func TestXdsCache(t *testing.T) {
 		}
 	})
 
-	t.Run("write without token causes panic", func(t *testing.T) {
+	t.Run("write without token does nothing", func(t *testing.T) {
 		c := model.NewLenientXdsCache()
-		defer func() {
-			ret := recover()
-			if ret == nil {
-				t.Fatalf("expected no keys, got: %v", c.Keys())
-			}
-		}()
 		c.Add(ep1, &model.PushRequest{}, any1)
+		if got, f := c.Get(ep1); f {
+			t.Fatalf("unexpected result: %v, want none", got)
+		}
 	})
 
 	t.Run("write with evicted token", func(t *testing.T) {


### PR DESCRIPTION

For the CacheToken added, it is to prevent stale cache.

But there are still cases that it can be stale, e.g. A thread generates eds for a proxy runs super slow, but other threads for the other proxies run super fast.
```
v1 --> proxy2 eds pushed--> v2 --> (proxy1 eds pushed for v1, cache stale endpoint) -> proxy2 eds pushed -> proxy 1 eds push for v2
```




[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.