### PR TITLE
test framework support connection via proxy

### DIFF
--- a/pkg/kube/spdy.go
+++ b/pkg/kube/spdy.go
@@ -38,7 +38,12 @@ func roundTripperFor(restConfig *rest.Config) (http.RoundTripper, spdy.Upgrader,
 		}
 	}
 
-	upgrader := spdyStream.NewRoundTripper(tlsConfig, true, false)
+	var upgrader *spdyStream.SpdyRoundTripper
+	if restConfig.Proxy != nil {
+		upgrader = spdyStream.NewRoundTripperWithProxy(tlsConfig, true, false, restConfig.Proxy)
+	} else {
+		upgrader = spdyStream.NewRoundTripper(tlsConfig, true, false)
+	}
 	wrapper, err := rest.HTTPWrappersForConfig(restConfig, upgrader)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed creating SPDY upgrade wrapper: %w", err)

--- a/pkg/test/echo/server/forwarder/instance.go
+++ b/pkg/test/echo/server/forwarder/instance.go
@@ -41,6 +41,8 @@ type Config struct {
 
 	// XDSTestBootstrap, for gRPC forwarders, is used to set the bootstrap without using a global one defined in the env
 	XDSTestBootstrap []byte
+	// Http proxy used for connection
+	Proxy string
 }
 
 func (c Config) fillInDefaults() Config {

--- a/pkg/test/echo/server/forwarder/protocol.go
+++ b/pkg/test/echo/server/forwarder/protocol.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -179,6 +180,13 @@ func newProtocol(cfg Config) (protocol, error) {
 				Timeout: timeout,
 			},
 			do: cfg.Dialer.HTTP,
+		}
+		if len(cfg.Proxy) > 0 {
+			proxyURL, err := url.Parse(cfg.Proxy)
+			if err != nil {
+				return nil, err
+			}
+			proto.client.Transport.(*http.Transport).Proxy = http.ProxyURL(proxyURL)
 		}
 		if cfg.Request.Http3 && scheme.Instance(urlScheme) == scheme.HTTP {
 			return nil, fmt.Errorf("http3 requires HTTPS")

--- a/pkg/test/framework/components/cluster/cluster.go
+++ b/pkg/test/framework/components/cluster/cluster.go
@@ -209,6 +209,6 @@ type Cluster interface {
 	// ConfigName returns the name of the config cluster for this cluster.
 	ConfigName() string
 
-	// Proxy returns the http proxy config to connect to the cluster
-	Proxy() string
+	// HTTPProxy returns the HTTP proxy config to connect to the cluster
+	HTTPProxy() string
 }

--- a/pkg/test/framework/components/cluster/cluster.go
+++ b/pkg/test/framework/components/cluster/cluster.go
@@ -208,4 +208,7 @@ type Cluster interface {
 
 	// ConfigName returns the name of the config cluster for this cluster.
 	ConfigName() string
+
+	// Proxy returns the http proxy config to connect to the cluster
+	Proxy() string
 }

--- a/pkg/test/framework/components/cluster/config.go
+++ b/pkg/test/framework/components/cluster/config.go
@@ -32,7 +32,7 @@ type Config struct {
 	Kind               Kind       `yaml:"kind,omitempty"`
 	Name               string     `yaml:"clusterName,omitempty"`
 	Network            string     `yaml:"network,omitempty"`
-	Proxy              string     `yaml:"proxy,omitempty"`
+	HTTPProxy          string     `yaml:"httpProxy,omitempty"`
 	PrimaryClusterName string     `yaml:"primaryClusterName,omitempty"`
 	ConfigClusterName  string     `yaml:"configClusterName,omitempty"`
 	Meta               config.Map `yaml:"meta,omitempty"`

--- a/pkg/test/framework/components/cluster/config.go
+++ b/pkg/test/framework/components/cluster/config.go
@@ -32,6 +32,7 @@ type Config struct {
 	Kind               Kind       `yaml:"kind,omitempty"`
 	Name               string     `yaml:"clusterName,omitempty"`
 	Network            string     `yaml:"network,omitempty"`
+	Proxy              string     `yaml:"proxy,omitempty"`
 	PrimaryClusterName string     `yaml:"primaryClusterName,omitempty"`
 	ConfigClusterName  string     `yaml:"configClusterName,omitempty"`
 	Meta               config.Map `yaml:"meta,omitempty"`

--- a/pkg/test/framework/components/cluster/kube/factory.go
+++ b/pkg/test/framework/components/cluster/kube/factory.go
@@ -48,8 +48,8 @@ func buildKube(origCfg cluster.Config, topology cluster.Topology) (cluster.Clust
 	}
 
 	var client istioKube.ExtendedClient
-	if len(cfg.Proxy) > 0 {
-		proxyURL, err := url.Parse(cfg.Proxy)
+	if len(cfg.HTTPProxy) > 0 {
+		proxyURL, err := url.Parse(cfg.HTTPProxy)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/test/framework/components/cluster/kube/factory.go
+++ b/pkg/test/framework/components/cluster/kube/factory.go
@@ -16,6 +16,8 @@ package kube
 
 import (
 	"fmt"
+	"net/http"
+	"net/url"
 
 	"k8s.io/client-go/rest"
 
@@ -45,9 +47,21 @@ func buildKube(origCfg cluster.Config, topology cluster.Topology) (cluster.Clust
 		return nil, err
 	}
 
-	client, err := buildClient(kubeconfigPath)
-	if err != nil {
-		return nil, err
+	var client istioKube.ExtendedClient
+	if len(cfg.Proxy) > 0 {
+		proxyURL, err := url.Parse(cfg.Proxy)
+		if err != nil {
+			return nil, err
+		}
+		client, err = buildClientWithProxy(kubeconfigPath, proxyURL)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		client, err = buildClient(kubeconfigPath)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// support fake VMs by default
@@ -80,5 +94,17 @@ func buildClient(kubeconfig string) (istioKube.ExtendedClient, error) {
 	if err != nil {
 		return nil, err
 	}
+	return istioKube.NewExtendedClient(istioKube.NewClientConfigForRestConfig(rc), "")
+}
+
+func buildClientWithProxy(kubeconfig string, proxyURL *url.URL) (istioKube.ExtendedClient, error) {
+	rc, err := istioKube.DefaultRestConfig(kubeconfig, "", func(config *rest.Config) {
+		config.QPS = 200
+		config.Burst = 400
+	})
+	if err != nil {
+		return nil, err
+	}
+	rc.Proxy = http.ProxyURL(proxyURL)
 	return istioKube.NewExtendedClient(istioKube.NewClientConfigForRestConfig(rc), "")
 }

--- a/pkg/test/framework/components/cluster/topology.go
+++ b/pkg/test/framework/components/cluster/topology.go
@@ -30,7 +30,7 @@ func NewTopology(config Config, allClusters Map) Topology {
 		ClusterName:        config.Name,
 		ClusterKind:        config.Kind,
 		Network:            config.Network,
-		ClusterHTTPProxy:   config.Proxy,
+		ClusterHTTPProxy:   config.HTTPProxy,
 		PrimaryClusterName: config.PrimaryClusterName,
 		ConfigClusterName:  config.ConfigClusterName,
 		AllClusters:        allClusters,
@@ -62,8 +62,8 @@ func (c Topology) Name() string {
 	return c.ClusterName
 }
 
-// Proxy to connect to the cluster
-func (c Topology) Proxy() string {
+// HTTPProxy to connect to the cluster
+func (c Topology) HTTPProxy() string {
 	return c.ClusterHTTPProxy
 }
 
@@ -187,7 +187,7 @@ func (c Topology) String() string {
 	_, _ = fmt.Fprintf(buf, "PrimaryCluster:     %s\n", c.Primary().Name())
 	_, _ = fmt.Fprintf(buf, "ConfigCluster:      %s\n", c.Config().Name())
 	_, _ = fmt.Fprintf(buf, "Network:            %s\n", c.NetworkName())
-	_, _ = fmt.Fprintf(buf, "Proxy:            %s\n", c.Proxy())
+	_, _ = fmt.Fprintf(buf, "HTTPProxy:            %s\n", c.HTTPProxy())
 
 	return buf.String()
 }

--- a/pkg/test/framework/components/cluster/topology.go
+++ b/pkg/test/framework/components/cluster/topology.go
@@ -30,6 +30,7 @@ func NewTopology(config Config, allClusters Map) Topology {
 		ClusterName:        config.Name,
 		ClusterKind:        config.Kind,
 		Network:            config.Network,
+		ClusterHTTPProxy:   config.Proxy,
 		PrimaryClusterName: config.PrimaryClusterName,
 		ConfigClusterName:  config.ConfigClusterName,
 		AllClusters:        allClusters,
@@ -43,6 +44,7 @@ type Topology struct {
 	ClusterName        string
 	ClusterKind        Kind
 	Network            string
+	ClusterHTTPProxy   string
 	PrimaryClusterName string
 	ConfigClusterName  string
 	Index              int
@@ -58,6 +60,11 @@ func (c Topology) NetworkName() string {
 // Name provides the ClusterName this cluster used by Istio.
 func (c Topology) Name() string {
 	return c.ClusterName
+}
+
+// Proxy to connect to the cluster
+func (c Topology) Proxy() string {
+	return c.ClusterHTTPProxy
 }
 
 // knownClusterNames maintains a well-known set of cluster names. These will always be used with
@@ -180,6 +187,7 @@ func (c Topology) String() string {
 	_, _ = fmt.Fprintf(buf, "PrimaryCluster:     %s\n", c.Primary().Name())
 	_, _ = fmt.Fprintf(buf, "ConfigCluster:      %s\n", c.Config().Name())
 	_, _ = fmt.Fprintf(buf, "Network:            %s\n", c.NetworkName())
+	_, _ = fmt.Fprintf(buf, "Proxy:            %s\n", c.Proxy())
 
 	return buf.String()
 }

--- a/pkg/test/framework/components/echo/call.go
+++ b/pkg/test/framework/components/echo/call.go
@@ -86,8 +86,8 @@ type CallOptions struct {
 	// will be verified.
 	Validator Validator
 
-	// Http proxy used for making ingress echo call via proxy
-	Proxy string
+	// HTTProxy used for making ingress echo call via proxy
+	HTTPProxy string
 
 	Alpn       *proto.Alpn
 	ServerName string

--- a/pkg/test/framework/components/echo/call.go
+++ b/pkg/test/framework/components/echo/call.go
@@ -86,6 +86,9 @@ type CallOptions struct {
 	// will be verified.
 	Validator Validator
 
+	// Http proxy used for making ingress echo call via proxy
+	Proxy string
+
 	Alpn       *proto.Alpn
 	ServerName string
 }

--- a/pkg/test/framework/components/echo/common/call.go
+++ b/pkg/test/framework/components/echo/common/call.go
@@ -128,6 +128,7 @@ func CallEcho(opts *echo.CallOptions, retry bool, retryOptions ...retry.Option) 
 	send := func(req *proto.ForwardEchoRequest) (client.ParsedResponses, error) {
 		instance, err := forwarder.New(forwarder.Config{
 			Request: req,
+			Proxy:   opts.Proxy,
 		})
 		if err != nil {
 			return nil, err

--- a/pkg/test/framework/components/echo/common/call.go
+++ b/pkg/test/framework/components/echo/common/call.go
@@ -128,7 +128,7 @@ func CallEcho(opts *echo.CallOptions, retry bool, retryOptions ...retry.Option) 
 	send := func(req *proto.ForwardEchoRequest) (client.ParsedResponses, error) {
 		instance, err := forwarder.New(forwarder.Config{
 			Request: req,
-			Proxy:   opts.Proxy,
+			Proxy:   opts.HTTPProxy,
 		})
 		if err != nil {
 			return nil, err

--- a/pkg/test/framework/components/istio/ingress.go
+++ b/pkg/test/framework/components/istio/ingress.go
@@ -236,8 +236,8 @@ func (c *ingressImpl) callEcho(options echo.CallOptions, retry bool, retryOption
 	if host := options.Headers["Host"]; len(host) == 0 {
 		options.Headers["Host"] = []string{options.Address}
 	}
-	if len(c.cluster.Proxy()) > 0 {
-		options.Proxy = c.cluster.Proxy()
+	if len(c.cluster.HTTPProxy()) > 0 {
+		options.HTTPProxy = c.cluster.HTTPProxy()
 	}
 	return common.CallEcho(&options, retry, retryOptions...)
 }

--- a/pkg/test/framework/components/istio/ingress.go
+++ b/pkg/test/framework/components/istio/ingress.go
@@ -236,6 +236,9 @@ func (c *ingressImpl) callEcho(options echo.CallOptions, retry bool, retryOption
 	if host := options.Headers["Host"]; len(host) == 0 {
 		options.Headers["Host"] = []string{options.Address}
 	}
+	if len(c.cluster.Proxy()) > 0 {
+		options.Proxy = c.cluster.Proxy()
+	}
 	return common.CallEcho(&options, retry, retryOptions...)
 }
 


### PR DESCRIPTION
This PR is to extend the test framework to support connection via proxy. This is for testing with clusters which requires http proxy to connect to the kubernetes API server or connect to the ingress gateway.  



**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [X] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
