### PR TITLE
Fix bug-report always prints timeout, and has a fixed context cancel time

### DIFF
--- a/tools/bug-report/pkg/bugreport/bugreport.go
+++ b/tools/bug-report/pkg/bugreport/bugreport.go
@@ -132,10 +132,13 @@ func runBugReportCommand(_ *cobra.Command, logOpts *log.Options) error {
 	}
 	common.LogAndPrintf("\nCluster endpoint: %s\n", client.RESTConfig().Host)
 
-	clusterResourcesCtx, getClusterResourcesCancel := context.WithTimeout(context.Background(), bugReportDefaultTimeout)
+	clusterResourcesCtx, getClusterResourcesCancel := context.WithTimeout(context.Background(), commandTimeout)
+	curTime := time.Now()
 	defer func() {
 		message := "Timeout when get cluster resources, please using --include or --exclude to filter"
-		common.LogAndPrintf(message)
+		if time.Until(curTime.Add(commandTimeout)) < 0 {
+			common.LogAndPrintf(message)
+		}
 		getClusterResourcesCancel()
 	}()
 	resources, err := cluster2.GetClusterResources(clusterResourcesCtx, clientset, config)


### PR DESCRIPTION
**Please provide a description of this PR:**
After #36356 got merged, when executing `istioctl bug-report`, there will always be one line printed at the end of the bug-report like:

```
xxxxxxxxxxxx
Done.
Timeout when get cluster resources, please using --include or --exclude to filter
```

Added a condition check to prevent it always being printed.

Also, the cancel function should not use the fixed 30min timeout. Instead, it should use the flag value `--timeout` user passed in.