### PR TITLE
echo: return errors in dns

### DIFF
--- a/pkg/test/echo/server/forwarder/dns.go
+++ b/pkg/test/echo/server/forwarder/dns.go
@@ -105,7 +105,10 @@ func (c *dnsProtocol) makeRequest(ctx context.Context, rreq *request) (string, e
 	}()
 	ctx, cancel := context.WithTimeout(ctx, rreq.Timeout)
 	defer cancel()
-	ips, _ := r.LookupIP(ctx, nt, req.hostname)
+	ips, err := r.LookupIP(ctx, nt, req.hostname)
+	if err != nil {
+		return "", err
+	}
 
 	var outBuffer bytes.Buffer
 	outBuffer.WriteString(fmt.Sprintf("[%d] Hostname=%s\n", rreq.RequestID, req.hostname))


### PR DESCRIPTION
Currently we silently ignore them. This makes things a bit more explicit