### PR TITLE
Create the non-tagged variants in docker.save

### DIFF
--- a/tools/istio-docker.mk
+++ b/tools/istio-docker.mk
@@ -337,7 +337,7 @@ docker.all: $(DOCKER_TARGETS)
 # create a DOCKER_TAR_TARGETS that's each of DOCKER_TARGETS with a tar. prefix
 DOCKER_TAR_TARGETS:=
 $(foreach TGT,$(DOCKER_TARGETS),$(eval tar.$(TGT): $(TGT) | $(ISTIO_DOCKER_TAR) ; \
-         $(foreach VARIANT,$(DOCKER_BUILD_VARIANTS), time ( \
+         $(foreach VARIANT,$(DOCKER_BUILD_VARIANTS) default, time ( \
 		     docker save -o ${ISTIO_DOCKER_TAR}/$(subst docker.,,$(TGT))$(call variant-tag,$(VARIANT)).tar $(HUB)/$(subst docker.,,$(TGT)):$(subst -$(DEFAULT_DISTRIBUTION),,$(TAG)-$(VARIANT)) && \
              gzip ${ISTIO_DOCKER_TAR}/$(subst docker.,,$(TGT))$(call variant-tag,$(VARIANT)).tar \
 			   ); \
@@ -349,7 +349,7 @@ $(foreach TGT,$(DOCKER_TARGETS),$(eval DOCKER_TAR_TARGETS+=tar.$(TGT)))
 # this target saves a tar.gz of each docker image to ${ISTIO_OUT_LINUX}/docker/
 dockerx.save: dockerx $(ISTIO_DOCKER_TAR)
 	$(foreach TGT,$(DOCKER_TARGETS), \
-	$(foreach VARIANT,$(DOCKER_BUILD_VARIANTS), \
+	$(foreach VARIANT,$(DOCKER_BUILD_VARIANTS) default, \
 	   if ! ./tools/skip-image.sh $(TGT) $(VARIANT); then \
 	   time ( \
 		 echo $(TGT)-$(VARIANT); \


### PR DESCRIPTION
**Please provide a description of this PR:**

Fixes: https://github.com/istio/istio/issues/35664

Noting that when running `docker.save` (used as part of the please-build build step), the untagged image tar files are not created.

Testing was done by setting:
```
DOCKER_BUILD_VARIANTS=debug distroless
INCLUDE_UNTAGGED_DEFAULT=true
```
and running `docker.save`. Without the changes the empty variant tagged images were created but no tar file created. With this change, the tar files are now created:
```
> ls -la ./out/linux_amd64/release/docker
total 7190016
drwxr-xr-x  33 ericvn  staff   1.0K Oct 15 16:43 .
drwxr-xr-x  18 ericvn  staff   576B Oct 18 08:41 ..
-rw-r--r--   1 ericvn  staff    62M Oct 18 08:43 app-debug.tar.gz
-rw-r--r--   1 ericvn  staff    62M Oct 18 08:43 app.tar.gz
-rw-r--r--   1 ericvn  staff   201M Oct 18 08:46 app_sidecar_centos_7-debug.tar.gz
-rw-r--r--   1 ericvn  staff   201M Oct 18 08:46 app_sidecar_centos_7.tar.gz
-rw-r--r--   1 ericvn  staff   202M Oct 18 08:45 app_sidecar_centos_8-debug.tar.gz
-rw-r--r--   1 ericvn  staff   202M Oct 18 08:45 app_sidecar_centos_8.tar.gz
-rw-r--r--   1 ericvn  staff   164M Oct 18 08:45 app_sidecar_debian_10-debug.tar.gz
-rw-r--r--   1 ericvn  staff   164M Oct 18 08:45 app_sidecar_debian_10.tar.gz
-rw-r--r--   1 ericvn  staff   157M Oct 18 08:44 app_sidecar_debian_9-debug.tar.gz
-rw-r--r--   1 ericvn  staff   157M Oct 18 08:44 app_sidecar_debian_9.tar.gz
-rw-r--r--   1 ericvn  staff   137M Oct 18 08:43 app_sidecar_ubuntu_bionic-debug.tar.gz
-rw-r--r--   1 ericvn  staff   137M Oct 18 08:44 app_sidecar_ubuntu_bionic.tar.gz
-rw-r--r--   1 ericvn  staff   140M Oct 18 08:44 app_sidecar_ubuntu_focal-debug.tar.gz
-rw-r--r--   1 ericvn  staff   140M Oct 18 08:44 app_sidecar_ubuntu_focal.tar.gz
-rw-r--r--   1 ericvn  staff   158M Oct 18 08:43 app_sidecar_ubuntu_xenial-debug.tar.gz
-rw-r--r--   1 ericvn  staff   158M Oct 18 08:43 app_sidecar_ubuntu_xenial.tar.gz
-rw-r--r--   1 ericvn  staff    88M Oct 18 08:46 install-cni-debug.tar.gz
-rw-r--r--   1 ericvn  staff    49M Oct 18 08:46 install-cni-distroless.tar.gz
-rw-r--r--   1 ericvn  staff    88M Oct 18 08:47 install-cni.tar.gz
-rw-r--r--   1 ericvn  staff    63M Oct 18 08:46 istioctl-debug.tar.gz
-rw-r--r--   1 ericvn  staff    63M Oct 18 08:46 istioctl-distroless.tar.gz
-rw-r--r--   1 ericvn  staff    63M Oct 18 08:46 istioctl.tar.gz
-rw-r--r--   1 ericvn  staff    63M Oct 18 08:46 operator-debug.tar.gz
-rw-r--r--   1 ericvn  staff    24M Oct 18 08:46 operator-distroless.tar.gz
-rw-r--r--   1 ericvn  staff    63M Oct 18 08:46 operator.tar.gz
-rw-r--r--   1 ericvn  staff    63M Oct 18 08:42 pilot-debug.tar.gz
-rw-r--r--   1 ericvn  staff    24M Oct 18 08:42 pilot-distroless.tar.gz
-rw-r--r--   1 ericvn  staff    63M Oct 18 08:42 pilot.tar.gz
-rw-r--r--   1 ericvn  staff    84M Oct 18 08:43 proxyv2-debug.tar.gz
-rw-r--r--   1 ericvn  staff    54M Oct 18 08:43 proxyv2-distroless.tar.gz
-rw-r--r--   1 ericvn  staff    84M Oct 18 08:43 proxyv2.tar.gz
```

Note: I still need to verify that the publish step will create the additional images and push them to the gcr repo. (edit: the code just iterates over the tar files, so this should get the images in the repo as well).

Note #2, it seems the istioctl distroless image is not smaller that the debug image. Not sure on the reason for that.