### PR TITLE
Revert selecting virtual services

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/fake.go
+++ b/pilot/pkg/networking/core/v1alpha3/fake.go
@@ -264,7 +264,8 @@ func (f *ConfigGenTest) Clusters(p *model.Proxy) []*cluster.Cluster {
 func (f *ConfigGenTest) DeltaClusters(
 	p *model.Proxy,
 	configUpdated map[model.ConfigKey]struct{},
-	watched *model.WatchedResource) ([]*cluster.Cluster, []string, bool) {
+	watched *model.WatchedResource,
+) ([]*cluster.Cluster, []string, bool) {
 	raw, removed, _, delta := f.ConfigGen.BuildDeltaClusters(p,
 		&model.PushRequest{
 			Push: f.PushContext(), ConfigsUpdated: configUpdated,
@@ -338,7 +339,9 @@ func getConfigs(t test.Failer, opts TestOptions) []config.Config {
 			}
 			// Set creation timestamp to same time for all of them for consistency.
 			// If explicit setting is needed it can be set in the yaml
-			c.CreationTimestamp = t0
+			if c.CreationTimestamp.IsZero() {
+				c.CreationTimestamp = t0
+			}
 			cfgs = append(cfgs, c)
 		}
 	}

--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -48,7 +48,8 @@ const (
 func (configgen *ConfigGeneratorImpl) BuildHTTPRoutes(
 	node *model.Proxy,
 	req *model.PushRequest,
-	routeNames []string) ([]*discovery.Resource, model.XdsLogDetails) {
+	routeNames []string,
+) ([]*discovery.Resource, model.XdsLogDetails) {
 	routeConfigurations := make([]*discovery.Resource, 0)
 
 	efw := req.Push.EnvoyFilters(node)
@@ -100,7 +101,8 @@ func (configgen *ConfigGeneratorImpl) BuildHTTPRoutes(
 // buildSidecarInboundHTTPRouteConfig builds the route config with a single wildcard virtual host on the inbound path
 // TODO: trace decorators, inbound timeouts
 func (configgen *ConfigGeneratorImpl) buildSidecarInboundHTTPRouteConfig(
-	node *model.Proxy, push *model.PushContext, instance *model.ServiceInstance, clusterName string) *route.RouteConfiguration {
+	node *model.Proxy, push *model.PushContext, instance *model.ServiceInstance, clusterName string,
+) *route.RouteConfiguration {
 	traceOperation := util.TraceOperation(string(instance.Service.Hostname), instance.ServicePort.Port)
 	defaultRoute := istio_route.BuildDefaultHTTPInboundRoute(clusterName, traceOperation)
 
@@ -219,7 +221,8 @@ func BuildSidecarOutboundVirtualHosts(node *model.Proxy, push *model.PushContext
 	routeName string,
 	listenerPort int,
 	efKeys []string,
-	xdsCache model.XdsCache) ([]*route.VirtualHost, *discovery.Resource, *istio_route.Cache) {
+	xdsCache model.XdsCache,
+) ([]*route.VirtualHost, *discovery.Resource, *istio_route.Cache) {
 	var virtualServices []config.Config
 	var services []*model.Service
 

--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -37,7 +37,6 @@ import (
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/proto"
-	"istio.io/pkg/log"
 )
 
 const (
@@ -253,8 +252,6 @@ func selectVirtualServices(virtualServices []config.Config, servicesByName map[h
 
 		if match {
 			out = append(out, c)
-		} else {
-			log.Errorf("howardjohn: drop %v", c.Name)
 		}
 	}
 

--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -271,12 +271,6 @@ func BuildSidecarOutboundVirtualHosts(node *model.Proxy, push *model.PushContext
 		}
 	}
 
-	// This is hack to keep consistent with previous behavior.
-	if listenerPort != 80 {
-		// only select virtualServices that matches a service
-		virtualServices = model.SelectVirtualServices(virtualServices, hostsByNamespace)
-	}
-
 	var routeCache *istio_route.Cache
 
 	if listenerPort > 0 {
@@ -364,7 +358,8 @@ func BuildSidecarOutboundVirtualHosts(node *model.Proxy, push *model.PushContext
 	for _, virtualHostWrapper := range virtualHostWrappers {
 		for _, svc := range virtualHostWrapper.Services {
 			name := util.DomainName(string(svc.Hostname), virtualHostWrapper.Port)
-			knownFQDN.Insert(name, string(svc.Hostname))
+			knownFQDN.Insert(name)
+			knownFQDN.Insert(string(svc.Hostname))
 		}
 	}
 

--- a/pilot/pkg/networking/core/v1alpha3/httproute_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute_test.go
@@ -385,8 +385,7 @@ func TestSidecarOutboundHTTPRouteConfigWithDuplicateHosts(t *testing.T) {
 				"allow_any": "PassthroughCluster",
 				// From the service, go to the service
 				"test.default.svc.cluster.local:80": "outbound|80||test.default.svc.cluster.local",
-				// From the VS, go to VS destination
-				"test.default:80": "outbound|80||test.default",
+				"test.default:80":                   "outbound|80||test.default",
 			},
 		},
 		{
@@ -960,6 +959,24 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 		},
 
 		{
+			name:                  "sidecar config with allow any and virtual service includes non existing service",
+			routeName:             "80",
+			sidecarConfig:         sidecarConfigWithAllowAny,
+			virtualServiceConfigs: []*config.Config{&virtualService6},
+			expectedHosts: map[string]map[string]bool{
+				// does not include `match-no-service`
+				"test-private.com:80": {
+					"test-private.com": true, "test-private.com:80": true, "9.9.9.9": true, "9.9.9.9:80": true,
+				},
+				"match-no-service.not-default:80": {"match-no-service.not-default": true, "match-no-service.not-default:80": true},
+				"allow_any": {
+					"*": true,
+				},
+			},
+			registryOnly: false,
+		},
+
+		{
 			name:                  "wildcard egress importing from all namespaces: 9999",
 			routeName:             "9999",
 			sidecarConfig:         sidecarConfig,
@@ -1240,9 +1257,6 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 				"test.com:8080": {
 					"test.com:8080": true, "8.8.8.8:8080": true,
 				},
-				"test-svc.testns.svc.cluster.local:80": {
-					"test-svc.testns.svc.cluster.local": true, "test-svc.testns.svc.cluster.local:80": true,
-				},
 				"service-A.default.svc.cluster.local:7777": {
 					"service-A.default.svc.cluster.local:7777": true,
 				},
@@ -1284,6 +1298,192 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			testSidecarRDSVHosts(t, services, c.sidecarConfig, c.virtualServiceConfigs,
 				c.routeName, c.expectedHosts, c.expectedRoutes, c.registryOnly)
 		})
+	}
+}
+
+func TestSelectVirtualService(t *testing.T) {
+	services := []*model.Service{
+		buildHTTPService("bookinfo.com", visibility.Public, wildcardIP, "default", 9999, 70),
+		buildHTTPService("private.com", visibility.Private, wildcardIP, "default", 9999, 80),
+		buildHTTPService("test.com", visibility.Public, "8.8.8.8", "not-default", 8080),
+		buildHTTPService("test-private.com", visibility.Private, "9.9.9.9", "not-default", 80, 70),
+		buildHTTPService("test-private-2.com", visibility.Private, "9.9.9.10", "not-default", 60),
+		buildHTTPService("test-headless.com", visibility.Public, wildcardIP, "not-default", 8888),
+	}
+
+	servicesByName := make(map[host.Name]*model.Service, len(services))
+	for _, svc := range services {
+		servicesByName[svc.Hostname] = svc
+	}
+
+	virtualServiceSpec1 := &networking.VirtualService{
+		Hosts:    []string{"test-private-2.com"},
+		Gateways: []string{"mesh"},
+		Http: []*networking.HTTPRoute{
+			{
+				Route: []*networking.HTTPRouteDestination{
+					{
+						Destination: &networking.Destination{
+							// Subset: "some-subset",
+							Host: "example.org",
+							Port: &networking.PortSelector{
+								Number: 61,
+							},
+						},
+						Weight: 100,
+					},
+				},
+			},
+		},
+	}
+	virtualServiceSpec2 := &networking.VirtualService{
+		Hosts:    []string{"test-private-2.com"},
+		Gateways: []string{"mesh"},
+		Http: []*networking.HTTPRoute{
+			{
+				Route: []*networking.HTTPRouteDestination{
+					{
+						Destination: &networking.Destination{
+							Host: "test.org",
+							Port: &networking.PortSelector{
+								Number: 62,
+							},
+						},
+						Weight: 100,
+					},
+				},
+			},
+		},
+	}
+	virtualServiceSpec3 := &networking.VirtualService{
+		Hosts:    []string{"test-private-3.com"},
+		Gateways: []string{"mesh"},
+		Http: []*networking.HTTPRoute{
+			{
+				Route: []*networking.HTTPRouteDestination{
+					{
+						Destination: &networking.Destination{
+							Host: "test.org",
+							Port: &networking.PortSelector{
+								Number: 63,
+							},
+						},
+						Weight: 100,
+					},
+				},
+			},
+		},
+	}
+	virtualServiceSpec4 := &networking.VirtualService{
+		Hosts:    []string{"test-headless.com", "example.com"},
+		Gateways: []string{"mesh"},
+		Http: []*networking.HTTPRoute{
+			{
+				Route: []*networking.HTTPRouteDestination{
+					{
+						Destination: &networking.Destination{
+							Host: "test.org",
+							Port: &networking.PortSelector{
+								Number: 64,
+							},
+						},
+						Weight: 100,
+					},
+				},
+			},
+		},
+	}
+	virtualServiceSpec5 := &networking.VirtualService{
+		Hosts:    []string{"test-svc.testns.svc.cluster.local"},
+		Gateways: []string{"mesh"},
+		Http: []*networking.HTTPRoute{
+			{
+				Route: []*networking.HTTPRouteDestination{
+					{
+						Destination: &networking.Destination{
+							Host: "test-svc.testn.svc.cluster.local",
+						},
+						Weight: 100,
+					},
+				},
+			},
+		},
+	}
+	virtualServiceSpec6 := &networking.VirtualService{
+		Hosts:    []string{"match-no-service"},
+		Gateways: []string{"mesh"},
+		Http: []*networking.HTTPRoute{
+			{
+				Route: []*networking.HTTPRouteDestination{
+					{
+						Destination: &networking.Destination{
+							Host: "non-exist-service",
+						},
+						Weight: 100,
+					},
+				},
+			},
+		},
+	}
+	virtualService1 := config.Config{
+		Meta: config.Meta{
+			GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
+			Name:             "acme2-v1",
+			Namespace:        "not-default",
+		},
+		Spec: virtualServiceSpec1,
+	}
+	virtualService2 := config.Config{
+		Meta: config.Meta{
+			GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
+			Name:             "acme-v2",
+			Namespace:        "not-default",
+		},
+		Spec: virtualServiceSpec2,
+	}
+	virtualService3 := config.Config{
+		Meta: config.Meta{
+			GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
+			Name:             "acme-v3",
+			Namespace:        "not-default",
+		},
+		Spec: virtualServiceSpec3,
+	}
+	virtualService4 := config.Config{
+		Meta: config.Meta{
+			GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
+			Name:             "acme-v4",
+			Namespace:        "not-default",
+		},
+		Spec: virtualServiceSpec4,
+	}
+	virtualService5 := config.Config{
+		Meta: config.Meta{
+			GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
+			Name:             "acme-v3",
+			Namespace:        "not-default",
+		},
+		Spec: virtualServiceSpec5,
+	}
+	virtualService6 := config.Config{
+		Meta: config.Meta{
+			GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
+			Name:             "acme-v3",
+			Namespace:        "not-default",
+		},
+		Spec: virtualServiceSpec6,
+	}
+	configs := selectVirtualServices(
+		[]config.Config{virtualService1, virtualService2, virtualService3, virtualService4, virtualService5, virtualService6},
+		servicesByName)
+	expectedVS := []string{virtualService1.Name, virtualService2.Name, virtualService4.Name}
+	if len(expectedVS) != len(configs) {
+		t.Fatalf("Unexpected virtualService, got %d, epxected %d", len(configs), len(expectedVS))
+	}
+	for i, config := range configs {
+		if config.Name != expectedVS[i] {
+			t.Fatalf("Unexpected virtualService, got %s, epxected %s", config.Name, expectedVS[i])
+		}
 	}
 }
 

--- a/pilot/pkg/networking/core/v1alpha3/httproute_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute_test.go
@@ -1289,7 +1289,8 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 
 func testSidecarRDSVHosts(t *testing.T, services []*model.Service,
 	sidecarConfig *config.Config, virtualServices []*config.Config, routeName string,
-	expectedHosts map[string]map[string]bool, expectedRoutes int, registryOnly bool) {
+	expectedHosts map[string]map[string]bool, expectedRoutes int, registryOnly bool,
+) {
 	t.Helper()
 	p := &fakePlugin{}
 	configgen := NewConfigGenerator([]plugin.Plugin{p}, &model.DisabledCache{})

--- a/pilot/pkg/networking/core/v1alpha3/httproute_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute_test.go
@@ -385,7 +385,8 @@ func TestSidecarOutboundHTTPRouteConfigWithDuplicateHosts(t *testing.T) {
 				"allow_any": "PassthroughCluster",
 				// From the service, go to the service
 				"test.default.svc.cluster.local:80": "outbound|80||test.default.svc.cluster.local",
-				"test.default:80":                   "outbound|80||test.default",
+				// From the VS, go to VS destination
+				"test.default:80": "outbound|80||test.default",
 			},
 		},
 		{
@@ -1238,6 +1239,9 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 				},
 				"test.com:8080": {
 					"test.com:8080": true, "8.8.8.8:8080": true,
+				},
+				"test-svc.testns.svc.cluster.local:80": {
+					"test-svc.testns.svc.cluster.local": true, "test-svc.testns.svc.cluster.local:80": true,
 				},
 				"service-A.default.svc.cluster.local:7777": {
 					"service-A.default.svc.cluster.local:7777": true,

--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -232,15 +232,14 @@ func buildSidecarVirtualHostsForVirtualService(
 		}
 	}
 
-	// We need to group the virtual hosts by port, because each http connection manager is
-	// going to send a separate RDS request
-	// Note that we need to build non-default HTTP routes only for the virtual services.
-	// The services in the serviceRegistry will always have a default route (/)
 	if len(serviceByPort) == 0 {
-		// This is a gross HACK. Fix me. Its a much bigger surgery though, due to the way
-		// the current code is written.
-		serviceByPort[80] = nil
+		if listenPort == 80 {
+			// TODO: This is a gross HACK. Fix me. Its a much bigger surgery though, due to the way
+			// the current code is written.
+			serviceByPort[80] = nil
+		}
 	}
+
 	out := make([]VirtualHostWrapper, 0, len(serviceByPort))
 	for port, services := range serviceByPort {
 		out = append(out, VirtualHostWrapper{

--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -88,7 +88,8 @@ type VirtualHostWrapper struct {
 // service registry. Services are indexed by FQDN hostnames.
 // The list of Services is also passed to allow maintaining consistent ordering.
 func BuildSidecarVirtualHostWrapper(routeCache *Cache, node *model.Proxy, push *model.PushContext, serviceRegistry map[host.Name]*model.Service,
-	virtualServices []config.Config, listenPort int) []VirtualHostWrapper {
+	virtualServices []config.Config, listenPort int,
+) []VirtualHostWrapper {
 	out := make([]VirtualHostWrapper, 0)
 
 	// dependentDestinationRules includes all the destinationrules referenced by the virtualservices, which have consistent hash policy.
@@ -155,7 +156,8 @@ func BuildSidecarVirtualHostWrapper(routeCache *Cache, node *model.Proxy, push *
 // separateVSHostsAndServices splits the virtual service hosts into Services (if they are found in the registry) and
 // plain non-registry hostnames
 func separateVSHostsAndServices(virtualService config.Config,
-	serviceRegistry map[host.Name]*model.Service) ([]string, []*model.Service) {
+	serviceRegistry map[host.Name]*model.Service,
+) ([]string, []*model.Service) {
 	rule := virtualService.Spec.(*networking.VirtualService)
 	hosts := make([]string, 0)
 	servicesInVirtualService := make([]*model.Service, 0)
@@ -459,7 +461,8 @@ func applyHTTPRouteDestination(
 	authority string,
 	serviceRegistry map[host.Name]*model.Service,
 	listenerPort int,
-	hashByDestination map[*networking.HTTPRouteDestination]*networking.LoadBalancerSettings_ConsistentHashLB) {
+	hashByDestination map[*networking.HTTPRouteDestination]*networking.LoadBalancerSettings_ConsistentHashLB,
+) {
 	policy := in.Retries
 	if policy == nil {
 		// No VS policy set, use mesh defaults
@@ -1157,7 +1160,8 @@ func translateFault(in *networking.HTTPFaultInjection) *xdshttpfault.HTTPFault {
 }
 
 func portLevelSettingsConsistentHash(dst *networking.Destination,
-	pls []*networking.TrafficPolicy_PortTrafficPolicy) *networking.LoadBalancerSettings_ConsistentHashLB {
+	pls []*networking.TrafficPolicy_PortTrafficPolicy,
+) *networking.LoadBalancerSettings_ConsistentHashLB {
 	if dst.Port != nil {
 		portNumber := dst.GetPort().GetNumber()
 		for _, setting := range pls {
@@ -1217,7 +1221,8 @@ func consistentHashToHashPolicy(consistentHash *networking.LoadBalancerSettings_
 }
 
 func getHashForService(node *model.Proxy, push *model.PushContext,
-	svc *model.Service, port *model.Port) (*networking.LoadBalancerSettings_ConsistentHashLB, *config.Config) {
+	svc *model.Service, port *model.Port,
+) (*networking.LoadBalancerSettings_ConsistentHashLB, *config.Config) {
 	if push == nil {
 		return nil, nil
 	}
@@ -1243,7 +1248,8 @@ func getHashForService(node *model.Proxy, push *model.PushContext,
 
 func GetConsistentHashForVirtualService(push *model.PushContext, node *model.Proxy,
 	virtualService config.Config,
-	serviceRegistry map[host.Name]*model.Service) map[*networking.HTTPRouteDestination]*networking.LoadBalancerSettings_ConsistentHashLB {
+	serviceRegistry map[host.Name]*model.Service,
+) map[*networking.HTTPRouteDestination]*networking.LoadBalancerSettings_ConsistentHashLB {
 	hashByDestination := map[*networking.HTTPRouteDestination]*networking.LoadBalancerSettings_ConsistentHashLB{}
 	for _, httpRoute := range virtualService.Spec.(*networking.VirtualService).Http {
 		for _, destination := range httpRoute.Route {
@@ -1266,7 +1272,8 @@ func GetConsistentHashForVirtualService(push *model.PushContext, node *model.Pro
 
 // GetHashForHTTPDestination return the ConsistentHashLB and the DestinationRule associated with HTTP route destination.
 func GetHashForHTTPDestination(push *model.PushContext, node *model.Proxy, dst *networking.HTTPRouteDestination,
-	configNamespace string) (*networking.LoadBalancerSettings_ConsistentHashLB, *config.Config) {
+	configNamespace string,
+) (*networking.LoadBalancerSettings_ConsistentHashLB, *config.Config) {
 	if push == nil {
 		return nil, nil
 	}

--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -230,14 +230,15 @@ func buildSidecarVirtualHostsForVirtualService(
 		}
 	}
 
+	// We need to group the virtual hosts by port, because each http connection manager is
+	// going to send a separate RDS request
+	// Note that we need to build non-default HTTP routes only for the virtual services.
+	// The services in the serviceRegistry will always have a default route (/)
 	if len(serviceByPort) == 0 {
-		if listenPort == 80 {
-			// TODO: This is a gross HACK. Fix me. Its a much bigger surgery though, due to the way
-			// the current code is written.
-			serviceByPort[80] = nil
-		}
+		// This is a gross HACK. Fix me. Its a much bigger surgery though, due to the way
+		// the current code is written.
+		serviceByPort[80] = nil
 	}
-
 	out := make([]VirtualHostWrapper, 0, len(serviceByPort))
 	for port, services := range serviceByPort {
 		out = append(out, VirtualHostWrapper{

--- a/pilot/pkg/networking/core/v1alpha3/sidecar_simulation_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/sidecar_simulation_test.go
@@ -1403,7 +1403,8 @@ spec:
 
 	mkCall := func(port int, protocol simulation.Protocol,
 		tls simulation.TLSMode, validations []simulation.CustomFilterChainValidation,
-		mTLSSecretConfigName string) simulation.Call {
+		mTLSSecretConfigName string,
+	) simulation.Call {
 		return simulation.Call{
 			Protocol:                  protocol,
 			Port:                      port,
@@ -2064,7 +2065,7 @@ spec:
 			routeName: "80",
 			expected: map[string][]string{
 				// even though there is an *.example.com, since we do not import it we should create a wildcard matcher
-				"*.example.com":        {"outbound|80||arbitrary.example.com"},
+				"*.example.com": {"outbound|80||arbitrary.example.com"},
 				// We did not import this, shouldn't show up
 				"explicit.example.com": nil,
 			},

--- a/pilot/pkg/networking/core/v1alpha3/sidecar_simulation_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/sidecar_simulation_test.go
@@ -1782,11 +1782,9 @@ spec:
 			proxy:     proxy("default"),
 			routeName: "8080",
 			// For unknown services, we only will add a route to the port 80
-			// TODO even with port match?? that seems wrong!
-			//expected: map[string][]string{
-			//	"foo.com": {"outbound|8080||foo.com"},
-			//},
-			expected: nil,
+			expected: map[string][]string{
+				"foo.com": nil,
+			},
 		},
 		{
 			name: "unknown port 8080 dest 8080 ",

--- a/pilot/pkg/networking/core/v1alpha3/sidecar_simulation_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/sidecar_simulation_test.go
@@ -2132,6 +2132,37 @@ spec:
 			},
 		},
 		{
+			name: "wildcard and explicit unknown",
+			cfg: "" +
+				vs(t, vsArgs{
+					Namespace: "default",
+					Match:     "*.tld",
+					Dest:      "wild.example.com",
+					Time:      TimeOlder,
+				}) +
+				vs(t, vsArgs{
+					Namespace: "default",
+					Match:     "*.com",
+					Dest:      "explicit.example.com",
+					Time:      TimeNewer,
+				}) +
+				vs(t, vsArgs{
+					Namespace: "default",
+					Match:     "known-default.example.com",
+					Dest:      "explicit.example.com",
+					Time:      TimeBase,
+				}),
+			proxy:     proxy("default"),
+			routeName: "80",
+			expected: map[string][]string{
+				// wildcard does not match
+				"known-default.example.com": {"outbound|80||known-default.example.com"},
+				// Even though its less exact, this wildcard wins
+				"*.tld":         {"outbound|80||wild.example.com"},
+				"*.example.tld": nil,
+			},
+		},
+		{
 			name: "explicit match with wildcard sidecar",
 			cfg: "" +
 				vs(t, vsArgs{

--- a/pilot/pkg/networking/core/v1alpha3/sidecar_simulation_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/sidecar_simulation_test.go
@@ -2132,37 +2132,6 @@ spec:
 			},
 		},
 		{
-			name: "wildcard and explicit unknown",
-			cfg: "" +
-				vs(t, vsArgs{
-					Namespace: "default",
-					Match:     "*.tld",
-					Dest:      "wild.example.com",
-					Time:      TimeOlder,
-				}) +
-				vs(t, vsArgs{
-					Namespace: "default",
-					Match:     "*.com",
-					Dest:      "explicit.example.com",
-					Time:      TimeNewer,
-				}) +
-				vs(t, vsArgs{
-					Namespace: "default",
-					Match:     "known-default.example.com",
-					Dest:      "explicit.example.com",
-					Time:      TimeBase,
-				}),
-			proxy:     proxy("default"),
-			routeName: "80",
-			expected: map[string][]string{
-				// wildcard does not match
-				"known-default.example.com": {"outbound|80||known-default.example.com"},
-				// Even though its less exact, this wildcard wins
-				"*.tld":         {"outbound|80||wild.example.com"},
-				"*.example.tld": nil,
-			},
-		},
-		{
 			name: "explicit match with wildcard sidecar",
 			cfg: "" +
 				vs(t, vsArgs{


### PR DESCRIPTION
Revert https://github.com/istio/istio/pull/33764 to fix https://github.com/istio/istio/issues/37691. Alternative is https://github.com/istio/istio/pull/37721.

This was primarily to get the new tests I wrote passing. These same tests pass on the release-1.11 branch, ensuring we have no behavioral regression. I am ok moving forward with https://github.com/istio/istio/pull/37721 if we pull in these tests there and they all pass (currently they do not).

