### PR TITLE
Fix service entry instances store memory leak

### DIFF
--- a/pilot/pkg/serviceregistry/serviceentry/servicediscovery.go
+++ b/pilot/pkg/serviceregistry/serviceentry/servicediscovery.go
@@ -463,6 +463,8 @@ func (s *ServiceEntryStore) WorkloadInstanceHandler(wi *model.WorkloadInstance, 
 				instancesDeleted = append(instancesDeleted, di)
 			}
 			s.serviceInstances.deleteServiceEntryInstances(seNamespacedName, key)
+		} else if event == model.EventDelete {
+			s.serviceInstances.deleteServiceEntryInstances(seNamespacedName, key)
 		} else {
 			s.serviceInstances.updateServiceEntryInstancesPerConfig(seNamespacedName, key, instance)
 		}


### PR DESCRIPTION
**Please provide a description of this PR:**
If a workload was deleted, it would still remain in `serviceInstances.instancesBySE`
It does leak memory when users enable `ServiceEntrySelectPods`(which is enabled by default) and rely on it

You can reproduce it with [the test](https://github.com/dddddai/istio/blob/aca3a467528e02a1099235652d46cc4a2307d5c7/pilot/pkg/serviceregistry/serviceentry/servicediscovery_test.go#L984) in this pr