### PR TITLE
wip: remove mutex from model.Service

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -883,6 +883,13 @@ func (c *Controller) GetService(hostname host.Name) *model.Service {
 	return svc
 }
 
+// SetService inserts a service to the mape
+func (c *Controller) SetService(svc *model.Service) {
+	c.Lock()
+	c.servicesMap[svc.Hostname] = svc
+	c.Unlock()
+}
+
 // getPodLocality retrieves the locality for a pod.
 func (c *Controller) getPodLocality(pod *v1.Pod) string {
 	// if pod has `istio-locality` label, skip below ops

--- a/pilot/pkg/serviceregistry/kube/controller/serviceimportcache.go
+++ b/pilot/pkg/serviceregistry/kube/controller/serviceimportcache.go
@@ -199,8 +199,10 @@ func (ic *serviceImportCacheImpl) updateIPs(mcsService *model.Service, ips []str
 	prevIPs := mcsService.ClusterVIPs.GetAddressesFor(ic.Cluster())
 	if !util.StringSliceEqual(prevIPs, ips) {
 		// Update the VIPs
+		mcsService = mcsService.DeepCopy()
 		mcsService.ClusterVIPs.SetAddressesFor(ic.Cluster(), ips)
 		updated = true
+		ic.SetService(mcsService)
 	}
 	return
 }


### PR DESCRIPTION
Currently we are using a mutex to modify a model.Service. This seems wrong to me; PushContext is supposed to be a snapshot of the current state of the world, but we are mutating it at will. Instead, it seems more appropriate to create a new service with the desired state and trigger a push when we change this.


I am not sure if this fixes any bugs or is simply a refactor...

Currently tests are failing so still a WIP