### PR TITLE
Update docker file: python:2-onbuild to python:3-onbuild

### DIFF
--- a/samples/helloworld/src/Dockerfile
+++ b/samples/helloworld/src/Dockerfile
@@ -12,7 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-FROM python:2-onbuild
+FROM python:3-onbuild
 
 WORKDIR /opt/microservices
 COPY app.py /opt/microservices/


### PR DESCRIPTION
Docker image not building on python:2 version, updated to version 3

**Please provide a description of this PR:**

Docker image not building on python:2 version, updated to version 3