### PR TITLE
Fuzzing: Add kube fuzzer

### DIFF
--- a/tests/fuzz/kube_fuzzer.go
+++ b/tests/fuzz/kube_fuzzer.go
@@ -1,0 +1,86 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// nolint: golint
+package fuzz
+
+import (
+	fuzz "github.com/AdaLogics/go-fuzz-headers"
+
+	"istio.io/istio/galley/pkg/config/source/kube/inmemory"
+	"istio.io/istio/galley/pkg/config/testing/basicmeta"
+	"istio.io/istio/galley/pkg/config/testing/fixtures"
+)
+
+func setupKubeSource() *inmemory.KubeSource {
+	s := inmemory.NewKubeSource(basicmeta.MustGet().KubeCollections())
+	acc := &fixtures.Accumulator{}
+	s.Dispatch(acc)
+	return s
+}
+
+func applyFuzzedContent(f *fuzz.ConsumeFuzzer, s *inmemory.KubeSource) error {
+	name, err := f.GetString()
+	if err != nil {
+		return err
+	}
+	yamlText, err := f.GetString()
+	if err != nil {
+		return err
+	}
+	_ = s.ApplyContent(name, yamlText)
+	return nil
+}
+
+func removeFuzzedContent(f *fuzz.ConsumeFuzzer, s *inmemory.KubeSource) error {
+	name, err := f.GetString()
+	if err != nil {
+		return err
+	}
+	s.RemoveContent(name)
+	return nil
+}
+
+func FuzzInmemoryKube(data []byte) int {
+	f := fuzz.NewConsumer(data)
+	s := setupKubeSource()
+	s.Start()
+	defer s.Stop()
+
+	numberOfIterations, err := f.GetInt()
+	if err != nil {
+		return 0
+	}
+	totalIters := numberOfIterations % 30
+	for i := 0; i < totalIters; i++ {
+		action, err := f.GetInt()
+		if err != nil {
+			return 0
+		}
+		if action%1 == 0 {
+			err = applyFuzzedContent(f, s)
+			if err != nil {
+				return 0
+			}
+		} else if action%2 == 0 {
+			err = removeFuzzedContent(f, s)
+			if err != nil {
+				return 0
+			}
+		} else if action%3 == 0 {
+			_ = s.ContentNames()
+		}
+	}
+	return 1
+}

--- a/tests/fuzz/oss_fuzz_build.sh
+++ b/tests/fuzz/oss_fuzz_build.sh
@@ -42,6 +42,7 @@ compile_go_fuzzer istio.io/istio/tests/fuzz FuzzYAMLManifestPatch fuzz_yaml_mani
 compile_go_fuzzer istio.io/istio/tests/fuzz FuzzGalleyMeshFs fuzz_galley_mesh_fs
 compile_go_fuzzer istio.io/istio/tests/fuzz FuzzGalleyDiag fuzz_galley_diag
 compile_go_fuzzer istio.io/istio/tests/fuzz FuzzNewBootstrapServer fuzz_new_bootstrap_server
+compile_go_fuzzer istio.io/istio/tests/fuzz FuzzInmemoryKube fuzz_inmemory_kube
 
 # Create seed corpora:
 zip "${OUT}"/fuzz_analyzer_seed_corpus.zip "${SRC}"/istio/galley/pkg/config/analysis/analyzers/testdata/*.yaml

--- a/tests/fuzz/regression_test.go
+++ b/tests/fuzz/regression_test.go
@@ -143,6 +143,7 @@ func TestFuzzers(t *testing.T) {
 		{"FuzzGalleyMeshFs", FuzzGalleyMeshFs},
 		{"FuzzGalleyDiag", FuzzGalleyDiag},
 		{"FuzzNewBootstrapServer", FuzzNewBootstrapServer},
+		{"FuzzInmemoryKube", FuzzInmemoryKube},
 	}
 	for _, tt := range cases {
 		if testedFuzzers.Contains(tt.name) {


### PR DESCRIPTION
Adds fuzzer that targets istio.io/istio/galley/pkg/config/source/kube/inmemory APIs



**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [x] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [x] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
