### PR TITLE
speed up ads push scoping test

### DIFF
--- a/pilot/pkg/xds/ads_test.go
+++ b/pilot/pkg/xds/ads_test.go
@@ -648,7 +648,7 @@ func TestAdsPushScoping(t *testing.T) {
 	for _, c := range svcCases {
 		t.Run(c.desc, func(t *testing.T) {
 			// Let events from previous tests complete
-			time.Sleep(time.Millisecond * 100)
+			time.Sleep(time.Millisecond * 10)
 			adscConn.WaitClear()
 			var wantUpdates []string
 			wantUpdates = append(wantUpdates, c.expectUpdates...)
@@ -728,8 +728,8 @@ func TestAdsPushScoping(t *testing.T) {
 				t.Fatalf("wrong event for case %v", c)
 			}
 
-			timeout := time.Second
-			upd, _ := adscConn.Wait(timeout, wantUpdates...) // XXX slow for unexpect ...
+			timeout := time.Millisecond * 100
+			upd, _ := adscConn.Wait(timeout, wantUpdates...)
 			for _, expect := range c.expectUpdates {
 				if !contains(upd, expect) {
 					t.Fatalf("expected update %s not in updates %v", expect, upd)

--- a/pilot/pkg/xds/ads_test.go
+++ b/pilot/pkg/xds/ads_test.go
@@ -427,16 +427,16 @@ func TestAdsPushScoping(t *testing.T) {
 		}
 		cfgs []config.Config
 
-		expectUpdates   []string
-		unexpectUpdates []string
+		expectedUpdates   []string
+		unexpectedUpdates []string
 	}
 	svcCases := []svcCase{
 		{
-			desc:          "Add a scoped service",
-			ev:            model.EventAdd,
-			svcIndexes:    []int{4},
-			ns:            model.IstioDefaultConfigNamespace,
-			expectUpdates: []string{v3.ListenerType},
+			desc:            "Add a scoped service",
+			ev:              model.EventAdd,
+			svcIndexes:      []int{4},
+			ns:              model.IstioDefaultConfigNamespace,
+			expectedUpdates: []string{v3.ListenerType},
 		}, // then: default 1,2,3,4
 		{
 			desc: "Add instances to a scoped service",
@@ -445,8 +445,8 @@ func TestAdsPushScoping(t *testing.T) {
 				name    string
 				indexes []int
 			}{{fmt.Sprintf("svc%d%s", 4, svcSuffix), []int{1, 2}}},
-			ns:            model.IstioDefaultConfigNamespace,
-			expectUpdates: []string{v3.EndpointType},
+			ns:              model.IstioDefaultConfigNamespace,
+			expectedUpdates: []string{v3.EndpointType},
 		}, // then: default 1,2,3,4
 		{
 			desc: "Add virtual service to a scoped service",
@@ -456,7 +456,7 @@ func TestAdsPushScoping(t *testing.T) {
 				hosts []string
 				dest  string
 			}{{index: 4, hosts: []string{fmt.Sprintf("svc%d%s", 4, svcSuffix)}, dest: "unknown-svc"}},
-			expectUpdates: []string{v3.ListenerType},
+			expectedUpdates: []string{v3.ListenerType},
 		},
 		{
 			desc: "Delete virtual service of a scoped service",
@@ -466,7 +466,7 @@ func TestAdsPushScoping(t *testing.T) {
 				hosts []string
 				dest  string
 			}{{index: 4}},
-			expectUpdates: []string{v3.ListenerType},
+			expectedUpdates: []string{v3.ListenerType},
 		},
 		{
 			desc: "Add destination rule to a scoped service",
@@ -475,7 +475,7 @@ func TestAdsPushScoping(t *testing.T) {
 				index int
 				host  string
 			}{{4, fmt.Sprintf("svc%d%s", 4, svcSuffix)}},
-			expectUpdates: []string{v3.ClusterType},
+			expectedUpdates: []string{v3.ClusterType},
 		},
 		{
 			desc: "Delete destination rule of a scoped service",
@@ -484,14 +484,14 @@ func TestAdsPushScoping(t *testing.T) {
 				index int
 				host  string
 			}{{index: 4}},
-			expectUpdates: []string{v3.ClusterType},
+			expectedUpdates: []string{v3.ClusterType},
 		},
 		{
-			desc:            "Add a unscoped(name not match) service",
-			ev:              model.EventAdd,
-			svcNames:        []string{"foo.com"},
-			ns:              model.IstioDefaultConfigNamespace,
-			unexpectUpdates: []string{v3.ClusterType},
+			desc:              "Add a unscoped(name not match) service",
+			ev:                model.EventAdd,
+			svcNames:          []string{"foo.com"},
+			ns:                model.IstioDefaultConfigNamespace,
+			unexpectedUpdates: []string{v3.ClusterType},
 		}, // then: default 1,2,3,4, foo.com; ns1: 11
 		{
 			desc: "Add instances to an unscoped service",
@@ -500,15 +500,15 @@ func TestAdsPushScoping(t *testing.T) {
 				name    string
 				indexes []int
 			}{{"foo.com", []int{1, 2}}},
-			ns:              model.IstioDefaultConfigNamespace,
-			unexpectUpdates: []string{v3.EndpointType},
+			ns:                model.IstioDefaultConfigNamespace,
+			unexpectedUpdates: []string{v3.EndpointType},
 		}, // then: default 1,2,3,4
 		{
-			desc:            "Add a unscoped(ns not match) service",
-			ev:              model.EventAdd,
-			svcIndexes:      []int{11},
-			ns:              ns1,
-			unexpectUpdates: []string{v3.ClusterType},
+			desc:              "Add a unscoped(ns not match) service",
+			ev:                model.EventAdd,
+			svcIndexes:        []int{11},
+			ns:                ns1,
+			unexpectedUpdates: []string{v3.ClusterType},
 		}, // then: default 1,2,3,4, foo.com; ns1: 11
 		{
 			desc: "Add virtual service to an unscoped service",
@@ -518,7 +518,7 @@ func TestAdsPushScoping(t *testing.T) {
 				hosts []string
 				dest  string
 			}{{index: 0, hosts: []string{"foo.com"}, dest: "unknown-service"}},
-			unexpectUpdates: []string{v3.ClusterType},
+			unexpectedUpdates: []string{v3.ClusterType},
 		},
 		{
 			desc: "Delete virtual service of a unscoped service",
@@ -528,7 +528,7 @@ func TestAdsPushScoping(t *testing.T) {
 				hosts []string
 				dest  string
 			}{{index: 0}},
-			unexpectUpdates: []string{v3.ClusterType},
+			unexpectedUpdates: []string{v3.ClusterType},
 		},
 		{
 			desc: "Add destination rule to an unscoped service",
@@ -537,7 +537,7 @@ func TestAdsPushScoping(t *testing.T) {
 				index int
 				host  string
 			}{{0, "foo.com"}},
-			unexpectUpdates: []string{v3.ClusterType},
+			unexpectedUpdates: []string{v3.ClusterType},
 		},
 		{
 			desc: "Delete destination rule of a unscoped service",
@@ -546,7 +546,7 @@ func TestAdsPushScoping(t *testing.T) {
 				index int
 				host  string
 			}{{index: 0}},
-			unexpectUpdates: []string{v3.ClusterType},
+			unexpectedUpdates: []string{v3.ClusterType},
 		},
 		{
 			desc: "Add virtual service for scoped service with transitively scoped dest svc",
@@ -556,7 +556,7 @@ func TestAdsPushScoping(t *testing.T) {
 				hosts []string
 				dest  string
 			}{{index: 4, hosts: []string{fmt.Sprintf("svc%d%s", 4, svcSuffix)}, dest: "foo.com"}},
-			expectUpdates: []string{v3.ClusterType, v3.EndpointType},
+			expectedUpdates: []string{v3.ClusterType, v3.EndpointType},
 		},
 		{
 			desc: "Add instances for transitively scoped svc",
@@ -565,8 +565,8 @@ func TestAdsPushScoping(t *testing.T) {
 				name    string
 				indexes []int
 			}{{"foo.com", []int{1, 2}}},
-			ns:            model.IstioDefaultConfigNamespace,
-			expectUpdates: []string{v3.EndpointType},
+			ns:              model.IstioDefaultConfigNamespace,
+			expectedUpdates: []string{v3.EndpointType},
 		},
 		{
 			desc: "Delete virtual service for scoped service with transitively scoped dest svc",
@@ -576,7 +576,7 @@ func TestAdsPushScoping(t *testing.T) {
 				hosts []string
 				dest  string
 			}{{index: 4}},
-			expectUpdates: []string{v3.ClusterType},
+			expectedUpdates: []string{v3.ClusterType},
 		},
 		{
 			desc: "Add delegation virtual service for scoped service with transitively scoped dest svc",
@@ -586,7 +586,7 @@ func TestAdsPushScoping(t *testing.T) {
 				hosts []string
 				dest  string
 			}{{index: 4, hosts: []string{fmt.Sprintf("svc%d%s", 4, svcSuffix)}, dest: "foo.com"}},
-			expectUpdates: []string{v3.ListenerType, v3.RouteType, v3.ClusterType, v3.EndpointType},
+			expectedUpdates: []string{v3.ListenerType, v3.RouteType, v3.ClusterType, v3.EndpointType},
 		},
 		{
 			desc: "Update delegate virtual service should trigger full push",
@@ -596,7 +596,7 @@ func TestAdsPushScoping(t *testing.T) {
 				hosts []string
 				dest  string
 			}{{index: 4, hosts: []string{fmt.Sprintf("svc%d%s", 4, svcSuffix)}, dest: "foo.com"}},
-			expectUpdates: []string{v3.ListenerType, v3.RouteType, v3.ClusterType},
+			expectedUpdates: []string{v3.ListenerType, v3.RouteType, v3.ClusterType},
 		},
 		{
 			desc: "Delete delegate virtual service for scoped service with transitively scoped dest svc",
@@ -606,42 +606,42 @@ func TestAdsPushScoping(t *testing.T) {
 				hosts []string
 				dest  string
 			}{{index: 4}},
-			expectUpdates: []string{v3.ListenerType, v3.RouteType, v3.ClusterType},
+			expectedUpdates: []string{v3.ListenerType, v3.RouteType, v3.ClusterType},
 		},
 		{
-			desc:          "Remove a scoped service",
-			ev:            model.EventDelete,
-			svcIndexes:    []int{4},
-			ns:            model.IstioDefaultConfigNamespace,
-			expectUpdates: []string{v3.ListenerType},
+			desc:            "Remove a scoped service",
+			ev:              model.EventDelete,
+			svcIndexes:      []int{4},
+			ns:              model.IstioDefaultConfigNamespace,
+			expectedUpdates: []string{v3.ListenerType},
 		}, // then: default 1,2,3, foo.com; ns: 11
 		{
-			desc:            "Remove a unscoped(name not match) service",
-			ev:              model.EventDelete,
-			svcNames:        []string{"foo.com"},
-			ns:              model.IstioDefaultConfigNamespace,
-			unexpectUpdates: []string{v3.ClusterType},
+			desc:              "Remove a unscoped(name not match) service",
+			ev:                model.EventDelete,
+			svcNames:          []string{"foo.com"},
+			ns:                model.IstioDefaultConfigNamespace,
+			unexpectedUpdates: []string{v3.ClusterType},
 		}, // then: default 1,2,3; ns1: 11
 		{
-			desc:            "Remove a unscoped(ns not match) service",
-			ev:              model.EventDelete,
-			svcIndexes:      []int{11},
-			ns:              ns1,
-			unexpectUpdates: []string{v3.ClusterType},
+			desc:              "Remove a unscoped(ns not match) service",
+			ev:                model.EventDelete,
+			svcIndexes:        []int{11},
+			ns:                ns1,
+			unexpectedUpdates: []string{v3.ClusterType},
 		}, // then: default 1,2,3
 		{
-			desc:            "Add an unmatched Sidecar config",
-			ev:              model.EventAdd,
-			cfgs:            []config.Config{notMatchedScc},
-			ns:              model.IstioDefaultConfigNamespace,
-			unexpectUpdates: []string{v3.ListenerType, v3.RouteType, v3.ClusterType, v3.EndpointType},
+			desc:              "Add an unmatched Sidecar config",
+			ev:                model.EventAdd,
+			cfgs:              []config.Config{notMatchedScc},
+			ns:                model.IstioDefaultConfigNamespace,
+			unexpectedUpdates: []string{v3.ListenerType, v3.RouteType, v3.ClusterType, v3.EndpointType},
 		},
 		{
-			desc:          "Update the Sidecar config",
-			ev:            model.EventUpdate,
-			cfgs:          []config.Config{scc},
-			ns:            model.IstioDefaultConfigNamespace,
-			expectUpdates: []string{v3.ListenerType, v3.RouteType, v3.ClusterType, v3.EndpointType},
+			desc:            "Update the Sidecar config",
+			ev:              model.EventUpdate,
+			cfgs:            []config.Config{scc},
+			ns:              model.IstioDefaultConfigNamespace,
+			expectedUpdates: []string{v3.ListenerType, v3.RouteType, v3.ClusterType, v3.EndpointType},
 		},
 	}
 
@@ -651,8 +651,8 @@ func TestAdsPushScoping(t *testing.T) {
 			time.Sleep(time.Millisecond * 10)
 			adscConn.WaitClear()
 			var wantUpdates []string
-			wantUpdates = append(wantUpdates, c.expectUpdates...)
-			wantUpdates = append(wantUpdates, c.unexpectUpdates...)
+			wantUpdates = append(wantUpdates, c.expectedUpdates...)
+			wantUpdates = append(wantUpdates, c.unexpectedUpdates...)
 
 			switch c.ev {
 			case model.EventAdd:
@@ -730,12 +730,12 @@ func TestAdsPushScoping(t *testing.T) {
 
 			timeout := time.Millisecond * 100
 			upd, _ := adscConn.Wait(timeout, wantUpdates...)
-			for _, expect := range c.expectUpdates {
+			for _, expect := range c.expectedUpdates {
 				if !contains(upd, expect) {
 					t.Fatalf("expected update %s not in updates %v", expect, upd)
 				}
 			}
-			for _, unexpect := range c.unexpectUpdates {
+			for _, unexpect := range c.unexpectedUpdates {
 				if contains(upd, unexpect) {
 					t.Fatalf("expected to not get update %s, but it is in updates %v", unexpect, upd)
 				}


### PR DESCRIPTION
Improves perf of AdsPushScoping test. Tested this 100 times in my local with out flakes. If updates come in 100ms, we can safely assume if an update does not come in 100ms, it will never come (unexpected cases).

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure