### PR TITLE
fix flake: queue.TestClosed

### DIFF
--- a/pkg/queue/instance_test.go
+++ b/pkg/queue/instance_test.go
@@ -162,11 +162,14 @@ func TestClosed(t *testing.T) {
 			close(stop)
 			return nil
 		})
+		go q.Run(stop)
+		if err := WaitForClose(q, 10*time.Second); err != nil {
+			t.Error()
+		}
 		q.Push(func() error {
 			taskComplete.Store(true)
 			return nil
 		})
-		go q.Run(stop)
 		if taskComplete.Load() {
 			t.Error("task ran on closed queue")
 		}

--- a/pkg/queue/instance_test.go
+++ b/pkg/queue/instance_test.go
@@ -154,21 +154,21 @@ func TestClosed(t *testing.T) {
 			t.Error(err)
 		}
 	})
-	t.Run("close after tasks", func(t *testing.T) {
+	t.Run("no tasks after close", func(t *testing.T) {
 		stop := make(chan struct{})
 		q := NewQueue(0)
 		taskComplete := atomic.NewBool(false)
+		q.Push(func() error {
+			close(stop)
+			return nil
+		})
 		q.Push(func() error {
 			taskComplete.Store(true)
 			return nil
 		})
 		go q.Run(stop)
-		close(stop)
-		if err := WaitForClose(q, 10*time.Second); err != nil {
-			t.Error(err)
-		}
-		if !taskComplete.Load() {
-			t.Error("task did not complete")
+		if taskComplete.Load() {
+			t.Error("task ran on closed queue")
 		}
 	})
 }


### PR DESCRIPTION
fixes #37085 

The way this is written now better matches the impl. 
Older impls would fail this (running 1 more task after close, or trying to drain the queue). 

This should be good enough, and at least it isn't flaky. 

