### PR TITLE
Skip recompute SidecarScope if push version equals SidecarScope version

### DIFF
--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -786,7 +786,7 @@ func (node *Proxy) ServiceNode() string {
 func (node *Proxy) SetSidecarScope(ps *PushContext) {
 	// If SidecarScope has been computed for the pushContext, skip recomputing.
 	// https://github.com/istio/istio/issues/36791#issuecomment-1054832155 (Bug 2)
-	if node.SidecarScope != nil && ps.PushVersion == node.SidecarScope.Version {
+	if node.SidecarScope != nil && ps.PushVersion != "" && ps.PushVersion == node.SidecarScope.Version {
 		return
 	}
 	node.PrevSidecarScope = node.SidecarScope


### PR DESCRIPTION
**Please provide a description of this PR:**


Fix [TestClusterLocal flakes bug 2](https://github.com/istio/istio/issues/36791#)https://github.com/istio/istio/issues/36791


cc @howardjohn 


**Please check any characteristics that apply to this pull request.**

- [ x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.