### PR TITLE
grpc xds bootstrap: include full node metadata

### DIFF
--- a/pilot/pkg/config/kube/ingressv1/conversion.go
+++ b/pilot/pkg/config/kube/ingressv1/conversion.go
@@ -40,7 +40,7 @@ import (
 const (
 	IstioIngressController = "istio.io/ingress-controller"
 )
-var x =1
+
 var errNotFound = errors.New("item not found")
 
 // EncodeIngressRuleName encodes an ingress rule name for a given ingress resource name,

--- a/pilot/pkg/config/kube/ingressv1/conversion.go
+++ b/pilot/pkg/config/kube/ingressv1/conversion.go
@@ -40,7 +40,7 @@ import (
 const (
 	IstioIngressController = "istio.io/ingress-controller"
 )
-
+var x =1
 var errNotFound = errors.New("item not found")
 
 // EncodeIngressRuleName encodes an ingress rule name for a given ingress resource name,

--- a/pilot/pkg/networking/grpcgen/grpcgen_test.go
+++ b/pilot/pkg/networking/grpcgen/grpcgen_test.go
@@ -54,10 +54,12 @@ func bootstrapForTest(nodeID, namespace string) ([]byte, error) {
 	bootstrap, err := grpcxds.GenerateBootstrap(grpcxds.GenerateBootstrapOptions{
 		Node: &model.Node{
 			ID: nodeID,
-			RawMetadata: map[string]interface{}{
-				"NAMESPACE":  namespace,
-				"GENERATOR":  "grpc",
-				"CLUSTER_ID": "Kubernetes",
+			Metadata: &model.BootstrapNodeMetadata{
+				NodeMetadata: model.NodeMetadata{
+					Namespace: namespace,
+					Generator: "grpc",
+					ClusterID: "Kubernetes",
+				},
 			},
 		},
 		DiscoveryAddress: grpcXdsAddr,

--- a/pkg/istio-agent/agent_test.go
+++ b/pkg/istio-agent/agent_test.go
@@ -389,8 +389,11 @@ func TestAgent(t *testing.T) {
 		if err != nil {
 			t.Fatalf("could not read bootstrap config: %v", err)
 		}
-		// make UDS path in file deterministic
+		// make results determinitstic
 		got = []byte(strings.ReplaceAll(string(got), a.agent.cfg.XdsUdsPath, "etc/istio/XDS"))
+		got = []byte(strings.ReplaceAll(string(got), a.agent.proxyConfig.ConfigPath, "/something/predictable"))
+		got = []byte(strings.ReplaceAll(string(got), a.agent.proxyConfig.DiscoveryAddress, "something.predictable:123"))
+
 		testutil.CompareContent(got, filepath.Join(env.IstioSrc, "pkg/istio-agent/testdata/grpc-bootstrap.json"), t)
 	})
 }

--- a/pkg/istio-agent/agent_test.go
+++ b/pkg/istio-agent/agent_test.go
@@ -44,6 +44,7 @@ import (
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/envoy"
 	"istio.io/istio/pkg/file"
+	"istio.io/istio/pkg/istio-agent/grpcxds"
 	"istio.io/istio/pkg/security"
 	"istio.io/istio/pkg/spiffe"
 	"istio.io/istio/pkg/test"
@@ -385,14 +386,20 @@ func TestAgent(t *testing.T) {
 			a.envoyEnable = false
 			return a
 		})
-		got, err := os.ReadFile(bootstrapPath)
+		generated, err := grpcxds.LoadBootstrap(bootstrapPath)
 		if err != nil {
 			t.Fatalf("could not read bootstrap config: %v", err)
 		}
-		// make results determinitstic
+
+		// goldenfile determinism
+		for _, k := range []string{"PROV_CERT", "PROXY_CONFIG"} {
+			delete(generated.Node.Metadata.Fields, k)
+		}
+		got, err := json.MarshalIndent(generated, "", "  ")
+		if err != nil {
+			t.Fatalf("failed to marshal bootstrap: %v", err)
+		}
 		got = []byte(strings.ReplaceAll(string(got), a.agent.cfg.XdsUdsPath, "etc/istio/XDS"))
-		got = []byte(strings.ReplaceAll(string(got), a.agent.proxyConfig.ConfigPath, "/something/predictable"))
-		got = []byte(strings.ReplaceAll(string(got), a.agent.proxyConfig.DiscoveryAddress, "something.predictable:123"))
 
 		testutil.CompareContent(got, filepath.Join(env.IstioSrc, "pkg/istio-agent/testdata/grpc-bootstrap.json"), t)
 	})

--- a/pkg/istio-agent/grpcxds/grpc_bootstrap.go
+++ b/pkg/istio-agent/grpcxds/grpc_bootstrap.go
@@ -25,6 +25,7 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/structpb"
+
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/file"
 )

--- a/pkg/istio-agent/grpcxds/grpc_bootstrap.go
+++ b/pkg/istio-agent/grpcxds/grpc_bootstrap.go
@@ -17,7 +17,6 @@ package grpcxds
 import (
 	"encoding/json"
 	"fmt"
-	"google.golang.org/protobuf/types/known/structpb"
 	"os"
 	"path"
 	"time"
@@ -25,6 +24,7 @@ import (
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/structpb"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/file"
 )

--- a/pkg/istio-agent/grpcxds/grpc_bootstrap.go
+++ b/pkg/istio-agent/grpcxds/grpc_bootstrap.go
@@ -17,6 +17,7 @@ package grpcxds
 import (
 	"encoding/json"
 	"fmt"
+	"google.golang.org/protobuf/types/known/structpb"
 	"os"
 	"path"
 	"time"
@@ -24,8 +25,6 @@ import (
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/durationpb"
-	"google.golang.org/protobuf/types/known/structpb"
-
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/file"
 )
@@ -118,9 +117,9 @@ type GenerateBootstrapOptions struct {
 
 // GenerateBootstrap generates the bootstrap structure for gRPC XDS integration.
 func GenerateBootstrap(opts GenerateBootstrapOptions) (*Bootstrap, error) {
-	xdsMeta, err := structpb.NewStruct(opts.Node.RawMetadata)
+	xdsMeta, err := extractMeta(opts.Node)
 	if err != nil {
-		return nil, fmt.Errorf("failed converting to xds metadata: %v", err)
+		return nil, fmt.Errorf("failed extracting xds metadata: %v", err)
 	}
 
 	// TODO direct to CP should use secure channel (most likely JWT + TLS, but possibly allow mTLS)
@@ -165,6 +164,22 @@ func GenerateBootstrap(opts GenerateBootstrapOptions) (*Bootstrap, error) {
 	}
 
 	return &bootstrap, err
+}
+
+func extractMeta(node *model.Node) (*structpb.Struct, error) {
+	bytes, err := json.Marshal(node.Metadata)
+	if err != nil {
+		return nil, err
+	}
+	rawMeta := map[string]interface{}{}
+	if err := json.Unmarshal(bytes, &rawMeta); err != nil {
+		return nil, err
+	}
+	xdsMeta, err := structpb.NewStruct(rawMeta)
+	if err != nil {
+		return nil, err
+	}
+	return xdsMeta, nil
 }
 
 // GenerateBootstrapFile generates and writes atomically as JSON to the given file path.

--- a/pkg/istio-agent/testdata/grpc-bootstrap.json
+++ b/pkg/istio-agent/testdata/grpc-bootstrap.json
@@ -23,9 +23,9 @@
       "PROXY_CONFIG": {
         "binaryPath": "/Users/landow/go/src/istio.io/istio/out/darwin_amd64/envoy",
         "concurrency": 2,
-        "configPath": "/var/folders/43/dd38c_f97lvdt_p9rgj7hvq400r4rr/T/TestAgent_gRPC_XDS_bootstrap3603799447/001",
+        "configPath": "/something/predictable",
         "controlPlaneAuthPolicy": "MUTUAL_TLS",
-        "discoveryAddress": "localhost:55690",
+        "discoveryAddress": "something.predictable:123",
         "drainDuration": "45s",
         "parentShutdownDuration": "60s",
         "proxyAdminPort": 15000,

--- a/pkg/istio-agent/testdata/grpc-bootstrap.json
+++ b/pkg/istio-agent/testdata/grpc-bootstrap.json
@@ -19,26 +19,6 @@
       "PILOT_SAN": [
         "istiod.istio-system.svc"
       ],
-      "PROV_CERT": "/Users/landow/go/src/istio.io/istio/tests/testdata/certs/pilot/root-cert.pem",
-      "PROXY_CONFIG": {
-        "binaryPath": "/Users/landow/go/src/istio.io/istio/out/darwin_amd64/envoy",
-        "concurrency": 2,
-        "configPath": "/something/predictable",
-        "controlPlaneAuthPolicy": "MUTUAL_TLS",
-        "discoveryAddress": "something.predictable:123",
-        "drainDuration": "45s",
-        "parentShutdownDuration": "60s",
-        "proxyAdminPort": 15000,
-        "proxyBootstrapTemplatePath": "/Users/landow/go/src/istio.io/istio/tools/packaging/common/envoy_bootstrap.json",
-        "serviceCluster": "istio-proxy",
-        "statNameLength": 189,
-        "statusPort": 15020,
-        "tracing": {
-          "zipkin": {
-            "address": "zipkin.istio-system:9411"
-          }
-        }
-      },
       "PROXY_VIA_AGENT": true
     },
     "locality": {},
@@ -48,9 +28,9 @@
     "default": {
       "plugin_name": "file_watcher",
       "config": {
+        "ca_certificate_file": "/cert/path/root-cert.pem",
         "certificate_file": "/cert/path/cert-chain.pem",
         "private_key_file": "/cert/path/key.pem",
-        "ca_certificate_file": "/cert/path/root-cert.pem",
         "refresh_interval": "900s"
       }
     }

--- a/pkg/istio-agent/testdata/grpc-bootstrap.json
+++ b/pkg/istio-agent/testdata/grpc-bootstrap.json
@@ -14,7 +14,33 @@
   ],
   "node": {
     "id": "sidecar~127.0.0.1~pod1.fake-namespace~fake-namespace.svc.cluster.local",
-    "metadata": {},
+    "metadata": {
+      "INSTANCE_IPS": "127.0.0.1",
+      "PILOT_SAN": [
+        "istiod.istio-system.svc"
+      ],
+      "PROV_CERT": "/Users/landow/go/src/istio.io/istio/tests/testdata/certs/pilot/root-cert.pem",
+      "PROXY_CONFIG": {
+        "binaryPath": "/Users/landow/go/src/istio.io/istio/out/darwin_amd64/envoy",
+        "concurrency": 2,
+        "configPath": "/var/folders/43/dd38c_f97lvdt_p9rgj7hvq400r4rr/T/TestAgent_gRPC_XDS_bootstrap3603799447/001",
+        "controlPlaneAuthPolicy": "MUTUAL_TLS",
+        "discoveryAddress": "localhost:55690",
+        "drainDuration": "45s",
+        "parentShutdownDuration": "60s",
+        "proxyAdminPort": 15000,
+        "proxyBootstrapTemplatePath": "/Users/landow/go/src/istio.io/istio/tools/packaging/common/envoy_bootstrap.json",
+        "serviceCluster": "istio-proxy",
+        "statNameLength": 189,
+        "statusPort": 15020,
+        "tracing": {
+          "zipkin": {
+            "address": "zipkin.istio-system:9411"
+          }
+        }
+      },
+      "PROXY_VIA_AGENT": true
+    },
     "locality": {},
     "UserAgentVersionType": null
   },


### PR DESCRIPTION
The previous code used `Node.RawMetadata`

For everything except the following call, we extract into `untypedMeta`, but here we extract into typed meta.

https://github.com/istio/istio/blob/6da7a3193970e46ebe6cf748f6411f1de1d286ec/pkg/bootstrap/config.go#L492

This means the gRPC bootstrap ends up missing out on  a few critical fields:
* POD_NAME
* POD_NAMESPACE
* SERVICE_ACCOUNT
* ISTIO_METAJSON_LABELS

Without this fix we can't set namespace-level policy like PeerAuthn