### PR TITLE
Update gateway service to actually use service annotations

### DIFF
--- a/manifests/charts/gateway/templates/service.yaml
+++ b/manifests/charts/gateway/templates/service.yaml
@@ -10,7 +10,7 @@ metadata:
     topology.istio.io/network: "{{.}}"
     {{- end }}
   annotations:
-    {{- merge .Values.service.annotations .Values.annotations | toYaml | nindent 4 }}
+    {{- merge (deepCopy .Values.service.annotations) .Values.annotations | toYaml | nindent 4 }}
 spec:
 {{- with .Values.service.loadBalancerIP }}
   loadBalancerIP: "{{ . }}"

--- a/manifests/charts/gateway/templates/service.yaml
+++ b/manifests/charts/gateway/templates/service.yaml
@@ -10,7 +10,7 @@ metadata:
     topology.istio.io/network: "{{.}}"
     {{- end }}
   annotations:
-    {{- .Values.annotations | toYaml | nindent 4 }}
+    {{- merge .Values.service.annotations .Values.annotations | toYaml | nindent 4 }}
 spec:
 {{- with .Values.service.loadBalancerIP }}
   loadBalancerIP: "{{ . }}"


### PR DESCRIPTION
else the chart is barely usable in any public clouds