### PR TITLE
Basic support for Kubernetes MCS host

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -234,6 +234,11 @@ var (
 			"in a cluster will only discoverable within the same cluster unless explicitly exported "+
 			"(via the ServiceExport CR).").Get()
 
+	EnableMCSHost = env.RegisterBoolVar("ENABLE_MCS_HOST", false,
+		"If enabled, istiod will provide an alias <svc>.<namespace>.svc.clusterset.local for "+
+			"each Kubernetes service. Clients must, however, be able to successfully lookup these DNS hosts. "+
+			"That means that either Istio DNS interception must be enabled or an MCS controller must be used.").Get()
+
 	EnableAnalysis = env.RegisterBoolVar(
 		"PILOT_ENABLE_ANALYSIS",
 		false,

--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -419,33 +419,41 @@ func generateAltVirtualHosts(hostname string, port int, proxyDomain string) []st
 		return nil
 	}
 
+	// For Kubernetes services, If Kubernetes MCS host is enabled, also add a virtual host for 'clusterset.local'
+	if features.EnableMCSHost {
+		svcIndex := strings.LastIndex(hostname, ".svc.")
+		if svcIndex > 0 {
+			// It's a Kubernetes service. Add the virtual host for MCS.
+			mcsHost := hostname[:svcIndex+len(".svc.")] + mcsServiceDomain
+			vhosts = append(vhosts, mcsHost, domainName(mcsHost, port))
+		}
+	}
+
 	sharedDNSDomainParts := strings.Split(sharedDNSDomain, ".")
 	if len(strings.Split(uniqHostname, ".")) == 2 {
 		// This is the case of uniqHostname having namespace already.
 		dnsHostName := uniqHostname + "." + sharedDNSDomainParts[0]
 		vhosts = append(vhosts, uniqHostname, domainName(uniqHostname, port), dnsHostName, domainName(dnsHostName, port))
-	} else {
-		if strings.Contains(proxyDomain, ".svc.") {
-			// Derive the namespace from sharedDNSDomain and add virtual host.
-			namespace := sharedDNSDomainParts[0]
-			if strings.HasPrefix(proxyDomain, namespace+".svc.") {
-				// Split the domain and add only for Kubernetes proxies.
-				vhosts = append(vhosts, uniqHostname, domainName(uniqHostname, port))
-				if len(sharedDNSDomainParts) > 1 {
-					dnsHostName := uniqHostname + "." + namespace + "." + sharedDNSDomainParts[1]
-					vhosts = append(vhosts, dnsHostName, domainName(dnsHostName, port))
-				}
-				hostNameWithNS := uniqHostname + "." + namespace
-
-				// Don't add if they are same because we add it later and adding it here will result in duplicates.
-				if hostname != hostNameWithNS {
-					vhosts = append(vhosts, hostNameWithNS, domainName(hostNameWithNS, port))
-				}
-			}
-		} else {
-			// Add the uniqueHost if it is not a Kubernetes domain.
+	} else if strings.Contains(proxyDomain, ".svc.") {
+		// Derive the namespace from sharedDNSDomain and add virtual host.
+		namespace := sharedDNSDomainParts[0]
+		if strings.HasPrefix(proxyDomain, namespace+".svc.") {
+			// Split the domain and add only for Kubernetes proxies.
 			vhosts = append(vhosts, uniqHostname, domainName(uniqHostname, port))
+			if len(sharedDNSDomainParts) > 1 {
+				dnsHostName := uniqHostname + "." + namespace + "." + sharedDNSDomainParts[1]
+				vhosts = append(vhosts, dnsHostName, domainName(dnsHostName, port))
+			}
+			hostNameWithNS := uniqHostname + "." + namespace
+
+			// Don't add if they are same because we add it later and adding it here will result in duplicates.
+			if hostname != hostNameWithNS {
+				vhosts = append(vhosts, hostNameWithNS, domainName(hostNameWithNS, port))
+			}
 		}
+	} else {
+		// Add the uniqueHost if it is not a Kubernetes domain.
+		vhosts = append(vhosts, uniqHostname, domainName(uniqHostname, port))
 	}
 	return vhosts
 }

--- a/pilot/pkg/networking/core/v1alpha3/name_table.go
+++ b/pilot/pkg/networking/core/v1alpha3/name_table.go
@@ -21,9 +21,20 @@ import (
 	dnsServer "istio.io/istio/pkg/dns/server"
 )
 
+const mcsServiceDomain = "clusterset.local"
+
 // BuildNameTable produces a table of hostnames and their associated IPs that can then
 // be used by the agent to resolve DNS. This logic is always active. However, local DNS resolution
 // will only be effective if DNS capture is enabled in the proxy
 func (configgen *ConfigGeneratorImpl) BuildNameTable(node *model.Proxy, push *model.PushContext) *dnsProto.NameTable {
-	return dnsServer.BuildNameTable(node, push, features.MulticlusterHeadlessEnabled)
+	var altServiceDomains []string
+	if features.EnableMCSHost {
+		altServiceDomains = append(altServiceDomains, mcsServiceDomain)
+	}
+	return dnsServer.BuildNameTable(dnsServer.Config{
+		Node:                        node,
+		Push:                        push,
+		MulticlusterHeadlessEnabled: features.MulticlusterHeadlessEnabled,
+		AltServiceDomainSuffixes:    altServiceDomains,
+	})
 }

--- a/releasenotes/notes/mcs-host.yaml
+++ b/releasenotes/notes/mcs-host.yaml
@@ -1,0 +1,13 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+issue:
+  - 33949
+releaseNotes:
+  - |
+    **Added** experimental support for the Kubernetes Multi-Cluster Services (MCS) host (`clusterset.local`).
+    This feature is off by default, but can be enabled by setting the following flags in Istio:
+    `ENABLE_MCS_HOST` and `ENABLE_MCS_SERVICE_DISCOVERY`. When enabled Istio will include the MCS host as a
+    domain in the service's HTTP route. Additionally, Istio will support the MCS host during a DNS lookup.
+    For now, the MCS host is just an alias for `cluster.local` and resolves to the same service IP.
+    Future work will give the MCS host a separate IP as is defined by the MCS spec.

--- a/tests/integration/pilot/mcs/discoverability/discoverability_test.go
+++ b/tests/integration/pilot/mcs/discoverability/discoverability_test.go
@@ -140,7 +140,8 @@ func enableMCSServiceDiscovery(_ resource.Context, cfg *istio.Config) {
 values:
   pilot:
     env:
-      ENABLE_MCS_SERVICE_DISCOVERY: "true"`
+      ENABLE_MCS_SERVICE_DISCOVERY: "true"
+      ENABLE_MCS_HOST: "true"`
 }
 
 func deployEchos(t resource.Context) error {
@@ -196,7 +197,14 @@ func newServiceExport(service string) *v1alpha1.ServiceExport {
 
 func checkClustersReached(t framework.TestContext, src, dest echo.Instance, clusters cluster.Clusters) {
 	t.Helper()
+
+	// Call the service using the MCS clusterset host.
+	address := fmt.Sprintf("%s.%s.svc.clusterset.local",
+		dest.Config().Service,
+		dest.Config().Namespace.Name())
+
 	src.CallWithRetryOrFail(t, echo.CallOptions{
+		Address:   address,
 		Target:    dest,
 		Count:     50,
 		PortName:  "http",


### PR DESCRIPTION
This is the first phase of work for #33949.

This PR adds `clusterset.local` as an alias for `cluster.local` and resolves to the same IP. Since we're using the same IP, this change only impacts HTTP listeners and their routes.

The MCS host is also supported for DNS lookup.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.