### PR TITLE
Fuzzing: Add documentation and Dockerfile

### DIFF
--- a/tests/fuzz/Dockerfile.fuzz
+++ b/tests/fuzz/Dockerfile.fuzz
@@ -1,0 +1,24 @@
+# Copyright 2021 Istio Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specif
+
+FROM golang:1.15
+
+RUN apt-get update && apt-get install -y clang
+
+RUN go get -u github.com/dvyukov/go-fuzz/go-fuzz \
+    github.com/dvyukov/go-fuzz/go-fuzz-dep \
+    github.com/dvyukov/go-fuzz/go-fuzz-build
+
+RUN git clone https://github.com/istio/istio /istio
+WORKDIR /istio
+

--- a/tests/fuzz/Dockerfile.fuzz
+++ b/tests/fuzz/Dockerfile.fuzz
@@ -13,12 +13,20 @@
 
 FROM golang:1.15
 
-RUN apt-get update && apt-get install -y clang
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y \
+    clang && \
+    apt-get clean && \
+    rm -rf  /var/log/*log \
+    /var/lib/apt/lists/* \
+    /var/log/apt/* \
+    /var/lib/dpkg/*-old \
+    /var/cache/debconf/*-old
 
 RUN go get -u github.com/dvyukov/go-fuzz/go-fuzz \
     github.com/dvyukov/go-fuzz/go-fuzz-dep \
     github.com/dvyukov/go-fuzz/go-fuzz-build
 
-RUN git clone https://github.com/istio/istio /istio
+COPY . /istio
 WORKDIR /istio
 

--- a/tests/fuzz/README.md
+++ b/tests/fuzz/README.md
@@ -1,16 +1,33 @@
 # Istio fuzzing
+
 Istio has a series of fuzzers that run continuously through OSS-fuzz.
 
 ## Local testing
-To run the fuzzers, first build the fuzzer image from `tests/fuzz`:
+
+To run the fuzzers using `Dockerfile.fuzz`, follow these steps:
+
+```bash
+git clone https://github.com/istio/istio
+```
+
+```bash
+cd istio
+```
+
+```bash
+mv tests/fuzz/Dockerfile.fuzz ./
+```
 
 ```bash
 sudo docker build -t istio-fuzz -f Dockerfile.fuzz .
 ```
+
 Next, get a shell in the container:
+
 ```bash
 sudo docker run -it istio-fuzz
 ```
+
 At this point, you can navigate to `tests/fuzz` and build any of the fuzzers:
 
 ```bash
@@ -22,6 +39,7 @@ clang -fsanitize=fuzzer PACKAGE_NAME.a -o fuzzer
 If you encounter any errors when linking with `PACKAGE_NAME.a`, simply `ls` after running `go-fuzz-build...`, and you will see the archive to link with.
 
 If everything goes well until this point, you can run the fuzzer:
+
 ```bash
 ./fuzzer
 ```

--- a/tests/fuzz/README.md
+++ b/tests/fuzz/README.md
@@ -1,0 +1,27 @@
+# Istio fuzzing
+Istio has a series of fuzzers that run continuously through OSS-fuzz.
+
+## Local testing
+To run the fuzzers, first build the fuzzer image from `tests/fuzz`:
+
+```bash
+sudo docker build -t istio-fuzz -f Dockerfile.fuzz .
+```
+Next, get a shell in the container:
+```bash
+sudo docker run -it istio-fuzz
+```
+At this point, you can navigate to `tests/fuzz` and build any of the fuzzers:
+
+```bash
+cd $PATH_TO_FUZZER
+go-fuzz-build -libfuzzer -func=FUZZ_NAME && \
+clang -fsanitize=fuzzer PACKAGE_NAME.a -o fuzzer
+```
+
+If you encounter any errors when linking with `PACKAGE_NAME.a`, simply `ls` after running `go-fuzz-build...`, and you will see the archive to link with.
+
+If everything goes well until this point, you can run the fuzzer:
+```bash
+./fuzzer
+```


### PR DESCRIPTION
Adds a Dockerfile and documentation on running the go-fuzz fuzzers locally.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.