### PR TITLE
refactor build clusters logic

### DIFF
--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -212,7 +212,8 @@ var DefaultXdsLogDetails = XdsLogDetails{}
 type XdsResourceGenerator interface {
 	// Generate builds the xds resources for given proxy. Resources contain the newly added/updated resources.
 	// DeletedResources typically used in incremental Xds protocols contain the resources that have been deleted.
-	Generate(proxy *Proxy, push *PushContext, w *WatchedResource, updates *PushRequest) (Resources, DeletedResources, XdsLogDetails, error)
+	// It also indicates whether the response is delta or SoTW.
+	Generate(proxy *Proxy, push *PushContext, w *WatchedResource, updates *PushRequest) (Resources, DeletedResources, bool, XdsLogDetails, error)
 }
 
 // Proxy contains information about an specific instance of a proxy (envoy sidecar, gateway,

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -172,6 +172,8 @@ func (e *Environment) SetLedger(l ledger.Ledger) {
 // Resources is an alias for array of marshaled resources.
 type Resources = []*discovery.Resource
 
+type DeletedResources = []string
+
 func AnyToUnnamedResources(r []*any.Any) Resources {
 	a := make(Resources, 0, len(r))
 	for _, rr := range r {
@@ -208,10 +210,9 @@ var DefaultXdsLogDetails = XdsLogDetails{}
 // Note: any errors returned will completely close the XDS stream. Use with caution; typically and empty
 // or no response is preferred.
 type XdsResourceGenerator interface {
-	Generate(proxy *Proxy, push *PushContext, w *WatchedResource, updates *PushRequest) (Resources, XdsLogDetails, error)
-
-	// GenerateDeltas returns the changed and removed resources, along with whether or not delta was actually used.
-	GenerateDeltas(proxy *Proxy, push *PushContext, updates *PushRequest, w *WatchedResource) (Resources, []string, XdsLogDetails, bool, error)
+	// Generate builds the xds resources for given proxy. Resources contain the newly added/updated resources.
+	// DeletedResources typically used in incremental Xds protocols contain the resources that have been deleted.
+	Generate(proxy *Proxy, push *PushContext, w *WatchedResource, updates *PushRequest) (Resources, DeletedResources, XdsLogDetails, error)
 }
 
 // Proxy contains information about an specific instance of a proxy (envoy sidecar, gateway,

--- a/pilot/pkg/networking/apigen/apigen.go
+++ b/pilot/pkg/networking/apigen/apigen.go
@@ -63,7 +63,7 @@ func NewGenerator(store model.IstioConfigStore) *APIGenerator {
 //
 // Names are based on the current resource naming in istiod stores.
 func (g *APIGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource,
-	updates *model.PushRequest) (model.Resources, model.DeletedResources, model.XdsLogDetails, error) {
+	updates *model.PushRequest) (model.Resources, model.DeletedResources, bool, model.XdsLogDetails, error) {
 	resp := model.Resources{}
 
 	// Note: this is the style used by MCP and its config. Pilot is using 'Group/Version/Kind' as the
@@ -76,7 +76,7 @@ func (g *APIGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *
 	if len(kind) != 3 {
 		log.Warnf("ADS: Unknown watched resources %s", w.TypeUrl)
 		// Still return an empty response - to not break waiting code. It is fine to not know about some resource.
-		return resp, nil, model.DefaultXdsLogDetails, nil
+		return resp, nil, false, model.DefaultXdsLogDetails, nil
 	}
 	// TODO: extra validation may be needed - at least logging that a resource
 	// of unknown type was requested. This should not be an error - maybe client asks
@@ -97,7 +97,7 @@ func (g *APIGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *
 				Resource: a,
 			})
 		}
-		return resp, nil, model.DefaultXdsLogDetails, nil
+		return resp, nil, false, model.DefaultXdsLogDetails, nil
 	}
 
 	// TODO: what is the proper way to handle errors ?
@@ -108,7 +108,7 @@ func (g *APIGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *
 	cfg, err := g.store.List(rgvk, "")
 	if err != nil {
 		log.Warnf("ADS: Error reading resource %s %v", w.TypeUrl, err)
-		return resp, nil, model.DefaultXdsLogDetails, nil
+		return resp, nil, false, model.DefaultXdsLogDetails, nil
 	}
 	for _, c := range cfg {
 		// Right now model.Config is not a proto - until we change it, mcp.Resource.
@@ -167,7 +167,7 @@ func (g *APIGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *
 		}
 	}
 
-	return resp, nil, model.DefaultXdsLogDetails, nil
+	return resp, nil, false, model.DefaultXdsLogDetails, nil
 }
 
 // Convert from model.Config, which has no associated proto, to MCP Resource proto.

--- a/pilot/pkg/networking/apigen/apigen.go
+++ b/pilot/pkg/networking/apigen/apigen.go
@@ -63,7 +63,7 @@ func NewGenerator(store model.IstioConfigStore) *APIGenerator {
 //
 // Names are based on the current resource naming in istiod stores.
 func (g *APIGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource,
-	updates *model.PushRequest) (model.Resources, model.XdsLogDetails, error) {
+	updates *model.PushRequest) (model.Resources, model.DeletedResources, model.XdsLogDetails, error) {
 	resp := model.Resources{}
 
 	// Note: this is the style used by MCP and its config. Pilot is using 'Group/Version/Kind' as the
@@ -76,7 +76,7 @@ func (g *APIGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *
 	if len(kind) != 3 {
 		log.Warnf("ADS: Unknown watched resources %s", w.TypeUrl)
 		// Still return an empty response - to not break waiting code. It is fine to not know about some resource.
-		return resp, model.DefaultXdsLogDetails, nil
+		return resp, nil, model.DefaultXdsLogDetails, nil
 	}
 	// TODO: extra validation may be needed - at least logging that a resource
 	// of unknown type was requested. This should not be an error - maybe client asks
@@ -97,7 +97,7 @@ func (g *APIGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *
 				Resource: a,
 			})
 		}
-		return resp, model.DefaultXdsLogDetails, nil
+		return resp, nil, model.DefaultXdsLogDetails, nil
 	}
 
 	// TODO: what is the proper way to handle errors ?
@@ -108,7 +108,7 @@ func (g *APIGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *
 	cfg, err := g.store.List(rgvk, "")
 	if err != nil {
 		log.Warnf("ADS: Error reading resource %s %v", w.TypeUrl, err)
-		return resp, model.DefaultXdsLogDetails, nil
+		return resp, nil, model.DefaultXdsLogDetails, nil
 	}
 	for _, c := range cfg {
 		// Right now model.Config is not a proto - until we change it, mcp.Resource.
@@ -167,13 +167,7 @@ func (g *APIGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *
 		}
 	}
 
-	return resp, model.DefaultXdsLogDetails, nil
-}
-
-func (g *APIGenerator) GenerateDeltas(proxy *model.Proxy, push *model.PushContext, updates *model.PushRequest,
-	w *model.WatchedResource) (model.Resources, []string, model.XdsLogDetails, bool, error) {
-	res, logs, err := g.Generate(proxy, push, w, updates)
-	return res, nil, logs, false, err
+	return resp, nil, model.DefaultXdsLogDetails, nil
 }
 
 // Convert from model.Config, which has no associated proto, to MCP Resource proto.

--- a/pilot/pkg/networking/core/configgen.go
+++ b/pilot/pkg/networking/core/configgen.go
@@ -39,8 +39,7 @@ type ConfigGenerator interface {
 
 	// BuildDeltaClusters returns both a list of resources that need to be pushed for a given proxy and a list of resources
 	// that have been deleted and should be removed from a given proxy. This is Delta CDS output.
-	BuildDeltaClusters(node *model.Proxy, push *model.PushContext, updates *model.PushRequest,
-		watched *model.WatchedResource) ([]*discovery.Resource, []string, model.XdsLogDetails, bool)
+	BuildDeltaClusters(node *model.Proxy, updates *model.PushRequest, watched *model.WatchedResource) ([]*discovery.Resource, []string, model.XdsLogDetails)
 
 	// BuildHTTPRoutes returns the list of HTTP routes for the given proxy. This is the RDS output
 	BuildHTTPRoutes(node *model.Proxy, push *model.PushContext, routeNames []string) []*route.RouteConfiguration

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -78,6 +78,7 @@ func getDefaultCircuitBreakerThresholds() *cluster.CircuitBreakers_Thresholds {
 // Cluster type based on resolution
 // For inbound (sidecar only): Cluster for each inbound endpoint port and for each service port
 func (configgen *ConfigGeneratorImpl) BuildClusters(proxy *model.Proxy, req *model.PushRequest) ([]*discovery.Resource, model.XdsLogDetails) {
+	// In Sotw, we care about all services.
 	var services []*model.Service
 	if features.FilterGatewayClusterConfig && proxy.Type == model.Router {
 		services = req.Push.GatewayServices(proxy)

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -123,7 +123,8 @@ func (configgen *ConfigGeneratorImpl) BuildDeltaClusters(proxy *model.Proxy, upd
 }
 
 // buildClusters builds clusters for the proxy with the services passed.
-func (configgen *ConfigGeneratorImpl) buildClusters(proxy *model.Proxy, req *model.PushRequest, services []*model.Service) ([]*discovery.Resource, model.XdsLogDetails) {
+func (configgen *ConfigGeneratorImpl) buildClusters(proxy *model.Proxy, req *model.PushRequest,
+	services []*model.Service) ([]*discovery.Resource, model.XdsLogDetails) {
 	clusters := make([]*cluster.Cluster, 0)
 	resources := model.Resources{}
 	envoyFilterPatches := req.Push.EnvoyFilters(proxy)

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -36,7 +36,7 @@ import (
 	"istio.io/istio/pilot/pkg/networking/core/v1alpha3/loadbalancer"
 	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pilot/pkg/serviceregistry/provider"
-	"istio.io/istio/pkg/config"
+	"istio.io/istio/pilot/pkg/util/sets"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/config/schema/gvk"
@@ -52,6 +52,10 @@ var defaultTransportSocketMatch = &cluster.Cluster_TransportSocketMatch{
 		Name: util.EnvoyRawBufferSocketName,
 	},
 }
+
+// deltaConfigTypes are used to detect changes and trigger delta calculations. When config updates has ONLY entries
+// in this map, then delta calculation is triggered.
+var deltaConfigTypes = sets.NewSet(gvk.ServiceEntry.Kind)
 
 // getDefaultCircuitBreakerThresholds returns a copy of the default circuit breaker thresholds for the given traffic direction.
 func getDefaultCircuitBreakerThresholds() *cluster.CircuitBreakers_Thresholds {
@@ -74,6 +78,52 @@ func getDefaultCircuitBreakerThresholds() *cluster.CircuitBreakers_Thresholds {
 // Cluster type based on resolution
 // For inbound (sidecar only): Cluster for each inbound endpoint port and for each service port
 func (configgen *ConfigGeneratorImpl) BuildClusters(proxy *model.Proxy, req *model.PushRequest) ([]*discovery.Resource, model.XdsLogDetails) {
+	var services []*model.Service
+	if features.FilterGatewayClusterConfig && proxy.Type == model.Router {
+		services = req.Push.GatewayServices(proxy)
+	} else {
+		services = req.Push.Services(proxy)
+	}
+	return configgen.buildClusters(proxy, req, services)
+}
+
+// BuildDeltaClusters generates the deltas (add and delete) for a given proxy. Currently, only service changes are reflected with deltas.
+// Otherwise, we fall back onto generating everything.
+func (configgen *ConfigGeneratorImpl) BuildDeltaClusters(proxy *model.Proxy, updates *model.PushRequest,
+	watched *model.WatchedResource) ([]*discovery.Resource, []string, model.XdsLogDetails) {
+	// if we can't use delta, fall back to generate all
+	if !shouldUseDelta(updates) {
+		cl, lg := configgen.BuildClusters(proxy, updates)
+		return cl, nil, lg
+	}
+	deletedClusters := make([]string, 0)
+	services := make([]*model.Service, 0)
+	// In delta, we only care about the services that have changed.
+	for key := range updates.ConfigsUpdated {
+		// get the service that has changed.
+		service := updates.Push.ServiceForHostname(proxy, host.Name(key.Name))
+		// SidecarScope.Service will return nil if the proxy doesn't care about the service OR it was deleted.
+		// we can cross reference with WatchedResources to figure out which services were deleted.
+		if service == nil {
+			// WatchedResources.ResourceNames will contain the names of the clusters it is subscribed to. We can
+			// check with the name of our service (cluster names are in the format outbound|<port>||<hostname>.
+			// so, if this service is part of watched resources, we can conclude that it is a removed cluster.
+			for _, n := range watched.ResourceNames {
+				_, _, svcHost, _ := model.ParseSubsetKey(n)
+				if svcHost == host.Name(key.Name) {
+					deletedClusters = append(deletedClusters, n)
+				}
+			}
+		} else {
+			services = append(services, service)
+		}
+	}
+	clusters, log := configgen.buildClusters(proxy, updates, services)
+	return clusters, deletedClusters, log
+}
+
+// buildClusters builds clusters for the proxy with the services passed.
+func (configgen *ConfigGeneratorImpl) buildClusters(proxy *model.Proxy, req *model.PushRequest, services []*model.Service) ([]*discovery.Resource, model.XdsLogDetails) {
 	clusters := make([]*cluster.Cluster, 0)
 	resources := model.Resources{}
 	envoyFilterPatches := req.Push.EnvoyFilters(proxy)
@@ -84,7 +134,7 @@ func (configgen *ConfigGeneratorImpl) BuildClusters(proxy *model.Proxy, req *mod
 	case model.SidecarProxy:
 		// Setup outbound clusters
 		outboundPatcher := clusterPatcher{efw: envoyFilterPatches, pctx: networking.EnvoyFilter_SIDECAR_OUTBOUND}
-		ob, cs := configgen.buildOutboundClusters(cb, outboundPatcher)
+		ob, cs := configgen.buildOutboundClusters(cb, outboundPatcher, services)
 		cacheStats = cacheStats.merge(cs)
 		resources = append(resources, ob...)
 		// Add a blackhole and passthrough cluster for catching traffic to unresolved routes
@@ -99,7 +149,7 @@ func (configgen *ConfigGeneratorImpl) BuildClusters(proxy *model.Proxy, req *mod
 		clusters = append(clusters, inboundPatcher.insertedClusters()...)
 	default: // Gateways
 		patcher := clusterPatcher{efw: envoyFilterPatches, pctx: networking.EnvoyFilter_GATEWAY}
-		ob, cs := configgen.buildOutboundClusters(cb, patcher)
+		ob, cs := configgen.buildOutboundClusters(cb, patcher, services)
 		cacheStats = cacheStats.merge(cs)
 		resources = append(resources, ob...)
 		// Gateways do not require the default passthrough cluster as they do not have original dst listeners.
@@ -121,96 +171,13 @@ func (configgen *ConfigGeneratorImpl) BuildClusters(proxy *model.Proxy, req *mod
 	return resources, model.XdsLogDetails{AdditionalInfo: fmt.Sprintf("cached:%v/%v", cacheStats.hits, cacheStats.hits+cacheStats.miss)}
 }
 
-// BuildDeltaClusters generates the deltas (add and delete) for a given proxy. Currently, only service changes are reflected with deltas.
-// Otherwise, we fall back onto generating everything.
-func (configgen *ConfigGeneratorImpl) BuildDeltaClusters(proxy *model.Proxy, push *model.PushContext,
-	updates *model.PushRequest, watched *model.WatchedResource) ([]*discovery.Resource, []string, model.XdsLogDetails, bool) {
-	// if we can't use delta, fall back to generate all
-	if !shouldUseDelta(updates) {
-		cl, lg := configgen.BuildClusters(proxy, updates)
-		return cl, nil, lg, false
-	}
-	clusters := make([]*cluster.Cluster, 0)
-	resources := model.Resources{}
-	removedClusterNames := make([]string, 0)
-	services := make([]*model.Service, 0)
-	envoyFilterPatches := push.EnvoyFilters(proxy)
-	cb := NewClusterBuilder(proxy, updates, configgen.Cache)
-	instances := proxy.ServiceInstances
-	for key := range updates.ConfigsUpdated {
-		// get service that changed
-		service := push.ServiceForHostname(proxy, host.Name(key.Name))
-		// SidecarScope.Service will return nil if the proxy doesn't care about the service OR it was deleted.
-		// we can cross reference with WatchedResources to figure out which services were deleted.
-		if service == nil {
-			// WatchedResources.ResourceNames will contain the names of the clusters it is subscribed to. We can
-			// check with the name of our service (cluster names are in the format outbound|<port>||<hostname>
-			// so, we can check if the cluster names contains the service name, and determine if it is deleted by that
-			for _, n := range watched.ResourceNames {
-				_, _, svcHost, _ := model.ParseSubsetKey(n)
-				if svcHost == host.Name(key.Name) {
-					removedClusterNames = append(removedClusterNames, n)
-				}
-			}
-		} else {
-			services = append(services, service)
-		}
-	}
-	clusterCacheStats := cacheStats{}
-	switch proxy.Type {
-	case model.SidecarProxy:
-		// Setup outbound clusters
-		outboundPatcher := clusterPatcher{efw: envoyFilterPatches, pctx: networking.EnvoyFilter_SIDECAR_OUTBOUND}
-		ob, cs := configgen.buildOutboundClustersWithServices(cb, outboundPatcher, services)
-		resources = append(resources, ob...)
-		clusterCacheStats = clusterCacheStats.merge(cs)
-		// Add a blackhole and passthrough cluster for catching traffic to unresolved routes
-		clusters = outboundPatcher.conditionallyAppend(clusters, nil, cb.buildBlackHoleCluster(), cb.buildDefaultPassthroughCluster())
-		clusters = append(clusters, outboundPatcher.insertedClusters()...)
-
-		// Setup inbound clusters
-		inboundPatcher := clusterPatcher{efw: envoyFilterPatches, pctx: networking.EnvoyFilter_SIDECAR_INBOUND}
-		clusters = append(clusters, configgen.buildInboundClusters(cb, instances, inboundPatcher)...)
-		// Pass through clusters for inbound traffic. These cluster bind loopback-ish src address to access node local service.
-		clusters = inboundPatcher.conditionallyAppend(clusters, nil, cb.buildInboundPassthroughClusters()...)
-		clusters = append(clusters, inboundPatcher.insertedClusters()...)
-	default: // Gateways
-		patcher := clusterPatcher{efw: envoyFilterPatches, pctx: networking.EnvoyFilter_GATEWAY}
-		var ob []*discovery.Resource
-		var cs cacheStats
-		ob, cs = configgen.buildOutboundClusters(cb, patcher)
-		resources = append(resources, ob...)
-		// todo deltas for gateways -- logic is different than that of sidecars
-		clusterCacheStats = clusterCacheStats.merge(cs)
-		// Gateways do not require the default passthrough cluster as they do not have original dst listeners.
-		clusters = patcher.conditionallyAppend(clusters, nil, cb.buildBlackHoleCluster())
-		if proxy.Type == model.Router && proxy.MergedGateway != nil && proxy.MergedGateway.ContainsAutoPassthroughGateways {
-			clusters = append(clusters, configgen.buildOutboundSniDnatClusters(proxy, updates, patcher)...)
-		}
-		clusters = append(clusters, patcher.insertedClusters()...)
-	}
-
-	for _, c := range clusters {
-		resources = append(resources, &discovery.Resource{Name: c.Name, Resource: util.MessageToAny(c)})
-	}
-	resources = cb.normalizeClusters(resources)
-
-	if clusterCacheStats.empty() {
-		return resources, removedClusterNames, model.DefaultXdsLogDetails, true
-	}
-	return resources, removedClusterNames,
-		model.XdsLogDetails{AdditionalInfo: fmt.Sprintf("cached:%v/%v", clusterCacheStats.hits, clusterCacheStats.hits+clusterCacheStats.miss)}, true
-}
-
 func shouldUseDelta(updates *model.PushRequest) bool {
-	// Use delta when "only" services are modified. We will relax this restriction
-	// as we enhance delta code to handle other complex/mixed config changes.
-	return updates != nil && allConfigKeysOfType(updates.ConfigsUpdated, gvk.ServiceEntry) && len(updates.ConfigsUpdated) > 0
+	return updates != nil && allConfigKeysOfType(updates.ConfigsUpdated) && len(updates.ConfigsUpdated) > 0
 }
 
-func allConfigKeysOfType(cfgs map[model.ConfigKey]struct{}, cfg config.GroupVersionKind) bool {
+func allConfigKeysOfType(cfgs map[model.ConfigKey]struct{}) bool {
 	for k := range cfgs {
-		if k.Kind != cfg {
+		if !deltaConfigTypes.Contains(k.Kind.Kind) {
 			return false
 		}
 	}
@@ -250,17 +217,7 @@ func buildClusterKey(service *model.Service, port *model.Port, cb *ClusterBuilde
 }
 
 // buildOutboundClusters generates all outbound (including subsets) clusters for a given proxy.
-func (configgen *ConfigGeneratorImpl) buildOutboundClusters(cb *ClusterBuilder, cp clusterPatcher) ([]*discovery.Resource, cacheStats) {
-	var services []*model.Service
-	if features.FilterGatewayClusterConfig && cb.proxy.Type == model.Router {
-		services = cb.req.Push.GatewayServices(cb.proxy)
-	} else {
-		services = cb.req.Push.Services(cb.proxy)
-	}
-	return configgen.buildOutboundClustersWithServices(cb, cp, services)
-}
-
-func (configgen *ConfigGeneratorImpl) buildOutboundClustersWithServices(cb *ClusterBuilder, cp clusterPatcher,
+func (configgen *ConfigGeneratorImpl) buildOutboundClusters(cb *ClusterBuilder, cp clusterPatcher,
 	services []*model.Service) ([]*discovery.Resource, cacheStats) {
 	resources := make([]*discovery.Resource, 0)
 	hit, miss := 0, 0

--- a/pilot/pkg/networking/grpcgen/grpcgen.go
+++ b/pilot/pkg/networking/grpcgen/grpcgen.go
@@ -50,15 +50,15 @@ func subsetClusterKey(subset, hostname string, port int) string {
 }
 
 func (g *GrpcConfigGenerator) Generate(proxy *model.Proxy, push *model.PushContext,
-	w *model.WatchedResource, updates *model.PushRequest) (model.Resources, model.DeletedResources, model.XdsLogDetails, error) {
+	w *model.WatchedResource, updates *model.PushRequest) (model.Resources, model.DeletedResources, bool, model.XdsLogDetails, error) {
 	switch w.TypeUrl {
 	case v3.ListenerType:
-		return g.BuildListeners(proxy, push, w.ResourceNames), nil, model.DefaultXdsLogDetails, nil
+		return g.BuildListeners(proxy, push, w.ResourceNames), nil, false, model.DefaultXdsLogDetails, nil
 	case v3.ClusterType:
-		return g.BuildClusters(proxy, push, w.ResourceNames), nil, model.DefaultXdsLogDetails, nil
+		return g.BuildClusters(proxy, push, w.ResourceNames), nil, false, model.DefaultXdsLogDetails, nil
 	case v3.RouteType:
-		return g.BuildHTTPRoutes(proxy, push, w.ResourceNames), nil, model.DefaultXdsLogDetails, nil
+		return g.BuildHTTPRoutes(proxy, push, w.ResourceNames), nil, false, model.DefaultXdsLogDetails, nil
 	}
 
-	return nil, nil, model.DefaultXdsLogDetails, nil
+	return nil, nil, false, model.DefaultXdsLogDetails, nil
 }

--- a/pilot/pkg/networking/grpcgen/grpcgen.go
+++ b/pilot/pkg/networking/grpcgen/grpcgen.go
@@ -50,21 +50,15 @@ func subsetClusterKey(subset, hostname string, port int) string {
 }
 
 func (g *GrpcConfigGenerator) Generate(proxy *model.Proxy, push *model.PushContext,
-	w *model.WatchedResource, updates *model.PushRequest) (model.Resources, model.XdsLogDetails, error) {
+	w *model.WatchedResource, updates *model.PushRequest) (model.Resources, model.DeletedResources, model.XdsLogDetails, error) {
 	switch w.TypeUrl {
 	case v3.ListenerType:
-		return g.BuildListeners(proxy, push, w.ResourceNames), model.DefaultXdsLogDetails, nil
+		return g.BuildListeners(proxy, push, w.ResourceNames), nil, model.DefaultXdsLogDetails, nil
 	case v3.ClusterType:
-		return g.BuildClusters(proxy, push, w.ResourceNames), model.DefaultXdsLogDetails, nil
+		return g.BuildClusters(proxy, push, w.ResourceNames), nil, model.DefaultXdsLogDetails, nil
 	case v3.RouteType:
-		return g.BuildHTTPRoutes(proxy, push, w.ResourceNames), model.DefaultXdsLogDetails, nil
+		return g.BuildHTTPRoutes(proxy, push, w.ResourceNames), nil, model.DefaultXdsLogDetails, nil
 	}
 
-	return nil, model.DefaultXdsLogDetails, nil
-}
-
-func (g *GrpcConfigGenerator) GenerateDeltas(proxy *model.Proxy, push *model.PushContext, updates *model.PushRequest,
-	w *model.WatchedResource) (model.Resources, []string, model.XdsLogDetails, bool, error) {
-	res, logs, err := g.Generate(proxy, push, w, updates)
-	return res, nil, logs, false, err
+	return nil, nil, model.DefaultXdsLogDetails, nil
 }

--- a/pilot/pkg/xds/bench_test.go
+++ b/pilot/pkg/xds/bench_test.go
@@ -161,7 +161,7 @@ func BenchmarkRouteGeneration(b *testing.B) {
 			b.ResetTimer()
 			var c model.Resources
 			for n := 0; n < b.N; n++ {
-				c, _, _, _ = s.Discovery.Generators[v3.RouteType].Generate(proxy, s.PushContext(), &model.WatchedResource{ResourceNames: routeNames}, nil)
+				c, _, _, _, _ = s.Discovery.Generators[v3.RouteType].Generate(proxy, s.PushContext(), &model.WatchedResource{ResourceNames: routeNames}, nil)
 				if len(c) == 0 {
 					b.Fatal("Got no routes!")
 				}
@@ -175,7 +175,7 @@ func BenchmarkRouteGeneration(b *testing.B) {
 // update our benchmark doesn't become useless.
 func TestValidateTelemetry(t *testing.T) {
 	s, proxy := setupAndInitializeTest(t, ConfigInput{Name: "telemetry", Services: 1})
-	c, _, _, _ := s.Discovery.Generators[v3.ClusterType].Generate(proxy, s.PushContext(), nil, &model.PushRequest{Full: true, Push: s.PushContext()})
+	c, _, _, _, _ := s.Discovery.Generators[v3.ClusterType].Generate(proxy, s.PushContext(), nil, &model.PushRequest{Full: true, Push: s.PushContext()})
 	if len(c) == 0 {
 		t.Fatal("Got no clusters!")
 	}
@@ -316,7 +316,7 @@ func runBenchmark(b *testing.B, tpe string, testCases []ConfigInput) {
 			b.ResetTimer()
 			var c model.Resources
 			for n := 0; n < b.N; n++ {
-				c, _, _, _ = s.Discovery.Generators[tpe].Generate(proxy, s.PushContext(), wr, &model.PushRequest{Full: true, Push: s.PushContext()})
+				c, _, _, _, _ = s.Discovery.Generators[tpe].Generate(proxy, s.PushContext(), wr, &model.PushRequest{Full: true, Push: s.PushContext()})
 				if len(c) == 0 {
 					b.Fatalf("Got no %v's!", tpe)
 				}
@@ -341,7 +341,7 @@ func testBenchmark(t *testing.T, tpe string, testCases []ConfigInput) {
 				}
 				wr = &model.WatchedResource{ResourceNames: watchedResources}
 			}
-			c, _, _, _ := s.Discovery.Generators[tpe].Generate(proxy, s.PushContext(), wr, &model.PushRequest{Full: true, Push: s.PushContext()})
+			c, _, _, _, _ := s.Discovery.Generators[tpe].Generate(proxy, s.PushContext(), wr, &model.PushRequest{Full: true, Push: s.PushContext()})
 			if len(c) == 0 {
 				t.Fatalf("Got no %v's!", tpe)
 			}

--- a/pilot/pkg/xds/bench_test.go
+++ b/pilot/pkg/xds/bench_test.go
@@ -161,7 +161,7 @@ func BenchmarkRouteGeneration(b *testing.B) {
 			b.ResetTimer()
 			var c model.Resources
 			for n := 0; n < b.N; n++ {
-				c, _, _ = s.Discovery.Generators[v3.RouteType].Generate(proxy, s.PushContext(), &model.WatchedResource{ResourceNames: routeNames}, nil)
+				c, _, _, _ = s.Discovery.Generators[v3.RouteType].Generate(proxy, s.PushContext(), &model.WatchedResource{ResourceNames: routeNames}, nil)
 				if len(c) == 0 {
 					b.Fatal("Got no routes!")
 				}
@@ -175,7 +175,7 @@ func BenchmarkRouteGeneration(b *testing.B) {
 // update our benchmark doesn't become useless.
 func TestValidateTelemetry(t *testing.T) {
 	s, proxy := setupAndInitializeTest(t, ConfigInput{Name: "telemetry", Services: 1})
-	c, _, _ := s.Discovery.Generators[v3.ClusterType].Generate(proxy, s.PushContext(), nil, &model.PushRequest{Full: true, Push: s.PushContext()})
+	c, _, _, _ := s.Discovery.Generators[v3.ClusterType].Generate(proxy, s.PushContext(), nil, &model.PushRequest{Full: true, Push: s.PushContext()})
 	if len(c) == 0 {
 		t.Fatal("Got no clusters!")
 	}
@@ -316,7 +316,7 @@ func runBenchmark(b *testing.B, tpe string, testCases []ConfigInput) {
 			b.ResetTimer()
 			var c model.Resources
 			for n := 0; n < b.N; n++ {
-				c, _, _ = s.Discovery.Generators[tpe].Generate(proxy, s.PushContext(), wr, &model.PushRequest{Full: true, Push: s.PushContext()})
+				c, _, _, _ = s.Discovery.Generators[tpe].Generate(proxy, s.PushContext(), wr, &model.PushRequest{Full: true, Push: s.PushContext()})
 				if len(c) == 0 {
 					b.Fatalf("Got no %v's!", tpe)
 				}
@@ -341,7 +341,7 @@ func testBenchmark(t *testing.T, tpe string, testCases []ConfigInput) {
 				}
 				wr = &model.WatchedResource{ResourceNames: watchedResources}
 			}
-			c, _, _ := s.Discovery.Generators[tpe].Generate(proxy, s.PushContext(), wr, &model.PushRequest{Full: true, Push: s.PushContext()})
+			c, _, _, _ := s.Discovery.Generators[tpe].Generate(proxy, s.PushContext(), wr, &model.PushRequest{Full: true, Push: s.PushContext()})
 			if len(c) == 0 {
 				t.Fatalf("Got no %v's!", tpe)
 			}

--- a/pilot/pkg/xds/bootstrapds.go
+++ b/pilot/pkg/xds/bootstrapds.go
@@ -41,7 +41,7 @@ var _ model.XdsResourceGenerator = &BootstrapGenerator{}
 
 // Generate returns a bootstrap discovery response.
 func (e *BootstrapGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource,
-	updates *model.PushRequest) (model.Resources, model.DeletedResources, model.XdsLogDetails, error) {
+	updates *model.PushRequest) (model.Resources, model.DeletedResources, bool, model.XdsLogDetails, error) {
 	// The model.Proxy information is incomplete, re-parse the discovery request.
 	node := bootstrap.ConvertXDSNodeToNode(proxy.XdsNode)
 
@@ -51,7 +51,7 @@ func (e *BootstrapGenerator) Generate(proxy *model.Proxy, push *model.PushContex
 		Node: node,
 	}).WriteTo(templateFile, io.Writer(&buf))
 	if err != nil {
-		return nil, nil, model.DefaultXdsLogDetails, fmt.Errorf("failed to generate bootstrap config: %v", err)
+		return nil, nil, false, model.DefaultXdsLogDetails, fmt.Errorf("failed to generate bootstrap config: %v", err)
 	}
 
 	bs := &bootstrapv3.Bootstrap{}
@@ -63,7 +63,7 @@ func (e *BootstrapGenerator) Generate(proxy *model.Proxy, push *model.PushContex
 		&discovery.Resource{
 			Resource: util.MessageToAny(bs),
 		},
-	}, nil, model.DefaultXdsLogDetails, nil
+	}, nil, false, model.DefaultXdsLogDetails, nil
 }
 
 func (e *BootstrapGenerator) applyPatches(bs *bootstrapv3.Bootstrap, proxy *model.Proxy, push *model.PushContext) *bootstrapv3.Bootstrap {

--- a/pilot/pkg/xds/bootstrapds.go
+++ b/pilot/pkg/xds/bootstrapds.go
@@ -41,7 +41,7 @@ var _ model.XdsResourceGenerator = &BootstrapGenerator{}
 
 // Generate returns a bootstrap discovery response.
 func (e *BootstrapGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource,
-	updates *model.PushRequest) (model.Resources, model.XdsLogDetails, error) {
+	updates *model.PushRequest) (model.Resources, model.DeletedResources, model.XdsLogDetails, error) {
 	// The model.Proxy information is incomplete, re-parse the discovery request.
 	node := bootstrap.ConvertXDSNodeToNode(proxy.XdsNode)
 
@@ -51,7 +51,7 @@ func (e *BootstrapGenerator) Generate(proxy *model.Proxy, push *model.PushContex
 		Node: node,
 	}).WriteTo(templateFile, io.Writer(&buf))
 	if err != nil {
-		return nil, model.DefaultXdsLogDetails, fmt.Errorf("failed to generate bootstrap config: %v", err)
+		return nil, nil, model.DefaultXdsLogDetails, fmt.Errorf("failed to generate bootstrap config: %v", err)
 	}
 
 	bs := &bootstrapv3.Bootstrap{}
@@ -63,13 +63,7 @@ func (e *BootstrapGenerator) Generate(proxy *model.Proxy, push *model.PushContex
 		&discovery.Resource{
 			Resource: util.MessageToAny(bs),
 		},
-	}, model.DefaultXdsLogDetails, nil
-}
-
-func (e *BootstrapGenerator) GenerateDeltas(proxy *model.Proxy, push *model.PushContext, updates *model.PushRequest,
-	w *model.WatchedResource) (model.Resources, []string, model.XdsLogDetails, bool, error) {
-	res, logs, err := e.Generate(proxy, push, w, updates)
-	return res, nil, logs, false, err
+	}, nil, model.DefaultXdsLogDetails, nil
 }
 
 func (e *BootstrapGenerator) applyPatches(bs *bootstrapv3.Bootstrap, proxy *model.Proxy, push *model.PushContext) *bootstrapv3.Bootstrap {

--- a/pilot/pkg/xds/cds.go
+++ b/pilot/pkg/xds/cds.go
@@ -74,7 +74,7 @@ func (c CdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *m
 	if !cdsNeedsPush(updates, proxy) {
 		return nil, nil, false, model.DefaultXdsLogDetails, nil
 	}
-	if features.DeltaXds {
+	if features.DeltaXds && shouldUseDelta(updates) {
 		updatedClusters, removedClusters, logs := c.Server.ConfigGenerator.BuildDeltaClusters(proxy, updates, w)
 		return updatedClusters, removedClusters, true, logs, nil
 	}

--- a/pilot/pkg/xds/debug.go
+++ b/pilot/pkg/xds/debug.go
@@ -612,7 +612,7 @@ func (s *DiscoveryServer) configDump(conn *Connection) (*adminapi.ConfigDump, er
 
 	secretsDump := &adminapi.SecretsConfigDump{}
 	if s.Generators[v3.SecretType] != nil {
-		secrets, _, _, _ := s.Generators[v3.SecretType].Generate(conn.proxy, s.globalPushContext(), conn.Watched(v3.SecretType), nil)
+		secrets, _, _, _, _ := s.Generators[v3.SecretType].Generate(conn.proxy, s.globalPushContext(), conn.Watched(v3.SecretType), nil)
 		if len(secrets) > 0 {
 			for _, secretAny := range secrets {
 				secret := &tls.Secret{}
@@ -763,7 +763,7 @@ func (s *DiscoveryServer) Ndsz(w http.ResponseWriter, req *http.Request) {
 	}
 
 	if s.Generators[v3.NameTableType] != nil {
-		nds, _, _, _ := s.Generators[v3.NameTableType].Generate(con.proxy, s.globalPushContext(), nil, nil)
+		nds, _, _, _, _ := s.Generators[v3.NameTableType].Generate(con.proxy, s.globalPushContext(), nil, nil)
 		if len(nds) == 0 {
 			return
 		}

--- a/pilot/pkg/xds/debug.go
+++ b/pilot/pkg/xds/debug.go
@@ -612,7 +612,7 @@ func (s *DiscoveryServer) configDump(conn *Connection) (*adminapi.ConfigDump, er
 
 	secretsDump := &adminapi.SecretsConfigDump{}
 	if s.Generators[v3.SecretType] != nil {
-		secrets, _, _ := s.Generators[v3.SecretType].Generate(conn.proxy, s.globalPushContext(), conn.Watched(v3.SecretType), nil)
+		secrets, _, _, _ := s.Generators[v3.SecretType].Generate(conn.proxy, s.globalPushContext(), conn.Watched(v3.SecretType), nil)
 		if len(secrets) > 0 {
 			for _, secretAny := range secrets {
 				secret := &tls.Secret{}
@@ -763,7 +763,7 @@ func (s *DiscoveryServer) Ndsz(w http.ResponseWriter, req *http.Request) {
 	}
 
 	if s.Generators[v3.NameTableType] != nil {
-		nds, _, _ := s.Generators[v3.NameTableType].Generate(con.proxy, s.globalPushContext(), nil, nil)
+		nds, _, _, _ := s.Generators[v3.NameTableType].Generate(con.proxy, s.globalPushContext(), nil, nil)
 		if len(nds) == 0 {
 			return
 		}

--- a/pilot/pkg/xds/debuggen.go
+++ b/pilot/pkg/xds/debuggen.go
@@ -85,14 +85,14 @@ func NewDebugGen(s *DiscoveryServer, systemNamespace string) *DebugGen {
 
 // Generate XDS debug responses according to the incoming debug request
 func (dg *DebugGen) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource,
-	updates *model.PushRequest) (model.Resources, model.DeletedResources, model.XdsLogDetails, error) {
+	updates *model.PushRequest) (model.Resources, model.DeletedResources, bool, model.XdsLogDetails, error) {
 	res := model.Resources{}
 	var buffer bytes.Buffer
 	if w.ResourceNames == nil {
-		return res, nil, model.DefaultXdsLogDetails, fmt.Errorf("debug type is required")
+		return res, nil, false, model.DefaultXdsLogDetails, fmt.Errorf("debug type is required")
 	}
 	if len(w.ResourceNames) != 1 {
-		return res, nil, model.DefaultXdsLogDetails, fmt.Errorf("only one debug request is allowed")
+		return res, nil, false, model.DefaultXdsLogDetails, fmt.Errorf("only one debug request is allowed")
 	}
 	resourceName := w.ResourceNames[0]
 	u, _ := url.Parse(resourceName)
@@ -104,7 +104,7 @@ func (dg *DebugGen) Generate(proxy *model.Proxy, push *model.PushContext, w *mod
 			shouldAllow = true
 		}
 		if !shouldAllow {
-			return res, nil, model.DefaultXdsLogDetails, fmt.Errorf("the debug info is not available for current identity: %q", identity)
+			return res, nil, false, model.DefaultXdsLogDetails, fmt.Errorf("the debug info is not available for current identity: %q", identity)
 		}
 	}
 	debugURL := "/debug/" + resourceName
@@ -124,5 +124,5 @@ func (dg *DebugGen) Generate(proxy *model.Proxy, push *model.PushContext, w *mod
 			Value:   buffer.Bytes(),
 		},
 	})
-	return res, nil, model.DefaultXdsLogDetails, nil
+	return res, nil, false, model.DefaultXdsLogDetails, nil
 }

--- a/pilot/pkg/xds/debuggen.go
+++ b/pilot/pkg/xds/debuggen.go
@@ -85,14 +85,14 @@ func NewDebugGen(s *DiscoveryServer, systemNamespace string) *DebugGen {
 
 // Generate XDS debug responses according to the incoming debug request
 func (dg *DebugGen) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource,
-	updates *model.PushRequest) (model.Resources, model.XdsLogDetails, error) {
+	updates *model.PushRequest) (model.Resources, model.DeletedResources, model.XdsLogDetails, error) {
 	res := model.Resources{}
 	var buffer bytes.Buffer
 	if w.ResourceNames == nil {
-		return res, model.DefaultXdsLogDetails, fmt.Errorf("debug type is required")
+		return res, nil, model.DefaultXdsLogDetails, fmt.Errorf("debug type is required")
 	}
 	if len(w.ResourceNames) != 1 {
-		return res, model.DefaultXdsLogDetails, fmt.Errorf("only one debug request is allowed")
+		return res, nil, model.DefaultXdsLogDetails, fmt.Errorf("only one debug request is allowed")
 	}
 	resourceName := w.ResourceNames[0]
 	u, _ := url.Parse(resourceName)
@@ -104,7 +104,7 @@ func (dg *DebugGen) Generate(proxy *model.Proxy, push *model.PushContext, w *mod
 			shouldAllow = true
 		}
 		if !shouldAllow {
-			return res, model.DefaultXdsLogDetails, fmt.Errorf("the debug info is not available for current identity: %q", identity)
+			return res, nil, model.DefaultXdsLogDetails, fmt.Errorf("the debug info is not available for current identity: %q", identity)
 		}
 	}
 	debugURL := "/debug/" + resourceName
@@ -124,11 +124,5 @@ func (dg *DebugGen) Generate(proxy *model.Proxy, push *model.PushContext, w *mod
 			Value:   buffer.Bytes(),
 		},
 	})
-	return res, model.DefaultXdsLogDetails, nil
-}
-
-func (dg *DebugGen) GenerateDeltas(proxy *model.Proxy, push *model.PushContext, updates *model.PushRequest,
-	w *model.WatchedResource) (model.Resources, []string, model.XdsLogDetails, bool, error) {
-	res, logs, err := dg.Generate(proxy, push, w, updates)
-	return res, nil, logs, false, err
+	return res, nil, model.DefaultXdsLogDetails, nil
 }

--- a/pilot/pkg/xds/delta.go
+++ b/pilot/pkg/xds/delta.go
@@ -408,13 +408,13 @@ func (s *DiscoveryServer) pushDeltaXds(con *Connection, push *model.PushContext,
 	if w == nil {
 		return nil
 	}
-	gen := s.findGenerator("delta/"+w.TypeUrl, con)
+	gen := s.findGenerator(w.TypeUrl, con)
 	if gen == nil {
 		return nil
 	}
 	t0 := time.Now()
 
-	res, deletedRes, logdata, err := gen.Generate(con.proxy, push, w, req)
+	res, deletedRes, delta, logdata, err := gen.Generate(con.proxy, push, w, req)
 	if err != nil || res == nil {
 		// If we have nothing to send, report that we got an ACK for this version.
 		if s.StatusReporter != nil {
@@ -446,7 +446,7 @@ func (s *DiscoveryServer) pushDeltaXds(con *Connection, push *model.PushContext,
 		Nonce:             nonce(push.LedgerVersion),
 		Resources:         res,
 	}
-	if len(deletedRes) > 0 {
+	if delta {
 		resp.RemovedResources = deletedRes
 	} else {
 		// similar to sotw

--- a/pilot/pkg/xds/delta.go
+++ b/pilot/pkg/xds/delta.go
@@ -408,13 +408,13 @@ func (s *DiscoveryServer) pushDeltaXds(con *Connection, push *model.PushContext,
 	if w == nil {
 		return nil
 	}
-	gen := s.findGenerator(w.TypeUrl, con)
+	gen := s.findGenerator("delta/"+w.TypeUrl, con)
 	if gen == nil {
 		return nil
 	}
 	t0 := time.Now()
 
-	res, deletedRes, logdata, usedDelta, err := gen.GenerateDeltas(con.proxy, push, req, w)
+	res, deletedRes, logdata, err := gen.Generate(con.proxy, push, w, req)
 	if err != nil || res == nil {
 		// If we have nothing to send, report that we got an ACK for this version.
 		if s.StatusReporter != nil {
@@ -446,7 +446,7 @@ func (s *DiscoveryServer) pushDeltaXds(con *Connection, push *model.PushContext,
 		Nonce:             nonce(push.LedgerVersion),
 		Resources:         res,
 	}
-	if usedDelta {
+	if len(deletedRes) > 0 {
 		resp.RemovedResources = deletedRes
 	} else {
 		// similar to sotw

--- a/pilot/pkg/xds/discovery.go
+++ b/pilot/pkg/xds/discovery.go
@@ -555,6 +555,7 @@ func (s *DiscoveryServer) sendPushes(stopCh <-chan struct{}) {
 
 // InitGenerators initializes generators to be used by XdsServer.
 func (s *DiscoveryServer) InitGenerators(env *model.Environment, systemNameSpace string) {
+	// SOTW Xds Generators.
 	edsGen := &EdsGenerator{Server: s}
 	s.StatusGen = NewStatusGen(s)
 	s.Generators[v3.ClusterType] = &CdsGenerator{Server: s}
@@ -564,6 +565,9 @@ func (s *DiscoveryServer) InitGenerators(env *model.Environment, systemNameSpace
 	s.Generators[v3.NameTableType] = &NdsGenerator{Server: s}
 	s.Generators[v3.ExtensionConfigurationType] = &EcdsGenerator{Server: s}
 	s.Generators[v3.ProxyConfigType] = &PcdsGenerator{Server: s, TrustBundle: env.TrustBundle}
+
+	// Delta Xds Generators.
+	s.Generators["delta/"+v3.ClusterType] = &CdsGenerator{Server: s, delta: true}
 
 	s.Generators["grpc"] = &grpcgen.GrpcConfigGenerator{}
 	s.Generators["grpc/"+v3.EndpointType] = edsGen

--- a/pilot/pkg/xds/discovery.go
+++ b/pilot/pkg/xds/discovery.go
@@ -566,9 +566,6 @@ func (s *DiscoveryServer) InitGenerators(env *model.Environment, systemNameSpace
 	s.Generators[v3.ExtensionConfigurationType] = &EcdsGenerator{Server: s}
 	s.Generators[v3.ProxyConfigType] = &PcdsGenerator{Server: s, TrustBundle: env.TrustBundle}
 
-	// Delta Xds Generators.
-	s.Generators["delta/"+v3.ClusterType] = &CdsGenerator{Server: s, delta: true}
-
 	s.Generators["grpc"] = &grpcgen.GrpcConfigGenerator{}
 	s.Generators["grpc/"+v3.EndpointType] = edsGen
 	s.Generators["grpc/"+v3.ListenerType] = s.Generators["grpc"]

--- a/pilot/pkg/xds/ecds.go
+++ b/pilot/pkg/xds/ecds.go
@@ -52,13 +52,13 @@ func ecdsNeedsPush(req *model.PushRequest) bool {
 
 // Generate returns ECDS resources for a given proxy.
 func (e *EcdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource,
-	req *model.PushRequest) (model.Resources, model.DeletedResources, model.XdsLogDetails, error) {
+	req *model.PushRequest) (model.Resources, model.DeletedResources, bool, model.XdsLogDetails, error) {
 	if !ecdsNeedsPush(req) {
-		return nil, nil, model.DefaultXdsLogDetails, nil
+		return nil, nil, false, model.DefaultXdsLogDetails, nil
 	}
 	ec := e.Server.ConfigGenerator.BuildExtensionConfiguration(proxy, push, w.ResourceNames)
 	if ec == nil {
-		return nil, nil, model.DefaultXdsLogDetails, nil
+		return nil, nil, false, model.DefaultXdsLogDetails, nil
 	}
 
 	resources := make(model.Resources, 0, len(ec))
@@ -68,5 +68,5 @@ func (e *EcdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w 
 			Resource: util.MessageToAny(c),
 		})
 	}
-	return resources, nil, model.DefaultXdsLogDetails, nil
+	return resources, nil, false, model.DefaultXdsLogDetails, nil
 }

--- a/pilot/pkg/xds/ecds.go
+++ b/pilot/pkg/xds/ecds.go
@@ -52,13 +52,13 @@ func ecdsNeedsPush(req *model.PushRequest) bool {
 
 // Generate returns ECDS resources for a given proxy.
 func (e *EcdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource,
-	req *model.PushRequest) (model.Resources, model.XdsLogDetails, error) {
+	req *model.PushRequest) (model.Resources, model.DeletedResources, model.XdsLogDetails, error) {
 	if !ecdsNeedsPush(req) {
-		return nil, model.DefaultXdsLogDetails, nil
+		return nil, nil, model.DefaultXdsLogDetails, nil
 	}
 	ec := e.Server.ConfigGenerator.BuildExtensionConfiguration(proxy, push, w.ResourceNames)
 	if ec == nil {
-		return nil, model.DefaultXdsLogDetails, nil
+		return nil, nil, model.DefaultXdsLogDetails, nil
 	}
 
 	resources := make(model.Resources, 0, len(ec))
@@ -68,11 +68,5 @@ func (e *EcdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w 
 			Resource: util.MessageToAny(c),
 		})
 	}
-	return resources, model.DefaultXdsLogDetails, nil
-}
-
-func (e *EcdsGenerator) GenerateDeltas(proxy *model.Proxy, push *model.PushContext, updates *model.PushRequest,
-	w *model.WatchedResource) (model.Resources, []string, model.XdsLogDetails, bool, error) {
-	res, logs, err := e.Generate(proxy, push, w, updates)
-	return res, nil, logs, false, err
+	return resources, nil, model.DefaultXdsLogDetails, nil
 }

--- a/pilot/pkg/xds/eds.go
+++ b/pilot/pkg/xds/eds.go
@@ -374,9 +374,9 @@ func edsNeedsPush(updates model.XdsUpdates) bool {
 }
 
 func (eds *EdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource,
-	req *model.PushRequest) (model.Resources, model.XdsLogDetails, error) {
+	req *model.PushRequest) (model.Resources, model.DeletedResources, model.XdsLogDetails, error) {
 	if !edsNeedsPush(req.ConfigsUpdated) {
-		return nil, model.DefaultXdsLogDetails, nil
+		return nil, nil, model.DefaultXdsLogDetails, nil
 	}
 	var edsUpdatedServices map[string]struct{}
 	if !req.Full {
@@ -419,16 +419,10 @@ func (eds *EdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w
 			eds.Server.Cache.Add(builder, req, resource)
 		}
 	}
-	return resources, model.XdsLogDetails{
+	return resources, nil, model.XdsLogDetails{
 		Incremental:    len(edsUpdatedServices) != 0,
 		AdditionalInfo: fmt.Sprintf("empty:%v cached:%v/%v", empty, cached, cached+regenerated),
 	}, nil
-}
-
-func (eds *EdsGenerator) GenerateDeltas(proxy *model.Proxy, push *model.PushContext, updates *model.PushRequest,
-	w *model.WatchedResource) (model.Resources, []string, model.XdsLogDetails, bool, error) {
-	res, logs, err := eds.Generate(proxy, push, w, updates)
-	return res, nil, logs, false, err
 }
 
 func getOutlierDetectionAndLoadBalancerSettings(

--- a/pilot/pkg/xds/eds.go
+++ b/pilot/pkg/xds/eds.go
@@ -374,9 +374,9 @@ func edsNeedsPush(updates model.XdsUpdates) bool {
 }
 
 func (eds *EdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource,
-	req *model.PushRequest) (model.Resources, model.DeletedResources, model.XdsLogDetails, error) {
+	req *model.PushRequest) (model.Resources, model.DeletedResources, bool, model.XdsLogDetails, error) {
 	if !edsNeedsPush(req.ConfigsUpdated) {
-		return nil, nil, model.DefaultXdsLogDetails, nil
+		return nil, nil, false, model.DefaultXdsLogDetails, nil
 	}
 	var edsUpdatedServices map[string]struct{}
 	if !req.Full {
@@ -419,7 +419,7 @@ func (eds *EdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w
 			eds.Server.Cache.Add(builder, req, resource)
 		}
 	}
-	return resources, nil, model.XdsLogDetails{
+	return resources, nil, false, model.XdsLogDetails{
 		Incremental:    len(edsUpdatedServices) != 0,
 		AdditionalInfo: fmt.Sprintf("empty:%v cached:%v/%v", empty, cached, cached+regenerated),
 	}, nil

--- a/pilot/pkg/xds/lds.go
+++ b/pilot/pkg/xds/lds.go
@@ -57,9 +57,9 @@ func ldsNeedsPush(req *model.PushRequest) bool {
 }
 
 func (l LdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource,
-	req *model.PushRequest) (model.Resources, model.XdsLogDetails, error) {
+	req *model.PushRequest) (model.Resources, model.DeletedResources, model.XdsLogDetails, error) {
 	if !ldsNeedsPush(req) {
-		return nil, model.DefaultXdsLogDetails, nil
+		return nil, nil, model.DefaultXdsLogDetails, nil
 	}
 	listeners := l.Server.ConfigGenerator.BuildListeners(proxy, push)
 	resources := model.Resources{}
@@ -69,11 +69,5 @@ func (l LdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *m
 			Resource: util.MessageToAny(c),
 		})
 	}
-	return resources, model.DefaultXdsLogDetails, nil
-}
-
-func (l *LdsGenerator) GenerateDeltas(proxy *model.Proxy, push *model.PushContext, updates *model.PushRequest,
-	w *model.WatchedResource) (model.Resources, []string, model.XdsLogDetails, bool, error) {
-	res, logs, err := l.Generate(proxy, push, w, updates)
-	return res, nil, logs, false, err
+	return resources, nil, model.DefaultXdsLogDetails, nil
 }

--- a/pilot/pkg/xds/lds.go
+++ b/pilot/pkg/xds/lds.go
@@ -57,9 +57,9 @@ func ldsNeedsPush(req *model.PushRequest) bool {
 }
 
 func (l LdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource,
-	req *model.PushRequest) (model.Resources, model.DeletedResources, model.XdsLogDetails, error) {
+	req *model.PushRequest) (model.Resources, model.DeletedResources, bool, model.XdsLogDetails, error) {
 	if !ldsNeedsPush(req) {
-		return nil, nil, model.DefaultXdsLogDetails, nil
+		return nil, nil, false, model.DefaultXdsLogDetails, nil
 	}
 	listeners := l.Server.ConfigGenerator.BuildListeners(proxy, push)
 	resources := model.Resources{}
@@ -69,5 +69,5 @@ func (l LdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *m
 			Resource: util.MessageToAny(c),
 		})
 	}
-	return resources, nil, model.DefaultXdsLogDetails, nil
+	return resources, nil, false, model.DefaultXdsLogDetails, nil
 }

--- a/pilot/pkg/xds/nds.go
+++ b/pilot/pkg/xds/nds.go
@@ -68,20 +68,14 @@ func ndsNeedsPush(req *model.PushRequest) bool {
 }
 
 func (n NdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource,
-	req *model.PushRequest) (model.Resources, model.XdsLogDetails, error) {
+	req *model.PushRequest) (model.Resources, model.DeletedResources, model.XdsLogDetails, error) {
 	if !ndsNeedsPush(req) {
-		return nil, model.DefaultXdsLogDetails, nil
+		return nil, nil, model.DefaultXdsLogDetails, nil
 	}
 	nt := n.Server.ConfigGenerator.BuildNameTable(proxy, push)
 	if nt == nil {
-		return nil, model.DefaultXdsLogDetails, nil
+		return nil, nil, model.DefaultXdsLogDetails, nil
 	}
 	resources := model.Resources{&discovery.Resource{Resource: util.MessageToAny(nt)}}
-	return resources, model.DefaultXdsLogDetails, nil
-}
-
-func (n *NdsGenerator) GenerateDeltas(proxy *model.Proxy, push *model.PushContext, updates *model.PushRequest,
-	w *model.WatchedResource) (model.Resources, []string, model.XdsLogDetails, bool, error) {
-	res, logs, err := n.Generate(proxy, push, w, updates)
-	return res, nil, logs, false, err
+	return resources, nil, model.DefaultXdsLogDetails, nil
 }

--- a/pilot/pkg/xds/nds.go
+++ b/pilot/pkg/xds/nds.go
@@ -68,14 +68,14 @@ func ndsNeedsPush(req *model.PushRequest) bool {
 }
 
 func (n NdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource,
-	req *model.PushRequest) (model.Resources, model.DeletedResources, model.XdsLogDetails, error) {
+	req *model.PushRequest) (model.Resources, model.DeletedResources, bool, model.XdsLogDetails, error) {
 	if !ndsNeedsPush(req) {
-		return nil, nil, model.DefaultXdsLogDetails, nil
+		return nil, nil, false, model.DefaultXdsLogDetails, nil
 	}
 	nt := n.Server.ConfigGenerator.BuildNameTable(proxy, push)
 	if nt == nil {
-		return nil, nil, model.DefaultXdsLogDetails, nil
+		return nil, nil, false, model.DefaultXdsLogDetails, nil
 	}
 	resources := model.Resources{&discovery.Resource{Resource: util.MessageToAny(nt)}}
-	return resources, nil, model.DefaultXdsLogDetails, nil
+	return resources, nil, false, model.DefaultXdsLogDetails, nil
 }

--- a/pilot/pkg/xds/pcds.go
+++ b/pilot/pkg/xds/pcds.go
@@ -55,22 +55,16 @@ func pcdsNeedsPush(req *model.PushRequest) bool {
 
 // Generate returns ProxyConfig protobuf containing TrustBundle for given proxy
 func (e *PcdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource,
-	req *model.PushRequest) (model.Resources, model.XdsLogDetails, error) {
+	req *model.PushRequest) (model.Resources, model.DeletedResources, model.XdsLogDetails, error) {
 	if !pcdsNeedsPush(req) {
-		return nil, model.DefaultXdsLogDetails, nil
+		return nil, nil, model.DefaultXdsLogDetails, nil
 	}
 	if e.TrustBundle == nil {
-		return nil, model.DefaultXdsLogDetails, nil
+		return nil, nil, model.DefaultXdsLogDetails, nil
 	}
 	// TODO: For now, only TrustBundle updates are pushed. Eventually, this should push entire Proxy Configuration
 	pc := &mesh.ProxyConfig{
 		CaCertificatesPem: e.TrustBundle.GetTrustBundle(),
 	}
-	return model.Resources{&discovery.Resource{Resource: gogo.MessageToAny(pc)}}, model.DefaultXdsLogDetails, nil
-}
-
-func (e *PcdsGenerator) GenerateDeltas(proxy *model.Proxy, push *model.PushContext, updates *model.PushRequest,
-	w *model.WatchedResource) (model.Resources, []string, model.XdsLogDetails, bool, error) {
-	res, logs, err := e.Generate(proxy, push, w, updates)
-	return res, nil, logs, false, err
+	return model.Resources{&discovery.Resource{Resource: gogo.MessageToAny(pc)}}, nil, model.DefaultXdsLogDetails, nil
 }

--- a/pilot/pkg/xds/pcds.go
+++ b/pilot/pkg/xds/pcds.go
@@ -55,16 +55,16 @@ func pcdsNeedsPush(req *model.PushRequest) bool {
 
 // Generate returns ProxyConfig protobuf containing TrustBundle for given proxy
 func (e *PcdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource,
-	req *model.PushRequest) (model.Resources, model.DeletedResources, model.XdsLogDetails, error) {
+	req *model.PushRequest) (model.Resources, model.DeletedResources, bool, model.XdsLogDetails, error) {
 	if !pcdsNeedsPush(req) {
-		return nil, nil, model.DefaultXdsLogDetails, nil
+		return nil, nil, false, model.DefaultXdsLogDetails, nil
 	}
 	if e.TrustBundle == nil {
-		return nil, nil, model.DefaultXdsLogDetails, nil
+		return nil, nil, false, model.DefaultXdsLogDetails, nil
 	}
 	// TODO: For now, only TrustBundle updates are pushed. Eventually, this should push entire Proxy Configuration
 	pc := &mesh.ProxyConfig{
 		CaCertificatesPem: e.TrustBundle.GetTrustBundle(),
 	}
-	return model.Resources{&discovery.Resource{Resource: gogo.MessageToAny(pc)}}, nil, model.DefaultXdsLogDetails, nil
+	return model.Resources{&discovery.Resource{Resource: gogo.MessageToAny(pc)}}, nil, false, model.DefaultXdsLogDetails, nil
 }

--- a/pilot/pkg/xds/rds.go
+++ b/pilot/pkg/xds/rds.go
@@ -60,9 +60,9 @@ func rdsNeedsPush(req *model.PushRequest) bool {
 }
 
 func (c RdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource,
-	req *model.PushRequest) (model.Resources, model.DeletedResources, model.XdsLogDetails, error) {
+	req *model.PushRequest) (model.Resources, model.DeletedResources, bool, model.XdsLogDetails, error) {
 	if !rdsNeedsPush(req) {
-		return nil, nil, model.DefaultXdsLogDetails, nil
+		return nil, nil, false, model.DefaultXdsLogDetails, nil
 	}
 	rawRoutes := c.Server.ConfigGenerator.BuildHTTPRoutes(proxy, push, w.ResourceNames)
 	resources := model.Resources{}
@@ -72,5 +72,5 @@ func (c RdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *m
 			Resource: util.MessageToAny(c),
 		})
 	}
-	return resources, nil, model.DefaultXdsLogDetails, nil
+	return resources, nil, false, model.DefaultXdsLogDetails, nil
 }

--- a/pilot/pkg/xds/rds.go
+++ b/pilot/pkg/xds/rds.go
@@ -60,9 +60,9 @@ func rdsNeedsPush(req *model.PushRequest) bool {
 }
 
 func (c RdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource,
-	req *model.PushRequest) (model.Resources, model.XdsLogDetails, error) {
+	req *model.PushRequest) (model.Resources, model.DeletedResources, model.XdsLogDetails, error) {
 	if !rdsNeedsPush(req) {
-		return nil, model.DefaultXdsLogDetails, nil
+		return nil, nil, model.DefaultXdsLogDetails, nil
 	}
 	rawRoutes := c.Server.ConfigGenerator.BuildHTTPRoutes(proxy, push, w.ResourceNames)
 	resources := model.Resources{}
@@ -72,11 +72,5 @@ func (c RdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *m
 			Resource: util.MessageToAny(c),
 		})
 	}
-	return resources, model.DefaultXdsLogDetails, nil
-}
-
-func (c *RdsGenerator) GenerateDeltas(proxy *model.Proxy, push *model.PushContext, updates *model.PushRequest,
-	w *model.WatchedResource) (model.Resources, []string, model.XdsLogDetails, bool, error) {
-	res, logs, err := c.Generate(proxy, push, w, updates)
-	return res, nil, logs, false, err
+	return resources, nil, model.DefaultXdsLogDetails, nil
 }

--- a/pilot/pkg/xds/sds.go
+++ b/pilot/pkg/xds/sds.go
@@ -148,13 +148,13 @@ func getAuthorizationMode(resources []SecretResource, proxy *model.Proxy) Author
 }
 
 func (s *SecretGen) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource,
-	req *model.PushRequest) (model.Resources, model.XdsLogDetails, error) {
+	req *model.PushRequest) (model.Resources, model.DeletedResources, model.XdsLogDetails, error) {
 	if proxy.VerifiedIdentity == nil {
 		log.Warnf("proxy %v is not authorized to receive secrets. Ensure you are connecting over TLS port and are authenticated.", proxy.ID)
-		return nil, model.DefaultXdsLogDetails, nil
+		return nil, nil, model.DefaultXdsLogDetails, nil
 	}
 	if req == nil || !needsUpdate(proxy, req.ConfigsUpdated) {
-		return nil, model.DefaultXdsLogDetails, nil
+		return nil, nil, model.DefaultXdsLogDetails, nil
 	}
 	var updatedSecrets map[model.ConfigKey]struct{}
 	if !req.Full {
@@ -166,7 +166,7 @@ func (s *SecretGen) Generate(proxy *model.Proxy, push *model.PushContext, w *mod
 	if err != nil {
 		log.Warnf("proxy %v is from an unknown cluster, cannot retrieve certificates: %v", proxy.ID, err)
 		pilotSDSCertificateErrors.Increment()
-		return nil, model.DefaultXdsLogDetails, nil
+		return nil, nil, model.DefaultXdsLogDetails, nil
 	}
 
 	resources := parseResources(w.ResourceNames, proxy)
@@ -175,7 +175,7 @@ func (s *SecretGen) Generate(proxy *model.Proxy, push *model.PushContext, w *mod
 		if err := secrets.Authorize(proxy.VerifiedIdentity.ServiceAccount, proxy.VerifiedIdentity.Namespace); err != nil {
 			log.Warnf("proxy %v is not authorized to receive secrets: %v", proxy.ID, err)
 			pilotSDSCertificateErrors.Increment()
-			return nil, model.DefaultXdsLogDetails, nil
+			return nil, nil, model.DefaultXdsLogDetails, nil
 		}
 	}
 
@@ -223,13 +223,7 @@ func (s *SecretGen) Generate(proxy *model.Proxy, push *model.PushContext, w *mod
 			}
 		}
 	}
-	return results, model.XdsLogDetails{AdditionalInfo: fmt.Sprintf("cached:%v/%v", cached, cached+regenerated)}, nil
-}
-
-func (s *SecretGen) GenerateDeltas(proxy *model.Proxy, push *model.PushContext, updates *model.PushRequest,
-	w *model.WatchedResource) (model.Resources, []string, model.XdsLogDetails, bool, error) {
-	res, logs, err := s.Generate(proxy, push, w, updates)
-	return res, nil, logs, false, err
+	return results, nil, model.XdsLogDetails{AdditionalInfo: fmt.Sprintf("cached:%v/%v", cached, cached+regenerated)}, nil
 }
 
 func toEnvoyCaSecret(name string, cert []byte) *discovery.Resource {

--- a/pilot/pkg/xds/sds_test.go
+++ b/pilot/pkg/xds/sds_test.go
@@ -322,7 +322,7 @@ func TestGenerate(t *testing.T) {
 
 			gen := s.Discovery.Generators[v3.SecretType]
 			tt.request.Start = time.Now()
-			secrets, _, _, _ := gen.Generate(s.SetupProxy(tt.proxy), s.PushContext(),
+			secrets, _, _, _, _ := gen.Generate(s.SetupProxy(tt.proxy), s.PushContext(),
 				&model.WatchedResource{ResourceNames: tt.resources}, tt.request)
 			raw := xdstest.ExtractTLSSecrets(t, model.ResourcesToAny(secrets))
 
@@ -358,7 +358,7 @@ func TestCaching(t *testing.T) {
 	istiosystem := &model.Proxy{VerifiedIdentity: &spiffe.Identity{Namespace: "istio-system"}, Type: model.Router, ConfigNamespace: "istio-system"}
 	otherNamespace := &model.Proxy{VerifiedIdentity: &spiffe.Identity{Namespace: "other-namespace"}, Type: model.Router, ConfigNamespace: "other-namespace"}
 
-	secrets, _, _, _ := gen.Generate(s.SetupProxy(istiosystem), s.PushContext(),
+	secrets, _, _, _, _ := gen.Generate(s.SetupProxy(istiosystem), s.PushContext(),
 		&model.WatchedResource{ResourceNames: []string{"kubernetes://generic"}}, fullPush)
 	raw := xdstest.ExtractTLSSecrets(t, model.ResourcesToAny(secrets))
 	if len(raw) != 1 {
@@ -366,7 +366,7 @@ func TestCaching(t *testing.T) {
 	}
 
 	// We should not get secret returned, even though we are asking for the same one
-	secrets, _, _, _ = gen.Generate(s.SetupProxy(otherNamespace), s.PushContext(),
+	secrets, _, _, _, _ = gen.Generate(s.SetupProxy(otherNamespace), s.PushContext(),
 		&model.WatchedResource{ResourceNames: []string{"kubernetes://generic"}}, fullPush)
 	raw = xdstest.ExtractTLSSecrets(t, model.ResourcesToAny(secrets))
 	if len(raw) != 0 {

--- a/pilot/pkg/xds/sds_test.go
+++ b/pilot/pkg/xds/sds_test.go
@@ -322,7 +322,7 @@ func TestGenerate(t *testing.T) {
 
 			gen := s.Discovery.Generators[v3.SecretType]
 			tt.request.Start = time.Now()
-			secrets, _, _ := gen.Generate(s.SetupProxy(tt.proxy), s.PushContext(),
+			secrets, _, _, _ := gen.Generate(s.SetupProxy(tt.proxy), s.PushContext(),
 				&model.WatchedResource{ResourceNames: tt.resources}, tt.request)
 			raw := xdstest.ExtractTLSSecrets(t, model.ResourcesToAny(secrets))
 
@@ -358,7 +358,7 @@ func TestCaching(t *testing.T) {
 	istiosystem := &model.Proxy{VerifiedIdentity: &spiffe.Identity{Namespace: "istio-system"}, Type: model.Router, ConfigNamespace: "istio-system"}
 	otherNamespace := &model.Proxy{VerifiedIdentity: &spiffe.Identity{Namespace: "other-namespace"}, Type: model.Router, ConfigNamespace: "other-namespace"}
 
-	secrets, _, _ := gen.Generate(s.SetupProxy(istiosystem), s.PushContext(),
+	secrets, _, _, _ := gen.Generate(s.SetupProxy(istiosystem), s.PushContext(),
 		&model.WatchedResource{ResourceNames: []string{"kubernetes://generic"}}, fullPush)
 	raw := xdstest.ExtractTLSSecrets(t, model.ResourcesToAny(secrets))
 	if len(raw) != 1 {
@@ -366,7 +366,7 @@ func TestCaching(t *testing.T) {
 	}
 
 	// We should not get secret returned, even though we are asking for the same one
-	secrets, _, _ = gen.Generate(s.SetupProxy(otherNamespace), s.PushContext(),
+	secrets, _, _, _ = gen.Generate(s.SetupProxy(otherNamespace), s.PushContext(),
 		&model.WatchedResource{ResourceNames: []string{"kubernetes://generic"}}, fullPush)
 	raw = xdstest.ExtractTLSSecrets(t, model.ResourcesToAny(secrets))
 	if len(raw) != 0 {

--- a/pilot/pkg/xds/statusgen.go
+++ b/pilot/pkg/xds/statusgen.go
@@ -68,7 +68,7 @@ func NewStatusGen(s *DiscoveryServer) *StatusGen {
 // - NACKs
 // We can also expose ACKS.
 func (sg *StatusGen) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource,
-	updates *model.PushRequest) (model.Resources, model.DeletedResources, model.XdsLogDetails, error) {
+	updates *model.PushRequest) (model.Resources, model.DeletedResources, bool, model.XdsLogDetails, error) {
 	res := model.Resources{}
 
 	switch w.TypeUrl {
@@ -94,7 +94,7 @@ func (sg *StatusGen) Generate(proxy *model.Proxy, push *model.PushContext, w *mo
 			break
 		}
 	}
-	return res, nil, model.DefaultXdsLogDetails, nil
+	return res, nil, false, model.DefaultXdsLogDetails, nil
 }
 
 // isSidecar ad-hoc method to see if connection represents a sidecar

--- a/pilot/pkg/xds/statusgen.go
+++ b/pilot/pkg/xds/statusgen.go
@@ -68,7 +68,7 @@ func NewStatusGen(s *DiscoveryServer) *StatusGen {
 // - NACKs
 // We can also expose ACKS.
 func (sg *StatusGen) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource,
-	updates *model.PushRequest) (model.Resources, model.XdsLogDetails, error) {
+	updates *model.PushRequest) (model.Resources, model.DeletedResources, model.XdsLogDetails, error) {
 	res := model.Resources{}
 
 	switch w.TypeUrl {
@@ -94,13 +94,7 @@ func (sg *StatusGen) Generate(proxy *model.Proxy, push *model.PushContext, w *mo
 			break
 		}
 	}
-	return res, model.DefaultXdsLogDetails, nil
-}
-
-func (sg *StatusGen) GenerateDeltas(proxy *model.Proxy, push *model.PushContext, updates *model.PushRequest,
-	w *model.WatchedResource) (model.Resources, []string, model.XdsLogDetails, bool, error) {
-	res, logs, err := sg.Generate(proxy, push, w, updates)
-	return res, nil, logs, false, err
+	return res, nil, model.DefaultXdsLogDetails, nil
 }
 
 // isSidecar ad-hoc method to see if connection represents a sidecar

--- a/pilot/pkg/xds/xdsgen.go
+++ b/pilot/pkg/xds/xdsgen.go
@@ -98,7 +98,7 @@ func (s *DiscoveryServer) pushXds(con *Connection, push *model.PushContext,
 
 	t0 := time.Now()
 
-	res, _, logdata, err := gen.Generate(con.proxy, push, w, req)
+	res, _, _, logdata, err := gen.Generate(con.proxy, push, w, req)
 	if err != nil || res == nil {
 		// If we have nothing to send, report that we got an ACK for this version.
 		if s.StatusReporter != nil {

--- a/pilot/pkg/xds/xdsgen.go
+++ b/pilot/pkg/xds/xdsgen.go
@@ -98,7 +98,7 @@ func (s *DiscoveryServer) pushXds(con *Connection, push *model.PushContext,
 
 	t0 := time.Now()
 
-	res, logdata, err := gen.Generate(con.proxy, push, w, req)
+	res, _, logdata, err := gen.Generate(con.proxy, push, w, req)
 	if err != nil || res == nil {
 		// If we have nothing to send, report that we got an ACK for this version.
 		if s.StatusReporter != nil {

--- a/security/pkg/nodeagent/sds/sdsservice.go
+++ b/security/pkg/nodeagent/sds/sdsservice.go
@@ -157,13 +157,13 @@ func (s *sdsservice) generate(resourceNames []string) (model.Resources, error) {
 // Generate implements the XDS Generator interface. This allows the XDS server to dispatch requests
 // for SecretTypeV3 to our server to generate the Envoy response.
 func (s *sdsservice) Generate(_ *model.Proxy, _ *model.PushContext, w *model.WatchedResource,
-	updates *model.PushRequest) (model.Resources, model.DeletedResources, model.XdsLogDetails, error) {
+	updates *model.PushRequest) (model.Resources, model.DeletedResources, bool, model.XdsLogDetails, error) {
 	// updates.Full indicates we should do a complete push of all updated resources
 	// In practice, all pushes should be incremental (ie, if the `default` cert changes we won't push
 	// all file certs).
 	if updates.Full {
 		resp, err := s.generate(w.ResourceNames)
-		return resp, nil, pushLog(w.ResourceNames), err
+		return resp, nil, false, pushLog(w.ResourceNames), err
 	}
 	names := []string{}
 	watched := sets.NewSet(w.ResourceNames...)
@@ -173,7 +173,7 @@ func (s *sdsservice) Generate(_ *model.Proxy, _ *model.PushContext, w *model.Wat
 		}
 	}
 	resp, err := s.generate(names)
-	return resp, nil, pushLog(names), err
+	return resp, nil, false, pushLog(names), err
 }
 
 // register adds the SDS handle to the grpc server

--- a/security/pkg/nodeagent/sds/sdsservice.go
+++ b/security/pkg/nodeagent/sds/sdsservice.go
@@ -157,13 +157,13 @@ func (s *sdsservice) generate(resourceNames []string) (model.Resources, error) {
 // Generate implements the XDS Generator interface. This allows the XDS server to dispatch requests
 // for SecretTypeV3 to our server to generate the Envoy response.
 func (s *sdsservice) Generate(_ *model.Proxy, _ *model.PushContext, w *model.WatchedResource,
-	updates *model.PushRequest) (model.Resources, model.XdsLogDetails, error) {
+	updates *model.PushRequest) (model.Resources, model.DeletedResources, model.XdsLogDetails, error) {
 	// updates.Full indicates we should do a complete push of all updated resources
 	// In practice, all pushes should be incremental (ie, if the `default` cert changes we won't push
 	// all file certs).
 	if updates.Full {
 		resp, err := s.generate(w.ResourceNames)
-		return resp, pushLog(w.ResourceNames), err
+		return resp, nil, pushLog(w.ResourceNames), err
 	}
 	names := []string{}
 	watched := sets.NewSet(w.ResourceNames...)
@@ -173,13 +173,7 @@ func (s *sdsservice) Generate(_ *model.Proxy, _ *model.PushContext, w *model.Wat
 		}
 	}
 	resp, err := s.generate(names)
-	return resp, pushLog(names), err
-}
-
-func (s *sdsservice) GenerateDeltas(proxy *model.Proxy, push *model.PushContext, updates *model.PushRequest,
-	w *model.WatchedResource) (model.Resources, []string, model.XdsLogDetails, bool, error) {
-	res, logs, err := s.Generate(proxy, push, w, updates)
-	return res, nil, logs, false, err
+	return resp, nil, pushLog(names), err
 }
 
 // register adds the SDS handle to the grpc server


### PR DESCRIPTION
This PR does the following
- Removes `GenerateDeltas` - I did not see a need for it. It is actually lot of boiler plate and many generates do not care about it. Changed the existing `Generate` signature to return `DeletedResources` also which will be used in case of incremental Xds like Delta
- Removed `usedDelta` flag that indicates whether deltas have been actually used. All we care about is whether there are removedResources. We can just rely on length of removedResources
- Refactor buildCluster logic so that is used by both `BuildClusters` and `BuildDeltaClusters`
- Some other minor refactors to simplify the code.

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [X ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
