### PR TITLE
Remove liveness prober from CNI Daemonset.

### DIFF
--- a/manifests/charts/istio-cni/templates/daemonset.yaml
+++ b/manifests/charts/istio-cni/templates/daemonset.yaml
@@ -69,11 +69,6 @@ spec:
 {{- if or .Values.cni.pullPolicy .Values.global.imagePullPolicy }}
           imagePullPolicy: {{ .Values.cni.pullPolicy | default .Values.global.imagePullPolicy }}
 {{- end }}
-          livenessProbe:
-            httpGet:
-              path: /healthz
-              port: 8000
-            initialDelaySeconds: 5
           readinessProbe:
             httpGet:
               path: /readyz


### PR DESCRIPTION
Fix https://github.com/istio/istio/issues/36363. CNI Daemonset logic is straightforward and can hardly benefit from the liveness prober.