### PR TITLE
proxyless grpc: test virtualservice timeout

### DIFF
--- a/pilot/pkg/networking/grpcgen/grpcecho_test.go
+++ b/pilot/pkg/networking/grpcgen/grpcecho_test.go
@@ -353,8 +353,8 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: echo-app
-  name: echo-app
+    app: echo-timeout
+  name: echo-timeout
   namespace: default
 spec:
   clusterIP: 1.2.3.4
@@ -372,15 +372,15 @@ metadata:
   name: echo-timeout
 spec:
   hosts:
-  - echo-app.default.svc.cluster.local
+  - echo-timeout.default.svc.cluster.local
   http:
   - route:
     - destination:
-        host: echo-app.default.svc.cluster.local
+        host: echo-timeout.default.svc.cluster.local
     timeout: 0.5s
 `,
 	}, echoCfg{version: "v1"})
-	c := tt.dialEcho("xds:///echo-app.default.svc.cluster.local:7070")
+	c := tt.dialEcho("xds:///echo-timeout.default.svc.cluster.local:7070")
 
 	st := time.Now()
 	_, err := c.ForwardEcho(context.Background(), &proto.ForwardEchoRequest{

--- a/pilot/pkg/networking/grpcgen/grpcecho_test.go
+++ b/pilot/pkg/networking/grpcgen/grpcecho_test.go
@@ -347,6 +347,7 @@ spec:
 }
 
 func TestTimeout(t *testing.T) {
+	t.Skip("likely to be flaky")
 	tt := newConfigGenTest(t, xds.FakeOptions{
 		KubernetesObjectString: `
 apiVersion: v1

--- a/pilot/pkg/networking/grpcgen/grpcecho_test.go
+++ b/pilot/pkg/networking/grpcgen/grpcecho_test.go
@@ -347,7 +347,7 @@ spec:
 }
 
 func TestTimeout(t *testing.T) {
-	t.Skip("likely to be flaky")
+	t.Skip("likely to be flaky: https://github.com/istio/istio/pull/35515#discussion_r724541855")
 	tt := newConfigGenTest(t, xds.FakeOptions{
 		KubernetesObjectString: `
 apiVersion: v1


### PR DESCRIPTION
adds a test for #35417 setting the correct field in xDS for timeouts 