### PR TITLE
Remove duplicate Grafana Pod port definition.

### DIFF
--- a/samples/addons/grafana.yaml
+++ b/samples/addons/grafana.yaml
@@ -157,9 +157,6 @@ spec:
             - name: service
               containerPort: 3000
               protocol: TCP
-            - name: grafana
-              containerPort: 3000
-              protocol: TCP
           env:
             
             - name: GF_PATHS_DATA


### PR DESCRIPTION
Keep the one named "service" because that's what the port's called on the _Service_

**Please provide a description of this PR:**

Minor fix to the Grafana addon resources.
Note that while `kubectl` is happy to apply this, some systems' pre-checks (eg Flux 2) reject the file because of this error.


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [X] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
