### PR TITLE
Drop packets in INVALID state to avoid intermittent connection reset from sidecar

### DIFF
--- a/tools/istio-iptables/pkg/capture/run.go
+++ b/tools/istio-iptables/pkg/capture/run.go
@@ -424,6 +424,9 @@ func (cfg *IptablesConfigurator) Run() {
 	cfg.iptables.AppendRule(iptableslog.UndefinedCommand, constants.ISTIOINBOUND, constants.NAT, "-p", constants.TCP, "--dport",
 		cfg.cfg.InboundTunnelPort, "-j", constants.RETURN)
 
+	cfg.iptables.AppendRule(iptableslog.UndefinedCommand, constants.ISTIOINBOUND, constants.MANGLE, "-m", "conntrack", "--ctstate",
+		"INVALID", "-j", constants.DROP)
+
 	// Create a new chain for redirecting outbound traffic to the common Envoy port.
 	// In both chains, '-j RETURN' bypasses Envoy and '-j ISTIOREDIRECT'
 	// redirects to Envoy.

--- a/tools/istio-iptables/pkg/constants/constants.go
+++ b/tools/istio-iptables/pkg/constants/constants.go
@@ -53,6 +53,7 @@ const (
 	REDIRECT = "REDIRECT"
 	MARK     = "MARK"
 	CT       = "CT"
+	DROP     = "DROP"
 )
 
 const (


### PR DESCRIPTION
**Please provide a description of this PR:**
This is to fix bug https://github.com/istio/istio/issues/36489 
Similar upstream issue in k8s https://kubernetes.io/blog/2019/03/29/kube-proxy-subtleties-debugging-an-intermittent-connection-reset/

We find the root cause that sidecar will intermittent reset the connection to ingress gateway during high throughput request(like upload large files 300MB) and the root cause is that there are some out of order packet comes to backend application directly without being DNAT by iptables, so the application reset it directly.

Here is the overflow:

![Screen Shot 2021-12-16 at 8 33 51 PM](https://user-images.githubusercontent.com/12857255/146373145-83601fac-4a9b-4bf3-bf36-e8352d115c59.png)


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ x] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure