### PR TITLE
Make bootstrap folder if not present for proxyless

### DIFF
--- a/pkg/istio-agent/agent.go
+++ b/pkg/istio-agent/agent.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"os/signal"
 	"path"
+	"path/filepath"
 	"strings"
 	"sync"
 	"syscall"
@@ -491,6 +492,10 @@ func (a *Agent) generateGRPCBootstrap() error {
 	node, err := a.generateNodeMetadata()
 	if err != nil {
 		return fmt.Errorf("failed generating node metadata: %v", err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(a.cfg.GRPCBootstrapPath), 0o700); err != nil {
+		return err
 	}
 
 	_, err = grpcxds.GenerateBootstrapFile(grpcxds.GenerateBootstrapOptions{


### PR DESCRIPTION
This mirrors the logic in standard envoy bootstrap. Ran into it running
locally, may happen in other non-k8s environments as well

**Please provide a description of this PR:**