### PR TITLE
disable clearRouteCache on sidecars for JWT claim based routing

### DIFF
--- a/pilot/pkg/networking/plugin/authn/authentication.go
+++ b/pilot/pkg/networking/plugin/authn/authentication.go
@@ -60,15 +60,14 @@ func (Plugin) OnInboundListener(in *plugin.InputParams, mutable *networking.Muta
 func buildFilter(in *plugin.InputParams, mutable *networking.MutableObjects) error {
 	ns := in.Node.Metadata.Namespace
 	applier := factory.NewPolicyApplier(in.Push, ns, labels.Collection{in.Node.Metadata.Labels})
-
+	forSidecar := in.Node.Type == model.SidecarProxy
 	for i := range mutable.FilterChains {
 		if mutable.FilterChains[i].ListenerProtocol == networking.ListenerProtocolHTTP {
 			// Adding Jwt filter and authn filter, if needed.
 			if filter := applier.JwtFilter(); filter != nil {
 				mutable.FilterChains[i].HTTP = append(mutable.FilterChains[i].HTTP, filter)
 			}
-			// TODO(yangminzhu): Set DisableClearRouteCache to true on sidecars.
-			if filter := applier.AuthNFilter(); filter != nil {
+			if filter := applier.AuthNFilter(forSidecar); filter != nil {
 				mutable.FilterChains[i].HTTP = append(mutable.FilterChains[i].HTTP, filter)
 			}
 		}

--- a/pilot/pkg/security/authn/policy_applier.go
+++ b/pilot/pkg/security/authn/policy_applier.go
@@ -34,7 +34,7 @@ type PolicyApplier interface {
 
 	// AuthNFilter returns the (authn) HTTP filter to enforce the underlying authentication policy.
 	// It may return nil, if no authentication is needed.
-	AuthNFilter() *http_conn.HttpFilter
+	AuthNFilter(forSidecar bool) *http_conn.HttpFilter
 
 	// PortLevelSetting returns port level mTLS settings.
 	PortLevelSetting() map[uint32]*v1beta1.PeerAuthentication_MutualTLS

--- a/pilot/pkg/security/authn/v1beta1/policy_applier.go
+++ b/pilot/pkg/security/authn/v1beta1/policy_applier.go
@@ -121,7 +121,7 @@ func (a *v1beta1PolicyApplier) setAuthnFilterForRequestAuthn(config *authn_filte
 // AuthNFilter returns the Istio authn filter config:
 // - If RequestAuthentication is used, it overwrite the settings for request principal validation and extraction based on the new API.
 // - If RequestAuthentication is used, principal binding is always set to ORIGIN.
-func (a *v1beta1PolicyApplier) AuthNFilter() *http_conn.HttpFilter {
+func (a *v1beta1PolicyApplier) AuthNFilter(forSidecar bool) *http_conn.HttpFilter {
 	var filterConfigProto *authn_filter.FilterConfig
 
 	// Override the config with request authentication, if applicable.
@@ -130,6 +130,8 @@ func (a *v1beta1PolicyApplier) AuthNFilter() *http_conn.HttpFilter {
 	if filterConfigProto == nil {
 		return nil
 	}
+	// disable clear route cache for sidecars because the JWT claim based routing is only supported on gateways.
+	filterConfigProto.DisableClearRouteCache = forSidecar
 
 	// Note: in previous Istio versions, the authn filter also handled PeerAuthentication, to extract principal.
 	// This has been modified to rely on the TCP filter


### PR DESCRIPTION
**Please provide a description of this PR:**
The JWT claim based routing only supports gateways, we can disable this flag on sidecars to avoid potential (small) performance overhead.