### PR TITLE
Ignore failing workaround iptables command

### DIFF
--- a/prow/integ-suite-kind.sh
+++ b/prow/integ-suite-kind.sh
@@ -30,7 +30,7 @@ set -u
 set -x
 
 # Workaround https://github.com/kubernetes/test-infra/issues/23741. Should be removed once its fixed upstream
-iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
+iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu || true
 
 # shellcheck source=prow/lib.sh
 source "${ROOT}/prow/lib.sh"


### PR DESCRIPTION
**Please provide a description of this PR:**

The `iptables` command (workaround) isn't needed, but fails, when running the integration tests locally on a Mac:
```
build-tools:/work# ARTIFACTS=$PWD/artifacts ./prow/integ-suite-kind.sh --topology MULTICLUSTER --skip-build --skip-cleanup --topology-config prow/config/topology/external-istiod.json
+ iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
getsockopt failed strangely: Operation not permitted
```

This PR prevents the bash script from exiting in this case.