### PR TITLE
envoy: fix confusing log

### DIFF
--- a/pilot/cmd/pilot-agent/metrics/metrics.go
+++ b/pilot/cmd/pilot-agent/metrics/metrics.go
@@ -60,7 +60,7 @@ var processStartTime = time.Now()
 func RecordStartupTime() {
 	delta := time.Since(processStartTime)
 	startupTime.Record(delta.Seconds())
-	log.Infof("Initialization took %v", delta)
+	log.Infof("Readiness succeeded in %v", delta)
 }
 
 func init() {


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

Envoy is initialized way before the readiness succeeds. Make this explicit in the comment.