### PR TITLE
istioctl: fix skip confirmation with dryrun while upgrading istio

### DIFF
--- a/operator/cmd/mesh/upgrade.go
+++ b/operator/cmd/mesh/upgrade.go
@@ -215,7 +215,7 @@ func upgrade(rootArgs *rootArgs, args *upgradeArgs, l clog.Logger) (err error) {
 	}
 	checkUpgradeIOPS(currentProfileIOPSYaml, targetIOPYaml, overrideIOPYaml, l)
 
-	waitForConfirmation(args.skipConfirmation, l)
+	waitForConfirmation(args.skipConfirmation || rootArts.dryRun, l)
 
 	// Apply the Istio Control Plane specs reading from inFilenames to the cluster
 	iop, err := InstallManifests(targetIOP, args.force, rootArgs.dryRun, restConfig, client, args.readinessTimeout, l)

--- a/operator/cmd/mesh/upgrade.go
+++ b/operator/cmd/mesh/upgrade.go
@@ -215,7 +215,7 @@ func upgrade(rootArgs *rootArgs, args *upgradeArgs, l clog.Logger) (err error) {
 	}
 	checkUpgradeIOPS(currentProfileIOPSYaml, targetIOPYaml, overrideIOPYaml, l)
 
-	waitForConfirmation(args.skipConfirmation && !rootArgs.dryRun, l)
+	waitForConfirmation(args.skipConfirmation, l)
 
 	// Apply the Istio Control Plane specs reading from inFilenames to the cluster
 	iop, err := InstallManifests(targetIOP, args.force, rootArgs.dryRun, restConfig, client, args.readinessTimeout, l)

--- a/operator/cmd/mesh/upgrade.go
+++ b/operator/cmd/mesh/upgrade.go
@@ -215,7 +215,7 @@ func upgrade(rootArgs *rootArgs, args *upgradeArgs, l clog.Logger) (err error) {
 	}
 	checkUpgradeIOPS(currentProfileIOPSYaml, targetIOPYaml, overrideIOPYaml, l)
 
-	waitForConfirmation(args.skipConfirmation || rootArts.dryRun, l)
+	waitForConfirmation(args.skipConfirmation || rootArgs.dryRun, l)
 
 	// Apply the Istio Control Plane specs reading from inFilenames to the cluster
 	iop, err := InstallManifests(targetIOP, args.force, rootArgs.dryRun, restConfig, client, args.readinessTimeout, l)


### PR DESCRIPTION
**Please provide a description of this PR:**

I encounter bug behavior while executing istioctl upgrade with skip confirmation and dry-run in 1.9.7 and master branch.
```
./out/linux_amd64/istioctl upgrade --force --dry-run --skip-confirmation -f /root/infrastructure/community-ops/istio_mesh/cluster.yaml 

.
.
Upgrade version check passed: 1.9.7 -> 1.12.0.
.
.
.

Confirm to proceed [y/N]? ^C
```

`waitForConfirmation()` function should not be depends on `dryRun` args. This PR removing the bad logic when calling `waitForConfirmation()`.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [x] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [x] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
