### PR TITLE
fix tcp stats test: don't explicitly use Kubernetes name in filter

### DIFF
--- a/prow/config/topology/single.json
+++ b/prow/config/topology/single.json
@@ -1,7 +1,7 @@
 [
   {
     "kind": "Kubernetes",
-    "clusterName": "istio-testing",
+    "clusterName": "Kubernetes",
     "podSubnet": "10.10.0.0/16",
     "svcSubnet": "10.255.10.0/24",
     "network": "istio-testing"

--- a/tests/integration/telemetry/stats/prometheus/stats.go
+++ b/tests/integration/telemetry/stats/prometheus/stats.go
@@ -106,18 +106,14 @@ func TestStatsFilter(t *testing.T, feature features.Feature) {
 							return err
 						}
 						c := cltInstance.Config().Cluster
-						sourceCluster := "Kubernetes"
-						if len(ctx.AllClusters()) > 1 {
-							sourceCluster = c.Name()
-						}
-						sourceQuery, destinationQuery, appQuery := buildQuery(sourceCluster)
+						sourceQuery, destinationQuery, appQuery := buildQuery(c.Name())
 						// Query client side metrics
 						if _, err := QueryPrometheus(t, c, sourceQuery, GetPromInstance()); err != nil {
 							t.Logf("prometheus values for istio_requests_total for cluster %v: \n%s", c.Name(), util.PromDump(c, promInst, "istio_requests_total"))
 							return err
 						}
 						// Query client side metrics for non-injected server
-						outOfMeshServerQuery := buildOutOfMeshServerQuery(sourceCluster)
+						outOfMeshServerQuery := buildOutOfMeshServerQuery(c.Name())
 						if _, err := QueryPrometheus(t, c, outOfMeshServerQuery, GetPromInstance()); err != nil {
 							t.Logf("prometheus values for istio_requests_total for cluster %v: \n%s", c.Name(), util.PromDump(c, promInst, "istio_requests_total"))
 							return err
@@ -181,11 +177,7 @@ func TestStatsTCPFilter(t *testing.T, feature features.Feature) {
 							return err
 						}
 						c := cltInstance.Config().Cluster
-						sourceCluster := "Kubernetes"
-						if len(ctx.AllClusters()) > 1 {
-							sourceCluster = c.Name()
-						}
-						destinationQuery := buildTCPQuery(sourceCluster)
+						destinationQuery := buildTCPQuery(c.Name())
 						if _, err := QueryPrometheus(t, c, destinationQuery, GetPromInstance()); err != nil {
 							t.Logf("prometheus values for istio_tcp_connections_opened_total: \n%s", util.PromDump(c, promInst, "istio_tcp_connections_opened_total"))
 							return err


### PR DESCRIPTION
The reason we needed this workaround is that we use `istio-testing` instead of `Kubernetes` in our test config, and our deploy logic doesn't push that name to the cluster unless `len(clusters) > 1`. We could also just fix this there... 