### PR TITLE
use sets.Set to replace the array

### DIFF
--- a/pilot/pkg/security/trustdomain/bundle_test.go
+++ b/pilot/pkg/security/trustdomain/bundle_test.go
@@ -16,6 +16,7 @@ package trustdomain
 
 import (
 	"reflect"
+	"sort"
 	"testing"
 )
 
@@ -115,6 +116,8 @@ func TestReplaceTrustDomainAliases(t *testing.T) {
 
 	for _, tc := range testCases {
 		got := tc.trustDomainBundle.ReplaceTrustDomainAliases(tc.principals)
+		sort.Strings(tc.expect)
+		sort.Strings(got)
 		if !reflect.DeepEqual(got, tc.expect) {
 			t.Errorf("%s failed. Expect: %s. Got: %s", tc.name, tc.expect, got)
 		}

--- a/pilot/pkg/security/trustdomain/util.go
+++ b/pilot/pkg/security/trustdomain/util.go
@@ -48,12 +48,3 @@ func suffixMatch(a string, pattern string) bool {
 	pattern = strings.TrimPrefix(pattern, "*")
 	return strings.HasSuffix(a, pattern)
 }
-
-func isKeyInList(key string, list []string) bool {
-	for _, l := range list {
-		if key == l {
-			return true
-		}
-	}
-	return false
-}


### PR DESCRIPTION

1. use sets.Set to determine whether obj exists
2. fix a typo


- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure


- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
