### PR TITLE
do not compare cert bytes directly

### DIFF
--- a/security/pkg/pki/ra/k8s_ra.go
+++ b/security/pkg/pki/ra/k8s_ra.go
@@ -15,7 +15,6 @@
 package ra
 
 import (
-	"bytes"
 	"fmt"
 	"strings"
 	"sync"
@@ -116,20 +115,11 @@ func (r *KubernetesRA) SignWithCertChain(csrPEM []byte, certOpts ca.CertOpts) ([
 		if err != nil {
 			return nil, fmt.Errorf("failed to find root cert from mesh config (%v)", err.Error())
 		}
-		if rootCertFromCertChain != nil && rootCertFromMeshConfig != nil {
-			if !bytes.Equal(rootCertFromCertChain, rootCertFromMeshConfig) {
-				return nil, fmt.Errorf("root cert from signed cert-chain" +
-					" is conflicting with the one specified in mesh config")
-			}
-		}
 		if rootCertFromMeshConfig != nil {
 			rootCert = rootCertFromMeshConfig
-		}
-
-		if rootCertFromCertChain != nil {
+		} else if rootCertFromCertChain != nil {
 			rootCert = rootCertFromCertChain
 		}
-
 		if verifyErr := util.VerifyCertificate(nil, cert, rootCert, nil); verifyErr != nil {
 			return nil, fmt.Errorf("root cert from signed cert-chain is invalid %v ", verifyErr)
 		}

--- a/tests/integration/security/external_ca/main_test.go
+++ b/tests/integration/security/external_ca/main_test.go
@@ -77,7 +77,6 @@ func SetupApps(ctx resource.Context, apps *EchoDeployments) error {
 func TestMain(m *testing.M) {
 	// Integration test for testing interoperability with external CA's that are integrated with K8s CSR API
 	// Refer to https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/
-	// nolint: staticcheck
 	framework.NewSuite(m).
 		Label(label.CustomSetup).
 		RequireMinVersion(19).
@@ -119,31 +118,32 @@ values:
 {{.rootcert2 | indent 8}}
       certSigners:
       - {{.signer2}}
-  components:
-    pilot:
-      k8s:
-        env:
-        - name: CERT_SIGNER_DOMAIN
-          value: clusterissuers.istio.io
-        - name: EXTERNAL_CA
-          value: ISTIOD_RA_KUBERNETES_API
-        - name: PILOT_CERT_PROVIDER
-          value: k8s.io/clusterissuers.istio.io/signer2
-        overlays:
-          # Amend ClusterRole to add permission for istiod to approve certificate signing by custom signer
-          - kind: ClusterRole
-            name: istiod-clusterrole-istio-system
-            patches:
-              - path: rules[-1]
-                value: |
-                  apiGroups:
-                  - certificates.k8s.io
-                  resourceNames:
-                  - clusterissuers.istio.io/*
-                  resources:
-                  - signers
-                  verbs:
-                  - approve
+components:
+  pilot:
+    enabled: true
+    k8s:
+      env:
+      - name: CERT_SIGNER_DOMAIN
+        value: clusterissuers.istio.io
+      - name: EXTERNAL_CA
+        value: ISTIOD_RA_KUBERNETES_API
+      - name: PILOT_CERT_PROVIDER
+        value: k8s.io/clusterissuers.istio.io/signer2
+      overlays:
+        # Amend ClusterRole to add permission for istiod to approve certificate signing by custom signer
+        - kind: ClusterRole
+          name: istiod-clusterrole-istio-system
+          patches:
+            - path: rules[-1]
+              value: |
+                apiGroups:
+                - certificates.k8s.io
+                resourceNames:
+                - clusterissuers.istio.io/*
+                resources:
+                - signers
+                verbs:
+                - approve
 `, map[string]string{"rootcert1": cert1.Rootcert, "signer1": cert1.Signer, "rootcert2": cert2.Rootcert, "signer2": cert2.Signer})
 	cfg.ControlPlaneValues = cfgYaml
 	cfg.DeployEastWestGW = false


### PR DESCRIPTION
We should not compare the root certs bytes directly, instead we can rely on the https://github.com/istio/istio/compare/master...irisdingbj:verifyfix?expand=1#diff-df16ac4e2cc1c048a4ce70aa3f27ec9c173573fc5288fb029fdc19b93c0ae259L133 to make sure the cert chain retured is correctly signed from root cert. 