### PR TITLE
Delete GetValidatingWebhooksWithRevision func

### DIFF
--- a/istioctl/pkg/tag/util.go
+++ b/istioctl/pkg/tag/util.go
@@ -61,18 +61,6 @@ func GetWebhooksWithRevision(ctx context.Context, client kubernetes.Interface, r
 	return webhooks.Items, nil
 }
 
-// GetValidatingWebhooksWithRevision returns validating webhooks tagged with istio.io/rev=<rev> and NOT TAGGED with istio.io/tag.
-// this retrieves the webhook created at revision installation rather than tags.
-func GetValidatingWebhooksWithRevision(ctx context.Context, client kubernetes.Interface, rev string) ([]admit_v1.ValidatingWebhookConfiguration, error) {
-	webhooks, err := client.AdmissionregistrationV1().ValidatingWebhookConfigurations().List(ctx, metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("%s=%s,!%s", label.IoIstioRev.Name, rev, IstioTagLabel),
-	})
-	if err != nil {
-		return nil, err
-	}
-	return webhooks.Items, nil
-}
-
 // GetNamespacesWithTag retrieves all namespaces pointed at the given tag.
 func GetNamespacesWithTag(ctx context.Context, client kubernetes.Interface, tag string) ([]string, error) {
 	namespaces, err := client.CoreV1().Namespaces().List(ctx, metav1.ListOptions{


### PR DESCRIPTION
**Please provide a description of this PR:**
delete `GetValidatingWebhooksWithRevision` func
`GetValidatingWebhooksWithRevision` unused


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [x] Networking


**Please check any characteristics that apply to this pull request.**
NONE

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
