### PR TITLE
check for pods without labels to prevent 'assignment to entry in nil map' panics

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/endpointslice.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpointslice.go
@@ -358,8 +358,13 @@ func (esc *endpointSliceController) InstancesByPort(c *Controller, svc *model.Se
 
 func (esc *endpointSliceController) newEndpointBuilder(pod *corev1.Pod) *EndpointBuilder {
 	if pod != nil {
+		// Set pod labels to an empty map[string]string to prevent 'assignment to entry in nil map' panics
+		if pod.Labels == nil {
+			pod.Labels = map[string]string{}
+		}
+
 		// Respect pod "istio-locality" label
-		if pod.Labels != nil && pod.Labels[model.LocalityLabel] == "" {
+		if pod.Labels[model.LocalityLabel] == "" {
 			pod = pod.DeepCopy()
 			// mutate the labels, only need `istio-locality`
 			pod.Labels[model.LocalityLabel] = esc.c.getPodLocality(pod)

--- a/pilot/pkg/serviceregistry/kube/controller/endpointslice.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpointslice.go
@@ -359,7 +359,7 @@ func (esc *endpointSliceController) InstancesByPort(c *Controller, svc *model.Se
 func (esc *endpointSliceController) newEndpointBuilder(pod *corev1.Pod) *EndpointBuilder {
 	if pod != nil {
 		// Respect pod "istio-locality" label
-		if pod.Labels[model.LocalityLabel] == "" {
+		if pod.Labels != nil && pod.Labels[model.LocalityLabel] == "" {
 			pod = pod.DeepCopy()
 			// mutate the labels, only need `istio-locality`
 			pod.Labels[model.LocalityLabel] = esc.c.getPodLocality(pod)


### PR DESCRIPTION
**Please provide a description of this PR:**
`istiod` fails to start with `panic: assignment to entry in nil map` when there are pods without labels in the cluster. The specific scenario I encountered was using the Lens product, which creates `node-shell` pods in the `kube-system` namespace without labels when connecting to a node. After deleting those pods, `istiod` started without issue. I encountered this issue running istio 1.13.0.