### PR TITLE
Fix race condition for auto mTLS plus workload level peer authn.

### DIFF
--- a/common/scripts/gobuild.sh
+++ b/common/scripts/gobuild.sh
@@ -47,7 +47,6 @@ LDFLAGS=${LDFLAGS:--extldflags -static}
 GOBUILDFLAGS=${GOBUILDFLAGS:-""}
 # Split GOBUILDFLAGS by spaces into an array called GOBUILDFLAGS_ARRAY.
 IFS=' ' read -r -a GOBUILDFLAGS_ARRAY <<< "$GOBUILDFLAGS"
-echo $GOBUILDFLAGS
 
 GCFLAGS=${GCFLAGS:-}
 export CGO_ENABLED=${CGO_ENABLED:-0}
@@ -84,9 +83,7 @@ if [ "${DEBUG}" == "1" ]; then
     OPTIMIZATION_FLAGS=()
 fi
 
-export CGO_ENABLED=1
 time GOOS=${BUILD_GOOS} GOARCH=${BUILD_GOARCH} ${GOBINARY} build \
-        -race \
         ${V} "${GOBUILDFLAGS_ARRAY[@]}" ${GCFLAGS:+-gcflags "${GCFLAGS}"} \
         -o "${OUT}" \
         "${OPTIMIZATION_FLAGS[@]}" \

--- a/common/scripts/gobuild.sh
+++ b/common/scripts/gobuild.sh
@@ -47,6 +47,7 @@ LDFLAGS=${LDFLAGS:--extldflags -static}
 GOBUILDFLAGS=${GOBUILDFLAGS:-""}
 # Split GOBUILDFLAGS by spaces into an array called GOBUILDFLAGS_ARRAY.
 IFS=' ' read -r -a GOBUILDFLAGS_ARRAY <<< "$GOBUILDFLAGS"
+echo $GOBUILDFLAGS
 
 GCFLAGS=${GCFLAGS:-}
 export CGO_ENABLED=${CGO_ENABLED:-0}
@@ -83,7 +84,9 @@ if [ "${DEBUG}" == "1" ]; then
     OPTIMIZATION_FLAGS=()
 fi
 
+export CGO_ENABLED=1
 time GOOS=${BUILD_GOOS} GOARCH=${BUILD_GOARCH} ${GOBINARY} build \
+        -race \
         ${V} "${GOBUILDFLAGS_ARRAY[@]}" ${GCFLAGS:+-gcflags "${GCFLAGS}"} \
         -o "${OUT}" \
         "${OPTIMIZATION_FLAGS[@]}" \

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -147,7 +147,7 @@ var (
 		"Skip validating the peer is from the same trust domain when mTLS is enabled in authentication policy").Get()
 
 	EnableAutomTLSCheckPolicies = env.RegisterBoolVar(
-		"ENABLE_AUTO_MTLS_CHECK_POLICIES", false,
+		"ENABLE_AUTO_MTLS_CHECK_POLICIES", true,
 		"Enable the auto mTLS EDS output to consult the PeerAuthentication Policy, only set the {tlsMode: istio} "+
 			" when server side policy enables mTLS PERMISSIVE or STRICT.").Get()
 

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -527,7 +527,6 @@ func BuildLbEndpointMetadata(networkID network.ID, tlsMode, workloadname, namesp
 // MaybeApplyTLSModeLabel may or may not update the metadata for the Envoy transport socket matches for auto mTLS.
 func MaybeApplyTLSModeLabel(ep *endpoint.LbEndpoint, tlsMode string) (*endpoint.LbEndpoint, bool) {
 	if ep == nil || ep.Metadata == nil {
-		// if metadata == nil {
 		return nil, false
 	}
 	epTLSMode := ""
@@ -536,7 +535,7 @@ func MaybeApplyTLSModeLabel(ep *endpoint.LbEndpoint, tlsMode string) (*endpoint.
 			epTLSMode = v.Fields[model.TLSModeLabelShortname].GetStringValue()
 		}
 	}
-	// Normalize the tls label name before comparison. This ensure we want falsely cloning
+	// Normalize the tls label name before comparison. This ensure we won't falsely cloning
 	// the endpoint when they are "" and model.DisabledTLSModeLabel.
 	if epTLSMode == model.DisabledTLSModeLabel {
 		epTLSMode = ""

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -536,7 +536,7 @@ func MaybeApplyTLSModeLabel(ep *endpoint.LbEndpoint, tlsMode string) (*endpoint.
 			epTLSMode = v.Fields[model.TLSModeLabelShortname].GetStringValue()
 		}
 	}
-	// Normalize the tls label name before comparision. This ensure we want falsely cloning
+	// Normalize the tls label name before comparison. This ensure we want falsely cloning
 	// the endpoint when they are "" and model.DisabledTLSModeLabel.
 	if epTLSMode == model.DisabledTLSModeLabel {
 		epTLSMode = ""

--- a/pilot/pkg/xds/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoint_builder.go
@@ -331,7 +331,9 @@ func (b *EndpointBuilder) buildLocalityLbEndpointsFromShards(
 				if b.mtlsChecker != nil && b.mtlsChecker.mtlsDisabledByPeerAuthentication(ep) {
 					tlsMode = ""
 				}
-				util.MaybeUpdateTLSModeLabel(ep.EnvoyEndpoint.Metadata, tlsMode)
+				if nep, modified := util.MaybeUpdateTLSModeLabel(ep.EnvoyEndpoint, tlsMode); modified {
+					ep.EnvoyEndpoint = nep
+				}
 			}
 			locLbEps.append(ep, ep.EnvoyEndpoint, ep.TunnelAbility)
 

--- a/pilot/pkg/xds/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoint_builder.go
@@ -331,7 +331,7 @@ func (b *EndpointBuilder) buildLocalityLbEndpointsFromShards(
 				if b.mtlsChecker != nil && b.mtlsChecker.mtlsDisabledByPeerAuthentication(ep) {
 					tlsMode = ""
 				}
-				if nep, modified := util.MaybeUpdateTLSModeLabel(ep.EnvoyEndpoint, tlsMode); modified {
+				if nep, modified := util.MaybeApplyTLSModeLabel(ep.EnvoyEndpoint, tlsMode); modified {
 					ep.EnvoyEndpoint = nep
 				}
 			}

--- a/tests/integration/security/reachability_test.go
+++ b/tests/integration/security/reachability_test.go
@@ -89,30 +89,29 @@ func TestReachability(t *testing.T) {
 					ExpectMTLS:             Never,
 					SkippedForMulticluster: true,
 				},
-				// Skipped for https://github.com/istio/istio/issues/34227
-				//{
-				//	ConfigFile: "beta-mtls-automtls-workload.yaml",
-				//	Namespace:  apps.Namespace1,
-				//	Include: func(src echo.Instance, opts echo.CallOptions) bool {
-				//		return (apps.B.Contains(src) || apps.IsNaked(src)) &&
-				//			(apps.A.Contains(opts.Target) || apps.B.Contains(opts.Target))
-				//	},
-				//	ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
-				//		// Sidecar injected client always succeed.
-				//		if apps.B.Contains(src) {
-				//			return true
-				//		}
-				//		// For naked app as client, only requests targeted to mTLS disabled endpoints succeed:
-				//		// A are disabled by workload selector for entire service.
-				//		// B port 8090 http port are disabled.
-				//		return apps.A.Contains(opts.Target) || (apps.B.Contains(opts.Target) && opts.PortName == "http")
-				//	},
-				//	// Only when the source is B and the destination does not disable mTLS.
-				//	ExpectMTLS: func(src echo.Instance, opts echo.CallOptions) bool {
-				//		return apps.B.Contains(src) && opts.PortName != "http" && !apps.A.Contains(opts.Target)
-				//	},
-				//	SkippedForMulticluster: true,
-				//},
+				{
+					ConfigFile: "beta-mtls-automtls-workload.yaml",
+					Namespace:  apps.Namespace1,
+					Include: func(src echo.Instance, opts echo.CallOptions) bool {
+						return (apps.B.Contains(src) || apps.IsNaked(src)) &&
+							(apps.A.Contains(opts.Target) || apps.B.Contains(opts.Target))
+					},
+					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
+						// Sidecar injected client always succeed.
+						if apps.B.Contains(src) {
+							return true
+						}
+						// For naked app as client, only requests targeted to mTLS disabled endpoints succeed:
+						// A are disabled by workload selector for entire service.
+						// B port 8090 http port are disabled.
+						return apps.A.Contains(opts.Target) || (apps.B.Contains(opts.Target) && opts.PortName == "http")
+					},
+					// Only when the source is B and the destination does not disable mTLS.
+					ExpectMTLS: func(src echo.Instance, opts echo.CallOptions) bool {
+						return apps.B.Contains(src) && opts.PortName != "http" && !apps.A.Contains(opts.Target)
+					},
+					SkippedForMulticluster: true,
+				},
 				{
 					ConfigFile:             "plaintext-to-permissive.yaml",
 					Namespace:              systemNM,


### PR DESCRIPTION
Fix #34227

The root cause is because two xds stream are both operating on the same `endpointBuilder.IstioEndpoint (a pointer)`. When one stream is sending endpoints to sidecar the other one is mutating the Endpiont.Metadata.FilterMetadata （a map).

We avoid this by making a copy of the original one. The copy is only on demand when necessary. This is similar to what we did in  https://github.com/istio/istio/blob/e490aed372744254e622c6da27edd02f03dbe968/pilot/pkg/xds/endpoint_builder.go#L203