### PR TITLE
fix mutatingwebhook patch problem

### DIFF
--- a/pilot/pkg/bootstrap/sidecarinjector.go
+++ b/pilot/pkg/bootstrap/sidecarinjector.go
@@ -92,10 +92,8 @@ func (s *Server) initSidecarInjector(args *PilotArgs) (*inject.Webhook, error) {
 	if features.InjectionWebhookConfigName != "" {
 		s.addStartFunc(func(stop <-chan struct{}) error {
 			// No leader election - different istiod revisions will patch their own cert.
-			caBundle := s.istiodCertBundleWatcher.GetCABundle()
-			// TODO(hzxuzhonghu): this should be consistent with validating webhook,
 			// update webhook configuration by watching the cabundle
-			patcher, err := webhooks.NewWebhookCertPatcher(s.kubeClient, args.Revision, webhookName, caBundle)
+			patcher, err := webhooks.NewWebhookCertPatcher(s.kubeClient, args.Revision, webhookName, s.istiodCertBundleWatcher)
 			if err != nil {
 				log.Errorf("failed to create webhook cert patcher: %v", err)
 				return nil

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -247,7 +247,7 @@ func (m *Multicluster) AddMemberCluster(clusterID cluster.ID, rc *secretcontroll
 		if features.InjectionWebhookConfigName != "" && m.caBundleWatcher != nil {
 			// TODO prevent istiods in primary clusters from trying to patch eachother. should we also leader-elect?
 			log.Infof("initializing webhook cert patch for cluster %s", clusterID)
-			patcher, err := webhooks.NewWebhookCertPatcher(client.Kube(), m.revision, webhookName, m.caBundleWatcher.GetCABundle())
+			patcher, err := webhooks.NewWebhookCertPatcher(client.Kube(), m.revision, webhookName, m.caBundleWatcher)
 			if err != nil {
 				log.Errorf("could not initialize webhook cert patcher: %v", err)
 			} else {

--- a/pkg/webhooks/util/util.go
+++ b/pkg/webhooks/util/util.go
@@ -1,3 +1,17 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package util
 
 import (

--- a/pkg/webhooks/util/util.go
+++ b/pkg/webhooks/util/util.go
@@ -1,0 +1,46 @@
+package util
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+
+	"istio.io/istio/pilot/pkg/keycertbundle"
+)
+
+type ConfigError struct {
+	err    error
+	reason string
+}
+
+func (e ConfigError) Error() string {
+	return e.err.Error()
+}
+
+func (e ConfigError) Reason() string {
+	return e.reason
+}
+
+func LoadCABundle(caBundleWatcher *keycertbundle.Watcher) ([]byte, error) {
+	caBundle := caBundleWatcher.GetCABundle()
+	if err := VerifyCABundle(caBundle); err != nil {
+		return nil, &ConfigError{err, "could not verify caBundle"}
+	}
+
+	return caBundle, nil
+}
+
+func VerifyCABundle(caBundle []byte) error {
+	block, _ := pem.Decode(caBundle)
+	if block == nil {
+		return errors.New("could not decode pem")
+	}
+	if block.Type != "CERTIFICATE" {
+		return fmt.Errorf("cert contains wrong pem type: %q", block.Type)
+	}
+	if _, err := x509.ParseCertificate(block.Bytes); err != nil {
+		return fmt.Errorf("cert contains invalid x509 certificate: %v", err)
+	}
+	return nil
+}

--- a/pkg/webhooks/validation/controller/controller_test.go
+++ b/pkg/webhooks/validation/controller/controller_test.go
@@ -40,6 +40,7 @@ import (
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/test/util/retry"
 	"istio.io/istio/pkg/testcerts"
+	"istio.io/istio/pkg/webhooks/util"
 )
 
 var (
@@ -335,7 +336,7 @@ func TestLoadCaCertPem(t *testing.T) {
 
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("[%v] %s", i, c.name), func(tt *testing.T) {
-			err := verifyCABundle(c.cert)
+			err := util.VerifyCABundle(c.cert)
 			if err != nil {
 				if !c.wantError {
 					tt.Fatalf("unexpected error: got error %q", err)

--- a/pkg/webhooks/webhookpatch.go
+++ b/pkg/webhooks/webhookpatch.go
@@ -187,7 +187,7 @@ func (w *WebhookCertPatcher) startCaBundleWatcher(stop <-chan struct{}) {
 		case <-watchCh:
 			whcList, err := w.client.AdmissionregistrationV1().MutatingWebhookConfigurations().List(context.TODO(), options)
 			if err != nil {
-				log.Debugf("failed to get mutatingWebhookConfigurations %s", err)
+				log.Errorf("failed to get mutatingWebhookConfigurations %s", err)
 				break
 			}
 			var whcNameList []string

--- a/pkg/webhooks/webhookpatch.go
+++ b/pkg/webhooks/webhookpatch.go
@@ -32,7 +32,6 @@ import (
 	"istio.io/istio/pilot/pkg/keycertbundle"
 	"istio.io/istio/pkg/queue"
 	"istio.io/istio/pkg/webhooks/util"
-
 	"istio.io/pkg/log"
 )
 


### PR DESCRIPTION
when rootCABundle rotates, mutatingwebhook fails to pick up the latest one.  This PR utilize the keycertBundleWatcher to fix the problem. 