### PR TITLE
Bump up default grpc transport settings for adsc.

### DIFF
--- a/pkg/adsc/adsc.go
+++ b/pkg/adsc/adsc.go
@@ -20,6 +20,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
+	"math"
 	"net"
 	"os"
 	"sort"
@@ -55,6 +56,12 @@ import (
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/security"
 	"istio.io/pkg/log"
+)
+
+const (
+	defaultClientMaxReceiveMessageSize = math.MaxInt32
+	defaultInitialConnWindowSize       = 1024 * 1024 // default gRPC InitialWindowSize
+	defaultInitialWindowSize           = 1024 * 1024 // default gRPC ConnWindowSize
 )
 
 // Config for the ADS connection.
@@ -115,6 +122,15 @@ type Config struct {
 	ResponseHandler ResponseHandler
 
 	GrpcOpts []grpc.DialOption
+}
+
+func DefaultGrpcDialOptions() []grpc.DialOption {
+	return []grpc.DialOption{
+		// TODO(SpecialYang) maybe need to make it configurable.
+		grpc.WithInitialWindowSize(int32(defaultInitialWindowSize)),
+		grpc.WithInitialConnWindowSize(int32(defaultInitialConnWindowSize)),
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(defaultClientMaxReceiveMessageSize)),
+	}
 }
 
 // ADSC implements a basic client for ADS, for use in stress tests and tools
@@ -298,7 +314,8 @@ func (a *ADSC) Dial() error {
 	opts := a.cfg
 
 	var err error
-	grpcDialOptions := opts.GrpcOpts
+	grpcDialOptions := DefaultGrpcDialOptions()
+	grpcDialOptions = append(grpcDialOptions, opts.GrpcOpts...)
 	// If we need MTLS - CertDir or Secrets provider is set.
 	if len(opts.CertDir) > 0 || opts.SecretManager != nil {
 		tlsCfg, err := a.tlsConfig()

--- a/pkg/adsc/adsc.go
+++ b/pkg/adsc/adsc.go
@@ -313,9 +313,12 @@ func New(discoveryAddr string, opts *Config) (*ADSC, error) {
 func (a *ADSC) Dial() error {
 	opts := a.cfg
 
-	var err error
-	grpcDialOptions := DefaultGrpcDialOptions()
+	defaultGrpcDialOptions := DefaultGrpcDialOptions()
+	var grpcDialOptions []grpc.DialOption
+	grpcDialOptions = append(grpcDialOptions, defaultGrpcDialOptions...)
 	grpcDialOptions = append(grpcDialOptions, opts.GrpcOpts...)
+
+	var err error
 	// If we need MTLS - CertDir or Secrets provider is set.
 	if len(opts.CertDir) > 0 || opts.SecretManager != nil {
 		tlsCfg, err := a.tlsConfig()
@@ -326,7 +329,7 @@ func (a *ADSC) Dial() error {
 		grpcDialOptions = append(grpcDialOptions, grpc.WithTransportCredentials(creds))
 	}
 
-	if len(grpcDialOptions) == 0 {
+	if len(grpcDialOptions) == len(defaultGrpcDialOptions) {
 		// Only disable transport security if the user didn't supply custom dial options
 		grpcDialOptions = append(grpcDialOptions, grpc.WithInsecure())
 	}


### PR DESCRIPTION
**Please provide a description of this PR:**
Our mcp resources server has lots of services with huge number of service instances. When we use mcp-over-xds protocol to get service entry resources by adsc client, we got the following error.

```
2021-09-01T20:13:39.787444Z info    adsc    Connection closed for node sidecar~22.1.72.106~test-
1.default~default.svc.cluster.local with err: rpc error: 
code = ResourceExhausted desc = grpc: received message larger than max (19542550 vs. 4194304)
```

The default received message size of grpc is 4mb which is really not enough for huge services. So I think we can simply set it to math.MaxInt32 which does same with `XdsProxy`.
https://github.com/istio/istio/blob/dceadfc91e5d7aafefd12cac87c7ffc27858dc9b/pkg/istio-agent/xds_proxy.go#L630-L655