### PR TITLE
fix proxyConfig overrides

### DIFF
--- a/pkg/config/mesh/mesh.go
+++ b/pkg/config/mesh/mesh.go
@@ -128,16 +128,13 @@ func ApplyProxyConfig(yaml string, meshConfig meshconfig.MeshConfig) (*meshconfi
 }
 
 func applyProxyConfig(yaml string, proxyConfig *meshconfig.ProxyConfig) (*meshconfig.ProxyConfig, error) {
-	result, err := deepCopyProxyConfig(proxyConfig)
-	if err != nil {
-		return nil, fmt.Errorf("could not deep copy proxy config: %v", err)
-	}
-	if err := gogoprotomarshal.ApplyYAML(yaml, result); err != nil {
+	origMetadata := proxyConfig.ProxyMetadata
+	if err := gogoprotomarshal.ApplyYAML(yaml, proxyConfig); err != nil {
 		return nil, fmt.Errorf("could not parse proxy config: %v", err)
 	}
-	origMetadata := proxyConfig.ProxyMetadata
-	result.ProxyMetadata = mergeMap(origMetadata, result.ProxyMetadata)
-	return result, nil
+	newMetadata := proxyConfig.ProxyMetadata
+	proxyConfig.ProxyMetadata = mergeMap(origMetadata, newMetadata)
+	return proxyConfig, nil
 }
 
 func extractYamlField(key string, mp map[string]interface{}) (string, error) {
@@ -234,14 +231,13 @@ func mergeMap(original map[string]string, merger map[string]string) map[string]s
 	if original == nil && merger == nil {
 		return nil
 	}
-	result := map[string]string{}
-	for k, v := range original {
-		result[k] = v
+	if original == nil {
+		original = map[string]string{}
 	}
 	for k, v := range merger {
-		result[k] = v
+		original[k] = v
 	}
-	return result
+	return original
 }
 
 // ApplyMeshConfigDefaults returns a new MeshConfig decoded from the
@@ -260,18 +256,6 @@ func DeepCopyMeshConfig(mc *meshconfig.MeshConfig) (*meshconfig.MeshConfig, erro
 		return nil, err
 	}
 	return nmc, nil
-}
-
-func deepCopyProxyConfig(mc *meshconfig.ProxyConfig) (*meshconfig.ProxyConfig, error) {
-	j, err := gogoprotomarshal.ToJSON(mc)
-	if err != nil {
-		return nil, err
-	}
-	npc := &meshconfig.ProxyConfig{}
-	if err := gogoprotomarshal.ApplyJSON(j, npc); err != nil {
-		return nil, err
-	}
-	return npc, nil
 }
 
 // EmptyMeshNetworks configuration with no networks

--- a/pkg/config/mesh/mesh_test.go
+++ b/pkg/config/mesh/mesh_test.go
@@ -68,9 +68,16 @@ func TestApplyProxyConfig(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		// Ensure we didn't modify the passed in mesh config
-		if !reflect.DeepEqual(mc.DefaultConfig.ProxyMetadata, map[string]string{
+		// Ensure we didn't modify the default mesh config
+		if !reflect.DeepEqual(config.DefaultConfig.ProxyMetadata, map[string]string{
+			"merged":  "original",
+			"default": "foo",
+		}) {
+			t.Fatalf("unexpected proxy metadata: %+v", config.DefaultConfig.ProxyMetadata)
+		}
 
+		// Ensure we did modify the mesh config
+		if !reflect.DeepEqual(mc.DefaultConfig.ProxyMetadata, map[string]string{
 			"merged":   "override",
 			"default":  "foo",
 			"override": "bar",
@@ -89,14 +96,22 @@ func TestApplyProxyConfig(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		// Ensure we didn't modify the passed in mesh config
-		if !reflect.DeepEqual(mc.DefaultConfig.ProxyMetadata, map[string]string{
-
+		// Ensure we did modify the mesh config
+		expected := map[string]string{
 			"merged":   "override",
 			"default":  "foo",
 			"override": "bar",
-		}) {
-			t.Fatalf("unexpected proxy metadata: %+v", mc.DefaultConfig.ProxyMetadata)
+		}
+		if !reflect.DeepEqual(mc.DefaultConfig.ProxyMetadata, expected) {
+			t.Fatalf("unexpected proxy metadata. expected: %+v, actual: %+v", expected, config.DefaultConfig.ProxyMetadata)
+		}
+		// Ensure we didn't modify the default mesh config
+		expected = map[string]string{
+			"merged":  "original",
+			"default": "foo",
+		}
+		if !reflect.DeepEqual(config.DefaultConfig.ProxyMetadata, expected) {
+			t.Fatalf("unexpected proxy metadata. expected: %+v, actual: %+v", expected, config.DefaultConfig.ProxyMetadata)
 		}
 	})
 }


### PR DESCRIPTION
Subject: Fix a bug in ProxyConfig overrides that causes overrides to be applied to the default config.

**Please provide a description of this PR:**
Description:
+ When using proxy config overrides via pod annotation the overrides are applied to the global default config so all new pod gets the overrides.
+ The bug is caused by a lack of deep copying of the relevant map.
+ The test were updated to check the default config to remain as the old one.


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [X ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [X ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
