### PR TITLE
Stop plugin certs watch when server shuts down.

### DIFF
--- a/pilot/pkg/bootstrap/istio_ca.go
+++ b/pilot/pkg/bootstrap/istio_ca.go
@@ -333,7 +333,7 @@ func (s *Server) handleCACertsFileWatch() {
 
 		case event, ok := <-s.cacertsWatcher.Events:
 			if !ok {
-				log.Info("Failed to catch events on cacerts files")
+				log.Error("Failed to catch events on cacerts files")
 				continue
 			}
 
@@ -348,6 +348,9 @@ func (s *Server) handleCACertsFileWatch() {
 			if err != nil {
 				log.Error("Failed to catch events on cacerts file: ", err)
 			}
+
+		case <-s.internalStop:
+			return
 		}
 	}
 }

--- a/pilot/pkg/bootstrap/istio_ca.go
+++ b/pilot/pkg/bootstrap/istio_ca.go
@@ -333,8 +333,8 @@ func (s *Server) handleCACertsFileWatch() {
 
 		case event, ok := <-s.cacertsWatcher.Events:
 			if !ok {
-				log.Error("Failed to catch events on cacerts files")
-				continue
+				log.Debug("plugin cacerts watch stopped")
+				return
 			}
 
 			if event.Op&fsnotify.Write == fsnotify.Write || event.Op&fsnotify.Create == fsnotify.Create {
@@ -347,6 +347,7 @@ func (s *Server) handleCACertsFileWatch() {
 		case err := <-s.cacertsWatcher.Errors:
 			if err != nil {
 				log.Error("Failed to catch events on cacerts file: ", err)
+				return
 			}
 
 		case <-s.internalStop:


### PR DESCRIPTION
Otherwise istiod pod will spam with file watch error:

```
2021-12-20T00:52:36.229935Z     info   Failed to catch events on cacerts files
2021-12-20T00:52:36.229938Z     info   Failed to catch events on cacerts files
2021-12-20T00:52:36.229942Z     info   Failed to catch events on cacerts files
2021-12-20T00:52:36.229946Z     info   Failed to catch events on cacerts files
2021-12-20T00:52:36.229950Z     info   Failed to catch events on cacerts files
2021-12-20T00:52:36.229954Z     info   Failed to catch events on cacerts files
2021-12-20T00:52:36.229957Z     info   Failed to catch events on cacerts files
```