### PR TITLE
[1.11] Fix usage of `ISTIO_MUTUAL` with `credentialName`. (#36935)

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -476,6 +476,11 @@ var (
 		"If enabled, pilot will only send the delta configs as opposed to the state of the world on a "+
 			"Resource Request. This feature uses the delta xds api, but does not currently send the actual deltas.").Get()
 
+	EnableLegacyIstioMutualCredentialName = env.RegisterBoolVar("PILOT_ENABLE_LEGACY_ISTIO_MUTUAL_CREDENTIAL_NAME",
+		true,
+		"If enabled, Gateway's with ISTIO_MUTUAL mode and credentialName configured will use simple TLS. "+
+			"This is to retain legacy behavior only and not recommended for use beyond migration.").Get()
+
 	EnableLegacyAutoPassthrough = env.RegisterBoolVar(
 		"PILOT_ENABLE_LEGACY_AUTO_PASSTHROUGH",
 		false,

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -572,6 +572,14 @@ func validateTLSOptions(tls *networking.ServerTLSSettings) (v Validation) {
 		if tls.CaCertificates != "" {
 			v = appendValidation(v, fmt.Errorf("ISTIO_MUTUAL TLS cannot have associated CA bundle"))
 		}
+		if tls.CredentialName != "" {
+			if features.EnableLegacyIstioMutualCredentialName {
+				// Legacy mode enabled, just warn
+				v = appendWarningf(v, "ISTIO_MUTUAL TLS cannot have associated credentialName")
+			} else {
+				v = appendValidation(v, fmt.Errorf("ISTIO_MUTUAL TLS cannot have associated credentialName"))
+			}
+		}
 
 		return
 	}

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -1365,6 +1365,14 @@ func TestValidateTlsOptions(t *testing.T) {
 			"cannot have associated private key", "",
 		},
 		{
+			"istio_mutual with credential name",
+			&networking.ServerTLSSettings{
+				Mode:           networking.ServerTLSSettings_ISTIO_MUTUAL,
+				CredentialName: "some-cred",
+			},
+			"", "cannot have associated credentialName",
+		},
+		{
 			"invalid cipher suites",
 			&networking.ServerTLSSettings{
 				Mode:           networking.ServerTLSSettings_SIMPLE,

--- a/releasenotes/notes/istio-mutual-cred-name.yaml
+++ b/releasenotes/notes/istio-mutual-cred-name.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+releaseNotes:
+- |
+  **Fixed** an issue where using `ISTIO_MUTUAL` TLS mode in Gateways while also setting `credentialName` cause mutual TLS to not be configured.
+  For backwards compatibility, this only introduces a warning. To enable the new behavior, set the `PILOT_ENABLE_LEGACY_ISTIO_MUTUAL_CREDENTIAL_NAME=true`
+  environment variable in Istiod. This will cause invalid configurations to be rejected, and will be the default behavior in future releases.


### PR DESCRIPTION
Currently, if a user sets both of these, there is no validation or
warning. What ends up happening is the `ISTIO_MUTUAL` part is completely
ignored, and you get one way TLS using the `credentialName` configs.

This is highly unexpected and may lead to misconfigurations where users
expect mTLS to be used/enforce, but it is not.

This modifies the behavior to reject this in validation, and if are both
somehow set then the ISTIO_MUTUAL has precedence. This mirrors the
behavior for file-mounted cert references in the original PR 2.5 years
ago:
https://github.com/istio/istio/commit/fd80f5d11d0ad527d0c3de73f06aa0c2d4501c8e#diff-1488ede8a94d615faf5bbbd17f81fdb16b0409a3cc21ae6525a91991e55df34fR381.

Because this represents a backwards incompatible change, and there are
known users with this configuration, an opt-out flag is added. This PR
will be backported with settings:

* master, 1.13 - new behavior by default
* 1.12, 1.11 - old behavior by default, but with a new warning

(cherry picked from commit b44595320593f4b3325070cb794bad01a04a326f)

**Please provide a description of this PR:**