### PR TITLE
add exponential backoff for webhook patch retry

### DIFF
--- a/pkg/queue/instance.go
+++ b/pkg/queue/instance.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff"
+
 	"istio.io/pkg/log"
 )
 
@@ -48,7 +49,7 @@ type queueImpl struct {
 
 func newExponentialBackOff(eb *backoff.ExponentialBackOff) *backoff.ExponentialBackOff {
 	if eb == nil {
-		return eb
+		return nil
 	}
 	teb := backoff.NewExponentialBackOff()
 	teb.InitialInterval = eb.InitialInterval

--- a/pkg/queue/instance.go
+++ b/pkg/queue/instance.go
@@ -18,11 +18,17 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cenkalti/backoff"
 	"istio.io/pkg/log"
 )
 
 // Task to be performed.
 type Task func() error
+
+type BackoffTask struct {
+	task Task
+	eb   *backoff.ExponentialBackOff
+}
 
 // Instance of work tickets processed using a rate-limiting loop
 type Instance interface {
@@ -34,22 +40,39 @@ type Instance interface {
 
 type queueImpl struct {
 	delay   time.Duration
-	tasks   []Task
+	tasks   []*BackoffTask
 	cond    *sync.Cond
 	closing bool
+}
+
+func newExponentialBackOff(delay time.Duration) *backoff.ExponentialBackOff {
+	eb := backoff.NewExponentialBackOff()
+	eb.InitialInterval = delay
+	eb.MaxElapsedTime = 0                          // never elapses.
+	eb.MaxInterval = backoff.DefaultMaxElapsedTime // set max inteerval to 15 mins.
+	return eb
 }
 
 // NewQueue instantiates a queue with a processing function
 func NewQueue(errorDelay time.Duration) Instance {
 	return &queueImpl{
 		delay:   errorDelay,
-		tasks:   make([]Task, 0),
+		tasks:   make([]*BackoffTask, 0),
 		closing: false,
 		cond:    sync.NewCond(&sync.Mutex{}),
 	}
 }
 
 func (q *queueImpl) Push(item Task) {
+	q.cond.L.Lock()
+	defer q.cond.L.Unlock()
+	if !q.closing {
+		q.tasks = append(q.tasks, &BackoffTask{item, newExponentialBackOff(q.delay)})
+	}
+	q.cond.Signal()
+}
+
+func (q *queueImpl) pushRetryTask(item *BackoffTask) {
 	q.cond.L.Lock()
 	defer q.cond.L.Unlock()
 	if !q.closing {
@@ -79,17 +102,17 @@ func (q *queueImpl) Run(stop <-chan struct{}) {
 			return
 		}
 
-		task := q.tasks[0]
+		backoffTask := q.tasks[0]
 		// Slicing will not free the underlying elements of the array, so explicitly clear them out here
 		q.tasks[0] = nil
 		q.tasks = q.tasks[1:]
 
 		q.cond.L.Unlock()
 
-		if err := task(); err != nil {
+		if err := backoffTask.task(); err != nil {
 			log.Infof("Work item handle failed (%v), retry after delay %v", err, q.delay)
-			time.AfterFunc(q.delay, func() {
-				q.Push(task)
+			time.AfterFunc(backoffTask.eb.NextBackOff(), func() {
+				q.pushRetryTask(backoffTask)
 			})
 		}
 	}

--- a/pkg/webhooks/webhookpatch.go
+++ b/pkg/webhooks/webhookpatch.go
@@ -80,7 +80,7 @@ func NewWebhookCertPatcher(
 	retryBackoff.InitialInterval = 2 * time.Second
 	retryBackoff.MaxInterval = 15 * time.Minute // Max Backoff interval.
 	// If certificate has not been patched with in an hour of retries, let us stop retrying.
-	retryBackoff.MaxElapsedTime = 1 * time.Hour
+	retryBackoff.MaxElapsedTime = 0
 	return &WebhookCertPatcher{
 		client:          client,
 		revision:        revision,

--- a/pkg/webhooks/webhookpatch.go
+++ b/pkg/webhooks/webhookpatch.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cenkalti/backoff"
 	v1 "k8s.io/api/admissionregistration/v1"
 	kubeErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -75,12 +76,17 @@ func NewWebhookCertPatcher(
 		func(options *metav1.ListOptions) {
 			options.LabelSelector = fmt.Sprintf("%s=%s", label.IoIstioRev.Name, revision)
 		})
+	retryBackoff := backoff.NewExponentialBackOff()
+	retryBackoff.InitialInterval = 2 * time.Second
+	retryBackoff.MaxInterval = 15 * time.Minute // Max Backoff interval.
+	// If certificate has not been patched with in an hour of retries, let us stop retrying.
+	retryBackoff.MaxElapsedTime = 1 * time.Hour
 	return &WebhookCertPatcher{
 		client:          client,
 		revision:        revision,
 		webhookName:     webhookName,
 		CABundleWatcher: caBundleWatcher,
-		queue:           queue.NewQueue(time.Second * 2),
+		queue:           queue.NewBackOffQueue(retryBackoff),
 		whcLw:           whcLw,
 	}, nil
 }


### PR DESCRIPTION
Recently we had an issue where the root certificate on istiod nodes was inconsistent and as a result of that both istiod instances were competing with each other to update the webhook certificate which resulted in retry loop 
with the following error - spamming k8s api server and almost bringing down etcd.

"Work item handle failed (Operation cannot be fulfilled on mutatingwebhookconfigurations.admissionregistration.k8s.io "istio-sidecar-injector-mesh-control-plane": the object has been modified; please apply your changes to the latest version and try again), retry after delay 2s

This PR adds exponential backoff with random jitter for patching retries so that all istiod instances do not compete with a fixed delay 2s.
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
