### PR TITLE
Add a rate limit to incoming XDS requests

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -64,6 +64,12 @@ var (
 		"Limits the number of concurrent pushes allowed. On larger machines this can be increased for faster pushes",
 	).Get()
 
+	RequestLimit = env.RegisterFloatVar(
+		"PILOT_MAX_REQUESTS_PER_SECOND",
+		100.0,
+		"Limits the number of incoming XDS requests per second. On larger machines this can be increased to handle more proxies concurrently.",
+	).Get()
+
 	// MaxRecvMsgSize The max receive buffer size of gRPC received channel of Pilot in bytes.
 	MaxRecvMsgSize = env.RegisterIntVar(
 		"ISTIO_GPRC_MAXRECVMSGSIZE",

--- a/pilot/pkg/grpc/grpc.go
+++ b/pilot/pkg/grpc/grpc.go
@@ -32,13 +32,11 @@ import (
 
 type SendHandler func() error
 
-var timeout = features.XdsPushSendTimeout
-
 // Send with timeout if specified. If timeout is zero, sends without timeout.
 func Send(ctx context.Context, send SendHandler) error {
-	if timeout.Nanoseconds() > 0 {
+	if features.XdsPushSendTimeout.Nanoseconds() > 0 {
 		errChan := make(chan error, 1)
-		timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
+		timeoutCtx, cancel := context.WithTimeout(ctx, features.XdsPushSendTimeout)
 		defer cancel()
 		go func() {
 			err := send()

--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -276,6 +276,11 @@ func (s *DiscoveryServer) Stream(stream DiscoveryStream) error {
 		peerAddr = peerInfo.Addr.String()
 	}
 
+	if err := s.WaitForRequestLimit(stream.Context()); err != nil {
+		log.Warnf("ADS: %q exceeded rate limit: %v", peerAddr, err)
+		return status.Errorf(codes.ResourceExhausted, "request rate limit exceeded: %v", err)
+	}
+
 	ids, err := s.authenticate(ctx)
 	if err != nil {
 		return status.Error(codes.Unauthenticated, err.Error())

--- a/pilot/pkg/xds/delta.go
+++ b/pilot/pkg/xds/delta.go
@@ -61,6 +61,11 @@ func (s *DiscoveryServer) StreamDeltas(stream DeltaDiscoveryStream) error {
 		peerAddr = peerInfo.Addr.String()
 	}
 
+	if err := s.WaitForRequestLimit(stream.Context()); err != nil {
+		log.Warnf("ADS: %q exceeded rate limit: %v", peerAddr, err)
+		return status.Errorf(codes.ResourceExhausted, "request rate limit exceeded: %v", err)
+	}
+
 	ids, err := s.authenticate(ctx)
 	if err != nil {
 		return err


### PR DESCRIPTION
In a cluster we saw thundering herd problem. When a new istiod spins up, it instantly receives 1k requests and attempts to process them all. This leads to OOM, so all of them disconnect and try again to new instance. While the instance can handle 1k connections, it cannot handle 1k requests all at once. Requests are the most expensive (always total full push) and there is no limiting.

With rate limit, we can limit max memory and avoid throttling, allowing us to slowly ramp up number of connections.

An alternative or addition we can do is to have a semaphore limiting max *concurrent* requests. The reason I went with this is:
* Rate limit makes it easier to block requests immediately - before we do anything expensive at all or cause churn with connects+disconnects, workload entry registration, etc. If we had a semaphore that early then we would be blocking all requests on synchronous api-server calls (for VM registration) which could block everyone. This doesn't seem right.
* I thought about *also* adding a semaphore. We have an existing one for pushes; I don't think we want to reuse it though, as requests must take precedence over pushes. If we had a way to have a shared semaphore that favors requests over pushes that would be ideal IMO but seems a bit too complex for now