### PR TITLE
ext-authz: add e2e tests for related header options in authz extension provider

### DIFF
--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -154,7 +154,7 @@ spec:
 {{- end }}
 {{- if $.IncludeExtAuthz }}
       - name: ext-authz
-        image: docker.io/istio/ext-authz:0.6
+        image: gcr.io/istio-testing/ext-authz:0.7
         imagePullPolicy: {{ $.PullPolicy }}
         ports:
         - containerPort: 8000

--- a/samples/extauthz/README.md
+++ b/samples/extauthz/README.md
@@ -83,3 +83,17 @@ Note that `a` is just a default value for testing. It can be changed with the fl
     $ kubectl delete -f ../sleep/sleep.yaml
     $ kubectl delete -f ext-authz.yaml
     ```
+
+## Advanced features
+
+The Ext Authz server supports the following advanced features that are useful for testing:
+
+- The ext authz server will add the `x-ext-authz-check-received` header to the user request. The content is the dump of
+  the check request it received from the ext-authz filter. This header is useful in verifying the ext-authz filter sending
+  the expected request to the ext authz server.
+
+- The ext authz server will add (or override if it already exists) the header `x-ext-authz-additional-header-override` to
+  the user request. The value of the header depends on the type of ext-authz server.
+  The ext authz HTTP server will set it to the value of the same `x-ext-authz-additional-header-override` header in the
+  check request. The ext authz gRPC server will set it to the constant value `grpc-additional-header-override-value`.
+  This header is useful in verifying the header override behavior in the ext-authz filter.

--- a/samples/extauthz/ext-authz.yaml
+++ b/samples/extauthz/ext-authz.yaml
@@ -46,7 +46,7 @@ spec:
         app: ext-authz
     spec:
       containers:
-      - image: docker.io/istio/ext-authz:0.6
+      - image: gcr.io/istio-testing/ext-authz:0.7
         imagePullPolicy: IfNotPresent
         name: ext-authz
         ports:

--- a/samples/extauthz/local-ext-authz.yaml
+++ b/samples/extauthz/local-ext-authz.yaml
@@ -70,7 +70,7 @@ spec:
         name: httpbin
         ports:
         - containerPort: 80
-      - image: docker.io/istio/ext-authz:0.5
+      - image: gcr.io/istio-testing/ext-authz:0.7
         imagePullPolicy: IfNotPresent
         name: ext-authz
         ports:

--- a/samples/extauthz/src/Makefile
+++ b/samples/extauthz/src/Makefile
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-HUB ?= docker.io/istio/ext-authz
-TAG ?= 0.6
+HUB ?= gcr.io/istio-testing/ext-authz
+TAG ?= 0.7
 
 build: main.go go.mod go.sum Dockerfile
 	docker build . -t $(HUB):$(TAG)

--- a/samples/extauthz/src/main.go
+++ b/samples/extauthz/src/main.go
@@ -17,6 +17,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -39,11 +40,14 @@ import (
 )
 
 const (
-	checkHeader   = "x-ext-authz"
-	allowedValue  = "allow"
-	resultHeader  = "x-ext-authz-check-result"
-	resultAllowed = "allowed"
-	resultDenied  = "denied"
+	checkHeader       = "x-ext-authz"
+	allowedValue      = "allow"
+	resultHeader      = "x-ext-authz-check-result"
+	receivedHeader    = "x-ext-authz-check-received"
+	overrideHeader    = "x-ext-authz-additional-header-override"
+	overrideGRPCValue = "grpc-additional-header-override-value"
+	resultAllowed     = "allowed"
+	resultDenied      = "denied"
 )
 
 var (
@@ -87,6 +91,18 @@ func (s *extAuthzServerV2) Check(ctx context.Context, request *authv2.CheckReque
 								Value: resultAllowed,
 							},
 						},
+						{
+							Header: &corev2.HeaderValue{
+								Key:   receivedHeader,
+								Value: request.GetAttributes().String(),
+							},
+						},
+						{
+							Header: &corev2.HeaderValue{
+								Key:   overrideHeader,
+								Value: overrideGRPCValue,
+							},
+						},
 					},
 				},
 			},
@@ -105,6 +121,18 @@ func (s *extAuthzServerV2) Check(ctx context.Context, request *authv2.CheckReque
 						Header: &corev2.HeaderValue{
 							Key:   resultHeader,
 							Value: resultDenied,
+						},
+					},
+					{
+						Header: &corev2.HeaderValue{
+							Key:   receivedHeader,
+							Value: request.GetAttributes().String(),
+						},
+					},
+					{
+						Header: &corev2.HeaderValue{
+							Key:   overrideHeader,
+							Value: overrideGRPCValue,
 						},
 					},
 				},
@@ -132,6 +160,18 @@ func (s *extAuthzServerV3) Check(ctx context.Context, request *authv3.CheckReque
 								Value: resultAllowed,
 							},
 						},
+						{
+							Header: &corev3.HeaderValue{
+								Key:   receivedHeader,
+								Value: request.GetAttributes().String(),
+							},
+						},
+						{
+							Header: &corev3.HeaderValue{
+								Key:   overrideHeader,
+								Value: overrideGRPCValue,
+							},
+						},
 					},
 				},
 			},
@@ -152,6 +192,18 @@ func (s *extAuthzServerV3) Check(ctx context.Context, request *authv3.CheckReque
 							Value: resultDenied,
 						},
 					},
+					{
+						Header: &corev3.HeaderValue{
+							Key:   receivedHeader,
+							Value: request.GetAttributes().String(),
+						},
+					},
+					{
+						Header: &corev3.HeaderValue{
+							Key:   overrideHeader,
+							Value: overrideGRPCValue,
+						},
+					},
 				},
 			},
 		},
@@ -161,14 +213,22 @@ func (s *extAuthzServerV3) Check(ctx context.Context, request *authv3.CheckReque
 
 // ServeHTTP implements the HTTP check request.
 func (s *ExtAuthzServer) ServeHTTP(response http.ResponseWriter, request *http.Request) {
-	l := fmt.Sprintf("%s %s%s, headers: %v\n", request.Method, request.Host, request.URL, request.Header)
+	body, err := ioutil.ReadAll(request.Body)
+	if err != nil {
+		log.Printf("[HTTP] read body failed: %v", err)
+	}
+	l := fmt.Sprintf("%s %s%s, headers: %v, body: [%s]\n", request.Method, request.Host, request.URL, request.Header, body)
 	if allowedValue == request.Header.Get(checkHeader) {
 		log.Printf("[HTTP][allowed]: %s", l)
 		response.Header().Set(resultHeader, resultAllowed)
+		response.Header().Set(overrideHeader, request.Header.Get(overrideHeader))
+		response.Header().Set(receivedHeader, l)
 		response.WriteHeader(http.StatusOK)
 	} else {
 		log.Printf("[HTTP][denied]: %s", l)
 		response.Header().Set(resultHeader, resultDenied)
+		response.Header().Set(overrideHeader, request.Header.Get(overrideHeader))
+		response.Header().Set(receivedHeader, l)
 		response.WriteHeader(http.StatusForbidden)
 		response.Write([]byte(denyBody))
 	}

--- a/tests/integration/security/main_test.go
+++ b/tests/integration/security/main_test.go
@@ -75,7 +75,12 @@ meshConfig:
       service: %q
       port: 8000
       pathPrefix: "/check"
-      includeHeadersInCheck: ["x-ext-authz"]
+      headersToUpstreamOnAllow: ["x-ext-authz-*"]
+      headersToDownstreamOnDeny: ["x-ext-authz-*"]
+      includeRequestHeadersInCheck: ["x-ext-authz"]
+      includeAdditionalHeadersInCheck:
+        x-ext-authz-additional-header-new: additional-header-new-value
+        x-ext-authz-additional-header-override: additional-header-override-value
   - name: "ext-authz-grpc"
     envoyExtAuthzGrpc:
       service: %q
@@ -85,7 +90,12 @@ meshConfig:
       service: ext-authz-http.local
       port: 8000
       pathPrefix: "/check"
-      includeHeadersInCheck: ["x-ext-authz"]
+      headersToUpstreamOnAllow: ["x-ext-authz-*"]
+      headersToDownstreamOnDeny: ["x-ext-authz-*"]
+      includeRequestHeadersInCheck: ["x-ext-authz"]
+      includeAdditionalHeadersInCheck:
+        x-ext-authz-additional-header-new: additional-header-new-value
+        x-ext-authz-additional-header-override: additional-header-override-value
   - name: "ext-authz-grpc-local"
     envoyExtAuthzGrpc:
       service: ext-authz-grpc.local


### PR DESCRIPTION
This PR extends the sample ext-authz server and add new e2e tests to cover the new `headersToUpstreamOnAllow`, `headersToDownstreamOnDeny` and `includeAdditionalHeadersInCheck` options in the extension provider.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[x] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.