### PR TITLE
Fix incorrect indexing in xds cache

### DIFF
--- a/pilot/pkg/model/xds_cache.go
+++ b/pilot/pkg/model/xds_cache.go
@@ -252,8 +252,8 @@ func (l *lruCache) Add(entry XdsCacheEntry, token CacheToken, value *discovery.R
 		l.assertUnchanged(k, cur.(cacheValue).value, value)
 	}
 	l.store.Add(k, toWrite)
-	indexConfig(l.configIndex, entry.Key(), entry)
-	indexType(l.typesIndex, entry.Key(), entry)
+	indexConfig(l.configIndex, k, entry)
+	indexType(l.typesIndex, k, entry)
 	size(l.store.Len())
 }
 
@@ -276,6 +276,8 @@ func (l *lruCache) Get(entry XdsCacheEntry) (*discovery.Resource, CacheToken, bo
 		// a new token. Subsequent writes must include it.
 		tok := CacheToken(l.nextToken.Inc())
 		l.store.Add(k, cacheValue{token: tok})
+		indexConfig(l.configIndex, k, entry)
+		indexType(l.typesIndex, k, entry)
 		return nil, tok, false
 	}
 	cv := val.(cacheValue)


### PR DESCRIPTION
When we generate a token, we do not add it to the indexes. This means
its not properly invalidated. This leads to the following sequence of
events:

* Generate token 1, while endpoint state is v1
* Endpoint update to v2. Invalidate cache // BUG - token 1 is not removed since its not in the index
* Write token 1 at v1
* Fetch token 1, while endpoint state is v2
* Write token 1 at v2 // This triggers the assertion, as the cache should not mutate

With the fix:


* Generate token 1, while endpoint state is v1
* Endpoint update to v2. Invalidate cache
* Write token 1 at v1 // SKIPPED - invalidated
* Fetch token 1, while endpoint state is v2
* Write token 1 at v2 // This triggers the assertion, as the cache should not mutate

