### PR TITLE
Fixing data race in aggregate controller

### DIFF
--- a/pilot/pkg/serviceregistry/aggregate/controller.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller.go
@@ -180,9 +180,6 @@ func mergeService(dst, src *model.Service, srcRegistry serviceregistry.Instance)
 
 func mergeHostVIPs(dst, src *model.HostVIPs, srcRegistry serviceregistry.Instance) {
 	// Prefer the k8s HostVIPs where possible
-	if srcRegistry.Provider() == provider.Kubernetes || len(dst.Hostname) == 0 {
-		dst.Hostname = src.Hostname
-	}
 	clusterID := srcRegistry.Cluster()
 	if srcRegistry.Provider() == provider.Kubernetes || len(dst.ClusterVIPs.GetAddressesFor(clusterID)) == 0 {
 		newAddresses := src.ClusterVIPs.GetAddressesFor(clusterID)


### PR DESCRIPTION
The aggregate controller performs a merge of service VIPs when it iterates across the service registries. This logic is protected by a mutex. However, we recently added the copying of `hostname` to this logic as well, which is not protected. This shouldn't be needed, however, since the first service should already have the correct hostname.

Fixes #35079

**Please provide a description of this PR:**