### PR TITLE
Enable building for base images

### DIFF
--- a/tools/docker-builder/main.go
+++ b/tools/docker-builder/main.go
@@ -287,6 +287,10 @@ func vmImageName(target string) string {
 		// Not a VM
 		return ""
 	}
+	if strings.HasPrefix(target, "app_sidecar_base") {
+		return strings.Split(target, "_")[3]
+	}
+
 	return strings.Split(target, "_")[2]
 }
 
@@ -295,6 +299,10 @@ func vmImageVersion(target string) string {
 		// Not a VM
 		return ""
 	}
+	if strings.HasPrefix(target, "app_sidecar_base") {
+		return strings.Split(target, "_")[4]
+	}
+
 	return strings.Split(target, "_")[3]
 }
 


### PR DESCRIPTION
Now for DOCKER_V2_BUILDER, it does not support the explicit building for
base images, for example, when building with
make dockerx.app_sidecar_base_ubuntu_xenial
it would show some error information for the wrong VM_IMAGE_NAME and
VM_IMAGE_VERSION, now we just fix it here.

And add other base images in the istio-docker.mk in the default list too.

Signed-off-by: trevor.tao <trevor.tao@arm.com>

**Please provide a description of this PR:**