### PR TITLE
Apply namespace scoping to Gateway servers in samples

### DIFF
--- a/samples/bookinfo/networking/bookinfo-gateway.yaml
+++ b/samples/bookinfo/networking/bookinfo-gateway.yaml
@@ -2,6 +2,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
   name: bookinfo-gateway
+  namespace: default
 spec:
   selector:
     istio: ingressgateway # use istio default controller
@@ -17,6 +18,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: bookinfo
+  namespace: default
 spec:
   hosts:
   - "*"

--- a/samples/bookinfo/networking/bookinfo-gateway.yaml
+++ b/samples/bookinfo/networking/bookinfo-gateway.yaml
@@ -11,7 +11,7 @@ spec:
       name: http
       protocol: HTTP
     hosts:
-    - "*"
+    - "default/*"
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService

--- a/samples/bookinfo/networking/certmanager-gateway.yaml
+++ b/samples/bookinfo/networking/certmanager-gateway.yaml
@@ -12,7 +12,7 @@ spec:
       name: http
       protocol: HTTP
     hosts:
-    - "*"
+    - "istio-system/*"
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService

--- a/samples/helloworld/helloworld-gateway.yaml
+++ b/samples/helloworld/helloworld-gateway.yaml
@@ -2,6 +2,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
   name: helloworld-gateway
+  namespace: default
 spec:
   selector:
     istio: ingressgateway # use istio default controller
@@ -17,6 +18,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: helloworld
+  namespace: default
 spec:
   hosts:
   - "*"

--- a/samples/helloworld/helloworld-gateway.yaml
+++ b/samples/helloworld/helloworld-gateway.yaml
@@ -11,7 +11,7 @@ spec:
       name: http
       protocol: HTTP
     hosts:
-    - "*"
+    - "default/*"
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService

--- a/samples/httpbin/httpbin-gateway.yaml
+++ b/samples/httpbin/httpbin-gateway.yaml
@@ -2,6 +2,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
   name: httpbin-gateway
+  namespace: default
 spec:
   selector:
     istio: ingressgateway
@@ -17,6 +18,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: httpbin
+  namespace: default
 spec:
   hosts:
   - "*"

--- a/samples/httpbin/httpbin-gateway.yaml
+++ b/samples/httpbin/httpbin-gateway.yaml
@@ -11,7 +11,7 @@ spec:
       name: http
       protocol: HTTP
     hosts:
-    - "*"
+    - "default/*"
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService

--- a/samples/multicluster/expose-istiod-https.yaml
+++ b/samples/multicluster/expose-istiod-https.yaml
@@ -61,6 +61,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
   name: istiod-dr
+  namespace: istio-system
 spec:
   host: istiod.istio-system.svc.cluster.local
   trafficPolicy:

--- a/samples/multicluster/expose-istiod-https.yaml
+++ b/samples/multicluster/expose-istiod-https.yaml
@@ -2,6 +2,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
   name: istiod-gateway
+  namespace: istio-system
 spec:
   selector:
     istio: eastwestgateway
@@ -16,7 +17,7 @@ spec:
         credentialName: "$CREDENTIAL_NAME"
       hosts:
       # use a valid gateway host and domain for istiod
-      - "ISTIOD-HOST.DOMAIN"
+      - "istio-system/ISTIOD-HOST.DOMAIN"
     - port:
         name: https-istiodwebhook
         number: 15017
@@ -27,12 +28,13 @@ spec:
         credentialName: "$CREDENTIAL_NAME"
       hosts:
       # use a valid gateway host and domain for istiod
-      - "ISTIOD-HOST.DOMAIN"
+      - "istio-system/ISTIOD-HOST.DOMAIN"
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: istiod-vs
+  namespace: istio-system
 spec:
   hosts:
   # use a valid gateway host and domain for istiod
@@ -69,7 +71,7 @@ spec:
         mode: SIMPLE
       connectionPool:
         http:
-          h2UpgradePolicy: UPGRADE        
+          h2UpgradePolicy: UPGRADE
     - port:
         number: 443
       tls:

--- a/samples/multicluster/expose-istiod.yaml
+++ b/samples/multicluster/expose-istiod.yaml
@@ -2,6 +2,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
   name: istiod-gateway
+  namespace: istio-system
 spec:
   selector:
     istio: eastwestgateway
@@ -11,22 +12,23 @@ spec:
         number: 15012
         protocol: tls
       tls:
-        mode: PASSTHROUGH        
+        mode: PASSTHROUGH
       hosts:
-        - "*"
+        - "istio-system/*"
     - port:
         name: tls-istiodwebhook
         number: 15017
         protocol: tls
       tls:
-        mode: PASSTHROUGH          
+        mode: PASSTHROUGH
       hosts:
-        - "*"
+        - "istio-system/*"
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: istiod-vs
+  namespace: istio-system
 spec:
   hosts:
   - "*"

--- a/samples/multicluster/expose-services.yaml
+++ b/samples/multicluster/expose-services.yaml
@@ -2,6 +2,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
   name: cross-network-gateway
+  namespace: istio-system
 spec:
   selector:
     istio: eastwestgateway

--- a/samples/tcp-echo/tcp-echo-all-v1.yaml
+++ b/samples/tcp-echo/tcp-echo-all-v1.yaml
@@ -16,6 +16,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
   name: tcp-echo-gateway
+  namespace: default
 spec:
   selector:
     istio: ingressgateway
@@ -31,6 +32,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
   name: tcp-echo-destination
+  namespace: default
 spec:
   host: tcp-echo
   subsets:
@@ -45,6 +47,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: tcp-echo
+  namespace: default
 spec:
   hosts:
   - "*"

--- a/samples/tcp-echo/tcp-echo-all-v1.yaml
+++ b/samples/tcp-echo/tcp-echo-all-v1.yaml
@@ -25,7 +25,7 @@ spec:
       name: tcp
       protocol: TCP
     hosts:
-    - "*"
+    - "default/*"
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule

--- a/samples/websockets/route.yaml
+++ b/samples/websockets/route.yaml
@@ -2,6 +2,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
   name: tornado-gateway
+  namespace: default
 spec:
   selector:
     istio: ingressgateway
@@ -17,6 +18,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: tornado
+  namespace: default
 spec:
   hosts:
   - "*"

--- a/samples/websockets/route.yaml
+++ b/samples/websockets/route.yaml
@@ -11,7 +11,7 @@ spec:
       name: http
       protocol: HTTP
     hosts:
-    - "*"
+    - "default/*"
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService


### PR DESCRIPTION
Gateways allow namespace bound virtual service selection (e.g.,
foo/foo.example.com). This is a good security best practice.

This patch spreads this usage to all samples to restrict the set of
virtual services that can bind to a gateway server.

Fixes https://github.com/istio/istio/issues/33977

Signed-off-by: Kailun Qin <kailun.qin@intel.com>

[ ] Configuration Infrastructure
[x] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
