### PR TITLE
Expose keepalive options to agent cmd line flags.

### DIFF
--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -33,6 +33,7 @@ import (
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/envoy"
 	istio_agent "istio.io/istio/pkg/istio-agent"
+	istiokeepalive "istio.io/istio/pkg/keepalive"
 	"istio.io/istio/pkg/security"
 	"istio.io/istio/pkg/util/gogoprotomarshal"
 	stsserver "istio.io/istio/security/pkg/stsservice/server"
@@ -66,6 +67,7 @@ var (
 	templateFile           string
 	loggingOptions         = log.DefaultOptions()
 	outlierLogPath         string
+	keepaliveOptions       = istiokeepalive.DefaultOption()
 
 	rootCmd = &cobra.Command{
 		Use:          "pilot-agent",
@@ -134,7 +136,7 @@ var (
 				Sidecar:           proxy.Type == model.SidecarProxy,
 				OutlierLogPath:    outlierLogPath,
 			}
-			agentOptions := options.NewAgentOptions(proxy, proxyConfig)
+			agentOptions := options.NewAgentOptions(proxy, proxyConfig, keepaliveOptions)
 			agent := istio_agent.NewAgent(proxyConfig, agentOptions, secOpts, envoyOptions)
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
@@ -185,6 +187,8 @@ func init() {
 		"Go template bootstrap config")
 	proxyCmd.PersistentFlags().StringVar(&outlierLogPath, "outlierLogPath", "",
 		"The log path for outlier detection")
+
+	keepaliveOptions.AttachCobraFlags(proxyCmd)
 
 	// Attach the Istio logging options to the command.
 	loggingOptions.AttachCobraFlags(rootCmd)

--- a/pilot/cmd/pilot-agent/options/agent.go
+++ b/pilot/cmd/pilot-agent/options/agent.go
@@ -23,17 +23,19 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/bootstrap/platform"
 	istioagent "istio.io/istio/pkg/istio-agent"
+	istiokeepalive "istio.io/istio/pkg/keepalive"
 )
 
 // Similar with ISTIO_META_, which is used to customize the node metadata - this customizes extra header.
 const xdsHeaderPrefix = "XDS_HEADER_"
 
-func NewAgentOptions(proxy *model.Proxy, cfg *meshconfig.ProxyConfig) *istioagent.AgentOptions {
+func NewAgentOptions(proxy *model.Proxy, cfg *meshconfig.ProxyConfig, options *istiokeepalive.Options) *istioagent.AgentOptions {
 	o := &istioagent.AgentOptions{
 		XDSRootCerts:             xdsRootCA,
 		CARootCerts:              caRootCA,
 		XDSHeaders:               map[string]string{},
 		XdsUdsPath:               filepath.Join(cfg.ConfigPath, "XDS"),
+		KeepaliveOptions:         options,
 		IsIPv6:                   proxy.SupportsIPv6(),
 		ProxyType:                proxy.Type,
 		EnableDynamicProxyConfig: enableProxyConfigXdsEnv,

--- a/pkg/istio-agent/agent.go
+++ b/pkg/istio-agent/agent.go
@@ -46,6 +46,7 @@ import (
 	dnsProto "istio.io/istio/pkg/dns/proto"
 	"istio.io/istio/pkg/envoy"
 	"istio.io/istio/pkg/istio-agent/grpcxds"
+	istiokeepalive "istio.io/istio/pkg/keepalive"
 	"istio.io/istio/pkg/security"
 	"istio.io/istio/security/pkg/nodeagent/cache"
 	"istio.io/istio/security/pkg/nodeagent/caclient"
@@ -162,6 +163,9 @@ type AgentOptions struct {
 
 	// Path to local UDS to communicate with Envoy
 	XdsUdsPath string
+
+	// Options defines the set of options used for grpc keepalive.
+	KeepaliveOptions *istiokeepalive.Options
 
 	// Ability to retrieve ProxyConfig dynamically through XDS
 	EnableDynamicProxyConfig bool


### PR DESCRIPTION
Signed-off-by: devincd <505259926@qq.com>


I need a place to configure grpc keepalive options when running the pilot-agent.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.