### PR TITLE
Add error messages on failure to fetch SDS creds

### DIFF
--- a/pilot/pkg/secrets/kube/secrets.go
+++ b/pilot/pkg/secrets/kube/secrets.go
@@ -193,7 +193,7 @@ func (s *SecretsController) GetCaCert(name, namespace string) (cert []byte, err 
 		// Could not fetch cert, look for secret without -cacert suffix
 		k8sSecret, caCertErr := s.secrets.Lister().Secrets(namespace).Get(strippedName)
 		if caCertErr != nil {
-			return nil, nil
+			return nil, fmt.Errorf("secret %v/%v not found", namespace, strippedName)
 		}
 		return extractRoot(k8sSecret)
 	}
@@ -221,7 +221,7 @@ func hasValue(d map[string][]byte, keys ...string) bool {
 }
 
 // extractKeyAndCert extracts server key, certificate
-func extractKeyAndCert(scrt *v1.Secret) (key, cert []byte, error error) {
+func extractKeyAndCert(scrt *v1.Secret) (key, cert []byte, err error) {
 	if hasValue(scrt.Data, GenericScrtCert, GenericScrtKey) {
 		return scrt.Data[GenericScrtKey], scrt.Data[GenericScrtCert], nil
 	}

--- a/pilot/pkg/secrets/kube/secrets.go
+++ b/pilot/pkg/secrets/kube/secrets.go
@@ -17,6 +17,7 @@ package kube
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -176,52 +177,99 @@ func (s *SecretsController) Authorize(serviceAccount, namespace string) error {
 	return resp
 }
 
-func (s *SecretsController) GetKeyAndCert(name, namespace string) (key []byte, cert []byte) {
+func (s *SecretsController) GetKeyAndCert(name, namespace string) (key []byte, cert []byte, err error) {
 	k8sSecret, err := s.secrets.Lister().Secrets(namespace).Get(name)
 	if err != nil {
-		return nil, nil
+		return nil, nil, fmt.Errorf("secret %v/%v not found", namespace, name)
 	}
 
 	return extractKeyAndCert(k8sSecret)
 }
 
-func (s *SecretsController) GetCaCert(name, namespace string) (cert []byte) {
+func (s *SecretsController) GetCaCert(name, namespace string) (cert []byte, err error) {
 	strippedName := strings.TrimSuffix(name, GatewaySdsCaSuffix)
 	k8sSecret, err := s.secrets.Lister().Secrets(namespace).Get(name)
-	var rootCert []byte
 	if err != nil {
 		// Could not fetch cert, look for secret without -cacert suffix
 		k8sSecret, caCertErr := s.secrets.Lister().Secrets(namespace).Get(strippedName)
 		if caCertErr != nil {
-			return nil
+			return nil, nil
 		}
-		rootCert = extractRoot(k8sSecret)
-	} else {
 		return extractRoot(k8sSecret)
 	}
-	return rootCert
+	return extractRoot(k8sSecret)
+}
+
+func hasKeys(d map[string][]byte, keys ...string) bool {
+	for _, k := range keys {
+		_, f := d[k]
+		if !f {
+			return false
+		}
+	}
+	return true
+}
+
+func hasValue(d map[string][]byte, keys ...string) bool {
+	for _, k := range keys {
+		v := d[k]
+		if len(v) == 0 {
+			return false
+		}
+	}
+	return true
 }
 
 // extractKeyAndCert extracts server key, certificate
-func extractKeyAndCert(scrt *v1.Secret) (key, cert []byte) {
-	if len(scrt.Data[GenericScrtCert]) > 0 {
-		cert = scrt.Data[GenericScrtCert]
-		key = scrt.Data[GenericScrtKey]
-	} else {
-		cert = scrt.Data[TLSSecretCert]
-		key = scrt.Data[TLSSecretKey]
+func extractKeyAndCert(scrt *v1.Secret) (key, cert []byte, error error) {
+	if hasValue(scrt.Data, GenericScrtCert, GenericScrtKey) {
+		return scrt.Data[GenericScrtKey], scrt.Data[GenericScrtCert], nil
 	}
-	return key, cert
+	if hasValue(scrt.Data, TLSSecretCert, TLSSecretKey) {
+		return scrt.Data[TLSSecretKey], scrt.Data[TLSSecretCert], nil
+	}
+	// No cert found. Try to generate a helpful error messsage
+	if hasKeys(scrt.Data, GenericScrtCert, GenericScrtKey) {
+		return nil, nil, fmt.Errorf("found keys %q and %q, but they were empty", GenericScrtCert, GenericScrtKey)
+	}
+	if hasKeys(scrt.Data, TLSSecretCert, TLSSecretKey) {
+		return nil, nil, fmt.Errorf("found keys %q and %q, but they were empty", TLSSecretCert, TLSSecretKey)
+	}
+	found := truncatedKeysMessage(scrt.Data)
+	return nil, nil, fmt.Errorf("found secret, but didn't have expected keys (%s and %s) or (%s and %s); found: %s",
+		GenericScrtCert, GenericScrtKey, TLSSecretCert, TLSSecretKey, found)
+}
+
+func truncatedKeysMessage(data map[string][]byte) string {
+	keys := []string{}
+	for k := range data {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	if len(keys) < 3 {
+		return strings.Join(keys, ", ")
+	}
+	return fmt.Sprintf("%s, and %d more...", strings.Join(keys[:3], ", "), len(keys)-3)
 }
 
 // extractRoot extracts the root certificate
-func extractRoot(scrt *v1.Secret) (cert []byte) {
-	if len(scrt.Data[GenericScrtCaCert]) > 0 {
-		return scrt.Data[GenericScrtCaCert]
-	} else if len(scrt.Data[TLSSecretCaCert]) > 0 {
-		return scrt.Data[TLSSecretCaCert]
+func extractRoot(scrt *v1.Secret) (cert []byte, err error) {
+	if hasValue(scrt.Data, GenericScrtCaCert) {
+		return scrt.Data[GenericScrtCaCert], nil
 	}
-	return nil
+	if hasValue(scrt.Data, TLSSecretCaCert) {
+		return scrt.Data[TLSSecretCaCert], nil
+	}
+	// No cert found. Try to generate a helpful error messsage
+	if hasKeys(scrt.Data, GenericScrtCaCert) {
+		return nil, fmt.Errorf("found key %q, but it was empty", GenericScrtCaCert)
+	}
+	if hasKeys(scrt.Data, TLSSecretCaCert) {
+		return nil, fmt.Errorf("found key %q, but it was empty", TLSSecretCaCert)
+	}
+	found := truncatedKeysMessage(scrt.Data)
+	return nil, fmt.Errorf("found secret, but didn't have expected keys %s or %s; found: %s",
+		GenericScrtCaCert, TLSSecretCaCert, found)
 }
 
 func (s *SecretsController) AddEventHandler(f func(name string, namespace string)) {

--- a/pilot/pkg/secrets/kube/secrets_test.go
+++ b/pilot/pkg/secrets/kube/secrets_test.go
@@ -399,9 +399,9 @@ func TestSecretsControllerMulticluster(t *testing.T) {
 			if tt.cert != string(cert) {
 				t.Errorf("got cert %q, wanted %q", string(cert), tt.cert)
 			}
-			caCert, _ := con.GetCaCert(tt.name, tt.namespace)
+			caCert, err := con.GetCaCert(tt.name, tt.namespace)
 			if tt.caCert != string(caCert) {
-				t.Errorf("got caCert %q, wanted %q", string(caCert), tt.caCert)
+				t.Errorf("got caCert %q, wanted %q with err %v", string(caCert), tt.caCert, err)
 			}
 		})
 	}

--- a/pilot/pkg/secrets/kube/secrets_test.go
+++ b/pilot/pkg/secrets/kube/secrets_test.go
@@ -176,9 +176,10 @@ func TestSecretsController(t *testing.T) {
 			expectedError: "found secret, but didn't have expected keys (cert and key) or (tls.crt and tls.key); found: ca.crt",
 		},
 		{
-			name:          "generic",
-			namespace:     "wrong-namespace",
-			expectedError: `secret wrong-namespace/generic not found`,
+			name:            "generic",
+			namespace:       "wrong-namespace",
+			expectedError:   `secret wrong-namespace/generic not found`,
+			expectedCAError: `secret wrong-namespace/generic not found`,
 		},
 		{
 			name:            "empty-cert",

--- a/pilot/pkg/secrets/kube/secrets_test.go
+++ b/pilot/pkg/secrets/kube/secrets_test.go
@@ -75,6 +75,12 @@ var (
 	tlsMtlsCertSplitCa = makeSecret("tls-mtls-split-cacert", map[string]string{
 		TLSSecretCaCert: "tls-mtls-split-ca",
 	})
+	emptyCert = makeSecret("empty-cert", map[string]string{
+		TLSSecretCert: "", TLSSecretKey: "tls-key",
+	})
+	wrongKeys = makeSecret("wrong-keys", map[string]string{
+		"foo-bar": "my-cert", TLSSecretKey: "tls-key",
+	})
 )
 
 func TestSecretsController(t *testing.T) {
@@ -89,6 +95,8 @@ func TestSecretsController(t *testing.T) {
 		tlsMtlsCert,
 		tlsMtlsCertSplit,
 		tlsMtlsCertSplitCa,
+		emptyCert,
+		wrongKeys,
 	}
 	client := kube.NewFakeClient(secrets...)
 	sc := NewSecretsController(client, "")
@@ -98,39 +106,121 @@ func TestSecretsController(t *testing.T) {
 	})
 	client.RunAndWait(stop)
 	cases := []struct {
-		name      string
-		namespace string
-		cert      string
-		key       string
-		caCert    string
+		name            string
+		namespace       string
+		cert            string
+		key             string
+		caCert          string
+		expectedError   string
+		expectedCAError string
 	}{
-		{"generic", "default", "generic-cert", "generic-key", ""},
-		{"generic-mtls", "default", "generic-mtls-cert", "generic-mtls-key", "generic-mtls-ca"},
-		{"generic-mtls-split", "default", "generic-mtls-split-cert", "generic-mtls-split-key", ""},
-		{"generic-mtls-split-cacert", "default", "", "", "generic-mtls-split-ca"},
+		{
+			name:            "generic",
+			namespace:       "default",
+			cert:            "generic-cert",
+			key:             "generic-key",
+			expectedCAError: "found secret, but didn't have expected keys cacert or ca.crt; found: cert, key",
+		},
+		{
+			name:      "generic-mtls",
+			namespace: "default",
+			cert:      "generic-mtls-cert",
+			key:       "generic-mtls-key",
+			caCert:    "generic-mtls-ca",
+		},
+		{
+			name:            "generic-mtls-split",
+			namespace:       "default",
+			cert:            "generic-mtls-split-cert",
+			key:             "generic-mtls-split-key",
+			expectedCAError: "found secret, but didn't have expected keys cacert or ca.crt; found: cert, key",
+		},
+		{
+			name:          "generic-mtls-split-cacert",
+			namespace:     "default",
+			caCert:        "generic-mtls-split-ca",
+			expectedError: "found secret, but didn't have expected keys (cert and key) or (tls.crt and tls.key); found: cacert",
+		},
 		// The -cacert secret has precedence
-		{"overlap-cacert", "default", "", "", "split-ca"},
-		{"tls", "default", "tls-cert", "tls-key", ""},
-		{"tls-mtls", "default", "tls-mtls-cert", "tls-mtls-key", "tls-mtls-ca"},
-		{"tls-mtls-split", "default", "tls-mtls-split-cert", "tls-mtls-split-key", ""},
-		{"tls-mtls-split-cacert", "default", "", "", "tls-mtls-split-ca"},
-		{"generic", "wrong-namespace", "", "", ""},
+		{
+			name:          "overlap-cacert",
+			namespace:     "default",
+			caCert:        "split-ca",
+			expectedError: "found secret, but didn't have expected keys (cert and key) or (tls.crt and tls.key); found: cacert",
+		},
+		{
+			name:            "tls",
+			namespace:       "default",
+			cert:            "tls-cert",
+			key:             "tls-key",
+			expectedCAError: "found secret, but didn't have expected keys cacert or ca.crt; found: tls.crt, tls.key",
+		},
+		{
+			name:      "tls-mtls",
+			namespace: "default",
+			cert:      "tls-mtls-cert",
+			key:       "tls-mtls-key",
+			caCert:    "tls-mtls-ca",
+		},
+		{
+			name:            "tls-mtls-split",
+			namespace:       "default",
+			cert:            "tls-mtls-split-cert",
+			key:             "tls-mtls-split-key",
+			expectedCAError: "found secret, but didn't have expected keys cacert or ca.crt; found: tls.crt, tls.key",
+		},
+		{
+			name:          "tls-mtls-split-cacert",
+			namespace:     "default",
+			caCert:        "tls-mtls-split-ca",
+			expectedError: "found secret, but didn't have expected keys (cert and key) or (tls.crt and tls.key); found: ca.crt",
+		},
+		{
+			name:          "generic",
+			namespace:     "wrong-namespace",
+			expectedError: `secret wrong-namespace/generic not found`,
+		},
+		{
+			name:            "empty-cert",
+			namespace:       "default",
+			expectedError:   `found keys "tls.crt" and "tls.key", but they were empty`,
+			expectedCAError: "found secret, but didn't have expected keys cacert or ca.crt; found: tls.crt, tls.key",
+		},
+		{
+			name:            "wrong-keys",
+			namespace:       "default",
+			expectedError:   `found secret, but didn't have expected keys (cert and key) or (tls.crt and tls.key); found: foo-bar, tls.key`,
+			expectedCAError: "found secret, but didn't have expected keys cacert or ca.crt; found: foo-bar, tls.key",
+		},
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			key, cert := sc.GetKeyAndCert(tt.name, tt.namespace)
+			key, cert, err := sc.GetKeyAndCert(tt.name, tt.namespace)
 			if tt.key != string(key) {
 				t.Errorf("got key %q, wanted %q", string(key), tt.key)
 			}
 			if tt.cert != string(cert) {
 				t.Errorf("got cert %q, wanted %q", string(cert), tt.cert)
 			}
-			caCert := sc.GetCaCert(tt.name, tt.namespace)
+			if tt.expectedError != errString(err) {
+				t.Errorf("got err %q, wanted %q", errString(err), tt.expectedError)
+			}
+			caCert, err := sc.GetCaCert(tt.name, tt.namespace)
 			if tt.caCert != string(caCert) {
 				t.Errorf("got caCert %q, wanted %q", string(caCert), tt.caCert)
 			}
+			if tt.expectedCAError != errString(err) {
+				t.Errorf("got ca err %q, wanted %q", errString(err), tt.expectedCAError)
+			}
 		})
 	}
+}
+
+func errString(e error) string {
+	if e == nil {
+		return ""
+	}
+	return e.Error()
 }
 
 func allowIdentities(c kube.Client, identities ...string) {
@@ -302,14 +392,14 @@ func TestSecretsControllerMulticluster(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			key, cert := con.GetKeyAndCert(tt.name, tt.namespace)
+			key, cert, _ := con.GetKeyAndCert(tt.name, tt.namespace)
 			if tt.key != string(key) {
 				t.Errorf("got key %q, wanted %q", string(key), tt.key)
 			}
 			if tt.cert != string(cert) {
 				t.Errorf("got cert %q, wanted %q", string(cert), tt.cert)
 			}
-			caCert := con.GetCaCert(tt.name, tt.namespace)
+			caCert, _ := con.GetCaCert(tt.name, tt.namespace)
 			if tt.caCert != string(caCert) {
 				t.Errorf("got caCert %q, wanted %q", string(caCert), tt.caCert)
 			}

--- a/pilot/pkg/secrets/model.go
+++ b/pilot/pkg/secrets/model.go
@@ -17,8 +17,8 @@ package secrets
 import "istio.io/istio/pkg/cluster"
 
 type Controller interface {
-	GetKeyAndCert(name, namespace string) (key []byte, cert []byte)
-	GetCaCert(name, namespace string) (cert []byte)
+	GetKeyAndCert(name, namespace string) (key []byte, cert []byte, err error)
+	GetCaCert(name, namespace string) (cert []byte, err error)
 	Authorize(serviceAccount, namespace string) error
 	AddEventHandler(func(name, namespace string))
 }


### PR DESCRIPTION
Before:
```
failed to fetch key and certificate for kubernetes://sds-credential
```

After (various error states):
```
failed to fetch key and certificate for kubernetes://sds-credential: secret "sds-credential" not found
failed to fetch key and certificate for kubernetes://sds-credential: found keys "tls.crt" and "tls.key", but they were empty
failed to fetch key and certificate for kubernetes://sds-credential: found secret, but didn't have expected keys (cert and key) or (tls.crt and tls.key); found: tls.crt
```
