### PR TITLE
simplify yaml package: replace github.com/ghodss/yaml with sigs.k8s.io/yaml

### DIFF
--- a/galley/pkg/config/analysis/msg/generate.main.go
+++ b/galley/pkg/config/analysis/msg/generate.main.go
@@ -24,7 +24,7 @@ import (
 	"regexp"
 	"text/template"
 
-	"github.com/ghodss/yaml"
+	"sigs.k8s.io/yaml"
 )
 
 const (

--- a/galley/pkg/config/mesh/fs.go
+++ b/galley/pkg/config/mesh/fs.go
@@ -18,9 +18,9 @@ import (
 	"os"
 	"sync"
 
-	"github.com/ghodss/yaml"
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/gogo/protobuf/proto"
+	"sigs.k8s.io/yaml"
 
 	"istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/galley/pkg/config/scope"

--- a/galley/pkg/config/util/pb/proto.go
+++ b/galley/pkg/config/util/pb/proto.go
@@ -17,10 +17,10 @@ package pb
 import (
 	"strings"
 
-	"github.com/ghodss/yaml"
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/gogo/protobuf/proto"
 	yaml2 "gopkg.in/yaml.v2"
+	"sigs.k8s.io/yaml"
 )
 
 // UnmarshalData data into the proto.

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,6 @@ require (
 	github.com/fatih/color v1.13.0
 	github.com/florianl/go-nflog/v2 v2.0.1
 	github.com/fsnotify/fsnotify v1.5.1
-	github.com/ghodss/yaml v1.0.0
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/protobuf v1.5.2
 	github.com/google/go-cmp v0.5.6

--- a/istioctl/cmd/add-to-mesh.go
+++ b/istioctl/cmd/add-to-mesh.go
@@ -22,7 +22,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/ghodss/yaml"
 	"github.com/hashicorp/go-multierror"
 	"github.com/spf13/cobra"
 	appsv1 "k8s.io/api/apps/v1"
@@ -33,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/yaml"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/api/networking/v1alpha3"

--- a/istioctl/cmd/kubeinject.go
+++ b/istioctl/cmd/kubeinject.go
@@ -29,7 +29,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ghodss/yaml"
 	"github.com/hashicorp/go-multierror"
 	"github.com/spf13/cobra"
 	admission "k8s.io/api/admission/v1"
@@ -43,6 +42,7 @@ import (
 	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/kubectl/pkg/polymorphichelpers"
 	"k8s.io/kubectl/pkg/util/podutils"
+	"sigs.k8s.io/yaml"
 
 	"istio.io/api/label"
 	meshconfig "istio.io/api/mesh/v1alpha1"

--- a/istioctl/cmd/kubeuninject.go
+++ b/istioctl/cmd/kubeuninject.go
@@ -25,7 +25,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/ghodss/yaml"
 	"github.com/hashicorp/go-multierror"
 	"github.com/spf13/cobra"
 	batch "k8s.io/api/batch/v1"
@@ -33,6 +32,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	yamlDecoder "k8s.io/apimachinery/pkg/util/yaml"
+	"sigs.k8s.io/yaml"
 
 	istioStatus "istio.io/istio/pilot/cmd/pilot-agent/status"
 	"istio.io/istio/pkg/kube/inject"

--- a/istioctl/cmd/proxyconfig.go
+++ b/istioctl/cmd/proxyconfig.go
@@ -23,8 +23,8 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/ghodss/yaml"
 	"github.com/spf13/cobra"
+	"sigs.k8s.io/yaml"
 
 	"istio.io/istio/istioctl/pkg/util/handlers"
 	"istio.io/istio/istioctl/pkg/writer/envoy/clusters"

--- a/istioctl/cmd/workload.go
+++ b/istioctl/cmd/workload.go
@@ -26,11 +26,11 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/ghodss/yaml"
 	"github.com/spf13/cobra"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/yaml"
 
 	"istio.io/api/annotation"
 	"istio.io/api/label"

--- a/istioctl/pkg/util/formatting/formatter.go
+++ b/istioctl/pkg/util/formatting/formatter.go
@@ -21,8 +21,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/ghodss/yaml"
 	"github.com/mattn/go-isatty"
+	"sigs.k8s.io/yaml"
 
 	"istio.io/istio/galley/pkg/config/analysis/diag"
 	"istio.io/pkg/env"

--- a/istioctl/pkg/validate/validate_test.go
+++ b/istioctl/pkg/validate/validate_test.go
@@ -23,9 +23,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ghodss/yaml"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/yaml"
 )
 
 const (

--- a/istioctl/pkg/verifier/verifier.go
+++ b/istioctl/pkg/verifier/verifier.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 
 	"github.com/fatih/color"
-	"github.com/ghodss/yaml"
 	admit_v1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	v1batch "k8s.io/api/batch/v1"
@@ -32,6 +31,7 @@ import (
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/yaml"
 
 	"istio.io/api/label"
 	"istio.io/istio/istioctl/pkg/clioptions"

--- a/operator/cmd/mesh/profile-dump.go
+++ b/operator/cmd/mesh/profile-dump.go
@@ -20,8 +20,8 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/ghodss/yaml"
 	"github.com/spf13/cobra"
+	"sigs.k8s.io/yaml"
 
 	"istio.io/istio/operator/pkg/manifest"
 	"istio.io/istio/operator/pkg/tpath"

--- a/operator/pkg/component/component.go
+++ b/operator/pkg/component/component.go
@@ -22,7 +22,7 @@ package component
 import (
 	"fmt"
 
-	"github.com/ghodss/yaml"
+	"sigs.k8s.io/yaml"
 
 	"istio.io/api/operator/v1alpha1"
 	"istio.io/istio/operator/pkg/helm"

--- a/operator/pkg/manifest/shared.go
+++ b/operator/pkg/manifest/shared.go
@@ -21,9 +21,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/ghodss/yaml"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"sigs.k8s.io/yaml"
 
 	"istio.io/api/operator/v1alpha1"
 	"istio.io/istio/istioctl/pkg/install/k8sversion"

--- a/operator/pkg/name/name_test.go
+++ b/operator/pkg/name/name_test.go
@@ -18,7 +18,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/ghodss/yaml"
+	"sigs.k8s.io/yaml"
 
 	"istio.io/istio/operator/pkg/tpath"
 	"istio.io/istio/operator/pkg/util"

--- a/operator/pkg/object/objects.go
+++ b/operator/pkg/object/objects.go
@@ -25,11 +25,11 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/ghodss/yaml"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
+	"sigs.k8s.io/yaml"
 
 	"istio.io/istio/operator/pkg/apis/istio/v1alpha1"
 	"istio.io/istio/operator/pkg/helm"

--- a/operator/pkg/tpath/struct_test.go
+++ b/operator/pkg/tpath/struct_test.go
@@ -17,7 +17,7 @@ package tpath
 import (
 	"testing"
 
-	"github.com/ghodss/yaml"
+	"sigs.k8s.io/yaml"
 
 	"istio.io/istio/operator/pkg/util"
 )

--- a/operator/pkg/tpath/tree.go
+++ b/operator/pkg/tpath/tree.go
@@ -30,9 +30,9 @@ import (
 	"strconv"
 	"strings"
 
-	yaml2 "github.com/ghodss/yaml"
 	"github.com/kylelemons/godebug/pretty"
 	"gopkg.in/yaml.v2"
+	yaml2 "sigs.k8s.io/yaml"
 
 	"istio.io/istio/operator/pkg/util"
 	"istio.io/pkg/log"

--- a/operator/pkg/tpath/tree_test.go
+++ b/operator/pkg/tpath/tree_test.go
@@ -17,7 +17,7 @@ package tpath
 import (
 	"testing"
 
-	"github.com/ghodss/yaml"
+	"sigs.k8s.io/yaml"
 
 	"istio.io/istio/operator/pkg/util"
 )

--- a/operator/pkg/tpath/util.go
+++ b/operator/pkg/tpath/util.go
@@ -19,8 +19,8 @@ util.go contains utility function for dealing with trees.
 package tpath
 
 import (
-	yaml2 "github.com/ghodss/yaml"
 	"gopkg.in/yaml.v2"
+	yaml2 "sigs.k8s.io/yaml"
 
 	"istio.io/istio/operator/pkg/util"
 )

--- a/operator/pkg/tpath/util_test.go
+++ b/operator/pkg/tpath/util_test.go
@@ -74,7 +74,7 @@ func TestGetConfigSubtree(t *testing.T) {
 			desc:     "empty",
 			manifest: ``,
 			path:     ``,
-			expect: `null
+			expect: `{}
 `,
 			err: false,
 		},

--- a/operator/pkg/translate/translate.go
+++ b/operator/pkg/translate/translate.go
@@ -22,12 +22,12 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/ghodss/yaml"
 	"github.com/gogo/protobuf/proto"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/yaml"
 
 	"istio.io/api/operator/v1alpha1"
 	iopv1alpha1 "istio.io/istio/operator/pkg/apis/istio/v1alpha1"

--- a/operator/pkg/translate/translate_value.go
+++ b/operator/pkg/translate/translate_value.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/ghodss/yaml"
+	"sigs.k8s.io/yaml"
 
 	"istio.io/api/operator/v1alpha1"
 	"istio.io/istio/operator/pkg/metrics"

--- a/operator/pkg/translate/translate_value_test.go
+++ b/operator/pkg/translate/translate_value_test.go
@@ -17,9 +17,9 @@ package translate
 import (
 	"testing"
 
-	"github.com/ghodss/yaml"
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/kr/pretty"
+	"sigs.k8s.io/yaml"
 
 	"istio.io/istio/operator/pkg/apis/istio/v1alpha1"
 	"istio.io/istio/operator/pkg/util"

--- a/operator/pkg/util/merge_iop.go
+++ b/operator/pkg/util/merge_iop.go
@@ -18,10 +18,10 @@ import (
 	"fmt"
 	"strings"
 
-	yaml2 "github.com/ghodss/yaml"
 	protobuf "github.com/gogo/protobuf/types"
 	v11 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
+	yaml2 "sigs.k8s.io/yaml"
 
 	v1alpha13 "istio.io/api/mesh/v1alpha1"
 	"istio.io/api/networking/v1alpha3"

--- a/operator/pkg/util/merge_iop_test.go
+++ b/operator/pkg/util/merge_iop_test.go
@@ -19,7 +19,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/ghodss/yaml"
+	"sigs.k8s.io/yaml"
 
 	v1alpha12 "istio.io/api/operator/v1alpha1"
 	"istio.io/istio/operator/pkg/apis/istio/v1alpha1"

--- a/operator/pkg/util/yaml.go
+++ b/operator/pkg/util/yaml.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 
 	jsonpatch "github.com/evanphx/json-patch/v5"
-	yaml2 "github.com/ghodss/yaml"
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/gogo/protobuf/proto"
 	"github.com/kylelemons/godebug/diff"
@@ -29,7 +28,7 @@ import (
 
 // ToYAML returns a YAML string representation of val, or the error string if an error occurs.
 func ToYAML(val interface{}) string {
-	y, err := yaml2.Marshal(val)
+	y, err := yaml.Marshal(val)
 	if err != nil {
 		return err.Error()
 	}
@@ -119,11 +118,11 @@ func OverlayYAML(base, overlay string) (string, error) {
 	if strings.TrimSpace(overlay) == "" {
 		return base, nil
 	}
-	bj, err := yaml2.YAMLToJSON([]byte(base))
+	bj, err := yaml.YAMLToJSON([]byte(base))
 	if err != nil {
 		return "", fmt.Errorf("yamlToJSON error in base: %s\n%s", err, bj)
 	}
-	oj, err := yaml2.YAMLToJSON([]byte(overlay))
+	oj, err := yaml.YAMLToJSON([]byte(overlay))
 	if err != nil {
 		return "", fmt.Errorf("yamlToJSON error in overlay: %s\n%s", err, oj)
 	}
@@ -138,7 +137,7 @@ func OverlayYAML(base, overlay string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("json merge error (%s) for base object: \n%s\n override object: \n%s", err, bj, oj)
 	}
-	my, err := yaml2.JSONToYAML(merged)
+	my, err := yaml.JSONToYAML(merged)
 	if err != nil {
 		return "", fmt.Errorf("jsonToYAML error (%s) for merged object: \n%s", err, merged)
 	}

--- a/operator/pkg/validate/common.go
+++ b/operator/pkg/validate/common.go
@@ -22,9 +22,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/ghodss/yaml"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/yaml"
 
 	"istio.io/istio/operator/pkg/apis/istio/v1alpha1"
 	"istio.io/istio/operator/pkg/util"

--- a/operator/pkg/validate/validate.go
+++ b/operator/pkg/validate/validate.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/ghodss/yaml"
+	"sigs.k8s.io/yaml"
 
 	"istio.io/api/operator/v1alpha1"
 	operator_v1alpha1 "istio.io/istio/operator/pkg/apis/istio/v1alpha1"

--- a/operator/pkg/validate/validate_values.go
+++ b/operator/pkg/validate/validate_values.go
@@ -15,7 +15,7 @@
 package validate
 
 import (
-	"github.com/ghodss/yaml"
+	"sigs.k8s.io/yaml"
 
 	"istio.io/istio/operator/pkg/apis/istio/v1alpha1"
 	"istio.io/istio/operator/pkg/util"

--- a/operator/pkg/validate/validate_values_test.go
+++ b/operator/pkg/validate/validate_values_test.go
@@ -20,7 +20,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/ghodss/yaml"
+	"sigs.k8s.io/yaml"
 
 	"istio.io/istio/operator/pkg/helm"
 	"istio.io/istio/operator/pkg/object"

--- a/pilot/pkg/config/kube/gateway/conversion_test.go
+++ b/pilot/pkg/config/kube/gateway/conversion_test.go
@@ -22,11 +22,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ghodss/yaml"
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8s "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	"sigs.k8s.io/yaml"
 
 	"istio.io/istio/pilot/pkg/config/kube/crd"
 	"istio.io/istio/pilot/pkg/model"

--- a/pilot/pkg/config/kube/ingress/conversion_test.go
+++ b/pilot/pkg/config/kube/ingress/conversion_test.go
@@ -23,7 +23,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ghodss/yaml"
 	"github.com/google/go-cmp/cmp"
 	coreV1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
@@ -35,6 +34,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	listerv1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
+	"sigs.k8s.io/yaml"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"

--- a/pilot/pkg/config/kube/ingressv1/conversion_test.go
+++ b/pilot/pkg/config/kube/ingressv1/conversion_test.go
@@ -23,7 +23,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ghodss/yaml"
 	"github.com/google/go-cmp/cmp"
 	coreV1 "k8s.io/api/core/v1"
 	knetworking "k8s.io/api/networking/v1"
@@ -35,6 +34,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	listerv1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
+	"sigs.k8s.io/yaml"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"

--- a/pkg/bootstrap/instance_test.go
+++ b/pkg/bootstrap/instance_test.go
@@ -32,10 +32,10 @@ import (
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	trace "github.com/envoyproxy/go-control-plane/envoy/config/trace/v3"
 	matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
-	"github.com/ghodss/yaml"
 	"github.com/gogo/protobuf/proto"
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/protobuf/testing/protocmp"
+	"sigs.k8s.io/yaml"
 
 	"istio.io/api/annotation"
 	meshconfig "istio.io/api/mesh/v1alpha1"

--- a/pkg/config/mesh/mesh.go
+++ b/pkg/config/mesh/mesh.go
@@ -20,10 +20,10 @@ import (
 	"os"
 	"time"
 
-	"github.com/ghodss/yaml"
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/types"
 	"github.com/hashicorp/go-multierror"
+	"sigs.k8s.io/yaml"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/api/networking/v1alpha3"

--- a/pkg/config/model.go
+++ b/pkg/config/model.go
@@ -21,7 +21,6 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/ghodss/yaml"
 	gogojsonpb "github.com/gogo/protobuf/jsonpb"
 	gogoproto "github.com/gogo/protobuf/proto"
 	gogotypes "github.com/gogo/protobuf/types"
@@ -31,6 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	kubetypes "k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/yaml"
 
 	"istio.io/istio/pkg/util/gogoprotomarshal"
 	"istio.io/istio/pkg/util/protomarshal"

--- a/pkg/config/schema/ast/ast.go
+++ b/pkg/config/schema/ast/ast.go
@@ -18,7 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/ghodss/yaml"
+	"sigs.k8s.io/yaml"
 
 	"istio.io/istio/pkg/config/validation"
 	"istio.io/istio/pkg/util/strcase"

--- a/pkg/envoy/options.go
+++ b/pkg/envoy/options.go
@@ -25,8 +25,8 @@ import (
 	"time"
 
 	envoyBootstrap "github.com/envoyproxy/go-control-plane/envoy/config/bootstrap/v3"
-	"github.com/ghodss/yaml"
 	"github.com/hashicorp/go-multierror"
+	"sigs.k8s.io/yaml"
 
 	"istio.io/pkg/log"
 )

--- a/pkg/kube/inject/inject.go
+++ b/pkg/kube/inject/inject.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/Masterminds/sprig/v3"
 	jsonpatch "github.com/evanphx/json-patch/v5"
-	"github.com/ghodss/yaml"
 	"github.com/hashicorp/go-multierror"
 	appsv1 "k8s.io/api/apps/v1"
 	batch "k8s.io/api/batch/v1"
@@ -40,6 +39,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	yamlDecoder "k8s.io/apimachinery/pkg/util/yaml"
+	"sigs.k8s.io/yaml"
 
 	"istio.io/api/annotation"
 	"istio.io/api/label"

--- a/pkg/kube/inject/template.go
+++ b/pkg/kube/inject/template.go
@@ -24,12 +24,12 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/ghodss/yaml"
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/types"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pkg/config/mesh"

--- a/pkg/kube/inject/webhook_test.go
+++ b/pkg/kube/inject/webhook_test.go
@@ -28,7 +28,6 @@ import (
 	"testing"
 
 	jsonpatch "github.com/evanphx/json-patch/v5"
-	"github.com/ghodss/yaml"
 	"github.com/gogo/protobuf/types"
 	openshiftv1 "github.com/openshift/api/apps/v1"
 	"k8s.io/api/admission/v1beta1"
@@ -40,6 +39,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
+	"sigs.k8s.io/yaml"
 
 	"istio.io/api/annotation"
 	meshconfig "istio.io/api/mesh/v1alpha1"

--- a/pkg/test/framework/features/features.go
+++ b/pkg/test/framework/features/features.go
@@ -19,7 +19,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/ghodss/yaml"
+	"sigs.k8s.io/yaml"
 
 	"istio.io/istio/pkg/test/env"
 	"istio.io/pkg/log"

--- a/pkg/test/util/yml/apply.go
+++ b/pkg/test/util/yml/apply.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/ghodss/yaml"
+	"sigs.k8s.io/yaml"
 
 	"istio.io/istio/pkg/test"
 )

--- a/pkg/test/util/yml/parse.go
+++ b/pkg/test/util/yml/parse.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/ghodss/yaml"
+	"sigs.k8s.io/yaml"
 )
 
 // Metadata metadata for a kubernetes resource.

--- a/pkg/test/util/yml/parts.go
+++ b/pkg/test/util/yml/parts.go
@@ -18,8 +18,8 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/ghodss/yaml"
 	kubeApiMeta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
 )
 
 const (

--- a/pkg/util/gogoprotomarshal/protomarshal.go
+++ b/pkg/util/gogoprotomarshal/protomarshal.go
@@ -19,9 +19,9 @@ import (
 	"errors"
 	"strings"
 
-	"github.com/ghodss/yaml"
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/gogo/protobuf/proto"
+	"sigs.k8s.io/yaml"
 
 	"istio.io/pkg/log"
 )

--- a/pkg/util/protomarshal/protomarshal.go
+++ b/pkg/util/protomarshal/protomarshal.go
@@ -25,10 +25,10 @@ import (
 	"errors"
 	"strings"
 
-	"github.com/ghodss/yaml"
 	"github.com/golang/protobuf/jsonpb"
 	legacyproto "github.com/golang/protobuf/proto"
 	"google.golang.org/protobuf/proto"
+	"sigs.k8s.io/yaml"
 
 	"istio.io/pkg/log"
 )

--- a/tests/integration/pilot/mcs/discoverability/discoverability_test.go
+++ b/tests/integration/pilot/mcs/discoverability/discoverability_test.go
@@ -27,11 +27,11 @@ import (
 	"time"
 
 	envoy_admin_v3 "github.com/envoyproxy/go-control-plane/envoy/admin/v3"
-	"github.com/ghodss/yaml"
 	"golang.org/x/sync/errgroup"
 	kubeCore "k8s.io/api/core/v1"
 	kubeMeta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	mcs "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
+	"sigs.k8s.io/yaml"
 
 	"istio.io/api/annotation"
 	"istio.io/istio/pkg/test/framework"

--- a/tools/bug-report/pkg/bugreport/flags.go
+++ b/tools/bug-report/pkg/bugreport/flags.go
@@ -21,8 +21,8 @@ import (
 	"time"
 
 	jsonpatch "github.com/evanphx/json-patch/v5"
-	"github.com/ghodss/yaml"
 	"github.com/spf13/cobra"
+	"sigs.k8s.io/yaml"
 
 	analyzer_util "istio.io/istio/galley/pkg/config/analysis/analyzers/util"
 	config2 "istio.io/istio/tools/bug-report/pkg/config"

--- a/tools/bug-report/pkg/config/config_test.go
+++ b/tools/bug-report/pkg/config/config_test.go
@@ -19,9 +19,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ghodss/yaml"
 	"github.com/google/go-cmp/cmp"
 	"github.com/kr/pretty"
+	"sigs.k8s.io/yaml"
 )
 
 func TestUnmarshalKubeCaptureConfig(t *testing.T) {

--- a/tools/bug-report/pkg/filter/filter_test.go
+++ b/tools/bug-report/pkg/filter/filter_test.go
@@ -17,8 +17,8 @@ package filter
 import (
 	"testing"
 
-	"github.com/ghodss/yaml"
 	. "github.com/onsi/gomega"
+	"sigs.k8s.io/yaml"
 
 	cluster2 "istio.io/istio/tools/bug-report/pkg/cluster"
 	config2 "istio.io/istio/tools/bug-report/pkg/config"


### PR DESCRIPTION
**Please provide a description of this PR:**
istio has four `yaml` related packages, as below, 
```
github.com/ghodss/yaml
gopkg.in/yaml.v2
gopkg.in/yaml.v3
sigs.k8s.io/yaml
```
we can simplify these packages only to one, we can keep only the one package.
this pr replace package `github.com/ghodss/yaml` with `sigs.k8s.io/yaml`


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
