### PR TITLE
Fuzzing: Run FuzzInitContext on OSS-fuzz

### DIFF
--- a/tests/fuzz/oss_fuzz_build.sh
+++ b/tests/fuzz/oss_fuzz_build.sh
@@ -19,3 +19,4 @@ compile_go_fuzzer istio.io/istio/tests/fuzz FuzzParseAndBuildSchema fuzz_parse_a
 compile_go_fuzzer istio.io/istio/tests/fuzz FuzzConfigValidation fuzz_config_validation
 compile_go_fuzzer istio.io/istio/tests/fuzz FuzzParseMeshNetworks fuzz_parse_mesh_networks
 compile_go_fuzzer istio.io/istio/tests/fuzz FuzzValidateMeshConfig fuzz_validate_mesh_config
+compile_go_fuzzer istio.io/istio/tests/fuzz FuzzInitContext fuzz_init_context


### PR DESCRIPTION
Enables `FuzzInitContext` to run continuously by OSS-fuzz.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[x] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.