### PR TITLE
adding standalone test for multi CA and error less changes to ca bundle

### DIFF
--- a/tests/integration/security/sds_ingress/.gitignore
+++ b/tests/integration/security/sds_ingress/.gitignore
@@ -1,0 +1,4 @@
+*.crt
+*.csr
+*.key
+fortio_ca_test.json

--- a/tests/integration/security/sds_ingress/multi_cacert_test.sh
+++ b/tests/integration/security/sds_ingress/multi_cacert_test.sh
@@ -1,0 +1,187 @@
+#! /bin/bash
+# Generates test CAs and matching test client certs and confirm you can add/remove CAs without error to
+# traffic to existing ones
+#
+# Related to
+# https://istio.io/latest/docs/tasks/traffic-management/ingress/secure-ingress/#configure-a-mutual-tls-ingress-gateway
+
+set -ex
+
+# In Envoy custom log format: %DOWNSTREAM_PEER_SUBJECT% should show the ESN
+# (to compare with X-Serial-Number)
+
+HOST=testca1.istio.io
+
+function gen_ca {
+    SUFFIX=$1
+    openssl req -x509 -sha256 -nodes -days 365 -newkey rsa:2048 \
+        -subj "/O=TestCA${SUFFIX}_o/CN=TestCA${SUFFIX}_cn" -keyout ca$SUFFIX.key -out ca$SUFFIX.crt
+}
+
+function gen_cli {
+    SUFFIX=$1
+    openssl req -out cli$SUFFIX.csr -newkey rsa:2048 -nodes -keyout cli$SUFFIX.key \
+        -subj "/CN=TEST_CLI${SUFFIX}_001/O=Client test org${SUFFIX}"
+    openssl x509 -req -days 30 -CA ca$SUFFIX.crt -CAkey ca$SUFFIX.key -set_serial 1 \
+        -in cli$SUFFIX.csr -out cli$SUFFIX.crt
+}
+
+# different CA for server - single cert
+function gen_server {
+    SUFFIX=SRV
+    gen_ca $SUFFIX
+    openssl req -out srv.csr -newkey rsa:2048 -nodes -keyout srv.key \
+        -subj "/CN=$HOST/O=Server test organization" \
+        -reqexts SAN \
+        -config <(cat /etc/ssl/openssl.cnf \
+            <(printf "\n[SAN]\nsubjectAltName=DNS:$HOST"))
+    openssl x509 -req -days 90 -CA caSRV.crt -CAkey caSRV.key -set_serial 0 \
+        -in srv.csr -out srv.crt \
+        -extfile <(printf "subjectAltName=DNS:$HOST\n")
+}
+
+
+function add_ingress {
+    SUFFIX=$1
+    cat <<_EOF_ | sed -e "s/SUFFIX/$SUFFIX/g" -e "s/HOST/$HOST/g" | tee >(cat 1>&2) | kubectl apply -f -
+apiVersion: networking.istio.io/v1beta1
+kind: Gateway
+metadata:
+ name: mtls-test-gatewaySUFFIX
+ namespace: istio-system
+spec:
+ selector:
+   istio: ingressgateway
+ servers:
+ - port:
+     number: 443
+     name: https
+     protocol: HTTPS
+   tls:
+     mode: MUTUAL
+     credentialName: testSUFFIX-credential # must be the same as secret
+   hosts:
+   - HOST
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: fortio-ca-debug
+  namespace: istio-system
+spec:
+  hosts:
+  - HOST
+  gateways:
+  - mtls-test-gatewaySUFFIX
+  http:
+  - match:
+    - uri:
+        prefix: /fortio
+    route:
+      - destination:
+          host: fortio-client.fortio.svc.cluster.local
+          port:
+            number: 8080
+_EOF_
+}
+
+gen_server
+
+for suffix in 1 2 ; do
+    gen_ca CLI$suffix
+    gen_cli CLI$suffix
+    kubectl delete -n istio-system secret test$suffix-credential || true
+    kubectl create -n istio-system secret tls test$suffix-credential \
+        --key=srv.key --cert=srv.crt
+    # Seperate the CA config map from the server cert one using credential-cacert:
+    kubectl delete -n istio-system secret test$suffix-credential-cacert || true
+    kubectl create -n istio-system secret generic test$suffix-credential-cacert \
+        --from-file=ca.crt=caCLI$suffix.crt
+done
+# Both/All CAs in a bundle:
+cat caCLI?.crt > caCLIall.crt
+
+ls -l *.crt
+
+add_ingress 1
+#add_ingress 2
+
+function bothCA {
+  kubectl create -n istio-system secret generic test1-credential-cacert \
+    --from-file=ca.crt=caCLIall.crt --dry-run=client -o yaml | kubectl apply -f -
+}
+
+function only1CA {
+   kubectl create -n istio-system secret generic test1-credential-cacert \
+    --from-file=ca.crt=caCLI1.crt --dry-run=client -o yaml | kubectl apply -f -
+}
+
+# Give it a second
+sleep 5
+
+INGRESS_HOST=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
+INGRESS_IP=$(nslookup $INGRESS_HOST | awk '/^Address:/ {print $2}'|tail -1)
+
+echo "Ingress served by $INGRESS_HOST ($INGRESS_IP)"
+
+function singleCall {
+  SUFFIX=$1
+#  fortio curl is easier with resolve but regular curl is more standard.
+#  fortio curl -resolve $INGRESS_HOST -cert cliCLI$SUFFIX.crt -key cliCLI$SUFFIX.key -cacert caSRV.crt  https://$HOST/fortio/debug/
+  curl -v --resolve "$HOST:443:$INGRESS_IP" --cert cliCLI$SUFFIX.crt --key cliCLI$SUFFIX.key --cacert caSRV.crt  https://$HOST/fortio/debug/
+}
+
+function check2fail {
+  set +e
+  singleCall 2
+  if [ $? -eq 0 ]
+  then
+    echo "** call using cli cert/ca 2 should have failed"
+    exit 1
+  else
+    echo "cli2 failed as expected"
+  fi
+  set -e
+}
+
+# We start with only 1 CA:
+sleep 5
+
+# Start fortio test during the changes of CA, on cli1 should not get any errors:
+RES_FILE=fortio_ca_test.json
+fortio load -json $RES_FILE -jitter -c 2 -qps 10 -t 0 -resolve $INGRESS_HOST -cert cliCLI1.crt -key cliCLI1.key -cacert caSRV.crt  https://$HOST/fortio/debug/ &
+FORTIO_PID=$!
+
+# Should succeed
+singleCall 1
+# Should fail
+check2fail
+
+# We switch to 2 CAs:
+bothCA ; sleep 10
+
+# 1 should still work
+singleCall 1
+# but 2 should now work too
+singleCall 2
+
+# Back to only 1 CA:
+
+only1CA ; sleep 10
+# 1 should still work
+singleCall 1
+# 2 should fail again
+check2fail
+
+kill -int $FORTIO_PID
+
+TOTAL_REQUESTS=$(jq .DurationHistogram.Count < $RES_FILE)
+OK_REQUESTS=$(jq .RetCodes.\"200\" < $RES_FILE)
+
+if [[ $TOTAL_REQUESTS != $OK_REQUESTS ]]
+then
+  echo "Errors found $TOTAL_REQUESTS != $OK_REQUESTS"
+  jq .RetCodes < $RES_FILE
+fi
+
+echo "*** All tested passed"


### PR DESCRIPTION
This is the test I used to figure out the answer to my question on slack on whether `cacert` can be multiple certs or not and if you can change the CAs without errors to existing one (answer is yes for both)

https://istio.slack.com/archives/C3TEGNZ7W/p1625089441112200

https://github.com/istio/istio.io/pull/10032

[ ] Configuration Infrastructure
[x] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[x] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.


Here is the output of a run of the test:
```shell
$ ./multi_cacert_test.sh 
+ HOST=testca1.istio.io
+ gen_server
+ SUFFIX=SRV
+ gen_ca SRV
+ SUFFIX=SRV
+ openssl req -x509 -sha256 -nodes -days 365 -newkey rsa:2048 -subj /O=TestCASRV_o/CN=TestCASRV_cn -keyout caSRV.key -out caSRV.crt
Generating a 2048 bit RSA private key
..........................+++
.................................................+++
writing new private key to 'caSRV.key'
-----
+ openssl req -out srv.csr -newkey rsa:2048 -nodes -keyout srv.key -subj '/CN=testca1.istio.io/O=Server test organization' -reqexts SAN -config /dev/fd/63
++ cat /etc/ssl/openssl.cnf /dev/fd/63
+++ printf '\n[SAN]\nsubjectAltName=DNS:%s' testca1.istio.io
Generating a 2048 bit RSA private key
......................+++
...................................+++
writing new private key to 'srv.key'
-----
+ openssl x509 -req -days 90 -CA caSRV.crt -CAkey caSRV.key -set_serial 0 -in srv.csr -out srv.crt -extfile /dev/fd/63
++ printf 'subjectAltName=DNS:%s\n' testca1.istio.io
Signature ok
subject=/CN=testca1.istio.io/O=Server test organization
Getting CA Private Key
+ for suffix in 1 2
+ gen_ca CLI1
+ SUFFIX=CLI1
+ openssl req -x509 -sha256 -nodes -days 365 -newkey rsa:2048 -subj /O=TestCACLI1_o/CN=TestCACLI1_cn -keyout caCLI1.key -out caCLI1.crt
Generating a 2048 bit RSA private key
...................+++
......................................................+++
writing new private key to 'caCLI1.key'
-----
+ gen_cli CLI1
+ SUFFIX=CLI1
+ openssl req -out cliCLI1.csr -newkey rsa:2048 -nodes -keyout cliCLI1.key -subj '/CN=TEST_CLICLI1_001/O=Client test orgCLI1'
Generating a 2048 bit RSA private key
......................................................................................................+++
..............................+++
writing new private key to 'cliCLI1.key'
-----
+ openssl x509 -req -days 30 -CA caCLI1.crt -CAkey caCLI1.key -set_serial 1 -in cliCLI1.csr -out cliCLI1.crt
Signature ok
subject=/CN=TEST_CLICLI1_001/O=Client test orgCLI1
Getting CA Private Key
+ kubectl delete -n istio-system secret test1-credential
secret "test1-credential" deleted
+ kubectl create -n istio-system secret tls test1-credential --key=srv.key --cert=srv.crt
secret/test1-credential created
+ kubectl delete -n istio-system secret test1-credential-cacert
secret "test1-credential-cacert" deleted
+ kubectl create -n istio-system secret generic test1-credential-cacert --from-file=ca.crt=caCLI1.crt
secret/test1-credential-cacert created
+ for suffix in 1 2
+ gen_ca CLI2
+ SUFFIX=CLI2
+ openssl req -x509 -sha256 -nodes -days 365 -newkey rsa:2048 -subj /O=TestCACLI2_o/CN=TestCACLI2_cn -keyout caCLI2.key -out caCLI2.crt
Generating a 2048 bit RSA private key
...........................+++
....................................+++
writing new private key to 'caCLI2.key'
-----
+ gen_cli CLI2
+ SUFFIX=CLI2
+ openssl req -out cliCLI2.csr -newkey rsa:2048 -nodes -keyout cliCLI2.key -subj '/CN=TEST_CLICLI2_001/O=Client test orgCLI2'
Generating a 2048 bit RSA private key
.......+++
...............................................................................................+++
writing new private key to 'cliCLI2.key'
-----
+ openssl x509 -req -days 30 -CA caCLI2.crt -CAkey caCLI2.key -set_serial 1 -in cliCLI2.csr -out cliCLI2.crt
Signature ok
subject=/CN=TEST_CLICLI2_001/O=Client test orgCLI2
Getting CA Private Key
+ kubectl delete -n istio-system secret test2-credential
secret "test2-credential" deleted
+ kubectl create -n istio-system secret tls test2-credential --key=srv.key --cert=srv.crt
secret/test2-credential created
+ kubectl delete -n istio-system secret test2-credential-cacert
secret "test2-credential-cacert" deleted
+ kubectl create -n istio-system secret generic test2-credential-cacert --from-file=ca.crt=caCLI2.crt
secret/test2-credential-cacert created
+ cat caCLI1.crt caCLI2.crt
+ ls -l -- caCLI1.crt caCLI2.crt caCLIall.crt caSRV.crt cliCLI1.crt cliCLI2.crt srv.crt
-rw-r--r--  1 ldemailly  CORP\Domain Users  1050 Jul  7 14:26 caCLI1.crt
-rw-r--r--  1 ldemailly  CORP\Domain Users  1050 Jul  7 14:26 caCLI2.crt
-rw-r--r--  1 ldemailly  CORP\Domain Users  2100 Jul  7 14:26 caCLIall.crt
-rw-r--r--  1 ldemailly  CORP\Domain Users  1046 Jul  7 14:26 caSRV.crt
-rw-r--r--  1 ldemailly  CORP\Domain Users  1054 Jul  7 14:26 cliCLI1.crt
-rw-r--r--  1 ldemailly  CORP\Domain Users  1054 Jul  7 14:26 cliCLI2.crt
-rw-r--r--  1 ldemailly  CORP\Domain Users  1107 Jul  7 14:26 srv.crt
+ add_ingress 1
+ SUFFIX=1
+ cat
+ sed -e s/SUFFIX/1/g -e s/HOST/testca1.istio.io/g
+ kubectl apply -f -
+ tee /dev/fd/63
++ cat
apiVersion: networking.istio.io/v1beta1
kind: Gateway
metadata:
 name: mtls-test-gateway1
 namespace: istio-system
spec:
 selector:
   istio: ingressgateway
 servers:
 - port:
     number: 443
     name: https
     protocol: HTTPS
   tls:
     mode: MUTUAL
     credentialName: test1-credential # must be the same as secret
   hosts:
   - testca1.istio.io
---
apiVersion: networking.istio.io/v1alpha3
kind: VirtualService
metadata:
  name: fortio-ca-debug
  namespace: istio-system
spec:
  hosts:
  - testca1.istio.io
  gateways:
  - mtls-test-gateway1
  http:
  - match:
    - uri:
        prefix: /fortio
    route:
      - destination:
          host: fortio-client.fortio.svc.cluster.local
          port:
            number: 8080
gateway.networking.istio.io/mtls-test-gateway1 unchanged
virtualservice.networking.istio.io/fortio-ca-debug unchanged
+ wait_for_propagation
+ sleep 10
++ kubectl -n istio-system get service istio-ingressgateway -o 'jsonpath={.status.loadBalancer.ingress[0].hostname}'
+ INGRESS_HOST=a16fc46e9_REDACTED_43b519a25e97-32_REDACTED_beaf7.elb.us-west-2.amazonaws.com
++ nslookup a16fc46e9_REDACTED_43b519a25e97-32_REDACTED_beaf7.elb.us-west-2.amazonaws.com
++ awk '/^Address:/ {print $2}'
++ tail -1
+ INGRESS_IP=54._REDACTED_212
+ echo 'Ingress served by a16fc46e9_REDACTED_43b519a25e97-32_REDACTED_beaf7.elb.us-west-2.amazonaws.com (54._REDACTED_212)'
Ingress served by a16fc46e9_REDACTED_43b519a25e97-32_REDACTED_beaf7.elb.us-west-2.amazonaws.com (54._REDACTED_212)
+ wait_for_propagation
+ sleep 10
+ RES_FILE=fortio_ca_test.json
+ FORTIO_PID=88635
+ singleCall 1
+ SUFFIX=1
+ curl -v --resolve testca1.istio.io:443:54._REDACTED_212 --cert cliCLI1.crt --key cliCLI1.key --cacert caSRV.crt https://testca1.istio.io/fortio/debug/
+ fortio load -json fortio_ca_test.json -jitter -c 2 -qps 10 -t 0 -resolve a16fc46e9_REDACTED_43b519a25e97-32_REDACTED_beaf7.elb.us-west-2.amazonaws.com -cert cliCLI1.crt -key cliCLI1.key -cacert caSRV.crt https://testca1.istio.io/fortio/debug/
* Added testca1.istio.io:443:54._REDACTED_212 to DNS cache
* Hostname testca1.istio.io was found in DNS cache
*   Trying 54._REDACTED_212...
* TCP_NODELAY set
Fortio 1.17.0 running at 10 queries per second, 16->16 procs, until interrupted: https://testca1.istio.io/fortio/debug/
14:27:06 I httprunner.go:81> Starting http test for https://testca1.istio.io/fortio/debug/ with 2 threads at 10.0 qps
14:27:06 W http_client.go:146> https requested, switching to standard go client
* Connected to testca1.istio.io (54._REDACTED_212) port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*   CAfile: caSRV.crt
  CApath: none
* TLSv1.2 (OUT), TLS handshake, Client hello (1):
* TLSv1.2 (IN), TLS handshake, Server hello (2):
* TLSv1.2 (IN), TLS handshake, Certificate (11):
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
* TLSv1.2 (IN), TLS handshake, Request CERT (13):
* TLSv1.2 (IN), TLS handshake, Server finished (14):
* TLSv1.2 (OUT), TLS handshake, Certificate (11):
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
* TLSv1.2 (OUT), TLS handshake, CERT verify (15):
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
* TLSv1.2 (OUT), TLS handshake, Finished (20):
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
* TLSv1.2 (IN), TLS handshake, Finished (20):
* SSL connection using TLSv1.2 / ECDHE-RSA-CHACHA20-POLY1305
* ALPN, server accepted to use h2
* Server certificate:
*  subject: CN=testca1.istio.io; O=Server test organization
*  start date: Jul  7 21:26:35 2021 GMT
*  expire date: Oct  5 21:26:35 2021 GMT
*  subjectAltName: host "testca1.istio.io" matched cert's "testca1.istio.io"
*  issuer: O=TestCASRV_o; CN=TestCASRV_cn
*  SSL certificate verify ok.
* Using HTTP2, server supports multi-use
* Connection state changed (HTTP/2 confirmed)
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* Using Stream ID: 1 (easy handle 0x7f98de009200)
> GET /fortio/debug/ HTTP/2
> Host: testca1.istio.io
> User-Agent: curl/7.64.1
> Accept: */*
> 
* Connection state changed (MAX_CONCURRENT_STREAMS == 2147483647)!
< HTTP/2 200 
< content-type: text/plain; charset=UTF-8
< content-length: 2108
< date: Wed, 07 Jul 2021 21:26:42 GMT
< x-envoy-upstream-service-time: 1
< server: istio-envoy
< 
Φορτίο version 1.14.2 2021-03-10 22:28 ee098c572115f4149a67d2a812cb3d1ca79e30e1 go1.15.9 echo debug server up for 36h1m40s on fortio-client-deployment-8d5fcd9d9-zhltn - request from 127.0.0.6:39437

GET /fortio/debug/ HTTP/2.0

headers:

Host: testca1.istio.io
Accept: */*
User-Agent: curl/7.64.1
X-B3-Parentspanid: e74fe24d9e18b915
X-B3-Sampled: 0
X-B3-Spanid: 20fa885a108e6019
X-B3-Traceid: 879eb9b5a9bce2bae74fe24d9e18b915
X-Envoy-Attempt-Count: 1
X-Envoy-External-Address: 50_REDACTED_193
X-Forwarded-Client-Cert: Hash=0f9d2ced3d19f19d623e401475dc6cbd8aad39e2c78970dafb16d9bb807b4535;Cert="-----BEGIN%20CERTIFICATE-----%0AMIIC3DCCAcQCAQEwDQYJKoZIhvcNAQEFBQAwLzEVMBMGA1UECgwMVGVzdENBQ0xJ%0AMV9vMRYwFAYDVQQDDA1UZXN0Q0FDTEkxX2NuMB4XDTIxMDcwNzIxMjYzNVoXDTIx%0AMDgwNjIxMjYzNVowOTEZMBcGA1UEAwwQVEVTVF9DTElDTEkxXzAwMTEcMBoGA1UE%0ACgwTQ2xpZW50IHRlc3Qgb3JnQ0xJMTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCC%0AAQoCggEBAK2A6C4y7ElzIxXgd01B%2Fr5egMHzfzhHvUuNGyxbQA6%2BloAucANYrZN9%0ApMmR8CsXUuv8O%2FjoONZaI4uYolnMfLtZhVRCAXRbCO3vqj3LhJ7DrMGHjx1kh4TI%0AkkPimdjFayevoKE3zK0%2FKR98wyVNH3ixyP9cjgd2jqAoTVaykHD0ulOYqENxY6ZH%0AjQSrKjI%2F91bnYM76DssGLkPdeMsR2bo2b8VHhP3qKvHUzotExX2mfUty7AlDZrms%0ACkHTGqv6OGuyZLky4YLKbRIgueIq0emXv75QXYj8X1o7MUcZ7rsJnZnRphDfAIqa%0AjdqrvRCsJBZM0xJtqNO2kCiH9U6tDj8CAwEAATANBgkqhkiG9w0BAQUFAAOCAQEA%0AK9ksMGbczP4a%2F8hoUg%2BWcKsZKtzGVvad8K2e9tWG76b7kMkGo%2FKdafIYMAdFcAl3%0AuEzwL9xyu41cKORALDun80FiIRVPgFNbfOuurJrX7imBeTHAlaVsUtDGFYT4cuR1%0ArLCUO%2B3CZrVZuOpdmjEIBcBL6iPjanOxzdavTkpJjfsLt6Xz1vD72F%2BAHGUzbVhm%0A0wcppUBIwnCoT9QyLAQJWcGZ1Bf%2BGoK9lTnYXae7RKK6G1HHBIm9eb55%2Fd2CIiQ2%0AI57fXitkrnZX%2B7ytgLhhJE9IR66sHkQmTil3vf%2F0gjSbpVC52Ev23qooAFITYqmO%0Ax3IfZsZIxVmMtRah5uzkMQ%3D%3D%0A-----END%20CERTIFICATE-----%0A";Subject="O=Client test orgCLI1,CN=TEST_CLICLI1_001";URI=,By=spiffe://cluster.local/ns/fortio/sa/default;Hash=8ac68f7d0775d6018b4ff041f0a8a21c9f6037c807c4b0b0ed2a551accef3a84;Subject="";URI=spiffe://cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account
X-Forwarded-For: 50_REDACTED_193
X-Forwarded-Proto: https
X-Request-Id: bbfe90bd-c587-4857-bc4c-a47a2f71c795

body:


* Connection #0 to host testca1.istio.io left intact
* Closing connection 0
+ check2fail
+ set +e
+ singleCall 2
+ SUFFIX=2
+ curl -v --resolve testca1.istio.io:443:54._REDACTED_212 --cert cliCLI2.crt --key cliCLI2.key --cacert caSRV.crt https://testca1.istio.io/fortio/debug/
* Added testca1.istio.io:443:54._REDACTED_212 to DNS cache
* Hostname testca1.istio.io was found in DNS cache
*   Trying 54._REDACTED_212...
* TCP_NODELAY set
* Connected to testca1.istio.io (54._REDACTED_212) port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*   CAfile: caSRV.crt
  CApath: none
* TLSv1.2 (OUT), TLS handshake, Client hello (1):
* TLSv1.2 (IN), TLS handshake, Server hello (2):
* TLSv1.2 (IN), TLS handshake, Certificate (11):
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
* TLSv1.2 (IN), TLS handshake, Request CERT (13):
* TLSv1.2 (IN), TLS handshake, Server finished (14):
* TLSv1.2 (OUT), TLS handshake, Certificate (11):
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
* TLSv1.2 (OUT), TLS handshake, CERT verify (15):
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
* TLSv1.2 (OUT), TLS handshake, Finished (20):
* TLSv1.2 (IN), TLS alert, unknown CA (560):
* error:1401E418:SSL routines:CONNECT_CR_FINISHED:tlsv1 alert unknown ca
* Closing connection 0
curl: (35) error:1401E418:SSL routines:CONNECT_CR_FINISHED:tlsv1 alert unknown ca
+ echo 'cli2 failed as expected'
cli2 failed as expected
+ set -e
+ bothCA
+ kubectl create -n istio-system secret generic test1-credential-cacert --from-file=ca.crt=caCLIall.crt --dry-run=client -o yaml
+ kubectl apply -f -
Starting at 10 qps with 2 thread(s) [gomax 16] until interrupted
Warning: resource secrets/test1-credential-cacert is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
secret/test1-credential-cacert configured
+ wait_for_propagation
+ sleep 10
+ singleCall 1
+ SUFFIX=1
+ curl -v --resolve testca1.istio.io:443:54._REDACTED_212 --cert cliCLI1.crt --key cliCLI1.key --cacert caSRV.crt https://testca1.istio.io/fortio/debug/
* Added testca1.istio.io:443:54._REDACTED_212 to DNS cache
* Hostname testca1.istio.io was found in DNS cache
*   Trying 54._REDACTED_212...
* TCP_NODELAY set
* Connected to testca1.istio.io (54._REDACTED_212) port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*   CAfile: caSRV.crt
  CApath: none
* TLSv1.2 (OUT), TLS handshake, Client hello (1):
* TLSv1.2 (IN), TLS handshake, Server hello (2):
* TLSv1.2 (IN), TLS handshake, Certificate (11):
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
* TLSv1.2 (IN), TLS handshake, Request CERT (13):
* TLSv1.2 (IN), TLS handshake, Server finished (14):
* TLSv1.2 (OUT), TLS handshake, Certificate (11):
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
* TLSv1.2 (OUT), TLS handshake, CERT verify (15):
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
* TLSv1.2 (OUT), TLS handshake, Finished (20):
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
* TLSv1.2 (IN), TLS handshake, Finished (20):
* SSL connection using TLSv1.2 / ECDHE-RSA-CHACHA20-POLY1305
* ALPN, server accepted to use h2
* Server certificate:
*  subject: CN=testca1.istio.io; O=Server test organization
*  start date: Jul  7 21:26:35 2021 GMT
*  expire date: Oct  5 21:26:35 2021 GMT
*  subjectAltName: host "testca1.istio.io" matched cert's "testca1.istio.io"
*  issuer: O=TestCASRV_o; CN=TestCASRV_cn
*  SSL certificate verify ok.
* Using HTTP2, server supports multi-use
* Connection state changed (HTTP/2 confirmed)
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* Using Stream ID: 1 (easy handle 0x7fbc1f009200)
> GET /fortio/debug/ HTTP/2
> Host: testca1.istio.io
> User-Agent: curl/7.64.1
> Accept: */*
> 
* Connection state changed (MAX_CONCURRENT_STREAMS == 2147483647)!
< HTTP/2 200 
< content-type: text/plain; charset=UTF-8
< content-length: 2110
< date: Wed, 07 Jul 2021 21:26:54 GMT
< x-envoy-upstream-service-time: 1
< server: istio-envoy
< 
Φορτίο version 1.14.2 2021-03-10 22:28 ee098c572115f4149a67d2a812cb3d1ca79e30e1 go1.15.9 echo debug server up for 36h1m51.8s on fortio-client-deployment-8d5fcd9d9-zhltn - request from 127.0.0.6:39437

GET /fortio/debug/ HTTP/2.0

headers:

Host: testca1.istio.io
Accept: */*
User-Agent: curl/7.64.1
X-B3-Parentspanid: 6a665d38933782e2
X-B3-Sampled: 0
X-B3-Spanid: 5451bd81e959c35a
X-B3-Traceid: c4413f4e7a88f2d16a665d38933782e2
X-Envoy-Attempt-Count: 1
X-Envoy-External-Address: 50_REDACTED_193
X-Forwarded-Client-Cert: Hash=0f9d2ced3d19f19d623e401475dc6cbd8aad39e2c78970dafb16d9bb807b4535;Cert="-----BEGIN%20CERTIFICATE-----%0AMIIC3DCCAcQCAQEwDQYJKoZIhvcNAQEFBQAwLzEVMBMGA1UECgwMVGVzdENBQ0xJ%0AMV9vMRYwFAYDVQQDDA1UZXN0Q0FDTEkxX2NuMB4XDTIxMDcwNzIxMjYzNVoXDTIx%0AMDgwNjIxMjYzNVowOTEZMBcGA1UEAwwQVEVTVF9DTElDTEkxXzAwMTEcMBoGA1UE%0ACgwTQ2xpZW50IHRlc3Qgb3JnQ0xJMTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCC%0AAQoCggEBAK2A6C4y7ElzIxXgd01B%2Fr5egMHzfzhHvUuNGyxbQA6%2BloAucANYrZN9%0ApMmR8CsXUuv8O%2FjoONZaI4uYolnMfLtZhVRCAXRbCO3vqj3LhJ7DrMGHjx1kh4TI%0AkkPimdjFayevoKE3zK0%2FKR98wyVNH3ixyP9cjgd2jqAoTVaykHD0ulOYqENxY6ZH%0AjQSrKjI%2F91bnYM76DssGLkPdeMsR2bo2b8VHhP3qKvHUzotExX2mfUty7AlDZrms%0ACkHTGqv6OGuyZLky4YLKbRIgueIq0emXv75QXYj8X1o7MUcZ7rsJnZnRphDfAIqa%0AjdqrvRCsJBZM0xJtqNO2kCiH9U6tDj8CAwEAATANBgkqhkiG9w0BAQUFAAOCAQEA%0AK9ksMGbczP4a%2F8hoUg%2BWcKsZKtzGVvad8K2e9tWG76b7kMkGo%2FKdafIYMAdFcAl3%0AuEzwL9xyu41cKORALDun80FiIRVPgFNbfOuurJrX7imBeTHAlaVsUtDGFYT4cuR1%0ArLCUO%2B3CZrVZuOpdmjEIBcBL6iPjanOxzdavTkpJjfsLt6Xz1vD72F%2BAHGUzbVhm%0A0wcppUBIwnCoT9QyLAQJWcGZ1Bf%2BGoK9lTnYXae7RKK6G1HHBIm9eb55%2Fd2CIiQ2%0AI57fXitkrnZX%2B7ytgLhhJE9IR66sHkQmTil3vf%2F0gjSbpVC52Ev23qooAFITYqmO%0Ax3IfZsZIxVmMtRah5uzkMQ%3D%3D%0A-----END%20CERTIFICATE-----%0A";Subject="O=Client test orgCLI1,CN=TEST_CLICLI1_001";URI=,By=spiffe://cluster.local/ns/fortio/sa/default;Hash=8ac68f7d0775d6018b4ff041f0a8a21c9f6037c807c4b0b0ed2a551accef3a84;Subject="";URI=spiffe://cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account
X-Forwarded-For: 50_REDACTED_193
X-Forwarded-Proto: https
X-Request-Id: 7e6880e7-a17d-4f31-ac77-3eb2ee7467bb

body:


* Connection #0 to host testca1.istio.io left intact
* Closing connection 0
+ singleCall 2
+ SUFFIX=2
+ curl -v --resolve testca1.istio.io:443:54._REDACTED_212 --cert cliCLI2.crt --key cliCLI2.key --cacert caSRV.crt https://testca1.istio.io/fortio/debug/
* Added testca1.istio.io:443:54._REDACTED_212 to DNS cache
* Hostname testca1.istio.io was found in DNS cache
*   Trying 54._REDACTED_212...
* TCP_NODELAY set
* Connected to testca1.istio.io (54._REDACTED_212) port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*   CAfile: caSRV.crt
  CApath: none
* TLSv1.2 (OUT), TLS handshake, Client hello (1):
* TLSv1.2 (IN), TLS handshake, Server hello (2):
* TLSv1.2 (IN), TLS handshake, Certificate (11):
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
* TLSv1.2 (IN), TLS handshake, Request CERT (13):
* TLSv1.2 (IN), TLS handshake, Server finished (14):
* TLSv1.2 (OUT), TLS handshake, Certificate (11):
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
* TLSv1.2 (OUT), TLS handshake, CERT verify (15):
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
* TLSv1.2 (OUT), TLS handshake, Finished (20):
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
* TLSv1.2 (IN), TLS handshake, Finished (20):
* SSL connection using TLSv1.2 / ECDHE-RSA-CHACHA20-POLY1305
* ALPN, server accepted to use h2
* Server certificate:
*  subject: CN=testca1.istio.io; O=Server test organization
*  start date: Jul  7 21:26:35 2021 GMT
*  expire date: Oct  5 21:26:35 2021 GMT
*  subjectAltName: host "testca1.istio.io" matched cert's "testca1.istio.io"
*  issuer: O=TestCASRV_o; CN=TestCASRV_cn
*  SSL certificate verify ok.
* Using HTTP2, server supports multi-use
* Connection state changed (HTTP/2 confirmed)
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* Using Stream ID: 1 (easy handle 0x7fa89e008200)
> GET /fortio/debug/ HTTP/2
> Host: testca1.istio.io
> User-Agent: curl/7.64.1
> Accept: */*
> 
* Connection state changed (MAX_CONCURRENT_STREAMS == 2147483647)!
< HTTP/2 200 
< content-type: text/plain; charset=UTF-8
< content-length: 2118
< date: Wed, 07 Jul 2021 21:26:54 GMT
< x-envoy-upstream-service-time: 3
< server: istio-envoy
< 
Φορτίο version 1.14.2 2021-03-10 22:28 ee098c572115f4149a67d2a812cb3d1ca79e30e1 go1.15.9 echo debug server up for 36h1m52s on fortio-client-deployment-8d5fcd9d9-zhltn - request from 127.0.0.6:39437

GET /fortio/debug/ HTTP/2.0

headers:

Host: testca1.istio.io
Accept: */*
User-Agent: curl/7.64.1
X-B3-Parentspanid: a07cd88de0da88d5
X-B3-Sampled: 0
X-B3-Spanid: 734b71fdc96feeee
X-B3-Traceid: 31049495b9898935a07cd88de0da88d5
X-Envoy-Attempt-Count: 1
X-Envoy-External-Address: 50_REDACTED_193
X-Forwarded-Client-Cert: Hash=cfe83498d18f0adf9bc100f551ce63a0a58c8cc5d4fd228de6f612ee59590810;Cert="-----BEGIN%20CERTIFICATE-----%0AMIIC3DCCAcQCAQEwDQYJKoZIhvcNAQEFBQAwLzEVMBMGA1UECgwMVGVzdENBQ0xJ%0AMl9vMRYwFAYDVQQDDA1UZXN0Q0FDTEkyX2NuMB4XDTIxMDcwNzIxMjYzOVoXDTIx%0AMDgwNjIxMjYzOVowOTEZMBcGA1UEAwwQVEVTVF9DTElDTEkyXzAwMTEcMBoGA1UE%0ACgwTQ2xpZW50IHRlc3Qgb3JnQ0xJMjCCASIwDQYJKoZIhvcNAQEBBQADggEPADCC%0AAQoCggEBAM66zXOoQS0Gkx2JObBq153kJMSrw0KplJWONFlZ%2BbmOo0K9Skd8vzzn%0AkCEnUxrDcn1AhuOcnXIq6TIHht2LX9BdoVZKzVuidgdPCqDmXS9Su4rrobpIwzXi%0AHhdXxRipwNxDrP%2Fzxz1UQIBMTq8DAXirm6u%2F2O3bsBFF45O5D9iM%2BJNdE3hGP6a%2F%0AQTG6%2FRC%2FaE5E219TVG%2Fr4OD0gqL3JhmsLoHfPRx7Sw5dYDq2F04xQaa9oFlaieA%2B%0ARN%2F%2Bv04aewGP9VfoyFvrv7fUTp2tjYC7SA%2BSafYiILjorq%2F261%2FWraf8Bac6QBgU%0AfSwWPJUFOU0%2B0fvtrjhLqXnjGaJCe1cCAwEAATANBgkqhkiG9w0BAQUFAAOCAQEA%0AehgB4C9SqjK3ns2pBfflRwJpXippm3l9pEiexdKabOq4kmeWZaEM0eH0R1b92vIY%0AnAXd5DW2Tp0VSpNtVYmZVc1o3pBk943ua2rahSZp6yTmH686iUQfBrI0kGEvZH17%0ABEEfETUFA4RGo0Q5eSwpMN%2BkWoU8d3vH0J8EN3%2FJRst7CnBYoTMkj22rHB6ksp8f%0AXfTqOv0ZGK6m3FbCyB1M93fceJwumxPtjpcdxYVzPA4R7QDFR0F2KX4N5xHYTMxl%0AqR3T3ynMhrwS0juVPXkZL4w8S3jLSxkuUE%2FQYkmxdqqe4bm4XEhQxqbmGA6I1TTL%0AH6P2Z%2FNKwMNsbCfEuTBRiA%3D%3D%0A-----END%20CERTIFICATE-----%0A";Subject="O=Client test orgCLI2,CN=TEST_CLICLI2_001";URI=,By=spiffe://cluster.local/ns/fortio/sa/default;Hash=8ac68f7d0775d6018b4ff041f0a8a21c9f6037c807c4b0b0ed2a551accef3a84;Subject="";URI=spiffe://cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account
X-Forwarded-For: 50_REDACTED_193
X-Forwarded-Proto: https
X-Request-Id: 770fffb5-c306-4dfa-bea9-09054e8872fa

body:


* Connection #0 to host testca1.istio.io left intact
* Closing connection 0
+ only1CA
+ kubectl create -n istio-system secret generic test1-credential-cacert --from-file=ca.crt=caCLI1.crt --dry-run=client -o yaml
+ kubectl apply -f -
secret/test1-credential-cacert configured
+ wait_for_propagation
+ sleep 10
+ singleCall 1
+ SUFFIX=1
+ curl -v --resolve testca1.istio.io:443:54._REDACTED_212 --cert cliCLI1.crt --key cliCLI1.key --cacert caSRV.crt https://testca1.istio.io/fortio/debug/
* Added testca1.istio.io:443:54._REDACTED_212 to DNS cache
* Hostname testca1.istio.io was found in DNS cache
*   Trying 54._REDACTED_212...
* TCP_NODELAY set
* Connected to testca1.istio.io (54._REDACTED_212) port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*   CAfile: caSRV.crt
  CApath: none
* TLSv1.2 (OUT), TLS handshake, Client hello (1):
* TLSv1.2 (IN), TLS handshake, Server hello (2):
* TLSv1.2 (IN), TLS handshake, Certificate (11):
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
* TLSv1.2 (IN), TLS handshake, Request CERT (13):
* TLSv1.2 (IN), TLS handshake, Server finished (14):
* TLSv1.2 (OUT), TLS handshake, Certificate (11):
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
* TLSv1.2 (OUT), TLS handshake, CERT verify (15):
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
* TLSv1.2 (OUT), TLS handshake, Finished (20):
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
* TLSv1.2 (IN), TLS handshake, Finished (20):
* SSL connection using TLSv1.2 / ECDHE-RSA-CHACHA20-POLY1305
* ALPN, server accepted to use h2
* Server certificate:
*  subject: CN=testca1.istio.io; O=Server test organization
*  start date: Jul  7 21:26:35 2021 GMT
*  expire date: Oct  5 21:26:35 2021 GMT
*  subjectAltName: host "testca1.istio.io" matched cert's "testca1.istio.io"
*  issuer: O=TestCASRV_o; CN=TestCASRV_cn
*  SSL certificate verify ok.
* Using HTTP2, server supports multi-use
* Connection state changed (HTTP/2 confirmed)
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* Using Stream ID: 1 (easy handle 0x7f847880d600)
> GET /fortio/debug/ HTTP/2
> Host: testca1.istio.io
> User-Agent: curl/7.64.1
> Accept: */*
> 
* Connection state changed (MAX_CONCURRENT_STREAMS == 2147483647)!
< HTTP/2 200 
< content-type: text/plain; charset=UTF-8
< content-length: 2109
< date: Wed, 07 Jul 2021 21:27:06 GMT
< x-envoy-upstream-service-time: 1
< server: istio-envoy
< 
Φορτίο version 1.14.2 2021-03-10 22:28 ee098c572115f4149a67d2a812cb3d1ca79e30e1 go1.15.9 echo debug server up for 36h2m3.7s on fortio-client-deployment-8d5fcd9d9-zhltn - request from 127.0.0.6:39437

GET /fortio/debug/ HTTP/2.0

headers:

Host: testca1.istio.io
Accept: */*
User-Agent: curl/7.64.1
X-B3-Parentspanid: b46937001cdd776d
X-B3-Sampled: 0
X-B3-Spanid: a6445af0b2b9907a
X-B3-Traceid: a920c371e1971625b46937001cdd776d
X-Envoy-Attempt-Count: 1
X-Envoy-External-Address: 50_REDACTED_193
X-Forwarded-Client-Cert: Hash=0f9d2ced3d19f19d623e401475dc6cbd8aad39e2c78970dafb16d9bb807b4535;Cert="-----BEGIN%20CERTIFICATE-----%0AMIIC3DCCAcQCAQEwDQYJKoZIhvcNAQEFBQAwLzEVMBMGA1UECgwMVGVzdENBQ0xJ%0AMV9vMRYwFAYDVQQDDA1UZXN0Q0FDTEkxX2NuMB4XDTIxMDcwNzIxMjYzNVoXDTIx%0AMDgwNjIxMjYzNVowOTEZMBcGA1UEAwwQVEVTVF9DTElDTEkxXzAwMTEcMBoGA1UE%0ACgwTQ2xpZW50IHRlc3Qgb3JnQ0xJMTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCC%0AAQoCggEBAK2A6C4y7ElzIxXgd01B%2Fr5egMHzfzhHvUuNGyxbQA6%2BloAucANYrZN9%0ApMmR8CsXUuv8O%2FjoONZaI4uYolnMfLtZhVRCAXRbCO3vqj3LhJ7DrMGHjx1kh4TI%0AkkPimdjFayevoKE3zK0%2FKR98wyVNH3ixyP9cjgd2jqAoTVaykHD0ulOYqENxY6ZH%0AjQSrKjI%2F91bnYM76DssGLkPdeMsR2bo2b8VHhP3qKvHUzotExX2mfUty7AlDZrms%0ACkHTGqv6OGuyZLky4YLKbRIgueIq0emXv75QXYj8X1o7MUcZ7rsJnZnRphDfAIqa%0AjdqrvRCsJBZM0xJtqNO2kCiH9U6tDj8CAwEAATANBgkqhkiG9w0BAQUFAAOCAQEA%0AK9ksMGbczP4a%2F8hoUg%2BWcKsZKtzGVvad8K2e9tWG76b7kMkGo%2FKdafIYMAdFcAl3%0AuEzwL9xyu41cKORALDun80FiIRVPgFNbfOuurJrX7imBeTHAlaVsUtDGFYT4cuR1%0ArLCUO%2B3CZrVZuOpdmjEIBcBL6iPjanOxzdavTkpJjfsLt6Xz1vD72F%2BAHGUzbVhm%0A0wcppUBIwnCoT9QyLAQJWcGZ1Bf%2BGoK9lTnYXae7RKK6G1HHBIm9eb55%2Fd2CIiQ2%0AI57fXitkrnZX%2B7ytgLhhJE9IR66sHkQmTil3vf%2F0gjSbpVC52Ev23qooAFITYqmO%0Ax3IfZsZIxVmMtRah5uzkMQ%3D%3D%0A-----END%20CERTIFICATE-----%0A";Subject="O=Client test orgCLI1,CN=TEST_CLICLI1_001";URI=,By=spiffe://cluster.local/ns/fortio/sa/default;Hash=8ac68f7d0775d6018b4ff041f0a8a21c9f6037c807c4b0b0ed2a551accef3a84;Subject="";URI=spiffe://cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account
X-Forwarded-For: 50_REDACTED_193
X-Forwarded-Proto: https
X-Request-Id: b76f19b3-7d38-496d-9193-ebaaf4f80a9f

body:


* Connection #0 to host testca1.istio.io left intact
* Closing connection 0
+ check2fail
+ set +e
+ singleCall 2
+ SUFFIX=2
+ curl -v --resolve testca1.istio.io:443:54._REDACTED_212 --cert cliCLI2.crt --key cliCLI2.key --cacert caSRV.crt https://testca1.istio.io/fortio/debug/
* Added testca1.istio.io:443:54._REDACTED_212 to DNS cache
* Hostname testca1.istio.io was found in DNS cache
*   Trying 54._REDACTED_212...
* TCP_NODELAY set
* Connected to testca1.istio.io (54._REDACTED_212) port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*   CAfile: caSRV.crt
  CApath: none
* TLSv1.2 (OUT), TLS handshake, Client hello (1):
* TLSv1.2 (IN), TLS handshake, Server hello (2):
* TLSv1.2 (IN), TLS handshake, Certificate (11):
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
* TLSv1.2 (IN), TLS handshake, Request CERT (13):
* TLSv1.2 (IN), TLS handshake, Server finished (14):
* TLSv1.2 (OUT), TLS handshake, Certificate (11):
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
* TLSv1.2 (OUT), TLS handshake, CERT verify (15):
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
* TLSv1.2 (OUT), TLS handshake, Finished (20):
* TLSv1.2 (IN), TLS alert, unknown CA (560):
* error:1401E418:SSL routines:CONNECT_CR_FINISHED:tlsv1 alert unknown ca
* Closing connection 0
curl: (35) error:1401E418:SSL routines:CONNECT_CR_FINISHED:tlsv1 alert unknown ca
+ echo 'cli2 failed as expected'
cli2 failed as expected
+ set -e
+ kill -int 88635
+ wait
14:27:30 I periodic.go:558> T001 ended after 23.545193849s : 118 calls. qps=5.011638500696041
14:27:30 I periodic.go:558> T000 ended after 23.545183859s : 118 calls. qps=5.0116406270871074
Ended after 23.546163872s : 236 calls. qps=10.023
Sleep times : count 236 avg 0.16174523 +/- 0.0138 min 0.125584232 max 0.19537878 sum 38.1718738
Aggregated Function Time : count 236 avg 0.036335165 +/- 0.003765 min 0.030287153 max 0.059190137 sum 8.57509904
# range, mid point, percentile, count
>= 0.0302872 <= 0.035 , 0.0326436 , 44.49, 105
> 0.035 <= 0.04 , 0.0375 , 85.59, 97
> 0.04 <= 0.045 , 0.0425 , 97.88, 29
> 0.045 <= 0.05 , 0.0475 , 99.15, 3
> 0.05 <= 0.0591901 , 0.0545951 , 100.00, 2
# target 50% 0.0356701
# target 75% 0.0387113
# target 90% 0.0417931
# target 99% 0.0494
# target 99.9% 0.0581057
Sockets used: 0 (for perfect keepalive, would be 2)
Jitter: true
Code 200 : 236 (100.0 %)
Response Header Sizes : count 236 avg 0 +/- 0 min 0 max 0 sum 0
Response Body/Total Sizes : count 236 avg 2110.839 +/- 0.3675 min 2110 max 2111 sum 498158
All done 236 calls (plus 2 warmup) 36.335 ms avg, 10.0 qps
Successfully wrote 2252 bytes of Json data to fortio_ca_test.json
++ jq .DurationHistogram.Count
+ TOTAL_REQUESTS=236
++ jq '.RetCodes."200"'
+ OK_REQUESTS=236
+ [[ 236 != \2\3\6 ]]
+ echo '*** All tested passed'
*** All tested passed
```