### PR TITLE
[echo] Make readiness check timeout configurable.

### DIFF
--- a/pkg/test/framework/components/echo/common/config.go
+++ b/pkg/test/framework/components/echo/common/config.go
@@ -17,7 +17,6 @@ package common
 import (
 	"fmt"
 	"strings"
-	"time"
 
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/protocol"
@@ -134,7 +133,7 @@ func FillInDefaults(ctx resource.Context, c *echo.Config) (err error) {
 	// If readiness probe is not specified by a test, wait a long time
 	// Waiting forever would cause the test to timeout and lose logs
 	if c.ReadinessTimeout == 0 {
-		c.ReadinessTimeout = time.Minute * 10
+		c.ReadinessTimeout = echo.DefaultReadinessTimeout()
 	}
 
 	return nil

--- a/pkg/test/framework/components/echo/flags.go
+++ b/pkg/test/framework/components/echo/flags.go
@@ -22,8 +22,9 @@ import (
 )
 
 var (
-	callTimeout = 20 * time.Second
-	callDelay   = 10 * time.Millisecond
+	callTimeout      = 20 * time.Second
+	callDelay        = 10 * time.Millisecond
+	readinessTimeout = 10 * time.Minute
 )
 
 // init registers the command-line flags that we can exposed for "go test".
@@ -32,9 +33,16 @@ func init() {
 		"Specifies the default total timeout used when retrying calls to the Echo service")
 	flag.DurationVar(&callDelay, "istio.test.echo.callDelay", callDelay,
 		"Specifies the default delay between successive retry attempts when calling the Echo service")
+	flag.DurationVar(&readinessTimeout, "istio.test.echo.readinessTimeout", readinessTimeout,
+		"Specifies the default timeout for echo readiness check")
 }
 
 // DefaultCallRetryOptions returns the default call retry options as specified in command-line flags.
 func DefaultCallRetryOptions() []retry.Option {
 	return []retry.Option{retry.Timeout(callTimeout), retry.BackoffDelay(callDelay)}
+}
+
+// DefaultReadinessTimeout returns the default echo readiness check timeout.
+func DefaultReadinessTimeout() time.Duration {
+	return readinessTimeout
 }


### PR DESCRIPTION
In case of deployment of echo workload happens at the same time as cluster upgrade/repair events, it could take quite long before the echo app become schedulable. cc @ZhengzheYang 