### PR TITLE
fix: send reponse error cannot continue to log debug

### DIFF
--- a/security/pkg/stsservice/server/server.go
+++ b/security/pkg/stsservice/server/server.go
@@ -196,6 +196,7 @@ func (s *Server) sendSuccessfulResponse(w http.ResponseWriter, tokenData []byte)
 	w.WriteHeader(http.StatusOK)
 	if _, err := w.Write(tokenData); err != nil {
 		stsServerLog.Errorf("failure in sending STS success response: %v", err)
+		return
 	}
 	stsServerLog.Debug("sent out STS success response")
 }


### PR DESCRIPTION

**when `sendSuccessfulResponse` failed, we cannot continue to print debug logs `sent out STS success response`**


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.