### PR TITLE
validation controller reconciler improvements

### DIFF
--- a/pkg/webhooks/validation/controller/controller.go
+++ b/pkg/webhooks/validation/controller/controller.go
@@ -403,7 +403,7 @@ func (c *Controller) updateValidatingWebhookConfiguration(current *kubeApiAdmiss
 	dirty := false
 	for i := range current.Webhooks {
 		if !bytes.Equal(current.Webhooks[i].ClientConfig.CABundle, caBundle) ||
-			*current.Webhooks[i].FailurePolicy != failurePolicy {
+			(current.Webhooks[i].FailurePolicy != nil && *current.Webhooks[i].FailurePolicy != failurePolicy) {
 			dirty = true
 			break
 		}

--- a/pkg/webhooks/validation/controller/controller.go
+++ b/pkg/webhooks/validation/controller/controller.go
@@ -193,7 +193,7 @@ func newController(
 	c := &Controller{
 		o:      o,
 		client: client,
-		queue:  workqueue.NewRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(1*time.Second, 1*time.Minute)),
+		queue:  workqueue.NewRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(1*time.Second, 5*time.Minute)),
 	}
 
 	webhookInformer := cache.NewSharedIndexInformer(
@@ -350,8 +350,9 @@ func (c *Controller) readyForFailClose() bool {
 }
 
 const (
-	deniedRequestMessageFragment   = `denied the request`
-	missingResourceMessageFragment = `the server could not find the requested resource`
+	deniedRequestMessageFragment     = `denied the request`
+	missingResourceMessageFragment   = `the server could not find the requested resource`
+	unsupportedDryRunMessageFragment = `does not support dry run`
 )
 
 // Confirm invalid configuration is successfully rejected before switching to FAIL-CLOSE.
@@ -388,36 +389,48 @@ func (c *Controller) isDryRunOfInvalidConfigRejected() (rejected bool, reason st
 		scope.Warnf("Missing Gateway CRD, cannot perform validation check. Assuming validation is ready")
 		return true, ""
 	}
+	// If some validating webhooks does not support dryRun(sideEffects=Unknown or Some), we will get this error.
+	// We should assume valdiation is ready because there is no point in retrying this request.
+	if strings.Contains(err.Error(), unsupportedDryRunMessageFragment) {
+		scope.Warnf("One of the validating webhooks does not support DryRun, cannot perform validation check. Assuming validation is ready. Details: %v", err)
+		return true, ""
+	}
 	return false, fmt.Sprintf("dummy invalid rejected for the wrong reason: %v", err)
 }
 
 func (c *Controller) updateValidatingWebhookConfiguration(current *kubeApiAdmission.ValidatingWebhookConfiguration,
 	caBundle []byte, failurePolicy kubeApiAdmission.FailurePolicyType) error {
+	dirty := false
+	for i := range current.Webhooks {
+		if !bytes.Equal(current.Webhooks[i].ClientConfig.CABundle, caBundle) ||
+			*current.Webhooks[i].FailurePolicy != failurePolicy {
+			dirty = true
+			break
+		}
+	}
+	if !dirty {
+		scope.Infof("validatingwebhookconfiguration %v (failurePolicy=%v, resourceVersion=%v) is up-to-date. No change required.",
+			current.Name, failurePolicy, current.ResourceVersion)
+		return nil
+	}
 	updated := current.DeepCopy()
 	for i := range updated.Webhooks {
 		updated.Webhooks[i].ClientConfig.CABundle = caBundle
 		updated.Webhooks[i].FailurePolicy = &failurePolicy
 	}
 
-	if !reflect.DeepEqual(updated, current) {
-		latest, err := c.client.AdmissionregistrationV1().
-			ValidatingWebhookConfigurations().Update(context.TODO(), updated, metav1.UpdateOptions{})
-		if err != nil {
-			scope.Errorf("Failed to update validatingwebhookconfiguration %v (failurePolicy=%v, resourceVersion=%v): %v",
-				updated.Name, failurePolicy, updated.ResourceVersion, err)
-			reportValidationConfigUpdateError(kubeErrors.ReasonForError(err))
-			return err
-		}
-
-		scope.Infof("Successfully updated validatingwebhookconfiguration %v (failurePolicy=%v,resourceVersion=%v)",
-			updated.Name, failurePolicy, latest.ResourceVersion)
-		reportValidationConfigUpdate()
-		return nil
+	latest, err := c.client.AdmissionregistrationV1().
+		ValidatingWebhookConfigurations().Update(context.TODO(), updated, metav1.UpdateOptions{})
+	if err != nil {
+		scope.Errorf("Failed to update validatingwebhookconfiguration %v (failurePolicy=%v, resourceVersion=%v): %v",
+			updated.Name, failurePolicy, updated.ResourceVersion, err)
+		reportValidationConfigUpdateError(kubeErrors.ReasonForError(err))
+		return err
 	}
 
-	scope.Infof("validatingwebhookconfiguration %v (failurePolicy=%v, resourceVersion=%v) is up-to-date. No change required.",
-		current.Name, failurePolicy, current.ResourceVersion)
-
+	scope.Infof("Successfully updated validatingwebhookconfiguration %v (failurePolicy=%v,resourceVersion=%v)",
+		updated.Name, failurePolicy, latest.ResourceVersion)
+	reportValidationConfigUpdate()
 	return nil
 }
 


### PR DESCRIPTION
Some improvements to validation controller based on our recent experience
- Increase the MaxBackOff delay to 5m from 1m. When there is an error these retry calls are too frequent.
- If there is a  validation webhook that does not allow dryRun - the reconciler never exists the loop and continuously spams the logs with the error 
```
Not ready to switch validation to fail-closed: dummy invalid rejected for the wrong reason: admission webhook "validating-webhook.openpolicyagent.org" does not support dry run
```
- Improve update logic (in retries it is firing updates even though nothing is changed because I guess failure policy is a pointer in webhook I guess)

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure