### PR TITLE
Allow disabling check for duplicate webhooks based on selectors

### DIFF
--- a/galley/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_test.go
@@ -509,6 +509,17 @@ var testGrid = []testCase{
 		},
 	},
 	{
+		name: "webook skip duplicate selector check",
+		inputFiles: []string{
+			"testdata/webhook.yaml",
+		},
+		analyzer: &webhook.Analyzer{
+			SkipServiceCheck:         true,
+			SkipWebhookSelectorCheck: true,
+		},
+		expected: []message{},
+	},
+	{
 		name: "Route Rule no effect on Ingress",
 		inputFiles: []string{
 			"testdata/virtualservice_route_rule_no_effects_ingress.yaml",

--- a/galley/pkg/config/analysis/analyzers/webhook/webhook.go
+++ b/galley/pkg/config/analysis/analyzers/webhook/webhook.go
@@ -37,7 +37,8 @@ var (
 )
 
 type Analyzer struct {
-	SkipServiceCheck bool
+	SkipServiceCheck         bool
+	SkipWebhookSelectorCheck bool
 }
 
 var _ analysis.Analyzer = &Analyzer{}
@@ -105,21 +106,23 @@ func (a *Analyzer) Analyze(context analysis.Context) {
 	}
 
 	// For each permutation, we check which webhooks it matches. It must match exactly 0 or 1!
-	for _, nl := range namespaceLabels {
-		for _, ol := range objectLabels {
-			matches := sets.NewSet()
-			for name, whs := range webhooks {
-				for _, wh := range whs {
-					if selectorMatches(wh.NamespaceSelector, nl) && selectorMatches(wh.ObjectSelector, ol) {
-						matches.Insert(fmt.Sprintf("%v/%v", name, wh.Name))
+	if !a.SkipWebhookSelectorCheck {
+		for _, nl := range namespaceLabels {
+			for _, ol := range objectLabels {
+				matches := sets.NewSet()
+				for name, whs := range webhooks {
+					for _, wh := range whs {
+						if selectorMatches(wh.NamespaceSelector, nl) && selectorMatches(wh.ObjectSelector, ol) {
+							matches.Insert(fmt.Sprintf("%v/%v", name, wh.Name))
+						}
 					}
 				}
-			}
-			if len(matches) > 1 {
-				for match := range matches {
-					others := matches.Difference(sets.NewSet(match))
-					context.Report(webhookCol, msg.NewInvalidWebhook(resources[match],
-						fmt.Sprintf("Webhook overlaps with others: %v. This may cause injection to occur twice.", others.UnsortedList())))
+				if len(matches) > 1 {
+					for match := range matches {
+						others := matches.Difference(sets.NewSet(match))
+						context.Report(webhookCol, msg.NewInvalidWebhook(resources[match],
+							fmt.Sprintf("Webhook overlaps with others: %v. This may cause injection to occur twice.", others.UnsortedList())))
+					}
 				}
 			}
 		}

--- a/operator/cmd/mesh/install.go
+++ b/operator/cmd/mesh/install.go
@@ -64,6 +64,8 @@ type installArgs struct {
 	skipConfirmation bool
 	// force proceeds even if there are validation errors
 	force bool
+	// skipWebhookSelectorCheck skips check for duplicate webhook configurations
+	skipWebhookSelectorCheck bool
 	// verify after installation
 	verify bool
 	// set is a string with element format "path=value" where path is an IstioOperator path and the value is a
@@ -83,6 +85,7 @@ func addInstallFlags(cmd *cobra.Command, args *installArgs) {
 		"Maximum time to wait for Istio resources in each component to be ready.")
 	cmd.PersistentFlags().BoolVarP(&args.skipConfirmation, "skip-confirmation", "y", false, skipConfirmationFlagHelpStr)
 	cmd.PersistentFlags().BoolVar(&args.force, "force", false, ForceFlagHelpStr)
+	cmd.PersistentFlags().BoolVar(&args.skipWebhookSelectorCheck, "skipWebhookSelectorCheck", false, SkipConfirmationFlagHelpStr)
 	cmd.PersistentFlags().BoolVar(&args.verify, "verify", false, VerifyCRInstallHelpStr)
 	cmd.PersistentFlags().StringArrayVarP(&args.set, "set", "s", nil, setFlagHelpStr)
 	cmd.PersistentFlags().StringVarP(&args.manifestsPath, "charts", "", "", ChartsDeprecatedStr)
@@ -184,7 +187,7 @@ func runApplyCmd(cmd *cobra.Command, rootArgs *rootArgs, iArgs *installArgs, log
 
 	// Detect whether previous installation exists prior to performing the installation.
 	exists := revtag.PreviousInstallExists(context.Background(), kubeClient)
-	iop, err = InstallManifests(iop, iArgs.force, rootArgs.dryRun, restConfig, client, iArgs.readinessTimeout, l)
+	iop, err = InstallManifests(iop, iArgs.force, iArgs.skipWebhookSelectorCheck, rootArgs.dryRun, restConfig, client, iArgs.readinessTimeout, l)
 	if err != nil {
 		return fmt.Errorf("failed to install manifests: %v", err)
 	}
@@ -231,13 +234,14 @@ func runApplyCmd(cmd *cobra.Command, rootArgs *rootArgs, iArgs *installArgs, log
 //  force   validation warnings are written to logger but command is not aborted
 //  dryRun  all operations are done but nothing is written
 // Returns final IstioOperator after installation if successful.
-func InstallManifests(iop *v1alpha12.IstioOperator, force bool, dryRun bool, restConfig *rest.Config, client client.Client,
+func InstallManifests(iop *v1alpha12.IstioOperator, force bool, skipWebhookSelectorCheck bool, dryRun bool, restConfig *rest.Config, client client.Client,
 	waitTimeout time.Duration, l clog.Logger) (*v1alpha12.IstioOperator, error) {
 	// Needed in case we are running a test through this path that doesn't start a new process.
 	cache.FlushObjectCaches()
 	opts := &helmreconciler.Options{
 		DryRun: dryRun, Log: l, WaitTimeout: waitTimeout, ProgressLog: progress.NewLog(),
-		Force: force,
+		Force:                    force,
+		SkipWebhookSelectorCheck: skipWebhookSelectorCheck,
 	}
 	reconciler, err := helmreconciler.NewHelmReconciler(client, restConfig, iop, opts)
 	if err != nil {

--- a/operator/cmd/mesh/root.go
+++ b/operator/cmd/mesh/root.go
@@ -45,13 +45,14 @@ const (
 If set to true, the user is not prompted and a Yes response is assumed in all cases.`
 	filenameFlagHelpStr = `Path to file containing IstioOperator custom resource
 This flag can be specified multiple times to overlay multiple files. Multiple files are overlaid in left to right order.`
-	installationCompleteStr = `Installation complete`
-	ForceFlagHelpStr        = `Proceed even with validation errors.`
-	KubeConfigFlagHelpStr   = `Path to kube config.`
-	ContextFlagHelpStr      = `The name of the kubeconfig context to use.`
-	HubFlagHelpStr          = `The hub for the operator controller image.`
-	TagFlagHelpStr          = `The tag for the operator controller image.`
-	ImagePullSecretsHelpStr = `The imagePullSecrets are used to pull the operator image from the private registry,
+	installationCompleteStr     = `Installation complete`
+	ForceFlagHelpStr            = `Proceed even with validation errors.`
+	SkipConfirmationFlagHelpStr = `Skips webhook selector check for duplicate webhookconfigurations.`
+	KubeConfigFlagHelpStr       = `Path to kube config.`
+	ContextFlagHelpStr          = `The name of the kubeconfig context to use.`
+	HubFlagHelpStr              = `The hub for the operator controller image.`
+	TagFlagHelpStr              = `The tag for the operator controller image.`
+	ImagePullSecretsHelpStr     = `The imagePullSecrets are used to pull the operator image from the private registry,
 could be secret list separated by comma, eg. '--imagePullSecrets imagePullSecret1,imagePullSecret2'`
 	OperatorNamespaceHelpstr = `The namespace the operator controller is installed into.`
 	OperatorRevFlagHelpStr   = `Target revision for the operator.`

--- a/operator/cmd/mesh/upgrade.go
+++ b/operator/cmd/mesh/upgrade.go
@@ -80,6 +80,8 @@ type upgradeArgs struct {
 	skipConfirmation bool
 	// force means directly applying the upgrade without eligibility checks.
 	force bool
+	// skipWebhookSelectorCheck skips check for duplicate webhook configurations
+	skipWebhookSelectorCheck bool
 	// manifestsPath is a path to a charts and profiles directory in the local filesystem, or URL with a release tgz.
 	manifestsPath string
 	// verify verifies control plane health
@@ -100,6 +102,7 @@ func addUpgradeFlags(cmd *cobra.Command, args *upgradeArgs) {
 		"Maximum time to wait for Istio resources in each component to be ready.")
 	cmd.PersistentFlags().BoolVar(&args.force, "force", false,
 		"Apply the upgrade without eligibility checks")
+	cmd.PersistentFlags().BoolVar(&args.skipWebhookSelectorCheck, "skipWebhookSelectorCheck", false, SkipConfirmationFlagHelpStr)
 	cmd.PersistentFlags().StringArrayVarP(&args.set, "set", "s", nil, setFlagHelpStr)
 	cmd.PersistentFlags().StringVarP(&args.manifestsPath, "charts", "", "", ChartsDeprecatedStr)
 	cmd.PersistentFlags().StringVarP(&args.manifestsPath, "manifests", "d", "", ManifestsFlagHelpStr)
@@ -218,7 +221,7 @@ func upgrade(rootArgs *rootArgs, args *upgradeArgs, l clog.Logger) (err error) {
 	waitForConfirmation(args.skipConfirmation || rootArgs.dryRun, l)
 
 	// Apply the Istio Control Plane specs reading from inFilenames to the cluster
-	iop, err := InstallManifests(targetIOP, args.force, rootArgs.dryRun, restConfig, client, args.readinessTimeout, l)
+	iop, err := InstallManifests(targetIOP, args.force, args.skipWebhookSelectorCheck, rootArgs.dryRun, restConfig, client, args.readinessTimeout, l)
 	if err != nil {
 		return fmt.Errorf("failed to apply the Istio Control Plane specs. Error: %v", err)
 	}

--- a/operator/pkg/helmreconciler/reconciler.go
+++ b/operator/pkg/helmreconciler/reconciler.go
@@ -87,7 +87,7 @@ type Options struct {
 	ProgressLog *progress.Log
 	// Force ignores validation errors
 	Force bool
-	// Skips check for duplicate webhook configurations based on label selector
+	// Skips check for duplicate webhook configurations based on label selector.
 	SkipWebhookSelectorCheck bool
 }
 

--- a/operator/pkg/helmreconciler/reconciler.go
+++ b/operator/pkg/helmreconciler/reconciler.go
@@ -87,6 +87,8 @@ type Options struct {
 	ProgressLog *progress.Log
 	// Force ignores validation errors
 	Force bool
+	// Skips check for duplicate webhook configurations based on label selector
+	SkipWebhookSelectorCheck bool
 }
 
 var defaultOptions = &Options{
@@ -561,7 +563,8 @@ func (h *HelmReconciler) analyzeWebhooks(whs []string) error {
 	}
 
 	sa := local.NewSourceAnalyzer(istioConfigSchema.MustGet(), analysis.Combine("webhook", &webhook.Analyzer{
-		SkipServiceCheck: true,
+		SkipServiceCheck:         true,
+		SkipWebhookSelectorCheck: h.opts.SkipWebhookSelectorCheck,
 	}),
 		resource.Namespace(h.iop.Spec.GetNamespace()), resource.Namespace(istioV1Alpha1.Namespace(h.iop.Spec)), nil, true, 30*time.Second)
 	var localWebhookYAMLReaders []local.ReaderSource


### PR DESCRIPTION
**Please provide a description of this PR:**
- This PR adds a flag to enable skipping check for duplicate webhooks based on label selectors


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [x] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
