### PR TITLE
Fuzzing: Add helm reconciler fuzzer

### DIFF
--- a/tests/fuzz/helm_reconciler_fuzzer.go
+++ b/tests/fuzz/helm_reconciler_fuzzer.go
@@ -1,0 +1,50 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// nolint: golint
+package fuzz
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"istio.io/istio/operator/pkg/helmreconciler"
+	"istio.io/istio/operator/pkg/object"
+)
+
+type fakeClientWrapper struct {
+	client.Client
+}
+
+func FuzzHelmReconciler(data []byte) int {
+	k8obj, err := object.ParseYAMLToK8sObject(data)
+	if err != nil {
+		return 0
+	}
+	obj := k8obj.UnstructuredObject()
+	gvk := obj.GetObjectKind().GroupVersionKind()
+	if len(gvk.Kind) == 0 {
+		return 0
+	}
+	if len(gvk.Version) == 0 {
+		return 0
+	}
+	cl := &fakeClientWrapper{fake.NewClientBuilder().WithRuntimeObjects(obj).Build()}
+	h, err := helmreconciler.NewHelmReconciler(cl, nil, nil, nil)
+	if err != nil {
+		return 0
+	}
+	_ = h.ApplyObject(obj, false)
+	return 1
+}

--- a/tests/fuzz/oss_fuzz_build.sh
+++ b/tests/fuzz/oss_fuzz_build.sh
@@ -24,10 +24,12 @@ compile_go_fuzzer istio.io/istio/tests/fuzz FuzzInitContext fuzz_init_context
 compile_go_fuzzer istio.io/istio/tests/fuzz FuzzAnalyzer fuzz_analyzer
 compile_go_fuzzer istio.io/istio/tests/fuzz FuzzXds fuzz_xds
 compile_go_fuzzer istio.io/istio/tests/fuzz FuzzCompareDiff fuzz_compare_diff
+compile_go_fuzzer istio.io/istio/tests/fuzz FuzzHelmReconciler fuzz_helm_reconciler
 
 # Create seed corpora:
 zip "${OUT}"/fuzz_analyzer_seed_corpus.zip "${SRC}"/istio/galley/pkg/config/analysis/analyzers/testdata/*.yaml
 zip "${OUT}"/fuzz_config_validation2_seed_corpus.zip "${SRC}"/istio/tests/fuzz/testdata/FuzzConfigValidation2/seed1
+zip "${OUT}"/fuzz_helm_reconciler_seed_corpus.zip "${SRC}"/istio/operator/pkg/helmreconciler/testdata/*
 
 # Add dictionaries
 cp "${SRC}"/istio/tests/fuzz/testdata/FuzzConfigValidation2/fuzz_config_validation2.dict "${OUT}"/

--- a/tests/fuzz/regression_test.go
+++ b/tests/fuzz/regression_test.go
@@ -87,6 +87,7 @@ func TestFuzzers(t *testing.T) {
 		{"FuzzValidateMeshConfig", FuzzValidateMeshConfig},
 		{"FuzzInitContext", FuzzInitContext},
 		{"FuzzCompareDiff", FuzzCompareDiff},
+		{"FuzzHelmReconciler", FuzzHelmReconciler},
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Adds a fuzzer that creates a fuzzed k8sobject, passes its unstructured object to a fake client, creates a helm reconciler, and then calls `ApplyObject` with the same unstructured object.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[x] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.