### PR TITLE
Fix usage of `ISTIO_MUTUAL` with `credentialName`.

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -527,6 +527,11 @@ var (
 		"If enabled, pilot will only send the delta configs as opposed to the state of the world on a "+
 			"Resource Request. This feature uses the delta xds api, but does not currently send the actual deltas.").Get()
 
+	EnableLegacyIstioMutualCredentialName = env.RegisterBoolVar("PILOT_ENABLE_LEGACY_ISTIO_MUTUAL_CREDENTIAL_NAME",
+		false,
+		"If enabled, Gateway's with ISTIO_MUTUAL mode and credentialName configured will use simple TLS. "+
+			"This is to retain legacy behavior only and not recommended for use beyond migration.").Get()
+
 	EnableLegacyAutoPassthrough = env.RegisterBoolVar(
 		"PILOT_ENABLE_LEGACY_AUTO_PASSTHROUGH",
 		false,

--- a/pilot/pkg/networking/core/v1alpha3/gateway_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway_test.go
@@ -116,6 +116,72 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 				RequireClientCertificate: proto.BoolTrue,
 			},
 		},
+		{
+			// regression test for having both fields set. This is rejected in validation.
+			name: "tls mode ISTIO_MUTUAL, with credentialName",
+			server: &networking.Server{
+				Hosts: []string{"httpbin.example.com"},
+				Tls: &networking.ServerTLSSettings{
+					Mode:           networking.ServerTLSSettings_ISTIO_MUTUAL,
+					CredentialName: "ignored",
+				},
+			},
+			result: &auth.DownstreamTlsContext{
+				CommonTlsContext: &auth.CommonTlsContext{
+					AlpnProtocols: util.ALPNHttp,
+					TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{
+						{
+							Name: "default",
+							SdsConfig: &core.ConfigSource{
+								InitialFetchTimeout: durationpb.New(time.Second * 0),
+								ResourceApiVersion:  core.ApiVersion_V3,
+								ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
+									ApiConfigSource: &core.ApiConfigSource{
+										ApiType:                   core.ApiConfigSource_GRPC,
+										SetNodeOnFirstMessageOnly: true,
+										TransportApiVersion:       core.ApiVersion_V3,
+										GrpcServices: []*core.GrpcService{
+											{
+												TargetSpecifier: &core.GrpcService_EnvoyGrpc_{
+													EnvoyGrpc: &core.GrpcService_EnvoyGrpc{ClusterName: model.SDSClusterName},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					ValidationContextType: &auth.CommonTlsContext_CombinedValidationContext{
+						CombinedValidationContext: &auth.CommonTlsContext_CombinedCertificateValidationContext{
+							DefaultValidationContext: &auth.CertificateValidationContext{},
+							ValidationContextSdsSecretConfig: &auth.SdsSecretConfig{
+								Name: "ROOTCA",
+								SdsConfig: &core.ConfigSource{
+									InitialFetchTimeout: durationpb.New(time.Second * 0),
+									ResourceApiVersion:  core.ApiVersion_V3,
+									ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
+										ApiConfigSource: &core.ApiConfigSource{
+											ApiType:                   core.ApiConfigSource_GRPC,
+											SetNodeOnFirstMessageOnly: true,
+											TransportApiVersion:       core.ApiVersion_V3,
+											GrpcServices: []*core.GrpcService{
+												{
+													TargetSpecifier: &core.GrpcService_EnvoyGrpc_{
+														EnvoyGrpc: &core.GrpcService_EnvoyGrpc{ClusterName: model.SDSClusterName},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				RequireClientCertificate: proto.BoolTrue,
+			},
+		},
 		{ // No credential name is specified, generate file paths for key/cert.
 			name: "no credential name no key no cert tls SIMPLE",
 			server: &networking.Server{

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -594,6 +594,14 @@ func validateTLSOptions(tls *networking.ServerTLSSettings) (v Validation) {
 		if tls.CaCertificates != "" {
 			v = appendValidation(v, fmt.Errorf("ISTIO_MUTUAL TLS cannot have associated CA bundle"))
 		}
+		if tls.CredentialName != "" {
+			if features.EnableLegacyIstioMutualCredentialName {
+				// Legacy mode enabled, just warn
+				v = appendWarningf(v, "ISTIO_MUTUAL TLS cannot have associated credentialName")
+			} else {
+				v = appendValidation(v, fmt.Errorf("ISTIO_MUTUAL TLS cannot have associated credentialName"))
+			}
+		}
 
 		return
 	}

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -1367,6 +1367,14 @@ func TestValidateTlsOptions(t *testing.T) {
 			"cannot have associated private key", "",
 		},
 		{
+			"istio_mutual with credential name",
+			&networking.ServerTLSSettings{
+				Mode:           networking.ServerTLSSettings_ISTIO_MUTUAL,
+				CredentialName: "some-cred",
+			},
+			"cannot have associated credentialName", "",
+		},
+		{
 			"invalid cipher suites",
 			&networking.ServerTLSSettings{
 				Mode:           networking.ServerTLSSettings_SIMPLE,

--- a/releasenotes/notes/istio-mutual-cred-name.yaml
+++ b/releasenotes/notes/istio-mutual-cred-name.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+releaseNotes:
+- |
+  **Fixed** an issue where using `ISTIO_MUTUAL` TLS mode in Gateways while also setting `credentialName` cause mutual TLS to not be configured.
+  This configuration is now rejected, as `ISTIO_MUTUAL` is intended to be used without `credentialName` set.
+  The old behavior can be retaind by configuring the `PILOT_ENABLE_LEGACY_ISTIO_MUTUAL_CREDENTIAL_NAME=true` environment variable in Istiod.


### PR DESCRIPTION
Currently, if a user sets both of these, there is no validation or
warning. What ends up happening is the `ISTIO_MUTUAL` part is completely
ignored, and you get one way TLS using the `credentialName` configs.

This is highly unexpected and may lead to misconfigurations where users
expect mTLS to be used/enforce, but it is not.

This modifies the behavior to reject this in validation, and if are both
somehow set then the ISTIO_MUTUAL has precedence. This mirrors the
behavior for file-mounted cert references in the original PR 2.5 years
ago:
https://github.com/istio/istio/commit/fd80f5d11d0ad527d0c3de73f06aa0c2d4501c8e#diff-1488ede8a94d615faf5bbbd17f81fdb16b0409a3cc21ae6525a91991e55df34fR381.

Because this represents a backwards incompatible change, and there are
known users with this configuration, an opt-out flag is added. This PR
will be backported with settings:

* master, 1.13 - new behavior by default
* 1.12, 1.11 - old behavior by default, but with a new warning

**Please provide a description of this PR:**