### PR TITLE
Update build with local envoy

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -159,22 +159,6 @@ export ISTIO_ENVOY_MACOS_RELEASE_DIR ?= ${TARGET_OUT}/release
 export ISTIO_ENVOY_MACOS_RELEASE_NAME ?= envoy-${ISTIO_ENVOY_MACOS_VERSION}
 export ISTIO_ENVOY_MACOS_RELEASE_PATH ?= ${ISTIO_ENVOY_MACOS_RELEASE_DIR}/${ISTIO_ENVOY_MACOS_RELEASE_NAME}
 
-# Allow user-override for a local Envoy build.
-export USE_LOCAL_PROXY ?= 0
-ifeq ($(USE_LOCAL_PROXY),1)
-  export ISTIO_ENVOY_LOCAL ?= $(realpath ${ISTIO_GO}/../proxy/bazel-bin/src/envoy/envoy)
-  # Point the native paths to the local envoy build.
-  ifeq ($(GOOS_LOCAL), Darwin)
-    export ISTIO_ENVOY_MACOS_RELEASE_DIR = $(dir ${ISTIO_ENVOY_LOCAL})
-    export ISTIO_ENVOY_MACOS_RELEASE_PATH = ${ISTIO_ENVOY_LOCAL}
-  else
-    export ISTIO_ENVOY_LINUX_DEBUG_DIR = $(dir ${ISTIO_ENVOY_LOCAL})
-    export ISTIO_ENVOY_LINUX_RELEASE_DIR = $(dir ${ISTIO_ENVOY_LOCAL})
-    export ISTIO_ENVOY_LINUX_DEBUG_PATH = ${ISTIO_ENVOY_LOCAL}
-    export ISTIO_ENVOY_LINUX_RELEASE_PATH = ${ISTIO_ENVOY_LOCAL}
-  endif
-endif
-
 # Allow user-override envoy bootstrap config path.
 export ISTIO_ENVOY_BOOTSTRAP_CONFIG_PATH ?= ${ISTIO_GO}/tools/packaging/common/envoy_bootstrap.json
 export ISTIO_ENVOY_BOOTSTRAP_CONFIG_DIR = $(dir ${ISTIO_ENVOY_BOOTSTRAP_CONFIG_PATH})

--- a/tools/istio-docker.mk
+++ b/tools/istio-docker.mk
@@ -68,16 +68,14 @@ $(foreach FILE,$(DOCKER_FILES_FROM_SOURCE), \
 # BUILD_ARGS tells  $(DOCKER_RULE) to execute a docker build with the specified commands
 
 # The file must be named 'envoy', depends on the release.
-${ISTIO_ENVOY_LINUX_RELEASE_DIR}/${SIDECAR}: ${ISTIO_ENVOY_LINUX_RELEASE_PATH}
+${ISTIO_ENVOY_LINUX_RELEASE_DIR}/${SIDECAR}: ${ISTIO_ENVOY_LINUX_RELEASE_PATH} ${ISTIO_ENVOY_LOCAL}
 	mkdir -p $(DOCKER_BUILD_TOP)/proxyv2
-
 ifdef ISTIO_ENVOY_LOCAL
 	# Replace the downloaded envoy with a local Envoy for proxy container build.
 	# This will require addtional volume mount if build runs in container using `CONDITIONAL_HOST_MOUNTS`.
 	# e.g. CONDITIONAL_HOST_MOUNTS="--mount type=bind,source=<path-to-envoy>,destination=/envoy ISTIO_ENVOY_LOCAL=/envoy"
 	cp ${ISTIO_ENVOY_LOCAL} ${ISTIO_ENVOY_LINUX_RELEASE_DIR}/${SIDECAR}
 endif
-
 ifdef DEBUG_IMAGE
 	cp ${ISTIO_ENVOY_LINUX_DEBUG_PATH} ${ISTIO_ENVOY_LINUX_RELEASE_DIR}/${SIDECAR}
 else

--- a/tools/istio-docker.mk
+++ b/tools/istio-docker.mk
@@ -70,14 +70,13 @@ $(foreach FILE,$(DOCKER_FILES_FROM_SOURCE), \
 # The file must be named 'envoy', depends on the release.
 ${ISTIO_ENVOY_LINUX_RELEASE_DIR}/${SIDECAR}: ${ISTIO_ENVOY_LINUX_RELEASE_PATH} ${ISTIO_ENVOY_LOCAL}
 	mkdir -p $(DOCKER_BUILD_TOP)/proxyv2
-ifdef ISTIO_ENVOY_LOCAL
+ifdef DEBUG_IMAGE
+	cp ${ISTIO_ENVOY_LINUX_DEBUG_PATH} ${ISTIO_ENVOY_LINUX_RELEASE_DIR}/${SIDECAR}
+else ifdef ISTIO_ENVOY_LOCAL
 	# Replace the downloaded envoy with a local Envoy for proxy container build.
 	# This will require addtional volume mount if build runs in container using `CONDITIONAL_HOST_MOUNTS`.
 	# e.g. CONDITIONAL_HOST_MOUNTS="--mount type=bind,source=<path-to-envoy>,destination=/envoy ISTIO_ENVOY_LOCAL=/envoy"
 	cp ${ISTIO_ENVOY_LOCAL} ${ISTIO_ENVOY_LINUX_RELEASE_DIR}/${SIDECAR}
-endif
-ifdef DEBUG_IMAGE
-	cp ${ISTIO_ENVOY_LINUX_DEBUG_PATH} ${ISTIO_ENVOY_LINUX_RELEASE_DIR}/${SIDECAR}
 else
 	cp ${ISTIO_ENVOY_LINUX_RELEASE_PATH} ${ISTIO_ENVOY_LINUX_RELEASE_DIR}/${SIDECAR}
 endif

--- a/tools/istio-docker.mk
+++ b/tools/istio-docker.mk
@@ -70,6 +70,14 @@ $(foreach FILE,$(DOCKER_FILES_FROM_SOURCE), \
 # The file must be named 'envoy', depends on the release.
 ${ISTIO_ENVOY_LINUX_RELEASE_DIR}/${SIDECAR}: ${ISTIO_ENVOY_LINUX_RELEASE_PATH}
 	mkdir -p $(DOCKER_BUILD_TOP)/proxyv2
+
+ifdef ISTIO_ENVOY_LOCAL
+	# Replace the downloaded envoy with a local Envoy for proxy container build.
+	# This will require addtional volume mount if build runs in container using `CONDITIONAL_HOST_MOUNTS`.
+	# e.g. CONDITIONAL_HOST_MOUNTS="--mount type=bind,source=<path-to-envoy>,destination=/envoy ISTIO_ENVOY_LOCAL=/envoy"
+	cp ${ISTIO_ENVOY_LOCAL} ${ISTIO_ENVOY_LINUX_RELEASE_DIR}/${SIDECAR}
+endif
+
 ifdef DEBUG_IMAGE
 	cp ${ISTIO_ENVOY_LINUX_DEBUG_PATH} ${ISTIO_ENVOY_LINUX_RELEASE_DIR}/${SIDECAR}
 else


### PR DESCRIPTION
Current USE_LOCAL_PROXY option does not work. This change removes existing options, and rework it to replace envoy binary at docker build time.