### PR TITLE
BootstrapNodeMetadata unmarshalJSON fails

### DIFF
--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -477,7 +477,7 @@ type BootstrapNodeMetadata struct {
 	Owner string `json:"OWNER,omitempty"`
 
 	// ProxyViaAgent specifies whether xDS streams are proxied through the agent.
-	ProxyViaAgent bool `json:"PROXY_VIA_AGENT,omitempty"`
+	ProxyViaAgent bool `json:"PROXY_VIA_AGENT,string,omitempty"`
 
 	// PilotSAN is the list of subject alternate names for the xDS server.
 	PilotSubjectAltName []string `json:"PILOT_SAN,omitempty"`

--- a/pilot/pkg/model/context_test.go
+++ b/pilot/pkg/model/context_test.go
@@ -622,3 +622,16 @@ func TestGlobalUnicastIP(t *testing.T) {
 		})
 	}
 }
+func TestBootstrapNodeMetadata(t *testing.T) {
+	t.Run("UnmarshalJSON", func(t *testing.T) {
+		var bnm model.BootstrapNodeMetadata
+		sampleJSON := `{"PROXY_VIA_AGENT":"true"}`
+		err := bnm.UnmarshalJSON([]byte(sampleJSON))
+		if err != nil {
+			t.Errorf("%v", err)
+		}
+		if bnm.ProxyViaAgent != true {
+			t.Errorf("got %v, want %v", bnm.ProxyViaAgent, true)
+		}
+	})
+}


### PR DESCRIPTION
when PROXY_VIA_AGENT is set due to missing
`,string` tag in struct

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ x ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
