### PR TITLE
enable mTLS from proxyless gRPC clients

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -962,6 +962,8 @@ data:
             env:
             - name: "GRPC_XDS_BOOTSTRAP"
               value: "/var/lib/istio/data/grpc-bootstrap.json"
+            - name: "GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT"
+              value: "/var/lib/istio/data/grpc-bootstrap.json"
             volumeMounts:
             - mountPath: /var/lib/istio/data
               name: istio-data
@@ -990,8 +992,6 @@ data:
           {{- end }}
             env:
             - name: "GRPC_XDS_BOOTSTRAP"
-              value: "/var/lib/istio/data/grpc-bootstrap.json"
-            - name: "GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT"
               value: "/var/lib/istio/data/grpc-bootstrap.json"
             - name: ISTIO_META_GENERATOR
               value: grpc

--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -991,6 +991,8 @@ data:
             env:
             - name: "GRPC_XDS_BOOTSTRAP"
               value: "/var/lib/istio/data/grpc-bootstrap.json"
+            - name: "GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT"
+              value: "/var/lib/istio/data/grpc-bootstrap.json"
             - name: ISTIO_META_GENERATOR
               value: grpc
             - name: OUTPUT_CERTS

--- a/manifests/charts/istio-control/istio-discovery/files/grpc-agent.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/grpc-agent.yaml
@@ -15,6 +15,8 @@ spec:
     env:
     - name: "GRPC_XDS_BOOTSTRAP"
       value: "/var/lib/istio/data/grpc-bootstrap.json"
+    - name: "GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT"
+      value: "/var/lib/istio/data/grpc-bootstrap.json"
     volumeMounts:
     - mountPath: /var/lib/istio/data
       name: istio-data

--- a/pilot/pkg/networking/grpcgen/cds.go
+++ b/pilot/pkg/networking/grpcgen/cds.go
@@ -220,13 +220,15 @@ func (b *clusterBuilder) applyLoadBalancing(_ *cluster.Cluster, policy *networki
 }
 
 func (b *clusterBuilder) applyTLS(c *cluster.Cluster, policy *networking.TrafficPolicy) {
-	// TODO check for automtls
-	mode := networking.ClientTLSSettings_ISTIO_MUTUAL
+	// TODO for now, we leave mTLS *off* by default:
+	// 1. We don't know if the client uses xds.NewClientCredentials; these settings will be ignored if not
+	// 2. We cannot reach servers in PERMISSIVE mode; gRPC doesn't allow us to override the alpn to one of Istio's
+	// 3. Once we support gRPC servers, we have no good way to detect if a server is implemented with xds.NewGrpcServer and will actually support our config
+	// For these reasons, support only explicit tls configuration.
+	mode := networking.ClientTLSSettings_DISABLE
 	if settings := policy.GetTls(); settings != nil {
 		mode = settings.GetMode()
 	}
-
-	log.Infof("grpc cds: tls mode for %s: %s", b.node.ID, mode.String())
 
 	switch mode {
 	case networking.ClientTLSSettings_DISABLE:

--- a/pilot/pkg/networking/grpcgen/cds.go
+++ b/pilot/pkg/networking/grpcgen/cds.go
@@ -200,7 +200,7 @@ func (b *clusterBuilder) applyDestinationRule(defaultCluster *cluster.Cluster) (
 // applyTrafficPolicy mutates the give cluster (if not-nil) so that the given merged traffic policy applies.
 func (b *clusterBuilder) applyTrafficPolicy(c *cluster.Cluster, trafficPolicy *networking.TrafficPolicy) {
 	// cluster can be nil if it wasn't requested
-	if c == nil || trafficPolicy == nil {
+	if c == nil {
 		return
 	}
 	b.applyTLS(c, trafficPolicy)
@@ -209,7 +209,7 @@ func (b *clusterBuilder) applyTrafficPolicy(c *cluster.Cluster, trafficPolicy *n
 }
 
 func (b *clusterBuilder) applyLoadBalancing(_ *cluster.Cluster, policy *networking.TrafficPolicy) {
-	switch policy.LoadBalancer.GetSimple() {
+	switch policy.GetLoadBalancer().GetSimple() {
 	case networking.LoadBalancerSettings_ROUND_ROBIN:
 	// ok
 	default:
@@ -225,6 +225,8 @@ func (b *clusterBuilder) applyTLS(c *cluster.Cluster, policy *networking.Traffic
 	if settings := policy.GetTls(); settings != nil {
 		mode = settings.GetMode()
 	}
+
+	log.Infof("grpc cds: tls mode for %s: %s", b.node.ID, mode.String())
 
 	switch mode {
 	case networking.ClientTLSSettings_DISABLE:

--- a/pilot/pkg/networking/grpcgen/cds.go
+++ b/pilot/pkg/networking/grpcgen/cds.go
@@ -225,12 +225,7 @@ func (b *clusterBuilder) applyTLS(c *cluster.Cluster, policy *networking.Traffic
 	// 2. We cannot reach servers in PERMISSIVE mode; gRPC doesn't allow us to override the alpn to one of Istio's
 	// 3. Once we support gRPC servers, we have no good way to detect if a server is implemented with xds.NewGrpcServer and will actually support our config
 	// For these reasons, support only explicit tls configuration.
-	mode := networking.ClientTLSSettings_DISABLE
-	if settings := policy.GetTls(); settings != nil {
-		mode = settings.GetMode()
-	}
-
-	switch mode {
+	switch policy.GetTls().GetMode() {
 	case networking.ClientTLSSettings_DISABLE:
 		// nothing to do
 	case networking.ClientTLSSettings_SIMPLE:

--- a/pkg/istio-agent/grpcxds/grpc_bootstrap.go
+++ b/pkg/istio-agent/grpcxds/grpc_bootstrap.go
@@ -17,13 +17,13 @@ package grpcxds
 import (
 	"encoding/json"
 	"fmt"
-	"google.golang.org/protobuf/encoding/protojson"
 	"io/ioutil"
 	"os"
 	"path"
 	"time"
 
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/structpb"
 
@@ -148,7 +148,7 @@ func GenerateBootstrap(opts GenerateBootstrapOptions) (*Bootstrap, error) {
 					PrivateKeyFile:    path.Join(opts.CertDir, "key.pem"),
 					CertificateFile:   path.Join(opts.CertDir, "cert-chain.pem"),
 					CACertificateFile: path.Join(opts.CertDir, "root-cert.pem"),
-					RefreshDuration: refresh,
+					RefreshDuration:   refresh,
 				},
 			},
 		}

--- a/pkg/istio-agent/grpcxds/grpc_bootstrap.go
+++ b/pkg/istio-agent/grpcxds/grpc_bootstrap.go
@@ -51,8 +51,8 @@ type XdsServer struct {
 }
 
 type CertificateProvider struct {
-	Name   string      `json:"name,omitempty"`
-	Config interface{} `json:"config,omitempty"`
+	PluginName string      `json:"plugin_name,omitempty"`
+	Config     interface{} `json:"config,omitempty"`
 }
 
 const FileWatcherCertProviderName = "file_watcher"
@@ -74,7 +74,7 @@ func (b *Bootstrap) FileWatcherProvider() *FileWatcherCertProviderConfig {
 		return nil
 	}
 	for _, provider := range b.CertProviders {
-		if provider.Name == FileWatcherCertProviderName {
+		if provider.PluginName == FileWatcherCertProviderName {
 			cfg, ok := provider.Config.(FileWatcherCertProviderConfig)
 			if !ok {
 				return nil
@@ -136,7 +136,7 @@ func GenerateBootstrap(opts GenerateBootstrapOptions) (*Bootstrap, error) {
 	if opts.CertDir != "" {
 		bootstrap.CertProviders = map[string]CertificateProvider{
 			"default": {
-				Name: "file_watcher",
+				PluginName: "file_watcher",
 				Config: FileWatcherCertProviderConfig{
 					PrivateKeyFile:    path.Join(opts.CertDir, "key.pem"),
 					CertificateFile:   path.Join(opts.CertDir, "cert-chain.pem"),

--- a/pkg/istio-agent/testdata/grpc-bootstrap.json
+++ b/pkg/istio-agent/testdata/grpc-bootstrap.json
@@ -20,14 +20,12 @@
   },
   "certificate_providers": {
     "default": {
-      "name": "file_watcher",
+      "plugin_name": "file_watcher",
       "config": {
         "certificate_file": "/cert/path/cert-chain.pem",
         "private_key_file": "/cert/path/key.pem",
         "ca_certificate_file": "/cert/path/root-cert.pem",
-        "refresh_interval": {
-          "seconds": 900
-        }
+        "refresh_interval": "900s"
       }
     }
   }

--- a/pkg/test/echo/server/forwarder/protocol.go
+++ b/pkg/test/echo/server/forwarder/protocol.go
@@ -23,8 +23,6 @@ import (
 	"crypto/x509/pkix"
 	"encoding/asn1"
 	"fmt"
-	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/grpc/credentials/xds"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -37,6 +35,8 @@ import (
 	"golang.org/x/net/http2"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/credentials/xds"
 
 	"istio.io/istio/pkg/test/echo/common"
 	"istio.io/istio/pkg/test/echo/common/scheme"

--- a/pkg/test/echo/server/forwarder/protocol.go
+++ b/pkg/test/echo/server/forwarder/protocol.go
@@ -23,6 +23,8 @@ import (
 	"crypto/x509/pkix"
 	"encoding/asn1"
 	"fmt"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/credentials/xds"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -156,7 +158,7 @@ func newProtocol(cfg Config) (protocol, error) {
 	if cfg.Request.FollowRedirects {
 		redirectFn = nil
 	}
-	switch scheme.Instance(urlScheme) {
+	switch s := scheme.Instance(urlScheme); s {
 	case scheme.HTTP, scheme.HTTPS:
 		if cfg.Request.Alpn == nil {
 			tlsConfig.NextProtos = []string{"http/1.1"}
@@ -215,6 +217,13 @@ func newProtocol(cfg Config) (protocol, error) {
 
 		// transport security
 		security := grpc.WithInsecure()
+		if s == scheme.XDS {
+			creds, err := xds.NewClientCredentials(xds.ClientOptions{FallbackCreds: insecure.NewCredentials()})
+			if err != nil {
+				return nil, err
+			}
+			security = grpc.WithTransportCredentials(creds)
+		}
 		if getClientCertificate != nil {
 			security = grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))
 		}

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -1444,8 +1444,9 @@ func protocolSniffingCases() []TrafficTestCase {
 				Timeout:  time.Second * 5,
 			},
 			validate: func(src echo.Caller, dst echo.Instances) echo.Validator {
-				if call.scheme == scheme.TCP {
+				if call.scheme == scheme.TCP || src.(echo.Instance).Config().IsProxylessGRPC() {
 					// no host header for TCP
+					// TODO understand why proxyless adds the port to :authority md
 					return echo.ExpectOK()
 				}
 				return echo.And(


### PR DESCRIPTION
* Set the experimental flag
* Build proper transport credential
* Cleanup CDS
* Cleanup bootstrap:
  * correct plugin name
  * properly marshal durationpb  

---

Tested with:

```
apiVersion: security.istio.io/v1beta1
kind: PeerAuthentication
metadata:
  name: "default"
spec:
  mtls:
    mode: STRICT
```

Before, we'd not even attempt TLS and the request would fail. This change gets me a successful request to a workload running envoy, with TLS. 

![Screen Shot 2021-07-16 at 12 18 46 PM](https://user-images.githubusercontent.com/16195656/125998201-74291914-b8d7-4302-976d-0053ba4ee07c.png)

---

Planning to add proxyless to the security reachabilty suite in a follow up

