### PR TITLE
go 1.17 compatibility

### DIFF
--- a/pkg/test/echo/server/forwarder/protocol.go
+++ b/pkg/test/echo/server/forwarder/protocol.go
@@ -197,7 +197,7 @@ func newProtocol(cfg Config) (protocol, error) {
 			}
 		} else if cfg.Request.Http2 && scheme.Instance(urlScheme) == scheme.HTTPS {
 			if cfg.Request.Alpn == nil {
-				tlsConfig.NextProtos = []string{"h2"}
+				tlsConfig.NextProtos = []string{"h2", "http/1.1"}
 			}
 			proto.client.Transport = &http2.Transport{
 				TLSClientConfig: tlsConfig,


### PR DESCRIPTION
go 1.17 no longer supports fallback from h2 to http1.1 when using ALPN. See https://github.com/golang/go/issues/46310


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [X] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ X Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
