### PR TITLE
refactor transport socket merge logic

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/cluster_patch.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/cluster_patch.go
@@ -73,53 +73,52 @@ func mergeTransportSocketCluster(c *cluster.Cluster, cp *model.EnvoyFilterConfig
 		return false, fmt.Errorf("cast of cp.Value failed: %v", okCpCast)
 	}
 
+	// Check if cluster patch has a transport socket.
+	if cpValueCast.GetTransportSocket() == nil {
+		return false, nil
+	}
 	var tsmPatch *core.TransportSocket
 
-	// Check if cluster patch has a transport socket.
-	if cpValueCast.GetTransportSocket() != nil {
-		// First check if the transport socket matches with any cluster transport socket matches.
-		if len(c.GetTransportSocketMatches()) > 0 {
-			for _, tsm := range c.GetTransportSocketMatches() {
-				if tsm.GetTransportSocket() != nil && cpValueCast.GetTransportSocket().Name == tsm.GetTransportSocket().Name {
-					tsmPatch = tsm.GetTransportSocket()
-					break
-				}
-			}
-			if tsmPatch == nil && len(c.GetTransportSocketMatches()) > 0 {
-				// If we merged we would get both a transport_socket and transport_socket_matches which is not valid
-				// Drop the filter, but indicate that we handled the merge so that the outer function does not try
-				// to merge it again
-				return true, nil
-			}
-		} else if c.GetTransportSocket() != nil {
-			if cpValueCast.GetTransportSocket().Name == c.GetTransportSocket().Name {
-				tsmPatch = c.GetTransportSocket()
+	// First check if the transport socket matches with any cluster transport socket matches.
+	if len(c.GetTransportSocketMatches()) > 0 {
+		for _, tsm := range c.GetTransportSocketMatches() {
+			if tsm.GetTransportSocket() != nil && cpValueCast.GetTransportSocket().Name == tsm.GetTransportSocket().Name {
+				tsmPatch = tsm.GetTransportSocket()
+				break
 			}
 		}
-		// This means either there is a name mismatch or cluster does not have transport socket matches/transport socket.
-		// We cannot do a deep merge. Instead just replace the transport socket
-		if tsmPatch == nil {
-			c.TransportSocket = cpValueCast.TransportSocket
+		if tsmPatch == nil && len(c.GetTransportSocketMatches()) > 0 {
+			// If we merged we would get both a transport_socket and transport_socket_matches which is not valid
+			// Drop the filter, but indicate that we handled the merge so that the outer function does not try
+			// to merge it again
 			return true, nil
-		} else {
-			// Merge the patch and the cluster at a lower level
-			dstCluster := tsmPatch.GetTypedConfig()
-			srcPatch := cpValueCast.GetTransportSocket().GetTypedConfig()
-
-			if dstCluster != nil && srcPatch != nil {
-
-				retVal, errMerge := util.MergeAnyWithAny(dstCluster, srcPatch)
-				if errMerge != nil {
-					return false, fmt.Errorf("function MergeAnyWithAny failed for ApplyClusterMerge: %v", errMerge)
-				}
-
-				// Merge the above result with the whole cluster
-				proto.Merge(dstCluster, retVal)
-				return true, nil
-			}
+		}
+	} else if c.GetTransportSocket() != nil {
+		if cpValueCast.GetTransportSocket().Name == c.GetTransportSocket().Name {
+			tsmPatch = c.GetTransportSocket()
 		}
 	}
-	return false, nil
+	// This means either there is a name mismatch or cluster does not have transport socket matches/transport socket.
+	// We cannot do a deep merge. Instead just replace the transport socket
+	if tsmPatch == nil {
+		c.TransportSocket = cpValueCast.TransportSocket
+	} else {
+		// Merge the patch and the cluster at a lower level
+		dstCluster := tsmPatch.GetTypedConfig()
+		srcPatch := cpValueCast.GetTransportSocket().GetTypedConfig()
+
+		if dstCluster != nil && srcPatch != nil {
+
+			retVal, errMerge := util.MergeAnyWithAny(dstCluster, srcPatch)
+			if errMerge != nil {
+				return false, fmt.Errorf("function MergeAnyWithAny failed for ApplyClusterMerge: %v", errMerge)
+			}
+
+			// Merge the above result with the whole cluster
+			proto.Merge(dstCluster, retVal)
+		}
+	}
+	return true, nil
 }
 
 // ShouldKeepCluster checks if there is a REMOVE patch on the cluster, returns false if there is on so that it is removed.

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/cluster_patch.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/cluster_patch.go
@@ -78,20 +78,20 @@ func mergeTransportSocketCluster(c *cluster.Cluster, cp *model.EnvoyFilterConfig
 	// Check if cluster patch has a transport socket.
 	if cpValueCast.GetTransportSocket() != nil {
 		// First check if the transport socket matches with any cluster transport socket matches.
-		for _, tsm := range c.GetTransportSocketMatches() {
-			if tsm.GetTransportSocket() != nil && cpValueCast.GetTransportSocket().Name == tsm.GetTransportSocket().Name {
-				tsmPatch = tsm.GetTransportSocket()
-				break
+		if len(c.GetTransportSocketMatches()) > 0 {
+			for _, tsm := range c.GetTransportSocketMatches() {
+				if tsm.GetTransportSocket() != nil && cpValueCast.GetTransportSocket().Name == tsm.GetTransportSocket().Name {
+					tsmPatch = tsm.GetTransportSocket()
+					break
+				}
 			}
-		}
-		if tsmPatch == nil && len(c.GetTransportSocketMatches()) > 0 {
-			// If we merged we would get both a transport_socket and transport_socket_matches which is not valid
-			// Drop the filter, but indicate that we handled the merge so that the outer function does not try
-			// to merge it again
-			return true, nil
-		}
-		// Now check if this matches if existing cluster's transport socket.
-		if c.GetTransportSocket() != nil {
+			if tsmPatch == nil && len(c.GetTransportSocketMatches()) > 0 {
+				// If we merged we would get both a transport_socket and transport_socket_matches which is not valid
+				// Drop the filter, but indicate that we handled the merge so that the outer function does not try
+				// to merge it again
+				return true, nil
+			}
+		} else if c.GetTransportSocket() != nil {
 			if cpValueCast.GetTransportSocket().Name == c.GetTransportSocket().Name {
 				tsmPatch = c.GetTransportSocket()
 			}


### PR DESCRIPTION
No functional change. Just refactors merge transport logic to simplify if conditions and also when the cluster does not have transport socket avoids proto.Merge call.

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure