### PR TITLE
Correct route precedence logic for k8s ingress

### DIFF
--- a/pilot/pkg/config/kube/ingress/conversion.go
+++ b/pilot/pkg/config/kube/ingress/conversion.go
@@ -29,6 +29,7 @@ import (
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/serviceregistry/kube"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/constants"
@@ -150,13 +151,11 @@ func ConvertIngressVirtualService(ingress v1beta1.Ingress, domainSuffix string, 
 			host = "*"
 		}
 		virtualService := &networking.VirtualService{
-			Hosts:    []string{},
+			Hosts:    []string{host},
 			Gateways: []string{fmt.Sprintf("%s/%s-%s-%s", ingressNamespace, ingress.Name, constants.IstioIngressGatewayName, ingress.Namespace)},
 		}
 
-		virtualService.Hosts = []string{host}
-
-		httpRoutes := make([]*networking.HTTPRoute, 0)
+		httpRoutes := make([]*networking.HTTPRoute, 0, len(rule.HTTP.Paths))
 		for _, httpPath := range rule.HTTP.Paths {
 			httpMatch := &networking.HTTPMatchRequest{}
 			if httpPath.PathType != nil {
@@ -216,19 +215,36 @@ func ConvertIngressVirtualService(ingress v1beta1.Ingress, domainSuffix string, 
 		if f {
 			vs := old.Spec.(*networking.VirtualService)
 			vs.Http = append(vs.Http, httpRoutes...)
-			sort.SliceStable(vs.Http, func(i, j int) bool {
-				r1 := vs.Http[i].Match[0].GetUri()
-				r2 := vs.Http[j].Match[0].GetUri()
-				_, r1Ex := r1.GetMatchType().(*networking.StringMatch_Exact)
-				_, r2Ex := r2.GetMatchType().(*networking.StringMatch_Exact)
-				// TODO: default at the end
-				if r1Ex && !r2Ex {
-					return true
-				}
-				return false
-			})
+			if features.LegacyIngressBehavior {
+				sort.SliceStable(vs.Http, func(i, j int) bool {
+					r1 := vs.Http[i].Match[0].GetUri()
+					r2 := vs.Http[j].Match[0].GetUri()
+					_, r1Ex := r1.GetMatchType().(*networking.StringMatch_Exact)
+					_, r2Ex := r2.GetMatchType().(*networking.StringMatch_Exact)
+					// TODO: default at the end
+					if r1Ex && !r2Ex {
+						return true
+					}
+					return false
+				})
+			}
 		} else {
 			ingressByHost[host] = &virtualServiceConfig
+		}
+
+		if !features.LegacyIngressBehavior {
+			// sort routes to meet ingress route precedence requirements
+			// see https://kubernetes.io/docs/concepts/services-networking/ingress/#multiple-matches
+			vs := ingressByHost[host].Spec.(*networking.VirtualService)
+			sort.SliceStable(vs.Http, func(i, j int) bool {
+				r1Len, r1Ex := getMatchURILength(vs.Http[i].Match[0])
+				r2Len, r2Ex := getMatchURILength(vs.Http[j].Match[0])
+				// TODO: default at the end
+				if r1Len == r2Len {
+					return r1Ex && !r2Ex
+				}
+				return r1Len > r2Len
+			})
 		}
 	}
 
@@ -238,6 +254,22 @@ func ConvertIngressVirtualService(ingress v1beta1.Ingress, domainSuffix string, 
 		log.Infof("Ignore default wildcard ingress, use VirtualService %s:%s",
 			ingress.Namespace, ingress.Name)
 	}
+}
+
+// getMatchURILength returns the length of matching path, and whether the match type is EXACT
+func getMatchURILength(match *networking.HTTPMatchRequest) (length int, exact bool) {
+	uri := match.GetUri()
+	switch uri.GetMatchType().(type) {
+	case *networking.StringMatch_Exact:
+		return len(uri.GetExact()), true
+	case *networking.StringMatch_Prefix:
+		return len(uri.GetPrefix()), false
+	case *networking.StringMatch_Regex:
+		// trim the regex suffix
+		return len(uri.GetRegex()) - len(prefixMatchRegex), false
+	}
+	// should not happen
+	return -1, false
 }
 
 func ingressBackendToHTTPRoute(backend *v1beta1.IngressBackend, namespace string, domainSuffix string,

--- a/pilot/pkg/config/kube/ingress/testdata/simple.yaml.golden
+++ b/pilot/pkg/config/kube/ingress/testdata/simple.yaml.golden
@@ -29,12 +29,21 @@ spec:
   http:
   - match:
     - uri:
-        exact: /path
+        exact: /sub/path/
     route:
     - destination:
         host: service1.ns.svc.mydomain
         port:
-          number: 4200
+          number: 4202
+      weight: 100
+  - match:
+    - uri:
+        exact: /sub/path/
+    route:
+    - destination:
+        host: service1.ns.svc.mydomain
+        port:
+          number: 4207
       weight: 100
   - match:
     - uri:
@@ -47,57 +56,12 @@ spec:
       weight: 100
   - match:
     - uri:
-        exact: /sub/path/
-    route:
-    - destination:
-        host: service1.ns.svc.mydomain
-        port:
-          number: 4202
-      weight: 100
-  - match:
-    - uri:
-        prefix: /regex1
-    route:
-    - destination:
-        host: service1.ns.svc.mydomain
-        port:
-          number: 4203
-      weight: 100
-  - match:
-    - uri:
-        exact: /regex2*
-    route:
-    - destination:
-        host: service1.ns.svc.mydomain
-        port:
-          number: 4204
-      weight: 100
-  - match:
-    - uri:
-        prefix: /regex3
-    route:
-    - destination:
-        host: service1.ns.svc.mydomain
-        port:
-          number: 4205
-      weight: 100
-  - match:
-    - uri:
         exact: /sub/path
     route:
     - destination:
         host: service1.ns.svc.mydomain
         port:
           number: 4206
-      weight: 100
-  - match:
-    - uri:
-        exact: /sub/path/
-    route:
-    - destination:
-        host: service1.ns.svc.mydomain
-        port:
-          number: 4207
       weight: 100
   - match:
     - uri:
@@ -116,5 +80,41 @@ spec:
         host: service1.ns.svc.mydomain
         port:
           number: 4209
+      weight: 100
+  - match:
+    - uri:
+        exact: /regex2*
+    route:
+    - destination:
+        host: service1.ns.svc.mydomain
+        port:
+          number: 4204
+      weight: 100
+  - match:
+    - uri:
+        prefix: /regex1
+    route:
+    - destination:
+        host: service1.ns.svc.mydomain
+        port:
+          number: 4203
+      weight: 100
+  - match:
+    - uri:
+        prefix: /regex3
+    route:
+    - destination:
+        host: service1.ns.svc.mydomain
+        port:
+          number: 4205
+      weight: 100
+  - match:
+    - uri:
+        exact: /path
+    route:
+    - destination:
+        host: service1.ns.svc.mydomain
+        port:
+          number: 4200
       weight: 100
 ---

--- a/pilot/pkg/config/kube/ingressv1/conversion.go
+++ b/pilot/pkg/config/kube/ingressv1/conversion.go
@@ -28,8 +28,8 @@ import (
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
-	"istio.io/istio/pilot/pkg/serviceregistry/kube"
 	"istio.io/istio/pilot/pkg/features"
+	"istio.io/istio/pilot/pkg/serviceregistry/kube"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/labels"

--- a/pilot/pkg/config/kube/ingressv1/conversion_test.go
+++ b/pilot/pkg/config/kube/ingressv1/conversion_test.go
@@ -135,6 +135,10 @@ func readConfig(t *testing.T, filename string) ([]runtime.Object, error) {
 func TestConversion(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
+	prefix := knetworking.PathTypePrefix
+	exact := knetworking.PathTypeExact
+
 	ingress := knetworking.Ingress{
 		ObjectMeta: metaV1.ObjectMeta{
 			Namespace: "mock", // goes into backend full name
@@ -148,6 +152,16 @@ func TestConversion(t *testing.T) {
 							Paths: []knetworking.HTTPIngressPath{
 								{
 									Path: "/test",
+									Backend: knetworking.IngressBackend{
+										Service: &knetworking.IngressServiceBackend{
+											Name: "foo",
+											Port: knetworking.ServiceBackendPort{Number: 8000},
+										},
+									},
+								},
+								{
+									Path:     "/test/foo",
+									PathType: &prefix,
 									Backend: knetworking.IngressBackend{
 										Service: &knetworking.IngressServiceBackend{
 											Name: "foo",
@@ -218,6 +232,26 @@ func TestConversion(t *testing.T) {
 										},
 									},
 								},
+								{
+									Path:     "/test/foo/bar",
+									PathType: &prefix,
+									Backend: knetworking.IngressBackend{
+										Service: &knetworking.IngressServiceBackend{
+											Name: "foo",
+											Port: knetworking.ServiceBackendPort{Number: 8000},
+										},
+									},
+								},
+								{
+									Path:     "/test/foo/bar",
+									PathType: &exact,
+									Backend: knetworking.IngressBackend{
+										Service: &knetworking.IngressServiceBackend{
+											Name: "foo",
+											Port: knetworking.ServiceBackendPort{Number: 8000},
+										},
+									},
+								},
 							},
 						},
 					},
@@ -234,6 +268,9 @@ func TestConversion(t *testing.T) {
 		t.Error("VirtualServices, expected 3 got ", len(cfgs))
 	}
 
+	expectedLength := [5]int{13, 13, 9, 6, 5}
+	expectedExact := [5]bool{true, false, false, true, true}
+
 	for n, cfg := range cfgs {
 		vs := cfg.Spec.(*networking.VirtualService)
 
@@ -241,8 +278,15 @@ func TestConversion(t *testing.T) {
 			if vs.Hosts[0] != "my.host.com" {
 				t.Error("Unexpected host", vs)
 			}
-			if len(vs.Http) != 2 {
+			if len(vs.Http) != 5 {
 				t.Error("Unexpected rules", vs.Http)
+			}
+			for i, route := range vs.Http {
+				length, exact := getMatchURILength(route.Match[0])
+				if length != expectedLength[i] || exact != expectedExact[i] {
+					t.Errorf("Unexpected rule at idx:%d, want {length:%d, exact:%v}, got {length:%d, exact: %v}",
+						i, expectedLength[i], expectedExact[i], length, exact)
+				}
 			}
 		}
 	}

--- a/pilot/pkg/config/kube/ingressv1/testdata/simple.yaml.golden
+++ b/pilot/pkg/config/kube/ingressv1/testdata/simple.yaml.golden
@@ -29,12 +29,21 @@ spec:
   http:
   - match:
     - uri:
-        exact: /path
+        exact: /sub/path/
     route:
     - destination:
         host: service1.ns.svc.mydomain
         port:
-          number: 4200
+          number: 4202
+      weight: 100
+  - match:
+    - uri:
+        exact: /sub/path/
+    route:
+    - destination:
+        host: service1.ns.svc.mydomain
+        port:
+          number: 4207
       weight: 100
   - match:
     - uri:
@@ -47,57 +56,12 @@ spec:
       weight: 100
   - match:
     - uri:
-        exact: /sub/path/
-    route:
-    - destination:
-        host: service1.ns.svc.mydomain
-        port:
-          number: 4202
-      weight: 100
-  - match:
-    - uri:
-        prefix: /regex1
-    route:
-    - destination:
-        host: service1.ns.svc.mydomain
-        port:
-          number: 4203
-      weight: 100
-  - match:
-    - uri:
-        exact: /regex2*
-    route:
-    - destination:
-        host: service1.ns.svc.mydomain
-        port:
-          number: 4204
-      weight: 100
-  - match:
-    - uri:
-        prefix: /regex3
-    route:
-    - destination:
-        host: service1.ns.svc.mydomain
-        port:
-          number: 4205
-      weight: 100
-  - match:
-    - uri:
         exact: /sub/path
     route:
     - destination:
         host: service1.ns.svc.mydomain
         port:
           number: 4206
-      weight: 100
-  - match:
-    - uri:
-        exact: /sub/path/
-    route:
-    - destination:
-        host: service1.ns.svc.mydomain
-        port:
-          number: 4207
       weight: 100
   - match:
     - uri:
@@ -116,5 +80,41 @@ spec:
         host: service1.ns.svc.mydomain
         port:
           number: 4209
+      weight: 100
+  - match:
+    - uri:
+        exact: /regex2*
+    route:
+    - destination:
+        host: service1.ns.svc.mydomain
+        port:
+          number: 4204
+      weight: 100
+  - match:
+    - uri:
+        prefix: /regex1
+    route:
+    - destination:
+        host: service1.ns.svc.mydomain
+        port:
+          number: 4203
+      weight: 100
+  - match:
+    - uri:
+        prefix: /regex3
+    route:
+    - destination:
+        host: service1.ns.svc.mydomain
+        port:
+          number: 4205
+      weight: 100
+  - match:
+    - uri:
+        exact: /path
+    route:
+    - destination:
+        host: service1.ns.svc.mydomain
+        port:
+          number: 4200
       weight: 100
 ---

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -338,6 +338,10 @@ var (
 		return durationpb.New(defaultRequestTimeoutVar.Get())
 	}()
 
+	LegacyIngressBehavior = env.RegisterBoolVar("PILOT_LEGACY_INGRESS_BEHAVIOR", false,
+		"If this is set to true, istio ingress will perform the legacy behavior, "+
+			"which does not meet https://kubernetes.io/docs/concepts/services-networking/ingress/#multiple-matches.").Get()
+
 	EnableGatewayAPI = env.RegisterBoolVar("PILOT_ENABLE_GATEWAY_API", true,
 		"If this is set to true, support for Kubernetes gateway-api (github.com/kubernetes-sigs/gateway-api) will "+
 			" be enabled. In addition to this being enabled, the gateway-api CRDs need to be installed.").Get()

--- a/releasenotes/notes/ingress-routes.yaml
+++ b/releasenotes/notes/ingress-routes.yaml
@@ -1,0 +1,12 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+- https://github.com/istio/istio/issues/35033
+releaseNotes:
+- |
+  **Fixed** an issue where the route precedence logic of istio ingress is different from kubernetes ingress doc.
+- |
+  **Added** a feature flag `PILOT_LEGACY_INGRESS_BEHAVIOR`, default to false.
+  If this is set to true, istio ingress will perform the legacy behavior, 
+  which does not meet https://kubernetes.io/docs/concepts/services-networking/ingress/#multiple-matches.


### PR DESCRIPTION
**Please provide a description of this PR:**
Sort generated vs routes to meet ingress route precedence requirements, please refer to https://kubernetes.io/docs/concepts/services-networking/ingress/#multiple-matches

> In some cases, multiple paths within an Ingress will match a request. In those cases **precedence will be given first to the longest matching path. If two paths are still equally matched, precedence will be given to paths with an exact path type over prefix path type.**



Fixes #35033