### PR TITLE
Fuzzing: Add BootstrapNodeMetadata unmarshaling fuzzer

### DIFF
--- a/tests/fuzz/oss_fuzz_build.sh
+++ b/tests/fuzz/oss_fuzz_build.sh
@@ -27,6 +27,7 @@ compile_go_fuzzer istio.io/istio/tests/fuzz FuzzCompareDiff fuzz_compare_diff
 compile_go_fuzzer istio.io/istio/tests/fuzz FuzzHelmReconciler fuzz_helm_reconciler
 compile_go_fuzzer istio.io/istio/tests/fuzz FuzzIntoResourceFile fuzz_into_resource_file
 compile_go_fuzzer istio.io/istio/tests/fuzz FuzzTranslateFromValueToSpec fuzz_translate_from_value_to_spec
+compile_go_fuzzer istio.io/istio/tests/fuzz FuzzBNMUnmarshalJSON fuzz_bnm_unmarshal_json
 
 # Create seed corpora:
 zip "${OUT}"/fuzz_analyzer_seed_corpus.zip "${SRC}"/istio/galley/pkg/config/analysis/analyzers/testdata/*.yaml

--- a/tests/fuzz/pilot_model_fuzzer.go
+++ b/tests/fuzz/pilot_model_fuzzer.go
@@ -205,3 +205,9 @@ func FuzzInitContext(data []byte) int {
 	_ = pc.InitContext(env, nil, nil)
 	return 1
 }
+
+func FuzzBNMUnmarshalJSON(data []byte) int {
+	var bnm model.BootstrapNodeMetadata
+	_ = bnm.UnmarshalJSON(data)
+	return 1
+}

--- a/tests/fuzz/regression_test.go
+++ b/tests/fuzz/regression_test.go
@@ -126,6 +126,7 @@ func TestFuzzers(t *testing.T) {
 		{"FuzzIntoResourceFile", FuzzIntoResourceFile},
 		{"FuzzTranslateFromValueToSpec", FuzzTranslateFromValueToSpec},
 		{"FuzzConfigValidation2", FuzzConfigValidation2},
+		{"FuzzBNMUnmarshalJSON", FuzzBNMUnmarshalJSON},
 	}
 	for _, tt := range cases {
 		if testedFuzzers.Contains(tt.name) {


### PR DESCRIPTION
Adds a fuzzer for the BootstrapNodeMetadata unmarshaling api.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[x] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.