### PR TITLE
routeConfiguration.vhost.name use empty string as wildcard

### DIFF
--- a/samples/bookinfo/policy/productpage_envoy_ratelimit.yaml
+++ b/samples/bookinfo/policy/productpage_envoy_ratelimit.yaml
@@ -70,7 +70,7 @@ spec:
         context: GATEWAY
         routeConfiguration:
           vhost:
-            name: "*:80"
+            name: ""
             route:
               action: ANY
       patch:


### PR DESCRIPTION
According to [routeMatch](https://github.com/istio/istio/blob/767767161b3b3350a30a4b7bb6b337857405c0ed/pilot/pkg/networking/core/v1alpha3/envoyfilter/rc_patch.go#L364), `routeConfiguration.vhost.name` use empty string as wildcard, not `"*:80`.

```go
func routeMatch(httpRoute *route.Route, rp *model.EnvoyFilterConfigPatchWrapper) bool {
...
	// check if httpRoute names match
	if match.Name != "" && match.Name != httpRoute.Name {
		return false
	}
```

If we specify it to `"*:80`, `routeMatch` will do exactly string check, which will failed all the time.

As this is used by gateway, we could set empty string to `routeConfiguration.vhost.name`, to match all `vhost.name`.

Related to #32381

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[X] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.