### PR TITLE
Fix TestIngress update flake

### DIFF
--- a/tests/integration/pilot/ingress_test.go
+++ b/tests/integration/pilot/ingress_test.go
@@ -296,7 +296,7 @@ spec:
 			}
 
 			successValidator := echo.And(echo.ExpectOK(), echo.ExpectReachedClusters(apps.PodB.Clusters()))
-			failureValidator := echo.And(echo.ExpectCode("404"))
+			failureValidator := echo.ExpectCode("404")
 			count := 1
 			if t.Clusters().IsMulticluster() {
 				count = 2 * len(t.Clusters())
@@ -538,7 +538,7 @@ spec:
 						Headers: map[string][]string{
 							"Host": {"server"},
 						},
-						Validator: echo.ExpectCode("404"),
+						Validator: echo.ExpectError(),
 					},
 				},
 				{

--- a/tests/integration/pilot/ingress_test.go
+++ b/tests/integration/pilot/ingress_test.go
@@ -538,7 +538,7 @@ spec:
 						Headers: map[string][]string{
 							"Host": {"server"},
 						},
-						Validator: echo.ExpectError(),
+						Validator: echo.Or(echo.ExpectError(), echo.ExpectCode("404")),
 					},
 				},
 				{


### PR DESCRIPTION
Fixes #34359.

Before we'd expect a `404` when hitting an ingress endpoint where the corresponding `Ingress` resource had a bogus ingress class. This is wrong since when the Ingress class doesn't match we shouldn't get a response at all (should not even have a generated Gateway). The test relies on a race condition and only passing when the new `Ingress` has not yet taken effect.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
