### PR TITLE
Fix non-deterministic behavior in multi-network code

### DIFF
--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -548,7 +548,8 @@ type ServiceDiscovery interface {
 	// Deprecated - service account tracking moved to XdsServer, incremental.
 	GetIstioServiceAccounts(svc *Service, ports []int) []string
 
-	// NetworkManager returns a list of network gateways that can be used to access endpoints residing in this registry..
+	// NetworkGateways returns a list of network gateways that can be used to access endpoints
+	// residing in this registry.
 	NetworkGateways() []*NetworkGateway
 }
 

--- a/pilot/pkg/serviceregistry/kube/controller/network.go
+++ b/pilot/pkg/serviceregistry/kube/controller/network.go
@@ -17,9 +17,7 @@ package controller
 import (
 	"net"
 	"reflect"
-	"sort"
 	"strconv"
-	"strings"
 
 	"github.com/yl2chen/cidranger"
 
@@ -204,7 +202,7 @@ func (c *Controller) extractGatewaysInner(svc *model.Service) bool {
 	}
 
 	previousGateways := c.networkGateways[svc.Hostname][nw]
-	gatewaysChanged := newGateways.equals(previousGateways)
+	gatewaysChanged := !newGateways.equals(previousGateways)
 	c.networkGateways[svc.Hostname][nw] = newGateways
 
 	return gatewaysChanged
@@ -306,18 +304,5 @@ func (s gatewaySet) toArray() []*model.NetworkGateway {
 	}
 
 	// Sort the array so that it's stable.
-	sort.SliceStable(gws, func(i, j int) bool {
-		if cmp := strings.Compare(string(gws[i].Network), string(gws[j].Network)); cmp < 0 {
-			return true
-		}
-		if cmp := strings.Compare(string(gws[i].Cluster), string(gws[j].Cluster)); cmp < 0 {
-			return true
-		}
-		if cmp := strings.Compare(gws[i].Addr, gws[j].Addr); cmp < 0 {
-			return true
-		}
-		return gws[i].Port < gws[j].Port
-	})
-
-	return gws
+	return model.SortGateways(gws)
 }

--- a/pilot/pkg/xds/debug.go
+++ b/pilot/pkg/xds/debug.go
@@ -46,6 +46,7 @@ import (
 	"istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/collection"
+	"istio.io/istio/pkg/network"
 	istiolog "istio.io/pkg/log"
 )
 
@@ -688,19 +689,14 @@ func (s *DiscoveryServer) PushStatusHandler(w http.ResponseWriter, req *http.Req
 // PushContextDebug holds debug information for push context.
 type PushContextDebug struct {
 	AuthorizationPolicies *model.AuthorizationPolicies
-	NetworkGateways       map[string][]*model.NetworkGateway
+	NetworkGateways       map[network.ID][]*model.NetworkGateway
 }
 
 // PushContextHandler dumps the current PushContext
 func (s *DiscoveryServer) PushContextHandler(w http.ResponseWriter, _ *http.Request) {
-	gateways := s.globalPushContext().NetworkManager().AllGateways()
-	byNetwork := make(map[string][]*model.NetworkGateway)
-	for _, gateway := range gateways {
-		byNetwork[string(gateway.Network)] = append(byNetwork[string(gateway.Network)], gateway)
-	}
 	push := PushContextDebug{
 		AuthorizationPolicies: s.globalPushContext().AuthzPolicies,
-		NetworkGateways:       byNetwork,
+		NetworkGateways:       s.globalPushContext().NetworkManager().GatewaysByNetwork(),
 	}
 
 	writeJSON(w, push)

--- a/pilot/pkg/xds/ep_filters_test.go
+++ b/pilot/pkg/xds/ep_filters_test.go
@@ -15,6 +15,7 @@
 package xds
 
 import (
+	"reflect"
 	"sort"
 	"testing"
 
@@ -655,6 +656,13 @@ func runNetworkFilterTest(t *testing.T, env *model.Environment, tests []networkF
 						t.Errorf("Unexpected address for endpoint %d: %v", i, addr)
 					}
 				}
+			}
+
+			b2 := NewEndpointBuilder("outbound|80||example.ns.svc.cluster.local", tt.conn.proxy, push)
+			testEndpoints2 := b2.buildLocalityLbEndpointsFromShards(testShards(), &model.Port{Name: "http", Port: 80, Protocol: protocol.HTTP})
+			filtered2 := b2.EndpointsByNetworkFilter(testEndpoints2)
+			if !reflect.DeepEqual(filtered2, filtered) {
+				t.Fatalf("output of EndpointsByNetworkFilter is non-deterministic")
 			}
 		})
 	}


### PR DESCRIPTION
Discovered while investigating #34051.

Enabling [UNSAFE_PILOT_ENABLE_RUNTIME_ASSERTIONS](https://github.com/istio/istio/blob/dbf6a9e1c123bf6abbab45683b1c6c1f7660916c/pilot/pkg/features/pilot.go#L461)
Revealed that recent changes to managing multi-network gateways caused issues with EDS caching.

This PR fixes a couple of things:

- Kube controller now correctly identifies when network gateways have changed
- EDS filtering logic for split horizon now generates deterministic results

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.