### PR TITLE
fix the way of getting url host

### DIFF
--- a/pkg/security/security.go
+++ b/pkg/security/security.go
@@ -51,8 +51,10 @@ const (
 	// TODO: change all the pilot one reference definition here instead.
 	WorkloadKeyCertResourceName = "default"
 
-	// Credential fetcher type
-	GCE  = "GoogleComputeEngine"
+	// GCE is Credential fetcher type of Google plugin
+	GCE = "GoogleComputeEngine"
+
+	// Mock is Credential fetcher type of mock plugin
 	Mock = "Mock" // testing only
 
 	// GoogleCAProvider uses the Google CA for workload certificate signing

--- a/security/pkg/credentialfetcher/fetcher.go
+++ b/security/pkg/credentialfetcher/fetcher.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// credentailfetcher fetches workload credentials through platform plugins.
+// Package credentialfetcher fetches workload credentials through platform plugins.
 package credentialfetcher
 
 import (

--- a/security/pkg/credentialfetcher/plugin/gce.go
+++ b/security/pkg/credentialfetcher/plugin/gce.go
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 // This is Google plugin of credentialfetcher.
+
 package plugin
 
 import (
@@ -46,7 +47,7 @@ func SetTokenRotation(enable bool) {
 	rotateToken = enable
 }
 
-// The plugin object.
+// GCEPlugin is the plugin object.
 type GCEPlugin struct {
 	// aud is the unique URI agreed upon by both the instance and the system verifying the instance's identity.
 	// For more info: https://cloud.google.com/compute/docs/instances/verifying-instance-identity
@@ -161,7 +162,7 @@ func (p *GCEPlugin) GetType() string {
 }
 
 // GetIdentityProvider returns the name of the identity provider that can authenticate the workload credential.
-// GCE idenity provider is named "GoogleComputeEngine".
+// GCE identity provider is named "GoogleComputeEngine".
 func (p *GCEPlugin) GetIdentityProvider() string {
 	return p.identityProvider
 }


### PR DESCRIPTION
1. It's not correct to use function `strings.Trim` to remove prefix `"http://"` of URL, using `url/net` to `Parse` URL to get host
   according to go standard lib, `Trim` is used for 
```
// Trim returns a slice of the string s with all leading and
// trailing Unicode code points contained in cutset removed.
```
2. fix some non-standard comments


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.