### PR TITLE
Fix panic in iptables when there is an error

### DIFF
--- a/tools/istio-iptables/pkg/dependencies/implementation.go
+++ b/tools/istio-iptables/pkg/dependencies/implementation.go
@@ -141,7 +141,9 @@ func (r *RealDependencies) executeXTables(cmd string, ignoreErrors bool, args ..
 		stderrStr := stderr.String()
 
 		// Transform to xtables-specific error messages with more useful and actionable hints.
-		stderrStr = transformToXTablesErrorMessage(stderrStr, err)
+		if err != nil {
+			stderrStr = transformToXTablesErrorMessage(stderrStr, err)
+		}
 
 		log.Errorf("Command error output: %v", stderrStr)
 	}


### PR DESCRIPTION
This occurs when `err` is nil but there is stderr output



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.