### PR TITLE
tf: cleanup usages of Workload

### DIFF
--- a/pkg/test/framework/components/echo/calloptions.go
+++ b/pkg/test/framework/components/echo/calloptions.go
@@ -97,8 +97,14 @@ type Target interface {
 
 // CallOptions defines options for calling a Endpoint.
 type CallOptions struct {
-	// To is the Target to be called. Required.
+	// To is the Target to be called.
 	To Target
+
+	// ToWorkload will call a specific workload in this instance, rather than the Service.
+	// If there are multiple workloads in the Instance, the first is used.
+	// Can be used with `ToWorkload: to.WithWorkloads(someWl)` to send to a specific workload.
+	// When using the Port field, the ServicePort should be used.
+	ToWorkload Instance
 
 	// Port to be used for the call. Ignored if Scheme == DNS. If the Port.ServicePort is set,
 	// either Port.Protocol or Scheme must also be set. If Port.ServicePort is not set,
@@ -215,12 +221,21 @@ func (o *CallOptions) FillDefaults() error {
 
 func (o *CallOptions) fillAddress() error {
 	if o.Address == "" {
-		if o.To == nil {
-			return errors.New("if address is not set, then To must be set")
+		if o.To != nil {
+			// No host specified, use the fully qualified domain name for the service.
+			o.Address = o.To.Config().ClusterLocalFQDN()
+			return nil
+		}
+		if o.ToWorkload != nil {
+			wl, err := o.ToWorkload.Workloads()
+			if err != nil {
+				return err
+			}
+			o.Address = wl[0].Address()
+			return nil
 		}
 
-		// No host specified, use the fully qualified domain name for the service.
-		o.Address = o.To.Config().ClusterLocalFQDN()
+		return errors.New("if address is not set, then To must be set")
 	}
 	return nil
 }
@@ -241,33 +256,57 @@ func (o *CallOptions) fillPort() error {
 	}
 
 	if o.To != nil {
-		servicePorts := o.To.Config().Ports.GetServicePorts()
-
-		if o.Port.Name != "" {
-			// Look up the port by name.
-			p, found := servicePorts.ForName(o.Port.Name)
-			if !found {
-				return fmt.Errorf("callOptions: no port named %s available in To Instance", o.Port.Name)
-			}
-			o.Port = p
-			return nil
+		return o.fillPort2(o.To)
+	} else if o.ToWorkload != nil {
+		err := o.fillPort2(o.ToWorkload)
+		if err != nil {
+			return err
 		}
-
-		if o.Port.Protocol != "" {
-			// Look up the port by protocol.
-			p, found := servicePorts.ForProtocol(o.Port.Protocol)
-			if !found {
-				return fmt.Errorf("callOptions: no port for protocol %s available in To Instance", o.Port.Protocol)
-			}
-			o.Port = p
-			return nil
-		}
+		// Set the ServicePort to workload port since we are not reaching it through the Service
+		p := o.Port
+		p.ServicePort = p.WorkloadPort
+		o.Port = p
 	}
 
 	if o.Port.ServicePort <= 0 || (o.Port.Protocol == "" && o.Scheme == "") || o.Address == "" {
 		return fmt.Errorf("if target is not set, then port.servicePort, port.protocol or schema, and address must be set")
 	}
 
+	return nil
+}
+
+func (o *CallOptions) fillPort2(target Target) error {
+	servicePorts := target.Config().Ports.GetServicePorts()
+
+	if o.Port.Name != "" {
+		// Look up the port by name.
+		p, found := servicePorts.ForName(o.Port.Name)
+		if !found {
+			return fmt.Errorf("callOptions: no port named %s available in To Instance", o.Port.Name)
+		}
+		o.Port = p
+		return nil
+	}
+
+	if o.Port.Protocol != "" {
+		// Look up the port by protocol.
+		p, found := servicePorts.ForProtocol(o.Port.Protocol)
+		if !found {
+			return fmt.Errorf("callOptions: no port for protocol %s available in To Instance", o.Port.Protocol)
+		}
+		o.Port = p
+		return nil
+	}
+
+	if o.Port.ServicePort != 0 {
+		// We just have a single port number, populate the rest of the fields
+		p, found := servicePorts.ForServicePort(o.Port.ServicePort)
+		if !found {
+			return fmt.Errorf("callOptions: no port %d available in To Instance", o.Port.ServicePort)
+		}
+		o.Port = p
+		return nil
+	}
 	return nil
 }
 
@@ -283,6 +322,9 @@ func (o *CallOptions) fillScheme() error {
 }
 
 func (o *CallOptions) fillHeaders() {
+	if o.ToWorkload != nil {
+		return
+	}
 	// Initialize the headers and add a default Host header if none provided.
 	if o.HTTP.Headers == nil {
 		o.HTTP.Headers = make(http.Header)

--- a/pkg/test/framework/components/echo/check/checkers.go
+++ b/pkg/test/framework/components/echo/check/checkers.go
@@ -117,6 +117,24 @@ func ErrorContains(expected string) echo.Checker {
 	}
 }
 
+func ErrorOrStatus(expected int) echo.Checker {
+	expectedStr := ""
+	if expected > 0 {
+		expectedStr = strconv.Itoa(expected)
+	}
+	return func(resp echo.CallResult, err error) error {
+		if err != nil {
+			return nil
+		}
+		for _, r := range resp.Responses {
+			if r.Code != expectedStr {
+				return fmt.Errorf("expected response code `%s`, got %q", expectedStr, r.Code)
+			}
+		}
+		return nil
+	}
+}
+
 // OK is a shorthand for NoErrorAndStatus(200).
 func OK() echo.Checker {
 	return NoErrorAndStatus(http.StatusOK)

--- a/pkg/test/framework/components/echo/echotest/filters_test.go
+++ b/pkg/test/framework/components/echo/echotest/filters_test.go
@@ -328,6 +328,10 @@ func instanceKey(i echo.Instance) string {
 // fakeInstance wraps echo.Config for test-framework internals tests where we don't actually make calls
 type fakeInstance echo.Config
 
+func (f fakeInstance) WithWorkloads(wl ...echo.Workload) echo.Instance {
+	panic("implement me")
+}
+
 func (f fakeInstance) Instances() echo.Instances {
 	return echo.Instances{f}
 }

--- a/pkg/test/framework/components/echo/instance.go
+++ b/pkg/test/framework/components/echo/instance.go
@@ -32,4 +32,7 @@ type Instance interface {
 
 	// Restart restarts the workloads associated with this echo instance
 	Restart() error
+
+	// WithWorkloads returns a target with only the specified subset of workloads
+	WithWorkloads(wl ...Workload) Instance
 }

--- a/pkg/test/framework/components/echo/match/matchers_test.go
+++ b/pkg/test/framework/components/echo/match/matchers_test.go
@@ -95,6 +95,11 @@ var _ echo.Instance = fakeInstance{}
 // fakeInstance wraps echo.Config for test-framework internals tests where we don't actually make calls
 type fakeInstance echo.Config
 
+func (f fakeInstance) WithWorkloads(wl ...echo.Workload) echo.Instance {
+	// TODO implement me
+	panic("implement me")
+}
+
 func (f fakeInstance) Instances() echo.Instances {
 	return echo.Instances{f}
 }

--- a/pkg/test/framework/components/echo/port.go
+++ b/pkg/test/framework/components/echo/port.go
@@ -118,6 +118,16 @@ func (ps Ports) ForProtocol(protocol protocol.Instance) (Port, bool) {
 	return Port{}, false
 }
 
+// ForServicePort returns the first port found with the given service port.
+func (ps Ports) ForServicePort(port int) (Port, bool) {
+	for _, p := range ps {
+		if p.ServicePort == port {
+			return p, true
+		}
+	}
+	return Port{}, false
+}
+
 // MustForProtocol calls ForProtocol and panics if not found.
 func (ps Ports) MustForProtocol(protocol protocol.Instance) Port {
 	p, found := ps.ForProtocol(protocol)

--- a/pkg/test/framework/components/echo/staticvm/instance.go
+++ b/pkg/test/framework/components/echo/staticvm/instance.go
@@ -39,10 +39,11 @@ func init() {
 }
 
 type instance struct {
-	id        resource.ID
-	config    echo.Config
-	address   string
-	workloads echo.Workloads
+	id             resource.ID
+	config         echo.Config
+	address        string
+	workloads      echo.Workloads
+	workloadFilter []echo.Workload
 }
 
 func newInstances(ctx resource.Context, config []echo.Config) (echo.Instances, error) {
@@ -128,8 +129,27 @@ func (i *instance) Addresses() []string {
 	return []string{i.address}
 }
 
+func (i *instance) WithWorkloads(wls ...echo.Workload) echo.Instance {
+	n := *i
+	i.workloadFilter = wls
+	return &n
+}
+
 func (i *instance) Workloads() (echo.Workloads, error) {
-	return i.workloads, nil
+	final := []echo.Workload{}
+	for _, wl := range i.workloads {
+		filtered := false
+		for _, filter := range i.workloadFilter {
+			if wl.Address() != filter.Address() {
+				filtered = true
+				break
+			}
+		}
+		if !filtered {
+			final = append(final, wl)
+		}
+	}
+	return final, nil
 }
 
 func (i *instance) WorkloadsOrFail(t test.Failer) echo.Workloads {
@@ -161,7 +181,11 @@ func (i *instance) Instances() echo.Instances {
 }
 
 func (i *instance) defaultClient() (*echoClient.Client, error) {
-	return i.workloads[0].(*workload).Client, nil
+	wl, err := i.Workloads()
+	if err != nil {
+		return nil, err
+	}
+	return wl[0].(*workload).Client, nil
 }
 
 func (i *instance) Call(opts echo.CallOptions) (echo.CallResult, error) {

--- a/tests/integration/security/ca_custom_root/trust_domain_validation_test.go
+++ b/tests/integration/security/ca_custom_root/trust_domain_validation_test.go
@@ -18,22 +18,17 @@
 package cacustomroot
 
 import (
-	"context"
 	"fmt"
-	"net"
 	"os"
 	"path"
 	"testing"
-	"time"
 
 	"istio.io/istio/pkg/test/echo/common/scheme"
-	epb "istio.io/istio/pkg/test/echo/proto"
 	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/echo/check"
 	"istio.io/istio/pkg/test/framework/components/echo/match"
-	"istio.io/istio/pkg/test/util/retry"
 )
 
 const (
@@ -145,34 +140,23 @@ func TestTrustDomainValidation(t *testing.T) {
 									Cert: trustDomains[td].cert,
 									Key:  trustDomains[td].key,
 								},
-								Retry: echo.Retry{
-									NoRetry: true,
-								},
 							}
-							retry.UntilSuccessOrFail(t, func() error {
-								result := echo.CallResult{
-									From: from,
-									Opts: opt,
+							if port == passThrough {
+								// Manually make the request for pass through port.
+								opt = echo.CallOptions{
+									ToWorkload: server,
+									Port:       echo.Port{Name: tcpWL},
+									TLS: echo.TLS{
+										Cert: trustDomains[td].cert,
+										Key:  trustDomains[td].key,
+									},
+									Check: check.OK(),
 								}
-								var err error
-								if port == passThrough {
-									// Manually make the request for pass through port.
-									fromWorkload := from.WorkloadsOrFail(t)[0]
-									toWorkload := server.WorkloadsOrFail(t)[0]
-									result.Responses, err = fromWorkload.ForwardEcho(context.TODO(), &epb.ForwardEchoRequest{
-										Url:   fmt.Sprintf("tcp://%s", net.JoinHostPort(toWorkload.Address(), "9000")),
-										Count: 1,
-										Cert:  trustDomains[td].cert,
-										Key:   trustDomains[td].key,
-									})
-								} else {
-									result, err = from.Call(opt)
-								}
-								if allow {
-									return check.OK().Check(result, err)
-								}
-								return check.ErrorContains("tls: unknown certificate").Check(result, err)
-							}, retry.Delay(250*time.Millisecond), retry.Timeout(30*time.Second), retry.Converge(5))
+							}
+							if !allow {
+								opt.Check = check.ErrorContains("tls: unknown certificate")
+							}
+							from.CallOrFail(t, opt)
 						})
 					}
 

--- a/tests/integration/security/pass_through_filter_chain_test.go
+++ b/tests/integration/security/pass_through_filter_chain_test.go
@@ -23,7 +23,6 @@ import (
 	"testing"
 
 	"istio.io/istio/pkg/config/protocol"
-	"istio.io/istio/pkg/http/headers"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/echo/check"
@@ -646,41 +645,19 @@ spec:
 								if from.Config().IsNaked() {
 									want = expect.plaintextSucceeds
 								}
+								c := check.OK()
+								if !want {
+									c = check.ErrorOrStatus(http.StatusForbidden)
+								}
 								name := fmt.Sprintf("%v/port %d[%t]", nameSuffix, expect.port.ServicePort, want)
-								host := fmt.Sprintf("%s:%d", to.WorkloadsOrFail(t)[0].Address(), expect.port.ServicePort)
 								callOpt := echo.CallOptions{
-									Count: util.CallsPerCluster * to.WorkloadsOrFail(t).Len(),
-									Port:  expect.port,
-									HTTP: echo.HTTP{
-										Headers: headers.New().WithHost(host).Build(),
-									},
+									Count:   util.CallsPerCluster * to.WorkloadsOrFail(t).Len(),
+									Port:    expect.port,
 									Message: "HelloWorld",
 									// Do not set To to dest, otherwise fillInCallOptions() will
 									// complain with port does not match.
-									Address: to.WorkloadsOrFail(t)[0].Address(),
-									Check: func(result echo.CallResult, err error) error {
-										if want {
-											if err != nil {
-												return fmt.Errorf("want allow but got error: %v", err)
-											}
-											if result.Responses.Len() < 1 {
-												return fmt.Errorf("received no responses from request to %s", host)
-											}
-											if okErr := check.OK().Check(result, err); okErr != nil && expect.port.Protocol == protocol.HTTP {
-												return fmt.Errorf("want status %d but got %s", http.StatusOK, okErr.Error())
-											}
-										} else {
-											// Check HTTP forbidden response
-											if result.Responses.Len() >= 1 && check.Status(http.StatusForbidden).Check(result, err) == nil {
-												return nil
-											}
-
-											if err == nil {
-												return fmt.Errorf("want error but got none: %v", result.Responses.String())
-											}
-										}
-										return nil
-									},
+									ToWorkload: to.Instances()[0],
+									Check:      c,
 								}
 								t.NewSubTest(name).Run(func(t framework.TestContext) {
 									from.CallOrFail(t, callOpt)

--- a/tests/integration/telemetry/stats/prometheus/stats.go
+++ b/tests/integration/telemetry/stats/prometheus/stats.go
@@ -151,9 +151,9 @@ func TestStatsFilter(t *testing.T, feature features.Feature) {
 			for _, prom := range mockProm {
 				st := match.Cluster(prom.Config().Cluster).FirstOrFail(t, server)
 				prom.CallOrFail(t, echo.CallOptions{
-					Address: st.WorkloadsOrFail(t)[0].Address(),
-					Scheme:  scheme.HTTPS,
-					Port:    echo.Port{ServicePort: 15014},
+					ToWorkload: st,
+					Scheme:     scheme.HTTPS,
+					Port:       echo.Port{ServicePort: 15014},
 					HTTP: echo.HTTP{
 						Path: "/metrics",
 					},


### PR DESCRIPTION

This introduces a new TargetWorkload entry to call *pods* rather than
*services*. And cleans up a bunch of usages where we use to do things
the hard way