### PR TITLE
add proxyconfig control of service-cluster naming scheme

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -85,7 +85,7 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	helm.sh/helm/v3 v3.7.2
-	istio.io/api v0.0.0-20220118161705-ec7515ed524a
+	istio.io/api v0.0.0-20220119195125-7f5ee7917eb1
 	istio.io/client-go v1.12.0-alpha.5.0.20220113014857-3b7795784525
 	istio.io/pkg v0.0.0-20220110182003-89d2d53e36e1
 	k8s.io/api v0.23.1

--- a/go.sum
+++ b/go.sum
@@ -2131,10 +2131,6 @@ honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 istio.io/api v0.0.0-20220113014359-2bcfbc334255/go.mod h1:RVwW5wv5bZYrmHvhYtyp0EQvM2VN3Gw4tLpUrynDCH0=
-istio.io/api v0.0.0-20220118161705-ec7515ed524a h1:fb6e/2Ag8syp6vAIUYP8gRKIaMNxBRgEBY2dhkxLJuY=
-istio.io/api v0.0.0-20220118161705-ec7515ed524a/go.mod h1:RVwW5wv5bZYrmHvhYtyp0EQvM2VN3Gw4tLpUrynDCH0=
-istio.io/api v0.0.0-20220118173337-a3a1e91b0610 h1:UFtl/6GmlqEaaD0tw4jh3B9JyRXcy99PE1udHM7g/K8=
-istio.io/api v0.0.0-20220118173337-a3a1e91b0610/go.mod h1:RVwW5wv5bZYrmHvhYtyp0EQvM2VN3Gw4tLpUrynDCH0=
 istio.io/api v0.0.0-20220119195125-7f5ee7917eb1 h1:e3U3k4rG7XSEWmQf2/AQb7xYJZ5x1bp6pc9vJdlhaCg=
 istio.io/api v0.0.0-20220119195125-7f5ee7917eb1/go.mod h1:RVwW5wv5bZYrmHvhYtyp0EQvM2VN3Gw4tLpUrynDCH0=
 istio.io/client-go v1.12.0-alpha.5.0.20220113014857-3b7795784525 h1:8/meYcL2uIKcopQZlVEiqZam8VDCNp9f+tD7IDPesxk=

--- a/go.sum
+++ b/go.sum
@@ -2133,6 +2133,10 @@ honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9
 istio.io/api v0.0.0-20220113014359-2bcfbc334255/go.mod h1:RVwW5wv5bZYrmHvhYtyp0EQvM2VN3Gw4tLpUrynDCH0=
 istio.io/api v0.0.0-20220118161705-ec7515ed524a h1:fb6e/2Ag8syp6vAIUYP8gRKIaMNxBRgEBY2dhkxLJuY=
 istio.io/api v0.0.0-20220118161705-ec7515ed524a/go.mod h1:RVwW5wv5bZYrmHvhYtyp0EQvM2VN3Gw4tLpUrynDCH0=
+istio.io/api v0.0.0-20220118173337-a3a1e91b0610 h1:UFtl/6GmlqEaaD0tw4jh3B9JyRXcy99PE1udHM7g/K8=
+istio.io/api v0.0.0-20220118173337-a3a1e91b0610/go.mod h1:RVwW5wv5bZYrmHvhYtyp0EQvM2VN3Gw4tLpUrynDCH0=
+istio.io/api v0.0.0-20220119195125-7f5ee7917eb1 h1:e3U3k4rG7XSEWmQf2/AQb7xYJZ5x1bp6pc9vJdlhaCg=
+istio.io/api v0.0.0-20220119195125-7f5ee7917eb1/go.mod h1:RVwW5wv5bZYrmHvhYtyp0EQvM2VN3Gw4tLpUrynDCH0=
 istio.io/client-go v1.12.0-alpha.5.0.20220113014857-3b7795784525 h1:8/meYcL2uIKcopQZlVEiqZam8VDCNp9f+tD7IDPesxk=
 istio.io/client-go v1.12.0-alpha.5.0.20220113014857-3b7795784525/go.mod h1:jCiz6CWAxq0NSfl0K5T07zPwF1lztXR6BEPgXBQDX5s=
 istio.io/gogo-genproto v0.0.0-20211208193508-5ab4acc9eb1e h1:z2WI3y55w0K3c6hmarcp5EcOiP4vVpTBXA8nYstP+cE=

--- a/istioctl/cmd/add-to-mesh.go
+++ b/istioctl/cmd/add-to-mesh.go
@@ -249,7 +249,7 @@ func externalSvcMeshifyCmd() *cobra.Command {
 		Use:     "external-service <svcname> <ip> [name1:]port1 [[name2:]port2] ...",
 		Aliases: []string{"es"},
 		Short:   "Add external service (e.g. services running on a VM) to Istio service mesh",
-		Long: `istioctl experimental add-to-mesh external-service create a ServiceEntry and 
+		Long: `istioctl experimental add-to-mesh external-service create a ServiceEntry and
 a Service without selector for the specified external service in Istio service mesh.
 The typical usage scenario is Mesh Expansion on VMs.
 
@@ -273,12 +273,12 @@ See also 'istioctl experimental remove-from-mesh external-service' which does th
 			ns := handlers.HandleNamespace(namespace, defaultNamespace)
 			_, err = client.CoreV1().Services(ns).Get(context.TODO(), args[0], metav1.GetOptions{})
 			if err != nil {
-				return addServiceOnVMToMesh(seClient, client, ns, args, labels, annotations, svcAcctAnn, writer)
+				return addServiceOnVMToMesh(seClient, client, ns, args, resourceLabels, annotations, svcAcctAnn, writer)
 			}
 			return fmt.Errorf("service %q already exists, skip", args[0])
 		},
 	}
-	cmd.PersistentFlags().StringSliceVarP(&labels, "labels", "l",
+	cmd.PersistentFlags().StringSliceVarP(&resourceLabels, "labels", "l",
 		nil, "List of labels to apply if creating a service/endpoint; e.g. -l env=prod,vers=2")
 	cmd.PersistentFlags().StringSliceVarP(&annotations, "annotations", "a",
 		nil, "List of string annotations to apply if creating a service/endpoint; e.g. -a foo=bar,x=y")

--- a/istioctl/cmd/workload.go
+++ b/istioctl/cmd/workload.go
@@ -47,7 +47,7 @@ import (
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/config/validation"
 	"istio.io/istio/pkg/kube"
-	"istio.io/istio/pkg/kube/inject"
+	"istio.io/istio/pkg/kube/labels"
 	"istio.io/istio/pkg/url"
 	"istio.io/istio/pkg/util/gogoprotomarshal"
 	"istio.io/istio/pkg/util/shellescape"
@@ -69,7 +69,7 @@ var (
 	autoRegister   bool
 	dnsCapture     bool
 	ports          []string
-	labels         []string
+	resourceLabels []string
 	annotations    []string
 	svcAcctAnn     string
 )
@@ -142,7 +142,7 @@ The default output is serialized YAML, which can be piped into 'kubectl apply -f
 			}
 			spec := &networkingv1alpha3.WorkloadGroup{
 				Metadata: &networkingv1alpha3.WorkloadGroup_ObjectMeta{
-					Labels:      convertToStringMap(labels),
+					Labels:      convertToStringMap(resourceLabels),
 					Annotations: convertToStringMap(annotations),
 				},
 				Template: &networkingv1alpha3.WorkloadEntry{
@@ -160,7 +160,7 @@ The default output is serialized YAML, which can be piped into 'kubectl apply -f
 	}
 	createCmd.PersistentFlags().StringVar(&name, "name", "", "The name of the workload group")
 	createCmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", "", "The namespace that the workload instances will belong to")
-	createCmd.PersistentFlags().StringSliceVarP(&labels, "labels", "l", nil, "The labels to apply to the workload instances; e.g. -l env=prod,vers=2")
+	createCmd.PersistentFlags().StringSliceVarP(&resourceLabels, "labels", "l", nil, "The labels to apply to the workload instances; e.g. -l env=prod,vers=2")
 	createCmd.PersistentFlags().StringSliceVarP(&annotations, "annotations", "a", nil, "The annotations to apply to the workload instances")
 	createCmd.PersistentFlags().StringSliceVarP(&ports, "ports", "p", nil, "The incoming ports exposed by the workload instance")
 	createCmd.PersistentFlags().StringVarP(&serviceAccount, "serviceAccount", "s", "default", "The service identity to associate with the workload instances")
@@ -476,16 +476,16 @@ func createMeshConfig(kubeClient kube.ExtendedClient, wg *clientv1alpha3.Workloa
 
 	meshConfig.DefaultConfig.ProxyMetadata = proxyMetadata
 
-	labels := map[string]string{}
+	lbls := map[string]string{}
 	for k, v := range wg.Spec.Metadata.Labels {
-		labels[k] = v
+		lbls[k] = v
 	}
 	// case where a user provided custom workload group has labels in the workload entry template field
 	we := wg.Spec.Template
 	if len(we.Labels) > 0 {
 		fmt.Printf("Labels should be set in the metadata. The following WorkloadEntry labels will override metadata labels: %s\n", we.Labels)
 		for k, v := range we.Labels {
-			labels[k] = v
+			lbls[k] = v
 		}
 	}
 
@@ -496,7 +496,7 @@ func createMeshConfig(kubeClient kube.ExtendedClient, wg *clientv1alpha3.Workloa
 		md = map[string]string{}
 		meshConfig.DefaultConfig.ProxyMetadata = md
 	}
-	md["CANONICAL_SERVICE"], md["CANONICAL_REVISION"] = inject.ExtractCanonicalServiceLabels(labels, wg.Name)
+	md["CANONICAL_SERVICE"], md["CANONICAL_REVISION"] = labels.CanonicalService(lbls, wg.Name)
 	md["POD_NAMESPACE"] = wg.Namespace
 	md["SERVICE_ACCOUNT"] = we.ServiceAccount
 	md["TRUST_DOMAIN"] = meshConfig.TrustDomain
@@ -508,9 +508,9 @@ func createMeshConfig(kubeClient kube.ExtendedClient, wg *clientv1alpha3.Workloa
 		md["ISTIO_META_POD_PORTS"] = string(portsJSON)
 	}
 	md["ISTIO_META_WORKLOAD_NAME"] = wg.Name
-	labels[label.ServiceCanonicalName.Name] = md["CANONICAL_SERVICE"]
-	labels[label.ServiceCanonicalRevision.Name] = md["CANONICAL_REVISION"]
-	if labelsJSON, err := json.Marshal(labels); err == nil {
+	lbls[label.ServiceCanonicalName.Name] = md["CANONICAL_SERVICE"]
+	lbls[label.ServiceCanonicalRevision.Name] = md["CANONICAL_REVISION"]
+	if labelsJSON, err := json.Marshal(lbls); err == nil {
 		md["ISTIO_METAJSON_LABELS"] = string(labelsJSON)
 	}
 

--- a/operator/pkg/util/merge_iop.go
+++ b/operator/pkg/util/merge_iop.go
@@ -161,6 +161,10 @@ type (
 		Name     string                              `json:"string"`
 		Provider meshConfigExtensionProviderInstance `json:"provider"`
 	}
+	clusterName struct {
+		ServiceCluster     *v1alpha13.ProxyConfig_ServiceCluster      `json:"serviceCluster,omitempty"`
+		TracingServiceName *v1alpha13.ProxyConfig_TracingServiceName_ `json:"tracingServiceName,omitempty"`
+	}
 )
 
 type meshConfigExtensionProviderInstance struct {
@@ -180,6 +184,7 @@ type proxyConfig struct {
 	TerminationDrainDuration       *protobuf.Duration                      `json:"terminationDrainDuration" patchStrategy:"replace"`
 	Concurrency                    *protobuf.Int32Value                    `json:"concurrency" patchStrategy:"replace"`
 	ConfigSources                  []*v1alpha13.ConfigSource               `json:"configSources" patchStrategy:"replace"`
+	ClusterName                    *clusterName                            `json:"clusterName" patchStrategy:"replace"`
 	TrustDomainAliases             []string                                `json:"trustDomainAliases" patchStrategy:"replace"`
 	DefaultServiceExportTo         []string                                `json:"defaultServiceExportTo" patchStrategy:"replace"`
 	DefaultVirtualServiceExportTo  []string                                `json:"defaultVirtualServiceExportTo" patchStrategy:"replace"`

--- a/operator/pkg/util/merge_iop_test.go
+++ b/operator/pkg/util/merge_iop_test.go
@@ -46,7 +46,7 @@ func TestOverlayIOPDefaultMeshConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 	mm := make(map[string]interface{})
-	if err := yaml.Unmarshal(my, &mm); err != nil {
+	if err := yaml.Unmarshal([]byte(my), &mm); err != nil {
 		t.Fatal(err)
 	}
 	iop := &v1alpha1.IstioOperator{

--- a/operator/pkg/util/merge_iop_test.go
+++ b/operator/pkg/util/merge_iop_test.go
@@ -46,7 +46,7 @@ func TestOverlayIOPDefaultMeshConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 	mm := make(map[string]interface{})
-	if err := yaml.Unmarshal([]byte(my), &mm); err != nil {
+	if err := yaml.Unmarshal(my, &mm); err != nil {
 		t.Fatal(err)
 	}
 	iop := &v1alpha1.IstioOperator{

--- a/pilot/cmd/pilot-agent/config/config.go
+++ b/pilot/cmd/pilot-agent/config/config.go
@@ -64,8 +64,10 @@ func ConstructProxyConfig(meshConfigFile, serviceCluster, proxyConfigEnv string,
 		// proxy config.
 		proxyConfig.Concurrency = &types.Int32Value{Value: int32(concurrency)}
 	}
-	if proxyConfig.ServiceCluster == "" {
-		proxyConfig.ServiceCluster = serviceCluster
+	if x, ok := proxyConfig.GetClusterName().(*meshconfig.ProxyConfig_ServiceCluster); ok {
+		if x.ServiceCluster == "" {
+			proxyConfig.ClusterName = &meshconfig.ProxyConfig_ServiceCluster{ServiceCluster: serviceCluster}
+		}
 	}
 	// resolve statsd address
 	if proxyConfig.StatsdUdpAddress != "" {

--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -282,10 +282,10 @@ func getServiceCluster(metadata *model.BootstrapNodeMetadata) string {
 		case meshAPI.ProxyConfig_APP_LABEL_AND_NAMESPACE:
 			return serviceClusterOrDefault("istio-proxy", metadata)
 		case meshAPI.ProxyConfig_CANONICAL_NAME_ONLY:
-			cs, _ := inject.ExtractCanonicalServiceLabels(metadata.Labels, metadata.WorkloadName)
+			cs, _ := inject.ExtractCanonicalServiceLabels(metadata.Labels, workloadName)
 			return serviceClusterOrDefault(cs, metadata)
 		case meshAPI.ProxyConfig_CANONICAL_NAME_AND_NAMESPACE:
-			cs, _ := inject.ExtractCanonicalServiceLabels(metadata.Labels, metadata.WorkloadName)
+			cs, _ := inject.ExtractCanonicalServiceLabels(metadata.Labels, workloadName)
 			if metadata.Namespace != "" {
 				return cs + "." + metadata.Namespace
 			}

--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -268,7 +268,6 @@ func getLocalityOptions(l *core.Locality) []option.Instance {
 }
 
 func getServiceCluster(metadata *model.BootstrapNodeMetadata) string {
-
 	switch name := metadata.ProxyConfig.ClusterName.(type) {
 	case *meshAPI.ProxyConfig_ServiceCluster:
 		return serviceClusterOrDefault(name.ServiceCluster, metadata)

--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -625,8 +625,9 @@ func ConvertXDSNodeToNode(node *core.Node) *model.Node {
 	}
 	if metadata.ProxyConfig == nil {
 		metadata.ProxyConfig = &model.NodeMetaProxyConfig{}
+		metadata.ProxyConfig.ClusterName = &meshAPI.ProxyConfig_ServiceCluster{ServiceCluster: node.Cluster}
 	}
-	metadata.ProxyConfig.ClusterName = &meshAPI.ProxyConfig_ServiceCluster{ServiceCluster: node.Cluster}
+
 	return &model.Node{
 		ID:       node.Id,
 		Locality: node.Locality,

--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -36,7 +36,7 @@ import (
 	"istio.io/istio/pkg/bootstrap/option"
 	"istio.io/istio/pkg/bootstrap/platform"
 	"istio.io/istio/pkg/config/constants"
-	"istio.io/istio/pkg/kube/inject"
+	"istio.io/istio/pkg/kube/labels"
 	"istio.io/istio/pkg/util/protomarshal"
 	"istio.io/pkg/log"
 )
@@ -282,10 +282,10 @@ func getServiceCluster(metadata *model.BootstrapNodeMetadata) string {
 		case meshAPI.ProxyConfig_APP_LABEL_AND_NAMESPACE:
 			return serviceClusterOrDefault("istio-proxy", metadata)
 		case meshAPI.ProxyConfig_CANONICAL_NAME_ONLY:
-			cs, _ := inject.ExtractCanonicalServiceLabels(metadata.Labels, workloadName)
+			cs, _ := labels.CanonicalService(metadata.Labels, workloadName)
 			return serviceClusterOrDefault(cs, metadata)
 		case meshAPI.ProxyConfig_CANONICAL_NAME_AND_NAMESPACE:
-			cs, _ := inject.ExtractCanonicalServiceLabels(metadata.Labels, workloadName)
+			cs, _ := labels.CanonicalService(metadata.Labels, workloadName)
 			if metadata.Namespace != "" {
 				return cs + "." + metadata.Namespace
 			}

--- a/pkg/bootstrap/config_test.go
+++ b/pkg/bootstrap/config_test.go
@@ -150,7 +150,6 @@ func TestConvertNodeMetadata(t *testing.T) {
 }
 
 func TestConvertNodeServiceClusterNaming(t *testing.T) {
-
 	cases := []struct {
 		name        string
 		proxyCfg    *model.NodeMetaProxyConfig

--- a/pkg/config/mesh/mesh.go
+++ b/pkg/config/mesh/mesh.go
@@ -38,7 +38,7 @@ func DefaultProxyConfig() meshconfig.ProxyConfig {
 	// TODO: set default namespace based on POD_NAMESPACE env
 	return meshconfig.ProxyConfig{
 		ConfigPath:               constants.ConfigPathDir,
-		ServiceCluster:           constants.ServiceClusterName,
+		ClusterName:              &meshconfig.ProxyConfig_ServiceCluster{ServiceCluster: constants.ServiceClusterName},
 		DrainDuration:            types.DurationProto(45 * time.Second),
 		ParentShutdownDuration:   types.DurationProto(60 * time.Second),
 		TerminationDrainDuration: types.DurationProto(5 * time.Second),

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -487,7 +487,7 @@ func TestValidateMeshConfigProxyConfig(t *testing.T) {
 		ProxyAdminPort:         15000,
 		DrainDuration:          types.DurationProto(45 * time.Second),
 		ParentShutdownDuration: types.DurationProto(60 * time.Second),
-		ServiceCluster:         "istio-proxy",
+		ClusterName:            &meshconfig.ProxyConfig_ServiceCluster{ServiceCluster: "istio-proxy"},
 		StatsdUdpAddress:       "istio-statsd-prom-bridge.istio-system:9125",
 		EnvoyMetricsService:    &meshconfig.RemoteService{Address: "metrics-service.istio-system:15000"},
 		EnvoyAccessLogService:  &meshconfig.RemoteService{Address: "accesslog-service.istio-system:15000"},
@@ -563,8 +563,10 @@ func TestValidateMeshConfigProxyConfig(t *testing.T) {
 			isValid: false,
 		},
 		{
-			name:    "service cluster invalid",
-			in:      modify(valid, func(c *meshconfig.ProxyConfig) { c.ServiceCluster = "" }),
+			name: "service cluster invalid",
+			in: modify(valid, func(c *meshconfig.ProxyConfig) {
+				c.ClusterName = &meshconfig.ProxyConfig_ServiceCluster{ServiceCluster: ""}
+			}),
 			isValid: false,
 		},
 		{
@@ -795,7 +797,7 @@ func TestValidateMeshConfigProxyConfig(t *testing.T) {
 		ProxyAdminPort:         0,
 		DrainDuration:          types.DurationProto(-1 * time.Second),
 		ParentShutdownDuration: types.DurationProto(-1 * time.Second),
-		ServiceCluster:         "",
+		ClusterName:            &meshconfig.ProxyConfig_ServiceCluster{ServiceCluster: ""},
 		StatsdUdpAddress:       "10.0.0.100",
 		EnvoyMetricsService:    &meshconfig.RemoteService{Address: "metrics-service"},
 		EnvoyAccessLogService:  &meshconfig.RemoteService{Address: "accesslog-service"},

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -450,7 +450,7 @@ func TestValidateMeshConfig(t *testing.T) {
 			"invalid protocol detection timeout: duration: nil Duration",
 			"config path must be set",
 			"binary path must be set",
-			"service cluster must be set",
+			"oneof service cluster or tracing service name must be specified",
 			"invalid parent and drain time combination invalid drain duration",
 			"invalid parent and drain time combination invalid parent shutdown duration",
 			"discovery address must be set to the proxy discovery service",

--- a/pkg/envoy/proxy_test.go
+++ b/pkg/envoy/proxy_test.go
@@ -20,13 +20,14 @@ import (
 
 	"github.com/gogo/protobuf/types"
 
+	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/config/mesh"
 )
 
 func TestEnvoyArgs(t *testing.T) {
 	proxyConfig := model.NodeMetaProxyConfig(mesh.DefaultProxyConfig())
-	proxyConfig.ServiceCluster = "my-cluster"
+	proxyConfig.ClusterName = &meshconfig.ProxyConfig_ServiceCluster{ServiceCluster: "my-cluster"}
 	proxyConfig.Concurrency = &types.Int32Value{Value: 8}
 
 	cfg := ProxyConfig{

--- a/pkg/kube/inject/template.go
+++ b/pkg/kube/inject/template.go
@@ -296,9 +296,6 @@ func cleanProxyConfig(msg proto.Message) proto.Message {
 	if pc.ControlPlaneAuthPolicy == defaults.ControlPlaneAuthPolicy {
 		pc.ControlPlaneAuthPolicy = 0
 	}
-	if pc.ServiceCluster == defaults.ServiceCluster {
-		pc.ServiceCluster = ""
-	}
 	if reflect.DeepEqual(pc.DrainDuration, defaults.DrainDuration) {
 		pc.DrainDuration = nil
 	}

--- a/pkg/kube/inject/template.go
+++ b/pkg/kube/inject/template.go
@@ -296,6 +296,11 @@ func cleanProxyConfig(msg proto.Message) proto.Message {
 	if pc.ControlPlaneAuthPolicy == defaults.ControlPlaneAuthPolicy {
 		pc.ControlPlaneAuthPolicy = 0
 	}
+	if x, ok := pc.GetClusterName().(*meshconfig.ProxyConfig_ServiceCluster); ok {
+		if x.ServiceCluster == defaults.GetClusterName().(*meshconfig.ProxyConfig_ServiceCluster).ServiceCluster {
+			pc.ClusterName = nil
+		}
+	}
 	if reflect.DeepEqual(pc.DrainDuration, defaults.DrainDuration) {
 		pc.DrainDuration = nil
 	}

--- a/pkg/kube/inject/webhook.go
+++ b/pkg/kube/inject/webhook.go
@@ -232,42 +232,6 @@ func enablePrometheusMerge(mesh *meshconfig.MeshConfig, anno map[string]string) 
 	return true
 }
 
-func ExtractCanonicalServiceLabels(podLabels map[string]string, workloadName string) (string, string) {
-	return extractCanonicalServiceLabel(podLabels, workloadName), extractCanonicalServiceRevision(podLabels)
-}
-
-func extractCanonicalServiceRevision(podLabels map[string]string) string {
-	if rev, ok := podLabels[model.IstioCanonicalServiceRevisionLabelName]; ok {
-		return rev
-	}
-
-	if rev, ok := podLabels["app.kubernetes.io/version"]; ok {
-		return rev
-	}
-
-	if rev, ok := podLabels["version"]; ok {
-		return rev
-	}
-
-	return "latest"
-}
-
-func extractCanonicalServiceLabel(podLabels map[string]string, workloadName string) string {
-	if svc, ok := podLabels[model.IstioCanonicalServiceLabelName]; ok {
-		return svc
-	}
-
-	if svc, ok := podLabels["app.kubernetes.io/name"]; ok {
-		return svc
-	}
-
-	if svc, ok := podLabels["app"]; ok {
-		return svc
-	}
-
-	return workloadName
-}
-
 func toAdmissionResponse(err error) *kube.AdmissionResponse {
 	return &kube.AdmissionResponse{Result: &metav1.Status{Message: err.Error()}}
 }

--- a/pkg/kube/labels/labels.go
+++ b/pkg/kube/labels/labels.go
@@ -1,0 +1,63 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package labels provides utility methods for retrieving Istio-specific labels
+// from Kubernetes resources.
+package labels
+
+import "istio.io/istio/pilot/pkg/model"
+
+// CanonicalService returns the values of the following labels from the supplied map:
+// - service.istio.io/canonical-name
+// - service.istio.io/canonical-revision
+//
+// If the labels are not in the map, a set of fallbacks are checked. For canonical name,
+// `app.kubernetes.io/name` is checked, then `app`, evenutually falling back to the
+// supplied `workloadName`. For canonical revision, `app.kubernetes.io/version` is checked,
+// followed by `version` and finally defaulting to the literal value of `"latest"`.
+func CanonicalService(labels map[string]string, workloadName string) (string, string) {
+	return canonicalServiceName(labels, workloadName), canonicalServiceRevision(labels)
+}
+
+func canonicalServiceRevision(labels map[string]string) string {
+	if rev, ok := labels[model.IstioCanonicalServiceRevisionLabelName]; ok {
+		return rev
+	}
+
+	if rev, ok := labels["app.kubernetes.io/version"]; ok {
+		return rev
+	}
+
+	if rev, ok := labels["version"]; ok {
+		return rev
+	}
+
+	return "latest"
+}
+
+func canonicalServiceName(labels map[string]string, workloadName string) string {
+	if svc, ok := labels[model.IstioCanonicalServiceLabelName]; ok {
+		return svc
+	}
+
+	if svc, ok := labels["app.kubernetes.io/name"]; ok {
+		return svc
+	}
+
+	if svc, ok := labels["app"]; ok {
+		return svc
+	}
+
+	return workloadName
+}

--- a/releasenotes/notes/36809.yaml
+++ b/releasenotes/notes/36809.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: telemetry
+issue:
+  - 36162
+releaseNotes:
+  - |
+    **Added** configurable service-cluster naming scheme support.


### PR DESCRIPTION
Adds control plane implementation of API surface added in https://github.com/istio/api/pull/2174.

This will allow Istio users (mesh admins) to configure how service-cluster names are generated for proxies. This primarily impacts trace span service naming. The PR (with the API PR) is meant to address a regression in control that appeared in 1.12.

Related issue: istio/istio#36162
Prior discussion: istio/istio#12644

- [ X ] Networking
- [ X ] Policies and Telemetry
