### PR TITLE
Configure warmupDurationSecs for slow start mode

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -760,11 +760,11 @@ func applyLoadBalancer(c *cluster.Cluster, lb *networking.LoadBalancerSettings, 
 	// DO not do if else here. since lb.GetSimple returns a enum value (not pointer).
 	switch lb.GetSimple() {
 	case networking.LoadBalancerSettings_LEAST_CONN, networking.LoadBalancerSettings_LEAST_REQUEST:
-		ApplyLeastRequestLoadBalancer(c, lb.GetWarmupDurationSecs())
+		ApplyLeastRequestLoadBalancer(c, lb)
 	case networking.LoadBalancerSettings_RANDOM:
 		c.LbPolicy = cluster.Cluster_RANDOM
 	case networking.LoadBalancerSettings_ROUND_ROBIN:
-		ApplyRoundRobinLoadBalancer(c, lb.GetWarmupDurationSecs())
+		ApplyRoundRobinLoadBalancer(c, lb)
 	case networking.LoadBalancerSettings_PASSTHROUGH:
 		c.LbPolicy = cluster.Cluster_CLUSTER_PROVIDED
 		c.ClusterDiscoveryType = &cluster.Cluster_Type{Type: cluster.Cluster_ORIGINAL_DST}
@@ -776,26 +776,26 @@ func applyLoadBalancer(c *cluster.Cluster, lb *networking.LoadBalancerSettings, 
 }
 
 // ApplyRoundRobinLoadBalancer will set the LbPolicy and create an LbConfig for ROUND_ROBIN if used in LoadBalancerSettings
-func ApplyRoundRobinLoadBalancer(c *cluster.Cluster, warmupDurationSecs *types.Duration) {
+func ApplyRoundRobinLoadBalancer(c *cluster.Cluster, loadbalancer *networking.LoadBalancerSettings) {
 	c.LbPolicy = cluster.Cluster_ROUND_ROBIN
 
-	if warmupDurationSecs != nil {
+	if loadbalancer.GetWarmupDurationSecs() != nil {
 		c.LbConfig = &cluster.Cluster_RoundRobinLbConfig_{
 			RoundRobinLbConfig: &cluster.Cluster_RoundRobinLbConfig{
-				SlowStartConfig: setSlowStartConfig(warmupDurationSecs),
+				SlowStartConfig: setSlowStartConfig(loadbalancer.GetWarmupDurationSecs()),
 			},
 		}
 	}
 }
 
 // ApplyLeastRequestLoadBalancer will set the LbPolicy and create an LbConfig for LEAST_REQUEST if used in LoadBalancerSettings
-func ApplyLeastRequestLoadBalancer(c *cluster.Cluster, warmupDurationSecs *types.Duration) {
+func ApplyLeastRequestLoadBalancer(c *cluster.Cluster, loadbalancer *networking.LoadBalancerSettings) {
 	c.LbPolicy = cluster.Cluster_LEAST_REQUEST
 
-	if warmupDurationSecs != nil {
+	if loadbalancer.GetWarmupDurationSecs() != nil {
 		c.LbConfig = &cluster.Cluster_LeastRequestLbConfig_{
 			LeastRequestLbConfig: &cluster.Cluster_LeastRequestLbConfig{
-				SlowStartConfig: setSlowStartConfig(warmupDurationSecs),
+				SlowStartConfig: setSlowStartConfig(loadbalancer.GetWarmupDurationSecs()),
 			},
 		}
 	}

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -25,6 +25,8 @@ import (
 	endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	xdstype "github.com/envoyproxy/go-control-plane/envoy/type/v3"
+	"github.com/gogo/protobuf/types"
+	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/structpb"
 	wrappers "google.golang.org/protobuf/types/known/wrapperspb"
 
@@ -735,7 +737,6 @@ func applyLoadBalancer(c *cluster.Cluster, lb *networking.LoadBalancerSettings, 
 			LocalityWeightedLbConfig: &cluster.Cluster_CommonLbConfig_LocalityWeightedLbConfig{},
 		}
 	}
-
 	// Use locality lb settings from load balancer settings if present, else use mesh wide locality lb settings
 	applyLocalityLBSetting(locality, proxyLabels, c, localityLbSetting)
 
@@ -759,11 +760,11 @@ func applyLoadBalancer(c *cluster.Cluster, lb *networking.LoadBalancerSettings, 
 	// DO not do if else here. since lb.GetSimple returns a enum value (not pointer).
 	switch lb.GetSimple() {
 	case networking.LoadBalancerSettings_LEAST_CONN, networking.LoadBalancerSettings_LEAST_REQUEST:
-		c.LbPolicy = cluster.Cluster_LEAST_REQUEST
+		ApplyLeastRequestLoadBalancer(c, lb.GetWarmupDurationSecs())
 	case networking.LoadBalancerSettings_RANDOM:
 		c.LbPolicy = cluster.Cluster_RANDOM
 	case networking.LoadBalancerSettings_ROUND_ROBIN:
-		c.LbPolicy = cluster.Cluster_ROUND_ROBIN
+		ApplyRoundRobinLoadBalancer(c, lb.GetWarmupDurationSecs())
 	case networking.LoadBalancerSettings_PASSTHROUGH:
 		c.LbPolicy = cluster.Cluster_CLUSTER_PROVIDED
 		c.ClusterDiscoveryType = &cluster.Cluster_Type{Type: cluster.Cluster_ORIGINAL_DST}
@@ -772,6 +773,39 @@ func applyLoadBalancer(c *cluster.Cluster, lb *networking.LoadBalancerSettings, 
 	}
 
 	ApplyRingHashLoadBalancer(c, lb)
+}
+
+// ApplyRoundRobinLoadBalancer will set the LbPolicy and create an LbConfig for ROUND_ROBIN if used in LoadBalancerSettings
+func ApplyRoundRobinLoadBalancer(c *cluster.Cluster, warmupDurationSecs *types.Duration) {
+	c.LbPolicy = cluster.Cluster_ROUND_ROBIN
+
+	if warmupDurationSecs != nil {
+		c.LbConfig = &cluster.Cluster_RoundRobinLbConfig_{
+			RoundRobinLbConfig: &cluster.Cluster_RoundRobinLbConfig{
+				SlowStartConfig: setSlowStartConfig(warmupDurationSecs),
+			},
+		}
+	}
+}
+
+// ApplyLeastRequestLoadBalancer will set the LbPolicy and create an LbConfig for LEAST_REQUEST if used in LoadBalancerSettings
+func ApplyLeastRequestLoadBalancer(c *cluster.Cluster, warmupDurationSecs *types.Duration) {
+	c.LbPolicy = cluster.Cluster_LEAST_REQUEST
+
+	if warmupDurationSecs != nil {
+		c.LbConfig = &cluster.Cluster_LeastRequestLbConfig_{
+			LeastRequestLbConfig: &cluster.Cluster_LeastRequestLbConfig{
+				SlowStartConfig: setSlowStartConfig(warmupDurationSecs),
+			},
+		}
+	}
+}
+
+// setSlowStartConfig will set the warmupDurationSecs for LEAST_REQUEST and ROUND_ROBIN if provided in DestinationRule
+func setSlowStartConfig(warmupDurationSecs *types.Duration) *cluster.Cluster_SlowStartConfig {
+	return &cluster.Cluster_SlowStartConfig{
+		SlowStartWindow: &durationpb.Duration{Seconds: warmupDurationSecs.GetSeconds()},
+	}
 }
 
 // ApplyRingHashLoadBalancer will set the LbPolicy and create an LbConfig for RING_HASH if  used in LoadBalancerSettings

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -1333,7 +1333,7 @@ func TestSlowStartConfig(t *testing.T) {
 				mesh:            testMesh(),
 				destRule: &networking.DestinationRule{
 					Host:          test.name,
-					TrafficPolicy: getSlowStartTrafficPolicy(test.slowStartEnabled, networking.LoadBalancerSettings_ROUND_ROBIN),
+					TrafficPolicy: getSlowStartTrafficPolicy(test.slowStartEnabled, test.lbType),
 				},
 			})
 

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -1310,6 +1310,71 @@ func TestClusterDiscoveryTypeAndLbPolicyRoundRobin(t *testing.T) {
 	g.Expect(c.GetClusterDiscoveryType()).To(Equal(&cluster.Cluster_Type{Type: cluster.Cluster_ORIGINAL_DST}))
 }
 
+func TestSlowStartConfig(t *testing.T) {
+	g := NewWithT(t)
+	testcases := []struct {
+		name     string
+		clusters []*cluster.Cluster
+	}{
+		{"roundrobin", buildTestClusters(clusterTest{
+			t:               t,
+			serviceHostname: "roundrobin",
+			nodeType:        model.SidecarProxy,
+			mesh:            testMesh(),
+			destRule: &networking.DestinationRule{
+				Host:          "roundrobin",
+				TrafficPolicy: getSlowStartTrafficPolicy(networking.LoadBalancerSettings_ROUND_ROBIN),
+			},
+		})},
+		{"leastrequest", buildTestClusters(clusterTest{
+			t:               t,
+			serviceHostname: "leastrequest",
+			nodeType:        model.SidecarProxy,
+			mesh:            testMesh(),
+			destRule: &networking.DestinationRule{
+				Host:          "leastrequest",
+				TrafficPolicy: getSlowStartTrafficPolicy(networking.LoadBalancerSettings_ROUND_ROBIN),
+			},
+		})},
+		{"passthrough", buildTestClusters(clusterTest{
+			t:               t,
+			serviceHostname: "passthrough",
+			nodeType:        model.SidecarProxy,
+			mesh:            testMesh(),
+			destRule: &networking.DestinationRule{
+				Host:          "passthrough",
+				TrafficPolicy: getSlowStartTrafficPolicy(networking.LoadBalancerSettings_PASSTHROUGH),
+			},
+		})},
+	}
+
+	for _, test := range testcases {
+		t.Run(test.name, func(t *testing.T) {
+			c := xdstest.ExtractCluster("outbound|8080||"+test.name,
+				test.clusters)
+			switch c.LbPolicy {
+			case cluster.Cluster_ROUND_ROBIN:
+				g.Expect(c.GetRoundRobinLbConfig().GetSlowStartConfig().GetSlowStartWindow().Seconds).To(Equal(int64(15)))
+			case cluster.Cluster_LEAST_REQUEST:
+				g.Expect(c.GetLeastRequestLbConfig().GetSlowStartConfig().GetSlowStartWindow().Seconds).To(Equal(int64(15)))
+			default:
+				g.Expect(c.GetLbConfig()).To(BeNil())
+			}
+		})
+	}
+}
+
+func getSlowStartTrafficPolicy(lbType networking.LoadBalancerSettings_SimpleLB) *networking.TrafficPolicy {
+	return &networking.TrafficPolicy{
+		LoadBalancer: &networking.LoadBalancerSettings{
+			LbPolicy: &networking.LoadBalancerSettings_Simple{
+				Simple: lbType,
+			},
+			WarmupDurationSecs: &types.Duration{Seconds: 15},
+		},
+	}
+}
+
 func TestClusterDiscoveryTypeAndLbPolicyPassthrough(t *testing.T) {
 	g := NewWithT(t)
 


### PR DESCRIPTION
**Please provide a description of this PR:**


- This PR configures slow start warmup duration for `ROUND_ROBIN` and `LEAST_REQUEST` loadbalancer when user sets `warmup_duration_secs` in DestinationRule trafficPolicy based on this api -> https://github.com/istio/api/pull/2153.
- Adds unit test to validate slowStart config is applied in above scenario.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [x] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
