### PR TITLE
Properly handle redirects in app prober

### DIFF
--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -234,11 +235,35 @@ func NewServer(config Options) (*Server, error) {
 					TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 					DialContext:     d.DialContext,
 				},
+				CheckRedirect: redirectChecker(),
 			}
 		}
 	}
 
 	return s, nil
+}
+
+// Copies logic from https://github.com/kubernetes/kubernetes/blob/b152001f459/pkg/probe/http/http.go#L129-L130
+func isRedirect(code int) bool {
+	return code >= http.StatusMultipleChoices && code < http.StatusBadRequest
+}
+
+// Using the same redirect logic that kubelet does: https://github.com/kubernetes/kubernetes/blob/b152001f459/pkg/probe/http/http.go#L141
+// This means that:
+// * If we exceed 10 redirects, the probe fails
+// * If we redirect somewhere external, the probe succeeds (https://github.com/kubernetes/kubernetes/blob/b152001f459/pkg/probe/http/http.go#L130)
+// * If we redirect to the same address, the probe will follow the redirect
+func redirectChecker() func(*http.Request, []*http.Request) error {
+	return func(req *http.Request, via []*http.Request) error {
+		if req.URL.Hostname() != via[0].URL.Hostname() {
+			return http.ErrUseLastResponse
+		}
+		// Default behavior: stop after 10 redirects.
+		if len(via) >= 10 {
+			return errors.New("stopped after 10 redirects")
+		}
+		return nil
+	}
 }
 
 func validateAppKubeProber(path string, prober *Prober) error {
@@ -650,6 +675,12 @@ func (s *Server) handleAppProbeHTTPGet(w http.ResponseWriter, req *http.Request,
 		_ = response.Body.Close()
 	}()
 
+	if isRedirect(response.StatusCode) { // Redirect
+		// In other cases, we return the original status code. For redirects, it is illegal to
+		// not have Location header, so we need to switch to just 200.
+		w.WriteHeader(http.StatusOK)
+		return
+	}
 	// We only write the status code to the response.
 	w.WriteHeader(response.StatusCode)
 }

--- a/pilot/cmd/pilot-agent/status/server_test.go
+++ b/pilot/cmd/pilot-agent/status/server_test.go
@@ -56,7 +56,9 @@ const (
 var liveServerStats = "cluster_manager.cds.update_success: 1\nlistener_manager.lds.update_success: 1\nserver.state: 0\nlistener_manager.workers_started: 1"
 
 func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	if r.URL.Path == "/header" {
+	segments := strings.Split(r.URL.Path[1:], "/")
+	switch segments[0] {
+	case "header":
 		if r.Host != testHostValue {
 			log.Errorf("Missing expected host header, got %v", r.Host)
 			w.WriteHeader(http.StatusBadRequest)
@@ -65,11 +67,21 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			log.Errorf("Missing expected Some-Header, got %v", r.Header)
 			w.WriteHeader(http.StatusBadRequest)
 		}
-	}
-	if r.URL.Path != "/hello/sunnyvale" && r.URL.Path != "/" {
+	case "redirect":
+		http.Redirect(w, r, "/", http.StatusMovedPermanently)
+	case "redirect-loop":
+		http.Redirect(w, r, "/redirect-loop", http.StatusMovedPermanently)
+	case "remote-redirect":
+		http.Redirect(w, r, "http://example.com/foo", http.StatusMovedPermanently)
+	case "", "hello/sunnyvale":
+		w.Write([]byte("welcome, it works"))
+	case "status":
+		code, _ := strconv.Atoi(segments[1])
+		w.Header().Set("Location", "/")
+		w.WriteHeader(code)
+	default:
 		return
 	}
-	w.Write([]byte("welcome, it works"))
 }
 
 func TestNewServer(t *testing.T) {
@@ -522,14 +534,15 @@ func TestAppProbe(t *testing.T) {
 		},
 	}
 
-	testCases := []struct {
+	type test struct {
 		name       string
 		probePath  string
 		config     KubeAppProbers
 		podIP      string
 		ipv6       bool
 		statusCode int
-	}{
+	}
+	testCases := []test{
 		{
 			name:       "http-bad-path",
 			probePath:  "bad-path-should-be-404",
@@ -640,54 +653,121 @@ func TestAppProbe(t *testing.T) {
 			statusCode: http.StatusOK,
 			podIP:      "localhost",
 		},
+		{
+			name:      "redirect",
+			probePath: "app-health/redirect/livez",
+			config: KubeAppProbers{
+				"/app-health/redirect/livez": &Prober{
+					HTTPGet: &apimirror.HTTPGetAction{
+						Path: "redirect",
+						Port: intstr.IntOrString{IntVal: int32(appPort)},
+					},
+				},
+			},
+			statusCode: http.StatusOK,
+		},
+		{
+			name:      "redirect loop",
+			probePath: "app-health/redirect-loop/livez",
+			config: KubeAppProbers{
+				"/app-health/redirect-loop/livez": &Prober{
+					HTTPGet: &apimirror.HTTPGetAction{
+						Path: "redirect-loop",
+						Port: intstr.IntOrString{IntVal: int32(appPort)},
+					},
+				},
+			},
+			statusCode: http.StatusInternalServerError,
+		},
+		{
+			name:      "remote redirect",
+			probePath: "app-health/remote-redirect/livez",
+			config: KubeAppProbers{
+				"/app-health/remote-redirect/livez": &Prober{
+					HTTPGet: &apimirror.HTTPGetAction{
+						Path: "remote-redirect",
+						Port: intstr.IntOrString{IntVal: int32(appPort)},
+					},
+				},
+			},
+			statusCode: http.StatusOK,
+		},
+	}
+	testFn := func(t *testing.T, tc test) {
+		appProber, err := json.Marshal(tc.config)
+		if err != nil {
+			t.Fatalf("invalid app probers")
+		}
+		config := Options{
+			StatusPort:     0,
+			KubeAppProbers: string(appProber),
+			PodIP:          tc.podIP,
+			IPv6:           tc.ipv6,
+		}
+		// Starts the pilot agent status server.
+		server, err := NewServer(config)
+		if err != nil {
+			t.Fatalf("failed to create status server %v", err)
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		go server.Run(ctx)
+
+		if tc.ipv6 {
+			server.upstreamLocalAddress = &net.TCPAddr{IP: net.ParseIP("::1")} // required because ::6 is NOT a loopback address (IPv6 only has ::1)
+		}
+
+		var statusPort uint16
+		for statusPort == 0 {
+			server.mutex.RLock()
+			statusPort = server.statusPort
+			server.mutex.RUnlock()
+		}
+
+		client := http.Client{}
+		req, err := http.NewRequest("GET", fmt.Sprintf("http://localhost:%v/%s", statusPort, tc.probePath), nil)
+		if err != nil {
+			t.Fatalf("[%v] failed to create request", tc.probePath)
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatal("request failed: ", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != tc.statusCode {
+			t.Errorf("[%v] unexpected status code, want = %v, got = %v", tc.probePath, tc.statusCode, resp.StatusCode)
+		}
 	}
 	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			appProber, err := json.Marshal(tc.config)
-			if err != nil {
-				t.Fatalf("invalid app probers")
-			}
-			config := Options{
-				StatusPort:     0,
-				KubeAppProbers: string(appProber),
-				PodIP:          tc.podIP,
-				IPv6:           tc.ipv6,
-			}
-			// Starts the pilot agent status server.
-			server, err := NewServer(config)
-			if err != nil {
-				t.Fatalf("failed to create status server %v", err)
-			}
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-			go server.Run(ctx)
-
-			if tc.ipv6 {
-				server.upstreamLocalAddress = &net.TCPAddr{IP: net.ParseIP("::1")} // required because ::6 is NOT a loopback address (IPv6 only has ::1)
-			}
-
-			var statusPort uint16
-			for statusPort == 0 {
-				server.mutex.RLock()
-				statusPort = server.statusPort
-				server.mutex.RUnlock()
-			}
-
-			client := http.Client{}
-			req, err := http.NewRequest("GET", fmt.Sprintf("http://localhost:%v/%s", statusPort, tc.probePath), nil)
-			if err != nil {
-				t.Fatalf("[%v] failed to create request", tc.probePath)
-			}
-			resp, err := client.Do(req)
-			if err != nil {
-				t.Fatal("request failed: ", err)
-			}
-			defer resp.Body.Close()
-			if resp.StatusCode != tc.statusCode {
-				t.Errorf("[%v] unexpected status code, want = %v, got = %v", tc.probePath, tc.statusCode, resp.StatusCode)
-			}
-		})
+		t.Run(tc.name, func(t *testing.T) { testFn(t, tc) })
 	}
+	// Next we check ever
+	t.Run("status codes", func(t *testing.T) {
+		for code := http.StatusOK; code <= http.StatusNetworkAuthenticationRequired; code++ {
+			if http.StatusText(code) == "" { // Not a valid HTTP code
+				continue
+			}
+			expect := code
+			if isRedirect(code) {
+				expect = 200
+			}
+			t.Run(fmt.Sprint(code), func(t *testing.T) {
+				testFn(t, test{
+					probePath: "app-health/code/livez",
+					config: KubeAppProbers{
+						"/app-health/code/livez": &Prober{
+							TimeoutSeconds: 1,
+							HTTPGet: &apimirror.HTTPGetAction{
+								Path: fmt.Sprintf("status/%d", code),
+								Port: intstr.IntOrString{IntVal: int32(appPort)},
+							},
+						},
+					},
+					statusCode: expect,
+				})
+			})
+		}
+	})
 }
 
 func TestHttpsAppProbe(t *testing.T) {

--- a/releasenotes/notes/probe-redirect.yaml
+++ b/releasenotes/notes/probe-redirect.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+- 34238
+- 29468
+releaseNotes:
+- |
+  **Fixed** application readiness probes to properly handle redirects.


### PR DESCRIPTION
This is large copy+paste from kubelet code. Before, we would just
blindly follow redirects. This has some DOS implications (not a big deal
since it just kills your own pod, unlike kubelet which is shared) and
also breaks when the redirect goes external because sourceIP=127.0.0.6
does not work for external call.

The new logic, matching kubelet:
* If we exceed 10 redirects, the probe fails
* If we redirect somewhere external, the probe succeeds immediately
* If we redirect to the same address, the probe will follow the redirect

Fixes https://github.com/istio/istio/issues/29468
Fixes https://github.com/istio/istio/issues/34238