### PR TITLE
Set sysctls for gateway ports

### DIFF
--- a/manifests/charts/gateway/README.md
+++ b/manifests/charts/gateway/README.md
@@ -100,7 +100,12 @@ It could be upgraded with
 helm upgrade istio-ingress manifests/charts/gateway -n istio-system --set name=istio-ingressgateway --set labels.app=istio-ingressgateway --set labels.istio=ingressgateway
 ```
 
-Note the name and labels are overridden to match the names of the existing installation
+Note the name and labels are overridden to match the names of the existing installation.
+
+Warning: the helm charts here default to using port 80 and 443, while the old charts used 8080 and 8443.
+If you have AuthorizationPolicies that reference port these ports, you should update them during this process,
+or customize the ports to match the old defaults.
+See the [security advisory](https://istio.io/latest/news/security/istio-security-2021-002/) for more information.
 
 #### Other migrations
 

--- a/manifests/charts/gateway/templates/deployment.yaml
+++ b/manifests/charts/gateway/templates/deployment.yaml
@@ -1,11 +1,3 @@
-{{/*
-unPriv port determines if net.ipv4.ip_unprivileged_port_start should be set, which allows binding to low ports like 80.
-Because its not safe for all versions, we allow explicitly configuring or automatically setting based on version
-This is safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326.
-The expression is complex but is basically `unpriv = explicitly enabled || (auto && recent enough version)`
-If not true, users should bind to ports >1024 with targetPort or set runAsRoot.
-*/}}
-{{ $unprivPort := or (eq (toString .Values.unprivilegedPort) "true") (and (eq (toString .Values.unprivilegedPort) "auto") (semverCompare ">=1.22-0" .Capabilities.KubeVersion.GitVersion)) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -40,36 +32,45 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "gateway.serviceAccountName" . }}
-      {{- if not .Values.runAsRoot }}
       securityContext:
-        {{- if $unprivPort }}
+      {{- if .Values.securityContext }}
+        {{- toYaml .Values.securityContext | nindent 8 }}
+      {{- else if (semverCompare ">=1.22-0" .Capabilities.KubeVersion.GitVersion) }}
         # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
         sysctls:
         - name: net.ipv4.ip_unprivileged_port_start
           value: "0"
-        {{- end }}
-        runAsUser: 1337
-        runAsGroup: 1337
-        runAsNonRoot: true
-        fsGroup: 1337
       {{- end }}
       containers:
         - name: istio-proxy
           image: auto
-          {{- if not .Values.runAsRoot }}
           securityContext:
-            allowPrivilegeEscalation: false
+          {{- if .Values.containerSecurityContext }}
+            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          {{- else if (semverCompare ">=1.22-0" .Capabilities.KubeVersion.GitVersion) }}
+            # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
             capabilities:
               drop:
               - ALL
+            allowPrivilegeEscalation: false
             privileged: false
+            readOnlyRootFilesystem: true
+            runAsUser: 1337
+            runAsGroup: 1337
+            runAsNonRoot: true
+          {{- else }}
+            capabilities:
+              drop:
+              - ALL
+              add:
+              - NET_BIND_SERVICE
+            runAsUser: 0
+            runAsGroup: 1337
+            runAsNonRoot: false
+            allowPrivilegeEscalation: true
             readOnlyRootFilesystem: true
           {{- end }}
           env:
-          {{- if and (not .Values.runAsRoot) (not $unprivPort) }}
-          - name: ISTIO_META_UNPRIVILEGED_POD
-            value: "true"
-          {{- end }}
           {{- with .Values.networkGateway }}
           - name: ISTIO_META_REQUESTED_NETWORK_VIEW
             value: "{{.}}"

--- a/manifests/charts/gateway/templates/deployment.yaml
+++ b/manifests/charts/gateway/templates/deployment.yaml
@@ -1,3 +1,11 @@
+{{/*
+unPriv port determines if net.ipv4.ip_unprivileged_port_start should be set, which allows binding to low ports like 80.
+Because its not safe for all versions, we allow explicitly configuring or automatically setting based on version
+This is safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326.
+The expression is complex but is basically `unpriv = explicitly enabled || (auto && recent enough version)`
+If not true, users should bind to ports >1024 with targetPort or set runAsRoot.
+*/}}
+{{ $unprivPort := or (eq (toString .Values.unprivilegedPort) "true") (and (eq (toString .Values.unprivilegedPort) "auto") (semverCompare ">=1.22-0" .Capabilities.KubeVersion.GitVersion)) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -34,6 +42,12 @@ spec:
       serviceAccountName: {{ include "gateway.serviceAccountName" . }}
       {{- if not .Values.runAsRoot }}
       securityContext:
+        {{- if $unprivPort }}
+        # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
+        sysctls:
+        - name: net.ipv4.ip_unprivileged_port_start
+          value: "0"
+        {{- end }}
         runAsUser: 1337
         runAsGroup: 1337
         runAsNonRoot: true
@@ -52,7 +66,7 @@ spec:
             readOnlyRootFilesystem: true
           {{- end }}
           env:
-          {{- if not .Values.runAsRoot }}
+          {{- if and (not .Values.runAsRoot) (not $unprivPort) }}
           - name: ISTIO_META_UNPRIVILEGED_POD
             value: "true"
           {{- end }}

--- a/manifests/charts/gateway/values.schema.json
+++ b/manifests/charts/gateway/values.schema.json
@@ -97,6 +97,10 @@
     "runAsRoot": {
       "type": "boolean"
     },
+    "unprivilegedPort": {
+      "type": ["string", "boolean"],
+      "enum": [true, false, "auto"]
+    },
     "service": {
       "type": "object",
       "properties": {

--- a/manifests/charts/gateway/values.schema.json
+++ b/manifests/charts/gateway/values.schema.json
@@ -6,6 +6,12 @@
     "affinity": {
       "type": "object"
     },
+    "securityContext": {
+      "type": ["object", "null"]
+    },
+    "containerSecurityContext": {
+      "type": ["object", "null"]
+    },
     "annotations": {
       "additionalProperties": {
         "type": [

--- a/manifests/charts/gateway/values.yaml
+++ b/manifests/charts/gateway/values.yaml
@@ -28,6 +28,11 @@ podAnnotations:
 
 # Whether to run the gateway in a privileged container
 runAsRoot: false
+# Whether to enable net.ipv4.ip_unprivileged_port_start. Generally if this is set, runAsRoot should be false,
+# unless root is desired for other reasons.
+# This is only supported by default on 1.22+; when auto is used this will be set based on the Kubernetes version.
+# Note: `helm template` cannot determine the version, so `auto` may yield incorrect results.
+unprivilegedPort: auto
 
 service:
   # Type of service. Set to "None" to disable the service entirely

--- a/manifests/charts/gateway/values.yaml
+++ b/manifests/charts/gateway/values.yaml
@@ -26,13 +26,11 @@ podAnnotations:
   inject.istio.io/templates: "gateway"
   sidecar.istio.io/inject: "true"
 
-# Whether to run the gateway in a privileged container
-runAsRoot: false
-# Whether to enable net.ipv4.ip_unprivileged_port_start. Generally if this is set, runAsRoot should be false,
-# unless root is desired for other reasons.
-# This is only supported by default on 1.22+; when auto is used this will be set based on the Kubernetes version.
-# Note: `helm template` cannot determine the version, so `auto` may yield incorrect results.
-unprivilegedPort: auto
+# Define the security context for the pod.
+# If unset, this will be automatically set to the minimum privileges required to bind to port 80 and 443.
+# On Kubernetes 1.22+, this only requires the `net.ipv4.ip_unprivileged_port_start` sysctl.
+securityContext: ~
+containerSecurityContext: ~
 
 service:
   # Type of service. Set to "None" to disable the service entirely
@@ -45,11 +43,11 @@ service:
   - name: http2
     port: 80
     protocol: TCP
-    targetPort: 8080
+    targetPort: 80
   - name: https
     port: 443
     protocol: TCP
-    targetPort: 8443
+    targetPort: 443
   annotations: {}
   loadBalancerIP: ""
   loadBalancerSourceRanges: []

--- a/pilot/pkg/config/kube/gateway/templates/deployment.yaml
+++ b/pilot/pkg/config/kube/gateway/templates/deployment.yaml
@@ -42,6 +42,30 @@ spec:
       containers:
       - image: auto
         name: istio-proxy
+        securityContext:
+        {{- if .KubeVersion122 }}
+          # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
+          capabilities:
+            drop:
+            - ALL
+          allowPrivilegeEscalation: false
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsUser: 1337
+          runAsGroup: 1337
+          runAsNonRoot: true
+        {{- else }}
+          capabilities:
+            drop:
+            - ALL
+            add:
+            - NET_BIND_SERVICE
+          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: false
+          allowPrivilegeEscalation: true
+          readOnlyRootFilesystem: true
+        {{- end }}
         ports:
         - containerPort: 15021
           name: status-port

--- a/pilot/pkg/config/kube/gateway/templates/deployment.yaml
+++ b/pilot/pkg/config/kube/gateway/templates/deployment.yaml
@@ -32,6 +32,13 @@ spec:
           .Labels
           | nindent 8}}
     spec:
+      {{- if .KubeVersion122 }}
+      {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
+      securityContext:
+        sysctls:
+        - name: net.ipv4.ip_unprivileged_port_start
+          value: "0"
+      {{- end }}
       containers:
       - image: auto
         name: istio-proxy

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/cluster-ip.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/cluster-ip.yaml
@@ -67,6 +67,10 @@ spec:
           periodSeconds: 2
           successThreshold: 1
           timeoutSeconds: 2
+      securityContext:
+        sysctls:
+        - name: net.ipv4.ip_unprivileged_port_start
+          value: "0"
 ---
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: Gateway

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/cluster-ip.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/cluster-ip.yaml
@@ -67,6 +67,16 @@ spec:
           periodSeconds: 2
           successThreshold: 1
           timeoutSeconds: 2
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       securityContext:
         sysctls:
         - name: net.ipv4.ip_unprivileged_port_start

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/manual-ip.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/manual-ip.yaml
@@ -62,6 +62,16 @@ spec:
           periodSeconds: 2
           successThreshold: 1
           timeoutSeconds: 2
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       securityContext:
         sysctls:
         - name: net.ipv4.ip_unprivileged_port_start

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/manual-ip.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/manual-ip.yaml
@@ -62,6 +62,10 @@ spec:
           periodSeconds: 2
           successThreshold: 1
           timeoutSeconds: 2
+      securityContext:
+        sysctls:
+        - name: net.ipv4.ip_unprivileged_port_start
+          value: "0"
 ---
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: Gateway

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/simple.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/simple.yaml
@@ -61,6 +61,10 @@ spec:
           periodSeconds: 2
           successThreshold: 1
           timeoutSeconds: 2
+      securityContext:
+        sysctls:
+        - name: net.ipv4.ip_unprivileged_port_start
+          value: "0"
 ---
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: Gateway

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/simple.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/simple.yaml
@@ -61,6 +61,16 @@ spec:
           periodSeconds: 2
           successThreshold: 1
           timeoutSeconds: 2
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
       securityContext:
         sysctls:
         - name: net.ipv4.ip_unprivileged_port_start


### PR DESCRIPTION
Currently, we have two options for gateway ports:
* Use targetPort to bind >1024
* Run as root

Since Kubernetes 1.22, there is another option available, by
configuring the sysctls on the pod.

This is especially important in the gateway controller, as users do not
control the Service. This means we would either need to automagically
configure the targetPort, which becomes tricky (what if we set it to
8080 and then they also want to bind to 8080?) - especially since things
like AuthorizationPolicy use the target port! Even worse, we can never
change it without downtime, so we are locking ourselves into using
targetPort when its not even needed anymore on newer Kubernetes
versions.

This changes the *new* gateway injection template and the Gateway
controller to use this new option when 1.22+ is used. Both of these are
net-new in Istio 1.12, so there is no compatibility concerns at all.

Note: currently the gateway controller is running as root. So this is
dropping privileges, not adding them.

 Prior attempt: https://github.com/istio/istio/pull/35846