### PR TITLE
Add nodemetadata debug interface

### DIFF
--- a/pilot/pkg/xds/debug.go
+++ b/pilot/pkg/xds/debug.go
@@ -173,7 +173,7 @@ func (s *DiscoveryServer) AddDebugHandlers(mux, internalMux *http.ServeMux, enab
 		s.addDebugHandler(mux, internalMux, "/debug/force_disconnect", "Disconnects a proxy from this Pilot", s.forceDisconnect)
 	}
 
-	s.addDebugHandler(mux, internalMux, "/debug/edsz", "Status and debug interface for EDS", s.edsz)
+	s.addDebugHandler(mux, internalMux, "/debug/edsz", "Status and debug interface for EDS", s.Edsz)
 	s.addDebugHandler(mux, internalMux, "/debug/ndsz", "Status and debug interface for NDS", s.ndsz)
 	s.addDebugHandler(mux, internalMux, "/debug/adsz", "Status and debug interface for ADS", s.adsz)
 	s.addDebugHandler(mux, internalMux, "/debug/adsz?push=true", "Initiates push of the current state to all connected endpoints", s.adsz)
@@ -800,9 +800,9 @@ func (s *DiscoveryServer) ndsz(w http.ResponseWriter, req *http.Request) {
 	}
 }
 
-// edsz implements a status and debug interface for EDS.
+// Edsz implements a status and debug interface for EDS.
 // It is mapped to /debug/edsz on the monitor port (15014).
-func (s *DiscoveryServer) edsz(w http.ResponseWriter, req *http.Request) {
+func (s *DiscoveryServer) Edsz(w http.ResponseWriter, req *http.Request) {
 	if s.handlePushRequest(w, req) {
 		return
 	}

--- a/pilot/pkg/xds/debug.go
+++ b/pilot/pkg/xds/debug.go
@@ -471,7 +471,7 @@ func (s *DiscoveryServer) configz(w http.ResponseWriter, req *http.Request) {
 
 // SidecarScope debugging
 func (s *DiscoveryServer) sidecarz(w http.ResponseWriter, req *http.Request) {
-	proxyID, con := s.getDebugConnection(w, req)
+	proxyID, con := s.getDebugConnection(req)
 	if con == nil {
 		s.errorHandler(w, proxyID, con)
 		return
@@ -531,7 +531,7 @@ func (s *DiscoveryServer) adsz(w http.ResponseWriter, req *http.Request) {
 	if s.handlePushRequest(w, req) {
 		return
 	}
-	proxyID, con := s.getDebugConnection(w, req)
+	proxyID, con := s.getDebugConnection(req)
 	if proxyID != "" && con == nil {
 		// We can't guarantee the Pilot we are connected to has a connection to the proxy we requested
 		// There isn't a great way around this, but for debugging purposes its suitable to have the caller retry.
@@ -574,7 +574,7 @@ func (s *DiscoveryServer) adsz(w http.ResponseWriter, req *http.Request) {
 // The dump will only contain dynamic listeners/clusters/routes and can be used to compare what an Envoy instance
 // should look like according to Pilot vs what it currently does look like.
 func (s *DiscoveryServer) ConfigDump(w http.ResponseWriter, req *http.Request) {
-	proxyID, con := s.getDebugConnection(w, req)
+	proxyID, con := s.getDebugConnection(req)
 	if con == nil {
 		s.errorHandler(w, proxyID, con)
 		return
@@ -785,7 +785,7 @@ func (s *DiscoveryServer) ndsz(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	proxyID, con := s.getDebugConnection(w, req)
+	proxyID, con := s.getDebugConnection(req)
 	if con == nil {
 		s.errorHandler(w, proxyID, con)
 		return
@@ -807,7 +807,7 @@ func (s *DiscoveryServer) Edsz(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	proxyID, con := s.getDebugConnection(w, req)
+	proxyID, con := s.getDebugConnection(req)
 	if con == nil {
 		s.errorHandler(w, proxyID, con)
 		return
@@ -822,7 +822,7 @@ func (s *DiscoveryServer) Edsz(w http.ResponseWriter, req *http.Request) {
 }
 
 func (s *DiscoveryServer) forceDisconnect(w http.ResponseWriter, req *http.Request) {
-	proxyID, con := s.getDebugConnection(w, req)
+	proxyID, con := s.getDebugConnection(req)
 	if con == nil {
 		s.errorHandler(w, proxyID, con)
 		return
@@ -916,7 +916,7 @@ func (s *DiscoveryServer) handlePushRequest(w http.ResponseWriter, req *http.Req
 }
 
 // getDebugConnection fetches the Connection requested by proxyID
-func (s *DiscoveryServer) getDebugConnection(w http.ResponseWriter, req *http.Request) (string, *Connection) {
+func (s *DiscoveryServer) getDebugConnection(req *http.Request) (string, *Connection) {
 	if proxyID := req.URL.Query().Get("proxyID"); proxyID != "" {
 		return proxyID, s.getProxyConnection(proxyID)
 	}


### PR DESCRIPTION
**Please provide a description of this PR:**

Allows users to get proxy node metadata via /debug/adsz

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
