### PR TITLE
Recompute service account at endpoint shard when all endpoints are removed

### DIFF
--- a/pilot/pkg/xds/eds.go
+++ b/pilot/pkg/xds/eds.go
@@ -127,11 +127,11 @@ func (s *DiscoveryServer) EDSCacheUpdate(shard model.ShardKey, serviceName strin
 func (s *DiscoveryServer) edsCacheUpdate(shard model.ShardKey, hostname string, namespace string, istioEndpoints []*model.IstioEndpoint) bool {
 	if len(istioEndpoints) == 0 {
 		// Should delete the service EndpointShards when endpoints become zero to prevent memory leak,
-		// but we should not do not delete the keys from EndpointShardsByService map - that will trigger
+		// but we should not delete the keys from EndpointShardsByService map - that will trigger
 		// unnecessary full push which can become a real problem if a pod is in crashloop and thus endpoints
 		// flip flopping between 1 and 0.
 		s.deleteEndpointShards(shard, hostname, namespace)
-		log.Infof("Incremental push, service %s has no endpoints", hostname)
+		log.Infof("Incremental push, service %s at shard %v has no endpoints", hostname, shard)
 		return false
 	}
 
@@ -216,6 +216,14 @@ func (s *DiscoveryServer) deleteEndpointShards(shard model.ShardKey, serviceName
 		epShards := s.EndpointShardsByService[serviceName][namespace]
 		epShards.mutex.Lock()
 		delete(epShards.Shards, shard)
+		epShards.ServiceAccounts = sets.Set{}
+		for _, shard := range epShards.Shards {
+			for _, ep := range shard {
+				if ep.ServiceAccount != "" {
+					epShards.ServiceAccounts.Insert(ep.ServiceAccount)
+				}
+			}
+		}
 		// Clear the cache here to avoid race in cache writes (see edsCacheUpdate for details).
 		s.Cache.Clear(map[model.ConfigKey]struct{}{{
 			Kind:      gvk.ServiceEntry,

--- a/releasenotes/notes/36465.yaml
+++ b/releasenotes/notes/36465.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - https://github.com/istio/istio/issues/36456
+releaseNotes:
+  - |
+    **Fixed** an issue where scaling endpoint for a service from 0 to 1
+    might cause client side serivce account verification populated incorrectly.


### PR DESCRIPTION
fix https://github.com/istio/istio/issues/36465 and https://github.com/istio/istio/issues/31534.

The sequence to trigger the issue:

1. Scale down a service's workloads to zero, either manually, or some upgrade or reschedule event. This will trigger an EDS push, which does not update Cluster / push CDS.
2. Update any istio config or any service, which will trigger a Cluster update and CDS push for all services (Note CDS cache is invalidated at step 1, which means Cluster for this service will be recomputed), and for this service, since there is no endpoint, the default validation context / SAN match will be empty `"default_validation_context": {}`.
3. Now scale up the workloads, this will trigger another EDS push, and we have the logic to check if the service accounts have any update (https://github.com/istio/istio/blob/4dea7d99eba0ab42e84056d50e1a96151f301887/pilot/pkg/xds/eds.go#L150). if there is, a CDS update will also be triggered. However, whether the service account change is checked against the EndpointShards cache, which is not cleaned up when all endpoints get removed at step 1, so no CDS update will happen.
