### PR TITLE
docker: rewrite make+bash with a simple golang tool

### DIFF
--- a/pkg/test/env/istio.go
+++ b/pkg/test/env/istio.go
@@ -15,6 +15,7 @@
 package env
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path"
@@ -120,4 +121,26 @@ func CheckFileExists(path string) error {
 		return err
 	}
 	return nil
+}
+
+func ReadProxySHA() (string, error) {
+	type DepsFile struct {
+		Name          string `json:"name"`
+		LastStableSHA string `json:"lastStableSHA"`
+	}
+	f := filepath.Join(IstioSrc, "istio.deps")
+	depJSON, err := os.ReadFile(f)
+	if err != nil {
+		return "", err
+	}
+	var deps []DepsFile
+	if err := json.Unmarshal(depJSON, &deps); err != nil {
+		return "", err
+	}
+	for _, d := range deps {
+		if d.Name == "PROXY_REPO_SHA" {
+			return d.LastStableSHA, nil
+		}
+	}
+	return "", fmt.Errorf("PROXY_REPO_SHA not found")
 }

--- a/tests/integration/telemetry/stats/prometheus/customizemetrics/customize_metrics_test.go
+++ b/tests/integration/telemetry/stats/prometheus/customizemetrics/customize_metrics_test.go
@@ -18,11 +18,9 @@
 package customizemetrics
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
-	"path"
 	"strings"
 	"testing"
 	"time"
@@ -200,20 +198,9 @@ func setupEnvoyFilter(ctx resource.Context) error {
 	if nsErr != nil {
 		return nsErr
 	}
-	proxyDepFile := path.Join(env.IstioSrc, "istio.deps")
-	depJSON, err := os.ReadFile(proxyDepFile)
+	proxySHA, err := env.ReadProxySHA()
 	if err != nil {
 		return err
-	}
-	var deps []interface{}
-	if err := json.Unmarshal(depJSON, &deps); err != nil {
-		return err
-	}
-	proxySHA := ""
-	for _, d := range deps {
-		if dm, ok := d.(map[string]interface{}); ok && dm["repoName"].(string) == "proxy" {
-			proxySHA = dm["lastStableSHA"].(string)
-		}
 	}
 	content, err := os.ReadFile("testdata/attributegen_envoy_filter.yaml")
 	if err != nil {

--- a/tools/docker
+++ b/tools/docker
@@ -18,6 +18,8 @@ WD=$(dirname "$0")
 WD=$(cd "$WD"; pwd)
 ROOT=$(dirname "$WD")
 
+set -eu
+
 cd "${ROOT}"
 
 export REPO_ROOT="${ROOT}"

--- a/tools/docker
+++ b/tools/docker
@@ -28,9 +28,9 @@ if [[ -f out/linux_amd64/docker-builder ]]; then
   CURRENT_BUILD="$(./common/scripts/report_build_info.sh | grep buildGitRevision | cut -d= -f2)"
   PREBUILT="$(out/linux_amd64/docker-builder --version)"
   if [[ "${CURRENT_BUILD}" != "${PREBUILT}" ]]; then
-    ./common/scripts/gobuild.sh out/linux_amd64/docker-builder ./tools/docker-builder/main.go
+    ./common/scripts/gobuild.sh out/linux_amd64/docker-builder ./tools/docker-builder
   fi
 else
-  ./common/scripts/gobuild.sh out/linux_amd64/docker-builder ./tools/docker-builder/main.go
+  ./common/scripts/gobuild.sh out/linux_amd64/docker-builder ./tools/docker-builder
 fi
 out/linux_amd64/docker-builder "$@"

--- a/tools/docker
+++ b/tools/docker
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Copyright Istio Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+WD=$(dirname "$0")
+WD=$(cd "$WD"; pwd)
+ROOT=$(dirname "$WD")
+
+cd "${ROOT}"
+
+export REPO_ROOT="${ROOT}"
+
+if [[ -f out/linux_amd64/docker-builder ]]; then
+  CURRENT_BUILD="$(./common/scripts/report_build_info.sh | grep buildGitRevision | cut -d= -f2)"
+  PREBUILT="$(out/linux_amd64/docker-builder --version)"
+  if [[ "${CURRENT_BUILD}" != "${PREBUILT}" ]]; then
+    ./common/scripts/gobuild.sh out/linux_amd64/docker-builder ./tools/docker-builder/main.go
+  fi
+else
+  ./common/scripts/gobuild.sh out/linux_amd64/docker-builder ./tools/docker-builder/main.go
+fi
+out/linux_amd64/docker-builder "$@"

--- a/tools/docker-builder/main.go
+++ b/tools/docker-builder/main.go
@@ -1,16 +1,49 @@
 package main
 
 import (
+	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
 	"k8s.io/utils/env"
 
-	"istio.io/pkg/log"
+	"istio.io/istio/pilot/pkg/util/sets"
 	testenv "istio.io/istio/pkg/test/env"
+	"istio.io/pkg/log"
 )
+
+type Group struct {
+	Targets []string `json:"targets" hcl:"targets"`
+}
+
+type BakeFile struct {
+	Target map[string]Target `json:"target,omitempty"`
+	Group  map[string]Group `json:"group,omitempty"`
+}
+
+type Target struct {
+	Context          *string           `json:"context,omitempty" hcl:"context,optional"`
+	Dockerfile       *string           `json:"dockerfile,omitempty" hcl:"dockerfile,optional"`
+	DockerfileInline *string           `json:"dockerfile-inline,omitempty" hcl:"dockerfile-inline,optional"`
+	Args             map[string]string `json:"args,omitempty" hcl:"args,optional"`
+	Labels           map[string]string `json:"labels,omitempty" hcl:"labels,optional"`
+	Tags             []string          `json:"tags,omitempty" hcl:"tags,optional"`
+	CacheFrom        []string          `json:"cache-from,omitempty"  hcl:"cache-from,optional"`
+	CacheTo          []string          `json:"cache-to,omitempty"  hcl:"cache-to,optional"`
+	Target           *string           `json:"target,omitempty" hcl:"target,optional"`
+	Secrets          []string          `json:"secret,omitempty" hcl:"secret,optional"`
+	SSH              []string          `json:"ssh,omitempty" hcl:"ssh,optional"`
+	Platforms        []string          `json:"platforms,omitempty" hcl:"platforms,optional"`
+	Outputs          []string          `json:"output,omitempty" hcl:"output,optional"`
+	Pull             *bool             `json:"pull,omitempty" hcl:"pull,optional"`
+	NoCache          *bool             `json:"no-cache,omitempty" hcl:"no-cache,optional"`
+
+	// IMPORTANT: if you add more fields here, do not forget to update newOverrides and README.
+}
 
 // docker-builder
 // * --push
@@ -72,8 +105,48 @@ var rootCmd = &cobra.Command{
 	Short: "Builds Istio docker images",
 	Run: func(cmd *cobra.Command, _ []string) {
 		log.Infof("Args: %+v", args)
+		ConstructBakeFile(args)
 		RunMake(args, "docker.pilot2")
 	},
+}
+
+func sp(s string) *string {
+	return &s
+}
+
+func ConstructBakeFile(a Args) error {
+	targets := map[string]Target{}
+	for _, variant := range a.Variants {
+		for _, target := range a.Targets {
+			p := filepath.Join(testenv.IstioOut, "dockerx_build", fmt.Sprintf("docker.%s", target))
+			t := Target{
+				Context:    sp(p),
+				Dockerfile: sp(fmt.Sprintf("Dockerfile.%s", target)),
+				Args: map[string]string{
+					"BASE_VERSION":      "2021-10-06T19-01-15",
+					"BASE_DISTRIBUTION": "debug",
+					"proxy_version":     "istio-proxy:74393cf764c167b545f32eb895314e624186e5b6",
+					"istio_version":     "1.12-dev",
+					"VM_IMAGE_NAME":     "",
+					"VM_IMAGE_VERSION":  "",
+				},
+				Tags:      []string{fmt.Sprintf("%s/%s:%s-%s", a.Hub, target, a.Tag, variant)},
+				Platforms: []string{"linux/amd64"},
+				Outputs:   []string{"type=docker"}, // TODO push
+			}
+			targets[fmt.Sprintf("%s-%s", target, variant)] = t
+		}
+	}
+	bf := BakeFile{
+		Target: targets,
+		Group:  nil,
+	}
+	out := filepath.Join(testenv.IstioOut, "dockerx_build", "docker-bake.json")
+	j, err := json.MarshalIndent(bf, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(out, j, 0o644)
 }
 
 // VerboseCommand runs a command, outputting stderr and stdout
@@ -87,13 +160,17 @@ func VerboseCommand(name string, arg ...string) *exec.Cmd {
 
 func StandardEnv(args Args) []string {
 	env := os.Environ()
+	if len(sets.NewSet(args.Targets...).Delete("proxyv2")) <= 1 {
+		// If we are building multiple, it is faster to build all binaries in a single invocation
+		// Otherwise, build just the single item. proxyv2 is special since it is always built separately with tag=agent.
+		// Ideally we would just always build the targets we need but our Makefile is not that smart
+		env = append(env, "BUILD_ALL=false")
+	}
 	env = append(env,
 		"BUILD_WITH_CONTAINER=0", // Build should already run in container, having multiple layers of docker causes issues
 	)
 	return env
 }
-
-
 
 // RunMake runs a make command for the repo, with standard environment variables set
 func RunMake(args Args, c ...string) error {

--- a/tools/docker-builder/main.go
+++ b/tools/docker-builder/main.go
@@ -164,12 +164,12 @@ var rootCmd = &cobra.Command{
 		for _, t := range args.Targets {
 			targets = append(targets, fmt.Sprintf("docker.%s", t))
 		}
-		//if err := RunMake(args, targets...); err != nil {
-		//	return err
-		//}
-		//if err := RunBake(args); err != nil {
-		//	return err
-		//}
+		if err := RunMake(args, targets...); err != nil {
+			return err
+		}
+		if err := RunBake(args); err != nil {
+			return err
+		}
 		if err := RunSave(args, allTags); err != nil {
 			return err
 		}
@@ -342,6 +342,7 @@ func ConstructBakeFile(a Args) (sets.Set, error) {
 	if err != nil {
 		return nil, err
 	}
+	_ = os.MkdirAll(filepath.Join(testenv.IstioOut, "dockerx_build"), 0o755)
 	return allTags, os.WriteFile(out, j, 0o644)
 }
 

--- a/tools/docker-builder/main.go
+++ b/tools/docker-builder/main.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"k8s.io/utils/env"
+
+	"istio.io/pkg/log"
+	testenv "istio.io/istio/pkg/test/env"
+)
+
+// docker-builder
+// * --push
+// * --legacy
+// * --targets
+// * --save
+// * --
+
+type Args struct {
+	Push          bool
+	Save          bool
+	BuildxEnabled bool
+	Targets       []string
+	Variants      []string
+	Tag           string
+	Hub           string
+}
+
+func DefaultArgs() Args {
+	targets := []string{
+		"pilot",
+		"proxyv2",
+		"app",
+
+		"app_sidecar_ubuntu_xenia",
+		"app_sidecar_ubuntu_bionic",
+		"app_sidecar_ubuntu_focal",
+
+		"app_sidecar_debian_9",
+		"app_sidecar_debian_10",
+
+		"app_sidecar_centos_8",
+		"app_sidecar_centos_7",
+
+		"istioctl",
+		"operator",
+		"install-ci",
+	}
+	if legacy, f := os.LookupEnv("DOCKER_TARGETS"); f {
+		log.Warnf("Using legacy DOCKER_TARGETS; use --targets instead")
+		targets = []string{}
+		for _, v := range strings.Split(legacy, " ") {
+			targets = append(targets, strings.TrimPrefix(v, "docker."))
+		}
+	}
+	return Args{
+		Push:          false,
+		Save:          false,
+		BuildxEnabled: true,
+		Hub:           env.GetString("HUB", "localhost:5000"),
+		Tag:           env.GetString("TAG", "latest"),
+		Targets:       targets,
+		Variants:      []string{"default"},
+	}
+}
+
+var rootCmd = &cobra.Command{
+	Use:   "",
+	Short: "Builds Istio docker images",
+	Run: func(cmd *cobra.Command, _ []string) {
+		log.Infof("Args: %+v", args)
+		RunMake(args, "docker.pilot2")
+	},
+}
+
+// VerboseCommand runs a command, outputting stderr and stdout
+func VerboseCommand(name string, arg ...string) *exec.Cmd {
+	log.Infof("Running command: %v %v", name, strings.Join(arg, " "))
+	cmd := exec.Command(name, arg...)
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = os.Stdout
+	return cmd
+}
+
+func StandardEnv(args Args) []string {
+	env := os.Environ()
+	env = append(env,
+		"BUILD_WITH_CONTAINER=0", // Build should already run in container, having multiple layers of docker causes issues
+	)
+	return env
+}
+
+
+
+// RunMake runs a make command for the repo, with standard environment variables set
+func RunMake(args Args, c ...string) error {
+	cmd := VerboseCommand("make", c...)
+	cmd.Env = StandardEnv(args)
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = os.Stdout
+	cmd.Dir = testenv.IstioSrc
+	log.Infof("Running make %v with wd=%v", strings.Join(c, " "), cmd.Dir)
+	return cmd.Run()
+}
+
+var args = DefaultArgs()
+
+func main() {
+	rootCmd.Flags().StringVar(&args.Hub, "hub", args.Hub, "docker hub")
+	rootCmd.Flags().StringVar(&args.Tag, "tag", args.Tag, "docker tag")
+	rootCmd.Flags().StringSliceVar(&args.Targets, "targets", args.Targets, "targets to build")
+	rootCmd.Flags().StringSliceVar(&args.Variants, "variants", args.Variants, "variants to build")
+	rootCmd.Flags().BoolVar(&args.Push, "push", args.Push, "push targets to registry")
+	rootCmd.Flags().BoolVar(&args.Save, "save", args.Save, "save targets to tar.gz")
+	rootCmd.Flags().BoolVar(&args.BuildxEnabled, "buildx", args.BuildxEnabled, "use buildx for builds")
+	if err := rootCmd.Execute(); err != nil {
+		os.Exit(-1)
+	}
+}

--- a/tools/docker-builder/main.go
+++ b/tools/docker-builder/main.go
@@ -118,7 +118,8 @@ func ConstructBakeFile(a Args) error {
 	targets := map[string]Target{}
 	for _, variant := range a.Variants {
 		for _, target := range a.Targets {
-			p := filepath.Join(testenv.IstioOut, "dockerx_build", fmt.Sprintf("docker.%s", target))
+			// TODO remove 2
+			p := filepath.Join(testenv.IstioOut, "dockerx_build", fmt.Sprintf("docker.%s2", target))
 			t := Target{
 				Context:    sp(p),
 				Dockerfile: sp(fmt.Sprintf("Dockerfile.%s", target)),

--- a/tools/docker-builder/main.go
+++ b/tools/docker-builder/main.go
@@ -107,6 +107,9 @@ func DefaultArgs() Args {
 	if legacy, f := os.LookupEnv("DOCKER_TARGETS"); f {
 		targets = []string{}
 		for _, v := range strings.Split(legacy, " ") {
+			if v == "" {
+				continue
+			}
 			targets = append(targets, strings.TrimPrefix(v, "docker."))
 		}
 	}

--- a/tools/docker-builder/main.go
+++ b/tools/docker-builder/main.go
@@ -14,6 +14,7 @@ import (
 	"istio.io/istio/pilot/pkg/util/sets"
 	testenv "istio.io/istio/pkg/test/env"
 	"istio.io/pkg/log"
+	pkgversion "istio.io/pkg/version"
 )
 
 type Group struct {
@@ -104,6 +105,10 @@ var rootCmd = &cobra.Command{
 	Use:   "",
 	Short: "Builds Istio docker images",
 	Run: func(cmd *cobra.Command, _ []string) {
+		if version {
+			fmt.Println(pkgversion.Info.GitRevision)
+			os.Exit(0)
+		}
 		log.Infof("Args: %+v", args)
 		ConstructBakeFile(args)
 		RunMake(args, "docker.pilot2")
@@ -199,7 +204,10 @@ func RunMake(args Args, c ...string) error {
 	return cmd.Run()
 }
 
-var args = DefaultArgs()
+var (
+	args    = DefaultArgs()
+	version = true
+)
 
 func main() {
 	rootCmd.Flags().StringVar(&args.Hub, "hub", args.Hub, "docker hub")
@@ -209,6 +217,8 @@ func main() {
 	rootCmd.Flags().BoolVar(&args.Push, "push", args.Push, "push targets to registry")
 	rootCmd.Flags().BoolVar(&args.Save, "save", args.Save, "save targets to tar.gz")
 	rootCmd.Flags().BoolVar(&args.BuildxEnabled, "buildx", args.BuildxEnabled, "use buildx for builds")
+	rootCmd.Flags().BoolVar(&version, "version", version, "show build version")
+
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(-1)
 	}

--- a/tools/docker-builder/main.go
+++ b/tools/docker-builder/main.go
@@ -119,6 +119,15 @@ func DefaultArgs() Args {
 	if legacy, f := os.LookupEnv("DOCKER_BUILD_VARIANTS"); f {
 		variants = strings.Split(legacy, " ")
 	}
+
+	if os.Getenv("INCLUDE_UNTAGGED_DEFAULT") == "true" {
+		// This legacy env var was to workaround the old build logic not being very smart
+		// In the new builder, we automagically detect this. So just insert the 'default' variant
+		cur := sets.NewSet(variants...)
+		cur.Insert(DefaultVariant)
+		variants = cur.SortedList()
+	}
+
 	arch := []string{"linux/amd64"}
 	if legacy, f := os.LookupEnv("DOCKER_ARCHITECTURES"); f {
 		arch = strings.Split(legacy, ",")

--- a/tools/docker-builder/main.go
+++ b/tools/docker-builder/main.go
@@ -66,6 +66,12 @@ var rootCmd = &cobra.Command{
 			// TODO(https://github.com/moby/buildkit/issues/1555) support both
 			return fmt.Errorf("--push and --save are mutually exclusive")
 		}
+		_, inCI := os.LookupEnv("CI")
+		if (args.Hub == "docker.io/istio" || args.Hub == "istio" || args.Hub == "gcr.io/istio-release") && !inCI {
+			// Safety check against developer error. If they have a legitimate use case, they can set CI var
+			return fmt.Errorf("pushing to official registry only supported in CI")
+		}
+
 		tarFiles, err := ConstructBakeFile(args)
 		if err != nil {
 			return err

--- a/tools/docker-builder/main.go
+++ b/tools/docker-builder/main.go
@@ -95,8 +95,8 @@ var rootCmd = &cobra.Command{
 }
 
 func RunBake(args Args) error {
-	out := filepath.Join(testenv.IstioOut, "dockerx_build", "docker-bake.json")
-	_ = os.MkdirAll(filepath.Join(testenv.IstioOut, "release", "docker"), 0o755)
+	out := filepath.Join(testenv.LocalOut, "dockerx_build", "docker-bake.json")
+	_ = os.MkdirAll(filepath.Join(testenv.LocalOut, "release", "docker"), 0o755)
 	if err := createBuildxBuilderIfNeeded(args); err != nil {
 		return err
 	}
@@ -131,7 +131,7 @@ func RunSave(a Args, files map[string]string) error {
 		return nil
 	}
 
-	root := filepath.Join(testenv.IstioOut, "release", "docker")
+	root := filepath.Join(testenv.LocalOut, "release", "docker")
 	for name, alias := range files {
 		// Gzip the file
 		if err := VerboseCommand("gzip", "--fast", "--force", filepath.Join(root, name+".tar")).Run(); err != nil {
@@ -211,7 +211,7 @@ func ConstructBakeFile(a Args) (map[string]string, error) {
 			if strings.HasPrefix(target, "app_") && variant == DistrolessVariant {
 				continue
 			}
-			p := filepath.Join(testenv.IstioOut, "dockerx_build", fmt.Sprintf("docker.%s", target))
+			p := filepath.Join(testenv.LocalOut, "dockerx_build", fmt.Sprintf("docker.%s", target))
 			t := Target{
 				Context:    sp(p),
 				Dockerfile: sp(fmt.Sprintf("Dockerfile.%s", target)),
@@ -254,7 +254,7 @@ func ConstructBakeFile(a Args) (map[string]string, error) {
 				if variant == PrimaryVariant && hasDoubleDefault {
 					tarFiles[n] = target
 				}
-				t.Outputs = []string{"type=docker,dest=" + filepath.Join(testenv.IstioOut, "release", "docker", n+".tar")}
+				t.Outputs = []string{"type=docker,dest=" + filepath.Join(testenv.LocalOut, "release", "docker", n+".tar")}
 			} else {
 				t.Outputs = []string{"type=docker"}
 			}
@@ -273,12 +273,12 @@ func ConstructBakeFile(a Args) (map[string]string, error) {
 		Target: targets,
 		Group:  groups,
 	}
-	out := filepath.Join(testenv.IstioOut, "dockerx_build", "docker-bake.json")
+	out := filepath.Join(testenv.LocalOut, "dockerx_build", "docker-bake.json")
 	j, err := json.MarshalIndent(bf, "", "  ")
 	if err != nil {
 		return nil, err
 	}
-	_ = os.MkdirAll(filepath.Join(testenv.IstioOut, "dockerx_build"), 0o755)
+	_ = os.MkdirAll(filepath.Join(testenv.LocalOut, "dockerx_build"), 0o755)
 	return tarFiles, os.WriteFile(out, j, 0o644)
 }
 

--- a/tools/docker-builder/types.go
+++ b/tools/docker-builder/types.go
@@ -1,3 +1,17 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/tools/docker-builder/types.go
+++ b/tools/docker-builder/types.go
@@ -92,7 +92,7 @@ func DefaultArgs() Args {
 		"app",
 		"istioctl",
 		"operator",
-		"install-ci",
+		"install-cni",
 
 		"app_sidecar_ubuntu_xenial",
 		"app_sidecar_ubuntu_bionic",

--- a/tools/docker-builder/types.go
+++ b/tools/docker-builder/types.go
@@ -89,7 +89,7 @@ func DefaultArgs() Args {
 		"app_sidecar_centos_7",
 	}
 	if legacy, f := os.LookupEnv("DOCKER_TARGETS"); f {
-		// Allow env var config. It is a string seperated list like "docker.pilot docker.proxy"
+		// Allow env var config. It is a string separated list like "docker.pilot docker.proxy"
 		targets = []string{}
 		for _, v := range strings.Split(legacy, " ") {
 			if v == "" {

--- a/tools/docker-builder/types.go
+++ b/tools/docker-builder/types.go
@@ -1,0 +1,179 @@
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"k8s.io/utils/env"
+
+	"istio.io/istio/pilot/pkg/util/sets"
+	testenv "istio.io/istio/pkg/test/env"
+	"istio.io/pkg/log"
+)
+
+// Types mirrored from https://github.com/docker/buildx/blob/master/bake/bake.go
+type Group struct {
+	Targets []string `json:"targets" hcl:"targets"`
+}
+
+type BakeFile struct {
+	Target map[string]Target `json:"target,omitempty"`
+	Group  map[string]Group  `json:"group,omitempty"`
+}
+
+type Target struct {
+	Context          *string           `json:"context,omitempty" hcl:"context,optional"`
+	Dockerfile       *string           `json:"dockerfile,omitempty" hcl:"dockerfile,optional"`
+	DockerfileInline *string           `json:"dockerfile-inline,omitempty" hcl:"dockerfile-inline,optional"`
+	Args             map[string]string `json:"args,omitempty" hcl:"args,optional"`
+	Labels           map[string]string `json:"labels,omitempty" hcl:"labels,optional"`
+	Tags             []string          `json:"tags,omitempty" hcl:"tags,optional"`
+	CacheFrom        []string          `json:"cache-from,omitempty"  hcl:"cache-from,optional"`
+	CacheTo          []string          `json:"cache-to,omitempty"  hcl:"cache-to,optional"`
+	Target           *string           `json:"target,omitempty" hcl:"target,optional"`
+	Secrets          []string          `json:"secret,omitempty" hcl:"secret,optional"`
+	SSH              []string          `json:"ssh,omitempty" hcl:"ssh,optional"`
+	Platforms        []string          `json:"platforms,omitempty" hcl:"platforms,optional"`
+	Outputs          []string          `json:"output,omitempty" hcl:"output,optional"`
+	Pull             *bool             `json:"pull,omitempty" hcl:"pull,optional"`
+	NoCache          *bool             `json:"no-cache,omitempty" hcl:"no-cache,optional"`
+}
+
+type Args struct {
+	Push          bool
+	Save          bool
+	BuildxEnabled bool
+	Targets       []string
+	Variants      []string
+	Architectures []string
+	BaseVersion   string
+	ProxyVersion  string
+	IstioVersion  string
+	Tag           string
+	Hub           string
+}
+
+// Define variants, which control the base image of an image.
+// Tags will have the variant append (like 1.0-distroless).
+// The DefaultVariant is a special variant that has no explicit tag (like 1.0); it
+// is not a unique variant though. Currently, it represents DebugVariant.
+// If both DebugVariant and DefaultVariant are built, there will be a single build but multiple tags
+const (
+	// PrimaryVariant is the variant that DefaultVariant actually builds
+	PrimaryVariant = DebugVariant
+
+	DefaultVariant    = "default"
+	DebugVariant      = "debug"
+	DistrolessVariant = "distroless"
+)
+
+func DefaultArgs() Args {
+	// By default, we build all targets
+	targets := []string{
+		"pilot",
+		"proxyv2",
+		"app",
+		"istioctl",
+		"operator",
+		"install-ci",
+
+		"app_sidecar_ubuntu_xenial",
+		"app_sidecar_ubuntu_bionic",
+		"app_sidecar_ubuntu_focal",
+		"app_sidecar_debian_9",
+		"app_sidecar_debian_10",
+		"app_sidecar_centos_8",
+		"app_sidecar_centos_7",
+	}
+	if legacy, f := os.LookupEnv("DOCKER_TARGETS"); f {
+		// Allow env var config. It is a string seperated list like "docker.pilot docker.proxy"
+		targets = []string{}
+		for _, v := range strings.Split(legacy, " ") {
+			if v == "" {
+				continue
+			}
+			targets = append(targets, strings.TrimPrefix(v, "docker."))
+		}
+	}
+	pv, err := testenv.ReadProxySHA()
+	if err != nil {
+		log.Warnf("failed to read proxy sha")
+		pv = "unknown"
+	}
+	variants := []string{DefaultVariant}
+	if legacy, f := os.LookupEnv("DOCKER_BUILD_VARIANTS"); f {
+		variants = strings.Split(legacy, " ")
+	}
+
+	if os.Getenv("INCLUDE_UNTAGGED_DEFAULT") == "true" {
+		// This legacy env var was to workaround the old build logic not being very smart
+		// In the new builder, we automagically detect this. So just insert the 'default' variant
+		cur := sets.NewSet(variants...)
+		cur.Insert(DefaultVariant)
+		variants = cur.SortedList()
+	}
+
+	arch := []string{"linux/amd64"}
+	if legacy, f := os.LookupEnv("DOCKER_ARCHITECTURES"); f {
+		arch = strings.Split(legacy, ",")
+	}
+	return Args{
+		Push:          false,
+		Save:          false,
+		BuildxEnabled: true,
+		Hub:           env.GetString("HUB", "localhost:5000"),
+		Tag:           env.GetString("TAG", "latest"),
+		BaseVersion:   fetchBaseVersion(),
+		IstioVersion:  fetchIstioVersion(),
+		ProxyVersion:  pv,
+		Architectures: arch,
+		Targets:       targets,
+		Variants:      variants,
+	}
+}
+
+var (
+	args    = DefaultArgs()
+	version = false
+)
+
+var baseVersionRegexp = regexp.MustCompile(`BASE_VERSION \?= (.*)`)
+
+func fetchBaseVersion() string {
+	if b, f := os.LookupEnv("BASE_VERSION"); f {
+		return b
+	}
+	b, err := ioutil.ReadFile(filepath.Join(testenv.IstioSrc, "Makefile.core.mk"))
+	if err != nil {
+		log.Fatalf("failed to read file: %v", err)
+		return "unknown"
+	}
+	match := baseVersionRegexp.FindSubmatch(b)
+	if len(match) < 2 {
+		log.Fatalf("failed to find match")
+		return "unknown"
+	}
+	return string(match[1])
+}
+
+var istioVersionRegexp = regexp.MustCompile(`VERSION \?= (.*)`)
+
+func fetchIstioVersion() string {
+	if b, f := os.LookupEnv("VERSION"); f {
+		return b
+	}
+	b, err := ioutil.ReadFile(filepath.Join(testenv.IstioSrc, "Makefile.core.mk"))
+	if err != nil {
+		log.Fatalf("failed to read file: %v", err)
+		return "unknown"
+	}
+	match := istioVersionRegexp.FindSubmatch(b)
+	if len(match) < 2 {
+		log.Fatalf("failed to find match")
+		return "unknown"
+	}
+	return string(match[1])
+}

--- a/tools/docker-copy.sh
+++ b/tools/docker-copy.sh
@@ -41,7 +41,7 @@ function may_copy_into_arch_named_sub_dir() {
       *aarch64*)
         mkdir -p "${DOCKER_WORKING_DIR}/arm64/" && cp -rp "${FILE}" "${DOCKER_WORKING_DIR}/arm64/"
         ;;
-        *)
+      *)
         cp -rp "${FILE}" "${DOCKER_WORKING_DIR}"
         ;;
     esac
@@ -66,9 +66,7 @@ function may_copy_into_arch_named_sub_dir() {
   fi
 }
 
-
+mkdir -p "${DOCKER_WORKING_DIR}"
 for FILE in "${FILES[@]}"; do
   may_copy_into_arch_named_sub_dir "${FILE}"
 done
-
-ls "${DOCKER_WORKING_DIR}";

--- a/tools/istio-docker.mk
+++ b/tools/istio-docker.mk
@@ -111,6 +111,7 @@ docker.pilot2: ${ISTIO_ENVOY_BOOTSTRAP_CONFIG_DIR}/envoy_bootstrap.json
 docker.pilot2: ${ISTIO_ENVOY_BOOTSTRAP_CONFIG_DIR}/gcp_envoy_bootstrap.json
 docker.pilot2: $(ISTIO_OUT_LINUX)/pilot-discovery
 docker.pilot2: pilot/docker/Dockerfile.pilot
+	@$(DOCKER_BUILDER_RULE)
 
 # Test application
 docker.app: BUILD_PRE=
@@ -331,6 +332,7 @@ DOCKER_ALL_VARIANTS ?= debug distroless
 INCLUDE_UNTAGGED_DEFAULT ?= false
 DEFAULT_DISTRIBUTION=debug
 DOCKER_RULE ?= $(foreach VARIANT,$(DOCKER_BUILD_VARIANTS), time (mkdir -p $(DOCKER_BUILD_TOP)/$@ && TARGET_ARCH=$(TARGET_ARCH) ./tools/docker-copy.sh $^ $(DOCKER_BUILD_TOP)/$@ && cd $(DOCKER_BUILD_TOP)/$@ $(BUILD_PRE) && docker build $(BUILD_ARGS) --build-arg BASE_DISTRIBUTION=$(call normalize-tag,$(VARIANT)) -t $(HUB)/$(subst docker.,,$@):$(TAG)$(call variant-tag,$(VARIANT)) -f Dockerfile$(suffix $@) . ); )
+DOCKER_BUILDER_RULE ?= ./tools/docker-copy.sh $^ $(DOCKERX_BUILD_TOP)/$@
 RENAME_TEMPLATE ?= mkdir -p $(DOCKER_BUILD_TOP)/$@ && cp $(ECHO_DOCKER)/$(VM_OS_DOCKERFILE_TEMPLATE) $(DOCKER_BUILD_TOP)/$@/Dockerfile$(suffix $@)
 
 # This target will package all docker images used in test and release, without re-building

--- a/tools/istio-docker.mk
+++ b/tools/istio-docker.mk
@@ -105,6 +105,13 @@ docker.pilot: $(ISTIO_OUT_LINUX)/pilot-discovery
 docker.pilot: pilot/docker/Dockerfile.pilot
 	$(DOCKER_RULE)
 
+docker.pilot2: BUILD_PRE=&& chmod 644 envoy_bootstrap.json gcp_envoy_bootstrap.json
+docker.pilot2: BUILD_ARGS=--build-arg BASE_VERSION=${BASE_VERSION}
+docker.pilot2: ${ISTIO_ENVOY_BOOTSTRAP_CONFIG_DIR}/envoy_bootstrap.json
+docker.pilot2: ${ISTIO_ENVOY_BOOTSTRAP_CONFIG_DIR}/gcp_envoy_bootstrap.json
+docker.pilot2: $(ISTIO_OUT_LINUX)/pilot-discovery
+docker.pilot2: pilot/docker/Dockerfile.pilot
+
 # Test application
 docker.app: BUILD_PRE=
 docker.app: BUILD_ARGS=--build-arg BASE_VERSION=${BASE_VERSION}


### PR DESCRIPTION
This rewrites the amalgamation of make+bash that we use to build docker files today into a fairly simple go program. The bash and make combination is horrible to use - it has a bash HCL generation, and some extreme make complexity (example: `${ISTIO_DOCKER_TAR}/$(subst docker.,,$(TGT))$(call variant-tag,$(VARIANT)).tar $(HUB)/$(subst docker.,,$(TGT)):$(subst -$(DEFAULT_DISTRIBUTION),,$(TAG)-$(VARIANT)) && \`). This has caused a few issues:
* Code is hard to understand
* Code is even harder to change. I tried to make a simple change and it took all day, and popped up many new bugs. When we fix one bug, a new one pops up. This is directly related to the complexity of the code.
* Code is not optimal because its too painful to do the right thing. This leads to people like me having tons of crazy aliases to optimize workflows, while others are left with poor UX.

This re-implementation (attempts) to fix these. Along with simply rewriting in a more readable manner, there are a few other benefits:
* More efficient: automatically determine how to invoke `go build` for optimal performance
* More efficient: for --save mode, emit to tar file in buildx instead of double invocation+copy
* More efficient: for --save mode, only do it once for -debug and default
* Easier to understand. There are 3 variants, debug default and distroless. Do not need to manage INCLUDE_UNTAGGED_DEFAULT as it happens automatically.

In the initial iteration, this simply wraps existing docker commands like `make docker`, `make dockerx`, `make docker.push` to use the new tool. An env var DOCKER_V2_BUILDER is added as an opt out in case this breaks something (which is why the PR has no code removed).

In the future, we can consider the long term plan. Part of the goal of this was to provide a better CLI experience for developers. For example, instead of trying to remember the right make command, I can run things like `tools/docker --push --targets pilot`. Long term, we will need to consider if we start using the tool directly, both in our own usage and in developer recommendations, and sunset the old `make` commands. However, we can decide that after merging this.