### PR TITLE
controllers: abstract Kubernetes queue into common package

### DIFF
--- a/pilot/pkg/bootstrap/sidecarinjector.go
+++ b/pilot/pkg/bootstrap/sidecarinjector.go
@@ -99,7 +99,7 @@ func (s *Server) initSidecarInjector(args *PilotArgs) (*inject.Webhook, error) {
 				return nil
 			}
 
-			patcher.Run(stop)
+			go patcher.Run(stop)
 			return nil
 		})
 	}

--- a/pilot/pkg/config/kube/gateway/deploymentcontroller.go
+++ b/pilot/pkg/config/kube/gateway/deploymentcontroller.go
@@ -91,7 +91,9 @@ func NewDeploymentController(client kube.Client) *DeploymentController {
 			return err
 		},
 	}
-	dc.queue = controllers.NewQueue(controllers.WithReconciler(dc.Reconcile))
+	dc.queue = controllers.NewQueue("gateway deployment",
+		controllers.WithReconciler(dc.Reconcile),
+		controllers.WithMaxAttempts(5))
 
 	// Set up a handler that will add the parent Gateway object onto the queue.
 	// The queue will only handle Gateway objects; if child resources (Service, etc) are updated we re-add

--- a/pilot/pkg/config/kube/gateway/deploymentcontroller.go
+++ b/pilot/pkg/config/kube/gateway/deploymentcontroller.go
@@ -96,7 +96,7 @@ func NewDeploymentController(client kube.Client) *DeploymentController {
 	// Set up a handler that will add the parent Gateway object onto the queue.
 	// The queue will only handle Gateway objects; if child resources (Service, etc) are updated we re-add
 	// the Gateway to the queue and reconcile the state of the world.
-	handler := controllers.LatestVersionHandlerFuncs(controllers.EnqueueForParentHandler(dc.queue, gvk.KubernetesGateway))
+	handler := controllers.ObjectHandler(controllers.EnqueueForParentHandler(dc.queue, gvk.KubernetesGateway))
 
 	// Use the full informer, since we are already fetching all Services for other purposes
 	// If we somehow stop watching Services in the future we can add a label selector like below.
@@ -115,7 +115,7 @@ func NewDeploymentController(client kube.Client) *DeploymentController {
 
 	// Use the full informer; we are already watching all Gateways for the core Istiod logic
 	client.GatewayAPIInformer().Gateway().V1alpha2().Gateways().Informer().
-		AddEventHandler(controllers.LatestVersionHandlerFuncs(controllers.EnqueueForSelf(dc.queue)))
+		AddEventHandler(controllers.ObjectHandler(dc.queue.AddObject))
 
 	return dc
 }

--- a/pilot/pkg/config/kube/gateway/deploymentcontroller.go
+++ b/pilot/pkg/config/kube/gateway/deploymentcontroller.go
@@ -32,7 +32,6 @@ import (
 	appsinformersv1 "k8s.io/client-go/informers/apps/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/util/workqueue"
 	gateway "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	"sigs.k8s.io/yaml"
 
@@ -68,7 +67,7 @@ import (
 // * This leaves YAML templates, converted to unstructured types and Applied with the dynamic client.
 type DeploymentController struct {
 	client    kube.Client
-	queue     workqueue.RateLimitingInterface
+	queue     controllers.Queue
 	templates *template.Template
 	patcher   patcher
 }
@@ -79,11 +78,25 @@ type patcher func(gvr schema.GroupVersionResource, name string, namespace string
 // NewDeploymentController constructs a DeploymentController and registers required informers.
 // The controller will not start until Run() is called.
 func NewDeploymentController(client kube.Client) *DeploymentController {
-	q := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+	dc := &DeploymentController{
+		client:    client,
+		templates: processTemplates(),
+		patcher: func(gvr schema.GroupVersionResource, name string, namespace string, data []byte, subresources ...string) error {
+			c := client.Dynamic().Resource(gvr).Namespace(namespace)
+			t := true
+			_, err := c.Patch(context.Background(), name, types.ApplyPatchType, data, metav1.PatchOptions{
+				Force:        &t,
+				FieldManager: ControllerName,
+			}, subresources...)
+			return err
+		},
+	}
+	dc.queue = controllers.NewQueue(controllers.WithReconciler(dc.Reconcile))
+
 	// Set up a handler that will add the parent Gateway object onto the queue.
 	// The queue will only handle Gateway objects; if child resources (Service, etc) are updated we re-add
 	// the Gateway to the queue and reconcile the state of the world.
-	handler := controllers.LatestVersionHandlerFuncs(controllers.EnqueueForParentHandler(q, gvk.KubernetesGateway))
+	handler := controllers.LatestVersionHandlerFuncs(controllers.EnqueueForParentHandler(dc.queue, gvk.KubernetesGateway))
 
 	// Use the full informer, since we are already fetching all Services for other purposes
 	// If we somehow stop watching Services in the future we can add a label selector like below.
@@ -102,56 +115,13 @@ func NewDeploymentController(client kube.Client) *DeploymentController {
 
 	// Use the full informer; we are already watching all Gateways for the core Istiod logic
 	client.GatewayAPIInformer().Gateway().V1alpha2().Gateways().Informer().
-		AddEventHandler(controllers.LatestVersionHandlerFuncs(controllers.EnqueueForSelf(q)))
+		AddEventHandler(controllers.LatestVersionHandlerFuncs(controllers.EnqueueForSelf(dc.queue)))
 
-	return &DeploymentController{
-		client:    client,
-		queue:     q,
-		templates: processTemplates(),
-		patcher: func(gvr schema.GroupVersionResource, name string, namespace string, data []byte, subresources ...string) error {
-			c := client.Dynamic().Resource(gvr).Namespace(namespace)
-			t := true
-			_, err := c.Patch(context.Background(), name, types.ApplyPatchType, data, metav1.PatchOptions{
-				Force:        &t,
-				FieldManager: ControllerName,
-			}, subresources...)
-			return err
-		},
-	}
+	return dc
 }
 
 func (d *DeploymentController) Run(stop <-chan struct{}) {
-	defer d.queue.ShutDown()
-	log.Infof("starting gateway deployment controller")
-	go func() {
-		// Process updates until we return false, which indicates the queue is terminated
-		for d.processNextItem() {
-		}
-	}()
-	<-stop
-}
-
-func (d *DeploymentController) processNextItem() bool {
-	// Wait until there is a new item in the working queue
-	key, quit := d.queue.Get()
-	if quit {
-		return false
-	}
-
-	log.Debugf("handling update for %v", key)
-
-	defer d.queue.Done(key)
-
-	err := d.Reconcile(key.(types.NamespacedName))
-	if err != nil {
-		if d.queue.NumRequeues(key) < 5 {
-			log.Errorf("error handling %v, retrying: %v", key, err)
-			d.queue.AddRateLimited(key)
-		} else {
-			log.Errorf("error handling %v, and retry budget exceeded: %v", key, err)
-		}
-	}
-	return true
+	d.queue.Run(stop)
 }
 
 // Reconcile takes in the name of a Gateway and ensures the cluster is in the desired state

--- a/pilot/pkg/config/kube/ingress/controller.go
+++ b/pilot/pkg/config/kube/ingress/controller.go
@@ -177,7 +177,7 @@ func NewController(client kube.Client, meshWatcher mesh.Holder,
 		serviceLister:   serviceInformer.Lister(),
 	}
 
-	handler := controllers.LatestVersionHandlerFuncs(controllers.EnqueueForSelf(q))
+	handler := controllers.ObjectHandler(controllers.EnqueueForSelf(q))
 	c.ingressInformer.AddEventHandler(handler)
 
 	return c

--- a/pilot/pkg/config/kube/ingress/controller.go
+++ b/pilot/pkg/config/kube/ingress/controller.go
@@ -21,20 +21,16 @@ import (
 	"fmt"
 	"sort"
 	"sync"
-	"time"
 
 	"github.com/hashicorp/go-multierror"
 	ingress "k8s.io/api/networking/v1beta1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/version"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers/networking/v1beta1"
 	listerv1 "k8s.io/client-go/listers/core/v1"
 	networkinglister "k8s.io/client-go/listers/networking/v1beta1"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/util/workqueue"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/pkg/model"
@@ -85,13 +81,13 @@ type controller struct {
 	meshWatcher  mesh.Holder
 	domainSuffix string
 
-	queue                  workqueue.RateLimitingInterface
+	queue                  controllers.Queue
 	virtualServiceHandlers []model.EventHandler
 	gatewayHandlers        []model.EventHandler
 
 	mutex sync.RWMutex
 	// processed ingresses
-	ingresses map[string]*ingress.Ingress
+	ingresses map[types.NamespacedName]*ingress.Ingress
 
 	ingressInformer cache.SharedInformer
 	ingressLister   networkinglister.IngressLister
@@ -147,7 +143,6 @@ func NetworkingIngressAvailable(client kube.Client) bool {
 // NewController creates a new Kubernetes controller
 func NewController(client kube.Client, meshWatcher mesh.Holder,
 	options kubecontroller.Options) model.ConfigStoreCache {
-	q := workqueue.NewRateLimitingQueue(workqueue.DefaultItemBasedRateLimiter())
 
 	if ingressNamespace == "" {
 		ingressNamespace = constants.IstioIngressNamespace
@@ -168,8 +163,7 @@ func NewController(client kube.Client, meshWatcher mesh.Holder,
 	c := &controller{
 		meshWatcher:     meshWatcher,
 		domainSuffix:    options.DomainSuffix,
-		queue:           q,
-		ingresses:       make(map[string]*ingress.Ingress),
+		ingresses:       make(map[types.NamespacedName]*ingress.Ingress),
 		ingressInformer: ingressInformer.Informer(),
 		ingressLister:   ingressInformer.Lister(),
 		classes:         classes,
@@ -177,43 +171,16 @@ func NewController(client kube.Client, meshWatcher mesh.Holder,
 		serviceLister:   serviceInformer.Lister(),
 	}
 
-	handler := controllers.ObjectHandler(controllers.EnqueueForSelf(q))
-	c.ingressInformer.AddEventHandler(handler)
+	c.queue = controllers.NewQueue("ingress",
+		controllers.WithReconciler(c.onEvent),
+		controllers.WithMaxAttempts(5))
+	c.ingressInformer.AddEventHandler(controllers.ObjectHandler(c.queue.AddObject))
 
 	return c
 }
 
 func (c *controller) Run(stop <-chan struct{}) {
-	defer utilruntime.HandleCrash()
-	defer c.queue.ShutDown()
-
-	if !cache.WaitForCacheSync(stop, c.HasSynced) {
-		log.Error("Failed to sync controller cache")
-		return
-	}
-	go wait.Until(c.worker, time.Second, stop)
-	<-stop
-}
-
-func (c *controller) worker() {
-	for c.processNextWorkItem() {
-	}
-}
-
-func (c *controller) processNextWorkItem() bool {
-	key, quit := c.queue.Get()
-	if quit {
-		return false
-	}
-	defer c.queue.Done(key)
-	ingressNamespacedName := key.(types.NamespacedName)
-	if err := c.onEvent(ingressNamespacedName.Namespace, ingressNamespacedName.Name); err != nil {
-		log.Errorf("error processing ingress item (%v) (retrying): %v", key, err)
-		c.queue.AddRateLimited(key)
-	} else {
-		c.queue.Forget(key)
-	}
-	return true
+	c.queue.Run(stop)
 }
 
 func (c *controller) shouldProcessIngress(mesh *meshconfig.MeshConfig, i *ingress.Ingress) (bool, error) {
@@ -234,36 +201,37 @@ func (c *controller) shouldProcessIngressUpdate(ing *ingress.Ingress) (bool, err
 	if err != nil {
 		return false, err
 	}
+	item := types.NamespacedName{Name: ing.Name, Namespace: ing.Namespace}
 	if shouldProcess {
 		// record processed ingress
 		c.mutex.Lock()
-		c.ingresses[ing.Namespace+"/"+ing.Name] = ing
+		c.ingresses[item] = ing
 		c.mutex.Unlock()
 		return true, nil
 	}
 
 	c.mutex.Lock()
-	_, preProcessed := c.ingresses[ing.Namespace+"/"+ing.Name]
+	_, preProcessed := c.ingresses[item]
 	// previous processed but should not currently, delete it
 	if preProcessed && !shouldProcess {
-		delete(c.ingresses, ing.Namespace+"/"+ing.Name)
+		delete(c.ingresses, item)
 	} else {
-		c.ingresses[ing.Namespace+"/"+ing.Name] = ing
+		c.ingresses[item] = ing
 	}
 	c.mutex.Unlock()
 
 	return preProcessed, nil
 }
 
-func (c *controller) onEvent(namespace, name string) error {
+func (c *controller) onEvent(item types.NamespacedName) error {
 	event := model.EventUpdate
-	ing, err := c.ingressLister.Ingresses(namespace).Get(name)
+	ing, err := c.ingressLister.Ingresses(item.Namespace).Get(item.Name)
 	if err != nil {
 		if kerrors.IsNotFound(err) {
 			event = model.EventDelete
 			c.mutex.Lock()
-			ing = c.ingresses[namespace+"/"+name]
-			delete(c.ingresses, namespace+"/"+name)
+			ing = c.ingresses[item]
+			delete(c.ingresses, item)
 			c.mutex.Unlock()
 		} else {
 			return err
@@ -287,15 +255,15 @@ func (c *controller) onEvent(namespace, name string) error {
 	}
 
 	vsmetadata := config.Meta{
-		Name:             ing.Name + "-" + "virtualservice",
-		Namespace:        ing.Namespace,
+		Name:             item.Name + "-" + "virtualservice",
+		Namespace:        item.Namespace,
 		GroupVersionKind: gvk.VirtualService,
 		// Set this label so that we do not compare configs and just push.
 		Labels: map[string]string{constants.AlwaysPushLabel: "true"},
 	}
 	gatewaymetadata := config.Meta{
-		Name:             ing.Name + "-" + "gateway",
-		Namespace:        ing.Namespace,
+		Name:             item.Name + "-" + "gateway",
+		Namespace:        item.Namespace,
 		GroupVersionKind: gvk.Gateway,
 		// Set this label so that we do not compare configs and just push.
 		Labels: map[string]string{constants.AlwaysPushLabel: "true"},
@@ -335,7 +303,7 @@ func (c *controller) SetWatchErrorHandler(handler func(r *cache.Reflector, err e
 
 func (c *controller) HasSynced() bool {
 	return c.ingressInformer.HasSynced() && c.serviceInformer.HasSynced() &&
-		(c.classes == nil || c.classes.Informer().HasSynced())
+		(c.classes == nil || c.classes.Informer().HasSynced()) && c.queue.HasSynced()
 }
 
 func (c *controller) Schemas() collection.Schemas {

--- a/pilot/pkg/config/kube/ingress/controller.go
+++ b/pilot/pkg/config/kube/ingress/controller.go
@@ -143,7 +143,6 @@ func NetworkingIngressAvailable(client kube.Client) bool {
 // NewController creates a new Kubernetes controller
 func NewController(client kube.Client, meshWatcher mesh.Holder,
 	options kubecontroller.Options) model.ConfigStoreCache {
-
 	if ingressNamespace == "" {
 		ingressNamespace = constants.IstioIngressNamespace
 	}

--- a/pilot/pkg/config/kube/ingress/controller.go
+++ b/pilot/pkg/config/kube/ingress/controller.go
@@ -301,8 +301,9 @@ func (c *controller) SetWatchErrorHandler(handler func(r *cache.Reflector, err e
 }
 
 func (c *controller) HasSynced() bool {
+	// TODO: add c.queue.HasSynced() once #36332 is ready, ensuring Run is called before HasSynced
 	return c.ingressInformer.HasSynced() && c.serviceInformer.HasSynced() &&
-		(c.classes == nil || c.classes.Informer().HasSynced()) && c.queue.HasSynced()
+		(c.classes == nil || c.classes.Informer().HasSynced())
 }
 
 func (c *controller) Schemas() collection.Schemas {

--- a/pilot/pkg/config/kube/ingressv1/controller.go
+++ b/pilot/pkg/config/kube/ingressv1/controller.go
@@ -132,7 +132,7 @@ func NewController(client kube.Client, meshWatcher mesh.Holder,
 		serviceLister:   serviceInformer.Lister(),
 	}
 
-	handler := controllers.LatestVersionHandlerFuncs(controllers.EnqueueForSelf(q))
+	handler := controllers.ObjectHandler(controllers.EnqueueForSelf(q))
 	c.ingressInformer.AddEventHandler(handler)
 	return c
 }

--- a/pilot/pkg/config/kube/ingressv1/controller.go
+++ b/pilot/pkg/config/kube/ingressv1/controller.go
@@ -254,8 +254,9 @@ func (c *controller) SetWatchErrorHandler(handler func(r *cache.Reflector, err e
 }
 
 func (c *controller) HasSynced() bool {
+	// TODO: add c.queue.HasSynced() once #36332 is ready, ensuring Run is called before HasSynced
 	return c.ingressInformer.HasSynced() && c.serviceInformer.HasSynced() &&
-		(c.classes == nil || c.classes.Informer().HasSynced()) && c.queue.HasSynced()
+		(c.classes == nil || c.classes.Informer().HasSynced())
 }
 
 func (c *controller) Schemas() collection.Schemas {

--- a/pilot/pkg/config/kube/ingressv1/controller.go
+++ b/pilot/pkg/config/kube/ingressv1/controller.go
@@ -103,7 +103,6 @@ var errUnsupportedOp = errors.New("unsupported operation: the ingress config sto
 // NewController creates a new Kubernetes controller
 func NewController(client kube.Client, meshWatcher mesh.Holder,
 	options kubecontroller.Options) model.ConfigStoreCache {
-
 	if ingressNamespace == "" {
 		ingressNamespace = constants.IstioIngressNamespace
 	}

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -239,7 +239,7 @@ func (m *Multicluster) ClusterAdded(cluster *multicluster.Cluster, clusterStopCh
 			if err != nil {
 				log.Errorf("could not initialize webhook cert patcher: %v", err)
 			} else {
-				patcher.Run(clusterStopCh)
+				go patcher.Run(clusterStopCh)
 			}
 		}
 		// Patch validation webhook cert

--- a/pkg/kube/configmapwatcher/configmapwatcher_test.go
+++ b/pkg/kube/configmapwatcher/configmapwatcher_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"istio.io/istio/pkg/kube"
+	"istio.io/pkg/log"
 )
 
 const (
@@ -103,7 +104,7 @@ func Test_ConfigMapWatcher(t *testing.T) {
 	cache.WaitForCacheSync(stop, c.HasSynced)
 
 	cms := client.Kube().CoreV1().ConfigMaps(configMapNamespace)
-
+	log.FindScope("controllers").SetOutputLevel(log.DebugLevel)
 	for i, step := range steps {
 		resetCalled()
 

--- a/pkg/kube/controllers/common.go
+++ b/pkg/kube/controllers/common.go
@@ -86,7 +86,7 @@ func ObjectToGVR(u Object) (schema.GroupVersionResource, error) {
 }
 
 // EnqueueForParentHandler returns a handler that will enqueue the parent (by ownerRef) resource
-func EnqueueForParentHandler(q Enqueuer, kind config.GroupVersionKind) func(obj Object) {
+func EnqueueForParentHandler(q Queue, kind config.GroupVersionKind) func(obj Object) {
 	handler := func(obj Object) {
 		for _, ref := range obj.GetOwnerReferences() {
 			refGV, err := schema.ParseGroupVersion(ref.APIVersion)

--- a/pkg/kube/controllers/common.go
+++ b/pkg/kube/controllers/common.go
@@ -17,142 +17,19 @@ package controllers
 import (
 	"fmt"
 
-	"go.uber.org/atomic"
+	"istio.io/istio/pkg/config"
+	"istio.io/istio/pkg/config/schema/collections"
+	istiolog "istio.io/pkg/log"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/util/workqueue"
-
-	"istio.io/istio/pkg/config"
-	"istio.io/istio/pkg/config/schema/collections"
-	istiolog "istio.io/pkg/log"
 )
 
 var log = istiolog.RegisterScope("controllers", "common controller logic", 0)
-
-type Enqueuer interface {
-	Add(item interface{})
-}
-
-type Queue struct {
-	queue       workqueue.RateLimitingInterface
-	initialSync *atomic.Bool
-	name        string
-	maxAttempts int
-	work        func(key interface{}) error
-}
-
-func WithName(name string) func(q *Queue) {
-	return func(q *Queue) {
-		q.name = name
-	}
-}
-
-func WithRateLimiter(r workqueue.RateLimiter) func(q *Queue) {
-	return func(q *Queue) {
-		q.queue = workqueue.NewRateLimitingQueue(r)
-	}
-}
-
-func WithMaxAttempts(n int) func(q *Queue) {
-	return func(q *Queue) {
-		q.maxAttempts = n
-	}
-}
-
-func WithReconciler(f func(name types.NamespacedName) error) func(q *Queue) {
-	return func(q *Queue) {
-		q.work = func(key interface{}) error {
-			return f(key.(types.NamespacedName))
-		}
-	}
-}
-
-func WithWork(f func(key interface{}) error) func(q *Queue) {
-	return func(q *Queue) {
-		q.work = f
-	}
-}
-
-type syncSignal struct{}
-
-var defaultSyncSignal = syncSignal{}
-
-func NewQueue(options ...func(*Queue)) Queue {
-	q := Queue{
-		initialSync: atomic.NewBool(false),
-	}
-	for _, o := range options {
-		o(&q)
-	}
-	if q.name == "" {
-		q.name = "queue"
-	}
-	if q.queue == nil {
-		q.queue = workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
-	}
-	if q.maxAttempts == 0 {
-		q.maxAttempts = 5
-	}
-	return q
-}
-
-func (q Queue) Add(item interface{}) {
-	q.queue.Add(item)
-}
-
-func (q Queue) Run(stop <-chan struct{}) {
-	defer utilruntime.HandleCrash()
-	defer q.queue.ShutDown()
-	log.Infof("starting %v", q.name)
-	q.Add(defaultSyncSignal)
-	go func() {
-		// Process updates until we return false, which indicates the queue is terminated
-		for q.processNextItem() {
-		}
-	}()
-	<-stop
-	log.Infof("stopped %v", q.name)
-}
-
-func (q Queue) HasSynced() bool {
-	return q.initialSync.Load()
-}
-
-func (q Queue) processNextItem() bool {
-	// Wait until there is a new item in the working queue
-	key, quit := q.queue.Get()
-	if quit {
-		return false
-	}
-	if key == defaultSyncSignal {
-		log.Debugf("%v synced", q.name)
-		q.initialSync.Store(true)
-		return true
-	}
-
-	log.Debugf("handling update for %v: %v", q.name, key)
-
-	defer q.queue.Done(key)
-
-	err := q.work(key)
-	if err != nil {
-		if q.queue.NumRequeues(key) < q.maxAttempts {
-			log.Errorf("%v: error handling %v, retrying: %v", q.name, key, err)
-			q.queue.AddRateLimited(key)
-			return true
-		} else {
-			log.Errorf("error handling %v, and retry budget exceeded: %v", key, err)
-		}
-	}
-	q.queue.Forget(key)
-	return true
-}
 
 // Object is a union of runtime + meta objects. Essentially every k8s object meets this interface.
 // and certainly all that we care about.

--- a/pkg/kube/controllers/common.go
+++ b/pkg/kube/controllers/common.go
@@ -17,9 +17,6 @@ package controllers
 import (
 	"fmt"
 
-	"istio.io/istio/pkg/config"
-	"istio.io/istio/pkg/config/schema/collections"
-	istiolog "istio.io/pkg/log"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -27,6 +24,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
+
+	"istio.io/istio/pkg/config"
+	"istio.io/istio/pkg/config/schema/collections"
+	istiolog "istio.io/pkg/log"
 )
 
 var log = istiolog.RegisterScope("controllers", "common controller logic", 0)
@@ -115,10 +116,10 @@ func EnqueueForSelf(q Enqueuer) func(obj Object) {
 	}
 }
 
-// LatestVersionHandlerFuncs returns a handler that will act on the latest version of an object
+// ObjectHandler returns a handler that will act on the latest version of an object
 // This means Add/Update/Delete are all handled the same and are just used to trigger reconciling.
 // If filters are set, returning 'false' will exclude the event
-func LatestVersionHandlerFuncs(handler func(o Object), filters ...func(o Object) bool) cache.ResourceEventHandler {
+func ObjectHandler(handler func(o Object), filters ...func(o Object) bool) cache.ResourceEventHandler {
 	h := fromObjectHandler(handler, filters...)
 	return cache.ResourceEventHandlerFuncs{
 		AddFunc: h,

--- a/pkg/kube/controllers/queue.go
+++ b/pkg/kube/controllers/queue.go
@@ -126,6 +126,7 @@ func (q Queue) Run(stop <-chan struct{}) {
 // when we have processed all items added to the queue prior to Run().
 type syncSignal struct{}
 
+// defaultSyncSignal is a singleton instanceof syncSignal.
 var defaultSyncSignal = syncSignal{}
 
 // HasSynced returns true if the queue has 'synced'. A synced queue has started running and has

--- a/pkg/kube/controllers/queue.go
+++ b/pkg/kube/controllers/queue.go
@@ -22,10 +22,6 @@ import (
 	istiolog "istio.io/pkg/log"
 )
 
-type Enqueuer interface {
-	Add(item interface{})
-}
-
 // Queue defines an abstraction around Kubernetes' workqueue.
 // Items enqueued are deduplicated; this generally means relying on ordering of events in the queue is not feasible.
 type Queue struct {

--- a/pkg/kube/controllers/queue.go
+++ b/pkg/kube/controllers/queue.go
@@ -125,3 +125,10 @@ func (q Queue) processNextItem() bool {
 	q.queue.Forget(key)
 	return true
 }
+
+func (q Queue) AddObject(obj Object) {
+	q.Add(types.NamespacedName{
+		Namespace: obj.GetNamespace(),
+		Name:      obj.GetName(),
+	})
+}

--- a/pkg/kube/controllers/queue.go
+++ b/pkg/kube/controllers/queue.go
@@ -1,0 +1,127 @@
+package controllers
+
+import (
+	"go.uber.org/atomic"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/util/workqueue"
+)
+
+type Enqueuer interface {
+	Add(item interface{})
+}
+
+type Queue struct {
+	queue       workqueue.RateLimitingInterface
+	initialSync *atomic.Bool
+	name        string
+	maxAttempts int
+	work        func(key interface{}) error
+}
+
+func WithName(name string) func(q *Queue) {
+	return func(q *Queue) {
+		q.name = name
+	}
+}
+
+func WithRateLimiter(r workqueue.RateLimiter) func(q *Queue) {
+	return func(q *Queue) {
+		q.queue = workqueue.NewRateLimitingQueue(r)
+	}
+}
+
+func WithMaxAttempts(n int) func(q *Queue) {
+	return func(q *Queue) {
+		q.maxAttempts = n
+	}
+}
+
+func WithReconciler(f func(name types.NamespacedName) error) func(q *Queue) {
+	return func(q *Queue) {
+		q.work = func(key interface{}) error {
+			return f(key.(types.NamespacedName))
+		}
+	}
+}
+
+func WithWork(f func(key interface{}) error) func(q *Queue) {
+	return func(q *Queue) {
+		q.work = f
+	}
+}
+
+type syncSignal struct{}
+
+var defaultSyncSignal = syncSignal{}
+
+func NewQueue(options ...func(*Queue)) Queue {
+	q := Queue{
+		initialSync: atomic.NewBool(false),
+	}
+	for _, o := range options {
+		o(&q)
+	}
+	if q.name == "" {
+		q.name = "queue"
+	}
+	if q.queue == nil {
+		q.queue = workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+	}
+	if q.maxAttempts == 0 {
+		q.maxAttempts = 5
+	}
+	return q
+}
+
+func (q Queue) Add(item interface{}) {
+	q.queue.Add(item)
+}
+
+func (q Queue) Run(stop <-chan struct{}) {
+	defer utilruntime.HandleCrash()
+	defer q.queue.ShutDown()
+	log.Infof("starting %v", q.name)
+	q.Add(defaultSyncSignal)
+	go func() {
+		// Process updates until we return false, which indicates the queue is terminated
+		for q.processNextItem() {
+		}
+	}()
+	<-stop
+	log.Infof("stopped %v", q.name)
+}
+
+func (q Queue) HasSynced() bool {
+	return q.initialSync.Load()
+}
+
+func (q Queue) processNextItem() bool {
+	// Wait until there is a new item in the working queue
+	key, quit := q.queue.Get()
+	if quit {
+		return false
+	}
+	if key == defaultSyncSignal {
+		log.Debugf("%v synced", q.name)
+		q.initialSync.Store(true)
+		return true
+	}
+
+	log.Debugf("handling update for %v: %v", q.name, key)
+
+	defer q.queue.Done(key)
+
+	err := q.work(key)
+	if err != nil {
+		if q.queue.NumRequeues(key) < q.maxAttempts {
+			log.Errorf("%v: error handling %v, retrying: %v", q.name, key, err)
+			q.queue.AddRateLimited(key)
+			return true
+		} else {
+			log.Errorf("error handling %v, and retry budget exceeded: %v", key, err)
+		}
+	}
+	q.queue.Forget(key)
+	return true
+}

--- a/pkg/kube/controllers/queue.go
+++ b/pkg/kube/controllers/queue.go
@@ -159,9 +159,8 @@ func (q Queue) processNextItem() bool {
 			q.queue.AddRateLimited(key)
 			// Return early, so we do not call Forget(), allowing the rate limiting to backoff
 			return true
-		} else {
-			log.Errorf("error handling %v, and retry budget exceeded: %v", key, err)
 		}
+		log.Errorf("error handling %v, and retry budget exceeded: %v", key, err)
 	}
 	// 'Forget indicates that an item is finished being retried.' - should be called whenever we do not want to backoff on this key.
 	q.queue.Forget(key)

--- a/pkg/kube/controllers/queue.go
+++ b/pkg/kube/controllers/queue.go
@@ -11,6 +11,8 @@ type Enqueuer interface {
 	Add(item interface{})
 }
 
+// Queue defines an abstraction around Kubernetes' workqueue.
+// Items enqueued are deduplicated; this generally means relying on ordering of events in the queue is not feasible.
 type Queue struct {
 	queue       workqueue.RateLimitingInterface
 	initialSync *atomic.Bool
@@ -19,24 +21,28 @@ type Queue struct {
 	work        func(key interface{}) error
 }
 
+// WithName sets a name for the queue. This is used for logging
 func WithName(name string) func(q *Queue) {
 	return func(q *Queue) {
 		q.name = name
 	}
 }
 
+// WithRateLimiter allows defining a custom rate limitter for the queue
 func WithRateLimiter(r workqueue.RateLimiter) func(q *Queue) {
 	return func(q *Queue) {
 		q.queue = workqueue.NewRateLimitingQueue(r)
 	}
 }
 
+// WithMaxAttempts allows defining a custom max attempts for the queue. If not set, items will be discarded after 5 attempts
 func WithMaxAttempts(n int) func(q *Queue) {
 	return func(q *Queue) {
 		q.maxAttempts = n
 	}
 }
 
+// WithReconciler defines the to handle items on the queue
 func WithReconciler(f func(name types.NamespacedName) error) func(q *Queue) {
 	return func(q *Queue) {
 		q.work = func(key interface{}) error {
@@ -45,16 +51,7 @@ func WithReconciler(f func(name types.NamespacedName) error) func(q *Queue) {
 	}
 }
 
-func WithWork(f func(key interface{}) error) func(q *Queue) {
-	return func(q *Queue) {
-		q.work = f
-	}
-}
-
-type syncSignal struct{}
-
-var defaultSyncSignal = syncSignal{}
-
+// NewQueue creates a new queue
 func NewQueue(options ...func(*Queue)) Queue {
 	q := Queue{
 		initialSync: atomic.NewBool(false),
@@ -74,34 +71,62 @@ func NewQueue(options ...func(*Queue)) Queue {
 	return q
 }
 
+// Add an item to the queue.
 func (q Queue) Add(item interface{}) {
 	q.queue.Add(item)
 }
 
+// AddObject takes an Object and adds the types.NamespacedName associated.
+func (q Queue) AddObject(obj Object) {
+	q.Add(types.NamespacedName{
+		Namespace: obj.GetNamespace(),
+		Name:      obj.GetName(),
+	})
+}
+
+// Run the queue. This is synchronous, so should typically be called in a goroutine.
 func (q Queue) Run(stop <-chan struct{}) {
 	defer utilruntime.HandleCrash()
 	defer q.queue.ShutDown()
 	log.Infof("starting %v", q.name)
 	q.Add(defaultSyncSignal)
+	done := make(chan struct{})
 	go func() {
 		// Process updates until we return false, which indicates the queue is terminated
 		for q.processNextItem() {
 		}
+		close(done)
 	}()
-	<-stop
+	select {
+	case <-stop:
+	case <-done:
+	}
 	log.Infof("stopped %v", q.name)
 }
 
+// syncSignal defines a dummy signal that is enqueued when .Run() is called. This allows us to detect
+// when we have processed all items added to the queue prior to Run().
+type syncSignal struct{}
+
+var defaultSyncSignal = syncSignal{}
+
+// HasSynced returns true if the queue has 'synced'. A synced queue has started running and has
+// processed all events that were added prior to Run() being called Warning: these items will be
+// processed at least once, but may have failed.
 func (q Queue) HasSynced() bool {
 	return q.initialSync.Load()
 }
 
+// processNextItem is the main work loop for the queue
 func (q Queue) processNextItem() bool {
 	// Wait until there is a new item in the working queue
 	key, quit := q.queue.Get()
 	if quit {
+		// We are done, signal to exit the queue
 		return false
 	}
+
+	// We got the sync signal. This is not a real event, so we exit early after signaling we are synced
 	if key == defaultSyncSignal {
 		log.Debugf("%v synced", q.name)
 		q.initialSync.Store(true)
@@ -110,6 +135,7 @@ func (q Queue) processNextItem() bool {
 
 	log.Debugf("handling update for %v: %v", q.name, key)
 
+	// 'Done marks item as done processing' - should be called at the end of all processing
 	defer q.queue.Done(key)
 
 	err := q.work(key)
@@ -117,18 +143,13 @@ func (q Queue) processNextItem() bool {
 		if q.queue.NumRequeues(key) < q.maxAttempts {
 			log.Errorf("%v: error handling %v, retrying: %v", q.name, key, err)
 			q.queue.AddRateLimited(key)
+			// Return early, so we do not call Forget(), allowing the rate limiting to backoff
 			return true
 		} else {
 			log.Errorf("error handling %v, and retry budget exceeded: %v", key, err)
 		}
 	}
+	// 'Forget indicates that an item is finished being retried.' - should be called whenever we do not want to backoff on this key.
 	q.queue.Forget(key)
 	return true
-}
-
-func (q Queue) AddObject(obj Object) {
-	q.Add(types.NamespacedName{
-		Namespace: obj.GetNamespace(),
-		Name:      obj.GetName(),
-	})
 }

--- a/pkg/kube/controllers/queue.go
+++ b/pkg/kube/controllers/queue.go
@@ -1,3 +1,17 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package controllers
 
 import (

--- a/pkg/kube/controllers/queue_test.go
+++ b/pkg/kube/controllers/queue_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestQueue(t *testing.T) {
 	handles := atomic.NewInt32(0)
-	q := NewQueue(WithName("custom"), WithReconciler(func(name types.NamespacedName) error {
+	q := NewQueue("custom", WithReconciler(func(name types.NamespacedName) error {
 		handles.Inc()
 		return nil
 	}))

--- a/pkg/kube/controllers/queue_test.go
+++ b/pkg/kube/controllers/queue_test.go
@@ -1,0 +1,28 @@
+package controllers
+
+import (
+	"testing"
+
+	"go.uber.org/atomic"
+	"k8s.io/apimachinery/pkg/types"
+
+	"istio.io/istio/pkg/test/util/retry"
+)
+
+func TestQueue(t *testing.T) {
+	handles := atomic.NewInt32(0)
+	q := NewQueue(WithName("custom"), WithReconciler(func(name types.NamespacedName) error {
+		handles.Inc()
+		return nil
+	}))
+	stop := make(chan struct{})
+	t.Cleanup(func() {
+		close(stop)
+	})
+	q.Add(types.NamespacedName{Name: "something"})
+	go q.Run(stop)
+	retry.UntilOrFail(t, q.HasSynced)
+	if got := handles.Load(); got != 1 {
+		t.Fatalf("expected 1 handle, got %v", got)
+	}
+}

--- a/pkg/kube/controllers/queue_test.go
+++ b/pkg/kube/controllers/queue_test.go
@@ -1,3 +1,17 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package controllers
 
 import (

--- a/pkg/kube/multicluster/secretcontroller.go
+++ b/pkg/kube/multicluster/secretcontroller.go
@@ -247,7 +247,7 @@ func NewController(kubeclientset kube.Client, namespace string, localClusterID c
 		informer:           secretsInformer,
 		syncInterval:       100 * time.Millisecond,
 	}
-	controller.queue = controllers.NewQueue(controllers.WithReconciler(controller.processItem))
+	controller.queue = controllers.NewQueue("multicluster secret", controllers.WithReconciler(controller.processItem))
 
 	secretsInformer.AddEventHandler(controllers.ObjectHandler(controller.queue.AddObject))
 	return controller

--- a/pkg/kube/multicluster/secretcontroller.go
+++ b/pkg/kube/multicluster/secretcontroller.go
@@ -249,7 +249,7 @@ func NewController(kubeclientset kube.Client, namespace string, localClusterID c
 	}
 	controller.queue = controllers.NewQueue(controllers.WithReconciler(controller.processItem))
 
-	secretsInformer.AddEventHandler(controllers.LatestVersionHandlerFuncs(controllers.EnqueueForSelf(controller.queue)))
+	secretsInformer.AddEventHandler(controllers.ObjectHandler(controller.queue.AddObject))
 	return controller
 }
 

--- a/pkg/revisions/default_watcher.go
+++ b/pkg/revisions/default_watcher.go
@@ -59,9 +59,10 @@ func NewDefaultWatcher(client kube.Client, revision string) DefaultWatcher {
 		revision: revision,
 		mu:       sync.RWMutex{},
 	}
+	log.Errorf("howardjohn: default watch 1")
 	p.queue = controllers.NewQueue(controllers.WithName("default revision"), controllers.WithReconciler(p.setDefault))
 	p.webhookInformer = client.KubeInformer().Admissionregistration().V1().MutatingWebhookConfigurations().Informer()
-	p.webhookInformer.AddEventHandler(controllers.ObjectHandler(p.queue.AddObject, filterUpdate))
+	p.webhookInformer.AddEventHandler(controllers.ObjectHandler(p.queue.AddObject, isDefaultTagWebhook))
 
 	return p
 }
@@ -113,6 +114,6 @@ func (p *defaultWatcher) setDefault(key types.NamespacedName) error {
 	return nil
 }
 
-func filterUpdate(obj controllers.Object) bool {
+func isDefaultTagWebhook(obj controllers.Object) bool {
 	return obj.GetName() == defaultTagWebhookName
 }

--- a/pkg/revisions/default_watcher.go
+++ b/pkg/revisions/default_watcher.go
@@ -59,7 +59,6 @@ func NewDefaultWatcher(client kube.Client, revision string) DefaultWatcher {
 		revision: revision,
 		mu:       sync.RWMutex{},
 	}
-	log.Errorf("howardjohn: default watch 1")
 	p.queue = controllers.NewQueue(controllers.WithName("default revision"), controllers.WithReconciler(p.setDefault))
 	p.webhookInformer = client.KubeInformer().Admissionregistration().V1().MutatingWebhookConfigurations().Informer()
 	p.webhookInformer.AddEventHandler(controllers.ObjectHandler(p.queue.AddObject, isDefaultTagWebhook))

--- a/pkg/revisions/default_watcher.go
+++ b/pkg/revisions/default_watcher.go
@@ -61,7 +61,7 @@ func NewDefaultWatcher(client kube.Client, revision string) DefaultWatcher {
 	}
 	p.queue = controllers.NewQueue("default revision", controllers.WithReconciler(p.setDefault))
 	p.webhookInformer = client.KubeInformer().Admissionregistration().V1().MutatingWebhookConfigurations().Informer()
-	p.webhookInformer.AddEventHandler(controllers.ObjectHandler(p.queue.AddObject, isDefaultTagWebhook))
+	p.webhookInformer.AddEventHandler(controllers.FilteredObjectHandler(p.queue.AddObject, isDefaultTagWebhook))
 
 	return p
 }

--- a/pkg/revisions/default_watcher.go
+++ b/pkg/revisions/default_watcher.go
@@ -59,7 +59,7 @@ func NewDefaultWatcher(client kube.Client, revision string) DefaultWatcher {
 		revision: revision,
 		mu:       sync.RWMutex{},
 	}
-	p.queue = controllers.NewQueue(controllers.WithName("default revision"), controllers.WithReconciler(p.setDefault))
+	p.queue = controllers.NewQueue("default revision", controllers.WithReconciler(p.setDefault))
 	p.webhookInformer = client.KubeInformer().Admissionregistration().V1().MutatingWebhookConfigurations().Informer()
 	p.webhookInformer.AddEventHandler(controllers.ObjectHandler(p.queue.AddObject, isDefaultTagWebhook))
 

--- a/pkg/revisions/default_watcher.go
+++ b/pkg/revisions/default_watcher.go
@@ -61,7 +61,7 @@ func NewDefaultWatcher(client kube.Client, revision string) DefaultWatcher {
 	}
 	p.queue = controllers.NewQueue(controllers.WithName("default revision"), controllers.WithReconciler(p.setDefault))
 	p.webhookInformer = client.KubeInformer().Admissionregistration().V1().MutatingWebhookConfigurations().Informer()
-	p.webhookInformer.AddEventHandler(controllers.LatestVersionHandlerFuncs(controllers.EnqueueForSelf(p.queue), filterUpdate))
+	p.webhookInformer.AddEventHandler(controllers.ObjectHandler(p.queue.AddObject, filterUpdate))
 
 	return p
 }

--- a/pkg/revisions/default_watcher.go
+++ b/pkg/revisions/default_watcher.go
@@ -19,22 +19,21 @@ import (
 	"time"
 
 	"go.uber.org/atomic"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/util/workqueue"
 
 	"istio.io/api/label"
 	"istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/kube/controllers"
 	"istio.io/pkg/log"
 )
 
 const (
 	defaultTagWebhookName = "istio-revision-tag-default"
-	initSignal            = "INIT"
 )
+
+var initSignal = types.NamespacedName{Name: "INIT"}
 
 // DefaultWatcher keeps track of the current default revision and can notify watchers
 // when the default revision changes.
@@ -53,8 +52,8 @@ type defaultWatcher struct {
 	defaultRevision string
 	handlers        []DefaultHandler
 
-	queue           workqueue.RateLimitingInterface
-	webhookInformer cache.SharedInformer
+	queue           controllers.Queue
+	webhookInformer cache.SharedIndexInformer
 	initialSync     *atomic.Bool
 	mu              sync.RWMutex
 }
@@ -62,26 +61,23 @@ type defaultWatcher struct {
 func NewDefaultWatcher(client kube.Client, revision string) DefaultWatcher {
 	p := &defaultWatcher{
 		revision:    revision,
-		queue:       workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
 		initialSync: atomic.NewBool(false),
 		mu:          sync.RWMutex{},
 	}
+	p.queue = controllers.NewQueue(controllers.WithName("default revision"), controllers.WithReconciler(p.setDefault))
 	p.webhookInformer = client.KubeInformer().Admissionregistration().V1().MutatingWebhookConfigurations().Informer()
-	p.webhookInformer.AddEventHandler(p.makeHandler())
+	p.webhookInformer.AddEventHandler(controllers.LatestVersionHandlerFuncs(controllers.EnqueueForSelf(p.queue), filterUpdate))
 
 	return p
 }
 
 func (p *defaultWatcher) Run(stopCh <-chan struct{}) {
-	defer utilruntime.HandleCrash()
-	defer p.queue.ShutDown()
 	if !kube.WaitForCacheSyncInterval(stopCh, time.Second, p.webhookInformer.HasSynced) {
 		log.Errorf("failed to sync default watcher")
 		return
 	}
 	p.queue.Add(initSignal)
-	go wait.Until(p.runQueue, time.Second, stopCh)
-	<-stopCh
+	p.queue.Run(stopCh)
 }
 
 // GetDefault returns the current default revision.
@@ -102,55 +98,6 @@ func (p *defaultWatcher) HasSynced() bool {
 	return p.initialSync.Load()
 }
 
-func (p *defaultWatcher) runQueue() {
-	for p.processNextItem() {
-	}
-}
-
-func (p *defaultWatcher) processNextItem() bool {
-	item, quit := p.queue.Get()
-	if quit {
-		log.Debug("default watcher shutting down, returning")
-		return false
-	}
-	defer p.queue.Done(item)
-
-	if item.(string) == initSignal {
-		p.initialSync.Store(true)
-	} else {
-		p.setDefault(item.(string))
-	}
-
-	return true
-}
-
-func (p *defaultWatcher) makeHandler() *cache.ResourceEventHandlerFuncs {
-	return &cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
-			meta, _ := meta.Accessor(obj)
-			if filterUpdate(meta) {
-				return
-			}
-			p.queue.Add(getDefault(meta))
-		},
-		UpdateFunc: func(oldObj interface{}, newObj interface{}) {
-			meta, _ := meta.Accessor(newObj)
-			if filterUpdate(meta) {
-				return
-			}
-			p.queue.Add(getDefault(meta))
-		},
-		DeleteFunc: func(obj interface{}) {
-			meta, _ := meta.Accessor(obj)
-			if filterUpdate(meta) {
-				return
-			}
-			// treat "" to mean no default revision is set
-			p.queue.Add("")
-		},
-	}
-}
-
 // notifyHandlers notifies all registered handlers on default revision change.
 // assumes externally locked.
 func (p *defaultWatcher) notifyHandlers() {
@@ -159,20 +106,23 @@ func (p *defaultWatcher) notifyHandlers() {
 	}
 }
 
-func getDefault(meta metav1.Object) string {
-	if revision, ok := meta.GetLabels()[label.IoIstioRev.Name]; ok {
-		return revision
+func (p *defaultWatcher) setDefault(key types.NamespacedName) error {
+	if key == initSignal {
+		p.initialSync.Store(true)
+		return nil
 	}
-	return ""
-}
-
-func (p *defaultWatcher) setDefault(revision string) {
+	revision := ""
+	wh, _, _ := p.webhookInformer.GetIndexer().GetByKey(key.Name)
+	if wh != nil {
+		revision = wh.(metav1.Object).GetLabels()[label.IoIstioRev.Name]
+	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.defaultRevision = revision
 	p.notifyHandlers()
+	return nil
 }
 
-func filterUpdate(obj metav1.Object) bool {
-	return obj.GetName() != defaultTagWebhookName
+func filterUpdate(obj controllers.Object) bool {
+	return obj.GetName() == defaultTagWebhookName
 }

--- a/pkg/revisions/default_watcher_test.go
+++ b/pkg/revisions/default_watcher_test.go
@@ -29,6 +29,7 @@ import (
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/util/retry"
+	"istio.io/pkg/log"
 )
 
 func newDefaultWatcher(client kube.Client, revision string) DefaultWatcher {
@@ -74,7 +75,7 @@ func expectRevision(t test.Failer, watcher DefaultWatcher, expected string) {
 			return fmt.Errorf("wanted default revision %q, got %q", expected, got)
 		}
 		return nil
-	}, retry.Timeout(time.Second*10), retry.Delay(time.Millisecond*350))
+	}, retry.Timeout(time.Second*10), retry.BackoffDelay(time.Millisecond*10))
 }
 
 func expectRevisionChan(t test.Failer, revisionChan chan string, expected string) {
@@ -100,6 +101,7 @@ func TestNoDefaultRevision(t *testing.T) {
 }
 
 func TestDefaultRevisionChanges(t *testing.T) {
+	log.FindScope("controllers").SetOutputLevel(log.DebugLevel)
 	stop := make(chan struct{})
 	client := kube.NewFakeClient()
 	w := newDefaultWatcher(client, "default")

--- a/pkg/webhooks/webhookpatch.go
+++ b/pkg/webhooks/webhookpatch.go
@@ -17,30 +17,31 @@ package webhooks
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
-	"time"
 
 	v1 "k8s.io/api/admissionregistration/v1"
 	kubeErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/types"
 	admissioninformer "k8s.io/client-go/informers/admissionregistration/v1"
 	"k8s.io/client-go/kubernetes"
 	admissionregistrationv1client "k8s.io/client-go/kubernetes/typed/admissionregistration/v1"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/util/workqueue"
 
 	"istio.io/api/label"
 	"istio.io/istio/pilot/pkg/keycertbundle"
 	kubelib "istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/kube/controllers"
 	"istio.io/istio/pkg/webhooks/util"
 	"istio.io/pkg/log"
 )
 
 var (
 	errWrongRevision     = errors.New("webhook does not belong to target revision")
+	errNotFound          = errors.New("webhook not found")
 	errNoWebhookWithName = errors.New("webhook configuration did not contain webhook with target name")
 )
 
@@ -52,7 +53,7 @@ type WebhookCertPatcher struct {
 	revision    string
 	webhookName string
 
-	queue workqueue.RateLimitingInterface
+	queue controllers.Queue
 
 	// File path to the x509 certificate bundle used by the webhook server
 	// and patched into the webhook config.
@@ -70,59 +71,26 @@ func NewWebhookCertPatcher(
 		revision:        revision,
 		webhookName:     webhookName,
 		CABundleWatcher: caBundleWatcher,
-		queue:           workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "mutatingwebhookconfiguration"),
 	}
+	p.queue = controllers.NewQueue(controllers.WithName("webhook patcher"), controllers.WithReconciler(p.webhookPatchTask))
 	informer := admissioninformer.NewFilteredMutatingWebhookConfigurationInformer(client, 0, cache.Indexers{}, func(options *metav1.ListOptions) {
 		options.LabelSelector = fmt.Sprintf("%s=%s", label.IoIstioRev.Name, revision)
 	})
 	p.informer = informer
-	informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		UpdateFunc: func(oldObj, newObj interface{}) {
-			oldConfig := oldObj.(*v1.MutatingWebhookConfiguration)
-			newConfig := newObj.(*v1.MutatingWebhookConfiguration)
-			p.updateWebhookHandler(oldConfig, newConfig)
-		},
-		AddFunc: func(obj interface{}) {
-			config := obj.(*v1.MutatingWebhookConfiguration)
-			p.addWebhookHandler(config)
-		},
-	})
+	informer.AddEventHandler(controllers.ObjectHandler(p.queue.AddObject))
 
 	return p, nil
 }
 
 // Run runs the WebhookCertPatcher
 func (w *WebhookCertPatcher) Run(stopChan <-chan struct{}) {
-	go w.runWebhookController(stopChan)
+	go w.informer.Run(stopChan)
 	go w.startCaBundleWatcher(stopChan)
-	go wait.Until(w.worker, time.Second, stopChan)
+	w.queue.Run(stopChan)
 }
 
-func (w *WebhookCertPatcher) worker() {
-	for w.processNextItem() {
-	}
-}
-
-func (w *WebhookCertPatcher) processNextItem() bool {
-	item, shutdown := w.queue.Get()
-	if shutdown {
-		return false
-	}
-	defer w.queue.Done(item)
-
-	key := item.(string)
-	err := w.webhookPatchTask(key)
-	if err != nil {
-		log.Errorf("patching webhook %s failed: %v", key, err)
-		w.queue.AddRateLimited(item)
-		return true
-	}
-	w.queue.Forget(item)
-	return true
-}
-
-func (w *WebhookCertPatcher) runWebhookController(stopChan <-chan struct{}) {
-	w.informer.Run(stopChan)
+func (w *WebhookCertPatcher) HasSynced() bool {
+	return w.informer.HasSynced() && w.queue.HasSynced()
 }
 
 func (w *WebhookCertPatcher) updateWebhookHandler(oldConfig, newConfig *v1.MutatingWebhookConfiguration) {
@@ -152,20 +120,20 @@ func (w *WebhookCertPatcher) addWebhookHandler(config *v1.MutatingWebhookConfigu
 }
 
 // webhookPatchTask takes the result of patchMutatingWebhookConfig and modifies the result for use in task queue
-func (w *WebhookCertPatcher) webhookPatchTask(webhookConfigName string) error {
-	reportWebhookPatchAttempts(webhookConfigName)
+func (w *WebhookCertPatcher) webhookPatchTask(o types.NamespacedName) error {
+	reportWebhookPatchAttempts(o.Name)
 	err := w.patchMutatingWebhookConfig(
 		w.client.AdmissionregistrationV1().MutatingWebhookConfigurations(),
-		webhookConfigName)
+		o.Name)
 
 	// do not want to retry the task if these errors occur, they indicate that
 	// we should no longer be patching the given webhook
-	if kubeErrors.IsNotFound(err) || errors.Is(err, errWrongRevision) || errors.Is(err, errNoWebhookWithName) {
+	if kubeErrors.IsNotFound(err) || errors.Is(err, errWrongRevision) || errors.Is(err, errNoWebhookWithName) || errors.Is(err, errNotFound) {
 		return nil
 	}
 
 	if err != nil {
-		reportWebhookPatchRetry(webhookConfigName)
+		reportWebhookPatchRetry(o.Name)
 	}
 
 	return err
@@ -175,19 +143,23 @@ func (w *WebhookCertPatcher) webhookPatchTask(webhookConfigName string) error {
 func (w *WebhookCertPatcher) patchMutatingWebhookConfig(
 	client admissionregistrationv1client.MutatingWebhookConfigurationInterface,
 	webhookConfigName string) error {
-	config, err := client.Get(context.TODO(), webhookConfigName, metav1.GetOptions{})
-	if err != nil {
+	raw, _, err := w.informer.GetIndexer().GetByKey(webhookConfigName)
+	if raw == nil || err != nil {
 		reportWebhookPatchFailure(webhookConfigName, reasonWebhookConfigNotFound)
-		return err
+		return errNotFound
 	}
+	config := raw.(*v1.MutatingWebhookConfiguration)
 	// prevents a race condition between multiple istiods when the revision is changed or modified
 	v, ok := config.Labels[label.IoIstioRev.Name]
 	if v != w.revision || !ok {
+		debug, _ := json.MarshalIndent(config, "howardjohn", "  ")
+		log.Errorf("howardjohn: %s", debug)
 		reportWebhookPatchFailure(webhookConfigName, reasonWrongRevision)
 		return errWrongRevision
 	}
 
 	found := false
+	updated := false
 	caCertPem, err := util.LoadCABundle(w.CABundleWatcher)
 	if err != nil {
 		log.Errorf("Failed to load CA bundle: %v", err)
@@ -196,6 +168,9 @@ func (w *WebhookCertPatcher) patchMutatingWebhookConfig(
 	}
 	for i, wh := range config.Webhooks {
 		if strings.HasSuffix(wh.Name, w.webhookName) {
+			if !bytes.Equal(caCertPem, config.Webhooks[i].ClientConfig.CABundle) {
+				updated = true
+			}
 			config.Webhooks[i].ClientConfig.CABundle = caCertPem
 			found = true
 		}
@@ -205,9 +180,11 @@ func (w *WebhookCertPatcher) patchMutatingWebhookConfig(
 		return errNoWebhookWithName
 	}
 
-	_, err = client.Update(context.TODO(), config, metav1.UpdateOptions{})
-	if err != nil {
-		reportWebhookPatchFailure(webhookConfigName, reasonWebhookUpdateFailure)
+	if updated {
+		_, err = client.Update(context.Background(), config, metav1.UpdateOptions{})
+		if err != nil {
+			reportWebhookPatchFailure(webhookConfigName, reasonWebhookUpdateFailure)
+		}
 	}
 
 	return err

--- a/pkg/webhooks/webhookpatch.go
+++ b/pkg/webhooks/webhookpatch.go
@@ -72,7 +72,9 @@ func NewWebhookCertPatcher(
 		webhookName:     webhookName,
 		CABundleWatcher: caBundleWatcher,
 	}
-	p.queue = controllers.NewQueue(controllers.WithName("webhook patcher"), controllers.WithReconciler(p.webhookPatchTask))
+	p.queue = controllers.NewQueue("webhook patcher",
+		controllers.WithReconciler(p.webhookPatchTask),
+		controllers.WithMaxAttempts(5))
 	informer := admissioninformer.NewFilteredMutatingWebhookConfigurationInformer(client, 0, cache.Indexers{}, func(options *metav1.ListOptions) {
 		options.LabelSelector = fmt.Sprintf("%s=%s", label.IoIstioRev.Name, revision)
 	})

--- a/pkg/webhooks/webhookpatch_test.go
+++ b/pkg/webhooks/webhookpatch_test.go
@@ -219,7 +219,8 @@ func TestMutatingWebhookPatch(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			client := kube.NewFakeClient()
 			for _, wh := range tc.configs.Items {
-				if _, err := client.AdmissionregistrationV1().MutatingWebhookConfigurations().Create(context.Background(), wh.DeepCopy(), metav1.CreateOptions{}); err != nil {
+				if _, err := client.AdmissionregistrationV1().
+					MutatingWebhookConfigurations().Create(context.Background(), wh.DeepCopy(), metav1.CreateOptions{}); err != nil {
 					t.Fatal(err)
 				}
 			}

--- a/pkg/webhooks/webhookpatch_test.go
+++ b/pkg/webhooks/webhookpatch_test.go
@@ -22,10 +22,11 @@ import (
 
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes/fake"
 
 	"istio.io/api/label"
 	"istio.io/istio/pilot/pkg/keycertbundle"
+	"istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/test/util/retry"
 )
 
 var caBundle0 = []byte(`-----BEGIN CERTIFICATE-----
@@ -70,7 +71,7 @@ func TestMutatingWebhookPatch(t *testing.T) {
 			"config1",
 			"webhook1",
 			caBundle0,
-			"\"config1\" not found",
+			errNotFound.Error(),
 		},
 		{
 			"WebhookEntryNotFound",
@@ -159,7 +160,7 @@ func TestMutatingWebhookPatch(t *testing.T) {
 			"config1",
 			"webhook1",
 			caBundle0,
-			errWrongRevision.Error(),
+			errNotFound.Error(),
 		},
 		{
 			"WrongRevisionWebhookNotUpdated",
@@ -183,7 +184,7 @@ func TestMutatingWebhookPatch(t *testing.T) {
 			"config1",
 			"webhook1",
 			caBundle0,
-			errWrongRevision.Error(),
+			errNotFound.Error(),
 		},
 		{
 			"MultipleWebhooks",
@@ -216,15 +217,30 @@ func TestMutatingWebhookPatch(t *testing.T) {
 	}
 	for _, tc := range ts {
 		t.Run(tc.name, func(t *testing.T) {
-			client := fake.NewSimpleClientset(tc.configs.DeepCopyObject())
-			whPatcher := WebhookCertPatcher{
-				client:          client,
-				revision:        tc.revision,
-				webhookName:     tc.webhookName,
-				CABundleWatcher: watcher,
+			client := kube.NewFakeClient()
+			for _, wh := range tc.configs.Items {
+				if _, err := client.AdmissionregistrationV1().MutatingWebhookConfigurations().Create(context.Background(), wh.DeepCopy(), metav1.CreateOptions{}); err != nil {
+					t.Fatal(err)
+				}
 			}
 
-			err := whPatcher.patchMutatingWebhookConfig(client.AdmissionregistrationV1().MutatingWebhookConfigurations(),
+			watcher := keycertbundle.NewWatcher()
+			watcher.SetAndNotify(nil, nil, tc.pemData)
+			whPatcher, err := NewWebhookCertPatcher(client, tc.revision, tc.webhookName, watcher)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			stop := make(chan struct{})
+			t.Cleanup(func() {
+				close(stop)
+			})
+			go whPatcher.informer.Run(stop)
+			client.RunAndWait(stop)
+			retry.UntilOrFail(t, whPatcher.informer.HasSynced)
+
+			err = whPatcher.patchMutatingWebhookConfig(
+				client.AdmissionregistrationV1().MutatingWebhookConfigurations(),
 				tc.configName)
 			if (err != nil) != (tc.err != "") {
 				t.Fatalf("Wrong error: got %v want %v", err, tc.err)

--- a/tests/fuzz/kube_controller_fuzzer.go
+++ b/tests/fuzz/kube_controller_fuzzer.go
@@ -21,14 +21,13 @@ package controller
 import (
 	"context"
 
-	"k8s.io/apimachinery/pkg/api/errors"
-
-	"istio.io/istio/pkg/network"
+	fuzz "github.com/AdaLogics/go-fuzz-headers"
 	coreV1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	fuzz "github.com/AdaLogics/go-fuzz-headers"
+	"istio.io/istio/pkg/network"
 )
 
 func InternalFuzzKubeController(data []byte) int {
@@ -78,7 +77,6 @@ func InternalFuzzKubeController(data []byte) int {
 func generatePodFuzz(f *fuzz.ConsumeFuzzer) (*coreV1.Pod, error) {
 	pod := &coreV1.Pod{}
 	return pod, f.GenerateStruct(pod)
-
 }
 
 func generateNodeForFuzzing(f *fuzz.ConsumeFuzzer) (*coreV1.Node, error) {


### PR DESCRIPTION
We have made a lot of new controllers use the Kubernetes queue. Generally this is a good thing, but the API is way too low level. This leads to complex logic throughout much of our code, and its all slightly different with slightly different bugs.

This abstracts this into a new `controllers.Queue` type. In addition, secretcontroller, webhook, gateway deployment, and default revision controllers are moved over to the new queue