### PR TITLE
[1.11] Fully disable CDS cache

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -38,6 +38,7 @@ import (
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/util"
 	authn_model "istio.io/istio/pilot/pkg/security/model"
@@ -1039,6 +1040,9 @@ func (cb *ClusterBuilder) normalizeClusters(clusters []*discovery.Resource) []*d
 // This code will only trigger a cache hit if all subset clusters are present. This simplifies the code a bit,
 // as the non-subset and subset cluster generation are tightly coupled, in exchange for a likely trivial cache hit rate impact.
 func (cb *ClusterBuilder) getAllCachedSubsetClusters(clusterKey clusterCache) ([]*discovery.Resource, map[string]model.CacheToken, bool) {
+	if features.EnableCDSCaching {
+		return nil, nil, false
+	}
 	destinationRule := CastDestinationRule(clusterKey.destinationRule)
 	res := make([]*discovery.Resource, 0, 1+len(destinationRule.GetSubsets()))
 	tokens := make(map[string]model.CacheToken, 1+len(destinationRule.GetSubsets()))


### PR DESCRIPTION
![2021-09-08_08-58-28](https://user-images.githubusercontent.com/623453/128736903-53c7deab-c6ff-438b-a91c-691f21c0152b.png)

Causes excessive memory usage. I am almost certain this is fixed in `master` already because we got rid of the tokens; over 75% of the memory is spent on storing the tokens.