### PR TITLE
[stackdriver] add default 1 hour stale metric expiry.

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.13.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.13.yaml
@@ -360,7 +360,10 @@ spec:
                   "@type": "type.googleapis.com/google.protobuf.StringValue"
                   value: |
                     {{- if not .Values.telemetry.v2.stackdriver.configOverride }}
-                    {"access_logging": "{{ .Values.telemetry.v2.stackdriver.outboundAccessLogging }}"}
+                    {
+                      "access_logging": "{{ .Values.telemetry.v2.stackdriver.outboundAccessLogging }}",
+                      "metric_expiry_duration": "3600s"
+                    }
                     {{- else }}
                     {{ toJson .Values.telemetry.v2.stackdriver.configOverride | indent 18 }}
                     {{- end }}
@@ -395,7 +398,12 @@ spec:
                   "@type": "type.googleapis.com/google.protobuf.StringValue"
                   value: |
                     {{- if not .Values.telemetry.v2.stackdriver.configOverride }}
-                    {"disable_server_access_logging": {{ not .Values.telemetry.v2.stackdriver.logging }}, "access_logging": "{{ .Values.telemetry.v2.stackdriver.inboundAccessLogging }}", "disable_host_header_fallback": true}
+                    {
+                      "disable_server_access_logging": {{ not .Values.telemetry.v2.stackdriver.logging }},
+                      "access_logging": "{{ .Values.telemetry.v2.stackdriver.inboundAccessLogging }}",
+                      "disable_host_header_fallback": true,
+                      "metric_expiry_duration": "3600s"
+                    }
                     {{- else }}
                     {{ toJson .Values.telemetry.v2.stackdriver.configOverride | indent 18 }}
                     {{- end }}
@@ -429,7 +437,11 @@ spec:
                   "@type": "type.googleapis.com/google.protobuf.StringValue"
                   value: |
                     {{- if not .Values.telemetry.v2.stackdriver.configOverride }}
-                    {"access_logging": "{{ .Values.telemetry.v2.stackdriver.outboundAccessLogging }}", "disable_host_header_fallback": true}
+                    {
+                      "access_logging": "{{ .Values.telemetry.v2.stackdriver.outboundAccessLogging }}",
+                      "disable_host_header_fallback": true,
+                      "metric_expiry_duration": "3600s"
+                    }
                     {{- else }}
                     {{ toJson .Values.telemetry.v2.stackdriver.configOverride | indent 18 }}
                     {{- end }}
@@ -476,7 +488,10 @@ spec:
                 "@type": "type.googleapis.com/google.protobuf.StringValue"
                 value: |
                   {{- if not .Values.telemetry.v2.stackdriver.configOverride }}
-                  {"access_logging": "{{ .Values.telemetry.v2.stackdriver.outboundAccessLogging }}"}
+                  {
+                    "access_logging": "{{ .Values.telemetry.v2.stackdriver.outboundAccessLogging }}",
+                    "metric_expiry_duration": "3600s"
+                  }
                   {{- else }}
                   {{ toJson .Values.telemetry.v2.stackdriver.configOverride | indent 18 }}
                   {{- end }}
@@ -509,7 +524,11 @@ spec:
                 "@type": "type.googleapis.com/google.protobuf.StringValue"
                 value: |
                   {{- if not .Values.telemetry.v2.stackdriver.configOverride }}
-                  {"disable_server_access_logging": {{ not .Values.telemetry.v2.stackdriver.logging }}, "access_logging": "{{ .Values.telemetry.v2.stackdriver.inboundAccessLogging }}"}
+                  {
+                    "disable_server_access_logging": {{ not .Values.telemetry.v2.stackdriver.logging }},
+                    "access_logging": "{{ .Values.telemetry.v2.stackdriver.inboundAccessLogging }}",
+                    "metric_expiry_duration": "3600s"
+                  }
                   {{- else }}
                   {{ toJson .Values.telemetry.v2.stackdriver.configOverride | indent 18 }}
                   {{- end }}
@@ -541,7 +560,10 @@ spec:
                 "@type": "type.googleapis.com/google.protobuf.StringValue"
                 value: |
                   {{- if not .Values.telemetry.v2.stackdriver.configOverride }}
-                  {"access_logging": "{{ .Values.telemetry.v2.stackdriver.outboundAccessLogging }}"}
+                  {
+                    "access_logging": "{{ .Values.telemetry.v2.stackdriver.outboundAccessLogging }}",
+                    "metric_expiry_duration": "3600s"
+                  }
                   {{- else }}
                   {{ toJson .Values.telemetry.v2.stackdriver.configOverride | indent 18 }}
                   {{- end }}

--- a/manifests/charts/istiod-remote/templates/telemetryv2_1.13.yaml
+++ b/manifests/charts/istiod-remote/templates/telemetryv2_1.13.yaml
@@ -360,7 +360,10 @@ spec:
                   "@type": "type.googleapis.com/google.protobuf.StringValue"
                   value: |
                     {{- if not .Values.telemetry.v2.stackdriver.configOverride }}
-                    {"access_logging": "{{ .Values.telemetry.v2.stackdriver.outboundAccessLogging }}"}
+                    {
+                      "access_logging": "{{ .Values.telemetry.v2.stackdriver.outboundAccessLogging }}",
+                      "metric_expiry_duration": "3600s"
+                    }
                     {{- else }}
                     {{ toJson .Values.telemetry.v2.stackdriver.configOverride | indent 18 }}
                     {{- end }}
@@ -395,7 +398,12 @@ spec:
                   "@type": "type.googleapis.com/google.protobuf.StringValue"
                   value: |
                     {{- if not .Values.telemetry.v2.stackdriver.configOverride }}
-                    {"disable_server_access_logging": {{ not .Values.telemetry.v2.stackdriver.logging }}, "access_logging": "{{ .Values.telemetry.v2.stackdriver.inboundAccessLogging }}", "disable_host_header_fallback": true}
+                    {
+                      "disable_server_access_logging": {{ not .Values.telemetry.v2.stackdriver.logging }},
+                      "access_logging": "{{ .Values.telemetry.v2.stackdriver.inboundAccessLogging }}",
+                      "disable_host_header_fallback": true,
+                      "metric_expiry_duration": "3600s"
+                    }
                     {{- else }}
                     {{ toJson .Values.telemetry.v2.stackdriver.configOverride | indent 18 }}
                     {{- end }}
@@ -429,7 +437,11 @@ spec:
                   "@type": "type.googleapis.com/google.protobuf.StringValue"
                   value: |
                     {{- if not .Values.telemetry.v2.stackdriver.configOverride }}
-                    {"access_logging": "{{ .Values.telemetry.v2.stackdriver.outboundAccessLogging }}", "disable_host_header_fallback": true}
+                    {
+                      "access_logging": "{{ .Values.telemetry.v2.stackdriver.outboundAccessLogging }}",
+                      "disable_host_header_fallback": true,
+                      "metric_expiry_duration": "3600s"
+                    }
                     {{- else }}
                     {{ toJson .Values.telemetry.v2.stackdriver.configOverride | indent 18 }}
                     {{- end }}
@@ -476,7 +488,10 @@ spec:
                 "@type": "type.googleapis.com/google.protobuf.StringValue"
                 value: |
                   {{- if not .Values.telemetry.v2.stackdriver.configOverride }}
-                  {"access_logging": "{{ .Values.telemetry.v2.stackdriver.outboundAccessLogging }}"}
+                  {
+                    "access_logging": "{{ .Values.telemetry.v2.stackdriver.outboundAccessLogging }}",
+                    "metric_expiry_duration": "3600s"
+                  }
                   {{- else }}
                   {{ toJson .Values.telemetry.v2.stackdriver.configOverride | indent 18 }}
                   {{- end }}
@@ -509,7 +524,11 @@ spec:
                 "@type": "type.googleapis.com/google.protobuf.StringValue"
                 value: |
                   {{- if not .Values.telemetry.v2.stackdriver.configOverride }}
-                  {"disable_server_access_logging": {{ not .Values.telemetry.v2.stackdriver.logging }}, "access_logging": "{{ .Values.telemetry.v2.stackdriver.inboundAccessLogging }}"}
+                  {
+                    "disable_server_access_logging": {{ not .Values.telemetry.v2.stackdriver.logging }},
+                    "access_logging": "{{ .Values.telemetry.v2.stackdriver.inboundAccessLogging }}",
+                    "metric_expiry_duration": "3600s"
+                  }
                   {{- else }}
                   {{ toJson .Values.telemetry.v2.stackdriver.configOverride | indent 18 }}
                   {{- end }}
@@ -541,7 +560,10 @@ spec:
                 "@type": "type.googleapis.com/google.protobuf.StringValue"
                 value: |
                   {{- if not .Values.telemetry.v2.stackdriver.configOverride }}
-                  {"access_logging": "{{ .Values.telemetry.v2.stackdriver.outboundAccessLogging }}"}
+                  {
+                    "access_logging": "{{ .Values.telemetry.v2.stackdriver.outboundAccessLogging }}",
+                    "metric_expiry_duration": "3600s"
+                  }
                   {{- else }}
                   {{ toJson .Values.telemetry.v2.stackdriver.configOverride | indent 18 }}
                   {{- end }}

--- a/pilot/pkg/model/telemetry.go
+++ b/pilot/pkg/model/telemetry.go
@@ -18,6 +18,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	httpwasm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/wasm/v3"
@@ -26,6 +27,7 @@ import (
 	wasm "github.com/envoyproxy/go-control-plane/envoy/extensions/wasm/v3"
 	"github.com/gogo/protobuf/types"
 	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/durationpb"
 	wrappers "google.golang.org/protobuf/types/known/wrapperspb"
 
 	sd "istio.io/api/envoy/extensions/stackdriver/config/v1alpha1"
@@ -834,6 +836,7 @@ func generateSDConfig(class networking.ListenerClass, telemetryConfig telemetryF
 			cfg.AccessLogging = sd.PluginConfig_ERRORS_ONLY
 		}
 	}
+	cfg.MetricExpiryDuration = durationpb.New(1 * time.Hour)
 	// In WASM we are not actually processing protobuf at all, so we need to encode this to JSON
 	cfgJSON, _ := protomarshal.MarshalProtoNames(&cfg)
 	return networking.MessageToAny(&wrappers.StringValue{Value: string(cfgJSON)})

--- a/pilot/pkg/model/telemetry_test.go
+++ b/pilot/pkg/model/telemetry_test.go
@@ -565,7 +565,7 @@ func TestTelemetryFilters(t *testing.T) {
 			networking.ListenerProtocolHTTP,
 			nil,
 			map[string]string{
-				"istio.stackdriver": `{}`,
+				"istio.stackdriver": `{"metric_expiry_duration":"3600s"}`,
 			},
 		},
 		{
@@ -576,7 +576,7 @@ func TestTelemetryFilters(t *testing.T) {
 			networking.ListenerProtocolHTTP,
 			nil,
 			map[string]string{
-				"istio.stackdriver": `{"metrics_overrides":{"client/request_count":{"tag_overrides":{"add":"bar"}}}}`,
+				"istio.stackdriver": `{"metric_expiry_duration":"3600s","metrics_overrides":{"client/request_count":{"tag_overrides":{"add":"bar"}}}}`,
 			},
 		},
 		{
@@ -590,7 +590,7 @@ func TestTelemetryFilters(t *testing.T) {
 			networking.ListenerProtocolHTTP,
 			nil,
 			map[string]string{
-				"istio.stackdriver": `{}`,
+				"istio.stackdriver": `{"metric_expiry_duration":"3600s"}`,
 			},
 		},
 		{
@@ -630,7 +630,7 @@ func TestTelemetryFilters(t *testing.T) {
 			networking.ListenerProtocolHTTP,
 			&meshconfig.MeshConfig_DefaultProviders{Metrics: []string{"prometheus"}},
 			map[string]string{
-				"istio.stackdriver": `{}`,
+				"istio.stackdriver": `{"metric_expiry_duration":"3600s"}`,
 			},
 		},
 		{
@@ -643,7 +643,7 @@ func TestTelemetryFilters(t *testing.T) {
 			networking.ListenerProtocolHTTP,
 			nil,
 			map[string]string{
-				"istio.stackdriver": `{"access_logging":"ERRORS_ONLY"}`,
+				"istio.stackdriver": `{"access_logging":"ERRORS_ONLY","metric_expiry_duration":"3600s"}`,
 			},
 		},
 		{
@@ -656,7 +656,7 @@ func TestTelemetryFilters(t *testing.T) {
 			networking.ListenerProtocolHTTP,
 			&meshconfig.MeshConfig_DefaultProviders{AccessLogging: []string{"stackdriver"}},
 			map[string]string{
-				"istio.stackdriver": `{"disable_host_header_fallback":true,"access_logging":"FULL"}`,
+				"istio.stackdriver": `{"disable_host_header_fallback":true,"access_logging":"FULL","metric_expiry_duration":"3600s"}`,
 			},
 		},
 		{
@@ -670,7 +670,7 @@ func TestTelemetryFilters(t *testing.T) {
 				AccessLogging: []string{"stackdriver"},
 			},
 			map[string]string{
-				"istio.stackdriver": `{"disable_host_header_fallback":true,"access_logging":"FULL"}`,
+				"istio.stackdriver": `{"disable_host_header_fallback":true,"access_logging":"FULL","metric_expiry_duration":"3600s"}`,
 			},
 		},
 	}


### PR DESCRIPTION
This will clean up stale time series (i.e. time series that have not been updated for the last hour) to be removed from memory, and thus not be reported to SD.