### PR TITLE
Improve iptables debugability

### DIFF
--- a/cni/pkg/plugin/testdata/basic.txt.golden
+++ b/cni/pkg/plugin/testdata/basic.txt.golden
@@ -5,14 +5,14 @@
 -N ISTIO_OUTPUT
 -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
--A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
--A PREROUTING -p tcp -j ISTIO_INBOUND
--A ISTIO_INBOUND -p tcp --dport 22 -j RETURN
--A ISTIO_INBOUND -p tcp --dport 15020 -j RETURN
--A ISTIO_INBOUND -p tcp --dport 15021 -j RETURN
--A ISTIO_INBOUND -p tcp --dport 15090 -j RETURN
+-A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
+-A PREROUTING -p tcp -j ISTIO_INBOUND -m comment --comment "direct all traffic through ISTIO_INBOUND chain"
+-A ISTIO_INBOUND -p tcp --dport 22 -j RETURN -m comment --comment "exclude inbound port from capture"
+-A ISTIO_INBOUND -p tcp --dport 15020 -j RETURN -m comment --comment "exclude inbound port from capture"
+-A ISTIO_INBOUND -p tcp --dport 15021 -j RETURN -m comment --comment "exclude inbound port from capture"
+-A ISTIO_INBOUND -p tcp --dport 15090 -j RETURN -m comment --comment "exclude inbound port from capture"
 -A ISTIO_INBOUND -p tcp -j ISTIO_IN_REDIRECT
--A OUTPUT -p tcp -j ISTIO_OUTPUT
+-A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
 -A ISTIO_OUTPUT -p tcp --dport 15020 -j RETURN
 -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
 -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT

--- a/cni/pkg/plugin/testdata/dns.txt.golden
+++ b/cni/pkg/plugin/testdata/dns.txt.golden
@@ -5,14 +5,14 @@
 -N ISTIO_OUTPUT
 -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
--A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
--A PREROUTING -p tcp -j ISTIO_INBOUND
--A ISTIO_INBOUND -p tcp --dport 22 -j RETURN
--A ISTIO_INBOUND -p tcp --dport 15020 -j RETURN
--A ISTIO_INBOUND -p tcp --dport 15021 -j RETURN
--A ISTIO_INBOUND -p tcp --dport 15090 -j RETURN
+-A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
+-A PREROUTING -p tcp -j ISTIO_INBOUND -m comment --comment "direct all traffic through ISTIO_INBOUND chain"
+-A ISTIO_INBOUND -p tcp --dport 22 -j RETURN -m comment --comment "exclude inbound port from capture"
+-A ISTIO_INBOUND -p tcp --dport 15020 -j RETURN -m comment --comment "exclude inbound port from capture"
+-A ISTIO_INBOUND -p tcp --dport 15021 -j RETURN -m comment --comment "exclude inbound port from capture"
+-A ISTIO_INBOUND -p tcp --dport 15090 -j RETURN -m comment --comment "exclude inbound port from capture"
 -A ISTIO_INBOUND -p tcp -j ISTIO_IN_REDIRECT
--A OUTPUT -p tcp -j ISTIO_OUTPUT
+-A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
 -A ISTIO_OUTPUT -p tcp --dport 15020 -j RETURN
 -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
 -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -p tcp ! --dport 53 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT

--- a/cni/pkg/plugin/testdata/include-exclude-ip.txt.golden
+++ b/cni/pkg/plugin/testdata/include-exclude-ip.txt.golden
@@ -5,14 +5,14 @@
 -N ISTIO_OUTPUT
 -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
--A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
--A PREROUTING -p tcp -j ISTIO_INBOUND
--A ISTIO_INBOUND -p tcp --dport 22 -j RETURN
--A ISTIO_INBOUND -p tcp --dport 15020 -j RETURN
--A ISTIO_INBOUND -p tcp --dport 15021 -j RETURN
--A ISTIO_INBOUND -p tcp --dport 15090 -j RETURN
+-A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
+-A PREROUTING -p tcp -j ISTIO_INBOUND -m comment --comment "direct all traffic through ISTIO_INBOUND chain"
+-A ISTIO_INBOUND -p tcp --dport 22 -j RETURN -m comment --comment "exclude inbound port from capture"
+-A ISTIO_INBOUND -p tcp --dport 15020 -j RETURN -m comment --comment "exclude inbound port from capture"
+-A ISTIO_INBOUND -p tcp --dport 15021 -j RETURN -m comment --comment "exclude inbound port from capture"
+-A ISTIO_INBOUND -p tcp --dport 15090 -j RETURN -m comment --comment "exclude inbound port from capture"
 -A ISTIO_INBOUND -p tcp -j ISTIO_IN_REDIRECT
--A OUTPUT -p tcp -j ISTIO_OUTPUT
+-A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
 -A ISTIO_OUTPUT -p tcp --dport 15020 -j RETURN
 -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
 -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT

--- a/cni/pkg/plugin/testdata/include-exclude-ports.txt.golden
+++ b/cni/pkg/plugin/testdata/include-exclude-ports.txt.golden
@@ -5,11 +5,11 @@
 -N ISTIO_OUTPUT
 -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
--A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
--A PREROUTING -p tcp -j ISTIO_INBOUND
--A ISTIO_INBOUND -p tcp --dport 1111 -j ISTIO_IN_REDIRECT
--A ISTIO_INBOUND -p tcp --dport 2222 -j ISTIO_IN_REDIRECT
--A OUTPUT -p tcp -j ISTIO_OUTPUT
+-A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
+-A PREROUTING -p tcp -j ISTIO_INBOUND -m comment --comment "direct all traffic through ISTIO_INBOUND chain"
+-A ISTIO_INBOUND -p tcp --dport 1111 -j ISTIO_IN_REDIRECT -m comment --comment "include inbound port for capture"
+-A ISTIO_INBOUND -p tcp --dport 2222 -j ISTIO_IN_REDIRECT -m comment --comment "include inbound port for capture"
+-A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
 -A ISTIO_OUTPUT -p tcp --dport 5555 -j RETURN
 -A ISTIO_OUTPUT -p tcp --dport 6666 -j RETURN
 -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN

--- a/cni/pkg/plugin/testdata/tproxy.txt.golden
+++ b/cni/pkg/plugin/testdata/tproxy.txt.golden
@@ -5,11 +5,11 @@
 -A ISTIO_DIVERT -j MARK --set-mark 1337
 -A ISTIO_DIVERT -j ACCEPT
 -A ISTIO_TPROXY ! -d 127.0.0.1/32 -p tcp -j TPROXY --tproxy-mark 1337/0xffffffff --on-port 15006
--A PREROUTING -p tcp -j ISTIO_INBOUND
--A ISTIO_INBOUND -p tcp --dport 22 -j RETURN
--A ISTIO_INBOUND -p tcp --dport 15020 -j RETURN
--A ISTIO_INBOUND -p tcp --dport 15021 -j RETURN
--A ISTIO_INBOUND -p tcp --dport 15090 -j RETURN
+-A PREROUTING -p tcp -j ISTIO_INBOUND -m comment --comment "direct all traffic through ISTIO_INBOUND chain"
+-A ISTIO_INBOUND -p tcp --dport 22 -j RETURN -m comment --comment "exclude inbound port from capture"
+-A ISTIO_INBOUND -p tcp --dport 15020 -j RETURN -m comment --comment "exclude inbound port from capture"
+-A ISTIO_INBOUND -p tcp --dport 15021 -j RETURN -m comment --comment "exclude inbound port from capture"
+-A ISTIO_INBOUND -p tcp --dport 15090 -j RETURN -m comment --comment "exclude inbound port from capture"
 -A ISTIO_INBOUND -p tcp -m conntrack --ctstate RELATED,ESTABLISHED -j ISTIO_DIVERT
 -A ISTIO_INBOUND -p tcp -j ISTIO_TPROXY
 -A PREROUTING -p tcp -m mark --mark 1337 -j CONNMARK --save-mark
@@ -28,8 +28,8 @@ COMMIT
 -N ISTIO_OUTPUT
 -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
--A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
--A OUTPUT -p tcp -j ISTIO_OUTPUT
+-A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
+-A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
 -A ISTIO_OUTPUT -p tcp --dport 15020 -j RETURN
 -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
 -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/evanphx/json-patch v4.11.0+incompatible
 	github.com/evanphx/json-patch/v5 v5.5.0
 	github.com/fatih/color v1.12.0
+	github.com/florianl/go-nflog/v2 v2.0.0
 	github.com/fsnotify/fsnotify v1.5.1
 	github.com/ghodss/yaml v1.0.0
 	github.com/gogo/protobuf v1.3.2

--- a/go.sum
+++ b/go.sum
@@ -439,6 +439,8 @@ github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGE
 github.com/fatih/color v1.12.0 h1:mRhaKNwANqRgUBGKmnI5ZxEk7QXmjQeCcuYFMX2bfcc=
 github.com/fatih/color v1.12.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
+github.com/florianl/go-nflog/v2 v2.0.0 h1:idPb3jSXeevvNnftjgYk48R8i24h3PYwn0IKmdkFHrg=
+github.com/florianl/go-nflog/v2 v2.0.0/go.mod h1:Zku+bG/hU26B2Oti6mCJQtM1SnzRgtOUie2w3rDI5/E=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/form3tech-oss/jwt-go v3.2.3+incompatible h1:7ZaBxOI7TMoYBfyA3cQHErNNyAWIKUMIwqxEtgHOs5c=
@@ -771,6 +773,9 @@ github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8Hm
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/jpillora/backoff v1.0.0 h1:uvFg412JmmHBHw7iwprIxkPMI+sGQ4kzOWsMeHnm2EA=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
+github.com/jsimonetti/rtnetlink v0.0.0-20190606172950-9527aa82566a/go.mod h1:Oz+70psSo5OFh8DBl0Zv2ACw7Esh6pPUphlvZG9x7uw=
+github.com/jsimonetti/rtnetlink v0.0.0-20200117123717-f846d4f6c1f4 h1:nwOc1YaOrYJ37sEBrtWZrdqzK22hiJs3GpDmP3sR2Yw=
+github.com/jsimonetti/rtnetlink v0.0.0-20200117123717-f846d4f6c1f4/go.mod h1:WGuG/smIU4J/54PblvSbh+xvCZmpJnFgr3ds6Z55XMQ=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.8/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
@@ -884,6 +889,10 @@ github.com/mattn/go-sqlite3 v1.14.6/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
+github.com/mdlayher/netlink v0.0.0-20190409211403-11939a169225/go.mod h1:eQB3mZE4aiYnlUsyGGCOpPETfdQq4Jhsgf1fk3cwQaA=
+github.com/mdlayher/netlink v1.0.0/go.mod h1:KxeJAFOFLG6AjpyDkQ/iIhxygIUKD+vcwqcnu43w/+M=
+github.com/mdlayher/netlink v1.1.0 h1:mpdLgm+brq10nI9zM1BpX1kpDbh3NLl3RSnVq6ZSkfg=
+github.com/mdlayher/netlink v1.1.0/go.mod h1:H4WCitaheIsdF9yOYu8CFmCgQthAPIWZmcKp9uZHgmY=
 github.com/microcosm-cc/bluemonday v1.0.1/go.mod h1:hsXNsILzKxV+sX77C5b8FSuKF00vh2OMYv+xgHpAMF4=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.43 h1:JKfpVSCB84vrAmHzyrsxB5NAr5kLoMXZArPSw7Qlgyg=
@@ -1426,6 +1435,7 @@ golang.org/x/net v0.0.0-20190724013045-ca1201d0de80/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191004110552-13f9640d40b9/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20191007182048-72f939374954/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -1512,6 +1522,7 @@ golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190316082340-a2f829d7f35f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190321052220-f7bb7a8bee54/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190411185658-b44545bcd369/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190502145724-3ef323f4f1fd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -1532,6 +1543,7 @@ golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191001151750-bb3f8db39f24/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191002063906-3421d5a6bb1c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191022100944-742c48ecaeb7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191115151921-52ab43148777/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -1564,6 +1576,7 @@ golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200728102440-3e129f6d46b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200817155316-9781c653f443/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200828194041-157a740278f4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200831180312-196b9ba8737a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200905004654-be1d3432aa8f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200909081042-eff7692f9009/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/licenses/github.com/florianl/go-nflog/v2/LICENSE
+++ b/licenses/github.com/florianl/go-nflog/v2/LICENSE
@@ -1,0 +1,10 @@
+MIT License
+===========
+
+Copyright (C) 2018  Florian Lehner <dev@der-flo.net>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/licenses/github.com/mdlayher/netlink/LICENSE.md
+++ b/licenses/github.com/mdlayher/netlink/LICENSE.md
@@ -1,0 +1,10 @@
+MIT License
+===========
+
+Copyright (C) 2016-2019 Matt Layher
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -525,6 +525,20 @@ data:
               failureThreshold: {{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/failureThreshold` .Values.global.proxy.readinessFailureThreshold }}
             {{ end -}}
             securityContext:
+              {{- if eq (index .ProxyConfig.ProxyMetadata "IPTABLES_TRACE_LOGGING") "true" }}
+              allowPrivilegeEscalation: true
+              capabilities:
+                add:
+                - NET_ADMIN
+                drop:
+                - ALL
+              privileged: true
+              readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
+              runAsGroup: 1337
+              fsGroup: 1337
+              runAsNonRoot: false
+              runAsUser: 0
+              {{- else }}
               allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
               capabilities:
                 {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
@@ -548,6 +562,7 @@ data:
               {{- else -}}
               runAsNonRoot: true
               runAsUser: 1337
+              {{- end }}
               {{- end }}
             resources:
           {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}

--- a/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
@@ -310,6 +310,20 @@ spec:
       failureThreshold: {{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/failureThreshold` .Values.global.proxy.readinessFailureThreshold }}
     {{ end -}}
     securityContext:
+      {{- if eq (index .ProxyConfig.ProxyMetadata "IPTABLES_TRACE_LOGGING") "true" }}
+      allowPrivilegeEscalation: true
+      capabilities:
+        add:
+        - NET_ADMIN
+        drop:
+        - ALL
+      privileged: true
+      readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
+      runAsGroup: 1337
+      fsGroup: 1337
+      runAsNonRoot: false
+      runAsUser: 0
+      {{- else }}
       allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
       capabilities:
         {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
@@ -333,6 +347,7 @@ spec:
       {{- else -}}
       runAsNonRoot: true
       runAsUser: 1337
+      {{- end }}
       {{- end }}
     resources:
   {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}

--- a/manifests/charts/istiod-remote/files/injection-template.yaml
+++ b/manifests/charts/istiod-remote/files/injection-template.yaml
@@ -310,6 +310,20 @@ spec:
       failureThreshold: {{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/failureThreshold` .Values.global.proxy.readinessFailureThreshold }}
     {{ end -}}
     securityContext:
+      {{- if eq (index .ProxyConfig.ProxyMetadata "IPTABLES_TRACE_LOGGING") "true" }}
+      allowPrivilegeEscalation: true
+      capabilities:
+        add:
+        - NET_ADMIN
+        drop:
+        - ALL
+      privileged: true
+      readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
+      runAsGroup: 1337
+      fsGroup: 1337
+      runAsNonRoot: false
+      runAsUser: 0
+      {{- else }}
       allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
       capabilities:
         {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
@@ -333,6 +347,7 @@ spec:
       {{- else -}}
       runAsNonRoot: true
       runAsUser: 1337
+      {{- end }}
       {{- end }}
     resources:
   {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}

--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -39,6 +39,7 @@ import (
 	"istio.io/istio/security/pkg/stsservice/tokenmanager"
 	cleaniptables "istio.io/istio/tools/istio-clean-iptables/pkg/cmd"
 	iptables "istio.io/istio/tools/istio-iptables/pkg/cmd"
+	iptableslog "istio.io/istio/tools/istio-iptables/pkg/log"
 	"istio.io/pkg/collateral"
 	"istio.io/pkg/log"
 	"istio.io/pkg/version"
@@ -145,6 +146,8 @@ var (
 					return err
 				}
 			}
+
+			go iptableslog.ReadNFLOGSocket(ctx)
 
 			// On SIGINT or SIGTERM, cancel the context, triggering a graceful shutdown
 			go cmd.WaitSignalFunc(cancel)

--- a/tools/istio-iptables/pkg/builder/iptables_builder_impl.go
+++ b/tools/istio-iptables/pkg/builder/iptables_builder_impl.go
@@ -20,6 +20,7 @@ import (
 
 	"istio.io/istio/tools/istio-iptables/pkg/config"
 	"istio.io/istio/tools/istio-iptables/pkg/constants"
+	"istio.io/istio/tools/istio-iptables/pkg/log"
 )
 
 // Rule represents iptables rule - chain, table and options
@@ -55,58 +56,101 @@ func NewIptablesBuilder(cfg *config.Config) *IptablesBuilder {
 	}
 }
 
-func (rb *IptablesBuilder) InsertRule(chain string, table string, position int, params ...string) *IptablesBuilder {
-	rb.InsertRuleV4(chain, table, position, params...)
-	rb.InsertRuleV6(chain, table, position, params...)
+func (rb *IptablesBuilder) InsertRule(command log.Command, chain string, table string, position int, params ...string) *IptablesBuilder {
+	rb.InsertRuleV4(command, chain, table, position, params...)
+	rb.InsertRuleV6(command, chain, table, position, params...)
 	return rb
 }
 
-func (rb *IptablesBuilder) InsertRuleV4(chain string, table string, position int, params ...string) *IptablesBuilder {
-	rb.rules.rulesv4 = append(rb.rules.rulesv4, &Rule{
+func (rb *IptablesBuilder) insertInternal(ipt *[]*Rule, command log.Command, chain string, table string, position int, params ...string) *IptablesBuilder {
+	rules := params
+	// If we have a comment for this entry, insert it
+	if command.Comment != "" {
+		rules = append(rules, "-m", "comment", "--comment", fmt.Sprintf(`%q`, command.Comment))
+	}
+	*ipt = append(*ipt, &Rule{
 		chain:  chain,
 		table:  table,
-		params: append([]string{"-I", chain, fmt.Sprint(position)}, params...),
+		params: append([]string{"-I", chain, fmt.Sprint(position)}, rules...),
 	})
+	idx := indexOf("-j", params)
+	// We have identified the type of command this is and logging is enabled. Insert a rule to log this chain was hit.
+	// Since this is insert we do this *after* the real chain, which will result in it bumping it forward
+	if rb.cfg.TraceLogging && idx >= 0 && command != log.UndefinedCommand {
+		match := params[:idx]
+		// 1337 group is just a random constant to be matched on the log reader side
+		// Size of 20 allows reading the IPv4 IP header.
+		match = append(match, "-j", "NFLOG", "--nflog-prefix", fmt.Sprintf(`%q`, command.Identifier), "--nflog-group", "1337", "--nflog-size", "20")
+		*ipt = append(*ipt, &Rule{
+			chain:  chain,
+			table:  table,
+			params: append([]string{"-I", chain, fmt.Sprint(position)}, match...),
+		})
+	}
 	return rb
 }
 
-func (rb *IptablesBuilder) InsertRuleV6(chain string, table string, position int, params ...string) *IptablesBuilder {
+func (rb *IptablesBuilder) InsertRuleV4(command log.Command, chain string, table string, position int, params ...string) *IptablesBuilder {
+	return rb.insertInternal(&rb.rules.rulesv4, command, chain, table, position, params...)
+}
+
+func (rb *IptablesBuilder) InsertRuleV6(command log.Command, chain string, table string, position int, params ...string) *IptablesBuilder {
 	if !rb.cfg.EnableInboundIPv6 {
 		return rb
 	}
-	rb.rules.rulesv6 = append(rb.rules.rulesv6, &Rule{
+	return rb.insertInternal(&rb.rules.rulesv6, command, chain, table, position, params...)
+}
+
+func indexOf(element string, data []string) int {
+	for k, v := range data {
+		if element == v {
+			return k
+		}
+	}
+	return -1 // not found.
+}
+
+func (rb *IptablesBuilder) appendInternal(ipt *[]*Rule, command log.Command, chain string, table string, params ...string) *IptablesBuilder {
+	idx := indexOf("-j", params)
+	// We have identified the type of command this is and logging is enabled. Appending a rule to log this chain will be hit
+	if rb.cfg.TraceLogging && idx >= 0 && command != log.UndefinedCommand {
+		match := params[:idx]
+		// 1337 group is just a random constant to be matched on the log reader side
+		// Size of 20 allows reading the IPv4 IP header.
+		match = append(match, "-j", "NFLOG", "--nflog-prefix", fmt.Sprintf(`%q`, command.Identifier), "--nflog-group", "1337", "--nflog-size", "20")
+		*ipt = append(*ipt, &Rule{
+			chain:  chain,
+			table:  table,
+			params: append([]string{"-A", chain}, match...),
+		})
+	}
+	rules := params
+	if command.Comment != "" {
+		rules = append(rules, "-m", "comment", "--comment", fmt.Sprintf(`%q`, command.Comment))
+	}
+	*ipt = append(*ipt, &Rule{
 		chain:  chain,
 		table:  table,
-		params: append([]string{"-I", chain, fmt.Sprint(position)}, params...),
+		params: append([]string{"-A", chain}, rules...),
 	})
 	return rb
 }
 
-func (rb *IptablesBuilder) AppendRuleV4(chain string, table string, params ...string) *IptablesBuilder {
-	rb.rules.rulesv4 = append(rb.rules.rulesv4, &Rule{
-		chain:  chain,
-		table:  table,
-		params: append([]string{"-A", chain}, params...),
-	})
+func (rb *IptablesBuilder) AppendRuleV4(command log.Command, chain string, table string, params ...string) *IptablesBuilder {
+	return rb.appendInternal(&rb.rules.rulesv4, command, chain, table, params...)
+}
+
+func (rb *IptablesBuilder) AppendRule(command log.Command, chain string, table string, params ...string) *IptablesBuilder {
+	rb.AppendRuleV4(command, chain, table, params...)
+	rb.AppendRuleV6(command, chain, table, params...)
 	return rb
 }
 
-func (rb *IptablesBuilder) AppendRule(chain string, table string, params ...string) *IptablesBuilder {
-	rb.AppendRuleV4(chain, table, params...)
-	rb.AppendRuleV6(chain, table, params...)
-	return rb
-}
-
-func (rb *IptablesBuilder) AppendRuleV6(chain string, table string, params ...string) *IptablesBuilder {
+func (rb *IptablesBuilder) AppendRuleV6(command log.Command, chain string, table string, params ...string) *IptablesBuilder {
 	if !rb.cfg.EnableInboundIPv6 {
 		return rb
 	}
-	rb.rules.rulesv6 = append(rb.rules.rulesv6, &Rule{
-		chain:  chain,
-		table:  table,
-		params: append([]string{"-A", chain}, params...),
-	})
-	return rb
+	return rb.appendInternal(&rb.rules.rulesv6, command, chain, table, params...)
 }
 
 func (rb *IptablesBuilder) buildRules(command string, rules []*Rule) [][]string {
@@ -189,9 +233,9 @@ func (rb *IptablesBuilder) BuildV6Restore() string {
 
 // AppendVersionedRule takes is a wrapper around AppendRule that substitutes an ipv4/ipv6 specific value
 // in place in the params. This allows appending a dual-stack rule that has an IP value in it.
-func (rb *IptablesBuilder) AppendVersionedRule(ipv4 string, ipv6 string, chain string, table string, params ...string) {
-	rb.AppendRuleV4(chain, table, replaceVersionSpecific(ipv4, params...)...)
-	rb.AppendRuleV6(chain, table, replaceVersionSpecific(ipv6, params...)...)
+func (rb *IptablesBuilder) AppendVersionedRule(ipv4 string, ipv6 string, command log.Command, chain string, table string, params ...string) {
+	rb.AppendRuleV4(command, chain, table, replaceVersionSpecific(ipv4, params...)...)
+	rb.AppendRuleV6(command, chain, table, replaceVersionSpecific(ipv6, params...)...)
 }
 
 func replaceVersionSpecific(contents string, inputs ...string) []string {

--- a/tools/istio-iptables/pkg/builder/iptables_builder_test.go
+++ b/tools/istio-iptables/pkg/builder/iptables_builder_test.go
@@ -20,6 +20,7 @@ import (
 
 	"istio.io/istio/tools/istio-iptables/pkg/config"
 	"istio.io/istio/tools/istio-iptables/pkg/constants"
+	iptableslog "istio.io/istio/tools/istio-iptables/pkg/log"
 )
 
 // TODO(abhide): Add more testcases once BuildV6Restore() are implemented
@@ -44,7 +45,7 @@ func TestBuildV4Restore(t *testing.T) {
 
 func TestBuildV4InsertSingleRule(t *testing.T) {
 	iptables := NewIptablesBuilder(nil)
-	iptables.InsertRuleV4("chain", "table", 2, "-f", "foo", "-b", "bar")
+	iptables.InsertRuleV4(iptableslog.UndefinedCommand, "chain", "table", 2, "-f", "foo", "-b", "bar")
 	if err := len(iptables.rules.rulesv6) != 0; err {
 		t.Errorf("Expected rulesV6 to be empty; but got %#v", iptables.rules.rulesv6)
 	}
@@ -65,7 +66,7 @@ func TestBuildV4InsertSingleRule(t *testing.T) {
 
 func TestBuildV4AppendSingleRule(t *testing.T) {
 	iptables := NewIptablesBuilder(nil)
-	iptables.AppendRuleV4("chain", "table", "-f", "foo", "-b", "bar")
+	iptables.AppendRuleV4(iptableslog.UndefinedCommand, "chain", "table", "-f", "foo", "-b", "bar")
 	if err := len(iptables.rules.rulesv6) != 0; err {
 		t.Errorf("Expected rulesV6 to be empty; but got %#v", iptables.rules.rulesv6)
 	}
@@ -86,9 +87,9 @@ func TestBuildV4AppendSingleRule(t *testing.T) {
 
 func TestBuildV4AppendMultipleRules(t *testing.T) {
 	iptables := NewIptablesBuilder(nil)
-	iptables.AppendRuleV4("chain", "table", "-f", "foo", "-b", "bar")
-	iptables.AppendRuleV4("chain", "table", "-f", "fu", "-b", "bar")
-	iptables.AppendRuleV4("chain", "table", "-f", "foo", "-b", "baz")
+	iptables.AppendRuleV4(iptableslog.UndefinedCommand, "chain", "table", "-f", "foo", "-b", "bar")
+	iptables.AppendRuleV4(iptableslog.UndefinedCommand, "chain", "table", "-f", "fu", "-b", "bar")
+	iptables.AppendRuleV4(iptableslog.UndefinedCommand, "chain", "table", "-f", "foo", "-b", "baz")
 	if err := len(iptables.rules.rulesv6) != 0; err {
 		t.Errorf("Expected rulesV6 to be empty; but got %#v", iptables.rules.rulesv6)
 	}
@@ -111,9 +112,9 @@ func TestBuildV4AppendMultipleRules(t *testing.T) {
 
 func TestBuildV4InsertMultipleRules(t *testing.T) {
 	iptables := NewIptablesBuilder(nil)
-	iptables.InsertRuleV4("chain", "table", 1, "-f", "foo", "-b", "bar")
-	iptables.InsertRuleV4("chain", "table", 2, "-f", "foo", "-b", "baaz")
-	iptables.InsertRuleV4("chain", "table", 3, "-f", "foo", "-b", "baz")
+	iptables.InsertRuleV4(iptableslog.UndefinedCommand, "chain", "table", 1, "-f", "foo", "-b", "bar")
+	iptables.InsertRuleV4(iptableslog.UndefinedCommand, "chain", "table", 2, "-f", "foo", "-b", "baaz")
+	iptables.InsertRuleV4(iptableslog.UndefinedCommand, "chain", "table", 3, "-f", "foo", "-b", "baz")
 	if err := len(iptables.rules.rulesv6) != 0; err {
 		t.Errorf("Expected rulesV6 to be empty; but got %#v", iptables.rules.rulesv6)
 	}
@@ -136,9 +137,9 @@ func TestBuildV4InsertMultipleRules(t *testing.T) {
 
 func TestBuildV4AppendInsertMultipleRules(t *testing.T) {
 	iptables := NewIptablesBuilder(nil)
-	iptables.AppendRuleV4("chain", "table", "-f", "foo", "-b", "bar")
-	iptables.InsertRuleV4("chain", "table", 2, "-f", "foo", "-b", "bar")
-	iptables.AppendRuleV4("chain", "table", "-f", "foo", "-b", "baz")
+	iptables.AppendRuleV4(iptableslog.UndefinedCommand, "chain", "table", "-f", "foo", "-b", "bar")
+	iptables.InsertRuleV4(iptableslog.UndefinedCommand, "chain", "table", 2, "-f", "foo", "-b", "bar")
+	iptables.AppendRuleV4(iptableslog.UndefinedCommand, "chain", "table", "-f", "foo", "-b", "baz")
 	if err := len(iptables.rules.rulesv6) != 0; err {
 		t.Errorf("Expected rulesV6 to be empty; but got %#v", iptables.rules.rulesv6)
 	}
@@ -165,7 +166,7 @@ var IPv6Config = &config.Config{
 
 func TestBuildV6InsertSingleRule(t *testing.T) {
 	iptables := NewIptablesBuilder(IPv6Config)
-	iptables.InsertRuleV6("chain", "table", 2, "-f", "foo", "-b", "bar")
+	iptables.InsertRuleV6(iptableslog.UndefinedCommand, "chain", "table", 2, "-f", "foo", "-b", "bar")
 	if err := len(iptables.rules.rulesv4) != 0; err {
 		t.Errorf("Expected rulesV4 to be empty; but got %#v", iptables.rules.rulesv4)
 	}
@@ -186,7 +187,7 @@ func TestBuildV6InsertSingleRule(t *testing.T) {
 
 func TestBuildV6AppendSingleRule(t *testing.T) {
 	iptables := NewIptablesBuilder(IPv6Config)
-	iptables.AppendRuleV6("chain", "table", "-f", "foo", "-b", "bar")
+	iptables.AppendRuleV6(iptableslog.UndefinedCommand, "chain", "table", "-f", "foo", "-b", "bar")
 	if err := len(iptables.rules.rulesv4) != 0; err {
 		t.Errorf("Expected rulesV6 to be empty; but got %#v", iptables.rules.rulesv6)
 	}
@@ -207,9 +208,9 @@ func TestBuildV6AppendSingleRule(t *testing.T) {
 
 func TestBuildV6AppendMultipleRules(t *testing.T) {
 	iptables := NewIptablesBuilder(IPv6Config)
-	iptables.AppendRuleV6("chain", "table", "-f", "foo", "-b", "bar")
-	iptables.AppendRuleV6("chain", "table", "-f", "fu", "-b", "bar")
-	iptables.AppendRuleV6("chain", "table", "-f", "foo", "-b", "baz")
+	iptables.AppendRuleV6(iptableslog.UndefinedCommand, "chain", "table", "-f", "foo", "-b", "bar")
+	iptables.AppendRuleV6(iptableslog.UndefinedCommand, "chain", "table", "-f", "fu", "-b", "bar")
+	iptables.AppendRuleV6(iptableslog.UndefinedCommand, "chain", "table", "-f", "foo", "-b", "baz")
 	if err := len(iptables.rules.rulesv4) != 0; err {
 		t.Errorf("Expected rulesV6 to be empty; but got %#v", iptables.rules.rulesv6)
 	}
@@ -232,9 +233,9 @@ func TestBuildV6AppendMultipleRules(t *testing.T) {
 
 func TestBuildV6InsertMultipleRules(t *testing.T) {
 	iptables := NewIptablesBuilder(IPv6Config)
-	iptables.InsertRuleV6("chain", "table", 1, "-f", "foo", "-b", "bar")
-	iptables.InsertRuleV6("chain", "table", 2, "-f", "foo", "-b", "baaz")
-	iptables.InsertRuleV6("chain", "table", 3, "-f", "foo", "-b", "baz")
+	iptables.InsertRuleV6(iptableslog.UndefinedCommand, "chain", "table", 1, "-f", "foo", "-b", "bar")
+	iptables.InsertRuleV6(iptableslog.UndefinedCommand, "chain", "table", 2, "-f", "foo", "-b", "baaz")
+	iptables.InsertRuleV6(iptableslog.UndefinedCommand, "chain", "table", 3, "-f", "foo", "-b", "baz")
 	if err := len(iptables.rules.rulesv4) != 0; err {
 		t.Errorf("Expected rulesV4 to be empty; but got %#v", iptables.rules.rulesv4)
 	}
@@ -257,9 +258,9 @@ func TestBuildV6InsertMultipleRules(t *testing.T) {
 
 func TestBuildV6InsertAppendMultipleRules(t *testing.T) {
 	iptables := NewIptablesBuilder(IPv6Config)
-	iptables.AppendRuleV6("chain", "table", "-f", "foo", "-b", "bar")
-	iptables.InsertRuleV6("chain", "table", 2, "-f", "foo", "-b", "bar")
-	iptables.InsertRuleV6("chain", "table", 1, "-f", "foo", "-b", "bar")
+	iptables.AppendRuleV6(iptableslog.UndefinedCommand, "chain", "table", "-f", "foo", "-b", "bar")
+	iptables.InsertRuleV6(iptableslog.UndefinedCommand, "chain", "table", 2, "-f", "foo", "-b", "bar")
+	iptables.InsertRuleV6(iptableslog.UndefinedCommand, "chain", "table", 1, "-f", "foo", "-b", "bar")
 	if err := len(iptables.rules.rulesv4) != 0; err {
 		t.Errorf("Expected rulesV4 to be empty; but got %#v", iptables.rules.rulesv4)
 	}
@@ -282,13 +283,13 @@ func TestBuildV6InsertAppendMultipleRules(t *testing.T) {
 
 func TestBuildV4V6MultipleRulesWithNewChain(t *testing.T) {
 	iptables := NewIptablesBuilder(IPv6Config)
-	iptables.AppendRuleV4("chain", "table", "-f", "foo", "-b", "bar")
-	iptables.InsertRuleV4("chain", "table", 2, "-f", "foo", "-b", "bar")
-	iptables.AppendRuleV4("chain", "table", "-f", "foo", "-b", "baz")
-	iptables.AppendRuleV6("chain", "table", "-f", "foo", "-b", "bar")
-	iptables.InsertRuleV6("chain", "table", 2, "-f", "foo", "-b", "bar")
-	iptables.InsertRuleV6("chain", "table", 1, "-f", "foo", "-b", "bar")
-	iptables.AppendRuleV4(constants.PREROUTING, constants.NAT, "-f", "foo", "-b", "bar")
+	iptables.AppendRuleV4(iptableslog.UndefinedCommand, "chain", "table", "-f", "foo", "-b", "bar")
+	iptables.InsertRuleV4(iptableslog.UndefinedCommand, "chain", "table", 2, "-f", "foo", "-b", "bar")
+	iptables.AppendRuleV4(iptableslog.UndefinedCommand, "chain", "table", "-f", "foo", "-b", "baz")
+	iptables.AppendRuleV6(iptableslog.UndefinedCommand, "chain", "table", "-f", "foo", "-b", "bar")
+	iptables.InsertRuleV6(iptableslog.UndefinedCommand, "chain", "table", 2, "-f", "foo", "-b", "bar")
+	iptables.InsertRuleV6(iptableslog.UndefinedCommand, "chain", "table", 1, "-f", "foo", "-b", "bar")
+	iptables.AppendRuleV4(iptableslog.UndefinedCommand, constants.PREROUTING, constants.NAT, "-f", "foo", "-b", "bar")
 	actualV4 := iptables.BuildV4()
 	actualV6 := iptables.BuildV6()
 	expectedV6 := [][]string{

--- a/tools/istio-iptables/pkg/cmd/root.go
+++ b/tools/istio-iptables/pkg/cmd/root.go
@@ -96,7 +96,7 @@ func constructConfig() *config.Config {
 		OutboundPortsExclude:    viper.GetString(constants.LocalOutboundPortsExclude),
 		OutboundIPRangesInclude: viper.GetString(constants.ServiceCidr),
 		OutboundIPRangesExclude: viper.GetString(constants.ServiceExcludeCidr),
-		KubevirtInterfaces:      viper.GetString(constants.KubeVirtInterfaces),
+		KubeVirtInterfaces:      viper.GetString(constants.KubeVirtInterfaces),
 		ExcludeInterfaces:       viper.GetString(constants.ExcludeInterfaces),
 		IptablesProbePort:       uint16(viper.GetUint(constants.IptablesProbePort)),
 		ProbeTimeout:            viper.GetDuration(constants.ProbeTimeout),

--- a/tools/istio-iptables/pkg/cmd/root.go
+++ b/tools/istio-iptables/pkg/cmd/root.go
@@ -80,6 +80,7 @@ var rootCmd = &cobra.Command{
 func constructConfig() *config.Config {
 	cfg := &config.Config{
 		DryRun:                  viper.GetBool(constants.DryRun),
+		TraceLogging:            viper.GetBool(constants.TraceLogging),
 		RestoreFormat:           viper.GetBool(constants.RestoreFormat),
 		ProxyPort:               viper.GetString(constants.EnvoyPort),
 		InboundCapturePort:      viper.GetString(constants.InboundCapturePort),
@@ -267,6 +268,11 @@ func bindFlags(cmd *cobra.Command, args []string) {
 	}
 	viper.SetDefault(constants.DryRun, false)
 
+	if err := viper.BindPFlag(constants.TraceLogging, cmd.Flags().Lookup(constants.TraceLogging)); err != nil {
+		handleError(err)
+	}
+	viper.SetDefault(constants.TraceLogging, false)
+
 	if err := viper.BindPFlag(constants.RestoreFormat, cmd.Flags().Lookup(constants.RestoreFormat)); err != nil {
 		handleError(err)
 	}
@@ -372,6 +378,8 @@ func init() {
 	rootCmd.Flags().StringP(constants.InboundTProxyRouteTable, "r", "", "")
 
 	rootCmd.Flags().BoolP(constants.DryRun, "n", false, "Do not call any external dependencies like iptables")
+
+	rootCmd.Flags().Bool(constants.TraceLogging, false, "Insert tracing logs for each iptables rules, using the LOG chain.")
 
 	rootCmd.Flags().BoolP(constants.RestoreFormat, "f", true, "Print iptables rules in iptables-restore interpretable format")
 

--- a/tools/istio-iptables/pkg/cmd/run.go
+++ b/tools/istio-iptables/pkg/cmd/run.go
@@ -25,6 +25,7 @@ import (
 	"istio.io/istio/tools/istio-iptables/pkg/config"
 	"istio.io/istio/tools/istio-iptables/pkg/constants"
 	dep "istio.io/istio/tools/istio-iptables/pkg/dependencies"
+	iptableslog "istio.io/istio/tools/istio-iptables/pkg/log"
 	"istio.io/pkg/log"
 )
 
@@ -85,7 +86,7 @@ func split(s string) []string {
 	return filterEmpty(strings.Split(s, ","))
 }
 
-func (iptConfigurator *IptablesConfigurator) separateV4V6(cidrList string) (NetworkRange, NetworkRange, error) {
+func (cfg *IptablesConfigurator) separateV4V6(cidrList string) (NetworkRange, NetworkRange, error) {
 	if cidrList == "*" {
 		return NetworkRange{IsWildcard: true}, NetworkRange{IsWildcard: true}, nil
 	}
@@ -115,7 +116,7 @@ func (iptConfigurator *IptablesConfigurator) separateV4V6(cidrList string) (Netw
 	return ipv4Ranges, ipv6Ranges, nil
 }
 
-func (iptConfigurator *IptablesConfigurator) logConfig() {
+func (cfg *IptablesConfigurator) logConfig() {
 	// Dump out our environment for debugging purposes.
 	var b strings.Builder
 	b.WriteString(fmt.Sprintf("ENVOY_PORT=%s\n", os.Getenv("ENVOY_PORT")))
@@ -130,82 +131,88 @@ func (iptConfigurator *IptablesConfigurator) logConfig() {
 	b.WriteString(fmt.Sprintf("ISTIO_SERVICE_EXCLUDE_CIDR=%s\n", os.Getenv("ISTIO_SERVICE_EXCLUDE_CIDR")))
 	b.WriteString(fmt.Sprintf("ISTIO_META_DNS_CAPTURE=%s", os.Getenv("ISTIO_META_DNS_CAPTURE")))
 	log.Infof("Istio iptables environment:\n%s", b.String())
-	iptConfigurator.cfg.Print()
+	cfg.cfg.Print()
 }
 
-func (iptConfigurator *IptablesConfigurator) handleInboundPortsInclude() {
+func (cfg *IptablesConfigurator) handleInboundPortsInclude() {
 	// Handling of inbound ports. Traffic will be redirected to Envoy, which will process and forward
 	// to the local service. If not set, no inbound port will be intercepted by istio iptablesOrFail.
 	var table string
-	if iptConfigurator.cfg.InboundPortsInclude != "" {
-		if iptConfigurator.cfg.InboundInterceptionMode == constants.TPROXY {
+	if cfg.cfg.InboundPortsInclude != "" {
+		if cfg.cfg.InboundInterceptionMode == constants.TPROXY {
 			// When using TPROXY, create a new chain for routing all inbound traffic to
 			// Envoy. Any packet entering this chain gets marked with the ${INBOUND_TPROXY_MARK} mark,
 			// so that they get routed to the loopback interface in order to get redirected to Envoy.
 			// In the ISTIOINBOUND chain, '-j ISTIODIVERT' reroutes to the loopback
 			// interface.
 			// Mark all inbound packets.
-			iptConfigurator.iptables.AppendRule(constants.ISTIODIVERT, constants.MANGLE, "-j", constants.MARK, "--set-mark",
-				iptConfigurator.cfg.InboundTProxyMark)
-			iptConfigurator.iptables.AppendRule(constants.ISTIODIVERT, constants.MANGLE, "-j", constants.ACCEPT)
+			cfg.iptables.AppendRule(iptableslog.UndefinedCommand, constants.ISTIODIVERT, constants.MANGLE, "-j", constants.MARK, "--set-mark",
+				cfg.cfg.InboundTProxyMark)
+			cfg.iptables.AppendRule(iptableslog.UndefinedCommand, constants.ISTIODIVERT, constants.MANGLE, "-j", constants.ACCEPT)
 			// Route all packets marked in chain ISTIODIVERT using routing table ${INBOUND_TPROXY_ROUTE_TABLE}.
 			// TODO: (abhide): Move this out of this method
-			iptConfigurator.ext.RunOrFail(
-				constants.IP, "-f", "inet", "rule", "add", "fwmark", iptConfigurator.cfg.InboundTProxyMark, "lookup",
-				iptConfigurator.cfg.InboundTProxyRouteTable)
+			cfg.ext.RunOrFail(
+				constants.IP, "-f", "inet", "rule", "add", "fwmark", cfg.cfg.InboundTProxyMark, "lookup",
+				cfg.cfg.InboundTProxyRouteTable)
 			// In routing table ${INBOUND_TPROXY_ROUTE_TABLE}, create a single default rule to route all traffic to
 			// the loopback interface.
 			// TODO: (abhide): Move this out of this method
-			err := iptConfigurator.ext.Run(constants.IP, "-f", "inet", "route", "add", "local", "default", "dev", "lo", "table",
-				iptConfigurator.cfg.InboundTProxyRouteTable)
+			err := cfg.ext.Run(constants.IP, "-f", "inet", "route", "add", "local", "default", "dev", "lo", "table",
+				cfg.cfg.InboundTProxyRouteTable)
 			if err != nil {
 				// TODO: (abhide): Move this out of this method
-				iptConfigurator.ext.RunOrFail(constants.IP, "route", "show", "table", "all")
+				cfg.ext.RunOrFail(constants.IP, "route", "show", "table", "all")
 			}
 
 			// Create a new chain for redirecting inbound traffic to the common Envoy
 			// port.
 			// In the ISTIOINBOUND chain, '-j RETURN' bypasses Envoy and
 			// '-j ISTIOTPROXY' redirects to Envoy.
-			iptConfigurator.iptables.AppendVersionedRule("127.0.0.1/32", "::1/128", constants.ISTIOTPROXY, constants.MANGLE, "!", "-d", constants.IPVersionSpecific,
+			cfg.iptables.AppendVersionedRule("127.0.0.1/32", "::1/128", iptableslog.UndefinedCommand,
+				constants.ISTIOTPROXY, constants.MANGLE, "!", "-d", constants.IPVersionSpecific,
 				"-p", constants.TCP, "-j", constants.TPROXY,
-				"--tproxy-mark", iptConfigurator.cfg.InboundTProxyMark+"/0xffffffff", "--on-port", iptConfigurator.cfg.InboundCapturePort)
+				"--tproxy-mark", cfg.cfg.InboundTProxyMark+"/0xffffffff", "--on-port", cfg.cfg.InboundCapturePort)
 			table = constants.MANGLE
 		} else {
 			table = constants.NAT
 		}
-		iptConfigurator.iptables.AppendRule(constants.PREROUTING, table, "-p", constants.TCP, "-j", constants.ISTIOINBOUND)
+		cfg.iptables.AppendRule(iptableslog.JumpInbound, constants.PREROUTING, table, "-p", constants.TCP,
+			"-j", constants.ISTIOINBOUND)
 
-		if iptConfigurator.cfg.InboundPortsInclude == "*" {
+		if cfg.cfg.InboundPortsInclude == "*" {
 			// Makes sure SSH is not redirected
-			iptConfigurator.iptables.AppendRule(constants.ISTIOINBOUND, table, "-p", constants.TCP, "--dport", "22", "-j", constants.RETURN)
+			cfg.iptables.AppendRule(iptableslog.ExcludeInboundPort, constants.ISTIOINBOUND, table, "-p", constants.TCP,
+				"--dport", "22", "-j", constants.RETURN)
 			// Apply any user-specified port exclusions.
-			if iptConfigurator.cfg.InboundPortsExclude != "" {
-				for _, port := range split(iptConfigurator.cfg.InboundPortsExclude) {
-					iptConfigurator.iptables.AppendRule(constants.ISTIOINBOUND, table, "-p", constants.TCP, "--dport", port, "-j", constants.RETURN)
+			if cfg.cfg.InboundPortsExclude != "" {
+				for _, port := range split(cfg.cfg.InboundPortsExclude) {
+					cfg.iptables.AppendRule(iptableslog.ExcludeInboundPort, constants.ISTIOINBOUND, table, "-p", constants.TCP,
+						"--dport", port, "-j", constants.RETURN)
 				}
 			}
 			// Redirect remaining inbound traffic to Envoy.
-			if iptConfigurator.cfg.InboundInterceptionMode == constants.TPROXY {
+			if cfg.cfg.InboundInterceptionMode == constants.TPROXY {
 				// If an inbound packet belongs to an established socket, route it to the
 				// loopback interface.
-				iptConfigurator.iptables.AppendRule(constants.ISTIOINBOUND, constants.MANGLE, "-p", constants.TCP,
+				cfg.iptables.AppendRule(iptableslog.UndefinedCommand, constants.ISTIOINBOUND, constants.MANGLE, "-p", constants.TCP,
 					"-m", "conntrack", "--ctstate", "RELATED,ESTABLISHED", "-j", constants.ISTIODIVERT)
 				// Otherwise, it's a new connection. Redirect it using TPROXY.
-				iptConfigurator.iptables.AppendRule(constants.ISTIOINBOUND, constants.MANGLE, "-p", constants.TCP, "-j", constants.ISTIOTPROXY)
+				cfg.iptables.AppendRule(iptableslog.UndefinedCommand, constants.ISTIOINBOUND, constants.MANGLE, "-p", constants.TCP,
+					"-j", constants.ISTIOTPROXY)
 			} else {
-				iptConfigurator.iptables.AppendRule(constants.ISTIOINBOUND, constants.NAT, "-p", constants.TCP, "-j", constants.ISTIOINREDIRECT)
+				cfg.iptables.AppendRule(iptableslog.UndefinedCommand, constants.ISTIOINBOUND, constants.NAT, "-p", constants.TCP,
+					"-j", constants.ISTIOINREDIRECT)
 			}
 		} else {
 			// User has specified a non-empty list of ports to be redirected to Envoy.
-			for _, port := range split(iptConfigurator.cfg.InboundPortsInclude) {
-				if iptConfigurator.cfg.InboundInterceptionMode == constants.TPROXY {
-					iptConfigurator.iptables.AppendRule(constants.ISTIOINBOUND, constants.MANGLE, "-p", constants.TCP,
+			for _, port := range split(cfg.cfg.InboundPortsInclude) {
+				if cfg.cfg.InboundInterceptionMode == constants.TPROXY {
+					cfg.iptables.AppendRule(iptableslog.IncludeInboundPort, constants.ISTIOINBOUND, constants.MANGLE, "-p", constants.TCP,
 						"--dport", port, "-m", "conntrack", "--ctstate", "RELATED,ESTABLISHED", "-j", constants.ISTIODIVERT)
-					iptConfigurator.iptables.AppendRule(
+					cfg.iptables.AppendRule(iptableslog.IncludeInboundPort,
 						constants.ISTIOINBOUND, constants.MANGLE, "-p", constants.TCP, "--dport", port, "-j", constants.ISTIOTPROXY)
 				} else {
-					iptConfigurator.iptables.AppendRule(
+					cfg.iptables.AppendRule(iptableslog.IncludeInboundPort,
 						constants.ISTIOINBOUND, constants.NAT, "-p", constants.TCP, "--dport", port, "-j", constants.ISTIOINREDIRECT)
 				}
 			}
@@ -213,51 +220,51 @@ func (iptConfigurator *IptablesConfigurator) handleInboundPortsInclude() {
 	}
 }
 
-func (iptConfigurator *IptablesConfigurator) handleOutboundIncludeRules(
+func (cfg *IptablesConfigurator) handleOutboundIncludeRules(
 	rangeInclude NetworkRange,
-	appendRule func(chain string, table string, params ...string) *builder.IptablesBuilder,
-	insert func(chain string, table string, position int, params ...string) *builder.IptablesBuilder) {
+	appendRule func(command iptableslog.Command, chain string, table string, params ...string) *builder.IptablesBuilder,
+	insert func(command iptableslog.Command, chain string, table string, position int, params ...string) *builder.IptablesBuilder) {
 	// Apply outbound IP inclusions.
 	if rangeInclude.IsWildcard {
 		// Wildcard specified. Redirect all remaining outbound traffic to Envoy.
-		appendRule(constants.ISTIOOUTPUT, constants.NAT, "-j", constants.ISTIOREDIRECT)
-		for _, internalInterface := range split(iptConfigurator.cfg.KubevirtInterfaces) {
-			insert(
+		appendRule(iptableslog.UndefinedCommand, constants.ISTIOOUTPUT, constants.NAT, "-j", constants.ISTIOREDIRECT)
+		for _, internalInterface := range split(cfg.cfg.KubevirtInterfaces) {
+			insert(iptableslog.KubevirtCommand,
 				constants.PREROUTING, constants.NAT, 1, "-i", internalInterface, "-j", constants.ISTIOREDIRECT)
 		}
 	} else if len(rangeInclude.IPNets) > 0 {
 		// User has specified a non-empty list of cidrs to be redirected to Envoy.
 		for _, cidr := range rangeInclude.IPNets {
-			for _, internalInterface := range split(iptConfigurator.cfg.KubevirtInterfaces) {
-				insert(constants.PREROUTING, constants.NAT, 1, "-i", internalInterface,
+			for _, internalInterface := range split(cfg.cfg.KubevirtInterfaces) {
+				insert(iptableslog.KubevirtCommand, constants.PREROUTING, constants.NAT, 1, "-i", internalInterface,
 					"-d", cidr.String(), "-j", constants.ISTIOREDIRECT)
 			}
-			appendRule(
+			appendRule(iptableslog.UndefinedCommand,
 				constants.ISTIOOUTPUT, constants.NAT, "-d", cidr.String(), "-j", constants.ISTIOREDIRECT)
 		}
 		// All other traffic is not redirected.
-		appendRule(constants.ISTIOOUTPUT, constants.NAT, "-j", constants.RETURN)
+		appendRule(iptableslog.UndefinedCommand, constants.ISTIOOUTPUT, constants.NAT, "-j", constants.RETURN)
 	}
 }
 
-func (iptConfigurator *IptablesConfigurator) shortCircuitKubeInternalInterface() {
-	for _, internalInterface := range split(iptConfigurator.cfg.KubevirtInterfaces) {
-		iptConfigurator.iptables.InsertRule(constants.PREROUTING, constants.NAT, 1, "-i", internalInterface, "-j", constants.RETURN)
+func (cfg *IptablesConfigurator) shortCircuitKubeInternalInterface() {
+	for _, internalInterface := range split(cfg.cfg.KubevirtInterfaces) {
+		cfg.iptables.InsertRule(iptableslog.KubevirtCommand, constants.PREROUTING, constants.NAT, 1, "-i", internalInterface, "-j", constants.RETURN)
 	}
 }
 
-func (iptConfigurator *IptablesConfigurator) shortCircuitExcludeInterfaces() {
-	for _, excludeInterface := range split(iptConfigurator.cfg.ExcludeInterfaces) {
-		iptConfigurator.iptables.AppendRule(
-			constants.PREROUTING, constants.NAT, "-i", excludeInterface, "-j", constants.RETURN)
-		iptConfigurator.iptables.AppendRule(constants.OUTPUT, constants.NAT, "-o", excludeInterface, "-j", constants.RETURN)
+func (cfg *IptablesConfigurator) shortCircuitExcludeInterfaces() {
+	for _, excludeInterface := range split(cfg.cfg.ExcludeInterfaces) {
+		cfg.iptables.AppendRule(
+			iptableslog.ExcludeInterfaceCommand, constants.PREROUTING, constants.NAT, "-i", excludeInterface, "-j", constants.RETURN)
+		cfg.iptables.AppendRule(iptableslog.ExcludeInterfaceCommand, constants.OUTPUT, constants.NAT, "-o", excludeInterface, "-j", constants.RETURN)
 	}
-	if iptConfigurator.cfg.InboundInterceptionMode == constants.TPROXY {
-		for _, excludeInterface := range split(iptConfigurator.cfg.ExcludeInterfaces) {
+	if cfg.cfg.InboundInterceptionMode == constants.TPROXY {
+		for _, excludeInterface := range split(cfg.cfg.ExcludeInterfaces) {
 
-			iptConfigurator.iptables.AppendRule(
-				constants.PREROUTING, constants.MANGLE, "-i", excludeInterface, "-j", constants.RETURN)
-			iptConfigurator.iptables.AppendRule(constants.OUTPUT, constants.MANGLE, "-o", excludeInterface, "-j", constants.RETURN)
+			cfg.iptables.AppendRule(
+				iptableslog.ExcludeInterfaceCommand, constants.PREROUTING, constants.MANGLE, "-i", excludeInterface, "-j", constants.RETURN)
+			cfg.iptables.AppendRule(iptableslog.ExcludeInterfaceCommand, constants.OUTPUT, constants.MANGLE, "-o", excludeInterface, "-j", constants.RETURN)
 		}
 	}
 }
@@ -274,19 +281,19 @@ func SplitV4V6(ips []string) (ipv4 []string, ipv6 []string) {
 	return
 }
 
-func (iptConfigurator *IptablesConfigurator) run() {
+func (cfg *IptablesConfigurator) run() {
 	defer func() {
 		// Best effort since we don't know if the commands exist
-		_ = iptConfigurator.ext.Run(constants.IPTABLESSAVE)
-		if iptConfigurator.cfg.EnableInboundIPv6 {
-			_ = iptConfigurator.ext.Run(constants.IP6TABLESSAVE)
+		_ = cfg.ext.Run(constants.IPTABLESSAVE)
+		if cfg.cfg.EnableInboundIPv6 {
+			_ = cfg.ext.Run(constants.IP6TABLESSAVE)
 		}
 	}()
 
 	// Since OUTBOUND_IP_RANGES_EXCLUDE could carry ipv4 and ipv6 ranges
 	// need to split them in different arrays one for ipv4 and one for ipv6
 	// in order to not to fail
-	ipv4RangesExclude, ipv6RangesExclude, err := iptConfigurator.separateV4V6(iptConfigurator.cfg.OutboundIPRangesExclude)
+	ipv4RangesExclude, ipv6RangesExclude, err := cfg.separateV4V6(cfg.cfg.OutboundIPRangesExclude)
 	if err != nil {
 		panic(err)
 	}
@@ -295,58 +302,59 @@ func (iptConfigurator *IptablesConfigurator) run() {
 	}
 	// FixMe: Do we need similar check for ipv6RangesExclude as well ??
 
-	ipv4RangesInclude, ipv6RangesInclude, err := iptConfigurator.separateV4V6(iptConfigurator.cfg.OutboundIPRangesInclude)
+	ipv4RangesInclude, ipv6RangesInclude, err := cfg.separateV4V6(cfg.cfg.OutboundIPRangesInclude)
 	if err != nil {
 		panic(err)
 	}
 
-	redirectDNS := iptConfigurator.cfg.RedirectDNS
-	iptConfigurator.logConfig()
+	redirectDNS := cfg.cfg.RedirectDNS
+	cfg.logConfig()
 
-	if iptConfigurator.cfg.EnableInboundIPv6 {
+	if cfg.cfg.EnableInboundIPv6 {
 		// TODO: (abhide): Move this out of this method
-		iptConfigurator.ext.RunOrFail(constants.IP, "-6", "addr", "add", "::6/128", "dev", "lo")
+		cfg.ext.RunOrFail(constants.IP, "-6", "addr", "add", "::6/128", "dev", "lo")
 	}
 
-	iptConfigurator.shortCircuitExcludeInterfaces()
+	cfg.shortCircuitExcludeInterfaces()
 
 	// Do not capture internal interface.
-	iptConfigurator.shortCircuitKubeInternalInterface()
+	cfg.shortCircuitKubeInternalInterface()
 
 	// Create a new chain for to hit tunnel port directly. Envoy will be listening on port acting as VPN tunnel.
-	iptConfigurator.iptables.AppendRule(constants.ISTIOINBOUND, constants.NAT, "-p", constants.TCP, "--dport",
-		iptConfigurator.cfg.InboundTunnelPort, "-j", constants.RETURN)
+	cfg.iptables.AppendRule(iptableslog.UndefinedCommand, constants.ISTIOINBOUND, constants.NAT, "-p", constants.TCP, "--dport",
+		cfg.cfg.InboundTunnelPort, "-j", constants.RETURN)
 
 	// Create a new chain for redirecting outbound traffic to the common Envoy port.
 	// In both chains, '-j RETURN' bypasses Envoy and '-j ISTIOREDIRECT'
 	// redirects to Envoy.
-	iptConfigurator.iptables.AppendRule(
-		constants.ISTIOREDIRECT, constants.NAT, "-p", constants.TCP, "-j", constants.REDIRECT, "--to-ports", iptConfigurator.cfg.ProxyPort)
+	cfg.iptables.AppendRule(iptableslog.UndefinedCommand,
+		constants.ISTIOREDIRECT, constants.NAT, "-p", constants.TCP, "-j", constants.REDIRECT, "--to-ports", cfg.cfg.ProxyPort)
 
 	// Use this chain also for redirecting inbound traffic to the common Envoy port
 	// when not using TPROXY.
 
-	iptConfigurator.iptables.AppendRule(constants.ISTIOINREDIRECT, constants.NAT, "-p", constants.TCP, "-j", constants.REDIRECT,
-		"--to-ports", iptConfigurator.cfg.InboundCapturePort)
+	cfg.iptables.AppendRule(iptableslog.InboundCapture, constants.ISTIOINREDIRECT, constants.NAT, "-p", constants.TCP, "-j", constants.REDIRECT,
+		"--to-ports", cfg.cfg.InboundCapturePort)
 
-	iptConfigurator.handleInboundPortsInclude()
+	cfg.handleInboundPortsInclude()
 
 	// TODO: change the default behavior to not intercept any output - user may use http_proxy or another
 	// iptablesOrFail wrapper (like ufw). Current default is similar with 0.1
 	// Jump to the ISTIOOUTPUT chain from OUTPUT chain for all tcp traffic, and UDP dns (if enabled)
-	iptConfigurator.iptables.AppendRule(constants.OUTPUT, constants.NAT, "-p", constants.TCP, "-j", constants.ISTIOOUTPUT)
+	cfg.iptables.AppendRule(iptableslog.JumpOutbound, constants.OUTPUT, constants.NAT, "-p", constants.TCP, "-j", constants.ISTIOOUTPUT)
 	// Apply port based exclusions. Must be applied before connections back to self are redirected.
-	if iptConfigurator.cfg.OutboundPortsExclude != "" {
-		for _, port := range split(iptConfigurator.cfg.OutboundPortsExclude) {
-			iptConfigurator.iptables.AppendRule(constants.ISTIOOUTPUT, constants.NAT, "-p", constants.TCP, "--dport", port, "-j", constants.RETURN)
+	if cfg.cfg.OutboundPortsExclude != "" {
+		for _, port := range split(cfg.cfg.OutboundPortsExclude) {
+			cfg.iptables.AppendRule(iptableslog.UndefinedCommand, constants.ISTIOOUTPUT, constants.NAT, "-p", constants.TCP,
+				"--dport", port, "-j", constants.RETURN)
 		}
 	}
 
 	// 127.0.0.6/::7 is bind connect from inbound passthrough cluster
-	iptConfigurator.iptables.AppendVersionedRule("127.0.0.6/32", "::6/128", constants.ISTIOOUTPUT, constants.NAT,
+	cfg.iptables.AppendVersionedRule("127.0.0.6/32", "::6/128", iptableslog.UndefinedCommand, constants.ISTIOOUTPUT, constants.NAT,
 		"-o", "lo", "-s", constants.IPVersionSpecific, "-j", constants.RETURN)
 
-	for _, uid := range split(iptConfigurator.cfg.ProxyUID) {
+	for _, uid := range split(cfg.cfg.ProxyUID) {
 		// Redirect app calls back to itself via Envoy when using the service VIP
 		// e.g. appN => Envoy (client) => Envoy (server) => appN.
 		// nolint: lll
@@ -355,12 +363,12 @@ func (iptConfigurator *IptablesConfigurator) run() {
 			// app => istio-agent => Envoy inbound => dns server
 			// Instead, we just have:
 			// app => istio-agent => dns server
-			iptConfigurator.iptables.AppendVersionedRule("127.0.0.1/32", "::1/128", constants.ISTIOOUTPUT, constants.NAT,
+			cfg.iptables.AppendVersionedRule("127.0.0.1/32", "::1/128", iptableslog.UndefinedCommand, constants.ISTIOOUTPUT, constants.NAT,
 				"-o", "lo", "!", "-d", constants.IPVersionSpecific,
 				"-p", "tcp", "!", "--dport", "53",
 				"-m", "owner", "--uid-owner", uid, "-j", constants.ISTIOINREDIRECT)
 		} else {
-			iptConfigurator.iptables.AppendVersionedRule("127.0.0.1/32", "::1/128", constants.ISTIOOUTPUT, constants.NAT,
+			cfg.iptables.AppendVersionedRule("127.0.0.1/32", "::1/128", iptableslog.UndefinedCommand, constants.ISTIOOUTPUT, constants.NAT,
 				"-o", "lo", "!", "-d", constants.IPVersionSpecific,
 				"-m", "owner", "--uid-owner", uid, "-j", constants.ISTIOINREDIRECT)
 		}
@@ -375,23 +383,25 @@ func (iptConfigurator *IptablesConfigurator) run() {
 				// handle this case, we exclude port 53 from this rule. Note: We cannot just move the
 				// port 53 redirection rule further up the list, as we will want to avoid capturing
 				// DNS requests from the proxy UID/GID
-				iptConfigurator.iptables.AppendRule(constants.ISTIOOUTPUT, constants.NAT, "-o", "lo", "-p", "tcp",
+				cfg.iptables.AppendRule(iptableslog.UndefinedCommand, constants.ISTIOOUTPUT, constants.NAT, "-o", "lo", "-p", "tcp",
 					"!", "--dport", "53",
 					"-m", "owner", "!", "--uid-owner", uid, "-j", constants.RETURN)
 			} else {
-				iptConfigurator.iptables.AppendRule(constants.ISTIOOUTPUT, constants.NAT, "-o", "lo", "-m", "owner", "!", "--uid-owner", uid, "-j", constants.RETURN)
+				cfg.iptables.AppendRule(iptableslog.UndefinedCommand, constants.ISTIOOUTPUT, constants.NAT,
+					"-o", "lo", "-m", "owner", "!", "--uid-owner", uid, "-j", constants.RETURN)
 			}
 		}
 
 		// Avoid infinite loops. Don't redirect Envoy traffic directly back to
 		// Envoy for non-loopback traffic.
-		iptConfigurator.iptables.AppendRule(constants.ISTIOOUTPUT, constants.NAT, "-m", "owner", "--uid-owner", uid, "-j", constants.RETURN)
+		cfg.iptables.AppendRule(iptableslog.UndefinedCommand, constants.ISTIOOUTPUT, constants.NAT,
+			"-m", "owner", "--uid-owner", uid, "-j", constants.RETURN)
 	}
 
-	for _, gid := range split(iptConfigurator.cfg.ProxyGID) {
+	for _, gid := range split(cfg.cfg.ProxyGID) {
 		// Redirect app calls back to itself via Envoy when using the service VIP
 		// e.g. appN => Envoy (client) => Envoy (server) => appN.
-		iptConfigurator.iptables.AppendVersionedRule("127.0.0.1/32", "::1/128", constants.ISTIOOUTPUT, constants.NAT,
+		cfg.iptables.AppendVersionedRule("127.0.0.1/32", "::1/128", iptableslog.UndefinedCommand, constants.ISTIOOUTPUT, constants.NAT,
 			"-o", "lo", "!", "-d", constants.IPVersionSpecific,
 			"-m", "owner", "--gid-owner", gid, "-j", constants.ISTIOINREDIRECT)
 
@@ -405,31 +415,33 @@ func (iptConfigurator *IptablesConfigurator) run() {
 				// handle this case, we exclude port 53 from this rule. Note: We cannot just move the
 				// port 53 redirection rule further up the list, as we will want to avoid capturing
 				// DNS requests from the proxy UID/GID
-				iptConfigurator.iptables.AppendRule(constants.ISTIOOUTPUT, constants.NAT, "-o", "lo", "-p", "tcp",
+				cfg.iptables.AppendRule(iptableslog.UndefinedCommand, constants.ISTIOOUTPUT, constants.NAT,
+					"-o", "lo", "-p", "tcp",
 					"!", "--dport", "53",
 					"-m", "owner", "!", "--gid-owner", gid, "-j", constants.RETURN)
 			} else {
-				iptConfigurator.iptables.AppendRule(constants.ISTIOOUTPUT, constants.NAT, "-o", "lo", "-m", "owner", "!", "--gid-owner", gid, "-j", constants.RETURN)
+				cfg.iptables.AppendRule(iptableslog.UndefinedCommand, constants.ISTIOOUTPUT, constants.NAT,
+					"-o", "lo", "-m", "owner", "!", "--gid-owner", gid, "-j", constants.RETURN)
 			}
 		}
 
 		// Avoid infinite loops. Don't redirect Envoy traffic directly back to
 		// Envoy for non-loopback traffic.
-		iptConfigurator.iptables.AppendRule(constants.ISTIOOUTPUT, constants.NAT, "-m", "owner", "--gid-owner", gid, "-j", constants.RETURN)
+		cfg.iptables.AppendRule(iptableslog.UndefinedCommand, constants.ISTIOOUTPUT, constants.NAT, "-m", "owner", "--gid-owner", gid, "-j", constants.RETURN)
 	}
 
 	if redirectDNS {
-		if iptConfigurator.cfg.CaptureAllDNS {
+		if cfg.cfg.CaptureAllDNS {
 			// Redirect all TCP dns traffic on port 53 to the agent on port 15053
 			// This will be useful for the CNI case where pod DNS server address cannot be decided.
-			iptConfigurator.iptables.AppendRule(
+			cfg.iptables.AppendRule(iptableslog.UndefinedCommand,
 				constants.ISTIOOUTPUT, constants.NAT,
 				"-p", constants.TCP,
 				"--dport", "53",
 				"-j", constants.REDIRECT,
 				"--to-ports", constants.IstioAgentDNSListenerPort)
 		} else {
-			for _, s := range iptConfigurator.cfg.DNSServersV4 {
+			for _, s := range cfg.cfg.DNSServersV4 {
 				// redirect all TCP dns traffic on port 53 to the agent on port 15053 for all servers
 				// in etc/resolv.conf
 				// We avoid redirecting all IP ranges to avoid infinite loops when there are local DNS proxies
@@ -437,7 +449,7 @@ func (iptConfigurator *IptablesConfigurator) run() {
 				// This ensures that we do not get requests from dnsmasq sent back to the agent dns server in a loop.
 				// Note: If a user somehow configured etc/resolv.conf to point to dnsmasq and server X, and dnsmasq also
 				// pointed to server X, this would not work. However, the assumption is that is not a common case.
-				iptConfigurator.iptables.AppendRuleV4(
+				cfg.iptables.AppendRuleV4(iptableslog.UndefinedCommand,
 					constants.ISTIOOUTPUT, constants.NAT,
 					"-p", constants.TCP,
 					"--dport", "53",
@@ -445,8 +457,8 @@ func (iptConfigurator *IptablesConfigurator) run() {
 					"-j", constants.REDIRECT,
 					"--to-ports", constants.IstioAgentDNSListenerPort)
 			}
-			for _, s := range iptConfigurator.cfg.DNSServersV6 {
-				iptConfigurator.iptables.AppendRuleV6(
+			for _, s := range cfg.cfg.DNSServersV6 {
+				cfg.iptables.AppendRuleV6(iptableslog.UndefinedCommand,
 					constants.ISTIOOUTPUT, constants.NAT,
 					"-p", constants.TCP,
 					"--dport", "53",
@@ -460,61 +472,61 @@ func (iptConfigurator *IptablesConfigurator) run() {
 	// Skip redirection for Envoy-aware applications and
 	// container-to-container traffic both of which explicitly use
 	// localhost.
-	iptConfigurator.iptables.AppendVersionedRule("127.0.0.1/32", "::1/128", constants.ISTIOOUTPUT, constants.NAT,
+	cfg.iptables.AppendVersionedRule("127.0.0.1/32", "::1/128", iptableslog.UndefinedCommand, constants.ISTIOOUTPUT, constants.NAT,
 		"-d", constants.IPVersionSpecific, "-j", constants.RETURN)
 	// Apply outbound IPv4 exclusions. Must be applied before inclusions.
 	for _, cidr := range ipv4RangesExclude.IPNets {
-		iptConfigurator.iptables.AppendRuleV4(constants.ISTIOOUTPUT, constants.NAT, "-d", cidr.String(), "-j", constants.RETURN)
+		cfg.iptables.AppendRuleV4(iptableslog.UndefinedCommand, constants.ISTIOOUTPUT, constants.NAT, "-d", cidr.String(), "-j", constants.RETURN)
 	}
 	for _, cidr := range ipv6RangesExclude.IPNets {
-		iptConfigurator.iptables.AppendRuleV6(constants.ISTIOOUTPUT, constants.NAT, "-d", cidr.String(), "-j", constants.RETURN)
+		cfg.iptables.AppendRuleV6(iptableslog.UndefinedCommand, constants.ISTIOOUTPUT, constants.NAT, "-d", cidr.String(), "-j", constants.RETURN)
 	}
 
-	iptConfigurator.handleOutboundPortsInclude()
+	cfg.handleOutboundPortsInclude()
 
-	iptConfigurator.handleOutboundIncludeRules(ipv4RangesInclude, iptConfigurator.iptables.AppendRuleV4, iptConfigurator.iptables.InsertRuleV4)
-	iptConfigurator.handleOutboundIncludeRules(ipv6RangesInclude, iptConfigurator.iptables.AppendRuleV6, iptConfigurator.iptables.InsertRuleV6)
+	cfg.handleOutboundIncludeRules(ipv4RangesInclude, cfg.iptables.AppendRuleV4, cfg.iptables.InsertRuleV4)
+	cfg.handleOutboundIncludeRules(ipv6RangesInclude, cfg.iptables.AppendRuleV6, cfg.iptables.InsertRuleV6)
 
 	if redirectDNS {
 		HandleDNSUDP(
-			AppendOps, iptConfigurator.iptables, iptConfigurator.ext, "",
-			iptConfigurator.cfg.ProxyUID, iptConfigurator.cfg.ProxyGID,
-			iptConfigurator.cfg.DNSServersV4, iptConfigurator.cfg.DNSServersV6, iptConfigurator.cfg.CaptureAllDNS)
+			AppendOps, cfg.iptables, cfg.ext, "",
+			cfg.cfg.ProxyUID, cfg.cfg.ProxyGID,
+			cfg.cfg.DNSServersV4, cfg.cfg.DNSServersV6, cfg.cfg.CaptureAllDNS)
 	}
 
-	if iptConfigurator.cfg.InboundInterceptionMode == constants.TPROXY {
+	if cfg.cfg.InboundInterceptionMode == constants.TPROXY {
 		// save packet mark set by envoy.filters.listener.original_src as connection mark
-		iptConfigurator.iptables.AppendRule(constants.PREROUTING, constants.MANGLE,
-			"-p", constants.TCP, "-m", "mark", "--mark", iptConfigurator.cfg.InboundTProxyMark, "-j", "CONNMARK", "--save-mark")
+		cfg.iptables.AppendRule(iptableslog.UndefinedCommand, constants.PREROUTING, constants.MANGLE,
+			"-p", constants.TCP, "-m", "mark", "--mark", cfg.cfg.InboundTProxyMark, "-j", "CONNMARK", "--save-mark")
 		// If the packet is already marked with 1337, then return. This is to prevent mark envoy --> app traffic again.
-		iptConfigurator.iptables.AppendRule(constants.OUTPUT, constants.MANGLE,
-			"-p", constants.TCP, "-o", "lo", "-m", "mark", "--mark", iptConfigurator.cfg.InboundTProxyMark, "-j", constants.RETURN)
-		for _, uid := range split(iptConfigurator.cfg.ProxyUID) {
+		cfg.iptables.AppendRule(iptableslog.UndefinedCommand, constants.OUTPUT, constants.MANGLE,
+			"-p", constants.TCP, "-o", "lo", "-m", "mark", "--mark", cfg.cfg.InboundTProxyMark, "-j", constants.RETURN)
+		for _, uid := range split(cfg.cfg.ProxyUID) {
 			// mark outgoing packets from envoy to workload by pod ip
 			// app call VIP --> envoy outbound -(mark 1338)-> envoy inbound --> app
-			iptConfigurator.iptables.AppendRule(constants.OUTPUT, constants.MANGLE,
+			cfg.iptables.AppendRule(iptableslog.UndefinedCommand, constants.OUTPUT, constants.MANGLE,
 				"!", "-d", "127.0.0.1/32", "-p", constants.TCP, "-o", "lo", "-m", "owner", "--uid-owner", uid, "-j", constants.MARK, "--set-mark", outboundMark)
 		}
-		for _, gid := range split(iptConfigurator.cfg.ProxyGID) {
+		for _, gid := range split(cfg.cfg.ProxyGID) {
 			// mark outgoing packets from envoy to workload by pod ip
 			// app call VIP --> envoy outbound -(mark 1338)-> envoy inbound --> app
-			iptConfigurator.iptables.AppendRule(constants.OUTPUT, constants.MANGLE,
+			cfg.iptables.AppendRule(iptableslog.UndefinedCommand, constants.OUTPUT, constants.MANGLE,
 				"!", "-d", "127.0.0.1/32", "-p", constants.TCP, "-o", "lo", "-m", "owner", "--gid-owner", gid, "-j", constants.MARK, "--set-mark", outboundMark)
 		}
 		// mark outgoing packets from workload, match it to policy routing entry setup for TPROXY mode
-		iptConfigurator.iptables.AppendRule(constants.OUTPUT, constants.MANGLE,
-			"-p", constants.TCP, "-m", "connmark", "--mark", iptConfigurator.cfg.InboundTProxyMark, "-j", "CONNMARK", "--restore-mark")
+		cfg.iptables.AppendRule(iptableslog.UndefinedCommand, constants.OUTPUT, constants.MANGLE,
+			"-p", constants.TCP, "-m", "connmark", "--mark", cfg.cfg.InboundTProxyMark, "-j", "CONNMARK", "--restore-mark")
 		// prevent infinite redirect
-		iptConfigurator.iptables.InsertRule(constants.ISTIOINBOUND, constants.MANGLE, 1,
-			"-p", constants.TCP, "-m", "mark", "--mark", iptConfigurator.cfg.InboundTProxyMark, "-j", constants.RETURN)
+		cfg.iptables.InsertRule(iptableslog.UndefinedCommand, constants.ISTIOINBOUND, constants.MANGLE, 1,
+			"-p", constants.TCP, "-m", "mark", "--mark", cfg.cfg.InboundTProxyMark, "-j", constants.RETURN)
 		// prevent intercept traffic from envoy/pilot-agent ==> app by 127.0.0.6 --> podip
-		iptConfigurator.iptables.InsertRule(constants.ISTIOINBOUND, constants.MANGLE, 2,
+		cfg.iptables.InsertRule(iptableslog.UndefinedCommand, constants.ISTIOINBOUND, constants.MANGLE, 2,
 			"-p", constants.TCP, "-s", "127.0.0.6/32", "-i", "lo", "-j", constants.RETURN)
 		// prevent intercept traffic from app ==> app by pod ip
-		iptConfigurator.iptables.InsertRule(constants.ISTIOINBOUND, constants.MANGLE, 3,
+		cfg.iptables.InsertRule(iptableslog.UndefinedCommand, constants.ISTIOINBOUND, constants.MANGLE, 3,
 			"-p", constants.TCP, "-i", "lo", "-m", "mark", "!", "--mark", outboundMark, "-j", constants.RETURN)
 	}
-	iptConfigurator.executeCommands()
+	cfg.executeCommands()
 }
 
 type UDPRuleApplier struct {
@@ -529,7 +541,7 @@ type UDPRuleApplier struct {
 func (f UDPRuleApplier) RunV4(args ...string) {
 	switch f.ops {
 	case AppendOps:
-		f.iptables.AppendRuleV4(f.chain, f.table, args...)
+		f.iptables.AppendRuleV4(iptableslog.UndefinedCommand, f.chain, f.table, args...)
 	case DeleteOps:
 		deleteArgs := []string{"-t", f.table, opsToString[f.ops], f.chain}
 		deleteArgs = append(deleteArgs, args...)
@@ -540,7 +552,7 @@ func (f UDPRuleApplier) RunV4(args ...string) {
 func (f UDPRuleApplier) RunV6(args ...string) {
 	switch f.ops {
 	case AppendOps:
-		f.iptables.AppendRuleV6(f.chain, f.table, args...)
+		f.iptables.AppendRuleV6(iptableslog.UndefinedCommand, f.chain, f.table, args...)
 	case DeleteOps:
 		deleteArgs := []string{"-t", f.table, opsToString[f.ops], f.chain}
 		deleteArgs = append(deleteArgs, args...)
@@ -661,16 +673,16 @@ func addConntrackZoneDNSUDP(
 	}
 }
 
-func (iptConfigurator *IptablesConfigurator) handleOutboundPortsInclude() {
-	if iptConfigurator.cfg.OutboundPortsInclude != "" {
-		for _, port := range split(iptConfigurator.cfg.OutboundPortsInclude) {
-			iptConfigurator.iptables.AppendRule(
+func (cfg *IptablesConfigurator) handleOutboundPortsInclude() {
+	if cfg.cfg.OutboundPortsInclude != "" {
+		for _, port := range split(cfg.cfg.OutboundPortsInclude) {
+			cfg.iptables.AppendRule(iptableslog.UndefinedCommand,
 				constants.ISTIOOUTPUT, constants.NAT, "-p", constants.TCP, "--dport", port, "-j", constants.ISTIOREDIRECT)
 		}
 	}
 }
 
-func (iptConfigurator *IptablesConfigurator) createRulesFile(f *os.File, contents string) error {
+func (cfg *IptablesConfigurator) createRulesFile(f *os.File, contents string) error {
 	defer f.Close()
 	log.Infof("Writing following contents to rules file: %v\n%v", f.Name(), strings.TrimSpace(contents))
 	writer := bufio.NewWriter(f)
@@ -682,34 +694,34 @@ func (iptConfigurator *IptablesConfigurator) createRulesFile(f *os.File, content
 	return err
 }
 
-func (iptConfigurator *IptablesConfigurator) executeIptablesCommands(commands [][]string) {
+func (cfg *IptablesConfigurator) executeIptablesCommands(commands [][]string) {
 	for _, cmd := range commands {
 		if len(cmd) > 1 {
-			iptConfigurator.ext.RunOrFail(cmd[0], cmd[1:]...)
+			cfg.ext.RunOrFail(cmd[0], cmd[1:]...)
 		} else {
-			iptConfigurator.ext.RunOrFail(cmd[0])
+			cfg.ext.RunOrFail(cmd[0])
 		}
 	}
 }
 
-func (iptConfigurator *IptablesConfigurator) executeIptablesRestoreCommand(isIpv4 bool) error {
+func (cfg *IptablesConfigurator) executeIptablesRestoreCommand(isIpv4 bool) error {
 	var data, filename, cmd string
 	if isIpv4 {
-		data = iptConfigurator.iptables.BuildV4Restore()
+		data = cfg.iptables.BuildV4Restore()
 		filename = fmt.Sprintf("iptables-rules-%d.txt", time.Now().UnixNano())
 		cmd = constants.IPTABLESRESTORE
 	} else {
-		data = iptConfigurator.iptables.BuildV6Restore()
+		data = cfg.iptables.BuildV6Restore()
 		filename = fmt.Sprintf("ip6tables-rules-%d.txt", time.Now().UnixNano())
 		cmd = constants.IP6TABLESRESTORE
 	}
 	var rulesFile *os.File
 	var err error
-	if iptConfigurator.cfg.OutputPath != "" {
+	if cfg.cfg.OutputPath != "" {
 		// Print the iptables rules into the given output file.
-		rulesFile, err = os.OpenFile(iptConfigurator.cfg.OutputPath, os.O_CREATE|os.O_WRONLY, 0o644)
+		rulesFile, err = os.OpenFile(cfg.cfg.OutputPath, os.O_CREATE|os.O_WRONLY, 0o644)
 		if err != nil {
-			return fmt.Errorf("unable to open iptables rules output file %v: %v", iptConfigurator.cfg.OutputPath, err)
+			return fmt.Errorf("unable to open iptables rules output file %v: %v", cfg.cfg.OutputPath, err)
 		}
 	} else {
 		// Otherwise create a temporary file to write iptables rules to, which will be cleaned up at the end.
@@ -719,33 +731,33 @@ func (iptConfigurator *IptablesConfigurator) executeIptablesRestoreCommand(isIpv
 		}
 		defer os.Remove(rulesFile.Name())
 	}
-	if err := iptConfigurator.createRulesFile(rulesFile, data); err != nil {
+	if err := cfg.createRulesFile(rulesFile, data); err != nil {
 		return err
 	}
 	// --noflush to prevent flushing/deleting previous contents from table
-	iptConfigurator.ext.RunOrFail(cmd, "--noflush", rulesFile.Name())
+	cfg.ext.RunOrFail(cmd, "--noflush", rulesFile.Name())
 	return nil
 }
 
-func (iptConfigurator *IptablesConfigurator) executeCommands() {
-	if iptConfigurator.cfg.RestoreFormat {
+func (cfg *IptablesConfigurator) executeCommands() {
+	if cfg.cfg.RestoreFormat {
 		// Execute iptables-restore
-		err := iptConfigurator.executeIptablesRestoreCommand(true)
+		err := cfg.executeIptablesRestoreCommand(true)
 		if err != nil {
 			log.Errorf("Failed to execute iptables-restore command: %v", err)
 			os.Exit(1)
 		}
 		// Execute ip6tables-restore
-		err = iptConfigurator.executeIptablesRestoreCommand(false)
+		err = cfg.executeIptablesRestoreCommand(false)
 		if err != nil {
 			log.Errorf("Failed to execute iptables-restore command: %v", err)
 			os.Exit(1)
 		}
 	} else {
 		// Execute iptables commands
-		iptConfigurator.executeIptablesCommands(iptConfigurator.iptables.BuildV4())
+		cfg.executeIptablesCommands(cfg.iptables.BuildV4())
 		// Execute ip6tables commands
-		iptConfigurator.executeIptablesCommands(iptConfigurator.iptables.BuildV6())
+		cfg.executeIptablesCommands(cfg.iptables.BuildV6())
 
 	}
 }

--- a/tools/istio-iptables/pkg/cmd/run.go
+++ b/tools/istio-iptables/pkg/cmd/run.go
@@ -228,14 +228,14 @@ func (cfg *IptablesConfigurator) handleOutboundIncludeRules(
 	if rangeInclude.IsWildcard {
 		// Wildcard specified. Redirect all remaining outbound traffic to Envoy.
 		appendRule(iptableslog.UndefinedCommand, constants.ISTIOOUTPUT, constants.NAT, "-j", constants.ISTIOREDIRECT)
-		for _, internalInterface := range split(cfg.cfg.KubevirtInterfaces) {
+		for _, internalInterface := range split(cfg.cfg.KubeVirtInterfaces) {
 			insert(iptableslog.KubevirtCommand,
 				constants.PREROUTING, constants.NAT, 1, "-i", internalInterface, "-j", constants.ISTIOREDIRECT)
 		}
 	} else if len(rangeInclude.IPNets) > 0 {
 		// User has specified a non-empty list of cidrs to be redirected to Envoy.
 		for _, cidr := range rangeInclude.IPNets {
-			for _, internalInterface := range split(cfg.cfg.KubevirtInterfaces) {
+			for _, internalInterface := range split(cfg.cfg.KubeVirtInterfaces) {
 				insert(iptableslog.KubevirtCommand, constants.PREROUTING, constants.NAT, 1, "-i", internalInterface,
 					"-d", cidr.String(), "-j", constants.ISTIOREDIRECT)
 			}
@@ -248,7 +248,7 @@ func (cfg *IptablesConfigurator) handleOutboundIncludeRules(
 }
 
 func (cfg *IptablesConfigurator) shortCircuitKubeInternalInterface() {
-	for _, internalInterface := range split(cfg.cfg.KubevirtInterfaces) {
+	for _, internalInterface := range split(cfg.cfg.KubeVirtInterfaces) {
 		cfg.iptables.InsertRule(iptableslog.KubevirtCommand, constants.PREROUTING, constants.NAT, 1, "-i", internalInterface, "-j", constants.RETURN)
 	}
 }

--- a/tools/istio-iptables/pkg/cmd/run_test.go
+++ b/tools/istio-iptables/pkg/cmd/run_test.go
@@ -222,6 +222,12 @@ func TestIptables(t *testing.T) {
 				cfg.ExcludeInterfaces = "not-istio-nic"
 			},
 		},
+		{
+			"logging",
+			func(cfg *config.Config) {
+				cfg.TraceLogging = true
+			},
+		},
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {

--- a/tools/istio-iptables/pkg/cmd/run_test.go
+++ b/tools/istio-iptables/pkg/cmd/run_test.go
@@ -92,7 +92,7 @@ func TestIptables(t *testing.T) {
 			"ipv6-virt-interfaces",
 			func(cfg *config.Config) {
 				cfg.InboundPortsInclude = "4000,5000"
-				cfg.KubevirtInterfaces = "eth0,eth1"
+				cfg.KubeVirtInterfaces = "eth0,eth1"
 				cfg.EnableInboundIPv6 = true
 			},
 		},
@@ -101,7 +101,7 @@ func TestIptables(t *testing.T) {
 			func(cfg *config.Config) {
 				cfg.InboundPortsInclude = "4000,5000"
 				cfg.InboundPortsExclude = "6000,7000,"
-				cfg.KubevirtInterfaces = "eth0,eth1"
+				cfg.KubeVirtInterfaces = "eth0,eth1"
 				cfg.OutboundIPRangesExclude = "2001:db8::/32"
 				cfg.OutboundIPRangesInclude = "2001:db8::/32"
 				cfg.EnableInboundIPv6 = true
@@ -112,7 +112,7 @@ func TestIptables(t *testing.T) {
 			func(cfg *config.Config) {
 				cfg.InboundPortsInclude = "4000,5000"
 				cfg.InboundPortsExclude = "6000,7000"
-				cfg.KubevirtInterfaces = "eth0,eth1"
+				cfg.KubeVirtInterfaces = "eth0,eth1"
 				cfg.ProxyGID = "1,2"
 				cfg.ProxyUID = "3,4"
 				cfg.EnableInboundIPv6 = true
@@ -135,7 +135,7 @@ func TestIptables(t *testing.T) {
 		{
 			"kube-virt-interfaces",
 			func(cfg *config.Config) {
-				cfg.KubevirtInterfaces = "eth1,eth2"
+				cfg.KubeVirtInterfaces = "eth1,eth2"
 				cfg.OutboundIPRangesInclude = "*"
 			},
 		},
@@ -148,7 +148,7 @@ func TestIptables(t *testing.T) {
 		{
 			"ipnets-with-kube-virt-interfaces",
 			func(cfg *config.Config) {
-				cfg.KubevirtInterfaces = "eth1,eth2"
+				cfg.KubeVirtInterfaces = "eth1,eth2"
 				cfg.OutboundIPRangesInclude = "10.0.0.0/8"
 			},
 		},

--- a/tools/istio-iptables/pkg/cmd/testdata/basic-exclude-nic.golden
+++ b/tools/istio-iptables/pkg/cmd/testdata/basic-exclude-nic.golden
@@ -2,12 +2,12 @@ iptables -t nat -N ISTIO_INBOUND
 iptables -t nat -N ISTIO_REDIRECT
 iptables -t nat -N ISTIO_IN_REDIRECT
 iptables -t nat -N ISTIO_OUTPUT
-iptables -t nat -A PREROUTING -i not-istio-nic -j RETURN
-iptables -t nat -A OUTPUT -o not-istio-nic -j RETURN
+iptables -t nat -A PREROUTING -i not-istio-nic -j RETURN -m comment --comment "Excluded interface"
+iptables -t nat -A OUTPUT -o not-istio-nic -j RETURN -m comment --comment "Excluded interface"
 iptables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 iptables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
-iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
-iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
+iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
+iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
 iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 1337 -j RETURN

--- a/tools/istio-iptables/pkg/cmd/testdata/dns-uid-gid.golden
+++ b/tools/istio-iptables/pkg/cmd/testdata/dns-uid-gid.golden
@@ -4,8 +4,8 @@ iptables -t nat -N ISTIO_IN_REDIRECT
 iptables -t nat -N ISTIO_OUTPUT
 iptables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 iptables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
-iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
-iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
+iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
+iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
 iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -p tcp ! --dport 53 -m owner --uid-owner 3 -j ISTIO_IN_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -o lo -p tcp ! --dport 53 -m owner ! --uid-owner 3 -j RETURN
@@ -42,8 +42,8 @@ ip6tables -t nat -N ISTIO_IN_REDIRECT
 ip6tables -t nat -N ISTIO_OUTPUT
 ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 ip6tables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
-ip6tables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
-ip6tables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
+ip6tables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
+ip6tables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
 ip6tables -t nat -A ISTIO_OUTPUT -o lo -s ::6/128 -j RETURN
 ip6tables -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -p tcp ! --dport 53 -m owner --uid-owner 3 -j ISTIO_IN_REDIRECT
 ip6tables -t nat -A ISTIO_OUTPUT -o lo -p tcp ! --dport 53 -m owner ! --uid-owner 3 -j RETURN

--- a/tools/istio-iptables/pkg/cmd/testdata/empty.golden
+++ b/tools/istio-iptables/pkg/cmd/testdata/empty.golden
@@ -4,8 +4,8 @@ iptables -t nat -N ISTIO_IN_REDIRECT
 iptables -t nat -N ISTIO_OUTPUT
 iptables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 iptables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
-iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
-iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
+iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
+iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
 iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 1337 -j RETURN

--- a/tools/istio-iptables/pkg/cmd/testdata/inbound-ports-include.golden
+++ b/tools/istio-iptables/pkg/cmd/testdata/inbound-ports-include.golden
@@ -4,11 +4,11 @@ iptables -t nat -N ISTIO_IN_REDIRECT
 iptables -t nat -N ISTIO_OUTPUT
 iptables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 iptables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
-iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
-iptables -t nat -A PREROUTING -p tcp -j ISTIO_INBOUND
-iptables -t nat -A ISTIO_INBOUND -p tcp --dport 32000 -j ISTIO_IN_REDIRECT
-iptables -t nat -A ISTIO_INBOUND -p tcp --dport 31000 -j ISTIO_IN_REDIRECT
-iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
+iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
+iptables -t nat -A PREROUTING -p tcp -j ISTIO_INBOUND -m comment --comment "direct all traffic through ISTIO_INBOUND chain"
+iptables -t nat -A ISTIO_INBOUND -p tcp --dport 32000 -j ISTIO_IN_REDIRECT -m comment --comment "include inbound port for capture"
+iptables -t nat -A ISTIO_INBOUND -p tcp --dport 31000 -j ISTIO_IN_REDIRECT -m comment --comment "include inbound port for capture"
+iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
 iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 1337 -j RETURN

--- a/tools/istio-iptables/pkg/cmd/testdata/inbound-ports-tproxy.golden
+++ b/tools/istio-iptables/pkg/cmd/testdata/inbound-ports-tproxy.golden
@@ -7,16 +7,16 @@ iptables -t mangle -N ISTIO_INBOUND
 iptables -t nat -N ISTIO_OUTPUT
 iptables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 iptables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
-iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
+iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
 iptables -t mangle -A ISTIO_DIVERT -j MARK --set-mark 1337
 iptables -t mangle -A ISTIO_DIVERT -j ACCEPT
 iptables -t mangle -A ISTIO_TPROXY ! -d 127.0.0.1/32 -p tcp -j TPROXY --tproxy-mark 1337/0xffffffff --on-port 15006
-iptables -t mangle -A PREROUTING -p tcp -j ISTIO_INBOUND
-iptables -t mangle -A ISTIO_INBOUND -p tcp --dport 32000 -m conntrack --ctstate RELATED,ESTABLISHED -j ISTIO_DIVERT
-iptables -t mangle -A ISTIO_INBOUND -p tcp --dport 32000 -j ISTIO_TPROXY
-iptables -t mangle -A ISTIO_INBOUND -p tcp --dport 31000 -m conntrack --ctstate RELATED,ESTABLISHED -j ISTIO_DIVERT
-iptables -t mangle -A ISTIO_INBOUND -p tcp --dport 31000 -j ISTIO_TPROXY
-iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
+iptables -t mangle -A PREROUTING -p tcp -j ISTIO_INBOUND -m comment --comment "direct all traffic through ISTIO_INBOUND chain"
+iptables -t mangle -A ISTIO_INBOUND -p tcp --dport 32000 -m conntrack --ctstate RELATED,ESTABLISHED -j ISTIO_DIVERT -m comment --comment "include inbound port for capture"
+iptables -t mangle -A ISTIO_INBOUND -p tcp --dport 32000 -j ISTIO_TPROXY -m comment --comment "include inbound port for capture"
+iptables -t mangle -A ISTIO_INBOUND -p tcp --dport 31000 -m conntrack --ctstate RELATED,ESTABLISHED -j ISTIO_DIVERT -m comment --comment "include inbound port for capture"
+iptables -t mangle -A ISTIO_INBOUND -p tcp --dport 31000 -j ISTIO_TPROXY -m comment --comment "include inbound port for capture"
+iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
 iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 1337 -j RETURN

--- a/tools/istio-iptables/pkg/cmd/testdata/inbound-ports-wildcard-tproxy.golden
+++ b/tools/istio-iptables/pkg/cmd/testdata/inbound-ports-wildcard-tproxy.golden
@@ -7,15 +7,15 @@ iptables -t mangle -N ISTIO_INBOUND
 iptables -t nat -N ISTIO_OUTPUT
 iptables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 iptables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
-iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
+iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
 iptables -t mangle -A ISTIO_DIVERT -j MARK --set-mark 1337
 iptables -t mangle -A ISTIO_DIVERT -j ACCEPT
 iptables -t mangle -A ISTIO_TPROXY ! -d 127.0.0.1/32 -p tcp -j TPROXY --tproxy-mark 1337/0xffffffff --on-port 15006
-iptables -t mangle -A PREROUTING -p tcp -j ISTIO_INBOUND
-iptables -t mangle -A ISTIO_INBOUND -p tcp --dport 22 -j RETURN
+iptables -t mangle -A PREROUTING -p tcp -j ISTIO_INBOUND -m comment --comment "direct all traffic through ISTIO_INBOUND chain"
+iptables -t mangle -A ISTIO_INBOUND -p tcp --dport 22 -j RETURN -m comment --comment "exclude inbound port from capture"
 iptables -t mangle -A ISTIO_INBOUND -p tcp -m conntrack --ctstate RELATED,ESTABLISHED -j ISTIO_DIVERT
 iptables -t mangle -A ISTIO_INBOUND -p tcp -j ISTIO_TPROXY
-iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
+iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
 iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 1337 -j RETURN

--- a/tools/istio-iptables/pkg/cmd/testdata/inbound-ports-wildcard.golden
+++ b/tools/istio-iptables/pkg/cmd/testdata/inbound-ports-wildcard.golden
@@ -4,11 +4,11 @@ iptables -t nat -N ISTIO_IN_REDIRECT
 iptables -t nat -N ISTIO_OUTPUT
 iptables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 iptables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
-iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
-iptables -t nat -A PREROUTING -p tcp -j ISTIO_INBOUND
-iptables -t nat -A ISTIO_INBOUND -p tcp --dport 22 -j RETURN
+iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
+iptables -t nat -A PREROUTING -p tcp -j ISTIO_INBOUND -m comment --comment "direct all traffic through ISTIO_INBOUND chain"
+iptables -t nat -A ISTIO_INBOUND -p tcp --dport 22 -j RETURN -m comment --comment "exclude inbound port from capture"
 iptables -t nat -A ISTIO_INBOUND -p tcp -j ISTIO_IN_REDIRECT
-iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
+iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
 iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 1337 -j RETURN

--- a/tools/istio-iptables/pkg/cmd/testdata/ip-range.golden
+++ b/tools/istio-iptables/pkg/cmd/testdata/ip-range.golden
@@ -4,8 +4,8 @@ iptables -t nat -N ISTIO_IN_REDIRECT
 iptables -t nat -N ISTIO_OUTPUT
 iptables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 iptables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
-iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
-iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
+iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
+iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
 iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -p tcp ! --dport 53 -m owner --uid-owner 3 -j ISTIO_IN_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -o lo -p tcp ! --dport 53 -m owner ! --uid-owner 3 -j RETURN

--- a/tools/istio-iptables/pkg/cmd/testdata/ipnets-with-kube-virt-interfaces.golden
+++ b/tools/istio-iptables/pkg/cmd/testdata/ipnets-with-kube-virt-interfaces.golden
@@ -2,12 +2,12 @@ iptables -t nat -N ISTIO_INBOUND
 iptables -t nat -N ISTIO_REDIRECT
 iptables -t nat -N ISTIO_IN_REDIRECT
 iptables -t nat -N ISTIO_OUTPUT
-iptables -t nat -I PREROUTING 1 -i eth1 -j RETURN
-iptables -t nat -I PREROUTING 1 -i eth2 -j RETURN
+iptables -t nat -I PREROUTING 1 -i eth1 -j RETURN -m comment --comment "Kubevirt outbound redirect"
+iptables -t nat -I PREROUTING 1 -i eth2 -j RETURN -m comment --comment "Kubevirt outbound redirect"
 iptables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 iptables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
-iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
-iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
+iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
+iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
 iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 1337 -j RETURN
@@ -16,7 +16,7 @@ iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --gid-owner 133
 iptables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --gid-owner 1337 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -m owner --gid-owner 1337 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -d 127.0.0.1/32 -j RETURN
-iptables -t nat -I PREROUTING 1 -i eth1 -d 10.0.0.0/8 -j ISTIO_REDIRECT
-iptables -t nat -I PREROUTING 1 -i eth2 -d 10.0.0.0/8 -j ISTIO_REDIRECT
+iptables -t nat -I PREROUTING 1 -i eth1 -d 10.0.0.0/8 -j ISTIO_REDIRECT -m comment --comment "Kubevirt outbound redirect"
+iptables -t nat -I PREROUTING 1 -i eth2 -d 10.0.0.0/8 -j ISTIO_REDIRECT -m comment --comment "Kubevirt outbound redirect"
 iptables -t nat -A ISTIO_OUTPUT -d 10.0.0.0/8 -j ISTIO_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -j RETURN

--- a/tools/istio-iptables/pkg/cmd/testdata/ipnets.golden
+++ b/tools/istio-iptables/pkg/cmd/testdata/ipnets.golden
@@ -4,8 +4,8 @@ iptables -t nat -N ISTIO_IN_REDIRECT
 iptables -t nat -N ISTIO_OUTPUT
 iptables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 iptables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
-iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
-iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
+iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
+iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
 iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 1337 -j RETURN

--- a/tools/istio-iptables/pkg/cmd/testdata/ipv6-dns-uid-gid.golden
+++ b/tools/istio-iptables/pkg/cmd/testdata/ipv6-dns-uid-gid.golden
@@ -4,8 +4,8 @@ iptables -t nat -N ISTIO_IN_REDIRECT
 iptables -t nat -N ISTIO_OUTPUT
 iptables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 iptables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
-iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
-iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
+iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
+iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
 iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -p tcp ! --dport 53 -m owner --uid-owner 3 -j ISTIO_IN_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -o lo -p tcp ! --dport 53 -m owner ! --uid-owner 3 -j RETURN
@@ -38,8 +38,8 @@ ip6tables -t nat -N ISTIO_IN_REDIRECT
 ip6tables -t nat -N ISTIO_OUTPUT
 ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 ip6tables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
-ip6tables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
-ip6tables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
+ip6tables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
+ip6tables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
 ip6tables -t nat -A ISTIO_OUTPUT -o lo -s ::6/128 -j RETURN
 ip6tables -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -p tcp ! --dport 53 -m owner --uid-owner 3 -j ISTIO_IN_REDIRECT
 ip6tables -t nat -A ISTIO_OUTPUT -o lo -p tcp ! --dport 53 -m owner ! --uid-owner 3 -j RETURN

--- a/tools/istio-iptables/pkg/cmd/testdata/ipv6-empty-inbound-ports.golden
+++ b/tools/istio-iptables/pkg/cmd/testdata/ipv6-empty-inbound-ports.golden
@@ -4,8 +4,8 @@ iptables -t nat -N ISTIO_IN_REDIRECT
 iptables -t nat -N ISTIO_OUTPUT
 iptables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 iptables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
-iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
-iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
+iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
+iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
 iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 1337 -j RETURN
@@ -20,8 +20,8 @@ ip6tables -t nat -N ISTIO_IN_REDIRECT
 ip6tables -t nat -N ISTIO_OUTPUT
 ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 ip6tables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
-ip6tables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
-ip6tables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
+ip6tables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
+ip6tables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
 ip6tables -t nat -A ISTIO_OUTPUT -o lo -s ::6/128 -j RETURN
 ip6tables -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT
 ip6tables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 1337 -j RETURN

--- a/tools/istio-iptables/pkg/cmd/testdata/ipv6-inbound-ports.golden
+++ b/tools/istio-iptables/pkg/cmd/testdata/ipv6-inbound-ports.golden
@@ -4,11 +4,11 @@ iptables -t nat -N ISTIO_IN_REDIRECT
 iptables -t nat -N ISTIO_OUTPUT
 iptables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 iptables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
-iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
-iptables -t nat -A PREROUTING -p tcp -j ISTIO_INBOUND
-iptables -t nat -A ISTIO_INBOUND -p tcp --dport 4000 -j ISTIO_IN_REDIRECT
-iptables -t nat -A ISTIO_INBOUND -p tcp --dport 5000 -j ISTIO_IN_REDIRECT
-iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
+iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
+iptables -t nat -A PREROUTING -p tcp -j ISTIO_INBOUND -m comment --comment "direct all traffic through ISTIO_INBOUND chain"
+iptables -t nat -A ISTIO_INBOUND -p tcp --dport 4000 -j ISTIO_IN_REDIRECT -m comment --comment "include inbound port for capture"
+iptables -t nat -A ISTIO_INBOUND -p tcp --dport 5000 -j ISTIO_IN_REDIRECT -m comment --comment "include inbound port for capture"
+iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
 iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 1337 -j RETURN
@@ -23,11 +23,11 @@ ip6tables -t nat -N ISTIO_IN_REDIRECT
 ip6tables -t nat -N ISTIO_OUTPUT
 ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 ip6tables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
-ip6tables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
-ip6tables -t nat -A PREROUTING -p tcp -j ISTIO_INBOUND
-ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 4000 -j ISTIO_IN_REDIRECT
-ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 5000 -j ISTIO_IN_REDIRECT
-ip6tables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
+ip6tables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
+ip6tables -t nat -A PREROUTING -p tcp -j ISTIO_INBOUND -m comment --comment "direct all traffic through ISTIO_INBOUND chain"
+ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 4000 -j ISTIO_IN_REDIRECT -m comment --comment "include inbound port for capture"
+ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 5000 -j ISTIO_IN_REDIRECT -m comment --comment "include inbound port for capture"
+ip6tables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
 ip6tables -t nat -A ISTIO_OUTPUT -o lo -s ::6/128 -j RETURN
 ip6tables -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT
 ip6tables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 1337 -j RETURN

--- a/tools/istio-iptables/pkg/cmd/testdata/ipv6-ipnets.golden
+++ b/tools/istio-iptables/pkg/cmd/testdata/ipv6-ipnets.golden
@@ -2,15 +2,15 @@ iptables -t nat -N ISTIO_INBOUND
 iptables -t nat -N ISTIO_REDIRECT
 iptables -t nat -N ISTIO_IN_REDIRECT
 iptables -t nat -N ISTIO_OUTPUT
-iptables -t nat -I PREROUTING 1 -i eth0 -j RETURN
-iptables -t nat -I PREROUTING 1 -i eth1 -j RETURN
+iptables -t nat -I PREROUTING 1 -i eth0 -j RETURN -m comment --comment "Kubevirt outbound redirect"
+iptables -t nat -I PREROUTING 1 -i eth1 -j RETURN -m comment --comment "Kubevirt outbound redirect"
 iptables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 iptables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
-iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
-iptables -t nat -A PREROUTING -p tcp -j ISTIO_INBOUND
-iptables -t nat -A ISTIO_INBOUND -p tcp --dport 4000 -j ISTIO_IN_REDIRECT
-iptables -t nat -A ISTIO_INBOUND -p tcp --dport 5000 -j ISTIO_IN_REDIRECT
-iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
+iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
+iptables -t nat -A PREROUTING -p tcp -j ISTIO_INBOUND -m comment --comment "direct all traffic through ISTIO_INBOUND chain"
+iptables -t nat -A ISTIO_INBOUND -p tcp --dport 4000 -j ISTIO_IN_REDIRECT -m comment --comment "include inbound port for capture"
+iptables -t nat -A ISTIO_INBOUND -p tcp --dport 5000 -j ISTIO_IN_REDIRECT -m comment --comment "include inbound port for capture"
+iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
 iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 1337 -j RETURN
@@ -23,15 +23,15 @@ ip6tables -t nat -N ISTIO_INBOUND
 ip6tables -t nat -N ISTIO_REDIRECT
 ip6tables -t nat -N ISTIO_IN_REDIRECT
 ip6tables -t nat -N ISTIO_OUTPUT
-ip6tables -t nat -I PREROUTING 1 -i eth0 -j RETURN
-ip6tables -t nat -I PREROUTING 1 -i eth1 -j RETURN
+ip6tables -t nat -I PREROUTING 1 -i eth0 -j RETURN -m comment --comment "Kubevirt outbound redirect"
+ip6tables -t nat -I PREROUTING 1 -i eth1 -j RETURN -m comment --comment "Kubevirt outbound redirect"
 ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 ip6tables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
-ip6tables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
-ip6tables -t nat -A PREROUTING -p tcp -j ISTIO_INBOUND
-ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 4000 -j ISTIO_IN_REDIRECT
-ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 5000 -j ISTIO_IN_REDIRECT
-ip6tables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
+ip6tables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
+ip6tables -t nat -A PREROUTING -p tcp -j ISTIO_INBOUND -m comment --comment "direct all traffic through ISTIO_INBOUND chain"
+ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 4000 -j ISTIO_IN_REDIRECT -m comment --comment "include inbound port for capture"
+ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 5000 -j ISTIO_IN_REDIRECT -m comment --comment "include inbound port for capture"
+ip6tables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
 ip6tables -t nat -A ISTIO_OUTPUT -o lo -s ::6/128 -j RETURN
 ip6tables -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT
 ip6tables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 1337 -j RETURN
@@ -41,7 +41,7 @@ ip6tables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --gid-owner 1337 -j RETURN
 ip6tables -t nat -A ISTIO_OUTPUT -m owner --gid-owner 1337 -j RETURN
 ip6tables -t nat -A ISTIO_OUTPUT -d ::1/128 -j RETURN
 ip6tables -t nat -A ISTIO_OUTPUT -d 2001:db8::/32 -j RETURN
-ip6tables -t nat -I PREROUTING 1 -i eth0 -d 2001:db8::/32 -j ISTIO_REDIRECT
-ip6tables -t nat -I PREROUTING 1 -i eth1 -d 2001:db8::/32 -j ISTIO_REDIRECT
+ip6tables -t nat -I PREROUTING 1 -i eth0 -d 2001:db8::/32 -j ISTIO_REDIRECT -m comment --comment "Kubevirt outbound redirect"
+ip6tables -t nat -I PREROUTING 1 -i eth1 -d 2001:db8::/32 -j ISTIO_REDIRECT -m comment --comment "Kubevirt outbound redirect"
 ip6tables -t nat -A ISTIO_OUTPUT -d 2001:db8::/32 -j ISTIO_REDIRECT
 ip6tables -t nat -A ISTIO_OUTPUT -j RETURN

--- a/tools/istio-iptables/pkg/cmd/testdata/ipv6-outbound-ports.golden
+++ b/tools/istio-iptables/pkg/cmd/testdata/ipv6-outbound-ports.golden
@@ -4,8 +4,8 @@ iptables -t nat -N ISTIO_IN_REDIRECT
 iptables -t nat -N ISTIO_OUTPUT
 iptables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 iptables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
-iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
-iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
+iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
+iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
 iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 1337 -j RETURN
@@ -22,8 +22,8 @@ ip6tables -t nat -N ISTIO_IN_REDIRECT
 ip6tables -t nat -N ISTIO_OUTPUT
 ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 ip6tables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
-ip6tables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
-ip6tables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
+ip6tables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
+ip6tables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
 ip6tables -t nat -A ISTIO_OUTPUT -o lo -s ::6/128 -j RETURN
 ip6tables -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT
 ip6tables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 1337 -j RETURN

--- a/tools/istio-iptables/pkg/cmd/testdata/ipv6-uid-gid.golden
+++ b/tools/istio-iptables/pkg/cmd/testdata/ipv6-uid-gid.golden
@@ -2,15 +2,15 @@ iptables -t nat -N ISTIO_INBOUND
 iptables -t nat -N ISTIO_REDIRECT
 iptables -t nat -N ISTIO_IN_REDIRECT
 iptables -t nat -N ISTIO_OUTPUT
-iptables -t nat -I PREROUTING 1 -i eth0 -j RETURN
-iptables -t nat -I PREROUTING 1 -i eth1 -j RETURN
+iptables -t nat -I PREROUTING 1 -i eth0 -j RETURN -m comment --comment "Kubevirt outbound redirect"
+iptables -t nat -I PREROUTING 1 -i eth1 -j RETURN -m comment --comment "Kubevirt outbound redirect"
 iptables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 iptables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
-iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
-iptables -t nat -A PREROUTING -p tcp -j ISTIO_INBOUND
-iptables -t nat -A ISTIO_INBOUND -p tcp --dport 4000 -j ISTIO_IN_REDIRECT
-iptables -t nat -A ISTIO_INBOUND -p tcp --dport 5000 -j ISTIO_IN_REDIRECT
-iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
+iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
+iptables -t nat -A PREROUTING -p tcp -j ISTIO_INBOUND -m comment --comment "direct all traffic through ISTIO_INBOUND chain"
+iptables -t nat -A ISTIO_INBOUND -p tcp --dport 4000 -j ISTIO_IN_REDIRECT -m comment --comment "include inbound port for capture"
+iptables -t nat -A ISTIO_INBOUND -p tcp --dport 5000 -j ISTIO_IN_REDIRECT -m comment --comment "include inbound port for capture"
+iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
 iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 3 -j ISTIO_IN_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 3 -j RETURN
@@ -29,15 +29,15 @@ ip6tables -t nat -N ISTIO_INBOUND
 ip6tables -t nat -N ISTIO_REDIRECT
 ip6tables -t nat -N ISTIO_IN_REDIRECT
 ip6tables -t nat -N ISTIO_OUTPUT
-ip6tables -t nat -I PREROUTING 1 -i eth0 -j RETURN
-ip6tables -t nat -I PREROUTING 1 -i eth1 -j RETURN
+ip6tables -t nat -I PREROUTING 1 -i eth0 -j RETURN -m comment --comment "Kubevirt outbound redirect"
+ip6tables -t nat -I PREROUTING 1 -i eth1 -j RETURN -m comment --comment "Kubevirt outbound redirect"
 ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 ip6tables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
-ip6tables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
-ip6tables -t nat -A PREROUTING -p tcp -j ISTIO_INBOUND
-ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 4000 -j ISTIO_IN_REDIRECT
-ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 5000 -j ISTIO_IN_REDIRECT
-ip6tables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
+ip6tables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
+ip6tables -t nat -A PREROUTING -p tcp -j ISTIO_INBOUND -m comment --comment "direct all traffic through ISTIO_INBOUND chain"
+ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 4000 -j ISTIO_IN_REDIRECT -m comment --comment "include inbound port for capture"
+ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 5000 -j ISTIO_IN_REDIRECT -m comment --comment "include inbound port for capture"
+ip6tables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
 ip6tables -t nat -A ISTIO_OUTPUT -o lo -s ::6/128 -j RETURN
 ip6tables -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -m owner --uid-owner 3 -j ISTIO_IN_REDIRECT
 ip6tables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 3 -j RETURN
@@ -53,7 +53,7 @@ ip6tables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --gid-owner 2 -j RETURN
 ip6tables -t nat -A ISTIO_OUTPUT -m owner --gid-owner 2 -j RETURN
 ip6tables -t nat -A ISTIO_OUTPUT -d ::1/128 -j RETURN
 ip6tables -t nat -A ISTIO_OUTPUT -d 2001:db8::/32 -j RETURN
-ip6tables -t nat -I PREROUTING 1 -i eth0 -d 2001:db8::/32 -j ISTIO_REDIRECT
-ip6tables -t nat -I PREROUTING 1 -i eth1 -d 2001:db8::/32 -j ISTIO_REDIRECT
+ip6tables -t nat -I PREROUTING 1 -i eth0 -d 2001:db8::/32 -j ISTIO_REDIRECT -m comment --comment "Kubevirt outbound redirect"
+ip6tables -t nat -I PREROUTING 1 -i eth1 -d 2001:db8::/32 -j ISTIO_REDIRECT -m comment --comment "Kubevirt outbound redirect"
 ip6tables -t nat -A ISTIO_OUTPUT -d 2001:db8::/32 -j ISTIO_REDIRECT
 ip6tables -t nat -A ISTIO_OUTPUT -j RETURN

--- a/tools/istio-iptables/pkg/cmd/testdata/ipv6-virt-interfaces.golden
+++ b/tools/istio-iptables/pkg/cmd/testdata/ipv6-virt-interfaces.golden
@@ -2,15 +2,15 @@ iptables -t nat -N ISTIO_INBOUND
 iptables -t nat -N ISTIO_REDIRECT
 iptables -t nat -N ISTIO_IN_REDIRECT
 iptables -t nat -N ISTIO_OUTPUT
-iptables -t nat -I PREROUTING 1 -i eth0 -j RETURN
-iptables -t nat -I PREROUTING 1 -i eth1 -j RETURN
+iptables -t nat -I PREROUTING 1 -i eth0 -j RETURN -m comment --comment "Kubevirt outbound redirect"
+iptables -t nat -I PREROUTING 1 -i eth1 -j RETURN -m comment --comment "Kubevirt outbound redirect"
 iptables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 iptables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
-iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
-iptables -t nat -A PREROUTING -p tcp -j ISTIO_INBOUND
-iptables -t nat -A ISTIO_INBOUND -p tcp --dport 4000 -j ISTIO_IN_REDIRECT
-iptables -t nat -A ISTIO_INBOUND -p tcp --dport 5000 -j ISTIO_IN_REDIRECT
-iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
+iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
+iptables -t nat -A PREROUTING -p tcp -j ISTIO_INBOUND -m comment --comment "direct all traffic through ISTIO_INBOUND chain"
+iptables -t nat -A ISTIO_INBOUND -p tcp --dport 4000 -j ISTIO_IN_REDIRECT -m comment --comment "include inbound port for capture"
+iptables -t nat -A ISTIO_INBOUND -p tcp --dport 5000 -j ISTIO_IN_REDIRECT -m comment --comment "include inbound port for capture"
+iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
 iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 1337 -j RETURN
@@ -23,15 +23,15 @@ ip6tables -t nat -N ISTIO_INBOUND
 ip6tables -t nat -N ISTIO_REDIRECT
 ip6tables -t nat -N ISTIO_IN_REDIRECT
 ip6tables -t nat -N ISTIO_OUTPUT
-ip6tables -t nat -I PREROUTING 1 -i eth0 -j RETURN
-ip6tables -t nat -I PREROUTING 1 -i eth1 -j RETURN
+ip6tables -t nat -I PREROUTING 1 -i eth0 -j RETURN -m comment --comment "Kubevirt outbound redirect"
+ip6tables -t nat -I PREROUTING 1 -i eth1 -j RETURN -m comment --comment "Kubevirt outbound redirect"
 ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 ip6tables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
-ip6tables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
-ip6tables -t nat -A PREROUTING -p tcp -j ISTIO_INBOUND
-ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 4000 -j ISTIO_IN_REDIRECT
-ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 5000 -j ISTIO_IN_REDIRECT
-ip6tables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
+ip6tables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
+ip6tables -t nat -A PREROUTING -p tcp -j ISTIO_INBOUND -m comment --comment "direct all traffic through ISTIO_INBOUND chain"
+ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 4000 -j ISTIO_IN_REDIRECT -m comment --comment "include inbound port for capture"
+ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 5000 -j ISTIO_IN_REDIRECT -m comment --comment "include inbound port for capture"
+ip6tables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
 ip6tables -t nat -A ISTIO_OUTPUT -o lo -s ::6/128 -j RETURN
 ip6tables -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT
 ip6tables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 1337 -j RETURN

--- a/tools/istio-iptables/pkg/cmd/testdata/kube-virt-interfaces.golden
+++ b/tools/istio-iptables/pkg/cmd/testdata/kube-virt-interfaces.golden
@@ -2,12 +2,12 @@ iptables -t nat -N ISTIO_INBOUND
 iptables -t nat -N ISTIO_REDIRECT
 iptables -t nat -N ISTIO_IN_REDIRECT
 iptables -t nat -N ISTIO_OUTPUT
-iptables -t nat -I PREROUTING 1 -i eth1 -j RETURN
-iptables -t nat -I PREROUTING 1 -i eth2 -j RETURN
+iptables -t nat -I PREROUTING 1 -i eth1 -j RETURN -m comment --comment "Kubevirt outbound redirect"
+iptables -t nat -I PREROUTING 1 -i eth2 -j RETURN -m comment --comment "Kubevirt outbound redirect"
 iptables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 iptables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
-iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
-iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
+iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
+iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
 iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 1337 -j RETURN
@@ -17,5 +17,5 @@ iptables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --gid-owner 1337 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -m owner --gid-owner 1337 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -d 127.0.0.1/32 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -j ISTIO_REDIRECT
-iptables -t nat -I PREROUTING 1 -i eth1 -j ISTIO_REDIRECT
-iptables -t nat -I PREROUTING 1 -i eth2 -j ISTIO_REDIRECT
+iptables -t nat -I PREROUTING 1 -i eth1 -j ISTIO_REDIRECT -m comment --comment "Kubevirt outbound redirect"
+iptables -t nat -I PREROUTING 1 -i eth2 -j ISTIO_REDIRECT -m comment --comment "Kubevirt outbound redirect"

--- a/tools/istio-iptables/pkg/cmd/testdata/logging.golden
+++ b/tools/istio-iptables/pkg/cmd/testdata/logging.golden
@@ -4,7 +4,9 @@ iptables -t nat -N ISTIO_IN_REDIRECT
 iptables -t nat -N ISTIO_OUTPUT
 iptables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 iptables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
+iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j NFLOG --nflog-prefix "InboundCapture" --nflog-group 1337 --nflog-size 20
 iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
+iptables -t nat -A OUTPUT -p tcp -j NFLOG --nflog-prefix "JumpOutbound" --nflog-group 1337 --nflog-size 20
 iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
 iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT
@@ -14,5 +16,3 @@ iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --gid-owner 133
 iptables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --gid-owner 1337 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -m owner --gid-owner 1337 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -d 127.0.0.1/32 -j RETURN
-iptables -t nat -A ISTIO_OUTPUT -p tcp --dport 32000 -j ISTIO_REDIRECT
-iptables -t nat -A ISTIO_OUTPUT -p tcp --dport 31000 -j ISTIO_REDIRECT

--- a/tools/istio-iptables/pkg/cmd/testdata/loopback-outbound-iprange.golden
+++ b/tools/istio-iptables/pkg/cmd/testdata/loopback-outbound-iprange.golden
@@ -4,8 +4,8 @@ iptables -t nat -N ISTIO_IN_REDIRECT
 iptables -t nat -N ISTIO_OUTPUT
 iptables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 iptables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
-iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
-iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
+iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
+iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
 iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -p tcp ! --dport 53 -m owner --uid-owner 3 -j ISTIO_IN_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -m owner --uid-owner 3 -j RETURN

--- a/tools/istio-iptables/pkg/cmd/testdata/tproxy.golden
+++ b/tools/istio-iptables/pkg/cmd/testdata/tproxy.golden
@@ -5,21 +5,21 @@ iptables -t mangle -N ISTIO_DIVERT
 iptables -t mangle -N ISTIO_TPROXY
 iptables -t mangle -N ISTIO_INBOUND
 iptables -t nat -N ISTIO_OUTPUT
-iptables -t nat -A PREROUTING -i not-istio-nic -j RETURN
-iptables -t nat -A OUTPUT -o not-istio-nic -j RETURN
-iptables -t mangle -A PREROUTING -i not-istio-nic -j RETURN
-iptables -t mangle -A OUTPUT -o not-istio-nic -j RETURN
+iptables -t nat -A PREROUTING -i not-istio-nic -j RETURN -m comment --comment "Excluded interface"
+iptables -t nat -A OUTPUT -o not-istio-nic -j RETURN -m comment --comment "Excluded interface"
+iptables -t mangle -A PREROUTING -i not-istio-nic -j RETURN -m comment --comment "Excluded interface"
+iptables -t mangle -A OUTPUT -o not-istio-nic -j RETURN -m comment --comment "Excluded interface"
 iptables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 iptables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
-iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
+iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
 iptables -t mangle -A ISTIO_DIVERT -j MARK --set-mark 1337
 iptables -t mangle -A ISTIO_DIVERT -j ACCEPT
 iptables -t mangle -A ISTIO_TPROXY ! -d 127.0.0.1/32 -p tcp -j TPROXY --tproxy-mark 1337/0xffffffff --on-port 15006
-iptables -t mangle -A PREROUTING -p tcp -j ISTIO_INBOUND
-iptables -t mangle -A ISTIO_INBOUND -p tcp --dport 22 -j RETURN
+iptables -t mangle -A PREROUTING -p tcp -j ISTIO_INBOUND -m comment --comment "direct all traffic through ISTIO_INBOUND chain"
+iptables -t mangle -A ISTIO_INBOUND -p tcp --dport 22 -j RETURN -m comment --comment "exclude inbound port from capture"
 iptables -t mangle -A ISTIO_INBOUND -p tcp -m conntrack --ctstate RELATED,ESTABLISHED -j ISTIO_DIVERT
 iptables -t mangle -A ISTIO_INBOUND -p tcp -j ISTIO_TPROXY
-iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
+iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
 iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -p tcp ! --dport 53 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -o lo -p tcp ! --dport 53 -m owner ! --uid-owner 1337 -j RETURN
@@ -56,21 +56,21 @@ ip6tables -t mangle -N ISTIO_DIVERT
 ip6tables -t mangle -N ISTIO_TPROXY
 ip6tables -t mangle -N ISTIO_INBOUND
 ip6tables -t nat -N ISTIO_OUTPUT
-ip6tables -t nat -A PREROUTING -i not-istio-nic -j RETURN
-ip6tables -t nat -A OUTPUT -o not-istio-nic -j RETURN
-ip6tables -t mangle -A PREROUTING -i not-istio-nic -j RETURN
-ip6tables -t mangle -A OUTPUT -o not-istio-nic -j RETURN
+ip6tables -t nat -A PREROUTING -i not-istio-nic -j RETURN -m comment --comment "Excluded interface"
+ip6tables -t nat -A OUTPUT -o not-istio-nic -j RETURN -m comment --comment "Excluded interface"
+ip6tables -t mangle -A PREROUTING -i not-istio-nic -j RETURN -m comment --comment "Excluded interface"
+ip6tables -t mangle -A OUTPUT -o not-istio-nic -j RETURN -m comment --comment "Excluded interface"
 ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 ip6tables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
-ip6tables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
+ip6tables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
 ip6tables -t mangle -A ISTIO_DIVERT -j MARK --set-mark 1337
 ip6tables -t mangle -A ISTIO_DIVERT -j ACCEPT
 ip6tables -t mangle -A ISTIO_TPROXY ! -d ::1/128 -p tcp -j TPROXY --tproxy-mark 1337/0xffffffff --on-port 15006
-ip6tables -t mangle -A PREROUTING -p tcp -j ISTIO_INBOUND
-ip6tables -t mangle -A ISTIO_INBOUND -p tcp --dport 22 -j RETURN
+ip6tables -t mangle -A PREROUTING -p tcp -j ISTIO_INBOUND -m comment --comment "direct all traffic through ISTIO_INBOUND chain"
+ip6tables -t mangle -A ISTIO_INBOUND -p tcp --dport 22 -j RETURN -m comment --comment "exclude inbound port from capture"
 ip6tables -t mangle -A ISTIO_INBOUND -p tcp -m conntrack --ctstate RELATED,ESTABLISHED -j ISTIO_DIVERT
 ip6tables -t mangle -A ISTIO_INBOUND -p tcp -j ISTIO_TPROXY
-ip6tables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
+ip6tables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
 ip6tables -t nat -A ISTIO_OUTPUT -o lo -s ::6/128 -j RETURN
 ip6tables -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -p tcp ! --dport 53 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT
 ip6tables -t nat -A ISTIO_OUTPUT -o lo -p tcp ! --dport 53 -m owner ! --uid-owner 1337 -j RETURN

--- a/tools/istio-iptables/pkg/config/config.go
+++ b/tools/istio-iptables/pkg/config/config.go
@@ -41,7 +41,7 @@ type Config struct {
 	OutboundPortsExclude    string        `json:"OUTBOUND_PORTS_EXCLUDE"`
 	OutboundIPRangesInclude string        `json:"OUTBOUND_IPRANGES_INCLUDE"`
 	OutboundIPRangesExclude string        `json:"OUTBOUND_IPRANGES_EXCLUDE"`
-	KubevirtInterfaces      string        `json:"KUBEVIRT_INTERFACES"`
+	KubevirtInterfaces      string        `json:"KUBE_VIRT_INTERFACES"`
 	ExcludeInterfaces       string        `json:"EXCLUDE_INTERFACES"`
 	IptablesProbePort       uint16        `json:"IPTABLES_PROBE_PORT"`
 	ProbeTimeout            time.Duration `json:"PROBE_TIMEOUT"`
@@ -57,6 +57,7 @@ type Config struct {
 	OutputPath              string        `json:"OUTPUT_PATH"`
 	NetworkNamespace        string        `json:"NETWORK_NAMESPACE"`
 	CNIMode                 bool          `json:"CNI_MODE"`
+	TraceLogging            bool          `json:"IPTABLES_TRACE_LOGGING"`
 }
 
 func (c *Config) String() string {
@@ -83,7 +84,7 @@ func (c *Config) Print() {
 	b.WriteString(fmt.Sprintf("OUTBOUND_IP_RANGES_EXCLUDE=%s\n", c.OutboundIPRangesExclude))
 	b.WriteString(fmt.Sprintf("OUTBOUND_PORTS_INCLUDE=%s\n", c.OutboundPortsInclude))
 	b.WriteString(fmt.Sprintf("OUTBOUND_PORTS_EXCLUDE=%s\n", c.OutboundPortsExclude))
-	b.WriteString(fmt.Sprintf("KUBEVIRT_INTERFACES=%s\n", c.KubevirtInterfaces))
+	b.WriteString(fmt.Sprintf("KUBE_VIRT_INTERFACES=%s\n", c.KubevirtInterfaces))
 	b.WriteString(fmt.Sprintf("ENABLE_INBOUND_IPV6=%t\n", c.EnableInboundIPv6))
 	b.WriteString(fmt.Sprintf("DNS_CAPTURE=%t\n", c.RedirectDNS))
 	b.WriteString(fmt.Sprintf("CAPTURE_ALL_DNS=%t\n", c.CaptureAllDNS))

--- a/tools/istio-iptables/pkg/config/config.go
+++ b/tools/istio-iptables/pkg/config/config.go
@@ -41,7 +41,7 @@ type Config struct {
 	OutboundPortsExclude    string        `json:"OUTBOUND_PORTS_EXCLUDE"`
 	OutboundIPRangesInclude string        `json:"OUTBOUND_IPRANGES_INCLUDE"`
 	OutboundIPRangesExclude string        `json:"OUTBOUND_IPRANGES_EXCLUDE"`
-	KubevirtInterfaces      string        `json:"KUBE_VIRT_INTERFACES"`
+	KubeVirtInterfaces      string        `json:"KUBE_VIRT_INTERFACES"`
 	ExcludeInterfaces       string        `json:"EXCLUDE_INTERFACES"`
 	IptablesProbePort       uint16        `json:"IPTABLES_PROBE_PORT"`
 	ProbeTimeout            time.Duration `json:"PROBE_TIMEOUT"`
@@ -84,7 +84,7 @@ func (c *Config) Print() {
 	b.WriteString(fmt.Sprintf("OUTBOUND_IP_RANGES_EXCLUDE=%s\n", c.OutboundIPRangesExclude))
 	b.WriteString(fmt.Sprintf("OUTBOUND_PORTS_INCLUDE=%s\n", c.OutboundPortsInclude))
 	b.WriteString(fmt.Sprintf("OUTBOUND_PORTS_EXCLUDE=%s\n", c.OutboundPortsExclude))
-	b.WriteString(fmt.Sprintf("KUBE_VIRT_INTERFACES=%s\n", c.KubevirtInterfaces))
+	b.WriteString(fmt.Sprintf("KUBE_VIRT_INTERFACES=%s\n", c.KubeVirtInterfaces))
 	b.WriteString(fmt.Sprintf("ENABLE_INBOUND_IPV6=%t\n", c.EnableInboundIPv6))
 	b.WriteString(fmt.Sprintf("DNS_CAPTURE=%t\n", c.RedirectDNS))
 	b.WriteString(fmt.Sprintf("CAPTURE_ALL_DNS=%t\n", c.CaptureAllDNS))

--- a/tools/istio-iptables/pkg/constants/constants.go
+++ b/tools/istio-iptables/pkg/constants/constants.go
@@ -90,6 +90,7 @@ const (
 	ProxyGID                  = "proxy-gid"
 	KubeVirtInterfaces        = "kube-virt-interfaces"
 	DryRun                    = "dry-run"
+	TraceLogging              = "iptables-trace-logging"
 	Clean                     = "clean"
 	RestoreFormat             = "restore-format"
 	SkipRuleApply             = "skip-rule-apply"

--- a/tools/istio-iptables/pkg/log/command.go
+++ b/tools/istio-iptables/pkg/log/command.go
@@ -32,12 +32,12 @@ var (
 )
 
 var IDToCommand = map[string]Command{
-	"JumpInbound": JumpInbound,
-	"JumpOutbound": JumpOutbound,
-	"ExcludeInboundPort": ExcludeInboundPort,
-	"IncludeInboundPort": IncludeInboundPort,
-	"InboundCapture": InboundCapture,
-	"KubevirtCommand": KubevirtCommand,
+	"JumpInbound":             JumpInbound,
+	"JumpOutbound":            JumpOutbound,
+	"ExcludeInboundPort":      ExcludeInboundPort,
+	"IncludeInboundPort":      IncludeInboundPort,
+	"InboundCapture":          InboundCapture,
+	"KubevirtCommand":         KubevirtCommand,
 	"ExcludeInterfaceCommand": ExcludeInterfaceCommand,
-	"UndefinedCommand": UndefinedCommand,
+	"UndefinedCommand":        UndefinedCommand,
 }

--- a/tools/istio-iptables/pkg/log/command.go
+++ b/tools/istio-iptables/pkg/log/command.go
@@ -1,0 +1,43 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+type Command struct {
+	// Short identifier that shows up in NFLOG output. Must be less than 64 characters
+	Identifier string
+	Comment    string
+}
+
+var (
+	JumpInbound             = Command{"JumpInbound", "direct all traffic through ISTIO_INBOUND chain"}
+	JumpOutbound            = Command{"JumpOutbound", "direct all traffic through ISTIO_OUTBOUND chain"}
+	ExcludeInboundPort      = Command{"ExcludeInboundPort", "exclude inbound port from capture"}
+	IncludeInboundPort      = Command{"IncludeInboundPort", "include inbound port for capture"}
+	InboundCapture          = Command{"InboundCapture", "redirect inbound request to proxy"}
+	KubevirtCommand         = Command{"KubevirtCommand", "Kubevirt outbound redirect"}
+	ExcludeInterfaceCommand = Command{"ExcludeInterfaceCommand", "Excluded interface"}
+	UndefinedCommand        = Command{"UndefinedCommand", ""}
+)
+
+var IDToCommand = map[string]Command{
+	"JumpInbound": JumpInbound,
+	"JumpOutbound": JumpOutbound,
+	"ExcludeInboundPort": ExcludeInboundPort,
+	"IncludeInboundPort": IncludeInboundPort,
+	"InboundCapture": InboundCapture,
+	"KubevirtCommand": KubevirtCommand,
+	"ExcludeInterfaceCommand": ExcludeInterfaceCommand,
+	"UndefinedCommand": UndefinedCommand,
+}

--- a/tools/istio-iptables/pkg/log/nflog.go
+++ b/tools/istio-iptables/pkg/log/nflog.go
@@ -1,0 +1,117 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"context"
+	golog "log"
+	"net"
+	"os"
+	"time"
+
+	"github.com/florianl/go-nflog/v2"
+	"golang.org/x/net/ipv4"
+
+	"istio.io/pkg/env"
+	"istio.io/pkg/log"
+)
+
+var TraceLoggingEnabled = env.RegisterBoolVar(
+	"IPTABLES_TRACE_LOGGING",
+	false,
+	"When enable, all iptables actions will be logged. "+
+		"This requires NET_ADMIN privilege and has noisy logs; as a result, this is intended for debugging only").Get()
+
+var iptablesTrace = log.RegisterScope("iptables", "trace logs for iptables", 0)
+
+// ReadNFLOGSocket reads from the nflog socket, sending output to logs.
+// This is intended for debugging only.
+func ReadNFLOGSocket(ctx context.Context) {
+	if !TraceLoggingEnabled {
+		return
+	}
+	iptablesTrace.Infof("starting nftable log")
+	// We expect to read logs from rules like:
+	// `-j NFLOG --nflog-group 1337`
+	config := nflog.Config{
+		Group:       1337,
+		Copymode:    nflog.CopyPacket,
+		ReadTimeout: 10 * time.Millisecond,
+		Logger:      golog.New(os.Stdout, "nflog log", 0),
+	}
+
+	nf, err := nflog.Open(&config)
+	if err != nil {
+		log.Errorf("could not open nflog socket: %v", err)
+		return
+	}
+	defer nf.Close()
+
+	fn := func(attrs nflog.Attribute) int {
+		src, dst := "", ""
+		if attrs.Payload != nil {
+			v4, err := ipv4.ParseHeader(*attrs.Payload)
+			if err == nil {
+				src = v4.Src.String()
+				dst = v4.Dst.String()
+			}
+		}
+		prefix := ""
+		if attrs.Prefix != nil {
+			prefix = *attrs.Prefix
+		}
+		comment := IDToCommand[prefix].Comment
+		uid, gid := uint32(0), uint32(0)
+		if attrs.UID != nil {
+			uid = *attrs.UID
+		}
+		if attrs.GID != nil {
+			gid = *attrs.GID
+		}
+		inDev, outDev := "", ""
+		if attrs.InDev != nil {
+			ii, err := net.InterfaceByIndex(int(*attrs.InDev))
+			if err == nil {
+				inDev = ii.Name
+			}
+		}
+		if attrs.OutDev != nil {
+			ii, err := net.InterfaceByIndex(int(*attrs.OutDev))
+			if err == nil {
+				outDev = ii.Name
+			}
+		}
+		iptablesTrace.WithLabels(
+			"command", prefix,
+			"uid", uid,
+			"gid", gid,
+			"inDev", inDev,
+			"outDev", outDev,
+			"src", src,
+			"dst", dst,
+		).Infof(comment)
+		return 0
+	}
+
+	// Register our callback for the nflog
+	err = nf.Register(ctx, fn)
+	if err != nil {
+		log.Errorf("failed to register nflog callback: %v", err)
+		return
+	}
+
+	// Block util the context expires
+	<-ctx.Done()
+}


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/33965

This adds two big changes to iptables:
* comment each iptables rule, to explain what it is doing
* Add (optional) trace logging to each rule. This allows seeing which rules each packet hits. The istio-agent will emit these logs, which requires NET_ADMIN. This is meant for spot-debugging only and not intended to run continually -- it is very noisy.

This PR has the base foundation complete, but it is not fully implemented - only a few of the chains will emit logs currently. Opening early to get feedback.

Example outbound request:
```
2021-07-20T23:32:16.925827Z     info    iptables        direct all traffic through ISTIO_OUTBOUND chain command=IPT02 uid=0 gid=0 inDev= outDev=eth0 src=10.244.0.42 dst=10.96.116.22
2021-07-20T23:32:16.926390Z     info    iptables        direct all traffic through ISTIO_OUTBOUND chain command=IPT02 uid=0 gid=1337 inDev= outDev=eth0 src=10.244.0.42 dst=10.244.0.6
```
Here you can see request to envoy, and the request from envoy.