### PR TITLE
fix break the looop when k8s config is found

### DIFF
--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -331,11 +331,7 @@ func (s *Server) initStatusController(args *PilotArgs, writeStatus bool) {
 }
 
 func (s *Server) makeKubeConfigController(args *PilotArgs) (model.ConfigStoreCache, error) {
-	c, err := crdclient.New(s.kubeClient, args.Revision, args.RegistryOptions.KubeOptions.DomainSuffix)
-	if err != nil {
-		return nil, err
-	}
-	return c, nil
+	return crdclient.New(s.kubeClient, args.Revision, args.RegistryOptions.KubeOptions.DomainSuffix)
 }
 
 func (s *Server) makeFileMonitor(fileDir string, domainSuffix string, configController model.ConfigStore) error {

--- a/pilot/pkg/bootstrap/options.go
+++ b/pilot/pkg/bootstrap/options.go
@@ -102,7 +102,7 @@ type InjectionOptions struct {
 	InjectionDirectory string
 }
 
-// Optional TLS parameters for Istiod server.
+// TLSOptions is optional TLS parameters for Istiod server.
 type TLSOptions struct {
 	CaCertFile      string
 	CertFile        string

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -566,6 +566,7 @@ func (s *Server) initKubeClient(args *PilotArgs) error {
 			for _, cs := range meshConfig.ConfigSources {
 				if cs.Address == string(Kubernetes)+"://" {
 					hasK8SConfigStore = true
+					break
 				}
 			}
 		} else if args.RegistryOptions.KubeConfig != "" {
@@ -660,7 +661,7 @@ func (s *Server) initDiscoveryService(args *PilotArgs) {
 	} else {
 		// This happens only if the GRPC port (15010) is disabled. We will multiplex
 		// it on the HTTP port. Does not impact the HTTPS gRPC or HTTPS.
-		log.Info("multiplexing gRPC on http port ", args.ServerOptions.HTTPAddr)
+		log.Info("multiplexing gRPC on http addr ", args.ServerOptions.HTTPAddr)
 		s.MultiplexGRPC = true
 	}
 }


### PR DESCRIPTION
when k8s config is found, we could break the loop but not to continue.
simplify some codes, fix some comments and logs


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.