### PR TITLE
Reduce delay on tf call, and introduce backoff

### DIFF
--- a/pkg/test/framework/components/echo/common/envoy.go
+++ b/pkg/test/framework/components/echo/common/envoy.go
@@ -31,7 +31,7 @@ const (
 	defaultConfigTimeout = time.Second * 30
 
 	// DefaultDelay the default delay between successive retry attempts
-	defaultConfigDelay = time.Second * 2
+	defaultConfigDelay = time.Millisecond * 100
 )
 
 // ConfigFetchFunc retrieves the config dump from Envoy.
@@ -43,7 +43,7 @@ type ConfigFetchFunc func() (*envoyAdmin.ConfigDump, error)
 type ConfigAcceptFunc func(*envoyAdmin.ConfigDump) (bool, error)
 
 func WaitForConfig(fetch ConfigFetchFunc, accept ConfigAcceptFunc, options ...retry.Option) error {
-	options = append([]retry.Option{retry.Delay(defaultConfigDelay), retry.Timeout(defaultConfigTimeout)}, options...)
+	options = append([]retry.Option{retry.BackoffDelay(defaultConfigDelay), retry.Timeout(defaultConfigTimeout)}, options...)
 
 	var cfg *envoyAdmin.ConfigDump
 	_, err := retry.Do(func() (result interface{}, completed bool, err error) {

--- a/pkg/test/framework/components/echo/flags.go
+++ b/pkg/test/framework/components/echo/flags.go
@@ -23,7 +23,7 @@ import (
 
 var (
 	callTimeout = 20 * time.Second
-	callDelay   = 100 * time.Millisecond
+	callDelay   = 10 * time.Millisecond
 )
 
 // init registers the command-line flags that we can exposed for "go test".
@@ -36,5 +36,5 @@ func init() {
 
 // DefaultCallRetryOptions returns the default call retry options as specified in command-line flags.
 func DefaultCallRetryOptions() []retry.Option {
-	return []retry.Option{retry.Timeout(callTimeout), retry.Delay(callDelay)}
+	return []retry.Option{retry.Timeout(callTimeout), retry.BackoffDelay(callDelay)}
 }

--- a/pkg/test/framework/components/echo/kube/instance.go
+++ b/pkg/test/framework/components/echo/kube/instance.go
@@ -45,7 +45,7 @@ var (
 	_ echo.Instance = &instance{}
 	_ io.Closer     = &instance{}
 
-	startDelay = retry.Delay(2 * time.Second)
+	startDelay = retry.BackoffDelay(time.Millisecond * 100)
 )
 
 type instance struct {

--- a/pkg/test/framework/components/echo/kube/workload.go
+++ b/pkg/test/framework/components/echo/kube/workload.go
@@ -194,7 +194,7 @@ func (w *workload) connect(pod kubeCore.Pod) (err error) {
 				pod.Namespace, pod.Name, err)
 		}
 		return nil
-	}, retry.Delay(1*time.Second), retry.Timeout(10*time.Second)); err != nil {
+	}, retry.BackoffDelay(100*time.Millisecond), retry.Timeout(10*time.Second)); err != nil {
 		return err
 	}
 

--- a/pkg/test/framework/components/istio/ingress.go
+++ b/pkg/test/framework/components/istio/ingress.go
@@ -49,7 +49,7 @@ const (
 
 var (
 	getAddressTimeout = retry.Timeout(3 * time.Minute)
-	getAddressDelay   = retry.Delay(5 * time.Second)
+	getAddressDelay   = retry.BackoffDelay(500 * time.Millisecond)
 
 	_ ingress.Instance = &ingressImpl{}
 )

--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -63,7 +63,7 @@ const (
 var (
 	// the retry options for waiting for an individual component to be ready
 	componentDeployTimeout = retry.Timeout(1 * time.Minute)
-	componentDeployDelay   = retry.Delay(1 * time.Second)
+	componentDeployDelay   = retry.BackoffDelay(200 * time.Millisecond)
 )
 
 type operatorComponent struct {

--- a/pkg/test/kube/util.go
+++ b/pkg/test/kube/util.go
@@ -34,7 +34,7 @@ import (
 
 var (
 	defaultRetryTimeout = retry.Timeout(time.Minute * 10)
-	defaultRetryDelay   = retry.Delay(time.Second * 1)
+	defaultRetryDelay   = retry.BackoffDelay(time.Millisecond * 200)
 )
 
 // PodFetchFunc fetches pods from a k8s Client.

--- a/pkg/test/util/retry/retry.go
+++ b/pkg/test/util/retry/retry.go
@@ -36,6 +36,7 @@ const (
 var defaultConfig = config{
 	timeout:  DefaultTimeout,
 	delay:    DefaultDelay,
+	delayMax: DefaultDelay,
 	converge: DefaultConverge,
 }
 

--- a/tests/integration/pilot/common/traffic.go
+++ b/tests/integration/pilot/common/traffic.go
@@ -19,7 +19,6 @@ package common
 
 import (
 	"fmt"
-	"time"
 
 	"istio.io/istio/pkg/test"
 	echoclient "istio.io/istio/pkg/test/echo/client"
@@ -37,8 +36,8 @@ import (
 // callsPerCluster is used to ensure cross-cluster load balancing has a chance to work
 const callsPerCluster = 5
 
-// Slow down retries to allow for delayed_close_timeout. Also require 3 successive successes.
-var retryOptions = []retry.Option{retry.Delay(1000 * time.Millisecond), retry.Converge(3)}
+// Require 3 successive successes. Delay can be configured with istio.test.echo.callDelay
+var retryOptions = []retry.Option{retry.Converge(3)}
 
 type TrafficCall struct {
 	name string


### PR DESCRIPTION
Right now every call has a 1s backoff. 99% of the time, the first call
fails because the config has *just* been sent and there is a 100ms
debounce time in Istiod.

This drops down the delay. At the same time, we make it respect the
existing callDelay flag, and switch some other slow usages over to using
a lower time but with exponential backoff. This allows fast cases to
finish quickly without overloading things.

**Please provide a description of this PR:**