### PR TITLE
Handle PrivateKeyProvider configuration

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -535,7 +535,7 @@ func (s *Server) initSDSServer() {
 				Reason: []model.TriggerReason{model.SecretTrigger},
 			})
 		})
-		s.XDSServer.Generators[v3.SecretType] = xds.NewSecretGen(creds, s.XDSServer.Cache, s.clusterID, s.environment.IstioConfigStore, s.environment.Mesh())
+		s.XDSServer.Generators[v3.SecretType] = xds.NewSecretGen(creds, s.XDSServer.Cache, s.clusterID, s.environment.Mesh())
 		s.multiclusterController.AddHandler(creds)
 	}
 }

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -40,7 +40,6 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 
-	"istio.io/api/mesh/v1alpha1"
 	"istio.io/api/security/v1beta1"
 	kubecredentials "istio.io/istio/pilot/pkg/credentials/kube"
 	"istio.io/istio/pilot/pkg/features"
@@ -513,14 +512,6 @@ func (s *Server) WaitUntilCompletion() {
 	s.server.Wait()
 }
 
-func (s *Server) fetchPrivateKeyProviderConfig() *v1alpha1.PrivateKeyProvider {
-	meshConf := s.environment.Mesh()
-	proxyConf := meshConf.GetDefaultConfig()
-
-	pkpConf := proxyConf.GetPrivateKeyProvider()
-	return pkpConf
-}
-
 // initSDSServer starts the SDS server
 func (s *Server) initSDSServer() {
 	if s.kubeClient == nil {
@@ -544,8 +535,7 @@ func (s *Server) initSDSServer() {
 				Reason: []model.TriggerReason{model.SecretTrigger},
 			})
 		})
-		pkpConf := s.fetchPrivateKeyProviderConfig()
-		s.XDSServer.Generators[v3.SecretType] = xds.NewSecretGen(creds, s.XDSServer.Cache, s.clusterID, pkpConf)
+		s.XDSServer.Generators[v3.SecretType] = xds.NewSecretGen(creds, s.XDSServer.Cache, s.clusterID, s.environment.IstioConfigStore, s.environment.Mesh())
 		s.multiclusterController.AddHandler(creds)
 	}
 }

--- a/pilot/pkg/xds/fake.go
+++ b/pilot/pkg/xds/fake.go
@@ -173,7 +173,7 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 		}
 	}
 	creds := kubesecrets.NewMulticluster(opts.DefaultClusterName)
-	s.Generators[v3.SecretType] = NewSecretGen(creds, s.Cache, opts.DefaultClusterName)
+	s.Generators[v3.SecretType] = NewSecretGen(creds, s.Cache, opts.DefaultClusterName, nil)
 	for k8sCluster, objs := range k8sObjects {
 		client := kubelib.NewFakeClientWithVersion(opts.KubernetesVersion, objs...)
 		if opts.KubeClientModifier != nil {

--- a/pilot/pkg/xds/fake.go
+++ b/pilot/pkg/xds/fake.go
@@ -173,7 +173,7 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 		}
 	}
 	creds := kubesecrets.NewMulticluster(opts.DefaultClusterName)
-	s.Generators[v3.SecretType] = NewSecretGen(creds, s.Cache, opts.DefaultClusterName, nil, nil)
+	s.Generators[v3.SecretType] = NewSecretGen(creds, s.Cache, opts.DefaultClusterName, nil)
 	for k8sCluster, objs := range k8sObjects {
 		client := kubelib.NewFakeClientWithVersion(opts.KubernetesVersion, objs...)
 		if opts.KubeClientModifier != nil {

--- a/pilot/pkg/xds/fake.go
+++ b/pilot/pkg/xds/fake.go
@@ -173,7 +173,7 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 		}
 	}
 	creds := kubesecrets.NewMulticluster(opts.DefaultClusterName)
-	s.Generators[v3.SecretType] = NewSecretGen(creds, s.Cache, opts.DefaultClusterName, nil)
+	s.Generators[v3.SecretType] = NewSecretGen(creds, s.Cache, opts.DefaultClusterName, nil, nil)
 	for k8sCluster, objs := range k8sObjects {
 		client := kubelib.NewFakeClientWithVersion(opts.KubernetesVersion, objs...)
 		if opts.KubeClientModifier != nil {

--- a/pilot/pkg/xds/sds.go
+++ b/pilot/pkg/xds/sds.go
@@ -21,13 +21,13 @@ import (
 	"strings"
 	"time"
 
+	cryptomb "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/private_key_providers/cryptomb/v3alpha"
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoytls "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
 
-	cryptomb "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/private_key_providers/cryptomb/v3alpha"
 	mesh "istio.io/api/mesh/v1alpha1"
 	credscontroller "istio.io/istio/pilot/pkg/credentials"
 	"istio.io/istio/pilot/pkg/features"

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -1645,6 +1645,20 @@ func validateServiceSettings(config *meshconfig.MeshConfig) (errs error) {
 	return
 }
 
+func validatePrivateKeyProvider(pkpConf *meshconfig.PrivateKeyProvider) error {
+	var errs error
+	if pkpConf.GetName() == "" {
+		errs = multierror.Append(errs, errors.New("name is required"))
+	}
+
+	if config := pkpConf.GetConfig(); config == nil {
+		errs = multierror.Append(errs, errors.New("confguration is required"))
+	}
+	// TODO: Detailed validation of configuration
+
+	return errs
+}
+
 // ValidateMeshConfigProxyConfig checks that the mesh config is well-formed
 func ValidateMeshConfigProxyConfig(config *meshconfig.ProxyConfig) (errs error) {
 	if config.ConfigPath == "" {
@@ -1746,6 +1760,12 @@ func ValidateMeshConfigProxyConfig(config *meshconfig.ProxyConfig) (errs error) 
 
 	if err := ValidatePort(int(config.StatusPort)); err != nil {
 		errs = multierror.Append(errs, multierror.Prefix(err, "invalid status port:"))
+	}
+
+	if pkpConf := config.GetPrivateKeyProvider(); pkpConf != nil {
+		if err := validatePrivateKeyProvider(pkpConf); err != nil {
+			errs = multierror.Append(errs, multierror.Prefix(err, "invalid private key provider confguration:"))
+		}
 	}
 
 	return

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -1651,10 +1651,19 @@ func validatePrivateKeyProvider(pkpConf *meshconfig.PrivateKeyProvider) error {
 		errs = multierror.Append(errs, errors.New("name is required"))
 	}
 
-	if config := pkpConf.GetConfig(); config == nil {
-		errs = multierror.Append(errs, errors.New("confguration is required"))
+	if pkpConf.GetName() == "cryptomb" {
+		cryptomb := pkpConf.GetCryptomb()
+		if cryptomb == nil {
+			errs = multierror.Append(errs, errors.New("cryptomb confguration is required"))
+		} else {
+			pollDelay := cryptomb.GetPollDelay()
+			if pollDelay == nil {
+				errs = multierror.Append(errs, errors.New("pollDelay is required"))
+			} else if pollDelay.GetNanos() == 0 {
+				errs = multierror.Append(errs, errors.New("pollDelay must be non zero"))
+			}
+		}
 	}
-	// TODO: Detailed validation of configuration
 
 	return errs
 }

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -1660,7 +1660,7 @@ func validatePrivateKeyProvider(pkpConf *meshconfig.PrivateKeyProvider) error {
 			pollDelay := cryptomb.GetPollDelay()
 			if pollDelay == nil {
 				errs = multierror.Append(errs, errors.New("pollDelay is required"))
-			} else if pollDelay.GetNanos() == 0 {
+			} else if pollDelay.GetSeconds() == 0 && pollDelay.GetNanos() == 0 {
 				errs = multierror.Append(errs, errors.New("pollDelay must be non zero"))
 			}
 		}

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -1647,11 +1647,12 @@ func validateServiceSettings(config *meshconfig.MeshConfig) (errs error) {
 
 func validatePrivateKeyProvider(pkpConf *meshconfig.PrivateKeyProvider) error {
 	var errs error
-	if pkpConf.GetName() == "" {
-		errs = multierror.Append(errs, errors.New("name is required"))
+	if pkpConf.GetProvider() == nil {
+		errs = multierror.Append(errs, errors.New("private key provider confguration is required"))
 	}
 
-	if pkpConf.GetName() == "cryptomb" {
+	switch pkpConf.GetProvider().(type) {
+	case *meshconfig.PrivateKeyProvider_Cryptomb:
 		cryptomb := pkpConf.GetCryptomb()
 		if cryptomb == nil {
 			errs = multierror.Append(errs, errors.New("cryptomb confguration is required"))
@@ -1663,6 +1664,8 @@ func validatePrivateKeyProvider(pkpConf *meshconfig.PrivateKeyProvider) error {
 				errs = multierror.Append(errs, errors.New("pollDelay must be non zero"))
 			}
 		}
+	default:
+		errs = multierror.Append(errs, errors.New("unknown private key provider"))
 	}
 
 	return errs

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -823,7 +823,7 @@ func TestValidateMeshConfigProxyConfig(t *testing.T) {
 			isValid: false,
 		},
 		{
-			name: "private key provider with empty config",
+			name: "private key provider with empty cryptomb",
 			in: modify(valid,
 				func(c *meshconfig.ProxyConfig) {
 					c.PrivateKeyProvider = &meshconfig.PrivateKeyProvider{
@@ -834,12 +834,50 @@ func TestValidateMeshConfigProxyConfig(t *testing.T) {
 			isValid: false,
 		},
 		{
-			name: "private key provider with name and config",
+			name: "private key provider with name and cryptomb without poll_delay",
 			in: modify(valid,
 				func(c *meshconfig.ProxyConfig) {
 					c.PrivateKeyProvider = &meshconfig.PrivateKeyProvider{
-						Name:   "cryptomb",
-						Config: &types.Struct{},
+						Name: "cryptomb",
+						Provider: &meshconfig.PrivateKeyProvider_Cryptomb{
+							Cryptomb: &meshconfig.PrivateKeyProvider_CryptoMb{},
+						},
+					}
+				},
+			),
+			isValid: false,
+		},
+		{
+			name: "private key provider with name and cryptomb zero poll_delay",
+			in: modify(valid,
+				func(c *meshconfig.ProxyConfig) {
+					c.PrivateKeyProvider = &meshconfig.PrivateKeyProvider{
+						Name: "cryptomb",
+						Provider: &meshconfig.PrivateKeyProvider_Cryptomb{
+							Cryptomb: &meshconfig.PrivateKeyProvider_CryptoMb{
+								PollDelay: &types.Duration{
+									Nanos: 0,
+								},
+							},
+						},
+					}
+				},
+			),
+			isValid: false,
+		},
+		{
+			name: "private key provider with name and cryptomb",
+			in: modify(valid,
+				func(c *meshconfig.ProxyConfig) {
+					c.PrivateKeyProvider = &meshconfig.PrivateKeyProvider{
+						Name: "cryptomb",
+						Provider: &meshconfig.PrivateKeyProvider_Cryptomb{
+							Cryptomb: &meshconfig.PrivateKeyProvider_CryptoMb{
+								PollDelay: &types.Duration{
+									Nanos: 10000,
+								},
+							},
+						},
 					}
 				},
 			),

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -812,33 +812,19 @@ func TestValidateMeshConfigProxyConfig(t *testing.T) {
 			isValid: false,
 		},
 		{
-			name: "private key provider with empty name",
+			name: "private key provider with empty provider",
 			in: modify(valid,
 				func(c *meshconfig.ProxyConfig) {
-					c.PrivateKeyProvider = &meshconfig.PrivateKeyProvider{
-						Name: "",
-					}
+					c.PrivateKeyProvider = &meshconfig.PrivateKeyProvider{}
 				},
 			),
 			isValid: false,
 		},
 		{
-			name: "private key provider with empty cryptomb",
+			name: "private key provider with cryptomb without poll_delay",
 			in: modify(valid,
 				func(c *meshconfig.ProxyConfig) {
 					c.PrivateKeyProvider = &meshconfig.PrivateKeyProvider{
-						Name: "cryptomb",
-					}
-				},
-			),
-			isValid: false,
-		},
-		{
-			name: "private key provider with name and cryptomb without poll_delay",
-			in: modify(valid,
-				func(c *meshconfig.ProxyConfig) {
-					c.PrivateKeyProvider = &meshconfig.PrivateKeyProvider{
-						Name: "cryptomb",
 						Provider: &meshconfig.PrivateKeyProvider_Cryptomb{
 							Cryptomb: &meshconfig.PrivateKeyProvider_CryptoMb{},
 						},
@@ -848,11 +834,10 @@ func TestValidateMeshConfigProxyConfig(t *testing.T) {
 			isValid: false,
 		},
 		{
-			name: "private key provider with name and cryptomb zero poll_delay",
+			name: "private key provider with cryptomb zero poll_delay",
 			in: modify(valid,
 				func(c *meshconfig.ProxyConfig) {
 					c.PrivateKeyProvider = &meshconfig.PrivateKeyProvider{
-						Name: "cryptomb",
 						Provider: &meshconfig.PrivateKeyProvider_Cryptomb{
 							Cryptomb: &meshconfig.PrivateKeyProvider_CryptoMb{
 								PollDelay: &types.Duration{
@@ -866,11 +851,10 @@ func TestValidateMeshConfigProxyConfig(t *testing.T) {
 			isValid: false,
 		},
 		{
-			name: "private key provider with name and cryptomb",
+			name: "private key provider with cryptomb",
 			in: modify(valid,
 				func(c *meshconfig.ProxyConfig) {
 					c.PrivateKeyProvider = &meshconfig.PrivateKeyProvider{
-						Name: "cryptomb",
 						Provider: &meshconfig.PrivateKeyProvider_Cryptomb{
 							Cryptomb: &meshconfig.PrivateKeyProvider_CryptoMb{
 								PollDelay: &types.Duration{

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -840,7 +840,7 @@ func TestValidateMeshConfigProxyConfig(t *testing.T) {
 					c.PrivateKeyProvider = &meshconfig.PrivateKeyProvider{
 						Provider: &meshconfig.PrivateKeyProvider_Cryptomb{
 							Cryptomb: &meshconfig.PrivateKeyProvider_CryptoMb{
-								PollDelay: &types.Duration{
+								PollDelay: &durationpb.Duration{
 									Seconds: 0,
 									Nanos:   0,
 								},
@@ -858,7 +858,7 @@ func TestValidateMeshConfigProxyConfig(t *testing.T) {
 					c.PrivateKeyProvider = &meshconfig.PrivateKeyProvider{
 						Provider: &meshconfig.PrivateKeyProvider_Cryptomb{
 							Cryptomb: &meshconfig.PrivateKeyProvider_CryptoMb{
-								PollDelay: &types.Duration{
+								PollDelay: &durationpb.Duration{
 									Seconds: 0,
 									Nanos:   10000,
 								},

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -495,6 +495,7 @@ func TestValidateMeshConfigProxyConfig(t *testing.T) {
 		ControlPlaneAuthPolicy: meshconfig.AuthenticationPolicy_MUTUAL_TLS,
 		Tracing:                nil,
 		StatusPort:             15020,
+		PrivateKeyProvider:     nil,
 	}
 
 	modify := func(config *meshconfig.ProxyConfig, fieldSetter func(*meshconfig.ProxyConfig)) *meshconfig.ProxyConfig {
@@ -809,6 +810,40 @@ func TestValidateMeshConfigProxyConfig(t *testing.T) {
 				},
 			),
 			isValid: false,
+		},
+		{
+			name: "private key provider with empty name",
+			in: modify(valid,
+				func(c *meshconfig.ProxyConfig) {
+					c.PrivateKeyProvider = &meshconfig.PrivateKeyProvider{
+						Name: "",
+					}
+				},
+			),
+			isValid: false,
+		},
+		{
+			name: "private key provider with empty config",
+			in: modify(valid,
+				func(c *meshconfig.ProxyConfig) {
+					c.PrivateKeyProvider = &meshconfig.PrivateKeyProvider{
+						Name: "cryptomb",
+					}
+				},
+			),
+			isValid: false,
+		},
+		{
+			name: "private key provider with name and config",
+			in: modify(valid,
+				func(c *meshconfig.ProxyConfig) {
+					c.PrivateKeyProvider = &meshconfig.PrivateKeyProvider{
+						Name:   "cryptomb",
+						Config: &types.Struct{},
+					}
+				},
+			),
+			isValid: true,
 		},
 	}
 	for _, c := range cases {

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -841,7 +841,8 @@ func TestValidateMeshConfigProxyConfig(t *testing.T) {
 						Provider: &meshconfig.PrivateKeyProvider_Cryptomb{
 							Cryptomb: &meshconfig.PrivateKeyProvider_CryptoMb{
 								PollDelay: &types.Duration{
-									Nanos: 0,
+									Seconds: 0,
+									Nanos:   0,
 								},
 							},
 						},
@@ -858,7 +859,8 @@ func TestValidateMeshConfigProxyConfig(t *testing.T) {
 						Provider: &meshconfig.PrivateKeyProvider_Cryptomb{
 							Cryptomb: &meshconfig.PrivateKeyProvider_CryptoMb{
 								PollDelay: &types.Duration{
-									Nanos: 10000,
+									Seconds: 0,
+									Nanos:   10000,
 								},
 							},
 						},

--- a/pkg/istio-agent/agent.go
+++ b/pkg/istio-agent/agent.go
@@ -503,7 +503,8 @@ func (a *Agent) initSdsServer() error {
 		}
 	}
 
-	a.sdsServer = sds.NewServer(a.secOpts, a.secretCache)
+	pkpConf := a.proxyConfig.GetPrivateKeyProvider()
+	a.sdsServer = sds.NewServer(a.secOpts, a.secretCache, pkpConf)
 	a.secretCache.SetUpdateCallback(a.sdsServer.UpdateCallback)
 
 	return nil

--- a/pkg/istio-agent/agent_test.go
+++ b/pkg/istio-agent/agent_test.go
@@ -284,7 +284,7 @@ func TestAgent(t *testing.T) {
 
 		// this SDS Server listens on the well-known socket path serving the certs copied to the temp directory,
 		// and acts as the external SDS Server that the Agent will detect at startup
-		sdsServer := sds.NewServer(secOpts, secretCache)
+		sdsServer := sds.NewServer(secOpts, secretCache, nil)
 		defer sdsServer.Stop()
 
 		Setup(t).Check(t, security.WorkloadKeyCertResourceName, security.RootCertReqResourceName)

--- a/releasenotes/notes/37681.yaml
+++ b/releasenotes/notes/37681.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: feature
+area: security
+
+releaseNotes:
+- |
+  **Added** support for using PrivateKeyProvider in SDS. See [#35809](https://github.com/istio/istio/issues/35809)

--- a/security/pkg/nodeagent/sds/sdsservice.go
+++ b/security/pkg/nodeagent/sds/sdsservice.go
@@ -209,7 +209,7 @@ func (s *sdsservice) Close() {
 	s.XdsServer.Shutdown()
 }
 
-func toEnvoySecretWithPrivateKeyProvider(s *security.SecretItem, caRootPath string, pkpConf *mesh.PrivateKeyProvider) *tls.Secret_TlsCertificate {
+func toEnvoySecretWithPrivateKeyProvider(s *security.SecretItem, pkpConf *mesh.PrivateKeyProvider) *tls.Secret_TlsCertificate {
 	var secretType *tls.Secret_TlsCertificate
 	if pkpConf == nil {
 		return nil
@@ -270,7 +270,7 @@ func toEnvoySecret(s *security.SecretItem, caRootPath string, pkpConf *mesh.Priv
 			},
 		}
 	} else {
-		res := toEnvoySecretWithPrivateKeyProvider(s, caRootPath, pkpConf)
+		res := toEnvoySecretWithPrivateKeyProvider(s, pkpConf)
 		if res != nil {
 			secret.Type = res
 		} else {

--- a/security/pkg/nodeagent/sds/sdsservice.go
+++ b/security/pkg/nodeagent/sds/sdsservice.go
@@ -214,7 +214,8 @@ func toEnvoySecretWithPrivateKeyProvider(s *security.SecretItem, caRootPath stri
 	if pkpConf == nil {
 		return nil
 	}
-	if pkpConf.Name == "cryptomb" {
+	switch pkpConf.GetProvider().(type) {
+	case *mesh.PrivateKeyProvider_Cryptomb:
 		crypto := pkpConf.GetCryptomb()
 		msg := util.MessageToAny(&cryptomb.CryptoMbPrivateKeyMethodConfig{
 			PollDelay: durationpb.New(time.Duration(crypto.GetPollDelay().Nanos)),
@@ -232,15 +233,15 @@ func toEnvoySecretWithPrivateKeyProvider(s *security.SecretItem, caRootPath stri
 					},
 				},
 				PrivateKeyProvider: &tls.PrivateKeyProvider{
-					ProviderName: pkpConf.Name,
+					ProviderName: "cryptomb",
 					ConfigType: &tls.PrivateKeyProvider_TypedConfig{
 						TypedConfig: msg,
 					},
 				},
 			},
 		}
-	} else {
-		sdsServiceLog.Warnf("Unknown PrivateKeyProvider: %s", pkpConf.Name)
+	default:
+		sdsServiceLog.Warnf("Unknown PrivateKeyProvider")
 		return nil
 	}
 	return secretType

--- a/security/pkg/nodeagent/sds/sdsservice_test.go
+++ b/security/pkg/nodeagent/sds/sdsservice_test.go
@@ -22,11 +22,15 @@ import (
 	cryptomb "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/private_key_providers/cryptomb/v3alpha"
 	tlsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
-	"github.com/gogo/protobuf/types"
 	"github.com/google/go-cmp/cmp"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+<<<<<<< HEAD
+=======
+	"google.golang.org/protobuf/types/known/durationpb"
+	"k8s.io/apimachinery/pkg/util/uuid"
+>>>>>>> fix rebase conflicts
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/pkg/xds"
@@ -52,7 +56,7 @@ var (
 	fakePrivateKeyProviderConf = &meshconfig.PrivateKeyProvider{
 		Provider: &meshconfig.PrivateKeyProvider_Cryptomb{
 			Cryptomb: &meshconfig.PrivateKeyProvider_CryptoMb{
-				PollDelay: &types.Duration{
+				PollDelay: &durationpb.Duration{
 					Seconds: 0,
 					Nanos:   10000,
 				},
@@ -136,20 +140,13 @@ func setupSDS(t *testing.T) *TestServer {
 		ResourceName: ca2.RootCertReqResourceName,
 	})
 
-<<<<<<< HEAD
 	opts := &ca2.Options{}
-	server := NewServer(opts, st, nil)
-=======
-	opts := &ca2.Options{
-		WorkloadUDSPath: fmt.Sprintf("/tmp/workload_gotest%s.sock", string(uuid.NewUUID())),
-	}
 
 	if usefakePrivateKeyProviderConf {
 		server = NewServer(opts, st, fakePrivateKeyProviderConf)
 	} else {
 		server = NewServer(opts, st, nil)
 	}
->>>>>>> add tests
 	t.Cleanup(func() {
 		server.Stop()
 	})

--- a/security/pkg/nodeagent/sds/sdsservice_test.go
+++ b/security/pkg/nodeagent/sds/sdsservice_test.go
@@ -26,11 +26,7 @@ import (
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
-<<<<<<< HEAD
-=======
 	"google.golang.org/protobuf/types/known/durationpb"
-	"k8s.io/apimachinery/pkg/util/uuid"
->>>>>>> fix rebase conflicts
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/pkg/xds"

--- a/security/pkg/nodeagent/sds/sdsservice_test.go
+++ b/security/pkg/nodeagent/sds/sdsservice_test.go
@@ -19,12 +19,16 @@ import (
 	"strings"
 	"testing"
 
+	cryptomb "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/private_key_providers/cryptomb/v3alpha"
+	tlsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	"github.com/gogo/protobuf/types"
 	"github.com/google/go-cmp/cmp"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
+	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/pkg/xds"
 	"istio.io/istio/pilot/test/xdstest"
 	ca2 "istio.io/istio/pkg/security"
@@ -43,8 +47,19 @@ var (
 		PrivateKey:       fakePushPrivateKey,
 		ResourceName:     testResourceName,
 	}
-	testResourceName = "default"
-	rootResourceName = "ROOTCA"
+	testResourceName           = "default"
+	rootResourceName           = "ROOTCA"
+	fakePrivateKeyProviderConf = &meshconfig.PrivateKeyProvider{
+		Provider: &meshconfig.PrivateKeyProvider_Cryptomb{
+			Cryptomb: &meshconfig.PrivateKeyProvider_CryptoMb{
+				PollDelay: &types.Duration{
+					Seconds: 0,
+					Nanos:   10000,
+				},
+			},
+		},
+	}
+	usefakePrivateKeyProviderConf = false
 )
 
 type TestServer struct {
@@ -75,6 +90,12 @@ type Expectation struct {
 	RootCert     []byte
 }
 
+func (s *TestServer) extractPrivateKeyProvider(provider *tlsv3.PrivateKeyProvider) []byte {
+	var cmb cryptomb.CryptoMbPrivateKeyMethodConfig
+	provider.GetTypedConfig().UnmarshalTo(&cmb)
+	return cmb.GetPrivateKey().GetInlineBytes()
+}
+
 func (s *TestServer) Verify(resp *discovery.DiscoveryResponse, expectations ...Expectation) *discovery.DiscoveryResponse {
 	s.t.Helper()
 	if len(resp.Resources) != len(expectations) {
@@ -83,9 +104,15 @@ func (s *TestServer) Verify(resp *discovery.DiscoveryResponse, expectations ...E
 	got := xdstest.ExtractTLSSecrets(s.t, resp.Resources)
 	for _, e := range expectations {
 		scrt := got[e.ResourceName]
+		var expectationKey []byte
+		if provider := scrt.GetTlsCertificate().GetPrivateKeyProvider(); provider != nil {
+			expectationKey = s.extractPrivateKeyProvider(provider)
+		} else {
+			expectationKey = scrt.GetTlsCertificate().GetPrivateKey().GetInlineBytes()
+		}
 		r := Expectation{
 			ResourceName: e.ResourceName,
-			Key:          scrt.GetTlsCertificate().GetPrivateKey().GetInlineBytes(),
+			Key:          expectationKey,
 			CertChain:    scrt.GetTlsCertificate().GetCertificateChain().GetInlineBytes(),
 			RootCert:     scrt.GetValidationContext().GetTrustedCa().GetInlineBytes(),
 		}
@@ -97,6 +124,7 @@ func (s *TestServer) Verify(resp *discovery.DiscoveryResponse, expectations ...E
 }
 
 func setupSDS(t *testing.T) *TestServer {
+	var server *Server
 	st := ca2.NewDirectSecretManager()
 	st.Set(testResourceName, &ca2.SecretItem{
 		CertificateChain: fakeCertificateChain,
@@ -108,8 +136,20 @@ func setupSDS(t *testing.T) *TestServer {
 		ResourceName: ca2.RootCertReqResourceName,
 	})
 
+<<<<<<< HEAD
 	opts := &ca2.Options{}
 	server := NewServer(opts, st, nil)
+=======
+	opts := &ca2.Options{
+		WorkloadUDSPath: fmt.Sprintf("/tmp/workload_gotest%s.sock", string(uuid.NewUUID())),
+	}
+
+	if usefakePrivateKeyProviderConf {
+		server = NewServer(opts, st, fakePrivateKeyProviderConf)
+	} else {
+		server = NewServer(opts, st, nil)
+	}
+>>>>>>> add tests
 	t.Cleanup(func() {
 		server.Stop()
 	})
@@ -281,6 +321,15 @@ func TestSDS(t *testing.T) {
 		c := s.Connect()
 		c.RequestResponseNack(t, &discovery.DiscoveryRequest{ResourceNames: []string{testResourceName}})
 		c.ExpectNoResponse(t)
+	})
+	t.Run("connect_with_cryptomb", func(t *testing.T) {
+		usefakePrivateKeyProviderConf = true
+		s := setupSDS(t)
+		c := s.Connect()
+		s.Verify(c.RequestResponseAck(t, &discovery.DiscoveryRequest{ResourceNames: []string{testResourceName}}), expectCert)
+		// Close out the connection
+		c.Cleanup()
+		usefakePrivateKeyProviderConf = false
 	})
 }
 

--- a/security/pkg/nodeagent/sds/sdsservice_test.go
+++ b/security/pkg/nodeagent/sds/sdsservice_test.go
@@ -109,7 +109,7 @@ func setupSDS(t *testing.T) *TestServer {
 	})
 
 	opts := &ca2.Options{}
-	server := NewServer(opts, st)
+	server := NewServer(opts, st, nil)
 	t.Cleanup(func() {
 		server.Stop()
 	})

--- a/security/pkg/nodeagent/sds/server.go
+++ b/security/pkg/nodeagent/sds/server.go
@@ -46,15 +46,9 @@ type Server struct {
 // NewServer creates and starts the Grpc server for SDS.
 func NewServer(options *security.Options, workloadSecretCache security.SecretManager, pkpConf *mesh.PrivateKeyProvider) *Server {
 	s := &Server{stopped: atomic.NewBool(false)}
-<<<<<<< HEAD
-	s.workloadSds = newSDSService(workloadSecretCache, options)
+	s.workloadSds = newSDSService(workloadSecretCache, options, pkpConf)
 	s.initWorkloadSdsService()
 	sdsServiceLog.Infof("SDS server for workload certificates started, listening on %q", security.WorkloadIdentitySocketPath)
-=======
-	s.workloadSds = newSDSService(workloadSecretCache, options, pkpConf)
-	s.initWorkloadSdsService(options)
-	sdsServiceLog.Infof("SDS server for workload certificates started, listening on %q", options.WorkloadUDSPath)
->>>>>>> Handle PrivateKeyProvider configuration
 	return s
 }
 

--- a/security/pkg/nodeagent/sds/server.go
+++ b/security/pkg/nodeagent/sds/server.go
@@ -21,6 +21,7 @@ import (
 	"go.uber.org/atomic"
 	"google.golang.org/grpc"
 
+	mesh "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/security"
@@ -43,11 +44,17 @@ type Server struct {
 }
 
 // NewServer creates and starts the Grpc server for SDS.
-func NewServer(options *security.Options, workloadSecretCache security.SecretManager) *Server {
+func NewServer(options *security.Options, workloadSecretCache security.SecretManager, pkpConf *mesh.PrivateKeyProvider) *Server {
 	s := &Server{stopped: atomic.NewBool(false)}
+<<<<<<< HEAD
 	s.workloadSds = newSDSService(workloadSecretCache, options)
 	s.initWorkloadSdsService()
 	sdsServiceLog.Infof("SDS server for workload certificates started, listening on %q", security.WorkloadIdentitySocketPath)
+=======
+	s.workloadSds = newSDSService(workloadSecretCache, options, pkpConf)
+	s.initWorkloadSdsService(options)
+	sdsServiceLog.Infof("SDS server for workload certificates started, listening on %q", options.WorkloadUDSPath)
+>>>>>>> Handle PrivateKeyProvider configuration
 	return s
 }
 


### PR DESCRIPTION
**Please provide a description of this PR:**

When the PrivateKeyProvider configuration information is provided through Istio operator yaml file, parse and pass it to gateway or sidecars. Envoy will act based on the information provided by the configuration.

To set the mesh wide defaults, configure the `defaultConfig` section of `meshConfig`.
For example:

```
meshConfig:
  defaultConfig:
    privateKeyProvider:
      cryptomb:
        pollDelay: 0.01s
```

This can also be configured on a per-workload basis by configuring the `proxy.istio.io/config`
annotation on the pod.
For example:

```
annotations:
  proxy.istio.io/config: |
    privateKeyProvider:
      cryptomb:
        pollDelay: 0.01s
```



This requires https://github.com/istio/api/pull/2261