### PR TITLE
When the istioctl -h command is executed, available commands displays the alias

### DIFF
--- a/istioctl/cmd/root.go
+++ b/istioctl/cmd/root.go
@@ -76,6 +76,34 @@ var (
 
 	// scope is for dev logging.  Warning: log levels are not set by --log_output_level until command is Run().
 	scope = log.RegisterScope("cli", "istioctl", 0)
+
+	// usageTemplate is nearly identical to the default template.
+	// only change available commands name to name and aliases.
+	usageTemplate = `Usage:{{if .Runnable}}
+  {{.UseLine}}{{end}}{{if .HasSubCommands}}
+  {{ .CommandPath}} [command]{{end}}{{if gt .Aliases 0}}
+
+Aliases:
+  {{.NameAndAliases}}
+{{end}}{{if .HasExample}}
+
+Examples:
+{{ .Example }}{{end}}{{ if .HasAvailableSubCommands}}
+
+Available Commands:{{range .Commands}}{{if .IsAvailableCommand}}
+  {{rpad .NameAndAliases .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{ if .HasLocalFlags}}
+
+Flags:
+{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
+
+Global Flags:
+{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
+
+Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
+  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
+
+Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
+`
 )
 
 func defaultLogOptions() *log.Options {
@@ -301,6 +329,8 @@ debug and diagnose their Istio mesh.
 			return CommandParseError{e}
 		})
 	}
+
+	rootCmd.SetUsageTemplate(usageTemplate)
 
 	return rootCmd
 }


### PR DESCRIPTION
When users use istioctl, if executed **istioctl -h** echos the alias of the command, it will be more convenient to use.

1. old version： When the **istioctl -h** command is executed available commands does not show aliases.
```
...
Usage:
  istioctl [command]
Available Commands:
  proxy-config   Retrieve information about proxy configuration from Envoy [kube only]
  proxy-status   Retrieves the synchronization status of each Envoy in the mesh [kube only]
  upgrade        Upgrade Istio control plane in-place
  validate       Validate Istio policy and rules files
  verify-install Verifies Istio Installation Status
  version        Prints out build version information
...
```

2. for this PR ：When the **istioctl -h** command is executed available commands display alias.
```
...
Usage:
  istioctl [command]
Available Commands:
  admin, istiod           Manage control plane (istiod) configuration
  proxy-config, pc        Retrieve information about proxy configuration from Envoy [kube only]
  proxy-status, ps        Retrieves the synchronization status of each Envoy in the mesh [kube only]
...
```

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure



- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
