### PR TITLE
update Kiali addon to v1.42

### DIFF
--- a/manifests/addons/gen.sh
+++ b/manifests/addons/gen.sh
@@ -30,7 +30,7 @@ TMP=$(mktemp -d)
 {
 helm3 template kiali-server \
   --namespace istio-system \
-  --version 1.40.0 \
+  --version 1.42.0 \
   --include-crds \
   --set nameOverride=kiali \
   --set fullnameOverride=kiali \

--- a/manifests/addons/values-kiali.yaml
+++ b/manifests/addons/values-kiali.yaml
@@ -6,7 +6,7 @@ deployment:
     sidecar.istio.io/inject: "false"
   accessible_namespaces:
   - '**'
-  image_version: v1.38
+  image_version: v1.42
   ingress_enabled: false
 login_token:
   signing_key: CHANGEME

--- a/samples/addons/kiali.yaml
+++ b/samples/addons/kiali.yaml
@@ -6,12 +6,12 @@ metadata:
   name: kiali
   namespace: istio-system
   labels:
-    helm.sh/chart: kiali-server-1.40.0
+    helm.sh/chart: kiali-server-1.42.0
     app: kiali
     app.kubernetes.io/name: kiali
     app.kubernetes.io/instance: kiali
-    version: "v1.40.0"
-    app.kubernetes.io/version: "v1.40.0"
+    version: "v1.42.0"
+    app.kubernetes.io/version: "v1.42.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: "kiali"
 ...
@@ -23,12 +23,12 @@ metadata:
   name: kiali
   namespace: istio-system
   labels:
-    helm.sh/chart: kiali-server-1.40.0
+    helm.sh/chart: kiali-server-1.42.0
     app: kiali
     app.kubernetes.io/name: kiali
     app.kubernetes.io/instance: kiali
-    version: "v1.40.0"
-    app.kubernetes.io/version: "v1.40.0"
+    version: "v1.42.0"
+    app.kubernetes.io/version: "v1.42.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: "kiali"
 data:
@@ -46,13 +46,15 @@ data:
         node: {}
         pod: {}
         pod_anti: {}
+      host_aliases: []
       hpa:
         api_version: autoscaling/v2beta2
         spec: {}
+      image_digest: ""
       image_name: quay.io/kiali/kiali
       image_pull_policy: Always
       image_pull_secrets: []
-      image_version: v1.38
+      image_version: v1.42
       ingress_enabled: false
       instance_name: kiali
       logger:
@@ -74,7 +76,7 @@ data:
       service_annotations: {}
       service_type: ""
       tolerations: []
-      version_label: v1.40.0
+      version_label: v1.42.0
       view_only_mode: false
     external_services:
       custom_dashboards:
@@ -106,12 +108,12 @@ kind: ClusterRole
 metadata:
   name: kiali-viewer
   labels:
-    helm.sh/chart: kiali-server-1.40.0
+    helm.sh/chart: kiali-server-1.42.0
     app: kiali
     app.kubernetes.io/name: kiali
     app.kubernetes.io/instance: kiali
-    version: "v1.40.0"
-    app.kubernetes.io/version: "v1.40.0"
+    version: "v1.42.0"
+    app.kubernetes.io/version: "v1.42.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: "kiali"
 rules:
@@ -203,12 +205,12 @@ kind: ClusterRole
 metadata:
   name: kiali
   labels:
-    helm.sh/chart: kiali-server-1.40.0
+    helm.sh/chart: kiali-server-1.42.0
     app: kiali
     app.kubernetes.io/name: kiali
     app.kubernetes.io/instance: kiali
-    version: "v1.40.0"
-    app.kubernetes.io/version: "v1.40.0"
+    version: "v1.42.0"
+    app.kubernetes.io/version: "v1.42.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: "kiali"
 rules:
@@ -310,12 +312,12 @@ kind: ClusterRoleBinding
 metadata:
   name: kiali
   labels:
-    helm.sh/chart: kiali-server-1.40.0
+    helm.sh/chart: kiali-server-1.42.0
     app: kiali
     app.kubernetes.io/name: kiali
     app.kubernetes.io/instance: kiali
-    version: "v1.40.0"
-    app.kubernetes.io/version: "v1.40.0"
+    version: "v1.42.0"
+    app.kubernetes.io/version: "v1.42.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: "kiali"
 roleRef:
@@ -335,12 +337,12 @@ metadata:
   name: kiali-controlplane
   namespace: istio-system
   labels:
-    helm.sh/chart: kiali-server-1.40.0
+    helm.sh/chart: kiali-server-1.42.0
     app: kiali
     app.kubernetes.io/name: kiali
     app.kubernetes.io/instance: kiali
-    version: "v1.40.0"
-    app.kubernetes.io/version: "v1.40.0"
+    version: "v1.42.0"
+    app.kubernetes.io/version: "v1.42.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: "kiali"
 rules:
@@ -368,12 +370,12 @@ metadata:
   name: kiali-controlplane
   namespace: istio-system
   labels:
-    helm.sh/chart: kiali-server-1.40.0
+    helm.sh/chart: kiali-server-1.42.0
     app: kiali
     app.kubernetes.io/name: kiali
     app.kubernetes.io/instance: kiali
-    version: "v1.40.0"
-    app.kubernetes.io/version: "v1.40.0"
+    version: "v1.42.0"
+    app.kubernetes.io/version: "v1.42.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: "kiali"
 roleRef:
@@ -393,12 +395,12 @@ metadata:
   name: kiali
   namespace: istio-system
   labels:
-    helm.sh/chart: kiali-server-1.40.0
+    helm.sh/chart: kiali-server-1.42.0
     app: kiali
     app.kubernetes.io/name: kiali
     app.kubernetes.io/instance: kiali
-    version: "v1.40.0"
-    app.kubernetes.io/version: "v1.40.0"
+    version: "v1.42.0"
+    app.kubernetes.io/version: "v1.42.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: "kiali"
   annotations:
@@ -422,12 +424,12 @@ metadata:
   name: kiali
   namespace: istio-system
   labels:
-    helm.sh/chart: kiali-server-1.40.0
+    helm.sh/chart: kiali-server-1.42.0
     app: kiali
     app.kubernetes.io/name: kiali
     app.kubernetes.io/instance: kiali
-    version: "v1.40.0"
-    app.kubernetes.io/version: "v1.40.0"
+    version: "v1.42.0"
+    app.kubernetes.io/version: "v1.42.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: "kiali"
 spec:
@@ -445,23 +447,24 @@ spec:
     metadata:
       name: kiali
       labels:
-        helm.sh/chart: kiali-server-1.40.0
+        helm.sh/chart: kiali-server-1.42.0
         app: kiali
         app.kubernetes.io/name: kiali
         app.kubernetes.io/instance: kiali
-        version: "v1.40.0"
-        app.kubernetes.io/version: "v1.40.0"
+        version: "v1.42.0"
+        app.kubernetes.io/version: "v1.42.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: "kiali"
         sidecar.istio.io/inject: "false"
       annotations:
+        checksum/config: b31bec684f9bd4f948204b8c379ba871227a4193ddf6066efa3dc4cb19d3ae13
         prometheus.io/scrape: "true"
         prometheus.io/port: "9090"
         kiali.io/dashboards: go,kiali
     spec:
       serviceAccountName: kiali
       containers:
-      - image: "quay.io/kiali/kiali:v1.38"
+      - image: "quay.io/kiali/kiali:v1.42"
         imagePullPolicy: Always
         name: kiali
         command:


### PR DESCRIPTION
Updates the Kiali addon to the latest v1.42 release. This is intended to be the Kiali release for Istio 1.12.

cc @howardjohn 