### PR TITLE
Add time flag validation to bug-report

### DIFF
--- a/tools/bug-report/pkg/bugreport/flags.go
+++ b/tools/bug-report/pkg/bugreport/flags.go
@@ -160,6 +160,9 @@ func parseTimes(config *config2.BugReportConfig, startTime, endTime string) erro
 			if err != nil {
 				return fmt.Errorf("bad format for start-time: %s, expect RFC3339 e.g. %s", startTime, time.RFC3339)
 			}
+			if config.StartTime.After(config.EndTime) {
+				return fmt.Errorf("bad format for start-time and end-time: start-time is after end-time")
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
**Please provide a description of this PR:**
To validate if the `--end-time` flag is set to be after the `--start-time` flag.


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [x] Test and Release
- [x] User Experience
- [ ] Developer Infrastructure