### PR TITLE
fix portforwarder Close time

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -682,10 +682,10 @@ func (c *client) portForwardRequest(ctx context.Context, podName, podNamespace, 
 	if err != nil {
 		return nil, err
 	}
+	defer fw.Close()
 	if err = fw.Start(); err != nil {
 		return nil, formatError(err)
 	}
-	defer fw.Close()
 	req, err := http.NewRequest(method, fmt.Sprintf("http://%s/%s", fw.Address(), path), nil)
 	if err != nil {
 		return nil, formatError(err)


### PR DESCRIPTION
PortFowarder should be close as soon as being created successfully, but not only after start it successfully


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.