### PR TITLE
Filter container with exit code 0 from crashed container.

### DIFF
--- a/pkg/test/kube/dump.go
+++ b/pkg/test/kube/dump.go
@@ -214,13 +214,13 @@ func containerRestarts(pod corev1.Pod, container string) int {
 	return 0
 }
 
-func containerCrashed(pod corev1.Pod, container string) bool {
+func containerCrashed(pod corev1.Pod, container string) (bool, *corev1.ContainerStateTerminated) {
 	for _, cs := range pod.Status.ContainerStatuses {
-		if cs.Name == container {
-			return cs.State.Terminated != nil
+		if cs.Name == container && cs.State.Terminated != nil {
+			return true, cs.State.Terminated
 		}
 	}
-	return false
+	return false, nil
 }
 
 // DumpPodLogs will dump logs from each container in each of the provided pods
@@ -259,8 +259,8 @@ func DumpPodLogs(_ resource.Context, c cluster.Cluster, workDir, namespace strin
 				}
 			}
 
-			if containerCrashed(pod, container.Name) {
-				scopes.Framework.Errorf("FAIL: pod %v/%v crashed with status: terminated", pod.Name, container.Name)
+			if crashed, terminateState := containerCrashed(pod, container.Name); crashed {
+				scopes.Framework.Errorf("FAIL: pod %v/%v crashed with status: %+v", pod.Name, container.Name, terminateState)
 			}
 
 			// Get envoy logs if the pod is a VM, since kubectl logs only shows the logs from iptables for VMs

--- a/pkg/test/kube/dump.go
+++ b/pkg/test/kube/dump.go
@@ -216,7 +216,7 @@ func containerRestarts(pod corev1.Pod, container string) int {
 
 func containerCrashed(pod corev1.Pod, container string) (bool, *corev1.ContainerStateTerminated) {
 	for _, cs := range pod.Status.ContainerStatuses {
-		if cs.Name == container && cs.State.Terminated != nil {
+		if cs.Name == container && cs.State.Terminated != nil && cs.State.Terminated.ExitCode != 0 {
 			return true, cs.State.Terminated
 		}
 	}


### PR DESCRIPTION
Got a case where test log suggests container crash, but pod state and log does not have any indication about that: https://prow.istio.io/view/gs/istio-prow/pr-logs/pull/istio_istio/34202/integ-cni-k8s-tests_istio/1418257862072733696 feels like there might be a race between resource clean up and container crash detection, but before digging into that it would be great to print more terminate state and understand if it is just because container exited normally. We might want to filter out container with exit code 0 from crashed container.