### PR TITLE
auto set concurrency for gateways from cpu limit

### DIFF
--- a/manifests/charts/gateways/istio-egress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-egress/templates/deployment.yaml
@@ -286,6 +286,11 @@ spec:
             - path: "annotations"
               fieldRef:
                 fieldPath: metadata.annotations
+            - path: "cpu-limit"
+              resourceFieldRef:
+                containerName: istio-proxy
+                resource: limits.cpu
+                divisor: 1m
       - name: istio-envoy
         emptyDir: {}
       - name: istio-data

--- a/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
@@ -286,6 +286,11 @@ spec:
             - path: "annotations"
               fieldRef:
                 fieldPath: metadata.annotations
+            - path: "cpu-limit"
+              resourceFieldRef:
+                containerName: istio-proxy
+                resource: limits.cpu
+                divisor: 1m
       - name: istio-envoy
         emptyDir: {}
       - name: istio-data

--- a/pilot/cmd/pilot-agent/config/config.go
+++ b/pilot/cmd/pilot-agent/config/config.go
@@ -16,7 +16,6 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
 	"math"
 	"os"
 	"strconv"
@@ -63,7 +62,7 @@ func ConstructProxyConfig(meshConfigFile, serviceCluster, proxyConfigEnv string,
 	}
 
 	if concurrency == 0 && role.Type == model.Router {
-		// If --concurrency is unset and not override in env & annotations, we will automatically set this
+		// If --concurrency is unset and not override in file, env, or annotations, we will automatically set this
 		// based on CPU limits.
 		if proxyConfig.Concurrency == nil {
 			byResources := determineConcurrencyOption()
@@ -164,7 +163,7 @@ func fileExists(path string) bool {
 }
 
 func readPodCPULimits() (int, error) {
-	b, err := ioutil.ReadFile(constants.PodInfoCPULimitsPath)
+	b, err := os.ReadFile(constants.PodInfoCPULimitsPath)
 	if err != nil {
 		return 0, err
 	}

--- a/pilot/cmd/pilot-agent/config/config.go
+++ b/pilot/cmd/pilot-agent/config/config.go
@@ -65,7 +65,7 @@ func ConstructProxyConfig(meshConfigFile, serviceCluster, proxyConfigEnv string,
 	if concurrency == 0 && role.Type == model.Router {
 		// If --concurrency is unset and not override in env & annotations, we will automatically set this
 		// based on CPU limits.
-		if proxyConfig.Concurrency.GetValue() == 0 {
+		if proxyConfig.Concurrency == nil {
 			byResources := determineConcurrencyOption()
 			if byResources != nil {
 				proxyConfig.Concurrency = byResources

--- a/pilot/cmd/pilot-agent/config/config.go
+++ b/pilot/cmd/pilot-agent/config/config.go
@@ -97,7 +97,7 @@ func ConstructProxyConfig(meshConfigFile, serviceCluster, proxyConfigEnv string,
 }
 
 // determineConcurrencyOption determines the correct setting for --concurrency based on CPU limits
-func determineConcurrencyOption() *types.Int32Value {
+func determineConcurrencyOption() *wrapperspb.Int32Value {
 	// If limit is set, us that
 	// The format in the file is a plain integer. `100` in the file is equal to `100m` (based on `divisor: 1m`
 	// in the pod spec).
@@ -105,7 +105,7 @@ func determineConcurrencyOption() *types.Int32Value {
 	// the pod will get concurrency=1. With 6500m, it will get concurrency=7.
 	limit, err := readPodCPULimits()
 	if err == nil && limit > 0 {
-		return &types.Int32Value{Value: int32(math.Ceil(float64(limit) / 1000))}
+		return &wrapperspb.Int32Value{Value: int32(math.Ceil(float64(limit) / 1000))}
 	}
 	return nil
 }

--- a/pilot/cmd/pilot-agent/config/config_test.go
+++ b/pilot/cmd/pilot-agent/config/config_test.go
@@ -160,7 +160,12 @@ func TestConstructProxyConfig_Concurrency(t *testing.T) {
 			expect:    mesh.DefaultProxyConfig().Concurrency.GetValue(),
 		},
 		{
-			name:     "CPU limit unset",
+			name: "CPU limit unset",
+			file: `
+defaultConfig:
+  proxyMetadata:
+  SOME: setting
+`,
 			cpuLimit: 0,
 			expect:   0, // 0 means "all" cores on host
 		},
@@ -196,7 +201,7 @@ defaultConfig:
 			expect:   6,
 		},
 		{
-			name: "Override in file",
+			name: "Override in file (zero)",
 			file: `
 defaultConfig:
   concurrency: 0
@@ -211,7 +216,7 @@ defaultConfig:
 			expect:    5,
 		},
 		{
-			name:      "Override in environment variable",
+			name:      "Override in environment variable (zero)",
 			configEnv: `concurrency: 0`,
 			cpuLimit:  4000,
 			expect:    0,
@@ -223,7 +228,7 @@ defaultConfig:
 			expect:      5,
 		},
 		{
-			name:        "Override in annotation",
+			name:        "Override in annotation (zero)",
 			annotations: `proxy.istio.io/config="concurrency: 0"`,
 			cpuLimit:    4000,
 			expect:      0,
@@ -305,7 +310,7 @@ defaultConfig:
 				t.Fatal(err)
 			}
 			concurrency := got.Concurrency.GetValue()
-			if !cmp.DeepEqual(concurrency, tt.expect) {
+			if !cmp.Equal(concurrency, tt.expect) {
 				t.Fatalf("got %v, expected %v", concurrency, tt.expect)
 			}
 		})

--- a/pilot/cmd/pilot-agent/config/config_test.go
+++ b/pilot/cmd/pilot-agent/config/config_test.go
@@ -259,33 +259,33 @@ defaultConfig:
 	writeTestData := func(t *testing.T, file string, annotations string, limit int) {
 		// Setup mesh
 		if file != "" {
-			err := os.MkdirAll(filepath.Dir(meshConfigFile), 0777)
+			err := os.MkdirAll(filepath.Dir(meshConfigFile), 0o777)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			err = os.WriteFile(meshConfigFile, []byte(file), 0666)
+			err = os.WriteFile(meshConfigFile, []byte(file), 0o666)
 			if err != nil {
 				t.Fatal(err)
 			}
 		}
 
 		// Setup pod annotations (simulate downward)
-		err := os.MkdirAll(filepath.Dir(constants.PodInfoAnnotationsPath), 0777)
+		err := os.MkdirAll(filepath.Dir(constants.PodInfoAnnotationsPath), 0o777)
 		if err != nil {
 			t.Fatal(err)
 		}
-		err = os.WriteFile(constants.PodInfoAnnotationsPath, []byte(annotations), 0666)
+		err = os.WriteFile(constants.PodInfoAnnotationsPath, []byte(annotations), 0o666)
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		// Setup pod cpu limit (simulate downward)
-		err = os.MkdirAll(filepath.Dir(constants.PodInfoCPULimitsPath), 0777)
+		err = os.MkdirAll(filepath.Dir(constants.PodInfoCPULimitsPath), 0o777)
 		if err != nil {
 			t.Fatal(err)
 		}
-		err = os.WriteFile(constants.PodInfoCPULimitsPath, []byte(strconv.Itoa(limit)), 0666)
+		err = os.WriteFile(constants.PodInfoCPULimitsPath, []byte(strconv.Itoa(limit)), 0o666)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/config/constants/constants.go
+++ b/pkg/config/constants/constants.go
@@ -96,6 +96,10 @@ const (
 	// This is typically set by the downward API
 	PodInfoAnnotationsPath = "./etc/istio/pod/annotations"
 
+	// PodInfoCPULimitsPath is the filepath that pod CPU limits will be stored
+	// This is typically set by the downward API
+	PodInfoCPULimitsPath = "./etc/istio/pod/cpu-limit"
+
 	// DefaultServiceAccountName is the default service account to use for remote cluster access.
 	DefaultServiceAccountName = "istio-reader-service-account"
 

--- a/releasenotes/notes/36884.yaml
+++ b/releasenotes/notes/36884.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+
+releaseNotes:
+  - |
+    **Updated** Previously, by default all cores on the machine will be used for gateways. Now the gateway uses max
+    available cores from cpu limit if not override in proxy config, environment variable, or pod annotation.


### PR DESCRIPTION
**Please provide a description of this PR:**

Currently, the gateway uses all hosts cpu, however, when CPU limit is set, and when during load the gateway gives us poor performance (high latency) due to CFS aggresive throttling.

This proposal uses cpu limit when concurrency is not set, which should mitigate this problem