### PR TITLE
enable multicluster headless by default

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -536,7 +536,7 @@ var (
 	EnableRouteCollapse = env.RegisterBoolVar("PILOT_ENABLE_ROUTE_COLLAPSE_OPTIMIZATION", true,
 		"If true, Pilot will merge virtual hosts with the same routes into a single virtual host, as an optimization.").Get()
 
-	MulticlusterHeadlessEnabled = env.RegisterBoolVar("ENABLE_MULTICLUSTER_HEADLESS", false,
+	MulticlusterHeadlessEnabled = env.RegisterBoolVar("ENABLE_MULTICLUSTER_HEADLESS", true,
 		"If true, the DNS name table for a headless service will resolve to same-network endpoints in any cluster.").Get()
 
 	CertSignerDomain = env.RegisterStringVar("CERT_SIGNER_DOMAIN", "", "The cert signer domain info").Get()

--- a/releasenotes/notes/35883.yaml
+++ b/releasenotes/notes/35883.yaml
@@ -1,5 +1,6 @@
 area: traffic-management
 releaseNotes:
 - |
-  **Enabled** discovering cross-cluster, same network, endpoints for headless services. This can be disabled by setting
+  **Enabled** discovering cross-cluster, same network, endpoints for headless services when `ISTIO_META_DNS_CAPTURE` and
+  `ISTIO_META_DNS_AUTO_ALLOCATE` are enabled in `ProxyConfig.proxyMetadata`. This can be disabled by setting
   `ENABLE_MULTICLUSTER_HEADLESS=false` in istiod.

--- a/releasenotes/notes/35883.yaml
+++ b/releasenotes/notes/35883.yaml
@@ -1,3 +1,5 @@
+apiVersion: release-notes/v2
+kind: feature
 area: traffic-management
 releaseNotes:
 - |

--- a/releasenotes/notes/35883.yaml
+++ b/releasenotes/notes/35883.yaml
@@ -1,10 +1,5 @@
-apiVersion: release-notes/v2
-kind: feature
-area: istioctl
-issue:
-  - 18487
-
+area: traffic-management
 releaseNotes:
 - |
-  **Updated** `WorkloadEntry` resources will be read across clusters and no longer need to be manually mirrored to other
-  clusters. These endpoints are now automatically discovered and reachable in both multi-cluster and multi-network meshes.
+  **Enabled** discovering cross-cluster, same network, endpoints for headless services. This can be disabled by setting
+  `ENABLE_MULTICLUSTER_HEADLESS=false` in istiod.

--- a/releasenotes/notes/35884.yaml
+++ b/releasenotes/notes/35884.yaml
@@ -1,0 +1,5 @@
+area: traffic-management
+releaseNotes:
+  - |
+    **Updated** `WorkloadEntry` resources will be read across clusters and no longer need to be manually mirrored to other
+    clusters. These endpoints are now automatically discovered and reachable in both multi-cluster and multi-network meshes.

--- a/releasenotes/notes/35884.yaml
+++ b/releasenotes/notes/35884.yaml
@@ -1,3 +1,5 @@
+apiVersion: release-notes/v2
+kind: feature
 area: traffic-management
 releaseNotes:
   - |

--- a/tests/integration/iop-integration-test-defaults-with-quic.yaml
+++ b/tests/integration/iop-integration-test-defaults-with-quic.yaml
@@ -60,7 +60,6 @@ spec:
       autoscaleEnabled: false
       env:
         UNSAFE_ENABLE_ADMIN_ENDPOINTS: true
-        ENABLE_MULTICLUSTER_HEADLESS: true
         PILOT_REMOTE_CLUSTER_TIMEOUT: 15s
         PILOT_ENABLE_QUIC_LISTENERS: true
 

--- a/tests/integration/iop-integration-test-defaults.yaml
+++ b/tests/integration/iop-integration-test-defaults.yaml
@@ -56,7 +56,6 @@ spec:
       autoscaleEnabled: false
       env:
         UNSAFE_ENABLE_ADMIN_ENDPOINTS: true
-        ENABLE_MULTICLUSTER_HEADLESS: true
         PILOT_REMOTE_CLUSTER_TIMEOUT: 15s
 
     gateways:


### PR DESCRIPTION
We've had this integration tested for some time, and it has been tried by [some users](https://istio.slack.com/archives/C01AT2S8B7B/p1630861283017700).

The only concern is users who relied on these being cluster-local, the release note partially covers that. Some of the docs for multi-cluster in 1.12 will show better mechanisms to do cluster-local settings on a per-service basis.