### PR TITLE
gateway chart: support envoy's bootstrap configuration override

### DIFF
--- a/manifests/charts/gateway/templates/configmap.yaml
+++ b/manifests/charts/gateway/templates/configmap.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.customBootstrap }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "gateway.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "gateway.labels" . | nindent 4 }}
+data:
+  {{- with .Values.customBootstrap }}
+  custom_bootstrap.json: |-
+    {{- . | mustToPrettyJson | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/manifests/charts/gateway/templates/deployment.yaml
+++ b/manifests/charts/gateway/templates/deployment.yaml
@@ -19,6 +19,7 @@ spec:
       {{- with .Values.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") $ | sha256sum }}
       {{- end }}
       labels:
         sidecar.istio.io/inject: "true"
@@ -75,6 +76,10 @@ spec:
           - name: ISTIO_META_REQUESTED_NETWORK_VIEW
             value: "{{.}}"
           {{- end }}
+          {{- if .Values.customBootstrap }}
+          - name: ISTIO_BOOTSTRAP_OVERRIDE
+            value: /etc/istio/custom-bootstrap
+          {{- end }}
           {{- range $key, $val := .Values.env }}
           - name: {{ $key }}
             value: {{ $val }}
@@ -85,6 +90,13 @@ spec:
             name: http-envoy-prom
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            {{- if .Values.customBootstrap }}
+            - name: custom-bootstrap
+              mountPath: /etc/istio/custom-bootstrap
+              subPath: custom_bootstrap.json
+              readOnly: true
+            {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -96,4 +108,15 @@ spec:
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+      {{- if .Values.customBootstrap }}
+      - name: custom-bootstrap
+        configMap:
+          name: {{ include "gateway.name" . }}
+          items:
+          - key: custom_bootstrap.json
+            path: custom_bootstrap.json
+          defaultMode: 420
+          optional: false
       {{- end }}

--- a/manifests/charts/gateway/values.schema.json
+++ b/manifests/charts/gateway/values.schema.json
@@ -174,6 +174,9 @@
     },
     "networkGateway": {
       "type": "string"
+    },
+    "customBootstrap": {
+      "type": ["object", "null"]
     }
   }
 }

--- a/manifests/charts/gateway/values.yaml
+++ b/manifests/charts/gateway/values.yaml
@@ -84,3 +84,13 @@ affinity: {}
 
 # If specified, the gateway will act as a network gateway for the given network.
 networkGateway: ""
+
+# Override Envoy's bootstrap configuration
+# reference: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/bootstrap/v3/bootstrap.proto
+customBootstrap: {}
+# customBootstrap: # example (Runtime configuration override)
+#   layered_runtime:
+#     layers:
+#     - name: custom-static-layer-helm
+#       static_layer:
+#         envoy.reloadable_features.experimental_matching_api: true


### PR DESCRIPTION
I implemented gateway's HelmChart mostly about this article:
https://medium.com/@nizam./envoy-layered-runtime-configuration-override-ac3499f82f6f

After this change, we can configure additonal bootstrap configuration of EnvoyProxy.
In order to override admin setting, runtime configuration, and so on.