### PR TITLE
[tf] Dump external control plane cluster

### DIFF
--- a/pkg/test/kube/dump.go
+++ b/pkg/test/kube/dump.go
@@ -90,7 +90,7 @@ func DumpPods(ctx resource.Context, workDir, namespace string, selectors []strin
 	}
 
 	wg := sync.WaitGroup{}
-	for _, cluster := range ctx.Clusters().Kube() {
+	for _, cluster := range ctx.AllClusters().Kube() {
 		pods, err := cluster.PodsForSelector(context.TODO(), namespace, selectors...)
 		if err != nil {
 			scopes.Framework.Warnf("Error getting pods list via kubectl: %v", err)


### PR DESCRIPTION
On test failure we should dump all Kube clusters, including the external control plane cluster.

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [x] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
