### PR TITLE
fix body close leaking when ioutil.ReadAll failed or response.StatusCode is not 2xx

### DIFF
--- a/pilot/pkg/model/jwks_resolver.go
+++ b/pilot/pkg/model/jwks_resolver.go
@@ -331,18 +331,18 @@ func (r *JwksResolver) getRemoteContentWithRetry(uri string, retry int) ([]byte,
 	}
 
 	getPublicKey := func() (b []byte, e error) {
-		resp, err := client.Get(uri)
 		defer func() {
 			if e != nil {
 				networkFetchFailCounter.Increment()
-				return
+			} else {
+				networkFetchSuccessCounter.Increment()
 			}
-			networkFetchSuccessCounter.Increment()
-			_ = resp.Body.Close()
 		}()
+		resp, err := client.Get(uri)
 		if err != nil {
 			return nil, err
 		}
+		defer resp.Body.Close()
 
 		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {


### PR DESCRIPTION

When `client.Get(uri)` is success, but `ioutil.ReadAll` is failed or `resp.StatusCode` is not 2xx, the defer function will only calls `networkFetchFailCounter.Increment()` and return, missing call to `resp.Body.Close()`.
This will result in a leaking of resp.Body.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.