### PR TITLE
Fuzzing: Refactor misc fuzzers

### DIFF
--- a/tests/fuzz/oss_fuzz_build.sh
+++ b/tests/fuzz/oss_fuzz_build.sh
@@ -93,7 +93,6 @@ compile_go_fuzzer istio.io/istio/tests/fuzz FuzzCheckIstioOperatorSpec fuzz_chec
 compile_go_fuzzer istio.io/istio/tests/fuzz FuzzV1Alpha1ValidateConfig fuzz_v1alpha1_validate_config
 compile_go_fuzzer istio.io/istio/tests/fuzz FuzzGetEnabledComponents fuzz_get_enabled_components
 compile_go_fuzzer istio.io/istio/tests/fuzz FuzzUnmarshalAndValidateIOPS fuzz_unmarshal_and_validate_iops
-compile_go_fuzzer istio.io/istio/tests/fuzz FuzzVerify fuzz_verify
 compile_go_fuzzer istio.io/istio/tests/fuzz FuzzRenderManifests fuzz_render_manifests
 compile_go_fuzzer istio.io/istio/tests/fuzz FuzzOverlayIOP fuzz_overlay_iop
 compile_go_fuzzer istio.io/istio/tests/fuzz FuzzNewControlplane fuzz_new_control_plane

--- a/tests/fuzz/regression_test.go
+++ b/tests/fuzz/regression_test.go
@@ -130,7 +130,6 @@ func TestFuzzers(t *testing.T) {
 		{"FuzzV1Alpha1ValidateConfig", FuzzV1Alpha1ValidateConfig},
 		{"FuzzGetEnabledComponents", FuzzGetEnabledComponents},
 		{"FuzzUnmarshalAndValidateIOPS", FuzzUnmarshalAndValidateIOPS},
-		{"FuzzVerify", FuzzVerify},
 		{"FuzzRenderManifests", FuzzRenderManifests},
 		{"FuzzOverlayIOP", FuzzOverlayIOP},
 		{"FuzzNewControlplane", FuzzNewControlplane},


### PR DESCRIPTION
**Please provide a description of this PR:**
This PR provides 2 fixes:

1)
The `FuzzNewControlplane` runs into a nil-deref (https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=37993&q=istio&can=1).

The crash occurs on [this line](https://github.com/istio/istio/blob/master/operator/pkg/component/component.go#L161) in case `opts.Translator.ComponentMaps[name.PilotComponentName]`  does not exist in the map. It looks like this will never happen in the wild, however, so the fuzzer gets adjusted in this PR to always include that.

2)
Remove the `FuzzVerify` fuzzer. The `StatusVerifier` is missing a client which I don't see an trivial fix for at this moment, so I'd rather just delete and add later when fixed.