### PR TITLE
Change default value of arch to current platform

### DIFF
--- a/tools/istio-docker.mk
+++ b/tools/istio-docker.mk
@@ -214,7 +214,8 @@ docker.install-cni: cni/deployments/kubernetes/Dockerfile.install-cni
 .PHONY: dockerx dockerx.save
 
 # Can also be linux/arm64, or both with linux/amd64,linux/arm64
-DOCKER_ARCHITECTURES ?= linux/amd64
+DOCKER_ARCHITECTURES ?= $(TARGET_OS)/$(TARGET_ARCH)
+
 
 # Docker has an experimental new build engine, https://github.com/docker/buildx
 # This brings substantial (10x) performance improvements when building Istio


### PR DESCRIPTION
When building the base images by
make dockerx.push
or
make dockerx, the default value of
DOCKER_ARCHITECTURES should be
the value of current build system, which is
$(TARGET_OS)/$(TARGET_ARCH) and then it would
work on both amd64 and other platforms, e.g., arm64
by default smoothly.

Signed-off-by: trevor tao <trevor.tao@arm.com>

**Please provide a description of this PR:**



**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
