### PR TITLE
Headless service should use target port in istio

### DIFF
--- a/pkg/test/framework/components/echo/common/call.go
+++ b/pkg/test/framework/components/echo/common/call.go
@@ -195,6 +195,10 @@ func fillInCallOptions(opts *echo.CallOptions) error {
 			for _, port := range targetPorts {
 				if reflect.DeepEqual(port, *opts.Port) {
 					found = true
+					if opts.Target.Config().Headless {
+						// set service port to instance port
+						opts.Port.ServicePort = opts.Port.InstancePort
+					}
 					break
 				}
 			}
@@ -204,10 +208,15 @@ func fillInCallOptions(opts *echo.CallOptions) error {
 		} else {
 			// Look up the port.
 			found := false
-			for i, port := range targetPorts {
+			for _, port := range targetPorts {
 				if opts.PortName == port.Name {
 					found = true
-					opts.Port = &targetPorts[i]
+					copied := port
+					if opts.Target.Config().Headless {
+						// set service port to instance port
+						copied.ServicePort = copied.InstancePort
+					}
+					opts.Port = &copied
 					break
 				}
 			}

--- a/tests/integration/pilot/common/apps.go
+++ b/tests/integration/pilot/common/apps.go
@@ -129,12 +129,6 @@ func SetupApps(t resource.Context, i istio.Instance, apps *EchoDeployments) erro
 	apps.Ingress = i.IngressFor(t.Clusters().Default())
 	apps.Ingresses = i.Ingresses()
 
-	// Headless services don't work with targetPort, set to same port
-	headlessPorts := make([]echo.Port, len(common.EchoPorts))
-	for i, p := range common.EchoPorts {
-		p.ServicePort = p.InstancePort
-		headlessPorts[i] = p
-	}
 	builder := echoboot.NewBuilder(t).
 		WithClusters(t.Clusters()...).
 		WithConfig(echo.Config{
@@ -163,7 +157,7 @@ func SetupApps(t resource.Context, i istio.Instance, apps *EchoDeployments) erro
 			Service:           HeadlessSvc,
 			Headless:          true,
 			Namespace:         apps.Namespace,
-			Ports:             headlessPorts,
+			Ports:             common.EchoPorts,
 			Subsets:           []echo.SubsetConfig{{}},
 			WorkloadOnlyPorts: common.WorkloadPorts,
 		}).
@@ -172,7 +166,7 @@ func SetupApps(t resource.Context, i istio.Instance, apps *EchoDeployments) erro
 			Headless:          true,
 			StatefulSet:       true,
 			Namespace:         apps.Namespace,
-			Ports:             headlessPorts,
+			Ports:             common.EchoPorts,
 			Subsets:           []echo.SubsetConfig{{}},
 			WorkloadOnlyPorts: common.WorkloadPorts,
 		}).


### PR DESCRIPTION
**Please provide a description of this PR:**

Without this, a headless service with

 port: 80
 targetPort: 8080

Istio does not generate a listener for 8080, not event to manage its traffic.

TODO: should add a release note