### PR TITLE
Revert "Bump addon versions"

### DIFF
--- a/manifests/addons/gen.sh
+++ b/manifests/addons/gen.sh
@@ -30,7 +30,7 @@ TMP=$(mktemp -d)
 {
 helm3 template kiali-server \
   --namespace istio-system \
-  --version 1.40.0 \
+  --version 1.38.0 \
   --include-crds \
   --set nameOverride=kiali \
   --set fullnameOverride=kiali \
@@ -42,7 +42,7 @@ helm3 template kiali-server \
 # Set up prometheus
 helm3 template prometheus prometheus \
   --namespace istio-system \
-  --version 14.6.1 \
+  --version 14.3.0 \
   --repo https://prometheus-community.github.io/helm-charts \
   -f "${WD}/values-prometheus.yaml" \
   > "${ADDONS}/prometheus.yaml"
@@ -55,7 +55,7 @@ function compressDashboard() {
 {
   helm3 template grafana grafana \
     --namespace istio-system \
-    --version 6.16.6 \
+    --version 6.11.0 \
     --repo https://grafana.github.io/helm-charts \
     -f "${WD}/values-grafana.yaml"
 

--- a/samples/addons/grafana.yaml
+++ b/samples/addons/grafana.yaml
@@ -4,10 +4,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    helm.sh/chart: grafana-6.16.6
+    helm.sh/chart: grafana-6.11.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: grafana
-    app.kubernetes.io/version: "8.1.2"
+    app.kubernetes.io/version: "7.5.5"
     app.kubernetes.io/managed-by: Helm
   name: grafana
   namespace: istio-system
@@ -19,10 +19,10 @@ metadata:
   name: grafana
   namespace: istio-system
   labels:
-    helm.sh/chart: grafana-6.16.6
+    helm.sh/chart: grafana-6.11.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: grafana
-    app.kubernetes.io/version: "8.1.2"
+    app.kubernetes.io/version: "7.5.5"
     app.kubernetes.io/managed-by: Helm
 data:
   grafana.ini: |
@@ -75,10 +75,10 @@ metadata:
   name: grafana
   namespace: istio-system
   labels:
-    helm.sh/chart: grafana-6.16.6
+    helm.sh/chart: grafana-6.11.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: grafana
-    app.kubernetes.io/version: "8.1.2"
+    app.kubernetes.io/version: "7.5.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -99,10 +99,10 @@ metadata:
   name: grafana
   namespace: istio-system
   labels:
-    helm.sh/chart: grafana-6.16.6
+    helm.sh/chart: grafana-6.11.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: grafana
-    app.kubernetes.io/version: "8.1.2"
+    app.kubernetes.io/version: "7.5.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -121,21 +121,19 @@ spec:
         app: grafana
         sidecar.istio.io/inject: "false"
       annotations:
-        checksum/config: 0db0166dec9b75eb6486494512ab843bc085e0806457bc09e92597a418a115ae
+        checksum/config: af4530cc6e67e63b6285f3ceccaf0aaa2a20d322e35c9f0ae48721add3b58eb0
         checksum/dashboards-json-config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
         checksum/sc-dashboard-provider-config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
     spec:
       
       serviceAccountName: grafana
-      automountServiceAccountToken: true
       securityContext:
         fsGroup: 472
         runAsGroup: 472
         runAsUser: 472
-      enableServiceLinks: true
       containers:
         - name: grafana
-          image: "grafana/grafana:8.1.2"
+          image: "grafana/grafana:7.5.5"
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: config
@@ -149,10 +147,10 @@ spec:
               mountPath: "/var/lib/grafana/dashboards/istio-services"
             - name: config
               mountPath: "/etc/grafana/provisioning/datasources/datasources.yaml"
-              subPath: "datasources.yaml"
+              subPath: datasources.yaml
             - name: config
               mountPath: "/etc/grafana/provisioning/dashboards/dashboardproviders.yaml"
-              subPath: "dashboardproviders.yaml"
+              subPath: dashboardproviders.yaml
           ports:
             - name: service
               containerPort: 3000

--- a/samples/addons/kiali.yaml
+++ b/samples/addons/kiali.yaml
@@ -6,12 +6,12 @@ metadata:
   name: kiali
   namespace: istio-system
   labels:
-    helm.sh/chart: kiali-server-1.40.0
+    helm.sh/chart: kiali-server-1.38.0
     app: kiali
     app.kubernetes.io/name: kiali
     app.kubernetes.io/instance: kiali
-    version: "v1.40.0"
-    app.kubernetes.io/version: "v1.40.0"
+    version: "v1.38.0"
+    app.kubernetes.io/version: "v1.38.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: "kiali"
 ...
@@ -23,12 +23,12 @@ metadata:
   name: kiali
   namespace: istio-system
   labels:
-    helm.sh/chart: kiali-server-1.40.0
+    helm.sh/chart: kiali-server-1.38.0
     app: kiali
     app.kubernetes.io/name: kiali
     app.kubernetes.io/instance: kiali
-    version: "v1.40.0"
-    app.kubernetes.io/version: "v1.40.0"
+    version: "v1.38.0"
+    app.kubernetes.io/version: "v1.38.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: "kiali"
 data:
@@ -74,7 +74,7 @@ data:
       service_annotations: {}
       service_type: ""
       tolerations: []
-      version_label: v1.40.0
+      version_label: v1.38.0
       view_only_mode: false
     external_services:
       custom_dashboards:
@@ -83,14 +83,6 @@ data:
       cert_file: ""
       private_key_file: ""
     istio_namespace: istio-system
-    kiali_feature_flags:
-      certificates_information_indicators:
-        enabled: true
-        secrets:
-        - cacerts
-        - istio-ca-secret
-      clustering:
-        enabled: true
     login_token:
       signing_key: CHANGEME
     server:
@@ -106,12 +98,12 @@ kind: ClusterRole
 metadata:
   name: kiali-viewer
   labels:
-    helm.sh/chart: kiali-server-1.40.0
+    helm.sh/chart: kiali-server-1.38.0
     app: kiali
     app.kubernetes.io/name: kiali
     app.kubernetes.io/instance: kiali
-    version: "v1.40.0"
-    app.kubernetes.io/version: "v1.40.0"
+    version: "v1.38.0"
+    app.kubernetes.io/version: "v1.38.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: "kiali"
 rules:
@@ -203,12 +195,12 @@ kind: ClusterRole
 metadata:
   name: kiali
   labels:
-    helm.sh/chart: kiali-server-1.40.0
+    helm.sh/chart: kiali-server-1.38.0
     app: kiali
     app.kubernetes.io/name: kiali
     app.kubernetes.io/instance: kiali
-    version: "v1.40.0"
-    app.kubernetes.io/version: "v1.40.0"
+    version: "v1.38.0"
+    app.kubernetes.io/version: "v1.38.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: "kiali"
 rules:
@@ -310,12 +302,12 @@ kind: ClusterRoleBinding
 metadata:
   name: kiali
   labels:
-    helm.sh/chart: kiali-server-1.40.0
+    helm.sh/chart: kiali-server-1.38.0
     app: kiali
     app.kubernetes.io/name: kiali
     app.kubernetes.io/instance: kiali
-    version: "v1.40.0"
-    app.kubernetes.io/version: "v1.40.0"
+    version: "v1.38.0"
+    app.kubernetes.io/version: "v1.38.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: "kiali"
 roleRef:
@@ -335,12 +327,12 @@ metadata:
   name: kiali-controlplane
   namespace: istio-system
   labels:
-    helm.sh/chart: kiali-server-1.40.0
+    helm.sh/chart: kiali-server-1.38.0
     app: kiali
     app.kubernetes.io/name: kiali
     app.kubernetes.io/instance: kiali
-    version: "v1.40.0"
-    app.kubernetes.io/version: "v1.40.0"
+    version: "v1.38.0"
+    app.kubernetes.io/version: "v1.38.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: "kiali"
 rules:
@@ -349,16 +341,6 @@ rules:
   - secrets
   verbs:
   - list
-- apiGroups: [""]
-  resourceNames:
-  - cacerts
-  - istio-ca-secret
-  resources:
-  - secrets
-  verbs:
-  - get
-  - list
-  - watch
 ...
 ---
 # Source: kiali-server/templates/rolebinding-controlplane.yaml
@@ -368,12 +350,12 @@ metadata:
   name: kiali-controlplane
   namespace: istio-system
   labels:
-    helm.sh/chart: kiali-server-1.40.0
+    helm.sh/chart: kiali-server-1.38.0
     app: kiali
     app.kubernetes.io/name: kiali
     app.kubernetes.io/instance: kiali
-    version: "v1.40.0"
-    app.kubernetes.io/version: "v1.40.0"
+    version: "v1.38.0"
+    app.kubernetes.io/version: "v1.38.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: "kiali"
 roleRef:
@@ -393,12 +375,12 @@ metadata:
   name: kiali
   namespace: istio-system
   labels:
-    helm.sh/chart: kiali-server-1.40.0
+    helm.sh/chart: kiali-server-1.38.0
     app: kiali
     app.kubernetes.io/name: kiali
     app.kubernetes.io/instance: kiali
-    version: "v1.40.0"
-    app.kubernetes.io/version: "v1.40.0"
+    version: "v1.38.0"
+    app.kubernetes.io/version: "v1.38.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: "kiali"
   annotations:
@@ -422,12 +404,12 @@ metadata:
   name: kiali
   namespace: istio-system
   labels:
-    helm.sh/chart: kiali-server-1.40.0
+    helm.sh/chart: kiali-server-1.38.0
     app: kiali
     app.kubernetes.io/name: kiali
     app.kubernetes.io/instance: kiali
-    version: "v1.40.0"
-    app.kubernetes.io/version: "v1.40.0"
+    version: "v1.38.0"
+    app.kubernetes.io/version: "v1.38.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: "kiali"
 spec:
@@ -445,12 +427,12 @@ spec:
     metadata:
       name: kiali
       labels:
-        helm.sh/chart: kiali-server-1.40.0
+        helm.sh/chart: kiali-server-1.38.0
         app: kiali
         app.kubernetes.io/name: kiali
         app.kubernetes.io/instance: kiali
-        version: "v1.40.0"
-        app.kubernetes.io/version: "v1.40.0"
+        version: "v1.38.0"
+        app.kubernetes.io/version: "v1.38.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: "kiali"
         sidecar.istio.io/inject: "false"

--- a/samples/addons/prometheus.yaml
+++ b/samples/addons/prometheus.yaml
@@ -7,7 +7,7 @@ metadata:
     component: "server"
     app: prometheus
     release: prometheus
-    chart: prometheus-14.6.1
+    chart: prometheus-14.3.0
     heritage: Helm
   name: prometheus
   namespace: istio-system
@@ -22,7 +22,7 @@ metadata:
     component: "server"
     app: prometheus
     release: prometheus
-    chart: prometheus-14.6.1
+    chart: prometheus-14.3.0
     heritage: Helm
   name: prometheus
   namespace: istio-system
@@ -250,7 +250,7 @@ data:
         - __meta_kubernetes_pod_name
         target_label: kubernetes_pod_name
       - action: drop
-        regex: Pending|Succeeded|Failed|Completed
+        regex: Pending|Succeeded|Failed
         source_labels:
         - __meta_kubernetes_pod_phase
     - job_name: kubernetes-pods-slow
@@ -289,7 +289,7 @@ data:
         - __meta_kubernetes_pod_name
         target_label: kubernetes_pod_name
       - action: drop
-        regex: Pending|Succeeded|Failed|Completed
+        regex: Pending|Succeeded|Failed
         source_labels:
         - __meta_kubernetes_pod_phase
       scrape_interval: 5m
@@ -307,7 +307,7 @@ metadata:
     component: "server"
     app: prometheus
     release: prometheus
-    chart: prometheus-14.6.1
+    chart: prometheus-14.3.0
     heritage: Helm
   name: prometheus
 rules:
@@ -349,7 +349,7 @@ metadata:
     component: "server"
     app: prometheus
     release: prometheus
-    chart: prometheus-14.6.1
+    chart: prometheus-14.3.0
     heritage: Helm
   name: prometheus
 subjects:
@@ -369,7 +369,7 @@ metadata:
     component: "server"
     app: prometheus
     release: prometheus
-    chart: prometheus-14.6.1
+    chart: prometheus-14.3.0
     heritage: Helm
   name: prometheus
   namespace: istio-system
@@ -394,7 +394,7 @@ metadata:
     component: "server"
     app: prometheus
     release: prometheus
-    chart: prometheus-14.6.1
+    chart: prometheus-14.3.0
     heritage: Helm
   name: prometheus
   namespace: istio-system
@@ -411,12 +411,11 @@ spec:
         component: "server"
         app: prometheus
         release: prometheus
-        chart: prometheus-14.6.1
+        chart: prometheus-14.3.0
         heritage: Helm
         
         sidecar.istio.io/inject: "false"
     spec:
-      enableServiceLinks: true
       serviceAccountName: prometheus
       containers:
         - name: prometheus-server-configmap-reload


### PR DESCRIPTION
Reverts istio/istio#35196

The original PR causes the https://preliminary.istio.io/latest/docs/tasks/observability/metrics/using-istio-dashboard/ istio.io test to fail, preventing merges in the istio.io master branch.  Part of that test is to do a curl to the dashboard which instead of getting a `200` now gets a `404`:

++access_grafana_istio_mesh_dashboard(): curl -L -s -o /dev/null -w '%{http_code}' http://localhost:3000/dashboard/db/istio-mesh-dashboard
+__verify_with_retry(): out=404

I'm fine not reverting this and updating the test a replacement for the `http://localhost:3000/dashboard/db/istio-mesh-dashboard` can be found for the test case.

A smaller revert of just the `samples/addons/grafana.yaml` might be acceptable, but not sure if that's a good idea or not.