### PR TITLE
pilot-agent add cert expiry metric

### DIFF
--- a/pilot/pkg/bootstrap/monitoring.go
+++ b/pilot/pkg/bootstrap/monitoring.go
@@ -47,7 +47,7 @@ var (
 	)
 )
 
-func init() {
+func init(){
 	uptime.ValueFrom(func() float64 {
 		return time.Since(serverStart).Seconds()
 	})

--- a/pilot/pkg/bootstrap/monitoring.go
+++ b/pilot/pkg/bootstrap/monitoring.go
@@ -47,7 +47,7 @@ var (
 	)
 )
 
-func init(){
+func init() {
 	uptime.ValueFrom(func() float64 {
 		return time.Since(serverStart).Seconds()
 	})

--- a/security/pkg/nodeagent/cache/monitoring.go
+++ b/security/pkg/nodeagent/cache/monitoring.go
@@ -51,7 +51,7 @@ var (
 		"cert_expiry_seconds",
 		"The left time, in seconds, when cert chain will expire. "+
 			"A negative value indicates the cert is expired.",
-			monitoring.WithLabelKeys("resource_name"))
+		monitoring.WithLabelKeys("resource_name"))
 )
 
 func init() {

--- a/security/pkg/nodeagent/cache/monitoring.go
+++ b/security/pkg/nodeagent/cache/monitoring.go
@@ -14,7 +14,9 @@
 
 package cache
 
-import "istio.io/pkg/monitoring"
+import (
+	"istio.io/pkg/monitoring"
+)
 
 var RequestType = monitoring.MustCreateLabel("request_type")
 
@@ -44,6 +46,12 @@ var (
 	numFileSecretFailures = monitoring.NewSum(
 		"num_file_secret_failures_total",
 		"Number of times secret generation failed for files")
+
+	certExpirySeconds = monitoring.NewDerivedGauge(
+		"cert_expiry_seconds",
+		"The left time, in seconds, when cert chain will expire. "+
+			"A negative value indicates the cert is expired.",
+			monitoring.WithLabelKeys("resource_name"))
 )
 
 func init() {

--- a/security/pkg/nodeagent/cache/secretcache.go
+++ b/security/pkg/nodeagent/cache/secretcache.go
@@ -628,6 +628,7 @@ func (sc *SecretManagerClient) rotateTime(secret security.SecretItem) time.Durat
 
 func (sc *SecretManagerClient) registerSecret(item security.SecretItem) {
 	delay := sc.rotateTime(item)
+	certExpirySeconds.ValueFrom(func() float64 { return time.Until(item.ExpireTime).Seconds() }, item.ResourceName)
 	item.ResourceName = security.WorkloadKeyCertResourceName
 	// In case there are two calls to GenerateSecret at once, we don't want both to be concurrently registered
 	if sc.cache.GetWorkload() != nil {


### PR DESCRIPTION
**Please provide a description of this PR:**

add a Gauge metric of `default` cert expiry minutes on `pilot-agent`

```console
# HELP istio_agent_cert_expiry_minutes The left minutes, when cert chain will expire. A negative value indicates the cert is expired.
# TYPE istio_agent_cert_expiry_minutes gauge
istio_agent_cert_expiry_minutes{resource_name="default"} 701
```

fixed: https://github.com/istio/istio/issues/37291

***warning***

see from 
https://github.com/census-instrumentation/opencensus-go/blob/49838f207d61097fc0ebb8aeef306913388376ca/metric/registry.go#L237

the registry use metric.Name as key, I think we can not have multi DerivedGauge (same name but different in labels) before we modify the implement of upstream.

In short-term, this PR will allow user monitor `default` cert.
for a long-term, we should make `DerivedGauge ` support metrics with different labels.

BTW, `opencensus-go` is merged to `OpenTelemetry`, so that would take a little more time to achieve this.


