### PR TITLE
Use buffered channel with signal.Notify

### DIFF
--- a/pkg/istio-agent/agent.go
+++ b/pkg/istio-agent/agent.go
@@ -465,7 +465,7 @@ func (a *Agent) Run(ctx context.Context) (func(), error) {
 		}()
 	} else if a.WaitForSigterm() {
 		// wait for SIGTERM and perform graceful shutdown
-		stop := make(chan os.Signal)
+		stop := make(chan os.Signal, 1)
 		signal.Notify(stop, syscall.SIGTERM)
 		a.wg.Add(1)
 		go func() {


### PR DESCRIPTION
The channel used with signal.Notify should be buffered.