### PR TITLE
Add Warning for IPs in SNI Hosts in TLSRoute.Match criteria

### DIFF
--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -2489,7 +2489,7 @@ func validateSniHost(sniHost string, context *networking.VirtualService) (errs V
 	if err := ValidateWildcardDomain(sniHost); err != nil {
 		ipAddr := net.ParseIP(sniHost) // Could also be an IP
 		if ipAddr != nil {
-			errs = appendValidation(errs, WrapWarning(fmt.Errorf("IP address %q is not a valid SNI host value", ipAddr)))
+			errs = appendValidation(errs, WrapWarning(fmt.Errorf("using an IP address (%q) goes against SNI spec and most clients do no support this", ipAddr)))
 			return
 		}
 		return appendValidation(errs, err)

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -2492,9 +2492,10 @@ func validateTLSMatch(match *networking.TLSMatchAttributes, context *networking.
 func validateSniHost(sniHost string, context *networking.VirtualService) error {
 	if err := ValidateWildcardDomain(sniHost); err != nil {
 		ipAddr := net.ParseIP(sniHost) // Could also be an IP
-		if ipAddr == nil {
-			return err
+		if ipAddr != nil {
+			return fmt.Errorf("IP address %q is not a valid SNI host value", ipAddr)
 		}
+		return err
 	}
 	sniHostname := host.Name(sniHost)
 	for _, hostname := range context.Hosts {

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -2443,68 +2443,65 @@ func requestName(match interface{}, matchn int) string {
 	return fmt.Sprintf("#%d", matchn)
 }
 
-func validateTLSRoute(tls *networking.TLSRoute, context *networking.VirtualService) error {
-	var errs error
+func validateTLSRoute(tls *networking.TLSRoute, context *networking.VirtualService) (errs Validation) {
 	if tls == nil {
-		return nil
+		return
 	}
 	if len(tls.Match) == 0 {
-		errs = appendErrors(errs, errors.New("TLS route must have at least one match condition"))
+		errs = appendValidation(errs, errors.New("TLS route must have at least one match condition"))
 	}
 	for _, match := range tls.Match {
-		errs = appendErrors(errs, validateTLSMatch(match, context))
+		errs = appendValidation(errs, validateTLSMatch(match, context))
 	}
 	if len(tls.Route) == 0 {
-		errs = appendErrors(errs, errors.New("TLS route is required"))
+		errs = appendValidation(errs, errors.New("TLS route is required"))
 	}
-	errs = appendErrors(errs, validateRouteDestinations(tls.Route))
+	errs = appendValidation(errs, validateRouteDestinations(tls.Route))
 	return errs
 }
 
-func validateTLSMatch(match *networking.TLSMatchAttributes, context *networking.VirtualService) (errs error) {
+func validateTLSMatch(match *networking.TLSMatchAttributes, context *networking.VirtualService) (errs Validation) {
 	if match == nil {
-		errs = appendErrors(errs, errors.New("TLS match may not be null"))
+		errs = appendValidation(errs, errors.New("TLS match may not be null"))
 		return
 	}
 	if len(match.SniHosts) == 0 {
-		errs = appendErrors(errs, fmt.Errorf("TLS match must have at least one SNI host"))
+		errs = appendValidation(errs, fmt.Errorf("TLS match must have at least one SNI host"))
 	} else {
 		for _, sniHost := range match.SniHosts {
-			err := validateSniHost(sniHost, context)
-			if err != nil {
-				errs = appendErrors(errs, err)
-			}
+			errs = appendValidation(errs, validateSniHost(sniHost, context))
 		}
 	}
 
 	for _, destinationSubnet := range match.DestinationSubnets {
-		errs = appendErrors(errs, ValidateIPSubnet(destinationSubnet))
+		errs = appendValidation(errs, ValidateIPSubnet(destinationSubnet))
 	}
 
 	if match.Port != 0 {
-		errs = appendErrors(errs, ValidatePort(int(match.Port)))
+		errs = appendValidation(errs, ValidatePort(int(match.Port)))
 	}
-	errs = appendErrors(errs, labels.Instance(match.SourceLabels).Validate())
-	errs = appendErrors(errs, validateGatewayNames(match.Gateways))
+	errs = appendValidation(errs, labels.Instance(match.SourceLabels).Validate())
+	errs = appendValidation(errs, validateGatewayNames(match.Gateways))
 	return
 }
 
-func validateSniHost(sniHost string, context *networking.VirtualService) error {
+func validateSniHost(sniHost string, context *networking.VirtualService) (errs Validation) {
 	if err := ValidateWildcardDomain(sniHost); err != nil {
 		ipAddr := net.ParseIP(sniHost) // Could also be an IP
 		if ipAddr != nil {
-			return fmt.Errorf("IP address %q is not a valid SNI host value", ipAddr)
+			errs = appendValidation(errs, WrapWarning(fmt.Errorf("IP address %q is not a valid SNI host value", ipAddr)))
+			return
 		}
-		return err
+		return appendValidation(errs, err)
 	}
 	sniHostname := host.Name(sniHost)
 	for _, hostname := range context.Hosts {
 		if sniHostname.SubsetOf(host.Name(hostname)) {
-			return nil
+			return
 		}
 	}
-	return fmt.Errorf("SNI host %q is not a compatible subset of any of the virtual service hosts: [%s]",
-		sniHost, strings.Join(context.Hosts, ", "))
+	return appendValidation(errs, fmt.Errorf("SNI host %q is not a compatible subset of any of the virtual service hosts: [%s]",
+		sniHost, strings.Join(context.Hosts, ", ")))
 }
 
 func validateTCPRoute(tcp *networking.TCPRoute) (errs error) {

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -2489,7 +2489,7 @@ func validateSniHost(sniHost string, context *networking.VirtualService) (errs V
 	if err := ValidateWildcardDomain(sniHost); err != nil {
 		ipAddr := net.ParseIP(sniHost) // Could also be an IP
 		if ipAddr != nil {
-			errs = appendValidation(errs, WrapWarning(fmt.Errorf("using an IP address (%q) goes against SNI spec and most clients do no support this", ipAddr)))
+			errs = appendValidation(errs, WrapWarning(fmt.Errorf("using an IP address (%q) goes against SNI spec and most clients do not support this", ipAddr)))
 			return
 		}
 		return appendValidation(errs, err)

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -2786,6 +2786,34 @@ func TestValidateVirtualService(t *testing.T) {
 				},
 			}},
 		}, valid: false, warning: false},
+		{name: "ip address as sni host", in: &networking.VirtualService{
+			Hosts: []string{"foo.bar"},
+			Tls: []*networking.TLSRoute{{
+				Route: []*networking.RouteDestination{{
+					Destination: &networking.Destination{Host: "foo.baz"},
+				}},
+				Match: []*networking.TLSMatchAttributes{
+					{
+						Port:     999,
+						SniHosts: []string{"1.1.1.1"},
+					},
+				},
+			}},
+		}, valid: false},
+		{name: "invalid wildcard as sni host", in: &networking.VirtualService{
+			Hosts: []string{"foo.bar"},
+			Tls: []*networking.TLSRoute{{
+				Route: []*networking.RouteDestination{{
+					Destination: &networking.Destination{Host: "foo.baz"},
+				}},
+				Match: []*networking.TLSMatchAttributes{
+					{
+						Port:     999,
+						SniHosts: []string{"foo.*.com"},
+					},
+				},
+			}},
+		}, valid: false},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -2545,247 +2545,247 @@ func TestValidateVirtualService(t *testing.T) {
 		valid   bool
 		warning bool
 	}{
-		{name: "simple", in: &networking.VirtualService{
-			Hosts: []string{"foo.bar"},
-			Http: []*networking.HTTPRoute{{
-				Route: []*networking.HTTPRouteDestination{{
-					Destination: &networking.Destination{Host: "foo.baz"},
-				}},
-			}},
-		}, valid: true},
-		{name: "duplicate hosts", in: &networking.VirtualService{
-			Hosts: []string{"*.foo.bar", "*.bar"},
-			Http: []*networking.HTTPRoute{{
-				Route: []*networking.HTTPRouteDestination{{
-					Destination: &networking.Destination{Host: "foo.baz"},
-				}},
-			}},
-		}, valid: false},
-		{name: "with no destination", in: &networking.VirtualService{
-			Hosts: []string{"*.foo.bar", "*.bar"},
-			Http: []*networking.HTTPRoute{{
-				Route: []*networking.HTTPRouteDestination{{}},
-			}},
-		}, valid: false},
-		{name: "destination with out hosts", in: &networking.VirtualService{
-			Hosts: []string{"*.foo.bar", "*.bar"},
-			Http: []*networking.HTTPRoute{{
-				Route: []*networking.HTTPRouteDestination{{
-					Destination: &networking.Destination{},
-				}},
-			}},
-		}, valid: false},
-		{name: "delegate with no hosts", in: &networking.VirtualService{
-			Hosts: nil,
-			Http: []*networking.HTTPRoute{{
-				Route: []*networking.HTTPRouteDestination{{
-					Destination: &networking.Destination{Host: "foo.baz"},
-				}},
-			}},
-		}, valid: true},
-		{name: "bad host", in: &networking.VirtualService{
-			Hosts: []string{"foo.ba!r"},
-			Http: []*networking.HTTPRoute{{
-				Route: []*networking.HTTPRouteDestination{{
-					Destination: &networking.Destination{Host: "foo.baz"},
-				}},
-			}},
-		}, valid: false},
-		{name: "no tcp or http routing", in: &networking.VirtualService{
-			Hosts: []string{"foo.bar"},
-		}, valid: false},
-		{name: "bad gateway", in: &networking.VirtualService{
-			Hosts:    []string{"foo.bar"},
-			Gateways: []string{"b@dgateway"},
-			Http: []*networking.HTTPRoute{{
-				Route: []*networking.HTTPRouteDestination{{
-					Destination: &networking.Destination{Host: "foo.baz"},
-				}},
-			}},
-		}, valid: false},
-		{name: "FQDN for gateway", in: &networking.VirtualService{
-			Hosts:    []string{"foo.bar"},
-			Gateways: []string{"gateway.example.com"},
-			Http: []*networking.HTTPRoute{{
-				Route: []*networking.HTTPRouteDestination{{
-					Destination: &networking.Destination{Host: "foo.baz"},
-				}},
-			}},
-		}, valid: true, warning: true},
-		{name: "namespace/name for gateway", in: &networking.VirtualService{
-			Hosts:    []string{"foo.bar"},
-			Gateways: []string{"ns1/gateway"},
-			Http: []*networking.HTTPRoute{{
-				Route: []*networking.HTTPRouteDestination{{
-					Destination: &networking.Destination{Host: "foo.baz"},
-				}},
-			}},
-		}, valid: true},
-		{name: "namespace/* for gateway", in: &networking.VirtualService{
-			Hosts:    []string{"foo.bar"},
-			Gateways: []string{"ns1/*"},
-			Http: []*networking.HTTPRoute{{
-				Route: []*networking.HTTPRouteDestination{{
-					Destination: &networking.Destination{Host: "foo.baz"},
-				}},
-			}},
-		}, valid: false},
-		{name: "*/name for gateway", in: &networking.VirtualService{
-			Hosts:    []string{"foo.bar"},
-			Gateways: []string{"*/gateway"},
-			Http: []*networking.HTTPRoute{{
-				Route: []*networking.HTTPRouteDestination{{
-					Destination: &networking.Destination{Host: "foo.baz"},
-				}},
-			}},
-		}, valid: false},
-		{name: "wildcard for mesh gateway", in: &networking.VirtualService{
-			Hosts: []string{"*"},
-			Http: []*networking.HTTPRoute{{
-				Route: []*networking.HTTPRouteDestination{{
-					Destination: &networking.Destination{Host: "foo.baz"},
-				}},
-			}},
-		}, valid: false},
-		{name: "wildcard for non-mesh gateway", in: &networking.VirtualService{
-			Hosts:    []string{"*"},
-			Gateways: []string{"somegateway"},
-			Http: []*networking.HTTPRoute{{
-				Route: []*networking.HTTPRouteDestination{{
-					Destination: &networking.Destination{Host: "foo.baz"},
-				}},
-			}},
-		}, valid: true},
-		{name: "missing tcp route", in: &networking.VirtualService{
-			Hosts: []string{"foo.bar"},
-			Tcp: []*networking.TCPRoute{{
-				Match: []*networking.L4MatchAttributes{
-					{Port: 999},
-				},
-			}},
-		}, valid: false},
-		{name: "missing tls route", in: &networking.VirtualService{
-			Hosts: []string{"foo.bar"},
-			Tls: []*networking.TLSRoute{{
-				Match: []*networking.TLSMatchAttributes{
-					{
-						Port:     999,
-						SniHosts: []string{"foo.bar"},
-					},
-				},
-			}},
-		}, valid: false},
-		{name: "deprecated mirror", in: &networking.VirtualService{
-			Hosts:    []string{"foo.bar"},
-			Gateways: []string{"ns1/gateway"},
-			Http: []*networking.HTTPRoute{{
-				MirrorPercent: &types.UInt32Value{Value: 5},
-				Route: []*networking.HTTPRouteDestination{{
-					Destination: &networking.Destination{Host: "foo.baz"},
-				}},
-			}},
-		}, valid: true, warning: true},
-		{name: "set authority", in: &networking.VirtualService{
-			Hosts: []string{"foo.bar"},
-			Http: []*networking.HTTPRoute{{
-				Headers: &networking.Headers{
-					Request: &networking.Headers_HeaderOperations{Set: map[string]string{":authority": "foo"}},
-				},
-				Route: []*networking.HTTPRouteDestination{{
-					Destination: &networking.Destination{Host: "foo.baz"},
-				}},
-			}},
-		}, valid: true, warning: false},
-		{name: "set authority in destination", in: &networking.VirtualService{
-			Hosts: []string{"foo.bar"},
-			Http: []*networking.HTTPRoute{{
-				Route: []*networking.HTTPRouteDestination{{
-					Destination: &networking.Destination{Host: "foo.baz"},
-					Headers: &networking.Headers{
-						Request: &networking.Headers_HeaderOperations{Set: map[string]string{":authority": "foo"}},
-					},
-				}},
-			}},
-		}, valid: false, warning: false},
-		{name: "set authority in rewrite and header", in: &networking.VirtualService{
-			Hosts: []string{"foo.bar"},
-			Http: []*networking.HTTPRoute{{
-				Headers: &networking.Headers{
-					Request: &networking.Headers_HeaderOperations{Set: map[string]string{":authority": "foo"}},
-				},
-				Rewrite: &networking.HTTPRewrite{Authority: "bar"},
-				Route: []*networking.HTTPRouteDestination{{
-					Destination: &networking.Destination{Host: "foo.baz"},
-				}},
-			}},
-		}, valid: false, warning: false},
-		{name: "non-method-get", in: &networking.VirtualService{
-			Hosts: []string{"foo.bar"},
-			Http: []*networking.HTTPRoute{{
-				Route: []*networking.HTTPRouteDestination{{
-					Destination: &networking.Destination{Host: "foo.baz"},
-				}},
-				Match: []*networking.HTTPMatchRequest{
-					{
-						Uri: &networking.StringMatch{
-							MatchType: &networking.StringMatch_Prefix{Prefix: "/api/v1/product"},
-						},
-					},
-					{
-						Uri: &networking.StringMatch{
-							MatchType: &networking.StringMatch_Prefix{Prefix: "/api/v1/products"},
-						},
-						Method: &networking.StringMatch{
-							MatchType: &networking.StringMatch_Exact{Exact: "GET"},
-						},
-					},
-				},
-			}},
-		}, valid: true, warning: true},
-		{name: "uri-with-prefix-exact", in: &networking.VirtualService{
-			Hosts: []string{"foo.bar"},
-			Http: []*networking.HTTPRoute{{
-				Route: []*networking.HTTPRouteDestination{{
-					Destination: &networking.Destination{Host: "foo.baz"},
-				}},
-				Match: []*networking.HTTPMatchRequest{
-					{
-						Uri: &networking.StringMatch{
-							MatchType: &networking.StringMatch_Prefix{Prefix: "/"},
-						},
-					},
-					{
-						Uri: &networking.StringMatch{
-							MatchType: &networking.StringMatch_Exact{Exact: "/"},
-						},
-						Method: &networking.StringMatch{
-							MatchType: &networking.StringMatch_Exact{Exact: "GET"},
-						},
-					},
-				},
-			}},
-		}, valid: true, warning: false},
-		{name: "jwt claim route without gateway", in: &networking.VirtualService{
-			Hosts:    []string{"foo.bar"},
-			Gateways: []string{"mesh"},
-			Http: []*networking.HTTPRoute{{
-				Route: []*networking.HTTPRouteDestination{{
-					Destination: &networking.Destination{Host: "foo.baz"},
-				}},
-				Match: []*networking.HTTPMatchRequest{
-					{
-						Uri: &networking.StringMatch{
-							MatchType: &networking.StringMatch_Prefix{Prefix: "/"},
-						},
-						Headers: map[string]*networking.StringMatch{
-							"@request.auth.claims.foo": {
-								MatchType: &networking.StringMatch_Exact{Exact: "bar"},
-							},
-						},
-					},
-				},
-			}},
-		}, valid: false, warning: false},
+		// {name: "simple", in: &networking.VirtualService{
+		// 	Hosts: []string{"foo.bar"},
+		// 	Http: []*networking.HTTPRoute{{
+		// 		Route: []*networking.HTTPRouteDestination{{
+		// 			Destination: &networking.Destination{Host: "foo.baz"},
+		// 		}},
+		// 	}},
+		// }, valid: true},
+		// {name: "duplicate hosts", in: &networking.VirtualService{
+		// 	Hosts: []string{"*.foo.bar", "*.bar"},
+		// 	Http: []*networking.HTTPRoute{{
+		// 		Route: []*networking.HTTPRouteDestination{{
+		// 			Destination: &networking.Destination{Host: "foo.baz"},
+		// 		}},
+		// 	}},
+		// }, valid: false},
+		// {name: "with no destination", in: &networking.VirtualService{
+		// 	Hosts: []string{"*.foo.bar", "*.bar"},
+		// 	Http: []*networking.HTTPRoute{{
+		// 		Route: []*networking.HTTPRouteDestination{{}},
+		// 	}},
+		// }, valid: false},
+		// {name: "destination with out hosts", in: &networking.VirtualService{
+		// 	Hosts: []string{"*.foo.bar", "*.bar"},
+		// 	Http: []*networking.HTTPRoute{{
+		// 		Route: []*networking.HTTPRouteDestination{{
+		// 			Destination: &networking.Destination{},
+		// 		}},
+		// 	}},
+		// }, valid: false},
+		// {name: "delegate with no hosts", in: &networking.VirtualService{
+		// 	Hosts: nil,
+		// 	Http: []*networking.HTTPRoute{{
+		// 		Route: []*networking.HTTPRouteDestination{{
+		// 			Destination: &networking.Destination{Host: "foo.baz"},
+		// 		}},
+		// 	}},
+		// }, valid: true},
+		// {name: "bad host", in: &networking.VirtualService{
+		// 	Hosts: []string{"foo.ba!r"},
+		// 	Http: []*networking.HTTPRoute{{
+		// 		Route: []*networking.HTTPRouteDestination{{
+		// 			Destination: &networking.Destination{Host: "foo.baz"},
+		// 		}},
+		// 	}},
+		// }, valid: false},
+		// {name: "no tcp or http routing", in: &networking.VirtualService{
+		// 	Hosts: []string{"foo.bar"},
+		// }, valid: false},
+		// {name: "bad gateway", in: &networking.VirtualService{
+		// 	Hosts:    []string{"foo.bar"},
+		// 	Gateways: []string{"b@dgateway"},
+		// 	Http: []*networking.HTTPRoute{{
+		// 		Route: []*networking.HTTPRouteDestination{{
+		// 			Destination: &networking.Destination{Host: "foo.baz"},
+		// 		}},
+		// 	}},
+		// }, valid: false},
+		// {name: "FQDN for gateway", in: &networking.VirtualService{
+		// 	Hosts:    []string{"foo.bar"},
+		// 	Gateways: []string{"gateway.example.com"},
+		// 	Http: []*networking.HTTPRoute{{
+		// 		Route: []*networking.HTTPRouteDestination{{
+		// 			Destination: &networking.Destination{Host: "foo.baz"},
+		// 		}},
+		// 	}},
+		// }, valid: true, warning: true},
+		// {name: "namespace/name for gateway", in: &networking.VirtualService{
+		// 	Hosts:    []string{"foo.bar"},
+		// 	Gateways: []string{"ns1/gateway"},
+		// 	Http: []*networking.HTTPRoute{{
+		// 		Route: []*networking.HTTPRouteDestination{{
+		// 			Destination: &networking.Destination{Host: "foo.baz"},
+		// 		}},
+		// 	}},
+		// }, valid: true},
+		// {name: "namespace/* for gateway", in: &networking.VirtualService{
+		// 	Hosts:    []string{"foo.bar"},
+		// 	Gateways: []string{"ns1/*"},
+		// 	Http: []*networking.HTTPRoute{{
+		// 		Route: []*networking.HTTPRouteDestination{{
+		// 			Destination: &networking.Destination{Host: "foo.baz"},
+		// 		}},
+		// 	}},
+		// }, valid: false},
+		// {name: "*/name for gateway", in: &networking.VirtualService{
+		// 	Hosts:    []string{"foo.bar"},
+		// 	Gateways: []string{"*/gateway"},
+		// 	Http: []*networking.HTTPRoute{{
+		// 		Route: []*networking.HTTPRouteDestination{{
+		// 			Destination: &networking.Destination{Host: "foo.baz"},
+		// 		}},
+		// 	}},
+		// }, valid: false},
+		// {name: "wildcard for mesh gateway", in: &networking.VirtualService{
+		// 	Hosts: []string{"*"},
+		// 	Http: []*networking.HTTPRoute{{
+		// 		Route: []*networking.HTTPRouteDestination{{
+		// 			Destination: &networking.Destination{Host: "foo.baz"},
+		// 		}},
+		// 	}},
+		// }, valid: false},
+		// {name: "wildcard for non-mesh gateway", in: &networking.VirtualService{
+		// 	Hosts:    []string{"*"},
+		// 	Gateways: []string{"somegateway"},
+		// 	Http: []*networking.HTTPRoute{{
+		// 		Route: []*networking.HTTPRouteDestination{{
+		// 			Destination: &networking.Destination{Host: "foo.baz"},
+		// 		}},
+		// 	}},
+		// }, valid: true},
+		// {name: "missing tcp route", in: &networking.VirtualService{
+		// 	Hosts: []string{"foo.bar"},
+		// 	Tcp: []*networking.TCPRoute{{
+		// 		Match: []*networking.L4MatchAttributes{
+		// 			{Port: 999},
+		// 		},
+		// 	}},
+		// }, valid: false},
+		// {name: "missing tls route", in: &networking.VirtualService{
+		// 	Hosts: []string{"foo.bar"},
+		// 	Tls: []*networking.TLSRoute{{
+		// 		Match: []*networking.TLSMatchAttributes{
+		// 			{
+		// 				Port:     999,
+		// 				SniHosts: []string{"foo.bar"},
+		// 			},
+		// 		},
+		// 	}},
+		// }, valid: false},
+		// {name: "deprecated mirror", in: &networking.VirtualService{
+		// 	Hosts:    []string{"foo.bar"},
+		// 	Gateways: []string{"ns1/gateway"},
+		// 	Http: []*networking.HTTPRoute{{
+		// 		MirrorPercent: &types.UInt32Value{Value: 5},
+		// 		Route: []*networking.HTTPRouteDestination{{
+		// 			Destination: &networking.Destination{Host: "foo.baz"},
+		// 		}},
+		// 	}},
+		// }, valid: true, warning: true},
+		// {name: "set authority", in: &networking.VirtualService{
+		// 	Hosts: []string{"foo.bar"},
+		// 	Http: []*networking.HTTPRoute{{
+		// 		Headers: &networking.Headers{
+		// 			Request: &networking.Headers_HeaderOperations{Set: map[string]string{":authority": "foo"}},
+		// 		},
+		// 		Route: []*networking.HTTPRouteDestination{{
+		// 			Destination: &networking.Destination{Host: "foo.baz"},
+		// 		}},
+		// 	}},
+		// }, valid: true, warning: false},
+		// {name: "set authority in destination", in: &networking.VirtualService{
+		// 	Hosts: []string{"foo.bar"},
+		// 	Http: []*networking.HTTPRoute{{
+		// 		Route: []*networking.HTTPRouteDestination{{
+		// 			Destination: &networking.Destination{Host: "foo.baz"},
+		// 			Headers: &networking.Headers{
+		// 				Request: &networking.Headers_HeaderOperations{Set: map[string]string{":authority": "foo"}},
+		// 			},
+		// 		}},
+		// 	}},
+		// }, valid: false, warning: false},
+		// {name: "set authority in rewrite and header", in: &networking.VirtualService{
+		// 	Hosts: []string{"foo.bar"},
+		// 	Http: []*networking.HTTPRoute{{
+		// 		Headers: &networking.Headers{
+		// 			Request: &networking.Headers_HeaderOperations{Set: map[string]string{":authority": "foo"}},
+		// 		},
+		// 		Rewrite: &networking.HTTPRewrite{Authority: "bar"},
+		// 		Route: []*networking.HTTPRouteDestination{{
+		// 			Destination: &networking.Destination{Host: "foo.baz"},
+		// 		}},
+		// 	}},
+		// }, valid: false, warning: false},
+		// {name: "non-method-get", in: &networking.VirtualService{
+		// 	Hosts: []string{"foo.bar"},
+		// 	Http: []*networking.HTTPRoute{{
+		// 		Route: []*networking.HTTPRouteDestination{{
+		// 			Destination: &networking.Destination{Host: "foo.baz"},
+		// 		}},
+		// 		Match: []*networking.HTTPMatchRequest{
+		// 			{
+		// 				Uri: &networking.StringMatch{
+		// 					MatchType: &networking.StringMatch_Prefix{Prefix: "/api/v1/product"},
+		// 				},
+		// 			},
+		// 			{
+		// 				Uri: &networking.StringMatch{
+		// 					MatchType: &networking.StringMatch_Prefix{Prefix: "/api/v1/products"},
+		// 				},
+		// 				Method: &networking.StringMatch{
+		// 					MatchType: &networking.StringMatch_Exact{Exact: "GET"},
+		// 				},
+		// 			},
+		// 		},
+		// 	}},
+		// }, valid: true, warning: true},
+		// {name: "uri-with-prefix-exact", in: &networking.VirtualService{
+		// 	Hosts: []string{"foo.bar"},
+		// 	Http: []*networking.HTTPRoute{{
+		// 		Route: []*networking.HTTPRouteDestination{{
+		// 			Destination: &networking.Destination{Host: "foo.baz"},
+		// 		}},
+		// 		Match: []*networking.HTTPMatchRequest{
+		// 			{
+		// 				Uri: &networking.StringMatch{
+		// 					MatchType: &networking.StringMatch_Prefix{Prefix: "/"},
+		// 				},
+		// 			},
+		// 			{
+		// 				Uri: &networking.StringMatch{
+		// 					MatchType: &networking.StringMatch_Exact{Exact: "/"},
+		// 				},
+		// 				Method: &networking.StringMatch{
+		// 					MatchType: &networking.StringMatch_Exact{Exact: "GET"},
+		// 				},
+		// 			},
+		// 		},
+		// 	}},
+		// }, valid: true, warning: false},
+		// {name: "jwt claim route without gateway", in: &networking.VirtualService{
+		// 	Hosts:    []string{"foo.bar"},
+		// 	Gateways: []string{"mesh"},
+		// 	Http: []*networking.HTTPRoute{{
+		// 		Route: []*networking.HTTPRouteDestination{{
+		// 			Destination: &networking.Destination{Host: "foo.baz"},
+		// 		}},
+		// 		Match: []*networking.HTTPMatchRequest{
+		// 			{
+		// 				Uri: &networking.StringMatch{
+		// 					MatchType: &networking.StringMatch_Prefix{Prefix: "/"},
+		// 				},
+		// 				Headers: map[string]*networking.StringMatch{
+		// 					"@request.auth.claims.foo": {
+		// 						MatchType: &networking.StringMatch_Exact{Exact: "bar"},
+		// 					},
+		// 				},
+		// 			},
+		// 		},
+		// 	}},
+		// }, valid: false, warning: false},
 		{name: "ip address as sni host", in: &networking.VirtualService{
 			Hosts: []string{"foo.bar"},
 			Tls: []*networking.TLSRoute{{
@@ -2799,7 +2799,7 @@ func TestValidateVirtualService(t *testing.T) {
 					},
 				},
 			}},
-		}, valid: false},
+		}, valid: true, warning: true},
 		{name: "invalid wildcard as sni host", in: &networking.VirtualService{
 			Hosts: []string{"foo.bar"},
 			Tls: []*networking.TLSRoute{{
@@ -2813,7 +2813,7 @@ func TestValidateVirtualService(t *testing.T) {
 					},
 				},
 			}},
-		}, valid: false},
+		}, valid: false, warning: false},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -2545,247 +2545,247 @@ func TestValidateVirtualService(t *testing.T) {
 		valid   bool
 		warning bool
 	}{
-		// {name: "simple", in: &networking.VirtualService{
-		// 	Hosts: []string{"foo.bar"},
-		// 	Http: []*networking.HTTPRoute{{
-		// 		Route: []*networking.HTTPRouteDestination{{
-		// 			Destination: &networking.Destination{Host: "foo.baz"},
-		// 		}},
-		// 	}},
-		// }, valid: true},
-		// {name: "duplicate hosts", in: &networking.VirtualService{
-		// 	Hosts: []string{"*.foo.bar", "*.bar"},
-		// 	Http: []*networking.HTTPRoute{{
-		// 		Route: []*networking.HTTPRouteDestination{{
-		// 			Destination: &networking.Destination{Host: "foo.baz"},
-		// 		}},
-		// 	}},
-		// }, valid: false},
-		// {name: "with no destination", in: &networking.VirtualService{
-		// 	Hosts: []string{"*.foo.bar", "*.bar"},
-		// 	Http: []*networking.HTTPRoute{{
-		// 		Route: []*networking.HTTPRouteDestination{{}},
-		// 	}},
-		// }, valid: false},
-		// {name: "destination with out hosts", in: &networking.VirtualService{
-		// 	Hosts: []string{"*.foo.bar", "*.bar"},
-		// 	Http: []*networking.HTTPRoute{{
-		// 		Route: []*networking.HTTPRouteDestination{{
-		// 			Destination: &networking.Destination{},
-		// 		}},
-		// 	}},
-		// }, valid: false},
-		// {name: "delegate with no hosts", in: &networking.VirtualService{
-		// 	Hosts: nil,
-		// 	Http: []*networking.HTTPRoute{{
-		// 		Route: []*networking.HTTPRouteDestination{{
-		// 			Destination: &networking.Destination{Host: "foo.baz"},
-		// 		}},
-		// 	}},
-		// }, valid: true},
-		// {name: "bad host", in: &networking.VirtualService{
-		// 	Hosts: []string{"foo.ba!r"},
-		// 	Http: []*networking.HTTPRoute{{
-		// 		Route: []*networking.HTTPRouteDestination{{
-		// 			Destination: &networking.Destination{Host: "foo.baz"},
-		// 		}},
-		// 	}},
-		// }, valid: false},
-		// {name: "no tcp or http routing", in: &networking.VirtualService{
-		// 	Hosts: []string{"foo.bar"},
-		// }, valid: false},
-		// {name: "bad gateway", in: &networking.VirtualService{
-		// 	Hosts:    []string{"foo.bar"},
-		// 	Gateways: []string{"b@dgateway"},
-		// 	Http: []*networking.HTTPRoute{{
-		// 		Route: []*networking.HTTPRouteDestination{{
-		// 			Destination: &networking.Destination{Host: "foo.baz"},
-		// 		}},
-		// 	}},
-		// }, valid: false},
-		// {name: "FQDN for gateway", in: &networking.VirtualService{
-		// 	Hosts:    []string{"foo.bar"},
-		// 	Gateways: []string{"gateway.example.com"},
-		// 	Http: []*networking.HTTPRoute{{
-		// 		Route: []*networking.HTTPRouteDestination{{
-		// 			Destination: &networking.Destination{Host: "foo.baz"},
-		// 		}},
-		// 	}},
-		// }, valid: true, warning: true},
-		// {name: "namespace/name for gateway", in: &networking.VirtualService{
-		// 	Hosts:    []string{"foo.bar"},
-		// 	Gateways: []string{"ns1/gateway"},
-		// 	Http: []*networking.HTTPRoute{{
-		// 		Route: []*networking.HTTPRouteDestination{{
-		// 			Destination: &networking.Destination{Host: "foo.baz"},
-		// 		}},
-		// 	}},
-		// }, valid: true},
-		// {name: "namespace/* for gateway", in: &networking.VirtualService{
-		// 	Hosts:    []string{"foo.bar"},
-		// 	Gateways: []string{"ns1/*"},
-		// 	Http: []*networking.HTTPRoute{{
-		// 		Route: []*networking.HTTPRouteDestination{{
-		// 			Destination: &networking.Destination{Host: "foo.baz"},
-		// 		}},
-		// 	}},
-		// }, valid: false},
-		// {name: "*/name for gateway", in: &networking.VirtualService{
-		// 	Hosts:    []string{"foo.bar"},
-		// 	Gateways: []string{"*/gateway"},
-		// 	Http: []*networking.HTTPRoute{{
-		// 		Route: []*networking.HTTPRouteDestination{{
-		// 			Destination: &networking.Destination{Host: "foo.baz"},
-		// 		}},
-		// 	}},
-		// }, valid: false},
-		// {name: "wildcard for mesh gateway", in: &networking.VirtualService{
-		// 	Hosts: []string{"*"},
-		// 	Http: []*networking.HTTPRoute{{
-		// 		Route: []*networking.HTTPRouteDestination{{
-		// 			Destination: &networking.Destination{Host: "foo.baz"},
-		// 		}},
-		// 	}},
-		// }, valid: false},
-		// {name: "wildcard for non-mesh gateway", in: &networking.VirtualService{
-		// 	Hosts:    []string{"*"},
-		// 	Gateways: []string{"somegateway"},
-		// 	Http: []*networking.HTTPRoute{{
-		// 		Route: []*networking.HTTPRouteDestination{{
-		// 			Destination: &networking.Destination{Host: "foo.baz"},
-		// 		}},
-		// 	}},
-		// }, valid: true},
-		// {name: "missing tcp route", in: &networking.VirtualService{
-		// 	Hosts: []string{"foo.bar"},
-		// 	Tcp: []*networking.TCPRoute{{
-		// 		Match: []*networking.L4MatchAttributes{
-		// 			{Port: 999},
-		// 		},
-		// 	}},
-		// }, valid: false},
-		// {name: "missing tls route", in: &networking.VirtualService{
-		// 	Hosts: []string{"foo.bar"},
-		// 	Tls: []*networking.TLSRoute{{
-		// 		Match: []*networking.TLSMatchAttributes{
-		// 			{
-		// 				Port:     999,
-		// 				SniHosts: []string{"foo.bar"},
-		// 			},
-		// 		},
-		// 	}},
-		// }, valid: false},
-		// {name: "deprecated mirror", in: &networking.VirtualService{
-		// 	Hosts:    []string{"foo.bar"},
-		// 	Gateways: []string{"ns1/gateway"},
-		// 	Http: []*networking.HTTPRoute{{
-		// 		MirrorPercent: &types.UInt32Value{Value: 5},
-		// 		Route: []*networking.HTTPRouteDestination{{
-		// 			Destination: &networking.Destination{Host: "foo.baz"},
-		// 		}},
-		// 	}},
-		// }, valid: true, warning: true},
-		// {name: "set authority", in: &networking.VirtualService{
-		// 	Hosts: []string{"foo.bar"},
-		// 	Http: []*networking.HTTPRoute{{
-		// 		Headers: &networking.Headers{
-		// 			Request: &networking.Headers_HeaderOperations{Set: map[string]string{":authority": "foo"}},
-		// 		},
-		// 		Route: []*networking.HTTPRouteDestination{{
-		// 			Destination: &networking.Destination{Host: "foo.baz"},
-		// 		}},
-		// 	}},
-		// }, valid: true, warning: false},
-		// {name: "set authority in destination", in: &networking.VirtualService{
-		// 	Hosts: []string{"foo.bar"},
-		// 	Http: []*networking.HTTPRoute{{
-		// 		Route: []*networking.HTTPRouteDestination{{
-		// 			Destination: &networking.Destination{Host: "foo.baz"},
-		// 			Headers: &networking.Headers{
-		// 				Request: &networking.Headers_HeaderOperations{Set: map[string]string{":authority": "foo"}},
-		// 			},
-		// 		}},
-		// 	}},
-		// }, valid: false, warning: false},
-		// {name: "set authority in rewrite and header", in: &networking.VirtualService{
-		// 	Hosts: []string{"foo.bar"},
-		// 	Http: []*networking.HTTPRoute{{
-		// 		Headers: &networking.Headers{
-		// 			Request: &networking.Headers_HeaderOperations{Set: map[string]string{":authority": "foo"}},
-		// 		},
-		// 		Rewrite: &networking.HTTPRewrite{Authority: "bar"},
-		// 		Route: []*networking.HTTPRouteDestination{{
-		// 			Destination: &networking.Destination{Host: "foo.baz"},
-		// 		}},
-		// 	}},
-		// }, valid: false, warning: false},
-		// {name: "non-method-get", in: &networking.VirtualService{
-		// 	Hosts: []string{"foo.bar"},
-		// 	Http: []*networking.HTTPRoute{{
-		// 		Route: []*networking.HTTPRouteDestination{{
-		// 			Destination: &networking.Destination{Host: "foo.baz"},
-		// 		}},
-		// 		Match: []*networking.HTTPMatchRequest{
-		// 			{
-		// 				Uri: &networking.StringMatch{
-		// 					MatchType: &networking.StringMatch_Prefix{Prefix: "/api/v1/product"},
-		// 				},
-		// 			},
-		// 			{
-		// 				Uri: &networking.StringMatch{
-		// 					MatchType: &networking.StringMatch_Prefix{Prefix: "/api/v1/products"},
-		// 				},
-		// 				Method: &networking.StringMatch{
-		// 					MatchType: &networking.StringMatch_Exact{Exact: "GET"},
-		// 				},
-		// 			},
-		// 		},
-		// 	}},
-		// }, valid: true, warning: true},
-		// {name: "uri-with-prefix-exact", in: &networking.VirtualService{
-		// 	Hosts: []string{"foo.bar"},
-		// 	Http: []*networking.HTTPRoute{{
-		// 		Route: []*networking.HTTPRouteDestination{{
-		// 			Destination: &networking.Destination{Host: "foo.baz"},
-		// 		}},
-		// 		Match: []*networking.HTTPMatchRequest{
-		// 			{
-		// 				Uri: &networking.StringMatch{
-		// 					MatchType: &networking.StringMatch_Prefix{Prefix: "/"},
-		// 				},
-		// 			},
-		// 			{
-		// 				Uri: &networking.StringMatch{
-		// 					MatchType: &networking.StringMatch_Exact{Exact: "/"},
-		// 				},
-		// 				Method: &networking.StringMatch{
-		// 					MatchType: &networking.StringMatch_Exact{Exact: "GET"},
-		// 				},
-		// 			},
-		// 		},
-		// 	}},
-		// }, valid: true, warning: false},
-		// {name: "jwt claim route without gateway", in: &networking.VirtualService{
-		// 	Hosts:    []string{"foo.bar"},
-		// 	Gateways: []string{"mesh"},
-		// 	Http: []*networking.HTTPRoute{{
-		// 		Route: []*networking.HTTPRouteDestination{{
-		// 			Destination: &networking.Destination{Host: "foo.baz"},
-		// 		}},
-		// 		Match: []*networking.HTTPMatchRequest{
-		// 			{
-		// 				Uri: &networking.StringMatch{
-		// 					MatchType: &networking.StringMatch_Prefix{Prefix: "/"},
-		// 				},
-		// 				Headers: map[string]*networking.StringMatch{
-		// 					"@request.auth.claims.foo": {
-		// 						MatchType: &networking.StringMatch_Exact{Exact: "bar"},
-		// 					},
-		// 				},
-		// 			},
-		// 		},
-		// 	}},
-		// }, valid: false, warning: false},
+		{name: "simple", in: &networking.VirtualService{
+			Hosts: []string{"foo.bar"},
+			Http: []*networking.HTTPRoute{{
+				Route: []*networking.HTTPRouteDestination{{
+					Destination: &networking.Destination{Host: "foo.baz"},
+				}},
+			}},
+		}, valid: true},
+		{name: "duplicate hosts", in: &networking.VirtualService{
+			Hosts: []string{"*.foo.bar", "*.bar"},
+			Http: []*networking.HTTPRoute{{
+				Route: []*networking.HTTPRouteDestination{{
+					Destination: &networking.Destination{Host: "foo.baz"},
+				}},
+			}},
+		}, valid: false},
+		{name: "with no destination", in: &networking.VirtualService{
+			Hosts: []string{"*.foo.bar", "*.bar"},
+			Http: []*networking.HTTPRoute{{
+				Route: []*networking.HTTPRouteDestination{{}},
+			}},
+		}, valid: false},
+		{name: "destination with out hosts", in: &networking.VirtualService{
+			Hosts: []string{"*.foo.bar", "*.bar"},
+			Http: []*networking.HTTPRoute{{
+				Route: []*networking.HTTPRouteDestination{{
+					Destination: &networking.Destination{},
+				}},
+			}},
+		}, valid: false},
+		{name: "delegate with no hosts", in: &networking.VirtualService{
+			Hosts: nil,
+			Http: []*networking.HTTPRoute{{
+				Route: []*networking.HTTPRouteDestination{{
+					Destination: &networking.Destination{Host: "foo.baz"},
+				}},
+			}},
+		}, valid: true},
+		{name: "bad host", in: &networking.VirtualService{
+			Hosts: []string{"foo.ba!r"},
+			Http: []*networking.HTTPRoute{{
+				Route: []*networking.HTTPRouteDestination{{
+					Destination: &networking.Destination{Host: "foo.baz"},
+				}},
+			}},
+		}, valid: false},
+		{name: "no tcp or http routing", in: &networking.VirtualService{
+			Hosts: []string{"foo.bar"},
+		}, valid: false},
+		{name: "bad gateway", in: &networking.VirtualService{
+			Hosts:    []string{"foo.bar"},
+			Gateways: []string{"b@dgateway"},
+			Http: []*networking.HTTPRoute{{
+				Route: []*networking.HTTPRouteDestination{{
+					Destination: &networking.Destination{Host: "foo.baz"},
+				}},
+			}},
+		}, valid: false},
+		{name: "FQDN for gateway", in: &networking.VirtualService{
+			Hosts:    []string{"foo.bar"},
+			Gateways: []string{"gateway.example.com"},
+			Http: []*networking.HTTPRoute{{
+				Route: []*networking.HTTPRouteDestination{{
+					Destination: &networking.Destination{Host: "foo.baz"},
+				}},
+			}},
+		}, valid: true, warning: true},
+		{name: "namespace/name for gateway", in: &networking.VirtualService{
+			Hosts:    []string{"foo.bar"},
+			Gateways: []string{"ns1/gateway"},
+			Http: []*networking.HTTPRoute{{
+				Route: []*networking.HTTPRouteDestination{{
+					Destination: &networking.Destination{Host: "foo.baz"},
+				}},
+			}},
+		}, valid: true},
+		{name: "namespace/* for gateway", in: &networking.VirtualService{
+			Hosts:    []string{"foo.bar"},
+			Gateways: []string{"ns1/*"},
+			Http: []*networking.HTTPRoute{{
+				Route: []*networking.HTTPRouteDestination{{
+					Destination: &networking.Destination{Host: "foo.baz"},
+				}},
+			}},
+		}, valid: false},
+		{name: "*/name for gateway", in: &networking.VirtualService{
+			Hosts:    []string{"foo.bar"},
+			Gateways: []string{"*/gateway"},
+			Http: []*networking.HTTPRoute{{
+				Route: []*networking.HTTPRouteDestination{{
+					Destination: &networking.Destination{Host: "foo.baz"},
+				}},
+			}},
+		}, valid: false},
+		{name: "wildcard for mesh gateway", in: &networking.VirtualService{
+			Hosts: []string{"*"},
+			Http: []*networking.HTTPRoute{{
+				Route: []*networking.HTTPRouteDestination{{
+					Destination: &networking.Destination{Host: "foo.baz"},
+				}},
+			}},
+		}, valid: false},
+		{name: "wildcard for non-mesh gateway", in: &networking.VirtualService{
+			Hosts:    []string{"*"},
+			Gateways: []string{"somegateway"},
+			Http: []*networking.HTTPRoute{{
+				Route: []*networking.HTTPRouteDestination{{
+					Destination: &networking.Destination{Host: "foo.baz"},
+				}},
+			}},
+		}, valid: true},
+		{name: "missing tcp route", in: &networking.VirtualService{
+			Hosts: []string{"foo.bar"},
+			Tcp: []*networking.TCPRoute{{
+				Match: []*networking.L4MatchAttributes{
+					{Port: 999},
+				},
+			}},
+		}, valid: false},
+		{name: "missing tls route", in: &networking.VirtualService{
+			Hosts: []string{"foo.bar"},
+			Tls: []*networking.TLSRoute{{
+				Match: []*networking.TLSMatchAttributes{
+					{
+						Port:     999,
+						SniHosts: []string{"foo.bar"},
+					},
+				},
+			}},
+		}, valid: false},
+		{name: "deprecated mirror", in: &networking.VirtualService{
+			Hosts:    []string{"foo.bar"},
+			Gateways: []string{"ns1/gateway"},
+			Http: []*networking.HTTPRoute{{
+				MirrorPercent: &types.UInt32Value{Value: 5},
+				Route: []*networking.HTTPRouteDestination{{
+					Destination: &networking.Destination{Host: "foo.baz"},
+				}},
+			}},
+		}, valid: true, warning: true},
+		{name: "set authority", in: &networking.VirtualService{
+			Hosts: []string{"foo.bar"},
+			Http: []*networking.HTTPRoute{{
+				Headers: &networking.Headers{
+					Request: &networking.Headers_HeaderOperations{Set: map[string]string{":authority": "foo"}},
+				},
+				Route: []*networking.HTTPRouteDestination{{
+					Destination: &networking.Destination{Host: "foo.baz"},
+				}},
+			}},
+		}, valid: true, warning: false},
+		{name: "set authority in destination", in: &networking.VirtualService{
+			Hosts: []string{"foo.bar"},
+			Http: []*networking.HTTPRoute{{
+				Route: []*networking.HTTPRouteDestination{{
+					Destination: &networking.Destination{Host: "foo.baz"},
+					Headers: &networking.Headers{
+						Request: &networking.Headers_HeaderOperations{Set: map[string]string{":authority": "foo"}},
+					},
+				}},
+			}},
+		}, valid: false, warning: false},
+		{name: "set authority in rewrite and header", in: &networking.VirtualService{
+			Hosts: []string{"foo.bar"},
+			Http: []*networking.HTTPRoute{{
+				Headers: &networking.Headers{
+					Request: &networking.Headers_HeaderOperations{Set: map[string]string{":authority": "foo"}},
+				},
+				Rewrite: &networking.HTTPRewrite{Authority: "bar"},
+				Route: []*networking.HTTPRouteDestination{{
+					Destination: &networking.Destination{Host: "foo.baz"},
+				}},
+			}},
+		}, valid: false, warning: false},
+		{name: "non-method-get", in: &networking.VirtualService{
+			Hosts: []string{"foo.bar"},
+			Http: []*networking.HTTPRoute{{
+				Route: []*networking.HTTPRouteDestination{{
+					Destination: &networking.Destination{Host: "foo.baz"},
+				}},
+				Match: []*networking.HTTPMatchRequest{
+					{
+						Uri: &networking.StringMatch{
+							MatchType: &networking.StringMatch_Prefix{Prefix: "/api/v1/product"},
+						},
+					},
+					{
+						Uri: &networking.StringMatch{
+							MatchType: &networking.StringMatch_Prefix{Prefix: "/api/v1/products"},
+						},
+						Method: &networking.StringMatch{
+							MatchType: &networking.StringMatch_Exact{Exact: "GET"},
+						},
+					},
+				},
+			}},
+		}, valid: true, warning: true},
+		{name: "uri-with-prefix-exact", in: &networking.VirtualService{
+			Hosts: []string{"foo.bar"},
+			Http: []*networking.HTTPRoute{{
+				Route: []*networking.HTTPRouteDestination{{
+					Destination: &networking.Destination{Host: "foo.baz"},
+				}},
+				Match: []*networking.HTTPMatchRequest{
+					{
+						Uri: &networking.StringMatch{
+							MatchType: &networking.StringMatch_Prefix{Prefix: "/"},
+						},
+					},
+					{
+						Uri: &networking.StringMatch{
+							MatchType: &networking.StringMatch_Exact{Exact: "/"},
+						},
+						Method: &networking.StringMatch{
+							MatchType: &networking.StringMatch_Exact{Exact: "GET"},
+						},
+					},
+				},
+			}},
+		}, valid: true, warning: false},
+		{name: "jwt claim route without gateway", in: &networking.VirtualService{
+			Hosts:    []string{"foo.bar"},
+			Gateways: []string{"mesh"},
+			Http: []*networking.HTTPRoute{{
+				Route: []*networking.HTTPRouteDestination{{
+					Destination: &networking.Destination{Host: "foo.baz"},
+				}},
+				Match: []*networking.HTTPMatchRequest{
+					{
+						Uri: &networking.StringMatch{
+							MatchType: &networking.StringMatch_Prefix{Prefix: "/"},
+						},
+						Headers: map[string]*networking.StringMatch{
+							"@request.auth.claims.foo": {
+								MatchType: &networking.StringMatch_Exact{Exact: "bar"},
+							},
+						},
+					},
+				},
+			}},
+		}, valid: false, warning: false},
 		{name: "ip address as sni host", in: &networking.VirtualService{
 			Hosts: []string{"foo.bar"},
 			Tls: []*networking.TLSRoute{{

--- a/releasenotes/notes/ip-sni-hosts.yaml
+++ b/releasenotes/notes/ip-sni-hosts.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: networking
+issue:
+- 33401
+releaseNotes:
+- |
+  **Added** warning messages for users attempting to use IP addresses as SNI values in VirtualService.TLSRoute.Match.SniHosts

--- a/releasenotes/notes/ip-sni-hosts.yaml
+++ b/releasenotes/notes/ip-sni-hosts.yaml
@@ -1,6 +1,6 @@
 apiVersion: release-notes/v2
-kind: feature
-area: networking
+kind: bug-fix
+area: traffic-management
 issue:
 - 33401
 releaseNotes:


### PR DESCRIPTION
**Please provide a description of this PR:**

Follow-up to discussion in here https://github.com/istio/istio/issues/33401#issuecomment-971788146, to prevent users from specifying an IP address in the `sniHosts` field of [VirtualService.TLSRoute.Match](https://github.com/istio/api/blob/0511549a0fae34380fdf1399075ccf51bc240be8/networking/v1alpha3/virtual_service.pb.go#L2131) since most clients will not include an IP address in the SNI.  Example of a VirtualService that will no longer pass validation:

```yaml
apiVersion: networking.istio.io/v1alpha3
kind: VirtualService
metadata:
  name: direct-cnn-through-egress-gateway
spec:
  hosts:
  - 1.2.3.4
  tls:
  - match:
    - gateways:
      - mesh
      port: 443
      sniHosts:
      - 1.2.3.4.  ## no longer valid
    route:
    - destination:
        host: istio-egressgateway.istio-system.svc.cluster.local
        port:
          number: 443
```

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ X ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure