### PR TITLE
Support rewriting gRPC probes

### DIFF
--- a/pkg/kube/apimirror/probe.go
+++ b/pkg/kube/apimirror/probe.go
@@ -70,3 +70,17 @@ type TCPSocketAction struct {
 	// +optional
 	Host string `json:"host,omitempty" protobuf:"bytes,2,opt,name=host"`
 }
+
+// GRPCAction describes an action based on GRPC health check
+type GRPCAction struct {
+	// Port number of the gRPC service. Number must be in the range 1 to 65535.
+	Port int32 `json:"port" protobuf:"bytes,1,opt,name=port"`
+
+	// Service is the name of the service to place in the gRPC HealthCheckRequest
+	// (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+	//
+	// If this is not specified, the default behavior is defined by gRPC.
+	// +optional
+	// +default=""
+	Service *string `json:"service" protobuf:"bytes,2,opt,name=service"`
+}

--- a/pkg/kube/inject/app_probe_test.go
+++ b/pkg/kube/inject/app_probe_test.go
@@ -14,12 +14,15 @@
 package inject
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/gogo/protobuf/types"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"istio.io/api/annotation"
+	"istio.io/istio/pkg/test"
 )
 
 func TestFindSidecar(t *testing.T) {
@@ -107,6 +110,258 @@ func TestShouldRewriteAppHTTPProbers(t *testing.T) {
 		want := tc.expected
 		if got != want {
 			t.Errorf("[%v] failed, want %v, got %v", tc.name, want, got)
+		}
+	}
+}
+
+func TestDumpAppGRPCProbers(t *testing.T) {
+	svc := "foo"
+	for _, tc := range []struct {
+		name     string
+		podSpec  *corev1.PodSpec
+		expected string
+	}{
+		{
+			name: "simple gRPC liveness probe",
+			podSpec: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "foo",
+						LivenessProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								GRPC: &corev1.GRPCAction{
+									Port: 1234,
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: `
+{
+    "/app-health/foo/livez": {
+        "grpc": {
+            "port": 1234,
+            "service": null
+        }
+    }
+}`,
+		},
+		{
+			name: "gRPC readiness probe with service",
+			podSpec: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "bar",
+						ReadinessProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								GRPC: &corev1.GRPCAction{
+									Port:    1234,
+									Service: &svc,
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: `
+{
+    "/app-health/bar/readyz": {
+        "grpc": {
+            "port": 1234,
+            "service": "foo"
+        }
+    }
+}`,
+		},
+		{
+			name: "gRPC startup probe with service and timeout",
+			podSpec: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "foo",
+						StartupProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								GRPC: &corev1.GRPCAction{
+									Port:    1234,
+									Service: &svc,
+								},
+							},
+							TimeoutSeconds: 10,
+						},
+					},
+				},
+			},
+			expected: `
+{
+    "/app-health/foo/startupz": {
+        "grpc": {
+            "port": 1234,
+            "service": "foo"
+        },
+        "timeoutSeconds": 10
+    }
+}`,
+		},
+	} {
+		got := DumpAppProbers(tc.podSpec, 15020)
+		test.JSONEquals(t, got, tc.expected)
+	}
+}
+
+func TestPatchRewriteProbe(t *testing.T) {
+	svc := "foo"
+	annotations := map[string]string{}
+	statusPort := intstr.FromInt(15020)
+	for _, tc := range []struct {
+		name        string
+		pod         *corev1.Pod
+		annotations map[string]string
+		expected    *corev1.Pod
+	}{
+		{
+			name: "pod with no probes",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "foo",
+						},
+					},
+				},
+			},
+			expected: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "foo",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "pod with a gRPC liveness probe",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "foo",
+							LivenessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									GRPC: &corev1.GRPCAction{
+										Port: 1234,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "foo",
+							LivenessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path: "/app-health/foo/livez",
+										Port: statusPort,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "pod with gRPC liveness,readiness,startup probes",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "foo",
+							LivenessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									GRPC: &corev1.GRPCAction{
+										Port:    1234,
+										Service: &svc,
+									},
+								},
+							},
+							ReadinessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									GRPC: &corev1.GRPCAction{
+										Port:    1235,
+										Service: &svc,
+									},
+								},
+								TimeoutSeconds: 10,
+							},
+						},
+						{
+							Name: "bar",
+							StartupProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									GRPC: &corev1.GRPCAction{
+										Port: 1236,
+									},
+								},
+								TimeoutSeconds:      20,
+								PeriodSeconds:       10,
+								InitialDelaySeconds: 10,
+							},
+						},
+					},
+				},
+			},
+			expected: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "foo",
+							LivenessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path: "/app-health/foo/livez",
+										Port: statusPort,
+									},
+								},
+							},
+							ReadinessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path: "/app-health/foo/readyz",
+										Port: statusPort,
+									},
+								},
+								TimeoutSeconds: 10,
+							},
+						},
+						{
+							Name: "bar",
+							StartupProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path: "/app-health/bar/startupz",
+										Port: statusPort,
+									},
+								},
+								TimeoutSeconds:      20,
+								PeriodSeconds:       10,
+								InitialDelaySeconds: 10,
+							},
+						},
+					},
+				},
+			},
+		},
+	} {
+		patchRewriteProbe(annotations, tc.pod, 15020)
+		if !reflect.DeepEqual(tc.pod, tc.expected) {
+			t.Errorf("[%v] failed, want %v, got %v", tc.name, tc.expected, tc.pod)
 		}
 	}
 }

--- a/pkg/kube/inject/webhook.go
+++ b/pkg/kube/inject/webhook.go
@@ -590,6 +590,10 @@ func reorderPod(pod *corev1.Pod, req InjectionParameters) error {
 }
 
 func applyRewrite(pod *corev1.Pod, req InjectionParameters) error {
+	sidecar := FindSidecar(pod.Spec.Containers)
+	if sidecar == nil {
+		return nil
+	}
 	valuesStruct := &opconfig.Values{}
 	if err := gogoprotomarshal.ApplyYAML(req.valuesConfig, valuesStruct); err != nil {
 		log.Infof("Failed to parse values config: %v [%v]\n", err, req.valuesConfig)
@@ -597,10 +601,8 @@ func applyRewrite(pod *corev1.Pod, req InjectionParameters) error {
 	}
 
 	rewrite := ShouldRewriteAppHTTPProbers(pod.Annotations, valuesStruct.GetSidecarInjectorWebhook().GetRewriteAppHTTPProbe())
-	sidecar := FindSidecar(pod.Spec.Containers)
-
 	// We don't have to escape json encoding here when using golang libraries.
-	if rewrite && sidecar != nil {
+	if rewrite {
 		if prober := DumpAppProbers(&pod.Spec, req.meshConfig.GetDefaultConfig().GetStatusPort()); prober != "" {
 			sidecar.Env = append(sidecar.Env, corev1.EnvVar{Name: status.KubeAppProberEnvName, Value: prober})
 		}

--- a/pkg/test/framework/components/echo/config.go
+++ b/pkg/test/framework/components/echo/config.go
@@ -106,6 +106,9 @@ type Config struct {
 	// ReadinessTCPPort if set, use this port for the TCP readiness probe (instead of using a HTTP probe).
 	ReadinessTCPPort string
 
+	// ReadinessGRPCPort if set, use this port for the GRPC readiness probe (instead of using a HTTP probe).
+	ReadinessGRPCPort string
+
 	// Subsets contains the list of Subsets config belonging to this echo
 	// service instance.
 	Subsets []SubsetConfig

--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -248,6 +248,9 @@ spec:
 {{- if $.ReadinessTCPPort }}
           tcpSocket:
             port: {{ $.ReadinessTCPPort }}
+{{- else if $.ReadinessGRPCPort }}
+          grpc:
+            port: {{ $.ReadinessGRPCPort }}			
 {{- else }}
           httpGet:
             path: /
@@ -693,6 +696,7 @@ func templateParams(cfg echo.Config, imgSettings *image.Settings, settings *reso
 		"Namespace":          namespace,
 		"ImagePullSecret":    imagePullSecret,
 		"ReadinessTCPPort":   cfg.ReadinessTCPPort,
+		"ReadinessGRPCPort":  cfg.ReadinessGRPCPort,
 		"VM": map[string]interface{}{
 			"Image": vmImage,
 		},

--- a/pkg/test/framework/features/features.yaml
+++ b/pkg/test/framework/features/features.yaml
@@ -68,6 +68,7 @@ features:
       analysis:
         line-numbers:
       tcp-probe:
+      grpc-probe:
     helpers:
       add-to-mesh:
       remove-from-mesh:

--- a/prow/config/mixedlb-service.yaml
+++ b/prow/config/mixedlb-service.yaml
@@ -5,6 +5,7 @@ apiVersion: kind.x-k8s.io/v1alpha4
 featureGates:
   MixedProtocolLBService: true
   EndpointSlice: true
+  GRPCContainerProbe: true
 kubeadmConfigPatches:
   - |
     apiVersion: kubeadm.k8s.io/v1beta2

--- a/releasenotes/notes/grpc-probe.yaml
+++ b/releasenotes/notes/grpc-probe.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+releaseNotes:
+- |
+  **Added** support rewriting gRPC probes

--- a/tests/integration/pilot/grpc_probe_test.go
+++ b/tests/integration/pilot/grpc_probe_test.go
@@ -1,0 +1,101 @@
+//go:build integ
+// +build integ
+
+//  Copyright Istio Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package pilot
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"istio.io/istio/pkg/config/protocol"
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/echo"
+	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
+	"istio.io/istio/pkg/test/framework/components/namespace"
+)
+
+func TestGRPCProbe(t *testing.T) {
+	framework.NewTest(t).
+		Features("usability.observability.grpc-probe").
+		Run(func(t framework.TestContext) {
+			ns := namespace.NewOrFail(t, t, namespace.Config{Prefix: "grpc-probe", Inject: true})
+			// apply strict mtls
+			t.ConfigKube().ApplyYAMLOrFail(t, ns.Name(), fmt.Sprintf(`
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: grpc-probe-mtls
+  namespace: %s
+spec:
+  mtls:
+    mode: STRICT`, ns.Name()))
+
+			for _, testCase := range []struct {
+				name     string
+				rewrite  bool
+				ready    bool
+				openPort bool
+			}{
+				{name: "norewrite-unready", rewrite: false, ready: false, openPort: true},
+				{name: "rewrite-unready", rewrite: true, ready: false, openPort: false},
+				{name: "rewrite-ready", rewrite: true, ready: true, openPort: true},
+			} {
+				t.NewSubTest(testCase.name).Run(func(t framework.TestContext) {
+					runGRPCProbeDeployment(t, ns, testCase.name, testCase.rewrite, testCase.ready, testCase.openPort)
+				})
+			}
+		})
+}
+
+func runGRPCProbeDeployment(ctx framework.TestContext, ns namespace.Instance, //nolint:interfacer
+	name string, rewrite bool, wantReady bool, openPort bool) {
+	ctx.Helper()
+
+	var grpcProbe echo.Instance
+	cfg := echo.Config{
+		Namespace:         ns,
+		Service:           name,
+		ReadinessGRPCPort: "1234",
+		Subsets: []echo.SubsetConfig{
+			{
+				Annotations: echo.NewAnnotations().SetBool(echo.SidecarRewriteAppHTTPProbers, rewrite),
+			},
+		},
+	}
+
+	if openPort {
+		cfg.Ports = []echo.Port{{
+			Name:         "readiness-grpc-port",
+			Protocol:     protocol.GRPC,
+			ServicePort:  1234,
+			InstancePort: 1234,
+		}}
+	}
+
+	// Negative test, we expect the grpc readiness check fails, so set a timeout duration.
+	if !wantReady {
+		cfg.ReadinessTimeout = time.Second * 15
+	}
+	_, err := echoboot.NewBuilder(ctx).
+		With(&grpcProbe, cfg).
+		Build()
+	gotReady := err == nil
+	if gotReady != wantReady {
+		ctx.Errorf("grpcProbe app %v, got error %v, want ready = %v", name, err, wantReady)
+	}
+}


### PR DESCRIPTION
**Please provide a description of this PR:**
Support rewriting gRPC probes for Kubernetes v1.23
Fix #36314
 
I'm not very familiar with the integration test, but I've tested it in my local environment, and here's the result:

#### 1. Apply strict mtls:
```sh
kubectl apply -f - <<EOF
apiVersion: security.istio.io/v1beta1
kind: PeerAuthentication
metadata:
  name: "default"
  namespace: "istio-system"
spec:
  mtls:
    mode: STRICT
EOF
```
#### 2. Create a pod with a grpc probe

Before rewriting([an example in k8s doc](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-grpc-liveness-probe "example in k8s doc")):
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: etcd-with-grpc
spec:
  containers:
  - name: etcd
    image: k8s.gcr.io/etcd:3.5.1-0
    command: [ "/usr/local/bin/etcd", "--data-dir",  "/var/lib/etcd", "--listen-client-urls", "http://0.0.0.0:2379", "--advertise-client-urls", "http://127.0.0.1:2379", "--log-level", "debug"]
    ports:
    - containerPort: 2379
    readinessProbe:
      grpc:
        port: 2379
      initialDelaySeconds: 10
```

After rewriting:
```yaml
...........
      readinessProbe:
        failureThreshold: 3
        httpGet:
          path: /app-health/etcd/readyz
          port: 15020
          scheme: HTTP
        initialDelaySeconds: 10
        periodSeconds: 10
        successThreshold: 1
        timeoutSeconds: 1
...........
      - name: ISTIO_KUBE_APP_PROBERS
        value: '{"/app-health/etcd/readyz":{"grpc":{"port":2379,"service":""},"timeoutSeconds":1}}'
      image: docker.io/istio/proxyv2:1.12.1
...........
```

And the container stays ready
```sh
[root@new grpc-health]# kubectl get po
NAME             READY   STATUS    RESTARTS   AGE
etcd-with-grpc   2/2     Running   0          5m3s
```

#### 3. Set rewrite to `false` and recreate the pod
```yaml
......
metadata:
  annotations: 
    sidecar.istio.io/rewriteAppHTTPProbers: "false"
......
```

Turns out the probe would not be rewrited:
```yaml
      readinessProbe:
        failureThreshold: 3
        grpc:
          port: 2379
          service: ""
        initialDelaySeconds: 10
        periodSeconds: 10
        successThreshold: 1
        timeoutSeconds: 1
```

The container would become unready
```sh
[root@new grpc-health]# kubectl get po
NAME                             READY   STATUS    RESTARTS   AGE
etcd-7c7d558878-bv8dd            1/2     Running   0          4m22s
```