### PR TITLE
vm support: don't generate virtual inbound/outbound listeners for proxies that are not using Iptables redirection

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/accesslog_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/accesslog_test.go
@@ -113,7 +113,7 @@ func TestListenerAccessLog(t *testing.T) {
 			accessLogBuilder.reset()
 
 			// Validate that access log filter uses the new format.
-			listeners := buildAllListeners(&fakePlugin{}, env)
+			listeners := buildAllListeners(&fakePlugin{}, env, getProxy())
 			for _, l := range listeners {
 				if l.AccessLog[0].Filter == nil {
 					t.Fatal("expected filter config in listener access log configuration")

--- a/pilot/pkg/networking/core/v1alpha3/listener_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_builder.go
@@ -350,8 +350,7 @@ func (lb *ListenerBuilder) buildHTTPProxyListener(configgen *ConfigGeneratorImpl
 }
 
 func (lb *ListenerBuilder) buildVirtualOutboundListener(configgen *ConfigGeneratorImpl) *ListenerBuilder {
-	noneMode := lb.node.GetInterceptionMode() == model.InterceptionNone
-	if noneMode {
+	if lb.node.GetInterceptionMode() == model.InterceptionNone {
 		// virtual listener is not necessary since workload is not using IPtables for traffic interception
 		return lb
 	}
@@ -382,8 +381,7 @@ func (lb *ListenerBuilder) buildVirtualOutboundListener(configgen *ConfigGenerat
 // TProxy uses only the virtual outbound listener on 15001 for both directions
 // but we still ship the no-op virtual inbound listener, so that the code flow is same across REDIRECT and TPROXY.
 func (lb *ListenerBuilder) buildVirtualInboundListener(configgen *ConfigGeneratorImpl) *ListenerBuilder {
-	noneMode := lb.node.GetInterceptionMode() == model.InterceptionNone
-	if noneMode {
+	if lb.node.GetInterceptionMode() == model.InterceptionNone {
 		// virtual listener is not necessary since workload is not using IPtables for traffic interception
 		return lb
 	}

--- a/pilot/pkg/networking/core/v1alpha3/listener_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_builder.go
@@ -350,6 +350,12 @@ func (lb *ListenerBuilder) buildHTTPProxyListener(configgen *ConfigGeneratorImpl
 }
 
 func (lb *ListenerBuilder) buildVirtualOutboundListener(configgen *ConfigGeneratorImpl) *ListenerBuilder {
+	noneMode := lb.node.GetInterceptionMode() == model.InterceptionNone
+	if noneMode {
+		// virtual listener is not necessary since workload is not using IPtables for traffic interception
+		return lb
+	}
+
 	var isTransparentProxy *wrappers.BoolValue
 	if lb.node.GetInterceptionMode() == model.InterceptionTproxy {
 		isTransparentProxy = proto.BoolTrue
@@ -376,6 +382,12 @@ func (lb *ListenerBuilder) buildVirtualOutboundListener(configgen *ConfigGenerat
 // TProxy uses only the virtual outbound listener on 15001 for both directions
 // but we still ship the no-op virtual inbound listener, so that the code flow is same across REDIRECT and TPROXY.
 func (lb *ListenerBuilder) buildVirtualInboundListener(configgen *ConfigGeneratorImpl) *ListenerBuilder {
+	noneMode := lb.node.GetInterceptionMode() == model.InterceptionNone
+	if noneMode {
+		// virtual listener is not necessary since workload is not using IPtables for traffic interception
+		return lb
+	}
+
 	var isTransparentProxy *wrappers.BoolValue
 	if lb.node.GetInterceptionMode() == model.InterceptionTproxy {
 		isTransparentProxy = proto.BoolTrue

--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -1647,12 +1647,12 @@ func TestVirtualListeners_TrafficRedirectionEnabled(t *testing.T) {
 
 			got := buildAllListeners(p, env, proxy)
 
-			virtualInboundListener := findListenerByPort(got, 15001)
+			virtualInboundListener := findListenerByName(got, model.VirtualInboundListenerName)
 			if virtualInboundListener == nil {
 				t.Fatalf("buildSidecarListeners() did not generate virtual inbound listener")
 			}
 
-			virtualOutboundListener := findListenerByPort(got, 15006)
+			virtualOutboundListener := findListenerByName(got, model.VirtualOutboundListenerName)
 			if virtualOutboundListener == nil {
 				t.Fatalf("buildSidecarListeners() did not generate virtual outbound listener")
 			}
@@ -1670,8 +1670,14 @@ func TestVirtualListeners_TrafficRedirectionDisabled(t *testing.T) {
 
 	got := buildAllListeners(p, env, proxy)
 
-	if diff := cmp.Diff(0, len(got)); diff != "" {
-		t.Fatalf("buildSidecarListeners() generated virtual inbound/outbound listener(s) while it shouldn't")
+	virtualInboundListener := findListenerByName(got, model.VirtualInboundListenerName)
+	if virtualInboundListener != nil {
+		t.Fatalf("buildSidecarListeners() generated virtual inbound listener while it shouldn't")
+	}
+
+	virtualOutboundListener := findListenerByName(got, model.VirtualOutboundListenerName)
+	if virtualOutboundListener != nil {
+		t.Fatalf("buildSidecarListeners() generated virtual outbound listener while it shouldn't")
 	}
 }
 
@@ -2633,6 +2639,16 @@ func findListenerByPort(listeners []*listener.Listener, port uint32) *listener.L
 func findListenerByAddress(listeners []*listener.Listener, address string) *listener.Listener {
 	for _, l := range listeners {
 		if address == l.Address.GetSocketAddress().Address {
+			return l
+		}
+	}
+
+	return nil
+}
+
+func findListenerByName(listeners []*listener.Listener, name string) *listener.Listener {
+	for _, l := range listeners {
+		if name == l.Name {
 			return l
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Yaroslav Skopets <yaroslav@tetrate.io>

**Please provide a description of this PR:**

This PR turns off generation of virtual inbound/outbound listeners for proxies that are not using Iptables redirection.

The purpose of this PR is to remove configuration Istio sidecar doesn't need, minimize potential for conflicts over ports, get closer to the support of multiple Istio Sidecars per VM.