### PR TITLE
Fix panic when use generators

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"istio.io/istio/pilot/pkg/networking/apigen"
 	"net"
 	"net/http"
 	"os"
@@ -264,6 +265,8 @@ func NewServer(args *PilotArgs, initFuncs ...func(*Server)) (*Server, error) {
 	if err := s.initControllers(args); err != nil {
 		return nil, err
 	}
+
+	s.XDSServer.Generators["api"] = apigen.NewGenerator(e.IstioConfigStore)
 
 	// Initialize workloadTrustBundle after CA has been initialized
 	if err := s.initWorkloadTrustBundle(args); err != nil {

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"istio.io/istio/pilot/pkg/networking/apigen"
 	"net"
 	"net/http"
 	"os"
@@ -266,7 +265,7 @@ func NewServer(args *PilotArgs, initFuncs ...func(*Server)) (*Server, error) {
 		return nil, err
 	}
 
-	s.XDSServer.Generators["api"] = apigen.NewGenerator(e.IstioConfigStore)
+	s.XDSServer.InitGenerators(e, args.Namespace)
 
 	// Initialize workloadTrustBundle after CA has been initialized
 	if err := s.initWorkloadTrustBundle(args); err != nil {

--- a/pilot/pkg/xds/discovery.go
+++ b/pilot/pkg/xds/discovery.go
@@ -196,8 +196,6 @@ func NewDiscoveryServer(env *model.Environment, plugins []string, instanceID str
 
 	out.initJwksResolver()
 
-	out.initGenerators(env, systemNameSpace)
-
 	if features.EnableXDSCaching {
 		out.Cache = model.NewXdsCache()
 	}
@@ -536,8 +534,8 @@ func (s *DiscoveryServer) sendPushes(stopCh <-chan struct{}) {
 	doSendPushes(stopCh, s.concurrentPushLimit, s.pushQueue)
 }
 
-// initGenerators initializes generators to be used by XdsServer.
-func (s *DiscoveryServer) initGenerators(env *model.Environment, systemNameSpace string) {
+// InitGenerators initializes generators to be used by XdsServer.
+func (s *DiscoveryServer) InitGenerators(env *model.Environment, systemNameSpace string) {
 	edsGen := &EdsGenerator{Server: s}
 	s.StatusGen = NewStatusGen(s)
 	s.Generators[v3.ClusterType] = &CdsGenerator{Server: s}

--- a/pilot/pkg/xds/fake.go
+++ b/pilot/pkg/xds/fake.go
@@ -115,6 +115,7 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 	// Init with a dummy environment, since we have a circular dependency with the env creation.
 	s := NewDiscoveryServer(&model.Environment{PushContext: model.NewPushContext()}, []string{plugin.AuthzCustom, plugin.Authn, plugin.Authz},
 		"pilot-123", "istio-system")
+	s.InitGenerators(&model.Environment{PushContext: model.NewPushContext()}, "istio-system")
 	t.Cleanup(func() {
 		s.JwtKeyResolver.Close()
 		s.pushQueue.ShutDown()

--- a/pilot/pkg/xds/simple.go
+++ b/pilot/pkg/xds/simple.go
@@ -80,6 +80,7 @@ func NewXDS(stop chan struct{}) *SimpleServer {
 	env.Init()
 
 	ds := NewDiscoveryServer(env, nil, "istiod", "istio-system")
+	ds.InitGenerators(env, "istio-system")
 	ds.CachesSynced()
 
 	// Config will have a fixed format:


### PR DESCRIPTION

When I use the master branch code to reproduce this issue https://github.com/istio/istio/issues/34126 ，I found a panic error

```
2021-07-22T01:41:10.072491Z	info	ads	RDS: PUSH for node:reviews-v3-84779c7bbc-246qn.default resources:15 size:11.6kB
2021-07-22T01:41:11.417046Z	info	ads	ADS: new connection for node:test-1.default-7
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0x2b5a95a]

goroutine 683 [running]:
istio.io/istio/pilot/pkg/networking/apigen.(*APIGenerator).Generate(0xc0011ad9d0, 0xc00272e400, 0xc001036000, 0xc002717550, 0xc0018e2f50, 0xc00270d600, 0x29, 0xc00270d8c0, 0x2d, 0xd0, ...)
	istio.io/istio/pilot/pkg/networking/apigen/apigen.go:108 +0x25a
istio.io/istio/pilot/pkg/xds.(*DiscoveryServer).pushXds(0xc0011a1680, 0xc000826780, 0xc001036000, 0xc00012cab0, 0x16, 0xc002717550, 0xc0018e2f50, 0x0, 0x0)
	istio.io/istio/pilot/pkg/xds/xdsgen.go:101 +0x1d6
istio.io/istio/pilot/pkg/xds.(*DiscoveryServer).processRequest(0xc0011a1680, 0xc001e56f00, 0xc000826780, 0x0, 0x3)
	istio.io/istio/pilot/pkg/xds/ads.go:236 +0x1f9
istio.io/istio/pilot/pkg/xds.(*DiscoveryServer).Stream(0xc0011a1680, 0x3cc6b10, 0xc002709820, 0x40e301, 0xc002709820)
	istio.io/istio/pilot/pkg/xds/ads.go:311 +0x5ac
istio.io/istio/pilot/pkg/xds.(*DiscoveryServer).StreamAggregatedResources(0xc0011a1680, 0x3cc6b10, 0xc002709820, 0x3c5aa88, 0xc0011a1680)
	istio.io/istio/pilot/pkg/xds/ads.go:241 +0x3f
github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3._AggregatedDiscoveryService_StreamAggregatedResources_Handler(0x3724f40, 0xc0011a1680, 0x3cbaea0, 0xc0008266c0, 0x2e75280, 0xc002709810)
	github.com/envoyproxy/go-control-plane@v0.9.10-0.20210708144103-3a95f2df6351/envoy/service/discovery/v3/ads.pb.go:298 +0xad
google.golang.org/grpc.(*Server).processStreamingRPC(0xc000c89dc0, 0x3cca9f8, 0xc00285e180, 0xc002720900, 0xc00128cb40, 0x5c83ae0, 0x0, 0x0, 0x0)
	google.golang.org/grpc@v1.39.0/server.go:1541 +0xe73
google.golang.org/grpc.(*Server).handleStream(0xc000c89dc0, 0x3cca9f8, 0xc00285e180, 0xc002720900, 0x0)
	google.golang.org/grpc@v1.39.0/server.go:1621 +0xca5
google.golang.org/grpc.(*Server).serveStreams.func1.2(0xc0011e2790, 0xc000c89dc0, 0x3cca9f8, 0xc00285e180, 0xc002720900)
	google.golang.org/grpc@v1.39.0/server.go:940 +0xab
created by google.golang.org/grpc.(*Server).serveStreams.func1
	google.golang.org/grpc@v1.39.0/server.go:938 +0x1fd
```

When the program is executed here, the panic will be triggered because of the null pointer
https://github.com/istio/istio/blob/415695e4b18c7d886177e0a52734a066428b5d7f/pilot/pkg/networking/apigen/apigen.go#L108

Function InitGenerators depends on s.environment.IstioConfigStore initialized in function initControllers.initConfigController, IstioConfigStore is initialized after Function InitGenerator。

Move from the previously initialized position to the current position, and no function using Generators is found in the middle

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
