### PR TITLE
gitignore: cleanup stale entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,10 +17,6 @@ tools/vagrant/.vagrant/
 *.bak
 # python artifacts
 *.pyc
-# Vm setup generated files
-cluster.env
-sidecar.env
-kubedns
 # pilot
 pilot/pkg/kube/config
 pilot/pkg/proxy/envoy/envoy


### PR DESCRIPTION
Aside from not being relevant anymore, if you happen to have these old
test files around (which are no longer generated), the tests will fail.
So make it obvious they exist and let `git clean` remove them.

**Please provide a description of this PR:**



**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
