### PR TITLE
In the scene where service entry select workload entry：set up istio endpoint port

### DIFF
--- a/pilot/pkg/serviceregistry/serviceentry/conversion.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion.go
@@ -228,14 +228,12 @@ func convertEndpoint(service *model.Service, servicePort *networking.Port,
 	wle *networking.WorkloadEntry, configKey *configKey, clusterID cluster.ID) *model.ServiceInstance {
 	var instancePort uint32
 	addr := wle.GetAddress()
+	// priority level: unixAddress > we.ports > se.port.targetPort > se.port.number
 	if strings.HasPrefix(addr, model.UnixAddressPrefix) {
 		instancePort = 0
 		addr = strings.TrimPrefix(addr, model.UnixAddressPrefix)
-	} else if len(wle.Ports) > 0 { // endpoint port map takes precedence
-		instancePort = wle.Ports[servicePort.Name]
-		if instancePort == 0 {
-			instancePort = servicePort.Number
-		}
+	} else if port, ok := wle.Ports[servicePort.Name]; ok && port > 0 {
+		instancePort = port
 	} else if servicePort.TargetPort > 0 {
 		instancePort = servicePort.TargetPort
 	} else {


### PR DESCRIPTION
In the scene where service entry select workload entry
The priority of the model.IstioEndPoint.EndpointPort port should be : unixAddress > we.ports > se.port.targetPort > se.port.number


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
