### PR TITLE
Fuzzing: Add xds fuzzer

### DIFF
--- a/tests/fuzz/oss_fuzz_build.sh
+++ b/tests/fuzz/oss_fuzz_build.sh
@@ -21,6 +21,7 @@ compile_go_fuzzer istio.io/istio/tests/fuzz FuzzParseMeshNetworks fuzz_parse_mes
 compile_go_fuzzer istio.io/istio/tests/fuzz FuzzValidateMeshConfig fuzz_validate_mesh_config
 compile_go_fuzzer istio.io/istio/tests/fuzz FuzzInitContext fuzz_init_context
 compile_go_fuzzer istio.io/istio/tests/fuzz FuzzAnalyzer fuzz_analyzer
+compile_go_fuzzer istio.io/istio/tests/fuzz FuzzXds fuzz_xds
 
 
 # Create seed corpora:

--- a/tests/fuzz/xds_fuzzer.go
+++ b/tests/fuzz/xds_fuzzer.go
@@ -1,0 +1,47 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// nolint: golint
+package fuzz
+
+import (
+	"testing"
+
+	"istio.io/istio/pilot/pkg/config/kube/crd"
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/xds"
+)
+
+func init() {
+	testing.Init()
+}
+
+func FuzzXds(data []byte) int {
+	t := &testing.T{}
+
+	// Use crd.ParseInputs to verify data
+	_, _, err := crd.ParseInputs(string(data))
+	if err != nil {
+		return 0
+	}
+	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{
+		ConfigString: string(data),
+	})
+	proxy := s.SetupProxy(&model.Proxy{
+		ConfigNamespace: "app",
+	})
+	_ = s.Listeners(proxy)
+	_ = s.Routes(proxy)
+	return 1
+}


### PR DESCRIPTION
Adds a fuzzer that creates a `FakeDiscoveryServer` with a fuzzed `ConfigString` and then calls `Listeners` and `Routes` with the created `FakeDiscoveryServer`.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[x] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.