### PR TITLE
Fix syntax error in stackdriver test file templates

### DIFF
--- a/tests/integration/telemetry/stackdriver/testdata/client_request_count.json.tmpl
+++ b/tests/integration/telemetry/stackdriver/testdata/client_request_count.json.tmpl
@@ -25,8 +25,7 @@
           "source_workload_name": "clt-{{ .ClusterName }}-v1",
           "source_workload_namespace": "{{ .EchoNamespace }}"
        }
-    },
-    {{- if .OnGCE  }}
+    }{{- if .OnGCE  }},
     "resource": {
        "labels": {
           "namespace_name": "{{ .EchoNamespace }}"

--- a/tests/integration/telemetry/stackdriver/testdata/client_tcp_connection_count.json.tmpl
+++ b/tests/integration/telemetry/stackdriver/testdata/client_tcp_connection_count.json.tmpl
@@ -23,8 +23,7 @@
           "source_workload_name": "clt-{{ .ClusterName }}-v1",
           "source_workload_namespace": "{{ .EchoNamespace }}"
        }
-    },
-    {{- if .OnGCE  }}
+    }{{- if .OnGCE  }},
     "resource": {
        "labels": {
           "namespace_name": "{{ .EchoNamespace }}"

--- a/tests/integration/telemetry/stackdriver/testdata/custom_bootstrap.yaml.tmpl
+++ b/tests/integration/telemetry/stackdriver/testdata/custom_bootstrap.yaml.tmpl
@@ -14,8 +14,7 @@ data:
           "STACKDRIVER_MONITORING_EXPORT_INTERVAL_SECS": "10",
           "MESH_ID": "proj-test-mesh",
         }
-      },
-      {{- if not .UseRealSD }}
+      }{{- if not .UseRealSD }},
       "tracing": {
         "http": {
           "name": "envoy.tracers.opencensus",
@@ -52,6 +51,6 @@ data:
             ]
           }
         }
-      },
+      }
       {{- end }}
     }

--- a/tests/integration/telemetry/stackdriver/testdata/server_request_count.json.tmpl
+++ b/tests/integration/telemetry/stackdriver/testdata/server_request_count.json.tmpl
@@ -25,8 +25,7 @@
           "source_workload_name": "clt-{{ .ClusterName }}-v1",
           "source_workload_namespace": "{{ .EchoNamespace }}"
        }
-    },
-    {{- if .OnGCE }}
+    }{{- if .OnGCE  }},
     "resource": {
        "labels": {
           "container_name": "app",

--- a/tests/integration/telemetry/stackdriver/testdata/server_tcp_connection_count.json.tmpl
+++ b/tests/integration/telemetry/stackdriver/testdata/server_tcp_connection_count.json.tmpl
@@ -23,8 +23,7 @@
           "source_workload_name": "clt-{{ .ClusterName }}-v1",
           "source_workload_namespace": "{{ .EchoNamespace }}"
        }
-    },
-    {{- if .OnGCE }}
+    }{{- if .OnGCE  }},
     "resource": {
        "labels": {
           "container_name": "app",


### PR DESCRIPTION
**Please provide a description of this PR:**

I'm getting a syntax error in some of the stackdriver yaml files when running the telemetry tests using the `istiodremote` topology. One example of the problem is that `OnGCE` is false [here](https://github.com/istio/istio/blob/e24ded225705aeb4849014f0942260eee55b717b/tests/integration/telemetry/stackdriver/testdata/server_request_count.json.tmpl#L29). As a result, unmashalling the expanded template complains about the `,` on line 28. It seems that the comma needs to be moved inside the `{{- if .OnGCE }}`.

@douglas-reid I was also wondering if it sounds right to you that `OnGCE` is false when I run the tests? Where is that set? Have I missed something in the configuration for running the tests?

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [x] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
