### PR TITLE
Only setup the credentials if there is one

### DIFF
--- a/prow/lib.sh
+++ b/prow/lib.sh
@@ -41,6 +41,11 @@ function trace() {
 }
 
 function setup_gcloud_credentials() {
+  # Only setup the credentials if there is one
+  if [[ -z "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
+    return
+  fi
+
   if [[ $(command -v gcloud) ]]; then
     gcloud auth configure-docker -q
   elif [[ $(command -v docker-credential-gcr) ]]; then


### PR DESCRIPTION
Otherwise the credential helpers will be installed globally and this
might mess with pulls from `gcr.io`.