### PR TITLE
ServiceEntry ignores inactive pods at EventAdd

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/pod.go
+++ b/pilot/pkg/serviceregistry/kube/controller/pod.go
@@ -134,6 +134,8 @@ func (pc *PodCache) onEvent(curr interface{}, ev model.Event) error {
 				if !IsPodReady(pod) {
 					ev = model.EventDelete
 				}
+			default:
+				return nil
 			}
 		case model.EventUpdate:
 			if pod.DeletionTimestamp != nil {


### PR DESCRIPTION
**Please provide a description of this PR:**

ServiceEntry should ignore inactive pods on pod EventAdd.

If not, inactive pods (whose phase is Succeeded or Failed) will be used by ServiceEntry to make instances when pilot firstly received these pods' Add events.