### PR TITLE
fix: StatusInfo synced add Lock

### DIFF
--- a/pkg/mcp/snapshot/snapshot.go
+++ b/pkg/mcp/snapshot/snapshot.go
@@ -122,7 +122,9 @@ func (c *Cache) Watch(
 			pushResponse(response)
 			return nil
 		}
+		info.mu.Lock()
 		info.synced[request.Collection][peerAddr] = true
+		info.mu.Unlock()
 	}
 
 	// Otherwise, open a watch if no snapshot was available or the requested version is up-to-date.
@@ -157,11 +159,14 @@ func (c *Cache) fillStatus(group string, request *source.Request, peerAddr strin
 		}
 		peerStatus := make(map[string]bool)
 		peerStatus[peerAddr] = false
+		info.mu.Lock()
 		info.synced[request.Collection] = peerStatus
+		info.mu.Unlock()
 		c.status[group] = info
 	} else {
 		collectionExists := false
 		peerExists := false
+		info.mu.Lock()
 		for collection, synced := range info.synced {
 			if collection == request.Collection {
 				collectionExists = true
@@ -185,6 +190,7 @@ func (c *Cache) fillStatus(group string, request *source.Request, peerAddr strin
 		if !peerExists {
 			info.synced[request.Collection][peerAddr] = false
 		}
+		info.mu.Unlock()
 	}
 
 	// update last responseWatch request time


### PR DESCRIPTION
Please provide a description for what this PR is for.

`StatusInfo` structure has a `RWMutex` lock, and its field `watches` and `lastWatchRequestTime` all have mutex locked when read or write, i think field `synced` read or write should also be protected just like two other fields


And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
