### PR TITLE
perf: reuse PushRequest object during Merge

### DIFF
--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -113,9 +113,13 @@ func TestMergeUpdateRequest(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			got := tt.left.Merge(tt.right)
+			got := tt.left.CopyMerge(tt.right)
 			if !reflect.DeepEqual(&tt.merged, got) {
-				t.Fatalf("expected %v, got %v: %v", &tt.merged, got, cmp.Diff(&tt.merged, got))
+				t.Fatalf("expected %v, got %v", &tt.merged, got)
+			}
+			got = tt.left.Merge(tt.right)
+			if !reflect.DeepEqual(&tt.merged, got) {
+				t.Fatalf("expected %v, got %v", &tt.merged, got)
 			}
 		})
 	}
@@ -126,7 +130,7 @@ func TestConcurrentMerge(t *testing.T) {
 	reqB := &PushRequest{Reason: []TriggerReason{ServiceUpdate, ProxyUpdate}}
 	for i := 0; i < 50; i++ {
 		go func() {
-			reqA.Merge(reqB)
+			reqA.CopyMerge(reqB)
 		}()
 	}
 	if len(reqA.Reason) != 0 {

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -107,7 +107,7 @@ func TestMergeUpdateRequest(t *testing.T) {
 			&PushRequest{Full: true, ConfigsUpdated: map[ConfigKey]struct{}{{
 				Kind: config.GroupVersionKind{Kind: "cfg2"},
 			}: {}}},
-			PushRequest{Full: true, ConfigsUpdated: nil, Reason: []TriggerReason{}},
+			PushRequest{Full: true, ConfigsUpdated: nil, Reason: nil},
 		},
 	}
 
@@ -115,7 +115,7 @@ func TestMergeUpdateRequest(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.left.Merge(tt.right)
 			if !reflect.DeepEqual(&tt.merged, got) {
-				t.Fatalf("expected %v, got %v", &tt.merged, got)
+				t.Fatalf("expected %v, got %v: %v", &tt.merged, got, cmp.Diff(&tt.merged, got))
 			}
 		})
 	}

--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -752,7 +752,7 @@ func (s *DiscoveryServer) pushConnection(con *Connection, pushEv *Event) error {
 			totalDelayedPushes.With(typeTag.Value(v3.GetMetricType(w.TypeUrl))).Increment()
 			log.Debugf("%s: QUEUE for node:%s", v3.GetShortType(w.TypeUrl), con.proxy.ID)
 			con.proxy.Lock()
-			con.blockedPushes[w.TypeUrl] = con.blockedPushes[w.TypeUrl].Merge(pushEv.pushRequest)
+			con.blockedPushes[w.TypeUrl] = con.blockedPushes[w.TypeUrl].CopyMerge(pushEv.pushRequest)
 			con.proxy.Unlock()
 		}
 	}

--- a/pilot/pkg/xds/delta.go
+++ b/pilot/pkg/xds/delta.go
@@ -179,7 +179,7 @@ func (s *DiscoveryServer) pushConnectionDelta(con *Connection, pushEv *Event) er
 			totalDelayedPushes.With(typeTag.Value(v3.GetMetricType(w.TypeUrl))).Increment()
 			log.Debugf("%s: QUEUE for node:%s", v3.GetShortType(w.TypeUrl), con.proxy.ID)
 			con.proxy.Lock()
-			con.blockedPushes[w.TypeUrl] = con.blockedPushes[w.TypeUrl].Merge(pushEv.pushRequest)
+			con.blockedPushes[w.TypeUrl] = con.blockedPushes[w.TypeUrl].CopyMerge(pushEv.pushRequest)
 			con.proxy.Unlock()
 		}
 	}

--- a/pilot/pkg/xds/pushqueue.go
+++ b/pilot/pkg/xds/pushqueue.go
@@ -58,12 +58,12 @@ func (p *PushQueue) Enqueue(con *Connection, pushRequest *model.PushRequest) {
 
 	// If its already in progress, merge the info and return
 	if request, f := p.processing[con]; f {
-		p.processing[con] = request.Merge(pushRequest)
+		p.processing[con] = request.CopyMerge(pushRequest)
 		return
 	}
 
 	if request, f := p.pending[con]; f {
-		p.pending[con] = request.Merge(pushRequest)
+		p.pending[con] = request.CopyMerge(pushRequest)
 		return
 	}
 


### PR DESCRIPTION
On a cluster with ~10k configs (svcs, eps, etc):
Before: `All caches have been synced up in 7.978471048s, marking server ready`
After: `All caches have been synced up in 2.101581551s, marking server ready`

Currently all usages already are safe, so mutation should not cause any issue.

This is so much faster mostly because ConfigUpdates; before we are allocating a ton of maps