### PR TITLE
allow node selection parameters in operator chart

### DIFF
--- a/manifests/charts/istio-operator/templates/deployment.yaml
+++ b/manifests/charts/istio-operator/templates/deployment.yaml
@@ -55,4 +55,16 @@ spec:
               value: {{.Values.waitForResourcesTimeout | quote}}
             - name: REVISION
               value: {{.Values.revision | quote}}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 ---

--- a/manifests/charts/istio-operator/values.yaml
+++ b/manifests/charts/istio-operator/values.yaml
@@ -25,6 +25,15 @@ operator:
       cpu: 50m
       memory: 128Mi
 
+# Node labels for pod assignment
+nodeSelector: {}
+
+# Tolerations for pod assignment
+tolerations: []
+
+# Affinity for pod assignment
+affinity: {}
+
 # Additional labels and annotations to apply on the pod level for monitoring and logging configuration.
 podLabels: {}
 podAnnotations: {}


### PR DESCRIPTION
All credits go to @matheusfm. This is a rebase of #31262, since this was closed before anyone took a chance to look at it.

**Please provide a description of this PR:**

Allow kubernetes parameters for node selection in istio-operator helm chart: `nodeSelector`, `tolerations` and `affinity`.
Users can constrain the Istio Operator pod(s) to only be able to run on particular node(s). The new parameters have default values that does not affect the users. 