### PR TITLE
Add istio.io/injectedBy injection label

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -222,6 +222,7 @@ data:
             security.istio.io/tlsMode: {{ index .ObjectMeta.Labels `security.istio.io/tlsMode` | default "istio"  | quote }}
             service.istio.io/canonical-name: {{ index .ObjectMeta.Labels `service.istio.io/canonical-name` | default (index .ObjectMeta.Labels `app.kubernetes.io/name`) | default (index .ObjectMeta.Labels `app`) | default .DeploymentMeta.Name  | quote }}
             service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
+            istio.io/injectedBy: {{ .Revision | default "default" | quote }}
           annotations: {
             {{- if eq (len $containers) 1 }}
             kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",

--- a/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
@@ -5,6 +5,7 @@ metadata:
     security.istio.io/tlsMode: {{ index .ObjectMeta.Labels `security.istio.io/tlsMode` | default "istio"  | quote }}
     service.istio.io/canonical-name: {{ index .ObjectMeta.Labels `service.istio.io/canonical-name` | default (index .ObjectMeta.Labels `app.kubernetes.io/name`) | default (index .ObjectMeta.Labels `app`) | default .DeploymentMeta.Name  | quote }}
     service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
+    istio.io/injectedBy: {{ .Revision | default "default" | quote }}
   annotations: {
     {{- if eq (len $containers) 1 }}
     kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",

--- a/manifests/charts/istiod-remote/files/injection-template.yaml
+++ b/manifests/charts/istiod-remote/files/injection-template.yaml
@@ -5,6 +5,7 @@ metadata:
     security.istio.io/tlsMode: {{ index .ObjectMeta.Labels `security.istio.io/tlsMode` | default "istio"  | quote }}
     service.istio.io/canonical-name: {{ index .ObjectMeta.Labels `service.istio.io/canonical-name` | default (index .ObjectMeta.Labels `app.kubernetes.io/name`) | default (index .ObjectMeta.Labels `app`) | default .DeploymentMeta.Name  | quote }}
     service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
+    istio.io/injectedBy: {{ .Revision | default "default" | quote }}
   annotations: {
     {{- if eq (len $containers) 1 }}
     kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",

--- a/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
@@ -23,6 +23,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/auth.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/auth.yaml.injected
@@ -23,6 +23,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
@@ -15,6 +15,7 @@ spec:
         sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
       creationTimestamp: null
       labels:
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hellocron
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
@@ -21,6 +21,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/deploymentconfig-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/deploymentconfig-multi.yaml.injected
@@ -36,6 +36,7 @@ items:
         creationTimestamp: null
         labels:
           app: hello
+          istio.io/injectedBy: default
           security.istio.io/tlsMode: istio
           service.istio.io/canonical-name: hello
           service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/deploymentconfig-with-canonical-service-label.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/deploymentconfig-with-canonical-service-label.yaml.injected
@@ -21,6 +21,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: test-service-name
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/deploymentconfig.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/deploymentconfig.yaml.injected
@@ -21,6 +21,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/enable-core-dump-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/enable-core-dump-annotation.yaml.injected
@@ -24,6 +24,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
@@ -23,6 +23,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/explicit-security-context.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/explicit-security-context.yaml.injected
@@ -20,6 +20,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
@@ -23,6 +23,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/frontend.yaml.injected
@@ -37,6 +37,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
@@ -23,6 +23,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/hello-cncf-networks.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-cncf-networks.yaml.injected
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/hello-existing-cncf-networks-json.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-existing-cncf-networks-json.yaml.injected
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/hello-existing-cncf-networks.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-existing-cncf-networks.yaml.injected
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/hello-image-pull-secret.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-image-pull-secret.yaml.injected
@@ -23,6 +23,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/hello-image-secrets-in-values.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-image-secrets-in-values.yaml.injected
@@ -23,6 +23,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/hello-mount-mtls-certs.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-mount-mtls-certs.yaml.injected
@@ -23,6 +23,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/hello-mtls-not-ready.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-mtls-not-ready.yaml.injected
@@ -23,6 +23,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: disabled
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
@@ -24,6 +24,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: v1
@@ -235,6 +236,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: v2

--- a/pkg/kube/inject/testdata/inject/hello-multiple-image-secrets.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-multiple-image-secrets.yaml.injected
@@ -23,6 +23,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/hello-namespace.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-namespace.yaml.injected
@@ -24,6 +24,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
@@ -23,6 +23,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/hello-no-seccontext.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-no-seccontext.yaml.injected
@@ -23,6 +23,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.injected
@@ -22,6 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/hello-probes-proxyHoldApplication-ProxyConfig.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-probes-proxyHoldApplication-ProxyConfig.yaml.injected
@@ -22,6 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/hello-probes-with-flag-set-in-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-probes-with-flag-set-in-annotation.yaml.injected
@@ -22,6 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/hello-probes-with-flag-unset-in-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-probes-with-flag-unset-in-annotation.yaml.injected
@@ -22,6 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/hello-probes.proxyHoldsApplication.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-probes.proxyHoldsApplication.yaml.injected
@@ -21,6 +21,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/hello-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-probes.yaml.injected
@@ -21,6 +21,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
@@ -24,6 +24,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/hello-readiness.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-readiness.yaml.injected
@@ -23,6 +23,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/hello-template-in-values.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-template-in-values.yaml.injected
@@ -23,6 +23,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
@@ -23,6 +23,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/hello.proxyHoldsApplication.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello.proxyHoldsApplication.yaml.injected
@@ -23,6 +23,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/hello.yaml.cni.injected
+++ b/pkg/kube/inject/testdata/inject/hello.yaml.cni.injected
@@ -27,6 +27,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/hello.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello.yaml.injected
@@ -23,6 +23,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/https-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/https-probes.yaml.injected
@@ -21,6 +21,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/job.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/job.yaml.injected
@@ -15,6 +15,7 @@ spec:
         sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
       creationTimestamp: null
       labels:
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: pi
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml.injected
@@ -24,6 +24,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml.injected
@@ -24,6 +24,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
@@ -38,6 +38,7 @@ items:
         creationTimestamp: null
         labels:
           app: hello
+          istio.io/injectedBy: default
           security.istio.io/tlsMode: istio
           service.istio.io/canonical-name: hello
           service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/list.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/list.yaml.injected
@@ -26,6 +26,7 @@ items:
         creationTimestamp: null
         labels:
           app: hello
+          istio.io/injectedBy: default
           security.istio.io/tlsMode: istio
           service.istio.io/canonical-name: hello
           service.istio.io/canonical-revision: v1
@@ -236,6 +237,7 @@ items:
         creationTimestamp: null
         labels:
           app: hello
+          istio.io/injectedBy: default
           security.istio.io/tlsMode: istio
           service.istio.io/canonical-name: hello
           service.istio.io/canonical-revision: v2

--- a/pkg/kube/inject/testdata/inject/multi-container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/multi-container.yaml.injected
@@ -19,6 +19,7 @@ spec:
       creationTimestamp: null
       labels:
         app: app
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: app
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
@@ -23,6 +23,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/multiple-templates.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/multiple-templates.yaml.injected
@@ -22,6 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/named_port.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/named_port.yaml.injected
@@ -23,6 +23,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/one_container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/one_container.yaml.injected
@@ -23,6 +23,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/only-proxy-container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/only-proxy-container.yaml.injected
@@ -19,6 +19,7 @@ spec:
       creationTimestamp: null
       labels:
         istio: ingressgateway
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: istio-ingressgateway
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/pod.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/pod.yaml.injected
@@ -10,6 +10,7 @@ metadata:
     sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
   creationTimestamp: null
   labels:
+    istio.io/injectedBy: default
     security.istio.io/tlsMode: istio
     service.istio.io/canonical-name: hellopod
     service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/proxy-override-args.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/proxy-override-args.yaml.injected
@@ -21,6 +21,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/proxy-override.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/proxy-override.yaml.injected
@@ -21,6 +21,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/ready_live.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/ready_live.yaml.injected
@@ -21,6 +21,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/ready_only.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/ready_only.yaml.injected
@@ -23,6 +23,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
@@ -20,6 +20,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
@@ -19,6 +19,7 @@ spec:
       creationTimestamp: null
       labels:
         app: nginx
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: nginx
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/resource_annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/resource_annotations.yaml.injected
@@ -25,6 +25,7 @@ spec:
       creationTimestamp: null
       labels:
         app: resource
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: resource
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/startup_live.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/startup_live.yaml.injected
@@ -21,6 +21,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/startup_only.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/startup_only.yaml.injected
@@ -23,6 +23,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/startup_ready_live.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/startup_ready_live.yaml.injected
@@ -21,6 +21,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
@@ -23,6 +23,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/status_annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/status_annotations.yaml.injected
@@ -26,6 +26,7 @@ spec:
       creationTimestamp: null
       labels:
         app: status
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: status
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/status_annotations_zeroport.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/status_annotations_zeroport.yaml.injected
@@ -26,6 +26,7 @@ spec:
       creationTimestamp: null
       labels:
         app: status
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: status
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/status_params.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/status_params.yaml.injected
@@ -21,6 +21,7 @@ spec:
       creationTimestamp: null
       labels:
         app: status
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: status
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/tcp-probes-disabled.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/tcp-probes-disabled.yaml.injected
@@ -23,6 +23,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/tcp-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/tcp-probes.yaml.injected
@@ -23,6 +23,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
@@ -25,6 +25,7 @@ spec:
       creationTimestamp: null
       labels:
         app: traffic
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: traffic
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
@@ -25,6 +25,7 @@ spec:
       creationTimestamp: null
       labels:
         app: traffic
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: traffic
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
@@ -33,6 +33,7 @@ spec:
       creationTimestamp: null
       labels:
         app: traffic
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: traffic
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
@@ -21,6 +21,7 @@ spec:
       creationTimestamp: null
       labels:
         app: traffic
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: traffic
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
@@ -21,6 +21,7 @@ spec:
       creationTimestamp: null
       labels:
         app: traffic
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: traffic
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/two_container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/two_container.yaml.injected
@@ -21,6 +21,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/user-volume.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/user-volume.yaml.injected
@@ -25,6 +25,7 @@ spec:
       creationTimestamp: null
       labels:
         app: user-volume
+        istio.io/injectedBy: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: user-volume
         service.istio.io/canonical-revision: latest

--- a/releasenotes/notes/injected-by-label.yaml
+++ b/releasenotes/notes/injected-by-label.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+releaseNotes:
+  - |
+    **Added** the `istio.io/injectedBy` pod label to indicate which control plane revision injected a given pod.


### PR DESCRIPTION
Since https://github.com/istio/istio/pull/33447 we haven't had a good way to identify pods injected by a given revision.

That PR removed the `istio.io/rev` label since it didn't play nice with revision tags (`istio.io/rev` label would get overwritten on injection) but there's no reason we can't add another, non-overlapping label (`istio.io/injectedBy`) to serve the same purpose. This is extra-useful when using revision tags since there's an extra layer of indirection between what `istio.io/rev` label you have and what revision actually does the injection.

- [ ] Configuration Infrastructure
- [ ] Docs
- [x] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure