### PR TITLE
Add portforward to operator ClusterRole

### DIFF
--- a/manifests/charts/istio-operator/files/gen-operator.yaml
+++ b/manifests/charts/istio-operator/files/gen-operator.yaml
@@ -115,6 +115,7 @@ rules:
   - namespaces
   - pods
   - pods/proxy
+  - pods/portforward
   - persistentvolumeclaims
   - secrets
   - services

--- a/manifests/charts/istio-operator/templates/clusterrole.yaml
+++ b/manifests/charts/istio-operator/templates/clusterrole.yaml
@@ -106,6 +106,7 @@ rules:
   - namespaces
   - pods
   - pods/proxy
+  - pods/portforward
   - persistentvolumeclaims
   - secrets
   - services


### PR DESCRIPTION
Signed-off-by: Tong Li <litong01@us.ibm.com>

**Please provide a description of this PR:**
When revision is used, while delete istio resources, the operator will use GetProxyInfo to retrieve resource information, it will need the pods/portforward resource to be in the clusterrole. Without it, the method fails, and the reconciler goes into infinite loop. This PR fixes issue/#35016