### PR TITLE
Add UNINITIALIZED state to `istioctl proxy-config secret`

### DIFF
--- a/istioctl/pkg/writer/compare/sds/util.go
+++ b/istioctl/pkg/writer/compare/sds/util.go
@@ -162,6 +162,9 @@ func GetEnvoySecrets(
 			return nil, fmt.Errorf("failed building warming secret %s: %v",
 				activeSecret.Name, err)
 		}
+		if activeSecret.VersionInfo == "uninitialized" {
+			secret.State = "UNINITIALIZED"
+		}
 		proxySecretItems = append(proxySecretItems, secret)
 	}
 	return proxySecretItems, nil


### PR DESCRIPTION
This is a state Envoy can get into when it fails to parse a secret.
Today, everything in istioctl reports its fine, when it really is just
as blocking as `WARMING`

Can reproduce with a cert that has the cert field in both the cert AND key section. which is not valid of course