### PR TITLE
enabled tests in multi-cluster env

### DIFF
--- a/tests/integration/security/authorization_test.go
+++ b/tests/integration/security/authorization_test.go
@@ -321,11 +321,6 @@ func TestAuthorization_Deny(t *testing.T) {
 	framework.NewTest(t).
 		Features("security.authorization.deny-action").
 		Run(func(t framework.TestContext) {
-			// TODO: Convert into multicluster support. Currently reachability does
-			// not cover all clusters.
-			if t.Clusters().IsMulticluster() {
-				t.Skip()
-			}
 			ns := apps.Namespace1
 			rootns := newRootNS(t)
 			b := apps.B.Match(echo.Namespace(apps.Namespace1.Name()))
@@ -1249,10 +1244,6 @@ func TestAuthorization_Path(t *testing.T) {
 func TestAuthorization_Audit(t *testing.T) {
 	framework.NewTest(t).
 		Run(func(t framework.TestContext) {
-			// TODO: finish convert all authorization tests into multicluster supported
-			if t.Clusters().IsMulticluster() {
-				t.Skip()
-			}
 			ns := apps.Namespace1
 			a := apps.A.Match(echo.Namespace(ns.Name()))
 			b := apps.B.Match(echo.Namespace(ns.Name()))

--- a/tests/integration/security/authorization_test.go
+++ b/tests/integration/security/authorization_test.go
@@ -335,7 +335,9 @@ func TestAuthorization_Deny(t *testing.T) {
 			}
 			applyPolicy := func(filename string, ns namespace.Instance) {
 				policy := tmpl.EvaluateAllOrFail(t, args, file.AsStringOrFail(t, filename))
-				t.ConfigIstio().ApplyYAMLOrFail(t, ns.Name(), policy...)
+				for _, cluster := range t.AllClusters() {
+					t.ConfigKube(cluster).ApplyYAMLOrFail(t, ns.Name(), policy...)
+				}
 				util.WaitForConfig(t, ns, policy...)
 			}
 			applyPolicy("testdata/authz/v1beta1-deny.yaml.tmpl", ns)

--- a/tests/integration/security/authorization_test.go
+++ b/tests/integration/security/authorization_test.go
@@ -345,7 +345,7 @@ func TestAuthorization_Deny(t *testing.T) {
 				// so we can validate all clusters are hit
 				callCount = util.CallsPerCluster * len(t.Clusters())
 			}
-			for _, srcCluster := range t.Clusters() {
+			for _, srcCluster := range t.AllClusters() {
 				t.NewSubTest(fmt.Sprintf("From %s", srcCluster.StableName())).Run(func(t framework.TestContext) {
 					a := apps.A.Match(echo.InCluster(srcCluster).And(echo.Namespace(apps.Namespace1.Name())))
 					util.CheckExistence(t, a)

--- a/tests/integration/security/jwt_test.go
+++ b/tests/integration/security/jwt_test.go
@@ -258,10 +258,6 @@ func TestRequestAuthentication(t *testing.T) {
 							authHeaderKey:    "Bearer " + jwt.TokenIssuer1,
 							"X-Test-Payload": payload1,
 						},
-						// This test does not generate cross-cluster traffic, but is flaky
-						// in multicluster test. Skip in multicluster mesh.
-						// TODO(JimmyCYJ): enable the test in multicluster mesh.
-						SkipMultiCluster: true,
 					},
 					{
 						Name:   "invalid-aud",
@@ -436,6 +432,20 @@ func TestRequestAuthentication(t *testing.T) {
 							Count: callCount,
 						},
 						ExpectResponseCode: response.StatusCodeForbidden,
+					},
+					{
+						Name:   "invalid-header-valid-params",
+						Config: "headers-params",
+						CallOpts: echo.CallOptions{
+							PortName: "http",
+							Scheme:   scheme.HTTP,
+							Headers: map[string][]string{
+								"X-Jwt-Token": {"Value " + jwt.TokenExpired},
+							},
+							Path:  "/valid-token?secondary_token=" + jwt.TokenIssuer1,
+							Count: callCount,
+						},
+						ExpectResponseCode: response.StatusUnauthorized,
 					},
 				}
 				for _, c := range testCases {


### PR DESCRIPTION
**Please provide a description of this PR:**
Enabled authz and requestauth tests in multicluster environment.
Add one more test to check the combination of `fromHeaders` and `fromParams`