### PR TITLE
[CNI] Returns config file path for clean up even cni config write errors out.

### DIFF
--- a/cni/pkg/install/cniconfig.go
+++ b/cni/pkg/install/cniconfig.go
@@ -149,6 +149,7 @@ func writeCNIConfig(ctx context.Context, cniConfig []byte, cfg pluginConfig) (st
 	}
 
 	if err = file.AtomicWrite(cniConfigFilepath, cniConfig, os.FileMode(0o644)); err != nil {
+		installLog.Errorf("Failed to write CNI config file %v: %v", cniConfigFilepath, err)
 		return cniConfigFilepath, err
 	}
 
@@ -157,6 +158,7 @@ func writeCNIConfig(ctx context.Context, cniConfig []byte, cfg pluginConfig) (st
 		installLog.Infof("Renaming %s extension to .conflist", cniConfigFilepath)
 		err = os.Rename(cniConfigFilepath, cniConfigFilepath+"list")
 		if err != nil {
+			installLog.Errorf("Failed to rename CNI config file %v: %v", cniConfigFilepath, err)
 			return cniConfigFilepath, err
 		}
 		cniConfigFilepath += "list"

--- a/cni/pkg/install/cniconfig.go
+++ b/cni/pkg/install/cniconfig.go
@@ -149,7 +149,7 @@ func writeCNIConfig(ctx context.Context, cniConfig []byte, cfg pluginConfig) (st
 	}
 
 	if err = file.AtomicWrite(cniConfigFilepath, cniConfig, os.FileMode(0o644)); err != nil {
-		return "", err
+		return cniConfigFilepath, err
 	}
 
 	if cfg.chainedCNIPlugin && strings.HasSuffix(cniConfigFilepath, ".conf") {
@@ -157,7 +157,7 @@ func writeCNIConfig(ctx context.Context, cniConfig []byte, cfg pluginConfig) (st
 		installLog.Infof("Renaming %s extension to .conflist", cniConfigFilepath)
 		err = os.Rename(cniConfigFilepath, cniConfigFilepath+"list")
 		if err != nil {
-			return "", err
+			return cniConfigFilepath, err
 		}
 		cniConfigFilepath += "list"
 	}


### PR DESCRIPTION
Context: https://github.com/istio/istio/issues/36821

Pod removal is stuck with network plugin cannot find error. This suggests that the cni config file has istio-cni configure, but the istio-cni binary does not present. Based on the logic, this can only happen if cni config file update errors out after updating the config file. This change makes those error returns also return config file path, which will go through the final clean up code path.