### PR TITLE
always generate grpc bootstrap

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -980,10 +980,10 @@ data:
           {{ if not (eq $container.Name "istio-proxy") }}
           - name: {{ $container.Name }}
             env:
-            - name: "GRPC_XDS_BOOTSTRAP"
-              value: "/var/lib/istio/data/grpc-bootstrap.json"
             - name: "GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT"
               value: "true"
+            - name: "GRPC_XDS_BOOTSTRAP"
+              value: "/etc/istio/proxy/grpc-bootstrap.json"
             volumeMounts:
             - mountPath: /var/lib/istio/data
               name: istio-data
@@ -1011,8 +1011,6 @@ data:
             - --log_as_json
           {{- end }}
             env:
-            - name: "GRPC_XDS_BOOTSTRAP"
-              value: "/var/lib/istio/data/grpc-bootstrap.json"
             - name: ISTIO_META_GENERATOR
               value: grpc
             - name: OUTPUT_CERTS

--- a/manifests/charts/istio-control/istio-discovery/files/grpc-agent.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/grpc-agent.yaml
@@ -14,10 +14,10 @@ spec:
   {{ if not (eq $container.Name "istio-proxy") }}
   - name: {{ $container.Name }}
     env:
-    - name: "GRPC_XDS_BOOTSTRAP"
-      value: "/var/lib/istio/data/grpc-bootstrap.json"
     - name: "GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT"
       value: "true"
+    - name: "GRPC_XDS_BOOTSTRAP"
+      value: "/etc/istio/proxy/grpc-bootstrap.json"
     volumeMounts:
     - mountPath: /var/lib/istio/data
       name: istio-data
@@ -45,8 +45,6 @@ spec:
     - --log_as_json
   {{- end }}
     env:
-    - name: "GRPC_XDS_BOOTSTRAP"
-      value: "/var/lib/istio/data/grpc-bootstrap.json"
     - name: ISTIO_META_GENERATOR
       value: grpc
     - name: OUTPUT_CERTS

--- a/pilot/cmd/pilot-agent/options/options.go
+++ b/pilot/cmd/pilot-agent/options/options.go
@@ -15,9 +15,11 @@
 package options
 
 import (
+	"path/filepath"
 	"time"
 
 	"istio.io/istio/pilot/cmd/pilot-agent/status"
+	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/jwt"
 	"istio.io/pkg/env"
 )
@@ -106,7 +108,7 @@ var (
 		"Envoy prometheus redirection port value").Get()
 
 	// Defined by https://github.com/grpc/proposal/blob/c5722a35e71f83f07535c6c7c890cf0c58ec90c0/A27-xds-global-load-balancing.md#xdsclient-and-bootstrap-file
-	grpcBootstrapEnv = env.RegisterStringVar("GRPC_XDS_BOOTSTRAP", "",
+	grpcBootstrapEnv = env.RegisterStringVar("GRPC_XDS_BOOTSTRAP", filepath.Join(constants.ConfigPathDir, "grpc-bootstrap.json"),
 		"Path where gRPC expects to read a bootstrap file. Agent will generate one if set.").Get()
 
 	disableEnvoyEnv = env.RegisterBoolVar("DISABLE_ENVOY", false,

--- a/pkg/kube/inject/testdata/inject/grpc-agent.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/grpc-agent.yaml.injected
@@ -26,10 +26,10 @@ spec:
     spec:
       containers:
       - env:
-        - name: GRPC_XDS_BOOTSTRAP
-          value: /var/lib/istio/data/grpc-bootstrap.json
         - name: GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT
           value: "true"
+        - name: GRPC_XDS_BOOTSTRAP
+          value: /etc/istio/proxy/grpc-bootstrap.json
         image: fake.docker.io/google-samples/traffic-go-gke:1.0
         name: traffic
         readinessProbe:
@@ -48,8 +48,6 @@ spec:
         - $(POD_NAMESPACE).svc.cluster.local
         - --log_output_level=default:info
         env:
-        - name: GRPC_XDS_BOOTSTRAP
-          value: /var/lib/istio/data/grpc-bootstrap.json
         - name: ISTIO_META_GENERATOR
           value: grpc
         - name: OUTPUT_CERTS


### PR DESCRIPTION
Agent will generate a file if this var is set.

By always generating it, users can use the default injection with Envoy, and set `GRPC_XDS_BOOTSTRAP` on their app container + use `traffic.sidecar.istio.io/<in|ex>clude<In|Out>boundPorts` to allow their gRPC app to use proxyless features while still capturing TCP/HTTP traffic. 