### PR TITLE
Minor fix to xds tests to support subtests

### DIFF
--- a/pilot/pkg/xds/ads_test.go
+++ b/pilot/pkg/xds/ads_test.go
@@ -84,14 +84,14 @@ func TestAdsReconnectAfterRestart(t *testing.T) {
 	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
 
 	ads := s.ConnectADS().WithType(v3.EndpointType)
-	res := ads.RequestResponseAck(&discovery.DiscoveryRequest{ResourceNames: []string{"fake-cluster"}})
+	res := ads.RequestResponseAck(t, &discovery.DiscoveryRequest{ResourceNames: []string{"fake-cluster"}})
 	// Close the connection and reconnect
 	ads.Cleanup()
 
 	ads = s.ConnectADS().WithType(v3.EndpointType)
 
 	// Reconnect with the same resources
-	ads.RequestResponseAck(&discovery.DiscoveryRequest{
+	ads.RequestResponseAck(t, &discovery.DiscoveryRequest{
 		ResourceNames: []string{"fake-cluster"},
 		ResponseNonce: res.Nonce,
 		VersionInfo:   res.VersionInfo,
@@ -102,32 +102,32 @@ func TestAdsUnsubscribe(t *testing.T) {
 	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
 
 	ads := s.ConnectADS().WithType(v3.EndpointType)
-	res := ads.RequestResponseAck(&discovery.DiscoveryRequest{ResourceNames: []string{"fake-cluster"}})
+	res := ads.RequestResponseAck(t, &discovery.DiscoveryRequest{ResourceNames: []string{"fake-cluster"}})
 
-	ads.Request(&discovery.DiscoveryRequest{
+	ads.Request(t, &discovery.DiscoveryRequest{
 		ResourceNames: nil,
 		ResponseNonce: res.Nonce,
 		VersionInfo:   res.VersionInfo,
 	})
-	ads.ExpectNoResponse()
+	ads.ExpectNoResponse(t)
 }
 
 // Regression for envoy restart and overlapping connections
 func TestAdsReconnect(t *testing.T) {
 	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
 	ads := s.ConnectADS().WithType(v3.ClusterType)
-	ads.RequestResponseAck(nil)
+	ads.RequestResponseAck(t, nil)
 
 	// envoy restarts and reconnects
 	ads2 := s.ConnectADS().WithType(v3.ClusterType)
-	ads2.RequestResponseAck(nil)
+	ads2.RequestResponseAck(t, nil)
 
 	// closes old process
 	ads.Cleanup()
 
 	// event happens, expect push to the remaining connection
 	xds.AdsPushAll(s.Discovery)
-	ads2.ExpectResponse()
+	ads2.ExpectResponse(t)
 }
 
 // Regression for connection with a bad ID
@@ -135,7 +135,7 @@ func TestAdsBadId(t *testing.T) {
 	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
 	ads := s.ConnectADS().WithID("").WithType(v3.ClusterType)
 	xds.AdsPushAll(s.Discovery)
-	ads.ExpectNoResponse()
+	ads.ExpectNoResponse(t)
 }
 
 func TestAdsClusterUpdate(t *testing.T) {
@@ -145,7 +145,7 @@ func TestAdsClusterUpdate(t *testing.T) {
 	version := ""
 	nonce := ""
 	sendEDSReqAndVerify := func(clusterName string) {
-		res := ads.RequestResponseAck(&discovery.DiscoveryRequest{
+		res := ads.RequestResponseAck(t, &discovery.DiscoveryRequest{
 			ResourceNames: []string{clusterName},
 			VersionInfo:   version,
 			ResponseNonce: nonce,
@@ -769,7 +769,7 @@ func TestAdsUpdate(t *testing.T) {
 		newEndpointWithAccount("10.2.0.1", "hello-sa", "v1"))
 
 	cluster := "outbound|2080||adsupdate.default.svc.cluster.local"
-	res := ads.RequestResponseAck(&discovery.DiscoveryRequest{
+	res := ads.RequestResponseAck(t, &discovery.DiscoveryRequest{
 		ResourceNames: []string{cluster},
 		TypeUrl:       v3.EndpointType,
 	})
@@ -787,28 +787,28 @@ func TestAdsUpdate(t *testing.T) {
 	// will trigger recompute and push for all clients - including some that may be closing
 	// This reproduced the 'push on closed connection' bug.
 	xds.AdsPushAll(s.Discovery)
-	res1 := ads.ExpectResponse()
+	res1 := ads.ExpectResponse(t)
 	xdstest.UnmarshalClusterLoadAssignment(t, res1.GetResources())
 }
 
 func TestEnvoyRDSProtocolError(t *testing.T) {
 	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
 	ads := s.ConnectADS().WithType(v3.RouteType)
-	ads.RequestResponseAck(&discovery.DiscoveryRequest{ResourceNames: []string{routeA}})
+	ads.RequestResponseAck(t, &discovery.DiscoveryRequest{ResourceNames: []string{routeA}})
 
 	xds.AdsPushAll(s.Discovery)
-	res := ads.ExpectResponse()
+	res := ads.ExpectResponse(t)
 
 	// send empty response and validate no response is returned.
-	ads.Request(&discovery.DiscoveryRequest{
+	ads.Request(t, &discovery.DiscoveryRequest{
 		ResourceNames: nil,
 		VersionInfo:   res.VersionInfo,
 		ResponseNonce: res.Nonce,
 	})
-	ads.ExpectNoResponse()
+	ads.ExpectNoResponse(t)
 
 	// Refresh routes
-	ads.Request(&discovery.DiscoveryRequest{
+	ads.Request(t, &discovery.DiscoveryRequest{
 		ResourceNames: []string{routeA, routeB},
 		VersionInfo:   res.VersionInfo,
 		ResponseNonce: res.Nonce,
@@ -824,65 +824,65 @@ func TestBlockedPush(t *testing.T) {
 		features.EnableFlowControl = true
 		s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
 		ads := s.ConnectADS().WithType(v3.ClusterType)
-		ads.RequestResponseAck(nil)
+		ads.RequestResponseAck(t, nil)
 		// Send push, get a response but do not ACK it
 		xds.AdsPushAll(s.Discovery)
-		res := ads.ExpectResponse()
+		res := ads.ExpectResponse(t)
 
 		// Another push results in no response as we are blocked
 		xds.AdsPushAll(s.Discovery)
-		ads.ExpectNoResponse()
+		ads.ExpectNoResponse(t)
 
 		// ACK, unblocking the previous push
-		ads.Request(&discovery.DiscoveryRequest{ResponseNonce: res.Nonce})
-		res = ads.ExpectResponse()
+		ads.Request(t, &discovery.DiscoveryRequest{ResponseNonce: res.Nonce})
+		res = ads.ExpectResponse(t)
 
 		// ACK again, ensure we do not response
-		ads.Request(&discovery.DiscoveryRequest{ResponseNonce: res.Nonce})
-		ads.ExpectNoResponse()
+		ads.Request(t, &discovery.DiscoveryRequest{ResponseNonce: res.Nonce})
+		ads.ExpectNoResponse(t)
 
 		// request new resources, expect response
-		ads.Request(&discovery.DiscoveryRequest{ResponseNonce: res.Nonce, ResourceNames: []string{"foo"}})
-		res = ads.ExpectResponse()
+		ads.Request(t, &discovery.DiscoveryRequest{ResponseNonce: res.Nonce, ResourceNames: []string{"foo"}})
+		res = ads.ExpectResponse(t)
 		// request new resources, expect response, even without explicit ACK
-		ads.Request(&discovery.DiscoveryRequest{ResponseNonce: res.Nonce, ResourceNames: []string{"foo", "bar"}})
-		ads.ExpectResponse()
+		ads.Request(t, &discovery.DiscoveryRequest{ResponseNonce: res.Nonce, ResourceNames: []string{"foo", "bar"}})
+		ads.ExpectResponse(t)
 	})
 	t.Run("flow control enabled NACK", func(t *testing.T) {
 		features.EnableFlowControl = true
 		s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
 		ads := s.ConnectADS().WithType(v3.ClusterType)
-		ads.RequestResponseAck(nil)
+		ads.RequestResponseAck(t, nil)
 
 		// Send push, get a response and NACK it
 		xds.AdsPushAll(s.Discovery)
-		res := ads.ExpectResponse()
-		ads.Request(&discovery.DiscoveryRequest{ResponseNonce: res.Nonce, ErrorDetail: &status.Status{Message: "Test request NACK"}})
+		res := ads.ExpectResponse(t)
+		ads.Request(t, &discovery.DiscoveryRequest{ResponseNonce: res.Nonce, ErrorDetail: &status.Status{Message: "Test request NACK"}})
 
 		// Another push results in a response as we are not blocked (NACK unblocks)
 		xds.AdsPushAll(s.Discovery)
-		ads.ExpectResponse()
+		ads.ExpectResponse(t)
 
 		// ACK should not get push
-		ads.Request(&discovery.DiscoveryRequest{ResponseNonce: res.Nonce})
-		ads.ExpectNoResponse()
+		ads.Request(t, &discovery.DiscoveryRequest{ResponseNonce: res.Nonce})
+		ads.ExpectNoResponse(t)
 	})
 	t.Run("flow control disabled", func(t *testing.T) {
 		features.EnableFlowControl = false
 		s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
 		ads := s.ConnectADS().WithType(v3.ClusterType)
-		ads.RequestResponseAck(nil)
+		ads.RequestResponseAck(t, nil)
 		// Send push, get a response but do not ACK it
 		xds.AdsPushAll(s.Discovery)
-		res := ads.ExpectResponse()
+		res := ads.ExpectResponse(t)
 
 		// Another push results in response as we do not care that we are blocked
 		xds.AdsPushAll(s.Discovery)
-		ads.ExpectResponse()
+		ads.ExpectResponse(t)
 
 		// ACK gets no response as we don't have flow control enabled
-		ads.Request(&discovery.DiscoveryRequest{ResponseNonce: res.Nonce})
-		ads.ExpectNoResponse()
+		ads.Request(t, &discovery.DiscoveryRequest{ResponseNonce: res.Nonce})
+		ads.ExpectNoResponse(t)
 	})
 }
 
@@ -896,23 +896,23 @@ func TestEnvoyRDSUpdatedRouteRequest(t *testing.T) {
 	}
 	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
 	ads := s.ConnectADS().WithType(v3.RouteType)
-	resp := ads.RequestResponseAck(&discovery.DiscoveryRequest{ResourceNames: []string{routeA}})
+	resp := ads.RequestResponseAck(t, &discovery.DiscoveryRequest{ResourceNames: []string{routeA}})
 	expectRoutes(resp, routeA)
 
 	xds.AdsPushAll(s.Discovery)
-	resp = ads.ExpectResponse()
+	resp = ads.ExpectResponse(t)
 	expectRoutes(resp, routeA)
 
 	// Test update from A -> B
-	resp = ads.RequestResponseAck(&discovery.DiscoveryRequest{ResourceNames: []string{routeB}})
+	resp = ads.RequestResponseAck(t, &discovery.DiscoveryRequest{ResourceNames: []string{routeB}})
 	expectRoutes(resp, routeB)
 
 	// Test update from B -> A, B
-	resp = ads.RequestResponseAck(&discovery.DiscoveryRequest{ResourceNames: []string{routeA, routeB}})
+	resp = ads.RequestResponseAck(t, &discovery.DiscoveryRequest{ResourceNames: []string{routeA, routeB}})
 	expectRoutes(resp, routeA, routeB)
 
 	// Test update from B, B -> A
-	resp = ads.RequestResponseAck(&discovery.DiscoveryRequest{ResourceNames: []string{routeA}})
+	resp = ads.RequestResponseAck(t, &discovery.DiscoveryRequest{ResourceNames: []string{routeA}})
 	expectRoutes(resp, routeA)
 }
 

--- a/pilot/pkg/xds/cds_test.go
+++ b/pilot/pkg/xds/cds_test.go
@@ -23,5 +23,5 @@ import (
 func TestCDS(t *testing.T) {
 	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
 	ads := s.ConnectADS().WithType(v3.ClusterType)
-	ads.RequestResponseAck(nil)
+	ads.RequestResponseAck(t, nil)
 }

--- a/pilot/pkg/xds/debug_test.go
+++ b/pilot/pkg/xds/debug_test.go
@@ -34,13 +34,13 @@ func TestSyncz(t *testing.T) {
 		s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
 		ads := s.ConnectADS()
 
-		ads.RequestResponseAck(&discovery.DiscoveryRequest{TypeUrl: v3.ClusterType})
-		ads.RequestResponseAck(&discovery.DiscoveryRequest{TypeUrl: v3.ListenerType})
-		ads.RequestResponseAck(&discovery.DiscoveryRequest{
+		ads.RequestResponseAck(t, &discovery.DiscoveryRequest{TypeUrl: v3.ClusterType})
+		ads.RequestResponseAck(t, &discovery.DiscoveryRequest{TypeUrl: v3.ListenerType})
+		ads.RequestResponseAck(t, &discovery.DiscoveryRequest{
 			TypeUrl:       v3.EndpointType,
 			ResourceNames: []string{"outbound|9080||app2.default.svc.cluster.local"},
 		})
-		ads.RequestResponseAck(&discovery.DiscoveryRequest{
+		ads.RequestResponseAck(t, &discovery.DiscoveryRequest{
 			TypeUrl:       v3.RouteType,
 			ResourceNames: []string{"80", "8080"},
 		})
@@ -52,13 +52,13 @@ func TestSyncz(t *testing.T) {
 		s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
 		ads := s.ConnectADS()
 
-		ads.RequestResponseNack(&discovery.DiscoveryRequest{TypeUrl: v3.ClusterType})
-		ads.RequestResponseNack(&discovery.DiscoveryRequest{TypeUrl: v3.ListenerType})
-		ads.RequestResponseNack(&discovery.DiscoveryRequest{
+		ads.RequestResponseNack(t, &discovery.DiscoveryRequest{TypeUrl: v3.ClusterType})
+		ads.RequestResponseNack(t, &discovery.DiscoveryRequest{TypeUrl: v3.ListenerType})
+		ads.RequestResponseNack(t, &discovery.DiscoveryRequest{
 			TypeUrl:       v3.EndpointType,
 			ResourceNames: []string{"outbound|9080||app2.default.svc.cluster.local"},
 		})
-		ads.RequestResponseNack(&discovery.DiscoveryRequest{
+		ads.RequestResponseNack(t, &discovery.DiscoveryRequest{
 			TypeUrl:       v3.RouteType,
 			ResourceNames: []string{"80", "8080"},
 		})
@@ -156,9 +156,9 @@ func TestConfigDump(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
 			ads := s.ConnectADS()
-			ads.RequestResponseAck(&discovery.DiscoveryRequest{TypeUrl: v3.ClusterType})
-			ads.RequestResponseAck(&discovery.DiscoveryRequest{TypeUrl: v3.ListenerType})
-			ads.RequestResponseAck(&discovery.DiscoveryRequest{
+			ads.RequestResponseAck(t, &discovery.DiscoveryRequest{TypeUrl: v3.ClusterType})
+			ads.RequestResponseAck(t, &discovery.DiscoveryRequest{TypeUrl: v3.ListenerType})
+			ads.RequestResponseAck(t, &discovery.DiscoveryRequest{
 				TypeUrl:       v3.RouteType,
 				ResourceNames: []string{"80", "8080"},
 			})

--- a/pilot/pkg/xds/ecds_test.go
+++ b/pilot/pkg/xds/ecds_test.go
@@ -30,7 +30,7 @@ func TestECDS(t *testing.T) {
 
 	ads := s.ConnectADS().WithType(v3.ExtensionConfigurationType)
 	wantExtensionConfigName := "extension-config"
-	res := ads.RequestResponseAck(&discovery.DiscoveryRequest{
+	res := ads.RequestResponseAck(t, &discovery.DiscoveryRequest{
 		Node: &corev3.Node{
 			Id: ads.ID,
 		},

--- a/pilot/pkg/xds/eds_sh_test.go
+++ b/pilot/pkg/xds/eds_sh_test.go
@@ -166,7 +166,7 @@ func verifySplitHorizonResponse(t *testing.T, s *xds.FakeDiscoveryServer, networ
 		"NETWORK":       {Kind: &structpb.Value_StringValue{StringValue: network}},
 	}}
 
-	ads.RequestResponseAck(&discovery.DiscoveryRequest{
+	ads.RequestResponseAck(t, &discovery.DiscoveryRequest{
 		Node: &core.Node{
 			Id:       ads.ID,
 			Metadata: metadata,
@@ -175,7 +175,7 @@ func verifySplitHorizonResponse(t *testing.T, s *xds.FakeDiscoveryServer, networ
 	})
 
 	clusterName := "outbound|1080||service5.default.svc.cluster.local"
-	res := ads.RequestResponseAck(&discovery.DiscoveryRequest{
+	res := ads.RequestResponseAck(t, &discovery.DiscoveryRequest{
 		Node: &core.Node{
 			Id:       ads.ID,
 			Metadata: metadata,

--- a/pilot/pkg/xds/eds_test.go
+++ b/pilot/pkg/xds/eds_test.go
@@ -817,7 +817,7 @@ func multipleRequest(s *xds.FakeDiscoveryServer, inc bool, nclients,
 	// be detected
 	// This is not using adsc, which consumes the events automatically.
 	ads := s.ConnectADS()
-	ads.Request(nil)
+	ads.Request(t, nil)
 
 	n := nclients
 	wg.Add(n)

--- a/pilot/pkg/xds/lds_test.go
+++ b/pilot/pkg/xds/lds_test.go
@@ -190,7 +190,7 @@ func TestLDS(t *testing.T) {
 	t.Run("sidecar", func(t *testing.T) {
 		s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
 		ads := s.ConnectADS().WithType(v3.ListenerType)
-		ads.RequestResponseAck(nil)
+		ads.RequestResponseAck(t, nil)
 	})
 
 	// 'router' or 'gateway' type of listener
@@ -199,7 +199,7 @@ func TestLDS(t *testing.T) {
 		// Matches Gateway config in test data
 		labels := map[string]string{"version": "v2", "app": "my-gateway-controller"}
 		ads := s.ConnectADS().WithType(v3.ListenerType).WithID(gatewayID(gatewayIP))
-		ads.RequestResponseAck(&discovery.DiscoveryRequest{
+		ads.RequestResponseAck(t, &discovery.DiscoveryRequest{
 			Node: &core.Node{
 				Id:       ads.ID,
 				Metadata: model.NodeMetadata{Labels: labels}.ToStruct(),

--- a/pilot/pkg/xds/nds_test.go
+++ b/pilot/pkg/xds/nds_test.go
@@ -79,7 +79,7 @@ func TestNDS(t *testing.T) {
 			})
 
 			ads := s.ConnectADS().WithType(v3.NameTableType)
-			res := ads.RequestResponseAck(&discovery.DiscoveryRequest{
+			res := ads.RequestResponseAck(t, &discovery.DiscoveryRequest{
 				Node: &corev3.Node{
 					Id:       ads.ID,
 					Metadata: tt.meta.ToStruct(),

--- a/pilot/pkg/xds/rds_test.go
+++ b/pilot/pkg/xds/rds_test.go
@@ -52,7 +52,7 @@ func TestRDS(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ads := s.ConnectADS().WithType(v3.RouteType).WithID(tt.node)
-			ads.RequestResponseAck(&discovery.DiscoveryRequest{ResourceNames: tt.routes})
+			ads.RequestResponseAck(t, &discovery.DiscoveryRequest{ResourceNames: tt.routes})
 		})
 	}
 }

--- a/pkg/istio-agent/agent_test.go
+++ b/pkg/istio-agent/agent_test.go
@@ -92,14 +92,14 @@ func TestAgent(t *testing.T) {
 	t.Run("Kubernetes defaults", func(t *testing.T) {
 		// XDS and CA are both using JWT authentication and TLS. Root certificates distributed in
 		// configmap to each namespace.
-		Setup(t).Check(security.WorkloadKeyCertResourceName, security.RootCertReqResourceName)
+		Setup(t).Check(t, security.WorkloadKeyCertResourceName, security.RootCertReqResourceName)
 	})
 	t.Run("RSA", func(t *testing.T) {
 		// All of the other tests use ECC for speed. Here we make sure RSA still works
 		Setup(t, func(a AgentTest) AgentTest {
 			a.Security.ECCSigAlg = ""
 			return a
-		}).Check(security.WorkloadKeyCertResourceName, security.RootCertReqResourceName)
+		}).Check(t, security.WorkloadKeyCertResourceName, security.RootCertReqResourceName)
 	})
 	t.Run("Kubernetes defaults output key and cert", func(t *testing.T) {
 		// same as "Kubernetes defaults", but also output the key and cert. This can be used for tools
@@ -109,7 +109,7 @@ func TestAgent(t *testing.T) {
 			a.Security.OutputKeyCertToDir = dir
 			a.Security.SecretRotationGracePeriodRatio = 1
 			return a
-		}).Check(security.WorkloadKeyCertResourceName, security.RootCertReqResourceName)
+		}).Check(t, security.WorkloadKeyCertResourceName, security.RootCertReqResourceName)
 
 		// Ensure we output the certs
 		checkCertsWritten(t, dir)
@@ -156,7 +156,7 @@ func TestAgent(t *testing.T) {
 			a.ProxyConfig.ProxyMetadata[MetadataClientRootCert] = filepath.Join(dir, "root-cert.pem")
 			a.Security.FileMountedCerts = true
 			return a
-		}).Check(cfg.GetRootResourceName(), cfg.GetResourceName())
+		}).Check(t, cfg.GetRootResourceName(), cfg.GetResourceName())
 	})
 	t.Run("Implicit file mounted certs", func(t *testing.T) {
 		// User mounts certificates in /etc/certs (hardcoded path). CA communication is disabled.
@@ -171,7 +171,7 @@ func TestAgent(t *testing.T) {
 			// Ensure we don't try to connect to CA
 			a.CaAuthenticator.Set("", "")
 			return a
-		}).Check(security.WorkloadKeyCertResourceName, security.RootCertReqResourceName)
+		}).Check(t, security.WorkloadKeyCertResourceName, security.RootCertReqResourceName)
 	})
 	t.Run("VMs", func(t *testing.T) {
 		// Bootstrap sets up a short lived JWT token and root certificate. The initial run will fetch
@@ -185,12 +185,12 @@ func TestAgent(t *testing.T) {
 				a.Security.ProvCert = dir
 				return a
 			})
-			a.Check(security.WorkloadKeyCertResourceName, security.RootCertReqResourceName)
+			a.Check(t, security.WorkloadKeyCertResourceName, security.RootCertReqResourceName)
 
 			// Switch out our auth to only allow mTLS. In practice, the real server would allow JWT, but we
 			// don't have a good way to expire JWTs here. Instead, we just deny all JWTs to ensure mTLS is used
 			a.CaAuthenticator.Set("", filepath.Join(dir, "cert-chain.pem"))
-			a.Check(security.WorkloadKeyCertResourceName, security.RootCertReqResourceName)
+			a.Check(t, security.WorkloadKeyCertResourceName, security.RootCertReqResourceName)
 		})
 		t.Run("reboot", func(t *testing.T) {
 			// Switch the JWT to a bogus path, to simulate the VM being rebooted
@@ -203,8 +203,8 @@ func TestAgent(t *testing.T) {
 				return a
 			})
 			// Ensure we can still make requests
-			a.Check(security.WorkloadKeyCertResourceName, security.RootCertReqResourceName)
-			a.Check(security.WorkloadKeyCertResourceName, security.RootCertReqResourceName)
+			a.Check(t, security.WorkloadKeyCertResourceName, security.RootCertReqResourceName)
+			a.Check(t, security.WorkloadKeyCertResourceName, security.RootCertReqResourceName)
 		})
 	})
 	t.Run("VMs to etc/certs", func(t *testing.T) {
@@ -224,7 +224,7 @@ func TestAgent(t *testing.T) {
 			a.Security.SecretRotationGracePeriodRatio = 1
 			return a
 		})
-		sds := a.Check(security.WorkloadKeyCertResourceName, security.RootCertReqResourceName)
+		sds := a.Check(t, security.WorkloadKeyCertResourceName, security.RootCertReqResourceName)
 
 		// Ensure we output the certs
 		checkCertsWritten(t, dir)
@@ -248,7 +248,7 @@ func TestAgent(t *testing.T) {
 			a.Security.ProvCert = dir
 			a.Security.SecretRotationGracePeriodRatio = 1
 			return a
-		}).Check(security.WorkloadKeyCertResourceName, security.RootCertReqResourceName)
+		}).Check(t, security.WorkloadKeyCertResourceName, security.RootCertReqResourceName)
 
 		// The provisioning certificates should not be touched
 		go sds[security.WorkloadKeyCertResourceName].DrainResponses()
@@ -268,7 +268,7 @@ func TestAgent(t *testing.T) {
 			a.Security.ProvCert = dir
 			a.Security.SecretRotationGracePeriodRatio = 1
 			return a
-		}).Check(security.WorkloadKeyCertResourceName, security.RootCertReqResourceName)
+		}).Check(t, security.WorkloadKeyCertResourceName, security.RootCertReqResourceName)
 
 		// The provisioning certificates should not be touched
 		go sds[security.WorkloadKeyCertResourceName].DrainResponses()
@@ -281,7 +281,7 @@ func TestAgent(t *testing.T) {
 			a.CaAuthenticator.Set("some-token", "")
 			a.Security.TokenExchanger = camock.NewMockTokenExchangeServer(map[string]string{"fake": "some-token"})
 			return a
-		}).Check(security.WorkloadKeyCertResourceName, security.RootCertReqResourceName)
+		}).Check(t, security.WorkloadKeyCertResourceName, security.RootCertReqResourceName)
 	})
 	t.Run("Token exchange with credential fetcher", func(t *testing.T) {
 		// This is used with platform credentials, where the platform provides some underlying
@@ -299,7 +299,7 @@ func TestAgent(t *testing.T) {
 			return a
 		})
 
-		a.Check(security.WorkloadKeyCertResourceName, security.RootCertReqResourceName)
+		a.Check(t, security.WorkloadKeyCertResourceName, security.RootCertReqResourceName)
 	})
 	t.Run("Token exchange with credential fetcher downtime", func(t *testing.T) {
 		// This ensures our pre-warming is resilient to temporary downtime of the CA
@@ -333,7 +333,7 @@ func TestAgent(t *testing.T) {
 			a.CaAuthenticator.Set("some-token", "")
 		}()
 
-		a.Check(security.WorkloadKeyCertResourceName, security.RootCertReqResourceName)
+		a.Check(t, security.WorkloadKeyCertResourceName, security.RootCertReqResourceName)
 	})
 	envoyReady := func(t test.Failer, name string, port int) {
 		retry.UntilSuccessOrFail(t, func() error {
@@ -353,7 +353,7 @@ func TestAgent(t *testing.T) {
 			a.AgentConfig.EnvoyStatusPort = 15021
 			a.AgentConfig.ProxyXDSDebugViaAgent = false // uses a fixed port
 			return a
-		}).Check(security.WorkloadKeyCertResourceName, security.RootCertReqResourceName)
+		}).Check(t, security.WorkloadKeyCertResourceName, security.RootCertReqResourceName)
 		envoyReady(t, "first agent", 15000)
 		Setup(t, func(a AgentTest) AgentTest {
 			a.envoyEnable = true
@@ -363,7 +363,7 @@ func TestAgent(t *testing.T) {
 			a.AgentConfig.EnvoyStatusPort = 25021
 			a.AgentConfig.ProxyXDSDebugViaAgent = false // uses a fixed port
 			return a
-		}).Check(security.WorkloadKeyCertResourceName, security.RootCertReqResourceName)
+		}).Check(t, security.WorkloadKeyCertResourceName, security.RootCertReqResourceName)
 		envoyReady(t, "second agent", 25000)
 	})
 	t.Run("Envoy bootstrap discovery", func(t *testing.T) {
@@ -375,7 +375,7 @@ func TestAgent(t *testing.T) {
 			a.AgentConfig.EnvoyStatusPort = 15021
 			a.AgentConfig.EnableDynamicBootstrap = true
 			return a
-		}).Check(security.WorkloadKeyCertResourceName, security.RootCertReqResourceName)
+		}).Check(t, security.WorkloadKeyCertResourceName, security.RootCertReqResourceName)
 		envoyReady(t, "bootstrap discovery", 15000)
 	})
 	t.Run("gRPC XDS bootstrap", func(t *testing.T) {
@@ -397,7 +397,6 @@ func TestAgent(t *testing.T) {
 }
 
 type AgentTest struct {
-	t                *testing.T
 	ProxyConfig      meshconfig.ProxyConfig
 	Security         security.Options
 	AgentConfig      AgentOptions
@@ -412,7 +411,6 @@ type AgentTest struct {
 func Setup(t *testing.T, opts ...func(a AgentTest) AgentTest) *AgentTest {
 	d := t.TempDir()
 	resp := AgentTest{
-		t:                t,
 		XdsAuthenticator: security.NewFakeAuthenticator("xds").Set("fake", ""),
 		CaAuthenticator:  security.NewFakeAuthenticator("ca").Set("fake", ""),
 	}
@@ -482,33 +480,33 @@ func Setup(t *testing.T, opts ...func(a AgentTest) AgentTest) *AgentTest {
 	return &resp
 }
 
-func (a *AgentTest) Check(expectedSDS ...string) map[string]*xds.AdsTest {
+func (a *AgentTest) Check(t *testing.T, expectedSDS ...string) map[string]*xds.AdsTest {
 	// Ensure we can send XDS requests
-	meta := proxyConfigToMetadata(a.t, a.ProxyConfig)
+	meta := proxyConfigToMetadata(t, a.ProxyConfig)
 
 	// We add a retry around XDS since some of the auth methods are eventually consistent, relying on
 	// the CSR flow to complete first. This mirrors Envoy, which will also retry indefinitely
 	var resp *discovery.DiscoveryResponse
-	retry.UntilSuccessOrFail(a.t, func() error {
+	retry.UntilSuccessOrFail(t, func() error {
 		return test.Wrap(func(t test.Failer) {
 			conn := setupDownstreamConnectionUDS(t, a.AgentConfig.XdsUdsPath)
 			xdsc := xds.NewAdsTest(t, conn).WithMetadata(meta)
-			resp = xdsc.RequestResponseAck(nil)
+			resp = xdsc.RequestResponseAck(t, nil)
 		})
 	}, retry.Timeout(time.Second*15), retry.Delay(time.Millisecond*200))
 
 	sdsStreams := map[string]*xds.AdsTest{}
 	gotKeys := []string{}
-	for _, res := range xdstest.ExtractSecretResources(a.t, resp.Resources) {
-		sds := xds.NewSdsTest(a.t, setupDownstreamConnectionUDS(a.t, a.Security.WorkloadUDSPath)).
+	for _, res := range xdstest.ExtractSecretResources(t, resp.Resources) {
+		sds := xds.NewSdsTest(t, setupDownstreamConnectionUDS(t, a.Security.WorkloadUDSPath)).
 			WithMetadata(meta).
 			WithTimeout(time.Second * 20) // CSR can be extremely slow with race detection enabled due to 2048 RSA
-		sds.RequestResponseAck(&discovery.DiscoveryRequest{ResourceNames: []string{res}})
+		sds.RequestResponseAck(t, &discovery.DiscoveryRequest{ResourceNames: []string{res}})
 		sdsStreams[res] = sds
 		gotKeys = append(gotKeys, res)
 	}
 	if !reflect.DeepEqual(expectedSDS, gotKeys) {
-		a.t.Errorf("expected SDS resources %v got %v", expectedSDS, gotKeys)
+		t.Errorf("expected SDS resources %v got %v", expectedSDS, gotKeys)
 	}
 	return sdsStreams
 }

--- a/security/pkg/nodeagent/sds/sdsservice_test.go
+++ b/security/pkg/nodeagent/sds/sdsservice_test.go
@@ -138,38 +138,38 @@ func TestSDS(t *testing.T) {
 		// In reality Envoy doesn't do this, but it *could* per XDS spec
 		s := setupSDS(t)
 		c := s.Connect()
-		resp := s.Verify(c.RequestResponseAck(&discovery.DiscoveryRequest{ResourceNames: []string{testResourceName}}), expectCert)
-		c.ExpectNoResponse()
-		s.Verify(c.RequestResponseAck(&discovery.DiscoveryRequest{
+		resp := s.Verify(c.RequestResponseAck(t, &discovery.DiscoveryRequest{ResourceNames: []string{testResourceName}}), expectCert)
+		c.ExpectNoResponse(t)
+		s.Verify(c.RequestResponseAck(t, &discovery.DiscoveryRequest{
 			ResourceNames: []string{testResourceName, rootResourceName},
 			ResponseNonce: resp.Nonce,
 		}), expectCert, expectRoot)
-		c.ExpectNoResponse()
+		c.ExpectNoResponse(t)
 	})
 	t.Run("multiplexed root first", func(t *testing.T) {
 		s := setupSDS(t)
 		c := s.Connect()
-		s.Verify(c.RequestResponseAck(&discovery.DiscoveryRequest{ResourceNames: []string{rootResourceName}}), expectRoot)
-		c.ExpectNoResponse()
-		s.Verify(c.RequestResponseAck(&discovery.DiscoveryRequest{ResourceNames: []string{testResourceName}}), expectCert)
-		c.ExpectNoResponse()
+		s.Verify(c.RequestResponseAck(t, &discovery.DiscoveryRequest{ResourceNames: []string{rootResourceName}}), expectRoot)
+		c.ExpectNoResponse(t)
+		s.Verify(c.RequestResponseAck(t, &discovery.DiscoveryRequest{ResourceNames: []string{testResourceName}}), expectCert)
+		c.ExpectNoResponse(t)
 	})
 	t.Run("multiplexed multiple single", func(t *testing.T) {
 		s := setupSDS(t)
 		c := s.Connect()
-		s.Verify(c.RequestResponseAck(&discovery.DiscoveryRequest{ResourceNames: []string{rootResourceName}}), expectRoot)
-		s.Verify(c.RequestResponseAck(&discovery.DiscoveryRequest{ResourceNames: []string{rootResourceName}}), expectRoot)
-		c.ExpectNoResponse()
+		s.Verify(c.RequestResponseAck(t, &discovery.DiscoveryRequest{ResourceNames: []string{rootResourceName}}), expectRoot)
+		s.Verify(c.RequestResponseAck(t, &discovery.DiscoveryRequest{ResourceNames: []string{rootResourceName}}), expectRoot)
+		c.ExpectNoResponse(t)
 	})
 	t.Run("parallel", func(t *testing.T) {
 		s := setupSDS(t)
 		cert := s.Connect()
 		root := s.Connect()
 
-		s.Verify(cert.RequestResponseAck(&discovery.DiscoveryRequest{ResourceNames: []string{testResourceName}}), expectCert)
-		s.Verify(root.RequestResponseAck(&discovery.DiscoveryRequest{ResourceNames: []string{rootResourceName}}), expectRoot)
-		cert.ExpectNoResponse()
-		root.ExpectNoResponse()
+		s.Verify(cert.RequestResponseAck(t, &discovery.DiscoveryRequest{ResourceNames: []string{testResourceName}}), expectCert)
+		s.Verify(root.RequestResponseAck(t, &discovery.DiscoveryRequest{ResourceNames: []string{rootResourceName}}), expectRoot)
+		cert.ExpectNoResponse(t)
+		root.ExpectNoResponse(t)
 	})
 	t.Run("unknown", func(t *testing.T) {
 		s := setupSDS(t)
@@ -177,8 +177,8 @@ func TestSDS(t *testing.T) {
 		cert := s.Connect()
 
 		// When we connect, we get get an error
-		cert.Request(&discovery.DiscoveryRequest{ResourceNames: []string{testResourceName}})
-		if err := cert.ExpectError(); !strings.Contains(fmt.Sprint(err), "failed to generate secret") {
+		cert.Request(t, &discovery.DiscoveryRequest{ResourceNames: []string{testResourceName}})
+		if err := cert.ExpectError(t); !strings.Contains(fmt.Sprint(err), "failed to generate secret") {
 			t.Fatalf("didn't get expected error; got %v", err)
 		}
 		cert.Cleanup()
@@ -186,7 +186,7 @@ func TestSDS(t *testing.T) {
 		s.UpdateSecret(testResourceName, pushSecret)
 		// If the secret is added later, new connections will succeed
 		cert = s.Connect()
-		s.Verify(cert.RequestResponseAck(&discovery.DiscoveryRequest{ResourceNames: []string{testResourceName}}), Expectation{
+		s.Verify(cert.RequestResponseAck(t, &discovery.DiscoveryRequest{ResourceNames: []string{testResourceName}}), Expectation{
 			ResourceName: testResourceName,
 			CertChain:    fakePushCertificateChain,
 			Key:          fakePushPrivateKey,
@@ -196,54 +196,54 @@ func TestSDS(t *testing.T) {
 		s := setupSDS(t)
 		cert := s.Connect()
 
-		s.Verify(cert.RequestResponseAck(&discovery.DiscoveryRequest{ResourceNames: []string{testResourceName}}), expectCert)
+		s.Verify(cert.RequestResponseAck(t, &discovery.DiscoveryRequest{ResourceNames: []string{testResourceName}}), expectCert)
 
 		// Remove secret and trigger push. This simulates CA outage. We should get an error, which
 		// would force the client to retry
 		s.UpdateSecret(testResourceName, nil)
-		if err := cert.ExpectError(); !strings.Contains(fmt.Sprint(err), "failed to generate secret") {
+		if err := cert.ExpectError(t); !strings.Contains(fmt.Sprint(err), "failed to generate secret") {
 			t.Fatalf("didn't get expected error; got %v", err)
 		}
 	})
 	t.Run("serial", func(t *testing.T) {
 		s := setupSDS(t)
 		cert := s.Connect()
-		s.Verify(cert.RequestResponseAck(&discovery.DiscoveryRequest{ResourceNames: []string{testResourceName}}), expectCert)
-		cert.ExpectNoResponse()
+		s.Verify(cert.RequestResponseAck(t, &discovery.DiscoveryRequest{ResourceNames: []string{testResourceName}}), expectCert)
+		cert.ExpectNoResponse(t)
 
 		root := s.Connect()
-		s.Verify(root.RequestResponseAck(&discovery.DiscoveryRequest{ResourceNames: []string{rootResourceName}}), expectRoot)
-		root.ExpectNoResponse()
-		cert.ExpectNoResponse()
+		s.Verify(root.RequestResponseAck(t, &discovery.DiscoveryRequest{ResourceNames: []string{rootResourceName}}), expectRoot)
+		root.ExpectNoResponse(t)
+		cert.ExpectNoResponse(t)
 	})
 	t.Run("push cert", func(t *testing.T) {
 		s := setupSDS(t)
 		cert := s.Connect()
 		root := s.Connect()
-		s.Verify(cert.RequestResponseAck(&discovery.DiscoveryRequest{ResourceNames: []string{testResourceName}}), expectCert)
-		s.Verify(root.RequestResponseAck(&discovery.DiscoveryRequest{ResourceNames: []string{rootResourceName}}), expectRoot)
-		cert.ExpectNoResponse()
-		root.ExpectNoResponse()
+		s.Verify(cert.RequestResponseAck(t, &discovery.DiscoveryRequest{ResourceNames: []string{testResourceName}}), expectCert)
+		s.Verify(root.RequestResponseAck(t, &discovery.DiscoveryRequest{ResourceNames: []string{rootResourceName}}), expectRoot)
+		cert.ExpectNoResponse(t)
+		root.ExpectNoResponse(t)
 
 		s.UpdateSecret(testResourceName, pushSecret)
-		s.Verify(cert.ExpectResponse(), Expectation{
+		s.Verify(cert.ExpectResponse(t), Expectation{
 			ResourceName: testResourceName,
 			CertChain:    fakePushCertificateChain,
 			Key:          fakePushPrivateKey,
 		})
 		// No need to push a new root if just the cert changes
-		root.ExpectNoResponse()
+		root.ExpectNoResponse(t)
 	})
 	t.Run("reconnect", func(t *testing.T) {
 		s := setupSDS(t)
 		c := s.Connect()
-		res := s.Verify(c.RequestResponseAck(&discovery.DiscoveryRequest{ResourceNames: []string{testResourceName}}), expectCert)
+		res := s.Verify(c.RequestResponseAck(t, &discovery.DiscoveryRequest{ResourceNames: []string{testResourceName}}), expectCert)
 		// Close out the connection
 		c.Cleanup()
 
 		// Reconnect with the same resources
 		c = s.Connect()
-		s.Verify(c.RequestResponseAck(&discovery.DiscoveryRequest{
+		s.Verify(c.RequestResponseAck(t, &discovery.DiscoveryRequest{
 			ResourceNames: []string{testResourceName},
 			ResponseNonce: res.Nonce,
 			VersionInfo:   res.VersionInfo,
@@ -252,10 +252,10 @@ func TestSDS(t *testing.T) {
 	t.Run("concurrent reconnect", func(t *testing.T) {
 		s := setupSDS(t)
 		c := s.Connect()
-		res := s.Verify(c.RequestResponseAck(&discovery.DiscoveryRequest{ResourceNames: []string{testResourceName}}), expectCert)
+		res := s.Verify(c.RequestResponseAck(t, &discovery.DiscoveryRequest{ResourceNames: []string{testResourceName}}), expectCert)
 		// Reconnect with the same resources, without closing the original connection
 		c = s.Connect()
-		s.Verify(c.RequestResponseAck(&discovery.DiscoveryRequest{
+		s.Verify(c.RequestResponseAck(t, &discovery.DiscoveryRequest{
 			ResourceNames: []string{testResourceName},
 			ResponseNonce: res.Nonce,
 			VersionInfo:   res.VersionInfo,
@@ -263,26 +263,26 @@ func TestSDS(t *testing.T) {
 	})
 	t.Run("concurrent connections", func(t *testing.T) {
 		s := setupSDS(t)
-		s.Verify(s.Connect().RequestResponseAck(&discovery.DiscoveryRequest{ResourceNames: []string{testResourceName}}), expectCert)
-		s.Verify(s.Connect().RequestResponseAck(&discovery.DiscoveryRequest{ResourceNames: []string{testResourceName}}), expectCert)
+		s.Verify(s.Connect().RequestResponseAck(t, &discovery.DiscoveryRequest{ResourceNames: []string{testResourceName}}), expectCert)
+		s.Verify(s.Connect().RequestResponseAck(t, &discovery.DiscoveryRequest{ResourceNames: []string{testResourceName}}), expectCert)
 	})
 	t.Run("unsubscribe", func(t *testing.T) {
 		s := setupSDS(t)
 		c := s.Connect()
-		res := c.RequestResponseAck(&discovery.DiscoveryRequest{ResourceNames: []string{testResourceName}})
+		res := c.RequestResponseAck(t, &discovery.DiscoveryRequest{ResourceNames: []string{testResourceName}})
 		s.Verify(res, expectCert)
-		c.Request(&discovery.DiscoveryRequest{
+		c.Request(t, &discovery.DiscoveryRequest{
 			ResourceNames: nil,
 			ResponseNonce: res.Nonce,
 			VersionInfo:   res.VersionInfo,
 		})
-		c.ExpectNoResponse()
+		c.ExpectNoResponse(t)
 	})
 	t.Run("nack", func(t *testing.T) {
 		s := setupSDS(t)
 		c := s.Connect()
-		c.RequestResponseNack(&discovery.DiscoveryRequest{ResourceNames: []string{testResourceName}})
-		c.ExpectNoResponse()
+		c.RequestResponseNack(t, &discovery.DiscoveryRequest{ResourceNames: []string{testResourceName}})
+		c.ExpectNoResponse(t)
 	})
 }
 


### PR DESCRIPTION
Currently, most methods for XDS tests rely on a `testing.T` variable that is stored within a struct. This typically references the parent test and if it fails during a subtest, it will bring down all sibling tests with it.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.