### PR TITLE
Istioctl x describe add PeerAuthentication debug info

### DIFF
--- a/istioctl/cmd/describe.go
+++ b/istioctl/cmd/describe.go
@@ -151,7 +151,7 @@ the configuration objects that affect that pod.`,
 
 			// render PeerAuthentication info
 			fmt.Fprintf(writer, "--------------------\n")
-			err = describePeerAuthentication(writer, kubeClient, configClient, istioNamespace, ns, k8s_labels.Set(pod.ObjectMeta.Labels))
+			err = describePeerAuthentication(writer, kubeClient, configClient, ns, k8s_labels.Set(pod.ObjectMeta.Labels))
 			if err != nil {
 				return err
 			}
@@ -1203,8 +1203,7 @@ func containerReady(pod *v1.Pod, containerName string) (bool, error) {
 // describePeerAuthentication fetches all PeerAuthentication in workload and root namespace.
 // It lists the ones applied to the pod, and the current active mTLS mode.
 // When the client doesn't have access to root namespace, it will only show workload namespace Peerauthentications.
-func describePeerAuthentication(writer io.Writer, kubeClient kube.ExtendedClient, configClient istioclient.Interface, istioNamespace, workloadNamespace string, podsLabels k8s_labels.Set) error { // nolint: lll
-	// get root namespace
+func describePeerAuthentication(writer io.Writer, kubeClient kube.ExtendedClient, configClient istioclient.Interface, workloadNamespace string, podsLabels k8s_labels.Set) error { // nolint: lll
 	meshCfg, err := getMeshConfig(kubeClient)
 	if err != nil {
 		return fmt.Errorf("failed to fetch mesh config: %v", err)

--- a/istioctl/cmd/describe.go
+++ b/istioctl/cmd/describe.go
@@ -149,7 +149,7 @@ the configuration objects that affect that pod.`,
 
 			// render PeerAuthentication info
 			fmt.Fprintf(writer, "--------------------\n")
-			err = describePeerAuthentication(writer, kubeClient, configClient, istioNamespace, ns, pod, k8s_labels.Set(pod.ObjectMeta.Labels))
+			err = describePeerAuthentication(writer, configClient, istioNamespace, ns, pod, k8s_labels.Set(pod.ObjectMeta.Labels))
 			if err != nil {
 				return err
 			}
@@ -1201,7 +1201,7 @@ func containerReady(pod *v1.Pod, containerName string) (bool, error) {
 // describePeerAuthentication fetches all PeerAuthentication in workload and root namespace.
 // It lists the ones applied to the pod, and the current active mTLS mode.
 // When the client doesn't have access to root namespace, it will only show workload namespace Peerauthentications.
-func describePeerAuthentication(writer io.Writer, kubeClient kube.ExtendedClient, configClient istioclient.Interface, istioNamespace, workloadNamespace string, pod *v1.Pod, podsLabels k8s_labels.Set) error { // nolint: lll
+func describePeerAuthentication(writer io.Writer, configClient istioclient.Interface, istioNamespace, workloadNamespace string, pod *v1.Pod, podsLabels k8s_labels.Set) error { // nolint: lll
 	workloadPAList, err := configClient.SecurityV1beta1().PeerAuthentications(workloadNamespace).List(context.Background(), metav1.ListOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to fetch workload namespace PeerAuthentication: %v", err)
@@ -1226,7 +1226,7 @@ func describePeerAuthentication(writer io.Writer, kubeClient kube.ExtendedClient
 		cfgs = append(cfgs, &cfg)
 	}
 
-	matchedPA := findMatchedConfigs(podsLabels, cfgs, writer)
+	matchedPA := findMatchedConfigs(podsLabels, cfgs)
 	printConfigs(writer, matchedPA)
 
 	if hasRootNamespaceAccess {
@@ -1246,7 +1246,7 @@ type Workloader interface {
 // Configs passed into this method should only contains workload's namespaces configs
 // and rootNamespaces configs, caller should be responsible for controlling configs passed
 // in.
-func findMatchedConfigs(podsLabels k8s_labels.Set, configs []*config.Config, writer io.Writer) []*config.Config {
+func findMatchedConfigs(podsLabels k8s_labels.Set, configs []*config.Config) []*config.Config {
 	var cfgs []*config.Config
 
 	for _, cfg := range configs {

--- a/istioctl/cmd/describe.go
+++ b/istioctl/cmd/describe.go
@@ -149,7 +149,7 @@ the configuration objects that affect that pod.`,
 
 			// render PeerAuthentication info
 			fmt.Fprintf(writer, "--------------------\n")
-			err = describePeerAuthentication(writer, configClient, istioNamespace, ns, pod, k8s_labels.Set(pod.ObjectMeta.Labels))
+			err = describePeerAuthentication(writer, configClient, istioNamespace, ns, k8s_labels.Set(pod.ObjectMeta.Labels))
 			if err != nil {
 				return err
 			}
@@ -1201,7 +1201,7 @@ func containerReady(pod *v1.Pod, containerName string) (bool, error) {
 // describePeerAuthentication fetches all PeerAuthentication in workload and root namespace.
 // It lists the ones applied to the pod, and the current active mTLS mode.
 // When the client doesn't have access to root namespace, it will only show workload namespace Peerauthentications.
-func describePeerAuthentication(writer io.Writer, configClient istioclient.Interface, istioNamespace, workloadNamespace string, pod *v1.Pod, podsLabels k8s_labels.Set) error { // nolint: lll
+func describePeerAuthentication(writer io.Writer, configClient istioclient.Interface, istioNamespace, workloadNamespace string, podsLabels k8s_labels.Set) error { // nolint: lll
 	workloadPAList, err := configClient.SecurityV1beta1().PeerAuthentications(workloadNamespace).List(context.Background(), metav1.ListOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to fetch workload namespace PeerAuthentication: %v", err)

--- a/istioctl/cmd/kubeinject.go
+++ b/istioctl/cmd/kubeinject.go
@@ -426,6 +426,7 @@ var (
 
 const (
 	defaultMeshConfigMapName       = "istio"
+	defaultMeshConfigMapKey        = "mesh"
 	defaultInjectConfigMapName     = "istio-sidecar-injector"
 	defaultInjectWebhookConfigName = "istio-sidecar-injector"
 	defaultWebhookName             = "sidecar-injector.istio.io"

--- a/pilot/pkg/security/authn/v1beta1/policy_applier.go
+++ b/pilot/pkg/security/authn/v1beta1/policy_applier.go
@@ -178,7 +178,7 @@ func NewPolicyApplier(rootNamespace string,
 		jwtPolicies:            jwtPolicies,
 		peerPolices:            peerPolicies,
 		processedJwtRules:      processedJwtRules,
-		consolidatedPeerPolicy: composePeerAuthentication(rootNamespace, peerPolicies),
+		consolidatedPeerPolicy: ComposePeerAuthentication(rootNamespace, peerPolicies),
 		push:                   push,
 	}
 }
@@ -362,7 +362,7 @@ func getMutualTLSMode(mtls *v1beta1.PeerAuthentication_MutualTLS) model.MutualTL
 	return model.ConvertToMutualTLSMode(mtls.Mode)
 }
 
-// composePeerAuthentication returns the effective PeerAuthentication given the list of applicable
+// ComposePeerAuthentication returns the effective PeerAuthentication given the list of applicable
 // configs. This list should contains at most 1 mesh-level and 1 namespace-level configs.
 // Workload-level configs should not be in root namespace (this should be guaranteed by the caller,
 // though they will be safely ignored in this function). If the input config list is empty, returns
@@ -375,7 +375,7 @@ func getMutualTLSMode(mtls *v1beta1.PeerAuthentication_MutualTLS) model.MutualTL
 // - UNSET will be replaced with the setting from the parent. I.e UNSET port-level config will be
 // replaced with config from workload-level, UNSET in workload-level config will be replaced with
 // one in namespace-level and so on.
-func composePeerAuthentication(rootNamespace string, configs []*config.Config) *v1beta1.PeerAuthentication {
+func ComposePeerAuthentication(rootNamespace string, configs []*config.Config) *v1beta1.PeerAuthentication {
 	var meshCfg, namespaceCfg, workloadCfg *config.Config
 
 	// Initial outputPolicy is set to a PERMISSIVE.

--- a/pilot/pkg/security/authn/v1beta1/policy_applier_test.go
+++ b/pilot/pkg/security/authn/v1beta1/policy_applier_test.go
@@ -2048,7 +2048,7 @@ func TestComposePeerAuthentication(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := composePeerAuthentication("root-namespace", tt.configs); !reflect.DeepEqual(got, tt.want) {
+			if got := ComposePeerAuthentication("root-namespace", tt.configs); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("composePeerAuthentication() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
This PR is to add PeerAuthentication debug info into `istioctl x describe pod` command. 
1. If client has access to root namespace, debug info will includes all applied PA to the specified pod the active mTLS mode.
2. If client doesn't have access to root namespace, debug info will only includes all applied PA in the workload's namespace.

Related design doc: [link](https://docs.google.com/document/d/1apxj7duekYneZL3BCczCfQM0cpTJARdsYswNC7EIG8c)