### PR TITLE
revise admin log to be more formatted like other commands

### DIFF
--- a/istioctl/cmd/istiodconfig.go
+++ b/istioctl/cmd/istiodconfig.go
@@ -132,7 +132,7 @@ func (ga *getAllLogLevelsState) run() (string, error) {
 	var output strings.Builder
 	switch ga.outputFormat {
 	case "short":
-		output.Write([]byte("active_scopes:\n"))
+		output.Write([]byte("Active scopes:\n"))
 		for _, sll := range resultScopeLogLevel {
 			_, _ = fmt.Fprintf(&output, "  %s:%s\n", sll.ScopeName, sll.LogLevel)
 		}

--- a/istioctl/cmd/istiodconfig_test.go
+++ b/istioctl/cmd/istiodconfig_test.go
@@ -26,7 +26,7 @@ import (
 
 func TestCtlPlaneConfig(t *testing.T) {
 	istiodConfigMap := map[string][]byte{
-		"istiod-7b69ff6f8c-fvjvw": []byte("active_scopes:\n  ads:info"),
+		"istiod-7b69ff6f8c-fvjvw": []byte("Active scopes:\n  ads:info"),
 	}
 
 	cases := []execTestCase{

--- a/releasenotes/notes/34982.yaml
+++ b/releasenotes/notes/34982.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: istioctl
+releaseNotes:
+  - |
+    **Fixed** `istioctl admin log` format.


### PR DESCRIPTION
Currently, the `admin log` command will output something like:
```
➜  istio-1.11.1 istioctl admin log
active_scopes:
  ads:info
  adsc:info
  analysis:info
  authn:info
```

This PR is to revise the first line of the ouput, to be the format like below:
```
Active scopes:
  ads:info
  adsc:info
  analysis:info
  authn:info
```

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [x] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
