### PR TITLE
Clean up istio-iptables log.

### DIFF
--- a/tools/istio-iptables/pkg/cmd/run.go
+++ b/tools/istio-iptables/pkg/cmd/run.go
@@ -118,20 +118,18 @@ func (iptConfigurator *IptablesConfigurator) separateV4V6(cidrList string) (Netw
 
 func (iptConfigurator *IptablesConfigurator) logConfig() {
 	// Dump out our environment for debugging purposes.
-	log.Info("Environment:")
-	log.Info("------------")
-	log.Infof("ENVOY_PORT=%s", os.Getenv("ENVOY_PORT"))
-	log.Infof("INBOUND_CAPTURE_PORT=%s", os.Getenv("INBOUND_CAPTURE_PORT"))
-	log.Infof("ISTIO_INBOUND_INTERCEPTION_MODE=%s", os.Getenv("ISTIO_INBOUND_INTERCEPTION_MODE"))
-	log.Infof("ISTIO_INBOUND_TPROXY_MARK=%s", os.Getenv("ISTIO_INBOUND_TPROXY_MARK"))
-	log.Infof("ISTIO_INBOUND_TPROXY_ROUTE_TABLE=%s", os.Getenv("ISTIO_INBOUND_TPROXY_ROUTE_TABLE"))
-	log.Infof("ISTIO_INBOUND_PORTS=%s", os.Getenv("ISTIO_INBOUND_PORTS"))
-	log.Infof("ISTIO_OUTBOUND_PORTS=%s", os.Getenv("ISTIO_OUTBOUND_PORTS"))
-	log.Infof("ISTIO_LOCAL_EXCLUDE_PORTS=%s", os.Getenv("ISTIO_LOCAL_EXCLUDE_PORTS"))
-	log.Infof("ISTIO_SERVICE_CIDR=%s", os.Getenv("ISTIO_SERVICE_CIDR"))
-	log.Infof("ISTIO_SERVICE_EXCLUDE_CIDR=%s", os.Getenv("ISTIO_SERVICE_EXCLUDE_CIDR"))
-	log.Infof("ISTIO_META_DNS_CAPTURE=%s", os.Getenv("ISTIO_META_DNS_CAPTURE"))
-	log.Info("")
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("ENVOY_PORT=%s\n", os.Getenv("ENVOY_PORT")))
+	b.WriteString(fmt.Sprintf("INBOUND_CAPTURE_PORT=%s\n", os.Getenv("INBOUND_CAPTURE_PORT")))
+	b.WriteString(fmt.Sprintf("ISTIO_INBOUND_INTERCEPTION_MODE=%s\n", os.Getenv("ISTIO_INBOUND_INTERCEPTION_MODE")))
+	b.WriteString(fmt.Sprintf("ISTIO_INBOUND_TPROXY_ROUTE_TABLE=%s\n", os.Getenv("ISTIO_INBOUND_TPROXY_ROUTE_TABLE")))
+	b.WriteString(fmt.Sprintf("ISTIO_INBOUND_PORTS=%s\n", os.Getenv("ISTIO_INBOUND_PORTS")))
+	b.WriteString(fmt.Sprintf("ISTIO_OUTBOUND_PORTS=%s\n", os.Getenv("ISTIO_OUTBOUND_PORTS")))
+	b.WriteString(fmt.Sprintf("ISTIO_LOCAL_EXCLUDE_PORTS=%s\n", os.Getenv("ISTIO_LOCAL_EXCLUDE_PORTS")))
+	b.WriteString(fmt.Sprintf("ISTIO_SERVICE_CIDR=%s\n", os.Getenv("ISTIO_SERVICE_CIDR")))
+	b.WriteString(fmt.Sprintf("ISTIO_SERVICE_EXCLUDE_CIDR=%s\n", os.Getenv("ISTIO_SERVICE_EXCLUDE_CIDR")))
+	b.WriteString(fmt.Sprintf("ISTIO_META_DNS_CAPTURE=%s", os.Getenv("ISTIO_META_DNS_CAPTURE")))
+	log.Infof("Istio iptables environment:\n%s", b.String())
 	iptConfigurator.cfg.Print()
 }
 
@@ -815,7 +813,7 @@ func (iptConfigurator *IptablesConfigurator) handleOutboundPortsInclude() {
 
 func (iptConfigurator *IptablesConfigurator) createRulesFile(f *os.File, contents string) error {
 	defer f.Close()
-	log.Infof("Writing following contents to rules file: %v\n%v", f.Name(), contents)
+	log.Infof("Writing following contents to rules file: %v\n%v", f.Name(), strings.TrimSpace(contents))
 	writer := bufio.NewWriter(f)
 	_, err := writer.WriteString(contents)
 	if err != nil {

--- a/tools/istio-iptables/pkg/config/config.go
+++ b/tools/istio-iptables/pkg/config/config.go
@@ -16,6 +16,8 @@ package config
 
 import (
 	"encoding/json"
+	"fmt"
+	"strings"
 	"time"
 
 	"istio.io/pkg/log"
@@ -61,26 +63,25 @@ func (c *Config) String() string {
 }
 
 func (c *Config) Print() {
-	log.Info("Variables:")
-	log.Info("----------")
-	log.Infof("PROXY_PORT=%s", c.ProxyPort)
-	log.Infof("PROXY_INBOUND_CAPTURE_PORT=%s", c.InboundCapturePort)
-	log.Infof("PROXY_TUNNEL_PORT=%s", c.InboundTunnelPort)
-	log.Infof("PROXY_UID=%s", c.ProxyUID)
-	log.Infof("PROXY_GID=%s", c.ProxyGID)
-	log.Infof("INBOUND_INTERCEPTION_MODE=%s", c.InboundInterceptionMode)
-	log.Infof("INBOUND_TPROXY_MARK=%s", c.InboundTProxyMark)
-	log.Infof("INBOUND_TPROXY_ROUTE_TABLE=%s", c.InboundTProxyRouteTable)
-	log.Infof("INBOUND_PORTS_INCLUDE=%s", c.InboundPortsInclude)
-	log.Infof("INBOUND_PORTS_EXCLUDE=%s", c.InboundPortsExclude)
-	log.Infof("OUTBOUND_IP_RANGES_INCLUDE=%s", c.OutboundIPRangesInclude)
-	log.Infof("OUTBOUND_IP_RANGES_EXCLUDE=%s", c.OutboundIPRangesExclude)
-	log.Infof("OUTBOUND_PORTS_INCLUDE=%s", c.OutboundPortsInclude)
-	log.Infof("OUTBOUND_PORTS_EXCLUDE=%s", c.OutboundPortsExclude)
-	log.Infof("KUBEVIRT_INTERFACES=%s", c.KubevirtInterfaces)
-	log.Infof("ENABLE_INBOUND_IPV6=%t", c.EnableInboundIPv6)
-	log.Infof("DNS_CAPTURE=%t", c.RedirectDNS)
-	log.Infof("CAPTURE_ALL_DNS=%t", c.CaptureAllDNS)
-	log.Infof("DNS_SERVERS=%s,%s", c.DNSServersV4, c.DNSServersV6)
-	log.Info("")
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("PROXY_PORT=%s\n", c.ProxyPort))
+	b.WriteString(fmt.Sprintf("PROXY_INBOUND_CAPTURE_PORT=%s\n", c.InboundCapturePort))
+	b.WriteString(fmt.Sprintf("PROXY_TUNNEL_PORT=%s\n", c.InboundTunnelPort))
+	b.WriteString(fmt.Sprintf("PROXY_UID=%s\n", c.ProxyUID))
+	b.WriteString(fmt.Sprintf("PROXY_GID=%s\n", c.ProxyGID))
+	b.WriteString(fmt.Sprintf("INBOUND_INTERCEPTION_MODE=%s\n", c.InboundInterceptionMode))
+	b.WriteString(fmt.Sprintf("INBOUND_TPROXY_MARK=%s\n", c.InboundTProxyMark))
+	b.WriteString(fmt.Sprintf("INBOUND_TPROXY_ROUTE_TABLE=%s\n", c.InboundTProxyRouteTable))
+	b.WriteString(fmt.Sprintf("INBOUND_PORTS_INCLUDE=%s\n", c.InboundPortsInclude))
+	b.WriteString(fmt.Sprintf("INBOUND_PORTS_EXCLUDE=%s\n", c.InboundPortsExclude))
+	b.WriteString(fmt.Sprintf("OUTBOUND_IP_RANGES_INCLUDE=%s\n", c.OutboundIPRangesInclude))
+	b.WriteString(fmt.Sprintf("OUTBOUND_IP_RANGES_EXCLUDE=%s\n", c.OutboundIPRangesExclude))
+	b.WriteString(fmt.Sprintf("OUTBOUND_PORTS_INCLUDE=%s\n", c.OutboundPortsInclude))
+	b.WriteString(fmt.Sprintf("OUTBOUND_PORTS_EXCLUDE=%s\n", c.OutboundPortsExclude))
+	b.WriteString(fmt.Sprintf("KUBEVIRT_INTERFACES=%s\n", c.KubevirtInterfaces))
+	b.WriteString(fmt.Sprintf("ENABLE_INBOUND_IPV6=%t\n", c.EnableInboundIPv6))
+	b.WriteString(fmt.Sprintf("DNS_CAPTURE=%t\n", c.RedirectDNS))
+	b.WriteString(fmt.Sprintf("CAPTURE_ALL_DNS=%t\n", c.CaptureAllDNS))
+	b.WriteString(fmt.Sprintf("DNS_SERVERS=%s,%s", c.DNSServersV4, c.DNSServersV6))
+	log.Infof("Istio iptables variables:\n%s", b.String())
 }

--- a/tools/istio-iptables/pkg/dependencies/implementation.go
+++ b/tools/istio-iptables/pkg/dependencies/implementation.go
@@ -63,38 +63,47 @@ var XTablesCmds = sets.NewSet(
 // RealDependencies implementation of interface Dependencies, which is used in production
 type RealDependencies struct{}
 
-func (r *RealDependencies) execute(cmd string, redirectStdout bool, args ...string) error {
-	log.Infof("%s %s", cmd, strings.Join(args, " "))
+func (r *RealDependencies) execute(cmd string, ignoreErrors bool, args ...string) error {
+	log.Infof("Running command: %s %s", cmd, strings.Join(args, " "))
 	externalCommand := exec.Command(cmd, args...)
-	externalCommand.Stdout = os.Stdout
-	// TODO Check naming and redirection logic
-	if !redirectStdout {
-		externalCommand.Stderr = os.Stderr
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	externalCommand.Stdout = stdout
+	externalCommand.Stderr = stderr
+
+	if len(stdout.String()) != 0 {
+		log.Infof("Command output: \n%v", stdout.String())
 	}
+
+	if !ignoreErrors && len(stderr.Bytes()) != 0 {
+		log.Errorf("Command error output: \n%v", stderr.String())
+	}
+
 	return externalCommand.Run()
 }
 
-func (r *RealDependencies) executeXTables(cmd string, redirectStdout bool, args ...string) error {
-	log.Infof("%s %s", cmd, strings.Join(args, " "))
+func (r *RealDependencies) executeXTables(cmd string, ignoreErrors bool, args ...string) error {
+	log.Infof("Running command: %s %s", cmd, strings.Join(args, " "))
 	externalCommand := exec.Command(cmd, args...)
-	externalCommand.Stdout = os.Stdout
-
-	var stderr bytes.Buffer
-	// TODO Check naming and redirection logic
-	if !redirectStdout {
-		externalCommand.Stderr = &stderr
-	}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	externalCommand.Stdout = stdout
+	externalCommand.Stderr = stderr
 
 	err := externalCommand.Run()
+
+	if len(stdout.String()) != 0 {
+		log.Infof("Command output: \n%v", stdout.String())
+	}
+
 	// TODO Check naming and redirection logic
-	if err != nil && !redirectStdout {
+	if (err != nil || len(stderr.String()) != 0) && !ignoreErrors {
 		stderrStr := stderr.String()
 
 		// Transform to xtables-specific error messages with more useful and actionable hints.
 		stderrStr = transformToXTablesErrorMessage(stderrStr, err)
 
-		// Print stderr to os.Stderr by default.
-		fmt.Fprintln(os.Stderr, stderrStr)
+		log.Errorf("Command error output: %v", stderrStr)
 	}
 
 	return err
@@ -117,7 +126,12 @@ func transformToXTablesErrorMessage(stderr string, err error) string {
 		// `Try 'iptables -h' or 'iptables --help' for more information.`
 		// Reusing the `error hints` and optional `try help information` parts of the original stderr to form
 		// an error message with explicit xtables error information.
-		return fmt.Sprintf("%v: %v", errtypeStr, strings.Trim(strings.SplitN(stderr, ":", 2)[1], " "))
+		errStrParts := strings.SplitN(stderr, ":", 2)
+		errStr := stderr
+		if len(errStrParts) > 1 {
+			errStr = errStrParts[1]
+		}
+		return fmt.Sprintf("%v: %v", errtypeStr, strings.TrimSpace(errStr))
 	}
 
 	return stderr


### PR DESCRIPTION
Follow up PR of https://github.com/istio/istio/pull/33808. After switching iptables log to istio log pkg, several log lines do not make much sense. Change including:
* Combine iptables env and variables into a single multiple lines log entry
* Log iptables command stdout/stderr output with istio log pkg.
* Hardening the xtables error message parsing to avoid possible out-of-range crashing.

Example log output after this change: https://gist.githubusercontent.com/bianpengyuan/42e21d8fe68f2ecc675d4f2dbcb8415e/raw/f89c18766e52564fd6e88be872ef32c80f62f195/istio-init.log