### PR TITLE
Fix rootca-compare cmd validate logic error

### DIFF
--- a/istioctl/cmd/proxyconfig.go
+++ b/istioctl/cmd/proxyconfig.go
@@ -959,7 +959,7 @@ func rootCACompareConfigCmd() *cobra.Command {
   istioctl proxy-config rootca-compare <pod-name-1[.namespace]> <pod-name-2[.namespace]>`,
 		Aliases: []string{"rootca-compare", "rc"},
 		Args: func(cmd *cobra.Command, args []string) error {
-			if (len(args) <= 2) != (configDumpFile == "") {
+			if len(args) != 2 {
 				cmd.Println(cmd.UsageString())
 				return fmt.Errorf("rootca-compare requires 2 pods as an argument")
 			}


### PR DESCRIPTION
`configDumpFile` not inited in this cmd... we should not use it...