### PR TITLE
echotest exlcudes vms for skipvm flag

### DIFF
--- a/pkg/test/framework/components/echo/echotest/echotest.go
+++ b/pkg/test/framework/components/echo/echotest/echotest.go
@@ -39,5 +39,10 @@ func New(ctx framework.TestContext, instances echo.Instances) *T {
 	s, d := make(echo.Instances, len(instances)), make(echo.Instances, len(instances))
 	copy(s, instances)
 	copy(d, instances)
-	return &T{rootCtx: ctx, sources: s, destinations: d}
+	t := &T{rootCtx: ctx, sources: s, destinations: d}
+	if ctx.Settings().SkipVM {
+		noVM := Not(FilterMatch(echo.IsVirtualMachine()))
+		t = t.From(noVM).To(noVM)
+	}
+	return t
 }


### PR DESCRIPTION
An extra check to avoid using VMs when skip VM is specified. The only reason this doesn't matter is because we exclude the VM config in the echo builder; this adds another layer of safety and decouples from the current echo builder impl. 