### PR TITLE
Verify cert at client san

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -585,6 +585,7 @@ type buildClusterOpts struct {
 	// Indicates the service registry of the cluster being built.
 	serviceRegistry provider.ID
 	cache           model.XdsCache
+	host            string
 }
 
 type upgradeTuple struct {

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -241,7 +241,7 @@ func (cb *ClusterBuilder) applyDestinationRule(mc *MutableCluster, clusterMode C
 
 	host := ""
 	if destinationRule != nil {
-		host = destinationRule.Host
+		host = service.Hostname.String()
 	}
 	// merge applicable port level traffic policy settings
 	trafficPolicy := MergeTrafficPolicy(nil, destinationRule.GetTrafficPolicy(), port)

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -1001,7 +1001,7 @@ func (cb *ClusterBuilder) applyUpstreamTLSSettings(opts *buildClusterOpts, tls *
 }
 
 func selectSAN(san []string, hostname string) []string {
-	if len(san) < 1 && features.VerifyCertAtClient && hostname != "" {
+	if len(san) == 0 && features.VerifyCertAtClient && hostname != "" {
 		return []string{hostname}
 	}
 	return san

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -1074,7 +1074,7 @@ func (cb *ClusterBuilder) buildUpstreamClusterTLSContext(opts *buildClusterOpts,
 			if !res.IsRootCertificate() {
 				tlsContext.CommonTlsContext.ValidationContextType = &auth.CommonTlsContext_ValidationContext{}
 			} else {
-				subjectAltNames := make([]string, 0)
+				var subjectAltNames []string
 				if tls.SubjectAltNames != nil && len(tls.SubjectAltNames) != 0 {
 					subjectAltNames = tls.SubjectAltNames
 				} else if features.VerifyCertAtClient && opts != nil && opts.host != "" {
@@ -1130,9 +1130,16 @@ func (cb *ClusterBuilder) buildUpstreamClusterTLSContext(opts *buildClusterOpts,
 			if !res.IsRootCertificate() {
 				tlsContext.CommonTlsContext.ValidationContextType = &auth.CommonTlsContext_ValidationContext{}
 			} else {
+				var subjectAltNames []string
+				if tls.SubjectAltNames != nil && len(tls.SubjectAltNames) != 0 {
+					subjectAltNames = tls.SubjectAltNames
+				} else if features.VerifyCertAtClient && opts != nil && opts.host != "" {
+					subjectAltNames = append(subjectAltNames, opts.host)
+					tls.SubjectAltNames = subjectAltNames
+				}
 				tlsContext.CommonTlsContext.ValidationContextType = &auth.CommonTlsContext_CombinedValidationContext{
 					CombinedValidationContext: &auth.CommonTlsContext_CombinedCertificateValidationContext{
-						DefaultValidationContext:         &auth.CertificateValidationContext{MatchSubjectAltNames: util.StringToExactMatch(tls.SubjectAltNames)},
+						DefaultValidationContext:         &auth.CertificateValidationContext{MatchSubjectAltNames: util.StringToExactMatch(subjectAltNames)},
 						ValidationContextSdsSecretConfig: authn_model.ConstructSdsSecretConfig(res.GetRootResourceName()),
 					},
 				}

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -1001,7 +1001,7 @@ func (cb *ClusterBuilder) applyUpstreamTLSSettings(opts *buildClusterOpts, tls *
 }
 
 func selectSAN(san []string, hostname string) []string {
-	if features.VerifyCertAtClient && hostname != "" {
+	if len(san) < 1 && features.VerifyCertAtClient && hostname != "" {
 		return []string{hostname}
 	}
 	return san

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -1001,7 +1001,7 @@ func (cb *ClusterBuilder) applyUpstreamTLSSettings(opts *buildClusterOpts, tls *
 }
 
 func selectSAN(san []string, hostname string) []string {
-	if len(san) == 0 && features.VerifyCertAtClient && hostname != "" {
+	if len(san) == 0 && features.VerifyCertAtClient && hostname != "" && !strings.Contains(hostname, "*") {
 		return []string{hostname}
 	}
 	return san

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -1074,6 +1074,9 @@ func (cb *ClusterBuilder) buildUpstreamClusterTLSContext(opts *buildClusterOpts,
 			if !res.IsRootCertificate() {
 				tlsContext.CommonTlsContext.ValidationContextType = &auth.CommonTlsContext_ValidationContext{}
 			} else {
+				// SubjectAltNames is used to check what host the certificate is issued to.
+				// If SubjectAltNames is not set, the certificate is never checked to be issued to the host.
+				// VerifyCertAtClient will ensure the hostname will be used if no other SubjectAltNames are provided.
 				var subjectAltNames []string
 				if tls.SubjectAltNames != nil && len(tls.SubjectAltNames) != 0 {
 					subjectAltNames = tls.SubjectAltNames
@@ -1130,6 +1133,9 @@ func (cb *ClusterBuilder) buildUpstreamClusterTLSContext(opts *buildClusterOpts,
 			if !res.IsRootCertificate() {
 				tlsContext.CommonTlsContext.ValidationContextType = &auth.CommonTlsContext_ValidationContext{}
 			} else {
+				// SubjectAltNames is used to check what host the certificate is issued to.
+				// If SubjectAltNames is not set, the certificate is never checked to be issued to the host.
+				// VerifyCertAtClient will ensure the hostname will be used if no other SubjectAltNames are provided.
 				var subjectAltNames []string
 				if tls.SubjectAltNames != nil && len(tls.SubjectAltNames) != 0 {
 					subjectAltNames = tls.SubjectAltNames

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -1081,7 +1081,7 @@ func (cb *ClusterBuilder) buildUpstreamClusterTLSContext(opts *buildClusterOpts,
 				if tls.SubjectAltNames != nil && len(tls.SubjectAltNames) != 0 {
 					subjectAltNames = tls.SubjectAltNames
 				} else if features.VerifyCertAtClient && opts != nil && opts.host != "" {
-					subjectAltNames = append(subjectAltNames, opts.host)
+					subjectAltNames = []string{opts.host}
 					tls.SubjectAltNames = subjectAltNames
 				}
 				tlsContext.CommonTlsContext.ValidationContextType = &auth.CommonTlsContext_CombinedValidationContext{
@@ -1140,7 +1140,7 @@ func (cb *ClusterBuilder) buildUpstreamClusterTLSContext(opts *buildClusterOpts,
 				if tls.SubjectAltNames != nil && len(tls.SubjectAltNames) != 0 {
 					subjectAltNames = tls.SubjectAltNames
 				} else if features.VerifyCertAtClient && opts != nil && opts.host != "" {
-					subjectAltNames = append(subjectAltNames, opts.host)
+					subjectAltNames = []string{opts.host}
 					tls.SubjectAltNames = subjectAltNames
 				}
 				tlsContext.CommonTlsContext.ValidationContextType = &auth.CommonTlsContext_CombinedValidationContext{

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
@@ -3065,7 +3065,7 @@ func TestApplyDestinationRuleOSCACert(t *testing.T) {
 
 func generateSimpleSANDR(san []string) *networking.DestinationRule {
 	return &networking.DestinationRule{
-		Host: "foo.default.svc.cluster.local",
+		Host: "*.default.svc.cluster.local",
 		TrafficPolicy: &networking.TrafficPolicy{
 			ConnectionPool: &networking.ConnectionPoolSettings{
 				Http: &networking.ConnectionPoolSettings_HTTPSettings{
@@ -3084,7 +3084,7 @@ func generateSimpleSANDR(san []string) *networking.DestinationRule {
 
 func generateMutualSANDR(san []string) *networking.DestinationRule {
 	return &networking.DestinationRule{
-		Host: "foo.default.svc.cluster.local",
+		Host: "*.default.svc.cluster.local",
 		TrafficPolicy: &networking.TrafficPolicy{
 			ConnectionPool: &networking.ConnectionPoolSettings{
 				Http: &networking.ConnectionPoolSettings_HTTPSettings{

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
@@ -3264,7 +3264,7 @@ func TestApplySAN(t *testing.T) {
 			enableVerifyCertAtClient: true,
 		},
 		{
-			name:                     "VerifyCertAtClient false, SE SAN and SIMPLE TLS mode. No change in behavior. SE SAN expected.",
+			name:                     "VerifyCertAtClient true, SE SAN and SIMPLE TLS mode. No change in behavior. SE SAN expected.",
 			cluster:                  &cluster.Cluster{Name: "foo", ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS}},
 			clusterMode:              DefaultClusterMode,
 			service:                  service,
@@ -3276,7 +3276,7 @@ func TestApplySAN(t *testing.T) {
 			enableVerifyCertAtClient: true,
 		},
 		{
-			name:                     "VerifyCertAtClient false, SE SAN and MUTUAL TLS mode. No change in behavior. SE SAN expected.",
+			name:                     "VerifyCertAtClient true, SE SAN and MUTUAL TLS mode. No change in behavior. SE SAN expected.",
 			cluster:                  &cluster.Cluster{Name: "foo", ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS}},
 			clusterMode:              DefaultClusterMode,
 			service:                  service,
@@ -3288,7 +3288,7 @@ func TestApplySAN(t *testing.T) {
 			enableVerifyCertAtClient: true,
 		},
 		{
-			name:                     "VerifyCertAtClient false, DR SAN and SIMPLE TLS mode. No change in behavior. DR SAN expected.",
+			name:                     "VerifyCertAtClient true, DR SAN and SIMPLE TLS mode. No change in behavior. DR SAN expected.",
 			cluster:                  &cluster.Cluster{Name: "foo", ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS}},
 			clusterMode:              DefaultClusterMode,
 			service:                  service,
@@ -3300,7 +3300,7 @@ func TestApplySAN(t *testing.T) {
 			enableVerifyCertAtClient: true,
 		},
 		{
-			name:                     "VerifyCertAtClient false, DR SAN and MUTUAL TLS mode. No change in behavior. DR SAN expected.",
+			name:                     "VerifyCertAtClient true, DR SAN and MUTUAL TLS mode. No change in behavior. DR SAN expected.",
 			cluster:                  &cluster.Cluster{Name: "foo", ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS}},
 			clusterMode:              DefaultClusterMode,
 			service:                  service,
@@ -3312,7 +3312,7 @@ func TestApplySAN(t *testing.T) {
 			enableVerifyCertAtClient: true,
 		},
 		{
-			name:                     "VerifyCertAtClient false, SE and DR SAN and SIMPLE TLS mode. No change in behavior. DR SAN expected.",
+			name:                     "VerifyCertAtClient true, SE and DR SAN and SIMPLE TLS mode. No change in behavior. DR SAN expected.",
 			cluster:                  &cluster.Cluster{Name: "foo", ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS}},
 			clusterMode:              DefaultClusterMode,
 			service:                  service,
@@ -3324,7 +3324,7 @@ func TestApplySAN(t *testing.T) {
 			enableVerifyCertAtClient: true,
 		},
 		{
-			name:                     "VerifyCertAtClient false, SE and DR SAN and MUTUAL TLS mode. No change in behavior. DR SAN expected.",
+			name:                     "VerifyCertAtClient true, SE and DR SAN and MUTUAL TLS mode. No change in behavior. DR SAN expected.",
 			cluster:                  &cluster.Cluster{Name: "foo", ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS}},
 			clusterMode:              DefaultClusterMode,
 			service:                  service,

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
@@ -3088,6 +3088,7 @@ func TestApplyDestinationRuleSAN(t *testing.T) {
 		Resolution: model.ClientSideLB,
 		Attributes: model.ServiceAttributes{
 			Namespace: TestServiceNamespace,
+			ServiceRegistry: provider.External,
 		},
 	}
 

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
@@ -3130,12 +3130,13 @@ func TestApplySAN(t *testing.T) {
 	}
 
 	cases := []struct {
-		name                     string
-		cluster                  *cluster.Cluster
-		clusterMode              ClusterMode
-		service                  *model.Service
-		port                     *model.Port
-		networkView              map[network.ID]bool
+		name        string
+		cluster     *cluster.Cluster
+		clusterMode ClusterMode
+		service     *model.Service
+		port        *model.Port
+		networkView map[network.ID]bool
+		// serviceAccounts is the parameter passed in to applyDestinationRule with the ServiceEntry SAN
 		serviceAccounts          []string
 		destRule                 *networking.DestinationRule
 		expectedSubjectAltNames  []string

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
@@ -3378,7 +3378,7 @@ func TestApplySAN(t *testing.T) {
 			ec := NewMutableCluster(tt.cluster)
 			destRule := cb.req.Push.DestinationRule(proxy, tt.service)
 
-			// ACT
+			// ACT: apply the DestinationRule and compare new fields
 			_ = cb.applyDestinationRule(ec, tt.clusterMode, tt.service, tt.port, tt.networkView, destRule, tt.serviceAccounts)
 
 			byteArray, err := config.ToJSON(destRule.Spec)

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
@@ -3129,6 +3129,16 @@ func TestApplySAN(t *testing.T) {
 		},
 	}
 
+	badService := &model.Service{
+		Hostname:   host.Name("*.default.svc.cluster.local"),
+		Ports:      servicePort,
+		Resolution: model.ClientSideLB,
+		Attributes: model.ServiceAttributes{
+			Namespace:       TestServiceNamespace,
+			ServiceRegistry: provider.External,
+		},
+	}
+
 	cases := []struct {
 		name        string
 		cluster     *cluster.Cluster
@@ -3249,6 +3259,18 @@ func TestApplySAN(t *testing.T) {
 			serviceAccounts:          nil,
 			destRule:                 generateSimpleSANDR(nil),
 			expectedSubjectAltNames:  []string{"foo.default.svc.cluster.local"},
+			enableVerifyCertAtClient: true,
+		},
+		{
+			name:                     "VerifyCertAtClient true, no SAN and SIMPLE TLS mode. SE Hostname contains wildcard. No SAN expected, Hostname with wild card is rejected.",
+			cluster:                  &cluster.Cluster{Name: "foo", ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS}},
+			clusterMode:              DefaultClusterMode,
+			service:                  badService,
+			port:                     servicePort[0],
+			networkView:              map[network.ID]bool{},
+			serviceAccounts:          nil,
+			destRule:                 generateSimpleSANDR(nil),
+			expectedSubjectAltNames:  []string{},
 			enableVerifyCertAtClient: true,
 		},
 		{

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
@@ -3080,10 +3080,7 @@ func TestApplyDestinationRuleSAN(t *testing.T) {
 		},
 	}
 	service := &model.Service{
-		ClusterLocal: model.HostVIPs{
-			Hostname: host.Name("foo.default.svc.cluster.local"),
-		},
-		Address:    "1.1.1.1",
+		Hostname:   host.Name("foo.default.svc.cluster.local"),
 		Ports:      servicePort,
 		Resolution: model.ClientSideLB,
 		Attributes: model.ServiceAttributes{

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
@@ -3262,7 +3262,7 @@ func TestApplySAN(t *testing.T) {
 			enableVerifyCertAtClient: true,
 		},
 		{
-			name:                     "VerifyCertAtClient true, no SAN and SIMPLE TLS mode. SE Hostname contains wildcard. No SAN expected, Hostname with wild card is rejected.",
+			name:                     "VerifyCertAtClient true, no SAN and SIMPLE TLS mode. No SAN expected, Hostname with wild card is rejected.",
 			cluster:                  &cluster.Cluster{Name: "foo", ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS}},
 			clusterMode:              DefaultClusterMode,
 			service:                  badService,

--- a/releasenotes/notes/35437.yaml
+++ b/releasenotes/notes/35437.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: security
+issue:
+  - 35436
+releaseNotes:
+  - |
+    **Added** Setting `VERIFY_CERT_AT_CLIENT` enables the `DestinationRule` host name to be used as a `SAN` entry if `ServiceEntries` and `DestinationRule` do not contain a `SAN` field.

--- a/releasenotes/notes/35437.yaml
+++ b/releasenotes/notes/35437.yaml
@@ -5,4 +5,4 @@ issue:
   - 35436
 releaseNotes:
   - |
-    **Added** Setting `VERIFY_CERT_AT_CLIENT` enables the `DestinationRule` host name to be used as a `SAN` entry if `ServiceEntries` and `DestinationRule` do not contain a `SAN` field.
+    **Added** Setting `VERIFY_CERTIFICATE_AT_CLIENT` enables the `DestinationRule` host name to be used as a `SAN` entry if `ServiceEntries` and `DestinationRule` do not contain a `SAN` field.


### PR DESCRIPTION
**Please provide a description of this PR:**
Introduce SAN checking by default. This is possibly breaking behavior so I propose using `VerifyCertAtClient` to introduce this behavior.

If no SAN field is specified in the ServiceEntry or DestinationRule, the host name will be used as a SAN. This should handle certificates more appropriately.

This addresses #35436