### PR TITLE
Allow cached response in initial discovery request

### DIFF
--- a/pilot/pkg/model/xds_cache.go
+++ b/pilot/pkg/model/xds_cache.go
@@ -210,7 +210,17 @@ func (l *lruCache) assertUnchanged(key string, existing *discovery.Resource, rep
 	}
 }
 
+func (l *lruCache) assertInvalidPushRequest(entry XdsCacheEntry, req *PushRequest) {
+	if !l.enableAssertions {
+		return
+	}
+	if req == nil || req.Start.Equal(time.Time{}) {
+		panic(fmt.Sprintf("attempted to update cache without request start time set for key %v", entry.Key()))
+	}
+}
+
 func (l *lruCache) Add(entry XdsCacheEntry, pushReq *PushRequest, value *discovery.Resource) {
+	l.assertInvalidPushRequest(entry, pushReq)
 	if !entry.Cacheable() || pushReq == nil || pushReq.Start.Equal(time.Time{}) {
 		return
 	}

--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -233,6 +233,7 @@ func (s *DiscoveryServer) processRequest(req *discovery.DiscoveryRequest, con *C
 	}
 
 	request.Reason = append(request.Reason, model.ProxyRequest)
+	request.Start = time.Now()
 	return s.pushXds(con, push, versionInfo(), con.Watched(req.TypeUrl), request)
 }
 

--- a/pilot/pkg/xds/delta.go
+++ b/pilot/pkg/xds/delta.go
@@ -309,6 +309,8 @@ func (s *DiscoveryServer) processDeltaRequest(req *discovery.DeltaDiscoveryReque
 		}
 	}
 
+	request.Reason = append(request.Reason, model.ProxyRequest)
+	request.Start = time.Now()
 	return s.pushDeltaXds(con, push, versionInfo(), con.Watched(req.TypeUrl), req.ResourceNamesSubscribe, request)
 }
 


### PR DESCRIPTION
This is a small regression in the change to the token invalidation - .Start is not set on push requests so we lose out on one of the biggest sources of cache hits.