### PR TITLE
Drop import of github.com/stretchr/testify 

### DIFF
--- a/cni/pkg/install/cniconfig_test.go
+++ b/cni/pkg/install/cniconfig_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
+	"istio.io/istio/pkg/test/util/assert"
 
 	"istio.io/istio/cni/pkg/config"
 	testutils "istio.io/istio/pilot/test/util"
@@ -235,7 +235,7 @@ func TestGetCNIConfigFilepath(t *testing.T) {
 				defer cancel()
 				result, err := getCNIConfigFilepath(ctx1, cfg)
 				if err != nil {
-					assert.Empty(t, result)
+					assert.Equal(t, result, "")
 					if err == context.DeadlineExceeded {
 						t.Fatalf("timed out waiting for expected %s", expectedFilepath)
 					}
@@ -264,7 +264,6 @@ func TestGetCNIConfigFilepath(t *testing.T) {
 
 			select {
 			case result := <-resultChan:
-				assert.NotEmpty(t, result)
 				if len(c.delayedConfName) > 0 {
 					// Delayed case
 					t.Fatalf("did not expect to retrieve a CNI config file %s", result)
@@ -301,7 +300,6 @@ func TestGetCNIConfigFilepath(t *testing.T) {
 			// Only for delayed cases
 			select {
 			case result := <-resultChan:
-				assert.NotEmpty(t, result)
 				if result != expectedFilepath {
 					if len(expectedFilepath) > 0 {
 						t.Fatalf("expected %s, got %s", expectedFilepath, result)
@@ -516,7 +514,7 @@ func TestCreateCNIConfigFile(t *testing.T) {
 				defer cancel()
 				resultFilepath, err := createCNIConfigFile(ctx, &cfg, "")
 				if err != nil {
-					assert.Empty(t, resultFilepath)
+					assert.Equal(t, resultFilepath, "")
 					if err == context.DeadlineExceeded {
 						if len(c.expectedConfName) > 0 {
 							t.Fatalf("timed out waiting for expected %s", expectedFilepath)
@@ -526,8 +524,6 @@ func TestCreateCNIConfigFile(t *testing.T) {
 					}
 					t.Fatal(err)
 				}
-
-				assert.NotEmpty(t, resultFilepath)
 
 				if resultFilepath != expectedFilepath {
 					if len(expectedFilepath) > 0 {

--- a/cni/pkg/install/cniconfig_test.go
+++ b/cni/pkg/install/cniconfig_test.go
@@ -22,11 +22,10 @@ import (
 	"testing"
 	"time"
 
-	"istio.io/istio/pkg/test/util/assert"
-
 	"istio.io/istio/cni/pkg/config"
 	testutils "istio.io/istio/pilot/test/util"
 	"istio.io/istio/pkg/file"
+	"istio.io/istio/pkg/test/util/assert"
 )
 
 func TestGetDefaultCNINetwork(t *testing.T) {
@@ -359,9 +358,9 @@ func TestInsertCNIConfig(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			istioConf := testutils.ReadFile(filepath.Join("testdata", c.newConfFilename), t)
+			istioConf := testutils.ReadFile(t, filepath.Join("testdata", c.newConfFilename))
 			existingConfFilepath := filepath.Join("testdata", c.existingConfFilename)
-			existingConf := testutils.ReadFile(existingConfFilepath, t)
+			existingConf := testutils.ReadFile(t, existingConfFilepath)
 
 			output, err := insertCNIConfig(istioConf, existingConf)
 			if err != nil {
@@ -372,8 +371,8 @@ func TestInsertCNIConfig(t *testing.T) {
 			}
 
 			goldenFilepath := existingConfFilepath + ".golden"
-			goldenConfig := testutils.ReadFile(goldenFilepath, t)
-			testutils.CompareBytes(output, goldenConfig, goldenFilepath, t)
+			goldenConfig := testutils.ReadFile(t, goldenFilepath)
+			testutils.CompareBytes(t, output, goldenConfig, goldenFilepath)
 		})
 	}
 }
@@ -532,11 +531,11 @@ func TestCreateCNIConfigFile(t *testing.T) {
 					t.Fatalf("did not expect to retrieve a CNI config file %s", resultFilepath)
 				}
 
-				resultConfig := testutils.ReadFile(resultFilepath, t)
+				resultConfig := testutils.ReadFile(t, resultFilepath)
 
 				goldenFilepath := filepath.Join("testdata", c.goldenConfName)
-				goldenConfig := testutils.ReadFile(goldenFilepath, t)
-				testutils.CompareBytes(resultConfig, goldenConfig, goldenFilepath, t)
+				goldenConfig := testutils.ReadFile(t, goldenFilepath)
+				testutils.CompareBytes(t, resultConfig, goldenConfig, goldenFilepath)
 			}
 		}
 		t.Run("network-config-file "+c.name, test(cfgFile))

--- a/cni/pkg/install/install_test.go
+++ b/cni/pkg/install/install_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
+	"istio.io/istio/pkg/test/util/assert"
 
 	"istio.io/istio/cni/pkg/config"
 	testutils "istio.io/istio/pilot/test/util"
@@ -182,7 +182,7 @@ func TestSleepCheckInstall(t *testing.T) {
 			if err = sleepCheckInstall(ctx, cfg, cniConfigFilepath, isReady); err != nil {
 				t.Fatalf("error should be nil due to invalid config, got: %v", err)
 			}
-			assert.Falsef(t, isReady.Load().(bool), "isReady should still be false")
+			assert.Equal(t, isReady.Load(), false)
 
 			if len(c.invalidConfigFilename) > 0 {
 				if err = os.Remove(cniConfigFilepath); err != nil {
@@ -221,7 +221,7 @@ func TestSleepCheckInstall(t *testing.T) {
 
 			select {
 			case <-readyChan:
-				assert.Truef(t, isReady.Load().(bool), "isReady should have been set to true")
+				assert.Equal(t, isReady.Load(), true)
 			case err = <-errChan:
 				if err == nil {
 					t.Fatal("invalid configuration detected")
@@ -250,7 +250,7 @@ func TestSleepCheckInstall(t *testing.T) {
 					// Either an invalid config did not return nil (which is an issue) or an unexpected error occurred
 					t.Fatal(err)
 				}
-				assert.Falsef(t, isReady.Load().(bool), "isReady should have been set to false after returning from sleepCheckInstall")
+				assert.Equal(t, isReady.Load(), false)
 			case <-time.After(5 * time.Second):
 				t.Fatal("timed out waiting for invalid configuration to be detected")
 			}

--- a/cni/pkg/install/install_test.go
+++ b/cni/pkg/install/install_test.go
@@ -23,11 +23,10 @@ import (
 	"testing"
 	"time"
 
-	"istio.io/istio/pkg/test/util/assert"
-
 	"istio.io/istio/cni/pkg/config"
 	testutils "istio.io/istio/pilot/test/util"
 	"istio.io/istio/pkg/file"
+	"istio.io/istio/pkg/test/util/assert"
 )
 
 func TestCheckInstall(t *testing.T) {
@@ -337,11 +336,11 @@ func TestCleanup(t *testing.T) {
 
 			// check if conf file is deleted/conflist file is updated
 			if c.chainedCNIPlugin {
-				resultConfig := testutils.ReadFile(cniConfigFilePath, t)
+				resultConfig := testutils.ReadFile(t, cniConfigFilePath)
 
 				goldenFilepath := filepath.Join("testdata", c.expectedConfigFilename)
-				goldenConfig := testutils.ReadFile(goldenFilepath, t)
-				testutils.CompareBytes(resultConfig, goldenConfig, goldenFilepath, t)
+				goldenConfig := testutils.ReadFile(t, goldenFilepath)
+				testutils.CompareBytes(t, resultConfig, goldenConfig, goldenFilepath)
 			} else if file.Exists(cniConfigFilePath) {
 				t.Fatalf("file %s was not deleted", c.configFilename)
 			}

--- a/cni/pkg/install/kubeconfig_test.go
+++ b/cni/pkg/install/kubeconfig_test.go
@@ -20,7 +20,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"istio.io/istio/pkg/test/util/assert"
 
 	"istio.io/istio/cni/pkg/config"
 	"istio.io/istio/cni/pkg/constants"
@@ -102,7 +102,7 @@ func TestCreateKubeconfigFile(t *testing.T) {
 			}
 			resultFilepath, err := createKubeconfigFile(cfg, c.saToken)
 			if err != nil {
-				assert.Empty(t, resultFilepath)
+				assert.Equal(t, resultFilepath, "")
 				if !c.expectedFailure {
 					t.Fatalf("did not expect failure: %v", err)
 				}

--- a/cni/pkg/install/kubeconfig_test.go
+++ b/cni/pkg/install/kubeconfig_test.go
@@ -20,12 +20,11 @@ import (
 	"path/filepath"
 	"testing"
 
-	"istio.io/istio/pkg/test/util/assert"
-
 	"istio.io/istio/cni/pkg/config"
 	"istio.io/istio/cni/pkg/constants"
 	testutils "istio.io/istio/pilot/test/util"
 	"istio.io/istio/pkg/file"
+	"istio.io/istio/pkg/test/util/assert"
 )
 
 const (
@@ -140,9 +139,9 @@ func TestCreateKubeconfigFile(t *testing.T) {
 				goldenFilepath = "testdata/kubeconfig-tls"
 			}
 
-			goldenConfig := testutils.ReadFile(goldenFilepath, t)
-			resultConfig := testutils.ReadFile(resultFilepath, t)
-			testutils.CompareBytes(resultConfig, goldenConfig, goldenFilepath, t)
+			goldenConfig := testutils.ReadFile(t, goldenFilepath)
+			resultConfig := testutils.ReadFile(t, resultFilepath)
+			testutils.CompareBytes(t, resultConfig, goldenConfig, goldenFilepath)
 		})
 	}
 }

--- a/cni/pkg/install/server_test.go
+++ b/cni/pkg/install/server_test.go
@@ -19,16 +19,15 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"istio.io/istio/cni/pkg/constants"
+	"istio.io/istio/pkg/test/util/assert"
 )
 
 func TestServer(t *testing.T) {
 	router := http.NewServeMux()
 	isReady := initRouter(router)
 
-	assert.Falsef(t, isReady.Load().(bool), "isReady should be initialized to false")
+	assert.Equal(t, isReady.Load(), false)
 
 	server := httptest.NewServer(router)
 	defer server.Close()
@@ -37,13 +36,13 @@ func TestServer(t *testing.T) {
 	makeReq(t, server.URL, constants.ReadinessEndpoint, http.StatusServiceUnavailable)
 
 	SetReady(isReady)
-	assert.Truef(t, isReady.Load().(bool), "isReady should be set to true")
+	assert.Equal(t, isReady.Load(), true)
 
 	makeReq(t, server.URL, constants.LivenessEndpoint, http.StatusOK)
 	makeReq(t, server.URL, constants.ReadinessEndpoint, http.StatusOK)
 
 	SetNotReady(isReady)
-	assert.Falsef(t, isReady.Load().(bool), "isReady should be set to false")
+	assert.Equal(t, isReady.Load(), false)
 
 	makeReq(t, server.URL, constants.LivenessEndpoint, http.StatusOK)
 	makeReq(t, server.URL, constants.ReadinessEndpoint, http.StatusServiceUnavailable)

--- a/cni/pkg/plugin/plugin_dryrun_test.go
+++ b/cni/pkg/plugin/plugin_dryrun_test.go
@@ -188,5 +188,5 @@ func refreshGoldens(t *testing.T, goldenFileName string, generatedRules map[stri
 	for _, t := range tables {
 		goldenFileContent += generatedRules[t] + "\n"
 	}
-	diff.RefreshGoldenFile([]byte(goldenFileContent), goldenFileName, t)
+	diff.RefreshGoldenFile(t, []byte(goldenFileContent), goldenFileName)
 }

--- a/go.mod
+++ b/go.mod
@@ -70,7 +70,6 @@ require (
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.8.1
-	github.com/stretchr/testify v1.7.0
 	github.com/vishvananda/netlink v1.1.1-0.20210330154013-f5de75959ad5
 	github.com/yl2chen/cidranger v1.0.2
 	go.opencensus.io v0.23.0
@@ -223,6 +222,7 @@ require (
 	github.com/spf13/afero v1.2.2 // indirect
 	github.com/spf13/cast v1.3.1 // indirect
 	github.com/spf13/jwalterweatherman v1.0.0 // indirect
+	github.com/stretchr/testify v1.7.0 // indirect
 	github.com/vbatts/tar-split v0.11.2 // indirect
 	github.com/vishvananda/netns v0.0.0-20210104183010-2eb08e3e575f // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect

--- a/istioctl/cmd/describe_test.go
+++ b/istioctl/cmd/describe_test.go
@@ -106,7 +106,7 @@ func verifyExecAndK8sConfigTestCaseTestOutput(t *testing.T, c execAndK8sConfigTe
 	}
 
 	if c.goldenFilename != "" {
-		util.CompareContent([]byte(output), c.goldenFilename, t)
+		util.CompareContent(t, []byte(output), c.goldenFilename)
 	}
 
 	if c.wantException {

--- a/istioctl/cmd/istioctl_test.go
+++ b/istioctl/cmd/istioctl_test.go
@@ -109,7 +109,7 @@ func verifyOutput(t *testing.T, c testCase) {
 	}
 
 	if c.goldenFilename != "" {
-		util.CompareContent([]byte(output), c.goldenFilename, t)
+		util.CompareContent(t, []byte(output), c.goldenFilename)
 	}
 
 	if c.wantException {

--- a/istioctl/cmd/proxyconfig_test.go
+++ b/istioctl/cmd/proxyconfig_test.go
@@ -38,7 +38,7 @@ type execTestCase struct {
 
 func TestProxyConfig(t *testing.T) {
 	loggingConfig := map[string][]byte{
-		"details-v1-5b7f94f9bc-wp5tb": util.ReadFile("../pkg/writer/envoy/logging/testdata/logging.txt", t),
+		"details-v1-5b7f94f9bc-wp5tb": util.ReadFile(t, "../pkg/writer/envoy/logging/testdata/logging.txt"),
 		"httpbin-794b576b6c-qx6pf":    []byte("{}"),
 	}
 	cases := []execTestCase{
@@ -192,7 +192,7 @@ func verifyExecTestOutput(t *testing.T, c execTestCase) {
 	}
 
 	if c.goldenFilename != "" {
-		util.CompareContent([]byte(output), c.goldenFilename, t)
+		util.CompareContent(t, []byte(output), c.goldenFilename)
 	}
 
 	if c.wantException {

--- a/istioctl/cmd/workload_test.go
+++ b/istioctl/cmd/workload_test.go
@@ -183,7 +183,7 @@ func TestWorkloadEntryConfigure(t *testing.T) {
 						&v1.ConfigMap{
 							ObjectMeta: metav1.ObjectMeta{Namespace: "istio-system", Name: "istio-rev-1"},
 							Data: map[string]string{
-								"mesh": string(util.ReadFile(path.Join(testdir, "meshconfig.yaml"), t)),
+								"mesh": string(util.ReadFile(t, path.Join(testdir, "meshconfig.yaml"))),
 							},
 						},
 						&v1.Secret{
@@ -328,10 +328,10 @@ func checkOutputFiles(t *testing.T, testdir string, checkFiles map[string]bool) 
 		}
 		if checkGolden {
 			t.Run(f.Name(), func(t *testing.T) {
-				contents := util.ReadFile(path.Join(testdir, f.Name()), t)
+				contents := util.ReadFile(t, path.Join(testdir, f.Name()))
 				goldenFile := path.Join(testdir, f.Name()+goldenSuffix)
-				util.RefreshGoldenFile(contents, goldenFile, t)
-				util.CompareContent(contents, goldenFile, t)
+				util.RefreshGoldenFile(t, contents, goldenFile)
+				util.CompareContent(t, contents, goldenFile)
 			})
 		}
 	}

--- a/istioctl/pkg/validate/validate_test.go
+++ b/istioctl/pkg/validate/validate_test.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"istio.io/istio/pkg/test/util/assert"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/yaml"
 )

--- a/istioctl/pkg/validate/validate_test.go
+++ b/istioctl/pkg/validate/validate_test.go
@@ -23,9 +23,10 @@ import (
 	"strings"
 	"testing"
 
-	"istio.io/istio/pkg/test/util/assert"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/yaml"
+
+	"istio.io/istio/pkg/test/util/assert"
 )
 
 const (
@@ -639,14 +640,14 @@ Error: 1 error occurred:
 }
 
 func TestGetTemplateLabels(t *testing.T) {
-	assert := assert.New(t)
 	un := fromYAML(validDeployment)
 
 	labels, err := GetTemplateLabels(un)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.NotEmpty(t, labels)
-	assert.Contains(labels, "app")
-	assert.Contains(labels, "version")
+	assert.Equal(t, labels, map[string]string{
+		"app":     "helloworld",
+		"version": "v1",
+	})
 }

--- a/istioctl/pkg/writer/envoy/configdump/configdump_test.go
+++ b/istioctl/pkg/writer/envoy/configdump/configdump_test.go
@@ -86,7 +86,7 @@ func TestConfigWriter_PrintBootstrapDump(t *testing.T) {
 			}
 			err := cw.PrintBootstrapDump("json")
 			if tt.wantOutputFile != "" {
-				util.CompareContent(gotOut.Bytes(), tt.wantOutputFile, t)
+				util.CompareContent(t, gotOut.Bytes(), tt.wantOutputFile)
 			}
 			if err == nil && tt.wantErr {
 				t.Errorf("PrintBootstrapDump (%v) did not produce expected err", tt.name)
@@ -124,7 +124,7 @@ func TestConfigWriter_PrintVersionSummary(t *testing.T) {
 			}
 			err := cw.PrintVersionSummary()
 			if tt.wantOutputFile != "" {
-				util.CompareContent(gotOut.Bytes(), tt.wantOutputFile, t)
+				util.CompareContent(t, gotOut.Bytes(), tt.wantOutputFile)
 			}
 			if err == nil && tt.wantErr {
 				t.Errorf("PrintVersionSummary (%v) did not produce expected err", tt.name)

--- a/istioctl/pkg/writer/envoy/configdump/configdump_test.go
+++ b/istioctl/pkg/writer/envoy/configdump/configdump_test.go
@@ -19,9 +19,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"istio.io/istio/pilot/test/util"
+	"istio.io/istio/pkg/test/util/assert"
 )
 
 func TestConfigWriter_Prime(t *testing.T) {

--- a/istioctl/pkg/writer/pilot/status_test.go
+++ b/istioctl/pkg/writer/pilot/status_test.go
@@ -24,8 +24,8 @@ import (
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	status "github.com/envoyproxy/go-control-plane/envoy/service/status/v3"
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
 	any "google.golang.org/protobuf/types/known/anypb"
+	"istio.io/istio/pkg/test/util/assert"
 
 	networkingutil "istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pilot/pkg/xds"

--- a/istioctl/pkg/writer/pilot/status_test.go
+++ b/istioctl/pkg/writer/pilot/status_test.go
@@ -25,11 +25,11 @@ import (
 	status "github.com/envoyproxy/go-control-plane/envoy/service/status/v3"
 	"github.com/google/uuid"
 	any "google.golang.org/protobuf/types/known/anypb"
-	"istio.io/istio/pkg/test/util/assert"
 
 	networkingutil "istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pilot/pkg/xds"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
+	"istio.io/istio/pkg/test/util/assert"
 	"istio.io/istio/tests/util"
 	istioversion "istio.io/pkg/version"
 )

--- a/operator/cmd/mesh/manifest-generate_test.go
+++ b/operator/cmd/mesh/manifest-generate_test.go
@@ -751,7 +751,7 @@ func runTestGroup(t *testing.T, tests testGroup) {
 				}
 			}
 
-			tutil.RefreshGoldenFile([]byte(got), outPath, t)
+			tutil.RefreshGoldenFile(t, []byte(got), outPath)
 
 			want, err := readFile(outPath)
 			if err != nil {

--- a/pilot/pkg/config/kube/gateway/deploymentcontroller_test.go
+++ b/pilot/pkg/config/kube/gateway/deploymentcontroller_test.go
@@ -115,7 +115,7 @@ func TestConfigureIstioGateway(t *testing.T) {
 			}
 
 			resp := timestampRegex.ReplaceAll(buf.Bytes(), []byte("lastTransitionTime: fake"))
-			util.CompareContent(resp, filepath.Join("testdata", "deployment", tt.name+".yaml"), t)
+			util.CompareContent(t, resp, filepath.Join("testdata", "deployment", tt.name+".yaml"))
 		})
 	}
 }

--- a/pilot/pkg/model/context_test.go
+++ b/pilot/pkg/model/context_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/gogo/protobuf/types"
 	structpb "google.golang.org/protobuf/types/known/structpb"
-	"istio.io/istio/pkg/test/util/assert"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/api/networking/v1alpha3"
@@ -30,6 +29,7 @@ import (
 	"istio.io/istio/pilot/pkg/serviceregistry/memory"
 	"istio.io/istio/pilot/pkg/serviceregistry/mock"
 	"istio.io/istio/pkg/config/host"
+	"istio.io/istio/pkg/test/util/assert"
 	"istio.io/istio/pkg/util/protomarshal"
 )
 

--- a/pilot/pkg/model/context_test.go
+++ b/pilot/pkg/model/context_test.go
@@ -21,8 +21,8 @@ import (
 	"time"
 
 	"github.com/gogo/protobuf/types"
-	"github.com/stretchr/testify/assert"
 	structpb "google.golang.org/protobuf/types/known/structpb"
+	"istio.io/istio/pkg/test/util/assert"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/api/networking/v1alpha3"

--- a/pilot/pkg/networking/core/v1alpha3/accesslog_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/accesslog_test.go
@@ -26,12 +26,12 @@ import (
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/protobuf/testing/protocmp"
-	"istio.io/istio/pkg/test/util/assert"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pilot/test/xdstest"
+	"istio.io/istio/pkg/test/util/assert"
 	"istio.io/istio/pkg/util/protomarshal"
 )
 

--- a/pilot/pkg/networking/core/v1alpha3/accesslog_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/accesslog_test.go
@@ -25,8 +25,8 @@ import (
 	"github.com/envoyproxy/go-control-plane/pkg/conversion"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"github.com/google/go-cmp/cmp"
-	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/testing/protocmp"
+	"istio.io/istio/pkg/test/util/assert"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/pkg/model"

--- a/pilot/pkg/security/authz/builder/builder_test.go
+++ b/pilot/pkg/security/authz/builder/builder_test.go
@@ -359,7 +359,7 @@ func verify(t *testing.T, gots []proto.Message, baseDir string, wants []string, 
 			t.Fatalf("failed to convert to YAML: %v", err)
 		}
 
-		util.RefreshGoldenFile([]byte(gotYaml), wantFile, t)
+		util.RefreshGoldenFile(t, []byte(gotYaml), wantFile)
 		if err := util.Compare([]byte(gotYaml), []byte(wantYaml)); err != nil {
 			t.Error(err)
 		}

--- a/pkg/bootstrap/instance_test.go
+++ b/pkg/bootstrap/instance_test.go
@@ -354,7 +354,7 @@ func TestGolden(t *testing.T) {
 			}
 
 			goldenFile := "testdata/" + c.base + "_golden.json"
-			util.RefreshGoldenFile(read, goldenFile, t)
+			util.RefreshGoldenFile(t, read, goldenFile)
 
 			golden, err := os.ReadFile(goldenFile)
 			if err != nil {

--- a/pkg/config/analysis/analyzers/authz/authorizationpolicies_test.go
+++ b/pkg/config/analysis/analyzers/authz/authorizationpolicies_test.go
@@ -17,17 +17,15 @@ package authz
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"istio.io/istio/pkg/test/util/assert"
 )
 
 func TestNamespaceMatch(t *testing.T) {
-	assert := assert.New(t)
+	assert.Equal(t, namespaceMatch("test-login", "*"), true)
 
-	assert.True(namespaceMatch("test-login", "*"))
+	assert.Equal(t, namespaceMatch("test-login", "test-*"), true)
+	assert.Equal(t, namespaceMatch("test-login", "*-test"), false)
 
-	assert.True(namespaceMatch("test-login", "test-*"))
-	assert.False(namespaceMatch("test-login", "*-test"))
-
-	assert.False(namespaceMatch("test-login", "login-*"))
-	assert.True(namespaceMatch("test-login", "*-login"))
+	assert.Equal(t, namespaceMatch("test-login", "login-*"), false)
+	assert.Equal(t, namespaceMatch("test-login", "*-login"), true)
 }

--- a/pkg/config/mesh/mesh_test.go
+++ b/pkg/config/mesh/mesh_test.go
@@ -26,6 +26,7 @@ import (
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/validation"
+	"istio.io/istio/pkg/test/util/assert"
 	"istio.io/istio/pkg/util/gogoprotomarshal"
 )
 
@@ -64,18 +65,13 @@ func TestApplyProxyConfig(t *testing.T) {
 			"default": "foo",
 		}
 		mc, err := mesh.ApplyProxyConfig(`proxyMetadata: {"merged":"override","override":"bar"}`, config)
-		if err != nil {
-			t.Fatal(err)
-		}
+		assert.NoError(t, err)
 		// Ensure we didn't modify the passed in mesh config
-		if !reflect.DeepEqual(mc.DefaultConfig.ProxyMetadata, map[string]string{
-
+		assert.Equal(t, mc.DefaultConfig.ProxyMetadata, map[string]string{
 			"merged":   "override",
 			"default":  "foo",
 			"override": "bar",
-		}) {
-			t.Fatalf("unexpected proxy metadata: %+v", mc.DefaultConfig.ProxyMetadata)
-		}
+		}, "unexpected proxy metadata")
 	})
 	t.Run("apply proxy metadata to mesh config", func(t *testing.T) {
 		config := mesh.DefaultMeshConfig()
@@ -89,14 +85,11 @@ func TestApplyProxyConfig(t *testing.T) {
 			t.Fatal(err)
 		}
 		// Ensure we didn't modify the passed in mesh config
-		if !reflect.DeepEqual(mc.DefaultConfig.ProxyMetadata, map[string]string{
-
+		assert.Equal(t, mc.DefaultConfig.ProxyMetadata, map[string]string{
 			"merged":   "override",
 			"default":  "foo",
 			"override": "bar",
-		}) {
-			t.Fatalf("unexpected proxy metadata: %+v", mc.DefaultConfig.ProxyMetadata)
-		}
+		}, "unexpected proxy metadata")
 	})
 	t.Run("apply should not modify", func(t *testing.T) {
 		config := mesh.DefaultMeshConfig()
@@ -149,9 +142,7 @@ defaultConfig:
 	if err != nil {
 		t.Fatalf("ApplyMeshConfigDefaults() failed: %v", err)
 	}
-	if !reflect.DeepEqual(got, &want) {
-		t.Fatalf("Wrong default values:\n got %#v \nwant %#v", got, &want)
-	}
+	assert.Equal(t, got, &want)
 	// Verify overrides
 	got, err = mesh.ApplyMeshConfigDefaults(`
 serviceSettings: 
@@ -408,9 +399,7 @@ networks:
 	if err != nil {
 		t.Fatalf("ApplyMeshNetworksDefaults() failed: %v", err)
 	}
-	if !reflect.DeepEqual(got, &want) {
-		t.Fatalf("Wrong values:\n got %#v \nwant %#v", got, &want)
-	}
+	assert.Equal(t, got, &want)
 }
 
 func TestResolveHostsInNetworksConfig(t *testing.T) {

--- a/pkg/istio-agent/agent_test.go
+++ b/pkg/istio-agent/agent_test.go
@@ -487,7 +487,7 @@ func TestAgent(t *testing.T) {
 		}
 		got = []byte(strings.ReplaceAll(string(got), a.agent.cfg.XdsUdsPath, "etc/istio/XDS"))
 
-		testutil.CompareContent(got, filepath.Join(env.IstioSrc, "pkg/istio-agent/testdata/grpc-bootstrap.json"), t)
+		testutil.CompareContent(t, got, filepath.Join(env.IstioSrc, "pkg/istio-agent/testdata/grpc-bootstrap.json"))
 	})
 }
 
@@ -664,7 +664,7 @@ func expectFileChanged(t *testing.T, files ...string) {
 	t.Helper()
 	initials := [][]byte{}
 	for _, f := range files {
-		initials = append(initials, testutil.ReadFile(f, t))
+		initials = append(initials, testutil.ReadFile(t, f))
 	}
 	retry.UntilSuccessOrFail(t, func() error {
 		for i, f := range files {
@@ -684,12 +684,12 @@ func expectFileUnchanged(t *testing.T, files ...string) {
 	t.Helper()
 	initials := [][]byte{}
 	for _, f := range files {
-		initials = append(initials, testutil.ReadFile(f, t))
+		initials = append(initials, testutil.ReadFile(t, f))
 	}
 	for attempt := 0; attempt < 10; attempt++ {
 		time.Sleep(time.Millisecond * 10)
 		for i, f := range files {
-			now := testutil.ReadFile(f, t)
+			now := testutil.ReadFile(t, f)
 			if !reflect.DeepEqual(initials[i], now) {
 				t.Fatalf("file is changed!")
 			}
@@ -738,8 +738,8 @@ func setupCa(t *testing.T, auth *security.FakeAuthenticator) *mock.CAServer {
 	t.Helper()
 	opt := tlsOptions(t)
 	s, err := mock.NewCAServerWithKeyCert(0,
-		testutil.ReadFile(filepath.Join(env.IstioSrc, "./tests/testdata/certs/pilot/ca-key.pem"), t),
-		testutil.ReadFile(filepath.Join(env.IstioSrc, "./tests/testdata/certs/pilot/ca-cert.pem"), t),
+		testutil.ReadFile(t, filepath.Join(env.IstioSrc, "./tests/testdata/certs/pilot/ca-key.pem")),
+		testutil.ReadFile(t, filepath.Join(env.IstioSrc, "./tests/testdata/certs/pilot/ca-cert.pem")),
 		opt)
 	if err != nil {
 		t.Fatal(err)
@@ -761,7 +761,7 @@ func tlsOptions(t *testing.T, extraRoots ...[]byte) grpc.ServerOption {
 	}
 	peerCertVerifier := spiffe.NewPeerCertVerifier()
 	if err := peerCertVerifier.AddMappingFromPEM("cluster.local",
-		testutil.ReadFile(filepath.Join(env.IstioSrc, "./tests/testdata/certs/pilot/root-cert.pem"), t)); err != nil {
+		testutil.ReadFile(t, filepath.Join(env.IstioSrc, "./tests/testdata/certs/pilot/root-cert.pem"))); err != nil {
 		t.Fatal(err)
 	}
 	for _, r := range extraRoots {

--- a/pkg/kube/inject/inject_test.go
+++ b/pkg/kube/inject/inject_test.go
@@ -405,9 +405,9 @@ func TestInjection(t *testing.T) {
 
 				// The version string is a maintenance pain for this test. Strip the version string before comparing.
 				gotBytes := util.StripVersion(got.Bytes())
-				wantBytes := util.ReadGoldenFile(gotBytes, wantFilePath, t)
+				wantBytes := util.ReadGoldenFile(t, gotBytes, wantFilePath)
 
-				util.CompareBytes(gotBytes, wantBytes, wantFilePath, t)
+				util.CompareBytes(t, gotBytes, wantBytes, wantFilePath)
 			})
 
 			// Exit early if we don't need to test webhook. We can skip errors since its redundant

--- a/pkg/kube/inject/webhook_test.go
+++ b/pkg/kube/inject/webhook_test.go
@@ -655,7 +655,7 @@ func loadInjectionSettings(t testing.TB, setFlags []string, inFilePath string) (
 
 func splitYamlFile(yamlFile string, t *testing.T) [][]byte {
 	t.Helper()
-	yamlBytes := util.ReadFile(yamlFile, t)
+	yamlBytes := util.ReadFile(t, yamlFile)
 	return splitYamlBytes(yamlBytes, t)
 }
 

--- a/pkg/spiffe/spiffe_test.go
+++ b/pkg/spiffe/spiffe_test.go
@@ -347,11 +347,11 @@ func TestRetrieveSpiffeBundleRootCertsFromStringInput(t *testing.T) {
 
 // TestVerifyPeerCert tests VerifyPeerCert is effective at the client side, using a TLS server.
 func TestGetGeneralCertPoolAndVerifyPeerCert(t *testing.T) {
-	validRootCert := string(util.ReadFile(validRootCertFile1, t))
-	validRootCert2 := string(util.ReadFile(validRootCertFile2, t))
-	validIntCert := string(util.ReadFile(validIntCertFile, t))
-	validWorkloadCert := string(util.ReadFile(validWorkloadCertFile, t))
-	validWorkloadKey := string(util.ReadFile(validWorkloadKeyFile, t))
+	validRootCert := string(util.ReadFile(t, validRootCertFile1))
+	validRootCert2 := string(util.ReadFile(t, validRootCertFile2))
+	validIntCert := string(util.ReadFile(t, validIntCertFile))
+	validWorkloadCert := string(util.ReadFile(t, validWorkloadCertFile))
+	validWorkloadKey := string(util.ReadFile(t, validWorkloadKeyFile))
 
 	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/pkg/test/framework/components/echo/cmd/echogen/echogen_test.go
+++ b/pkg/test/framework/components/echo/cmd/echogen/echogen_test.go
@@ -45,5 +45,5 @@ func TestGenerate(t *testing.T) {
 	})
 	out := bytes.NewBuffer([]byte{})
 	generate(testCfg, "", false, out)
-	util.CompareContent(out.Bytes(), goldenFile, t)
+	util.CompareContent(t, out.Bytes(), goldenFile)
 }

--- a/pkg/test/framework/components/echo/kube/deployment_test.go
+++ b/pkg/test/framework/components/echo/kube/deployment_test.go
@@ -208,14 +208,14 @@ func TestDeploymentYAML(t *testing.T) {
 				t.Errorf("failed to generate deployment %v", err)
 			}
 			gotBytes := []byte(serviceYAML + "---" + deploymentYAML)
-			wantedBytes := testutil.ReadGoldenFile(gotBytes, tc.wantFilePath, t)
+			wantedBytes := testutil.ReadGoldenFile(t, gotBytes, tc.wantFilePath)
 
 			wantBytes := testutil.StripVersion(wantedBytes)
 			gotBytes = testutil.StripVersion(gotBytes)
 
-			testutil.RefreshGoldenFile(gotBytes, tc.wantFilePath, t)
+			testutil.RefreshGoldenFile(t, gotBytes, tc.wantFilePath)
 
-			testutil.CompareBytes(gotBytes, wantBytes, tc.wantFilePath, t)
+			testutil.CompareBytes(t, gotBytes, wantBytes, tc.wantFilePath)
 		})
 	}
 }

--- a/pkg/test/util/assert/assert.go
+++ b/pkg/test/util/assert/assert.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/protobuf/testing/protocmp"
+
 	"istio.io/istio/pkg/test"
 )
 

--- a/pkg/test/util/assert/assert.go
+++ b/pkg/test/util/assert/assert.go
@@ -1,3 +1,17 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package assert
 
 import (

--- a/pkg/test/util/assert/assert.go
+++ b/pkg/test/util/assert/assert.go
@@ -1,0 +1,35 @@
+package assert
+
+import (
+	"strings"
+
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/testing/protocmp"
+	"istio.io/istio/pkg/test"
+)
+
+// Equal
+func Equal(t test.Failer, a, b interface{}, context ...string) {
+	t.Helper()
+	if !cmp.Equal(a, b, protocmp.Transform()) {
+		cs := ""
+		if len(context) > 0 {
+			cs = " " + strings.Join(context, ", ") + ":"
+		}
+		t.Fatal("found diff:%s %v", cs, cmp.Diff(a, b, protocmp.Transform()))
+	}
+}
+
+func Error(t test.Failer, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected error but got nil")
+	}
+}
+
+func NoError(t test.Failer, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatal("expected no error but got: %v", err)
+	}
+}

--- a/pkg/url/url_test.go
+++ b/pkg/url/url_test.go
@@ -17,7 +17,7 @@ package url
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"istio.io/istio/pkg/test/util/assert"
 )
 
 func TestURL(t *testing.T) {

--- a/security/pkg/nodeagent/caclient/providers/citadel/client_test.go
+++ b/security/pkg/nodeagent/caclient/providers/citadel/client_test.go
@@ -85,7 +85,7 @@ func tlsOptions(t *testing.T) grpc.ServerOption {
 	}
 	peerCertVerifier := spiffe.NewPeerCertVerifier()
 	if err := peerCertVerifier.AddMappingFromPEM("cluster.local",
-		testutil.ReadFile(filepath.Join(env.IstioSrc, "./tests/testdata/certs/pilot/root-cert.pem"), t)); err != nil {
+		testutil.ReadFile(t, filepath.Join(env.IstioSrc, "./tests/testdata/certs/pilot/root-cert.pem"))); err != nil {
 		t.Fatal(err)
 	}
 	return grpc.Creds(credentials.NewTLS(&tls.Config{
@@ -130,7 +130,7 @@ func TestCitadelClientRotation(t *testing.T) {
 		server := mockCAServer{Certs: fakeCert, Err: nil, Authenticator: security.NewFakeAuthenticator("ca")}
 		addr := serve(t, server, tlsOptions(t))
 		opts := &security.Options{CAEndpoint: addr, JWTPath: "testdata/token", ProvCert: certDir}
-		cli, err := NewCitadelClient(opts, true, testutil.ReadFile(filepath.Join(certDir, "root-cert.pem"), t))
+		cli, err := NewCitadelClient(opts, true, testutil.ReadFile(t, filepath.Join(certDir, "root-cert.pem")))
 		if err != nil {
 			t.Errorf("failed to create ca client: %v", err)
 		}
@@ -146,7 +146,7 @@ func TestCitadelClientRotation(t *testing.T) {
 		server := mockCAServer{Certs: fakeCert, Err: nil, Authenticator: security.NewFakeAuthenticator("ca")}
 		addr := serve(t, server, tlsOptions(t))
 		opts := &security.Options{CAEndpoint: addr, JWTPath: "testdata/token", ProvCert: "."}
-		cli, err := NewCitadelClient(opts, true, testutil.ReadFile(filepath.Join(certDir, "root-cert.pem"), t))
+		cli, err := NewCitadelClient(opts, true, testutil.ReadFile(t, filepath.Join(certDir, "root-cert.pem")))
 		if err != nil {
 			t.Errorf("failed to create ca client: %v", err)
 		}
@@ -161,7 +161,7 @@ func TestCitadelClientRotation(t *testing.T) {
 		server := mockCAServer{Certs: fakeCert, Err: nil, Authenticator: security.NewFakeAuthenticator("ca")}
 		addr := serve(t, server, tlsOptions(t))
 		opts := &security.Options{CAEndpoint: addr, JWTPath: "testdata/token", ProvCert: dir}
-		cli, err := NewCitadelClient(opts, true, testutil.ReadFile(filepath.Join(certDir, "root-cert.pem"), t))
+		cli, err := NewCitadelClient(opts, true, testutil.ReadFile(t, filepath.Join(certDir, "root-cert.pem")))
 		if err != nil {
 			t.Errorf("failed to create ca client: %v", err)
 		}

--- a/tools/bug-report/pkg/processlog/processlog_test.go
+++ b/tools/bug-report/pkg/processlog/processlog_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestTimeRangeFilter(t *testing.T) {
 	testDataDir := filepath.Join(env.IstioSrc, "tools/bug-report/pkg/testdata/")
-	b := util.ReadFile(filepath.Join(testDataDir, "input/ingress.log"), t)
+	b := util.ReadFile(t, filepath.Join(testDataDir, "input/ingress.log"))
 	inLog := string(b)
 	tests := []struct {
 		name      string
@@ -65,7 +65,7 @@ func TestTimeRangeFilter(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var b []byte
 			if !tt.wantEmpty {
-				b = util.ReadFile(filepath.Join(testDataDir, "output", tt.name+".log"), t)
+				b = util.ReadFile(t, filepath.Join(testDataDir, "output", tt.name+".log"))
 			}
 			want := string(b)
 			start, err := time.Parse(time.RFC3339Nano, tt.start)

--- a/tools/istio-iptables/pkg/capture/run_test.go
+++ b/tools/istio-iptables/pkg/capture/run_test.go
@@ -301,5 +301,5 @@ func compareToGolden(t *testing.T, name string, actual []string) {
 	t.Helper()
 	gotBytes := []byte(strings.Join(actual, "\n"))
 	goldenFile := filepath.Join("testdata", name+".golden")
-	testutil.CompareContent(gotBytes, goldenFile, t)
+	testutil.CompareContent(t, gotBytes, goldenFile)
 }


### PR DESCRIPTION
Trim dependency set a bit. Instead, provide our own 20 line library that is Istio opinionated and:
* Supports protobuf properly
* Takes in our `test.Failer` type

Also refactored some helps that use `t` in a non-standard position.