### PR TITLE
fix authz dry-run test flaky by reducing the logWindowDuration

### DIFF
--- a/tests/integration/telemetry/stackdriver/stackdriver_filter_dry_run_test.go
+++ b/tests/integration/telemetry/stackdriver/stackdriver_filter_dry_run_test.go
@@ -67,7 +67,7 @@ func testDryRun(t *testing.T, policies []string, cases []dryRunCase) {
 									return err
 								}
 								return verifyAccessLog(t, cltInstance, tc.wantLog)
-							}, retry.Delay(framework.TelemetryRetryDelay), retry.Timeout(framework.TelemetryRetryTimeout*2))
+							}, retry.Delay(framework.TelemetryRetryDelay), retry.Timeout(framework.TelemetryRetryTimeout))
 							if err != nil {
 								return err
 							}

--- a/tests/integration/telemetry/stackdriver/stackdriver_filter_test.go
+++ b/tests/integration/telemetry/stackdriver/stackdriver_filter_test.go
@@ -167,6 +167,7 @@ meshConfig:
 	cfg.Values["global.proxy.tracer"] = "stackdriver"
 	cfg.Values["pilot.traceSampling"] = "100"
 	cfg.Values["telemetry.v2.accessLogPolicy.enabled"] = "true"
+	cfg.Values["telemetry.v2.accessLogPolicy.logWindowDuration"] = "1s"
 	cfg.Values["global.proxy.componentLogLevel"] = "rbac:debug,wasm:debug"
 
 	// conditionally use a fake metadata server for testing off of GCP


### PR DESCRIPTION
This could potentially fix the https://github.com/istio/istio/issues/33243, also reverted the previous change of doubling the dry-run test timeout.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[x] Policies and Telemetry
[x] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.