### PR TITLE
add support for specifying default host in http10

### DIFF
--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -582,6 +582,10 @@ type NodeMetadata struct {
 	// Alpha in 1.1, based on feedback may be turned into an API or change. Set to "1" to enable.
 	HTTP10 string `json:"HTTP10,omitempty"`
 
+	// DefaultHTTP10Host indicates the default host to be be used when HTTP/1.0 is enabled and request does
+	// not have host header as host header is not mandatory for HTTP/1.0.
+	DefaultHTTP10Host string `json:"DEFAULT_HTTP10_HOST,omitempty"`
+
 	// Generator indicates the client wants to use a custom Generator plugin.
 	Generator string `json:"GENERATOR,omitempty"`
 

--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -543,8 +543,9 @@ func (configgen *ConfigGeneratorImpl) createGatewayHTTPFilterChainOpts(node *mod
 
 func buildGatewayConnectionManager(proxyConfig *meshconfig.ProxyConfig, node *model.Proxy) *hcm.HttpConnectionManager {
 	httpProtoOpts := &core.Http1ProtocolOptions{}
-	if features.HTTP10 || enableHTTP10(node.Metadata.HTTP10) {
+	if enableHTTP10(node.Metadata.HTTP10) {
 		httpProtoOpts.AcceptHttp_10 = true
+		httpProtoOpts.DefaultHostForHttp_10 = node.Metadata.DefaultHTTP10Host
 	}
 	xffNumTrustedHops := uint32(0)
 	forwardClientCertDetails := util.MeshConfigToEnvoyForwardClientCertDetails(meshconfig.Topology_SANITIZE_SET)

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -293,9 +293,10 @@ func (configgen *ConfigGeneratorImpl) buildSidecarInboundHTTPListenerOptsForPort
 		}
 	}
 
-	if features.HTTP10 || enableHTTP10(node.Metadata.HTTP10) {
+	if enableHTTP10(node.Metadata.HTTP10) {
 		httpOpts.connectionManager.HttpProtocolOptions = &core.Http1ProtocolOptions{
-			AcceptHttp_10: true,
+			AcceptHttp_10:         true,
+			DefaultHostForHttp_10: node.Metadata.DefaultHTTP10Host,
 		}
 	}
 
@@ -304,7 +305,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarInboundHTTPListenerOptsForPort
 
 // if enableFlag is "1" indicates that AcceptHttp_10 is enabled.
 func enableHTTP10(enableFlag string) bool {
-	return enableFlag == "1"
+	return features.HTTP10 || enableFlag == "1"
 }
 
 // buildSidecarInboundListenerForPortOrUDS creates a single listener on the server-side (inbound)
@@ -655,7 +656,7 @@ func (configgen *ConfigGeneratorImpl) buildHTTPProxy(node *model.Proxy,
 	httpOpts := &core.Http1ProtocolOptions{
 		AllowAbsoluteUrl: proto.BoolTrue,
 	}
-	if features.HTTP10 || enableHTTP10(node.Metadata.HTTP10) {
+	if enableHTTP10(node.Metadata.HTTP10) {
 		httpOpts.AcceptHttp_10 = true
 	}
 
@@ -775,10 +776,11 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundHTTPListenerOptsForPor
 		rds:              rdsName,
 	}
 
-	if features.HTTP10 || enableHTTP10(listenerOpts.proxy.Metadata.HTTP10) {
+	if enableHTTP10(listenerOpts.proxy.Metadata.HTTP10) {
 		httpOpts.connectionManager = &hcm.HttpConnectionManager{
 			HttpProtocolOptions: &core.Http1ProtocolOptions{
-				AcceptHttp_10: true,
+				AcceptHttp_10:         true,
+				DefaultHostForHttp_10: listenerOpts.proxy.Metadata.DefaultHTTP10Host,
 			},
 		}
 	}


### PR DESCRIPTION
Host Header is optional in Http1.0 and Envoy recommends setting [DefaultHttpHostHeader ](https://github.com/envoyproxy/envoy/blob/3a4baf64a5c300739b7ce47128c1e62fd2a38f33/api/envoy/config/core/v3/protocol.proto#L215) when Http1.0 is enabled. We might need this feature for migrating our legacy customers. This PR adds that config support via Metadata.
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure