### PR TITLE
Add Hostname to leader election name for improve visibility

### DIFF
--- a/pilot/pkg/leaderelection/leaderelection.go
+++ b/pilot/pkg/leaderelection/leaderelection.go
@@ -16,6 +16,8 @@ package leaderelection
 
 import (
 	"context"
+	"fmt"
+	"os"
 	"time"
 
 	"go.uber.org/atomic"
@@ -124,7 +126,8 @@ func (l *LeaderElection) AddRunFunction(f func(stop <-chan struct{})) *LeaderEle
 
 func NewLeaderElection(namespace, name, electionID string, client kubernetes.Interface) *LeaderElection {
 	if name == "" {
-		name = "unknown"
+		hn, _ := os.Hostname()
+		name = fmt.Sprintf("unknown-%s", hn)
 	}
 	return &LeaderElection{
 		namespace:  namespace,


### PR DESCRIPTION
This is only used in cases when pod name is not set, to help with
debugging. Typically this would happen in a local dev setting, but could
happen in external control plane.

**Please provide a description of this PR:**