### PR TITLE
Import from k8s.io/utils/clock instead

### DIFF
--- a/pilot/pkg/leaderelection/k8sleaderelection/healthzadaptor_test.go
+++ b/pilot/pkg/leaderelection/k8sleaderelection/healthzadaptor_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/apimachinery/pkg/util/clock"
+	testingclock "k8s.io/utils/clock/testing"
 
 	rl "istio.io/istio/pilot/pkg/leaderelection/k8sleaderelection/k8sresourcelock"
 )
@@ -97,7 +97,7 @@ func TestLeaderElectionHealthChecker(t *testing.T) {
 					HolderIdentity: "healthTest",
 				},
 				observedTime: current,
-				clock:        clock.NewFakeClock(current.Add(time.Hour)),
+				clock:        testingclock.NewFakeClock(current.Add(time.Hour)),
 			},
 		},
 		{
@@ -114,7 +114,7 @@ func TestLeaderElectionHealthChecker(t *testing.T) {
 					HolderIdentity: "otherServer",
 				},
 				observedTime: current,
-				clock:        clock.NewFakeClock(current.Add(time.Hour)),
+				clock:        testingclock.NewFakeClock(current.Add(time.Hour)),
 			},
 		},
 		{
@@ -131,7 +131,7 @@ func TestLeaderElectionHealthChecker(t *testing.T) {
 					HolderIdentity: "healthTest",
 				},
 				observedTime: current,
-				clock:        clock.NewFakeClock(current),
+				clock:        testingclock.NewFakeClock(current),
 			},
 		},
 		{
@@ -148,7 +148,7 @@ func TestLeaderElectionHealthChecker(t *testing.T) {
 					HolderIdentity: "healthTest",
 				},
 				observedTime: current,
-				clock:        clock.NewFakeClock(current.Add(time.Minute).Add(time.Second)),
+				clock:        testingclock.NewFakeClock(current.Add(time.Minute).Add(time.Second)),
 			},
 		},
 	}

--- a/pilot/pkg/leaderelection/k8sleaderelection/leaderelection.go
+++ b/pilot/pkg/leaderelection/k8sleaderelection/leaderelection.go
@@ -61,10 +61,10 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/clock"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/clock"
 
 	"istio.io/istio/pilot/pkg/leaderelection/k8sleaderelection/k8sresourcelock"
 )

--- a/pilot/pkg/leaderelection/k8sleaderelection/leaderelection_test.go
+++ b/pilot/pkg/leaderelection/k8sleaderelection/leaderelection_test.go
@@ -30,11 +30,11 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/clock"
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/client-go/kubernetes/fake"
 	fakeclient "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/clock"
 
 	rl "istio.io/istio/pilot/pkg/leaderelection/k8sleaderelection/k8sresourcelock"
 )


### PR DESCRIPTION
**Please provide a description of this PR:**

Change import path to `k8s.io/utils/clock `

Due to [kubernetes/kubernetes#94738](https://github.com/kubernetes/kubernetes/issues/94738)
