### PR TITLE
Standardize run commands for integ tests

### DIFF
--- a/tests/integration/tests.mk
+++ b/tests/integration/tests.mk
@@ -64,10 +64,12 @@ else
 	_INTEGRATION_TEST_FLAGS += --istio.test.kube.config=$(_INTEGRATION_TEST_KUBECONFIG)
 endif
 
+RUN_TEST=$(GO) test -p 1 ${T} -tags=integ -vet=off
+
 test.integration.analyze: test.integration...analyze
 
 test.integration.%.analyze: | $(JUNIT_REPORT) check-go-tag
-	$(GO) test -p 1 ${T} -tags=integ -vet=off ./tests/integration/$(subst .,/,$*)/... -timeout 30m \
+	$(RUN_TEST) ./tests/integration/$(subst .,/,$*)/... -timeout 30m \
 	${_INTEGRATION_TEST_FLAGS} \
 	--istio.test.analyze \
 	2>&1 | tee >($(JUNIT_REPORT) > $(JUNIT_OUT))
@@ -79,7 +81,7 @@ check-go-tag:
 
 # Generate integration test targets for kubernetes environment.
 test.integration.%.kube: | $(JUNIT_REPORT) check-go-tag
-	$(GO) test -p 1 -vet=off ${T} -tags=integ ./tests/integration/$(subst .,/,$*)/... -timeout 30m \
+	$(RUN_TEST) ./tests/integration/$(subst .,/,$*)/... -timeout 30m \
 	${_INTEGRATION_TEST_FLAGS} ${_INTEGRATION_TEST_SELECT_FLAGS} \
 	2>&1 | tee >($(JUNIT_REPORT) > $(JUNIT_OUT))
 
@@ -101,7 +103,7 @@ test.integration.kube: test.integration.kube.presubmit
 # Presubmit integration tests targeting Kubernetes environment. Really used for postsubmit on different k8s versions.
 .PHONY: test.integration.kube.presubmit
 test.integration.kube.presubmit: | $(JUNIT_REPORT) check-go-tag
-	$(GO) test -p 1 -vet=off ${T} -tags=integ $(shell go list -tags=integ ./tests/integration/... | grep -v /qualification | grep -v /examples) -timeout 30m \
+	$(RUN_TEST) ./tests/integration/security -timeout 30m \
 	${_INTEGRATION_TEST_FLAGS} ${_INTEGRATION_TEST_SELECT_FLAGS} \
 	2>&1 | tee >($(JUNIT_REPORT) > $(JUNIT_OUT))
 
@@ -109,7 +111,7 @@ test.integration.kube.presubmit: | $(JUNIT_REPORT) check-go-tag
 # This test suite should be avoided in favor test.integration.kube.environment
 .PHONY: test.integration.kube.reachability
 test.integration.kube.reachability: | $(JUNIT_REPORT) check-go-tag
-	$(GO) test -p 1 ${T} -tags=integ ./tests/integration/security/ -timeout 30m \
+	$(RUN_TEST) ./tests/integration/security/ -timeout 30m \
 	${_INTEGRATION_TEST_FLAGS} ${_INTEGRATION_TEST_SELECT_FLAGS} \
 	--test.run=TestReachability \
 	2>&1 | tee >($(JUNIT_REPORT) > $(JUNIT_OUT))
@@ -119,11 +121,11 @@ test.integration.kube.reachability: | $(JUNIT_REPORT) check-go-tag
 .PHONY: test.integration.kube.environment
 test.integration.kube.environment: | $(JUNIT_REPORT) check-go-tag
 ifeq (${JOB_TYPE},postsubmit)
-	PATH=${PATH}:${ISTIO_OUT} $(GO) test -p 1 ${T} -tags=integ ./tests/integration/... -timeout 30m \
+	$(RUN_TEST) ./tests/integration/... -timeout 30m \
 	${_INTEGRATION_TEST_FLAGS} ${_INTEGRATION_TEST_SELECT_FLAGS} \
 	2>&1 | tee >($(JUNIT_REPORT) > $(JUNIT_OUT))
 else
-	PATH=${PATH}:${ISTIO_OUT} $(GO) test -p 1 ${T} -tags=integ ./tests/integration/security/ ./tests/integration/pilot -timeout 30m \
+	$(RUN_TEST) ./tests/integration/security/ ./tests/integration/pilot -timeout 30m \
 	${_INTEGRATION_TEST_FLAGS} ${_INTEGRATION_TEST_SELECT_FLAGS} \
 	--test.run="TestReachability|TestTraffic" \
 	2>&1 | tee >($(JUNIT_REPORT) > $(JUNIT_OUT))


### PR DESCRIPTION
Some did not have `-vet=false`

**Please provide a description of this PR:**