### PR TITLE
Only get hostnames at endpoint removal.

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/endpointslice.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpointslice.go
@@ -118,7 +118,6 @@ func (esc *endpointSliceController) onEvent(curr interface{}, event model.Event)
 	}
 
 	esLabels := ep.GetLabels()
-	log.Infof("bianpengyuan: on endpoint slice event %v for endpoint slice %v", event, ep.GetName())
 	if endpointSliceSelector.Matches(klabels.Set(esLabels)) {
 		return processEndpointEvent(esc.c, esc, serviceNameForEndpointSlice(esLabels), ep.GetNamespace(), event, ep)
 	}

--- a/pilot/pkg/serviceregistry/kube/controller/endpointslice.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpointslice.go
@@ -118,6 +118,7 @@ func (esc *endpointSliceController) onEvent(curr interface{}, event model.Event)
 	}
 
 	esLabels := ep.GetLabels()
+	log.Infof("bianpengyuan: on endpoint slice event %v for endpoint slice %v", event, ep.GetName())
 	if endpointSliceSelector.Matches(klabels.Set(esLabels)) {
 		return processEndpointEvent(esc.c, esc, serviceNameForEndpointSlice(esLabels), ep.GetNamespace(), event, ep)
 	}
@@ -202,11 +203,12 @@ func (esc *endpointSliceController) forgetEndpoint(endpoint interface{}) map[hos
 	}
 
 	out := make(map[host.Name][]*model.IstioEndpoint)
-	for _, svc := range esc.c.servicesForNamespacedName(esc.getServiceNamespacedName(slice)) {
+	for _, hostName := range esc.c.hostNamesForNamespacedName(esc.getServiceNamespacedName(slice)) {
 		// endpointSlice cache update
-		hostName := svc.Hostname
-		esc.endpointCache.Delete(hostName, slice.Name)
-		out[hostName] = esc.endpointCache.Get(hostName)
+		if esc.endpointCache.Has(hostName) {
+			esc.endpointCache.Delete(hostName, slice.Name)
+			out[hostName] = esc.endpointCache.Get(hostName)
+		}
 	}
 	return out
 }
@@ -436,6 +438,13 @@ func (e *endpointSliceCache) Get(hostname host.Name) []*model.IstioEndpoint {
 		}
 	}
 	return endpoints
+}
+
+func (e *endpointSliceCache) Has(hostname host.Name) bool {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	_, found := e.endpointsByServiceAndSlice[hostname]
+	return found
 }
 
 func endpointSliceSelectorForService(name string) klabels.Selector {

--- a/pilot/pkg/serviceregistry/kube/controller/endpointslice_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpointslice_test.go
@@ -135,7 +135,9 @@ func TestEndpointSliceCache(t *testing.T) {
 	if !testEndpointsEqual(cache.Get(hostname), []*model.IstioEndpoint{ep1}) {
 		t.Fatalf("unexpected endpoints")
 	}
-
+	if !cache.Has(hostname) {
+		t.Fatalf("expect to find the host name")
+	}
 	// add a new endpoint
 	ep2 := &model.IstioEndpoint{
 		Address:         "2.3.4.5",

--- a/releasenotes/notes/36510.yaml
+++ b/releasenotes/notes/36510.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - https://github.com/istio/istio/issues/36510
+releaseNotes:
+  - |
+    **Fixed** an issue where stale endpoints can be configured when a service gets deleted and created again.


### PR DESCRIPTION
Fix #36510.

When an endpoint slice gets removed, the corresponding service could also be removed, and query service registry for the service for that service would not return anything and some stale endpoint will be kept in the cache. This change make removal logic go through all possible host names for a slice removal.