### PR TITLE
remove duplicate mutex lock from atomic bool

### DIFF
--- a/pilot/pkg/serviceregistry/serviceentry/servicediscovery.go
+++ b/pilot/pkg/serviceregistry/serviceentry/servicediscovery.go
@@ -347,9 +347,7 @@ func (s *ServiceEntryStore) serviceEntryHandler(old, curr config.Config, event m
 
 	// Recomputing the index here is too expensive - lazy build when it is needed.
 	// Only recompute indexes if services have changed.
-	s.storeMutex.Lock()
 	s.refreshIndexes.Store(true)
-	s.storeMutex.Unlock()
 
 	// When doing a full push, the non DNS added, updated, unchanged services trigger an eds update
 	// so that endpoint shards are updated.
@@ -569,7 +567,7 @@ func (s *ServiceEntryStore) ResyncEDS() {
 // And triggers a push if `push` is true.
 func (s *ServiceEntryStore) edsUpdate(instances []*model.ServiceInstance, push bool) {
 	// must call it here to refresh s.instances if necessary
-	// otherwise may get no instances or miss some new addes instances
+	// otherwise may get no instances or miss some new added instances
 	s.maybeRefreshIndexes()
 	// Find all keys we need to lookup
 	keys := map[instancesKey]struct{}{}
@@ -581,7 +579,7 @@ func (s *ServiceEntryStore) edsUpdate(instances []*model.ServiceInstance, push b
 
 func (s *ServiceEntryStore) edsUpdateByKeys(keys map[instancesKey]struct{}, push bool) {
 	// must call it here to refresh s.instances if necessary
-	// otherwise may get no instances or miss some new addess instances
+	// otherwise may get no instances or miss some new added instances
 	s.maybeRefreshIndexes()
 	allInstances := []*model.ServiceInstance{}
 	s.storeMutex.RLock()

--- a/pilot/pkg/serviceregistry/serviceentry/servicediscovery_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/servicediscovery_test.go
@@ -153,9 +153,7 @@ func TestServiceDiscoveryServices(t *testing.T) {
 
 	createConfigs([]*config.Config{httpDNS, tcpStatic}, store, t)
 
-	sd.storeMutex.Lock()
 	sd.refreshIndexes.Store(true)
-	sd.storeMutex.Unlock()
 
 	services, err := sd.Services()
 	if err != nil {
@@ -177,9 +175,7 @@ func TestServiceDiscoveryGetService(t *testing.T) {
 
 	createConfigs([]*config.Config{httpDNS, tcpStatic}, store, t)
 
-	sd.storeMutex.Lock()
 	sd.refreshIndexes.Store(true)
-	sd.storeMutex.Unlock()
 
 	service, err := sd.GetService(host.Name(hostDNE))
 	if err != nil {


### PR DESCRIPTION
field `refreshIndexes` is already `atomic bool` value, so we do not need to use mutex to protect its read/write.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.