### PR TITLE
Add check against admission webhooks installed in helm integration tests

### DIFF
--- a/pkg/test/kube/util.go
+++ b/pkg/test/kube/util.go
@@ -255,9 +255,30 @@ func newRetryOptions(opts ...retry.Option) []retry.Option {
 	return out
 }
 
-// MutatingWebhookConfigurationsExists returns true if all of the given mutating webhook configs exist.
+// MutatingWebhookConfigurationsExists returns true if all the given mutating webhook configs exist.
 func MutatingWebhookConfigurationsExists(a kubernetes.Interface, names []string) bool {
 	cfgs, err := a.AdmissionregistrationV1().MutatingWebhookConfigurations().List(context.TODO(), kubeApiMeta.ListOptions{})
+	if err != nil {
+		return false
+	}
+
+	if len(cfgs.Items) != len(names) {
+		return false
+	}
+
+	sort.Strings(names)
+	for _, cfg := range cfgs.Items {
+		if idx := sort.SearchStrings(names, cfg.Name); idx == len(names) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// ValidatingWebhookConfigurationsExists returns true if all the given validating webhook configs exist.
+func ValidatingWebhookConfigurationsExists(a kubernetes.Interface, names []string) bool {
+	cfgs, err := a.AdmissionregistrationV1().ValidatingWebhookConfigurations().List(context.TODO(), kubeApiMeta.ListOptions{})
 	if err != nil {
 		return false
 	}

--- a/tests/integration/helm/util.go
+++ b/tests/integration/helm/util.go
@@ -231,6 +231,16 @@ func VerifyMutatingWebhookConfigurations(ctx framework.TestContext, cs cluster.C
 	scopes.Framework.Infof("=== succeeded ===")
 }
 
+// ValidatingWebhookConfigurations verifies that the proper number of validating webhooks are running, used with
+// revisions and revision tags
+func ValidatingWebhookConfigurations(ctx framework.TestContext, cs cluster.Cluster, names []string) {
+	scopes.Framework.Infof("=== verifying validating webhook configurations === ")
+	if ok := kubetest.ValidatingWebhookConfigurationsExists(cs, names); !ok {
+		ctx.Fatalf("Not all validating webhook configurations were installed. Expected [%v]", names)
+	}
+	scopes.Framework.Infof("=== succeeded ===")
+}
+
 // VerifyValidation verifies that Istio resource validation is active on the cluster.
 func VerifyValidation(ctx framework.TestContext) {
 	ctx.Helper()


### PR DESCRIPTION
**Please provide a description of this PR:**

Check that the MutatingWebhooks and ValidatingWebhooks are installed as expected for in-place, revision and revision tags.

I will later add an integration test that works when changing the validation webhook.