### PR TITLE
Make priorityClass of cni in helm chart config

### DIFF
--- a/manifests/charts/istio-cni/templates/daemonset.yaml
+++ b/manifests/charts/istio-cni/templates/daemonset.yaml
@@ -52,7 +52,7 @@ spec:
           operator: Exists
         - effect: NoExecute
           operator: Exists
-      priorityClassName: system-node-critical
+      priorityClassName: {{ default 'system-node-critical' .Values.priorityClassName }}
       serviceAccountName: istio-cni
       # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.

--- a/manifests/charts/istio-cni/templates/daemonset.yaml
+++ b/manifests/charts/istio-cni/templates/daemonset.yaml
@@ -52,7 +52,7 @@ spec:
           operator: Exists
         - effect: NoExecute
           operator: Exists
-      priorityClassName: {{ default 'system-node-critical' .Values.priorityClassName }}
+      priorityClassName: {{ default 'system-node-critical' .Values.cni.priorityClassName }}
       serviceAccountName: istio-cni
       # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.

--- a/manifests/charts/istio-cni/values.yaml
+++ b/manifests/charts/istio-cni/values.yaml
@@ -3,6 +3,7 @@ cni:
   tag: ""
   image: install-cni
   pullPolicy: ""
+  priorityClassName: system-node-critical
 
   logLevel: info
 


### PR DESCRIPTION
The priorityClassName is hardcoded in helm charts of cni. We need it to be configurable to deploy in our custom enviroment.