### PR TITLE
`InsertedExtensionConfigurations` should return all configs when `nam…

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/extension_configuration_patch.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/extension_configuration_patch.go
@@ -40,9 +40,10 @@ func InsertedExtensionConfigurations(efw *model.EnvoyFilterWrapper, names []stri
 			log.Errorf("extension config patch %+v does not match TypeExtensionConfig type", p.Value)
 			continue
 		}
-		if hasName.Contains(ec.GetName()) {
-			result = append(result, proto.Clone(p.Value).(*core.TypedExtensionConfig))
+		if len(hasName) != 0 && !hasName.Contains(ec.GetName()) {
+			continue
 		}
+		result = append(result, proto.Clone(p.Value).(*core.TypedExtensionConfig))
 	}
 	return result
 }

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/extension_configuration_patch_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/extension_configuration_patch_test.go
@@ -77,6 +77,18 @@ func TestInsertedExtensionConfig(t *testing.T) {
 			},
 		},
 		{
+			name:           "empty request names",
+			requestedNames: []string{},
+			wantExtensionConfig: []*core.TypedExtensionConfig{
+				{
+					Name: "add-extension-config1",
+				},
+				{
+					Name: "add-extension-config2",
+				},
+			},
+		},
+		{
 			name:                "miss extension config",
 			requestedNames:      []string{"random-extension-config"},
 			wantExtensionConfig: []*core.TypedExtensionConfig{},

--- a/pilot/pkg/networking/core/v1alpha3/extension/wasmplugin.go
+++ b/pilot/pkg/networking/core/v1alpha3/extension/wasmplugin.go
@@ -150,7 +150,7 @@ func InsertedExtensionConfigurations(
 	hasName := sets.NewSet(names...)
 	for _, list := range wasmPlugins {
 		for _, p := range list {
-			if !hasName.Contains(p.ExtensionConfiguration.Name) {
+			if len(hasName) != 0 && !hasName.Contains(p.ExtensionConfiguration.Name) {
 				continue
 			}
 			result = append(result, proto.Clone(p.ExtensionConfiguration).(*envoy_config_core_v3.TypedExtensionConfig))

--- a/pilot/pkg/networking/core/v1alpha3/extension/wasmplugin_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/extension/wasmplugin_test.go
@@ -218,6 +218,20 @@ func TestInsertedExtensionConfigurations(t *testing.T) {
 				someAuthNFilter.ExtensionConfiguration,
 			},
 		},
+		{
+			name: "empty-names",
+			wasmPlugins: map[extensions.PluginPhase][]*model.WasmPluginWrapper{
+				extensions.PluginPhase_AUTHN: {
+					someAuthNFilter,
+					someAuthZFilter,
+				},
+			},
+			names: []string{},
+			expectedECs: []*envoy_config_core_v3.TypedExtensionConfig{
+				someAuthNFilter.ExtensionConfiguration,
+				someAuthZFilter.ExtensionConfiguration,
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
`InsertedExtensionConfigurations` should return all configs when `names` is empty