### PR TITLE
fixed issue# 34966 to add IPv6 addresses in virtual host routes on single stack IPv6

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -469,11 +469,7 @@ func generateVirtualHostDomains(service *model.Service, port int, node *model.Pr
 
 	svcAddr := service.GetAddressForProxy(node)
 	if len(svcAddr) > 0 && svcAddr != constants.UnspecifiedIP {
-		// add a vhost match for the IP (if its non CIDR)
-		cidr := util.ConvertAddressToCidr(svcAddr)
-		if cidr.PrefixLen.Value == 32 {
-			domains = append(domains, svcAddr, util.DomainName(svcAddr, port))
-		}
+		domains = append(domains, util.IPv6Compliant(svcAddr), util.DomainName(svcAddr, port))
 	}
 	return domains, altHosts
 }


### PR DESCRIPTION
fixed issue #34966 to add IPv6 addresses in virtual host routes on single stack IPv6

**Please provide a description of this PR:**