### PR TITLE
add dual stack support for echo server [TF]

### DIFF
--- a/pkg/test/echo/server/endpoint/util.go
+++ b/pkg/test/echo/server/endpoint/util.go
@@ -28,7 +28,16 @@ import (
 var epLog = log.RegisterScope("endpoint", "echo serverside", 0)
 
 func listenOnAddress(ip string, port int) (net.Listener, int, error) {
-	ln, err := net.Listen("tcp", net.JoinHostPort(ip, strconv.Itoa(port)))
+	parsedIP := net.ParseIP(ip)
+	ipBind := "tcp"
+	if parsedIP != nil {
+		if parsedIP.To4() == nil && parsedIP.To16() != nil {
+			ipBind = "tcp6"
+		} else if parsedIP.To4() != nil {
+			ipBind = "tcp4"
+		}
+	}
+	ln, err := net.Listen(ipBind, net.JoinHostPort(ip, strconv.Itoa(port)))
 	if err != nil {
 		return nil, 0, err
 	}
@@ -38,11 +47,19 @@ func listenOnAddress(ip string, port int) (net.Listener, int, error) {
 }
 
 func listenOnAddressTLS(ip string, port int, cfg *tls.Config) (net.Listener, int, error) {
-	ln, err := tls.Listen("tcp", net.JoinHostPort(ip, strconv.Itoa(port)), cfg)
+	ipBind := "tcp"
+	parsedIP := net.ParseIP(ip)
+	if parsedIP != nil {
+		if parsedIP.To4() == nil && parsedIP.To16() != nil {
+			ipBind = "tcp6"
+		} else if parsedIP.To4() != nil {
+			ipBind = "tcp4"
+		}
+	}
+	ln, err := tls.Listen(ipBind, net.JoinHostPort(ip, strconv.Itoa(port)), cfg)
 	if err != nil {
 		return nil, 0, err
 	}
-
 	port = ln.Addr().(*net.TCPAddr).Port
 	return ln, port, nil
 }

--- a/pkg/test/echo/server/instance.go
+++ b/pkg/test/echo/server/instance.go
@@ -133,7 +133,7 @@ func (s *Instance) Start() (err error) {
 }
 
 func getBindAddresses(ip string) []string {
-	if ip != "localhost" {
+	if ip != "" && ip != "localhost" {
 		return []string{ip}
 	}
 	// Binding to "localhost" will only bind to a single address (v4 or v6). We want both, so we need
@@ -158,10 +158,18 @@ func getBindAddresses(ip string) []string {
 	}
 	addrs := []string{}
 	if v4 {
-		addrs = append(addrs, "127.0.0.1")
+		if ip == "localhost" {
+			addrs = append(addrs, "127.0.0.1")
+		} else {
+			addrs = append(addrs, "0.0.0.0")
+		}
 	}
 	if v6 {
-		addrs = append(addrs, "::1")
+		if ip == "localhost" {
+			addrs = append(addrs, "::1")
+		} else {
+			addrs = append(addrs, "::")
+		}
 	}
 	return addrs
 }


### PR DESCRIPTION
**Please provide a description of this PR:**
Modify the Echo Server to support Dual Stack. Based on the IP addresses of the Pod, Echo server will listen IPv4 or IPv6 addresses.
Part of https://github.com/istio/istio/issues/37533


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [x ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [x] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
