### PR TITLE
Rename charts we will publish to help repo

### DIFF
--- a/manifests/charts/istio-cni/Chart.yaml
+++ b/manifests/charts/istio-cni/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-name: istio-cni
+name: cni
 version: 1.1.0
 description: Helm chart for istio-cni components
 keywords:

--- a/manifests/charts/istio-control/istio-discovery/Chart.yaml
+++ b/manifests/charts/istio-control/istio-discovery/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-name: istio-discovery
+name: istiod
 version: 1.2.0
 tillerVersion: ">=2.7.2"
 description: Helm chart for istio control plane

--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: istio-discovery/templates/poddisruptionbudget.yaml
+# Source: istiod/templates/poddisruptionbudget.yaml
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
@@ -19,7 +19,7 @@ spec:
       app: istiod
       istio: pilot
 ---
-# Source: istio-discovery/templates/serviceaccount.yaml
+# Source: istiod/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -29,7 +29,7 @@ metadata:
     app: istiod
     release: istio
 ---
-# Source: istio-discovery/templates/configmap.yaml
+# Source: istiod/templates/configmap.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -56,7 +56,7 @@ data:
     rootNamespace: istio-system
     trustDomain: cluster.local
 ---
-# Source: istio-discovery/templates/istiod-injector-configmap.yaml
+# Source: istiod/templates/istiod-injector-configmap.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -1183,7 +1183,7 @@ data:
           {{ end }}
           {{ end }}
 ---
-# Source: istio-discovery/templates/clusterrole.yaml
+# Source: istiod/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -1283,7 +1283,7 @@ rules:
     resources: ["serviceexports"]
     verbs: ["get", "watch", "list", "create", "delete"]
 ---
-# Source: istio-discovery/templates/reader-clusterrole.yaml
+# Source: istiod/templates/reader-clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -1325,7 +1325,7 @@ rules:
     resources: ["subjectaccessreviews"]
     verbs: ["create"]
 ---
-# Source: istio-discovery/templates/clusterrolebinding.yaml
+# Source: istiod/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -1342,7 +1342,7 @@ subjects:
     name: istiod
     namespace: istio-system
 ---
-# Source: istio-discovery/templates/reader-clusterrolebinding.yaml
+# Source: istiod/templates/reader-clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -1359,7 +1359,7 @@ subjects:
     name: istio-reader-service-account
     namespace: istio-system
 ---
-# Source: istio-discovery/templates/role.yaml
+# Source: istiod/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -1381,7 +1381,7 @@ rules:
   # TODO lock this down to istio-ca-cert if not using the DNS cert mesh config
   verbs: ["create", "get", "watch", "list", "update", "delete"]
 ---
-# Source: istio-discovery/templates/rolebinding.yaml
+# Source: istiod/templates/rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -1399,7 +1399,7 @@ subjects:
     name: istiod
     namespace: istio-system
 ---
-# Source: istio-discovery/templates/service.yaml
+# Source: istiod/templates/service.yaml
 apiVersion: v1
 kind: Service
 metadata:
@@ -1433,7 +1433,7 @@ spec:
     # This avoids default deployment picking the canary
     istio: pilot
 ---
-# Source: istio-discovery/templates/deployment.yaml
+# Source: istiod/templates/deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -1579,7 +1579,7 @@ spec:
           secretName: istio-kubeconfig
           optional: true
 ---
-# Source: istio-discovery/templates/autoscale.yaml
+# Source: istiod/templates/autoscale.yaml
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
@@ -1604,12 +1604,12 @@ spec:
       name: cpu
       targetAverageUtilization: 80
 ---
-# Source: istio-discovery/templates/revision-tags.yaml
+# Source: istiod/templates/revision-tags.yaml
 # Adapted from istio-discovery/templates/mutatingwebhook.yaml
 # Removed paths for legacy and default selectors since a revision tag
 # is inherently created from a specific revision
 ---
-# Source: istio-discovery/templates/telemetryv2_1.10.yaml
+# Source: istiod/templates/telemetryv2_1.10.yaml
 # Note: metadata exchange filter is wasm enabled only in sidecars.
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
@@ -1704,7 +1704,7 @@ spec:
                     local:
                       inline_string: envoy.wasm.metadata_exchange
 ---
-# Source: istio-discovery/templates/telemetryv2_1.10.yaml
+# Source: istiod/templates/telemetryv2_1.10.yaml
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
@@ -1762,7 +1762,7 @@ spec:
               value:
                 protocol: istio-peer-exchange
 ---
-# Source: istio-discovery/templates/telemetryv2_1.10.yaml
+# Source: istiod/templates/telemetryv2_1.10.yaml
 # Note: http stats filter is wasm enabled only in sidecars.
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
@@ -1886,7 +1886,7 @@ spec:
                     local:
                       inline_string: envoy.wasm.stats
 ---
-# Source: istio-discovery/templates/telemetryv2_1.10.yaml
+# Source: istiod/templates/telemetryv2_1.10.yaml
 # Note: tcp stats filter is wasm enabled only in sidecars.
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
@@ -2002,7 +2002,7 @@ spec:
                     local:
                       inline_string: "envoy.wasm.stats"
 ---
-# Source: istio-discovery/templates/telemetryv2_1.11.yaml
+# Source: istiod/templates/telemetryv2_1.11.yaml
 # Note: metadata exchange filter is wasm enabled only in sidecars.
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
@@ -2097,7 +2097,7 @@ spec:
                     local:
                       inline_string: envoy.wasm.metadata_exchange
 ---
-# Source: istio-discovery/templates/telemetryv2_1.11.yaml
+# Source: istiod/templates/telemetryv2_1.11.yaml
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
@@ -2155,7 +2155,7 @@ spec:
               value:
                 protocol: istio-peer-exchange
 ---
-# Source: istio-discovery/templates/telemetryv2_1.11.yaml
+# Source: istiod/templates/telemetryv2_1.11.yaml
 # Note: http stats filter is wasm enabled only in sidecars.
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
@@ -2279,7 +2279,7 @@ spec:
                     local:
                       inline_string: envoy.wasm.stats
 ---
-# Source: istio-discovery/templates/telemetryv2_1.11.yaml
+# Source: istiod/templates/telemetryv2_1.11.yaml
 # Note: tcp stats filter is wasm enabled only in sidecars.
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
@@ -2395,7 +2395,7 @@ spec:
                     local:
                       inline_string: "envoy.wasm.stats"
 ---
-# Source: istio-discovery/templates/telemetryv2_1.12.yaml
+# Source: istiod/templates/telemetryv2_1.12.yaml
 # Note: metadata exchange filter is wasm enabled only in sidecars.
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
@@ -2490,7 +2490,7 @@ spec:
                     local:
                       inline_string: envoy.wasm.metadata_exchange
 ---
-# Source: istio-discovery/templates/telemetryv2_1.12.yaml
+# Source: istiod/templates/telemetryv2_1.12.yaml
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
@@ -2548,7 +2548,7 @@ spec:
               value:
                 protocol: istio-peer-exchange
 ---
-# Source: istio-discovery/templates/telemetryv2_1.12.yaml
+# Source: istiod/templates/telemetryv2_1.12.yaml
 # Note: http stats filter is wasm enabled only in sidecars.
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
@@ -2672,7 +2672,7 @@ spec:
                     local:
                       inline_string: envoy.wasm.stats
 ---
-# Source: istio-discovery/templates/telemetryv2_1.12.yaml
+# Source: istiod/templates/telemetryv2_1.12.yaml
 # Note: tcp stats filter is wasm enabled only in sidecars.
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
@@ -2788,7 +2788,7 @@ spec:
                     local:
                       inline_string: "envoy.wasm.stats"
 ---
-# Source: istio-discovery/templates/mutatingwebhook.yaml
+# Source: istiod/templates/mutatingwebhook.yaml
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:


### PR DESCRIPTION
Before, this name was ~meaningless. With
https://github.com/istio/release-builder/pull/757, this will become the
"API" that users install under. We should use this as an opportunity to
rename.

UX will be:
```
helm install istio/base
helm install istio/istiod
helm install istio/gateway
helm install istio/cni
```
Note: this is a blocker for https://github.com/istio/release-builder/pull/757 to pass