### PR TITLE
Update release-builder dep + others (-proxy)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -245,7 +245,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.66.2 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
-	istio.io/gogo-genproto v0.0.0-20211208193508-5ab4acc9eb1e // indirect
+	istio.io/gogo-genproto v0.0.0-20220203154911-542602f9bf4f // indirect
 	k8s.io/component-base v0.23.3 // indirect
 	sigs.k8s.io/json v0.0.0-20211020170558-c049b76a60c6 // indirect
 	sigs.k8s.io/kustomize/api v0.10.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -87,7 +87,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	helm.sh/helm/v3 v3.8.0
 	istio.io/api v0.0.0-20220207030416-a6aeb68ad2d9
-	istio.io/client-go v1.12.0-alpha.5.0.20220131165747-51ff28692b8a
+	istio.io/client-go v1.12.0-alpha.5.0.20220203164518-4649c29f2df4
 	istio.io/pkg v0.0.0-20220203154910-aa99fc270afc
 	k8s.io/api v0.23.3
 	k8s.io/apiextensions-apiserver v0.23.1

--- a/go.sum
+++ b/go.sum
@@ -2145,6 +2145,8 @@ istio.io/client-go v1.12.0-alpha.5.0.20220131165747-51ff28692b8a h1:dLrES8FWniJq
 istio.io/client-go v1.12.0-alpha.5.0.20220131165747-51ff28692b8a/go.mod h1:NamWMvM0EVhP7NykoqZymZVmyOIGfG1X5Dk0k6B7vBU=
 istio.io/gogo-genproto v0.0.0-20211208193508-5ab4acc9eb1e h1:z2WI3y55w0K3c6hmarcp5EcOiP4vVpTBXA8nYstP+cE=
 istio.io/gogo-genproto v0.0.0-20211208193508-5ab4acc9eb1e/go.mod h1:vJDAniIqryf/z///fgZqVPKJ7N2lBk7Gg8DCTB7oCfU=
+istio.io/gogo-genproto v0.0.0-20220203154911-542602f9bf4f h1:Qz/sQH9I2u8XfasvCNWmdMdjRendJc1gKi5NkLCpS5g=
+istio.io/gogo-genproto v0.0.0-20220203154911-542602f9bf4f/go.mod h1:vJDAniIqryf/z///fgZqVPKJ7N2lBk7Gg8DCTB7oCfU=
 istio.io/pkg v0.0.0-20220203154910-aa99fc270afc h1:DoWxXPqlpaztQ5ZPMtHGCnGrA1drPL6opc/0e+LZwf0=
 istio.io/pkg v0.0.0-20220203154910-aa99fc270afc/go.mod h1:i95AmfHLCp5JThoiCGCyzZ6bOHJk5fD+BicBvGDr9Xg=
 k8s.io/api v0.18.2/go.mod h1:SJCWI7OLzhZSvbY7U8zwNl9UA4o1fizoug34OV/2r78=

--- a/go.sum
+++ b/go.sum
@@ -2138,12 +2138,11 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
-istio.io/api v0.0.0-20220131164128-92d21b0b869d/go.mod h1:8ZZgyVgYrHhsFQarEgTfPnMGpdgTDZbxSjYhdwTUuAQ=
+istio.io/api v0.0.0-20220203163703-135c864f3866/go.mod h1:8ZZgyVgYrHhsFQarEgTfPnMGpdgTDZbxSjYhdwTUuAQ=
 istio.io/api v0.0.0-20220207030416-a6aeb68ad2d9 h1:IyHNQElSS1fF9EUJMZKEbuY4DYHWfMdJlGMxTP4SiiY=
 istio.io/api v0.0.0-20220207030416-a6aeb68ad2d9/go.mod h1:8ZZgyVgYrHhsFQarEgTfPnMGpdgTDZbxSjYhdwTUuAQ=
-istio.io/client-go v1.12.0-alpha.5.0.20220131165747-51ff28692b8a h1:dLrES8FWniJq+DkOMMXsvGhttvd4cNiT6eEDf9e8THQ=
-istio.io/client-go v1.12.0-alpha.5.0.20220131165747-51ff28692b8a/go.mod h1:NamWMvM0EVhP7NykoqZymZVmyOIGfG1X5Dk0k6B7vBU=
-istio.io/gogo-genproto v0.0.0-20211208193508-5ab4acc9eb1e h1:z2WI3y55w0K3c6hmarcp5EcOiP4vVpTBXA8nYstP+cE=
+istio.io/client-go v1.12.0-alpha.5.0.20220203164518-4649c29f2df4 h1:IU2bM9ITqHAeHM3zSz+KbkROV7LkFoU5mjUwcJWytBs=
+istio.io/client-go v1.12.0-alpha.5.0.20220203164518-4649c29f2df4/go.mod h1:aPDIAfOEDUctTZx4O+CwyAIPrbY5bViitTYVz340SPc=
 istio.io/gogo-genproto v0.0.0-20211208193508-5ab4acc9eb1e/go.mod h1:vJDAniIqryf/z///fgZqVPKJ7N2lBk7Gg8DCTB7oCfU=
 istio.io/gogo-genproto v0.0.0-20220203154911-542602f9bf4f h1:Qz/sQH9I2u8XfasvCNWmdMdjRendJc1gKi5NkLCpS5g=
 istio.io/gogo-genproto v0.0.0-20220203154911-542602f9bf4f/go.mod h1:vJDAniIqryf/z///fgZqVPKJ7N2lBk7Gg8DCTB7oCfU=

--- a/prow/release-commit.sh
+++ b/prow/release-commit.sh
@@ -32,7 +32,7 @@ DOCKER_HUB=${DOCKER_HUB:-gcr.io/istio-testing}
 GCS_BUCKET=${GCS_BUCKET:-istio-build/dev}
 
 # Use a pinned version in case breaking changes are needed
-BUILDER_SHA=48a3d9a351c40a7afd4da2767c305861f50f5f43
+BUILDER_SHA=1e0e0905de03fd56959c71e4b6ec9b4676ca33f3
 
 # Reference to the next minor version of Istio
 # This will create a version like 1.4-alpha.sha

--- a/prow/release-commit.sh
+++ b/prow/release-commit.sh
@@ -32,7 +32,7 @@ DOCKER_HUB=${DOCKER_HUB:-gcr.io/istio-testing}
 GCS_BUCKET=${GCS_BUCKET:-istio-build/dev}
 
 # Use a pinned version in case breaking changes are needed
-BUILDER_SHA=1e0e0905de03fd56959c71e4b6ec9b4676ca33f3
+BUILDER_SHA=601aab5c9e10c618362a80a14c521fbc1537c0db
 
 # Reference to the next minor version of Istio
 # This will create a version like 1.4-alpha.sha


### PR DESCRIPTION
**Please provide a description of this PR:**

The new _release-builder_ commit will generate Bill of Materials. Grab the latest of the other deps minus proxy whose latest release doesn't work.