### PR TITLE
Remove the restriction from helm not supporting k8s 1.22 in integrati…

### DIFF
--- a/tests/integration/helm/upgrade/main_test.go
+++ b/tests/integration/helm/upgrade/main_test.go
@@ -26,8 +26,6 @@ import (
 func TestMain(m *testing.M) {
 	framework.
 		NewSuite(m).
-		// Kubernetes 1.22 drops support for a number of legacy resources, so we cannot install the old versions
-		RequireMaxVersion(21).
 		RequireSingleCluster().
 		Run()
 }


### PR DESCRIPTION
…on tests

**Please provide a description of this PR:**

Helm integration tests should be able to run on K8s 1.22+.