### PR TITLE
Build multiarch images for bookinfo

### DIFF
--- a/releasenotes/notes/40405.yaml
+++ b/releasenotes/notes/40405.yaml
@@ -1,6 +1,6 @@
 apiVersion: release-notes/v2
 kind: feature
-area: samples 
+area: documentation
 issue:
   - 40405
 

--- a/releasenotes/notes/40405.yaml
+++ b/releasenotes/notes/40405.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: feature
+area: samples 
+issue:
+  - 40405
+
+releaseNotes:
+- |
+  **Added** `build_push_update_images.sh` now supports the `--multiarch-images` argument to build multi-arch container images used in the bookinfo application.

--- a/samples/bookinfo/build_push_update_images.sh
+++ b/samples/bookinfo/build_push_update_images.sh
@@ -100,7 +100,7 @@ function run_vulnerability_scanning() {
 for IMAGE in ${IMAGES};
 do
   # Multiarch images have already been pushed using buildx build	
-  if [[ "ENABLE_MULTIARCH_IMAGES" == "false" ]]; then	
+  if [[ "${ENABLE_MULTIARCH_IMAGES}" == "false" ]]; then	
   	echo "Pushing: ${IMAGE}"
   	docker push "${IMAGE}";
   fi

--- a/samples/bookinfo/src/build-services.sh
+++ b/samples/bookinfo/src/build-services.sh
@@ -59,15 +59,26 @@ popd
 pushd "$SCRIPTDIR/reviews"
   #java build the app.
   docker run --rm -u root -v "$(pwd)":/home/gradle/project -w /home/gradle/project gradle:4.8.1 gradle clean build
+  
+  # Temporarily clone https://github.com/OpenLiberty/ci.docker
+  # to allow this project to build multiarch(linux/arm64) images not provided by the OpenLiberty CI
+  # Remove this workaround once https://github.com/OpenLiberty/ci.docker/issues/241 is fixed
+  git clone https://github.com/OpenLiberty/ci.docker.git openliberty-base
+  pushd openliberty-base
+    ${DOCKER_BUILD_ARGS} --pull -t "${PREFIX}/websphere-liberty:22.0.0.8-full-java8-ibmjava" -f releases/22.0.0.8/full/Dockerfile.ubuntu.openjdk8 releases/22.0.0.8/full 
+  popd
+  rm -rf openliberty-base 
+  
   pushd reviews-wlpcfg
     #plain build -- no ratings
-    ${DOCKER_BUILD_ARGS} --pull -t "${PREFIX}/examples-bookinfo-reviews-v1:${VERSION}" -t "${PREFIX}/examples-bookinfo-reviews-v1:latest" --build-arg service_version=v1 .
+    ${DOCKER_BUILD_ARGS} --pull -t "${PREFIX}/examples-bookinfo-reviews-v1:${VERSION}" -t "${PREFIX}/examples-bookinfo-reviews-v1:latest" --build-arg service_version=v1 \
+	    --build-arg REPO=${PREFIX} .
     #with ratings black stars
     ${DOCKER_BUILD_ARGS} --pull -t "${PREFIX}/examples-bookinfo-reviews-v2:${VERSION}" -t "${PREFIX}/examples-bookinfo-reviews-v2:latest" --build-arg service_version=v2 \
-	   --build-arg enable_ratings=true .
+	   --build-arg enable_ratings=true --build-arg REPO=${PREFIX} .
     #with ratings red stars
     ${DOCKER_BUILD_ARGS} --pull -t "${PREFIX}/examples-bookinfo-reviews-v3:${VERSION}" -t "${PREFIX}/examples-bookinfo-reviews-v3:latest" --build-arg service_version=v3 \
-	   --build-arg enable_ratings=true --build-arg star_color=red .
+	   --build-arg enable_ratings=true --build-arg star_color=red --build-arg REPO=${PREFIX} .
   popd
 popd
 

--- a/samples/bookinfo/src/build-services.sh
+++ b/samples/bookinfo/src/build-services.sh
@@ -60,25 +60,15 @@ pushd "$SCRIPTDIR/reviews"
   #java build the app.
   docker run --rm -u root -v "$(pwd)":/home/gradle/project -w /home/gradle/project gradle:4.8.1 gradle clean build
   
-  # Temporarily clone https://github.com/OpenLiberty/ci.docker
-  # to allow this project to build multiarch(linux/arm64) images not provided by the OpenLiberty CI
-  # Remove this workaround once https://github.com/OpenLiberty/ci.docker/issues/241 is fixed
-  git clone https://github.com/OpenLiberty/ci.docker.git openliberty-base
-  pushd openliberty-base
-    ${DOCKER_BUILD_ARGS} --pull -t "${PREFIX}/websphere-liberty:22.0.0.8-full-java8-ibmjava" -f releases/22.0.0.8/full/Dockerfile.ubuntu.openjdk8 releases/22.0.0.8/full 
-  popd
-  rm -rf openliberty-base 
-  
   pushd reviews-wlpcfg
     #plain build -- no ratings
-    ${DOCKER_BUILD_ARGS} --pull -t "${PREFIX}/examples-bookinfo-reviews-v1:${VERSION}" -t "${PREFIX}/examples-bookinfo-reviews-v1:latest" --build-arg service_version=v1 \
-	    --build-arg REGISTRY="${PREFIX}" .
+    ${DOCKER_BUILD_ARGS} --pull -t "${PREFIX}/examples-bookinfo-reviews-v1:${VERSION}" -t "${PREFIX}/examples-bookinfo-reviews-v1:latest" --build-arg service_version=v1 . 
     #with ratings black stars
     ${DOCKER_BUILD_ARGS} --pull -t "${PREFIX}/examples-bookinfo-reviews-v2:${VERSION}" -t "${PREFIX}/examples-bookinfo-reviews-v2:latest" --build-arg service_version=v2 \
-	   --build-arg enable_ratings=true --build-arg REGISTRY="${PREFIX}" .
+	   --build-arg enable_ratings=true .
     #with ratings red stars
     ${DOCKER_BUILD_ARGS} --pull -t "${PREFIX}/examples-bookinfo-reviews-v3:${VERSION}" -t "${PREFIX}/examples-bookinfo-reviews-v3:latest" --build-arg service_version=v3 \
-	   --build-arg enable_ratings=true --build-arg star_color=red --build-arg REGISTRY="${PREFIX}" .
+	   --build-arg enable_ratings=true --build-arg star_color=red .
   popd
 popd
 

--- a/samples/bookinfo/src/build-services.sh
+++ b/samples/bookinfo/src/build-services.sh
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-set -o errexit
+set -ox errexit
 
 if [ "$#" -ne 2 ]; then
     echo "Incorrect parameters"
@@ -26,48 +26,64 @@ VERSION=$1
 PREFIX=$2
 SCRIPTDIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
+# Docker build variables
+ENABLE_MULTIARCH_IMAGES=${ENABLE_MULTIARCH_IMAGES:-"false"}
+
+if [ "${ENABLE_MULTIARCH_IMAGES}" == "true" ]; then
+  PLATFORMS="linux/arm64,linux/amd64"	
+  DOCKER_BUILD_ARGS="docker buildx build --platform ${PLATFORMS} --push"
+  # Install QEMU emulators
+  docker run --rm --privileged tonistiigi/binfmt --install all
+  docker buildx rm multi-builder || :
+  docker buildx create --use --name multi-builder --platform ${PLATFORMS}
+  docker buildx use multi-builder
+else
+  DOCKER_BUILD_ARGS="docker build"	
+fi
+
 pushd "$SCRIPTDIR/productpage"
-  docker build --pull -t "${PREFIX}/examples-bookinfo-productpage-v1:${VERSION}" -t "${PREFIX}/examples-bookinfo-productpage-v1:latest" .
+  ${DOCKER_BUILD_ARGS} --pull -t "${PREFIX}/examples-bookinfo-productpage-v1:${VERSION}" -t "${PREFIX}/examples-bookinfo-productpage-v1:latest" .
   #flooding
-  docker build --pull -t "${PREFIX}/examples-bookinfo-productpage-v-flooding:${VERSION}" -t "${PREFIX}/examples-bookinfo-productpage-v-flooding:latest" --build-arg flood_factor=100 .
+  ${DOCKER_BUILD_ARGS} --pull -t "${PREFIX}/examples-bookinfo-productpage-v-flooding:${VERSION}" -t "${PREFIX}/examples-bookinfo-productpage-v-flooding:latest" --build-arg flood_factor=100 .
 popd
 
 pushd "$SCRIPTDIR/details"
   #plain build -- no calling external book service to fetch topics
-  docker build --pull -t "${PREFIX}/examples-bookinfo-details-v1:${VERSION}" -t "${PREFIX}/examples-bookinfo-details-v1:latest" --build-arg service_version=v1 .
+  ${DOCKER_BUILD_ARGS} --pull -t "${PREFIX}/examples-bookinfo-details-v1:${VERSION}" -t "${PREFIX}/examples-bookinfo-details-v1:latest" --build-arg service_version=v1 .
   #with calling external book service to fetch topic for the book
-  docker build --pull -t "${PREFIX}/examples-bookinfo-details-v2:${VERSION}" -t "${PREFIX}/examples-bookinfo-details-v2:latest" --build-arg service_version=v2 \
+  ${DOCKER_BUILD_ARGS} --pull -t "${PREFIX}/examples-bookinfo-details-v2:${VERSION}" -t "${PREFIX}/examples-bookinfo-details-v2:latest" --build-arg service_version=v2 \
 	 --build-arg enable_external_book_service=true .
 popd
+
 
 pushd "$SCRIPTDIR/reviews"
   #java build the app.
   docker run --rm -u root -v "$(pwd)":/home/gradle/project -w /home/gradle/project gradle:4.8.1 gradle clean build
   pushd reviews-wlpcfg
     #plain build -- no ratings
-    docker build --pull -t "${PREFIX}/examples-bookinfo-reviews-v1:${VERSION}" -t "${PREFIX}/examples-bookinfo-reviews-v1:latest" --build-arg service_version=v1 .
+    ${DOCKER_BUILD_ARGS} --pull -t "${PREFIX}/examples-bookinfo-reviews-v1:${VERSION}" -t "${PREFIX}/examples-bookinfo-reviews-v1:latest" --build-arg service_version=v1 .
     #with ratings black stars
-    docker build --pull -t "${PREFIX}/examples-bookinfo-reviews-v2:${VERSION}" -t "${PREFIX}/examples-bookinfo-reviews-v2:latest" --build-arg service_version=v2 \
+    ${DOCKER_BUILD_ARGS} --pull -t "${PREFIX}/examples-bookinfo-reviews-v2:${VERSION}" -t "${PREFIX}/examples-bookinfo-reviews-v2:latest" --build-arg service_version=v2 \
 	   --build-arg enable_ratings=true .
     #with ratings red stars
-    docker build --pull -t "${PREFIX}/examples-bookinfo-reviews-v3:${VERSION}" -t "${PREFIX}/examples-bookinfo-reviews-v3:latest" --build-arg service_version=v3 \
+    ${DOCKER_BUILD_ARGS} --pull -t "${PREFIX}/examples-bookinfo-reviews-v3:${VERSION}" -t "${PREFIX}/examples-bookinfo-reviews-v3:latest" --build-arg service_version=v3 \
 	   --build-arg enable_ratings=true --build-arg star_color=red .
   popd
 popd
 
 pushd "$SCRIPTDIR/ratings"
-  docker build --pull -t "${PREFIX}/examples-bookinfo-ratings-v1:${VERSION}" -t "${PREFIX}/examples-bookinfo-ratings-v1:latest" --build-arg service_version=v1 .
-  docker build --pull -t "${PREFIX}/examples-bookinfo-ratings-v2:${VERSION}" -t "${PREFIX}/examples-bookinfo-ratings-v2:latest" --build-arg service_version=v2 .
-  docker build --pull -t "${PREFIX}/examples-bookinfo-ratings-v-faulty:${VERSION}" -t "${PREFIX}/examples-bookinfo-ratings-v-faulty:latest" --build-arg service_version=v-faulty .
-  docker build --pull -t "${PREFIX}/examples-bookinfo-ratings-v-delayed:${VERSION}" -t "${PREFIX}/examples-bookinfo-ratings-v-delayed:latest" --build-arg service_version=v-delayed .
-  docker build --pull -t "${PREFIX}/examples-bookinfo-ratings-v-unavailable:${VERSION}" -t "${PREFIX}/examples-bookinfo-ratings-v-unavailable:latest" --build-arg service_version=v-unavailable .
-  docker build --pull -t "${PREFIX}/examples-bookinfo-ratings-v-unhealthy:${VERSION}" -t "${PREFIX}/examples-bookinfo-ratings-v-unhealthy:latest" --build-arg service_version=v-unhealthy .
+  ${DOCKER_BUILD_ARGS} --pull -t "${PREFIX}/examples-bookinfo-ratings-v1:${VERSION}" -t "${PREFIX}/examples-bookinfo-ratings-v1:latest" --build-arg service_version=v1 .
+  ${DOCKER_BUILD_ARGS} --pull -t "${PREFIX}/examples-bookinfo-ratings-v2:${VERSION}" -t "${PREFIX}/examples-bookinfo-ratings-v2:latest" --build-arg service_version=v2 .
+  ${DOCKER_BUILD_ARGS} --pull -t "${PREFIX}/examples-bookinfo-ratings-v-faulty:${VERSION}" -t "${PREFIX}/examples-bookinfo-ratings-v-faulty:latest" --build-arg service_version=v-faulty .
+  ${DOCKER_BUILD_ARGS} --pull -t "${PREFIX}/examples-bookinfo-ratings-v-delayed:${VERSION}" -t "${PREFIX}/examples-bookinfo-ratings-v-delayed:latest" --build-arg service_version=v-delayed .
+  ${DOCKER_BUILD_ARGS} --pull -t "${PREFIX}/examples-bookinfo-ratings-v-unavailable:${VERSION}" -t "${PREFIX}/examples-bookinfo-ratings-v-unavailable:latest" --build-arg service_version=v-unavailable .
+  ${DOCKER_BUILD_ARGS} --pull -t "${PREFIX}/examples-bookinfo-ratings-v-unhealthy:${VERSION}" -t "${PREFIX}/examples-bookinfo-ratings-v-unhealthy:latest" --build-arg service_version=v-unhealthy .
 popd
 
 pushd "$SCRIPTDIR/mysql"
-  docker build --pull -t "${PREFIX}/examples-bookinfo-mysqldb:${VERSION}" -t "${PREFIX}/examples-bookinfo-mysqldb:latest" .
+  ${DOCKER_BUILD_ARGS} --pull -t "${PREFIX}/examples-bookinfo-mysqldb:${VERSION}" -t "${PREFIX}/examples-bookinfo-mysqldb:latest" .
 popd
 
 pushd "$SCRIPTDIR/mongodb"
-  docker build --pull -t "${PREFIX}/examples-bookinfo-mongodb:${VERSION}" -t "${PREFIX}/examples-bookinfo-mongodb:latest" .
+  ${DOCKER_BUILD_ARGS} --pull -t "${PREFIX}/examples-bookinfo-mongodb:${VERSION}" -t "${PREFIX}/examples-bookinfo-mongodb:latest" .
 popd

--- a/samples/bookinfo/src/build-services.sh
+++ b/samples/bookinfo/src/build-services.sh
@@ -72,13 +72,13 @@ pushd "$SCRIPTDIR/reviews"
   pushd reviews-wlpcfg
     #plain build -- no ratings
     ${DOCKER_BUILD_ARGS} --pull -t "${PREFIX}/examples-bookinfo-reviews-v1:${VERSION}" -t "${PREFIX}/examples-bookinfo-reviews-v1:latest" --build-arg service_version=v1 \
-	    --build-arg REPO=${PREFIX} .
+	    --build-arg REGISTRY="${PREFIX}" .
     #with ratings black stars
     ${DOCKER_BUILD_ARGS} --pull -t "${PREFIX}/examples-bookinfo-reviews-v2:${VERSION}" -t "${PREFIX}/examples-bookinfo-reviews-v2:latest" --build-arg service_version=v2 \
-	   --build-arg enable_ratings=true --build-arg REPO=${PREFIX} .
+	   --build-arg enable_ratings=true --build-arg REGISTRY="${PREFIX}" .
     #with ratings red stars
     ${DOCKER_BUILD_ARGS} --pull -t "${PREFIX}/examples-bookinfo-reviews-v3:${VERSION}" -t "${PREFIX}/examples-bookinfo-reviews-v3:latest" --build-arg service_version=v3 \
-	   --build-arg enable_ratings=true --build-arg star_color=red --build-arg REPO=${PREFIX} .
+	   --build-arg enable_ratings=true --build-arg star_color=red --build-arg REGISTRY="${PREFIX}" .
   popd
 popd
 

--- a/samples/bookinfo/src/mongodb/Dockerfile
+++ b/samples/bookinfo/src/mongodb/Dockerfile
@@ -12,7 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-FROM mongo:4.0.19-xenial
+FROM mongo:5.0.10
 WORKDIR /app/data/
 COPY ratings_data.json /app/data/
 COPY script.sh /docker-entrypoint-initdb.d/

--- a/samples/bookinfo/src/mysql/Dockerfile
+++ b/samples/bookinfo/src/mysql/Dockerfile
@@ -12,7 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-FROM mysql:8.0.20
+FROM mysql:8.0.30
 # MYSQL_ROOT_PASSWORD must be supplied as an env var
 
 COPY ./mysqldb-init.sql /docker-entrypoint-initdb.d

--- a/samples/bookinfo/src/productpage/Dockerfile
+++ b/samples/bookinfo/src/productpage/Dockerfile
@@ -15,11 +15,14 @@
 FROM python:3.7.7-slim
 
 WORKDIR /
+RUN apt-get update \
+&& apt-get install gcc -y \
+&& apt-get clean
 COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip3 install -vvv --no-cache-dir -r requirements.txt
 
 COPY test-requirements.txt ./
-RUN pip install --no-cache-dir -r test-requirements.txt
+RUN pip3 install --no-cache-dir -r test-requirements.txt
 
 COPY productpage.py /opt/microservices/
 COPY tests/unit/* /opt/microservices/

--- a/samples/bookinfo/src/productpage/Dockerfile
+++ b/samples/bookinfo/src/productpage/Dockerfile
@@ -15,9 +15,7 @@
 FROM python:3.7.7-slim
 
 WORKDIR /
-RUN apt-get update \
-&& apt-get install make gcc -y \
-&& apt-get clean
+
 COPY requirements.txt ./
 RUN pip3 install -vvv --no-cache-dir -r requirements.txt
 

--- a/samples/bookinfo/src/productpage/Dockerfile
+++ b/samples/bookinfo/src/productpage/Dockerfile
@@ -16,7 +16,7 @@ FROM python:3.7.7-slim
 
 WORKDIR /
 RUN apt-get update \
-&& apt-get install gcc -y \
+&& apt-get install make gcc -y \
 && apt-get clean
 COPY requirements.txt ./
 RUN pip3 install -vvv --no-cache-dir -r requirements.txt

--- a/samples/bookinfo/src/productpage/requirements.txt
+++ b/samples/bookinfo/src/productpage/requirements.txt
@@ -19,7 +19,7 @@ MarkupSafe==0.23
 nose==1.3.7
 opentracing==1.2.2
 opentracing-instrumentation==2.4.3
-requests==2.21.0
+requests==2.28.1
 simplejson==3.16.0
 six==1.12.0
 threadloop==1.0.2

--- a/samples/bookinfo/src/productpage/requirements.txt
+++ b/samples/bookinfo/src/productpage/requirements.txt
@@ -8,8 +8,8 @@ Flask-Bootstrap==3.3.7.1
 Flask-JSON==0.3.3
 future==0.17.1
 futures==3.1.1
-gevent==1.5.0
-greenlet==0.4.17
+gevent==21.12.0
+greenlet==1.1.2
 idna==2.8
 itsdangerous==1.1.0
 jaeger-client==3.13.0

--- a/samples/bookinfo/src/reviews/reviews-wlpcfg/Dockerfile
+++ b/samples/bookinfo/src/reviews/reviews-wlpcfg/Dockerfile
@@ -12,14 +12,15 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-FROM websphere-liberty:20.0.0.6-full-java8-ibmjava
+ARG REPO=istio
+FROM $REPO/websphere-liberty:22.0.0.8-full-java8-ibmjava
 
 ENV SERVERDIRNAME reviews
 
-COPY ./servers/LibertyProjectServer /opt/ibm/wlp/usr/servers/defaultServer/
+COPY ./servers/LibertyProjectServer /opt/ol/wlp/usr/servers/defaultServer/
 
-RUN /opt/ibm/wlp/bin/installUtility install  --acceptLicense /opt/ibm/wlp/usr/servers/defaultServer/server.xml && \
-    chmod -R g=rwx /opt/ibm/wlp/output/defaultServer/
+RUN /opt/ol/wlp/bin/featureUtility installServerFeatures  --acceptLicense /opt/ol/wlp/usr/servers/defaultServer/server.xml && \
+    chmod -R g=rwx /opt/ol/wlp/output/defaultServer/
 
 ARG service_version
 ARG enable_ratings
@@ -28,4 +29,4 @@ ENV SERVICE_VERSION ${service_version:-v1}
 ENV ENABLE_RATINGS ${enable_ratings:-false}
 ENV STAR_COLOR ${star_color:-black}
 
-CMD ["/opt/ibm/wlp/bin/server", "run", "defaultServer"]
+CMD ["/opt/ol/wlp/bin/server", "run", "defaultServer"]

--- a/samples/bookinfo/src/reviews/reviews-wlpcfg/Dockerfile
+++ b/samples/bookinfo/src/reviews/reviews-wlpcfg/Dockerfile
@@ -12,8 +12,8 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-ARG REPO=istio
-FROM $REPO/websphere-liberty:22.0.0.8-full-java8-ibmjava
+ARG REGISTRY=istio
+FROM $REGISTRY/websphere-liberty:22.0.0.8-full-java8-ibmjava
 
 ENV SERVERDIRNAME reviews
 

--- a/samples/bookinfo/src/reviews/reviews-wlpcfg/Dockerfile
+++ b/samples/bookinfo/src/reviews/reviews-wlpcfg/Dockerfile
@@ -12,8 +12,9 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-ARG REGISTRY=istio
-FROM $REGISTRY/websphere-liberty:22.0.0.8-full-java8-ibmjava
+# Use library image once https://github.com/OpenLiberty/ci.docker/issues/241
+# is fixed
+FROM gcr.io/istio-testing/websphere-liberty:22.0.0.8-full-java8-ibmjava
 
 ENV SERVERDIRNAME reviews
 


### PR DESCRIPTION
* Allows the user to pass a `--multiarch-images` flag
to `build_push_update_images.sh` which builds and pushes
a multiarch(`linux/amd64`, `linux/arm64`) image using
`docker buildx build`

Signed-off-by: Arko Dasgupta <arko@tetrate.io>

**Please provide a description of this PR:**
Raising this PR in anticipation of https://github.com/istio/istio/issues/35176 ( which is taking the route of faster native builds for multi arch rather than this approach of emulated builds using `docker buildx`. 
This could also be made faster with [cross compiled builds](https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide/)

Fixes: https://github.com/istio/istio/issues/40405