### PR TITLE
gateway: expose mechanism to use spiffe workload cert at gateway

### DIFF
--- a/pilot/pkg/model/credentials/resource.go
+++ b/pilot/pkg/model/credentials/resource.go
@@ -30,6 +30,9 @@ const (
 	// take the form kubernetes-gateway://namespace/name. They are pulled from the config cluster.
 	KubernetesGatewaySecretType    = "kubernetes-gateway"
 	kubernetesGatewaySecretTypeURI = KubernetesGatewaySecretType + "://"
+	// BuiltinGatewaySecretType is the name of a SDS secret that uses the workloads own mTLS certificate
+	BuiltinGatewaySecretType    = "builtin"
+	BuiltinGatewaySecretTypeURI = BuiltinGatewaySecretType + "://"
 )
 
 // SecretResource defines a reference to a secret
@@ -52,11 +55,17 @@ func (sr SecretResource) Key() string {
 }
 
 func ToKubernetesGatewayResource(namespace, name string) string {
+	if strings.HasPrefix(name, BuiltinGatewaySecretTypeURI) {
+		return BuiltinGatewaySecretTypeURI
+	}
 	return fmt.Sprintf("%s://%s/%s", KubernetesGatewaySecretType, namespace, name)
 }
 
 // ToResourceName turns a `credentialName` into a resource name used for SDS
 func ToResourceName(name string) string {
+	if strings.HasPrefix(name, BuiltinGatewaySecretTypeURI) {
+		return "default"
+	}
 	// If they explicitly defined the type, keep it
 	if strings.HasPrefix(name, kubernetesSecretTypeURI) || strings.HasPrefix(name, kubernetesGatewaySecretTypeURI) {
 		return name

--- a/pilot/pkg/model/credentials/resource_test.go
+++ b/pilot/pkg/model/credentials/resource_test.go
@@ -105,3 +105,42 @@ func TestParseResourceName(t *testing.T) {
 		})
 	}
 }
+
+func TestToResourceName(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+	}{
+		{"foo", "kubernetes://foo"},
+		{"kubernetes://bar", "kubernetes://bar"},
+		{"kubernetes-gateway://bar", "kubernetes-gateway://bar"},
+		{"builtin://", "default"},
+		{"builtin://extra", "default"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ToResourceName(tt.name); got != tt.want {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestToKubernetesGatewayResource(t *testing.T) {
+	tests := []struct {
+		name      string
+		namespace string
+		want      string
+	}{
+		{"foo", "ns", "kubernetes-gateway://ns/foo"},
+		{"builtin://", "anything", "builtin://"},
+		{"builtin://extra", "anything", "builtin://"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ToKubernetesGatewayResource(tt.namespace, tt.name); got != tt.want {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pilot/pkg/security/model/authentication.go
+++ b/pilot/pkg/security/model/authentication.go
@@ -80,6 +80,12 @@ func ConstructSdsSecretConfigForCredential(name string) *tls.SdsSecretConfig {
 	if name == "" {
 		return nil
 	}
+	if name == credentials.BuiltinGatewaySecretTypeURI {
+		return ConstructSdsSecretConfig(SDSDefaultResourceName)
+	}
+	if name == credentials.BuiltinGatewaySecretTypeURI+SdsCaSuffix {
+		return ConstructSdsSecretConfig(SDSRootResourceName)
+	}
 
 	return &tls.SdsSecretConfig{
 		Name:      credentials.ToResourceName(name),

--- a/pilot/pkg/xds/sds_test.go
+++ b/pilot/pkg/xds/sds_test.go
@@ -239,7 +239,7 @@ func TestGenerate(t *testing.T) {
 			// If an unknown resource is request, we return all the ones we do know about
 			name:      "unknown",
 			proxy:     &model.Proxy{VerifiedIdentity: &spiffe.Identity{Namespace: "istio-system"}, Type: model.Router},
-			resources: []string{"kubernetes://generic", "foo://invalid", "kubernetes://not-found"},
+			resources: []string{"kubernetes://generic", "foo://invalid", "kubernetes://not-found", "default", "builtin://"},
 			request:   &model.PushRequest{Full: true},
 			expect: map[string]Expected{
 				"kubernetes://generic": {


### PR DESCRIPTION
There are various times when users need to deploy TLS on a workload, but
doesn't care at all what certificate is used. One example could be
istio.io docs, but that is a minor case. The more important is things
like
https://aws.amazon.com/blogs/containers/secure-end-to-end-traffic-on-amazon-eks-using-tls-certificate-in-acm-alb-and-istio/.

Folks will run `client ---TLS---> Cloud LB (terminate) --TLS---> Istio
Ingress (terminate) ---> backend`.

The connection between cloud LB and Istio Ingress doesn't do any
verification, which leads to using self signed certs. While there is
technically nothing wrong with this, it adds extra steps and draws
scrutiny from security-conscious users.

As a step to make this easier, we can allow using the workloads mTLS
certs. This works in `MUTUAL` and `SIMPLE` cases.

Opening to get feedback, will add tests if there is agreement. @ramaraochavali @hzxuzhonghu 
