### PR TITLE
Report internal address if external address is not present

### DIFF
--- a/pilot/pkg/config/kube/gateway/conversion.go
+++ b/pilot/pkg/config/kube/gateway/conversion.go
@@ -1033,11 +1033,17 @@ func convertGateways(r *KubernetesResources) ([]config.Config, map[RouteKey][]ga
 		}
 		obj.Status.(*kstatus.WrappedStatus).Mutate(func(s config.Status) config.Status {
 			gs := s.(*k8s.GatewayStatus)
-			gs.Addresses = make([]k8s.GatewayAddress, 0, len(external))
-			for _, addr := range external {
-				ip := k8s.IPAddressType
+			addressesToReport := external
+			addrType := k8s.IPAddressType
+			if len(addressesToReport) == 0 {
+				addressesToReport = internal
+				// TODO should be hostname, in v1alpha2
+				addrType = k8s.NamedAddressType
+			}
+			gs.Addresses = make([]k8s.GatewayAddress, 0, len(addressesToReport))
+			for _, addr := range addressesToReport {
 				gs.Addresses = append(gs.Addresses, k8s.GatewayAddress{
-					Type:  &ip,
+					Type:  &addrType,
 					Value: addr,
 				})
 			}

--- a/pilot/pkg/config/kube/gateway/testdata/zero.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/zero.yaml.golden
@@ -27,7 +27,12 @@ spec:
   hosts:
   - first.domain.example
   http:
-  - match:
+  - fault:
+      abort:
+        httpStatus: 503
+        percentage:
+          value: 100
+    match:
     - uri:
         regex: /get((\/).*)?
     route:
@@ -35,12 +40,6 @@ spec:
         host: httpbin-zero.default.svc.domain.suffix
         port:
           number: 8080
-      weight: 0
-    fault:
-      abort:
-        percentage:
-          value: 100
-        httpStatus: 503
   - match:
     - uri:
         regex: /weighted-100((\/).*)?


### PR DESCRIPTION
Joined with https://github.com/kubernetes-sigs/gateway-api/pull/743,
this allows displaying non-empty results when there is no external IP
for the Gateway (ie its a cluster IP gateway)
