### PR TITLE
check key and cert are valid before sending to Envoy

### DIFF
--- a/security/pkg/nodeagent/cache/secretcache.go
+++ b/security/pkg/nodeagent/cache/secretcache.go
@@ -18,6 +18,7 @@ package cache
 import (
 	"bytes"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -417,6 +418,9 @@ func (sc *SecretManagerClient) generateKeyCertFromExistingFiles(certChainPath, k
 	b.InitialInterval = sc.configOptions.FileDebounceDuration
 	secretValid := func() error {
 		_, err := tls.LoadX509KeyPair(certChainPath, keyPath)
+		if errors.Is(err, os.ErrNotExist) {
+			return backoff.Permanent(err)
+		}
 		return err
 	}
 	if err := backoff.Retry(secretValid, b); err != nil {

--- a/security/pkg/nodeagent/cache/secretcache.go
+++ b/security/pkg/nodeagent/cache/secretcache.go
@@ -17,6 +17,7 @@ package cache
 
 import (
 	"bytes"
+	"crypto/tls"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -411,9 +412,16 @@ func (sc *SecretManagerClient) generateRootCertFromExistingFile(rootCertPath, re
 // Generate a key and certificate item from the existing key certificate files from the passed in file paths.
 func (sc *SecretManagerClient) generateKeyCertFromExistingFiles(certChainPath, keyPath, resourceName string) (*security.SecretItem, error) {
 	// There is a remote possibility that key is written and cert is not written yet.
-	// To handle that case, we wait for some time here.
-	timer := time.After(sc.configOptions.FileDebounceDuration)
-	<-timer
+	// To handle that case, check if cert and key are valid if they are valid then only send to proxy.
+	b := backoff.NewExponentialBackOff()
+	b.InitialInterval = sc.configOptions.FileDebounceDuration
+	secretValid := func() error {
+		_, err := tls.LoadX509KeyPair(certChainPath, keyPath)
+		return err
+	}
+	if err := backoff.Retry(secretValid, b); err != nil {
+		return nil, err
+	}
 	return sc.keyCertSecretItem(certChainPath, keyPath, resourceName)
 }
 

--- a/security/pkg/nodeagent/cache/secretcache_test.go
+++ b/security/pkg/nodeagent/cache/secretcache_test.go
@@ -377,13 +377,17 @@ func runFileAgentTest(t *testing.T, sds bool) {
 	if err := file.AtomicWrite(sc.existingCertificateFile.CertificatePath, testcerts.RotatedCert, os.FileMode(0o644)); err != nil {
 		t.Fatal(err)
 	}
+	if err := file.AtomicWrite(sc.existingCertificateFile.PrivateKeyPath, testcerts.RotatedKey, os.FileMode(0o644)); err != nil {
+		t.Fatal(err)
+	}
+
 	// Expect update callback
 	u.Expect(map[string]int{workloadResource: 1})
 	// On the next generate call, we should get the new cert
 	checkSecret(t, sc, workloadResource, security.SecretItem{
 		ResourceName:     workloadResource,
 		CertificateChain: testcerts.RotatedCert,
-		PrivateKey:       privateKey,
+		PrivateKey:       testcerts.RotatedKey,
 	})
 
 	if err := file.AtomicWrite(sc.existingCertificateFile.PrivateKeyPath, testcerts.RotatedKey, os.FileMode(0o644)); err != nil {
@@ -391,7 +395,6 @@ func runFileAgentTest(t *testing.T, sds bool) {
 	}
 	// We do NOT expect update callback. We only watch the cert file, since the key and cert must be updated
 	// in tandem.
-	// TODO: what if they update out of sync? We probably shouldn't send an update of just one change
 	u.Expect(map[string]int{workloadResource: 1})
 	checkSecret(t, sc, workloadResource, security.SecretItem{
 		ResourceName:     workloadResource,


### PR DESCRIPTION
Currently we only watch cert and assume when cert changes key is also changed (wait for some debounce duration) and send it to Envoy. We have seen in some cases cert changes, but key is not changed with in the debounce period, leading to sending incorrect cert and key combination to Envoy resulting in cluster/listener NACKs.

This PR validates that key and cert form a correct combination with a retry (starting with debounce , upto max 1min). If the  key and cert are not a valid combination it returns error - to avoid NACKs.

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [X] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
