### PR TITLE
fix passing exit on zero active connections to metadata

### DIFF
--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -70,7 +70,7 @@ type Config struct {
 	*model.Node
 }
 
-// newTemplateParams creates a new template configuration for the given configuration.
+// toTemplateParams creates a new template configuration for the given configuration.
 func (cfg Config) toTemplateParams() (map[string]interface{}, error) {
 	opts := make([]option.Instance, 0)
 
@@ -498,18 +498,19 @@ func extractAttributesMetadata(envVars []string, plat platform.Environment, meta
 
 // MetadataOptions for constructing node metadata.
 type MetadataOptions struct {
-	Envs                []string
-	Platform            platform.Environment
-	InstanceIPs         []string
-	StsPort             int
-	ID                  string
-	ProxyConfig         *meshAPI.ProxyConfig
-	PilotSubjectAltName []string
-	OutlierLogPath      string
-	ProvCert            string
-	annotationFilePath  string
-	EnvoyStatusPort     int
-	EnvoyPrometheusPort int
+	Envs                        []string
+	Platform                    platform.Environment
+	InstanceIPs                 []string
+	StsPort                     int
+	ID                          string
+	ProxyConfig                 *meshAPI.ProxyConfig
+	PilotSubjectAltName         []string
+	OutlierLogPath              string
+	ProvCert                    string
+	annotationFilePath          string
+	EnvoyStatusPort             int
+	EnvoyPrometheusPort         int
+	ExitOnZeroActiveConnections bool
 }
 
 // GetNodeMetaData function uses an environment variable contract
@@ -550,6 +551,7 @@ func GetNodeMetaData(options MetadataOptions) (*model.Node, error) {
 	}
 	meta.EnvoyStatusPort = options.EnvoyStatusPort
 	meta.EnvoyPrometheusPort = options.EnvoyPrometheusPort
+	meta.ExitOnZeroActiveConnections = model.StringBool(options.ExitOnZeroActiveConnections)
 
 	meta.ProxyConfig = (*model.NodeMetaProxyConfig)(options.ProxyConfig)
 

--- a/pkg/bootstrap/config_test.go
+++ b/pkg/bootstrap/config_test.go
@@ -86,19 +86,22 @@ func TestGetNodeMetaData(t *testing.T) {
 
 	expectOwner := "test"
 	expectWorkloadName := "workload"
+	expectExitOnZeroActiveConnections := model.StringBool(true)
 
 	os.Setenv(IstioMetaPrefix+"OWNER", inputOwner)
 	os.Setenv(IstioMetaPrefix+"WORKLOAD_NAME", inputWorkloadName)
 
 	node, err := GetNodeMetaData(MetadataOptions{
-		ID:   "test",
-		Envs: os.Environ(),
+		ID:                          "test",
+		Envs:                        os.Environ(),
+		ExitOnZeroActiveConnections: true,
 	})
 
 	g := NewWithT(t)
 	g.Expect(err).Should(BeNil())
 	g.Expect(node.Metadata.Owner).To(Equal(expectOwner))
 	g.Expect(node.Metadata.WorkloadName).To(Equal(expectWorkloadName))
+	g.Expect(node.Metadata.ExitOnZeroActiveConnections).To(Equal(expectExitOnZeroActiveConnections))
 	g.Expect(node.RawMetadata["OWNER"]).To(Equal(expectOwner))
 	g.Expect(node.RawMetadata["WORKLOAD_NAME"]).To(Equal(expectWorkloadName))
 }

--- a/pkg/bootstrap/config_test.go
+++ b/pkg/bootstrap/config_test.go
@@ -25,6 +25,7 @@ import (
 
 	"istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/bootstrap/option"
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/util/protomarshal"
 )
@@ -226,6 +227,48 @@ func TestConvertNodeServiceClusterNaming(t *testing.T) {
 			out := ConvertNodeToXDSNode(node)
 			if got, want := out.Cluster, v.wantCluster; got != want {
 				tt.Errorf("ConvertNodeToXDSNode(%#v) => cluster = %s; want %s", node, got, want)
+			}
+		})
+	}
+}
+
+func TestGetStatOptions(t *testing.T) {
+	cases := []struct {
+		name            string
+		metadataOptions MetadataOptions
+		// TODO(ramaraochavali): Add validation for prefix and tags also.
+		wantInclusionSuffixes []string
+	}{
+		{
+			name: "with exit on zero connections enabled",
+			metadataOptions: MetadataOptions{
+				ID:                          "test",
+				Envs:                        os.Environ(),
+				ProxyConfig:                 &v1alpha1.ProxyConfig{},
+				ExitOnZeroActiveConnections: true,
+			},
+			wantInclusionSuffixes: []string{"rbac.allowed", "rbac.denied", "shadow_allowed", "shadow_denied", "downstream_cx_active"},
+		},
+		{
+			name: "with exit on zero connections disabled",
+			metadataOptions: MetadataOptions{
+				ID:                          "test",
+				Envs:                        os.Environ(),
+				ProxyConfig:                 &v1alpha1.ProxyConfig{},
+				ExitOnZeroActiveConnections: false,
+			},
+			wantInclusionSuffixes: []string{"rbac.allowed", "rbac.denied", "shadow_allowed", "shadow_denied"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(tt *testing.T) {
+			node, _ := GetNodeMetaData(tc.metadataOptions)
+			options := getStatsOptions(node.Metadata)
+			templateParams, _ := option.NewTemplateParams(options...)
+			inclusionSuffixes := templateParams["inclusionSuffix"]
+			if !reflect.DeepEqual(inclusionSuffixes, tc.wantInclusionSuffixes) {
+				tt.Errorf("unexpected inclusion suffixes. want: %v, got: %v", tc.wantInclusionSuffixes, inclusionSuffixes)
 			}
 		})
 	}

--- a/pkg/istio-agent/agent.go
+++ b/pkg/istio-agent/agent.go
@@ -242,17 +242,18 @@ func (a *Agent) generateNodeMetadata() (*model.Node, error) {
 	}
 
 	return bootstrap.GetNodeMetaData(bootstrap.MetadataOptions{
-		ID:                  a.cfg.ServiceNode,
-		Envs:                os.Environ(),
-		Platform:            a.cfg.Platform,
-		InstanceIPs:         a.cfg.ProxyIPAddresses,
-		StsPort:             a.secOpts.STSPort,
-		ProxyConfig:         a.proxyConfig,
-		PilotSubjectAltName: pilotSAN,
-		OutlierLogPath:      a.envoyOpts.OutlierLogPath,
-		ProvCert:            provCert,
-		EnvoyPrometheusPort: a.cfg.EnvoyPrometheusPort,
-		EnvoyStatusPort:     a.cfg.EnvoyStatusPort,
+		ID:                          a.cfg.ServiceNode,
+		Envs:                        os.Environ(),
+		Platform:                    a.cfg.Platform,
+		InstanceIPs:                 a.cfg.ProxyIPAddresses,
+		StsPort:                     a.secOpts.STSPort,
+		ProxyConfig:                 a.proxyConfig,
+		PilotSubjectAltName:         pilotSAN,
+		OutlierLogPath:              a.envoyOpts.OutlierLogPath,
+		ProvCert:                    provCert,
+		EnvoyPrometheusPort:         a.cfg.EnvoyPrometheusPort,
+		EnvoyStatusPort:             a.cfg.EnvoyStatusPort,
+		ExitOnZeroActiveConnections: a.cfg.ExitOnZeroActiveConnections,
 	})
 }
 


### PR DESCRIPTION
Without this the "downstream_cx_*" stats are not added by default if this feature is enabled.

Refer https://github.com/istio/istio/issues/34855#issuecomment-1053441642

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure