### PR TITLE
[Optimize] reduce pilot memory in large degree

### DIFF
--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -311,6 +311,7 @@ type Proxy struct {
 
 // WatchedResource tracks an active DiscoveryRequest subscription.
 type WatchedResource struct {
+	sync.Mutex
 	// TypeUrl is copied from the DiscoveryRequest.TypeUrl that initiated watching this resource.
 	// nolint
 	TypeUrl string
@@ -336,6 +337,12 @@ type WatchedResource struct {
 
 	// LastSent tracks the time of the generated push, to determine the time it takes the client to ack.
 	LastSent time.Time
+}
+
+func (w *WatchedResource) GetResources() []string {
+	w.Lock()
+	defer w.Unlock()
+	return w.ResourceNames
 }
 
 var istioVersionRegexp = regexp.MustCompile(`^([1-9]+)\.([0-9]+)(\.([0-9]+))?`)

--- a/pilot/pkg/networking/grpcgen/grpcgen.go
+++ b/pilot/pkg/networking/grpcgen/grpcgen.go
@@ -57,11 +57,11 @@ func (g *GrpcConfigGenerator) Generate(proxy *model.Proxy, push *model.PushConte
 	w *model.WatchedResource, updates *model.PushRequest) (model.Resources, model.XdsLogDetails, error) {
 	switch w.TypeUrl {
 	case v3.ListenerType:
-		return g.BuildListeners(proxy, push, w.ResourceNames), model.DefaultXdsLogDetails, nil
+		return g.BuildListeners(proxy, push, w.GetResources()), model.DefaultXdsLogDetails, nil
 	case v3.ClusterType:
-		return g.BuildClusters(proxy, push, w.ResourceNames), model.DefaultXdsLogDetails, nil
+		return g.BuildClusters(proxy, push, w.GetResources()), model.DefaultXdsLogDetails, nil
 	case v3.RouteType:
-		return g.BuildHTTPRoutes(proxy, push, w.ResourceNames), model.DefaultXdsLogDetails, nil
+		return g.BuildHTTPRoutes(proxy, push, w.GetResources()), model.DefaultXdsLogDetails, nil
 	}
 
 	return nil, model.DefaultXdsLogDetails, nil

--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -211,7 +211,7 @@ func (s *DiscoveryServer) receive(con *Connection, identities []string) {
 func deepCopyNode(node *core.Node) *core.Node {
 	out := &core.Node{}
 	buffer, _ := protomarshal.Marshal(node)
-	_ = protomarshal.Unmarshal(buffer, node)
+	_ = protomarshal.Unmarshal(buffer, out)
 	return out
 }
 

--- a/pilot/pkg/xds/debug.go
+++ b/pilot/pkg/xds/debug.go
@@ -555,7 +555,7 @@ func (s *DiscoveryServer) adsz(w http.ResponseWriter, req *http.Request) {
 		}
 		c.proxy.RLock()
 		for k, wr := range c.proxy.WatchedResources {
-			r := wr.ResourceNames
+			r := wr.GetResources()
 			if r == nil {
 				r = []string{}
 			}

--- a/pilot/pkg/xds/debuggen.go
+++ b/pilot/pkg/xds/debuggen.go
@@ -88,13 +88,14 @@ func (dg *DebugGen) Generate(proxy *model.Proxy, push *model.PushContext, w *mod
 	updates *model.PushRequest) (model.Resources, model.XdsLogDetails, error) {
 	res := model.Resources{}
 	var buffer bytes.Buffer
-	if w.ResourceNames == nil {
+	resources := w.GetResources()
+	if resources == nil {
 		return res, model.DefaultXdsLogDetails, fmt.Errorf("debug type is required")
 	}
-	if len(w.ResourceNames) != 1 {
+	if len(resources) != 1 {
 		return res, model.DefaultXdsLogDetails, fmt.Errorf("only one debug request is allowed")
 	}
-	resourceName := w.ResourceNames[0]
+	resourceName := resources[0]
 	u, _ := url.Parse(resourceName)
 	debugType := u.Path
 	identity := proxy.VerifiedIdentity

--- a/pilot/pkg/xds/ecds.go
+++ b/pilot/pkg/xds/ecds.go
@@ -59,7 +59,7 @@ func (e *EcdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w 
 	if !ecdsNeedsPush(req) {
 		return nil, model.DefaultXdsLogDetails, nil
 	}
-	ec := e.Server.ConfigGenerator.BuildExtensionConfiguration(proxy, push, w.ResourceNames)
+	ec := e.Server.ConfigGenerator.BuildExtensionConfiguration(proxy, push, w.GetResources())
 	if ec == nil {
 		return nil, model.DefaultXdsLogDetails, nil
 	}

--- a/pilot/pkg/xds/eds.go
+++ b/pilot/pkg/xds/eds.go
@@ -393,7 +393,7 @@ func (eds *EdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w
 
 	cached := 0
 	regenerated := 0
-	for _, clusterName := range w.ResourceNames {
+	for _, clusterName := range w.GetResources() {
 		if edsUpdatedServices != nil {
 			_, _, hostname, _ := model.ParseSubsetKey(clusterName)
 			if _, ok := edsUpdatedServices[string(hostname)]; !ok {

--- a/pilot/pkg/xds/rds.go
+++ b/pilot/pkg/xds/rds.go
@@ -61,6 +61,6 @@ func (c RdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *m
 	if !rdsNeedsPush(req) {
 		return nil, model.DefaultXdsLogDetails, nil
 	}
-	resources, logDetails := c.Server.ConfigGenerator.BuildHTTPRoutes(proxy, req, w.ResourceNames)
+	resources, logDetails := c.Server.ConfigGenerator.BuildHTTPRoutes(proxy, req, w.GetResources())
 	return resources, logDetails, nil
 }

--- a/pilot/pkg/xds/sds.go
+++ b/pilot/pkg/xds/sds.go
@@ -118,7 +118,7 @@ func (s *SecretGen) Generate(proxy *model.Proxy, push *model.PushContext, w *mod
 	// Filter down to resources we can access. We do not return an error if they attempt to access a Secret
 	// they cannot; instead we just exclude it. This ensures that a single bad reference does not break the whole
 	// SDS flow. The pilotSDSCertificateErrors metric and logs handle visibility into invalid references.
-	resources := filterAuthorizedResources(s.parseResources(w.ResourceNames, proxy), proxy, proxyClusterSecrets)
+	resources := filterAuthorizedResources(s.parseResources(w.GetResources(), proxy), proxy, proxyClusterSecrets)
 
 	results := model.Resources{}
 	cached, regenerated := 0, 0


### PR DESCRIPTION
**Please provide a description of this PR:**


pre processing request in receive thread as the main stream thread can be stuck when pushing xds. This is obvious when doing large scale performance test with pilot-load.

 We created total 15000 pods and 2400 services in 150 namespaces. And we have three pilot instances which means we make xds connections per pilot 5000.

The memory usage of pilot-discovery comparison is updated with latest code :

|  | Before | After |
| ------ | ------ | ------ |
| Peek | 13.96GB|  11.7 GB |
| Stable | 7.56 GiB | 7.36 GiB |


