### PR TITLE
validation: do not exit early on gateway TLS warnings

### DIFF
--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -574,12 +574,13 @@ func validateTLSOptions(tls *networking.ServerTLSSettings) (v Validation) {
 			}
 		}
 	}
+
 	if len(invalidCiphers) > 0 {
-		return WrapWarning(fmt.Errorf("ignoring invalid cipher suites: %v", invalidCiphers.SortedList()))
+		v = appendWarningf(v, "ignoring invalid cipher suites: %v", invalidCiphers.SortedList())
 	}
 
 	if len(duplicateCiphers) > 0 {
-		return WrapWarning(fmt.Errorf("ignoring duplicate cipher suites: %v", duplicateCiphers.SortedList()))
+		v = appendWarningf(v, "ignoring duplicate cipher suites: %v", duplicateCiphers.SortedList())
 	}
 
 	if tls.Mode == networking.ServerTLSSettings_ISTIO_MUTUAL {

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -1402,6 +1402,14 @@ func TestValidateTlsOptions(t *testing.T) {
 			},
 			"", "ECDHE-ECDSA-AES128-SHA",
 		},
+		{
+			"invalid cipher suites with invalid config",
+			&networking.ServerTLSSettings{
+				Mode:         networking.ServerTLSSettings_SIMPLE,
+				CipherSuites: []string{"not-a-cipher-suite"},
+			},
+			"requires a private key", "not-a-cipher-suite",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
This hides errors when we hit warnings - we should send both the errors
and warnings.
Broken out of https://github.com/istio/istio/pull/36933 to make it more backport-able