### PR TITLE
Fix `make push` and `make dockerx.push`

### DIFF
--- a/tools/istio-docker.mk
+++ b/tools/istio-docker.mk
@@ -365,7 +365,7 @@ docker.save: dockerx.save
 # the local docker image to another hub
 # a possible optimization is to use tag.$(TGT) as a dependency to do the tag for us
 $(foreach TGT,$(DOCKER_TARGETS),$(eval push.$(TGT): | $(TGT) ; \
-	time (set -e && for distro in $(DOCKER_BUILD_VARIANTS); do tag=$(TAG)-$$$${distro}; docker push $(HUB)/$(subst docker.,,$(TGT)):$$$${tag%-$(DEFAULT_DISTRIBUTION)}; done)))
+	time (set -e && for distro in $(DOCKER_BUILD_VARIANTS); do tag=$(TAG)-$$$${distro}; docker push $(HUB)/$(subst docker.,,$(TGT)):$$$${tag%-default}; done)))
 
 define run_vulnerability_scanning
         $(eval RESULTS_DIR := vulnerability_scan_results)
@@ -383,7 +383,7 @@ docker.push: $(DOCKER_PUSH_TARGETS)
 # Build and push docker images using dockerx
 dockerx.push: dockerx
 	$(foreach TGT,$(DOCKER_TARGETS), time ( \
-		set -e && for distro in $(DOCKER_BUILD_VARIANTS); do tag=$(TAG)-$${distro}; docker push $(HUB)/$(subst docker.,,$(TGT)):$${tag%-$(DEFAULT_DISTRIBUTION)}; done); \
+		set -e && for distro in $(DOCKER_BUILD_VARIANTS); do tag=$(TAG)-$${distro}; docker push $(HUB)/$(subst docker.,,$(TGT)):$${tag%-default}; done); \
 	)
 
 # Build and push docker images using dockerx. Pushing is done inline as an optimization


### PR DESCRIPTION
**Please provide a description of this PR:**

Fixes https://github.com/istio/istio/issues/35737

The failure with `make push` and `make docker.pushx` is that the Makefile was trying to remove **DEFAULT_DISTRIBUTION** from the image name, and this was recently changed to **debug**. I talked with @howardjohn and the design was to have the behavior remain the same as before the **debug** related changes, so we want to continue to remove **-default** if it was present, thus the change was to not remove **DEFAULT_DISTRIBUTION**, but to remove **-default** for those two targets.

I did verify that the two commands no longer fail trying to push _image_-debug and do push _image_.