### PR TITLE
Fix split-horizon LB for MCS

### DIFF
--- a/pilot/pkg/model/network.go
+++ b/pilot/pkg/model/network.go
@@ -82,20 +82,36 @@ func NewNetworkManager(env *Environment) *NetworkManager {
 		}
 	}
 
+	// Calculate the upper-bound on the number of gateways per network.
+	var maxGatewaysPerNetwork int
+	for _, gws := range byNetwork {
+		if len(gws) > maxGatewaysPerNetwork {
+			maxGatewaysPerNetwork = len(gws)
+		}
+	}
+
 	return &NetworkManager{
-		byNetwork:           byNetwork,
-		byNetworkAndCluster: byNetworkAndCluster,
+		maxGatewaysPerNetwork: uint32(maxGatewaysPerNetwork),
+		byNetwork:             byNetwork,
+		byNetworkAndCluster:   byNetworkAndCluster,
 	}
 }
 
 // NetworkManager provides gateway details for accessing remote networks.
 type NetworkManager struct {
-	byNetwork           map[network.ID][]*NetworkGateway
-	byNetworkAndCluster map[networkAndCluster][]*NetworkGateway
+	maxGatewaysPerNetwork uint32
+	byNetwork             map[network.ID][]*NetworkGateway
+	byNetworkAndCluster   map[networkAndCluster][]*NetworkGateway
 }
 
 func (mgr *NetworkManager) IsMultiNetworkEnabled() bool {
 	return len(mgr.byNetwork) > 0
+}
+
+// GetMaxGatewaysPerNetwork returns an upper bound on the number of gateways there
+// could be for any one network.
+func (mgr *NetworkManager) GetMaxGatewaysPerNetwork() uint32 {
+	return mgr.maxGatewaysPerNetwork
 }
 
 func (mgr *NetworkManager) AllGateways() []*NetworkGateway {

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -282,7 +282,7 @@ func WorkloadInstancesEqual(first, second *WorkloadInstance) bool {
 	if first.Endpoint.Locality != second.Endpoint.Locality {
 		return false
 	}
-	if first.Endpoint.LbWeight != second.Endpoint.LbWeight {
+	if first.Endpoint.GetLoadBalancingWeight() != second.Endpoint.GetLoadBalancingWeight() {
 		return false
 	}
 	if first.Namespace != second.Namespace {
@@ -417,6 +417,14 @@ type IstioEndpoint struct {
 
 	// Determines the discoverability of this endpoint throughout the mesh.
 	DiscoverabilityPolicy EndpointDiscoverabilityPolicy `json:"-"`
+}
+
+// GetLoadBalancingWeight returns the weight for this endpoint, normalized to always be > 0.
+func (ep *IstioEndpoint) GetLoadBalancingWeight() uint32 {
+	if ep.LbWeight > 0 {
+		return ep.LbWeight
+	}
+	return 1
 }
 
 // IsDiscoverableFromProxy indicates whether or not this endpoint is discoverable from the given Proxy.

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -420,11 +420,8 @@ func (cb *ClusterBuilder) buildLocalityLbEndpoints(proxyNetworkView map[network.
 				},
 			},
 			LoadBalancingWeight: &wrappers.UInt32Value{
-				Value: 1,
+				Value: instance.Endpoint.GetLoadBalancingWeight(),
 			},
-		}
-		if instance.Endpoint.LbWeight > 0 {
-			ep.LoadBalancingWeight.Value = instance.Endpoint.LbWeight
 		}
 		ep.Metadata = util.BuildLbEndpointMetadata(instance.Endpoint.Network, instance.Endpoint.TLSMode, instance.Endpoint.WorkloadName,
 			instance.Endpoint.Namespace, instance.Endpoint.Locality.ClusterID, instance.Endpoint.Labels)

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -490,14 +490,6 @@ func BuildLbEndpointMetadata(networkID network.ID, tlsMode, workloadname, namesp
 		FilterMetadata: map[string]*pstruct.Struct{},
 	}
 
-	if networkID != "" {
-		addIstioEndpointLabel(metadata, "network", &pstruct.Value{Kind: &pstruct.Value_StringValue{StringValue: networkID.String()}})
-	}
-	// TODO(nmittler): Is there any concern with adding an extra label?
-	if clusterID != "" {
-		addIstioEndpointLabel(metadata, "cluster", &pstruct.Value{Kind: &pstruct.Value_StringValue{StringValue: clusterID.String()}})
-	}
-
 	if tlsMode != "" && tlsMode != model.DisabledTLSModeLabel {
 		metadata.FilterMetadata[EnvoyTransportSocketMetadataKey] = &pstruct.Struct{
 			Fields: map[string]*pstruct.Value{

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -480,9 +480,9 @@ func MergeAnyWithAny(dst *any.Any, src *any.Any) (*any.Any, error) {
 }
 
 // BuildLbEndpointMetadata adds metadata values to a lb endpoint
-func BuildLbEndpointMetadata(network network.ID, tlsMode, workloadname, namespace string,
+func BuildLbEndpointMetadata(networkID network.ID, tlsMode, workloadname, namespace string,
 	clusterID cluster.ID, labels labels.Instance) *core.Metadata {
-	if network == "" && (tlsMode == "" || tlsMode == model.DisabledTLSModeLabel) && !features.EndpointTelemetryLabel {
+	if networkID == "" && (tlsMode == "" || tlsMode == model.DisabledTLSModeLabel) && !features.EndpointTelemetryLabel {
 		return nil
 	}
 
@@ -490,8 +490,12 @@ func BuildLbEndpointMetadata(network network.ID, tlsMode, workloadname, namespac
 		FilterMetadata: map[string]*pstruct.Struct{},
 	}
 
-	if network != "" {
-		addIstioEndpointLabel(metadata, "network", &pstruct.Value{Kind: &pstruct.Value_StringValue{StringValue: network.String()}})
+	if networkID != "" {
+		addIstioEndpointLabel(metadata, "network", &pstruct.Value{Kind: &pstruct.Value_StringValue{StringValue: networkID.String()}})
+	}
+	// TODO(nmittler): Is there any concern with adding an extra label?
+	if clusterID != "" {
+		addIstioEndpointLabel(metadata, "cluster", &pstruct.Value{Kind: &pstruct.Value_StringValue{StringValue: clusterID.String()}})
 	}
 
 	if tlsMode != "" && tlsMode != model.DisabledTLSModeLabel {

--- a/pilot/pkg/networking/util/util_test.go
+++ b/pilot/pkg/networking/util/util_test.go
@@ -1211,11 +1211,6 @@ func TestEndpointMetadata(t *testing.T) {
 					},
 					IstioMetadataKey: {
 						Fields: map[string]*structpb.Value{
-							"network": {
-								Kind: &structpb.Value_StringValue{
-									StringValue: "network",
-								},
-							},
 							"workload": {
 								Kind: &structpb.Value_StringValue{
 									StringValue: ";;;;",
@@ -1250,16 +1245,6 @@ func TestEndpointMetadata(t *testing.T) {
 					},
 					IstioMetadataKey: {
 						Fields: map[string]*structpb.Value{
-							"network": {
-								Kind: &structpb.Value_StringValue{
-									StringValue: "network",
-								},
-							},
-							"cluster": {
-								Kind: &structpb.Value_StringValue{
-									StringValue: "cluster",
-								},
-							},
 							"workload": {
 								Kind: &structpb.Value_StringValue{
 									StringValue: "workload;default;service;v1;cluster",
@@ -1290,16 +1275,6 @@ func TestEndpointMetadata(t *testing.T) {
 					},
 					IstioMetadataKey: {
 						Fields: map[string]*structpb.Value{
-							"network": {
-								Kind: &structpb.Value_StringValue{
-									StringValue: "network",
-								},
-							},
-							"cluster": {
-								Kind: &structpb.Value_StringValue{
-									StringValue: "cluster",
-								},
-							},
 							"workload": {
 								Kind: &structpb.Value_StringValue{
 									StringValue: "workload;default;;;cluster",
@@ -1330,16 +1305,6 @@ func TestEndpointMetadata(t *testing.T) {
 					},
 					IstioMetadataKey: {
 						Fields: map[string]*structpb.Value{
-							"network": {
-								Kind: &structpb.Value_StringValue{
-									StringValue: "network",
-								},
-							},
-							"cluster": {
-								Kind: &structpb.Value_StringValue{
-									StringValue: "cluster",
-								},
-							},
 							"workload": {
 								Kind: &structpb.Value_StringValue{
 									StringValue: ";;;;cluster",

--- a/pilot/pkg/networking/util/util_test.go
+++ b/pilot/pkg/networking/util/util_test.go
@@ -1255,6 +1255,11 @@ func TestEndpointMetadata(t *testing.T) {
 									StringValue: "network",
 								},
 							},
+							"cluster": {
+								Kind: &structpb.Value_StringValue{
+									StringValue: "cluster",
+								},
+							},
 							"workload": {
 								Kind: &structpb.Value_StringValue{
 									StringValue: "workload;default;service;v1;cluster",
@@ -1290,6 +1295,11 @@ func TestEndpointMetadata(t *testing.T) {
 									StringValue: "network",
 								},
 							},
+							"cluster": {
+								Kind: &structpb.Value_StringValue{
+									StringValue: "cluster",
+								},
+							},
 							"workload": {
 								Kind: &structpb.Value_StringValue{
 									StringValue: "workload;default;;;cluster",
@@ -1323,6 +1333,11 @@ func TestEndpointMetadata(t *testing.T) {
 							"network": {
 								Kind: &structpb.Value_StringValue{
 									StringValue: "network",
+								},
+							},
+							"cluster": {
+								Kind: &structpb.Value_StringValue{
+									StringValue: "cluster",
 								},
 							},
 							"workload": {

--- a/pilot/pkg/serviceregistry/kube/controller/network.go
+++ b/pilot/pkg/serviceregistry/kube/controller/network.go
@@ -282,6 +282,9 @@ func (c *Controller) getNodePortGatewayServices() []*model.Service {
 type gatewaySet map[model.NetworkGateway]struct{}
 
 func (s gatewaySet) equals(other gatewaySet) bool {
+	if len(s) != len(other) {
+		return false
+	}
 	return reflect.DeepEqual(s, other)
 }
 
@@ -291,7 +294,7 @@ func (s gatewaySet) add(gw model.NetworkGateway) {
 
 func (s gatewaySet) addAll(other gatewaySet) {
 	for gw := range other {
-		s[gw] = struct{}{}
+		s.add(gw)
 	}
 }
 

--- a/pilot/pkg/xds/eds.go
+++ b/pilot/pkg/xds/eds.go
@@ -315,11 +315,9 @@ func (s *DiscoveryServer) generateEndpoints(b EndpointBuilder) *endpoint.Cluster
 		return buildEmptyClusterLoadAssignment(b.clusterName)
 	}
 
-	// If networks are set (by default they aren't) apply the Split Horizon
-	// EDS filter on the endpoints
-	if b.push.NetworkManager().IsMultiNetworkEnabled() {
-		llbOpts = b.EndpointsByNetworkFilter(llbOpts)
-	}
+	// Apply the Split Horizon EDS filter, if applicable.
+	llbOpts = b.EndpointsByNetworkFilter(llbOpts)
+
 	if model.IsDNSSrvSubsetKey(b.clusterName) {
 		// For the SNI-DNAT clusters, we are using AUTO_PASSTHROUGH gateway. AUTO_PASSTHROUGH is intended
 		// to passthrough mTLS requests. However, at the gateway we do not actually have any way to tell if the

--- a/pilot/pkg/xds/eds_sh_test.go
+++ b/pilot/pkg/xds/eds_sh_test.go
@@ -92,20 +92,20 @@ func TestSplitHorizonEds(t *testing.T) {
 			want: expectedResults{
 				weights: map[string]uint32{
 					// 1 local endpoint
-					"10.1.0.1": 4,
+					"10.1.0.1": 2,
 
 					// 2 endopints on network 2, go through single gateway.
-					"159.122.219.2": 8,
+					"159.122.219.2": 4,
 
 					// 3 endpoints on network 3, weights split across 2 gateways.
-					"159.122.219.3": 6,
-					"179.114.119.3": 6,
+					"159.122.219.3": 3,
+					"179.114.119.3": 3,
 
 					// no gateway defined for network 4 - treat as directly reachable.
-					"10.4.0.1": 4,
-					"10.4.0.2": 4,
-					"10.4.0.3": 4,
-					"10.4.0.4": 4,
+					"10.4.0.1": 2,
+					"10.4.0.2": 2,
+					"10.4.0.3": 2,
+					"10.4.0.4": 2,
 				},
 			},
 		},
@@ -117,21 +117,21 @@ func TestSplitHorizonEds(t *testing.T) {
 			want: expectedResults{
 				weights: map[string]uint32{
 					// 2 local endpoints
-					"10.2.0.1": 4,
-					"10.2.0.2": 4,
+					"10.2.0.1": 2,
+					"10.2.0.2": 2,
 
 					// 1 endpoint on network 1, accessed via gateway.
-					"159.122.219.1": 4,
+					"159.122.219.1": 2,
 
 					// 3 endpoints on network 3, weights split across 2 gateways.
-					"159.122.219.3": 6,
-					"179.114.119.3": 6,
+					"159.122.219.3": 3,
+					"179.114.119.3": 3,
 
 					// no gateway defined for network 4 - treat as directly reachable.
-					"10.4.0.1": 4,
-					"10.4.0.2": 4,
-					"10.4.0.3": 4,
-					"10.4.0.4": 4,
+					"10.4.0.1": 2,
+					"10.4.0.2": 2,
+					"10.4.0.3": 2,
+					"10.4.0.4": 2,
 				},
 			},
 		},
@@ -143,21 +143,21 @@ func TestSplitHorizonEds(t *testing.T) {
 			want: expectedResults{
 				weights: map[string]uint32{
 					// 3 local endpoints.
-					"10.3.0.1": 4,
-					"10.3.0.2": 4,
-					"10.3.0.3": 4,
+					"10.3.0.1": 2,
+					"10.3.0.2": 2,
+					"10.3.0.3": 2,
 
 					// 1 endpoint on network 1, accessed via gateway.
-					"159.122.219.1": 4,
+					"159.122.219.1": 2,
 
 					// 2 endpoint on network 2, accessed via gateway.
-					"159.122.219.2": 8,
+					"159.122.219.2": 4,
 
 					// no gateway defined for network 4 - treat as directly reachable.
-					"10.4.0.1": 4,
-					"10.4.0.2": 4,
-					"10.4.0.3": 4,
-					"10.4.0.4": 4,
+					"10.4.0.1": 2,
+					"10.4.0.2": 2,
+					"10.4.0.3": 2,
+					"10.4.0.4": 2,
 				},
 			},
 		},
@@ -169,20 +169,20 @@ func TestSplitHorizonEds(t *testing.T) {
 			want: expectedResults{
 				weights: map[string]uint32{
 					// 4 local endpoints.
-					"10.4.0.1": 4,
-					"10.4.0.2": 4,
-					"10.4.0.3": 4,
-					"10.4.0.4": 4,
+					"10.4.0.1": 2,
+					"10.4.0.2": 2,
+					"10.4.0.3": 2,
+					"10.4.0.4": 2,
 
 					// 1 endpoint on network 1, accessed via gateway.
-					"159.122.219.1": 4,
+					"159.122.219.1": 2,
 
 					// 2 endpoint on network 2, accessed via gateway.
-					"159.122.219.2": 8,
+					"159.122.219.2": 4,
 
 					// 3 endpoints on network 3, weights split across 2 gateways.
-					"159.122.219.3": 6,
-					"179.114.119.3": 6,
+					"159.122.219.3": 3,
+					"179.114.119.3": 3,
 				},
 			},
 		},

--- a/pilot/pkg/xds/eds_sh_test.go
+++ b/pilot/pkg/xds/eds_sh_test.go
@@ -15,6 +15,7 @@ package xds_test
 
 import (
 	"fmt"
+	"sort"
 	"testing"
 	"time"
 
@@ -41,6 +42,15 @@ import (
 
 type expectedResults struct {
 	weights map[string]uint32
+}
+
+func (r expectedResults) getAddrs() []string {
+	var out []string
+	for addr := range r.weights {
+		out = append(out, addr)
+	}
+	sort.Strings(out)
+	return out
 }
 
 // The test will setup 3 networks with various number of endpoints for the same service within
@@ -81,14 +91,21 @@ func TestSplitHorizonEds(t *testing.T) {
 			sidecarID: sidecarID("10.1.0.1", "app3"),
 			want: expectedResults{
 				weights: map[string]uint32{
-					"10.1.0.1":      2,
-					"159.122.219.2": 4,
-					"159.122.219.3": 3,
-					"179.114.119.3": 3,
-					"10.4.0.1":      2,
-					"10.4.0.2":      2,
-					"10.4.0.3":      2,
-					"10.4.0.4":      2,
+					// 1 local endpoint
+					"10.1.0.1": 4,
+
+					// 2 endopints on network 2, go through single gateway.
+					"159.122.219.2": 8,
+
+					// 3 endpoints on network 3, weights split across 2 gateways.
+					"159.122.219.3": 6,
+					"179.114.119.3": 6,
+
+					// no gateway defined for network 4 - treat as directly reachable.
+					"10.4.0.1": 4,
+					"10.4.0.2": 4,
+					"10.4.0.3": 4,
+					"10.4.0.4": 4,
 				},
 			},
 		},
@@ -99,15 +116,22 @@ func TestSplitHorizonEds(t *testing.T) {
 			sidecarID: sidecarID("10.2.0.1", "app3"),
 			want: expectedResults{
 				weights: map[string]uint32{
-					"10.2.0.1":      2,
-					"10.2.0.2":      2,
-					"159.122.219.1": 2,
-					"159.122.219.3": 3,
-					"179.114.119.3": 3,
-					"10.4.0.1":      2,
-					"10.4.0.2":      2,
-					"10.4.0.3":      2,
-					"10.4.0.4":      2,
+					// 2 local endpoints
+					"10.2.0.1": 4,
+					"10.2.0.2": 4,
+
+					// 1 endpoint on network 1, accessed via gateway.
+					"159.122.219.1": 4,
+
+					// 3 endpoints on network 3, weights split across 2 gateways.
+					"159.122.219.3": 6,
+					"179.114.119.3": 6,
+
+					// no gateway defined for network 4 - treat as directly reachable.
+					"10.4.0.1": 4,
+					"10.4.0.2": 4,
+					"10.4.0.3": 4,
+					"10.4.0.4": 4,
 				},
 			},
 		},
@@ -118,15 +142,22 @@ func TestSplitHorizonEds(t *testing.T) {
 			sidecarID: sidecarID("10.3.0.1", "app3"),
 			want: expectedResults{
 				weights: map[string]uint32{
-					"159.122.219.1": 2,
-					"159.122.219.2": 4,
-					"10.3.0.1":      2,
-					"10.3.0.2":      2,
-					"10.3.0.3":      2,
-					"10.4.0.1":      2,
-					"10.4.0.2":      2,
-					"10.4.0.3":      2,
-					"10.4.0.4":      2,
+					// 3 local endpoints.
+					"10.3.0.1": 4,
+					"10.3.0.2": 4,
+					"10.3.0.3": 4,
+
+					// 1 endpoint on network 1, accessed via gateway.
+					"159.122.219.1": 4,
+
+					// 2 endpoint on network 2, accessed via gateway.
+					"159.122.219.2": 8,
+
+					// no gateway defined for network 4 - treat as directly reachable.
+					"10.4.0.1": 4,
+					"10.4.0.2": 4,
+					"10.4.0.3": 4,
+					"10.4.0.4": 4,
 				},
 			},
 		},
@@ -137,20 +168,27 @@ func TestSplitHorizonEds(t *testing.T) {
 			sidecarID: sidecarID("10.4.0.1", "app3"),
 			want: expectedResults{
 				weights: map[string]uint32{
-					"10.4.0.1":      2,
-					"10.4.0.2":      2,
-					"10.4.0.3":      2,
-					"10.4.0.4":      2,
-					"159.122.219.1": 2,
-					"159.122.219.2": 4,
-					"159.122.219.3": 3,
-					"179.114.119.3": 3,
+					// 4 local endpoints.
+					"10.4.0.1": 4,
+					"10.4.0.2": 4,
+					"10.4.0.3": 4,
+					"10.4.0.4": 4,
+
+					// 1 endpoint on network 1, accessed via gateway.
+					"159.122.219.1": 4,
+
+					// 2 endpoint on network 2, accessed via gateway.
+					"159.122.219.2": 8,
+
+					// 3 endpoints on network 3, weights split across 2 gateways.
+					"159.122.219.3": 6,
+					"179.114.119.3": 6,
 				},
 			},
 		},
 	}
 	for _, tt := range tests {
-		t.Run(tt.network, func(t *testing.T) {
+		t.Run("from "+tt.network, func(t *testing.T) {
 			verifySplitHorizonResponse(t, s, tt.network, tt.sidecarID, tt.want)
 		})
 	}
@@ -187,12 +225,12 @@ func verifySplitHorizonResponse(t *testing.T, s *xds.FakeDiscoveryServer, networ
 	eps := cla.Endpoints
 
 	if len(eps) != 1 {
-		t.Fatal(fmt.Errorf("expecting 1 locality endpoint but got %d", len(eps)))
+		t.Fatalf("expecting 1 locality endpoint but got %d", len(eps))
 	}
 
 	lbEndpoints := eps[0].LbEndpoints
 	if len(lbEndpoints) != len(expected.weights) {
-		t.Fatal(fmt.Errorf("number of endpoints should be %d but got %d", len(expected.weights), len(lbEndpoints)))
+		t.Fatalf("unexpected number of endpoints.\nWant:\n%v\nGot:\n%v", expected.getAddrs(), getLbEndpointAddrs(lbEndpoints))
 	}
 
 	for addr, weight := range expected.weights {
@@ -204,10 +242,10 @@ func verifySplitHorizonResponse(t *testing.T, s *xds.FakeDiscoveryServer, networ
 			}
 		}
 		if match == nil {
-			t.Fatal(fmt.Errorf("couldn't find endpoint with address %s", addr))
+			t.Fatalf("couldn't find endpoint with address %s: found %v", addr, getLbEndpointAddrs(lbEndpoints))
 		}
 		if match.LoadBalancingWeight.Value != weight {
-			t.Fatal(fmt.Errorf("weight for endpoint %s is expected to be %d but got %d", addr, weight, match.LoadBalancingWeight.Value))
+			t.Errorf("weight for endpoint %s is expected to be %d but got %d", addr, weight, match.LoadBalancingWeight.Value)
 		}
 	}
 }
@@ -215,9 +253,9 @@ func verifySplitHorizonResponse(t *testing.T, s *xds.FakeDiscoveryServer, networ
 // initRegistry creates and initializes a memory registry that holds a single
 // service with the provided amount of endpoints. It also creates a service for
 // the ingress with the provided external IP
-func initRegistry(server *xds.FakeDiscoveryServer, clusterNum int, gatewaysIP []string, numOfEndpoints int) {
-	clusterID := cluster.ID(fmt.Sprintf("cluster%d", clusterNum))
-	networkID := network.ID(fmt.Sprintf("network%d", clusterNum))
+func initRegistry(server *xds.FakeDiscoveryServer, networkNum int, gatewaysIP []string, numOfEndpoints int) {
+	clusterID := cluster.ID(fmt.Sprintf("cluster%d", networkNum))
+	networkID := network.ID(fmt.Sprintf("network%d", networkNum))
 	memRegistry := memory.NewServiceDiscovery(nil)
 	memRegistry.EDSUpdater = server.Discovery
 
@@ -271,13 +309,16 @@ func initRegistry(server *xds.FakeDiscoveryServer, clusterNum int, gatewaysIP []
 	})
 	istioEndpoints := make([]*model.IstioEndpoint, numOfEndpoints)
 	for i := 0; i < numOfEndpoints; i++ {
+		addr := fmt.Sprintf("10.%d.0.%d", networkNum, i+1)
+		fmt.Printf("NM: adding address %v\n", addr)
 		istioEndpoints[i] = &model.IstioEndpoint{
-			Address:         fmt.Sprintf("10.%d.0.%d", clusterNum, i+1),
+			Address:         addr,
 			EndpointPort:    2080,
 			ServicePortName: "http-main",
 			Network:         networkID,
 			Locality: model.Locality{
-				Label: "az",
+				Label:     "az",
+				ClusterID: clusterID,
 			},
 			Labels:  svcLabels,
 			TLSMode: model.IstioMutualTLSModeLabel,
@@ -295,4 +336,13 @@ func addNetwork(server *xds.FakeDiscoveryServer, id network.ID, network *meshcon
 	c[string(id)] = network
 	meshNetworks.Networks = c
 	server.Env().SetNetworks(&meshNetworks)
+}
+
+func getLbEndpointAddrs(eps []*endpoint.LbEndpoint) []string {
+	addrs := make([]string, 0)
+	for _, lbEp := range eps {
+		addrs = append(addrs, lbEp.GetEndpoint().Address.GetSocketAddress().Address)
+	}
+	sort.Strings(addrs)
+	return addrs
 }

--- a/pilot/pkg/xds/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoint_builder.go
@@ -385,13 +385,9 @@ func (b *EndpointBuilder) createClusterLoadAssignment(llbOpts []*LocLbEndpointsA
 func buildEnvoyLbEndpoint(e *model.IstioEndpoint) *endpoint.LbEndpoint {
 	addr := util.BuildAddress(e.Address, e.EndpointPort)
 
-	epWeight := e.LbWeight
-	if epWeight == 0 {
-		epWeight = 1
-	}
 	ep := &endpoint.LbEndpoint{
 		LoadBalancingWeight: &wrappers.UInt32Value{
-			Value: epWeight,
+			Value: e.GetLoadBalancingWeight(),
 		},
 		HostIdentifier: &endpoint.LbEndpoint_Endpoint{
 			Endpoint: &endpoint.Endpoint{

--- a/pilot/pkg/xds/ep_filters_test.go
+++ b/pilot/pkg/xds/ep_filters_test.go
@@ -63,16 +63,16 @@ var networkFiltered = []networkFilterCase{
 			{
 				lbEps: []LbEpInfo{
 					// 2 local endpoints on network1
-					{address: "10.0.0.1", weight: 4},
-					{address: "10.0.0.2", weight: 4},
+					{address: "10.0.0.1", weight: 2},
+					{address: "10.0.0.2", weight: 2},
 					// 1 endpoint on network2, cluster2a
-					{address: "2.2.2.2", weight: 4},
+					{address: "2.2.2.2", weight: 2},
 					// 2 endpoints on network2, cluster2b
-					{address: "2.2.2.20", weight: 8},
+					{address: "2.2.2.20", weight: 4},
 					// 1 endpoint on network4 with no gateway (i.e. directly accessible)
-					{address: "40.0.0.1", weight: 4},
+					{address: "40.0.0.1", weight: 2},
 				},
-				weight: 24,
+				weight: 12,
 			},
 		},
 	},
@@ -83,16 +83,16 @@ var networkFiltered = []networkFilterCase{
 			{
 				lbEps: []LbEpInfo{
 					// 2 local endpoints on network1
-					{address: "10.0.0.1", weight: 4},
-					{address: "10.0.0.2", weight: 4},
+					{address: "10.0.0.1", weight: 2},
+					{address: "10.0.0.2", weight: 2},
 					// 1 endpoint on network2, cluster2a
-					{address: "2.2.2.2", weight: 4},
+					{address: "2.2.2.2", weight: 2},
 					// 2 endpoints on network2, cluster2b
-					{address: "2.2.2.20", weight: 8},
+					{address: "2.2.2.20", weight: 4},
 					// 1 endpoint on network4 with no gateway (i.e. directly accessible)
-					{address: "40.0.0.1", weight: 4},
+					{address: "40.0.0.1", weight: 2},
 				},
-				weight: 24,
+				weight: 12,
 			},
 		},
 	},
@@ -103,15 +103,15 @@ var networkFiltered = []networkFilterCase{
 			{
 				lbEps: []LbEpInfo{
 					// 3 local endpoints in network2
-					{address: "20.0.0.1", weight: 4},
-					{address: "20.0.0.2", weight: 4},
-					{address: "20.0.0.3", weight: 4},
+					{address: "20.0.0.1", weight: 2},
+					{address: "20.0.0.2", weight: 2},
+					{address: "20.0.0.3", weight: 2},
 					// 2 endpoint on network1 with weight aggregated at the gateway
-					{address: "1.1.1.1", weight: 8},
+					{address: "1.1.1.1", weight: 4},
 					// 1 endpoint on network4 with no gateway (i.e. directly accessible)
-					{address: "40.0.0.1", weight: 4},
+					{address: "40.0.0.1", weight: 2},
 				},
-				weight: 24,
+				weight: 12,
 			},
 		},
 	},
@@ -122,15 +122,15 @@ var networkFiltered = []networkFilterCase{
 			{
 				lbEps: []LbEpInfo{
 					// 3 local endpoints in network2
-					{address: "20.0.0.1", weight: 4},
-					{address: "20.0.0.2", weight: 4},
-					{address: "20.0.0.3", weight: 4},
+					{address: "20.0.0.1", weight: 2},
+					{address: "20.0.0.2", weight: 2},
+					{address: "20.0.0.3", weight: 2},
 					// 2 endpoint on network1 with weight aggregated at the gateway
-					{address: "1.1.1.1", weight: 8},
+					{address: "1.1.1.1", weight: 4},
 					// 1 endpoint on network4 with no gateway (i.e. directly accessible)
-					{address: "40.0.0.1", weight: 4},
+					{address: "40.0.0.1", weight: 2},
 				},
-				weight: 24,
+				weight: 12,
 			},
 		},
 	},
@@ -141,15 +141,15 @@ var networkFiltered = []networkFilterCase{
 			{
 				lbEps: []LbEpInfo{
 					// 2 endpoint on network2 with weight aggregated at the gateway
-					{address: "1.1.1.1", weight: 8},
+					{address: "1.1.1.1", weight: 4},
 					// 1 endpoint on network2, cluster2a
-					{address: "2.2.2.2", weight: 4},
+					{address: "2.2.2.2", weight: 2},
 					// 2 endpoints on network2, cluster2b
-					{address: "2.2.2.20", weight: 8},
+					{address: "2.2.2.20", weight: 4},
 					// 1 endpoint on network4 with no gateway (i.e. directly accessible)
-					{address: "40.0.0.1", weight: 4},
+					{address: "40.0.0.1", weight: 2},
 				},
-				weight: 24,
+				weight: 12,
 			},
 		},
 	},
@@ -160,15 +160,15 @@ var networkFiltered = []networkFilterCase{
 			{
 				lbEps: []LbEpInfo{
 					// 1 local endpoint on network4
-					{address: "40.0.0.1", weight: 4},
+					{address: "40.0.0.1", weight: 2},
 					// 2 endpoint on network2 with weight aggregated at the gateway
-					{address: "1.1.1.1", weight: 8},
+					{address: "1.1.1.1", weight: 4},
 					// 1 endpoint on network2, cluster2a
-					{address: "2.2.2.2", weight: 4},
+					{address: "2.2.2.2", weight: 2},
 					// 2 endpoints on network2, cluster2b
-					{address: "2.2.2.20", weight: 8},
+					{address: "2.2.2.20", weight: 4},
 				},
-				weight: 24,
+				weight: 12,
 			},
 		},
 	},
@@ -192,12 +192,12 @@ func TestEndpointsByNetworkFilter_WithConfig(t *testing.T) {
 				{
 					lbEps: []LbEpInfo{
 						// 2 local endpoints on network1
-						{address: "10.0.0.1", weight: 4},
-						{address: "10.0.0.2", weight: 4},
+						{address: "10.0.0.1", weight: 2},
+						{address: "10.0.0.2", weight: 2},
 						// 1 endpoint on network4 with no gateway (i.e. directly accessible)
-						{address: "40.0.0.1", weight: 4},
+						{address: "40.0.0.1", weight: 2},
 					},
-					weight: 12,
+					weight: 6,
 				},
 			},
 		},
@@ -208,12 +208,12 @@ func TestEndpointsByNetworkFilter_WithConfig(t *testing.T) {
 				{
 					lbEps: []LbEpInfo{
 						// 2 local endpoints on network1
-						{address: "10.0.0.1", weight: 4},
-						{address: "10.0.0.2", weight: 4},
+						{address: "10.0.0.1", weight: 2},
+						{address: "10.0.0.2", weight: 2},
 						// 1 endpoint on network4 with no gateway (i.e. directly accessible)
-						{address: "40.0.0.1", weight: 4},
+						{address: "40.0.0.1", weight: 2},
 					},
-					weight: 12,
+					weight: 6,
 				},
 			},
 		},
@@ -224,13 +224,13 @@ func TestEndpointsByNetworkFilter_WithConfig(t *testing.T) {
 				{
 					lbEps: []LbEpInfo{
 						// 1 local endpoint on network2
-						{address: "20.0.0.1", weight: 4},
-						{address: "20.0.0.2", weight: 4},
-						{address: "20.0.0.3", weight: 4},
+						{address: "20.0.0.1", weight: 2},
+						{address: "20.0.0.2", weight: 2},
+						{address: "20.0.0.3", weight: 2},
 						// 1 endpoint on network4 with no gateway (i.e. directly accessible)
-						{address: "40.0.0.1", weight: 4},
+						{address: "40.0.0.1", weight: 2},
 					},
-					weight: 16,
+					weight: 8,
 				},
 			},
 		},
@@ -241,13 +241,13 @@ func TestEndpointsByNetworkFilter_WithConfig(t *testing.T) {
 				{
 					lbEps: []LbEpInfo{
 						// 1 local endpoint on network2
-						{address: "20.0.0.1", weight: 4},
-						{address: "20.0.0.2", weight: 4},
-						{address: "20.0.0.3", weight: 4},
+						{address: "20.0.0.1", weight: 2},
+						{address: "20.0.0.2", weight: 2},
+						{address: "20.0.0.3", weight: 2},
 						// 1 endpoint on network4 with no gateway (i.e. directly accessible)
-						{address: "40.0.0.1", weight: 4},
+						{address: "40.0.0.1", weight: 2},
 					},
-					weight: 16,
+					weight: 8,
 				},
 			},
 		},
@@ -258,9 +258,9 @@ func TestEndpointsByNetworkFilter_WithConfig(t *testing.T) {
 				{
 					lbEps: []LbEpInfo{
 						// 1 endpoint on network4 with no gateway (i.e. directly accessible)
-						{address: "40.0.0.1", weight: 4},
+						{address: "40.0.0.1", weight: 2},
 					},
-					weight: 4,
+					weight: 2,
 				},
 			},
 		},
@@ -271,9 +271,9 @@ func TestEndpointsByNetworkFilter_WithConfig(t *testing.T) {
 				{
 					lbEps: []LbEpInfo{
 						// 1 local endpoint on network4
-						{address: "40.0.0.1", weight: 4},
+						{address: "40.0.0.1", weight: 2},
 					},
-					weight: 4,
+					weight: 2,
 				},
 			},
 		},

--- a/pilot/pkg/xds/ep_filters_test.go
+++ b/pilot/pkg/xds/ep_filters_test.go
@@ -18,6 +18,8 @@ import (
 	"sort"
 	"testing"
 
+	endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
 	security "istio.io/api/security/v1beta1"
@@ -45,74 +47,128 @@ type LocLbEpInfo struct {
 	weight uint32
 }
 
+func (i LocLbEpInfo) getAddrs() []string {
+	addrs := make([]string, 0)
+	for _, ep := range i.lbEps {
+		addrs = append(addrs, ep.address)
+	}
+	return addrs
+}
+
 var networkFiltered = []networkFilterCase{
 	{
-		name: "from_network1",
-		conn: xdsConnection("network1"),
+		name: "from_network1_cluster1a",
+		conn: xdsConnection("network1", "cluster1a"),
 		want: []LocLbEpInfo{
 			{
 				lbEps: []LbEpInfo{
-					// 2 local endpoints
-					{address: "10.0.0.1", weight: 2},
-					{address: "10.0.0.2", weight: 2},
-					// 1 endpoint to gateway of network2 with weight 1 because it has 1 endpoint
-					{address: "2.2.2.2", weight: 1},
-					{address: "2.2.2.20", weight: 1},
-					// network4 has no gateway, which means it can be accessed from network1
-					{address: "40.0.0.1", weight: 2},
+					// 2 local endpoints on network1
+					{address: "10.0.0.1", weight: 4},
+					{address: "10.0.0.2", weight: 4},
+					// 1 endpoint on network2, cluster2a
+					{address: "2.2.2.2", weight: 4},
+					// 2 endpoints on network2, cluster2b
+					{address: "2.2.2.20", weight: 8},
+					// 1 endpoint on network4 with no gateway (i.e. directly accessible)
+					{address: "40.0.0.1", weight: 4},
 				},
-				weight: 8,
+				weight: 24,
 			},
 		},
 	},
 	{
-		name: "from_network2",
-		conn: xdsConnection("network2"),
+		name: "from_network1_cluster1b",
+		conn: xdsConnection("network1", "cluster1b"),
 		want: []LocLbEpInfo{
 			{
 				lbEps: []LbEpInfo{
-					// 1 local endpoint
-					{address: "20.0.0.1", weight: 2},
-					// 1 endpoint to gateway of network1 with weight 4 because it has 2 endpoints
-					{address: "1.1.1.1", weight: 4},
-					{address: "40.0.0.1", weight: 2},
+					// 2 local endpoints on network1
+					{address: "10.0.0.1", weight: 4},
+					{address: "10.0.0.2", weight: 4},
+					// 1 endpoint on network2, cluster2a
+					{address: "2.2.2.2", weight: 4},
+					// 2 endpoints on network2, cluster2b
+					{address: "2.2.2.20", weight: 8},
+					// 1 endpoint on network4 with no gateway (i.e. directly accessible)
+					{address: "40.0.0.1", weight: 4},
 				},
-				weight: 8,
+				weight: 24,
 			},
 		},
 	},
 	{
-		name: "from_network3",
-		conn: xdsConnection("network3"),
+		name: "from_network2_cluster2a",
+		conn: xdsConnection("network2", "cluster2a"),
 		want: []LocLbEpInfo{
 			{
 				lbEps: []LbEpInfo{
-					// 1 endpoint to gateway of network1 with weight 4 because it has 2 endpoints
-					{address: "1.1.1.1", weight: 4},
-					// 1 endpoint to gateway of network2 with weight 2 because it has 1 endpoint
-					{address: "2.2.2.2", weight: 1},
-					{address: "2.2.2.20", weight: 1},
-					{address: "40.0.0.1", weight: 2},
+					// 3 local endpoints in network2
+					{address: "20.0.0.1", weight: 4},
+					{address: "20.0.0.2", weight: 4},
+					{address: "20.0.0.3", weight: 4},
+					// 2 endpoint on network1 with weight aggregated at the gateway
+					{address: "1.1.1.1", weight: 8},
+					// 1 endpoint on network4 with no gateway (i.e. directly accessible)
+					{address: "40.0.0.1", weight: 4},
 				},
-				weight: 8,
+				weight: 24,
 			},
 		},
 	},
 	{
-		name: "from_network4",
-		conn: xdsConnection("network4"),
+		name: "from_network2_cluster2b",
+		conn: xdsConnection("network2", "cluster2b"),
 		want: []LocLbEpInfo{
 			{
 				lbEps: []LbEpInfo{
-					// 1 local endpoint
-					{address: "40.0.0.1", weight: 2},
-					// 1 endpoint to gateway of network1 with weight 2 because it has 2 endpoints
-					{address: "1.1.1.1", weight: 4},
-					// 1 endpoint to gateway of network2 with weight 1 because it has 1 endpoint
-					{address: "2.2.2.2", weight: 1},
-					{address: "2.2.2.20", weight: 1},
+					// 3 local endpoints in network2
+					{address: "20.0.0.1", weight: 4},
+					{address: "20.0.0.2", weight: 4},
+					{address: "20.0.0.3", weight: 4},
+					// 2 endpoint on network1 with weight aggregated at the gateway
+					{address: "1.1.1.1", weight: 8},
+					// 1 endpoint on network4 with no gateway (i.e. directly accessible)
+					{address: "40.0.0.1", weight: 4},
 				},
-				weight: 8,
+				weight: 24,
+			},
+		},
+	},
+	{
+		name: "from_network3_cluster3",
+		conn: xdsConnection("network3", "cluster3"),
+		want: []LocLbEpInfo{
+			{
+				lbEps: []LbEpInfo{
+					// 2 endpoint on network2 with weight aggregated at the gateway
+					{address: "1.1.1.1", weight: 8},
+					// 1 endpoint on network2, cluster2a
+					{address: "2.2.2.2", weight: 4},
+					// 2 endpoints on network2, cluster2b
+					{address: "2.2.2.20", weight: 8},
+					// 1 endpoint on network4 with no gateway (i.e. directly accessible)
+					{address: "40.0.0.1", weight: 4},
+				},
+				weight: 24,
+			},
+		},
+	},
+	{
+		name: "from_network4_cluster4",
+		conn: xdsConnection("network4", "cluster4"),
+		want: []LocLbEpInfo{
+			{
+				lbEps: []LbEpInfo{
+					// 1 local endpoint on network4
+					{address: "40.0.0.1", weight: 4},
+					// 2 endpoint on network2 with weight aggregated at the gateway
+					{address: "1.1.1.1", weight: 8},
+					// 1 endpoint on network2, cluster2a
+					{address: "2.2.2.2", weight: 4},
+					// 2 endpoints on network2, cluster2b
+					{address: "2.2.2.20", weight: 8},
+				},
+				weight: 24,
 			},
 		},
 	},
@@ -130,59 +186,94 @@ func TestEndpointsByNetworkFilter(t *testing.T) {
 func TestEndpointsByNetworkFilter_WithConfig(t *testing.T) {
 	noCrossNetwork := []networkFilterCase{
 		{
-			name: "from_network1",
-			conn: xdsConnection("network1"),
+			name: "from_network1_cluster1a",
+			conn: xdsConnection("network1", "cluster1a"),
 			want: []LocLbEpInfo{
 				{
 					lbEps: []LbEpInfo{
-						// 2 local endpoints
-						{address: "10.0.0.1", weight: 2},
-						{address: "10.0.0.2", weight: 2},
-						// network4 has no gateway, which means it can be accessed from network1
-						{address: "40.0.0.1", weight: 2},
+						// 2 local endpoints on network1
+						{address: "10.0.0.1", weight: 4},
+						{address: "10.0.0.2", weight: 4},
+						// 1 endpoint on network4 with no gateway (i.e. directly accessible)
+						{address: "40.0.0.1", weight: 4},
 					},
-					weight: 6,
+					weight: 12,
 				},
 			},
 		},
 		{
-			name: "from_network2",
-			conn: xdsConnection("network2"),
+			name: "from_network1_cluster1b",
+			conn: xdsConnection("network1", "cluster1b"),
 			want: []LocLbEpInfo{
 				{
 					lbEps: []LbEpInfo{
-						// 1 local endpoint
-						{address: "20.0.0.1", weight: 2},
-						// network4 has no gateway, which means it can be accessed from network2
-						{address: "40.0.0.1", weight: 2},
+						// 2 local endpoints on network1
+						{address: "10.0.0.1", weight: 4},
+						{address: "10.0.0.2", weight: 4},
+						// 1 endpoint on network4 with no gateway (i.e. directly accessible)
+						{address: "40.0.0.1", weight: 4},
+					},
+					weight: 12,
+				},
+			},
+		},
+		{
+			name: "from_network2_cluster2a",
+			conn: xdsConnection("network2", "cluster2a"),
+			want: []LocLbEpInfo{
+				{
+					lbEps: []LbEpInfo{
+						// 1 local endpoint on network2
+						{address: "20.0.0.1", weight: 4},
+						{address: "20.0.0.2", weight: 4},
+						{address: "20.0.0.3", weight: 4},
+						// 1 endpoint on network4 with no gateway (i.e. directly accessible)
+						{address: "40.0.0.1", weight: 4},
+					},
+					weight: 16,
+				},
+			},
+		},
+		{
+			name: "from_network2_cluster2b",
+			conn: xdsConnection("network2", "cluster2b"),
+			want: []LocLbEpInfo{
+				{
+					lbEps: []LbEpInfo{
+						// 1 local endpoint on network2
+						{address: "20.0.0.1", weight: 4},
+						{address: "20.0.0.2", weight: 4},
+						{address: "20.0.0.3", weight: 4},
+						// 1 endpoint on network4 with no gateway (i.e. directly accessible)
+						{address: "40.0.0.1", weight: 4},
+					},
+					weight: 16,
+				},
+			},
+		},
+		{
+			name: "from_network3_cluster3",
+			conn: xdsConnection("network3", "cluster3"),
+			want: []LocLbEpInfo{
+				{
+					lbEps: []LbEpInfo{
+						// 1 endpoint on network4 with no gateway (i.e. directly accessible)
+						{address: "40.0.0.1", weight: 4},
 					},
 					weight: 4,
 				},
 			},
 		},
 		{
-			name: "from_network3",
-			conn: xdsConnection("network3"),
+			name: "from_network4_cluster4",
+			conn: xdsConnection("network4", "cluster4"),
 			want: []LocLbEpInfo{
 				{
 					lbEps: []LbEpInfo{
-						// network4 has no gateway, which means it can be accessed from network3
-						{address: "40.0.0.1", weight: 2},
+						// 1 local endpoint on network4
+						{address: "40.0.0.1", weight: 4},
 					},
-					weight: 2,
-				},
-			},
-		},
-		{
-			name: "from_network4",
-			conn: xdsConnection("network4"),
-			want: []LocLbEpInfo{
-				{
-					lbEps: []LbEpInfo{
-						// 1 local endpoint
-						{address: "40.0.0.1", weight: 2},
-					},
-					weight: 2,
+					weight: 4,
 				},
 			},
 		},
@@ -486,7 +577,8 @@ func TestEndpointsByNetworkFilter_SkipLBWithHostname(t *testing.T) {
 		Hostname: "istio-ingressgateway.istio-system.svc.cluster.local",
 		Attributes: model.ServiceAttributes{
 			ClusterExternalAddresses: map[cluster.ID][]string{
-				"cluster2": {""},
+				"cluster2a": {""},
+				"cluster2b": {""},
 			},
 		},
 	}}, origServices...))
@@ -536,7 +628,8 @@ func runNetworkFilterTest(t *testing.T, env *model.Environment, tests []networkF
 
 			for i, ep := range filtered {
 				if len(ep.llbEndpoints.LbEndpoints) != len(tt.want[i].lbEps) {
-					t.Errorf("Unexpected number of LB endpoints within endpoint %d: %v, want %v", i, len(ep.llbEndpoints.LbEndpoints), len(tt.want[i].lbEps))
+					t.Errorf("Unexpected number of LB endpoints within endpoint %d: %v, want %v",
+						i, getLbEndpointAddrs(&ep.llbEndpoints), tt.want[i].getAddrs())
 				}
 
 				if ep.llbEndpoints.LoadBalancingWeight.GetValue() != tt.want[i].weight {
@@ -549,6 +642,12 @@ func runNetworkFilterTest(t *testing.T, env *model.Environment, tests []networkF
 					for _, wantLbEp := range tt.want[i].lbEps {
 						if addr == wantLbEp.address {
 							found = true
+
+							// Now compare the weight.
+							if lbEp.GetLoadBalancingWeight().Value != wantLbEp.weight {
+								t.Errorf("Unexpected weight for endpoint %s: got %v, want %v",
+									addr, lbEp.GetLoadBalancingWeight().Value, wantLbEp.weight)
+							}
 							break
 						}
 					}
@@ -561,10 +660,13 @@ func runNetworkFilterTest(t *testing.T, env *model.Environment, tests []networkF
 	}
 }
 
-func xdsConnection(network network.ID) *Connection {
+func xdsConnection(nw network.ID, c cluster.ID) *Connection {
 	return &Connection{
 		proxy: &model.Proxy{
-			Metadata: &model.NodeMetadata{Network: network},
+			Metadata: &model.NodeMetadata{
+				Network:   nw,
+				ClusterID: c,
+			},
 		},
 	}
 }
@@ -575,59 +677,58 @@ func xdsConnection(network network.ID) *Connection {
 //  - 1 gateway for network3
 //  - 0 gateways for network4
 func environment() *model.Environment {
-	return &model.Environment{
-		ServiceDiscovery: memregistry.NewServiceDiscovery([]*model.Service{
-			{
-				Hostname:   "example.ns.svc.cluster.local",
-				Attributes: model.ServiceAttributes{Name: "example", Namespace: "ns"},
-			},
-		}),
+	sd := memregistry.NewServiceDiscovery([]*model.Service{
+		{
+			Hostname:   "example.ns.svc.cluster.local",
+			Attributes: model.ServiceAttributes{Name: "example", Namespace: "ns"},
+		},
+	})
+	env := &model.Environment{
+		ServiceDiscovery: sd,
 		IstioConfigStore: model.MakeIstioStore(memory.Make(collections.Pilot)),
 		Watcher:          mesh.NewFixedWatcher(&meshconfig.MeshConfig{RootNamespace: "istio-system"}),
-		NetworksWatcher: mesh.NewFixedNetworksWatcher(&meshconfig.MeshNetworks{
-			Networks: map[string]*meshconfig.Network{
-				"network1": {
-					Gateways: []*meshconfig.Network_IstioNetworkGateway{
-						{
-							Gw: &meshconfig.Network_IstioNetworkGateway_Address{
-								Address: "1.1.1.1",
-							},
-							Port: 80,
-						},
-					},
-				},
-				"network2": {
-					Gateways: []*meshconfig.Network_IstioNetworkGateway{
-						{
-							Gw: &meshconfig.Network_IstioNetworkGateway_Address{
-								Address: "2.2.2.2",
-							},
-							Port: 80,
-						},
-						{
-							Gw: &meshconfig.Network_IstioNetworkGateway_Address{
-								Address: "2.2.2.20",
-							},
-							Port: 80,
-						},
-					},
-				},
-				"network3": {
-					Gateways: []*meshconfig.Network_IstioNetworkGateway{
-						{
-							Gw: &meshconfig.Network_IstioNetworkGateway_Address{
-								Address: "3.3.3.3",
-							},
-							Port: 443,
-						},
-					},
-				},
-				"network4": {
-					Gateways: []*meshconfig.Network_IstioNetworkGateway{},
-				},
-			},
-		}),
+		NetworksWatcher:  mesh.NewFixedNetworksWatcher(&meshconfig.MeshNetworks{}),
 	}
+
+	// Configure the network gateways.
+	sd.AddGateways(
+		// network1 has only 1 gateway in cluster1a, which will be used for the endpoints
+		// in both cluster1a and cluster1b.
+		&model.NetworkGateway{
+			Network: "network1",
+			Cluster: "cluster1a",
+			Addr:    "1.1.1.1",
+			Port:    80,
+		},
+
+		// network2 has one gateway in each cluster2a and cluster2b. When targeting a particular
+		// endpoint, only the gateway for its cluster will be selected. Since the clusters do not
+		// have the same number of endpoints, the weights for the gateways will be different.
+		&model.NetworkGateway{
+			Network: "network2",
+			Cluster: "cluster2a",
+			Addr:    "2.2.2.2",
+			Port:    80,
+		},
+		&model.NetworkGateway{
+			Network: "network2",
+			Cluster: "cluster2b",
+			Addr:    "2.2.2.20",
+			Port:    80,
+		},
+
+		// network3 has a gateway in cluster3, but no endpoints.
+		&model.NetworkGateway{
+			Network: "network3",
+			Cluster: "cluster3",
+			Addr:    "3.3.3.3",
+			Port:    443,
+		},
+
+		// network4 has no gateways, so its endpoints will be considered reachable from every
+		// other cluster.
+	)
+	return env
 }
 
 // testShards creates endpoints to be handed to the filter:
@@ -636,25 +737,54 @@ func environment() *model.Environment {
 //  - 0 endpoints in network3
 //  - 1 endpoints in network4
 //
-// All endpoints are part of service example.ns.svc.cluster.local on port 80 (http) on cluster-0
+// All endpoints are part of service example.ns.svc.cluster.local on port 80 (http).
 func testShards() *EndpointShards {
 	shards := &EndpointShards{Shards: map[string][]*model.IstioEndpoint{
-		"cluster-0": {
+		// network1 has one endpoint in each cluster
+		"cluster1a": {
 			{Network: "network1", Address: "10.0.0.1"},
+		},
+		"cluster1b": {
 			{Network: "network1", Address: "10.0.0.2"},
+		},
+
+		// network2 has an imbalance of endpoints between its clusters
+		"cluster2a": {
 			{Network: "network2", Address: "20.0.0.1"},
+		},
+		"cluster2b": {
+			{Network: "network2", Address: "20.0.0.2"},
+			{Network: "network2", Address: "20.0.0.3"},
+		},
+
+		// network3 has no endpoints.
+
+		// network4 has a single endpoint, but not gateway so it will always
+		// be considered directly reachable.
+		"cluster4": {
 			{Network: "network4", Address: "40.0.0.1"},
 		},
 	}}
 	// apply common properties
-	for i, ep := range shards.Shards["cluster-0"] {
-		ep.ServicePortName = "http"
-		ep.Namespace = "ns"
-		ep.HostName = "example.ns.svc.cluster.local"
-		ep.EndpointPort = 8080
-		ep.TLSMode = "istio"
-		ep.Labels = map[string]string{"app": "example"}
-		shards.Shards["cluster-0"][i] = ep
+	for clusterID, shard := range shards.Shards {
+		for i, ep := range shard {
+			ep.ServicePortName = "http"
+			ep.Namespace = "ns"
+			ep.HostName = "example.ns.svc.cluster.local"
+			ep.EndpointPort = 8080
+			ep.TLSMode = "istio"
+			ep.Labels = map[string]string{"app": "example"}
+			ep.Locality.ClusterID = cluster.ID(clusterID)
+			shards.Shards[clusterID][i] = ep
+		}
 	}
 	return shards
+}
+
+func getLbEndpointAddrs(ep *endpoint.LocalityLbEndpoints) []string {
+	addrs := make([]string, 0)
+	for _, lbEp := range ep.LbEndpoints {
+		addrs = append(addrs, lbEp.GetEndpoint().Address.GetSocketAddress().Address)
+	}
+	return addrs
 }

--- a/tests/integration/pilot/mcs/discoverability/discoverability_test.go
+++ b/tests/integration/pilot/mcs/discoverability/discoverability_test.go
@@ -154,13 +154,9 @@ func deployEchos(t resource.Context) error {
 	}
 	testNS = ns.Name()
 
-	// TODO(https://github.com/istio/istio/issues/33526)
-	// To avoid a multi-network bug with MCS, we'll only deploy our workloads on the same network
-	clusters := findClustersOnTheSameNetwork(t)
-
 	// Create echo instances in each cluster.
 	echos, err = echoboot.NewBuilder(t).
-		WithClusters(clusters...).
+		WithClusters(t.Clusters()...).
 		WithConfig(echo.Config{
 			Service:   serviceA,
 			Namespace: ns,
@@ -172,18 +168,6 @@ func deployEchos(t resource.Context) error {
 			Ports:     common.EchoPorts,
 		}).Build()
 	return err
-}
-
-func findClustersOnTheSameNetwork(t resource.Context) cluster.Clusters {
-	networkMap := t.Clusters().ByNetwork()
-	var out cluster.Clusters
-	// Pick the network with the most clusters.
-	for _, clusters := range networkMap {
-		if len(clusters) > len(out) {
-			out = clusters
-		}
-	}
-	return out
 }
 
 func sendTrafficBetweenAllClusters(


### PR DESCRIPTION
Previous logic was broken for the case when only some clusters export service endpoints (via MCS ServiceExport). In this case, it's possible that we can accidentally hit unexported endpoints that share the same network as exported endpoints.

Refactoring the load balancing logic to prefer gateways with the same cluster as the endpoint. Going forward, we should recommend installing east-west gateway in all clusters to support the MCS use case.

Fixes #33526



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.