### PR TITLE
respect cert TTL in client side for k8s RA

### DIFF
--- a/pilot/pkg/bootstrap/certcontroller.go
+++ b/pilot/pkg/bootstrap/certcontroller.go
@@ -114,7 +114,7 @@ func (s *Server) initDNSCerts(hostname, namespace string) error {
 	if features.PilotCertProvider == constants.CertProviderKubernetes {
 		log.Infof("Generating K8S-signed cert for %v", s.dnsNames)
 		certChain, keyPEM, _, err = chiron.GenKeyCertK8sCA(s.kubeClient,
-			strings.Join(s.dnsNames, ","), hostnamePrefix+".csr.secret", namespace, defaultCACertPath, "", true)
+			strings.Join(s.dnsNames, ","), hostnamePrefix+".csr.secret", namespace, defaultCACertPath, "", true, SelfSignedCACertTTL.Get())
 		if err != nil {
 			return fmt.Errorf("failed generating key and cert by kubernetes: %v", err)
 		}

--- a/pkg/config/constants/constants.go
+++ b/pkg/config/constants/constants.go
@@ -125,4 +125,6 @@ const (
 	// CertProviderNone does not create any certificates for the control plane. It is assumed that some external
 	// load balancer, such as an Istio Gateway, is terminating the TLS.
 	CertProviderNone = "none"
+
+	RequestLifeTimeAnnotationForCertManager = "experimental.cert-manager.io/request-duration"
 )

--- a/pkg/config/constants/constants.go
+++ b/pkg/config/constants/constants.go
@@ -125,6 +125,4 @@ const (
 	// CertProviderNone does not create any certificates for the control plane. It is assumed that some external
 	// load balancer, such as an Istio Gateway, is terminating the TLS.
 	CertProviderNone = "none"
-
-	RequestLifeTimeAnnotationForCertManager = "experimental.cert-manager.io/request-duration"
 )

--- a/pkg/test/csrctrl/controllers/csr_controller.go
+++ b/pkg/test/csrctrl/controllers/csr_controller.go
@@ -25,6 +25,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/test/csrctrl/signer"
 	"istio.io/istio/security/pkg/pki/util"
 	"istio.io/pkg/log"
@@ -76,7 +77,15 @@ func (r *CertificateSigningRequestSigningReconciler) Reconcile(_ context.Context
 		if signer, ok = r.Signers[csr.Spec.SignerName]; !ok {
 			return ctrl.Result{}, fmt.Errorf("error no signer can sign this csr: %v", err)
 		}
-		cert, err := signer.Sign(x509cr, csr.Spec.Usages)
+		requestedLifeTime := signer.CertTTL
+		requestedDuration, ok := csr.Annotations[constants.RequestLifeTimeAnnotationForCertManager]
+		if ok {
+			duration, err := time.ParseDuration(requestedDuration)
+			if err == nil {
+				requestedLifeTime = duration
+			}
+		}
+		cert, err := signer.Sign(x509cr, csr.Spec.Usages, requestedLifeTime)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("error auto signing csr: %v", err)
 		}

--- a/pkg/test/csrctrl/controllers/csr_controller.go
+++ b/pkg/test/csrctrl/controllers/csr_controller.go
@@ -25,8 +25,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/test/csrctrl/signer"
+	"istio.io/istio/security/pkg/k8s/chiron"
 	"istio.io/istio/security/pkg/pki/util"
 	"istio.io/pkg/log"
 )
@@ -78,7 +78,7 @@ func (r *CertificateSigningRequestSigningReconciler) Reconcile(_ context.Context
 			return ctrl.Result{}, fmt.Errorf("error no signer can sign this csr: %v", err)
 		}
 		requestedLifeTime := signer.CertTTL
-		requestedDuration, ok := csr.Annotations[constants.RequestLifeTimeAnnotationForCertManager]
+		requestedDuration, ok := csr.Annotations[chiron.RequestLifeTimeAnnotationForCertManager]
 		if ok {
 			duration, err := time.ParseDuration(requestedDuration)
 			if err == nil {

--- a/pkg/test/csrctrl/signer/signer.go
+++ b/pkg/test/csrctrl/signer/signer.go
@@ -30,7 +30,7 @@ import (
 
 type Signer struct {
 	caProvider *caProvider
-	certTTL    time.Duration
+	CertTTL    time.Duration
 }
 
 func NewSigner(signerRoot, signerName string, certificateDuration time.Duration) (*Signer, error) {
@@ -41,18 +41,18 @@ func NewSigner(signerRoot, signerName string, certificateDuration time.Duration)
 
 	ret := &Signer{
 		caProvider: caProvider,
-		certTTL:    certificateDuration,
+		CertTTL:    certificateDuration,
 	}
 	return ret, nil
 }
 
-func (s *Signer) Sign(x509cr *x509.CertificateRequest, usages []capi.KeyUsage) ([]byte, error) {
+func (s *Signer) Sign(x509cr *x509.CertificateRequest, usages []capi.KeyUsage, requestedLifetime time.Duration) ([]byte, error) {
 	currCA, err := s.caProvider.currentCA()
 	if err != nil {
 		return nil, err
 	}
 	der, err := currCA.Sign(x509cr.Raw, authority.PermissiveSigningPolicy{
-		TTL:    s.certTTL,
+		TTL:    requestedLifetime,
 		Usages: usages,
 	})
 	if err != nil {

--- a/security/pkg/k8s/chiron/controller.go
+++ b/security/pkg/k8s/chiron/controller.go
@@ -205,8 +205,9 @@ func (wc *WebhookController) upsertSecret(secretName, dnsName, secretNamespace s
 		return nil
 	}
 
+	requestedLifetime := time.Duration(0)
 	// Now we know the secret does not exist yet. So we create a new one.
-	chain, key, caCert, err := GenKeyCertK8sCA(wc.clientset, dnsName, secretName, secretNamespace, wc.k8sCaCertFile, wc.certIssuer, true)
+	chain, key, caCert, err := GenKeyCertK8sCA(wc.clientset, dnsName, secretName, secretNamespace, wc.k8sCaCertFile, wc.certIssuer, true, requestedLifetime)
 	if err != nil {
 		log.Errorf("failed to generate key and certificate for secret %v in namespace %v (error %v)",
 			secretName, secretNamespace, err)
@@ -327,7 +328,8 @@ func (wc *WebhookController) refreshSecret(scrt *v1.Secret) error {
 		return fmt.Errorf("failed to find the service name for the secret (%v) to refresh", scrtName)
 	}
 
-	chain, key, caCert, err := GenKeyCertK8sCA(wc.clientset, dnsName, scrtName, namespace, wc.k8sCaCertFile, wc.certIssuer, true)
+	requestedLifetime := time.Duration(0)
+	chain, key, caCert, err := GenKeyCertK8sCA(wc.clientset, dnsName, scrtName, namespace, wc.k8sCaCertFile, wc.certIssuer, true, requestedLifetime)
 	if err != nil {
 		return err
 	}

--- a/security/pkg/k8s/chiron/utils.go
+++ b/security/pkg/k8s/chiron/utils.go
@@ -35,7 +35,6 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	clientset "k8s.io/client-go/kubernetes"
 
-	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/security/pkg/pki/util"
 	"istio.io/pkg/log"
 )
@@ -43,6 +42,8 @@ import (
 const (
 	randomLength  = 18
 	csrRetriesMax = 3
+	// cert-manager use below annotation on kubernetes CSR to control TTL for the generated cert.
+	RequestLifeTimeAnnotationForCertManager = "experimental.cert-manager.io/request-duration"
 )
 
 type CsrNameGenerator func(string, string) string
@@ -214,7 +215,7 @@ func submitCSR(clientset clientset.Interface,
 				},
 			}
 			if requestedLifetime != time.Duration(0) {
-				csr.ObjectMeta.Annotations = map[string]string{constants.RequestLifeTimeAnnotationForCertManager: requestedLifetime.String()}
+				csr.ObjectMeta.Annotations = map[string]string{RequestLifeTimeAnnotationForCertManager: requestedLifetime.String()}
 			}
 			v1req, err := clientset.CertificatesV1().CertificateSigningRequests().Create(context.TODO(), csr, metav1.CreateOptions{})
 			if err == nil {
@@ -245,7 +246,7 @@ func submitCSR(clientset clientset.Interface,
 			v1beta1csr.Spec.Usages = append(v1beta1csr.Spec.Usages, certv1beta1.KeyUsage(usage))
 		}
 		if requestedLifetime != time.Duration(0) {
-			v1beta1csr.ObjectMeta.Annotations = map[string]string{constants.RequestLifeTimeAnnotationForCertManager: requestedLifetime.String()}
+			v1beta1csr.ObjectMeta.Annotations = map[string]string{RequestLifeTimeAnnotationForCertManager: requestedLifetime.String()}
 		}
 		// create v1beta1 certificate request
 		v1beta1req, err := clientset.CertificatesV1beta1().CertificateSigningRequests().Create(context.TODO(), v1beta1csr, metav1.CreateOptions{})

--- a/security/pkg/k8s/chiron/utils.go
+++ b/security/pkg/k8s/chiron/utils.go
@@ -214,7 +214,7 @@ func submitCSR(clientset clientset.Interface,
 				},
 			}
 			if requestedLifetime.String() != "0s" {
-				csr.ObjectMeta.Annotations = map[string]string{constants.RequestLifeTimeAnnotationForCertManager:requestedLifetime.String()}
+				csr.ObjectMeta.Annotations = map[string]string{constants.RequestLifeTimeAnnotationForCertManager: requestedLifetime.String()}
 			}
 			v1req, err := clientset.CertificatesV1().CertificateSigningRequests().Create(context.TODO(), csr, metav1.CreateOptions{})
 			if err == nil {
@@ -245,7 +245,7 @@ func submitCSR(clientset clientset.Interface,
 			v1beta1csr.Spec.Usages = append(v1beta1csr.Spec.Usages, certv1beta1.KeyUsage(usage))
 		}
 		if requestedLifetime.String() != "0s" {
-			v1beta1csr.ObjectMeta.Annotations = map[string]string{constants.RequestLifeTimeAnnotationForCertManager:requestedLifetime.String()}
+			v1beta1csr.ObjectMeta.Annotations = map[string]string{constants.RequestLifeTimeAnnotationForCertManager: requestedLifetime.String()}
 		}
 		// create v1beta1 certificate request
 		v1beta1req, err := clientset.CertificatesV1beta1().CertificateSigningRequests().Create(context.TODO(), v1beta1csr, metav1.CreateOptions{})

--- a/security/pkg/k8s/chiron/utils.go
+++ b/security/pkg/k8s/chiron/utils.go
@@ -213,7 +213,7 @@ func submitCSR(clientset clientset.Interface,
 					SignerName: signerName,
 				},
 			}
-			if requestedLifetime.String() != "0s" {
+			if requestedLifetime != time.Duration(0) {
 				csr.ObjectMeta.Annotations = map[string]string{constants.RequestLifeTimeAnnotationForCertManager: requestedLifetime.String()}
 			}
 			v1req, err := clientset.CertificatesV1().CertificateSigningRequests().Create(context.TODO(), csr, metav1.CreateOptions{})
@@ -244,7 +244,7 @@ func submitCSR(clientset clientset.Interface,
 		for _, usage := range usages {
 			v1beta1csr.Spec.Usages = append(v1beta1csr.Spec.Usages, certv1beta1.KeyUsage(usage))
 		}
-		if requestedLifetime.String() != "0s" {
+		if requestedLifetime != time.Duration(0) {
 			v1beta1csr.ObjectMeta.Annotations = map[string]string{constants.RequestLifeTimeAnnotationForCertManager: requestedLifetime.String()}
 		}
 		// create v1beta1 certificate request

--- a/security/pkg/k8s/chiron/utils_test.go
+++ b/security/pkg/k8s/chiron/utils_test.go
@@ -74,6 +74,7 @@ SpAJos6OfJqyok7JXDdOYRDD5/hBerj68R9llWzNJd27/1jZ0NF2sIE1W4QFddy/
 e+5z6MTAO6ktvHdQlSuH6ARn47bJrZOlkttAhg==
 -----END CERTIFICATE-----
 `
+	DefaulCertTTL = 24 * time.Hour
 )
 
 type mockTLSServer struct {
@@ -127,7 +128,7 @@ func TestGenKeyCertK8sCA(t *testing.T) {
 		}
 
 		_, _, _, err = GenKeyCertK8sCA(wc.clientset, tc.dnsNames[0], tc.secretNames[0],
-			tc.serviceNamespaces[0], wc.k8sCaCertFile, "testSigner", true)
+			tc.serviceNamespaces[0], wc.k8sCaCertFile, "testSigner", true, DefaulCertTTL)
 		if tc.expectFail {
 			if err == nil {
 				t.Errorf("should have failed")
@@ -387,7 +388,7 @@ func TestSubmitCSR(t *testing.T) {
 		}
 
 		_, r, _, err := submitCSR(wc.clientset, []byte("test-pem"), "test-signer",
-			usages, numRetries)
+			usages, numRetries, DefaulCertTTL)
 		if tc.expectFail {
 			if err == nil {
 				t.Errorf("test case (%s) should have failed", tcName)


### PR DESCRIPTION
**Please provide a description of this PR:**
user can specify the workload cert TTL via `SECRET_TTL`, however this option is ignored if we use K8s RA as cert provider. 
cert-manager supports to use `experimental.cert-manager.io/request-duration` annotation in  k8s CSR, So this PR will add the annotation to the CSR istio generated to support the eco-system.



