### PR TITLE
Add release notes to promote CNI to beta.

### DIFF
--- a/releasenotes/notes/cni-promote.yaml
+++ b/releasenotes/notes/cni-promote.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+issue:
+  - https://github.com/istio/enhancements/issues/86
+
+releaseNotes:
+- |
+  **Promoted** CNI to beta.


### PR DESCRIPTION
https://github.com/istio/enhancements/issues/86 tracks cni beta promotion and will be closed once https://github.com/istio/enhancements/pull/94 is merged.