### PR TITLE
Wait for cache sync before proceeding with leader election

### DIFF
--- a/pilot/pkg/leaderelection/leaderelection.go
+++ b/pilot/pkg/leaderelection/leaderelection.go
@@ -24,7 +24,6 @@ import (
 	"go.uber.org/atomic"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/cache"
 
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/leaderelection/k8sleaderelection"
@@ -77,9 +76,6 @@ type LeaderElection struct {
 // Run will start leader election, calling all runFns when we become the leader.
 func (l *LeaderElection) Run(stop <-chan struct{}) {
 	go l.defaultWatcher.Run(stop)
-	if !cache.WaitForCacheSync(stop, l.defaultWatcher.HasSynced) {
-		log.Errorf("could not sync cache for default watcher in leader election %s", l.electionID)
-	}
 	for {
 		le, err := l.create()
 		if err != nil {

--- a/pilot/pkg/leaderelection/leaderelection_test.go
+++ b/pilot/pkg/leaderelection/leaderelection_test.go
@@ -74,6 +74,9 @@ func (w *fakeDefaultWatcher) setDefaultRevision(r string) {
 	w.defaultRevision = r
 }
 
+func (w *fakeDefaultWatcher) Run(stop <-chan struct{}) {
+}
+
 func (w *fakeDefaultWatcher) HasSynced() bool {
 	return true
 }

--- a/pilot/pkg/leaderelection/leaderelection_test.go
+++ b/pilot/pkg/leaderelection/leaderelection_test.go
@@ -74,7 +74,8 @@ func (w *fakeDefaultWatcher) setDefaultRevision(r string) {
 	w.defaultRevision = r
 }
 
-func (w *fakeDefaultWatcher) Run(stop <-chan struct{}) {
+func (w *fakeDefaultWatcher) HasSynced() bool {
+	return true
 }
 
 func (w *fakeDefaultWatcher) GetDefault() string {

--- a/pilot/pkg/leaderelection/leaderelection_test.go
+++ b/pilot/pkg/leaderelection/leaderelection_test.go
@@ -74,6 +74,9 @@ func (w *fakeDefaultWatcher) setDefaultRevision(r string) {
 	w.defaultRevision = r
 }
 
+func (w *fakeDefaultWatcher) Run(stop <-chan struct{}) {
+}
+
 func (w *fakeDefaultWatcher) GetDefault() string {
 	return w.defaultRevision
 }

--- a/pkg/revisions/default_watcher.go
+++ b/pkg/revisions/default_watcher.go
@@ -32,7 +32,7 @@ const (
 // DefaultWatcher keeps track of the current default revision and can notify watchers
 // when the default revision changes.
 type DefaultWatcher interface {
-	Run(stop <-chan struct{})
+	HasSynced() bool
 	GetDefault() string
 	AddHandler(handler DefaultHandler)
 }
@@ -44,6 +44,7 @@ type defaultWatcher struct {
 	revision        string
 	defaultRevision string
 	handlers        []DefaultHandler
+
 	webhookInformer cache.SharedInformer
 	mu              sync.Mutex
 }
@@ -59,8 +60,8 @@ func NewDefaultWatcher(client kube.Client, revision string) DefaultWatcher {
 	return p
 }
 
-func (p *defaultWatcher) Run(stop <-chan struct{}) {
-	cache.WaitForCacheSync(stop, p.webhookInformer.HasSynced)
+func (p *defaultWatcher) HasSynced() bool {
+	return p.webhookInformer.HasSynced()
 }
 
 func (p *defaultWatcher) makeHandler() *cache.ResourceEventHandlerFuncs {

--- a/pkg/revisions/default_watcher.go
+++ b/pkg/revisions/default_watcher.go
@@ -32,6 +32,7 @@ const (
 // DefaultWatcher keeps track of the current default revision and can notify watchers
 // when the default revision changes.
 type DefaultWatcher interface {
+	Run(stop <-chan struct{})
 	GetDefault() string
 	AddHandler(handler DefaultHandler)
 }
@@ -56,6 +57,10 @@ func NewDefaultWatcher(client kube.Client, revision string) DefaultWatcher {
 	p.webhookInformer.AddEventHandler(p.makeHandler())
 
 	return p
+}
+
+func (p *defaultWatcher) Run(stop <-chan struct{}) {
+	cache.WaitForCacheSync(stop, p.webhookInformer.HasSynced)
 }
 
 func (p *defaultWatcher) makeHandler() *cache.ResourceEventHandlerFuncs {

--- a/pkg/revisions/default_watcher.go
+++ b/pkg/revisions/default_watcher.go
@@ -16,22 +16,30 @@ package revisions
 
 import (
 	"sync"
+	"time"
 
+	"go.uber.org/atomic"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
 
 	"istio.io/api/label"
 	"istio.io/istio/pkg/kube"
+	"istio.io/pkg/log"
 )
 
 const (
 	defaultTagWebhookName = "istio-revision-tag-default"
+	initSignal            = "INIT"
 )
 
 // DefaultWatcher keeps track of the current default revision and can notify watchers
 // when the default revision changes.
 type DefaultWatcher interface {
+	Run(stopCh <-chan struct{})
 	HasSynced() bool
 	GetDefault() string
 	AddHandler(handler DefaultHandler)
@@ -45,14 +53,18 @@ type defaultWatcher struct {
 	defaultRevision string
 	handlers        []DefaultHandler
 
+	queue           workqueue.RateLimitingInterface
 	webhookInformer cache.SharedInformer
-	mu              sync.Mutex
+	initialSync     *atomic.Bool
+	mu              sync.RWMutex
 }
 
 func NewDefaultWatcher(client kube.Client, revision string) DefaultWatcher {
 	p := &defaultWatcher{
-		revision: revision,
-		mu:       sync.Mutex{},
+		revision:    revision,
+		queue:       workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+		initialSync: atomic.NewBool(false),
+		mu:          sync.RWMutex{},
 	}
 	p.webhookInformer = client.KubeInformer().Admissionregistration().V1().MutatingWebhookConfigurations().Informer()
 	p.webhookInformer.AddEventHandler(p.makeHandler())
@@ -60,8 +72,56 @@ func NewDefaultWatcher(client kube.Client, revision string) DefaultWatcher {
 	return p
 }
 
+func (p *defaultWatcher) Run(stopCh <-chan struct{}) {
+	defer utilruntime.HandleCrash()
+	defer p.queue.ShutDown()
+	if !kube.WaitForCacheSyncInterval(stopCh, time.Second, p.webhookInformer.HasSynced) {
+		log.Errorf("failed to sync default watcher")
+		return
+	}
+	p.queue.Add(initSignal)
+	go wait.Until(p.runQueue, time.Second, stopCh)
+	<-stopCh
+}
+
+// GetDefault returns the current default revision.
+func (p *defaultWatcher) GetDefault() string {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.defaultRevision
+}
+
+// AddHandler registers a new handler for updates to default revision changes.
+func (p *defaultWatcher) AddHandler(handler DefaultHandler) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.handlers = append(p.handlers, handler)
+}
+
 func (p *defaultWatcher) HasSynced() bool {
-	return p.webhookInformer.HasSynced()
+	return p.initialSync.Load()
+}
+
+func (p *defaultWatcher) runQueue() {
+	for p.processNextItem() {
+	}
+}
+
+func (p *defaultWatcher) processNextItem() bool {
+	item, quit := p.queue.Get()
+	if quit {
+		log.Debug("default watcher shutting down, returning")
+		return false
+	}
+	defer p.queue.Done(item)
+
+	if item.(string) == initSignal {
+		p.initialSync.Store(true)
+	} else {
+		p.setDefault(item.(string))
+	}
+
+	return true
 }
 
 func (p *defaultWatcher) makeHandler() *cache.ResourceEventHandlerFuncs {
@@ -71,40 +131,23 @@ func (p *defaultWatcher) makeHandler() *cache.ResourceEventHandlerFuncs {
 			if filterUpdate(meta) {
 				return
 			}
-			p.setDefaultFromLabels(meta.GetLabels())
+			p.queue.Add(getDefault(meta))
 		},
 		UpdateFunc: func(oldObj interface{}, newObj interface{}) {
 			meta, _ := meta.Accessor(newObj)
 			if filterUpdate(meta) {
 				return
 			}
-			p.setDefaultFromLabels(meta.GetLabels())
+			p.queue.Add(getDefault(meta))
 		},
 		DeleteFunc: func(obj interface{}) {
 			meta, _ := meta.Accessor(obj)
 			if filterUpdate(meta) {
 				return
 			}
-			p.mu.Lock()
-			p.defaultRevision = ""
-			p.notifyHandlers()
-			p.mu.Unlock()
+			// treat "" to mean no default revision is set
+			p.queue.Add("")
 		},
-	}
-}
-
-func filterUpdate(obj metav1.Object) bool {
-	return obj.GetName() != defaultTagWebhookName
-}
-
-func (p *defaultWatcher) setDefaultFromLabels(labels map[string]string) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	if revision, ok := labels[label.IoIstioRev.Name]; ok {
-		if revision != p.defaultRevision {
-			p.defaultRevision = revision
-			p.notifyHandlers()
-		}
 	}
 }
 
@@ -116,16 +159,20 @@ func (p *defaultWatcher) notifyHandlers() {
 	}
 }
 
-// GetDefault returns the current default revision.
-func (p *defaultWatcher) GetDefault() string {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	return p.defaultRevision
+func getDefault(meta metav1.Object) string {
+	if revision, ok := meta.GetLabels()[label.IoIstioRev.Name]; ok {
+		return revision
+	}
+	return ""
 }
 
-// AddHandler registers a new handler for updates to default revision changes.
-func (p *defaultWatcher) AddHandler(handler DefaultHandler) {
+func (p *defaultWatcher) setDefault(revision string) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	p.handlers = append(p.handlers, handler)
+	p.defaultRevision = revision
+	p.notifyHandlers()
+}
+
+func filterUpdate(obj metav1.Object) bool {
+	return obj.GetName() != defaultTagWebhookName
 }

--- a/pkg/revisions/default_watcher_test.go
+++ b/pkg/revisions/default_watcher_test.go
@@ -93,6 +93,7 @@ func TestNoDefaultRevision(t *testing.T) {
 	client := kube.NewFakeClient()
 	w := newDefaultWatcher(client, "default")
 	client.RunAndWait(stop)
+	go w.Run(stop)
 	// if have no default tag for some reason, should return ""
 	expectRevision(t, w, "")
 	close(stop)
@@ -103,6 +104,7 @@ func TestDefaultRevisionChanges(t *testing.T) {
 	client := kube.NewFakeClient()
 	w := newDefaultWatcher(client, "default")
 	client.RunAndWait(stop)
+	go w.Run(stop)
 	expectRevision(t, w, "")
 	// change default to "red"
 	createDefaultWebhook(t, client, "red")
@@ -123,6 +125,7 @@ func TestHandlers(t *testing.T) {
 	client := kube.NewFakeClient()
 	w := newDefaultWatcher(client, "default")
 	client.RunAndWait(stop)
+	go w.Run(stop)
 	expectRevision(t, w, "")
 
 	// add a handler to watch default revision changes, ensure it's triggered


### PR DESCRIPTION
Makes it so that we wait for caches to sync before proceeding with leader election. This prevents a race condition where revision with name "" would steal the leader lock on startup

fixes #35765
