### PR TITLE
1.12: multicluster: add allowlist for kubeconfig auth methods

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -568,7 +568,7 @@ var (
 	InsecureKubeConfigOptions = func() sets.Set {
 		v := env.RegisterStringVar(
 			"PILOT_INSECURE_MULTICLUSTER_KUBECONFIG_OPTIONS",
-			"",
+			"gcp,azure,exec,openstack,clientkey,clientCertificate,tokenFile",
 			"Comma separated list of potentially insecure kubeconfig authentication options that are allowed for multicluster authentication."+
 				"Support values: all authProviders (`gcp`, `azure`, `exec`, `openstack`), "+
 				"`clientKey`, `clientCertificate`, `tokenFile`, and `exec`.").Get()

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -15,10 +15,12 @@
 package features
 
 import (
+	"strings"
 	"time"
 
 	"google.golang.org/protobuf/types/known/durationpb"
 
+	"istio.io/istio/pilot/pkg/util/sets"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/jwt"
 	"istio.io/pkg/env"
@@ -562,6 +564,16 @@ var (
 
 	PrioritizedLeaderElection = env.RegisterBoolVar("PRIORITIZED_LEADER_ELECTION", true,
 		"If enabled, the default revision will steal leader locks from non-default revisions").Get()
+
+	InsecureKubeConfigOptions = func() sets.Set {
+		v := env.RegisterStringVar(
+			"PILOT_INSECURE_MULTICLUSTER_KUBECONFIG_OPTIONS",
+			"",
+			"Comma separated list of potentially insecure kubeconfig authentication options that are allowed for multicluster authentication."+
+				"Support values: all authProviders (`gcp`, `azure`, `exec`, `openstack`), "+
+				"`clientKey`, `clientCertificate`, `tokenFile`, and `exec`.").Get()
+		return sets.NewSet(strings.Split(v, ",")...)
+	}()
 )
 
 // UnsafeFeaturesEnabled returns true if any unsafe features are enabled.

--- a/pkg/kube/multicluster/secretcontroller.go
+++ b/pkg/kube/multicluster/secretcontroller.go
@@ -35,9 +35,11 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/client-go/util/workqueue"
 
 	"istio.io/istio/pilot/pkg/features"
+	"istio.io/istio/pilot/pkg/util/sets"
 	"istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/kube"
 	"istio.io/pkg/log"
@@ -434,6 +436,9 @@ var BuildClientsFromConfig = func(kubeConfig []byte) (kube.Client, error) {
 	if err := clientcmd.Validate(*rawConfig); err != nil {
 		return nil, fmt.Errorf("kubeconfig is not valid: %v", err)
 	}
+	if err := sanitizeKubeConfig(*rawConfig, features.InsecureKubeConfigOptions); err != nil {
+		return nil, fmt.Errorf("kubeconfig is not allowed: %v", err)
+	}
 
 	clientConfig := clientcmd.NewDefaultClientConfig(*rawConfig, &clientcmd.ConfigOverrides{})
 
@@ -442,6 +447,66 @@ var BuildClientsFromConfig = func(kubeConfig []byte) (kube.Client, error) {
 		return nil, fmt.Errorf("failed to create kube clients: %v", err)
 	}
 	return clients, nil
+}
+
+// sanitizeKubeConfig sanitizes a kubeconfig file to strip out insecure settings which may leak
+// confidential materials.
+// See https://github.com/kubernetes/kubectl/issues/697
+func sanitizeKubeConfig(config api.Config, allowlist sets.Set) error {
+	for k, auths := range config.AuthInfos {
+		if ap := auths.AuthProvider; ap != nil {
+			// We currently are importing 5 authenticators: gcp, azure, exec, and openstack
+			switch ap.Name {
+			case "oidc":
+				// OIDC is safe as it doesn't read files or execute code.
+				// create-remote-secret specifically supports OIDC so its probably important to not break this.
+			default:
+				if !allowlist.Contains(ap.Name) {
+					// All the others - gcp, azure, exec, and openstack - are unsafe
+					return fmt.Errorf("auth provider %s is not allowed", ap.Name)
+				}
+			}
+		}
+		if auths.ClientKey != "" && !allowlist.Contains("clientKey") {
+			return fmt.Errorf("clientKey is not allowed")
+		}
+		if auths.ClientCertificate != "" && !allowlist.Contains("clientCertificate") {
+			return fmt.Errorf("clientCertificate is not allowed")
+		}
+		if auths.TokenFile != "" && !allowlist.Contains("tokenFile") {
+			return fmt.Errorf("tokenFile is not allowed")
+		}
+		if auths.Exec != nil && !allowlist.Contains("exec") {
+			return fmt.Errorf("exec is not allowed")
+		}
+		// Reconstruct the AuthInfo so if a new field is added we will not include it without review
+		config.AuthInfos[k] = &api.AuthInfo{
+			// LocationOfOrigin: Not needed
+			ClientCertificate:     auths.ClientCertificate,
+			ClientCertificateData: auths.ClientCertificateData,
+			ClientKey:             auths.ClientKey,
+			ClientKeyData:         auths.ClientKeyData,
+			Token:                 auths.Token,
+			TokenFile:             auths.TokenFile,
+			Impersonate:           auths.Impersonate,
+			ImpersonateGroups:     auths.ImpersonateGroups,
+			ImpersonateUserExtra:  auths.ImpersonateUserExtra,
+			Username:              auths.Username,
+			Password:              auths.Password,
+			AuthProvider:          auths.AuthProvider, // Included because it is sanitized above
+			Exec:                  auths.Exec,
+			// Extensions: Not needed,
+		}
+
+		// Other relevant fields that are not acted on:
+		// * Cluster.Server (and ProxyURL). This allows the user to send requests to arbitrary URLs, enabling potential SSRF attacks.
+		//   However, we don't actually know what valid URLs are, so we cannot reasonably constrain this. Instead,
+		//   we try to limit what confidential information could be exfiltrated (from AuthInfo). Additionally, the user cannot control
+		//   the paths we send requests to, limiting potential attack scope.
+		// * Cluster.CertificateAuthority. While this reads from files, the result is not attached to the request and is instead
+		//   entirely local
+	}
+	return nil
 }
 
 func (c *Controller) createRemoteCluster(kubeConfig []byte, clusterID string) (*Cluster, error) {

--- a/pkg/kube/multicluster/secretcontroller_test.go
+++ b/pkg/kube/multicluster/secretcontroller_test.go
@@ -21,11 +21,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/clientcmd/api"
 
 	"istio.io/istio/pilot/pkg/features"
+	"istio.io/istio/pilot/pkg/util/sets"
 	"istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/test/util/retry"
@@ -189,6 +192,73 @@ func Test_SecretController(t *testing.T) {
 					defer mu.Unlock()
 					return added == "" && updated == "" && deleted == ""
 				}).Should(Equal(true))
+			}
+		})
+	}
+}
+
+func TestSanitizeKubeConfig(t *testing.T) {
+	cases := []struct {
+		name      string
+		config    api.Config
+		allowlist sets.Set
+		want      api.Config
+		wantErr   bool
+	}{
+		{
+			name:    "empty",
+			config:  api.Config{},
+			want:    api.Config{},
+			wantErr: false,
+		},
+		{
+			name: "exec",
+			config: api.Config{
+				AuthInfos: map[string]*api.AuthInfo{
+					"default": {
+						Exec: &api.ExecConfig{
+							Command: "sleep",
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name:      "exec allowlist",
+			allowlist: sets.NewSet("exec"),
+			config: api.Config{
+				AuthInfos: map[string]*api.AuthInfo{
+					"default": {
+						Exec: &api.ExecConfig{
+							Command: "sleep",
+						},
+					},
+				},
+			},
+			want: api.Config{
+				AuthInfos: map[string]*api.AuthInfo{
+					"default": {
+						Exec: &api.ExecConfig{
+							Command: "sleep",
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			err := sanitizeKubeConfig(tt.config, tt.allowlist)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("sanitizeKubeConfig() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err != nil {
+				return
+			}
+			if diff := cmp.Diff(tt.config, tt.want); diff != "" {
+				t.Fatal(diff)
 			}
 		})
 	}

--- a/releasenotes/notes/multicuster-secret-auth.yaml
+++ b/releasenotes/notes/multicuster-secret-auth.yaml
@@ -1,0 +1,18 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+releaseNotes:
+- |
+  **Removed** support for a number of nonstandard kubeconfig authentication methods when using multicluster secret.
+
+upgradeNotes:
+- title: Multicluster Secret Authentication Changes
+  content: |
+    When kubeconfig files are created to [enable endpoint discovery](https://istio.io/latest/docs/setup/install/multicluster/multi-primary/#enable-endpoint-discovery)
+    in multicluster installations, the authentication methods allowed in the configuration is now limited.
+
+    The two authentication methods output but `istioctl create-remote-secret` (`oidc` and `token`), are not impacted.
+    As a result, only users that are creating custom kubeconfig files will be impacted.
+
+    A new environment variable, `PILOT_INSECURE_MULTICLUSTER_KUBECONFIG_OPTIONS`, is added to Istiod to enable the methods that were removed.
+    For example, if `exec` authentication is used, set `PILOT_INSECURE_MULTICLUSTER_KUBECONFIG_OPTIONS=exec`.

--- a/releasenotes/notes/multicuster-secret-auth.yaml
+++ b/releasenotes/notes/multicuster-secret-auth.yaml
@@ -3,16 +3,5 @@ kind: bug-fix
 area: installation
 releaseNotes:
 - |
-  **Removed** support for a number of nonstandard kubeconfig authentication methods when using multicluster secret.
-
-upgradeNotes:
-- title: Multicluster Secret Authentication Changes
-  content: |
-    When kubeconfig files are created to [enable endpoint discovery](https://istio.io/latest/docs/setup/install/multicluster/multi-primary/#enable-endpoint-discovery)
-    in multicluster installations, the authentication methods allowed in the configuration is now limited.
-
-    The two authentication methods output but `istioctl create-remote-secret` (`oidc` and `token`), are not impacted.
-    As a result, only users that are creating custom kubeconfig files will be impacted.
-
-    A new environment variable, `PILOT_INSECURE_MULTICLUSTER_KUBECONFIG_OPTIONS`, is added to Istiod to enable the methods that were removed.
-    For example, if `exec` authentication is used, set `PILOT_INSECURE_MULTICLUSTER_KUBECONFIG_OPTIONS=exec`.
+  **Added** an option to disable a number of nonstandard kubeconfig authentication methods when using multicluster secret by configuring the
+  `PILOT_INSECURE_MULTICLUSTER_KUBECONFIG_OPTIONS` environment variable in Istiod. By default, this option is configured to allow all methods; future versions will restrict this by default.


### PR DESCRIPTION
Cherrypick https://github.com/istio/istio/pull/36307

Custom 1.12-only parts are in a split commit.