### PR TITLE
add completion support for namespace

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -65,9 +65,9 @@ require (
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.25.0
 	github.com/ryanuber/go-glob v1.0.0
-	github.com/spf13/cobra v1.1.3
+	github.com/spf13/cobra v1.2.1
 	github.com/spf13/pflag v1.0.5
-	github.com/spf13/viper v1.7.1
+	github.com/spf13/viper v1.8.1
 	github.com/stretchr/testify v1.7.0
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/yl2chen/cidranger v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -952,8 +952,9 @@ github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3
 github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=
 github.com/spf13/cobra v1.0.0/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
 github.com/spf13/cobra v1.1.1/go.mod h1:WnodtKOvamDL/PwE2M4iKs8aMDBZ5Q5klgD3qfVJQMI=
-github.com/spf13/cobra v1.1.3 h1:xghbfqPkxzxP3C/f3n5DdpAbdKLj4ZE4BWQI362l53M=
 github.com/spf13/cobra v1.1.3/go.mod h1:pGADOWyqRD/YMrPZigI/zbliZ2wVD/23d+is3pSWzOo=
+github.com/spf13/cobra v1.2.1 h1:+KmjbUw1hriSNMF55oPrkZcb27aECyrj8V2ytv7kWDw=
+github.com/spf13/cobra v1.2.1/go.mod h1:ExllRjgxM/piMAM+3tAZvg8fsklGAf3tPfi+i8t68Nk=
 github.com/spf13/jwalterweatherman v1.0.0 h1:XHEdyB+EcvlqZamSM4ZOMGlc93t6AcsBEu9Gc1vn7yk=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=

--- a/istioctl/cmd/completion.go
+++ b/istioctl/cmd/completion.go
@@ -93,3 +93,37 @@ func validServiceArgs(cmd *cobra.Command, args []string, toComplete string) ([]s
 	}
 	return servicesName, cobra.ShellCompDirectiveNoFileComp
 }
+
+func getNamespacesName(toComplete string) ([]string, error) {
+	kubeClient, err := kubeClient(kubeconfig, configContext)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx := context.Background()
+	nsList, err := getNamespaces(ctx, kubeClient)
+	if err != nil {
+		return nil, err
+	}
+
+	var nsNameList []string
+	for _, ns := range nsList {
+		if toComplete == "" || strings.HasPrefix(ns.Name, toComplete) {
+			nsNameList = append(nsNameList, ns.Name)
+		}
+	}
+
+	return nsNameList, nil
+}
+
+func validNamespaceArgs(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) != 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	nsName, err := getNamespacesName(toComplete)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	return nsName, cobra.ShellCompDirectiveNoFileComp
+}

--- a/istioctl/cmd/root.go
+++ b/istioctl/cmd/root.go
@@ -157,6 +157,9 @@ debug and diagnose their Istio mesh.
 	rootCmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", v1.NamespaceAll,
 		"Config namespace")
 
+	_ = rootCmd.RegisterFlagCompletionFunc("istioNamespace", validNamespaceArgs)
+	_ = rootCmd.RegisterFlagCompletionFunc("namespace", validNamespaceArgs)
+
 	// Attach the Istio logging options to the command.
 	loggingOptions.AttachCobraFlags(rootCmd)
 	hiddenFlags := []string{

--- a/releasenotes/notes/istioctl_completion-ns.yaml
+++ b/releasenotes/notes/istioctl_completion-ns.yaml
@@ -1,0 +1,30 @@
+apiVersion: release-notes/v2
+
+# This YAML file describes the format for specifying a release notes entry for Istio.
+# This should be filled in for all user facing changes.
+
+# kind describes the type of change that this represents.
+# Valid Values are:
+# - bug-fix -- Used to specify that this change represents a bug fix.
+# - security-fix -- Used to specify that this change represents a vulnerability fix.
+# - feature -- Used to specify a new feature that has been added.
+# - test -- Used to describe additional testing added. This file is optional for
+#   tests, but included for completeness.
+kind: feature
+
+# area describes the area that this change affects.
+# Valid values are:
+# - traffic-management
+# - security
+# - telemetry
+# - installation
+# - istioctl
+# - documentation
+area: istioctl
+
+
+# releaseNotes is a markdown listing of any user facing changes. This will appear in the
+# release notes.
+releaseNotes:
+- |
+  **Added** support for auto-completion of the namespace for istioctl.


### PR DESCRIPTION
Add namespace completion supports for `istioctl`.

```
$ istioctl -i <tab><tab>
istio-system          kube-public          istio-demo          metallb-system
$ istioctl -n <tab><tab>
istio-system          kube-public          istio-demo          metallb-system
```


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[X] User Experience
[ ] Developer Infrastructure

This PR needs [cobra 1.2.0](https://github.com/spf13/cobra/releases) for the PR [RegisterFlagCompletionFunc as a global var not working in multi-threaded programs](https://github.com/spf13/cobra/pull/1423), to fix `concurrent map writes errors` of tests in parallel of istio([here is an example](https://github.com/istio/istio/blob/cabd1c2454702585426e5ddfa08144280ca299b6/pkg/test/framework/components/istio/operator.go#L336), this is introduced by #28434).
And as cobra 1.2.0 add a new feature **Automatically adds completion command for shell completions**, this PR will also add a new command `istioctl completion`. I will replace `istioctl collateral --bash/--zsh` to `istioctl completion bash/zsh` in another PR later. 



Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.