### PR TITLE
tracing: allow specification of no sampling with reporting via Telemetry API

### DIFF
--- a/pilot/pkg/model/telemetry_test.go
+++ b/pilot/pkg/model/telemetry_test.go
@@ -371,6 +371,16 @@ func TestTracing(t *testing.T) {
 			},
 		},
 	}
+	overridesWithDefaultSampling := &tpb.Telemetry{
+		Tracing: []*tpb.Tracing{
+			{
+				CustomTags: map[string]*tpb.Tracing_CustomTag{
+					"foo": {},
+					"baz": {},
+				},
+			},
+		},
+	}
 	nonExistant := &tpb.Telemetry{
 		Tracing: []*tpb.Tracing{
 			{
@@ -463,6 +473,20 @@ func TestTracing(t *testing.T) {
 				CustomTags: map[string]*tpb.Tracing_CustomTag{
 					"foo": {},
 					"bar": {},
+				},
+			},
+		},
+		{
+			"overrides with default sampling",
+			[]config.Config{newTelemetry("istio-system", overridesWithDefaultSampling)},
+			sidecar,
+			[]string{"envoy"},
+			&TracingConfig{
+				Provider:                 &meshconfig.MeshConfig_ExtensionProvider{Name: "envoy"},
+				RandomSamplingPercentage: 0.0,
+				CustomTags: map[string]*tpb.Tracing_CustomTag{
+					"foo": {},
+					"baz": {},
 				},
 			},
 		},

--- a/pilot/pkg/networking/core/v1alpha3/tracing.go
+++ b/pilot/pkg/networking/core/v1alpha3/tracing.go
@@ -429,7 +429,6 @@ func configureSampling(hcmTracing *hpb.HttpConnectionManager_Tracing, providerPe
 	hcmTracing.RandomSampling = &xdstype.Percent{
 		Value: providerPercentage,
 	}
-	return
 }
 
 func proxyConfigSamplingValue(config *meshconfig.ProxyConfig) float64 {

--- a/pilot/pkg/networking/core/v1alpha3/tracing.go
+++ b/pilot/pkg/networking/core/v1alpha3/tracing.go
@@ -60,7 +60,7 @@ func configureTracingFromSpec(tracing *model.TracingConfig, opts buildListenerOp
 		}
 		// use the prior configuration bits of sampling and custom tags
 		hcm.Tracing = &hpb.HttpConnectionManager_Tracing{}
-		configureSampling(hcm.Tracing, proxyConfigSamplingValue(proxyCfg), proxyCfg)
+		configureSampling(hcm.Tracing, proxyConfigSamplingValue(proxyCfg))
 		configureCustomTags(hcm.Tracing, map[string]*telemetrypb.Tracing_CustomTag{}, proxyCfg, opts.proxy.Metadata)
 		if proxyCfg.GetTracing().GetMaxPathTagLength() != 0 {
 			hcm.Tracing.MaxPathTagLength = wrapperspb.UInt32(proxyCfg.GetTracing().MaxPathTagLength)
@@ -89,7 +89,7 @@ func configureTracingFromSpec(tracing *model.TracingConfig, opts buildListenerOp
 
 	// gracefully fallback to MeshConfig configuration. It will act as an implicit
 	// parent configuration during transition period.
-	configureSampling(hcm.Tracing, tracing.RandomSamplingPercentage, proxyCfg)
+	configureSampling(hcm.Tracing, tracing.RandomSamplingPercentage)
 	configureCustomTags(hcm.Tracing, tracing.CustomTags, proxyCfg, opts.proxy.Metadata)
 
 	// if there is configured max tag length somewhere, fallback to it.
@@ -419,7 +419,7 @@ func buildServiceTags(metadata *model.NodeMetadata) []*tracing.CustomTag {
 	}
 }
 
-func configureSampling(hcmTracing *hpb.HttpConnectionManager_Tracing, providerPercentage float64, proxyCfg *meshconfig.ProxyConfig) {
+func configureSampling(hcmTracing *hpb.HttpConnectionManager_Tracing, providerPercentage float64) {
 	hcmTracing.ClientSampling = &xdstype.Percent{
 		Value: 100.0,
 	}


### PR DESCRIPTION
The Telemetry API documents that the default value for `randomSamplingPercentage` is `0.0`. This change will allow the control plane to respect that documentation (and user intent).

With this PR, Telemetry API users will no longer fallback to pilot environment variables, etc., when the value is not specified.

Related issue: https://github.com/istio/istio/issues/36750
- [ X ] Policies and Telemetry
