### PR TITLE
Replace openssl with echo client

### DIFF
--- a/pkg/test/echo/common/scheme/scheme.go
+++ b/pkg/test/echo/common/scheme/scheme.go
@@ -24,5 +24,10 @@ const (
 	XDS       Instance = "xds"
 	WebSocket Instance = "ws"
 	TCP       Instance = "tcp"
-	DNS       Instance = "dns"
+	// TLS sends a TLS connection and reports back the properties of the TLS connection
+	// This is similar to `openssl s_client`
+	// Response data is not returned; only information about the TLS handshake.
+	TLS Instance = "tls"
+	// DNS does a DNS query and reports back the results.
+	DNS Instance = "dns"
 )

--- a/pkg/test/echo/server/forwarder/protocol.go
+++ b/pkg/test/echo/server/forwarder/protocol.go
@@ -291,6 +291,21 @@ func newProtocol(cfg Config) (protocol, error) {
 				return tls.Dial("tcp", address, tlsConfig)
 			},
 		}, nil
+	case scheme.TLS:
+		return &tlsProtocol{
+			conn: func() (*tls.Conn, error) {
+				dialer := net.Dialer{
+					Timeout: timeout,
+				}
+				address := rawURL[len(urlScheme+"://"):]
+
+				con, err := tls.DialWithDialer(&dialer, "tcp", address, tlsConfig)
+				if err != nil {
+					return nil, err
+				}
+				return con, nil
+			},
+		}, nil
 	}
 
 	return nil, fmt.Errorf("unrecognized protocol %q", urlScheme)

--- a/pkg/test/echo/server/forwarder/tls.go
+++ b/pkg/test/echo/server/forwarder/tls.go
@@ -1,0 +1,102 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package forwarder
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/pem"
+	"fmt"
+	"strings"
+)
+
+var _ protocol = &tlsProtocol{}
+
+type tlsProtocol struct {
+	// conn returns a new connection. This is not just a shared connection as we will
+	// not re-use the connection for multiple requests with TCP
+	conn func() (*tls.Conn, error)
+}
+
+func (c *tlsProtocol) makeRequest(ctx context.Context, req *request) (string, error) {
+	conn, err := c.conn()
+	if err != nil {
+		return "", err
+	}
+	defer conn.Close()
+	msgBuilder := strings.Builder{}
+	msgBuilder.WriteString(fmt.Sprintf("[%d] Url=%s\n", req.RequestID, req.URL))
+
+	// Apply per-request timeout to calculate deadline for reads/writes.
+	ctx, cancel := context.WithTimeout(ctx, req.Timeout)
+	defer cancel()
+
+	// Apply the deadline to the connection.
+	deadline, _ := ctx.Deadline()
+	if err := conn.SetWriteDeadline(deadline); err != nil {
+		return msgBuilder.String(), err
+	}
+	if err := conn.SetReadDeadline(deadline); err != nil {
+		return msgBuilder.String(), err
+	}
+
+	if err := conn.HandshakeContext(ctx); err != nil {
+		return "", err
+	}
+	// Make sure the client writes something to the buffer
+	message := "HelloWorld"
+	if req.Message != "" {
+		message = req.Message
+	}
+	if _, err := conn.Write([]byte(message + "\n")); err != nil {
+		fwLog.Warnf("TCP write failed: %v", err)
+		return msgBuilder.String(), err
+	}
+
+	cs := conn.ConnectionState()
+	msgBuilder.WriteString(fmt.Sprintf("[%d] Cipher=%s\n", req.RequestID, tls.CipherSuiteName(cs.CipherSuite)))
+	msgBuilder.WriteString(fmt.Sprintf("[%d] Version=%s\n", req.RequestID, versionName(cs.Version)))
+	msgBuilder.WriteString(fmt.Sprintf("[%d] ServerName=%s\n", req.RequestID, cs.ServerName))
+	msgBuilder.WriteString(fmt.Sprintf("[%d] Alpn=%s\n", req.RequestID, cs.NegotiatedProtocol))
+	for n, i := range cs.PeerCertificates {
+		pemBlock := pem.Block{
+			Type:  "CERTIFICATE",
+			Bytes: i.Raw,
+		}
+		msgBuilder.WriteString(fmt.Sprintf("[%d body] Response%d=%q\n", req.RequestID, n, string(pem.EncodeToMemory(&pemBlock))))
+	}
+
+	msg := msgBuilder.String()
+	return msg, nil
+}
+
+func versionName(v uint16) string {
+	switch v {
+	case tls.VersionTLS10:
+		return "1.0"
+	case tls.VersionTLS11:
+		return "1.1"
+	case tls.VersionTLS12:
+		return "1.2"
+	case tls.VersionTLS13:
+		return "1.3"
+	default:
+		return fmt.Sprintf("unknown-%v", v)
+	}
+}
+
+func (c *tlsProtocol) Close() error {
+	return nil
+}

--- a/pkg/test/framework/components/echo/call.go
+++ b/pkg/test/framework/components/echo/call.go
@@ -22,7 +22,6 @@ import (
 
 	"istio.io/istio/pkg/test/echo/client"
 	"istio.io/istio/pkg/test/echo/common/scheme"
-	"istio.io/istio/pkg/test/echo/proto"
 	"istio.io/istio/pkg/test/framework/components/cluster"
 )
 
@@ -93,7 +92,7 @@ type CallOptions struct {
 	// HTTProxy used for making ingress echo call via proxy
 	HTTPProxy string
 
-	Alpn       *proto.Alpn
+	Alpn       []string
 	ServerName string
 }
 
@@ -130,9 +129,8 @@ func (o CallOptions) DeepCopy() CallOptions {
 		clone.Port = &dc
 	}
 	if o.Alpn != nil {
-		clone.Alpn = &proto.Alpn{
-			Value: o.Alpn.GetValue(),
-		}
+		clone.Alpn = make([]string, len(o.Alpn))
+		copy(clone.Alpn, o.Alpn)
 	}
 	return clone
 }

--- a/pkg/test/framework/components/echo/common/call.go
+++ b/pkg/test/framework/components/echo/common/call.go
@@ -84,7 +84,11 @@ func callInternal(srcName string, opts *echo.CallOptions, send sendFunc,
 		InsecureSkipVerify: opts.InsecureSkipVerify,
 		FollowRedirects:    opts.FollowRedirects,
 		ServerName:         opts.ServerName,
-		Alpn:               opts.Alpn,
+	}
+	if opts.Alpn != nil {
+		req.Alpn = &proto.Alpn{
+			Value: opts.Alpn,
+		}
 	}
 
 	var responses client.ParsedResponses

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -940,7 +940,7 @@ func autoPassthroughCases(apps *EchoDeployments) []TrafficTestCase {
 		for _, sni := range snis {
 			for _, alpn := range alpns {
 				alpn, sni, mode := alpn, sni, mode
-				al := &epb.Alpn{Value: []string{alpn}}
+				al := []string{alpn}
 				if alpn == "" {
 					al = nil
 				}

--- a/tests/integration/security/ecc_signature_algorithm/mtls_strict_test.go
+++ b/tests/integration/security/ecc_signature_algorithm/mtls_strict_test.go
@@ -20,12 +20,11 @@ package eccsignaturealgorithm
 import (
 	"crypto/x509"
 	"encoding/pem"
-	"fmt"
+	"strings"
 	"testing"
 
 	"istio.io/istio/pkg/test/echo/common/scheme"
 	"istio.io/istio/pkg/test/framework"
-	"istio.io/istio/pkg/test/framework/components/cluster/kube"
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/util/tmpl"
 	"istio.io/istio/tests/integration/security/util"
@@ -82,20 +81,15 @@ func TestStrictMTLS(t *testing.T) {
 				t.Fatalf("client could not reach server: %v", err)
 			}
 
-			kubeconfig := (t.Clusters().Default().(*kube.Cluster)).Filename()
-			target := fmt.Sprintf("server.%s:8091", apps.Namespace.Name())
-			certPEM, err := cert.DumpCertFromSidecar(apps.Namespace, "app=client", "istio-proxy", kubeconfig, target)
-			if err != nil {
-				t.Fatalf("client could not get certificate from server: %v", err)
-			}
-			block, _ := pem.Decode([]byte(certPEM))
+			certPEMs := cert.DumpCertFromSidecar(t, apps.Client, apps.Server, "http")
+			block, _ := pem.Decode([]byte(strings.Join(certPEMs, "\n")))
 			if block == nil { // nolint: staticcheck
 				t.Fatalf("failed to parse certificate PEM")
 			}
 
-			certificate, parseErr := x509.ParseCertificate(block.Bytes) // nolint: staticcheck
+			certificate, err := x509.ParseCertificate(block.Bytes) // nolint: staticcheck
 			if err != nil {
-				t.Fatalf("failed to parse certificate: %v", parseErr)
+				t.Fatalf("failed to parse certificate: %v", err)
 			}
 
 			if certificate.PublicKeyAlgorithm != x509.ECDSA {


### PR DESCRIPTION
This allows tests to run in environments that do not have an openssl binary in the istio-proxy container. A new protocol is implemented for echo that basically does the same thing openssl did - connect to an endpoint and dump the tls handshake info.