### PR TITLE
fixed logic bug in --include option for issue#36317

### DIFF
--- a/pkg/config/analysis/analyzers/util/config.go
+++ b/pkg/config/analysis/analyzers/util/config.go
@@ -15,6 +15,8 @@
 package util
 
 import (
+	"strings"
+
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/resource"
 )
@@ -57,6 +59,15 @@ func IsIncluded(slice []string, term string) bool {
 		if val == term {
 			return true
 		}
+	}
+	return false
+}
+
+// IsMatched check if the term can be matched in a slice of string
+func IsMatched(slice []string, term string) bool {
+	for _, val := range slice {
+		matched := strings.Contains(term, val)
+		return matched
 	}
 	return false
 }

--- a/tools/bug-report/pkg/bugreport/bugreport.go
+++ b/tools/bug-report/pkg/bugreport/bugreport.go
@@ -132,7 +132,13 @@ func runBugReportCommand(_ *cobra.Command, logOpts *log.Options) error {
 	}
 	common.LogAndPrintf("\nCluster endpoint: %s\n", client.RESTConfig().Host)
 
-	resources, err := cluster2.GetClusterResources(context.Background(), clientset)
+	clusterResourcesCtx, getClusterResourcesCancel := context.WithTimeout(context.Background(), bugReportDefaultTimeout)
+	defer func() {
+		message := "Timeout when get cluster resources, please using --include or --exclude to filter"
+		common.LogAndPrintf(message)
+		getClusterResourcesCancel()
+	}()
+	resources, err := cluster2.GetClusterResources(clusterResourcesCtx, clientset, config)
 	if err != nil {
 		return err
 	}

--- a/tools/bug-report/pkg/cluster/cluster_test.go
+++ b/tools/bug-report/pkg/cluster/cluster_test.go
@@ -1,0 +1,354 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cluster
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	config2 "istio.io/istio/tools/bug-report/pkg/config"
+)
+
+func TestShouldSkip(t *testing.T) {
+	cases := []struct {
+		name       string
+		pod        *v1.Pod
+		config     *config2.BugReportConfig
+		deployment string
+		expected   bool
+	}{
+		{
+			"tested namespace not skip",
+			&v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "in-namespace1",
+				},
+			},
+			&config2.BugReportConfig{
+				Include: []*config2.SelectionSpec{
+					{
+						Namespaces: []string{"in-"},
+					},
+				},
+				Exclude: []*config2.SelectionSpec{
+					{
+						Namespaces: []string{"ex-"},
+					},
+				},
+			},
+			"*",
+			false,
+		},
+		{
+			"tested namespace skip",
+			&v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ex-namespace1",
+				},
+			},
+			&config2.BugReportConfig{
+				Include: []*config2.SelectionSpec{
+					{
+						Namespaces: []string{"in-"},
+					},
+				},
+				Exclude: []*config2.SelectionSpec{
+					{
+						Namespaces: []string{"ex-"},
+					},
+				},
+			},
+			"*",
+			true,
+		},
+		{
+			"tested pod name not skip",
+			&v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "in-pod1",
+				},
+			},
+			&config2.BugReportConfig{
+				Include: []*config2.SelectionSpec{
+					{
+						Pods: []string{"in-"},
+					},
+				},
+				Exclude: []*config2.SelectionSpec{
+					{
+						Pods: []string{"ex-"},
+					},
+				},
+			},
+			"*",
+			false,
+		},
+		{
+			"tested pod name skip",
+			&v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ex-pod1",
+				},
+			},
+			&config2.BugReportConfig{
+				Include: []*config2.SelectionSpec{
+					{
+						Pods: []string{"in-"},
+					},
+				},
+				Exclude: []*config2.SelectionSpec{
+					{
+						Pods: []string{"ex-"},
+					},
+				},
+			},
+			"*",
+			true,
+		},
+		{
+			"tested deployment not skip",
+			&v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "in-test1",
+				},
+			},
+			&config2.BugReportConfig{
+				Include: []*config2.SelectionSpec{
+					{
+						Deployments: []string{"in-"},
+					},
+				},
+				Exclude: []*config2.SelectionSpec{
+					{
+						Deployments: []string{"ex-"},
+					},
+				},
+			},
+			"in-dep1",
+			false,
+		},
+		{
+			"tested deployment skip",
+			&v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "in-test1",
+				},
+			},
+			&config2.BugReportConfig{
+				Include: []*config2.SelectionSpec{
+					{
+						Pods:        []string{"in-"},
+						Deployments: []string{"in-"},
+					},
+				},
+				Exclude: []*config2.SelectionSpec{
+					{
+						Pods:        []string{"ex-"},
+						Deployments: []string{"ex-"},
+					},
+				},
+			},
+			"ex-dep1",
+			true,
+		},
+		{
+			"tested container not skip",
+			&v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "in-test1",
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name: "in-con1",
+						},
+					},
+				},
+			},
+			&config2.BugReportConfig{
+				Include: []*config2.SelectionSpec{
+					{
+						Pods:       []string{"in-"},
+						Containers: []string{"in-"},
+					},
+				},
+				Exclude: []*config2.SelectionSpec{
+					{
+						Pods:       []string{"ex-"},
+						Containers: []string{"ex-"},
+					},
+				},
+			},
+			"*",
+			false,
+		},
+		{
+			"tested container skip",
+			&v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "in-test1",
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name: "ex-con1",
+						},
+					},
+				},
+			},
+			&config2.BugReportConfig{
+				Include: []*config2.SelectionSpec{
+					{
+						Pods:       []string{"in-"},
+						Containers: []string{"in-"},
+					},
+				},
+				Exclude: []*config2.SelectionSpec{
+					{
+						Pods:       []string{"ex-"},
+						Containers: []string{"ex-"},
+					},
+				},
+			},
+			"*",
+			true,
+		},
+		{
+			"tested label not skip",
+			&v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "in-test1",
+					Labels: map[string]string{
+						"l1": "lv1",
+						"l2": "lv2",
+					},
+					Annotations: map[string]string{
+						"a1": "av1",
+						"a2": "av1",
+					},
+				},
+			},
+			&config2.BugReportConfig{
+				Include: []*config2.SelectionSpec{
+					{
+						Pods: []string{"in-"},
+						Labels: map[string]string{
+							"l1": "lv1",
+							"l2": "lv2",
+						},
+					},
+				},
+			},
+			"*",
+			false,
+		},
+		{
+			"tested label skip",
+			&v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "in-test1",
+					Labels: map[string]string{
+						"l1": "lv1",
+					},
+					Annotations: map[string]string{
+						"a1": "av1",
+						"a2": "av1",
+					},
+				},
+			},
+			&config2.BugReportConfig{
+				Include: []*config2.SelectionSpec{
+					{
+						Pods: []string{"in-"},
+						Labels: map[string]string{
+							"l1": "lv1",
+							"l2": "lv2",
+						},
+					},
+				},
+			},
+			"*",
+			true,
+		},
+		{
+			"tested annotation not skip",
+			&v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "in-test1",
+					Labels: map[string]string{
+						"l3": "lv3",
+						"l4": "lv4",
+					},
+					Annotations: map[string]string{
+						"a3": "av3",
+						"a4": "av4",
+					},
+				},
+			},
+			&config2.BugReportConfig{
+				Include: []*config2.SelectionSpec{
+					{
+						Pods: []string{"in-"},
+						Annotations: map[string]string{
+							"a3": "av3",
+							"a4": "av4",
+						},
+					},
+				},
+			},
+			"*",
+			false,
+		},
+		{
+			"tested annotation skip",
+			&v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "in-test1",
+					Labels: map[string]string{
+						"l3": "lv3",
+						"l4": "lv4",
+					},
+					Annotations: map[string]string{
+						"a3": "av3",
+					},
+				},
+			},
+			&config2.BugReportConfig{
+				Include: []*config2.SelectionSpec{
+					{
+						Pods: []string{"in-"},
+						Annotations: map[string]string{
+							"a3": "av3",
+							"a4": "av4",
+						},
+					},
+				},
+			},
+			"*",
+			true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			skip := shouldSkip(c.deployment, c.config, c.pod)
+			if skip != c.expected {
+				t.Errorf("shouldSkip() for test case name [%s] return= %v, want %v", c.name, skip, c.expected)
+			}
+		})
+	}
+}

--- a/tools/bug-report/pkg/config/config.go
+++ b/tools/bug-report/pkg/config/config.go
@@ -21,8 +21,17 @@ import (
 	"math"
 	"strings"
 	"time"
+)
 
-	cluster2 "istio.io/istio/tools/bug-report/pkg/cluster"
+type ResourceType int
+
+const (
+	Namespace ResourceType = iota
+	Deployment
+	Pod
+	Label
+	Annotation
+	Container
 )
 
 // SelectionSpec is a spec for pods that will be Include in the capture
@@ -210,28 +219,28 @@ func parseToIncludeTypeMap(s string) (map[string]string, error) {
 }
 
 func (s *SelectionSpec) UnmarshalJSON(b []byte) error {
-	ft := []cluster2.ResourceType{cluster2.Namespace, cluster2.Deployment, cluster2.Pod, cluster2.Label, cluster2.Annotation, cluster2.Container}
+	ft := []ResourceType{Namespace, Deployment, Pod, Label, Annotation, Container}
 	str := strings.TrimPrefix(strings.TrimSuffix(string(b), `"`), `"`)
 	for i, f := range strings.Split(str, "/") {
 		var err error
 		switch ft[i] {
-		case cluster2.Namespace:
+		case Namespace:
 			s.Namespaces = parseToIncludeTypeSlice(f)
-		case cluster2.Deployment:
+		case Deployment:
 			s.Deployments = parseToIncludeTypeSlice(f)
-		case cluster2.Pod:
+		case Pod:
 			s.Pods = parseToIncludeTypeSlice(f)
-		case cluster2.Label:
+		case Label:
 			s.Labels, err = parseToIncludeTypeMap(f)
 			if err != nil {
 				return err
 			}
-		case cluster2.Annotation:
+		case Annotation:
 			s.Annotations, err = parseToIncludeTypeMap(f)
 			if err != nil {
 				return err
 			}
-		case cluster2.Container:
+		case Container:
 			s.Containers = parseToIncludeTypeSlice(f)
 		}
 	}


### PR DESCRIPTION
**Please provide a description of this PR:**
Fixed logic bug in --include option for issue#36317.
This issue relates to that golang map is nondeterministic as @howardjohn mentioned in issue #36317. And the root cause is really that wrong flag setting for label and annotation maps. 
Moreover, I paste the different below:

```
@@ -124,13 +124,12 @@ func shouldSkip(deployment string, config *config2.BugReportConfig, pod *corev1.
                        }
 
                        if len(ild.Labels) > 0 {
-                               isLabelsMatch := false
+                               isLabelsMatch := true
                                for kLabel, vLable := range ild.Labels {
                                        if evLable, exists := pod.Labels[kLabel]; exists {
                                                if vLable != evLable {
                                                        isLabelsMatch = false
-                                               } else {
-                                                       isLabelsMatch = true
+                                                       break
                                                }
                                                // need to match, but no such label
                                        } else {
@@ -143,13 +142,12 @@ func shouldSkip(deployment string, config *config2.BugReportConfig, pod *corev1.
                        }
 
                        if len(ild.Annotations) > 0 {
-                               isAnnotationMatch := false
+                               isAnnotationMatch := true
                                for kAnnotation, vAnnotation := range ild.Annotations {
                                        if evAnnotation, exists := pod.Annotations[kAnnotation]; exists {
                                                if vAnnotation != evAnnotation {
                                                        isAnnotationMatch = false
-                                               } else {
-                                                       isAnnotationMatch = true
+                                                       break
                                                }
                                                // need to match, but no such annotation
                                        } else {
```