### PR TITLE
Skip TestClusterLocal on pre-1.11 versions

### DIFF
--- a/tests/integration/pilot/multicluster_test.go
+++ b/tests/integration/pilot/multicluster_test.go
@@ -43,6 +43,7 @@ func TestClusterLocal(t *testing.T) {
 			"installation.multicluster.remote",
 		).
 		RequiresMinClusters(2).
+		RequireIstioVersion("1.11").
 		Run(func(t framework.TestContext) {
 			// TODO use echotest to dynamically pick 2 simple pods from apps.All
 			sources := apps.PodA


### PR DESCRIPTION
Earlier PR skipped cluster local test in `pilot/mcs/discoverability`, need to also skip here in `pilot/multicluster_test.go`.

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure