### PR TITLE
Use json format with indent for logging meshconfig instead of spew

### DIFF
--- a/pilot/pkg/bootstrap/mesh.go
+++ b/pilot/pkg/bootstrap/mesh.go
@@ -21,7 +21,6 @@ import (
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/mesh/kubemesh"
-	"istio.io/istio/pkg/util/gogoprotomarshal"
 	"istio.io/pkg/filewatcher"
 	"istio.io/pkg/log"
 	"istio.io/pkg/version"
@@ -49,8 +48,7 @@ func (s *Server) initMeshConfiguration(args *PilotArgs, fileWatcher filewatcher.
 	log.Info("initializing mesh configuration ", args.MeshConfigFile)
 	defer func() {
 		if s.environment.Watcher != nil {
-			meshdump, _ := gogoprotomarshal.ToJSONWithIndent(s.environment.Mesh(), "    ")
-			log.Infof("mesh configuration: %s", meshdump)
+			log.Infof("mesh configuration: %s", mesh.PrettyFormatOfMeshConfig(s.environment.Mesh()))
 			log.Infof("version: %s", version.Info.String())
 			argsdump, _ := json.MarshalIndent(args, "", "   ")
 			log.Infof("flags: %s", argsdump)

--- a/pkg/config/mesh/watcher.go
+++ b/pkg/config/mesh/watcher.go
@@ -151,7 +151,7 @@ func (w *InternalWatcher) merged() *meshconfig.MeshConfig {
 			log.Errorf("user config invalid, ignoring it %v %s", err, w.userMeshConfig)
 		} else {
 			mc = *mc1
-			log.Info("Applied user config: %s", PrettyFormatOfMeshConfig(&mc))
+			log.Infof("Applied user config: %s", PrettyFormatOfMeshConfig(&mc))
 		}
 	}
 	if w.revMeshConfig != "" {
@@ -160,7 +160,7 @@ func (w *InternalWatcher) merged() *meshconfig.MeshConfig {
 			log.Errorf("revision config invalid, ignoring it %v %s", err, w.userMeshConfig)
 		} else {
 			mc = *mc1
-			log.Info("Applied revision mesh config: %s", PrettyFormatOfMeshConfig(&mc))
+			log.Infof("Applied revision mesh config: %s", PrettyFormatOfMeshConfig(&mc))
 		}
 	}
 	return &mc

--- a/pkg/config/mesh/watcher.go
+++ b/pkg/config/mesh/watcher.go
@@ -21,9 +21,8 @@ import (
 	"time"
 	"unsafe"
 
-	"istio.io/istio/pkg/util/gogoprotomarshal"
-
 	meshconfig "istio.io/api/mesh/v1alpha1"
+	"istio.io/istio/pkg/util/gogoprotomarshal"
 	"istio.io/pkg/filewatcher"
 	"istio.io/pkg/log"
 )

--- a/pkg/config/mesh/watcher.go
+++ b/pkg/config/mesh/watcher.go
@@ -21,7 +21,7 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/davecgh/go-spew/spew"
+	"istio.io/istio/pkg/util/gogoprotomarshal"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/pkg/filewatcher"
@@ -152,7 +152,7 @@ func (w *InternalWatcher) merged() *meshconfig.MeshConfig {
 			log.Errorf("user config invalid, ignoring it %v %s", err, w.userMeshConfig)
 		} else {
 			mc = *mc1
-			log.Infoa("Applied user config: ", spew.Sdump(mc))
+			log.Info("Applied user config: %s", PrettyFormatOfMeshConfig(&mc))
 		}
 	}
 	if w.revMeshConfig != "" {
@@ -161,7 +161,7 @@ func (w *InternalWatcher) merged() *meshconfig.MeshConfig {
 			log.Errorf("revision config invalid, ignoring it %v %s", err, w.userMeshConfig)
 		} else {
 			mc = *mc1
-			log.Infoa("Applied revision mesh config: ", spew.Sdump(mc))
+			log.Info("Applied revision mesh config: %s", PrettyFormatOfMeshConfig(&mc))
 		}
 	}
 	return &mc
@@ -180,7 +180,7 @@ func (w *InternalWatcher) handleMeshConfigInternal(meshConfig *meshconfig.MeshCo
 	var handlers []func()
 
 	if !reflect.DeepEqual(meshConfig, w.MeshConfig) {
-		log.Infof("mesh configuration updated to: %s", spew.Sdump(meshConfig))
+		log.Infof("mesh configuration updated to: %s", PrettyFormatOfMeshConfig(meshConfig))
 		if !reflect.DeepEqual(meshConfig.ConfigSources, w.MeshConfig.ConfigSources) {
 			log.Info("mesh configuration sources have changed")
 			// TODO Need to recreate or reload initConfigController()
@@ -217,4 +217,9 @@ func addFileWatcher(fileWatcher filewatcher.FileWatcher, file string, callback f
 			}
 		}
 	}()
+}
+
+func PrettyFormatOfMeshConfig(meshConfig *meshconfig.MeshConfig) string {
+	meshConfigDump, _ := gogoprotomarshal.ToJSONWithIndent(meshConfig, "    ")
+	return meshConfigDump
 }


### PR DESCRIPTION
**Please provide a description of this PR:**
Same with this pr https://github.com/istio/istio/pull/19878, we use json format with indent instead of spew for readability.