### PR TITLE
Fix bookinfo k8s ingress example

### DIFF
--- a/samples/bookinfo/platform/kube/bookinfo-ingress.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-ingress.yaml
@@ -15,7 +15,7 @@
 ###########################################################################
 # Ingress resource (gateway)
 ##########################################################################
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: gateway
@@ -26,23 +26,38 @@ spec:
   - http:
       paths:
       - path: /productpage
+        pathType: Exact
         backend:
-          serviceName: productpage
-          servicePort: 9080
-      - path: /static/*
+          service:
+            name: productpage
+            port:
+              number: 9080
+      - path: /static/
+        pathType: Prefix
         backend:
-          serviceName: productpage
-          servicePort: 9080
+          service:
+            name: productpage
+            port:
+              number: 9080
       - path: /login
+        pathType: Exact
         backend:
-          serviceName: productpage
-          servicePort: 9080
+          service:
+            name: productpage
+            port:
+              number: 9080
       - path: /logout
+        pathType: Exact
         backend:
-          serviceName: productpage
-          servicePort: 9080
-      - path: /api/v1/products.*
+          service:
+            name: productpage
+            port:
+              number: 9080
+      - path: /api/v1/products
+        pathType: Prefix
         backend:
-          serviceName: productpage
-          servicePort: 9080
+          service:
+            name: productpage
+            port:
+              number: 9080
 ---


### PR DESCRIPTION
**Please provide a description of this PR:**
`v1` is introduced in v1.19, and `v1beta1` is no longer served as of 1.22
https://kubernetes.io/docs/reference/using-api/deprecation-guide/