### PR TITLE
Enable ratelimit config reload automatically when the configMap has been updated

### DIFF
--- a/samples/ratelimit/rate-limit-service.yaml
+++ b/samples/ratelimit/rate-limit-service.yaml
@@ -132,6 +132,8 @@ spec:
           value: ratelimit
         - name: RUNTIME_WATCH_ROOT
           value: "false"
+        - name: RUNTIME_IGNOREDOTFILES
+          value: "true"
         ports:
         - containerPort: 8080
         - containerPort: 8081

--- a/samples/ratelimit/rate-limit-service.yaml
+++ b/samples/ratelimit/rate-limit-service.yaml
@@ -130,14 +130,15 @@ spec:
           value: /data
         - name: RUNTIME_SUBDIRECTORY
           value: ratelimit
+        - name: RUNTIME_WATCH_ROOT
+          value: "false"
         ports:
         - containerPort: 8080
         - containerPort: 8081
         - containerPort: 6070
         volumeMounts:
         - name: config-volume
-          mountPath: /data/ratelimit/config/config.yaml
-          subPath: config.yaml
+          mountPath: /data/ratelimit/config
       volumes:
       - name: config-volume
         configMap:


### PR DESCRIPTION
Enable ratelimit config reload automatically when the configMap has been updated.

How to do this?
- Set the RUNTIME_WATCH_ROOT environment variable to false, and let ratelimit update the contents inside RUNTIME_ROOT/RUNTIME_SUBDIRECTORY/config/ directly.
- Delete the subPath, because a container using a ConfigMap as a subPath volume mount will not receive ConfigMaps updates.

Related issue: https://github.com/istio/istio/issues/34890

Signed-off-by: devincd <505259926@qq.com>

**Please provide a description of this PR:**