### PR TITLE
reduce pilot-agent binary size

### DIFF
--- a/pilot/pkg/serviceregistry/util/label/label.go
+++ b/pilot/pkg/serviceregistry/util/label/label.go
@@ -16,7 +16,6 @@ package label
 
 import (
 	"istio.io/api/label"
-
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/config/labels"

--- a/pilot/pkg/serviceregistry/util/label/label.go
+++ b/pilot/pkg/serviceregistry/util/label/label.go
@@ -15,13 +15,19 @@
 package label
 
 import (
-	v1 "k8s.io/api/core/v1"
-
 	"istio.io/api/label"
+
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/network"
+)
+
+// copied from https://github.com/kubernetes/api/blob/master/core/v1/well_known_labels.go
+// It is to remove dependency on k8s.io/api/core/v1
+const (
+	LabelTopologyZone   = "topology.kubernetes.io/zone"
+	LabelTopologyRegion = "topology.kubernetes.io/region"
 )
 
 // AugmentLabels adds additional labels to the those provided.
@@ -34,10 +40,10 @@ func AugmentLabels(in labels.Instance, clusterID cluster.ID, locality string, ne
 
 	region, zone, subzone := model.SplitLocalityLabel(locality)
 	if len(region) > 0 {
-		out[v1.LabelTopologyRegion] = region
+		out[LabelTopologyRegion] = region
 	}
 	if len(zone) > 0 {
-		out[v1.LabelTopologyZone] = zone
+		out[LabelTopologyZone] = zone
 	}
 	if len(subzone) > 0 {
 		out[label.TopologySubzone.Name] = subzone


### PR DESCRIPTION
**Please provide a description of this PR:**

By removing dependency on k8s core/v1, it reduces  size by 4M