### PR TITLE
istioctl workload sets discovery address for revision

### DIFF
--- a/istioctl/cmd/testdata/vmconfig/simple/mesh.yaml.golden
+++ b/istioctl/cmd/testdata/vmconfig/simple/mesh.yaml.golden
@@ -1,4 +1,5 @@
 defaultConfig:
+  discoveryAddress: istiod-rev-1.istio-system.svc.cluster.local
   proxyMetadata:
     CANONICAL_REVISION: latest
     CANONICAL_SERVICE: foo

--- a/istioctl/cmd/workload.go
+++ b/istioctl/cmd/workload.go
@@ -470,12 +470,11 @@ func createMeshConfig(kubeClient kube.ExtendedClient, wg *clientv1alpha3.Workloa
 			ProxyMetadata: map[string]string{},
 		},
 	}
-	if revision != "" && revision != "default" {
-		meshConfig.DefaultConfig.DiscoveryAddress = fmt.Sprintf("istiod-%s.%s.svc.cluster.local", revision, istioNamespace)
-	}
-
 	if err := gogoprotomarshal.ApplyYAML(istio.Data[configMapKey], meshConfig); err != nil {
 		return nil, err
+	}
+	if revision != "" && revision != "default" && meshConfig.DefaultConfig.DiscoveryAddress == "" {
+		meshConfig.DefaultConfig.DiscoveryAddress = fmt.Sprintf("istiod-%s.%s.svc.cluster.local", revision, istioNamespace)
 	}
 
 	// performing separate map-merge, apply seems to completely overwrite all metadata

--- a/istioctl/cmd/workload.go
+++ b/istioctl/cmd/workload.go
@@ -470,6 +470,10 @@ func createMeshConfig(kubeClient kube.ExtendedClient, wg *clientv1alpha3.Workloa
 			ProxyMetadata: map[string]string{},
 		},
 	}
+	if revision != "" && revision != "default" {
+		meshConfig.DefaultConfig.DiscoveryAddress = fmt.Sprintf("istiod-%s.%s.svc.cluster.local", revision, istioNamespace)
+	}
+
 	if err := gogoprotomarshal.ApplyYAML(istio.Data[configMapKey], meshConfig); err != nil {
 		return nil, err
 	}

--- a/istioctl/cmd/workload_test.go
+++ b/istioctl/cmd/workload_test.go
@@ -171,6 +171,7 @@ func TestWorkloadEntryConfigure(t *testing.T) {
 			testdir := path.Join("testdata/vmconfig", dir.Name())
 			kubeClientWithRevision = func(_, _, _ string) (kube.ExtendedClient, error) {
 				return &kube.MockClient{
+					RevisionValue: "rev-1",
 					Interface: fake.NewSimpleClientset(
 						&v1.ServiceAccount{
 							ObjectMeta: metav1.ObjectMeta{Namespace: "bar", Name: "vm-serviceaccount"},
@@ -181,7 +182,7 @@ func TestWorkloadEntryConfigure(t *testing.T) {
 							Data:       map[string]string{"root-cert.pem": string(fakeCACert)},
 						},
 						&v1.ConfigMap{
-							ObjectMeta: metav1.ObjectMeta{Namespace: "istio-system", Name: "istio"},
+							ObjectMeta: metav1.ObjectMeta{Namespace: "istio-system", Name: "istio-rev-1"},
 							Data: map[string]string{
 								"mesh": string(util.ReadFile(path.Join(testdir, "meshconfig.yaml"), t)),
 							},

--- a/tests/integration/pilot/revisions/revisions_test.go
+++ b/tests/integration/pilot/revisions/revisions_test.go
@@ -92,6 +92,12 @@ func TestMultiRevision(t *testing.T) {
 						},
 					},
 				}).
+				// tests bootstrap
+				WithConfig(echo.Config{
+					Service:   "vm",
+					Namespace: canary,
+					Ports:     []echo.Port{},
+				}).
 				BuildOrFail(t)
 			retry.UntilSuccessOrFail(t, func() error {
 				resp, err := client.Call(echo.CallOptions{


### PR DESCRIPTION
If the revision is set, we try to use the same discovery address that we setup in /etc/hosts

fixes https://github.com/istio/istio/issues/34058