### PR TITLE
Fix validation test on old k8s

### DIFF
--- a/galley/testdatasets/validation/dataset/networking-v1alpha3-Sidecar-invalid.yaml
+++ b/galley/testdatasets/validation/dataset/networking-v1alpha3-Sidecar-invalid.yaml
@@ -3,4 +3,4 @@ kind: Sidecar
 metadata:
   name: invalid-sidecar-config
 spec:
-  egress:
+  egress: []

--- a/galley/testdatasets/validation/dataset/networking-v1beta-Sidecar-invalid.yaml
+++ b/galley/testdatasets/validation/dataset/networking-v1beta-Sidecar-invalid.yaml
@@ -3,4 +3,4 @@ kind: Sidecar
 metadata:
   name: invalid-sidecar-config
 spec:
-  egress:
+  egress: []


### PR DESCRIPTION
In 1.21, they made this valid on OpenAPI, so it passed presubmit and failed in webhook validator.

For older versions, it is rejected by openapi and so the test fails