### PR TITLE
fix spiffe possible memory leak

### DIFF
--- a/pkg/spiffe/spiffe.go
+++ b/pkg/spiffe/spiffe.go
@@ -214,6 +214,11 @@ func RetrieveSpiffeBundleRootCerts(config map[string]string, caCertPool *x509.Ce
 		retryBackoffTime := firstRetryBackOffTime
 		startTime := time.Now()
 		var resp *http.Response
+		defer func() {
+			if resp != nil {
+				resp.Body.Close()
+			}
+		}()
 		for {
 			resp, err = httpClient.Get(endpoint)
 			var errMsg string
@@ -239,7 +244,6 @@ func RetrieveSpiffeBundleRootCerts(config map[string]string, caCertPool *x509.Ce
 			time.Sleep(retryBackoffTime)
 			retryBackoffTime *= 2 // Exponentially increase the retry backoff time.
 		}
-		defer resp.Body.Close()
 
 		doc := new(bundleDoc)
 		if err := json.NewDecoder(resp.Body).Decode(doc); err != nil {


### PR DESCRIPTION
only when the http Get operation is successful, `defer resp.Body.Close()` will be triggered.
And during the `for` loop, if timeout occurs, we will return directly without close `resp.Body`,
And this return may be triggered if the `resp.StatusCode != http.StatusOK`, and on this circumstance `resp.Body` is also not-nil, so we should release `Body` resource


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.