### PR TITLE
Handle CRDs created after Istio starts

### DIFF
--- a/pilot/pkg/config/aggregate/config.go
+++ b/pilot/pkg/config/aggregate/config.go
@@ -181,7 +181,7 @@ func (cr *storeCache) HasSynced() bool {
 	return true
 }
 
-func (cr *storeCache) RegisterEventHandler(kind config.GroupVersionKind, handler func(config.Config, config.Config, model.Event)) {
+func (cr *storeCache) RegisterEventHandler(kind config.GroupVersionKind, handler model.EventHandler) {
 	for _, cache := range cr.caches {
 		if _, exists := cache.Schemas().FindByGroupVersionKind(kind); exists {
 			cache.RegisterEventHandler(kind, handler)

--- a/pilot/pkg/config/kube/crdclient/cache_handler.go
+++ b/pilot/pkg/config/kube/crdclient/cache_handler.go
@@ -70,7 +70,7 @@ func (h *cacheHandler) onEvent(old interface{}, curr interface{}, event model.Ev
 }
 
 func createCacheHandler(cl *Client, schema collection.Schema, i informers.GenericInformer) *cacheHandler {
-	scope.Debugf("registered CRD %v", schema.Resource())
+	scope.Debugf("registered CRD %v", schema.Resource().GroupVersionKind())
 	h := &cacheHandler{
 		client:   cl,
 		schema:   schema,

--- a/pilot/pkg/config/kube/crdclient/cache_handler.go
+++ b/pilot/pkg/config/kube/crdclient/cache_handler.go
@@ -36,7 +36,6 @@ import (
 type cacheHandler struct {
 	client   *Client
 	informer cache.SharedIndexInformer
-	handlers []func(config.Config, config.Config, model.Event)
 	schema   collection.Schema
 	lister   func(namespace string) cache.GenericNamespaceLister
 }
@@ -64,13 +63,14 @@ func (h *cacheHandler) onEvent(old interface{}, curr interface{}, event model.Ev
 	}
 
 	// TODO we may consider passing a pointer to handlers instead of the value. While spec is a pointer, the meta will be copied
-	for _, f := range h.handlers {
+	for _, f := range h.client.handlers[h.schema.Resource().GroupVersionKind()] {
 		f(oldConfig, currConfig, event)
 	}
 	return nil
 }
 
 func createCacheHandler(cl *Client, schema collection.Schema, i informers.GenericInformer) *cacheHandler {
+	scope.Debugf("registered CRD %v", schema.Resource())
 	h := &cacheHandler{
 		client:   cl,
 		schema:   schema,

--- a/pilot/pkg/config/kube/crdclient/client.go
+++ b/pilot/pkg/config/kube/crdclient/client.go
@@ -57,6 +57,7 @@ import (
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/collection"
 	"istio.io/istio/pkg/config/schema/collections"
+	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/queue"
 	"istio.io/pkg/log"
@@ -78,8 +79,12 @@ type Client struct {
 	revision string
 
 	// kinds keeps track of all cache handlers for known types
-	kinds map[config.GroupVersionKind]*cacheHandler
-	queue queue.Instance
+	kinds   map[config.GroupVersionKind]*cacheHandler
+	kindsMu sync.RWMutex
+	queue   queue.Instance
+
+	// handlers defines a list of event handlers per-type
+	handlers map[config.GroupVersionKind][]model.EventHandler
 
 	// The istio/client-go client we will use to access objects
 	istioClient istioclient.Interface
@@ -90,7 +95,10 @@ type Client struct {
 	// beginSync is set to true when calling SyncAll, it indicates the controller has began sync resources.
 	beginSync *atomic.Bool
 	// initialSync is set to true after performing an initial processing of all objects.
-	initialSync *atomic.Bool
+	initialSync         *atomic.Bool
+	schemasByCRDName    map[string]collection.Schema
+	client              kube.Client
+	crdMetadataInformer cache.SharedIndexInformer
 }
 
 var _ model.ConfigStoreCache = &Client{}
@@ -104,16 +112,27 @@ func New(client kube.Client, revision, domainSuffix string) (model.ConfigStoreCa
 }
 
 func NewForSchemas(ctx context.Context, client kube.Client, revision, domainSuffix string, schemas collection.Schemas) (model.ConfigStoreCache, error) {
+	schemasByCRDName := map[string]collection.Schema{}
+	for _, s := range schemas.All() {
+		// From the spec: "Its name MUST be in the format <.spec.name>.<.spec.group>."
+		name := fmt.Sprintf("%s.%s", s.Resource().Plural(), s.Resource().Group())
+		schemasByCRDName[name] = s
+	}
 	out := &Client{
 		domainSuffix:     domainSuffix,
 		schemas:          schemas,
+		schemasByCRDName: schemasByCRDName,
 		revision:         revision,
 		queue:            queue.NewQueue(1 * time.Second),
 		kinds:            map[config.GroupVersionKind]*cacheHandler{},
+		handlers:         map[config.GroupVersionKind][]model.EventHandler{},
+		client:           client,
 		istioClient:      client.Istio(),
 		gatewayAPIClient: client.GatewayAPI(),
-		beginSync:        atomic.NewBool(false),
-		initialSync:      atomic.NewBool(false),
+		crdMetadataInformer: client.MetadataInformer().ForResource(collections.K8SApiextensionsK8SIoV1Customresourcedefinitions.Resource().
+			GroupVersionResource()).Informer(),
+		beginSync:   atomic.NewBool(false),
+		initialSync: atomic.NewBool(false),
 	}
 
 	known, err := knownCRDs(ctx, client.Ext())
@@ -124,20 +143,9 @@ func NewForSchemas(ctx context.Context, client kube.Client, revision, domainSuff
 		// From the spec: "Its name MUST be in the format <.spec.name>.<.spec.group>."
 		name := fmt.Sprintf("%s.%s", s.Resource().Plural(), s.Resource().Group())
 		if _, f := known[name]; f {
-			var i informers.GenericInformer
-			var err error
-			if s.Resource().Group() == "networking.x-k8s.io" {
-				i, err = client.GatewayAPIInformer().ForResource(s.Resource().GroupVersionResource())
-			} else {
-				i, err = client.IstioInformer().ForResource(s.Resource().GroupVersionResource())
-			}
-			if err != nil {
-				return nil, err
-			}
-			out.kinds[s.Resource().GroupVersionKind()] = createCacheHandler(out, s, i)
+			handleCRDAdd(out, name, nil)
 		} else {
 			scope.Warnf("Skipping CRD %v as it is not present", s.Resource().GroupVersionKind())
-			out.schemas = out.schemas.Remove(s)
 		}
 	}
 
@@ -156,18 +164,13 @@ func (cl *Client) checkReadyForEvents(curr interface{}) error {
 	return nil
 }
 
-func (cl *Client) RegisterEventHandler(kind config.GroupVersionKind, handler func(config.Config, config.Config, model.Event)) {
-	h, exists := cl.kinds[kind]
-	if !exists {
-		return
-	}
-
-	h.handlers = append(h.handlers, handler)
+func (cl *Client) RegisterEventHandler(kind config.GroupVersionKind, handler model.EventHandler) {
+	cl.handlers[kind] = append(cl.handlers[kind], handler)
 }
 
 func (cl *Client) SetWatchErrorHandler(handler func(r *cache.Reflector, err error)) error {
 	var errs error
-	for _, h := range cl.kinds {
+	for _, h := range cl.allKinds() {
 		if err := h.informer.SetWatchErrorHandler(handler); err != nil {
 			errs = multierror.Append(errs, err)
 		}
@@ -187,14 +190,29 @@ func (cl *Client) Run(stop <-chan struct{}) {
 	cl.SyncAll()
 	cl.initialSync.Store(true)
 	scope.Info("Pilot K8S CRD controller synced ", time.Since(t0))
+
+	cl.crdMetadataInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			crd, ok := obj.(*metav1.PartialObjectMetadata)
+			if !ok {
+				// Shouldn't happen
+				scope.Errorf("wrong type %T: %v", obj, obj)
+				return
+			}
+			handleCRDAdd(cl, crd.Name, stop)
+		},
+		UpdateFunc: nil,
+		DeleteFunc: nil,
+	})
+
 	cl.queue.Run(stop)
 	scope.Info("controller terminated")
 }
 
 func (cl *Client) informerSynced() bool {
-	for kind, ctl := range cl.kinds {
+	for _, ctl := range cl.allKinds() {
 		if !ctl.informer.HasSynced() {
-			scope.Infof("controller %q is syncing...", kind)
+			scope.Infof("controller %q is syncing...", ctl.schema.Resource().GroupVersionKind())
 			return false
 		}
 	}
@@ -209,8 +227,9 @@ func (cl *Client) HasSynced() bool {
 func (cl *Client) SyncAll() {
 	cl.beginSync.Store(true)
 	wg := sync.WaitGroup{}
-	for _, h := range cl.kinds {
-		if len(h.handlers) == 0 {
+	for _, h := range cl.allKinds() {
+		handlers := cl.handlers[h.schema.Resource().GroupVersionKind()]
+		if len(handlers) == 0 {
 			continue
 		}
 		h := h
@@ -225,7 +244,7 @@ func (cl *Client) SyncAll() {
 					continue
 				}
 				currConfig := *TranslateObject(currItem, h.schema.Resource().GroupVersionKind(), h.client.domainSuffix)
-				for _, f := range h.handlers {
+				for _, f := range handlers {
 					f(config.Config{}, currConfig, model.EventAdd)
 				}
 			}
@@ -241,7 +260,7 @@ func (cl *Client) Schemas() collection.Schemas {
 
 // Get implements store interface
 func (cl *Client) Get(typ config.GroupVersionKind, name, namespace string) *config.Config {
-	h, f := cl.kinds[typ]
+	h, f := cl.kind(typ)
 	if !f {
 		scope.Warnf("unknown type: %s", typ)
 		return nil
@@ -319,7 +338,7 @@ func (cl *Client) Delete(typ config.GroupVersionKind, name, namespace string, re
 
 // List implements store interface
 func (cl *Client) List(kind config.GroupVersionKind, namespace string) ([]config.Config, error) {
-	h, f := cl.kinds[kind]
+	h, f := cl.kind(kind)
 	if !f {
 		return nil, nil
 	}
@@ -347,6 +366,23 @@ func (cl *Client) objectInRevision(o *config.Config) bool {
 	}
 	// Otherwise, only return if the
 	return configEnv == cl.revision
+}
+
+func (cl *Client) allKinds() []*cacheHandler {
+	cl.kindsMu.RLock()
+	defer cl.kindsMu.RUnlock()
+	ret := make([]*cacheHandler, 0, len(cl.kinds))
+	for _, k := range cl.kinds {
+		ret = append(ret, k)
+	}
+	return ret
+}
+
+func (cl *Client) kind(r config.GroupVersionKind) (*cacheHandler, bool) {
+	cl.kindsMu.RLock()
+	defer cl.kindsMu.RUnlock()
+	ch, ok := cl.kinds[r]
+	return ch, ok
 }
 
 // knownCRDs returns all CRDs present in the cluster, with retries
@@ -422,4 +458,57 @@ func genPatchBytes(oldRes, modRes runtime.Object, patchType types.PatchType) ([]
 	default:
 		return nil, fmt.Errorf("unsupported patch type: %v. must be one of JSONPatchType or MergePatchType", patchType)
 	}
+}
+
+func handleCRDAdd(cl *Client, name string, stop <-chan struct{}) {
+	scope.Debugf("adding CRD %q", name)
+	s, f := cl.schemasByCRDName[name]
+	if !f {
+		scope.Debugf("added resource that we are not watching: %v", name)
+		return
+	}
+	resourceGVK := s.Resource().GroupVersionKind()
+	gvr := s.Resource().GroupVersionResource()
+
+	cl.kindsMu.Lock()
+	defer cl.kindsMu.Unlock()
+	if ch, f := cl.kinds[s.Resource().GroupVersionKind()]; f {
+		scope.Debugf("added resource that already exists: %v", resourceGVK)
+		// Wait for it to sync again. This ensures that SyncAll will properly wait
+		cache.WaitForCacheSync(nil, func() bool {
+			if ch.informer.HasSynced() {
+				return true
+			}
+			scope.Infof("waiting for %v to sync...", resourceGVK)
+			return false
+		})
+		return
+	}
+	var i informers.GenericInformer
+	var ifactory starter
+	var err error
+	if s.Resource().Group() == gvk.ServiceApisGateway.Group {
+		ifactory = cl.client.GatewayAPIInformer()
+		i, err = cl.client.GatewayAPIInformer().ForResource(gvr)
+	} else {
+		ifactory = cl.client.IstioInformer()
+		i, err = cl.client.IstioInformer().ForResource(gvr)
+	}
+
+	if err != nil {
+		// Shouldn't happen
+		scope.Errorf("failed to create informer for %v", resourceGVK)
+		return
+	}
+	cl.kinds[s.Resource().GroupVersionKind()] = createCacheHandler(cl, s, i)
+	if stop != nil {
+		// Start informer factory, only if stop is defined. In startup case, we will not start here as
+		// we will start all factories once we are ready to initialize.
+		// For dynamically added CRDs, we need to start immediately though
+		ifactory.Start(stop)
+	}
+}
+
+type starter interface {
+	Start(stopCh <-chan struct{})
 }

--- a/pilot/pkg/config/kube/crdclient/client.go
+++ b/pilot/pkg/config/kube/crdclient/client.go
@@ -472,16 +472,8 @@ func handleCRDAdd(cl *Client, name string, stop <-chan struct{}) {
 
 	cl.kindsMu.Lock()
 	defer cl.kindsMu.Unlock()
-	if ch, f := cl.kinds[s.Resource().GroupVersionKind()]; f {
+	if _, f := cl.kinds[resourceGVK]; f {
 		scope.Debugf("added resource that already exists: %v", resourceGVK)
-		// Wait for it to sync again. This ensures that SyncAll will properly wait
-		cache.WaitForCacheSync(nil, func() bool {
-			if ch.informer.HasSynced() {
-				return true
-			}
-			scope.Infof("waiting for %v to sync...", resourceGVK)
-			return false
-		})
 		return
 	}
 	var i informers.GenericInformer

--- a/pilot/pkg/config/kube/gateway/controller.go
+++ b/pilot/pkg/config/kube/gateway/controller.go
@@ -272,7 +272,7 @@ func (c *Controller) Delete(typ config.GroupVersionKind, name, namespace string,
 	return errUnsupportedOp
 }
 
-func (c *Controller) RegisterEventHandler(typ config.GroupVersionKind, handler func(config.Config, config.Config, model.Event)) {
+func (c *Controller) RegisterEventHandler(typ config.GroupVersionKind, handler model.EventHandler) {
 	// do nothing as c.cache has been registered
 }
 

--- a/pilot/pkg/config/kube/ingress/controller.go
+++ b/pilot/pkg/config/kube/ingress/controller.go
@@ -81,8 +81,8 @@ type controller struct {
 	domainSuffix string
 
 	queue                  queue.Instance
-	virtualServiceHandlers []func(config.Config, config.Config, model.Event)
-	gatewayHandlers        []func(config.Config, config.Config, model.Event)
+	virtualServiceHandlers []model.EventHandler
+	gatewayHandlers        []model.EventHandler
 
 	ingressInformer cache.SharedInformer
 	serviceInformer cache.SharedInformer
@@ -275,7 +275,7 @@ func (c *controller) onEvent(oldObj, curObj interface{}, event model.Event) erro
 	return nil
 }
 
-func (c *controller) RegisterEventHandler(kind config.GroupVersionKind, f func(config.Config, config.Config, model.Event)) {
+func (c *controller) RegisterEventHandler(kind config.GroupVersionKind, f model.EventHandler) {
 	switch kind {
 	case gvk.VirtualService:
 		c.virtualServiceHandlers = append(c.virtualServiceHandlers, f)

--- a/pilot/pkg/config/kube/ingressv1/controller.go
+++ b/pilot/pkg/config/kube/ingressv1/controller.go
@@ -80,8 +80,8 @@ type controller struct {
 	domainSuffix string
 
 	queue                  queue.Instance
-	virtualServiceHandlers []func(config.Config, config.Config, model.Event)
-	gatewayHandlers        []func(config.Config, config.Config, model.Event)
+	virtualServiceHandlers []model.EventHandler
+	gatewayHandlers        []model.EventHandler
 
 	ingressInformer cache.SharedInformer
 	serviceInformer cache.SharedInformer
@@ -230,7 +230,7 @@ func (c *controller) onEvent(oldObj, curObj interface{}, event model.Event) erro
 	return nil
 }
 
-func (c *controller) RegisterEventHandler(kind config.GroupVersionKind, f func(config.Config, config.Config, model.Event)) {
+func (c *controller) RegisterEventHandler(kind config.GroupVersionKind, f model.EventHandler) {
 	switch kind {
 	case gvk.VirtualService:
 		c.virtualServiceHandlers = append(c.virtualServiceHandlers, f)

--- a/pilot/pkg/config/memory/controller.go
+++ b/pilot/pkg/config/memory/controller.go
@@ -51,7 +51,7 @@ func NewSyncController(cs model.ConfigStore) model.ConfigStoreCache {
 	return out
 }
 
-func (c *controller) RegisterEventHandler(kind config.GroupVersionKind, f func(config.Config, config.Config, model.Event)) {
+func (c *controller) RegisterEventHandler(kind config.GroupVersionKind, f model.EventHandler) {
 	c.monitor.AppendEventHandler(kind, f)
 }
 

--- a/pilot/pkg/model/config.go
+++ b/pilot/pkg/model/config.go
@@ -153,6 +153,8 @@ type ConfigStore interface {
 	Delete(typ config.GroupVersionKind, name, namespace string, resourceVersion *string) error
 }
 
+type EventHandler = func(config.Config, config.Config, Event)
+
 // ConfigStoreCache is a local fully-replicated cache of the config store.  The
 // cache actively synchronizes its local state with the remote store and
 // provides a notification mechanism to receive update events. As such, the
@@ -171,7 +173,7 @@ type ConfigStoreCache interface {
 
 	// RegisterEventHandler adds a handler to receive config update events for a
 	// configuration type
-	RegisterEventHandler(kind config.GroupVersionKind, handler func(config.Config, config.Config, Event))
+	RegisterEventHandler(kind config.GroupVersionKind, handler EventHandler)
 
 	// Run until a signal is received
 	Run(stop <-chan struct{})

--- a/pkg/config/schema/collections/collections.gen.go
+++ b/pkg/config/schema/collections/collections.gen.go
@@ -321,7 +321,7 @@ var (
 		Resource: resource.Builder{
 			Group:         "apiextensions.k8s.io",
 			Kind:          "CustomResourceDefinition",
-			Plural:        "CustomResourceDefinitions",
+			Plural:        "customresourcedefinitions",
 			Version:       "v1",
 			Proto:         "k8s.io.apiextensions_apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinition",
 			ReflectType:   reflect.TypeOf(&k8sioapiextensionsapiserverpkgapisapiextensionsv1.CustomResourceDefinition{}).Elem(),

--- a/pkg/config/schema/metadata.gen.go
+++ b/pkg/config/schema/metadata.gen.go
@@ -311,7 +311,7 @@ snapshots:
 resources:
   # Kubernetes specific configuration.
   - kind: "CustomResourceDefinition"
-    plural: "CustomResourceDefinitions"
+    plural: "customresourcedefinitions"
     group: "apiextensions.k8s.io"
     version: "v1"
     proto: "k8s.io.apiextensions_apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinition"

--- a/pkg/config/schema/metadata.yaml
+++ b/pkg/config/schema/metadata.yaml
@@ -256,7 +256,7 @@ snapshots:
 resources:
   # Kubernetes specific configuration.
   - kind: "CustomResourceDefinition"
-    plural: "CustomResourceDefinitions"
+    plural: "customresourcedefinitions"
     group: "apiextensions.k8s.io"
     version: "v1"
     proto: "k8s.io.apiextensions_apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinition"

--- a/pkg/kube/secretcontroller/secretcontroller.go
+++ b/pkg/kube/secretcontroller/secretcontroller.go
@@ -308,7 +308,6 @@ func (c *Controller) hasSynced() bool {
 func (c *Controller) HasSynced() bool {
 	synced := c.hasSynced()
 	if synced {
-		log.Info("all remote clusters have been synced")
 		return true
 	}
 	if c.remoteSyncTimeout.Load() {

--- a/tests/integration/pilot/ingress_test.go
+++ b/tests/integration/pilot/ingress_test.go
@@ -52,6 +52,13 @@ func TestGateway(t *testing.T) {
 			if !supportsCRDv1(t) {
 				t.Skip("Not supported; requires CRDv1 support.")
 			}
+			crd, err := ioutil.ReadFile("testdata/service-apis-crd.yaml")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := t.Config().ApplyYAMLNoCleanup("", string(crd)); err != nil {
+				t.Fatal(err)
+			}
 			t.Config().ApplyYAMLOrFail(t, "", `
 apiVersion: networking.x-k8s.io/v1alpha1
 kind: GatewayClass

--- a/tests/integration/pilot/main_test.go
+++ b/tests/integration/pilot/main_test.go
@@ -16,7 +16,6 @@
 package pilot
 
 import (
-	"io/ioutil"
 	"testing"
 
 	"istio.io/istio/pkg/config/protocol"
@@ -52,16 +51,6 @@ func supportsCRDv1(t resource.Context) bool {
 func TestMain(m *testing.M) {
 	framework.
 		NewSuite(m).
-		Setup(func(t resource.Context) (err error) {
-			if supportsCRDv1(t) {
-				crd, err := ioutil.ReadFile("testdata/service-apis-crd.yaml")
-				if err != nil {
-					return err
-				}
-				return t.Config().ApplyYAMLNoCleanup("", string(crd))
-			}
-			return nil
-		}).
 		Setup(istio.Setup(&i, nil)).
 		Setup(func(t resource.Context) error {
 			return common.SetupApps(t, i, apps)


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/30834

This is especially useful as we add support for more third party CRDs
(gateway-api and MCS). Currently, using these resources requires a
restart of Istiod. In normal cases, this is not ideal. In worst case
(external Istiod) this is impossible.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.