### PR TITLE
fix duplicate loop of startCaBundleWatcher

### DIFF
--- a/pkg/webhooks/webhookpatch.go
+++ b/pkg/webhooks/webhookpatch.go
@@ -197,14 +197,10 @@ func (w *WebhookCertPatcher) startCaBundleWatcher(stop <-chan struct{}) {
 				break
 			}
 			whcList := lists.(*v1.MutatingWebhookConfigurationList)
-			var whcNameList []string
 			for _, whc := range whcList.Items {
-				whcNameList = append(whcNameList, whc.Name)
-			}
-			for _, whcName := range whcNameList {
-				log.Debugf("updating caBundle for webhook %q", whcName)
+				log.Debugf("updating caBundle for webhook %q", whc.Name)
 				w.queue.Push(func() error {
-					return w.webhookPatchTask(whcName)
+					return w.webhookPatchTask(whc.Name)
 				})
 			}
 		case <-stop:


### PR DESCRIPTION
Please provide a description for what this PR is for.
remove duplicate `for-range` loop, we don't need to range twice, just only need range once to update caBundle for webhook

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
