### PR TITLE
no need to use defer to release response Body

### DIFF
--- a/security/pkg/nodeagent/plugin/providers/google/stsclient/stsclient.go
+++ b/security/pkg/nodeagent/plugin/providers/google/stsclient/stsclient.go
@@ -51,7 +51,7 @@ type federatedTokenResponse struct {
 	ExpiresIn       int64  `json:"expires_in"` // Expiration time in seconds
 }
 
-// TokenExchanger for google securetoken api interaction.
+// SecureTokenServiceExchanger for google securetoken api interaction.
 type SecureTokenServiceExchanger struct {
 	httpClient  *http.Client
 	credFetcher security.CredFetcher
@@ -100,8 +100,8 @@ func (p *SecureTokenServiceExchanger) requestWithRetry(reqBytes []byte) ([]byte,
 			continue
 		}
 		if resp.StatusCode == http.StatusOK {
-			defer resp.Body.Close()
 			body, err := ioutil.ReadAll(resp.Body)
+			resp.Body.Close()
 			return body, err
 		}
 		body, _ := ioutil.ReadAll(resp.Body)


### PR DESCRIPTION
There is no need to use `defer` func to release response Body, just Close it directly. And another codes that processing Closing the Body also Close directly
fix some comments of stsclient


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.