### PR TITLE
Using errors library API instead of DeepEqual as the judgment condition

### DIFF
--- a/security/pkg/k8s/tokenreview/k8sauthn_test.go
+++ b/security/pkg/k8s/tokenreview/k8sauthn_test.go
@@ -15,7 +15,6 @@
 package tokenreview
 
 import (
-	"errors"
 	"fmt"
 	"reflect"
 	"testing"
@@ -109,7 +108,7 @@ func TestGetTokenReviewResult(t *testing.T) {
 		if !reflect.DeepEqual(result, tc.expectedResult) {
 			t.Errorf("TestGetTokenReviewResult failed: case: %q, actual result is %v, expected is %v", tc.name, result, tc.expectedResult)
 		}
-		if !errors.Is(err, tc.expectedError) {
+		if !(err.Error() == tc.expectedError.Error()) {
 			t.Errorf("TestGetTokenReviewResult failed: case: %q, actual error is %v, expected is %v", tc.name, err, tc.expectedError)
 		}
 	}

--- a/security/pkg/k8s/tokenreview/k8sauthn_test.go
+++ b/security/pkg/k8s/tokenreview/k8sauthn_test.go
@@ -15,6 +15,7 @@
 package tokenreview
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"testing"
@@ -108,7 +109,7 @@ func TestGetTokenReviewResult(t *testing.T) {
 		if !reflect.DeepEqual(result, tc.expectedResult) {
 			t.Errorf("TestGetTokenReviewResult failed: case: %q, actual result is %v, expected is %v", tc.name, result, tc.expectedResult)
 		}
-		if !reflect.DeepEqual(err, tc.expectedError) {
+		if !errors.Is(err, tc.expectedError) {
 			t.Errorf("TestGetTokenReviewResult failed: case: %q, actual error is %v, expected is %v", tc.name, err, tc.expectedError)
 		}
 	}

--- a/security/pkg/k8s/tokenreview/k8sauthn_test.go
+++ b/security/pkg/k8s/tokenreview/k8sauthn_test.go
@@ -17,6 +17,7 @@ package tokenreview
 import (
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 
 	authenticationv1 "k8s.io/api/authentication/v1"
@@ -108,7 +109,7 @@ func TestGetTokenReviewResult(t *testing.T) {
 		if !reflect.DeepEqual(result, tc.expectedResult) {
 			t.Errorf("TestGetTokenReviewResult failed: case: %q, actual result is %v, expected is %v", tc.name, result, tc.expectedResult)
 		}
-		if !(err.Error() == tc.expectedError.Error()) {
+		if !strings.EqualFold(err.Error(), tc.expectedError.Error()) {
 			t.Errorf("TestGetTokenReviewResult failed: case: %q, actual error is %v, expected is %v", tc.name, err, tc.expectedError)
 		}
 	}

--- a/security/pkg/k8s/tokenreview/k8sauthn_test.go
+++ b/security/pkg/k8s/tokenreview/k8sauthn_test.go
@@ -17,7 +17,6 @@ package tokenreview
 import (
 	"fmt"
 	"reflect"
-	"strings"
 	"testing"
 
 	authenticationv1 "k8s.io/api/authentication/v1"
@@ -109,8 +108,18 @@ func TestGetTokenReviewResult(t *testing.T) {
 		if !reflect.DeepEqual(result, tc.expectedResult) {
 			t.Errorf("TestGetTokenReviewResult failed: case: %q, actual result is %v, expected is %v", tc.name, result, tc.expectedResult)
 		}
-		if !strings.EqualFold(err.Error(), tc.expectedError.Error()) {
+		if !errEqual(err, tc.expectedError) {
 			t.Errorf("TestGetTokenReviewResult failed: case: %q, actual error is %v, expected is %v", tc.name, err, tc.expectedError)
 		}
+	}
+}
+
+func errEqual(err error, target error) bool {
+	if target == nil {
+		return err == target
+	} else if err == nil {
+		return false
+	} else {
+		return err.Error() == target.Error()
 	}
 }

--- a/security/pkg/pki/util/generate_csr_test.go
+++ b/security/pkg/pki/util/generate_csr_test.go
@@ -59,7 +59,7 @@ func TestGenCSR(t *testing.T) {
 		csrPem, _, err := GenCSR(tc.csrOptions)
 		if err != nil {
 			if tc.err != nil {
-				if reflect.DeepEqual(err, tc.err) {
+				if errors.Is(err, tc.err) {
 					continue
 				}
 				t.Fatalf("%s: expected error to match expected error: %v", id, err)

--- a/security/pkg/pki/util/generate_csr_test.go
+++ b/security/pkg/pki/util/generate_csr_test.go
@@ -59,7 +59,7 @@ func TestGenCSR(t *testing.T) {
 		csrPem, _, err := GenCSR(tc.csrOptions)
 		if err != nil {
 			if tc.err != nil {
-				if errors.Is(err, tc.err) {
+				if err.Error() == tc.err.Error() {
 					continue
 				}
 				t.Fatalf("%s: expected error to match expected error: %v", id, err)

--- a/security/pkg/pki/util/generate_csr_test.go
+++ b/security/pkg/pki/util/generate_csr_test.go
@@ -59,7 +59,7 @@ func TestGenCSR(t *testing.T) {
 		csrPem, _, err := GenCSR(tc.csrOptions)
 		if err != nil {
 			if tc.err != nil {
-				if err.Error() == tc.err.Error() {
+				if strings.EqualFold(err.Error(), tc.err.Error()) {
 					continue
 				}
 				t.Fatalf("%s: expected error to match expected error: %v", id, err)

--- a/security/pkg/pki/util/generate_csr_test.go
+++ b/security/pkg/pki/util/generate_csr_test.go
@@ -59,7 +59,7 @@ func TestGenCSR(t *testing.T) {
 		csrPem, _, err := GenCSR(tc.csrOptions)
 		if err != nil {
 			if tc.err != nil {
-				if strings.EqualFold(err.Error(), tc.err.Error()) {
+				if err.Error() == tc.err.Error() {
 					continue
 				}
 				t.Fatalf("%s: expected error to match expected error: %v", id, err)


### PR DESCRIPTION
**Please provide a description of this PR:**
Using errors library API instead of DeepEqual as the errors equal judgment condition:

Since the reflect.DeepEqual() does not support error type compare, replace it with the Is function in the golang errors standard library.