### PR TITLE
Benchmark and optimize PushRequest

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -327,6 +327,7 @@ type PushRequest struct {
 
 type TriggerReason string
 
+// If adding a new reason, update xds/monitoring.go:triggerMetric
 const (
 	// EndpointUpdate describes a push triggered by an Endpoint change
 	EndpointUpdate TriggerReason = "endpoint"

--- a/pilot/pkg/xds/monitoring.go
+++ b/pilot/pkg/xds/monitoring.go
@@ -202,9 +202,29 @@ func recordXDSClients(version string, delta float64) {
 	xdsClients.With(versionTag.Value(version)).Record(xdsClientTracker[version])
 }
 
+// triggerMetric is a precomputed monitoring.Metric for each trigger type. This saves on a lot of allocations
+var triggerMetric = map[model.TriggerReason]monitoring.Metric{
+	model.EndpointUpdate:  pushTriggers.With(typeTag.Value(string(model.EndpointUpdate))),
+	model.ConfigUpdate:    pushTriggers.With(typeTag.Value(string(model.ConfigUpdate))),
+	model.ServiceUpdate:   pushTriggers.With(typeTag.Value(string(model.ServiceUpdate))),
+	model.ProxyUpdate:     pushTriggers.With(typeTag.Value(string(model.ProxyUpdate))),
+	model.GlobalUpdate:    pushTriggers.With(typeTag.Value(string(model.GlobalUpdate))),
+	model.UnknownTrigger:  pushTriggers.With(typeTag.Value(string(model.UnknownTrigger))),
+	model.DebugTrigger:    pushTriggers.With(typeTag.Value(string(model.DebugTrigger))),
+	model.SecretTrigger:   pushTriggers.With(typeTag.Value(string(model.SecretTrigger))),
+	model.NetworksTrigger: pushTriggers.With(typeTag.Value(string(model.NetworksTrigger))),
+	model.ProxyRequest:    pushTriggers.With(typeTag.Value(string(model.ProxyRequest))),
+	model.NamespaceUpdate: pushTriggers.With(typeTag.Value(string(model.NamespaceUpdate))),
+}
+
 func recordPushTriggers(reasons ...model.TriggerReason) {
 	for _, r := range reasons {
-		pushTriggers.With(typeTag.Value(string(r))).Increment()
+		t, f := triggerMetric[r]
+		if f {
+			t.Increment()
+		} else {
+			pushTriggers.With(typeTag.Value(string(r))).Increment()
+		}
 	}
 }
 


### PR DESCRIPTION
While this is a seemingly innocent code path, it shows up in pprof's a lot - like 5-10%+ of CPU and allocs.

```
name           old time/op    new time/op    delta
PushRequest-6    6.15ms ± 1%    5.42ms ± 8%  -11.87%  (p=0.002 n=6+6)

name           old alloc/op   new alloc/op   delta
PushRequest-6    4.24MB ± 0%    3.48MB ± 0%  -17.94%  (p=0.002 n=6+6)

name           old allocs/op  new allocs/op  delta
PushRequest-6     85.1k ± 0%     60.1k ± 0%  -29.39%  (p=0.000 n=5+6)
```

This will get faster with the fixes in https://github.com/census-instrumentation/opencensus-go/issues/1265 as well