### PR TITLE
add resource names in debug cache

### DIFF
--- a/pilot/pkg/xds/debug.go
+++ b/pilot/pkg/xds/debug.go
@@ -318,12 +318,13 @@ func (s *DiscoveryServer) cachez(w http.ResponseWriter, req *http.Request) {
 		snapshot := s.Cache.Snapshot()
 		res := make(map[string]string, len(snapshot))
 		totalSize := 0
-		for k, v := range snapshot {
-			if v == nil {
+		for _, resource := range snapshot {
+			if resource == nil {
 				continue
 			}
-			sz := len(v.Resource.GetValue())
-			res[k] = util.ByteCount(sz)
+			resourceType := resource.Resource.TypeUrl
+			sz := len(resource.Resource.GetValue())
+			res[resourceType] += util.ByteCount(sz)
 			totalSize += sz
 		}
 		res["total"] = util.ByteCount(totalSize)
@@ -331,10 +332,13 @@ func (s *DiscoveryServer) cachez(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 	snapshot := s.Cache.Snapshot()
-	resources := make(map[string][]string) // Key is typeUrl and value is resource names.
-	for _, resource := range snapshot {
+	resources := make(map[string][]string, len(snapshot)) // Key is typeUrl and value is resource names.
+	for key, resource := range snapshot {
+		if resource == nil {
+			continue
+		}
 		resourceType := resource.Resource.TypeUrl
-		resources[resourceType] = append(resources[resourceType], resource.Name)
+		resources[resourceType] = append(resources[resourceType], resource.Name+"/"+key)
 	}
 	writeJSON(w, resources)
 }

--- a/pilot/pkg/xds/debug.go
+++ b/pilot/pkg/xds/debug.go
@@ -330,9 +330,13 @@ func (s *DiscoveryServer) cachez(w http.ResponseWriter, req *http.Request) {
 		writeJSON(w, res)
 		return
 	}
-	keys := s.Cache.Keys()
-	sort.Strings(keys)
-	writeJSON(w, keys)
+	snapshot := s.Cache.Snapshot()
+	resources := make(map[string][]string) // Key is typeUrl and value is resource names.
+	for _, resource := range snapshot {
+		typeUrl := resource.Resource.TypeUrl
+		resources[typeUrl] = append(resources[typeUrl], resource.Name)
+	}
+	writeJSON(w, resources)
 }
 
 type endpointzResponse struct {

--- a/pilot/pkg/xds/debug.go
+++ b/pilot/pkg/xds/debug.go
@@ -333,8 +333,8 @@ func (s *DiscoveryServer) cachez(w http.ResponseWriter, req *http.Request) {
 	snapshot := s.Cache.Snapshot()
 	resources := make(map[string][]string) // Key is typeUrl and value is resource names.
 	for _, resource := range snapshot {
-		typeUrl := resource.Resource.TypeUrl
-		resources[typeUrl] = append(resources[typeUrl], resource.Name)
+		resourceType := resource.Resource.TypeUrl
+		resources[resourceType] = append(resources[resourceType], resource.Name)
 	}
 	writeJSON(w, resources)
 }


### PR DESCRIPTION
Since we are moving hash as cache keys we need a better way to represent them in debug. This PR displays typeUrl and resource names in debug mode.

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
