### PR TITLE
Generate MCS service from merged Service

### DIFF
--- a/pilot/pkg/bootstrap/servicecontroller.go
+++ b/pilot/pkg/bootstrap/servicecontroller.go
@@ -81,12 +81,12 @@ func (s *Server) initKubeRegistry(args *PilotArgs) (err error) {
 	args.RegistryOptions.KubeOptions.NetworksWatcher = s.environment.NetworksWatcher
 	args.RegistryOptions.KubeOptions.MeshWatcher = s.environment.Watcher
 	args.RegistryOptions.KubeOptions.SystemNamespace = args.Namespace
+	args.RegistryOptions.KubeOptions.MeshServiceController = s.ServiceController()
 
 	mc := kubecontroller.NewMulticluster(args.PodName,
 		s.kubeClient,
 		args.RegistryOptions.ClusterRegistriesNamespace,
 		args.RegistryOptions.KubeOptions,
-		s.ServiceController(),
 		s.serviceEntryStore,
 		s.istiodCertBundleWatcher,
 		args.Revision,

--- a/pilot/pkg/serviceregistry/aggregate/controller.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller.go
@@ -45,6 +45,8 @@ type Controller struct {
 	storeLock  sync.RWMutex
 	meshHolder mesh.Holder
 	running    *atomic.Bool
+
+	handlers model.ControllerHandlers
 }
 
 type Options struct {
@@ -66,6 +68,10 @@ func (c *Controller) AddRegistry(registry serviceregistry.Instance) {
 	defer c.storeLock.Unlock()
 
 	c.registries = append(c.registries, registry)
+
+	// Observe the registry for events.
+	registry.AppendServiceHandler(c.handlers.NotifyServiceHandlers)
+	registry.AppendWorkloadHandler(c.handlers.NotifyWorkloadHandlers)
 }
 
 // DeleteRegistry deletes specified registry from the aggregated controller
@@ -295,17 +301,12 @@ func (c *Controller) HasSynced() bool {
 	return true
 }
 
-// AppendServiceHandler implements a service catalog operation
 func (c *Controller) AppendServiceHandler(f func(*model.Service, model.Event)) {
-	for _, r := range c.GetRegistries() {
-		r.AppendServiceHandler(f)
-	}
+	c.handlers.AppendServiceHandler(f)
 }
 
 func (c *Controller) AppendWorkloadHandler(f func(*model.WorkloadInstance, model.Event)) {
-	for _, r := range c.GetRegistries() {
-		r.AppendWorkloadHandler(f)
-	}
+	c.handlers.AppendWorkloadHandler(f)
 }
 
 // GetIstioServiceAccounts implements model.ServiceAccounts operation.

--- a/pilot/pkg/serviceregistry/aggregate/controller_test.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller_test.go
@@ -390,10 +390,12 @@ func TestAddRegistry(t *testing.T) {
 		{
 			ProviderID: "registry1",
 			ClusterID:  "cluster1",
+			Controller: &mock.Controller{},
 		},
 		{
 			ProviderID: "registry2",
 			ClusterID:  "cluster2",
+			Controller: &mock.Controller{},
 		},
 	}
 	ctrl := NewController(Options{})
@@ -410,14 +412,17 @@ func TestGetDeleteRegistry(t *testing.T) {
 		{
 			ProviderID: "registry1",
 			ClusterID:  "cluster1",
+			Controller: &mock.Controller{},
 		},
 		{
 			ProviderID: "registry2",
 			ClusterID:  "cluster2",
+			Controller: &mock.Controller{},
 		},
 		{
 			ProviderID: "registry3",
 			ClusterID:  "cluster3",
+			Controller: &mock.Controller{},
 		},
 	}
 	ctrl := NewController(Options{})
@@ -444,10 +449,22 @@ func TestGetDeleteRegistry(t *testing.T) {
 }
 
 func TestSkipSearchingRegistryForProxy(t *testing.T) {
-	cluster1 := serviceregistry.Simple{ClusterID: "cluster-1", ProviderID: provider.Kubernetes}
-	cluster2 := serviceregistry.Simple{ClusterID: "cluster-2", ProviderID: provider.Kubernetes}
+	cluster1 := serviceregistry.Simple{
+		ClusterID:  "cluster-1",
+		ProviderID: provider.Kubernetes,
+		Controller: &mock.Controller{},
+	}
+	cluster2 := serviceregistry.Simple{
+		ClusterID:  "cluster-2",
+		ProviderID: provider.Kubernetes,
+		Controller: &mock.Controller{},
+	}
 	// external registries may eventually be associated with a cluster
-	external := serviceregistry.Simple{ClusterID: "cluster-1", ProviderID: provider.External}
+	external := serviceregistry.Simple{
+		ClusterID:  "cluster-1",
+		ProviderID: provider.External,
+		Controller: &mock.Controller{},
+	}
 
 	cases := []struct {
 		nodeClusterID cluster.ID

--- a/pilot/pkg/serviceregistry/kube/controller/fake.go
+++ b/pilot/pkg/serviceregistry/kube/controller/fake.go
@@ -21,6 +21,7 @@ import (
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/serviceregistry/aggregate"
 	"istio.io/istio/pilot/pkg/serviceregistry/kube/controller/filter"
 	"istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/config/mesh"
@@ -175,6 +176,8 @@ func NewFakeControllerWithOptions(opts FakeControllerOptions) (*FakeController, 
 		opts.MeshWatcher = mesh.NewFixedWatcher(&meshconfig.MeshConfig{})
 	}
 
+	meshServiceController := aggregate.NewController(aggregate.Options{MeshHolder: opts.MeshWatcher})
+
 	options := Options{
 		DomainSuffix:              domainSuffix,
 		XDSUpdater:                xdsUpdater,
@@ -185,8 +188,11 @@ func NewFakeControllerWithOptions(opts FakeControllerOptions) (*FakeController, 
 		ClusterID:                 opts.ClusterID,
 		SyncInterval:              time.Microsecond,
 		DiscoveryNamespacesFilter: opts.DiscoveryNamespacesFilter,
+		MeshServiceController:     meshServiceController,
 	}
 	c := NewController(opts.Client, options)
+	meshServiceController.AddRegistry(c)
+
 	if opts.ServiceHandler != nil {
 		c.AppendServiceHandler(opts.ServiceHandler)
 	}
@@ -196,7 +202,7 @@ func NewFakeControllerWithOptions(opts FakeControllerOptions) (*FakeController, 
 	}
 	// Run in initiation to prevent calling each test
 	// TODO: fix it, so we can remove `stop` channel
-	go c.Run(c.stop)
+	go meshServiceController.Run(c.stop)
 	opts.Client.RunAndWait(c.stop)
 	if !opts.SkipCacheSyncWait {
 		// Wait for the caches to sync, otherwise we may hit race conditions where events are dropped

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -29,7 +29,6 @@ import (
 	"istio.io/istio/pilot/pkg/leaderelection"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/server"
-	"istio.io/istio/pilot/pkg/serviceregistry/aggregate"
 	"istio.io/istio/pilot/pkg/serviceregistry/provider"
 	"istio.io/istio/pilot/pkg/serviceregistry/serviceentry"
 	"istio.io/istio/pkg/cluster"
@@ -65,7 +64,6 @@ type Multicluster struct {
 	s       server.Instance
 	closing bool
 
-	serviceController *aggregate.Controller
 	serviceEntryStore *serviceentry.ServiceEntryStore
 	XDSUpdater        model.XDSUpdater
 
@@ -90,7 +88,6 @@ func NewMulticluster(
 	kc kubernetes.Interface,
 	secretNamespace string,
 	opts Options,
-	serviceController *aggregate.Controller,
 	serviceEntryStore *serviceentry.ServiceEntryStore,
 	caBundleWatcher *keycertbundle.Watcher,
 	revision string,
@@ -102,7 +99,6 @@ func NewMulticluster(
 	mc := &Multicluster{
 		serverID:              serverID,
 		opts:                  opts,
-		serviceController:     serviceController,
 		serviceEntryStore:     serviceEntryStore,
 		caBundleWatcher:       caBundleWatcher,
 		revision:              revision,
@@ -170,7 +166,7 @@ func (m *Multicluster) AddMemberCluster(clusterID cluster.ID, rc *secretcontroll
 
 	log.Infof("Initializing Kubernetes service registry %q", options.ClusterID)
 	kubeRegistry := NewController(client, options)
-	m.serviceController.AddRegistry(kubeRegistry)
+	m.opts.MeshServiceController.AddRegistry(kubeRegistry)
 	m.remoteKubeControllers[clusterID] = &kubeController{
 		Controller: kubeRegistry,
 	}
@@ -201,7 +197,7 @@ func (m *Multicluster) AddMemberCluster(clusterID cluster.ID, rc *secretcontroll
 					configStore, model.MakeIstioStore(configStore), options.XDSUpdater,
 					serviceentry.DisableServiceEntryProcessing(), serviceentry.WithClusterID(clusterID),
 					serviceentry.WithNetworkIDCb(kubeRegistry.Network))
-				m.serviceController.AddRegistry(m.remoteKubeControllers[clusterID].workloadEntryStore)
+				m.opts.MeshServiceController.AddRegistry(m.remoteKubeControllers[clusterID].workloadEntryStore)
 				// Services can select WorkloadEntry from the same cluster. We only duplicate the Service to configure kube-dns.
 				m.remoteKubeControllers[clusterID].workloadEntryStore.AppendWorkloadHandler(kubeRegistry.WorkloadInstanceHandler)
 				go configStore.Run(clusterStopCh)
@@ -212,7 +208,7 @@ func (m *Multicluster) AddMemberCluster(clusterID cluster.ID, rc *secretcontroll
 	}
 
 	// TODO make the aggregate controller keep clusters tied to their individual stop channels
-	if m.serviceController.Running() {
+	if m.opts.MeshServiceController.Running() {
 		// if serviceController isn't running, it will start its members when it is started
 		go kubeRegistry.Run(clusterStopCh)
 	}
@@ -306,7 +302,7 @@ func (m *Multicluster) UpdateMemberCluster(clusterID cluster.ID, rc *secretcontr
 func (m *Multicluster) DeleteMemberCluster(clusterID cluster.ID) error {
 	m.m.Lock()
 	defer m.m.Unlock()
-	m.serviceController.DeleteRegistry(clusterID, provider.Kubernetes)
+	m.opts.MeshServiceController.DeleteRegistry(clusterID, provider.Kubernetes)
 	kc, ok := m.remoteKubeControllers[clusterID]
 	if !ok {
 		log.Infof("cluster %s does not exist, maybe caused by invalid kubeconfig", clusterID)
@@ -316,7 +312,7 @@ func (m *Multicluster) DeleteMemberCluster(clusterID cluster.ID) error {
 		log.Warnf("failed cleaning up services in %s: %v", clusterID, err)
 	}
 	if kc.workloadEntryStore != nil {
-		m.serviceController.DeleteRegistry(clusterID, provider.External)
+		m.opts.MeshServiceController.DeleteRegistry(clusterID, provider.External)
 	}
 	delete(m.remoteKubeControllers, clusterID)
 	if m.XDSUpdater != nil {

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster_test.go
@@ -93,11 +93,12 @@ func Test_KubeSecretController(t *testing.T) {
 		clientset,
 		testSecretNameSpace,
 		Options{
-			DomainSuffix: DomainSuffix,
-			ResyncPeriod: ResyncPeriod,
-			SyncInterval: time.Microsecond,
-			MeshWatcher:  mesh.NewFixedWatcher(&meshconfig.MeshConfig{}),
-		}, mockserviceController, nil, nil, "default", nil, nil, s)
+			DomainSuffix:          DomainSuffix,
+			ResyncPeriod:          ResyncPeriod,
+			SyncInterval:          time.Microsecond,
+			MeshWatcher:           mesh.NewFixedWatcher(&meshconfig.MeshConfig{}),
+			MeshServiceController: mockserviceController,
+		}, nil, nil, "default", nil, nil, s)
 	mc.InitSecretController(stop)
 	cache.WaitForCacheSync(stop, mc.HasSynced)
 	clientset.RunAndWait(stop)
@@ -150,11 +151,12 @@ func Test_KubeSecretController_ExternalIstiod_MultipleClusters(t *testing.T) {
 		clientset,
 		testSecretNameSpace,
 		Options{
-			DomainSuffix: DomainSuffix,
-			ResyncPeriod: ResyncPeriod,
-			SyncInterval: time.Microsecond,
-			MeshWatcher:  mesh.NewFixedWatcher(&meshconfig.MeshConfig{}),
-		}, mockserviceController, nil, certWatcher, "default", nil, nil, s)
+			DomainSuffix:          DomainSuffix,
+			ResyncPeriod:          ResyncPeriod,
+			SyncInterval:          time.Microsecond,
+			MeshWatcher:           mesh.NewFixedWatcher(&meshconfig.MeshConfig{}),
+			MeshServiceController: mockserviceController,
+		}, nil, certWatcher, "default", nil, nil, s)
 	mc.InitSecretController(stop)
 	cache.WaitForCacheSync(stop, mc.HasSynced)
 	clientset.RunAndWait(stop)

--- a/pilot/pkg/serviceregistry/kube/controller/pod.go
+++ b/pilot/pkg/serviceregistry/kube/controller/pod.go
@@ -167,7 +167,7 @@ func (pc *PodCache) onEvent(curr interface{}, ev model.Event) error {
 			}
 		}
 		// fire instance handles for workload
-		for _, handler := range pc.c.workloadHandlers {
+		for _, handler := range pc.c.handlers.GetWorkloadHandlers() {
 			ep := NewEndpointBuilder(pc.c, pod).buildIstioEndpoint(ip, 0, "", model.AlwaysDiscoverable)
 			handler(&model.WorkloadInstance{
 				Name:      pod.Name,


### PR DESCRIPTION
Currently, the MCS `serviceImportCache` requires that the kube `Service` exist in each cluster containing a `ServiceImport` resource. This is an overly strict requirement and goes against the spirit of the MCS spec.

This PR modifies the `serviceImportCache` to use the merged, mesh-wide `Service` from the `aggregate.Controller` instead. This means that as long as the service exists somewhere in the mesh, it can be imported in any cluster and can generate the synthetic MCS service for the `clusterset.local` host.

**Please provide a description of this PR:**