### PR TITLE
Improve injection performance

### DIFF
--- a/pkg/kube/inject/template.go
+++ b/pkg/kube/inject/template.go
@@ -149,7 +149,6 @@ func fromJSON(j string) interface{} {
 		return "{}"
 	}
 
-	log.Warnf("%v", m)
 	return m
 }
 

--- a/pkg/kube/inject/webhook.go
+++ b/pkg/kube/inject/webhook.go
@@ -718,6 +718,9 @@ func (wh *Webhook) inject(ar *kube.AdmissionReview, path string) *kube.Admission
 			string(req.Object.Raw)))
 		return toAdmissionResponse(err)
 	}
+	// Managed fields is sometimes extremely large, leading to excessive CPU time on patch generation
+	// It does not impact the injection output at all, so we can just remove it.
+	pod.ManagedFields = nil
 
 	// Deal with potential empty fields, e.g., when the pod is created by a deployment
 	podName := potentialPodName(pod.ObjectMeta)

--- a/pkg/kube/inject/webhook_test.go
+++ b/pkg/kube/inject/webhook_test.go
@@ -1045,11 +1045,12 @@ func BenchmarkInjectServe(b *testing.B) {
 	wh.Run(stop)
 
 	body := makeTestData(b, false, "v1beta1")
-	req := httptest.NewRequest("POST", "http://sidecar-injector/inject", bytes.NewReader(body))
-	req.Header.Add("Content-Type", "application/json")
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
+		req := httptest.NewRequest("POST", "http://sidecar-injector/inject", bytes.NewReader(body))
+		req.Header.Add("Content-Type", "application/json")
+
 		wh.serveInject(httptest.NewRecorder(), req)
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/34799
Inspired by https://github.com/istio/istio/pull/34803 (we may still want that one as well)
```
$ cat /tmp/old
goos: linux
goarch: amd64
pkg: istio.io/istio/pkg/kube/inject
cpu: Intel(R) Core(TM) i7-8665U CPU @ 1.90GHz
       10        12302795235 ns/op       3494954690 B/op  7523207 allocs/op
       10        12152944856 ns/op       3495193698 B/op  7523328 allocs/op
       10        13032458981 ns/op       3495241792 B/op  7523395 allocs/op
PASS
ok      istio.io/istio/pkg/kube/inject  158.548s
$ cat /tmp/new
goos: linux
goarch: amd64
pkg: istio.io/istio/pkg/kube/inject
cpu: Intel(R) Core(TM) i7-8665U CPU @ 1.90GHz
      10         858556624 ns/op        351448878 B/op    585319 allocs/op
      10        1010176965 ns/op        351284525 B/op    585313 allocs/op
      10        1092338275 ns/op        351240620 B/op    585312 allocs/op
PASS
ok      istio.io/istio/pkg/kube/inject  36.286s
```

About 14x slower. Example comes from a real world pod.

**Please provide a description of this PR:**



**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
