### PR TITLE
Add option to replace Round Robin LB with Least Request

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -278,6 +278,14 @@ var (
 			"ENABLE_MCS_HOST also be enabled.").Get() &&
 		EnableMCSHost
 
+	EnableBetterLoadBalancing = env.RegisterBoolVar(
+		"ENABLE_BETTER_LOAD_BALANCING",
+		false,
+		"If enabled, Istio will replace any configuration using ROUND_ROBIN load balancing (the default) "+
+			"with LEAST_CONN (least request), which performs strictly better than round robin and is more safe for "+
+			"general use, in particular when weighting is used.",
+	).Get()
+
 	EnableAnalysis = env.RegisterBoolVar(
 		"PILOT_ENABLE_ANALYSIS",
 		false,

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -726,12 +726,16 @@ func applyLoadBalancer(c *cluster.Cluster, lb *networking.LoadBalancerSettings, 
 
 	// DO not do if else here. since lb.GetSimple returns a enum value (not pointer).
 	switch lb.GetSimple() {
+	case networking.LoadBalancerSettings_ROUND_ROBIN:
+		if features.EnableBetterLoadBalancing {
+			c.LbPolicy = cluster.Cluster_LEAST_REQUEST
+		} else {
+			c.LbPolicy = cluster.Cluster_ROUND_ROBIN
+		}
 	case networking.LoadBalancerSettings_LEAST_CONN:
 		c.LbPolicy = cluster.Cluster_LEAST_REQUEST
 	case networking.LoadBalancerSettings_RANDOM:
 		c.LbPolicy = cluster.Cluster_RANDOM
-	case networking.LoadBalancerSettings_ROUND_ROBIN:
-		c.LbPolicy = cluster.Cluster_ROUND_ROBIN
 	case networking.LoadBalancerSettings_PASSTHROUGH:
 		c.LbPolicy = cluster.Cluster_CLUSTER_PROVIDED
 		c.ClusterDiscoveryType = &cluster.Cluster_Type{Type: cluster.Cluster_ORIGINAL_DST}

--- a/tests/integration/iop-integration-test-defaults-with-quic.yaml
+++ b/tests/integration/iop-integration-test-defaults-with-quic.yaml
@@ -61,6 +61,7 @@ spec:
       env:
         UNSAFE_ENABLE_ADMIN_ENDPOINTS: true
         PILOT_REMOTE_CLUSTER_TIMEOUT: 15s
+        ENABLE_BETTER_LOAD_BALANCING: true
         PILOT_ENABLE_QUIC_LISTENERS: true
 
     gateways:

--- a/tests/integration/iop-integration-test-defaults.yaml
+++ b/tests/integration/iop-integration-test-defaults.yaml
@@ -57,6 +57,7 @@ spec:
       env:
         UNSAFE_ENABLE_ADMIN_ENDPOINTS: true
         PILOT_REMOTE_CLUSTER_TIMEOUT: 15s
+        ENABLE_BETTER_LOAD_BALANCING: true
 
     gateways:
       istio-ingressgateway:


### PR DESCRIPTION
This is the first part of the work described in [Better Load Balancing by Default](https://docs.google.com/document/d/1SspUSsOt2GXWmSl8EmyVuvXROIHLAkD6XkcUsmw1y7w/edit?resourcekey=0-kXCZGVsqypEE9YZB5lVOFw#heading=h.xw1gqgyqs5b).

Various comparisons have shown Least Request (LEAST_CONN) LB to be strictly better and safer than Round Robin. With this change, LR will always be used instead of RR in all cases except gRPC, which does not currently support LR.

This option is expected to eventually be enabled by default (likely in the next release).

**Please provide a description of this PR:**