### PR TITLE
Make status and xds status have the consistent "NOT_SENT"

### DIFF
--- a/istioctl/pkg/writer/pilot/status.go
+++ b/istioctl/pkg/writer/pilot/status.go
@@ -127,7 +127,7 @@ func statusPrintln(w io.Writer, status *writerStatus) error {
 
 func xdsStatus(sent, acked string) string {
 	if sent == "" {
-		return "NOT SENT"
+		return "NOT_SENT"
 	}
 	if sent == acked {
 		return "SYNCED"

--- a/istioctl/pkg/writer/pilot/testdata/multiStatusMultiPilot.txt
+++ b/istioctl/pkg/writer/pilot/testdata/multiStatusMultiPilot.txt
@@ -1,5 +1,4 @@
 NAME       CDS                            LDS          EDS                            RDS          ISTIOD      VERSION
-proxy1     STALE                          SYNCED       SYNCED                         NOT SENT     istiod1     1.1
+proxy1     STALE                          SYNCED       SYNCED                         NOT_SENT     istiod1     1.1
 proxy2     STALE                          SYNCED       STALE                          SYNCED       istiod2     1.1
-proxy3     STALE (Never Acknowledged)     NOT SENT     STALE (Never Acknowledged)     SYNCED       istiod3     1.1
-
+proxy3     STALE (Never Acknowledged)     NOT_SENT     STALE (Never Acknowledged)     SYNCED       istiod3     1.1

--- a/istioctl/pkg/writer/pilot/testdata/multiStatusSinglePilot.txt
+++ b/istioctl/pkg/writer/pilot/testdata/multiStatusSinglePilot.txt
@@ -1,3 +1,3 @@
 NAME       CDS       LDS        EDS        RDS          ISTIOD      VERSION
-proxy1     STALE     SYNCED     SYNCED     NOT SENT     istiod1     1.1
+proxy1     STALE     SYNCED     SYNCED     NOT_SENT     istiod1     1.1
 proxy2     STALE     SYNCED     STALE      SYNCED       istiod1     1.1


### PR DESCRIPTION
**Please provide a description of this PR:**
To change the proxy status `NOT SENT` to consistent with the envoy [NOT_SENT](https://github.com/envoyproxy/go-control-plane/blob/c2a905638ae8c2245137c7749df5663ae2a90e28/envoy/service/status/v3/csds.pb.go#L66) .
Which will make something like `istioctl ps` and `istioctl x ps` have the same format.