### PR TITLE
Break instead of return on empty resources at xds proxy.

### DIFF
--- a/pkg/istio-agent/xds_proxy.go
+++ b/pkg/istio-agent/xds_proxy.go
@@ -503,7 +503,7 @@ func (p *XdsProxy) handleUpstreamResponse(con *ProxyConnection) {
 				if len(resp.Resources) == 0 {
 					// Empty response, nothing to do
 					// This assumes internal types are always singleton
-					return
+					break
 				}
 				err := h(resp.Resources[0])
 				var errorResp *google_rpc.Status

--- a/pkg/istio-agent/xds_proxy_delta.go
+++ b/pkg/istio-agent/xds_proxy_delta.go
@@ -221,7 +221,7 @@ func (p *XdsProxy) handleUpstreamDeltaResponse(con *ProxyConnection) {
 				if len(resp.Resources) == 0 {
 					// Empty response, nothing to do
 					// This assumes internal types are always singleton
-					return
+					break
 				}
 				err := h(resp.Resources[0].Resource)
 				var errorResp *google_rpc.Status


### PR DESCRIPTION
Otherwise xds proxy will just stop if for some reason control plane is passing empty resource, which is catastrophic. 