### PR TITLE
[release-1.10] Update base image

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -22,7 +22,7 @@ SHELL := /bin/bash -o pipefail
 export VERSION ?= 1.10-dev
 
 # Base version of Istio image to use
-BASE_VERSION ?= 1.10-dev.7
+BASE_VERSION ?= 1.10-dev.8
 
 export GO111MODULE ?= on
 export GOPROXY ?= https://proxy.golang.org


### PR DESCRIPTION

The base image was updated by the release tooling and the PR create failed. This is a manual PR to update the image. We need to update the image else, the next failing scan will try and create these images again and fail resulting in a non-build.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.