### PR TITLE
fix secret controller log line

### DIFF
--- a/pkg/kube/secretcontroller/secretcontroller.go
+++ b/pkg/kube/secretcontroller/secretcontroller.go
@@ -240,7 +240,7 @@ func (c *Controller) Run(stopCh <-chan struct{}) {
 		log.Error("Failed to sync secret controller cache")
 		return
 	}
-	log.Infof("Secret controller cache synced in %v", time.Since(t0))
+	log.Info("Secret controller cache synced in ", time.Since(t0))
 	// all secret events before this signal must be processed before we're marked "ready"
 	c.queue.Add(initialSyncSignal)
 	if features.RemoteClusterTimeout != 0 {


### PR DESCRIPTION
This log line is not printed because if there is only one arg, it seems using fmt.Sprint

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
