### PR TITLE
Add --force flag to istio-operator server command

### DIFF
--- a/operator/cmd/operator/server.go
+++ b/operator/cmd/operator/server.go
@@ -29,6 +29,7 @@ import (
 	root "istio.io/istio/operator/cmd/mesh"
 	"istio.io/istio/operator/pkg/apis"
 	"istio.io/istio/operator/pkg/controller"
+	"istio.io/istio/operator/pkg/controller/istiocontrolplane"
 	"istio.io/istio/operator/pkg/metrics"
 	"istio.io/pkg/ctrlz"
 	"istio.io/pkg/log"
@@ -195,7 +196,8 @@ func run(sArgs *serverArgs) {
 	}
 
 	// Setup all Controllers
-	if err := controller.AddToManager(mgr, sArgs.force); err != nil {
+	options := &istiocontrolplane.Options{Force: sArgs.force}
+	if err := controller.AddToManager(mgr, options); err != nil {
 		log.Fatalf("Could not add all controllers to operator manager: %v", err)
 	}
 

--- a/operator/cmd/operator/server.go
+++ b/operator/cmd/operator/server.go
@@ -26,6 +26,13 @@ import (
 	"go.opencensus.io/stats/view"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+
 	root "istio.io/istio/operator/cmd/mesh"
 	"istio.io/istio/operator/pkg/apis"
 	"istio.io/istio/operator/pkg/controller"
@@ -34,12 +41,6 @@ import (
 	"istio.io/pkg/ctrlz"
 	"istio.io/pkg/log"
 	"istio.io/pkg/version"
-	_ "k8s.io/client-go/plugin/pkg/client/auth"
-	"sigs.k8s.io/controller-runtime/pkg/cache"
-	"sigs.k8s.io/controller-runtime/pkg/client/config"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
-	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
-	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
 // Should match deploy/service.yaml

--- a/operator/pkg/controller/controller.go
+++ b/operator/pkg/controller/controller.go
@@ -21,6 +21,6 @@ import (
 )
 
 // AddToManager adds all Controllers to the Manager
-func AddToManager(m manager.Manager) error {
-	return istiocontrolplane.Add(m)
+func AddToManager(m manager.Manager, force bool) error {
+	return istiocontrolplane.Add(m, force)
 }

--- a/operator/pkg/controller/controller.go
+++ b/operator/pkg/controller/controller.go
@@ -15,12 +15,11 @@
 package controller
 
 import (
-	"sigs.k8s.io/controller-runtime/pkg/manager"
-
 	"istio.io/istio/operator/pkg/controller/istiocontrolplane"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 // AddToManager adds all Controllers to the Manager
-func AddToManager(m manager.Manager, force bool) error {
-	return istiocontrolplane.Add(m, force)
+func AddToManager(m manager.Manager, options *istiocontrolplane.Options) error {
+	return istiocontrolplane.Add(m, options)
 }

--- a/operator/pkg/controller/controller.go
+++ b/operator/pkg/controller/controller.go
@@ -15,8 +15,8 @@
 package controller
 
 import (
-	"istio.io/istio/operator/pkg/controller/istiocontrolplane"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"istio.io/istio/operator/pkg/controller/istiocontrolplane"
 )
 
 // AddToManager adds all Controllers to the Manager

--- a/operator/pkg/controller/controller.go
+++ b/operator/pkg/controller/controller.go
@@ -16,7 +16,7 @@ package controller
 
 import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-	
+
 	"istio.io/istio/operator/pkg/controller/istiocontrolplane"
 )
 

--- a/operator/pkg/controller/controller.go
+++ b/operator/pkg/controller/controller.go
@@ -16,6 +16,7 @@ package controller
 
 import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	
 	"istio.io/istio/operator/pkg/controller/istiocontrolplane"
 )
 

--- a/operator/pkg/controller/istiocontrolplane/istiocontrolplane_controller.go
+++ b/operator/pkg/controller/istiocontrolplane/istiocontrolplane_controller.go
@@ -69,6 +69,7 @@ const (
 var (
 	scope      = log.RegisterScope("installer", "installer", 0)
 	restConfig *rest.Config
+	force      bool
 )
 
 var (
@@ -338,7 +339,7 @@ func (r *ReconcileIstioOperator) Reconcile(_ context.Context, request reconcile.
 		scope.Errorf(errdict.OperatorFailedToConfigure, "failed to apply IstioOperator resources. Error %s", err)
 		return reconcile.Result{}, err
 	}
-	reconciler, err := helmreconciler.NewHelmReconciler(r.client, r.clientSet, r.config, iopMerged, nil)
+	reconciler, err := helmreconciler.NewHelmReconciler(r.client, r.clientSet, r.config, iopMerged, &helmreconciler.Options{Force: force})
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -416,8 +417,9 @@ func mergeIOPSWithProfile(iop *iopv1alpha1.IstioOperator) (*v1alpha1.IstioOperat
 }
 
 // Add creates a new IstioOperator Controller and adds it to the Manager. The Manager will set fields on the Controller
-// and Start it when the Manager is Started.
-func Add(mgr manager.Manager) error {
+// and Start it when the Manager is Started. Additionally, forceFlag is used to ignore validation failures in helmreconciler
+func Add(mgr manager.Manager, forceFlag bool) error {
+	force = forceFlag
 	restConfig = mgr.GetConfig()
 	return add(mgr, &ReconcileIstioOperator{client: mgr.GetClient(), scheme: mgr.GetScheme(), config: mgr.GetConfig()})
 }

--- a/operator/pkg/controller/istiocontrolplane/istiocontrolplane_controller.go
+++ b/operator/pkg/controller/istiocontrolplane/istiocontrolplane_controller.go
@@ -52,6 +52,8 @@ import (
 	"istio.io/istio/operator/pkg/tpath"
 	"istio.io/istio/operator/pkg/translate"
 	"istio.io/istio/operator/pkg/util"
+	"istio.io/istio/operator/pkg/util/clog"
+	"istio.io/istio/operator/pkg/util/progress"
 	"istio.io/istio/pkg/errdict"
 	"istio.io/istio/pkg/url"
 	"istio.io/pkg/log"
@@ -69,8 +71,11 @@ const (
 var (
 	scope      = log.RegisterScope("installer", "installer", 0)
 	restConfig *rest.Config
-	force      bool
 )
+
+type Options struct {
+	Force bool
+}
 
 var (
 	// watchedResources contains all resources we will watch and reconcile when changed
@@ -184,6 +189,7 @@ type ReconcileIstioOperator struct {
 	clientSet kubernetes.Interface
 	config    *rest.Config
 	scheme    *runtime.Scheme
+	options   *Options
 }
 
 // Reconcile reads that state of the cluster for a IstioOperator object and makes changes based on the state read
@@ -339,7 +345,14 @@ func (r *ReconcileIstioOperator) Reconcile(_ context.Context, request reconcile.
 		scope.Errorf(errdict.OperatorFailedToConfigure, "failed to apply IstioOperator resources. Error %s", err)
 		return reconcile.Result{}, err
 	}
-	reconciler, err := helmreconciler.NewHelmReconciler(r.client, r.clientSet, r.config, iopMerged, &helmreconciler.Options{Force: force})
+	helmReconcilerOptions := &helmreconciler.Options{
+		Log:         clog.NewDefaultLogger(),
+		ProgressLog: progress.NewLog(),
+	}
+	if r.options != nil {
+		helmReconcilerOptions.Force = r.options.Force
+	}
+	reconciler, err := helmreconciler.NewHelmReconciler(r.client, r.clientSet, r.config, iopMerged, helmReconcilerOptions)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -417,11 +430,10 @@ func mergeIOPSWithProfile(iop *iopv1alpha1.IstioOperator) (*v1alpha1.IstioOperat
 }
 
 // Add creates a new IstioOperator Controller and adds it to the Manager. The Manager will set fields on the Controller
-// and Start it when the Manager is Started. Additionally, forceFlag is used to ignore validation failures in helmreconciler
-func Add(mgr manager.Manager, forceFlag bool) error {
-	force = forceFlag
+// and Start it when the Manager is Started. It also provides additional options to modify internal reconciler behavior.
+func Add(mgr manager.Manager, options *Options) error {
 	restConfig = mgr.GetConfig()
-	return add(mgr, &ReconcileIstioOperator{client: mgr.GetClient(), scheme: mgr.GetScheme(), config: mgr.GetConfig()})
+	return add(mgr, &ReconcileIstioOperator{client: mgr.GetClient(), scheme: mgr.GetScheme(), config: mgr.GetConfig(), options: options})
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler


### PR DESCRIPTION
**Please provide a description of this PR:**

- After adding a test in this PR  https://github.com/istio/istio/pull/35107 , based on discussion from this thread https://github.com/istio/istio/issues/33537#issuecomment-897571950, we realized that when istio-operator is started with `./operator server` command, there is no way for us to pass `--force` flag.
- This PR adds the ability to enable `--force` for operator server as well. `--force` is already supported in `istioctl` command.
- The flag is passed down to `helmreconciler` so that we can use it to skip webhook analysis check.


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [x] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.



