### PR TITLE
ignore FQDN endpointslice

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/endpointslice.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpointslice.go
@@ -149,6 +149,10 @@ func serviceNameForEndpointSlice(labels map[string]string) string {
 func (esc *endpointSliceController) sliceServiceInstances(c *Controller, slice interface{}, proxy *model.Proxy) []*model.ServiceInstance {
 	var out []*model.ServiceInstance
 	ep := wrapEndpointSlice(slice)
+	if ep.AddressType() == v1.AddressTypeFQDN {
+		// TODO support FQDN endpointslice
+		return out
+	}
 	for _, svc := range c.servicesForNamespacedName(esc.getServiceNamespacedName(ep)) {
 		pod := c.pods.getPodByProxy(proxy)
 		builder := NewEndpointBuilder(c, pod)
@@ -215,7 +219,10 @@ func (esc *endpointSliceController) buildIstioEndpoints(es interface{}, hostName
 func (esc *endpointSliceController) updateEndpointCacheForSlice(hostName host.Name, ep interface{}) {
 	var endpoints []*model.IstioEndpoint
 	slice := wrapEndpointSlice(ep)
-
+	if slice.AddressType() == v1.AddressTypeFQDN {
+		// TODO support FQDN endpointslice
+		return
+	}
 	discoverabilityPolicy := esc.c.exports.EndpointDiscoverabilityPolicy(esc.c.GetService(hostName))
 
 	for _, e := range slice.Endpoints() {
@@ -296,6 +303,10 @@ func (esc *endpointSliceController) InstancesByPort(c *Controller, svc *model.Se
 	var out []*model.ServiceInstance
 	for _, es := range slices {
 		slice := wrapEndpointSlice(es)
+		if slice.AddressType() == v1.AddressTypeFQDN {
+			// TODO support FQDN endpointslice
+			continue
+		}
 		for _, e := range slice.Endpoints() {
 			for _, a := range e.Addresses {
 				var podLabels labels.Instance
@@ -457,6 +468,13 @@ type endpointSliceWrapper struct {
 	metav1.ObjectMeta
 	v1beta1 *v1beta1.EndpointSlice
 	v1      *v1.EndpointSlice
+}
+
+func (esw *endpointSliceWrapper) AddressType() v1.AddressType {
+	if esw.v1 != nil {
+		return esw.v1.AddressType
+	}
+	return v1.AddressType(esw.v1beta1.AddressType)
 }
 
 func (esw *endpointSliceWrapper) Ports() []v1.EndpointPort {

--- a/pilot/pkg/serviceregistry/kube/controller/endpointslice.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpointslice.go
@@ -150,7 +150,7 @@ func (esc *endpointSliceController) sliceServiceInstances(c *Controller, slice i
 	var out []*model.ServiceInstance
 	ep := wrapEndpointSlice(slice)
 	if ep.AddressType() == v1.AddressTypeFQDN {
-		// TODO support FQDN endpointslice
+		// TODO(https://github.com/istio/istio/issues/34995) support FQDN endpointslice
 		return out
 	}
 	for _, svc := range c.servicesForNamespacedName(esc.getServiceNamespacedName(ep)) {
@@ -220,7 +220,7 @@ func (esc *endpointSliceController) updateEndpointCacheForSlice(hostName host.Na
 	var endpoints []*model.IstioEndpoint
 	slice := wrapEndpointSlice(ep)
 	if slice.AddressType() == v1.AddressTypeFQDN {
-		// TODO support FQDN endpointslice
+		// TODO(https://github.com/istio/istio/issues/34995) support FQDN endpointslice
 		return
 	}
 	discoverabilityPolicy := esc.c.exports.EndpointDiscoverabilityPolicy(esc.c.GetService(hostName))
@@ -304,7 +304,7 @@ func (esc *endpointSliceController) InstancesByPort(c *Controller, svc *model.Se
 	for _, es := range slices {
 		slice := wrapEndpointSlice(es)
 		if slice.AddressType() == v1.AddressTypeFQDN {
-			// TODO support FQDN endpointslice
+			// TODO(https://github.com/istio/istio/issues/34995) support FQDN endpointslice
 			continue
 		}
 		for _, e := range slice.Endpoints() {

--- a/pilot/pkg/serviceregistry/serviceregistry_test.go
+++ b/pilot/pkg/serviceregistry/serviceregistry_test.go
@@ -981,6 +981,10 @@ func TestEndpointsDeduping(t *testing.T) {
 	createEndpointSlice(t, s.KubeClient(), "slice1", "service", namespace, []v1.EndpointPort{{Name: "http", Port: 80}}, []string{"1.2.3.4"})
 	expectEndpoints(t, s, "outbound|80||service.namespace.svc.cluster.local", []string{"1.2.3.4:80"})
 
+	// create an FQDN endpoint that should be ignored
+	createEndpointSliceWithType(t, s.KubeClient(), "slice1", "service", namespace, []v1.EndpointPort{{Name: "http", Port: 80}}, []string{"foo.com"}, discovery.AddressTypeFQDN)
+	expectEndpoints(t, s, "outbound|80||service.namespace.svc.cluster.local", []string{"1.2.3.4:80"})
+
 	// Add another port endpoint
 	createEndpointSlice(t, s.KubeClient(), "slice1", "service", namespace,
 		[]v1.EndpointPort{{Name: "http-other", Port: 90}, {Name: "http", Port: 80}}, []string{"1.2.3.4", "2.3.4.5"})
@@ -1287,8 +1291,12 @@ func createEndpoints(t *testing.T, c kubernetes.Interface, name, namespace strin
 	}
 }
 
+func createEndpointSlice(t *testing.T, c kubernetes.Interface, name, serviceName, namespace string, ports []v1.EndpointPort, addrs []string) {
+	createEndpointSliceWithType(t, c, name, serviceName, namespace, ports, addrs, discovery.AddressTypeIPv4)
+}
+
 // nolint: unparam
-func createEndpointSlice(t *testing.T, c kubernetes.Interface, name, serviceName, namespace string, ports []v1.EndpointPort, ips []string) {
+func createEndpointSliceWithType(t *testing.T, c kubernetes.Interface, name, serviceName, namespace string, ports []v1.EndpointPort, ips []string, addrType discovery.AddressType) {
 	esps := make([]discovery.EndpointPort, 0)
 	for _, name := range ports {
 		n := name // Create a stable reference to take the pointer from
@@ -1315,8 +1323,9 @@ func createEndpointSlice(t *testing.T, c kubernetes.Interface, name, serviceName
 				discovery.LabelServiceName: serviceName,
 			},
 		},
-		Endpoints: sliceEndpoint,
-		Ports:     esps,
+		AddressType: addrType,
+		Endpoints:   sliceEndpoint,
+		Ports:       esps,
 	}
 	if _, err := c.DiscoveryV1().EndpointSlices(namespace).Create(context.TODO(), endpointSlice, metav1.CreateOptions{}); err != nil {
 		if kerrors.IsAlreadyExists(err) {

--- a/pilot/pkg/serviceregistry/serviceregistry_test.go
+++ b/pilot/pkg/serviceregistry/serviceregistry_test.go
@@ -982,7 +982,8 @@ func TestEndpointsDeduping(t *testing.T) {
 	expectEndpoints(t, s, "outbound|80||service.namespace.svc.cluster.local", []string{"1.2.3.4:80"})
 
 	// create an FQDN endpoint that should be ignored
-	createEndpointSliceWithType(t, s.KubeClient(), "slice1", "service", namespace, []v1.EndpointPort{{Name: "http", Port: 80}}, []string{"foo.com"}, discovery.AddressTypeFQDN)
+	createEndpointSliceWithType(t, s.KubeClient(), "slice1", "service",
+		namespace, []v1.EndpointPort{{Name: "http", Port: 80}}, []string{"foo.com"}, discovery.AddressTypeFQDN)
 	expectEndpoints(t, s, "outbound|80||service.namespace.svc.cluster.local", []string{"1.2.3.4:80"})
 
 	// Add another port endpoint
@@ -1291,12 +1292,14 @@ func createEndpoints(t *testing.T, c kubernetes.Interface, name, namespace strin
 	}
 }
 
+// nolint: unparam
 func createEndpointSlice(t *testing.T, c kubernetes.Interface, name, serviceName, namespace string, ports []v1.EndpointPort, addrs []string) {
 	createEndpointSliceWithType(t, c, name, serviceName, namespace, ports, addrs, discovery.AddressTypeIPv4)
 }
 
 // nolint: unparam
-func createEndpointSliceWithType(t *testing.T, c kubernetes.Interface, name, serviceName, namespace string, ports []v1.EndpointPort, ips []string, addrType discovery.AddressType) {
+func createEndpointSliceWithType(t *testing.T, c kubernetes.Interface, name, serviceName, namespace string,
+	ports []v1.EndpointPort, ips []string, addrType discovery.AddressType) {
 	esps := make([]discovery.EndpointPort, 0)
 	for _, name := range ports {
 		n := name // Create a stable reference to take the pointer from


### PR DESCRIPTION
If I understand the comments in https://github.com/kubernetes/kubernetes/issues/105172 and #34995 , we should be able to safely ignore these EndpointSlices for now, so `PILOT_USE_ENDPOINT_SLICE` doesn't cause NACKs. 