### PR TITLE
fix metrics service render

### DIFF
--- a/pkg/bootstrap/instance_test.go
+++ b/pkg/bootstrap/instance_test.go
@@ -150,6 +150,9 @@ func TestGolden(t *testing.T) {
 			base: "tracing_datadog",
 		},
 		{
+			base: "metrics_no_statsd",
+		},
+		{
 			base:    "tracing_stackdriver",
 			stsPort: 15463,
 			platformMeta: map[string]string{

--- a/pkg/bootstrap/testdata/metrics_no_statsd.proxycfg
+++ b/pkg/bootstrap/testdata/metrics_no_statsd.proxycfg
@@ -1,0 +1,12 @@
+config_path:                      "/etc/istio/proxy"
+binary_path:                      "/usr/local/bin/envoy"
+service_cluster:                  "istio-proxy"
+drain_duration:                   {seconds: 5}
+parent_shutdown_duration:         {seconds: 6}
+discovery_address:                "mypilot:15011"
+envoy_metrics_service:            {address: "metrics-service:15000", tls_settings: { mode: MUTUAL, client_certificate: "/etc/istio/ms/client.pem", private_key: "/etc/istio/ms/key.pem", ca_certificates: "/etc/istio/ms/ca.pem"}}
+proxy_admin_port:                 15000
+control_plane_auth_policy:        MUTUAL_TLS
+stat_name_length:                 200
+
+# Sets all relevant options to values different than default

--- a/pkg/bootstrap/testdata/metrics_no_statsd_golden.json
+++ b/pkg/bootstrap/testdata/metrics_no_statsd_golden.json
@@ -1,0 +1,607 @@
+{
+  "node": {
+    "id": "sidecar~1.2.3.4~foo~bar",
+    "cluster": "istio-proxy",
+    "locality": {
+    },
+    "metadata": {"ENVOY_PROMETHEUS_PORT":15090,"ENVOY_STATUS_PORT":15021,"INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","OUTLIER_LOG_PATH":"/dev/stdout","PILOT_SAN":["spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account"],"PROXY_CONFIG":{"binaryPath":"/usr/local/bin/envoy","configPath":"/tmp/bootstrap/metrics_no_statsd","controlPlaneAuthPolicy":"MUTUAL_TLS","customConfigFile":"envoy_bootstrap.json","discoveryAddress":"mypilot:15011","drainDuration":"5s","envoyMetricsService":{"address":"metrics-service:15000","tlsSettings":{"caCertificates":"/etc/istio/ms/ca.pem","clientCertificate":"/etc/istio/ms/client.pem","mode":"MUTUAL","privateKey":"/etc/istio/ms/key.pem"}},"parentShutdownDuration":"6s","proxyAdminPort":15000,"serviceCluster":"istio-proxy","statNameLength":200,"statusPort":15020}}
+  },
+  "layered_runtime": {
+      "layers": [
+          {
+              "name": "deprecation",
+              "static_layer": {
+                  "envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst": true,
+                  "envoy.reloadable_features.require_strict_1xx_and_204_response_headers": false,
+                  "re2.max_program_size.error_level": 1024,
+                  "envoy.reloadable_features.treat_host_like_authority": false,
+                  "envoy.reloadable_features.new_tcp_connection_pool": false
+              }
+          },
+          {
+            "name": "global config",
+            "static_layer": {
+                "overload.global_downstream_max_connections": 2147483647
+            }
+          },
+          {
+              "name": "admin",
+              "admin_layer": {}
+          }
+      ]
+  },
+  "stats_config": {
+    "use_all_default_tags": false,
+    "stats_tags": [
+      {
+        "tag_name": "cluster_name",
+        "regex": "^cluster\\.((.+?(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
+      },
+      {
+        "tag_name": "tcp_prefix",
+        "regex": "^tcp\\.((.*?)\\.)\\w+?$"
+      },
+      {
+        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
+        "tag_name": "response_code"
+      },
+      {
+        "tag_name": "response_code_class",
+        "regex": "_rq(_(\\dxx))$"
+      },
+      {
+        "tag_name": "http_conn_manager_listener_prefix",
+        "regex": "^listener(?=\\.).*?\\.http\\.(((?:[_.[:digit:]]*|[_\\[\\]aAbBcCdDeEfF[:digit:]]*))\\.)"
+      },
+      {
+        "tag_name": "http_conn_manager_prefix",
+        "regex": "^http\\.(((?:[_.[:digit:]]*|[_\\[\\]aAbBcCdDeEfF[:digit:]]*))\\.)"
+      },
+      {
+        "tag_name": "listener_address",
+        "regex": "^listener\\.(((?:[_.[:digit:]]*|[_\\[\\]aAbBcCdDeEfF[:digit:]]*))\\.)"
+      },
+      {
+        "tag_name": "mongo_prefix",
+        "regex": "^mongo\\.(.+?)\\.(collection|cmd|cx_|op_|delays_|decoding_)(.*?)$"
+      },
+      {
+        "regex": "(reporter=\\.=(.*?);\\.;)",
+        "tag_name": "reporter"
+      },
+      {
+        "regex": "(source_namespace=\\.=(.*?);\\.;)",
+        "tag_name": "source_namespace"
+      },
+      {
+        "regex": "(source_workload=\\.=(.*?);\\.;)",
+        "tag_name": "source_workload"
+      },
+      {
+        "regex": "(source_workload_namespace=\\.=(.*?);\\.;)",
+        "tag_name": "source_workload_namespace"
+      },
+      {
+        "regex": "(source_principal=\\.=(.*?);\\.;)",
+        "tag_name": "source_principal"
+      },
+      {
+        "regex": "(source_app=\\.=(.*?);\\.;)",
+        "tag_name": "source_app"
+      },
+      {
+        "regex": "(source_version=\\.=(.*?);\\.;)",
+        "tag_name": "source_version"
+      },
+      {
+        "regex": "(source_cluster=\\.=(.*?);\\.;)",
+        "tag_name": "source_cluster"
+      },
+      {
+        "regex": "(destination_namespace=\\.=(.*?);\\.;)",
+        "tag_name": "destination_namespace"
+      },
+      {
+        "regex": "(destination_workload=\\.=(.*?);\\.;)",
+        "tag_name": "destination_workload"
+      },
+      {
+        "regex": "(destination_workload_namespace=\\.=(.*?);\\.;)",
+        "tag_name": "destination_workload_namespace"
+      },
+      {
+        "regex": "(destination_principal=\\.=(.*?);\\.;)",
+        "tag_name": "destination_principal"
+      },
+      {
+        "regex": "(destination_app=\\.=(.*?);\\.;)",
+        "tag_name": "destination_app"
+      },
+      {
+        "regex": "(destination_version=\\.=(.*?);\\.;)",
+        "tag_name": "destination_version"
+      },
+      {
+        "regex": "(destination_service=\\.=(.*?);\\.;)",
+        "tag_name": "destination_service"
+      },
+      {
+        "regex": "(destination_service_name=\\.=(.*?);\\.;)",
+        "tag_name": "destination_service_name"
+      },
+      {
+        "regex": "(destination_service_namespace=\\.=(.*?);\\.;)",
+        "tag_name": "destination_service_namespace"
+      },
+      {
+        "regex": "(destination_port=\\.=(.*?);\\.;)",
+        "tag_name": "destination_port"
+      },
+      {
+        "regex": "(destination_cluster=\\.=(.*?);\\.;)",
+        "tag_name": "destination_cluster"
+      },
+      {
+        "regex": "(request_protocol=\\.=(.*?);\\.;)",
+        "tag_name": "request_protocol"
+      },
+      {
+        "regex": "(request_operation=\\.=(.*?);\\.;)",
+        "tag_name": "request_operation"
+      },
+      {
+        "regex": "(request_host=\\.=(.*?);\\.;)",
+        "tag_name": "request_host"
+      },
+      {
+        "regex": "(response_flags=\\.=(.*?);\\.;)",
+        "tag_name": "response_flags"
+      },
+      {
+        "regex": "(grpc_response_status=\\.=(.*?);\\.;)",
+        "tag_name": "grpc_response_status"
+      },
+      {
+        "regex": "(connection_security_policy=\\.=(.*?);\\.;)",
+        "tag_name": "connection_security_policy"
+      },
+      {
+        "regex": "(source_canonical_service=\\.=(.*?);\\.;)",
+        "tag_name": "source_canonical_service"
+      },
+      {
+        "regex": "(destination_canonical_service=\\.=(.*?);\\.;)",
+        "tag_name": "destination_canonical_service"
+      },
+      {
+        "regex": "(source_canonical_revision=\\.=(.*?);\\.;)",
+        "tag_name": "source_canonical_revision"
+      },
+      {
+        "regex": "(destination_canonical_revision=\\.=(.*?);\\.;)",
+        "tag_name": "destination_canonical_revision"
+      },
+      {
+        "regex": "(cache\\.(.+?)\\.)",
+        "tag_name": "cache"
+      },
+      {
+        "regex": "(component\\.(.+?)\\.)",
+        "tag_name": "component"
+      },
+      {
+        "regex": "(tag\\.(.+?);\\.)",
+        "tag_name": "tag"
+      },
+      {
+        "regex": "(wasm_filter\\.(.+?)\\.)",
+        "tag_name": "wasm_filter"
+      },
+      {
+        "tag_name": "authz_enforce_result",
+        "regex": "rbac(\\.(allowed|denied))"
+      },
+      {
+        "tag_name": "authz_dry_run_action",
+        "regex": "(\\.istio_dry_run_(allow|deny)_)"
+      },
+      {
+        "tag_name": "authz_dry_run_result",
+        "regex": "(\\.shadow_(allowed|denied))"
+      }
+    ],
+    "stats_matcher": {
+      "inclusion_list": {
+        "patterns": [
+          {
+          "prefix": "reporter="
+          },
+          {
+          "prefix": "cluster_manager"
+          },
+          {
+          "prefix": "listener_manager"
+          },
+          {
+          "prefix": "server"
+          },
+          {
+          "prefix": "cluster.xds-grpc"
+          },
+          {
+          "prefix": "wasm"
+          },
+          {
+          "suffix": "rbac.allowed"
+          },
+          {
+          "suffix": "rbac.denied"
+          },
+          {
+          "suffix": "shadow_allowed"
+          },
+          {
+          "suffix": "shadow_denied"
+          },
+          {
+          "prefix": "component"
+          }
+        ]
+      }
+    }
+  },
+  "admin": {
+    "access_log_path": "/dev/null",
+    "profile_path": "/var/lib/istio/data/envoy.prof",
+    "address": {
+      "socket_address": {
+        "address": "127.0.0.1",
+        "port_value": 15000
+      }
+    }
+  },
+  "dynamic_resources": {
+    "lds_config": {
+      "ads": {},
+      "initial_fetch_timeout": "0s",
+      "resource_api_version": "V3"
+    },
+    "cds_config": {
+      "ads": {},
+      "initial_fetch_timeout": "0s",
+      "resource_api_version": "V3"
+    },
+    "ads_config": {
+      "api_type": "GRPC",
+      "set_node_on_first_message_only": true,
+      "transport_api_version": "V3",
+      "grpc_services": [
+        {
+          "envoy_grpc": {
+            "cluster_name": "xds-grpc"
+          }
+        }
+      ]
+    }
+  },
+  "static_resources": {
+    "clusters": [
+      {
+        "name": "prometheus_stats",
+        "type": "STATIC",
+        "connect_timeout": "0.250s",
+        "lb_policy": "ROUND_ROBIN",
+        "load_assignment": {
+          "cluster_name": "prometheus_stats",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "socket_address": {
+                    "protocol": "TCP",
+                    "address": "127.0.0.1",
+                    "port_value": 15000
+                  }
+                }
+              }
+            }]
+          }]
+        }
+      },
+      {
+        "name": "agent",
+        "type": "STATIC",
+        "connect_timeout": "0.250s",
+        "lb_policy": "ROUND_ROBIN",
+        "load_assignment": {
+          "cluster_name": "agent",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "socket_address": {
+                    "protocol": "TCP",
+                    "address": "127.0.0.1",
+                    "port_value": 15020
+                  }
+                }
+              }
+            }]
+          }]
+        }
+      },
+      {
+        "name": "sds-grpc",
+        "type": "STATIC",
+        "typed_extension_protocol_options": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+           "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+           "explicit_http_config": {
+            "http2_protocol_options": {}
+           }
+          }
+        },
+        "connect_timeout": "1s",
+        "lb_policy": "ROUND_ROBIN",
+        "load_assignment": {
+          "cluster_name": "sds-grpc",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "pipe": {
+                    "path": "/tmp/bootstrap/metrics_no_statsd/SDS"
+                  }
+                }
+              }
+            }]
+          }]
+        }
+      },
+      {
+        "name": "xds-grpc",
+        "type": "STRICT_DNS",
+        "respect_dns_ttl": true,
+        "dns_lookup_family": "V4_ONLY",
+        "connect_timeout": "1s",
+        "lb_policy": "ROUND_ROBIN",
+        "transport_socket": {
+          "name": "envoy.transport_sockets.tls",
+          "typed_config": {
+            "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+            "sni": "mypilot",
+            "common_tls_context": {
+              "alpn_protocols": [
+                "h2"
+              ],
+              "tls_certificate_sds_secret_configs": [
+                {
+                  "name": "default",
+                  "sds_config": {
+                    "resource_api_version": "V3",
+                    "initial_fetch_timeout": "0s",
+                    "api_config_source": {
+                      "api_type": "GRPC",
+                      "transport_api_version": "V3",
+                      "grpc_services": [
+                        {
+                          "envoy_grpc": { "cluster_name": "sds-grpc" }
+                        }
+                      ]
+                    }
+                  }
+                }
+              ],
+              "validation_context": {
+                "trusted_ca": {
+                  "filename": ""
+                 },
+                "match_subject_alt_names": [{"exact":"spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account"}]
+              }
+            }
+          }
+        },
+        "load_assignment": {
+          "cluster_name": "xds-grpc",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "socket_address": {"address": "mypilot", "port_value": 15011}
+                }
+              }
+            }]
+          }]
+        },
+        "circuit_breakers": {
+          "thresholds": [
+            {
+              "priority": "DEFAULT",
+              "max_connections": 100000,
+              "max_pending_requests": 100000,
+              "max_requests": 100000
+            },
+            {
+              "priority": "HIGH",
+              "max_connections": 100000,
+              "max_pending_requests": 100000,
+              "max_requests": 100000
+            }
+          ]
+        },
+        "upstream_connection_options": {
+          "tcp_keepalive": {
+            "keepalive_time": 300
+          }
+        },
+        "max_requests_per_connection": 1,
+        "typed_extension_protocol_options": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+           "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+           "explicit_http_config": {
+            "http2_protocol_options": {}
+           }
+          }
+        }
+      }
+      
+      ,
+      {
+        "name": "envoy_metrics_service",
+        "type": "STRICT_DNS",
+        "transport_socket": {"name":"envoy.transport_sockets.tls","typed_config":{"@type":"type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext","common_tls_context":{"alpn_protocols":["h2"],"combined_validation_context":{"default_validation_context":{},"validation_context_sds_secret_config":{"name":"file-root:/etc/istio/ms/ca.pem","sds_config":{"api_config_source":{"api_type":"GRPC","grpc_services":[{"envoy_grpc":{"cluster_name":"sds-grpc"}}],"set_node_on_first_message_only":true,"transport_api_version":"V3"},"resource_api_version":"V3"}}},"tls_certificate_sds_secret_configs":[{"name":"file-cert:/etc/istio/ms/client.pem~/etc/istio/ms/key.pem","sds_config":{"api_config_source":{"api_type":"GRPC","grpc_services":[{"envoy_grpc":{"cluster_name":"sds-grpc"}}],"set_node_on_first_message_only":true,"transport_api_version":"V3"},"resource_api_version":"V3"}}]}}},
+        "respect_dns_ttl": true,
+        "dns_lookup_family": "V4_ONLY",
+        "connect_timeout": "1s",
+        "lb_policy": "ROUND_ROBIN",
+        "typed_extension_protocol_options": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+           "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+           "explicit_http_config": {
+            "http2_protocol_options": {}
+           }
+          }
+        },
+        "load_assignment": {
+          "cluster_name": "envoy_metrics_service",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "socket_address": {"address": "metrics-service", "port_value": 15000}
+                }
+              }
+            }]
+          }]
+        }
+      }
+      
+    ],
+    "listeners":[
+      {
+        "address": {
+          "socket_address": {
+            "protocol": "TCP",
+            "address": "0.0.0.0",
+            "port_value": 15090
+          }
+        },
+        "filter_chains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.http_connection_manager",
+                "typed_config": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "codec_type": "AUTO",
+                  "stat_prefix": "stats",
+                  "route_config": {
+                    "virtual_hosts": [
+                      {
+                        "name": "backend",
+                        "domains": [
+                          "*"
+                        ],
+                        "routes": [
+                          {
+                            "match": {
+                              "prefix": "/stats/prometheus"
+                            },
+                            "route": {
+                              "cluster": "prometheus_stats"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "http_filters": [{
+                    "name": "envoy.filters.http.router",
+                    "typed_config": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                    }
+                  }]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "address": {
+           "socket_address": {
+             "protocol": "TCP",
+             "address": "0.0.0.0",
+             "port_value": 15021
+           }
+        },
+        "filter_chains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.http_connection_manager",
+                "typed_config": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "codec_type": "AUTO",
+                  "stat_prefix": "agent",
+                  "route_config": {
+                    "virtual_hosts": [
+                      {
+                        "name": "backend",
+                        "domains": [
+                          "*"
+                        ],
+                        "routes": [
+                          {
+                            "match": {
+                              "prefix": "/healthz/ready"
+                            },
+                            "route": {
+                              "cluster": "agent"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "http_filters": [{
+                    "name": "envoy.filters.http.router",
+                    "typed_config": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                    }
+                  }]
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }  
+  ,
+  "stats_sinks": [
+    
+    {
+      "name": "envoy.stat_sinks.metrics_service",
+      "typed_config": {
+        "@type": "type.googleapis.com/envoy.config.metrics.v3.MetricsServiceConfig",
+        "transport_api_version": "V3",
+        "grpc_service": {
+          "envoy_grpc": {
+            "cluster_name": "envoy_metrics_service"
+          }
+        }
+      }
+    }
+    
+  ]
+  
+  
+  ,
+  "cluster_manager": {
+    "outlier_detection": {
+      "event_log_path": "/dev/stdout"
+    }
+  }
+  
+}

--- a/tools/packaging/common/envoy_bootstrap.json
+++ b/tools/packaging/common/envoy_bootstrap.json
@@ -740,7 +740,10 @@
           }
         }
       }
-    },
+    }
+    {{ end }}
+    {{ if and .envoy_metrics_service_address .statsd }}
+    ,
     {{ end }}
     {{ if .statsd }}
     {


### PR DESCRIPTION
**Please provide a description of this PR:**

Due to the new Bootstrap Discovery Service, and how the template is rendered in transport, a formatting issue in bootstrap template related to the metrics service just surfaced. This fixes the issue for a strict JSON formatting.

When `envoyMetricsService` is present in the `MeshConfig`, the following warning can be observed in `istiod`
```2021-08-05T12:40:13.550596Z     warn       ads     failed to unmarshal bootstrap from JSON "": invalid character ']' looking for beginning of value```
Which corresponds to the following [line of code](https://github.com/istio/istio/blob/master/pilot/pkg/xds/bootstrapds.go#L58).

It seems that the way this was being rendered was not an issue before, but the jsonpb Unmarshal is stricter about commas.

IstioOperator used:
```
apiVersion: install.istio.io/v1alpha1
kind: IstioOperator
metadata:
  name: example-istiooperator
  namespace: istio-system
spec:
  profile: preview
  meshConfig:
    enableAutoMtls: true
    defaultConfig:
      envoyAccessLogService:
        address: enterprise-agent.gloo-mesh:9977
      envoyMetricsService:
        address: enterprise-agent.gloo-mesh:9977
      proxyMetadata:
        # Enable Istio agent to handle DNS requests for known hosts
        # Unknown hosts will automatically be resolved using upstream dns servers in resolv.conf
        ISTIO_META_DNS_CAPTURE: "true"
      proxyStatsMatcher:
        inclusionPrefixes:
        - "http"
  components:
    # Istio Gateway feature
    ingressGateways:
    - name: istio-ingressgateway
      enabled: true
      label:
        traffic: east-west
      k8s:
        env:
          # needed for Gateway TLS AUTO_PASSTHROUGH mode, reference: https://istio.io/latest/docs/reference/config/networking/gateway/#ServerTLSSettings-TLSmode
          - name: ISTIO_META_ROUTER_MODE
            value: "sni-dnat"
        service:
          type: NodePort
          selector:
            app: istio-ingressgateway
            istio: ingressgateway
            traffic: east-west
          ports:
            - port: 443
              targetPort: 8443
              name: https
            - port: 15443
              targetPort: 15443
              name: tls
              nodePort: 32000
  values:
    global:
      pilotCertProvider: istiod
```


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [x] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
