### PR TITLE
Fix external CP integration test

### DIFF
--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -884,7 +884,7 @@ func configureRemoteConfigClusterDiscovery(i *operatorComponent, cfg Config, c c
 				{
 					Name:     "tls-webhook",
 					Protocol: kubeApiCore.ProtocolTCP,
-					Port:     15017,
+					Port:     443,
 				},
 				{
 					Name:     "tls",
@@ -892,7 +892,6 @@ func configureRemoteConfigClusterDiscovery(i *operatorComponent, cfg Config, c c
 					Port:     15443,
 				},
 			},
-			ClusterIP: "None",
 		},
 	}
 	_, err = c.CoreV1().Services(cfg.SystemNamespace).Create(context.TODO(), svc, kubeApiMeta.CreateOptions{})
@@ -920,7 +919,7 @@ func configureRemoteConfigClusterDiscovery(i *operatorComponent, cfg Config, c c
 					{
 						Name:     "tls-webhook",
 						Protocol: kubeApiCore.ProtocolTCP,
-						Port:     15017,
+						Port:     443,
 					},
 				},
 			},

--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -289,6 +289,9 @@ func deploy(ctx resource.Context, env *kube.Environment, cfg Config) (Instance, 
 
 	scopes.Framework.Infof("=== Istio Component Config ===")
 	scopes.Framework.Infof("\n%s", cfg.String())
+	scopes.Framework.Infof("\nctx:%+v", ctx)
+	scopes.Framework.Infof("\nctx.Environment:%+v", ctx.Environment())
+	scopes.Framework.Infof("\nctx.Environment config cluster:%+v", ctx.Environment().Clusters().Configs())
 	scopes.Framework.Infof("================================")
 
 	t0 := time.Now()
@@ -957,7 +960,7 @@ func (i *operatorComponent) configureRemoteConfigForControlPlane(c cluster.Clust
 		return err
 	}
 
-	scopes.Framework.Infof("configuring external control plane to use config cluster in %s", c.Name())
+	scopes.Framework.Infof("configuring external control plane in %s to use config cluster in %s", c.Name(), configCluster.Name())
 	// ensure system namespace exists
 	_, err = c.CoreV1().Namespaces().
 		Create(context.TODO(), &kubeApiCore.Namespace{

--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -539,10 +539,13 @@ func installControlPlaneCluster(i *operatorComponent, cfg Config, c cluster.Clus
 	// Set the clusterName for the local cluster.
 	// This MUST match the clusterName in the remote secret for this cluster.
 	if i.environment.IsMulticluster() {
-		clusterName := c.Name()
 		if i.isExternalControlPlane() || cfg.IstiodlessRemotes {
 			// enable namespace controller writing to remote clusters
 			installSettings = append(installSettings, "--set", "values.pilot.env.EXTERNAL_ISTIOD=true")
+		}
+		clusterName := c.Name()
+		if !c.IsConfig() {
+			clusterName = c.ConfigName()
 		}
 		installSettings = append(installSettings, "--set", "values.global.multiCluster.clusterName="+clusterName)
 	}

--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -289,9 +289,6 @@ func deploy(ctx resource.Context, env *kube.Environment, cfg Config) (Instance, 
 
 	scopes.Framework.Infof("=== Istio Component Config ===")
 	scopes.Framework.Infof("\n%s", cfg.String())
-	scopes.Framework.Infof("\nctx:%+v", ctx)
-	scopes.Framework.Infof("\nctx.Environment:%+v", ctx.Environment())
-	scopes.Framework.Infof("\nctx.Environment config cluster:%+v", ctx.Environment().Clusters().Configs())
 	scopes.Framework.Infof("================================")
 
 	t0 := time.Now()

--- a/tests/integration/multicluster/centralremotekubeconfig/main_test.go
+++ b/tests/integration/multicluster/centralremotekubeconfig/main_test.go
@@ -96,8 +96,8 @@ components:
         - path: spec.template.spec.volumes[100]
           value: |-
             name: inject-volume
-              configMap:
-                name: istio-sidecar-injector
+            configMap:
+              name: istio-sidecar-injector
         - path: spec.template.spec.containers[0].volumeMounts[100]
           value: |-
             name: config-volume

--- a/tests/integration/multicluster/centralremotekubeconfig/main_test.go
+++ b/tests/integration/multicluster/centralremotekubeconfig/main_test.go
@@ -70,11 +70,7 @@ values:
     omitSidecarInjectorConfigMap: true
     configCluster: true
   pilot:
-    configMap: true
-  istiodRemote:
-    injectionURL: https://istiod.istio-system.svc:443/inject
-  base:
-    validationURL: https://istiod.istio-system.svc:443/validate`
+    configMap: true`
 			cfg.ControlPlaneValues = `
 components:
   base:

--- a/tests/integration/multicluster/centralremotekubeconfig/main_test.go
+++ b/tests/integration/multicluster/centralremotekubeconfig/main_test.go
@@ -72,9 +72,9 @@ values:
   pilot:
     configMap: true
   istiodRemote:
-    injectionURL: https://istiod.istio-system.svc:15017/inject
+    injectionURL: https://istiod.istio-system.svc:443/inject
   base:
-    validationURL: https://istiod.istio-system.svc:15017/validate`
+    validationURL: https://istiod.istio-system.svc:443/validate`
 			cfg.ControlPlaneValues = `
 components:
   base:

--- a/tests/integration/multicluster/centralremotekubeconfig/main_test.go
+++ b/tests/integration/multicluster/centralremotekubeconfig/main_test.go
@@ -32,13 +32,13 @@ var ist istio.Instance
 func TestMain(m *testing.M) {
 	framework.
 		NewSuite(m).
-		Skip("https://github.com/istio/istio/pull/33045").
+		// Skip("https://github.com/istio/istio/pull/33045").
 		Label(label.Multicluster).
 		RequireMinClusters(2).
 		Setup(func(ctx resource.Context) error {
 			// TODO, this should be exclusively configurable outside of the framework
-			configCluster := ctx.Clusters()[0]
-			externalControlPlaneCluster := ctx.Clusters()[1]
+			configCluster := ctx.Clusters()[1]
+			externalControlPlaneCluster := ctx.Clusters()[0]
 			for _, c := range ctx.Clusters() {
 				c.(*kubecluster.Cluster).OverrideTopology(func(c cluster.Topology) cluster.Topology {
 					return c.
@@ -50,23 +50,27 @@ func TestMain(m *testing.M) {
 		}).
 		Setup(istio.Setup(&ist, func(_ resource.Context, cfg *istio.Config) {
 			// Set the control plane values on the config.
-			cfg.ConfigClusterValues =
-				`components:
+			cfg.ConfigClusterValues = `
+components:
   base:
     enabled: false
   pilot:
     enabled: false
-  telemetry:
-    enabled: false
   ingressGateways:
-  - enabled: false
-    name: istio-ingressgateway
+  - name: istio-ingressgateway
+    enabled: false
+  egressGateways:
+  - name: istio-egressgateway
+    enabled: false
   istiodRemote:
     enabled: true
 values:
   global:
     externalIstiod: true
+    omitSidecarInjectorConfigMap: true
     configCluster: true
+  pilot:
+    configMap: true
   istiodRemote:
     injectionURL: https://istiod.istio-system.svc:15017/inject
   base:
@@ -80,12 +84,45 @@ components:
     k8s:
       service:
         type: LoadBalancer
+      overlays:
+      - kind: Deployment
+        name: istiod
+        patches:
+        - path: spec.template.spec.volumes[100]
+          value: |-
+            name: config-volume
+            configMap:
+              name: istio
+        - path: spec.template.spec.volumes[100]
+          value: |-
+            name: inject-volume
+              configMap:
+                name: istio-sidecar-injector
+        - path: spec.template.spec.containers[0].volumeMounts[100]
+          value: |-
+            name: config-volume
+            mountPath: /etc/istio/config
+        - path: spec.template.spec.containers[0].volumeMounts[100]
+          value: |-
+            name: inject-volume
+            mountPath: /var/lib/istio/inject
+      env:
+      - name: INJECTION_WEBHOOK_CONFIG_NAME
+        value: ""
+      - name: VALIDATION_WEBHOOK_CONFIG_NAME
+        value: ""
+      - name: EXTERNAL_ISTIOD
+        value: "true"
+      - name: CLUSTER_ID
+        value: remote
+      - name: SHARED_MESH_CONFIG
+        value: istio
   ingressGateways:
-  - enabled: false
-    name: istio-ingressgateway
+  - name: istio-ingressgateway
+    enabled: false
   egressGateways:
-  - enabled: false
-    name: istio-egressgateway
+  - name: istio-egressgateway
+    enabled: false
 values:
   global:
     operatorManageWebhooks: true

--- a/tests/integration/multicluster/centralremotekubeconfig/main_test.go
+++ b/tests/integration/multicluster/centralremotekubeconfig/main_test.go
@@ -104,9 +104,9 @@ components:
             mountPath: /var/lib/istio/inject
       env:
       - name: INJECTION_WEBHOOK_CONFIG_NAME
-        value: ""
+        value: "istio-sidecar-injector-istio-system"
       - name: VALIDATION_WEBHOOK_CONFIG_NAME
-        value: ""
+        value: "istio-istio-system"
       - name: EXTERNAL_ISTIOD
         value: "true"
       - name: CLUSTER_ID

--- a/tests/integration/multicluster/centralremotekubeconfig/main_test.go
+++ b/tests/integration/multicluster/centralremotekubeconfig/main_test.go
@@ -126,6 +126,7 @@ components:
 values:
   global:
     operatorManageWebhooks: true
+    configValidation: false
 `
 		})).
 		Run()

--- a/tests/integration/multicluster/gateway.go
+++ b/tests/integration/multicluster/gateway.go
@@ -55,7 +55,7 @@ func GatewayTest(t *testing.T, feature features.Feature) {
 					}
 					for _, cluster := range clusters {
 						_, err = cluster.AdmissionregistrationV1().ValidatingWebhookConfigurations().Get(context.TODO(),
-							"istiod-istio-system", metav1.GetOptions{})
+							"istio-validator-istio-system", metav1.GetOptions{})
 						if err == nil {
 							istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{Cluster: cluster})
 							scopes.Framework.Debugf("cluster Name %s", cluster.Name())

--- a/tests/integration/multicluster/gateway.go
+++ b/tests/integration/multicluster/gateway.go
@@ -65,11 +65,11 @@ func GatewayTest(t *testing.T, feature features.Feature) {
 								if err != nil {
 									return err
 								}
-								if len(pods.Items) == 0 {
-									return fmt.Errorf("still waiting the ingress gateway pod to start")
+								if len(pods.Items) == 0 || pods.Items[0].Status.Phase != v1.PodRunning {
+									return fmt.Errorf("still waiting for the ingress gateway pod to start")
 								}
-								if pods.Items[0].Status.Phase != v1.PodRunning {
-									return fmt.Errorf("still waiting the ingress gateway pod to start")
+								if !pods.Items[0].Status.ContainerStatuses[0].Ready {
+									return fmt.Errorf("still waiting for ingress gateway pod container to be ready")
 								}
 								return nil
 							}, retry.Delay(3*time.Second), retry.Timeout(80*time.Second))

--- a/tests/integration/multicluster/testdata/gateway.yaml
+++ b/tests/integration/multicluster/testdata/gateway.yaml
@@ -6,3 +6,7 @@ spec:
     ingressGateways:
       - name: test-gateway
         enabled: true
+  values:
+    gateways:
+      test-gateway:
+        injectionTemplate: gateway

--- a/tests/integration/multicluster/testdata/gateway.yaml
+++ b/tests/integration/multicluster/testdata/gateway.yaml
@@ -8,5 +8,5 @@ spec:
         enabled: true
   values:
     gateways:
-      test-gateway:
+      istio-ingressgateway:
         injectionTemplate: gateway


### PR DESCRIPTION
Work on re-enabling this test with changes. The original test didn't ever work properly as its SUCCESS was a false positive. The test will verify that the test-gateway is actually running and is updated for the External Istiod changes that are in 1.11.

Thanks to many: @GregHanson, @frankbu, @howardjohn, and @stevenctl who contributed to getting this working.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.