### PR TITLE
Revert /host prefix from CNI log volume mount path.

### DIFF
--- a/cni/pkg/cmd/root.go
+++ b/cni/pkg/cmd/root.go
@@ -137,7 +137,7 @@ func init() {
 	registerStringArrayParameter(constants.SkipCNIBinaries, []string{},
 		"Binaries that should not be installed. Currently Istio only installs one binary `istio-cni`")
 	registerIntegerParameter(constants.MonitoringPort, 15014, "HTTP port to serve prometheus metrics")
-	registerStringParameter(constants.LogUDSAddress, "/host/var/run/istio-cni/log.sock", "The UDS server address which CNI plugin will copy log ouptut to")
+	registerStringParameter(constants.LogUDSAddress, "/var/run/istio-cni/log.sock", "The UDS server address which CNI plugin will copy log ouptut to")
 
 	// Repair
 	registerBooleanParameter(constants.RepairEnabled, true, "Whether to enable race condition repair or not")

--- a/manifests/charts/istio-cni/templates/daemonset.yaml
+++ b/manifests/charts/istio-cni/templates/daemonset.yaml
@@ -126,7 +126,7 @@ spec:
               name: cni-bin-dir
             - mountPath: /host/etc/cni/net.d
               name: cni-net-dir
-            - mountPath: /host/var/run/istio-cni
+            - mountPath: /var/run/istio-cni
               name: cni-log-dir
           resources:
 {{- if .Values.cni.resources }}


### PR DESCRIPTION
This path is shared between CNI plugin process and CNI daemonset, and it has to be same at the moment.