### PR TITLE
add flag to control cluster telemetry metadata

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -400,7 +400,7 @@ var (
 			"Setting the timeout to 0 disables this behavior.",
 	).Get()
 
-	EnableTelemetry = env.RegisterBoolVar("PILOT_ENABLE_TELEMETRY", true,
+	EnableTelemetry = env.RegisterBoolVar("PILOT_ENABLE_TELEMETRY_LABEL", true,
 		"If true, pilot will add telemetry related metadata to cluster and endpoint resources, which will be consumed by telemetry filter.",
 	).Get()
 

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -400,6 +400,10 @@ var (
 			"Setting the timeout to 0 disables this behavior.",
 	).Get()
 
+	EnableTelemetry = env.RegisterBoolVar("PILOT_ENABLE_TELEMETRY", true,
+		"If true, pilot will add telemetry related metadata to cluster and endpoint resources, which will be consumed by telemetry filter.",
+	).Get()
+
 	EndpointTelemetryLabel = env.RegisterBoolVar("PILOT_ENDPOINT_TELEMETRY_LABEL", true,
 		"If true, pilot will add telemetry related metadata to Endpoint resource, which will be consumed by telemetry filter.",
 	).Get()

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -400,7 +400,7 @@ var (
 			"Setting the timeout to 0 disables this behavior.",
 	).Get()
 
-	EnableTelemetry = env.RegisterBoolVar("PILOT_ENABLE_TELEMETRY_LABEL", true,
+	EnableTelemetryLabel = env.RegisterBoolVar("PILOT_ENABLE_TELEMETRY_LABEL", true,
 		"If true, pilot will add telemetry related metadata to cluster and endpoint resources, which will be consumed by telemetry filter.",
 	).Get()
 

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -762,7 +762,7 @@ func applyLocalityLBSetting(locality *core.Locality, proxyLabels map[string]stri
 }
 
 func addTelemetryMetadata(opts buildClusterOpts, service *model.Service, direction model.TrafficDirection, instances []*model.ServiceInstance) {
-	if !features.EnableTelemetry {
+	if !features.EnableTelemetryLabel {
 		return
 	}
 	if opts.mutable.cluster == nil {

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -762,6 +762,9 @@ func applyLocalityLBSetting(locality *core.Locality, proxyLabels map[string]stri
 }
 
 func addTelemetryMetadata(opts buildClusterOpts, service *model.Service, direction model.TrafficDirection, instances []*model.ServiceInstance) {
+	if features.EnableTelemetry {
+		return
+	}
 	if opts.mutable.cluster == nil {
 		return
 	}

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -762,7 +762,7 @@ func applyLocalityLBSetting(locality *core.Locality, proxyLabels map[string]stri
 }
 
 func addTelemetryMetadata(opts buildClusterOpts, service *model.Service, direction model.TrafficDirection, instances []*model.ServiceInstance) {
-	if features.EnableTelemetry {
+	if !features.EnableTelemetry {
 		return
 	}
 	if opts.mutable.cluster == nil {

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -489,7 +489,7 @@ func MergeAnyWithAny(dst *any.Any, src *any.Any) (*any.Any, error) {
 func BuildLbEndpointMetadata(networkID network.ID, tlsMode, workloadname, namespace string,
 	clusterID cluster.ID, labels labels.Instance) *core.Metadata {
 	if networkID == "" && (tlsMode == "" || tlsMode == model.DisabledTLSModeLabel) &&
-		(!features.EndpointTelemetryLabel || !features.EnableTelemetry) {
+		(!features.EndpointTelemetryLabel || !features.EnableTelemetryLabel) {
 		return nil
 	}
 

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -488,7 +488,8 @@ func MergeAnyWithAny(dst *any.Any, src *any.Any) (*any.Any, error) {
 // BuildLbEndpointMetadata adds metadata values to a lb endpoint
 func BuildLbEndpointMetadata(networkID network.ID, tlsMode, workloadname, namespace string,
 	clusterID cluster.ID, labels labels.Instance) *core.Metadata {
-	if networkID == "" && (tlsMode == "" || tlsMode == model.DisabledTLSModeLabel) && !features.EndpointTelemetryLabel {
+	if networkID == "" && (tlsMode == "" || tlsMode == model.DisabledTLSModeLabel) &&
+		(!features.EndpointTelemetryLabel || !features.EnableTelemetry) {
 		return nil
 	}
 


### PR DESCRIPTION
This is not a huge perf impact but with many clusters (especially in large k8s clusters) this is adding some overhead. So adding a flag to control this behaviour. Ideally we can deprecate existing `PILOT_ENDPOINT_TELEMETRY_LABEL` and remove it later. For now I have added a new flag that works for both.

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure