### PR TITLE
Add ericvn to top level OWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
-*                                                                @costinm @linsun @howardjohn @nmittler
+*                                                                @costinm @linsun @howardjohn @nmittler @ericvn
 /.gitattributes                                                  @istio/wg-test-and-release-maintainers
 /.gitignore                                                      @istio/wg-test-and-release-maintainers
 /Makefile.core.mk                                                @istio/wg-test-and-release-maintainers


### PR DESCRIPTION
Rationale:
* Eric is on TOC and T&R. Top level primarily deals with these areas
* Active PR reviewer
* Currently we have some bottlenecks in the owners reviews
* Maintain more company distribution
