### PR TITLE
Allow `/validate/*` URL for validation

### DIFF
--- a/pkg/webhooks/validation/server/server.go
+++ b/pkg/webhooks/validation/server/server.go
@@ -116,6 +116,7 @@ func New(o Options) (*Webhook, error) {
 	}
 
 	o.Mux.HandleFunc("/validate", wh.serveValidate)
+	o.Mux.HandleFunc("/validate/", wh.serveValidate)
 
 	return wh, nil
 }


### PR DESCRIPTION
This matches the injector, and allows using the same URL suffix for inject and
validation for simplicity

**Please provide a description of this PR:**



**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
