### PR TITLE
do not build catch all virtual host every time

### DIFF
--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	gogojsonpb "github.com/gogo/protobuf/jsonpb"
 	"github.com/golang/protobuf/jsonpb"
@@ -34,6 +35,7 @@ import (
 	structpb "github.com/golang/protobuf/ptypes/struct"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
+	networking "istio.io/api/networking/v1alpha3"
 	istionetworking "istio.io/istio/pilot/pkg/networking"
 	"istio.io/istio/pilot/pkg/trustbundle"
 	"istio.io/istio/pkg/cluster"
@@ -303,6 +305,8 @@ type Proxy struct {
 
 	// XdsNode is the xDS node identifier
 	XdsNode *core.Node
+
+	CatchAllVirtualHost *route.VirtualHost
 }
 
 // WatchedResource tracks an active DiscoveryRequest subscription.
@@ -798,6 +802,25 @@ func (node *Proxy) SetSidecarScope(ps *PushContext) {
 		node.SidecarScope = ps.getSidecarScope(node, nil)
 	}
 	node.PrevSidecarScope = sidecarScope
+	// Build CatchAllVirtualHost and cache it. This depends on sidecar scope config.
+	node.BuildCatchAllVirtualHost()
+}
+
+// Exposed only for tests. If used in regular code, should be called after SetSidecarScope.
+func (node *Proxy) BuildCatchAllVirtualHost() {
+	// Build CatchAllVirtualHost and cache it. This depends on sidecar scope config.
+	allowAny := false
+	if node.SidecarScope.OutboundTrafficPolicy != nil &&
+		node.SidecarScope.OutboundTrafficPolicy.Mode == networking.OutboundTrafficPolicy_ALLOW_ANY {
+		allowAny = true
+	}
+	egressDestination := ""
+	destination := node.SidecarScope.OutboundTrafficPolicy.EgressProxy
+	if destination != nil {
+		egressDestination = BuildSubsetKey(TrafficDirectionOutbound, destination.Subset, host.Name(destination.Host), 0)
+	}
+
+	node.CatchAllVirtualHost = istionetworking.BuildCatchAllVirtualHost(allowAny, egressDestination)
 }
 
 // SetGatewaysForProxy merges the Gateway objects associated with this

--- a/pilot/pkg/networking/core/v1alpha3/httproute_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute_test.go
@@ -1245,6 +1245,7 @@ func testSidecarRDSVHosts(t *testing.T, services []*model.Service,
 	} else {
 		proxy.SidecarScope = model.ConvertToSidecarScope(env.PushContext, sidecarConfig, sidecarConfig.Namespace)
 	}
+	proxy.BuildCatchAllVirtualHost()
 
 	vHostCache := make(map[int][]*route.VirtualHost)
 	resource, _ := configgen.buildSidecarOutboundHTTPRouteConfig(proxy, &model.PushRequest{Push: env.PushContext}, routeName, vHostCache, nil, nil)

--- a/pilot/pkg/networking/networking.go
+++ b/pilot/pkg/networking/networking.go
@@ -17,8 +17,10 @@ package networking
 import (
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	http_conn "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	tls "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
+	"google.golang.org/protobuf/types/known/durationpb"
 
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pkg/config/protocol"
@@ -36,6 +38,19 @@ const (
 	ListenerProtocolHTTP
 	// ListenerProtocolAuto enables auto protocol detection
 	ListenerProtocolAuto
+)
+
+const (
+	// BlackHoleCluster to catch traffic from routes with unresolved clusters. Traffic arriving here goes nowhere.
+	BlackHoleCluster = "BlackHoleCluster"
+	// BlackHole is the name of the virtual host and route name used to block all traffic
+	BlackHole = "block_all"
+	// PassthroughCluster to forward traffic to the original destination requested. This cluster is used when
+	// traffic does not match any listener in envoy.
+	PassthroughCluster = "PassthroughCluster"
+	// Passthrough is the name of the virtual host used to forward traffic to the
+	// PassthroughCluster
+	Passthrough = "allow_any"
 )
 
 // ModelProtocolToListenerProtocol converts from a config.Protocol to its corresponding plugin.ListenerProtocol
@@ -183,3 +198,61 @@ const (
 	ListenerClassSidecarOutbound
 	ListenerClassGateway
 )
+
+func BuildCatchAllVirtualHost(allowAnyoutbound bool, sidecarDestination string) *route.VirtualHost {
+	if allowAnyoutbound {
+		egressCluster := PassthroughCluster
+		notimeout := durationpb.New(0)
+
+		if sidecarDestination != "" {
+			// user has provided an explicit destination for all the unknown traffic.
+			// build a cluster out of this destination
+			egressCluster = sidecarDestination
+		}
+
+		routeAction := &route.RouteAction{
+			ClusterSpecifier: &route.RouteAction_Cluster{Cluster: egressCluster},
+			// Disable timeout instead of assuming some defaults.
+			Timeout: notimeout,
+			// Use deprecated value for now as the replacement MaxStreamDuration has some regressions.
+			// nolint: staticcheck
+			MaxGrpcTimeout: notimeout,
+		}
+
+		return &route.VirtualHost{
+			Name:    Passthrough,
+			Domains: []string{"*"},
+			Routes: []*route.Route{
+				{
+					Name: Passthrough,
+					Match: &route.RouteMatch{
+						PathSpecifier: &route.RouteMatch_Prefix{Prefix: "/"},
+					},
+					Action: &route.Route_Route{
+						Route: routeAction,
+					},
+				},
+			},
+			IncludeRequestAttemptCount: true,
+		}
+	}
+
+	return &route.VirtualHost{
+		Name:    BlackHole,
+		Domains: []string{"*"},
+		Routes: []*route.Route{
+			{
+				Name: BlackHole,
+				Match: &route.RouteMatch{
+					PathSpecifier: &route.RouteMatch_Prefix{Prefix: "/"},
+				},
+				Action: &route.Route_DirectResponse{
+					DirectResponse: &route.DirectResponseAction{
+						Status: 502,
+					},
+				},
+			},
+		},
+		IncludeRequestAttemptCount: true,
+	}
+}

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -54,15 +54,15 @@ import (
 
 const (
 	// BlackHoleCluster to catch traffic from routes with unresolved clusters. Traffic arriving here goes nowhere.
-	BlackHoleCluster = "BlackHoleCluster"
+	BlackHoleCluster = istionetworking.BlackHoleCluster
 	// BlackHole is the name of the virtual host and route name used to block all traffic
-	BlackHole = "block_all"
+	BlackHole = istionetworking.BlackHole
 	// PassthroughCluster to forward traffic to the original destination requested. This cluster is used when
 	// traffic does not match any listener in envoy.
-	PassthroughCluster = "PassthroughCluster"
+	PassthroughCluster = istionetworking.PassthroughCluster
 	// Passthrough is the name of the virtual host used to forward traffic to the
 	// PassthroughCluster
-	Passthrough = "allow_any"
+	Passthrough = istionetworking.Passthrough
 	// PassthroughFilterChain to catch traffic that doesn't match other filter chains.
 	PassthroughFilterChain = "PassthroughFilterChain"
 

--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -670,7 +670,7 @@ func (s *DiscoveryServer) computeProxyState(proxy *model.Proxy, request *model.P
 			}
 		}
 	}
-	// compute the sidecarscope for both proxy type whenever it changes.
+	// compute the sidecarscope for both proxy types whenever it changes.
 	if sidecar {
 		proxy.SetSidecarScope(push)
 	}


### PR DESCRIPTION
CatchAllVirtualHost only changes when sidecar for a proxy is changed. We do not have to build it for every route every time.

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
