### PR TITLE
Fix env var schema in gateway

### DIFF
--- a/manifests/charts/gateway/values.schema.json
+++ b/manifests/charts/gateway/values.schema.json
@@ -39,7 +39,7 @@
       }
     },
     "env": {
-      "type": "array"
+      "type": "object"
     },
     "labels": {
       "type": "object"

--- a/manifests/charts/gateway/values.yaml
+++ b/manifests/charts/gateway/values.yaml
@@ -68,7 +68,7 @@ autoscaling:
   targetCPUUtilizationPercentage: 80
 
 # Pod environment variables
-env: []
+env: {}
 
 # Labels to apply to all resources
 labels: {}


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/36392

Used the map form for convenience with `--set env.foo=bar` vs dealing with a list, and as its fairly common in helm charts to use a map here.