### PR TITLE
Fixes #32145. Ensures safe re-execution of init containers.

### DIFF
--- a/releasenotes/notes/32145.yaml
+++ b/releasenotes/notes/32145.yaml
@@ -1,0 +1,12 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+
+# issue is a list of GitHub issues resolved in this note.
+issue:
+  - https://github.com/istio/istio/issues/32145
+  - 30393
+
+releaseNotes:
+- |
+  **Fixed** an issue where re-executing the init container crashed the pod

--- a/tools/istio-clean-iptables/pkg/cmd/cleanup.go
+++ b/tools/istio-clean-iptables/pkg/cmd/cleanup.go
@@ -65,7 +65,7 @@ func cleanup(cfg *config.Config) {
 	defer func() {
 		for _, cmd := range []string{constants.IPTABLESSAVE, constants.IP6TABLESSAVE} {
 			// iptables-save is best efforts
-			ext.Run(cmd)
+			_, _ = ext.Run(cmd)
 		}
 	}()
 

--- a/tools/istio-clean-iptables/pkg/cmd/cleanup.go
+++ b/tools/istio-clean-iptables/pkg/cmd/cleanup.go
@@ -65,7 +65,7 @@ func cleanup(cfg *config.Config) {
 	defer func() {
 		for _, cmd := range []string{constants.IPTABLESSAVE, constants.IP6TABLESSAVE} {
 			// iptables-save is best efforts
-			_ = ext.Run(cmd)
+			ext.Run(cmd)
 		}
 	}()
 

--- a/tools/istio-iptables/pkg/cmd/run.go
+++ b/tools/istio-iptables/pkg/cmd/run.go
@@ -407,7 +407,7 @@ func (iptConfigurator *IptablesConfigurator) run() {
 
 	if iptConfigurator.cfg.EnableInboundIPv6 {
 		// TODO: (abhide): Move this out of this method
-		iptConfigurator.ext.RunOrFail(constants.IP, "-6", "addr", "add", "::6/128", "dev", "lo")
+		iptConfigurator.ext.RunOrFail(constants.IP, "-6", "addr", "replace", "::6/128", "dev", "lo")
 	}
 
 	// Do not capture internal interface.
@@ -859,17 +859,36 @@ func (iptConfigurator *IptablesConfigurator) executeIptablesRestoreCommand(isIpv
 
 func (iptConfigurator *IptablesConfigurator) executeCommands() {
 	if iptConfigurator.cfg.RestoreFormat {
-		// Execute iptables-restore
-		err := iptConfigurator.executeIptablesRestoreCommand(true)
-		if err != nil {
-			log.Errorf("Failed to execute iptables-restore command: %v", err)
-			os.Exit(1)
+
+		// Get the standard output of the iptables-save command
+		output, _ := iptConfigurator.ext.CmdOutput(constants.IPTABLESSAVE, "-t", constants.NAT)
+
+		// Skip execution of iptables-restore if it has already run before
+		// This ensures safe re-execution of init-containers
+		if strings.Contains(output, "ISTIO") {
+			fmt.Printf("ISTIO chain(s) already exist in the %s table of the %s", constants.NAT, constants.IPTABLES)
+		} else {
+			// Execute iptables-restore
+			err := iptConfigurator.executeIptablesRestoreCommand(true)
+			if err != nil {
+				log.Errorf("Failed to execute iptables-restore command: %v", err)
+				os.Exit(1)
+			}
 		}
-		// Execute ip6tables-restore
-		err = iptConfigurator.executeIptablesRestoreCommand(false)
-		if err != nil {
-			log.Errorf("Failed to execute iptables-restore command: %v", err)
-			os.Exit(1)
+
+		// Get the standard output of the ip6tables-save command
+		output, _ = iptConfigurator.ext.CmdOutput(constants.IP6TABLESSAVE, "-t", constants.NAT)
+
+		// Skip execution of iptables6-restore for the same reason as IPv4 above
+		if strings.Contains(output, "ISTIO") && iptConfigurator.cfg.EnableInboundIPv6 {
+			fmt.Printf("ISTIO chain(s) already exist in the %s table of the %s", constants.NAT, constants.IP6TABLES)
+		} else {
+			// Execute ip6tables-restore
+			err := iptConfigurator.executeIptablesRestoreCommand(false)
+			if err != nil {
+				log.Errorf("Failed to execute iptables-restore command: %v", err)
+				os.Exit(1)
+			}
 		}
 	} else {
 		// Execute iptables commands

--- a/tools/istio-iptables/pkg/cmd/run.go
+++ b/tools/istio-iptables/pkg/cmd/run.go
@@ -156,7 +156,7 @@ func (iptConfigurator *IptablesConfigurator) handleInboundPortsInclude() {
 			// In routing table ${INBOUND_TPROXY_ROUTE_TABLE}, create a single default rule to route all traffic to
 			// the loopback interface.
 			// TODO: (abhide): Move this out of this method
-			err := iptConfigurator.ext.Run(constants.IP, "-f", "inet", "route", "add", "local", "default", "dev", "lo", "table",
+			_, err := iptConfigurator.ext.Run(constants.IP, "-f", "inet", "route", "add", "local", "default", "dev", "lo", "table",
 				iptConfigurator.cfg.InboundTProxyRouteTable)
 			if err != nil {
 				// TODO: (abhide): Move this out of this method
@@ -379,9 +379,9 @@ func SplitV4V6(ips []string) (ipv4 []string, ipv6 []string) {
 func (iptConfigurator *IptablesConfigurator) run() {
 	defer func() {
 		// Best effort since we don't know if the commands exist
-		_ = iptConfigurator.ext.Run(constants.IPTABLESSAVE)
+		iptConfigurator.ext.Run(constants.IPTABLESSAVE)
 		if iptConfigurator.cfg.EnableInboundIPv6 {
-			_ = iptConfigurator.ext.Run(constants.IP6TABLESSAVE)
+			iptConfigurator.ext.Run(constants.IP6TABLESSAVE)
 		}
 	}()
 
@@ -861,7 +861,7 @@ func (iptConfigurator *IptablesConfigurator) executeCommands() {
 	if iptConfigurator.cfg.RestoreFormat {
 
 		// Get the standard output of the iptables-save command
-		output, _ := iptConfigurator.ext.CmdOutput(constants.IPTABLESSAVE, "-t", constants.NAT)
+		output, _ := iptConfigurator.ext.Run(constants.IPTABLESSAVE, "-t", constants.NAT)
 
 		// Skip execution of iptables-restore if it has already run before
 		// This ensures safe re-execution of init containers
@@ -877,7 +877,7 @@ func (iptConfigurator *IptablesConfigurator) executeCommands() {
 		}
 
 		// Get the standard output of the ip6tables-save command
-		output, _ = iptConfigurator.ext.CmdOutput(constants.IP6TABLESSAVE, "-t", constants.NAT)
+		output, _ = iptConfigurator.ext.Run(constants.IP6TABLESSAVE, "-t", constants.NAT)
 
 		// Skip execution of ip6tables-restore for the same reason as IPv4 above
 		if strings.Contains(output, "ISTIO") && iptConfigurator.cfg.EnableInboundIPv6 {

--- a/tools/istio-iptables/pkg/cmd/run.go
+++ b/tools/istio-iptables/pkg/cmd/run.go
@@ -379,9 +379,9 @@ func SplitV4V6(ips []string) (ipv4 []string, ipv6 []string) {
 func (iptConfigurator *IptablesConfigurator) run() {
 	defer func() {
 		// Best effort since we don't know if the commands exist
-		iptConfigurator.ext.Run(constants.IPTABLESSAVE)
+		_, _ = iptConfigurator.ext.Run(constants.IPTABLESSAVE)
 		if iptConfigurator.cfg.EnableInboundIPv6 {
-			iptConfigurator.ext.Run(constants.IP6TABLESSAVE)
+			_, _ = iptConfigurator.ext.Run(constants.IP6TABLESSAVE)
 		}
 	}()
 

--- a/tools/istio-iptables/pkg/cmd/run.go
+++ b/tools/istio-iptables/pkg/cmd/run.go
@@ -864,9 +864,9 @@ func (iptConfigurator *IptablesConfigurator) executeCommands() {
 		output, _ := iptConfigurator.ext.CmdOutput(constants.IPTABLESSAVE, "-t", constants.NAT)
 
 		// Skip execution of iptables-restore if it has already run before
-		// This ensures safe re-execution of init-containers
+		// This ensures safe re-execution of init containers
 		if strings.Contains(output, "ISTIO") {
-			fmt.Printf("ISTIO chain(s) already exist in the %s table of the %s", constants.NAT, constants.IPTABLES)
+			log.Infof("ISTIO chain(s) already exist in the %s table of the %s", constants.NAT, constants.IPTABLES)
 		} else {
 			// Execute iptables-restore
 			err := iptConfigurator.executeIptablesRestoreCommand(true)
@@ -879,9 +879,9 @@ func (iptConfigurator *IptablesConfigurator) executeCommands() {
 		// Get the standard output of the ip6tables-save command
 		output, _ = iptConfigurator.ext.CmdOutput(constants.IP6TABLESSAVE, "-t", constants.NAT)
 
-		// Skip execution of iptables6-restore for the same reason as IPv4 above
+		// Skip execution of ip6tables-restore for the same reason as IPv4 above
 		if strings.Contains(output, "ISTIO") && iptConfigurator.cfg.EnableInboundIPv6 {
-			fmt.Printf("ISTIO chain(s) already exist in the %s table of the %s", constants.NAT, constants.IP6TABLES)
+			log.Infof("ISTIO chain(s) already exist in the %s table of the %s", constants.NAT, constants.IP6TABLES)
 		} else {
 			// Execute ip6tables-restore
 			err := iptConfigurator.executeIptablesRestoreCommand(false)

--- a/tools/istio-iptables/pkg/dependencies/implementation.go
+++ b/tools/istio-iptables/pkg/dependencies/implementation.go
@@ -166,8 +166,8 @@ func (r *RealDependencies) Run(cmd string, args ...string) (stdout string, err e
 // RunQuietlyAndIgnore runs a command quietly and ignores errors
 func (r *RealDependencies) RunQuietlyAndIgnore(cmd string, args ...string) {
 	if XTablesCmds.Contains(cmd) {
-		r.executeXTables(cmd, true, args...)
+		_, _ = r.executeXTables(cmd, true, args...)
 	} else {
-		r.execute(cmd, true, args...)
+		_, _ = r.execute(cmd, true, args...)
 	}
 }

--- a/tools/istio-iptables/pkg/dependencies/implementation.go
+++ b/tools/istio-iptables/pkg/dependencies/implementation.go
@@ -169,3 +169,9 @@ func (r *RealDependencies) RunQuietlyAndIgnore(cmd string, args ...string) {
 		_ = r.execute(cmd, true, args...)
 	}
 }
+
+// CmdOutput runs a command and returns its standard output
+func (r *RealDependencies) CmdOutput(cmd string, args ...string) (string, error) {
+	output, err := exec.Command(cmd, args...).Output()
+	return string(output), err
+}

--- a/tools/istio-iptables/pkg/dependencies/interface.go
+++ b/tools/istio-iptables/pkg/dependencies/interface.go
@@ -18,10 +18,8 @@ package dependencies
 type Dependencies interface {
 	// RunOrFail runs a command and panics, if it fails
 	RunOrFail(cmd string, args ...string)
-	// Run runs a command
-	Run(cmd string, args ...string) error
+	// Run runs a command, returns its standard output and error
+	Run(cmd string, args ...string) (string, error)
 	// RunQuietlyAndIgnore runs a command quietly and ignores errors
 	RunQuietlyAndIgnore(cmd string, args ...string)
-	// CmdOutput runs a command and returns its standard output
-	CmdOutput(cmd string, args ...string) (string, error)
 }

--- a/tools/istio-iptables/pkg/dependencies/interface.go
+++ b/tools/istio-iptables/pkg/dependencies/interface.go
@@ -22,5 +22,6 @@ type Dependencies interface {
 	Run(cmd string, args ...string) error
 	// RunQuietlyAndIgnore runs a command quietly and ignores errors
 	RunQuietlyAndIgnore(cmd string, args ...string)
+	// CmdOutput runs a command and returns its standard output
 	CmdOutput(cmd string, args ...string) (string, error)
 }

--- a/tools/istio-iptables/pkg/dependencies/interface.go
+++ b/tools/istio-iptables/pkg/dependencies/interface.go
@@ -22,4 +22,5 @@ type Dependencies interface {
 	Run(cmd string, args ...string) error
 	// RunQuietlyAndIgnore runs a command quietly and ignores errors
 	RunQuietlyAndIgnore(cmd string, args ...string)
+	CmdOutput(cmd string, args ...string) (string, error)
 }

--- a/tools/istio-iptables/pkg/dependencies/stub.go
+++ b/tools/istio-iptables/pkg/dependencies/stub.go
@@ -28,19 +28,13 @@ func (s *StdoutStubDependencies) RunOrFail(cmd string, args ...string) {
 	log.Infof("%s %s", cmd, strings.Join(args, " "))
 }
 
-// Run runs a command
-func (s *StdoutStubDependencies) Run(cmd string, args ...string) error {
+// Run runs a command, returns its standard output and error
+func (s *StdoutStubDependencies) Run(cmd string, args ...string) (string, error) {
 	log.Infof("%s %s", cmd, strings.Join(args, " "))
-	return nil
+	return "", nil
 }
 
 // RunQuietlyAndIgnore runs a command quietly and ignores errors
 func (s *StdoutStubDependencies) RunQuietlyAndIgnore(cmd string, args ...string) {
 	log.Infof("%s %s", cmd, strings.Join(args, " "))
-}
-
-// CmdOutput runs a command and returns its standard output
-func (s *StdoutStubDependencies) CmdOutput(cmd string, args ...string) (string, error) {
-	log.Infof("%s %s", cmd, strings.Join(args, " "))
-	return "", nil
 }

--- a/tools/istio-iptables/pkg/dependencies/stub.go
+++ b/tools/istio-iptables/pkg/dependencies/stub.go
@@ -38,3 +38,9 @@ func (s *StdoutStubDependencies) Run(cmd string, args ...string) error {
 func (s *StdoutStubDependencies) RunQuietlyAndIgnore(cmd string, args ...string) {
 	log.Infof("%s %s", cmd, strings.Join(args, " "))
 }
+
+// CmdOutput runs a command and returns its standard output
+func (s *StdoutStubDependencies) CmdOutput(cmd string, args ...string) (string, error) {
+	log.Infof("%s %s", cmd, strings.Join(args, " "))
+	return "", nil
+}


### PR DESCRIPTION
As mentioned in issue #32145, #30393, and also kubernetes documentation, the init container could be re-executed for various reasons and hence, the init container code must be idempotent. Currently, re-executing init container crashes the running Pod with status _Init:Error_. This PR fixes this issue by avoiding duplicates in the iptables/ip6tables and possible errors because of this by running the iptables-restore/ip6tables-restore command only for the first time in the lifecyle of the Pod. If the init container is re-executed, then successfully generated iptables/ip6tables from the previous run will be used.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[X] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.