### PR TITLE
Add env to configure the RSA key size of workload certificates

### DIFF
--- a/pilot/cmd/pilot-agent/options/options.go
+++ b/pilot/cmd/pilot-agent/options/options.go
@@ -75,6 +75,8 @@ var (
 
 	secretRotationGracePeriodRatioEnv = env.RegisterFloatVar("SECRET_GRACE_PERIOD_RATIO", 0.5,
 		"The grace period ratio for the cert rotation, by default 0.5.").Get()
+	workloadRSAKeySizeEnv = env.RegisterIntVar("WORKLOAD_RSA_KEY_SIZE", 2048,
+		"Specify the RSA key size to use for workload certificates.").Get()
 	pkcs8KeysEnv = env.RegisterBoolVar("PKCS8_KEY", false,
 		"Whether to generate PKCS#8 private keys").Get()
 	eccSigAlgEnv        = env.RegisterStringVar("ECC_SIGNATURE_ALGORITHM", "", "The type of ECC signature algorithm to use when generating private keys").Get()

--- a/pilot/cmd/pilot-agent/options/security.go
+++ b/pilot/cmd/pilot-agent/options/security.go
@@ -47,6 +47,7 @@ func NewSecurityOptions(proxyConfig *meshconfig.ProxyConfig, stsPort int, tokenM
 		ServiceAccount:                 serviceAccountVar.Get(),
 		XdsAuthProvider:                xdsAuthProvider.Get(),
 		TrustDomain:                    trustDomainEnv,
+		WorkloadRSAKeySize:             workloadRSAKeySizeEnv,
 		Pkcs8Keys:                      pkcs8KeysEnv,
 		ECCSigAlg:                      eccSigAlgEnv,
 		SecretTTL:                      secretTTLEnv,

--- a/pkg/istio-agent/agent_test.go
+++ b/pkg/istio-agent/agent_test.go
@@ -99,6 +99,7 @@ func TestAgent(t *testing.T) {
 		// All of the other tests use ECC for speed. Here we make sure RSA still works
 		Setup(t, func(a AgentTest) AgentTest {
 			a.Security.ECCSigAlg = ""
+			a.Security.WorkloadRSAKeySize = 2048
 			return a
 		}).Check(t, security.WorkloadKeyCertResourceName, security.RootCertReqResourceName)
 	})

--- a/pkg/security/security.go
+++ b/pkg/security/security.go
@@ -133,6 +133,9 @@ type Options struct {
 	// https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE-ID.md#21-trust-domain
 	TrustDomain string
 
+	// WorkloadRSAKeySize is the size of a private key for a workload certificate.
+	WorkloadRSAKeySize int
+
 	// Whether to generate PKCS#8 private keys.
 	Pkcs8Keys bool
 

--- a/releasenotes/notes/env-workload-rsa-keysize.yaml
+++ b/releasenotes/notes/env-workload-rsa-keysize.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: security
+releaseNotes:
+- |
+  **Added** an environment variable for configuring the RSA key size of workload certificates.

--- a/security/pkg/nodeagent/cache/secretcache.go
+++ b/security/pkg/nodeagent/cache/secretcache.go
@@ -45,9 +45,6 @@ var (
 )
 
 const (
-	// The size of a private key for a leaf certificate.
-	keySize = 2048
-
 	// firstRetryBackOffInMilliSec is the initial backoff time interval when hitting
 	// non-retryable error in CSR request or while there is an error in reading file mounts.
 	firstRetryBackOffInMilliSec = 50
@@ -560,7 +557,7 @@ func (sc *SecretManagerClient) generateNewSecret(resourceName string) (*security
 	cacheLog.Debugf("constructed host name for CSR: %s", csrHostName.String())
 	options := pkiutil.CertOptions{
 		Host:       csrHostName.String(),
-		RSAKeySize: keySize,
+		RSAKeySize: sc.configOptions.WorkloadRSAKeySize,
 		PKCS8Key:   sc.configOptions.Pkcs8Keys,
 		ECSigAlg:   pkiutil.SupportedECSignatureAlgorithms(sc.configOptions.ECCSigAlg),
 	}

--- a/security/pkg/nodeagent/cache/secretcache_test.go
+++ b/security/pkg/nodeagent/cache/secretcache_test.go
@@ -69,7 +69,7 @@ func testWorkloadAgentGenerateSecret(t *testing.T, isUsingPluginProvider bool) {
 		opt.TokenExchanger = fakePlugin
 	}
 
-	sc := createCache(t, fakeCACli, func(resourceName string) {}, security.Options{})
+	sc := createCache(t, fakeCACli, func(resourceName string) {}, security.Options{WorkloadRSAKeySize: 2048})
 	gotSecret, err := sc.GenerateSecret(security.WorkloadKeyCertResourceName)
 	if err != nil {
 		t.Fatalf("Failed to get secrets: %v", err)
@@ -151,7 +151,7 @@ func TestWorkloadAgentRefreshSecret(t *testing.T) {
 		t.Fatalf("Error creating Mock CA client: %v", err)
 	}
 	u := NewUpdateTracker(t)
-	sc := createCache(t, fakeCACli, u.Callback, security.Options{})
+	sc := createCache(t, fakeCACli, u.Callback, security.Options{WorkloadRSAKeySize: 2048})
 
 	_, err = sc.GenerateSecret(security.WorkloadKeyCertResourceName)
 	if err != nil {
@@ -552,7 +552,7 @@ func TestProxyConfigAnchors(t *testing.T) {
 	}
 	u := NewUpdateTracker(t)
 
-	sc := createCache(t, fakeCACli, u.Callback, security.Options{})
+	sc := createCache(t, fakeCACli, u.Callback, security.Options{WorkloadRSAKeySize: 2048})
 	_, err = sc.GenerateSecret(security.WorkloadKeyCertResourceName)
 	if err != nil {
 		t.Errorf("failed to generate certificate for trustAnchor test case")
@@ -666,7 +666,7 @@ func TestOSCACertGenerateSecretEmpty(t *testing.T) {
 	fakePlugin := mock.NewMockTokenExchangeServer(nil)
 	opt.TokenExchanger = fakePlugin
 
-	sc := createCache(t, fakeCACli, func(resourceName string) {}, security.Options{})
+	sc := createCache(t, fakeCACli, func(resourceName string) {}, security.Options{WorkloadRSAKeySize: 2048})
 	certPath := security.GetOSRootFilePath()
 	expected, err := sc.GenerateSecret("file-root:" + certPath)
 	if err != nil {


### PR DESCRIPTION
This PR adds a new env, "WORKLOAD_RSA_KEY_SIZE" to make the RSA key size of workload certificates configurable. Note that there is already a similar env for configuring the RSA key size of self-signed CA. Both of these default to 2048 bits. Users who prefer to have a higher key size for better security can benefit from this env.