### PR TITLE
proxyless: do not rewrite app probes

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -886,6 +886,8 @@ data:
             fsGroup: 1337
           {{- end }}
       grpc-simple: |
+        metadata:
+          sidecar.istio.io/rewriteAppHTTPProbers: "false"
         spec:
           initContainers:
             - name: grpc-bootstrap-init
@@ -953,6 +955,7 @@ data:
             kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",
             kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
             {{ end }}
+            sidecar.istio.io/rewriteAppHTTPProbers: "false",
           }
         spec:
           containers:

--- a/manifests/charts/istio-control/istio-discovery/files/grpc-agent.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/grpc-agent.yaml
@@ -6,6 +6,7 @@ metadata:
     kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",
     kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
     {{ end }}
+    sidecar.istio.io/rewriteAppHTTPProbers: "false",
   }
 spec:
   containers:

--- a/manifests/charts/istio-control/istio-discovery/files/grpc-simple.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/grpc-simple.yaml
@@ -1,3 +1,5 @@
+metadata:
+  sidecar.istio.io/rewriteAppHTTPProbers: "false"
 spec:
   initContainers:
     - name: grpc-bootstrap-init

--- a/pkg/kube/inject/testdata/inject/grpc-agent.yaml
+++ b/pkg/kube/inject/testdata/inject/grpc-agent.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grpc
+spec:
+  selector:
+    matchLabels:
+      app: grpc
+  template:
+    metadata:
+      annotations:
+        inject.istio.io/templates: grpc-agent
+      labels:
+        app: grpc
+    spec:
+      containers:
+      - name: traffic
+        image: "fake.docker.io/google-samples/traffic-go-gke:1.0"
+        readinessProbe:
+          httpGet:
+            port: 80

--- a/pkg/kube/inject/testdata/inject/grpc-agent.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/grpc-agent.yaml.injected
@@ -1,0 +1,162 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  name: grpc
+spec:
+  selector:
+    matchLabels:
+      app: grpc
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        inject.istio.io/templates: grpc-agent
+        kubectl.kubernetes.io/default-container: traffic
+        kubectl.kubernetes.io/default-logs-container: traffic
+        prometheus.io/path: /stats/prometheus
+        prometheus.io/port: "15020"
+        prometheus.io/scrape: "true"
+        proxy.istio.io/overrides: '{"containers":[{"name":"traffic","image":"fake.docker.io/google-samples/traffic-go-gke:1.0","resources":{},"readinessProbe":{"httpGet":{"port":80}}}]}'
+        sidecar.istio.io/rewriteAppHTTPProbers: "false"
+        sidecar.istio.io/status: '{"initContainers":null,"containers":["traffic","istio-proxy"],"volumes":["istio-xds","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+      creationTimestamp: null
+      labels:
+        app: grpc
+    spec:
+      containers:
+      - env:
+        - name: GRPC_XDS_BOOTSTRAP
+          value: /var/lib/istio/data/grpc-bootstrap.json
+        - name: GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT
+          value: "true"
+        image: fake.docker.io/google-samples/traffic-go-gke:1.0
+        name: traffic
+        readinessProbe:
+          httpGet:
+            port: 80
+        resources: {}
+        volumeMounts:
+        - mountPath: /var/lib/istio/data
+          name: istio-data
+        - mountPath: /etc/istio/proxy
+          name: istio-xds
+      - args:
+        - proxy
+        - sidecar
+        - --domain
+        - $(POD_NAMESPACE).svc.cluster.local
+        - --log_output_level=default:info
+        env:
+        - name: GRPC_XDS_BOOTSTRAP
+          value: /var/lib/istio/data/grpc-bootstrap.json
+        - name: ISTIO_META_GENERATOR
+          value: grpc
+        - name: OUTPUT_CERTS
+          value: /var/lib/istio/data
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: istiod
+        - name: CA_ADDR
+          value: istiod.istio-system.svc:15012
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: INSTANCE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: PROXY_CONFIG
+          value: |
+            {}
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+            ]
+        - name: ISTIO_META_APP_CONTAINERS
+          value: traffic
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
+        - name: ISTIO_META_INTERCEPTION_MODE
+          value: REDIRECT
+        - name: ISTIO_META_WORKLOAD_NAME
+          value: grpc
+        - name: ISTIO_META_OWNER
+          value: kubernetes://apis/apps/v1/namespaces/default/deployments/grpc
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
+        - name: TRUST_DOMAIN
+          value: cluster.local
+        - name: ISTIO_META_DNS_CAPTURE
+          value: "false"
+        - name: DISABLE_ENVOY
+          value: "true"
+        image: gcr.io/istio-testing/proxyv2:latest
+        name: istio-proxy
+        readinessProbe:
+          failureThreshold: 30
+          httpGet:
+            path: /healthz/ready
+            port: 15020
+          initialDelaySeconds: 1
+          periodSeconds: 2
+          timeoutSeconds: 3
+        resources:
+          limits:
+            cpu: "2"
+            memory: 1Gi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        volumeMounts:
+        - mountPath: /var/run/secrets/istio
+          name: istiod-ca-cert
+        - mountPath: /var/lib/istio/data
+          name: istio-data
+        - mountPath: /etc/istio/proxy
+          name: istio-xds
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
+        - mountPath: /etc/istio/pod
+          name: istio-podinfo
+      volumes:
+      - emptyDir:
+          medium: Memory
+        name: istio-xds
+      - emptyDir: {}
+        name: istio-data
+      - downwardAPI:
+          items:
+          - fieldRef:
+              fieldPath: metadata.labels
+            path: labels
+          - fieldRef:
+              fieldPath: metadata.annotations
+            path: annotations
+        name: istio-podinfo
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: istiod-ca-cert
+status: {}
+---

--- a/pkg/kube/inject/testdata/inject/grpc-simple.yaml
+++ b/pkg/kube/inject/testdata/inject/grpc-simple.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grpc
+spec:
+  selector:
+    matchLabels:
+      app: grpc
+  template:
+    metadata:
+      annotations:
+        inject.istio.io/templates: grpc-simple
+      labels:
+        app: grpc
+    spec:
+      containers:
+      - name: traffic
+        image: "fake.docker.io/google-samples/traffic-go-gke:1.0"
+        readinessProbe:
+          httpGet:
+            port: 80

--- a/pkg/kube/inject/testdata/inject/grpc-simple.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/grpc-simple.yaml.injected
@@ -1,0 +1,86 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  name: grpc
+spec:
+  selector:
+    matchLabels:
+      app: grpc
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        inject.istio.io/templates: grpc-simple
+        prometheus.io/path: /stats/prometheus
+        prometheus.io/port: "15020"
+        prometheus.io/scrape: "true"
+        proxy.istio.io/overrides: '{"containers":[{"name":"traffic","image":"fake.docker.io/google-samples/traffic-go-gke:1.0","resources":{},"readinessProbe":{"httpGet":{"port":80}}}]}'
+        sidecar.istio.io/status: '{"initContainers":["grpc-bootstrap-init"],"containers":["traffic"],"volumes":["grpc-io-proxyless-bootstrap"],"imagePullSecrets":null,"revision":"default"}'
+      creationTimestamp: null
+      labels:
+        app: grpc
+    spec:
+      containers:
+      - env:
+        - name: GRPC_XDS_BOOTSTRAP
+          value: /var/lib/grpc/data/bootstrap.json
+        - name: GRPC_GO_LOG_VERBOSITY_LEVEL
+          value: "99"
+        - name: GRPC_GO_LOG_SEVERITY_LEVEL
+          value: info
+        image: fake.docker.io/google-samples/traffic-go-gke:1.0
+        name: traffic
+        readinessProbe:
+          httpGet:
+            port: 80
+        resources: {}
+        volumeMounts:
+        - mountPath: /var/lib/grpc/data/
+          name: grpc-io-proxyless-bootstrap
+      initContainers:
+      - command:
+        - sh
+        - -c
+        - |-
+          NODE_ID="sidecar~${INSTANCE_IP}~${POD_NAME}.${POD_NAMESPACE}~cluster.local"
+          echo '
+          {
+            "xds_servers": [
+              {
+                "server_uri": "dns:///istiod.istio-system.svc:15010",
+                "channel_creds": [{"type": "insecure"}],
+                "server_features" : ["xds_v3"]
+              }
+            ],
+            "node": {
+              "id": "'${NODE_ID}'",
+              "metadata": {
+                "GENERATOR": "grpc"
+              }
+            }
+          }' > /var/lib/grpc/data/bootstrap.json
+        env:
+        - name: INSTANCE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: busybox:1.28
+        name: grpc-bootstrap-init
+        resources: {}
+        volumeMounts:
+        - mountPath: /var/lib/grpc/data/
+          name: grpc-io-proxyless-bootstrap
+      volumes:
+      - emptyDir: {}
+        name: grpc-io-proxyless-bootstrap
+status: {}
+---


### PR DESCRIPTION
There is no need to, and it breaks IPv6. Or really - there might be a need, but it doesn't
work right now anyways as the whole idea was to bypass the mTLS but we
cannot do that for proxyless
Fixes https://github.com/istio/istio/issues/34372