### PR TITLE
Time.tickers that are no longer in use should be closed

### DIFF
--- a/pkg/istio-agent/health/health_check.go
+++ b/pkg/istio-agent/health/health_check.go
@@ -180,6 +180,7 @@ func (w *WorkloadHealthChecker) PerformApplicationHealthCheck(callback func(*Pro
 	// Send the first request immediately
 	doCheck()
 	periodTicker := time.NewTicker(w.config.CheckFrequency)
+	defer periodTicker.Stop()
 	for {
 		select {
 		case <-quit:

--- a/security/pkg/pki/ca/ca.go
+++ b/security/pkg/pki/ca/ca.go
@@ -110,6 +110,7 @@ func NewSelfSignedIstioCAOptions(ctx context.Context,
 	if scrtErr != nil && readCertRetryInterval > time.Duration(0) {
 		pkiCaLog.Infof("Citadel in signing key/cert read only mode. Wait until secret %s:%s can be loaded...", namespace, CASecret)
 		ticker := time.NewTicker(readCertRetryInterval)
+		defer ticker.Stop()
 		for scrtErr != nil {
 			select {
 			case <-ticker.C:


### PR DESCRIPTION
1. if time.ticker no longer in use ,stop it


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
