### PR TITLE
Record proxy clients in addConn.

### DIFF
--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -603,7 +603,6 @@ func (s *DiscoveryServer) initializeProxy(node *core.Node, con *Connection) erro
 		proxy.XdsResourceGenerator = s.Generators[proxy.Metadata.Generator]
 	}
 
-	recordXDSClients(proxy.Metadata.IstioVersion, 1)
 	return nil
 }
 
@@ -880,6 +879,7 @@ func (s *DiscoveryServer) addCon(conID string, con *Connection) {
 	s.adsClientsMutex.Lock()
 	defer s.adsClientsMutex.Unlock()
 	s.adsClients[conID] = con
+	recordXDSClients(con.proxy.Metadata.IstioVersion, 1)
 }
 
 func (s *DiscoveryServer) removeCon(conID string) {


### PR DESCRIPTION
We observed that proxy_clients gauge could go negative in some cases, which based on code inspection could happen if `initConnection` errors out before incrementing the gauge, while `removeConn` is still called to decrement the gauge. This change make proxyClients gets incremented at `addCon`, which at least makes sure the proxy_clients gauge will be the same as `len(s.adsClients)` so that it won't be negative.