### PR TITLE
Fix centos sidecar

### DIFF
--- a/pkg/test/echo/docker/Dockerfile.app_sidecar_base_centos
+++ b/pkg/test/echo/docker/Dockerfile.app_sidecar_base_centos
@@ -3,7 +3,7 @@ FROM centos:${VM_IMAGE_VERSION}
 ARG VM_IMAGE_VERSION=8
 
 # Workaround Centos 8 death
-RUN if [ "${VM_IMAGE_VERSION}" = "8" ]; then sed -i -e "s|mirrorlist=|#mirrorlist=|g" -e "s|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g" /etc/yum.repos.d/CentOS-Linux-* ; fi
+RUN if [ "${VM_IMAGE_VERSION}" = "8" ]; then sed -i -e "s|mirrorlist=|#mirrorlist=|g" -e "s|#baseurl=http://mirror.centos.org|baseurl=https://vault.centos.org|g" /etc/yum.repos.d/CentOS-Linux-* ; fi
 
 # hadolint ignore=DL3005,DL3008,DL3033
 RUN yum install -y \


### PR DESCRIPTION
**Please provide a description of this PR:**

Seeing a failure trying to build the centos image. It looks like they moved from http to https

```
curl http://vault.centos.org/centos/8/AppStream/x86_64/os/repodata/repomd.xml
...
<title>301 Moved Permanently</title>
</head><body>
<h1>Moved Permanently</h1>
<p>The document has moved <a href="https://vault.centos.org/centos/8/AppStream/x86_64/os/repodata/repomd.xml">here</a>.</p>
```