### PR TITLE
Handle empty ratings collection when using Mongo

### DIFF
--- a/samples/bookinfo/src/ratings/ratings.js
+++ b/samples/bookinfo/src/ratings/ratings.js
@@ -152,8 +152,12 @@ dispatcher.onGet(/^\/ratings\/[0-9]*/, function (req, res) {
               res.end(JSON.stringify({error: 'could not load ratings from database'}))
               console.log(err)
             } else {
-              firstRating = data[0].rating
-              secondRating = data[1].rating
+              if (data[0]) {
+                firstRating = data[0].rating
+              }
+              if (data[1]) {
+                secondRating = data[1].rating
+              }
               var result = {
                 id: productId,
                 ratings: {


### PR DESCRIPTION
If the mongo db was empty, the ratings service would throw the following error:

TypeError: Cannot read property 'rating' of undefined
at /opt/microservices/ratings.js:155:37