### PR TITLE
Fix --no-clobber ignoring of `latest` images

### DIFF
--- a/tools/docker-builder/main.go
+++ b/tools/docker-builder/main.go
@@ -335,7 +335,7 @@ func ConstructBakeFile(a Args) (map[string]string, error) {
 	if args.NoClobber {
 		e := errgroup.Group{}
 		for _, i := range allDestinations.SortedList() {
-			if i == "latest" { // Allow clobbering of latest - don't verify existence
+			if strings.HasSuffix(i, ":latest") { // Allow clobbering of latest - don't verify existence
 				continue
 			}
 			i := i


### PR DESCRIPTION
**Please provide a description of this PR:**

Prior fix tried comparing `latest` with whole image name. Change to see if the suffix is `:latest`