### PR TITLE
[Test Framework] Fix host header when Address specified

### DIFF
--- a/pkg/test/framework/components/echo/call.go
+++ b/pkg/test/framework/components/echo/call.go
@@ -97,6 +97,32 @@ type CallOptions struct {
 	ServerName string
 }
 
+// GetHost returns the best default host for the call. Returns the first host defined from the following
+// sources (in order of precedence): Host header, target's DefaultHostHeader, Address, target's FQDN.
+func (o CallOptions) GetHost() string {
+	// First, use the host header, if specified.
+	if h := o.Headers["Host"]; len(h) > 0 {
+		return o.Headers["Host"][0]
+	}
+
+	// Next use the target's default, if specified.
+	if o.Target != nil && len(o.Target.Config().DefaultHostHeader) > 0 {
+		return o.Target.Config().DefaultHostHeader
+	}
+
+	// Next, if the Address was manually specified use it as the Host.
+	if len(o.Address) > 0 {
+		return o.Address
+	}
+
+	// Finally, use the target's FQDN.
+	if o.Target != nil {
+		return o.Target.Config().FQDN()
+	}
+
+	return ""
+}
+
 // Validator validates that the given responses are expected.
 type Validator interface {
 	// Validate performs the validation check for this Validator.

--- a/pkg/test/framework/components/echo/common/call.go
+++ b/pkg/test/framework/components/echo/common/call.go
@@ -240,9 +240,9 @@ func fillInCallOptions(opts *echo.CallOptions) error {
 		// Avoid mutating input, which can lead to concurrent writes
 		opts.Headers = opts.Headers.Clone()
 	}
-	if h := opts.Headers["Host"]; len(h) == 0 && opts.Target != nil {
-		// No host specified, use the hostname for the service.
-		opts.Headers["Host"] = []string{opts.Target.Config().HostHeader()}
+
+	if h := opts.GetHost(); len(h) > 0 {
+		opts.Headers["Host"] = []string{h}
 	}
 
 	if opts.Timeout <= 0 {

--- a/pkg/test/framework/components/istio/ingress.go
+++ b/pkg/test/framework/components/istio/ingress.go
@@ -233,8 +233,8 @@ func (c *ingressImpl) callEcho(options echo.CallOptions, retry bool, retryOption
 	if options.Headers == nil {
 		options.Headers = map[string][]string{}
 	}
-	if host := options.Headers["Host"]; len(host) == 0 {
-		options.Headers["Host"] = []string{options.Address}
+	if host := options.GetHost(); len(host) > 0 {
+		options.Headers["Host"] = []string{host}
 	}
 	if len(c.cluster.HTTPProxy()) > 0 {
 		options.HTTPProxy = c.cluster.HTTPProxy()

--- a/tests/integration/pilot/common/traffic.go
+++ b/tests/integration/pilot/common/traffic.go
@@ -61,8 +61,8 @@ type TrafficTestCase struct {
 	// setupOpts allows modifying options based on sources/destinations
 	setupOpts func(src echo.Caller, dest echo.Instances, opts *echo.CallOptions)
 	// validate is used to build validators dynamically when using RunForApps based on the active/src dest pair
-	validate     func(src echo.Caller, dst echo.Instances) echo.Validator
-	validateForN func(src echo.Caller, dst echo.Services) echo.Validator
+	validate     func(src echo.Caller, dst echo.Instances, opts *echo.CallOptions) echo.Validator
+	validateForN func(src echo.Caller, dst echo.Services, opts *echo.CallOptions) echo.Validator
 
 	// setting cases to skipped is better than not adding them - gives visibility to what needs to be fixed
 	skip bool
@@ -150,10 +150,10 @@ func (c TrafficTestCase) RunForApps(t framework.TestContext, apps echo.Instances
 				opts := options
 				opts.Target = dsts[0][0]
 				if c.validate != nil {
-					opts.Validator = c.validate(src, dsts[0])
+					opts.Validator = c.validate(src, dsts[0], &opts)
 				}
 				if c.validateForN != nil {
-					opts.Validator = c.validateForN(src, dsts)
+					opts.Validator = c.validateForN(src, dsts, &opts)
 				}
 				if opts.Count == 0 {
 					opts.Count = callsPerCluster * len(dsts) * len(dsts[0])


### PR DESCRIPTION
This was discovered as an issue while testing the Kubernetes Multi-Cluster Services (MCS) host (clusterset.local). When setting `Address`, it's expected that the host header would match by default.

**Please provide a description of this PR:**