### PR TITLE
Enable validation for mcp-over-xds store.

### DIFF
--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -254,7 +254,7 @@ func (s *Server) initConfigSources(args *PilotArgs) (err error) {
 			if err != nil {
 				return fmt.Errorf("failed to dial XDS %s %v", configSource.Address, err)
 			}
-			store := memory.MakeSkipValidation(collections.Pilot)
+			store := memory.Make(collections.Pilot)
 			configController := memory.NewController(store)
 			configController.RegisterHasSyncedHandler(xdsMCP.HasSynced)
 			xdsMCP.Store = model.MakeIstioStore(configController)


### PR DESCRIPTION
We should not skip validation for CR configs via mcp-over-xds.
We always do this check in previous versions until this pr https://github.com/istio/istio/pull/31356 has been merged.

PTAL @hzxuzhonghu