### PR TITLE
configure request without query access log formatter

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/accesslog.go
+++ b/pilot/pkg/networking/core/v1alpha3/accesslog.go
@@ -18,14 +18,13 @@ import (
 	"sync"
 
 	accesslog "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v3"
-	formatters "github.com/envoyproxy/go-control-plane/envoy/extensions/formatter/req_without_query/v3"
-
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	fileaccesslog "github.com/envoyproxy/go-control-plane/envoy/extensions/access_loggers/file/v3"
 	grpcaccesslog "github.com/envoyproxy/go-control-plane/envoy/extensions/access_loggers/grpc/v3"
 	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	tcp "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
+	formatters "github.com/envoyproxy/go-control-plane/envoy/extensions/formatter/req_without_query/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	structpb "google.golang.org/protobuf/types/known/structpb"
 

--- a/pilot/pkg/networking/core/v1alpha3/accesslog.go
+++ b/pilot/pkg/networking/core/v1alpha3/accesslog.go
@@ -62,7 +62,7 @@ const (
 	// This cluster is created in bootstrap.
 	EnvoyAccessLogCluster = "envoy_accesslog_service"
 
-	requestWithoutQuery = "REQ_WITHOUT_QUERY"
+	requestWithoutQuery = "%REQ_WITHOUT_QUERY%"
 )
 
 var (
@@ -245,8 +245,11 @@ func buildFileAccessLogHelper(path string, mesh *meshconfig.MeshConfig) *accessl
 				jsonLogStruct = &parsedJSONLogStruct
 			}
 		}
-		if _, exists := jsonLogStruct.Fields[requestWithoutQuery]; exists {
-			needsFormatter = true
+		for _, value := range jsonLogStruct.Fields {
+			if value.GetStringValue() == requestWithoutQuery {
+				needsFormatter = true
+				break
+			}
 		}
 		fl.AccessLogFormat = &fileaccesslog.FileAccessLog_LogFormat{
 			LogFormat: &core.SubstitutionFormatString{


### PR DESCRIPTION
Configures access log formatter for REQ_WITHOUT_QUERY - Without this if user specifies it access log format, the listener will be rejected.

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
