### PR TITLE
Fixing MCS for EndpointSlice mode

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/endpointcontroller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpointcontroller.go
@@ -39,7 +39,7 @@ type kubeEndpointsController interface {
 	InstancesByPort(c *Controller, svc *model.Service, reqSvcPort int, labelsList labels.Collection) []*model.ServiceInstance
 	GetProxyServiceInstances(c *Controller, proxy *model.Proxy) []*model.ServiceInstance
 	buildIstioEndpoints(ep interface{}, host host.Name) []*model.IstioEndpoint
-	buildIstioEndpointsWithService(name, namespace string, host host.Name) []*model.IstioEndpoint
+	buildIstioEndpointsWithService(name, namespace string, host host.Name, clearCache bool) []*model.IstioEndpoint
 	// forgetEndpoint does internal bookkeeping on a deleted endpoint
 	forgetEndpoint(endpoint interface{}) map[host.Name][]*model.IstioEndpoint
 	getServiceNamespacedName(ep interface{}) types.NamespacedName

--- a/pilot/pkg/serviceregistry/kube/controller/endpoints.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpoints.go
@@ -212,7 +212,7 @@ func (e *endpointsController) buildIstioEndpoints(endpoint interface{}, host hos
 	return endpoints
 }
 
-func (e *endpointsController) buildIstioEndpointsWithService(name, namespace string, host host.Name) []*model.IstioEndpoint {
+func (e *endpointsController) buildIstioEndpointsWithService(name, namespace string, host host.Name, _ bool) []*model.IstioEndpoint {
 	ep, err := listerv1.NewEndpointsLister(e.informer.GetIndexer()).Endpoints(namespace).Get(name)
 	if err != nil || ep == nil {
 		log.Debugf("endpoints(%s, %s) not found => error %v", name, namespace, err)

--- a/pilot/pkg/serviceregistry/kube/controller/serviceexportcache.go
+++ b/pilot/pkg/serviceregistry/kube/controller/serviceexportcache.go
@@ -29,6 +29,11 @@ import (
 	kubesr "istio.io/istio/pilot/pkg/serviceregistry/kube"
 )
 
+type exportedService struct {
+	namespacedName                types.NamespacedName
+	endpointDiscoverabilityPolicy string
+}
+
 // serviceExportCache reads Kubernetes Multi-Cluster Services (MCS) ServiceExport resources in the
 // cluster and generates discoverability policies for the endpoints.
 type serviceExportCache interface {
@@ -36,7 +41,7 @@ type serviceExportCache interface {
 	EndpointDiscoverabilityPolicy(svc *model.Service) model.EndpointDiscoverabilityPolicy
 
 	// ExportedServices returns the list of services that are exported in this cluster. Used for debugging.
-	ExportedServices() []types.NamespacedName
+	ExportedServices() []exportedService
 
 	// HasSynced indicates whether the kube client has synced for the watched resources.
 	HasSynced() bool
@@ -53,7 +58,7 @@ func newServiceExportCache(c *Controller) serviceExportCache {
 		}
 
 		// Register callbacks for events.
-		c.registerHandlers(informer, "ServiceExports", sec.onEvent, nil)
+		c.registerHandlers(informer, "ServiceExports", sec.onServiceExportEvent, nil)
 		return sec
 	}
 
@@ -68,7 +73,7 @@ type serviceExportCacheImpl struct {
 	lister   mcsLister.ServiceExportLister
 }
 
-func (ec *serviceExportCacheImpl) onEvent(obj interface{}, event model.Event) error {
+func (ec *serviceExportCacheImpl) onServiceExportEvent(obj interface{}, event model.Event) error {
 	se, ok := obj.(*mcsCore.ServiceExport)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
@@ -91,28 +96,30 @@ func (ec *serviceExportCacheImpl) onEvent(obj interface{}, event model.Event) er
 }
 
 func (ec *serviceExportCacheImpl) updateXDS(se metav1.Object) {
-	hostname := kubesr.ServiceHostnameForKR(se, ec.opts.DomainSuffix)
-	svc := ec.GetService(hostname)
-	if svc == nil {
-		// The service doesn't exist - nothing to update.
-		return
-	}
-
-	// Update the endpoint cache for this cluster and push an update.
-	endpoints := ec.buildEndpointsForService(svc)
-	if len(endpoints) > 0 {
+	for _, svc := range ec.servicesForNamespacedName(kubesr.NamespacedNameForK8sObject(se)) {
+		// Re-build the endpoints for this service with a new discoverability policy.
+		// Also update any internal caching.
+		endpoints := ec.buildEndpointsForService(svc, true)
 		shard := model.ShardKeyFromRegistry(ec)
-		ec.opts.XDSUpdater.EDSUpdate(shard, string(hostname), se.GetNamespace(), endpoints)
+		ec.opts.XDSUpdater.EDSUpdate(shard, svc.Hostname.String(), se.GetNamespace(), endpoints)
 	}
 }
 
-func (ec *serviceExportCacheImpl) EndpointDiscoverabilityPolicy(svc *model.Service) model.EndpointDiscoverabilityPolicy {
-	if svc == nil || !ec.isExported(namespacedNameForService(svc)) {
+func (ec *serviceExportCacheImpl) EndpointDiscoverabilityPolicy(svc *model.Service) (policy model.EndpointDiscoverabilityPolicy) {
+	if svc == nil {
+		// Default policy when the service doesn't exist.
 		return model.DiscoverableFromSameCluster
 	}
 
 	// TODO(nmittler): Once we can configure cluster.local to actually be cluster.local, consider the hostname.
-	return model.AlwaysDiscoverable
+
+	// MCS hosts (clusterset.local) and exported services are discoverable from anywhere in the mesh.
+	if ec.isExported(namespacedNameForService(svc)) {
+		return model.AlwaysDiscoverable
+	}
+
+	// Otherwise, endpoints are only discoverable from within the same cluster.
+	return model.DiscoverableFromSameCluster
 }
 
 func (ec *serviceExportCacheImpl) isExported(name types.NamespacedName) bool {
@@ -120,17 +127,25 @@ func (ec *serviceExportCacheImpl) isExported(name types.NamespacedName) bool {
 	return err == nil
 }
 
-func (ec *serviceExportCacheImpl) ExportedServices() []types.NamespacedName {
+func (ec *serviceExportCacheImpl) ExportedServices() []exportedService {
 	// List all exports in this cluster.
-	exports, err := ec.lister.List(klabels.NewSelector())
+	exports, err := ec.lister.List(klabels.Everything())
 	if err != nil {
-		return make([]types.NamespacedName, 0)
+		return make([]exportedService, 0)
 	}
 
-	out := make([]types.NamespacedName, 0, len(exports))
+	ec.RLock()
+
+	out := make([]exportedService, 0, len(exports))
 	for _, export := range exports {
-		out = append(out, kubesr.NamespacedNameForK8sObject(export))
+		svc := ec.servicesMap[kubesr.ServiceHostname(export.Name, export.Namespace, ec.opts.DomainSuffix)]
+		out = append(out, exportedService{
+			namespacedName:                kubesr.NamespacedNameForK8sObject(export),
+			endpointDiscoverabilityPolicy: ec.EndpointDiscoverabilityPolicy(svc).String(),
+		})
 	}
+
+	ec.RUnlock()
 
 	return out
 }
@@ -151,7 +166,7 @@ func (c disabledServiceExportCache) HasSynced() bool {
 	return true
 }
 
-func (c disabledServiceExportCache) ExportedServices() []types.NamespacedName {
+func (c disabledServiceExportCache) ExportedServices() []exportedService {
 	// MCS is disabled - returning `nil`, which is semantically different here than an empty list.
 	return nil
 }

--- a/pilot/pkg/serviceregistry/kube/controller/serviceimportcache_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/serviceimportcache_test.go
@@ -53,112 +53,148 @@ var (
 )
 
 func TestServiceNotImported(t *testing.T) {
-	c, ic, cleanup := newTestServiceImportCache()
-	defer cleanup()
+	for _, mode := range []EndpointMode{EndpointsOnly, EndpointSliceOnly} {
+		t.Run(mode.String(), func(t *testing.T) {
+			c, ic, cleanup := newTestServiceImportCache(mode)
+			defer cleanup()
 
-	ic.createKubeService(t, c)
+			ic.createKubeService(t, c)
 
-	// Check that the service does not have ClusterSet IPs.
-	ic.checkServiceInstances(t)
+			// Check that the service does not have ClusterSet IPs.
+			ic.checkServiceInstances(t)
+		})
+	}
 }
 
 func TestServiceImportedAfterCreated(t *testing.T) {
-	c, ic, cleanup := newTestServiceImportCache()
-	defer cleanup()
+	for _, mode := range []EndpointMode{EndpointsOnly, EndpointSliceOnly} {
+		t.Run(mode.String(), func(t *testing.T) {
+			c, ic, cleanup := newTestServiceImportCache(mode)
+			defer cleanup()
 
-	ic.createKubeService(t, c)
-	ic.createServiceImport(t, mcs.ClusterSetIP, serviceImportVIPs)
+			ic.createKubeService(t, c)
+			ic.createServiceImport(t, mcs.ClusterSetIP, serviceImportVIPs)
 
-	// Check that the service has been assigned ClusterSet IPs.
-	ic.checkServiceInstances(t)
+			// Check that the service has been assigned ClusterSet IPs.
+			ic.checkServiceInstances(t)
+		})
+	}
 }
 
 func TestServiceCreatedAfterImported(t *testing.T) {
-	c, ic, cleanup := newTestServiceImportCache()
-	defer cleanup()
+	for _, mode := range []EndpointMode{EndpointsOnly, EndpointSliceOnly} {
+		t.Run(mode.String(), func(t *testing.T) {
+			c, ic, cleanup := newTestServiceImportCache(mode)
+			defer cleanup()
 
-	ic.createServiceImport(t, mcs.ClusterSetIP, serviceImportVIPs)
-	ic.createKubeService(t, c)
+			ic.createServiceImport(t, mcs.ClusterSetIP, serviceImportVIPs)
+			ic.createKubeService(t, c)
 
-	// Check that the service has been assigned ClusterSet IPs.
-	ic.checkServiceInstances(t)
+			// Check that the service has been assigned ClusterSet IPs.
+			ic.checkServiceInstances(t)
+		})
+	}
 }
 
 func TestUpdateImportedService(t *testing.T) {
-	c, ic, cleanup := newTestServiceImportCache()
-	defer cleanup()
+	for _, mode := range []EndpointMode{EndpointsOnly, EndpointSliceOnly} {
+		t.Run(mode.String(), func(t *testing.T) {
+			c, ic, cleanup := newTestServiceImportCache(mode)
+			defer cleanup()
 
-	ic.createKubeService(t, c)
-	ic.createServiceImport(t, mcs.ClusterSetIP, serviceImportVIPs)
-	ic.checkServiceInstances(t)
+			ic.createKubeService(t, c)
+			ic.createServiceImport(t, mcs.ClusterSetIP, serviceImportVIPs)
+			ic.checkServiceInstances(t)
 
-	// Update the k8s service and verify that both services are updated.
-	ic.updateKubeService(t)
+			// Update the k8s service and verify that both services are updated.
+			ic.updateKubeService(t)
+		})
+	}
 }
 
 func TestHeadlessServiceImported(t *testing.T) {
-	// Create and run the controller.
-	c, ic, cleanup := newTestServiceImportCache()
-	defer cleanup()
+	for _, mode := range []EndpointMode{EndpointsOnly, EndpointSliceOnly} {
+		t.Run(mode.String(), func(t *testing.T) {
+			// Create and run the controller.
+			c, ic, cleanup := newTestServiceImportCache(mode)
+			defer cleanup()
 
-	ic.createKubeService(t, c)
-	ic.createServiceImport(t, mcs.Headless, nil)
+			ic.createKubeService(t, c)
+			ic.createServiceImport(t, mcs.Headless, nil)
 
-	// Verify that we did not generate the synthetic service for the headless service.
-	ic.checkServiceInstances(t)
+			// Verify that we did not generate the synthetic service for the headless service.
+			ic.checkServiceInstances(t)
+		})
+	}
 }
 
 func TestDeleteImportedService(t *testing.T) {
-	// Create and run the controller.
-	c, ic, cleanup := newTestServiceImportCache()
-	defer cleanup()
+	for _, mode := range []EndpointMode{EndpointsOnly, EndpointSliceOnly} {
+		t.Run(mode.String(), func(t *testing.T) {
+			// Create and run the controller.
+			c, ic, cleanup := newTestServiceImportCache(mode)
+			defer cleanup()
 
-	ic.createKubeService(t, c)
-	ic.createServiceImport(t, mcs.ClusterSetIP, serviceImportVIPs)
-	ic.checkServiceInstances(t)
+			ic.createKubeService(t, c)
+			ic.createServiceImport(t, mcs.ClusterSetIP, serviceImportVIPs)
+			ic.checkServiceInstances(t)
 
-	// Delete the k8s service and verify that all internal services are removed.
-	ic.deleteKubeService(t)
+			// Delete the k8s service and verify that all internal services are removed.
+			ic.deleteKubeService(t)
+		})
+	}
 }
 
 func TestUnimportService(t *testing.T) {
-	// Create and run the controller.
-	c, ic, cleanup := newTestServiceImportCache()
-	defer cleanup()
+	for _, mode := range []EndpointMode{EndpointsOnly, EndpointSliceOnly} {
+		t.Run(mode.String(), func(t *testing.T) {
+			// Create and run the controller.
+			c, ic, cleanup := newTestServiceImportCache(mode)
+			defer cleanup()
 
-	ic.createKubeService(t, c)
-	ic.createServiceImport(t, mcs.ClusterSetIP, serviceImportVIPs)
-	ic.checkServiceInstances(t)
+			ic.createKubeService(t, c)
+			ic.createServiceImport(t, mcs.ClusterSetIP, serviceImportVIPs)
+			ic.checkServiceInstances(t)
 
-	ic.unimportService(t)
+			ic.unimportService(t)
+		})
+	}
 }
 
 func TestAddServiceImportVIPs(t *testing.T) {
-	// Create and run the controller.
-	c, ic, cleanup := newTestServiceImportCache()
-	defer cleanup()
+	for _, mode := range []EndpointMode{EndpointsOnly, EndpointSliceOnly} {
+		t.Run(mode.String(), func(t *testing.T) {
+			// Create and run the controller.
+			c, ic, cleanup := newTestServiceImportCache(mode)
+			defer cleanup()
 
-	ic.createKubeService(t, c)
-	ic.createServiceImport(t, mcs.ClusterSetIP, nil)
-	ic.checkServiceInstances(t)
+			ic.createKubeService(t, c)
+			ic.createServiceImport(t, mcs.ClusterSetIP, nil)
+			ic.checkServiceInstances(t)
 
-	ic.setServiceImportVIPs(t, serviceImportVIPs)
+			ic.setServiceImportVIPs(t, serviceImportVIPs)
+		})
+	}
 }
 
 func TestUpdateServiceImportVIPs(t *testing.T) {
-	// Create and run the controller.
-	c, ic, cleanup := newTestServiceImportCache()
-	defer cleanup()
+	for _, mode := range []EndpointMode{EndpointsOnly, EndpointSliceOnly} {
+		t.Run(mode.String(), func(t *testing.T) {
+			// Create and run the controller.
+			c, ic, cleanup := newTestServiceImportCache(mode)
+			defer cleanup()
 
-	ic.createKubeService(t, c)
-	ic.createServiceImport(t, mcs.ClusterSetIP, serviceImportVIPs)
-	ic.checkServiceInstances(t)
+			ic.createKubeService(t, c)
+			ic.createServiceImport(t, mcs.ClusterSetIP, serviceImportVIPs)
+			ic.checkServiceInstances(t)
 
-	updatedVIPs := []string{"1.1.1.1", "1.1.1.2"}
-	ic.setServiceImportVIPs(t, updatedVIPs)
+			updatedVIPs := []string{"1.1.1.1", "1.1.1.2"}
+			ic.setServiceImportVIPs(t, updatedVIPs)
+		})
+	}
 }
 
-func newTestServiceImportCache() (c *FakeController, ic *serviceImportCacheImpl, cleanup func()) {
+func newTestServiceImportCache(mode EndpointMode) (c *FakeController, ic *serviceImportCacheImpl, cleanup func()) {
 	stopCh := make(chan struct{})
 	prevEnableMCSHost := features.EnableMCSHost
 	features.EnableMCSHost = true
@@ -170,6 +206,7 @@ func newTestServiceImportCache() (c *FakeController, ic *serviceImportCacheImpl,
 	c, _ = NewFakeControllerWithOptions(FakeControllerOptions{
 		Stop:      stopCh,
 		ClusterID: serviceImportCluster,
+		Mode:      mode,
 	})
 
 	ic = c.imports.(*serviceImportCacheImpl)


### PR DESCRIPTION
When receiving a `ServiceExport`, the `serviceExportCache` calls into the kube endpoint controller to build the endpoints. However, when in `EndpointSlice` mode, this simply returns the pre-built endpoints in an internal cache. This means that the endpoints will never get the updated `EndpointDiscoverabilityPolicy`, allowing them to be discovered across the mesh.

This PR allows the `serviceExportCache` to request a rebuild of the cache for the service.

Also does some other minor improvements around debuggability (mcsz), etc.

**Please provide a description of this PR:**