### PR TITLE
Use stable name for dumping

### DIFF
--- a/pkg/test/kube/dump.go
+++ b/pkg/test/kube/dump.go
@@ -51,7 +51,7 @@ func podOutputPath(workDir string, cluster cluster.Cluster, pod corev1.Pod, dump
 
 // outputPath gives a path in the form of workDir/cluster/<prefix>_<suffix>
 func outputPath(workDir string, cluster cluster.Cluster, prefix, suffix string) string {
-	dir := path.Join(workDir, cluster.Name())
+	dir := path.Join(workDir, cluster.StableName())
 	if err := os.MkdirAll(dir, os.ModeDir|0o700); err != nil {
 		scopes.Framework.Warnf("failed creating directory: %s", dir)
 	}


### PR DESCRIPTION
Currently we use the real cluster name. This is hard to debug, as we
will see a test like `from_primary-1`, but then folder is
`foo-cluster-1236`. We may not know which is which.

Granted, there may be cases the opposite is true. However, I think its less likely and the test logs do show the mapping so its still possible