### PR TITLE
Improve config store error return

### DIFF
--- a/pilot/pkg/config/file/store.go
+++ b/pilot/pkg/config/file/store.go
@@ -210,8 +210,8 @@ func (s *KubeSource) ApplyContent(name, yamlText string) error {
 			if err != nil {
 				_, err = s.inner.Create(*r.config)
 				if err != nil {
-					return fmt.Errorf("cannot store config %v from reader: %s",
-						r.config.Meta, err)
+					return fmt.Errorf("cannot store config %s/%s %s from reader: %s",
+						r.schema.Resource().Version(), r.schema.Resource().Kind(), r.fullName(), err)
 				}
 			}
 			s.shas[key] = r.sha


### PR DESCRIPTION
**Please provide a description of this PR:**
The analyze errors are messy before, like:
```
Error(s) adding files: 21 errors occurred:
        * cannot store config {apps/v1/Deployment  conflicting-ports bookinfo  map[app:conflicting-ports version:v1] map[istiofilefieldmap:{"{.apiVersion}":74,"{.kind}":75,"{.metadata.labels.app}":80,"{.metadata.labels.version}":81,"{.metadata.namespace}":78,"{.metadata.name}":77,"{.spec.replicas}":83,"{.spec.selector.matchLabels.app}":86,"{.spec.selector.matchLabels.version}":87,"{.spec.template.metadata.labels.app}":91,"{.spec.template.metadata.labels.version}":92,"{.spec.template.spec.containers[0].imagePullPolicy}":98,"{.spec.template.spec.containers[0].image}":97,"{.spec.template.spec.containers[0].name}":96,"{.spec.template.spec.containers[0].ports[0].containerPort}":100,"{.spec.template.spec.serviceAccountName}":94} istiosource:{"Filename":"pkg/config/analysis/analyzers/testdata/deployment-multi-service.yaml","Line":72}] v28 0001-01-01 00:00:00 +0000 UTC [] 0} from reader: item already exists
        * cannot store config {networking.istio.io/v1alpha3/DestinationRule  db-mtls default  map[] map[istiofilefieldmap:{"{.apiVersion}":2,"{.kind}":3,"{.metadata.name}":5,"{.spec.host}":7,"{.spec.trafficPolicy.portLevelSettings[0].port.number}":15,"{.spec.trafficPolicy.portLevelSettings[0].tls.clientCertificate}":18,"{.spec.trafficPolicy.portLevelSettings[0].tls.mode}":17,"{.spec.trafficPolicy.portLevelSettings[0].tls.privateKey}":19,"{.spec.trafficPolicy.portLevelSettings[0].tls.sni}":20,"{.spec.trafficPolicy.tls.clientCertificate}":11,"{.spec.trafficPolicy.tls.mode}":10,"{.spec.trafficPolicy.tls.privateKey}":12} istiosource:{"Filename":"pkg/config/analysis/analyzers/testdata/destinationrule-compound-simple-mutual.yaml","Line":1}] v34 0001-01-01 00:00:00 +0000 UTC [] 0} from reader: item already exists
```

After this fix it will be:
```
Error(s) adding files: 21 errors occurred:
        * cannot store config v1/Deployment bookinfo/conflicting-ports from reader: item already exists
        * cannot store config v1alpha3/DestinationRule default/db-mtls from reader: item already exists
        * cannot store config v1alpha3/DestinationRule default/db-tls from reader: item already exists
        * cannot store config v1alpha3/Gateway default/httpbin-gateway from reader: item already exists
```