### PR TITLE
pilot-agent support reload ROOTCA

### DIFF
--- a/pkg/istio-agent/agent.go
+++ b/pkg/istio-agent/agent.go
@@ -475,6 +475,11 @@ func (a *Agent) Run(ctx context.Context) (func(), error) {
 }
 
 func (a *Agent) caFileWatcherHandler(ctx context.Context, caFile string) {
+	if err := a.caFileWatcher.Add(caFile); err != nil {
+		log.Warnf("Failed to add file watcher %s, caFile", caFile)
+	}
+
+	log.Debugf("Add CA file %s watcher", caFile)
 	for {
 		select {
 		case gotEvent := <-a.caFileWatcher.Events(caFile):

--- a/pkg/istio-agent/agent_test.go
+++ b/pkg/istio-agent/agent_test.go
@@ -489,6 +489,39 @@ func TestAgent(t *testing.T) {
 
 		testutil.CompareContent(t, got, filepath.Join(env.IstioSrc, "pkg/istio-agent/testdata/grpc-bootstrap.json"))
 	})
+	t.Run("ROOT CA change", func(t *testing.T) {
+		dir := mktemp()
+		rootCertFileName := "root-cert.pem"
+
+		// use a invalid root cert, XDS will fail with `authentication handshake failed`
+		localRootCert := filepath.Join(env.IstioSrc, "./tests/testdata/local/etc/certs/root-cert.pem")
+		if err := file.Copy(localRootCert, dir, rootCertFileName); err != nil {
+			t.Fatalf("failed to init root CA: %v", err)
+		}
+		a := Setup(t, func(a AgentTest) AgentTest {
+			a.AgentConfig.XDSRootCerts = path.Join(dir, rootCertFileName)
+			return a
+		})
+		meta := proxyConfigToMetadata(t, a.ProxyConfig)
+		err := retry.Until(func() bool {
+			err := test.Wrap(func(t test.Failer) {
+				conn := setupDownstreamConnectionUDS(t, a.AgentConfig.XdsUdsPath)
+				xdsc := xds.NewAdsTest(t, conn).WithMetadata(meta)
+				_ = xdsc.RequestResponseAck(t, nil)
+			})
+
+			return err == nil
+		}, retry.Timeout(time.Second*5), retry.Delay(time.Millisecond*200))
+		if err == nil {
+			t.Fatalf("connect success with wrong CA")
+		}
+
+		// change ROOT CA, XDS will success
+		if err := file.Copy(path.Join(certDir, rootCertFileName), dir, rootCertFileName); err != nil {
+			t.Fatalf("failed to change root CA: %v", err)
+		}
+		a.Check(t, security.WorkloadKeyCertResourceName, security.RootCertReqResourceName)
+	})
 }
 
 type AgentTest struct {

--- a/pkg/istio-agent/agent_test.go
+++ b/pkg/istio-agent/agent_test.go
@@ -503,16 +503,11 @@ func TestAgent(t *testing.T) {
 			return a
 		})
 		meta := proxyConfigToMetadata(t, a.ProxyConfig)
-		err := retry.Until(func() bool {
-			err := test.Wrap(func(t test.Failer) {
-				conn := setupDownstreamConnectionUDS(t, a.AgentConfig.XdsUdsPath)
-				xdsc := xds.NewAdsTest(t, conn).WithMetadata(meta)
-				_ = xdsc.RequestResponseAck(t, nil)
-			})
-
-			return err == nil
-		}, retry.Timeout(time.Second*5), retry.Delay(time.Millisecond*200))
-		if err == nil {
+		if err := test.Wrap(func(t test.Failer) {
+			conn := setupDownstreamConnectionUDS(t, a.AgentConfig.XdsUdsPath)
+			xdsc := xds.NewAdsTest(t, conn).WithMetadata(meta)
+			_ = xdsc.RequestResponseAck(t, nil)
+		}); err == nil {
 			t.Fatalf("connect success with wrong CA")
 		}
 

--- a/pkg/istio-agent/xds_proxy.go
+++ b/pkg/istio-agent/xds_proxy.go
@@ -348,10 +348,12 @@ func (p *XdsProxy) handleStream(downstream adsStream) error {
 }
 
 func (p *XdsProxy) buildUpstreamConn(ctx context.Context) (*grpc.ClientConn, error) {
-	p.optsMutex.Lock()
-	defer p.optsMutex.Unlock()
+	p.optsMutex.RLock()
+	opts := make([]grpc.DialOption, 0, len(p.istiodDialOptions))
+	opts = append(opts, p.istiodDialOptions...)
+	p.optsMutex.RUnlock()
 
-	return grpc.DialContext(ctx, p.istiodAddress, p.istiodDialOptions...)
+	return grpc.DialContext(ctx, p.istiodAddress, opts...)
 }
 
 func (p *XdsProxy) HandleUpstream(ctx context.Context, con *ProxyConnection, xds discovery.AggregatedDiscoveryServiceClient) error {

--- a/pkg/istio-agent/xds_proxy_delta.go
+++ b/pkg/istio-agent/xds_proxy_delta.go
@@ -103,7 +103,7 @@ func (p *XdsProxy) DeltaAggregatedResources(downstream discovery.AggregatedDisco
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
-	upstreamConn, err := grpc.DialContext(ctx, p.istiodAddress, p.istiodDialOptions...)
+	upstreamConn, err := p.buildUpstreamConn(ctx)
 	if err != nil {
 		proxyLog.Errorf("failed to connect to upstream %s: %v", p.istiodAddress, err)
 		metrics.IstiodConnectionFailures.Increment()

--- a/releasenotes/notes/36813.yaml
+++ b/releasenotes/notes/36813.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+issue:
+- 36723
+releaseNotes:
+  - |
+    **Fixed** an issue when envoy lost connection after `istio-ca-root-cert` changed.


### PR DESCRIPTION
**Please provide a description of this PR:**

this PR will fix https://github.com/istio/istio/issues/36723, add a mechanism allow pilot-agent to reload ca file once the ROOTCA changed.

```shell
2022-01-13T14:27:18.657508Z	info	Envoy proxy is ready
2022-01-13T14:28:17.949238Z	warning	envoy config	StreamAggregatedResources gRPC config stream closed since 31s ago: 14, connection error: desc = "transport: Error while dialing dial tcp: lookup istiod.istio-system.svc on 10.96.0.10:53: no such host"
2022-01-13T14:28:22.473133Z	warning	envoy config	StreamAggregatedResources gRPC config stream closed since 36s ago: 14, connection error: desc = "transport: Error while dialing dial tcp: lookup istiod.istio-system.svc on 10.96.0.10:53: no such host"
2022-01-13T14:28:28.059480Z	info	Receive file var/run/secrets/istio/root-cert.pem event "var/run/secrets/istio/..2022_01_13_14_28_28.461962497": CHMOD
2022-01-13T14:28:28.059585Z	info	citadelclient	Citadel client using custom root cert: var/run/secrets/istio/root-cert.pem
2022-01-13T14:28:28.060340Z	info	ads	XDS: Incremental Pushing:0 ConnectedEndpoints:2 Version:
2022-01-13T14:28:28.060363Z	info	ads	XDS: Incremental Pushing:0 ConnectedEndpoints:2 Version:
2022-01-13T14:28:28.060573Z	info	cache	returned workload trust anchor from cache	ttl=23h58m48.939433951s
2022-01-13T14:28:28.060643Z	info	ads	SDS: PUSH for node:httpbin-74fb669cc6-g2svb.default resources:1 size:1.1kB resource:ROOTCA
2022-01-13T14:28:28.060763Z	info	cache	returned workload certificate from cache	ttl=23h58m48.939242047s
2022-01-13T14:28:28.060815Z	info	ads	SDS: PUSH for node:httpbin-74fb669cc6-g2svb.default resources:1 size:4.0kB resource:default
2022-01-13T14:28:33.647786Z	warning	envoy config	StreamAggregatedResources gRPC config stream closed since 47s ago: 14, connection error: desc = "transport: Error while dialing dial tcp: lookup istiod.istio-system.svc on 10.96.0.10:53: no such host"
2022-01-13T14:28:43.764632Z	info	xdsproxy	connected to upstream XDS server: istiod.istio-system.svc:15012

```