### PR TITLE
add fault filter to top of filters

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -1322,9 +1322,13 @@ func buildHTTPConnectionManager(listenerOpts buildListenerOpts, httpOpts *httpLi
 		filters = append(filters, xdsfilters.Alpn)
 	}
 
-	filters = append(filters, xdsfilters.Cors, xdsfilters.Fault)
+	filters = append(filters, xdsfilters.Cors)
 	filters = append(filters, listenerOpts.push.Telemetry.HTTPFilters(listenerOpts.proxy, listenerOpts.class)...)
 	filters = append(filters, xdsfilters.BuildRouterFilter(routerFilterCtx))
+
+	// Add fault filter at the top.
+	filters = append(filters[:1], filters[0:]...)
+	filters[0] = xdsfilters.Fault
 
 	connectionManager.HttpFilters = filters
 

--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -2261,7 +2261,7 @@ func verifyInboundEnvoyListenerNumber(t *testing.T, l *listener.Listener) {
 			t.Fatalf("expected HTTP filter, found none")
 		}
 
-		expect := []string{xdsfilters.MxFilterName, xdsfilters.Cors.Name, xdsfilters.Fault.Name, xdsfilters.Router.Name}
+		expect := []string{xdsfilters.Fault.Name, xdsfilters.MxFilterName, xdsfilters.Cors.Name, xdsfilters.Router.Name}
 		got := getHCMFilters(t, f)
 		if !reflect.DeepEqual(expect, got) {
 			t.Fatalf("expected http filters %v, found %v", expect, got)


### PR DESCRIPTION
Fault Injection should be added as the first filter https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/fault_filter.html?highlight=fault%20injection#configuration

This PR fixes that ordering

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ X] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [X ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
