### PR TITLE
Fix lint error of install-cni CLI description.

### DIFF
--- a/cni/pkg/cmd/root.go
+++ b/cni/pkg/cmd/root.go
@@ -45,7 +45,7 @@ var (
 
 var rootCmd = &cobra.Command{
 	Use:   "install-cni",
-	Short: "Install and configure Istio CNI plugin on a node, detect and repair pod which is broken by race condition",
+	Short: "Install and configure Istio CNI plugin on a node, detect and repair pod which is broken by race condition.",
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		if err := log.Configure(logOptions); err != nil {
 			log.Errorf("Failed to configure log %v", err)


### PR DESCRIPTION
Get a lint error when adding install-cni CLI reference: https://github.com/istio/istio.io/pull/10087 because of missing period.