### PR TITLE
[TF] echo.Call use retry.Converge by default

### DIFF
--- a/pkg/test/framework/components/echo/flags.go
+++ b/pkg/test/framework/components/echo/flags.go
@@ -24,6 +24,7 @@ import (
 var (
 	callTimeout      = 20 * time.Second
 	callDelay        = 10 * time.Millisecond
+	callConverge     = 3
 	readinessTimeout = 10 * time.Minute
 )
 
@@ -33,13 +34,15 @@ func init() {
 		"Specifies the default total timeout used when retrying calls to the Echo service")
 	flag.DurationVar(&callDelay, "istio.test.echo.callDelay", callDelay,
 		"Specifies the default delay between successive retry attempts when calling the Echo service")
+	flag.IntVar(&callConverge, "istio.test.echo.callConverge", callConverge,
+		"Specifies the number of successive retry attempts that must be successful when calling the Echo service")
 	flag.DurationVar(&readinessTimeout, "istio.test.echo.readinessTimeout", readinessTimeout,
 		"Specifies the default timeout for echo readiness check")
 }
 
 // DefaultCallRetryOptions returns the default call retry options as specified in command-line flags.
 func DefaultCallRetryOptions() []retry.Option {
-	return []retry.Option{retry.Timeout(callTimeout), retry.BackoffDelay(callDelay)}
+	return []retry.Option{retry.Timeout(callTimeout), retry.BackoffDelay(callDelay), retry.Converge(callConverge)}
 }
 
 // DefaultReadinessTimeout returns the default echo readiness check timeout.

--- a/tests/integration/pilot/common/traffic.go
+++ b/tests/integration/pilot/common/traffic.go
@@ -37,9 +37,6 @@ import (
 // callsPerCluster is used to ensure cross-cluster load balancing has a chance to work
 const callsPerCluster = 5
 
-// Require 3 successive successes. Delay can be configured with istio.test.echo.callDelay
-var retryOptions = []retry.Option{retry.Converge(3)}
-
 type TrafficCall struct {
 	name string
 	call func(t test.Failer, options echo.CallOptions, retryOptions ...retry.Option) echoclient.ParsedResponses
@@ -164,11 +161,11 @@ func (c TrafficTestCase) RunForApps(t framework.TestContext, apps echo.Instances
 				return opts
 			}
 			if optsSpecified {
-				src.CallWithRetryOrFail(t, buildOpts(c.opts), retryOptions...)
+				src.CallWithRetryOrFail(t, buildOpts(c.opts))
 			}
 			for _, child := range c.children {
 				t.NewSubTest(child.name).Run(func(t framework.TestContext) {
-					src.CallWithRetryOrFail(t, buildOpts(child.opts), retryOptions...)
+					src.CallWithRetryOrFail(t, buildOpts(child.opts))
 				})
 			}
 		}
@@ -217,13 +214,12 @@ func (c TrafficTestCase) Run(t framework.TestContext, namespace string) {
 		}
 
 		if c.call != nil {
-			// Call the function with a few custom retry options.
-			c.call(t, c.opts, retryOptions...)
+			c.call(t, c.opts)
 		}
 
 		for _, child := range c.children {
 			t.NewSubTest(child.name).Run(func(t framework.TestContext) {
-				child.call(t, child.opts, retryOptions...)
+				child.call(t, child.opts)
 			})
 		}
 	}


### PR DESCRIPTION
We're already using `retry.Converge(3)` for all networking traffic tests. This PR promotes this to a default for all echo-based tests.

**Please provide a description of this PR:**