### PR TITLE
Add validation for service entry port.targetPort

### DIFF
--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -2935,6 +2935,13 @@ var ValidateServiceEntry = registerValidateFunc("ValidateServiceEntry",
 				errs = appendValidation(errs, fmt.Errorf("service entry port %d already defined", port.Number))
 			}
 			servicePortNumbers[port.Number] = true
+			if port.TargetPort != 0 {
+				errs = appendValidation(errs, ValidatePort(int(port.TargetPort)))
+			}
+			errs = appendValidation(errs,
+				ValidatePortName(port.Name),
+				ValidateProtocol(port.Protocol),
+				ValidatePort(int(port.Number)))
 		}
 
 		switch serviceEntry.Resolution {
@@ -3036,17 +3043,6 @@ var ValidateServiceEntry = registerValidateFunc("ValidateServiceEntry",
 			if !canDifferentiate {
 				errs = appendValidation(errs, fmt.Errorf("multiple hosts provided with non-HTTP, non-TLS ports"))
 			}
-		}
-
-		for _, port := range serviceEntry.Ports {
-			if port == nil {
-				errs = appendValidation(errs, errors.New("port may not be null"))
-				continue
-			}
-			errs = appendValidation(errs,
-				ValidatePortName(port.Name),
-				ValidateProtocol(port.Protocol),
-				ValidatePort(int(port.Number)))
 		}
 
 		errs = appendValidation(errs, validateExportTo(cfg.Namespace, serviceEntry.ExportTo, true))

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -4317,6 +4317,37 @@ func TestValidateServiceEntries(t *testing.T) {
 			},
 			valid: false,
 		},
+		{
+			name: "repeat target port", in: networking.ServiceEntry{
+				Hosts:            []string{"google.com"},
+				WorkloadSelector: &networking.WorkloadSelector{Labels: map[string]string{"key": "bar"}},
+				Ports: []*networking.Port{
+					{Number: 80, Protocol: "http", Name: "http-valid1", TargetPort: 80},
+					{Number: 81, Protocol: "http", Name: "http-valid2", TargetPort: 80},
+				},
+			},
+			valid: true,
+		},
+		{
+			name: "valid target port", in: networking.ServiceEntry{
+				Hosts:            []string{"google.com"},
+				WorkloadSelector: &networking.WorkloadSelector{Labels: map[string]string{"key": "bar"}},
+				Ports: []*networking.Port{
+					{Number: 80, Protocol: "http", Name: "http-valid1", TargetPort: 81},
+				},
+			},
+			valid: true,
+		},
+		{
+			name: "invalid target port", in: networking.ServiceEntry{
+				Hosts:            []string{"google.com"},
+				WorkloadSelector: &networking.WorkloadSelector{Labels: map[string]string{"key": "bar"}},
+				Ports: []*networking.Port{
+					{Number: 80, Protocol: "http", Name: "http-valid1", TargetPort: 65536},
+				},
+			},
+			valid: false,
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
1）if targetport is set, add validation for targetPort
2）move ports parameter validation to the same for loop

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
