### PR TITLE
tf: log CPU info on test run

### DIFF
--- a/prow/integ-suite-kind.sh
+++ b/prow/integ-suite-kind.sh
@@ -101,6 +101,9 @@ while (( "$#" )); do
   esac
 done
 
+echo "Checking CPU..."
+grep 'model' /proc/cpuinfo
+
 # Default IP family of the cluster is IPv4
 export IP_FAMILY="${IP_FAMILY:-ipv4}"
 


### PR DESCRIPTION
The e2 nodes we use get a ~random CPU type. Add logging so we can see if
this correlates to flakes

**Please provide a description of this PR:**