### PR TITLE
Fix ServiceEntry selecting WorkloadEntry with host & UDS address.

### DIFF
--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -266,6 +266,8 @@ type WorkloadInstance struct {
 	Kind     workloadKind      `json:"kind"`
 	Endpoint *IstioEndpoint    `json:"endpoint,omitempty"`
 	PortMap  map[string]uint32 `json:"portMap,omitempty"`
+	// Can only be selected by service entry.
+	ServiceEntryOnly bool `json:"serviceEntryOnly,omitempty"`
 }
 
 // DeepCopy creates a copy of WorkloadInstance.

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -266,8 +266,8 @@ type WorkloadInstance struct {
 	Kind     workloadKind      `json:"kind"`
 	Endpoint *IstioEndpoint    `json:"endpoint,omitempty"`
 	PortMap  map[string]uint32 `json:"portMap,omitempty"`
-	// Can only be selected by service entry.
-	ServiceEntryOnly bool `json:"serviceEntryOnly,omitempty"`
+	// Can only be selected by service entry of DNS type.
+	DNSServiceEntryOnly bool `json:"dnsServiceEntryOnly,omitempty"`
 }
 
 // DeepCopy creates a copy of WorkloadInstance.

--- a/pilot/pkg/serviceregistry/serviceentry/conversion.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion.go
@@ -386,14 +386,14 @@ func (s *ServiceEntryStore) convertWorkloadEntryToWorkloadInstance(cfg config.Co
 		labels[k] = v
 	}
 	addr := we.GetAddress()
-	serviceEntryOnly := false
+	dnsServiceEntryOnly := false
 	if strings.HasPrefix(addr, model.UnixAddressPrefix) {
 		// k8s can't use uds for service objects
-		serviceEntryOnly = true
+		dnsServiceEntryOnly = true
 	}
 	if net.ParseIP(addr) == nil {
 		// k8s can't use workloads with hostnames in the address field.
-		serviceEntryOnly = true
+		dnsServiceEntryOnly = true
 	}
 	tlsMode := getTLSModeFromWorkloadEntry(we)
 	sa := ""
@@ -420,10 +420,10 @@ func (s *ServiceEntryStore) convertWorkloadEntryToWorkloadInstance(cfg config.Co
 			TLSMode:        tlsMode,
 			ServiceAccount: sa,
 		},
-		PortMap:          we.Ports,
-		Namespace:        cfg.Namespace,
-		Name:             cfg.Name,
-		Kind:             model.WorkloadEntryKind,
-		ServiceEntryOnly: serviceEntryOnly,
+		PortMap:             we.Ports,
+		Namespace:           cfg.Namespace,
+		Name:                cfg.Name,
+		Kind:                model.WorkloadEntryKind,
+		DNSServiceEntryOnly: dnsServiceEntryOnly,
 	}
 }

--- a/pilot/pkg/serviceregistry/serviceentry/conversion.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion.go
@@ -386,13 +386,14 @@ func (s *ServiceEntryStore) convertWorkloadEntryToWorkloadInstance(cfg config.Co
 		labels[k] = v
 	}
 	addr := we.GetAddress()
+	serviceEntryOnly := false
 	if strings.HasPrefix(addr, model.UnixAddressPrefix) {
 		// k8s can't use uds for service objects
-		return nil
+		serviceEntryOnly = true
 	}
 	if net.ParseIP(addr) == nil {
 		// k8s can't use workloads with hostnames in the address field.
-		return nil
+		serviceEntryOnly = true
 	}
 	tlsMode := getTLSModeFromWorkloadEntry(we)
 	sa := ""
@@ -419,9 +420,10 @@ func (s *ServiceEntryStore) convertWorkloadEntryToWorkloadInstance(cfg config.Co
 			TLSMode:        tlsMode,
 			ServiceAccount: sa,
 		},
-		PortMap:   we.Ports,
-		Namespace: cfg.Namespace,
-		Name:      cfg.Name,
-		Kind:      model.WorkloadEntryKind,
+		PortMap:          we.Ports,
+		Namespace:        cfg.Namespace,
+		Name:             cfg.Name,
+		Kind:             model.WorkloadEntryKind,
+		ServiceEntryOnly: serviceEntryOnly,
 	}
 }

--- a/pilot/pkg/serviceregistry/serviceentry/conversion_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion_test.go
@@ -1003,7 +1003,7 @@ func TestConvertWorkloadEntryToWorkloadInstance(t *testing.T) {
 						ClusterID: cluster.ID(clusterID),
 					},
 				},
-				ServiceEntryOnly: true,
+				DNSServiceEntryOnly: true,
 			},
 		},
 		{
@@ -1032,7 +1032,7 @@ func TestConvertWorkloadEntryToWorkloadInstance(t *testing.T) {
 						ClusterID: cluster.ID(clusterID),
 					},
 				},
-				ServiceEntryOnly: true,
+				DNSServiceEntryOnly: true,
 			},
 		},
 		{

--- a/pilot/pkg/serviceregistry/serviceentry/conversion_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion_test.go
@@ -988,7 +988,23 @@ func TestConvertWorkloadEntryToWorkloadInstance(t *testing.T) {
 					ServiceAccount: "scooby",
 				},
 			},
-			out: nil,
+			out: &model.WorkloadInstance{
+				Namespace: "ns1",
+				Kind:      model.WorkloadEntryKind,
+				Endpoint: &model.IstioEndpoint{
+					Labels: map[string]string{
+						"topology.istio.io/cluster": clusterID,
+					},
+					Address:        "unix://foo/bar",
+					ServiceAccount: "spiffe://cluster.local/ns/ns1/sa/scooby",
+					TLSMode:        "istio",
+					Namespace:      "ns1",
+					Locality: model.Locality{
+						ClusterID: cluster.ID(clusterID),
+					},
+				},
+				ServiceEntryOnly: true,
+			},
 		},
 		{
 			name: "DNS address",
@@ -1001,7 +1017,23 @@ func TestConvertWorkloadEntryToWorkloadInstance(t *testing.T) {
 					ServiceAccount: "scooby",
 				},
 			},
-			out: nil,
+			out: &model.WorkloadInstance{
+				Namespace: "ns1",
+				Kind:      model.WorkloadEntryKind,
+				Endpoint: &model.IstioEndpoint{
+					Labels: map[string]string{
+						"topology.istio.io/cluster": clusterID,
+					},
+					Address:        "scooby.com",
+					ServiceAccount: "spiffe://cluster.local/ns/ns1/sa/scooby",
+					TLSMode:        "istio",
+					Namespace:      "ns1",
+					Locality: model.Locality{
+						ClusterID: cluster.ID(clusterID),
+					},
+				},
+				ServiceEntryOnly: true,
+			},
 		},
 		{
 			name: "metadata labels only",

--- a/pilot/pkg/serviceregistry/serviceentry/servicediscovery.go
+++ b/pilot/pkg/serviceregistry/serviceentry/servicediscovery.go
@@ -174,7 +174,7 @@ func (s *ServiceEntryStore) workloadEntryHandler(old, curr config.Config, event 
 	}
 
 	wi := s.convertWorkloadEntryToWorkloadInstance(curr, s.Cluster())
-	if wi != nil {
+	if wi != nil && !wi.ServiceEntryOnly {
 		// fire off the k8s handlers
 		for _, h := range s.workloadHandlers {
 			h(wi, event)


### PR DESCRIPTION
Fix https://github.com/istio/istio/issues/36468

For a workload entry, it won't be added to workload instances if address is not IP, which will cause it not being selected if a ServiceEntry being added later. This change will add WorkloadEntry with host and UDS address to workload instances, and mark it explicitly only selectable by ServiceEntry.