### PR TITLE
Add analyzer to detect "image: auto" on non-injected pods and deployments

### DIFF
--- a/galley/pkg/config/analysis/analyzers/all.go
+++ b/galley/pkg/config/analysis/analyzers/all.go
@@ -47,6 +47,7 @@ func All() []analysis.Analyzer {
 		&gateway.ConflictingGatewayAnalyzer{},
 		&injection.Analyzer{},
 		&injection.ImageAnalyzer{},
+		&injection.ImageAutoAnalyzer{},
 		&multicluster.MeshNetworksAnalyzer{},
 		&service.PortNameAnalyzer{},
 		&sidecar.DefaultSelectorAnalyzer{},

--- a/galley/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_test.go
@@ -546,7 +546,7 @@ var testGrid = []testCase{
 		},
 		analyzer: &injection.ImageAutoAnalyzer{},
 		expected: []message{
-			{msg.ImageAutoWithoutInjection, "Deployment non-injected-gateway-deployment"},
+			{msg.ImageAutoWithoutInjectionWarning, "Deployment non-injected-gateway-deployment"},
 		},
 	},
 }

--- a/galley/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_test.go
@@ -547,6 +547,7 @@ var testGrid = []testCase{
 		analyzer: &injection.ImageAutoAnalyzer{},
 		expected: []message{
 			{msg.ImageAutoWithoutInjectionWarning, "Deployment non-injected-gateway-deployment"},
+			{msg.ImageAutoWithoutInjectionError, "Pod injected-pod.default"},
 		},
 	},
 }

--- a/galley/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_test.go
@@ -539,6 +539,16 @@ var testGrid = []testCase{
 			{msg.InvalidApplicationUID, "Deployment deploy-con-sec-uid"},
 		},
 	},
+	{
+		name: "Detect `image: auto` in non-injected pods",
+		inputFiles: []string{
+			"testdata/image-auto.yaml",
+		},
+		analyzer: &injection.ImageAutoAnalyzer{},
+		expected: []message{
+			{msg.ImageAutoWithoutInjection, "Deployment non-injected-gateway-deployment"},
+		},
+	},
 }
 
 // regex patterns for analyzer names that should be explicitly ignored for testing

--- a/galley/pkg/config/analysis/analyzers/injection/image-auto.go
+++ b/galley/pkg/config/analysis/analyzers/injection/image-auto.go
@@ -1,0 +1,130 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package injection
+
+import (
+	"strings"
+
+	admit_v1 "k8s.io/api/admissionregistration/v1"
+	apps_v1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	klabels "k8s.io/apimachinery/pkg/labels"
+
+	"istio.io/istio/galley/pkg/config/analysis"
+	"istio.io/istio/galley/pkg/config/analysis/msg"
+	"istio.io/istio/pkg/config/resource"
+	"istio.io/istio/pkg/config/schema/collection"
+	"istio.io/istio/pkg/config/schema/collections"
+)
+
+// ImageAutoAnalyzer reports an error if Pods and Deployments with `image: auto` are not going to be injected.
+type ImageAutoAnalyzer struct{}
+
+var _ analysis.Analyzer = &ImageAutoAnalyzer{}
+
+const manualInjectionImage = "auto"
+
+// Metadata implements Analyzer.
+func (a *ImageAutoAnalyzer) Metadata() analysis.Metadata {
+	return analysis.Metadata{
+		Name:        "injection.ImageAutoAnalyzer",
+		Description: "Makes sure that Pods and Deployments with `image: auto` are going to be injected",
+		Inputs: collection.Names{
+			collections.K8SCoreV1Namespaces.Name(),
+			collections.K8SCoreV1Pods.Name(),
+			collections.K8SAdmissionregistrationK8SIoV1Mutatingwebhookconfigurations.Name(),
+		},
+	}
+}
+
+// Analyze implements Analyzer.
+func (a *ImageAutoAnalyzer) Analyze(c analysis.Context) {
+	var istioWebhooks []admit_v1.MutatingWebhook
+	c.ForEach(collections.K8SAdmissionregistrationK8SIoV1Mutatingwebhookconfigurations.Name(), func(resource *resource.Instance) bool {
+		mwhc := resource.Message.(*admit_v1.MutatingWebhookConfiguration)
+		for _, wh := range mwhc.Webhooks {
+			if strings.HasSuffix(wh.Name, "istio.io") {
+				istioWebhooks = append(istioWebhooks, wh)
+			}
+		}
+		return true
+	})
+	c.ForEach(collections.K8SCoreV1Pods.Name(), func(resource *resource.Instance) bool {
+		p := resource.Message.(*v1.Pod)
+		if !hasAutoImage(&p.Spec) {
+			return true
+		}
+		nsLabels := getNamespaceLabels(c, p.Namespace)
+		if !matchesWebhooks(nsLabels, p.Labels, istioWebhooks) {
+			m := msg.NewImageAutoWithoutInjection(resource, "Pod", p.Name)
+			c.Report(collections.K8SCoreV1Pods.Name(), m)
+		}
+		return true
+	})
+	c.ForEach(collections.K8SAppsV1Deployments.Name(), func(resource *resource.Instance) bool {
+		d := resource.Message.(*apps_v1.Deployment)
+		if !hasAutoImage(&d.Spec.Template.Spec) {
+			return true
+		}
+		nsLabels := getNamespaceLabels(c, d.Spec.Template.Namespace)
+		if !matchesWebhooks(nsLabels, d.Spec.Template.Labels, istioWebhooks) {
+			m := msg.NewImageAutoWithoutInjection(resource, "Deployment", d.Name)
+			c.Report(collections.K8SAppsV1Deployments.Name(), m)
+		}
+		return true
+	})
+}
+
+func hasAutoImage(spec *v1.PodSpec) bool {
+	for _, c := range spec.Containers {
+		if c.Image == manualInjectionImage {
+			return true
+		}
+	}
+	return false
+}
+
+func getNamespaceLabels(c analysis.Context, nsName string) map[string]string {
+	if nsName == "" {
+		nsName = "default"
+	}
+	ns := c.Find(collections.K8SCoreV1Namespaces.Name(), resource.NewFullName("", resource.LocalName(nsName)))
+	if ns == nil {
+		return nil
+	}
+	return ns.Metadata.Labels
+}
+
+func matchesWebhooks(nsLabels, podLabels map[string]string, istioWebhooks []admit_v1.MutatingWebhook) bool {
+	for _, w := range istioWebhooks {
+		if selectorMatches(w.NamespaceSelector, nsLabels) && selectorMatches(w.ObjectSelector, podLabels) {
+			return true
+		}
+	}
+	return false
+}
+
+func selectorMatches(selector *metav1.LabelSelector, labels klabels.Set) bool {
+	// From webhook spec: "Default to the empty LabelSelector, which matchesWebhooks everything."
+	if selector == nil {
+		return true
+	}
+	s, err := metav1.LabelSelectorAsSelector(selector)
+	if err != nil {
+		return false
+	}
+	return s.Matches(labels)
+}

--- a/galley/pkg/config/analysis/analyzers/injection/image-auto.go
+++ b/galley/pkg/config/analysis/analyzers/injection/image-auto.go
@@ -45,6 +45,7 @@ func (a *ImageAutoAnalyzer) Metadata() analysis.Metadata {
 		Inputs: collection.Names{
 			collections.K8SCoreV1Namespaces.Name(),
 			collections.K8SCoreV1Pods.Name(),
+			collections.K8SAppsV1Deployments.Name(),
 			collections.K8SAdmissionregistrationK8SIoV1Mutatingwebhookconfigurations.Name(),
 		},
 	}

--- a/galley/pkg/config/analysis/analyzers/injection/image-auto.go
+++ b/galley/pkg/config/analysis/analyzers/injection/image-auto.go
@@ -70,7 +70,7 @@ func (a *ImageAutoAnalyzer) Analyze(c analysis.Context) {
 		}
 		nsLabels := getNamespaceLabels(c, p.Namespace)
 		if !matchesWebhooks(nsLabels, p.Labels, istioWebhooks) {
-			m := msg.NewImageAutoWithoutInjection(resource, "Pod", p.Name)
+			m := msg.NewImageAutoWithoutInjectionError(resource, "Pod", p.Name)
 			c.Report(collections.K8SCoreV1Pods.Name(), m)
 		}
 		return true
@@ -82,7 +82,7 @@ func (a *ImageAutoAnalyzer) Analyze(c analysis.Context) {
 		}
 		nsLabels := getNamespaceLabels(c, d.Spec.Template.Namespace)
 		if !matchesWebhooks(nsLabels, d.Spec.Template.Labels, istioWebhooks) {
-			m := msg.NewImageAutoWithoutInjection(resource, "Deployment", d.Name)
+			m := msg.NewImageAutoWithoutInjectionWarning(resource, "Deployment", d.Name)
 			c.Report(collections.K8SAppsV1Deployments.Name(), m)
 		}
 		return true

--- a/galley/pkg/config/analysis/analyzers/testdata/image-auto.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/image-auto.yaml
@@ -38,7 +38,7 @@ webhooks:
       matchLabels:
         sidecar.istio.io/inject: "true"
 ---
-# Injected because of namespace, should not produce error!
+# Should produce error!
 apiVersion: v1
 kind: Pod
 metadata:
@@ -46,8 +46,8 @@ metadata:
   namespace: default
 spec:
   containers:
-    - image: istio-proxy
-      name: auto
+    - image: auto
+      name: istio-proxy
 ---
 # Not injected, should produce error!
 apiVersion: apps/v1
@@ -70,7 +70,7 @@ spec:
         - name: istio-proxy
           image: auto
 ---
-# Injected because of object selector, should not produce error!
+# No image auto, should not produce error!
 apiVersion: v1
 kind: Pod
 metadata:
@@ -82,5 +82,5 @@ metadata:
     sidecar.istio.io/inject: "true"
 spec:
   containers:
-    - image: auto
-      name: istio-proxy
+    - image: ubuntu
+      name: ubuntu

--- a/galley/pkg/config/analysis/analyzers/testdata/image-auto.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/image-auto.yaml
@@ -1,0 +1,86 @@
+# Injected namespace.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: injected
+  labels:
+    istio-injection: enabled
+---
+# Non-injected namespace.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: non-injected
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: istio-sidecar-injector
+webhooks:
+  - admissionReviewVersions:
+      - v1beta1
+    clientConfig:
+      service:
+        name: fake
+        namespace: istio-system
+    name: namespace.sidecar-injector.istio.io
+    namespaceSelector:
+      matchLabels:
+        istio-injection: enabled
+  - admissionReviewVersions:
+      - v1beta1
+    clientConfig:
+      service:
+        name: fake
+        namespace: istio-system
+    name: object.sidecar-injector.istio.io
+    objectSelector:
+      matchLabels:
+        sidecar.istio.io/inject: "true"
+---
+# Injected because of namespace, should not produce error!
+apiVersion: v1
+kind: Pod
+metadata:
+  name: injected-pod
+  namespace: default
+spec:
+  containers:
+    - image: istio-proxy
+      name: auto
+---
+# Not injected, should produce error!
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: non-injected-gateway-deployment
+spec:
+  selector:
+    matchLabels:
+      istio: ingressgateway
+  template:
+    metadata:
+      annotations:
+        inject.istio.io/templates: gateway
+      labels:
+        istio: ingressgateway
+        istio.io/rev: non-existent-rev
+    spec:
+      containers:
+        - name: istio-proxy
+          image: auto
+---
+# Injected because of object selector, should not produce error!
+apiVersion: v1
+kind: Pod
+metadata:
+  name: istiod-canary-1234567890-12345
+  namespace: istio-system
+  labels:
+    app: istiod
+    istio: pilot
+    sidecar.istio.io/inject: "true"
+spec:
+  containers:
+    - image: auto
+      name: istio-proxy

--- a/galley/pkg/config/analysis/msg/messages.gen.go
+++ b/galley/pkg/config/analysis/msg/messages.gen.go
@@ -176,6 +176,10 @@ var (
 	// ConflictingGateways defines a diag.MessageType for message "ConflictingGateways".
 	// Description: Gateway should not have the same selector, port and matched hosts of server
 	ConflictingGateways = diag.NewMessageType(diag.Error, "IST0145", "Conflict with gateways %s (workload selector %s, port %s, hosts %v).")
+
+	// ImageAutoWithoutInjection defines a diag.MessageType for message "ImageAutoWithoutInjection".
+	// Description: Pods and Deployments with `image: auto` should be targeted for injection.
+	ImageAutoWithoutInjection = diag.NewMessageType(diag.Error, "IST0146", "%s %s contains `image: auto` but does not match any Istio injection webhook selectors.")
 )
 
 // All returns a list of all known message types.
@@ -223,6 +227,7 @@ func All() []*diag.MessageType {
 		LocalhostListener,
 		InvalidApplicationUID,
 		ConflictingGateways,
+		ImageAutoWithoutInjection,
 	}
 }
 
@@ -645,5 +650,15 @@ func NewConflictingGateways(r *resource.Instance, gateway string, selector strin
 		selector,
 		portnumber,
 		hosts,
+	)
+}
+
+// NewImageAutoWithoutInjection returns a new diag.Message based on ImageAutoWithoutInjection.
+func NewImageAutoWithoutInjection(r *resource.Instance, resourceType string, resourceName string) diag.Message {
+	return diag.NewMessage(
+		ImageAutoWithoutInjection,
+		r,
+		resourceType,
+		resourceName,
 	)
 }

--- a/galley/pkg/config/analysis/msg/messages.gen.go
+++ b/galley/pkg/config/analysis/msg/messages.gen.go
@@ -178,11 +178,11 @@ var (
 	ConflictingGateways = diag.NewMessageType(diag.Error, "IST0145", "Conflict with gateways %s (workload selector %s, port %s, hosts %v).")
 
 	// ImageAutoWithoutInjectionWarning defines a diag.MessageType for message "ImageAutoWithoutInjectionWarning".
-	// Description: Pods and Deployments with `image: auto` should be targeted for injection.
+	// Description: Deployments with `image: auto` should be targeted for injection.
 	ImageAutoWithoutInjectionWarning = diag.NewMessageType(diag.Warning, "IST0146", "%s %s contains `image: auto` but does not match any Istio injection webhook selectors.")
 
 	// ImageAutoWithoutInjectionError defines a diag.MessageType for message "ImageAutoWithoutInjectionError".
-	// Description: Pods and Deployments with `image: auto` should be targeted for injection.
+	// Description: Pods with `image: auto` should be targeted for injection.
 	ImageAutoWithoutInjectionError = diag.NewMessageType(diag.Error, "IST0147", "%s %s contains `image: auto` but does not match any Istio injection webhook selectors.")
 )
 

--- a/galley/pkg/config/analysis/msg/messages.gen.go
+++ b/galley/pkg/config/analysis/msg/messages.gen.go
@@ -179,7 +179,7 @@ var (
 
 	// ImageAutoWithoutInjection defines a diag.MessageType for message "ImageAutoWithoutInjection".
 	// Description: Pods and Deployments with `image: auto` should be targeted for injection.
-	ImageAutoWithoutInjection = diag.NewMessageType(diag.Error, "IST0146", "%s %s contains `image: auto` but does not match any Istio injection webhook selectors.")
+	ImageAutoWithoutInjection = diag.NewMessageType(diag.Warning, "IST0146", "%s %s contains `image: auto` but does not match any Istio injection webhook selectors.")
 )
 
 // All returns a list of all known message types.

--- a/galley/pkg/config/analysis/msg/messages.gen.go
+++ b/galley/pkg/config/analysis/msg/messages.gen.go
@@ -177,9 +177,13 @@ var (
 	// Description: Gateway should not have the same selector, port and matched hosts of server
 	ConflictingGateways = diag.NewMessageType(diag.Error, "IST0145", "Conflict with gateways %s (workload selector %s, port %s, hosts %v).")
 
-	// ImageAutoWithoutInjection defines a diag.MessageType for message "ImageAutoWithoutInjection".
+	// ImageAutoWithoutInjectionWarning defines a diag.MessageType for message "ImageAutoWithoutInjectionWarning".
 	// Description: Pods and Deployments with `image: auto` should be targeted for injection.
-	ImageAutoWithoutInjection = diag.NewMessageType(diag.Warning, "IST0146", "%s %s contains `image: auto` but does not match any Istio injection webhook selectors.")
+	ImageAutoWithoutInjectionWarning = diag.NewMessageType(diag.Warning, "IST0146", "%s %s contains `image: auto` but does not match any Istio injection webhook selectors.")
+
+	// ImageAutoWithoutInjectionError defines a diag.MessageType for message "ImageAutoWithoutInjectionError".
+	// Description: Pods and Deployments with `image: auto` should be targeted for injection.
+	ImageAutoWithoutInjectionError = diag.NewMessageType(diag.Error, "IST0147", "%s %s contains `image: auto` but does not match any Istio injection webhook selectors.")
 )
 
 // All returns a list of all known message types.
@@ -227,7 +231,8 @@ func All() []*diag.MessageType {
 		LocalhostListener,
 		InvalidApplicationUID,
 		ConflictingGateways,
-		ImageAutoWithoutInjection,
+		ImageAutoWithoutInjectionWarning,
+		ImageAutoWithoutInjectionError,
 	}
 }
 
@@ -653,10 +658,20 @@ func NewConflictingGateways(r *resource.Instance, gateway string, selector strin
 	)
 }
 
-// NewImageAutoWithoutInjection returns a new diag.Message based on ImageAutoWithoutInjection.
-func NewImageAutoWithoutInjection(r *resource.Instance, resourceType string, resourceName string) diag.Message {
+// NewImageAutoWithoutInjectionWarning returns a new diag.Message based on ImageAutoWithoutInjectionWarning.
+func NewImageAutoWithoutInjectionWarning(r *resource.Instance, resourceType string, resourceName string) diag.Message {
 	return diag.NewMessage(
-		ImageAutoWithoutInjection,
+		ImageAutoWithoutInjectionWarning,
+		r,
+		resourceType,
+		resourceName,
+	)
+}
+
+// NewImageAutoWithoutInjectionError returns a new diag.Message based on ImageAutoWithoutInjectionError.
+func NewImageAutoWithoutInjectionError(r *resource.Instance, resourceType string, resourceName string) diag.Message {
+	return diag.NewMessage(
+		ImageAutoWithoutInjectionError,
 		r,
 		resourceType,
 		resourceName,

--- a/galley/pkg/config/analysis/msg/messages.yaml
+++ b/galley/pkg/config/analysis/msg/messages.yaml
@@ -508,7 +508,7 @@ messages:
   - name: "ImageAutoWithoutInjectionWarning"
     code: IST0146
     level: Warning
-    description: "Pods and Deployments with `image: auto` should be targeted for injection."
+    description: "Deployments with `image: auto` should be targeted for injection."
     template: "%s %s contains `image: auto` but does not match any Istio injection webhook selectors."
     url: "https://istio.io/latest/docs/reference/config/analysis/ist0146/"
     args:
@@ -520,9 +520,9 @@ messages:
   - name: "ImageAutoWithoutInjectionError"
     code: IST0147
     level: Error
-    description: "Pods and Deployments with `image: auto` should be targeted for injection."
+    description: "Pods with `image: auto` should be targeted for injection."
     template: "%s %s contains `image: auto` but does not match any Istio injection webhook selectors."
-    url: "https://istio.io/latest/docs/reference/config/analysis/ist0146/"
+    url: "https://istio.io/latest/docs/reference/config/analysis/ist0147/"
     args:
       - name: resourceType
         type: string

--- a/galley/pkg/config/analysis/msg/messages.yaml
+++ b/galley/pkg/config/analysis/msg/messages.yaml
@@ -504,3 +504,15 @@ messages:
         type: string
       - name: hosts
         type: string
+
+  - name: "ImageAutoWithoutInjection"
+    code: IST0146
+    level: Error
+    description: "Pods and Deployments with `image: auto` should be targeted for injection."
+    template: "%s %s contains `image: auto` but does not match any Istio injection webhook selectors."
+    url: "https://istio.io/latest/docs/reference/config/analysis/ist0106/"
+    args:
+      - name: resourceType
+        type: string
+      - name: resourceName
+        type: string

--- a/galley/pkg/config/analysis/msg/messages.yaml
+++ b/galley/pkg/config/analysis/msg/messages.yaml
@@ -505,9 +505,21 @@ messages:
       - name: hosts
         type: string
 
-  - name: "ImageAutoWithoutInjection"
+  - name: "ImageAutoWithoutInjectionWarning"
     code: IST0146
     level: Warning
+    description: "Pods and Deployments with `image: auto` should be targeted for injection."
+    template: "%s %s contains `image: auto` but does not match any Istio injection webhook selectors."
+    url: "https://istio.io/latest/docs/reference/config/analysis/ist0146/"
+    args:
+      - name: resourceType
+        type: string
+      - name: resourceName
+        type: string
+
+  - name: "ImageAutoWithoutInjectionError"
+    code: IST0147
+    level: Error
     description: "Pods and Deployments with `image: auto` should be targeted for injection."
     template: "%s %s contains `image: auto` but does not match any Istio injection webhook selectors."
     url: "https://istio.io/latest/docs/reference/config/analysis/ist0146/"

--- a/galley/pkg/config/analysis/msg/messages.yaml
+++ b/galley/pkg/config/analysis/msg/messages.yaml
@@ -507,7 +507,7 @@ messages:
 
   - name: "ImageAutoWithoutInjection"
     code: IST0146
-    level: Error
+    level: Warning
     description: "Pods and Deployments with `image: auto` should be targeted for injection."
     template: "%s %s contains `image: auto` but does not match any Istio injection webhook selectors."
     url: "https://istio.io/latest/docs/reference/config/analysis/ist0146/"

--- a/galley/pkg/config/analysis/msg/messages.yaml
+++ b/galley/pkg/config/analysis/msg/messages.yaml
@@ -510,7 +510,7 @@ messages:
     level: Error
     description: "Pods and Deployments with `image: auto` should be targeted for injection."
     template: "%s %s contains `image: auto` but does not match any Istio injection webhook selectors."
-    url: "https://istio.io/latest/docs/reference/config/analysis/ist0106/"
+    url: "https://istio.io/latest/docs/reference/config/analysis/ist0146/"
     args:
       - name: resourceType
         type: string

--- a/releasenotes/notes/image-auto-analyzer.yaml
+++ b/releasenotes/notes/image-auto-analyzer.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: istioctl
+releaseNotes:
+  - |
+    **Added** a new analyzer to check for `image: auto` in Pods and Deployments that will not be injected.


### PR DESCRIPTION
If we see `image: auto` in user manifests we know that the resource is intended to be injected. We should warn them if the resource doesn't match injection labels.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[x] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
