### PR TITLE
Fix container builds on arm64

### DIFF
--- a/pilot/docker/Dockerfile.pilot
+++ b/pilot/docker/Dockerfile.pilot
@@ -15,7 +15,7 @@ FROM gcr.io/istio-release/distroless:${BASE_VERSION} as distroless
 FROM ${BASE_DISTRIBUTION}
 
 ARG TARGETARCH
-COPY ${TARGETARCH:-amd64}/pilot-discovery /usr/local/bin/pilot-discovery
+COPY ${TARGETARCH}/pilot-discovery /usr/local/bin/pilot-discovery
 
 # Copy templates for bootstrap generation.
 COPY envoy_bootstrap.json /var/lib/istio/envoy/envoy_bootstrap_tmpl.json

--- a/pilot/docker/Dockerfile.proxyv2
+++ b/pilot/docker/Dockerfile.proxyv2
@@ -29,7 +29,7 @@ COPY gcp_envoy_bootstrap.json /var/lib/istio/envoy/gcp_envoy_bootstrap_tmpl.json
 
 # Install Envoy.
 ARG TARGETARCH
-COPY ${TARGETARCH:-amd64}/${SIDECAR} /usr/local/bin/${SIDECAR}
+COPY ${TARGETARCH}/${SIDECAR} /usr/local/bin/${SIDECAR}
 
 # Environment variable indicating the exact proxy sha - for debugging or version-specific configs 
 ENV ISTIO_META_ISTIO_PROXY_SHA $proxy_version
@@ -37,7 +37,7 @@ ENV ISTIO_META_ISTIO_PROXY_SHA $proxy_version
 ENV ISTIO_META_ISTIO_VERSION $istio_version
 
 ARG TARGETARCH
-COPY ${TARGETARCH:-amd64}/pilot-agent /usr/local/bin/pilot-agent
+COPY ${TARGETARCH}/pilot-agent /usr/local/bin/pilot-agent
 
 COPY stats-filter.wasm /etc/istio/extensions/stats-filter.wasm
 COPY stats-filter.compiled.wasm /etc/istio/extensions/stats-filter.compiled.wasm


### PR DESCRIPTION
Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.


This change removes the default value from the usages of `${TARGETARCH}` argument in docker files. It's not immediately clear why this is necessary, but on when building on `arm64` with `make dockerx`, this default value prevents Docker from locating the correct binary version. According to [Docker documentation](https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope), that `ARG` is always provided when using the Buildkit backend, which I *think* is the case, but please correct me if I am wrong.