### PR TITLE
Fix endpoint filter

### DIFF
--- a/pilot/pkg/model/network.go
+++ b/pilot/pkg/model/network.go
@@ -15,6 +15,7 @@
 package model
 
 import (
+	"fmt"
 	"net"
 	"sort"
 	"strings"
@@ -88,45 +89,52 @@ func NewNetworkManager(env *Environment) *NetworkManager {
 		nc := networkAndClusterForGateway(&gw)
 		byNetworkAndCluster[nc] = append(byNetworkAndCluster[nc], &gw)
 	}
+	fmt.Println(byNetwork, byNetworkAndCluster)
 
+	gwNum := []int{}
 	// Sort the gateways in byNetwork, and also calculate the max number
 	// of gateways per network.
-	var maxGatewaysPerNetwork int
 	for k, gws := range byNetwork {
 		byNetwork[k] = SortGateways(gws)
-
-		if len(gws) > maxGatewaysPerNetwork {
-			maxGatewaysPerNetwork = len(gws)
-		}
+		gwNum = append(gwNum, len(gws))
 	}
 
 	// Sort the gateways in byNetworkAndCluster.
 	for k, gws := range byNetworkAndCluster {
 		byNetworkAndCluster[k] = SortGateways(gws)
+		gwNum = append(gwNum, len(gws))
+	}
+
+	fmt.Println(gwNum)
+
+	lcmVal := 1
+	// calculate lcm
+	for _, num := range gwNum {
+		lcmVal = lcm(lcmVal, num)
 	}
 
 	return &NetworkManager{
-		maxGatewaysPerNetwork: uint32(maxGatewaysPerNetwork),
-		byNetwork:             byNetwork,
-		byNetworkAndCluster:   byNetworkAndCluster,
+		lcm:                 uint32(lcmVal),
+		byNetwork:           byNetwork,
+		byNetworkAndCluster: byNetworkAndCluster,
 	}
 }
 
 // NetworkManager provides gateway details for accessing remote networks.
 type NetworkManager struct {
-	maxGatewaysPerNetwork uint32
-	byNetwork             map[network.ID][]*NetworkGateway
-	byNetworkAndCluster   map[networkAndCluster][]*NetworkGateway
+	// least common multiple of gateway number of {per network, per cluster}
+	lcm                 uint32
+	byNetwork           map[network.ID][]*NetworkGateway
+	byNetworkAndCluster map[networkAndCluster][]*NetworkGateway
 }
 
 func (mgr *NetworkManager) IsMultiNetworkEnabled() bool {
 	return len(mgr.byNetwork) > 0
 }
 
-// GetMaxGatewaysPerNetwork returns an upper bound on the number of gateways there
-// could be for any one network.
-func (mgr *NetworkManager) GetMaxGatewaysPerNetwork() uint32 {
-	return mgr.maxGatewaysPerNetwork
+// GetLCM returns the least common multiple of the number of gateways.
+func (mgr *NetworkManager) GetLCM() uint32 {
+	return mgr.lcm
 }
 
 func (mgr *NetworkManager) AllGateways() []*NetworkGateway {
@@ -179,4 +187,23 @@ func SortGateways(gws []*NetworkGateway) []*NetworkGateway {
 		return gws[i].Port < gws[j].Port
 	})
 	return gws
+}
+
+// greatest common divisor of x and y
+func gcd(x, y int) int {
+	var tmp int
+	for {
+		tmp = x % y
+		if tmp > 0 {
+			x = y
+			y = tmp
+		} else {
+			return y
+		}
+	}
+}
+
+// least common multiple of x and y
+func lcm(x, y int) int {
+	return x * y / gcd(x, y)
 }

--- a/pilot/pkg/model/network.go
+++ b/pilot/pkg/model/network.go
@@ -128,9 +128,13 @@ func (mgr *NetworkManager) IsMultiNetworkEnabled() bool {
 	return len(mgr.byNetwork) > 0
 }
 
-// GetLCM returns the least common multiple of the number of gateways.
-func (mgr *NetworkManager) GetLCM() uint32 {
-	return mgr.lcm
+// GetLCM returns the least common multiple of the number of gateways for excluding those from the given network.
+func (mgr *NetworkManager) GetLCM(id network.ID) uint32 {
+	divisor := uint32(len(mgr.byNetwork[id]))
+	if divisor == 0 {
+		divisor = 1
+	}
+	return mgr.lcm / divisor
 }
 
 func (mgr *NetworkManager) AllGateways() []*NetworkGateway {

--- a/pilot/pkg/model/network.go
+++ b/pilot/pkg/model/network.go
@@ -15,7 +15,6 @@
 package model
 
 import (
-	"fmt"
 	"net"
 	"sort"
 	"strings"
@@ -89,7 +88,6 @@ func NewNetworkManager(env *Environment) *NetworkManager {
 		nc := networkAndClusterForGateway(&gw)
 		byNetworkAndCluster[nc] = append(byNetworkAndCluster[nc], &gw)
 	}
-	fmt.Println(byNetwork, byNetworkAndCluster)
 
 	gwNum := []int{}
 	// Sort the gateways in byNetwork, and also calculate the max number
@@ -104,8 +102,6 @@ func NewNetworkManager(env *Environment) *NetworkManager {
 		byNetworkAndCluster[k] = SortGateways(gws)
 		gwNum = append(gwNum, len(gws))
 	}
-
-	fmt.Println(gwNum)
 
 	lcmVal := 1
 	// calculate lcm

--- a/pilot/pkg/xds/eds_sh_test.go
+++ b/pilot/pkg/xds/eds_sh_test.go
@@ -144,21 +144,21 @@ func TestSplitHorizonEds(t *testing.T) {
 			want: expectedResults{
 				weights: map[string]uint32{
 					// 3 local endpoints.
-					"10.3.0.1": 2,
-					"10.3.0.2": 2,
-					"10.3.0.3": 2,
+					"10.3.0.1": 1,
+					"10.3.0.2": 1,
+					"10.3.0.3": 1,
 
 					// 1 endpoint on network 1, accessed via gateway.
-					"159.122.219.1": 2,
+					"159.122.219.1": 1,
 
 					// 2 endpoint on network 2, accessed via gateway.
-					"159.122.219.2": 4,
+					"159.122.219.2": 2,
 
 					// no gateway defined for network 4 - treat as directly reachable.
-					"10.4.0.1": 2,
-					"10.4.0.2": 2,
-					"10.4.0.3": 2,
-					"10.4.0.4": 2,
+					"10.4.0.1": 1,
+					"10.4.0.2": 1,
+					"10.4.0.3": 1,
+					"10.4.0.4": 1,
 				},
 			},
 		},

--- a/pilot/pkg/xds/ep_filters.go
+++ b/pilot/pkg/xds/ep_filters.go
@@ -47,7 +47,12 @@ func (b *EndpointBuilder) EndpointsByNetworkFilter(endpoints []*LocLbEndpointsAn
 	// Scale all weights by the lcm of gateways per network and gateways per cluster.
 	// This will allow us to more easily spread traffic to the endpoint across multiple
 	// network gateways, increasing reliability of the endpoint.
-	scaleFactor := b.push.NetworkManager().GetLCM()
+	divisor := uint32(len(b.push.NetworkManager().GatewaysForNetwork(b.network)))
+	if divisor == 0 {
+		divisor = 1
+	}
+	scaleFactor := b.push.NetworkManager().GetLCM() / divisor
+
 	// Go through all cluster endpoints and add those with the same network as the sidecar
 	// to the result. Also count the number of endpoints per each remote network while
 	// iterating so that it can be used as the weight for the gateway endpoint

--- a/pilot/pkg/xds/ep_filters.go
+++ b/pilot/pkg/xds/ep_filters.go
@@ -188,12 +188,11 @@ func splitWeightAmongGateways(weight uint32, gateways []*model.NetworkGateway, g
 	// Spread the remaining weight across the gateways.
 	weightPerGateway := weight / uint32(len(gateways))
 	remain := weight % uint32(len(gateways))
-
 	for i, gateway := range gateways {
 		gatewayWeights[*gateway] += weightPerGateway
 		if uint32(i) < remain {
 			// This should not happen, just in case
-			gatewayWeights[*gateway] += 1
+			gatewayWeights[*gateway]++
 		}
 	}
 }

--- a/pilot/pkg/xds/ep_filters.go
+++ b/pilot/pkg/xds/ep_filters.go
@@ -47,11 +47,7 @@ func (b *EndpointBuilder) EndpointsByNetworkFilter(endpoints []*LocLbEndpointsAn
 	// Scale all weights by the lcm of gateways per network and gateways per cluster.
 	// This will allow us to more easily spread traffic to the endpoint across multiple
 	// network gateways, increasing reliability of the endpoint.
-	divisor := uint32(len(b.push.NetworkManager().GatewaysForNetwork(b.network)))
-	if divisor == 0 {
-		divisor = 1
-	}
-	scaleFactor := b.push.NetworkManager().GetLCM() / divisor
+	scaleFactor := b.push.NetworkManager().GetLCM(b.network)
 
 	// Go through all cluster endpoints and add those with the same network as the sidecar
 	// to the result. Also count the number of endpoints per each remote network while

--- a/pilot/pkg/xds/ep_filters.go
+++ b/pilot/pkg/xds/ep_filters.go
@@ -101,31 +101,7 @@ func (b *EndpointBuilder) EndpointsByNetworkFilter(endpoints []*LocLbEndpointsAn
 			}
 
 			// Apply the weight for this endpoint to the network gateways.
-			remainingWeight := weight
-			for remainingWeight > 0 {
-				// Spread the remaining weight across the gateways.
-				weightPerGateway := remainingWeight / uint32(len(gateways))
-				if weightPerGateway == 0 {
-					// There are more gateways than weight. Just apply 1 to each gateway until all the
-					// weight has been exhausted.
-					weightPerGateway = 1
-				}
-
-				for _, gateway := range gateways {
-					// Add the portion of weight to this gateway.
-					if weightPerGateway > remainingWeight {
-						weightPerGateway = remainingWeight
-					}
-					gatewayWeights[*gateway] += weightPerGateway
-
-					// Update the remaining weight.
-					remainingWeight -= weightPerGateway
-					if remainingWeight == 0 {
-						// The weight for this endpoint has been exhausted. We're done.
-						break
-					}
-				}
-			}
+			splitWeightAmongGateways(weight, gateways, gatewayWeights)
 		}
 
 		// Sort the gateways into an ordered list so that the generated endpoints are deterministic.
@@ -201,6 +177,20 @@ func (b *EndpointBuilder) scaleEndpointLBWeight(ep *endpoint.LbEndpoint, scaleFa
 		weight = ep.GetLoadBalancingWeight().Value * scaleFactor
 	}
 	return weight
+}
+
+// Apply the weight for this endpoint to the network gateways.
+func splitWeightAmongGateways(weight uint32, gateways []*model.NetworkGateway, gatewayWeights map[model.NetworkGateway]uint32) {
+	// Spread the remaining weight across the gateways.
+	weightPerGateway := weight / uint32(len(gateways))
+	remain := weight % uint32(len(gateways))
+
+	for i, gateway := range gateways {
+		gatewayWeights[*gateway] += weightPerGateway
+		if uint32(i) < remain {
+			gatewayWeights[*gateway] += 1
+		}
+	}
 }
 
 // EndpointsWithMTLSFilter removes all endpoints that do not handle mTLS. This is determined by looking at

--- a/pilot/pkg/xds/ep_filters.go
+++ b/pilot/pkg/xds/ep_filters.go
@@ -44,11 +44,10 @@ func (b *EndpointBuilder) EndpointsByNetworkFilter(endpoints []*LocLbEndpointsAn
 	// remote gateways (if any)
 	filtered := make([]*LocLbEndpointsAndOptions, 0)
 
-	// Scale all weights by the maximum number of gateways that might appear for a network.
+	// Scale all weights by the lcm of gateways per network and gateways per cluster.
 	// This will allow us to more easily spread traffic to the endpoint across multiple
 	// network gateways, increasing reliability of the endpoint.
-	scaleFactor := b.push.NetworkManager().GetMaxGatewaysPerNetwork()
-
+	scaleFactor := b.push.NetworkManager().GetLCM()
 	// Go through all cluster endpoints and add those with the same network as the sidecar
 	// to the result. Also count the number of endpoints per each remote network while
 	// iterating so that it can be used as the weight for the gateway endpoint
@@ -188,6 +187,7 @@ func splitWeightAmongGateways(weight uint32, gateways []*model.NetworkGateway, g
 	for i, gateway := range gateways {
 		gatewayWeights[*gateway] += weightPerGateway
 		if uint32(i) < remain {
+			// This should not happen, just in case
 			gatewayWeights[*gateway] += 1
 		}
 	}

--- a/pilot/pkg/xds/ep_filters_test.go
+++ b/pilot/pkg/xds/ep_filters_test.go
@@ -64,16 +64,17 @@ var networkFiltered = []networkFilterCase{
 			{
 				lbEps: []LbEpInfo{
 					// 2 local endpoints on network1
-					{address: "10.0.0.1", weight: 2},
-					{address: "10.0.0.2", weight: 2},
+					{address: "10.0.0.1", weight: 6},
+					{address: "10.0.0.2", weight: 6},
 					// 1 endpoint on network2, cluster2a
-					{address: "2.2.2.2", weight: 2},
+					{address: "2.2.2.2", weight: 6},
 					// 2 endpoints on network2, cluster2b
-					{address: "2.2.2.20", weight: 4},
+					{address: "2.2.2.20", weight: 6},
+					{address: "2.2.2.21", weight: 6},
 					// 1 endpoint on network4 with no gateway (i.e. directly accessible)
-					{address: "40.0.0.1", weight: 2},
+					{address: "40.0.0.1", weight: 6},
 				},
-				weight: 12,
+				weight: 36,
 			},
 		},
 	},
@@ -84,16 +85,17 @@ var networkFiltered = []networkFilterCase{
 			{
 				lbEps: []LbEpInfo{
 					// 2 local endpoints on network1
-					{address: "10.0.0.1", weight: 2},
-					{address: "10.0.0.2", weight: 2},
+					{address: "10.0.0.1", weight: 6},
+					{address: "10.0.0.2", weight: 6},
 					// 1 endpoint on network2, cluster2a
-					{address: "2.2.2.2", weight: 2},
+					{address: "2.2.2.2", weight: 6},
 					// 2 endpoints on network2, cluster2b
-					{address: "2.2.2.20", weight: 4},
+					{address: "2.2.2.20", weight: 6},
+					{address: "2.2.2.21", weight: 6},
 					// 1 endpoint on network4 with no gateway (i.e. directly accessible)
-					{address: "40.0.0.1", weight: 2},
+					{address: "40.0.0.1", weight: 6},
 				},
-				weight: 12,
+				weight: 36,
 			},
 		},
 	},
@@ -142,15 +144,16 @@ var networkFiltered = []networkFilterCase{
 			{
 				lbEps: []LbEpInfo{
 					// 2 endpoint on network2 with weight aggregated at the gateway
-					{address: "1.1.1.1", weight: 4},
+					{address: "1.1.1.1", weight: 12},
 					// 1 endpoint on network2, cluster2a
-					{address: "2.2.2.2", weight: 2},
+					{address: "2.2.2.2", weight: 6},
 					// 2 endpoints on network2, cluster2b
-					{address: "2.2.2.20", weight: 4},
+					{address: "2.2.2.20", weight: 6},
+					{address: "2.2.2.21", weight: 6},
 					// 1 endpoint on network4 with no gateway (i.e. directly accessible)
-					{address: "40.0.0.1", weight: 2},
+					{address: "40.0.0.1", weight: 6},
 				},
-				weight: 12,
+				weight: 36,
 			},
 		},
 	},
@@ -161,15 +164,16 @@ var networkFiltered = []networkFilterCase{
 			{
 				lbEps: []LbEpInfo{
 					// 1 local endpoint on network4
-					{address: "40.0.0.1", weight: 2},
+					{address: "40.0.0.1", weight: 6},
 					// 2 endpoint on network2 with weight aggregated at the gateway
-					{address: "1.1.1.1", weight: 4},
+					{address: "1.1.1.1", weight: 12},
 					// 1 endpoint on network2, cluster2a
-					{address: "2.2.2.2", weight: 2},
+					{address: "2.2.2.2", weight: 6},
 					// 2 endpoints on network2, cluster2b
-					{address: "2.2.2.20", weight: 4},
+					{address: "2.2.2.20", weight: 6},
+					{address: "2.2.2.21", weight: 6},
 				},
-				weight: 12,
+				weight: 36,
 			},
 		},
 	},
@@ -193,12 +197,12 @@ func TestEndpointsByNetworkFilter_WithConfig(t *testing.T) {
 				{
 					lbEps: []LbEpInfo{
 						// 2 local endpoints on network1
-						{address: "10.0.0.1", weight: 2},
-						{address: "10.0.0.2", weight: 2},
+						{address: "10.0.0.1", weight: 6},
+						{address: "10.0.0.2", weight: 6},
 						// 1 endpoint on network4 with no gateway (i.e. directly accessible)
-						{address: "40.0.0.1", weight: 2},
+						{address: "40.0.0.1", weight: 6},
 					},
-					weight: 6,
+					weight: 18,
 				},
 			},
 		},
@@ -209,12 +213,12 @@ func TestEndpointsByNetworkFilter_WithConfig(t *testing.T) {
 				{
 					lbEps: []LbEpInfo{
 						// 2 local endpoints on network1
-						{address: "10.0.0.1", weight: 2},
-						{address: "10.0.0.2", weight: 2},
+						{address: "10.0.0.1", weight: 6},
+						{address: "10.0.0.2", weight: 6},
 						// 1 endpoint on network4 with no gateway (i.e. directly accessible)
-						{address: "40.0.0.1", weight: 2},
+						{address: "40.0.0.1", weight: 6},
 					},
-					weight: 6,
+					weight: 18,
 				},
 			},
 		},
@@ -259,9 +263,9 @@ func TestEndpointsByNetworkFilter_WithConfig(t *testing.T) {
 				{
 					lbEps: []LbEpInfo{
 						// 1 endpoint on network4 with no gateway (i.e. directly accessible)
-						{address: "40.0.0.1", weight: 2},
+						{address: "40.0.0.1", weight: 6},
 					},
-					weight: 2,
+					weight: 6,
 				},
 			},
 		},
@@ -272,9 +276,9 @@ func TestEndpointsByNetworkFilter_WithConfig(t *testing.T) {
 				{
 					lbEps: []LbEpInfo{
 						// 1 local endpoint on network4
-						{address: "40.0.0.1", weight: 2},
+						{address: "40.0.0.1", weight: 6},
 					},
-					weight: 2,
+					weight: 6,
 				},
 			},
 		},
@@ -681,7 +685,7 @@ func xdsConnection(nw network.ID, c cluster.ID) *Connection {
 
 // environment defines the networks with:
 //  - 1 gateway for network1
-//  - 2 gateway for network2
+//  - 3 gateway for network2
 //  - 1 gateway for network3
 //  - 0 gateways for network4
 func environment() *model.Environment {
@@ -722,6 +726,12 @@ func environment() *model.Environment {
 			Network: "network2",
 			Cluster: "cluster2b",
 			Addr:    "2.2.2.20",
+			Port:    80,
+		},
+		&model.NetworkGateway{
+			Network: "network2",
+			Cluster: "cluster2b",
+			Addr:    "2.2.2.21",
 			Port:    80,
 		},
 


### PR DESCRIPTION
**Please provide a description of this PR:**


It could be this case, 

cluster1, neytwork1:

     -  3 eastwest gateway
     -  1 endpoint (10.0.0.1)

cluster2, network2:

     -  2 eastwest gateway (20.0.0.1) (20.0.0.2)
     -  1 endpoint (20.0.0.100)


Take this as an example, for a proxy in cluster1:

** Without this pr:

endpoints:
  - 10.0.0.1 weight 3
  - 20.0.0.1 weight 2
  - 20.0.0.2 weight 1

We can see the two gateways of networks get unbalanced weight. As the real endpoints in network2 grows, the unbalance becomes severe. 

** With this pr:

endpoints:
  - 10.0.0.1 weight 6
  - 20.0.0.1 weight 3
  - 20.0.0.2 weight 3

The gateways of network2 have equal lb weight



    

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
