### PR TITLE
Added network label

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller_test.go
@@ -44,6 +44,7 @@ import (
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/protocol"
 	kubelib "istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/network"
 	"istio.io/istio/pkg/spiffe"
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/util/retry"
@@ -315,6 +316,7 @@ func TestController_GetPodLocality(t *testing.T) {
 
 func TestGetProxyServiceInstances(t *testing.T) {
 	clusterID := cluster.ID("fakeCluster")
+	networkID := network.ID("fakeNetwork")
 	for mode, name := range EndpointModeNames {
 		mode := mode
 		t.Run(name, func(t *testing.T) {
@@ -322,6 +324,8 @@ func TestGetProxyServiceInstances(t *testing.T) {
 				Mode:      mode,
 				ClusterID: clusterID,
 			})
+			// add a network ID to test endpoints include topology.istio.io/network label
+			controller.network = networkID
 			defer controller.Stop()
 			p := generatePod("128.0.0.1", "pod1", "nsa", "foo", "node1", map[string]string{"app": "test-app"}, map[string]string{})
 			addPods(t, controller, fx, p)
@@ -404,7 +408,6 @@ func TestGetProxyServiceInstances(t *testing.T) {
 			})
 
 			expected := &model.ServiceInstance{
-
 				Service: &model.Service{
 					Hostname:        "svc1.nsa.svc.company.com",
 					Address:         "10.0.0.1",
@@ -426,9 +429,11 @@ func TestGetProxyServiceInstances(t *testing.T) {
 						NodeRegionLabelGA:          "r",
 						NodeZoneLabelGA:            "z",
 						label.TopologyCluster.Name: clusterID.String(),
+						label.TopologyNetwork.Name: networkID.String(),
 					},
 					ServiceAccount:  "account",
 					Address:         "1.1.1.1",
+					Network:         networkID,
 					EndpointPort:    0,
 					ServicePortName: "tcp-port",
 					Locality: model.Locality{
@@ -491,6 +496,7 @@ func TestGetProxyServiceInstances(t *testing.T) {
 				ServicePort: &model.Port{Name: "tcp-port", Port: 8080, Protocol: protocol.TCP},
 				Endpoint: &model.IstioEndpoint{
 					Address:         "129.0.0.1",
+					Network:         networkID,
 					EndpointPort:    0,
 					ServicePortName: "tcp-port",
 					Locality: model.Locality{
@@ -503,6 +509,7 @@ func TestGetProxyServiceInstances(t *testing.T) {
 						NodeZoneLabelGA:            "zone1",
 						label.TopologySubzone.Name: "subzone1",
 						label.TopologyCluster.Name: clusterID.String(),
+						label.TopologyNetwork.Name: networkID.String(),
 					},
 					ServiceAccount: "spiffe://cluster.local/ns/nsa/sa/svcaccount",
 					TLSMode:        model.DisabledTLSModeLabel,
@@ -556,6 +563,7 @@ func TestGetProxyServiceInstances(t *testing.T) {
 				ServicePort: &model.Port{Name: "tcp-port", Port: 8080, Protocol: protocol.TCP},
 				Endpoint: &model.IstioEndpoint{
 					Address:         "129.0.0.2",
+					Network:         networkID,
 					EndpointPort:    0,
 					ServicePortName: "tcp-port",
 					Locality: model.Locality{
@@ -568,6 +576,7 @@ func TestGetProxyServiceInstances(t *testing.T) {
 						NodeRegionLabelGA:          "region",
 						NodeZoneLabelGA:            "zone",
 						label.TopologyCluster.Name: clusterID.String(),
+						label.TopologyNetwork.Name: networkID.String(),
 					},
 					ServiceAccount: "spiffe://cluster.local/ns/nsa/sa/svcaccount",
 					TLSMode:        model.DisabledTLSModeLabel,

--- a/pilot/pkg/serviceregistry/kube/controller/endpoint_builder.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpoint_builder.go
@@ -49,7 +49,7 @@ type EndpointBuilder struct {
 }
 
 func NewEndpointBuilder(c controllerInterface, pod *v1.Pod) *EndpointBuilder {
-	locality, sa, namespace, hostname, subdomain := "", "", "", "", ""
+	locality, sa, namespace, hostname, subdomain, ip := "", "", "", "", "", ""
 	var podLabels labels.Instance
 	if pod != nil {
 		locality = c.getPodLocality(pod)
@@ -63,6 +63,7 @@ func NewEndpointBuilder(c controllerInterface, pod *v1.Pod) *EndpointBuilder {
 				hostname = pod.Name
 			}
 		}
+		ip = pod.Status.PodIP
 	}
 	dm, _ := kubeUtil.GetDeployMetaFromPod(pod)
 	out := &EndpointBuilder{
@@ -78,7 +79,7 @@ func NewEndpointBuilder(c controllerInterface, pod *v1.Pod) *EndpointBuilder {
 		hostname:     hostname,
 		subDomain:    subdomain,
 	}
-	networkID := out.endpointNetwork(pod.Status.PodIP)
+	networkID := out.endpointNetwork(ip)
 	out.labels = augmentLabels(podLabels, c.Cluster(), locality, networkID)
 	return out
 }

--- a/pilot/pkg/serviceregistry/kube/controller/endpoint_builder.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpoint_builder.go
@@ -96,7 +96,10 @@ func NewEndpointBuilderFromMetadata(c controllerInterface, proxy *model.Proxy) *
 		},
 		tlsMode: model.GetTLSModeFromEndpointLabels(proxy.Metadata.Labels),
 	}
-	networkID := out.endpointNetwork(proxy.IPAddresses[0])
+	var networkID network.ID
+	if len(proxy.IPAddresses) > 0 {
+		networkID = out.endpointNetwork(proxy.IPAddresses[0])
+	}
 	out.labels = augmentLabels(proxy.Metadata.Labels, c.Cluster(), locality, networkID)
 	return out
 }

--- a/pilot/pkg/serviceregistry/kube/controller/endpoint_builder_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpoint_builder_test.go
@@ -74,10 +74,25 @@ func TestNewEndpointBuilderTopologyLabels(t *testing.T) {
 			},
 		},
 		{
+			name: "network only ",
+			ctl: testController{
+				locality: "myregion",
+				network:  "mynetwork",
+			},
+			podLabels: labels.Instance{
+				"k1": "v1",
+			},
+			expected: labels.Instance{
+				"k1":                       "v1",
+				label.TopologyNetwork.Name: "mynetwork",
+			},
+		},
+		{
 			name: "all values",
 			ctl: testController{
 				locality: "myregion/myzone/mysubzone",
 				cluster:  "mycluster",
+				network:  "mynetwork",
 			},
 			podLabels: labels.Instance{
 				"k1":                       "v1",
@@ -213,6 +228,7 @@ var _ controllerInterface = testController{}
 type testController struct {
 	locality string
 	cluster  cluster2.ID
+	network  network.ID
 }
 
 func (c testController) getPodLocality(*v1.Pod) string {
@@ -224,7 +240,7 @@ func (c testController) cidrRanger() cidranger.Ranger {
 }
 
 func (c testController) defaultNetwork() network.ID {
-	return ""
+	return c.network
 }
 
 func (c testController) Cluster() cluster2.ID {

--- a/pilot/pkg/serviceregistry/kube/controller/endpoint_builder_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpoint_builder_test.go
@@ -76,8 +76,7 @@ func TestNewEndpointBuilderTopologyLabels(t *testing.T) {
 		{
 			name: "network only ",
 			ctl: testController{
-				locality: "myregion",
-				network:  "mynetwork",
+				network: "mynetwork",
 			},
 			podLabels: labels.Instance{
 				"k1": "v1",

--- a/pilot/pkg/serviceregistry/serviceentry/conversion_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion_test.go
@@ -24,12 +24,15 @@ import (
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry/provider"
+	labelutil "istio.io/istio/pilot/pkg/serviceregistry/util/label"
 	"istio.io/istio/pilot/test/util"
+	"istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/config/schema/gvk"
+	"istio.io/istio/pkg/network"
 	"istio.io/istio/pkg/spiffe"
 )
 
@@ -717,7 +720,7 @@ func TestConvertInstances(t *testing.T) {
 
 	for _, tt := range serviceInstanceTests {
 		t.Run(strings.Join(tt.externalSvc.Spec.(*networking.ServiceEntry).Hosts, "_"), func(t *testing.T) {
-			instances := convertServiceEntryToInstances(*tt.externalSvc, nil)
+			instances := convertServiceEntryToInstances(*tt.externalSvc, nil, "xxxx")
 			sortServiceInstances(instances)
 			sortServiceInstances(tt.out)
 			if err := compare(t, instances, tt.out); err != nil {
@@ -732,10 +735,11 @@ func TestConvertWorkloadEntryToServiceInstances(t *testing.T) {
 		"app": "wle",
 	}
 	serviceInstanceTests := []struct {
-		name string
-		wle  *networking.WorkloadEntry
-		se   *config.Config
-		out  []*model.ServiceInstance
+		name      string
+		wle       *networking.WorkloadEntry
+		se        *config.Config
+		clusterID cluster.ID
+		out       []*model.ServiceInstance
 	}{
 		{
 			name: "simple",
@@ -777,14 +781,43 @@ func TestConvertWorkloadEntryToServiceInstances(t *testing.T) {
 				makeInstance(selector, "1.1.1.1", 8080, selector.Spec.(*networking.ServiceEntry).Ports[1], labels, PlainText),
 			},
 		},
+		{
+			name: "augment label",
+			wle: &networking.WorkloadEntry{
+				Address:        "1.1.1.1",
+				Labels:         labels,
+				Locality:       "region1/zone1/sunzone1",
+				Network:        "network1",
+				ServiceAccount: "default",
+			},
+			se:        selector,
+			clusterID: "fakeCluster",
+			out: []*model.ServiceInstance{
+				makeInstanceWithServiceAccount(selector, "1.1.1.1", 444, selector.Spec.(*networking.ServiceEntry).Ports[0], labels, "default"),
+				makeInstanceWithServiceAccount(selector, "1.1.1.1", 445, selector.Spec.(*networking.ServiceEntry).Ports[1], labels, "default"),
+			},
+		},
 	}
 
 	for _, tt := range serviceInstanceTests {
 		t.Run(tt.name, func(t *testing.T) {
 			services := convertServices(*tt.se)
-			instances := convertWorkloadEntryToServiceInstances(tt.wle, services, tt.se.Spec.(*networking.ServiceEntry), &configKey{})
+			instances := convertWorkloadEntryToServiceInstances(tt.wle, services, tt.se.Spec.(*networking.ServiceEntry), &configKey{}, tt.clusterID)
 			sortServiceInstances(instances)
 			sortServiceInstances(tt.out)
+
+			if tt.wle.Locality != "" || tt.clusterID != "" || tt.wle.Network != "" {
+				for _, serviceInstance := range tt.out {
+					serviceInstance.Endpoint.Locality = model.Locality{
+						Label:     tt.wle.Locality,
+						ClusterID: tt.clusterID,
+					}
+					serviceInstance.Endpoint.Network = network.ID(tt.wle.Network)
+					serviceInstance.Endpoint.Labels = labelutil.AugmentLabels(serviceInstance.Endpoint.Labels,
+						tt.clusterID, tt.wle.Locality, network.ID(tt.wle.Network))
+				}
+			}
+
 			if err := compare(t, instances, tt.out); err != nil {
 				t.Fatal(err)
 			}
@@ -795,6 +828,12 @@ func TestConvertWorkloadEntryToServiceInstances(t *testing.T) {
 func TestConvertWorkloadEntryToWorkloadInstance(t *testing.T) {
 	labels := map[string]string{
 		"app": "wle",
+	}
+
+	clusterID := "fakeCluster"
+	expectedLabel := map[string]string{
+		"app":                       "wle",
+		"topology.istio.io/cluster": clusterID,
 	}
 
 	workloadInstanceTests := []struct {
@@ -820,10 +859,14 @@ func TestConvertWorkloadEntryToWorkloadInstance(t *testing.T) {
 			out: &model.WorkloadInstance{
 				Namespace: "ns1",
 				Endpoint: &model.IstioEndpoint{
-					Labels:         labels,
+					Labels:         expectedLabel,
 					Address:        "1.1.1.1",
 					ServiceAccount: "spiffe://cluster.local/ns/ns1/sa/scooby",
 					TLSMode:        "istio",
+					Namespace:      "ns1",
+					Locality: model.Locality{
+						ClusterID: cluster.ID(clusterID),
+					},
 				},
 				PortMap: map[string]uint32{
 					"http": 80,
@@ -852,10 +895,15 @@ func TestConvertWorkloadEntryToWorkloadInstance(t *testing.T) {
 				Endpoint: &model.IstioEndpoint{
 					Labels: map[string]string{
 						"security.istio.io/tlsMode": "disabled",
+						"topology.istio.io/cluster": clusterID,
 					},
 					Address:        "1.1.1.1",
 					ServiceAccount: "spiffe://cluster.local/ns/ns1/sa/scooby",
 					TLSMode:        "disabled",
+					Namespace:      "ns1",
+					Locality: model.Locality{
+						ClusterID: cluster.ID(clusterID),
+					},
 				},
 				PortMap: map[string]uint32{
 					"http": 80,
@@ -906,10 +954,14 @@ func TestConvertWorkloadEntryToWorkloadInstance(t *testing.T) {
 			out: &model.WorkloadInstance{
 				Namespace: "ns1",
 				Endpoint: &model.IstioEndpoint{
-					Labels:         labels,
+					Labels:         expectedLabel,
 					Address:        "1.1.1.1",
 					ServiceAccount: "spiffe://cluster.local/ns/ns1/sa/scooby",
 					TLSMode:        "istio",
+					Namespace:      "ns1",
+					Locality: model.Locality{
+						ClusterID: cluster.ID(clusterID),
+					},
 				},
 				PortMap: map[string]uint32{
 					"http": 80,
@@ -938,12 +990,60 @@ func TestConvertWorkloadEntryToWorkloadInstance(t *testing.T) {
 				Namespace: "ns1",
 				Endpoint: &model.IstioEndpoint{
 					Labels: map[string]string{
-						"my-label": "bar",
-						"app":      "wle",
+						"my-label":                  "bar",
+						"app":                       "wle",
+						"topology.istio.io/cluster": clusterID,
 					},
 					Address:        "1.1.1.1",
 					ServiceAccount: "spiffe://cluster.local/ns/ns1/sa/scooby",
 					TLSMode:        "istio",
+					Namespace:      "ns1",
+					Locality: model.Locality{
+						ClusterID: cluster.ID(clusterID),
+					},
+				},
+				PortMap: map[string]uint32{
+					"http": 80,
+				},
+			},
+		},
+		{
+			name: "augment labels",
+			wle: config.Config{
+				Meta: config.Meta{
+					Namespace: "ns1",
+				},
+				Spec: &networking.WorkloadEntry{
+					Address: "1.1.1.1",
+					Labels:  labels,
+					Ports: map[string]uint32{
+						"http": 80,
+					},
+					Locality:       "region1/zone1/subzone1",
+					Network:        "network1",
+					ServiceAccount: "scooby",
+				},
+			},
+			out: &model.WorkloadInstance{
+				Namespace: "ns1",
+				Endpoint: &model.IstioEndpoint{
+					Labels: map[string]string{
+						"app":                           "wle",
+						"topology.kubernetes.io/region": "region1",
+						"topology.kubernetes.io/zone":   "zone1",
+						"topology.istio.io/subzone":     "subzone1",
+						"topology.istio.io/network":     "network1",
+						"topology.istio.io/cluster":     clusterID,
+					},
+					Address: "1.1.1.1",
+					Network: "network1",
+					Locality: model.Locality{
+						Label:     "region1/zone1/subzone1",
+						ClusterID: cluster.ID(clusterID),
+					},
+					ServiceAccount: "spiffe://cluster.local/ns/ns1/sa/scooby",
+					TLSMode:        "istio",
+					Namespace:      "ns1",
 				},
 				PortMap: map[string]uint32{
 					"http": 80,
@@ -954,7 +1054,7 @@ func TestConvertWorkloadEntryToWorkloadInstance(t *testing.T) {
 
 	for _, tt := range workloadInstanceTests {
 		t.Run(tt.name, func(t *testing.T) {
-			instance := convertWorkloadEntryToWorkloadInstance(tt.wle)
+			instance := convertWorkloadEntryToWorkloadInstance(tt.wle, cluster.ID(clusterID))
 			if err := compare(t, instance, tt.out); err != nil {
 				t.Fatal(err)
 			}

--- a/pilot/pkg/serviceregistry/serviceentry/conversion_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion_test.go
@@ -720,7 +720,7 @@ func TestConvertInstances(t *testing.T) {
 
 	for _, tt := range serviceInstanceTests {
 		t.Run(strings.Join(tt.externalSvc.Spec.(*networking.ServiceEntry).Hosts, "_"), func(t *testing.T) {
-			instances := convertServiceEntryToInstances(*tt.externalSvc, nil, "xxxx")
+			instances := convertServiceEntryToInstances(*tt.externalSvc, nil, "")
 			sortServiceInstances(instances)
 			sortServiceInstances(tt.out)
 			if err := compare(t, instances, tt.out); err != nil {

--- a/pilot/pkg/serviceregistry/serviceentry/servicediscovery.go
+++ b/pilot/pkg/serviceregistry/serviceentry/servicediscovery.go
@@ -160,7 +160,7 @@ func (s *ServiceEntryStore) workloadEntryHandler(old, curr config.Config, event 
 
 	// fire off the k8s handlers
 	if len(s.workloadHandlers) > 0 {
-		wi := convertWorkloadEntryToWorkloadInstance(curr)
+		wi := convertWorkloadEntryToWorkloadInstance(curr, s.Cluster())
 		if wi != nil {
 			for _, h := range s.workloadHandlers {
 				h(wi, event)
@@ -190,13 +190,13 @@ func (s *ServiceEntryStore) workloadEntryHandler(old, curr config.Config, event 
 				oldWorkloadLabels := labels.Collection{oldWle.Labels}
 				if oldWorkloadLabels.IsSupersetOf(se.entry.WorkloadSelector.Labels) {
 					selected = true
-					instance := convertWorkloadEntryToServiceInstances(oldWle, se.services, se.entry, &key)
+					instance := convertWorkloadEntryToServiceInstances(oldWle, se.services, se.entry, &key, s.Cluster())
 					instancesDeleted = append(instancesDeleted, instance...)
 				}
 			}
 		} else {
 			selected = true
-			instance := convertWorkloadEntryToServiceInstances(wle, se.services, se.entry, &key)
+			instance := convertWorkloadEntryToServiceInstances(wle, se.services, se.entry, &key, s.Cluster())
 			instancesUpdated = append(instancesUpdated, instance...)
 		}
 
@@ -333,7 +333,7 @@ func (s *ServiceEntryStore) serviceEntryHandler(old, curr config.Config, event m
 		// If will do full-push, leave the edsUpdate to that.
 		// XXX We should do edsUpdate for all unchangedSvcs since we begin to calculate service
 		// data according to this "configsUpdated" and thus remove the "!willFullPush" condition.
-		instances := convertServiceEntryToInstances(curr, unchangedSvcs)
+		instances := convertServiceEntryToInstances(curr, unchangedSvcs, s.Cluster())
 		key := configKey{
 			kind:      serviceEntryConfigType,
 			name:      curr.Name,
@@ -668,7 +668,7 @@ func (s *ServiceEntryStore) maybeRefreshIndexes() {
 				name:      cfg.Name,
 				namespace: cfg.Namespace,
 			}
-			updateInstances(key, convertServiceEntryToInstances(cfg, nil), instanceMap, ip2instances)
+			updateInstances(key, convertServiceEntryToInstances(cfg, nil, s.Cluster()), instanceMap, ip2instances)
 			services := convertServices(cfg)
 
 			se := cfg.Spec.(*networking.ServiceEntry)
@@ -724,7 +724,7 @@ func (s *ServiceEntryStore) maybeRefreshIndexes() {
 				// Not a match, skip this one
 				continue
 			}
-			updateInstances(key, convertWorkloadEntryToServiceInstances(wle, se.services, se.entry, &key), instanceMap, ip2instances)
+			updateInstances(key, convertWorkloadEntryToServiceInstances(wle, se.services, se.entry, &key, s.Cluster()), instanceMap, ip2instances)
 		}
 	}
 

--- a/pilot/pkg/serviceregistry/util/label/label.go
+++ b/pilot/pkg/serviceregistry/util/label/label.go
@@ -1,0 +1,53 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package label
+
+import (
+	v1 "k8s.io/api/core/v1"
+
+	"istio.io/api/label"
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/cluster"
+	"istio.io/istio/pkg/config/labels"
+	"istio.io/istio/pkg/network"
+)
+
+// AugmentLabels adds additional labels to the those provided.
+func AugmentLabels(in labels.Instance, clusterID cluster.ID, locality string, networkID network.ID) labels.Instance {
+	// Copy the original labels to a new map.
+	out := make(labels.Instance, len(in)+5)
+	for k, v := range in {
+		out[k] = v
+	}
+
+	// Don't need to add label.TopologyNetwork.Name, since that's already added by injection.
+	region, zone, subzone := model.SplitLocalityLabel(locality)
+	if len(region) > 0 {
+		out[v1.LabelTopologyRegion] = region
+	}
+	if len(zone) > 0 {
+		out[v1.LabelTopologyZone] = zone
+	}
+	if len(subzone) > 0 {
+		out[label.TopologySubzone.Name] = subzone
+	}
+	if len(clusterID) > 0 {
+		out[label.TopologyCluster.Name] = clusterID.String()
+	}
+	if len(networkID) > 0 {
+		out[label.TopologyNetwork.Name] = networkID.String()
+	}
+	return out
+}


### PR DESCRIPTION
**Please provide a description of this PR:**

With this, we can support weighted traffic routing to different networks.

```
apiVersion: networking.istio.io/v1alpha3
kind: DestinationRule
metadata:
  name: httpbin
spec:
  host: httpbin
  trafficPolicy:
    loadBalancer:
      simple: LEAST_CONN
  subsets:
  - name: network1
    labels:
      topology.istio.io/network: network1
  - name: kubernetes
    labels:
      topology.istio.io/network: network2

```

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [x] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
