### PR TITLE
fix(dashboards): workloads dashboard should display namespaces with only sent bytes

### DIFF
--- a/manifests/addons/dashboards/istio-workload-dashboard.json
+++ b/manifests/addons/dashboards/istio-workload-dashboard.json
@@ -2513,11 +2513,11 @@
         "multi": false,
         "name": "namespace",
         "options": [],
-        "query": "query_result(sum(istio_requests_total) by (destination_workload_namespace) or sum(istio_tcp_sent_bytes_total) by (destination_workload_namespace))",
+        "query": "query_result(sum(istio_requests_total) by (destination_workload_namespace) or sum(istio_tcp_sent_bytes_total) by (destination_workload_namespace) or sum(istio_tcp_received_bytes_total) by (source_workload_namespace))",
         "refresh": 1,
         "regex": "/.*_namespace=\"([^\"]*).*/",
         "skipUrlSync": false,
-        "sort": 0,
+        "sort": 1,
         "tagValuesQuery": "",
         "tags": [],
         "tagsQuery": "",
@@ -2550,8 +2550,14 @@
         "allValue": null,
         "current": {
           "selected": true,
-          "text": "destination",
-          "value": "destination"
+          "text": [
+            "destination",
+            "source"
+          ],
+          "value": [
+            "destination",
+            "source"
+          ]
         },
         "datasource": "Prometheus",
         "definition": "",


### PR DESCRIPTION
**Please provide a description of this PR:**
Currently if you are running workloads that read and write from an external destination (for example reading and writing from kafka topics on MSK) the namespace those workloads run in will not be displayed in the namespaces dropdown. This PR includes namespaces that only have `istio_tcp_received_bytes_total` metrics and not just `istio_tcp_sent_bytes_total` or `istio_requests_total`.

I've also included a change that causes the `Reporter` dropdown to select both `source` and `destination` by default rather than the current behavior of only `destination` which I personally think makes more sense as it causes charts in use cases like I mentioned above to show data by default rather than be empty.