### PR TITLE
Update --no-clobber to not check existence of tag `latest`

### DIFF
--- a/tools/build-base-images.sh
+++ b/tools/build-base-images.sh
@@ -37,4 +37,4 @@ DOCKER_TARGETS="${DOCKER_TARGETS:-base,distroless,app_sidecar_base_debian_9,app_
 # * docker buildx create --name multi-arch --platform linux/amd64,linux/arm64 --use
 # * export DOCKER_ARCHITECTURES="linux/amd64,linux/arm64"
 # Note: if you already have a container builder before running the qemu setup you will need to restart them
-"${ROOT}/tools/docker" --push --no-cache --targets="${DOCKER_TARGETS}"
+"${ROOT}/tools/docker" --push --no-cache --no-clobber --targets="${DOCKER_TARGETS}"

--- a/tools/build-base-images.sh
+++ b/tools/build-base-images.sh
@@ -37,4 +37,4 @@ DOCKER_TARGETS="${DOCKER_TARGETS:-base,distroless,app_sidecar_base_debian_9,app_
 # * docker buildx create --name multi-arch --platform linux/amd64,linux/arm64 --use
 # * export DOCKER_ARCHITECTURES="linux/amd64,linux/arm64"
 # Note: if you already have a container builder before running the qemu setup you will need to restart them
-"${ROOT}/tools/docker" --push --no-cache --no-clobber --targets="${DOCKER_TARGETS}"
+"${ROOT}/tools/docker" --push --no-cache --targets="${DOCKER_TARGETS}"

--- a/tools/docker-builder/main.go
+++ b/tools/docker-builder/main.go
@@ -335,6 +335,9 @@ func ConstructBakeFile(a Args) (map[string]string, error) {
 	if args.NoClobber {
 		e := errgroup.Group{}
 		for _, i := range allDestinations.SortedList() {
+			if i == "latest" { // Allow clobbering of latest - don't verify existence
+				continue
+			}
 			i := i
 			e.Go(func() error {
 				return assertImageNonExisting(i)


### PR DESCRIPTION
**Please provide a description of this PR:**

Job build-base-images_release-builder_periodic of type periodic ended with state failure fails with:
```
Error: image "docker.io/istio/app_sidecar_base_centos_7:latest" already exists
```

This was caused by a recent change to create :latest tags of the images (#https://github.com/istio/istio/pull/37417)