### PR TITLE
remove redundant logic in validateHTTPRouteMatchRequest

### DIFF
--- a/pkg/config/validation/virtualservice.go
+++ b/pkg/config/validation/virtualservice.go
@@ -155,9 +155,6 @@ func validateHTTPRouteMatchRequest(http *networking.HTTPRoute, routeType HTTPRou
 				for _, qp := range match.GetQueryParams() {
 					errs = appendErrors(errs, validateStringMatchRegexp(qp, "queryParams"))
 				}
-				for _, h := range match.GetHeaders() {
-					errs = appendErrors(errs, validateStringMatchRegexp(h, "headers"))
-				}
 			}
 		}
 	} else {


### PR DESCRIPTION
**Please provide a description of this PR:**

redundant login in  validateHTTPRouteMatchRequest . 


				for name, header := range match.Headers {
					if header == nil {
						errs = appendErrors(errs, fmt.Errorf("header match %v cannot be null", name))
					}
					errs = appendErrors(errs, ValidateHTTPHeaderName(name))
					errs = appendErrors(errs, validateStringMatchRegexp(header, "headers"))
				}



**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
