### PR TITLE
tf: use consistent log format

### DIFF
--- a/tests/integration/security/main_test.go
+++ b/tests/integration/security/main_test.go
@@ -60,7 +60,6 @@ values:
     env: 
       PILOT_JWT_ENABLE_REMOTE_JWKS: true
 meshConfig:
-  accessLogEncoding: JSON
   accessLogFile: /dev/stdout
   defaultConfig:
     image:


### PR DESCRIPTION
Currently all other tests use text log, and this is read by humans which makes test based more readable.