### PR TITLE
Remove previous default tag on non-revisioned installation

### DIFF
--- a/istioctl/cmd/tag.go
+++ b/istioctl/cmd/tag.go
@@ -358,7 +358,7 @@ func removeTag(ctx context.Context, kubeClient kubernetes.Interface, tagName str
 	}
 
 	// proceed with webhook deletion
-	err = tag.DeleteTagWebhooks(ctx, kubeClient, webhooks)
+	err = tag.DeleteTagWebhooks(ctx, kubeClient, tagName)
 	if err != nil {
 		return fmt.Errorf("failed to delete Istio revision tag MutatingConfigurationWebhook: %v", err)
 	}

--- a/istioctl/pkg/tag/util.go
+++ b/istioctl/pkg/tag/util.go
@@ -106,7 +106,11 @@ func GetWebhookRevision(wh admit_v1.MutatingWebhookConfiguration) (string, error
 }
 
 // DeleteTagWebhooks deletes the given webhooks.
-func DeleteTagWebhooks(ctx context.Context, client kubernetes.Interface, webhooks []admit_v1.MutatingWebhookConfiguration) error {
+func DeleteTagWebhooks(ctx context.Context, client kubernetes.Interface, tag string) error {
+	webhooks, err := GetWebhooksWithTag(ctx, client, tag)
+	if err != nil {
+		return err
+	}
 	var result error
 	for _, wh := range webhooks {
 		result = multierror.Append(client.AdmissionregistrationV1().MutatingWebhookConfigurations().Delete(ctx, wh.Name, metav1.DeleteOptions{})).ErrorOrNil()

--- a/operator/cmd/mesh/install.go
+++ b/operator/cmd/mesh/install.go
@@ -184,12 +184,16 @@ func runApplyCmd(cmd *cobra.Command, rootArgs *rootArgs, iArgs *installArgs, log
 
 	// Detect whether previous installation exists prior to performing the installation.
 	exists := revtag.PreviousInstallExists(context.Background(), kubeClient)
+	pilotEnabled := iop.Spec.Components.Pilot != nil && iop.Spec.Components.Pilot.Enabled.Value
+	rev := iop.Spec.Revision
+	if rev == "" && pilotEnabled {
+		_ = revtag.DeleteTagWebhooks(context.Background(), kubeClient, revtag.DefaultRevisionName)
+	}
 	iop, err = InstallManifests(iop, iArgs.force, rootArgs.dryRun, restConfig, client, iArgs.readinessTimeout, l)
 	if err != nil {
 		return fmt.Errorf("failed to install manifests: %v", err)
 	}
 
-	rev := iop.Spec.Revision
 	if !exists || rev == "" {
 		cmd.Println("Making this installation the default for injection and validation.")
 		if rev == "" {


### PR DESCRIPTION
Part of the fix for #34932 

Installing Istio without a revision should be considered as installing a default revision, and therefore we should remove the previous default tag on install to avoid mutating webhook overlap issues (otherwise analyzer will detect duplicate between default injector and default tag and fail out).

Noticed another issue when looking into this: since we rely on the default tag to provide resource validation now, and the in-cluster operator does not use this, we have no validation when installing with in-cluster operator currently. Need to address this before 1.12 release (either document to use `istioctl tag set default` or do it in `istioctl operator init` similar to how we autogenerate tag for `istioctl install`).

- [ ] Configuration Infrastructure
- [ ] Docs
- [x] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure