### PR TITLE
istioctl proxy-config stats

### DIFF
--- a/istioctl/cmd/proxyconfig.go
+++ b/istioctl/cmd/proxyconfig.go
@@ -589,9 +589,8 @@ func statsConfigCmd() *cobra.Command {
 					return err
 				}
 				for _, pod := range podNames {
-					stats, err := setupEnvoyStatsConfig(pod, podNamespace)
-					podStats = append(podStats, fmt.Sprintf("# POD - %s", pod))
-					podStats = append(podStats, stats)
+					stats, err := setupEnvoyStatsConfig(podName, podNamespace)
+					podStats = append(podStats, fmt.Sprintf("# POD - %s/%s", podNamespace, podName), stats)
 					if err != nil {
 						return err
 					}
@@ -604,7 +603,7 @@ func statsConfigCmd() *cobra.Command {
 					return err
 				}
 				stats, err := setupEnvoyStatsConfig(podName, podNamespace)
-				podStats = append(podStats, stats)
+				podStats = append(podStats, fmt.Sprintf("# POD - %s/%s", podNamespace, podName), stats)
 				if err != nil {
 					return err
 				}

--- a/istioctl/cmd/proxyconfig.go
+++ b/istioctl/cmd/proxyconfig.go
@@ -568,12 +568,16 @@ func statsConfigCmd() *cobra.Command {
 		Long:  `Retrieve Envoy emitted metrics for the specified pod.`,
 		Example: `  # Retrieve Envoy emitted metrics for the specified pod.
   istioctl proxy-config stats <pod-name[.namespace]>
+
+  # Retrieve Envoy metrics for pods that match label selector
+  istioctl proxy-config stats --selector app=istio-ingressgateway
+
 `,
 		Aliases: []string{"stat", "s"},
 		Args: func(cmd *cobra.Command, args []string) error {
-			if len(args) != 1  && (labelSelector == ""){
+			if len(args) != 1 && (labelSelector == "") {
 				cmd.Println(cmd.UsageString())
-				return fmt.Errorf("stats requires pod name")
+				return fmt.Errorf("stats requires pod name or label selector")
 			}
 			return nil
 		},
@@ -605,7 +609,7 @@ func statsConfigCmd() *cobra.Command {
 					return err
 				}
 			}
-			_, _ = fmt.Fprint(c.OutOrStdout(), strings.Join(podStats,"\n"))
+			_, _ = fmt.Fprint(c.OutOrStdout(), strings.Join(podStats, "\n"))
 			return nil
 		},
 		ValidArgsFunction: validPodsNameArgs,

--- a/istioctl/cmd/proxyconfig.go
+++ b/istioctl/cmd/proxyconfig.go
@@ -205,6 +205,19 @@ func setupConfigdumpEnvoyConfigWriter(debug []byte, out io.Writer) (*configdump.
 	return cw, nil
 }
 
+func setupEnvoyStatsConfig(podName, podNamespace string) (string, error) {
+	kubeClient, err := kubeClient(kubeconfig, configContext)
+	if err != nil {
+		return "", fmt.Errorf("failed to create Kubernetes client: %v", err)
+	}
+	path := "stats"
+	result, err := kubeClient.EnvoyDo(context.TODO(), podName, podNamespace, "GET", path)
+	if err != nil {
+		return "", fmt.Errorf("failed to execute command on Envoy: %v", err)
+	}
+	return string(result), nil
+}
+
 func setupEnvoyLogConfig(param, podName, podNamespace string) (string, error) {
 	kubeClient, err := kubeClient(kubeconfig, configContext)
 	if err != nil {
@@ -543,6 +556,63 @@ func listenerConfigCmd() *cobra.Command {
 		"Envoy config dump JSON file")
 
 	return listenerConfigCmd
+}
+
+func statsConfigCmd() *cobra.Command {
+	var podName, podNamespace string
+	var podNames []string
+
+	statsConfigCmd := &cobra.Command{
+		Use:   "stats [<type>/]<name>[.<namespace>]",
+		Short: "Retrieves Envoy metrics in the specified pod",
+		Long:  `Retrieve Envoy emitted metrics for the specified pod.`,
+		Example: `  # Retrieve Envoy emitted metrics for the specified pod.
+  istioctl proxy-config stats <pod-name[.namespace]>
+`,
+		Aliases: []string{"stat", "s"},
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 1  && (labelSelector == ""){
+				cmd.Println(cmd.UsageString())
+				return fmt.Errorf("stats requires pod name")
+			}
+			return nil
+		},
+		RunE: func(c *cobra.Command, args []string) error {
+			var podStats []string
+			var err error
+			if labelSelector != "" {
+				if podNames, podNamespace, err = getPodNameBySelector(labelSelector); err != nil {
+					return err
+				}
+				for _, pod := range podNames {
+					stats, err := setupEnvoyStatsConfig(pod, podNamespace)
+					podStats = append(podStats, fmt.Sprintf("# POD - %s", pod))
+					podStats = append(podStats, stats)
+					if err != nil {
+						return err
+					}
+				}
+				if err != nil {
+					return err
+				}
+			} else {
+				if podName, podNamespace, err = getPodName(args[0]); err != nil {
+					return err
+				}
+				stats, err := setupEnvoyStatsConfig(podName, podNamespace)
+				podStats = append(podStats, stats)
+				if err != nil {
+					return err
+				}
+			}
+			_, _ = fmt.Fprint(c.OutOrStdout(), strings.Join(podStats,"\n"))
+			return nil
+		},
+		ValidArgsFunction: validPodsNameArgs,
+	}
+	statsConfigCmd.PersistentFlags().StringVarP(&labelSelector, "selector", "l", "", "Label selector")
+
+	return statsConfigCmd
 }
 
 func logCmd() *cobra.Command {
@@ -1030,6 +1100,7 @@ func proxyConfig() *cobra.Command {
 	configCmd.AddCommand(clusterConfigCmd())
 	configCmd.AddCommand(allConfigCmd())
 	configCmd.AddCommand(listenerConfigCmd())
+	configCmd.AddCommand(statsConfigCmd())
 	configCmd.AddCommand(logCmd())
 	configCmd.AddCommand(routeConfigCmd())
 	configCmd.AddCommand(bootstrapConfigCmd())

--- a/istioctl/cmd/proxyconfig.go
+++ b/istioctl/cmd/proxyconfig.go
@@ -593,10 +593,10 @@ func statsConfigCmd() *cobra.Command {
 		Example: `  # Retrieve Envoy emitted metrics for the specified pod.
   istioctl proxy-config stats <pod-name[.namespace]>
 
-  # Retrieve Envoy metrics in prometheus format
+  # Retrieve Envoy server metrics in prometheus format
   istioctl proxy-config stats <pod-name[.namespace]> --output prom
 
-  # Retrieve Envoy metrics in prometheus format
+  # Retrieve Envoy cluster metrics
   istioctl proxy-config stats <pod-name[.namespace]> --type clusters
 
 `,

--- a/istioctl/cmd/proxyconfig.go
+++ b/istioctl/cmd/proxyconfig.go
@@ -236,7 +236,7 @@ func setupEnvoyServerStatsConfig(podName, podNamespace string, outputFormat stri
 	if outputFormat == prometheusOutput {
 		path += "/prometheus"
 	}
-	result, err := kubeClient.EnvoyDo(context.TODO(), podName, podNamespace, "GET", path)
+	result, err := kubeClient.EnvoyDo(context.Background(), podName, podNamespace, "GET", path)
 	if err != nil {
 		return "", fmt.Errorf("failed to execute command on Envoy: %v", err)
 	}

--- a/istioctl/cmd/proxyconfig.go
+++ b/istioctl/cmd/proxyconfig.go
@@ -587,20 +587,19 @@ func statsConfigCmd() *cobra.Command {
 	var podName, podNamespace string
 
 	statsConfigCmd := &cobra.Command{
-		Use:   "stats [<type>/]<name>[.<namespace>]",
+		Use:   "envoy-stats [<type>/]<name>[.<namespace>]",
 		Short: "Retrieves Envoy metrics in the specified pod",
 		Long:  `Retrieve Envoy emitted metrics for the specified pod.`,
 		Example: `  # Retrieve Envoy emitted metrics for the specified pod.
-  istioctl proxy-config stats <pod-name[.namespace]>
+  istioctl experimental envoy-stats <pod-name[.namespace]>
 
   # Retrieve Envoy server metrics in prometheus format
-  istioctl proxy-config stats <pod-name[.namespace]> --output prom
+  istioctl experimental envoy-stats <pod-name[.namespace]> --output prom
 
   # Retrieve Envoy cluster metrics
-  istioctl proxy-config stats <pod-name[.namespace]> --type clusters
-
+  istioctl experimental envoy-stats <pod-name[.namespace]> --type clusters
 `,
-		Aliases: []string{"stat", "s"},
+		Aliases: []string{"es"},
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 && (labelSelector == "") {
 				cmd.Println(cmd.UsageString())
@@ -1136,7 +1135,6 @@ func proxyConfig() *cobra.Command {
 	configCmd.AddCommand(clusterConfigCmd())
 	configCmd.AddCommand(allConfigCmd())
 	configCmd.AddCommand(listenerConfigCmd())
-	configCmd.AddCommand(statsConfigCmd())
 	configCmd.AddCommand(logCmd())
 	configCmd.AddCommand(routeConfigCmd())
 	configCmd.AddCommand(bootstrapConfigCmd())

--- a/istioctl/cmd/root.go
+++ b/istioctl/cmd/root.go
@@ -235,6 +235,7 @@ debug and diagnose their Istio mesh.
 	experimentalCmd.AddCommand(revisionCommand())
 	experimentalCmd.AddCommand(debugCommand())
 	experimentalCmd.AddCommand(preCheck())
+	experimentalCmd.AddCommand(statsConfigCmd())
 
 	analyzeCmd := Analyze()
 	hideInheritedFlags(analyzeCmd, FlagIstioNamespace)

--- a/releasenotes/notes/istioctl-proxy-config-stats.yaml
+++ b/releasenotes/notes/istioctl-proxy-config-stats.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: feature
+area: istioctl
+
+releaseNotes:
+- |
+  **Added** stats command `istioctl proxy-config stats` for retrieving istio-proxy envoy metrics.

--- a/releasenotes/notes/istioctl-proxy-config-stats.yaml
+++ b/releasenotes/notes/istioctl-proxy-config-stats.yaml
@@ -4,4 +4,4 @@ area: istioctl
 
 releaseNotes:
 - |
-  **Added** stats command `istioctl proxy-config stats` for retrieving istio-proxy envoy metrics.
+  **Added** stats command `istioctl experimental envoy-stats` for retrieving istio-proxy envoy metrics.


### PR DESCRIPTION
**Please provide a description of this PR:**
Adds a stats command to istioctl proxy-config to grab envoy stats `http://localhost:15000/stats`

Example output
```txt
istioctl proxy-config stats --namespace ns-1 backend-00001-deployment-574bd5b4fd-97xtw
cluster_manager.cds.version_text: "2021-11-30T18:41:37Z/56"
listener_manager.lds.version_text: "2021-11-30T18:41:37Z/56"
cluster.xds-grpc.assignment_stale: 0
cluster.xds-grpc.assignment_timeout_received: 0
cluster.xds-grpc.bind_errors: 0
cluster.xds-grpc.circuit_breakers.default.cx_open: 0
cluster.xds-grpc.circuit_breakers.default.cx_pool_open: 0
cluster.xds-grpc.circuit_breakers.default.rq_open: 0
cluster.xds-grpc.circuit_breakers.default.rq_pending_open: 0
cluster.xds-grpc.circuit_breakers.default.rq_retry_open: 0
cluster.xds-grpc.circuit_breakers.high.cx_open: 0
cluster.xds-grpc.circuit_breakers.high.cx_pool_open: 0
cluster.xds-grpc.circuit_breakers.high.rq_open: 0
cluster.xds-grpc.circuit_breakers.high.rq_pending_open: 0
cluster.xds-grpc.circuit_breakers.high.rq_retry_open: 0
cluster.xds-grpc.default.total_match_count: 1
cluster.xds-grpc.http2.dropped_headers_with_underscores: 0
cluster.xds-grpc.http2.header_overflow: 0
...
```

Prometheus
```txt
istioctl proxy-config stats --output prom --namespace ns-1 backend-00001-deployment-574bd5b4fd-97xtw
# TYPE envoy_cluster_assignment_stale counter
envoy_cluster_assignment_stale{cluster_name="xds-grpc"} 0

# TYPE envoy_cluster_assignment_timeout_received counter
envoy_cluster_assignment_timeout_received{cluster_name="xds-grpc"} 0

# TYPE envoy_cluster_bind_errors counter
envoy_cluster_bind_errors{cluster_name="xds-grpc"} 0

# TYPE envoy_cluster_default_total_match_count counter
envoy_cluster_default_total_match_count{cluster_name="xds-grpc"} 1

# TYPE envoy_cluster_http2_dropped_headers_with_underscores counter
envoy_cluster_http2_dropped_headers_with_underscores{cluster_name="xds-grpc"} 0

# TYPE envoy_cluster_http2_header_overflow counter
envoy_cluster_http2_header_overflow{cluster_name="xds-grpc"} 0

# TYPE envoy_cluster_http2_headers_cb_no_stream counter
envoy_cluster_http2_headers_cb_no_stream{cluster_name="xds-grpc"} 0

# TYPE envoy_cluster_http2_inbound_empty_frames_flood counter
envoy_cluster_http2_inbound_empty_frames_flood{cluster_name="xds-grpc"} 0

# TYPE envoy_cluster_http2_inbound_priority_frames_flood counter
envoy_cluster_http2_inbound_priority_frames_flood{cluster_name="xds-grpc"} 0

```

YAML Output
```yaml
istioctl proxy-config stats --output yaml --namespace ns-1 backend-00001-deployment-574bd5b4fd-97xtw
stats:
- name: cluster_manager.cds.version_text
  value: 2021-11-30T18:41:37Z/56
- name: listener_manager.lds.version_text
  value: 2021-11-30T18:41:37Z/56
- name: cluster.xds-grpc.assignment_stale
  value: 0
- name: cluster.xds-grpc.assignment_timeout_received
  value: 0
```

JSON Output
```json
istioctl proxy-config stats --output json --namespace ns-1 backend-00001-deployment-574bd5b4fd-97xtw
{
   "stats":[
      {
         "value":"2021-11-30T18:41:37Z/56",
         "name":"cluster_manager.cds.version_text"
      },
      {
         "name":"listener_manager.lds.version_text",
         "value":"2021-11-30T18:41:37Z/56"
      },
      {
         "name":"cluster.xds-grpc.assignment_stale",
         "value":0
      },
      {
         "name":"cluster.xds-grpc.assignment_timeout_received",
         "value":0
      },
      {
         "value":0,
         "name":"cluster.xds-grpc.bind_errors"
      },
      {
         "name":"cluster.xds-grpc.circuit_breakers.default.cx_open",
         "value":0
      },
      {
         "name":"cluster.xds-grpc.circuit_breakers.default.cx_pool_open",
         "value":0
      },
      {
         "value":0,
         "name":"cluster.xds-grpc.circuit_breakers.default.rq_open"
      },
      {
         "name":"cluster.xds-grpc.circuit_breakers.default.rq_pending_open",
         "value":0
      },
```

## Cluster Metrics

Raw
```
istioctl proxy-config stats --namespace ns-1 backend-00001-deployment-574bd5b4fd-97xtw --type clusters
inbound|9090||::default_priority::max_connections::4294967295
inbound|9090||::default_priority::max_pending_requests::4294967295
inbound|9090||::default_priority::max_requests::4294967295
inbound|9090||::default_priority::max_retries::4294967295
inbound|9090||::high_priority::max_connections::1024
inbound|9090||::high_priority::max_pending_requests::1024
inbound|9090||::high_priority::max_requests::1024
inbound|9090||::high_priority::max_retries::3
inbound|9090||::added_via_api::true
inbound|9090||::127.0.0.1:9090::cx_active::1
inbound|9090||::127.0.0.1:9090::cx_connect_fail::0
inbound|9090||::127.0.0.1:9090::cx_total::1
inbound|9090||::127.0.0.1:9090::rq_active::0
inbound|9090||::127.0.0.1:9090::rq_error::0
inbound|9090||::127.0.0.1:9090::rq_success::6228

```

YAML output 
```yaml
istioctl proxy-config stats --output yaml --namespace ns-1 backend-00001-deployment-574bd5b4fd-97xtw --type clusters
cluster_statuses:
- added_via_api: true
  circuit_breakers:
    thresholds:
    - max_connections: 4294967295
      max_pending_requests: 4294967295
      max_requests: 4294967295
      max_retries: 4294967295
    - max_connections: 1024
      max_pending_requests: 1024
      max_requests: 1024
      max_retries: 3
      priority: HIGH
  host_statuses:
  - address:
      socket_address:
        address: 127.0.0.1
        port_value: 9090
    health_status:
      eds_health_status: HEALTHY
    locality: {}

```




