### PR TITLE
extract clusterID from injector config for istioctl experimental workload entry configure

### DIFF
--- a/istioctl/cmd/options.go
+++ b/istioctl/cmd/options.go
@@ -53,3 +53,14 @@ func optionsCommand(rootCmd *cobra.Command) *cobra.Command {
 
 	return retval
 }
+
+// validateFlagIsSetManuallyOrNot can validate that a persistent flag is set manually or not by user for given command
+func validateFlagIsSetManuallyOrNot(istioCmd *cobra.Command, flagName string) bool {
+	if istioCmd != nil {
+		allPersistentFlagSet := istioCmd.PersistentFlags()
+		if flagName != "" {
+			return allPersistentFlagSet.Changed(flagName)
+		}
+	}
+	return false
+}


### PR DESCRIPTION
This PR fixed bug to extract clusterID from injector config for istioctl experimental workload entry configure.
In this PR, I imported a function named `validateFlagIsSetManuallyOrNot`  to validate that a persistent flag is set manually or not by user for given command. I think it should be a useful.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [x] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
