### PR TITLE
Reduce test duration for google mock CA

### DIFF
--- a/security/pkg/nodeagent/caclient/providers/google-cas/mock/ca_mock.go
+++ b/security/pkg/nodeagent/caclient/providers/google-cas/mock/ca_mock.go
@@ -156,7 +156,7 @@ func CreateServer(service *CASService) (*CASServer, *bufconn.Listener, error) {
 	}()
 
 	select {
-	case <-time.After(1 * time.Second):
+	case <-time.After(100 * time.Millisecond):
 		err = nil
 	case err = <-serveErr:
 	}

--- a/security/pkg/nodeagent/caclient/providers/google/mock/ca_mock.go
+++ b/security/pkg/nodeagent/caclient/providers/google/mock/ca_mock.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"time"
 
 	"google.golang.org/grpc"
 
@@ -69,9 +68,6 @@ func CreateServer(addr string, service *CAService) (*CAServer, error) {
 		}
 	}()
 
-	// The goroutine starting the server may not be ready, results in flakiness
-	// This extra delay ensures that the future grpc dial does not fail in the worst case scenario
-	time.Sleep(100 * time.Millisecond)
 	if serveErr != nil {
 		return nil, err
 	}

--- a/security/pkg/nodeagent/caclient/providers/google/mock/ca_mock.go
+++ b/security/pkg/nodeagent/caclient/providers/google/mock/ca_mock.go
@@ -62,15 +62,16 @@ func CreateServer(addr string, service *CAService) (*CAServer, error) {
 	s.Address = lis.Addr().String()
 
 	var serveErr error
+	gcapb.RegisterMeshCertificateServiceServer(s.Server, service)
 	go func() {
-		gcapb.RegisterMeshCertificateServiceServer(s.Server, service)
 		if err := s.Server.Serve(lis); err != nil {
 			serveErr = err
 		}
 	}()
 
-	// The goroutine starting the server may not be ready, results in flakiness.
-	time.Sleep(1 * time.Second)
+	// The goroutine starting the server may not be ready, results in flakiness
+	// This extra delay ensures that the future grpc dial does not fail in the worst case scenario
+	time.Sleep(100 * time.Millisecond)
 	if serveErr != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Reduce the sleep delay for the mock CA server. The reason for the flakiness is the time it takes until the [first listener accept call](https://github.com/grpc/grpc-go/blob/v1.44.0/server.go#L779) which should not take over 1 second.

Tested on 1000 retries on my local machine.

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [x] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
