### PR TITLE
push context: refactor DestinationRule to split usages

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -936,17 +936,9 @@ func (ps *PushContext) getSidecarScope(proxy *Proxy, workloadLabels labels.Colle
 }
 
 // DestinationRule returns a destination rule for a service name in a given domain.
-func (ps *PushContext) DestinationRule(proxy *Proxy, service *Service) *config.Config {
+func (ps *PushContext) destinationRuleForSidecarScope(proxy *Proxy, service *Service) *config.Config {
 	if service == nil {
 		return nil
-	}
-
-	// If proxy has a sidecar scope that is user supplied, then get the destination rules from the sidecar scope
-	// sidecarScope.config is nil if there is no sidecar scope for the namespace
-	if proxy.SidecarScope != nil && proxy.Type == SidecarProxy {
-		// If there is a sidecar scope for this proxy, return the destination rule
-		// from the sidecar scope.
-		return proxy.SidecarScope.destinationRules[service.Hostname]
 	}
 
 	// If the proxy config namespace is same as the root config namespace

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -1343,7 +1343,7 @@ func TestSetDestinationRuleInheritance(t *testing.T) {
 	ps.SetDestinationRules([]config.Config{meshDestinationRule, nsDestinationRule, svcDestinationRule, destinationRuleNamespace2})
 
 	for _, tt := range testCases {
-		mergedConfig := ps.DestinationRule(&Proxy{ConfigNamespace: tt.proxyNs},
+		mergedConfig := ps.destinationRuleForSidecarScope(&Proxy{ConfigNamespace: tt.proxyNs},
 			&Service{
 				Hostname: host.Name(tt.serviceHostname),
 				Attributes: ServiceAttributes{
@@ -1622,7 +1622,7 @@ func TestSetDestinationRuleWithExportTo(t *testing.T) {
 	}
 	for _, tt := range cases {
 		t.Run(fmt.Sprintf("%s-%s", tt.proxyNs, tt.serviceNs), func(t *testing.T) {
-			destRuleConfig := ps.DestinationRule(&Proxy{ConfigNamespace: tt.proxyNs},
+			destRuleConfig := ps.destinationRuleForSidecarScope(&Proxy{ConfigNamespace: tt.proxyNs},
 				&Service{
 					Hostname: host.Name(tt.host),
 					Attributes: ServiceAttributes{

--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -210,7 +210,7 @@ func DefaultSidecarScopeForNamespace(ps *PushContext, configNamespace string) *S
 			continue
 		}
 		out.servicesByHostname[s.Hostname] = s
-		if dr := ps.DestinationRule(&dummyNode, s); dr != nil {
+		if dr := ps.destinationRuleForSidecarScope(&dummyNode, s); dr != nil {
 			out.destinationRules[s.Hostname] = dr
 		}
 		out.AddConfigDependencies(ConfigKey{
@@ -405,7 +405,7 @@ func ConvertToSidecarScope(ps *PushContext, sidecarConfig *config.Config, config
 	out.destinationRules = make(map[host.Name]*config.Config)
 	for _, s := range out.services {
 		out.servicesByHostname[s.Hostname] = s
-		dr := ps.DestinationRule(&dummyNode, s)
+		dr := ps.destinationRuleForSidecarScope(&dummyNode, s)
 		if dr != nil {
 			out.destinationRules[s.Hostname] = dr
 			out.AddConfigDependencies(ConfigKey{
@@ -555,6 +555,10 @@ func (sc *SidecarScope) AddConfigDependencies(dependencies ...ConfigKey) {
 	for _, config := range dependencies {
 		sc.configDependencies[config.HashCode()] = struct{}{}
 	}
+}
+
+func (sc *SidecarScope) DestinationRule(svc host.Name) *config.Config {
+	return sc.destinationRules[svc]
 }
 
 // Return filtered services through the hosts field in the egress portion of the Sidecar config.

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -214,7 +214,7 @@ func buildClusterKey(service *model.Service, port *model.Port, cb *ClusterBuilde
 		downstreamAuto:  cb.sidecarProxy() && util.IsProtocolSniffingEnabledForOutboundPort(port),
 		supportsIPv4:    cb.supportsIPv4,
 		service:         service,
-		destinationRule: cb.req.Push.DestinationRule(proxy, service),
+		destinationRule: proxy.SidecarScope.DestinationRule(service.Hostname),
 		envoyFilterKeys: efKeys,
 		metadataCerts:   cb.metadataCerts,
 		peerAuthVersion: cb.req.Push.AuthnPolicies.GetVersion(),
@@ -338,7 +338,7 @@ func (configgen *ConfigGeneratorImpl) buildOutboundSniDnatClusters(proxy *model.
 		if service.MeshExternal {
 			continue
 		}
-		destRule := cb.req.Push.DestinationRule(proxy, service)
+		destRule := proxy.SidecarScope.DestinationRule(service.Hostname)
 		for _, port := range service.Ports {
 			if port.Protocol == protocol.UDP {
 				continue

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -529,7 +529,7 @@ func (cb *ClusterBuilder) buildInboundClusterForPortOrUDS(clusterPort int, bind 
 	// (not the defaults) to handle the increased traffic volume
 	// TODO: This is not foolproof - if instance is part of multiple services listening on same port,
 	// choice of inbound cluster is arbitrary. So the connection pool settings may not apply cleanly.
-	cfg := cb.req.Push.DestinationRule(proxy, instance.Service)
+	cfg := proxy.SidecarScope.DestinationRule(instance.Service.Hostname)
 	if cfg != nil {
 		destinationRule := cfg.Spec.(*networking.DestinationRule)
 		if destinationRule.TrafficPolicy != nil {

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
@@ -491,7 +491,7 @@ func TestApplyDestinationRule(t *testing.T) {
 			cb := NewClusterBuilder(proxy, &model.PushRequest{Push: cg.PushContext()}, nil)
 
 			ec := NewMutableCluster(tt.cluster)
-			destRule := cb.req.Push.DestinationRule(proxy, tt.service)
+			destRule := proxy.SidecarScope.DestinationRule(tt.service.Hostname)
 
 			subsetClusters := cb.applyDestinationRule(ec, tt.clusterMode, tt.service, tt.port, tt.networkView, destRule, nil)
 			if len(subsetClusters) != len(tt.expectedSubsetClusters) {
@@ -3047,7 +3047,7 @@ func TestApplyDestinationRuleOSCACert(t *testing.T) {
 			cb := NewClusterBuilder(proxy, &model.PushRequest{Push: cg.PushContext()}, nil)
 
 			ec := NewMutableCluster(tt.cluster)
-			destRule := cb.req.Push.DestinationRule(proxy, tt.service)
+			destRule := proxy.SidecarScope.DestinationRule(tt.service.Hostname)
 
 			// ACT
 			_ = cb.applyDestinationRule(ec, tt.clusterMode, tt.service, tt.port, tt.networkView, destRule, nil)

--- a/pilot/pkg/networking/core/v1alpha3/fake.go
+++ b/pilot/pkg/networking/core/v1alpha3/fake.go
@@ -62,6 +62,7 @@ type TestOptions struct {
 	// Services to pre-populate as part of the service discovery
 	Services  []*model.Service
 	Instances []*model.ServiceInstance
+	Gateways  []model.NetworkGateway
 
 	// If provided, this mesh config will be used
 	MeshConfig      *meshconfig.MeshConfig
@@ -130,6 +131,7 @@ func NewConfigGenTest(t test.Failer, opts TestOptions) *ConfigGenTest {
 	for _, instance := range opts.Instances {
 		msd.AddInstance(instance.Service.Hostname, instance)
 	}
+	msd.AddGateways(opts.Gateways...)
 	msd.ClusterID = string(provider.Mock)
 	serviceDiscovery.AddRegistry(serviceregistry.Simple{
 		ClusterID:        cluster2.ID(provider.Mock),

--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -866,8 +866,7 @@ func builtAutoPassthroughFilterChains(push *model.PushContext, proxy *model.Prox
 			if len(push.Mesh.OutboundClusterStatName) != 0 {
 				statPrefix = util.BuildStatPrefix(push.Mesh.OutboundClusterStatName, string(service.Hostname), "", port, &service.Attributes)
 			}
-			destRule := push.DestinationRule(proxy, service)
-			destinationRule := CastDestinationRule(destRule)
+			destinationRule := CastDestinationRule(proxy.SidecarScope.DestinationRule(service.Hostname))
 
 			// First, we build the standard cluster. We match on the SNI matching the cluster name
 			// (per the spec of AUTO_PASSTHROUGH), as well as all possible Istio mTLS ALPNs. This,

--- a/pilot/pkg/networking/core/v1alpha3/networkfilter.go
+++ b/pilot/pkg/networking/core/v1alpha3/networkfilter.go
@@ -223,8 +223,10 @@ func buildOutboundNetworkFilters(node *model.Proxy,
 	routes []*networking.RouteDestination, push *model.PushContext,
 	port *model.Port, configMeta config.Meta) []*listener.Filter {
 	service := push.ServiceForHostname(node, host.Name(routes[0].Destination.Host))
-	destRule := push.DestinationRule(node, service)
-	destinationRule := CastDestinationRule(destRule)
+	var destinationRule *networking.DestinationRule
+	if service != nil {
+		destinationRule = CastDestinationRule(node.SidecarScope.DestinationRule(service.Hostname))
+	}
 	if len(routes) == 1 {
 		clusterName := istioroute.GetDestinationCluster(routes[0].Destination, service, port.Port)
 		statPrefix := clusterName

--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -1272,7 +1272,7 @@ func getHashForService(node *model.Proxy, push *model.PushContext,
 	if push == nil {
 		return nil, nil
 	}
-	destinationRule := push.DestinationRule(node, svc)
+	destinationRule := node.SidecarScope.DestinationRule(svc.Hostname)
 	if destinationRule == nil {
 		return nil, nil
 	}
@@ -1323,11 +1323,7 @@ func GetHashForHTTPDestination(push *model.PushContext, node *model.Proxy, dst *
 	}
 
 	destination := dst.GetDestination()
-	destinationRule := push.DestinationRule(node,
-		&model.Service{
-			Hostname:   host.Name(destination.Host),
-			Attributes: model.ServiceAttributes{Namespace: configNamespace},
-		})
+	destinationRule := node.SidecarScope.DestinationRule(host.Name(destination.Host))
 	if destinationRule == nil {
 		return nil, nil
 	}

--- a/pilot/pkg/networking/core/v1alpha3/tls.go
+++ b/pilot/pkg/networking/core/v1alpha3/tls.go
@@ -195,8 +195,7 @@ func buildSidecarOutboundTLSFilterChainOpts(node *model.Proxy, push *model.PushC
 		if len(destinationCIDR) > 0 || len(svcListenAddress) == 0 || (svcListenAddress == actualWildcard && bind == actualWildcard) {
 			sniHosts = []string{string(service.Hostname)}
 		}
-		destRule := push.DestinationRule(node, service)
-		destinationRule := CastDestinationRule(destRule)
+		destinationRule := CastDestinationRule(node.SidecarScope.DestinationRule(service.Hostname))
 		out = append(out, &filterChainOpts{
 			sniHosts:         sniHosts,
 			destinationCIDRs: []string{destinationCIDR},
@@ -296,8 +295,7 @@ TcpLoop:
 
 		clusterName := model.BuildSubsetKey(model.TrafficDirectionOutbound, "", service.Hostname, port)
 		statPrefix := clusterName
-		destRule := push.DestinationRule(node, service)
-		destinationRule := CastDestinationRule(destRule)
+		destinationRule := CastDestinationRule(node.SidecarScope.DestinationRule(service.Hostname))
 		// If stat name is configured, use it to build the stat prefix.
 		if len(push.Mesh.OutboundClusterStatName) != 0 {
 			statPrefix = util.BuildStatPrefix(push.Mesh.OutboundClusterStatName, string(service.Hostname), "", &model.Port{Port: port}, &service.Attributes)

--- a/pilot/pkg/networking/grpcgen/cds.go
+++ b/pilot/pkg/networking/grpcgen/cds.go
@@ -176,7 +176,7 @@ func (b *clusterBuilder) applyDestinationRule(defaultCluster *cluster.Cluster) (
 	}
 
 	// resolve policy from context
-	destinationRule := corexds.CastDestinationRule(b.push.DestinationRule(b.node, b.svc))
+	destinationRule := corexds.CastDestinationRule(b.node.SidecarScope.DestinationRule(b.svc.Hostname))
 	trafficPolicy := corexds.MergeTrafficPolicy(nil, destinationRule.GetTrafficPolicy(), b.port)
 
 	// setup default cluster

--- a/pilot/pkg/xds/ep_filters_test.go
+++ b/pilot/pkg/xds/ep_filters_test.go
@@ -21,20 +21,16 @@ import (
 
 	endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 
-	meshconfig "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
 	security "istio.io/api/security/v1beta1"
 	"istio.io/api/type/v1beta1"
-	"istio.io/istio/pilot/pkg/config/memory"
 	"istio.io/istio/pilot/pkg/model"
-	memregistry "istio.io/istio/pilot/pkg/serviceregistry/memory"
 	"istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/config"
-	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/protocol"
-	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/network"
+	"istio.io/istio/pkg/test"
 )
 
 type LbEpInfo struct {
@@ -180,12 +176,10 @@ var networkFiltered = []networkFilterCase{
 }
 
 func TestEndpointsByNetworkFilter(t *testing.T) {
-	env := environment()
-	env.Init()
-	env.InitNetworksManager(nil)
+	env := environment(t)
+	env.Env().InitNetworksManager(env.Discovery)
 	// The tests below are calling the endpoints filter from each one of the
 	// networks and examines the returned filtered endpoints
-
 	runNetworkFilterTest(t, env, networkFiltered)
 }
 
@@ -552,19 +546,11 @@ func TestEndpointsByNetworkFilter_WithConfig(t *testing.T) {
 		t.Run(configType, func(t *testing.T) {
 			for name, pa := range cases {
 				t.Run(name, func(t *testing.T) {
-					env := environment()
 					cfgs := pa.Configs
 					if pa.Config.Name != "" {
 						cfgs = append(cfgs, pa.Config)
 					}
-					for _, cfg := range cfgs {
-						_, err := env.IstioConfigStore.Create(cfg)
-						if err != nil {
-							t.Fatalf("failed creating %s: %v", cfg.Name, err)
-						}
-					}
-					env.Init()
-					env.InitNetworksManager(nil)
+					env := environment(t, cfgs...)
 					runNetworkFilterTest(t, env, pa.Tests)
 				})
 			}
@@ -577,10 +563,10 @@ func TestEndpointsByNetworkFilter_SkipLBWithHostname(t *testing.T) {
 	//  - 1 DNS gateway for network2
 	//  - 1 IP gateway for network3
 	//  - 0 gateways for network4
-	env := environment()
-	origServices, _ := env.Services()
-	origGateways := env.NetworkGateways()
-	serviceDiscovery := memregistry.NewServiceDiscovery(append([]*model.Service{{
+	ds := environment(t)
+	origServices, _ := ds.Env().Services()
+	origGateways := ds.Env().NetworkGateways()
+	ds.MemRegistry.AddService("istio-ingressgateway.istio-system.svc.cluster.local", &model.Service{
 		Hostname: "istio-ingressgateway.istio-system.svc.cluster.local",
 		Attributes: model.ServiceAttributes{
 			ClusterExternalAddresses: model.AddressMap{
@@ -590,20 +576,20 @@ func TestEndpointsByNetworkFilter_SkipLBWithHostname(t *testing.T) {
 				},
 			},
 		},
-	}}, origServices...))
-	serviceDiscovery.AddGateways(origGateways...)
+	})
+	for _, svc := range origServices {
+		ds.MemRegistry.AddService(svc.Hostname, svc)
+	}
+	ds.MemRegistry.AddGateways(origGateways...)
 	// Also add a hostname-based Gateway, which will be rejected.
-	serviceDiscovery.AddGateways(model.NetworkGateway{
+	ds.MemRegistry.AddGateways(model.NetworkGateway{
 		Network: "network2",
 		Addr:    "aeiou.scooby.do",
 		Port:    80,
 	})
 
-	env.ServiceDiscovery = serviceDiscovery
-	env.Init()
-	env.InitNetworksManager(nil)
 	// Run the tests and ensure that the new gateway is never used.
-	runNetworkFilterTest(t, env, networkFiltered)
+	runNetworkFilterTest(t, ds, networkFiltered)
 }
 
 type networkFilterCase struct {
@@ -614,12 +600,11 @@ type networkFilterCase struct {
 
 // runNetworkFilterTest calls the endpoints filter from each one of the
 // networks and examines the returned filtered endpoints
-func runNetworkFilterTest(t *testing.T, env *model.Environment, tests []networkFilterCase) {
+func runNetworkFilterTest(t *testing.T, ds *FakeDiscoveryServer, tests []networkFilterCase) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			push := model.NewPushContext()
-			_ = push.InitContext(env, nil, nil)
-			b := NewEndpointBuilder("outbound|80||example.ns.svc.cluster.local", tt.conn.proxy, push)
+			proxy := ds.SetupProxy(tt.conn.proxy)
+			b := NewEndpointBuilder("outbound|80||example.ns.svc.cluster.local", proxy, ds.PushContext())
 			testEndpoints := b.buildLocalityLbEndpointsFromShards(testShards(), &model.Port{Name: "http", Port: 80, Protocol: protocol.HTTP})
 			filtered := b.EndpointsByNetworkFilter(testEndpoints)
 			for _, e := range testEndpoints {
@@ -667,7 +652,7 @@ func runNetworkFilterTest(t *testing.T, env *model.Environment, tests []networkF
 				}
 			}
 
-			b2 := NewEndpointBuilder("outbound|80||example.ns.svc.cluster.local", tt.conn.proxy, push)
+			b2 := NewEndpointBuilder("outbound|80||example.ns.svc.cluster.local", proxy, ds.PushContext())
 			testEndpoints2 := b2.buildLocalityLbEndpointsFromShards(testShards(), &model.Port{Name: "http", Port: 80, Protocol: protocol.HTTP})
 			filtered2 := b2.EndpointsByNetworkFilter(testEndpoints2)
 			if !reflect.DeepEqual(filtered2, filtered) {
@@ -693,65 +678,55 @@ func xdsConnection(nw network.ID, c cluster.ID) *Connection {
 //  - 3 gateway for network2
 //  - 1 gateway for network3
 //  - 0 gateways for network4
-func environment() *model.Environment {
-	sd := memregistry.NewServiceDiscovery([]*model.Service{
-		{
+func environment(t test.Failer, c ...config.Config) *FakeDiscoveryServer {
+	ds := NewFakeDiscoveryServer(t, FakeOptions{
+		Configs: c,
+		Services: []*model.Service{{
 			Hostname:   "example.ns.svc.cluster.local",
 			Attributes: model.ServiceAttributes{Name: "example", Namespace: "ns"},
+		}},
+		Gateways: []model.NetworkGateway{
+			// network1 has only 1 gateway in cluster1a, which will be used for the endpoints
+			// in both cluster1a and cluster1b.
+			{
+				Network: "network1",
+				Cluster: "cluster1a",
+				Addr:    "1.1.1.1",
+				Port:    80,
+			},
+
+			// network2 has one gateway in each cluster2a and cluster2b. When targeting a particular
+			// endpoint, only the gateway for its cluster will be selected. Since the clusters do not
+			// have the same number of endpoints, the weights for the gateways will be different.
+			{
+				Network: "network2",
+				Cluster: "cluster2a",
+				Addr:    "2.2.2.2",
+				Port:    80,
+			},
+			{
+				Network: "network2",
+				Cluster: "cluster2b",
+				Addr:    "2.2.2.20",
+				Port:    80,
+			},
+			{
+				Network: "network2",
+				Cluster: "cluster2b",
+				Addr:    "2.2.2.21",
+				Port:    80,
+			},
+
+			// network3 has a gateway in cluster3, but no endpoints.
+			{
+				Network: "network3",
+				Cluster: "cluster3",
+				Addr:    "3.3.3.3",
+				Port:    443,
+			},
 		},
 	})
-	env := &model.Environment{
-		ServiceDiscovery: sd,
-		IstioConfigStore: model.MakeIstioStore(memory.Make(collections.Pilot)),
-		Watcher:          mesh.NewFixedWatcher(&meshconfig.MeshConfig{RootNamespace: "istio-system"}),
-		NetworksWatcher:  mesh.NewFixedNetworksWatcher(&meshconfig.MeshNetworks{}),
-	}
-
-	// Configure the network gateways.
-	sd.AddGateways(
-		// network1 has only 1 gateway in cluster1a, which will be used for the endpoints
-		// in both cluster1a and cluster1b.
-		model.NetworkGateway{
-			Network: "network1",
-			Cluster: "cluster1a",
-			Addr:    "1.1.1.1",
-			Port:    80,
-		},
-
-		// network2 has one gateway in each cluster2a and cluster2b. When targeting a particular
-		// endpoint, only the gateway for its cluster will be selected. Since the clusters do not
-		// have the same number of endpoints, the weights for the gateways will be different.
-		model.NetworkGateway{
-			Network: "network2",
-			Cluster: "cluster2a",
-			Addr:    "2.2.2.2",
-			Port:    80,
-		},
-		model.NetworkGateway{
-			Network: "network2",
-			Cluster: "cluster2b",
-			Addr:    "2.2.2.20",
-			Port:    80,
-		},
-		model.NetworkGateway{
-			Network: "network2",
-			Cluster: "cluster2b",
-			Addr:    "2.2.2.21",
-			Port:    80,
-		},
-
-		// network3 has a gateway in cluster3, but no endpoints.
-		model.NetworkGateway{
-			Network: "network3",
-			Cluster: "cluster3",
-			Addr:    "3.3.3.3",
-			Port:    443,
-		},
-
-		// network4 has no gateways, so its endpoints will be considered reachable from every
-		// other cluster.
-	)
-	return env
+	return ds
 }
 
 // testShards creates endpoints to be handed to the filter:

--- a/pilot/pkg/xds/fake.go
+++ b/pilot/pkg/xds/fake.go
@@ -100,6 +100,8 @@ type FakeOptions struct {
 	// EnableFakeXDSUpdater will use a XDSUpdater that can be used to watch events
 	EnableFakeXDSUpdater       bool
 	DisableSecretAuthorization bool
+	Services                   []*model.Service
+	Gateways                   []model.NetworkGateway
 }
 
 type FakeDiscoveryServer struct {
@@ -219,6 +221,8 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 		ConfigStoreCaches:   []model.ConfigStoreCache{ingr},
 		SkipRun:             true,
 		ClusterID:           defaultKubeController.Cluster(),
+		Services:            opts.Services,
+		Gateways:            opts.Gateways,
 	})
 	cg.ServiceEntryRegistry.AppendServiceHandler(serviceHandler)
 	s.updateMutex.Lock()

--- a/pilot/pkg/xds/xds_test.go
+++ b/pilot/pkg/xds/xds_test.go
@@ -543,7 +543,7 @@ spec:
 					fakeOpts.MeshConfig = &meshConfig
 					s := NewFakeDiscoveryServer(t, fakeOpts)
 					for clusterID := range want {
-						p := &model.Proxy{Metadata: &model.NodeMetadata{ClusterID: clusterID}}
+						p := s.SetupProxy(&model.Proxy{Metadata: &model.NodeMetadata{ClusterID: clusterID}})
 						eps := xdstest.ExtractLoadAssignments(s.Endpoints(p))[tt.serviceCluster]
 						if want := want[clusterID]; !listEqualUnordered(eps, want) {
 							t.Errorf("got %v but want %v for %s", eps, want, clusterID)


### PR DESCRIPTION
Currently, we actually have two distinct code paths in a single
function. This is pretty confusing to follow, and makes other PRs more
complex (https://github.com/istio/istio/pull/37174/files).

This splits out to an internal function, which is to be called when
creating SidecarScope, and a method on SidecarScope to be called by
consumers (eg Cluster builder code).

This can be cleaned up further to stop doing the `dummyNode` thing,
which is a major source of bugs historically, if we do the same with
Service. But trying to keep this minimal.

This PR also has a lot of testing changes, as many of our tests do
things that are not realistic.

**Please provide a description of this PR:**