### PR TITLE
Fix pushqueue memory leak

### DIFF
--- a/pilot/pkg/xds/pushqueue.go
+++ b/pilot/pkg/xds/pushqueue.go
@@ -88,7 +88,11 @@ func (p *PushQueue) Dequeue() (con *Connection, request *model.PushRequest, shut
 		return nil, nil, true
 	}
 
-	con, p.queue = p.queue[0], p.queue[1:]
+	con = p.queue[0]
+	// The underlying array will still exist, despite the slice changing, so the object may not GC without this
+	// See https://github.com/grpc/grpc-go/issues/4758
+	p.queue[0] = nil
+	p.queue = p.queue[1:]
 
 	request = p.pending[con]
 	delete(p.pending, con)

--- a/pilot/pkg/xds/pushqueue_test.go
+++ b/pilot/pkg/xds/pushqueue_test.go
@@ -26,6 +26,7 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/gvk"
+	"istio.io/istio/tests/util/leak"
 )
 
 // Helper function to remove an item or timeout and return nil if there are no pending pushes
@@ -368,4 +369,16 @@ func TestProxyQueue(t *testing.T) {
 			t.Fatalf("expected order %v, but got %v", expected, processed)
 		}
 	})
+}
+
+// TestPushQueueLeak is a regression test for https://github.com/grpc/grpc-go/issues/4758
+func TestPushQueueLeak(t *testing.T) {
+	ds := NewFakeDiscoveryServer(t, FakeOptions{})
+	p := ds.ConnectADS()
+	p.RequestResponseAck(t, nil)
+	for _, c := range ds.Discovery.AllClients() {
+		leak.MustGarbageCollect(t, c)
+	}
+	ds.Discovery.startPush(&model.PushRequest{})
+	p.Cleanup()
 }

--- a/pkg/queue/instance.go
+++ b/pkg/queue/instance.go
@@ -79,8 +79,11 @@ func (q *queueImpl) Run(stop <-chan struct{}) {
 			return
 		}
 
-		var task Task
-		task, q.tasks = q.tasks[0], q.tasks[1:]
+		task := q.tasks[0]
+		// Slicing will not free the underlying elements of the array, so explicitly clear them out here
+		q.tasks[0] = nil
+		q.tasks = q.tasks[1:]
+
 		q.cond.L.Unlock()
 
 		if err := task(); err != nil {

--- a/releasenotes/notes/pq-memory-leak.yaml
+++ b/releasenotes/notes/pq-memory-leak.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+releaseNotes:
+- |
+  **Fixed** an issue causing memory to not be freed after XDS clients disconnect.


### PR DESCRIPTION
Currently, the queue has a memory leak. This leads to retaining
Connection objects after the proxy has disconnected. This object
includes references to PushContext, gRPC rw buffers (100kb), and can
store the DiscoveryResp/DiscoveryRequest as well. Overall, this adds up
a LOT - in many cases memory usage over 2gb wasted.

https://github.com/grpc/grpc-go/issues/4758 discusses this a bit more in
depth.

The root cause is the queue using `slice[1:]`. While this moves the
slice, it the underlying array may still store a reference to the
`Connection` at (formerly) `slice[0]`. This will get freed only if the
slice is completely copied to a new array (during an append, for
example), allowing the underlying array to be freed.

Before (memory not freed after client disconnect):
![](https://user-images.githubusercontent.com/623453/132927871-3859848f-e085-48f3-8146-d6a86f07a83e.png)
After (memory freed after client disconnect):
![2021-13-09_11-02-02](https://user-images.githubusercontent.com/623453/133133860-8f967f49-1414-433a-b9fc-e79fc4ed3984.png)
