### PR TITLE
Fix alt-host generation when hostname has a partial overlap with cluster domain

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -535,14 +535,13 @@ func generateAltVirtualHostsForKubernetesService(hostname string, port int, prox
 				hostname[:ih] + ".svc",
 				util.DomainName(hostname[:ih]+".svc", port),
 			}
-		} else {
-			// Different namespace
-			return []string{
-				hostname[:ih],
-				util.DomainName(hostname[:ih], port),
-				hostname[:ih] + ".svc",
-				util.DomainName(hostname[:ih]+".svc", port),
-			}
+		}
+		// Different namespace
+		return []string{
+			hostname[:ih],
+			util.DomainName(hostname[:ih], port),
+			hostname[:ih] + ".svc",
+			util.DomainName(hostname[:ih]+".svc", port),
 		}
 	}
 	// Proxy is in k8s, but service isn't. No alt hosts

--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -521,7 +521,7 @@ func generateAltVirtualHostsForKubernetesService(hostname string, port int, prox
 	ih := strings.Index(hostname, ".svc.")
 	if ih > 0 { // Proxy and service hostname are in kube
 		ns := strings.Index(hostname, ".")
-		if ns <= len(hostname) {
+		if ns >= len(hostname) {
 			// Invalid domain
 			return nil
 		}

--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -521,7 +521,7 @@ func generateAltVirtualHostsForKubernetesService(hostname string, port int, prox
 	ih := strings.Index(hostname, ".svc.")
 	if ih > 0 { // Proxy and service hostname are in kube
 		ns := strings.Index(hostname, ".")
-		if ns >= len(hostname) {
+		if ns+1 >= len(hostname) || ns+1 > ih {
 			// Invalid domain
 			return nil
 		}
@@ -530,10 +530,10 @@ func generateAltVirtualHostsForKubernetesService(hostname string, port int, prox
 			return []string{
 				hostname[:ns],
 				util.DomainName(hostname[:ns], port),
-				hostname[:ih],
-				util.DomainName(hostname[:ih], port),
 				hostname[:ih] + ".svc",
 				util.DomainName(hostname[:ih]+".svc", port),
+				hostname[:ih],
+				util.DomainName(hostname[:ih], port),
 			}
 		}
 		// Different namespace

--- a/pilot/pkg/networking/core/v1alpha3/httproute_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute_test.go
@@ -153,6 +153,54 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 			},
 			want: []string{"[2406:3003:2064:35b8:864:a648:4b96:e37d]", "[2406:3003:2064:35b8:864:a648:4b96:e37d]:8123"},
 		},
+		{
+			name: "back subset of cluster domain in address",
+			service: &model.Service{
+				Hostname:     "aaa.example.local",
+				MeshExternal: true,
+			},
+			port: 7777,
+			node: &model.Proxy{
+				DNSDomain: "tests.svc.cluster.local",
+			},
+			want: []string{"aaa.example.local", "aaa.example.local:7777"},
+		},
+		{
+			name: "front subset of cluster domain in address",
+			service: &model.Service{
+				Hostname:     "aaa.example.my",
+				MeshExternal: true,
+			},
+			port: 7777,
+			node: &model.Proxy{
+				DNSDomain: "tests.svc.my.long.domain.suffix",
+			},
+			want: []string{"aaa.example.my", "aaa.example.my:7777"},
+		},
+		{
+			name: "large subset of cluster domain in address",
+			service: &model.Service{
+				Hostname:     "aaa.example.my.long",
+				MeshExternal: true,
+			},
+			port: 7777,
+			node: &model.Proxy{
+				DNSDomain: "tests.svc.my.long.domain.suffix",
+			},
+			want: []string{"aaa.example.my.long", "aaa.example.my.long:7777"},
+		},
+		{
+			name: "no overlap of cluster domain in address",
+			service: &model.Service{
+				Hostname:     "aaa.example.com",
+				MeshExternal: true,
+			},
+			port: 7777,
+			node: &model.Proxy{
+				DNSDomain: "tests.svc.cluster.local",
+			},
+			want: []string{"aaa.example.com", "aaa.example.com:7777"},
+		},
 	}
 
 	testFn := func(service *model.Service, port int, node *model.Proxy, want []string) error {

--- a/pilot/pkg/networking/core/v1alpha3/httproute_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute_test.go
@@ -105,10 +105,10 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 				"echo.default.svc.cluster.local:8123",
 				"echo",
 				"echo:8123",
-				"echo.default",
-				"echo.default:8123",
 				"echo.default.svc",
 				"echo.default.svc:8123",
+				"echo.default",
+				"echo.default:8123",
 			},
 		},
 		{

--- a/pilot/pkg/networking/core/v1alpha3/httproute_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute_test.go
@@ -17,7 +17,6 @@ package v1alpha3
 import (
 	"fmt"
 	"reflect"
-	"sort"
 	"testing"
 	"time"
 
@@ -56,8 +55,8 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 				DNSDomain: "local.campus.net",
 			},
 			want: []string{
-				"foo", "foo.local.campus.net",
-				"foo:80", "foo.local.campus.net:80",
+				"foo.local.campus.net", "foo.local.campus.net:80",
+				"foo", "foo:80",
 			},
 		},
 		{
@@ -71,8 +70,12 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 				DNSDomain: "remote.campus.net",
 			},
 			want: []string{
-				"foo.local", "foo.local.campus", "foo.local.campus.net",
-				"foo.local:80", "foo.local.campus:80", "foo.local.campus.net:80",
+				"foo.local.campus.net",
+				"foo.local.campus.net:80",
+				"foo.local",
+				"foo.local:80",
+				"foo.local.campus",
+				"foo.local.campus:80",
 			},
 		},
 		{
@@ -98,8 +101,14 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 				DNSDomain: "default.svc.cluster.local",
 			},
 			want: []string{
-				"echo", "echo.default", "echo.default.svc", "echo.default.svc.cluster.local",
-				"echo:8123", "echo.default:8123", "echo.default.svc:8123", "echo.default.svc.cluster.local:8123",
+				"echo.default.svc.cluster.local",
+				"echo.default.svc.cluster.local:8123",
+				"echo",
+				"echo:8123",
+				"echo.default",
+				"echo.default:8123",
+				"echo.default.svc",
+				"echo.default.svc:8123",
 			},
 		},
 		{
@@ -113,8 +122,12 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 				DNSDomain: "mesh.svc.cluster.local",
 			},
 			want: []string{
-				"echo.default", "echo.default.svc", "echo.default.svc.cluster.local",
-				"echo.default:8123", "echo.default.svc:8123", "echo.default.svc.cluster.local:8123",
+				"echo.default.svc.cluster.local",
+				"echo.default.svc.cluster.local:8123",
+				"echo.default",
+				"echo.default:8123",
+				"echo.default.svc",
+				"echo.default.svc:8123",
 			},
 		},
 		{
@@ -205,8 +218,6 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 
 	testFn := func(service *model.Service, port int, node *model.Proxy, want []string) error {
 		out, _ := generateVirtualHostDomains(service, port, node)
-		sort.SliceStable(want, func(i, j int) bool { return want[i] < want[j] })
-		sort.SliceStable(out, func(i, j int) bool { return out[i] < out[j] })
 		if !reflect.DeepEqual(out, want) {
 			return fmt.Errorf("unexpected virtual hosts:\ngot  %v\nwant %v", out, want)
 		}

--- a/releasenotes/notes/vhost-name-generation.yaml
+++ b/releasenotes/notes/vhost-name-generation.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+- 35676
+releaseNotes:
+- |
+  **Fixed** an issue causing hostnames overlapping the cluster domain (such as `example.local`) to generate invalid routes.


### PR DESCRIPTION
For example, a service `foo.bar.local` behaves incorrectly because we
incorrectly match the `.local` up with `.cluster.local`

Fixes https://github.com/istio/istio/issues/35676