### PR TITLE
Fix: grpc probe is not working with ipv6

### DIFF
--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -754,7 +754,7 @@ func (s *Server) handleAppProbeGRPC(w http.ResponseWriter, req *http.Request, pr
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	addr := net.JoinHostPort(s.appProbersDestination, fmt.Sprintf("%d", prober.GRPC.Port))
+	addr := fmt.Sprintf("%s:%d", s.appProbersDestination, prober.GRPC.Port)
 	conn, err := grpc.DialContext(ctx, addr, opts...)
 	if err != nil {
 		log.Errorf("Failed to create grpc connection to probe app: %v", err)


### PR DESCRIPTION
**Please provide a description of this PR:**
We should not use `net.JoinHostPort` to build destination addr, otherwise there would be 2 brackets since the `appProbersDestination` has already been wrapped with "[]"
https://github.com/istio/istio/blob/7c6403332f5044f78d8f541ce983066c8357bd90/pilot/cmd/pilot-agent/status/server.go#L186

https://github.com/istio/istio/blob/7c6403332f5044f78d8f541ce983066c8357bd90/pilot/cmd/pilot-agent/status/server.go#L841-L851

Fix [the failing test](https://prow.istio.io/view/gs/istio-prow/logs/integ-ipv6-k8s-tests_istio_postsubmit/1479643573191184384) 