### PR TITLE
CronJobs already GA in k8s V1.21

### DIFF
--- a/pkg/kube/util.go
+++ b/pkg/kube/util.go
@@ -235,9 +235,6 @@ func GetDeployMetaFromPod(pod *kubeApiCore.Pod) (metav1.ObjectMeta, metav1.TypeM
 				if _, err := strconv.Atoi(controllerRef.Name[l-10:]); err == nil && string(controllerRef.Name[l-11]) == "-" {
 					deployMeta.Name = controllerRef.Name[:l-11]
 					typeMetadata.Kind = "CronJob"
-					// heuristically set cron job api version to v1beta1 as it cannot be derived from pod metadata.
-					// Cronjob is not GA yet and latest version is v1beta1: https://github.com/kubernetes/enhancements/pull/978
-					typeMetadata.APIVersion = "batch/v1beta1"
 				}
 			}
 		}


### PR DESCRIPTION
The latest version of Cronjob is batch/v1, which is GA in version 1.21 of k8s
it can be derived from pod metadata

k8s PR：Promote CronJobs to batch/v1
https://github.com/kubernetes/kubernetes/pull/98965



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
