### PR TITLE
allow discoveryAddress to be set via proxyConfig for VMs with revision

### DIFF
--- a/istioctl/cmd/testdata/vmconfig/simple/mesh.yaml.golden
+++ b/istioctl/cmd/testdata/vmconfig/simple/mesh.yaml.golden
@@ -1,5 +1,5 @@
 defaultConfig:
-  discoveryAddress: istiod-rev-1.istio-system.svc.cluster.local
+  discoveryAddress: istiod-rev-1.istio-system.svc:15012
   proxyMetadata:
     CANONICAL_REVISION: latest
     CANONICAL_SERVICE: foo

--- a/istioctl/cmd/testdata/vmconfig/simple/sidecar.env.golden
+++ b/istioctl/cmd/testdata/vmconfig/simple/sidecar.env.golden
@@ -1,1 +1,2 @@
+CA_ADDR='istiod-rev-1.istio-system.svc:15012'
 ISTIO_SVC_IP='10.10.10.10'

--- a/istioctl/cmd/workload.go
+++ b/istioctl/cmd/workload.go
@@ -589,7 +589,8 @@ func createHosts(kubeClient kube.ExtendedClient, ingressIP, dir string, revision
 	if net.ParseIP(ingressIP) != nil {
 		hosts = fmt.Sprintf("%s %s\n", ingressIP, istiodHost(revision))
 	} else {
-		log.Warnf("Could not auto-detect IP for. Use --ingressIP to manually specify the Gateway address to reach istiod from the VM.", istiodHost(revision), istioNamespace)
+		log.Warnf("Could not auto-detect IP for. Use --ingressIP to manually specify the Gateway address to reach istiod from the VM.",
+			istiodHost(revision), istioNamespace)
 	}
 	return os.WriteFile(filepath.Join(dir, "hosts"), []byte(hosts), filePerms)
 }

--- a/istioctl/cmd/workload.go
+++ b/istioctl/cmd/workload.go
@@ -298,19 +298,20 @@ func createConfig(kubeClient kube.ExtendedClient, wg *clientv1alpha3.WorkloadGro
 		err         error
 		proxyConfig *meshconfig.ProxyConfig
 	)
-	if proxyConfig, err = createMeshConfig(kubeClient, wg, clusterID, outputDir); err != nil {
+	revision := kubeClient.Revision()
+	if proxyConfig, err = createMeshConfig(kubeClient, wg, clusterID, outputDir, revision); err != nil {
 		return err
 	}
 	if err := createClusterEnv(wg, proxyConfig, outputDir); err != nil {
 		return err
 	}
-	if err := createSidecarEnv(internalIP, externalIP, outputDir); err != nil {
+	if err := createSidecarEnv(internalIP, externalIP, outputDir, revision); err != nil {
 		return err
 	}
 	if err := createCertsTokens(kubeClient, wg, outputDir, out); err != nil {
 		return err
 	}
-	if err := createHosts(kubeClient, ingressIP, outputDir); err != nil {
+	if err := createHosts(kubeClient, ingressIP, outputDir, revision); err != nil {
 		return err
 	}
 	return nil
@@ -361,8 +362,8 @@ func createClusterEnv(wg *clientv1alpha3.WorkloadGroup, config *meshconfig.Proxy
 	return os.WriteFile(filepath.Join(dir, "cluster.env"), []byte(mapToString(clusterEnv)), filePerms)
 }
 
-func createSidecarEnv(internalIP string, externalIP, dir string) error {
-	sidecarEnv := generateSidecarEnvAsMap(internalIP, externalIP)
+func createSidecarEnv(internalIP, externalIP, dir, revision string) error {
+	sidecarEnv := generateSidecarEnvAsMap(internalIP, externalIP, revision)
 
 	// If there is no sidecar specific configuration, then don't write the file and exit first.
 	allEmpty := true
@@ -378,9 +379,12 @@ func createSidecarEnv(internalIP string, externalIP, dir string) error {
 	return os.WriteFile(filepath.Join(dir, "sidecar.env"), []byte(mapToString(sidecarEnv)), filePerms)
 }
 
-func generateSidecarEnvAsMap(internalIP string, externalIP string) map[string]string {
+func generateSidecarEnvAsMap(internalIP string, externalIP string, revision string) map[string]string {
 	sidecarEnv := make(map[string]string)
 
+	if isRevisioned(revision) {
+		sidecarEnv["CA_ADDR"] = istiodAddr(revision)
+	}
 	if len(internalIP) > 0 {
 		sidecarEnv["ISTIO_SVC_IP"] = internalIP
 	} else if len(externalIP) > 0 {
@@ -452,11 +456,10 @@ func createCertsTokens(kubeClient kube.ExtendedClient, wg *clientv1alpha3.Worklo
 	return nil
 }
 
-func createMeshConfig(kubeClient kube.ExtendedClient, wg *clientv1alpha3.WorkloadGroup, clusterID, dir string) (*meshconfig.ProxyConfig, error) {
+func createMeshConfig(kubeClient kube.ExtendedClient, wg *clientv1alpha3.WorkloadGroup, clusterID, dir, revision string) (*meshconfig.ProxyConfig, error) {
 	istioCM := "istio"
 	// Case with multiple control planes
-	revision := kubeClient.Revision()
-	if revision != "" && revision != "default" {
+	if isRevisioned(revision) {
 		istioCM = fmt.Sprintf("%s-%s", istioCM, revision)
 	}
 	istio, err := kubeClient.CoreV1().ConfigMaps(istioNamespace).Get(context.Background(), istioCM, metav1.GetOptions{})
@@ -473,9 +476,8 @@ func createMeshConfig(kubeClient kube.ExtendedClient, wg *clientv1alpha3.Workloa
 	if err := gogoprotomarshal.ApplyYAML(istio.Data[configMapKey], meshConfig); err != nil {
 		return nil, err
 	}
-	if revision != "" && revision != "default" && meshConfig.DefaultConfig.DiscoveryAddress == "" {
-		// TODO make port configurable
-		meshConfig.DefaultConfig.DiscoveryAddress = fmt.Sprintf("istiod-%s.%s.svc.cluster.local:15012", revision, istioNamespace)
+	if isRevisioned(revision) && meshConfig.DefaultConfig.DiscoveryAddress == "" {
+		meshConfig.DefaultConfig.DiscoveryAddress = istiodAddr(revision)
 	}
 
 	// performing separate map-merge, apply seems to completely overwrite all metadata
@@ -563,7 +565,7 @@ func workloadEntryToPodPortsMeta(p map[string]uint32) model.PodPortList {
 }
 
 // Retrieves the external IP of the ingress-gateway for the hosts file additions
-func createHosts(kubeClient kube.ExtendedClient, ingressIP, dir string) error {
+func createHosts(kubeClient kube.ExtendedClient, ingressIP, dir string, revision string) error {
 	// try to infer the ingress IP if the provided one is invalid
 	if validation.ValidateIPAddress(ingressIP) != nil {
 		p := strings.Split(ingressSvc, ".")
@@ -584,17 +586,29 @@ func createHosts(kubeClient kube.ExtendedClient, ingressIP, dir string) error {
 	}
 
 	var hosts string
-	istiod := "istiod"
-	revision := kubeClient.Revision()
-	if revision != "" && revision != "default" {
-		istiod = fmt.Sprintf("%s-%s", istiod, revision)
-	}
 	if net.ParseIP(ingressIP) != nil {
-		hosts = fmt.Sprintf("%s %s.%s.svc\n", ingressIP, istiod, istioNamespace)
+		hosts = fmt.Sprintf("%s %s\n", ingressIP, istiodHost(revision))
 	} else {
-		log.Warnf("Could not auto-detect IP for %s.%s. Use --ingressIP to manually specify the Gateway address to reach istiod from the VM.", istiod, istioNamespace)
+		log.Warnf("Could not auto-detect IP for. Use --ingressIP to manually specify the Gateway address to reach istiod from the VM.", istiodHost(revision), istioNamespace)
 	}
 	return os.WriteFile(filepath.Join(dir, "hosts"), []byte(hosts), filePerms)
+}
+
+func isRevisioned(revision string) bool {
+	return revision != "" && revision != "default"
+}
+
+func istiodHost(revision string) string {
+	istiod := "istiod"
+	if isRevisioned(revision) {
+		istiod = fmt.Sprintf("%s-%s", istiod, revision)
+	}
+	return fmt.Sprintf("%s.%s.svc", istiod, istioNamespace)
+}
+
+func istiodAddr(revision string) string {
+	// TODO make port configurable
+	return fmt.Sprintf("%s:%d", istiodHost(revision), 15012)
 }
 
 // Returns a map with each k,v entry on a new line
@@ -612,7 +626,7 @@ func extractClusterIDFromInjectionConfig(kubeClient kube.ExtendedClient) (string
 	injectionConfigMap := "istio-sidecar-injector"
 	// Case with multiple control planes
 	revision := kubeClient.Revision()
-	if revision != "" && revision != "default" {
+	if isRevisioned(revision) {
 		injectionConfigMap = fmt.Sprintf("%s-%s", injectionConfigMap, revision)
 	}
 	istioInjectionCM, err := kubeClient.CoreV1().ConfigMaps(istioNamespace).Get(context.Background(), injectionConfigMap, metav1.GetOptions{})

--- a/istioctl/cmd/workload.go
+++ b/istioctl/cmd/workload.go
@@ -474,7 +474,8 @@ func createMeshConfig(kubeClient kube.ExtendedClient, wg *clientv1alpha3.Workloa
 		return nil, err
 	}
 	if revision != "" && revision != "default" && meshConfig.DefaultConfig.DiscoveryAddress == "" {
-		meshConfig.DefaultConfig.DiscoveryAddress = fmt.Sprintf("istiod-%s.%s.svc.cluster.local", revision, istioNamespace)
+		// TODO make port configurable
+		meshConfig.DefaultConfig.DiscoveryAddress = fmt.Sprintf("istiod-%s.%s.svc.cluster.local:15012", revision, istioNamespace)
 	}
 
 	// performing separate map-merge, apply seems to completely overwrite all metadata

--- a/istioctl/cmd/workload_test.go
+++ b/istioctl/cmd/workload_test.go
@@ -354,7 +354,7 @@ func TestSidecarConfigGeneration(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		gotSidecarEnvMap := generateSidecarEnvAsMap(tt.internalIP, tt.externalIP)
+		gotSidecarEnvMap := generateSidecarEnvAsMap(tt.internalIP, tt.externalIP, "")
 		if !reflect.DeepEqual(gotSidecarEnvMap, tt.expectedSidecarEnv) {
 			t.Errorf("generateSidecarEnvAsMap() got = %v, want %v", gotSidecarEnvMap, tt.expectedSidecarEnv)
 		}

--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -370,7 +370,7 @@ spec:
 
           # place mounted bootstrap files (token is mounted directly to the correct location)
           sudo cp /var/run/secrets/istio/bootstrap/root-cert.pem /var/run/secrets/istio/root-cert.pem
-          sudo cp /var/run/secrets/istio/bootstrap/cluster.env /var/lib/istio/envoy/cluster.env
+          sudo cp /var/run/secrets/istio/bootstrap/*.env /var/lib/istio/envoy/
           sudo cp /var/run/secrets/istio/bootstrap/mesh.yaml /etc/istio/config/mesh
           sudo sh -c 'cat /var/run/secrets/istio/bootstrap/hosts >> /etc/hosts'
 
@@ -835,8 +835,15 @@ spec:
 
 		// push boostrap config as a ConfigMap so we can mount it on our "vm" pods
 		cmData := map[string][]byte{}
-		for _, file := range []string{"cluster.env", "mesh.yaml", "root-cert.pem", "hosts"} {
-			cmData[file], err = os.ReadFile(path.Join(subsetDir, file))
+		generatedFiles, err := os.ReadDir(subsetDir)
+		if err != nil {
+			return err
+		}
+		for _, file := range generatedFiles {
+			if file.IsDir() {
+				continue
+			}
+			cmData[file.Name()], err = os.ReadFile(path.Join(subsetDir, file.Name()))
 			if err != nil {
 				return err
 			}

--- a/pkg/test/framework/components/istio/eastwest.go
+++ b/pkg/test/framework/components/istio/eastwest.go
@@ -37,7 +37,7 @@ import (
 var (
 	mcSamples              = path.Join(env.IstioSrc, "samples", "multicluster")
 	exposeIstiodGateway    = path.Join(mcSamples, "expose-istiod.yaml")
-	exposeIstiodGatewayRev = path.Join(mcSamples, "expose-istiod-rev.yaml")
+	exposeIstiodGatewayRev = path.Join(mcSamples, "expose-istiod-rev.yaml.tmpl")
 	exposeServicesGateway  = path.Join(mcSamples, "expose-services.yaml")
 	genGatewayScript       = path.Join(mcSamples, "gen-eastwest-gateway.sh")
 )

--- a/pkg/test/framework/components/istio/eastwest.go
+++ b/pkg/test/framework/components/istio/eastwest.go
@@ -17,6 +17,7 @@ package istio
 import (
 	"context"
 	"fmt"
+	"istio.io/istio/pkg/test/util/tmpl"
 	"os"
 	"os/exec"
 	"path"
@@ -34,10 +35,11 @@ import (
 )
 
 var (
-	mcSamples             = path.Join(env.IstioSrc, "samples", "multicluster")
-	exposeIstiodGateway   = path.Join(mcSamples, "expose-istiod.yaml")
-	exposeServicesGateway = path.Join(mcSamples, "expose-services.yaml")
-	genGatewayScript      = path.Join(mcSamples, "gen-eastwest-gateway.sh")
+	mcSamples              = path.Join(env.IstioSrc, "samples", "multicluster")
+	exposeIstiodGateway    = path.Join(mcSamples, "expose-istiod.yaml")
+	exposeIstiodGatewayRev = path.Join(mcSamples, "expose-istiod-rev.yaml")
+	exposeServicesGateway  = path.Join(mcSamples, "expose-services.yaml")
+	genGatewayScript       = path.Join(mcSamples, "gen-eastwest-gateway.sh")
 )
 
 // deployEastWestGateway will create a separate gateway deployment for cross-cluster discovery or cross-network services.
@@ -128,7 +130,15 @@ func (i *operatorComponent) exposeUserServices(cluster cluster.Cluster) error {
 	return cluster.ApplyYAMLFiles(i.settings.SystemNamespace, exposeServicesGateway)
 }
 
-func (i *operatorComponent) applyIstiodGateway(cluster cluster.Cluster) error {
+func (i *operatorComponent) applyIstiodGateway(cluster cluster.Cluster, revision string) error {
 	scopes.Framework.Infof("Exposing istiod via eastwestgateway in %v", cluster.Name())
-	return cluster.ApplyYAMLFiles(i.settings.SystemNamespace, exposeIstiodGateway)
+	if revision == "" {
+		return cluster.ApplyYAMLFiles(i.settings.SystemNamespace, exposeIstiodGateway)
+	}
+	gwTmpl, err := os.ReadFile(exposeIstiodGatewayRev)
+	if err != nil {
+		return fmt.Errorf("failed loading template %s: %v", exposeIstiodGatewayRev, err)
+	}
+	out, err := tmpl.Evaluate(string(gwTmpl), map[string]string{"Revision": revision})
+	return i.ctx.Config(cluster).ApplyYAML(i.settings.SystemNamespace, out)
 }

--- a/pkg/test/framework/components/istio/eastwest.go
+++ b/pkg/test/framework/components/istio/eastwest.go
@@ -17,7 +17,6 @@ package istio
 import (
 	"context"
 	"fmt"
-	"istio.io/istio/pkg/test/util/tmpl"
 	"os"
 	"os/exec"
 	"path"
@@ -32,6 +31,7 @@ import (
 	"istio.io/istio/pkg/test/framework/image"
 	"istio.io/istio/pkg/test/scopes"
 	"istio.io/istio/pkg/test/util/retry"
+	"istio.io/istio/pkg/test/util/tmpl"
 )
 
 var (
@@ -140,5 +140,8 @@ func (i *operatorComponent) applyIstiodGateway(cluster cluster.Cluster, revision
 		return fmt.Errorf("failed loading template %s: %v", exposeIstiodGatewayRev, err)
 	}
 	out, err := tmpl.Evaluate(string(gwTmpl), map[string]string{"Revision": revision})
+	if err != nil {
+		return fmt.Errorf("failed running template %s: %v", exposeIstiodGatewayRev, err)
+	}
 	return i.ctx.Config(cluster).ApplyYAML(i.settings.SystemNamespace, out)
 }

--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -595,7 +595,7 @@ func installControlPlaneCluster(i *operatorComponent, cfg Config, c cluster.Clus
 			return err
 		}
 		// Other clusters should only use this for discovery if its a config cluster.
-		if err := i.applyIstiodGateway(c); err != nil {
+		if err := i.applyIstiodGateway(c, spec.Revision); err != nil {
 			return fmt.Errorf("failed applying istiod gateway for cluster %s: %v", c.Name(), err)
 		}
 		if err := waitForIstioReady(i.ctx, c, cfg); err != nil {

--- a/pkg/test/framework/components/namespace/kube.go
+++ b/pkg/test/framework/components/namespace/kube.go
@@ -101,7 +101,7 @@ func (n *kubeNamespace) Labels() (map[string]string, error) {
 			continue
 		}
 		if diff := cmp.Diff(perCluster[0], clusterLabels); diff != "" {
-			log.Warnf("namespace labels are different accross clusters:\n%s", diff)
+			log.Warnf("namespace labels are different across clusters:\n%s", diff)
 		}
 	}
 	return perCluster[0], nil

--- a/pkg/test/framework/components/namespace/kube.go
+++ b/pkg/test/framework/components/namespace/kube.go
@@ -23,8 +23,10 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/go-multierror"
 	kubeApiCore "k8s.io/api/core/v1"
-	kubeApiMeta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	"istio.io/api/label"
@@ -32,6 +34,7 @@ import (
 	"istio.io/istio/pkg/test/framework/resource"
 	kube2 "istio.io/istio/pkg/test/kube"
 	"istio.io/istio/pkg/test/scopes"
+	"istio.io/pkg/log"
 )
 
 var (
@@ -76,6 +79,34 @@ func (n *kubeNamespace) Prefix() string {
 	return n.prefix
 }
 
+func (n *kubeNamespace) Labels() (map[string]string, error) {
+	perCluster := make([]map[string]string, len(n.ctx.Clusters()))
+	errG := multierror.Group{}
+	for i, cluster := range n.ctx.Clusters() {
+		i, cluster := i, cluster
+		errG.Go(func() error {
+			ns, err := cluster.CoreV1().Namespaces().Get(context.TODO(), n.Name(), metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			perCluster[i] = ns.Labels
+			return nil
+		})
+	}
+	if err := errG.Wait().ErrorOrNil(); err != nil {
+		return nil, err
+	}
+	for i, clusterLabels := range perCluster {
+		if i == 0 {
+			continue
+		}
+		if diff := cmp.Diff(perCluster[0], clusterLabels); diff != "" {
+			log.Warnf("namespace labels are different accross clusters:\n%s", diff)
+		}
+	}
+	return perCluster[0], nil
+}
+
 func (n *kubeNamespace) SetLabel(key, value string) error {
 	return n.setNamespaceLabel(key, value)
 }
@@ -108,11 +139,11 @@ func claimKube(ctx resource.Context, nsConfig *Config) (Instance, error) {
 	for _, cluster := range ctx.Clusters().Kube() {
 		if !kube2.NamespaceExists(cluster, nsConfig.Prefix) {
 			if _, err := cluster.CoreV1().Namespaces().Create(context.TODO(), &kubeApiCore.Namespace{
-				ObjectMeta: kubeApiMeta.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:   nsConfig.Prefix,
 					Labels: createNamespaceLabels(ctx, nsConfig),
 				},
-			}, kubeApiMeta.CreateOptions{}); err != nil {
+			}, metav1.CreateOptions{}); err != nil {
 				return nil, err
 			}
 		}
@@ -126,7 +157,7 @@ func (n *kubeNamespace) setNamespaceLabel(key, value string) error {
 	jsonPatchEscapedKey := strings.ReplaceAll(key, "/", "~1")
 	for _, cluster := range n.ctx.Clusters().Kube() {
 		nsLabelPatch := fmt.Sprintf(`[{"op":"replace","path":"/metadata/labels/%s","value":"%s"}]`, jsonPatchEscapedKey, value)
-		if _, err := cluster.CoreV1().Namespaces().Patch(context.TODO(), n.name, types.JSONPatchType, []byte(nsLabelPatch), kubeApiMeta.PatchOptions{}); err != nil {
+		if _, err := cluster.CoreV1().Namespaces().Patch(context.TODO(), n.name, types.JSONPatchType, []byte(nsLabelPatch), metav1.PatchOptions{}); err != nil {
 			return err
 		}
 	}
@@ -140,7 +171,7 @@ func (n *kubeNamespace) removeNamespaceLabel(key string) error {
 	jsonPatchEscapedKey := strings.ReplaceAll(key, "/", "~1")
 	for _, cluster := range n.ctx.Clusters().Kube() {
 		nsLabelPatch := fmt.Sprintf(`[{"op":"remove","path":"/metadata/labels/%s"}]`, jsonPatchEscapedKey)
-		if _, err := cluster.CoreV1().Namespaces().Patch(context.TODO(), n.name, types.JSONPatchType, []byte(nsLabelPatch), kubeApiMeta.PatchOptions{}); err != nil {
+		if _, err := cluster.CoreV1().Namespaces().Patch(context.TODO(), n.name, types.JSONPatchType, []byte(nsLabelPatch), metav1.PatchOptions{}); err != nil {
 			return err
 		}
 	}
@@ -167,11 +198,11 @@ func newKube(ctx resource.Context, nsConfig *Config) (Instance, error) {
 
 	for _, cluster := range n.ctx.Clusters().Kube() {
 		if _, err := cluster.CoreV1().Namespaces().Create(context.TODO(), &kubeApiCore.Namespace{
-			ObjectMeta: kubeApiMeta.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:   ns,
 				Labels: createNamespaceLabels(ctx, nsConfig),
 			},
-		}, kubeApiMeta.CreateOptions{}); err != nil {
+		}, metav1.CreateOptions{}); err != nil {
 			return nil, err
 		}
 		settings, err := image.SettingsFromCommandLine()

--- a/pkg/test/framework/components/namespace/namespace.go
+++ b/pkg/test/framework/components/namespace/namespace.go
@@ -37,6 +37,7 @@ type Instance interface {
 	SetLabel(key, value string) error
 	RemoveLabel(key string) error
 	Prefix() string
+	Labels() (map[string]string, error)
 }
 
 // Claim an existing namespace in all clusters, or create a new one if doesn't exist.

--- a/pkg/test/framework/components/namespace/static.go
+++ b/pkg/test/framework/components/namespace/static.go
@@ -30,6 +30,10 @@ func (s Static) Prefix() string {
 	return string(s)
 }
 
+func (s Static) Labels() (map[string]string, error) {
+	panic("implement me")
+}
+
 func (s Static) SetLabel(key, value string) error {
 	panic("implement me")
 }

--- a/releasenotes/notes/35290.yaml
+++ b/releasenotes/notes/35290.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+
+releaseNotes:
+  - |
+    **Fixed** VMs are able to use a revisioned control plane specified by `--revision` on the `istioctl x workload entry`
+    command.

--- a/samples/multicluster/expose-istiod-rev.yaml
+++ b/samples/multicluster/expose-istiod-rev.yaml
@@ -26,7 +26,7 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
-  name: istiod-vs-{{.Revision}}
+  name: istiod-vs
 spec:
   hosts:
   - "*"

--- a/samples/multicluster/expose-istiod-rev.yaml
+++ b/samples/multicluster/expose-istiod-rev.yaml
@@ -1,0 +1,54 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: istiod-gateway
+spec:
+  selector:
+    istio: eastwestgateway
+  servers:
+    - port:
+        name: tls-istiod
+        number: 15012
+        protocol: tls
+      tls:
+        mode: PASSTHROUGH        
+      hosts:
+        - "*"
+    - port:
+        name: tls-istiodwebhook
+        number: 15017
+        protocol: tls
+      tls:
+        mode: PASSTHROUGH          
+      hosts:
+        - "*"
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: istiod-vs-{{.Revision}}
+spec:
+  hosts:
+  - "*"
+  gateways:
+  - istiod-gateway
+  tls:
+  - match:
+    - port: 15012
+      sniHosts:
+      - "*"
+    route:
+    - destination:
+        host: istiod-{{.Revision}}.istio-system.svc.cluster.local
+        port:
+          number: 15012
+  - match:
+    - port: 15017
+      sniHosts:
+      - "*"
+    route:
+    - destination:
+        host: istiod-{{.Revision}}.istio-system.svc.cluster.local
+        port:
+          number: 443
+

--- a/samples/multicluster/expose-istiod-rev.yaml.tmpl
+++ b/samples/multicluster/expose-istiod-rev.yaml.tmpl
@@ -26,7 +26,7 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
-  name: istiod-vs
+  name: istiod-vs-{{.Revision}}
 spec:
   hosts:
   - "*"
@@ -36,7 +36,8 @@ spec:
   - match:
     - port: 15012
       sniHosts:
-      - "*"
+      - "istiod-{{.Revision}}.istio-system.svc"
+      - "istiod-{{.Revision}}.istio-system.svc.cluster.local"
     route:
     - destination:
         host: istiod-{{.Revision}}.istio-system.svc.cluster.local
@@ -45,7 +46,8 @@ spec:
   - match:
     - port: 15017
       sniHosts:
-      - "*"
+      - "istiod-{{.Revision}}.istio-system.svc"
+      - "istiod-{{.Revision}}.istio-system.svc.cluster.local"
     route:
     - destination:
         host: istiod-{{.Revision}}.istio-system.svc.cluster.local

--- a/tests/integration/pilot/revisions/revisions_test.go
+++ b/tests/integration/pilot/revisions/revisions_test.go
@@ -18,6 +18,9 @@
 package revisions
 
 import (
+	"testing"
+	"time"
+
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
@@ -27,8 +30,6 @@ import (
 	"istio.io/istio/pkg/test/framework/label"
 	"istio.io/istio/pkg/test/framework/resource"
 	"istio.io/istio/pkg/test/util/retry"
-	"testing"
-	"time"
 )
 
 // TestMain defines the entrypoint for pilot tests using a standard Istio installation.

--- a/tests/integration/pilot/revisions/revisions_test.go
+++ b/tests/integration/pilot/revisions/revisions_test.go
@@ -95,9 +95,10 @@ func TestMultiRevision(t *testing.T) {
 				}).
 				// tests bootstrap
 				WithConfig(echo.Config{
-					Service:   "vm",
-					Namespace: canary,
-					Ports:     []echo.Port{},
+					Service:    "vm",
+					Namespace:  canary,
+					DeployAsVM: true,
+					Ports:      []echo.Port{},
 				}).
 				BuildOrFail(t)
 			retry.UntilSuccessOrFail(t, func() error {

--- a/tools/packaging/common/istio-start.sh
+++ b/tools/packaging/common/istio-start.sh
@@ -46,10 +46,6 @@ NS=${ISTIO_NAMESPACE:-default}
 SVC=${ISTIO_SERVICE:-rawvm}
 ISTIO_SYSTEM_NAMESPACE=${ISTIO_SYSTEM_NAMESPACE:-istio-system}
 
-# The default matches the default istio.yaml - use sidecar.env to override this if you
-# enable auth. This requires node-agent to be running.
-ISTIO_PILOT_PORT=${ISTIO_PILOT_PORT:-15012}
-
 # If set, override the default
 CONTROL_PLANE_AUTH_POLICY=${ISTIO_CP_AUTH:-"MUTUAL_TLS"}
 
@@ -99,11 +95,16 @@ if [ "${ISTIO_INBOUND_INTERCEPTION_MODE}" = "TPROXY" ] ; then
   EXEC_USER=root
 fi
 
-if [ -z "${PILOT_ADDRESS:-}" ]; then
-  PILOT_ADDRESS=istiod.${ISTIO_SYSTEM_NAMESPACE}.svc:${ISTIO_PILOT_PORT}
+# The default matches the default istio.yaml - use sidecar.env to override ISTIO_PILOT_PORT or CA_ADDR if you
+# enable auth. This requires node-agent to be running.
+DEFAULT_PILOT_ADDRESS="istiod.${ISTIO_SYSTEM_NAMESPACE}.svc:15012"
+CUSTOM_PILOT_ADDRESS="${PILOT_ADDRESS:-}"
+if [ -z "${CUSTOM_PILOT_ADDRESS}" ] && [ -n "${ISTIO_PILOT_PORT:-}" ]; then
+  CUSTOM_PILOT_ADDRESS=istiod.${ISTIO_SYSTEM_NAMESPACE}.svc:${ISTIO_PILOT_PORT}
 fi
 
-CA_ADDR=${CA_ADDR:-${PILOT_ADDRESS}}
+# CA_ADDR > PILOT_ADDRESS > ISTIO_PILOT_PORT
+CA_ADDR=${CA_ADDR:-${CUSTOM_PILOT_ADDRESS:-${DEFAULT_PILOT_ADDRESS}}}
 PROV_CERT=${PROV_CERT-/etc/certs}
 OUTPUT_CERTS=${OUTPUT_CERTS-/etc/certs}
 
@@ -116,11 +117,18 @@ ISTIO_AGENT_FLAGS=${ISTIO_AGENT_FLAGS:-}
 # Split ISTIO_AGENT_FLAGS by spaces.
 IFS=' ' read -r -a ISTIO_AGENT_FLAGS_ARRAY <<< "$ISTIO_AGENT_FLAGS"
 
-export PROXY_CONFIG=${PROXY_CONFIG:-"
+DEFAULT_PROXY_CONFIG="
 serviceCluster: $SVC
 controlPlaneAuthPolicy: ${CONTROL_PLANE_AUTH_POLICY}
-discoveryAddress: ${PILOT_ADDRESS}
-"}
+"
+if [ -n "${CUSTOM_PILOT_ADDRESS}" ]; then
+  PROXY_CONFIG="$PROXY_CONFIG
+  discoveryAddress: ${CUSTOM_PILOT_ADDRESS}
+"
+fi
+
+# PROXY_CONFIG > PILOT_ADDRESS > ISTIO_PILOT_PORT
+export PROXY_CONFIG=${PROXY_CONFIG:-${DEFAULT_PROXY_CONFIG}}
 
 if [ ${EXEC_USER} == "${USER:-}" ] ; then
   # if started as istio-proxy (or current user), do a normal start, without

--- a/tools/packaging/common/istio-start.sh
+++ b/tools/packaging/common/istio-start.sh
@@ -123,7 +123,7 @@ controlPlaneAuthPolicy: ${CONTROL_PLANE_AUTH_POLICY}
 "
 if [ -n "${CUSTOM_PILOT_ADDRESS}" ]; then
   PROXY_CONFIG="$PROXY_CONFIG
-  discoveryAddress: ${CUSTOM_PILOT_ADDRESS}
+discoveryAddress: ${CUSTOM_PILOT_ADDRESS}
 "
 fi
 


### PR DESCRIPTION
similar to #34060 – need to do more investigation on the safety and triple check the test does what I think it does 

* This should make `CA_ADDR`, `PILOT_ADDRESS` and `ISTIO_PILOT_PORT` vars still work in a backward compatible way, but avoid overriding with the default if the user didn't customize the envs. 
* The workload command now properly sets the port for the discovery address
* The workload command sets the CA_ADDR to match the discovery address (if rev is specified)
* The tests actually copy `sidecar.env` 
* The tests actually deploy a VM
* The test send traffic from the VM to make sure it connected to istiod properly
* The tests deploy a VirtualService pointing to the revisioned version of the eastwest gateway (this may need some cleanup to match the specific SNI)