### PR TITLE
gateway: fix bug with managed gateway status and class

### DIFF
--- a/pilot/pkg/config/kube/gateway/conditions.go
+++ b/pilot/pkg/config/kube/gateway/conditions.go
@@ -134,8 +134,8 @@ type condition struct {
 	// error defines an error state; the reason and message will be replaced with that of the error and
 	// the status inverted
 	error *ConfigError
-	// setOnce, if enabled, will only set the condition if it is not yet present
-	setOnce bool
+	// setOnce, if enabled, will only set the condition if it is not yet present or set to this reason
+	setOnce string
 }
 
 // setConditions sets the existingConditions with the new conditions
@@ -149,8 +149,10 @@ func setConditions(generation int64, existingConditions []metav1.Condition, cond
 	for _, k := range condKeys {
 		cond := conditions[k]
 		setter := kstatus.UpdateConditionIfChanged
-		if cond.setOnce {
-			setter = kstatus.CreateCondition
+		if cond.setOnce != "" {
+			setter = func(conditions []metav1.Condition, condition metav1.Condition) []metav1.Condition {
+				return kstatus.CreateCondition(conditions, condition, cond.setOnce)
+			}
 		}
 		// A condition can be "negative polarity" (ex: ListenerInvalid) or "positive polarity" (ex:
 		// ListenerValid), so in order to determine the status we should set each `condition` defines its

--- a/pilot/pkg/config/kube/gateway/conversion.go
+++ b/pilot/pkg/config/kube/gateway/conversion.go
@@ -1033,7 +1033,7 @@ func convertGateways(r *KubernetesResources) ([]config.Config, map[parentKey]map
 					Reason:  "ResourcesPending",
 					Message: "Resources not yet deployed to the cluster",
 				},
-				setOnce: true,
+				setOnce: string(k8s.GatewayReasonNotReconciled), // Default reason
 			}
 		} else {
 			gatewayConditions[string(k8s.GatewayConditionScheduled)] = &condition{

--- a/pilot/pkg/model/kstatus/helper.go
+++ b/pilot/pkg/model/kstatus/helper.go
@@ -108,12 +108,17 @@ func UpdateConditionIfChanged(conditions []metav1.Condition, condition metav1.Co
 }
 
 // CreateCondition sets a condition only if it has not already been set
-func CreateCondition(conditions []metav1.Condition, condition metav1.Condition) []metav1.Condition {
+func CreateCondition(conditions []metav1.Condition, condition metav1.Condition, unsetReason string) []metav1.Condition {
 	ret := append([]metav1.Condition(nil), conditions...)
 	idx := -1
 	for i, cond := range ret {
 		if cond.Type == condition.Type {
 			idx = i
+			if cond.Reason == unsetReason {
+				// Condition is set, but its for unsetReason. This is needed because some conditions have defaults
+				ret[idx] = condition
+				return ret
+			}
 			break
 		}
 	}


### PR DESCRIPTION
Two bugs:
* `setOnce` was supposed to only set status once. The problem is the
status is always set by Kubernetes by default due to CRD defaulting.
Handle that using the special NotReconciled status reason
* GatewayClass only looks at the *name*, not the *controller*. Update
this to use the same (correct) logic the main code uses.

We definitely need more test coverage here. I am looking into how we can get
defaults for the first case, for the latter we just need more time.
Thanks @robscott for finding these