### PR TITLE
change iptables probe port to string

### DIFF
--- a/pilot/cmd/pilot-agent/status/grpcready/probe.go
+++ b/pilot/cmd/pilot-agent/status/grpcready/probe.go
@@ -38,7 +38,7 @@ func NewProbe(bootstrapPath string) ready.Prober {
 }
 
 func (p *probe) Check() error {
-	// TODO file watcH?
+	// TODO file watch?
 	if p.getBootstrap() == nil {
 		bootstrap, err := grpcxds.LoadBootstrap(p.bootstrapPath)
 		if err != nil {

--- a/pilot/cmd/pilot-agent/status/ready/probe.go
+++ b/pilot/cmd/pilot-agent/status/ready/probe.go
@@ -100,11 +100,11 @@ func (p *Probe) isEnvoyReady() error {
 }
 
 func (p *Probe) checkEnvoyReadiness() error {
-	// If Envoy is ready atleast once i.e. server state is LIVE and workers
+	// If Envoy is ready at least once i.e. server state is LIVE and workers
 	// have started, they will not go back in the life time of Envoy process.
-	// They will only change at hot restart or health check fails. Since Istio
+	// They will only change at hot restart or health check fails. Since istio
 	// does not use both of them, it is safe to cache this value. Since the
-	// actual readiness probe goes via Envoy it ensures that Envoy is actively
+	// actual readiness probe goes via Envoy, it ensures that Envoy is actively
 	// serving traffic and we can rely on that.
 	if p.atleastOnceReady {
 		return nil

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -357,7 +357,7 @@ var (
 		"If this is set to false, the debug interface will not be ebabled on Http, recommended for production").Get()
 
 	EnableUnsafeAdminEndpoints = env.RegisterBoolVar("UNSAFE_ENABLE_ADMIN_ENDPOINTS", false,
-		"If this is set to true, dangerous admin endpoins will be exposed on the debug interface. Not recommended for production.").Get()
+		"If this is set to true, dangerous admin endpoints will be exposed on the debug interface. Not recommended for production.").Get()
 
 	XDSAuth = env.RegisterBoolVar("XDS_AUTH", true,
 		"If true, will authenticate XDS clients.").Get()

--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -460,7 +460,7 @@ type MetadataOptions struct {
 
 // GetNodeMetaData function uses an environment variable contract
 // ISTIO_METAJSON_* env variables contain json_string in the value.
-// 					The name of variable is ignored.
+// The name of variable is ignored.
 // ISTIO_META_* env variables are passed thru
 func GetNodeMetaData(options MetadataOptions) (*model.Node, error) {
 	meta := &model.BootstrapNodeMetadata{}
@@ -658,7 +658,6 @@ func ParseDownwardAPI(i string) (map[string]string, error) {
 		}
 		key := sl[0]
 		// Strip the leading/trailing quotes
-
 		val, err := strconv.Unquote(sl[1])
 		if err != nil {
 			return nil, fmt.Errorf("failed to unquote %v: %v", sl[1], err)

--- a/tools/istio-iptables/pkg/cmd/root.go
+++ b/tools/istio-iptables/pkg/cmd/root.go
@@ -19,7 +19,6 @@ import (
 	"net"
 	"os"
 	"os/user"
-	"strconv"
 	"strings"
 
 	"github.com/miekg/dns"
@@ -282,7 +281,7 @@ func bindFlags(cmd *cobra.Command, args []string) {
 	if err := viper.BindPFlag(constants.IptablesProbePort, cmd.Flags().Lookup(constants.IptablesProbePort)); err != nil {
 		handleError(err)
 	}
-	viper.SetDefault(constants.IptablesProbePort, strconv.Itoa(constants.DefaultIptablesProbePort))
+	viper.SetDefault(constants.IptablesProbePort, constants.DefaultIptablesProbePort)
 
 	if err := viper.BindPFlag(constants.ProbeTimeout, cmd.Flags().Lookup(constants.ProbeTimeout)); err != nil {
 		handleError(err)
@@ -384,7 +383,7 @@ func init() {
 
 	rootCmd.Flags().BoolP(constants.RestoreFormat, "f", true, "Print iptables rules in iptables-restore interpretable format")
 
-	rootCmd.Flags().String(constants.IptablesProbePort, strconv.Itoa(constants.DefaultIptablesProbePort), "set listen port for failure detection")
+	rootCmd.Flags().String(constants.IptablesProbePort, constants.DefaultIptablesProbePort, "set listen port for failure detection")
 
 	rootCmd.Flags().Duration(constants.ProbeTimeout, constants.DefaultProbeTimeout, "failure detection timeout")
 

--- a/tools/istio-iptables/pkg/constants/constants.go
+++ b/tools/istio-iptables/pkg/constants/constants.go
@@ -133,7 +133,7 @@ const (
 )
 
 const (
-	DefaultIptablesProbePort = 15002
+	DefaultIptablesProbePort = "15002"
 	DefaultProbeTimeout      = 5 * time.Second
 )
 


### PR DESCRIPTION
1. Change port from int to string.
2. Fix some typo.


~~3. Fix grpc xds port . 15012 port is grpc xds port, instead of https-dns.~~

```bash
# kubectl -n istio-system get istiod -oyaml
...
  - name: https-dns
    port: 15012
    protocol: TCP
```

~~Reference this [doc](https://istio.io/latest/docs/ops/deployment/requirements/#ports-used-by-istio) to verify the port.~~

~~So I think the port name should be changed to `grpc-xds`~~

Signed-off-by: zackzhangkai <zhangkaiamm@gmail.com>
