### PR TITLE
add kind configuration with `MixedProtocolLBService` feature flag turned on

### DIFF
--- a/prow/config/mixedlb-service.yaml
+++ b/prow/config/mixedlb-service.yaml
@@ -1,0 +1,25 @@
+# This configs KinD to spin up a k8s cluster with mixed protocol LB support
+# This should be used to create K8s clusters with versions >= 1.20
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+featureGates:
+  MixedProtocolLBService: true
+  EndpointSlice: true
+kubeadmConfigPatches:
+  - |
+    apiVersion: kubeadm.k8s.io/v1beta2
+    kind: ClusterConfiguration
+    metadata:
+      name: config
+    etcd:
+      local:
+        # Run etcd in a tmpfs (in RAM) for performance improvements
+        dataDir: /tmp/kind-cluster-etcd
+    apiServer:
+      extraArgs:
+        "service-account-issuer": "kubernetes.default.svc"
+        "service-account-signing-key-file": "/etc/kubernetes/pki/sa.key"
+containerdConfigPatches:
+  - |-
+    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5000"]
+      endpoint = ["http://kind-registry:5000"]


### PR DESCRIPTION
Signed-off-by: su225 <suchithjn22@gmail.com>

**Please provide a description of this PR:**
Required for https://github.com/istio/istio/pull/33817

Updating existing configurations break post-submit test as `MixedProtocolLBService` feature gate was introduced in Kubernetes in 1.20 as documented [here](https://kubernetes.io/docs/concepts/services-networking/service/#load-balancers-with-mixed-protocol-types). So test infra should be updated to use this configuration for K8s >= 1.20.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [X] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure