### PR TITLE
[release-1.13] run UPDATE_BRANCH=release-1.13 ./bin/update_deps.sh

### DIFF
--- a/docker/Dockerfile.distroless
+++ b/docker/Dockerfile.distroless
@@ -1,5 +1,5 @@
 # prepare a distroless source context to copy files from
-FROM gcr.io/distroless/static-debian11@sha256:1cc74da80bbf80d89c94e0c7fe22830aa617f47643f2db73f66c8bd5bf510b25 as distroless_source
+FROM gcr.io/distroless/static-debian11@sha256:8ad6f3ec70dad966479b9fb48da991138c72ba969859098ec689d1450c2e6c97 as distroless_source
 
 # prepare a base dev to modify file contents
 FROM ubuntu:focal as ubuntu_source

--- a/prow/release-commit.sh
+++ b/prow/release-commit.sh
@@ -32,7 +32,7 @@ DOCKER_HUB=${DOCKER_HUB:-gcr.io/istio-testing}
 GCS_BUCKET=${GCS_BUCKET:-istio-build/dev}
 
 # Use a pinned version in case breaking changes are needed
-BUILDER_SHA=5c13ba8b2b7c5507cd3bd6fa60856dc5c0381694
+BUILDER_SHA=71a490ca5da73534f54d9f7b1d9fae823c0a49cd
 
 # Reference to the next minor version of Istio
 # This will create a version like 1.4-alpha.sha


### PR DESCRIPTION
distroless fixed a CVE recently (we aren't affected, but should update our packages accordingly)