### PR TITLE
Skip push cds for sidecar when virtualService updated

### DIFF
--- a/pilot/pkg/xds/ads_test.go
+++ b/pilot/pkg/xds/ads_test.go
@@ -556,7 +556,8 @@ func TestAdsPushScoping(t *testing.T) {
 				hosts []string
 				dest  string
 			}{{index: 4, hosts: []string{fmt.Sprintf("svc%d%s", 4, svcSuffix)}, dest: "foo.com"}},
-			expectUpdates: []string{},
+			expectUpdates:   []string{v3.ListenerType, v3.RouteType},
+			unexpectUpdates: []string{v3.ClusterType, v3.EndpointType},
 		},
 		{
 			desc: "Add instances for transitively scoped svc",
@@ -576,7 +577,8 @@ func TestAdsPushScoping(t *testing.T) {
 				hosts []string
 				dest  string
 			}{{index: 4}},
-			expectUpdates: []string{},
+			expectUpdates:   []string{v3.ListenerType, v3.RouteType},
+			unexpectUpdates: []string{v3.ClusterType, v3.EndpointType},
 		},
 		{
 			desc: "Add delegation virtual service for scoped service with transitively scoped dest svc",
@@ -586,7 +588,8 @@ func TestAdsPushScoping(t *testing.T) {
 				hosts []string
 				dest  string
 			}{{index: 4, hosts: []string{fmt.Sprintf("svc%d%s", 4, svcSuffix)}, dest: "foo.com"}},
-			expectUpdates: []string{v3.ListenerType, v3.RouteType},
+			expectUpdates:   []string{v3.ListenerType, v3.RouteType},
+			unexpectUpdates: []string{v3.ClusterType, v3.EndpointType},
 		},
 		{
 			desc: "Update delegate virtual service should trigger full push",
@@ -596,7 +599,8 @@ func TestAdsPushScoping(t *testing.T) {
 				hosts []string
 				dest  string
 			}{{index: 4, hosts: []string{fmt.Sprintf("svc%d%s", 4, svcSuffix)}, dest: "foo.com"}},
-			expectUpdates: []string{v3.ListenerType, v3.RouteType},
+			expectUpdates:   []string{v3.ListenerType, v3.RouteType},
+			unexpectUpdates: []string{v3.ClusterType, v3.EndpointType},
 		},
 		{
 			desc: "Delete delegate virtual service for scoped service with transitively scoped dest svc",
@@ -606,7 +610,8 @@ func TestAdsPushScoping(t *testing.T) {
 				hosts []string
 				dest  string
 			}{{index: 4}},
-			expectUpdates: []string{v3.ListenerType, v3.RouteType},
+			expectUpdates:   []string{v3.ListenerType, v3.RouteType},
+			unexpectUpdates: []string{v3.ClusterType, v3.EndpointType},
 		},
 		{
 			desc:          "Remove a scoped service",

--- a/pilot/pkg/xds/ads_test.go
+++ b/pilot/pkg/xds/ads_test.go
@@ -556,7 +556,7 @@ func TestAdsPushScoping(t *testing.T) {
 				hosts []string
 				dest  string
 			}{{index: 4, hosts: []string{fmt.Sprintf("svc%d%s", 4, svcSuffix)}, dest: "foo.com"}},
-			expectUpdates: []string{v3.ClusterType, v3.EndpointType},
+			expectUpdates: []string{},
 		},
 		{
 			desc: "Add instances for transitively scoped svc",
@@ -576,7 +576,7 @@ func TestAdsPushScoping(t *testing.T) {
 				hosts []string
 				dest  string
 			}{{index: 4}},
-			expectUpdates: []string{v3.ClusterType},
+			expectUpdates: []string{},
 		},
 		{
 			desc: "Add delegation virtual service for scoped service with transitively scoped dest svc",
@@ -586,7 +586,7 @@ func TestAdsPushScoping(t *testing.T) {
 				hosts []string
 				dest  string
 			}{{index: 4, hosts: []string{fmt.Sprintf("svc%d%s", 4, svcSuffix)}, dest: "foo.com"}},
-			expectUpdates: []string{v3.ListenerType, v3.RouteType, v3.ClusterType, v3.EndpointType},
+			expectUpdates: []string{v3.ListenerType, v3.RouteType},
 		},
 		{
 			desc: "Update delegate virtual service should trigger full push",
@@ -596,7 +596,7 @@ func TestAdsPushScoping(t *testing.T) {
 				hosts []string
 				dest  string
 			}{{index: 4, hosts: []string{fmt.Sprintf("svc%d%s", 4, svcSuffix)}, dest: "foo.com"}},
-			expectUpdates: []string{v3.ListenerType, v3.RouteType, v3.ClusterType},
+			expectUpdates: []string{v3.ListenerType, v3.RouteType},
 		},
 		{
 			desc: "Delete delegate virtual service for scoped service with transitively scoped dest svc",
@@ -606,7 +606,7 @@ func TestAdsPushScoping(t *testing.T) {
 				hosts []string
 				dest  string
 			}{{index: 4}},
-			expectUpdates: []string{v3.ListenerType, v3.RouteType, v3.ClusterType},
+			expectUpdates: []string{v3.ListenerType, v3.RouteType},
 		},
 		{
 			desc:          "Remove a scoped service",

--- a/pilot/pkg/xds/cds.go
+++ b/pilot/pkg/xds/cds.go
@@ -28,6 +28,7 @@ var _ model.XdsResourceGenerator = &CdsGenerator{}
 
 // Map of all configs that do not impact CDS
 var skippedCdsConfigs = map[config.GroupVersionKind]struct{}{
+	gvk.VirtualService:        {},
 	gvk.Gateway:               {},
 	gvk.WorkloadEntry:         {},
 	gvk.WorkloadGroup:         {},
@@ -42,7 +43,7 @@ var pushCdsGatewayConfig = map[config.GroupVersionKind]struct{}{
 	gvk.Gateway:        {},
 }
 
-func cdsNeedsPush(req *model.PushRequest, proxy *model.Proxy) bool {
+func CdsNeedsPush(req *model.PushRequest, proxy *model.Proxy) bool {
 	if req == nil {
 		return true
 	}
@@ -54,6 +55,7 @@ func cdsNeedsPush(req *model.PushRequest, proxy *model.Proxy) bool {
 	if len(req.ConfigsUpdated) == 0 {
 		return true
 	}
+
 	for config := range req.ConfigsUpdated {
 		if proxy.Type == model.Router {
 			if _, f := pushCdsGatewayConfig[config.Kind]; f {
@@ -70,7 +72,7 @@ func cdsNeedsPush(req *model.PushRequest, proxy *model.Proxy) bool {
 
 func (c CdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource,
 	updates *model.PushRequest) (model.Resources, model.XdsLogDetails, error) {
-	if !cdsNeedsPush(updates, proxy) {
+	if !CdsNeedsPush(updates, proxy) {
 		return nil, model.DefaultXdsLogDetails, nil
 	}
 	clusters, logs := c.Server.ConfigGenerator.BuildClusters(proxy, updates)
@@ -80,7 +82,7 @@ func (c CdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *m
 // GenerateDeltas for CDS currently only builds deltas when services change. todo implement changes for DestinationRule, etc
 func (c CdsGenerator) GenerateDeltas(proxy *model.Proxy, push *model.PushContext, updates *model.PushRequest,
 	w *model.WatchedResource) (model.Resources, []string, model.XdsLogDetails, bool, error) {
-	if !cdsNeedsPush(updates, proxy) {
+	if !CdsNeedsPush(updates, proxy) {
 		return nil, nil, model.DefaultXdsLogDetails, false, nil
 	}
 	updatedClusters, removedClusters, logs, usedDelta := c.Server.ConfigGenerator.BuildDeltaClusters(proxy, push, updates, w)

--- a/pilot/pkg/xds/cds_test.go
+++ b/pilot/pkg/xds/cds_test.go
@@ -16,12 +16,126 @@ package xds_test
 import (
 	"testing"
 
+	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/xds"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
+	"istio.io/istio/pkg/config/schema/gvk"
 )
 
 func TestCDS(t *testing.T) {
 	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
 	ads := s.ConnectADS().WithType(v3.ClusterType)
 	ads.RequestResponseAck(t, nil)
+}
+
+func TestCdsNeedsPush(t *testing.T) {
+	testCases := []struct {
+		name           string
+		proxyType      model.NodeType
+		configsUpdated map[model.ConfigKey]struct{}
+		expected       bool
+	}{
+		{
+			name:      "sidecar without configs that do not influence cds",
+			proxyType: model.SidecarProxy,
+			configsUpdated: map[model.ConfigKey]struct{}{
+				{
+					Kind:      gvk.VirtualService,
+					Name:      "vs1",
+					Namespace: "test",
+				}: {},
+				{
+					Kind:      gvk.Gateway,
+					Name:      "gw1",
+					Namespace: "test",
+				}: {},
+				{
+					Kind:      gvk.AuthorizationPolicy,
+					Name:      "authz1",
+					Namespace: "test",
+				}: {},
+				{
+					Kind:      gvk.RequestAuthentication,
+					Name:      "ra1",
+					Namespace: "test",
+				}: {},
+			},
+			expected: false,
+		},
+		{
+			name:      "sidecar with configs that influence cds",
+			proxyType: model.SidecarProxy,
+			configsUpdated: map[model.ConfigKey]struct{}{
+				{
+					Kind:      gvk.VirtualService,
+					Name:      "vs1",
+					Namespace: "test",
+				}: {},
+				{
+					Kind:      gvk.Gateway,
+					Name:      "gw1",
+					Namespace: "test",
+				}: {},
+				{
+					Kind:      gvk.AuthorizationPolicy,
+					Name:      "authz1",
+					Namespace: "test",
+				}: {},
+				{
+					Kind:      gvk.RequestAuthentication,
+					Name:      "ra1",
+					Namespace: "test",
+				}: {},
+				{
+					Kind:      gvk.DestinationRule,
+					Name:      "ra1",
+					Namespace: "test",
+				}: {},
+			},
+			expected: true,
+		},
+		{
+			name:      "gateway with nil configs",
+			proxyType: model.SidecarProxy,
+			expected:  true,
+		},
+		{
+			name:      "gateway with common configs that influence cds",
+			proxyType: model.Router,
+			configsUpdated: map[model.ConfigKey]struct{}{
+				{
+					Kind:      gvk.VirtualService,
+					Name:      "vs1",
+					Namespace: "test",
+				}: {},
+			},
+			expected: true,
+		},
+		{
+			name:      "gateway with common configs that influence cds",
+			proxyType: model.Router,
+			configsUpdated: map[model.ConfigKey]struct{}{
+				{
+					Kind:      gvk.ServiceEntry,
+					Name:      "svc",
+					Namespace: "test",
+				}: {},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := &model.PushRequest{
+				Full:           true,
+				ConfigsUpdated: tc.configsUpdated,
+			}
+			proxy := &model.Proxy{Type: tc.proxyType}
+			got := xds.CdsNeedsPush(req, proxy)
+			if got != tc.expected {
+				t.Errorf("Got unexpected %v, expected %v", got, tc.expected)
+			}
+		})
+	}
 }


### PR DESCRIPTION
**Please provide a description of this PR:**

VirtualService and Gateway both donot influence sidecar cds.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [x] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
