### PR TITLE
client protocol jobs: expand coverage to more port names

### DIFF
--- a/pkg/test/framework/components/echo/cmd/echogen/testdata/golden.yaml
+++ b/pkg/test/framework/components/echo/cmd/echogen/testdata/golden.yaml
@@ -13,6 +13,9 @@ spec:
   - name: grpc
     port: 7070
     targetPort: 17070
+  - name: http2
+    port: 85
+    targetPort: 18085
   - name: tcp
     port: 9090
     targetPort: 19090
@@ -81,6 +84,8 @@ spec:
         - "18080"
         - --grpc
         - "17070"
+        - --port
+        - "18085"
         - --tcp
         - "19090"
         - --port
@@ -138,6 +143,7 @@ spec:
         ports:
         - containerPort: 18080
         - containerPort: 17070
+        - containerPort: 18085
         - containerPort: 19090
         - containerPort: 18443
         - containerPort: 16060

--- a/pkg/test/framework/components/echo/common/defaults.go
+++ b/pkg/test/framework/components/echo/common/defaults.go
@@ -22,6 +22,7 @@ import (
 var EchoPorts = []echo.Port{
 	{Name: "http", Protocol: protocol.HTTP, ServicePort: 80, InstancePort: 18080},
 	{Name: "grpc", Protocol: protocol.GRPC, ServicePort: 7070, InstancePort: 17070},
+	{Name: "http2", Protocol: protocol.HTTP, ServicePort: 85, InstancePort: 18085},
 	{Name: "tcp", Protocol: protocol.TCP, ServicePort: 9090, InstancePort: 19090},
 	{Name: "https", Protocol: protocol.HTTPS, ServicePort: 443, InstancePort: 18443, TLS: true},
 	{Name: "tcp-server", Protocol: protocol.TCP, ServicePort: 9091, InstancePort: 16060, ServerFirst: true},


### PR DESCRIPTION
Ensure that `useClientProtocol` works with ports named "auto", "http",
and "http2"

**Please provide a description of this PR:**