### PR TITLE
include missing gomplate def

### DIFF
--- a/manifests/charts/base/templates/validatingwebhookconfiguration.yaml
+++ b/manifests/charts/base/templates/validatingwebhookconfiguration.yaml
@@ -14,7 +14,7 @@ webhooks:
       url: {{ .Values.base.validationURL }}
       {{- else }}
       service:
-        name: istiod
+        name: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
         namespace: {{ .Values.global.istioNamespace }}
         path: "/validate"
       {{- end }}


### PR DESCRIPTION

[ ] Configuration Infrastructure
[ ] Docs
[x] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.

## Describe the problem

We currently use the `revision` feature of `istioctl` and noticed that we were unable to apply any Istio resources due to the validating web-hook pointing to a non-existent istiod service. We never deploy an istio release _without_ the revision flag, not sure if this is bad practice?

Anyway, to get around this we have the following hack:

```shell
$i manifest generate \
    -f profile.yaml \
    --revision "1-10-2" \
    | sed "s/name:\ istiod$/name: istiod-1-10-2/g" > template.yaml
```