### PR TITLE
change envoy filter metrics from counter to gauge

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/monitoring.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/monitoring.go
@@ -62,7 +62,7 @@ func IncrementEnvoyFilterMetric(name string, pt PatchType, applied bool) {
 	if !features.EnableEnvoyFilterMetrics {
 		return
 	}
-	// Only set the Gauge when the filter it atleast applied once.
+	// Only set the Gauge when the filter is atleast applied once.
 	if applied {
 		envoyFilterStatus.With(nameType.Value(name)).With(patchType.Value(string(pt))).
 			With(resultType.Value(string(Applied))).Record(1)

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/monitoring.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/monitoring.go
@@ -102,7 +102,7 @@ func RecordMetrics() {
 			if !applied {
 				result = Skipped
 			}
-			envoyFilterStatus.With(nameType.Value(name)).With(patchType.Value(string(pt))).
+			envoyFilterStatus.With(nameType.Value(name)).With(patchType.Value(pt)).
 				With(resultType.Value(string(result))).Record(1)
 		}
 	}

--- a/pilot/pkg/xds/discovery.go
+++ b/pilot/pkg/xds/discovery.go
@@ -295,7 +295,6 @@ func (s *DiscoveryServer) periodicRefreshMetrics(stopCh <-chan struct{}) {
 				}
 			}
 			model.LastPushMutex.Unlock()
-			envoyfilter.RecordMetrics()
 		case <-stopCh:
 			return
 		}

--- a/pilot/pkg/xds/discovery.go
+++ b/pilot/pkg/xds/discovery.go
@@ -30,6 +30,7 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/apigen"
 	"istio.io/istio/pilot/pkg/networking/core"
+	"istio.io/istio/pilot/pkg/networking/core/v1alpha3/envoyfilter"
 	"istio.io/istio/pilot/pkg/networking/grpcgen"
 	"istio.io/istio/pilot/pkg/serviceregistry"
 	"istio.io/istio/pilot/pkg/serviceregistry/aggregate"
@@ -294,6 +295,7 @@ func (s *DiscoveryServer) periodicRefreshMetrics(stopCh <-chan struct{}) {
 				}
 			}
 			model.LastPushMutex.Unlock()
+			envoyfilter.RecordMetrics()
 		case <-stopCh:
 			return
 		}
@@ -324,6 +326,8 @@ func (s *DiscoveryServer) Push(req *model.PushRequest) {
 	oldPushContext := s.globalPushContext()
 	if oldPushContext != nil {
 		oldPushContext.OnConfigChange()
+		// Push the previous push Envoy metrics.
+		envoyfilter.RecordMetrics()
 	}
 	// PushContext is reset after a config change. Previous status is
 	// saved.


### PR DESCRIPTION
We did a trial run of these stats in dev clusters and this being a counter is getting incremented on every push and the skip counter is almost useless as it is being skipped on every listener/filter chain.

So I am proposing to change that stat to gauge and set only if it ever applied once so we can easily track filters that were never applied (which was our usecase)
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
