### PR TITLE
build name table for passthrough ServiceEntry

### DIFF
--- a/pkg/dns/server/name_table.go
+++ b/pkg/dns/server/name_table.go
@@ -55,9 +55,17 @@ func BuildNameTable(cfg Config) *dnsProto.NameTable {
 		svcAddress := svc.GetServiceAddressForProxy(cfg.Node)
 		var addressList []string
 
-		// The IP will be unspecified here if its headless service or if the auto
-		// IP allocation logic for service entry was unable to allocate an IP.
-		if svcAddress == constants.UnspecifiedIP {
+		if svcAddress != constants.UnspecifiedIP {
+			// Filter out things we cannot parse as IP. Generally this means CIDRs, as anything else
+			// should be caught in validation.
+			if addr := net.ParseIP(svcAddress); addr == nil {
+				continue
+			}
+			addressList = append(addressList, svcAddress)
+		} else {
+			// The IP will be unspecified here if its headless service or if the auto
+			// IP allocation logic for service entry was unable to allocate an IP.
+
 			// For all k8s headless services, populate the dns table with the endpoint IPs as k8s does.
 			// And for each individual pod, populate the dns table with the endpoint IP with a manufactured host name.
 			if svc.Attributes.ServiceRegistry == provider.Kubernetes &&
@@ -106,20 +114,23 @@ func BuildNameTable(cfg Config) *dnsProto.NameTable {
 					// TODO: should we skip the node's own IP like we do in listener?
 					addressList = append(addressList, instance.Endpoint.Address)
 				}
+			} else if svc.Attributes.ServiceRegistry == provider.External &&
+				svc.Resolution == model.Passthrough && len(svc.Ports) > 0 {
+				for _, instance := range cfg.Push.ServiceInstancesByPort(svc, svc.Ports[0].Port, nil) {
+					sameNetwork := cfg.Node.InNetwork(instance.Endpoint.Network)
+					sameCluster := cfg.Node.InCluster(instance.Endpoint.Locality.ClusterID)
+					if sameNetwork {
+						if sameCluster || cfg.MulticlusterHeadlessEnabled {
+							addressList = append(addressList, instance.Endpoint.Address)
+						}
+					}
+				}
 			}
-
 			if len(addressList) == 0 {
 				// could not reliably determine the addresses of endpoints of headless service
 				// or this is not a k8s service
 				continue
 			}
-		} else {
-			// Filter out things we cannot parse as IP. Generally this means CIDRs, as anything else
-			// should be caught in validation.
-			if addr := net.ParseIP(svcAddress); addr == nil {
-				continue
-			}
-			addressList = append(addressList, svcAddress)
 		}
 
 		nameInfo := &dnsProto.NameTable_NameInfo{

--- a/pkg/dns/server/name_table_test.go
+++ b/pkg/dns/server/name_table_test.go
@@ -433,6 +433,32 @@ func TestNameTable(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:  "service entry with resolution = NONE with network isolation",
+			proxy: nw1proxy,
+			push:  sepush,
+			expectedNameTable: &dnsProto.NameTable{
+				Table: map[string]*dnsProto.NameTable_NameInfo{
+					"foo.bar.com": {
+						Ips:      []string{"1.2.3.4", "19.6.7.8", "9.16.7.8"},
+						Registry: "External",
+					},
+				},
+			},
+		},
+		{
+			name:  "multi cluster service entry with resolution = NONE",
+			proxy: cl1proxy,
+			push:  sepush,
+			expectedNameTable: &dnsProto.NameTable{
+				Table: map[string]*dnsProto.NameTable_NameInfo{
+					"foo.bar.com": {
+						Ips:      []string{"1.2.3.4", "19.6.7.8", "9.16.7.8"},
+						Registry: "External",
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/dns/server/name_table_test.go
+++ b/pkg/dns/server/name_table_test.go
@@ -104,6 +104,23 @@ func TestNameTable(t *testing.T) {
 		},
 	}
 
+	headlessServiceForServiceEntry := &model.Service{
+		Hostname:    host.Name("foo.bar.com"),
+		Address:     constants.UnspecifiedIP,
+		ClusterVIPs: make(map[cluster.ID]string),
+		Ports: model.PortList{&model.Port{
+			Name:     "tcp-port",
+			Port:     9000,
+			Protocol: protocol.TCP,
+		}},
+		Resolution: model.Passthrough,
+		Attributes: model.ServiceAttributes{
+			Name:            "foo.bar.com",
+			Namespace:       "testns",
+			ServiceRegistry: provider.External,
+		},
+	}
+
 	wildcardService := &model.Service{
 		Hostname:    host.Name("*.testns.svc.cluster.local"),
 		Address:     "172.10.10.10",
@@ -168,6 +185,17 @@ func TestNameTable(t *testing.T) {
 
 	cpush := model.NewPushContext()
 	wpush.AddPublicServices([]*model.Service{cidrService})
+
+	sepush := model.NewPushContext()
+	sepush.AddPublicServices([]*model.Service{headlessServiceForServiceEntry})
+	sepush.AddServiceInstances(headlessServiceForServiceEntry,
+		makeServiceInstances(pod1, headlessServiceForServiceEntry, "", ""))
+	sepush.AddServiceInstances(headlessServiceForServiceEntry,
+		makeServiceInstances(pod2, headlessServiceForServiceEntry, "", ""))
+	sepush.AddServiceInstances(headlessServiceForServiceEntry,
+		makeServiceInstances(pod3, headlessServiceForServiceEntry, "", ""))
+	sepush.AddServiceInstances(headlessServiceForServiceEntry,
+		makeServiceInstances(pod4, headlessServiceForServiceEntry, "", ""))
 
 	cases := []struct {
 		name                       string
@@ -388,6 +416,19 @@ func TestNameTable(t *testing.T) {
 						Shortname: "headless-svc",
 						Namespace: "testns",
 						AltHosts:  []string{"headless-svc.testns.svc.clusterset.local"},
+					},
+				},
+			},
+		},
+		{
+			name:  "service entry with resolution = NONE",
+			proxy: proxy,
+			push:  sepush,
+			expectedNameTable: &dnsProto.NameTable{
+				Table: map[string]*dnsProto.NameTable_NameInfo{
+					"foo.bar.com": {
+						Ips:      []string{"1.2.3.4", "9.6.7.8", "19.6.7.8", "9.16.7.8"},
+						Registry: "External",
 					},
 				},
 			},


### PR DESCRIPTION
Please provide a description for what this PR is for.

ServiceEntry with resolution set to NONE, is similar to k8s headless service, the hostname should be resolved to workload instance ips.

Fix: #34224

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
