### PR TITLE
Remove minikube flag from testing infrastructure

### DIFF
--- a/pkg/test/framework/components/environment/kube/flags.go
+++ b/pkg/test/framework/components/environment/kube/flags.go
@@ -60,9 +60,6 @@ func NewSettingsFromCommandLine() (*Settings, error) {
 	}
 
 	s := settingsFromCommandLine.clone()
-	if s.minikube {
-		return nil, fmt.Errorf("istio.test.kube.minikube is deprecated; set --istio.test.kube.loadbalancer=false instead")
-	}
 
 	// Process the kube clusterConfigs.
 	var err error
@@ -264,11 +261,9 @@ var _ config.Value = &configsVal{}
 func init() {
 	flag.StringVar(&kubeConfigs, "istio.test.kube.config", "",
 		"A comma-separated list of paths to kube config files for cluster environments.")
-	flag.BoolVar(&settingsFromCommandLine.minikube, "istio.test.kube.minikube", settingsFromCommandLine.minikube,
-		"Deprecated. See istio.test.kube.loadbalancer. Setting this flag will fail tests.")
 	flag.BoolVar(&settingsFromCommandLine.LoadBalancerSupported, "istio.test.kube.loadbalancer", settingsFromCommandLine.LoadBalancerSupported,
 		"Indicates whether or not clusters in the environment support external IPs for LoadBalaner services. Used "+
-			"to obtain the right IP address for the Ingress Gateway. Set --istio.test.kube.loadbalancer=false for local KinD/minikube tests."+
+			"to obtain the right IP address for the Ingress Gateway. Set --istio.test.kube.loadbalancer=false for local KinD tests."+
 			"without MetalLB installed.")
 	flag.StringVar(&controlPlaneTopology, "istio.test.kube.controlPlaneTopology",
 		"", "Specifies the mapping for each cluster to the cluster hosting its control plane. The value is a "+

--- a/pkg/test/framework/components/environment/kube/settings.go
+++ b/pkg/test/framework/components/environment/kube/settings.go
@@ -40,10 +40,6 @@ type Settings struct {
 	// An array of paths to kube config files. Required if the environment is kubernetes.
 	KubeConfig []string
 
-	// Indicates that the Ingress Gateway is not available. This typically happens in minikube. The Ingress
-	// component will fall back to node-port in this case.
-	minikube bool
-
 	// Indicates that the LoadBalancer services can obtain a public IP. If not, NodePort be used as a workaround
 	// for ingress gateway. KinD will not support LoadBalancer out of the box and requires a workaround such as
 	// MetalLB.

--- a/tests/integration/tests.mk
+++ b/tests/integration/tests.mk
@@ -12,11 +12,7 @@ ifneq ($(CI),)
 	_INTEGRATION_TEST_FLAGS += --istio.test.pullpolicy=IfNotPresent
 endif
 
-ifeq ($(TEST_ENV),minikube)
-    _INTEGRATION_TEST_FLAGS += --istio.test.kube.loadbalancer=false
-else ifeq ($(TEST_ENV),minikube-none)
-    _INTEGRATION_TEST_FLAGS += --istio.test.kube.loadbalancer=false
-else ifeq ($(TEST_ENV),kind)
+ifeq ($(TEST_ENV),kind)
     _INTEGRATION_TEST_FLAGS += --istio.test.kube.loadbalancer=false
 endif
 


### PR DESCRIPTION
**Please provide a description of this PR:**

Flag has been deprecated for a while and hasn't been used. Remove it.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [X] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
