### PR TITLE
pkg/kube: fix client.PodExecCommands repeated error message

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -573,9 +573,10 @@ func (c *client) PodExecCommands(podName, podNamespace, container string, comman
 			if len(stderr) > 0 {
 				err = fmt.Errorf("error exec'ing into %s/%s %s container: %v\n%s",
 					podName, podNamespace, container, err, stderr)
+			} else {
+				err = fmt.Errorf("error exec'ing into %s/%s %s container: %v",
+					podName, podNamespace, container, err)
 			}
-			err = fmt.Errorf("error exec'ing into %s/%s %s container: %v",
-				podName, podNamespace, container, err)
 		}
 	}()
 


### PR DESCRIPTION
fix `client.PodExecCommands` repeated error message if has stderr

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[x] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
