### PR TITLE
Option to run istio-cni with privileged securityContext

### DIFF
--- a/manifests/charts/istio-cni/templates/daemonset.yaml
+++ b/manifests/charts/istio-cni/templates/daemonset.yaml
@@ -130,6 +130,10 @@ spec:
 {{- else }}
 {{ toYaml .Values.global.defaultResources | trim | indent 12 }}
 {{- end }}
+{{- if .Values.cni.runAsPrivileged }}
+          securityContext:
+            privileged: true
+{{- end }}
 {{- if .Values.cni.taint.enabled }}
         - name: taint-controller
 {{- if contains "/" .Values.cni.image }}

--- a/manifests/charts/istio-cni/values.yaml
+++ b/manifests/charts/istio-cni/values.yaml
@@ -60,6 +60,8 @@ cni:
     enabled: false
     pods: 5000
 
+  runAsPrivileged: false
+
 # Revision is set as 'version' label and part of the resource names when installing multiple control planes.
 revision: ""
 


### PR DESCRIPTION
CNI installation gives the following error when installing, adding this securityContext allows it to run.

Logs
```
2021-09-07T06:56:26.478044Z     error   Failed to start up UDS Log Server: failed to create UDS listener: listen unix /var/run/istio-cni/log.sock: bind: permission denied
Error: failed to create UDS listener: listen unix /var/run/istio-cni/log.sock: bind: permission denied
```
Istio Version
```
$ istioctl version
client version: 1.11.1
control plane version: 1.11.1
```
OS info
```
$ cat /etc/redhat-release
Red Hat Enterprise Linux Server release x.x (xxxxx)
```

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [X] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
