### PR TITLE
Fix Deployment namespace bug in image: auto analyzer

### DIFF
--- a/galley/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_test.go
@@ -578,7 +578,7 @@ var testGrid = []testCase{
 		},
 		analyzer: &injection.ImageAutoAnalyzer{},
 		expected: []message{
-			{msg.ImageAutoWithoutInjectionWarning, "Deployment non-injected-gateway-deployment"},
+			{msg.ImageAutoWithoutInjectionWarning, "Deployment non-injected-gateway-deployment.not-injected"},
 			{msg.ImageAutoWithoutInjectionError, "Pod injected-pod.default"},
 		},
 	},

--- a/galley/pkg/config/analysis/analyzers/injection/image-auto.go
+++ b/galley/pkg/config/analysis/analyzers/injection/image-auto.go
@@ -81,7 +81,7 @@ func (a *ImageAutoAnalyzer) Analyze(c analysis.Context) {
 		if !hasAutoImage(&d.Spec.Template.Spec) {
 			return true
 		}
-		nsLabels := getNamespaceLabels(c, d.Spec.Template.Namespace)
+		nsLabels := getNamespaceLabels(c, d.Namespace)
 		if !matchesWebhooks(nsLabels, d.Spec.Template.Labels, istioWebhooks) {
 			m := msg.NewImageAutoWithoutInjectionWarning(resource, "Deployment", d.Name)
 			c.Report(collections.K8SAppsV1Deployments.Name(), m)

--- a/galley/pkg/config/analysis/analyzers/testdata/image-auto.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/image-auto.yaml
@@ -54,6 +54,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: non-injected-gateway-deployment
+  namespace: not-injected
 spec:
   selector:
     matchLabels:
@@ -64,7 +65,6 @@ spec:
         inject.istio.io/templates: gateway
       labels:
         istio: ingressgateway
-        istio.io/rev: non-existent-rev
     spec:
       containers:
         - name: istio-proxy


### PR DESCRIPTION
Fixes #34929. Should ignore the namespace from the pod spec and use the namespace from the deployment spec when determining namespace selector matches for "image: auto" analyzer.

- [ ] Configuration Infrastructure
- [ ] Docs
- [x] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure