### PR TITLE
Delete the duplicated definition method RegisterService

### DIFF
--- a/pkg/test/echo/server/endpoint/grpc.go
+++ b/pkg/test/echo/server/endpoint/grpc.go
@@ -51,7 +51,6 @@ var _ Instance = &grpcInstance{}
 type grpcServer interface {
 	reflection.GRPCServer
 	Serve(listener net.Listener) error
-	RegisterService(sd *grpc.ServiceDesc, ss interface{})
 	Stop()
 }
 


### PR DESCRIPTION
method RegisterService has been defined in the ServiceRegistrar
reflection.GRPCServer inherits ServiceRegistrar and grpcServer inherits reflection.GRPCServer,  so grpcServer inherits this method, does not need define this method again.

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure