### PR TITLE
fix issue that is Helm chart creates invalid manifest when given boolean or numeric value for environment variables

### DIFF
--- a/manifests/charts/gateway/templates/deployment.yaml
+++ b/manifests/charts/gateway/templates/deployment.yaml
@@ -77,7 +77,7 @@ spec:
           {{- end }}
           {{- range $key, $val := .Values.env }}
           - name: {{ $key }}
-            value: {{ $val }}
+            value: {{ $val | quote }}
           {{- end }}
           ports:
           - containerPort: 15090

--- a/manifests/charts/gateways/istio-egress/templates/injected-deployment.yaml
+++ b/manifests/charts/gateways/istio-egress/templates/injected-deployment.yaml
@@ -99,7 +99,7 @@ spec:
           {{- end }}
           {{- range $key, $val := $gateway.env }}
           - name: {{ $key }}
-            value: {{ $val }}
+            value: {{ $val | quote }}
           {{- end }}
           volumeMounts:
           {{- range $gateway.secretVolumes }}

--- a/manifests/charts/gateways/istio-ingress/templates/injected-deployment.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/injected-deployment.yaml
@@ -99,7 +99,7 @@ spec:
           {{- end }}
           {{- range $key, $val := $gateway.env }}
           - name: {{ $key }}
-            value: {{ $val }}
+            value: {{ $val | quote }}
           {{- end }}
           volumeMounts:
           {{- range $gateway.secretVolumes }}

--- a/releasenotes/notes/36946.yaml
+++ b/releasenotes/notes/36946.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+issue:
+  - 36946
+releaseNotes:
+  - |
+    **FIXED** Helm chart creates invalid manifest when given boolean or numeric value for environment variables.

--- a/releasenotes/notes/36946.yaml
+++ b/releasenotes/notes/36946.yaml
@@ -5,4 +5,4 @@ issue:
   - 36946
 releaseNotes:
   - |
-    **FIXED** Helm chart creates invalid manifest when given boolean or numeric value for environment variables.
+    **Fixed** Helm chart generates invalid manifest when given boolean or numeric value for environment variables.


### PR DESCRIPTION
**Please provide a description of this PR:**

In Istio v1.12.2, Helm chart creates invalid manifest when given boolean or numeric value for environment variables.

procedure for reproducing
```sh
cat <<EOS | helm install new-gateway istio/gateway --version 1.12.2 --values -
env:
  MYENV: "true"
EOS
```

console output
```
Error: INSTALLATION FAILED: Deployment in version "v1" cannot be handled as a Deployment: v1.Deployment.Spec: v1.DeploymentSpec.Template: v1.PodTemplateSpec.Spec: v1.PodSpec.Containers: []v1.Container: v1.Container.Env: []v1.EnvVar: v1.EnvVar.Value: ReadString: expects " or n, but found t, error found in #10 byte of ...|,"value":true}],"ima|..., bigger context ...|":{"containers":[{"env":[{"name":"MYENV","value":true}],"image":"auto","name":"istio-proxy","ports":|...
```

part of generated invalid manifest
```yaml
kind: Deployment
spec:
  template:
    spec:
      containers:
        - name: istio-proxy
          env:
          - name: MYENV
            value: true # <- invalid
```

---

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [x] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
