### PR TITLE
test cluster-local config using service subsets

### DIFF
--- a/tests/integration/pilot/multicluster_test.go
+++ b/tests/integration/pilot/multicluster_test.go
@@ -20,7 +20,6 @@ package pilot
 import (
 	"context"
 	"fmt"
-	"istio.io/istio/pkg/test/util/tmpl"
 	"testing"
 	"time"
 
@@ -33,6 +32,7 @@ import (
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/util/retry"
+	"istio.io/istio/pkg/test/util/tmpl"
 )
 
 func TestClusterLocal(t *testing.T) {

--- a/tests/integration/pilot/multicluster_test.go
+++ b/tests/integration/pilot/multicluster_test.go
@@ -98,7 +98,7 @@ spec:
         topology.istio.io/cluster: {{ .Config.Cluster.Name }}
     route:
     - destination:
-        host: {{.host}}
+        host: {{$.host}}
         subset: {{ .Config.Cluster.Name }}
 {{- end }}
 `, map[string]interface{}{"src": sources, "dst": destination, "host": destination[0].Config().ClusterLocalFQDN()})

--- a/tests/integration/pilot/multicluster_test.go
+++ b/tests/integration/pilot/multicluster_test.go
@@ -129,8 +129,8 @@ spec:
 				})
 			}
 
-		// this runs in a separate test context - confirms the cluster local config was cleaned up
-		t.NewSubTest("cross cluster").Run(func(t framework.TestContext) {
+			// this runs in a separate test context - confirms the cluster local config was cleaned up
+			t.NewSubTest("cross cluster").Run(func(t framework.TestContext) {
 				for _, source := range sources {
 					source := source
 					t.NewSubTest(source.Config().Cluster.StableName()).Run(func(t framework.TestContext) {

--- a/tests/integration/pilot/multicluster_test.go
+++ b/tests/integration/pilot/multicluster_test.go
@@ -20,6 +20,7 @@ package pilot
 import (
 	"context"
 	"fmt"
+	"istio.io/istio/pkg/test/util/tmpl"
 	"testing"
 	"time"
 
@@ -48,29 +49,88 @@ func TestClusterLocal(t *testing.T) {
 			// TODO use echotest to dynamically pick 2 simple pods from apps.All
 			sources := apps.PodA
 			destination := apps.PodB
-			t.NewSubTest("cluster local").Run(func(t framework.TestContext) {
-				istio.PatchMeshConfig(t, i.Settings().SystemNamespace, destination.Clusters(), fmt.Sprintf(`
+
+			tests := []struct {
+				name  string
+				setup func(t framework.TestContext)
+			}{
+				{
+					"MeshConfig.serviceSettings",
+					func(t framework.TestContext) {
+						istio.PatchMeshConfig(t, i.Settings().SystemNamespace, destination.Clusters(), fmt.Sprintf(`
 serviceSettings: 
 - settings:
     clusterLocal: true
   hosts:
   - "%s"
 `, apps.PodB[0].Config().ClusterLocalFQDN()))
-				for _, source := range sources {
-					source := source
-					t.NewSubTest(source.Config().Cluster.StableName()).Run(func(t framework.TestContext) {
-						source.CallWithRetryOrFail(t, echo.CallOptions{
-							Target:   destination[0],
-							Count:    3 * len(destination),
-							PortName: "http",
-							Scheme:   scheme.HTTP,
-							Validator: echo.And(
-								echo.ExpectOK(),
-								echo.ExpectReachedClusters(cluster.Clusters{source.Config().Cluster}),
-							),
+					},
+				},
+				{
+					"subsets",
+					func(t framework.TestContext) {
+						cfg := tmpl.EvaluateOrFail(t, `
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: mysvc-dr
+spec:
+  host: {{.host}}
+  subsets:
+{{- range .dst }}
+  - name: {{ .Config.Cluster.Name }}
+    labels:
+      topology.istio.io/cluster: {{ .Config.Cluster.Name }}
+{{- end }}
+---
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: mysvc-vs
+spec:
+  hosts:
+  - {{.host}}
+  http:
+{{- range .dst }}
+  - name: "{{ .Config.Cluster.Name }}-local"
+    match:
+    - sourceLabels:
+        topology.istio.io/cluster: {{ .Config.Cluster.Name }}
+    route:
+    - destination:
+        host: {{.host}}
+        subset: {{ .Config.Cluster.Name }}
+{{- end }}
+`, map[string]interface{}{"src": sources, "dst": destination, "host": destination[0].Config().ClusterLocalFQDN()})
+						t.ConfigIstio().ApplyYAMLOrFail(t, sources[0].Config().Namespace.Name(), cfg)
+					},
+				},
+			}
+
+			for _, test := range tests {
+				test := test
+				t.NewSubTest(test.name).Run(func(t framework.TestContext) {
+					test.setup(t)
+					for _, source := range sources {
+						source := source
+						// TODO can probably RunParallel here
+						t.NewSubTest(source.Config().Cluster.StableName()).Run(func(t framework.TestContext) {
+							source.CallWithRetryOrFail(t, echo.CallOptions{
+								Target:   destination[0],
+								Count:    3 * len(destination),
+								PortName: "http",
+								Scheme:   scheme.HTTP,
+								Validator: echo.And(
+									echo.ExpectOK(),
+									echo.ExpectReachedClusters(cluster.Clusters{source.Config().Cluster}),
+								),
+							})
 						})
-					})
-				}
+					}
+				})
+			}
+			t.NewSubTest("MeshConfig.serviceSettings").Run(func(t framework.TestContext) {
+
 			})
 			t.NewSubTest("cross cluster").Run(func(t framework.TestContext) {
 				// this runs in a separate test context - confirms the cluster local config was cleaned up

--- a/tests/integration/pilot/multicluster_test.go
+++ b/tests/integration/pilot/multicluster_test.go
@@ -113,8 +113,7 @@ spec:
 					test.setup(t)
 					for _, source := range sources {
 						source := source
-						// TODO can probably RunParallel here
-						t.NewSubTest(source.Config().Cluster.StableName()).Run(func(t framework.TestContext) {
+						t.NewSubTest(source.Config().Cluster.StableName()).RunParallel(func(t framework.TestContext) {
 							source.CallWithRetryOrFail(t, echo.CallOptions{
 								Target:   destination[0],
 								Count:    3 * len(destination),
@@ -129,11 +128,9 @@ spec:
 					}
 				})
 			}
-			t.NewSubTest("MeshConfig.serviceSettings").Run(func(t framework.TestContext) {
 
-			})
-			t.NewSubTest("cross cluster").Run(func(t framework.TestContext) {
-				// this runs in a separate test context - confirms the cluster local config was cleaned up
+		// this runs in a separate test context - confirms the cluster local config was cleaned up
+		t.NewSubTest("cross cluster").Run(func(t framework.TestContext) {
 				for _, source := range sources {
 					source := source
 					t.NewSubTest(source.Config().Cluster.StableName()).Run(func(t framework.TestContext) {


### PR DESCRIPTION
After looking through the code a bit, I think the suggestion [here](https://github.com/istio/istio/issues/29335#issuecomment-950967806) is already possible due to:

https://github.com/istio/istio/blob/57b27bfceb507d56fa59b46917a44eb60524c3ae/pilot/pkg/xds/ads.go#L621
