### PR TITLE
Fix panic when passing empty status field

### DIFF
--- a/pilot/pkg/config/kube/crd/conversion.go
+++ b/pilot/pkg/config/kube/crd/conversion.go
@@ -59,7 +59,7 @@ func IstioStatusJSONFromMap(jsonMap map[string]interface{}) (config.Status, erro
 	if err != nil {
 		return nil, err
 	}
-	return status, nil
+	return &status, nil
 }
 
 // FromYAML converts a canonical YAML to a proto message

--- a/pilot/pkg/config/kube/crd/conversion_test.go
+++ b/pilot/pkg/config/kube/crd/conversion_test.go
@@ -39,7 +39,7 @@ func TestConvert(t *testing.T) {
 			Annotations:      map[string]string{"annotation": "value"},
 		},
 		Spec: mock.ExampleVirtualService,
-		Status: v1alpha1.IstioStatus{
+		Status: &v1alpha1.IstioStatus{
 			Conditions: []*v1alpha1.IstioCondition{
 				{Type: "Health"},
 			},

--- a/pilot/pkg/config/monitor/file_snapshot_test.go
+++ b/pilot/pkg/config/monitor/file_snapshot_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package monitor_test
+package monitor
 
 import (
 	"os"
@@ -22,7 +22,6 @@ import (
 	"github.com/onsi/gomega"
 
 	networking "istio.io/api/networking/v1alpha3"
-	"istio.io/istio/pilot/pkg/config/monitor"
 	"istio.io/istio/pkg/config/schema/collection"
 	"istio.io/istio/pkg/config/schema/collections"
 )
@@ -41,6 +40,24 @@ spec:
     hosts:
     - "*.example.com"
 `
+
+var statusRegressionYAML = `
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: test
+  namespace: test-1
+spec:
+  selector:
+    app: istio-ingressgateway
+  servers:
+  - hosts:
+    - example.com
+    port:
+      name: http
+      number: 80
+      protocol: HTTP
+status: {}`
 
 var virtualServiceYAML = `
 apiVersion: networking.istio.io/v1alpha3
@@ -68,7 +85,7 @@ func TestFileSnapshotNoFilter(t *testing.T) {
 	ts.testSetup(t)
 	defer ts.testTeardown(t)
 
-	fileWatcher := monitor.NewFileSnapshot(ts.rootPath, collection.SchemasFor(), "foo")
+	fileWatcher := NewFileSnapshot(ts.rootPath, collection.SchemasFor(), "foo")
 	configs, err := fileWatcher.ReadConfigFiles()
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	g.Expect(configs).To(gomega.HaveLen(1))
@@ -93,7 +110,7 @@ func TestFileSnapshotWithFilter(t *testing.T) {
 	ts.testSetup(t)
 	defer ts.testTeardown(t)
 
-	fileWatcher := monitor.NewFileSnapshot(ts.rootPath, collection.SchemasFor(collections.IstioNetworkingV1Alpha3Virtualservices), "")
+	fileWatcher := NewFileSnapshot(ts.rootPath, collection.SchemasFor(collections.IstioNetworkingV1Alpha3Virtualservices), "")
 	configs, err := fileWatcher.ReadConfigFiles()
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	g.Expect(configs).To(gomega.HaveLen(1))
@@ -115,7 +132,7 @@ func TestFileSnapshotSorting(t *testing.T) {
 	ts.testSetup(t)
 	defer ts.testTeardown(t)
 
-	fileWatcher := monitor.NewFileSnapshot(ts.rootPath, collection.SchemasFor(), "")
+	fileWatcher := NewFileSnapshot(ts.rootPath, collection.SchemasFor(), "")
 
 	configs, err := fileWatcher.ReadConfigFiles()
 	g.Expect(err).NotTo(gomega.HaveOccurred())

--- a/pilot/pkg/config/monitor/monitor_test.go
+++ b/pilot/pkg/config/monitor/monitor_test.go
@@ -27,6 +27,7 @@ import (
 	"istio.io/istio/pkg/config/schema/collection"
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/config/schema/gvk"
+	"istio.io/istio/pkg/test/util/retry"
 )
 
 var createConfigSet = []*config.Config{
@@ -144,6 +145,24 @@ func TestMonitorForChange(t *testing.T) {
 	g.Eventually(func() ([]config.Config, error) {
 		return store.List(gvk.Gateway, "")
 	}).Should(gomega.HaveLen(0))
+}
+
+func TestMonitorFileSnapshot(t *testing.T) {
+	ts := &testState{
+		ConfigFiles: map[string][]byte{"gateway.yml": []byte(statusRegressionYAML)},
+	}
+
+	ts.testSetup(t)
+	defer ts.testTeardown(t)
+
+	store := memory.Make(collection.SchemasFor(collections.IstioNetworkingV1Alpha3Gateways))
+	fileWatcher := NewFileSnapshot(ts.rootPath, collection.SchemasFor(), "foo")
+
+	mon := NewMonitor("", store, fileWatcher.ReadConfigFiles, "")
+	stop := make(chan struct{})
+	defer func() { close(stop) }()
+	mon.Start(stop)
+	retry.UntilOrFail(t, func() bool { return store.Get(gvk.Gateway, "test", "test-1") != nil })
 }
 
 func TestMonitorForError(t *testing.T) {

--- a/pkg/config/model.go
+++ b/pkg/config/model.go
@@ -273,12 +273,21 @@ func DeepCopy(s interface{}) interface{} {
 		return nil
 	}
 
-	data := reflect.New(reflect.TypeOf(s).Elem()).Interface()
-	err = json.Unmarshal(js, &data)
-	if err != nil {
-		return nil
+	var data interface{}
+	if reflect.TypeOf(s).Kind() != reflect.Ptr {
+		data = reflect.New(reflect.TypeOf(s)).Interface()
+		if err := json.Unmarshal(js, data); err != nil {
+			return nil
+		}
+		data = reflect.ValueOf(data).Elem().Interface()
+		return data
+	} else {
+		data = reflect.New(reflect.TypeOf(s).Elem()).Interface()
+		if err := json.Unmarshal(js, data); err != nil {
+			return nil
+		}
+		return data
 	}
-	return data
 }
 
 type Status interface{}

--- a/pkg/config/model.go
+++ b/pkg/config/model.go
@@ -273,21 +273,12 @@ func DeepCopy(s interface{}) interface{} {
 		return nil
 	}
 
-	var data interface{}
-	if reflect.TypeOf(s).Kind() != reflect.Ptr {
-		data = reflect.New(reflect.TypeOf(s)).Interface()
-		if err := json.Unmarshal(js, data); err != nil {
-			return nil
-		}
-		data = reflect.ValueOf(data).Elem().Interface()
-		return data
-	} else {
-		data = reflect.New(reflect.TypeOf(s).Elem()).Interface()
-		if err := json.Unmarshal(js, data); err != nil {
-			return nil
-		}
-		return data
+	data := reflect.New(reflect.TypeOf(s)).Interface()
+	if err := json.Unmarshal(js, data); err != nil {
+		return nil
 	}
+	data = reflect.ValueOf(data).Elem().Interface()
+	return data
 }
 
 type Status interface{}

--- a/pkg/config/model_test.go
+++ b/pkg/config/model_test.go
@@ -120,12 +120,52 @@ func TestDeepCopyTypes(t *testing.T) {
 			},
 			protocmp.Transform(),
 		},
-		// Random struct
+		// Random struct pointer
 		{
 			&TestStruct{Name: "foobar"},
 			func(c Spec) Spec {
 				c.(*TestStruct).Name = "bar"
 				return c
+			},
+			nil,
+		},
+		// Random struct
+		{
+			TestStruct{Name: "foobar"},
+			func(c Spec) Spec {
+				x := c.(TestStruct)
+				x.Name = "bar"
+				return x
+			},
+			nil,
+		},
+		// Slice
+		{
+			[]string{"foo"},
+			func(c Spec) Spec {
+				x := c.([]string)
+				x[0] = "a"
+				return x
+			},
+			nil,
+		},
+		// Array
+		{
+			[1]string{"foo"},
+			func(c Spec) Spec {
+				x := c.([1]string)
+				x[0] = "a"
+				return x
+			},
+			nil,
+		},
+		// Map
+		{
+			map[string]string{"a": "b"},
+			func(c Spec) Spec {
+				x := c.(map[string]string)
+				x["a"] = "x"
+				return x
 			},
 			nil,
 		},


### PR DESCRIPTION
When DeepCopy is called on objects that have gone through this conversion, they may panic as DeepCopy doesn't handle non-pointers, and the conversion logic has Status as a non-pointer.

This PR does two things:
* Make Status a pointer, which I think it should be since we are expected to always have pointers for protos. golang/protobuf makes this requirement more explicit which we will likely move to soon anyways
* Makes DeepCopy robust to non-pointer types and adds a bunch of tets.