### PR TITLE
Fix broken helloworld sample

### DIFF
--- a/samples/helloworld/helloworld.yaml
+++ b/samples/helloworld/helloworld.yaml
@@ -44,35 +44,6 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: helloworld-v3
-  labels:
-    app: helloworld
-    version: v3
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: helloworld
-      version: v3
-  template:
-    metadata:
-      labels:
-        app: helloworld
-        version: v3
-    spec:
-      containers:
-      - name: helloworld
-        image: docker.io/istio/examples-helloworld-v3
-        resources:
-          requests:
-            cpu: "100m"
-        imagePullPolicy: IfNotPresent #Always
-        ports:
-        - containerPort: 5000
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
   name: helloworld-v2
   labels:
     app: helloworld


### PR DESCRIPTION
**Please provide a description of this PR:**

`helloworld.yaml` has been changed to create a third (`v3`) helloworld deployment. This is wrong for 2 reasons:

1. The sample doc says that it creates only two versions (`v1` and `v2`).
1. It's using an image that doesn't exist at docker hub (`docker.io/istio/examples-helloworld-v3`) and therefore fails to run.

Maybe this was added for local testing and accidentally merged but if we want a third version, we'll need to change the documentation and probably best to create a different yaml file for deploying it.