### PR TITLE
Make istioctl pc route less verbose for regex match

### DIFF
--- a/istioctl/pkg/writer/envoy/configdump/listener.go
+++ b/istioctl/pkg/writer/envoy/configdump/listener.go
@@ -358,7 +358,7 @@ func describeMatch(match *route.RouteMatch) string {
 		conds = append(conds, match.GetPath())
 	}
 	if match.GetSafeRegex() != nil {
-		conds = append(conds, fmt.Sprintf("regex %s", match.GetSafeRegex().String()))
+		conds = append(conds, fmt.Sprintf("regex %s", match.GetSafeRegex().Regex))
 	}
 	// Ignore headers
 	return strings.Join(conds, " ")


### PR DESCRIPTION
Fixes #34344.

Makes it so that we don't print the regex engine type on `isitoctl pc route`. Does not implement the smarter prefix recognition.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[x] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
