### PR TITLE
tf: show prometheus/SD diff on failure instead of dump

### DIFF
--- a/pkg/test/framework/components/prometheus/kube.go
+++ b/pkg/test/framework/components/prometheus/kube.go
@@ -30,7 +30,6 @@ import (
 	kubeApiMeta "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	istioKube "istio.io/istio/pkg/kube"
-	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/pkg/test/framework/components/cluster"
 	"istio.io/istio/pkg/test/framework/components/istio"
@@ -177,14 +176,6 @@ func (c *kubeComponent) Query(cluster cluster.Cluster, query Query) (model.Value
 	}
 }
 
-func (c *kubeComponent) QueryOrFail(t test.Failer, cluster cluster.Cluster, query Query) model.Value {
-	val, err := c.Query(cluster, query)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return val
-}
-
 func (c *kubeComponent) QuerySum(cluster cluster.Cluster, query Query) (float64, error) {
 	val, err := c.Query(cluster, query)
 	if err != nil {
@@ -195,14 +186,6 @@ func (c *kubeComponent) QuerySum(cluster cluster.Cluster, query Query) (float64,
 		return 0, fmt.Errorf("could not find metric value: %v", err)
 	}
 	return got, nil
-}
-
-func (c *kubeComponent) QuerySumOrFail(t test.Failer, cluster cluster.Cluster, query Query) float64 {
-	v, err := c.QuerySum(cluster, query)
-	if err != nil {
-		t.Fatal("failed QuerySum: %v", err)
-	}
-	return v
 }
 
 func Sum(val model.Value) (float64, error) {

--- a/pkg/test/framework/components/prometheus/prometheus.go
+++ b/pkg/test/framework/components/prometheus/prometheus.go
@@ -31,12 +31,12 @@ type Instance interface {
 	APIForCluster(cluster cluster.Cluster) v1.API
 
 	// Query Run the provided query against the given cluster
-	Query(cluster cluster.Cluster, query string) (prom.Value, error)
-	QueryOrFail(t test.Failer, cluster cluster.Cluster, query string) prom.Value
+	Query(cluster cluster.Cluster, query Query) (prom.Value, error)
+	QueryOrFail(t test.Failer, cluster cluster.Cluster, query Query) prom.Value
 
 	// QuerySum is a help around Query to compute the sum
-	QuerySum(cluster cluster.Cluster, query string) (float64, error)
-	QuerySumOrFail(t test.Failer, cluster cluster.Cluster, query string) float64
+	QuerySum(cluster cluster.Cluster, query Query) (float64, error)
+	QuerySumOrFail(t test.Failer, cluster cluster.Cluster, query Query) float64
 }
 
 type Config struct {

--- a/pkg/test/framework/components/prometheus/prometheus.go
+++ b/pkg/test/framework/components/prometheus/prometheus.go
@@ -32,11 +32,9 @@ type Instance interface {
 
 	// Query Run the provided query against the given cluster
 	Query(cluster cluster.Cluster, query Query) (prom.Value, error)
-	QueryOrFail(t test.Failer, cluster cluster.Cluster, query Query) prom.Value
 
 	// QuerySum is a help around Query to compute the sum
 	QuerySum(cluster cluster.Cluster, query Query) (float64, error)
-	QuerySumOrFail(t test.Failer, cluster cluster.Cluster, query Query) float64
 }
 
 type Config struct {

--- a/tests/integration/security/sds_egress/sds_istio_mutual_egress_test.go
+++ b/tests/integration/security/sds_egress/sds_istio_mutual_egress_test.go
@@ -19,7 +19,6 @@ package sdsegress
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"testing"
 	"time"
@@ -141,9 +140,10 @@ func applySetupConfig(ctx framework.TestContext, ns namespace.Instance) {
 }
 
 func getEgressRequestCountOrFail(ctx framework.TestContext, ns namespace.Instance, prom prometheus.Instance) int {
-	query := fmt.Sprintf("istio_requests_total{destination_app=\"%s\",source_workload_namespace=\"%s\"}",
-		egressName, ns.Name())
 	ctx.Helper()
 
-	return int(prom.QuerySumOrFail(ctx, ctx.Clusters().Default(), query))
+	return int(prom.QuerySumOrFail(ctx, ctx.Clusters().Default(), prometheus.Query{Metric: "istio_requests_total", Labels: map[string]string{
+		"destination_app":           egressName,
+		"source_workload_namespace": ns.Name(),
+	}}))
 }

--- a/tests/integration/telemetry/outboundtrafficpolicy/helper.go
+++ b/tests/integration/telemetry/outboundtrafficpolicy/helper.go
@@ -154,11 +154,10 @@ type TestCase struct {
 // prometheus to validate that expected telemetry information was gathered;
 // as well as the http response code
 type Expected struct {
-	Metric          string
-	PromQueryFormat string
-	StatusCode      int
-	Protocol        string
-	RequestHeaders  map[string]string
+	Query          prometheus.Query
+	StatusCode     int
+	Protocol       string
+	RequestHeaders map[string]string
 }
 
 // TrafficPolicy is the mode of the outbound traffic policy to use
@@ -279,8 +278,8 @@ func RunExternalRequest(cases []*TestCase, prometheus prometheus.Instance, mode 
 						},
 					})
 
-					if tc.Expected.Metric != "" {
-						promtest.ValidateMetric(t, ctx.Clusters().Default(), prometheus, tc.Expected.PromQueryFormat, tc.Expected.Metric, 1)
+					if tc.Expected.Query.Metric != "" {
+						promtest.ValidateMetric(t, ctx.Clusters().Default(), prometheus, tc.Expected.Query, 1)
 					}
 				})
 			}

--- a/tests/integration/telemetry/outboundtrafficpolicy/traffic_allow_any_test.go
+++ b/tests/integration/telemetry/outboundtrafficpolicy/traffic_allow_any_test.go
@@ -133,7 +133,7 @@ func TestOutboundTrafficPolicy_AllowAny(t *testing.T) {
 			Host:     "some-external-site.com",
 			Expected: Expected{
 				Query: prometheus.Query{
-					Metric:      "istio_tcp_connections_opened_total",
+					Metric:      "istio_requests_total",
 					Aggregation: "sum",
 					Labels: map[string]string{
 						"reporter":                 "source",
@@ -156,7 +156,7 @@ func TestOutboundTrafficPolicy_AllowAny(t *testing.T) {
 			Host:     "some-external-site.com",
 			Expected: Expected{
 				Query: prometheus.Query{
-					Metric:      "istio_tcp_connections_opened_total",
+					Metric:      "istio_requests_total",
 					Aggregation: "sum",
 					Labels: map[string]string{
 						"reporter":                 "source",

--- a/tests/integration/telemetry/outboundtrafficpolicy/traffic_allow_any_test.go
+++ b/tests/integration/telemetry/outboundtrafficpolicy/traffic_allow_any_test.go
@@ -20,6 +20,8 @@ package outboundtrafficpolicy
 import (
 	"net/http"
 	"testing"
+
+	"istio.io/istio/pkg/test/framework/components/prometheus"
 )
 
 func TestOutboundTrafficPolicy_AllowAny(t *testing.T) {
@@ -28,10 +30,17 @@ func TestOutboundTrafficPolicy_AllowAny(t *testing.T) {
 			Name:     "HTTP Traffic",
 			PortName: "http",
 			Expected: Expected{
-				Metric:          "istio_requests_total",
-				PromQueryFormat: `sum(istio_requests_total{reporter="source",destination_service_name="PassthroughCluster",response_code="200"})`,
-				StatusCode:      http.StatusOK,
-				Protocol:        "HTTP/1.1",
+				Query: prometheus.Query{
+					Metric:      "istio_requests_total",
+					Aggregation: "sum",
+					Labels: map[string]string{
+						"reporter":                 "source",
+						"destination_service_name": "PassthroughCluster",
+						"response_code":            "200",
+					},
+				},
+				StatusCode: http.StatusOK,
+				Protocol:   "HTTP/1.1",
 			},
 		},
 		{
@@ -39,30 +48,49 @@ func TestOutboundTrafficPolicy_AllowAny(t *testing.T) {
 			PortName: "http",
 			HTTP2:    true,
 			Expected: Expected{
-				Metric:          "istio_requests_total",
-				PromQueryFormat: `sum(istio_requests_total{reporter="source",destination_service_name="PassthroughCluster",response_code="200"})`,
-				StatusCode:      http.StatusOK,
-				Protocol:        "HTTP/2.0",
+				Query: prometheus.Query{
+					Metric:      "istio_requests_total",
+					Aggregation: "sum",
+					Labels: map[string]string{
+						"reporter":                 "source",
+						"destination_service_name": "PassthroughCluster",
+						"response_code":            "200",
+					},
+				},
+				StatusCode: http.StatusOK,
+				Protocol:   "HTTP/2.0",
 			},
 		},
 		{
 			Name:     "HTTPS Traffic",
 			PortName: "https",
 			Expected: Expected{
-				Metric:          "istio_tcp_connections_opened_total",
-				PromQueryFormat: `sum(istio_tcp_connections_opened_total{reporter="source",destination_service_name="PassthroughCluster"})`,
-				StatusCode:      http.StatusOK,
-				Protocol:        "HTTP/1.1",
+				Query: prometheus.Query{
+					Metric:      "istio_tcp_connections_opened_total",
+					Aggregation: "sum",
+					Labels: map[string]string{
+						"reporter":                 "source",
+						"destination_service_name": "PassthroughCluster",
+					},
+				},
+				StatusCode: http.StatusOK,
+				Protocol:   "HTTP/1.1",
 			},
 		},
 		{
 			Name:     "HTTPS Traffic Conflict",
 			PortName: "https-conflict",
 			Expected: Expected{
-				Metric:          "istio_tcp_connections_opened_total",
-				PromQueryFormat: `sum(istio_tcp_connections_opened_total{reporter="source",destination_service_name="PassthroughCluster"})`,
-				StatusCode:      http.StatusOK,
-				Protocol:        "HTTP/1.1",
+				Query: prometheus.Query{
+					Metric:      "istio_tcp_connections_opened_total",
+					Aggregation: "sum",
+					Labels: map[string]string{
+						"reporter":                 "source",
+						"destination_service_name": "PassthroughCluster",
+					},
+				},
+				StatusCode: http.StatusOK,
+				Protocol:   "HTTP/1.1",
 			},
 		},
 		{
@@ -70,10 +98,16 @@ func TestOutboundTrafficPolicy_AllowAny(t *testing.T) {
 			PortName: "https",
 			HTTP2:    true,
 			Expected: Expected{
-				Metric:          "istio_tcp_connections_opened_total",
-				PromQueryFormat: `sum(istio_tcp_connections_opened_total{reporter="source",destination_service_name="PassthroughCluster"})`,
-				StatusCode:      http.StatusOK,
-				Protocol:        "HTTP/2.0",
+				Query: prometheus.Query{
+					Metric:      "istio_tcp_connections_opened_total",
+					Aggregation: "sum",
+					Labels: map[string]string{
+						"reporter":                 "source",
+						"destination_service_name": "PassthroughCluster",
+					},
+				},
+				StatusCode: http.StatusOK,
+				Protocol:   "HTTP/2.0",
 			},
 		},
 		{
@@ -81,10 +115,16 @@ func TestOutboundTrafficPolicy_AllowAny(t *testing.T) {
 			PortName: "https-conflict",
 			HTTP2:    true,
 			Expected: Expected{
-				Metric:          "istio_tcp_connections_opened_total",
-				PromQueryFormat: `sum(istio_tcp_connections_opened_total{reporter="source",destination_service_name="PassthroughCluster"})`,
-				StatusCode:      http.StatusOK,
-				Protocol:        "HTTP/2.0",
+				Query: prometheus.Query{
+					Metric:      "istio_tcp_connections_opened_total",
+					Aggregation: "sum",
+					Labels: map[string]string{
+						"reporter":                 "source",
+						"destination_service_name": "PassthroughCluster",
+					},
+				},
+				StatusCode: http.StatusOK,
+				Protocol:   "HTTP/2.0",
 			},
 		},
 		{
@@ -92,10 +132,17 @@ func TestOutboundTrafficPolicy_AllowAny(t *testing.T) {
 			PortName: "http",
 			Host:     "some-external-site.com",
 			Expected: Expected{
-				Metric:          "istio_requests_total",
-				PromQueryFormat: `sum(istio_requests_total{reporter="source",destination_service_name="istio-egressgateway",response_code="200"})`, // nolint: lll
-				StatusCode:      http.StatusOK,
-				Protocol:        "HTTP/1.1",
+				Query: prometheus.Query{
+					Metric:      "istio_tcp_connections_opened_total",
+					Aggregation: "sum",
+					Labels: map[string]string{
+						"reporter":                 "source",
+						"destination_service_name": "istio-egressgateway",
+						"response_code":            "200",
+					},
+				},
+				StatusCode: http.StatusOK,
+				Protocol:   "HTTP/1.1",
 				RequestHeaders: map[string]string{
 					// We inject this header in the VirtualService
 					"Handled-By-Egress-Gateway": "true",
@@ -108,9 +155,16 @@ func TestOutboundTrafficPolicy_AllowAny(t *testing.T) {
 			HTTP2:    true,
 			Host:     "some-external-site.com",
 			Expected: Expected{
-				Metric:          "istio_requests_total",
-				PromQueryFormat: `sum(istio_requests_total{reporter="source",destination_service_name="istio-egressgateway",response_code="200"})`, // nolint: lll
-				StatusCode:      http.StatusOK,
+				Query: prometheus.Query{
+					Metric:      "istio_tcp_connections_opened_total",
+					Aggregation: "sum",
+					Labels: map[string]string{
+						"reporter":                 "source",
+						"destination_service_name": "istio-egressgateway",
+						"response_code":            "200",
+					},
+				},
+				StatusCode: http.StatusOK,
 				// Even though we send h2 to the gateway, the gateway should send h1, as configured by the ServiceEntry
 				Protocol: "HTTP/1.1",
 				RequestHeaders: map[string]string{

--- a/tests/integration/telemetry/stackdriver/api/stackdriver_filter_test.go
+++ b/tests/integration/telemetry/stackdriver/api/stackdriver_filter_test.go
@@ -74,7 +74,7 @@ func TestStackdriverMonitoring(t *testing.T) {
 						}
 						t.Logf("Metrics validated")
 
-						if err := stackdrivertest.ValidateLogs(filepath.Join(env.IstioSrc, serverLogEntry), clName, trustDomain, stackdriver.ServerAccessLog); err != nil {
+						if err := stackdrivertest.ValidateLogs(t, filepath.Join(env.IstioSrc, serverLogEntry), clName, trustDomain, stackdriver.ServerAccessLog); err != nil {
 							return err
 						}
 						t.Logf("logs validated")

--- a/tests/integration/telemetry/stackdriver/common.go
+++ b/tests/integration/telemetry/stackdriver/common.go
@@ -43,6 +43,7 @@ import (
 	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/framework/components/stackdriver"
 	"istio.io/istio/pkg/test/framework/resource"
+	"istio.io/istio/pkg/test/scopes"
 	"istio.io/istio/pkg/test/util/tmpl"
 	"istio.io/istio/pkg/util/protomarshal"
 	"istio.io/istio/tests/integration/telemetry"
@@ -261,9 +262,12 @@ func ConditionallySetupMetadataServer(ctx resource.Context) (err error) {
 	// TODO: this looks at the machine the node is running on. This would not work if the host and test
 	// cluster differ.
 	if !metadata.OnGCE() {
+		scopes.Framework.Infof("Not on GCE, setup fake GCE metadata server")
 		if GCEInst, err = gcemetadata.New(ctx, gcemetadata.Config{}); err != nil {
 			return
 		}
+	} else {
+		scopes.Framework.Infof("On GCE, setup fake GCE metadata server")
 	}
 	return nil
 }
@@ -351,7 +355,7 @@ func logDiff(t test.Failer, tp string, query map[string]string, entries []map[st
 		t.Log("no diff found")
 		return
 	}
-	t.Logf("query for %d returned %d entries (%d distinct), but none matched our query exactly.", tp, len(entries), len(seen))
+	t.Logf("query for %s returned %d entries (%d distinct), but none matched our query exactly.", tp, len(entries), len(seen))
 	sort.Slice(allMismatches, func(i, j int) bool {
 		return len(allMismatches[i]) < len(allMismatches[j])
 	})

--- a/tests/integration/telemetry/stackdriver/common.go
+++ b/tests/integration/telemetry/stackdriver/common.go
@@ -228,9 +228,13 @@ func ValidateMetrics(t *testing.T, serverReqCount, clientReqCount, clName, trust
 			gotClient = true
 		}
 	}
-	if !gotServer || !gotClient {
-		return fmt.Errorf("metrics: did not get expected metrics for cluster %s; got %v\n want client %v\n want server %v",
-			clName, ts, wantClient.String(), wantServer.String())
+	if !gotServer {
+		LogMetricsDiff(t, &wantServer, ts)
+		return fmt.Errorf("metrics: did not get expected metrics for cluster %s", clName)
+	}
+	if !gotClient {
+		LogMetricsDiff(t, &wantClient, ts)
+		return fmt.Errorf("metrics: did not get expected metrics for cluster %s", clName)
 	}
 	return nil
 }
@@ -322,7 +326,6 @@ func logDiff(t test.Failer, query map[string]string, entries []map[string]string
 		return
 	}
 	allMismatches := []map[string]string{}
-	full := []map[string]string{}
 	seen := sets.NewSet()
 	for _, s := range entries {
 		b, _ := json.Marshal(s)
@@ -342,7 +345,6 @@ func logDiff(t test.Failer, query map[string]string, entries []map[string]string
 			continue
 		}
 		allMismatches = append(allMismatches, misMatched)
-		full = append(full, s)
 	}
 	if len(allMismatches) == 0 {
 		t.Log("no diff found")

--- a/tests/integration/telemetry/stackdriver/stackdriver_filter_audit_test.go
+++ b/tests/integration/telemetry/stackdriver/stackdriver_filter_audit_test.go
@@ -77,21 +77,21 @@ func TestStackdriverHTTPAuditLogging(t *testing.T) {
 
 						var errs []string
 
-						errAuditFoo := ValidateLogs(filepath.Join(env.IstioSrc, serverAuditFooLogEntry), clName, trustDomain, stackdriver.ServerAuditLog)
+						errAuditFoo := ValidateLogs(t, filepath.Join(env.IstioSrc, serverAuditFooLogEntry), clName, trustDomain, stackdriver.ServerAuditLog)
 						if errAuditFoo == nil {
 							t.Logf("Foo Audit Log validated for cluster %v", clName)
 						} else {
 							errs = append(errs, errAuditFoo.Error())
 						}
 
-						errAuditBar := ValidateLogs(filepath.Join(env.IstioSrc, serverAuditBarLogEntry), clName, trustDomain, stackdriver.ServerAuditLog)
+						errAuditBar := ValidateLogs(t, filepath.Join(env.IstioSrc, serverAuditBarLogEntry), clName, trustDomain, stackdriver.ServerAuditLog)
 						if errAuditBar == nil {
 							t.Logf("Bar Audit Log validated for cluster %v", clName)
 						} else {
 							errs = append(errs, errAuditBar.Error())
 						}
 
-						errAuditAll := ValidateLogs(filepath.Join(env.IstioSrc, serverAuditAllLogEntry), clName, trustDomain, stackdriver.ServerAuditLog)
+						errAuditAll := ValidateLogs(t, filepath.Join(env.IstioSrc, serverAuditAllLogEntry), clName, trustDomain, stackdriver.ServerAuditLog)
 						if errAuditAll == nil {
 							t.Logf("All Audit Log validated for cluster %v", clName)
 						} else {
@@ -114,7 +114,7 @@ func TestStackdriverHTTPAuditLogging(t *testing.T) {
 						}
 
 						return fmt.Errorf(strings.Join(errs, "\n"))
-					}, retry.Delay(5*time.Second), retry.Timeout(80*time.Second))
+					}, retry.Delay(5*time.Second), retry.Timeout(20*time.Second))
 					if err != nil {
 						return err
 					}

--- a/tests/integration/telemetry/stackdriver/stackdriver_filter_dry_run_test.go
+++ b/tests/integration/telemetry/stackdriver/stackdriver_filter_dry_run_test.go
@@ -201,11 +201,11 @@ func createDryRunPolicy(ctx framework.TestContext, authz string) {
 	ctx.ConfigIstio().WaitForConfigOrFail(ctx, ctx, ns.Name(), policies...)
 }
 
-func verifyAccessLog(ctx framework.TestContext, cltInstance echo.Instance, wantLog string) error {
-	ctx.Logf("Validating for cluster %v", cltInstance.Config().Cluster.Name())
+func verifyAccessLog(t framework.TestContext, cltInstance echo.Instance, wantLog string) error {
+	t.Logf("Validating for cluster %v", cltInstance.Config().Cluster.Name())
 	clName := cltInstance.Config().Cluster.Name()
 	trustDomain := telemetry.GetTrustDomain(cltInstance.Config().Cluster, Ist.Settings().SystemNamespace)
-	if err := ValidateLogs(wantLog, clName, trustDomain, stackdriver.ServerAccessLog); err != nil {
+	if err := ValidateLogs(t, wantLog, clName, trustDomain, stackdriver.ServerAccessLog); err != nil {
 		return err
 	}
 	return nil

--- a/tests/integration/telemetry/stackdriver/stackdriver_filter_test.go
+++ b/tests/integration/telemetry/stackdriver/stackdriver_filter_test.go
@@ -39,13 +39,6 @@ import (
 	"istio.io/istio/tests/integration/telemetry"
 )
 
-const (
-	fakeGCEMetadataServerValues = `
-  defaultConfig:
-    proxyMetadata:
-      GCE_METADATA_HOST: `
-)
-
 // TestStackdriverMonitoring verifies that stackdriver WASM filter exports metrics with expected labels.
 func TestStackdriverMonitoring(t *testing.T) {
 	framework.NewTest(t).
@@ -69,7 +62,7 @@ func TestStackdriverMonitoring(t *testing.T) {
 							return err
 						}
 						t.Logf("Metrics validated")
-						if err := ValidateLogs(filepath.Join(env.IstioSrc, serverLogEntry), clName, trustDomain, stackdriver.ServerAccessLog); err != nil {
+						if err := ValidateLogs(t, filepath.Join(env.IstioSrc, serverLogEntry), clName, trustDomain, stackdriver.ServerAccessLog); err != nil {
 							return err
 						}
 						t.Logf("logs validated")
@@ -119,11 +112,11 @@ meshConfig:
 	cfg.Values["pilot.traceSampling"] = "100"
 	cfg.Values["telemetry.v2.accessLogPolicy.enabled"] = "true"
 	cfg.Values["telemetry.v2.accessLogPolicy.logWindowDuration"] = "1s"
-	cfg.Values["global.proxy.componentLogLevel"] = "rbac:debug,wasm:debug"
+	// cfg.Values["global.proxy.componentLogLevel"] = "rbac:debug,wasm:debug"
 
 	// conditionally use a fake metadata server for testing off of GCP
 	if GCEInst != nil {
-		cfg.ControlPlaneValues = strings.Join([]string{cfg.ControlPlaneValues, fakeGCEMetadataServerValues, GCEInst.Address()}, "")
+		cfg.ControlPlaneValues = strings.Join([]string{cfg.ControlPlaneValues, FakeGCEMetadataServerValues, GCEInst.Address()}, "")
 	}
 }
 

--- a/tests/integration/telemetry/stackdriver/stackdriver_filter_test.go
+++ b/tests/integration/telemetry/stackdriver/stackdriver_filter_test.go
@@ -112,7 +112,7 @@ meshConfig:
 	cfg.Values["pilot.traceSampling"] = "100"
 	cfg.Values["telemetry.v2.accessLogPolicy.enabled"] = "true"
 	cfg.Values["telemetry.v2.accessLogPolicy.logWindowDuration"] = "1s"
-	// cfg.Values["global.proxy.componentLogLevel"] = "rbac:debug,wasm:debug"
+	cfg.Values["global.proxy.componentLogLevel"] = "rbac:debug,wasm:debug"
 
 	// conditionally use a fake metadata server for testing off of GCP
 	if GCEInst != nil {

--- a/tests/integration/telemetry/stackdriver/stackdriver_tcp_filter_test.go
+++ b/tests/integration/telemetry/stackdriver/stackdriver_tcp_filter_test.go
@@ -63,8 +63,7 @@ func TestTCPStackdriverMonitoring(t *testing.T) {
 							filepath.Join(env.IstioSrc, tcpClientConnectionCount), clName, trustDomain); err != nil {
 							return err
 						}
-						if err := ValidateLogs(filepath.Join(env.IstioSrc, tcpServerLogEntry), clName,
-							trustDomain, stackdriver.ServerAccessLog); err != nil {
+						if err := ValidateLogs(t, filepath.Join(env.IstioSrc, tcpServerLogEntry), clName, trustDomain, stackdriver.ServerAccessLog); err != nil {
 							return err
 						}
 

--- a/tests/integration/telemetry/stackdriver/vm/main_test.go
+++ b/tests/integration/telemetry/stackdriver/vm/main_test.go
@@ -184,11 +184,13 @@ func testSetup(ctx resource.Context) error {
 		"ISTIO_META_MESH_ID":                                     "proj-test-mesh",
 		"ISTIO_META_WORKLOAD_NAME":                               "vm-server-v1",
 		"ISTIO_METAJSON_LABELS":                                  vmLabelsJSON,
-		"GCE_METADATA_HOST":                                      sdtest.GCEInst.Address(),
 		"CANONICAL_SERVICE":                                      "vm-server",
 		"CANONICAL_REVISION":                                     "v1",
 		// we must supply a bootstrap override to get the test endpoint uri into the tracing configuration
 		"ISTIO_BOOTSTRAP_OVERRIDE": "/etc/istio/custom-bootstrap/custom_bootstrap.json",
+	}
+	if sdtest.GCEInst != nil {
+		vmEnv["GCE_METADATA_HOST"] = sdtest.GCEInst.Address()
 	}
 
 	trustDomain := telemetry.GetTrustDomain(ctx.Clusters()[0], istioInst.Settings().SystemNamespace)

--- a/tests/integration/telemetry/stackdriver/vm/vm_test.go
+++ b/tests/integration/telemetry/stackdriver/vm/vm_test.go
@@ -28,10 +28,12 @@ import (
 	monitoring "google.golang.org/genproto/googleapis/monitoring/v3"
 	"google.golang.org/protobuf/proto"
 
+	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/stackdriver"
 	"istio.io/istio/pkg/test/util/retry"
+	sdtest "istio.io/istio/tests/integration/telemetry/stackdriver"
 	"istio.io/pkg/log"
 )
 
@@ -54,13 +56,13 @@ func TestVMTelemetry(t *testing.T) {
 				}
 
 				// Verify stackdriver metrics
-				gotMetrics := gotRequestCountMetrics(wantClientReqs, wantServerReqs)
+				gotMetrics := gotRequestCountMetrics(t, wantClientReqs, wantServerReqs)
 
 				// Verify log entry
-				gotLogs := gotLogEntry(wantLogEntry)
+				gotLogs := gotLogEntry(t, wantLogEntry)
 
 				// verify traces
-				gotTraces := gotTrace(wantTrace)
+				gotTraces := gotTrace(t, wantTrace)
 
 				if !(gotMetrics && gotLogs && gotTraces) {
 					return fmt.Errorf("did not receive all expected telemetry; status: metrics=%t, logs=%t, traces=%t", gotMetrics, gotLogs, gotTraces)
@@ -103,7 +105,7 @@ func traceEqual(got, want *cloudtrace.Trace) bool {
 	return true
 }
 
-func gotRequestCountMetrics(wantClient, wantServer *monitoring.TimeSeries) bool {
+func gotRequestCountMetrics(t test.Failer, wantClient, wantServer *monitoring.TimeSeries) bool {
 	ts, err := sdInst.ListTimeSeries(ns.Name())
 	if err != nil {
 		log.Errorf("could not get list of time-series from stackdriver: %v", err)
@@ -123,32 +125,19 @@ func gotRequestCountMetrics(wantClient, wantServer *monitoring.TimeSeries) bool 
 	}
 
 	if !gotServer {
-		log.Errorf("incorrect metric: got %v\n want client %v\n", ts, wantServer)
+		sdtest.LogMetricsDiff(t, wantServer, ts)
 	}
 	if !gotClient {
-		log.Errorf("incorrect metric: got %v\n want client %v\n", ts, wantClient)
+		sdtest.LogMetricsDiff(t, wantClient, ts)
 	}
 	return gotServer && gotClient
 }
 
-func gotLogEntry(want *loggingpb.LogEntry) bool {
-	entries, err := sdInst.ListLogEntries(stackdriver.ServerAccessLog, ns.Name())
-	if err != nil {
-		log.Errorf("failed to get list of log entries from stackdriver: %v", err)
-		return false
-	}
-	for _, l := range entries {
-		l.Trace = ""
-		l.SpanId = ""
-		if proto.Equal(l, want) {
-			return true
-		}
-		log.Errorf("incorrect log: got %v\nwant %v", l, want)
-	}
-	return false
+func gotLogEntry(t test.Failer, want *loggingpb.LogEntry) bool {
+	return sdtest.ValidateLogEntry(t, want, stackdriver.ServerAccessLog) == nil
 }
 
-func gotTrace(want *cloudtrace.Trace) bool {
+func gotTrace(t test.Failer, want *cloudtrace.Trace) bool {
 	traces, err := sdInst.ListTraces(ns.Name())
 	if err != nil {
 		log.Errorf("failed to retrieve list of tracespans from stackdriver: %v", err)
@@ -160,5 +149,6 @@ func gotTrace(want *cloudtrace.Trace) bool {
 			return true
 		}
 	}
+	sdtest.LogTraceDiff(t, want, traces)
 	return false
 }

--- a/tests/integration/telemetry/stats/prometheus/customizemetrics/customize_metrics_test.go
+++ b/tests/integration/telemetry/stats/prometheus/customizemetrics/customize_metrics_test.go
@@ -64,7 +64,7 @@ func TestCustomizeMetrics(t *testing.T) {
 		Run(func(ctx framework.TestContext) {
 			ctx.Cleanup(func() {
 				if ctx.Failed() {
-					util.PromDump(ctx.Clusters().Default(), promInst, "istio_requests_total")
+					util.PromDump(ctx.Clusters().Default(), promInst, prometheus.Query{Metric: "istio_requests_total"})
 				}
 			})
 			httpDestinationQuery := buildQuery(httpProtocol)
@@ -95,8 +95,8 @@ func TestCustomizeMetrics(t *testing.T) {
 			if strings.Contains(httpMetricVal, removedTag) {
 				t.Errorf("failed to remove tag: %v", removedTag)
 			}
-			common.ValidateMetric(t, cluster, promInst, httpDestinationQuery, "istio_requests_total", 1)
-			common.ValidateMetric(t, cluster, promInst, grpcDestinationQuery, "istio_requests_total", 1)
+			common.ValidateMetric(t, cluster, promInst, httpDestinationQuery, 1)
+			common.ValidateMetric(t, cluster, promInst, grpcDestinationQuery, 1)
 		})
 }
 
@@ -291,7 +291,7 @@ func sendTraffic(t *testing.T) error {
 	return nil
 }
 
-func buildQuery(protocol string) (destinationQuery string) {
+func buildQuery(protocol string) (destinationQuery prometheus.Query) {
 	labels := map[string]string{
 		"request_protocol":               "http",
 		"response_code":                  "2xx",

--- a/tests/integration/telemetry/stats/prometheus/util_prometheus.go
+++ b/tests/integration/telemetry/stats/prometheus/util_prometheus.go
@@ -28,7 +28,7 @@ import (
 )
 
 // QueryPrometheus queries prometheus and returns the result once the query stabilizes
-func QueryPrometheus(t *testing.T, cluster cluster.Cluster, query string, promInst prometheus.Instance) (string, error) {
+func QueryPrometheus(t *testing.T, cluster cluster.Cluster, query prometheus.Query, promInst prometheus.Instance) (string, error) {
 	t.Logf("query prometheus with: %v", query)
 
 	val, err := promInst.Query(cluster, query)
@@ -44,10 +44,10 @@ func QueryPrometheus(t *testing.T, cluster cluster.Cluster, query string, promIn
 	return val.String(), nil
 }
 
-func ValidateMetric(t *testing.T, cluster cluster.Cluster, prometheus prometheus.Instance, query, metricName string, want float64) {
+func ValidateMetric(t *testing.T, cluster cluster.Cluster, prometheus prometheus.Instance, query prometheus.Query, want float64) {
 	retry.UntilSuccessOrFail(t, func() error {
 		got, err := prometheus.QuerySum(cluster, query)
-		t.Logf("%s: %f", metricName, got)
+		t.Logf("%s: %f", query.Metric, got)
 		if err != nil {
 			return err
 		}

--- a/tests/integration/telemetry/util.go
+++ b/tests/integration/telemetry/util.go
@@ -43,6 +43,7 @@ func PromDiff(t test.Failer, prom prometheus.Instance, cluster cluster.Cluster, 
 	case model.ValVector:
 		value := v.(model.Vector)
 		var allMismatches []map[string]string
+		full := []model.Metric{}
 		for _, s := range value {
 			misMatched := map[string]string{}
 			for k, want := range query.Labels {
@@ -55,15 +56,16 @@ func PromDiff(t test.Failer, prom prometheus.Instance, cluster cluster.Cluster, 
 				continue
 			}
 			allMismatches = append(allMismatches, misMatched)
-
+			full = append(full, s.Metric)
 		}
 		if len(allMismatches) == 0 {
 			t.Logf("no diff found")
 			return
 		}
 		t.Logf("query %q returned %v series, but none matched our query exactly.", query.Metric, len(value))
+		t.Logf("Original query: %v", query.String())
 		for i, m := range allMismatches {
-			t.Logf("Series %d", i)
+			t.Logf("Series %d (source: %v/%v)", i, full[i]["namespace"], full[i]["pod"])
 			missing := []string{}
 			for k, v := range m {
 				if v == "" {

--- a/tests/integration/telemetry/util.go
+++ b/tests/integration/telemetry/util.go
@@ -34,7 +34,7 @@ import (
 func PromDiff(t test.Failer, prom prometheus.Instance, cluster cluster.Cluster, query prometheus.Query) {
 	t.Helper()
 	unlabelled := prometheus.Query{Metric: query.Metric}
-	v := prom.QueryOrFail(t, cluster, unlabelled)
+	v, _ := prom.Query(cluster, unlabelled)
 	if v == nil {
 		t.Logf("no metrics found for %v", unlabelled)
 		return

--- a/tests/integration/telemetry/util.go
+++ b/tests/integration/telemetry/util.go
@@ -20,17 +20,73 @@ package telemetry
 import (
 	"context"
 
+	"github.com/prometheus/common/model"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"istio.io/istio/pkg/config/mesh"
+	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/framework/components/cluster"
 	"istio.io/istio/pkg/test/framework/components/prometheus"
 )
 
+// PromDiff compares a query with labels to a query of the same metric without labels, and notes the closest matching
+// metric.
+func PromDiff(t test.Failer, prom prometheus.Instance, cluster cluster.Cluster, query prometheus.Query) {
+	t.Helper()
+	unlabelled := prometheus.Query{Metric: query.Metric}
+	v := prom.QueryOrFail(t, cluster, unlabelled)
+	if v == nil {
+		t.Logf("no metrics found for %v", unlabelled)
+		return
+	}
+	switch v.Type() {
+	case model.ValVector:
+		value := v.(model.Vector)
+		var allMismatches []map[string]string
+		for _, s := range value {
+			misMatched := map[string]string{}
+			for k, want := range query.Labels {
+				got := string(s.Metric[model.LabelName(k)])
+				if want != got {
+					misMatched[k] = got
+				}
+			}
+			if len(misMatched) == 0 {
+				continue
+			}
+			allMismatches = append(allMismatches, misMatched)
+
+		}
+		if len(allMismatches) == 0 {
+			t.Logf("no diff found")
+			return
+		}
+		t.Logf("query %q returned %v series, but none matched our query exactly.", query.Metric, len(value))
+		for i, m := range allMismatches {
+			t.Logf("Series %d", i)
+			missing := []string{}
+			for k, v := range m {
+				if v == "" {
+					missing = append(missing, k)
+				} else {
+					t.Logf("  for label %q, wanted %q but got %q", k, query.Labels[k], v)
+				}
+			}
+			if len(missing) > 0 {
+				t.Logf("  missing labels: %v", missing)
+			}
+		}
+
+	default:
+		t.Fatalf("PromDiff expects Vector, got %v", v.Type())
+
+	}
+}
+
 // PromDump gets all of the recorded values for a metric by name and generates a report of the values.
 // used for debugging of failures to provide a comprehensive view of traffic experienced.
-func PromDump(cluster cluster.Cluster, prometheus prometheus.Instance, metric string) string {
-	if value, err := prometheus.Query(cluster, metric); err == nil {
+func PromDump(cluster cluster.Cluster, prometheus prometheus.Instance, query prometheus.Query) string {
+	if value, err := prometheus.Query(cluster, query); err == nil {
 		return value.String()
 	}
 


### PR DESCRIPTION
Example output:
```
   stats.go:130: query "istio_requests_total" returned 2 series, but none matched our query exactly.
    stats.go:130: Series 0
    stats.go:130:   for label "reporter", wanted "destination" but got "source"
    stats.go:130: Series 1
    stats.go:130:   for label "reporter", wanted "destination" but got "source"
    stats.go:130:   for label "destination_app", wanted "server" but got "unknown"
    stats.go:130:   for label "destination_service", wanted "server.echo.svc.cluster.local" but got "server-no-sidecar.echo.svc.cluster.local"
    stats.go:130:   for label "destination_version", wanted "v1" but got "unknown"
    stats.go:130:   for label "destination_service_name", wanted "server" but got "server-no-sidecar"
```

As part of this, refactored how we pass around Queries to make things more useable in this manner

Fixes https://github.com/istio/istio/issues/35923 in the process