### PR TITLE
add enforcing consecutive local origin failures

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -594,6 +594,7 @@ func applyOutlierDetection(c *cluster.Cluster, outlier *networking.OutlierDetect
 		out.SplitExternalLocalOriginErrors = true
 		if outlier.ConsecutiveLocalOriginFailures.GetValue() > 0 {
 			out.ConsecutiveLocalOriginFailure = &wrappers.UInt32Value{Value: outlier.ConsecutiveLocalOriginFailures.Value}
+			out.EnforcingConsecutiveLocalOriginFailure = &wrappers.UInt32Value{Value: 100}
 		}
 		// SuccessRate based outlier detection should be disabled.
 		out.EnforcingLocalOriginSuccessRate = &wrappers.UInt32Value{Value: 0}

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -1084,10 +1084,11 @@ func TestApplyOutlierDetection(t *testing.T) {
 				ConsecutiveLocalOriginFailures: &types.UInt32Value{Value: 10},
 			},
 			&cluster.OutlierDetection{
-				EnforcingSuccessRate:            &wrappers.UInt32Value{Value: 0},
-				SplitExternalLocalOriginErrors:  true,
-				ConsecutiveLocalOriginFailure:   &wrappers.UInt32Value{Value: 10},
-				EnforcingLocalOriginSuccessRate: &wrappers.UInt32Value{Value: 0},
+				EnforcingSuccessRate:                   &wrappers.UInt32Value{Value: 0},
+				SplitExternalLocalOriginErrors:         true,
+				ConsecutiveLocalOriginFailure:          &wrappers.UInt32Value{Value: 10},
+				EnforcingLocalOriginSuccessRate:        &wrappers.UInt32Value{Value: 0},
+				EnforcingConsecutiveLocalOriginFailure: &wrappers.UInt32Value{Value: 100},
 			},
 		},
 	}


### PR DESCRIPTION
Does not change any functionality but to be consistent with other failure modes we have.
[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
