### PR TITLE
Fixing invalid target for  k8s cert generation makefile

### DIFF
--- a/tools/certs/Makefile.k8s.mk
+++ b/tools/certs/Makefile.k8s.mk
@@ -75,7 +75,7 @@ k8s-root-key.pem:
 ##<namespace>-certs: generate intermediate certificates and sign certificates for a virtual machine connected to the namespace `<namespace> using serviceAccount `$SERVICE_ACCOUNT` using root cert from k8s cluster.
 .PHONY: %-certs
 
-%-certs: %/workload-cert-chain.pem k8s-root-cert.pem
+%-certs: fetch-root-ca %/workload-cert-chain.pem k8s-root-cert.pem
 	@echo "done"
 
 %/workload-cert-chain.pem: k8s-root-cert.pem %/ca-cert.pem %/workload-cert.pem
@@ -91,3 +91,12 @@ k8s-root-key.pem:
 		-extensions req_ext -extfile $(dir $<)/workload.conf \
 		-in $< -out $@
 
+%/workload.csr: L=$(dir $@)
+%/workload.csr: %/key.pem %/workload.conf
+	@echo "generating $@"
+	@openssl req -new -config $(L)/workload.conf -key $< -out $@
+
+%/key.pem:
+	@echo "generating $@"
+	@mkdir -p $(dir $@)
+	@openssl genrsa -out $@ 4096

--- a/tools/certs/Makefile.k8s.mk
+++ b/tools/certs/Makefile.k8s.mk
@@ -54,10 +54,10 @@ k8s-root-key.pem:
 	@echo "Intermediate certs stored in $(dir $<)"
 	@cp k8s-root-cert.pem $(dir $<)/root-cert.pem
 
-%/ca-cert.pem: %/cluster-ca.csr root-key.pem k8s-root-cert.pem
+%/ca-cert.pem: %/cluster-ca.csr k8s-root-key.pem k8s-root-cert.pem
 	@echo "generating $@"
 	@openssl x509 -req -days $(INTERMEDIATE_DAYS) \
-		-CA k8s-root-cert.pem -CAkey root-key.pem -CAcreateserial\
+		-CA k8s-root-cert.pem -CAkey k8s-root-key.pem -CAcreateserial\
 		-extensions req_ext -extfile $(dir $<)/intermediate.conf \
 		-in $< -out $@
 


### PR DESCRIPTION
**Please provide a description of this PR:**

There was an issue with the Makefile for the k8s cert generations using an already deployed CA cert flow. It had an invalid target location that was not changed from the self-signed flow. It was changed to use the proper root certificate pulled from the cluster.


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
