### PR TITLE
Allow file-mounted-cert to authenticate XDS server with non metadata certificates

### DIFF
--- a/pkg/istio-agent/agent.go
+++ b/pkg/istio-agent/agent.go
@@ -564,8 +564,8 @@ func (a *Agent) FindRootCAForXDS() (string, error) {
 		// For VMs, the root cert file used to auth may be populated afterwards.
 		// Thus, return directly here and skip checking for existence.
 		return a.secOpts.ProvCert + "/root-cert.pem", nil
-	} else if a.secOpts.FileMountedCerts {
-		// FileMountedCerts - Load it from Proxy Metadata.
+	} else if a.secOpts.FileMountedCerts && a.proxyConfig.ProxyMetadata[MetadataClientRootCert] != "" {
+		// FileMountedCerts - Load it from Proxy Metadata if MetadataClientRootCert is configured.
 		rootCAPath = a.proxyConfig.ProxyMetadata[MetadataClientRootCert]
 	} else if a.secOpts.PilotCertProvider == constants.CertProviderNone {
 		return "", fmt.Errorf("root CA file for XDS required but configured provider as none")


### PR DESCRIPTION
**Please provide a description of this PR:**
https://github.com/istio/istio/issues/35385

This PR allows file-mounted-cert to configure the root CA path for authenticating XDS server, instead of only using the cert path in the metadata ISTIO_META_TLS_CLIENT_ROOT_CERT:
- When ISTIO_META_TLS_CLIENT_ROOT_CERT is non-empty, the root CA path for authenticating XDS server will be based on ISTIO_META_TLS_CLIENT_ROOT_CERT.
- Otherwise, the root CA path for authenticating XDS server will be based on PilotCertProvider and other factors.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [X ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [X ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
