### PR TITLE
Speed up TestK8sSignWithMeshConfig

### DIFF
--- a/security/pkg/pki/ra/k8s_ra_test.go
+++ b/security/pkg/pki/ra/k8s_ra_test.go
@@ -15,6 +15,7 @@
 package ra
 
 import (
+	"context"
 	"os"
 	"path"
 	"testing"
@@ -22,14 +23,12 @@ import (
 
 	cert "k8s.io/api/certificates/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/kubernetes/fake"
-	kt "k8s.io/client-go/testing"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
+	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/spiffe"
+	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/env"
-	"istio.io/istio/security/pkg/k8s/chiron"
 	"istio.io/istio/security/pkg/pki/ca"
 	pkiutil "istio.io/istio/security/pkg/pki/util"
 )
@@ -63,88 +62,87 @@ var (
 	mismatchCertChainFile string = "../testdata/cert-chain.pem"
 )
 
-func defaultReactionFunc(obj runtime.Object) kt.ReactionFunc {
-	return func(act kt.Action) (bool, runtime.Object, error) {
-		return true, obj, nil
-	}
-}
-
 func TestK8sSignWithMeshConfig(t *testing.T) {
-	cases := map[string]struct {
+	cases := []struct {
+		name                         string
 		rootCertForMeshConfig        string
 		certChain                    string
 		updatedRootCertForMeshConfig string
 		expectedFail                 bool
 	}{
-		"Root cert from mesh config and cert chain does not match": {
+		{
+			name:                  "Root cert from mesh config and cert chain does not match",
 			rootCertForMeshConfig: path.Join(env.IstioSrc, "samples/certs", "root-cert.pem"),
 			certChain:             mismatchCertChainFile,
 			expectedFail:          true,
 		},
-		"Root cert is specified in mesh config and Root cert from cert chain is empty(only one leaf cert)": {
+		{
+			name:                  "Root cert is specified in mesh config and Root cert from cert chain is empty(only one leaf cert)",
 			rootCertForMeshConfig: path.Join(env.IstioSrc, "samples/certs", "root-cert.pem"),
 			certChain:             path.Join(env.IstioSrc, "samples/certs", "cert-chain.pem"),
 		},
-		"Root cert is specified in mesh config and cert chain contains only intermediate CA(only leaf cert + intermediate CA) ": {
+		{
+			name:                  "Root cert is specified in mesh config and cert chain contains only intermediate CA(only leaf cert + intermediate CA) ",
 			rootCertForMeshConfig: path.Join(env.IstioSrc, "samples/certs", "root-cert.pem"),
 			certChain:             path.Join(env.IstioSrc, "samples/certs", "workload-foo-cert.pem"),
 		},
-		"Root cert is specified in mesh config and be updated to an invalid value": {
+		{
+			name:                         "Root cert is specified in mesh config and be updated to an invalid value",
 			rootCertForMeshConfig:        path.Join(env.IstioSrc, "samples/certs", "root-cert.pem"),
 			certChain:                    path.Join(env.IstioSrc, "samples/certs", "cert-chain.pem"),
 			updatedRootCertForMeshConfig: TestCACertFile,
 			expectedFail:                 true,
 		},
 	}
-	for id, tc := range cases {
-		csrPEM := createFakeCsr(t)
-		csrName := chiron.GenCsrName()
-		rootCertPem, err := os.ReadFile(tc.rootCertForMeshConfig)
-		if err != nil {
-			t.Errorf("Failed to read sample root-cert.pem")
-		}
-		certChainPem, err := os.ReadFile(tc.certChain)
-		if err != nil {
-			t.Errorf("Failed to read sample cert-chain.pem")
-		}
-		client := initFakeKubeClient(csrName, string(certChainPem))
-		ra, err := createFakeK8sRA(client, "")
-		if err != nil {
-			t.Errorf("Failed to create Fake K8s RA")
-		}
-		signer := "kubernates.io/kube-apiserver-client"
-		ra.certSignerDomain = "kubernates.io"
-		caCertificates := []*meshconfig.MeshConfig_CertificateData{
-			{CertificateData: &meshconfig.MeshConfig_CertificateData_Pem{Pem: string(rootCertPem)}, CertSigners: []string{signer}},
-		}
-		ra.SetCACertificatesFromMeshConfig(caCertificates)
-		subjectID := spiffe.Identity{TrustDomain: "cluster.local", Namespace: "default", ServiceAccount: "bookinfo-productpage"}.String()
-		certOptions := ca.CertOpts{
-			SubjectIDs: []string{subjectID},
-			TTL:        60 * time.Second, ForCA: false,
-			CertSigner: "kube-apiserver-client",
-		}
-		// expect to sign back successfully
-		_, err = ra.SignWithCertChain(csrPEM, certOptions)
-		if err != nil && !tc.expectedFail {
-			t.Errorf("%s failed", id)
-		}
-		if tc.updatedRootCertForMeshConfig != "" {
-			testCACert, err := os.ReadFile(tc.updatedRootCertForMeshConfig)
-			if err != nil && !tc.expectedFail {
-				t.Errorf("Failed to read test CA Cert file")
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			csrPEM := createFakeCsr(t)
+			rootCertPem, err := os.ReadFile(tc.rootCertForMeshConfig)
+			if err != nil {
+				t.Errorf("Failed to read sample root-cert.pem")
 			}
-			updatedCACertificates := []*meshconfig.MeshConfig_CertificateData{
-				{CertificateData: &meshconfig.MeshConfig_CertificateData_Pem{Pem: string(testCACert)}, CertSigners: []string{signer}},
+			certChainPem, err := os.ReadFile(tc.certChain)
+			if err != nil {
+				t.Errorf("Failed to read sample cert-chain.pem")
 			}
-			ra.SetCACertificatesFromMeshConfig(updatedCACertificates)
-			// expect failure in sign since root cert in mesh config does not match
+			client := initFakeKubeClient(t, certChainPem)
+			ra, err := createFakeK8sRA(client, "")
+			if err != nil {
+				t.Errorf("Failed to create Fake K8s RA")
+			}
+			signer := "kubernates.io/kube-apiserver-client"
+			ra.certSignerDomain = "kubernates.io"
+			caCertificates := []*meshconfig.MeshConfig_CertificateData{
+				{CertificateData: &meshconfig.MeshConfig_CertificateData_Pem{Pem: string(rootCertPem)}, CertSigners: []string{signer}},
+			}
+			ra.SetCACertificatesFromMeshConfig(caCertificates)
+			subjectID := spiffe.Identity{TrustDomain: "cluster.local", Namespace: "default", ServiceAccount: "bookinfo-productpage"}.String()
+			certOptions := ca.CertOpts{
+				SubjectIDs: []string{subjectID},
+				TTL:        60 * time.Second, ForCA: false,
+				CertSigner: "kube-apiserver-client",
+			}
+			// expect to sign back successfully
 			_, err = ra.SignWithCertChain(csrPEM, certOptions)
-			if err == nil && !tc.expectedFail {
-				t.Errorf("%s failed", id)
+			if err != nil && !tc.expectedFail {
+				t.Fatal(err)
 			}
-		}
-
+			if tc.updatedRootCertForMeshConfig != "" {
+				testCACert, err := os.ReadFile(tc.updatedRootCertForMeshConfig)
+				if err != nil && !tc.expectedFail {
+					t.Errorf("Failed to read test CA Cert file")
+				}
+				updatedCACertificates := []*meshconfig.MeshConfig_CertificateData{
+					{CertificateData: &meshconfig.MeshConfig_CertificateData_Pem{Pem: string(testCACert)}, CertSigners: []string{signer}},
+				}
+				ra.SetCACertificatesFromMeshConfig(updatedCACertificates)
+				// expect failure in sign since root cert in mesh config does not match
+				_, err = ra.SignWithCertChain(csrPEM, certOptions)
+				if err == nil && !tc.expectedFail {
+					t.Fatalf("expected failed, got none")
+				}
+			}
+		})
 	}
 }
 
@@ -163,21 +161,30 @@ func createFakeCsr(t *testing.T) []byte {
 	return csrPEM
 }
 
-func initFakeKubeClient(csrName, certificate string) *fake.Clientset {
-	client := fake.NewSimpleClientset()
-	csr := &cert.CertificateSigningRequest{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: csrName,
-		},
-		Status: cert.CertificateSigningRequestStatus{
-			Certificate: []byte(certificate),
-		},
-	}
-	client.PrependReactor("get", "certificatesigningrequests", defaultReactionFunc(csr))
+func initFakeKubeClient(t test.Failer, certificate []byte) kube.ExtendedClient {
+	client := kube.NewFakeClient()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	w, _ := client.CertificatesV1().CertificateSigningRequests().Watch(ctx, metav1.ListOptions{})
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case r := <-w.ResultChan():
+				csr := r.Object.(*cert.CertificateSigningRequest).DeepCopy()
+				if csr.Status.Certificate != nil {
+					continue
+				}
+				csr.Status.Certificate = certificate
+				client.CertificatesV1().CertificateSigningRequests().UpdateStatus(ctx, csr, metav1.UpdateOptions{})
+			}
+		}
+	}()
 	return client
 }
 
-func createFakeK8sRA(client *fake.Clientset, caCertFile string) (*KubernetesRA, error) {
+func createFakeK8sRA(client kube.Client, caCertFile string) (*KubernetesRA, error) {
 	defaultCertTTL := 30 * time.Minute
 	maxCertTTL := time.Hour
 	caSigner := "kubernates.io/kube-apiserver-client"
@@ -196,8 +203,7 @@ func createFakeK8sRA(client *fake.Clientset, caCertFile string) (*KubernetesRA, 
 // TestK8sSign : Verify that ra.k8sSign returns a valid certPEM while using k8s Fake Client to create a CSR
 func TestK8sSign(t *testing.T) {
 	csrPEM := createFakeCsr(t)
-	csrName := chiron.GenCsrName()
-	client := initFakeKubeClient(csrName, TestCertificatePEM)
+	client := initFakeKubeClient(t, []byte(TestCertificatePEM))
 	r, err := createFakeK8sRA(client, TestCACertFile)
 	if err != nil {
 		t.Errorf("Validation CSR failed")
@@ -214,8 +220,7 @@ func TestK8sSign(t *testing.T) {
 
 func TestValidateCSR(t *testing.T) {
 	csrPEM := createFakeCsr(t)
-	csrName := chiron.GenCsrName()
-	client := initFakeKubeClient(csrName, TestCertificatePEM)
+	client := initFakeKubeClient(t, []byte(TestCertificatePEM))
 	_, err := createFakeK8sRA(client, TestCACertFile)
 	if err != nil {
 		t.Errorf("Validation CSR failed")

--- a/security/pkg/pki/ra/leak_test.go
+++ b/security/pkg/pki/ra/leak_test.go
@@ -1,0 +1,26 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ra
+
+import (
+	"testing"
+
+	"istio.io/istio/tests/util/leak"
+)
+
+func TestMain(m *testing.M) {
+	// CheckMain asserts that no goroutines are leaked after a test package exits.
+	leak.CheckMain(m)
+}


### PR DESCRIPTION
for https://github.com/istio/istio/issues/37555

Before this test took 25s. Now its ~instant. This was because we used Watches incorrectly, so it always hit 5s timeout