### PR TITLE
tf: go back to cleaning up prometheus

### DIFF
--- a/pkg/test/framework/components/prometheus/kube.go
+++ b/pkg/test/framework/components/prometheus/kube.go
@@ -78,7 +78,7 @@ func installPrometheus(ctx resource.Context, ns string) error {
 	if err != nil {
 		return err
 	}
-	return ctx.Config().ApplyYAMLNoCleanup(ns, yaml)
+	return ctx.Config().ApplyYAML(ns, yaml)
 }
 
 func newKube(ctx resource.Context, cfgIn Config) (Instance, error) {


### PR DESCRIPTION
I suspect this is why the tests fail in postsubmit now. TBH I have no
idea why not cleaning up promethues would break only 1.20 and older.

Reverts
https://github.com/istio/istio/commit/0f92d7f2048ce09954becb897cd849d6c196e147#diff-dddd25d4fe9a446fe0304739799d4743661eba600515e764aee1eab4b87e5bfeL81
from last week
