### PR TITLE
fix istioctl install display error

### DIFF
--- a/operator/cmd/mesh/install.go
+++ b/operator/cmd/mesh/install.go
@@ -347,7 +347,7 @@ func getProfileNSAndEnabledComponents(iop *v1alpha12.IstioOperator) (string, str
 	}
 
 	if configuredNamespace := v1alpha12.Namespace(iop.Spec); configuredNamespace != "" {
-		return iop.Spec.Profile, configuredNamespace, enabledComponents, nil
+		return renderWithDefault(iop.Spec.Profile, "default"), configuredNamespace, enabledComponents, nil
 	}
 	return renderWithDefault(iop.Spec.Profile, "default"), name.IstioDefaultNamespace, enabledComponents, nil
 }

--- a/operator/cmd/mesh/install.go
+++ b/operator/cmd/mesh/install.go
@@ -347,14 +347,7 @@ func getProfileNSAndEnabledComponents(iop *v1alpha12.IstioOperator) (string, str
 	}
 
 	if configuredNamespace := v1alpha12.Namespace(iop.Spec); configuredNamespace != "" {
-		return renderWithDefault(iop.Spec.Profile, "default"), configuredNamespace, enabledComponents, nil
+		return iop.Spec.Profile, configuredNamespace, enabledComponents, nil
 	}
-	return renderWithDefault(iop.Spec.Profile, "default"), name.IstioDefaultNamespace, enabledComponents, nil
-}
-
-func renderWithDefault(s, def string) string {
-	if s != "" {
-		return s
-	}
-	return def
+	return iop.Spec.Profile, name.IstioDefaultNamespace, enabledComponents, nil
 }

--- a/operator/cmd/mesh/install.go
+++ b/operator/cmd/mesh/install.go
@@ -349,5 +349,12 @@ func getProfileNSAndEnabledComponents(iop *v1alpha12.IstioOperator) (string, str
 	if configuredNamespace := v1alpha12.Namespace(iop.Spec); configuredNamespace != "" {
 		return iop.Spec.Profile, configuredNamespace, enabledComponents, nil
 	}
-	return iop.Spec.Profile, name.IstioDefaultNamespace, enabledComponents, nil
+	return renderWithDefault(iop.Spec.Profile, "default"), name.IstioDefaultNamespace, enabledComponents, nil
+}
+
+func renderWithDefault(s, def string) string {
+	if s != "" {
+		return s
+	}
+	return def
 }

--- a/operator/pkg/manifest/shared.go
+++ b/operator/pkg/manifest/shared.go
@@ -212,6 +212,9 @@ func GenIOPFromProfile(profileOrPath, fileOverlayYAML string, setFlags []string,
 	if ns := GetValueForSetFlag(setFlags, "values.global.istioNamespace"); ns != "" {
 		finalIOP.Namespace = ns
 	}
+	if finalIOP.Spec.Profile == "" {
+		finalIOP.Spec.Profile = name.DefaultProfileName
+	}
 	return util.ToYAMLWithJSONPB(finalIOP), finalIOP, nil
 }
 
@@ -516,8 +519,6 @@ func overlaySetFlagValues(iopYAML string, setFlags []string) (string, error) {
 		iop = make(map[string]interface{})
 	}
 
-	setFlags = addDefaultProfileFlagIfNotSet(setFlags)
-
 	for _, sf := range setFlags {
 		p, v := getPV(sf)
 		p = strings.TrimPrefix(p, "spec.")
@@ -537,20 +538,6 @@ func overlaySetFlagValues(iopYAML string, setFlags []string) (string, error) {
 	}
 
 	return string(out), nil
-}
-
-// addDefaultProfileFlagIfNotSet adds the `profile=default` value to set flags if no profile value is set.
-func addDefaultProfileFlagIfNotSet(setFlags []string) []string {
-	isProfileSet := false
-	for _, setFlag := range setFlags {
-		if strings.HasPrefix(setFlag, "profile=") {
-			isProfileSet = true
-		}
-	}
-	if !isProfileSet {
-		setFlags = append(setFlags, fmt.Sprintf("profile=%s", name.DefaultProfileName))
-	}
-	return setFlags
 }
 
 // GetValueForSetFlag parses the passed set flags which have format key=value and if any set the given path,

--- a/operator/pkg/manifest/shared.go
+++ b/operator/pkg/manifest/shared.go
@@ -92,6 +92,8 @@ func GenManifests(inFilename []string, setFlags []string, force bool,
 // The force flag causes validation errors not to abort but only emit log/console warnings.
 func GenerateConfig(inFilenames []string, setFlags []string, force bool, kubeConfig *rest.Config,
 	l clog.Logger) (string, *iopv1alpha1.IstioOperator, error) {
+	setFlags = addDefaultProfileFlagIfNotSet(setFlags)
+
 	if err := validateSetFlags(setFlags); err != nil {
 		return "", nil, err
 	}
@@ -120,6 +122,20 @@ func OverlayYAMLStrings(profile string, fy string,
 		return "", nil, fmt.Errorf("generated config failed semantic validation: %v", errs)
 	}
 	return iopsString, iops, nil
+}
+
+// addDefaultProfileFlagIfNotSet adds the `profile=default` value to set flags if no profile value is set.
+func addDefaultProfileFlagIfNotSet(setFlags []string) []string {
+	isProfileSet := false
+	for _, setFlag := range setFlags {
+		if strings.HasPrefix(setFlag, "profile=") {
+			isProfileSet = true
+		}
+	}
+	if !isProfileSet {
+		setFlags = append(setFlags, fmt.Sprintf("profile=%s", name.DefaultProfileName))
+	}
+	return setFlags
 }
 
 // GenIOPFromProfile generates an IstioOperator from the given profile name or path, and overlay YAMLs from user

--- a/operator/pkg/manifest/shared.go
+++ b/operator/pkg/manifest/shared.go
@@ -92,8 +92,6 @@ func GenManifests(inFilename []string, setFlags []string, force bool,
 // The force flag causes validation errors not to abort but only emit log/console warnings.
 func GenerateConfig(inFilenames []string, setFlags []string, force bool, kubeConfig *rest.Config,
 	l clog.Logger) (string, *iopv1alpha1.IstioOperator, error) {
-	setFlags = addDefaultProfileFlagIfNotSet(setFlags)
-
 	if err := validateSetFlags(setFlags); err != nil {
 		return "", nil, err
 	}
@@ -122,20 +120,6 @@ func OverlayYAMLStrings(profile string, fy string,
 		return "", nil, fmt.Errorf("generated config failed semantic validation: %v", errs)
 	}
 	return iopsString, iops, nil
-}
-
-// addDefaultProfileFlagIfNotSet adds the `profile=default` value to set flags if no profile value is set.
-func addDefaultProfileFlagIfNotSet(setFlags []string) []string {
-	isProfileSet := false
-	for _, setFlag := range setFlags {
-		if strings.HasPrefix(setFlag, "profile=") {
-			isProfileSet = true
-		}
-	}
-	if !isProfileSet {
-		setFlags = append(setFlags, fmt.Sprintf("profile=%s", name.DefaultProfileName))
-	}
-	return setFlags
 }
 
 // GenIOPFromProfile generates an IstioOperator from the given profile name or path, and overlay YAMLs from user
@@ -532,6 +516,8 @@ func overlaySetFlagValues(iopYAML string, setFlags []string) (string, error) {
 		iop = make(map[string]interface{})
 	}
 
+	setFlags = addDefaultProfileFlagIfNotSet(setFlags)
+
 	for _, sf := range setFlags {
 		p, v := getPV(sf)
 		p = strings.TrimPrefix(p, "spec.")
@@ -551,6 +537,20 @@ func overlaySetFlagValues(iopYAML string, setFlags []string) (string, error) {
 	}
 
 	return string(out), nil
+}
+
+// addDefaultProfileFlagIfNotSet adds the `profile=default` value to set flags if no profile value is set.
+func addDefaultProfileFlagIfNotSet(setFlags []string) []string {
+	isProfileSet := false
+	for _, setFlag := range setFlags {
+		if strings.HasPrefix(setFlag, "profile=") {
+			isProfileSet = true
+		}
+	}
+	if !isProfileSet {
+		setFlags = append(setFlags, fmt.Sprintf("profile=%s", name.DefaultProfileName))
+	}
+	return setFlags
 }
 
 // GetValueForSetFlag parses the passed set flags which have format key=value and if any set the given path,

--- a/releasenotes/notes/33864.yaml
+++ b/releasenotes/notes/33864.yaml
@@ -5,4 +5,4 @@ issue:
   - 33857
 releaseNotes:
   - |
-    **Fixed** a message format bug for `istioctl install` command with the default file setting.
+    **Fixed** an issue where the `default` profile name was missing in the `istioctl install` confirmation prompt message.

--- a/releasenotes/notes/33864.yaml
+++ b/releasenotes/notes/33864.yaml
@@ -5,4 +5,4 @@ issue:
   - 33857
 releaseNotes:
   - |
-    **Fixed** istioctl install display error with default file.
+    **Fixed** a message format bug for `istioctl install` command with the default file setting.

--- a/releasenotes/notes/33864.yaml
+++ b/releasenotes/notes/33864.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: istioctl
+issue:
+  - 33857
+releaseNotes:
+  - |
+    **Fixed** istioctl install display error with default file.


### PR DESCRIPTION
This PR is to fix issue #33857. It will show `This will install the Istio 1.10.1 default profile with` instead of `This will install the Istio 1.10.1  profile with` if no arg is provided.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[x] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.