### PR TITLE
Impl HasSynced for memory controller and improve HasSynced of ADSC

### DIFF
--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -221,7 +221,9 @@ func (s *Server) initConfigSources(args *PilotArgs) (err error) {
 				return fmt.Errorf("failed to dial XDS %s %v", configSource.Address, err)
 			}
 			store := memory.MakeSkipValidation(collections.Pilot)
-			configController := memory.NewController(store)
+			configController := memory.NewControllerWithOptions(store, &memory.Config{
+				HasSynced: xdsMCP.HasSynced,
+			})
 			xdsMCP.Store = model.MakeIstioStore(configController)
 			err = xdsMCP.Run()
 			if err != nil {

--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -221,9 +221,7 @@ func (s *Server) initConfigSources(args *PilotArgs) (err error) {
 				return fmt.Errorf("failed to dial XDS %s %v", configSource.Address, err)
 			}
 			store := memory.MakeSkipValidation(collections.Pilot)
-			configController := memory.NewControllerWithOptions(store, &memory.Config{
-				HasSynced: xdsMCP.HasSynced,
-			})
+			configController := memory.NewController(store, memory.PatchHasSynced(xdsMCP.HasSynced))
 			xdsMCP.Store = model.MakeIstioStore(configController)
 			err = xdsMCP.Run()
 			if err != nil {

--- a/pilot/pkg/config/memory/controller.go
+++ b/pilot/pkg/config/memory/controller.go
@@ -87,7 +87,7 @@ func (c *controller) SetWatchErrorHandler(handler func(r *cache.Reflector, err e
 
 // Memory implementation is always synchronized with cache
 func (c *controller) HasSynced() bool {
-	if c.opts.HasSynced == nil {
+	if c.opts == nil || c.opts.HasSynced == nil {
 		return true
 	}
 	return c.opts.HasSynced()

--- a/pilot/pkg/config/memory/controller_test.go
+++ b/pilot/pkg/config/memory/controller_test.go
@@ -15,6 +15,7 @@
 package memory_test
 
 import (
+	"sync/atomic"
 	"testing"
 
 	"istio.io/istio/pilot/pkg/config/memory"
@@ -44,4 +45,22 @@ func TestControllerClientSync(t *testing.T) {
 	store := memory.Make(collections.Mocks)
 	ctl := memory.NewController(store)
 	mock.CheckCacheSync(store, ctl, TestNamespace, 5, t)
+}
+
+func TestControllerHashSynced(t *testing.T) {
+	store := memory.Make(collections.Mocks)
+	var v int32
+	ctl := memory.NewControllerWithOptions(store, &memory.Config{
+		HasSynced: func() bool {
+			return atomic.LoadInt32(&v) > 0
+		},
+	})
+
+	if ctl.HasSynced() {
+		t.Error("has synced but should not")
+	}
+	atomic.StoreInt32(&v, 1)
+	if !ctl.HasSynced() {
+		t.Error("has not synced but should")
+	}
 }

--- a/pilot/pkg/config/memory/controller_test.go
+++ b/pilot/pkg/config/memory/controller_test.go
@@ -50,11 +50,9 @@ func TestControllerClientSync(t *testing.T) {
 func TestControllerHashSynced(t *testing.T) {
 	store := memory.Make(collections.Mocks)
 	var v int32
-	ctl := memory.NewControllerWithOptions(store, &memory.Config{
-		HasSynced: func() bool {
-			return atomic.LoadInt32(&v) > 0
-		},
-	})
+	ctl := memory.NewController(store, memory.PatchHasSynced(func() bool {
+		return atomic.LoadInt32(&v) > 0
+	}))
 
 	if ctl.HasSynced() {
 		t.Error("has synced but should not")

--- a/pkg/adsc/adsc_test.go
+++ b/pkg/adsc/adsc_test.go
@@ -135,12 +135,12 @@ func TestADSC_Run(t *testing.T) {
 			desc.expectedTypeUrls = desc.reqTypeUrls
 		}
 		var initReqs []*xdsapi.DiscoveryRequest
-		for _, typeUrl := range desc.reqTypeUrls {
-			initReqs = append(initReqs, &xdsapi.DiscoveryRequest{TypeUrl: typeUrl})
-			expected[typeUrl] = &xdsapi.DiscoveryResponse{TypeUrl: typeUrl}
+		for _, typeURL := range desc.reqTypeUrls {
+			initReqs = append(initReqs, &xdsapi.DiscoveryRequest{TypeUrl: typeURL})
+			expected[typeURL] = &xdsapi.DiscoveryResponse{TypeUrl: typeURL}
 		}
-		for _, typeUrl := range desc.expectedTypeUrls {
-			expected[typeUrl] = &xdsapi.DiscoveryResponse{TypeUrl: typeUrl}
+		for _, typeURL := range desc.expectedTypeUrls {
+			expected[typeURL] = &xdsapi.DiscoveryResponse{TypeUrl: typeURL}
 		}
 
 		if desc.validator == nil {
@@ -167,9 +167,9 @@ func TestADSC_Run(t *testing.T) {
 				syncCh:      make(chan string, len(desc.reqTypeUrls)),
 			},
 			streamHandler: func(stream xdsapi.AggregatedDiscoveryService_StreamAggregatedResourcesServer) error {
-				for _, typeUrl := range desc.expectedTypeUrls {
+				for _, typeURL := range desc.expectedTypeUrls {
 					_ = stream.Send(&xdsapi.DiscoveryResponse{
-						TypeUrl: typeUrl,
+						TypeUrl: typeURL,
 					})
 				}
 				return nil

--- a/pkg/adsc/adsc_test.go
+++ b/pkg/adsc/adsc_test.go
@@ -137,7 +137,6 @@ func TestADSC_Run(t *testing.T) {
 		var initReqs []*xdsapi.DiscoveryRequest
 		for _, typeURL := range desc.reqTypeUrls {
 			initReqs = append(initReqs, &xdsapi.DiscoveryRequest{TypeUrl: typeURL})
-			expected[typeURL] = &xdsapi.DiscoveryResponse{TypeUrl: typeURL}
 		}
 		for _, typeURL := range desc.expectedTypeUrls {
 			expected[typeURL] = &xdsapi.DiscoveryResponse{TypeUrl: typeURL}
@@ -164,7 +163,6 @@ func TestADSC_Run(t *testing.T) {
 				},
 				VersionInfo: map[string]string{},
 				sync:        map[string]time.Time{},
-				syncCh:      make(chan string, len(desc.reqTypeUrls)),
 			},
 			streamHandler: func(stream xdsapi.AggregatedDiscoveryService_StreamAggregatedResourcesServer) error {
 				for _, typeURL := range desc.expectedTypeUrls {

--- a/pkg/adsc/adsc_test.go
+++ b/pkg/adsc/adsc_test.go
@@ -15,11 +15,14 @@
 package adsc
 
 import (
+	"fmt"
 	"log"
 	"net"
 	"os"
+	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
@@ -52,59 +55,132 @@ func (t *testAdscRunServer) DeltaAggregatedResources(xdsapi.AggregatedDiscoveryS
 }
 
 func TestADSC_Run(t *testing.T) {
-	tests := []struct {
+	type testCase struct {
 		desc                 string
 		inAdsc               *ADSC
 		streamHandler        func(server xdsapi.AggregatedDiscoveryService_StreamAggregatedResourcesServer) error
 		expectedADSResources *ADSC
-	}{
+		validator            func(testCase) error
+	}
+	var tests []testCase
+
+	type testDesc struct {
+		desc             string
+		reqTypeUrls      []string
+		expectedTypeUrls []string // nil means equals to requested
+		validator        func(testCase) error
+	}
+
+	descs := []testDesc{
 		{
-			desc: "stream-no-resources",
+			desc:        "stream-no-resources",
+			reqTypeUrls: []string{},
+		},
+		{
+			desc:        "stream-2-unnamed-resources",
+			reqTypeUrls: []string{"foo", "bar"},
+		},
+		// todo tests for listeners, clusters, eds, and routes, not sure how to do this.
+	}
+
+	initTypeUrls := func() []string {
+		var ret []string
+		for _, req := range ConfigInitialRequests() {
+			ret = append(ret, req.TypeUrl)
+		}
+		return ret
+	}()
+	incompleteTypeUrls := func() []string {
+		var ret []string
+		for idx, item := range initTypeUrls {
+			if strings.Count(item, "/") == 3 {
+				ret = append(ret, initTypeUrls[:idx]...)
+				ret = append(ret, initTypeUrls[idx+1:]...)
+				break
+			}
+		}
+		if ret == nil {
+			ret = initTypeUrls
+		}
+		return ret
+	}()
+	descs = append(descs, testDesc{
+		desc:        "mcp-should-hasSynced",
+		reqTypeUrls: initTypeUrls,
+		validator: func(tc testCase) error {
+			if !tc.inAdsc.HasSynced() {
+				return fmt.Errorf("adsc not synced")
+			}
+			return nil
+		},
+	})
+	if len(incompleteTypeUrls) != len(initTypeUrls) {
+		descs = append(descs, testDesc{
+			desc:             "mcp-should-not-hasSynced",
+			reqTypeUrls:      initTypeUrls,
+			expectedTypeUrls: incompleteTypeUrls,
+			validator: func(tc testCase) error {
+				if tc.inAdsc.HasSynced() {
+					return fmt.Errorf("adsc synced but should not")
+				}
+				return nil
+			},
+		})
+	}
+
+	for _, item := range descs {
+		desc := item // avoid refer to on-stack-var
+		expected := map[string]*xdsapi.DiscoveryResponse{}
+		if desc.expectedTypeUrls == nil {
+			desc.expectedTypeUrls = desc.reqTypeUrls
+		}
+		var initReqs []*xdsapi.DiscoveryRequest
+		for _, typeUrl := range desc.reqTypeUrls {
+			initReqs = append(initReqs, &xdsapi.DiscoveryRequest{TypeUrl: typeUrl})
+			expected[typeUrl] = &xdsapi.DiscoveryResponse{TypeUrl: typeUrl}
+		}
+		for _, typeUrl := range desc.expectedTypeUrls {
+			expected[typeUrl] = &xdsapi.DiscoveryResponse{TypeUrl: typeUrl}
+		}
+
+		if desc.validator == nil {
+			desc.validator = func(tc testCase) error {
+				if !cmp.Equal(tc.inAdsc.Received, tc.expectedADSResources.Received, protocmp.Transform()) {
+					return fmt.Errorf("%s: expected recv %v got %v", tc.desc, tc.expectedADSResources.Received, tc.inAdsc.Received)
+				}
+				return nil
+			}
+		}
+
+		tc := testCase{
+			desc: desc.desc,
 			inAdsc: &ADSC{
 				Received:   make(map[string]*xdsapi.DiscoveryResponse),
 				Updates:    make(chan string),
 				XDSUpdates: make(chan *xdsapi.DiscoveryResponse),
 				RecvWg:     sync.WaitGroup{},
-				cfg:        &Config{},
-			},
-			streamHandler: func(server xdsapi.AggregatedDiscoveryService_StreamAggregatedResourcesServer) error {
-				return nil
-			},
-			expectedADSResources: &ADSC{
-				Received: map[string]*xdsapi.DiscoveryResponse{},
-			},
-		},
-		{
-			desc: "stream-2-unnamed-resources",
-			inAdsc: &ADSC{
-				Received:    make(map[string]*xdsapi.DiscoveryResponse),
-				Updates:     make(chan string),
-				XDSUpdates:  make(chan *xdsapi.DiscoveryResponse),
-				RecvWg:      sync.WaitGroup{},
-				cfg:         &Config{},
+				cfg: &Config{
+					InitialDiscoveryRequests: initReqs,
+				},
 				VersionInfo: map[string]string{},
+				sync:        map[string]time.Time{},
+				syncCh:      make(chan string, len(desc.reqTypeUrls)),
 			},
 			streamHandler: func(stream xdsapi.AggregatedDiscoveryService_StreamAggregatedResourcesServer) error {
-				_ = stream.Send(&xdsapi.DiscoveryResponse{
-					TypeUrl: "foo",
-				})
-				_ = stream.Send(&xdsapi.DiscoveryResponse{
-					TypeUrl: "bar",
-				})
+				for _, typeUrl := range desc.expectedTypeUrls {
+					_ = stream.Send(&xdsapi.DiscoveryResponse{
+						TypeUrl: typeUrl,
+					})
+				}
 				return nil
 			},
 			expectedADSResources: &ADSC{
-				Received: map[string]*xdsapi.DiscoveryResponse{
-					"foo": {
-						TypeUrl: "foo",
-					},
-					"bar": {
-						TypeUrl: "bar",
-					},
-				},
+				Received: expected,
 			},
-		},
-		// todo tests for listeners, clusters, eds, and routes, not sure how to do this.
+			validator: desc.validator,
+		}
+
+		tests = append(tests, tc)
 	}
 
 	for _, tt := range tests {
@@ -139,8 +215,9 @@ func TestADSC_Run(t *testing.T) {
 				return
 			}
 			tt.inAdsc.RecvWg.Wait()
-			if !cmp.Equal(tt.inAdsc.Received, tt.expectedADSResources.Received, protocmp.Transform()) {
-				t.Errorf("%s: expected recv %v got %v", tt.desc, tt.expectedADSResources.Received, tt.inAdsc.Received)
+
+			if err := tt.validator(tt); err != nil {
+				t.Error(err)
 			}
 		})
 	}


### PR DESCRIPTION
**Please provide a description of this PR:**

In current istio codebase, memory config controller does not impl the `HasSynced` method which means we will wait for readiness of config source using mem store (such as mcp-over-xds). And this will break the integrity of istiod state control.

This PR impl `HasSynced` for mem controller and use it in the XDS configsource case.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
