### PR TITLE
Skip failing istiodremote tests (for now)

### DIFF
--- a/tests/integration/security/chiron/main_test.go
+++ b/tests/integration/security/chiron/main_test.go
@@ -35,6 +35,7 @@ func TestMain(m *testing.M) {
 		Label(label.CustomSetup).
 		// https://github.com/istio/istio/issues/22161. 1.22 drops support for legacy-unknown signer
 		RequireMaxVersion(21).
+		RequireLocalControlPlane().
 		Setup(istio.Setup(&inst, setupConfig)).
 		Run()
 }

--- a/tests/integration/security/external_ca/main_test.go
+++ b/tests/integration/security/external_ca/main_test.go
@@ -80,6 +80,7 @@ func TestMain(m *testing.M) {
 		Label(label.CustomSetup).
 		RequireMinVersion(19).
 		RequireSingleCluster().
+		RequireLocalControlPlane().
 		Setup(istio.Setup(&inst, setupConfig)).
 		Setup(func(ctx resource.Context) error {
 			return SetupApps(ctx, apps)

--- a/tests/integration/security/file_mounted_certs/main_test.go
+++ b/tests/integration/security/file_mounted_certs/main_test.go
@@ -59,6 +59,7 @@ func TestMain(m *testing.M) {
 		NewSuite(m).
 		Label(label.CustomSetup).
 		RequireSingleCluster().
+		RequireLocalControlPlane().
 		Label("CustomSetup").
 		Setup(istio.Setup(&inst, setupConfig, CreateCustomIstiodSecret)).
 		Run()

--- a/tests/integration/security/filebased_tls_origination/main_test.go
+++ b/tests/integration/security/filebased_tls_origination/main_test.go
@@ -34,6 +34,7 @@ func TestMain(m *testing.M) {
 		NewSuite(m).
 		Label(label.CustomSetup).
 		Label("CustomSetup").
+		RequireLocalControlPlane().
 		Setup(istio.Setup(&inst, setupConfig, cert.CreateCustomEgressSecret)).
 		Run()
 }

--- a/tests/integration/security/mtlsk8sca/main_test.go
+++ b/tests/integration/security/mtlsk8sca/main_test.go
@@ -36,6 +36,7 @@ func TestMain(m *testing.M) {
 	framework.
 		NewSuite(m).
 		RequireSingleCluster().
+		RequireLocalControlPlane().
 		Label(label.CustomSetup).
 		// https://github.com/istio/istio/issues/22161. 1.22 drops support for legacy-unknown signer
 		RequireMaxVersion(21).

--- a/tests/integration/security/sds_ingress/quic/ingress_test.go
+++ b/tests/integration/security/sds_ingress/quic/ingress_test.go
@@ -37,6 +37,7 @@ func TestMain(m *testing.M) {
 		NewSuite(m).
 		// Need support for MixedProtocolLBService
 		RequireMinVersion(20).
+		RequireLocalControlPlane().
 		Setup(istio.Setup(&inst, func(_ resource.Context, cfg *istio.Config) {
 			cfg.PrimaryClusterIOPFile = istio.IntegrationTestDefaultsIOPWithQUIC
 		})).

--- a/tests/integration/security/sds_ingress_k8sca/main_test.go
+++ b/tests/integration/security/sds_ingress_k8sca/main_test.go
@@ -37,6 +37,7 @@ func TestMain(m *testing.M) {
 	framework.
 		NewSuite(m).
 		RequireSingleCluster().
+		RequireLocalControlPlane().
 		// https://github.com/istio/istio/issues/22161. 1.22 drops support for legacy-unknown signer
 		RequireMaxVersion(21).
 		Setup(istio.Setup(&inst, setupConfig)).


### PR DESCRIPTION
**Please provide a description of this PR:**

Skipping security tests that don't currently work in the istiodremote configuration. We will investigate the failures and re-enable, in followup PRs, any test(s) that we decide makes sense to fix and run with external istiod.