### PR TITLE
remove duplicate method ValidateDurationGogo

### DIFF
--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -1203,7 +1203,7 @@ func validateOutlierDetection(outlier *networking.OutlierDetection) (errs Valida
 	}
 
 	if outlier.BaseEjectionTime != nil {
-		errs = appendValidation(errs, ValidateDurationGogo(outlier.BaseEjectionTime))
+		errs = appendValidation(errs, ValidateDuration(outlier.BaseEjectionTime))
 	}
 	if outlier.ConsecutiveErrors != 0 {
 		warn := "outlier detection consecutive errors is deprecated, use consecutiveGatewayErrors or consecutive5xxErrors instead"
@@ -1215,7 +1215,7 @@ func validateOutlierDetection(outlier *networking.OutlierDetection) (errs Valida
 		errs = appendValidation(errs, errors.New(err))
 	}
 	if outlier.Interval != nil {
-		errs = appendValidation(errs, ValidateDurationGogo(outlier.Interval))
+		errs = appendValidation(errs, ValidateDuration(outlier.Interval))
 	}
 	errs = appendValidation(errs, ValidatePercent(outlier.MaxEjectionPercent), ValidatePercent(outlier.MinHealthPercent))
 
@@ -1244,7 +1244,7 @@ func validateConnectionPool(settings *networking.ConnectionPoolSettings) (errs e
 			errs = appendErrors(errs, fmt.Errorf("max retries must be non-negative"))
 		}
 		if httpSettings.IdleTimeout != nil {
-			errs = appendErrors(errs, ValidateDurationGogo(httpSettings.IdleTimeout))
+			errs = appendErrors(errs, ValidateDuration(httpSettings.IdleTimeout))
 		}
 		if httpSettings.H2UpgradePolicy == networking.ConnectionPoolSettings_HTTPSettings_UPGRADE && httpSettings.UseClientProtocol {
 			errs = appendErrors(errs, fmt.Errorf("use client protocol must not be true when H2UpgradePolicy is UPGRADE"))
@@ -1256,7 +1256,7 @@ func validateConnectionPool(settings *networking.ConnectionPoolSettings) (errs e
 			errs = appendErrors(errs, fmt.Errorf("max connections must be non-negative"))
 		}
 		if tcp.ConnectTimeout != nil {
-			errs = appendErrors(errs, ValidateDurationGogo(tcp.ConnectTimeout))
+			errs = appendErrors(errs, ValidateDuration(tcp.ConnectTimeout))
 		}
 	}
 
@@ -1365,21 +1365,6 @@ func ValidateProxyAddress(hostAddr string) error {
 		}
 	}
 
-	return nil
-}
-
-// ValidateDurationGogo checks that a gogo proto duration is well-formed
-func ValidateDurationGogo(pd *types.Duration) error {
-	dur, err := types.DurationFromProto(pd)
-	if err != nil {
-		return err
-	}
-	if dur < time.Millisecond {
-		return errors.New("duration must be greater than 1ms")
-	}
-	if dur%time.Millisecond != 0 {
-		return errors.New("only durations to ms precision are supported")
-	}
 	return nil
 }
 
@@ -2621,7 +2606,7 @@ func validateCORSPolicy(policy *networking.CorsPolicy) (errs error) {
 	}
 
 	if policy.MaxAge != nil {
-		errs = appendErrors(errs, ValidateDurationGogo(policy.MaxAge))
+		errs = appendErrors(errs, ValidateDuration(policy.MaxAge))
 		if policy.MaxAge.Nanos > 0 {
 			errs = multierror.Append(errs, errors.New("max_age duration is accurate only to seconds precision"))
 		}
@@ -2705,9 +2690,9 @@ func validateHTTPFaultInjectionDelay(delay *networking.HTTPFaultInjection_Delay)
 
 	switch v := delay.HttpDelayType.(type) {
 	case *networking.HTTPFaultInjection_Delay_FixedDelay:
-		errs = appendErrors(errs, ValidateDurationGogo(v.FixedDelay))
+		errs = appendErrors(errs, ValidateDuration(v.FixedDelay))
 	case *networking.HTTPFaultInjection_Delay_ExponentialDelay:
-		errs = appendErrors(errs, ValidateDurationGogo(v.ExponentialDelay))
+		errs = appendErrors(errs, ValidateDuration(v.ExponentialDelay))
 		errs = multierror.Append(errs, fmt.Errorf("exponentialDelay not supported yet"))
 	}
 
@@ -2770,7 +2755,7 @@ func validateHTTPRetry(retries *networking.HTTPRetry) (errs error) {
 	}
 
 	if retries.PerTryTimeout != nil {
-		errs = appendErrors(errs, ValidateDurationGogo(retries.PerTryTimeout))
+		errs = appendErrors(errs, ValidateDuration(retries.PerTryTimeout))
 	}
 	if retries.RetryOn != "" {
 		retryOnPolicies := strings.Split(retries.RetryOn, ",")

--- a/pkg/config/validation/virtualservice.go
+++ b/pkg/config/validation/virtualservice.go
@@ -106,7 +106,7 @@ func validateHTTPRoute(http *networking.HTTPRoute, delegate bool) (errs Validati
 	errs = appendValidation(errs, validateAuthorityRewrite(http.Rewrite, http.Headers))
 	errs = appendValidation(errs, validateHTTPRouteDestinations(http.Route))
 	if http.Timeout != nil {
-		errs = appendValidation(errs, ValidateDurationGogo(http.Timeout))
+		errs = appendValidation(errs, ValidateDuration(http.Timeout))
 	}
 
 	return


### PR DESCRIPTION
method `ValidateDurationGogo` is the same as method `ValidateDuration`

ValidateDurationGogo:
https://github.com/istio/istio/blob/cea3f7ee98d45c6a9d17f2afede077af38208e61/pkg/config/validation/validation.go#L1372

ValidateDuration:
https://github.com/istio/istio/blob/cea3f7ee98d45c6a9d17f2afede077af38208e61/pkg/config/validation/validation.go#L1387


- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [x] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
