### PR TITLE
auto allocate ip while updating the store

### DIFF
--- a/pilot/pkg/serviceregistry/serviceentry/conversion.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion.go
@@ -226,7 +226,6 @@ func buildServices(hostAddresses []*HostAddress, namespace string, ports model.P
 			ServiceAccounts: saccounts,
 		})
 	}
-	out = autoAllocateIPs(out)
 	return out
 }
 

--- a/pilot/pkg/serviceregistry/serviceentry/conversion.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion.go
@@ -226,6 +226,7 @@ func buildServices(hostAddresses []*HostAddress, namespace string, ports model.P
 			ServiceAccounts: saccounts,
 		})
 	}
+	out = autoAllocateIPs(out)
 	return out
 }
 

--- a/pilot/pkg/serviceregistry/serviceentry/conversion_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion_test.go
@@ -676,9 +676,6 @@ func TestConvertService(t *testing.T) {
 	})
 
 	for _, tt := range serviceTests {
-		if tt.externalSvc.Name != "httpDNSnoEndpoints" {
-			continue
-		}
 		autoAllocatedServices := autoAllocateIPs(tt.services)
 		services := convertServices(*tt.externalSvc)
 		if err := compare(t, services, autoAllocatedServices); err != nil {

--- a/pilot/pkg/serviceregistry/serviceentry/conversion_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion_test.go
@@ -501,7 +501,6 @@ func makeService(hostname host.Name, configNamespace, address string, ports map[
 
 	sortPorts(svcPorts)
 	svc.Ports = svcPorts
-
 	return svc
 }
 
@@ -677,8 +676,12 @@ func TestConvertService(t *testing.T) {
 	})
 
 	for _, tt := range serviceTests {
+		if tt.externalSvc.Name != "httpDNSnoEndpoints" {
+			continue
+		}
+		autoAllocatedServices := autoAllocateIPs(tt.services)
 		services := convertServices(*tt.externalSvc)
-		if err := compare(t, services, tt.services); err != nil {
+		if err := compare(t, services, autoAllocatedServices); err != nil {
 			t.Errorf("testcase: %v\n%v ", tt.externalSvc.Name, err)
 		}
 	}

--- a/pilot/pkg/serviceregistry/serviceentry/conversion_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion_test.go
@@ -676,9 +676,8 @@ func TestConvertService(t *testing.T) {
 	})
 
 	for _, tt := range serviceTests {
-		autoAllocatedServices := autoAllocateIPs(tt.services)
 		services := convertServices(*tt.externalSvc)
-		if err := compare(t, services, autoAllocatedServices); err != nil {
+		if err := compare(t, services, tt.services); err != nil {
 			t.Errorf("testcase: %v\n%v ", tt.externalSvc.Name, err)
 		}
 	}

--- a/pilot/pkg/serviceregistry/serviceentry/servicediscovery.go
+++ b/pilot/pkg/serviceregistry/serviceentry/servicediscovery.go
@@ -735,10 +735,9 @@ func servicesDiff(os []*model.Service, ns []*model.Service) ([]*model.Service, [
 }
 
 func servicesEqual(os *model.Service, ns *model.Service) bool {
-	// TODO(ramaraochavali): do a field level comparison and exclude autoallocated addresses.
-	s := os.DeepCopy()
+	s := *os
 	s.AutoAllocatedAddress = ""
-	return reflect.DeepEqual(s, ns)
+	return reflect.DeepEqual(&s, ns)
 }
 
 // Automatically allocates IPs for service entry services WITHOUT an

--- a/pilot/pkg/serviceregistry/serviceentry/servicediscovery.go
+++ b/pilot/pkg/serviceregistry/serviceentry/servicediscovery.go
@@ -735,6 +735,8 @@ func servicesDiff(os []*model.Service, ns []*model.Service) ([]*model.Service, [
 }
 
 func servicesEqual(os *model.Service, ns *model.Service) bool {
+	// Disabling `go vet` warning since this is actually safe in this case.
+	// nolint: vet
 	s := *os
 	s.AutoAllocatedAddress = ""
 	return reflect.DeepEqual(&s, ns)

--- a/pilot/pkg/serviceregistry/serviceentry/servicediscovery.go
+++ b/pilot/pkg/serviceregistry/serviceentry/servicediscovery.go
@@ -516,16 +516,7 @@ func (s *ServiceEntryStore) Services() ([]*model.Service, error) {
 	s.mutex.RLock()
 	allServices := s.services.getAllServices()
 	s.mutex.RUnlock()
-
-	out := make([]*model.Service, 0, len(allServices))
-	for _, svc := range allServices {
-		// TODO: eliminate the deepcopy here
-		// autoAllocateIPs will re-allocate ips for the service,
-		// if return the pointer directly, there will be a race with `BuildNameTable`
-		out = append(out, svc.DeepCopy())
-	}
-	autoAllocateIPs(out)
-	return out, nil
+	return allServices, nil
 }
 
 // GetService retrieves a service by host name if it exists.

--- a/pilot/pkg/serviceregistry/serviceentry/servicediscovery_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/servicediscovery_test.go
@@ -1033,6 +1033,17 @@ func expectProxyInstances(t testing.TB, sd *ServiceEntryStore, expected []*model
 		instances := sd.GetProxyServiceInstances(&model.Proxy{IPAddresses: []string{ip}, Metadata: &model.NodeMetadata{}})
 		sortServiceInstances(instances)
 		sortServiceInstances(expected)
+		sd.mutex.RLock()
+		allServices := sd.services.getAllServices()
+		sd.mutex.RUnlock()
+		for _, inst := range expected {
+			for _, asvc := range allServices {
+				if inst.Service.Hostname == asvc.Hostname {
+					inst.Service.AutoAllocatedAddress = asvc.AutoAllocatedAddress
+					break
+				}
+			}
+		}
 		if err := compare(t, instances, expected); err != nil {
 			return err
 		}
@@ -1093,6 +1104,17 @@ func expectServiceInstances(t testing.TB, sd *ServiceEntryStore, cfg *config.Con
 			instances := sd.InstancesByPort(svc, port, nil)
 			sortServiceInstances(instances)
 			sortServiceInstances(expected[i])
+			sd.mutex.RLock()
+			allServices := sd.services.getAllServices()
+			sd.mutex.RUnlock()
+			for _, inst := range expected[i] {
+				for _, asvc := range allServices {
+					if inst.Service.Hostname == asvc.Hostname {
+						inst.Service.AutoAllocatedAddress = asvc.AutoAllocatedAddress
+						break
+					}
+				}
+			}
 			if err := compare(t, instances, expected[i]); err != nil {
 				return fmt.Errorf("%d: %v", i, err)
 			}

--- a/pilot/pkg/serviceregistry/serviceentry/store.go
+++ b/pilot/pkg/serviceregistry/serviceentry/store.go
@@ -170,4 +170,5 @@ func (s *serviceStore) deleteServices(key types.NamespacedName) {
 
 func (s *serviceStore) updateServices(key types.NamespacedName, services []*model.Service) {
 	s.servicesBySE[key] = services
+	autoAllocateIPs(s.getAllServices())
 }


### PR DESCRIPTION
Auto allocate IPs during store update to avoid DeepCopy in Services() call as Services() is frequently used.