### PR TITLE
add new subcommand for proxy-config to check the ROOTCA between 2 given pods

### DIFF
--- a/istioctl/cmd/proxyconfig.go
+++ b/istioctl/cmd/proxyconfig.go
@@ -950,16 +950,16 @@ func rootCACompareConfigCmd() *cobra.Command {
 	var podName1, podName2, podNamespace1, podNamespace2 string
 
 	rootCACompareConfigCmd := &cobra.Command{
-		Use:   "rootca-cmp [pod/]<name-1>[.<namespace-1>] [pod/]<name-2>[.<namespace-2>]",
+		Use:   "rootca-compare [pod/]<name-1>[.<namespace-1>] [pod/]<name-2>[.<namespace-2>]",
 		Short: "Compare ROOTCA values for the two given pods",
 		Long:  `Compare ROOTCA values for given 2 pods to check the connectivity between them.`,
 		Example: `  # Compare ROOTCA values for given 2 pods to check the connectivity between them.
-  istioctl proxy-config rootca-cmp <pod-name-1[.namespace]> <pod-name-2[.namespace]>`,
-		Aliases: []string{"rootca-cmp", "rc"},
+  istioctl proxy-config rootca-compare <pod-name-1[.namespace]> <pod-name-2[.namespace]>`,
+		Aliases: []string{"rootca-compare", "rc"},
 		Args: func(cmd *cobra.Command, args []string) error {
 			if (len(args) <= 2) != (configDumpFile == "") {
 				cmd.Println(cmd.UsageString())
-				return fmt.Errorf("rootca-cmp requires 2 pods as an argument")
+				return fmt.Errorf("rootca-compare requires 2 pods as an argument")
 			}
 			return nil
 		},
@@ -984,7 +984,7 @@ func rootCACompareConfigCmd() *cobra.Command {
 				}
 			} else {
 				c.Println(c.UsageString())
-				return fmt.Errorf("rootca-cmp requires 2 pods as an argument")
+				return fmt.Errorf("rootca-compare requires 2 pods as an argument")
 			}
 
 			rootCA1, err1 := configWriter1.PrintPodRootCAFromDynamicSecretDump()
@@ -1005,7 +1005,6 @@ func rootCACompareConfigCmd() *cobra.Command {
 			} else {
 				report := fmt.Sprintf("Both [%s.%s] and [%s.%s] have the non identical ROOTCA, theoretically the connectivity between them is unavailable",
 					podName1, podNamespace1, podName2, podNamespace2)
-				c.Println(report)
 				returnErr = fmt.Errorf(report)
 			}
 			return returnErr

--- a/istioctl/cmd/proxyconfig.go
+++ b/istioctl/cmd/proxyconfig.go
@@ -946,6 +946,77 @@ func secretConfigCmd() *cobra.Command {
 	return secretConfigCmd
 }
 
+func rootCACompareConfigCmd() *cobra.Command {
+	var podName1, podName2, podNamespace1, podNamespace2 string
+
+	rootCACompareConfigCmd := &cobra.Command{
+		Use:   "rootca-comp [pod/]<name-1>[.<namespace-1>] [pod/]<name-2>[.<namespace-2>]",
+		Short: "Compare ROOTCA values for given 2 pods",
+		Long:  `Compare ROOTCA values for given 2 pods to check the connectivity availability between them.`,
+		Example: `  # Compare ROOTCA values for given 2 pods to check the connectivity availability between them.
+  istioctl proxy-config rootca-comp <pod-name-1[.namespace]> <pod-name-2[.namespace]>`,
+		Aliases: []string{"rootca-comp", "rc"},
+		Args: func(cmd *cobra.Command, args []string) error {
+			if (len(args) <= 2) != (configDumpFile == "") {
+				cmd.Println(cmd.UsageString())
+				return fmt.Errorf("see the usage above, rootca-comp requires 2 pods as arguments")
+			}
+			return nil
+		},
+		RunE: func(c *cobra.Command, args []string) error {
+			var configWriter1, configWriter2 *configdump.ConfigWriter
+			var err error
+			if len(args) == 2 {
+				if podName1, podNamespace1, err = getPodName(args[0]); err != nil {
+					return err
+				}
+				configWriter1, err = setupPodConfigdumpWriter(podName1, podNamespace1, c.OutOrStdout())
+				if err != nil {
+					return err
+				}
+
+				if podName2, podNamespace2, err = getPodName(args[1]); err != nil {
+					return err
+				}
+				configWriter2, err = setupPodConfigdumpWriter(podName2, podNamespace2, c.OutOrStdout())
+				if err != nil {
+					return err
+				}
+			} else {
+				c.Println(c.UsageString())
+				return fmt.Errorf("please see the usage above and make sure that there are 2 pods for the comparison")
+			}
+
+			rootCA1, err1 := configWriter1.PrintPodRootCAFromDynamicSecretDump()
+			if err1 != nil {
+				return fmt.Errorf("error when retrieving ROOTCA of [%s]: %v", args[0], err1)
+			}
+			rootCA2, err2 := configWriter2.PrintPodRootCAFromDynamicSecretDump()
+			if err2 != nil {
+				return fmt.Errorf("error when retrieving ROOTCA of [%s]: %v", args[1], err2)
+			}
+
+			var returnErr error
+			if rootCA1 == rootCA2 {
+				report := fmt.Sprintf("Both [%s.%s] and [%s.%s] have the identical ROOTCA, theoretically the connectivity between them is available",
+					podName1, podNamespace1, podName2, podNamespace2)
+				c.Println(report)
+				returnErr = nil
+			} else {
+				report := fmt.Sprintf("Both [%s.%s] and [%s.%s] have the non identical ROOTCA, theoretically the connectivity between them is unavailable",
+					podName1, podNamespace1, podName2, podNamespace2)
+				c.Println(report)
+				returnErr = fmt.Errorf(report)
+			}
+			return returnErr
+		},
+		ValidArgsFunction: validPodsNameArgs,
+	}
+
+	rootCACompareConfigCmd.Long += "\n\n" + ExperimentalMsg
+	return rootCACompareConfigCmd
+}
+
 func proxyConfig() *cobra.Command {
 	configCmd := &cobra.Command{
 		Use:   "proxy-config",
@@ -966,6 +1037,7 @@ func proxyConfig() *cobra.Command {
 	configCmd.AddCommand(bootstrapConfigCmd())
 	configCmd.AddCommand(endpointConfigCmd())
 	configCmd.AddCommand(secretConfigCmd())
+	configCmd.AddCommand(rootCACompareConfigCmd())
 
 	return configCmd
 }

--- a/istioctl/cmd/proxyconfig.go
+++ b/istioctl/cmd/proxyconfig.go
@@ -959,7 +959,7 @@ func rootCACompareConfigCmd() *cobra.Command {
 		Args: func(cmd *cobra.Command, args []string) error {
 			if (len(args) <= 2) != (configDumpFile == "") {
 				cmd.Println(cmd.UsageString())
-				return fmt.Errorf("see the usage above, rootca-comp requires 2 pods as arguments")
+				return fmt.Errorf("rootca-comp requires 2 pods as an argument")
 			}
 			return nil
 		},
@@ -984,7 +984,7 @@ func rootCACompareConfigCmd() *cobra.Command {
 				}
 			} else {
 				c.Println(c.UsageString())
-				return fmt.Errorf("please see the usage above and make sure that there are 2 pods for the comparison")
+				return fmt.Errorf("rootca-comp requires 2 pods as an argument")
 			}
 
 			rootCA1, err1 := configWriter1.PrintPodRootCAFromDynamicSecretDump()

--- a/istioctl/cmd/proxyconfig.go
+++ b/istioctl/cmd/proxyconfig.go
@@ -951,9 +951,9 @@ func rootCACompareConfigCmd() *cobra.Command {
 
 	rootCACompareConfigCmd := &cobra.Command{
 		Use:   "rootca-comp [pod/]<name-1>[.<namespace-1>] [pod/]<name-2>[.<namespace-2>]",
-		Short: "Compare ROOTCA values for given 2 pods",
-		Long:  `Compare ROOTCA values for given 2 pods to check the connectivity availability between them.`,
-		Example: `  # Compare ROOTCA values for given 2 pods to check the connectivity availability between them.
+		Short: "Compare ROOTCA values for the two given pods",
+		Long:  `Compare ROOTCA values for given 2 pods to check the connectivity between them.`,
+		Example: `  # Compare ROOTCA values for given 2 pods to check the connectivity between them.
   istioctl proxy-config rootca-comp <pod-name-1[.namespace]> <pod-name-2[.namespace]>`,
 		Aliases: []string{"rootca-comp", "rc"},
 		Args: func(cmd *cobra.Command, args []string) error {

--- a/istioctl/cmd/proxyconfig.go
+++ b/istioctl/cmd/proxyconfig.go
@@ -950,16 +950,16 @@ func rootCACompareConfigCmd() *cobra.Command {
 	var podName1, podName2, podNamespace1, podNamespace2 string
 
 	rootCACompareConfigCmd := &cobra.Command{
-		Use:   "rootca-comp [pod/]<name-1>[.<namespace-1>] [pod/]<name-2>[.<namespace-2>]",
+		Use:   "rootca-cmp [pod/]<name-1>[.<namespace-1>] [pod/]<name-2>[.<namespace-2>]",
 		Short: "Compare ROOTCA values for the two given pods",
 		Long:  `Compare ROOTCA values for given 2 pods to check the connectivity between them.`,
 		Example: `  # Compare ROOTCA values for given 2 pods to check the connectivity between them.
-  istioctl proxy-config rootca-comp <pod-name-1[.namespace]> <pod-name-2[.namespace]>`,
-		Aliases: []string{"rootca-comp", "rc"},
+  istioctl proxy-config rootca-cmp <pod-name-1[.namespace]> <pod-name-2[.namespace]>`,
+		Aliases: []string{"rootca-cmp", "rc"},
 		Args: func(cmd *cobra.Command, args []string) error {
 			if (len(args) <= 2) != (configDumpFile == "") {
 				cmd.Println(cmd.UsageString())
-				return fmt.Errorf("rootca-comp requires 2 pods as an argument")
+				return fmt.Errorf("rootca-cmp requires 2 pods as an argument")
 			}
 			return nil
 		},
@@ -984,7 +984,7 @@ func rootCACompareConfigCmd() *cobra.Command {
 				}
 			} else {
 				c.Println(c.UsageString())
-				return fmt.Errorf("rootca-comp requires 2 pods as an argument")
+				return fmt.Errorf("rootca-cmp requires 2 pods as an argument")
 			}
 
 			rootCA1, err1 := configWriter1.PrintPodRootCAFromDynamicSecretDump()

--- a/istioctl/pkg/util/configdump/secret.go
+++ b/istioctl/pkg/util/configdump/secret.go
@@ -15,7 +15,12 @@
 package configdump
 
 import (
+	"encoding/base64"
+	"fmt"
+
 	adminapi "github.com/envoyproxy/go-control-plane/envoy/admin/v3"
+	extapi "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
+	any "github.com/golang/protobuf/ptypes/any"
 )
 
 // GetSecretsConfigDump retrieves a secret dump from a config dump wrapper
@@ -30,4 +35,35 @@ func (w *Wrapper) GetSecretConfigDump() (*adminapi.SecretsConfigDump, error) {
 		return nil, err
 	}
 	return secretDump, nil
+}
+
+// GetRootCAFromSecretConfigDump retrieves root CA from a secret config dump wrapper
+func (w *Wrapper) GetRootCAFromSecretConfigDump(anySec *any.Any) (string, error) {
+	var secret extapi.Secret
+	if err := anySec.UnmarshalTo(&secret); err != nil {
+		return "", fmt.Errorf("failed to unmarshall ROOTCA secret: %v", err)
+	}
+	var returnStr string
+	var returnErr error
+	rCASecret := secret.GetValidationContext()
+	if rCASecret != nil {
+		trustCA := rCASecret.GetTrustedCa()
+		if trustCA != nil {
+			inlineBytes := trustCA.GetInlineBytes()
+			if inlineBytes != nil {
+				returnStr = base64.StdEncoding.EncodeToString(inlineBytes)
+				returnErr = nil
+			} else {
+				returnStr = ""
+				returnErr = fmt.Errorf("can not retrieve inlineBytes from trustCA section")
+			}
+		} else {
+			returnStr = ""
+			returnErr = fmt.Errorf("can not retrieve trustedCa from secret ROOTCA")
+		}
+	} else {
+		returnStr = ""
+		returnErr = fmt.Errorf("can not find ROOTCA from secret config dump")
+	}
+	return returnStr, returnErr
 }


### PR DESCRIPTION
This PR will add new subcommand for proxy-config of istioctl to check their ROOTCA between 2 given pods.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[x] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
