### PR TITLE
Avoid canonicalizing headers in echo client

### DIFF
--- a/pkg/test/echo/common/util.go
+++ b/pkg/test/echo/common/util.go
@@ -61,7 +61,8 @@ func GetCount(request *proto.ForwardEchoRequest) int {
 func GetHeaders(request *proto.ForwardEchoRequest) http.Header {
 	headers := make(http.Header)
 	for _, h := range request.Headers {
-		headers.Add(h.Key, h.Value)
+		// Avoid using .Add() to allow users to pass non-canonical forms
+		headers[h.Key] = append(headers[h.Key], h.Value)
 	}
 	return headers
 }

--- a/pkg/test/echo/server/endpoint/http.go
+++ b/pkg/test/echo/server/endpoint/http.go
@@ -373,7 +373,8 @@ func setHeaderResponseFromHeaders(request *http.Request, response http.ResponseW
 		}
 		name := parts[0]
 		value := parts[1]
-		response.Header().Set(name, value)
+		// Avoid using .Set() to allow users to pass non-canonical forms
+		response.Header()[name] = []string{value}
 	}
 	return nil
 }

--- a/pkg/test/echo/server/forwarder/http.go
+++ b/pkg/test/echo/server/forwarder/http.go
@@ -105,7 +105,8 @@ func (c *httpProtocol) makeRequest(ctx context.Context, req *request) (string, e
 		if key == hostHeader {
 			host = value
 		} else {
-			httpReq.Header.Add(key, value)
+			// Avoid using .Add() to allow users to pass non-canonical forms
+			httpReq.Header[key] = append(httpReq.Header[key], value)
 		}
 	})
 

--- a/pkg/test/echo/server/forwarder/util.go
+++ b/pkg/test/echo/server/forwarder/util.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"fmt"
 	"net/http"
-	"net/textproto"
 
 	"istio.io/pkg/log"
 )
@@ -31,7 +30,6 @@ var fwLog = log.RegisterScope("forwarder", "echo clientside", 0)
 
 func writeHeaders(requestID int, header http.Header, outBuffer bytes.Buffer, addFn func(string, string)) {
 	for key, values := range header {
-		key = textproto.CanonicalMIMEHeaderKey(key)
 		for _, v := range values {
 			addFn(key, v)
 			if key == hostHeader {


### PR DESCRIPTION
Currently echo client has been designed to allow doing things that are
non-standard to allow testing non-standard scenarios. For example, we do
not normalize the URL.

This applies to same logic to headers to allow arbitrary header casing,
etc.

**Please provide a description of this PR:**