### PR TITLE
use EndpointSlices by default in 1.21

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -228,11 +228,7 @@ func NewServer(args *PilotArgs, initFuncs ...func(*Server)) (*Server, error) {
 	}
 
 	// used for both initKubeRegistry and initClusterRegistries
-	if features.EnableEndpointSliceController(s.kubeClient) {
-		args.RegistryOptions.KubeOptions.EndpointMode = kubecontroller.EndpointSliceOnly
-	} else {
-		args.RegistryOptions.KubeOptions.EndpointMode = kubecontroller.EndpointsOnly
-	}
+	args.RegistryOptions.KubeOptions.EndpointMode = kubecontroller.DetectEndpointMode(s.kubeClient)
 
 	s.initMeshConfiguration(args, s.fileWatcher)
 	spiffe.SetTrustDomain(s.environment.Mesh().GetTrustDomain())

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -220,18 +220,18 @@ func NewServer(args *PilotArgs, initFuncs ...func(*Server)) (*Server, error) {
 	e.TrustBundle = s.workloadTrustBundle
 	s.XDSServer = xds.NewDiscoveryServer(e, args.Plugins, args.PodName, args.Namespace, args.RegistryOptions.KubeOptions.ClusterAliases)
 
-	// used for both initKubeRegistry and initClusterRegistries
-	if features.EnableEndpointSliceController {
-		args.RegistryOptions.KubeOptions.EndpointMode = kubecontroller.EndpointSliceOnly
-	} else {
-		args.RegistryOptions.KubeOptions.EndpointMode = kubecontroller.EndpointsOnly
-	}
-
 	prometheus.EnableHandlingTimeHistogram()
 
 	// Apply the arguments to the configuration.
 	if err := s.initKubeClient(args); err != nil {
 		return nil, fmt.Errorf("error initializing kube client: %v", err)
+	}
+
+	// used for both initKubeRegistry and initClusterRegistries
+	if features.EnableEndpointSliceController(s.kubeClient) {
+		args.RegistryOptions.KubeOptions.EndpointMode = kubecontroller.EndpointSliceOnly
+	} else {
+		args.RegistryOptions.KubeOptions.EndpointMode = kubecontroller.EndpointsOnly
 	}
 
 	s.initMeshConfiguration(args, s.fileWatcher)

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -21,7 +21,6 @@ import (
 
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/jwt"
-	"istio.io/istio/pkg/kube"
 	"istio.io/pkg/env"
 	"istio.io/pkg/log"
 )
@@ -565,13 +564,9 @@ var (
 		"If enabled, the default revision will steal leader locks from non-default revisions").Get()
 )
 
-// EnableEndpointSliceController gets the status of the feature flag.
-// The default behavior is conditional on the Kubernetes version.
-func EnableEndpointSliceController(kubeClient kube.Client) bool {
-	if kubeClient == nil || endpointSliceControllerSpecified {
-		return enableEndpointSliceController
-	}
-	return kube.IsAtLeastVersion(kubeClient, 21)
+// EnableEndpointSliceController returns the value of the feature flag and whether it was actually specified.
+func EnableEndpointSliceController() (value bool, ok bool) {
+	return enableEndpointSliceController, endpointSliceControllerSpecified
 }
 
 // UnsafeFeaturesEnabled returns true if any unsafe features are enabled.

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -568,7 +568,7 @@ var (
 // EnableEndpointSliceController gets the status of the feature flag.
 // The default behavior is conditional on the Kubernetes version.
 func EnableEndpointSliceController(kubeClient kube.Client) bool {
-	if endpointSliceControllerSpecified {
+	if kubeClient == nil || endpointSliceControllerSpecified {
 		return enableEndpointSliceController
 	}
 	return kube.IsAtLeastVersion(kubeClient, 21)

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -161,6 +161,22 @@ func (o Options) GetSyncInterval() time.Duration {
 	return time.Millisecond * 100
 }
 
+// EnableEndpointSliceController determines whether to use Endpoints or EndpointSlice based on the
+// feature flag and/or Kubernetes version
+func DetectEndpointMode(kubeClient kubelib.Client) EndpointMode {
+	useEndpointslice, ok := features.EnableEndpointSliceController()
+
+	// we have a client, and flag wasn't set explicitly, auto-detect
+	if kubeClient != nil && !ok && kubelib.IsAtLeastVersion(kubeClient, 21) {
+		useEndpointslice = true
+	}
+
+	if useEndpointslice {
+		return EndpointSliceOnly
+	}
+	return EndpointsOnly
+}
+
 // EndpointMode decides what source to use to get endpoint information
 type EndpointMode int
 

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -160,13 +160,8 @@ func (m *Multicluster) ClusterAdded(cluster *multicluster.Cluster, clusterStopCh
 	options.ClusterID = cluster.ID
 	// the aggregate registry's HasSynced will use the k8s controller's HasSynced, so we reference the same timeout
 	options.SyncTimeout = cluster.SyncTimeout
-
 	// different clusters may have different k8s version, re-apply conditional default
-	if features.EnableEndpointSliceController(client) {
-		options.EndpointMode = EndpointSliceOnly
-	} else {
-		options.EndpointMode = EndpointsOnly
-	}
+	options.EndpointMode = DetectEndpointMode(client)
 
 	log.Infof("Initializing Kubernetes service registry %q", options.ClusterID)
 	kubeRegistry := NewController(client, options)

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -161,6 +161,13 @@ func (m *Multicluster) ClusterAdded(cluster *multicluster.Cluster, clusterStopCh
 	// the aggregate registry's HasSynced will use the k8s controller's HasSynced, so we reference the same timeout
 	options.SyncTimeout = cluster.SyncTimeout
 
+	// different clusters may have different k8s version, re-apply conditional default
+	if features.EnableEndpointSliceController(client) {
+		options.EndpointMode = EndpointSliceOnly
+	} else {
+		options.EndpointMode = EndpointsOnly
+	}
+
 	log.Infof("Initializing Kubernetes service registry %q", options.ClusterID)
 	kubeRegistry := NewController(client, options)
 	m.remoteKubeControllers[cluster.ID] = &kubeController{

--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -282,6 +282,8 @@ func (i *operatorComponent) Dump(ctx resource.Context) {
 	kube2.DumpWebhooks(ctx, d)
 	for _, c := range ctx.Clusters().Kube() {
 		kube2.DumpDebug(ctx, c, d, "configz")
+		kube2.DumpDebug(ctx, c, d, "importz")
+		kube2.DumpDebug(ctx, c, d, "exportz")
 		kube2.DumpDebug(ctx, c, d, "clusterz")
 	}
 	// Dump istio-cni.

--- a/releasenotes/notes/endpoint-slice.yaml
+++ b/releasenotes/notes/endpoint-slice.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+
+releaseNotes:
+- |
+  **Updated** the control plane to read `EndpointSlice` insead of `Endpoints`
+  for service discovery for Kubernetes 1.21 or later. To switch back to the old
+  `Endpoints` based behavior set `PILOT_USE_ENDPOINT_SLICE=false` in istiod.

--- a/tests/integration/pilot/endpointslice/endpointslice_test.go
+++ b/tests/integration/pilot/endpointslice/endpointslice_test.go
@@ -18,6 +18,8 @@
 package pilot
 
 import (
+	"fmt"
+	kubelib "istio.io/istio/pkg/kube"
 	"testing"
 
 	"istio.io/istio/pkg/test/framework"
@@ -41,11 +43,13 @@ func TestMain(m *testing.M) {
 		RequireLocalControlPlane().
 		RequireMinVersion(17).
 		Setup(istio.Setup(&i, func(t resource.Context, cfg *istio.Config) {
-			cfg.ControlPlaneValues = `
+			cfg.ControlPlaneValues = fmt.Sprintf(`
 values:
   pilot:
     env:
-      PILOT_USE_ENDPOINT_SLICE: "true"`
+      PILOT_USE_ENDPOINT_SLICE: "%v"`,
+      			// for k8s 1.21+, this suite should test disabling EndpointSlice mode
+				kubelib.IsLessThanVersion(t.Clusters().Kube().Default(), 21))
 		})).
 		Setup(func(t resource.Context) error {
 			return common.SetupApps(t, i, apps)

--- a/tests/integration/pilot/endpointslice/endpointslice_test.go
+++ b/tests/integration/pilot/endpointslice/endpointslice_test.go
@@ -19,9 +19,9 @@ package pilot
 
 import (
 	"fmt"
-	kubelib "istio.io/istio/pkg/kube"
 	"testing"
 
+	kubelib "istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/resource"
@@ -48,7 +48,7 @@ values:
   pilot:
     env:
       PILOT_USE_ENDPOINT_SLICE: "%v"`,
-      			// for k8s 1.21+, this suite should test disabling EndpointSlice mode
+				// for k8s 1.21+, this suite should test disabling EndpointSlice mode
 				kubelib.IsLessThanVersion(t.Clusters().Kube().Default(), 21))
 		})).
 		Setup(func(t resource.Context) error {


### PR DESCRIPTION
Not sure if we have other examples changing default behavior conditionally on the k8s version, this seems like it would wor.