### PR TITLE
fix istioctl manifest generate default inconsistent behavior

### DIFF
--- a/operator/cmd/mesh/manifest-generate.go
+++ b/operator/cmd/mesh/manifest-generate.go
@@ -99,6 +99,11 @@ func manifestGenerate(args *rootArgs, mgArgs *manifestGenerateArgs, logopts *log
 		return fmt.Errorf("could not configure logs: %s", err)
 	}
 
+	profile := manifest.GetValueForSetFlag(mgArgs.set, "profile")
+	if len(mgArgs.inFilename) == 0 && profile == "" || profile == name.DefaultProfileName {
+		mgArgs.inFilename = []string{"./manifests/profiles/default.yaml"}
+	}
+
 	manifests, _, err := manifest.GenManifests(mgArgs.inFilename, applyFlagAliases(mgArgs.set, mgArgs.manifestsPath, mgArgs.revision), mgArgs.force, nil, l)
 	if err != nil {
 		return err

--- a/operator/cmd/mesh/manifest-generate.go
+++ b/operator/cmd/mesh/manifest-generate.go
@@ -99,15 +99,6 @@ func manifestGenerate(args *rootArgs, mgArgs *manifestGenerateArgs, logopts *log
 		return fmt.Errorf("could not configure logs: %s", err)
 	}
 
-	inFileName := make([]string, 0)
-	for _, p := range mgArgs.inFilename {
-		if strings.Contains(p, fmt.Sprintf("%s.yaml", name.DefaultProfileName)) {
-			continue
-		}
-		inFileName = append(inFileName, p)
-	}
-	mgArgs.inFilename = inFileName
-
 	manifests, _, err := manifest.GenManifests(mgArgs.inFilename, applyFlagAliases(mgArgs.set, mgArgs.manifestsPath, mgArgs.revision), mgArgs.force, nil, l)
 	if err != nil {
 		return err

--- a/operator/cmd/mesh/manifest-generate.go
+++ b/operator/cmd/mesh/manifest-generate.go
@@ -99,10 +99,14 @@ func manifestGenerate(args *rootArgs, mgArgs *manifestGenerateArgs, logopts *log
 		return fmt.Errorf("could not configure logs: %s", err)
 	}
 
-	profile := manifest.GetValueForSetFlag(mgArgs.set, "profile")
-	if len(mgArgs.inFilename) == 0 && profile == "" || profile == name.DefaultProfileName {
-		mgArgs.inFilename = []string{"./manifests/profiles/default.yaml"}
+	inFileName := make([]string, 0)
+	for _, p := range mgArgs.inFilename {
+		if strings.Contains(p, fmt.Sprintf("%s.yaml", name.DefaultProfileName)) {
+			continue
+		}
+		inFileName = append(inFileName, p)
 	}
+	mgArgs.inFilename = inFileName
 
 	manifests, _, err := manifest.GenManifests(mgArgs.inFilename, applyFlagAliases(mgArgs.set, mgArgs.manifestsPath, mgArgs.revision), mgArgs.force, nil, l)
 	if err != nil {

--- a/operator/pkg/manifest/shared.go
+++ b/operator/pkg/manifest/shared.go
@@ -227,19 +227,24 @@ func ReadYamlProfile(inFilenames []string, setFlags []string, force bool, l clog
 	}
 	if fp != "" {
 		profile = fp
-	} else {
-		// Unable to find the profile from the list of files, use the default profile and its YAML values.
-		defaultYAML, err := helm.GetProfileYAML("", profile)
-		if err != nil {
-			return "", "", err
-		}
-		fy = defaultYAML
 	}
 	// The profile coming from --set flag has the highest precedence.
 	psf := GetValueForSetFlag(setFlags, "profile")
 	if psf != "" {
 		profile = psf
 	}
+
+	// If the profile cannot be obtained from the list of files passed in, and
+	// the profile is not set from --set flag, use the default profile and its YAML values.
+	if sfp := GetValueForSetFlag(setFlags, "installPackagePath"); sfp == "" &&
+		profile == name.DefaultProfileName && fy == "" {
+		defaultYAML, err := helm.GetProfileYAML("", profile)
+		if err != nil {
+			return "", "", err
+		}
+		fy = defaultYAML
+	}
+
 	return fy, profile, nil
 }
 

--- a/operator/pkg/manifest/shared.go
+++ b/operator/pkg/manifest/shared.go
@@ -56,6 +56,15 @@ func GenManifests(inFilename []string, setFlags []string, force bool,
 	if err != nil {
 		return nil, nil, err
 	}
+
+	if len(inFilename) == 0 {
+		t := translate.NewReverseTranslator()
+		mergedYAML, err = t.TranslateK8SfromValueToIOP(mergedYAML)
+		if err != nil {
+			return nil, nil, fmt.Errorf("could not overlay k8s settings from values to IOP: %s", err)
+		}
+	}
+
 	mergedIOPS, err := unmarshalAndValidateIOP(mergedYAML, force, false, l)
 	if err != nil {
 		return nil, nil, err

--- a/operator/pkg/manifest/shared.go
+++ b/operator/pkg/manifest/shared.go
@@ -52,12 +52,13 @@ var installerScope = log.RegisterScope("installer", "installer", 0)
 // supplied logger.
 func GenManifests(inFilename []string, setFlags []string, force bool,
 	kubeConfig *rest.Config, l clog.Logger) (name.ManifestMap, *iopv1alpha1.IstioOperator, error) {
-	mergedYAML, _, err := GenerateConfig(inFilename, setFlags, force, kubeConfig, l)
+	mergedYAML, mergedIOPs, err := GenerateConfig(inFilename, setFlags, force, kubeConfig, l)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	if len(inFilename) == 0 {
+	profile := mergedIOPs.Spec.Profile
+	if len(inFilename) == 0 && profile == name.DefaultProfileName {
 		t := translate.NewReverseTranslator()
 		mergedYAML, err = t.TranslateK8SfromValueToIOP(mergedYAML)
 		if err != nil {

--- a/releasenotes/notes/34849.yaml
+++ b/releasenotes/notes/34849.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: istioctl
+issue:
+  - 34758
+releaseNotes:
+  - |
+    **Fixed** `istioctl manifest generate` has the inconsistent behavior when using the default profile.


### PR DESCRIPTION
This PR is to fix issue https://github.com/istio/istio/issues/34758

Applying this fix will result in

`istioctl manifest generate`
and
`istioctl manifest generate -f ./manifests/profiles/default.yaml`
have the identical result.

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [x] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
