### PR TITLE
Output message with explanation when using --save

### DIFF
--- a/tools/docker-builder/main.go
+++ b/tools/docker-builder/main.go
@@ -126,7 +126,7 @@ func createBuildxBuilderIfNeeded(a Args) error {
 		if !a.Save {
 			return nil
 		}
-		// --save is specifed so verify if the current builder's driver is `docker-container` (needed to satisfy the export)
+		// --save is specified so verify if the current builder's driver is `docker-container` (needed to satisfy the export)
 		// This is typically used when running release-builder locally.
 		// Output an error message telling the user how to create a builder with the correct driver.
 		c := VerboseCommand("docker", "buildx", "ls") // get current builder
@@ -139,13 +139,13 @@ func createBuildxBuilderIfNeeded(a Args) error {
 		scanner := bufio.NewScanner(out)
 		for scanner.Scan() {
 			line := scanner.Text()
-			if strings.Split(string(line), " ")[1] == "*" { // This is the default builder
-				if strings.Split(string(line), " ")[3] == "docker-container" { // if using docker-container driver
+			if strings.Split(line, " ")[1] == "*" { // This is the default builder
+				if strings.Split(line, " ")[3] == "docker-container" { // if using docker-container driver
 					return nil // current builder will work for --save
-				} else {
-					return fmt.Errorf("The docker buildx builder is not using the docker-container driver needed for .save.\n" +
-						"Create a new builder (ex: docker buildx create --driver-opt network=host,image=gcr.io/istio-testing/buildkit:v0.9.2 --name istio-builder --driver docker-container --buildkitd-flags=\"--debug\" --use)")
 				}
+				return fmt.Errorf("the docker buildx builder is not using the docker-container driver needed for .save.\n" +
+					"Create a new builder (ex: docker buildx create --driver-opt network=host,image=gcr.io/istio-testing/buildkit:v0.9.2" +
+					" --name istio-builder --driver docker-container --buildkitd-flags=\"--debug\" --use)")
 			}
 		}
 	}


### PR DESCRIPTION
**Please provide a description of this PR:**

Fixes https://github.com/istio/istio/issues/37069

In the past, the user would see:
```
022-01-28T14:39:07.101176Z	info	Running command: docker buildx bake -f /tmp/istio-release/work/src/istio.io/istio/out/linux_amd64/dockerx_build/docker-bake.json all
[+] Building 0.0s (0/0)
error: Docker exporter feature is currently not supported for docker driver. Please switch to a different driver (eg. "docker buildx create --use")
Error: exit status 1
make[1]: *** [tools/istio-docker.mk:379: dockerx.save] Error 255
make[1]: Leaving directory '/tmp/istio-release/work/src/istio.io/istio'
Error: failed to build: failed to build Docker: failed to create istio docker archives: exit status 2
exit status 1
```
This change helps explain the issue, hopefully in a better way. New output:
```
nt /work/out/linux_amd64/dockerx_build/build.docker.install-cni
2022-02-03T19:12:19.043952Z	info	Running command: docker buildx ls
Error: The docker buildx builder is not using the docker-container driver needed for .save.
Create a new builder (ex: docker buildx create --driver-opt network=host,image=gcr.io/istio-testing/buildkit:v0.9.2 --name istio-builder --driver docker-container --buildkitd-flags="--debug" --use)
make[1]: *** [tools/istio-docker.mk:40: docker.save] Error 255
make: *** [docker.save] Error 2
```