### PR TITLE
log error when webhook patching fails

### DIFF
--- a/pkg/webhooks/webhookpatch.go
+++ b/pkg/webhooks/webhookpatch.go
@@ -108,6 +108,7 @@ func (w *WebhookCertPatcher) webhookPatchTask(o types.NamespacedName) error {
 	}
 
 	if err != nil {
+		log.Errorf("patching webhook %s failed: %v", o.Name, err)
 		reportWebhookPatchRetry(o.Name)
 	}
 


### PR DESCRIPTION
We used to log this error - some how got missed with recent changes.