### PR TITLE
Fix bug-report timeout is not honored

### DIFF
--- a/tools/bug-report/pkg/content/content.go
+++ b/tools/bug-report/pkg/content/content.go
@@ -218,10 +218,10 @@ func GetNetstat(p *Params) (map[string]string, error) {
 }
 
 // GetAnalyze returns the output of istioctl analyze.
-func GetAnalyze(p *Params) (map[string]string, error) {
+func GetAnalyze(p *Params, timeout time.Duration) (map[string]string, error) {
 	out := make(map[string]string)
 	sa := local.NewSourceAnalyzer(schema.NewMustGet(), analyzers.AllCombined(),
-		resource.Namespace(p.Namespace), resource.Namespace(p.IstioNamespace), nil, true, 5*time.Minute)
+		resource.Namespace(p.Namespace), resource.Namespace(p.IstioNamespace), nil, true, timeout)
 
 	k, err := kube.NewClient(kube.NewClientConfigForRestConfig(p.Client.RESTConfig()))
 	if err != nil {


### PR DESCRIPTION
**Please provide a description of this PR:**
Currently the `istioctl bug-report` timeout only works for the processes without the analysis process. The analysis process has a fixed timeout 5mins. This PR is to fix it by changing the default 5mins to the time left after doing other processes.


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [x] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
