### PR TITLE
Build: refactor docker_build outputs to support build multi-arch images

### DIFF
--- a/cni/deployments/kubernetes/Dockerfile.install-cni
+++ b/cni/deployments/kubernetes/Dockerfile.install-cni
@@ -16,11 +16,12 @@ FROM ${BASE_DISTRIBUTION}
 
 LABEL description="Istio CNI plugin installer."
 
-COPY istio-cni /opt/cni/bin/
-COPY install-cni /usr/local/bin/
+ARG TARGETARCH
+COPY ${TARGETARCH:-amd64}/istio-cni /opt/cni/bin/istio-cni
+COPY ${TARGETARCH:-amd64}/install-cni /usr/local/bin/install-cni
 
 # Copy over the Taint binary
-COPY istio-cni-taint /opt/local/bin/
+COPY ${TARGETARCH:-amd64}/istio-cni-taint /opt/local/bin/istio-cni-taint
 
 ENV PATH=$PATH:/opt/cni/bin
 WORKDIR /opt/cni/bin

--- a/istioctl/docker/Dockerfile.istioctl
+++ b/istioctl/docker/Dockerfile.istioctl
@@ -2,5 +2,6 @@
 ARG BASE_VERSION=latest
 FROM gcr.io/istio-release/base:${BASE_VERSION}
 USER 1000:1000
-COPY istioctl /usr/local/bin/
+ARG TARGETARCH
+COPY ${TARGETARCH:-amd64}/istioctl /usr/local/bin/istioctl
 ENTRYPOINT ["/usr/local/bin/istioctl"]

--- a/operator/docker/Dockerfile.operator
+++ b/operator/docker/Dockerfile.operator
@@ -15,7 +15,8 @@ FROM gcr.io/istio-release/distroless:${BASE_VERSION} as distroless
 FROM ${BASE_DISTRIBUTION}
 
 # install operator binary
-COPY operator /usr/local/bin/
+ARG TARGETARCH
+COPY ${TARGETARCH:-amd64}/operator /usr/local/bin/operator
 
 # add operator manifests
 COPY manifests/ /var/lib/istio/manifests/

--- a/pilot/docker/Dockerfile.pilot
+++ b/pilot/docker/Dockerfile.pilot
@@ -14,7 +14,8 @@ FROM gcr.io/istio-release/distroless:${BASE_VERSION} as distroless
 # hadolint ignore=DL3006
 FROM ${BASE_DISTRIBUTION}
 
-COPY pilot-discovery /usr/local/bin/
+ARG TARGETARCH
+COPY ${TARGETARCH:-amd64}/pilot-discovery /usr/local/bin/pilot-discovery
 
 # Copy templates for bootstrap generation.
 COPY envoy_bootstrap.json /var/lib/istio/envoy/envoy_bootstrap_tmpl.json

--- a/pilot/docker/Dockerfile.proxyv2
+++ b/pilot/docker/Dockerfile.proxyv2
@@ -28,14 +28,16 @@ COPY envoy_bootstrap.json /var/lib/istio/envoy/envoy_bootstrap_tmpl.json
 COPY gcp_envoy_bootstrap.json /var/lib/istio/envoy/gcp_envoy_bootstrap_tmpl.json
 
 # Install Envoy.
-COPY $SIDECAR /usr/local/bin/$SIDECAR
+ARG TARGETARCH
+COPY ${TARGETARCH:-amd64}/${SIDECAR} /usr/local/bin/${SIDECAR}
 
 # Environment variable indicating the exact proxy sha - for debugging or version-specific configs 
 ENV ISTIO_META_ISTIO_PROXY_SHA $proxy_version
 # Environment variable indicating the exact build, for debugging
 ENV ISTIO_META_ISTIO_VERSION $istio_version
 
-COPY pilot-agent /usr/local/bin/pilot-agent
+ARG TARGETARCH
+COPY ${TARGETARCH:-amd64}/pilot-agent /usr/local/bin/pilot-agent
 
 COPY stats-filter.wasm /etc/istio/extensions/stats-filter.wasm
 COPY stats-filter.compiled.wasm /etc/istio/extensions/stats-filter.compiled.wasm

--- a/pkg/test/echo/docker/Dockerfile.app
+++ b/pkg/test/echo/docker/Dockerfile.app
@@ -2,8 +2,9 @@ ARG BASE_VERSION=latest
 
 FROM gcr.io/istio-release/base:${BASE_VERSION}
 
-COPY client /usr/local/bin/client
-COPY server /usr/local/bin/server
+ARG TARGETARCH
+COPY ${TARGETARCH:-amd64}/client /usr/local/bin/client
+COPY ${TARGETARCH:-amd64}/server /usr/local/bin/server
 COPY certs/cert.crt /cert.crt
 COPY certs/cert.key /cert.key
 

--- a/pkg/test/echo/docker/Dockerfile.app_sidecar
+++ b/pkg/test/echo/docker/Dockerfile.app_sidecar
@@ -16,8 +16,9 @@ RUN echo "istio-proxy ALL=NOPASSWD: ALL" >> /etc/sudoers
 
 # Install the Echo application
 COPY echo-start.sh /usr/local/bin/echo-start.sh
-COPY client /usr/local/bin/client
-COPY server /usr/local/bin/server
+ARG TARGETARCH
+COPY ${TARGETARCH:-amd64}/client /usr/local/bin/client
+COPY ${TARGETARCH:-amd64}/server /usr/local/bin/server
 RUN chmod +x /usr/local/bin/client /usr/local/bin/server
 
 ENTRYPOINT ["/usr/local/bin/echo-start.sh"]

--- a/pkg/test/echo/docker/Dockerfile.app_sidecar_centos_7
+++ b/pkg/test/echo/docker/Dockerfile.app_sidecar_centos_7
@@ -14,8 +14,9 @@ RUN echo "istio-proxy ALL=NOPASSWD: ALL" >> /etc/sudoers
 
 # Install the Echo application
 COPY echo-start.sh /usr/local/bin/echo-start.sh
-COPY client /usr/local/bin/client
-COPY server /usr/local/bin/server
+ARG TARGETARCH
+COPY ${TARGETARCH:-amd64}/client /usr/local/bin/client
+COPY ${TARGETARCH:-amd64}/server /usr/local/bin/server
 RUN chmod +x /usr/local/bin/client /usr/local/bin/server
 
 ENTRYPOINT ["/usr/local/bin/echo-start.sh"]

--- a/pkg/test/echo/docker/Dockerfile.app_sidecar_centos_8
+++ b/pkg/test/echo/docker/Dockerfile.app_sidecar_centos_8
@@ -14,8 +14,9 @@ RUN echo "istio-proxy ALL=NOPASSWD: ALL" >> /etc/sudoers
 
 # Install the Echo application
 COPY echo-start.sh /usr/local/bin/echo-start.sh
-COPY client /usr/local/bin/client
-COPY server /usr/local/bin/server
+ARG TARGETARCH
+COPY ${TARGETARCH:-amd64}/client /usr/local/bin/client
+COPY ${TARGETARCH:-amd64}/server /usr/local/bin/server
 RUN chmod +x /usr/local/bin/client /usr/local/bin/server
 
 ENTRYPOINT ["/usr/local/bin/echo-start.sh"]

--- a/tools/buildx-gen.sh
+++ b/tools/buildx-gen.sh
@@ -26,18 +26,10 @@ shift
 function to_platform_list() {
   image="${1}"
   platforms="${2}"
-  # Allow list images verified to work with multi architecture
-  # Eventually this should be everything but the testing images (app_sidecar_)
-  if [[ "${image}" == base || "${image}" == distroless ]]; then
-    # convert CSV to "foo","bar" list
-    # shellcheck disable=SC2001
-    echo "\"$(echo "${platforms}" | sed 's/,/","/g')\""
-  else
-    echo '"linux/amd64"'
-  fi
+  # convert CSV to "foo","bar" list
+  # shellcheck disable=SC2001
+  echo "\"$(echo "${platforms}" | sed 's/,/","/g')\""
 }
-
-
 
 variants=\"$(for i in ${DOCKER_ALL_VARIANTS}; do echo "\"${i}\""; done | xargs | sed -e 's/ /\", \"/g')\"
 cat <<EOF > "${config}"

--- a/tools/docker-copy.sh
+++ b/tools/docker-copy.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+# Copyright 2019 Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+INPUTS=("${@}")
+TARGET_ARCH=${TARGET_ARCH:-amd64}
+DOCKER_WORKING_DIR=${INPUTS[${#INPUTS[@]}-1]}
+FILES=("${INPUTS[@]:0:${#INPUTS[@]}-1}")
+
+set -eu;
+
+function may_copy_into_arch_named_sub_dir() {
+  FILE=${1}
+  COPY_ARCH_RELATED=${COPY_ARCH_RELATED:-1}
+
+  FILE_INFO=$(file "${FILE}" || true)
+  # when file is an `ELF 64-bit LSB`,
+  # will put an arch named sub dir
+  # like
+  #   arm64/
+  #   amd64/
+  if [[ ${FILE_INFO} == *"ELF 64-bit LSB"* ]]; then
+    chmod 755 "${FILE}"
+
+    case ${FILE_INFO} in
+      *x86-64*)
+        mkdir -p "${DOCKER_WORKING_DIR}/amd64/" && cp -rp "${FILE}" "${DOCKER_WORKING_DIR}/amd64/"
+        ;;
+      *aarch64*)
+        mkdir -p "${DOCKER_WORKING_DIR}/arm64/" && cp -rp "${FILE}" "${DOCKER_WORKING_DIR}/arm64/"
+        ;;
+        *)
+        cp -rp "${FILE}" "${DOCKER_WORKING_DIR}"
+        ;;
+    esac
+
+
+    if [[ ${COPY_ARCH_RELATED} == 1 ]]; then
+      # if other arch files exists, should copy too.
+      for ARCH in "amd64" "arm64"; do
+        # like file `out/linux_amd64/pilot-discovery`
+        # should check  `out/linux_arm64/pilot-discovery` exists then do copy
+
+        FILE_ARCH_RELATED=${FILE/linux_${TARGET_ARCH}/linux_${ARCH}}
+
+        if [[ ${FILE_ARCH_RELATED} != "${FILE}" && -f ${FILE_ARCH_RELATED} ]]; then
+          COPY_ARCH_RELATED=0 may_copy_into_arch_named_sub_dir "${FILE_ARCH_RELATED}"
+        fi
+      done
+    fi
+
+  else
+    cp -rp "${FILE}" "${DOCKER_WORKING_DIR}"
+  fi
+}
+
+
+for FILE in "${FILES[@]}"; do
+  may_copy_into_arch_named_sub_dir "${FILE}"
+done
+
+ls "${DOCKER_WORKING_DIR}";


### PR DESCRIPTION
Signed-off-by: Morlay <morlay.null@gmail.com>


---
Follow this suggestion https://github.com/istio/istio/pull/33724#pullrequestreview-696679939

When we copy to dockerx_build, we set up directory like:

```
. Dockerfile.pilot
  amd64/
  | pilot-discovery
  arm64/
  | pilot-discovery
```

Then we could be use build multi-arch images (now need to wait istio-proxy for arm64 provided)

```
TARGET_ARCH=amd64 make build-linux
TARGET_ARCH=arm64 make build-linux
make dockerx.push DOCKER_ARCHITECTURES=linux/amd64,linux/arm64 
```

All `${TARGETARCH:-amd64}` in Dockerfiles is for docker build if not used docker buildx


once arm64 istio-proxy for arm64 provided. can download into `out/linux_arm64/envoy`

---


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.