### PR TITLE
Require Istio 1.11 for MCS test

### DIFF
--- a/tests/integration/pilot/mcs/discoverability/discoverability_test.go
+++ b/tests/integration/pilot/mcs/discoverability/discoverability_test.go
@@ -71,6 +71,7 @@ func TestMain(m *testing.M) {
 func TestClusterLocal(t *testing.T) {
 	framework.NewTest(t).
 		Features("traffic.mcs.servicediscovery").
+		RequireIstioVersion("1.11").
 		Run(func(t framework.TestContext) {
 			// Don't export service B in any cluster. All requests should stay in-cluster.
 


### PR DESCRIPTION
Feature was introduced in 1.11

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [x] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure