### PR TITLE
ipv6: fix VM healthcheck ipv6 detection

### DIFF
--- a/pilot/cmd/pilot-agent/options/agent.go
+++ b/pilot/cmd/pilot-agent/options/agent.go
@@ -21,6 +21,7 @@ import (
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/util/network"
 	"istio.io/istio/pkg/bootstrap/platform"
 	istioagent "istio.io/istio/pkg/istio-agent"
 )
@@ -29,12 +30,13 @@ import (
 const xdsHeaderPrefix = "XDS_HEADER_"
 
 func NewAgentOptions(proxy *model.Proxy, cfg *meshconfig.ProxyConfig) *istioagent.AgentOptions {
+	proxy.DiscoverIPVersions()
 	o := &istioagent.AgentOptions{
 		XDSRootCerts:                xdsRootCA,
 		CARootCerts:                 caRootCA,
 		XDSHeaders:                  map[string]string{},
 		XdsUdsPath:                  filepath.Join(cfg.ConfigPath, "XDS"),
-		IsIPv6:                      proxy.SupportsIPv6(),
+		IsIPv6:                      network.IsIPv6Proxy(proxy.IPAddresses),
 		ProxyType:                   proxy.Type,
 		EnableDynamicProxyConfig:    enableProxyConfigXdsEnv,
 		EnableDynamicBootstrap:      enableBootstrapXdsEnv,


### PR DESCRIPTION
Currently its 100% broken. SupportsIPv6 ALWAYS returns false since we
never called DiscoverIPVersions. Even if we fix that, we still should
not use it since we need to be consistent with the code that selects
where Envoy admin server binds, which uses `network.IsIPv6Proxy`

**Please provide a description of this PR:**