### PR TITLE
support istio skip ugrade testing

### DIFF
--- a/pkg/test/framework/components/echo/kube/deployment_test.go
+++ b/pkg/test/framework/components/echo/kube/deployment_test.go
@@ -152,6 +152,27 @@ func TestDeploymentYAML(t *testing.T) {
 				},
 			},
 			revVerMap: resource.RevVerMap{
+				"rev-a": resource.IstioVersion("1.9.0"),
+				"rev-b": resource.IstioVersion("1.10.0"),
+			},
+			compatibility: true,
+		},
+		{
+			name:         "multiple-istio-versions-no-proxy",
+			wantFilePath: "testdata/multiple-istio-versions-no-proxy.yaml",
+			config: echo.Config{
+				Service: "foo",
+				Version: "bar",
+				Ports: []echo.Port{
+					{
+						Name:         "http",
+						Protocol:     protocol.HTTP,
+						InstancePort: 8090,
+						ServicePort:  8090,
+					},
+				},
+			},
+			revVerMap: resource.RevVerMap{
 				"rev-a": resource.IstioVersion("1.8.2"),
 				"rev-b": resource.IstioVersion("1.9.0"),
 			},

--- a/pkg/test/framework/components/echo/kube/testdata/multiple-istio-versions-no-proxy.yaml
+++ b/pkg/test/framework/components/echo/kube/testdata/multiple-istio-versions-no-proxy.yaml
@@ -40,10 +40,6 @@ spec:
       imagePullSecrets:
       - name: myregistrykey
       containers:
-      - name: istio-proxy
-        image: auto
-        securityContext: # to allow core dumps
-          readOnlyRootFilesystem: false
       - name: app
         image: testing.hub/app:latest
         imagePullPolicy: Always
@@ -65,7 +61,7 @@ spec:
           - --version
           - "bar"
           - --istio-version
-          - "1.9.0"
+          - "1.8.2"
           - --crt=/cert.crt
           - --key=/cert.key
         ports:
@@ -122,10 +118,6 @@ spec:
       imagePullSecrets:
       - name: myregistrykey
       containers:
-      - name: istio-proxy
-        image: auto
-        securityContext: # to allow core dumps
-          readOnlyRootFilesystem: false
       - name: app
         image: testing.hub/app:latest
         imagePullPolicy: Always
@@ -147,7 +139,7 @@ spec:
           - --version
           - "bar"
           - --istio-version
-          - "1.10.0"
+          - "1.9.0"
           - --crt=/cert.crt
           - --key=/cert.key
         ports:


### PR DESCRIPTION
**Please provide a description of this PR:**
This PR is part of future work to support istio skip-level upgrade testing from versions below 1.8 (which do not re-inject a pod if istio-proxy is already present).


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [X] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
