### PR TITLE
Remove `-m comment` from iptables output

### DIFF
--- a/cni/pkg/plugin/testdata/basic.txt.golden
+++ b/cni/pkg/plugin/testdata/basic.txt.golden
@@ -5,14 +5,14 @@
 -N ISTIO_OUTPUT
 -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
--A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
--A PREROUTING -p tcp -j ISTIO_INBOUND -m comment --comment "direct all traffic through ISTIO_INBOUND chain"
--A ISTIO_INBOUND -p tcp --dport 22 -j RETURN -m comment --comment "exclude inbound port from capture"
--A ISTIO_INBOUND -p tcp --dport 15020 -j RETURN -m comment --comment "exclude inbound port from capture"
--A ISTIO_INBOUND -p tcp --dport 15021 -j RETURN -m comment --comment "exclude inbound port from capture"
--A ISTIO_INBOUND -p tcp --dport 15090 -j RETURN -m comment --comment "exclude inbound port from capture"
+-A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
+-A PREROUTING -p tcp -j ISTIO_INBOUND
+-A ISTIO_INBOUND -p tcp --dport 22 -j RETURN
+-A ISTIO_INBOUND -p tcp --dport 15020 -j RETURN
+-A ISTIO_INBOUND -p tcp --dport 15021 -j RETURN
+-A ISTIO_INBOUND -p tcp --dport 15090 -j RETURN
 -A ISTIO_INBOUND -p tcp -j ISTIO_IN_REDIRECT
--A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
+-A OUTPUT -p tcp -j ISTIO_OUTPUT
 -A ISTIO_OUTPUT -p tcp --dport 15020 -j RETURN
 -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
 -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT

--- a/cni/pkg/plugin/testdata/dns.txt.golden
+++ b/cni/pkg/plugin/testdata/dns.txt.golden
@@ -5,14 +5,14 @@
 -N ISTIO_OUTPUT
 -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
--A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
--A PREROUTING -p tcp -j ISTIO_INBOUND -m comment --comment "direct all traffic through ISTIO_INBOUND chain"
--A ISTIO_INBOUND -p tcp --dport 22 -j RETURN -m comment --comment "exclude inbound port from capture"
--A ISTIO_INBOUND -p tcp --dport 15020 -j RETURN -m comment --comment "exclude inbound port from capture"
--A ISTIO_INBOUND -p tcp --dport 15021 -j RETURN -m comment --comment "exclude inbound port from capture"
--A ISTIO_INBOUND -p tcp --dport 15090 -j RETURN -m comment --comment "exclude inbound port from capture"
+-A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
+-A PREROUTING -p tcp -j ISTIO_INBOUND
+-A ISTIO_INBOUND -p tcp --dport 22 -j RETURN
+-A ISTIO_INBOUND -p tcp --dport 15020 -j RETURN
+-A ISTIO_INBOUND -p tcp --dport 15021 -j RETURN
+-A ISTIO_INBOUND -p tcp --dport 15090 -j RETURN
 -A ISTIO_INBOUND -p tcp -j ISTIO_IN_REDIRECT
--A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
+-A OUTPUT -p tcp -j ISTIO_OUTPUT
 -A ISTIO_OUTPUT -p tcp --dport 15020 -j RETURN
 -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
 -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -p tcp ! --dport 53 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT

--- a/cni/pkg/plugin/testdata/include-exclude-ip.txt.golden
+++ b/cni/pkg/plugin/testdata/include-exclude-ip.txt.golden
@@ -5,14 +5,14 @@
 -N ISTIO_OUTPUT
 -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
--A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
--A PREROUTING -p tcp -j ISTIO_INBOUND -m comment --comment "direct all traffic through ISTIO_INBOUND chain"
--A ISTIO_INBOUND -p tcp --dport 22 -j RETURN -m comment --comment "exclude inbound port from capture"
--A ISTIO_INBOUND -p tcp --dport 15020 -j RETURN -m comment --comment "exclude inbound port from capture"
--A ISTIO_INBOUND -p tcp --dport 15021 -j RETURN -m comment --comment "exclude inbound port from capture"
--A ISTIO_INBOUND -p tcp --dport 15090 -j RETURN -m comment --comment "exclude inbound port from capture"
+-A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
+-A PREROUTING -p tcp -j ISTIO_INBOUND
+-A ISTIO_INBOUND -p tcp --dport 22 -j RETURN
+-A ISTIO_INBOUND -p tcp --dport 15020 -j RETURN
+-A ISTIO_INBOUND -p tcp --dport 15021 -j RETURN
+-A ISTIO_INBOUND -p tcp --dport 15090 -j RETURN
 -A ISTIO_INBOUND -p tcp -j ISTIO_IN_REDIRECT
--A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
+-A OUTPUT -p tcp -j ISTIO_OUTPUT
 -A ISTIO_OUTPUT -p tcp --dport 15020 -j RETURN
 -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
 -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT

--- a/cni/pkg/plugin/testdata/include-exclude-ports.txt.golden
+++ b/cni/pkg/plugin/testdata/include-exclude-ports.txt.golden
@@ -5,11 +5,11 @@
 -N ISTIO_OUTPUT
 -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
--A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
--A PREROUTING -p tcp -j ISTIO_INBOUND -m comment --comment "direct all traffic through ISTIO_INBOUND chain"
--A ISTIO_INBOUND -p tcp --dport 1111 -j ISTIO_IN_REDIRECT -m comment --comment "include inbound port for capture"
--A ISTIO_INBOUND -p tcp --dport 2222 -j ISTIO_IN_REDIRECT -m comment --comment "include inbound port for capture"
--A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
+-A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
+-A PREROUTING -p tcp -j ISTIO_INBOUND
+-A ISTIO_INBOUND -p tcp --dport 1111 -j ISTIO_IN_REDIRECT
+-A ISTIO_INBOUND -p tcp --dport 2222 -j ISTIO_IN_REDIRECT
+-A OUTPUT -p tcp -j ISTIO_OUTPUT
 -A ISTIO_OUTPUT -p tcp --dport 5555 -j RETURN
 -A ISTIO_OUTPUT -p tcp --dport 6666 -j RETURN
 -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN

--- a/cni/pkg/plugin/testdata/tproxy.txt.golden
+++ b/cni/pkg/plugin/testdata/tproxy.txt.golden
@@ -5,11 +5,11 @@
 -A ISTIO_DIVERT -j MARK --set-mark 1337
 -A ISTIO_DIVERT -j ACCEPT
 -A ISTIO_TPROXY ! -d 127.0.0.1/32 -p tcp -j TPROXY --tproxy-mark 1337/0xffffffff --on-port 15006
--A PREROUTING -p tcp -j ISTIO_INBOUND -m comment --comment "direct all traffic through ISTIO_INBOUND chain"
--A ISTIO_INBOUND -p tcp --dport 22 -j RETURN -m comment --comment "exclude inbound port from capture"
--A ISTIO_INBOUND -p tcp --dport 15020 -j RETURN -m comment --comment "exclude inbound port from capture"
--A ISTIO_INBOUND -p tcp --dport 15021 -j RETURN -m comment --comment "exclude inbound port from capture"
--A ISTIO_INBOUND -p tcp --dport 15090 -j RETURN -m comment --comment "exclude inbound port from capture"
+-A PREROUTING -p tcp -j ISTIO_INBOUND
+-A ISTIO_INBOUND -p tcp --dport 22 -j RETURN
+-A ISTIO_INBOUND -p tcp --dport 15020 -j RETURN
+-A ISTIO_INBOUND -p tcp --dport 15021 -j RETURN
+-A ISTIO_INBOUND -p tcp --dport 15090 -j RETURN
 -A ISTIO_INBOUND -p tcp -m conntrack --ctstate RELATED,ESTABLISHED -j ISTIO_DIVERT
 -A ISTIO_INBOUND -p tcp -j ISTIO_TPROXY
 -A PREROUTING -p tcp -m mark --mark 1337 -j CONNMARK --save-mark
@@ -28,8 +28,8 @@ COMMIT
 -N ISTIO_OUTPUT
 -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
--A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
--A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
+-A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
+-A OUTPUT -p tcp -j ISTIO_OUTPUT
 -A ISTIO_OUTPUT -p tcp --dport 15020 -j RETURN
 -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
 -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT

--- a/tools/istio-iptables/pkg/builder/iptables_builder_impl.go
+++ b/tools/istio-iptables/pkg/builder/iptables_builder_impl.go
@@ -64,10 +64,6 @@ func (rb *IptablesBuilder) InsertRule(command log.Command, chain string, table s
 
 func (rb *IptablesBuilder) insertInternal(ipt *[]*Rule, command log.Command, chain string, table string, position int, params ...string) *IptablesBuilder {
 	rules := params
-	// If we have a comment for this entry, insert it
-	if command.Comment != "" {
-		rules = append(rules, "-m", "comment", "--comment", fmt.Sprintf(`%q`, command.Comment))
-	}
 	*ipt = append(*ipt, &Rule{
 		chain:  chain,
 		table:  table,
@@ -125,9 +121,6 @@ func (rb *IptablesBuilder) appendInternal(ipt *[]*Rule, command log.Command, cha
 		})
 	}
 	rules := params
-	if command.Comment != "" {
-		rules = append(rules, "-m", "comment", "--comment", fmt.Sprintf(`%q`, command.Comment))
-	}
 	*ipt = append(*ipt, &Rule{
 		chain:  chain,
 		table:  table,

--- a/tools/istio-iptables/pkg/cmd/testdata/basic-exclude-nic.golden
+++ b/tools/istio-iptables/pkg/cmd/testdata/basic-exclude-nic.golden
@@ -2,12 +2,12 @@ iptables -t nat -N ISTIO_INBOUND
 iptables -t nat -N ISTIO_REDIRECT
 iptables -t nat -N ISTIO_IN_REDIRECT
 iptables -t nat -N ISTIO_OUTPUT
-iptables -t nat -A PREROUTING -i not-istio-nic -j RETURN -m comment --comment "Excluded interface"
-iptables -t nat -A OUTPUT -o not-istio-nic -j RETURN -m comment --comment "Excluded interface"
+iptables -t nat -A PREROUTING -i not-istio-nic -j RETURN
+iptables -t nat -A OUTPUT -o not-istio-nic -j RETURN
 iptables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 iptables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
-iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
-iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
+iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
+iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
 iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 1337 -j RETURN

--- a/tools/istio-iptables/pkg/cmd/testdata/dns-uid-gid.golden
+++ b/tools/istio-iptables/pkg/cmd/testdata/dns-uid-gid.golden
@@ -4,8 +4,8 @@ iptables -t nat -N ISTIO_IN_REDIRECT
 iptables -t nat -N ISTIO_OUTPUT
 iptables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 iptables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
-iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
-iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
+iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
+iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
 iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -p tcp ! --dport 53 -m owner --uid-owner 3 -j ISTIO_IN_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -o lo -p tcp ! --dport 53 -m owner ! --uid-owner 3 -j RETURN
@@ -42,8 +42,8 @@ ip6tables -t nat -N ISTIO_IN_REDIRECT
 ip6tables -t nat -N ISTIO_OUTPUT
 ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 ip6tables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
-ip6tables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
-ip6tables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
+ip6tables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
+ip6tables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
 ip6tables -t nat -A ISTIO_OUTPUT -o lo -s ::6/128 -j RETURN
 ip6tables -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -p tcp ! --dport 53 -m owner --uid-owner 3 -j ISTIO_IN_REDIRECT
 ip6tables -t nat -A ISTIO_OUTPUT -o lo -p tcp ! --dport 53 -m owner ! --uid-owner 3 -j RETURN

--- a/tools/istio-iptables/pkg/cmd/testdata/empty.golden
+++ b/tools/istio-iptables/pkg/cmd/testdata/empty.golden
@@ -4,8 +4,8 @@ iptables -t nat -N ISTIO_IN_REDIRECT
 iptables -t nat -N ISTIO_OUTPUT
 iptables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 iptables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
-iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
-iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
+iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
+iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
 iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 1337 -j RETURN

--- a/tools/istio-iptables/pkg/cmd/testdata/inbound-ports-include.golden
+++ b/tools/istio-iptables/pkg/cmd/testdata/inbound-ports-include.golden
@@ -4,11 +4,11 @@ iptables -t nat -N ISTIO_IN_REDIRECT
 iptables -t nat -N ISTIO_OUTPUT
 iptables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 iptables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
-iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
-iptables -t nat -A PREROUTING -p tcp -j ISTIO_INBOUND -m comment --comment "direct all traffic through ISTIO_INBOUND chain"
-iptables -t nat -A ISTIO_INBOUND -p tcp --dport 32000 -j ISTIO_IN_REDIRECT -m comment --comment "include inbound port for capture"
-iptables -t nat -A ISTIO_INBOUND -p tcp --dport 31000 -j ISTIO_IN_REDIRECT -m comment --comment "include inbound port for capture"
-iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
+iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
+iptables -t nat -A PREROUTING -p tcp -j ISTIO_INBOUND
+iptables -t nat -A ISTIO_INBOUND -p tcp --dport 32000 -j ISTIO_IN_REDIRECT
+iptables -t nat -A ISTIO_INBOUND -p tcp --dport 31000 -j ISTIO_IN_REDIRECT
+iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
 iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 1337 -j RETURN

--- a/tools/istio-iptables/pkg/cmd/testdata/inbound-ports-tproxy.golden
+++ b/tools/istio-iptables/pkg/cmd/testdata/inbound-ports-tproxy.golden
@@ -7,16 +7,16 @@ iptables -t mangle -N ISTIO_INBOUND
 iptables -t nat -N ISTIO_OUTPUT
 iptables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 iptables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
-iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
+iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
 iptables -t mangle -A ISTIO_DIVERT -j MARK --set-mark 1337
 iptables -t mangle -A ISTIO_DIVERT -j ACCEPT
 iptables -t mangle -A ISTIO_TPROXY ! -d 127.0.0.1/32 -p tcp -j TPROXY --tproxy-mark 1337/0xffffffff --on-port 15006
-iptables -t mangle -A PREROUTING -p tcp -j ISTIO_INBOUND -m comment --comment "direct all traffic through ISTIO_INBOUND chain"
-iptables -t mangle -A ISTIO_INBOUND -p tcp --dport 32000 -m conntrack --ctstate RELATED,ESTABLISHED -j ISTIO_DIVERT -m comment --comment "include inbound port for capture"
-iptables -t mangle -A ISTIO_INBOUND -p tcp --dport 32000 -j ISTIO_TPROXY -m comment --comment "include inbound port for capture"
-iptables -t mangle -A ISTIO_INBOUND -p tcp --dport 31000 -m conntrack --ctstate RELATED,ESTABLISHED -j ISTIO_DIVERT -m comment --comment "include inbound port for capture"
-iptables -t mangle -A ISTIO_INBOUND -p tcp --dport 31000 -j ISTIO_TPROXY -m comment --comment "include inbound port for capture"
-iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
+iptables -t mangle -A PREROUTING -p tcp -j ISTIO_INBOUND
+iptables -t mangle -A ISTIO_INBOUND -p tcp --dport 32000 -m conntrack --ctstate RELATED,ESTABLISHED -j ISTIO_DIVERT
+iptables -t mangle -A ISTIO_INBOUND -p tcp --dport 32000 -j ISTIO_TPROXY
+iptables -t mangle -A ISTIO_INBOUND -p tcp --dport 31000 -m conntrack --ctstate RELATED,ESTABLISHED -j ISTIO_DIVERT
+iptables -t mangle -A ISTIO_INBOUND -p tcp --dport 31000 -j ISTIO_TPROXY
+iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
 iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 1337 -j RETURN

--- a/tools/istio-iptables/pkg/cmd/testdata/inbound-ports-wildcard-tproxy.golden
+++ b/tools/istio-iptables/pkg/cmd/testdata/inbound-ports-wildcard-tproxy.golden
@@ -7,15 +7,15 @@ iptables -t mangle -N ISTIO_INBOUND
 iptables -t nat -N ISTIO_OUTPUT
 iptables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 iptables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
-iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
+iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
 iptables -t mangle -A ISTIO_DIVERT -j MARK --set-mark 1337
 iptables -t mangle -A ISTIO_DIVERT -j ACCEPT
 iptables -t mangle -A ISTIO_TPROXY ! -d 127.0.0.1/32 -p tcp -j TPROXY --tproxy-mark 1337/0xffffffff --on-port 15006
-iptables -t mangle -A PREROUTING -p tcp -j ISTIO_INBOUND -m comment --comment "direct all traffic through ISTIO_INBOUND chain"
-iptables -t mangle -A ISTIO_INBOUND -p tcp --dport 22 -j RETURN -m comment --comment "exclude inbound port from capture"
+iptables -t mangle -A PREROUTING -p tcp -j ISTIO_INBOUND
+iptables -t mangle -A ISTIO_INBOUND -p tcp --dport 22 -j RETURN
 iptables -t mangle -A ISTIO_INBOUND -p tcp -m conntrack --ctstate RELATED,ESTABLISHED -j ISTIO_DIVERT
 iptables -t mangle -A ISTIO_INBOUND -p tcp -j ISTIO_TPROXY
-iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
+iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
 iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 1337 -j RETURN

--- a/tools/istio-iptables/pkg/cmd/testdata/inbound-ports-wildcard.golden
+++ b/tools/istio-iptables/pkg/cmd/testdata/inbound-ports-wildcard.golden
@@ -4,11 +4,11 @@ iptables -t nat -N ISTIO_IN_REDIRECT
 iptables -t nat -N ISTIO_OUTPUT
 iptables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 iptables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
-iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
-iptables -t nat -A PREROUTING -p tcp -j ISTIO_INBOUND -m comment --comment "direct all traffic through ISTIO_INBOUND chain"
-iptables -t nat -A ISTIO_INBOUND -p tcp --dport 22 -j RETURN -m comment --comment "exclude inbound port from capture"
+iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
+iptables -t nat -A PREROUTING -p tcp -j ISTIO_INBOUND
+iptables -t nat -A ISTIO_INBOUND -p tcp --dport 22 -j RETURN
 iptables -t nat -A ISTIO_INBOUND -p tcp -j ISTIO_IN_REDIRECT
-iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
+iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
 iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 1337 -j RETURN

--- a/tools/istio-iptables/pkg/cmd/testdata/ip-range.golden
+++ b/tools/istio-iptables/pkg/cmd/testdata/ip-range.golden
@@ -4,8 +4,8 @@ iptables -t nat -N ISTIO_IN_REDIRECT
 iptables -t nat -N ISTIO_OUTPUT
 iptables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 iptables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
-iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
-iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
+iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
+iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
 iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -p tcp ! --dport 53 -m owner --uid-owner 3 -j ISTIO_IN_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -o lo -p tcp ! --dport 53 -m owner ! --uid-owner 3 -j RETURN

--- a/tools/istio-iptables/pkg/cmd/testdata/ipnets-with-kube-virt-interfaces.golden
+++ b/tools/istio-iptables/pkg/cmd/testdata/ipnets-with-kube-virt-interfaces.golden
@@ -2,12 +2,12 @@ iptables -t nat -N ISTIO_INBOUND
 iptables -t nat -N ISTIO_REDIRECT
 iptables -t nat -N ISTIO_IN_REDIRECT
 iptables -t nat -N ISTIO_OUTPUT
-iptables -t nat -I PREROUTING 1 -i eth1 -j RETURN -m comment --comment "Kubevirt outbound redirect"
-iptables -t nat -I PREROUTING 1 -i eth2 -j RETURN -m comment --comment "Kubevirt outbound redirect"
+iptables -t nat -I PREROUTING 1 -i eth1 -j RETURN
+iptables -t nat -I PREROUTING 1 -i eth2 -j RETURN
 iptables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 iptables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
-iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
-iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
+iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
+iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
 iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 1337 -j RETURN
@@ -16,7 +16,7 @@ iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --gid-owner 133
 iptables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --gid-owner 1337 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -m owner --gid-owner 1337 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -d 127.0.0.1/32 -j RETURN
-iptables -t nat -I PREROUTING 1 -i eth1 -d 10.0.0.0/8 -j ISTIO_REDIRECT -m comment --comment "Kubevirt outbound redirect"
-iptables -t nat -I PREROUTING 1 -i eth2 -d 10.0.0.0/8 -j ISTIO_REDIRECT -m comment --comment "Kubevirt outbound redirect"
+iptables -t nat -I PREROUTING 1 -i eth1 -d 10.0.0.0/8 -j ISTIO_REDIRECT
+iptables -t nat -I PREROUTING 1 -i eth2 -d 10.0.0.0/8 -j ISTIO_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -d 10.0.0.0/8 -j ISTIO_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -j RETURN

--- a/tools/istio-iptables/pkg/cmd/testdata/ipnets.golden
+++ b/tools/istio-iptables/pkg/cmd/testdata/ipnets.golden
@@ -4,8 +4,8 @@ iptables -t nat -N ISTIO_IN_REDIRECT
 iptables -t nat -N ISTIO_OUTPUT
 iptables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 iptables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
-iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
-iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
+iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
+iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
 iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 1337 -j RETURN

--- a/tools/istio-iptables/pkg/cmd/testdata/ipv6-dns-uid-gid.golden
+++ b/tools/istio-iptables/pkg/cmd/testdata/ipv6-dns-uid-gid.golden
@@ -4,8 +4,8 @@ iptables -t nat -N ISTIO_IN_REDIRECT
 iptables -t nat -N ISTIO_OUTPUT
 iptables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 iptables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
-iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
-iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
+iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
+iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
 iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -p tcp ! --dport 53 -m owner --uid-owner 3 -j ISTIO_IN_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -o lo -p tcp ! --dport 53 -m owner ! --uid-owner 3 -j RETURN
@@ -38,8 +38,8 @@ ip6tables -t nat -N ISTIO_IN_REDIRECT
 ip6tables -t nat -N ISTIO_OUTPUT
 ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 ip6tables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
-ip6tables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
-ip6tables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
+ip6tables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
+ip6tables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
 ip6tables -t nat -A ISTIO_OUTPUT -o lo -s ::6/128 -j RETURN
 ip6tables -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -p tcp ! --dport 53 -m owner --uid-owner 3 -j ISTIO_IN_REDIRECT
 ip6tables -t nat -A ISTIO_OUTPUT -o lo -p tcp ! --dport 53 -m owner ! --uid-owner 3 -j RETURN

--- a/tools/istio-iptables/pkg/cmd/testdata/ipv6-empty-inbound-ports.golden
+++ b/tools/istio-iptables/pkg/cmd/testdata/ipv6-empty-inbound-ports.golden
@@ -4,8 +4,8 @@ iptables -t nat -N ISTIO_IN_REDIRECT
 iptables -t nat -N ISTIO_OUTPUT
 iptables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 iptables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
-iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
-iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
+iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
+iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
 iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 1337 -j RETURN
@@ -20,8 +20,8 @@ ip6tables -t nat -N ISTIO_IN_REDIRECT
 ip6tables -t nat -N ISTIO_OUTPUT
 ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 ip6tables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
-ip6tables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
-ip6tables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
+ip6tables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
+ip6tables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
 ip6tables -t nat -A ISTIO_OUTPUT -o lo -s ::6/128 -j RETURN
 ip6tables -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT
 ip6tables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 1337 -j RETURN

--- a/tools/istio-iptables/pkg/cmd/testdata/ipv6-inbound-ports.golden
+++ b/tools/istio-iptables/pkg/cmd/testdata/ipv6-inbound-ports.golden
@@ -4,11 +4,11 @@ iptables -t nat -N ISTIO_IN_REDIRECT
 iptables -t nat -N ISTIO_OUTPUT
 iptables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 iptables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
-iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
-iptables -t nat -A PREROUTING -p tcp -j ISTIO_INBOUND -m comment --comment "direct all traffic through ISTIO_INBOUND chain"
-iptables -t nat -A ISTIO_INBOUND -p tcp --dport 4000 -j ISTIO_IN_REDIRECT -m comment --comment "include inbound port for capture"
-iptables -t nat -A ISTIO_INBOUND -p tcp --dport 5000 -j ISTIO_IN_REDIRECT -m comment --comment "include inbound port for capture"
-iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
+iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
+iptables -t nat -A PREROUTING -p tcp -j ISTIO_INBOUND
+iptables -t nat -A ISTIO_INBOUND -p tcp --dport 4000 -j ISTIO_IN_REDIRECT
+iptables -t nat -A ISTIO_INBOUND -p tcp --dport 5000 -j ISTIO_IN_REDIRECT
+iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
 iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 1337 -j RETURN
@@ -23,11 +23,11 @@ ip6tables -t nat -N ISTIO_IN_REDIRECT
 ip6tables -t nat -N ISTIO_OUTPUT
 ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 ip6tables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
-ip6tables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
-ip6tables -t nat -A PREROUTING -p tcp -j ISTIO_INBOUND -m comment --comment "direct all traffic through ISTIO_INBOUND chain"
-ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 4000 -j ISTIO_IN_REDIRECT -m comment --comment "include inbound port for capture"
-ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 5000 -j ISTIO_IN_REDIRECT -m comment --comment "include inbound port for capture"
-ip6tables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
+ip6tables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
+ip6tables -t nat -A PREROUTING -p tcp -j ISTIO_INBOUND
+ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 4000 -j ISTIO_IN_REDIRECT
+ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 5000 -j ISTIO_IN_REDIRECT
+ip6tables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
 ip6tables -t nat -A ISTIO_OUTPUT -o lo -s ::6/128 -j RETURN
 ip6tables -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT
 ip6tables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 1337 -j RETURN

--- a/tools/istio-iptables/pkg/cmd/testdata/ipv6-ipnets.golden
+++ b/tools/istio-iptables/pkg/cmd/testdata/ipv6-ipnets.golden
@@ -2,15 +2,15 @@ iptables -t nat -N ISTIO_INBOUND
 iptables -t nat -N ISTIO_REDIRECT
 iptables -t nat -N ISTIO_IN_REDIRECT
 iptables -t nat -N ISTIO_OUTPUT
-iptables -t nat -I PREROUTING 1 -i eth0 -j RETURN -m comment --comment "Kubevirt outbound redirect"
-iptables -t nat -I PREROUTING 1 -i eth1 -j RETURN -m comment --comment "Kubevirt outbound redirect"
+iptables -t nat -I PREROUTING 1 -i eth0 -j RETURN
+iptables -t nat -I PREROUTING 1 -i eth1 -j RETURN
 iptables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 iptables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
-iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
-iptables -t nat -A PREROUTING -p tcp -j ISTIO_INBOUND -m comment --comment "direct all traffic through ISTIO_INBOUND chain"
-iptables -t nat -A ISTIO_INBOUND -p tcp --dport 4000 -j ISTIO_IN_REDIRECT -m comment --comment "include inbound port for capture"
-iptables -t nat -A ISTIO_INBOUND -p tcp --dport 5000 -j ISTIO_IN_REDIRECT -m comment --comment "include inbound port for capture"
-iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
+iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
+iptables -t nat -A PREROUTING -p tcp -j ISTIO_INBOUND
+iptables -t nat -A ISTIO_INBOUND -p tcp --dport 4000 -j ISTIO_IN_REDIRECT
+iptables -t nat -A ISTIO_INBOUND -p tcp --dport 5000 -j ISTIO_IN_REDIRECT
+iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
 iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 1337 -j RETURN
@@ -23,15 +23,15 @@ ip6tables -t nat -N ISTIO_INBOUND
 ip6tables -t nat -N ISTIO_REDIRECT
 ip6tables -t nat -N ISTIO_IN_REDIRECT
 ip6tables -t nat -N ISTIO_OUTPUT
-ip6tables -t nat -I PREROUTING 1 -i eth0 -j RETURN -m comment --comment "Kubevirt outbound redirect"
-ip6tables -t nat -I PREROUTING 1 -i eth1 -j RETURN -m comment --comment "Kubevirt outbound redirect"
+ip6tables -t nat -I PREROUTING 1 -i eth0 -j RETURN
+ip6tables -t nat -I PREROUTING 1 -i eth1 -j RETURN
 ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 ip6tables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
-ip6tables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
-ip6tables -t nat -A PREROUTING -p tcp -j ISTIO_INBOUND -m comment --comment "direct all traffic through ISTIO_INBOUND chain"
-ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 4000 -j ISTIO_IN_REDIRECT -m comment --comment "include inbound port for capture"
-ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 5000 -j ISTIO_IN_REDIRECT -m comment --comment "include inbound port for capture"
-ip6tables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
+ip6tables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
+ip6tables -t nat -A PREROUTING -p tcp -j ISTIO_INBOUND
+ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 4000 -j ISTIO_IN_REDIRECT
+ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 5000 -j ISTIO_IN_REDIRECT
+ip6tables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
 ip6tables -t nat -A ISTIO_OUTPUT -o lo -s ::6/128 -j RETURN
 ip6tables -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT
 ip6tables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 1337 -j RETURN
@@ -41,7 +41,7 @@ ip6tables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --gid-owner 1337 -j RETURN
 ip6tables -t nat -A ISTIO_OUTPUT -m owner --gid-owner 1337 -j RETURN
 ip6tables -t nat -A ISTIO_OUTPUT -d ::1/128 -j RETURN
 ip6tables -t nat -A ISTIO_OUTPUT -d 2001:db8::/32 -j RETURN
-ip6tables -t nat -I PREROUTING 1 -i eth0 -d 2001:db8::/32 -j ISTIO_REDIRECT -m comment --comment "Kubevirt outbound redirect"
-ip6tables -t nat -I PREROUTING 1 -i eth1 -d 2001:db8::/32 -j ISTIO_REDIRECT -m comment --comment "Kubevirt outbound redirect"
+ip6tables -t nat -I PREROUTING 1 -i eth0 -d 2001:db8::/32 -j ISTIO_REDIRECT
+ip6tables -t nat -I PREROUTING 1 -i eth1 -d 2001:db8::/32 -j ISTIO_REDIRECT
 ip6tables -t nat -A ISTIO_OUTPUT -d 2001:db8::/32 -j ISTIO_REDIRECT
 ip6tables -t nat -A ISTIO_OUTPUT -j RETURN

--- a/tools/istio-iptables/pkg/cmd/testdata/ipv6-outbound-ports.golden
+++ b/tools/istio-iptables/pkg/cmd/testdata/ipv6-outbound-ports.golden
@@ -4,8 +4,8 @@ iptables -t nat -N ISTIO_IN_REDIRECT
 iptables -t nat -N ISTIO_OUTPUT
 iptables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 iptables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
-iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
-iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
+iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
+iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
 iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 1337 -j RETURN
@@ -22,8 +22,8 @@ ip6tables -t nat -N ISTIO_IN_REDIRECT
 ip6tables -t nat -N ISTIO_OUTPUT
 ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 ip6tables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
-ip6tables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
-ip6tables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
+ip6tables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
+ip6tables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
 ip6tables -t nat -A ISTIO_OUTPUT -o lo -s ::6/128 -j RETURN
 ip6tables -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT
 ip6tables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 1337 -j RETURN

--- a/tools/istio-iptables/pkg/cmd/testdata/ipv6-uid-gid.golden
+++ b/tools/istio-iptables/pkg/cmd/testdata/ipv6-uid-gid.golden
@@ -2,15 +2,15 @@ iptables -t nat -N ISTIO_INBOUND
 iptables -t nat -N ISTIO_REDIRECT
 iptables -t nat -N ISTIO_IN_REDIRECT
 iptables -t nat -N ISTIO_OUTPUT
-iptables -t nat -I PREROUTING 1 -i eth0 -j RETURN -m comment --comment "Kubevirt outbound redirect"
-iptables -t nat -I PREROUTING 1 -i eth1 -j RETURN -m comment --comment "Kubevirt outbound redirect"
+iptables -t nat -I PREROUTING 1 -i eth0 -j RETURN
+iptables -t nat -I PREROUTING 1 -i eth1 -j RETURN
 iptables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 iptables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
-iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
-iptables -t nat -A PREROUTING -p tcp -j ISTIO_INBOUND -m comment --comment "direct all traffic through ISTIO_INBOUND chain"
-iptables -t nat -A ISTIO_INBOUND -p tcp --dport 4000 -j ISTIO_IN_REDIRECT -m comment --comment "include inbound port for capture"
-iptables -t nat -A ISTIO_INBOUND -p tcp --dport 5000 -j ISTIO_IN_REDIRECT -m comment --comment "include inbound port for capture"
-iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
+iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
+iptables -t nat -A PREROUTING -p tcp -j ISTIO_INBOUND
+iptables -t nat -A ISTIO_INBOUND -p tcp --dport 4000 -j ISTIO_IN_REDIRECT
+iptables -t nat -A ISTIO_INBOUND -p tcp --dport 5000 -j ISTIO_IN_REDIRECT
+iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
 iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 3 -j ISTIO_IN_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 3 -j RETURN
@@ -29,15 +29,15 @@ ip6tables -t nat -N ISTIO_INBOUND
 ip6tables -t nat -N ISTIO_REDIRECT
 ip6tables -t nat -N ISTIO_IN_REDIRECT
 ip6tables -t nat -N ISTIO_OUTPUT
-ip6tables -t nat -I PREROUTING 1 -i eth0 -j RETURN -m comment --comment "Kubevirt outbound redirect"
-ip6tables -t nat -I PREROUTING 1 -i eth1 -j RETURN -m comment --comment "Kubevirt outbound redirect"
+ip6tables -t nat -I PREROUTING 1 -i eth0 -j RETURN
+ip6tables -t nat -I PREROUTING 1 -i eth1 -j RETURN
 ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 ip6tables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
-ip6tables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
-ip6tables -t nat -A PREROUTING -p tcp -j ISTIO_INBOUND -m comment --comment "direct all traffic through ISTIO_INBOUND chain"
-ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 4000 -j ISTIO_IN_REDIRECT -m comment --comment "include inbound port for capture"
-ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 5000 -j ISTIO_IN_REDIRECT -m comment --comment "include inbound port for capture"
-ip6tables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
+ip6tables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
+ip6tables -t nat -A PREROUTING -p tcp -j ISTIO_INBOUND
+ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 4000 -j ISTIO_IN_REDIRECT
+ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 5000 -j ISTIO_IN_REDIRECT
+ip6tables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
 ip6tables -t nat -A ISTIO_OUTPUT -o lo -s ::6/128 -j RETURN
 ip6tables -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -m owner --uid-owner 3 -j ISTIO_IN_REDIRECT
 ip6tables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 3 -j RETURN
@@ -53,7 +53,7 @@ ip6tables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --gid-owner 2 -j RETURN
 ip6tables -t nat -A ISTIO_OUTPUT -m owner --gid-owner 2 -j RETURN
 ip6tables -t nat -A ISTIO_OUTPUT -d ::1/128 -j RETURN
 ip6tables -t nat -A ISTIO_OUTPUT -d 2001:db8::/32 -j RETURN
-ip6tables -t nat -I PREROUTING 1 -i eth0 -d 2001:db8::/32 -j ISTIO_REDIRECT -m comment --comment "Kubevirt outbound redirect"
-ip6tables -t nat -I PREROUTING 1 -i eth1 -d 2001:db8::/32 -j ISTIO_REDIRECT -m comment --comment "Kubevirt outbound redirect"
+ip6tables -t nat -I PREROUTING 1 -i eth0 -d 2001:db8::/32 -j ISTIO_REDIRECT
+ip6tables -t nat -I PREROUTING 1 -i eth1 -d 2001:db8::/32 -j ISTIO_REDIRECT
 ip6tables -t nat -A ISTIO_OUTPUT -d 2001:db8::/32 -j ISTIO_REDIRECT
 ip6tables -t nat -A ISTIO_OUTPUT -j RETURN

--- a/tools/istio-iptables/pkg/cmd/testdata/ipv6-virt-interfaces.golden
+++ b/tools/istio-iptables/pkg/cmd/testdata/ipv6-virt-interfaces.golden
@@ -2,15 +2,15 @@ iptables -t nat -N ISTIO_INBOUND
 iptables -t nat -N ISTIO_REDIRECT
 iptables -t nat -N ISTIO_IN_REDIRECT
 iptables -t nat -N ISTIO_OUTPUT
-iptables -t nat -I PREROUTING 1 -i eth0 -j RETURN -m comment --comment "Kubevirt outbound redirect"
-iptables -t nat -I PREROUTING 1 -i eth1 -j RETURN -m comment --comment "Kubevirt outbound redirect"
+iptables -t nat -I PREROUTING 1 -i eth0 -j RETURN
+iptables -t nat -I PREROUTING 1 -i eth1 -j RETURN
 iptables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 iptables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
-iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
-iptables -t nat -A PREROUTING -p tcp -j ISTIO_INBOUND -m comment --comment "direct all traffic through ISTIO_INBOUND chain"
-iptables -t nat -A ISTIO_INBOUND -p tcp --dport 4000 -j ISTIO_IN_REDIRECT -m comment --comment "include inbound port for capture"
-iptables -t nat -A ISTIO_INBOUND -p tcp --dport 5000 -j ISTIO_IN_REDIRECT -m comment --comment "include inbound port for capture"
-iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
+iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
+iptables -t nat -A PREROUTING -p tcp -j ISTIO_INBOUND
+iptables -t nat -A ISTIO_INBOUND -p tcp --dport 4000 -j ISTIO_IN_REDIRECT
+iptables -t nat -A ISTIO_INBOUND -p tcp --dport 5000 -j ISTIO_IN_REDIRECT
+iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
 iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 1337 -j RETURN
@@ -23,15 +23,15 @@ ip6tables -t nat -N ISTIO_INBOUND
 ip6tables -t nat -N ISTIO_REDIRECT
 ip6tables -t nat -N ISTIO_IN_REDIRECT
 ip6tables -t nat -N ISTIO_OUTPUT
-ip6tables -t nat -I PREROUTING 1 -i eth0 -j RETURN -m comment --comment "Kubevirt outbound redirect"
-ip6tables -t nat -I PREROUTING 1 -i eth1 -j RETURN -m comment --comment "Kubevirt outbound redirect"
+ip6tables -t nat -I PREROUTING 1 -i eth0 -j RETURN
+ip6tables -t nat -I PREROUTING 1 -i eth1 -j RETURN
 ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 ip6tables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
-ip6tables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
-ip6tables -t nat -A PREROUTING -p tcp -j ISTIO_INBOUND -m comment --comment "direct all traffic through ISTIO_INBOUND chain"
-ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 4000 -j ISTIO_IN_REDIRECT -m comment --comment "include inbound port for capture"
-ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 5000 -j ISTIO_IN_REDIRECT -m comment --comment "include inbound port for capture"
-ip6tables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
+ip6tables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
+ip6tables -t nat -A PREROUTING -p tcp -j ISTIO_INBOUND
+ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 4000 -j ISTIO_IN_REDIRECT
+ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 5000 -j ISTIO_IN_REDIRECT
+ip6tables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
 ip6tables -t nat -A ISTIO_OUTPUT -o lo -s ::6/128 -j RETURN
 ip6tables -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT
 ip6tables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 1337 -j RETURN

--- a/tools/istio-iptables/pkg/cmd/testdata/kube-virt-interfaces.golden
+++ b/tools/istio-iptables/pkg/cmd/testdata/kube-virt-interfaces.golden
@@ -2,12 +2,12 @@ iptables -t nat -N ISTIO_INBOUND
 iptables -t nat -N ISTIO_REDIRECT
 iptables -t nat -N ISTIO_IN_REDIRECT
 iptables -t nat -N ISTIO_OUTPUT
-iptables -t nat -I PREROUTING 1 -i eth1 -j RETURN -m comment --comment "Kubevirt outbound redirect"
-iptables -t nat -I PREROUTING 1 -i eth2 -j RETURN -m comment --comment "Kubevirt outbound redirect"
+iptables -t nat -I PREROUTING 1 -i eth1 -j RETURN
+iptables -t nat -I PREROUTING 1 -i eth2 -j RETURN
 iptables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 iptables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
-iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
-iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
+iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
+iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
 iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 1337 -j RETURN
@@ -17,5 +17,5 @@ iptables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --gid-owner 1337 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -m owner --gid-owner 1337 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -d 127.0.0.1/32 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -j ISTIO_REDIRECT
-iptables -t nat -I PREROUTING 1 -i eth1 -j ISTIO_REDIRECT -m comment --comment "Kubevirt outbound redirect"
-iptables -t nat -I PREROUTING 1 -i eth2 -j ISTIO_REDIRECT -m comment --comment "Kubevirt outbound redirect"
+iptables -t nat -I PREROUTING 1 -i eth1 -j ISTIO_REDIRECT
+iptables -t nat -I PREROUTING 1 -i eth2 -j ISTIO_REDIRECT

--- a/tools/istio-iptables/pkg/cmd/testdata/logging.golden
+++ b/tools/istio-iptables/pkg/cmd/testdata/logging.golden
@@ -5,9 +5,9 @@ iptables -t nat -N ISTIO_OUTPUT
 iptables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 iptables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
 iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j NFLOG --nflog-prefix "InboundCapture" --nflog-group 1337 --nflog-size 20
-iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
+iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
 iptables -t nat -A OUTPUT -p tcp -j NFLOG --nflog-prefix "JumpOutbound" --nflog-group 1337 --nflog-size 20
-iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
+iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
 iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 1337 -j RETURN

--- a/tools/istio-iptables/pkg/cmd/testdata/loopback-outbound-iprange.golden
+++ b/tools/istio-iptables/pkg/cmd/testdata/loopback-outbound-iprange.golden
@@ -4,8 +4,8 @@ iptables -t nat -N ISTIO_IN_REDIRECT
 iptables -t nat -N ISTIO_OUTPUT
 iptables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 iptables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
-iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
-iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
+iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
+iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
 iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -p tcp ! --dport 53 -m owner --uid-owner 3 -j ISTIO_IN_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -m owner --uid-owner 3 -j RETURN

--- a/tools/istio-iptables/pkg/cmd/testdata/outbound-ports-include.golden
+++ b/tools/istio-iptables/pkg/cmd/testdata/outbound-ports-include.golden
@@ -4,8 +4,8 @@ iptables -t nat -N ISTIO_IN_REDIRECT
 iptables -t nat -N ISTIO_OUTPUT
 iptables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 iptables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
-iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
-iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
+iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
+iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
 iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 1337 -j RETURN

--- a/tools/istio-iptables/pkg/cmd/testdata/tproxy.golden
+++ b/tools/istio-iptables/pkg/cmd/testdata/tproxy.golden
@@ -5,21 +5,21 @@ iptables -t mangle -N ISTIO_DIVERT
 iptables -t mangle -N ISTIO_TPROXY
 iptables -t mangle -N ISTIO_INBOUND
 iptables -t nat -N ISTIO_OUTPUT
-iptables -t nat -A PREROUTING -i not-istio-nic -j RETURN -m comment --comment "Excluded interface"
-iptables -t nat -A OUTPUT -o not-istio-nic -j RETURN -m comment --comment "Excluded interface"
-iptables -t mangle -A PREROUTING -i not-istio-nic -j RETURN -m comment --comment "Excluded interface"
-iptables -t mangle -A OUTPUT -o not-istio-nic -j RETURN -m comment --comment "Excluded interface"
+iptables -t nat -A PREROUTING -i not-istio-nic -j RETURN
+iptables -t nat -A OUTPUT -o not-istio-nic -j RETURN
+iptables -t mangle -A PREROUTING -i not-istio-nic -j RETURN
+iptables -t mangle -A OUTPUT -o not-istio-nic -j RETURN
 iptables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 iptables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
-iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
+iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
 iptables -t mangle -A ISTIO_DIVERT -j MARK --set-mark 1337
 iptables -t mangle -A ISTIO_DIVERT -j ACCEPT
 iptables -t mangle -A ISTIO_TPROXY ! -d 127.0.0.1/32 -p tcp -j TPROXY --tproxy-mark 1337/0xffffffff --on-port 15006
-iptables -t mangle -A PREROUTING -p tcp -j ISTIO_INBOUND -m comment --comment "direct all traffic through ISTIO_INBOUND chain"
-iptables -t mangle -A ISTIO_INBOUND -p tcp --dport 22 -j RETURN -m comment --comment "exclude inbound port from capture"
+iptables -t mangle -A PREROUTING -p tcp -j ISTIO_INBOUND
+iptables -t mangle -A ISTIO_INBOUND -p tcp --dport 22 -j RETURN
 iptables -t mangle -A ISTIO_INBOUND -p tcp -m conntrack --ctstate RELATED,ESTABLISHED -j ISTIO_DIVERT
 iptables -t mangle -A ISTIO_INBOUND -p tcp -j ISTIO_TPROXY
-iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
+iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
 iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
 iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -p tcp ! --dport 53 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT
 iptables -t nat -A ISTIO_OUTPUT -o lo -p tcp ! --dport 53 -m owner ! --uid-owner 1337 -j RETURN
@@ -56,21 +56,21 @@ ip6tables -t mangle -N ISTIO_DIVERT
 ip6tables -t mangle -N ISTIO_TPROXY
 ip6tables -t mangle -N ISTIO_INBOUND
 ip6tables -t nat -N ISTIO_OUTPUT
-ip6tables -t nat -A PREROUTING -i not-istio-nic -j RETURN -m comment --comment "Excluded interface"
-ip6tables -t nat -A OUTPUT -o not-istio-nic -j RETURN -m comment --comment "Excluded interface"
-ip6tables -t mangle -A PREROUTING -i not-istio-nic -j RETURN -m comment --comment "Excluded interface"
-ip6tables -t mangle -A OUTPUT -o not-istio-nic -j RETURN -m comment --comment "Excluded interface"
+ip6tables -t nat -A PREROUTING -i not-istio-nic -j RETURN
+ip6tables -t nat -A OUTPUT -o not-istio-nic -j RETURN
+ip6tables -t mangle -A PREROUTING -i not-istio-nic -j RETURN
+ip6tables -t mangle -A OUTPUT -o not-istio-nic -j RETURN
 ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
 ip6tables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
-ip6tables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006 -m comment --comment "redirect inbound request to proxy"
+ip6tables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
 ip6tables -t mangle -A ISTIO_DIVERT -j MARK --set-mark 1337
 ip6tables -t mangle -A ISTIO_DIVERT -j ACCEPT
 ip6tables -t mangle -A ISTIO_TPROXY ! -d ::1/128 -p tcp -j TPROXY --tproxy-mark 1337/0xffffffff --on-port 15006
-ip6tables -t mangle -A PREROUTING -p tcp -j ISTIO_INBOUND -m comment --comment "direct all traffic through ISTIO_INBOUND chain"
-ip6tables -t mangle -A ISTIO_INBOUND -p tcp --dport 22 -j RETURN -m comment --comment "exclude inbound port from capture"
+ip6tables -t mangle -A PREROUTING -p tcp -j ISTIO_INBOUND
+ip6tables -t mangle -A ISTIO_INBOUND -p tcp --dport 22 -j RETURN
 ip6tables -t mangle -A ISTIO_INBOUND -p tcp -m conntrack --ctstate RELATED,ESTABLISHED -j ISTIO_DIVERT
 ip6tables -t mangle -A ISTIO_INBOUND -p tcp -j ISTIO_TPROXY
-ip6tables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT -m comment --comment "direct all traffic through ISTIO_OUTBOUND chain"
+ip6tables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
 ip6tables -t nat -A ISTIO_OUTPUT -o lo -s ::6/128 -j RETURN
 ip6tables -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -p tcp ! --dport 53 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT
 ip6tables -t nat -A ISTIO_OUTPUT -o lo -p tcp ! --dport 53 -m owner ! --uid-owner 1337 -j RETURN


### PR DESCRIPTION
We are already emiting the logs which has the command name as part of
it, so its a bit redundant to store the full comment in the kernel. This
has caused some compatibility issues with kernels not supporting
`comment` module
We never shipped this so its backwards compat