### PR TITLE
Update exclude namespaces default for istio-cni.

### DIFF
--- a/manifests/charts/istio-cni/values.yaml
+++ b/manifests/charts/istio-cni/values.yaml
@@ -19,6 +19,7 @@ cni:
 
   excludeNamespaces:
     - istio-system
+    - kube-system
 
   # Custom annotations on pod level, if you need them
   podAnnotations: {}


### PR DESCRIPTION
Typically `kube-system` will be excluded as well.