### PR TITLE
Fix metadata with wrong plural type

### DIFF
--- a/pkg/config/schema/collections/collections.gen.go
+++ b/pkg/config/schema/collections/collections.gen.go
@@ -302,7 +302,7 @@ var (
 		Resource: resource.Builder{
 			Group:         "admissionregistration.k8s.io",
 			Kind:          "MutatingWebhookConfiguration",
-			Plural:        "MutatingWebhookConfigurations",
+			Plural:        "mutatingwebhookconfigurations",
 			Version:       "v1",
 			Proto:         "k8s.io.api.admissionregistration.v1.MutatingWebhookConfiguration",
 			ReflectType:   reflect.TypeOf(&k8sioapiadmissionregistrationv1.MutatingWebhookConfiguration{}).Elem(),
@@ -339,7 +339,7 @@ var (
 		Resource: resource.Builder{
 			Group:         "apps",
 			Kind:          "Deployment",
-			Plural:        "Deployments",
+			Plural:        "deployments",
 			Version:       "v1",
 			Proto:         "k8s.io.api.apps.v1.Deployment",
 			ReflectType:   reflect.TypeOf(&k8sioapiappsv1.Deployment{}).Elem(),

--- a/pkg/config/schema/metadata.gen.go
+++ b/pkg/config/schema/metadata.gen.go
@@ -318,14 +318,14 @@ resources:
     protoPackage: "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 
   - kind: "MutatingWebhookConfiguration"
-    plural: "MutatingWebhookConfigurations"
+    plural: "mutatingwebhookconfigurations"
     group: "admissionregistration.k8s.io"
     version: "v1"
     proto: "k8s.io.api.admissionregistration.v1.MutatingWebhookConfiguration"
     protoPackage: "k8s.io/api/admissionregistration/v1"
 
   - kind: "Deployment"
-    plural: "Deployments"
+    plural: "deployments"
     group: "apps"
     version: "v1"
     proto: "k8s.io.api.apps.v1.Deployment"

--- a/pkg/config/schema/metadata.yaml
+++ b/pkg/config/schema/metadata.yaml
@@ -263,14 +263,14 @@ resources:
     protoPackage: "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 
   - kind: "MutatingWebhookConfiguration"
-    plural: "MutatingWebhookConfigurations"
+    plural: "mutatingwebhookconfigurations"
     group: "admissionregistration.k8s.io"
     version: "v1"
     proto: "k8s.io.api.admissionregistration.v1.MutatingWebhookConfiguration"
     protoPackage: "k8s.io/api/admissionregistration/v1"
 
   - kind: "Deployment"
-    plural: "Deployments"
+    plural: "deployments"
     group: "apps"
     version: "v1"
     proto: "k8s.io.api.apps.v1.Deployment"


### PR DESCRIPTION
Split out of another PR. This is broken but doesn't impact anything since nothing uses it (yet).

