### PR TITLE
[1.11] istioctl: fix order dependant tests (#37045)

### DIFF
--- a/cni/pkg/plugin/plugin_test.go
+++ b/cni/pkg/plugin/plugin_test.go
@@ -427,6 +427,8 @@ func TestCmdAddInvalidK8sArgsKeyword(t *testing.T) {
 }
 
 func TestCmdAddInvalidVersion(t *testing.T) {
+	defer resetGlobalTestVariables()
+	getKubePodInfo = mockgetK8sPodInfo
 	testCmdInvalidVersion(t, CmdAdd)
 }
 

--- a/istioctl/cmd/tag_test.go
+++ b/istioctl/cmd/tag_test.go
@@ -199,6 +199,7 @@ func TestTagList(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			var out bytes.Buffer
 			client := fake.NewSimpleClientset(tc.webhooks.DeepCopyObject(), tc.namespaces.DeepCopyObject())
+			revArgs.output = jsonFormat
 			err := listTags(context.Background(), client, &out)
 			if tc.error == "" && err != nil {
 				t.Fatalf("expected no error, got %v", err)

--- a/istioctl/cmd/workload.go
+++ b/istioctl/cmd/workload.go
@@ -564,6 +564,9 @@ func marshalWorkloadEntryPodPorts(p map[string]uint32) string {
 	if len(out) == 0 {
 		return ""
 	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].Name < out[j].Name
+	})
 	str, err := json.Marshal(out)
 	if err != nil {
 		return ""


### PR DESCRIPTION
* istioctl: fix order dependant tests

* Fix cni and pilot test as well

(cherry picked from commit b872e512c22166a3dc338f37d45f20728b37c48c)
(cherry picked from commit d98d84fb7fddab6c331cb0998520bb6a3c355982)

**Please provide a description of this PR:**