### PR TITLE
Fix bug-report --duration flag never gets used

### DIFF
--- a/releasenotes/notes/36044.yaml
+++ b/releasenotes/notes/36044.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: istioctl
+releaseNotes:
+  - |
+    **Fixed** the `--duration` flag never gets used in the `istioctl bug-report` command.

--- a/tools/bug-report/pkg/bugreport/flags.go
+++ b/tools/bug-report/pkg/bugreport/flags.go
@@ -26,7 +26,6 @@ import (
 
 	analyzer_util "istio.io/istio/galley/pkg/config/analysis/analyzers/util"
 	config2 "istio.io/istio/tools/bug-report/pkg/config"
-	"istio.io/pkg/log"
 )
 
 var (
@@ -74,12 +73,12 @@ func addFlags(cmd *cobra.Command, args *config2.BugReportConfig) {
 	// log time ranges
 	cmd.PersistentFlags().StringVar(&startTime, "start-time", "",
 		"Start time for the range of log entries to include in the archive. "+
-			"Default is the infinite past. If set, Since must be unset.")
+			"Default is the infinite past. If set, --duration must be unset.")
 	cmd.PersistentFlags().StringVar(&endTime, "end-time", "",
 		"End time for the range of log entries to include in the archive. Default is now.")
 	cmd.PersistentFlags().DurationVar(&since, "duration", 0,
 		"How far to go back in time from end-time for log entries to include in the archive. "+
-			"Default is infinity. If set, start-time must be unset.")
+			"Default is infinity. If set, --start-time must be unset.")
 
 	// log error control
 	cmd.PersistentFlags().StringSliceVar(&args.CriticalErrors, "critical-errs", nil,
@@ -106,8 +105,8 @@ func parseConfig() (*config2.BugReportConfig, error) {
 		}
 	}
 
-	if err := parseTimes(gConfig, startTime, endTime); err != nil {
-		log.Fatal(err.Error())
+	if err := parseTimes(gConfig, startTime, endTime, since); err != nil {
+		return nil, err
 	}
 	gConfig.CommandTimeout = config2.Duration(commandTimeout)
 	for _, s := range included {
@@ -137,8 +136,9 @@ func parseConfig() (*config2.BugReportConfig, error) {
 	return overlayConfig(fileConfig, gConfig)
 }
 
-func parseTimes(config *config2.BugReportConfig, startTime, endTime string) error {
+func parseTimes(config *config2.BugReportConfig, startTime, endTime string, duration time.Duration) error {
 	config.EndTime = time.Now()
+	config.Since = config2.Duration(duration)
 	if endTime != "" {
 		var err error
 		config.EndTime, err = time.Parse(time.RFC3339, endTime)
@@ -148,7 +148,7 @@ func parseTimes(config *config2.BugReportConfig, startTime, endTime string) erro
 	}
 	if config.Since != 0 {
 		if startTime != "" {
-			return fmt.Errorf("only one --start-time or --since may be set")
+			return fmt.Errorf("only one --start-time or --duration may be set")
 		}
 		config.StartTime = config.EndTime.Add(-1 * time.Duration(config.Since))
 	} else {


### PR DESCRIPTION
**Please provide a description of this PR:**
`--duration` flag is never used in the `istioctl bug-report` command. Although it has been parsed to `since` parameter, the `since` parameter never gets called. This PR is to fix this issue, and correctly handle the error situation when users try to input `--duration` and `--start-time` flags at the same time.


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [x] Test and Release
- [x] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
