### PR TITLE
grpc xds: support calling service using shortnames

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -470,7 +470,7 @@ func getVirtualHostsForSniffedServicePort(vhosts []*route.VirtualHost, routeName
 // generateVirtualHostDomains generates the set of domain matches for a service being accessed from
 // a proxy node
 func generateVirtualHostDomains(service *model.Service, port int, node *model.Proxy) ([]string, []string) {
-	altHosts := generateAltVirtualHosts(string(service.Hostname), port, node.DNSDomain)
+	altHosts := GenerateAltVirtualHosts(string(service.Hostname), port, node.DNSDomain)
 	domains := []string{ipv6Compliant(string(service.Hostname)), domainName(string(service.Hostname), port)}
 	domains = append(domains, altHosts...)
 
@@ -492,7 +492,7 @@ func generateVirtualHostDomains(service *model.Service, port int, node *model.Pr
 	return domains, altHosts
 }
 
-// Given a service, and a port, this function generates all possible HTTP Host headers.
+// GenerateAltVirtualHosts given a service and a port, generates all possible HTTP Host headers.
 // For example, a service of the form foo.local.campus.net on port 80, with local domain "local.campus.net"
 // could be accessed as http://foo:80 within the .local network, as http://foo.local:80 (by other clients
 // in the campus.net domain), as http://foo.local.campus:80, etc.
@@ -508,7 +508,7 @@ func generateVirtualHostDomains(service *model.Service, port int, node *model.Pr
 //
 // - Given foo.local.campus.net on proxy domain "" or proxy domain example.com, this
 // function returns nil
-func generateAltVirtualHosts(hostname string, port int, proxyDomain string) []string {
+func GenerateAltVirtualHosts(hostname string, port int, proxyDomain string) []string {
 	var vhosts []string
 	uniqueHostnameParts, sharedDNSDomainParts := getUniqueAndSharedDNSDomain(hostname, proxyDomain)
 

--- a/pilot/pkg/networking/grpcgen/grpcecho_test.go
+++ b/pilot/pkg/networking/grpcgen/grpcecho_test.go
@@ -143,7 +143,7 @@ func makeWE(s echoCfg, host string, port int) config.Config {
 }
 
 func (t *configGenTest) dialEcho(addr string) *client.Instance {
-	resolver := resolverForTest(t)
+	resolver := resolverForTest(t, "default")
 	out, err := client.New(addr, nil, grpc.WithResolvers(resolver))
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
When a proxyless client dials `xds:///foo:123`, it expects a listener named `foo:123` exactly. 

Currently, we look at egress listener services and generate a listener if the filtered name and port matches the FQDN of the service. 

To support making requests using shortnames (foo, foo.ns, foo.ns.svc) we generate the list of AltVirtualHost domains. If the requested listener matches one of these, we build the listener with that exact name. 

Since it's possible for a gRPC app to have watches against both `foo` and `foo.ns`, we must duplicate the listener with each of the requested names.
