### PR TITLE
Revert "Skip push cds for sidecar when virtualService updated"

### DIFF
--- a/pilot/pkg/xds/ads_test.go
+++ b/pilot/pkg/xds/ads_test.go
@@ -556,8 +556,7 @@ func TestAdsPushScoping(t *testing.T) {
 				hosts []string
 				dest  string
 			}{{index: 4, hosts: []string{fmt.Sprintf("svc%d%s", 4, svcSuffix)}, dest: "foo.com"}},
-			expectUpdates:   []string{v3.ListenerType, v3.RouteType},
-			unexpectUpdates: []string{v3.ClusterType, v3.EndpointType},
+			expectUpdates: []string{v3.ClusterType, v3.EndpointType},
 		},
 		{
 			desc: "Add instances for transitively scoped svc",
@@ -577,8 +576,7 @@ func TestAdsPushScoping(t *testing.T) {
 				hosts []string
 				dest  string
 			}{{index: 4}},
-			expectUpdates:   []string{v3.ListenerType, v3.RouteType},
-			unexpectUpdates: []string{v3.ClusterType, v3.EndpointType},
+			expectUpdates: []string{v3.ClusterType},
 		},
 		{
 			desc: "Add delegation virtual service for scoped service with transitively scoped dest svc",
@@ -588,8 +586,7 @@ func TestAdsPushScoping(t *testing.T) {
 				hosts []string
 				dest  string
 			}{{index: 4, hosts: []string{fmt.Sprintf("svc%d%s", 4, svcSuffix)}, dest: "foo.com"}},
-			expectUpdates:   []string{v3.ListenerType, v3.RouteType},
-			unexpectUpdates: []string{v3.ClusterType, v3.EndpointType},
+			expectUpdates: []string{v3.ListenerType, v3.RouteType, v3.ClusterType, v3.EndpointType},
 		},
 		{
 			desc: "Update delegate virtual service should trigger full push",
@@ -599,8 +596,7 @@ func TestAdsPushScoping(t *testing.T) {
 				hosts []string
 				dest  string
 			}{{index: 4, hosts: []string{fmt.Sprintf("svc%d%s", 4, svcSuffix)}, dest: "foo.com"}},
-			expectUpdates:   []string{v3.ListenerType, v3.RouteType},
-			unexpectUpdates: []string{v3.ClusterType, v3.EndpointType},
+			expectUpdates: []string{v3.ListenerType, v3.RouteType, v3.ClusterType},
 		},
 		{
 			desc: "Delete delegate virtual service for scoped service with transitively scoped dest svc",
@@ -610,8 +606,7 @@ func TestAdsPushScoping(t *testing.T) {
 				hosts []string
 				dest  string
 			}{{index: 4}},
-			expectUpdates:   []string{v3.ListenerType, v3.RouteType},
-			unexpectUpdates: []string{v3.ClusterType, v3.EndpointType},
+			expectUpdates: []string{v3.ListenerType, v3.RouteType, v3.ClusterType},
 		},
 		{
 			desc:          "Remove a scoped service",

--- a/pilot/pkg/xds/cds.go
+++ b/pilot/pkg/xds/cds.go
@@ -28,7 +28,6 @@ var _ model.XdsResourceGenerator = &CdsGenerator{}
 
 // Map of all configs that do not impact CDS
 var skippedCdsConfigs = map[config.GroupVersionKind]struct{}{
-	gvk.VirtualService:        {},
 	gvk.Gateway:               {},
 	gvk.WorkloadEntry:         {},
 	gvk.WorkloadGroup:         {},
@@ -43,7 +42,7 @@ var pushCdsGatewayConfig = map[config.GroupVersionKind]struct{}{
 	gvk.Gateway:        {},
 }
 
-func CdsNeedsPush(req *model.PushRequest, proxy *model.Proxy) bool {
+func cdsNeedsPush(req *model.PushRequest, proxy *model.Proxy) bool {
 	if req == nil {
 		return true
 	}
@@ -55,7 +54,6 @@ func CdsNeedsPush(req *model.PushRequest, proxy *model.Proxy) bool {
 	if len(req.ConfigsUpdated) == 0 {
 		return true
 	}
-
 	for config := range req.ConfigsUpdated {
 		if proxy.Type == model.Router {
 			if _, f := pushCdsGatewayConfig[config.Kind]; f {
@@ -72,7 +70,7 @@ func CdsNeedsPush(req *model.PushRequest, proxy *model.Proxy) bool {
 
 func (c CdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource,
 	updates *model.PushRequest) (model.Resources, model.XdsLogDetails, error) {
-	if !CdsNeedsPush(updates, proxy) {
+	if !cdsNeedsPush(updates, proxy) {
 		return nil, model.DefaultXdsLogDetails, nil
 	}
 	clusters, logs := c.Server.ConfigGenerator.BuildClusters(proxy, updates)
@@ -82,7 +80,7 @@ func (c CdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *m
 // GenerateDeltas for CDS currently only builds deltas when services change. todo implement changes for DestinationRule, etc
 func (c CdsGenerator) GenerateDeltas(proxy *model.Proxy, push *model.PushContext, updates *model.PushRequest,
 	w *model.WatchedResource) (model.Resources, []string, model.XdsLogDetails, bool, error) {
-	if !CdsNeedsPush(updates, proxy) {
+	if !cdsNeedsPush(updates, proxy) {
 		return nil, nil, model.DefaultXdsLogDetails, false, nil
 	}
 	updatedClusters, removedClusters, logs, usedDelta := c.Server.ConfigGenerator.BuildDeltaClusters(proxy, updates, w)

--- a/pilot/pkg/xds/cds_test.go
+++ b/pilot/pkg/xds/cds_test.go
@@ -16,126 +16,12 @@ package xds_test
 import (
 	"testing"
 
-	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/xds"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
-	"istio.io/istio/pkg/config/schema/gvk"
 )
 
 func TestCDS(t *testing.T) {
 	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
 	ads := s.ConnectADS().WithType(v3.ClusterType)
 	ads.RequestResponseAck(t, nil)
-}
-
-func TestCdsNeedsPush(t *testing.T) {
-	testCases := []struct {
-		name           string
-		proxyType      model.NodeType
-		configsUpdated map[model.ConfigKey]struct{}
-		expected       bool
-	}{
-		{
-			name:      "sidecar without configs that do not influence cds",
-			proxyType: model.SidecarProxy,
-			configsUpdated: map[model.ConfigKey]struct{}{
-				{
-					Kind:      gvk.VirtualService,
-					Name:      "vs1",
-					Namespace: "test",
-				}: {},
-				{
-					Kind:      gvk.Gateway,
-					Name:      "gw1",
-					Namespace: "test",
-				}: {},
-				{
-					Kind:      gvk.AuthorizationPolicy,
-					Name:      "authz1",
-					Namespace: "test",
-				}: {},
-				{
-					Kind:      gvk.RequestAuthentication,
-					Name:      "ra1",
-					Namespace: "test",
-				}: {},
-			},
-			expected: false,
-		},
-		{
-			name:      "sidecar with configs that influence cds",
-			proxyType: model.SidecarProxy,
-			configsUpdated: map[model.ConfigKey]struct{}{
-				{
-					Kind:      gvk.VirtualService,
-					Name:      "vs1",
-					Namespace: "test",
-				}: {},
-				{
-					Kind:      gvk.Gateway,
-					Name:      "gw1",
-					Namespace: "test",
-				}: {},
-				{
-					Kind:      gvk.AuthorizationPolicy,
-					Name:      "authz1",
-					Namespace: "test",
-				}: {},
-				{
-					Kind:      gvk.RequestAuthentication,
-					Name:      "ra1",
-					Namespace: "test",
-				}: {},
-				{
-					Kind:      gvk.DestinationRule,
-					Name:      "ra1",
-					Namespace: "test",
-				}: {},
-			},
-			expected: true,
-		},
-		{
-			name:      "gateway with nil configs",
-			proxyType: model.SidecarProxy,
-			expected:  true,
-		},
-		{
-			name:      "gateway with common configs that influence cds",
-			proxyType: model.Router,
-			configsUpdated: map[model.ConfigKey]struct{}{
-				{
-					Kind:      gvk.VirtualService,
-					Name:      "vs1",
-					Namespace: "test",
-				}: {},
-			},
-			expected: true,
-		},
-		{
-			name:      "gateway with common configs that influence cds",
-			proxyType: model.Router,
-			configsUpdated: map[model.ConfigKey]struct{}{
-				{
-					Kind:      gvk.ServiceEntry,
-					Name:      "svc",
-					Namespace: "test",
-				}: {},
-			},
-			expected: true,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			req := &model.PushRequest{
-				Full:           true,
-				ConfigsUpdated: tc.configsUpdated,
-			}
-			proxy := &model.Proxy{Type: tc.proxyType}
-			got := xds.CdsNeedsPush(req, proxy)
-			if got != tc.expected {
-				t.Errorf("Got unexpected %v, expected %v", got, tc.expected)
-			}
-		})
-	}
 }


### PR DESCRIPTION
Reverts istio/istio#34537

This is to add back https://github.com/istio/istio/pull/27651 which fixed https://github.com/istio/istio/issues/27650

We can probably filter many VS updates, but need a bit more complex logic I think