### PR TITLE
Remove network from EDS metadata

### DIFF
--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -490,10 +490,6 @@ func BuildLbEndpointMetadata(network network.ID, tlsMode, workloadname, namespac
 		FilterMetadata: map[string]*pstruct.Struct{},
 	}
 
-	if network != "" {
-		addIstioEndpointLabel(metadata, "network", &pstruct.Value{Kind: &pstruct.Value_StringValue{StringValue: network.String()}})
-	}
-
 	if tlsMode != "" && tlsMode != model.DisabledTLSModeLabel {
 		metadata.FilterMetadata[EnvoyTransportSocketMetadataKey] = &pstruct.Struct{
 			Fields: map[string]*pstruct.Value{


### PR DESCRIPTION
As far as I can tell this is only legacy from mixer and is not used.

```
$ benchstat /tmp/{old,new}
name                         old time/op        new time/op        delta
EndpointGeneration/100/10-6        3.53ms ± 3%        2.81ms ± 2%  -20.36%  (p=0.008 n=5+5)

name                         old kb/msg         new kb/msg         delta
EndpointGeneration/100/10-6          84.2 ± 0%          59.2 ± 0%  -29.68%  (p=0.008 n=5+5)

name                         old resources/msg  new resources/msg  delta
EndpointGeneration/100/10-6          10.0 ± 0%          10.0 ± 0%     ~     (all equal)

name                         old alloc/op       new alloc/op       delta
EndpointGeneration/100/10-6         871kB ± 0%         709kB ± 0%  -18.63%  (p=0.008 n=5+5)

name                         old allocs/op      new allocs/op      delta
EndpointGeneration/100/10-6         18.3k ± 0%         14.2k ± 0%  -22.00%  (p=0.008 n=5+5)
```



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.