### PR TITLE
[WIP] Ipv6 for metallb

### DIFF
--- a/common/scripts/kind_provisioner.sh
+++ b/common/scripts/kind_provisioner.sh
@@ -363,7 +363,9 @@ function connect_metallb() {
 function cidr_to_ips() {
     CIDR="$1"
     python3 - <<EOF
-from ipaddress import IPv4Network; [print(str(ip)) for ip in IPv4Network('$CIDR').hosts()]
+from ipaddress import IPv4Network, IPv6Network; 
+[print(str(ip)) for ip in IPv4Network('$CIDR').hosts()]
+[print(str(ip)) for ip in IPv6Network('$CIDR').hosts()]
 EOF
 }
 
@@ -371,7 +373,8 @@ function ips_to_cidrs() {
   IP_RANGE_START="$1"
   IP_RANGE_END="$2"
   python3 - <<EOF
-from ipaddress import summarize_address_range, IPv4Address
+from ipaddress import summarize_address_range, IPv4Address, IPv6Address
 [ print(n.compressed) for n in summarize_address_range(IPv4Address(u'$IP_RANGE_START'), IPv4Address(u'$IP_RANGE_END')) ]
+[ print(n.compressed) for n in summarize_address_range(IPv6Address(u'$IP_RANGE_START'), IPv6Address(u'$IP_RANGE_END')) ]
 EOF
 }

--- a/prow/integ-suite-kind.sh
+++ b/prow/integ-suite-kind.sh
@@ -104,12 +104,8 @@ done
 # Default IP family of the cluster is IPv4
 export IP_FAMILY="${IP_FAMILY:-ipv4}"
 
-# KinD will not have a LoadBalancer, so we need to disable it
-export TEST_ENV=kind
-# LoadBalancer in Kind is supported using metallb if not ipv6.
-if [ "${IP_FAMILY}" != "ipv6" ]; then
-  export TEST_ENV=kind-metallb
-fi
+# LoadBalancer in Kind is supported using metallb
+export TEST_ENV=kind-metallb
 
 # See https://kind.sigs.k8s.io/docs/user/quick-start/#loading-an-image-into-your-cluster
 export PULL_POLICY=IfNotPresent


### PR DESCRIPTION
**Enable metallb + ipv6 support:**
 
Modified "/common/scripts/kind_provisioner.sh" to add IPv6Address for metallb. This patch is to solve [#34945](https://github.com/istio/istio/issues/34945). 