### PR TITLE
Support multiple trust domains in trustbundle pkg.

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -1171,11 +1171,8 @@ func (s *Server) addIstioCAToTrustBundle(args *PilotArgs) error {
 	var err error
 	if s.CA != nil {
 		// If IstioCA is setup, derive trustAnchor directly from CA
-		rootCerts := []string{string(s.CA.GetCAKeyCertBundle().GetRootCertPem())}
-		err = s.workloadTrustBundle.UpdateTrustAnchor(&tb.TrustAnchorUpdate{
-			TrustAnchorConfig: tb.TrustAnchorConfig{Certs: rootCerts},
-			Source:            tb.SourceIstioCA,
-		})
+		err = s.workloadTrustBundle.AddTrustAnchorInDefaultTrustDomain(tb.SourceIstioCA,
+			string(s.CA.GetCAKeyCertBundle().GetRootCertPem()))
 		if err != nil {
 			log.Errorf("unable to add CA root from namespace %s as trustAnchor", args.Namespace)
 			return err
@@ -1224,11 +1221,8 @@ func (s *Server) initWorkloadTrustBundle(args *PilotArgs) error {
 	// IstioRA: Explicitly add roots corresponding to RA
 	if s.RA != nil {
 		// Implicitly add the Istio RA certificates to the Workload Trust Bundle
-		rootCerts := []string{string(s.RA.GetCAKeyCertBundle().GetRootCertPem())}
-		err = s.workloadTrustBundle.UpdateTrustAnchor(&tb.TrustAnchorUpdate{
-			TrustAnchorConfig: tb.TrustAnchorConfig{Certs: rootCerts},
-			Source:            tb.SourceIstioRA,
-		})
+		err = s.workloadTrustBundle.AddTrustAnchorInDefaultTrustDomain(tb.SourceIstioRA,
+			string(s.RA.GetCAKeyCertBundle().GetRootCertPem()))
 		if err != nil {
 			log.Errorf("fatal: unable to add RA root as trustAnchor")
 			return err


### PR DESCRIPTION
Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>

**Please provide a description of this PR:**

The first PR to support multiple trust bundles from multiple domains in mTLS. Notably this *only* refactors the `spiffe` and `trustbnudle` packages, and `trustbundle` package now is aware of `trust_domains` field on `CertificateData` message introduced in https://github.com/istio/api/pull/2090, though note that this doesn't contain any functional change beyond these packages since we just return trust anchors belonging to the default trust domain from `GetTrustBundle()`. The follow-up PRs will make actual changes to mTLS behaviors leveraging the SPIFFE certificate validator in Envoy.


Related links
- https://github.com/istio/api/pull/2090
- https://github.com/istio/istio/issues/30454