### PR TITLE
return error if no certificate has been returned from signer for k8s CSR

### DIFF
--- a/security/pkg/k8s/chiron/utils.go
+++ b/security/pkg/k8s/chiron/utils.go
@@ -300,7 +300,7 @@ func readSignedCertificate(client clientset.Interface, csrName string,
 	certPEM := readSignedCsr(client, csrName, watchTimeout, readInterval, maxNumRead, usev1)
 
 	if len(certPEM) == 0 {
-		return []byte{}, []byte{}, nil
+		return []byte{}, []byte{}, fmt.Errorf("no certificate returned for the CSR: %q", csrName)
 	}
 	certsParsed, err := util.ParsePemEncodedCertificateChain(certPEM)
 	if err != nil {


### PR DESCRIPTION
instead of return silently when no certificate has been returned for the k8s CSR, log an error out to user to let user know the failure reasons.