### PR TITLE
replace deprecated HeaderMatchSpecifier with HeaderMatcher_StringMatch

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/route/route_internal_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route_internal_test.go
@@ -169,11 +169,14 @@ func TestIsCatchAllRoute(t *testing.T) {
 					Headers: []*route.HeaderMatcher{
 						{
 							Name: "Authentication",
-							HeaderMatchSpecifier: &route.HeaderMatcher_SafeRegexMatch{
-								SafeRegexMatch: &matcher.RegexMatcher{
-									// nolint: staticcheck
-									EngineType: &matcher.RegexMatcher_GoogleRe2{},
-									Regex:      "*",
+							HeaderMatchSpecifier: &route.HeaderMatcher_StringMatch{
+								StringMatch: &matcher.StringMatcher{
+									MatchPattern: &matcher.StringMatcher_SafeRegex{
+										SafeRegex: &matcher.RegexMatcher{
+											EngineType: regexEngine,
+											Regex:      "*",
+										},
+									},
 								},
 							},
 						},

--- a/pilot/pkg/networking/core/v1alpha3/route/route_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route_test.go
@@ -197,7 +197,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		g.Expect(len(routes)).To(gomega.Equal(1))
 		// nolint: staticcheck
 		// Update to not use the deprecated fields later.
-		g.Expect(routes[0].GetMatch().GetHeaders()[0].GetSafeRegexMatch().GetRegex()).To(gomega.Equal("Bearer .+?\\..+?\\..+?"))
+		g.Expect(routes[0].GetMatch().GetHeaders()[0].GetStringMatch().GetSafeRegex().GetRegex()).To(gomega.Equal("Bearer .+?\\..+?\\..+?"))
 	})
 
 	t.Run("for virtual service with regex matching on without_header", func(t *testing.T) {
@@ -209,7 +209,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		g.Expect(len(routes)).To(gomega.Equal(1))
 		// nolint: staticcheck
 		// Update to not use the deprecated fields later.
-		g.Expect(routes[0].GetMatch().GetHeaders()[0].GetSafeRegexMatch().GetRegex()).To(gomega.Equal("BAR .+?\\..+?\\..+?"))
+		g.Expect(routes[0].GetMatch().GetHeaders()[0].GetStringMatch().GetSafeRegex().GetRegex()).To(gomega.Equal("BAR .+?\\..+?\\..+?"))
 		g.Expect(routes[0].GetMatch().GetHeaders()[0].GetInvertMatch()).To(gomega.Equal(true))
 	})
 
@@ -1451,9 +1451,11 @@ func TestCombineVHostRoutes(t *testing.T) {
 			},
 			Headers: []*envoyroute.HeaderMatcher{
 				{
-					Name:                 "foo",
-					HeaderMatchSpecifier: &envoyroute.HeaderMatcher_ExactMatch{ExactMatch: "bar"},
-					InvertMatch:          false,
+					Name: "foo",
+					HeaderMatchSpecifier: &envoyroute.HeaderMatcher_StringMatch{
+						StringMatch: &matcher.StringMatcher{MatchPattern: &matcher.StringMatcher_Exact{Exact: "bar"}},
+					},
+					InvertMatch: false,
 				},
 			},
 		}},
@@ -1485,9 +1487,11 @@ func TestCombineVHostRoutes(t *testing.T) {
 			},
 			Headers: []*envoyroute.HeaderMatcher{
 				{
-					Name:                 "foo",
-					HeaderMatchSpecifier: &envoyroute.HeaderMatcher_ExactMatch{ExactMatch: "bar"},
-					InvertMatch:          false,
+					Name: "foo",
+					HeaderMatchSpecifier: &envoyroute.HeaderMatcher_StringMatch{
+						StringMatch: &matcher.StringMatcher{MatchPattern: &matcher.StringMatcher_Exact{Exact: "bar"}},
+					},
+					InvertMatch: false,
 				},
 			},
 		}},

--- a/pilot/pkg/security/authz/builder/testdata/http/allow-full-rule-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/allow-full-rule-out.yaml
@@ -51,14 +51,17 @@ typedConfig:
             - orRules:
                 rules:
                 - header:
-                    exactMatch: method
                     name: :method
+                    stringMatch:
+                      exact: method
                 - header:
                     name: :method
-                    prefixMatch: method-prefix-
+                    stringMatch:
+                      prefix: method-prefix-
                 - header:
                     name: :method
-                    suffixMatch: -suffix-method
+                    stringMatch:
+                      suffix: -suffix-method
                 - header:
                     name: :method
                     presentMatch: true
@@ -66,14 +69,17 @@ typedConfig:
                 orRules:
                   rules:
                   - header:
-                      exactMatch: not-method
                       name: :method
+                      stringMatch:
+                        exact: not-method
                   - header:
                       name: :method
-                      prefixMatch: not-method-prefix-
+                      stringMatch:
+                        prefix: not-method-prefix-
                   - header:
                       name: :method
-                      suffixMatch: -not-suffix-method
+                      stringMatch:
+                        suffix: -not-suffix-method
                   - header:
                       name: :method
                       presentMatch: true
@@ -422,14 +428,17 @@ typedConfig:
             - orIds:
                 ids:
                 - header:
-                    exactMatch: header
                     name: X-header
+                    stringMatch:
+                      exact: header
                 - header:
                     name: X-header
-                    prefixMatch: header-prefix-
+                    stringMatch:
+                      prefix: header-prefix-
                 - header:
                     name: X-header
-                    suffixMatch: -suffix-header
+                    stringMatch:
+                      suffix: -suffix-header
                 - header:
                     name: X-header
                     presentMatch: true
@@ -437,14 +446,17 @@ typedConfig:
                 orIds:
                   ids:
                   - header:
-                      exactMatch: not-header
                       name: X-header
+                      stringMatch:
+                        exact: not-header
                   - header:
                       name: X-header
-                      prefixMatch: not-header-prefix-
+                      stringMatch:
+                        prefix: not-header-prefix-
                   - header:
                       name: X-header
-                      suffixMatch: -not-suffix-header
+                      stringMatch:
+                        suffix: -not-suffix-header
                   - header:
                       name: X-header
                       presentMatch: true

--- a/pilot/pkg/security/authz/builder/testdata/http/allow-host-before-111-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/allow-host-before-111-out.yaml
@@ -11,19 +11,22 @@ typedConfig:
                 rules:
                 - header:
                     name: :authority
-                    safeRegexMatch:
-                      googleRe2: {}
-                      regex: (?i)example\.com
+                    stringMatch:
+                      safeRegex:
+                        googleRe2: { }
+                        regex: (?i)example\.com
                 - header:
                     name: :authority
-                    safeRegexMatch:
-                      googleRe2: {}
-                      regex: (?i)prefix\.example\..*
+                    stringMatch:
+                      safeRegex:
+                        googleRe2: { }
+                        regex: (?i)prefix\.example\..*
                 - header:
                     name: :authority
-                    safeRegexMatch:
-                      googleRe2: {}
-                      regex: (?i).*\.example\.com
+                    stringMatch:
+                      safeRegex:
+                        googleRe2: { }
+                        regex: (?i).*\.example\.com
                 - header:
                     name: :authority
                     presentMatch: true
@@ -32,19 +35,22 @@ typedConfig:
                   rules:
                   - header:
                       name: :authority
-                      safeRegexMatch:
-                        googleRe2: {}
-                        regex: (?i)not-example\.com
+                      stringMatch:
+                        safeRegex:
+                          googleRe2: { }
+                          regex: (?i)not-example\.com
                   - header:
                       name: :authority
-                      safeRegexMatch:
-                        googleRe2: {}
-                        regex: (?i)prefix\.not-example\..*
+                      stringMatch:
+                        safeRegex:
+                          googleRe2: { }
+                          regex: (?i)prefix\.not-example\..*
                   - header:
                       name: :authority
-                      safeRegexMatch:
-                        googleRe2: {}
-                        regex: (?i).*\.not-example\.com
+                      stringMatch:
+                        safeRegex:
+                          googleRe2: { }
+                          regex: (?i).*\.not-example\.com
                   - header:
                       name: :authority
                       presentMatch: true

--- a/pilot/pkg/security/authz/builder/testdata/http/allow-host-before-111-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/allow-host-before-111-out.yaml
@@ -13,19 +13,19 @@ typedConfig:
                     name: :authority
                     stringMatch:
                       safeRegex:
-                        googleRe2: { }
+                        googleRe2: {}
                         regex: (?i)example\.com
                 - header:
                     name: :authority
                     stringMatch:
                       safeRegex:
-                        googleRe2: { }
+                        googleRe2: {}
                         regex: (?i)prefix\.example\..*
                 - header:
                     name: :authority
                     stringMatch:
                       safeRegex:
-                        googleRe2: { }
+                        googleRe2: {}
                         regex: (?i).*\.example\.com
                 - header:
                     name: :authority
@@ -37,19 +37,19 @@ typedConfig:
                       name: :authority
                       stringMatch:
                         safeRegex:
-                          googleRe2: { }
+                          googleRe2: {}
                           regex: (?i)not-example\.com
                   - header:
                       name: :authority
                       stringMatch:
                         safeRegex:
-                          googleRe2: { }
+                          googleRe2: {}
                           regex: (?i)prefix\.not-example\..*
                   - header:
                       name: :authority
                       stringMatch:
                         safeRegex:
-                          googleRe2: { }
+                          googleRe2: {}
                           regex: (?i).*\.not-example\.com
                   - header:
                       name: :authority

--- a/pilot/pkg/security/authz/builder/testdata/http/multiple-policies-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/multiple-policies-out.yaml
@@ -10,11 +10,13 @@ typedConfig:
             - orRules:
                 rules:
                 - header:
-                    exactMatch: GET
                     name: :method
+                    stringMatch:
+                      exact: GET
                 - header:
-                    exactMatch: POST
                     name: :method
+                    stringMatch:
+                      exact: POST
         principals:
         - andIds:
             ids:
@@ -154,9 +156,11 @@ typedConfig:
             - orIds:
                 ids:
                 - header:
-                    exactMatch: abc1
                     name: X-abc
+                    stringMatch:
+                      exact: abc1
                 - header:
-                    exactMatch: abc2
                     name: X-abc
+                    stringMatch:
+                      exact: abc2
   shadowRulesStatPrefix: istio_dry_run_allow_

--- a/pilot/pkg/security/authz/builder/testdata/http/simple-policy-td-aliases-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/simple-policy-td-aliases-out.yaml
@@ -10,8 +10,9 @@ typedConfig:
             - orRules:
                 rules:
                 - header:
-                    exactMatch: rule[0]-to[0]-method[0]
                     name: :method
+                    stringMatch:
+                      exact: rule[0]-to[0]-method[0]
         principals:
         - andIds:
             ids:
@@ -53,8 +54,9 @@ typedConfig:
             - orRules:
                 rules:
                 - header:
-                    exactMatch: rule[1]-to[0]-method[0]
                     name: :method
+                    stringMatch:
+                      exact: rule[1]-to[0]-method[0]
         principals:
         - andIds:
             ids:

--- a/pilot/pkg/security/authz/builder/testdata/http/single-policy-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/single-policy-out.yaml
@@ -22,11 +22,13 @@ typedConfig:
             - orRules:
                 rules:
                 - header:
-                    exactMatch: rule[0]-to[0]-method[1]
                     name: :method
+                    stringMatch:
+                      exact: rule[0]-to[0]-method[1]
                 - header:
-                    exactMatch: rule[0]-to[0]-method[2]
                     name: :method
+                    stringMatch:
+                      exact: rule[0]-to[0]-method[2]
             - orRules:
                 rules:
                 - urlPath:
@@ -64,11 +66,13 @@ typedConfig:
             - orRules:
                 rules:
                 - header:
-                    exactMatch: rule[0]-to[1]-method[1]
                     name: :method
+                    stringMatch:
+                      exact: rule[0]-to[1]-method[1]
                 - header:
-                    exactMatch: rule[0]-to[1]-method[2]
                     name: :method
+                    stringMatch:
+                      exact: rule[0]-to[1]-method[2]
             - orRules:
                 rules:
                 - urlPath:
@@ -144,14 +148,17 @@ typedConfig:
             - orIds:
                 ids:
                 - header:
-                    exactMatch: header
                     name: X-header
+                    stringMatch:
+                      exact: header
                 - header:
                     name: X-header
-                    prefixMatch: header-prefix-
+                    stringMatch:
+                      prefix: header-prefix-
                 - header:
                     name: X-header
-                    suffixMatch: -suffix-header
+                    stringMatch:
+                      suffix: -suffix-header
                 - header:
                     name: X-header
                     presentMatch: true
@@ -220,14 +227,17 @@ typedConfig:
             - orIds:
                 ids:
                 - header:
-                    exactMatch: header
                     name: X-header
+                    stringMatch:
+                      exact: header
                 - header:
                     name: X-header
-                    prefixMatch: header-prefix-
+                    stringMatch:
+                      prefix: header-prefix-
                 - header:
                     name: X-header
-                    suffixMatch: -suffix-header
+                    stringMatch:
+                      suffix: -suffix-header
                 - header:
                     name: X-header
                     presentMatch: true
@@ -258,11 +268,13 @@ typedConfig:
             - orRules:
                 rules:
                 - header:
-                    exactMatch: rule[1]-to[0]-method[1]
                     name: :method
+                    stringMatch:
+                      exact: rule[1]-to[0]-method[1]
                 - header:
-                    exactMatch: rule[1]-to[0]-method[2]
                     name: :method
+                    stringMatch:
+                      exact: rule[1]-to[0]-method[2]
             - orRules:
                 rules:
                 - urlPath:
@@ -292,11 +304,13 @@ typedConfig:
             - orRules:
                 rules:
                 - header:
-                    exactMatch: rule[1]-to[1]-method[1]
                     name: :method
+                    stringMatch:
+                      exact: rule[1]-to[1]-method[1]
                 - header:
-                    exactMatch: rule[1]-to[1]-method[2]
                     name: :method
+                    stringMatch:
+                      exact: rule[1]-to[1]-method[2]
             - orRules:
                 rules:
                 - urlPath:

--- a/pilot/pkg/security/authz/matcher/header.go
+++ b/pilot/pkg/security/authz/matcher/header.go
@@ -36,22 +36,34 @@ func HeaderMatcher(k, v string) *routepb.HeaderMatcher {
 	} else if strings.HasPrefix(v, "*") {
 		return &routepb.HeaderMatcher{
 			Name: k,
-			HeaderMatchSpecifier: &routepb.HeaderMatcher_SuffixMatch{
-				SuffixMatch: v[1:],
+			HeaderMatchSpecifier: &routepb.HeaderMatcher_StringMatch{
+				StringMatch: &matcherpb.StringMatcher{
+					MatchPattern: &matcherpb.StringMatcher_Suffix{
+						Suffix: v[1:],
+					},
+				},
 			},
 		}
 	} else if strings.HasSuffix(v, "*") {
 		return &routepb.HeaderMatcher{
 			Name: k,
-			HeaderMatchSpecifier: &routepb.HeaderMatcher_PrefixMatch{
-				PrefixMatch: v[:len(v)-1],
+			HeaderMatchSpecifier: &routepb.HeaderMatcher_StringMatch{
+				StringMatch: &matcherpb.StringMatcher{
+					MatchPattern: &matcherpb.StringMatcher_Prefix{
+						Prefix: v[:len(v)-1],
+					},
+				},
 			},
 		}
 	}
 	return &routepb.HeaderMatcher{
 		Name: k,
-		HeaderMatchSpecifier: &routepb.HeaderMatcher_ExactMatch{
-			ExactMatch: v,
+		HeaderMatchSpecifier: &routepb.HeaderMatcher_StringMatch{
+			StringMatch: &matcherpb.StringMatcher{
+				MatchPattern: &matcherpb.StringMatcher_Exact{
+					Exact: v,
+				},
+			},
 		},
 	}
 }
@@ -75,12 +87,16 @@ func HostMatcherWithRegex(k, v string) *routepb.HeaderMatcher {
 	}
 	return &routepb.HeaderMatcher{
 		Name: k,
-		HeaderMatchSpecifier: &routepb.HeaderMatcher_SafeRegexMatch{
-			SafeRegexMatch: &matcherpb.RegexMatcher{
-				EngineType: &matcherpb.RegexMatcher_GoogleRe2{
-					GoogleRe2: &matcherpb.RegexMatcher_GoogleRE2{},
+		HeaderMatchSpecifier: &routepb.HeaderMatcher_StringMatch{
+			StringMatch: &matcherpb.StringMatcher{
+				MatchPattern: &matcherpb.StringMatcher_SafeRegex{
+					SafeRegex: &matcherpb.RegexMatcher{
+						EngineType: &matcherpb.RegexMatcher_GoogleRe2{
+							GoogleRe2: &matcherpb.RegexMatcher_GoogleRE2{},
+						},
+						Regex: `(?i)` + regex,
+					},
 				},
-				Regex: `(?i)` + regex,
 			},
 		},
 	}

--- a/pilot/pkg/security/authz/matcher/header_test.go
+++ b/pilot/pkg/security/authz/matcher/header_test.go
@@ -37,8 +37,12 @@ func TestHeaderMatcher(t *testing.T) {
 			V:    "/productpage",
 			Expect: &routepb.HeaderMatcher{
 				Name: ":path",
-				HeaderMatchSpecifier: &routepb.HeaderMatcher_ExactMatch{
-					ExactMatch: "/productpage",
+				HeaderMatchSpecifier: &routepb.HeaderMatcher_StringMatch{
+					StringMatch: &matcherpb.StringMatcher{
+						MatchPattern: &matcherpb.StringMatcher_Exact{
+							Exact: "/productpage",
+						},
+					},
 				},
 			},
 		},
@@ -48,8 +52,12 @@ func TestHeaderMatcher(t *testing.T) {
 			V:    "*/productpage*",
 			Expect: &routepb.HeaderMatcher{
 				Name: ":path",
-				HeaderMatchSpecifier: &routepb.HeaderMatcher_SuffixMatch{
-					SuffixMatch: "/productpage*",
+				HeaderMatchSpecifier: &routepb.HeaderMatcher_StringMatch{
+					StringMatch: &matcherpb.StringMatcher{
+						MatchPattern: &matcherpb.StringMatcher_Suffix{
+							Suffix: "/productpage*",
+						},
+					},
 				},
 			},
 		},
@@ -85,12 +93,16 @@ func TestHostMatcherWithRegex(t *testing.T) {
 			V:    "*.example.com",
 			Expect: &routepb.HeaderMatcher{
 				Name: ":authority",
-				HeaderMatchSpecifier: &routepb.HeaderMatcher_SafeRegexMatch{
-					SafeRegexMatch: &matcherpb.RegexMatcher{
-						EngineType: &matcherpb.RegexMatcher_GoogleRe2{
-							GoogleRe2: &matcherpb.RegexMatcher_GoogleRE2{},
+				HeaderMatchSpecifier: &routepb.HeaderMatcher_StringMatch{
+					StringMatch: &matcherpb.StringMatcher{
+						MatchPattern: &matcherpb.StringMatcher_SafeRegex{
+							SafeRegex: &matcherpb.RegexMatcher{
+								EngineType: &matcherpb.RegexMatcher_GoogleRe2{
+									GoogleRe2: &matcherpb.RegexMatcher_GoogleRE2{},
+								},
+								Regex: `(?i).*\.example\.com`,
+							},
 						},
-						Regex: `(?i).*\.example\.com`,
 					},
 				},
 			},
@@ -101,12 +113,16 @@ func TestHostMatcherWithRegex(t *testing.T) {
 			V:    "example.*",
 			Expect: &routepb.HeaderMatcher{
 				Name: ":authority",
-				HeaderMatchSpecifier: &routepb.HeaderMatcher_SafeRegexMatch{
-					SafeRegexMatch: &matcherpb.RegexMatcher{
-						EngineType: &matcherpb.RegexMatcher_GoogleRe2{
-							GoogleRe2: &matcherpb.RegexMatcher_GoogleRE2{},
+				HeaderMatchSpecifier: &routepb.HeaderMatcher_StringMatch{
+					StringMatch: &matcherpb.StringMatcher{
+						MatchPattern: &matcherpb.StringMatcher_SafeRegex{
+							SafeRegex: &matcherpb.RegexMatcher{
+								EngineType: &matcherpb.RegexMatcher_GoogleRe2{
+									GoogleRe2: &matcherpb.RegexMatcher_GoogleRE2{},
+								},
+								Regex: `(?i)example\..*`,
+							},
 						},
-						Regex: `(?i)example\..*`,
 					},
 				},
 			},
@@ -117,12 +133,16 @@ func TestHostMatcherWithRegex(t *testing.T) {
 			V:    "example.com",
 			Expect: &routepb.HeaderMatcher{
 				Name: ":authority",
-				HeaderMatchSpecifier: &routepb.HeaderMatcher_SafeRegexMatch{
-					SafeRegexMatch: &matcherpb.RegexMatcher{
-						EngineType: &matcherpb.RegexMatcher_GoogleRe2{
-							GoogleRe2: &matcherpb.RegexMatcher_GoogleRE2{},
+				HeaderMatchSpecifier: &routepb.HeaderMatcher_StringMatch{
+					StringMatch: &matcherpb.StringMatcher{
+						MatchPattern: &matcherpb.StringMatcher_SafeRegex{
+							SafeRegex: &matcherpb.RegexMatcher{
+								EngineType: &matcherpb.RegexMatcher_GoogleRe2{
+									GoogleRe2: &matcherpb.RegexMatcher_GoogleRE2{},
+								},
+								Regex: `(?i)example\.com`,
+							},
 						},
-						Regex: `(?i)example\.com`,
 					},
 				},
 			},
@@ -133,8 +153,7 @@ func TestHostMatcherWithRegex(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			actual := HostMatcherWithRegex(tc.K, tc.V)
 			// nolint: staticcheck
-			// Update to not use the deprecated fields later.
-			if re := actual.GetSafeRegexMatch().GetRegex(); re != "" {
+			if re := actual.GetStringMatch().GetSafeRegex().GetRegex(); re != "" {
 				_, err := regexp.Compile(re)
 				if err != nil {
 					t.Errorf("failed to compile regex %s: %v", re, err)

--- a/pilot/pkg/security/authz/model/generator_test.go
+++ b/pilot/pkg/security/authz/model/generator_test.go
@@ -199,8 +199,9 @@ func TestGenerator(t *testing.T) {
 			value: "foo",
 			want: yamlPrincipal(t, `
          header:
-          exactMatch: foo
-          name: x-foo`),
+          name: x-foo
+          stringMatch:
+            exact: foo`),
 		},
 		{
 			name:  "requestClaimGenerator",
@@ -254,10 +255,11 @@ func TestGenerator(t *testing.T) {
 			value: "foo",
 			want: yamlPermission(t, `
          header:
-          safeRegexMatch:
-            googleRe2: {}
-            regex: (?i)foo
-          name: :authority`),
+          name: :authority
+          stringMatch:
+            safeRegex:
+              googleRe2: {}
+              regex: (?i)foo`),
 		},
 		{
 			name:  "pathGenerator",
@@ -274,8 +276,9 @@ func TestGenerator(t *testing.T) {
 			value: "GET",
 			want: yamlPermission(t, `
          header:
-          exactMatch: GET
-          name: :method`),
+          name: :method
+          stringMatch:
+            exact: GET`),
 		},
 	}
 


### PR DESCRIPTION
**Please provide a description of this PR:**

`HeaderMatcher_ExactMatch`/`HeaderMatcher_SafeRegexMatch`/`HeaderMatcher_PrefixMatch`/`HeaderMatcher_SuffixMatch` are deprecated, which can be replaced with `HeaderMatcher_StringMatch`.