### PR TITLE
Update to fix hadolint warning

### DIFF
--- a/samples/bookinfo/src/productpage/Dockerfile
+++ b/samples/bookinfo/src/productpage/Dockerfile
@@ -14,6 +14,7 @@
 
 FROM python:3.7.7-slim
 
+WORKDIR /
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 


### PR DESCRIPTION
**Please provide a description of this PR:**

Testing hadolint 2.7.0 and this change was identified.

```
./samples/bookinfo/src/productpage/Dockerfile:17 DL3045 warning: `COPY` to a relative destination without `WORKDIR` set.
./samples/bookinfo/src/productpage/Dockerfile:20 DL3045 warning: `COPY` to a relative destination without `WORKDIR` set.
```