### PR TITLE
Allow turning off ALPN in echo server

### DIFF
--- a/pkg/test/echo/cmd/server/main.go
+++ b/pkg/test/echo/cmd/server/main.go
@@ -48,6 +48,7 @@ var (
 	crt              string
 	key              string
 	istioVersion     string
+	disableALPN      bool
 
 	loggingOptions = log.DefaultOptions()
 
@@ -123,6 +124,7 @@ var (
 				Cluster:               cluster,
 				IstioVersion:          istioVersion,
 				UDSServer:             uds,
+				DisableALPN:           disableALPN,
 			})
 
 			if err := s.Start(); err != nil {
@@ -164,6 +166,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&crt, "crt", "", "gRPC TLS server-side certificate")
 	rootCmd.PersistentFlags().StringVar(&key, "key", "", "gRPC TLS server-side key")
 	rootCmd.PersistentFlags().StringVar(&istioVersion, "istio-version", "", "Istio sidecar version")
+	rootCmd.PersistentFlags().BoolVar(&disableALPN, "disable-alpn", disableALPN, "disable ALPN negotiation")
 
 	loggingOptions.AttachCobraFlags(rootCmd)
 

--- a/pkg/test/echo/common/model.go
+++ b/pkg/test/echo/common/model.go
@@ -28,6 +28,11 @@ type TLSSettings struct {
 	Hostname string
 	// If set to true, the cert will be provisioned by proxy, and extra cert volume will be mounted.
 	ProxyProvision bool
+	// AcceptAnyALPN, if true, will make the server accept ANY ALPNs. This comes at the expense of
+	// allowing h2 negotiation and being able to detect the negotiated ALPN (as there is none), because
+	// Golang doesn't like us doing this (https://github.com/golang/go/issues/46310).
+	// This is useful when the server is simulating Envoy which does unconventional things with ALPN.
+	AcceptAnyALPN bool
 }
 
 // Port represents a network port where a service is listening for

--- a/pkg/test/echo/server/endpoint/http.go
+++ b/pkg/test/echo/server/endpoint/http.go
@@ -86,9 +86,13 @@ func (s *httpInstance) Start(onReady OnReadyFunc) error {
 		if cerr != nil {
 			return fmt.Errorf("could not load TLS keys: %v", cerr)
 		}
+		nextProtos := []string{"h2", "http/1.1", "http/1.0"}
+		if s.DisableALPN {
+			nextProtos = nil
+		}
 		config := &tls.Config{
 			Certificates: []tls.Certificate{cert},
-			NextProtos:   []string{"h2", "http/1.1", "http/1.0"},
+			NextProtos:   nextProtos,
 			GetConfigForClient: func(info *tls.ClientHelloInfo) (*tls.Config, error) {
 				// There isn't a way to pass through all ALPNs presented by the client down to the
 				// HTTP server to return in the response. However, for debugging, we can at least log

--- a/pkg/test/echo/server/endpoint/instance.go
+++ b/pkg/test/echo/server/endpoint/instance.go
@@ -40,6 +40,7 @@ type Config struct {
 	Port          *common.Port
 	ListenerIP    string
 	IstioVersion  string
+	DisableALPN   bool
 }
 
 // Instance of an endpoint that serves the Echo application on a single port/protocol.

--- a/pkg/test/echo/server/instance.go
+++ b/pkg/test/echo/server/instance.go
@@ -47,6 +47,7 @@ type Config struct {
 	Cluster               string
 	Dialer                common.Dialer
 	IstioVersion          string
+	DisableALPN           bool
 }
 
 func (c Config) String() string {
@@ -164,6 +165,7 @@ func (s *Instance) newEndpoint(port *common.Port, udsServer string) (endpoint.In
 		TLSKey:        s.TLSKey,
 		Dialer:        s.Dialer,
 		ListenerIP:    ip,
+		DisableALPN:   s.DisableALPN,
 		IstioVersion:  s.IstioVersion,
 	})
 }

--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -221,6 +221,9 @@ spec:
 {{- if $.TLSSettings }}
           - --crt=/etc/certs/custom/cert-chain.pem
           - --key=/etc/certs/custom/key.pem
+{{- if $.TLSSettings.AcceptAnyALPN}}
+          - --disable-alpn
+{{- end }}
 {{- else }}
           - --crt=/cert.crt
           - --key=/cert.key

--- a/tests/integration/security/ca_custom_root/main_test.go
+++ b/tests/integration/security/ca_custom_root/main_test.go
@@ -141,9 +141,10 @@ func SetupApps(ctx resource.Context, apps *EchoDeployments) error {
 				},
 			},
 			TLSSettings: &common.TLSSettings{
-				RootCert:   rootCert,
-				ClientCert: clientCert,
-				Key:        Key,
+				RootCert:      rootCert,
+				ClientCert:    clientCert,
+				Key:           Key,
+				AcceptAnyALPN: true,
 			},
 		}).
 		WithConfig(echo.Config{
@@ -165,9 +166,10 @@ func SetupApps(ctx resource.Context, apps *EchoDeployments) error {
 				},
 			},
 			TLSSettings: &common.TLSSettings{
-				RootCert:   rootCert,
-				ClientCert: clientCert,
-				Key:        Key,
+				RootCert:      rootCert,
+				ClientCert:    clientCert,
+				Key:           Key,
+				AcceptAnyALPN: true,
 			},
 		}).
 		WithConfig(echo.Config{
@@ -190,9 +192,10 @@ func SetupApps(ctx resource.Context, apps *EchoDeployments) error {
 				},
 			},
 			TLSSettings: &common.TLSSettings{
-				RootCert:   rootCertAlt,
-				ClientCert: clientCertAlt,
-				Key:        keyAlt,
+				RootCert:      rootCertAlt,
+				ClientCert:    clientCertAlt,
+				Key:           keyAlt,
+				AcceptAnyALPN: true,
 			},
 		}).
 		WithConfig(echo.Config{


### PR DESCRIPTION
Sad we have to resort to this but I don't see any other good options 

This is required for Go 1.17. They removed the ability to have unknown ALPN treated as HTTP 1 *and* h2 negotiation at the same time. For our tests, we rely on one or the other of these functionalities, so we can just make the test opt-in. Needing unknown ALPN is very rare (only when we are simulating Envoy mTLS via echo app) so its not a huge burden