### PR TITLE
Specify a default metrics format

### DIFF
--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -467,6 +467,9 @@ func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 			metrics.AppScrapeErrors.Increment()
 		}
 		format = negotiateMetricsFormat(contentType)
+	} else {
+		// Without app metrics format use a default
+		format = expfmt.FmtText
 	}
 
 	if agent, err = scrapeAgentMetrics(); err != nil {


### PR DESCRIPTION
This fixes an issue where a blank Content-Type header would
be returned in cases where application metrics were disabled 
as would be the case pilot-agent is running as a gateway.

This addresses https://github.com/istio/istio/issues/3633