### PR TITLE
fix: don't remove finalizer of IstioOperator when action is still required

### DIFF
--- a/operator/pkg/controller/istiocontrolplane/istiocontrolplane_controller.go
+++ b/operator/pkg/controller/istiocontrolplane/istiocontrolplane_controller.go
@@ -252,6 +252,10 @@ func (r *ReconcileIstioOperator) Reconcile(_ context.Context, request reconcile.
 		if err := reconciler.Delete(); err != nil {
 			return reconcile.Result{}, err
 		}
+		//return if action is still required before removing the finalizer
+		if iop.Status.Status == v1alpha1.InstallStatus_ACTION_REQUIRED {
+			return reconcile.Result{}, nil
+		}
 		finalizers.Delete(finalizer)
 		iop.SetFinalizers(finalizers.List())
 		finalizerError := r.client.Update(context.TODO(), iop)


### PR DESCRIPTION
**Please provide a description of this PR:**

This issue helps resolve #35016 when deleting the IstioOperator ingress/egress components are not cleaned up. This seems to be an issue when the helm reconciler sets a status of `InstallStatus_ACTION_REQUIRED`. The code currently does not seem to check that [here](https://github.com/istio/istio/blob/master/operator/pkg/controller/istiocontrolplane/istiocontrolplane_controller.go#L255) and instead removes the finalizer immediately not giving the user the chance to understand why the components weren't removed.