### PR TITLE
istioctl x metrice support to specify resource type, support type [workload]

### DIFF
--- a/istioctl/cmd/metrics_test.go
+++ b/istioctl/cmd/metrics_test.go
@@ -72,6 +72,26 @@ func TestMetrics(t *testing.T) {
 			expectedRegexp: regexp.MustCompile("could not build metrics for workload"),
 			wantException:  true,
 		},
+		{ // case 1
+			args:           strings.Split("experimental metrics workload/details", " "),
+			expectedRegexp: regexp.MustCompile("could not build metrics for workload"),
+			wantException:  true,
+		},
+		{ // case 2
+			args:           strings.Split("experimental metrics workload/details.ns1", " "),
+			expectedRegexp: regexp.MustCompile("could not build metrics for workload"),
+			wantException:  true,
+		},
+		{ // case 3
+			args:           strings.Split("experimental metrics workload,service/details", " "),
+			expectedRegexp: regexp.MustCompile("arguments in resource/name form must have a single resource and name"),
+			wantException:  true,
+		},
+		{ // case 4
+			args:           strings.Split("experimental metrics service/details", " "),
+			expectedRegexp: regexp.MustCompilePOSIX("invalid resouce type"),
+			wantException:  true,
+		},
 	}
 
 	for i, c := range cases {
@@ -123,7 +143,10 @@ func TestPrintMetrics(t *testing.T) {
 			},
 		},
 	}
-	workload := "details"
+	workload := resourceTuple{
+		Type: workload_ResourceType,
+		Name: "details",
+	}
 
 	sm, err := metrics(mockProm, workload, time.Minute)
 	if err != nil {

--- a/istioctl/cmd/metrics_test.go
+++ b/istioctl/cmd/metrics_test.go
@@ -89,7 +89,7 @@ func TestMetrics(t *testing.T) {
 		},
 		{ // case 4
 			args:           strings.Split("experimental metrics service/details", " "),
-			expectedRegexp: regexp.MustCompilePOSIX("invalid resouce type"),
+			expectedRegexp: regexp.MustCompilePOSIX("invalid resource type"),
 			wantException:  true,
 		},
 	}
@@ -144,7 +144,7 @@ func TestPrintMetrics(t *testing.T) {
 		},
 	}
 	workload := resourceTuple{
-		Type: workload_ResourceType,
+		Type: workloadResourceType,
 		Name: "details",
 	}
 

--- a/releasenotes/notes/37822.yaml
+++ b/releasenotes/notes/37822.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: feature
+area: istioctl
+issue:
+  - https://github.com/istio/istio/issues/36428
+  - 37822
+releaseNotes:
+- |
+    **Added** Retrieve resource metrics by their type and name, support type [workload], for example: `istioctl experimental metrics workload/productpage-v1`


### PR DESCRIPTION
**Please provide a description of this PR:**
1. refactor `istioctl x metrics`code  of  add the advance features
2. user-facing: 
  ```
  # Retrieve resource metrics by their type and name, support type [workload]
  istioctl experimental metrics workload/productpage-v1
  ```

more info:
issue: https://github.com/istio/istio/issues/36428
doc:  https://docs.google.com/document/d/1ATp4qCHktncfAFjH_S9yWm9dGxI_aXHN2cw1AD4kveQ/edit?usp=sharing