### PR TITLE
override port for remotePilotAddress to support NodePort

### DIFF
--- a/manifests/charts/base/templates/endpoints.yaml
+++ b/manifests/charts/base/templates/endpoints.yaml
@@ -9,7 +9,7 @@ subsets:
 - addresses:
   - ip: {{ .Values.global.remotePilotAddress }}
   ports:
-  - port: 15012
+  - port: {{ .Values.global.remotePilotPort | default 15012 }}
     name: tcp-istiod
     protocol: TCP
   {{- else if regexMatch "^([0-9]*\\.){3}[0-9]*$" .Values.global.remotePilotAddress }}
@@ -22,7 +22,7 @@ subsets:
 - addresses:
   - ip: {{ .Values.global.remotePilotAddress }}
   ports:
-  - port: 15012
+  - port: {{ .Values.global.remotePilotPort | default 15012 }}
     name: tcp-istiod
     protocol: TCP
   {{- end }}

--- a/manifests/charts/base/templates/services.yaml
+++ b/manifests/charts/base/templates/services.yaml
@@ -11,6 +11,9 @@ spec:
   - port: 15012
     name: tcp-istiod
     protocol: TCP
+    {{- if not (eq .Values.global.remotePilotPort 0) }}
+    targetPort: {{.Values.global.remotePilotPort}}
+    {{- end }}
   clusterIP: None
   {{- else }}
 # when istiod isn't enabled in remote cluster, we can use istiod service name
@@ -24,6 +27,9 @@ spec:
   - port: 15012
     name: tcp-istiod
     protocol: TCP
+    {{- if not (eq .Values.global.remotePilotPort 0) }}
+    targetPort: {{.Values.global.remotePilotPort}}
+    {{- end }}
   # if the remotePilotAddress is IP addr, we use clusterIP: None.
   # else, we use externalName
   {{- if regexMatch "^([0-9]*\\.){3}[0-9]*$" .Values.global.remotePilotAddress }}

--- a/manifests/charts/base/values.yaml
+++ b/manifests/charts/base/values.yaml
@@ -14,6 +14,7 @@ global:
   configValidation: true
   externalIstiod: false
   remotePilotAddress: ""
+  remotePilotPort: 0
 
 base:
   # Used for helm2 to add the CRDs to templates.

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -377,6 +377,7 @@ global:
 
   # configure remote pilot and istiod service and endpoint
   remotePilotAddress: ""
+  remotePilotPort: 0
 
   ##############################################################################################
   # The following values are found in other charts. To effectively modify these values, make   #

--- a/manifests/charts/istiod-remote/values.yaml
+++ b/manifests/charts/istiod-remote/values.yaml
@@ -319,6 +319,7 @@ global:
         memory: 10Mi
   # configure remote pilot and istiod service and endpoint
   remotePilotAddress: ""
+  remotePilotPort: 0
   ##############################################################################################
   # The following values are found in other charts. To effectively modify these values, make   #
   # make sure they are consistent across your Istio helm charts                                #


### PR DESCRIPTION
untested but possible solution to access the control plane via node-port (https://github.com/istio/istio/issues/29482)