### PR TITLE
Istio-hostnetwork

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -60,6 +60,9 @@ spec:
 {{- end }}
       securityContext:
         fsGroup: 1337
+      {{- if .Values.istiod.hostNetwork }}
+      hostNetwork: true
+      {{- end }}
       containers:
         - name: discovery
 {{- if contains "/" .Values.pilot.image }}

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -63,6 +63,10 @@ pilot:
   # If false, pilot wil use default values (by default) or user-supplied values.
   configMap: true
 
+## Ability to run istiod on a hostnetwork. 
+istiod:
+  hostNetwork: false
+
 
 sidecarInjectorWebhook:
   # If enabled, the legacy webhook selection logic will be used. This relies on filtering of webhook


### PR DESCRIPTION
Ability to run istiod pods on hostnetwork, while using helm charts for deploying them.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.