### PR TITLE
 Envoy expects IPv6 address within '[]' for domains under route_config #34533 

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -120,7 +120,8 @@ func (configgen *ConfigGeneratorImpl) buildSidecarInboundHTTPRouteConfig(
 	return r
 }
 
-// IPv6 addresses are enclosed within square brackets
+// IPv6 addresses are enclosed in square brackets followed by port number in Host header/URIs
+// needed distinguish port number as ':' is part of IPv6 address
 func ipv6Compliant(host string) string {
 	if strings.Contains(host, ":") {
 		return "[" + host + "]"

--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -16,7 +16,6 @@ package v1alpha3
 
 import (
 	"fmt"
-	"net"
 	"sort"
 	"strconv"
 	"strings"
@@ -123,7 +122,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarInboundHTTPRouteConfig(
 
 // IPv6 addresses are enclosed within square brackets
 func ipv6Compliant(host string) string {
-	if net.ParseIP(host) != nil && strings.Contains(host, ":") {
+	if strings.Contains(host, ":") {
 		return "[" + host + "]"
 	}
 	return host

--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -16,6 +16,7 @@ package v1alpha3
 
 import (
 	"fmt"
+	"net"
 	"sort"
 	"strconv"
 	"strings"
@@ -120,14 +121,22 @@ func (configgen *ConfigGeneratorImpl) buildSidecarInboundHTTPRouteConfig(
 	return r
 }
 
+// IPv6 addresses are enclosed within square brackets
+func ipv6Compliant(host string) string {
+	if net.ParseIP(host) != nil && strings.Contains(host, ":") {
+		return "[" + host + "]"
+	}
+	return host
+}
+
 // domainName builds the domain name for a given host and port
 func domainName(host string, port int) string {
-	return host + ":" + strconv.Itoa(port)
+	return ipv6Compliant(host) + ":" + strconv.Itoa(port)
 }
 
 func traceOperation(host string, port int) string {
 	// Format : "%s:%d/*"
-	return host + ":" + strconv.Itoa(port) + "/*"
+	return ipv6Compliant(host) + ":" + strconv.Itoa(port) + "/*"
 }
 
 // buildSidecarOutboundHTTPRouteConfig builds an outbound HTTP Route for sidecar.
@@ -342,7 +351,7 @@ func BuildSidecarOutboundVirtualHosts(node *model.Proxy, push *model.PushContext
 		var domains []string
 		var altHosts []string
 		if svc == nil {
-			domains = []string{hostname, name}
+			domains = []string{ipv6Compliant(hostname), name}
 		} else {
 			domains, altHosts = generateVirtualHostDomains(svc, vhwrapper.Port, node)
 		}
@@ -462,7 +471,7 @@ func getVirtualHostsForSniffedServicePort(vhosts []*route.VirtualHost, routeName
 // a proxy node
 func generateVirtualHostDomains(service *model.Service, port int, node *model.Proxy) ([]string, []string) {
 	altHosts := generateAltVirtualHosts(string(service.Hostname), port, node.DNSDomain)
-	domains := []string{string(service.Hostname), domainName(string(service.Hostname), port)}
+	domains := []string{ipv6Compliant(string(service.Hostname)), domainName(string(service.Hostname), port)}
 	domains = append(domains, altHosts...)
 
 	if service.Resolution == model.Passthrough &&

--- a/pilot/pkg/networking/core/v1alpha3/httproute_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute_test.go
@@ -162,7 +162,8 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 			node: &model.Proxy{
 				DNSDomain: "example.com",
 			},
-			want: []string{"1.2.3.4", "1.2.3.4:8123"},
+			want:        []string{"1.2.3.4", "1.2.3.4:8123"},
+			wantWithMCS: []string{"1.2.3.4", "1.2.3.4:8123"},
 		},
 		{
 			name: "ipv6 domain",
@@ -174,12 +175,15 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 			node: &model.Proxy{
 				DNSDomain: "example.com",
 			},
-			want: []string{"[2406:3003:2064:35b8:864:a648:4b96:e37d]", "[2406:3003:2064:35b8:864:a648:4b96:e37d]:8123"},
+			want:        []string{"[2406:3003:2064:35b8:864:a648:4b96:e37d]", "[2406:3003:2064:35b8:864:a648:4b96:e37d]:8123"},
+			wantWithMCS: []string{"[2406:3003:2064:35b8:864:a648:4b96:e37d]", "[2406:3003:2064:35b8:864:a648:4b96:e37d]:8123"},
 		},
 	}
 
 	testFn := func(service *model.Service, port int, node *model.Proxy, want []string) error {
 		out, _ := generateVirtualHostDomains(service, port, node)
+		fmt.Println(out)
+		fmt.Println(want)
 		sort.SliceStable(want, func(i, j int) bool { return want[i] < want[j] })
 		sort.SliceStable(out, func(i, j int) bool { return out[i] < out[j] })
 		if !reflect.DeepEqual(out, want) {

--- a/pilot/pkg/networking/core/v1alpha3/httproute_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute_test.go
@@ -152,6 +152,30 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 			want:        []string{"google.local", "google.local:8123"},
 			wantWithMCS: []string{"google.local", "google.local:8123"},
 		},
+		{
+			name: "ipv4 domain",
+			service: &model.Service{
+				Hostname:     "1.2.3.4",
+				MeshExternal: false,
+			},
+			port: 8123,
+			node: &model.Proxy{
+				DNSDomain: "example.com",
+			},
+			want: []string{"1.2.3.4", "1.2.3.4:8123"},
+		},
+		{
+			name: "ipv6 domain",
+			service: &model.Service{
+				Hostname:     "2406:3003:2064:35b8:864:a648:4b96:e37d",
+				MeshExternal: false,
+			},
+			port: 8123,
+			node: &model.Proxy{
+				DNSDomain: "example.com",
+			},
+			want: []string{"[2406:3003:2064:35b8:864:a648:4b96:e37d]", "[2406:3003:2064:35b8:864:a648:4b96:e37d]:8123"},
+		},
 	}
 
 	testFn := func(service *model.Service, port int, node *model.Proxy, want []string) error {

--- a/pilot/pkg/networking/core/v1alpha3/httproute_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute_test.go
@@ -182,8 +182,6 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 
 	testFn := func(service *model.Service, port int, node *model.Proxy, want []string) error {
 		out, _ := generateVirtualHostDomains(service, port, node)
-		fmt.Println(out)
-		fmt.Println(want)
 		sort.SliceStable(want, func(i, j int) bool { return want[i] < want[j] })
 		sort.SliceStable(out, func(i, j int) bool { return out[i] < out[j] })
 		if !reflect.DeepEqual(out, want) {


### PR DESCRIPTION
**Please provide a description of this PR:**

Fix for https://github.com/istio/istio/issues/34533 . Brackets are added to ipv6 addresses while pushing envoy config.


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
