### PR TITLE
Require min Istio version 1.11 to deploy Delta app

### DIFF
--- a/tests/integration/pilot/common/apps.go
+++ b/tests/integration/pilot/common/apps.go
@@ -224,7 +224,8 @@ func SetupApps(t resource.Context, i istio.Instance, apps *EchoDeployments) erro
 			WorkloadOnlyPorts: common.WorkloadPorts,
 		})
 
-	if !t.Settings().SkipDelta {
+	skipDelta := t.Settings().SkipDelta || t.Settings().Revisions.Minimum().Compare("1.10") > 0
+	if skipDelta {
 		builder = builder.
 			WithConfig(echo.Config{
 				Service:   DeltaSvc,
@@ -275,7 +276,7 @@ func SetupApps(t resource.Context, i istio.Instance, apps *EchoDeployments) erro
 	if !t.Settings().SkipVM {
 		apps.VM = echos.Match(echo.Service(VMSvc))
 	}
-	if !t.Settings().SkipDelta {
+	if skipDelta {
 		apps.DeltaXDS = echos.Match(echo.Service(DeltaSvc))
 	}
 


### PR DESCRIPTION
Having `ISTIO_DELTA_XDS` enabled prior to version 1.10 causes the Delta deployment to hang.

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [x] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
