### PR TITLE
Add Affinity and Tolerations for deployment

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -61,6 +61,14 @@ spec:
       nodeSelector:
 {{ toYaml .Values.pilot.nodeSelector | indent 8 }}
 {{- end }}
+{{- if .Values.pilot.affinity }}
+      affinity:
+{{- toYaml .Values.pilot.affinity | nindent 8 }}
+{{- end }}
+{{- if .Values.pilot.tolerations }}
+      tolerations:
+{{- toYaml .Values.pilot.tolerations | nindent 6 }}
+{{- end }}
       serviceAccountName: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
 {{- if .Values.global.priorityClassName }}
       priorityClassName: "{{ .Values.global.priorityClassName }}"

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -33,6 +33,8 @@ pilot:
   enableProtocolSniffingForInbound: true
 
   nodeSelector: {}
+  affinity: {}
+  tolerations: []
   podAnnotations: {}
   serviceAnnotations: {}
 


### PR DESCRIPTION
**Please provide a description of this PR:**
Add ability to configure `Affinity` and `Tolerations` for istiod deployment based on [values](https://github.com/istio/istio/blob/master/manifests/charts/istio-control/istio-discovery/values.yaml).
Example of usage:
```yaml
pilot:
  affinity:
    nodeAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
        nodeSelectorTerms:
        - matchExpressions:
          - key: node-role.kubernetes.io/istio
            operator: Exists
  tolerations:
  - key: "node-role.kubernetes.io/istio"
    operator: "Exists"
    effect: "NoSchedule"
```
BTW, [Gateway](https://github.com/istio/istio/blob/master/manifests/charts/gateway/values.yaml#L81-L83) already have ability to configure this.