### PR TITLE
add timeout to autopassthrough test

### DIFF
--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -790,6 +790,7 @@ func autoPassthroughCases(apps *EchoDeployments) []TrafficTestCase {
 						ServerName: sni,
 						Alpn:       al,
 						Validator:  echo.ExpectError(),
+						Timeout:    5 * time.Second,
 					},
 				},
 				)


### PR DESCRIPTION
Getting hung on the initial request, either from test runner -> gw or gw -> endpoint can fail this test. This helps the test fail fast(er) and actually leverage retries. 