### PR TITLE
Sample Jaeger version 1.23 -> 1.29

### DIFF
--- a/samples/addons/jaeger.yaml
+++ b/samples/addons/jaeger.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: jaeger
-          image: "docker.io/jaegertracing/all-in-one:1.23"
+          image: "docker.io/jaegertracing/all-in-one:1.29"
           env:
             - name: BADGER_EPHEMERAL
               value: "false"


### PR DESCRIPTION
The docker.io/jaegertracing/all-in-one image supports multi-platform build since [1.24](https://registry.hub.docker.com/layers/jaegertracing/all-in-one/1.24/images/sha256-5d86c2944deaf08f418d06939f5043791694b4fba3a8b258c514d0a06420e0af).