### PR TITLE
fix kind create cluster failed on linux when do integrate test manually

### DIFF
--- a/common/Makefile.common.mk
+++ b/common/Makefile.common.mk
@@ -72,7 +72,7 @@ tidy-go:
 	@go mod tidy
 
 mod-download-go:
-	@-GOFLAGS="-mod=readonly" go mod download
+	@GOFLAGS="-mod=readonly" go mod download
 # go mod tidy is needed with Golang 1.16+ as go mod download affects go.sum
 # https://github.com/golang/go/issues/43994
 	@go mod tidy

--- a/common/scripts/kind_provisioner.sh
+++ b/common/scripts/kind_provisioner.sh
@@ -37,6 +37,8 @@ DEFAULT_KIND_IMAGE="gcr.io/istio-testing/kindest/node:v1.19.1"
 # COMMON_SCRIPTS contains the directory this file is in.
 COMMON_SCRIPTS=$(dirname "${BASH_SOURCE:-$0}")
 
+KUBECONFIG=${KUBECONFIG:-$HOME/.kube/config}
+
 # load_cluster_topology function reads cluster configuration topology file and
 # sets up environment variables used by other functions. So this should be called
 # before anything else.


### PR DESCRIPTION
Signed-off-by: zackzhangkai <you@example.com>

**Please provide a description of this PR:**
1. Fix kind create cluster
When do integrate test on linux by hand, it will come out the errors:

```bash
make shell
./prow/integ-suite-kind.sh
```

```bash
✓ Installing CNI 🔌
 ✓ Installing StorageClass 💾
 ✓ Waiting ≤ 3m0s for control-plane = Ready ⏳
 • Ready after 24s 💚
ERROR: failed to create cluster: failed to write KUBECONFIG: open /config/fb379ac4: read-only file system
Stack Trace:
sigs.k8s.io/kind/pkg/errors.Wrap
	/tmp/go/pkg/mod/sigs.k8s.io/kind@v0.11.1/pkg/errors/errors.go:47
sigs.k8s.io/kind/pkg/cluster/internal/kubeconfig/internal/kubeconfig.write
	/tmp/go/pkg/mod/sigs.k8s.io/kind@v0.11.1/pkg/cluster/internal/kubeconfig/internal/kubeconfig/write.go:42
sigs.k8s.io/kind/pkg/cluster/internal/kubeconfig/internal/kubeconfig.WriteMerged
	/tmp/go/pkg/mod/sigs.k8s.io/kind@v0.11.1/pkg/cluster/internal/kubeconfig/internal/kubeconfig/merge.go:52
sigs.k8s.io/kind/pkg/cluster/internal/kubeconfig.Export
	/tmp/go/pkg/mod/sigs.k8s.io/kind@v0.11.1/pkg/cluster/internal/kubeconfig/kubeconfig.go:40
sigs.k8s.io/kind/pkg/cluster/internal/create.Cluster
	/tmp/go/pkg/mod/sigs.k8s.io/kind@v0.11.1/pkg/cluster/internal/create/create.go:154
sigs.k8s.io/kind/pkg/cluster.(*Provider).Create
	/tmp/go/pkg/mod/sigs.k8s.io/kind@v0.11.1/pkg/cluster/provider.go:183
sigs.k8s.io/kind/pkg/cmd/kind/create/cluster.runE
	/tmp/go/pkg/mod/sigs.k8s.io/kind@v0.11.1/pkg/cmd/kind/create/cluster/createcluster.go:80
sigs.k8s.io/kind/pkg/cmd/kind/create/cluster.NewCommand.func1
	/tmp/go/pkg/mod/sigs.k8s.io/kind@v0.11.1/pkg/cmd/kind/create/cluster/createcluster.go:55
github.com/spf13/cobra.(*Command).execute
	/tmp/go/pkg/mod/github.com/spf13/cobra@v1.1.1/command.go:850
github.com/spf13/cobra.(*Command).ExecuteC
	/tmp/go/pkg/mod/github.com/spf13/cobra@v1.1.1/command.go:958
github.com/spf13/cobra.(*Command).Execute
	/tmp/go/pkg/mod/github.com/spf13/cobra@v1.1.1/command.go:895
sigs.k8s.io/kind/cmd/kind/app.Run
	/tmp/go/pkg/mod/sigs.k8s.io/kind@v0.11.1/cmd/kind/app/main.go:53
sigs.k8s.io/kind/cmd/kind/app.Main
	/tmp/go/pkg/mod/sigs.k8s.io/kind@v0.11.1/cmd/kind/app/main.go:35
main.main
	/tmp/go/pkg/mod/sigs.k8s.io/kind@v0.11.1/main.go:25
runtime.main
	/usr/local/go/src/runtime/proc.go:255
runtime.goexit
	/usr/local/go/src/runtime/asm_amd64.s:1581
+ echo 'Could not setup KinD environment. Something wrong with KinD setup. Exporting logs.'
Could not setup KinD environment. Something wrong with KinD setup. Exporting logs.
```

The reason is that when create kind cluster, the kubeconfig file is the default on /config/xxx, which had no permission to write. So we set the PATH to address this issue.

2. Fix `make gen` errors, which will hint should set `-mod=readonly`