### PR TITLE
Change sort --version-sort to -V for alpine (other Linux/GNU supports)

### DIFF
--- a/release/downloadIstioCandidate.sh
+++ b/release/downloadIstioCandidate.sh
@@ -37,7 +37,7 @@ fi
 # Determine the latest Istio version by version number ignoring alpha, beta, and rc versions.
 if [ "x${ISTIO_VERSION}" = "x" ] ; then
   ISTIO_VERSION="$(curl -sL https://github.com/istio/istio/releases | \
-                  grep -o 'releases/[0-9]*.[0-9]*.[0-9]*/' | sort --version-sort | \
+                  grep -o 'releases/[0-9]*.[0-9]*.[0-9]*/' | sort -V | \
                   tail -1 | awk -F'/' '{ print $2}')"
   ISTIO_VERSION="${ISTIO_VERSION##*/}"
 fi
@@ -108,7 +108,7 @@ ARCH_SUPPORTED="1.6"
 
 if [ "${OS}" = "Linux" ] ; then
   # This checks if ISTIO_VERSION is less than ARCH_SUPPORTED (version-sort's before it)
-  if [ "$(printf '%s\n%s' "${ARCH_SUPPORTED}" "${ISTIO_VERSION}" | sort --version-sort | head -n 1)" = "${ISTIO_VERSION}" ]; then
+  if [ "$(printf '%s\n%s' "${ARCH_SUPPORTED}" "${ISTIO_VERSION}" | sort -V | head -n 1)" = "${ISTIO_VERSION}" ]; then
     without_arch
   else
     with_arch

--- a/release/downloadIstioCtl.sh
+++ b/release/downloadIstioCtl.sh
@@ -34,7 +34,7 @@ fi
 # Determine the latest Istio version by version number ignoring alpha, beta, and rc versions.
 if [ "x${ISTIO_VERSION}" = "x" ] ; then
   ISTIO_VERSION="$(curl -sL https://github.com/istio/istio/releases | \
-                  grep -o 'releases/[0-9]*.[0-9]*.[0-9]*/' | sort --version-sort | \
+                  grep -o 'releases/[0-9]*.[0-9]*.[0-9]*/' | sort -V | \
                   tail -1 | awk -F'/' '{ print $2}')"
   ISTIO_VERSION="${ISTIO_VERSION##*/}"
 fi
@@ -112,7 +112,7 @@ ARCH_SUPPORTED="1.6"
 
 if [ "${OS}" = "Linux" ] ; then
   # This checks if ISTIO_VERSION is less than ARCH_SUPPORTED (version-sort's before it)
-  if [ "$(printf '%s\n%s' "${ARCH_SUPPORTED}" "${ISTIO_VERSION}" | sort --version-sort | head -n 1)" = "${ISTIO_VERSION}" ]; then
+  if [ "$(printf '%s\n%s' "${ARCH_SUPPORTED}" "${ISTIO_VERSION}" | sort -V | head -n 1)" = "${ISTIO_VERSION}" ]; then
     without_arch
   else
     with_arch


### PR DESCRIPTION
**Please provide a description of this PR:**

Fixes https://github.com/istio/istio/issues/34668. Change the sort parameter from --version-sort to -V as Alpine only supports the later. The Mac and looking at man pages for other Linux versions shows the -V is supported there as well.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [X] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
