### PR TITLE
Bump timeout on TestAuthZCheck

### DIFF
--- a/tests/integration/pilot/istioctl_test.go
+++ b/tests/integration/pilot/istioctl_test.go
@@ -530,7 +530,7 @@ func TestAuthZCheck(t *testing.T) {
 							}
 						}
 						return nil
-					}, retry.Timeout(time.Second*5))
+					}, retry.Timeout(time.Second*30))
 				})
 			}
 		})


### PR DESCRIPTION
Currently it will only try 1x since the command is pretty slow

see
https://storage.googleapis.com/istio-prow/pr-logs/pull/istio_istio/37414/integ-pilot_istio/1494713565586657280/build-log.txt

**Please provide a description of this PR:**