### PR TITLE
minor refactor in ads

### DIFF
--- a/pilot/pkg/controller/workloadentry/workloadentry_controller.go
+++ b/pilot/pkg/controller/workloadentry/workloadentry_controller.go
@@ -263,6 +263,7 @@ func (c *Controller) RegisterWorkload(proxy *model.Proxy, conTime time.Time) err
 	if entryName == "" {
 		return nil
 	}
+	proxy.AutoregisteredWorkloadEntryName = entryName
 
 	c.mutex.Lock()
 	c.adsConnections[makeProxyKey(proxy)]++
@@ -324,7 +325,7 @@ func (c *Controller) QueueUnregisterWorkload(proxy *model.Proxy, origConnect tim
 		return
 	}
 	// check if the WE already exists, update the status
-	entryName := autoregisteredWorkloadEntryName(proxy)
+	entryName := proxy.AutoregisteredWorkloadEntryName
 	if entryName == "" {
 		return
 	}
@@ -412,7 +413,7 @@ func (c *Controller) QueueWorkloadEntryHealth(proxy *model.Proxy, event HealthEv
 	// we assume that the workload entry exists
 	// if auto registration does not exist, try looking
 	// up in NodeMetadata
-	entryName := autoregisteredWorkloadEntryName(proxy)
+	entryName := proxy.AutoregisteredWorkloadEntryName
 	if entryName == "" {
 		log.Errorf("unable to derive WorkloadEntry for health update for %v", proxy.ID)
 		return

--- a/pilot/pkg/controller/workloadentry/workloadentry_controller_test.go
+++ b/pilot/pkg/controller/workloadentry/workloadentry_controller_test.go
@@ -424,7 +424,7 @@ func checkEntryOrFail(
 }
 
 func checkEntryHealth(store model.ConfigStoreCache, proxy *model.Proxy, healthy bool) (err error) {
-	name := autoregisteredWorkloadEntryName(proxy)
+	name := proxy.AutoregisteredWorkloadEntryName
 	cfg := store.Get(gvk.WorkloadEntry, name, proxy.Metadata.Namespace)
 	if cfg == nil || cfg.Status == nil {
 		err = multierror.Append(fmt.Errorf("expected workloadEntry %s/%s to exist", name, proxy.Metadata.Namespace))

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -307,6 +307,8 @@ type Proxy struct {
 	XdsNode *core.Node
 
 	CatchAllVirtualHost *route.VirtualHost
+
+	AutoregisteredWorkloadEntryName string
 }
 
 // WatchedResource tracks an active DiscoveryRequest subscription.

--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -121,6 +121,10 @@ type Event struct {
 	done func()
 }
 
+func (c *Connection) IsDelta() bool {
+	return c.deltaStream != nil
+}
+
 func newConnection(peerAddr string, stream DiscoveryStream) *Connection {
 	return &Connection{
 		pushChannel:   make(chan *Event),
@@ -189,7 +193,7 @@ func (s *DiscoveryServer) receive(con *Connection, identities []string) {
 	}
 }
 
-// processRequest is handling one request. This is currently called from the 'main' thread, which also
+// processRequest handles one discovery request. This is currently called from the 'main' thread, which also
 // handles 'push' requests and close - the code will eventually call the 'push' code, and it needs more mutex
 // protection. Original code avoided the mutexes by doing both 'push' and 'process requests' in same thread.
 func (s *DiscoveryServer) processRequest(req *discovery.DiscoveryRequest, con *Connection) error {
@@ -699,38 +703,47 @@ func (s *DiscoveryServer) pushConnection(con *Connection, pushEv *Event) error {
 	// Send pushes to all generators
 	// Each Generator is responsible for determining if the push event requires a push
 	for _, w := range orderWatchedResources(con.proxy.WatchedResources) {
+		shouldPush := false
 		if !features.EnableFlowControl {
 			// Always send the push if flow control disabled
-			if err := s.pushXds(con, pushRequest.Push, w, pushRequest); err != nil {
-				return err
-			}
-			continue
-		}
-		// If flow control is enabled, we will only push if we got an ACK for the previous response
-		synced, timeout := con.Synced(w.TypeUrl)
-		if !synced && timeout {
-			// We are not synced, but we have been stuck for too long. We will trigger the push anyways to
-			// avoid any scenario where this may deadlock.
-			// This can possibly be removed in the future if we find this never causes issues
-			totalDelayedPushes.With(typeTag.Value(v3.GetMetricType(w.TypeUrl))).Increment()
-			log.Warnf("%s: QUEUE TIMEOUT for node:%s", v3.GetShortType(w.TypeUrl), con.proxy.ID)
-		}
-		if synced || timeout {
-			// Send the push now
-			if err := s.pushXds(con, pushRequest.Push, w, pushRequest); err != nil {
-				return err
-			}
+			shouldPush = true
 		} else {
-			// The type is not yet synced. Instead of pushing now, which may overload Envoy,
-			// we will wait until the last push is ACKed and trigger the push. See
-			// https://github.com/istio/istio/issues/25685 for details on the performance
-			// impact of sending pushes before Envoy ACKs.
-			totalDelayedPushes.With(typeTag.Value(v3.GetMetricType(w.TypeUrl))).Increment()
-			log.Debugf("%s: QUEUE for node:%s", v3.GetShortType(w.TypeUrl), con.proxy.ID)
-			con.proxy.Lock()
-			con.blockedPushes[w.TypeUrl] = con.blockedPushes[w.TypeUrl].CopyMerge(pushEv.pushRequest)
-			con.proxy.Unlock()
+			// If flow control is enabled, we will only push if we got an ACK for the previous response
+			// or there is no response with in FlowControlTimeout.
+			synced, timeout := con.Synced(w.TypeUrl)
+			if !synced && timeout {
+				// We are not synced, but we have been stuck for too long. We will trigger the push anyways to
+				// avoid any scenario where this may deadlock.
+				// This can possibly be removed in the future if we find this never causes issues
+				totalDelayedPushes.With(typeTag.Value(v3.GetMetricType(w.TypeUrl))).Increment()
+				log.Warnf("%s: QUEUE TIMEOUT for node:%s", v3.GetShortType(w.TypeUrl), con.proxy.ID)
+			}
+			if synced || timeout {
+				shouldPush = true
+			} else {
+				// The type is not yet synced. Instead of pushing now, which may overload Envoy,
+				// we will wait until the last push is ACKed and trigger the push. See
+				// https://github.com/istio/istio/issues/25685 for details on the performance
+				// impact of sending pushes before Envoy ACKs.
+				totalDelayedPushes.With(typeTag.Value(v3.GetMetricType(w.TypeUrl))).Increment()
+				log.Debugf("%s: QUEUE for node:%s", v3.GetShortType(w.TypeUrl), con.proxy.ID)
+				con.proxy.Lock()
+				con.blockedPushes[w.TypeUrl] = con.blockedPushes[w.TypeUrl].CopyMerge(pushEv.pushRequest)
+				con.proxy.Unlock()
+			}
 		}
+		if shouldPush {
+			if con.IsDelta() {
+				if err := s.pushDeltaXds(con, pushRequest.Push, w, nil, pushRequest); err != nil {
+					return err
+				}
+			} else {
+				if err := s.pushXds(con, pushRequest.Push, w, pushRequest); err != nil {
+					return err
+				}
+			}
+		}
+
 	}
 	if pushRequest.Full {
 		// Report all events for unwatched resources. Watched resources will be reported in pushXds or on ack.


### PR DESCRIPTION
This PR does the following
- Stores autoregistration group name in Proxy so that we do not search metadata every time health request comes
- Refactors pushConnection to work for both ads and delta - Removed pushConnectionDelta method

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
