### PR TITLE
TelemetryAPI: Disable Stackdriver logging if not configured (by default, or otherwise) 

### DIFF
--- a/pilot/pkg/model/telemetry.go
+++ b/pilot/pkg/model/telemetry.go
@@ -855,7 +855,10 @@ func generateSDConfig(class networking.ListenerClass, telemetryConfig telemetryF
 				cfg.AccessLogging = sd.PluginConfig_ERRORS_ONLY
 			}
 		}
+	} else {
+		cfg.DisableServerAccessLogging = true
 	}
+
 	cfg.MetricExpiryDuration = durationpb.New(1 * time.Hour)
 	// In WASM we are not actually processing protobuf at all, so we need to encode this to JSON
 	cfgJSON, _ := protomarshal.MarshalProtoNames(&cfg)

--- a/pilot/pkg/model/telemetry.go
+++ b/pilot/pkg/model/telemetry.go
@@ -856,7 +856,8 @@ func generateSDConfig(class networking.ListenerClass, telemetryConfig telemetryF
 			}
 		}
 	} else {
-		cfg.DisableServerAccessLogging = true
+		// The field is deprecated, but until it is removed we need to set it.
+		cfg.DisableServerAccessLogging = true // nolint: staticcheck
 	}
 
 	cfg.MetricExpiryDuration = durationpb.New(1 * time.Hour)

--- a/pilot/pkg/model/telemetry_test.go
+++ b/pilot/pkg/model/telemetry_test.go
@@ -687,7 +687,7 @@ func TestTelemetryFilters(t *testing.T) {
 			networking.ListenerProtocolHTTP,
 			nil,
 			map[string]string{
-				"istio.stackdriver": `{"metric_expiry_duration":"3600s"}`,
+				"istio.stackdriver": `{"disable_server_access_logging":true,"metric_expiry_duration":"3600s"}`,
 			},
 		},
 		{
@@ -713,7 +713,7 @@ func TestTelemetryFilters(t *testing.T) {
 			networking.ListenerProtocolHTTP,
 			nil,
 			map[string]string{
-				"istio.stackdriver": `{"metric_expiry_duration":"3600s"}`,
+				"istio.stackdriver": `{"disable_server_access_logging":true,"metric_expiry_duration":"3600s"}`,
 			},
 		},
 		{
@@ -753,7 +753,7 @@ func TestTelemetryFilters(t *testing.T) {
 			networking.ListenerProtocolHTTP,
 			&meshconfig.MeshConfig_DefaultProviders{Metrics: []string{"prometheus"}},
 			map[string]string{
-				"istio.stackdriver": `{"metric_expiry_duration":"3600s"}`,
+				"istio.stackdriver": `{"disable_server_access_logging":true,"metric_expiry_duration":"3600s"}`,
 			},
 		},
 		{

--- a/releasenotes/notes/37708.yaml
+++ b/releasenotes/notes/37708.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: telemetry
+issue:
+  - https://github.com/istio/istio/issues/37667
+releaseNotes:
+  - |
+    **Fixed** an issue where when enabling Stackdriver metrics collection with the Telemetry API, logging was incorrectly enabled in certain scenarios.


### PR DESCRIPTION
The deprecated field `disable_server_access_logging` in Stackdriver configuration still impacts logging enablement. In particular, if not explicitly set to `true`, logging will be enabled for inbound traffic if the Stackdriver extension is configured. For situations in which metrics-only behavior has been enabled, this is incorrect behavior.

This PR sets the appropriate flag in the configuration to disable logging in these scenarios. Follow-on work should be pursued to remove the deprecated field's impact on logging decisions. This may require work in managed Istio packages that rely on the deprecated behavior.

- [ X ] Policies and Telemetry
- [ X ] User Experience

Fixes: https://github.com/istio/istio/issues/37667