### PR TITLE
During SyncAll(), do syncDiscoveryNamespaces before sync pods,services,endpoints

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -781,6 +781,7 @@ func (c *Controller) informersSynced() bool {
 func (c *Controller) SyncAll() error {
 	c.beginSync.Store(true)
 	var err *multierror.Error
+	err = multierror.Append(err, c.syncDiscoveryNamespaces())
 	err = multierror.Append(err, c.syncSystemNamespace())
 	err = multierror.Append(err, c.syncNodes())
 	err = multierror.Append(err, c.syncServices())
@@ -798,6 +799,14 @@ func (c *Controller) syncSystemNamespace() error {
 		if sysNs != nil {
 			err = c.onSystemNamespaceEvent(sysNs, model.EventAdd)
 		}
+	}
+	return err
+}
+
+func (c *Controller) syncDiscoveryNamespaces() error {
+	var err error
+	if c.nsLister != nil {
+		err = c.opts.DiscoveryNamespacesFilter.SyncNamespaces()
 	}
 	return err
 }

--- a/pilot/pkg/serviceregistry/kube/controller/filter/discoverynamespaces.go
+++ b/pilot/pkg/serviceregistry/kube/controller/filter/discoverynamespaces.go
@@ -156,16 +156,17 @@ func (d *discoveryNamespacesFilter) SyncNamespaces() error {
 		return err
 	}
 
+	// omitting discoverySelectors indicates discovering all namespaces
+	if len(d.discoverySelectors) == 0 {
+		for _, ns := range namespaceList {
+			newDiscoveryNamespaces.Insert(ns.Name)
+		}
+	}
+
 	// range over all namespaces to get discovery namespaces
 	for _, ns := range namespaceList {
 		for _, selector := range d.discoverySelectors {
 			if selector.Matches(labels.Set(ns.Labels)) {
-				newDiscoveryNamespaces.Insert(ns.Name)
-			}
-		}
-		// omitting discoverySelectors indicates discovering all namespaces
-		if len(d.discoverySelectors) == 0 {
-			for _, ns := range namespaceList {
 				newDiscoveryNamespaces.Insert(ns.Name)
 			}
 		}


### PR DESCRIPTION
**Please provide a description of this PR:**
Before sync Services,pods,endpoints, discoveryNamespacesFilter.discoveryNamespaces should be updated first. Otherwise 
if we have many namespaces,some resources may be ignored when namespace have not been inserted into discoveryNamespacesFilter.discoveryNamespaces.