### PR TITLE
fix the problem that missing remote pilot name in dns names

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -960,7 +960,14 @@ func (s *Server) initIstiodCerts(args *PilotArgs, host string) error {
 
 	// The first is the recommended one, also used by Apiserver for webhooks.
 	// add a few known hostnames
-	for _, altName := range []string{"istiod", "istiod-remote", "istio-pilot"} {
+	knownHosts := []string{"istiod", "istiod-remote", "istio-pilot"}
+	// In some conditions, pilot address for sds is different from other xds,
+	// like multi-cluster primary-remote mode with revision.
+	if args.Revision != "" && args.Revision != "default" {
+		knownHosts = append(knownHosts, "istiod"+"-"+args.Revision)
+	}
+
+	for _, altName := range knownHosts {
 		name := fmt.Sprintf("%v.%v.svc", altName, args.Namespace)
 		if name == host || name == customHost {
 			continue


### PR DESCRIPTION
**Please provide a description of this PR:**
fix https://github.com/istio/istio/issues/35939
Today, the remote profile will install an istiod server in the remote cluster which will be used for CA and webhook injection for workloads in that cluster. Service discovery, however, will be directed to the control plane in the primary cluster.
Remote pilot sets istiodHost to "istiod-remote" for envoy, but the real remote pilot address for sds connection is "istiod" or "istiod-{{ .Values.revision }}".The problem is "istiod-{{ .values.revison }}" is not in the default dns names and will cause server certificate verifying problem when initiating a remote CSR request.