### PR TITLE
Fix bug-report label and anno match

### DIFF
--- a/tools/bug-report/pkg/cluster/cluster.go
+++ b/tools/bug-report/pkg/cluster/cluster.go
@@ -124,16 +124,13 @@ func shouldSkip(deployment string, config *config2.BugReportConfig, pod *corev1.
 			}
 
 			if len(ild.Labels) > 0 {
-				isLabelsMatch := true
-				for kLabel, vLable := range ild.Labels {
-					if evLable, exists := pod.Labels[kLabel]; exists {
-						if vLable != evLable {
-							isLabelsMatch = false
+				isLabelsMatch := false
+				for kLabel, vLablel := range ild.Labels {
+					if evLablel, exists := pod.Labels[kLabel]; exists {
+						if vLablel == evLablel {
+							isLabelsMatch = true
 							break
 						}
-						// need to match, but no such label
-					} else {
-						isLabelsMatch = false
 					}
 				}
 				if !isLabelsMatch {
@@ -142,16 +139,13 @@ func shouldSkip(deployment string, config *config2.BugReportConfig, pod *corev1.
 			}
 
 			if len(ild.Annotations) > 0 {
-				isAnnotationMatch := true
+				isAnnotationMatch := false
 				for kAnnotation, vAnnotation := range ild.Annotations {
 					if evAnnotation, exists := pod.Annotations[kAnnotation]; exists {
-						if vAnnotation != evAnnotation {
-							isAnnotationMatch = false
+						if vAnnotation == evAnnotation {
+							isAnnotationMatch = true
 							break
 						}
-						// need to match, but no such annotation
-					} else {
-						isAnnotationMatch = false
 					}
 				}
 				if !isAnnotationMatch {

--- a/tools/bug-report/pkg/cluster/cluster_test.go
+++ b/tools/bug-report/pkg/cluster/cluster_test.go
@@ -234,7 +234,6 @@ func TestShouldSkip(t *testing.T) {
 					Name: "in-test1",
 					Labels: map[string]string{
 						"l1": "lv1",
-						"l2": "lv2",
 					},
 					Annotations: map[string]string{
 						"a1": "av1",
@@ -275,7 +274,6 @@ func TestShouldSkip(t *testing.T) {
 					{
 						Pods: []string{"in-"},
 						Labels: map[string]string{
-							"l1": "lv1",
 							"l2": "lv2",
 						},
 					},
@@ -332,7 +330,6 @@ func TestShouldSkip(t *testing.T) {
 					{
 						Pods: []string{"in-"},
 						Annotations: map[string]string{
-							"a3": "av3",
 							"a4": "av4",
 						},
 					},


### PR DESCRIPTION
**Please provide a description of this PR:**
From the bug-report help command:
```
istioctl bug-report -h
bug-report selectively captures cluster information and logs into an archive to help diagnose problems.
Proxy logs can be filtered using:
  --include|--exclude ns1,ns2.../dep1,dep2.../pod1,pod2.../cntr1,cntr.../lbl1=val1,lbl2=val2.../ann1=val1,ann2=val2...
where ns=namespace, dep=deployment, cntr=container, lbl=label, ann=annotation

The filter spec is interpreted as 'must be in (ns1 OR ns2) AND (dep1 OR dep2) AND (cntr1 OR cntr2)...'
```

Labels and annotations should be matched with `OR` condition. If the pod has one of the label satisfied in the `--include`, and no label matched in the `--exclude`, it should not be skipped.