### PR TITLE
remove unnecessary sort

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -17,7 +17,6 @@ package controller
 import (
 	"fmt"
 	"net"
-	"sort"
 	"sync"
 	"time"
 
@@ -877,7 +876,6 @@ func (c *Controller) Services() ([]*model.Service, error) {
 		out = append(out, svc)
 	}
 	c.RUnlock()
-	sort.Slice(out, func(i, j int) bool { return out[i].Hostname < out[j].Hostname })
 	return out, nil
 }
 

--- a/pilot/pkg/serviceregistry/serviceentry/servicediscovery.go
+++ b/pilot/pkg/serviceregistry/serviceentry/servicediscovery.go
@@ -134,7 +134,7 @@ func NewServiceDiscovery(
 			instancesByKey: map[types.NamespacedName]*model.WorkloadInstance{},
 		},
 		services: serviceStore{
-			servicesBySE: map[types.NamespacedName][]*model.Service{},
+			services: map[types.NamespacedName][]*model.Service{},
 		},
 		edsQueue:            queue.NewQueue(time.Second),
 		processServiceEntry: true,

--- a/pilot/pkg/serviceregistry/serviceentry/store.go
+++ b/pilot/pkg/serviceregistry/serviceentry/store.go
@@ -148,26 +148,26 @@ func (w *workloadInstancesStore) update(wi *model.WorkloadInstance) {
 // stores all the services converted from serviceEntries
 type serviceStore struct {
 	// services keeps track of all services - mainly used to return from Services() to avoid reconversion.
-	servicesBySE map[types.NamespacedName][]*model.Service
+	services map[types.NamespacedName][]*model.Service
 }
 
 func (s *serviceStore) getAllServices() []*model.Service {
 	var out []*model.Service
-	for _, svcs := range s.servicesBySE {
+	for _, svcs := range s.services {
 		out = append(out, svcs...)
 	}
 
-	return model.SortServicesByCreationTime(out)
+	return out
 }
 
 func (s *serviceStore) getServices(key types.NamespacedName) []*model.Service {
-	return s.servicesBySE[key]
+	return s.services[key]
 }
 
 func (s *serviceStore) deleteServices(key types.NamespacedName) {
-	delete(s.servicesBySE, key)
+	delete(s.services, key)
 }
 
 func (s *serviceStore) updateServices(key types.NamespacedName, services []*model.Service) {
-	s.servicesBySE[key] = services
+	s.services[key] = services
 }

--- a/pilot/pkg/serviceregistry/serviceentry/store_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/store_test.go
@@ -179,7 +179,7 @@ func TestWorkloadInstancesStore(t *testing.T) {
 
 func TestServiceStore(t *testing.T) {
 	store := serviceStore{
-		servicesBySE: map[types.NamespacedName][]*model.Service{},
+		services: map[types.NamespacedName][]*model.Service{},
 	}
 
 	expectedServices := []*model.Service{


### PR DESCRIPTION
These two sorts are not needed as we sort all service before processing in push_context

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
