### PR TITLE
[tf] Add AtLeast to RevVerMap

### DIFF
--- a/pkg/test/framework/resource/version.go
+++ b/pkg/test/framework/resource/version.go
@@ -131,6 +131,11 @@ func (rv *RevVerMap) Maximum() IstioVersion {
 	return rv.Versions().Maximum()
 }
 
+// AtLeast returns true if the minimum Istio version under test is at least the given version.
+func (rv *RevVerMap) AtLeast(v IstioVersion) bool {
+	return rv.Versions().Minimum().Compare(v) >= 0
+}
+
 // IsMultiVersion returns whether the associated IstioVersions have multiple specified versions.
 func (rv *RevVerMap) IsMultiVersion() bool {
 	return rv != nil && len(*rv) > 0

--- a/pkg/test/framework/resource/version_test.go
+++ b/pkg/test/framework/resource/version_test.go
@@ -1,0 +1,149 @@
+package resource
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+)
+
+func TestCompareIstioVersion(t *testing.T) {
+	tcs := []struct {
+		a, b   IstioVersion
+		result int
+	}{
+		{
+			IstioVersion("1.4"),
+			IstioVersion("1.5"),
+			-1,
+		},
+		{
+			IstioVersion("1.9.0"),
+			IstioVersion("1.10"),
+			-1,
+		},
+		{
+			IstioVersion("1.8.0"),
+			IstioVersion("1.8.1"),
+			-1,
+		},
+		{
+			IstioVersion("1.9.1"),
+			IstioVersion("1.9.1"),
+			0,
+		},
+		{
+			IstioVersion("1.12"),
+			IstioVersion("1.3"),
+			1,
+		},
+		{
+			IstioVersion(""),
+			IstioVersion(""),
+			0,
+		},
+		{
+			IstioVersion(""),
+			IstioVersion("1.9"),
+			1,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(fmt.Sprintf("compare version %s->%s", tc.a, tc.b), func(t *testing.T) {
+			r := tc.a.Compare(tc.b)
+			if r != tc.result {
+				t.Errorf("expected %d, got %d", tc.result, r)
+			}
+		})
+	}
+}
+
+func TestMinimumIstioVersion(t *testing.T) {
+	tcs := []struct {
+		name     string
+		versions IstioVersions
+		result   IstioVersion
+	}{
+		{
+			"two versions",
+			IstioVersions([]IstioVersion{
+				"1.4", "1.5",
+			}),
+			IstioVersion("1.4"),
+		},
+		{
+			"three versions",
+			IstioVersions([]IstioVersion{
+				"1.9", "1.13", "1.10",
+			}),
+			IstioVersion("1.9"),
+		},
+		{
+			"single version",
+			IstioVersions([]IstioVersion{
+				"1.9",
+			}),
+			IstioVersion("1.9"),
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			min := tc.versions.Minimum()
+			if min != tc.result {
+				t.Errorf("expected %v, got %v", tc.result, min)
+			}
+		})
+	}
+}
+
+func TestAtLeast(t *testing.T) {
+	tcs := []struct {
+		name     string
+		versions RevVerMap
+		version  IstioVersion
+		result   bool
+	}{
+		{
+			"not at least",
+			makeRevVerMap("1.4", "1.5"),
+			IstioVersion("1.8"),
+			false,
+		},
+		{
+			"tied with minimum",
+			makeRevVerMap("1.4", "1.5"),
+			IstioVersion("1.4"),
+			true,
+		},
+		{
+			"lower than minimum",
+			makeRevVerMap("1.4", "1.5"),
+			IstioVersion("1.3"),
+			true,
+		},
+		{
+			"no versions",
+			makeRevVerMap(),
+			IstioVersion("1.8"),
+			true,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			min := tc.versions.AtLeast(tc.version)
+			if min != tc.result {
+				t.Errorf("expected %v, got %v", tc.result, min)
+			}
+		})
+	}
+}
+
+func makeRevVerMap(versions ...string) RevVerMap {
+	m := make(map[string]IstioVersion)
+	for i, v := range versions {
+		m[strconv.Itoa(i)] = IstioVersion(v)
+	}
+	return m
+}

--- a/pkg/test/framework/resource/version_test.go
+++ b/pkg/test/framework/resource/version_test.go
@@ -1,3 +1,17 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package resource
 
 import (

--- a/pkg/test/framework/test.go
+++ b/pkg/test/framework/test.go
@@ -245,7 +245,7 @@ func (t *testImpl) doRun(ctx *testContext, fn func(ctx TestContext), parallel bo
 	}
 
 	if t.minIstioVersion != "" {
-		if resource.IstioVersion(t.minIstioVersion).Compare(t.ctx.Settings().Revisions.Minimum()) > 0 {
+		if !t.ctx.Settings().Revisions.AtLeast(resource.IstioVersion(t.minIstioVersion)) {
 			ctx.Done()
 			t.goTest.Skipf("Skipping %q: running with min Istio version %q, test requires at least %s",
 				t.goTest.Name(), t.ctx.Settings().Revisions.Minimum(), t.minIstioVersion)

--- a/tests/integration/pilot/common/apps.go
+++ b/tests/integration/pilot/common/apps.go
@@ -224,8 +224,8 @@ func SetupApps(t resource.Context, i istio.Instance, apps *EchoDeployments) erro
 			WorkloadOnlyPorts: common.WorkloadPorts,
 		})
 
-	skipDelta := t.Settings().SkipDelta || t.Settings().Revisions.Minimum().Compare("1.10") > 0
-	if skipDelta {
+	skipDelta := t.Settings().SkipDelta || !t.Settings().Revisions.AtLeast("1.10")
+	if !skipDelta {
 		builder = builder.
 			WithConfig(echo.Config{
 				Service:   DeltaSvc,
@@ -276,7 +276,7 @@ func SetupApps(t resource.Context, i istio.Instance, apps *EchoDeployments) erro
 	if !t.Settings().SkipVM {
 		apps.VM = echos.Match(echo.Service(VMSvc))
 	}
-	if skipDelta {
+	if !skipDelta {
 		apps.DeltaXDS = echos.Match(echo.Service(DeltaSvc))
 	}
 

--- a/tests/integration/pilot/common/traffic.go
+++ b/tests/integration/pilot/common/traffic.go
@@ -140,7 +140,7 @@ func (c TrafficTestCase) RunForApps(t framework.TestContext, apps echo.Instances
 				t.SkipNow()
 			}
 			if c.minIstioVersion != "" {
-				skipMV := resource.IstioVersion(c.minIstioVersion).Compare(t.Settings().Revisions.Minimum()) > 0
+				skipMV := !t.Settings().Revisions.AtLeast(resource.IstioVersion(c.minIstioVersion))
 				if skipMV {
 					t.SkipNow()
 				}
@@ -200,7 +200,7 @@ func (c TrafficTestCase) Run(t framework.TestContext, namespace string) {
 			t.SkipNow()
 		}
 		if c.minIstioVersion != "" {
-			skipMV := resource.IstioVersion(c.minIstioVersion).Compare(t.Settings().Revisions.Minimum()) > 0
+			skipMV := !t.Settings().Revisions.AtLeast(resource.IstioVersion(c.minIstioVersion))
 			if skipMV {
 				t.SkipNow()
 			}


### PR DESCRIPTION
Makes it much easier to deal with version-based skips, before had to do `Settings().Revisions.Minimum().Compare()` and deal with an int result.

Also fixes a backwards skip condition when deploying delta app (had the `Compare()` backwards and also had `skipDelta` where it should have been `!skipDelta`...)

cc @sergii-ssh 

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [x] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
