### PR TITLE
Bump min k8s version to 1.19

### DIFF
--- a/istioctl/pkg/install/k8sversion/version.go
+++ b/istioctl/pkg/install/k8sversion/version.go
@@ -28,7 +28,7 @@ import (
 const (
 	// MinK8SVersion is the minimum k8s version required to run this version of Istio
 	// https://istio.io/docs/setup/platform-setup/
-	MinK8SVersion = 17
+	MinK8SVersion = 19
 )
 
 // CheckKubernetesVersion checks if this Istio version is supported in the k8s version

--- a/releasenotes/notes/k8s_version_19.yaml
+++ b/releasenotes/notes/k8s_version_19.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+releaseNotes:
+  - |
+    **Updated** Min Kubernetes version to 1.19.


### PR DESCRIPTION
According to https://istio.io/latest/docs/releases/supported-releases/#support-status-of-istio-releases, the min k8s version is 1.19.