### PR TITLE
make use of new Listener.bind_to_port

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/listener_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_builder.go
@@ -21,7 +21,7 @@ import (
 	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	tcp "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
 	envoytype "github.com/envoyproxy/go-control-plane/envoy/type/v3"
-	wellknown "github.com/envoyproxy/go-control-plane/pkg/wellknown"
+	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	golangproto "github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -100,18 +100,12 @@ func amendFilterChainMatchFromInboundListener(chain *listener.FilterChain, l *li
 }
 
 func isBindtoPort(l *listener.Listener) bool {
-	// nolint: staticcheck
-	v1 := l.GetDeprecatedV1()
+	v1 := l.GetBindToPort()
 	if v1 == nil {
 		// Default is true
 		return true
 	}
-	bp := v1.BindToPort
-	if bp == nil {
-		// Default is true
-		return true
-	}
-	return bp.Value
+	return v1.GetValue()
 }
 
 // enabledInspector captures if for a given listener, listener filter inspectors are added


### PR DESCRIPTION
**Please provide a description of this PR:**

Envoy 1.17 `listener: added the Listener.bind_to_port field.`

https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.17.0


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
