### PR TITLE
Rename NetworkGateways to NetworkManager

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -202,7 +202,7 @@ type PushContext struct {
 
 	// cache gateways addresses for each network
 	// this is mainly used for kubernetes multi-cluster scenario
-	networkGateways *NetworkGateways
+	networkMgr *NetworkManager
 
 	initDone        atomic.Bool
 	initializeMutex sync.Mutex
@@ -963,7 +963,7 @@ func (ps *PushContext) InitContext(env *Environment, oldPushContext *PushContext
 	}
 
 	// TODO: only do this when meshnetworks or gateway service changed
-	ps.initMeshNetworks(env)
+	ps.initNetworkManager(env)
 
 	ps.clusterLocalHosts = env.ClusterLocal().GetClusterLocalHosts()
 
@@ -1873,12 +1873,12 @@ func instancesEmpty(m map[int][]*ServiceInstance) bool {
 }
 
 // pre computes gateways for each network
-func (ps *PushContext) initMeshNetworks(env *Environment) {
-	ps.networkGateways = newNetworkGateways(env)
+func (ps *PushContext) initNetworkManager(env *Environment) {
+	ps.networkMgr = newNetworkManager(env)
 }
 
-func (ps *PushContext) NetworkGateways() *NetworkGateways {
-	return ps.networkGateways
+func (ps *PushContext) NetworkManager() *NetworkManager {
+	return ps.networkMgr
 }
 
 // BestEffortInferServiceMTLSMode infers the mTLS mode for the service + port from all authentication

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -727,7 +727,7 @@ func TestInitPushContext(t *testing.T) {
 		// Allow looking into exported fields for parts of push context
 		cmp.AllowUnexported(PushContext{}, exportToDefaults{}, serviceIndex{}, virtualServiceIndex{},
 			destinationRuleIndex{}, gatewayIndex{}, processedDestRules{}, IstioEgressListenerWrapper{}, SidecarScope{},
-			AuthenticationPolicies{}, NetworkGateways{}),
+			AuthenticationPolicies{}, NetworkManager{}),
 		// These are not feasible/worth comparing
 		cmpopts.IgnoreTypes(sync.RWMutex{}, localServiceDiscovery{}, FakeStore{}, atomic.Bool{}, sync.Mutex{}),
 		cmpopts.IgnoreInterfaces(struct{ mesh.Holder }{}),

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -537,7 +537,7 @@ type ServiceDiscovery interface {
 	// Deprecated - service account tracking moved to XdsServer, incremental.
 	GetIstioServiceAccounts(svc *Service, ports []int) []string
 
-	// NetworkGateways returns a list of network gateways that can be used to access endpoints residing in this registry..
+	// NetworkManager returns a list of network gateways that can be used to access endpoints residing in this registry..
 	NetworkGateways() []*NetworkGateway
 }
 

--- a/pilot/pkg/xds/debug.go
+++ b/pilot/pkg/xds/debug.go
@@ -693,7 +693,7 @@ type PushContextDebug struct {
 
 // PushContextHandler dumps the current PushContext
 func (s *DiscoveryServer) PushContextHandler(w http.ResponseWriter, _ *http.Request) {
-	gateways := s.globalPushContext().NetworkGateways().All()
+	gateways := s.globalPushContext().NetworkManager().AllGateways()
 	byNetwork := make(map[string][]*model.NetworkGateway)
 	for _, gateway := range gateways {
 		byNetwork[string(gateway.Network)] = append(byNetwork[string(gateway.Network)], gateway)

--- a/pilot/pkg/xds/eds.go
+++ b/pilot/pkg/xds/eds.go
@@ -317,7 +317,7 @@ func (s *DiscoveryServer) generateEndpoints(b EndpointBuilder) *endpoint.Cluster
 
 	// If networks are set (by default they aren't) apply the Split Horizon
 	// EDS filter on the endpoints
-	if b.push.NetworkGateways().IsMultiNetworkEnabled() {
+	if b.push.NetworkManager().IsMultiNetworkEnabled() {
 		llbOpts = b.EndpointsByNetworkFilter(llbOpts)
 	}
 	if model.IsDNSSrvSubsetKey(b.clusterName) {

--- a/pilot/pkg/xds/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoint_builder.go
@@ -98,7 +98,7 @@ func NewEndpointBuilder(clusterName string, proxy *model.Proxy, push *model.Push
 		hostname:   hostname,
 		port:       port,
 	}
-	if b.push.NetworkGateways().IsMultiNetworkEnabled() || model.IsDNSSrvSubsetKey(clusterName) {
+	if b.push.NetworkManager().IsMultiNetworkEnabled() || model.IsDNSSrvSubsetKey(clusterName) {
 		// We only need this for multi-network, or for clusters meant for use with AUTO_PASSTHROUGH
 		// As an optimization, we skip this logic entirely for everything else.
 		b.mtlsChecker = newMtlsChecker(push, port, dr)

--- a/pilot/pkg/xds/ep_filters.go
+++ b/pilot/pkg/xds/ep_filters.go
@@ -66,7 +66,7 @@ func (b *EndpointBuilder) EndpointsByNetworkFilter(endpoints []*LocLbEndpointsAn
 			epNetwork := istioMetadata(lbEp, "network")
 			// This is a local endpoint or remote network endpoint
 			// but can be accessed directly from local network.
-			gatewaysForNetwork := b.push.NetworkGateways().ForNetwork(model.NetworkID(epNetwork))
+			gatewaysForNetwork := b.push.NetworkManager().GatewaysForNetwork(model.NetworkID(epNetwork))
 			if model.SameOrEmpty(b.network, epNetwork) || len(gatewaysForNetwork) == 0 {
 				// Copy on write.
 				clonedLbEp := proto.Clone(lbEp).(*endpoint.LbEndpoint)
@@ -99,7 +99,7 @@ func (b *EndpointBuilder) EndpointsByNetworkFilter(endpoints []*LocLbEndpointsAn
 		// we initiate mTLS automatically to this remote gateway. Split horizon to remote gateway cannot
 		// work with plaintext
 		for network, w := range remoteEps {
-			gateways := b.push.NetworkGateways().ForNetwork(model.NetworkID(network))
+			gateways := b.push.NetworkManager().GatewaysForNetwork(model.NetworkID(network))
 
 			gatewayNum := len(gateways)
 			weight := w * uint32(multiples/gatewayNum)
@@ -137,7 +137,7 @@ func (b *EndpointBuilder) EndpointsByNetworkFilter(endpoints []*LocLbEndpointsAn
 }
 
 func (b *EndpointBuilder) gatewaysByNetwork() map[model.NetworkID][]*model.NetworkGateway {
-	gateways := b.push.NetworkGateways().All()
+	gateways := b.push.NetworkManager().AllGateways()
 	byNetwork := make(map[model.NetworkID][]*model.NetworkGateway)
 	for _, gateway := range gateways {
 		networkGateways := append(byNetwork[gateway.Network], gateway)

--- a/pilot/pkg/xds/mesh_network_test.go
+++ b/pilot/pkg/xds/mesh_network_test.go
@@ -95,7 +95,7 @@ func TestNetworkGatewayUpdates(t *testing.T) {
 			t.Fatal(err)
 		}
 		if err := retry.Until(func() bool {
-			return len(s.PushContext().NetworkGateways().ForNetwork("network-1")) == 1
+			return len(s.PushContext().NetworkManager().GatewaysForNetwork("network-1")) == 1
 		}); err != nil {
 			t.Fatal("push context did not reinitialize with gateways; xds event may not have been triggred")
 		}


### PR DESCRIPTION
`NetworkGateways` implies a simpler collection than this is. `NetworkManager` can also allow us to expand the interface to provide a one-stop-shop for all networking related queries.

Also cleaning up the internal storage to reduce the total number of maps.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.