### PR TITLE
validation: add validation for re2 max regex size

### DIFF
--- a/pkg/bootstrap/testdata/all_golden.json
+++ b/pkg/bootstrap/testdata/all_golden.json
@@ -13,7 +13,7 @@
               "static_layer": {
                   "envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst": true,
                   "envoy.reloadable_features.require_strict_1xx_and_204_response_headers": false,
-                  "re2.max_program_size.error_level": 1024,
+                  "re2.max_program_size.error_level": 32768,
                   "envoy.reloadable_features.http_reject_path_with_fragment": false
               }
           },

--- a/pkg/bootstrap/testdata/auth_golden.json
+++ b/pkg/bootstrap/testdata/auth_golden.json
@@ -13,7 +13,7 @@
               "static_layer": {
                   "envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst": true,
                   "envoy.reloadable_features.require_strict_1xx_and_204_response_headers": false,
-                  "re2.max_program_size.error_level": 1024,
+                  "re2.max_program_size.error_level": 32768,
                   "envoy.reloadable_features.http_reject_path_with_fragment": false
               }
           },

--- a/pkg/bootstrap/testdata/authsds_golden.json
+++ b/pkg/bootstrap/testdata/authsds_golden.json
@@ -13,7 +13,7 @@
               "static_layer": {
                   "envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst": true,
                   "envoy.reloadable_features.require_strict_1xx_and_204_response_headers": false,
-                  "re2.max_program_size.error_level": 1024,
+                  "re2.max_program_size.error_level": 32768,
                   "envoy.reloadable_features.http_reject_path_with_fragment": false
               }
           },

--- a/pkg/bootstrap/testdata/default_golden.json
+++ b/pkg/bootstrap/testdata/default_golden.json
@@ -13,7 +13,7 @@
               "static_layer": {
                   "envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst": true,
                   "envoy.reloadable_features.require_strict_1xx_and_204_response_headers": false,
-                  "re2.max_program_size.error_level": 1024,
+                  "re2.max_program_size.error_level": 32768,
                   "envoy.reloadable_features.http_reject_path_with_fragment": false
               }
           },

--- a/pkg/bootstrap/testdata/metrics_no_statsd_golden.json
+++ b/pkg/bootstrap/testdata/metrics_no_statsd_golden.json
@@ -13,7 +13,7 @@
               "static_layer": {
                   "envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst": true,
                   "envoy.reloadable_features.require_strict_1xx_and_204_response_headers": false,
-                  "re2.max_program_size.error_level": 1024,
+                  "re2.max_program_size.error_level": 32768,
                   "envoy.reloadable_features.http_reject_path_with_fragment": false
               }
           },

--- a/pkg/bootstrap/testdata/running_golden.json
+++ b/pkg/bootstrap/testdata/running_golden.json
@@ -18,7 +18,7 @@
               "static_layer": {
                   "envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst": true,
                   "envoy.reloadable_features.require_strict_1xx_and_204_response_headers": false,
-                  "re2.max_program_size.error_level": 1024,
+                  "re2.max_program_size.error_level": 32768,
                   "envoy.reloadable_features.http_reject_path_with_fragment": false
               }
           },

--- a/pkg/bootstrap/testdata/runningsds_golden.json
+++ b/pkg/bootstrap/testdata/runningsds_golden.json
@@ -18,7 +18,7 @@
               "static_layer": {
                   "envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst": true,
                   "envoy.reloadable_features.require_strict_1xx_and_204_response_headers": false,
-                  "re2.max_program_size.error_level": 1024,
+                  "re2.max_program_size.error_level": 32768,
                   "envoy.reloadable_features.http_reject_path_with_fragment": false
               }
           },

--- a/pkg/bootstrap/testdata/stats_inclusion_golden.json
+++ b/pkg/bootstrap/testdata/stats_inclusion_golden.json
@@ -13,7 +13,7 @@
               "static_layer": {
                   "envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst": true,
                   "envoy.reloadable_features.require_strict_1xx_and_204_response_headers": false,
-                  "re2.max_program_size.error_level": 1024,
+                  "re2.max_program_size.error_level": 32768,
                   "envoy.reloadable_features.http_reject_path_with_fragment": false
               }
           },

--- a/pkg/bootstrap/testdata/tracing_datadog_golden.json
+++ b/pkg/bootstrap/testdata/tracing_datadog_golden.json
@@ -13,7 +13,7 @@
               "static_layer": {
                   "envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst": true,
                   "envoy.reloadable_features.require_strict_1xx_and_204_response_headers": false,
-                  "re2.max_program_size.error_level": 1024,
+                  "re2.max_program_size.error_level": 32768,
                   "envoy.reloadable_features.http_reject_path_with_fragment": false
               }
           },

--- a/pkg/bootstrap/testdata/tracing_lightstep_golden.json
+++ b/pkg/bootstrap/testdata/tracing_lightstep_golden.json
@@ -13,7 +13,7 @@
               "static_layer": {
                   "envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst": true,
                   "envoy.reloadable_features.require_strict_1xx_and_204_response_headers": false,
-                  "re2.max_program_size.error_level": 1024,
+                  "re2.max_program_size.error_level": 32768,
                   "envoy.reloadable_features.http_reject_path_with_fragment": false
               }
           },

--- a/pkg/bootstrap/testdata/tracing_opencensusagent_golden.json
+++ b/pkg/bootstrap/testdata/tracing_opencensusagent_golden.json
@@ -13,7 +13,7 @@
               "static_layer": {
                   "envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst": true,
                   "envoy.reloadable_features.require_strict_1xx_and_204_response_headers": false,
-                  "re2.max_program_size.error_level": 1024,
+                  "re2.max_program_size.error_level": 32768,
                   "envoy.reloadable_features.http_reject_path_with_fragment": false
               }
           },

--- a/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
+++ b/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
@@ -13,7 +13,7 @@
               "static_layer": {
                   "envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst": true,
                   "envoy.reloadable_features.require_strict_1xx_and_204_response_headers": false,
-                  "re2.max_program_size.error_level": 1024,
+                  "re2.max_program_size.error_level": 32768,
                   "envoy.reloadable_features.http_reject_path_with_fragment": false
               }
           },

--- a/pkg/bootstrap/testdata/tracing_tls_custom_sni_golden.json
+++ b/pkg/bootstrap/testdata/tracing_tls_custom_sni_golden.json
@@ -13,7 +13,7 @@
               "static_layer": {
                   "envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst": true,
                   "envoy.reloadable_features.require_strict_1xx_and_204_response_headers": false,
-                  "re2.max_program_size.error_level": 1024,
+                  "re2.max_program_size.error_level": 32768,
                   "envoy.reloadable_features.http_reject_path_with_fragment": false
               }
           },

--- a/pkg/bootstrap/testdata/tracing_tls_golden.json
+++ b/pkg/bootstrap/testdata/tracing_tls_golden.json
@@ -13,7 +13,7 @@
               "static_layer": {
                   "envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst": true,
                   "envoy.reloadable_features.require_strict_1xx_and_204_response_headers": false,
-                  "re2.max_program_size.error_level": 1024,
+                  "re2.max_program_size.error_level": 32768,
                   "envoy.reloadable_features.http_reject_path_with_fragment": false
               }
           },

--- a/pkg/bootstrap/testdata/tracing_zipkin_golden.json
+++ b/pkg/bootstrap/testdata/tracing_zipkin_golden.json
@@ -13,7 +13,7 @@
               "static_layer": {
                   "envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst": true,
                   "envoy.reloadable_features.require_strict_1xx_and_204_response_headers": false,
-                  "re2.max_program_size.error_level": 1024,
+                  "re2.max_program_size.error_level": 32768,
                   "envoy.reloadable_features.http_reject_path_with_fragment": false
               }
           },

--- a/pkg/bootstrap/testdata/xdsproxy_golden.json
+++ b/pkg/bootstrap/testdata/xdsproxy_golden.json
@@ -13,7 +13,7 @@
               "static_layer": {
                   "envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst": true,
                   "envoy.reloadable_features.require_strict_1xx_and_204_response_headers": false,
-                  "re2.max_program_size.error_level": 1024,
+                  "re2.max_program_size.error_level": 32768,
                   "envoy.reloadable_features.http_reject_path_with_fragment": false
               }
           },

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -2508,6 +2508,17 @@ func validateStringMatchRegexp(sm *networking.StringMatch, where string) error {
 		return fmt.Errorf("%q: regex string match should not be empty", where)
 	}
 
+	// Envoy enforces a re2.max_program_size.error_level re2 program size is not the same as length,
+	// but it is always *larger* than length. Because goland does not have a way to evaluate the
+	// program size, we approximate by the length. To ensure that a program that is smaller than 1024
+	// length but larger than 1024 size does not enter the system, we program Envoy to allow very large
+	// regexs to avoid NACKs. See
+	// https://github.com/jpeach/snippets/blob/889fda84cc8713af09205438b33553eb69dd5355/re2sz.cc to
+	// evaluate program size.
+	if len(re) > 1024 {
+		return fmt.Errorf("%q: regex is too large, max length allowed is 1024", where)
+	}
+
 	_, err := regexp.Compile(re)
 	if err == nil {
 		return nil

--- a/pkg/config/validation/virtualservice.go
+++ b/pkg/config/validation/virtualservice.go
@@ -155,6 +155,9 @@ func validateHTTPRouteMatchRequest(http *networking.HTTPRoute, routeType HTTPRou
 				for _, qp := range match.GetQueryParams() {
 					errs = appendErrors(errs, validateStringMatchRegexp(qp, "queryParams"))
 				}
+				for _, h := range match.GetHeaders() {
+					errs = appendErrors(errs, validateStringMatchRegexp(h, "headers"))
+				}
 			}
 		}
 	} else {

--- a/tools/packaging/common/envoy_bootstrap.json
+++ b/tools/packaging/common/envoy_bootstrap.json
@@ -31,7 +31,7 @@
                   {{- end }}
                   "envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst": true,
                   "envoy.reloadable_features.require_strict_1xx_and_204_response_headers": false,
-                  "re2.max_program_size.error_level": 1024,
+                  "re2.max_program_size.error_level": 32768,
                   "envoy.reloadable_features.http_reject_path_with_fragment": false
               }
           },


### PR DESCRIPTION
Currently, regex over 1024 program size will NACK envoy.

This introduces a new validation error if the program *length* exceeds
1024. Length is always less than program size. This ensures that anyone
this validation error fails for is already broken (by NACKs); we must
approximate as golang doesn't expose a program size.

In order to ensure that users with length<1024 but size>1024, we also
bump the max size enforced by envoy. This is set to a number 4x higher
than I was able to make any regex with length<1024, but with some margin
in case I missed some cases where there are larger sizes, while also not
being so high to allow absurdly high regexs in the worst case.

Overall, this should result in:
* All users with working config: continue to work
* Users with NACK and length<1024: will start working
* Users with NACK and length>1024: will start rejecting in webhook

**Please provide a description of this PR:**