### PR TITLE
fix format of error in istioctl

### DIFF
--- a/operator/pkg/validate/common.go
+++ b/operator/pkg/validate/common.go
@@ -93,7 +93,7 @@ var (
 func validateWithRegex(path util.Path, val interface{}, r *regexp.Regexp) (errs util.Errors) {
 	valStr := fmt.Sprint(val)
 	if len(r.FindString(valStr)) != len(valStr) {
-		errs = util.AppendErr(errs, fmt.Errorf("invalid value %s: %s", path, val))
+		errs = util.AppendErr(errs, fmt.Errorf("invalid value %s: %v", path, val))
 		printError(errs.ToError())
 	}
 	return errs


### PR DESCRIPTION
```
$ istioctl manifest generate --set tag=1643215493
Run the command with the --force flag if you want to ignore the validation error and proceed.
Error: invalid value Tag: %!!(MISSING)s(float64=1.643215493e+09)
$ go run ./istioctl/cmd/istioctl manifest generate --set tag=1643215493
Run the command with the --force flag if you want to ignore the validation error and proceed.
Error: invalid value Tag: 1.643215493e+09
```

We should also probably make it actually work but that is left as an exercise for someone else :-)