### PR TITLE
failure allocating port when doing port forward in IPv6 only k8s cluster

### DIFF
--- a/pkg/kube/portforwarder.go
+++ b/pkg/kube/portforwarder.go
@@ -134,16 +134,17 @@ func newPortForwarder(restConfig *rest.Config, podName, ns, localAddress string,
 		return nil, fmt.Errorf("pod is not running. Status=%v", pod.Status.Phase)
 	}
 
+	sLocalPort := fmt.Sprintf("%d", localPort)
 	return &forwarder{
 		forwarder: fw,
 		stopCh:    stopCh,
 		readyCh:   readyCh,
-		address:   fmt.Sprintf("%s:%d", localAddress, localPort),
+		address:   net.JoinHostPort(localAddress, sLocalPort),
 	}, nil
 }
 
 func availablePort(localAddr string) (int, error) {
-	addr, err := net.ResolveTCPAddr("tcp", localAddr+":0")
+	addr, err := net.ResolveTCPAddr("tcp", net.JoinHostPort(localAddr, "0"))
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
there is error message showing as below when doing port forward in IPv6 only k8s cluster,

```
Error: failed to execute command on productpage-v1-6b746f74dc-rj7dn.default sidecar: failure allocating port: address x:x:x:x:x:x:x:x:0 too many colons in address
```
Should use `net.JoinHostPort` to allocate port which can dynamically support for both IPv4 and IPv6 format.

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure