### PR TITLE
fix fsnotify event proc missing for install-cni

### DIFF
--- a/cni/pkg/install/install.go
+++ b/cni/pkg/install/install.go
@@ -190,9 +190,8 @@ func sleepCheckInstall(ctx context.Context, cfg *config.InstallConfig, cniConfig
 			// Valid configuration; set isReady to true and wait for modifications before checking again
 			SetReady(isReady)
 			cniInstalls.With(resultLabel.Value(resultSuccess)).Increment()
-			err = util.WaitForFileMod(ctx, fileModified, errChan)
 			// Pod set to "NotReady" before termination
-			return err
+			return util.WaitForFileMod(ctx, fileModified, errChan)
 		}
 	}
 }

--- a/cni/pkg/install/install.go
+++ b/cni/pkg/install/install.go
@@ -190,10 +190,9 @@ func sleepCheckInstall(ctx context.Context, cfg *config.InstallConfig, cniConfig
 			// Valid configuration; set isReady to true and wait for modifications before checking again
 			SetReady(isReady)
 			cniInstalls.With(resultLabel.Value(resultSuccess)).Increment()
-			if err = util.WaitForFileMod(ctx, fileModified, errChan); err != nil {
-				// Pod set to "NotReady" before termination
-				return err
-			}
+			err = util.WaitForFileMod(ctx, fileModified, errChan)
+			// Pod set to "NotReady" before termination
+			return err
 		}
 	}
 }

--- a/cni/pkg/util/util.go
+++ b/cni/pkg/util/util.go
@@ -46,11 +46,13 @@ func CreateFileWatcher(dir string) (watcher *fsnotify.Watcher, fileModified chan
 func watchFiles(watcher *fsnotify.Watcher, fileModified chan bool, errChan chan error) {
 	for {
 		select {
-		case _, ok := <-watcher.Events:
+		case event, ok := <-watcher.Events:
 			if !ok {
 				return
 			}
-			fileModified <- true
+			if event.Op&(fsnotify.Create|fsnotify.Write|fsnotify.Remove) != 0 {
+				fileModified <- true
+			}
 		case err, ok := <-watcher.Errors:
 			if !ok {
 				return


### PR DESCRIPTION
**Please provide a description of this PR:**

## problem

`Installer.Run` of `install-cni` will watch `cfg.MountedCNINetDir`(`/host/etc/cni/net.d`), if config files in this dir have changed, `Installer.Run` will reinstall all files(binary, kube config, cni config, etc).

```go
func (in *Installer) Run(ctx context.Context) (err error) {
	for {
		if err = copyBinaries(
			in.cfg.CNIBinSourceDir, in.cfg.CNIBinTargetDirs,
			in.cfg.UpdateCNIBinaries, in.cfg.SkipCNIBinaries); err != nil {
			cniInstalls.With(resultLabel.Value(resultCopyBinariesFailure)).Increment()
			return
		}
...
		if err = sleepCheckInstall(ctx, in.cfg, in.cniConfigFilepath, in.isReady); err != nil {
			return
		}
		// Invalid config; pod set to "NotReady"
		installLog.Info("Restarting...")
	}
}

```

When testing this feature I find that this only take effect when creating new files in `/host/etc/cni/net.d`. Whether delete or update files in the dir, the `sleepCheckInstall` func will not return and `Installer.Run` will not reinstall files.

## the reason

This is because there is a small problem in `sleepCheckInstall`.

```go
func sleepCheckInstall(ctx context.Context, cfg *config.InstallConfig, cniConfigFilepath string, isReady *atomic.Value) error {
	// Create file watcher before checking for installation
	// so that no file modifications are missed while and after checking
	watcher, fileModified, errChan, err := util.CreateFileWatcher(cfg.MountedCNINetDir)
	if err != nil {
		return err
	}
	defer func() {
		SetNotReady(isReady)
		_ = watcher.Close()
	}()

	for {
		if checkErr := checkInstall(cfg, cniConfigFilepath); checkErr != nil {
			// Pod set to "NotReady" due to invalid configuration
			installLog.Infof("Invalid configuration. %v", checkErr)
			return nil
		}
		// Check if file has been modified or if an error has occurred during checkInstall before setting isReady to true
		select {
		case <-fileModified:             //--- p1
			return nil
		case err := <-errChan:
			return err
		case <-ctx.Done():
			return ctx.Err()
		default:
			// Valid configuration; set isReady to true and wait for modifications before checking again
			SetReady(isReady)
			cniInstalls.With(resultLabel.Value(resultSuccess)).Increment()
			if err = util.WaitForFileMod(ctx, fileModified, errChan); err != nil {
				// Pod set to "NotReady" before termination
				return err
			}
		}
	}
}
```

After install-cni starts up, the `sleepCheckInstall` will fall to default branch and waits for `fileModified` / `errChan` / `ctx.Done()` in `WaitForFileMod`.

```go
// Waits until a file is modified (returns nil), the context is cancelled (returns context error), or returns error
func WaitForFileMod(ctx context.Context, fileModified chan bool, errChan chan error) error {
	select {
	case <-fileModified:                 //-- p2
		return nil
	case err := <-errChan:
		return err
	case <-ctx.Done():
		return ctx.Err()
	}
}
```

When creating new files, fsnotify will generate TWO events(`CREATE` and `CHMOD`), while when deleting or updating files, fsnotify will generate ONE event(`REMOVE` for deleting and `WRITE` for updating).

If we delete or update files, we will get ONE event, so we will return nil from `WaitForFileMod`(p2), and continue the loop in `sleepCheckInstall`. Since we have one event and the `fileModified` channel is empty now, we will fall to default branch again. The event is not actually processed.

If we add files, we will get TWO events, when we return nil from `WaitForFileMod`(p2) and continue the loop in `sleepCheckInstall`, the `fileModified` channel still have an element, so we will return nil from `sleepCheckInstall`(p1) to `Installer.Run`, and reinstall those files.

## how to fix

1. We only need to handle `fsnotify.Create|fsnotify.Write|fsnotify.Remove`, and ignore `fsnotify.Rename` and `fsnotify.Chmod`.
2. when return from `WaitForFileMod`, we should always return from `sleepCheckInstall` to `Installer.Run`.


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
