### PR TITLE
Enable metallb LoadBalancer for Kind dual-stack

### DIFF
--- a/prow/integ-suite-kind.sh
+++ b/prow/integ-suite-kind.sh
@@ -107,8 +107,12 @@ grep 'model' /proc/cpuinfo
 # Default IP family of the cluster is IPv4
 export IP_FAMILY="${IP_FAMILY:-ipv4}"
 
+#Kind will not have a LoadBalancer, so we need to disable it
+export TEST_ENV=kind
 # LoadBalancer in Kind is supported using metallb
-export TEST_ENV=kind-metallb
+if [ "${IP_FAMILY}" == "ipv4" ] || [ "${IP_FAMILY}" == "dual" ]; then
+  export TEST_ENV=kind-metallb
+fi
 
 # See https://kind.sigs.k8s.io/docs/user/quick-start/#loading-an-image-into-your-cluster
 export PULL_POLICY=IfNotPresent


### PR DESCRIPTION
**Please provide a description of this PR:**
First steps in https://github.com/istio/istio/issues/37533. This will start allowing dual-stack integration tests to run.
Requires https://github.com/istio/common-files/pull/540