### PR TITLE
fix flaky workload entry to ports

### DIFF
--- a/istioctl/cmd/workload.go
+++ b/istioctl/cmd/workload.go
@@ -537,15 +537,20 @@ func createMeshConfig(kubeClient kube.ExtendedClient, wg *clientv1alpha3.Workloa
 
 func marshalWorkloadEntryPodPorts(p map[string]uint32) string {
 	var out []model.PodPort
+
+	if len(p) == 0 {
+		return ""
+	}
+
 	for name, port := range p {
 		out = append(out, model.PodPort{Name: name, ContainerPort: int(port)})
 	}
-	if len(out) == 0 {
-		return ""
-	}
+
+	// sort by port number
 	sort.Slice(out, func(i, j int) bool {
-		return out[i].Name < out[j].Name
+		return out[i].ContainerPort < out[j].ContainerPort
 	})
+
 	str, err := json.Marshal(out)
 	if err != nil {
 		return ""

--- a/istioctl/cmd/workload.go
+++ b/istioctl/cmd/workload.go
@@ -545,10 +545,9 @@ func marshalWorkloadEntryPodPorts(p map[string]uint32) string {
 	for name, port := range p {
 		out = append(out, model.PodPort{Name: name, ContainerPort: int(port)})
 	}
-
-	// sort by port number
+	// sort by port name before marshaling to give consistent output
 	sort.Slice(out, func(i, j int) bool {
-		return out[i].ContainerPort < out[j].ContainerPort
+		return out[i].Name < out[j].Name
 	})
 
 	str, err := json.Marshal(out)

--- a/istioctl/cmd/workload_test.go
+++ b/istioctl/cmd/workload_test.go
@@ -28,6 +28,7 @@ import (
 
 	"istio.io/istio/pilot/test/util"
 	"istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/test/util/assert"
 )
 
 var fakeCACert = []byte("fake-CA-cert")
@@ -240,10 +241,22 @@ func TestWorkloadEntryToPodPortsMeta(t *testing.T) {
 		{
 			description: "test json marshal",
 			ports: map[string]uint32{
-				"HTTP":  80,
-				"HTTPS": 443,
+				"http":    80,
+				"https":   443,
+				"metrics": 8081,
+				"debug":   8088,
 			},
-			want: `[{"name":"HTTP","containerPort":80,"protocol":""},{"name":"HTTPS","containerPort":443,"protocol":""}]`,
+			want: func() string {
+				ll := []string{
+					"[",
+					`{"name":"debug","containerPort":8088,"protocol":""},`,
+					`{"name":"http","containerPort":80,"protocol":""},`,
+					`{"name":"https","containerPort":443,"protocol":""},`,
+					`{"name":"metrics","containerPort":8081,"protocol":""}`,
+					"]",
+				}
+				return strings.Join(ll, "")
+			}(),
 		},
 		{
 			description: "test json marshal - empty ports",
@@ -254,9 +267,7 @@ func TestWorkloadEntryToPodPortsMeta(t *testing.T) {
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("case %d %s", i, c.description), func(t *testing.T) {
 			str := marshalWorkloadEntryPodPorts(c.ports)
-			if c.want != str {
-				t.Errorf("want %s, got %s", c.want, str)
-			}
+			assert.Equal(t, str, c.want)
 		})
 	}
 }

--- a/istioctl/cmd/workload_test.go
+++ b/istioctl/cmd/workload_test.go
@@ -245,6 +245,11 @@ func TestWorkloadEntryToPodPortsMeta(t *testing.T) {
 			},
 			want: `[{"name":"HTTP","containerPort":80,"protocol":""},{"name":"HTTPS","containerPort":443,"protocol":""}]`,
 		},
+		{
+			description: "test json marshal - empty ports",
+			ports:       nil,
+			want:        "",
+		},
 	}
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("case %d %s", i, c.description), func(t *testing.T) {


### PR DESCRIPTION
**Please provide a description of this PR:**

Fix flaky test introduced in #36504

https://prow.istio.io/view/gs/istio-prow/pr-logs/pull/istio_istio/36930/unit-tests_istio/1486955106078298112

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [X] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
