### PR TITLE
Refactor ipv6 iptables to reduce code duplication

### DIFF
--- a/tools/istio-clean-iptables/pkg/cmd/cleanup.go
+++ b/tools/istio-clean-iptables/pkg/cmd/cleanup.go
@@ -39,7 +39,7 @@ func removeOldChains(cfg *config.Config, ext dep.Dependencies, cmd string) {
 	redirectDNS := cfg.RedirectDNS
 	// Remove the old DNS UDP rules
 	if redirectDNS {
-		common.HandleDNSUDP(common.DeleteOps, builder.NewIptablesBuilder(), ext, cmd, cfg.ProxyUID, cfg.ProxyGID, cfg.DNSServersV4, cfg.CaptureAllDNS)
+		common.HandleDNSUDP(common.DeleteOps, builder.NewIptablesBuilder(nil), ext, cmd, cfg.ProxyUID, cfg.ProxyGID, cfg.DNSServersV4, cfg.CaptureAllDNS)
 	}
 
 	// Flush and delete the istio chains from NAT table.

--- a/tools/istio-iptables/pkg/builder/iptables_builder_test.go
+++ b/tools/istio-iptables/pkg/builder/iptables_builder_test.go
@@ -18,12 +18,13 @@ import (
 	"reflect"
 	"testing"
 
+	"istio.io/istio/tools/istio-iptables/pkg/config"
 	"istio.io/istio/tools/istio-iptables/pkg/constants"
 )
 
 // TODO(abhide): Add more testcases once BuildV6Restore() are implemented
 func TestBuildV6Restore(t *testing.T) {
-	iptables := NewIptablesBuilder()
+	iptables := NewIptablesBuilder(nil)
 	expected := ""
 	actual := iptables.BuildV6Restore()
 	if expected != actual {
@@ -33,7 +34,7 @@ func TestBuildV6Restore(t *testing.T) {
 
 // TODO(abhide): Add more testcases once BuildV4Restore() are implemented
 func TestBuildV4Restore(t *testing.T) {
-	iptables := NewIptablesBuilder()
+	iptables := NewIptablesBuilder(nil)
 	expected := ""
 	actual := iptables.BuildV4Restore()
 	if expected != actual {
@@ -42,7 +43,7 @@ func TestBuildV4Restore(t *testing.T) {
 }
 
 func TestBuildV4InsertSingleRule(t *testing.T) {
-	iptables := NewIptablesBuilder()
+	iptables := NewIptablesBuilder(nil)
 	iptables.InsertRuleV4("chain", "table", 2, "-f", "foo", "-b", "bar")
 	if err := len(iptables.rules.rulesv6) != 0; err {
 		t.Errorf("Expected rulesV6 to be empty; but got %#v", iptables.rules.rulesv6)
@@ -63,7 +64,7 @@ func TestBuildV4InsertSingleRule(t *testing.T) {
 }
 
 func TestBuildV4AppendSingleRule(t *testing.T) {
-	iptables := NewIptablesBuilder()
+	iptables := NewIptablesBuilder(nil)
 	iptables.AppendRuleV4("chain", "table", "-f", "foo", "-b", "bar")
 	if err := len(iptables.rules.rulesv6) != 0; err {
 		t.Errorf("Expected rulesV6 to be empty; but got %#v", iptables.rules.rulesv6)
@@ -84,7 +85,7 @@ func TestBuildV4AppendSingleRule(t *testing.T) {
 }
 
 func TestBuildV4AppendMultipleRules(t *testing.T) {
-	iptables := NewIptablesBuilder()
+	iptables := NewIptablesBuilder(nil)
 	iptables.AppendRuleV4("chain", "table", "-f", "foo", "-b", "bar")
 	iptables.AppendRuleV4("chain", "table", "-f", "fu", "-b", "bar")
 	iptables.AppendRuleV4("chain", "table", "-f", "foo", "-b", "baz")
@@ -109,7 +110,7 @@ func TestBuildV4AppendMultipleRules(t *testing.T) {
 }
 
 func TestBuildV4InsertMultipleRules(t *testing.T) {
-	iptables := NewIptablesBuilder()
+	iptables := NewIptablesBuilder(nil)
 	iptables.InsertRuleV4("chain", "table", 1, "-f", "foo", "-b", "bar")
 	iptables.InsertRuleV4("chain", "table", 2, "-f", "foo", "-b", "baaz")
 	iptables.InsertRuleV4("chain", "table", 3, "-f", "foo", "-b", "baz")
@@ -134,7 +135,7 @@ func TestBuildV4InsertMultipleRules(t *testing.T) {
 }
 
 func TestBuildV4AppendInsertMultipleRules(t *testing.T) {
-	iptables := NewIptablesBuilder()
+	iptables := NewIptablesBuilder(nil)
 	iptables.AppendRuleV4("chain", "table", "-f", "foo", "-b", "bar")
 	iptables.InsertRuleV4("chain", "table", 2, "-f", "foo", "-b", "bar")
 	iptables.AppendRuleV4("chain", "table", "-f", "foo", "-b", "baz")
@@ -158,8 +159,12 @@ func TestBuildV4AppendInsertMultipleRules(t *testing.T) {
 	}
 }
 
+var IPv6Config = &config.Config{
+	EnableInboundIPv6: true,
+}
+
 func TestBuildV6InsertSingleRule(t *testing.T) {
-	iptables := NewIptablesBuilder()
+	iptables := NewIptablesBuilder(IPv6Config)
 	iptables.InsertRuleV6("chain", "table", 2, "-f", "foo", "-b", "bar")
 	if err := len(iptables.rules.rulesv4) != 0; err {
 		t.Errorf("Expected rulesV4 to be empty; but got %#v", iptables.rules.rulesv4)
@@ -180,7 +185,7 @@ func TestBuildV6InsertSingleRule(t *testing.T) {
 }
 
 func TestBuildV6AppendSingleRule(t *testing.T) {
-	iptables := NewIptablesBuilder()
+	iptables := NewIptablesBuilder(IPv6Config)
 	iptables.AppendRuleV6("chain", "table", "-f", "foo", "-b", "bar")
 	if err := len(iptables.rules.rulesv4) != 0; err {
 		t.Errorf("Expected rulesV6 to be empty; but got %#v", iptables.rules.rulesv6)
@@ -201,7 +206,7 @@ func TestBuildV6AppendSingleRule(t *testing.T) {
 }
 
 func TestBuildV6AppendMultipleRules(t *testing.T) {
-	iptables := NewIptablesBuilder()
+	iptables := NewIptablesBuilder(IPv6Config)
 	iptables.AppendRuleV6("chain", "table", "-f", "foo", "-b", "bar")
 	iptables.AppendRuleV6("chain", "table", "-f", "fu", "-b", "bar")
 	iptables.AppendRuleV6("chain", "table", "-f", "foo", "-b", "baz")
@@ -226,7 +231,7 @@ func TestBuildV6AppendMultipleRules(t *testing.T) {
 }
 
 func TestBuildV6InsertMultipleRules(t *testing.T) {
-	iptables := NewIptablesBuilder()
+	iptables := NewIptablesBuilder(IPv6Config)
 	iptables.InsertRuleV6("chain", "table", 1, "-f", "foo", "-b", "bar")
 	iptables.InsertRuleV6("chain", "table", 2, "-f", "foo", "-b", "baaz")
 	iptables.InsertRuleV6("chain", "table", 3, "-f", "foo", "-b", "baz")
@@ -251,7 +256,7 @@ func TestBuildV6InsertMultipleRules(t *testing.T) {
 }
 
 func TestBuildV6InsertAppendMultipleRules(t *testing.T) {
-	iptables := NewIptablesBuilder()
+	iptables := NewIptablesBuilder(IPv6Config)
 	iptables.AppendRuleV6("chain", "table", "-f", "foo", "-b", "bar")
 	iptables.InsertRuleV6("chain", "table", 2, "-f", "foo", "-b", "bar")
 	iptables.InsertRuleV6("chain", "table", 1, "-f", "foo", "-b", "bar")
@@ -276,7 +281,7 @@ func TestBuildV6InsertAppendMultipleRules(t *testing.T) {
 }
 
 func TestBuildV4V6MultipleRulesWithNewChain(t *testing.T) {
-	iptables := NewIptablesBuilder()
+	iptables := NewIptablesBuilder(IPv6Config)
 	iptables.AppendRuleV4("chain", "table", "-f", "foo", "-b", "bar")
 	iptables.InsertRuleV4("chain", "table", 2, "-f", "foo", "-b", "bar")
 	iptables.AppendRuleV4("chain", "table", "-f", "foo", "-b", "baz")

--- a/tools/istio-iptables/pkg/cmd/run_test.go
+++ b/tools/istio-iptables/pkg/cmd/run_test.go
@@ -180,10 +180,18 @@ func TestIptables(t *testing.T) {
 		{
 			"dns-uid-gid",
 			func(cfg *config.Config) {
-				cfg.DryRun = true
 				cfg.RedirectDNS = true
 				cfg.DNSServersV4 = []string{"127.0.0.53"}
 				cfg.EnableInboundIPv6 = false
+				cfg.ProxyGID = "1,2"
+				cfg.ProxyUID = "3,4"
+			},
+		},
+		{
+			"ipv6-dns-uid-gid",
+			func(cfg *config.Config) {
+				cfg.EnableInboundIPv6 = true
+				cfg.RedirectDNS = true
 				cfg.ProxyGID = "1,2"
 				cfg.ProxyUID = "3,4"
 			},

--- a/tools/istio-iptables/pkg/cmd/testdata/ipv6-dns-uid-gid.golden
+++ b/tools/istio-iptables/pkg/cmd/testdata/ipv6-dns-uid-gid.golden
@@ -1,0 +1,56 @@
+iptables -t nat -N ISTIO_INBOUND
+iptables -t nat -N ISTIO_REDIRECT
+iptables -t nat -N ISTIO_IN_REDIRECT
+iptables -t nat -N ISTIO_OUTPUT
+iptables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
+iptables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
+iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
+iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
+iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
+iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -p tcp ! --dport 53 -m owner --uid-owner 3 -j ISTIO_IN_REDIRECT
+iptables -t nat -A ISTIO_OUTPUT -o lo -p tcp ! --dport 53 -m owner ! --uid-owner 3 -j RETURN
+iptables -t nat -A ISTIO_OUTPUT -m owner --uid-owner 3 -j RETURN
+iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -p tcp ! --dport 53 -m owner --uid-owner 4 -j ISTIO_IN_REDIRECT
+iptables -t nat -A ISTIO_OUTPUT -o lo -p tcp ! --dport 53 -m owner ! --uid-owner 4 -j RETURN
+iptables -t nat -A ISTIO_OUTPUT -m owner --uid-owner 4 -j RETURN
+iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --gid-owner 1 -j ISTIO_IN_REDIRECT
+iptables -t nat -A ISTIO_OUTPUT -o lo -p tcp ! --dport 53 -m owner ! --gid-owner 1 -j RETURN
+iptables -t nat -A ISTIO_OUTPUT -m owner --gid-owner 1 -j RETURN
+iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --gid-owner 2 -j ISTIO_IN_REDIRECT
+iptables -t nat -A ISTIO_OUTPUT -o lo -p tcp ! --dport 53 -m owner ! --gid-owner 2 -j RETURN
+iptables -t nat -A ISTIO_OUTPUT -m owner --gid-owner 2 -j RETURN
+iptables -t nat -A ISTIO_OUTPUT -d 127.0.0.1/32 -j RETURN
+iptables -t nat -A OUTPUT -p udp --dport 53 -m owner --uid-owner 3 -j RETURN
+iptables -t nat -A OUTPUT -p udp --dport 53 -m owner --uid-owner 4 -j RETURN
+iptables -t nat -A OUTPUT -p udp --dport 53 -m owner --gid-owner 1 -j RETURN
+iptables -t nat -A OUTPUT -p udp --dport 53 -m owner --gid-owner 2 -j RETURN
+iptables -t raw -A OUTPUT -p udp --dport 53 -m owner --uid-owner 3 -j CT --zone 1
+iptables -t raw -A OUTPUT -p udp --sport 15053 -m owner --uid-owner 3 -j CT --zone 2
+iptables -t raw -A OUTPUT -p udp --dport 53 -m owner --uid-owner 4 -j CT --zone 1
+iptables -t raw -A OUTPUT -p udp --sport 15053 -m owner --uid-owner 4 -j CT --zone 2
+iptables -t raw -A OUTPUT -p udp --dport 53 -m owner --gid-owner 1 -j CT --zone 1
+iptables -t raw -A OUTPUT -p udp --sport 15053 -m owner --gid-owner 1 -j CT --zone 2
+iptables -t raw -A OUTPUT -p udp --dport 53 -m owner --gid-owner 2 -j CT --zone 1
+iptables -t raw -A OUTPUT -p udp --sport 15053 -m owner --gid-owner 2 -j CT --zone 2
+ip6tables -t nat -N ISTIO_INBOUND
+ip6tables -t nat -N ISTIO_REDIRECT
+ip6tables -t nat -N ISTIO_IN_REDIRECT
+ip6tables -t nat -N ISTIO_OUTPUT
+ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
+ip6tables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
+ip6tables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
+ip6tables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
+ip6tables -t nat -A ISTIO_OUTPUT -o lo -s ::6/128 -j RETURN
+ip6tables -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -p tcp ! --dport 53 -m owner --uid-owner 3 -j ISTIO_IN_REDIRECT
+ip6tables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 3 -j RETURN
+ip6tables -t nat -A ISTIO_OUTPUT -m owner --uid-owner 3 -j RETURN
+ip6tables -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -p tcp ! --dport 53 -m owner --uid-owner 4 -j ISTIO_IN_REDIRECT
+ip6tables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 4 -j RETURN
+ip6tables -t nat -A ISTIO_OUTPUT -m owner --uid-owner 4 -j RETURN
+ip6tables -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -m owner --gid-owner 1 -j ISTIO_IN_REDIRECT
+ip6tables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --gid-owner 1 -j RETURN
+ip6tables -t nat -A ISTIO_OUTPUT -m owner --gid-owner 1 -j RETURN
+ip6tables -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -m owner --gid-owner 2 -j ISTIO_IN_REDIRECT
+ip6tables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --gid-owner 2 -j RETURN
+ip6tables -t nat -A ISTIO_OUTPUT -m owner --gid-owner 2 -j RETURN
+ip6tables -t nat -A ISTIO_OUTPUT -d ::1/128 -j RETURN


### PR DESCRIPTION
This allows most calls (except ones with IPs) to use a single call for
v4 and v6. This will hopefully make things simpler and reduce drift.

Still not identical: tproxy and dns. Will do that in a followup
