### PR TITLE
Google Certificate Authority Service plugin (#33898)

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1185,6 +1185,7 @@ golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4/go.mod h1:RBQZq4jEuRlivfhVLd
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
 golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5 h1:wjuX4b5yYQnEQHzd+CBcrcC6OVR2J1CN6mUy0oSxIPo=
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -1439,6 +1440,7 @@ google.golang.org/api v0.38.0/go.mod h1:fYKFpnQN0DsDSKRVRcQSDQNtqWPfM9i+zNPxepjR
 google.golang.org/api v0.40.0/go.mod h1:fYKFpnQN0DsDSKRVRcQSDQNtqWPfM9i+zNPxepjRCQ8=
 google.golang.org/api v0.41.0/go.mod h1:RkxM5lITDfTzmyKFPt+wGrCJbVfniCr2ool8kTBzRTU=
 google.golang.org/api v0.43.0/go.mod h1:nQsDGjRXMo4lvh5hP0TKqF244gqhGcr/YSIykhUk/94=
+google.golang.org/api v0.46.0/go.mod h1:ceL4oozhkAiTID8XMmJBsIxID/9wMXJVVFXPg4ylg3I=
 google.golang.org/api v0.46.0/go.mod h1:ceL4oozhkAiTID8XMmJBsIxID/9wMXJVVFXPg4ylg3I=
 google.golang.org/api v0.47.0 h1:sQLWZQvP6jPGIP4JGPkJu4zHswrv81iobiyszr3b/0I=
 google.golang.org/api v0.47.0/go.mod h1:Wbvgpq1HddcWVtzsVLyfLp8lDg6AA241LmgIL59tHXo=

--- a/pilot/cmd/pilot-agent/options/security.go
+++ b/pilot/cmd/pilot-agent/options/security.go
@@ -107,7 +107,7 @@ func SetupSecurityOptions(proxyConfig *meshconfig.ProxyConfig, secOpt *security.
 		o.CAProviderName = security.GoogleCAProvider
 	}
 	// TODO extract this logic out to a plugin
-	if o.CAProviderName == security.GoogleCAProvider {
+	if o.CAProviderName == security.GoogleCAProvider || o.CAProviderName == security.GoogleCASProvider {
 		o.TokenExchanger = stsclient.NewSecureTokenServiceExchanger(o.CredFetcher, o.TrustDomain)
 	}
 

--- a/pkg/istio-agent/agent.go
+++ b/pkg/istio-agent/agent.go
@@ -34,6 +34,7 @@ import (
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"github.com/gogo/protobuf/types"
 	"github.com/golang/protobuf/jsonpb"
+	"google.golang.org/api/option"
 	"google.golang.org/grpc"
 
 	mesh "istio.io/api/mesh/v1alpha1"
@@ -52,6 +53,7 @@ import (
 	"istio.io/istio/security/pkg/nodeagent/caclient"
 	citadel "istio.io/istio/security/pkg/nodeagent/caclient/providers/citadel"
 	gca "istio.io/istio/security/pkg/nodeagent/caclient/providers/google"
+	cas "istio.io/istio/security/pkg/nodeagent/caclient/providers/google-cas"
 	"istio.io/istio/security/pkg/nodeagent/sds"
 	"istio.io/pkg/log"
 )
@@ -638,6 +640,14 @@ func (a *Agent) newSecretManager() (*cache.SecretManagerClient, error) {
 		// This is only used if the proper env variables are injected - otherwise the existing Citadel or Istiod will be
 		// used.
 		caClient, err := gca.NewGoogleCAClient(a.secOpts.CAEndpoint, true, caclient.NewCATokenProvider(a.secOpts))
+		if err != nil {
+			return nil, err
+		}
+		return cache.NewSecretManagerClient(caClient, a.secOpts)
+	} else if a.secOpts.CAProviderName == security.GoogleCASProvider {
+		// Use a plugin
+		caClient, err := cas.NewGoogleCASClient(a.secOpts.CAEndpoint,
+			option.WithGRPCDialOption(grpc.WithPerRPCCredentials(caclient.NewCATokenProvider(a.secOpts))))
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/security/security.go
+++ b/pkg/security/security.go
@@ -57,6 +57,9 @@ const (
 
 	// GoogleCAProvider uses the Google CA for workload certificate signing
 	GoogleCAProvider = "GoogleCA"
+
+	// GoogleCASProvider uses the Google certificate Authority Service to sign workload certificates
+	GoogleCASProvider = "GoogleCAS"
 )
 
 // TODO: For 1.8, make sure MeshConfig is updated with those settings,
@@ -223,6 +226,7 @@ type StsRequestParameters struct {
 type Client interface {
 	CSRSign(csrPEM []byte, certValidTTLInSec int64) ([]string, error)
 	Close()
+	// Retrieve CA root certs If CA publishes API endpoint for this
 	GetRootCertBundle() ([]string, error)
 }
 

--- a/security/pkg/nodeagent/caclient/providers/citadel/client.go
+++ b/security/pkg/nodeagent/caclient/providers/citadel/client.go
@@ -235,6 +235,7 @@ func (c *CitadelClient) reconnectIfNeeded() error {
 	return nil
 }
 
+// GetRootCertBundle: Citadel (Istiod) CA doesn't publish any endpoint to retrieve CA certs
 func (c *CitadelClient) GetRootCertBundle() ([]string, error) {
 	return []string{}, nil
 }

--- a/security/pkg/nodeagent/caclient/providers/google-cas/client.go
+++ b/security/pkg/nodeagent/caclient/providers/google-cas/client.go
@@ -1,0 +1,150 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package caclient
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	privateca "cloud.google.com/go/security/privateca/apiv1"
+	"google.golang.org/api/option"
+	privatecapb "google.golang.org/genproto/googleapis/cloud/security/privateca/v1"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"k8s.io/apimachinery/pkg/util/rand"
+
+	"istio.io/istio/pkg/security"
+	"istio.io/pkg/log"
+)
+
+var googleCASClientLog = log.RegisterScope("googlecas", "Google CAS client debugging", 0)
+
+// GoogleCASClient: Agent side plugin for Google CAS
+type GoogleCASClient struct {
+	caSigner string
+	caClient *privateca.CertificateAuthorityClient
+}
+
+// NewGoogleCASClient create a CA client for Google CAS.
+func NewGoogleCASClient(capool string, options ...option.ClientOption) (security.Client, error) {
+	caClient := &GoogleCASClient{caSigner: capool}
+	ctx := context.Background()
+	var err error
+
+	caClient.caClient, err = privateca.NewCertificateAuthorityClient(ctx, options...)
+
+	if err != nil {
+		googleCASClientLog.Errorf("unable to initialize google cas caclient: %v", err)
+		return nil, err
+	}
+	googleCASClientLog.Debugf("Intitialized Google CAS plugin with endpoint: %v", capool)
+	return caClient, nil
+}
+
+func (r *GoogleCASClient) createCertReq(name string, csrPEM []byte, lifetime time.Duration) *privatecapb.CreateCertificateRequest {
+	var isCA bool = false
+
+	// We use Certificate_Config option to ensure that we only request a certificate with CAS supported extensions/usages.
+	// CAS uses the PEM encoded CSR only for its public key and infers the certificate SAN (identity) of the workload through SPIFFE identity reflection
+	creq := &privatecapb.CreateCertificateRequest{
+		Parent:        r.caSigner,
+		CertificateId: name,
+		Certificate: &privatecapb.Certificate{
+			Lifetime: durationpb.New(lifetime),
+			CertificateConfig: &privatecapb.Certificate_Config{
+				Config: &privatecapb.CertificateConfig{
+					SubjectConfig: &privatecapb.CertificateConfig_SubjectConfig{
+						Subject: &privatecapb.Subject{},
+					},
+					X509Config: &privatecapb.X509Parameters{
+						KeyUsage: &privatecapb.KeyUsage{
+							BaseKeyUsage: &privatecapb.KeyUsage_KeyUsageOptions{
+								DigitalSignature: true,
+								KeyEncipherment:  true,
+							},
+							ExtendedKeyUsage: &privatecapb.KeyUsage_ExtendedKeyUsageOptions{
+								ServerAuth: true,
+								ClientAuth: true,
+							},
+						},
+						CaOptions: &privatecapb.X509Parameters_CaOptions{
+							IsCa: &isCA,
+						},
+					},
+					PublicKey: &privatecapb.PublicKey{
+						Format: privatecapb.PublicKey_PEM,
+						Key:    csrPEM,
+					},
+				},
+			},
+			SubjectMode: privatecapb.SubjectRequestMode_REFLECTED_SPIFFE,
+		},
+	}
+	return creq
+}
+
+// CSR Sign calls Google CAS to sign a CSR.
+func (r *GoogleCASClient) CSRSign(csrPEM []byte, certValidTTLInSec int64) ([]string, error) {
+	certChain := []string{}
+
+	rand.Seed(time.Now().UnixNano())
+	name := fmt.Sprintf("csr-workload-%s", rand.String(8))
+	creq := r.createCertReq(name, csrPEM, time.Duration(certValidTTLInSec)*time.Second)
+
+	ctx := context.Background()
+
+	cresp, err := r.caClient.CreateCertificate(ctx, creq)
+	if err != nil {
+		googleCASClientLog.Errorf("unable to create certificate: %v", err)
+		return []string{}, err
+	}
+	certChain = append(certChain, cresp.GetPemCertificate())
+	certChain = append(certChain, cresp.GetPemCertificateChain()...)
+	return certChain, nil
+}
+
+// GetRootCertBundle:  Get CA certs of the pool from Google CAS API endpoint
+func (r *GoogleCASClient) GetRootCertBundle() ([]string, error) {
+	var rootCertMap map[string]struct{} = make(map[string]struct{})
+	var trustbundle []string = []string{}
+	var err error
+
+	ctx := context.Background()
+
+	req := &privatecapb.FetchCaCertsRequest{
+		CaPool: r.caSigner,
+	}
+	resp, err := r.caClient.FetchCaCerts(ctx, req)
+	if err != nil {
+		googleCASClientLog.Errorf("error when getting root-certs from CAS pool: %v", err)
+		return trustbundle, err
+	}
+	for _, certChain := range resp.CaCerts {
+		certs := certChain.Certificates
+		rootCert := certs[len(certs)-1]
+		if _, ok := rootCertMap[rootCert]; !ok {
+			rootCertMap[rootCert] = struct{}{}
+		}
+	}
+
+	for rootCert := range rootCertMap {
+		trustbundle = append(trustbundle, rootCert)
+	}
+	return trustbundle, nil
+}
+
+func (r *GoogleCASClient) Close() {
+	r.caClient.Close()
+}

--- a/security/pkg/nodeagent/caclient/providers/google-cas/client_test.go
+++ b/security/pkg/nodeagent/caclient/providers/google-cas/client_test.go
@@ -1,0 +1,110 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package caclient
+
+import (
+	"reflect"
+	"testing"
+
+	"google.golang.org/api/option"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"istio.io/istio/security/pkg/nodeagent/caclient/providers/google-cas/mock"
+)
+
+var (
+	fakeCert                 string = "foo"
+	fakeCertChain                   = []string{"baz", "bar"}
+	fakeCaBundle                    = [][]string{{"bar"}, {"baz", "bar"}}
+	fakeExpectedRootCaBundle        = []string{"bar"}
+	fakePoolLocator                 = "projects/test-project/locations/test-location/caPools/test-pool"
+	badPoolLocator                  = "bad-pool"
+)
+
+func TestGoogleCASClient(t *testing.T) {
+	fakeCombinedCert := append([]string{}, fakeCert)
+	fakeCombinedCert = append(fakeCombinedCert, fakeCertChain...)
+
+	testCases := map[string]struct {
+		poolLocator        string
+		service            mock.CASService
+		expectedCert       []string
+		expectedCertBundle []string
+		expectedErr        error
+	}{
+		"Valid certs": {
+			// Check RootCertBundle is correctly extracted from CAS response
+			// Check Certchain is correctly build from CAS response
+			poolLocator:        fakePoolLocator,
+			service:            mock.CASService{CertPEM: fakeCert, CertChainPEM: fakeCertChain, CaCertBundle: fakeCaBundle},
+			expectedCert:       fakeCombinedCert,
+			expectedCertBundle: fakeExpectedRootCaBundle,
+			expectedErr:        nil,
+		},
+		"Invalid Pool": {
+			// Destination is invalid pool
+			poolLocator:        badPoolLocator,
+			service:            mock.CASService{CertPEM: fakeCert, CertChainPEM: fakeCertChain, CaCertBundle: fakeCaBundle},
+			expectedCert:       fakeCombinedCert,
+			expectedCertBundle: fakeExpectedRootCaBundle,
+			expectedErr:        status.Error(codes.InvalidArgument, "malformed ca path"),
+		},
+	}
+
+	for id, tc := range testCases {
+		// create a local grpc server
+		s, lis, err := mock.CreateServer(&tc.service)
+		if err != nil {
+			t.Fatalf("Test case [%s] Mock CAS Server Init: failed to create server: %v", id, err)
+		}
+		defer s.Stop()
+
+		cli, err := NewGoogleCASClient(tc.poolLocator,
+			option.WithoutAuthentication(),
+			option.WithGRPCDialOption(grpc.WithContextDialer(mock.ContextDialerCreate(lis))),
+			option.WithGRPCDialOption(grpc.WithInsecure()))
+		if err != nil {
+			t.Errorf("Test case [%s] Client Init: failed to create ca client: %v", id, err)
+		}
+
+		resp, err := cli.CSRSign([]byte{01}, 1)
+		if err != nil {
+			if err.Error() != tc.expectedErr.Error() {
+				t.Errorf("Test case [%s] Cert Check: error (%s) does not match expected error (%s)", id, err.Error(), tc.expectedErr.Error())
+			}
+		} else {
+			if tc.expectedErr != nil {
+				t.Errorf("Test case [%s] Cert Check: expect error: %s but got no error", id, tc.expectedErr.Error())
+			} else if !reflect.DeepEqual(resp, tc.expectedCert) {
+				t.Errorf("Test case [%s] Cert Check: resp: got %+v, expected %v", id, resp, tc.expectedCert)
+			}
+		}
+
+		resp, err = cli.GetRootCertBundle()
+		if err != nil {
+			if err.Error() != tc.expectedErr.Error() {
+				t.Errorf("Test case [%s] RootCaBundle check: error (%s) does not match expected error (%s)", id, err.Error(), tc.expectedErr.Error())
+			}
+		} else {
+			if tc.expectedErr != nil {
+				t.Errorf("Test case [%s] RootCaBundle check: expect error: %s but got no error", id, tc.expectedErr.Error())
+			} else if !reflect.DeepEqual(resp, tc.expectedCertBundle) {
+				t.Errorf("Test case [%s] RootCaBundle check: resp: got %+v, expected %v", id, resp, tc.expectedCertBundle)
+			}
+		}
+	}
+}

--- a/security/pkg/nodeagent/caclient/providers/google-cas/mock/ca_mock.go
+++ b/security/pkg/nodeagent/caclient/providers/google-cas/mock/ca_mock.go
@@ -1,0 +1,176 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mock
+
+import (
+	"context"
+	"errors"
+	"net"
+	"path"
+	"strings"
+	"time"
+
+	privatecapb "google.golang.org/genproto/googleapis/cloud/security/privateca/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+const (
+	bufSize = 1024 * 1024
+)
+
+var lis *bufconn.Listener = nil
+
+type ContextDialer func(ctx context.Context, address string) (net.Conn, error)
+
+func ContextDialerCreate(listener *bufconn.Listener) ContextDialer {
+	bufDialer := func(ctx context.Context, address string) (net.Conn, error) {
+		return listener.Dial()
+	}
+	return bufDialer
+}
+
+func BufDialer(ctx context.Context, address string) (net.Conn, error) {
+	return lis.Dial()
+}
+
+type certificate struct {
+	resourcePath string
+	certPEM      string
+	certChainPEM []string
+}
+
+// CASService is a mock Google CAS Service.
+type CASService struct {
+	privatecapb.UnimplementedCertificateAuthorityServiceServer
+	CertPEM      string
+	CertChainPEM []string
+	CaCertBundle [][]string
+}
+
+func parseCertificateAuthorityPath(p string) (project, location, name string, err error) {
+	pieces := strings.Split(p, "/")
+	if len(pieces) != 6 {
+		return "", "", "", errors.New("malformed certificate authority path")
+	}
+	if pieces[0] != "projects" {
+		return "", "", "", errors.New("malformed certificate authority path")
+	}
+	project = pieces[1]
+	if pieces[2] != "locations" {
+		return "", "", "", errors.New("malformed certificate authority path")
+	}
+	location = pieces[3]
+	if pieces[4] != "caPools" {
+		return "", "", "", errors.New("malformed certificate authority path")
+	}
+	name = pieces[5]
+	return project, location, name, nil
+}
+
+func (ca CASService) certEncode(cert *certificate) *privatecapb.Certificate {
+	pb := &privatecapb.Certificate{
+		Name: cert.resourcePath,
+	}
+	if len(cert.certPEM) != 0 {
+		pb.PemCertificate = cert.certPEM
+	}
+	if len(cert.certChainPEM) != 0 {
+		pb.PemCertificateChain = cert.certChainPEM
+	}
+	return pb
+}
+
+// CreateCertificate is a mocked function for the Google CAS CA API.
+func (ca CASService) CreateCertificate(ctx context.Context, req *privatecapb.CreateCertificateRequest) (*privatecapb.Certificate, error) {
+	_, _, _, err := parseCertificateAuthorityPath(req.Parent)
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, "malformed ca path")
+	}
+	project, location, authority, _ := parseCertificateAuthorityPath(req.GetParent())
+	switch req.GetCertificate().CertificateConfig.(type) {
+	case *privatecapb.Certificate_PemCsr:
+		return nil, status.Errorf(codes.InvalidArgument, "cannot request certificates using PEM CSR format")
+	}
+	certResourcePath := path.Join("projects", project, "locations", location, "caPools", authority, "certificates", req.GetCertificate().GetName())
+	certObj := &certificate{
+		resourcePath: certResourcePath,
+		certPEM:      ca.CertPEM,
+		certChainPEM: ca.CertChainPEM,
+	}
+	return ca.certEncode(certObj), nil
+}
+
+func (ca CASService) FetchCaCerts(ctx context.Context, req *privatecapb.FetchCaCertsRequest) (*privatecapb.FetchCaCertsResponse, error) {
+	_, _, _, err := parseCertificateAuthorityPath(req.GetCaPool())
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, "malformed ca path")
+	}
+	certChains := []*privatecapb.FetchCaCertsResponse_CertChain{}
+	for _, trustBundle := range ca.CaCertBundle {
+		certChain := &privatecapb.FetchCaCertsResponse_CertChain{}
+		certChain.Certificates = trustBundle
+		certChains = append(certChains, certChain)
+	}
+	resp := &privatecapb.FetchCaCertsResponse{
+		CaCerts: certChains,
+	}
+	return resp, nil
+}
+
+// CASServer is the mocked Google CAS server.
+type CASServer struct {
+	Server  *grpc.Server
+	Address string
+}
+
+// CreateServer creates a mocked local Google CAS server and runs it in a separate goroutine.
+func CreateServer(service *CASService) (*CASServer, *bufconn.Listener, error) {
+	var err error
+	s := &CASServer{
+		Server: grpc.NewServer(),
+	}
+
+	lis = bufconn.Listen(bufSize)
+	serveErr := make(chan error, 1)
+
+	go func() {
+		privatecapb.RegisterCertificateAuthorityServiceServer(s.Server, service)
+		err := s.Server.Serve(lis)
+		serveErr <- err
+		close(serveErr)
+	}()
+
+	select {
+	case <-time.After(1 * time.Second):
+		err = nil
+	case err = <-serveErr:
+	}
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return s, lis, nil
+}
+
+// Stop stops the Mock Mesh CA server.
+func (s *CASServer) Stop() {
+	if s.Server != nil {
+		s.Server.Stop()
+	}
+}

--- a/security/pkg/nodeagent/caclient/providers/google/client.go
+++ b/security/pkg/nodeagent/caclient/providers/google/client.go
@@ -135,6 +135,11 @@ func (cl *googleCAClient) getTLSDialOption() (grpc.DialOption, error) {
 	return grpc.WithTransportCredentials(creds), nil
 }
 
+// GetRootCertBundle: Google Mesh CA doesn't publish any endpoint to retrieve CA certs
+func (cl *googleCAClient) GetRootCertBundle() ([]string, error) {
+	return []string{}, nil
+}
+
 func parseZone(clusterURL string) string {
 	// for Hub IDNS, the input is https://gkehub.googleapis.com/projects/HUB_PROJECT_ID/locations/global/memberships/MEMBERSHIP_ID which is global
 	if strings.HasPrefix(clusterURL, hubIDPPrefix) {
@@ -148,8 +153,4 @@ func parseZone(clusterURL string) string {
 		return ""
 	}
 	return rs[2]
-}
-
-func (cl *googleCAClient) GetRootCertBundle() ([]string, error) {
-	return []string{}, nil
 }


### PR DESCRIPTION
Preliminary effort to add a CA plugin to get certificates signed using[ Google CAS](https://cloud.google.com/certificate-authority-service). This is a manual cherry-pick from master branch 19fb530. 

Similar to Mesh CA integration, Google CAS issues  workload mTLS certificate using identity reflection.

* Istio - Google CAS Integration: Adding Google CAS Client plugin to istio-agent

* Google CAS: Add Mock Google CAS server and unit tests

* Fixing review comments

* Fixing more review comments



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.