### PR TITLE
chiron: Incorporating kubernetes csr v1 api

### DIFF
--- a/pilot/pkg/bootstrap/certcontroller.go
+++ b/pilot/pkg/bootstrap/certcontroller.go
@@ -131,7 +131,7 @@ func (s *Server) initDNSCerts(hostname, customHost, namespace string) error {
 	if features.PilotCertProvider == constants.CertProviderKubernetes {
 		log.Infof("Generating K8S-signed cert for %v", names)
 		certChain, keyPEM, _, err = chiron.GenKeyCertK8sCA(s.kubeClient,
-			strings.Join(names, ","), hostnamePrefix+".csr.secret", namespace, defaultCACertPath, "")
+			strings.Join(names, ","), hostnamePrefix+".csr.secret", namespace, defaultCACertPath, "", true)
 		if err != nil {
 			return fmt.Errorf("failed generating key and cert by kubernetes: %v", err)
 		}

--- a/pilot/pkg/bootstrap/certcontroller.go
+++ b/pilot/pkg/bootstrap/certcontroller.go
@@ -77,8 +77,7 @@ func (s *Server) initCertController(args *PilotArgs) error {
 	// Provision and manage the certificates for non-Pilot services.
 	// If services are empty, the certificate controller will do nothing.
 	s.certController, err = chiron.NewWebhookController(defaultCertGracePeriodRatio, defaultMinCertGracePeriod,
-		k8sClient.CoreV1(), k8sClient.CertificatesV1beta1(),
-		defaultCACertPath, secretNames, dnsNames, namespaces)
+		k8sClient, defaultCACertPath, secretNames, dnsNames, namespaces, "")
 	if err != nil {
 		return fmt.Errorf("failed to create certificate controller: %v", err)
 	}
@@ -131,7 +130,7 @@ func (s *Server) initDNSCerts(hostname, customHost, namespace string) error {
 	var err error
 	if features.PilotCertProvider == constants.CertProviderKubernetes {
 		log.Infof("Generating K8S-signed cert for %v", names)
-		certChain, keyPEM, _, err = chiron.GenKeyCertK8sCA(s.kubeClient.CertificatesV1beta1().CertificateSigningRequests(),
+		certChain, keyPEM, _, err = chiron.GenKeyCertK8sCA(s.kubeClient,
 			strings.Join(names, ","), hostnamePrefix+".csr.secret", namespace, defaultCACertPath, "")
 		if err != nil {
 			return fmt.Errorf("failed generating key and cert by kubernetes: %v", err)

--- a/pilot/pkg/bootstrap/istio_ca.go
+++ b/pilot/pkg/bootstrap/istio_ca.go
@@ -350,7 +350,7 @@ func (s *Server) createIstioRA(client kubelib.Client,
 		CaSigner:       opts.ExternalCASigner,
 		CaCertFile:     caCertFile,
 		VerifyAppendCA: true,
-		K8sClient:      client.CertificatesV1beta1(),
+		K8sClient:      client,
 		TrustDomain:    opts.TrustDomain,
 	}
 	return ra.NewIstioRA(raOpts)

--- a/security/pkg/k8s/chiron/controller.go
+++ b/security/pkg/k8s/chiron/controller.go
@@ -208,7 +208,7 @@ func (wc *WebhookController) upsertSecret(secretName, dnsName, secretNamespace s
 	}
 
 	// Now we know the secret does not exist yet. So we create a new one.
-	chain, key, caCert, err := GenKeyCertK8sCA(wc.clientset, dnsName, secretName, secretNamespace, wc.k8sCaCertFile, wc.certIssuer)
+	chain, key, caCert, err := GenKeyCertK8sCA(wc.clientset, dnsName, secretName, secretNamespace, wc.k8sCaCertFile, wc.certIssuer, true)
 	if err != nil {
 		log.Errorf("failed to generate key and certificate for secret %v in namespace %v (error %v)",
 			secretName, secretNamespace, err)
@@ -329,7 +329,7 @@ func (wc *WebhookController) refreshSecret(scrt *v1.Secret) error {
 		return fmt.Errorf("failed to find the service name for the secret (%v) to refresh", scrtName)
 	}
 
-	chain, key, caCert, err := GenKeyCertK8sCA(wc.clientset, dnsName, scrtName, namespace, wc.k8sCaCertFile, wc.certIssuer)
+	chain, key, caCert, err := GenKeyCertK8sCA(wc.clientset, dnsName, scrtName, namespace, wc.k8sCaCertFile, wc.certIssuer, true)
 	if err != nil {
 		return err
 	}

--- a/security/pkg/k8s/chiron/controller.go
+++ b/security/pkg/k8s/chiron/controller.go
@@ -29,8 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
-	certclient "k8s.io/client-go/kubernetes/typed/certificates/v1beta1"
-	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 
 	"istio.io/istio/pkg/listwatch"
@@ -77,9 +76,11 @@ type WebhookController struct {
 	serviceNamespaces []string
 
 	// Current CA certificate
-	CACert     []byte
-	core       corev1.CoreV1Interface
-	certClient certclient.CertificatesV1beta1Interface
+	CACert    []byte
+	clientset clientset.Interface
+
+	// certificate issuer
+	certIssuer string
 	// Controller and store for secret objects.
 	scrtController cache.Controller
 	scrtStore      cache.Store
@@ -94,8 +95,10 @@ type WebhookController struct {
 
 // NewWebhookController returns a pointer to a newly constructed WebhookController instance.
 func NewWebhookController(gracePeriodRatio float32, minGracePeriod time.Duration,
-	core corev1.CoreV1Interface, certClient certclient.CertificatesV1beta1Interface, k8sCaCertFile string,
-	secretNames, dnsNames, serviceNamespaces []string) (*WebhookController, error) {
+	client clientset.Interface,
+	k8sCaCertFile string,
+	secretNames, dnsNames,
+	serviceNamespaces []string, certIssuer string) (*WebhookController, error) {
 	if gracePeriodRatio < 0 || gracePeriodRatio > 1 {
 		return nil, fmt.Errorf("grace period ratio %f should be within [0, 1]", gracePeriodRatio)
 	}
@@ -123,12 +126,12 @@ func NewWebhookController(gracePeriodRatio float32, minGracePeriod time.Duration
 		gracePeriodRatio:  gracePeriodRatio,
 		minGracePeriod:    minGracePeriod,
 		k8sCaCertFile:     k8sCaCertFile,
-		core:              core,
-		certClient:        certClient,
+		clientset:         client,
 		secretNames:       secretNames,
 		dnsNames:          dnsNames,
 		serviceNamespaces: serviceNamespaces,
 		certUtil:          certutil.NewCertUtil(int(gracePeriodRatio * 100)),
+		certIssuer:        certIssuer,
 	}
 
 	// read CA cert at the beginning of launching the controller.
@@ -144,11 +147,11 @@ func NewWebhookController(gracePeriodRatio float32, minGracePeriod time.Duration
 			return &cache.ListWatch{
 				ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 					options.FieldSelector = istioSecretSelector
-					return core.Secrets(namespace).List(context.TODO(), options)
+					return client.CoreV1().Secrets(namespace).List(context.TODO(), options)
 				},
 				WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 					options.FieldSelector = istioSecretSelector
-					return core.Secrets(namespace).Watch(context.TODO(), options)
+					return client.CoreV1().Secrets(namespace).Watch(context.TODO(), options)
 				},
 			}
 		})
@@ -196,7 +199,7 @@ func (wc *WebhookController) upsertSecret(secretName, dnsName, secretNamespace s
 		Type: IstioDNSSecretType,
 	}
 
-	existingSecret, err := wc.core.Secrets(secretNamespace).Get(context.TODO(), secretName, metav1.GetOptions{})
+	existingSecret, err := wc.clientset.CoreV1().Secrets(secretNamespace).Get(context.TODO(), secretName, metav1.GetOptions{})
 	if err == nil && existingSecret != nil {
 		log.Debugf("upsertSecret(): the secret (%v) in namespace (%v) exists, return",
 			secretName, secretNamespace)
@@ -205,7 +208,7 @@ func (wc *WebhookController) upsertSecret(secretName, dnsName, secretNamespace s
 	}
 
 	// Now we know the secret does not exist yet. So we create a new one.
-	chain, key, caCert, err := GenKeyCertK8sCA(wc.certClient.CertificateSigningRequests(), dnsName, secretName, secretNamespace, wc.k8sCaCertFile, "")
+	chain, key, caCert, err := GenKeyCertK8sCA(wc.clientset, dnsName, secretName, secretNamespace, wc.k8sCaCertFile, wc.certIssuer)
 	if err != nil {
 		log.Errorf("failed to generate key and certificate for secret %v in namespace %v (error %v)",
 			secretName, secretNamespace, err)
@@ -219,7 +222,7 @@ func (wc *WebhookController) upsertSecret(secretName, dnsName, secretNamespace s
 
 	// We retry several times when create secret to mitigate transient network failures.
 	for i := 0; i < secretCreationRetry; i++ {
-		_, err = wc.core.Secrets(secretNamespace).Create(context.TODO(), secret, metav1.CreateOptions{})
+		_, err = wc.clientset.CoreV1().Secrets(secretNamespace).Create(context.TODO(), secret, metav1.CreateOptions{})
 		if err == nil || errors.IsAlreadyExists(err) {
 			if errors.IsAlreadyExists(err) {
 				log.Infof("Istio secret \"%s\" in namespace \"%s\" already exists", secretName, secretNamespace)
@@ -326,7 +329,7 @@ func (wc *WebhookController) refreshSecret(scrt *v1.Secret) error {
 		return fmt.Errorf("failed to find the service name for the secret (%v) to refresh", scrtName)
 	}
 
-	chain, key, caCert, err := GenKeyCertK8sCA(wc.certClient.CertificateSigningRequests(), dnsName, scrtName, namespace, wc.k8sCaCertFile, "")
+	chain, key, caCert, err := GenKeyCertK8sCA(wc.clientset, dnsName, scrtName, namespace, wc.k8sCaCertFile, wc.certIssuer)
 	if err != nil {
 		return err
 	}
@@ -335,7 +338,7 @@ func (wc *WebhookController) refreshSecret(scrt *v1.Secret) error {
 	scrt.Data[ca.PrivateKeyFile] = key
 	scrt.Data[ca.RootCertFile] = caCert
 
-	_, err = wc.core.Secrets(namespace).Update(context.TODO(), scrt, metav1.UpdateOptions{})
+	_, err = wc.clientset.CoreV1().Secrets(namespace).Update(context.TODO(), scrt, metav1.UpdateOptions{})
 	return err
 }
 

--- a/security/pkg/k8s/chiron/utils_test.go
+++ b/security/pkg/k8s/chiron/utils_test.go
@@ -86,16 +86,6 @@ func defaultReactionFunc(obj runtime.Object) kt.ReactionFunc {
 	}
 }
 
-func TestGetRandomCsrName(t *testing.T) {
-	secretName := "very-long-secret-name-that-will-be-truncated"
-	namespaceName := "very-long-namespace-name-that-will-be-truncated"
-
-	csrName := getRandomCsrName(secretName, namespaceName)
-	if len(csrName) > maxNameLength {
-		t.Errorf("the csr name returned %v is longer than %v", csrName, maxNameLength)
-	}
-}
-
 func TestGenKeyCertK8sCA(t *testing.T) {
 	testCases := map[string]struct {
 		gracePeriodRatio  float32
@@ -137,7 +127,7 @@ func TestGenKeyCertK8sCA(t *testing.T) {
 		}
 
 		_, _, _, err = GenKeyCertK8sCA(wc.clientset, tc.dnsNames[0], tc.secretNames[0],
-			tc.serviceNamespaces[0], wc.k8sCaCertFile, "testSigner")
+			tc.serviceNamespaces[0], wc.k8sCaCertFile, "testSigner", true)
 		if tc.expectFail {
 			if err == nil {
 				t.Errorf("should have failed")
@@ -387,7 +377,6 @@ func TestSubmitCSR(t *testing.T) {
 			continue
 		}
 
-		csrName := fmt.Sprintf("domain-%s-ns-%s-secret-%s", spiffe.GetTrustDomain(), tc.secretNameSpace, tc.secretName)
 		numRetries := 3
 
 		usages := []cert.KeyUsage{
@@ -397,7 +386,7 @@ func TestSubmitCSR(t *testing.T) {
 			cert.UsageClientAuth,
 		}
 
-		r, _, err := submitCSR(wc.clientset, []byte("test-pem"), csrName, "test-signer",
+		_, r, _, err := submitCSR(wc.clientset, []byte("test-pem"), "test-signer",
 			usages, numRetries)
 		if tc.expectFail {
 			if err == nil {

--- a/security/pkg/k8s/chiron/utils_test.go
+++ b/security/pkg/k8s/chiron/utils_test.go
@@ -16,7 +16,6 @@ package chiron
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -25,7 +24,7 @@ import (
 	"testing"
 	"time"
 
-	cert "k8s.io/api/certificates/v1beta1"
+	cert "k8s.io/api/certificates/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
@@ -130,15 +129,15 @@ func TestGenKeyCertK8sCA(t *testing.T) {
 		client.PrependReactor("get", "certificatesigningrequests", defaultReactionFunc(csr))
 
 		wc, err := NewWebhookController(tc.gracePeriodRatio, tc.minGracePeriod,
-			client.CoreV1(), client.CertificatesV1beta1(),
-			tc.k8sCaCertFile, tc.secretNames, tc.dnsNames, tc.serviceNamespaces)
+			client,
+			tc.k8sCaCertFile, tc.secretNames, tc.dnsNames, tc.serviceNamespaces, "test-issuer")
 		if err != nil {
 			t.Errorf("failed at creating webhook controller: %v", err)
 			continue
 		}
 
-		_, _, _, err = GenKeyCertK8sCA(wc.certClient.CertificateSigningRequests(), tc.dnsNames[0], tc.secretNames[0],
-			tc.serviceNamespaces[0], wc.k8sCaCertFile, "")
+		_, _, _, err = GenKeyCertK8sCA(wc.clientset, tc.dnsNames[0], tc.secretNames[0],
+			tc.serviceNamespaces[0], wc.k8sCaCertFile, "testSigner")
 		if tc.expectFail {
 			if err == nil {
 				t.Errorf("should have failed")
@@ -243,8 +242,7 @@ func TestReloadCACert(t *testing.T) {
 	for _, tc := range testCases {
 		client := fake.NewSimpleClientset()
 		wc, err := NewWebhookController(tc.gracePeriodRatio, tc.minGracePeriod,
-			client.CoreV1(), client.CertificatesV1beta1(),
-			tc.k8sCaCertFile, tc.secretNames, tc.dnsNames, tc.serviceNamespaces)
+			client, tc.k8sCaCertFile, tc.secretNames, tc.dnsNames, tc.serviceNamespaces, "test-issuer")
 		if err != nil {
 			t.Errorf("failed at creating webhook controller: %v", err)
 			continue
@@ -271,6 +269,79 @@ func TestReloadCACert(t *testing.T) {
 	}
 }
 
+func TestCheckDuplicateCSR(t *testing.T) {
+	testCases := map[string]struct {
+		gracePeriodRatio  float32
+		minGracePeriod    time.Duration
+		k8sCaCertFile     string
+		dnsNames          []string
+		secretNames       []string
+		serviceNamespaces []string
+		csrName           string
+		secretName        string
+		secretNameSpace   string
+		expectFail        bool
+		isDuplicate       bool
+	}{
+		"fetching a CSR without a duplicate should fail": {
+			gracePeriodRatio:  0.6,
+			k8sCaCertFile:     "./test-data/example-ca-cert.pem",
+			dnsNames:          []string{"foo"},
+			secretNames:       []string{"istio.webhook.foo"},
+			serviceNamespaces: []string{"foo.ns"},
+			secretName:        "mock-secret",
+			secretNameSpace:   "mock-secret-namespace",
+			expectFail:        true,
+			csrName:           "domain-cluster.local-ns--secret-mock-secret",
+			isDuplicate:       false,
+		},
+		"fetching a CSR with a duplicate should pass": {
+			gracePeriodRatio:  0.6,
+			k8sCaCertFile:     "./test-data/example-ca-cert.pem",
+			dnsNames:          []string{"foo"},
+			secretNames:       []string{"istio.webhook.foo"},
+			serviceNamespaces: []string{"foo.ns"},
+			secretName:        "mock-secret",
+			secretNameSpace:   "mock-secret-namespace",
+			expectFail:        false,
+			csrName:           "domain-cluster.local-ns--secret-mock-secret",
+			isDuplicate:       true,
+		},
+	}
+
+	for tcName, tc := range testCases {
+		client := fake.NewSimpleClientset()
+		csr := &cert.CertificateSigningRequest{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: tc.csrName,
+			},
+			Status: cert.CertificateSigningRequestStatus{
+				Certificate: []byte(exampleIssuedCert),
+			},
+		}
+		if tc.isDuplicate {
+			client.PrependReactor("get", "certificatesigningrequests", defaultReactionFunc(csr))
+		}
+		v1CsrReq, _ := checkDuplicateCsr(client, tc.csrName)
+		if tc.expectFail {
+			if v1CsrReq != nil {
+				t.Errorf("test case (%s) should have failed", tcName)
+			}
+		} else if v1CsrReq == nil {
+			t.Errorf("test case (%s) failed unexpectedly", tcName)
+		}
+
+		certData := readSignedCsr(client, tc.csrName, 1*time.Second, certReadInterval, 1, true)
+		if tc.expectFail {
+			if len(certData) != 0 {
+				t.Errorf("test case (%s) should have failed", tcName)
+			}
+		} else if len(certData) == 0 {
+			t.Errorf("test case (%s) failed unexpectedly", tcName)
+		}
+	}
+}
+
 func TestSubmitCSR(t *testing.T) {
 	testCases := map[string]struct {
 		gracePeriodRatio  float32
@@ -282,8 +353,6 @@ func TestSubmitCSR(t *testing.T) {
 
 		secretName      string
 		secretNameSpace string
-
-		createDuplicate bool
 		expectFail      bool
 	}{
 		"submitting a CSR without duplicate should succeed": {
@@ -294,23 +363,11 @@ func TestSubmitCSR(t *testing.T) {
 			serviceNamespaces: []string{"foo.ns"},
 			secretName:        "mock-secret",
 			secretNameSpace:   "mock-secret-namespace",
-			createDuplicate:   false,
-			expectFail:        false,
-		},
-		"submitting a CSR with duplicate should succeed": {
-			gracePeriodRatio:  0.6,
-			k8sCaCertFile:     "./test-data/example-ca-cert.pem",
-			dnsNames:          []string{"foo"},
-			secretNames:       []string{"istio.webhook.foo"},
-			serviceNamespaces: []string{"foo.ns"},
-			secretName:        "mock-secret",
-			secretNameSpace:   "mock-secret-namespace",
-			createDuplicate:   true,
 			expectFail:        false,
 		},
 	}
 
-	for _, tc := range testCases {
+	for tcName, tc := range testCases {
 		client := fake.NewSimpleClientset()
 		csr := &cert.CertificateSigningRequest{
 			ObjectMeta: metav1.ObjectMeta{
@@ -323,61 +380,31 @@ func TestSubmitCSR(t *testing.T) {
 		client.PrependReactor("get", "certificatesigningrequests", defaultReactionFunc(csr))
 
 		wc, err := NewWebhookController(tc.gracePeriodRatio, tc.minGracePeriod,
-			client.CoreV1(), client.CertificatesV1beta1(),
-			tc.k8sCaCertFile, tc.secretNames, tc.dnsNames, tc.serviceNamespaces)
+			client,
+			tc.k8sCaCertFile, tc.secretNames, tc.dnsNames, tc.serviceNamespaces, "test-issuer")
 		if err != nil {
-			t.Errorf("failed at creating webhook controller: %v", err)
+			t.Errorf("test case (%s) failed at creating webhook controller: %v", tcName, err)
 			continue
 		}
 
 		csrName := fmt.Sprintf("domain-%s-ns-%s-secret-%s", spiffe.GetTrustDomain(), tc.secretNameSpace, tc.secretName)
 		numRetries := 3
-		csrPEM := "fake-csr"
 
-		if tc.createDuplicate {
-			// Create a duplicate CSR to whether submitCSR() still functions correctly
-			k8sCSR := &cert.CertificateSigningRequest{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: "certificates.k8s.io/v1beta1",
-					Kind:       "CertificateSigningRequest",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name: csrName,
-				},
-				Spec: cert.CertificateSigningRequestSpec{
-					Request: []byte(csrPEM),
-					Groups:  []string{"system:authenticated"},
-					Usages: []cert.KeyUsage{
-						cert.UsageDigitalSignature,
-						cert.UsageKeyEncipherment,
-						cert.UsageServerAuth,
-						cert.UsageClientAuth,
-					},
-				},
-			}
-			reqRet, errRet := wc.certClient.CertificateSigningRequests().Create(context.TODO(), k8sCSR, metav1.CreateOptions{})
-			if errRet != nil && reqRet == nil {
-				t.Errorf("failed to create a CSR, return is nil or error (%v)", errRet)
-				continue
-			}
+		usages := []cert.KeyUsage{
+			cert.UsageDigitalSignature,
+			cert.UsageKeyEncipherment,
+			cert.UsageServerAuth,
+			cert.UsageClientAuth,
 		}
-		csrSpec := &cert.CertificateSigningRequestSpec{
-			Request: []byte(csrPEM),
-			Groups:  []string{"system:authenticated"},
-			Usages: []cert.KeyUsage{
-				cert.UsageDigitalSignature,
-				cert.UsageKeyEncipherment,
-				cert.UsageServerAuth,
-				cert.UsageClientAuth,
-			},
-		}
-		r, err := submitCSR(wc.certClient.CertificateSigningRequests(), csrName, csrSpec, numRetries)
+
+		r, _, err := submitCSR(wc.clientset, []byte("test-pem"), csrName, "test-signer",
+			usages, numRetries)
 		if tc.expectFail {
 			if err == nil {
-				t.Errorf("should have failed")
+				t.Errorf("test case (%s) should have failed", tcName)
 			}
 		} else if err != nil || r == nil {
-			t.Errorf("failed unexpectedly: %v", err)
+			t.Errorf("test case (%s) failed unexpectedly: %v", tcName, err)
 		}
 	}
 }
@@ -446,8 +473,7 @@ func TestReadSignedCertificate(t *testing.T) {
 		client.PrependReactor("get", "certificatesigningrequests", defaultReactionFunc(csr))
 
 		wc, err := NewWebhookController(tc.gracePeriodRatio, tc.minGracePeriod,
-			client.CoreV1(), client.CertificatesV1beta1(),
-			tc.k8sCaCertFile, tc.secretNames, tc.dnsNames, tc.serviceNamespaces)
+			client, tc.k8sCaCertFile, tc.secretNames, tc.dnsNames, tc.serviceNamespaces, "test-issuer")
 		if err != nil {
 			t.Errorf("failed at creating webhook controller: %v", err)
 			continue
@@ -455,8 +481,8 @@ func TestReadSignedCertificate(t *testing.T) {
 
 		// 4. Read the signed certificate
 		csrName := fmt.Sprintf("domain-%s-ns-%s-secret-%s", spiffe.GetTrustDomain(), tc.secretNameSpace, tc.secretName)
-		_, _, err = readSignedCertificate(wc.certClient.CertificateSigningRequests(), csrName,
-			certReadInterval, certWatchTimeout, maxNumCertRead, wc.k8sCaCertFile, true)
+		_, _, err = readSignedCertificate(wc.clientset, csrName,
+			1*time.Second, certReadInterval, maxNumCertRead, wc.k8sCaCertFile, true, true)
 
 		if tc.expectFail {
 			if err == nil {

--- a/security/pkg/pki/ra/common.go
+++ b/security/pkg/pki/ra/common.go
@@ -17,7 +17,7 @@ import (
 	"fmt"
 	"time"
 
-	certificatesv1beta1 "k8s.io/client-go/kubernetes/typed/certificates/v1beta1"
+	clientset "k8s.io/client-go/kubernetes"
 
 	raerror "istio.io/istio/security/pkg/pki/error"
 	"istio.io/istio/security/pkg/pki/util"
@@ -47,7 +47,7 @@ type IstioRAOptions struct {
 	// VerifyAppendCA : Whether to use caCertFile containing CA root cert to verify and append to signed cert-chain
 	VerifyAppendCA bool
 	// K8sClient : K8s API client
-	K8sClient certificatesv1beta1.CertificatesV1beta1Interface
+	K8sClient clientset.Interface
 	// TrustDomain
 	TrustDomain string
 }

--- a/security/pkg/pki/ra/k8s_ra.go
+++ b/security/pkg/pki/ra/k8s_ra.go
@@ -47,15 +47,15 @@ func NewKubernetesRA(raOpts *IstioRAOptions) (*KubernetesRA, error) {
 	return istioRA, nil
 }
 
-func (r *KubernetesRA) kubernetesSign(csrPEM []byte, csrName string, caCertFile string) ([]byte, error) {
+func (r *KubernetesRA) kubernetesSign(csrPEM []byte, caCertFile string) ([]byte, error) {
 	usages := []cert.KeyUsage{
 		cert.UsageDigitalSignature,
 		cert.UsageKeyEncipherment,
 		cert.UsageServerAuth,
 		cert.UsageClientAuth,
 	}
-	certChain, _, err := chiron.SignCSRK8s(r.csrInterface, csrPEM, csrName, r.raOpts.CaSigner,
-		nil, usages, "", caCertFile, false)
+	certChain, _, err := chiron.SignCSRK8s(r.csrInterface, csrPEM, r.raOpts.CaSigner,
+		nil, usages, "", caCertFile, true, false)
 	if err != nil {
 		return nil, raerror.NewError(raerror.CertGenError, err)
 	}
@@ -68,11 +68,7 @@ func (r *KubernetesRA) Sign(csrPEM []byte, certOpts ca.CertOpts) ([]byte, error)
 	if err != nil {
 		return nil, err
 	}
-	csrName, err := chiron.GetUniqueCsrName(chiron.GenCsrName, r.raOpts.K8sClient, "", "")
-	if err != nil {
-		return nil, err
-	}
-	return r.kubernetesSign(csrPEM, csrName, r.raOpts.CaCertFile)
+	return r.kubernetesSign(csrPEM, r.raOpts.CaCertFile)
 }
 
 // SignWithCertChain is similar to Sign but returns the leaf cert and the entire cert chain.

--- a/security/pkg/pki/ra/k8s_ra.go
+++ b/security/pkg/pki/ra/k8s_ra.go
@@ -17,8 +17,8 @@ package ra
 import (
 	"fmt"
 
-	cert "k8s.io/api/certificates/v1beta1"
-	certclient "k8s.io/client-go/kubernetes/typed/certificates/v1beta1"
+	cert "k8s.io/api/certificates/v1"
+	clientset "k8s.io/client-go/kubernetes"
 
 	"istio.io/istio/security/pkg/k8s/chiron"
 	"istio.io/istio/security/pkg/pki/ca"
@@ -28,7 +28,7 @@ import (
 
 // KubernetesRA integrated with an external CA using Kubernetes CSR API
 type KubernetesRA struct {
-	csrInterface  certclient.CertificatesV1beta1Interface
+	csrInterface  clientset.Interface
 	keyCertBundle *util.KeyCertBundle
 	raOpts        *IstioRAOptions
 }
@@ -48,18 +48,14 @@ func NewKubernetesRA(raOpts *IstioRAOptions) (*KubernetesRA, error) {
 }
 
 func (r *KubernetesRA) kubernetesSign(csrPEM []byte, csrName string, caCertFile string) ([]byte, error) {
-	csrSpec := &cert.CertificateSigningRequestSpec{
-		SignerName: &r.raOpts.CaSigner,
-		Request:    csrPEM,
-		Groups:     []string{"system:authenticated"},
-		Usages: []cert.KeyUsage{
-			cert.UsageDigitalSignature,
-			cert.UsageKeyEncipherment,
-			cert.UsageServerAuth,
-			cert.UsageClientAuth,
-		},
+	usages := []cert.KeyUsage{
+		cert.UsageDigitalSignature,
+		cert.UsageKeyEncipherment,
+		cert.UsageServerAuth,
+		cert.UsageClientAuth,
 	}
-	certChain, _, err := chiron.SignCSRK8s(r.csrInterface.CertificateSigningRequests(), csrName, csrSpec, "", caCertFile, false)
+	certChain, _, err := chiron.SignCSRK8s(r.csrInterface, csrPEM, csrName, r.raOpts.CaSigner,
+		nil, usages, "", caCertFile, false)
 	if err != nil {
 		return nil, raerror.NewError(raerror.CertGenError, err)
 	}
@@ -72,7 +68,10 @@ func (r *KubernetesRA) Sign(csrPEM []byte, certOpts ca.CertOpts) ([]byte, error)
 	if err != nil {
 		return nil, err
 	}
-	csrName := chiron.GenCsrName()
+	csrName, err := chiron.GetUniqueCsrName(chiron.GenCsrName, r.raOpts.K8sClient, "", "")
+	if err != nil {
+		return nil, err
+	}
 	return r.kubernetesSign(csrPEM, csrName, r.raOpts.CaCertFile)
 }
 

--- a/security/pkg/pki/ra/k8s_ra_test.go
+++ b/security/pkg/pki/ra/k8s_ra_test.go
@@ -113,7 +113,7 @@ func createFakeK8sRA(client *fake.Clientset) (*KubernetesRA, error) {
 // TestK8sSign : Verify that ra.k8sSign returns a valid certPEM while using k8s Fake Client to create a CSR
 func TestK8sSign(t *testing.T) {
 	csrPEM := createFakeCsr(t)
-	csrName := chiron.GenCsrName("", "")
+	csrName := chiron.GenCsrName()
 	client := initFakeKubeClient(csrName)
 	r, err := createFakeK8sRA(client)
 	if err != nil {
@@ -131,7 +131,7 @@ func TestK8sSign(t *testing.T) {
 
 func TestValidateCSR(t *testing.T) {
 	csrPEM := createFakeCsr(t)
-	csrName := chiron.GenCsrName("", "")
+	csrName := chiron.GenCsrName()
 	client := initFakeKubeClient(csrName)
 	_, err := createFakeK8sRA(client)
 	if err != nil {

--- a/security/pkg/pki/ra/k8s_ra_test.go
+++ b/security/pkg/pki/ra/k8s_ra_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 	"time"
 
-	cert "k8s.io/api/certificates/v1beta1"
+	cert "k8s.io/api/certificates/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
@@ -26,6 +26,7 @@ import (
 
 	"istio.io/istio/pkg/spiffe"
 	"istio.io/istio/security/pkg/k8s/chiron"
+	"istio.io/istio/security/pkg/pki/ca"
 	pkiutil "istio.io/istio/security/pkg/pki/util"
 )
 
@@ -104,7 +105,7 @@ func createFakeK8sRA(client *fake.Clientset) (*KubernetesRA, error) {
 		CaSigner:       caSigner,
 		CaCertFile:     caCertFile,
 		VerifyAppendCA: true,
-		K8sClient:      client.CertificatesV1beta1(),
+		K8sClient:      client,
 	}
 	return NewKubernetesRA(raOpts)
 }
@@ -112,13 +113,17 @@ func createFakeK8sRA(client *fake.Clientset) (*KubernetesRA, error) {
 // TestK8sSign : Verify that ra.k8sSign returns a valid certPEM while using k8s Fake Client to create a CSR
 func TestK8sSign(t *testing.T) {
 	csrPEM := createFakeCsr(t)
-	csrName := chiron.GenCsrName()
+	csrName := chiron.GenCsrName("", "")
 	client := initFakeKubeClient(csrName)
 	r, err := createFakeK8sRA(client)
 	if err != nil {
 		t.Errorf("Validation CSR failed")
 	}
-	_, err = r.kubernetesSign(csrPEM, csrName, r.raOpts.CaCertFile)
+	subjectID := spiffe.Identity{TrustDomain: "cluster.local", Namespace: "default", ServiceAccount: "bookinfo-productpage"}.String()
+	_, err = r.Sign(csrPEM, ca.CertOpts{
+		SubjectIDs: []string{subjectID},
+		TTL:        60 * time.Second, ForCA: false,
+	})
 	if err != nil {
 		t.Errorf("K8s CA Signing CSR failed")
 	}
@@ -126,7 +131,7 @@ func TestK8sSign(t *testing.T) {
 
 func TestValidateCSR(t *testing.T) {
 	csrPEM := createFakeCsr(t)
-	csrName := chiron.GenCsrName()
+	csrName := chiron.GenCsrName("", "")
 	client := initFakeKubeClient(csrName)
 	_, err := createFakeK8sRA(client)
 	if err != nil {


### PR DESCRIPTION
Add ability for chiron module of Istiod to use [Kubernetes v1 CSR api ](https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/) to sign Istiod DNS certificates and optionally sign workload certificates when Istiod functions as an RA. Refer to [Issue](https://github.com/istio/istio/issues/34012) for context


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[ ] Test and Release
[] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.