### PR TITLE
QueryParam support prefixMatch

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -857,6 +857,14 @@ func translateQueryParamMatch(name string, in *networking.StringMatch) *route.Qu
 				},
 			},
 		}
+	case *networking.StringMatch_Prefix:
+		out.QueryParameterMatchSpecifier = &route.QueryParameterMatcher_StringMatch{
+			StringMatch: &matcher.StringMatcher{
+				MatchPattern: &matcher.StringMatcher_Prefix{
+					Prefix: m.Prefix,
+				},
+			},
+		}
 	}
 
 	return out


### PR DESCRIPTION
**Please provide a description of this PR:**

Fix https://github.com/istio/istio/issues/33071. 
Though [istio/api](https://github.com/istio/api/blob/1.12.0-alpha.1/networking/v1alpha3/virtual_service.pb.go#L1581) said `prefix` is not supported, but actually envoy can support prefixMatch on QueryParam. 