### PR TITLE
compute sidecar for gateway when service entry is added

### DIFF
--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -669,6 +669,11 @@ func (s *DiscoveryServer) computeProxyState(proxy *model.Proxy, request *model.P
 		proxy.SetSidecarScope(push)
 	case gateway && proxy.Type == model.Router:
 		proxy.SetGatewaysForProxy(push)
+		// If any config related to service entry changes like adding a new service entry
+		// we should recompute the default sidecar scope for gateways.
+		if sidecar {
+			proxy.SetSidecarScope(push)
+		}
 	default:
 		proxy.SetSidecarScope(push)
 		proxy.SetGatewaysForProxy(push)

--- a/releasenotes/notes/35293.yaml
+++ b/releasenotes/notes/35293.yaml
@@ -2,7 +2,7 @@ apiVersion: release-notes/v2
 kind: bug-fix
 area: traffic-management
 issue:
-- 35068
+- 35172
 releaseNotes:
 - |
-  **Fixed** An issue when service entry and gateway created at same time, the service entry is ignored some times.
+  **Fixed** an issue when creating a Service and Gateway at the same time, causing the Service to be ignored.

--- a/releasenotes/notes/35293.yaml
+++ b/releasenotes/notes/35293.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+- 35068
+releaseNotes:
+- |
+  **Fixed** An issue when service entry and gateway created at same time, the service entry is ignored some times.


### PR DESCRIPTION
When service entry and gateway are added at the same time, service entry is not sent. Regression from this https://github.com/istio/istio/commit/ec1766dd7e315b2e43bb5497e008a8cd36271a9c.

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure