### PR TITLE
[1.10] Fix memory leak in xds_proxy when channels are blocked (#34098)

### DIFF
--- a/pilot/test/xdstest/grpc.go
+++ b/pilot/test/xdstest/grpc.go
@@ -1,0 +1,89 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package xdstest
+
+import (
+	"context"
+	"time"
+
+	"google.golang.org/grpc"
+
+	"istio.io/pkg/log"
+)
+
+func safeSleep(ctx context.Context, t time.Duration) {
+	select {
+	case <-time.After(t):
+	case <-ctx.Done():
+	}
+}
+
+type slowClientStream struct {
+	grpc.ClientStream
+	recv, send time.Duration
+}
+
+func (w *slowClientStream) RecvMsg(m interface{}) error {
+	if w.recv > 0 {
+		safeSleep(w.Context(), w.recv)
+		log.Infof("delayed recv for %v", w.recv)
+	}
+	return w.ClientStream.RecvMsg(m)
+}
+
+func (w *slowClientStream) SendMsg(m interface{}) error {
+	if w.send > 0 {
+		safeSleep(w.Context(), w.send)
+		log.Infof("delayed send for %v", w.send)
+	}
+	return w.ClientStream.SendMsg(m)
+}
+
+// SlowClientInterceptor is an interceptor that allows injecting delays on Send and Recv
+func SlowClientInterceptor(recv, send time.Duration) grpc.StreamClientInterceptor {
+	return func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn,
+		method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+		clientStream, err := streamer(ctx, desc, cc, method, opts...)
+		return &slowClientStream{clientStream, recv, send}, err
+	}
+}
+
+type slowServerStream struct {
+	grpc.ServerStream
+	recv, send time.Duration
+}
+
+func (w *slowServerStream) RecvMsg(m interface{}) error {
+	if w.recv > 0 {
+		safeSleep(w.Context(), w.recv)
+		log.Infof("delayed recv for %v", w.recv)
+	}
+	return w.ServerStream.RecvMsg(m)
+}
+
+func (w *slowServerStream) SendMsg(m interface{}) error {
+	if w.send > 0 {
+		safeSleep(w.Context(), w.send)
+		log.Infof("delayed send for %v", w.send)
+	}
+	return w.ServerStream.SendMsg(m)
+}
+
+// SlowServerInterceptor is an interceptor that allows injecting delays on Send and Recv
+func SlowServerInterceptor(recv, send time.Duration) grpc.StreamServerInterceptor {
+	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		return handler(srv, &slowServerStream{ss, recv, send})
+	}
+}

--- a/pilot/test/xdstest/mock_discovery.go
+++ b/pilot/test/xdstest/mock_discovery.go
@@ -1,0 +1,80 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package xdstest
+
+import (
+	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/test/bufconn"
+
+	"istio.io/istio/pkg/test"
+	"istio.io/pkg/log"
+)
+
+// MockDiscovery is a DiscoveryServer that allows users full control over responses.
+type MockDiscovery struct {
+	Listener  *bufconn.Listener
+	responses chan *discovery.DiscoveryResponse
+	close     chan struct{}
+}
+
+func NewMockServer(t test.Failer) *MockDiscovery {
+	s := &MockDiscovery{
+		close:     make(chan struct{}),
+		responses: make(chan *discovery.DiscoveryResponse),
+	}
+	buffer := 1024 * 1024
+	listener := bufconn.Listen(buffer)
+	grpcServer := grpc.NewServer()
+	discovery.RegisterAggregatedDiscoveryServiceServer(grpcServer, s)
+	go func() {
+		if err := grpcServer.Serve(listener); err != nil && !(err == grpc.ErrServerStopped || err.Error() == "closed") {
+			t.Fatal(err)
+		}
+	}()
+	t.Cleanup(func() {
+		grpcServer.Stop()
+		close(s.close)
+	})
+	s.Listener = listener
+	return s
+}
+
+func (f *MockDiscovery) StreamAggregatedResources(server discovery.AggregatedDiscoveryService_StreamAggregatedResourcesServer) error {
+	numberOfSends := 0
+	for {
+		select {
+		case <-f.close:
+			return nil
+		case resp := <-f.responses:
+			numberOfSends++
+			log.Infof("sending response from mock: %v", numberOfSends)
+			if err := server.Send(resp); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func (f *MockDiscovery) DeltaAggregatedResources(server discovery.AggregatedDiscoveryService_DeltaAggregatedResourcesServer) error {
+	panic("implement me")
+}
+
+// SendResponse sends a response to a (random) client. This can block if sends are blocked.
+func (f *MockDiscovery) SendResponse(dr *discovery.DiscoveryResponse) {
+	f.responses <- dr
+}
+
+var _ discovery.AggregatedDiscoveryServiceServer = &MockDiscovery{}

--- a/pkg/istio-agent/agent.go
+++ b/pkg/istio-agent/agent.go
@@ -22,6 +22,8 @@ import (
 	"path"
 	"strings"
 
+	"google.golang.org/grpc"
+
 	mesh "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/pkg/dns"
 	"istio.io/istio/pilot/pkg/model"
@@ -134,6 +136,8 @@ type AgentOptions struct {
 
 	// All of the proxy's IP Addresses
 	ProxyIPAddresses []string
+
+	DownstreamGrpcOptions []grpc.ServerOption
 }
 
 // NewAgent hosts the functionality for local SDS and XDS. This consists of the local SDS server and

--- a/pkg/istio-agent/leak_test.go
+++ b/pkg/istio-agent/leak_test.go
@@ -1,0 +1,26 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package istioagent
+
+import (
+	"testing"
+
+	"istio.io/istio/tests/util/leak"
+)
+
+func TestMain(m *testing.M) {
+	// CheckMain asserts that no goroutines are leaked after a test package exits.
+	leak.CheckMain(m)
+}

--- a/pkg/istio-agent/xds_proxy.go
+++ b/pkg/istio-agent/xds_proxy.go
@@ -106,8 +106,9 @@ type XdsProxy struct {
 	// TODO(bianpengyuan): this relies on the fact that istiod versions all ECDS resources
 	// the same in a update response. This needs update to support per resource versioning,
 	// in case istiod changes its behavior, or a different ECDS server is used.
-	ecdsLastAckVersion atomic.String
-	ecdsLastNonce      atomic.String
+	ecdsLastAckVersion    atomic.String
+	ecdsLastNonce         atomic.String
+	downstreamGrpcOptions []grpc.ServerOption
 }
 
 var proxyLog = log.RegisterScope("xdsproxy", "XDS Proxy in Istio Agent", 0)
@@ -128,15 +129,16 @@ func initXdsProxy(ia *Agent) (*XdsProxy, error) {
 		LocalHostAddr: localHostAddr,
 	}
 	proxy := &XdsProxy{
-		istiodAddress:  ia.proxyConfig.DiscoveryAddress,
-		clusterID:      ia.secOpts.ClusterID,
-		handlers:       map[string]ResponseHandler{},
-		stopChan:       make(chan struct{}),
-		healthChecker:  health.NewWorkloadHealthChecker(ia.proxyConfig.ReadinessProbe, envoyProbe, ia.cfg.ProxyIPAddresses, ia.cfg.IsIPv6),
-		xdsHeaders:     ia.cfg.XDSHeaders,
-		xdsUdsPath:     ia.cfg.XdsUdsPath,
-		wasmCache:      wasm.NewLocalFileCache(constants.IstioDataDir, wasm.DefaultWasmModulePurgeInteval, wasm.DefaultWasmModuleExpiry),
-		proxyAddresses: ia.cfg.ProxyIPAddresses,
+		istiodAddress:         ia.proxyConfig.DiscoveryAddress,
+		clusterID:             ia.secOpts.ClusterID,
+		handlers:              map[string]ResponseHandler{},
+		stopChan:              make(chan struct{}),
+		healthChecker:         health.NewWorkloadHealthChecker(ia.proxyConfig.ReadinessProbe, envoyProbe, ia.cfg.ProxyIPAddresses, ia.cfg.IsIPv6),
+		xdsHeaders:            ia.cfg.XDSHeaders,
+		xdsUdsPath:            ia.cfg.XdsUdsPath,
+		wasmCache:             wasm.NewLocalFileCache(constants.IstioDataDir, wasm.DefaultWasmModulePurgeInteval, wasm.DefaultWasmModuleExpiry),
+		proxyAddresses:        ia.cfg.ProxyIPAddresses,
+		downstreamGrpcOptions: ia.cfg.DownstreamGrpcOptions,
 	}
 
 	if ia.localDNSServer != nil {
@@ -221,17 +223,22 @@ func initXdsProxy(ia *Agent) (*XdsProxy, error) {
 // to the upstream XDS request we will resend this request.
 func (p *XdsProxy) PersistRequest(req *discovery.DiscoveryRequest) {
 	var ch chan *discovery.DiscoveryRequest
+	var stop chan struct{}
 
 	p.connectedMutex.Lock()
 	if p.connected != nil {
 		ch = p.connected.requestsChan
+		stop = p.connected.stopChan
 	}
 	p.initialRequest = req
 	p.connectedMutex.Unlock()
 
 	// Immediately send if we are currently connect
 	if ch != nil {
-		ch <- req
+		select {
+		case ch <- req:
+		case <-stop:
+		}
 	}
 }
 
@@ -268,6 +275,15 @@ type ProxyConnection struct {
 	upstreamDeltas     discovery.AggregatedDiscoveryService_DeltaAggregatedResourcesClient
 }
 
+// sendRequest is a small wrapper around sending to con.requestsChan. This ensures that we do not
+// block forever on
+func (con *ProxyConnection) sendRequest(req *discovery.DiscoveryRequest) {
+	select {
+	case con.requestsChan <- req:
+	case <-con.stopChan:
+	}
+}
+
 // Every time envoy makes a fresh connection to the agent, we reestablish a new connection to the upstream xds
 // This ensures that a new connection between istiod and agent doesn't end up consuming pending messages from envoy
 // as the new connection may not go to the same istiod. Vice versa case also applies.
@@ -298,27 +314,30 @@ func (p *XdsProxy) StreamAggregatedResources(downstream discovery.AggregatedDisc
 			// From Envoy
 			req, err := downstream.Recv()
 			if err != nil {
-				con.downstreamError <- err
+				select {
+				case con.downstreamError <- err:
+				case <-con.stopChan:
+				}
 				return
 			}
 			// forward to istiod
-			con.requestsChan <- req
+			con.sendRequest(req)
 			if !initialRequestsSent && req.TypeUrl == v3.ListenerType {
 				// fire off an initial NDS request
 				if _, f := p.handlers[v3.NameTableType]; f {
-					con.requestsChan <- &discovery.DiscoveryRequest{
+					con.sendRequest(&discovery.DiscoveryRequest{
 						TypeUrl: v3.NameTableType,
-					}
+					})
 				}
 				// fire off an initial PCDS request
 				if _, f := p.handlers[v3.ProxyConfigType]; f {
-					con.requestsChan <- &discovery.DiscoveryRequest{
+					con.sendRequest(&discovery.DiscoveryRequest{
 						TypeUrl: v3.ProxyConfigType,
-					}
+					})
 				}
 				// Fire of a configured initial request, if there is one
 				if initialRequest != nil {
-					con.requestsChan <- initialRequest
+					con.sendRequest(initialRequest)
 				}
 				initialRequestsSent = true
 			}
@@ -361,12 +380,18 @@ func (p *XdsProxy) HandleUpstream(ctx context.Context, con *ProxyConnection, xds
 	go func() {
 		for {
 			// from istiod
-			resp, err := upstream.Recv()
+			resp, err := con.upstream.Recv()
 			if err != nil {
-				con.upstreamError <- err
+				select {
+				case con.upstreamError <- err:
+				case <-con.stopChan:
+				}
 				return
 			}
-			con.responsesChan <- resp
+			select {
+			case con.responsesChan <- resp:
+			case <-con.stopChan:
+			}
 		}
 	}()
 
@@ -449,12 +474,12 @@ func (p *XdsProxy) handleUpstreamResponse(con *ProxyConnection) {
 					}
 				}
 				// Send ACK/NACK
-				con.requestsChan <- &discovery.DiscoveryRequest{
+				con.sendRequest(&discovery.DiscoveryRequest{
 					VersionInfo:   resp.VersionInfo,
 					TypeUrl:       resp.TypeUrl,
 					ResponseNonce: resp.Nonce,
 					ErrorDetail:   errorResp,
-				}
+				})
 				continue
 			}
 			switch resp.TypeUrl {
@@ -479,7 +504,7 @@ func (p *XdsProxy) rewriteAndForward(con *ProxyConnection, resp *discovery.Disco
 	sendNack := wasm.MaybeConvertWasmExtensionConfig(resp.Resources, p.wasmCache)
 	if sendNack {
 		proxyLog.Debugf("sending NACK for ECDS resources %+v", resp.Resources)
-		con.requestsChan <- &discovery.DiscoveryRequest{
+		con.sendRequest(&discovery.DiscoveryRequest{
 			VersionInfo:   p.ecdsLastAckVersion.Load(),
 			TypeUrl:       v3.ExtensionConfigurationType,
 			ResponseNonce: resp.Nonce,
@@ -487,7 +512,7 @@ func (p *XdsProxy) rewriteAndForward(con *ProxyConnection, resp *discovery.Disco
 				// TODO(bianpengyuan): make error message more informative.
 				Message: "failed to fetch wasm module",
 			},
-		}
+		})
 		return
 	}
 	proxyLog.Debugf("forward ECDS resources %+v", resp.Resources)
@@ -557,7 +582,7 @@ func (p *XdsProxy) initDownstreamServer() error {
 	if err != nil {
 		return err
 	}
-	grpcs := grpc.NewServer()
+	grpcs := grpc.NewServer(p.downstreamGrpcOptions...)
 	discovery.RegisterAggregatedDiscoveryServiceServer(grpcs, p)
 	reflection.Register(grpcs)
 	p.downstreamGrpcServer = grpcs

--- a/pkg/istio-agent/xds_proxy_delta.go
+++ b/pkg/istio-agent/xds_proxy_delta.go
@@ -30,6 +30,15 @@ import (
 	"istio.io/istio/pkg/wasm"
 )
 
+// sendDeltaRequest is a small wrapper around sending to con.requestsChan. This ensures that we do not
+// block forever on
+func (con *ProxyConnection) sendDeltaRequest(req *discovery.DeltaDiscoveryRequest) {
+	select {
+	case con.deltaRequestsChan <- req:
+	case <-con.stopChan:
+	}
+}
+
 // requests from envoy
 // for aditya:
 // downstream -> envoy (anything "behind" xds proxy)
@@ -60,27 +69,30 @@ func (p *XdsProxy) DeltaAggregatedResources(downstream discovery.AggregatedDisco
 			// From Envoy
 			req, err := downstream.Recv()
 			if err != nil {
-				con.downstreamError <- err
+				select {
+				case con.downstreamError <- err:
+				case <-con.stopChan:
+				}
 				return
 			}
 			// forward to istiod
-			con.deltaRequestsChan <- req
+			con.sendDeltaRequest(req)
 			if !initialRequestsSent && req.TypeUrl == v3.ListenerType {
 				// fire off an initial NDS request
 				if _, f := p.handlers[v3.NameTableType]; f {
-					con.deltaRequestsChan <- &discovery.DeltaDiscoveryRequest{
+					con.sendDeltaRequest(&discovery.DeltaDiscoveryRequest{
 						TypeUrl: v3.NameTableType,
-					}
+					})
 				}
 				// fire off an initial PCDS request
 				if _, f := p.handlers[v3.ProxyConfigType]; f {
-					con.deltaRequestsChan <- &discovery.DeltaDiscoveryRequest{
+					con.sendDeltaRequest(&discovery.DeltaDiscoveryRequest{
 						TypeUrl: v3.ProxyConfigType,
-					}
+					})
 				}
 				// Fire of a configured initial request, if there is one
 				if initialRequest != nil {
-					con.deltaRequestsChan <- initialRequest
+					con.sendDeltaRequest(initialRequest)
 				}
 				initialRequestsSent = true
 			}
@@ -124,10 +136,16 @@ func (p *XdsProxy) HandleDeltaUpstream(ctx context.Context, con *ProxyConnection
 		for {
 			resp, err := deltaUpstream.Recv()
 			if err != nil {
-				con.upstreamError <- err
+				select {
+				case con.upstreamError <- err:
+				case <-con.stopChan:
+				}
 				return
 			}
-			con.deltaResponsesChan <- resp
+			select {
+			case con.deltaResponsesChan <- resp:
+			case <-con.stopChan:
+			}
 		}
 	}()
 
@@ -210,11 +228,11 @@ func (p *XdsProxy) handleUpstreamDeltaResponse(con *ProxyConnection) {
 					}
 				}
 				// Send ACK/NACK
-				con.deltaRequestsChan <- &discovery.DeltaDiscoveryRequest{
+				con.sendDeltaRequest(&discovery.DeltaDiscoveryRequest{
 					TypeUrl:       resp.TypeUrl,
 					ResponseNonce: resp.Nonce,
 					ErrorDetail:   errorResp,
-				}
+				})
 				continue
 			}
 			switch resp.TypeUrl {
@@ -239,14 +257,14 @@ func (p *XdsProxy) deltaRewriteAndForward(con *ProxyConnection, resp *discovery.
 	sendNack := wasm.MaybeConvertWasmExtensionConfigDelta(resp.Resources, p.wasmCache)
 	if sendNack {
 		proxyLog.Debugf("sending NACK for ECDS resources %+v", resp.Resources)
-		con.deltaRequestsChan <- &discovery.DeltaDiscoveryRequest{
+		con.sendDeltaRequest(&discovery.DeltaDiscoveryRequest{
 			TypeUrl:       v3.ExtensionConfigurationType,
 			ResponseNonce: resp.Nonce,
 			ErrorDetail: &google_rpc.Status{
 				// TODO(bianpengyuan): make error message more informative.
 				Message: "failed to fetch wasm module",
 			},
-		}
+		})
 		return
 	}
 	proxyLog.Debugf("forward ECDS resources %+v", resp.Resources)
@@ -284,16 +302,21 @@ func sendDownstreamDeltaWithTimout(deltaUpstream discovery.AggregatedDiscoverySe
 
 func (p *XdsProxy) PersistDeltaRequest(req *discovery.DeltaDiscoveryRequest) {
 	var ch chan *discovery.DeltaDiscoveryRequest
+	var stop chan struct{}
 
 	p.connectedMutex.Lock()
 	if p.connected != nil {
 		ch = p.connected.deltaRequestsChan
+		stop = p.connected.stopChan
 	}
 	p.initialDeltaRequest = req
 	p.connectedMutex.Unlock()
 
 	// Immediately send if we are currently connect
 	if ch != nil {
-		ch <- req
+		select {
+		case ch <- req:
+		case <-stop:
+		}
 	}
 }

--- a/pkg/istio-agent/xds_proxy_test.go
+++ b/pkg/istio-agent/xds_proxy_test.go
@@ -42,6 +42,7 @@ import (
 	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pilot/pkg/xds"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
+	"istio.io/istio/pilot/test/xdstest"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/schema/gvk"
@@ -50,6 +51,36 @@ import (
 	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/pkg/test/util/retry"
 )
+
+// TestXdsLeak is a regression test for https://github.com/istio/istio/issues/34097
+func TestXdsLeak(t *testing.T) {
+	proxy := setupXdsProxyWithDownstreamOptions(t, []grpc.ServerOption{grpc.StreamInterceptor(xdstest.SlowServerInterceptor(time.Second, time.Second))})
+	f := xdstest.NewMockServer(t)
+	setDialOptions(proxy, f.Listener)
+	proxy.istiodDialOptions = append(proxy.istiodDialOptions, grpc.WithStreamInterceptor(xdstest.SlowClientInterceptor(0, time.Second*10)))
+	conn := setupDownstreamConnection(t, proxy)
+	downstream := stream(t, conn)
+	sendDownstreamWithoutResponse(t, downstream)
+	for i := 0; i < 15; i++ {
+		// Send a bunch of responses from Istiod. These should not block, even though there are more sends than responseChan can hold
+		f.SendResponse(&discovery.DiscoveryResponse{TypeUrl: v3.ClusterType})
+	}
+	// Exit test, closing the connections. We should not have any goroutine leaks (checked by leak.CheckMain)
+}
+
+// sendDownstreamWithoutResponse sends a response without waiting for a response
+func sendDownstreamWithoutResponse(t *testing.T, downstream discovery.AggregatedDiscoveryService_StreamAggregatedResourcesClient) {
+	t.Helper()
+	err := downstream.Send(&discovery.DiscoveryRequest{
+		TypeUrl: v3.ClusterType,
+		Node: &core.Node{
+			Id: "sidecar~0.0.0.0~debug~cluster.local",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
 
 // Validates basic xds proxy flow by proxying one CDS requests end to end.
 func TestXdsProxyBasicFlow(t *testing.T) {
@@ -198,6 +229,10 @@ func TestXdsProxyHealthCheck(t *testing.T) {
 }
 
 func setupXdsProxy(t *testing.T) *XdsProxy {
+	return setupXdsProxyWithDownstreamOptions(t, nil)
+}
+
+func setupXdsProxyWithDownstreamOptions(t *testing.T, opts []grpc.ServerOption) *XdsProxy {
 	secOpts := &security.Options{
 		FileMountedCerts: true,
 	}
@@ -213,7 +248,8 @@ func setupXdsProxy(t *testing.T) *XdsProxy {
 	}
 	dir := t.TempDir()
 	ia := NewAgent(&proxyConfig, &AgentOptions{
-		XdsUdsPath: filepath.Join(dir, "XDS"),
+		XdsUdsPath:            filepath.Join(dir, "XDS"),
+		DownstreamGrpcOptions: opts,
 	}, secOpts)
 	t.Cleanup(func() {
 		ia.Close()
@@ -222,6 +258,7 @@ func setupXdsProxy(t *testing.T) *XdsProxy {
 	if err != nil {
 		t.Fatalf("Failed to initialize xds proxy %v", err)
 	}
+	ia.xdsProxy = proxy
 
 	return proxy
 }


### PR DESCRIPTION
* Fix memory leak in xds_proxy when channels are blocked

* add test

* delta and test fixes

* fix logs

* fix other leak

(cherry picked from commit 7870103a91b8686ba24e807377227d804a03806d)



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.