### PR TITLE
ServiceEntry use port map to make instances of pod

### DIFF
--- a/pilot/pkg/serviceregistry/serviceentry/servicediscovery.go
+++ b/pilot/pkg/serviceregistry/serviceentry/servicediscovery.go
@@ -451,7 +451,7 @@ func (s *ServiceEntryStore) WorkloadInstanceHandler(wi *model.WorkloadInstance, 
 			// Not a match, skip this one
 			continue
 		}
-		instance := convertWorkloadInstanceToServiceInstance(wi.Endpoint, se.services, se.entry)
+		instance := convertWorkloadInstanceToServiceInstance(wi, se.services, se.entry)
 		instances = append(instances, instance...)
 		if addressToDelete != "" {
 			for _, i := range instance {
@@ -705,7 +705,7 @@ func (s *ServiceEntryStore) maybeRefreshIndexes() {
 				// Not a match, skip this one
 				continue
 			}
-			instance := convertWorkloadInstanceToServiceInstance(workloadInstance.Endpoint, se.services, se.entry)
+			instance := convertWorkloadInstanceToServiceInstance(workloadInstance, se.services, se.entry)
 			instances = append(instances, instance...)
 		}
 		updateInstances(key, instances, instanceMap, ip2instances)

--- a/pilot/pkg/serviceregistry/serviceentry/servicediscovery_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/servicediscovery_test.go
@@ -876,7 +876,7 @@ func TestServiceDiscoveryWorkloadInstance(t *testing.T) {
 		expectEvents(t, events, Event{kind: "eds", host: "selector.com", namespace: selector.Namespace, endpoints: 0})
 
 		// Add a workload instance, and use port map
-		fi1.PortMap = map[string]uint32 {"tcp-444": 4444, "http-445": 4445}
+		fi1.PortMap = map[string]uint32{"tcp-444": 4444, "http-445": 4445}
 		defer func() { fi1.PortMap = nil }()
 		callInstanceHandlers([]*model.WorkloadInstance{fi1}, sd, model.EventAdd, t)
 		instances = []*model.ServiceInstance{


### PR DESCRIPTION
Signed-off-by: pangshaoqiang <pangsq9413@gmail.com>

**Please provide a description of this PR:**

For now, serviceEntry use port map to make instances of workloadEntries but does not use port map to make instances of pods.
This pr aims to let serviceEntry can use port names when selecting pod's ports as its instances. 