### PR TITLE
fix operator prune resources for action required case.

### DIFF
--- a/operator/pkg/controller/istiocontrolplane/istiocontrolplane_controller.go
+++ b/operator/pkg/controller/istiocontrolplane/istiocontrolplane_controller.go
@@ -235,6 +235,16 @@ func (r *ReconcileIstioOperator) Reconcile(_ context.Context, request reconcile.
 		return reconcile.Result{}, nil
 	}
 
+	var err error
+	iopMerged := &iopv1alpha1.IstioOperator{}
+	*iopMerged = *iop
+	// get the merged values in iop on top of the defaults for the profile given by iop.profile
+	iopMerged.Spec, err = mergeIOPSWithProfile(iopMerged)
+	if err != nil {
+		scope.Errorf(errdict.OperatorFailedToMergeUserIOP, "failed to merge base profile with user IstioOperator CR %s, %s", iopName, err)
+		return reconcile.Result{}, err
+	}
+
 	deleted := iop.GetDeletionTimestamp() != nil
 	finalizers := sets.NewString(iop.GetFinalizers()...)
 	if deleted {
@@ -245,13 +255,15 @@ func (r *ReconcileIstioOperator) Reconcile(_ context.Context, request reconcile.
 		}
 		scope.Infof("Deleting IstioOperator %s", iopName)
 
-		reconciler, err := helmreconciler.NewHelmReconciler(r.client, r.clientSet, r.config, iop, nil)
+		reconciler, err := helmreconciler.NewHelmReconciler(r.client, r.clientSet, r.config, iopMerged, nil)
 		if err != nil {
 			return reconcile.Result{}, err
 		}
 		if err := reconciler.Delete(); err != nil {
+			scope.Errorf("Failed to delete resources with helm reconciler: %s.", err)
 			return reconcile.Result{}, err
 		}
+
 		finalizers.Delete(finalizer)
 		iop.SetFinalizers(finalizers.List())
 		finalizerError := r.client.Update(context.TODO(), iop)
@@ -296,16 +308,6 @@ func (r *ReconcileIstioOperator) Reconcile(_ context.Context, request reconcile.
 	}
 
 	scope.Info("Updating IstioOperator")
-	var err error
-	iopMerged := &iopv1alpha1.IstioOperator{}
-	*iopMerged = *iop
-	iopMerged.Spec, err = mergeIOPSWithProfile(iopMerged)
-
-	if err != nil {
-		scope.Errorf(errdict.OperatorFailedToMergeUserIOP, "failed to merge base profile with user IstioOperator CR %s, %s", iopName, err)
-		return reconcile.Result{}, err
-	}
-
 	if _, ok := iopMerged.Spec.Values["global"]; !ok {
 		iopMerged.Spec.Values["global"] = make(map[string]interface{})
 	}

--- a/operator/pkg/helmreconciler/prune.go
+++ b/operator/pkg/helmreconciler/prune.go
@@ -119,8 +119,17 @@ func (h *HelmReconciler) PruneControlPlaneByRevisionWithController(iopSpec *v1al
 		return errStatus,
 			fmt.Errorf("failed to check proxy infos: %v", err)
 	}
+	pilotEnabled := false
+	// check wherther the istiod is enabled
+	for _, c := range enabledComponents {
+		if c == string(name.PilotComponentName) {
+			pilotEnabled = true
+			break
+		}
+	}
+
 	// TODO(richardwxn): add warning message together with the status
-	if len(pids) != 0 {
+	if len(pids) != 0 && pilotEnabled {
 		msg := fmt.Sprintf("there are proxies still pointing to the pruned control plane: %s.",
 			strings.Join(pids, " "))
 		st := &v1alpha1.InstallStatus{Status: v1alpha1.InstallStatus_ACTION_REQUIRED, Message: msg}

--- a/operator/pkg/helmreconciler/reconciler.go
+++ b/operator/pkg/helmreconciler/reconciler.go
@@ -298,6 +298,12 @@ func (h *HelmReconciler) Delete() error {
 		return err
 	}
 
+	// check status here because terminating iop's status can't be updated.
+	if status.Status == v1alpha1.InstallStatus_ACTION_REQUIRED {
+		return fmt.Errorf("action is required before deleting the iop instance: %s", status.Message)
+	}
+
+	// updating status taking no effect for terminating resources.
 	if err := h.SetStatusComplete(status); err != nil {
 		return err
 	}

--- a/releasenotes/notes/35657.yaml
+++ b/releasenotes/notes/35657.yaml
@@ -6,5 +6,5 @@ issue:
 
 releaseNotes:
   - |
-    **Fixed** the in-cluster operator can't prune resources when istio control plane have active proxies conncted.
+    **Fixed** the in-cluster operator can't prune resources when the Istio control plane have active proxies connected.
 

--- a/releasenotes/notes/35657.yaml
+++ b/releasenotes/notes/35657.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+issue:
+- 35657
+
+releaseNotes:
+  - |
+    **Fixed** the in-cluster operator can't prune resources when istio control plane have active proxies conncted.
+


### PR DESCRIPTION
**Please provide a description of this PR:**
fix: https://github.com/istio/istio/issues/35657

Currently the in-cluster operator will check if there are active proxies connecting to the istio control plane before the istio control plane is deleted. But the operator didn't check if the deleted IOP instance actually contains the istiod component, for example if the deleting IOP instance only contains Gateways components, it should be safe to be deleted.