### PR TITLE
Fix and Improve the building of Helloworld Sample

### DIFF
--- a/samples/helloworld/src/Dockerfile
+++ b/samples/helloworld/src/Dockerfile
@@ -12,7 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-FROM python:2-onbuild
+FROM python:3.4-onbuild
 
 WORKDIR /opt/microservices
 COPY app.py /opt/microservices/

--- a/samples/helloworld/src/build_service.sh
+++ b/samples/helloworld/src/build_service.sh
@@ -20,3 +20,4 @@ SCRIPTDIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 docker build -t istio/examples-helloworld-v1 --build-arg service_version=v1 "${SCRIPTDIR}"
 docker build -t istio/examples-helloworld-v2 --build-arg service_version=v2 "${SCRIPTDIR}"
+docker build -t istio/examples-helloworld-v3 --build-arg service_version=v3 "${SCRIPTDIR}"


### PR DESCRIPTION
Now the Dockerfile of Helloworld uses a wrong base image of
Python, it would lead to an error:

    SyntaxError: invalid syntax
    Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-install-9z5clz/flask-json/
    You are using pip version 10.0.1, however version 20.3.4 is available.
    You should consider upgrading via the 'pip install --upgrade pip' command.

So we upgrade the base Python image to 3.4-onbuild which is also mulit-arch supported.

And we add a helloworld-v3 build to the description of helloworld.yaml in the build_service.sh script.

Signed-off-by: trevor.tao <trevor.tao@arm.com>

**Please provide a description of this PR:**