### PR TITLE
Fix TestGateway for TCP services

### DIFF
--- a/tests/integration/pilot/ingress_test.go
+++ b/tests/integration/pilot/ingress_test.go
@@ -205,14 +205,12 @@ spec:
 						}
 					})
 					t.NewSubTest("tcp").Run(func(t framework.TestContext) {
-						host, port := apps.Ingress.TCPAddress()
 						_ = apps.Ingress.CallWithRetryOrFail(t, echo.CallOptions{
 							Port: &echo.Port{
 								Protocol:    protocol.HTTP,
-								ServicePort: port,
+								ServicePort: 31400,
 							},
-							Address: host,
-							Path:    "/",
+							Path: "/",
 							Headers: map[string][]string{
 								"Host": {"my.domain.example"},
 							},


### PR DESCRIPTION
This is broken since we do the port -> nodeport translation twice in the
original code.

**Please provide a description of this PR:**