### PR TITLE
update the ratelimit service image

### DIFF
--- a/samples/ratelimit/rate-limit-service.yaml
+++ b/samples/ratelimit/rate-limit-service.yaml
@@ -113,7 +113,7 @@ spec:
         app: ratelimit
     spec:
       containers:
-      - image: envoyproxy/ratelimit:6f5de117 # 2021/01/08
+      - image: envoyproxy/ratelimit:40393342
         imagePullPolicy: Always
         name: ratelimit
         command: ["/bin/ratelimit"]


### PR DESCRIPTION
**Please provide a description of this PR:**
update the image used by the Rate Limit service，using `envoyproxy/ratelimit:6f5de117` image on the gateway will not work.
ref: https://github.com/istio/istio/issues/30900#issuecomment-786754760
       
**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [x] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
