### PR TITLE
In the mcp-over-xds scene: add resource version for service entry

### DIFF
--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -107,6 +107,9 @@ type Service struct {
 	// MeshExternal (if true) indicates that the service is external to the mesh.
 	// These services are defined using Istio's ServiceEntry spec.
 	MeshExternal bool
+
+	// ResourceVersion represents the internal version of this object.
+	ResourceVersion string
 }
 
 // Resolution indicates how the service instances need to be resolved before routing

--- a/pilot/pkg/serviceregistry/kube/conversion.go
+++ b/pilot/pkg/serviceregistry/kube/conversion.go
@@ -99,6 +99,7 @@ func ConvertService(svc coreV1.Service, domainSuffix string, clusterID cluster.I
 		Resolution:      resolution,
 		CreationTime:    svc.CreationTimestamp.Time,
 		ClusterVIPs:     map[cluster.ID]string{clusterID: addr},
+		ResourceVersion: svc.ResourceVersion,
 		Attributes: model.ServiceAttributes{
 			ServiceRegistry: provider.Kubernetes,
 			Name:            svc.Name,

--- a/pilot/pkg/serviceregistry/serviceentry/conversion.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion.go
@@ -121,6 +121,7 @@ func ServiceToServiceEntry(svc *model.Service) *config.Config {
 			Name:              "synthetic-" + svc.Attributes.Name,
 			Namespace:         svc.Attributes.Namespace,
 			CreationTimestamp: svc.CreationTime,
+			ResourceVersion:   svc.ResourceVersion,
 		},
 		Spec: se,
 	}


### PR DESCRIPTION
When I use the master branch code to reproduce this issue #34126 ，I found that service entry converted from k8s service does not have resource version. 

for client, function handles the received resources
https://github.com/istio/istio/blob/8efca561efcab2d1322ebd2d50b7ecc01bfe21e5/pkg/adsc/adsc.go#L1262

If the resource version is not set, the client store always updates the resource, even if the resource has not changed.

Add resource version: if service entry is converted from k8s service, it inherits the resource version of k8s service. update the client store only when the resource changed.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure



[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
