### PR TITLE
Skip security tests that fail in multicluter and external-controlplane topologies

### DIFF
--- a/tests/integration/security/ca_custom_root/secure_naming_test.go
+++ b/tests/integration/security/ca_custom_root/secure_naming_test.go
@@ -107,7 +107,7 @@ func TestSecureNaming(t *testing.T) {
 		Features("security.peer.secure-naming").
 		Run(func(t framework.TestContext) {
 			// TODO https://github.com/istio/istio/issues/32292
-			if t.Clusters().IsMulticluster() || t.Clusters().Default().Primary().IsExternalControlPlane() {
+			if t.AllClusters().IsMulticluster() {
 				t.Skip()
 			}
 			istioCfg := istio.DefaultConfigOrFail(t, t)

--- a/tests/integration/security/ca_custom_root/secure_naming_test.go
+++ b/tests/integration/security/ca_custom_root/secure_naming_test.go
@@ -107,7 +107,7 @@ func TestSecureNaming(t *testing.T) {
 		Features("security.peer.secure-naming").
 		Run(func(t framework.TestContext) {
 			// TODO https://github.com/istio/istio/issues/32292
-			if t.Clusters().IsMulticluster() {
+			if t.Clusters().IsMulticluster() || t.Clusters().Default().Primary().IsExternalControlPlane() {
 				t.Skip()
 			}
 			istioCfg := istio.DefaultConfigOrFail(t, t)

--- a/tests/integration/security/ca_custom_root/trust_domain_alias_secure_naming_test.go
+++ b/tests/integration/security/ca_custom_root/trust_domain_alias_secure_naming_test.go
@@ -70,7 +70,7 @@ func TestTrustDomainAliasSecureNaming(t *testing.T) {
 		Features("security.peer.trust-domain-alias-secure-naming").
 		Run(func(t framework.TestContext) {
 			// TODO: https://github.com/istio/istio/issues/32292
-			if t.Clusters().IsMulticluster() || t.Clusters().Default().Primary().IsExternalControlPlane() {
+			if t.AllClusters().IsMulticluster() {
 				t.Skip()
 			}
 			testNS := apps.Namespace

--- a/tests/integration/security/ca_custom_root/trust_domain_alias_secure_naming_test.go
+++ b/tests/integration/security/ca_custom_root/trust_domain_alias_secure_naming_test.go
@@ -70,7 +70,7 @@ func TestTrustDomainAliasSecureNaming(t *testing.T) {
 		Features("security.peer.trust-domain-alias-secure-naming").
 		Run(func(t framework.TestContext) {
 			// TODO: https://github.com/istio/istio/issues/32292
-			if t.Clusters().IsMulticluster() {
+			if t.Clusters().IsMulticluster() || t.Clusters().Default().Primary().IsExternalControlPlane() {
 				t.Skip()
 			}
 			testNS := apps.Namespace

--- a/tests/integration/security/ca_custom_root/trust_domain_validation_test.go
+++ b/tests/integration/security/ca_custom_root/trust_domain_validation_test.go
@@ -94,7 +94,7 @@ func TestTrustDomainValidation(t *testing.T) {
 	framework.NewTest(t).Features("security.peer.trust-domain-validation").Run(
 		func(ctx framework.TestContext) {
 			// TODO https://github.com/istio/istio/issues/32294
-			if ctx.Clusters().IsMulticluster() || ctx.Clusters().Default().Primary().IsExternalControlPlane() {
+			if ctx.AllClusters().IsMulticluster() {
 				ctx.Skip()
 			}
 

--- a/tests/integration/security/ca_custom_root/trust_domain_validation_test.go
+++ b/tests/integration/security/ca_custom_root/trust_domain_validation_test.go
@@ -94,7 +94,7 @@ func TestTrustDomainValidation(t *testing.T) {
 	framework.NewTest(t).Features("security.peer.trust-domain-validation").Run(
 		func(ctx framework.TestContext) {
 			// TODO https://github.com/istio/istio/issues/32294
-			if ctx.Clusters().IsMulticluster() {
+			if ctx.Clusters().IsMulticluster() || ctx.Clusters().Default().Primary().IsExternalControlPlane() {
 				ctx.Skip()
 			}
 


### PR DESCRIPTION
**Please provide a description of this PR:**

These three tests, which fail in a multicluster topology, are also failing with a remoteistiod topology. Same errors as described in the open issues referenced in the TODO comments.