### PR TITLE
Enhance authority rewrite support to allow port and scheme

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/route/route_internal_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route_internal_test.go
@@ -459,3 +459,33 @@ func TestSourceMatchHTTP(t *testing.T) {
 		})
 	}
 }
+
+func TestSplitRedirectAuthority(t *testing.T) {
+	tests := []struct {
+		redirect   string
+		wantScheme string
+		wantHost   string
+		wantPort   uint32
+	}{
+		{"simple-host", "", "simple-host", 0},
+		{"https://everything:1234", "https", "everything", 1234},
+		{":1234", "", "", 1234},
+		{"https://", "https", "", 0},
+		{"https://:1234", "https", "", 1234},
+		{"host:1234", "", "host", 1234},
+	}
+	for _, tt := range tests {
+		t.Run(tt.redirect, func(t *testing.T) {
+			gotScheme, gotHost, gotPort := splitRedirectAuthority(tt.redirect)
+			if gotScheme != tt.wantScheme {
+				t.Errorf("splitRedirectAuthority() gotScheme = %v, want %v", gotScheme, tt.wantScheme)
+			}
+			if gotHost != tt.wantHost {
+				t.Errorf("splitRedirectAuthority() gotHost = %v, want %v", gotHost, tt.wantHost)
+			}
+			if gotPort != tt.wantPort {
+				t.Errorf("splitRedirectAuthority() gotPort = %v, want %v", gotPort, tt.wantPort)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Currently, the redirect.authority can take any input, such as `new-host`, `https://new-host:80`, etc. However, only `host` and `host:port` actually work. For example `https://new-host` would end up with envoy setting Location to `http://https://new-host`.

The new Gateway API (https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io/v1alpha2.HTTPRequestRedirect) has port, hostname, and scheme as valid options. Any combination of these three may be set.

This PR makes `redirect.authority` more flexible, by natively understanding `scheme://host:port`, where any of the three are optional, and converting directly into Envoy's support for these in redirects rather than always doing host redirect.

Backwards compatibility:
* `host` form: not impacted
* `host:port` form: not impacted. The envoy config will now be `hostRedirect: host; portRedirect: port` but the end result is the same
* All other forms: before it would generate invalid location like  `http://https://new-host`, now it works
Therefore, all previously valid configs are still valid

Alternatives:
* Modify the API to have port and scheme first class
* Do something similar to this PR, but make it internal-facing only so it can _only_ be access by gateway-api objects.