### PR TITLE
Fix `make docker` related target on MacOS

### DIFF
--- a/tools/docker
+++ b/tools/docker
@@ -23,14 +23,12 @@ set -eux
 # LOCAL_OUT is set when runing in a Makefile and set to current architecture (not host)
 if [[ ! -z "${LOCAL_OUT}" ]]; then
   OS_ARCH=${LOCAL_OUT##*/}
-  LOCAL_TARGET_ARCH=${OS_ARCH##*_}
   LOCAL_TARGET_OS=${OS_ARCH%_*}
+  LOCAL_TARGET_ARCH=${OS_ARCH##*_}
+else
+  LOCAL_TARGET_OS=${TARGET_OS:-linux}
+  LOCAL_TARGET_ARCH=${TARGET_ARCH:-amd64}
 fi
-
-LOCAL_TARGET_OS=${LOCAL_TARGET_OS:-linux}
-LOCAL_TARGET_ARCH=${LOCAL_TARGET_ARCH:-amd64}
-LOCAL_GOOS_LOCAL=${LOCAL_TARGET_OS}
-LOCAL_GOARCH_LOCAL=${LOCAL_TARGET_ARCH}
 
 cd "${ROOT}"
 
@@ -41,9 +39,9 @@ if [[ -f out/${LOCAL_TARGET_OS}_${LOCAL_TARGET_ARCH}/docker-builder ]]; then
   PREBUILT="$(out/${LOCAL_TARGET_OS}_${LOCAL_TARGET_ARCH}/docker-builder --version)"
   CODE_CHG="$(git diff ./tools/docker-builder)"
   if [[ "${CURRENT_BUILD}" != "${PREBUILT}" ]] || [[ -n "${CODE_CHG}" ]]; then
-    GOOS=${LOCAL_GOOS_LOCAL} GOARCH=${LOCAL_GOARCH_LOCAL} ./common/scripts/gobuild.sh out/${LOCAL_TARGET_OS}_${LOCAL_TARGET_ARCH}/docker-builder ./tools/docker-builder
+    GOOS=${LOCAL_TARGET_OS} GOARCH=${LOCAL_TARGET_ARCH} ./common/scripts/gobuild.sh out/${LOCAL_TARGET_OS}_${LOCAL_TARGET_ARCH}/docker-builder ./tools/docker-builder
   fi
 else
-  GOOS=${LOCAL_GOOS_LOCAL} GOARCH=${LOCAL_GOARCH_LOCAL} ./common/scripts/gobuild.sh out/${LOCAL_TARGET_OS}_${LOCAL_TARGET_ARCH}/docker-builder ./tools/docker-builder
+  GOOS=${LOCAL_TARGET_OS} GOARCH=${LOCAL_TARGET_ARCH} ./common/scripts/gobuild.sh out/${LOCAL_TARGET_OS}_${LOCAL_TARGET_ARCH}/docker-builder ./tools/docker-builder
 fi
 out/${LOCAL_TARGET_OS}_${LOCAL_TARGET_ARCH}/docker-builder "$@"

--- a/tools/docker
+++ b/tools/docker
@@ -20,23 +20,18 @@ ROOT=$(dirname "$WD")
 
 set -eu
 
-TARGET_OS=${TARGET_OS:-linux}
-TARGET_ARCH=${TARGET_ARCH:-amd64}
-GOOS_LOCAL=${TARGET_OS}
-GOARCH_LOCAL=${TARGET_ARCH}
-
 cd "${ROOT}"
 
 export REPO_ROOT="${ROOT}"
 
-if [[ -f out/${TARGET_OS}_${TARGET_ARCH}/docker-builder ]]; then
+if [[ -f ${LOCAL_OUT}/docker-builder ]]; then
   CURRENT_BUILD="$(./common/scripts/report_build_info.sh | grep buildGitRevision | cut -d= -f2)"
   PREBUILT="$(out/${TARGET_OS}_${TARGET_ARCH}/docker-builder --version)"
   CODE_CHG="$(git diff ./tools/docker-builder)"
   if [[ "${CURRENT_BUILD}" != "${PREBUILT}" ]] || [[ -n "${CODE_CHG}" ]]; then
-    GOOS=${GOOS_LOCAL} GOARCH=${GOARCH_LOCAL} ./common/scripts/gobuild.sh out/${TARGET_OS}_${TARGET_ARCH}/docker-builder ./tools/docker-builder
+    ./common/scripts/gobuild.sh ${LOCAL_OUT}/docker-builder ./tools/docker-builder
   fi
 else
-  GOOS=${GOOS_LOCAL} GOARCH=${GOARCH_LOCAL} ./common/scripts/gobuild.sh out/${TARGET_OS}_${TARGET_ARCH}/docker-builder ./tools/docker-builder
+  ./common/scripts/gobuild.sh ${LOCAL_OUT}/docker-builder ./tools/docker-builder
 fi
-out/${TARGET_OS}_${TARGET_ARCH}/docker-builder "$@"
+${LOCAL_OUT}/docker-builder "$@"

--- a/tools/docker
+++ b/tools/docker
@@ -18,32 +18,32 @@ WD=$(dirname "$0")
 WD=$(cd "$WD"; pwd)
 ROOT=$(dirname "$WD")
 
-set -eu
+set -eux
 
 # LOCAL_OUT is set when runing in a Makefile and set to current architecture (not host)
 if [[ ! -z "${LOCAL_OUT}" ]]; then
   OS_ARCH=${LOCAL_OUT##*/}
-  TARGET_ARCH=${OS_ARCH##*_}
-  TARGET_OS=${OS_ARCH%_*}
+  LOCAL_TARGET_ARCH=${OS_ARCH##*_}
+  LOCAL_TARGET_OS=${OS_ARCH%_*}
 fi
 
-TARGET_OS=${TARGET_OS:-linux}
-TARGET_ARCH=${TARGET_ARCH:-amd64}
-GOOS_LOCAL=${TARGET_OS}
-GOARCH_LOCAL=${TARGET_ARCH}
+LOCAL_TARGET_OS=${LOCAL_TARGET_OS:-linux}
+LOCAL_TARGET_ARCH=${LOCAL_TARGET_ARCH:-amd64}
+LOCAL_GOOS_LOCAL=${LOCAL_TARGET_OS}
+LOCAL_GOARCH_LOCAL=${LOCAL_TARGET_ARCH}
 
 cd "${ROOT}"
 
 export REPO_ROOT="${ROOT}"
 
-if [[ -f out/${TARGET_OS}_${TARGET_ARCH}/docker-builder ]]; then
+if [[ -f out/${LOCAL_TARGET_OS}_${LOCAL_TARGET_ARCH}/docker-builder ]]; then
   CURRENT_BUILD="$(./common/scripts/report_build_info.sh | grep buildGitRevision | cut -d= -f2)"
-  PREBUILT="$(out/${TARGET_OS}_${TARGET_ARCH}/docker-builder --version)"
+  PREBUILT="$(out/${LOCAL_TARGET_OS}_${LOCAL_TARGET_ARCH}/docker-builder --version)"
   CODE_CHG="$(git diff ./tools/docker-builder)"
   if [[ "${CURRENT_BUILD}" != "${PREBUILT}" ]] || [[ -n "${CODE_CHG}" ]]; then
-    GOOS=${GOOS_LOCAL} GOARCH=${GOARCH_LOCAL} ./common/scripts/gobuild.sh out/${TARGET_OS}_${TARGET_ARCH}/docker-builder ./tools/docker-builder
+    GOOS=${LOCAL_GOOS_LOCAL} GOARCH=${LOCAL_GOARCH_LOCAL} ./common/scripts/gobuild.sh out/${LOCAL_TARGET_OS}_${LOCAL_TARGET_ARCH}/docker-builder ./tools/docker-builder
   fi
 else
-  GOOS=${GOOS_LOCAL} GOARCH=${GOARCH_LOCAL} ./common/scripts/gobuild.sh out/${TARGET_OS}_${TARGET_ARCH}/docker-builder ./tools/docker-builder
+  GOOS=${LOCAL_GOOS_LOCAL} GOARCH=${LOCAL_GOARCH_LOCAL} ./common/scripts/gobuild.sh out/${LOCAL_TARGET_OS}_${LOCAL_TARGET_ARCH}/docker-builder ./tools/docker-builder
 fi
-out/${TARGET_OS}_${TARGET_ARCH}/docker-builder "$@"
+out/${LOCAL_TARGET_OS}_${LOCAL_TARGET_ARCH}/docker-builder "$@"

--- a/tools/docker
+++ b/tools/docker
@@ -20,18 +20,30 @@ ROOT=$(dirname "$WD")
 
 set -eu
 
+# LOCAL_OUT is set when runing in a Makefile and set to current architecture (not host)
+if [[ ! -z "${LOCAL_OUT}" ]]; then
+  OS_ARCH=${LOCAL_OUT##*/}
+  TARGET_ARCH=${OS_ARCH##*_}
+  TARGET_OS=${OS_ARCH%_*}
+fi
+
+TARGET_OS=${TARGET_OS:-linux}
+TARGET_ARCH=${TARGET_ARCH:-amd64}
+GOOS_LOCAL=${TARGET_OS}
+GOARCH_LOCAL=${TARGET_ARCH}
+
 cd "${ROOT}"
 
 export REPO_ROOT="${ROOT}"
 
-if [[ -f ${LOCAL_OUT}/docker-builder ]]; then
+if [[ -f out/${TARGET_OS}_${TARGET_ARCH}/docker-builder ]]; then
   CURRENT_BUILD="$(./common/scripts/report_build_info.sh | grep buildGitRevision | cut -d= -f2)"
-  PREBUILT="$(${LOCAL_OUT}/docker-builder --version)"
+  PREBUILT="$(out/${TARGET_OS}_${TARGET_ARCH}/docker-builder --version)"
   CODE_CHG="$(git diff ./tools/docker-builder)"
   if [[ "${CURRENT_BUILD}" != "${PREBUILT}" ]] || [[ -n "${CODE_CHG}" ]]; then
-    ./common/scripts/gobuild.sh ${LOCAL_OUT}/docker-builder ./tools/docker-builder
+    GOOS=${GOOS_LOCAL} GOARCH=${GOARCH_LOCAL} ./common/scripts/gobuild.sh out/${TARGET_OS}_${TARGET_ARCH}/docker-builder ./tools/docker-builder
   fi
 else
-  ./common/scripts/gobuild.sh ${LOCAL_OUT}/docker-builder ./tools/docker-builder
+  GOOS=${GOOS_LOCAL} GOARCH=${GOARCH_LOCAL} ./common/scripts/gobuild.sh out/${TARGET_OS}_${TARGET_ARCH}/docker-builder ./tools/docker-builder
 fi
-${LOCAL_OUT}/docker-builder "$@"
+out/${TARGET_OS}_${TARGET_ARCH}/docker-builder "$@"

--- a/tools/docker
+++ b/tools/docker
@@ -26,7 +26,7 @@ export REPO_ROOT="${ROOT}"
 
 if [[ -f ${LOCAL_OUT}/docker-builder ]]; then
   CURRENT_BUILD="$(./common/scripts/report_build_info.sh | grep buildGitRevision | cut -d= -f2)"
-  PREBUILT="$(out/${TARGET_OS}_${TARGET_ARCH}/docker-builder --version)"
+  PREBUILT="$(${LOCAL_OUT}/docker-builder --version)"
   CODE_CHG="$(git diff ./tools/docker-builder)"
   if [[ "${CURRENT_BUILD}" != "${PREBUILT}" ]] || [[ -n "${CODE_CHG}" ]]; then
     ./common/scripts/gobuild.sh ${LOCAL_OUT}/docker-builder ./tools/docker-builder

--- a/tools/docker
+++ b/tools/docker
@@ -18,7 +18,7 @@ WD=$(dirname "$0")
 WD=$(cd "$WD"; pwd)
 ROOT=$(dirname "$WD")
 
-set -eux
+set -eu
 
 # LOCAL_OUT is set when runing in a Makefile and set to current architecture (not host)
 if [[ ! -z "${LOCAL_OUT}" ]]; then


### PR DESCRIPTION
**Please provide a description of this PR:**

Fixes https://github.com/istio/istio/issues/36052

A prior PR, https://github.com/istio/istio/pull/35965, updated the `docker` script to use the TARGET_OS and TARGET_ARCH env vars, however these point to the host's OS/ARCH and not that running locally in the container (or locally if not in the container). This causes the `docker-builder` to be built as a darwin executable which isn't able to be run locally in the container. This PR changes the script to use LOCAL_OUT which is the architecture where we are currently running in and should be used for build related artifacts. 