### PR TITLE
Do not read from stdin directly

### DIFF
--- a/istioctl/cmd/tag_test.go
+++ b/istioctl/cmd/tag_test.go
@@ -21,6 +21,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/pflag"
+	"istio.io/pkg/log"
 	admit_v1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -274,8 +276,9 @@ func TestRemoveTag(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			var out bytes.Buffer
+			var in bytes.Buffer
 			client := fake.NewSimpleClientset(tc.webhooksBefore.DeepCopyObject(), tc.namespaces.DeepCopyObject())
-			err := removeTag(context.Background(), client, tc.tag, tc.skipConfirmation, &out)
+			err := removeTag(context.Background(), client, tc.tag, tc.skipConfirmation, &out, &in)
 			if tc.error == "" && err != nil {
 				t.Fatalf("expected no error, got %v", err)
 			}

--- a/istioctl/cmd/tag_test.go
+++ b/istioctl/cmd/tag_test.go
@@ -21,8 +21,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/spf13/pflag"
-	"istio.io/pkg/log"
 	admit_v1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/istioctl/cmd/testdata/v1alpha3/.gitignore
+++ b/istioctl/cmd/testdata/v1alpha3/.gitignore
@@ -1,2 +1,0 @@
-# Only keep .golden files
-*.yaml

--- a/istioctl/cmd/testdata/vmconfig-nil-proxy-metadata/.gitignore
+++ b/istioctl/cmd/testdata/vmconfig-nil-proxy-metadata/.gitignore
@@ -1,6 +1,0 @@
-# Only keep golden and input files
-hosts
-istio-token
-mesh.yaml
-root-cert.pem
-cluster.env

--- a/istioctl/cmd/testdata/vmconfig/.gitignore
+++ b/istioctl/cmd/testdata/vmconfig/.gitignore
@@ -1,6 +1,0 @@
-# Only keep golden and input files
-../vmconfig-nil-proxy-metadata/hosts
-istio-token
-mesh.yaml
-root-cert.pem
-cluster.env

--- a/istioctl/cmd/testdata/vmconfig/simple/.gitignore
+++ b/istioctl/cmd/testdata/vmconfig/simple/.gitignore
@@ -1,6 +1,0 @@
-# Only keep golden and input files
-hosts
-istio-token
-mesh.yaml
-root-cert.pem
-cluster.env


### PR DESCRIPTION
In tests this sometimes means we hang forever

Also change WE tests to write to temp folders. This avoids race conditions between iterations of the tests (write same file is not safe), and avoids need for gitignore files

**Please provide a description of this PR:**