### PR TITLE
Enable affinity rules and tolerations on istiod chart

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -61,6 +61,14 @@ spec:
       nodeSelector:
 {{ toYaml .Values.pilot.nodeSelector | indent 8 }}
 {{- end }}
+{{- with .Values.pilot.affinity }}
+      affinity:
+{{- toYaml . | nindent 8 }}
+{{- end }}
+{{- with .Values.pilot.tolerations }}
+      tolerations:
+{{- toYaml . | nindent 8 }}
+{{- end }}
       serviceAccountName: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
 {{- if .Values.global.priorityClassName }}
       priorityClassName: "{{ .Values.global.priorityClassName }}"

--- a/releasenotes/notes/helm_chart_pilot_deployment_affinity_tolerations.yaml
+++ b/releasenotes/notes/helm_chart_pilot_deployment_affinity_tolerations.yaml
@@ -1,0 +1,16 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+
+# issue is a list of GitHub issues resolved in this note.
+issue: []
+
+docs: []
+
+releaseNotes:
+- |
+  **Added** values to the Istio Pilot Helm charts for configuring affinity rules and tolerations on the Deployment.  Can be used for better placement of Istio pilot workloads.
+
+upgradeNotes: []
+
+securityNotes: []


### PR DESCRIPTION
In order to better support placement of nodes, two features
are needed. Affinity rules and tolerations will help
with properly placing the workloads at desired nodes,
and isolating there from others.

Signed-off-by: Yolanda Robla <yolanda@miro.com>

In order to better support placement of nodes, two features
are needed. Affinity rules and tolerations will help
with properly placing the workloads at desired nodes,
and isolating there from others.


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [x] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
