### PR TITLE
Add support for recursive file watch to pilot

### DIFF
--- a/pilot/pkg/config/monitor/file_snapshot.go
+++ b/pilot/pkg/config/monitor/file_snapshot.go
@@ -23,7 +23,6 @@ import (
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/collection"
 	"istio.io/istio/pkg/config/schema/collections"
-	"istio.io/pkg/log"
 )
 
 var supportedExtensions = map[string]bool{


### PR DESCRIPTION
This is useful when users are trying to aggregate multiple sources into
a single folder to watch all of them. For example, mount multiple
configmaps to a common parent directory.

**Please provide a description of this PR:**