### PR TITLE
istio: re-invoke sidecar injector IfNeeded

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/mutatingwebhook.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/mutatingwebhook.yaml
@@ -21,6 +21,7 @@ a unique prefix to each. */}}
     apiVersions: ["v1"]
     resources: ["pods"]
   failurePolicy: Fail
+  reinvocationPolicy: IfNeeded
   admissionReviewVersions: ["v1beta1", "v1"]
 {{- end }}
 {{- /* Installed for each revision - not installed for cluster resources ( cluster roles, bindings, crds) */}}

--- a/manifests/charts/istio-control/istio-discovery/templates/revision-tags.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/revision-tags.yaml
@@ -20,6 +20,7 @@
       apiVersions: ["v1"]
       resources: ["pods"]
   failurePolicy: Fail
+  reinvocationPolicy: IfNeeded
   admissionReviewVersions: ["v1beta1", "v1"]
 {{- end }}
 

--- a/releasenotes/notes/reinvoke-injector-ifneeded.yaml
+++ b/releasenotes/notes/reinvoke-injector-ifneeded.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+issue:
+releaseNotes:
+  - |
+    **Updated** the sidecar injector webhook reinvocationPolicy to IfNeeded.


### PR DESCRIPTION
#28800 made the sidecar injector webhook idempotent. Internally we have another mutating webhook that updates the istio rev label to control the rollout of new istio control plane versions. Since sidecar injector webhook is idempotent, changing the reinvocationPolicy to IfNeeded so the sidecar injector can be invoked if related labels are updated.

[ ] Configuration Infrastructure
[ ] Docs
[x] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure

Pull Request Attributes

Please check any characteristics that apply to this pull request.

[ ] Does not have any user-facing changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.

@howardjohn