### PR TITLE
replace deprecated package io/ioutil with packages io and os

### DIFF
--- a/istioctl/pkg/tag/generate.go
+++ b/istioctl/pkg/tag/generate.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	admit_v1 "k8s.io/api/admissionregistration/v1"
@@ -316,7 +316,7 @@ func applyYAML(client kube.ExtendedClient, yamlContent, ns string) error {
 
 // writeToTempFile taken from remote_secret.go
 func writeToTempFile(content string) (string, error) {
-	outFile, err := ioutil.TempFile("", "revision-tag-manifest-*")
+	outFile, err := os.CreateTemp("", "revision-tag-manifest-*")
 	if err != nil {
 		return "", fmt.Errorf("failed creating temp file for manifest: %w", err)
 	}

--- a/pilot/cmd/pilot-agent/options/security_test.go
+++ b/pilot/cmd/pilot-agent/options/security_test.go
@@ -15,13 +15,12 @@
 package options
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 )
 
 func TestCheckGkeWorkloadCertificate(t *testing.T) {
-	cert, err := ioutil.TempFile("", "existing-cert-file")
+	cert, err := os.CreateTemp("", "existing-cert-file")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/test/csrctrl/signer/ca_provider.go
+++ b/pkg/test/csrctrl/signer/ca_provider.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"crypto"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"sync/atomic"
 	"time"
@@ -75,7 +74,7 @@ type caProvider struct {
 
 // currentCertContent retrieve current certificate content from cert file
 func (p *caProvider) currentCertContent() ([]byte, error) {
-	certBytes, err := ioutil.ReadFile(p.caIntermediate.CertFile)
+	certBytes, err := os.ReadFile(p.caIntermediate.CertFile)
 	if err != nil {
 		return []byte(""), fmt.Errorf("error reading CA from cert file %s: %v", p.caLoader.CertFile, err)
 	}
@@ -84,7 +83,7 @@ func (p *caProvider) currentCertContent() ([]byte, error) {
 
 // currentKeyContent retrieve current private key content from key file
 func (p *caProvider) currentKeyContent() ([]byte, error) {
-	keyBytes, err := ioutil.ReadFile(p.caIntermediate.KeyFile)
+	keyBytes, err := os.ReadFile(p.caIntermediate.KeyFile)
 	if err != nil {
 		return []byte(""), fmt.Errorf("error reading private key from key file %s: %v", p.caLoader.KeyFile, err)
 	}

--- a/pkg/test/util/file/file.go
+++ b/pkg/test/util/file/file.go
@@ -19,7 +19,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -98,7 +97,7 @@ func ReadTarFile(filePath string) (string, error) {
 		if hdr.Name != strings.TrimSuffix(filepath.Base(filePath), filepath.Ext(filePath)) {
 			continue
 		}
-		contents, err := ioutil.ReadAll(tr)
+		contents, err := io.ReadAll(tr)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/wasm/imagefetcher_test.go
+++ b/pkg/wasm/imagefetcher_test.go
@@ -22,7 +22,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http/httptest"
 	"net/url"
 	"strings"
@@ -460,7 +459,7 @@ type mockLayer struct {
 
 func (r *mockLayer) DiffID() (v1.Hash, error) { return v1.Hash{}, nil }
 func (r *mockLayer) Uncompressed() (io.ReadCloser, error) {
-	return ioutil.NopCloser(bytes.NewBuffer(r.raw)), nil
+	return io.NopCloser(bytes.NewBuffer(r.raw)), nil
 }
 func (r *mockLayer) MediaType() (types.MediaType, error) { return r.mediaType, nil }
 

--- a/tests/fuzz/misc_fuzzers.go
+++ b/tests/fuzz/misc_fuzzers.go
@@ -22,7 +22,6 @@
 package fuzz
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -191,7 +190,7 @@ func FuzzYAMLManifestPatch(data []byte) int {
 func FuzzGalleyMeshFs(data []byte) int {
 	f := fuzz.NewConsumer(data)
 
-	p, err := ioutil.TempDir("/tmp", "fuzz-data-")
+	p, err := os.MkdirTemp("/tmp", "fuzz-data-")
 	if err != nil {
 		return 0
 	}


### PR DESCRIPTION
**Please provide a description of this PR:**
package `io/ioutil` is deprecated in Go1.16, and according to the official doc(https://golang.org/doc/go1.16#ioutil), we could use definitions in `io` and `os`.
So replace all codes using `io/ioutil` with package `os` and `io`


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
