### PR TITLE
upgrade envoy filter envoy.lua from v2 to v3

### DIFF
--- a/tests/testdata/networking/envoyfilter-without-service/configs.yaml
+++ b/tests/testdata/networking/envoyfilter-without-service/configs.yaml
@@ -69,7 +69,7 @@ spec:
       value: # lua filter specification
         name: envoy.lua
         typed_config:
-          "@type": "type.googleapis.com/envoy.config.filter.http.lua.v2.Lua"
+          "@type": "type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua"
           inlineCode: |
             function envoy_on_request(request_handle)
               request_handle:logWarn("Hello World")


### PR DESCRIPTION

v2 XDS version is deprecated, it is better to upgrade to v3.

current config will get complains from istiod and sidecar

```
Warning: using deprecated type_url(s); type.googleapis.com/envoy.config.filter.http.lua.v2.Lua
```

```
virtualInbound: The v2 xDS major version is deprecated and disabled by default. Support for v2 will be removed from Envoy at the start of Q1 2021. You may make use of v2 in Q4 2020 by following the advice in https://www.envoyproxy.io/docs/envoy/latest/faq/api/transition. (envoy.config.filter.http.lua.v2.Lua)
```




[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.