### PR TITLE
Fix SSA for gateway template on old k8s

### DIFF
--- a/pilot/pkg/config/kube/gateway/templates/service.yaml
+++ b/pilot/pkg/config/kube/gateway/templates/service.yaml
@@ -19,6 +19,7 @@ spec:
   {{- range $key, $val := .Ports }}
   - name: {{ $val.Name }}
     port: {{ $val.Port }}
+    protocol: TCP
   {{- end }}
   selector:
     istio.io/gateway-name: {{.Name}}


### PR DESCRIPTION
In older versions, protocol is a required field for SSA. its always TCP,
so just hard code it.

**Please provide a description of this PR:**