### PR TITLE
add watching for cni plugin bin dir

### DIFF
--- a/cni/pkg/install/install.go
+++ b/cni/pkg/install/install.go
@@ -163,7 +163,7 @@ func readServiceAccountToken() (string, error) {
 func sleepCheckInstall(ctx context.Context, cfg *config.InstallConfig, cniConfigFilepath string, isReady *atomic.Value) error {
 	// Create file watcher before checking for installation
 	// so that no file modifications are missed while and after checking
-	watcher, fileModified, errChan, err := util.CreateFileWatcher(cfg.MountedCNINetDir)
+	watcher, fileModified, errChan, err := util.CreateFileWatcher(append(cfg.CNIBinTargetDirs, cfg.MountedCNINetDir)...)
 	if err != nil {
 		return err
 	}

--- a/cni/pkg/util/util.go
+++ b/cni/pkg/util/util.go
@@ -24,7 +24,7 @@ import (
 )
 
 // Creates a file watcher that watches for any changes to the directory
-func CreateFileWatcher(dir string) (watcher *fsnotify.Watcher, fileModified chan bool, errChan chan error, err error) {
+func CreateFileWatcher(dirs ...string) (watcher *fsnotify.Watcher, fileModified chan bool, errChan chan error, err error) {
 	watcher, err = fsnotify.NewWatcher()
 	if err != nil {
 		return
@@ -33,11 +33,13 @@ func CreateFileWatcher(dir string) (watcher *fsnotify.Watcher, fileModified chan
 	fileModified, errChan = make(chan bool), make(chan error)
 	go watchFiles(watcher, fileModified, errChan)
 
-	if err = watcher.Add(dir); err != nil {
-		if closeErr := watcher.Close(); closeErr != nil {
-			err = errors.Wrap(err, closeErr.Error())
+	for _, dir := range dirs {
+		if err = watcher.Add(dir); err != nil {
+			if closeErr := watcher.Close(); closeErr != nil {
+				err = errors.Wrap(err, closeErr.Error())
+			}
+			return nil, nil, nil, err
 		}
-		return nil, nil, nil, err
 	}
 
 	return

--- a/cni/pkg/util/util.go
+++ b/cni/pkg/util/util.go
@@ -21,6 +21,8 @@ import (
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/pkg/errors"
+
+	"istio.io/istio/pkg/file"
 )
 
 // Creates a file watcher that watches for any changes to the directory
@@ -34,6 +36,9 @@ func CreateFileWatcher(dirs ...string) (watcher *fsnotify.Watcher, fileModified 
 	go watchFiles(watcher, fileModified, errChan)
 
 	for _, dir := range dirs {
+		if file.IsDirWriteable(dir) != nil {
+			continue
+		}
 		if err = watcher.Add(dir); err != nil {
 			if closeErr := watcher.Close(); closeErr != nil {
 				err = errors.Wrap(err, closeErr.Error())


### PR DESCRIPTION
**Please provide a description of this PR:**

fix #34524

@bianpengyuan 
PR #34710 just fix watching for cni config dir, not the cni bin dir.
We should add cni bin dir to watcher, to make sure the cni bin file(istio-cni) is always correct.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
