### PR TITLE
Change Kiali's signing key

### DIFF
--- a/manifests/addons/values-kiali.yaml
+++ b/manifests/addons/values-kiali.yaml
@@ -8,4 +8,4 @@ deployment:
   - '**'
   ingress_enabled: false
 login_token:
-  signing_key: CHANGEME
+  signing_key: CHANGEME00000000

--- a/samples/addons/kiali.yaml
+++ b/samples/addons/kiali.yaml
@@ -105,7 +105,7 @@ data:
       clustering:
         enabled: true
     login_token:
-      signing_key: CHANGEME
+      signing_key: CHANGEME00000000
     server:
       metrics_enabled: true
       metrics_port: 9090
@@ -468,7 +468,7 @@ spec:
         app.kubernetes.io/part-of: "kiali"
         sidecar.istio.io/inject: "false"
       annotations:
-        checksum/config: 0b7a16e51830df3ef2ff816eb3d43341a23c822b38fea95050b3707ba2ca119e
+        checksum/config: a714a9c0c6be44fd505e291c57c8b03f6be5982e66c5887b4e9ffbdf4eb0e1b6
         prometheus.io/scrape: "true"
         prometheus.io/port: "9090"
         kiali.io/dashboards: go,kiali


### PR DESCRIPTION
**Please provide a description of this PR:**

Kiali is now requiring signing keys that are 16, 24 or 32 bytes long.
This adds a padding to the sample signing key to comply with the new
requirement.