### PR TITLE
wasm: support OCI image fetch in istio-agent.

### DIFF
--- a/pkg/wasm/cache.go
+++ b/pkg/wasm/cache.go
@@ -101,10 +101,6 @@ func NewLocalFileCache(dir string, purgeInterval, moduleExpiry time.Duration) *L
 
 // Get returns path the local Wasm module file.
 func (c *LocalFileCache) Get(downloadURL, checksum string, timeout time.Duration) (string, error) {
-	u, err := url.Parse(downloadURL)
-	if err != nil {
-		return "", fmt.Errorf("fail to parse Wasm module fetch url: %s", downloadURL)
-	}
 	// Construct Wasm cache key with downloading URL and provided checksum of the module.
 	key := cacheKey{
 		downloadURL: downloadURL,
@@ -114,6 +110,11 @@ func (c *LocalFileCache) Get(downloadURL, checksum string, timeout time.Duration
 	// First check if the cache entry is already downloaded.
 	if modulePath := c.getEntry(key); modulePath != "" {
 		return modulePath, nil
+	}
+
+	u, err := url.Parse(downloadURL)
+	if err != nil {
+		return "", fmt.Errorf("fail to parse Wasm module fetch url: %s", downloadURL)
 	}
 
 	// If not, fetch images

--- a/pkg/wasm/cache_test.go
+++ b/pkg/wasm/cache_test.go
@@ -185,8 +185,10 @@ func TestWasmCache(t *testing.T) {
 			purgeInterval:        DefaultWasmModulePurgeInterval,
 			wasmModuleExpiry:     DefaultWasmModuleExpiry,
 			requestTimeout:       time.Second * 10,
-			checksum:             "this is wrong.",
-			wantErrorMsgPrefix:   fmt.Sprintf("could not fetch Wasm OCI image: fetched image's digest (%s) does not match the expected one", dockerImageDigest),
+			checksum:             "wrongdigest",
+			wantErrorMsgPrefix: fmt.Sprintf(
+				"could not fetch Wasm OCI image: fetched image's digest does not match the expected one: got %s, but want wrongdigest", dockerImageDigest,
+			),
 		},
 		{
 			name:                 "fetch invalid oci",

--- a/pkg/wasm/cache_test.go
+++ b/pkg/wasm/cache_test.go
@@ -147,7 +147,7 @@ func TestWasmCache(t *testing.T) {
 		{
 			name:                 "fetch oci",
 			initialCachedModules: map[cacheKey]cacheEntry{},
-			fetchURL:             fmt.Sprintf("oci://%s/test/valid/docker", ou.Host),
+			fetchURL:             fmt.Sprintf("oci://%s/test/valid/docker:v0.1.0", ou.Host),
 			purgeInterval:        DefaultWasmModulePurgeInterval,
 			wasmModuleExpiry:     DefaultWasmModuleExpiry,
 			requestTimeout:       time.Second * 10,
@@ -232,7 +232,7 @@ func TestWasmCache(t *testing.T) {
 
 func setupOCIRegistry(t *testing.T, host string) (wantCheckSum [32]byte) {
 	// Push *compat* variant docker image (others are well tested in imagefetcher's test and the behavior is consistent).
-	ref := fmt.Sprintf("%s/test/valid/docker", host)
+	ref := fmt.Sprintf("%s/test/valid/docker:v0.1.0", host)
 	binary := "this is wasm plugin"
 
 	// Create docker layer.

--- a/pkg/wasm/cache_test.go
+++ b/pkg/wasm/cache_test.go
@@ -45,7 +45,7 @@ func TestWasmCache(t *testing.T) {
 	httpDataSha := sha256.Sum256([]byte("data/\n"))
 	httpDataCheckSum := hex.EncodeToString(httpDataSha[:])
 
-	//	Set up a fake registry for OCI images.
+	// Set up a fake registry for OCI images.
 	tos := httptest.NewServer(registry.New())
 	defer tos.Close()
 	ou, err := url.Parse(tos.URL)
@@ -54,7 +54,7 @@ func TestWasmCache(t *testing.T) {
 	}
 	wantOCIDockerBinaryChecksum, dockerImageDigest, invalidOCIImageDigest := setupOCIRegistry(t, ou.Host)
 
-	//	Calculate cachehit sum.
+	// Calculate cachehit sum.
 	cacheHitSha := sha256.Sum256([]byte("cachehit\n"))
 	cacheHitSum := hex.EncodeToString(cacheHitSha[:])
 

--- a/pkg/wasm/imagefetcher.go
+++ b/pkg/wasm/imagefetcher.go
@@ -18,6 +18,7 @@ import (
 	"archive/tar"
 	"compress/gzip"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 
@@ -32,6 +33,8 @@ import (
 // This file implements the fetcher of "Wasm Image Specificiation" compatible container images.
 // The spec is here https://github.com/solo-io/wasm/blob/master/spec/README.md.
 // Basically, this supports fetching and unpackaging three types of container images containing a Wasm binary.
+
+var errWasmOCIImageDigestMismatch = errors.New("fetched image's digest does not match the expected one")
 
 type ImageFetcherOption struct {
 	Username string
@@ -78,7 +81,7 @@ func (o *ImageFetcher) Fetch(url, expManifestDigest string) ([]byte, error) {
 	// Check Manifest's digest if expManifestDigest is not empty.
 	d, _ := img.Digest()
 	if expManifestDigest != "" && d.Hex != expManifestDigest {
-		return nil, fmt.Errorf("fetched image's digest (%s) does not match the expected one (%s)", d.Hex, expManifestDigest)
+		return nil, fmt.Errorf("%w: got %s, but want %s", errWasmOCIImageDigestMismatch, d.Hex, expManifestDigest)
 	}
 
 	manifest, err := img.Manifest()

--- a/pkg/wasm/imagefetcher_test.go
+++ b/pkg/wasm/imagefetcher_test.go
@@ -128,7 +128,6 @@ func TestImageFetcher_Fetch(t *testing.T) {
 		if err == nil {
 			t.Error("fetcher.Fetch should raise error for wrong digest")
 		}
-		t.Log(err)
 	})
 
 	t.Run("OCI standard", func(t *testing.T) {
@@ -190,7 +189,6 @@ func TestImageFetcher_Fetch(t *testing.T) {
 		if err == nil {
 			t.Error("fetcher.Fetch should raise error for wrong digest")
 		}
-		t.Log(err)
 	})
 
 	t.Run("OCI artifact", func(t *testing.T) {
@@ -267,7 +265,6 @@ func TestImageFetcher_Fetch(t *testing.T) {
 		if err == nil {
 			t.Error("fetcher.Fetch should raise error for wrong digest")
 		}
-		t.Log(err)
 	})
 
 	t.Run("invalid image", func(t *testing.T) {

--- a/pkg/wasm/imagefetcher_test.go
+++ b/pkg/wasm/imagefetcher_test.go
@@ -101,14 +101,34 @@ func TestImageFetcher_Fetch(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		// Fetch docker image.
-		actual, err := fetcher.Fetch(ref)
+		// Fetch docker image without digest
+		actual, err := fetcher.Fetch(ref, "")
 		if err != nil {
 			t.Fatal(err)
 		}
 		if string(actual) != exp {
 			t.Errorf("ImageFetcher.Fetch got %s, but want '%s'", string(actual), exp)
 		}
+
+		// Fetch docker image with digest
+		d, err := img.Digest()
+		if err != nil {
+			t.Fatal(err)
+		}
+		actual, err = fetcher.Fetch(ref, d.Hex)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(actual) != exp {
+			t.Errorf("ImageFetcher.Fetch got %s, but want '%s'", string(actual), exp)
+		}
+
+		// Giving wrong digest should be error
+		_, err = fetcher.Fetch(ref, "foobar")
+		if err == nil {
+			t.Error("fetcher.Fetch should raise error for wrong digest")
+		}
+		t.Log(err)
 	})
 
 	t.Run("OCI standard", func(t *testing.T) {
@@ -144,13 +164,33 @@ func TestImageFetcher_Fetch(t *testing.T) {
 		}
 
 		// Fetch OCI image.
-		actual, err := fetcher.Fetch(ref)
+		actual, err := fetcher.Fetch(ref, "")
 		if err != nil {
 			t.Fatal(err)
 		}
 		if string(actual) != exp {
 			t.Errorf("ImageFetcher.Fetch got %s, but want '%s'", string(actual), exp)
 		}
+
+		// Fetch OCI image with digest
+		d, err := img.Digest()
+		if err != nil {
+			t.Fatal(err)
+		}
+		actual, err = fetcher.Fetch(ref, d.Hex)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(actual) != exp {
+			t.Errorf("ImageFetcher.Fetch got %s, but want '%s'", string(actual), exp)
+		}
+
+		// Giving wrong digest should be error
+		_, err = fetcher.Fetch(ref, "foobar")
+		if err == nil {
+			t.Error("fetcher.Fetch should raise error for wrong digest")
+		}
+		t.Log(err)
 	})
 
 	t.Run("OCI artifact", func(t *testing.T) {
@@ -199,8 +239,8 @@ func TestImageFetcher_Fetch(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		// Fetch docker image.
-		actual, err := fetcher.Fetch(ref)
+		// Fetch OCI image.
+		actual, err := fetcher.Fetch(ref, "")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -208,6 +248,26 @@ func TestImageFetcher_Fetch(t *testing.T) {
 		if string(actual) != string(want) {
 			t.Errorf("ImageFetcher.Fetch got %s, but want '%s'", string(actual), string(want))
 		}
+
+		// Fetch OCI image with digest
+		d, err := img.Digest()
+		if err != nil {
+			t.Fatal(err)
+		}
+		actual, err = fetcher.Fetch(ref, d.Hex)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(actual) != string(want) {
+			t.Errorf("ImageFetcher.Fetch got %s, but want '%s'", string(actual), want)
+		}
+
+		// Giving wrong digest should be error
+		_, err = fetcher.Fetch(ref, "foobar")
+		if err == nil {
+			t.Error("fetcher.Fetch should raise error for wrong digest")
+		}
+		t.Log(err)
 	})
 
 	t.Run("invalid image", func(t *testing.T) {
@@ -236,7 +296,7 @@ func TestImageFetcher_Fetch(t *testing.T) {
 		}
 
 		// Try to fetch.
-		actual, err := fetcher.Fetch(ref)
+		actual, err := fetcher.Fetch(ref, "")
 		if actual != nil {
 			t.Errorf("ImageFetcher.Fetch got %s, but want nil", string(actual))
 		}

--- a/pkg/wasm/imagefetcher_test.go
+++ b/pkg/wasm/imagefetcher_test.go
@@ -63,7 +63,7 @@ func TestImageFetcherOption_useDefaultKeyChain(t *testing.T) {
 
 func TestImageFetcher_Fetch(t *testing.T) {
 	// Fetcher with anonymous auth.
-	fetcher := ImageFetcher{fetchOpt: remote.WithAuth(authn.Anonymous)}
+	fetcher := ImageFetcher{fetchOpts: []remote.Option{remote.WithAuth(authn.Anonymous)}}
 
 	// Set up a fake registry.
 	s := httptest.NewServer(registry.New())


### PR DESCRIPTION
Follow up on #33812. Add support for OCI image fetch in istio-agent for Wasm plugins.

Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>

