### PR TITLE
Speed up grpc tests

### DIFF
--- a/pilot/pkg/networking/grpcgen/grpcecho_test.go
+++ b/pilot/pkg/networking/grpcgen/grpcecho_test.go
@@ -46,6 +46,7 @@ const grpcEchoPort = 14058
 type echoCfg struct {
 	version   string
 	namespace string
+	tls       bool
 }
 
 type configGenTest struct {
@@ -75,6 +76,15 @@ func newConfigGenTest(t *testing.T, discoveryOpts xds.FakeOptions, servers ...ec
 	cgt := &configGenTest{T: t}
 	wg := sync.WaitGroup{}
 	for i, s := range servers {
+		host := fmt.Sprintf("127.0.0.%d", i+1)
+		discoveryOpts.Configs = append(discoveryOpts.Configs, makeWE(s, host, grpcEchoPort))
+	}
+	discoveryOpts.ListenerBuilder = func() (net.Listener, error) {
+		return net.Listen("tcp", grpcXdsAddr)
+	}
+	// Start XDS server
+	cgt.ds = xds.NewFakeDiscoveryServer(t, discoveryOpts)
+	for i, s := range servers {
 		if s.namespace == "" {
 			s.namespace = "default"
 		}
@@ -92,6 +102,7 @@ func newConfigGenTest(t *testing.T, discoveryOpts xds.FakeOptions, servers ...ec
 				Port:             grpcEchoPort,
 				Protocol:         protocol.GRPC,
 				XDSServer:        true,
+				XDSReadinessTLS:  s.tls,
 				XDSTestBootstrap: bootstrapBytes,
 			},
 			ListenerIP: host,
@@ -107,17 +118,12 @@ func newConfigGenTest(t *testing.T, discoveryOpts xds.FakeOptions, servers ...ec
 			t.Fatal(err)
 		}
 		cgt.endpoints = append(cgt.endpoints, ep)
-		discoveryOpts.Configs = append(discoveryOpts.Configs, makeWE(s, host, grpcEchoPort))
 		t.Cleanup(func() {
 			if err := ep.Close(); err != nil {
 				t.Errorf("failed to close endpoint %s: %v", host, err)
 			}
 		})
 	}
-	discoveryOpts.ListenerBuilder = func() (net.Listener, error) {
-		return net.Listen("tcp", grpcXdsAddr)
-	}
-	cgt.ds = xds.NewFakeDiscoveryServer(t, discoveryOpts)
 	// we know onReady will get called because there are internal timeouts for this
 	wg.Wait()
 	return cgt
@@ -272,7 +278,7 @@ spec:
   mtls:
     mode: STRICT
 `,
-	}, echoCfg{version: "v1"})
+	}, echoCfg{version: "v1", tls: true})
 
 	// ensure we can make 10 consecutive successful requests
 	retry.UntilSuccessOrFail(tt.T, func() error {
@@ -318,7 +324,7 @@ spec:
   - fault:
       delay:
         percent: 100
-        fixedDelay: 1s
+        fixedDelay: 100ms
     route:
     - destination:
         host: echo-app.default.svc.cluster.local
@@ -333,7 +339,7 @@ spec:
 	if err != nil {
 		t.Fatal(err)
 	}
-	if duration < time.Second {
+	if duration < time.Millisecond*100 {
 		t.Fatalf("expected to take over 1s but took %v", duration)
 	}
 

--- a/pkg/test/echo/common/model.go
+++ b/pkg/test/echo/common/model.go
@@ -69,6 +69,9 @@ type Port struct {
 
 	// XDSTestBootstrap allows settings per-endpoint bootstrap without using the GRPC_XDS_BOOTSTRAP env var
 	XDSTestBootstrap []byte
+
+	// XDSReadinessTLS determines if the XDS server should expect a TLS server, used for readiness probes
+	XDSReadinessTLS bool
 }
 
 // PortList is a set of ports


### PR DESCRIPTION
Currently these block for 10s each because the readiness probe is not
valid. This probe has a 10s timeout.

Even with this running multiple tests back-to-back adds a 1s delay where
it fails the first connection with a 1s timeout then tries again. I
don't know why - might be a real bug.

**Please provide a description of this PR:**