### PR TITLE
gateway controller: run as privileged

### DIFF
--- a/pilot/pkg/config/kube/gateway/templates/deployment.yaml
+++ b/pilot/pkg/config/kube/gateway/templates/deployment.yaml
@@ -32,6 +32,10 @@ spec:
           .Labels
           | nindent 8}}
     spec:
+      securityContext:
+        runAsUser: 0
+        runAsGroup: 1337
+        runAsNonRoot: false
       containers:
       - image: auto
         name: istio-proxy
@@ -39,6 +43,15 @@ spec:
         - containerPort: 15021
           name: status-port
           protocol: TCP
+        securityContext:
+          capabilities:
+            drop:
+            - ALL
+            add:
+            - NET_BIND_SERVICE
+          allowPrivilegeEscalation: true
+          privileged: true
+          readOnlyRootFilesystem: true
         readinessProbe:
           failureThreshold: 10
           successThreshold: 1

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/cluster-ip.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/cluster-ip.yaml
@@ -64,6 +64,19 @@ spec:
           periodSeconds: 2
           successThreshold: 1
           timeoutSeconds: 2
+        securityContext:
+          allowPrivilegeEscalation: true
+          capabilities:
+            add:
+            - NET_BIND_SERVICE
+            drop:
+            - ALL
+          privileged: true
+          readOnlyRootFilesystem: true
+      securityContext:
+        runAsGroup: 1337
+        runAsNonRoot: false
+        runAsUser: 0
 ---
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: Gateway

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/manual-ip.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/manual-ip.yaml
@@ -62,6 +62,19 @@ spec:
           periodSeconds: 2
           successThreshold: 1
           timeoutSeconds: 2
+        securityContext:
+          allowPrivilegeEscalation: true
+          capabilities:
+            add:
+            - NET_BIND_SERVICE
+            drop:
+            - ALL
+          privileged: true
+          readOnlyRootFilesystem: true
+      securityContext:
+        runAsGroup: 1337
+        runAsNonRoot: false
+        runAsUser: 0
 ---
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: Gateway

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/simple.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/simple.yaml
@@ -61,6 +61,19 @@ spec:
           periodSeconds: 2
           successThreshold: 1
           timeoutSeconds: 2
+        securityContext:
+          allowPrivilegeEscalation: true
+          capabilities:
+            add:
+            - NET_BIND_SERVICE
+            drop:
+            - ALL
+          privileged: true
+          readOnlyRootFilesystem: true
+      securityContext:
+        runAsGroup: 1337
+        runAsNonRoot: false
+        runAsUser: 0
 ---
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: Gateway


### PR DESCRIPTION
The alternative here is to automagically select a >1024 port if they use
one like 80. I think this is a really bad idea, since its complicated
*and cannot ever be changed without downtime*. In the near future,
Kubernetes will make NET_BIND_SERVICE the default (or runnable without
priv, I forget the details), so we should rely on that plan long term.

This works today because our image implicitly runs as root. However, the
distroless image doesn't, so distroless is broken. This is just
formalizing the fact that we run as root - it is not escalating
privileges beyond what are used today already. Also, this is only for
the alpha gateway implementation, not impacting prod usage.

Tested in https://github.com/istio/istio/pull/35354/files.

**Please provide a description of this PR:**