### PR TITLE
envoy: set so_reuseport

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/listener_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_builder.go
@@ -384,6 +384,7 @@ func (lb *ListenerBuilder) buildVirtualOutboundListener(configgen *ConfigGenerat
 		UseOriginalDst:   proto.BoolTrue,
 		FilterChains:     filterChains,
 		TrafficDirection: core.TrafficDirection_OUTBOUND,
+		ReusePort:        true,
 	}
 	accessLogBuilder.setListenerAccessLog(lb.push, lb.node, ipTablesListener)
 	lb.virtualOutboundListener = ipTablesListener
@@ -408,6 +409,7 @@ func (lb *ListenerBuilder) buildVirtualInboundListener(configgen *ConfigGenerato
 		UseOriginalDst:   proto.BoolTrue,
 		TrafficDirection: core.TrafficDirection_INBOUND,
 		FilterChains:     filterChains,
+		ReusePort:        true,
 	}
 	accessLogBuilder.setListenerAccessLog(lb.push, lb.node, lb.virtualInboundListener)
 	lb.aggregateVirtualInboundListener(passthroughInspector)


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

In preparation for new defaults, set SO_REUSEPORT on virtual listener sockets. This enables kernel load balancing for TCP accepts instead of in-process implementation. The high risk area is hot-restart which is not used in istio.

Ref: https://github.com/envoyproxy/envoy/pull/17259