### PR TITLE
Drop --bootstrap-version flag

### DIFF
--- a/istio.deps
+++ b/istio.deps
@@ -4,6 +4,6 @@
     "name": "PROXY_REPO_SHA",
     "repoName": "proxy",
     "file": "",
-    "lastStableSHA": "f5051e663f7a20e7b21b515dda1b21f2d291f559"
+    "lastStableSHA": "74393cf764c167b545f32eb895314e624186e5b6"
   }
 ]

--- a/istio.deps
+++ b/istio.deps
@@ -4,6 +4,6 @@
     "name": "PROXY_REPO_SHA",
     "repoName": "proxy",
     "file": "",
-    "lastStableSHA": "74393cf764c167b545f32eb895314e624186e5b6"
+    "lastStableSHA": "f5051e663f7a20e7b21b515dda1b21f2d291f559"
   }
 ]

--- a/pkg/envoy/proxy.go
+++ b/pkg/envoy/proxy.go
@@ -124,7 +124,6 @@ func (e *envoy) args(fname string, epoch int, bootstrapConfig string) []string {
 		"--drain-strategy", "immediate", // Clients are notified as soon as the drain process starts.
 		"--parent-shutdown-time-s", fmt.Sprint(int(convertDuration(e.ParentShutdownDuration) / time.Second)),
 		"--local-address-ip-version", proxyLocalAddressType,
-		"--bootstrap-version", "3",
 		// Reduce default flush interval from 10s to 1s. The access log buffer size is 64k and each log is ~256 bytes
 		// This means access logs will be written once we have ~250 requests, or ever 1s, which ever comes first.
 		// Reducing this to 1s optimizes for UX while retaining performance.

--- a/pkg/envoy/proxy_test.go
+++ b/pkg/envoy/proxy_test.go
@@ -60,7 +60,6 @@ func TestEnvoyArgs(t *testing.T) {
 		"--drain-strategy", "immediate",
 		"--parent-shutdown-time-s", "60",
 		"--local-address-ip-version", "v4",
-		"--bootstrap-version", "3",
 		"--file-flush-interval-msec", "1000",
 		"--disable-hot-restart",
 		"--log-format", "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n\t%v",

--- a/security/pkg/nodeagent/test/setup.go
+++ b/security/pkg/nodeagent/test/setup.go
@@ -116,7 +116,6 @@ func SetupTest(t *testing.T, testID uint16) *Env {
 	// Set up test environment for Proxy
 	proxySetup := envoy.NewTestSetup(testID, t)
 	proxySetup.EnvoyTemplate = string(getDataFromFile(istioEnv.IstioSrc+"/security/pkg/nodeagent/test/testdata/bootstrap.yaml", t))
-	proxySetup.EnvoyParams = []string{"--bootstrap-version", "3"}
 	env.ProxySetup = proxySetup
 	env.OutboundListenerPort = int(proxySetup.Ports().ClientProxyPort)
 	env.InboundListenerPort = int(proxySetup.Ports().ServerProxyPort)


### PR DESCRIPTION
Drop --bootstrap-version flag for envoy binary. Flag has been deprecated https://github.com/envoyproxy/envoy/pull/17724

- [ ] Configuration Infrastructure
- [ ] Docs
- [ x ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ x ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
