### PR TITLE
Allow publishing explicit `-debug` tagged images

### DIFF
--- a/cni/deployments/kubernetes/Dockerfile.install-cni
+++ b/cni/deployments/kubernetes/Dockerfile.install-cni
@@ -12,7 +12,7 @@ FROM gcr.io/istio-release/distroless:${BASE_VERSION} as distroless
 
 # This will build the final image based on either debug or distroless from above
 # hadolint ignore=DL3006
-FROM ${BASE_DISTRIBUTION}
+FROM ${BASE_DISTRIBUTION:-debug}
 
 LABEL description="Istio CNI plugin installer."
 

--- a/cni/deployments/kubernetes/Dockerfile.install-cni
+++ b/cni/deployments/kubernetes/Dockerfile.install-cni
@@ -1,16 +1,16 @@
 # BASE_DISTRIBUTION is used to switch between the old base distribution and distroless base images
-ARG BASE_DISTRIBUTION=default
+ARG BASE_DISTRIBUTION=debug
 
 # Version is the base image version from the TLD Makefile
 ARG BASE_VERSION=latest
 
-# The following section is used as base image if BASE_DISTRIBUTION=default
-FROM gcr.io/istio-release/base:${BASE_VERSION} as default
+# The following section is used as base image if BASE_DISTRIBUTION=debug
+FROM gcr.io/istio-release/base:${BASE_VERSION} as debug
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
 FROM gcr.io/istio-release/distroless:${BASE_VERSION} as distroless
 
-# This will build the final image based on either default or distroless from above
+# This will build the final image based on either debug or distroless from above
 # hadolint ignore=DL3006
 FROM ${BASE_DISTRIBUTION}
 

--- a/operator/docker/Dockerfile.operator
+++ b/operator/docker/Dockerfile.operator
@@ -12,7 +12,7 @@ FROM gcr.io/istio-release/distroless:${BASE_VERSION} as distroless
 
 # This will build the final image based on either debug or distroless from above
 # hadolint ignore=DL3006
-FROM ${BASE_DISTRIBUTION}
+FROM ${BASE_DISTRIBUTION:-debug}
 
 # install operator binary
 ARG TARGETARCH

--- a/operator/docker/Dockerfile.operator
+++ b/operator/docker/Dockerfile.operator
@@ -1,16 +1,16 @@
 # BASE_DISTRIBUTION is used to switch between the old base distribution and distroless base images
-ARG BASE_DISTRIBUTION=default
+ARG BASE_DISTRIBUTION=debug
 
 # Version is the base image version from the TLD Makefile
 ARG BASE_VERSION=latest
 
-# The following section is used as base image if BASE_DISTRIBUTION=default
-FROM gcr.io/istio-release/base:${BASE_VERSION} as default
+# The following section is used as base image if BASE_DISTRIBUTION=debug
+FROM gcr.io/istio-release/base:${BASE_VERSION} as debug
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
 FROM gcr.io/istio-release/distroless:${BASE_VERSION} as distroless
 
-# This will build the final image based on either default or distroless from above
+# This will build the final image based on either debug or distroless from above
 # hadolint ignore=DL3006
 FROM ${BASE_DISTRIBUTION}
 

--- a/pilot/docker/Dockerfile.pilot
+++ b/pilot/docker/Dockerfile.pilot
@@ -12,7 +12,7 @@ FROM gcr.io/istio-release/distroless:${BASE_VERSION} as distroless
 
 # This will build the final image based on either debug or distroless from above
 # hadolint ignore=DL3006
-FROM ${BASE_DISTRIBUTION}
+FROM ${BASE_DISTRIBUTION:-debug}
 
 ARG TARGETARCH
 COPY ${TARGETARCH:-amd64}/pilot-discovery /usr/local/bin/pilot-discovery

--- a/pilot/docker/Dockerfile.pilot
+++ b/pilot/docker/Dockerfile.pilot
@@ -1,16 +1,16 @@
 # BASE_DISTRIBUTION is used to switch between the old base distribution and distroless base images
-ARG BASE_DISTRIBUTION=default
+ARG BASE_DISTRIBUTION=debug
 
 # Version is the base image version from the TLD Makefile
 ARG BASE_VERSION=latest
 
-# The following section is used as base image if BASE_DISTRIBUTION=default
-FROM gcr.io/istio-release/base:${BASE_VERSION} as default
+# The following section is used as base image if BASE_DISTRIBUTION=debug
+FROM gcr.io/istio-release/base:${BASE_VERSION} as debug
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
 FROM gcr.io/istio-release/distroless:${BASE_VERSION} as distroless
 
-# This will build the final image based on either default or distroless from above
+# This will build the final image based on either debug or distroless from above
 # hadolint ignore=DL3006
 FROM ${BASE_DISTRIBUTION}
 

--- a/pilot/docker/Dockerfile.proxyv2
+++ b/pilot/docker/Dockerfile.proxyv2
@@ -1,11 +1,11 @@
 # BASE_DISTRIBUTION is used to switch between the old base distribution and distroless base images
-ARG BASE_DISTRIBUTION=default
+ARG BASE_DISTRIBUTION=debug
 
 # Version is the base image version from the TLD Makefile
 ARG BASE_VERSION=latest
 
-# The following section is used as base image if BASE_DISTRIBUTION=default
-FROM gcr.io/istio-release/base:${BASE_VERSION} as default
+# The following section is used as base image if BASE_DISTRIBUTION=debug
+FROM gcr.io/istio-release/base:${BASE_VERSION} as debug
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
 # This image is a custom built debian11 distroless image with multiarchitecture support.
@@ -14,7 +14,7 @@ FROM gcr.io/istio-release/base:${BASE_VERSION} as default
 # This version is from commit a2477f8b37647391020a12527a3a7126ced2b582.
 FROM gcr.io/istio-release/iptables@sha256:e5bbbcdab26db1b5bf580bd823204dc82485545e27ce877ca2ad2eb0dc3b55a0 as distroless
 
-# This will build the final image based on either default or distroless from above
+# This will build the final image based on either debug or distroless from above
 # hadolint ignore=DL3006
 FROM ${BASE_DISTRIBUTION}
 

--- a/pilot/docker/Dockerfile.proxyv2
+++ b/pilot/docker/Dockerfile.proxyv2
@@ -16,7 +16,7 @@ FROM gcr.io/istio-release/iptables@sha256:e5bbbcdab26db1b5bf580bd823204dc8248554
 
 # This will build the final image based on either debug or distroless from above
 # hadolint ignore=DL3006
-FROM ${BASE_DISTRIBUTION}
+FROM ${BASE_DISTRIBUTION:-debug}
 
 WORKDIR /
 

--- a/prow/release-commit.sh
+++ b/prow/release-commit.sh
@@ -32,7 +32,7 @@ DOCKER_HUB=${DOCKER_HUB:-gcr.io/istio-testing}
 GCS_BUCKET=${GCS_BUCKET:-istio-build/dev}
 
 # Use a pinned version in case breaking changes are needed
-BUILDER_SHA=b84702ef5d23549007093d9e59c0597e8d3538c2
+BUILDER_SHA=f3df7cc5dfb29887a276ee7194f1bd4c6d8555ba
 
 # Reference to the next minor version of Istio
 # This will create a version like 1.4-alpha.sha

--- a/prow/release-commit.sh
+++ b/prow/release-commit.sh
@@ -32,7 +32,7 @@ DOCKER_HUB=${DOCKER_HUB:-gcr.io/istio-testing}
 GCS_BUCKET=${GCS_BUCKET:-istio-build/dev}
 
 # Use a pinned version in case breaking changes are needed
-BUILDER_SHA=343862e8279d9acd0308256b69a5f93fe74d5fde
+BUILDER_SHA=b84702ef5d23549007093d9e59c0597e8d3538c2
 
 # Reference to the next minor version of Istio
 # This will create a version like 1.4-alpha.sha

--- a/samples/tcp-echo/src/Dockerfile
+++ b/samples/tcp-echo/src/Dockerfile
@@ -31,7 +31,7 @@ FROM gcr.io/distroless/static-debian10@sha256:4433370ec2b3b97b338674b4de5ffaef8c
 
 # This will build the final image based on either default or distroless from above
 # hadolint ignore=DL3006
-FROM ${BASE_DISTRIBUTION}
+FROM ${BASE_DISTRIBUTION:-debug}
 WORKDIR /bin/
 # copy the tcp-echo binary to a separate container based on BASE_DISTRIBUTION
 COPY --from=builder /go/src/istio.io/tcp-echo-server/tcp-echo .

--- a/tools/buildx-gen.sh
+++ b/tools/buildx-gen.sh
@@ -39,13 +39,10 @@ cat <<EOF > "${config}"
 group "all" {
     targets = [${variants}]
 }
-group "default" {
-    targets = ["${DEFAULT_VARIANT}"]
-}
 EOF
 
 # Generate the top header. This defines a group to build all images for each variant
-for variant in ${DOCKER_ALL_VARIANTS}; do
+for variant in ${DOCKER_ALL_VARIANTS} default; do
   # Get all images. Transform from `docker.target` to `"target"` as a comma separated list
   images=\"$(for i in "$@"; do
     if ! "${WD}/skip-image.sh" "$i" "$variant"; then echo "\"${i#docker.}-${variant}\""; fi
@@ -59,7 +56,7 @@ done
 
 # For each docker image, define a target to build it
 for file in "$@"; do
-  for variant in ${DOCKER_ALL_VARIANTS}; do
+  for variant in ${DOCKER_ALL_VARIANTS} default; do
     image=${file#docker.}
     tag="${TAG}-${variant}"
 
@@ -90,6 +87,8 @@ for file in "$@"; do
         if [[ "${INCLUDE_UNTAGGED_DEFAULT}" == "true" ]]; then
           tags=${tags}"\"${hub}/${image}:${TAG}\", "
         fi
+      elif [[ "${variant}" == "default" ]]; then
+        tags=${tags}"\"${hub}/${image}:${TAG}\", "
       else
         tags=${tags}"\"${hub}/${image}:${tag}\", "
       fi
@@ -104,7 +103,7 @@ target "$image-$variant" {
     platforms = [$(to_platform_list "${image}" "${DOCKER_ARCHITECTURES}")]
     args = {
       BASE_VERSION = "${BASE_VERSION}"
-      BASE_DISTRIBUTION = "${variant}"
+      BASE_DISTRIBUTION = "${variant/default/${DEFAULT_VARIANT}}"
       proxy_version = "istio-proxy:${PROXY_REPO_SHA}"
       istio_version = "${VERSION}"
       VM_IMAGE_NAME = "${VM_IMAGE_NAME}"

--- a/tools/buildx-gen.sh
+++ b/tools/buildx-gen.sh
@@ -24,7 +24,7 @@ config="${out}/docker-bake.hcl"
 shift
 
 DEFAULT_VARIANT="${DEFAULT_VARIANT:-debug}"
-INCLUDE_TAGGED_DEFAULT="${INCLUDE_TAGGED_DEFAULT:-false}"
+INCLUDE_UNTAGGED_DEFAULT="${INCLUDE_UNTAGGED_DEFAULT:-false}"
 
 function to_platform_list() {
   image="${1}"
@@ -86,9 +86,9 @@ for file in "$@"; do
     for hub in ${HUBS};
     do
       if [[ "${variant}" = "${DEFAULT_VARIANT}" ]]; then
-        tags=${tags}"\"${hub}/${image}:${TAG}\", "
-        if [[ "${INCLUDE_TAGGED_DEFAULT}" == "true" ]]; then
-          tags=${tags}"\"${hub}/${image}:${tag}\", "
+        tags=${tags}"\"${hub}/${image}:${tag}\", "
+        if [[ "${INCLUDE_UNTAGGED_DEFAULT}" == "true" ]]; then
+          tags=${tags}"\"${hub}/${image}:${TAG}\", "
         fi
       else
         tags=${tags}"\"${hub}/${image}:${tag}\", "

--- a/tools/istio-docker.mk
+++ b/tools/istio-docker.mk
@@ -235,6 +235,7 @@ dockerx:
 		VERSION=$(VERSION) \
 		DOCKER_ALL_VARIANTS="$(DOCKER_ALL_VARIANTS)" \
 		ISTIO_DOCKER_TAR=$(ISTIO_DOCKER_TAR) \
+		INCLUDE_TAGGED_DEFAULT=$(INCLUDE_TAGGED_DEFAULT) \
 		BASE_VERSION=$(BASE_VERSION) \
 		DOCKERX_PUSH=$(DOCKERX_PUSH) \
 		DOCKER_ARCHITECTURES=$(DOCKER_ARCHITECTURES) \
@@ -303,10 +304,11 @@ docker.distroless: docker/Dockerfile.distroless
 # 4. This rule runs $(BUILD_PRE) prior to any docker build and only if specified as a dependency variable
 # 5. This rule finally runs docker build passing $(BUILD_ARGS) to docker if they are specified as a dependency variable
 
-# DOCKER_BUILD_VARIANTS ?=default distroless
+# DOCKER_BUILD_VARIANTS ?=debug distroless
 DOCKER_BUILD_VARIANTS ?= default
-DOCKER_ALL_VARIANTS ?= default distroless
-DEFAULT_DISTRIBUTION=default
+DOCKER_ALL_VARIANTS ?= debug distroless
+INCLUDE_TAGGED_DEFAULT ?= false
+DEFAULT_DISTRIBUTION=debug
 DOCKER_RULE ?= $(foreach VARIANT,$(DOCKER_BUILD_VARIANTS), time (mkdir -p $(DOCKER_BUILD_TOP)/$@ && TARGET_ARCH=$(TARGET_ARCH) ./tools/docker-copy.sh $^ $(DOCKER_BUILD_TOP)/$@ && cd $(DOCKER_BUILD_TOP)/$@ $(BUILD_PRE) && docker build $(BUILD_ARGS) --build-arg BASE_DISTRIBUTION=$(VARIANT) -t $(HUB)/$(subst docker.,,$@):$(subst -$(DEFAULT_DISTRIBUTION),,$(TAG)-$(VARIANT)) -f Dockerfile$(suffix $@) . ); )
 RENAME_TEMPLATE ?= mkdir -p $(DOCKER_BUILD_TOP)/$@ && cp $(ECHO_DOCKER)/$(VM_OS_DOCKERFILE_TEMPLATE) $(DOCKER_BUILD_TOP)/$@/Dockerfile$(suffix $@)
 

--- a/tools/istio-docker.mk
+++ b/tools/istio-docker.mk
@@ -235,7 +235,7 @@ dockerx:
 		VERSION=$(VERSION) \
 		DOCKER_ALL_VARIANTS="$(DOCKER_ALL_VARIANTS)" \
 		ISTIO_DOCKER_TAR=$(ISTIO_DOCKER_TAR) \
-		INCLUDE_TAGGED_DEFAULT=$(INCLUDE_TAGGED_DEFAULT) \
+		INCLUDE_UNTAGGED_DEFAULT=$(INCLUDE_UNTAGGED_DEFAULT) \
 		BASE_VERSION=$(BASE_VERSION) \
 		DOCKERX_PUSH=$(DOCKERX_PUSH) \
 		DOCKER_ARCHITECTURES=$(DOCKER_ARCHITECTURES) \
@@ -304,12 +304,23 @@ docker.distroless: docker/Dockerfile.distroless
 # 4. This rule runs $(BUILD_PRE) prior to any docker build and only if specified as a dependency variable
 # 5. This rule finally runs docker build passing $(BUILD_ARGS) to docker if they are specified as a dependency variable
 
+
+define variant-tag
+$(if $(filter-out default,$(1)),-$(1),)
+endef
+
 # DOCKER_BUILD_VARIANTS ?=debug distroless
-DOCKER_BUILD_VARIANTS ?= default
+# Base images have two different forms:
+# * "debug", suffixed as -debug. This is a ubuntu based image with a bunch of debug tools
+# * "distroless", suffixed as -distroless. This is distroless image - no shell. proxyv2 uses a custom one with iptables added
+# * "default", no suffix. This is currently "debug"
+DOCKER_BUILD_VARIANTS ?= ""
 DOCKER_ALL_VARIANTS ?= debug distroless
-INCLUDE_TAGGED_DEFAULT ?= false
+# If INCLUDE_UNTAGGED_DEFAULT is set, then building the "DEFAULT_DISTRIBUTION" variant will publish both <tag>-<variant> and <tag>
+# This can be done with DOCKER_BUILD_VARIANTS="default debug" as well, but at the expense of building twice vs building once and tagging twice
+INCLUDE_UNTAGGED_DEFAULT ?= false
 DEFAULT_DISTRIBUTION=debug
-DOCKER_RULE ?= $(foreach VARIANT,$(DOCKER_BUILD_VARIANTS), time (mkdir -p $(DOCKER_BUILD_TOP)/$@ && TARGET_ARCH=$(TARGET_ARCH) ./tools/docker-copy.sh $^ $(DOCKER_BUILD_TOP)/$@ && cd $(DOCKER_BUILD_TOP)/$@ $(BUILD_PRE) && docker build $(BUILD_ARGS) --build-arg BASE_DISTRIBUTION=$(VARIANT) -t $(HUB)/$(subst docker.,,$@):$(subst -$(DEFAULT_DISTRIBUTION),,$(TAG)-$(VARIANT)) -f Dockerfile$(suffix $@) . ); )
+DOCKER_RULE ?= $(foreach VARIANT,$(DOCKER_BUILD_VARIANTS), time (mkdir -p $(DOCKER_BUILD_TOP)/$@ && TARGET_ARCH=$(TARGET_ARCH) ./tools/docker-copy.sh $^ $(DOCKER_BUILD_TOP)/$@ && cd $(DOCKER_BUILD_TOP)/$@ $(BUILD_PRE) && docker build $(BUILD_ARGS) --build-arg BASE_DISTRIBUTION=$(VARIANT) -t $(HUB)/$(subst docker.,,$@):$(TAG)$(call variant-tag,$(VARIANT)) -f Dockerfile$(suffix $@) . ); )
 RENAME_TEMPLATE ?= mkdir -p $(DOCKER_BUILD_TOP)/$@ && cp $(ECHO_DOCKER)/$(VM_OS_DOCKERFILE_TEMPLATE) $(DOCKER_BUILD_TOP)/$@/Dockerfile$(suffix $@)
 
 # This target will package all docker images used in test and release, without re-building
@@ -324,8 +335,8 @@ docker.all: $(DOCKER_TARGETS)
 DOCKER_TAR_TARGETS:=
 $(foreach TGT,$(DOCKER_TARGETS),$(eval tar.$(TGT): $(TGT) | $(ISTIO_DOCKER_TAR) ; \
          $(foreach VARIANT,$(DOCKER_BUILD_VARIANTS), time ( \
-		     docker save -o ${ISTIO_DOCKER_TAR}/$(subst docker.,,$(TGT))$(subst -$(DEFAULT_DISTRIBUTION),,-$(VARIANT)).tar $(HUB)/$(subst docker.,,$(TGT)):$(subst -$(DEFAULT_DISTRIBUTION),,$(TAG)-$(VARIANT)) && \
-             gzip ${ISTIO_DOCKER_TAR}/$(subst docker.,,$(TGT))$(subst -$(DEFAULT_DISTRIBUTION),,-$(VARIANT)).tar \
+		     docker save -o ${ISTIO_DOCKER_TAR}/$(subst docker.,,$(TGT))$(call variant-tag,$(VARIANT)).tar $(HUB)/$(subst docker.,,$(TGT)):$(subst -$(DEFAULT_DISTRIBUTION),,$(TAG)-$(VARIANT)) && \
+             gzip ${ISTIO_DOCKER_TAR}/$(subst docker.,,$(TGT))$(call variant-tag,$(VARIANT)).tar \
 			   ); \
 		  )))
 
@@ -339,8 +350,8 @@ dockerx.save: dockerx $(ISTIO_DOCKER_TAR)
 	   if ! ./tools/skip-image.sh $(TGT) $(VARIANT); then \
 	   time ( \
 		 echo $(TGT)-$(VARIANT); \
-		 docker save $(HUB)/$(subst docker.,,$(TGT)):$(subst -$(DEFAULT_DISTRIBUTION),,$(TAG)-$(VARIANT)) |\
-		 gzip --fast > ${ISTIO_DOCKER_TAR}/$(subst docker.,,$(TGT))$(subst -$(DEFAULT_DISTRIBUTION),,-$(VARIANT)).tar.gz \
+		 docker save $(HUB)/$(subst docker.,,$(TGT)):$(TAG)$(call variant-tag,$(VARIANT)) |\
+		 gzip --fast > ${ISTIO_DOCKER_TAR}/$(subst docker.,,$(TGT))$(call variant-tag,$(VARIANT)).tar.gz \
 	   ); \
 	   fi; \
 	 ))


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/31711

This shifts our images from three options:
* `-distroless` - explicit distroless
* `-debug` - explicit debug
* no suffix - whatever Istio project choses. Default now, distroless in
the future

Honestly this is pretty complex, the makefile is a bit of a mess..