### PR TITLE
enable multicluster workload entry by default

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -454,7 +454,7 @@ var (
 	WorkloadEntryHealthChecks = env.RegisterBoolVar("PILOT_ENABLE_WORKLOAD_ENTRY_HEALTHCHECKS", true,
 		"Enables automatic health checks of WorkloadEntries based on the config provided in the associated WorkloadGroup").Get()
 
-	WorkloadEntryCrossCluster = env.RegisterBoolVar("PILOT_ENABLE_CROSS_CLUSTER_WORKLOAD_ENTRY", false,
+	WorkloadEntryCrossCluster = env.RegisterBoolVar("PILOT_ENABLE_CROSS_CLUSTER_WORKLOAD_ENTRY", true,
 		"If enabled, pilot will read WorkloadEntry from other clusters, selectable by Services in that cluster.").Get()
 
 	EnableFlowControl = env.RegisterBoolVar(

--- a/releasenotes/notes/35883.yaml
+++ b/releasenotes/notes/35883.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: feature
+area: istioctl
+issue:
+  - 18487
+
+releaseNotes:
+- |
+  **Updated** `WorkloadEntry` resources will be read across clusters and no longer need to be manually mirrored to other
+  clusters. These endpoints are now automatically discovered and reachable in both multi-cluster and multi-network meshes.

--- a/tests/integration/iop-integration-test-defaults-with-quic.yaml
+++ b/tests/integration/iop-integration-test-defaults-with-quic.yaml
@@ -60,7 +60,6 @@ spec:
       autoscaleEnabled: false
       env:
         UNSAFE_ENABLE_ADMIN_ENDPOINTS: true
-        PILOT_ENABLE_CROSS_CLUSTER_WORKLOAD_ENTRY: true
         ENABLE_MULTICLUSTER_HEADLESS: true
         PILOT_REMOTE_CLUSTER_TIMEOUT: 15s
         PILOT_ENABLE_QUIC_LISTENERS: true

--- a/tests/integration/iop-integration-test-defaults.yaml
+++ b/tests/integration/iop-integration-test-defaults.yaml
@@ -56,7 +56,6 @@ spec:
       autoscaleEnabled: false
       env:
         UNSAFE_ENABLE_ADMIN_ENDPOINTS: true
-        PILOT_ENABLE_CROSS_CLUSTER_WORKLOAD_ENTRY: true
         ENABLE_MULTICLUSTER_HEADLESS: true
         PILOT_REMOTE_CLUSTER_TIMEOUT: 15s
 


### PR DESCRIPTION
This has been enabled since January in integration tests, it should be proven stable. 