### PR TITLE
Clean up for simple server

### DIFF
--- a/pilot/pkg/xds/simple.go
+++ b/pilot/pkg/xds/simple.go
@@ -104,12 +104,7 @@ func NewXDS(stop chan struct{}) *SimpleServer {
 	serviceControllers := aggregate.NewController(aggregate.Options{})
 
 	serviceEntryStore := serviceentry.NewServiceDiscovery(configController, s.MemoryConfigStore, ds)
-	serviceEntryRegistry := serviceregistry.Simple{
-		ProviderID:       "External",
-		Controller:       serviceEntryStore,
-		ServiceDiscovery: serviceEntryStore,
-	}
-	serviceControllers.AddRegistry(serviceEntryRegistry)
+	serviceControllers.AddRegistry(serviceEntryStore)
 
 	sd := controllermemory.NewServiceDiscovery(nil)
 	sd.EDSUpdater = ds


### PR DESCRIPTION
**Please provide a description of this PR:**
This is kind of clean up. Since `ServiceEntryStore` is already a registry, no need to convert it to simple registry.   