### PR TITLE
remove unnecessary type checks

### DIFF
--- a/manifests/manifest.go
+++ b/manifests/manifest.go
@@ -26,12 +26,6 @@ import (
 //go:embed charts/gateways/istio-ingress/templates/_affinity.tpl
 var FS embed.FS
 
-var (
-	_ fs.FS         = FS
-	_ fs.ReadFileFS = FS
-	_ fs.ReadDirFS  = FS
-)
-
 // BuiltinOrDir returns a FS for the provided directory. If no directory is passed, the compiled in
 // FS will be used
 func BuiltinOrDir(dir string) fs.FS {


### PR DESCRIPTION
**Please provide a description of this PR:**

ref: https://github.com/golang/go/blob/go1.17/src/io/fs/readdir.go#L14
ref: https://github.com/golang/go/blob/go1.17/src/io/fs/readfile.go#L11
`fs.ReadDirFS` and `fs.ReadFileFS` both implement the `fs.FS` interface.

ref: https://github.com/golang/go/blob/go1.17/src/embed/embed.go#L207
`embed.FS` has implemented the `fs.ReadDirFS` and `fs.ReadFileFS` interfaces.
