### PR TITLE
Add warning when file mounted certs are used at Gateway.

### DIFF
--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -574,12 +574,13 @@ func validateTLSOptions(tls *networking.ServerTLSSettings) (v Validation) {
 			}
 		}
 	}
+
 	if len(invalidCiphers) > 0 {
-		return WrapWarning(fmt.Errorf("ignoring invalid cipher suites: %v", invalidCiphers.SortedList()))
+		v = appendWarningf(v, "ignoring invalid cipher suites: %v", invalidCiphers.SortedList())
 	}
 
 	if len(duplicateCiphers) > 0 {
-		return WrapWarning(fmt.Errorf("ignoring duplicate cipher suites: %v", duplicateCiphers.SortedList()))
+		v = appendWarningf(v, "ignoring duplicate cipher suites: %v", duplicateCiphers.SortedList())
 	}
 
 	if tls.Mode == networking.ServerTLSSettings_ISTIO_MUTUAL {
@@ -596,6 +597,16 @@ func validateTLSOptions(tls *networking.ServerTLSSettings) (v Validation) {
 		}
 
 		return
+	}
+
+	if tls.ServerCertificate != "" {
+		v = appendWarningf(v, "Use of serverCertificate is not recommended. Prefer credentialName instead.")
+	}
+	if tls.PrivateKey != "" {
+		v = appendWarningf(v, "Use of privateKey is not recommended. Prefer credentialName instead.")
+	}
+	if tls.CaCertificates != "" {
+		v = appendWarningf(v, "Use of caCertificates is not recommended. Prefer credentialName instead.")
 	}
 
 	if (tls.Mode == networking.ServerTLSSettings_SIMPLE || tls.Mode == networking.ServerTLSSettings_MUTUAL) && tls.CredentialName != "" {

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -1175,7 +1175,7 @@ func TestValidateTlsOptions(t *testing.T) {
 				ServerCertificate: "Captain Jean-Luc Picard",
 				PrivateKey:        "Khan Noonien Singh",
 			},
-			"", "",
+			"", "Prefer credentialName instead",
 		},
 		{
 			"simple with client bundle",
@@ -1185,7 +1185,7 @@ func TestValidateTlsOptions(t *testing.T) {
 				PrivateKey:        "Khan Noonien Singh",
 				CaCertificates:    "Commander William T. Riker",
 			},
-			"", "",
+			"", "Prefer credentialName instead",
 		},
 		{
 			"simple sds with client bundle",
@@ -1196,7 +1196,7 @@ func TestValidateTlsOptions(t *testing.T) {
 				CaCertificates:    "Commander William T. Riker",
 				CredentialName:    "sds-name",
 			},
-			"", "",
+			"", "Prefer credentialName instead",
 		},
 		{
 			"simple no server cert",
@@ -1205,7 +1205,7 @@ func TestValidateTlsOptions(t *testing.T) {
 				ServerCertificate: "",
 				PrivateKey:        "Khan Noonien Singh",
 			},
-			"server certificate", "",
+			"server certificate", "Prefer credentialName instead",
 		},
 		{
 			"simple no private key",
@@ -1214,7 +1214,7 @@ func TestValidateTlsOptions(t *testing.T) {
 				ServerCertificate: "Captain Jean-Luc Picard",
 				PrivateKey:        "",
 			},
-			"private key", "",
+			"private key", "Prefer credentialName instead",
 		},
 		{
 			"simple sds no server cert",
@@ -1224,7 +1224,7 @@ func TestValidateTlsOptions(t *testing.T) {
 				PrivateKey:        "Khan Noonien Singh",
 				CredentialName:    "sds-name",
 			},
-			"", "",
+			"", "Prefer credentialName instead",
 		},
 		{
 			"simple sds no private key",
@@ -1234,7 +1234,7 @@ func TestValidateTlsOptions(t *testing.T) {
 				PrivateKey:        "",
 				CredentialName:    "sds-name",
 			},
-			"", "",
+			"", "Prefer credentialName instead",
 		},
 		{
 			"mutual",
@@ -1244,7 +1244,7 @@ func TestValidateTlsOptions(t *testing.T) {
 				PrivateKey:        "Khan Noonien Singh",
 				CaCertificates:    "Commander William T. Riker",
 			},
-			"", "",
+			"", "Prefer credentialName instead",
 		},
 		{
 			"mutual sds",
@@ -1255,7 +1255,7 @@ func TestValidateTlsOptions(t *testing.T) {
 				CaCertificates:    "Commander William T. Riker",
 				CredentialName:    "sds-name",
 			},
-			"", "",
+			"", "Prefer credentialName instead",
 		},
 		{
 			"mutual no server cert",
@@ -1265,7 +1265,7 @@ func TestValidateTlsOptions(t *testing.T) {
 				PrivateKey:        "Khan Noonien Singh",
 				CaCertificates:    "Commander William T. Riker",
 			},
-			"server certificate", "",
+			"server certificate", "Prefer credentialName instead",
 		},
 		{
 			"mutual sds no server cert",
@@ -1276,7 +1276,7 @@ func TestValidateTlsOptions(t *testing.T) {
 				CaCertificates:    "Commander William T. Riker",
 				CredentialName:    "sds-name",
 			},
-			"", "",
+			"", "Prefer credentialName instead",
 		},
 		{
 			"mutual no client CA bundle",
@@ -1286,7 +1286,7 @@ func TestValidateTlsOptions(t *testing.T) {
 				PrivateKey:        "Khan Noonien Singh",
 				CaCertificates:    "",
 			},
-			"client CA bundle", "",
+			"client CA bundle", "Prefer credentialName instead",
 		},
 		// this pair asserts we get errors about both client and server certs missing when in mutual mode
 		// and both are absent, but requires less rewriting of the testing harness than merging the cases
@@ -1401,6 +1401,14 @@ func TestValidateTlsOptions(t *testing.T) {
 				CipherSuites:   []string{"ECDHE-ECDSA-AES128-SHA", "ECDHE-ECDSA-AES128-SHA"},
 			},
 			"", "ECDHE-ECDSA-AES128-SHA",
+		},
+		{
+			"invalid cipher suites with invalid config",
+			&networking.ServerTLSSettings{
+				Mode:         networking.ServerTLSSettings_SIMPLE,
+				CipherSuites: []string{"not-a-cipher-suite"},
+			},
+			"requires a private key", "not-a-cipher-suite",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Using Secrets has been the recommended source of gateway credentials for
2+ years now. This introduces a warning when users use file mounted
certs, to suggest they instead use `credentialName`.

This is purely a warning. The file mounted certs will continue to work,
both now and in the future.

This also fixes a bug in the cipher validation. We exit early on warning, which means we may ignore errors later on.