### PR TITLE
Correct bug-report `--include|--exclude` params order

### DIFF
--- a/tools/bug-report/pkg/bugreport/bugreport.go
+++ b/tools/bug-report/pkg/bugreport/bugreport.go
@@ -68,8 +68,8 @@ func Cmd(logOpts *log.Options) *cobra.Command {
 		SilenceUsage: true,
 		Long: `bug-report selectively captures cluster information and logs into an archive to help diagnose problems.
 Proxy logs can be filtered using:
-  --include|--exclude ns1,ns2.../dep1,dep2.../pod1,pod2.../cntr1,cntr.../lbl1=val1,lbl2=val2.../ann1=val1,ann2=val2...
-where ns=namespace, dep=deployment, cntr=container, lbl=label, ann=annotation
+  --include|--exclude ns1,ns2.../dep1,dep2.../pod1,pod2.../lbl1=val1,lbl2=val2.../ann1=val1,ann2=val2.../cntr1,cntr...
+where ns=namespace, dep=deployment, lbl=label, ann=annotation, cntr=container
 
 The filter spec is interpreted as 'must be in (ns1 OR ns2) AND (dep1 OR dep2) AND (cntr1 OR cntr2)...'
 The log will be included only if the container matches at least one include filter and does not match any exclude filters.

--- a/tools/bug-report/pkg/config/config.go
+++ b/tools/bug-report/pkg/config/config.go
@@ -28,7 +28,7 @@ import (
 // SelectionSpec is a spec for pods that will be Include in the capture
 // archive. The format is:
 //
-//   Namespace1,Namespace2../Services/Pods/Label1,Label2.../Annotation1,Annotation2.../ContainerName1,ContainerName2...
+//   Namespace1,Namespace2../Deployments/Pods/Label1,Label2.../Annotation1,Annotation2.../ContainerName1,ContainerName2...
 //
 // Namespace, pod and container names are pattern matching while labels
 // and annotations may have pattern in the values with exact match for keys.
@@ -82,7 +82,7 @@ func (s SelectionSpecs) String() string {
 			st += fmt.Sprintf("Namespaces: %s", strings.Join(ss.Namespaces, ","))
 		}
 		if !defaultListSetting(ss.Deployments) {
-			st += fmt.Sprintf("/Services: %s", strings.Join(ss.Deployments, ","))
+			st += fmt.Sprintf("/Deployments: %s", strings.Join(ss.Deployments, ","))
 		}
 		if !defaultListSetting(ss.Pods) {
 			st += fmt.Sprintf("/Pods:%s", strings.Join(ss.Pods, ","))
@@ -243,17 +243,17 @@ func (s *SelectionSpec) MarshalJSON() ([]byte, error) {
 	out := fmt.Sprint(strings.Join(s.Namespaces, ","))
 	out += fmt.Sprintf("/%s", strings.Join(s.Deployments, ","))
 	out += fmt.Sprintf("/%s", strings.Join(s.Pods, ","))
-	out += fmt.Sprintf("/%s", strings.Join(s.Containers, ","))
-	tmp := "/"
+	tmp := []string{}
 	for k, v := range s.Labels {
-		tmp += fmt.Sprintf("%s=%s", k, v)
+		tmp = append(tmp, fmt.Sprintf("%s=%s", k, v))
 	}
-	out += tmp
-	tmp = "/"
+	out += fmt.Sprintf("/%s", strings.Join(tmp, ","))
+	tmp = []string{}
 	for k, v := range s.Annotations {
-		tmp += fmt.Sprintf("%s=%s", k, v)
+		tmp = append(tmp, fmt.Sprintf("%s=%s", k, v))
 	}
-	out += tmp
+	out += fmt.Sprintf("/%s", strings.Join(tmp, ","))
+	out += fmt.Sprintf("/%s", strings.Join(s.Containers, ","))
 	return []byte(`"` + out + `"`), nil
 }
 


### PR DESCRIPTION
Signed-off-by: dddddai <dddwq@foxmail.com>

**Please provide a description of this PR:**
bug-report `--include|--exclude` params order seems incorrect, which may result in parse error
The correct order should be: namespaces/deployments/pods/labels/annotations/**containers**

Please refer to:
https://github.com/istio/istio/blob/03dff9ab756a3058145349d5c52659a3b69bb6b0/tools/bug-report/pkg/config/config.go#L28-L31
https://github.com/istio/istio/blob/03dff9ab756a3058145349d5c52659a3b69bb6b0/tools/bug-report/pkg/config/config.go#L213-L217