### PR TITLE
Fire off eds update on pod label change

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -399,7 +399,7 @@ func NewController(kubeClient kubelib.Client, options Options) *Controller {
 			})
 		}
 	})
-	c.registerHandlers(c.pods.informer, "Pods", c.pods.onEvent, nil)
+	c.registerHandlers(c.pods.informer, "Pods", c.pods.onEvent, c.pods.checkPodLabelChange)
 
 	c.exports = newServiceExportCache(c)
 	c.imports = newServiceImportCache(c)

--- a/releasenotes/notes/update-eds.yaml
+++ b/releasenotes/notes/update-eds.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+- 36056
+releaseNotes:
+- |
+  **Added** update eds on pod label change


### PR DESCRIPTION
Signed-off-by: dddddai <dddwq@foxmail.com>

**Please provide a description of this PR:**
Now the control plane does not fire off an eds update when pod label changes, which may lead to inconsistency, please refer to https://github.com/istio/istio/issues/36056#issue-1052149403

Fix #36056

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [x] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
