### PR TITLE
refactor: merge JWTPath and credential fetcher

### DIFF
--- a/pilot/cmd/pilot-agent/options/options.go
+++ b/pilot/cmd/pilot-agent/options/options.go
@@ -21,6 +21,7 @@ import (
 	"istio.io/istio/pilot/cmd/pilot-agent/status"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/jwt"
+	"istio.io/istio/pkg/security"
 	"istio.io/pkg/env"
 )
 
@@ -78,7 +79,7 @@ var (
 		"Whether to generate PKCS#8 private keys").Get()
 	eccSigAlgEnv        = env.RegisterStringVar("ECC_SIGNATURE_ALGORITHM", "", "The type of ECC signature algorithm to use when generating private keys").Get()
 	fileMountedCertsEnv = env.RegisterBoolVar("FILE_MOUNTED_CERTS", false, "").Get()
-	credFetcherTypeEnv  = env.RegisterStringVar("CREDENTIAL_FETCHER_TYPE", "",
+	credFetcherTypeEnv  = env.RegisterStringVar("CREDENTIAL_FETCHER_TYPE", security.JWT,
 		"The type of the credential fetcher. Currently supported types include GoogleComputeEngine").Get()
 	credIdentityProvider = env.RegisterStringVar("CREDENTIAL_IDENTITY_PROVIDER", "GoogleComputeEngine",
 		"The identity provider for credential. Currently default supported identity provider is GoogleComputeEngine").Get()

--- a/pilot/cmd/pilot-agent/options/security.go
+++ b/pilot/cmd/pilot-agent/options/security.go
@@ -92,7 +92,6 @@ func SetupSecurityOptions(proxyConfig *meshconfig.ProxyConfig, secOpt *security.
 	}
 
 	o := secOpt
-	o.JWTPath = jwtPath
 
 	// If not set explicitly, default to the discovery address.
 	if o.CAEndpoint == "" {
@@ -100,17 +99,13 @@ func SetupSecurityOptions(proxyConfig *meshconfig.ProxyConfig, secOpt *security.
 		o.CAEndpointSAN = istiodSAN.Get()
 	}
 
-	// TODO (liminw): CredFetcher is a general interface. In 1.7, we limit the use on GCE only because
-	// GCE is the only supported plugin at the moment.
-	if credFetcherTypeEnv == security.GCE {
-		o.CredIdentityProvider = credIdentityProvider
-		credFetcher, err := credentialfetcher.NewCredFetcher(credFetcherTypeEnv, o.TrustDomain, jwtPath, o.CredIdentityProvider)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create credential fetcher: %v", err)
-		}
-		log.Infof("using credential fetcher of %s type in %s trust domain", credFetcherTypeEnv, o.TrustDomain)
-		o.CredFetcher = credFetcher
+	o.CredIdentityProvider = credIdentityProvider
+	credFetcher, err := credentialfetcher.NewCredFetcher(credFetcherTypeEnv, o.TrustDomain, jwtPath, o.CredIdentityProvider)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create credential fetcher: %v", err)
 	}
+	log.Infof("using credential fetcher of %s type in %s trust domain", credFetcherTypeEnv, o.TrustDomain)
+	o.CredFetcher = credFetcher
 
 	if o.CAProviderName == security.GkeWorkloadCertificateProvider {
 		if !CheckGkeWorkloadCertificate(security.GkeWorkloadCertChainFilePath,

--- a/pkg/istio-agent/agent_test.go
+++ b/pkg/istio-agent/agent_test.go
@@ -182,7 +182,7 @@ func TestAgent(t *testing.T) {
 			a.Security.CertChainFilePath = cfg.CertificatePath
 			a.Security.KeyFilePath = cfg.PrivateKeyPath
 			a.Security.RootCertFilePath = cfg.CaCertificatePath
-			a.Security.JWTPath = "bogus"
+			a.Security.CredFetcher = plugin.CreateTokenPlugin(filepath.Join(env.IstioSrc, "pkg/istio-agent/testdata/token"))
 			a.ProxyConfig.ProxyMetadata = map[string]string{}
 			a.ProxyConfig.ProxyMetadata[MetadataClientCertChain] = filepath.Join(dir, "cert-chain.pem")
 			a.ProxyConfig.ProxyMetadata[MetadataClientCertKey] = filepath.Join(dir, "key.pem")
@@ -285,7 +285,7 @@ func TestAgent(t *testing.T) {
 				a.CaAuthenticator.Set("", fakeSpiffeID)
 				a.Security.OutputKeyCertToDir = dir
 				a.Security.ProvCert = dir
-				a.Security.JWTPath = "bogus"
+				a.Security.CredFetcher = plugin.CreateTokenPlugin(filepath.Join(env.IstioSrc, "pkg/istio-agent/testdata/token"))
 				return a
 			})
 			// Ensure we can still make requests
@@ -547,7 +547,7 @@ func Setup(t *testing.T, opts ...func(a AgentTest) AgentTest) *AgentTest {
 		CAEndpoint:        ca.URL,
 		CAProviderName:    "Citadel",
 		TrustDomain:       "cluster.local",
-		JWTPath:           filepath.Join(env.IstioSrc, "pkg/istio-agent/testdata/token"),
+		CredFetcher:       plugin.CreateTokenPlugin(filepath.Join(env.IstioSrc, "pkg/istio-agent/testdata/token")),
 		WorkloadNamespace: "namespace",
 		ServiceAccount:    "sa",
 		// Signing in 2048 bit RSA is extremely slow when running with -race enabled, sometimes taking 5s+ in

--- a/pkg/security/security.go
+++ b/pkg/security/security.go
@@ -67,6 +67,9 @@ const (
 	// GCE is Credential fetcher type of Google plugin
 	GCE = "GoogleComputeEngine"
 
+	// JWT is a Credential fetcher type that reads from a JWT token file
+	JWT = "JWT"
+
 	// Mock is Credential fetcher type of mock plugin
 	Mock = "Mock" // testing only
 
@@ -132,9 +135,6 @@ type Options struct {
 
 	// Whether to generate PKCS#8 private keys.
 	Pkcs8Keys bool
-
-	// Location of JWTPath to connect to CA.
-	JWTPath string
 
 	// OutputKeyCertToDir is the directory for output the key and certificate
 	OutputKeyCertToDir string
@@ -310,9 +310,6 @@ type SecretItem struct {
 type CredFetcher interface {
 	// GetPlatformCredential fetches workload credential provided by the platform.
 	GetPlatformCredential() (string, error)
-
-	// GetType returns credential fetcher type. Currently the supported type is "GoogleComputeEngine".
-	GetType() string
 
 	// GetIdentityProvider returns the name of the IdentityProvider that can authenticate the workload credential.
 	GetIdentityProvider() string

--- a/security/pkg/credentialfetcher/fetcher.go
+++ b/security/pkg/credentialfetcher/fetcher.go
@@ -26,6 +26,9 @@ func NewCredFetcher(credtype, trustdomain, jwtPath, identityProvider string) (se
 	switch credtype {
 	case security.GCE:
 		return plugin.CreateGCEPlugin(trustdomain, jwtPath, identityProvider), nil
+	case security.JWT, "":
+		// If unset, also default to JWT for backwards compatibility
+		return plugin.CreateTokenPlugin(jwtPath), nil
 	case security.Mock: // for test only
 		return plugin.CreateMockPlugin("test_token"), nil
 	default:

--- a/security/pkg/credentialfetcher/plugin/gce.go
+++ b/security/pkg/credentialfetcher/plugin/gce.go
@@ -19,12 +19,12 @@ package plugin
 import (
 	"fmt"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
 	"cloud.google.com/go/compute/metadata"
 
-	"istio.io/istio/pkg/security"
 	"istio.io/istio/security/pkg/util"
 	"istio.io/pkg/log"
 )
@@ -153,12 +153,7 @@ func (p *GCEPlugin) GetPlatformCredential() (string, error) {
 		gcecredLog.Errorf("Encountered error when writing vm identity token: %v", err)
 		return "", err
 	}
-	return token, nil
-}
-
-// GetType returns credential fetcher type.
-func (p *GCEPlugin) GetType() string {
-	return security.GCE
+	return strings.TrimSpace(token), nil
 }
 
 // GetIdentityProvider returns the name of the identity provider that can authenticate the workload credential.

--- a/security/pkg/credentialfetcher/plugin/mock.go
+++ b/security/pkg/credentialfetcher/plugin/mock.go
@@ -24,7 +24,6 @@ import (
 	"os"
 	"sync"
 
-	"istio.io/istio/pkg/security"
 	"istio.io/pkg/log"
 )
 
@@ -49,11 +48,6 @@ func CreateMockPlugin(token string) *MockPlugin {
 func (p *MockPlugin) GetPlatformCredential() (string, error) {
 	mockcredLog.Debugf("mock plugin returns a constant token.")
 	return p.token, nil
-}
-
-// GetType returns credential fetcher type.
-func (p *MockPlugin) GetType() string {
-	return security.Mock
 }
 
 // GetIdentityProvider returns the name of the identity provider that can authenticate the workload credential.

--- a/security/pkg/credentialfetcher/plugin/token.go
+++ b/security/pkg/credentialfetcher/plugin/token.go
@@ -1,0 +1,54 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugin
+
+import (
+	"os"
+	"strings"
+
+	"istio.io/istio/pkg/security"
+	"istio.io/pkg/log"
+)
+
+type KubernetesTokenPlugin struct {
+	path string
+}
+
+var _ security.CredFetcher = &KubernetesTokenPlugin{}
+
+func CreateTokenPlugin(path string) *KubernetesTokenPlugin {
+	return &KubernetesTokenPlugin{
+		path: path,
+	}
+}
+
+func (t KubernetesTokenPlugin) GetPlatformCredential() (string, error) {
+	if t.path == "" {
+		return "", nil
+	}
+	tok, err := os.ReadFile(t.path)
+	if err != nil {
+		log.Warnf("failed to fetch token from file: %v", err)
+		return "", nil
+	}
+	return strings.TrimSpace(string(tok)), nil
+}
+
+func (t KubernetesTokenPlugin) GetIdentityProvider() string {
+	return ""
+}
+
+func (t KubernetesTokenPlugin) Stop() {
+}

--- a/security/pkg/nodeagent/caclient/credentials.go
+++ b/security/pkg/nodeagent/caclient/credentials.go
@@ -83,6 +83,9 @@ func (t *TokenProvider) RequireTransportSecurity() bool {
 // volatile memory), we can still proceed and allow other authentication methods to potentially
 // handle the request, such as mTLS.
 func (t *TokenProvider) GetToken() (string, error) {
+	if t.opts.CredFetcher == nil {
+		return "", nil
+	}
 	token, err := t.opts.CredFetcher.GetPlatformCredential()
 	if err != nil {
 		return "", fmt.Errorf("fetch platform credential: %v", err)

--- a/security/pkg/nodeagent/caclient/credentials.go
+++ b/security/pkg/nodeagent/caclient/credentials.go
@@ -18,8 +18,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
-	"strings"
 
 	"google.golang.org/grpc/credentials"
 
@@ -28,7 +26,6 @@ import (
 	"istio.io/istio/security/pkg/stsservice"
 	"istio.io/istio/security/pkg/stsservice/server"
 	"istio.io/istio/security/pkg/stsservice/tokenmanager/google"
-	"istio.io/pkg/log"
 )
 
 // TokenProvider is a grpc PerRPCCredentials that can be used to attach a JWT token to each gRPC call.
@@ -86,83 +83,43 @@ func (t *TokenProvider) RequireTransportSecurity() bool {
 // volatile memory), we can still proceed and allow other authentication methods to potentially
 // handle the request, such as mTLS.
 func (t *TokenProvider) GetToken() (string, error) {
-	if !t.forCA {
-		return t.GetTokenForXDS()
-	}
-	// For CA, we have two modes, using the newer CredentialFetcher or just reading directly from file
-	var token string
-	if t.opts.CredFetcher != nil {
-		var err error
-		token, err = t.opts.CredFetcher.GetPlatformCredential()
-		if err != nil {
-			return "", fmt.Errorf("fetch platform credential: %v", err)
-		}
-	} else {
-		if t.opts.JWTPath == "" {
-			return "", nil
-		}
-		tok, err := os.ReadFile(t.opts.JWTPath)
-		if err != nil {
-			log.Warnf("failed to fetch token from file: %v", err)
-			return "", nil
-		}
-		token = strings.TrimSpace(string(tok))
+	token, err := t.opts.CredFetcher.GetPlatformCredential()
+	if err != nil {
+		return "", fmt.Errorf("fetch platform credential: %v", err)
 	}
 
 	// Regardless of where the token came from, we (optionally) can exchange the token for a different
-	// one using the configured TokenExchanger.
-	return t.exchangeToken(token)
+	if t.forCA {
+		return t.exchangeCAToken(token)
+	}
+	return t.exchangeXDSToken(token)
 }
 
-// GetTokenForXDS gets the token for the XDS flow.
-func (t *TokenProvider) GetTokenForXDS() (string, error) {
-	if t.opts.XdsAuthProvider == google.GCPAuthProvider {
-		return t.getTokenForGCP()
+// exchangeCAToken exchanges the provided token using TokenExchanger, if configured. If not, the
+// original token is returned.
+func (t *TokenProvider) exchangeCAToken(token string) (string, error) {
+	if t.opts.TokenExchanger == nil {
+		return token, nil
 	}
-	// For XDS flow, when no token provider is specified, we only support reading from file.
-	if t.opts.JWTPath == "" {
-		return "", nil
-	}
-	tok, err := os.ReadFile(t.opts.JWTPath)
-	if err != nil {
-		log.Warnf("failed to fetch token from file: %v", err)
-		return "", nil
-	}
-	return strings.TrimSpace(string(tok)), nil
+	return t.opts.TokenExchanger.ExchangeToken(token)
 }
 
-func (t *TokenProvider) getTokenForGCP() (string, error) {
-	var tok string
-	var err error
-	if t.opts.CredFetcher != nil {
-		// When running at a non-k8s platform, use CredFetcher to get credential.
-		tok, err = t.opts.CredFetcher.GetPlatformCredential()
-		if err != nil {
-			return "", fmt.Errorf("failed to fetch platform credential: %v", err)
-		}
-	} else {
-		// When XDS auth provider is GCP, token is always required. We should return
-		// err when failed to get a token.
-		if t.opts.JWTPath == "" {
-			return "", fmt.Errorf("the JWTPath is not set")
-		}
-		tokBytes, err := os.ReadFile(t.opts.JWTPath)
-		if err != nil {
-			return "", fmt.Errorf("failed to fetch token from file: %v", err)
-		}
-		tok = string(tokBytes)
+func (t *TokenProvider) exchangeXDSToken(token string) (string, error) {
+	if t.opts.XdsAuthProvider != google.GCPAuthProvider {
+		return token, nil
 	}
+
 	// For XDS flow, the token exchange is different from that of the CA flow.
 	if t.opts.TokenManager == nil {
 		return "", fmt.Errorf("XDS token exchange is enabled but token manager is nil")
 	}
-	if strings.TrimSpace(tok) == "" {
+	if token == "" {
 		return "", fmt.Errorf("the token for XDS token exchange is empty")
 	}
 	params := security.StsRequestParameters{
 		Scope:            stsclient.Scope,
 		GrantType:        server.TokenExchangeGrantType,
-		SubjectToken:     strings.TrimSpace(tok),
+		SubjectToken:     token,
 		SubjectTokenType: server.SubjectTokenType,
 	}
 	body, err := t.opts.TokenManager.GenerateToken(params)
@@ -174,13 +131,4 @@ func (t *TokenProvider) getTokenForGCP() (string, error) {
 		return "", fmt.Errorf("failed to unmarshal access token response data: %v", err)
 	}
 	return respData.AccessToken, nil
-}
-
-// exchangeToken exchanges the provided token using TokenExchanger, if configured. If not, the
-// original token is returned.
-func (t *TokenProvider) exchangeToken(token string) (string, error) {
-	if t.opts.TokenExchanger == nil {
-		return token, nil
-	}
-	return t.opts.TokenExchanger.ExchangeToken(token)
 }

--- a/security/pkg/nodeagent/caclient/credentials_test.go
+++ b/security/pkg/nodeagent/caclient/credentials_test.go
@@ -27,6 +27,7 @@ import (
 	"istio.io/istio/pkg/jwt"
 	"istio.io/istio/pkg/security"
 	"istio.io/istio/security/pkg/credentialfetcher"
+	"istio.io/istio/security/pkg/credentialfetcher/plugin"
 	"istio.io/istio/security/pkg/nodeagent/caclient"
 	"istio.io/istio/security/pkg/stsservice"
 	stsmock "istio.io/istio/security/pkg/stsservice/mock"
@@ -78,7 +79,7 @@ func TestGetTokenForXDS(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to write the JWT token file: %v", err)
 	}
-	secOpts.JWTPath = jwtPath
+	secOpts.CredFetcher = plugin.CreateTokenPlugin(jwtPath)
 	defer os.Remove(jwtPath)
 
 	mockCredFetcher, err := credentialfetcher.NewCredFetcher(security.Mock, "", "", "")

--- a/security/pkg/nodeagent/caclient/providers/citadel/client_test.go
+++ b/security/pkg/nodeagent/caclient/providers/citadel/client_test.go
@@ -131,7 +131,11 @@ func TestCitadelClientRotation(t *testing.T) {
 	t.Run("cert always present", func(t *testing.T) {
 		server := mockCAServer{Certs: fakeCert, Err: nil, Authenticator: security.NewFakeAuthenticator("ca")}
 		addr := serve(t, server, tlsOptions(t))
-		opts := &security.Options{CAEndpoint: addr, JWTPath: "testdata/token", ProvCert: certDir}
+		opts := &security.Options{
+			CAEndpoint:  addr,
+			CredFetcher: plugin.CreateTokenPlugin("testdata/token"),
+			ProvCert:    certDir,
+		}
 		rootCert := path.Join(certDir, constants.RootCertFilename)
 		key := path.Join(certDir, constants.KeyFilename)
 		cert := path.Join(certDir, constants.CertChainFilename)
@@ -155,7 +159,11 @@ func TestCitadelClientRotation(t *testing.T) {
 	t.Run("cert never present", func(t *testing.T) {
 		server := mockCAServer{Certs: fakeCert, Err: nil, Authenticator: security.NewFakeAuthenticator("ca")}
 		addr := serve(t, server, tlsOptions(t))
-		opts := &security.Options{CAEndpoint: addr, JWTPath: "testdata/token", ProvCert: "."}
+		opts := &security.Options{
+			CAEndpoint:  addr,
+			CredFetcher: plugin.CreateTokenPlugin("testdata/token"),
+			ProvCert:    ".",
+		}
 		rootCert := path.Join(certDir, constants.RootCertFilename)
 		key := path.Join(opts.ProvCert, constants.KeyFilename)
 		cert := path.Join(opts.ProvCert, constants.CertChainFilename)
@@ -178,7 +186,11 @@ func TestCitadelClientRotation(t *testing.T) {
 		dir := t.TempDir()
 		server := mockCAServer{Certs: fakeCert, Err: nil, Authenticator: security.NewFakeAuthenticator("ca")}
 		addr := serve(t, server, tlsOptions(t))
-		opts := &security.Options{CAEndpoint: addr, JWTPath: "testdata/token", ProvCert: dir}
+		opts := &security.Options{
+			CAEndpoint:  addr,
+			CredFetcher: plugin.CreateTokenPlugin("testdata/token"),
+			ProvCert:    dir,
+		}
 		rootCert := path.Join(certDir, constants.RootCertFilename)
 		key := path.Join(opts.ProvCert, constants.KeyFilename)
 		cert := path.Join(opts.ProvCert, constants.CertChainFilename)

--- a/security/pkg/nodeagent/test/setup.go
+++ b/security/pkg/nodeagent/test/setup.go
@@ -30,6 +30,7 @@ import (
 	"istio.io/istio/pkg/spiffe"
 	istioEnv "istio.io/istio/pkg/test/env"
 	"istio.io/istio/pkg/test/envoy"
+	"istio.io/istio/security/pkg/credentialfetcher/plugin"
 	"istio.io/istio/security/pkg/nodeagent/cache"
 	citadel "istio.io/istio/security/pkg/nodeagent/caclient/providers/citadel"
 	"istio.io/istio/security/pkg/nodeagent/sds"
@@ -162,7 +163,7 @@ func (e *Env) StartProxy(t *testing.T) {
 func (e *Env) StartSDSServer(t *testing.T) {
 	serverOptions := &security.Options{
 		WorkloadUDSPath: e.ProxySetup.SDSPath(),
-		JWTPath:         proxyTokenPath,
+		CredFetcher:     plugin.CreateTokenPlugin(proxyTokenPath),
 		CAEndpoint:      fmt.Sprintf("127.0.0.1:%d", e.ProxySetup.Ports().ExtraPort),
 	}
 


### PR DESCRIPTION
Currently we have two ways to fetch credentials:
* JWTPath, which reads from a jwt token file
* CredentialFetcher, which is a generic interface to fetch credentials

This makes reading from a jwt token file a CredentialFetcher,
simplifying the code a bit

**Please provide a description of this PR:**