### PR TITLE
Delegation virtual service allows regex match

### DIFF
--- a/pilot/pkg/model/virtualservice.go
+++ b/pilot/pkg/model/virtualservice.go
@@ -429,8 +429,13 @@ func stringMatchConflict(root, leaf *networking.StringMatch) bool {
 	if root == nil || leaf == nil {
 		return false
 	}
-	// regex match is not allowed
-	if root.GetRegex() != "" || leaf.GetRegex() != "" {
+
+	// TODO: check regex conflict
+	// if one has regex ,the others can not be set
+	if root.GetRegex() != "" && (leaf.GetRegex() != "" || leaf.GetPrefix() != "" || leaf.GetExact() != "") {
+		return true
+	}
+	if leaf.GetRegex() != "" && (root.GetPrefix() != "" || root.GetExact() != "") {
 		return true
 	}
 	// root is exact match
@@ -459,7 +464,7 @@ func stringMatchConflict(root, leaf *networking.StringMatch) bool {
 		}
 	}
 
-	return true
+	return false
 }
 
 func isRootVs(vs *networking.VirtualService) bool {

--- a/pkg/config/validation/virtualservice_test.go
+++ b/pkg/config/validation/virtualservice_test.go
@@ -247,7 +247,7 @@ func TestValidateRootHTTPRoute(t *testing.T) {
 					},
 				},
 			}},
-		}, valid: false},
+		}, valid: true},
 		{name: "regex uri match", route: &networking.HTTPRoute{
 			Delegate: &networking.Delegate{
 				Name:      "test",
@@ -258,7 +258,7 @@ func TestValidateRootHTTPRoute(t *testing.T) {
 					MatchType: &networking.StringMatch_Regex{Regex: "test"},
 				},
 			}},
-		}, valid: false},
+		}, valid: true},
 		{name: "prefix uri match", route: &networking.HTTPRoute{
 			Delegate: &networking.Delegate{
 				Name:      "test",
@@ -323,7 +323,7 @@ func TestValidateRootHTTPRoute(t *testing.T) {
 					},
 				},
 			}},
-		}, valid: false},
+		}, valid: true},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
It is very difficult to check whether two regular expressions are in conflict, so the checking of conflict is not considered for the moment.
Regardless of the HTTPRoute type, the same validation logic is used to validate the networking.HTTPRoute object



[x] Configuration Infrastructure
[x] Docs
[x] Installation
[ ] Networking
[ ] Performance and Scalability
[x] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure

Fixes #29845

[x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
