### PR TITLE
DestinationRule triggers lds for gateways

### DIFF
--- a/pilot/pkg/xds/lds.go
+++ b/pilot/pkg/xds/lds.go
@@ -30,12 +30,20 @@ type LdsGenerator struct {
 var _ model.XdsResourceGenerator = &LdsGenerator{}
 
 // Map of all configs that do not impact LDS
-var skippedLdsConfigs = map[config.GroupVersionKind]struct{}{
-	gvk.WorkloadGroup:   {},
-	gvk.Secret:          {},
+var skippedLdsConfigs = map[model.NodeType]map[config.GroupVersionKind]struct{}{
+	model.Router: {
+		// for autopassthrough gateways, we build filterchains per-dr subset
+		gvk.WorkloadGroup: {},
+		gvk.Secret:        {},
+	},
+	model.SidecarProxy: {
+		gvk.DestinationRule: {},
+		gvk.WorkloadGroup:   {},
+		gvk.Secret:          {},
+	},
 }
 
-func ldsNeedsPush(req *model.PushRequest) bool {
+func ldsNeedsPush(proxy *model.Proxy, req *model.PushRequest) bool {
 	if req == nil {
 		return true
 	}
@@ -48,7 +56,7 @@ func ldsNeedsPush(req *model.PushRequest) bool {
 		return true
 	}
 	for config := range req.ConfigsUpdated {
-		if _, f := skippedLdsConfigs[config.Kind]; !f {
+		if _, f := skippedLdsConfigs[proxy.Type][config.Kind]; !f {
 			return true
 		}
 	}
@@ -57,7 +65,7 @@ func ldsNeedsPush(req *model.PushRequest) bool {
 
 func (l LdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource,
 	req *model.PushRequest) (model.Resources, model.XdsLogDetails, error) {
-	if !ldsNeedsPush(req) {
+	if !ldsNeedsPush(proxy, req) {
 		return nil, model.DefaultXdsLogDetails, nil
 	}
 	listeners := l.Server.ConfigGenerator.BuildListeners(proxy, push)

--- a/pilot/pkg/xds/lds.go
+++ b/pilot/pkg/xds/lds.go
@@ -31,7 +31,6 @@ var _ model.XdsResourceGenerator = &LdsGenerator{}
 
 // Map of all configs that do not impact LDS
 var skippedLdsConfigs = map[config.GroupVersionKind]struct{}{
-	gvk.DestinationRule: {},
 	gvk.WorkloadGroup:   {},
 	gvk.Secret:          {},
 }

--- a/releasenotes/notes/34944.yaml
+++ b/releasenotes/notes/34944.yaml
@@ -6,4 +6,4 @@ issue:
 
 releaseNotes:
 - |
-  **Fixed** `DestinationRule` updates not triggering an update for `AUTO_PASSTHROUGH` listeners.
+  **Fixed** `DestinationRule` updates not triggering an update for `AUTO_PASSTHROUGH` listeners on gateways.

--- a/releasenotes/notes/34944.yaml
+++ b/releasenotes/notes/34944.yaml
@@ -1,6 +1,6 @@
 apiVersion: release-notes/v2
-kind: feature
-area: networking
+kind: bug-fix
+area: traffic-management
 issue:
   - 34944
 

--- a/releasenotes/notes/34944.yaml
+++ b/releasenotes/notes/34944.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: feature
+area: networking
+issue:
+  - 34944
+
+releaseNotes:
+- |
+  **Fixed** `DestinationRule` updates not triggering an update for `AUTO_PASSTHROUGH` listeners.


### PR DESCRIPTION
Partial fix https://github.com/istio/istio/issues/34944 although this only affects a small number of cases. We should still have a way to optimize when there is no autopassthrough. 

This is better than config not being reflected though. 