### PR TITLE
restart echo listeners

### DIFF
--- a/pkg/test/echo/server/endpoint/grpc.go
+++ b/pkg/test/echo/server/endpoint/grpc.go
@@ -127,8 +127,10 @@ func (s *grpcInstance) Start(onReady OnReadyFunc) error {
 	}
 	// Start serving GRPC traffic.
 	go func() {
-		err := s.server.Serve(listener)
-		epLog.Warnf("Port %d listener terminated with error: %v", p, err)
+		for {
+			err := s.server.Serve(listener)
+			epLog.Warnf("Port %d listener terminated with error: %v", p, err)
+		}
 	}()
 
 	// Notify the WaitGroup once the port has transitioned to ready.


### PR DESCRIPTION
Not sure this is actually a good idea. This could prevent tests from failing when they should. 
An alternative is to `panic` here; IIRC we have something that marks tests failed if container restarts are detected. 