### PR TITLE
[FIX]default mesh config file path

### DIFF
--- a/pilot/cmd/pilot-discovery/app/cmd.go
+++ b/pilot/cmd/pilot-discovery/app/cmd.go
@@ -127,7 +127,7 @@ func addFlags(c *cobra.Command) {
 		serverArgs.RegistryOptions.ClusterRegistriesNamespace, "Namespace for ConfigMap which stores clusters configs")
 	c.PersistentFlags().StringVar(&serverArgs.RegistryOptions.KubeConfig, "kubeconfig", "",
 		"Use a Kubernetes configuration file instead of in-cluster configuration")
-	c.PersistentFlags().StringVar(&serverArgs.MeshConfigFile, "meshConfig", "./etc/istio/config/mesh",
+	c.PersistentFlags().StringVar(&serverArgs.MeshConfigFile, "meshConfig", "/etc/istio/config/mesh",
 		"File name for Istio mesh configuration. If not specified, a default mesh will be used.")
 	c.PersistentFlags().StringVar(&serverArgs.NetworksConfigFile, "networksConfig", "/etc/istio/config/meshNetworks",
 		"File name for Istio mesh networks configuration. If not specified, a default mesh networks will be used.")

--- a/pilot/cmd/pilot-discovery/app/cmd.go
+++ b/pilot/cmd/pilot-discovery/app/cmd.go
@@ -127,9 +127,9 @@ func addFlags(c *cobra.Command) {
 		serverArgs.RegistryOptions.ClusterRegistriesNamespace, "Namespace for ConfigMap which stores clusters configs")
 	c.PersistentFlags().StringVar(&serverArgs.RegistryOptions.KubeConfig, "kubeconfig", "",
 		"Use a Kubernetes configuration file instead of in-cluster configuration")
-	c.PersistentFlags().StringVar(&serverArgs.MeshConfigFile, "meshConfig", "/etc/istio/config/mesh",
+	c.PersistentFlags().StringVar(&serverArgs.MeshConfigFile, "meshConfig", "./etc/istio/config/mesh",
 		"File name for Istio mesh configuration. If not specified, a default mesh will be used.")
-	c.PersistentFlags().StringVar(&serverArgs.NetworksConfigFile, "networksConfig", "/etc/istio/config/meshNetworks",
+	c.PersistentFlags().StringVar(&serverArgs.NetworksConfigFile, "networksConfig", "./etc/istio/config/meshNetworks",
 		"File name for Istio mesh networks configuration. If not specified, a default mesh networks will be used.")
 	c.PersistentFlags().StringVarP(&serverArgs.Namespace, "namespace", "n", bootstrap.PodNamespace,
 		"Select a namespace where the controller resides. If not set, uses ${POD_NAMESPACE} environment variable")


### PR DESCRIPTION

The current path is `./etc/istio/config/mesh`, use absolute path instead, keep it consistent with `networksConfig`.


[ X ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ X ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.