### PR TITLE
Fix race in SDS tests

### DIFF
--- a/pilot/pkg/xds/fake.go
+++ b/pilot/pkg/xds/fake.go
@@ -74,6 +74,8 @@ type FakeOptions struct {
 
 	// Callback to modify the server before it is started
 	DiscoveryServerModifier func(s *DiscoveryServer)
+	// Callback to modify the kube client before it is started
+	KubeClientModifier func(c kubelib.Client)
 
 	// Time to debounce
 	// By default, set to 0s to speed up tests
@@ -136,6 +138,9 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 	}
 	for k8sCluster, objs := range k8sObjects {
 		client := kubelib.NewFakeClient(objs...)
+		if opts.KubeClientModifier != nil {
+			opts.KubeClientModifier(client)
+		}
 		k8s, _ := kube.NewFakeControllerWithOptions(kube.FakeControllerOptions{
 			ServiceHandler:  serviceHandler,
 			Client:          client,

--- a/pilot/pkg/xds/sds_test.go
+++ b/pilot/pkg/xds/sds_test.go
@@ -31,6 +31,7 @@ import (
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
 	"istio.io/istio/pilot/test/xdstest"
 	"istio.io/istio/pkg/config/schema/gvk"
+	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/spiffe"
 )
 
@@ -352,9 +353,11 @@ func TestGenerate(t *testing.T) {
 func TestCaching(t *testing.T) {
 	s := NewFakeDiscoveryServer(t, FakeOptions{
 		KubernetesObjects: []runtime.Object{genericCert},
+		KubeClientModifier: func(c kube.Client) {
+			cc := c.Kube().(*fake.Clientset)
+			kubesecrets.DisableAuthorizationForTest(cc)
+		},
 	})
-	cc := s.KubeClient().Kube().(*fake.Clientset)
-	kubesecrets.DisableAuthorizationForTest(cc)
 	gen := s.Discovery.Generators[v3.SecretType]
 
 	fullPush := &model.PushRequest{Full: true}


### PR DESCRIPTION
Example:
https://prow.istio.io/view/gs/istio-prow/pr-logs/pull/batch/unit-tests_istio/1409552953903157248

The issue is the controller starts and then we mutate the reactor.
Instead, we mutate before starting.
```
980 runs so far, 0 failures (100.00% pass rate). 5.95599005s avg, 8.056962472s max, 2.234816493s min
```