### PR TITLE
Fix route cache service key.

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -262,6 +262,8 @@ func BuildSidecarOutboundVirtualHosts(node *model.Proxy, push *model.PushContext
 				Resolution:     svc.Resolution,
 				Ports:          []*model.Port{svcPort},
 				Attributes: model.ServiceAttributes{
+					Name:            svc.Attributes.Name,
+					Namespace:       svc.Attributes.Namespace,
 					ServiceRegistry: svc.Attributes.ServiceRegistry,
 				},
 			}
@@ -306,7 +308,7 @@ func BuildSidecarOutboundVirtualHosts(node *model.Proxy, push *model.PushContext
 	virtualHostWrappers := istio_route.BuildSidecarVirtualHostWrapper(routeCache, node, push, servicesByName, virtualServices, listenerPort)
 
 	resource, exist := xdsCache.Get(routeCache)
-	if exist {
+	if exist && !features.EnableUnsafeAssertions {
 		return nil, resource, routeCache
 	}
 

--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -262,7 +262,6 @@ func BuildSidecarOutboundVirtualHosts(node *model.Proxy, push *model.PushContext
 				Resolution:     svc.Resolution,
 				Ports:          []*model.Port{svcPort},
 				Attributes: model.ServiceAttributes{
-					Name:            svc.Attributes.Name,
 					Namespace:       svc.Attributes.Namespace,
 					ServiceRegistry: svc.Attributes.ServiceRegistry,
 				},

--- a/pilot/pkg/networking/core/v1alpha3/route/route_cache.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route_cache.go
@@ -78,7 +78,7 @@ func (r *Cache) DependentConfigs() []model.ConfigKey {
 	configs := make([]model.ConfigKey, 0, len(r.Services)+len(r.VirtualServices)+
 		len(r.DelegateVirtualServices)+len(r.DestinationRules)+len(r.EnvoyFilterKeys))
 	for _, svc := range r.Services {
-		configs = append(configs, model.ConfigKey{Kind: gvk.ServiceEntry, Name: svc.Attributes.Namespace, Namespace: svc.Attributes.Namespace})
+		configs = append(configs, model.ConfigKey{Kind: gvk.ServiceEntry, Name: svc.Attributes.Name, Namespace: svc.Attributes.Namespace})
 	}
 	for _, vs := range r.VirtualServices {
 		configs = append(configs, model.ConfigKey{Kind: gvk.VirtualService, Name: vs.Name, Namespace: vs.Namespace})

--- a/pilot/pkg/networking/core/v1alpha3/route/route_cache.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route_cache.go
@@ -78,7 +78,7 @@ func (r *Cache) DependentConfigs() []model.ConfigKey {
 	configs := make([]model.ConfigKey, 0, len(r.Services)+len(r.VirtualServices)+
 		len(r.DelegateVirtualServices)+len(r.DestinationRules)+len(r.EnvoyFilterKeys))
 	for _, svc := range r.Services {
-		configs = append(configs, model.ConfigKey{Kind: gvk.ServiceEntry, Name: string(svc.Hostname), Namespace: svc.Attributes.Namespace})
+		configs = append(configs, model.ConfigKey{Kind: gvk.ServiceEntry, Name: svc.Attributes.Namespace, Namespace: svc.Attributes.Namespace})
 	}
 	for _, vs := range r.VirtualServices {
 		configs = append(configs, model.ConfigKey{Kind: gvk.VirtualService, Name: vs.Name, Namespace: vs.Namespace})

--- a/pilot/pkg/networking/core/v1alpha3/route/route_cache.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route_cache.go
@@ -78,7 +78,7 @@ func (r *Cache) DependentConfigs() []model.ConfigKey {
 	configs := make([]model.ConfigKey, 0, len(r.Services)+len(r.VirtualServices)+
 		len(r.DelegateVirtualServices)+len(r.DestinationRules)+len(r.EnvoyFilterKeys))
 	for _, svc := range r.Services {
-		configs = append(configs, model.ConfigKey{Kind: gvk.ServiceEntry, Name: svc.Attributes.Name, Namespace: svc.Attributes.Namespace})
+		configs = append(configs, model.ConfigKey{Kind: gvk.ServiceEntry, Name: string(svc.Hostname), Namespace: svc.Attributes.Namespace})
 	}
 	for _, vs := range r.VirtualServices {
 		configs = append(configs, model.ConfigKey{Kind: gvk.VirtualService, Name: vs.Name, Namespace: vs.Namespace})

--- a/releasenotes/notes/37356.yaml
+++ b/releasenotes/notes/37356.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - https://github.com/istio/istio/pull/37356
+releaseNotes:
+  - |
+    **Fixed** an issue where service update does not trigger route update.
+


### PR DESCRIPTION
Fix https://github.com/istio/istio/issues/37356

Route cache uses a copy of services when constructing key, which does not have attributes populated. Also cache assertion does not really work for rds cache for now and this PR fixes that.