### PR TITLE
Use leases lock for istio operator's resourcelock

### DIFF
--- a/operator/cmd/operator/server.go
+++ b/operator/cmd/operator/server.go
@@ -24,10 +24,10 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/spf13/cobra"
 	"go.opencensus.io/stats/view"
-	"k8s.io/client-go/tools/leaderelection/resourcelock"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"

--- a/operator/cmd/operator/server.go
+++ b/operator/cmd/operator/server.go
@@ -24,6 +24,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/spf13/cobra"
 	"go.opencensus.io/stats/view"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -151,24 +152,26 @@ func run(sArgs *serverArgs) {
 	if len(watchNamespaces) > 0 {
 		// Create MultiNamespacedCache with watched namespaces if it's not empty.
 		mgrOpt = manager.Options{
-			NewCache:                cache.MultiNamespacedCacheBuilder(watchNamespaces),
-			MetricsBindAddress:      fmt.Sprintf("%s:%d", metricsHost, metricsPort),
-			LeaderElection:          leaderElectionEnabled,
-			LeaderElectionNamespace: leaderElectionNS,
-			LeaderElectionID:        leaderElectionID,
-			LeaseDuration:           &leaseDuration,
-			RenewDeadline:           renewDeadline,
+			NewCache:                   cache.MultiNamespacedCacheBuilder(watchNamespaces),
+			MetricsBindAddress:         fmt.Sprintf("%s:%d", metricsHost, metricsPort),
+			LeaderElection:             leaderElectionEnabled,
+			LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
+			LeaderElectionNamespace:    leaderElectionNS,
+			LeaderElectionID:           leaderElectionID,
+			LeaseDuration:              &leaseDuration,
+			RenewDeadline:              renewDeadline,
 		}
 	} else {
 		// Create manager option for watching all namespaces.
 		mgrOpt = manager.Options{
-			Namespace:               "",
-			MetricsBindAddress:      fmt.Sprintf("%s:%d", metricsHost, metricsPort),
-			LeaderElection:          leaderElectionEnabled,
-			LeaderElectionNamespace: leaderElectionNS,
-			LeaderElectionID:        leaderElectionID,
-			LeaseDuration:           &leaseDuration,
-			RenewDeadline:           renewDeadline,
+			Namespace:                  "",
+			MetricsBindAddress:         fmt.Sprintf("%s:%d", metricsHost, metricsPort),
+			LeaderElection:             leaderElectionEnabled,
+			LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
+			LeaderElectionNamespace:    leaderElectionNS,
+			LeaderElectionID:           leaderElectionID,
+			LeaseDuration:              &leaseDuration,
+			RenewDeadline:              renewDeadline,
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Tianpeng Wang <tpwang@alauda.io>

**Please provide a description of this PR:**

Since 1.9 (https://github.com/istio/istio/commit/8ed67b3c4f2ef6691d65925b7c999652e0d95df8), the default resource lock is `configmapsleases`, now we can use "leases" only, which performs better than `configmaps` (for legacy reasons)

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [X] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
