### PR TITLE
Print pilot-discovery's version on startup

### DIFF
--- a/pilot/cmd/pilot-discovery/app/cmd.go
+++ b/pilot/cmd/pilot-discovery/app/cmd.go
@@ -83,6 +83,7 @@ func newDiscoveryCommand() *cobra.Command {
 			return nil
 		},
 		RunE: func(c *cobra.Command, args []string) error {
+			log.Info(version.Info.LongForm())
 			cmd.PrintFlags(c.Flags())
 
 			// Create the stop channel for all of the servers.


### PR DESCRIPTION
**Please provide a description of this PR:**
Pilot-discovery didn't print the version on startup, which makes inspecting logs in support cases harder.