### PR TITLE
remove precheck extra code logic

### DIFF
--- a/istioctl/cmd/precheck.go
+++ b/istioctl/cmd/precheck.go
@@ -308,7 +308,6 @@ func checkListeners(cli kube.ExtendedClient, namespace string) (diag.Messages, e
 					continue
 				}
 				ip := net.ParseIP(bind)
-				ip.IsGlobalUnicast()
 				portn, _ := strconv.Atoi(port)
 				if _, f := ports[portn]; f {
 					c := ports[portn]


### PR DESCRIPTION
Fix issue #35451.
Looks like `ip.IsGlobalUnicast()` is useless in this place.



**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
