### PR TITLE
add 'Kubernetes' as valid cluster ID for skipping proxy instances

### DIFF
--- a/pilot/pkg/serviceregistry/aggregate/controller.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller.go
@@ -226,7 +226,7 @@ func skipSearchingRegistryForProxy(nodeClusterID cluster.ID, r serviceregistry.I
 		return false
 	}
 
-	return !r.Cluster().Equals(nodeClusterID)
+	return !(r.Cluster().Equals(nodeClusterID) || nodeClusterID == cluster.ID(provider.Kubernetes))
 }
 
 // GetProxyServiceInstances lists service instances co-located with a given proxy

--- a/pilot/pkg/serviceregistry/aggregate/controller_test.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller_test.go
@@ -473,6 +473,8 @@ func TestSkipSearchingRegistryForProxy(t *testing.T) {
 	}{
 		// matching kube registry
 		{"cluster-1", cluster1, false},
+		// matching default k8s default provider name
+		{"Kubernetes", cluster1, false},
 		// unmatching kube registry
 		{"cluster-1", cluster2, true},
 		// always search external

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -1214,7 +1214,8 @@ func (c *Controller) onSystemNamespaceEvent(obj interface{}, ev model.Event) err
 // isControllerForProxy should be used for proxies assumed to be in the kube cluster for this controller. Workload Entries
 // may not necessarily pass this check, but we still want to allow kube services to select workload instances.
 func (c *Controller) isControllerForProxy(proxy *model.Proxy) bool {
-	return proxy.Metadata.ClusterID == "" || proxy.Metadata.ClusterID == c.Cluster()
+	return proxy.Metadata.ClusterID == "" || proxy.Metadata.ClusterID == cluster.ID(provider.Kubernetes) ||
+		proxy.Metadata.ClusterID == c.Cluster()
 }
 
 // getProxyServiceInstancesFromMetadata retrieves ServiceInstances using proxy Metadata rather than


### PR DESCRIPTION
The following sequence fails to build proxy services instances for old proxies
- Deployed Istio with `ISTIO_META_CLUSTER_ID` default (i.e. `Kubernetes`). All proxies now belong to `Kubernetes`.
- Add support for another cluster - now updated the `ISTIO_META_CLUSTER_ID` to point to the right cluster name
- Now old proxies which have `Kubernetes` does not get proxy service instances till they are restarted.

This could be a miss on our end to populate the cluster ID correctly even for single cluster to start with. - But since we are in this (may be others?) proposing this change. 

This PR tries to check if the proxy's cluster is `Kubernetes` (default value) and allows to get proxy service instances.

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
