### PR TITLE
Remove duplicate method Log/Logf

### DIFF
--- a/pkg/test/framework/testcontext.go
+++ b/pkg/test/framework/testcontext.go
@@ -65,8 +65,6 @@ type TestContext interface {
 	Error(args ...interface{})
 	Errorf(format string, args ...interface{})
 	Failed() bool
-	Log(args ...interface{})
-	Logf(format string, args ...interface{})
 	Name() string
 	Skip(args ...interface{})
 	SkipNow()


### PR DESCRIPTION
https://github.com/istio/istio/blob/fa03b30370ba489f78c5fd6b1094c2875f20c749/pkg/test/failer.go#L42
method Log/Logf has been defined in the `Failer`
`TestContext` inherits `Failer`, so `TestContext` does not need define this method again.

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
