### PR TITLE
Fix Kubernetes Ingress and Gateway prefix match

### DIFF
--- a/pilot/pkg/config/kube/gateway/conversion.go
+++ b/pilot/pkg/config/kube/gateway/conversion.go
@@ -16,6 +16,7 @@ package gateway
 
 import (
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -852,6 +853,10 @@ func createHeadersMatch(match k8s.HTTPRouteMatch) (map[string]*istio.StringMatch
 	return res, nil
 }
 
+// prefixMatchRegex optionally matches "/..." at the end of a path.
+// regex taken from https://github.com/projectcontour/contour/blob/2b3376449bedfea7b8cea5fbade99fb64009c0f6/internal/envoy/v3/route.go#L59
+const prefixMatchRegex = `((\/).*)?`
+
 func createURIMatch(match k8s.HTTPRouteMatch) (*istio.StringMatch, *ConfigError) {
 	tp := k8s.PathMatchPrefix
 	if match.Path.Type != nil {
@@ -864,7 +869,7 @@ func createURIMatch(match k8s.HTTPRouteMatch) (*istio.StringMatch, *ConfigError)
 	switch tp {
 	case k8s.PathMatchPrefix, k8s.PathMatchImplementationSpecific:
 		return &istio.StringMatch{
-			MatchType: &istio.StringMatch_Prefix{Prefix: dest},
+			MatchType: &istio.StringMatch_Regex{Regex: regexp.QuoteMeta(dest) + prefixMatchRegex},
 		}, nil
 	case k8s.PathMatchExact:
 		return &istio.StringMatch{

--- a/pilot/pkg/config/kube/gateway/testdata/http.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/http.yaml.golden
@@ -39,7 +39,7 @@ spec:
         my-header:
           exact: some-value
       uri:
-        prefix: /get
+        regex: /get((\/).*)?
     route:
     - destination:
         host: httpbin.default.svc.domain.suffix
@@ -60,7 +60,7 @@ spec:
   http:
   - match:
     - uri:
-        prefix: /second
+        regex: /second((\/).*)?
     route:
     - destination:
         host: httpbin-second.default.svc.domain.suffix

--- a/pilot/pkg/config/kube/gateway/testdata/weighted.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/weighted.yaml.golden
@@ -59,7 +59,7 @@ spec:
   http:
   - match:
     - uri:
-        prefix: /get
+        regex: /get((\/).*)?
     route:
     - destination:
         host: httpbin.default.svc.domain.suffix
@@ -73,7 +73,7 @@ spec:
       weight: 60
   - match:
     - uri:
-        prefix: /weighted-100
+        regex: /weighted-100((\/).*)?
     route:
     - destination:
         host: foo-svc.default.svc.domain.suffix

--- a/pilot/pkg/config/kube/gateway/testdata/zero.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/zero.yaml.golden
@@ -29,7 +29,7 @@ spec:
   http:
   - match:
     - uri:
-        prefix: /get
+        regex: /get((\/).*)?
     route:
     - destination:
         host: httpbin-zero.default.svc.domain.suffix
@@ -43,7 +43,7 @@ spec:
         httpStatus: 503
   - match:
     - uri:
-        prefix: /weighted-100
+        regex: /weighted-100((\/).*)?
     route:
     - destination:
         host: foo-svc.default.svc.domain.suffix

--- a/pilot/pkg/config/kube/ingress/conversion.go
+++ b/pilot/pkg/config/kube/ingress/conversion.go
@@ -17,6 +17,7 @@ package ingress
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -123,6 +124,10 @@ func ConvertIngressV1alpha3(ingress v1beta1.Ingress, mesh *meshconfig.MeshConfig
 	return gatewayConfig
 }
 
+// prefixMatchRegex optionally matches "/..." at the end of a path.
+// regex taken from https://github.com/projectcontour/contour/blob/2b3376449bedfea7b8cea5fbade99fb64009c0f6/internal/envoy/v3/route.go#L59
+const prefixMatchRegex = `((\/).*)?`
+
 // ConvertIngressVirtualService converts from ingress spec to Istio VirtualServices
 func ConvertIngressVirtualService(ingress v1beta1.Ingress, domainSuffix string, ingressByHost map[string]*config.Config, serviceLister listerv1.ServiceLister) {
 	// Ingress allows a single host - if missing '*' is assumed
@@ -162,13 +167,14 @@ func ConvertIngressVirtualService(ingress v1beta1.Ingress, domainSuffix string, 
 					}
 				case v1beta1.PathTypePrefix:
 					// From the spec: /foo/bar matches /foo/bar/baz, but does not match /foo/barbaz
-					// Envoy prefix match behaves differently, so insert a / if we don't have one
+					// and if the prefix is /foo/bar/ we must match /foo/bar and /foo/bar. We cannot simply strip the
+					// trailing "/" and do a prefix match since we'll match unwanted path continuations and we cannot add
+					// a "/" if not present since we won't match the prefix without trailing "/". Must be smarter and
+					// use regex.
 					path := httpPath.Path
-					if !strings.HasSuffix(path, "/") {
-						path += "/"
-					}
+					path = strings.TrimSuffix(path, "/")
 					httpMatch.Uri = &networking.StringMatch{
-						MatchType: &networking.StringMatch_Prefix{Prefix: path},
+						MatchType: &networking.StringMatch_Regex{Regex: regexp.QuoteMeta(path) + prefixMatchRegex},
 					}
 				default:
 					// Fallback to the legacy string matching

--- a/pilot/pkg/config/kube/ingress/conversion_test.go
+++ b/pilot/pkg/config/kube/ingress/conversion_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/ghodss/yaml"
+	"github.com/google/go-cmp/cmp"
 	coreV1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -85,8 +86,8 @@ func TestGoldenConversion(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if string(output) != string(expected) {
-				t.Fatalf("expected %v, got %v", string(expected), string(output))
+			if diff := cmp.Diff(expected, output); diff != "" {
+				t.Fatalf("Diff:\n%s", diff)
 			}
 		})
 	}

--- a/pilot/pkg/config/kube/ingress/testdata/simple.yaml.golden
+++ b/pilot/pkg/config/kube/ingress/testdata/simple.yaml.golden
@@ -101,7 +101,7 @@ spec:
       weight: 100
   - match:
     - uri:
-        prefix: /sub/path/
+        regex: /sub/path((\/).*)?
     route:
     - destination:
         host: service1.ns.svc.mydomain
@@ -110,7 +110,7 @@ spec:
       weight: 100
   - match:
     - uri:
-        prefix: /sub/path/
+        regex: /sub/path((\/).*)?
     route:
     - destination:
         host: service1.ns.svc.mydomain

--- a/pilot/pkg/config/kube/ingressv1/conversion.go
+++ b/pilot/pkg/config/kube/ingressv1/conversion.go
@@ -17,6 +17,7 @@ package ingress
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -122,6 +123,10 @@ func ConvertIngressV1alpha3(ingress knetworking.Ingress, mesh *meshconfig.MeshCo
 	return gatewayConfig
 }
 
+// prefixMatchRegex optionally matches "/..." at the end of a path.
+// regex taken from https://github.com/projectcontour/contour/blob/2b3376449bedfea7b8cea5fbade99fb64009c0f6/internal/envoy/v3/route.go#L59
+const prefixMatchRegex = `((\/).*)?`
+
 // ConvertIngressVirtualService converts from ingress spec to Istio VirtualServices
 func ConvertIngressVirtualService(ingress knetworking.Ingress, domainSuffix string,
 	ingressByHost map[string]*config.Config, serviceLister listerv1.ServiceLister) {
@@ -162,13 +167,14 @@ func ConvertIngressVirtualService(ingress knetworking.Ingress, domainSuffix stri
 					}
 				case knetworking.PathTypePrefix:
 					// From the spec: /foo/bar matches /foo/bar/baz, but does not match /foo/barbaz
-					// Envoy prefix match behaves differently, so insert a / if we don't have one
+					// and if the prefix is /foo/bar/ we must match /foo/bar and /foo/bar. We cannot simply strip the
+					// trailing "/" and do a prefix match since we'll match unwanted continuations and we cannot add
+					// a "/" if not present since we won't match the prefix without trailing "/". Must be smarter and
+					// use regex.
 					path := httpPath.Path
-					if !strings.HasSuffix(path, "/") {
-						path += "/"
-					}
+					path = strings.TrimSuffix(path, "/")
 					httpMatch.Uri = &networking.StringMatch{
-						MatchType: &networking.StringMatch_Prefix{Prefix: path},
+						MatchType: &networking.StringMatch_Regex{Regex: regexp.QuoteMeta(path) + prefixMatchRegex},
 					}
 				default:
 					// Fallback to the legacy string matching

--- a/pilot/pkg/config/kube/ingressv1/conversion_test.go
+++ b/pilot/pkg/config/kube/ingressv1/conversion_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/ghodss/yaml"
+	"github.com/google/go-cmp/cmp"
 	coreV1 "k8s.io/api/core/v1"
 	knetworking "k8s.io/api/networking/v1"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -85,8 +86,8 @@ func TestGoldenConversion(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if string(output) != string(expected) {
-				t.Fatalf("expected %v, got %v", string(expected), string(output))
+			if diff := cmp.Diff(expected, output); diff != "" {
+				t.Fatalf("Diff:\n%s", diff)
 			}
 		})
 	}

--- a/pilot/pkg/config/kube/ingressv1/testdata/simple.yaml.golden
+++ b/pilot/pkg/config/kube/ingressv1/testdata/simple.yaml.golden
@@ -101,7 +101,7 @@ spec:
       weight: 100
   - match:
     - uri:
-        prefix: /sub/path/
+        regex: /sub/path((\/).*)?
     route:
     - destination:
         host: service1.ns.svc.mydomain
@@ -110,7 +110,7 @@ spec:
       weight: 100
   - match:
     - uri:
-        prefix: /sub/path/
+        regex: /sub/path((\/).*)?
     route:
     - destination:
         host: service1.ns.svc.mydomain

--- a/releasenotes/notes/kubernetes-ingress-prefix.yaml
+++ b/releasenotes/notes/kubernetes-ingress-prefix.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: networking
+
+releaseNotes:
+  - |
+    **Fixed** a bug in Kubernetes Ingress causing paths with prefixes of the form `/foo` to
+    match the route `/foo/` but not the route `/foo`.

--- a/releasenotes/notes/kubernetes-ingress-prefix.yaml
+++ b/releasenotes/notes/kubernetes-ingress-prefix.yaml
@@ -1,6 +1,6 @@
 apiVersion: release-notes/v2
 kind: bug-fix
-area: networking
+area: traffic-management
 
 releaseNotes:
   - |

--- a/tests/integration/pilot/ingress_test.go
+++ b/tests/integration/pilot/ingress_test.go
@@ -247,7 +247,7 @@ spec:
             backend:
               serviceName: b
               servicePort: 80
-          - path: /prefix%s
+          - path: %s
             pathType: Prefix
             backend:
               serviceName: b
@@ -287,7 +287,7 @@ spec:
             name: b
             port:
               number: 80
-        path: /prefix%s
+        path: %s
         pathType: Prefix
 `
 			}
@@ -319,7 +319,8 @@ spec:
 						Validator: successValidator,
 						Count:     count,
 					},
-					path: "/test",
+					path:       "/test",
+					prefixPath: "/prefix",
 				},
 				{
 					// Prefix /prefix/should MATCHES prefix/should/match
@@ -336,7 +337,7 @@ spec:
 						Count:     count,
 					},
 					path:       "/test",
-					prefixPath: "/should",
+					prefixPath: "/prefix/should",
 				},
 				{
 					// Prefix /prefix/test/ should match path /prefix/test
@@ -353,7 +354,7 @@ spec:
 						Count:     count,
 					},
 					path:       "/test",
-					prefixPath: "/test/",
+					prefixPath: "/prefix/test/",
 				},
 				{
 					// Prefix /prefix/test should match /prefix/test/
@@ -370,7 +371,7 @@ spec:
 						Count:     count,
 					},
 					path:       "/test",
-					prefixPath: "/test",
+					prefixPath: "/prefix/test",
 				},
 				{
 					// Prefix /prefix/test should NOT match /prefix/testrandom
@@ -387,7 +388,7 @@ spec:
 						Count:     count,
 					},
 					path:       "/test",
-					prefixPath: "/test",
+					prefixPath: "/prefix/test",
 				},
 				{
 					// Basic HTTPS call for foo. CaCert matches the secret
@@ -404,7 +405,8 @@ spec:
 						Validator: successValidator,
 						Count:     count,
 					},
-					path: "/test",
+					path:       "/test",
+					prefixPath: "/prefix",
 				},
 				{
 					// Basic HTTPS call for bar. CaCert matches the secret
@@ -421,7 +423,8 @@ spec:
 						Validator: successValidator,
 						Count:     count,
 					},
-					path: "/test",
+					path:       "/test",
+					prefixPath: "/prefix",
 				},
 				{
 					// HTTPS call for bar with namedport route. CaCert matches the secret
@@ -438,7 +441,8 @@ spec:
 						Validator: successValidator,
 						Count:     count,
 					},
-					path: "/test",
+					path:       "/test",
+					prefixPath: "/prefix",
 				},
 			}
 

--- a/tests/integration/pilot/ingress_test.go
+++ b/tests/integration/pilot/ingress_test.go
@@ -512,7 +512,7 @@ spec:
 			// setup another ingress pointing to a different route; the ingress will have an ingress class that should be targeted at first
 			const updateIngressName = "update-test-ingress"
 			if err := t.Config().ApplyYAML(apps.Namespace.Name(), ingressClassConfig,
-				fmt.Sprintf(ingressConfigTemplate, updateIngressName, "istio-test", "/update-test", "/update-test")); err != nil {
+				fmt.Sprintf(ingressConfigTemplate, updateIngressName, "istio-test", "/update-test", "/update-test", "/update-test")); err != nil {
 				t.Fatal(err)
 			}
 			// these cases make sure that when new Ingress configs are applied our controller picks up on them

--- a/tests/integration/pilot/ingress_test.go
+++ b/tests/integration/pilot/ingress_test.go
@@ -246,7 +246,12 @@ spec:
           - path: %s
             backend:
               serviceName: b
-              servicePort: 80`
+              servicePort: 80
+          - path: /prefix%s
+            pathType: Prefix
+            backend:
+              serviceName: b
+              servicePort: http`
 			if apiVersion == "v1" {
 				ingressConfigTemplate = `
 apiVersion: networking.k8s.io/v1
@@ -277,23 +282,28 @@ spec:
               number: 80
         path: %s
         pathType: ImplementationSpecific
+      - backend:
+          service:
+            name: b
+            port:
+              number: 80
+        path: /prefix%s
+        pathType: Prefix
 `
 			}
 
-			if err := t.Config().ApplyYAML(apps.Namespace.Name(), ingressClassConfig,
-				fmt.Sprintf(ingressConfigTemplate, "ingress", "istio-test", "/test", "/test")); err != nil {
-				t.Fatal(err)
-			}
-
-			validator := echo.And(echo.ExpectOK(), echo.ExpectReachedClusters(apps.PodB.Clusters()))
+			successValidator := echo.And(echo.ExpectOK(), echo.ExpectReachedClusters(apps.PodB.Clusters()))
+			failureValidator := echo.And(echo.ExpectCode("404"))
 			count := 1
 			if t.Clusters().IsMulticluster() {
 				count = 2 * len(t.Clusters())
 			}
 			// TODO check all clusters were hit
 			cases := []struct {
-				name string
-				call echo.CallOptions
+				name       string
+				path       string
+				prefixPath string
+				call       echo.CallOptions
 			}{
 				{
 					// Basic HTTP call
@@ -306,9 +316,61 @@ spec:
 						Headers: map[string][]string{
 							"Host": {"server"},
 						},
-						Validator: validator,
+						Validator: successValidator,
 						Count:     count,
 					},
+					path: "/test",
+				},
+				{
+					// Prefix /prefix/test/ should match path /prefix/test
+					name: "http-prefix-matches-without-trailing-backslash",
+					call: echo.CallOptions{
+						Port: &echo.Port{
+							Protocol: protocol.HTTP,
+						},
+						Path: "/prefix/test",
+						Headers: map[string][]string{
+							"Host": {"server"},
+						},
+						Validator: successValidator,
+						Count:     count,
+					},
+					path:       "/test",
+					prefixPath: "/test/",
+				},
+				{
+					// Prefix /prefix/test should match /prefix/test/
+					name: "http-prefix-matches-trailing-blackslash",
+					call: echo.CallOptions{
+						Port: &echo.Port{
+							Protocol: protocol.HTTP,
+						},
+						Path: "/prefix/test/",
+						Headers: map[string][]string{
+							"Host": {"server"},
+						},
+						Validator: successValidator,
+						Count:     count,
+					},
+					path:       "/test",
+					prefixPath: "/test",
+				},
+				{
+					// Prefix /prefix/test should NOT match /prefix/testrandom
+					name: "http-prefix-should-not-match-path-continuation",
+					call: echo.CallOptions{
+						Port: &echo.Port{
+							Protocol: protocol.HTTP,
+						},
+						Path: "/prefix/testrandom/",
+						Headers: map[string][]string{
+							"Host": {"server"},
+						},
+						Validator: failureValidator,
+						Count:     count,
+					},
+					path:       "/test",
+					prefixPath: "/test",
 				},
 				{
 					// Basic HTTPS call for foo. CaCert matches the secret
@@ -322,9 +384,10 @@ spec:
 							"Host": {"foo.example.com"},
 						},
 						CaCert:    ingressutil.IngressCredentialA.CaCert,
-						Validator: validator,
+						Validator: successValidator,
 						Count:     count,
 					},
+					path: "/test",
 				},
 				{
 					// Basic HTTPS call for bar. CaCert matches the secret
@@ -338,9 +401,10 @@ spec:
 							"Host": {"bar.example.com"},
 						},
 						CaCert:    ingressutil.IngressCredentialB.CaCert,
-						Validator: validator,
+						Validator: successValidator,
 						Count:     count,
 					},
+					path: "/test",
 				},
 				{
 					// HTTPS call for bar with namedport route. CaCert matches the secret
@@ -354,9 +418,10 @@ spec:
 							"Host": {"bar.example.com"},
 						},
 						CaCert:    ingressutil.IngressCredentialB.CaCert,
-						Validator: validator,
+						Validator: successValidator,
 						Count:     count,
 					},
+					path: "/test",
 				},
 			}
 
@@ -366,7 +431,11 @@ spec:
 					for _, c := range cases {
 						c := c
 						t.NewSubTest(c.name).Run(func(t framework.TestContext) {
-							ingr.CallWithRetryOrFail(t, c.call, retry.Timeout(time.Minute*2))
+							if err := t.Config().ApplyYAML(apps.Namespace.Name(), ingressClassConfig,
+								fmt.Sprintf(ingressConfigTemplate, "ingress", "istio-test", c.path, c.path, c.prefixPath)); err != nil {
+								t.Fatal(err)
+							}
+							ingr.CallWithRetryOrFail(t, c.call, retry.Converge(3), retry.Delay(500*time.Millisecond), retry.Timeout(time.Minute*2))
 						})
 					}
 				})
@@ -375,6 +444,10 @@ spec:
 			t.NewSubTest("status").Run(func(t framework.TestContext) {
 				if !t.Environment().(*kube.Environment).Settings().LoadBalancerSupported {
 					t.Skip("ingress status not supported without load balancer")
+				}
+				if err := t.Config().ApplyYAML(apps.Namespace.Name(), ingressClassConfig,
+					fmt.Sprintf(ingressConfigTemplate, "ingress", "istio-test", "/test", "/test", "/test")); err != nil {
+					t.Fatal(err)
 				}
 
 				host, _ := apps.Ingress.HTTPAddress()
@@ -478,7 +551,7 @@ spec:
 
 			for _, c := range ingressUpdateCases {
 				c := c
-				updatedIngress := fmt.Sprintf(ingressConfigTemplate, updateIngressName, c.ingressClass, c.path, c.path)
+				updatedIngress := fmt.Sprintf(ingressConfigTemplate, updateIngressName, c.ingressClass, c.path, c.path, c.path)
 				t.Config().ApplyYAMLOrFail(t, apps.Namespace.Name(), updatedIngress)
 				t.NewSubTest(c.name).Run(func(t framework.TestContext) {
 					apps.Ingress.CallWithRetryOrFail(t, c.call, retry.Timeout(time.Minute))

--- a/tests/integration/pilot/ingress_test.go
+++ b/tests/integration/pilot/ingress_test.go
@@ -322,6 +322,23 @@ spec:
 					path: "/test",
 				},
 				{
+					// Prefix /prefix/should MATCHES prefix/should/match
+					name: "http-prefix-matches-subpath",
+					call: echo.CallOptions{
+						Port: &echo.Port{
+							Protocol: protocol.HTTP,
+						},
+						Path: "/prefix/should/match",
+						Headers: map[string][]string{
+							"Host": {"server"},
+						},
+						Validator: successValidator,
+						Count:     count,
+					},
+					path:       "/test",
+					prefixPath: "/should",
+				},
+				{
 					// Prefix /prefix/test/ should match path /prefix/test
 					name: "http-prefix-matches-without-trailing-backslash",
 					call: echo.CallOptions{

--- a/tests/integration/pilot/ingress_test.go
+++ b/tests/integration/pilot/ingress_test.go
@@ -95,7 +95,7 @@ spec:
   - matches:
     - path:
         type: Prefix
-        value: /get
+        value: /get/
     forwardTo:
     - serviceName: b
       port: 80
@@ -139,15 +139,18 @@ spec:
 `)
 
 			t.NewSubTest("http").Run(func(t framework.TestContext) {
-				_ = apps.Ingress.CallWithRetryOrFail(t, echo.CallOptions{
-					Port: &echo.Port{
-						Protocol: protocol.HTTP,
-					},
-					Path: "/get",
-					Headers: map[string][]string{
-						"Host": {"my.domain.example"},
-					},
-				})
+				paths := []string{"/get", "/get/", "/get/prefix"}
+				for _, path := range paths {
+					_ = apps.Ingress.CallWithRetryOrFail(t, echo.CallOptions{
+						Port: &echo.Port{
+							Protocol: protocol.HTTP,
+						},
+						Path: path,
+						Headers: map[string][]string{
+							"Host": {"my.domain.example"},
+						},
+					})
+				}
 			})
 			t.NewSubTest("tcp").Run(func(t framework.TestContext) {
 				host, port := apps.Ingress.TCPAddress()


### PR DESCRIPTION
Imagine a Kubernetes Ingress with `path: /sample` and `pathType: Prefix`:

```
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: minimal-ingress
  annotations:
    nginx.ingress.kubernetes.io/rewrite-target: /
spec:
  rules:
  - http:
      paths:
      - path: /sample
        pathType: Prefix
        backend:
          service:
            name: test
            port:
              number: 80
```

In our current implementation we append a `/` to  `/sample` which turns into an exact string prefix match for `/sample/`:

https://github.com/istio/istio/blob/db4afa01f9a696a2c77528d75dacccffa565ea13/pilot/pkg/config/kube/ingressv1/conversion.go#L166-L172

We do this to prevent `/sample` from matching `/samplerandomtext`. However, it also prevents us form matching on `/sample`, which must match per the Ingress spec. Need to use a smarter regex instead to make it so that we match the prefix without trailing slash AND match with additional path components after the prefix.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
