### PR TITLE
remove CheckProxyVerionForMX in 1.14

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -223,7 +223,7 @@ func (cb *ClusterBuilder) buildSubsetCluster(opts buildClusterOpts, destRule *co
 	maybeApplyEdsConfig(subsetCluster.cluster)
 
 	if cb.proxyType == model.Router || opts.direction == model.TrafficDirectionOutbound {
-		cb.applyMetadataExchange(cb.req.Push, opts.mutable.cluster)
+		cb.applyMetadataExchange(opts.mutable.cluster)
 	}
 
 	// Add the DestinationRule+subsets metadata. Metadata here is generated on a per-cluster
@@ -267,7 +267,7 @@ func (cb *ClusterBuilder) applyDestinationRule(mc *MutableCluster, clusterMode C
 	maybeApplyEdsConfig(mc.cluster)
 
 	if cb.proxyType == model.Router || opts.direction == model.TrafficDirectionOutbound {
-		cb.applyMetadataExchange(cb.req.Push, opts.mutable.cluster)
+		cb.applyMetadataExchange(opts.mutable.cluster)
 	}
 
 	if destRule != nil {
@@ -283,7 +283,7 @@ func (cb *ClusterBuilder) applyDestinationRule(mc *MutableCluster, clusterMode C
 	return subsetClusters
 }
 
-func (cb *ClusterBuilder) applyMetadataExchange(pc *model.PushContext, c *cluster.Cluster) {
+func (cb *ClusterBuilder) applyMetadataExchange(c *cluster.Cluster) {
 	if features.MetadataExchange {
 		c.Filters = append(c.Filters, xdsfilters.TCPClusterMx)
 	}
@@ -702,7 +702,7 @@ func (cb *ClusterBuilder) buildDefaultPassthroughCluster() *cluster.Cluster {
 		},
 	}
 	cb.applyConnectionPool(cb.req.Push.Mesh, NewMutableCluster(cluster), &networking.ConnectionPoolSettings{})
-	cb.applyMetadataExchange(cb.req.Push, cluster)
+	cb.applyMetadataExchange(cluster)
 	return cluster
 }
 

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -32,7 +32,7 @@ import (
 	"github.com/gogo/protobuf/types"
 	any "google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
-	structpb "google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/structpb"
 	wrappers "google.golang.org/protobuf/types/known/wrapperspb"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
@@ -284,7 +284,7 @@ func (cb *ClusterBuilder) applyDestinationRule(mc *MutableCluster, clusterMode C
 }
 
 func (cb *ClusterBuilder) applyMetadataExchange(pc *model.PushContext, c *cluster.Cluster) {
-	if features.MetadataExchange && util.CheckProxyVerionForMX(pc, model.ParseIstioVersion(cb.proxyVersion)) {
+	if features.MetadataExchange {
 		c.Filters = append(c.Filters, xdsfilters.TCPClusterMx)
 	}
 }

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -1421,7 +1421,7 @@ func buildHTTPConnectionManager(listenerOpts buildListenerOpts, httpOpts *httpLi
 	filters := make([]*hcm.HttpFilter, len(httpFilters))
 	copy(filters, httpFilters)
 
-	if features.MetadataExchange && util.CheckProxyVerionForMX(listenerOpts.push, listenerOpts.proxy.IstioVersion) {
+	if features.MetadataExchange {
 		filters = append(filters, xdsfilters.HTTPMx)
 	}
 

--- a/pilot/pkg/networking/core/v1alpha3/listener_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_builder.go
@@ -514,7 +514,7 @@ func buildInboundCatchAllFilterChains(configgen *ConfigGeneratorImpl,
 	}
 
 	var filters []*listener.Filter
-	filters = append(filters, buildMetadataExchangeNetworkFilters(push, istionetworking.ListenerClassSidecarInbound, node.IstioVersion)...)
+	filters = append(filters, buildMetadataExchangeNetworkFilters(istionetworking.ListenerClassSidecarInbound)...)
 	filters = append(filters, buildMetricsNetworkFilters(push, node, istionetworking.ListenerClassSidecarInbound)...)
 	filters = append(filters, &listener.Filter{
 		Name: wellknown.TCPProxy,
@@ -670,7 +670,7 @@ func (configgen *ConfigGeneratorImpl) buildInboundFilterchains(in *plugin.InputP
 		case istionetworking.ListenerProtocolHTTP:
 			fcOpt.httpOpts = configgen.buildSidecarInboundHTTPListenerOptsForPortOrUDS(in.Node, in, clusterName)
 			fcOpt.filterChain.TCP = append(
-				buildMetadataExchangeNetworkFilters(in.Push, istionetworking.ListenerClassSidecarInbound, in.Node.IstioVersion),
+				buildMetadataExchangeNetworkFilters(istionetworking.ListenerClassSidecarInbound),
 				fcOpt.filterChain.TCP...)
 		case istionetworking.ListenerProtocolTCP:
 			fcOpt.networkFilters = buildInboundNetworkFilters(in.Push, in.Node, in.ServiceInstance, clusterName)

--- a/pilot/pkg/networking/core/v1alpha3/networkfilter.go
+++ b/pilot/pkg/networking/core/v1alpha3/networkfilter.go
@@ -43,9 +43,6 @@ var redisOpTimeout = 5 * time.Second
 
 func buildMetadataExchangeNetworkFilters(push *model.PushContext, class istionetworking.ListenerClass, version *model.IstioVersion) []*listener.Filter {
 	filterstack := make([]*listener.Filter, 0)
-	if !util.CheckProxyVerionForMX(push, version) {
-		return filterstack
-	}
 	// We add metadata exchange on inbound only; outbound is handled in cluster filter
 	if class == istionetworking.ListenerClassSidecarInbound && features.MetadataExchange {
 		filterstack = append(filterstack, xdsfilters.TCPListenerMx)

--- a/pilot/pkg/networking/core/v1alpha3/networkfilter.go
+++ b/pilot/pkg/networking/core/v1alpha3/networkfilter.go
@@ -41,7 +41,7 @@ import (
 // redisOpTimeout is the default operation timeout for the Redis proxy filter.
 var redisOpTimeout = 5 * time.Second
 
-func buildMetadataExchangeNetworkFilters(push *model.PushContext, class istionetworking.ListenerClass, version *model.IstioVersion) []*listener.Filter {
+func buildMetadataExchangeNetworkFilters(class istionetworking.ListenerClass) []*listener.Filter {
 	filterstack := make([]*listener.Filter, 0)
 	// We add metadata exchange on inbound only; outbound is handled in cluster filter
 	if class == istionetworking.ListenerClassSidecarInbound && features.MetadataExchange {
@@ -74,7 +74,7 @@ func buildInboundNetworkFilters(push *model.PushContext, proxy *model.Proxy, ins
 	tcpFilter := setAccessLogAndBuildTCPFilter(push, proxy, tcpProxy)
 
 	var filters []*listener.Filter
-	filters = append(filters, buildMetadataExchangeNetworkFilters(push, istionetworking.ListenerClassSidecarInbound, proxy.IstioVersion)...)
+	filters = append(filters, buildMetadataExchangeNetworkFilters(istionetworking.ListenerClassSidecarInbound)...)
 	filters = append(filters, buildMetricsNetworkFilters(push, proxy, istionetworking.ListenerClassSidecarInbound)...)
 	filters = append(filters, buildNetworkFiltersStack(instance.ServicePort, tcpFilter, statPrefix, clusterName)...)
 	return filters
@@ -109,7 +109,7 @@ func buildOutboundNetworkFiltersWithSingleDestination(push *model.PushContext, n
 	tcpFilter := setAccessLogAndBuildTCPFilter(push, node, tcpProxy)
 
 	var filters []*listener.Filter
-	filters = append(filters, buildMetadataExchangeNetworkFilters(push, model.OutboundListenerClass(node.Type), node.IstioVersion)...)
+	filters = append(filters, buildMetadataExchangeNetworkFilters(model.OutboundListenerClass(node.Type))...)
 	filters = append(filters, buildMetricsNetworkFilters(push, node, model.OutboundListenerClass(node.Type))...)
 	filters = append(filters, buildNetworkFiltersStack(port, tcpFilter, statPrefix, clusterName)...)
 	return filters
@@ -153,7 +153,7 @@ func buildOutboundNetworkFiltersWithWeightedClusters(node *model.Proxy, routes [
 	tcpFilter := setAccessLogAndBuildTCPFilter(push, node, tcpProxy)
 
 	var filters []*listener.Filter
-	filters = append(filters, buildMetadataExchangeNetworkFilters(push, model.OutboundListenerClass(node.Type), node.IstioVersion)...)
+	filters = append(filters, buildMetadataExchangeNetworkFilters(model.OutboundListenerClass(node.Type))...)
 	filters = append(filters, buildMetricsNetworkFilters(push, node, model.OutboundListenerClass(node.Type))...)
 	filters = append(filters, buildNetworkFiltersStack(port, tcpFilter, statPrefix, clusterName)...)
 	return filters

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -100,11 +100,6 @@ const (
 
 	// Well-known header names
 	AltSvcHeader = "alt-svc"
-
-	// Well-known metadata exchange EnvoyFilter config name
-	// TODO: Remove these at 1.14.
-	MXName110 = "metadata-exchange-1.10"
-	MXName111 = "metadata-exchange-1.11"
 )
 
 // ALPNH2Only advertises that Proxy is going to use HTTP/2 when talking to the cluster.
@@ -721,26 +716,4 @@ func DomainName(host string, port int) string {
 func TraceOperation(host string, port int) string {
 	// Format : "%s:%d/*"
 	return DomainName(host, port) + "/*"
-}
-
-// CheckProxyVerionForMX checks whether metadata exchange filters should be injected
-// based on proxy version and presence of the well known metadata exchange EnvoyFilter.
-// TODO: Remove this at 1.14 release, since we support skip version upgrade
-//       now and 1.11 proxy can talk to 1.13 control plane.
-func CheckProxyVerionForMX(push *model.PushContext, proxyVersion *model.IstioVersion) bool {
-	if IsIstioVersionGE112(proxyVersion) {
-		// Always inject for proxy >= 1.12 since mx EnvoyFilters are removed.
-		return true
-	}
-	if IsIstioVersionGE111(proxyVersion) {
-		// If Istio version is >= 1.11 and < 1.12, inject only if the well known 1.11 EnvoyFilter does not present.
-		return !push.HasEnvoyFilters(MXName111, push.Mesh.RootNamespace)
-	}
-	if IsIstioVersionGE110(proxyVersion) {
-		// If Istio version is >= 1.10 and < 1.11, inject only if the well known 1.10 EnvoyFilter does not present.
-		return !push.HasEnvoyFilters(MXName110, push.Mesh.RootNamespace)
-	}
-
-	// For proxy < 1.10, this is not a supported case, we inject anyway.
-	return true
 }


### PR DESCRIPTION
**Please provide a description of this PR:**


For proxy >=1.12 metadata exchange filter is injected, so remove the check in 1.14


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [x] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
