### PR TITLE
Switch port naming for generated Service

### DIFF
--- a/pilot/pkg/config/kube/gateway/deploymentcontroller.go
+++ b/pilot/pkg/config/kube/gateway/deploymentcontroller.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 	"text/template"
 	"time"
 
@@ -286,14 +285,13 @@ func extractServicePorts(gw gateway.Gateway) []corev1.ServicePort {
 		Port: int32(15021),
 	})
 	portNums := map[int32]struct{}{}
-	for i, l := range gw.Spec.Listeners {
+	for _, l := range gw.Spec.Listeners {
 		if _, f := portNums[int32(l.Port)]; f {
 			continue
 		}
 		portNums[int32(l.Port)] = struct{}{}
-		name := fmt.Sprintf("%s-%d", strings.ToLower(string(l.Protocol)), i)
 		svcPorts = append(svcPorts, corev1.ServicePort{
-			Name: name,
+			Name: string(l.Name),
 			Port: int32(l.Port),
 		})
 	}

--- a/pilot/pkg/config/kube/gateway/deploymentcontroller_test.go
+++ b/pilot/pkg/config/kube/gateway/deploymentcontroller_test.go
@@ -68,7 +68,12 @@ func TestConfigureIstioGateway(t *testing.T) {
 					Namespace:   "default",
 					Annotations: map[string]string{"networking.istio.io/service-type": string(corev1.ServiceTypeClusterIP)},
 				},
-				Spec: v1alpha2.GatewaySpec{},
+				Spec: v1alpha2.GatewaySpec{
+					Listeners: []v1alpha2.Listener{{
+						Name: "http",
+						Port: v1alpha2.PortNumber(80),
+					}},
+				},
 			},
 		},
 	}

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/cluster-ip.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/cluster-ip.yaml
@@ -17,6 +17,9 @@ spec:
   - name: status-port
     port: 15021
     protocol: TCP
+  - name: http
+    port: 80
+    protocol: TCP
   selector:
     istio.io/gateway-name: default
   type: ClusterIP


### PR DESCRIPTION
Gateway Listener.name is already distinct, so it makes sense to mirror
that exactly. The current scheme may flip-flop depending on unimportant
YAML ordering
