### PR TITLE
fix: when service entry's host has tailing period, smart dns can not resolve it

### DIFF
--- a/pkg/dns/client/dns.go
+++ b/pkg/dns/client/dns.go
@@ -196,7 +196,10 @@ func (h *LocalDNSServer) UpdateLookupTable(nt *dnsProto.NameTable) {
 		if ni.Registry == string(provider.Kubernetes) {
 			altHosts = generateAltHosts(hostname, ni, h.proxyNamespace, h.proxyDomain, h.proxyDomainParts)
 		} else {
-			altHosts = map[string]struct{}{hostname + ".": {}}
+			if !strings.HasSuffix(hostname, ".") {
+				hostname = hostname + "."
+			}
+			altHosts = map[string]struct{}{hostname: {}}
 		}
 		ipv4, ipv6 := separateIPtypes(ni.Ips)
 		if len(ipv6) == 0 && len(ipv4) == 0 {

--- a/pkg/dns/client/dns.go
+++ b/pkg/dns/client/dns.go
@@ -197,7 +197,7 @@ func (h *LocalDNSServer) UpdateLookupTable(nt *dnsProto.NameTable) {
 			altHosts = generateAltHosts(hostname, ni, h.proxyNamespace, h.proxyDomain, h.proxyDomainParts)
 		} else {
 			if !strings.HasSuffix(hostname, ".") {
-				hostname = hostname + "."
+				hostname += "."
 			}
 			altHosts = map[string]struct{}{hostname: {}}
 		}

--- a/pkg/dns/client/dns_test.go
+++ b/pkg/dns/client/dns_test.go
@@ -222,7 +222,6 @@ func TestDNS(t *testing.T) {
 			host:     "example.localhost.",
 			expected: a("example.localhost.", []net.IP{net.ParseIP("3.3.3.3").To4()}),
 		},
-
 	}
 
 	clients := []dns.Client{

--- a/pkg/dns/client/dns_test.go
+++ b/pkg/dns/client/dns_test.go
@@ -217,6 +217,12 @@ func TestDNS(t *testing.T) {
 			expectResolutionFailure: dns.RcodeSuccess,
 			expected:                giantResponse[:29],
 		},
+		{
+			name:     "success: hostname with a period",
+			host:     "example.localhost.",
+			expected: a("example.localhost.", []net.IP{net.ParseIP("3.3.3.3").To4()}),
+		},
+
 	}
 
 	clients := []dns.Client{
@@ -512,6 +518,10 @@ func initDNS(t test.Failer) *LocalDNSServer {
 			},
 			"*.wildcard": {
 				Ips:      []string{"10.10.10.10"},
+				Registry: "External",
+			},
+			"example.localhost.": {
+				Ips:      []string{"3.3.3.3"},
 				Registry: "External",
 			},
 		},


### PR DESCRIPTION
**Please provide a description of this PR:**

If the hostname ends with a period, agent not append a period.
Fixes #36885 