### PR TITLE
feat(crdclient): populate istio crds with field path map

### DIFF
--- a/pilot/pkg/config/kube/crdclient/client_test_util.go
+++ b/pilot/pkg/config/kube/crdclient/client_test_util.go
@@ -1,0 +1,44 @@
+package crdclient
+
+import (
+	"context"
+	"fmt"
+
+	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metadatafake "k8s.io/client-go/metadata/fake"
+
+	"istio.io/istio/pkg/config/schema/collections"
+	"istio.io/istio/pkg/config/schema/resource"
+	"istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/test"
+)
+
+func CreateCRD(t test.Failer, client kube.Client, r resource.Schema) {
+	t.Helper()
+	crd := &v1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("%s.%s", r.Plural(), r.Group()),
+		},
+	}
+	if _, err := client.Ext().ApiextensionsV1().CustomResourceDefinitions().Create(context.TODO(), crd, metav1.CreateOptions{}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Metadata client fake is not kept in sync, so if using a fake clinet update that as well
+	fmc, ok := client.Metadata().(*metadatafake.FakeMetadataClient)
+	if !ok {
+		return
+	}
+	fmg := fmc.Resource(collections.K8SApiextensionsK8SIoV1Customresourcedefinitions.Resource().GroupVersionResource())
+	fmd, ok := fmg.(metadatafake.MetadataClient)
+	if !ok {
+		return
+	}
+	if _, err := fmd.CreateFake(&metav1.PartialObjectMetadata{
+		TypeMeta:   crd.TypeMeta,
+		ObjectMeta: crd.ObjectMeta,
+	}, metav1.CreateOptions{}); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pilot/pkg/config/kube/crdclient/gen/main.go
+++ b/pilot/pkg/config/kube/crdclient/gen/main.go
@@ -25,6 +25,7 @@ import (
 	"log"
 	"os"
 	"path"
+	"strings"
 	"text/template"
 
 	"istio.io/istio/pkg/config/schema/collection"
@@ -48,8 +49,9 @@ type ConfigData struct {
 	Client     string
 	TypeSuffix string
 
-	Readonly bool
-	NoSpec   bool
+	Readonly         bool
+	NoSpec           bool
+	WithFieldPathMap bool
 }
 
 var (
@@ -60,16 +62,17 @@ var (
 // MakeConfigData prepare data for code generation for the given schema.
 func MakeConfigData(schema collection.Schema) ConfigData {
 	out := ConfigData{
-		Namespaced:      !schema.Resource().IsClusterScoped(),
-		VariableName:    schema.VariableName(),
-		APIImport:       apiImport[schema.Resource().ProtoPackage()],
-		ClientImport:    clientGoImport[schema.Resource().ProtoPackage()],
-		ClientGroupPath: clientGoAccessPath[schema.Resource().ProtoPackage()],
-		ClientTypePath:  clientGoTypePath[schema.Resource().Plural()],
-		Kind:            schema.Resource().Kind(),
-		Client:          "ic",
-		StatusAPIImport: apiImport[schema.Resource().StatusPackage()],
-		StatusKind:      schema.Resource().StatusKind(),
+		Namespaced:       !schema.Resource().IsClusterScoped(),
+		VariableName:     schema.VariableName(),
+		APIImport:        apiImport[schema.Resource().ProtoPackage()],
+		ClientImport:     clientGoImport[schema.Resource().ProtoPackage()],
+		ClientGroupPath:  clientGoAccessPath[schema.Resource().ProtoPackage()],
+		ClientTypePath:   clientGoTypePath[schema.Resource().Plural()],
+		Kind:             schema.Resource().Kind(),
+		Client:           "ic",
+		StatusAPIImport:  apiImport[schema.Resource().StatusPackage()],
+		StatusKind:       schema.Resource().StatusKind(),
+		WithFieldPathMap: strings.HasPrefix(schema.Resource().ProtoPackage(), "istio.io/api"),
 	}
 	if _, f := GatewayAPITypes.Find(schema.Name().String()); f {
 		out.Client = "sc"

--- a/pilot/pkg/config/kube/crdclient/gen/types.go.tmpl
+++ b/pilot/pkg/config/kube/crdclient/gen/types.go.tmpl
@@ -22,18 +22,23 @@ package crdclient
 // as declared in the Istio config model.
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"encoding/json"
 	metav1alpha1 "istio.io/api/meta/v1alpha1"
 
 	versionedclient "istio.io/client-go/pkg/clientset/versioned"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	yamlv3 "gopkg.in/yaml.v3"
+	"sigs.k8s.io/yaml"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	gatewayapiclient "sigs.k8s.io/gateway-api/pkg/client/clientset/gateway/versioned"
 
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/collections"
+	"istio.io/istio/pilot/pkg/config/file"
 
 	extensionsv1alpha1 "istio.io/api/extensions/v1alpha1"
 	networkingv1alpha3 "istio.io/api/networking/v1alpha3"
@@ -152,17 +157,29 @@ func delete(ic versionedclient.Interface, sc gatewayapiclient.Interface, typ con
 	}
 }
 
-var translationMap = map[config.GroupVersionKind]func(r runtime.Object) config.Config{
+var translationMap = map[config.GroupVersionKind]func(r runtime.Object) config.Config {
 {{- range . }}
 	collections.{{ .VariableName }}.Resource().GroupVersionKind(): func(r runtime.Object) config.Config {
 		obj := r.(*{{ .ClientImport }}.{{ .Kind }})
+		{{- if .WithFieldPathMap }}
+		annots := obj.Annotations 
+		fieldPathMap, err := buildFieldPathMap(obj)
+		if err != nil {
+			scope.Errorf("failed to build field path map for object %s/%s: %v", obj.Namespace, obj.Name, err)
+		} else {
+			if annots == nil {
+				annots = map[string]string{}
+			}
+			annots[file.FieldMapKey] = fieldPathMap 
+		}
+		{{- end }}
 		return config.Config{
 		  Meta: config.Meta{
 		  	GroupVersionKind:  collections.{{ .VariableName }}.Resource().GroupVersionKind(),
 		  	Name:              obj.Name,
 		  	Namespace:         obj.Namespace,
 		  	Labels:            obj.Labels,
-		  	Annotations:       obj.Annotations,
+		  	Annotations:	{{ if .WithFieldPathMap }}annots{{ else }}obj.Annotations{{ end }},
 		  	ResourceVersion:   obj.ResourceVersion,
 		  	CreationTimestamp: obj.CreationTimestamp.Time,
 		  	OwnerReferences:   obj.OwnerReferences,
@@ -176,4 +193,31 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) config.C
 		}
 	},
 {{- end }}
+}
+
+func buildFieldPathMap(obj interface{}) (string, error) {
+	jsondoc, err := json.Marshal(obj)
+	if err != nil {
+		return "", err
+	}
+	doc, err := yaml.JSONToYAML(jsondoc)
+	if err != nil {
+		return "", err
+	}
+	chunk := bytes.TrimSpace(doc)
+	fieldPathMap := make(map[string]int)
+	yamlChunkNode := yamlv3.Node{}
+	err = yamlv3.Unmarshal(chunk, &yamlChunkNode)
+	if err != nil {
+		return "", err
+	}
+	if len(yamlChunkNode.Content) == 1 {
+		yamlNode := yamlChunkNode.Content[0]
+		file.BuildFieldPathMap(yamlNode, 0, "", fieldPathMap)
+	}
+	jsonfm, err := json.Marshal(fieldPathMap)
+	if err != nil {
+		return "", err
+	}
+	return string(jsonfm), nil
 }

--- a/pilot/pkg/config/kube/crdclient/types.gen.go
+++ b/pilot/pkg/config/kube/crdclient/types.gen.go
@@ -22,16 +22,21 @@ package crdclient
 // as declared in the Istio config model.
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	metav1alpha1 "istio.io/api/meta/v1alpha1"
 
+	yamlv3 "gopkg.in/yaml.v3"
 	versionedclient "istio.io/client-go/pkg/clientset/versioned"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	gatewayapiclient "sigs.k8s.io/gateway-api/pkg/client/clientset/gateway/versioned"
+	"sigs.k8s.io/yaml"
 
+	"istio.io/istio/pilot/pkg/config/file"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/collections"
 
@@ -754,13 +759,23 @@ func delete(ic versionedclient.Interface, sc gatewayapiclient.Interface, typ con
 var translationMap = map[config.GroupVersionKind]func(r runtime.Object) config.Config{
 	collections.IstioExtensionsV1Alpha1Wasmplugins.Resource().GroupVersionKind(): func(r runtime.Object) config.Config {
 		obj := r.(*clientextensionsv1alpha1.WasmPlugin)
+		annots := obj.Annotations
+		fieldPathMap, err := buildFieldPathMap(obj)
+		if err != nil {
+			scope.Errorf("failed to build field path map for object %s/%s: %v", obj.Namespace, obj.Name, err)
+		} else {
+			if annots == nil {
+				annots = map[string]string{}
+			}
+			annots[file.FieldMapKey] = fieldPathMap
+		}
 		return config.Config{
 			Meta: config.Meta{
 				GroupVersionKind:  collections.IstioExtensionsV1Alpha1Wasmplugins.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
 				Labels:            obj.Labels,
-				Annotations:       obj.Annotations,
+				Annotations:       annots,
 				ResourceVersion:   obj.ResourceVersion,
 				CreationTimestamp: obj.CreationTimestamp.Time,
 				OwnerReferences:   obj.OwnerReferences,
@@ -773,13 +788,23 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) config.C
 	},
 	collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind(): func(r runtime.Object) config.Config {
 		obj := r.(*clientnetworkingv1alpha3.DestinationRule)
+		annots := obj.Annotations
+		fieldPathMap, err := buildFieldPathMap(obj)
+		if err != nil {
+			scope.Errorf("failed to build field path map for object %s/%s: %v", obj.Namespace, obj.Name, err)
+		} else {
+			if annots == nil {
+				annots = map[string]string{}
+			}
+			annots[file.FieldMapKey] = fieldPathMap
+		}
 		return config.Config{
 			Meta: config.Meta{
 				GroupVersionKind:  collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
 				Labels:            obj.Labels,
-				Annotations:       obj.Annotations,
+				Annotations:       annots,
 				ResourceVersion:   obj.ResourceVersion,
 				CreationTimestamp: obj.CreationTimestamp.Time,
 				OwnerReferences:   obj.OwnerReferences,
@@ -792,13 +817,23 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) config.C
 	},
 	collections.IstioNetworkingV1Alpha3Envoyfilters.Resource().GroupVersionKind(): func(r runtime.Object) config.Config {
 		obj := r.(*clientnetworkingv1alpha3.EnvoyFilter)
+		annots := obj.Annotations
+		fieldPathMap, err := buildFieldPathMap(obj)
+		if err != nil {
+			scope.Errorf("failed to build field path map for object %s/%s: %v", obj.Namespace, obj.Name, err)
+		} else {
+			if annots == nil {
+				annots = map[string]string{}
+			}
+			annots[file.FieldMapKey] = fieldPathMap
+		}
 		return config.Config{
 			Meta: config.Meta{
 				GroupVersionKind:  collections.IstioNetworkingV1Alpha3Envoyfilters.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
 				Labels:            obj.Labels,
-				Annotations:       obj.Annotations,
+				Annotations:       annots,
 				ResourceVersion:   obj.ResourceVersion,
 				CreationTimestamp: obj.CreationTimestamp.Time,
 				OwnerReferences:   obj.OwnerReferences,
@@ -811,13 +846,23 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) config.C
 	},
 	collections.IstioNetworkingV1Alpha3Gateways.Resource().GroupVersionKind(): func(r runtime.Object) config.Config {
 		obj := r.(*clientnetworkingv1alpha3.Gateway)
+		annots := obj.Annotations
+		fieldPathMap, err := buildFieldPathMap(obj)
+		if err != nil {
+			scope.Errorf("failed to build field path map for object %s/%s: %v", obj.Namespace, obj.Name, err)
+		} else {
+			if annots == nil {
+				annots = map[string]string{}
+			}
+			annots[file.FieldMapKey] = fieldPathMap
+		}
 		return config.Config{
 			Meta: config.Meta{
 				GroupVersionKind:  collections.IstioNetworkingV1Alpha3Gateways.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
 				Labels:            obj.Labels,
-				Annotations:       obj.Annotations,
+				Annotations:       annots,
 				ResourceVersion:   obj.ResourceVersion,
 				CreationTimestamp: obj.CreationTimestamp.Time,
 				OwnerReferences:   obj.OwnerReferences,
@@ -830,13 +875,23 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) config.C
 	},
 	collections.IstioNetworkingV1Alpha3Serviceentries.Resource().GroupVersionKind(): func(r runtime.Object) config.Config {
 		obj := r.(*clientnetworkingv1alpha3.ServiceEntry)
+		annots := obj.Annotations
+		fieldPathMap, err := buildFieldPathMap(obj)
+		if err != nil {
+			scope.Errorf("failed to build field path map for object %s/%s: %v", obj.Namespace, obj.Name, err)
+		} else {
+			if annots == nil {
+				annots = map[string]string{}
+			}
+			annots[file.FieldMapKey] = fieldPathMap
+		}
 		return config.Config{
 			Meta: config.Meta{
 				GroupVersionKind:  collections.IstioNetworkingV1Alpha3Serviceentries.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
 				Labels:            obj.Labels,
-				Annotations:       obj.Annotations,
+				Annotations:       annots,
 				ResourceVersion:   obj.ResourceVersion,
 				CreationTimestamp: obj.CreationTimestamp.Time,
 				OwnerReferences:   obj.OwnerReferences,
@@ -849,13 +904,23 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) config.C
 	},
 	collections.IstioNetworkingV1Alpha3Sidecars.Resource().GroupVersionKind(): func(r runtime.Object) config.Config {
 		obj := r.(*clientnetworkingv1alpha3.Sidecar)
+		annots := obj.Annotations
+		fieldPathMap, err := buildFieldPathMap(obj)
+		if err != nil {
+			scope.Errorf("failed to build field path map for object %s/%s: %v", obj.Namespace, obj.Name, err)
+		} else {
+			if annots == nil {
+				annots = map[string]string{}
+			}
+			annots[file.FieldMapKey] = fieldPathMap
+		}
 		return config.Config{
 			Meta: config.Meta{
 				GroupVersionKind:  collections.IstioNetworkingV1Alpha3Sidecars.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
 				Labels:            obj.Labels,
-				Annotations:       obj.Annotations,
+				Annotations:       annots,
 				ResourceVersion:   obj.ResourceVersion,
 				CreationTimestamp: obj.CreationTimestamp.Time,
 				OwnerReferences:   obj.OwnerReferences,
@@ -868,13 +933,23 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) config.C
 	},
 	collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(): func(r runtime.Object) config.Config {
 		obj := r.(*clientnetworkingv1alpha3.VirtualService)
+		annots := obj.Annotations
+		fieldPathMap, err := buildFieldPathMap(obj)
+		if err != nil {
+			scope.Errorf("failed to build field path map for object %s/%s: %v", obj.Namespace, obj.Name, err)
+		} else {
+			if annots == nil {
+				annots = map[string]string{}
+			}
+			annots[file.FieldMapKey] = fieldPathMap
+		}
 		return config.Config{
 			Meta: config.Meta{
 				GroupVersionKind:  collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
 				Labels:            obj.Labels,
-				Annotations:       obj.Annotations,
+				Annotations:       annots,
 				ResourceVersion:   obj.ResourceVersion,
 				CreationTimestamp: obj.CreationTimestamp.Time,
 				OwnerReferences:   obj.OwnerReferences,
@@ -887,13 +962,23 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) config.C
 	},
 	collections.IstioNetworkingV1Alpha3Workloadentries.Resource().GroupVersionKind(): func(r runtime.Object) config.Config {
 		obj := r.(*clientnetworkingv1alpha3.WorkloadEntry)
+		annots := obj.Annotations
+		fieldPathMap, err := buildFieldPathMap(obj)
+		if err != nil {
+			scope.Errorf("failed to build field path map for object %s/%s: %v", obj.Namespace, obj.Name, err)
+		} else {
+			if annots == nil {
+				annots = map[string]string{}
+			}
+			annots[file.FieldMapKey] = fieldPathMap
+		}
 		return config.Config{
 			Meta: config.Meta{
 				GroupVersionKind:  collections.IstioNetworkingV1Alpha3Workloadentries.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
 				Labels:            obj.Labels,
-				Annotations:       obj.Annotations,
+				Annotations:       annots,
 				ResourceVersion:   obj.ResourceVersion,
 				CreationTimestamp: obj.CreationTimestamp.Time,
 				OwnerReferences:   obj.OwnerReferences,
@@ -906,13 +991,23 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) config.C
 	},
 	collections.IstioNetworkingV1Alpha3Workloadgroups.Resource().GroupVersionKind(): func(r runtime.Object) config.Config {
 		obj := r.(*clientnetworkingv1alpha3.WorkloadGroup)
+		annots := obj.Annotations
+		fieldPathMap, err := buildFieldPathMap(obj)
+		if err != nil {
+			scope.Errorf("failed to build field path map for object %s/%s: %v", obj.Namespace, obj.Name, err)
+		} else {
+			if annots == nil {
+				annots = map[string]string{}
+			}
+			annots[file.FieldMapKey] = fieldPathMap
+		}
 		return config.Config{
 			Meta: config.Meta{
 				GroupVersionKind:  collections.IstioNetworkingV1Alpha3Workloadgroups.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
 				Labels:            obj.Labels,
-				Annotations:       obj.Annotations,
+				Annotations:       annots,
 				ResourceVersion:   obj.ResourceVersion,
 				CreationTimestamp: obj.CreationTimestamp.Time,
 				OwnerReferences:   obj.OwnerReferences,
@@ -925,13 +1020,23 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) config.C
 	},
 	collections.IstioNetworkingV1Beta1Proxyconfigs.Resource().GroupVersionKind(): func(r runtime.Object) config.Config {
 		obj := r.(*clientnetworkingv1beta1.ProxyConfig)
+		annots := obj.Annotations
+		fieldPathMap, err := buildFieldPathMap(obj)
+		if err != nil {
+			scope.Errorf("failed to build field path map for object %s/%s: %v", obj.Namespace, obj.Name, err)
+		} else {
+			if annots == nil {
+				annots = map[string]string{}
+			}
+			annots[file.FieldMapKey] = fieldPathMap
+		}
 		return config.Config{
 			Meta: config.Meta{
 				GroupVersionKind:  collections.IstioNetworkingV1Beta1Proxyconfigs.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
 				Labels:            obj.Labels,
-				Annotations:       obj.Annotations,
+				Annotations:       annots,
 				ResourceVersion:   obj.ResourceVersion,
 				CreationTimestamp: obj.CreationTimestamp.Time,
 				OwnerReferences:   obj.OwnerReferences,
@@ -944,13 +1049,23 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) config.C
 	},
 	collections.IstioSecurityV1Beta1Authorizationpolicies.Resource().GroupVersionKind(): func(r runtime.Object) config.Config {
 		obj := r.(*clientsecurityv1beta1.AuthorizationPolicy)
+		annots := obj.Annotations
+		fieldPathMap, err := buildFieldPathMap(obj)
+		if err != nil {
+			scope.Errorf("failed to build field path map for object %s/%s: %v", obj.Namespace, obj.Name, err)
+		} else {
+			if annots == nil {
+				annots = map[string]string{}
+			}
+			annots[file.FieldMapKey] = fieldPathMap
+		}
 		return config.Config{
 			Meta: config.Meta{
 				GroupVersionKind:  collections.IstioSecurityV1Beta1Authorizationpolicies.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
 				Labels:            obj.Labels,
-				Annotations:       obj.Annotations,
+				Annotations:       annots,
 				ResourceVersion:   obj.ResourceVersion,
 				CreationTimestamp: obj.CreationTimestamp.Time,
 				OwnerReferences:   obj.OwnerReferences,
@@ -963,13 +1078,23 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) config.C
 	},
 	collections.IstioSecurityV1Beta1Peerauthentications.Resource().GroupVersionKind(): func(r runtime.Object) config.Config {
 		obj := r.(*clientsecurityv1beta1.PeerAuthentication)
+		annots := obj.Annotations
+		fieldPathMap, err := buildFieldPathMap(obj)
+		if err != nil {
+			scope.Errorf("failed to build field path map for object %s/%s: %v", obj.Namespace, obj.Name, err)
+		} else {
+			if annots == nil {
+				annots = map[string]string{}
+			}
+			annots[file.FieldMapKey] = fieldPathMap
+		}
 		return config.Config{
 			Meta: config.Meta{
 				GroupVersionKind:  collections.IstioSecurityV1Beta1Peerauthentications.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
 				Labels:            obj.Labels,
-				Annotations:       obj.Annotations,
+				Annotations:       annots,
 				ResourceVersion:   obj.ResourceVersion,
 				CreationTimestamp: obj.CreationTimestamp.Time,
 				OwnerReferences:   obj.OwnerReferences,
@@ -982,13 +1107,23 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) config.C
 	},
 	collections.IstioSecurityV1Beta1Requestauthentications.Resource().GroupVersionKind(): func(r runtime.Object) config.Config {
 		obj := r.(*clientsecurityv1beta1.RequestAuthentication)
+		annots := obj.Annotations
+		fieldPathMap, err := buildFieldPathMap(obj)
+		if err != nil {
+			scope.Errorf("failed to build field path map for object %s/%s: %v", obj.Namespace, obj.Name, err)
+		} else {
+			if annots == nil {
+				annots = map[string]string{}
+			}
+			annots[file.FieldMapKey] = fieldPathMap
+		}
 		return config.Config{
 			Meta: config.Meta{
 				GroupVersionKind:  collections.IstioSecurityV1Beta1Requestauthentications.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
 				Labels:            obj.Labels,
-				Annotations:       obj.Annotations,
+				Annotations:       annots,
 				ResourceVersion:   obj.ResourceVersion,
 				CreationTimestamp: obj.CreationTimestamp.Time,
 				OwnerReferences:   obj.OwnerReferences,
@@ -1001,13 +1136,23 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) config.C
 	},
 	collections.IstioTelemetryV1Alpha1Telemetries.Resource().GroupVersionKind(): func(r runtime.Object) config.Config {
 		obj := r.(*clienttelemetryv1alpha1.Telemetry)
+		annots := obj.Annotations
+		fieldPathMap, err := buildFieldPathMap(obj)
+		if err != nil {
+			scope.Errorf("failed to build field path map for object %s/%s: %v", obj.Namespace, obj.Name, err)
+		} else {
+			if annots == nil {
+				annots = map[string]string{}
+			}
+			annots[file.FieldMapKey] = fieldPathMap
+		}
 		return config.Config{
 			Meta: config.Meta{
 				GroupVersionKind:  collections.IstioTelemetryV1Alpha1Telemetries.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
 				Labels:            obj.Labels,
-				Annotations:       obj.Annotations,
+				Annotations:       annots,
 				ResourceVersion:   obj.ResourceVersion,
 				CreationTimestamp: obj.CreationTimestamp.Time,
 				OwnerReferences:   obj.OwnerReferences,
@@ -1330,4 +1475,31 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) config.C
 			Status: &obj.Status,
 		}
 	},
+}
+
+func buildFieldPathMap(obj interface{}) (string, error) {
+	jsondoc, err := json.Marshal(obj)
+	if err != nil {
+		return "", err
+	}
+	doc, err := yaml.JSONToYAML(jsondoc)
+	if err != nil {
+		return "", err
+	}
+	chunk := bytes.TrimSpace(doc)
+	fieldPathMap := make(map[string]int)
+	yamlChunkNode := yamlv3.Node{}
+	err = yamlv3.Unmarshal(chunk, &yamlChunkNode)
+	if err != nil {
+		return "", err
+	}
+	if len(yamlChunkNode.Content) == 1 {
+		yamlNode := yamlChunkNode.Content[0]
+		file.BuildFieldPathMap(yamlNode, 0, "", fieldPathMap)
+	}
+	jsonfm, err := json.Marshal(fieldPathMap)
+	if err != nil {
+		return "", err
+	}
+	return string(jsonfm), nil
 }


### PR DESCRIPTION
**Please provide a description of this PR:**

istio analyzer construct a field path map for the local yaml files to be analyzed before analyzing, it is store in the annotation field of the [Config](https://github.com/istio/istio/blob/284def0c93cc2dc37b07a1d7acd74f26eb24fb63/pkg/config/model.go#L97) struct and the error line is generated based on it

it would be useful that the analyzer generates error lines for incluster istio resources, this pr adds field path map for istio crds