### PR TITLE
wasm: check if fetched binaries are valid.

### DIFF
--- a/pkg/wasm/cache.go
+++ b/pkg/wasm/cache.go
@@ -15,6 +15,7 @@
 package wasm
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -159,9 +160,11 @@ func (c *LocalFileCache) Get(downloadURL, checksum string, timeout time.Duration
 		return "", fmt.Errorf("unsupported Wasm module downloading URL scheme: %v", u.Scheme)
 	}
 
-	wasmRemoteFetchCount.With(resultTag.Value(fetchSuccess)).Increment()
+	if !isValidWasmBinary(b) {
+		return "", fmt.Errorf("fetched Wasm binary from %s is invalid", downloadURL)
+	}
 
-	// TODO(bianpengyuan): Add sanity check on downloaded file to make sure it is a valid Wasm module.
+	wasmRemoteFetchCount.With(resultTag.Value(fetchSuccess)).Increment()
 
 	key.checksum = dChecksum
 	f := filepath.Join(c.dir, fmt.Sprintf("%s.wasm", dChecksum))
@@ -249,4 +252,11 @@ func (c *LocalFileCache) purge() {
 func (ce *cacheEntry) expired(expiry time.Duration) bool {
 	now := time.Now()
 	return now.Sub(ce.last) > expiry
+}
+
+var wasmMagicNumber = []byte{0x00, 0x61, 0x73, 0x6d}
+
+func isValidWasmBinary(in []byte) bool {
+	// Wasm file header is 8 bytes (magic number + version).
+	return len(in) >= 8 && bytes.Equal(in[:4], wasmMagicNumber)
 }

--- a/pkg/wasm/cache.go
+++ b/pkg/wasm/cache.go
@@ -161,6 +161,7 @@ func (c *LocalFileCache) Get(downloadURL, checksum string, timeout time.Duration
 	}
 
 	if !isValidWasmBinary(b) {
+		wasmRemoteFetchCount.With(resultTag.Value(fetchFailure)).Increment()
 		return "", fmt.Errorf("fetched Wasm binary from %s is invalid", downloadURL)
 	}
 

--- a/pkg/wasm/cache_test.go
+++ b/pkg/wasm/cache_test.go
@@ -365,8 +365,8 @@ func TestWasmCacheMissChecksum(t *testing.T) {
 		gotNumRequest++
 	}))
 	defer ts.Close()
-	wantFilePath1 := filepath.Join(tmpDir, fmt.Sprintf("%x.wasm", sha256.Sum256([]byte(binary1))))
-	wantFilePath2 := filepath.Join(tmpDir, fmt.Sprintf("%x.wasm", sha256.Sum256([]byte(binary2))))
+	wantFilePath1 := filepath.Join(tmpDir, fmt.Sprintf("%x.wasm", sha256.Sum256(binary1)))
+	wantFilePath2 := filepath.Join(tmpDir, fmt.Sprintf("%x.wasm", sha256.Sum256(binary2)))
 
 	// Get wasm module three times, since checksum is not specified, it will be fetched from module server every time.
 	// 1st time

--- a/pkg/wasm/cache_test.go
+++ b/pkg/wasm/cache_test.go
@@ -34,16 +34,29 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/types"
 )
 
+// Wasm header = magic number (4 bytes) + Wasm spec version (4 bytes).
+var wasmHeader = append(wasmMagicNumber, []byte{0x1, 0x00, 0x00, 0x00}...)
+
 func TestWasmCache(t *testing.T) {
 	// Setup http server.
-	var tsNumRequest int
+	tsNumRequest := 0
+	httpData := append(wasmHeader, []byte("data")...)
+	invalidHttpData := []byte("invalid binary")
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		tsNumRequest++
-		fmt.Fprintln(w, "data"+r.URL.Path)
+		if r.URL.Path == "/different-url" {
+			w.Write(append(httpData, []byte("different data")...))
+		} else if r.URL.Path == "/invalid-wasm-header" {
+			w.Write(invalidHttpData)
+		} else {
+			w.Write(httpData)
+		}
 	}))
 	defer ts.Close()
-	httpDataSha := sha256.Sum256([]byte("data/\n"))
+	httpDataSha := sha256.Sum256(httpData)
 	httpDataCheckSum := hex.EncodeToString(httpDataSha[:])
+	invalidHttpDataSha := sha256.Sum256(invalidHttpData)
+	invalidHttpDataCheckSum := hex.EncodeToString(invalidHttpDataSha[:])
 
 	// Set up a fake registry for OCI images.
 	tos := httptest.NewServer(registry.New())
@@ -55,7 +68,7 @@ func TestWasmCache(t *testing.T) {
 	wantOCIDockerBinaryChecksum, dockerImageDigest, invalidOCIImageDigest := setupOCIRegistry(t, ou.Host)
 
 	// Calculate cachehit sum.
-	cacheHitSha := sha256.Sum256([]byte("cachehit\n"))
+	cacheHitSha := sha256.Sum256([]byte("cachehit"))
 	cacheHitSum := hex.EncodeToString(cacheHitSha[:])
 
 	cases := []struct {
@@ -135,6 +148,18 @@ func TestWasmCache(t *testing.T) {
 			wasmModuleExpiry:   DefaultWasmModuleExpiry,
 			checksum:           httpDataCheckSum,
 			wantErrorMsgPrefix: fmt.Sprintf("module downloaded from %v/different-url has checksum", ts.URL),
+			wantServerReqNum:   1,
+		},
+		{
+			name: "invalid wasm header",
+			initialCachedModules: map[cacheKey]cacheEntry{
+				{downloadURL: ts.URL, checksum: httpDataCheckSum}: {modulePath: fmt.Sprintf("%s.wasm", httpDataCheckSum)},
+			},
+			fetchURL:           ts.URL + "/invalid-wasm-header",
+			purgeInterval:      DefaultWasmModulePurgeInterval,
+			wasmModuleExpiry:   DefaultWasmModuleExpiry,
+			checksum:           invalidHttpDataCheckSum,
+			wantErrorMsgPrefix: fmt.Sprintf("fetched Wasm binary from %s is invalid", ts.URL+"/invalid-wasm-header"),
 			wantServerReqNum:   1,
 		},
 		{
@@ -261,7 +286,7 @@ func TestWasmCache(t *testing.T) {
 func setupOCIRegistry(t *testing.T, host string) (wantBinaryCheckSum, dockerImageDigest, invalidOCIImageDigest string) {
 	// Push *compat* variant docker image (others are well tested in imagefetcher's test and the behavior is consistent).
 	ref := fmt.Sprintf("%s/test/valid/docker:v0.1.0", host)
-	binary := []byte("this is wasm plugin")
+	binary := append(wasmHeader, []byte("this is wasm plugin")...)
 
 	// Create docker layer.
 	l, err := newMockLayer(types.DockerLayer,


### PR DESCRIPTION
This PR resolves a [TODO](https://github.com/istio/istio/blob/master/pkg/wasm/cache.go#L164) left in pkg/wasm, and adds the sanity-check for verifying fetched Wasm binaries have valid binary header.

Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [x] Policies and Telemetry
- [x] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.


cc @bianpengyuan 