### PR TITLE
echoboot: deploy to multi-cluster by default

### DIFF
--- a/pkg/test/framework/components/echo/echoboot/echoboot.go
+++ b/pkg/test/framework/components/echo/echoboot/echoboot.go
@@ -45,9 +45,9 @@ var _ echo.Builder = builder{}
 
 // NewBuilder for Echo Instances.
 func NewBuilder(ctx resource.Context, clusters ...cluster.Cluster) echo.Builder {
-	// use default kube cluster unless otherwise specified
+	// use all workload clusters unless otherwise specified
 	if len(clusters) == 0 {
-		clusters = cluster.Clusters{ctx.Clusters().Default()}
+		clusters = ctx.Clusters()
 	}
 	b := builder{
 		ctx:        ctx,


### PR DESCRIPTION
This doesn't actually make a difference as most of our tests already use `.WithClusters` but it's a good default. 