### PR TITLE
Fuzzing: add operator/pkg/translate fuzzer

### DIFF
--- a/tests/fuzz/operator_translate_fuzzer.go
+++ b/tests/fuzz/operator_translate_fuzzer.go
@@ -1,0 +1,26 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// nolint: golint
+package fuzz
+
+import (
+	"istio.io/istio/operator/pkg/translate"
+)
+
+func FuzzTranslateFromValueToSpec(data []byte) int {
+	tr := translate.NewReverseTranslator()
+	_, _ = tr.TranslateFromValueToSpec(data, false)
+	return 1
+}

--- a/tests/fuzz/oss_fuzz_build.sh
+++ b/tests/fuzz/oss_fuzz_build.sh
@@ -26,6 +26,7 @@ compile_go_fuzzer istio.io/istio/tests/fuzz FuzzXds fuzz_xds
 compile_go_fuzzer istio.io/istio/tests/fuzz FuzzCompareDiff fuzz_compare_diff
 compile_go_fuzzer istio.io/istio/tests/fuzz FuzzHelmReconciler fuzz_helm_reconciler
 compile_go_fuzzer istio.io/istio/tests/fuzz FuzzIntoResourceFile fuzz_into_resource_file
+compile_go_fuzzer istio.io/istio/tests/fuzz FuzzTranslateFromValueToSpec fuzz_translate_from_value_to_spec
 
 # Create seed corpora:
 zip "${OUT}"/fuzz_analyzer_seed_corpus.zip "${SRC}"/istio/galley/pkg/config/analysis/analyzers/testdata/*.yaml

--- a/tests/fuzz/regression_test.go
+++ b/tests/fuzz/regression_test.go
@@ -89,6 +89,7 @@ func TestFuzzers(t *testing.T) {
 		{"FuzzCompareDiff", FuzzCompareDiff},
 		{"FuzzHelmReconciler", FuzzHelmReconciler},
 		{"FuzzIntoResourceFile", FuzzIntoResourceFile},
+		{"FuzzTranslateFromValueToSpec", FuzzTranslateFromValueToSpec},
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Adds a fuzzer that targets `operator/pkg/translate.TranslateFromValueToSpec`.

__________________________________



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[x] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.