### PR TITLE
Skip flaky TestWait

### DIFF
--- a/tests/integration/pilot/istioctl_test.go
+++ b/tests/integration/pilot/istioctl_test.go
@@ -65,6 +65,7 @@ Next Step: Add related labels to the deployment to align with Istio's requiremen
 )
 
 func TestWait(t *testing.T) {
+	t.Skip("https://github.com/istio/istio/issues/29315")
 	framework.NewTest(t).Features("usability.observability.wait").
 		RequiresSingleCluster().
 		RequiresLocalControlPlane().


### PR DESCRIPTION
See https://github.com/istio/istio/issues/29315. This is flaky and known
to be a real bug in an experimental feature. Disable until fixed.
Note: this is flaky enough that even on jobs where we retry jobs, it sometimes fails _both times_: https://prow.istio.io/view/gs/istio-prow/logs/integ-k8s-120_istio_postsubmit/1490698318555123712. So I think worth skipping for now.