### PR TITLE
gateway: avoid recreating Deployment on each kubectl apply

### DIFF
--- a/pilot/pkg/config/kube/gateway/templates.go
+++ b/pilot/pkg/config/kube/gateway/templates.go
@@ -52,13 +52,6 @@ func funcMap() template.FuncMap {
 		}
 		return strings.TrimSuffix(string(data), "\n")
 	}
-	f["toYaml"] = func(mps map[string]interface{}) string {
-		data, err := yaml.Marshal(mps)
-		if err != nil {
-			return ""
-		}
-		return strings.TrimSuffix(string(data), "\n")
-	}
 	f["omit"] = func(dict map[string]string, keys ...string) map[string]string {
 		res := map[string]string{}
 

--- a/pilot/pkg/config/kube/gateway/templates.go
+++ b/pilot/pkg/config/kube/gateway/templates.go
@@ -52,6 +52,28 @@ func funcMap() template.FuncMap {
 		}
 		return strings.TrimSuffix(string(data), "\n")
 	}
+	f["toYaml"] = func(mps map[string]interface{}) string {
+		data, err := yaml.Marshal(mps)
+		if err != nil {
+			return ""
+		}
+		return strings.TrimSuffix(string(data), "\n")
+	}
+	f["omit"] = func(dict map[string]string, keys ...string) map[string]string {
+		res := map[string]string{}
+
+		omit := make(map[string]bool, len(keys))
+		for _, k := range keys {
+			omit[k] = true
+		}
+
+		for k, v := range dict {
+			if _, ok := omit[k]; !ok {
+				res[k] = v
+			}
+		}
+		return res
+	}
 	return f
 }
 

--- a/pilot/pkg/config/kube/gateway/templates/deployment.yaml
+++ b/pilot/pkg/config/kube/gateway/templates/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    {{ toYamlMap .Annotations | nindent 4 }}
+    {{ toYamlMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration") | nindent 4 }}
   labels:
     {{ toYamlMap .Labels
       (strdict "gateway.istio.io/managed" "istio.io-gateway-controller")
@@ -23,7 +23,7 @@ spec:
       annotations:
         {{ toYamlMap
           (strdict "inject.istio.io/templates" "gateway")
-          .Annotations
+          (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration")
           | nindent 8}}
       labels:
         {{ toYamlMap

--- a/pilot/pkg/config/kube/gateway/templates/service.yaml
+++ b/pilot/pkg/config/kube/gateway/templates/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    {{ toYamlMap .Annotations | nindent 4 }}
+    {{ toYamlMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration") | nindent 4 }}
   labels:
     {{ toYamlMap .Labels
       (strdict "gateway.istio.io/managed" "istio.io-gateway-controller")


### PR DESCRIPTION
Currently, kubectl apply annotation from Gateway is propogated to
Deployment which triggers a restart everytime we change any field.

**Please provide a description of this PR:**