### PR TITLE
Make the adduser evaluation in post-install less OS dependant

### DIFF
--- a/tools/packaging/postinst.sh
+++ b/tools/packaging/postinst.sh
@@ -20,7 +20,7 @@ set -e
 umask 022
 
 if ! getent passwd istio-proxy >/dev/null; then
-    if [ -x /usr/sbin/useradd ]; then
+    if command -v useradd >/dev/null; then
         groupadd --system istio-proxy
         useradd --system --gid istio-proxy --home-dir /var/lib/istio istio-proxy
     else

--- a/tools/packaging/postinst.sh
+++ b/tools/packaging/postinst.sh
@@ -20,7 +20,7 @@ set -e
 umask 022
 
 if ! getent passwd istio-proxy >/dev/null; then
-    if  find /etc/*release | grep -Eiq 'centos|redhat'; then
+    if [ -x /usr/sbin/useradd ]; then
         groupadd --system istio-proxy
         useradd --system --gid istio-proxy --home-dir /var/lib/istio istio-proxy
     else


### PR DESCRIPTION
This change makes the evaluation of `useradd` and `groupadd` less dependant on the OS type and more reliant on the availability of the command itself. The current `if` statement does not work in SUSE distros since SUSE also uses  `groupadd` and `useradd` same as redhat and centos.



**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [x] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
