### PR TITLE
vm support: don't generate inbound/outbound listeners for privileged ports (1-1023) when sidecar is not using Iptables and explicitly indicated that it is unprivileged

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -871,7 +871,7 @@ func TestOutboundListener_PrivilegedPorts(t *testing.T) {
 	// if proxy is not using Iptables and cannot bind to privileged ports (1-1023).
 	//
 	// It is very common for the catch all egress listener to match services on ports 80 and 443.
-	// Therefore, the default behaviour should not force users to start from looking for a workaround.
+	// Therefore, the default behavior should not force users to start from looking for a workaround.
 	t.Run("implicit catch all egress listener", func(t *testing.T) {
 		testPrivilegedPorts(t, func(t *testing.T, proxy *model.Proxy, port uint32) []*listener.Listener {
 			p := &fakePlugin{}


### PR DESCRIPTION
Signed-off-by: Yaroslav Skopets <yaroslav@tetrate.io>

**Please provide a description of this PR:**

This PR stops generating inbound/outbound listeners for privileged ports (1-1023) when sidecar is not using Iptables and explicitly indicated that it is unprivileged.

Overall, this behaviour is similar to [the one for Ingress Gateways](https://github.com/istio/istio/blob/47260b9cd90073a5de70258dec253505329a45d1/pilot/pkg/networking/core/v1alpha3/gateway.go#L73-L80).

This PR addresses a problem common for sidecars on VMs that are not using Iptables:
* according to the default `Sidecar` config, sidecars get outbound listeners for all ports of all reachable services
* almost always, there are reachable services on ports `80` or `443`
* as a result, sidecar on VM rejects LDS updates since it's unable to bind to `127.0.0.1:80` or `127.0.0.1:443`
* to workaround the problem, a user has to start his/her journey from creating an intricate `Sidecar` config

The purpose of this PR is to ensure that Istio behaves reasonably by default.