### PR TITLE
Align config cluster default remote-secret sa with istiod-remote install

### DIFF
--- a/istioctl/pkg/multicluster/remote_secret.go
+++ b/istioctl/pkg/multicluster/remote_secret.go
@@ -334,7 +334,6 @@ func generateServiceAccountYAML(opt RemoteSecretOptions) (string, error) {
 	values := fmt.Sprintf(`
 global:
   istioNamespace: %s
-  externalIstiod: true
 `, opt.Namespace)
 
 	// Render the templates required for the service account and role bindings.

--- a/istioctl/pkg/multicluster/remote_secret.go
+++ b/istioctl/pkg/multicluster/remote_secret.go
@@ -334,6 +334,7 @@ func generateServiceAccountYAML(opt RemoteSecretOptions) (string, error) {
 	values := fmt.Sprintf(`
 global:
   istioNamespace: %s
+  externalIstiod: true
 `, opt.Namespace)
 
 	// Render the templates required for the service account and role bindings.
@@ -532,9 +533,9 @@ type RemoteSecretOptions struct {
 
 func (o *RemoteSecretOptions) addFlags(flagset *pflag.FlagSet) {
 	flagset.StringVar(&o.ServiceAccountName, "service-account", "",
-		"Create a secret with this service account's credentials. Use \""+
-			constants.DefaultServiceAccountName+"\" as default value if --type is \"remote\", use \""+
-			constants.DefaultConfigServiceAccountName+"\" as default value if --type is \"config\".")
+		"Create a secret with this service account's credentials. Default value is \""+
+			constants.DefaultServiceAccountName+"\" if --type is \"remote\", \""+
+			constants.DefaultConfigServiceAccountName+"\" if --type is \"config\".")
 	flagset.BoolVar(&o.CreateServiceAccount, "create-service-account", true,
 		"If true, the service account needed for creating the remote secret will be created "+
 			"if it doesn't exist.")

--- a/pkg/config/constants/constants.go
+++ b/pkg/config/constants/constants.go
@@ -93,8 +93,8 @@ const (
 	// DefaultServiceAccountName is the default service account to use for remote cluster access.
 	DefaultServiceAccountName = "istio-reader-service-account"
 
-	// DefaultConfigServiceAccountName is the default service account to use for external Istiod cluster access.
-	DefaultConfigServiceAccountName = "istiod-service-account"
+	// DefaultConfigServiceAccountName is the default service account to use for external Istiod config cluster access.
+	DefaultConfigServiceAccountName = "istiod"
 
 	// KubeSystemNamespace is the system namespace where we place kubernetes system components.
 	KubeSystemNamespace string = "kube-system"


### PR DESCRIPTION

Changes `istioctl x create-remote-secret --config` to use the `istiod` service-account by default, since `istiod-service-account` is now legacy for backward compat, and not even installed on an external istiod config cluster.