### PR TITLE
Fix Delta CDS: cluster not removed when port changed

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -104,35 +104,34 @@ func (configgen *ConfigGeneratorImpl) BuildDeltaClusters(proxy *model.Proxy, upd
 	for key := range updates.ConfigsUpdated {
 		// get the service that has changed.
 		service := updates.Push.ServiceForHostname(proxy, host.Name(key.Name))
-		// SidecarScope.Service will return nil if the proxy doesn't care about the service OR it was deleted.
-		// we can cross reference with WatchedResources to figure out which services were deleted.
-		if service == nil {
-			// WatchedResources.ResourceNames will contain the names of the clusters it is subscribed to. We can
-			// check with the name of our service (cluster names are in the format outbound|<port>||<hostname>.
-			// so, if this service is part of watched resources, we can conclude that it is a removed cluster.
-			for _, n := range watched.ResourceNames {
-				_, _, svcHost, _ := model.ParseSubsetKey(n)
-				if svcHost == host.Name(key.Name) {
-					deletedClusters = append(deletedClusters, n)
-				}
+		for _, n := range watched.ResourceNames {
+			if isClusterForServiceRemoved(n, key.Name, service) {
+				deletedClusters = append(deletedClusters, n)
 			}
-		} else {
-			// WatchedResources.ResourceNames will contain the names of the clusters it is subscribed to. We can
-			// check with the name of our service (cluster names are in the format outbound|<port>||<hostname>.
-			// so, if this service is part of watched resources, but the port is not found, we can conclude that it is a removed cluster.
-			for _, n := range watched.ResourceNames {
-				_, _, svcHost, port := model.ParseSubsetKey(n)
-				if svcHost == host.Name(key.Name) {
-					if _, exists := service.Ports.GetByPort(port); !exists {
-						deletedClusters = append(deletedClusters, n)
-					}
-				}
-			}
+		}
+		if service != nil {
 			services = append(services, service)
 		}
 	}
 	clusters, log := configgen.buildClusters(proxy, updates, services)
 	return clusters, deletedClusters, log, true
+}
+
+func isClusterForServiceRemoved(cluster string, hostName string, svc *model.Service) bool {
+	// WatchedResources.ResourceNames will contain the names of the clusters it is subscribed to. We can
+	// check with the name of our service (cluster names are in the format outbound|<port>||<hostname>.
+	_, _, svcHost, port := model.ParseSubsetKey(cluster)
+	if svcHost == host.Name(hostName) {
+		// if this service removed, we can conclude that it is a removed cluster.
+		if svc == nil {
+			return true
+		}
+		// if this service port is removed, we can conclude that it is a removed cluster.
+		if _, exists := svc.Ports.GetByPort(port); !exists {
+			return true
+		}
+	}
+	return false
 }
 
 // buildClusters builds clusters for the proxy with the services passed.

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -2447,7 +2447,7 @@ func TestBuildDeltaClusters(t *testing.T) {
 		map[model.ConfigKey]struct{}{{Kind: gvk.ServiceEntry, Name: "test.com", Namespace: TestServiceNamespace}: {}},
 		&model.WatchedResource{ResourceNames: []string{"outbound|7070||test.com"}})
 	if !delta {
-		t.Errorf("expected deleta cds")
+		t.Errorf("expected delta cds")
 	}
 	g.Expect(removed).To(Equal([]string{"outbound|7070||test.com"}))
 	g.Expect(xdstest.MapKeys(xdstest.ExtractClusters(clusters))).To(

--- a/pilot/pkg/networking/core/v1alpha3/fake.go
+++ b/pilot/pkg/networking/core/v1alpha3/fake.go
@@ -261,6 +261,22 @@ func (f *ConfigGenTest) Clusters(p *model.Proxy) []*cluster.Cluster {
 	return res
 }
 
+func (f *ConfigGenTest) DeltaClusters(p *model.Proxy, configUpdated map[model.ConfigKey]struct{}, watched *model.WatchedResource) ([]*cluster.Cluster, []string, bool) {
+	raw, removed, _, delta := f.ConfigGen.BuildDeltaClusters(p,
+		&model.PushRequest{
+			Push: f.PushContext(), ConfigsUpdated: configUpdated,
+		}, watched)
+	res := make([]*cluster.Cluster, 0, len(raw))
+	for _, r := range raw {
+		c := &cluster.Cluster{}
+		if err := r.Resource.UnmarshalTo(c); err != nil {
+			f.t.Fatal(err)
+		}
+		res = append(res, c)
+	}
+	return res, removed, delta
+}
+
 func (f *ConfigGenTest) Routes(p *model.Proxy) []*route.RouteConfiguration {
 	resources, _ := f.ConfigGen.BuildHTTPRoutes(p, &model.PushRequest{Push: f.PushContext()}, xdstest.ExtractRoutesFromListeners(f.Listeners(p)))
 	out := make([]*route.RouteConfiguration, 0, len(resources))

--- a/pilot/pkg/networking/core/v1alpha3/fake.go
+++ b/pilot/pkg/networking/core/v1alpha3/fake.go
@@ -261,7 +261,10 @@ func (f *ConfigGenTest) Clusters(p *model.Proxy) []*cluster.Cluster {
 	return res
 }
 
-func (f *ConfigGenTest) DeltaClusters(p *model.Proxy, configUpdated map[model.ConfigKey]struct{}, watched *model.WatchedResource) ([]*cluster.Cluster, []string, bool) {
+func (f *ConfigGenTest) DeltaClusters(
+	p *model.Proxy,
+	configUpdated map[model.ConfigKey]struct{},
+	watched *model.WatchedResource) ([]*cluster.Cluster, []string, bool) {
 	raw, removed, _, delta := f.ConfigGen.BuildDeltaClusters(p,
 		&model.PushRequest{
 			Push: f.PushContext(), ConfigsUpdated: configUpdated,


### PR DESCRIPTION
**Please provide a description of this PR:**

When a service ports has been updated, for the removed port, its cluster is still there.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
