### PR TITLE
fixed composite literal uses unkeyed

### DIFF
--- a/istioctl/cmd/analyze.go
+++ b/istioctl/cmd/analyze.go
@@ -66,8 +66,8 @@ func (f FileParseError) Error() string {
 var (
 	listAnalyzers     bool
 	useKube           bool
-	failureThreshold  = formatting.MessageThreshold{diag.Error} // messages at least this level will generate an error exit code
-	outputThreshold   = formatting.MessageThreshold{diag.Info}  // messages at least this level will be included in the output
+	failureThreshold  = formatting.MessageThreshold{Level: diag.Error} // messages at least this level will generate an error exit code
+	outputThreshold   = formatting.MessageThreshold{Level: diag.Info}  // messages at least this level will be included in the output
 	colorize          bool
 	msgOutputFormat   string
 	meshCfgFile       string

--- a/istioctl/pkg/writer/compare/comparator.go
+++ b/istioctl/pkg/writer/compare/comparator.go
@@ -66,7 +66,7 @@ func NewXdsComparator(w io.Writer, istiodResponses map[string]*xdsapi.DiscoveryR
 	for _, resp := range istiodResponses {
 		if len(resp.Resources) > 0 {
 			c.istiod = &configdump.Wrapper{
-				&adminapi.ConfigDump{
+				ConfigDump: &adminapi.ConfigDump{
 					Configs: resp.Resources,
 				},
 			}


### PR DESCRIPTION
Signed-off-by: WillardHu <wei.hu@daocloud.io>

**Please provide a description of this PR:**

When you add a field to a structure, everything you initialize with unkeyed is destroyed

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
