### PR TITLE
retry: fix default backoff

### DIFF
--- a/pkg/test/util/retry/retry.go
+++ b/pkg/test/util/retry/retry.go
@@ -39,7 +39,7 @@ const (
 var defaultConfig = config{
 	timeout:  DefaultTimeout,
 	delay:    DefaultDelay,
-	delayMax: DefaultDelay,
+	delayMax: DefaultDelay * 16,
 	converge: DefaultConverge,
 }
 
@@ -72,7 +72,7 @@ func Delay(delay time.Duration) Option {
 func BackoffDelay(delay time.Duration) Option {
 	return func(cfg *config) {
 		cfg.delay = delay
-		// Currently, hardcode to 4 backoffs. We can make it configurable if needed
+		// Currently, hardcode to 16 backoffs. We can make it configurable if needed
 		cfg.delayMax = delay * 16
 	}
 }


### PR DESCRIPTION
Before we set max to the base. Instead set it to 16*base, just like
explicit calls

**Please provide a description of this PR:**