### PR TITLE
Fix default DOCKER_BUILD_VARIANTS

### DIFF
--- a/tools/istio-docker.mk
+++ b/tools/istio-docker.mk
@@ -241,7 +241,7 @@ dockerx:
 		DOCKER_ARCHITECTURES=$(DOCKER_ARCHITECTURES) \
 		./tools/buildx-gen.sh $(DOCKERX_BUILD_TOP) $(DOCKER_TARGETS)
 	@# Retry works around https://github.com/docker/buildx/issues/298
-	DOCKER_CLI_EXPERIMENTAL=enabled bin/retry.sh "read: connection reset by peer" docker buildx bake $(BUILDX_BAKE_EXTRA_OPTIONS) -f $(DOCKERX_BUILD_TOP)/docker-bake.hcl "$(or $(DOCKER_BUILD_VARIANTS),default)" || \
+	DOCKER_CLI_EXPERIMENTAL=enabled bin/retry.sh "read: connection reset by peer" docker buildx bake $(BUILDX_BAKE_EXTRA_OPTIONS) -f $(DOCKERX_BUILD_TOP)/docker-bake.hcl $(or $(DOCKER_BUILD_VARIANTS),default) || \
 		{ tools/dump-docker-logs.sh; exit 1; }
 
 # Support individual images like `dockerx.pilot`

--- a/tools/istio-docker.mk
+++ b/tools/istio-docker.mk
@@ -241,7 +241,7 @@ dockerx:
 		DOCKER_ARCHITECTURES=$(DOCKER_ARCHITECTURES) \
 		./tools/buildx-gen.sh $(DOCKERX_BUILD_TOP) $(DOCKER_TARGETS)
 	@# Retry works around https://github.com/docker/buildx/issues/298
-	DOCKER_CLI_EXPERIMENTAL=enabled bin/retry.sh "read: connection reset by peer" docker buildx bake $(BUILDX_BAKE_EXTRA_OPTIONS) -f $(DOCKERX_BUILD_TOP)/docker-bake.hcl $(DOCKER_BUILD_VARIANTS) || \
+	DOCKER_CLI_EXPERIMENTAL=enabled bin/retry.sh "read: connection reset by peer" docker buildx bake $(BUILDX_BAKE_EXTRA_OPTIONS) -f $(DOCKERX_BUILD_TOP)/docker-bake.hcl "$(or $(DOCKER_BUILD_VARIANTS),default)" || \
 		{ tools/dump-docker-logs.sh; exit 1; }
 
 # Support individual images like `dockerx.pilot`
@@ -314,7 +314,7 @@ endef
 # * "debug", suffixed as -debug. This is a ubuntu based image with a bunch of debug tools
 # * "distroless", suffixed as -distroless. This is distroless image - no shell. proxyv2 uses a custom one with iptables added
 # * "default", no suffix. This is currently "debug"
-DOCKER_BUILD_VARIANTS ?= ""
+DOCKER_BUILD_VARIANTS ?=
 DOCKER_ALL_VARIANTS ?= debug distroless
 # If INCLUDE_UNTAGGED_DEFAULT is set, then building the "DEFAULT_DISTRIBUTION" variant will publish both <tag>-<variant> and <tag>
 # This can be done with DOCKER_BUILD_VARIANTS="default debug" as well, but at the expense of building twice vs building once and tagging twice


### PR DESCRIPTION
I don't fully understand how but this is somehow breaking our internal build. The problem is `DOCKER_BUILD_VARIANTS ?= ""` sets the variable to bash equivalent of `'""'` (ie length 2 double quotes, not empty string). We then call `buildx bake ""` which is broken.

I have no clue how it works in one place and not the other TBH. But might as well do it right; with this approach it works in both places