### PR TITLE
global object needs to be accepted, when gateway is used as dependency

### DIFF
--- a/manifests/charts/gateway/values.schema.json
+++ b/manifests/charts/gateway/values.schema.json
@@ -174,6 +174,9 @@
     },
     "networkGateway": {
       "type": "string"
+    },
+    "global": {
+      "type": "object"
     }
   }
 }

--- a/releasenotes/notes/35495.yaml
+++ b/releasenotes/notes/35495.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+releaseNotes:
+  - |
+    **Fixed** the `global variable error` when chart is used as dependency


### PR DESCRIPTION
In one of our setups, Gateway is used as a helm dependency.
Helmcharts populate an object `global` which is passed through all dependencies. By not including this in the schema the following error occures:
```
helm.go:88: [debug] values don't meet the specifications of the schema(s) in the following chart(s):
gateway:
- (root): Additional property global is not allowed

```

This change tries to fix that


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [x] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [x] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
