### PR TITLE
telemetry api: add support for stackdriver CEL filtering in pilot

### DIFF
--- a/pilot/pkg/model/telemetry.go
+++ b/pilot/pkg/model/telemetry.go
@@ -847,7 +847,7 @@ func generateSDConfig(class networking.ListenerClass, telemetryConfig telemetryF
 			if class == networking.ListenerClassSidecarInbound {
 				cfg.AccessLogging = sd.PluginConfig_FULL
 			} else {
-				// this can be achieved via CEL: `response.code >= 400`
+				// this can be achieved via CEL: `response.code >= 400 || response.code == 0`
 				cfg.AccessLogging = sd.PluginConfig_ERRORS_ONLY
 			}
 		}

--- a/pilot/pkg/model/telemetry_test.go
+++ b/pilot/pkg/model/telemetry_test.go
@@ -571,6 +571,13 @@ func TestTelemetryFilters(t *testing.T) {
 				Overrides: overrides,
 			},
 		},
+		AccessLogging: []*tpb.AccessLogging{
+			{
+				Filter: &tpb.AccessLogging_Filter{
+					Expression: "response.code>=500",
+				},
+			},
+		},
 	}
 	overridesEmptyProvider := &tpb.Telemetry{
 		Metrics: []*tpb.Metrics{
@@ -672,7 +679,7 @@ func TestTelemetryFilters(t *testing.T) {
 			networking.ListenerProtocolHTTP,
 			nil,
 			map[string]string{
-				"istio.stackdriver": `{"metric_expiry_duration":"3600s","metrics_overrides":{"client/request_count":{"tag_overrides":{"add":"bar"}}}}`,
+				"istio.stackdriver": `{"metric_expiry_duration":"3600s","metrics_overrides":{"client/request_count":{"tag_overrides":{"add":"bar"}}}, "access_logging_filter_expression": "response.code>=500"}`,
 			},
 		},
 		{

--- a/pilot/pkg/model/telemetry_test.go
+++ b/pilot/pkg/model/telemetry_test.go
@@ -680,7 +680,8 @@ func TestTelemetryFilters(t *testing.T) {
 			networking.ListenerProtocolHTTP,
 			nil,
 			map[string]string{
-				"istio.stackdriver": `{"access_logging_filter_expression":"response.code >= 500 && response.code <= 800","metric_expiry_duration":"3600s","metrics_overrides":{"client/request_count":{"tag_overrides":{"add":"bar"}}}}`,
+				"istio.stackdriver": `{"access_logging_filter_expression":"response.code >= 500 && response.code <= 800",` +
+					`"metric_expiry_duration":"3600s","metrics_overrides":{"client/request_count":{"tag_overrides":{"add":"bar"}}}}`,
 			},
 		},
 		{

--- a/pilot/pkg/model/telemetry_test.go
+++ b/pilot/pkg/model/telemetry_test.go
@@ -573,8 +573,9 @@ func TestTelemetryFilters(t *testing.T) {
 		},
 		AccessLogging: []*tpb.AccessLogging{
 			{
+				Providers: []*tpb.ProviderRef{{Name: "stackdriver"}},
 				Filter: &tpb.AccessLogging_Filter{
-					Expression: "response.code>=500",
+					Expression: `response.code >= 500 && response.code <= 800`,
 				},
 			},
 		},
@@ -679,7 +680,7 @@ func TestTelemetryFilters(t *testing.T) {
 			networking.ListenerProtocolHTTP,
 			nil,
 			map[string]string{
-				"istio.stackdriver": `{"metric_expiry_duration":"3600s","metrics_overrides":{"client/request_count":{"tag_overrides":{"add":"bar"}}}, "access_logging_filter_expression": "response.code>=500"}`,
+				"istio.stackdriver": `{"access_logging_filter_expression":"response.code >= 500 && response.code <= 800","metric_expiry_duration":"3600s","metrics_overrides":{"client/request_count":{"tag_overrides":{"add":"bar"}}}}`,
 			},
 		},
 		{


### PR DESCRIPTION
Stackdriver extension support for CEL filters (part of the Telemetry API) was added in https://github.com/istio/proxy/pull/3630. This PR adds configuration support for the extension in the control plan. 

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ X ] Policies and Telemetry

This PR cannot be completed and merged until https://github.com/istio/api/pull/2206 has been merged.