### PR TITLE
Fix analysis nil pointer panic error

### DIFF
--- a/pkg/config/analysis/analyzers/webhook/webhook.go
+++ b/pkg/config/analysis/analyzers/webhook/webhook.go
@@ -165,10 +165,11 @@ func extractRevisions(wh *v1.MutatingWebhookConfiguration) []string {
 			if r, f := webhook.NamespaceSelector.MatchLabels[label.IoIstioRev.Name]; f {
 				revs.Insert(r)
 			}
-		}
-		for _, ls := range webhook.NamespaceSelector.MatchExpressions {
-			if ls.Key == label.IoIstioRev.Name {
-				revs.Insert(ls.Values...)
+
+			for _, ls := range webhook.NamespaceSelector.MatchExpressions {
+				if ls.Key == label.IoIstioRev.Name {
+					revs.Insert(ls.Values...)
+				}
 			}
 		}
 		if webhook.ObjectSelector != nil {


### PR DESCRIPTION
**Please provide a description of this PR:**
Can only do forloop when `webhook.NamespaceSelector` is not nil.