### PR TITLE
DNM: Add tests for delta XDS

### DIFF
--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -351,6 +351,9 @@ type WatchedResource struct {
 	// Note that Envoy may send multiple requests for the same type, for
 	// example to update the set of watched resources or to ACK/NACK.
 	LastRequest *discovery.DiscoveryRequest
+
+	// LastMessage tracks the time of the generated push, to determine the time it takes the client to ack.
+	LastMessage Resources
 }
 
 var istioVersionRegexp = regexp.MustCompile(`^([1-9]+)\.([0-9]+)(\.([0-9]+))?`)


### PR DESCRIPTION
This allows checking for various delta xds bugs: missed deletions, extra deletions, missed updates, and areas we send NOP updates that we can optimzie.

We definitely cannot merge it in its current state, just pushing to share it. 