### PR TITLE
refactoring: reuse `workloadinstances.Index` in `serviceregistry/serviceentry`

### DIFF
--- a/pilot/pkg/serviceregistry/serviceentry/servicediscovery.go
+++ b/pilot/pkg/serviceregistry/serviceentry/servicediscovery.go
@@ -29,6 +29,7 @@ import (
 	"istio.io/istio/pilot/pkg/model/status"
 	"istio.io/istio/pilot/pkg/serviceregistry"
 	"istio.io/istio/pilot/pkg/serviceregistry/provider"
+	"istio.io/istio/pilot/pkg/serviceregistry/util/workloadinstances"
 	"istio.io/istio/pilot/pkg/util/informermetric"
 	"istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/config"
@@ -81,9 +82,11 @@ type ServiceEntryStore struct { // nolint:golint
 	// This lock is to make multi ops on the below stores.
 	// For example, in some case, it requires delete all instances and then update new ones.
 	// TODO: refactor serviceInstancesStore to remove the lock
-	mutex             sync.RWMutex
-	serviceInstances  serviceInstancesStore
-	workloadInstances workloadInstancesStore
+	mutex            sync.RWMutex
+	serviceInstances serviceInstancesStore
+	// NOTE: historically, one index for both WorkloadEntry(s) and Pod(s);
+	//       beware of naming collisions
+	workloadInstances workloadinstances.Index
 	services          serviceStore
 	// to make sure the eds update run in serial to prevent stale ones can override new ones
 	// There are multiple threads calling edsUpdate.
@@ -135,9 +138,7 @@ func NewServiceDiscovery(
 			instances:     map[instancesKey]map[configKey][]*model.ServiceInstance{},
 			instancesBySE: map[types.NamespacedName]map[configKey][]*model.ServiceInstance{},
 		},
-		workloadInstances: workloadInstancesStore{
-			instancesByKey: map[types.NamespacedName]*model.WorkloadInstance{},
-		},
+		workloadInstances: workloadinstances.NewIndex(),
 		services: serviceStore{
 			servicesBySE: map[types.NamespacedName][]*model.Service{},
 		},
@@ -245,10 +246,10 @@ func (s *ServiceEntryStore) workloadEntryHandler(old, curr config.Config, event 
 
 	s.serviceInstances.deleteInstances(key, instancesDeleted)
 	if event == model.EventDelete {
-		s.workloadInstances.delete(types.NamespacedName{Namespace: curr.Namespace, Name: curr.Name})
+		s.workloadInstances.Delete(wi)
 		s.serviceInstances.deleteInstances(key, instancesUpdated)
 	} else {
-		s.workloadInstances.update(wi)
+		s.workloadInstances.Insert(wi)
 		s.serviceInstances.updateInstances(key, instancesUpdated)
 	}
 	s.mutex.Unlock()
@@ -414,17 +415,11 @@ func (s *ServiceEntryStore) WorkloadInstanceHandler(wi *model.WorkloadInstance, 
 
 	// this is from a pod. Store it in separate map so that
 	// the refreshIndexes function can use these as well as the store ones.
-	k := types.NamespacedName{Namespace: wi.Namespace, Name: wi.Name}
 	switch event {
 	case model.EventDelete:
-		if s.workloadInstances.get(k) == nil {
-			// multiple delete events for the same pod (succeeded/failed/unknown status repeating).
-			redundantEventForPod = true
-		} else {
-			s.workloadInstances.delete(k)
-		}
+		redundantEventForPod = s.workloadInstances.Delete(wi) == nil
 	default: // add or update
-		if old := s.workloadInstances.get(k); old != nil {
+		if old := s.workloadInstances.Insert(wi); old != nil {
 			if old.Endpoint.Address != wi.Endpoint.Address {
 				addressToDelete = old.Endpoint.Address
 			}
@@ -435,7 +430,6 @@ func (s *ServiceEntryStore) WorkloadInstanceHandler(wi *model.WorkloadInstance, 
 				redundantEventForPod = true
 			}
 		}
-		s.workloadInstances.update(wi)
 	}
 
 	if redundantEventForPod {
@@ -847,7 +841,8 @@ func (s *ServiceEntryStore) buildServiceInstancesForSE(
 	serviceInstancesByConfig := map[configKey][]*model.ServiceInstance{}
 	// for service entry with labels
 	if currentServiceEntry.WorkloadSelector != nil {
-		workloadInstances := s.workloadInstances.listUnordered(curr.Namespace, labels.Collection{currentServiceEntry.WorkloadSelector.Labels})
+		selector := workloadinstances.ByServiceSelector(curr.Namespace, labels.Collection{currentServiceEntry.WorkloadSelector.Labels})
+		workloadInstances := workloadinstances.FindAllInIndex(s.workloadInstances, selector)
 		for _, wi := range workloadInstances {
 			if wi.DNSServiceEntryOnly && currentServiceEntry.Resolution != networking.ServiceEntry_DNS &&
 				currentServiceEntry.Resolution != networking.ServiceEntry_DNS_ROUND_ROBIN {

--- a/pilot/pkg/serviceregistry/serviceentry/store.go
+++ b/pilot/pkg/serviceregistry/serviceentry/store.go
@@ -18,7 +18,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"istio.io/istio/pilot/pkg/model"
-	"istio.io/istio/pkg/config/labels"
 )
 
 // stores all the service instances from SE, WLE and pods
@@ -109,40 +108,6 @@ func (s *serviceInstancesStore) deleteServiceEntryInstances(key types.Namespaced
 
 func (s *serviceInstancesStore) deleteAllServiceEntryInstances(key types.NamespacedName) {
 	delete(s.instancesBySE, key)
-}
-
-// stores all the workload instances from pods or workloadEntries
-type workloadInstancesStore struct {
-	// Stores a map of workload instance name/namespace to workload instance
-	instancesByKey map[types.NamespacedName]*model.WorkloadInstance
-}
-
-func (w *workloadInstancesStore) get(key types.NamespacedName) *model.WorkloadInstance {
-	return w.instancesByKey[key]
-}
-
-func (w *workloadInstancesStore) listUnordered(namespace string, selector labels.Collection) (out []*model.WorkloadInstance) {
-	for _, wi := range w.instancesByKey {
-		if wi.Namespace != namespace {
-			continue
-		}
-		if selector.HasSubsetOf(wi.Endpoint.Labels) {
-			out = append(out, wi)
-		}
-	}
-	return out
-}
-
-func (w *workloadInstancesStore) delete(key types.NamespacedName) {
-	delete(w.instancesByKey, key)
-}
-
-func (w *workloadInstancesStore) update(wi *model.WorkloadInstance) {
-	if wi == nil {
-		return
-	}
-	key := types.NamespacedName{Namespace: wi.Namespace, Name: wi.Name}
-	w.instancesByKey[key] = wi
 }
 
 // stores all the services converted from serviceEntries

--- a/pilot/pkg/serviceregistry/serviceentry/store_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/store_test.go
@@ -23,8 +23,6 @@ import (
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/config/constants"
-	"istio.io/istio/pkg/config/labels"
-	"istio.io/istio/pkg/spiffe"
 )
 
 func TestServiceInstancesStore(t *testing.T) {
@@ -101,79 +99,6 @@ func TestServiceInstancesStore(t *testing.T) {
 	gotInstances = store.getAll()
 	if len(gotInstances) != 0 {
 		t.Errorf("got unexpected instances %v", gotSeInstances)
-	}
-}
-
-func TestWorkloadInstancesStore(t *testing.T) {
-	// Setup a couple of workload instances for test. These will be selected by the `selector` SE
-	wi1 := &model.WorkloadInstance{
-		Name:      selector.Name,
-		Namespace: selector.Namespace,
-		Endpoint: &model.IstioEndpoint{
-			Address:        "2.2.2.2",
-			Labels:         map[string]string{"app": "wle"},
-			ServiceAccount: spiffe.MustGenSpiffeURI(selector.Name, "default"),
-			TLSMode:        model.IstioMutualTLSModeLabel,
-		},
-	}
-
-	wi2 := &model.WorkloadInstance{
-		Name:      "some-other-name",
-		Namespace: selector.Namespace,
-		Endpoint: &model.IstioEndpoint{
-			Address:        "3.3.3.3",
-			Labels:         map[string]string{"app": "wle"},
-			ServiceAccount: spiffe.MustGenSpiffeURI(selector.Name, "default"),
-			TLSMode:        model.IstioMutualTLSModeLabel,
-		},
-	}
-
-	wi3 := &model.WorkloadInstance{
-		Name:      "another-name",
-		Namespace: dnsSelector.Namespace,
-		Endpoint: &model.IstioEndpoint{
-			Address:        "2.2.2.2",
-			Labels:         map[string]string{"app": "dns-wle"},
-			ServiceAccount: spiffe.MustGenSpiffeURI(dnsSelector.Name, "default"),
-			TLSMode:        model.IstioMutualTLSModeLabel,
-		},
-	}
-	store := workloadInstancesStore{
-		instancesByKey: map[types.NamespacedName]*model.WorkloadInstance{},
-	}
-
-	// test update
-	store.update(wi1)
-	store.update(wi2)
-	store.update(wi3)
-
-	key := types.NamespacedName{
-		Namespace: wi1.Namespace,
-		Name:      wi1.Name,
-	}
-	// test get
-	got := store.get(key)
-	if !reflect.DeepEqual(got, wi1) {
-		t.Errorf("got unexpected workloadinstance %v", got)
-	}
-	workloadinstances := store.listUnordered(selector.Namespace, labels.Collection{{"app": "wle"}})
-	expected := map[string]*model.WorkloadInstance{
-		wi1.Name: wi1,
-		wi2.Name: wi2,
-	}
-	if len(workloadinstances) != 2 {
-		t.Errorf("got unexpected workload instance %v", workloadinstances)
-	}
-	for _, wi := range workloadinstances {
-		if !reflect.DeepEqual(expected[wi.Name], wi) {
-			t.Errorf("got unexpected workload instance %v", wi)
-		}
-	}
-
-	store.delete(key)
-	got = store.get(key)
-	if got != nil {
-		t.Errorf("workloadInstance %v was not deleted", got)
 	}
 }
 

--- a/pilot/pkg/serviceregistry/util/workloadinstances/selector.go
+++ b/pilot/pkg/serviceregistry/util/workloadinstances/selector.go
@@ -1,0 +1,42 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workloadinstances
+
+import (
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/config/labels"
+)
+
+// ByServiceSelector returns a predicate that matches workload instances
+// of a given service.
+func ByServiceSelector(namespace string, selector labels.Collection) func(*model.WorkloadInstance) bool {
+	return func(wi *model.WorkloadInstance) bool {
+		return wi.Namespace == namespace && selector.HasSubsetOf(wi.Endpoint.Labels)
+	}
+}
+
+// FindAllInIndex returns a list of workload instances in the index
+// that match given predicate.
+//
+// The returned list is not ordered.
+func FindAllInIndex(index Index, predicate func(*model.WorkloadInstance) bool) []*model.WorkloadInstance {
+	var instances []*model.WorkloadInstance
+	index.ForEach(func(instance *model.WorkloadInstance) {
+		if predicate(instance) {
+			instances = append(instances, instance)
+		}
+	})
+	return instances
+}


### PR DESCRIPTION
Signed-off-by: Yaroslav Skopets <yaroslav@tetrate.io>

**Please provide a description of this PR:**

This PR refactors `serviceregistry/serviceentry` to reuse the same code as `serviceregistry/kube`.