### PR TITLE
Add list object path dump for profile dump

### DIFF
--- a/operator/cmd/mesh/profile-dump.go
+++ b/operator/cmd/mesh/profile-dump.go
@@ -103,7 +103,12 @@ func yamlToPrettyJSON(yml string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	var decoded map[string]interface{}
+	var decoded interface{}
+	if uglyJSON[0] == '[' {
+		decoded = make([]interface{}, 0)
+	} else {
+		decoded = map[string]interface{}{}
+	}
 	if err := json.Unmarshal(uglyJSON, &decoded); err != nil {
 		return "", err
 	}
@@ -184,17 +189,23 @@ func yamlToFlags(yml string) ([]string, error) {
 	if err != nil {
 		return []string{}, err
 	}
-	var decoded map[string]interface{}
+	var decoded interface{}
+	if uglyJSON[0] == '[' {
+		decoded = make([]interface{}, 0)
+	} else {
+		decoded = map[string]interface{}{}
+	}
 	if err := json.Unmarshal(uglyJSON, &decoded); err != nil {
 		return []string{}, err
 	}
-	spec, ok := decoded["spec"]
-	if !ok {
-		// Fall back to showing the entire spec.
-		// (When --config-path is used there will be no spec to remove)
-		spec = decoded
+	if d, ok := decoded.(map[string]interface{}); ok {
+		if v, ok := d["spec"]; ok {
+			// Fall back to showing the entire spec.
+			// (When --config-path is used there will be no spec to remove)
+			decoded = v
+		}
 	}
-	setflags, err := walk("", "", spec)
+	setflags, err := walk("", "", decoded)
 	if err != nil {
 		return []string{}, err
 	}

--- a/operator/cmd/mesh/profile-dump_test.go
+++ b/operator/cmd/mesh/profile-dump_test.go
@@ -38,6 +38,10 @@ func TestProfileDump(t *testing.T) {
 			desc:       "config_path",
 			configPath: "components",
 		},
+		{
+			desc:       "list_path",
+			configPath: "values.gateways.istio-egressgateway.secretVolumes",
+		},
 	}
 	installPackagePathRegex := regexp.MustCompile("  installPackagePath: .*")
 	for _, tt := range tests {
@@ -96,6 +100,10 @@ func TestProfileDumpFlags(t *testing.T) {
 		{
 			desc:       "config_path",
 			configPath: "components",
+		},
+		{
+			desc:       "list_path",
+			configPath: "values.gateways.istio-egressgateway.secretVolumes",
 		},
 	}
 	installPackagePathRegex := regexp.MustCompile("(?m)^installPackagePath=\".*\"\n")

--- a/operator/cmd/mesh/testdata/profile-dump/input/list_path.yaml
+++ b/operator/cmd/mesh/testdata/profile-dump/input/list_path.yaml
@@ -1,0 +1,11 @@
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+metadata:
+  namespace: istio-system
+spec:
+  values:
+    gateways:
+      istio-egressgateway:
+        secretVolumes:
+          - mountPath: /etc/istio/egressgateway-certs
+            name: egressgateway-certs

--- a/operator/cmd/mesh/testdata/profile-dump/output/list_path.txt
+++ b/operator/cmd/mesh/testdata/profile-dump/output/list_path.txt
@@ -1,0 +1,6 @@
+[0].mountPath="/etc/istio/egressgateway-certs"
+[0].name="egressgateway-certs"
+[0].secretName="istio-egressgateway-certs"
+[1].mountPath="/etc/istio/egressgateway-ca-certs"
+[1].name="egressgateway-ca-certs"
+[1].secretName="istio-egressgateway-ca-certs"

--- a/operator/cmd/mesh/testdata/profile-dump/output/list_path.yaml
+++ b/operator/cmd/mesh/testdata/profile-dump/output/list_path.yaml
@@ -1,0 +1,7 @@
+- mountPath: /etc/istio/egressgateway-certs
+  name: egressgateway-certs
+  secretName: istio-egressgateway-certs
+- mountPath: /etc/istio/egressgateway-ca-certs
+  name: egressgateway-ca-certs
+  secretName: istio-egressgateway-ca-certs
+


### PR DESCRIPTION
**Please provide a description of this PR:**
Fix https://github.com/istio/istio/issues/35865

```console
$ istioctl profile dump demo -o json -p values.gateways.istio-egressgateway.secretVolumes
[
    {
        "mountPath": "/etc/istio/egressgateway-certs",
        "name": "egressgateway-certs",
        "secretName": "istio-egressgateway-certs"
    },
    {
        "mountPath": "/etc/istio/egressgateway-ca-certs",
        "name": "egressgateway-ca-certs",
        "secretName": "istio-egressgateway-ca-certs"
    }
]

```