### PR TITLE
fix incorrect use of fmt placeholder

### DIFF
--- a/cni/pkg/plugin/plugin_test.go
+++ b/cni/pkg/plugin/plugin_test.go
@@ -283,7 +283,7 @@ func TestCmdAddTwoContainersWithEmptyInboundPort(t *testing.T) {
 	}
 	mockIntercept, ok := GetInterceptRuleMgrCtor("mock")().(*mockInterceptRuleMgr)
 	if !ok {
-		t.Fatalf("expect using mockInterceptRuleMgr, actual %v", InterceptRuleMgrTypes["mock"])
+		t.Fatalf("expect using mockInterceptRuleMgr, actual %p", InterceptRuleMgrTypes["mock"])
 	}
 	r := mockIntercept.lastRedirect[len(mockIntercept.lastRedirect)-1]
 	if r.includePorts != "" {
@@ -303,7 +303,7 @@ func TestCmdAddTwoContainersWithEmptyExcludeInboundPort(t *testing.T) {
 	}
 	mockIntercept, ok := GetInterceptRuleMgrCtor("mock")().(*mockInterceptRuleMgr)
 	if !ok {
-		t.Fatalf("expect using mockInterceptRuleMgr, actual %v", InterceptRuleMgrTypes["mock"])
+		t.Fatalf("expect using mockInterceptRuleMgr, actual %p", InterceptRuleMgrTypes["mock"])
 	}
 	r := mockIntercept.lastRedirect[len(mockIntercept.lastRedirect)-1]
 	if r.excludeInboundPorts != "15020,15021,15090" {
@@ -323,7 +323,7 @@ func TestCmdAddTwoContainersWithExplictExcludeInboundPort(t *testing.T) {
 	}
 	mockIntercept, ok := GetInterceptRuleMgrCtor("mock")().(*mockInterceptRuleMgr)
 	if !ok {
-		t.Fatalf("expect using mockInterceptRuleMgr, actual %v", InterceptRuleMgrTypes["mock"])
+		t.Fatalf("expect using mockInterceptRuleMgr, actual %p", InterceptRuleMgrTypes["mock"])
 	}
 	r := mockIntercept.lastRedirect[len(mockIntercept.lastRedirect)-1]
 	if r.excludeInboundPorts != "3306,15020,15021,15090" {


### PR DESCRIPTION
**Please provide a description of this PR:**

The placeholder `%v` parameter is a function, we should use `%p` to print the pointer.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [x] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
