### PR TITLE
set gateway sidecarscope from getSidecarScope

### DIFF
--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -790,7 +790,7 @@ func (node *Proxy) SetSidecarScope(ps *PushContext) {
 		node.SidecarScope = ps.getSidecarScope(node, workloadLabels)
 	} else {
 		// Gateways should just have a default scope with egress: */*
-		node.SidecarScope = DefaultSidecarScopeForNamespace(ps, node.ConfigNamespace)
+		node.SidecarScope = ps.getSidecarScope(node, nil)
 	}
 	node.PrevSidecarScope = sidecarScope
 }

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -785,26 +785,36 @@ func (ps *PushContext) getSidecarScope(proxy *Proxy, workloadLabels labels.Colle
 	if sidecars, ok := ps.sidecarsByNamespace[proxy.ConfigNamespace]; ok {
 		// TODO: logic to merge multiple sidecar resources
 		// Currently we assume that there will be only one sidecar config for a namespace.
-		for _, wrapper := range sidecars {
-			if wrapper.Sidecar != nil {
-				sidecar := wrapper.Sidecar
-				// if there is no workload selector, the config applies to all workloads
-				// if there is a workload selector, check for matching workload labels
-				if sidecar.GetWorkloadSelector() != nil {
-					workloadSelector := labels.Instance(sidecar.GetWorkloadSelector().GetLabels())
-					// exclude workload selector that not match
-					if !workloadLabels.IsSupersetOf(workloadSelector) {
-						continue
-					}
+		if proxy.Type == Router {
+			for _, wrapper := range sidecars {
+				// Gateways should just have a default scope with egress: */*
+				if wrapper.Sidecar == nil {
+					return wrapper
 				}
+			}
+		}
+		if proxy.Type == SidecarProxy {
+			for _, wrapper := range sidecars {
+				if wrapper.Sidecar != nil {
+					sidecar := wrapper.Sidecar
+					// if there is no workload selector, the config applies to all workloads
+					// if there is a workload selector, check for matching workload labels
+					if sidecar.GetWorkloadSelector() != nil {
+						workloadSelector := labels.Instance(sidecar.GetWorkloadSelector().GetLabels())
+						// exclude workload selector that not match
+						if !workloadLabels.IsSupersetOf(workloadSelector) {
+							continue
+						}
+					}
 
-				// it is guaranteed sidecars with selectors are put in front
-				// and the sidecars are sorted by creation timestamp,
-				// return exact/wildcard matching one directly
+					// it is guaranteed sidecars with selectors are put in front
+					// and the sidecars are sorted by creation timestamp,
+					// return exact/wildcard matching one directly
+					return wrapper
+				}
+				// this happens at last, it is the default sidecar scope
 				return wrapper
 			}
-			// this happens at last, it is the default sidecar scope
-			return wrapper
 		}
 	}
 

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -743,6 +743,7 @@ func TestSidecarScope(t *testing.T) {
 	ps.Mesh = env.Mesh()
 	ps.ServiceIndex.HostnameAndNamespace[host.Name("svc1.default.cluster.local")] = map[string]*Service{"default": nil}
 	ps.ServiceIndex.HostnameAndNamespace[host.Name("svc2.nosidecar.cluster.local")] = map[string]*Service{"nosidecar": nil}
+	ps.ServiceIndex.HostnameAndNamespace[host.Name("svc3.istio-system.cluster.local")] = map[string]*Service{"istio-system": nil}
 
 	configStore := NewFakeStore()
 	sidecarWithWorkloadSelector := &networking.Sidecar{
@@ -813,12 +814,11 @@ func TestSidecarScope(t *testing.T) {
 			sidecar:    "nosidecar/global",
 			describe:   "no sidecar",
 		},
-
 		{
-			proxy:      &Proxy{Type: SidecarProxy, ConfigNamespace: "nosidecar"},
-			collection: labels.Collection{map[string]string{"app": "bar"}},
-			sidecar:    "nosidecar/global",
-			describe:   "no sidecar",
+			proxy:      &Proxy{Type: Router, ConfigNamespace: "istio-system"},
+			collection: labels.Collection{map[string]string{"app": "istio-gateway"}},
+			sidecar:    "istio-system/default-sidecar",
+			describe:   "gateway sidecar scope",
 		},
 	}
 	for _, c := range cases {

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -796,19 +796,26 @@ func TestSidecarScope(t *testing.T) {
 		describe   string
 	}{
 		{
-			proxy:      &Proxy{ConfigNamespace: "default"},
+			proxy:      &Proxy{Type: SidecarProxy, ConfigNamespace: "default"},
 			collection: labels.Collection{map[string]string{"app": "foo"}},
 			sidecar:    "default/foo",
 			describe:   "match local sidecar",
 		},
 		{
-			proxy:      &Proxy{ConfigNamespace: "default"},
+			proxy:      &Proxy{Type: SidecarProxy, ConfigNamespace: "default"},
 			collection: labels.Collection{map[string]string{"app": "bar"}},
 			sidecar:    "default/global",
 			describe:   "no match local sidecar",
 		},
 		{
-			proxy:      &Proxy{ConfigNamespace: "nosidecar"},
+			proxy:      &Proxy{Type: SidecarProxy, ConfigNamespace: "nosidecar"},
+			collection: labels.Collection{map[string]string{"app": "bar"}},
+			sidecar:    "nosidecar/global",
+			describe:   "no sidecar",
+		},
+
+		{
+			proxy:      &Proxy{Type: SidecarProxy, ConfigNamespace: "nosidecar"},
 			collection: labels.Collection{map[string]string{"app": "bar"}},
 			sidecar:    "nosidecar/global",
 			describe:   "no sidecar",


### PR DESCRIPTION
**Please provide a description of this PR:**

So that ingress-gateway and egress-gateway can reuse the existing namespace sidecarscope when no `Sidecar` created in root namespace instead of generating one for each gateway.


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [x] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
