### PR TITLE
Another attempt at fixing DOCKER_BUILD_VARIANTS

### DIFF
--- a/tools/istio-docker.mk
+++ b/tools/istio-docker.mk
@@ -308,19 +308,22 @@ docker.distroless: docker/Dockerfile.distroless
 define variant-tag
 $(if $(filter-out default,$(1)),-$(1),)
 endef
+define normalize-tag
+$(subst default,debug,$(1))
+endef
 
 # DOCKER_BUILD_VARIANTS ?=debug distroless
 # Base images have two different forms:
 # * "debug", suffixed as -debug. This is a ubuntu based image with a bunch of debug tools
 # * "distroless", suffixed as -distroless. This is distroless image - no shell. proxyv2 uses a custom one with iptables added
 # * "default", no suffix. This is currently "debug"
-DOCKER_BUILD_VARIANTS ?=
+DOCKER_BUILD_VARIANTS ?= default
 DOCKER_ALL_VARIANTS ?= debug distroless
 # If INCLUDE_UNTAGGED_DEFAULT is set, then building the "DEFAULT_DISTRIBUTION" variant will publish both <tag>-<variant> and <tag>
 # This can be done with DOCKER_BUILD_VARIANTS="default debug" as well, but at the expense of building twice vs building once and tagging twice
 INCLUDE_UNTAGGED_DEFAULT ?= false
 DEFAULT_DISTRIBUTION=debug
-DOCKER_RULE ?= $(foreach VARIANT,$(DOCKER_BUILD_VARIANTS), time (mkdir -p $(DOCKER_BUILD_TOP)/$@ && TARGET_ARCH=$(TARGET_ARCH) ./tools/docker-copy.sh $^ $(DOCKER_BUILD_TOP)/$@ && cd $(DOCKER_BUILD_TOP)/$@ $(BUILD_PRE) && docker build $(BUILD_ARGS) --build-arg BASE_DISTRIBUTION=$(VARIANT) -t $(HUB)/$(subst docker.,,$@):$(TAG)$(call variant-tag,$(VARIANT)) -f Dockerfile$(suffix $@) . ); )
+DOCKER_RULE ?= $(foreach VARIANT,$(DOCKER_BUILD_VARIANTS), time (mkdir -p $(DOCKER_BUILD_TOP)/$@ && TARGET_ARCH=$(TARGET_ARCH) ./tools/docker-copy.sh $^ $(DOCKER_BUILD_TOP)/$@ && cd $(DOCKER_BUILD_TOP)/$@ $(BUILD_PRE) && docker build $(BUILD_ARGS) --build-arg BASE_DISTRIBUTION=$(call normalize-tag,$(VARIANT)) -t $(HUB)/$(subst docker.,,$@):$(TAG)$(call variant-tag,$(VARIANT)) -f Dockerfile$(suffix $@) . ); )
 RENAME_TEMPLATE ?= mkdir -p $(DOCKER_BUILD_TOP)/$@ && cp $(ECHO_DOCKER)/$(VM_OS_DOCKERFILE_TEMPLATE) $(DOCKER_BUILD_TOP)/$@/Dockerfile$(suffix $@)
 
 # This target will package all docker images used in test and release, without re-building


### PR DESCRIPTION
Our goal is to have the ability to build a -debug suffix from ubuntu, a
"" suffix from ubuntu, and -distroless suffix from distroless.

This has caused quite a few issues. I think this is the right fix.

Previously, we loop over DOCKER_BUILD_VARIANTS which is empty, so we do
nothing. Now, we have `default` in the loop, then just do some
processing later to ensure that we correctly rewrite it to `debug` in
the dockerfiles, and `""` in the tag.

I have tested `docker`, `dockerx`, and the release-builder
At this point I am convinced we should rewrite this in golang, but that is for another day...