### PR TITLE
JWKS: No longer print entire response body on error

### DIFF
--- a/common-protos/google/api/auth.proto
+++ b/common-protos/google/api/auth.proto
@@ -93,7 +93,6 @@ message AuthProvider {
   // URL of the provider's public key set to validate signature of the JWT. See
   // [OpenID
   // Discovery](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata).
-  // The key set may not exceed 1 MiB.
   // Optional if the key set document:
   //  - can be retrieved from
   //    [OpenID

--- a/common-protos/google/api/auth.proto
+++ b/common-protos/google/api/auth.proto
@@ -93,6 +93,7 @@ message AuthProvider {
   // URL of the provider's public key set to validate signature of the JWT. See
   // [OpenID
   // Discovery](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata).
+  // The key set may not exceed 1 MiB.
   // Optional if the key set document:
   //  - can be retrieved from
   //    [OpenID

--- a/pilot/pkg/model/jwks_resolver.go
+++ b/pilot/pkg/model/jwks_resolver.go
@@ -346,15 +346,9 @@ func (r *JwksResolver) getRemoteContentWithRetry(uri string, retry int) ([]byte,
 		}
 		defer resp.Body.Close()
 
-		// RFC7517 does not specify a maximum length, but unbounded input may lead to resource exhaustion.
-		const maxBytesToRead int64 = 1048577 // 1MiB + 1Byte
-		limitedBody := io.LimitReader(resp.Body, maxBytesToRead)
-		body, err := io.ReadAll(limitedBody)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, err
-		}
-		if int64(len(body)) == maxBytesToRead {
-			return nil, fmt.Errorf("status %d, response exceeded maximum length of %d", resp.StatusCode, maxBytesToRead-1)
 		}
 
 		if resp.StatusCode < 200 || resp.StatusCode >= 300 {

--- a/pilot/pkg/model/jwks_resolver.go
+++ b/pilot/pkg/model/jwks_resolver.go
@@ -346,7 +346,7 @@ func (r *JwksResolver) getRemoteContentWithRetry(uri string, retry int) ([]byte,
 		defer resp.Body.Close()
 
 		// RFC7517 does not specify a maximum length, but unbounded input may lead to resource exhaustion.
-		var max_bytes_to_read int64 = 1048577 // 2^20+1
+		const max_bytes_to_read int64 = 1048577 // 2^20+1
 		limitedBody := io.LimitReader(resp.Body, max_bytes_to_read)
 		body, err := io.ReadAll(limitedBody)
 		if err != nil {

--- a/pilot/pkg/model/jwks_resolver.go
+++ b/pilot/pkg/model/jwks_resolver.go
@@ -15,7 +15,6 @@
 package model
 
 import (
-	"bytes"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
@@ -358,17 +357,11 @@ func (r *JwksResolver) getRemoteContentWithRetry(uri string, retry int) ([]byte,
 		}
 
 		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-			// Print up to 100 characters of the first line of the body.
-			limitedMessageReader := io.LimitReader(bytes.NewReader(body), 100)
-			limitedMessage, err := io.ReadAll(limitedMessageReader)
-			if err != nil {
-				return nil, err
+			message := strings.SplitN(string(body), "\n", 1)[0]
+			if len(message) > 100 {
+				message = message[:100]
 			}
-			oneLineMessage, err := bytes.NewBuffer(limitedMessage).ReadBytes('\n')
-			if err != nil {
-				return nil, err
-			}
-			return nil, fmt.Errorf("status %d, %s", resp.StatusCode, string(oneLineMessage))
+			return nil, fmt.Errorf("status %d, %s", resp.StatusCode, message)
 		}
 
 		return body, nil

--- a/pilot/pkg/model/jwks_resolver.go
+++ b/pilot/pkg/model/jwks_resolver.go
@@ -358,16 +358,17 @@ func (r *JwksResolver) getRemoteContentWithRetry(uri string, retry int) ([]byte,
 		}
 
 		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			// Print up to 100 characters of the first line of the body.
 			limitedMessageReader := io.LimitReader(bytes.NewReader(body), 100)
-			limitedBytesBody, err := io.ReadAll(limitedMessageReader)
+			limitedMessage, err := io.ReadAll(limitedMessageReader)
 			if err != nil {
 				return nil, err
 			}
-			firstLine, err := bytes.NewBuffer(limitedBytesBody).ReadBytes('\n')
+			oneLineMessage, err := bytes.NewBuffer(limitedMessage).ReadBytes('\n')
 			if err != nil {
 				return nil, err
 			}
-			return nil, fmt.Errorf("status %d, %s", resp.StatusCode, string(firstLine))
+			return nil, fmt.Errorf("status %d, %s", resp.StatusCode, string(oneLineMessage))
 		}
 
 		return body, nil

--- a/pilot/pkg/model/jwks_resolver.go
+++ b/pilot/pkg/model/jwks_resolver.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -357,11 +358,12 @@ func (r *JwksResolver) getRemoteContentWithRetry(uri string, retry int) ([]byte,
 		}
 
 		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-			message := strings.SplitN(string(body), "\n", 1)[0]
+			message := strconv.Quote(string(body))
 			if len(message) > 100 {
 				message = message[:100]
+				return nil, fmt.Errorf("status %d, message %s(truncated)", resp.StatusCode, message)
 			}
-			return nil, fmt.Errorf("status %d, %s", resp.StatusCode, message)
+			return nil, fmt.Errorf("status %d, message %s", resp.StatusCode, message)
 		}
 
 		return body, nil

--- a/pilot/pkg/model/jwks_resolver.go
+++ b/pilot/pkg/model/jwks_resolver.go
@@ -346,14 +346,14 @@ func (r *JwksResolver) getRemoteContentWithRetry(uri string, retry int) ([]byte,
 		defer resp.Body.Close()
 
 		// RFC7517 does not specify a maximum length, but unbounded input may lead to resource exhaustion.
-		const max_bytes_to_read int64 = 1048577 // 2^20+1
-		limitedBody := io.LimitReader(resp.Body, max_bytes_to_read)
+		const maxBytesToRead int64 = 1048577 // 1MiB + 1Byte
+		limitedBody := io.LimitReader(resp.Body, maxBytesToRead)
 		body, err := io.ReadAll(limitedBody)
 		if err != nil {
 			return nil, err
 		}
-		if int64(len(body)) == max_bytes_to_read {
-			return nil, fmt.Errorf("status %d, response exceeded maximum length of %d", resp.StatusCode, max_bytes_to_read-1)
+		if int64(len(body)) == maxBytesToRead {
+			return nil, fmt.Errorf("status %d, response exceeded maximum length of %d", resp.StatusCode, maxBytesToRead-1)
 		}
 
 		if resp.StatusCode < 200 || resp.StatusCode >= 300 {

--- a/releasenotes/notes/35723.yaml
+++ b/releasenotes/notes/35723.yaml
@@ -1,14 +1,8 @@
 apiVersion: release-notes/v2
-
-kind:
- - bug-fix
-
-area:
- - security
-
+kind: bug-fix
+area: security
 issue:
   - 35663
-
 releaseNotes:
 - |-
   **Added:** JWTRule: jwksUri rejects JWKS larger than 1MiB

--- a/releasenotes/notes/35723.yaml
+++ b/releasenotes/notes/35723.yaml
@@ -1,6 +1,6 @@
 apiVersion: release-notes/v2
 kind: bug-fix
-area: pilot
+area: telemetry
 issue:
   - 35663
 releaseNotes:

--- a/releasenotes/notes/35723.yaml
+++ b/releasenotes/notes/35723.yaml
@@ -1,0 +1,14 @@
+apiVersion: release-notes/v2
+
+kind:
+ - bug-fix
+
+area:
+ - security
+
+issue:
+  - 35663
+
+releaseNotes:
+- |-
+  **Added:** JWTRule: jwksUri rejects JWKS larger than 1MiB

--- a/releasenotes/notes/35723.yaml
+++ b/releasenotes/notes/35723.yaml
@@ -1,8 +1,8 @@
 apiVersion: release-notes/v2
 kind: bug-fix
-area: security
+area: pilot
 issue:
   - 35663
 releaseNotes:
 - |
-  **Added** JWTRule: jwksUri rejects JWKS larger than 1MiB
+  **Improved** Istiod JWTRule: Failed JWKS requests are now logged with truncation to 100 characters

--- a/releasenotes/notes/35723.yaml
+++ b/releasenotes/notes/35723.yaml
@@ -4,5 +4,5 @@ area: security
 issue:
   - 35663
 releaseNotes:
-- |-
-  **Added:** JWTRule: jwksUri rejects JWKS larger than 1MiB
+- |
+  **Added** JWTRule: jwksUri rejects JWKS larger than 1MiB


### PR DESCRIPTION
**Please provide a description of this PR:**
* Fixes #35663 
* Limits log output to 100 bytes of the first line of response body to reduce log verbosity.
* Refined take on https://github.com/istio/istio/pull/35723
