### PR TITLE
Added headers to propagate for token data

### DIFF
--- a/samples/bookinfo/src/details/details.rb
+++ b/samples/bookinfo/src/details/details.rb
@@ -175,6 +175,11 @@ def get_forward_headers(request)
       # Application-specific headers to forward.
       'end-user',
       'user-agent',
+
+      # Context and session specific headers
+      'cookie',
+      'authorization',
+      'jwt'
   ]
 
   request.each do |header, value|

--- a/samples/bookinfo/src/productpage/productpage.py
+++ b/samples/bookinfo/src/productpage/productpage.py
@@ -221,6 +221,11 @@ def getForwardHeaders(request):
 
         # Application-specific headers to forward.
         'user-agent',
+
+        # Context and session specific headers
+        'cookie',
+        'authorization',
+        'jwt',
     ]
     # For Zipkin, always propagate b3 headers.
     # For Lightstep, always propagate the x-ot-span-context header.

--- a/samples/bookinfo/src/productpage/requirements.txt
+++ b/samples/bookinfo/src/productpage/requirements.txt
@@ -8,8 +8,8 @@ Flask-Bootstrap==3.3.7.1
 Flask-JSON==0.3.3
 future==0.17.1
 futures==3.1.1
-gevent==1.4.0
-greenlet==0.4.15
+gevent==1.5.0
+greenlet==0.4.17
 idna==2.8
 itsdangerous==1.1.0
 jaeger-client==3.13.0

--- a/samples/bookinfo/src/reviews/reviews-application/src/main/java/application/rest/LibertyRestEndpoint.java
+++ b/samples/bookinfo/src/reviews/reviews-application/src/main/java/application/rest/LibertyRestEndpoint.java
@@ -88,6 +88,11 @@ public class LibertyRestEndpoint extends Application {
         // Application-specific headers to forward.
         "end-user",
         "user-agent",
+
+        // Context and session specific headers
+        "cookie",
+        "authorization",
+        "jwt",
     };
 
     private String getJsonResponse (String productId, int starsReviewer1, int starsReviewer2) {


### PR DESCRIPTION
**Please provide a description of this PR:**
This PR enhances the bookinfo sample application to propagate three headers containing potential token data:

- cookie
- jwt
- authorization

This was done to enable testing of more complex RequestAuthentication and AuthorizationPolicy logic with the sample apps.

In addition, I made a change to the productpage requirements for gevent (from 1.4.0 to 1.5.0) and greenlet (from 0.4.15 to 0.4.17).  This was to accommodate the latest version of Python (3.9) on Mac OSX 11.5.  


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [X] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
