### PR TITLE
Bump 1.10 base image

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -22,7 +22,7 @@ SHELL := /bin/bash -o pipefail
 export VERSION ?= 1.10-dev
 
 # Base version of Istio image to use
-BASE_VERSION ?= 1.10-dev.9
+BASE_VERSION ?= 1.10-dev.13
 
 export GO111MODULE ?= on
 export GOPROXY ?= https://proxy.golang.org


### PR DESCRIPTION
Seems like the build pipeline failed to create new base image `1.10-dev.10` but that `1.10-dev.11` ([build log](https://storage.googleapis.com/istio-prow/logs/build-release_release-builder_release-1.10_postsubmit/1442709735399755776/build-log.txt)) was manually created ~a month ago, so updating base to that image.