### PR TITLE
[1.9] Fix memory leak in xds_proxy when channels are blocked (#34098)

### DIFF
--- a/pilot/test/xdstest/grpc.go
+++ b/pilot/test/xdstest/grpc.go
@@ -1,0 +1,89 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package xdstest
+
+import (
+	"context"
+	"time"
+
+	"google.golang.org/grpc"
+
+	"istio.io/pkg/log"
+)
+
+func safeSleep(ctx context.Context, t time.Duration) {
+	select {
+	case <-time.After(t):
+	case <-ctx.Done():
+	}
+}
+
+type slowClientStream struct {
+	grpc.ClientStream
+	recv, send time.Duration
+}
+
+func (w *slowClientStream) RecvMsg(m interface{}) error {
+	if w.recv > 0 {
+		safeSleep(w.Context(), w.recv)
+		log.Infof("delayed recv for %v", w.recv)
+	}
+	return w.ClientStream.RecvMsg(m)
+}
+
+func (w *slowClientStream) SendMsg(m interface{}) error {
+	if w.send > 0 {
+		safeSleep(w.Context(), w.send)
+		log.Infof("delayed send for %v", w.send)
+	}
+	return w.ClientStream.SendMsg(m)
+}
+
+// SlowClientInterceptor is an interceptor that allows injecting delays on Send and Recv
+func SlowClientInterceptor(recv, send time.Duration) grpc.StreamClientInterceptor {
+	return func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn,
+		method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+		clientStream, err := streamer(ctx, desc, cc, method, opts...)
+		return &slowClientStream{clientStream, recv, send}, err
+	}
+}
+
+type slowServerStream struct {
+	grpc.ServerStream
+	recv, send time.Duration
+}
+
+func (w *slowServerStream) RecvMsg(m interface{}) error {
+	if w.recv > 0 {
+		safeSleep(w.Context(), w.recv)
+		log.Infof("delayed recv for %v", w.recv)
+	}
+	return w.ServerStream.RecvMsg(m)
+}
+
+func (w *slowServerStream) SendMsg(m interface{}) error {
+	if w.send > 0 {
+		safeSleep(w.Context(), w.send)
+		log.Infof("delayed send for %v", w.send)
+	}
+	return w.ServerStream.SendMsg(m)
+}
+
+// SlowServerInterceptor is an interceptor that allows injecting delays on Send and Recv
+func SlowServerInterceptor(recv, send time.Duration) grpc.StreamServerInterceptor {
+	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		return handler(srv, &slowServerStream{ss, recv, send})
+	}
+}

--- a/pilot/test/xdstest/mock_discovery.go
+++ b/pilot/test/xdstest/mock_discovery.go
@@ -1,0 +1,80 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package xdstest
+
+import (
+	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/test/bufconn"
+
+	"istio.io/istio/pkg/test"
+	"istio.io/pkg/log"
+)
+
+// MockDiscovery is a DiscoveryServer that allows users full control over responses.
+type MockDiscovery struct {
+	Listener  *bufconn.Listener
+	responses chan *discovery.DiscoveryResponse
+	close     chan struct{}
+}
+
+func NewMockServer(t test.Failer) *MockDiscovery {
+	s := &MockDiscovery{
+		close:     make(chan struct{}),
+		responses: make(chan *discovery.DiscoveryResponse),
+	}
+	buffer := 1024 * 1024
+	listener := bufconn.Listen(buffer)
+	grpcServer := grpc.NewServer()
+	discovery.RegisterAggregatedDiscoveryServiceServer(grpcServer, s)
+	go func() {
+		if err := grpcServer.Serve(listener); err != nil && !(err == grpc.ErrServerStopped || err.Error() == "closed") {
+			t.Fatal(err)
+		}
+	}()
+	t.Cleanup(func() {
+		grpcServer.Stop()
+		close(s.close)
+	})
+	s.Listener = listener
+	return s
+}
+
+func (f *MockDiscovery) StreamAggregatedResources(server discovery.AggregatedDiscoveryService_StreamAggregatedResourcesServer) error {
+	numberOfSends := 0
+	for {
+		select {
+		case <-f.close:
+			return nil
+		case resp := <-f.responses:
+			numberOfSends++
+			log.Infof("sending response from mock: %v", numberOfSends)
+			if err := server.Send(resp); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func (f *MockDiscovery) DeltaAggregatedResources(server discovery.AggregatedDiscoveryService_DeltaAggregatedResourcesServer) error {
+	panic("implement me")
+}
+
+// SendResponse sends a response to a (random) client. This can block if sends are blocked.
+func (f *MockDiscovery) SendResponse(dr *discovery.DiscoveryResponse) {
+	f.responses <- dr
+}
+
+var _ discovery.AggregatedDiscoveryServiceServer = &MockDiscovery{}

--- a/pkg/istio-agent/agent.go
+++ b/pkg/istio-agent/agent.go
@@ -21,6 +21,8 @@ import (
 	"path"
 	"strings"
 
+	"google.golang.org/grpc"
+
 	mesh "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/pkg/dns"
 	"istio.io/istio/pilot/pkg/model"
@@ -127,6 +129,8 @@ type AgentConfig struct {
 
 	// Path to local UDS to communicate with Envoy
 	XdsUdsPath string
+
+	DownstreamGrpcOptions []grpc.ServerOption
 }
 
 // NewAgent hosts the functionality for local SDS and XDS. This consists of the local SDS server and

--- a/pkg/istio-agent/leak_test.go
+++ b/pkg/istio-agent/leak_test.go
@@ -1,0 +1,26 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package istioagent
+
+import (
+	"testing"
+
+	"istio.io/istio/tests/util/leak"
+)
+
+func TestMain(m *testing.M) {
+	// CheckMain asserts that no goroutines are leaked after a test package exits.
+	leak.CheckMain(m)
+}


### PR DESCRIPTION
* Fix memory leak in xds_proxy when channels are blocked

* add test

* delta and test fixes

* fix logs

* fix other leak

(cherry picked from commit 7870103a91b8686ba24e807377227d804a03806d)
(cherry picked from commit 42a925dc015ace3357fc859a1285b02ba53f398d)



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.