### PR TITLE
add monitoring for webhook patching events

### DIFF
--- a/pkg/webhooks/monitoring.go
+++ b/pkg/webhooks/monitoring.go
@@ -1,0 +1,95 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webhooks
+
+import (
+	"istio.io/pkg/monitoring"
+)
+
+var (
+	// webhookConfigNameTag holds the target webhook config name for the context.
+	webhookConfigNameTag = monitoring.MustCreateLabel("name")
+
+	// reasonTag holds the error reason for the context.
+	reasonTag = monitoring.MustCreateLabel("reason")
+)
+
+var (
+	metricWebhookPatchAttempts = monitoring.NewSum(
+		"webhook_patch_attempts",
+		"Webhook patching attempts",
+		monitoring.WithLabels(webhookConfigNameTag),
+	)
+
+	metricWebhookPatchRetries = monitoring.NewSum(
+		"webhook_patch_retries",
+		"Webhook patching retries",
+		monitoring.WithLabels(webhookConfigNameTag),
+	)
+
+	metricWebhookPatchFailures = monitoring.NewSum(
+		"webhook_patch_failure",
+		"Webhook patching total failures",
+		monitoring.WithLabels(webhookConfigNameTag, reasonTag),
+	)
+
+	metricWebhookPatchSuccess = monitoring.NewSum(
+		"webhook_patch_success",
+		"Webhook patching total success count",
+		monitoring.WithLabels(webhookConfigNameTag, reasonTag),
+	)
+)
+
+const (
+	// webhook patching failure reasons
+	reasonWrongRevision         = "wrong_revision"
+	reasonLoadCABundleFailure   = "load_ca_bundle_failure"
+	reasonWebhookConfigNotFound = "webhook_config_not_found"
+	reasonWebhookEntryNotFound  = "webhook_entry_not_found"
+	reasonWebhookUpdateFailure  = "webhook_update_failure"
+)
+
+func init() {
+	monitoring.MustRegister(
+		metricWebhookPatchAttempts,
+		metricWebhookPatchRetries,
+		metricWebhookPatchFailures,
+	)
+}
+
+func reportWebhookPatchAttempts(webhookConfigName string) {
+	metricWebhookPatchAttempts.
+		With(webhookConfigNameTag.Value(webhookConfigName)).
+		Increment()
+}
+
+func reportWebhookPatchRetry(webhookConfigName string) {
+	metricWebhookPatchRetries.
+		With(webhookConfigNameTag.Value(webhookConfigName)).
+		Increment()
+}
+
+func reportWebhookPatchFailure(webhookConfigName string, reason string) {
+	metricWebhookPatchFailures.
+		With(webhookConfigNameTag.Value(webhookConfigName)).
+		With(reasonTag.Value(reason)).
+		Increment()
+}
+
+func reportWebhookPatchSuccess(webhookConfigName string) {
+	metricWebhookPatchSuccess.
+		With(webhookConfigNameTag.Value(webhookConfigName)).
+		Increment()
+}

--- a/pkg/webhooks/webhookpatch.go
+++ b/pkg/webhooks/webhookpatch.go
@@ -153,6 +153,7 @@ func (w *WebhookCertPatcher) addWebhookHandler(config *v1.MutatingWebhookConfigu
 
 // webhookPatchTask takes the result of patchMutatingWebhookConfig and modifies the result for use in task queue
 func (w *WebhookCertPatcher) webhookPatchTask(webhookConfigName string) error {
+	reportWebhookPatchAttempts(webhookConfigName)
 	err := w.patchMutatingWebhookConfig(
 		w.client.AdmissionregistrationV1().MutatingWebhookConfigurations(),
 		webhookConfigName)
@@ -161,6 +162,10 @@ func (w *WebhookCertPatcher) webhookPatchTask(webhookConfigName string) error {
 	// we should no longer be patching the given webhook
 	if kubeErrors.IsNotFound(err) || errors.Is(err, errWrongRevision) || errors.Is(err, errNoWebhookWithName) {
 		return nil
+	}
+
+	if err != nil {
+		reportWebhookPatchRetry(webhookConfigName)
 	}
 
 	return err
@@ -172,11 +177,13 @@ func (w *WebhookCertPatcher) patchMutatingWebhookConfig(
 	webhookConfigName string) error {
 	config, err := client.Get(context.TODO(), webhookConfigName, metav1.GetOptions{})
 	if err != nil {
+		reportWebhookPatchFailure(webhookConfigName, reasonWebhookConfigNotFound)
 		return err
 	}
 	// prevents a race condition between multiple istiods when the revision is changed or modified
 	v, ok := config.Labels[label.IoIstioRev.Name]
 	if v != w.revision || !ok {
+		reportWebhookPatchFailure(webhookConfigName, reasonWrongRevision)
 		return errWrongRevision
 	}
 
@@ -184,6 +191,7 @@ func (w *WebhookCertPatcher) patchMutatingWebhookConfig(
 	caCertPem, err := util.LoadCABundle(w.CABundleWatcher)
 	if err != nil {
 		log.Errorf("Failed to load CA bundle: %v", err)
+		reportWebhookPatchFailure(webhookConfigName, reasonLoadCABundleFailure)
 		return err
 	}
 	for i, wh := range config.Webhooks {
@@ -193,10 +201,17 @@ func (w *WebhookCertPatcher) patchMutatingWebhookConfig(
 		}
 	}
 	if !found {
+		reportWebhookPatchFailure(webhookConfigName, reasonWebhookEntryNotFound)
 		return errNoWebhookWithName
 	}
 
 	_, err = client.Update(context.TODO(), config, metav1.UpdateOptions{})
+	if err != nil {
+		reportWebhookPatchFailure(webhookConfigName, reasonWebhookUpdateFailure)
+	} else {
+		reportWebhookPatchSuccess(webhookConfigName)
+	}
+
 	return err
 }
 


### PR DESCRIPTION
**Please provide a description of this PR:**
- This PR adds monitoring for webhook patching, including patching attempts, errors, retries, and succeeded calls.
- Motivation for adding this flag is based on this thread https://github.com/istio/istio/issues/35344