### PR TITLE
Improve mesh config merge logic for Telemetry

### DIFF
--- a/operator/pkg/util/merge_iop.go
+++ b/operator/pkg/util/merge_iop.go
@@ -146,6 +146,20 @@ type meshConfig struct {
 	Certificates                   []*v1alpha13.Certificate                                  `json:"certificates" patchStrategy:"merge" patchMergeKey:"secretName"`
 	ThriftConfig                   *meshConfigThriftConfig                                   `json:"thriftConfig" patchStrategy:"merge"`
 	ServiceSettings                []*meshConfigServiceSettings                              `json:"serviceSettings" patchStrategy:"replace"`
+	DefaultProviders               *meshConfigDefaultProviders                               `json:"defaultProviders" patchStrategy:"merge"`
+	ExtensionProviders             []*meshConfigExtensionProvider                            `json:"extensionProviders" patchStrategy:"merge" patchMergeKey:"name"`
+}
+
+type (
+	meshConfigDefaultProviders  struct{}
+	meshConfigExtensionProvider struct {
+		Name     string                              `json:"string"`
+		Provider meshConfigExtensionProviderInstance `json:"provider"`
+	}
+)
+
+type meshConfigExtensionProviderInstance struct {
+	Prometheus struct{} `json:"prometheus"`
 }
 
 type meshConfigThriftConfig struct {

--- a/pkg/config/mesh/mesh_test.go
+++ b/pkg/config/mesh/mesh_test.go
@@ -19,10 +19,15 @@ import (
 	"reflect"
 	"testing"
 
+	ptypes "github.com/gogo/protobuf/types"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/testing/protocmp"
+
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/validation"
 	"istio.io/istio/pkg/util/gogoprotomarshal"
+	"istio.io/istio/pkg/util/protomarshal"
 )
 
 func TestApplyProxyConfig(t *testing.T) {
@@ -142,6 +147,11 @@ outboundTrafficPolicy:
   mode: REGISTRY_ONLY
 clusterLocalNamespaces: 
 - "foons"
+defaultProviders:
+  tracing: [foo]
+extensionProviders:
+- name: sd
+  stackdriver: {}
 defaultConfig:
   tracing: {}
   concurrency: 4`)
@@ -151,9 +161,136 @@ defaultConfig:
 	if got.DefaultConfig.Tracing.GetZipkin() != nil {
 		t.Error("Failed to override tracing")
 	}
+	if len(got.DefaultProviders.GetMetrics()) != 0 {
+		t.Errorf("default providers deep merge failed, got %v", got.DefaultProviders.GetMetrics())
+	}
+	if len(got.ExtensionProviders) != 1 {
+		t.Errorf("extension providers deep merge failed, got %v", got.ExtensionProviders)
+	}
 
 	gotY, err := gogoprotomarshal.ToYAML(got)
 	t.Log("Result: \n", gotY, err)
+}
+
+func TestDeepMerge(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		out  string
+	}{
+		{
+			name: "set other default provider",
+			in: `
+defaultProviders:
+  tracing: [foo]`,
+			out: `defaultProviders:
+  metrics:
+  - stackdriver
+  tracing:
+  - foo
+extensionProviders:
+- name: stackdriver
+  stackdriver:
+    maxNumberOfAttributes: 3
+`,
+		},
+		{
+			name: "override default provider",
+			in: `
+defaultProviders:
+  metrics: [foo]`,
+			out: `defaultProviders:
+  metrics:
+  - foo
+extensionProviders:
+- name: stackdriver
+  stackdriver:
+    maxNumberOfAttributes: 3
+`,
+		},
+		{
+			name: "replace builtin provider",
+			in: `
+extensionProviders:
+- name: stackdriver
+  stackdriver:
+    maxNumberOfAnnotations: 5`,
+			out: `defaultProviders:
+  metrics:
+  - stackdriver
+extensionProviders:
+- name: stackdriver
+  stackdriver:
+    maxNumberOfAnnotations: 5
+`,
+		},
+		{
+			name: "add provider with existing type",
+			in: `
+extensionProviders:
+- name: stackdriver-annotations
+  stackdriver:
+    maxNumberOfAnnotations: 5`,
+			out: `defaultProviders:
+  metrics:
+  - stackdriver
+extensionProviders:
+- name: stackdriver
+  stackdriver:
+    maxNumberOfAttributes: 3
+- name: stackdriver-annotations
+  stackdriver:
+    maxNumberOfAnnotations: 5
+`,
+		},
+		{
+			name: "add provider",
+			in: `
+extensionProviders:
+- name: prometheus
+  prometheus: {}`,
+			out: `defaultProviders:
+  metrics:
+  - stackdriver
+extensionProviders:
+- name: stackdriver
+  stackdriver:
+    maxNumberOfAttributes: 3
+- name: prometheus
+  prometheus: {}
+`,
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := mesh.DefaultMeshConfig()
+			mc.DefaultProviders = &meshconfig.MeshConfig_DefaultProviders{
+				Metrics: []string{"stackdriver"},
+			}
+			mc.ExtensionProviders = []*meshconfig.MeshConfig_ExtensionProvider{{
+				Name: "stackdriver",
+				Provider: &meshconfig.MeshConfig_ExtensionProvider_Stackdriver{
+					Stackdriver: &meshconfig.MeshConfig_ExtensionProvider_StackdriverProvider{
+						MaxNumberOfAttributes: &ptypes.Int64Value{Value: 3},
+					},
+				},
+			}}
+			res, err := mesh.ApplyMeshConfig(tt.in, mc)
+			if err != nil {
+				t.Fatal(err)
+			}
+			// Just extract fields we are testing
+			minimal := &meshconfig.MeshConfig{}
+			minimal.DefaultProviders = res.DefaultProviders
+			minimal.ExtensionProviders = res.ExtensionProviders
+
+			want := &meshconfig.MeshConfig{}
+			protomarshal.ApplyYAML(tt.out, want)
+			if d := cmp.Diff(want, minimal, protocmp.Transform()); d != "" {
+				t.Fatalf("got diff %v", d)
+			}
+		})
+	}
 }
 
 func TestApplyMeshNetworksDefaults(t *testing.T) {

--- a/pkg/config/validation/extensionprovider.go
+++ b/pkg/config/validation/extensionprovider.go
@@ -167,6 +167,14 @@ func validateExtensionProviderTracingSkyWalking(config *meshconfig.MeshConfig_Ex
 	return
 }
 
+func validateExtensionProviderMetricsPrometheus(prometheus *meshconfig.MeshConfig_ExtensionProvider_PrometheusMetricsProvider) error {
+	return nil
+}
+
+func validateExtensionProviderStackdriver(stackdriver *meshconfig.MeshConfig_ExtensionProvider_StackdriverProvider) error {
+	return nil
+}
+
 func validateExtensionProvider(config *meshconfig.MeshConfig) (errs error) {
 	definedProviders := map[string]struct{}{}
 	for _, c := range config.ExtensionProviders {
@@ -196,8 +204,12 @@ func validateExtensionProvider(config *meshconfig.MeshConfig) (errs error) {
 			currentErrs = appendErrors(currentErrs, validateExtensionProviderTracingOpenCensusAgent(provider.Opencensus))
 		case *meshconfig.MeshConfig_ExtensionProvider_Skywalking:
 			currentErrs = appendErrors(currentErrs, validateExtensionProviderTracingSkyWalking(provider.Skywalking))
+		case *meshconfig.MeshConfig_ExtensionProvider_Prometheus:
+			currentErrs = appendErrors(currentErrs, validateExtensionProviderMetricsPrometheus(provider.Prometheus))
+		case *meshconfig.MeshConfig_ExtensionProvider_Stackdriver:
+			currentErrs = appendErrors(currentErrs, validateExtensionProviderStackdriver(provider.Stackdriver))
 		default:
-			currentErrs = appendErrors(currentErrs, fmt.Errorf("unsupported provider: %v", provider))
+			currentErrs = appendErrors(currentErrs, fmt.Errorf("unsupported provider: %v of type %T", provider, provider))
 		}
 		currentErrs = multierror.Prefix(currentErrs, fmt.Sprintf("invalid extension provider %s:", c.Name))
 		errs = appendErrors(errs, currentErrs)


### PR DESCRIPTION
This adds improved semantics for the new providers fields:
* Extensions providers will replace existing providers with the same
name. If there are none, they will append.
* Default providers is a deeper merge (like proxy config), so you can configure the default
provider for tracing without impacting metrics (for example).

Unit tests are provided that will show the above as well

Both of these should have ~no impact today. However, in the future we
will have built in defaults for providers, at which point these will be
critical to avoid any additions completely wiping out the defaults.

This needs to be rebase on https://github.com/istio/istio/pull/33801 before merge