### PR TITLE
[tf] Use intersection of available injection templates in test framework

### DIFF
--- a/pilot/pkg/util/sets/string.go
+++ b/pilot/pkg/util/sets/string.go
@@ -73,6 +73,21 @@ func (s Set) Difference(s2 Set) Set {
 	return result
 }
 
+// Intersection returns a set of objects that are common between s and s2
+// For example:
+// s = {a1, a2, a3}
+// s2 = {a1, a2, a4, a5}
+// s.Intersection(s2) = {a1, a2}
+func (s Set) Intersection(s2 Set) Set {
+	result := NewSet()
+	for key := range s {
+		if _, exist := s2[key]; exist {
+			result.Insert(key)
+		}
+	}
+	return result
+}
+
 // SupersetOf returns true if s contains all elements of s2
 // For example:
 // s = {a1, a2, a3}
@@ -118,4 +133,9 @@ func (s Set) Equals(other Set) bool {
 	}
 
 	return true
+}
+
+// Empty returns whether the set is the empty set.
+func (s Set) Empty() bool {
+	return len(s) == 0
 }

--- a/pilot/pkg/util/sets/string_test.go
+++ b/pilot/pkg/util/sets/string_test.go
@@ -70,6 +70,27 @@ func TestDifference(t *testing.T) {
 	}
 }
 
+func TestIntersection(t *testing.T) {
+	elements := []string{"a", "b", "d"}
+	s1 := NewSet(elements...)
+
+	elements2 := []string{"a", "b", "c"}
+	s2 := NewSet(elements2...)
+
+	d := s1.Intersection(s2)
+
+	if len(d) != 2 {
+		t.Errorf("Expected len=2: %d", len(d))
+	}
+
+	if _, exist := d["a"]; !exist {
+		t.Errorf("a is not in %v", d)
+	}
+	if _, exist := d["b"]; !exist {
+		t.Errorf("b is not in %v", d)
+	}
+}
+
 func TestSupersetOf(t *testing.T) {
 	elements := []string{"a", "b", "c", "d"}
 	s1 := NewSet(elements...)


### PR DESCRIPTION
When testing with multiple versions we should just take the intersection of injection templates available across revisions and deploy / not deploy based on that.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
