### PR TITLE
build default transport socketmatch each time instead of using shared

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -45,16 +45,6 @@ import (
 	"istio.io/istio/pkg/util/gogo"
 )
 
-// defaultTransportSocketMatch applies to endpoints that have no security.istio.io/tlsMode label
-// or those whose label value does not match "istio"
-var defaultTransportSocketMatch = &cluster.Cluster_TransportSocketMatch{
-	Name:  "tlsMode-disabled",
-	Match: &structpb.Struct{},
-	TransportSocket: &core.TransportSocket{
-		Name: util.EnvoyRawBufferSocketName,
-	},
-}
-
 // deltaConfigTypes are used to detect changes and trigger delta calculations. When config updates has ONLY entries
 // in this map, then delta calculation is triggered.
 var deltaConfigTypes = sets.NewSet(gvk.ServiceEntry.Kind)

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -991,7 +991,7 @@ func (cb *ClusterBuilder) applyUpstreamTLSSettings(opts *buildClusterOpts, tls *
 					Match:           istioMtlsTransportSocketMatch,
 					TransportSocket: transportSocket,
 				},
-				defaultTransportSocketMatch,
+				defaultTransportSocketMatch(),
 			}
 		}
 	}
@@ -1291,6 +1291,18 @@ func defaultUpstreamCommonTLSContext() *auth.CommonTlsContext {
 			// if not specified, envoy use TLSv1_2 as default for client.
 			TlsMaximumProtocolVersion: auth.TlsParameters_TLSv1_3,
 			TlsMinimumProtocolVersion: auth.TlsParameters_TLSv1_2,
+		},
+	}
+}
+
+// defaultTransportSocketMatch applies to endpoints that have no security.istio.io/tlsMode label
+// or those whose label value does not match "istio"
+func defaultTransportSocketMatch() *cluster.Cluster_TransportSocketMatch {
+	return &cluster.Cluster_TransportSocketMatch{
+		Name:  "tlsMode-disabled",
+		Match: &structpb.Struct{},
+		TransportSocket: &core.TransportSocket{
+			Name: util.EnvoyRawBufferSocketName,
 		},
 	}
 }


### PR DESCRIPTION
**Please provide a description of this PR:**

To prevent cluster patch mutating the sharing default transport socket match