### PR TITLE
update chart template to use service.annotations

### DIFF
--- a/manifests/charts/gateway/templates/service.yaml
+++ b/manifests/charts/gateway/templates/service.yaml
@@ -10,6 +10,7 @@ metadata:
     topology.istio.io/network: "{{.}}"
     {{- end }}
   annotations:
+    {{- .Values.service.annotations | toYaml | nindent 4 }}
     {{- .Values.annotations | toYaml | nindent 4 }}
 spec:
 {{- with .Values.service.loadBalancerIP }}


### PR DESCRIPTION
**Please provide a description of this PR:**

The `values.yaml` file for the `gateway` chart includes `service.annotations`, but it looks like they were forgotten to be included.