### PR TITLE
add a new test target for fuzz integration tests

### DIFF
--- a/tests/integration/tests.mk
+++ b/tests/integration/tests.mk
@@ -77,6 +77,12 @@ test.integration.%.kube: | $(JUNIT_REPORT) check-go-tag
 	${_INTEGRATION_TEST_FLAGS} ${_INTEGRATION_TEST_SELECT_FLAGS} \
 	2>&1 | tee >($(JUNIT_REPORT) > $(JUNIT_OUT))
 
+# Generate integration fuzz test targets for kubernetes environment.
+test.integration-fuzz.%.kube: | $(JUNIT_REPORT) check-go-tag
+	PATH=${PATH}:${ISTIO_OUT} $(GO) test -p 1 -vet=off ${T} -tags="integfuzz integ" ./tests/integration/$(subst .,/,$*)/... -timeout 30m \
+	${_INTEGRATION_TEST_FLAGS} ${_INTEGRATION_TEST_SELECT_FLAGS} \
+	2>&1 | tee >($(JUNIT_REPORT) > $(JUNIT_OUT))
+
 # Generate presubmit integration test targets for each component in kubernetes environment
 test.integration.%.kube.presubmit:
 	@make test.integration.$*.kube


### PR DESCRIPTION
The target will later be used to add postsubmit or periodic job for the fuzz test.

related: https://github.com/istio/test-infra/pull/3402

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.