### PR TITLE
Fuzzing: Use NopTester

### DIFF
--- a/tests/fuzz/networking_core_v1alpha3_fuzzer.go
+++ b/tests/fuzz/networking_core_v1alpha3_fuzzer.go
@@ -177,7 +177,7 @@ func InternalFuzzbuildSidecarInboundListeners(data []byte) int {
 }
 
 func InternalFuzzbuildSidecarOutboundListeners(data []byte) int {
-	t := &testing.T{}
+	t := utils.NopTester{}
 	proxy := &model.Proxy{}
 	f := fuzz.NewConsumer(data)
 	to := TestOptions{}


### PR DESCRIPTION
**Please provide a description of this PR:**
Use the `utils.Noptester{}` instead of `&testing.T{}` in `InternalFuzzbuildSidecarOutboundListeners`