### PR TITLE
Add support for env var override of gcp quota project

### DIFF
--- a/pkg/bootstrap/platform/gcp.go
+++ b/pkg/bootstrap/platform/gcp.go
@@ -45,8 +45,12 @@ const (
 	GCPQuotaProject      = "gcp_quota_project"
 )
 
-var GCPMetadata = env.RegisterStringVar("GCP_METADATA", "", "Pipe separted GCP metadata, schemed as PROJECT_ID|PROJECT_NUMBER|CLUSTER_NAME|CLUSTER_ZONE").Get()
-var GCPQuotaProjectVar = env.RegisterStringVar("GCP_QUOTA_PROJECT", "", "Allows specification of a quota project to be used in requests to GCP APIs.").Get()
+var (
+	GCPMetadata = env.RegisterStringVar("GCP_METADATA", "", "Pipe separted GCP metadata, schemed as PROJECT_ID|PROJECT_NUMBER|CLUSTER_NAME|CLUSTER_ZONE").Get()
+
+	// GCPQuotaProjectVar holds the value of the `GCP_QUOTA_PROJECT` environment variable.
+	GCPQuotaProjectVar = env.RegisterStringVar("GCP_QUOTA_PROJECT", "", "Allows specification of a quota project to be used in requests to GCP APIs.").Get()
+)
 
 var (
 	shouldFillMetadata = metadata.OnGCE

--- a/pkg/bootstrap/platform/gcp.go
+++ b/pkg/bootstrap/platform/gcp.go
@@ -46,7 +46,7 @@ const (
 )
 
 var GCPMetadata = env.RegisterStringVar("GCP_METADATA", "", "Pipe separted GCP metadata, schemed as PROJECT_ID|PROJECT_NUMBER|CLUSTER_NAME|CLUSTER_ZONE").Get()
-var gcpQuotaProjectVar = env.RegisterStringVar("GCP_QUOTA_PROJECT", "", "Allows specification of a quota project to be used in requests to GCP APIs.")
+var GCPQuotaProjectVar = env.RegisterStringVar("GCP_QUOTA_PROJECT", "", "Allows specification of a quota project to be used in requests to GCP APIs.").Get()
 
 var (
 	shouldFillMetadata = metadata.OnGCE
@@ -165,8 +165,8 @@ func (e *gcpEnv) Metadata() map[string]string {
 	} else if cn, err := clusterNameFn(); err == nil {
 		md[GCPCluster] = cn
 	}
-	if gcpQuotaProjectVar.Get() != "" {
-		md[GCPQuotaProject] = gcpQuotaProjectVar.Get()
+	if GCPQuotaProjectVar != "" {
+		md[GCPQuotaProject] = GCPQuotaProjectVar
 	}
 	// Exit early now if not on GCE. This allows setting env var when not on GCE.
 	if !shouldFillMetadata() {

--- a/pkg/bootstrap/platform/gcp.go
+++ b/pkg/bootstrap/platform/gcp.go
@@ -42,9 +42,11 @@ const (
 	GCEInstanceID        = "gcp_gce_instance_id"
 	GCEInstanceTemplate  = "gcp_gce_instance_template"
 	GCEInstanceCreatedBy = "gcp_gce_instance_created_by"
+	GCPQuotaProject      = "gcp_quota_project"
 )
 
 var GCPMetadata = env.RegisterStringVar("GCP_METADATA", "", "Pipe separted GCP metadata, schemed as PROJECT_ID|PROJECT_NUMBER|CLUSTER_NAME|CLUSTER_ZONE").Get()
+var gcpQuotaProjectVar = env.RegisterStringVar("GCP_QUOTA_PROJECT", "", "Allows specification of a quota project to be used in requests to GCP APIs.")
 
 var (
 	shouldFillMetadata = metadata.OnGCE
@@ -162,6 +164,9 @@ func (e *gcpEnv) Metadata() map[string]string {
 		md[GCPCluster] = envCN
 	} else if cn, err := clusterNameFn(); err == nil {
 		md[GCPCluster] = cn
+	}
+	if gcpQuotaProjectVar.Get() != "" {
+		md[GCPQuotaProject] = gcpQuotaProjectVar.Get()
 	}
 	// Exit early now if not on GCE. This allows setting env var when not on GCE.
 	if !shouldFillMetadata() {

--- a/pkg/bootstrap/platform/gcp_test.go
+++ b/pkg/bootstrap/platform/gcp_test.go
@@ -273,7 +273,12 @@ func TestGCPQuotaProject(t *testing.T) {
 	for _, v := range cases {
 		t.Run(v.name, func(tt *testing.T) {
 			shouldFillMetadata = func() bool { return true }
-			os.Setenv("GCP_QUOTA_PROJECT", v.quotaProject)
+			tmpQuotaProject := GCPQuotaProjectVar
+			GCPQuotaProjectVar = v.quotaProject
+			defer func() {
+				GCPQuotaProjectVar = tmpQuotaProject
+				shouldFillMetadata = metadata.OnGCE
+			}()
 			meta := NewGCP().Metadata()
 			val, found := meta[GCPQuotaProject]
 			if got, want := found, v.wantFound; got != want {
@@ -282,8 +287,6 @@ func TestGCPQuotaProject(t *testing.T) {
 			if got, want := val, v.wantProject; got != want {
 				tt.Errorf("Incorrect value for GCPQuotaProject; got = %q, want = %q", got, want)
 			}
-			os.Unsetenv("GCP_QUOTA_PROJECT")
-			shouldFillMetadata = metadata.OnGCE
 		})
 	}
 }

--- a/pkg/bootstrap/platform/gcp_test.go
+++ b/pkg/bootstrap/platform/gcp_test.go
@@ -21,6 +21,8 @@ import (
 	"reflect"
 	"sync"
 	"testing"
+
+	"cloud.google.com/go/compute/metadata"
 )
 
 func TestGCPMetadata(t *testing.T) {
@@ -254,6 +256,34 @@ func TestGCPMetadata(t *testing.T) {
 				}
 			}
 			envOnce, envPid, envNpid, envCluster, envLocation = sync.Once{}, "", "", "", ""
+		})
+	}
+}
+
+func TestGCPQuotaProject(t *testing.T) {
+	cases := []struct {
+		name         string
+		quotaProject string
+		wantFound    bool
+		wantProject  string
+	}{
+		{"no value set", "", false, ""},
+		{"value set", "234234323", true, "234234323"},
+	}
+	for _, v := range cases {
+		t.Run(v.name, func(tt *testing.T) {
+			shouldFillMetadata = func() bool { return true }
+			os.Setenv("GCP_QUOTA_PROJECT", v.quotaProject)
+			meta := NewGCP().Metadata()
+			val, found := meta[GCPQuotaProject]
+			if got, want := found, v.wantFound; got != want {
+				tt.Errorf("Metadata() returned an unexpected value for GCPQuotaProject; found value: %t, want %t", got, want)
+			}
+			if got, want := val, v.wantProject; got != want {
+				tt.Errorf("Incorrect value for GCPQuotaProject; got = %q, want = %q", got, want)
+			}
+			os.Unsetenv("GCP_QUOTA_PROJECT")
+			shouldFillMetadata = metadata.OnGCE
 		})
 	}
 }


### PR DESCRIPTION
Sometimes, it is necessary to override the quota project for GCP (in addition to just the consumer project, as is done with GCP_METADATA). This PR provides a mechanism for that override.

[X] Policies and Telemetry
