### PR TITLE
configgentest: avoid running kubecontroller 2x

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/fake.go
+++ b/pilot/pkg/networking/core/v1alpha3/fake.go
@@ -67,6 +67,8 @@ type TestOptions struct {
 	MeshConfig      *meshconfig.MeshConfig
 	NetworksWatcher mesh.NetworksWatcher
 
+	// Optionally provide a top-level aggregate registry with subregistries added. The ConfigGenTest will handle running it.
+	AggregateRegistry *aggregate.Controller
 	// Additional service registries to use. A ServiceEntry and memory registry will always be created.
 	ServiceRegistries []serviceregistry.Instance
 
@@ -120,7 +122,10 @@ func NewConfigGenTest(t test.Failer, opts TestOptions) *ConfigGenTest {
 		m = &def
 	}
 
-	serviceDiscovery := aggregate.NewController(aggregate.Options{})
+	serviceDiscovery := opts.AggregateRegistry
+	if serviceDiscovery == nil {
+		serviceDiscovery = aggregate.NewController(aggregate.Options{})
+	}
 	se := serviceentry.NewServiceDiscovery(
 		configController, model.MakeIstioStore(configStore),
 		&FakeXdsUpdater{}, serviceentry.WithClusterID(opts.ClusterID))

--- a/pilot/pkg/serviceregistry/kube/controller/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller_test.go
@@ -284,7 +284,6 @@ func TestController_GetPodLocality(t *testing.T) {
 		// https://github.com/golang/go/wiki/CommonMistakes#using-goroutines-on-loop-iterator-variables
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
 			// Setup kube caches
 			// Pod locality only matters for Endpoints
 			controller, fx := NewFakeControllerWithOptions(FakeControllerOptions{Mode: EndpointsOnly})

--- a/pilot/pkg/serviceregistry/kube/controller/fake.go
+++ b/pilot/pkg/serviceregistry/kube/controller/fake.go
@@ -210,9 +210,9 @@ func NewFakeControllerWithOptions(opts FakeControllerOptions) (*FakeController, 
 
 	// we created the aggregate here, so we're responsible for starting it
 	if opts.AggregateController == nil {
+		meshServiceController.AddRegistry(c)
 		go meshServiceController.Run(c.stop)
 		// Wait for the caches to sync, otherwise we may hit race conditions where events are dropped
-		meshServiceController.AddRegistry(c)
 		cache.WaitForCacheSync(c.stop, c.HasSynced)
 	}
 

--- a/pilot/pkg/serviceregistry/kube/controller/fake.go
+++ b/pilot/pkg/serviceregistry/kube/controller/fake.go
@@ -206,12 +206,7 @@ func NewFakeControllerWithOptions(opts FakeControllerOptions) (*FakeController, 
 	if c.stop == nil {
 		c.stop = make(chan struct{})
 	}
-
-
-	// we created the client here, so we're responsible for starting it
-	if opts.Client == nil {
-		client.RunAndWait(c.stop)
-	}
+	client.RunAndWait(c.stop)
 
 	// we created the aggregate here, so we're responsible for starting it
 	if opts.AggregateController == nil {

--- a/pilot/pkg/serviceregistry/kube/controller/fake.go
+++ b/pilot/pkg/serviceregistry/kube/controller/fake.go
@@ -150,9 +150,9 @@ type FakeControllerOptions struct {
 	XDSUpdater                model.XDSUpdater
 	DiscoveryNamespacesFilter filter.DiscoveryNamespacesFilter
 
-	// when calling from NewFakeDiscoveryServer, we wait for the aggregate cache to sync. Waiting here can cause deadlock.
-	SkipCacheSyncWait bool
-	Stop              chan struct{}
+	// when calling from NewFakeDiscoveryServer use the same aggregate controller we add other registries to
+	AggregateController *aggregate.Controller
+	Stop                chan struct{}
 }
 
 type FakeController struct {
@@ -176,7 +176,10 @@ func NewFakeControllerWithOptions(opts FakeControllerOptions) (*FakeController, 
 		opts.MeshWatcher = mesh.NewFixedWatcher(&meshconfig.MeshConfig{})
 	}
 
-	meshServiceController := aggregate.NewController(aggregate.Options{MeshHolder: opts.MeshWatcher})
+	meshServiceController := opts.AggregateController
+	if meshServiceController == nil {
+		meshServiceController = aggregate.NewController(aggregate.Options{MeshHolder: opts.MeshWatcher})
+	}
 
 	options := Options{
 		DomainSuffix:              domainSuffix,
@@ -191,23 +194,32 @@ func NewFakeControllerWithOptions(opts FakeControllerOptions) (*FakeController, 
 		MeshServiceController:     meshServiceController,
 	}
 	c := NewController(opts.Client, options)
-	meshServiceController.AddRegistry(c)
 
 	if opts.ServiceHandler != nil {
 		c.AppendServiceHandler(opts.ServiceHandler)
 	}
+
+	// Run in initiation to prevent calling each test
+	// TODO: fix it, so we can remove `stop` channel
 	c.stop = opts.Stop
 	if c.stop == nil {
 		c.stop = make(chan struct{})
 	}
-	// Run in initiation to prevent calling each test
-	// TODO: fix it, so we can remove `stop` channel
-	go meshServiceController.Run(c.stop)
-	opts.Client.RunAndWait(c.stop)
-	if !opts.SkipCacheSyncWait {
+
+	// we created the aggregate here, so we're responsible for starting it
+	if opts.AggregateController == nil {
+		go meshServiceController.Run(c.stop)
 		// Wait for the caches to sync, otherwise we may hit race conditions where events are dropped
+		meshServiceController.AddRegistry(c)
 		cache.WaitForCacheSync(c.stop, c.HasSynced)
 	}
+
+	// we created the client here, so we're responsible for starting it
+	if opts.Client == nil {
+		opts.Client.RunAndWait(c.stop)
+	}
+
+
 	var fx *FakeXdsUpdater
 	if x, ok := xdsUpdater.(*FakeXdsUpdater); ok {
 		fx = x

--- a/pilot/pkg/xds/fake.go
+++ b/pilot/pkg/xds/fake.go
@@ -43,6 +43,7 @@ import (
 	"istio.io/istio/pilot/pkg/networking/core/v1alpha3"
 	"istio.io/istio/pilot/pkg/networking/plugin"
 	"istio.io/istio/pilot/pkg/serviceregistry"
+	"istio.io/istio/pilot/pkg/serviceregistry/aggregate"
 	kube "istio.io/istio/pilot/pkg/serviceregistry/kube/controller"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
 	"istio.io/istio/pilot/test/xdstest"
@@ -172,6 +173,7 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 	}
 	creds := kubesecrets.NewMulticluster(opts.DefaultClusterName)
 	s.Generators[v3.SecretType] = NewSecretGen(creds, s.Cache, opts.DefaultClusterName)
+	aggregateRegistry := aggregate.NewController(aggregate.Options{})
 	for k8sCluster, objs := range k8sObjects {
 		client := kubelib.NewFakeClientWithVersion(opts.KubernetesVersion, objs...)
 		if opts.KubeClientModifier != nil {
@@ -186,8 +188,8 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 			NetworksWatcher: opts.NetworksWatcher,
 			Mode:            opts.KubernetesEndpointMode,
 			// we wait for the aggregate to sync
-			SkipCacheSyncWait: true,
-			Stop:              stop,
+			AggregateController: aggregateRegistry,
+			Stop:                stop,
 		})
 		// start default client informers after creating ingress/secret controllers
 		if defaultKubeClient == nil || k8sCluster == opts.DefaultClusterName {
@@ -197,6 +199,7 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 			client.RunAndWait(stop)
 		}
 		registries = append(registries, k8s)
+		aggregateRegistry.AddRegistry(k8s)
 		if err := creds.ClusterAdded(&multicluster.Cluster{ID: k8sCluster, Client: client}, nil); err != nil {
 			t.Fatal(err)
 		}
@@ -218,6 +221,7 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 		ConfigTemplateInput: opts.ConfigTemplateInput,
 		MeshConfig:          opts.MeshConfig,
 		NetworksWatcher:     opts.NetworksWatcher,
+		AggregateRegistry:   aggregateRegistry,
 		ServiceRegistries:   registries,
 		PushContextLock:     &s.updateMutex,
 		ConfigStoreCaches:   []model.ConfigStoreCache{ingr},
@@ -305,9 +309,6 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 	// Start the discovery server
 	s.Start(stop)
 	cg.ServiceEntryRegistry.XdsUpdater = s
-	cache.WaitForCacheSync(stop,
-		cg.Registry.HasSynced,
-		cg.Store().HasSynced)
 	cg.ServiceEntryRegistry.ResyncEDS()
 
 	// Send an update. This ensures that even if there are no configs provided, the push context is
@@ -316,6 +317,9 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 
 	// Now that handlers are added, get everything started
 	cg.Run()
+	cache.WaitForCacheSync(stop,
+		cg.Registry.HasSynced,
+		cg.Store().HasSynced)
 
 	// Wait until initial updates are committed
 	c := s.InboundUpdates.Load()


### PR DESCRIPTION
It seems we're calling the kubecontrollers `Run` method 2x  in our tests. 