### PR TITLE
fix sidecar listener creation with bind and catchall in sidecar

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -841,7 +841,12 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundTCPListenerOptsForPort
 	// in the map.
 	//
 	// Check if this TCP listener conflicts with an existing HTTP listener
-	if *currentListenerEntry, exists = listenerMap[*listenerMapKey]; exists {
+	*currentListenerEntry, exists = listenerMap[*listenerMapKey]
+
+	if !exists {
+		*currentListenerEntry, exists = listenerMap[listenerKey(actualWildcard, listenerOpts.port.Port)]
+	}
+	if exists {
 		// NOTE: This is not a conflict. This is simply filtering the
 		// services for a given listener explicitly.
 		// When the user declares their own ports in Sidecar.egress

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -843,6 +843,12 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundTCPListenerOptsForPort
 	// Check if this TCP listener conflicts with an existing HTTP listener
 	*currentListenerEntry, exists = listenerMap[*listenerMapKey]
 
+	// If there is no listener with serviceListenAddress, check if a wildcard bind exists.
+	// This can happen if user specified a restricted service set on this port with wildcard
+	// bind and also adds a catchall('*/*' with no ports) listener. We should not create
+	// listener with serviceListenAddress in that case.
+	// TODO: Should we check if a listener on this port with any bind exists exists instead of
+	// just wildcard bind?
 	if !exists {
 		*currentListenerEntry, exists = listenerMap[listenerKey(actualWildcard, listenerOpts.port.Port)]
 	}

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -841,7 +841,9 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundTCPListenerOptsForPort
 	// in the map.
 	//
 	// Check if this TCP listener conflicts with an existing HTTP listener
-	*currentListenerEntry, exists = listenerMap[*listenerMapKey]
+	if *currentListenerEntry, exists = listenerMap[*listenerMapKey]; !exists {
+		*listenerMapKey = listenerKey(actualWildcard, listenerOpts.port.Port)
+	}
 
 	// If there is no listener with serviceListenAddress, check if a wildcard bind exists.
 	// This can happen if user specified a restricted service set on this port with wildcard
@@ -849,10 +851,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundTCPListenerOptsForPort
 	// listener with serviceListenAddress in that case.
 	// TODO: Should we check if a listener on this port with any bind exists exists instead of
 	// just wildcard bind?
-	if !exists {
-		*currentListenerEntry, exists = listenerMap[listenerKey(actualWildcard, listenerOpts.port.Port)]
-	}
-	if exists {
+	if *currentListenerEntry, exists = listenerMap[*listenerMapKey]; exists {
 		// NOTE: This is not a conflict. This is simply filtering the
 		// services for a given listener explicitly.
 		// When the user declares their own ports in Sidecar.egress

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -842,22 +842,16 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundTCPListenerOptsForPort
 	//
 	// Check if this TCP listener conflicts with an existing HTTP listener
 	*currentListenerEntry, exists = listenerMap[*listenerMapKey]
-	log.Infof("listener map key %s, exists: %v", *listenerMapKey, exists)
 
 	// If there is no listener with serviceListenAddress, check if a wildcard bind exists.
 	// This can happen if user specified a restricted service set on this port with wildcard
 	// bind and also adds a catchall('*/*' with no ports) listener. We should not create
 	// listener with serviceListenAddress in that case.
 	if !exists {
-		log.Infof("checking wildcard for listener map key %s, exists: %v", *listenerMapKey, exists)
 		wilcardListenerMapKey := listenerKey(actualWildcard, listenerOpts.port.Port)
 		listenerEntry, wcexists := listenerMap[listenerKey(actualWildcard, listenerOpts.port.Port)]
-		if wcexists {
-			log.Infof("listener entry protocol %v listeneropts protocol", listenerEntry.protocol, listenerOpts.port.Protocol)
-		}
 		if wcexists && listenerEntry.protocol == listenerOpts.port.Protocol {
 			exists = true
-			log.Infof("wildcard exists for %s", *listenerMapKey)
 			*currentListenerEntry = listenerEntry
 			*listenerMapKey = wilcardListenerMapKey
 		}

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -852,7 +852,9 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundTCPListenerOptsForPort
 		log.Infof("checking wildcard for listener map key %s, exists: %v", *listenerMapKey, exists)
 		*listenerMapKey = listenerKey(actualWildcard, listenerOpts.port.Port)
 		listenerEntry, wcexists := listenerMap[listenerKey(actualWildcard, listenerOpts.port.Port)]
-		log.Infof("listener entry protocol %v listeneropts protocol", listenerEntry.protocol, listenerOpts.port.Protocol)
+		if wcexists {
+			log.Infof("listener entry protocol %v listeneropts protocol", listenerEntry.protocol, listenerOpts.port.Protocol)
+		}
 		if wcexists && listenerEntry.protocol == listenerOpts.port.Protocol {
 			exists = true
 			log.Infof("wildcard exists for %s", *listenerMapKey)

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -850,7 +850,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundTCPListenerOptsForPort
 	// listener with serviceListenAddress in that case.
 	if !exists {
 		log.Infof("checking wildcard for listener map key %s, exists: %v", *listenerMapKey, exists)
-		*listenerMapKey = listenerKey(actualWildcard, listenerOpts.port.Port)
+		wilcardListenerMapKey := listenerKey(actualWildcard, listenerOpts.port.Port)
 		listenerEntry, wcexists := listenerMap[listenerKey(actualWildcard, listenerOpts.port.Port)]
 		if wcexists {
 			log.Infof("listener entry protocol %v listeneropts protocol", listenerEntry.protocol, listenerOpts.port.Protocol)
@@ -859,6 +859,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundTCPListenerOptsForPort
 			exists = true
 			log.Infof("wildcard exists for %s", *listenerMapKey)
 			*currentListenerEntry = listenerEntry
+			*listenerMapKey = wilcardListenerMapKey
 		}
 	}
 	if exists {

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -842,15 +842,20 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundTCPListenerOptsForPort
 	//
 	// Check if this TCP listener conflicts with an existing HTTP listener
 	*currentListenerEntry, exists = listenerMap[*listenerMapKey]
+	log.Infof("listener map key %s, exists: %v", *listenerMapKey, exists)
 
 	// If there is no listener with serviceListenAddress, check if a wildcard bind exists.
 	// This can happen if user specified a restricted service set on this port with wildcard
 	// bind and also adds a catchall('*/*' with no ports) listener. We should not create
 	// listener with serviceListenAddress in that case.
 	if !exists {
+		log.Infof("checking wildcard for listener map key %s, exists: %v", *listenerMapKey, exists)
+		*listenerMapKey = listenerKey(actualWildcard, listenerOpts.port.Port)
 		listenerEntry, wcexists := listenerMap[listenerKey(actualWildcard, listenerOpts.port.Port)]
+		log.Infof("listener entry protocol %v listeneropts protocol", listenerEntry.protocol, listenerOpts.port.Protocol)
 		if wcexists && listenerEntry.protocol == listenerOpts.port.Protocol {
 			exists = true
+			log.Infof("wildcard exists for %s", *listenerMapKey)
 			*currentListenerEntry = listenerEntry
 		}
 	}


### PR DESCRIPTION
When we have the following sidecar
```
spec:
  egress:
  - bind: 0.0.0.0
    hosts:
    - '*/test.testns.svc.cluster.local'
    port:
      name: redis-cluster
      number: 12000
      protocol: REDIS
   - hosts:
    - '*/*'
```
with a port and bind with a non HTTP protocol and a wildcard catchall - we end up creating listener on wildcard because of bind and service address because listener key does not match for TCP. This PR fixes it.


- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [X ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure