### PR TITLE
Fuzzing: Add parse k8s object fuzzer

### DIFF
--- a/tests/fuzz/cmd_mesh_fuzzer.go
+++ b/tests/fuzz/cmd_mesh_fuzzer.go
@@ -1,0 +1,30 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// nolint: golint
+package fuzz
+
+import (
+	"istio.io/istio/operator/cmd/mesh"
+	"istio.io/istio/operator/pkg/object"
+)
+
+func FuzzK8sObject(data []byte) int {
+	objSlice, err := object.ParseK8sObjectsFromYAMLManifest(string(data))
+	if err != nil {
+		return 0
+	}
+	_ = mesh.NewObjectSet(objSlice)
+	return 1
+}

--- a/tests/fuzz/oss_fuzz_build.sh
+++ b/tests/fuzz/oss_fuzz_build.sh
@@ -29,6 +29,7 @@ compile_go_fuzzer istio.io/istio/tests/fuzz FuzzIntoResourceFile fuzz_into_resou
 compile_go_fuzzer istio.io/istio/tests/fuzz FuzzTranslateFromValueToSpec fuzz_translate_from_value_to_spec
 compile_go_fuzzer istio.io/istio/tests/fuzz FuzzBNMUnmarshalJSON fuzz_bnm_unmarshal_json
 compile_go_fuzzer istio.io/istio/tests/fuzz FuzzValidateClusters fuzz_validate_clusters
+compile_go_fuzzer istio.io/istio/tests/fuzz FuzzK8sObject fuzz_k8s_object
 
 # Create seed corpora:
 zip "${OUT}"/fuzz_analyzer_seed_corpus.zip "${SRC}"/istio/galley/pkg/config/analysis/analyzers/testdata/*.yaml

--- a/tests/fuzz/regression_test.go
+++ b/tests/fuzz/regression_test.go
@@ -130,6 +130,7 @@ func TestFuzzers(t *testing.T) {
 		{"FuzzConfigValidation2", FuzzConfigValidation2},
 		{"FuzzBNMUnmarshalJSON", FuzzBNMUnmarshalJSON},
 		{"FuzzValidateClusters", FuzzValidateClusters},
+		{"FuzzK8sObject", FuzzK8sObject},
 	}
 	for _, tt := range cases {
 		if testedFuzzers.Contains(tt.name) {


### PR DESCRIPTION
Adds a fuzzer for `object.ParseK8sObjectsFromYAMLManifest`


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[x] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.