### PR TITLE
Fix local IP discovery in CNI

### DIFF
--- a/cni/pkg/plugin/iptables.go
+++ b/cni/pkg/plugin/iptables.go
@@ -31,6 +31,9 @@ import (
 var dryRunFilePath = env.RegisterStringVar("DRY_RUN_FILE_PATH", "",
 	"If provided, CNI will dry run iptables rule apply, and print the applied rules to the given file.")
 
+// getNs is a unit test override variable for interface create.
+var getNs = ns.GetNS
+
 type iptables struct{}
 
 func newIPTables() InterceptRuleMgr {
@@ -59,7 +62,7 @@ func (ipt *iptables) Program(podName, netns string, rdrct *Redirect) error {
 	viper.Set(constants.CaptureAllDNS, rdrct.dnsRedirect)
 	viper.Set(constants.DropInvalid, rdrct.invalidDrop)
 
-	netNs, err := ns.GetNS(netns)
+	netNs, err := getNs(netns)
 	if err != nil {
 		err = fmt.Errorf("failed to open netns %q: %s", netns, err)
 		return err

--- a/cni/pkg/plugin/iptables.go
+++ b/cni/pkg/plugin/iptables.go
@@ -18,9 +18,9 @@ package plugin
 
 import (
 	"fmt"
-	"github.com/spf13/viper"
 
 	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/spf13/viper"
 
 	"istio.io/istio/tools/istio-iptables/pkg/cmd"
 	"istio.io/istio/tools/istio-iptables/pkg/constants"

--- a/cni/pkg/plugin/plugin_dryrun_test.go
+++ b/cni/pkg/plugin/plugin_dryrun_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/containernetworking/cni/pkg/skel"
+	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/containernetworking/plugins/pkg/testutils"
 	"k8s.io/client-go/kubernetes"
 
@@ -40,6 +41,38 @@ type k8sPodInfoFunc func(*kubernetes.Clientset, string, string) (*PodInfo, error
 func generateMockK8sPodInfoFunc(pi *PodInfo) k8sPodInfoFunc {
 	return func(_ *kubernetes.Clientset, _, _ string) (*PodInfo, error) {
 		return pi, nil
+	}
+}
+
+type mockNetNs struct {
+	path string
+}
+
+func (ns *mockNetNs) Do(toRun func(ns.NetNS) error) error {
+	return toRun(ns)
+}
+
+func (*mockNetNs) Set() error {
+	return nil
+}
+
+func (ns *mockNetNs) Path() string {
+	return ns.path
+}
+
+func (*mockNetNs) Fd() uintptr {
+	return 0
+}
+
+func (*mockNetNs) Close() error {
+	return nil
+}
+
+type netNsFunc func(nspath string) (ns.NetNS, error)
+
+func generateMockGetNsFunc(netNs string) netNsFunc {
+	return func(nspath string) (ns.NetNS, error) {
+		return &mockNetNs{path: netNs}, nil
 	}
 }
 
@@ -131,6 +164,7 @@ func TestIPTablesRuleGeneration(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// TODO(bianpengyuan): How do we test ipv6 rules?
 			getKubePodInfo = generateMockK8sPodInfoFunc(tt.input)
+			getNs = generateMockGetNsFunc(sandboxDirectory)
 			tmpDir := t.TempDir()
 			outputFilePath := filepath.Join(tmpDir, "output.txt")
 			if _, err := os.Create(outputFilePath); err != nil {

--- a/releasenotes/notes/fix-cni-ipv6-detection.yaml
+++ b/releasenotes/notes/fix-cni-ipv6-detection.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 36871
+releaseNotes:
+  - |
+    **Fixed** IP family detection when using the CNI to behave the same way as without it.


### PR DESCRIPTION
**Please provide a description of this PR:**

Currently there is a disparity in IP detection when using the CNI vs. regular usage of the proxy. Since the latter runs on the host, IP detection will also be based on the host network (vs the pod network interfaces for the latter). This is for example an issue when you have dual-stack hosts, but a single-stack IPv6 cluster. In this case the CNI should setup for IPv6, but instead thinks it is running on an IPv4 cluster. A prominent example of this is EKS in IPv6 mode.

This change will make the CNI run its iptables code in the pod network namespace, just like it would when running without the CNI.

Fixes #36871.