### PR TITLE
Add labels section on pod level for  operator and pilot components

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -45,6 +45,9 @@ spec:
         {{- else }}
         istio: pilot
         {{- end }}
+        {{- range $key, $val := .Values.pilot.pilotLabels }}
+        {{ $key }}: "{{ $val }}"
+        {{- end }}
       annotations:
         {{- if .Values.meshConfig.enablePrometheusMerge }}
         prometheus.io/port: "15014"

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -63,6 +63,9 @@ pilot:
   # If false, pilot wil use default values (by default) or user-supplied values.
   configMap: true
 
+  # Additional labels to apply on the pod level for monitoring and logging configuration.
+  pilotLabels: {}
+
 
 sidecarInjectorWebhook:
   # You can use the field called alwaysInjectSelector and neverInjectSelector which will always inject the sidecar or

--- a/manifests/charts/istio-operator/templates/deployment.yaml
+++ b/manifests/charts/istio-operator/templates/deployment.yaml
@@ -12,6 +12,9 @@ spec:
     metadata:
       labels:
         name: istio-operator
+        {{- range $key, $val := .Values.operatorLabels }}
+        {{ $key }}: "{{ $val }}"
+        {{- end }}
     spec:
       serviceAccountName: istio-operator{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
       containers:

--- a/manifests/charts/istio-operator/values.yaml
+++ b/manifests/charts/istio-operator/values.yaml
@@ -27,3 +27,5 @@ operator:
       cpu: 50m
       memory: 128Mi
 
+# Additional labels to apply on the pod level for monitoring and logging configuration.
+operatorLabels: {}


### PR DESCRIPTION
Add labels on pod level for istio-operator and istiod. The additional labels might be required to configure logging and monitoring systems (fluentd as an example) 


[ ] Configuration Infrastructure
[ ] Docs
[ X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.