### PR TITLE
WIP: Adds ParsePEMCertificateChain for parsing certificate PEM chain. Used in istiod verification on Kube CSR responses

### DIFF
--- a/security/pkg/pki/util/crypto.go
+++ b/security/pkg/pki/util/crypto.go
@@ -20,6 +20,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"reflect"
 )
@@ -44,6 +45,35 @@ func ParsePemEncodedCertificate(certBytes []byte) (*x509.Certificate, error) {
 	}
 
 	return cert, nil
+}
+
+// ParsePemEncodedCertificateChain constructs a slice of `x509.Certificate`
+// objects using the given a PEM-encoded certificate chain.
+func ParsePemEncodedCertificateChain(certBytes []byte) ([]*x509.Certificate, error) {
+	var (
+		certs []*x509.Certificate
+		cb    *pem.Block
+	)
+
+	for {
+		cb, certBytes = pem.Decode(certBytes)
+		if cb == nil {
+			break
+		}
+
+		cert, err := x509.ParseCertificate(cb.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse X.509 certificate")
+		}
+
+		certs = append(certs, cert)
+	}
+
+	if len(certs) == 0 {
+		return nil, errors.New("no PEM encoded X.509 certificates parsed")
+	}
+
+	return certs, nil
 }
 
 // ParsePemEncodedCSR constructs a `x509.CertificateRequest` object using the


### PR DESCRIPTION
**Please provide a description of this PR:**

Fixes #34218 

This PR changes the istiod certificate verification when using the Kubernetes CSR strategy to include intermediates. Without this, most typical signers can't work as intermediates are shared during signing as the signed certificate chain.

NOTE: This PR hasn't updated unit tests yet.


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [X] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
