### PR TITLE
telemetry api: allow default json format for envoy file logger

### DIFF
--- a/pilot/pkg/model/telemetry_test.go
+++ b/pilot/pkg/model/telemetry_test.go
@@ -150,7 +150,7 @@ func TestAccessLogging(t *testing.T) {
 	empty := &tpb.Telemetry{
 		AccessLogging: []*tpb.AccessLogging{{}},
 	}
-	defaultJson := &tpb.Telemetry{
+	defaultJSON := &tpb.Telemetry{
 		AccessLogging: []*tpb.AccessLogging{
 			{
 				Providers: []*tpb.ProviderRef{
@@ -230,7 +230,7 @@ func TestAccessLogging(t *testing.T) {
 		},
 		{
 			"default envoy JSON",
-			[]config.Config{newTelemetry("istio-system", defaultJson)},
+			[]config.Config{newTelemetry("istio-system", defaultJSON)},
 			sidecar,
 			nil,
 			[]string{"envoy-json"},

--- a/pilot/pkg/networking/core/v1alpha3/accesslog.go
+++ b/pilot/pkg/networking/core/v1alpha3/accesslog.go
@@ -370,6 +370,11 @@ func buildFileAccessJSONLogFormat(
 		jsonLogStruct = EnvoyJSONLogFormatIstio
 	}
 
+	// allow default behavior when no labels supplied.
+	if len(jsonLogStruct.Fields) == 0 {
+		jsonLogStruct = EnvoyJSONLogFormatIstio
+	}
+
 	needsFormatter := false
 	for _, value := range jsonLogStruct.Fields {
 		if value.GetStringValue() == requestWithoutQuery {

--- a/pilot/pkg/networking/core/v1alpha3/accesslog_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/accesslog_test.go
@@ -228,6 +228,24 @@ func TestBuildAccessLogFromTelemetry(t *testing.T) {
 		},
 	}
 
+	defaultJsonFormat := &model.LoggingConfig{
+		Providers: []*meshconfig.MeshConfig_ExtensionProvider{
+			{
+				Name: "",
+				Provider: &meshconfig.MeshConfig_ExtensionProvider_EnvoyFileAccessLog{
+					EnvoyFileAccessLog: &meshconfig.MeshConfig_ExtensionProvider_EnvoyFileAccessLogProvider{
+						Path: devStdout,
+						LogFormat: &meshconfig.MeshConfig_ExtensionProvider_EnvoyFileAccessLogProvider_LogFormat{
+							LogFormat: &meshconfig.MeshConfig_ExtensionProvider_EnvoyFileAccessLogProvider_LogFormat_Labels{
+								Labels: &types.Struct{},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
 	customLabelsFormat := &model.LoggingConfig{
 		Providers: []*meshconfig.MeshConfig_ExtensionProvider{
 			{
@@ -429,6 +447,17 @@ func TestBuildAccessLogFromTelemetry(t *testing.T) {
 							InlineString: "%LOCAL_REPLY_BODY%:%RESPONSE_CODE%:path=%REQ(:path)%\n",
 						},
 					},
+				},
+			},
+		},
+	}
+
+	defaultJsonLabelsOut := &fileaccesslog.FileAccessLog{
+		Path: devStdout,
+		AccessLogFormat: &fileaccesslog.FileAccessLog_LogFormat{
+			LogFormat: &core.SubstitutionFormatString{
+				Format: &core.SubstitutionFormatString_JsonFormat{
+					JsonFormat: EnvoyJSONLogFormatIstio,
 				},
 			},
 		},
@@ -636,6 +665,20 @@ func TestBuildAccessLogFromTelemetry(t *testing.T) {
 				{
 					Name:       wellknown.FileAccessLog,
 					ConfigType: &accesslog.AccessLog_TypedConfig{TypedConfig: util.MessageToAny(customTextOut)},
+				},
+			},
+		},
+		{
+			name: "default-labels",
+			meshConfig: &meshconfig.MeshConfig{
+				AccessLogEncoding: meshconfig.MeshConfig_TEXT,
+			},
+			spec:        defaultJsonFormat,
+			forListener: false,
+			expected: []*accesslog.AccessLog{
+				{
+					Name:       wellknown.FileAccessLog,
+					ConfigType: &accesslog.AccessLog_TypedConfig{TypedConfig: util.MessageToAny(defaultJsonLabelsOut)},
 				},
 			},
 		},

--- a/pilot/pkg/networking/core/v1alpha3/accesslog_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/accesslog_test.go
@@ -228,7 +228,7 @@ func TestBuildAccessLogFromTelemetry(t *testing.T) {
 		},
 	}
 
-	defaultJsonFormat := &model.LoggingConfig{
+	defaultJSONFormat := &model.LoggingConfig{
 		Providers: []*meshconfig.MeshConfig_ExtensionProvider{
 			{
 				Name: "",
@@ -452,7 +452,7 @@ func TestBuildAccessLogFromTelemetry(t *testing.T) {
 		},
 	}
 
-	defaultJsonLabelsOut := &fileaccesslog.FileAccessLog{
+	defaultJSONLabelsOut := &fileaccesslog.FileAccessLog{
 		Path: devStdout,
 		AccessLogFormat: &fileaccesslog.FileAccessLog_LogFormat{
 			LogFormat: &core.SubstitutionFormatString{
@@ -673,12 +673,12 @@ func TestBuildAccessLogFromTelemetry(t *testing.T) {
 			meshConfig: &meshconfig.MeshConfig{
 				AccessLogEncoding: meshconfig.MeshConfig_TEXT,
 			},
-			spec:        defaultJsonFormat,
+			spec:        defaultJSONFormat,
 			forListener: false,
 			expected: []*accesslog.AccessLog{
 				{
 					Name:       wellknown.FileAccessLog,
-					ConfigType: &accesslog.AccessLog_TypedConfig{TypedConfig: util.MessageToAny(defaultJsonLabelsOut)},
+					ConfigType: &accesslog.AccessLog_TypedConfig{TypedConfig: util.MessageToAny(defaultJSONLabelsOut)},
 				},
 			},
 		},

--- a/releasenotes/notes/default-json-logging-envoy-telemetry-api.yaml
+++ b/releasenotes/notes/default-json-logging-envoy-telemetry-api.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: feature
+area: telemetry
+issue:
+  - 37663
+
+releaseNotes:
+- |
+  **Added** support for using default JSON access logs format with Telemetry API.


### PR DESCRIPTION
Currently, with the Telemetry API and EnvoyFileAccessLogger extension provider, there is no easy way to select the Istio-default JSON logging format. This PR attempts to add support for that behavior by treating an empty `labels` set as an indication of selection of default behavior (as there is no point to having an empty access log).

- [ X ] Policies and Telemetry
- [ X ] User Experience

Fixes: #37663