### PR TITLE
gateway: allow overriding type and LB IP

### DIFF
--- a/pilot/pkg/config/kube/gateway/deploymentcontroller_test.go
+++ b/pilot/pkg/config/kube/gateway/deploymentcontroller_test.go
@@ -1,0 +1,100 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gateway
+
+import (
+	"bytes"
+	"path/filepath"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/gateway-api/apis/v1alpha2"
+	"sigs.k8s.io/yaml"
+
+	"istio.io/istio/pilot/test/util"
+	"istio.io/istio/pkg/kube"
+	istiolog "istio.io/pkg/log"
+)
+
+func TestConfigureIstioGateway(t *testing.T) {
+	tests := []struct {
+		name string
+		gw   v1alpha2.Gateway
+	}{
+		{
+			"simple",
+			v1alpha2.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "default",
+					Namespace: "default",
+				},
+				Spec: v1alpha2.GatewaySpec{},
+			},
+		},
+		{
+			"manual-ip",
+			v1alpha2.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "default",
+					Namespace: "default",
+				},
+				Spec: v1alpha2.GatewaySpec{
+					Addresses: []v1alpha2.GatewayAddress{{
+						Type:  func() *v1alpha2.AddressType { x := v1alpha2.IPAddressType; return &x }(),
+						Value: "1.2.3.4",
+					}},
+				},
+			},
+		},
+		{
+			"cluster-ip",
+			v1alpha2.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "default",
+					Namespace:   "default",
+					Annotations: map[string]string{"networking.istio.io/service-type": string(corev1.ServiceTypeClusterIP)},
+				},
+				Spec: v1alpha2.GatewaySpec{},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf := &bytes.Buffer{}
+			d := &DeploymentController{
+				client:    kube.NewFakeClient(),
+				templates: processTemplates(),
+				patcher: func(gvr schema.GroupVersionResource, name string, namespace string, data []byte, subresources ...string) error {
+					b, err := yaml.JSONToYAML(data)
+					if err != nil {
+						return err
+					}
+					buf.Write(b)
+					buf.Write([]byte("---\n"))
+					return nil
+				},
+			}
+			err := d.configureIstioGateway(istiolog.FindScope(istiolog.DefaultScopeName), tt.gw)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			resp := timestampRegex.ReplaceAll(buf.Bytes(), []byte("lastTransitionTime: fake"))
+			util.CompareContent(resp, filepath.Join("testdata", "deployment", tt.name+".yaml"), t)
+		})
+	}
+}

--- a/pilot/pkg/config/kube/gateway/templates/service.yaml
+++ b/pilot/pkg/config/kube/gateway/templates/service.yaml
@@ -23,5 +23,8 @@ spec:
   {{- end }}
   selector:
     istio.io/gateway-name: {{.Name}}
-  type: LoadBalancer
+  {{- if .Spec.Addresses }}
+  loadBalancerIP: {{ (index .Spec.Addresses 0).Value}}
+  {{- end }}
+  type: {{ index .Annotations "networking.istio.io/service-type" | default "LoadBalancer" }}
 

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/cluster-ip.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/cluster-ip.yaml
@@ -1,0 +1,84 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    networking.istio.io/service-type: ClusterIP
+  labels:
+    gateway.istio.io/managed: istio.io-gateway-controller
+  name: default
+  namespace: default
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1alpha2
+    kind: Gateway
+    name: default
+    uid: null
+spec:
+  ports:
+  - name: status-port
+    port: 15021
+    protocol: TCP
+  selector:
+    istio.io/gateway-name: default
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    networking.istio.io/service-type: ClusterIP
+  labels:
+    gateway.istio.io/managed: istio.io-gateway-controller
+  name: default
+  namespace: default
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1alpha2
+    kind: Gateway
+    name: default
+    uid: null
+spec:
+  selector:
+    matchLabels:
+      istio.io/gateway-name: default
+  template:
+    metadata:
+      annotations:
+        inject.istio.io/templates: gateway
+        networking.istio.io/service-type: ClusterIP
+      labels:
+        istio.io/gateway-name: default
+        sidecar.istio.io/inject: "true"
+    spec:
+      containers:
+      - image: auto
+        name: istio-proxy
+        ports:
+        - containerPort: 15021
+          name: status-port
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 10
+          httpGet:
+            path: /healthz/ready
+            port: 15021
+            scheme: HTTP
+          periodSeconds: 2
+          successThreshold: 1
+          timeoutSeconds: 2
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: Gateway
+metadata:
+  creationTimestamp: null
+  name: default
+  namespace: default
+spec:
+  gatewayClassName: ""
+  listeners: null
+status:
+  conditions:
+  - lastTransitionTime: fake
+    message: Deployed gateway to the cluster
+    reason: ResourcesAvailable
+    status: "True"
+    type: Scheduled
+---

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/manual-ip.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/manual-ip.yaml
@@ -1,0 +1,82 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    gateway.istio.io/managed: istio.io-gateway-controller
+  name: default
+  namespace: default
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1alpha2
+    kind: Gateway
+    name: default
+    uid: null
+spec:
+  loadBalancerIP: 1.2.3.4
+  ports:
+  - name: status-port
+    port: 15021
+    protocol: TCP
+  selector:
+    istio.io/gateway-name: default
+  type: LoadBalancer
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations: {}
+  labels:
+    gateway.istio.io/managed: istio.io-gateway-controller
+  name: default
+  namespace: default
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1alpha2
+    kind: Gateway
+    name: default
+    uid: null
+spec:
+  selector:
+    matchLabels:
+      istio.io/gateway-name: default
+  template:
+    metadata:
+      annotations:
+        inject.istio.io/templates: gateway
+      labels:
+        istio.io/gateway-name: default
+        sidecar.istio.io/inject: "true"
+    spec:
+      containers:
+      - image: auto
+        name: istio-proxy
+        ports:
+        - containerPort: 15021
+          name: status-port
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 10
+          httpGet:
+            path: /healthz/ready
+            port: 15021
+            scheme: HTTP
+          periodSeconds: 2
+          successThreshold: 1
+          timeoutSeconds: 2
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: Gateway
+metadata:
+  creationTimestamp: null
+  name: default
+  namespace: default
+spec:
+  gatewayClassName: ""
+  listeners: null
+status:
+  conditions:
+  - lastTransitionTime: fake
+    message: Deployed gateway to the cluster
+    reason: ResourcesAvailable
+    status: "True"
+    type: Scheduled
+---

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/simple.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/simple.yaml
@@ -1,0 +1,81 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    gateway.istio.io/managed: istio.io-gateway-controller
+  name: default
+  namespace: default
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1alpha2
+    kind: Gateway
+    name: default
+    uid: null
+spec:
+  ports:
+  - name: status-port
+    port: 15021
+    protocol: TCP
+  selector:
+    istio.io/gateway-name: default
+  type: LoadBalancer
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations: {}
+  labels:
+    gateway.istio.io/managed: istio.io-gateway-controller
+  name: default
+  namespace: default
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1alpha2
+    kind: Gateway
+    name: default
+    uid: null
+spec:
+  selector:
+    matchLabels:
+      istio.io/gateway-name: default
+  template:
+    metadata:
+      annotations:
+        inject.istio.io/templates: gateway
+      labels:
+        istio.io/gateway-name: default
+        sidecar.istio.io/inject: "true"
+    spec:
+      containers:
+      - image: auto
+        name: istio-proxy
+        ports:
+        - containerPort: 15021
+          name: status-port
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 10
+          httpGet:
+            path: /healthz/ready
+            port: 15021
+            scheme: HTTP
+          periodSeconds: 2
+          successThreshold: 1
+          timeoutSeconds: 2
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: Gateway
+metadata:
+  creationTimestamp: null
+  name: default
+  namespace: default
+spec:
+  gatewayClassName: ""
+  listeners: null
+status:
+  conditions:
+  - lastTransitionTime: fake
+    message: Deployed gateway to the cluster
+    reason: ResourcesAvailable
+    status: "True"
+    type: Scheduled
+---

--- a/pilot/pkg/config/kube/gateway/testdata/invalid.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/invalid.yaml
@@ -65,7 +65,7 @@ spec:
   gatewayClassName: istio
   addresses:
   - value: 1.2.3.4
-    type: IPAddress
+    type: NamedAddress
   listeners:
   - name: default
     hostname: "*.domain.example"


### PR DESCRIPTION
This introduces two customizations that are extremely common:
* Explicitly set LB IP, to assign to existing static IP. This is done by
re-using the existing Gateway.addresses field, making it seemless
compared to other implementations
* Declare Service type (default=LoadBalancer). This is done via
annotation since there is no other place to put it.

This also adds tests which didn't really exist before.

**Please provide a description of this PR:**