### PR TITLE
Add DeepCopy to echo CallOptions

### DIFF
--- a/pkg/test/framework/components/echo/call.go
+++ b/pkg/test/framework/components/echo/call.go
@@ -123,6 +123,20 @@ func (o CallOptions) GetHost() string {
 	return ""
 }
 
+func (o CallOptions) DeepCopy() CallOptions {
+	clone := o
+	if o.Port != nil {
+		dc := *o.Port
+		clone.Port = &dc
+	}
+	if o.Alpn != nil {
+		clone.Alpn = &proto.Alpn{
+			Value: o.Alpn.GetValue(),
+		}
+	}
+	return clone
+}
+
 // Validator validates that the given responses are expected.
 type Validator interface {
 	// Validate performs the validation check for this Validator.

--- a/pkg/test/framework/components/istio/ingress.go
+++ b/pkg/test/framework/components/istio/ingress.go
@@ -204,6 +204,7 @@ func (c *ingressImpl) callEcho(options echo.CallOptions, retry bool, retryOption
 		addr string
 		port int
 	)
+	options = options.DeepCopy()
 	if options.Port.ServicePort == 0 {
 		// Default port based on protocol
 		switch options.Port.Protocol {


### PR DESCRIPTION
When using nodeport, we mutate the Calloptions port (a pointer). This
means on subsequent retries things get messed up.

Tested in https://github.com/istio/istio/pull/35354

**Please provide a description of this PR:**