### PR TITLE
fix delayQueue retry time not reaching the max cannot print reaching max logs

### DIFF
--- a/pkg/mcp/status/status.go
+++ b/pkg/mcp/status/status.go
@@ -50,7 +50,7 @@ func (se *statusError) Error() string {
 	return fmt.Sprintf("rpc error: code = %s desc = %s", codes.Code(p.GetCode()), p.GetMessage())
 }
 
-// Status converts the gogo/statusError to a grpc/status.
+// GRPCStatus converts the gogo/statusError to a grpc/status.
 func (se *statusError) GRPCStatus() *status.Status {
 	p := (*rpc.Status)(se)
 	s := &spb.Status{
@@ -131,7 +131,6 @@ func ErrorProto(s *rpc.Status) error {
 }
 
 // FromProto returns a Status representing s.
-// nolint: interfacer
 func FromProto(s *rpc.Status) *Status {
 	return &Status{s: proto.Clone(s).(*rpc.Status)}
 }

--- a/pkg/mcp/testing/groups/groups.go
+++ b/pkg/mcp/testing/groups/groups.go
@@ -21,7 +21,7 @@ import (
 // Default used for testing
 var Default = "default"
 
-// DefaultGroupIndexFn used for testing.
+// DefaultIndexFn used for testing.
 func DefaultIndexFn(_ string, _ *mcp.SinkNode) string {
 	return Default
 }

--- a/pkg/queue/delay.go
+++ b/pkg/queue/delay.go
@@ -236,6 +236,7 @@ func (d *delayQueue) work(stop <-chan struct{}) {
 					d.Push(t.do)
 					t.retries++
 					log.Warnf("Work item handle failed: %v %d times, retry it", err, t.retries)
+					continue
 				}
 				log.Errorf("Work item handle failed: %v, reaching the maximum retry times: %d, drop it", err, maxTaskRetry)
 			}

--- a/pkg/security/security.go
+++ b/pkg/security/security.go
@@ -31,10 +31,10 @@ const (
 	// i.e. mounted Secret or external plugin.
 	// If present, FileMountedCerts should be true.
 
-	// The well-known path for an existing certificate chain file
+	// DefaultCertChainFilePath is the well-known path for an existing certificate chain file
 	DefaultCertChainFilePath = "./etc/certs/cert-chain.pem"
 
-	// The well-known path for an existing key file
+	// DefaultKeyFilePath is the well-known path for an existing key file
 	DefaultKeyFilePath = "./etc/certs/key.pem"
 
 	// DefaultRootCertFilePath is the well-known path for an existing root certificate file
@@ -63,7 +63,7 @@ const (
 // they should be dynamic to allow migrations without restart.
 // Both are critical.
 var (
-	// Require 3P TOKEN disables the use of K8S 1P tokens. Note that 1P tokens can be used to request
+	// Require3PToken disables the use of K8S 1P tokens. Note that 1P tokens can be used to request
 	// 3P TOKENS. A 1P token is the token automatically mounted by Kubelet and used for authentication with
 	// the Apiserver.
 	Require3PToken = env.RegisterBoolVar("REQUIRE_3P_TOKEN", false,
@@ -265,7 +265,7 @@ type CredFetcher interface {
 	// GetType returns credential fetcher type. Currently the supported type is "GoogleComputeEngine".
 	GetType() string
 
-	// The name of the IdentityProvider that can authenticate the workload credential.
+	// GetIdentityProvider returns the name of the IdentityProvider that can authenticate the workload credential.
 	GetIdentityProvider() string
 
 	// Stop releases resources and cleans up.


### PR DESCRIPTION
Please provide a description for what this PR is for.
1. when delayQueue retry times does't reach the max retry times, we could not print `reaching the maximum retry times` logs
so add `continue` operation when not reach the max retry times
2. fix some comments

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
