### PR TITLE
operator: use shared kube client

### DIFF
--- a/istioctl/pkg/install/verify.go
+++ b/istioctl/pkg/install/verify.go
@@ -75,8 +75,11 @@ istioctl experimental precheck.
 			return nil
 		},
 		RunE: func(c *cobra.Command, args []string) error {
-			installationVerifier := verifier.NewStatusVerifier(istioNamespace, manifestsPath,
+			installationVerifier, err := verifier.NewStatusVerifier(istioNamespace, manifestsPath,
 				*kubeConfigFlags.KubeConfig, *kubeConfigFlags.Context, filenames, opts, nil, nil)
+			if err != nil {
+				return err
+			}
 			if formatting.IstioctlColorDefault(c.OutOrStdout()) {
 				installationVerifier.Colorize()
 			}

--- a/istioctl/pkg/verifier/verifier.go
+++ b/istioctl/pkg/verifier/verifier.go
@@ -56,14 +56,24 @@ var istioOperatorGVR = apimachinery_schema.GroupVersionResource{
 type StatusVerifier struct {
 	istioNamespace   string
 	manifestsPath    string
-	kubeconfig       string
-	context          string
 	filenames        []string
 	controlPlaneOpts clioptions.ControlPlaneOptions
 	logger           clog.Logger
 	iop              *v1alpha1.IstioOperator
 	successMarker    string
 	failureMarker    string
+	client           kube.ExtendedClient
+}
+
+func NewTestStatusVerifier(istioNamespace, manifestsPath string, client kube.ExtendedClient, logger *clog.ConsoleLogger) *StatusVerifier {
+	return &StatusVerifier{
+		istioNamespace: istioNamespace,
+		manifestsPath:  manifestsPath,
+		logger:         logger,
+		client:         client,
+		successMarker:  "✔",
+		failureMarker:  "✘",
+	}
 }
 
 // NewStatusVerifier creates a new instance of post-install verifier
@@ -71,9 +81,13 @@ type StatusVerifier struct {
 // TODO(su225): This is doing too many things. Refactor: break it down
 func NewStatusVerifier(istioNamespace, manifestsPath, kubeconfig, context string,
 	filenames []string, controlPlaneOpts clioptions.ControlPlaneOptions,
-	logger clog.Logger, installedIOP *v1alpha1.IstioOperator) *StatusVerifier {
+	logger clog.Logger, installedIOP *v1alpha1.IstioOperator) (*StatusVerifier, error) {
 	if logger == nil {
 		logger = clog.NewDefaultLogger()
+	}
+	client, err := kube.NewExtendedClient(kube.BuildClientCmd(kubeconfig, context), "")
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect Kubernetes API server, error: %v", err)
 	}
 	return &StatusVerifier{
 		istioNamespace:   istioNamespace,
@@ -81,12 +95,11 @@ func NewStatusVerifier(istioNamespace, manifestsPath, kubeconfig, context string
 		filenames:        filenames,
 		controlPlaneOpts: controlPlaneOpts,
 		logger:           logger,
-		kubeconfig:       kubeconfig,
-		context:          context,
+		client:           client,
 		iop:              installedIOP,
 		successMarker:    "✔",
 		failureMarker:    "✘",
-	}
+	}, nil
 }
 
 func (v *StatusVerifier) Colorize() {
@@ -138,8 +151,7 @@ func (v *StatusVerifier) verifyInstallIOPRevision() error {
 	if err != nil {
 		return err
 	}
-	mergedIOP, err := manifest.GetMergedIOP(string(by), profile, v.manifestsPath, v.controlPlaneOpts.Revision,
-		v.kubeconfig, v.context, v.logger)
+	mergedIOP, err := manifest.GetMergedIOP(string(by), profile, v.manifestsPath, v.controlPlaneOpts.Revision, v.client, v.logger)
 	if err != nil {
 		return err
 	}
@@ -152,11 +164,7 @@ func (v *StatusVerifier) getRevision() (string, error) {
 	var revision string
 	var revs string
 	revCount := 0
-	kubeClient, err := v.createClient()
-	if err != nil {
-		return "", err
-	}
-	pods, err := kubeClient.PodsForSelector(context.TODO(), v.istioNamespace, "app=istiod")
+	pods, err := v.client.PodsForSelector(context.TODO(), v.istioNamespace, "app=istiod")
 	if err != nil {
 		return "", fmt.Errorf("failed to fetch istiod pod, error: %v", err)
 	}
@@ -177,18 +185,6 @@ func (v *StatusVerifier) getRevision() (string, error) {
 	return revision, nil
 }
 
-func (v *StatusVerifier) createClient() (kube.ExtendedClient, error) {
-	cfg, err := kube.BuildClientConfig(v.kubeconfig, v.context)
-	if err != nil {
-		return nil, err
-	}
-	kubeClient, err := kube.NewExtendedClient(kube.NewClientConfigForRestConfig(cfg), "")
-	if err != nil {
-		return nil, fmt.Errorf("failed to connect Kubernetes API server, error: %v", err)
-	}
-	return kubeClient, nil
-}
-
 func (v *StatusVerifier) verifyFinalIOP() error {
 	crdCount, istioDeploymentCount, err := v.verifyPostInstallIstioOperator(
 		v.iop, fmt.Sprintf("IOP:%s", v.iop.GetName()))
@@ -197,7 +193,7 @@ func (v *StatusVerifier) verifyFinalIOP() error {
 
 func (v *StatusVerifier) verifyInstall() error {
 	// This is not a pre-check.  Check that the supplied resources exist in the cluster
-	r := resource.NewBuilder(v.k8sConfig()).
+	r := resource.NewBuilder(v.client.UtilFactory()).
 		Unstructured().
 		FilenameParam(false, &resource.FilenameOptions{Filenames: v.filenames}).
 		Flatten().
@@ -227,7 +223,7 @@ func (v *StatusVerifier) verifyPostInstallIstioOperator(iop *v1alpha1.IstioOpera
 		return 0, 0, errs.ToError()
 	}
 
-	builder := resource.NewBuilder(v.k8sConfig()).ContinueOnError().Unstructured()
+	builder := resource.NewBuilder(v.client.UtilFactory()).ContinueOnError().Unstructured()
 	for cat, manifest := range manifests {
 		for i, manitem := range manifest {
 			reader := strings.NewReader(manitem)
@@ -333,7 +329,7 @@ func (v *StatusVerifier) verifyPostInstall(visitor resource.Visitor, filename st
 			}
 			profile := manifest.GetProfile(unmergedIOP)
 			iop, err := manifest.GetMergedIOP(by, profile, v.manifestsPath, v.controlPlaneOpts.Revision,
-				v.kubeconfig, v.context, v.logger)
+				v.client, v.logger)
 			if err != nil {
 				v.reportFailure(kind, name, namespace, err)
 				return err
@@ -382,12 +378,7 @@ func (v *StatusVerifier) verifyPostInstall(visitor resource.Visitor, filename st
 
 // Find Istio injector matching revision.  ("" matches any revision.)
 func (v *StatusVerifier) injectorFromCluster(revision string) (*admit_v1.MutatingWebhookConfiguration, error) {
-	kubeClient, err := v.createClient()
-	if err != nil {
-		return nil, err
-	}
-	ctx := context.Background()
-	hooks, err := kubeClient.AdmissionregistrationV1().MutatingWebhookConfigurations().List(ctx, meta_v1.ListOptions{})
+	hooks, err := v.client.AdmissionregistrationV1().MutatingWebhookConfigurations().List(context.Background(), meta_v1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -416,15 +407,7 @@ func (v *StatusVerifier) injectorFromCluster(revision string) (*admit_v1.Mutatin
 // Find an IstioOperator matching revision in the cluster.  The IstioOperators
 // don't have a label for their revision, so we parse them and check .Spec.Revision
 func (v *StatusVerifier) operatorFromCluster(revision string) (*v1alpha1.IstioOperator, error) {
-	restConfig, err := v.k8sConfig().ToRESTConfig()
-	if err != nil {
-		return nil, err
-	}
-	client, err := dynamic.NewForConfig(restConfig)
-	if err != nil {
-		return nil, err
-	}
-	iops, err := AllOperatorsInCluster(client)
+	iops, err := AllOperatorsInCluster(v.client.Dynamic())
 	if err != nil {
 		return nil, err
 	}
@@ -489,10 +472,6 @@ func AllOperatorsInCluster(client dynamic.Interface) ([]*v1alpha1.IstioOperator,
 
 func istioVerificationFailureError(filename string, reason error) error {
 	return fmt.Errorf("Istio installation failed, incomplete or does not match \"%s\": %v", filename, reason) // nolint
-}
-
-func (v *StatusVerifier) k8sConfig() *genericclioptions.ConfigFlags {
-	return &genericclioptions.ConfigFlags{KubeConfig: &v.kubeconfig, Context: &v.context}
 }
 
 func (v *StatusVerifier) reportFailure(kind, name, namespace string, err error) {

--- a/istioctl/pkg/verifier/verifier.go
+++ b/istioctl/pkg/verifier/verifier.go
@@ -65,17 +65,6 @@ type StatusVerifier struct {
 	client           kube.ExtendedClient
 }
 
-func NewTestStatusVerifier(istioNamespace, manifestsPath string, client kube.ExtendedClient, logger *clog.ConsoleLogger) *StatusVerifier {
-	return &StatusVerifier{
-		istioNamespace: istioNamespace,
-		manifestsPath:  manifestsPath,
-		logger:         logger,
-		client:         client,
-		successMarker:  "✔",
-		failureMarker:  "✘",
-	}
-}
-
 // NewStatusVerifier creates a new instance of post-install verifier
 // which checks the status of various resources from the manifest.
 // TODO(su225): This is doing too many things. Refactor: break it down

--- a/operator/cmd/mesh/manifest-generate_test.go
+++ b/operator/cmd/mesh/manifest-generate_test.go
@@ -235,9 +235,9 @@ func TestManifestGenerateWithDuplicateMutatingWebhookConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	defer func() {
+	t.Cleanup(func() {
 		removeFile(filepath.Join(env.IstioSrc, helm.OperatorSubdirFilePath+"/"+testIstioDiscoveryChartPath+"/"+testResourceFile+".yaml"))
-	}()
+	})
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/operator/cmd/mesh/operator-init.go
+++ b/operator/cmd/mesh/operator-init.go
@@ -22,7 +22,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"istio.io/api/operator/v1alpha1"
-	"istio.io/istio/istioctl/pkg/install/k8sversion"
 	iopv1alpha1 "istio.io/istio/operator/pkg/apis/istio/v1alpha1"
 	"istio.io/istio/operator/pkg/name"
 	"istio.io/istio/operator/pkg/translate"
@@ -83,15 +82,12 @@ func operatorInitCmd(rootArgs *rootArgs, oiArgs *operatorInitArgs) *cobra.Comman
 func operatorInit(args *rootArgs, oiArgs *operatorInitArgs, l clog.Logger) {
 	initLogsOrExit(args)
 
-	restConfig, clientset, client, err := K8sConfig(oiArgs.kubeConfigPath, oiArgs.context)
+	kubeClient, client, err := KubernetesClients(oiArgs.kubeConfigPath, oiArgs.context, l)
 	if err != nil {
 		l.LogAndFatal(err)
 	}
-	if err := k8sversion.IsK8VersionSupported(clientset, l); err != nil {
-		l.LogAndFatal(err)
-	}
 	// Error here likely indicates Deployment is missing. If some other K8s error, we will hit it again later.
-	already, _ := isControllerInstalled(clientset, oiArgs.common.operatorNamespace, oiArgs.common.revision)
+	already, _ := isControllerInstalled(kubeClient, oiArgs.common.operatorNamespace, oiArgs.common.revision)
 	if already {
 		l.LogAndPrintf("Operator controller is already installed in %s namespace.", oiArgs.common.operatorNamespace)
 		l.LogAndPrintf("Upgrading operator controller in namespace: %s using image: %s/operator:%s",
@@ -131,7 +127,7 @@ func operatorInit(args *rootArgs, oiArgs *operatorInitArgs, l clog.Logger) {
 		}
 	}
 
-	if err := createNamespace(clientset, oiArgs.common.operatorNamespace, ""); err != nil {
+	if err := createNamespace(kubeClient, oiArgs.common.operatorNamespace, ""); err != nil {
 		l.LogAndFatal(err)
 	}
 
@@ -142,17 +138,17 @@ func operatorInit(args *rootArgs, oiArgs *operatorInitArgs, l clog.Logger) {
 		namespaces = append(namespaces, istioNamespace)
 	}
 	for _, ns := range namespaces {
-		if err := createNamespace(clientset, ns, ""); err != nil {
+		if err := createNamespace(kubeClient, ns, ""); err != nil {
 			l.LogAndFatal(err)
 		}
 	}
 
-	if err := applyManifest(restConfig, client, mstr, name.IstioOperatorComponentName, opts, iop, l); err != nil {
+	if err := applyManifest(kubeClient, client, mstr, name.IstioOperatorComponentName, opts, iop, l); err != nil {
 		l.LogAndFatal(err)
 	}
 
 	if customResource != "" {
-		if err := applyManifest(restConfig, client, customResource, name.IstioOperatorComponentName, opts, iop, l); err != nil {
+		if err := applyManifest(kubeClient, client, customResource, name.IstioOperatorComponentName, opts, iop, l); err != nil {
 			l.LogAndFatal(err)
 		}
 	}

--- a/operator/cmd/mesh/operator-remove.go
+++ b/operator/cmd/mesh/operator-remove.go
@@ -64,12 +64,12 @@ func operatorRemoveCmd(rootArgs *rootArgs, orArgs *operatorRemoveArgs) *cobra.Co
 func operatorRemove(args *rootArgs, orArgs *operatorRemoveArgs, l clog.Logger) {
 	initLogsOrExit(args)
 
-	restConfig, clientset, client, err := K8sConfig(orArgs.kubeConfigPath, orArgs.context)
+	kubeClient, client, err := KubernetesClients(orArgs.kubeConfigPath, orArgs.context, l)
 	if err != nil {
 		l.LogAndFatal(err)
 	}
 
-	installed, err := isControllerInstalled(clientset, orArgs.operatorNamespace, orArgs.revision)
+	installed, err := isControllerInstalled(kubeClient, orArgs.operatorNamespace, orArgs.revision)
 	if installed && err != nil {
 		l.LogAndFatal(err)
 	}
@@ -90,7 +90,7 @@ func operatorRemove(args *rootArgs, orArgs *operatorRemoveArgs, l clog.Logger) {
 			l.LogAndFatal(err)
 		}
 	}
-	reconciler, err := helmreconciler.NewHelmReconciler(client, nil, restConfig, iop, &helmreconciler.Options{DryRun: args.dryRun, Log: l})
+	reconciler, err := helmreconciler.NewHelmReconciler(client, kubeClient, iop, &helmreconciler.Options{DryRun: args.dryRun, Log: l})
 	if err != nil {
 		l.LogAndFatal(err)
 	}

--- a/operator/cmd/mesh/shared.go
+++ b/operator/cmd/mesh/shared.go
@@ -24,10 +24,10 @@ import (
 	"time"
 
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"istio.io/istio/istioctl/pkg/install/k8sversion"
 	"istio.io/istio/operator/pkg/apis/istio/v1alpha1"
 	"istio.io/istio/operator/pkg/cache"
 	"istio.io/istio/operator/pkg/helmreconciler"
@@ -95,41 +95,26 @@ func confirm(msg string, writer io.Writer) bool {
 	return false
 }
 
-// K8sConfig creates a rest.Config, Clientset and controller runtime Client from the given kubeconfig path and context.
-func K8sConfig(kubeConfigPath string, context string) (*rest.Config, *kubernetes.Clientset, client.Client, error) {
-	restConfig, clientset, err := InitK8SRestClient(kubeConfigPath, context)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	// We are running a one-off command locally, so we don't need to worry too much about rate limitting
-	// Bumping this up greatly decreases install time
-	restConfig.QPS = 50
-	restConfig.Burst = 100
-	client, err := client.New(restConfig, client.Options{Scheme: scheme.Scheme})
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	return restConfig, clientset, client, nil
-}
-
-// InitK8SRestClient creates a rest.Config qne Clientset from the given kubeconfig path and context.
-func InitK8SRestClient(kubeconfig, kubeContext string) (*rest.Config, *kubernetes.Clientset, error) {
-	if testRestConfig != nil || testK8Interface != nil {
-		if !(testRestConfig != nil && testK8Interface != nil) {
-			return nil, nil, fmt.Errorf("testRestConfig and testK8Interface must both be either nil or set")
-		}
-		return testRestConfig, testK8Interface, nil
-	}
-	restConfig, err := kube.DefaultRestConfig(kubeconfig, kubeContext)
+func KubernetesClients(kubeConfigPath, context string, l clog.Logger) (kube.ExtendedClient, client.Client, error) {
+	rc, err := kube.DefaultRestConfig(kubeConfigPath, context, func(config *rest.Config) {
+		config.QPS = 200
+		config.Burst = 400
+	})
 	if err != nil {
 		return nil, nil, err
 	}
-	clientset, err := kubernetes.NewForConfig(restConfig)
+	kubeClient, err := kube.NewExtendedClient(kube.NewClientConfigForRestConfig(rc), "")
+	if err != nil {
+		return nil, nil, fmt.Errorf("create Kubernetes client: %v", err)
+	}
+	client, err := client.New(kubeClient.RESTConfig(), client.Options{Scheme: kube.IstioScheme})
 	if err != nil {
 		return nil, nil, err
 	}
-
-	return restConfig, clientset, nil
+	if err := k8sversion.IsK8VersionSupported(kubeClient, l); err != nil {
+		return nil, nil, fmt.Errorf("check minimum supported Kubernetes version: %v", err)
+	}
+	return kubeClient, client, nil
 }
 
 // applyOptions contains the startup options for applying the manifest.
@@ -144,11 +129,11 @@ type applyOptions struct {
 	WaitTimeout time.Duration
 }
 
-func applyManifest(restConfig *rest.Config, client client.Client, manifestStr string,
+func applyManifest(kubeClient kube.Client, client client.Client, manifestStr string,
 	componentName name.ComponentName, opts *applyOptions, iop *v1alpha1.IstioOperator, l clog.Logger) error {
 	// Needed in case we are running a test through this path that doesn't start a new process.
 	cache.FlushObjectCaches()
-	reconciler, err := helmreconciler.NewHelmReconciler(client, nil, restConfig, iop, &helmreconciler.Options{DryRun: opts.DryRun, Log: l})
+	reconciler, err := helmreconciler.NewHelmReconciler(client, kubeClient, iop, &helmreconciler.Options{DryRun: opts.DryRun, Log: l})
 	if err != nil {
 		l.LogAndError(err)
 		return err

--- a/operator/cmd/mesh/shared.go
+++ b/operator/cmd/mesh/shared.go
@@ -97,8 +97,10 @@ func confirm(msg string, writer io.Writer) bool {
 
 func KubernetesClients(kubeConfigPath, context string, l clog.Logger) (kube.ExtendedClient, client.Client, error) {
 	rc, err := kube.DefaultRestConfig(kubeConfigPath, context, func(config *rest.Config) {
-		config.QPS = 200
-		config.Burst = 400
+		// We are running a one-off command locally, so we don't need to worry too much about rate limitting
+		// Bumping this up greatly decreases install time
+		config.QPS = 50
+		config.Burst = 100
 	})
 	if err != nil {
 		return nil, nil, err

--- a/operator/pkg/helm/helm.go
+++ b/operator/pkg/helm/helm.go
@@ -99,7 +99,8 @@ func renderChart(namespace, values string, chrt *chart.Chart, filterFunc Templat
 		return "", fmt.Errorf("failed to unmarshal values: %v", err)
 	}
 
-	vals, err := chartutil.ToRenderValues(chrt, valuesMap, options, nil)
+	caps := *chartutil.DefaultCapabilities
+	vals, err := chartutil.ToRenderValues(chrt, valuesMap, options, &caps)
 	if err != nil {
 		return "", err
 	}

--- a/operator/pkg/helmreconciler/apply.go
+++ b/operator/pkg/helmreconciler/apply.go
@@ -132,7 +132,7 @@ func (h *HelmReconciler) ApplyManifest(manifest name.Manifest, serverSideApply b
 			return processedObjects, 0, errs.ToError()
 		}
 
-		err := WaitForResources(processedObjects, h.restConfig, h.clientSet,
+		err := WaitForResources(processedObjects, h.kubeClient,
 			h.opts.WaitTimeout, h.opts.DryRun, plog)
 		if err != nil {
 			werr := fmt.Errorf("failed to wait for resource: %v", err)

--- a/operator/pkg/manifest/shared.go
+++ b/operator/pkg/manifest/shared.go
@@ -21,12 +21,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 	"sigs.k8s.io/yaml"
 
 	"istio.io/api/operator/v1alpha1"
-	"istio.io/istio/istioctl/pkg/install/k8sversion"
 	iopv1alpha1 "istio.io/istio/operator/pkg/apis/istio/v1alpha1"
 	"istio.io/istio/operator/pkg/apis/istio/v1alpha1/validation"
 	"istio.io/istio/operator/pkg/controlplane"
@@ -52,8 +49,8 @@ var installerScope = log.RegisterScope("installer", "installer", 0)
 // If force is set, validation errors will not cause processing to abort but will result in warnings going to the
 // supplied logger.
 func GenManifests(inFilename []string, setFlags []string, force bool,
-	kubeConfig *rest.Config, l clog.Logger) (name.ManifestMap, *iopv1alpha1.IstioOperator, error) {
-	mergedYAML, _, err := GenerateConfig(inFilename, setFlags, force, kubeConfig, l)
+	client kube.Client, l clog.Logger) (name.ManifestMap, *iopv1alpha1.IstioOperator, error) {
+	mergedYAML, _, err := GenerateConfig(inFilename, setFlags, force, client, l)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -90,7 +87,7 @@ func GenManifests(inFilename []string, setFlags []string, force bool,
 // Otherwise it will be the compiled in profile YAMLs.
 // In step 3, the remaining fields in the same user overlay are applied on the resulting profile base.
 // The force flag causes validation errors not to abort but only emit log/console warnings.
-func GenerateConfig(inFilenames []string, setFlags []string, force bool, kubeConfig *rest.Config,
+func GenerateConfig(inFilenames []string, setFlags []string, force bool, client kube.Client,
 	l clog.Logger) (string, *iopv1alpha1.IstioOperator, error) {
 	if err := validateSetFlags(setFlags); err != nil {
 		return "", nil, err
@@ -101,12 +98,12 @@ func GenerateConfig(inFilenames []string, setFlags []string, force bool, kubeCon
 		return "", nil, err
 	}
 
-	return OverlayYAMLStrings(profile, fy, setFlags, force, kubeConfig, l)
+	return OverlayYAMLStrings(profile, fy, setFlags, force, client, l)
 }
 
 func OverlayYAMLStrings(profile string, fy string,
-	setFlags []string, force bool, kubeConfig *rest.Config, l clog.Logger) (string, *iopv1alpha1.IstioOperator, error) {
-	iopsString, iops, err := GenIOPFromProfile(profile, fy, setFlags, force, false, kubeConfig, l)
+	setFlags []string, force bool, client kube.Client, l clog.Logger) (string, *iopv1alpha1.IstioOperator, error) {
+	iopsString, iops, err := GenIOPFromProfile(profile, fy, setFlags, force, false, client, l)
 	if err != nil {
 		return "", nil, err
 	}
@@ -125,7 +122,7 @@ func OverlayYAMLStrings(profile string, fy string,
 // GenIOPFromProfile generates an IstioOperator from the given profile name or path, and overlay YAMLs from user
 // files and the --set flag. If successful, it returns an IstioOperator string and struct.
 func GenIOPFromProfile(profileOrPath, fileOverlayYAML string, setFlags []string, skipValidation, allowUnknownField bool,
-	kubeConfig *rest.Config, l clog.Logger) (string, *iopv1alpha1.IstioOperator, error) {
+	client kube.Client, l clog.Logger) (string, *iopv1alpha1.IstioOperator, error) {
 	installPackagePath, err := getInstallPackagePath(fileOverlayYAML)
 	if err != nil {
 		return "", nil, err
@@ -155,8 +152,8 @@ func GenIOPFromProfile(profileOrPath, fileOverlayYAML string, setFlags []string,
 	}
 
 	// Merge k8s specific values.
-	if kubeConfig != nil {
-		kubeOverrides, err := getClusterSpecificValues(kubeConfig, skipValidation, l)
+	if client != nil {
+		kubeOverrides, err := getClusterSpecificValues(client, skipValidation, l)
 		if err != nil {
 			return "", nil, err
 		}
@@ -197,11 +194,7 @@ func GenIOPFromProfile(profileOrPath, fileOverlayYAML string, setFlags []string,
 	}
 
 	// Validate Final IOP config against K8s cluster
-	if kubeConfig != nil {
-		client, err := kubernetes.NewForConfig(kubeConfig)
-		if err != nil {
-			return "", nil, err
-		}
+	if client != nil {
 		err = util.ValidateIOPCAConfig(client, finalIOP)
 		if err != nil {
 			return "", nil, err
@@ -330,12 +323,8 @@ func GetProfile(iop *iopv1alpha1.IstioOperator) string {
 	return profile
 }
 
-func GetMergedIOP(userIOPStr, profile, manifestsPath, revision, kubeConfigPath, context string,
+func GetMergedIOP(userIOPStr, profile, manifestsPath, revision string, client kube.Client,
 	logger clog.Logger) (*iopv1alpha1.IstioOperator, error) {
-	restConfig, err := kube.BuildClientConfig(kubeConfigPath, context)
-	if err != nil {
-		return nil, err
-	}
 	extraFlags := make([]string, 0)
 	if manifestsPath != "" {
 		extraFlags = append(extraFlags, fmt.Sprintf("installPackagePath=%s", manifestsPath))
@@ -343,7 +332,7 @@ func GetMergedIOP(userIOPStr, profile, manifestsPath, revision, kubeConfigPath, 
 	if revision != "" {
 		extraFlags = append(extraFlags, fmt.Sprintf("revision=%s", revision))
 	}
-	_, mergedIOP, err := OverlayYAMLStrings(profile, userIOPStr, extraFlags, false, restConfig, logger)
+	_, mergedIOP, err := OverlayYAMLStrings(profile, userIOPStr, extraFlags, false, client, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -419,10 +408,10 @@ func overlayHubAndTag(yml string) (string, error) {
 	return out, nil
 }
 
-func getClusterSpecificValues(config *rest.Config, force bool, l clog.Logger) (string, error) {
+func getClusterSpecificValues(client kube.Client, force bool, l clog.Logger) (string, error) {
 	overlays := []string{}
 
-	fsgroup, err := getFSGroupOverlay(config)
+	fsgroup, err := getFSGroupOverlay(client)
 	if err != nil {
 		if force {
 			l.LogAndPrint(err)
@@ -432,7 +421,7 @@ func getClusterSpecificValues(config *rest.Config, force bool, l clog.Logger) (s
 	} else if fsgroup != "" {
 		overlays = append(overlays, fsgroup)
 	}
-	jwt, err := getJwtTypeOverlay(config, l)
+	jwt, err := getJwtTypeOverlay(client, l)
 	if err != nil {
 		if force {
 			l.LogAndPrint(err)
@@ -445,12 +434,8 @@ func getClusterSpecificValues(config *rest.Config, force bool, l clog.Logger) (s
 	return makeTreeFromSetList(overlays)
 }
 
-func getFSGroupOverlay(config *rest.Config) (string, error) {
-	version, err := k8sversion.GetKubernetesVersion(config)
-	if err != nil {
-		return "", fmt.Errorf("failed to determine JWT policy support. Use the --force flag to ignore this: %v", err)
-	}
-	if version >= 19 {
+func getFSGroupOverlay(config kube.Client) (string, error) {
+	if kube.IsAtLeastVersion(config, 19) {
 		return "values.pilot.env.ENABLE_LEGACY_FSGROUP_INJECTION=false", nil
 	}
 	return "", nil
@@ -489,11 +474,7 @@ func makeTreeFromSetList(setOverlay []string) (string, error) {
 	return tpath.AddSpecRoot(string(out))
 }
 
-func getJwtTypeOverlay(config *rest.Config, l clog.Logger) (string, error) {
-	client, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		return "", err
-	}
+func getJwtTypeOverlay(client kube.Client, l clog.Logger) (string, error) {
 	jwtPolicy, err := util.DetectSupportedJWTPolicy(client)
 	if err != nil {
 		return "", fmt.Errorf("failed to determine JWT policy support. Use the --force flag to ignore this: %v", err)

--- a/operator/pkg/manifest/shared.go
+++ b/operator/pkg/manifest/shared.go
@@ -411,14 +411,8 @@ func overlayHubAndTag(yml string) (string, error) {
 func getClusterSpecificValues(client kube.Client, force bool, l clog.Logger) (string, error) {
 	overlays := []string{}
 
-	fsgroup, err := getFSGroupOverlay(client)
-	if err != nil {
-		if force {
-			l.LogAndPrint(err)
-		} else {
-			return "", err
-		}
-	} else if fsgroup != "" {
+	fsgroup := getFSGroupOverlay(client)
+	if fsgroup != "" {
 		overlays = append(overlays, fsgroup)
 	}
 	jwt, err := getJwtTypeOverlay(client, l)
@@ -434,11 +428,11 @@ func getClusterSpecificValues(client kube.Client, force bool, l clog.Logger) (st
 	return makeTreeFromSetList(overlays)
 }
 
-func getFSGroupOverlay(config kube.Client) (string, error) {
+func getFSGroupOverlay(config kube.Client) string {
 	if kube.IsAtLeastVersion(config, 19) {
-		return "values.pilot.env.ENABLE_LEGACY_FSGROUP_INJECTION=false", nil
+		return "values.pilot.env.ENABLE_LEGACY_FSGROUP_INJECTION=false"
 	}
-	return "", nil
+	return ""
 }
 
 // makeTreeFromSetList creates a YAML tree from a string slice containing key-value pairs in the format key=value.

--- a/operator/pkg/util/k8s_test.go
+++ b/operator/pkg/util/k8s_test.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 
 	pkgAPI "istio.io/istio/operator/pkg/apis/istio/v1alpha1"
+	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/util/gogoprotomarshal"
 )
 
@@ -52,7 +53,6 @@ spec:
 
 func TestValidateIOPCAConfig(t *testing.T) {
 	var err error
-	k8sClient := fake.NewSimpleClientset()
 
 	tests := []struct {
 		major        string
@@ -87,6 +87,7 @@ func TestValidateIOPCAConfig(t *testing.T) {
 	}
 
 	for i, tt := range tests {
+		k8sClient := kube.NewFakeClient()
 		k8sClient.Discovery().(*fakediscovery.FakeDiscovery).FakedServerVersion = &version.Info{
 			Major: tt.major,
 			Minor: tt.minor,

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -80,6 +80,7 @@ import (
 	istioclient "istio.io/client-go/pkg/clientset/versioned"
 	istiofake "istio.io/client-go/pkg/clientset/versioned/fake"
 	istioinformer "istio.io/client-go/pkg/informers/externalversions"
+	"istio.io/istio/operator/pkg/apis"
 	"istio.io/istio/pkg/kube/mcs"
 	"istio.io/istio/pkg/queue"
 	"istio.io/pkg/version"
@@ -1066,5 +1067,6 @@ var IstioScheme = func() *runtime.Scheme {
 	utilruntime.Must(clienttelemetry.AddToScheme(scheme))
 	utilruntime.Must(clientextensions.AddToScheme(scheme))
 	utilruntime.Must(gatewayapi.AddToScheme(scheme))
+	utilruntime.Must(apis.AddToScheme(scheme))
 	return scheme
 }()

--- a/tests/fuzz/helm_reconciler_fuzzer.go
+++ b/tests/fuzz/helm_reconciler_fuzzer.go
@@ -53,7 +53,7 @@ func FuzzHelmReconciler(data []byte) int {
 		return 0
 	}
 	cl := &fakeClientWrapper{fake.NewClientBuilder().WithRuntimeObjects(obj).Build()}
-	h, err := helmreconciler.NewHelmReconciler(cl, nil, nil, nil, nil)
+	h, err := helmreconciler.NewHelmReconciler(cl, nil, nil, nil)
 	if err != nil {
 		return 0
 	}

--- a/tests/integration/operator/verify_test.go
+++ b/tests/integration/operator/verify_test.go
@@ -21,9 +21,9 @@ import (
 	"io"
 	"testing"
 
-	"istio.io/istio/istioctl/pkg/clioptions"
 	"istio.io/istio/istioctl/pkg/verifier"
 	"istio.io/istio/operator/pkg/util/clog"
+	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/istioctl"
 	"istio.io/istio/pkg/test/framework/image"
@@ -53,10 +53,8 @@ func TestPostInstallControlPlaneVerification(t *testing.T) {
 				"-y",
 			}
 			istioCtl.InvokeOrFail(t, installCmd)
-
 			tfLogger := clog.NewConsoleLogger(io.Discard, io.Discard, scopes.Framework)
-			statusVerifier := verifier.NewStatusVerifier(IstioNamespace, ManifestPath, "",
-				"", []string{}, clioptions.ControlPlaneOptions{}, tfLogger, nil)
+			statusVerifier := verifier.NewTestStatusVerifier(IstioNamespace, ManifestPath, kube.NewFakeClient(), tfLogger)
 			if err := statusVerifier.Verify(); err != nil {
 				t.Fatal(err)
 			}

--- a/tests/integration/operator/verify_test.go
+++ b/tests/integration/operator/verify_test.go
@@ -21,9 +21,9 @@ import (
 	"io"
 	"testing"
 
+	"istio.io/istio/istioctl/pkg/clioptions"
 	"istio.io/istio/istioctl/pkg/verifier"
 	"istio.io/istio/operator/pkg/util/clog"
-	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/istioctl"
 	"istio.io/istio/pkg/test/framework/image"
@@ -54,7 +54,11 @@ func TestPostInstallControlPlaneVerification(t *testing.T) {
 			}
 			istioCtl.InvokeOrFail(t, installCmd)
 			tfLogger := clog.NewConsoleLogger(io.Discard, io.Discard, scopes.Framework)
-			statusVerifier := verifier.NewTestStatusVerifier(IstioNamespace, ManifestPath, kube.NewFakeClient(), tfLogger)
+			statusVerifier, err := verifier.NewStatusVerifier(IstioNamespace, ManifestPath, "",
+				"", []string{}, clioptions.ControlPlaneOptions{}, tfLogger, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
 			if err := statusVerifier.Verify(); err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
Currently we create a TON of clients, and call a ton of things
redundantly. This consolodates the code so we use a single shared client
(almost?) everywhere.

Before: 180 GET calls to api server for `istioctl install`
After: 40 GET calls

**Please provide a description of this PR:**