### PR TITLE
Refactor test framework certificate management

### DIFF
--- a/tests/integration/pilot/ingress_test.go
+++ b/tests/integration/pilot/ingress_test.go
@@ -217,16 +217,8 @@ func TestIngress(t *testing.T) {
 			skipIfIngressClassUnsupported(t)
 			// Set up secret contain some TLS certs for *.example.com
 			// we will define one for foo.example.com and one for bar.example.com, to ensure both can co-exist
-			credName := "k8s-ingress-secret-foo"
-			ingressutil.CreateIngressKubeSecret(t, []string{credName}, ingressutil.TLS, ingressutil.IngressCredentialA, false, t.Clusters().Kube()...)
-			t.ConditionalCleanup(func() {
-				ingressutil.DeleteKubeSecret(t, []string{credName})
-			})
-			credName2 := "k8s-ingress-secret-bar"
-			ingressutil.CreateIngressKubeSecret(t, []string{credName2}, ingressutil.TLS, ingressutil.IngressCredentialB, false, t.Clusters().Kube()...)
-			t.ConditionalCleanup(func() {
-				ingressutil.DeleteKubeSecret(t, []string{credName2})
-			})
+			ingressutil.CreateIngressKubeSecret(t, "k8s-ingress-secret-foo", ingressutil.TLS, ingressutil.IngressCredentialA, false, t.Clusters().Kube()...)
+			ingressutil.CreateIngressKubeSecret(t, "k8s-ingress-secret-bar", ingressutil.TLS, ingressutil.IngressCredentialB, false, t.Clusters().Kube()...)
 
 			apiVersion := "v1beta1"
 			if t.Clusters().Default().MinKubeVersion(19) {

--- a/tests/integration/security/sds_ingress/ingress_test.go
+++ b/tests/integration/security/sds_ingress/ingress_test.go
@@ -76,9 +76,8 @@ func TestSingleTlsGateway_SecretRotation(t *testing.T) {
 				To(echotest.SingleSimplePodServiceAndAllSpecial()).
 				RunFromClusters(func(t framework.TestContext, src cluster.Cluster, dest echo.Instances) {
 					// Add kubernetes secret to provision key/cert for ingress gateway.
-					ingressutil.CreateIngressKubeSecret(t, []string{credName}, ingressutil.TLS,
+					ingressutil.CreateIngressKubeSecret(t, credName, ingressutil.TLS,
 						ingressutil.IngressCredentialA, false)
-					defer ingressutil.DeleteKubeSecret(t, []string{credName})
 
 					ing := inst.IngressFor(t.Clusters().Default())
 					if ing == nil {
@@ -93,7 +92,7 @@ func TestSingleTlsGateway_SecretRotation(t *testing.T) {
 						ingressutil.ExpectedResponse{ResponseCode: 200, ErrorMessage: ""})
 
 					// Now rotate the key/cert
-					ingressutil.RotateSecrets(t, []string{credName}, ingressutil.TLS,
+					ingressutil.RotateSecrets(t, credName, ingressutil.TLS,
 						ingressutil.IngressCredentialB, false)
 
 					t.NewSubTest("old cert should fail").Run(func(t framework.TestContext) {
@@ -126,8 +125,8 @@ func TestSingleMTLSGateway_ServerKeyCertRotation(t *testing.T) {
 		Features("security.ingress.mtls.secretrotation").
 		Run(func(t framework.TestContext) {
 			var (
-				credName   = []string{"testsinglemtlsgateway-serverkeycertrotation"}
-				credCaName = []string{"testsinglemtlsgateway-serverkeycertrotation-cacert"}
+				credName   = "testsinglemtlsgateway-serverkeycertrotation"
+				credCaName = "testsinglemtlsgateway-serverkeycertrotation-cacert"
 				host       = "testsinglemtlsgateway-serverkeycertrotation.example.com"
 			)
 
@@ -135,7 +134,7 @@ func TestSingleMTLSGateway_ServerKeyCertRotation(t *testing.T) {
 				SetupForDestination(func(t framework.TestContext, dst echo.Instances) error {
 					ingressutil.SetupConfig(t, apps.ServerNs, ingressutil.TestConfig{
 						Mode:           "MUTUAL",
-						CredentialName: credName[0],
+						CredentialName: credName,
 						Host:           host,
 						ServiceName:    dst[0].Config().Service,
 					})
@@ -148,8 +147,6 @@ func TestSingleMTLSGateway_ServerKeyCertRotation(t *testing.T) {
 						ingressutil.IngressCredentialCaCertA, false)
 					ingressutil.CreateIngressKubeSecret(t, credName, ingressutil.Mtls,
 						ingressutil.IngressCredentialServerKeyCertA, false)
-					defer ingressutil.DeleteKubeSecret(t, credName)
-					defer ingressutil.DeleteKubeSecret(t, credCaName)
 
 					ing := inst.IngressFor(t.Clusters().Default())
 					if ing == nil {
@@ -160,7 +157,7 @@ func TestSingleMTLSGateway_ServerKeyCertRotation(t *testing.T) {
 						PrivateKey: ingressutil.TLSClientKeyA,
 						Cert:       ingressutil.TLSClientCertA,
 					}
-					ingressutil.SendRequestOrFail(t, ing, host, credName[0], ingressutil.Mtls, tlsContext,
+					ingressutil.SendRequestOrFail(t, ing, host, credName, ingressutil.Mtls, tlsContext,
 						ingressutil.ExpectedResponse{ResponseCode: 200, ErrorMessage: ""})
 
 					t.NewSubTest("mismatched key/cert should fail").Run(func(t framework.TestContext) {
@@ -169,7 +166,7 @@ func TestSingleMTLSGateway_ServerKeyCertRotation(t *testing.T) {
 						ingressutil.RotateSecrets(t, credName, ingressutil.Mtls,
 							ingressutil.IngressCredentialServerKeyCertB, false)
 						// Client uses old server CA cert to set up SSL connection would fail.
-						ingressutil.SendRequestOrFail(t, ing, host, credName[0], ingressutil.Mtls, tlsContext,
+						ingressutil.SendRequestOrFail(t, ing, host, credName, ingressutil.Mtls, tlsContext,
 							ingressutil.ExpectedResponse{ResponseCode: 0, ErrorMessage: "certificate signed by unknown authority"})
 					})
 
@@ -179,7 +176,7 @@ func TestSingleMTLSGateway_ServerKeyCertRotation(t *testing.T) {
 						ingressutil.RotateSecrets(t, credName, ingressutil.Mtls,
 							ingressutil.IngressCredentialServerKeyCertA, false)
 						// Use old CA cert to set up SSL connection would succeed this time.
-						ingressutil.SendRequestOrFail(t, ing, host, credName[0], ingressutil.Mtls, tlsContext,
+						ingressutil.SendRequestOrFail(t, ing, host, credName, ingressutil.Mtls, tlsContext,
 							ingressutil.ExpectedResponse{ResponseCode: 200, ErrorMessage: ""})
 					})
 				})
@@ -198,14 +195,14 @@ func TestSingleMTLSGateway_CompoundSecretRotation(t *testing.T) {
 		Features("security.ingress.mtls.generic-compoundrotation").
 		Run(func(t framework.TestContext) {
 			var (
-				credName = []string{"testsinglemtlsgateway-generic-compoundrotation"}
+				credName = "testsinglemtlsgateway-generic-compoundrotation"
 				host     = "testsinglemtlsgateway-compoundsecretrotation.example.com"
 			)
 			echotest.New(t, apps.All).
 				SetupForDestination(func(t framework.TestContext, dst echo.Instances) error {
 					ingressutil.SetupConfig(t, apps.ServerNs, ingressutil.TestConfig{
 						Mode:           "MUTUAL",
-						CredentialName: credName[0],
+						CredentialName: credName,
 						Host:           host,
 						ServiceName:    dst[0].Config().Service,
 					})
@@ -216,7 +213,6 @@ func TestSingleMTLSGateway_CompoundSecretRotation(t *testing.T) {
 					// Add kubernetes secret to provision key/cert for ingress gateway.
 					ingressutil.CreateIngressKubeSecret(t, credName, ingressutil.Mtls,
 						ingressutil.IngressCredentialA, false)
-					defer ingressutil.DeleteKubeSecret(t, credName)
 
 					// Wait for ingress gateway to fetch key/cert from Gateway agent via SDS.
 					ing := inst.IngressFor(t.Clusters().Default())
@@ -225,7 +221,7 @@ func TestSingleMTLSGateway_CompoundSecretRotation(t *testing.T) {
 						PrivateKey: ingressutil.TLSClientKeyA,
 						Cert:       ingressutil.TLSClientCertA,
 					}
-					ingressutil.SendRequestOrFail(t, ing, host, credName[0], ingressutil.Mtls, tlsContext,
+					ingressutil.SendRequestOrFail(t, ing, host, credName, ingressutil.Mtls, tlsContext,
 						ingressutil.ExpectedResponse{ResponseCode: 200, ErrorMessage: ""})
 
 					t.NewSubTest("old server CA should fail").Run(func(t framework.TestContext) {
@@ -233,7 +229,7 @@ func TestSingleMTLSGateway_CompoundSecretRotation(t *testing.T) {
 						ingressutil.RotateSecrets(t, credName, ingressutil.Mtls,
 							ingressutil.IngressCredentialB, false)
 						// Use old server CA cert to set up SSL connection would fail.
-						ingressutil.SendRequestOrFail(t, ing, host, credName[0], ingressutil.Mtls, tlsContext,
+						ingressutil.SendRequestOrFail(t, ing, host, credName, ingressutil.Mtls, tlsContext,
 							ingressutil.ExpectedResponse{ResponseCode: 0, ErrorMessage: "certificate signed by unknown authority"})
 					})
 
@@ -244,7 +240,7 @@ func TestSingleMTLSGateway_CompoundSecretRotation(t *testing.T) {
 							PrivateKey: ingressutil.TLSClientKeyB,
 							Cert:       ingressutil.TLSClientCertB,
 						}
-						ingressutil.SendRequestOrFail(t, ing, host, credName[0], ingressutil.Mtls, tlsContext,
+						ingressutil.SendRequestOrFail(t, ing, host, credName, ingressutil.Mtls, tlsContext,
 							ingressutil.ExpectedResponse{ResponseCode: 200, ErrorMessage: ""})
 					})
 				})
@@ -263,14 +259,14 @@ func TestSingleMTLSGatewayAndNotGeneric_CompoundSecretRotation(t *testing.T) {
 		Features("security.ingress.mtls.nongeneric-compoundrotation").
 		Run(func(t framework.TestContext) {
 			var (
-				credName = []string{"testsinglemtlsgatewayandnotgeneric-compoundsecretrotation"}
+				credName = "testsinglemtlsgatewayandnotgeneric-compoundsecretrotation"
 				host     = "testsinglemtlsgatewayandnotgeneric-compoundsecretrotation.example.com"
 			)
 			echotest.New(t, apps.All).
 				SetupForDestination(func(t framework.TestContext, dst echo.Instances) error {
 					ingressutil.SetupConfig(t, apps.ServerNs, ingressutil.TestConfig{
 						Mode:           "MUTUAL",
-						CredentialName: credName[0],
+						CredentialName: credName,
 						Host:           host,
 						ServiceName:    dst[0].Config().Service,
 					})
@@ -281,7 +277,6 @@ func TestSingleMTLSGatewayAndNotGeneric_CompoundSecretRotation(t *testing.T) {
 					// Add kubernetes secret to provision key/cert for ingress gateway.
 					ingressutil.CreateIngressKubeSecret(t, credName, ingressutil.Mtls,
 						ingressutil.IngressCredentialA, true)
-					defer ingressutil.DeleteKubeSecret(t, credName)
 
 					// Wait for ingress gateway to fetch key/cert from Gateway agent via SDS.
 					ing := inst.IngressFor(t.Clusters().Default())
@@ -293,7 +288,7 @@ func TestSingleMTLSGatewayAndNotGeneric_CompoundSecretRotation(t *testing.T) {
 						PrivateKey: ingressutil.TLSClientKeyA,
 						Cert:       ingressutil.TLSClientCertA,
 					}
-					ingressutil.SendRequestOrFail(t, ing, host, credName[0], ingressutil.Mtls, tlsContext,
+					ingressutil.SendRequestOrFail(t, ing, host, credName, ingressutil.Mtls, tlsContext,
 						ingressutil.ExpectedResponse{ResponseCode: 200, ErrorMessage: ""})
 
 					t.NewSubTest("old server CA should fail").Run(func(t framework.TestContext) {
@@ -301,7 +296,7 @@ func TestSingleMTLSGatewayAndNotGeneric_CompoundSecretRotation(t *testing.T) {
 						ingressutil.RotateSecrets(t, credName, ingressutil.Mtls,
 							ingressutil.IngressCredentialB, true)
 						// Use old server CA cert to set up SSL connection would fail.
-						ingressutil.SendRequestOrFail(t, ing, host, credName[0], ingressutil.Mtls, tlsContext,
+						ingressutil.SendRequestOrFail(t, ing, host, credName, ingressutil.Mtls, tlsContext,
 							ingressutil.ExpectedResponse{ResponseCode: 0, ErrorMessage: "certificate signed by unknown authority"})
 					})
 
@@ -312,7 +307,7 @@ func TestSingleMTLSGatewayAndNotGeneric_CompoundSecretRotation(t *testing.T) {
 							PrivateKey: ingressutil.TLSClientKeyB,
 							Cert:       ingressutil.TLSClientCertB,
 						}
-						ingressutil.SendRequestOrFail(t, ing, host, credName[0], ingressutil.Mtls, tlsContext,
+						ingressutil.SendRequestOrFail(t, ing, host, credName, ingressutil.Mtls, tlsContext,
 							ingressutil.ExpectedResponse{ResponseCode: 200, ErrorMessage: ""})
 					})
 				})
@@ -363,8 +358,8 @@ func TestMultiTlsGateway_InvalidSecret(t *testing.T) {
 					name:       "tls ingress gateway invalid private key",
 					secretName: "testmultitlsgateway-invalidsecret-1",
 					ingressGatewayCredential: ingressutil.IngressCredential{
-						PrivateKey: "invalid",
-						ServerCert: ingressutil.TLSServerCertA,
+						PrivateKey:  "invalid",
+						Certificate: ingressutil.TLSServerCertA,
 					},
 					hostName: "testmultitlsgateway-invalidsecret1.example.com",
 					expectedResponse: ingressutil.ExpectedResponse{
@@ -383,8 +378,8 @@ func TestMultiTlsGateway_InvalidSecret(t *testing.T) {
 					name:       "tls ingress gateway invalid server cert",
 					secretName: "testmultitlsgateway-invalidsecret-2",
 					ingressGatewayCredential: ingressutil.IngressCredential{
-						PrivateKey: ingressutil.TLSServerKeyA,
-						ServerCert: "invalid",
+						PrivateKey:  ingressutil.TLSServerKeyA,
+						Certificate: "invalid",
 					},
 					hostName: "testmultitlsgateway-invalidsecret2.example.com",
 					expectedResponse: ingressutil.ExpectedResponse{
@@ -400,8 +395,8 @@ func TestMultiTlsGateway_InvalidSecret(t *testing.T) {
 					name:       "tls ingress gateway mis-matched key and cert",
 					secretName: "testmultitlsgateway-invalidsecret-3",
 					ingressGatewayCredential: ingressutil.IngressCredential{
-						PrivateKey: ingressutil.TLSServerKeyA,
-						ServerCert: ingressutil.TLSServerCertB,
+						PrivateKey:  ingressutil.TLSServerKeyA,
+						Certificate: ingressutil.TLSServerCertB,
 					},
 					hostName: "testmultitlsgateway-invalidsecret3.example.com",
 					expectedResponse: ingressutil.ExpectedResponse{
@@ -417,7 +412,7 @@ func TestMultiTlsGateway_InvalidSecret(t *testing.T) {
 					name:       "tls ingress gateway no private key",
 					secretName: "testmultitlsgateway-invalidsecret-4",
 					ingressGatewayCredential: ingressutil.IngressCredential{
-						ServerCert: ingressutil.TLSServerCertA,
+						Certificate: ingressutil.TLSServerCertA,
 					},
 					hostName: "testmultitlsgateway-invalidsecret4.example.com",
 					expectedResponse: ingressutil.ExpectedResponse{
@@ -465,9 +460,8 @@ func TestMultiTlsGateway_InvalidSecret(t *testing.T) {
 							t.Skip()
 						}
 						t.NewSubTest(c.name).Run(func(t framework.TestContext) {
-							ingressutil.CreateIngressKubeSecret(t, []string{c.secretName}, ingressutil.TLS,
+							ingressutil.CreateIngressKubeSecret(t, c.secretName, ingressutil.TLS,
 								c.ingressGatewayCredential, false)
-							defer ingressutil.DeleteKubeSecret(t, []string{c.secretName})
 
 							ingressutil.SendRequestOrFail(t, ing, c.hostName, c.secretName, c.callType, c.tlsContext,
 								c.expectedResponse)
@@ -497,9 +491,9 @@ func TestMultiMtlsGateway_InvalidSecret(t *testing.T) {
 					name:       "mtls ingress gateway invalid CA cert",
 					secretName: "testmultimtlsgateway-invalidsecret-1",
 					ingressGatewayCredential: ingressutil.IngressCredential{
-						PrivateKey: ingressutil.TLSServerKeyA,
-						ServerCert: ingressutil.TLSServerCertA,
-						CaCert:     "invalid",
+						PrivateKey:  ingressutil.TLSServerKeyA,
+						Certificate: ingressutil.TLSServerCertA,
+						CaCert:      "invalid",
 					},
 					hostName: "testmultimtlsgateway-invalidsecret1.example.com",
 					expectedResponse: ingressutil.ExpectedResponse{
@@ -520,8 +514,8 @@ func TestMultiMtlsGateway_InvalidSecret(t *testing.T) {
 					name:       "mtls ingress gateway no CA cert",
 					secretName: "testmultimtlsgateway-invalidsecret-2",
 					ingressGatewayCredential: ingressutil.IngressCredential{
-						PrivateKey: ingressutil.TLSServerKeyA,
-						ServerCert: ingressutil.TLSServerCertA,
+						PrivateKey:  ingressutil.TLSServerKeyA,
+						Certificate: ingressutil.TLSServerCertA,
 					},
 					hostName: "testmultimtlsgateway-invalidsecret2.example.com",
 					expectedResponse: ingressutil.ExpectedResponse{
@@ -539,9 +533,9 @@ func TestMultiMtlsGateway_InvalidSecret(t *testing.T) {
 					name:       "mtls ingress gateway mismatched CA cert",
 					secretName: "testmultimtlsgateway-invalidsecret-3",
 					ingressGatewayCredential: ingressutil.IngressCredential{
-						PrivateKey: ingressutil.TLSServerKeyA,
-						ServerCert: ingressutil.TLSServerCertA,
-						CaCert:     ingressutil.CaCertB,
+						PrivateKey:  ingressutil.TLSServerKeyA,
+						Certificate: ingressutil.TLSServerCertA,
+						CaCert:      ingressutil.CaCertB,
 					},
 					hostName: "testmultimtlsgateway-invalidsecret3.example.com",
 					expectedResponse: ingressutil.ExpectedResponse{
@@ -575,9 +569,8 @@ func TestMultiMtlsGateway_InvalidSecret(t *testing.T) {
 							t.Skip()
 						}
 						t.NewSubTest(c.name).Run(func(t framework.TestContext) {
-							ingressutil.CreateIngressKubeSecret(t, []string{c.secretName}, ingressutil.Mtls,
+							ingressutil.CreateIngressKubeSecret(t, c.secretName, ingressutil.Mtls,
 								c.ingressGatewayCredential, false)
-							defer ingressutil.DeleteKubeSecret(t, []string{c.secretName})
 
 							ingressutil.SendRequestOrFail(t, ing, c.hostName, c.secretName, c.callType, c.tlsContext,
 								c.expectedResponse)

--- a/tests/integration/security/sds_ingress/util/util.go
+++ b/tests/integration/security/sds_ingress/util/util.go
@@ -224,6 +224,16 @@ func createSecret(ingressType CallType, cn, ns string, ic IngressCredential, isC
 			},
 		}
 	}
+	data := map[string][]byte{}
+	if ic.Certificate != "" {
+		data[tlsScrtCert] = []byte(ic.Certificate)
+	}
+	if ic.PrivateKey != "" {
+		data[tlsScrtKey] = []byte(ic.PrivateKey)
+	}
+	if ic.CaCert != "" {
+		data[tlsScrtCaCert] = []byte(ic.CaCert)
+	}
 	return &v1.Secret{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Secret",
@@ -233,10 +243,7 @@ func createSecret(ingressType CallType, cn, ns string, ic IngressCredential, isC
 			Name:      cn,
 			Namespace: ns,
 		},
-		Data: map[string][]byte{
-			tlsScrtCert: []byte(ic.Certificate),
-			tlsScrtKey:  []byte(ic.PrivateKey),
-		},
+		Data: data,
 	}
 }
 

--- a/tests/integration/security/sds_ingress/util/util.go
+++ b/tests/integration/security/sds_ingress/util/util.go
@@ -70,20 +70,20 @@ type EchoDeployments struct {
 }
 
 type IngressCredential struct {
-	PrivateKey string
-	ServerCert string
-	CaCert     string
+	PrivateKey  string
+	Certificate string
+	CaCert      string
 }
 
 var IngressCredentialA = IngressCredential{
-	PrivateKey: TLSServerKeyA,
-	ServerCert: TLSServerCertA,
-	CaCert:     CaCertA,
+	PrivateKey:  TLSServerKeyA,
+	Certificate: TLSServerCertA,
+	CaCert:      CaCertA,
 }
 
 var IngressCredentialServerKeyCertA = IngressCredential{
-	PrivateKey: TLSServerKeyA,
-	ServerCert: TLSServerCertA,
+	PrivateKey:  TLSServerKeyA,
+	Certificate: TLSServerCertA,
 }
 
 var IngressCredentialCaCertA = IngressCredential{
@@ -91,14 +91,14 @@ var IngressCredentialCaCertA = IngressCredential{
 }
 
 var IngressCredentialB = IngressCredential{
-	PrivateKey: TLSServerKeyB,
-	ServerCert: TLSServerCertB,
-	CaCert:     CaCertB,
+	PrivateKey:  TLSServerKeyB,
+	Certificate: TLSServerCertB,
+	CaCert:      CaCertB,
 }
 
 var IngressCredentialServerKeyCertB = IngressCredential{
-	PrivateKey: TLSServerKeyB,
-	ServerCert: TLSServerCertB,
+	PrivateKey:  TLSServerKeyB,
+	Certificate: TLSServerCertB,
 }
 
 // IngressKubeSecretYAML will generate a credential for a gateway
@@ -115,17 +115,26 @@ func IngressKubeSecretYAML(name, namespace string, ingressType CallType, ingress
 // CreateIngressKubeSecret reads credential names from credNames and key/cert from ingressCred,
 // and creates K8s secrets for ingress gateway.
 // nolint: interfacer
-func CreateIngressKubeSecret(t framework.TestContext, credNames []string,
+func CreateIngressKubeSecret(t framework.TestContext, credName string,
 	ingressType CallType, ingressCred IngressCredential, isCompoundAndNotGeneric bool, clusters ...cluster.Cluster) {
 	t.Helper()
+
 	// Get namespace for ingress gateway pod.
 	istioCfg := istio.DefaultConfigOrFail(t, t)
 	systemNS := namespace.ClaimOrFail(t, t, istioCfg.SystemNamespace)
+	CreateIngressKubeSecretInNamespace(t, credName, ingressType, ingressCred, isCompoundAndNotGeneric, systemNS.Name(), clusters...)
+}
 
-	if len(credNames) == 0 {
-		t.Log("no credential names are specified, skip creating ingress secret")
-		return
-	}
+// CreateIngressKubeSecretInNamespace  reads credential names from credNames and key/cert from ingressCred,
+// and creates K8s secrets for ingress gateway in the given namespace.
+func CreateIngressKubeSecretInNamespace(t framework.TestContext, credName string,
+	ingressType CallType, ingressCred IngressCredential, isCompoundAndNotGeneric bool, ns string, clusters ...cluster.Cluster) {
+	t.Helper()
+
+	t.ConditionalCleanup(func() {
+		deleteKubeSecret(t, credName)
+	})
+
 	// Create Kubernetes secret for ingress gateway
 	wg := multierror.Group{}
 	if len(clusters) == 0 {
@@ -134,26 +143,22 @@ func CreateIngressKubeSecret(t framework.TestContext, credNames []string,
 	for _, cluster := range clusters {
 		cluster := cluster
 		wg.Go(func() error {
-			for _, cn := range credNames {
-				secret := createSecret(ingressType, cn, systemNS.Name(), ingressCred, isCompoundAndNotGeneric)
-				_, err := cluster.CoreV1().Secrets(systemNS.Name()).Create(context.TODO(), secret, metav1.CreateOptions{})
-				if err != nil {
-					if errors.IsAlreadyExists(err) {
-						if _, err := cluster.CoreV1().Secrets(systemNS.Name()).Update(context.TODO(), secret, metav1.UpdateOptions{}); err != nil {
-							return fmt.Errorf("failed to update secret (error: %s)", err)
-						}
-					} else {
+			secret := createSecret(ingressType, credName, ns, ingressCred, isCompoundAndNotGeneric)
+			_, err := cluster.CoreV1().Secrets(ns).Create(context.TODO(), secret, metav1.CreateOptions{})
+			if err != nil {
+				if errors.IsAlreadyExists(err) {
+					if _, err := cluster.CoreV1().Secrets(ns).Update(context.TODO(), secret, metav1.UpdateOptions{}); err != nil {
 						return fmt.Errorf("failed to update secret (error: %s)", err)
 					}
+				} else {
+					return fmt.Errorf("failed to update secret (error: %s)", err)
 				}
 			}
 			// Check if Kubernetes secret is ready
 			return retry.UntilSuccess(func() error {
-				for _, cn := range credNames {
-					_, err := cluster.CoreV1().Secrets(systemNS.Name()).Get(context.TODO(), cn, metav1.GetOptions{})
-					if err != nil {
-						return fmt.Errorf("secret %v not found: %v", cn, err)
-					}
+				_, err := cluster.CoreV1().Secrets(ns).Get(context.TODO(), credName, metav1.GetOptions{})
+				if err != nil {
+					return fmt.Errorf("secret %v not found: %v", credName, err)
 				}
 				return nil
 			}, retry.Timeout(time.Second*5))
@@ -164,26 +169,20 @@ func CreateIngressKubeSecret(t framework.TestContext, credNames []string,
 	}
 }
 
-// DeleteKubeSecret deletes a secret
+// deleteKubeSecret deletes a secret
 // nolint: interfacer
-func DeleteKubeSecret(ctx framework.TestContext, credNames []string) {
+func deleteKubeSecret(ctx framework.TestContext, credName string) {
 	// Get namespace for ingress gateway pod.
 	istioCfg := istio.DefaultConfigOrFail(ctx, ctx)
 	systemNS := namespace.ClaimOrFail(ctx, ctx, istioCfg.SystemNamespace)
 
-	if len(credNames) == 0 {
-		ctx.Log("no credential names are specified, skip creating ingress secret")
-		return
-	}
 	// Create Kubernetes secret for ingress gateway
 	cluster := ctx.Clusters().Default()
-	for _, cn := range credNames {
-		var immediate int64
-		err := cluster.CoreV1().Secrets(systemNS.Name()).Delete(context.TODO(), cn,
-			metav1.DeleteOptions{GracePeriodSeconds: &immediate})
-		if err != nil && !errors.IsNotFound(err) {
-			ctx.Fatalf("Failed to delete secret (error: %s)", err)
-		}
+	var immediate int64
+	err := cluster.CoreV1().Secrets(systemNS.Name()).Delete(context.TODO(), credName,
+		metav1.DeleteOptions{GracePeriodSeconds: &immediate})
+	if err != nil && !errors.IsNotFound(err) {
+		ctx.Fatalf("Failed to delete secret (error: %s)", err)
 	}
 }
 
@@ -203,7 +202,7 @@ func createSecret(ingressType CallType, cn, ns string, ic IngressCredential, isC
 					Namespace: ns,
 				},
 				Data: map[string][]byte{
-					tlsScrtCert:   []byte(ic.ServerCert),
+					tlsScrtCert:   []byte(ic.Certificate),
 					tlsScrtKey:    []byte(ic.PrivateKey),
 					tlsScrtCaCert: []byte(ic.CaCert),
 				},
@@ -219,7 +218,7 @@ func createSecret(ingressType CallType, cn, ns string, ic IngressCredential, isC
 				Namespace: ns,
 			},
 			Data: map[string][]byte{
-				genericScrtCert:   []byte(ic.ServerCert),
+				genericScrtCert:   []byte(ic.Certificate),
 				genericScrtKey:    []byte(ic.PrivateKey),
 				genericScrtCaCert: []byte(ic.CaCert),
 			},
@@ -235,7 +234,7 @@ func createSecret(ingressType CallType, cn, ns string, ic IngressCredential, isC
 			Namespace: ns,
 		},
 		Data: map[string][]byte{
-			tlsScrtCert: []byte(ic.ServerCert),
+			tlsScrtCert: []byte(ic.Certificate),
 			tlsScrtKey:  []byte(ic.PrivateKey),
 		},
 	}
@@ -305,30 +304,25 @@ func SendRequestOrFail(ctx framework.TestContext, ing ingress.Instance, host str
 
 // RotateSecrets deletes kubernetes secrets by name in credNames and creates same secrets using key/cert
 // from ingressCred.
-func RotateSecrets(ctx framework.TestContext, credNames []string, // nolint:interfacer
+func RotateSecrets(ctx framework.TestContext, credName string, // nolint:interfacer
 	ingressType CallType, ingressCred IngressCredential, isCompoundAndNotGeneric bool) {
 	ctx.Helper()
 	cluster := ctx.Clusters().Default()
 	ist := istio.GetOrFail(ctx, ctx)
 	systemNS := namespace.ClaimOrFail(ctx, ctx, ist.Settings().SystemNamespace)
-	for _, cn := range credNames {
-		scrt, err := cluster.CoreV1().Secrets(systemNS.Name()).Get(context.TODO(), cn, metav1.GetOptions{})
-		if err != nil {
-			ctx.Errorf("Failed to get secret %s:%s (error: %s)", systemNS.Name(), cn, err)
-			continue
-		}
-		scrt = updateSecret(ingressType, scrt, ingressCred, isCompoundAndNotGeneric)
-		if _, err = cluster.CoreV1().Secrets(systemNS.Name()).Update(context.TODO(), scrt, metav1.UpdateOptions{}); err != nil {
-			ctx.Errorf("Failed to update secret %s:%s (error: %s)", scrt.Namespace, scrt.Name, err)
-		}
+	scrt, err := cluster.CoreV1().Secrets(systemNS.Name()).Get(context.TODO(), credName, metav1.GetOptions{})
+	if err != nil {
+		ctx.Errorf("Failed to get secret %s:%s (error: %s)", systemNS.Name(), credName, err)
+	}
+	scrt = updateSecret(ingressType, scrt, ingressCred, isCompoundAndNotGeneric)
+	if _, err = cluster.CoreV1().Secrets(systemNS.Name()).Update(context.TODO(), scrt, metav1.UpdateOptions{}); err != nil {
+		ctx.Errorf("Failed to update secret %s:%s (error: %s)", scrt.Namespace, scrt.Name, err)
 	}
 	// Check if Kubernetes secret is ready
 	retry.UntilSuccessOrFail(ctx, func() error {
-		for _, cn := range credNames {
-			_, err := cluster.CoreV1().Secrets(systemNS.Name()).Get(context.TODO(), cn, metav1.GetOptions{})
-			if err != nil {
-				return fmt.Errorf("secret %v not found: %v", cn, err)
-			}
+		_, err := cluster.CoreV1().Secrets(systemNS.Name()).Get(context.TODO(), credName, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("secret %v not found: %v", credName, err)
 		}
 		return nil
 	}, retry.Timeout(time.Second*5))
@@ -339,16 +333,16 @@ func RotateSecrets(ctx framework.TestContext, credNames []string, // nolint:inte
 func updateSecret(ingressType CallType, scrt *v1.Secret, ic IngressCredential, isCompoundAndNotGeneric bool) *v1.Secret {
 	if ingressType == Mtls {
 		if isCompoundAndNotGeneric {
-			scrt.Data[tlsScrtCert] = []byte(ic.ServerCert)
+			scrt.Data[tlsScrtCert] = []byte(ic.Certificate)
 			scrt.Data[tlsScrtKey] = []byte(ic.PrivateKey)
 			scrt.Data[tlsScrtCaCert] = []byte(ic.CaCert)
 		} else {
-			scrt.Data[genericScrtCert] = []byte(ic.ServerCert)
+			scrt.Data[genericScrtCert] = []byte(ic.Certificate)
 			scrt.Data[genericScrtKey] = []byte(ic.PrivateKey)
 			scrt.Data[genericScrtCaCert] = []byte(ic.CaCert)
 		}
 	} else {
-		scrt.Data[tlsScrtCert] = []byte(ic.ServerCert)
+		scrt.Data[tlsScrtCert] = []byte(ic.Certificate)
 		scrt.Data[tlsScrtKey] = []byte(ic.PrivateKey)
 	}
 	return scrt
@@ -486,8 +480,9 @@ func RunTestMultiMtlsGateways(ctx framework.TestContext, inst istio.Instance, ap
 		}).
 		To(echotest.SingleSimplePodServiceAndAllSpecial()).
 		RunFromClusters(func(ctx framework.TestContext, src cluster.Cluster, dest echo.Instances) {
-			CreateIngressKubeSecret(ctx, credNames, Mtls, IngressCredentialA, false)
-			defer DeleteKubeSecret(ctx, credNames)
+			for _, cn := range credNames {
+				CreateIngressKubeSecret(ctx, cn, Mtls, IngressCredentialA, false)
+			}
 
 			ing := inst.IngressFor(src)
 			if ing == nil {
@@ -532,8 +527,9 @@ func RunTestMultiTLSGateways(ctx framework.TestContext, inst istio.Instance, app
 		}).
 		To(echotest.SingleSimplePodServiceAndAllSpecial()).
 		RunFromClusters(func(ctx framework.TestContext, src cluster.Cluster, dest echo.Instances) {
-			CreateIngressKubeSecret(ctx, credNames, Mtls, IngressCredentialA, false)
-			defer DeleteKubeSecret(ctx, credNames)
+			for _, cn := range credNames {
+				CreateIngressKubeSecret(ctx, cn, Mtls, IngressCredentialA, false)
+			}
 
 			ing := inst.IngressFor(src)
 			if ing == nil {


### PR DESCRIPTION
* Only pass in a single credential name. If they need multiple can
always just call the function in a loop
* Always delete it when create, instead of making all callers do it (and
some do it wrong)
* Allow specifying namespace explicitly. This is not used yet, but will
be in a near PR
* Reduce duplication of same logic in 2 places
