### PR TITLE
Fix build-services.sh building error

### DIFF
--- a/samples/bookinfo/src/productpage/Dockerfile
+++ b/samples/bookinfo/src/productpage/Dockerfile
@@ -16,7 +16,11 @@ FROM python:3.7.7-slim
 
 WORKDIR /
 COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
+RUN apt-get update \
+    && apt-get install gcc --no-install-recommends -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip install --no-cache-dir -r requirements.txt
 
 COPY test-requirements.txt ./
 RUN pip install --no-cache-dir -r test-requirements.txt


### PR DESCRIPTION
**Please provide a description of this PR:**
When executing
```
cd samples/bookinfo
src/build-services.sh <version> <prefix>
```
The log shows there's an error:
```
#7 19.76     creating build/temp.linux-aarch64-3.7
--
#7 19.76     gcc -pthread -Wno-unused-result   -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC   -I/usr/local/include/python3.7m -c greenlet.c -o   build/temp.linux-aarch64-3.7/greenlet.o
#7 19.76     unable to execute 'gcc': No such file or   directory
#7 19.76     error: command 'gcc' failed with exit   status 1
```

Added `gcc` to build services successfully.