### PR TITLE
terminate envoy when number of active connections is zero

### DIFF
--- a/pilot/cmd/pilot-agent/options/agent.go
+++ b/pilot/cmd/pilot-agent/options/agent.go
@@ -42,6 +42,7 @@ func NewAgentOptions(proxy *model.Proxy, cfg *meshconfig.ProxyConfig) *istioagen
 		ServiceNode:               proxy.ServiceNode(),
 		EnvoyStatusPort:           envoyStatusPortEnv,
 		EnvoyPrometheusPort:       envoyPrometheusPortEnv,
+		MinimumDrainDuration:      minimumDrainDurationEnv,
 		Platform:                  platform.Discover(),
 		GRPCBootstrapPath:         grpcBootstrapEnv,
 		DisableEnvoy:              disableEnvoyEnv,

--- a/pilot/cmd/pilot-agent/options/options.go
+++ b/pilot/cmd/pilot-agent/options/options.go
@@ -119,4 +119,9 @@ var (
 	istiodSAN = env.RegisterStringVar("ISTIOD_SAN", "",
 		"Override the ServerName used to validate Istiod certificate. "+
 			"Can be used as an alternative to setting /etc/hosts for VMs - discovery address will be an IP:port")
+
+	minimumDrainDurationEnv = env.RegisterDurationVar("MINIMUM_DRAIN_DURATION",
+		5*time.Second,
+		"The minimum duration for which agent waits before it checks for active connections and terminates proxy"+
+			"when number of active connections become zero").Get()
 )

--- a/pilot/cmd/pilot-agent/status/util/stats.go
+++ b/pilot/cmd/pilot-agent/status/util/stats.go
@@ -22,6 +22,8 @@ import (
 	"time"
 
 	multierror "github.com/hashicorp/go-multierror"
+
+	"istio.io/istio/pkg/http"
 )
 
 const (
@@ -72,7 +74,7 @@ func GetReadinessStats(localHostAddr string, adminPort uint16) (*uint64, bool, e
 	}
 
 	readinessURL := fmt.Sprintf("http://%s:%d/stats?usedonly&filter=%s", localHostAddr, adminPort, readyStatsRegex)
-	stats, err := doHTTPGetWithTimeout(readinessURL, readinessTimeout)
+	stats, err := http.DoHTTPGetWithTimeout(readinessURL, readinessTimeout)
 	if err != nil {
 		return nil, false, err
 	}
@@ -103,7 +105,7 @@ func GetUpdateStatusStats(localHostAddr string, adminPort uint16) (*Stats, error
 		localHostAddr = "localhost"
 	}
 
-	stats, err := doHTTPGet(fmt.Sprintf("http://%s:%d/stats?usedonly&filter=%s", localHostAddr, adminPort, updateStatsRegex))
+	stats, err := http.DoHTTPGet(fmt.Sprintf("http://%s:%d/stats?usedonly&filter=%s", localHostAddr, adminPort, updateStatsRegex))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/envoy/agent.go
+++ b/pkg/envoy/agent.go
@@ -17,8 +17,13 @@ package envoy
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strconv"
+	"strings"
 	"time"
 
+	"istio.io/istio/pilot/pkg/util/sets"
+	"istio.io/istio/pkg/http"
 	"istio.io/pkg/log"
 )
 
@@ -26,13 +31,30 @@ var errAbort = errors.New("epoch aborted")
 
 const errOutOfMemory = "signal: killed"
 
+var activeConnectionCheckDelay = time.Duration(1 * time.Second)
+
 // NewAgent creates a new proxy agent for the proxy start-up and clean-up functions.
-func NewAgent(proxy Proxy, terminationDrainDuration time.Duration) *Agent {
+func NewAgent(proxy Proxy, terminationDrainDuration, minDrainDuration time.Duration, localhost string,
+	adminPort, statusPort, prometheusPort int) *Agent {
+
+	knownIstioListeners := sets.NewSet(
+		fmt.Sprintf("listener.0.0.0.0_%d.downstream_cx_active", statusPort),
+		fmt.Sprintf("listener.0.0.0.0_%d.downstream_cx_active", prometheusPort),
+		"listener.admin.downstream_cx_active",
+		"listener.admin.main_thread.downstream_cx_active",
+	)
 	return &Agent{
 		proxy:                    proxy,
 		statusCh:                 make(chan exitStatus, 1), // context might stop drainage
+		drainCh:                  make(chan struct{}),
 		abortCh:                  make(chan error, 1),
 		terminationDrainDuration: terminationDrainDuration,
+		minDrainDuration:         minDrainDuration,
+		adminPort:                adminPort,
+		statusPort:               int(statusPort),
+		prometheusPort:           int(prometheusPort),
+		localhost:                localhost,
+		knownIstioListeners:      knownIstioListeners,
 	}
 }
 
@@ -59,10 +81,21 @@ type Agent struct {
 	// channel for proxy exit notifications
 	statusCh chan exitStatus
 
+	drainCh chan struct{}
+
 	abortCh chan error
 
 	// time to allow for the proxy to drain before terminating all remaining proxy processes
 	terminationDrainDuration time.Duration
+	minDrainDuration         time.Duration
+
+	adminPort int
+	localhost string
+
+	statusPort     int
+	prometheusPort int
+
+	knownIstioListeners sets.Set
 }
 
 type exitStatus struct {
@@ -105,11 +138,69 @@ func (a *Agent) terminate() {
 	if e != nil {
 		log.Warnf("Error in invoking drain listeners endpoint %v", e)
 	}
-	log.Infof("Graceful termination period is %v, starting...", a.terminationDrainDuration)
-	time.Sleep(a.terminationDrainDuration)
-	log.Infof("Graceful termination period complete, terminating remaining proxies.")
-	a.abortCh <- errAbort
+	log.Infof("Agent draining proxy for %v, then waiting for active connections to terminate...", a.minDrainDuration)
+	time.Sleep(a.minDrainDuration)
+	log.Infof("Termination drain duration period is %v, checking for active connections...", a.terminationDrainDuration)
+	go a.waitForDrain()
+	select {
+	case <-a.drainCh:
+		log.Info("There are no more active connections. terminating proxy...")
+		a.abortCh <- errAbort
+	// TODO: remove terminationDrainDuration and rely on "terminationGracefulPeriodSeconds" of pod?
+	case <-time.After(a.terminationDrainDuration):
+		log.Info("Termination period complete, terminating proxy...")
+		a.abortCh <- errAbort
+		close(a.drainCh)
+	}
 	log.Warnf("Aborted all epochs")
+}
+
+func (a *Agent) waitForDrain() {
+	for {
+		select {
+		case <-time.After(activeConnectionCheckDelay):
+			if a.activeProxyConnections() == 0 {
+				close(a.drainCh)
+				return
+			}
+		case <-a.drainCh:
+			return
+		}
+	}
+}
+
+func (a *Agent) activeProxyConnections() int {
+	activeConnectionsURL := fmt.Sprintf("http://%s:%d/stats?usedonly&filter=downstream_cx_active", a.localhost, a.adminPort)
+	stats, err := http.DoHTTPGet(activeConnectionsURL)
+	if err != nil {
+		log.Warnf("Unable to get listener stats from Envoy : %v", err)
+		return -1
+	}
+	activeConnections := 0
+	for stats.Len() > 0 {
+		line, _ := stats.ReadString('\n')
+		parts := strings.Split(line, ":")
+		if len(parts) != 2 {
+			log.Warnf("envoy stat line is missing separator. line:%s", line)
+			continue
+		}
+		// downstream_cx_active is accounted under "http." and "listener." for http listeners.
+		// Only consider listener stats.
+		if !strings.HasPrefix(parts[0], "listener.") {
+			continue
+		}
+		// If the stat is for a known Istio listener skip it.
+		if a.knownIstioListeners.Contains(parts[0]) {
+			continue
+		}
+		val, err := strconv.ParseUint(strings.TrimSpace(parts[1]), 10, 64)
+		if err != nil {
+			log.Warnf("failed parsing Envoy stat %s (error: %s) line: %s", parts[0], err.Error(), line)
+			continue
+		}
+		activeConnections += int(val)
+	}
+	return activeConnections
 }
 
 // runWait runs the start-up command as a go routine and waits for it to finish

--- a/pkg/envoy/agent_test.go
+++ b/pkg/envoy/agent_test.go
@@ -53,7 +53,7 @@ func (tp TestProxy) UpdateConfig(_ []byte) error {
 func TestStartExit(t *testing.T) {
 	ctx := context.Background()
 	done := make(chan struct{})
-	a := NewAgent(TestProxy{}, 0)
+	a := NewAgent(TestProxy{}, 0, 0, "", 0, 0, 0)
 	go func() {
 		a.Run(ctx)
 		done <- struct{}{}
@@ -84,7 +84,7 @@ func TestStartDrain(t *testing.T) {
 		}
 		return nil
 	}
-	a := NewAgent(TestProxy{run: start, blockChannel: blockChan}, -10*time.Second)
+	a := NewAgent(TestProxy{run: start, blockChannel: blockChan}, -10*time.Second, 0, "", 0, 0, 0)
 	go func() { a.Run(ctx) }()
 	<-blockChan
 	cancel()
@@ -107,7 +107,7 @@ func TestStartStop(t *testing.T) {
 			cancel()
 		}
 	}
-	a := NewAgent(TestProxy{run: start, cleanup: cleanup}, 0)
+	a := NewAgent(TestProxy{run: start, cleanup: cleanup}, 0, 0, "", 0, 0, 0)
 	go func() { a.Run(ctx) }()
 	<-ctx.Done()
 }
@@ -127,7 +127,7 @@ func TestRecovery(t *testing.T) {
 		<-ctx.Done()
 		return nil
 	}
-	a := NewAgent(TestProxy{run: start}, 0)
+	a := NewAgent(TestProxy{run: start}, 0, 0, "", 0, 0, 0)
 	go func() { a.Run(ctx) }()
 
 	// make sure we don't try to reconcile twice

--- a/pkg/http/get.go
+++ b/pkg/http/get.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package util
+package http
 
 import (
 	"bytes"
@@ -24,7 +24,7 @@ import (
 
 const requestTimeout = time.Second * 1 // Default timeout.
 
-func doHTTPGetWithTimeout(requestURL string, t time.Duration) (*bytes.Buffer, error) {
+func DoHTTPGetWithTimeout(requestURL string, t time.Duration) (*bytes.Buffer, error) {
 	httpClient := &http.Client{
 		Timeout: t,
 	}
@@ -46,6 +46,6 @@ func doHTTPGetWithTimeout(requestURL string, t time.Duration) (*bytes.Buffer, er
 	return &b, nil
 }
 
-func doHTTPGet(requestURL string) (*bytes.Buffer, error) {
-	return doHTTPGetWithTimeout(requestURL, requestTimeout)
+func DoHTTPGet(requestURL string) (*bytes.Buffer, error) {
+	return DoHTTPGetWithTimeout(requestURL, requestTimeout)
 }

--- a/pkg/istio-agent/agent.go
+++ b/pkg/istio-agent/agent.go
@@ -180,6 +180,8 @@ type AgentOptions struct {
 	// proxy config.
 	EnvoyPrometheusPort int
 
+	MinimumDrainDuration time.Duration
+
 	// Cloud platform
 	Platform platform.Environment
 
@@ -290,7 +292,12 @@ func (a *Agent) initializeEnvoyAgent(ctx context.Context) error {
 	envoyProxy := envoy.NewProxy(a.envoyOpts)
 
 	drainDuration, _ := types.DurationFromProto(a.proxyConfig.TerminationDrainDuration)
-	a.envoyAgent = envoy.NewAgent(envoyProxy, drainDuration)
+	localHostAddr := localHostIPv4
+	if a.cfg.IsIPv6 {
+		localHostAddr = localHostIPv6
+	}
+	a.envoyAgent = envoy.NewAgent(envoyProxy, drainDuration, a.cfg.MinimumDrainDuration, localHostAddr,
+		int(a.proxyConfig.ProxyAdminPort), a.cfg.EnvoyStatusPort, a.cfg.EnvoyPrometheusPort)
 	a.envoyWaitCh = make(chan error, 1)
 	if a.cfg.EnableDynamicBootstrap {
 		// Simulate an xDS request for a bootstrap


### PR DESCRIPTION
For #34855 except that it still uses terminationDrainDuration.

It gets downstream_cx_active of all listeners (ignores admin and stats listeners) and when the total becomes zero, it terminates Envoy or waits for terminationDrainDuration. It starts this process after waiting for minDrainDuration i.e. 5s.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
