### PR TITLE
Fuzzing: Add bootstrap fuzzer

### DIFF
--- a/tests/fuzz/bootstrap_fuzzer.go
+++ b/tests/fuzz/bootstrap_fuzzer.go
@@ -1,0 +1,82 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// nolint: golint
+package fuzz
+
+import (
+	"os"
+	"time"
+
+	fuzz "github.com/AdaLogics/go-fuzz-headers"
+
+	"istio.io/istio/pilot/pkg/bootstrap"
+	"istio.io/istio/pkg/config/mesh"
+)
+
+func FuzzNewBootstrapServer(data []byte) int {
+	f := fuzz.NewConsumer(data)
+
+	// Create mesh config file
+	meshConfigFile, err := createRandomConfigFile(f)
+	if err != nil {
+		return 0
+	}
+	defer os.Remove(meshConfigFile)
+	_, err = os.Stat(meshConfigFile)
+	if err != nil {
+		return 0
+	}
+	// Validate mesh config file
+	meshConfigYaml, err := mesh.ReadMeshConfigData(meshConfigFile)
+	if err != nil {
+		return 0
+	}
+	_, err = mesh.ApplyMeshConfigDefaults(meshConfigYaml)
+	if err != nil {
+		return 0
+	}
+
+	// Create kube config file
+	kubeConfigFile, err := createRandomConfigFile(f)
+	if err != nil {
+		return 0
+	}
+	defer os.Remove(kubeConfigFile)
+
+	args := &bootstrap.PilotArgs{}
+	err = f.GenerateStruct(args)
+	if err != nil {
+		return 0
+	}
+
+	args.MeshConfigFile = meshConfigFile
+	args.RegistryOptions.KubeConfig = kubeConfigFile
+	args.ShutdownDuration = 1 * time.Millisecond
+
+	stop := make(chan struct{})
+	s, err := bootstrap.NewServer(args)
+	if err != nil {
+		return 0
+	}
+	err = s.Start(stop)
+	if err != nil {
+		return 0
+	}
+	defer func() {
+		close(stop)
+		s.WaitUntilCompletion()
+	}()
+	return 1
+}

--- a/tests/fuzz/oss_fuzz_build.sh
+++ b/tests/fuzz/oss_fuzz_build.sh
@@ -41,6 +41,7 @@ compile_go_fuzzer istio.io/istio/tests/fuzz FuzzResolveK8sConflict fuzz_resolve_
 compile_go_fuzzer istio.io/istio/tests/fuzz FuzzYAMLManifestPatch fuzz_yaml_manifest_patch
 compile_go_fuzzer istio.io/istio/tests/fuzz FuzzGalleyMeshFs fuzz_galley_mesh_fs
 compile_go_fuzzer istio.io/istio/tests/fuzz FuzzGalleyDiag fuzz_galley_diag
+compile_go_fuzzer istio.io/istio/tests/fuzz FuzzNewBootstrapServer fuzz_new_bootstrap_server
 
 # Create seed corpora:
 zip "${OUT}"/fuzz_analyzer_seed_corpus.zip "${SRC}"/istio/galley/pkg/config/analysis/analyzers/testdata/*.yaml

--- a/tests/fuzz/regression_test.go
+++ b/tests/fuzz/regression_test.go
@@ -142,6 +142,7 @@ func TestFuzzers(t *testing.T) {
 		{"FuzzYAMLManifestPatch", FuzzYAMLManifestPatch},
 		{"FuzzGalleyMeshFs", FuzzGalleyMeshFs},
 		{"FuzzGalleyDiag", FuzzGalleyDiag},
+		{"FuzzNewBootstrapServer", FuzzNewBootstrapServer},
 	}
 	for _, tt := range cases {
 		if testedFuzzers.Contains(tt.name) {


### PR DESCRIPTION
Adds fuzzer that creates a fuzzed `bootstrap.PilotArgs{}` and passes it on to `bootstrap.NewServer()`



**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [x] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [x] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
