### PR TITLE
replace SubstitutionFormatString_TextFormat(deprecated) to SubstitutionFormatString_TextFormatSource for the accessLogFormat

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/accesslog.go
+++ b/pilot/pkg/networking/core/v1alpha3/accesslog.go
@@ -233,8 +233,12 @@ func buildFileAccessLogHelper(path string, mesh *meshconfig.MeshConfig) *accessl
 		}
 		fl.AccessLogFormat = &fileaccesslog.FileAccessLog_LogFormat{
 			LogFormat: &core.SubstitutionFormatString{
-				Format: &core.SubstitutionFormatString_TextFormat{
-					TextFormat: formatString,
+				Format: &core.SubstitutionFormatString_TextFormatSource{
+					TextFormatSource: &core.DataSource{
+						Specifier: &core.DataSource_InlineString{
+							InlineString: formatString,
+						},
+					},
 				},
 			},
 		}

--- a/pilot/pkg/networking/core/v1alpha3/accesslog_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/accesslog_test.go
@@ -142,7 +142,8 @@ func verify(t *testing.T, encoding meshconfig.MeshConfig_AccessLogEncoding, got 
 			t.Errorf("\nwant: %s\n got: %s", wantFormat, jsonFormatString)
 		}
 	} else {
-		textFormatString := cfg.GetFields()["log_format"].GetStructValue().GetFields()["text_format"].GetStringValue()
+		textFormatString := cfg.GetFields()["log_format"].GetStructValue().GetFields()["text_format_source"].GetStructValue().
+			GetFields()["inline_string"].GetStringValue()
 		if textFormatString != wantFormat {
 			t.Errorf("\nwant: %s\n got: %s", wantFormat, textFormatString)
 		}

--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -1592,7 +1592,8 @@ func TestListenerAccessLogs(t *testing.T) {
 			t.Fatal("expected filter config in listener access log configuration")
 		}
 		cfg, _ := conversion.MessageToStruct(l.AccessLog[0].GetTypedConfig())
-		textFormat := cfg.GetFields()["log_format"].GetStructValue().GetFields()["text_format"].GetStringValue()
+		textFormat := cfg.GetFields()["log_format"].GetStructValue().GetFields()["text_format_source"].GetStructValue().
+			GetFields()["inline_string"].GetStringValue()
 		if textFormat != env.Mesh().AccessLogFormat {
 			t.Fatalf("expected format to be %s, but got %s", env.Mesh().AccessLogFormat, textFormat)
 		}
@@ -1609,7 +1610,8 @@ func validateAccessLog(t *testing.T, l *listener.Listener, format string) {
 		t.Fatal("expected access log configuration")
 	}
 	cfg, _ := conversion.MessageToStruct(fc.AccessLog[0].GetTypedConfig())
-	textFormat := cfg.GetFields()["log_format"].GetStructValue().GetFields()["text_format"].GetStringValue()
+	textFormat := cfg.GetFields()["log_format"].GetStructValue().GetFields()["text_format_source"].GetStructValue().
+		GetFields()["inline_string"].GetStringValue()
 	if textFormat != format {
 		t.Fatalf("expected format to be %s, but got %s", format, textFormat)
 	}

--- a/releasenotes/notes/34468.yaml
+++ b/releasenotes/notes/34468.yaml
@@ -1,6 +1,6 @@
 apiVersion: release-notes/v2
 kind: bug-fix
-area: networking
+area: installation
 issue:
   - 34466
 releaseNotes:

--- a/releasenotes/notes/34468.yaml
+++ b/releasenotes/notes/34468.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: networking
+issue:
+  - 34466
+releaseNotes:
+  - |
+    **Fixed** `meshConfig.accessLogFormat` field doesn't work.

--- a/releasenotes/notes/34468.yaml
+++ b/releasenotes/notes/34468.yaml
@@ -1,8 +1,6 @@
 apiVersion: release-notes/v2
 kind: bug-fix
 area: installation
-issue:
-  - 34466
 releaseNotes:
   - |
-    **Fixed** `meshConfig.accessLogFormat` field doesn't work.
+    **Fixed** the old `meshConfig.accessLogFormat` syntax deprecated in Enovy v1.17.0

--- a/releasenotes/notes/34468.yaml
+++ b/releasenotes/notes/34468.yaml
@@ -1,6 +1,0 @@
-apiVersion: release-notes/v2
-kind: bug-fix
-area: installation
-releaseNotes:
-  - |
-    **Fixed** the old `meshConfig.accessLogFormat` syntax deprecated in Enovy v1.17.0


### PR DESCRIPTION
After reading the issue #34466, I found that the `SubstitutionFormatString_TextFormat` has been deprecated in Envoy v1.17.0 in favor of `SubstitutionFormatString_TextFormatSource`. This PR is to move the old syntax format to the newer API version.


- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [x] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
