### PR TITLE
Remove expose Services DestinationRule method from SidecarScope in ca…

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -658,7 +658,7 @@ func (ps *PushContext) Services(proxy *Proxy) []*Service {
 	// If proxy has a sidecar scope that is user supplied, then get the services from the sidecar scope
 	// sidecarScope.config is nil if there is no sidecar scope for the namespace
 	if proxy != nil && proxy.SidecarScope != nil && proxy.Type == SidecarProxy {
-		return proxy.SidecarScope.Services()
+		return proxy.SidecarScope.services
 	}
 
 	out := make([]*Service, 0)
@@ -791,7 +791,7 @@ func (ps *PushContext) DestinationRule(proxy *Proxy, service *Service) *config.C
 	if proxy.SidecarScope != nil && proxy.Type == SidecarProxy {
 		// If there is a sidecar scope for this proxy, return the destination rule
 		// from the sidecar scope.
-		return proxy.SidecarScope.DestinationRule(service.Hostname)
+		return proxy.SidecarScope.destinationRules[service.Hostname]
 	}
 
 	// If the proxy config namespace is same as the root config namespace

--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -463,32 +463,6 @@ func convertIstioListenerToWrapper(ps *PushContext, configNamespace string,
 	return out
 }
 
-// Services returns the list of services imported across all egress listeners by this
-// Sidecar config
-func (sc *SidecarScope) Services() []*Service {
-	if sc == nil {
-		return nil
-	}
-	return sc.services
-}
-
-func (sc *SidecarScope) Service(serviceHostname host.Name) *Service {
-	if sc == nil {
-		return nil
-	}
-	return sc.servicesByHostname[serviceHostname]
-}
-
-// DestinationRule returns the destination rule applicable for a given hostname
-// used by CDS code
-func (sc *SidecarScope) DestinationRule(hostname host.Name) *config.Config {
-	if sc == nil {
-		return nil
-	}
-
-	return sc.destinationRules[hostname]
-}
-
 // GetEgressListenerForRDS returns the egress listener corresponding to
 // the listener port or the bind address or the catch all listener
 func (sc *SidecarScope) GetEgressListenerForRDS(port int, bind string) *IstioEgressListenerWrapper {


### PR DESCRIPTION
…se misuse them in generators

**Please provide a description of this PR:**

It is very easy to be misused, originally these methods are intended to be called to initialize push context. 



**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
