### PR TITLE
fix TestRemoteClusters flake

### DIFF
--- a/tests/integration/pilot/istioctl_test.go
+++ b/tests/integration/pilot/istioctl_test.go
@@ -535,13 +535,12 @@ func TestKubeInject(t *testing.T) {
 }
 
 func TestRemoteClusters(t *testing.T) {
-	t.Skip("https://github.com/istio/istio/issues/34192")
 	framework.NewTest(t).Features("usability.observability.remote-clusters").
 		RequiresMinClusters(2).
 		Run(func(t framework.TestContext) {
 			for _, cluster := range t.Clusters().Primaries() {
 				cluster := cluster
-				t.NewSubTest(cluster.StableName()).RunParallel(func(t framework.TestContext) {
+				t.NewSubTest(cluster.StableName()).Run(func(t framework.TestContext) {
 					istioCtl := istioctl.NewOrFail(t, t, istioctl.Config{Cluster: cluster})
 					var output string
 					args := []string{"x", "remote-clusters"}


### PR DESCRIPTION
It seems like `primary` is showing the results from `cross-network-primary`'s istiod... I captured the loop var in a new closure so I'm not sure why that's happening. Switching away from `RunParallel` to see if it fixes https://github.com/istio/istio/issues/34192