### PR TITLE
Decrease flush interval of access logs

### DIFF
--- a/pkg/envoy/proxy_test.go
+++ b/pkg/envoy/proxy_test.go
@@ -61,6 +61,7 @@ func TestEnvoyArgs(t *testing.T) {
 		"--parent-shutdown-time-s", "60",
 		"--local-address-ip-version", "v4",
 		"--bootstrap-version", "3",
+		"--file-flush-interval-msec", "1000",
 		"--disable-hot-restart",
 		"--log-format", "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n\t%v",
 		"-l", "trace",


### PR DESCRIPTION
This is a UX improvement, by making access logs more responsive. There
is a tradeoff in responsiveness in performance; we could go even lower
but I feel 1s strikes the best balance (10s is the default).

The max buffer size is 64k. Each log is ~256 bytes. This gives us 263 logs per flush if the internal doesn't triger it
If we have 1 QPS: we would write 6/minute before and 60/minute after
If we have 10 QPS: we would write 22/minute before and 60/minute after
If we have 100 QPS: we would write 227/minute before and after
If we have 1000 QPS: we would write 2270/minute before and after

So this has no impact on users with >250 QPS.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.