### PR TITLE
Add per-revision leader election for webhook patching

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -810,7 +810,7 @@ func (s *Server) addReadinessProbe(name string, fn readinessProbe) {
 
 // addTerminatingStartFunc adds a function that should terminate before the serve shuts down
 // This is useful to do cleanup activities
-// This is does not guarantee they will terminate gracefully - best effort only
+// This does not guarantee they will terminate gracefully - best effort only
 // Function should be synchronous; once it returns it is considered "done"
 func (s *Server) addTerminatingStartFunc(fn server.Component) {
 	s.server.RunComponentAsyncAndWait(fn)

--- a/pilot/pkg/bootstrap/sidecarinjector.go
+++ b/pilot/pkg/bootstrap/sidecarinjector.go
@@ -91,7 +91,7 @@ func (s *Server) initSidecarInjector(args *PilotArgs) (*inject.Webhook, error) {
 	// This requires RBAC permissions - a low-priv Istiod should not attempt to patch but rely on
 	// operator or CI/CD
 	if features.InjectionWebhookConfigName != "" {
-		s.addStartFunc(func(stop <-chan struct{}) error {
+		s.addTerminatingStartFunc(func(stop <-chan struct{}) error {
 			go leaderelection.NewPerRevisionLeaderElection(args.Namespace, args.PodName, args.Revision, leaderelection.MutatingWebhookController, s.kubeClient.Kube()).
 				AddRunFunction(func(stop <-chan struct{}) {
 					// update webhook configuration by watching the cabundle

--- a/pilot/pkg/bootstrap/sidecarinjector.go
+++ b/pilot/pkg/bootstrap/sidecarinjector.go
@@ -95,12 +95,7 @@ func (s *Server) initSidecarInjector(args *PilotArgs) (*inject.Webhook, error) {
 			go leaderelection.NewPerRevisionLeaderElection(args.Namespace, args.PodName, args.Revision, leaderelection.MutatingWebhookController, s.kubeClient.Kube()).
 				AddRunFunction(func(stop <-chan struct{}) {
 					// update webhook configuration by watching the cabundle
-					patcher, err := webhooks.NewWebhookCertPatcher(s.kubeClient, args.Revision, webhookName, s.istiodCertBundleWatcher)
-					if err != nil {
-						// HANDLE THIS ERROR BETTER, CANNOT JUST RETURN?
-						log.Errorf("failed to create webhook cert patcher: %v", err)
-						return
-					}
+					patcher := webhooks.NewWebhookCertPatcher(s.kubeClient, args.Revision, webhookName, s.istiodCertBundleWatcher)
 					patcher.Run(stop)
 				}).Run(stop)
 			return nil

--- a/pilot/pkg/bootstrap/validation.go
+++ b/pilot/pkg/bootstrap/validation.go
@@ -41,7 +41,7 @@ func (s *Server) initConfigValidation(args *PilotArgs) error {
 	}
 
 	if features.ValidationWebhookConfigName != "" && s.kubeClient != nil {
-		s.addStartFunc(func(stop <-chan struct{}) error {
+		s.addTerminatingStartFunc(func(stop <-chan struct{}) error {
 			go leaderelection.NewPerRevisionLeaderElection(args.Namespace, args.PodName, args.Revision, leaderelection.MutatingWebhookController, s.kubeClient.Kube()).
 				AddRunFunction(func(stop <-chan struct{}) {
 					log.Infof("Starting validation controller")

--- a/pilot/pkg/leaderelection/leaderelection.go
+++ b/pilot/pkg/leaderelection/leaderelection.go
@@ -147,20 +147,10 @@ func NewLeaderElection(namespace, name, electionID string, client kubernetes.Int
 // For instance, in webhook patching, we want each revision to handle its own patching, but only a
 // single replica within that revision.
 func NewPerRevisionLeaderElection(namespace, name, revision, electionID string, client kubernetes.Interface) *LeaderElection {
-	if name == "" {
-		name = "unknown"
-	}
 	if revision != "" {
 		electionID = fmt.Sprintf("%s-%s", electionID, revision)
 	}
-	return &LeaderElection{
-		namespace:  namespace,
-		name:       name,
-		revision:   revision,
-		electionID: electionID,
-		client:     client,
-		// Default to a 30s ttl. Overridable for tests
-		ttl:   time.Second * 30,
-		cycle: atomic.NewInt32(0),
-	}
+	le := NewLeaderElection(namespace, name, electionID, client)
+	le.revision = revision
+	return le
 }

--- a/pilot/pkg/server/instance.go
+++ b/pilot/pkg/server/instance.go
@@ -39,7 +39,7 @@ type Instance interface {
 	RunComponentAsync(t Component)
 
 	// RunComponentAsync runs the given component asynchronously. When
-	// the serer Instance is shutting down, it will wait for the component
+	// the server Instance is shutting down, it will wait for the component
 	// to complete before exiting.
 	// Note: this is best effort; a process can die at any time.
 	RunComponentAsyncAndWait(t Component)

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -249,12 +249,8 @@ func (m *Multicluster) AddMemberCluster(clusterID cluster.ID, rc *secretcontroll
 			go leaderelection.NewPerRevisionLeaderElection(options.SystemNamespace, m.serverID, m.revision, leaderelection.MutatingWebhookController, client.Kube()).
 				AddRunFunction(func(leaderStop <-chan struct{}) {
 					log.Infof("initializing webhook cert patch for cluster %s", clusterID)
-					patcher, err := webhooks.NewWebhookCertPatcher(client.Kube(), m.revision, webhookName, m.caBundleWatcher)
-					if err != nil {
-						log.Errorf("could not initialize webhook cert patcher: %v", err)
-					} else {
-						patcher.Run(clusterStopCh)
-					}
+					patcher := webhooks.NewWebhookCertPatcher(client.Kube(), m.revision, webhookName, m.caBundleWatcher)
+					patcher.Run(clusterStopCh)
 				}).Run(clusterStopCh)
 		}
 		// Patch validation webhook cert

--- a/pkg/webhooks/webhookpatch.go
+++ b/pkg/webhooks/webhookpatch.go
@@ -67,7 +67,7 @@ func (w *WebhookCertPatcher) Run(stopChan <-chan struct{}) {
 // NewWebhookCertPatcher creates a WebhookCertPatcher
 func NewWebhookCertPatcher(
 	client kubernetes.Interface,
-	revision, webhookName string, caBundleWatcher *keycertbundle.Watcher) (*WebhookCertPatcher, error) {
+	revision, webhookName string, caBundleWatcher *keycertbundle.Watcher) *WebhookCertPatcher {
 	whcLw := cache.NewFilteredListWatchFromClient(
 		client.AdmissionregistrationV1().RESTClient(),
 		"mutatingwebhookconfigurations",
@@ -82,7 +82,7 @@ func NewWebhookCertPatcher(
 		CABundleWatcher: caBundleWatcher,
 		queue:           queue.NewQueue(time.Second * 2),
 		whcLw:           whcLw,
-	}, nil
+	}
 }
 
 func (w *WebhookCertPatcher) runWebhookController(stopChan <-chan struct{}) {

--- a/releasenotes/notes/per-revision-leader-election.yaml
+++ b/releasenotes/notes/per-revision-leader-election.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+releaseNotes:
+  - |
+    **Fixed** a bug causing multiple replicas of istiod to conflict when patching mutating or validating webhook configurations.


### PR DESCRIPTION
Potential fix for the problem addressed in #35243, adds a new kind of leader election that is winnable by a single replica from each revision (for operations like webhook patching).

- [ ] Configuration Infrastructure
- [ ] Docs
- [x] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
