### PR TITLE
Remove duplicate judgment for debug log enable

### DIFF
--- a/galley/pkg/config/source/inmemory/collection.go
+++ b/galley/pkg/config/source/inmemory/collection.go
@@ -116,7 +116,7 @@ func (c *Collection) Clear() {
 
 func (c *Collection) dispatchEvent(e event.Event) {
 	if scope.Source.DebugEnabled() {
-		scope.Source.Debugf(">>> Collection.dispatchEvent: (col: %-50s): %v", c.schema.Name(), e)
+		scope.Source.Debugf("Collection.dispatchEvent: (col: %-50s): %v", c.schema.Name(), e)
 	}
 	if c.handler != nil {
 		c.handler.Handle(e)

--- a/pilot/pkg/model/envoyfilter.go
+++ b/pilot/pkg/model/envoyfilter.go
@@ -79,9 +79,7 @@ func convertToEnvoyFilterWrapper(local *config.Config) *EnvoyFilterWrapper {
 		if cp.Patch == nil {
 			// Should be caught by validation, but sometimes its disabled and we don't want to crash
 			// as a result.
-			if log.DebugEnabled() {
-				log.Debugf("envoyfilter %v/%v discarded due to missing patch", local.Namespace, local.Name)
-			}
+			log.Debugf("envoyfilter %v/%v discarded due to missing patch", local.Namespace, local.Name)
 			continue
 		}
 		cpw := &EnvoyFilterConfigPatchWrapper{

--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -870,7 +870,7 @@ func (s *DiscoveryServer) startPush(req *model.PushRequest) {
 	if log.DebugEnabled() {
 		currentlyPending := s.pushQueue.Pending()
 		if currentlyPending != 0 {
-			log.Infof("Starting new push while %v were still pending", currentlyPending)
+			log.Debugf("Starting new push while %v were still pending", currentlyPending)
 		}
 	}
 	req.Start = time.Now()

--- a/pkg/adsc/adsc.go
+++ b/pkg/adsc/adsc.go
@@ -733,7 +733,7 @@ func (a *ADSC) handleCDS(ll []*cluster.Cluster) {
 	}
 	if adscLog.DebugEnabled() {
 		b, _ := json.MarshalIndent(ll, " ", " ")
-		adscLog.Info(string(b))
+		adscLog.Debugf(string(b))
 	}
 
 	a.mutex.Lock()
@@ -795,7 +795,7 @@ func (a *ADSC) handleEDS(eds []*endpoint.ClusterLoadAssignment) {
 	adscLog.Infof("eds: %d size=%d ep=%d", len(eds), edsSize, ep)
 	if adscLog.DebugEnabled() {
 		b, _ := json.MarshalIndent(eds, " ", " ")
-		adscLog.Info(string(b))
+		adscLog.Debugf(string(b))
 	}
 	if a.InitialLoad == 0 {
 		// first load - Envoy loads listeners after endpoints
@@ -843,7 +843,7 @@ func (a *ADSC) handleRDS(configurations []*route.RouteConfiguration) {
 
 	if adscLog.DebugEnabled() {
 		b, _ := json.MarshalIndent(configurations, " ", " ")
-		adscLog.Info(string(b))
+		adscLog.Debugf(string(b))
 	}
 
 	a.mutex.Lock()

--- a/security/pkg/nodeagent/plugin/providers/google/stsclient/stsclient.go
+++ b/security/pkg/nodeagent/plugin/providers/google/stsclient/stsclient.go
@@ -108,10 +108,11 @@ func (p *SecureTokenServiceExchanger) requestWithRetry(reqBytes []byte) ([]byte,
 			break
 		}
 		monitoring.NumOutgoingRetries.With(monitoring.RequestType.Value(monitoring.TokenExchange)).Increment()
-		if !stsClientLog.DebugEnabled() {
+		if stsClientLog.DebugEnabled() {
+			stsClientLog.Debugf("token exchange request failed: status code %v, body %v", resp.StatusCode, string(body))
+		} else {
 			stsClientLog.Errorf("token exchange request failed: status code %v", resp.StatusCode)
 		}
-		stsClientLog.Debugf("token exchange request failed: status code %v, body %v", resp.StatusCode, string(body))
 		time.Sleep(p.backoff)
 	}
 	return nil, fmt.Errorf("exchange failed all retries, last error: %v", lastError)

--- a/security/pkg/stsservice/tokenmanager/google/tokenexchangeplugin.go
+++ b/security/pkg/stsservice/tokenmanager/google/tokenexchangeplugin.go
@@ -240,10 +240,8 @@ func (p *Plugin) constructFederatedTokenRequest(parameters security.StsRequestPa
 		dReq, _ := http.NewRequest("POST", federatedTokenEndpoint, bytes.NewBuffer(dJSONQuery))
 		dReq.Header.Set("Content-Type", contentType)
 
-		if pluginLog.DebugEnabled() {
-			reqDump, _ := httputil.DumpRequest(dReq, true)
-			pluginLog.Debugf("Prepared federated token request: \n%s", string(reqDump))
-		}
+		reqDump, _ := httputil.DumpRequest(dReq, true)
+		pluginLog.Debugf("Prepared federated token request: \n%s", string(reqDump))
 	} else {
 		pluginLog.Infof("Prepared federated token request for aud %q", aud)
 	}
@@ -472,7 +470,7 @@ func (p *Plugin) generateSTSRespInner(token string, expire int64) ([]byte, error
 	statusJSON, err := json.MarshalIndent(stsRespParam, "", " ")
 	if pluginLog.DebugEnabled() {
 		stsRespParam.AccessToken = "redacted"
-		pluginLog.Infof("Populated STS response parameters: %+v", stsRespParam)
+		pluginLog.Debugf("Populated STS response parameters: %+v", stsRespParam)
 	}
 	return statusJSON, err
 }


### PR DESCRIPTION
 Function Debugf has the same judgment on enable debug as DebugEnabled

```
func (s *Scope) Debugf(args ...interface{}) {
	if s.GetOutputLevel() >= DebugLevel {
            ......
	}
}

func (s *Scope) DebugEnabled() bool {
	return s.GetOutputLevel() >= DebugLevel
}
```

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ √] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
