### PR TITLE
add retry conditions to existing virtual service tests

### DIFF
--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -136,11 +136,11 @@ spec:
   - route:
     - destination:
         host: {{ .dstSvc }}
-	retries:
+    retries:
       attempts: 3
       perTryTimeout: 2s
-	  retryOn: gateway-error,connect-failure,refused-stream
-	  retryRemoteLocalities: true
+      retryOn: gateway-error,connect-failure,refused-stream
+      retryRemoteLocalities: true
     headers:
       request:
         add:

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -120,8 +120,6 @@ func virtualServiceCases(skipVM bool) []TrafficTestCase {
 	})
 	var cases []TrafficTestCase
 	cases = append(cases,
-		// Retry conditions have been added to just validate that config is correct.
-		// Retries are not specifically tested.
 		TrafficTestCase{
 			name: "added header",
 			config: `
@@ -136,11 +134,6 @@ spec:
   - route:
     - destination:
         host: {{ .dstSvc }}
-    retries:
-      attempts: 3
-      perTryTimeout: 2s
-      retryOn: gateway-error,connect-failure,refused-stream
-      retryRemoteLocalities: true
     headers:
       request:
         add:
@@ -463,6 +456,34 @@ spec:
 								})),
 					},
 				},
+			},
+			workloadAgnostic: true,
+		},
+		// Retry conditions have been added to just validate that config is correct.
+		// Retries are not specifically tested.
+		TrafficTestCase{
+			name: "retry conditions",
+			config: `
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: default
+spec:
+  hosts:
+  - {{ .dstSvc }}
+  http:
+  - route:
+    - destination:
+        host: {{ .dstSvc }}
+    retries:
+      attempts: 3
+      perTryTimeout: 2s
+      retryOn: gateway-error,connect-failure,refused-stream
+      retryRemoteLocalities: true`,
+			opts: echo.CallOptions{
+				PortName:  "http",
+				Count:     1,
+				Validator: echo.ExpectOK(),
 			},
 			workloadAgnostic: true,
 		},

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -120,6 +120,8 @@ func virtualServiceCases(skipVM bool) []TrafficTestCase {
 	})
 	var cases []TrafficTestCase
 	cases = append(cases,
+		// Retry conditions have been added to just validate that config is correct.
+		// Retries are not specifically tested.
 		TrafficTestCase{
 			name: "added header",
 			config: `
@@ -134,6 +136,11 @@ spec:
   - route:
     - destination:
         host: {{ .dstSvc }}
+	retries:
+      attempts: 3
+      perTryTimeout: 2s
+	  retryOn: gateway-error,connect-failure,refused-stream
+	  retryRemoteLocalities: true
     headers:
       request:
         add:


### PR DESCRIPTION
Adds retry conditions to existing virtual service to validate that config is not rejected by Envoy.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
