### PR TITLE
envoy: remove another hardcoded port

### DIFF
--- a/pilot/cmd/pilot-agent/options/agent.go
+++ b/pilot/cmd/pilot-agent/options/agent.go
@@ -50,6 +50,7 @@ func NewAgentOptions(proxy *model.Proxy, cfg *meshconfig.ProxyConfig) *istioagen
 	if proxyXDSViaAgent {
 		o.ProxyXDSViaAgent = true
 		o.ProxyXDSDebugViaAgent = proxyXDSDebugViaAgent
+		o.ProxyXDSDebugViaAgentPort = proxyXDSDebugViaAgentPort
 		o.DNSCapture = DNSCaptureByAgent.Get()
 		o.DNSAddr = DNSCaptureAddr.Get()
 		o.ProxyNamespace = PodNamespaceVar.Get()

--- a/pilot/cmd/pilot-agent/options/options.go
+++ b/pilot/cmd/pilot-agent/options/options.go
@@ -80,7 +80,9 @@ var (
 		"If set to true, envoy will proxy XDS calls via the agent instead of directly connecting to istiod. This option "+
 			"will be removed once the feature is stabilized.").Get()
 	proxyXDSDebugViaAgent = env.RegisterBoolVar("PROXY_XDS_DEBUG_VIA_AGENT", true,
-		"If set to true, the agent will listen on 15004 and offer pilot's XDS istio.io/debug debug API there.").Get()
+		"If set to true, the agent will listen on tap port and offer pilot's XDS istio.io/debug debug API there.").Get()
+	proxyXDSDebugViaAgentPort = env.RegisterIntVar("PROXY_XDS_DEBUG_VIA_AGENT_PORT", 15004,
+		"Agent debugging port.").Get()
 	// DNSCaptureByAgent is a copy of the env var in the init code.
 	DNSCaptureByAgent = env.RegisterBoolVar("ISTIO_META_DNS_CAPTURE", false,
 		"If set to true, enable the capture of outgoing DNS packets on port 53, redirecting to istio-agent on :15053")

--- a/pkg/istio-agent/agent.go
+++ b/pkg/istio-agent/agent.go
@@ -130,9 +130,11 @@ type AgentOptions struct {
 	// ferry Envoy's XDS requests to istiod and responses back to envoy
 	// This flag is temporary until the feature is stabilized.
 	ProxyXDSViaAgent bool
-	// ProxyXDSDebugViaAgent if true will listen on 15004 and forward queries
+	// ProxyXDSDebugViaAgent if true will listen on the debug port and forward queries
 	// to XDS istio.io/debug. (Requires ProxyXDSViaAgent).
 	ProxyXDSDebugViaAgent bool
+	// Port value for the debugging endpoint.
+	ProxyXDSDebugViaAgentPort int
 	// DNSCapture indicates if the XDS proxy has dns capture enabled or not
 	// This option will not be considered if proxyXDSViaAgent is false.
 	DNSCapture bool
@@ -415,7 +417,7 @@ func (a *Agent) Run(ctx context.Context) (func(), error) {
 			return nil, fmt.Errorf("failed to start xds proxy: %v", err)
 		}
 		if a.cfg.ProxyXDSDebugViaAgent {
-			err = a.xdsProxy.initDebugInterface()
+			err = a.xdsProxy.initDebugInterface(a.cfg.ProxyXDSDebugViaAgentPort)
 			if err != nil {
 				return nil, fmt.Errorf("failed to start istio tap server: %v", err)
 			}

--- a/pkg/istio-agent/xds_proxy.go
+++ b/pkg/istio-agent/xds_proxy.go
@@ -823,10 +823,10 @@ func (p *XdsProxy) makeTapHandler() func(w http.ResponseWriter, req *http.Reques
 	}
 }
 
-// initDebugInterface() listens on localhost:15004 for path /debug/...
+// initDebugInterface() listens on localhost:${PORT} for path /debug/...
 // forwards the paths to Istiod as xDS requests
 // waits for response from Istiod, sends it as JSON
-func (p *XdsProxy) initDebugInterface() error {
+func (p *XdsProxy) initDebugInterface(port int) error {
 	p.tapResponseChannel = make(chan *discovery.DiscoveryResponse)
 
 	httpMux := http.NewServeMux()
@@ -835,7 +835,7 @@ func (p *XdsProxy) initDebugInterface() error {
 	httpMux.HandleFunc("/debug", handler) // For 1.10 Istiod which uses istio.io/debug
 
 	p.httpTapServer = &http.Server{
-		Addr:        "localhost:15004",
+		Addr:        fmt.Sprintf("localhost:%d", port),
 		Handler:     httpMux,
 		IdleTimeout: 90 * time.Second, // matches http.DefaultTransport keep-alive timeout
 		ReadTimeout: 30 * time.Second,


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

15004 is now apparently also hardcoded, so make it customizable.