### PR TITLE
Refactor `ModelProtocolToListenerProtocol` and added HTTP_PROXY

### DIFF
--- a/pilot/pkg/networking/networking.go
+++ b/pilot/pkg/networking/networking.go
@@ -41,8 +41,16 @@ const (
 // ModelProtocolToListenerProtocol converts from a config.Protocol to its corresponding plugin.ListenerProtocol
 func ModelProtocolToListenerProtocol(p protocol.Instance,
 	trafficDirection core.TrafficDirection) ListenerProtocol {
-	// If protocol sniffing is not enabled, the default value is TCP
-	if p == protocol.Unsupported {
+	switch p {
+	case protocol.HTTP, protocol.HTTP2, protocol.HTTP_PROXY, protocol.GRPC, protocol.GRPCWeb:
+		return ListenerProtocolHTTP
+	case protocol.TCP, protocol.HTTPS, protocol.TLS,
+		protocol.Mongo, protocol.Redis, protocol.MySQL, protocol.Thrift:
+		return ListenerProtocolTCP
+	case protocol.UDP:
+		return ListenerProtocolUnknown
+	case protocol.Unsupported:
+		// If protocol sniffing is not enabled, the default value is TCP
 		switch trafficDirection {
 		case core.TrafficDirection_INBOUND:
 			if !features.EnableProtocolSniffingForInbound {
@@ -55,17 +63,6 @@ func ModelProtocolToListenerProtocol(p protocol.Instance,
 		default:
 			// Should not reach here.
 		}
-	}
-
-	switch p {
-	case protocol.HTTP, protocol.HTTP2, protocol.HTTP_PROXY, protocol.GRPC, protocol.GRPCWeb:
-		return ListenerProtocolHTTP
-	case protocol.TCP, protocol.HTTPS, protocol.TLS,
-		protocol.Mongo, protocol.Redis, protocol.MySQL, protocol.Thrift:
-		return ListenerProtocolTCP
-	case protocol.UDP:
-		return ListenerProtocolUnknown
-	case protocol.Unsupported:
 		return ListenerProtocolAuto
 	default:
 		// Should not reach here.

--- a/pilot/pkg/networking/networking.go
+++ b/pilot/pkg/networking/networking.go
@@ -58,7 +58,7 @@ func ModelProtocolToListenerProtocol(p protocol.Instance,
 	}
 
 	switch p {
-	case protocol.HTTP, protocol.HTTP2, protocol.GRPC, protocol.GRPCWeb:
+	case protocol.HTTP, protocol.HTTP2, protocol.HTTP_PROXY, protocol.GRPC, protocol.GRPCWeb:
 		return ListenerProtocolHTTP
 	case protocol.TCP, protocol.HTTPS, protocol.TLS,
 		protocol.Mongo, protocol.Redis, protocol.MySQL, protocol.Thrift:

--- a/pilot/pkg/networking/networking_test.go
+++ b/pilot/pkg/networking/networking_test.go
@@ -49,6 +49,14 @@ func TestModelProtocolToListenerProtocol(t *testing.T) {
 			ListenerProtocolHTTP,
 		},
 		{
+			"HTTP to HTTP",
+			protocol.HTTP_PROXY,
+			core.TrafficDirection_OUTBOUND,
+			true,
+			true,
+			ListenerProtocolHTTP,
+		},
+		{
 			"MySQL to TCP",
 			protocol.MySQL,
 			core.TrafficDirection_INBOUND,


### PR DESCRIPTION
**Please provide a description of this PR:**

http_proxy should be as treated as http listener protocol


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [x] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
