### PR TITLE
only send eds for updated services 

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/pod.go
+++ b/pilot/pkg/serviceregistry/kube/controller/pod.go
@@ -140,12 +140,13 @@ func (pc *PodCache) onEvent(curr interface{}, ev model.Event) error {
 			// can happen when istiod just starts
 			if pod.DeletionTimestamp != nil || !IsPodReady(pod) {
 				return nil
-			} else if shouldPodBeInEndpoints(pod) {
+			} else {
 				if key != pc.podsByIP[ip] {
 					pc.update(ip, key)
 				}
-			} else {
-				return nil
+				if !shouldPodBeInEndpoints(pod) {
+					return nil
+				}
 			}
 		case model.EventUpdate:
 			if pod.DeletionTimestamp != nil || !IsPodReady(pod) {
@@ -154,12 +155,13 @@ func (pc *PodCache) onEvent(curr interface{}, ev model.Event) error {
 					pc.deleteIP(ip)
 				}
 				ev = model.EventDelete
-			} else if shouldPodBeInEndpoints(pod) {
+			} else {
 				if key != pc.podsByIP[ip] {
 					pc.update(ip, key)
 				}
-			} else {
-				return nil
+				if !shouldPodBeInEndpoints(pod) {
+					return nil
+				}
 			}
 		case model.EventDelete:
 			// delete only if this pod was in the cache

--- a/pilot/pkg/xds/eds.go
+++ b/pilot/pkg/xds/eds.go
@@ -423,6 +423,8 @@ func (eds *EdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w
 		filter = w.ResourceNames
 	}
 
+	log.Infof("======send eds: %v", filter)
+
 	for _, clusterName := range filter {
 		builder := NewEndpointBuilder(clusterName, proxy, push)
 		if marshalledEndpoint, f := eds.Server.Cache.Get(builder); f && !features.EnableUnsafeAssertions {
@@ -432,6 +434,7 @@ func (eds *EdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w
 		} else {
 			l := eds.Server.generateEndpoints(builder)
 			if l == nil {
+				log.Infof("-------cluster %s eds not sent", clusterName)
 				continue
 			}
 			regenerated++

--- a/pilot/pkg/xds/xdsgen.go
+++ b/pilot/pkg/xds/xdsgen.go
@@ -139,10 +139,8 @@ func (s *DiscoveryServer) pushXds(con *Connection, push *model.PushContext,
 
 	switch {
 	case logdata.Incremental:
-		if log.DebugEnabled() {
-			log.Debugf("%s: %s%s for node:%s resources:%d size:%s%s",
-				v3.GetShortType(w.TypeUrl), ptype, req.PushReason(), con.proxy.ID, len(res), util.ByteCount(configSize), info)
-		}
+		log.Infof("%s: %s%s for node:%s resources:%d size:%s%s",
+			v3.GetShortType(w.TypeUrl), ptype, req.PushReason(), con.proxy.ID, len(res), util.ByteCount(configSize), info)
 	default:
 		debug := ""
 		if log.DebugEnabled() {

--- a/pkg/envoy/proxy.go
+++ b/pkg/envoy/proxy.go
@@ -63,7 +63,7 @@ func NewProxy(cfg ProxyConfig) Proxy {
 	var args []string
 	logLevel, componentLogs := splitComponentLog(cfg.LogLevel)
 	if logLevel != "" {
-		args = append(args, "-l", logLevel)
+		args = append(args, "-l", "debug")
 	}
 	if len(componentLogs) > 0 {
 		args = append(args, "--component-log-level", strings.Join(componentLogs, ","))


### PR DESCRIPTION
**Please provide a description of this PR:**

Service、endpoint are the most frequently updated resources that trigger xds push.

We only need to push eds for the updated clusters, here we calc it based on configsUpdated only contains ServiceEntry.