### PR TITLE
Revert "fix portforwarder Close time"

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -681,10 +681,10 @@ func (c *client) portForwardRequest(ctx context.Context, podName, podNamespace, 
 	if err != nil {
 		return nil, err
 	}
-	defer fw.Close()
 	if err = fw.Start(); err != nil {
 		return nil, formatError(err)
 	}
+	defer fw.Close()
 	req, err := http.NewRequest(method, fmt.Sprintf("http://%s/%s", fw.Address(), path), nil)
 	if err != nil {
 		return nil, formatError(err)


### PR DESCRIPTION
Reverts istio/istio#34034
not sure  whether istio/istio#34034 is correct or not, 
not sure when `func (f *forwarder) Close()` should be called? only when PortFowarder  `Start()` function is called successfully, or 
just when it being created successfully
https://github.com/istio/istio/blob/0ba661aea9d7e264b7b5f1670d2d3bbfe4fd569d/pkg/kube/portforwarder.go#L74-L78