### PR TITLE
remove multicluster label as RequiresMinClusters > 1 implies that

### DIFF
--- a/tests/integration/istiodremote/base/main_test.go
+++ b/tests/integration/istiodremote/base/main_test.go
@@ -20,7 +20,6 @@ import (
 
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/istio"
-	"istio.io/istio/pkg/test/framework/label"
 	"istio.io/istio/tests/integration/istiodremote"
 )
 
@@ -29,7 +28,6 @@ var ist istio.Instance
 func TestMain(m *testing.M) {
 	framework.
 		NewSuite(m).
-		Label(label.Multicluster).
 		RequireMinClusters(2).
 		Setup(istio.Setup(&ist, nil)).
 		Run()

--- a/tests/integration/istiodremote/gateway.go
+++ b/tests/integration/istiodremote/gateway.go
@@ -30,7 +30,6 @@ import (
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/components/istioctl"
 	"istio.io/istio/pkg/test/framework/features"
-	"istio.io/istio/pkg/test/framework/label"
 	"istio.io/istio/pkg/test/scopes"
 	"istio.io/istio/pkg/test/util/retry"
 )
@@ -38,7 +37,7 @@ import (
 // GatewayTest tests that istio ingress gateway can be started successfully in remote cluster
 func GatewayTest(t *testing.T, feature features.Feature) {
 	framework.NewTest(t).
-		Label(label.Multicluster).
+		RequiresMinClusters(2).
 		Features(feature).
 		Run(func(ctx framework.TestContext) {
 			ctx.NewSubTest("gateway").

--- a/tests/integration/istiodremote/multicluster/main_test.go
+++ b/tests/integration/istiodremote/multicluster/main_test.go
@@ -20,7 +20,6 @@ import (
 
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/istio"
-	"istio.io/istio/pkg/test/framework/label"
 	"istio.io/istio/pkg/test/framework/resource"
 	"istio.io/istio/tests/integration/multicluster"
 )
@@ -33,7 +32,6 @@ var (
 func TestMain(m *testing.M) {
 	framework.
 		NewSuite(m).
-		Label(label.Multicluster).
 		RequireMinClusters(3).
 		Setup(multicluster.Setup(&appCtx)).
 		Setup(istio.Setup(&ist, func(_ resource.Context, cfg *istio.Config) {

--- a/tests/integration/multicluster/base/main_test.go
+++ b/tests/integration/multicluster/base/main_test.go
@@ -20,7 +20,6 @@ import (
 
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/istio"
-	"istio.io/istio/pkg/test/framework/label"
 	"istio.io/istio/pkg/test/framework/resource"
 	"istio.io/istio/tests/integration/multicluster"
 )
@@ -33,7 +32,6 @@ var (
 func TestMain(m *testing.M) {
 	framework.
 		NewSuite(m).
-		Label(label.Multicluster).
 		RequireMinClusters(2).
 		Setup(multicluster.Setup(&appCtx)).
 		Setup(istio.Setup(&ist, func(_ resource.Context, cfg *istio.Config) {

--- a/tests/integration/multicluster/cluster_local.go
+++ b/tests/integration/multicluster/cluster_local.go
@@ -21,7 +21,6 @@ import (
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/features"
-	"istio.io/istio/pkg/test/framework/label"
 )
 
 // ClusterLocalTest tests that traffic works within a local cluster while in a multicluster configuration
@@ -34,7 +33,7 @@ func ClusterLocalTest(t *testing.T, apps AppContext, features ...features.Featur
 				for _, c := range ctx.Clusters() {
 					c := c
 					ctx.NewSubTest(c.StableName()).
-						Label(label.Multicluster).
+						RequiresMinClusters(2).
 						Run(func(ctx framework.TestContext) {
 							local := apps.LocalEchos.GetOrFail(ctx, echo.InCluster(c))
 							callOrFail(ctx, local, local, echo.ExpectCluster(c.Name()))

--- a/tests/integration/multicluster/loadbalancing.go
+++ b/tests/integration/multicluster/loadbalancing.go
@@ -24,12 +24,11 @@ import (
 	"istio.io/istio/pkg/test/framework/components/cluster"
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/features"
-	"istio.io/istio/pkg/test/framework/label"
 )
 
 func LoadbalancingTest(t *testing.T, apps AppContext, features ...features.Feature) {
 	framework.NewTest(t).
-		Label(label.Multicluster).
+		RequiresMinClusters(2).
 		Features(features...).
 		Run(func(ctx framework.TestContext) {
 			ctx.NewSubTest("loadbalancing").

--- a/tests/integration/multicluster/reachability.go
+++ b/tests/integration/multicluster/reachability.go
@@ -22,13 +22,12 @@ import (
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/features"
-	"istio.io/istio/pkg/test/framework/label"
 )
 
 // ReachabilityTest tests that different services in 2 different clusters can talk to each other.
 func ReachabilityTest(t *testing.T, apps AppContext, features ...features.Feature) {
 	framework.NewTest(t).
-		Label(label.Multicluster).
+		RequiresMinClusters(2).
 		Features(features...).
 		Run(func(ctx framework.TestContext) {
 			ctx.NewSubTest("reachability").

--- a/tests/integration/multicluster/telemetry.go
+++ b/tests/integration/multicluster/telemetry.go
@@ -23,14 +23,13 @@ import (
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/features"
-	"istio.io/istio/pkg/test/framework/label"
 )
 
 // TelemetryTest validates that source and destination labels are collected
 // for multicluster traffic.
 func TelemetryTest(t *testing.T, apps AppContext, features ...features.Feature) {
 	framework.NewTest(t).
-		Label(label.Multicluster).
+		RequiresMinClusters(2).
 		Features(features...).
 		Run(func(ctx framework.TestContext) {
 			ctx.NewSubTest("telemetry").


### PR DESCRIPTION
Signed-off-by: su225 <suchithjn22@gmail.com>

**Please provide a description of this PR:**
Part of #34517 - As mentioned in this issue, `multicluster` label is no longer required as `RequiresMinClusters > 1` implies that. It is redundant. So remove it. However, the label itself is not removed as tests fail because of "unknown label". It will be removed once job configs are fixed in test-infra repo.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [X] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
