### PR TITLE
Fix build base images script

### DIFF
--- a/tools/build-base-images.sh
+++ b/tools/build-base-images.sh
@@ -52,4 +52,7 @@ set -e
 # * export DOCKER_ARCHITECTURES="linux/amd64,linux/arm64"
 # Note: if you already have a container builder before running the qemu setup you will need to restart them
 
-BUILDX_BAKE_EXTRA_OPTIONS="--no-cache --pull" DOCKER_TARGETS="${DOCKER_TARGETS}" make dockerx.pushx
+for hub in ${HUBS}
+do
+  HUB="${hub}" BUILDX_BAKE_EXTRA_OPTIONS="--no-cache --pull" DOCKER_TARGETS="${DOCKER_TARGETS}" make dockerx.pushx
+done


### PR DESCRIPTION
since we moved to the go-based builder we don't support the `HUBS` envvar, the script takes a single hub at a time. should fix failures in https://github.com/istio/istio/pull/36830 after triggering rebuild