### PR TITLE
enhance dns proxy metrics

### DIFF
--- a/pilot/pkg/dns/monitoring.go
+++ b/pilot/pkg/dns/monitoring.go
@@ -15,9 +15,11 @@
 package dns
 
 import (
-	"github.com/miekg/dns"
-	"istio.io/pkg/monitoring"
 	"strconv"
+
+	"github.com/miekg/dns"
+
+	"istio.io/pkg/monitoring"
 )
 
 var (
@@ -62,13 +64,14 @@ func registerStats() {
 	monitoring.MustRegister(upstreamRequests)
 	monitoring.MustRegister(failures)
 	monitoring.MustRegister(upstreamRequestDuration)
+	monitoring.MustRegister(requestDuration)
+	monitoring.MustRegister(responses)
 }
 
 func rcodeToLabelValue(rcode int) monitoring.LabelValue {
 	name, found := dns.RcodeToString[rcode]
 	if found {
 		return rcodeLabel.Value(name)
-	} else {
-		return rcodeLabel.Value(strconv.Itoa(rcode))
 	}
+	return rcodeLabel.Value(strconv.Itoa(rcode))
 }


### PR DESCRIPTION
Enhance DNS proxy metrics - originally filed as https://github.com/istio/istio/issues/33222, initially fixed in https://github.com/istio/istio/pull/33532

My goal is to get dns proxy metrics as close to [coredns metrics](https://coredns.io/plugins/metrics/), as reasonable. I remember we used to struggle with coredns metrics - i.e. we used to see lots of NXDOMAIN errors and were unable to tell which app is causing them. This PR would be significant improvement for me - bringing similar observability capabilities we have for http request to DNS requests.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
