### PR TITLE
Add flag to skip TProxy related parts in test.

### DIFF
--- a/pkg/test/framework/components/echo/echoboot/echoboot.go
+++ b/pkg/test/framework/components/echo/echoboot/echoboot.go
@@ -99,6 +99,10 @@ func (b builder) With(i *echo.Instance, cfg echo.Config) echo.Builder {
 		return b
 	}
 
+	if b.ctx.Settings().SkipTProxy && cfg.IsTProxy() {
+		return b
+	}
+
 	cfg = cfg.DeepCopy()
 	if err := common.FillInDefaults(b.ctx, &cfg); err != nil {
 		b.errs = multierror.Append(b.errs, err)

--- a/pkg/test/framework/resource/flags.go
+++ b/pkg/test/framework/resource/flags.go
@@ -119,6 +119,9 @@ func init() {
 	flag.BoolVar(&settingsFromCommandLine.SkipDelta, "istio.test.skipDelta", settingsFromCommandLine.SkipDelta,
 		"Skip Delta XDS related parts in all tests.")
 
+	flag.BoolVar(&settingsFromCommandLine.SkipTProxy, "istio.test.skipTProxy", settingsFromCommandLine.SkipTProxy,
+		"Skip TProxy related parts in all tests.")
+
 	flag.BoolVar(&settingsFromCommandLine.Compatibility, "istio.test.compatibility", settingsFromCommandLine.Compatibility,
 		"Transparently deploy echo instances pointing to each revision set in `Revisions`")
 

--- a/pkg/test/framework/resource/settings.go
+++ b/pkg/test/framework/resource/settings.go
@@ -85,6 +85,9 @@ type Settings struct {
 	// Skip Delta XDS related parts for all the tests.
 	SkipDelta bool
 
+	// Skip TProxy related parts for all the tests.
+	SkipTProxy bool
+
 	// Compatibility determines whether we should transparently deploy echo workloads attached to each revision
 	// specified in `Revisions` when creating echo instances. Used primarily for compatibility testing between revisions
 	// on different control plane versions.

--- a/tests/integration/pilot/common/apps.go
+++ b/tests/integration/pilot/common/apps.go
@@ -208,12 +208,10 @@ func SetupApps(t resource.Context, i istio.Instance, apps *EchoDeployments) erro
 			WorkloadOnlyPorts: common.WorkloadPorts,
 		}).
 		WithConfig(echo.Config{
-			Service:   PodTproxySvc,
-			Namespace: apps.Namespace,
-			Ports:     common.EchoPorts,
-			Subsets: []echo.SubsetConfig{{
-				Annotations: echo.NewAnnotations().Set(echo.SidecarInterceptionMode, "TPROXY"),
-			}},
+			Service:           PodTproxySvc,
+			Namespace:         apps.Namespace,
+			Ports:             common.EchoPorts,
+			Subsets:           []echo.SubsetConfig{{}},
 			WorkloadOnlyPorts: common.WorkloadPorts,
 		}).
 		WithConfig(echo.Config{

--- a/tests/integration/pilot/common/apps.go
+++ b/tests/integration/pilot/common/apps.go
@@ -208,10 +208,12 @@ func SetupApps(t resource.Context, i istio.Instance, apps *EchoDeployments) erro
 			WorkloadOnlyPorts: common.WorkloadPorts,
 		}).
 		WithConfig(echo.Config{
-			Service:           PodTproxySvc,
-			Namespace:         apps.Namespace,
-			Ports:             common.EchoPorts,
-			Subsets:           []echo.SubsetConfig{{}},
+			Service:   PodTproxySvc,
+			Namespace: apps.Namespace,
+			Ports:     common.EchoPorts,
+			Subsets: []echo.SubsetConfig{{
+				Annotations: echo.NewAnnotations().Set(echo.SidecarInterceptionMode, "TPROXY"),
+			}},
 			WorkloadOnlyPorts: common.WorkloadPorts,
 		}).
 		WithConfig(echo.Config{

--- a/tests/integration/pilot/original_src_addr_test.go
+++ b/tests/integration/pilot/original_src_addr_test.go
@@ -33,6 +33,9 @@ func TestTproxy(t *testing.T) {
 		Features("traffic.original-source-ip").
 		RequiresSingleCluster().
 		Run(func(t framework.TestContext) {
+			if t.Settings().SkipTProxy {
+				t.Skip()
+			}
 			workloads, err := apps.PodA[0].Workloads()
 			if err != nil {
 				t.Errorf("failed to get Subsets: %v", err)


### PR DESCRIPTION
In some env, like GKE autopilot, TProxy mode cannot work (Echo cannot become ready) because NET_ADMIN is disallowed. This follows VM and Delta xDS to add a flag to skip TProxy echo set up and test.