### PR TITLE
Enable/Fix multi-arch build for DOCKER_V2_BUILDER

### DIFF
--- a/tools/docker
+++ b/tools/docker
@@ -20,17 +20,22 @@ ROOT=$(dirname "$WD")
 
 set -eu
 
+TARGET_OS=${TARGET_OS:-linux}
+TARGET_ARCH=${TARGET_ARCH:-amd64}
+GOOS_LOCAL=${TARGET_OS}
+GOARCH_LOCAL=${TARGET_ARCH}
+
 cd "${ROOT}"
 
 export REPO_ROOT="${ROOT}"
 
-if [[ -f out/linux_amd64/docker-builder ]]; then
+if [[ -f out/${TARGET_OS}_${TARGET_ARCH}/docker-builder ]]; then
   CURRENT_BUILD="$(./common/scripts/report_build_info.sh | grep buildGitRevision | cut -d= -f2)"
-  PREBUILT="$(out/linux_amd64/docker-builder --version)"
+  PREBUILT="$(out/${TARGET_OS}_${TARGET_ARCH}/docker-builder --version)"
   if [[ "${CURRENT_BUILD}" != "${PREBUILT}" ]]; then
-    ./common/scripts/gobuild.sh out/linux_amd64/docker-builder ./tools/docker-builder
+    GOOS=${GOOS_LOCAL} GOARCH=${GOARCH_LOCAL} ./common/scripts/gobuild.sh out/${TARGET_OS}_${TARGET_ARCH}/docker-builder ./tools/docker-builder
   fi
 else
-  ./common/scripts/gobuild.sh out/linux_amd64/docker-builder ./tools/docker-builder
+  GOOS=${GOOS_LOCAL} GOARCH=${GOARCH_LOCAL} ./common/scripts/gobuild.sh out/${TARGET_OS}_${TARGET_ARCH}/docker-builder ./tools/docker-builder
 fi
-out/linux_amd64/docker-builder "$@"
+out/${TARGET_OS}_${TARGET_ARCH}/docker-builder "$@"


### PR DESCRIPTION
When DOCKER_V2_BUILDER=true, the build on arm64 would get an error:
./tools/docker: line 29: out/linux_amd64/docker-builder: cannot execute
binary file: Exec format error

which is due to lack of arch and os information in tools/docker when
building with common/scripts/gobuild.sh(so it would lead to an amd64
binary on arm64 platform).

Now we set the right OS and Arch to enable and fix the building both
on arm64 and amd64.

Signed-off-by: trevor.tao <trevor.tao@arm.com>

**Please provide a description of this PR:**