### PR TITLE
Improve operator dry-run test

### DIFF
--- a/operator/cmd/mesh/operator_test.go
+++ b/operator/cmd/mesh/operator_test.go
@@ -20,11 +20,13 @@ import (
 	"strings"
 	"testing"
 
+	fake3 "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
+	"istio.io/istio/operator/pkg/helmreconciler"
 	"istio.io/istio/operator/pkg/util"
 	"istio.io/istio/operator/pkg/util/clog"
 	"istio.io/istio/pkg/kube"
@@ -132,7 +134,6 @@ func TestOperatorDumpJSONFormat(t *testing.T) {
 	}
 }
 
-// TODO: rewrite this with running the actual top level command.
 func TestOperatorInit(t *testing.T) {
 	goldenFilepath := filepath.Join(operatorRootDir, "cmd/mesh/testdata/operator/output/operator-init.yaml")
 	rootArgs := &rootArgs{}
@@ -167,11 +168,33 @@ func TestOperatorInit(t *testing.T) {
 	if diff := util.YAMLDiff(wantYAML, gotYAML); diff != "" {
 		t.Fatalf("diff: %s", diff)
 	}
+
+	cmd := "operator init --hub " + oiArgs.common.hub
+	cmd += " --tag " + oiArgs.common.tag
+	cmd += " --operatorNamespace " + oiArgs.common.operatorNamespace
+	cmd += " --watchedNamespaces " + oiArgs.common.watchedNamespaces
+	cmd += " --manifests=" + string(snapshotCharts)
+
+	kubeClients = MockKubernetesClients
+	helmreconciler.TestMode = true
+
+	gotOutput, err := runCommand(cmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !isInstallationComplete(gotOutput) {
+		t.Fatal(err)
+	}
+}
+
+func isInstallationComplete(output string) bool {
+	return strings.Contains(output, installationCompleteStr)
 }
 
 func MockKubernetesClients(_, _ string, _ clog.Logger) (kube.ExtendedClient, client.Client, error) {
 	extendedClient = kube.MockClient{
 		Interface: fake.NewSimpleClientset(),
+		ExtClient: fake3.NewSimpleClientset(),
 	}
 	kubeClient, _ = client.New(&rest.Config{}, client.Options{})
 	return extendedClient, kubeClient, nil
@@ -213,9 +236,15 @@ func TestOperatorInitDryRun(t *testing.T) {
 			err := rootCmd.Execute()
 			assert.NoError(t, err)
 
+			readActions := map[string]bool{
+				"get":   true,
+				"list":  true,
+				"watch": true,
+			}
+
 			actions := extendedClient.Kube().(*fake.Clientset).Actions()
 			for _, action := range actions {
-				if action.GetVerb() != "get" {
+				if v, ok := readActions[action.GetVerb()]; !ok || !v {
 					t.Fatalf("unexpected action: %+v, expected %s", action.GetVerb(), "get")
 				}
 			}

--- a/pkg/kube/mock_client.go
+++ b/pkg/kube/mock_client.go
@@ -68,7 +68,6 @@ var _ PortForwarder = MockPortForwarder{}
 type MockClient struct {
 	kubernetes.Interface
 	RestClient *rest.RESTClient
-	ExtClient  clientset.Interface
 	// Results is a map of podName to the results of the expected test on the pod
 	Results           map[string][]byte
 	DiscoverablePods  map[string]map[string]*v1.PodList
@@ -213,7 +212,7 @@ func (c MockClient) DeleteYAMLFilesDryRun(string, ...string) error {
 }
 
 func (c MockClient) Ext() clientset.Interface {
-	return c.ExtClient
+	panic("not implemented by mock")
 }
 
 func (c MockClient) Dynamic() dynamic.Interface {

--- a/pkg/kube/mock_client.go
+++ b/pkg/kube/mock_client.go
@@ -68,6 +68,7 @@ var _ PortForwarder = MockPortForwarder{}
 type MockClient struct {
 	kubernetes.Interface
 	RestClient *rest.RESTClient
+	ExtClient  clientset.Interface
 	// Results is a map of podName to the results of the expected test on the pod
 	Results           map[string][]byte
 	DiscoverablePods  map[string]map[string]*v1.PodList
@@ -212,7 +213,7 @@ func (c MockClient) DeleteYAMLFilesDryRun(string, ...string) error {
 }
 
 func (c MockClient) Ext() clientset.Interface {
-	panic("not implemented by mock")
+	return c.ExtClient
 }
 
 func (c MockClient) Dynamic() dynamic.Interface {


### PR DESCRIPTION
**Please provide a description of this PR:**
* ~~Add ext client to mock client to let operator init tests to run on the top level command.~~(will investigate this test)
* Exclude list&watch actions from write actions for the operator dry-run test. (improve https://github.com/istio/istio/pull/36613)