### PR TITLE
Share complete scheme in all usages

### DIFF
--- a/pkg/config/schema/fuzz_test.go
+++ b/pkg/config/schema/fuzz_test.go
@@ -25,7 +25,6 @@ import (
 	fuzz "github.com/google/gofuzz"
 	"k8s.io/apimachinery/pkg/api/apitesting/fuzzer"
 	metafuzzer "k8s.io/apimachinery/pkg/apis/meta/fuzzer"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 
@@ -33,14 +32,11 @@ import (
 	networking "istio.io/api/networking/v1alpha3"
 	security "istio.io/api/security/v1beta1"
 	telemetry "istio.io/api/telemetry/v1alpha1"
-	clientnetworkingalpha "istio.io/client-go/pkg/apis/networking/v1alpha3"
-	clientnetworkingbeta "istio.io/client-go/pkg/apis/networking/v1beta1"
-	clientsecurity "istio.io/client-go/pkg/apis/security/v1beta1"
-	clienttelemetry "istio.io/client-go/pkg/apis/telemetry/v1alpha1"
 	"istio.io/istio/pilot/pkg/config/kube/crdclient"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/collections"
 	istiofuzz "istio.io/istio/pkg/config/schema/fuzz"
+	"istio.io/istio/pkg/kube"
 )
 
 // This test exercises round tripping of marshaling/unmarshaling of all of our CRDs, based on fuzzing
@@ -56,7 +52,7 @@ func TestRoundtripFuzzing(t *testing.T) {
 				Version: gvk.Version,
 				Kind:    gvk.Kind,
 			}
-			istiofuzz.RoundTrip(t, kgvk, scheme, fz)
+			istiofuzz.RoundTrip(t, kgvk, kube.IstioScheme, fz)
 		})
 	}
 }
@@ -80,7 +76,7 @@ func TestValidationFuzzing(t *testing.T) {
 					Version: gvk.Version,
 					Kind:    gvk.Kind,
 				}
-				obj := istiofuzz.Fuzz(t, kgvk, scheme, fz)
+				obj := istiofuzz.Fuzz(t, kgvk, kube.IstioScheme, fz)
 				iobj = crdclient.TranslateObject(obj, gvk, "cluster.local")
 				_, _ = r.Resource().ValidateConfig(*iobj)
 			}
@@ -88,18 +84,9 @@ func TestValidationFuzzing(t *testing.T) {
 	}
 }
 
-var scheme = runtime.NewScheme()
-
-func init() {
-	clientnetworkingalpha.AddToScheme(scheme)
-	clientnetworkingbeta.AddToScheme(scheme)
-	clientsecurity.AddToScheme(scheme)
-	clienttelemetry.AddToScheme(scheme)
-}
-
 func createFuzzer() *fuzz.Fuzzer {
 	fuzzerFuncs := fuzzer.MergeFuzzerFuncs(metafuzzer.Funcs, fixProtoFuzzer)
-	codecs := serializer.NewCodecFactory(scheme)
+	codecs := serializer.NewCodecFactory(kube.IstioScheme)
 	seed := time.Now().UTC().UnixNano()
 	fz := fuzzer.
 		FuzzerFor(fuzzerFuncs, rand.NewSource(seed), codecs).

--- a/pkg/kube/util.go
+++ b/pkg/kube/util.go
@@ -24,8 +24,8 @@ import (
 	kubeApiCore "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/kubernetes/scheme"
 
 	//  allow out of cluster authentication
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -148,7 +148,7 @@ func SetRestDefaults(config *rest.Config) *rest.Config {
 		// This codec factory ensures the resources are not converted. Therefore, resources
 		// will not be round-tripped through internal versions. Defaulting does not happen
 		// on the client.
-		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+		config.NegotiatedSerializer = serializer.NewCodecFactory(IstioScheme).WithoutConversion()
 	}
 	if len(config.UserAgent) == 0 {
 		config.UserAgent = IstioUserAgent()

--- a/tests/fuzz/config_validation_fuzzer.go
+++ b/tests/fuzz/config_validation_fuzzer.go
@@ -18,26 +18,13 @@ package fuzz
 import (
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	clientnetworkingalpha "istio.io/client-go/pkg/apis/networking/v1alpha3"
-	clientnetworkingbeta "istio.io/client-go/pkg/apis/networking/v1beta1"
-	clientsecurity "istio.io/client-go/pkg/apis/security/v1beta1"
-	clienttelemetry "istio.io/client-go/pkg/apis/telemetry/v1alpha1"
 	"istio.io/istio/pilot/pkg/config/kube/crdclient"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/collections"
+	"istio.io/istio/pkg/kube"
 )
-
-var scheme = runtime.NewScheme()
-
-func init() {
-	clientnetworkingalpha.AddToScheme(scheme)
-	clientnetworkingbeta.AddToScheme(scheme)
-	clientsecurity.AddToScheme(scheme)
-	clienttelemetry.AddToScheme(scheme)
-}
 
 func FuzzConfigValidation(data []byte) int {
 	f := fuzz.NewConsumer(data)
@@ -54,7 +41,7 @@ func FuzzConfigValidation(data []byte) int {
 		Version: gvk.Version,
 		Kind:    gvk.Kind,
 	}
-	object, err := scheme.New(kgvk)
+	object, err := kube.IstioScheme.New(kgvk)
 	if err != nil {
 		return 0
 	}


### PR DESCRIPTION
Alternative to https://github.com/istio/istio/pull/35023

See kubernetes-sigs/controller-runtime#1654

This makes a single Scheme with all Istio types. This should be used by anyone that needs a scheme like this. Aside from refactoring, this ensures the NegotiatedSerializer uses this Scheme which is the core fix.