### PR TITLE
Fix CSR test to run on 1.19+

### DIFF
--- a/tests/integration/security/external_ca/main_test.go
+++ b/tests/integration/security/external_ca/main_test.go
@@ -76,7 +76,7 @@ func TestMain(m *testing.M) {
 	// Refer to https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/
 	framework.NewSuite(m).
 		Label(label.CustomSetup).
-		RequireMinVersion(18).
+		RequireMinVersion(19).
 		RequireSingleCluster().
 		Setup(istio.Setup(&inst, setupConfig)).
 		Setup(func(ctx resource.Context) error {


### PR DESCRIPTION
https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/

Introduced in 1.19, not 1.18
Regression in https://github.com/istio/istio/pull/34353/files