### PR TITLE
Change istio-pilot address

### DIFF
--- a/pilot/pkg/xds/README.md
+++ b/pilot/pkg/xds/README.md
@@ -4,7 +4,7 @@ The debug handlers are configured on the monitoring port (default 15014) as well
 as on the http port (8080).
 
 ```bash
-PILOT=istio-pilot.istio-system:15014
+PILOT=istiod.istio-system:15014
 
 # What is sent to envoy
 # Listeners and routes


### PR DESCRIPTION
Change istio-pilot address ($PILOT) - istiod.istio-system instead of istio-pilot.istio-system

**Please provide a description of this PR:**

istio-pilot.istio-system now working now

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
