### PR TITLE
[1.9] Fix endpointslice duplicate IPs on service update (#33757)

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/endpointslice.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpointslice.go
@@ -197,12 +197,7 @@ func (esc *endpointSliceController) buildIstioEndpointsWithService(name, namespa
 		return nil
 	}
 
-	endpoints := make([]*model.IstioEndpoint, 0)
-	for _, es := range slices {
-		endpoints = append(endpoints, esc.buildIstioEndpoints(es, host)...)
-	}
-
-	return endpoints
+	return esc.endpointCache.Get(host)
 }
 
 func (esc *endpointSliceController) getServiceInfo(es interface{}) (host.Name, string, string) {

--- a/pilot/pkg/serviceregistry/serviceregistry_test.go
+++ b/pilot/pkg/serviceregistry/serviceregistry_test.go
@@ -47,80 +47,21 @@ import (
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/config/schema/gvk"
 	kubeclient "istio.io/istio/pkg/kube"
-	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/util/retry"
 )
-
-type Event struct {
-	kind      string
-	host      string
-	namespace string
-	endpoints int
-	pushReq   *model.PushRequest
-}
-
-type FakeXdsUpdater struct {
-	// Events tracks notifications received by the updater
-	Events chan Event
-}
-
-var _ model.XDSUpdater = &FakeXdsUpdater{}
-
-func (fx *FakeXdsUpdater) EDSUpdate(_, hostname string, namespace string, entry []*model.IstioEndpoint) {
-	fx.Events <- Event{kind: "eds", host: hostname, namespace: namespace, endpoints: len(entry)}
-}
-
-func (fx *FakeXdsUpdater) EDSCacheUpdate(_, hostname string, namespace string, entry []*model.IstioEndpoint) {
-	fx.Events <- Event{kind: "edscache", host: hostname, namespace: namespace, endpoints: len(entry)}
-}
-
-func (fx *FakeXdsUpdater) ConfigUpdate(req *model.PushRequest) {
-	fx.Events <- Event{kind: "xds", pushReq: req}
-}
-
-func (fx *FakeXdsUpdater) ProxyUpdate(_, _ string) {
-}
-
-func (fx *FakeXdsUpdater) SvcUpdate(_, hostname string, namespace string, _ model.Event) {
-	fx.Events <- Event{kind: "svcupdate", host: hostname, namespace: namespace}
-}
-
-func (fx *FakeXdsUpdater) WaitOrFail(t test.Failer, types ...string) *Event {
-	got := fx.Wait(types...)
-	if got == nil {
-		t.Fatal("missing event")
-	}
-	return got
-}
-
-func (fx *FakeXdsUpdater) Wait(types ...string) *Event {
-	for {
-		select {
-		case e := <-fx.Events:
-			for _, et := range types {
-				if e.kind == et {
-					return &e
-				}
-			}
-			continue
-		case <-time.After(1 * time.Second):
-			return nil
-		}
-	}
-}
 
 func setupTest(t *testing.T) (
 	*kubecontroller.Controller,
 	*serviceentry.ServiceEntryStore,
 	model.ConfigStoreCache,
 	kubernetes.Interface,
-	*FakeXdsUpdater) {
+	*xds.FakeXdsUpdater) {
 	t.Helper()
 	client := kubeclient.NewFakeClient()
 
-	eventch := make(chan Event, 100)
+	eventch := make(chan xds.FakeXdsEvent, 100)
 
-	xdsUpdater := &FakeXdsUpdater{
+	xdsUpdater := &xds.FakeXdsUpdater{
 		Events: eventch,
 	}
 	kc := kubecontroller.NewController(client, kubecontroller.Options{XDSUpdater: xdsUpdater, DomainSuffix: "cluster.local"})
@@ -391,14 +332,14 @@ func TestWorkloadInstances(t *testing.T) {
 		// Wait no event pushed when workload entry created as no service entry
 		select {
 		case ev := <-xdsUpdater.Events:
-			t.Fatalf("Got %s event, expect none", ev.kind)
+			t.Fatalf("Got %s event, expect none", ev.Kind)
 		case <-time.After(40 * time.Millisecond):
 		}
 
 		makeService(t, kube, service)
 		event := xdsUpdater.WaitOrFail(t, "edscache")
-		if event.endpoints != 1 {
-			t.Errorf("expecting 1 endpoints, but got %d ", event.endpoints)
+		if event.Endpoints != 1 {
+			t.Errorf("expecting 1 endpoints, but got %d ", event.Endpoints)
 		}
 
 		instances := []ServiceInstanceResponse{{
@@ -446,7 +387,7 @@ func TestWorkloadInstances(t *testing.T) {
 		// Wait no event pushed when workload entry created as no service entry
 		select {
 		case ev := <-xdsUpdater.Events:
-			t.Fatalf("Got %s event, expect none", ev.kind)
+			t.Fatalf("Got %s event, expect none", ev.Kind)
 		case <-time.After(200 * time.Millisecond):
 		}
 
@@ -870,12 +811,12 @@ func setHealth(cfg config.Config, healthy bool) config.Config {
 	})
 }
 
-func waitForEdsUpdate(t *testing.T, xdsUpdater *FakeXdsUpdater, expected int) {
+func waitForEdsUpdate(t *testing.T, xdsUpdater *xds.FakeXdsUpdater, expected int) {
 	t.Helper()
 	retry.UntilSuccessOrFail(t, func() error {
 		event := xdsUpdater.WaitOrFail(t, "eds", "edscache")
-		if event.endpoints != expected {
-			return fmt.Errorf("expecting %d endpoints, but got %d", expected, event.endpoints)
+		if event.Endpoints != expected {
+			return fmt.Errorf("expecting %d endpoints, but got %d", expected, event.Endpoints)
 		}
 		return nil
 	}, retry.Delay(time.Millisecond*10), retry.Timeout(time.Second))
@@ -950,9 +891,11 @@ func TestEndpointsDeduping(t *testing.T) {
 	}, 80, []ServiceInstanceResponse{})
 }
 
-func TestSameIPEndpointSlicing(t *testing.T) {
+// TestEndpointSlicingServiceUpdate is a regression test to ensure we do not end up with duplicate endpoints when a service changes.
+func TestEndpointSlicingServiceUpdate(t *testing.T) {
 	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{
 		KubernetesEndpointMode: kubecontroller.EndpointSliceOnly,
+		EnableFakeXDSUpdater:   true,
 	})
 	namespace := "namespace"
 	labels := map[string]string{
@@ -975,7 +918,62 @@ func TestSameIPEndpointSlicing(t *testing.T) {
 			ClusterIP: "9.9.9.9",
 		},
 	})
-	_, _, _, _, xdsUpdater := setupTest(t)
+	xdsUpdater := s.XdsUpdater.(*xds.FakeXdsUpdater)
+	createEndpointSlice(t, s.KubeClient(), "slice1", "service", namespace, []v1.EndpointPort{{Name: "http", Port: 80}}, []string{"1.2.3.4"})
+	createEndpointSlice(t, s.KubeClient(), "slice2", "service", namespace, []v1.EndpointPort{{Name: "http", Port: 80}}, []string{"1.2.3.4"})
+	expectEndpoints(t, s, "outbound|80||service.namespace.svc.cluster.local", []string{"1.2.3.4:80"})
+	xdsUpdater.WaitOrFail(t, "svcupdate")
+
+	// Trigger a service updates
+	makeService(t, s.KubeClient(), &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "service",
+			Namespace: namespace,
+			Labels:    map[string]string{"foo": "bar"},
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Name: "http",
+				Port: 80,
+			}, {
+				Name: "http-other",
+				Port: 90,
+			}},
+			Selector:  labels,
+			ClusterIP: "9.9.9.9",
+		},
+	})
+	xdsUpdater.WaitOrFail(t, "svcupdate")
+	expectEndpoints(t, s, "outbound|80||service.namespace.svc.cluster.local", []string{"1.2.3.4:80"})
+}
+
+func TestSameIPEndpointSlicing(t *testing.T) {
+	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{
+		KubernetesEndpointMode: kubecontroller.EndpointSliceOnly,
+		EnableFakeXDSUpdater:   true,
+	})
+	namespace := "namespace"
+	labels := map[string]string{
+		"app": "bar",
+	}
+	makeService(t, s.KubeClient(), &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "service",
+			Namespace: namespace,
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Name: "http",
+				Port: 80,
+			}, {
+				Name: "http-other",
+				Port: 90,
+			}},
+			Selector:  labels,
+			ClusterIP: "9.9.9.9",
+		},
+	})
+	xdsUpdater := s.XdsUpdater.(*xds.FakeXdsUpdater)
 
 	// Delete endpoints with same IP
 	createEndpointSlice(t, s.KubeClient(), "slice1", "service", namespace, []v1.EndpointPort{{Name: "http", Port: 80}}, []string{"1.2.3.4"})
@@ -984,10 +982,10 @@ func TestSameIPEndpointSlicing(t *testing.T) {
 
 	// delete slice 1, it should still exist
 	s.KubeClient().DiscoveryV1beta1().EndpointSlices(namespace).Delete(context.TODO(), "slice1", metav1.DeleteOptions{})
-	xdsUpdater.Wait("eds")
+	xdsUpdater.WaitOrFail(t, "eds")
 	expectEndpoints(t, s, "outbound|80||service.namespace.svc.cluster.local", []string{"1.2.3.4:80"})
 	s.KubeClient().DiscoveryV1beta1().EndpointSlices(namespace).Delete(context.TODO(), "slice2", metav1.DeleteOptions{})
-	xdsUpdater.Wait("eds")
+	xdsUpdater.WaitOrFail(t, "eds")
 	expectEndpoints(t, s, "outbound|80||service.namespace.svc.cluster.local", nil)
 }
 

--- a/pilot/pkg/xds/fake.go
+++ b/pilot/pkg/xds/fake.go
@@ -79,6 +79,9 @@ type FakeOptions struct {
 	// Time to debounce
 	// By default, set to 0s to speed up tests
 	DebounceTime time.Duration
+
+	// EnableFakeXDSUpdater will use a XDSUpdater that can be used to watch events
+	EnableFakeXDSUpdater bool
 }
 
 type FakeDiscoveryServer struct {
@@ -88,6 +91,7 @@ type FakeDiscoveryServer struct {
 	Listener     *bufconn.Listener
 	kubeClient   kubelib.Client
 	KubeRegistry *kube.FakeController
+	XdsUpdater   model.XDSUpdater
 }
 
 func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServer {
@@ -133,6 +137,14 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 			})
 		})
 	}
+	var xdsUpdater model.XDSUpdater = s
+	if opts.EnableFakeXDSUpdater {
+		evChan := make(chan FakeXdsEvent, 1000)
+		xdsUpdater = &FakeXdsUpdater{
+			Events:   evChan,
+			Delegate: s,
+		}
+	}
 	for cluster, objs := range k8sObjects {
 		client := kubelib.NewFakeClient(objs...)
 		k8s, _ := kube.NewFakeControllerWithOptions(kube.FakeControllerOptions{
@@ -140,7 +152,7 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 			Client:          client,
 			ClusterID:       cluster,
 			DomainSuffix:    "cluster.local",
-			XDSUpdater:      s,
+			XDSUpdater:      xdsUpdater,
 			NetworksWatcher: opts.NetworksWatcher,
 			Mode:            opts.KubernetesEndpointMode,
 			// we wait for the aggregate to sync
@@ -271,6 +283,7 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 		ConfigGenTest: cg,
 		kubeClient:    defaultKubeClient,
 		KubeRegistry:  defaultKubeController,
+		XdsUpdater:    xdsUpdater,
 	}
 
 	return fake
@@ -598,4 +611,79 @@ func (a *AdsTest) WithMetadata(m model.NodeMetadata) *AdsTest {
 func (a *AdsTest) WithTimeout(t time.Duration) *AdsTest {
 	a.timeout = t
 	return a
+}
+
+type FakeXdsEvent struct {
+	Kind      string
+	Host      string
+	Namespace string
+	Endpoints int
+	PushReq   *model.PushRequest
+}
+
+type FakeXdsUpdater struct {
+	// Events tracks notifications received by the updater
+	Events   chan FakeXdsEvent
+	Delegate model.XDSUpdater
+}
+
+var _ model.XDSUpdater = &FakeXdsUpdater{}
+
+func (fx *FakeXdsUpdater) EDSUpdate(s, hostname string, namespace string, entry []*model.IstioEndpoint) {
+	fx.Events <- FakeXdsEvent{Kind: "eds", Host: hostname, Namespace: namespace, Endpoints: len(entry)}
+	if fx.Delegate != nil {
+		fx.Delegate.EDSUpdate(s, hostname, namespace, entry)
+	}
+}
+
+func (fx *FakeXdsUpdater) EDSCacheUpdate(s, hostname string, namespace string, entry []*model.IstioEndpoint) {
+	fx.Events <- FakeXdsEvent{Kind: "edscache", Host: hostname, Namespace: namespace, Endpoints: len(entry)}
+	if fx.Delegate != nil {
+		fx.Delegate.EDSCacheUpdate(s, hostname, namespace, entry)
+	}
+}
+
+func (fx *FakeXdsUpdater) ConfigUpdate(req *model.PushRequest) {
+	fx.Events <- FakeXdsEvent{Kind: "xds", PushReq: req}
+	if fx.Delegate != nil {
+		fx.Delegate.ConfigUpdate(req)
+	}
+}
+
+func (fx *FakeXdsUpdater) ProxyUpdate(c, p string) {
+	if fx.Delegate != nil {
+		fx.Delegate.ProxyUpdate(c, p)
+	}
+}
+
+func (fx *FakeXdsUpdater) SvcUpdate(s, hostname string, namespace string, e model.Event) {
+	fx.Events <- FakeXdsEvent{Kind: "svcupdate", Host: hostname, Namespace: namespace}
+	if fx.Delegate != nil {
+		fx.Delegate.SvcUpdate(s, hostname, namespace, e)
+	}
+}
+
+func (fx *FakeXdsUpdater) WaitOrFail(t test.Failer, types ...string) *FakeXdsEvent {
+	t.Helper()
+	got := fx.Wait(types...)
+	if got == nil {
+		t.Fatal("missing event")
+	}
+	return got
+}
+
+func (fx *FakeXdsUpdater) Wait(types ...string) *FakeXdsEvent {
+	for {
+		select {
+		case e := <-fx.Events:
+			for _, et := range types {
+				if e.Kind == et {
+					return &e
+				}
+			}
+			continue
+		case <-time.After(1 * time.Second):
+			return nil
+		}
+	}
 }


### PR DESCRIPTION
We should be reading from the cache which is more efficient and handles
deduplication properly, rather than recomputing.

The PR is basically a few lines of a code and a lot of refactoring to
get the test to work. The problem was the XdsUpdater isn't actually set
in FakeXdsServer; in the TestSameIPEndpointSlicing test which this is
based on the Wait() always times out (so its not actually waiting)
because we use a xdsUpdater that isn't actually wired up to the
controller.

(cherry picked from commit 1274725f3d6d95c6ba638113ea503a6d04bda666)
Fixes https://github.com/istio/istio/issues/33762


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.