### PR TITLE
experiment with more logs in ADS for tests

### DIFF
--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -32,7 +32,6 @@ import (
 	gogojsonpb "github.com/gogo/protobuf/jsonpb"
 	any "google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/structpb"
-
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
 	istionetworking "istio.io/istio/pilot/pkg/networking"
@@ -793,6 +792,7 @@ func (node *Proxy) SetSidecarScope(ps *PushContext) {
 		// Gateways should just have a default scope with egress: */*
 		node.SidecarScope = ps.getSidecarScope(node, nil)
 	}
+	log.Errorf("howardjohn: %v set proxy stat: %v", node.ID, ps.PushVersion)
 	node.PrevSidecarScope = sidecarScope
 	// Build CatchAllVirtualHost and cache it. This depends on sidecar scope config.
 	node.BuildCatchAllVirtualHost()

--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -629,7 +629,7 @@ func (s *DiscoveryServer) computeProxyState(proxy *model.Proxy, request *model.P
 		}
 		for conf := range request.ConfigsUpdated {
 			switch conf.Kind {
-			case gvk.ServiceEntry, gvk.DestinationRule, gvk.VirtualService, gvk.Sidecar, gvk.HTTPRoute, gvk.TCPRoute:
+			case gvk.ServiceEntry, gvk.DestinationRule, gvk.VirtualService, gvk.Sidecar, gvk.HTTPRoute, gvk.TCPRoute, gvk.TLSRoute:
 				sidecar = true
 			case gvk.Gateway, gvk.KubernetesGateway, gvk.GatewayClass:
 				gateway = true
@@ -689,7 +689,7 @@ func (s *DiscoveryServer) pushConnection(con *Connection, pushEv *Event) error {
 	}
 
 	if !s.ProxyNeedsPush(con.proxy, pushRequest) {
-		log.Debugf("Skipping push to %v, no updates required", con.ConID)
+		log.Infof("Skipping push to %v, no updates required", con.ConID)
 		if pushRequest.Full {
 			// Only report for full versions, incremental pushes do not have a new version.
 			reportAllEvents(s.StatusReporter, con.ConID, pushRequest.Push.LedgerVersion, nil)

--- a/tools/docker-builder/main.go
+++ b/tools/docker-builder/main.go
@@ -58,7 +58,12 @@ func main() {
 	}
 }
 
-var privilegedHubs = sets.NewSet("docker.io/istio", "istio", "gcr.io/istio-release")
+var privilegedHubs = sets.NewSet(
+	"docker.io/istio",
+	"istio",
+	"gcr.io/istio-release",
+	"gcr.io/istio-testing",
+)
 
 var rootCmd = &cobra.Command{
 	SilenceUsage: true,


### PR DESCRIPTION
Hypothesis:
* We generate push v1 with cfg clusterLocal
* We generate push v2 with cfg non clusterLocal
* We generate push v3 with DR
* We generate push v4 with no DR
* ... not sure... lost my idea

Seeing two weird things:
* We have subsets for each cluster, and these configs have endpoints for all other clusters. Should be filtered
* We see debounce for DR once. Should be once to add it, once to remove it
I think there is some mangling between proxy state when there are close push requests and pushes. Possibly here: https://github.com/istio/istio/blob/38807d67c45c48630bf3a7c8d7b03a09a80408d5/pilot/pkg/xds/ads.go#L620. Not 100% sure how yet