### PR TITLE
add env var for platform and fix aws

### DIFF
--- a/pkg/bootstrap/platform/aws.go
+++ b/pkg/bootstrap/platform/aws.go
@@ -15,6 +15,8 @@
 package platform
 
 import (
+	"errors"
+	"io/fs"
 	"os"
 	"strings"
 
@@ -22,6 +24,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	"istio.io/pkg/log"
 )
 
 const (
@@ -36,11 +39,14 @@ func IsAWS() bool {
 	if !systemInfoSuggestsAWS() {
 		// fail-fast for local cases
 		// WARN: this may lead to some cases of false negatives.
+		log.Debug("system info suggests this is not an AWS environment")
 		return false
 	}
 
 	if client := getEC2MetadataClient(); client != nil {
-		return client.Available()
+		available := client.Available()
+		log.Debugf("EC2Metadata client available :%v", available)
+		return available
 	}
 	return false
 }
@@ -118,16 +124,24 @@ func getEC2MetadataClient() *ec2metadata.EC2Metadata {
 // Note: avoided importing the satellite package directly to reduce number of
 // dependencies, etc., required.
 func systemInfoSuggestsAWS() bool {
-	hypervisorUUIDBytes, _ := os.ReadFile("/sys/hypervisor/uuid")
+	hypervisorUUIDBytes, uerr := os.ReadFile("/sys/hypervisor/uuid")
 	hypervisorUUID := strings.ToLower(string(hypervisorUUIDBytes))
 
-	productUUIDBytes, _ := os.ReadFile("/sys/class/dmi/id/product_uuid")
+	productUUIDBytes, perr := os.ReadFile("/sys/class/dmi/id/product_uuid")
 	productUUID := strings.ToLower(string(productUUIDBytes))
 
 	hasEC2Prefix := strings.HasPrefix(hypervisorUUID, "ec2") || strings.HasPrefix(productUUID, "ec2")
 
-	version, _ := os.ReadFile("/sys/class/dmi/id/product_version")
+	version, verr := os.ReadFile("/sys/class/dmi/id/product_version")
 	hasAmazonProductVersion := strings.Contains(string(version), "amazon")
 
-	return hasEC2Prefix || hasAmazonProductVersion
+	// If the error is a permission error, treat it as AWS as the files exist but user does not have
+	// permissions - we can try with EC2 metadata client instead of totally failing with false positive.
+	hasPermissionError := isPermissionError(uerr) || isPermissionError(perr) || isPermissionError(verr)
+
+	return hasPermissionError || hasEC2Prefix || hasAmazonProductVersion
+}
+
+func isPermissionError(err error) bool {
+	return !errors.Is(err, fs.ErrNotExist) && errors.Is(err, fs.ErrPermission)
 }

--- a/pkg/bootstrap/platform/aws.go
+++ b/pkg/bootstrap/platform/aws.go
@@ -46,7 +46,7 @@ func IsAWS() bool {
 
 	if client := getEC2MetadataClient(); client != nil {
 		available := client.Available()
-		log.Debugf("EC2Metadata client available :%v", available)
+		log.Debugf("EC2Metadata client available: %v", available)
 		return available
 	}
 	return false

--- a/pkg/bootstrap/platform/aws.go
+++ b/pkg/bootstrap/platform/aws.go
@@ -24,6 +24,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+
 	"istio.io/pkg/log"
 )
 

--- a/pkg/bootstrap/platform/discovery.go
+++ b/pkg/bootstrap/platform/discovery.go
@@ -15,6 +15,7 @@
 package platform
 
 import (
+	"strings"
 	"sync"
 	"time"
 
@@ -27,15 +28,15 @@ const (
 	numPlatforms   = 3
 )
 
-var CloudPlatform = env.RegisterStringVar("CLOUD_PLATFORM", "", "Clound Platformn on which proxy is running, if not specified,"+
-	"Istio will try to discover the platform. Valid platform vaulues aws,azure,gcp.").Get()
+var CloudPlatform = env.RegisterStringVar("CLOUD_PLATFORM", "", "Clound Platform on which proxy is running, if not specified,"+
+	"Istio will try to discover the platform. Valid platform values aws,azure,gcp.").Get()
 
 // Discover attempts to discover the host platform, defaulting to
 // `Unknown` if a platform cannot be discovered.
 func Discover() Environment {
 	// First check if user has specified platform - use it if provided.
 	if len(CloudPlatform) > 0 {
-		switch CloudPlatform {
+		switch strings.ToLower(CloudPlatform) {
 		case "aws":
 			return NewAWS()
 		case "azure":
@@ -59,7 +60,7 @@ func DiscoverWithTimeout(timeout time.Duration) Environment {
 
 	go func() {
 		if IsGCP() {
-			log.Info("platform detected is Azure")
+			log.Info("platform detected is GCP")
 			plat <- NewGCP()
 		}
 		wg.Done()
@@ -67,7 +68,7 @@ func DiscoverWithTimeout(timeout time.Duration) Environment {
 
 	go func() {
 		if IsAWS() {
-			log.Info("platform detected is Aws")
+			log.Info("platform detected is AWS")
 			plat <- NewAWS()
 		}
 		wg.Done()

--- a/pkg/bootstrap/platform/discovery.go
+++ b/pkg/bootstrap/platform/discovery.go
@@ -29,7 +29,7 @@ const (
 )
 
 var CloudPlatform = env.RegisterStringVar("CLOUD_PLATFORM", "", "Clound Platform on which proxy is running, if not specified,"+
-	"Istio will try to discover the platform. Valid platform values aws,azure,gcp.").Get()
+	"Istio will try to discover the platform. Valid platform values aws,azure,gcp,none.").Get()
 
 // Discover attempts to discover the host platform, defaulting to
 // `Unknown` if a platform cannot be discovered.
@@ -43,6 +43,8 @@ func Discover() Environment {
 			return NewAzure()
 		case "gcp":
 			return NewGCP()
+		case "none":
+			return &Unknown{}
 		}
 	}
 	// Discover the platform if user has not specified.

--- a/pkg/bootstrap/platform/platform.go
+++ b/pkg/bootstrap/platform/platform.go
@@ -22,6 +22,9 @@ const (
 	KubernetesServiceHost = "KUBERNETES_SERVICE_HOST"
 )
 
+// Instance is an enumeration of all supported platforms.
+type Platform int
+
 // Environment provides information for the platform on which the bootstrapping
 // is taking place.
 type Environment interface {


### PR DESCRIPTION
This PR
- Adds env var support for specifying platform. So if user specifies a platform which he knows what platform is better, we do not have to discover and rely on user given value.
- Fixes AWS detection and treats permission error as AWS so that we can use metadata client rather than treating it as non AWS. This is needed for proxy running as  non root.

Fixes https://github.com/istio/istio/issues/32880

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
