### PR TITLE
PodCache donot lock workloadInstanceHandlers, it could do time costing work

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/pod.go
+++ b/pilot/pkg/serviceregistry/kube/controller/pod.go
@@ -113,9 +113,6 @@ func GetPodConditionFromList(conditions []v1.PodCondition, conditionType v1.PodC
 
 // onEvent updates the IP-based index (pc.podsByIP).
 func (pc *PodCache) onEvent(curr interface{}, ev model.Event) error {
-	pc.Lock()
-	defer pc.Unlock()
-
 	// When a pod is deleted obj could be an *v1.Pod or a DeletionFinalStateUnknown marker item.
 	pod, ok := curr.(*v1.Pod)
 	if !ok {
@@ -130,57 +127,60 @@ func (pc *PodCache) onEvent(curr interface{}, ev model.Event) error {
 	}
 
 	ip := pod.Status.PodIP
-
 	// PodIP will be empty when pod is just created, but before the IP is assigned
 	// via UpdateStatus.
-	if len(ip) > 0 {
-		key := kube.KeyFunc(pod.Name, pod.Namespace)
-		switch ev {
-		case model.EventAdd:
-			// can happen when istiod just starts
-			if pod.DeletionTimestamp != nil || !IsPodReady(pod) {
-				return nil
-			} else if shouldPodBeInEndpoints(pod) {
-				if key != pc.podsByIP[ip] {
-					pc.update(ip, key)
-				}
-			} else {
-				return nil
-			}
-		case model.EventUpdate:
-			if pod.DeletionTimestamp != nil || !IsPodReady(pod) {
-				// delete only if this pod was in the cache
-				if pc.podsByIP[ip] == key {
-					pc.deleteIP(ip)
-				}
-				ev = model.EventDelete
-			} else if shouldPodBeInEndpoints(pod) {
-				if key != pc.podsByIP[ip] {
-					pc.update(ip, key)
-				}
-			} else {
-				return nil
-			}
-		case model.EventDelete:
-			// delete only if this pod was in the cache
-			if pc.podsByIP[ip] == key {
-				pc.deleteIP(ip)
-			} else {
-				return nil
-			}
-		}
-		// fire instance handles for workload
-		ep := NewEndpointBuilder(pc.c, pod).buildIstioEndpoint(ip, 0, "", model.AlwaysDiscoverable)
-		workloadInstance := &model.WorkloadInstance{
-			Name:      pod.Name,
-			Namespace: pod.Namespace,
-			Kind:      model.PodKind,
-			Endpoint:  ep,
-			PortMap:   getPortMap(pod),
-		}
-		pc.c.handlers.NotifyWorkloadHandlers(workloadInstance, ev)
+	if len(ip) == 0 {
+		return nil
 	}
+
+	key := kube.KeyFunc(pod.Name, pod.Namespace)
+	switch ev {
+	case model.EventAdd:
+		// can happen when istiod just starts
+		if pod.DeletionTimestamp != nil || !IsPodReady(pod) {
+			return nil
+		} else if shouldPodBeInEndpoints(pod) {
+			if key != pc.podsByIP[ip] {
+				pc.update(ip, key)
+			}
+		} else {
+			return nil
+		}
+	case model.EventUpdate:
+		if pod.DeletionTimestamp != nil || !IsPodReady(pod) {
+			// delete only if this pod was in the cache
+			pc.deleteIP(ip, key)
+			ev = model.EventDelete
+		} else if shouldPodBeInEndpoints(pod) {
+			if key != pc.podsByIP[ip] {
+				pc.update(ip, key)
+			}
+		} else {
+			return nil
+		}
+	case model.EventDelete:
+		// delete only if this pod was in the cache,
+		// in most case it has already been deleted in `UPDATE` with `DeletionTimestamp` set.
+		if !pc.deleteIP(ip, key) {
+			return nil
+		}
+	}
+	pc.notifyWorkloadHandlers(pod, ev)
 	return nil
+}
+
+// notifyWorkloadHandlers fire workloadInstance handlers for pod
+func (pc *PodCache) notifyWorkloadHandlers(pod *v1.Pod, ev model.Event) {
+	// fire instance handles for workload
+	ep := NewEndpointBuilder(pc.c, pod).buildIstioEndpoint(pod.Status.PodIP, 0, "", model.AlwaysDiscoverable)
+	workloadInstance := &model.WorkloadInstance{
+		Name:      pod.Name,
+		Namespace: pod.Namespace,
+		Kind:      model.PodKind,
+		Endpoint:  ep,
+		PortMap:   getPortMap(pod),
+	}
+	pc.c.handlers.NotifyWorkloadHandlers(workloadInstance, ev)
 }
 
 func getPortMap(pod *v1.Pod) map[string]uint32 {
@@ -199,13 +199,20 @@ func getPortMap(pod *v1.Pod) map[string]uint32 {
 	return pmap
 }
 
-func (pc *PodCache) deleteIP(ip string) {
-	pod := pc.podsByIP[ip]
-	delete(pc.podsByIP, ip)
-	delete(pc.IPByPods, pod)
+// deleteIP returns true if the pod and ip are really deleted.
+func (pc *PodCache) deleteIP(ip string, podKey string) bool {
+	pc.Lock()
+	defer pc.Unlock()
+	if pc.podsByIP[ip] == podKey {
+		delete(pc.podsByIP, ip)
+		delete(pc.IPByPods, podKey)
+		return true
+	}
+	return false
 }
 
 func (pc *PodCache) update(ip, key string) {
+	pc.Lock()
 	if current, f := pc.IPByPods[key]; f {
 		// The pod already exists, but with another IP Address. We need to clean up that
 		delete(pc.podsByIP, current)
@@ -220,6 +227,7 @@ func (pc *PodCache) update(ip, key string) {
 		}
 		endpointsPendingPodUpdate.Record(float64(len(pc.needResync)))
 	}
+	pc.Unlock()
 
 	pc.proxyUpdates(ip)
 }


### PR DESCRIPTION
**Please provide a description of this PR:**


Reduce pod cache lock scope to not include `ServiceEntryStore.WorkloadInstanceHandler`


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [x] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
