### PR TITLE
mirrorPercentage should not be negative number

### DIFF
--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -2404,6 +2404,15 @@ func TestValidateHTTPRoute(t *testing.T) {
 			}},
 			Match: []*networking.HTTPMatchRequest{nil},
 		}, valid: true},
+		{name: "negative mirror percentage", route: &networking.HTTPRoute{
+			MirrorPercentage: &networking.Percent{
+				Value: -1,
+			},
+			Route: []*networking.HTTPRouteDestination{{
+				Destination: &networking.Destination{Host: "foo.bar"},
+			}},
+			Match: []*networking.HTTPMatchRequest{nil},
+		}, valid: false},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/config/validation/virtualservice.go
+++ b/pkg/config/validation/virtualservice.go
@@ -90,8 +90,12 @@ func validateHTTPRoute(http *networking.HTTPRoute, delegate bool) (errs Validati
 	}
 
 	if http.MirrorPercentage != nil {
-		if value := http.MirrorPercentage.GetValue(); value > 100 {
+		value := http.MirrorPercentage.GetValue()
+		if value > 100 {
 			errs = appendValidation(errs, fmt.Errorf("mirror_percentage must have a max value of 100 (it has %f)", value))
+		}
+		if value < 0 {
+			errs = appendValidation(errs, fmt.Errorf("mirror_percentage must have a min value of 0 (it has %f)", value))
 		}
 	}
 

--- a/pkg/config/validation/virtualservice_test.go
+++ b/pkg/config/validation/virtualservice_test.go
@@ -605,6 +605,15 @@ func TestValidateDelegateHTTPRoute(t *testing.T) {
 			}},
 			Match: []*networking.HTTPMatchRequest{nil},
 		}, valid: true},
+		{name: "negative mirror percentage", route: &networking.HTTPRoute{
+			MirrorPercentage: &networking.Percent{
+				Value: -1,
+			},
+			Route: []*networking.HTTPRouteDestination{{
+				Destination: &networking.Destination{Host: "foo.bar"},
+			}},
+			Match: []*networking.HTTPMatchRequest{nil},
+		}, valid: false},
 		{name: "delegate route with delegate", route: &networking.HTTPRoute{
 			Delegate: &networking.Delegate{
 				Name:      "test",


### PR DESCRIPTION
**Please provide a description of this PR:**

mirrorPercentage should not be negative number.
Current master branch allow users to set negative number and will not be effect, it looks alright but a little confused.

```
apiVersion: networking.istio.io/v1beta1
kind: VirtualService
metadata:
  name: httpbin
spec:
  hosts:
  - httpbin
  http:
  - mirror:
      host: httpbin
      subset: v2
    mirrorPercentage:
      value: -100
    route:
    - destination:
        host: httpbin
        subset: v1
      weight: 100
```

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
