### PR TITLE
Fix incorrect remove in the rpm-7/fpm build step

### DIFF
--- a/tools/packaging/packaging.mk
+++ b/tools/packaging/packaging.mk
@@ -85,7 +85,7 @@ rpm/fpm:
 
 # Centos 7 compatible RPM
 rpm-7/fpm:
-	rm -f ${ISTIO_OUT_LINUX}/release/istio-sidecar.rpm
+	rm -f ${ISTIO_OUT_LINUX}/release/istio-sidecar-centos-7.rpm
 	fpm -s dir -t rpm -n ${SIDECAR_PACKAGE_NAME} -p ${ISTIO_OUT_LINUX}/release/istio-sidecar-centos-7.rpm --version $(PACKAGE_VERSION) -f \
 		--url http://istio.io  \
 		--license Apache \


### PR DESCRIPTION
The incorrect binary was removed before building the CentOS 7 RPM.
Remove the CentOS-7 RPM instead of the newer one.

[ X] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
