### PR TITLE
Fix unexpected error when using mcp-over-xds

### DIFF
--- a/pilot/pkg/config/memory/store.go
+++ b/pilot/pkg/config/memory/store.go
@@ -199,14 +199,6 @@ func (cr *store) Update(cfg config.Config) (string, error) {
 		return "", errNotFound
 	}
 
-	existing, exists := ns.Load(cfg.Name)
-	if !exists {
-		return "", errNotFound
-	}
-	if hasConflict(existing.(config.Config), cfg) {
-		return "", errConflict
-	}
-
 	rev := time.Now().String()
 	cfg.ResourceVersion = rev
 	ns.Store(cfg.Name, cfg)
@@ -232,12 +224,9 @@ func (cr *store) UpdateStatus(cfg config.Config) (string, error) {
 		return "", errNotFound
 	}
 
-	existing, exists := ns.Load(cfg.Name)
+	_, exists = ns.Load(cfg.Name)
 	if !exists {
 		return "", errNotFound
-	}
-	if hasConflict(existing.(config.Config), cfg) {
-		return "", errConflict
 	}
 
 	rev := time.Now().String()
@@ -277,17 +266,4 @@ func (cr *store) Patch(orig config.Config, patchFn config.PatchFunc) (string, er
 	ns.Store(cfg.Name, cfg)
 
 	return rev, nil
-}
-
-// hasConflict checks if the two resources have a conflict, which will block Update calls
-func hasConflict(existing, replacement config.Config) bool {
-	if replacement.ResourceVersion == "" {
-		// We don't care about resource version, so just always overwrite
-		return false
-	}
-	// We set a resource version but its not matched, it is a conflict
-	if replacement.ResourceVersion != existing.ResourceVersion {
-		return true
-	}
-	return false
 }


### PR DESCRIPTION
Fixes #34126 

use the master branch code to reproduce this issue, there will also be these warn logs, but can receive update events
```
2021-07-22T07:25:58.033224Z	info	adsc	Received istiod.istio-system.svc:15010 type networking.istio.io/v1alpha3/VirtualService cnt=2 nonce=94AAXEWSWkU=5e49198f-e507-4e38-8d34-d0793609aaa7
2021-07-22T07:25:58.033555Z	info	config-controller	receive istio event update, curr istio-system/tcp-stats-filter-1.9
2021-07-22T07:25:58.033559Z	info	config-controller	receive istio event update, curr istio-system/metadata-exchange-1.10
2021-07-22T07:25:58.033562Z	info	config-controller	receive istio event update, curr istio-system/metadata-exchange-1.9
2021-07-22T07:25:58.033565Z	info	config-controller	receive istio event add, curr default/testwr
2021-07-22T07:25:58.033570Z	info	config-controller	receive istio event update, curr default/synthetic-kubernetes
2021-07-22T07:25:58.033573Z	info	config-controller	receive istio event update, curr istio-system/synthetic-istiod
```

use store.Create create a new Config, config.resourceVersion uses the current time to overwrite the original version number.
thus, When updating the Config, the resourceVersion of the Config to be updated and the Config cached in the store should not be compared.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
