### PR TITLE
Avoid panic on concurrent map writes in test

### DIFF
--- a/pkg/test/framework/components/echo/common/call.go
+++ b/pkg/test/framework/components/echo/common/call.go
@@ -233,6 +233,9 @@ func fillInCallOptions(opts *echo.CallOptions) error {
 	// Initialize the headers and add a default Host header if none provided.
 	if opts.Headers == nil {
 		opts.Headers = make(http.Header)
+	} else {
+		// Avoid mutating input, which can lead to concurrent writes
+		opts.Headers = opts.Headers.Clone()
 	}
 	if h := opts.Headers["Host"]; len(h) == 0 && opts.Target != nil {
 		// No host specified, use the hostname for the service.


### PR DESCRIPTION
Example failure:
https://prow.istio.io/view/gs/istio-prow/pr-logs/pull/istio_istio/33891/integ-telemetry-mc-k8s-tests_istio/1412883536393801728

The problem is we are mutating the same map in many goroutines. Instead,
make a copy.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.