### PR TITLE
Disable autoscaling in integration tests

### DIFF
--- a/pkg/test/framework/components/istio/eastwest.go
+++ b/pkg/test/framework/components/istio/eastwest.go
@@ -80,6 +80,7 @@ func (i *operatorComponent) deployEastWestGateway(cluster cluster.Cluster, revis
 		"--set", "hub=" + imgSettings.Hub,
 		"--set", "tag=" + imgSettings.Tag,
 		"--set", "values.global.imagePullPolicy=" + imgSettings.PullPolicy,
+		"--set", "values.gateways.istio-ingressgateway.autoscaleEnabled=false",
 		"-f", iopFile,
 	}
 	if revision != "" {

--- a/tests/integration/iop-integration-test-defaults.yaml
+++ b/tests/integration/iop-integration-test-defaults.yaml
@@ -53,6 +53,7 @@ spec:
             memory: 40Mi
 
     pilot:
+      autoscaleEnabled: false
       env:
         UNSAFE_ENABLE_ADMIN_ENDPOINTS: true
         PILOT_ENABLE_CROSS_CLUSTER_WORKLOAD_ENTRY: true
@@ -61,13 +62,13 @@ spec:
 
     gateways:
       istio-ingressgateway:
-        autoscaleMax: 1
+        autoscaleEnabled: false
         resources:
           requests:
             cpu: 10m
             memory: 40Mi
       istio-egressgateway:
-        autoscaleMax: 1
+        autoscaleEnabled: false
         resources:
           requests:
             cpu: 10m


### PR DESCRIPTION
This was disabled only for ingress/egress, not istiod or eastwest.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.