### PR TITLE
mitigate flaky tests temporarily

### DIFF
--- a/tests/integration/pilot/multicluster_test.go
+++ b/tests/integration/pilot/multicluster_test.go
@@ -54,6 +54,7 @@ func TestClusterLocal(t *testing.T) {
 		RequiresMinClusters(2).
 		RequireIstioVersion("1.11").
 		Run(func(t framework.TestContext) {
+			t.Skip("https://github.com/istio/istio/issues/36791") // Known bug
 			// TODO use echotest to dynamically pick 2 simple pods from apps.All
 			sources := apps.PodA
 			destination := apps.PodB

--- a/tests/integration/pilot/multicluster_test.go
+++ b/tests/integration/pilot/multicluster_test.go
@@ -54,7 +54,6 @@ func TestClusterLocal(t *testing.T) {
 		RequiresMinClusters(2).
 		RequireIstioVersion("1.11").
 		Run(func(t framework.TestContext) {
-			t.Skip("https://github.com/istio/istio/issues/36791") // Known bug
 			// TODO use echotest to dynamically pick 2 simple pods from apps.All
 			sources := apps.PodA
 			destination := apps.PodB

--- a/tests/integration/security/util/reachability/context.go
+++ b/tests/integration/security/util/reachability/context.go
@@ -198,7 +198,11 @@ func Run(testCases []TestCase, t framework.TestContext, apps *util.EchoDeploymen
 												t.Skip("https://github.com/istio/istio/issues/37307")
 											}
 
-											src.CallWithRetryOrFail(t, opts)
+											retryOpts := []retry.Option{}
+											retryOpts = append(retryOpts, echo.DefaultCallRetryOptions()...)
+											retryOpts = append(retryOpts, retry.Converge(1)) // TODO(https://github.com/istio/istio/issues/37629) go back to converge
+
+											src.CallWithRetryOrFail(t, opts, retryOpts...)
 										})
 								}
 							}


### PR DESCRIPTION
TestClusterLocal has a known fix which will land within a week.

The other one does not; we are not skipping though just making the test
slightly less exhaustive. This also reverts us to where we were 2 weeks ago,which added the converge.

**Please provide a description of this PR:**