### PR TITLE
Fix filterchain match's incorrect early match

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch.go
@@ -618,6 +618,13 @@ func filterChainMatch(listener *xdslistener.Listener, fc *xdslistener.FilterChai
 		return true
 	}
 
+	isVirtual := listener.Name == model.VirtualInboundListenerName || listener.Name == model.VirtualOutboundListenerName
+	// We only do this for virtual listeners, which will move the listener port into a FCM. For non-virtual listeners,
+	// we will handle this in the proper listener match.
+	if isVirtual && lMatch.GetPortNumber() > 0 && fc.GetFilterChainMatch().GetDestinationPort().GetValue() != lMatch.GetPortNumber() {
+		return false
+	}
+
 	match := lMatch.FilterChain
 	if match == nil {
 		return true
@@ -657,13 +664,6 @@ func filterChainMatch(listener *xdslistener.Listener, fc *xdslistener.FilterChai
 			return false
 		}
 	}
-	isVirtual := listener.Name == model.VirtualInboundListenerName || listener.Name == model.VirtualOutboundListenerName
-	// We only do this for virtual listeners, which will move the listener port into a FCM. For non-virtual listeners,
-	// we will handle this in the proper listener match.
-	if isVirtual && lMatch.GetPortNumber() > 0 && fc.GetFilterChainMatch().GetDestinationPort().GetValue() != lMatch.GetPortNumber() {
-		return false
-	}
-
 	return true
 }
 


### PR DESCRIPTION
Fixing incorrectly matched filterchain if `lMatch.FilterChain==nil`.
This moves filtering unrelated to `lMatch.FilterChain` before the nil check.

Signed-off-by: Mandar U Jog <mjog@google.com>

In absence of this PR, If a patch has only listener match but no filterchain match, it is incorrectly applied since missing filterchain match-clause was treated as a positive match.