### PR TITLE
test removing a remote secret

### DIFF
--- a/tests/integration/pilot/multicluster_test.go
+++ b/tests/integration/pilot/multicluster_test.go
@@ -183,6 +183,7 @@ func TestRemoveCluster(t *testing.T) {
 	framework.NewTest(t).
 		RequiresMinClusters(2).
 		RequiresLocalControlPlane().
+		Features("installation.multicluster.multimaster").
 		Run(func(t framework.TestContext) {
 			primary := t.Clusters().Primaries()[0]
 			remote := t.Clusters().Exclude(primary)[0]


### PR DESCRIPTION
I'm not 100% sure this is how we should test this – it could be slow, and flakes/failures would probably break a lot of surrounding tests. 

Possible alternatives:
* Tests that trigger the Cleanup method on serviceregistry/kube
* Enhance FakeDiscoveryServer to use the secretcontroller – this could add some bloat to UTs