### PR TITLE
no need to sort.SliceStable with name+namespace compared

### DIFF
--- a/pilot/pkg/config/kube/ingress/controller.go
+++ b/pilot/pkg/config/kube/ingress/controller.go
@@ -323,7 +323,7 @@ func sortIngressByCreationTime(configs []interface{}) []*ingress.Ingress {
 	for _, i := range configs {
 		ingr = append(ingr, i.(*ingress.Ingress))
 	}
-	sort.SliceStable(ingr, func(i, j int) bool {
+	sort.Slice(ingr, func(i, j int) bool {
 		// If creation time is the same, then behavior is nondeterministic. In this case, we can
 		// pick an arbitrary but consistent ordering based on name and namespace, which is unique.
 		// CreationTimestamp is stored in seconds, so this is not uncommon.

--- a/pilot/pkg/config/kube/ingressv1/controller.go
+++ b/pilot/pkg/config/kube/ingressv1/controller.go
@@ -279,7 +279,7 @@ func sortIngressByCreationTime(configs []interface{}) []*knetworking.Ingress {
 	for _, i := range configs {
 		ingr = append(ingr, i.(*knetworking.Ingress))
 	}
-	sort.SliceStable(ingr, func(i, j int) bool {
+	sort.Slice(ingr, func(i, j int) bool {
 		// If creation time is the same, then behavior is nondeterministic. In this case, we can
 		// pick an arbitrary but consistent ordering based on name and namespace, which is unique.
 		// CreationTimestamp is stored in seconds, so this is not uncommon.

--- a/pilot/pkg/model/config.go
+++ b/pilot/pkg/model/config.go
@@ -340,7 +340,7 @@ func (store *istioConfigStore) ServiceEntries() []config.Config {
 
 // sortConfigByCreationTime sorts the list of config objects in ascending order by their creation time (if available).
 func sortConfigByCreationTime(configs []config.Config) {
-	sort.SliceStable(configs, func(i, j int) bool {
+	sort.Slice(configs, func(i, j int) bool {
 		// If creation time is the same, then behavior is nondeterministic. In this case, we can
 		// pick an arbitrary but consistent ordering based on name and namespace, which is unique.
 		// CreationTimestamp is stored in seconds, so this is not uncommon.

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -70,7 +70,7 @@ type Environment struct {
 	// service registries.
 	mesh.NetworksWatcher
 
-	// PushContext holds informations during push generation. It is reset on config change, at the beginning
+	// PushContext holds information during push generation. It is reset on config change, at the beginning
 	// of the pushAll. It will hold all errors and stats and possibly caches needed during the entire cache computation.
 	// DO NOT USE EXCEPT FOR TESTS AND HANDLING OF NEW CONNECTIONS.
 	// ALL USE DURING A PUSH SHOULD USE THE ONE CREATED AT THE


### PR DESCRIPTION

similar to #34279

The less function used by `sort.SliceStable` will never be equal, as it uses name+namespace of resources to compare at last. name+namespace of resources wont be the same.
It is better to use `sort.Slice` than `sort.SliceStable`, as `sort.Slice` uses quick sort and `sort.SliceStable` uses insertion sort. This will improve performance when there are a lot of resources.

```go
func sortIngressByCreationTime(configs []interface{}) []*ingress.Ingress {
	ingr := make([]*ingress.Ingress, 0, len(configs))
	for _, i := range configs {
		ingr = append(ingr, i.(*ingress.Ingress))
	}
	sort.SliceStable(ingr, func(i, j int) bool {
		// If creation time is the same, then behavior is nondeterministic. In this case, we can
		// pick an arbitrary but consistent ordering based on name and namespace, which is unique.
		// CreationTimestamp is stored in seconds, so this is not uncommon.
		if ingr[i].CreationTimestamp == ingr[j].CreationTimestamp {
			in := ingr[i].Name + "." + ingr[i].Namespace
			jn := ingr[j].Name + "." + ingr[j].Namespace
			return in < jn
		}
		return ingr[i].CreationTimestamp.Before(&ingr[j].CreationTimestamp)
	})
	return ingr
}
```

Also fix a typo that the word “information” is an uncountable noun.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[X] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.