### PR TITLE
Add dry-run test for operator init

### DIFF
--- a/operator/cmd/mesh/operator-init.go
+++ b/operator/cmd/mesh/operator-init.go
@@ -42,6 +42,9 @@ type operatorInitArgs struct {
 	common operatorCommonArgs
 }
 
+// kubeClients is a unit test override variable for client interfaces creation.
+var kubeClients = KubernetesClients
+
 func addOperatorInitFlags(cmd *cobra.Command, args *operatorInitArgs) {
 	hub, tag := buildversion.DockerInfo.Hub, buildversion.DockerInfo.Tag
 
@@ -82,7 +85,7 @@ func operatorInitCmd(rootArgs *rootArgs, oiArgs *operatorInitArgs) *cobra.Comman
 func operatorInit(args *rootArgs, oiArgs *operatorInitArgs, l clog.Logger) {
 	initLogsOrExit(args)
 
-	kubeClient, client, err := KubernetesClients(oiArgs.kubeConfigPath, oiArgs.context, l)
+	kubeClient, client, err := kubeClients(oiArgs.kubeConfigPath, oiArgs.context, l)
 	if err != nil {
 		l.LogAndFatal(err)
 	}

--- a/operator/cmd/mesh/operator_test.go
+++ b/operator/cmd/mesh/operator_test.go
@@ -20,11 +20,21 @@ import (
 	"strings"
 	"testing"
 
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
 	"istio.io/istio/operator/pkg/util"
 	"istio.io/istio/operator/pkg/util/clog"
+	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/test/env"
+	"istio.io/istio/pkg/test/util/assert"
+)
+
+var (
+	extendedClient kube.ExtendedClient
+	kubeClient     client.Client
 )
 
 // TODO: rewrite this with running the actual top level command.
@@ -156,5 +166,59 @@ func TestOperatorInit(t *testing.T) {
 
 	if diff := util.YAMLDiff(wantYAML, gotYAML); diff != "" {
 		t.Fatalf("diff: %s", diff)
+	}
+}
+
+func MockKubernetesClients(_, _ string, _ clog.Logger) (kube.ExtendedClient, client.Client, error) {
+	extendedClient = kube.MockClient{
+		Interface: fake.NewSimpleClientset(),
+	}
+	kubeClient, _ = client.New(&rest.Config{}, client.Options{})
+	return extendedClient, kubeClient, nil
+}
+
+func TestOperatorInitDryRun(t *testing.T) {
+	tests := []struct {
+		operatorNamespace string
+		watchedNamespaces string
+	}{
+		{
+			// default nss
+			operatorNamespace: "",
+			watchedNamespaces: "",
+		},
+		{
+			operatorNamespace: "test",
+			watchedNamespaces: "test1",
+		},
+		{
+			operatorNamespace: "",
+			watchedNamespaces: "test4, test5",
+		},
+	}
+
+	kubeClients = MockKubernetesClients
+
+	for _, test := range tests {
+		t.Run("", func(t *testing.T) {
+			args := []string{"operator", "init", "--dry-run"}
+			if test.operatorNamespace != "" {
+				args = append(args, "--operatorNamespace", test.operatorNamespace)
+			}
+			if test.watchedNamespaces != "" {
+				args = append(args, "--watchedNamespaces", test.watchedNamespaces)
+			}
+
+			rootCmd := GetRootCmd(args)
+			err := rootCmd.Execute()
+			assert.NoError(t, err)
+
+			actions := extendedClient.Kube().(*fake.Clientset).Actions()
+			for _, action := range actions {
+				if action.GetVerb() != "get" {
+					t.Fatalf("unexpected action: %+v, expected %s", action.GetVerb(), "get")
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
**Please provide a description of this PR:**
Made the kube client creation function overridable to perform unit tests. Also, I've noticed `TODO` here:
https://github.com/istio/istio/blob/e0207105bb09baf1299a5752b98d83240ba981af/operator/cmd/mesh/operator_test.go#L30
I'll look into this one since the client creation is overridable now.