### PR TITLE
Fix endpoint slice cache memory leak

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/endpointslice_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpointslice_test.go
@@ -23,7 +23,9 @@ import (
 	mcs "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 
 	"istio.io/api/label"
+	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry/kube"
+	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/labels"
 )
 
@@ -118,4 +120,84 @@ func TestEndpointSliceFromMCSShouldBeIgnored(t *testing.T) {
 	if len(instances) != 0 {
 		t.Fatalf("should be 0 instances: len(instances) = %v", len(instances))
 	}
+}
+
+func TestEndpointSliceCache(t *testing.T) {
+	cache := newEndpointSliceCache()
+	hostname := host.Name("foo")
+
+	// add a endpoint
+	ep1 := &model.IstioEndpoint{
+		Address:         "1.2.3.4",
+		ServicePortName: "http",
+	}
+	cache.Update(hostname, "slice1", []*model.IstioEndpoint{ep1})
+	if !testEndpointsEqual(cache.Get(hostname), []*model.IstioEndpoint{ep1}) {
+		t.Fatalf("unexpected endpoints")
+	}
+
+	// add a new endpoint
+	ep2 := &model.IstioEndpoint{
+		Address:         "2.3.4.5",
+		ServicePortName: "http",
+	}
+	cache.Update(hostname, "slice1", []*model.IstioEndpoint{ep1, ep2})
+	if !testEndpointsEqual(cache.Get(hostname), []*model.IstioEndpoint{ep1, ep2}) {
+		t.Fatalf("unexpected endpoints")
+	}
+
+	// change service port name
+	ep1 = &model.IstioEndpoint{
+		Address:         "1.2.3.4",
+		ServicePortName: "http2",
+	}
+	ep2 = &model.IstioEndpoint{
+		Address:         "2.3.4.5",
+		ServicePortName: "http2",
+	}
+	cache.Update(hostname, "slice1", []*model.IstioEndpoint{ep1, ep2})
+	if !testEndpointsEqual(cache.Get(hostname), []*model.IstioEndpoint{ep1, ep2}) {
+		t.Fatalf("unexpected endpoints")
+	}
+
+	// add a new slice
+	ep3 := &model.IstioEndpoint{
+		Address:         "3.4.5.6",
+		ServicePortName: "http2",
+	}
+	cache.Update(hostname, "slice2", []*model.IstioEndpoint{ep3})
+	if !testEndpointsEqual(cache.Get(hostname), []*model.IstioEndpoint{ep1, ep2, ep3}) {
+		t.Fatalf("unexpected endpoints")
+	}
+
+	// dedup when transitioning
+	cache.Update(hostname, "slice2", []*model.IstioEndpoint{ep2, ep3})
+	if !testEndpointsEqual(cache.Get(hostname), []*model.IstioEndpoint{ep1, ep2, ep3}) {
+		t.Fatalf("unexpected endpoints")
+	}
+
+	cache.Delete(hostname, "slice1")
+	if !testEndpointsEqual(cache.Get(hostname), []*model.IstioEndpoint{ep2, ep3}) {
+		t.Fatalf("unexpected endpoints")
+	}
+
+	cache.Delete(hostname, "slice2")
+	if cache.Get(hostname) != nil {
+		t.Fatalf("unexpected endpoints")
+	}
+}
+
+func testEndpointsEqual(a, b []*model.IstioEndpoint) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	m1 := make(map[endpointKey]int)
+	m2 := make(map[endpointKey]int)
+	for _, i := range a {
+		m1[endpointKey{i.Address, i.ServicePortName}]++
+	}
+	for _, i := range b {
+		m2[endpointKey{i.Address, i.ServicePortName}]++
+	}
+	return reflect.DeepEqual(m1, m2)
 }


### PR DESCRIPTION
**Please provide a description of this PR:**
If an endpoint was deleted or the endpoint key was updated (e.g. `ServicePortName` changed), then the old endpoint would always remain in `endpointByKey` and never get freed

You can reproduce it with [this test](https://github.com/dddddai/istio/blob/memory-leak/pilot/pkg/serviceregistry/kube/controller/endpointslice_test.go#L125-L154)

So this pr drops `endpointByKey` to fix the problem