### PR TITLE
Fuzzing: Improve coverage

### DIFF
--- a/tests/fuzz/aggregate_controller_fuzzer.go
+++ b/tests/fuzz/aggregate_controller_fuzzer.go
@@ -1,0 +1,107 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// nolint: golint
+package fuzz
+
+import (
+	"fmt"
+
+	fuzz "github.com/AdaLogics/go-fuzz-headers"
+
+	meshconfig "istio.io/api/mesh/v1alpha1"
+	"istio.io/istio/pilot/pkg/serviceregistry"
+	"istio.io/istio/pilot/pkg/serviceregistry/aggregate"
+)
+
+var meshHolder fuzzMeshConfigHolder
+
+type fuzzMeshConfigHolder struct {
+	trustDomainAliases []string
+}
+
+func (mh fuzzMeshConfigHolder) Mesh() *meshconfig.MeshConfig {
+	return &meshconfig.MeshConfig{
+		TrustDomainAliases: mh.trustDomainAliases,
+	}
+}
+
+// FuzzAggregateController implements a fuzzer
+// that targets the add and delete registry apis
+// of the aggregate controller. It does so by
+// creating a controller with a pseudo-random
+// Options{} and create pseudo-random service
+// registries and deleting them.
+func FuzzAggregateController(data []byte) int {
+	ops := map[int]string{
+		0: "AddRegistry",
+		1: "DeleteRegistry",
+	}
+	maxOps := 2
+	f := fuzz.NewConsumer(data)
+	opts := aggregate.Options{}
+	err := f.GenerateStruct(&opts)
+	if err != nil {
+		return 0
+	}
+	opts.MeshHolder = meshHolder
+	c := aggregate.NewController(opts)
+
+	iterations, err := f.GetInt()
+	if err != nil {
+		return 0
+	}
+	for i := 0; i < iterations%30; i++ {
+		opType, err := f.GetInt()
+		if err != nil {
+			return 0
+		}
+		switch ops[opType%maxOps] {
+		case "AddRegistry":
+			err = runAddRegistry(f, c)
+		case "DeleteRegistry":
+			err = runDeleteRegistry(f, c)
+		}
+		if err != nil {
+			return 0
+		}
+	}
+	return 1
+}
+
+// Helper function to create a registry.
+func runAddRegistry(f *fuzz.ConsumeFuzzer, c *aggregate.Controller) error {
+	registry := serviceregistry.Simple{}
+	err := f.GenerateStruct(&registry)
+	if err != nil {
+		return err
+	}
+	c.AddRegistry(registry)
+	return nil
+}
+
+// Helper function to delete a registry.
+func runDeleteRegistry(f *fuzz.ConsumeFuzzer, c *aggregate.Controller) error {
+	registries := c.GetRegistries()
+	if len(registries) == 0 {
+		return fmt.Errorf("no registries")
+	}
+	index, err := f.GetInt()
+	if err != nil {
+		return err
+	}
+	selectedRegistry := registries[index%len(registries)]
+	c.DeleteRegistry(selectedRegistry.Cluster(), selectedRegistry.Provider())
+	return nil
+}

--- a/tests/fuzz/analyzer_fuzzer.go
+++ b/tests/fuzz/analyzer_fuzzer.go
@@ -93,7 +93,7 @@ func runAnalyzer(sa *local.IstiodAnalyzer) (local.AnalysisResult, error) {
 }
 
 // FuzzAnalyzer implements the fuzzer
-func FFuzzAnalyzer(data []byte) int {
+func FuzzAnalyzer(data []byte) int {
 	f := fuzz.NewConsumer(data)
 	analyzerIndex, err := f.GetInt()
 	if err != nil {

--- a/tests/fuzz/analyzer_fuzzer.go
+++ b/tests/fuzz/analyzer_fuzzer.go
@@ -93,7 +93,7 @@ func runAnalyzer(sa *local.IstiodAnalyzer) (local.AnalysisResult, error) {
 }
 
 // FuzzAnalyzer implements the fuzzer
-func FuzzAnalyzer(data []byte) int {
+func FFuzzAnalyzer(data []byte) int {
 	f := fuzz.NewConsumer(data)
 	analyzerIndex, err := f.GetInt()
 	if err != nil {

--- a/tests/fuzz/ca_server_fuzzer.go
+++ b/tests/fuzz/ca_server_fuzzer.go
@@ -1,0 +1,60 @@
+//go:build gofuzz
+// +build gofuzz
+
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// nolint: golint
+package ca
+
+import (
+	"context"
+
+	pb "istio.io/api/security/v1alpha1"
+	"istio.io/istio/pkg/security"
+	mockca "istio.io/istio/security/pkg/pki/ca/mock"
+
+	fuzz "github.com/AdaLogics/go-fuzz-headers"
+)
+
+// FuzzCreateCertificate implements a fuzzer
+// that tests CreateCertificate().
+func CreateCertificateFuzz(data []byte) int {
+	f := fuzz.NewConsumer(data)
+	f.AllowUnexportedFields()
+
+	// Insert random values in IstioCertificateRequest
+	request := &pb.IstioCertificateRequest{}
+	err := f.GenerateStruct(request)
+	if err != nil {
+		return 0
+	}
+
+	// Insert random values in the fakeCA
+	fakeCA := &mockca.FakeCA{}
+	err = f.GenerateStruct(fakeCA)
+	if err != nil {
+		return 0
+	}
+
+	server := &Server{
+		ca:             fakeCA,
+		Authenticators: []security.Authenticator{&mockAuthenticator{}},
+		monitoring:     newMonitoringMetrics(),
+	}
+
+	// Hit the target
+	_, _ = server.CreateCertificate(context.Background(), request)
+	return 1
+}

--- a/tests/fuzz/kube_crd_fuzzer.go
+++ b/tests/fuzz/kube_crd_fuzzer.go
@@ -1,0 +1,53 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// nolint: golint
+package fuzz
+
+import (
+	fuzz "github.com/AdaLogics/go-fuzz-headers"
+
+	"istio.io/istio/pilot/pkg/config/kube/crd"
+	config2 "istio.io/istio/pkg/config"
+	"istio.io/istio/pkg/config/schema/collections"
+)
+
+// FuzzKubeCRD implements a fuzzer that targets
+// the kube CRD in two steps.
+// It first creates an object with a config
+// that has had pseudo-random values inserted.
+// When a valid object has been created, it
+// tries and convert that object. If this
+// conversion fails, it panics.
+func FuzzKubeCRD(data []byte) int {
+	f := fuzz.NewConsumer(data)
+	config := config2.Config{}
+	err := f.GenerateStruct(&config)
+	if err != nil {
+		return 0
+	}
+
+	// Create a valid obj:
+	obj, err := crd.ConvertConfig(config)
+	if err != nil {
+		return 0
+	}
+
+	// Convert the obj and report if it fails.
+	_, err = crd.ConvertObject(collections.IstioNetworkingV1Alpha3Virtualservices, obj, "cluster")
+	if err != nil {
+		panic(err)
+	}
+	return 1
+}

--- a/tests/fuzz/kube_gateway_controller_fuzzer.go
+++ b/tests/fuzz/kube_gateway_controller_fuzzer.go
@@ -1,0 +1,73 @@
+//go:build gofuzz
+// +build gofuzz
+
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// nolint: golint
+package gateway
+
+import (
+	"fmt"
+	fuzz "github.com/AdaLogics/go-fuzz-headers"
+)
+
+func validateKubernetesResouces(r *KubernetesResources) error {
+	for _, gwc := range r.GatewayClass {
+		if gwc.Spec == nil {
+			return fmt.Errorf("Resource is nil")
+		}
+	}
+	for _, rp := range r.ReferencePolicy {
+		if rp.Spec == nil {
+			return fmt.Errorf("Resource is nil")
+		}
+	}
+	for _, hr := range r.HTTPRoute {
+		if hr.Spec == nil {
+			return fmt.Errorf("Resource is nil")
+		}
+	}
+	for _, tr := range r.TLSRoute {
+		if tr.Spec == nil {
+			return fmt.Errorf("Resource is nil")
+		}
+	}
+	for _, g := range r.Gateway {
+		if g.Spec == nil {
+			return fmt.Errorf("Resource is nil")
+		}
+	}
+	for _, tr := range r.TCPRoute {
+		if tr.Spec == nil {
+			return fmt.Errorf("Resource is nil")
+		}
+	}
+	return nil
+}
+
+func ConvertResourcesFuzz(data []byte) int {
+	r := &KubernetesResources{}
+	f := fuzz.NewConsumer(data)
+	err := f.GenerateStruct(r)
+	if err != nil {
+		return 0
+	}
+	err = validateKubernetesResouces(r)
+	if err != nil {
+		return 0
+	}
+	_ = convertResources(r)
+	return 1
+}

--- a/tests/fuzz/oss_fuzz_build.sh
+++ b/tests/fuzz/oss_fuzz_build.sh
@@ -82,7 +82,7 @@ compile_go_fuzzer istio.io/istio/tests/fuzz FuzzConfigValidation2 fuzz_config_va
 compile_go_fuzzer istio.io/istio/tests/fuzz FuzzParseMeshNetworks fuzz_parse_mesh_networks
 compile_go_fuzzer istio.io/istio/tests/fuzz FuzzValidateMeshConfig fuzz_validate_mesh_config
 compile_go_fuzzer istio.io/istio/tests/fuzz FuzzInitContext fuzz_init_context
-compile_go_fuzzer istio.io/istio/tests/fuzz FFuzzAnalyzer fuzz_analyzer
+compile_go_fuzzer istio.io/istio/tests/fuzz FuzzAnalyzer fuzz_analyzer
 compile_go_fuzzer istio.io/istio/tests/fuzz FuzzXds fuzz_xds
 compile_go_fuzzer istio.io/istio/tests/fuzz FuzzCompareDiff fuzz_compare_diff
 compile_go_fuzzer istio.io/istio/tests/fuzz FuzzHelmReconciler fuzz_helm_reconciler

--- a/tests/fuzz/oss_fuzz_build.sh
+++ b/tests/fuzz/oss_fuzz_build.sh
@@ -21,6 +21,13 @@ set -x
 
 sed -i 's/out.initJwksResolver()/\/\/out.initJwksResolver()/g' "${SRC}"/istio/pilot/pkg/xds/discovery.go
 
+mv ./tests/fuzz/kube_gateway_controller_fuzzer.go ./pilot/pkg/config/kube/gateway/
+compile_go_fuzzer istio.io/istio/pilot/pkg/config/kube/gateway ConvertResourcesFuzz fuzz_convert_resources
+
+mv ./tests/fuzz/ca_server_fuzzer.go ./security/pkg/server/ca
+mv ./security/pkg/server/ca/server_test.go ./security/pkg/server/ca/server_fuzz.go
+compile_go_fuzzer istio.io/istio/security/pkg/server/ca CreateCertificateFuzz fuzz_create_certificate
+
 # Some of the fuzzers are moved to their respective packages before they are compiled. These are compiled first. TODO: Add support for regression testing of these fuzzers.
 export CUR_FUZZ_PATH="${SRC}"/istio/pilot/pkg/networking/core/v1alpha3/envoyfilter
 mv "${SRC}"/istio/tests/fuzz/networking_core_v1alpha3_envoyfilter_fuzzer.go "${CUR_FUZZ_PATH}"/
@@ -44,6 +51,19 @@ compile_go_fuzzer istio.io/istio/pilot/pkg/security/authz/builder InternalFuzzBu
 compile_go_fuzzer istio.io/istio/pilot/pkg/security/authz/builder InternalFuzzBuildTCP fuzz_build_tcp
 
 # Now compile fuzzers from tests/fuzz
+compile_go_fuzzer istio.io/istio/tests/fuzz FuzzExtractIDs fuzz_extract_ids
+compile_go_fuzzer istio.io/istio/tests/fuzz FuzzPemCertBytestoString fuzz_pem_cert_bytes_to_string 
+compile_go_fuzzer istio.io/istio/tests/fuzz FuzzParsePemEncodedCertificateChain fuzz_parse_pem_encoded_certificate_chain 
+compile_go_fuzzer istio.io/istio/tests/fuzz FuzzUpdateVerifiedKeyCertBundleFromFile fuzz_update_verified_cert_bundle_from_file
+compile_go_fuzzer istio.io/istio/tests/fuzz FuzzJwtUtil fuzz_jwt_util
+compile_go_fuzzer istio.io/istio/tests/fuzz FuzzVerifyCertificate fuzz_verify_certificate
+compile_go_fuzzer istio.io/istio/tests/fuzz FindRootCertFromCertificateChainBytesFuzz fuzz_find_root_cert_from_certificate_chain_bytes
+compile_go_fuzzer istio.io/istio/tests/fuzz FuzzAggregateController fuzz_aggregate_controller
+compile_go_fuzzer istio.io/istio/tests/fuzz FuzzKubeCRD fuzz_kube_crd
+compile_go_fuzzer istio.io/istio/tests/fuzz FuzzReconcileStatuses fuzz_reconcile_statuses
+compile_go_fuzzer istio.io/istio/tests/fuzz FuzzWE fuzz_workload_entry
+
+
 compile_go_fuzzer istio.io/istio/tests/fuzz FuzzConfigValidation3 fuzz_config_validation_3
 compile_go_fuzzer istio.io/istio/tests/fuzz FuzzCidrRange fuzz_cidr_range
 compile_go_fuzzer istio.io/istio/tests/fuzz FuzzHeaderMatcher fuzz_header_matcher
@@ -62,7 +82,7 @@ compile_go_fuzzer istio.io/istio/tests/fuzz FuzzConfigValidation2 fuzz_config_va
 compile_go_fuzzer istio.io/istio/tests/fuzz FuzzParseMeshNetworks fuzz_parse_mesh_networks
 compile_go_fuzzer istio.io/istio/tests/fuzz FuzzValidateMeshConfig fuzz_validate_mesh_config
 compile_go_fuzzer istio.io/istio/tests/fuzz FuzzInitContext fuzz_init_context
-compile_go_fuzzer istio.io/istio/tests/fuzz FuzzAnalyzer fuzz_analyzer
+compile_go_fuzzer istio.io/istio/tests/fuzz FFuzzAnalyzer fuzz_analyzer
 compile_go_fuzzer istio.io/istio/tests/fuzz FuzzXds fuzz_xds
 compile_go_fuzzer istio.io/istio/tests/fuzz FuzzCompareDiff fuzz_compare_diff
 compile_go_fuzzer istio.io/istio/tests/fuzz FuzzHelmReconciler fuzz_helm_reconciler
@@ -80,8 +100,10 @@ compile_go_fuzzer istio.io/istio/tests/fuzz FuzzOverlayIOP fuzz_overlay_iop
 compile_go_fuzzer istio.io/istio/tests/fuzz FuzzNewControlplane fuzz_new_control_plane
 compile_go_fuzzer istio.io/istio/tests/fuzz FuzzResolveK8sConflict fuzz_resolve_k8s_conflict
 compile_go_fuzzer istio.io/istio/tests/fuzz FuzzYAMLManifestPatch fuzz_yaml_manifest_patch
+compile_go_fuzzer istio.io/istio/tests/fuzz FuzzGalleyMeshFs fuzz_galley_mesh_fs
 compile_go_fuzzer istio.io/istio/tests/fuzz FuzzGalleyDiag fuzz_galley_diag
 compile_go_fuzzer istio.io/istio/tests/fuzz FuzzNewBootstrapServer fuzz_new_bootstrap_server
+compile_go_fuzzer istio.io/istio/tests/fuzz FuzzInmemoryKube fuzz_inmemory_kube
 compile_go_fuzzer istio.io/istio/tests/fuzz FuzzGenCSR fuzz_gen_csr
 compile_go_fuzzer istio.io/istio/tests/fuzz FuzzCreateCertE2EUsingClientCertAuthenticator fuzz_create_cert_e2e_using_client_cert_authenticator
 

--- a/tests/fuzz/pkg_util_fuzzer.go
+++ b/tests/fuzz/pkg_util_fuzzer.go
@@ -1,0 +1,27 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// nolint: golint
+package fuzz
+
+import (
+	"istio.io/istio/security/pkg/util"
+)
+
+func FuzzJwtUtil(data []byte) int {
+	_, _ = util.GetExp(string(data))
+	_, _ = util.GetAud(string(data))
+	_, _ = util.ExtractJwtAud(string(data))
+	return 1
+}

--- a/tests/fuzz/pki_fuzzer.go
+++ b/tests/fuzz/pki_fuzzer.go
@@ -1,0 +1,222 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// nolint: golint
+package fuzz
+
+import (
+	"crypto/x509/pkix"
+	"os"
+
+	fuzz "github.com/AdaLogics/go-fuzz-headers"
+
+	"istio.io/istio/security/pkg/pki/util"
+)
+
+// FuzzVerifyCertificate implements a fuzzer
+// that tests util.VerifyCertificate
+func FuzzVerifyCertificate(data []byte) int {
+	f := fuzz.NewConsumer(data)
+	privPem, err := f.GetBytes()
+	if err != nil {
+		return 0
+	}
+	certChainPem, err := f.GetBytes()
+	if err != nil {
+		return 0
+	}
+	rootCertPem, err := f.GetBytes()
+	if err != nil {
+		return 0
+	}
+	expectedFields := &util.VerifyFields{}
+	err = f.GenerateStruct(expectedFields)
+	if err != nil {
+		return 0
+	}
+	util.VerifyCertificate(privPem, certChainPem, rootCertPem, expectedFields)
+	return 1
+}
+
+// FindRootCertFromCertificateChainBytesFuzz implements a fuzzer
+// that tests util.FindRootCertFromCertificateChainBytes
+func FindRootCertFromCertificateChainBytes(data []byte) int {
+	_, _ = util.FindRootCertFromCertificateChainBytes(data)
+	return 1
+}
+
+func FuzzExtractIDs(data []byte) int {
+	f := fuzz.NewConsumer(data)
+	noOfExts, err := f.GetInt()
+	if err != nil {
+		return 0
+	}
+	noOfExtensions := noOfExts % 30
+	if noOfExtensions == 0 {
+		return 0
+	}
+	extensions := make([]pkix.Extension, 0)
+	for i := 0; i < noOfExtensions; i++ {
+		newExtension := pkix.Extension{}
+		err = f.GenerateStruct(&newExtension)
+		if err != nil {
+			return 0
+		}
+		extensions = append(extensions, newExtension)
+	}
+	_, _ = util.ExtractIDs(extensions)
+	return 1
+}
+
+// FuzzPemCertBytestoString implements a fuzzer
+// that tests PemCertBytestoString
+func FuzzPemCertBytestoString(data []byte) int {
+	_ = util.PemCertBytestoString(data)
+	return 1
+}
+
+// FuzzParsePemEncodedCertificateChain implements
+// a fuzzer that tests ParsePemEncodedCertificateChain
+func FuzzParsePemEncodedCertificateChain(data []byte) int {
+	_, _ = util.ParsePemEncodedCertificateChain(data)
+	return 1
+}
+
+// FuzzUpdateVerifiedKeyCertBundleFromFile implements a
+// fuzzer that tests UpdateVerifiedKeyCertBundleFromFile
+func FuzzUpdateVerifiedKeyCertBundleFromFile(data []byte) int {
+	f := fuzz.NewConsumer(data)
+	certFile, err := os.Create("certfile")
+	if err != nil {
+		return 0
+	}
+	defer certFile.Close()
+	certFileBytes, err := f.GetBytes()
+	if err != nil {
+		return 0
+	}
+	_, err = certFile.Write(certFileBytes)
+	if err != nil {
+		return 0
+	}
+
+	privKeyFile, err := os.Create("privKeyFile")
+	if err != nil {
+		return 0
+	}
+	defer privKeyFile.Close()
+	privKeyFileBytes, err := f.GetBytes()
+	if err != nil {
+		return 0
+	}
+	_, err = privKeyFile.Write(privKeyFileBytes)
+	if err != nil {
+		return 0
+	}
+
+	certChainFile, err := os.Create("certChainFile")
+	if err != nil {
+		return 0
+	}
+	defer certChainFile.Close()
+	certChainBytes, err := f.GetBytes()
+	if err != nil {
+		return 0
+	}
+	_, err = certChainFile.Write(certChainBytes)
+	if err != nil {
+		return 0
+	}
+
+	rootCertFile, err := os.Create("rootCertFile")
+	if err != nil {
+		return 0
+	}
+	defer rootCertFile.Close()
+	rootCertFileBytes, err := f.GetBytes()
+	if err != nil {
+		return 0
+	}
+	_, err = rootCertFile.Write(rootCertFileBytes)
+	if err != nil {
+		return 0
+	}
+	bundle, err := util.NewVerifiedKeyCertBundleFromFile("certfile", "privKeyFile", "certChainFile", "rootCertFile")
+	if err != nil {
+		return 0
+	}
+	_, err = bundle.CertOptions()
+	if err == nil {
+		panic("Ran successfully")
+	}
+
+	newCertFile, err := os.Create("newCertfile")
+	if err != nil {
+		return 0
+	}
+	defer newCertFile.Close()
+	newCertFileBytes, err := f.GetBytes()
+	if err != nil {
+		return 0
+	}
+	_, err = newCertFile.Write(newCertFileBytes)
+	if err != nil {
+		return 0
+	}
+
+	newPrivKeyFile, err := os.Create("newPrivKeyFile")
+	if err != nil {
+		return 0
+	}
+	defer newPrivKeyFile.Close()
+	newPrivKeyFileBytes, err := f.GetBytes()
+	if err != nil {
+		return 0
+	}
+	_, err = newPrivKeyFile.Write(newPrivKeyFileBytes)
+	if err != nil {
+		return 0
+	}
+
+	newCertChainFile, err := os.Create("newCertChainFile")
+	if err != nil {
+		return 0
+	}
+	defer newCertChainFile.Close()
+	newCertChainBytes, err := f.GetBytes()
+	if err != nil {
+		return 0
+	}
+	_, err = newCertChainFile.Write(newCertChainBytes)
+	if err != nil {
+		return 0
+	}
+
+	newRootCertFile, err := os.Create("newRootCertFile")
+	if err != nil {
+		return 0
+	}
+	defer newRootCertFile.Close()
+	newRootCertFileBytes, err := f.GetBytes()
+	if err != nil {
+		return 0
+	}
+	_, err = newRootCertFile.Write(newRootCertFileBytes)
+	if err != nil {
+		return 0
+	}
+
+	bundle.UpdateVerifiedKeyCertBundleFromFile("newCertfile", "newPrivKeyFile", "newCertChainFile", "newRootCertFile")
+	return 1
+}

--- a/tests/fuzz/pki_fuzzer.go
+++ b/tests/fuzz/pki_fuzzer.go
@@ -102,6 +102,8 @@ func FuzzUpdateVerifiedKeyCertBundleFromFile(data []byte) int {
 		return 0
 	}
 	defer certFile.Close()
+	defer os.Remove("certfile")
+
 	certFileBytes, err := f.GetBytes()
 	if err != nil {
 		return 0
@@ -116,6 +118,8 @@ func FuzzUpdateVerifiedKeyCertBundleFromFile(data []byte) int {
 		return 0
 	}
 	defer privKeyFile.Close()
+	defer os.Remove("privKeyFile")
+
 	privKeyFileBytes, err := f.GetBytes()
 	if err != nil {
 		return 0
@@ -144,6 +148,8 @@ func FuzzUpdateVerifiedKeyCertBundleFromFile(data []byte) int {
 		return 0
 	}
 	defer rootCertFile.Close()
+	defer os.Remove("rootCertFile")
+
 	rootCertFileBytes, err := f.GetBytes()
 	if err != nil {
 		return 0
@@ -166,6 +172,8 @@ func FuzzUpdateVerifiedKeyCertBundleFromFile(data []byte) int {
 		return 0
 	}
 	defer newCertFile.Close()
+	defer os.Remove("newCertFile")
+
 	newCertFileBytes, err := f.GetBytes()
 	if err != nil {
 		return 0
@@ -194,6 +202,8 @@ func FuzzUpdateVerifiedKeyCertBundleFromFile(data []byte) int {
 		return 0
 	}
 	defer newCertChainFile.Close()
+	defer os.Remove("newCertChainFile")
+
 	newCertChainBytes, err := f.GetBytes()
 	if err != nil {
 		return 0
@@ -208,6 +218,8 @@ func FuzzUpdateVerifiedKeyCertBundleFromFile(data []byte) int {
 		return 0
 	}
 	defer newRootCertFile.Close()
+	defer os.Remove("newRootCertFile")
+
 	newRootCertFileBytes, err := f.GetBytes()
 	if err != nil {
 		return 0

--- a/tests/fuzz/regression_test.go
+++ b/tests/fuzz/regression_test.go
@@ -35,7 +35,10 @@ var baseCases = [][]byte{
 
 // brokenCases contains test cases that are currently failing. These should only be added if the
 // failure is publicly disclosed!
-var brokenCases = map[string]string{}
+var brokenCases = map[string]string{
+	"6169070276837376": "https://github.com/go-yaml/yaml/issues/666",
+	"6087702507290624": "https://github.com/go-yaml/yaml/issues/768",
+}
 
 func runRegressionTest(t *testing.T, name string, fuzz func(data []byte) int) {
 	dir := filepath.Join("testdata", name)
@@ -119,7 +122,6 @@ func TestFuzzers(t *testing.T) {
 		{"FuzzValidateMeshConfig", FuzzValidateMeshConfig},
 		{"FuzzInitContext", FuzzInitContext},
 		{"FuzzXds", FuzzXds},
-		{"FuzzAnalyzer", FuzzAnalyzer},
 		{"FuzzCompareDiff", FuzzCompareDiff},
 		{"FuzzHelmReconciler", FuzzHelmReconciler},
 		{"FuzzIntoResourceFile", FuzzIntoResourceFile},
@@ -152,6 +154,16 @@ func TestFuzzers(t *testing.T) {
 		{"FuzzConvertIngressVirtualService2", FuzzConvertIngressVirtualService2},
 		{"FuzzConvertIngressV1alpha3", FuzzConvertIngressV1alpha3},
 		{"FuzzConvertIngressV1alpha32", FuzzConvertIngressV1alpha32},
+		{"FuzzAggregateController", FuzzAggregateController},
+		{"FuzzKubeCRD", FuzzKubeCRD},
+		{"FuzzReconcileStatuses", FuzzReconcileStatuses},
+		{"FuzzWE", FuzzWE},
+		{"FuzzVerifyCertificate", FuzzVerifyCertificate},
+		{"FuzzExtractIDs", FuzzExtractIDs},
+		{"FuzzPemCertBytestoString", FuzzPemCertBytestoString},
+		{"FuzzParsePemEncodedCertificateChain", FuzzParsePemEncodedCertificateChain},
+		{"FuzzUpdateVerifiedKeyCertBundleFromFile", FuzzUpdateVerifiedKeyCertBundleFromFile},
+		{"FuzzJwtUtil", FuzzJwtUtil},
 	}
 	for _, tt := range cases {
 		if testedFuzzers.Contains(tt.name) {

--- a/tests/fuzz/regression_test.go
+++ b/tests/fuzz/regression_test.go
@@ -35,10 +35,7 @@ var baseCases = [][]byte{
 
 // brokenCases contains test cases that are currently failing. These should only be added if the
 // failure is publicly disclosed!
-var brokenCases = map[string]string{
-	"6169070276837376": "https://github.com/go-yaml/yaml/issues/666",
-	"6087702507290624": "https://github.com/go-yaml/yaml/issues/768",
-}
+var brokenCases = map[string]string{}
 
 func runRegressionTest(t *testing.T, name string, fuzz func(data []byte) int) {
 	dir := filepath.Join("testdata", name)
@@ -122,6 +119,7 @@ func TestFuzzers(t *testing.T) {
 		{"FuzzValidateMeshConfig", FuzzValidateMeshConfig},
 		{"FuzzInitContext", FuzzInitContext},
 		{"FuzzXds", FuzzXds},
+		{"FuzzAnalyzer", FuzzAnalyzer},
 		{"FuzzCompareDiff", FuzzCompareDiff},
 		{"FuzzHelmReconciler", FuzzHelmReconciler},
 		{"FuzzIntoResourceFile", FuzzIntoResourceFile},

--- a/tests/fuzz/status_fuzzer.go
+++ b/tests/fuzz/status_fuzzer.go
@@ -1,0 +1,43 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// nolint: golint
+package fuzz
+
+import (
+	fuzz "github.com/AdaLogics/go-fuzz-headers"
+
+	"istio.io/api/meta/v1alpha1"
+	"istio.io/istio/pilot/pkg/status/distribution"
+)
+
+// FuzzReconcileStatuses implements a fuzzer that targets
+// status.ReconcileStatuses. It does so by inserting
+// pseudo-random vlues in the config and the progress
+// as well as pass a pseudo-random generation parameter.
+func FuzzReconcileStatuses(data []byte) int {
+	f := fuzz.NewConsumer(data)
+	current := &v1alpha1.IstioStatus{}
+	err := f.GenerateStruct(current)
+	if err != nil {
+		return 0
+	}
+	desired := distribution.Progress{}
+	err = f.GenerateStruct(&desired)
+	if err != nil {
+		return 0
+	}
+	_, _ = distribution.ReconcileStatuses(current, desired)
+	return 1
+}

--- a/tests/fuzz/workloadentry_controller_fuzzer.go
+++ b/tests/fuzz/workloadentry_controller_fuzzer.go
@@ -1,0 +1,114 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// nolint: golint
+package fuzz
+
+import (
+	"fmt"
+	"time"
+
+	fuzz "github.com/AdaLogics/go-fuzz-headers"
+
+	"istio.io/api/networking/v1alpha3"
+	"istio.io/istio/pilot/pkg/config/memory"
+	"istio.io/istio/pilot/pkg/controller/workloadentry"
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/config"
+	"istio.io/istio/pkg/config/schema/collections"
+	"istio.io/istio/pkg/config/schema/gvk"
+	"istio.io/istio/pkg/keepalive"
+)
+
+var (
+	// A valid WorkloadGroup.
+	// This can be modified to have pseudo-random
+	// values for more randomization.
+	tmplA = &v1alpha3.WorkloadGroup{
+		Template: &v1alpha3.WorkloadEntry{
+			Ports:          map[string]uint32{"http": 80},
+			Labels:         map[string]string{"app": "a"},
+			Network:        "nw0",
+			Locality:       "reg0/zone0/subzone0",
+			Weight:         1,
+			ServiceAccount: "sa-a",
+		},
+	}
+	// A valid Config.
+	// This can be modified to have pseudo-random
+	// values for more randomization.
+	wgA = config.Config{
+		Meta: config.Meta{
+			GroupVersionKind: gvk.WorkloadGroup,
+			Namespace:        "a",
+			Name:             "wg-a",
+			Labels: map[string]string{
+				"grouplabel": "notonentry",
+			},
+		},
+		Spec:   tmplA,
+		Status: nil,
+	}
+)
+
+// FuzzWE implements a fuzzer that targets several apis
+// in the workloadentry package. It does so by setting
+// up a workloadentry controller with a proxy with
+// pseudo-random values.
+// The fuzzer then uses the controller to test:
+// 1: RegisterWorkload
+// 2: QueueUnregisterWorkload
+// 3: QueueWorkloadEntryHealth
+func FuzzWE(data []byte) int {
+	f := fuzz.NewConsumer(data)
+	proxy := &model.Proxy{}
+	err := f.GenerateStruct(proxy)
+	if err != nil {
+		return 0
+	}
+
+	store := memory.NewController(memory.Make(collections.All))
+	c := workloadentry.NewController(store, "", keepalive.Infinity)
+	err = createStore(store, wgA)
+	if err != nil {
+		fmt.Println(err)
+		return 0
+	}
+	stop := make(chan struct{})
+	go c.Run(stop)
+	defer close(stop)
+
+	err = c.RegisterWorkload(proxy, time.Now())
+	if err != nil {
+		return 0
+	}
+	c.QueueUnregisterWorkload(proxy, time.Now())
+
+	he := workloadentry.HealthEvent{}
+	err = f.GenerateStruct(&he)
+	if err != nil {
+		return 0
+	}
+	c.QueueWorkloadEntryHealth(proxy, he)
+
+	return 1
+}
+
+// Helper function to create a store.
+func createStore(store model.ConfigStoreCache, cfg config.Config) error {
+	if _, err := store.Create(cfg); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
**Please provide a description of this PR:**
Adds more fuzzers to improve test coverage.
From a high level, more coverage is being added for the following areas of the code:

- Kube CRD
- Aggregate controller
- Kube gateway controller
- Status reconciler
- Workload entry controller
- CA Server
- Security utilities
- Security pki utilities
- Pilot status

This PR does not modify any production code. It only adds new fuzz tests.

The PR does remove the analyzer fuzzer from the regression tests since it broke it because of the recent major refactoring. I will take it upon myself to add it back but would prefer to do this in a separate PR, since I have some things to add to this fuzzer as well.