### PR TITLE
Use v6 DNS resolution when we are on a ipv6 *only* proxy

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -212,6 +212,7 @@ func buildClusterKey(service *model.Service, port *model.Port, cb *ClusterBuilde
 		networkView:     cb.networkView,
 		http2:           port.Protocol.IsHTTP2(),
 		downstreamAuto:  cb.sidecarProxy() && util.IsProtocolSniffingEnabledForOutboundPort(port),
+		supportsIPv4:    cb.supportsIPv4,
 		service:         service,
 		destinationRule: cb.req.Push.DestinationRule(proxy, service),
 		envoyFilterKeys: efKeys,

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -352,7 +352,11 @@ func (cb *ClusterBuilder) buildDefaultCluster(name string, discoveryType cluster
 	ec := NewMutableCluster(c)
 	switch discoveryType {
 	case cluster.Cluster_STRICT_DNS, cluster.Cluster_LOGICAL_DNS:
-		c.DnsLookupFamily = cluster.Cluster_V4_ONLY
+		if cb.supportsIPv4 {
+			c.DnsLookupFamily = cluster.Cluster_V4_ONLY
+		} else {
+			c.DnsLookupFamily = cluster.Cluster_V6_ONLY
+		}
 		dnsRate := gogo.DurationToProtoDuration(cb.req.Push.Mesh.DnsRefreshRate)
 		c.DnsRefreshRate = dnsRate
 		c.RespectDnsTtl = true
@@ -412,6 +416,7 @@ type clusterCache struct {
 	// service attributes
 	http2          bool // http2 identifies if the cluster is for an http2 service
 	downstreamAuto bool
+	supportsIPv4   bool
 
 	// Dependent configs
 	service         *model.Service
@@ -425,7 +430,7 @@ func (t *clusterCache) Key() string {
 	params := []string{
 		t.clusterName, t.proxyVersion, util.LocalityToString(t.locality),
 		t.proxyClusterID, strconv.FormatBool(t.proxySidecar),
-		strconv.FormatBool(t.http2), strconv.FormatBool(t.downstreamAuto),
+		strconv.FormatBool(t.http2), strconv.FormatBool(t.downstreamAuto), strconv.FormatBool(t.supportsIPv4),
 	}
 	if t.networkView != nil {
 		nv := make([]string, 0, len(t.networkView))


### PR DESCRIPTION
Otherwise we cannot use DNS resolution at all.

probably we should use `V4_PREFERRED` if it supports both but I was
pretty concerned by past attempts:
* https://github.com/istio/istio/pull/27296
* https://github.com/istio/istio/pull/26409
* https://github.com/istio/istio/pull/27306

Tested in https://github.com/istio/istio/pull/35354/files