### PR TITLE
make use of new CommonHttpProtocolOptions.MaxRequestsPerConnection

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -924,7 +924,12 @@ func (cb *ClusterBuilder) applyConnectionPool(mesh *meshconfig.MeshConfig, mc *M
 			commonOptions.CommonHttpProtocolOptions.IdleTimeout = idleTimeoutDuration
 		}
 		if maxRequestsPerConnection > 0 {
-			commonOptions.CommonHttpProtocolOptions.MaxRequestsPerConnection = &wrappers.UInt32Value{Value: maxRequestsPerConnection}
+			if util.IsIstioVersionGE112(model.ParseIstioVersion(cb.proxyVersion)) {
+				commonOptions.CommonHttpProtocolOptions.MaxRequestsPerConnection = &wrappers.UInt32Value{Value: maxRequestsPerConnection}
+			} else {
+				// nolint: staticcheck
+				mc.cluster.MaxRequestsPerConnection = &wrappers.UInt32Value{Value: uint32(settings.Http.MaxRequestsPerConnection)}
+			}
 		}
 	}
 

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -115,7 +115,7 @@ type ClusterBuilder struct {
 	locality          *core.Locality           // Locality information of proxy.
 	proxyLabels       map[string]string        // Proxy labels.
 	networkView       map[network.ID]bool      // Proxy network view.
-	proxyIPAddresses  []string                 // IP addresses on which proxy is listenining on.
+	proxyIPAddresses  []string                 // IP addresses on which proxy is listening on.
 	configNamespace   string                   // Proxy config namespace.
 	// PushRequest to look for updates.
 	req   *model.PushRequest
@@ -875,6 +875,7 @@ func (cb *ClusterBuilder) applyConnectionPool(mesh *meshconfig.MeshConfig, mc *M
 
 	threshold := getDefaultCircuitBreakerThresholds()
 	var idleTimeout *types.Duration
+	var maxRequestsPerConnection uint32
 
 	if settings.Http != nil {
 		if settings.Http.Http2MaxRequests > 0 {
@@ -886,18 +887,13 @@ func (cb *ClusterBuilder) applyConnectionPool(mesh *meshconfig.MeshConfig, mc *M
 			threshold.MaxPendingRequests = &wrappers.UInt32Value{Value: uint32(settings.Http.Http1MaxPendingRequests)}
 		}
 
-		if settings.Http.MaxRequestsPerConnection > 0 {
-			// nolint: staticcheck
-			// Update to not use the deprecated fields later.
-			mc.cluster.MaxRequestsPerConnection = &wrappers.UInt32Value{Value: uint32(settings.Http.MaxRequestsPerConnection)}
-		}
-
 		// FIXME: zero is a valid value if explicitly set, otherwise we want to use the default
 		if settings.Http.MaxRetries > 0 {
 			threshold.MaxRetries = &wrappers.UInt32Value{Value: uint32(settings.Http.MaxRetries)}
 		}
 
 		idleTimeout = settings.Http.IdleTimeout
+		maxRequestsPerConnection = uint32(settings.Http.MaxRequestsPerConnection)
 	}
 
 	cb.applyDefaultConnectionPool(mc.cluster)
@@ -917,14 +913,18 @@ func (cb *ClusterBuilder) applyConnectionPool(mesh *meshconfig.MeshConfig, mc *M
 		Thresholds: []*cluster.CircuitBreakers_Thresholds{threshold},
 	}
 
-	if idleTimeout != nil {
-		idleTimeoutDuration := gogo.DurationToProtoDuration(idleTimeout)
+	if idleTimeout != nil || maxRequestsPerConnection > 0 {
 		if mc.httpProtocolOptions == nil {
 			mc.httpProtocolOptions = &http.HttpProtocolOptions{}
 		}
 		commonOptions := mc.httpProtocolOptions
-		commonOptions.CommonHttpProtocolOptions = &core.HttpProtocolOptions{
-			IdleTimeout: idleTimeoutDuration,
+		commonOptions.CommonHttpProtocolOptions = &core.HttpProtocolOptions{}
+		if idleTimeout != nil {
+			idleTimeoutDuration := gogo.DurationToProtoDuration(idleTimeout)
+			commonOptions.CommonHttpProtocolOptions.IdleTimeout = idleTimeoutDuration
+		}
+		if maxRequestsPerConnection > 0 {
+			commonOptions.CommonHttpProtocolOptions.MaxRequestsPerConnection = &wrappers.UInt32Value{Value: maxRequestsPerConnection}
 		}
 	}
 

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -128,12 +128,12 @@ func TestHTTPCircuitBreakerThresholds(t *testing.T) {
 					g.Expect(thresholds.MaxPendingRequests.Value).To(Equal(uint32(s.Http.Http1MaxPendingRequests)))
 					g.Expect(thresholds.MaxRequests).To(Not(BeNil()))
 					g.Expect(thresholds.MaxRequests.Value).To(Equal(uint32(s.Http.Http2MaxRequests)))
-					// nolint: staticcheck
-					// Update to not use the deprecated fields later.
-					g.Expect(cluster.MaxRequestsPerConnection).To(Not(BeNil()))
-					// nolint: staticcheck
-					// Update to not use the deprecated fields later.
-					g.Expect(cluster.MaxRequestsPerConnection.Value).To(Equal(uint32(s.Http.MaxRequestsPerConnection)))
+					g.Expect(cluster.TypedExtensionProtocolOptions).To(Not(BeNil()))
+					anyOptions := cluster.TypedExtensionProtocolOptions[v3.HttpProtocolOptionsType]
+					g.Expect(anyOptions).To(Not(BeNil()))
+					httpProtocolOptions := &http.HttpProtocolOptions{}
+					anyOptions.UnmarshalTo(httpProtocolOptions)
+					g.Expect(httpProtocolOptions.CommonHttpProtocolOptions.MaxRequestsPerConnection.GetValue()).To(Equal(uint32(s.Http.MaxRequestsPerConnection)))
 					g.Expect(thresholds.MaxRetries).To(Not(BeNil()))
 					g.Expect(thresholds.MaxRetries.Value).To(Equal(uint32(s.Http.MaxRetries)))
 				}

--- a/pilot/pkg/networking/core/v1alpha3/fake.go
+++ b/pilot/pkg/networking/core/v1alpha3/fake.go
@@ -205,7 +205,7 @@ func (f *ConfigGenTest) SetupProxy(p *model.Proxy) *model.Proxy {
 		p.Metadata = &model.NodeMetadata{}
 	}
 	if p.Metadata.IstioVersion == "" {
-		p.Metadata.IstioVersion = "1.9.0"
+		p.Metadata.IstioVersion = "1.12.0"
 	}
 	if p.IstioVersion == nil {
 		p.IstioVersion = model.ParseIstioVersion(p.Metadata.IstioVersion)

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -277,6 +277,12 @@ func IsIstioVersionGE111(node *model.Proxy) bool {
 		node.IstioVersion.Compare(&model.IstioVersion{Major: 1, Minor: 11, Patch: -1}) >= 0
 }
 
+// IsIstioVersionGE112 checks whether the given Istio version is greater than or equals 1.12.
+func IsIstioVersionGE112(version *model.IstioVersion) bool {
+	return version == nil ||
+		version.Compare(&model.IstioVersion{Major: 1, Minor: 12, Patch: -1}) >= 0
+}
+
 func IsProtocolSniffingEnabledForPort(port *model.Port) bool {
 	return features.EnableProtocolSniffingForOutbound && port.Protocol.IsUnsupported()
 }


### PR DESCRIPTION

**Please provide a description of this PR:**

cluster.MaxRequestsPerConnection has been deprecated for long



**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
