### PR TITLE
Bugfix: changes in delegate virtual service do not take effect

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -842,6 +842,9 @@ func (ps *PushContext) VirtualServicesForGateway(proxy *Proxy, gateway string) [
 // DelegateVirtualServicesConfigKey lists all the delegate virtual services configkeys associated with the provided virtual services
 func (ps *PushContext) DelegateVirtualServicesConfigKey(vses []config.Config) []ConfigKey {
 	var out []ConfigKey
+	if !features.EnableVirtualServiceDelegate {
+		return out
+	}
 	for _, vs := range vses {
 		out = append(out, ps.virtualServiceIndex.delegates[ConfigKey{Kind: gvk.VirtualService, Namespace: vs.Namespace, Name: vs.Name}]...)
 	}

--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -288,16 +288,17 @@ func BuildSidecarOutboundVirtualHosts(node *model.Proxy, push *model.PushContext
 		})
 
 		routeCache = &istio_route.Cache{
-			RouteName:       routeName,
-			ProxyVersion:    node.Metadata.IstioVersion,
-			ClusterID:       string(node.Metadata.ClusterID),
-			DNSDomain:       node.DNSDomain,
-			DNSCapture:      bool(node.Metadata.DNSCapture),
-			DNSAutoAllocate: bool(node.Metadata.DNSAutoAllocate),
-			ListenerPort:    listenerPort,
-			Services:        services,
-			VirtualServices: virtualServices,
-			EnvoyFilterKeys: efKeys,
+			RouteName:               routeName,
+			ProxyVersion:            node.Metadata.IstioVersion,
+			ClusterID:               string(node.Metadata.ClusterID),
+			DNSDomain:               node.DNSDomain,
+			DNSCapture:              bool(node.Metadata.DNSCapture),
+			DNSAutoAllocate:         bool(node.Metadata.DNSAutoAllocate),
+			ListenerPort:            listenerPort,
+			Services:                services,
+			VirtualServices:         virtualServices,
+			DelegateVirtualServices: push.DelegateVirtualServicesConfigKey(virtualServices),
+			EnvoyFilterKeys:         efKeys,
 		}
 	}
 

--- a/pilot/pkg/networking/core/v1alpha3/route/route_cache_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route_cache_test.go
@@ -1,0 +1,83 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package route
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+
+	networking "istio.io/api/networking/v1alpha3"
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/config"
+	"istio.io/istio/pkg/config/schema/gvk"
+)
+
+func TestClearRDSCacheOnDelegateUpdate(t *testing.T) {
+	xdsCache := model.NewXdsCache()
+	// root virtual service
+	root := config.Config{
+		Meta: config.Meta{Name: "root", Namespace: "default"},
+		Spec: &networking.VirtualService{
+			Http: []*networking.HTTPRoute{
+				{
+					Name: "route",
+					Delegate: &networking.Delegate{
+						Namespace: "default",
+						Name:      "delegate",
+					},
+				},
+			},
+		},
+	}
+	// delegate virtual service
+	delegate := model.ConfigKey{Kind: gvk.VirtualService, Name: "delegate", Namespace: "default"}
+	// rds cache entry
+	entry := Cache{
+		VirtualServices:         []config.Config{root},
+		DelegateVirtualServices: []model.ConfigKey{delegate},
+		ListenerPort:            8080,
+	}
+	resource := &discovery.Resource{Name: "bar"}
+
+	// add resource to cache
+	xdsCache.Add(&entry, &model.PushRequest{Start: time.Now()}, resource)
+	if got, found := xdsCache.Get(&entry); !found || !reflect.DeepEqual(got, resource) {
+		t.Fatalf("rds cache was not updated")
+	}
+
+	// clear cache when delegate virtual service is updated
+	// this func is called by `dropCacheForRequest` in `initPushContext`
+	xdsCache.Clear(map[model.ConfigKey]struct{}{
+		delegate: {},
+	})
+	if _, found := xdsCache.Get(&entry); found {
+		t.Fatalf("rds cache was not cleared")
+	}
+
+	// add resource to cache
+	xdsCache.Add(&entry, &model.PushRequest{Start: time.Now()}, resource)
+	irrelevantDelegate := model.ConfigKey{Kind: gvk.VirtualService, Name: "foo", Namespace: "default"}
+
+	// don't clear cache when irrelevant delegate virtual service is updated
+	xdsCache.Clear(map[model.ConfigKey]struct{}{
+		irrelevantDelegate: {},
+	})
+	if got, found := xdsCache.Get(&entry); !found || !reflect.DeepEqual(got, resource) {
+		t.Fatalf("rds cache was cleared by irrelevant delegate virtual service update")
+	}
+}

--- a/releasenotes/notes/refresh-rds-cache.yaml
+++ b/releasenotes/notes/refresh-rds-cache.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+- https://github.com/istio/istio/issues/36525
+releaseNotes:
+- |
+  **Fixed** changes in delegate virtual service do not take effect when rds cache enabled


### PR DESCRIPTION
**Please provide a description of this PR:**
The root cause is that the rds cache is not cleared when delegate virtual services were updated

This pr adds delegate virtual services to dependent configs of the rds cache entry, so that we can clear the cache when delegate virtual services are updated

Fix #36525