### PR TITLE
update addons manifest with explicit image path

### DIFF
--- a/samples/addons/extras/prometheus_vm.yaml
+++ b/samples/addons/extras/prometheus_vm.yaml
@@ -452,7 +452,7 @@ spec:
       serviceAccountName: prometheus
       containers:
         - name: prometheus-server-configmap-reload
-          image: "jimmidyson/configmap-reload:v0.5.0"
+          image: "docker.io/jimmidyson/configmap-reload:v0.5.0"
           imagePullPolicy: "IfNotPresent"
           args:
             - --volume-dir=/etc/config
@@ -468,7 +468,7 @@ spec:
               readOnly: true
 
         - name: prometheus-server
-          image: "prom/prometheus:v2.24.0"
+          image: "docker.io/prom/prometheus:v2.24.0"
           imagePullPolicy: "IfNotPresent"
           args:
             - --storage.tsdb.retention.time=15d
@@ -508,7 +508,7 @@ spec:
             - name: file-sd-volume
               mountPath: /etc/file_sd
         - name: vm-discovery
-          image: "istioecosystem/vm-discovery:latest"
+          image: "docker.io/istioecosystem/vm-discovery:latest"
           imagePullPolicy: "IfNotPresent"
       hostNetwork: false
       dnsPolicy: ClusterFirst

--- a/samples/addons/extras/prometheus_vm_tls.yaml
+++ b/samples/addons/extras/prometheus_vm_tls.yaml
@@ -464,7 +464,7 @@ spec:
       serviceAccountName: prometheus
       containers:
         - name: prometheus-server-configmap-reload
-          image: "jimmidyson/configmap-reload:v0.5.0"
+          image: "docker.io/jimmidyson/configmap-reload:v0.5.0"
           imagePullPolicy: "IfNotPresent"
           args:
             - --volume-dir=/etc/config
@@ -480,7 +480,7 @@ spec:
               readOnly: true
 
         - name: prometheus-server
-          image: "prom/prometheus:v2.24.0"
+          image: "docker.io/prom/prometheus:v2.24.0"
           imagePullPolicy: "IfNotPresent"
           args:
             - --storage.tsdb.retention.time=15d
@@ -522,7 +522,7 @@ spec:
             - name: istio-certs
               mountPath: /etc/prom-certs/
         - name: vm-discovery
-          image: "istioecosystem/vm-discovery:latest"
+          image: "docker.io/istioecosystem/vm-discovery:latest"
           imagePullPolicy: "IfNotPresent"
       hostNetwork: false
       dnsPolicy: ClusterFirst

--- a/samples/addons/extras/zipkin.yaml
+++ b/samples/addons/extras/zipkin.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: zipkin
-          image: openzipkin/zipkin-slim:2.23.0
+          image: docker.io/openzipkin/zipkin-slim:2.23.0
           env:
             - name: STORAGE_METHOD
               value: "mem"

--- a/samples/addons/grafana.yaml
+++ b/samples/addons/grafana.yaml
@@ -133,7 +133,7 @@ spec:
         runAsUser: 472
       containers:
         - name: grafana
-          image: "grafana/grafana:7.5.5"
+          image: "docker.io/grafana/grafana:7.5.5"
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: config

--- a/samples/addons/prometheus.yaml
+++ b/samples/addons/prometheus.yaml
@@ -420,7 +420,7 @@ spec:
       serviceAccountName: prometheus
       containers:
         - name: prometheus-server-configmap-reload
-          image: "jimmidyson/configmap-reload:v0.5.0"
+          image: "docker.io/jimmidyson/configmap-reload:v0.5.0"
           imagePullPolicy: "IfNotPresent"
           args:
             - --volume-dir=/etc/config
@@ -433,7 +433,7 @@ spec:
               readOnly: true
 
         - name: prometheus-server
-          image: "prom/prometheus:v2.26.0"
+          image: "docker.io/prom/prometheus:v2.26.0"
           imagePullPolicy: "IfNotPresent"
           args:
             - --storage.tsdb.retention.time=15d


### PR DESCRIPTION
none-docker-engine CRI env expect an explicit image path contains registry as well

[ ] Configuration Infrastructure
[X] Docs
[X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[X] User Experience
[X] Developer Infrastructure
