### PR TITLE
Deflake CNI TestInstall by prolonging timeout.

### DIFF
--- a/cni/test/install_cni.go
+++ b/cni/test/install_cni.go
@@ -218,7 +218,7 @@ func compareConfResult(result, expected string, t *testing.T) {
 	t.Helper()
 	retry.UntilSuccessOrFail(t, func() error {
 		return checkResult(result, expected)
-	}, retry.Delay(time.Millisecond*10), retry.Timeout(time.Second))
+	}, retry.Delay(time.Millisecond*10), retry.Timeout(time.Second*3))
 }
 
 // checkBinDir verifies the presence/absence of test files.


### PR DESCRIPTION
Example failure: https://storage.googleapis.com/istio-prow/pr-logs/pull/istio_istio/36564/unit-tests_istio/1472733363956617216/build-log.txt