### PR TITLE
fix defer close resp body

### DIFF
--- a/pkg/util/gogo/conversion.go
+++ b/pkg/util/gogo/conversion.go
@@ -35,7 +35,6 @@ func MessageToAnyWithError(msg proto.Message) (*any.Any, error) {
 		return nil, err
 	}
 	return &any.Any{
-		// nolint: staticcheck
 		TypeUrl: "type.googleapis.com/" + proto.MessageName(msg),
 		Value:   b.Bytes(),
 	}, nil

--- a/pkg/util/gogoprotomarshal/protomarshal.go
+++ b/pkg/util/gogoprotomarshal/protomarshal.go
@@ -100,8 +100,8 @@ func ApplyYAML(yml string, pb proto.Message) error {
 	return ApplyJSON(string(js), pb)
 }
 
-// ApplyYAML unmarshals a YAML string into a proto message.
-// Unknown fields are notallowed.
+// ApplyYAMLStrict unmarshals a YAML string into a proto message.
+// Unknown fields are not allowed.
 func ApplyYAMLStrict(yml string, pb proto.Message) error {
 	js, err := yaml.YAMLToJSON([]byte(yml))
 	if err != nil {

--- a/pkg/wasm/httpfetcher.go
+++ b/pkg/wasm/httpfetcher.go
@@ -59,8 +59,8 @@ func (f *HTTPFetcher) Fetch(url string, timeout time.Duration) ([]byte, error) {
 			continue
 		}
 		if resp.StatusCode == http.StatusOK {
-			defer resp.Body.Close()
 			body, err := ioutil.ReadAll(resp.Body)
+			resp.Body.Close()
 			return body, err
 		}
 		lastError = fmt.Errorf("wasm module download request failed: status code %v", resp.StatusCode)

--- a/pkg/webhooks/validation/controller/controller.go
+++ b/pkg/webhooks/validation/controller/controller.go
@@ -69,7 +69,7 @@ type Options struct {
 func (o Options) Validate() error {
 	var errs *multierror.Error
 	if o.WatchedNamespace == "" || !labels.IsDNS1123Label(o.WatchedNamespace) {
-		errs = multierror.Append(errs, fmt.Errorf("invalid namespace: %q", o.WatchedNamespace)) // nolint: lll
+		errs = multierror.Append(errs, fmt.Errorf("invalid namespace: %q", o.WatchedNamespace))
 	}
 	if o.ServiceName == "" || !labels.IsDNS1123Label(o.ServiceName) {
 		errs = multierror.Append(errs, fmt.Errorf("invalid service name: %q", o.ServiceName))
@@ -80,7 +80,7 @@ func (o Options) Validate() error {
 	return errs.ErrorOrNil()
 }
 
-// String produces a stringified version of the arguments for debugging.
+// String produces a string field version of the arguments for debugging.
 func (o Options) String() string {
 	buf := &bytes.Buffer{}
 	_, _ = fmt.Fprintf(buf, "WatchedNamespace: %v\n", o.WatchedNamespace)


### PR DESCRIPTION
Please provide a description for what this PR is for.

1. fix using `defer` to close `resp.Body` in the loop, just `Close` `Body` directly instead
And another branches of this function all adopt the direct way to release resource but not in the `defer` function
2. fix some comments

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
