### PR TITLE
Fix XDS server authn problem when using GKE workload certificates

### DIFF
--- a/pilot/cmd/pilot-agent/options/security.go
+++ b/pilot/cmd/pilot-agent/options/security.go
@@ -122,7 +122,6 @@ func SetupSecurityOptions(proxyConfig *meshconfig.ProxyConfig, secOpt *security.
 			return nil, fmt.Errorf(
 				"invalid options: PROV_CERT and FILE_MOUNTED_CERTS of GKE workload cert are mutually exclusive")
 		}
-		o.FileMountedCerts = true
 		o.CertChainFilePath = security.GkeWorkloadCertChainFilePath
 		o.KeyFilePath = security.GkeWorkloadKeyFilePath
 		o.RootCertFilePath = security.GkeWorkloadRootCertFilePath

--- a/pkg/istio-agent/agent.go
+++ b/pkg/istio-agent/agent.go
@@ -629,7 +629,7 @@ func (a *Agent) FindRootCAForCA() (string, error) {
 // newSecretManager creates the SecretManager for workload secrets
 func (a *Agent) newSecretManager() (*cache.SecretManagerClient, error) {
 	// If proxy is using file mounted certs, we do not have to connect to CA.
-	if a.secOpts.FileMountedCerts {
+	if a.secOpts.FileMountedCerts || a.secOpts.CAProviderName == security.GkeWorkloadCertificateProvider {
 		log.Info("Workload is using file mounted certificates. Skipping connecting to CA")
 		return cache.NewSecretManagerClient(nil, a.secOpts)
 	}

--- a/pkg/istio-agent/agent_test.go
+++ b/pkg/istio-agent/agent_test.go
@@ -255,7 +255,7 @@ func TestAgent(t *testing.T) {
 			a.Security.CertChainFilePath = cfg.CertificatePath
 			a.Security.KeyFilePath = cfg.PrivateKeyPath
 			a.Security.RootCertFilePath = cfg.CaCertificatePath
-			a.Security.FileMountedCerts = true
+			a.Security.CAProviderName = security.GkeWorkloadCertificateProvider
 			return a
 		}).Check(t, security.WorkloadKeyCertResourceName, security.RootCertReqResourceName)
 	})

--- a/security/pkg/nodeagent/sds/sdsservice.go
+++ b/security/pkg/nodeagent/sds/sdsservice.go
@@ -94,7 +94,7 @@ func newSDSService(st security.SecretManager, options *security.Options) *sdsser
 
 	ret.rootCaPath = options.CARootPath
 
-	if options.FileMountedCerts {
+	if options.FileMountedCerts || options.CAProviderName == security.GkeWorkloadCertificateProvider {
 		return ret
 	}
 


### PR DESCRIPTION
**Please provide a description of this PR:**
https://github.com/istio/istio/issues/35385

Problem: when security.Options.FileMountedCerts is true, the root CA path for authenticating XDS server is always obtained from ISTIO_META_TLS_CLIENT_ROOT_CERT. When using GKE workload certificates, the root CA path for authenticating XDS server is based on PilotCertProvider and ISTIO_META_TLS_CLIENT_ROOT_CERT is not set.

Solution: Decouple GKE workload certificates from security.Options.FileMountedCerts because coupling them will cause an empty root CA path for authenticating XDS server when using GKE workload certificates.


**Please check any characteristics that apply to this pull request.**

- [X ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.