### PR TITLE
echo: apply timeout for ingress calls

### DIFF
--- a/pkg/test/framework/components/echo/common/call.go
+++ b/pkg/test/framework/components/echo/common/call.go
@@ -133,8 +133,9 @@ func CallEcho(opts *echo.CallOptions, retry bool, retryOptions ...retry.Option) 
 			return nil, err
 		}
 		defer instance.Close()
-
-		ret, err := instance.Run(context.Background())
+		ctx, cancel := context.WithTimeout(context.Background(), opts.Timeout)
+		defer cancel()
+		ret, err := instance.Run(ctx)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Without this, we will never retry, and could get stuck on the first attempt for the entire `retry` package duration. 

```
 traffic.go:222: call failed from TestRunner to [redacted] (using https): timeout while waiting after 1 attempts (last error: <nil>)
```