### PR TITLE
support root cert specified in mesh config

### DIFF
--- a/pilot/pkg/bootstrap/istio_ca.go
+++ b/pilot/pkg/bootstrap/istio_ca.go
@@ -489,7 +489,17 @@ func (s *Server) createIstioRA(client kubelib.Client,
 		TrustDomain:      opts.TrustDomain,
 		CertSignerDomain: opts.CertSignerDomain,
 	}
-	return ra.NewIstioRA(raOpts)
+	raServer, err := ra.NewIstioRA(raOpts)
+	if err != nil {
+		return nil, err
+	}
+	raServer.SetCACertificatesFromMeshConfig(s.environment.Mesh().CaCertificates)
+	s.environment.AddMeshHandler(func() {
+		meshConfig := s.environment.Mesh()
+		caCertificates := meshConfig.CaCertificates
+		s.RA.SetCACertificatesFromMeshConfig(caCertificates)
+	})
+	return raServer, err
 }
 
 // getJwtPath returns jwt path.

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -1259,8 +1259,17 @@ func (s *Server) initWorkloadTrustBundle(args *PilotArgs) error {
 // It return true only if istiod certs is signed by Kubernetes and
 // workload certs are signed by external CA
 func (s *Server) isDisableCa() bool {
-	return (features.PilotCertProvider == constants.CertProviderKubernetes ||
-		strings.HasPrefix(features.PilotCertProvider, constants.CertProviderKubernetesSignerPrefix)) && s.RA != nil
+	if s.RA != nil {
+		// do not create CA server if PilotCertProvider is `kubernetes` and RA server exists
+		if features.PilotCertProvider == constants.CertProviderKubernetes {
+			return true
+		}
+		// do not create CA server if PilotCertProvider is `k8s.io/*` and RA server exists
+		if strings.HasPrefix(features.PilotCertProvider, constants.CertProviderKubernetesSignerPrefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *Server) initStatusManager(_ *PilotArgs) {

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -989,6 +989,12 @@ func (s *Server) initIstiodCerts(args *PilotArgs, host string) error {
 		if err == nil {
 			err = s.initIstiodCertLoader()
 		}
+	} else if strings.HasPrefix(features.PilotCertProvider, constants.CertProviderKubernetesSignerPrefix) {
+		log.Infof("initializing Istiod DNS certificates host: %s, custom host: %s", host, features.IstiodServiceCustomHost)
+		err = s.initDNSCerts(host, args.Namespace)
+		if err == nil {
+			err = s.initIstiodCertLoader()
+		}
 	}
 
 	return err
@@ -1009,7 +1015,13 @@ func (s *Server) createPeerCertVerifier(tlsOptions TLSOptions) (*spiffe.PeerCert
 		}
 	} else {
 		if s.RA != nil {
-			rootCertBytes = append(rootCertBytes, s.RA.GetCAKeyCertBundle().GetRootCertPem()...)
+			if strings.HasPrefix(features.PilotCertProvider, constants.CertProviderKubernetesSignerPrefix) {
+				signerName := strings.TrimPrefix(features.PilotCertProvider, constants.CertProviderKubernetesSignerPrefix)
+				caBundle, _ := s.RA.GetRootCertFromMeshConfig(signerName)
+				rootCertBytes = append(rootCertBytes, caBundle...)
+			} else {
+				rootCertBytes = append(rootCertBytes, s.RA.GetCAKeyCertBundle().GetRootCertPem()...)
+			}
 		}
 		if s.CA != nil {
 			rootCertBytes = append(rootCertBytes, s.CA.GetCAKeyCertBundle().GetRootCertPem()...)
@@ -1247,7 +1259,8 @@ func (s *Server) initWorkloadTrustBundle(args *PilotArgs) error {
 // It return true only if istiod certs is signed by Kubernetes and
 // workload certs are signed by external CA
 func (s *Server) isDisableCa() bool {
-	return features.PilotCertProvider == constants.CertProviderKubernetes && s.RA != nil
+	return (features.PilotCertProvider == constants.CertProviderKubernetes ||
+		strings.HasPrefix(features.PilotCertProvider, constants.CertProviderKubernetesSignerPrefix)) && s.RA != nil
 }
 
 func (s *Server) initStatusManager(_ *PilotArgs) {

--- a/pkg/config/constants/constants.go
+++ b/pkg/config/constants/constants.go
@@ -132,6 +132,8 @@ const (
 	CertProviderIstiod = "istiod"
 	// CertProviderKubernetes uses the Kubernetes CSR API to generate a DNS certificate for the control plane
 	CertProviderKubernetes = "kubernetes"
+	// CertProviderKubernetesSignerPrefix uses the Kubernetes CSR API and the specified signer to generate a DNS certificate for the control plane
+	CertProviderKubernetesSignerPrefix = "k8s.io/"
 	// CertProviderCustom uses the custom root certificate mounted in a well known location for the control plane
 	CertProviderCustom = "custom"
 	// CertProviderNone does not create any certificates for the control plane. It is assumed that some external

--- a/pkg/test/csrctrl/controllers/csr_controller.go
+++ b/pkg/test/csrctrl/controllers/csr_controller.go
@@ -34,11 +34,12 @@ import (
 // CertificateSigningRequestSigningReconciler reconciles a CertificateSigningRequest object
 type CertificateSigningRequestSigningReconciler struct {
 	client.Client
-	SignerRoot  string
-	CtrlCertTTL time.Duration
-	Scheme      *runtime.Scheme
-	SignerNames []string
-	Signers     map[string]*signer.Signer
+	SignerRoot     string
+	CtrlCertTTL    time.Duration
+	Scheme         *runtime.Scheme
+	SignerNames    []string
+	Signers        map[string]*signer.Signer
+	appendRootCert bool
 }
 
 // +kubebuilder:rbac:groups=certificates.k8s.io,resources=certificatesigningrequests,verbs=get;list;watch
@@ -85,7 +86,7 @@ func (r *CertificateSigningRequestSigningReconciler) Reconcile(_ context.Context
 				requestedLifeTime = duration
 			}
 		}
-		cert, err := signer.Sign(x509cr, csr.Spec.Usages, requestedLifeTime)
+		cert, err := signer.Sign(x509cr, csr.Spec.Usages, requestedLifeTime, r.appendRootCert)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("error auto signing csr: %v", err)
 		}

--- a/pkg/test/csrctrl/controllers/start_csrctrl.go
+++ b/pkg/test/csrctrl/controllers/start_csrctrl.go
@@ -46,7 +46,13 @@ var (
 	_              = corev1.AddToScheme(scheme)
 )
 
-func RunCSRController(signerNames string, config *rest.Config, c <-chan struct{}) {
+type SignerRootCert struct {
+	Signer   string
+	Rootcert string
+}
+
+func RunCSRController(signerNames string, appendRootCert bool, config *rest.Config, c <-chan struct{},
+	certChan chan *SignerRootCert) {
 	// Config Istio log
 	if err := log.Configure(loggingOptions); err != nil {
 		log.Infof("Unable to configure Istio log error: %v", err)
@@ -71,15 +77,26 @@ func RunCSRController(signerNames string, config *rest.Config, c <-chan struct{}
 			os.Exit(-1)
 		}
 		signersMap[signerName] = signer
+		rootCert, rErr := os.ReadFile(signer.GetRootCerts())
+		if rErr != nil {
+			log.Infof("Unable to read root cert for signer [%s], error: %v", signerName, sErr)
+			os.Exit(-1)
+		}
+		rootCertsForSigner := &SignerRootCert{
+			Signer:   signerName,
+			Rootcert: string(rootCert),
+		}
+		certChan <- rootCertsForSigner
 	}
 
 	if err := (&CertificateSigningRequestSigningReconciler{
-		Client:      mgr.GetClient(),
-		SignerRoot:  signerRoot,
-		CtrlCertTTL: certificateDuration,
-		Scheme:      mgr.GetScheme(),
-		SignerNames: arrSingers,
-		Signers:     signersMap,
+		Client:         mgr.GetClient(),
+		SignerRoot:     signerRoot,
+		CtrlCertTTL:    certificateDuration,
+		Scheme:         mgr.GetScheme(),
+		SignerNames:    arrSingers,
+		Signers:        signersMap,
+		appendRootCert: appendRootCert,
 	}).SetupWithManager(mgr); err != nil {
 		log.Infof("Unable to create Controller fro controller CSRSigningReconciler, error: %v", err)
 		os.Exit(-1)

--- a/security/pkg/pki/ca/ca.go
+++ b/security/pkg/pki/ca/ca.go
@@ -320,8 +320,8 @@ func (ca *IstioCA) Sign(csrPEM []byte, certOpts CertOpts) (
 
 // SignWithCertChain is similar to Sign but returns the leaf cert and the entire cert chain.
 func (ca *IstioCA) SignWithCertChain(csrPEM []byte, certOpts CertOpts) (
-	[]byte, error) {
-	return ca.signWithCertChain(csrPEM, certOpts.SubjectIDs, certOpts.TTL, true, certOpts.ForCA)
+	[]string, error) {
+	return ca.getSignedCertChain(csrPEM, certOpts.SubjectIDs, certOpts.TTL, true, certOpts.ForCA)
 }
 
 // GetCAKeyCertBundle returns the KeyCertBundle for the CA.
@@ -414,12 +414,31 @@ func (ca *IstioCA) sign(csrPEM []byte, subjectIDs []string, requestedLifetime ti
 	return cert, nil
 }
 
+func (ca *IstioCA) getSignedCertChain(csrPEM []byte, subjectIDs []string, requestedLifetime time.Duration, lifetimeCheck,
+	forCA bool) ([]string, error) {
+	cert, err := ca.sign(csrPEM, subjectIDs, requestedLifetime, lifetimeCheck, forCA)
+	if err != nil {
+		return nil, err
+	}
+	respCertChain := []string{string(cert)}
+	chainPem := ca.GetCAKeyCertBundle().GetCertChainPem()
+	if len(chainPem) > 0 {
+		respCertChain = append(respCertChain, string(chainPem))
+	}
+	_, _, _, rootCertBytes := ca.GetCAKeyCertBundle().GetAll()
+	if len(rootCertBytes) != 0 {
+		respCertChain = append(respCertChain, string(rootCertBytes))
+	}
+	return respCertChain, nil
+}
+
 func (ca *IstioCA) signWithCertChain(csrPEM []byte, subjectIDs []string, requestedLifetime time.Duration, lifetimeCheck,
 	forCA bool) ([]byte, error) {
 	cert, err := ca.sign(csrPEM, subjectIDs, requestedLifetime, lifetimeCheck, forCA)
 	if err != nil {
 		return nil, err
 	}
+
 	chainPem := ca.GetCAKeyCertBundle().GetCertChainPem()
 	if len(chainPem) > 0 {
 		cert = append(cert, chainPem...)

--- a/security/pkg/pki/ca/ca_test.go
+++ b/security/pkg/pki/ca/ca_test.go
@@ -562,7 +562,8 @@ func TestSignWithCertChain(t *testing.T) {
 		TTL:        time.Hour,
 		ForCA:      false,
 	}
-	certPEM, signErr := ca.SignWithCertChain(csrPEM, caCertOpts)
+	certPEM, signErr := ca.signWithCertChain(csrPEM, caCertOpts.SubjectIDs, caCertOpts.TTL, true, caCertOpts.ForCA)
+
 	if signErr != nil {
 		t.Error(err)
 	}

--- a/security/pkg/pki/ca/mock/fakeca.go
+++ b/security/pkg/pki/ca/mock/fakeca.go
@@ -38,15 +38,20 @@ func (ca *FakeCA) Sign(csr []byte, certOpts ca.CertOpts) ([]byte, error) {
 }
 
 // SignWithCertChain returns the SignErr if SignErr is not nil, otherwise, it returns SignedCert and the cert chain.
-func (ca *FakeCA) SignWithCertChain(csr []byte, certOpts ca.CertOpts) ([]byte, error) {
+func (ca *FakeCA) SignWithCertChain(csr []byte, certOpts ca.CertOpts) ([]string, error) {
 	if ca.SignErr != nil {
 		return nil, ca.SignErr
 	}
 	cert := ca.SignedCert
+	respCertChain := []string{string(cert)}
 	if ca.KeyCertBundle != nil {
-		cert = append(cert, ca.KeyCertBundle.GetCertChainPem()...)
+		respCertChain = append(respCertChain, string(ca.KeyCertBundle.GetCertChainPem()))
 	}
-	return cert, nil
+	_, _, _, rootCertBytes := ca.GetCAKeyCertBundle().GetAll()
+	if len(rootCertBytes) != 0 {
+		respCertChain = append(respCertChain, string(rootCertBytes))
+	}
+	return respCertChain, nil
 }
 
 // GetCAKeyCertBundle returns KeyCertBundle if KeyCertBundle is not nil, otherwise, it returns an empty

--- a/security/pkg/pki/ra/common.go
+++ b/security/pkg/pki/ra/common.go
@@ -19,6 +19,7 @@ import (
 
 	clientset "k8s.io/client-go/kubernetes"
 
+	meshconfig "istio.io/api/mesh/v1alpha1"
 	raerror "istio.io/istio/security/pkg/pki/error"
 	"istio.io/istio/security/pkg/pki/util"
 	caserver "istio.io/istio/security/pkg/server/ca"
@@ -27,6 +28,10 @@ import (
 // RegistrationAuthority : Registration Authority interface.
 type RegistrationAuthority interface {
 	caserver.CertificateAuthority
+	// SetCACertificatesFromMeshConfig sets the CACertificates using the ones from mesh config
+	SetCACertificatesFromMeshConfig([]*meshconfig.MeshConfig_CertificateData)
+	// GetRootCertFromMeshConfig returns the root cert for the specific signer in mesh config
+	GetRootCertFromMeshConfig(signerName string) ([]byte, error)
 }
 
 // CaExternalType : Type of External CA integration

--- a/security/pkg/pki/ra/k8s_ra_test.go
+++ b/security/pkg/pki/ra/k8s_ra_test.go
@@ -15,6 +15,8 @@
 package ra
 
 import (
+	"os"
+	"path"
 	"testing"
 	"time"
 
@@ -24,7 +26,9 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	kt "k8s.io/client-go/testing"
 
+	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pkg/spiffe"
+	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/security/pkg/k8s/chiron"
 	"istio.io/istio/security/pkg/pki/ca"
 	pkiutil "istio.io/istio/security/pkg/pki/util"
@@ -79,25 +83,24 @@ func createFakeCsr(t *testing.T) []byte {
 	return csrPEM
 }
 
-func initFakeKubeClient(csrName string) *fake.Clientset {
+func initFakeKubeClient(csrName, certificate string) *fake.Clientset {
 	client := fake.NewSimpleClientset()
 	csr := &cert.CertificateSigningRequest{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: csrName,
 		},
 		Status: cert.CertificateSigningRequestStatus{
-			Certificate: []byte(TestCertificatePEM),
+			Certificate: []byte(certificate),
 		},
 	}
 	client.PrependReactor("get", "certificatesigningrequests", defaultReactionFunc(csr))
 	return client
 }
 
-func createFakeK8sRA(client *fake.Clientset) (*KubernetesRA, error) {
+func createFakeK8sRA(client *fake.Clientset, caCertFile string) (*KubernetesRA, error) {
 	defaultCertTTL := 30 * time.Minute
 	maxCertTTL := time.Hour
 	caSigner := "kubernates.io/kube-apiserver-client"
-	caCertFile := "../testdata/example-ca-cert.pem"
 	raOpts := &IstioRAOptions{
 		ExternalCAType: ExtCAK8s,
 		DefaultCertTTL: defaultCertTTL,
@@ -110,12 +113,60 @@ func createFakeK8sRA(client *fake.Clientset) (*KubernetesRA, error) {
 	return NewKubernetesRA(raOpts)
 }
 
+func TestK8sSignWithMeshConfig(t *testing.T) {
+	csrPEM := createFakeCsr(t)
+	csrName := chiron.GenCsrName()
+	rootCertPem, err := os.ReadFile(path.Join(env.IstioSrc, "samples/certs", "root-cert.pem"))
+	if err != nil {
+		t.Errorf("Failed to read sample root-cert.pem")
+	}
+	certChainPem, err := os.ReadFile(path.Join(env.IstioSrc, "samples/certs", "cert-chain.pem"))
+	if err != nil {
+		t.Errorf("Failed to read sample cert-chain.pem")
+	}
+	client := initFakeKubeClient(csrName, string(certChainPem))
+	ra, err := createFakeK8sRA(client, "")
+	if err != nil {
+		t.Errorf("Failed to create Fake K8s RA")
+	}
+	signer := "kubernates.io/kube-apiserver-client"
+	ra.certSignerDomain = "kubernates.io"
+	caCertificates := []*meshconfig.MeshConfig_CertificateData{
+		{CertificateData: &meshconfig.MeshConfig_CertificateData_Pem{Pem: string(rootCertPem)}, CertSigners: []string{signer}},
+	}
+	ra.SetCACertificatesFromMeshConfig(caCertificates)
+	subjectID := spiffe.Identity{TrustDomain: "cluster.local", Namespace: "default", ServiceAccount: "bookinfo-productpage"}.String()
+	certOptions := ca.CertOpts{
+		SubjectIDs: []string{subjectID},
+		TTL:        60 * time.Second, ForCA: false,
+		CertSigner: "kube-apiserver-client",
+	}
+	// expect to sign back successfully
+	_, err = ra.SignWithCertChain(csrPEM, certOptions)
+	if err != nil {
+		t.Errorf("K8s CA Signing CSR With Root Cert In Meshconfig failed")
+	}
+	testCACert, err := os.ReadFile(TestCACertFile)
+	if err != nil {
+		t.Errorf("Failed to read test CA Cert file")
+	}
+	updatedCACertificates := []*meshconfig.MeshConfig_CertificateData{
+		{CertificateData: &meshconfig.MeshConfig_CertificateData_Pem{Pem: string(testCACert)}, CertSigners: []string{signer}},
+	}
+	ra.SetCACertificatesFromMeshConfig(updatedCACertificates)
+	// expect failure in sign since root cert in mesh config does not match
+	_, err = ra.SignWithCertChain(csrPEM, certOptions)
+	if err == nil {
+		t.Errorf("K8s CA Signing CSR With Root Cert In Meshconfig failed")
+	}
+}
+
 // TestK8sSign : Verify that ra.k8sSign returns a valid certPEM while using k8s Fake Client to create a CSR
 func TestK8sSign(t *testing.T) {
 	csrPEM := createFakeCsr(t)
 	csrName := chiron.GenCsrName()
-	client := initFakeKubeClient(csrName)
-	r, err := createFakeK8sRA(client)
+	client := initFakeKubeClient(csrName, TestCertificatePEM)
+	r, err := createFakeK8sRA(client, TestCACertFile)
 	if err != nil {
 		t.Errorf("Validation CSR failed")
 	}
@@ -132,8 +183,8 @@ func TestK8sSign(t *testing.T) {
 func TestValidateCSR(t *testing.T) {
 	csrPEM := createFakeCsr(t)
 	csrName := chiron.GenCsrName()
-	client := initFakeKubeClient(csrName)
-	_, err := createFakeK8sRA(client)
+	client := initFakeKubeClient(csrName, TestCertificatePEM)
+	_, err := createFakeK8sRA(client, TestCACertFile)
 	if err != nil {
 		t.Errorf("Validation CSR failed")
 	}

--- a/security/pkg/pki/util/verify_cert.go
+++ b/security/pkg/pki/util/verify_cert.go
@@ -185,7 +185,7 @@ func FindRootCertFromCertificateChainBytes(certBytes []byte) ([]byte, error) {
 	}
 	rootBlock, _ := pem.Decode(cert)
 	if rootBlock == nil {
-		return nil, fmt.Errorf("error decoding root certificate")
+		return nil, nil
 	}
 	rootCert, err := x509.ParseCertificate(rootBlock.Bytes)
 	if err != nil {

--- a/security/pkg/server/ca/server.go
+++ b/security/pkg/server/ca/server.go
@@ -39,8 +39,8 @@ type CertificateAuthority interface {
 	// Sign generates a certificate for a workload or CA, from the given CSR and cert opts.
 	Sign(csrPEM []byte, opts ca.CertOpts) ([]byte, error)
 	// SignWithCertChain is similar to Sign but returns the leaf cert and the entire cert chain.
-	SignWithCertChain(csrPEM []byte, opts ca.CertOpts) ([]byte, error)
-	// GetCAKeyCertBundle returns the KeyCertBundle used by CA.
+	SignWithCertChain(csrPEM []byte, opts ca.CertOpts) ([]string, error)
+	// SignWithCertChain is similar to Sign but returns the leaf cert and the entire cert chain.
 	GetCAKeyCertBundle() *util.KeyCertBundle
 }
 
@@ -81,38 +81,18 @@ func (s *Server) CreateCertificate(ctx context.Context, request *pb.IstioCertifi
 	crMetadata := request.Metadata.GetFields()
 	certSigner := crMetadata[security.CertSigner].GetStringValue()
 	log.Debugf("cert signer from workload %s", certSigner)
-	_, _, certChainBytes, rootCertBytes := s.ca.GetCAKeyCertBundle().GetAll()
 	certOpts := ca.CertOpts{
 		SubjectIDs: caller.Identities,
 		TTL:        time.Duration(request.ValidityDuration) * time.Second,
 		ForCA:      false,
 		CertSigner: certSigner,
 	}
-	cert, signErr := s.ca.Sign([]byte(request.Csr), certOpts)
+	respCertChain, signErr := s.ca.SignWithCertChain([]byte(request.Csr), certOpts)
 	if signErr != nil {
 		serverCaLog.Errorf("CSR signing error (%v)", signErr.Error())
 		s.monitoring.GetCertSignError(signErr.(*caerror.Error).ErrorType()).Increment()
 		return nil, status.Errorf(signErr.(*caerror.Error).HTTPErrorCode(), "CSR signing error (%v)", signErr.(*caerror.Error))
 	}
-	respCertChain := []string{string(cert)}
-	if len(certChainBytes) != 0 {
-		respCertChain = append(respCertChain, string(certChainBytes))
-	}
-	if len(rootCertBytes) == 0 {
-		rootCert, err := util.FindRootCertFromCertificateChainBytes(cert)
-		if err != nil {
-			serverCaLog.Errorf("failed to find root cert from signed cert-chain (%v)", err.Error())
-			s.monitoring.GetCertSignError(err.(*caerror.Error).ErrorType()).Increment()
-			return nil, status.Errorf(err.(*caerror.Error).HTTPErrorCode(), "failed to find root cert from signed cert-chain (%v)", err.(*caerror.Error))
-		}
-		if verifyErr := util.VerifyCertificate(nil, cert, rootCert, nil); verifyErr != nil {
-			serverCaLog.Errorf("root cert from signed cert-chain is invalid (%v)", err.Error())
-			s.monitoring.GetCertSignError(err.(*caerror.Error).ErrorType()).Increment()
-			return nil, status.Errorf(err.(*caerror.Error).HTTPErrorCode(), "root cert from signed cert-chain is invalid (%v)", err.(*caerror.Error))
-		}
-		rootCertBytes = rootCert
-	}
-	respCertChain = append(respCertChain, string(rootCertBytes))
 	response := &pb.IstioCertificateResponse{
 		CertChain: respCertChain,
 	}

--- a/tests/integration/security/external_ca/main_test.go
+++ b/tests/integration/security/external_ca/main_test.go
@@ -28,6 +28,7 @@ import (
 	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/framework/label"
 	"istio.io/istio/pkg/test/framework/resource"
+	"istio.io/istio/pkg/test/util/tmpl"
 	"istio.io/istio/tests/integration/security/util"
 )
 
@@ -91,41 +92,58 @@ func TestMain(m *testing.M) {
 }
 
 func setupConfig(ctx resource.Context, cfg *istio.Config) {
-	go csrctrl.RunCSRController("clusterissuers.istio.io/signer1", ctx.Clusters()[0].RESTConfig(), stopChan)
+	certsChan := make(chan *csrctrl.SignerRootCert, 2)
+	go csrctrl.RunCSRController("clusterissuers.istio.io/signer1,clusterissuers.istio.io/signer2", false,
+		ctx.Clusters()[0].RESTConfig(), stopChan, certsChan)
+	cert1 := <-certsChan
+	cert2 := <-certsChan
+
 	if cfg == nil {
 		return
 	}
-	cfg.ControlPlaneValues = `
-meshConfig:
-  defaultConfig:
-    proxyMetadata:
-      ISTIO_META_CERT_SIGNER: signer1
-components:
-  pilot:
-    k8s:
-      env:
-      - name: CERT_SIGNER_DOMAIN
-        value: clusterissuers.istio.io
-      - name: EXTERNAL_CA
-        value: ISTIOD_RA_KUBERNETES_API
-      overlays:
-        # Amend ClusterRole to add permission for istiod to approve certificate signing by custom signer
-        - kind: ClusterRole
-          name: istiod-clusterrole-istio-system
-          patches:
-            - path: rules[-1]
-              value: |
-                apiGroups:
-                - certificates.k8s.io
-                resourceNames:
-                - clusterissuers.istio.io/*
-                resources:
-                - signers
-                verbs:
-                - approve
+	cfgYaml := tmpl.MustEvaluate(`
 values:
   meshConfig:
+    defaultConfig:
+      proxyMetadata:
+        PROXY_CONFIG_XDS_AGENT: "true"
+        ISTIO_META_CERT_SIGNER: signer1
     trustDomainAliases: [some-other, trust-domain-foo]
-`
+    caCertificates:
+    - pem: |
+{{.rootcert1 | indent 8}}
+      certSigners:
+      - {{.signer1}}
+    - pem: |
+{{.rootcert2 | indent 8}}
+      certSigners:
+      - {{.signer2}}
+  components:
+    pilot:
+      k8s:
+        env:
+        - name: CERT_SIGNER_DOMAIN
+          value: clusterissuers.istio.io
+        - name: EXTERNAL_CA
+          value: ISTIOD_RA_KUBERNETES_API
+        - name: PILOT_CERT_PROVIDER
+          value: k8s.io/clusterissuers.istio.io/signer2
+        overlays:
+          # Amend ClusterRole to add permission for istiod to approve certificate signing by custom signer
+          - kind: ClusterRole
+            name: istiod-clusterrole-istio-system
+            patches:
+              - path: rules[-1]
+                value: |
+                  apiGroups:
+                  - certificates.k8s.io
+                  resourceNames:
+                  - clusterissuers.istio.io/*
+                  resources:
+                  - signers
+                  verbs:
+                  - approve
+`, map[string]string{"rootcert1": cert1.Rootcert, "signer1": cert1.Signer, "rootcert2": cert2.Rootcert, "signer2": cert2.Signer})
+	cfg.ControlPlaneValues = cfgYaml
 	cfg.DeployEastWestGW = false
 }


### PR DESCRIPTION
- do not create istio ca if `PILOT-CERT-PROVIDER` is `k8s.io/**` and `EXTERNAL_CA` is `ISTIOD_RA_KUBERNETES_API`
- Use root certs specified in meshconfig for workloads and istiod
- validate the root cert for signed cert from cert-chain against root cert specified in meshconfig