### PR TITLE
Added flag to enable capture of invalid drop into CNI

### DIFF
--- a/cni/pkg/plugin/iptables.go
+++ b/cni/pkg/plugin/iptables.go
@@ -54,6 +54,7 @@ func (ipt *iptables) Program(podName, netns string, rdrct *Redirect) error {
 	viper.Set(constants.OutputPath, drf)
 	viper.Set(constants.RedirectDNS, rdrct.dnsRedirect)
 	viper.Set(constants.CaptureAllDNS, rdrct.dnsRedirect)
+	viper.Set(constants.DropInvalid, rdrct.invalidDrop)
 	iptablesCmd := cmd.GetCommand()
 	log.Infof("============= Start iptables configuration for %v =============", podName)
 	defer log.Infof("============= End iptables configuration for %v =============", podName)

--- a/cni/pkg/plugin/plugin_dryrun_test.go
+++ b/cni/pkg/plugin/plugin_dryrun_test.go
@@ -32,6 +32,7 @@ import (
 	"istio.io/istio/pilot/cmd/pilot-agent/options"
 	diff "istio.io/istio/pilot/test/util"
 	"istio.io/istio/pkg/test/env"
+	"istio.io/istio/tools/istio-iptables/pkg/cmd"
 )
 
 type k8sPodInfoFunc func(*kubernetes.Clientset, string, string) (*PodInfo, error)
@@ -113,6 +114,16 @@ func TestIPTablesRuleGeneration(t *testing.T) {
 				ProxyEnvironments: map[string]string{options.DNSCaptureByAgent.Name: "true"},
 			},
 			golden: filepath.Join(env.IstioSrc, "cni/pkg/plugin/testdata/dns.txt.golden"),
+		},
+		{
+			name: "invalid-drop",
+			input: &PodInfo{
+				Containers:        []string{"test", "istio-proxy"},
+				InitContainers:    map[string]struct{}{"istio-validate": {}},
+				Annotations:       map[string]string{annotation.SidecarStatus.Name: "true"},
+				ProxyEnvironments: map[string]string{cmd.InvalidDropByIptables.Name: "true"},
+			},
+			golden: filepath.Join(env.IstioSrc, "cni/pkg/plugin/testdata/invalid-drop.txt.golden"),
 		},
 	}
 

--- a/cni/pkg/plugin/redirect.go
+++ b/cni/pkg/plugin/redirect.go
@@ -23,6 +23,7 @@ import (
 
 	"istio.io/api/annotation"
 	"istio.io/istio/pilot/cmd/pilot-agent/options"
+	"istio.io/istio/tools/istio-iptables/pkg/cmd"
 	"istio.io/pkg/log"
 )
 
@@ -78,6 +79,7 @@ type Redirect struct {
 	kubevirtInterfaces   string
 	excludeInterfaces    string
 	dnsRedirect          bool
+	invalidDrop          bool
 }
 
 type annotationValidationFunc func(value string) error
@@ -255,6 +257,12 @@ func NewRedirect(pi *PodInfo) (*Redirect, error) {
 			log.Warnf("cannot parse DNS capture environment variable %v", valErr)
 		}
 	}
-
+	if v, found := pi.ProxyEnvironments[cmd.InvalidDropByIptables.Name]; found {
+		// parse and set the bool value of invalidDrop
+		redir.invalidDrop, valErr = strconv.ParseBool(v)
+		if valErr != nil {
+			log.Warnf("cannot parse invalid drop environment variable %v", valErr)
+		}
+	}
 	return redir, nil
 }

--- a/cni/pkg/plugin/testdata/invalid-drop.txt.golden
+++ b/cni/pkg/plugin/testdata/invalid-drop.txt.golden
@@ -1,0 +1,28 @@
+* mangle
+-A PREROUTING -m conntrack --ctstate INVALID -j DROP
+COMMIT
+* nat
+-N ISTIO_INBOUND
+-N ISTIO_REDIRECT
+-N ISTIO_IN_REDIRECT
+-N ISTIO_OUTPUT
+-A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
+-A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
+-A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
+-A PREROUTING -p tcp -j ISTIO_INBOUND
+-A ISTIO_INBOUND -p tcp --dport 15020 -j RETURN
+-A ISTIO_INBOUND -p tcp --dport 15021 -j RETURN
+-A ISTIO_INBOUND -p tcp --dport 15090 -j RETURN
+-A ISTIO_INBOUND -p tcp -j ISTIO_IN_REDIRECT
+-A OUTPUT -p tcp -j ISTIO_OUTPUT
+-A ISTIO_OUTPUT -p tcp --dport 15020 -j RETURN
+-A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
+-A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT
+-A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 1337 -j RETURN
+-A ISTIO_OUTPUT -m owner --uid-owner 1337 -j RETURN
+-A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --gid-owner 1337 -j ISTIO_IN_REDIRECT
+-A ISTIO_OUTPUT -o lo -m owner ! --gid-owner 1337 -j RETURN
+-A ISTIO_OUTPUT -m owner --gid-owner 1337 -j RETURN
+-A ISTIO_OUTPUT -d 127.0.0.1/32 -j RETURN
+-A ISTIO_OUTPUT -j ISTIO_REDIRECT
+COMMIT

--- a/releasenotes/notes/36566.yaml
+++ b/releasenotes/notes/36566.yaml
@@ -6,5 +6,5 @@ issue:
 releaseNotes:
   - |
     **Fixed** an issue that sidecar iptables will cause intermittent connection reset due to the out of window packet.
-    Introduced a flag meshConfig.defaultConfig.proxyMetadata.ISTIO_META_INVALID_DROP to control this setting.
+    Introduced a flag meshConfig.defaultConfig.proxyMetadata.INVALID_DROP to control this setting.
 

--- a/tools/istio-iptables/pkg/capture/run.go
+++ b/tools/istio-iptables/pkg/capture/run.go
@@ -132,7 +132,7 @@ func (cfg *IptablesConfigurator) logConfig() {
 	b.WriteString(fmt.Sprintf("ISTIO_SERVICE_CIDR=%s\n", os.Getenv("ISTIO_SERVICE_CIDR")))
 	b.WriteString(fmt.Sprintf("ISTIO_SERVICE_EXCLUDE_CIDR=%s\n", os.Getenv("ISTIO_SERVICE_EXCLUDE_CIDR")))
 	b.WriteString(fmt.Sprintf("ISTIO_META_DNS_CAPTURE=%s\n", os.Getenv("ISTIO_META_DNS_CAPTURE")))
-	b.WriteString(fmt.Sprintf("ISTIO_META_INVALID_DROP=%s\n", os.Getenv("ISTIO_META_INVALID_DROP")))
+	b.WriteString(fmt.Sprintf("INVALID_DROP=%s\n", os.Getenv("INVALID_DROP")))
 	log.Infof("Istio iptables environment:\n%s", b.String())
 	cfg.cfg.Print()
 }

--- a/tools/istio-iptables/pkg/cmd/root.go
+++ b/tools/istio-iptables/pkg/cmd/root.go
@@ -39,9 +39,9 @@ var (
 	// Enable interception of DNS.
 	dnsCaptureByAgent = env.RegisterBoolVar("ISTIO_META_DNS_CAPTURE", false,
 		"If set to true, enable the capture of outgoing DNS packets on port 53, redirecting to istio-agent on :15053").Get()
-	// Enable invalid drop iptables rule to drop the out of window packets
-	invalidDropByIptables = env.RegisterBoolVar("ISTIO_META_INVALID_DROP", false,
-		"If set to true, enable the invalid drop iptables rule, default false will cause iptables reset out of window packets").Get()
+	// InvalidDropByIptables is the flag to enable invalid drop iptables rule to drop the out of window packets
+	InvalidDropByIptables = env.RegisterBoolVar("ISTIO_META_INVALID_DROP", false,
+		"If set to true, enable the invalid drop iptables rule, default false will cause iptables reset out of window packets")
 )
 
 var rootCmd = &cobra.Command{
@@ -328,7 +328,7 @@ func bindFlags(cmd *cobra.Command, args []string) {
 	if err := viper.BindPFlag(constants.DropInvalid, cmd.Flags().Lookup(constants.DropInvalid)); err != nil {
 		handleError(err)
 	}
-	viper.SetDefault(constants.DropInvalid, invalidDropByIptables)
+	viper.SetDefault(constants.DropInvalid, InvalidDropByIptables)
 
 	if err := viper.BindPFlag(constants.CaptureAllDNS, cmd.Flags().Lookup(constants.CaptureAllDNS)); err != nil {
 		handleError(err)
@@ -425,7 +425,7 @@ func bindCmdlineFlags(rootCmd *cobra.Command) {
 
 	rootCmd.Flags().Bool(constants.RedirectDNS, dnsCaptureByAgent, "Enable capture of dns traffic by istio-agent")
 
-	rootCmd.Flags().Bool(constants.DropInvalid, invalidDropByIptables, "Enable invalid drop in the iptables rules")
+	rootCmd.Flags().Bool(constants.DropInvalid, InvalidDropByIptables.Get(), "Enable invalid drop in the iptables rules")
 
 	rootCmd.Flags().Bool(constants.CaptureAllDNS, false,
 		"Instead of only capturing DNS traffic to DNS server IP, capture all DNS traffic at port 53. This setting is only effective when redirect dns is enabled.")

--- a/tools/istio-iptables/pkg/cmd/root.go
+++ b/tools/istio-iptables/pkg/cmd/root.go
@@ -40,7 +40,7 @@ var (
 	dnsCaptureByAgent = env.RegisterBoolVar("ISTIO_META_DNS_CAPTURE", false,
 		"If set to true, enable the capture of outgoing DNS packets on port 53, redirecting to istio-agent on :15053").Get()
 	// InvalidDropByIptables is the flag to enable invalid drop iptables rule to drop the out of window packets
-	InvalidDropByIptables = env.RegisterBoolVar("ISTIO_META_INVALID_DROP", false,
+	InvalidDropByIptables = env.RegisterBoolVar("INVALID_DROP", false,
 		"If set to true, enable the invalid drop iptables rule, default false will cause iptables reset out of window packets")
 )
 


### PR DESCRIPTION
**Please provide a description of this PR:**

This is related with https://github.com/istio/istio/pull/36566 which introduced a flag `ISTIO_META_INVALID_DROP` to enable the invalid drop iptables rule while there was a bug that this flag won't be passed from Pod environment variable to istio CNI.

**Steps to reproduce the bug:**
1. Install istio with cni and deploy the istio-cni DaemonSet with the cherry-picked fix https://github.com/istio/istio/pull/36566
2. Config the ISTIO_META_INVALID_DROP into proxyMetaData :
```
  mesh: |-
    accessLogEncoding: JSON
    accessLogFile: /var/log/proxy/access.log
    defaultConfig:
      concurrency: 40
      discoveryAddress: istiod.istio-pre-production.svc.87.tess.io:15012
      proxyMetadata:
        ISTIO_META_DNS_AUTO_ALLOCATE: "true"
        ISTIO_META_DNS_CAPTURE: "true"
        ISTIO_META_INVALID_DROP: "true"
```
2. Create a new pod with sidecar injection and we can see the env is in pod
```
    env:
    - name: ISTIO_META_DNS_AUTO_ALLOCATE
      value: "true"
    - name: ISTIO_META_DNS_CAPTURE
      value: "true"
    - name: ISTIO_META_INVALID_DROP
      value: "true"
```
3. nsenter the pod network namespace and check the iptables rule, the invalid drop policy is missing:
```
# Generated by xtables-save v1.8.2 on Thu Dec 30 01:31:55 2021
*mangle
:PREROUTING ACCEPT [0:0]
:INPUT ACCEPT [0:0]
:FORWARD ACCEPT [0:0]
:OUTPUT ACCEPT [0:0]
:POSTROUTING ACCEPT [0:0]
COMMIT
# Completed on Thu Dec 30 01:31:55 2021
# Generated by xtables-save v1.8.2 on Thu Dec 30 01:31:55 2021
*nat
:PREROUTING ACCEPT [0:0]
:INPUT ACCEPT [0:0]
:POSTROUTING ACCEPT [0:0]
:OUTPUT ACCEPT [0:0]
:ISTIO_INBOUND - [0:0]
:ISTIO_REDIRECT - [0:0]
:ISTIO_IN_REDIRECT - [0:0]
:ISTIO_OUTPUT - [0:0]
-A PREROUTING -p tcp -j ISTIO_INBOUND
-A OUTPUT -p tcp -j ISTIO_OUTPUT
-A OUTPUT -p udp -m udp --dport 53 -m owner --uid-owner 1337 -j RETURN
-A OUTPUT -p udp -m udp --dport 53 -m owner --gid-owner 1337 -j RETURN
-A OUTPUT -p udp -m udp --dport 53 -j REDIRECT --to-ports 15053
-A ISTIO_INBOUND -p tcp -m tcp --dport 15008 -j RETURN
-A ISTIO_INBOUND -p tcp -m tcp --dport 22 -j RETURN
-A ISTIO_INBOUND -p tcp -m tcp --dport 15020 -j RETURN
-A ISTIO_INBOUND -p tcp -m tcp --dport 15021 -j RETURN
-A ISTIO_INBOUND -p tcp -m tcp --dport 15090 -j RETURN
-A ISTIO_INBOUND -p tcp -j ISTIO_IN_REDIRECT
-A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
-A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
-A ISTIO_OUTPUT -p tcp -m tcp --dport 15020 -j RETURN
-A ISTIO_OUTPUT -s 127.0.0.6/32 -o lo -j RETURN
-A ISTIO_OUTPUT ! -d 127.0.0.1/32 -o lo -p tcp -m tcp ! --dport 53 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT
-A ISTIO_OUTPUT -o lo -p tcp -m tcp ! --dport 53 -m owner ! --uid-owner 1337 -j RETURN
-A ISTIO_OUTPUT -m owner --uid-owner 1337 -j RETURN
-A ISTIO_OUTPUT ! -d 127.0.0.1/32 -o lo -m owner --gid-owner 1337 -j ISTIO_IN_REDIRECT
-A ISTIO_OUTPUT -o lo -p tcp -m tcp ! --dport 53 -m owner ! --gid-owner 1337 -j RETURN
-A ISTIO_OUTPUT -m owner --gid-owner 1337 -j RETURN
-A ISTIO_OUTPUT -p tcp -m tcp --dport 53 -j REDIRECT --to-ports 15053
-A ISTIO_OUTPUT -d 127.0.0.1/32 -j RETURN
-A ISTIO_OUTPUT -j ISTIO_REDIRECT
COMMIT
# Completed on Thu Dec 30 01:31:55 2021
```
**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ x] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure