### PR TITLE
Cleanup regex string

### DIFF
--- a/istioctl/cmd/describe.go
+++ b/istioctl/cmd/describe.go
@@ -634,7 +634,7 @@ func getIstioVirtualServiceNameForSvc(cd *configdump.Wrapper, svc v1.Service, po
 
 	// Starting with recent 1.5.0 builds, the path will include .istio.io.  Handle both.
 	// nolint: gosimple
-	re := regexp.MustCompile("/apis/networking(\\.istio\\.io)?/v1alpha3/namespaces/(?P<namespace>[^/]+)/virtual-service/(?P<name>[^/]+)")
+	re := regexp.MustCompile(`/apis/networking(\.istio\.io)?/v1alpha3/namespaces/(?P<namespace>[^/]+)/virtual-service/(?P<name>[^/]+)`)
 	ss := re.FindStringSubmatch(path)
 	if ss == nil {
 		return "", "", fmt.Errorf("not a VS path: %s", path)
@@ -731,7 +731,7 @@ func getIstioDestinationRuleNameForSvc(cd *configdump.Wrapper, svc v1.Service, p
 
 	// Starting with recent 1.5.0 builds, the path will include .istio.io.  Handle both.
 	// nolint: gosimple
-	re := regexp.MustCompile("/apis/networking(\\.istio\\.io)?/v1alpha3/namespaces/(?P<namespace>[^/]+)/destination-rule/(?P<name>[^/]+)")
+	re := regexp.MustCompile(`/apis/networking(\.istio\.io)?/v1alpha3/namespaces/(?P<namespace>[^/]+)/destination-rule/(?P<name>[^/]+)`)
 	ss := re.FindStringSubmatch(path)
 	if ss == nil {
 		return "", "", fmt.Errorf("not a DR path: %s", path)


### PR DESCRIPTION
…cape twice

Signed-off-by: WillardHu <wei.hu@daocloud.io>

**Please provide a description of this PR:**

use raw string(`...`) with regexp.MustCompile to avoid having to escape twice