### PR TITLE
Add back empty check & delete to cni plugin.

### DIFF
--- a/cni/cmd/istio-cni/main.go
+++ b/cni/cmd/istio-cni/main.go
@@ -36,5 +36,6 @@ func main() {
 		os.Exit(1)
 	}
 	// TODO: implement plugin version
-	skel.PluginMain(plugin.CmdAdd, nil, nil, version.All, fmt.Sprintf("CNI plugin istio-cni %v", istioversion.Info.Version))
+	skel.PluginMain(plugin.CmdAdd, plugin.CmdCheck, plugin.CmdDelete, version.All,
+		fmt.Sprintf("CNI plugin istio-cni %v", istioversion.Info.Version))
 }

--- a/cni/pkg/plugin/plugin.go
+++ b/cni/pkg/plugin/plugin.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"runtime/debug"
 	"strconv"
 	"time"
 
@@ -122,7 +123,7 @@ func CmdAdd(args *skel.CmdArgs) (err error) {
 	// a proper error to the runtime.
 	defer func() {
 		if e := recover(); e != nil {
-			msg := fmt.Sprintf("istio-cni panicked during cmdAdd: %v", e)
+			msg := fmt.Sprintf("istio-cni panicked during cmdAdd: %v\n%v", e, string(debug.Stack()))
 			if err != nil {
 				// If we're recovering and there was also an error, then we need to
 				// present both.
@@ -272,4 +273,12 @@ func CmdAdd(args *skel.CmdArgs) (err error) {
 		result = conf.PrevResult
 	}
 	return types.PrintResult(result, conf.CNIVersion)
+}
+
+func CmdCheck(args *skel.CmdArgs) (err error) {
+	return nil
+}
+
+func CmdDelete(args *skel.CmdArgs) (err error) {
+	return nil
 }


### PR DESCRIPTION
cni plugin library does not check on nil before calling passed in cmd. Got a crash when pod sandbox gets cleaned up.

Also add stack printing to cni plugin crash recovery.