### PR TITLE
Fix unexpected error when using mcp-over-xds

### DIFF
--- a/pkg/adsc/adsc.go
+++ b/pkg/adsc/adsc.go
@@ -46,6 +46,7 @@ import (
 
 	mcp "istio.io/api/mcp/v1alpha1"
 	"istio.io/api/mesh/v1alpha1"
+	mem "istio.io/istio/pilot/pkg/config/memory"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pilot/pkg/serviceregistry/memory"
@@ -584,6 +585,9 @@ func mcpToPilot(m *mcp.Resource) (*config.Config, error) {
 			Labels:          m.Metadata.Labels,
 			Annotations:     m.Metadata.Annotations,
 		},
+	}
+	if c.Meta.Annotations == nil {
+		c.Meta.Annotations = make(map[string]string)
 	}
 	nsn := strings.Split(m.Metadata.Name, "/")
 	if len(nsn) != 2 {
@@ -1240,36 +1244,38 @@ func (a *ADSC) handleMCP(gvk []string, resources []*any.Any) {
 			adscLog.Warnf("Error unmarshalling received MCP config %v", err)
 			continue
 		}
-		val, err := mcpToPilot(m)
+		newCfg, err := mcpToPilot(m)
 		if err != nil {
 			adscLog.Warn("Invalid data ", err, " ", string(rsc.Value))
 			continue
 		}
-		received[val.Namespace+"/"+val.Name] = val
+		received[newCfg.Namespace+"/"+newCfg.Name] = newCfg
 
-		val.GroupVersionKind = groupVersionKind
-		cfg := a.Store.Get(val.GroupVersionKind, val.Name, val.Namespace)
-		if cfg == nil {
-			_, err = a.Store.Create(*val)
-			if err != nil {
+		newCfg.GroupVersionKind = groupVersionKind
+		oldCfg := a.Store.Get(newCfg.GroupVersionKind, newCfg.Name, newCfg.Namespace)
+
+		if oldCfg == nil {
+			if _, err = a.Store.Create(*newCfg); err != nil {
 				adscLog.Warnf("Error adding a new resource to the store %v", err)
 				continue
 			}
-		} else {
-			_, err = a.Store.Update(*val)
-			if err != nil {
+		} else if oldCfg.ResourceVersion != newCfg.ResourceVersion || newCfg.ResourceVersion == "" {
+			// update the store only when resource version differs or unset.
+			newCfg.Annotations[mem.ResourceVersion] = newCfg.ResourceVersion
+			newCfg.ResourceVersion = oldCfg.ResourceVersion
+			if _, err = a.Store.Update(*newCfg); err != nil {
 				adscLog.Warnf("Error updating an existing resource in the store %v", err)
 				continue
 			}
 		}
 		if a.LocalCacheDir != "" {
-			strResponse, err := json.MarshalIndent(val, "  ", "  ")
+			strResponse, err := json.MarshalIndent(newCfg, "  ", "  ")
 			if err != nil {
 				adscLog.Warnf("Error marshaling received MCP config %v", err)
 				continue
 			}
 			err = os.WriteFile(a.LocalCacheDir+"_res."+
-				val.GroupVersionKind.Kind+"."+val.Namespace+"."+val.Name+".json", strResponse, 0o644)
+				newCfg.GroupVersionKind.Kind+"."+newCfg.Namespace+"."+newCfg.Name+".json", strResponse, 0o644)
 			if err != nil {
 				adscLog.Warnf("Error writing received MCP config to local file %v", err)
 			}
@@ -1279,8 +1285,7 @@ func (a *ADSC) handleMCP(gvk []string, resources []*any.Any) {
 	// remove deleted resources from cache
 	for _, config := range existingConfigs {
 		if _, ok := received[config.Namespace+"/"+config.Name]; !ok {
-			err := a.Store.Delete(config.GroupVersionKind, config.Name, config.Namespace, nil)
-			if err != nil {
+			if err := a.Store.Delete(config.GroupVersionKind, config.Name, config.Namespace, nil); err != nil {
 				adscLog.Warnf("Error deleting an outdated resource from the store %v", err)
 			}
 		}

--- a/pkg/adsc/adsc_test.go
+++ b/pkg/adsc/adsc_test.go
@@ -343,8 +343,8 @@ func TestADSC_handleMCP(t *testing.T) {
 		{
 			desc: "create-resources",
 			resources: []*any.Any{
-				constructResource("foo1", "foo1.bar.com", "192.1.1.1"),
-				constructResource("foo2", "foo2.bar.com", "192.1.1.2"),
+				constructResource("foo1", "foo1.bar.com", "192.1.1.1", "1"),
+				constructResource("foo2", "foo2.bar.com", "192.1.1.2", "1"),
 			},
 			expectedResources: [][]string{
 				{"foo1", "foo1.bar.com", "192.1.1.1"},
@@ -354,23 +354,36 @@ func TestADSC_handleMCP(t *testing.T) {
 		{
 			desc: "update-and-create-resources",
 			resources: []*any.Any{
-				constructResource("foo1", "foo1.bar.com", "192.1.1.1"),
-				constructResource("foo2", "foo2.bar.com", "192.2.2.2"),
-				constructResource("foo3", "foo2.bar.com", "192.1.1.3"),
+				constructResource("foo1", "foo1.bar.com", "192.1.1.11", "2"),
+				constructResource("foo2", "foo2.bar.com", "192.1.1.22", "1"),
+				constructResource("foo3", "foo3.bar.com", "192.1.1.3", ""),
 			},
 			expectedResources: [][]string{
-				{"foo1", "foo1.bar.com", "192.1.1.1"},
-				{"foo2", "foo2.bar.com", "192.2.2.2"},
-				{"foo3", "foo2.bar.com", "192.1.1.3"},
+				{"foo1", "foo1.bar.com", "192.1.1.11"},
+				{"foo2", "foo2.bar.com", "192.1.1.2"},
+				{"foo3", "foo3.bar.com", "192.1.1.3"},
 			},
 		},
 		{
-			desc: "delete-and-create-resources",
+			desc: "update-delete-and-create-resources",
 			resources: []*any.Any{
-				constructResource("foo4", "foo4.bar.com", "192.1.1.4"),
+				constructResource("foo2", "foo2.bar.com", "192.1.1.222", "4"),
+				constructResource("foo4", "foo4.bar.com", "192.1.1.4", "1"),
 			},
 			expectedResources: [][]string{
+				{"foo2", "foo2.bar.com", "192.1.1.222"},
 				{"foo4", "foo4.bar.com", "192.1.1.4"},
+			},
+		},
+		{
+			desc: "update-and-delete-resources",
+			resources: []*any.Any{
+				constructResource("foo2", "foo2.bar.com", "192.2.2.22", "3"),
+				constructResource("foo3", "foo3.bar.com", "192.1.1.33", ""),
+			},
+			expectedResources: [][]string{
+				{"foo2", "foo2.bar.com", "192.2.2.22"},
+				{"foo3", "foo3.bar.com", "192.1.1.33"},
 			},
 		},
 	}
@@ -403,7 +416,7 @@ func TestADSC_handleMCP(t *testing.T) {
 	}
 }
 
-func constructResource(name string, host string, address string) *any.Any {
+func constructResource(name string, host string, address, version string) *any.Any {
 	service := &networking.ServiceEntry{
 		Hosts:     []string{host},
 		Addresses: []string{address},
@@ -413,6 +426,7 @@ func constructResource(name string, host string, address string) *any.Any {
 		Metadata: &mcp.Metadata{
 			Name:       "default/" + name,
 			CreateTime: types.TimestampNow(),
+			Version:    version,
 		},
 		Body: seAny,
 	}


### PR DESCRIPTION
Fixes #34126 

use the master branch code to reproduce this issue, there will also be these warn logs, but can receive update events
```
2021-07-22T07:25:58.033224Z	info	adsc	Received istiod.istio-system.svc:15010 type networking.istio.io/v1alpha3/VirtualService cnt=2 nonce=94AAXEWSWkU=5e49198f-e507-4e38-8d34-d0793609aaa7
2021-07-22T07:25:58.033555Z	info	config-controller	receive istio event update, curr istio-system/tcp-stats-filter-1.9
2021-07-22T07:25:58.033559Z	info	config-controller	receive istio event update, curr istio-system/metadata-exchange-1.10
2021-07-22T07:25:58.033562Z	info	config-controller	receive istio event update, curr istio-system/metadata-exchange-1.9
2021-07-22T07:25:58.033565Z	info	config-controller	receive istio event add, curr default/testwr
2021-07-22T07:25:58.033570Z	info	config-controller	receive istio event update, curr default/synthetic-kubernetes
2021-07-22T07:25:58.033573Z	info	config-controller	receive istio event update, curr istio-system/synthetic-istiod
```

for client, if the cfg resourceVersion to be updated exists and is the same as the existing cfg, there is no need to update, otherwise update.
resource version is only used to distinguish the version, if not set, use the current time.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
