### PR TITLE
set default cluster for fake discovery server

### DIFF
--- a/pilot/pkg/xds/xds_test.go
+++ b/pilot/pkg/xds/xds_test.go
@@ -462,6 +462,7 @@ subsets:
 					i++
 				}
 				return FakeOptions{
+					DefaultClusterName:              "cluster-1",
 					KubernetesObjectStringByCluster: k8sObjects,
 					ConfigString: `
 apiVersion: networking.istio.io/v1alpha3


### PR DESCRIPTION
```
~/g/s/i/istio ❯❯❯ go test ./pilot/pkg/xds -run TestClusterLocal -count 50                                                                                                                                              ✘ 130 master ✭ ✱
ok      istio.io/istio/pilot/pkg/xds    2.101s
```

Previously we decided the "default" cluster based on which cluster in the `k8sObjects` map we saw first (which has inconsistent map ordering). 

This allows setting that cluster explicitly. This is the cluster that WorkloadEntry endpoints are considered "local" to. 


fixes https://github.com/istio/istio/issues/34638