### PR TITLE
Drop packets in INVALID state to avoid intermittent connection reset from sidecar

### DIFF
--- a/releasenotes/notes/36566.yaml
+++ b/releasenotes/notes/36566.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - https://github.com/istio/istio/pull/36566
+releaseNotes:
+  - |
+    **Fixed** an issue that sidecar iptables will cause intermittent connection reset due to the out of window packet.
+    Introduced a flag meshConfig.defaultConfig.proxyMetadata.ISTIO_META_INVALID_DROP to control this setting.
+

--- a/tools/istio-iptables/pkg/capture/run.go
+++ b/tools/istio-iptables/pkg/capture/run.go
@@ -131,7 +131,8 @@ func (cfg *IptablesConfigurator) logConfig() {
 	b.WriteString(fmt.Sprintf("ISTIO_EXCLUDE_INTERFACES=%s\n", os.Getenv("ISTIO_EXCLUDE_INTERFACES")))
 	b.WriteString(fmt.Sprintf("ISTIO_SERVICE_CIDR=%s\n", os.Getenv("ISTIO_SERVICE_CIDR")))
 	b.WriteString(fmt.Sprintf("ISTIO_SERVICE_EXCLUDE_CIDR=%s\n", os.Getenv("ISTIO_SERVICE_EXCLUDE_CIDR")))
-	b.WriteString(fmt.Sprintf("ISTIO_META_DNS_CAPTURE=%s", os.Getenv("ISTIO_META_DNS_CAPTURE")))
+	b.WriteString(fmt.Sprintf("ISTIO_META_DNS_CAPTURE=%s\n", os.Getenv("ISTIO_META_DNS_CAPTURE")))
+	b.WriteString(fmt.Sprintf("ISTIO_META_INVALID_DROP=%s\n", os.Getenv("ISTIO_META_INVALID_DROP")))
 	log.Infof("Istio iptables environment:\n%s", b.String())
 	cfg.cfg.Print()
 }
@@ -354,6 +355,13 @@ func (cfg *IptablesConfigurator) Run() {
 
 	// Do not capture internal interface.
 	cfg.shortCircuitKubeInternalInterface()
+
+	// Create a rule for invalid drop in PREROUTING chain in mangle table, so the iptables will drop the out of window packets instead of reset connection .
+	dropInvalid := cfg.cfg.DropInvalid
+	if dropInvalid {
+		cfg.iptables.AppendRule(iptableslog.UndefinedCommand, constants.PREROUTING, constants.MANGLE, "-m", "conntrack", "--ctstate",
+			"INVALID", "-j", constants.DROP)
+	}
 
 	// Create a new chain for to hit tunnel port directly. Envoy will be listening on port acting as VPN tunnel.
 	cfg.iptables.AppendRule(iptableslog.UndefinedCommand, constants.ISTIOINBOUND, constants.NAT, "-p", constants.TCP, "--dport",

--- a/tools/istio-iptables/pkg/capture/run_test.go
+++ b/tools/istio-iptables/pkg/capture/run_test.go
@@ -228,6 +228,12 @@ func TestIptables(t *testing.T) {
 				cfg.TraceLogging = true
 			},
 		},
+		{
+			"drop-invalid",
+			func(cfg *config.Config) {
+				cfg.DropInvalid = true
+			},
+		},
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {

--- a/tools/istio-iptables/pkg/capture/testdata/drop-invalid.golden
+++ b/tools/istio-iptables/pkg/capture/testdata/drop-invalid.golden
@@ -1,0 +1,17 @@
+iptables -t nat -N ISTIO_INBOUND
+iptables -t nat -N ISTIO_REDIRECT
+iptables -t nat -N ISTIO_IN_REDIRECT
+iptables -t nat -N ISTIO_OUTPUT
+iptables -t mangle -A PREROUTING -m conntrack --ctstate INVALID -j DROP
+iptables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
+iptables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
+iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
+iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
+iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
+iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT
+iptables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 1337 -j RETURN
+iptables -t nat -A ISTIO_OUTPUT -m owner --uid-owner 1337 -j RETURN
+iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --gid-owner 1337 -j ISTIO_IN_REDIRECT
+iptables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --gid-owner 1337 -j RETURN
+iptables -t nat -A ISTIO_OUTPUT -m owner --gid-owner 1337 -j RETURN
+iptables -t nat -A ISTIO_OUTPUT -d 127.0.0.1/32 -j RETURN

--- a/tools/istio-iptables/pkg/config/config.go
+++ b/tools/istio-iptables/pkg/config/config.go
@@ -50,6 +50,7 @@ type Config struct {
 	SkipRuleApply           bool          `json:"SKIP_RULE_APPLY"`
 	RunValidation           bool          `json:"RUN_VALIDATION"`
 	RedirectDNS             bool          `json:"REDIRECT_DNS"`
+	DropInvalid             bool          `json:"DROP_INVALID"`
 	CaptureAllDNS           bool          `json:"CAPTURE_ALL_DNS"`
 	EnableInboundIPv6       bool          `json:"ENABLE_INBOUND_IPV6"`
 	DNSServersV4            []string      `json:"DNS_SERVERS_V4"`
@@ -87,6 +88,7 @@ func (c *Config) Print() {
 	b.WriteString(fmt.Sprintf("KUBE_VIRT_INTERFACES=%s\n", c.KubeVirtInterfaces))
 	b.WriteString(fmt.Sprintf("ENABLE_INBOUND_IPV6=%t\n", c.EnableInboundIPv6))
 	b.WriteString(fmt.Sprintf("DNS_CAPTURE=%t\n", c.RedirectDNS))
+	b.WriteString(fmt.Sprintf("DROP_INVALID=%t\n", c.DropInvalid))
 	b.WriteString(fmt.Sprintf("CAPTURE_ALL_DNS=%t\n", c.CaptureAllDNS))
 	b.WriteString(fmt.Sprintf("DNS_SERVERS=%s,%s\n", c.DNSServersV4, c.DNSServersV6))
 	b.WriteString(fmt.Sprintf("OUTPUT_PATH=%s\n", c.OutputPath))

--- a/tools/istio-iptables/pkg/constants/constants.go
+++ b/tools/istio-iptables/pkg/constants/constants.go
@@ -53,6 +53,7 @@ const (
 	REDIRECT = "REDIRECT"
 	MARK     = "MARK"
 	CT       = "CT"
+	DROP     = "DROP"
 )
 
 const (
@@ -98,6 +99,7 @@ const (
 	IptablesProbePort         = "iptables-probe-port"
 	ProbeTimeout              = "probe-timeout"
 	RedirectDNS               = "redirect-dns"
+	DropInvalid               = "drop-invalid"
 	CaptureAllDNS             = "capture-all-dns"
 	OutputPath                = "output-paths"
 	NetworkNamespace          = "network-namespace"


### PR DESCRIPTION
Please provide a description of this PR:
This is to fix bug #36489
Similar upstream issue in k8s https://kubernetes.io/blog/2019/03/29/kube-proxy-subtleties-debugging-an-intermittent-connection-reset/

We find the root cause that sidecar will intermittent reset the connection to ingress gateway during high throughput request(like upload large files 300MB) and the root cause is that there are some out of order packet comes to backend application directly without being DNAT by iptables, so the application reset it directly.

Here is the overflow:
<img width="1287" alt="Screen Shot 2021-12-22 at 1 54 59 PM" src="https://user-images.githubusercontent.com/12857255/147042897-feeb4b51-09e8-4c38-96c4-c1ff13c14f50.png">




**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ x] Networking
- [ x] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
