### PR TITLE
tf: do not cleanup external ServiceEntry

### DIFF
--- a/tests/integration/pilot/common/apps.go
+++ b/tests/integration/pilot/common/apps.go
@@ -325,7 +325,7 @@ spec:
 	if err != nil {
 		return err
 	}
-	if err := t.ConfigIstio().ApplyYAML(apps.Namespace.Name(), se); err != nil {
+	if err := t.ConfigIstio().ApplyYAMLNoCleanup(apps.Namespace.Name(), se); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
We do not clean up Service's, so cleaning up the ServiceEntry that is
for the same goals doesn't really make sense.

This only really impacts local debugging

**Please provide a description of this PR:**