### PR TITLE
sds: make error message show the invalid references

### DIFF
--- a/pilot/pkg/xds/sds.go
+++ b/pilot/pkg/xds/sds.go
@@ -200,6 +200,7 @@ func filterAuthorizedResources(resources []SecretResource, proxy *model.Proxy, s
 	// Unverified cross namespace. Never allowed.
 	// Unverified same namespace. Allowed if authorized.
 	allowedResources := make([]SecretResource, 0, len(resources))
+	deniedResources := make([]string, 0)
 	for _, r := range resources {
 		sameNamespace := r.Namespace == proxy.VerifiedIdentity.Namespace
 		verified := proxy.MergedGateway != nil && proxy.MergedGateway.VerifiedCertificateReferences.Contains(r.ResourceName)
@@ -210,12 +211,16 @@ func filterAuthorizedResources(resources []SecretResource, proxy *model.Proxy, s
 			// as the proxy), or a ReferencePolicy allowing the reference.
 			if verified {
 				allowedResources = append(allowedResources, r)
+			} else {
+				deniedResources = append(deniedResources, r.Name)
 			}
 		case credentials.KubernetesSecretType:
 			// For Kubernetes, we require the secret to be in the same namespace as the proxy and for it to be
 			// authorized for access.
 			if sameNamespace && isAuthorized() {
 				allowedResources = append(allowedResources, r)
+			} else {
+				deniedResources = append(deniedResources, r.Name)
 			}
 		default:
 			// Should never happen
@@ -226,16 +231,30 @@ func filterAuthorizedResources(resources []SecretResource, proxy *model.Proxy, s
 
 	// If we filtered any out, report an error. We aggregate errors in one place here, rather than in the loop,
 	// to avoid excessive logs.
-	if len(allowedResources) != len(resources) {
+	if len(deniedResources) > 0 {
 		errMessage := authzError
 		if errMessage == nil {
 			errMessage = fmt.Errorf("cross namespace secret reference requires ReferencePolicy")
 		}
-		log.Warnf("proxy %v attempted to access %d unauthorized certificates: %v", proxy.ID, len(resources)-len(allowedResources), errMessage)
+		log.Warnf("proxy %v attempted to access unauthorized certificates %v: %v", proxy.ID, atMostNJoin(deniedResources, 3), errMessage)
 		pilotSDSCertificateErrors.Increment()
 	}
 
 	return allowedResources
+}
+
+func atMostNJoin(data []string, limit int) string {
+	if limit == 0 || limit == 1 {
+		// Assume limit >1, but make sure we dpn't crash if someone does pass those
+		return strings.Join(data, ", ")
+	}
+	if len(data) == 0 {
+		return ""
+	}
+	if len(data) < limit {
+		return strings.Join(data, ", ")
+	}
+	return strings.Join(data[:limit-1], ", ") + fmt.Sprintf(", and %d others", len(data)-limit+1)
 }
 
 func toEnvoyCaSecret(name string, cert []byte) *discovery.Resource {

--- a/pilot/pkg/xds/sds_test.go
+++ b/pilot/pkg/xds/sds_test.go
@@ -16,6 +16,8 @@ package xds
 
 import (
 	"errors"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -326,5 +328,46 @@ func TestCaching(t *testing.T) {
 	raw = xdstest.ExtractTLSSecrets(t, model.ResourcesToAny(secrets))
 	if len(raw) != 0 {
 		t.Fatalf("failed to get expected secrets for unauthorized proxy: %v", raw)
+	}
+}
+
+func TestAtMostNJoin(t *testing.T) {
+	tests := []struct {
+		data  []string
+		limit int
+		want  string
+	}{
+		{
+			[]string{"a", "b", "c"},
+			2,
+			"a, and 2 others",
+		},
+		{
+			[]string{"a", "b", "c"},
+			4,
+			"a, b, c",
+		},
+		{
+			[]string{"a", "b", "c"},
+			1,
+			"a, b, c",
+		},
+		{
+			[]string{"a", "b", "c"},
+			0,
+			"a, b, c",
+		},
+		{
+			[]string{},
+			3,
+			"",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%s-%d", strings.Join(tt.data, "-"), tt.limit), func(t *testing.T) {
+			if got := atMostNJoin(tt.data, tt.limit); got != tt.want {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Right now we just get a number, which is hard to debug. It is more
useful to list the resource names we missed. This is limitted to
avoid massive logs

**Please provide a description of this PR:**