### PR TITLE
remove feature flag for virtual service delegates

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -352,11 +352,6 @@ var (
 	EnableGatewayAPIDeploymentController = env.RegisterBoolVar("PILOT_ENABLE_GATEWAY_API_DEPLOYMENT_CONTROLLER", true,
 		"If this is set to true, gateway-api resources will automatically provision in cluster deployment, services, etc").Get()
 
-	EnableVirtualServiceDelegate = env.RegisterBoolVar(
-		"PILOT_ENABLE_VIRTUAL_SERVICE_DELEGATE",
-		true,
-		"If set to false, virtualService delegate will not be supported.").Get()
-
 	ClusterName = env.RegisterStringVar("CLUSTER_ID", "Kubernetes",
 		"Defines the cluster and service registry that this Istiod instance is belongs to").Get()
 

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -844,9 +844,6 @@ func (ps *PushContext) VirtualServicesForGateway(proxy *Proxy, gateway string) [
 // DelegateVirtualServicesConfigKey lists all the delegate virtual services configkeys associated with the provided virtual services
 func (ps *PushContext) DelegateVirtualServicesConfigKey(vses []config.Config) []ConfigKey {
 	var out []ConfigKey
-	if !features.EnableVirtualServiceDelegate {
-		return out
-	}
 	for _, vs := range vses {
 		out = append(out, ps.virtualServiceIndex.delegates[ConfigKey{Kind: gvk.VirtualService, Namespace: vs.Namespace, Name: vs.Name}]...)
 	}

--- a/pilot/pkg/model/virtualservice.go
+++ b/pilot/pkg/model/virtualservice.go
@@ -20,7 +20,6 @@ import (
 	"github.com/gogo/protobuf/jsonpb"
 
 	networking "istio.io/api/networking/v1alpha3"
-	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/util/sets"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/constants"
@@ -177,12 +176,6 @@ func mergeVirtualServicesIfNeeded(
 
 		// the others are normal vs without delegate
 		out = append(out, vs)
-	}
-
-	// If `PILOT_ENABLE_VIRTUAL_SERVICE_DELEGATE` feature disabled,
-	// filter out invalid vs(root or delegate), this can happen after enable -> disable
-	if !features.EnableVirtualServiceDelegate {
-		return out, nil
 	}
 
 	delegatesByRoot := make(map[ConfigKey][]ConfigKey, len(rootVses))

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -1986,16 +1986,8 @@ var ValidateVirtualService = registerValidateFunc("ValidateVirtualService",
 			return nil, errors.New("cannot cast to virtual service")
 		}
 		errs := Validation{}
-		isDelegate := false
 		if len(virtualService.Hosts) == 0 {
-			if features.EnableVirtualServiceDelegate {
-				isDelegate = true
-			} else {
-				errs = appendValidation(errs, fmt.Errorf("virtual service must have at least one host"))
-			}
-		}
-
-		if isDelegate {
+			// This must be delegate - enforce delegate validations.
 			if len(virtualService.Gateways) != 0 {
 				// meaningless to specify gateways in delegate
 				errs = appendValidation(errs, fmt.Errorf("delegate virtual service must have no gateways specified"))
@@ -2079,7 +2071,7 @@ var ValidateVirtualService = registerValidateFunc("ValidateVirtualService",
 				errs = appendValidation(errs, errors.New("http route may not be null"))
 				continue
 			}
-			errs = appendValidation(errs, validateHTTPRoute(httpRoute, isDelegate))
+			errs = appendValidation(errs, validateHTTPRoute(httpRoute, len(virtualService.Hosts) == 0))
 		}
 		for _, tlsRoute := range virtualService.Tls {
 			errs = appendValidation(errs, validateTLSRoute(tlsRoute, virtualService))

--- a/pkg/config/validation/virtualservice.go
+++ b/pkg/config/validation/virtualservice.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 
 	networking "istio.io/api/networking/v1alpha3"
-	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pkg/config/labels"
 )
 
@@ -36,14 +35,10 @@ func getHTTPRouteType(http *networking.HTTPRoute, isDelegate bool) HTTPRouteType
 	if isDelegate {
 		return DelegateRoute
 	}
-
-	if features.EnableVirtualServiceDelegate {
-		// root vs's http route
-		if http.Delegate != nil {
-			return RootRoute
-		}
+	// root vs's http route
+	if http.Delegate != nil {
+		return RootRoute
 	}
-
 	return IndependentRoute
 }
 


### PR DESCRIPTION
This has been defaulted to true for more than 3 release and is stable. So removing the feature flag.

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure