### PR TITLE
Trim down long log lines:

### DIFF
--- a/pilot/pkg/model/config.go
+++ b/pilot/pkg/model/config.go
@@ -60,7 +60,7 @@ func (key ConfigKey) HashCode() uint64 {
 }
 
 func (key ConfigKey) String() string {
-	return key.Kind.String() + "/" + key.Namespace + "/" + key.Name
+	return key.Kind.Kind + "/" + key.Namespace + "/" + key.Name
 }
 
 // ConfigsOfKind extracts configs of the specified kind.


### PR DESCRIPTION
Before:
```
Push debounce stable[2] 1 for config networking.istio.io/v1alpha3/VirtualService/default/route:
```

After:
```
Push debounce stable[2] 1 for config VirtualService/default/route:
```

I do not feel we need to include the version - its actually misleading since users may use other versions externally and we just read a specific version. For group, there is only one case (Gateway) where it matters to distinguish and I don't feel that makes it worth so much extra log noise.