### PR TITLE
refactor: use `T.TempDir` to create temporary test directory

### DIFF
--- a/cni/pkg/install/cniconfig_test.go
+++ b/cni/pkg/install/cniconfig_test.go
@@ -16,7 +16,6 @@ package install
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -29,15 +28,7 @@ import (
 )
 
 func TestGetDefaultCNINetwork(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		if err := os.RemoveAll(tempDir); err != nil {
-			t.Fatal(err)
-		}
-	}()
+	tempDir := t.TempDir()
 
 	cases := []struct {
 		name            string
@@ -107,7 +98,7 @@ func TestGetDefaultCNINetwork(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			if c.fileContents != "" {
-				err = os.WriteFile(filepath.Join(c.dir, c.inFilename), []byte(c.fileContents), 0o644)
+				err := os.WriteFile(filepath.Join(c.dir, c.inFilename), []byte(c.fileContents), 0o644)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -197,18 +188,10 @@ func TestGetCNIConfigFilepath(t *testing.T) {
 		},
 	}
 
-	for i, c := range cases {
+	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			// Create temp directory for files
-			tempDir, err := os.MkdirTemp("", fmt.Sprintf("test-case-%d-", i))
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer func() {
-				if err := os.RemoveAll(tempDir); err != nil {
-					t.Fatal(err)
-				}
-			}()
+			tempDir := t.TempDir()
 
 			// Create existing config files if specified in test case
 			for _, filename := range c.existingConfFiles {
@@ -466,7 +449,7 @@ func TestCreateCNIConfigFile(t *testing.T) {
 		},
 	}
 
-	for i, c := range cases {
+	for _, c := range cases {
 		cfgFile := config.InstallConfig{
 			CNIConfName:          c.specifiedConfName,
 			ChainedCNIPlugin:     c.chainedCNIPlugin,
@@ -485,15 +468,7 @@ func TestCreateCNIConfigFile(t *testing.T) {
 		test := func(cfg config.InstallConfig) func(t *testing.T) {
 			return func(t *testing.T) {
 				// Create temp directory for files
-				tempDir, err := os.MkdirTemp("", fmt.Sprintf("test-case-%d-", i))
-				if err != nil {
-					t.Fatal(err)
-				}
-				defer func() {
-					if err := os.RemoveAll(tempDir); err != nil {
-						t.Fatal(err)
-					}
-				}()
+				tempDir := t.TempDir()
 
 				// Create existing config files if specified in test case
 				for srcFilename, targetFilename := range c.existingConfFiles {

--- a/cni/pkg/install/kubeconfig_test.go
+++ b/cni/pkg/install/kubeconfig_test.go
@@ -15,7 +15,6 @@
 package install
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -76,18 +75,10 @@ func TestCreateKubeconfigFile(t *testing.T) {
 		},
 	}
 
-	for i, c := range cases {
+	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			// Create temp directory for files
-			tempDir, err := os.MkdirTemp("", fmt.Sprintf("test-case-%d-", i))
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer func() {
-				if err := os.RemoveAll(tempDir); err != nil {
-					t.Fatal(err)
-				}
-			}()
+			tempDir := t.TempDir()
 
 			cfg := &config.InstallConfig{
 				MountedCNINetDir:   tempDir,

--- a/operator/cmd/mesh/manifest-generate_test.go
+++ b/operator/cmd/mesh/manifest-generate_test.go
@@ -532,11 +532,7 @@ func TestBogusControlPlaneSec(t *testing.T) {
 }
 
 func TestInstallPackagePath(t *testing.T) {
-	serverDir, err := os.MkdirTemp(os.TempDir(), "istio-test-server-*")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(serverDir)
+	serverDir := t.TempDir()
 	if err := tgz.Create(string(liveCharts), filepath.Join(serverDir, testTGZFilename)); err != nil {
 		t.Fatal(err)
 	}

--- a/operator/pkg/helm/urlfetcher_test.go
+++ b/operator/pkg/helm/urlfetcher_test.go
@@ -48,15 +48,11 @@ func TestFetch(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tmp, err := os.MkdirTemp("", InstallationDirectory)
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer os.RemoveAll(tmp)
+			tmp := t.TempDir()
 			rootDir := tmp + "/testout"
 			fq := NewURLFetcher(server.URL+"/"+tt.installationPackageName, rootDir)
 
-			err = fq.Fetch()
+			err := fq.Fetch()
 			if err != nil {
 				t.Error(err)
 				return

--- a/pilot/pkg/bootstrap/istio_ca_test.go
+++ b/pilot/pkg/bootstrap/istio_ca_test.go
@@ -34,9 +34,7 @@ const namespace = "istio-system"
 func TestRemoteCerts(t *testing.T) {
 	g := NewWithT(t)
 
-	dir, err := os.MkdirTemp("", t.Name())
-	defer removeSilent(dir)
-	g.Expect(err).Should(BeNil())
+	dir := t.TempDir()
 
 	s := Server{
 		kubeClient: kube.NewFakeClient(),
@@ -46,7 +44,7 @@ func TestRemoteCerts(t *testing.T) {
 	}
 
 	// Should do nothing because cacerts doesn't exist.
-	err = s.loadRemoteCACerts(caOpts, dir)
+	err := s.loadRemoteCACerts(caOpts, dir)
 	g.Expect(err).Should(BeNil())
 
 	_, err = os.Stat(path.Join(dir, "root-cert.pem"))
@@ -67,10 +65,6 @@ func TestRemoteCerts(t *testing.T) {
 	// Should fail because certs already exist locally.
 	err = s.loadRemoteCACerts(caOpts, dir)
 	g.Expect(err).NotTo(BeNil())
-}
-
-func removeSilent(dir string) {
-	_ = os.RemoveAll(dir)
 }
 
 func createCASecret(client kube.Client) error {

--- a/pilot/pkg/bootstrap/server_test.go
+++ b/pilot/pkg/bootstrap/server_test.go
@@ -40,21 +40,9 @@ import (
 )
 
 func TestNewServerCertInit(t *testing.T) {
-	configDir, err := os.MkdirTemp("", "test_istiod_config")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		_ = os.RemoveAll(configDir)
-	}()
+	configDir := t.TempDir()
 
-	certsDir, err := os.MkdirTemp("", "test_istiod_certs")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		_ = os.RemoveAll(certsDir)
-	}()
+	certsDir := t.TempDir()
 
 	certFile := filepath.Join(certsDir, "cert-file.pem")
 	keyFile := filepath.Join(certsDir, "key-file.pem")
@@ -182,7 +170,7 @@ func TestNewServerCertInit(t *testing.T) {
 }
 
 func TestReloadIstiodCert(t *testing.T) {
-	dir, err := os.MkdirTemp("", "istiod_certs")
+	dir := t.TempDir()
 	stop := make(chan struct{})
 	s := &Server{
 		fileWatcher:             filewatcher.NewWatcher(),
@@ -193,11 +181,7 @@ func TestReloadIstiodCert(t *testing.T) {
 	defer func() {
 		close(stop)
 		_ = s.fileWatcher.Close()
-		_ = os.RemoveAll(dir)
 	}()
-	if err != nil {
-		t.Fatalf("TempDir() failed: %v", err)
-	}
 
 	certFile := filepath.Join(dir, "cert-file.yaml")
 	keyFile := filepath.Join(dir, "key-file.yaml")
@@ -222,15 +206,15 @@ func TestReloadIstiodCert(t *testing.T) {
 	}
 
 	// setup cert watches.
-	if err = s.initCertificateWatches(tlsOptions); err != nil {
+	if err := s.initCertificateWatches(tlsOptions); err != nil {
 		t.Fatalf("initCertificateWatches failed: %v", err)
 	}
 
-	if err = s.initIstiodCertLoader(); err != nil {
+	if err := s.initIstiodCertLoader(); err != nil {
 		t.Fatalf("istiod unable to load its cert")
 	}
 
-	if err = s.server.Start(stop); err != nil {
+	if err := s.server.Start(stop); err != nil {
 		t.Fatalf("Could not invoke startFuncs: %v", err)
 	}
 
@@ -291,16 +275,10 @@ func TestNewServer(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			configDir, err := os.MkdirTemp("", "TestNewServer")
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			defer func() {
-				_ = os.RemoveAll(configDir)
-			}()
+			configDir := t.TempDir()
 
 			var secureGRPCPort int
+			var err error
 			if c.enableSecureGRPC {
 				secureGRPCPort, err = findFreePort()
 				if err != nil {
@@ -383,14 +361,7 @@ func TestIstiodCipherSuites(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			configDir, err := os.MkdirTemp("", "TestIstiodCipherSuites")
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			defer func() {
-				_ = os.RemoveAll(configDir)
-			}()
+			configDir := t.TempDir()
 
 			port, err := findFreePort()
 			if err != nil {
@@ -487,14 +458,7 @@ func TestNewServerWithMockRegistry(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			configDir, err := os.MkdirTemp("", "TestNewServer")
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			defer func() {
-				_ = os.RemoveAll(configDir)
-			}()
+			configDir := t.TempDir()
 
 			args := NewPilotArgs(func(p *PilotArgs) {
 				p.Namespace = "istio-system"

--- a/pilot/pkg/config/monitor/file_snapshot_test.go
+++ b/pilot/pkg/config/monitor/file_snapshot_test.go
@@ -83,7 +83,6 @@ func TestFileSnapshotNoFilter(t *testing.T) {
 	}
 
 	ts.testSetup(t)
-	defer ts.testTeardown(t)
 
 	fileWatcher := NewFileSnapshot(ts.rootPath, collection.SchemasFor(), "foo")
 	configs, err := fileWatcher.ReadConfigFiles()
@@ -108,7 +107,6 @@ func TestFileSnapshotWithFilter(t *testing.T) {
 	}
 
 	ts.testSetup(t)
-	defer ts.testTeardown(t)
 
 	fileWatcher := NewFileSnapshot(ts.rootPath, collection.SchemasFor(collections.IstioNetworkingV1Alpha3Virtualservices), "")
 	configs, err := fileWatcher.ReadConfigFiles()
@@ -130,7 +128,6 @@ func TestFileSnapshotSorting(t *testing.T) {
 	}
 
 	ts.testSetup(t)
-	defer ts.testTeardown(t)
 
 	fileWatcher := NewFileSnapshot(ts.rootPath, collection.SchemasFor(), "")
 
@@ -150,22 +147,12 @@ type testState struct {
 func (ts *testState) testSetup(t *testing.T) {
 	var err error
 
-	ts.rootPath, err = os.MkdirTemp("", "config-root")
-	if err != nil {
-		t.Fatal(err)
-	}
+	ts.rootPath = t.TempDir()
 
 	for name, content := range ts.ConfigFiles {
 		err = os.WriteFile(filepath.Join(ts.rootPath, name), content, 0o600)
 		if err != nil {
 			t.Fatal(err)
 		}
-	}
-}
-
-func (ts *testState) testTeardown(t *testing.T) {
-	err := os.RemoveAll(ts.rootPath)
-	if err != nil {
-		t.Fatal(err)
 	}
 }

--- a/pilot/pkg/config/monitor/monitor_test.go
+++ b/pilot/pkg/config/monitor/monitor_test.go
@@ -153,7 +153,6 @@ func TestMonitorFileSnapshot(t *testing.T) {
 	}
 
 	ts.testSetup(t)
-	defer ts.testTeardown(t)
 
 	store := memory.Make(collection.SchemasFor(collections.IstioNetworkingV1Alpha3Gateways))
 	fileWatcher := NewFileSnapshot(ts.rootPath, collection.SchemasFor(), "foo")

--- a/pilot/pkg/keycertbundle/watcher_test.go
+++ b/pilot/pkg/keycertbundle/watcher_test.go
@@ -19,8 +19,6 @@ import (
 	"os"
 	"path"
 	"testing"
-
-	. "github.com/onsi/gomega"
 )
 
 func TestWatcher(t *testing.T) {
@@ -81,7 +79,6 @@ func TestWatcher(t *testing.T) {
 }
 
 func TestWatcherFromFile(t *testing.T) {
-	g := NewWithT(t)
 	watcher := NewWatcher()
 
 	// 1. no key cert bundle
@@ -93,8 +90,7 @@ func TestWatcherFromFile(t *testing.T) {
 	default:
 	}
 
-	tmpDir, err := os.MkdirTemp(os.TempDir(), t.Name())
-	g.Expect(err).To(BeNil())
+	tmpDir := t.TempDir()
 
 	key := []byte("key")
 	cert := []byte("cert")

--- a/pkg/envoy/instance_test.go
+++ b/pkg/envoy/instance_test.go
@@ -428,7 +428,7 @@ type bootstrapHelper struct {
 
 func newBootstrapHelper(t *testing.T) *bootstrapHelper {
 	t.Helper()
-	tempDir := newTempDir(t)
+	tempDir := t.TempDir()
 	portMgr := reserveport.NewPortManagerOrFail(t)
 	adminPort := portMgr.ReservePortNumberOrFail(t)
 	listenerPort := portMgr.ReservePortNumberOrFail(t)
@@ -479,15 +479,6 @@ func absPath(path string) string {
 		panic(err)
 	}
 	return path
-}
-
-func newTempDir(t *testing.T) string {
-	t.Helper()
-	dir, err := os.MkdirTemp("", t.Name())
-	if err != nil {
-		t.Fatal(err)
-	}
-	return dir
 }
 
 func newBootstrapFile(t *testing.T, tempDir string, adminPort, listenerPort uint16) string {

--- a/pkg/test/util/yml/cache_test.go
+++ b/pkg/test/util/yml/cache_test.go
@@ -73,8 +73,7 @@ spec:
 
 func TestCache_Apply_Basic(t *testing.T) {
 	g := NewWithT(t)
-	d, err := os.MkdirTemp(os.TempDir(), t.Name())
-	g.Expect(err).To(BeNil())
+	d := t.TempDir()
 	t.Logf("Test Dir: %q", d)
 
 	c := NewCache(d)
@@ -125,8 +124,7 @@ func TestCache_Apply_Basic(t *testing.T) {
 
 func TestCache_Apply_MultiPart(t *testing.T) {
 	g := NewWithT(t)
-	d, err := os.MkdirTemp(os.TempDir(), t.Name())
-	g.Expect(err).To(BeNil())
+	d := t.TempDir()
 	t.Logf("Test Dir: %q", d)
 
 	c := NewCache(d)
@@ -173,8 +171,7 @@ func TestCache_Apply_MultiPart(t *testing.T) {
 
 func TestCache_Apply_Add_Update(t *testing.T) {
 	g := NewWithT(t)
-	d, err := os.MkdirTemp(os.TempDir(), t.Name())
-	g.Expect(err).To(BeNil())
+	d := t.TempDir()
 	t.Logf("Test Dir: %q", d)
 
 	c := NewCache(d)
@@ -206,8 +203,7 @@ func TestCache_Apply_Add_Update(t *testing.T) {
 
 func TestCache_Apply_SameContent(t *testing.T) {
 	g := NewWithT(t)
-	d, err := os.MkdirTemp(os.TempDir(), t.Name())
-	g.Expect(err).To(BeNil())
+	d := t.TempDir()
 	t.Logf("Test Dir: %q", d)
 
 	c := NewCache(d)
@@ -232,13 +228,12 @@ func TestCache_Apply_SameContent(t *testing.T) {
 
 func TestCache_Clear(t *testing.T) {
 	g := NewWithT(t)
-	d, err := os.MkdirTemp(os.TempDir(), t.Name())
-	g.Expect(err).To(BeNil())
+	d := t.TempDir()
 	t.Logf("Test Dir: %q", d)
 
 	c := NewCache(d)
 
-	_, err = c.Apply(gateway)
+	_, err := c.Apply(gateway)
 	g.Expect(err).To(BeNil())
 
 	_, err = c.Apply(virtualService)
@@ -257,8 +252,7 @@ func TestCache_Clear(t *testing.T) {
 
 func TestCache_GetFileFor_Empty(t *testing.T) {
 	g := NewWithT(t)
-	d, err := os.MkdirTemp(os.TempDir(), t.Name())
-	g.Expect(err).To(BeNil())
+	d := t.TempDir()
 	t.Logf("Test Dir: %q", d)
 
 	c := NewCache(d)
@@ -269,13 +263,12 @@ func TestCache_GetFileFor_Empty(t *testing.T) {
 
 func TestCache_Delete(t *testing.T) {
 	g := NewWithT(t)
-	d, err := os.MkdirTemp(os.TempDir(), t.Name())
-	g.Expect(err).To(BeNil())
+	d := t.TempDir()
 	t.Logf("Test Dir: %q", d)
 
 	c := NewCache(d)
 
-	_, err = c.Apply(gateway)
+	_, err := c.Apply(gateway)
 	g.Expect(err).To(BeNil())
 
 	keys1, err := c.Apply(virtualService)
@@ -300,13 +293,12 @@ func TestCache_Delete(t *testing.T) {
 
 func TestCache_Delete_Missing(t *testing.T) {
 	g := NewWithT(t)
-	d, err := os.MkdirTemp(os.TempDir(), t.Name())
-	g.Expect(err).To(BeNil())
+	d := t.TempDir()
 	t.Logf("Test Dir: %q", d)
 
 	c := NewCache(d)
 
-	_, err = c.Apply(gateway)
+	_, err := c.Apply(gateway)
 	g.Expect(err).To(BeNil())
 
 	err = c.Delete(virtualService)


### PR DESCRIPTION
**Please provide a description of this PR:**
We can write less code by using the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete.

Reference: https://pkg.go.dev/testing#T.TempDir