### PR TITLE
[TF] Top-level header fields in echo response

### DIFF
--- a/pkg/test/echo/fields.go
+++ b/pkg/test/echo/fields.go
@@ -17,6 +17,10 @@ package echo
 // Field is a list of fields returned in responses from the Echo server.
 type Field string
 
+func (f Field) String() string {
+	return string(f)
+}
+
 const (
 	RequestIDField      Field = "X-Request-Id"
 	ServiceVersionField Field = "ServiceVersion"
@@ -26,7 +30,10 @@ const (
 	HostField           Field = "Host"
 	HostnameField       Field = "Hostname"
 	MethodField         Field = "Method"
-	ResponseHeader      Field = "ResponseHeader"
+	ProtocolField       Field = "Proto"
+	AlpnField           Field = "Alpn"
+	RequestHeaderField  Field = "RequestHeader"
+	ResponseHeaderField Field = "ResponseHeader"
 	ClusterField        Field = "Cluster"
 	IstioVersionField   Field = "IstioVersion"
 	IPField             Field = "IP" // The Requester’s IP Address.

--- a/pkg/test/echo/responses.go
+++ b/pkg/test/echo/responses.go
@@ -21,6 +21,10 @@ import (
 // Responses is an ordered list of parsed response objects.
 type Responses []Response
 
+func (r Responses) IsEmpty() bool {
+	return len(r) == 0
+}
+
 // Len returns the length of the parsed responses.
 func (r Responses) Len() int {
 	return len(r)

--- a/pkg/test/echo/server/endpoint/http.go
+++ b/pkg/test/echo/server/endpoint/http.go
@@ -316,7 +316,7 @@ func (h *httpHandler) addResponsePayload(r *http.Request, body *bytes.Buffer) {
 	writeField(body, echo.IstioVersionField, h.IstioVersion)
 
 	writeField(body, echo.MethodField, r.Method)
-	writeField(body, "Proto", r.Proto)
+	writeField(body, echo.ProtocolField, r.Proto)
 	ip, _, _ := net.SplitHostPort(r.RemoteAddr)
 	writeField(body, echo.IPField, ip)
 
@@ -326,9 +326,9 @@ func (h *httpHandler) addResponsePayload(r *http.Request, body *bytes.Buffer) {
 	if r.TLS != nil {
 		alpn = r.TLS.NegotiatedProtocol
 	}
-	writeField(body, "Alpn", alpn)
+	writeField(body, echo.AlpnField, alpn)
 
-	keys := []string{}
+	var keys []string
 	for k := range r.Header {
 		keys = append(keys, k)
 	}
@@ -336,7 +336,7 @@ func (h *httpHandler) addResponsePayload(r *http.Request, body *bytes.Buffer) {
 	for _, key := range keys {
 		values := r.Header[key]
 		for _, value := range values {
-			writeField(body, echo.Field(key), value)
+			writeRequestHeader(body, key, value)
 		}
 	}
 

--- a/pkg/test/echo/server/endpoint/tcp.go
+++ b/pkg/test/echo/server/endpoint/tcp.go
@@ -155,6 +155,7 @@ func (s *tcpInstance) writeResponse(conn net.Conn) {
 		echo.ServiceVersionField: s.Version,
 		echo.ServicePortField:    strconv.Itoa(s.Port.Port),
 		echo.IPField:             ip,
+		echo.ProtocolField:       "TCP",
 	}
 	for field, val := range respFields {
 		val := fmt.Sprintf("%s=%s\n", string(field), val)

--- a/pkg/test/echo/server/endpoint/util.go
+++ b/pkg/test/echo/server/endpoint/util.go
@@ -61,3 +61,8 @@ func listenOnUDS(uds string) (net.Listener, error) {
 func writeField(out *bytes.Buffer, field echo.Field, value string) {
 	_, _ = out.WriteString(string(field) + "=" + value + "\n")
 }
+
+// nolint: interfacer
+func writeRequestHeader(out *bytes.Buffer, key, value string) {
+	writeField(out, echo.RequestHeaderField, key+":"+value)
+}

--- a/pkg/test/echo/server/forwarder/http.go
+++ b/pkg/test/echo/server/forwarder/http.go
@@ -127,7 +127,7 @@ func (c *httpProtocol) makeRequest(ctx context.Context, req *request) (string, e
 	for _, key := range keys {
 		values := httpResp.Header[key]
 		for _, value := range values {
-			outBuffer.WriteString(fmt.Sprintf("[%d] ResponseHeader=%s:%s\n", req.RequestID, key, value))
+			outBuffer.WriteString(fmt.Sprintf("[%d] %s=%s:%s\n", req.RequestID, echo.ResponseHeaderField, key, value))
 		}
 	}
 

--- a/tests/integration/pilot/ingress_test.go
+++ b/tests/integration/pilot/ingress_test.go
@@ -226,7 +226,7 @@ spec:
 							Path:     "/path",
 							Check: check.And(
 								check.OK(),
-								check.Key("My-Added-Header", "added-value")),
+								check.RequestHeader("My-Added-Header", "added-value")),
 						})
 					})
 					t.NewSubTest("status").Run(func(t framework.TestContext) {

--- a/tests/integration/security/file_mounted_certs/p2p_mtls_test.go
+++ b/tests/integration/security/file_mounted_certs/p2p_mtls_test.go
@@ -75,12 +75,12 @@ func TestClientToServiceTls(t *testing.T) {
 					return fmt.Errorf("got codes %q, expected %q", codes, []string{strconv.Itoa(http.StatusOK)})
 				}
 				for _, r := range resp {
-					if xfcc, f := r.RawResponse["X-Forwarded-Client-Cert"]; f {
-						if xfcc != ExpectedXfccHeader {
-							return fmt.Errorf("XFCC header's value is incorrect. Expected [%s], received [%s]", ExpectedXfccHeader, r.RawResponse)
+					if xfcc, f := r.RequestHeaders["X-Forwarded-Client-Cert"]; f {
+						if xfcc[0] != ExpectedXfccHeader {
+							return fmt.Errorf("XFCC header's value is incorrect. Expected [%s], received [%s]", ExpectedXfccHeader, r)
 						}
 					} else {
-						return fmt.Errorf("expected to see XFCC header, but none found. response: %+v", r.RawResponse)
+						return fmt.Errorf("expected to see XFCC header, but none found. response: %s", r)
 					}
 				}
 				return nil

--- a/tests/integration/security/filebased_tls_origination/egress_gateway_origination_test.go
+++ b/tests/integration/security/filebased_tls_origination/egress_gateway_origination_test.go
@@ -146,8 +146,8 @@ func TestEgressGatewayTls(t *testing.T) {
 								return fmt.Errorf("got codes %q, expected %q", codes, []string{strconv.Itoa(tc.code)})
 							}
 							for _, r := range resp {
-								if _, f := r.RawResponse["Handled-By-Egress-Gateway"]; tc.gateway && !f {
-									return fmt.Errorf("expected to be handled by gateway. response: %+v", r.RawResponse)
+								if _, f := r.RequestHeaders["Handled-By-Egress-Gateway"]; tc.gateway && !f {
+									return fmt.Errorf("expected to be handled by gateway. response: %s", r)
 								}
 							}
 							return nil

--- a/tests/integration/security/normalization_test.go
+++ b/tests/integration/security/normalization_test.go
@@ -230,7 +230,7 @@ pathNormalization:
 					for _, c := range apps.A {
 						for _, tt := range tt.expectations {
 							t.NewSubTest(tt.in).Run(func(t framework.TestContext) {
-								checker := check.Key("URL", tt.out)
+								checker := check.URL(tt.out)
 								if tt.out == "400" {
 									checker = check.StatusCode(http.StatusBadRequest)
 								}

--- a/tests/integration/security/sds_ingress/ingress_test.go
+++ b/tests/integration/security/sds_ingress/ingress_test.go
@@ -90,7 +90,7 @@ func TestSingleTlsGateway_SecretRotation(t *testing.T) {
 
 					// Verify the call works
 					ingressutil.SendRequestOrFail(t, ing, host, credName, ingressutil.TLS, tlsContextA,
-						ingressutil.ExpectedResponse{ResponseCode: http.StatusOK, ErrorMessage: ""})
+						ingressutil.ExpectedResponse{StatusCode: http.StatusOK})
 
 					// Now rotate the key/cert
 					ingressutil.RotateSecrets(t, credName, ingressutil.TLS,
@@ -99,13 +99,13 @@ func TestSingleTlsGateway_SecretRotation(t *testing.T) {
 					t.NewSubTest("old cert should fail").Run(func(t framework.TestContext) {
 						// Client use old server CA cert to set up SSL connection would fail.
 						ingressutil.SendRequestOrFail(t, ing, host, credName, ingressutil.TLS, tlsContextA,
-							ingressutil.ExpectedResponse{ResponseCode: 0, ErrorMessage: "certificate signed by unknown authority"})
+							ingressutil.ExpectedResponse{ErrorMessage: "certificate signed by unknown authority"})
 					})
 
 					t.NewSubTest("new cert should succeed").Run(func(t framework.TestContext) {
 						// Client use new server CA cert to set up SSL connection.
 						ingressutil.SendRequestOrFail(t, ing, host, credName, ingressutil.TLS, tlsContextB,
-							ingressutil.ExpectedResponse{ResponseCode: http.StatusOK, ErrorMessage: ""})
+							ingressutil.ExpectedResponse{StatusCode: http.StatusOK})
 					})
 				})
 		})
@@ -159,7 +159,7 @@ func TestSingleMTLSGateway_ServerKeyCertRotation(t *testing.T) {
 						Cert:       ingressutil.TLSClientCertA,
 					}
 					ingressutil.SendRequestOrFail(t, ing, host, credName, ingressutil.Mtls, tlsContext,
-						ingressutil.ExpectedResponse{ResponseCode: http.StatusOK, ErrorMessage: ""})
+						ingressutil.ExpectedResponse{StatusCode: http.StatusOK})
 
 					t.NewSubTest("mismatched key/cert should fail").Run(func(t framework.TestContext) {
 						// key/cert rotation using mis-matched server key/cert. The server cert cannot pass validation
@@ -168,7 +168,7 @@ func TestSingleMTLSGateway_ServerKeyCertRotation(t *testing.T) {
 							ingressutil.IngressCredentialServerKeyCertB, false)
 						// Client uses old server CA cert to set up SSL connection would fail.
 						ingressutil.SendRequestOrFail(t, ing, host, credName, ingressutil.Mtls, tlsContext,
-							ingressutil.ExpectedResponse{ResponseCode: 0, ErrorMessage: "certificate signed by unknown authority"})
+							ingressutil.ExpectedResponse{ErrorMessage: "certificate signed by unknown authority"})
 					})
 
 					t.NewSubTest("matched key/cert should succeed").Run(func(t framework.TestContext) {
@@ -178,7 +178,7 @@ func TestSingleMTLSGateway_ServerKeyCertRotation(t *testing.T) {
 							ingressutil.IngressCredentialServerKeyCertA, false)
 						// Use old CA cert to set up SSL connection would succeed this time.
 						ingressutil.SendRequestOrFail(t, ing, host, credName, ingressutil.Mtls, tlsContext,
-							ingressutil.ExpectedResponse{ResponseCode: http.StatusOK, ErrorMessage: ""})
+							ingressutil.ExpectedResponse{StatusCode: http.StatusOK})
 					})
 				})
 		})
@@ -223,7 +223,7 @@ func TestSingleMTLSGateway_CompoundSecretRotation(t *testing.T) {
 						Cert:       ingressutil.TLSClientCertA,
 					}
 					ingressutil.SendRequestOrFail(t, ing, host, credName, ingressutil.Mtls, tlsContext,
-						ingressutil.ExpectedResponse{ResponseCode: http.StatusOK, ErrorMessage: ""})
+						ingressutil.ExpectedResponse{StatusCode: http.StatusOK})
 
 					t.NewSubTest("old server CA should fail").Run(func(t framework.TestContext) {
 						// key/cert rotation
@@ -231,7 +231,7 @@ func TestSingleMTLSGateway_CompoundSecretRotation(t *testing.T) {
 							ingressutil.IngressCredentialB, false)
 						// Use old server CA cert to set up SSL connection would fail.
 						ingressutil.SendRequestOrFail(t, ing, host, credName, ingressutil.Mtls, tlsContext,
-							ingressutil.ExpectedResponse{ResponseCode: 0, ErrorMessage: "certificate signed by unknown authority"})
+							ingressutil.ExpectedResponse{ErrorMessage: "certificate signed by unknown authority"})
 					})
 
 					t.NewSubTest("new server CA should succeed").Run(func(t framework.TestContext) {
@@ -242,7 +242,7 @@ func TestSingleMTLSGateway_CompoundSecretRotation(t *testing.T) {
 							Cert:       ingressutil.TLSClientCertB,
 						}
 						ingressutil.SendRequestOrFail(t, ing, host, credName, ingressutil.Mtls, tlsContext,
-							ingressutil.ExpectedResponse{ResponseCode: http.StatusOK, ErrorMessage: ""})
+							ingressutil.ExpectedResponse{StatusCode: http.StatusOK})
 					})
 				})
 		})
@@ -290,7 +290,7 @@ func TestSingleMTLSGatewayAndNotGeneric_CompoundSecretRotation(t *testing.T) {
 						Cert:       ingressutil.TLSClientCertA,
 					}
 					ingressutil.SendRequestOrFail(t, ing, host, credName, ingressutil.Mtls, tlsContext,
-						ingressutil.ExpectedResponse{ResponseCode: http.StatusOK, ErrorMessage: ""})
+						ingressutil.ExpectedResponse{StatusCode: http.StatusOK})
 
 					t.NewSubTest("old server CA should fail").Run(func(t framework.TestContext) {
 						// key/cert rotation
@@ -298,7 +298,7 @@ func TestSingleMTLSGatewayAndNotGeneric_CompoundSecretRotation(t *testing.T) {
 							ingressutil.IngressCredentialB, true)
 						// Use old server CA cert to set up SSL connection would fail.
 						ingressutil.SendRequestOrFail(t, ing, host, credName, ingressutil.Mtls, tlsContext,
-							ingressutil.ExpectedResponse{ResponseCode: 0, ErrorMessage: "certificate signed by unknown authority"})
+							ingressutil.ExpectedResponse{ErrorMessage: "certificate signed by unknown authority"})
 					})
 
 					t.NewSubTest("new server CA should succeed").Run(func(t framework.TestContext) {
@@ -309,7 +309,7 @@ func TestSingleMTLSGatewayAndNotGeneric_CompoundSecretRotation(t *testing.T) {
 							Cert:       ingressutil.TLSClientCertB,
 						}
 						ingressutil.SendRequestOrFail(t, ing, host, credName, ingressutil.Mtls, tlsContext,
-							ingressutil.ExpectedResponse{ResponseCode: http.StatusOK, ErrorMessage: ""})
+							ingressutil.ExpectedResponse{StatusCode: http.StatusOK})
 					})
 				})
 		})
@@ -364,7 +364,6 @@ func TestMultiTlsGateway_InvalidSecret(t *testing.T) {
 					},
 					hostName: "testmultitlsgateway-invalidsecret1.example.com",
 					expectedResponse: ingressutil.ExpectedResponse{
-						ResponseCode: 0,
 						// TODO(JimmyCYJ): Temporarily skip verification of error message to deflake test.
 						//  Need a more accurate way to verify the request failures.
 						// https://github.com/istio/istio/issues/16998
@@ -384,7 +383,6 @@ func TestMultiTlsGateway_InvalidSecret(t *testing.T) {
 					},
 					hostName: "testmultitlsgateway-invalidsecret2.example.com",
 					expectedResponse: ingressutil.ExpectedResponse{
-						ResponseCode:                 0,
 						SkipErrorMessageVerification: true,
 					},
 					callType: ingressutil.TLS,
@@ -401,7 +399,6 @@ func TestMultiTlsGateway_InvalidSecret(t *testing.T) {
 					},
 					hostName: "testmultitlsgateway-invalidsecret3.example.com",
 					expectedResponse: ingressutil.ExpectedResponse{
-						ResponseCode:                 0,
 						SkipErrorMessageVerification: true,
 					},
 					callType: ingressutil.TLS,
@@ -417,7 +414,6 @@ func TestMultiTlsGateway_InvalidSecret(t *testing.T) {
 					},
 					hostName: "testmultitlsgateway-invalidsecret4.example.com",
 					expectedResponse: ingressutil.ExpectedResponse{
-						ResponseCode:                 0,
 						SkipErrorMessageVerification: true,
 					},
 					callType: ingressutil.TLS,
@@ -433,7 +429,6 @@ func TestMultiTlsGateway_InvalidSecret(t *testing.T) {
 					},
 					hostName: "testmultitlsgateway-invalidsecret5.example.com",
 					expectedResponse: ingressutil.ExpectedResponse{
-						ResponseCode:                 0,
 						SkipErrorMessageVerification: true,
 					},
 					callType: ingressutil.TLS,
@@ -498,7 +493,6 @@ func TestMultiMtlsGateway_InvalidSecret(t *testing.T) {
 					},
 					hostName: "testmultimtlsgateway-invalidsecret1.example.com",
 					expectedResponse: ingressutil.ExpectedResponse{
-						ResponseCode: 0,
 						// TODO(JimmyCYJ): Temporarily skip verification of error message to deflake test.
 						//  Need a more accurate way to verify the request failures.
 						// https://github.com/istio/istio/issues/16998
@@ -520,7 +514,6 @@ func TestMultiMtlsGateway_InvalidSecret(t *testing.T) {
 					},
 					hostName: "testmultimtlsgateway-invalidsecret2.example.com",
 					expectedResponse: ingressutil.ExpectedResponse{
-						ResponseCode:                 0,
 						SkipErrorMessageVerification: true,
 					},
 					callType: ingressutil.Mtls,
@@ -540,7 +533,6 @@ func TestMultiMtlsGateway_InvalidSecret(t *testing.T) {
 					},
 					hostName: "testmultimtlsgateway-invalidsecret3.example.com",
 					expectedResponse: ingressutil.ExpectedResponse{
-						ResponseCode:                 0,
 						SkipErrorMessageVerification: true,
 					},
 					callType: ingressutil.Mtls,

--- a/tests/integration/security/sds_ingress/util/util.go
+++ b/tests/integration/security/sds_ingress/util/util.go
@@ -257,7 +257,7 @@ const (
 )
 
 type ExpectedResponse struct {
-	ResponseCode                 int
+	StatusCode                   int
 	SkipErrorMessageVerification bool
 	ErrorMessage                 string
 }
@@ -314,7 +314,7 @@ func doSendRequestsOrFail(ctx framework.TestContext, ing ingress.Instance, host 
 				return nil
 			}
 
-			return check.StatusCode(exRsp.ResponseCode).Check(resp, nil)
+			return check.StatusCode(exRsp.StatusCode).Check(resp, nil)
 		},
 	}
 
@@ -523,7 +523,7 @@ func RunTestMultiMtlsGateways(ctx framework.TestContext, inst istio.Instance, ap
 			for _, h := range tests {
 				ctx.NewSubTest(h.Host).Run(func(t framework.TestContext) {
 					SendRequestOrFail(t, ing, h.Host, h.CredentialName, callType, tlsContext,
-						ExpectedResponse{ResponseCode: http.StatusOK, ErrorMessage: ""})
+						ExpectedResponse{StatusCode: http.StatusOK})
 				})
 			}
 		})
@@ -568,7 +568,7 @@ func RunTestMultiTLSGateways(t framework.TestContext, inst istio.Instance, apps 
 			for _, h := range tests {
 				t.NewSubTest(h.Host).Run(func(t framework.TestContext) {
 					SendRequestOrFail(t, ing, h.Host, h.CredentialName, callType, tlsContext,
-						ExpectedResponse{ResponseCode: http.StatusOK, ErrorMessage: ""})
+						ExpectedResponse{StatusCode: http.StatusOK})
 				})
 			}
 		})
@@ -623,7 +623,7 @@ func RunTestMultiQUICGateways(ctx framework.TestContext, inst istio.Instance, ca
 			for _, h := range tests {
 				ctx.NewSubTest(h.Host).Run(func(t framework.TestContext) {
 					SendQUICRequestsOrFail(ctx, ing, h.Host, h.CredentialName, callType, tlsContext,
-						ExpectedResponse{ResponseCode: http.StatusOK, ErrorMessage: ""})
+						ExpectedResponse{StatusCode: http.StatusOK})
 				})
 			}
 		})

--- a/tests/integration/security/util/cert/cert.go
+++ b/tests/integration/security/util/cert/cert.go
@@ -49,7 +49,7 @@ func DumpCertFromSidecar(t test.Failer, from, to echo.Instance, port string) []s
 		t.Fatalf("dump cert failed, no responses")
 	}
 	certs := []string{}
-	for _, rr := range resp[0].ResponseBody() {
+	for _, rr := range resp[0].Body() {
 		var s string
 		if err := json.Unmarshal([]byte(rr), &s); err != nil {
 			t.Fatalf("failed to unmarshal: %v", err)

--- a/tests/integration/telemetry/outboundtrafficpolicy/traffic_allow_any_test.go
+++ b/tests/integration/telemetry/outboundtrafficpolicy/traffic_allow_any_test.go
@@ -18,6 +18,7 @@
 package outboundtrafficpolicy
 
 import (
+	"net/http"
 	"testing"
 )
 
@@ -29,8 +30,8 @@ func TestOutboundTrafficPolicy_AllowAny(t *testing.T) {
 			Expected: Expected{
 				Metric:          "istio_requests_total",
 				PromQueryFormat: `sum(istio_requests_total{reporter="source",destination_service_name="PassthroughCluster",response_code="200"})`,
-				ResponseCode:    []string{"200"},
-				Metadata:        map[string]string{"Proto": "HTTP/1.1"},
+				StatusCode:      http.StatusOK,
+				Protocol:        "HTTP/1.1",
 			},
 		},
 		{
@@ -40,8 +41,8 @@ func TestOutboundTrafficPolicy_AllowAny(t *testing.T) {
 			Expected: Expected{
 				Metric:          "istio_requests_total",
 				PromQueryFormat: `sum(istio_requests_total{reporter="source",destination_service_name="PassthroughCluster",response_code="200"})`,
-				ResponseCode:    []string{"200"},
-				Metadata:        map[string]string{"Proto": "HTTP/2.0"},
+				StatusCode:      http.StatusOK,
+				Protocol:        "HTTP/2.0",
 			},
 		},
 		{
@@ -50,8 +51,8 @@ func TestOutboundTrafficPolicy_AllowAny(t *testing.T) {
 			Expected: Expected{
 				Metric:          "istio_tcp_connections_opened_total",
 				PromQueryFormat: `sum(istio_tcp_connections_opened_total{reporter="source",destination_service_name="PassthroughCluster"})`,
-				ResponseCode:    []string{"200"},
-				Metadata:        map[string]string{"Proto": "HTTP/1.1"},
+				StatusCode:      http.StatusOK,
+				Protocol:        "HTTP/1.1",
 			},
 		},
 		{
@@ -60,8 +61,8 @@ func TestOutboundTrafficPolicy_AllowAny(t *testing.T) {
 			Expected: Expected{
 				Metric:          "istio_tcp_connections_opened_total",
 				PromQueryFormat: `sum(istio_tcp_connections_opened_total{reporter="source",destination_service_name="PassthroughCluster"})`,
-				ResponseCode:    []string{"200"},
-				Metadata:        map[string]string{"Proto": "HTTP/1.1"},
+				StatusCode:      http.StatusOK,
+				Protocol:        "HTTP/1.1",
 			},
 		},
 		{
@@ -71,8 +72,8 @@ func TestOutboundTrafficPolicy_AllowAny(t *testing.T) {
 			Expected: Expected{
 				Metric:          "istio_tcp_connections_opened_total",
 				PromQueryFormat: `sum(istio_tcp_connections_opened_total{reporter="source",destination_service_name="PassthroughCluster"})`,
-				ResponseCode:    []string{"200"},
-				Metadata:        map[string]string{"Proto": "HTTP/2.0"},
+				StatusCode:      http.StatusOK,
+				Protocol:        "HTTP/2.0",
 			},
 		},
 		{
@@ -82,8 +83,8 @@ func TestOutboundTrafficPolicy_AllowAny(t *testing.T) {
 			Expected: Expected{
 				Metric:          "istio_tcp_connections_opened_total",
 				PromQueryFormat: `sum(istio_tcp_connections_opened_total{reporter="source",destination_service_name="PassthroughCluster"})`,
-				ResponseCode:    []string{"200"},
-				Metadata:        map[string]string{"Proto": "HTTP/2.0"},
+				StatusCode:      http.StatusOK,
+				Protocol:        "HTTP/2.0",
 			},
 		},
 		{
@@ -93,8 +94,9 @@ func TestOutboundTrafficPolicy_AllowAny(t *testing.T) {
 			Expected: Expected{
 				Metric:          "istio_requests_total",
 				PromQueryFormat: `sum(istio_requests_total{reporter="source",destination_service_name="istio-egressgateway",response_code="200"})`, // nolint: lll
-				ResponseCode:    []string{"200"},
-				Metadata: map[string]string{
+				StatusCode:      http.StatusOK,
+				Protocol:        "HTTP/1.1",
+				RequestHeaders: map[string]string{
 					// We inject this header in the VirtualService
 					"Handled-By-Egress-Gateway": "true",
 				},
@@ -108,13 +110,12 @@ func TestOutboundTrafficPolicy_AllowAny(t *testing.T) {
 			Expected: Expected{
 				Metric:          "istio_requests_total",
 				PromQueryFormat: `sum(istio_requests_total{reporter="source",destination_service_name="istio-egressgateway",response_code="200"})`, // nolint: lll
-				ResponseCode:    []string{"200"},
-				Metadata: map[string]string{
+				StatusCode:      http.StatusOK,
+				// Even though we send h2 to the gateway, the gateway should send h1, as configured by the ServiceEntry
+				Protocol: "HTTP/1.1",
+				RequestHeaders: map[string]string{
 					// We inject this header in the VirtualService
 					"Handled-By-Egress-Gateway": "true",
-					// Even though we send h2 to the gateway, the gateway should send h1, as configured by the ServiceEntry
-					"Proto": "HTTP/1.1",
-					//"Proto": "HTTP/2.0",
 				},
 			},
 		},
@@ -126,9 +127,8 @@ func TestOutboundTrafficPolicy_AllowAny(t *testing.T) {
 				// TODO(https://github.com/istio/istio/issues/22717) re-enable TCP
 				// Metric:          "istio_tcp_connections_closed_total",
 				// PromQueryFormat: `sum(istio_tcp_connections_closed_total{reporter="source",destination_service_name="PassthroughCluster",source_workload="client-v1"})`,
-				ResponseCode: []string{"200"},
-				// TCP will add StatusCode field. We don't really have a better way to identify as TCP
-				Metadata: map[string]string{"StatusCode": "200"},
+				StatusCode: http.StatusOK,
+				Protocol:   "TCP",
 			},
 		},
 		{
@@ -138,9 +138,8 @@ func TestOutboundTrafficPolicy_AllowAny(t *testing.T) {
 				// TODO(https://github.com/istio/istio/issues/22717) re-enable TCP
 				// Metric:          "istio_tcp_connections_closed_total",
 				// PromQueryFormat: `sum(istio_tcp_connections_closed_total{reporter="source",destination_service_name="PassthroughCluster",source_workload="client-v1"})`,
-				ResponseCode: []string{"200"},
-				// TCP will add StatusCode field. We don't really have a better way to identify as TCP
-				Metadata: map[string]string{"StatusCode": "200"},
+				StatusCode: http.StatusOK,
+				Protocol:   "TCP",
 			},
 		},
 	}

--- a/tests/integration/telemetry/outboundtrafficpolicy/traffic_registry_only_test.go
+++ b/tests/integration/telemetry/outboundtrafficpolicy/traffic_registry_only_test.go
@@ -18,6 +18,7 @@
 package outboundtrafficpolicy
 
 import (
+	"net/http"
 	"testing"
 )
 
@@ -29,7 +30,7 @@ func TestOutboundTrafficPolicy_RegistryOnly(t *testing.T) {
 			Expected: Expected{
 				Metric:          "istio_requests_total",
 				PromQueryFormat: `sum(istio_requests_total{destination_service_name="BlackHoleCluster",response_code="502"})`,
-				ResponseCode:    []string{"502"},
+				StatusCode:      http.StatusBadGateway,
 			},
 		},
 		{
@@ -38,7 +39,6 @@ func TestOutboundTrafficPolicy_RegistryOnly(t *testing.T) {
 			Expected: Expected{
 				Metric:          "istio_tcp_connections_closed_total",
 				PromQueryFormat: `sum(istio_tcp_connections_closed_total{destination_service_name="BlackHoleCluster"})`,
-				ResponseCode:    []string{},
 			},
 		},
 		{
@@ -47,7 +47,6 @@ func TestOutboundTrafficPolicy_RegistryOnly(t *testing.T) {
 			Expected: Expected{
 				Metric:          "istio_tcp_connections_closed_total",
 				PromQueryFormat: `sum(istio_tcp_connections_closed_total{destination_service_name="BlackHoleCluster"})`,
-				ResponseCode:    []string{},
 			},
 		},
 		{
@@ -57,8 +56,8 @@ func TestOutboundTrafficPolicy_RegistryOnly(t *testing.T) {
 			Expected: Expected{
 				Metric:          "istio_requests_total",
 				PromQueryFormat: `sum(istio_requests_total{destination_service_name="istio-egressgateway",response_code="200"})`,
-				ResponseCode:    []string{"200"},
-				Metadata: map[string]string{
+				StatusCode:      http.StatusOK,
+				RequestHeaders: map[string]string{
 					// We inject this header in the VirtualService
 					"Handled-By-Egress-Gateway": "true",
 				},
@@ -71,7 +70,6 @@ func TestOutboundTrafficPolicy_RegistryOnly(t *testing.T) {
 			Expected: Expected{
 				Metric:          "istio_tcp_connections_closed_total",
 				PromQueryFormat: `sum(istio_tcp_connections_closed_total{reporter="source",destination_service_name="BlackHoleCluster",source_workload="client-v1"})`,
-				ResponseCode:    []string{},
 			},
 		},
 		{
@@ -80,7 +78,6 @@ func TestOutboundTrafficPolicy_RegistryOnly(t *testing.T) {
 			Expected: Expected{
 				Metric:          "istio_tcp_connections_closed_total",
 				PromQueryFormat: `sum(istio_tcp_connections_closed_total{reporter="source",destination_service_name="BlackHoleCluster",source_workload="client-v1"})`,
-				ResponseCode:    []string{},
 			},
 		},
 	}


### PR DESCRIPTION
We currently don't have a way to distinguish between request and response headers when checking echo results. This promotes request and response headers to a top-level field in echo.Response and provides tools for validating headers.

**Please provide a description of this PR:**