### PR TITLE
Fix echo readiness probes when bound to other IPs

### DIFF
--- a/pkg/test/echo/server/endpoint/http.go
+++ b/pkg/test/echo/server/endpoint/http.go
@@ -129,7 +129,7 @@ func (s *httpInstance) Start(onReady OnReadyFunc) error {
 	}()
 
 	// Notify the WaitGroup once the port has transitioned to ready.
-	go s.awaitReady(onReady, port)
+	go s.awaitReady(onReady, listener.Addr().String())
 
 	return nil
 }
@@ -138,7 +138,7 @@ func (s *httpInstance) isUDS() bool {
 	return s.UDSServer != ""
 }
 
-func (s *httpInstance) awaitReady(onReady OnReadyFunc, port int) {
+func (s *httpInstance) awaitReady(onReady OnReadyFunc, address string) {
 	defer onReady()
 
 	client := http.Client{}
@@ -151,10 +151,10 @@ func (s *httpInstance) awaitReady(onReady OnReadyFunc, port int) {
 			},
 		}
 	} else if s.Port.TLS {
-		url = fmt.Sprintf("https://127.0.0.1:%d", port)
+		url = fmt.Sprintf("https://%s", address)
 		client.Transport = &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
 	} else {
-		url = fmt.Sprintf("http://127.0.0.1:%d", port)
+		url = fmt.Sprintf("http://%s", address)
 	}
 
 	err := retry.UntilSuccess(func() error {

--- a/pkg/test/echo/server/endpoint/tcp.go
+++ b/pkg/test/echo/server/endpoint/tcp.go
@@ -90,7 +90,7 @@ func (s *tcpInstance) Start(onReady OnReadyFunc) error {
 	}()
 
 	// Notify the WaitGroup once the port has transitioned to ready.
-	go s.awaitReady(onReady, port)
+	go s.awaitReady(onReady, listener.Addr().String())
 
 	return nil
 }
@@ -172,10 +172,8 @@ func (s *tcpInstance) Close() error {
 	return nil
 }
 
-func (s *tcpInstance) awaitReady(onReady OnReadyFunc, port int) {
+func (s *tcpInstance) awaitReady(onReady OnReadyFunc, address string) {
 	defer onReady()
-
-	address := fmt.Sprintf("127.0.0.1:%d", port)
 
 	err := retry.UntilSuccess(func() error {
 		conn, err := net.Dial("tcp", address)

--- a/pkg/test/echo/server/endpoint/util.go
+++ b/pkg/test/echo/server/endpoint/util.go
@@ -17,9 +17,9 @@ package endpoint
 import (
 	"bytes"
 	"crypto/tls"
-	"fmt"
 	"net"
 	"os"
+	"strconv"
 
 	"istio.io/istio/pkg/test/echo/common/response"
 	"istio.io/pkg/log"
@@ -28,7 +28,7 @@ import (
 var epLog = log.RegisterScope("endpoint", "echo serverside", 0)
 
 func listenOnAddress(ip string, port int) (net.Listener, int, error) {
-	ln, err := net.Listen("tcp", fmt.Sprintf("%s:%d", ip, port))
+	ln, err := net.Listen("tcp", net.JoinHostPort(ip, strconv.Itoa(port)))
 	if err != nil {
 		return nil, 0, err
 	}
@@ -38,7 +38,7 @@ func listenOnAddress(ip string, port int) (net.Listener, int, error) {
 }
 
 func listenOnAddressTLS(ip string, port int, cfg *tls.Config) (net.Listener, int, error) {
-	ln, err := tls.Listen("tcp", fmt.Sprintf("%s:%d", ip, port), cfg)
+	ln, err := tls.Listen("tcp", net.JoinHostPort(ip, strconv.Itoa(port)), cfg)
 	if err != nil {
 		return nil, 0, err
 	}


### PR DESCRIPTION
This fixes ipv6 and --bind-ip, where we do not want to connect to
127.0.0.1.

This may look like it works today, but each echo actually has a 10s
delay at startup (we timeout the readiness), likely slowing tests down.
