### PR TITLE
Revert "Only setup the credentials if there is one"

### DIFF
--- a/prow/lib.sh
+++ b/prow/lib.sh
@@ -41,11 +41,6 @@ function trace() {
 }
 
 function setup_gcloud_credentials() {
-  # Only setup the credentials if there is one
-  if [[ -z "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
-    return
-  fi
-
   if [[ $(command -v gcloud) ]]; then
     gcloud auth configure-docker -q
   elif [[ $(command -v docker-credential-gcr) ]]; then


### PR DESCRIPTION
Reverts istio/istio#37219

This broke releases https://prow.istio.io/view/gs/istio-prow/logs/release_istio_postsubmit/1491187672352296960.

I think we now use workload identity, so we need some other check I guess