### PR TITLE
rm PILOT_USE_TARGET_PORT_FOR_GATEWAY_ROUTES

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -509,13 +509,6 @@ var (
 	MulticlusterHeadlessEnabled = env.RegisterBoolVar("ENABLE_MULTICLUSTER_HEADLESS", false,
 		"If true, the DNS name table for a headless service will resolve to same-network endpoints in any cluster.").Get()
 
-	// UseTargetPortForGatewayRoutes determines which port to use for the routes. This flag is for safety only, and can be removed in future versions.
-	// Example setup: we have a Service on port 80, targetPort 8080
-	// Old behavior (false): we create listener 0.0.0.0_8080 and route http.80. This has potential for conflicts if there are other port 80s
-	// New behavior (true): we create listener 0.0.0.0_8080 and route http.8080. This has no conflicts; routes are 1:1 with listener.
-	UseTargetPortForGatewayRoutes = env.RegisterBoolVar("PILOT_USE_TARGET_PORT_FOR_GATEWAY_ROUTES", true,
-		"If true, routes will use the target port of the gateway service in the route name, not the service port.").Get()
-
 	CertSignerDomain = env.RegisterStringVar("CERT_SIGNER_DOMAIN", "", "The cert signer domain info").Get()
 
 	AutoReloadPluginCerts = env.RegisterBoolVar(

--- a/pilot/pkg/model/gateway.go
+++ b/pilot/pkg/model/gateway.go
@@ -351,12 +351,9 @@ func udpSupportedPort(number uint32, instances []*ServiceInstance) bool {
 // port and translating to the targetPort in addition to just directly referencing a port. In this
 // case, we just make a best effort guess by picking the first match.
 func resolvePorts(number uint32, instances []*ServiceInstance, legacyGatewaySelector bool) []uint32 {
-	if !features.UseTargetPortForGatewayRoutes {
-		return []uint32{number}
-	}
 	ports := map[uint32]struct{}{}
 	for _, w := range instances {
-		if _, directPortTranslation := w.Service.Attributes.Labels[DisableGatewayPortTranslationLabel]; directPortTranslation && legacyGatewaySelector {
+		if _, disablePortTranslation := w.Service.Attributes.Labels[DisableGatewayPortTranslationLabel]; disablePortTranslation && legacyGatewaySelector {
 			// Skip this Service, they opted out of port translation
 			// This is only done for legacyGatewaySelector, as the new gateway selection mechanism *only* allows
 			// referencing the Service port, and references are un-ambiguous.


### PR DESCRIPTION
**Please provide a description of this PR:**

According to the comments, it can be removed in 1.12