### PR TITLE
eds: copy endpoint only when we are mutating it

### DIFF
--- a/pilot/pkg/xds/ep_filters.go
+++ b/pilot/pkg/xds/ep_filters.go
@@ -71,9 +71,11 @@ func (b *EndpointBuilder) EndpointsByNetworkFilter(endpoints []*LocLbEndpointsAn
 			// When multiplying, be careful to avoid overflow - clipping the
 			// result at the maximum value for uint32.
 			weight := b.scaleEndpointLBWeight(lbEp, scaleFactor)
-			lbEp := proto.Clone(lbEp).(*endpoint.LbEndpoint)
-			lbEp.LoadBalancingWeight = &wrappers.UInt32Value{
-				Value: weight,
+			if lbEp.GetLoadBalancingWeight().GetValue() != weight {
+				lbEp = proto.Clone(lbEp).(*endpoint.LbEndpoint)
+				lbEp.LoadBalancingWeight = &wrappers.UInt32Value{
+					Value: weight,
+				}
 			}
 
 			istioEndpoint := ep.istioEndpoints[i]


### PR DESCRIPTION
From my understand we do not later assume the EP is a clone and mutable (especially since this code path is optional, so the clone doesn't *always* happen), so this should be safe. If not, race test ought to catch it.

```
name                         old time/op        new time/op        delta
EndpointGeneration/1/100-6          987µs ± 3%         627µs ± 3%  -36.45%  (p=0.008 n=5+5)
EndpointGeneration/10/10-6          651µs ± 1%         322µs ± 2%  -50.57%  (p=0.008 n=5+5)
EndpointGeneration/100/10-6        5.99ms ± 2%        2.75ms ± 2%  -54.03%  (p=0.008 n=5+5)
EndpointGeneration/1000/1-6        5.83ms ± 3%        2.67ms ± 2%  -54.23%  (p=0.008 n=5+5)

name                         old kb/msg         new kb/msg         delta
EndpointGeneration/1/100-6           10.1 ± 0%          10.1 ± 0%     ~     (all equal)
EndpointGeneration/10/10-6           7.13 ± 0%          7.13 ± 0%     ~     (all equal)
EndpointGeneration/100/10-6          69.2 ± 0%          69.2 ± 0%     ~     (all equal)
EndpointGeneration/1000/1-6          69.6 ± 0%          69.6 ± 0%     ~     (all equal)

name                         old resources/msg  new resources/msg  delta
EndpointGeneration/1/100-6            100 ± 0%           100 ± 0%     ~     (all equal)
EndpointGeneration/10/10-6           10.0 ± 0%          10.0 ± 0%     ~     (all equal)
EndpointGeneration/100/10-6          10.0 ± 0%          10.0 ± 0%     ~     (all equal)
EndpointGeneration/1000/1-6          1.00 ± 0%          1.00 ± 0%     ~     (all equal)

name                         old alloc/op       new alloc/op       delta
EndpointGeneration/1/100-6          389kB ± 0%         243kB ± 0%  -37.46%  (p=0.008 n=5+5)
EndpointGeneration/10/10-6          252kB ± 0%         106kB ± 0%  -57.98%  (p=0.008 n=5+5)
EndpointGeneration/100/10-6        2.39MB ± 0%        0.92MB ± 0%  -61.34%  (p=0.008 n=5+5)
EndpointGeneration/1000/1-6        2.37MB ± 0%        0.91MB ± 0%  -61.66%  (p=0.016 n=5+4)

name                         old allocs/op      new allocs/op      delta
EndpointGeneration/1/100-6          7.41k ± 0%         5.01k ± 0%  -32.38%  (p=0.008 n=5+5)
EndpointGeneration/10/10-6          4.52k ± 0%         2.12k ± 0%  -53.13%  (p=0.008 n=5+5)
EndpointGeneration/100/10-6         40.8k ± 0%         16.8k ± 0%  -58.94%  (p=0.008 n=5+5)
EndpointGeneration/1000/1-6         40.2k ± 0%         16.2k ± 0%  -59.82%  (p=0.016 n=5+4)
```