### PR TITLE
cleanup clusterID detection a bit

### DIFF
--- a/istioctl/cmd/workload_test.go
+++ b/istioctl/cmd/workload_test.go
@@ -158,7 +158,7 @@ const goldenSuffix = ".golden"
 // Each subdirectory contains two input files: workloadgroup.yaml and meshconfig.yaml that are used
 // to generate golden outputs from the VM command.
 func TestWorkloadEntryConfigure(t *testing.T) {
-	noClusterID := "--clusterID not supplied"
+	noClusterID := "failed to automatically determine the --clusterID"
 	files, err := os.ReadDir("testdata/vmconfig")
 	if err != nil {
 		t.Fatal(err)
@@ -235,7 +235,7 @@ func TestWorkloadEntryConfigure(t *testing.T) {
 // proxyMetadata is nil, no metadata would be generated at all.
 func TestWorkloadEntryConfigureNilProxyMetadata(t *testing.T) {
 	testdir := "testdata/vmconfig-nil-proxy-metadata"
-	noClusterID := "--clusterID not supplied"
+	noClusterID := "failed to automatically determine the --clusterID"
 
 	kubeClientWithRevision = func(_, _, _ string) (kube.ExtendedClient, error) {
 		return &kube.MockClient{


### PR DESCRIPTION
This removes the non-standard `INFO: ` output. It also makes the code
simpler.

Example output:
```
$ istioctl x workload entry configure --name vm --namespace default -o /tmp/vm
Error: failed to automatically determine the --clusterID: fetch injection template: configmaps "istio-sidecar-injector" not found
```

**Please provide a description of this PR:**



**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
