### PR TITLE
Add Steven to top level owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
-*                                                                @costinm @linsun @howardjohn @nmittler
+*                                                                @costinm @linsun @howardjohn @nmittler @stevenctl
 /.gitattributes                                                  @istio/wg-test-and-release-maintainers
 /.gitignore                                                      @istio/wg-test-and-release-maintainers
 /Makefile.core.mk                                                @istio/wg-test-and-release-maintainers


### PR DESCRIPTION
I am proposing we add @stevenctl to the top level owners to help reduce the bus factor a bit. Largely this just means approving go.mod changes. 

I specifically assigned Lin to avoid same company approval, although I don't think company diversity here is _that_ important since the role is pretty minor