### PR TITLE
add virtual service namespace to detect uniqueness

### DIFF
--- a/pilot/pkg/model/virtualservice.go
+++ b/pilot/pkg/model/virtualservice.go
@@ -36,10 +36,10 @@ func SelectVirtualServices(virtualServices []config.Config, hosts map[string][]h
 
 	vsset := sets.NewSet()
 	addVirtualService := func(vs config.Config, hosts host.Names) {
-		vsname := vs.Name
+		vsname := vs.Name + "/" + vs.Namespace
 		rule := vs.Spec.(*networking.VirtualService)
 		for _, ih := range hosts {
-			// Check if the hostnames match per usual hostname matching rules
+			// Check if the virtual service is already processed.
 			if vsset.Contains(vsname) {
 				break
 			}


### PR DESCRIPTION
If the virtual service has same name across namespaces, the current SelectVirtualServices logic incorrectly skips that VS. This fixes it.
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
