### PR TITLE
Add host header into ZipkinConfig for jaeger when using telemetry api 

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/tracing.go
+++ b/pilot/pkg/networking/core/v1alpha3/tracing.go
@@ -235,10 +235,12 @@ func configureFromProviderConfig(pushCtx *model.PushContext, meta *model.NodeMet
 type typedConfigGenFromClusterFn func(clusterName string) (*anypb.Any, error)
 
 func zipkinConfigGen(cluster string) (*anypb.Any, error) {
+	_, _, hostname, _ := model.ParseSubsetKey(cluster)
 	zc := &tracingcfg.ZipkinConfig{
 		CollectorCluster:         cluster,
 		CollectorEndpoint:        "/api/v2/spans",                   // envoy deprecated v1 support
 		CollectorEndpointVersion: tracingcfg.ZipkinConfig_HTTP_JSON, // use v2 JSON for now
+		CollectorHostname:        string(hostname),									 // http host header
 		TraceId_128Bit:           true,
 		SharedSpanContext:        wrapperspb.Bool(false),
 	}

--- a/pilot/pkg/networking/core/v1alpha3/tracing.go
+++ b/pilot/pkg/networking/core/v1alpha3/tracing.go
@@ -240,7 +240,7 @@ func zipkinConfigGen(cluster string) (*anypb.Any, error) {
 		CollectorCluster:         cluster,
 		CollectorEndpoint:        "/api/v2/spans",                   // envoy deprecated v1 support
 		CollectorEndpointVersion: tracingcfg.ZipkinConfig_HTTP_JSON, // use v2 JSON for now
-		CollectorHostname:        string(hostname),									 // http host header
+		CollectorHostname:        string(hostname),                  // http host header
 		TraceId_128Bit:           true,
 		SharedSpanContext:        wrapperspb.Bool(false),
 	}

--- a/pilot/pkg/networking/core/v1alpha3/tracing_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/tracing_test.go
@@ -367,10 +367,12 @@ var fakeEnvTag = &tracing.CustomTag{
 }
 
 func fakeZipkinProvider(expectClusterName, expectProviderName string) *tracingcfg.Tracing_Http {
+	_, _, hostname, _ := model.ParseSubsetKey(expectClusterName)
 	fakeZipkinProviderConfig := &tracingcfg.ZipkinConfig{
 		CollectorCluster:         expectClusterName,
 		CollectorEndpoint:        "/api/v2/spans",
 		CollectorEndpointVersion: tracingcfg.ZipkinConfig_HTTP_JSON,
+		CollectorHostname:        string(hostname),
 		TraceId_128Bit:           true,
 		SharedSpanContext:        wrapperspb.Bool(false),
 	}


### PR DESCRIPTION
**Please provide a description of this PR:**
work with @micalgenus
fix #35750

If jaeger is registered as zipkin for distributed tracking with telemetry api, the envoy setting is as follows.
```
...
 extensionProviders:
 - name: jaeger
   zipkin:
    port: 9411
    service: jaeger-collector.istio-system.svc.cluster.local
...
```
```
"provider": {
  "name": "jaeger",
  "typed_config": {
    "@type": "type.googleapis.com/envoy.config.trace.v3.ZipkinConfig",
    "collector_cluster": "outbound|9411||jaeger-collector.istio-system.svc.cluster.local",
    "collector_endpoint": "/api/v2/spans",
    "trace_id_128bit": true,
    "shared_span_context": false,
    "collector_endpoint_version": "HTTP_JSON"
  }
}
```
The mesh sends an http request as below for distributed tracking records.

```
POST /api/v2/spans HTTP/1.1
host: outbound|9411||jaeger-collector.istio-system.svc.cluster.local
content-type: application/json
x-envoy-internal: true
x-forwarded-for: 10.244.0.92
x-envoy-expected-rq-timeout-ms: **5000**
transfer-encoding: chunked
```

At this time, the previous one sends the following response.

```
HTTP/1.1 400 Bad Request: malformed Host header
Content-Type: text/plain; charset=utf-8
Connection: close
```

The error responds that the host header is malformed.


[According to the envoy document](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/trace/v3/zipkin.proto#config-trace-v3-zipkinconfig) the host may be designated as collector_hostname.

If the collector_hostname value is not specified, use collector_cluster.

We added a code parsing collector_hostname from cluster_name.




**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.