### PR TITLE
fix e2e test when go test TestGateway with flag istio.test.kube.loadbalancer=false

### DIFF
--- a/pkg/test/framework/components/echo/echoboot/echoboot.go
+++ b/pkg/test/framework/components/echo/echoboot/echoboot.go
@@ -92,7 +92,7 @@ func (b builder) WithConfig(cfg echo.Config) echo.Builder {
 }
 
 // With adds a new Echo configuration to the Builder. When a cluster is provided in the Config, it will only be applied
-// to that cluster, otherwise the Config is applied to all WithClusters. Once built, if being built for a sngle cluster,
+// to that cluster, otherwise the Config is applied to all WithClusters. Once built, if being built for a single cluster,
 // the instance pointer will be updated to point at the new Instance.
 func (b builder) With(i *echo.Instance, cfg echo.Config) echo.Builder {
 	if b.ctx.Settings().SkipVM && cfg.DeployAsVM {
@@ -203,7 +203,7 @@ func (b builder) injectionTemplates() (map[string]sets.Set, error) {
 					t.Insert(name)
 				}
 				// either intersection has not been set or we intersect these templates
-				// with the currenet set.
+				// with the current set.
 				if intersection.Empty() {
 					intersection = t
 				} else {

--- a/pkg/test/framework/components/istio/istio.go
+++ b/pkg/test/framework/components/istio/istio.go
@@ -30,7 +30,7 @@ import (
 type Instance interface {
 	resource.Resource
 
-	// Ingresses returns all ingresses for "istio-ingressgateay" in each cluster.
+	// Ingresses returns all ingresses for "istio-ingressgateway" in each cluster.
 	Ingresses() ingress.Instances
 	// IngressFor returns an ingress used for reaching workloads in the given cluster.
 	// The ingress's service name will be "istio-ingressgateway" and the istio label will be "ingressgateway".

--- a/tests/integration/pilot/ingress_test.go
+++ b/tests/integration/pilot/ingress_test.go
@@ -165,14 +165,11 @@ spec:
 				}
 			})
 			t.NewSubTest("tcp").Run(func(t framework.TestContext) {
-				host, port := apps.Ingress.TCPAddress()
 				_ = apps.Ingress.CallWithRetryOrFail(t, echo.CallOptions{
 					Port: &echo.Port{
-						Protocol:    protocol.HTTP,
-						ServicePort: port,
+						Protocol: protocol.HTTP,
 					},
-					Address: host,
-					Path:    "/",
+					Path: "/",
 					Headers: map[string][]string{
 						"Host": {"my.domain.example"},
 					},


### PR DESCRIPTION

local test e2e , if go test with flag istio.test.kube.loadbalancer=false ,there will get port error because of get port twice.




- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
