### PR TITLE
Get targetPort and targetPortName for service port

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/util.go
+++ b/pilot/pkg/serviceregistry/kube/controller/util.go
@@ -102,11 +102,8 @@ func findServiceTargetPort(servicePort *model.Port, k8sService *v1.Service) (int
 	for _, p := range k8sService.Spec.Ports {
 		// TODO(@hzxuzhonghu): check protocol as well as port
 		if p.Name == servicePort.Name || p.Port == int32(servicePort.Port) {
-			if p.TargetPort.Type == intstr.Int && p.TargetPort.IntVal > 0 {
-				targetPort = int(p.TargetPort.IntVal)
-			} else {
-				targetPortName = p.TargetPort.StrVal
-			}
+			targetPort = p.TargetPort.IntValue()
+			targetPortName = p.Name
 			break
 		}
 	}


### PR DESCRIPTION
When ports.name or ports.port of service port are equal to those of k8s service, get the target port and target port name of service port

[ ] Configuration Infrastructure
[x ] Docs
[x ] Installation
[ ] Networking
[ x] Performance and Scalability
[ x] Policies and Telemetry
[ x] Security
[x ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


[x ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
