### PR TITLE
grpc-agent template sets holdApplicationUntilProxyStarts

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -962,6 +962,8 @@ data:
           {{- range $index, $container := .Spec.Containers  }}
           {{ if not (eq $container.Name "istio-proxy") }}
           - name: {{ $container.Name }}
+            annotations:
+              proxy.istio.io/config: '{"holdApplicationUntilProxyStarts": true}'
             env:
             - name: "GRPC_XDS_BOOTSTRAP"
               value: "/var/lib/istio/data/grpc-bootstrap.json"

--- a/manifests/charts/istio-control/istio-discovery/files/grpc-agent.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/grpc-agent.yaml
@@ -13,6 +13,8 @@ spec:
   {{- range $index, $container := .Spec.Containers  }}
   {{ if not (eq $container.Name "istio-proxy") }}
   - name: {{ $container.Name }}
+    annotations:
+      proxy.istio.io/config: '{"holdApplicationUntilProxyStarts": true}'
     env:
     - name: "GRPC_XDS_BOOTSTRAP"
       value: "/var/lib/istio/data/grpc-bootstrap.json"


### PR DESCRIPTION
It's possible for an app to race with `server.Serve(listener)` and the agent generating the bootstrap/xds proxy being ready. 

