### PR TITLE
Fix missing trustDomain is helm templated configmap

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/configmap.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/configmap.yaml
@@ -1,7 +1,7 @@
 {{- define "mesh" }}
     # The trust domain corresponds to the trust root of a system.
     # Refer to https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE-ID.md#21-trust-domain
-    trustDomain: "cluster.local"
+    trustDomain: {{ .Values.meshConfig.trustDomain }}
 
     # The namespace to treat as the administrative root namespace for Istio configuration.
     # When processing a leaf namespace Istio will search for declarations in that namespace first

--- a/manifests/charts/istiod-remote/templates/configmap.yaml
+++ b/manifests/charts/istiod-remote/templates/configmap.yaml
@@ -1,7 +1,7 @@
 {{- define "mesh" }}
     # The trust domain corresponds to the trust root of a system.
     # Refer to https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE-ID.md#21-trust-domain
-    trustDomain: "cluster.local"
+    trustDomain: {{ .Values.meshConfig.trustDomain }}
 
     # The namespace to treat as the administrative root namespace for Istio configuration.
     # When processing a leaf namespace Istio will search for declarations in that namespace first


### PR DESCRIPTION
Not all trustDomain values are templated in the helm chart, resulting in incorrect
handling of trust domains that is other than cluster.local. This fixes the configmap
for remote and control.

Fixes: #36554

- [ ] Configuration Infrastructure
- [ ] Docs
- [X] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure