### PR TITLE
Cleanup usages of SkipXX in test framework

### DIFF
--- a/pkg/test/framework/components/echo/echoboot/echoboot.go
+++ b/pkg/test/framework/components/echo/echoboot/echoboot.go
@@ -31,6 +31,7 @@ import (
 	"istio.io/istio/pkg/test/framework/components/cluster"
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/echo/common"
+	"istio.io/istio/pkg/test/framework/components/echo/echotypes"
 	"istio.io/istio/pkg/test/framework/components/echo/kube"
 
 	// force registraton of factory func
@@ -95,14 +96,7 @@ func (b builder) WithConfig(cfg echo.Config) echo.Builder {
 // to that cluster, otherwise the Config is applied to all WithClusters. Once built, if being built for a single cluster,
 // the instance pointer will be updated to point at the new Instance.
 func (b builder) With(i *echo.Instance, cfg echo.Config) echo.Builder {
-	if b.ctx.Settings().SkipVM && cfg.DeployAsVM {
-		return b
-	}
 	if b.ctx.Settings().SkipWorkloadClasses.Contains(cfg.Class()) {
-		return b
-	}
-
-	if b.ctx.Settings().SkipTProxy && cfg.IsTProxy() {
 		return b
 	}
 
@@ -121,7 +115,7 @@ func (b builder) With(i *echo.Instance, cfg echo.Config) echo.Builder {
 	}
 
 	// If we didn't deploy VMs, but we don't care about VMs, we can ignore this.
-	shouldSkip := b.ctx.Settings().SkipVM && cfg.DeployAsVM
+	shouldSkip := b.ctx.Settings().Skip(echotypes.VM) && cfg.IsVM()
 	deployedTo := 0
 	for idx, c := range targetClusters {
 		ec, ok := c.(echo.Cluster)

--- a/pkg/test/framework/components/echo/echotest/echotest.go
+++ b/pkg/test/framework/components/echo/echotest/echotest.go
@@ -17,6 +17,7 @@ package echotest
 import (
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
+	"istio.io/istio/pkg/test/framework/components/echo/echotypes"
 )
 
 // T enumerates subtests given a set of workloads as echo.Instances.
@@ -40,7 +41,7 @@ func New(ctx framework.TestContext, instances echo.Instances) *T {
 	copy(s, instances)
 	copy(d, instances)
 	t := &T{rootCtx: ctx, sources: s, destinations: d}
-	if ctx.Settings().SkipVM {
+	if ctx.Settings().Skip(echotypes.VM) {
 		noVM := Not(FilterMatch(echo.IsVirtualMachine()))
 		t = t.From(noVM).To(noVM)
 	}

--- a/pkg/test/framework/resource/flags.go
+++ b/pkg/test/framework/resource/flags.go
@@ -51,13 +51,13 @@ func SettingsFromCommandLine(testID string) (*Settings, error) {
 	for _, wl := range s.skipWorkloadClasses {
 		s.SkipWorkloadClasses.Insert(strings.Split(wl, ",")...)
 	}
-	if s.SkipVM {
+	if s.skipVM {
 		s.SkipWorkloadClasses.Insert(echotypes.VM)
 	}
-	if s.SkipTProxy {
+	if s.skipTProxy {
 		s.SkipWorkloadClasses.Insert(echotypes.TProxy)
 	}
-	if s.SkipDelta {
+	if s.skipDelta {
 		// TODO we may also want to trigger this if we have an old verion
 		s.SkipWorkloadClasses.Insert(echotypes.Delta)
 	}
@@ -132,13 +132,13 @@ func init() {
 	flag.StringVar(&settingsFromCommandLine.Revision, "istio.test.revision", settingsFromCommandLine.Revision,
 		"If set to XXX, overwrite the default namespace label (istio-injection=enabled) with istio.io/rev=XXX.")
 
-	flag.BoolVar(&settingsFromCommandLine.SkipVM, "istio.test.skipVM", settingsFromCommandLine.SkipVM,
+	flag.BoolVar(&settingsFromCommandLine.skipVM, "istio.test.skipVM", settingsFromCommandLine.skipVM,
 		"Skip VM related parts in all tests.")
 
-	flag.BoolVar(&settingsFromCommandLine.SkipDelta, "istio.test.skipDelta", settingsFromCommandLine.SkipDelta,
+	flag.BoolVar(&settingsFromCommandLine.skipDelta, "istio.test.skipDelta", settingsFromCommandLine.skipDelta,
 		"Skip Delta XDS related parts in all tests.")
 
-	flag.BoolVar(&settingsFromCommandLine.SkipTProxy, "istio.test.skipTProxy", settingsFromCommandLine.SkipTProxy,
+	flag.BoolVar(&settingsFromCommandLine.skipTProxy, "istio.test.skipTProxy", settingsFromCommandLine.skipTProxy,
 		"Skip TProxy related parts in all tests.")
 
 	flag.BoolVar(&settingsFromCommandLine.Compatibility, "istio.test.compatibility", settingsFromCommandLine.Compatibility,

--- a/pkg/test/framework/resource/settings.go
+++ b/pkg/test/framework/resource/settings.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/uuid"
 
 	"istio.io/istio/pilot/pkg/util/sets"
+	"istio.io/istio/pkg/test/framework/components/echo/echotypes"
 	"istio.io/istio/pkg/test/framework/label"
 )
 
@@ -85,13 +86,13 @@ type Settings struct {
 	Revision string
 
 	// Skip VM related parts for all the tests.
-	SkipVM bool
+	skipVM bool
 
 	// Skip Delta XDS related parts for all the tests.
-	SkipDelta bool
+	skipDelta bool
 
 	// Skip TProxy related parts for all the tests.
-	SkipTProxy bool
+	skipTProxy bool
 
 	// Compatibility determines whether we should transparently deploy echo workloads attached to each revision
 	// specified in `Revisions` when creating echo instances. Used primarily for compatibility testing between revisions
@@ -105,6 +106,10 @@ type Settings struct {
 	// To configure it so that an Istio revision is on the latest version simply list the revision name without the version (i.e. "rev-a,rev-b")
 	// If using this flag with --istio.test.revision, this flag will take precedence.
 	Revisions RevVerMap
+}
+
+func (s Settings) Skip(class echotypes.Class) bool {
+	return s.SkipWorkloadClasses.Contains(class)
 }
 
 // RunDir is the name of the dir to output, for this particular run.
@@ -149,7 +154,7 @@ func (s *Settings) String() string {
 	result += fmt.Sprintf("Retries:           %v\n", s.Retries)
 	result += fmt.Sprintf("StableNamespaces:  %v\n", s.StableNamespaces)
 	result += fmt.Sprintf("Revision:          %v\n", s.Revision)
-	result += fmt.Sprintf("SkipVM:            %v\n", s.SkipVM)
+	result += fmt.Sprintf("SkipWorkloads      %v\n", s.SkipWorkloadClasses.SortedList())
 	result += fmt.Sprintf("Compatibility:     %v\n", s.Compatibility)
 	result += fmt.Sprintf("Revisions:         %v\n", s.Revisions.String())
 	return result

--- a/tests/integration/pilot/common/apps.go
+++ b/tests/integration/pilot/common/apps.go
@@ -27,6 +27,7 @@ import (
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/echo/common"
 	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
+	"istio.io/istio/pkg/test/framework/components/echo/echotypes"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/components/istio/ingress"
 	"istio.io/istio/pkg/test/framework/components/namespace"
@@ -226,7 +227,7 @@ func SetupApps(t resource.Context, i istio.Instance, apps *EchoDeployments) erro
 			WorkloadOnlyPorts: common.WorkloadPorts,
 		})
 
-	skipDelta := t.Settings().SkipDelta || !t.Settings().Revisions.AtLeast("1.11")
+	skipDelta := t.Settings().Skip(echotypes.Delta) || !t.Settings().Revisions.AtLeast("1.11")
 	if !skipDelta {
 		builder = builder.
 			WithConfig(echo.Config{
@@ -275,7 +276,7 @@ func SetupApps(t resource.Context, i istio.Instance, apps *EchoDeployments) erro
 	apps.Naked = echos.Match(echo.Service(NakedSvc))
 	apps.External = echos.Match(echo.Service(ExternalSvc))
 	apps.ProxylessGRPC = echos.Match(echo.Service(ProxylessGRPCSvc))
-	if !t.Settings().SkipVM {
+	if !t.Settings().Skip(echotypes.VM) {
 		apps.VM = echos.Match(echo.Service(VMSvc))
 	}
 	if !skipDelta {

--- a/tests/integration/pilot/common/traffic.go
+++ b/tests/integration/pilot/common/traffic.go
@@ -26,6 +26,7 @@ import (
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/echo/echotest"
+	"istio.io/istio/pkg/test/framework/components/echo/echotypes"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/components/istio/ingress"
 	"istio.io/istio/pkg/test/framework/label"
@@ -236,7 +237,7 @@ func RunAllTrafficTests(t framework.TestContext, i istio.Instance, apps *EchoDep
 	if !t.Settings().Selector.Excludes(label.NewSet(label.IPv4)) { // https://github.com/istio/istio/issues/35835
 		cases["jwt-claim-route"] = jwtClaimRoute(apps)
 	}
-	cases["virtualservice"] = virtualServiceCases(t.Settings().SkipVM)
+	cases["virtualservice"] = virtualServiceCases(t.Settings().Skip(echotypes.VM))
 	cases["sniffing"] = protocolSniffingCases(apps)
 	cases["selfcall"] = selfCallsCases()
 	cases["serverfirst"] = serverFirstTestCases(apps)
@@ -259,7 +260,7 @@ func RunAllTrafficTests(t framework.TestContext, i istio.Instance, apps *EchoDep
 	}
 	cases["use-client-protocol"] = useClientProtocolCases(apps)
 	cases["destinationrule"] = destinationRuleCases(apps)
-	if !t.Settings().SkipVM {
+	if !t.Settings().Skip(echotypes.VM) {
 		cases["vm"] = VMTestCases(apps.VM, apps)
 	}
 	cases["dns"] = DNSTestCases(apps, i.Settings().EnableCNI)

--- a/tests/integration/pilot/locality_test.go
+++ b/tests/integration/pilot/locality_test.go
@@ -31,6 +31,7 @@ import (
 	echoClient "istio.io/istio/pkg/test/echo"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
+	"istio.io/istio/pkg/test/framework/components/echo/echotypes"
 	"istio.io/istio/pkg/test/scopes"
 	"istio.io/istio/tests/integration/pilot/common"
 )
@@ -114,7 +115,7 @@ func TestLocality(t *testing.T) {
 			destA := apps.PodB[0]
 			destB := apps.PodC[0]
 			destC := apps.Naked[0]
-			if !t.Settings().SkipVM {
+			if !t.Settings().Skip(echotypes.VM) {
 				// TODO do we even need this to be a VM
 				destC = apps.VM[0]
 			}

--- a/tests/integration/pilot/original_src_addr_test.go
+++ b/tests/integration/pilot/original_src_addr_test.go
@@ -25,6 +25,7 @@ import (
 	"istio.io/istio/pkg/test/echo/common/scheme"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
+	"istio.io/istio/pkg/test/framework/components/echo/echotypes"
 )
 
 func TestTproxy(t *testing.T) {
@@ -33,7 +34,7 @@ func TestTproxy(t *testing.T) {
 		Features("traffic.original-source-ip").
 		RequiresSingleCluster().
 		Run(func(t framework.TestContext) {
-			if t.Settings().SkipTProxy {
+			if t.Settings().Skip(echotypes.TProxy) {
 				t.Skip()
 			}
 			workloads, err := apps.PodA[0].Workloads()

--- a/tests/integration/pilot/vm_test.go
+++ b/tests/integration/pilot/vm_test.go
@@ -35,6 +35,7 @@ import (
 	"istio.io/istio/pkg/test/framework/components/echo"
 	echocommon "istio.io/istio/pkg/test/framework/components/echo/common"
 	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
+	"istio.io/istio/pkg/test/framework/components/echo/echotypes"
 	"istio.io/istio/pkg/test/framework/components/echo/kube"
 	"istio.io/istio/pkg/test/framework/label"
 	"istio.io/istio/pkg/test/scopes"
@@ -59,7 +60,7 @@ func TestVmOSPost(t *testing.T) {
 		Features("traffic.reachability").
 		Label(label.Postsubmit).
 		Run(func(t framework.TestContext) {
-			if t.Settings().SkipVM {
+			if t.Settings().Skip(echotypes.VM) {
 				t.Skip("VM tests are disabled")
 			}
 			b := echoboot.NewBuilder(t, t.Clusters().Primaries().Default())
@@ -94,7 +95,7 @@ func TestVMRegistrationLifecycle(t *testing.T) {
 		RequiresSingleCluster().
 		Features("vm.autoregistration").
 		Run(func(t framework.TestContext) {
-			if t.Settings().SkipVM {
+			if t.Settings().Skip(echotypes.VM) {
 				t.Skip()
 			}
 			scaleDeploymentOrFail(t, "istiod", i.Settings().SystemNamespace, 2)

--- a/tests/integration/security/sds_ingress/util/util.go
+++ b/tests/integration/security/sds_ingress/util/util.go
@@ -41,6 +41,7 @@ import (
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
 	"istio.io/istio/pkg/test/framework/components/echo/echotest"
+	"istio.io/istio/pkg/test/framework/components/echo/echotypes"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/components/istio/ingress"
 	"istio.io/istio/pkg/test/framework/components/namespace"
@@ -398,7 +399,7 @@ func SetupTest(ctx resource.Context, apps *EchoDeployments) error {
 	if err != nil {
 		return err
 	}
-	buildVM := !ctx.Settings().SkipVM
+	buildVM := !ctx.Settings().Skip(echotypes.VM)
 	echos, err := echoboot.NewBuilder(ctx).
 		WithClusters(ctx.Clusters()...).
 		WithConfig(EchoConfig(ASvc, apps.ServerNs, false)).

--- a/tests/integration/security/sds_ingress_k8sca/main_test.go
+++ b/tests/integration/security/sds_ingress_k8sca/main_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/echo/echotypes"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/resource"
 	"istio.io/istio/tests/integration/security/sds_ingress/util"
@@ -44,7 +45,7 @@ func TestMain(m *testing.M) {
 		Setup(istio.Setup(&inst, setupConfig)).
 		Setup(func(ctx resource.Context) (err error) {
 			// Skip VM as eastwest gateway is disabled.
-			ctx.Settings().SkipVM = true
+			ctx.Settings().SkipWorkloadClasses.Insert(echotypes.VM)
 			return util.SetupTest(ctx, apps)
 		}).
 		Run()

--- a/tests/integration/security/util/framework.go
+++ b/tests/integration/security/util/framework.go
@@ -29,6 +29,7 @@ import (
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
 	"istio.io/istio/pkg/test/framework/components/echo/echotest"
+	"istio.io/istio/pkg/test/framework/components/echo/echotypes"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/framework/resource"
@@ -176,7 +177,7 @@ func MustReadCert(f string) string {
 }
 
 func SetupApps(ctx resource.Context, i istio.Instance, apps *EchoDeployments, buildVM bool) error {
-	if ctx.Settings().SkipVM {
+	if ctx.Settings().Skip(echotypes.VM) {
 		buildVM = false
 	}
 	var err error


### PR DESCRIPTION
These did not work with --skipWorkloads. Make it so we have one way to
do things that works for all cases.pick
: