### PR TITLE
wasm: allow "./" prefix in binary name in OCI images.

### DIFF
--- a/pkg/wasm/imagefetcher.go
+++ b/pkg/wasm/imagefetcher.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"path/filepath"
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
@@ -220,7 +221,7 @@ func extractWasmPluginBinary(r io.Reader) ([]byte, error) {
 		}
 
 		ret := make([]byte, h.Size)
-		if h.Name == wasmPluginFileName {
+		if filepath.Base(h.Name) == wasmPluginFileName {
 			_, err := io.ReadFull(tr, ret)
 			if err != nil {
 				return nil, fmt.Errorf("failed to read %s: %v", wasmPluginFileName, err)

--- a/pkg/wasm/imagefetcher_test.go
+++ b/pkg/wasm/imagefetcher_test.go
@@ -567,6 +567,36 @@ func TestExtractWasmPluginBinary(t *testing.T) {
 		}
 	})
 
+	t.Run("ok with relative path prefix", func(t *testing.T) {
+		buf := bytes.NewBuffer(nil)
+		gz := gzip.NewWriter(buf)
+		tw := tar.NewWriter(gz)
+
+		exp := "hello"
+		if err := tw.WriteHeader(&tar.Header{
+			Name: "./plugin.wasm",
+			Size: int64(len(exp)),
+		}); err != nil {
+			t.Fatal(err)
+		}
+
+		if _, err := io.WriteString(tw, exp); err != nil {
+			t.Fatal(err)
+		}
+
+		tw.Close()
+		gz.Close()
+
+		actual, err := extractWasmPluginBinary(buf)
+		if err != nil {
+			t.Errorf("extractWasmPluginBinary failed: %v", err)
+		}
+
+		if string(actual) != exp {
+			t.Errorf("extractWasmPluginBinary got %v, but want %v", string(actual), exp)
+		}
+	})
+
 	t.Run("not found", func(t *testing.T) {
 		buf := bytes.NewBuffer(nil)
 		gz := gzip.NewWriter(buf)


### PR DESCRIPTION
we should allow not only `plugin.wasm` in the OCI image layer but also `./plugin.wasm`. This is the case when users build images with Bazel.

Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>

cc @bianpengyuan 