### PR TITLE
make file debounce duration configurable

### DIFF
--- a/pilot/cmd/pilot-agent/options/agent.go
+++ b/pilot/cmd/pilot-agent/options/agent.go
@@ -45,6 +45,7 @@ func NewAgentOptions(proxy *model.Proxy, cfg *meshconfig.ProxyConfig) *istioagen
 		Platform:                 platform.Discover(),
 		GRPCBootstrapPath:        grpcBootstrapEnv,
 		DisableEnvoy:             disableEnvoyEnv,
+		FileDebounceDuration:     fileDebounceDuration,
 	}
 	extractXDSHeadersFromEnv(o)
 	if proxyXDSViaAgent {

--- a/pilot/cmd/pilot-agent/options/options.go
+++ b/pilot/cmd/pilot-agent/options/options.go
@@ -66,6 +66,10 @@ var (
 
 	secretTTLEnv = env.RegisterDurationVar("SECRET_TTL", 24*time.Hour,
 		"The cert lifetime requested by istio agent").Get()
+
+	fileDebounceDuration = env.RegisterDurationVar("FILE_DEBOUNCE_DURATION", 100*time.Millisecond,
+		"The duration for which the file read operation is delayed once file update is detected").Get()
+
 	secretRotationGracePeriodRatioEnv = env.RegisterFloatVar("SECRET_GRACE_PERIOD_RATIO", 0.5,
 		"The grace period ratio for the cert rotation, by default 0.5.").Get()
 	pkcs8KeysEnv = env.RegisterBoolVar("PKCS8_KEY", false,

--- a/pilot/cmd/pilot-agent/options/security.go
+++ b/pilot/cmd/pilot-agent/options/security.go
@@ -48,6 +48,7 @@ func NewSecurityOptions(proxyConfig *meshconfig.ProxyConfig, stsPort int, tokenM
 		Pkcs8Keys:                      pkcs8KeysEnv,
 		ECCSigAlg:                      eccSigAlgEnv,
 		SecretTTL:                      secretTTLEnv,
+		FileDebounceDuration:           fileDebounceDuration,
 		SecretRotationGracePeriodRatio: secretRotationGracePeriodRatioEnv,
 		STSPort:                        stsPort,
 		CertSigner:                     certSigner.Get(),

--- a/pkg/security/security.go
+++ b/pkg/security/security.go
@@ -183,6 +183,10 @@ type Options struct {
 
 	// Cert signer info
 	CertSigner string
+
+	// Delay in reading certificates from file after the change is detected. This is useful in cases
+	// where the write operation of key and cert take longer.
+	FileDebounceDuration time.Duration
 }
 
 // TokenManager contains methods for generating token.

--- a/security/pkg/nodeagent/cache/secretcache.go
+++ b/security/pkg/nodeagent/cache/secretcache.go
@@ -408,7 +408,7 @@ func (sc *SecretManagerClient) generateRootCertFromExistingFile(rootCertPath, re
 func (sc *SecretManagerClient) generateKeyCertFromExistingFiles(certChainPath, keyPath, resourceName string) (*security.SecretItem, error) {
 	// There is a remote possibility that key is written and cert is not written yet.
 	// To handle that case, we wait for some time here.
-	timer := time.After(100 * time.Millisecond) // TODO: Make this configurable if needed.
+	timer := time.After(sc.configOptions.FileDebounceDuration)
 	<-timer
 	return sc.keyCertSecretItem(certChainPath, keyPath, resourceName)
 }


### PR DESCRIPTION
In some baremetal cases we are seeing it is taking lot more time to write both key and certs. So making this configurable.

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [X] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
