### PR TITLE
fix an issue where the mounted external CA secret was ignored

### DIFF
--- a/pilot/pkg/bootstrap/istio_ca.go
+++ b/pilot/pkg/bootstrap/istio_ca.go
@@ -477,10 +477,13 @@ func (s *Server) createIstioRA(client kubelib.Client,
 	caCertFile := path.Join(ra.DefaultExtCACertDir, constants.CACertNamespaceConfigMapDataName)
 	certSignerDomain := opts.CertSignerDomain
 	_, err := os.Stat(caCertFile)
-	if err != nil && certSignerDomain == "" {
-		caCertFile = defaultCACertPath
-	} else {
-		caCertFile = ""
+	if err != nil {
+		log.Infof("CA cert file stat error: %v", err)
+		if certSignerDomain == "" {
+			caCertFile = defaultCACertPath
+		} else {
+			caCertFile = ""
+		}
 	}
 	raOpts := &ra.IstioRAOptions{
 		ExternalCAType:   opts.ExternalCAType,

--- a/pilot/pkg/bootstrap/istio_ca.go
+++ b/pilot/pkg/bootstrap/istio_ca.go
@@ -478,10 +478,16 @@ func (s *Server) createIstioRA(client kubelib.Client,
 	certSignerDomain := opts.CertSignerDomain
 	_, err := os.Stat(caCertFile)
 	if err != nil {
-		log.Infof("CA cert file stat error: %v", err)
+		if !os.IsNotExist(err) {
+			return nil, fmt.Errorf("failed to get file info: %v", err)
+		}
+
+		// File does not exist.
 		if certSignerDomain == "" {
+			log.Infof("CA cert file %q not found, using %q.", caCertFile, defaultCACertPath)
 			caCertFile = defaultCACertPath
 		} else {
+			log.Infof("CA cert file %q not found - ignoring.", caCertFile)
 			caCertFile = ""
 		}
 	}


### PR DESCRIPTION
**Please provide a description of this PR:**

Following the docs for [custom-ca-k8s](https://istio.io/latest/docs/tasks/security/cert-management/custom-ca-k8s/) I've found out that the external CA secret was ignored during `createIstioRA`.
Based on the comment 
```
// createIstioRA initializes the Istio RA signing functionality.
// the caOptions defines the external provider
// ca cert can come from three sources, order matters:
// 1. Define ca cert via kubernetes secret and mount the secret through `external-ca-cert` volume
// 2. Use kubernetes ca cert `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt` if signer is
//    kubernetes built-in `kubernetes.io/legacy-unknown" signer
// 3. Extract from the cert-chain signed by other CSR signer.
```

> Define ca cert via kubernetes secret and mount the secret through `external-ca-cert` volume

`./etc/external-ca-cert/root-cert.pem` should get priority, but the code just ignore it here
```
        _, err := os.Stat(caCertFile)
	if err != nil && certSignerDomain == "" {
		caCertFile = defaultCACertPath
	} else {
		caCertFile = ""
	}
```

I've updated the code to 
```
        _, err := os.Stat(caCertFile)
	if err != nil {
		log.Infof("CA cert file stat error: %v", err)
		if certSignerDomain == "" {
			caCertFile = defaultCACertPath
		} else {
			caCertFile = ""
		}
	}
```

So only if the file is missing the `caCertFile` will use the `defaultCACertPath` BUT if the file is found it should be used.

@irisdingbj since this code was written by you during `support multi signer in istiod (#34353` I'd love it if you could take a look.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [X] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
