### PR TITLE
Fix rendering of injectedAnnotations in Helm charts

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/istiod-injector-configmap.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/istiod-injector-configmap.yaml
@@ -36,7 +36,7 @@ data:
 {{ toYaml .Values.sidecarInjectorWebhook.neverInjectSelector | trim | indent 6 }}
     injectedAnnotations:
       {{- range $key, $val := .Values.sidecarInjectorWebhook.injectedAnnotations }}
-      "{{ $key }}": "{{ $val }}"
+      "{{ $key }}": {{ $val | quote }}
       {{- end }}
     {{- /* If someone ends up with this new template, but an older Istiod image, they will attempt to render this template
          which will fail with "Pod injection failed: template: inject:1: function "Istio_1_9_Required_Template_And_Version_Mismatched" not defined".

--- a/manifests/charts/istiod-remote/templates/istiod-injector-configmap.yaml
+++ b/manifests/charts/istiod-remote/templates/istiod-injector-configmap.yaml
@@ -36,7 +36,7 @@ data:
 {{ toYaml .Values.sidecarInjectorWebhook.neverInjectSelector | trim | indent 6 }}
     injectedAnnotations:
       {{- range $key, $val := .Values.sidecarInjectorWebhook.injectedAnnotations }}
-      "{{ $key }}": "{{ $val }}"
+      "{{ $key }}": {{ $val | quote }}
       {{- end }}
     {{- /* If someone ends up with this new template, but an older Istiod image, they will attempt to render this template
          which will fail with "Pod injection failed: template: inject:1: function "Istio_1_9_Required_Template_And_Version_Mismatched" not defined".


### PR DESCRIPTION
If an injected annotation value contained a double-quote character, the rendered istiod-injector-configmap YAML would be invalid. Unmarshalling the inject config would fail with: update error: failed to unmarshal injection template: error converting YAML to JSON: yaml: line 10: did not find expected key