### PR TITLE
Fix IPv6 detection for EKS

### DIFF
--- a/pilot/pkg/util/network/ip.go
+++ b/pilot/pkg/util/network/ip.go
@@ -81,7 +81,7 @@ func getPrivateIPsIfAvailable() ([]string, bool) {
 			case *net.IPAddr:
 				ip = v.IP
 			}
-			if ip == nil || ip.IsLoopback() {
+			if ip == nil || ip.IsLoopback() || ip.IsLinkLocalUnicast() {
 				continue
 			}
 			if ip.IsUnspecified() {

--- a/pilot/pkg/util/network/ip.go
+++ b/pilot/pkg/util/network/ip.go
@@ -81,7 +81,7 @@ func getPrivateIPsIfAvailable() ([]string, bool) {
 			case *net.IPAddr:
 				ip = v.IP
 			}
-			if ip == nil || ip.IsLoopback() || ip.IsLinkLocalUnicast() {
+			if ip == nil || ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
 				continue
 			}
 			if ip.IsUnspecified() {

--- a/releasenotes/notes/fix-eks-ipv6.yaml
+++ b/releasenotes/notes/fix-eks-ipv6.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 36961
+releaseNotes:
+  - |
+    **Fixed** IPv6 detection on clusters with IPv4 NAT implementation, such as Amazon EKS, by excluding link-local addresses from detection.

--- a/tools/istio-iptables/pkg/cmd/root.go
+++ b/tools/istio-iptables/pkg/cmd/root.go
@@ -177,7 +177,7 @@ func getLocalIP() (net.IP, error) {
 	}
 
 	for _, a := range addrs {
-		if ipnet, ok := a.(*net.IPNet); ok && !ipnet.IP.IsLoopback() {
+		if ipnet, ok := a.(*net.IPNet); ok && !ipnet.IP.IsLoopback() && !ipnet.IP.IsLinkLocalUnicast() {
 			return ipnet.IP, nil
 		}
 	}

--- a/tools/istio-iptables/pkg/cmd/root.go
+++ b/tools/istio-iptables/pkg/cmd/root.go
@@ -177,7 +177,7 @@ func getLocalIP() (net.IP, error) {
 	}
 
 	for _, a := range addrs {
-		if ipnet, ok := a.(*net.IPNet); ok && !ipnet.IP.IsLoopback() && !ipnet.IP.IsLinkLocalUnicast() {
+		if ipnet, ok := a.(*net.IPNet); ok && !ipnet.IP.IsLoopback() && !ipnet.IP.IsLinkLocalUnicast() && !ipnet.IP.IsLinkLocalMulticast() {
 			return ipnet.IP, nil
 		}
 	}


### PR DESCRIPTION
**Please provide a description of this PR:**

EKS clusters on IPv6 map a host-local NAT interface to each pod for IPv4 egress. For that the pod will be assigned an IP from the link-local reserved CIDR range (more specifcally, from `169.254.172.0/22`) that is unique only to the host. These IPs are not advertised to Kubernetes in any way, they are just available within the pod as the `v4if0` network interface. For proper IPv6 detection we need to exclude these IPs from the discovery mechanisms, otherwise Istio thinks that it is in an IPv4 cluster when it sees this network interface.

More details on the EKS IPv6 networking can be found in the [official blog post](https://aws.amazon.com/de/blogs/containers/amazon-eks-launches-ipv6-support/).

Unfortunately, I did not find existing tests for this code - if there are any that I have overlooked do let me know and I will update the pull request accordingly.

Fixes #36961.