### PR TITLE
fix `istioctl profile dump` and `istioctl profile diff` have the extra info log

### DIFF
--- a/istioctl/cmd/root.go
+++ b/istioctl/cmd/root.go
@@ -252,7 +252,7 @@ debug and diagnose their Istio mesh.
 	hideInheritedFlags(installCmd, "namespace", "istioNamespace", "charts")
 	rootCmd.AddCommand(installCmd)
 
-	profileCmd := mesh.ProfileCmd()
+	profileCmd := mesh.ProfileCmd(loggingOptions)
 	hideInheritedFlags(profileCmd, "namespace", "istioNamespace", "charts")
 	rootCmd.AddCommand(profileCmd)
 

--- a/istioctl/cmd/version.go
+++ b/istioctl/cmd/version.go
@@ -32,11 +32,12 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/xds"
 	"istio.io/istio/pkg/proxy"
+	"istio.io/pkg/log"
 	istioVersion "istio.io/pkg/version"
 )
 
 func newVersionCommand() *cobra.Command {
-	profileCmd := mesh.ProfileCmd()
+	profileCmd := mesh.ProfileCmd(log.DefaultOptions())
 	var opts clioptions.ControlPlaneOptions
 	versionCmd := istioVersion.CobraCommandWithOptions(istioVersion.CobraOptions{
 		GetRemoteVersion: getRemoteInfoWrapper(&profileCmd, &opts),

--- a/operator/cmd/mesh/profile-diff.go
+++ b/operator/cmd/mesh/profile-diff.go
@@ -70,7 +70,7 @@ func profileDiffCmd(rootArgs *rootArgs, pfArgs *profileDiffArgs, logOpts *log.Op
 func profileDiff(cmd *cobra.Command, rootArgs *rootArgs, pfArgs *profileDiffArgs, args []string, logOpts *log.Options) (bool, error) {
 	initLogsOrExit(rootArgs)
 
-	l := clog.NewConsoleLogger(cmd.OutOrStdout(), cmd.OutOrStderr(), installerScope)
+	l := clog.NewConsoleLogger(cmd.OutOrStdout(), cmd.OutOrStderr(), nil)
 	setFlags := make([]string, 0)
 	if pfArgs.manifestsPath != "" {
 		setFlags = append(setFlags, fmt.Sprintf("installPackagePath=%s", pfArgs.manifestsPath))
@@ -82,12 +82,12 @@ func profileDiff(cmd *cobra.Command, rootArgs *rootArgs, pfArgs *profileDiffArgs
 }
 
 func profileDiffInternal(profileA, profileB string, setFlags []string, writer io.Writer, l clog.Logger) (bool, error) {
-	a, _, err := manifest.GenIOPFromProfile(profileA, "", setFlags, false, false, nil, l)
+	a, _, err := manifest.GenIOPFromProfile(profileA, "", setFlags, true, true, nil, l)
 	if err != nil {
 		return false, fmt.Errorf("could not read %q: %v", profileA, err)
 	}
 
-	b, _, err := manifest.GenIOPFromProfile(profileB, "", setFlags, false, false, nil, l)
+	b, _, err := manifest.GenIOPFromProfile(profileB, "", setFlags, true, true, nil, l)
 	if err != nil {
 		return false, fmt.Errorf("could not read %q: %v", profileB, err)
 	}

--- a/operator/cmd/mesh/profile-diff.go
+++ b/operator/cmd/mesh/profile-diff.go
@@ -24,6 +24,7 @@ import (
 	"istio.io/istio/operator/pkg/manifest"
 	"istio.io/istio/operator/pkg/util"
 	"istio.io/istio/operator/pkg/util/clog"
+	"istio.io/pkg/log"
 )
 
 type profileDiffArgs struct {
@@ -36,7 +37,7 @@ func addProfileDiffFlags(cmd *cobra.Command, args *profileDiffArgs) {
 	cmd.PersistentFlags().StringVarP(&args.manifestsPath, "manifests", "d", "", ManifestsFlagHelpStr)
 }
 
-func profileDiffCmd(rootArgs *rootArgs, pfArgs *profileDiffArgs) *cobra.Command {
+func profileDiffCmd(rootArgs *rootArgs, pfArgs *profileDiffArgs, logOpts *log.Options) *cobra.Command {
 	return &cobra.Command{
 		Use:   "diff <profile|file1.yaml> <profile|file2.yaml>",
 		Short: "Diffs two Istio configuration profiles",
@@ -53,7 +54,7 @@ func profileDiffCmd(rootArgs *rootArgs, pfArgs *profileDiffArgs) *cobra.Command 
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			isdifferent, err := profileDiff(cmd, rootArgs, pfArgs, args)
+			isdifferent, err := profileDiff(cmd, rootArgs, pfArgs, args, logOpts)
 			if err != nil {
 				return err
 			}
@@ -66,21 +67,27 @@ func profileDiffCmd(rootArgs *rootArgs, pfArgs *profileDiffArgs) *cobra.Command 
 }
 
 // profileDiff compare two profile files.
-func profileDiff(cmd *cobra.Command, rootArgs *rootArgs, pfArgs *profileDiffArgs, args []string) (bool, error) {
+func profileDiff(cmd *cobra.Command, rootArgs *rootArgs, pfArgs *profileDiffArgs, args []string, logOpts *log.Options) (bool, error) {
 	initLogsOrExit(rootArgs)
 
-	l := clog.NewConsoleLogger(os.Stdout, os.Stderr, nil)
-	setFlags := []string{fmt.Sprintf("installPackagePath=%s", pfArgs.manifestsPath)}
+	l := clog.NewConsoleLogger(cmd.OutOrStdout(), cmd.OutOrStderr(), installerScope)
+	setFlags := make([]string, 0)
+	if pfArgs.manifestsPath != "" {
+		setFlags = append(setFlags, fmt.Sprintf("installPackagePath=%s", pfArgs.manifestsPath))
+	}
+	if err := configLogs(logOpts); err != nil {
+		return false, fmt.Errorf("could not configure logs: %s", err)
+	}
 	return profileDiffInternal(args[0], args[1], setFlags, cmd.OutOrStdout(), l)
 }
 
 func profileDiffInternal(profileA, profileB string, setFlags []string, writer io.Writer, l clog.Logger) (bool, error) {
-	a, _, err := manifest.GenIOPFromProfile(profileA, "", setFlags, true, true, nil, l)
+	a, _, err := manifest.GenIOPFromProfile(profileA, "", setFlags, false, false, nil, l)
 	if err != nil {
 		return false, fmt.Errorf("could not read %q: %v", profileA, err)
 	}
 
-	b, _, err := manifest.GenIOPFromProfile(profileB, "", setFlags, true, true, nil, l)
+	b, _, err := manifest.GenIOPFromProfile(profileB, "", setFlags, false, false, nil, l)
 	if err != nil {
 		return false, fmt.Errorf("could not read %q: %v", profileB, err)
 	}

--- a/operator/cmd/mesh/profile.go
+++ b/operator/cmd/mesh/profile.go
@@ -16,10 +16,12 @@ package mesh
 
 import (
 	"github.com/spf13/cobra"
+
+	"istio.io/pkg/log"
 )
 
 // ProfileCmd is a group of commands related to profile listing, dumping and diffing.
-func ProfileCmd() *cobra.Command {
+func ProfileCmd(logOpts *log.Options) *cobra.Command {
 	pc := &cobra.Command{
 		Use:   "profile",
 		Short: "Commands related to Istio configuration profiles",
@@ -34,8 +36,8 @@ func ProfileCmd() *cobra.Command {
 	args := &rootArgs{}
 
 	plc := profileListCmd(args, plArgs)
-	pdc := profileDumpCmd(args, pdArgs)
-	pdfc := profileDiffCmd(args, pdfArgs)
+	pdc := profileDumpCmd(args, pdArgs, logOpts)
+	pdfc := profileDiffCmd(args, pdfArgs, logOpts)
 
 	addFlags(pc, args)
 	addFlags(plc, args)

--- a/operator/cmd/mesh/root.go
+++ b/operator/cmd/mesh/root.go
@@ -83,7 +83,7 @@ func GetRootCmd(args []string) *cobra.Command {
 
 	rootCmd.AddCommand(ManifestCmd(log.DefaultOptions()))
 	rootCmd.AddCommand(InstallCmd(log.DefaultOptions()))
-	rootCmd.AddCommand(ProfileCmd())
+	rootCmd.AddCommand(ProfileCmd(log.DefaultOptions()))
 	rootCmd.AddCommand(OperatorCmd())
 	rootCmd.AddCommand(version.CobraCommand())
 	rootCmd.AddCommand(UpgradeCmd())

--- a/operator/pkg/manifest/shared.go
+++ b/operator/pkg/manifest/shared.go
@@ -154,7 +154,6 @@ func GenIOPFromProfile(profileOrPath, fileOverlayYAML string, setFlags []string,
 		return "", nil, err
 	}
 
-	ccold := ""
 	// Merge k8s specific values.
 	if kubeConfig != nil {
 		kubeOverrides, err := getClusterSpecificValues(kubeConfig, skipValidation, l)
@@ -162,8 +161,6 @@ func GenIOPFromProfile(profileOrPath, fileOverlayYAML string, setFlags []string,
 			return "", nil, err
 		}
 		installerScope.Infof("Applying Cluster specific settings: %v", kubeOverrides)
-		ccold = outYAML
-		fmt.Sprintf(ccold)
 		outYAML, err = util.OverlayYAML(outYAML, kubeOverrides)
 		if err != nil {
 			return "", nil, err

--- a/operator/pkg/manifest/shared.go
+++ b/operator/pkg/manifest/shared.go
@@ -154,6 +154,7 @@ func GenIOPFromProfile(profileOrPath, fileOverlayYAML string, setFlags []string,
 		return "", nil, err
 	}
 
+	ccold := ""
 	// Merge k8s specific values.
 	if kubeConfig != nil {
 		kubeOverrides, err := getClusterSpecificValues(kubeConfig, skipValidation, l)
@@ -161,6 +162,8 @@ func GenIOPFromProfile(profileOrPath, fileOverlayYAML string, setFlags []string,
 			return "", nil, err
 		}
 		installerScope.Infof("Applying Cluster specific settings: %v", kubeOverrides)
+		ccold = outYAML
+		fmt.Sprintf(ccold)
 		outYAML, err = util.OverlayYAML(outYAML, kubeOverrides)
 		if err != nil {
 			return "", nil, err

--- a/releasenotes/notes/34325.yaml
+++ b/releasenotes/notes/34325.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: istioctl
+releaseNotes:
+  - |
+    **Fixed** `istioctl profile diff` and `istioctl profile dump` have unexpected info logs.


### PR DESCRIPTION
When I use the `istioctl profile` command, it always shows the extra `info` log from the protobuf package like this:
```
XIAOPENGs-MacBook-Pro:~ xiaopenghan$ istioctl profile diff preview preview
2021-07-26T10:00:42.019747Z	info	proto: tag has too few fields: "-"
Profiles are identical
```

I just fixed it with the log option and tested the new behavior.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[x] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
