### PR TITLE
Optimize: reduce calling mtlsChecker.mtlsDisabledByPeerAuthentication

### DIFF
--- a/pilot/pkg/xds/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoint_builder.go
@@ -328,21 +328,21 @@ func (b *EndpointBuilder) buildLocalityLbEndpointsFromShards(
 			if ep.EnvoyEndpoint == nil {
 				ep.EnvoyEndpoint = buildEnvoyLbEndpoint(ep)
 			}
-			if features.EnableAutomTLSCheckPolicies {
-				tlsMode := ep.TLSMode
-				if b.mtlsChecker != nil && b.mtlsChecker.mtlsDisabledByPeerAuthentication(ep) {
-					tlsMode = ""
-				}
-				if nep, modified := util.MaybeApplyTLSModeLabel(ep.EnvoyEndpoint, tlsMode); modified {
-					ep.EnvoyEndpoint = nep
-				}
-			}
 			locLbEps.append(ep, ep.EnvoyEndpoint, ep.TunnelAbility)
 
 			// detect if mTLS is possible for this endpoint, used later during ep filtering
 			// this must be done while converting IstioEndpoints because we still have workload labels
 			if b.mtlsChecker != nil {
 				b.mtlsChecker.computeForEndpoint(ep)
+				if features.EnableAutomTLSCheckPolicies {
+					tlsMode := ep.TLSMode
+					if b.mtlsChecker != nil && b.mtlsChecker.isMtlsDisabled(ep.EnvoyEndpoint) {
+						tlsMode = ""
+					}
+					if nep, modified := util.MaybeApplyTLSModeLabel(ep.EnvoyEndpoint, tlsMode); modified {
+						ep.EnvoyEndpoint = nep
+					}
+				}
 			}
 		}
 	}

--- a/pilot/pkg/xds/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoint_builder.go
@@ -322,8 +322,6 @@ func (b *EndpointBuilder) buildLocalityLbEndpointsFromShards(
 			if ep.EnvoyEndpoint == nil {
 				ep.EnvoyEndpoint = buildEnvoyLbEndpoint(ep)
 			}
-			locLbEps.append(ep, ep.EnvoyEndpoint, ep.TunnelAbility)
-
 			// detect if mTLS is possible for this endpoint, used later during ep filtering
 			// this must be done while converting IstioEndpoints because we still have workload labels
 			if b.mtlsChecker != nil {
@@ -338,6 +336,7 @@ func (b *EndpointBuilder) buildLocalityLbEndpointsFromShards(
 					}
 				}
 			}
+			locLbEps.append(ep, ep.EnvoyEndpoint, ep.TunnelAbility)
 		}
 	}
 	shards.mutex.Unlock()

--- a/pilot/pkg/xds/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoint_builder.go
@@ -477,8 +477,9 @@ func (c *mtlsChecker) computeForEndpoint(ep *model.IstioEndpoint) {
 		}
 	}
 
-	if envoytransportSocketMetadata(ep.EnvoyEndpoint, model.TLSModeLabelShortname) != model.IstioMutualTLSModeLabel ||
-		c.mtlsDisabledByPeerAuthentication(ep) {
+	// if endpoint has no sidecar or explicitly tls disabled by "security.istio.io/tlsMode" label.
+	if ep.TLSMode != model.IstioMutualTLSModeLabel ||
+		c.mtlsDisabledByPeerAuthentication(ep) { // or tls disabled by PeerAuthentication
 		c.mtlsDisabledHosts[lbEpKey(ep.EnvoyEndpoint)] = struct{}{}
 	}
 }

--- a/pilot/pkg/xds/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoint_builder.go
@@ -103,15 +103,9 @@ func NewEndpointBuilder(clusterName string, proxy *model.Proxy, push *model.Push
 		port:       port,
 	}
 
-	enableMtlsChecker := false
 	// We need this for multi-network, or for clusters meant for use with AUTO_PASSTHROUGH.
-	if b.push.NetworkManager().IsMultiNetworkEnabled() || model.IsDNSSrvSubsetKey(clusterName) {
-		enableMtlsChecker = true
-	}
-	if features.EnableAutomTLSCheckPolicies {
-		enableMtlsChecker = true
-	}
-	if enableMtlsChecker {
+	if features.EnableAutomTLSCheckPolicies ||
+		b.push.NetworkManager().IsMultiNetworkEnabled() || model.IsDNSSrvSubsetKey(clusterName) {
 		b.mtlsChecker = newMtlsChecker(push, port, dr)
 	}
 	return b

--- a/pilot/pkg/xds/ep_filters.go
+++ b/pilot/pkg/xds/ep_filters.go
@@ -226,13 +226,3 @@ func (b *EndpointBuilder) EndpointsWithMTLSFilter(endpoints []*LocLbEndpointsAnd
 
 	return filtered
 }
-
-func envoytransportSocketMetadata(ep *endpoint.LbEndpoint, key string) string {
-	if ep.Metadata != nil &&
-		ep.Metadata.FilterMetadata[util.EnvoyTransportSocketMetadataKey] != nil &&
-		ep.Metadata.FilterMetadata[util.EnvoyTransportSocketMetadataKey].Fields != nil &&
-		ep.Metadata.FilterMetadata[util.EnvoyTransportSocketMetadataKey].Fields[key] != nil {
-		return ep.Metadata.FilterMetadata[util.EnvoyTransportSocketMetadataKey].Fields[key].GetStringValue()
-	}
-	return ""
-}


### PR DESCRIPTION
**Please provide a description of this PR:**

make use of `computeForEndpoint` calculated result instead of call mtlsDisabledByPeerAuthentication again