### PR TITLE
Fuzzing: Add CIFuzz

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,0 +1,26 @@
+name: CIFuzz
+on: [pull_request]
+jobs:
+  Fuzzing:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Build Fuzzers
+      id: build
+      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'istio'
+        dry-run: false
+        language: go
+    - name: Run Fuzzers
+      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'istio'
+        fuzz-seconds: 1200
+        dry-run: false
+        language: go
+    - name: Upload Crash
+      uses: actions/upload-artifact@v1
+      if: failure() && steps.build.outcome == 'success'
+      with:
+        name: artifacts
+        path: ./out/artifacts


### PR DESCRIPTION
**Please provide a description of this PR:**

This adds CIFuzz to Istios OSS-fuzz integration. Upon merging this PR, Istios fuzzers will run in the CI for 1200 seconds when a pull request is made. 

When https://github.com/istio/istio/pull/35727 gets merged, the 1200 seconds should be increased significantly.

Documentation for CIFuzz can be found at: https://google.github.io/oss-fuzz/getting-started/continuous-integration/