### PR TITLE
fix delete secret bug: delete secretKey cluster only once

### DIFF
--- a/pkg/kube/secretcontroller/secretcontroller.go
+++ b/pkg/kube/secretcontroller/secretcontroller.go
@@ -486,8 +486,9 @@ func (c *Controller) deleteSecret(secretKey string) {
 				clusterID, secretKey, err)
 		}
 		close(cluster.Stop)
-		delete(c.cs.remoteClusters, secretKey)
+		delete(c.cs.remoteClusters[secretKey], clusterID)
 	}
+	delete(c.cs.remoteClusters, secretKey)
 }
 
 func (c *Controller) deleteMemberCluster(secretKey string, clusterID cluster.ID) {


### PR DESCRIPTION
only after fininsh range `remoteClusters` using `secretKey`, we could delete from  `remoteClusters` map using key `secretKey`, and delete only once
first delete using secretKey and clusterID
finally delete all using secretKey

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.