### PR TITLE
Fix in resource settings in charts

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -222,18 +222,26 @@ data:
               requests:
                 {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
                 cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
+                {{ else if index .Values.global.proxy.resources "requests" "cpu" }}
+                cpu: "{{ index .Values.global.proxy.resources "requests" "cpu" }}"
                 {{ end }}
                 {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
                 memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
+                {{ else if index .Values.global.proxy.resources "requests" "memory" }}
+                memory: "{{ index .Values.global.proxy.resources "requests" "memory" }}"
                 {{ end }}
             {{- end }}
             {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
               limits:
                 {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
                 cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+                {{ else if index .Values.global.proxy.resources "limits" "cpu" }}
+                cpu: "{{ index .Values.global.proxy.resources "limits" "cpu" }}"
                 {{ end }}
                 {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
                 memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+                {{ else if index .Values.global.proxy.resources "limits" "memory" }}
+                memory: "{{ index .Values.global.proxy.resources "limits" "memory" }}"
                 {{ end }}
             {{- end }}
           {{- else }}
@@ -1129,18 +1137,26 @@ data:
               requests:
                 {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
                 cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
+                {{ else if index .Values.global.proxy.resources "requests" "cpu" }}
+                cpu: "{{ index .Values.global.proxy.resources "requests" "cpu" }}"
                 {{ end }}
                 {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
                 memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
+                {{ else if index .Values.global.proxy.resources "requests" "memory" }}
+                memory: "{{ index .Values.global.proxy.resources "requests" "memory" }}"
                 {{ end }}
             {{- end }}
             {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
               limits:
                 {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
                 cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+                {{ else if index .Values.global.proxy.resources "limits" "cpu" }}
+                cpu: "{{ index .Values.global.proxy.resources "limits" "cpu" }}"
                 {{ end }}
                 {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
                 memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+                {{ else if index .Values.global.proxy.resources "limits" "memory" }}
+                memory: "{{ index .Values.global.proxy.resources "limits" "memory" }}"
                 {{ end }}
             {{- end }}
           {{- else }}

--- a/manifests/charts/istio-control/istio-discovery/files/grpc-agent.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/grpc-agent.yaml
@@ -157,18 +157,26 @@ spec:
       requests:
         {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
         cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
+        {{ else if index .Values.global.proxy.resources "requests" "cpu" }}
+        cpu: "{{ index .Values.global.proxy.resources "requests" "cpu" }}"
         {{ end }}
         {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
         memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
+        {{ else if index .Values.global.proxy.resources "requests" "memory" }}
+        memory: "{{ index .Values.global.proxy.resources "requests" "memory" }}"
         {{ end }}
     {{- end }}
     {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
       limits:
         {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
         cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+        {{ else if index .Values.global.proxy.resources "limits" "cpu" }}
+        cpu: "{{ index .Values.global.proxy.resources "limits" "cpu" }}"
         {{ end }}
         {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
         memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+        {{ else if index .Values.global.proxy.resources "limits" "memory" }}
+        memory: "{{ index .Values.global.proxy.resources "limits" "memory" }}"
         {{ end }}
     {{- end }}
   {{- else }}

--- a/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
@@ -4,18 +4,26 @@
       requests:
         {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
         cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
+        {{ else if index .Values.global.proxy.resources "requests" "cpu" }}
+        cpu: "{{ index .Values.global.proxy.resources "requests" "cpu" }}"
         {{ end }}
         {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
         memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
+        {{ else if index .Values.global.proxy.resources "requests" "memory" }}
+        memory: "{{ index .Values.global.proxy.resources "requests" "memory" }}"
         {{ end }}
     {{- end }}
     {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
       limits:
         {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
         cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+        {{ else if index .Values.global.proxy.resources "limits" "cpu" }}
+        cpu: "{{ index .Values.global.proxy.resources "limits" "cpu" }}"
         {{ end }}
         {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
         memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+        {{ else if index .Values.global.proxy.resources "limits" "memory" }}
+        memory: "{{ index .Values.global.proxy.resources "limits" "memory" }}"
         {{ end }}
     {{- end }}
   {{- else }}

--- a/manifests/charts/istiod-remote/files/injection-template.yaml
+++ b/manifests/charts/istiod-remote/files/injection-template.yaml
@@ -4,18 +4,26 @@
       requests:
         {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
         cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
+        {{ else if index .Values.global.proxy.resources "requests" "cpu" }}
+        cpu: "{{ index .Values.global.proxy.resources "requests" "cpu" }}"
         {{ end }}
         {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
         memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
+        {{ else if index .Values.global.proxy.resources "requests" "memory" }}
+        memory: "{{ index .Values.global.proxy.resources "requests" "memory" }}"
         {{ end }}
     {{- end }}
     {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
       limits:
         {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
         cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+        {{ else if index .Values.global.proxy.resources "limits" "cpu" }}
+        cpu: "{{ index .Values.global.proxy.resources "limits" "cpu" }}"
         {{ end }}
         {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
         memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+        {{ else if index .Values.global.proxy.resources "limits" "memory" }}
+        memory: "{{ index .Values.global.proxy.resources "limits" "memory" }}"
         {{ end }}
     {{- end }}
   {{- else }}

--- a/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
@@ -124,6 +124,7 @@ spec:
         resources:
           requests:
             cpu: "4"
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -176,6 +177,7 @@ spec:
         resources:
           requests:
             cpu: "4"
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/kube/inject/testdata/inputs/custom-template.yaml.34.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/custom-template.yaml.34.template.gen.yaml
@@ -15,18 +15,26 @@ templates:
           requests:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "requests" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "requests" "memory" }}"
             {{ end }}
         {{- end }}
         {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
           limits:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "limits" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "limits" "memory" }}"
             {{ end }}
         {{- end }}
       {{- else }}
@@ -922,18 +930,26 @@ templates:
           requests:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "requests" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "requests" "memory" }}"
             {{ end }}
         {{- end }}
         {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
           limits:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "limits" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "limits" "memory" }}"
             {{ end }}
         {{- end }}
       {{- else }}

--- a/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
@@ -15,18 +15,26 @@ templates:
           requests:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "requests" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "requests" "memory" }}"
             {{ end }}
         {{- end }}
         {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
           limits:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "limits" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "limits" "memory" }}"
             {{ end }}
         {{- end }}
       {{- else }}
@@ -922,18 +930,26 @@ templates:
           requests:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "requests" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "requests" "memory" }}"
             {{ end }}
         {{- end }}
         {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
           limits:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "limits" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "limits" "memory" }}"
             {{ end }}
         {{- end }}
       {{- else }}

--- a/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
@@ -15,18 +15,26 @@ templates:
           requests:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "requests" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "requests" "memory" }}"
             {{ end }}
         {{- end }}
         {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
           limits:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "limits" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "limits" "memory" }}"
             {{ end }}
         {{- end }}
       {{- else }}
@@ -922,18 +930,26 @@ templates:
           requests:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "requests" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "requests" "memory" }}"
             {{ end }}
         {{- end }}
         {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
           limits:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "limits" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "limits" "memory" }}"
             {{ end }}
         {{- end }}
       {{- else }}

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
@@ -15,18 +15,26 @@ templates:
           requests:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "requests" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "requests" "memory" }}"
             {{ end }}
         {{- end }}
         {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
           limits:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "limits" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "limits" "memory" }}"
             {{ end }}
         {{- end }}
       {{- else }}
@@ -922,18 +930,26 @@ templates:
           requests:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "requests" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "requests" "memory" }}"
             {{ end }}
         {{- end }}
         {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
           limits:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "limits" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "limits" "memory" }}"
             {{ end }}
         {{- end }}
       {{- else }}

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
@@ -15,18 +15,26 @@ templates:
           requests:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "requests" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "requests" "memory" }}"
             {{ end }}
         {{- end }}
         {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
           limits:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "limits" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "limits" "memory" }}"
             {{ end }}
         {{- end }}
       {{- else }}
@@ -922,18 +930,26 @@ templates:
           requests:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "requests" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "requests" "memory" }}"
             {{ end }}
         {{- end }}
         {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
           limits:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "limits" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "limits" "memory" }}"
             {{ end }}
         {{- end }}
       {{- else }}

--- a/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
@@ -15,18 +15,26 @@ templates:
           requests:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "requests" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "requests" "memory" }}"
             {{ end }}
         {{- end }}
         {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
           limits:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "limits" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "limits" "memory" }}"
             {{ end }}
         {{- end }}
       {{- else }}
@@ -922,18 +930,26 @@ templates:
           requests:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "requests" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "requests" "memory" }}"
             {{ end }}
         {{- end }}
         {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
           limits:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "limits" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "limits" "memory" }}"
             {{ end }}
         {{- end }}
       {{- else }}

--- a/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
@@ -15,18 +15,26 @@ templates:
           requests:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "requests" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "requests" "memory" }}"
             {{ end }}
         {{- end }}
         {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
           limits:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "limits" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "limits" "memory" }}"
             {{ end }}
         {{- end }}
       {{- else }}
@@ -922,18 +930,26 @@ templates:
           requests:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "requests" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "requests" "memory" }}"
             {{ end }}
         {{- end }}
         {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
           limits:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "limits" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "limits" "memory" }}"
             {{ end }}
         {{- end }}
       {{- else }}

--- a/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
@@ -15,18 +15,26 @@ templates:
           requests:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "requests" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "requests" "memory" }}"
             {{ end }}
         {{- end }}
         {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
           limits:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "limits" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "limits" "memory" }}"
             {{ end }}
         {{- end }}
       {{- else }}
@@ -922,18 +930,26 @@ templates:
           requests:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "requests" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "requests" "memory" }}"
             {{ end }}
         {{- end }}
         {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
           limits:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "limits" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "limits" "memory" }}"
             {{ end }}
         {{- end }}
       {{- else }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
@@ -15,18 +15,26 @@ templates:
           requests:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "requests" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "requests" "memory" }}"
             {{ end }}
         {{- end }}
         {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
           limits:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "limits" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "limits" "memory" }}"
             {{ end }}
         {{- end }}
       {{- else }}
@@ -922,18 +930,26 @@ templates:
           requests:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "requests" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "requests" "memory" }}"
             {{ end }}
         {{- end }}
         {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
           limits:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "limits" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "limits" "memory" }}"
             {{ end }}
         {{- end }}
       {{- else }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
@@ -15,18 +15,26 @@ templates:
           requests:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "requests" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "requests" "memory" }}"
             {{ end }}
         {{- end }}
         {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
           limits:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "limits" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "limits" "memory" }}"
             {{ end }}
         {{- end }}
       {{- else }}
@@ -922,18 +930,26 @@ templates:
           requests:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "requests" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "requests" "memory" }}"
             {{ end }}
         {{- end }}
         {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
           limits:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "limits" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "limits" "memory" }}"
             {{ end }}
         {{- end }}
       {{- else }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
@@ -15,18 +15,26 @@ templates:
           requests:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "requests" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "requests" "memory" }}"
             {{ end }}
         {{- end }}
         {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
           limits:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "limits" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "limits" "memory" }}"
             {{ end }}
         {{- end }}
       {{- else }}
@@ -922,18 +930,26 @@ templates:
           requests:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "requests" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "requests" "memory" }}"
             {{ end }}
         {{- end }}
         {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
           limits:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "limits" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "limits" "memory" }}"
             {{ end }}
         {{- end }}
       {{- else }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
@@ -15,18 +15,26 @@ templates:
           requests:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "requests" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "requests" "memory" }}"
             {{ end }}
         {{- end }}
         {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
           limits:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "limits" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "limits" "memory" }}"
             {{ end }}
         {{- end }}
       {{- else }}
@@ -922,18 +930,26 @@ templates:
           requests:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "requests" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "requests" "memory" }}"
             {{ end }}
         {{- end }}
         {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
           limits:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "limits" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "limits" "memory" }}"
             {{ end }}
         {{- end }}
       {{- else }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
@@ -15,18 +15,26 @@ templates:
           requests:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "requests" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "requests" "memory" }}"
             {{ end }}
         {{- end }}
         {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
           limits:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "limits" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "limits" "memory" }}"
             {{ end }}
         {{- end }}
       {{- else }}
@@ -922,18 +930,26 @@ templates:
           requests:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "requests" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "requests" "memory" }}"
             {{ end }}
         {{- end }}
         {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
           limits:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "limits" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "limits" "memory" }}"
             {{ end }}
         {{- end }}
       {{- else }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
@@ -15,18 +15,26 @@ templates:
           requests:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "requests" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "requests" "memory" }}"
             {{ end }}
         {{- end }}
         {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
           limits:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "limits" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "limits" "memory" }}"
             {{ end }}
         {{- end }}
       {{- else }}
@@ -922,18 +930,26 @@ templates:
           requests:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "requests" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "requests" "memory" }}"
             {{ end }}
         {{- end }}
         {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
           limits:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "limits" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "limits" "memory" }}"
             {{ end }}
         {{- end }}
       {{- else }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
@@ -15,18 +15,26 @@ templates:
           requests:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "requests" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "requests" "memory" }}"
             {{ end }}
         {{- end }}
         {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
           limits:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "limits" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "limits" "memory" }}"
             {{ end }}
         {{- end }}
       {{- else }}
@@ -922,18 +930,26 @@ templates:
           requests:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "requests" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "requests" "memory" }}"
             {{ end }}
         {{- end }}
         {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
           limits:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "limits" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "limits" "memory" }}"
             {{ end }}
         {{- end }}
       {{- else }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
@@ -15,18 +15,26 @@ templates:
           requests:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "requests" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "requests" "memory" }}"
             {{ end }}
         {{- end }}
         {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
           limits:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "limits" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "limits" "memory" }}"
             {{ end }}
         {{- end }}
       {{- else }}
@@ -922,18 +930,26 @@ templates:
           requests:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "requests" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "requests" "memory" }}"
             {{ end }}
         {{- end }}
         {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
           limits:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "limits" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "limits" "memory" }}"
             {{ end }}
         {{- end }}
       {{- else }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
@@ -15,18 +15,26 @@ templates:
           requests:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "requests" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "requests" "memory" }}"
             {{ end }}
         {{- end }}
         {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
           limits:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "limits" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "limits" "memory" }}"
             {{ end }}
         {{- end }}
       {{- else }}
@@ -922,18 +930,26 @@ templates:
           requests:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "requests" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "requests" "memory" }}"
             {{ end }}
         {{- end }}
         {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
           limits:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "limits" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "limits" "memory" }}"
             {{ end }}
         {{- end }}
       {{- else }}

--- a/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
@@ -15,18 +15,26 @@ templates:
           requests:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "requests" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "requests" "memory" }}"
             {{ end }}
         {{- end }}
         {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
           limits:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "limits" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "limits" "memory" }}"
             {{ end }}
         {{- end }}
       {{- else }}
@@ -922,18 +930,26 @@ templates:
           requests:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "requests" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "requests" "memory" }}"
             {{ end }}
         {{- end }}
         {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
           limits:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "limits" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "limits" "memory" }}"
             {{ end }}
         {{- end }}
       {{- else }}

--- a/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
@@ -15,18 +15,26 @@ templates:
           requests:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "requests" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "requests" "memory" }}"
             {{ end }}
         {{- end }}
         {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
           limits:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "limits" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "limits" "memory" }}"
             {{ end }}
         {{- end }}
       {{- else }}
@@ -922,18 +930,26 @@ templates:
           requests:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "requests" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "requests" "memory" }}"
             {{ end }}
         {{- end }}
         {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
           limits:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "limits" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "limits" "memory" }}"
             {{ end }}
         {{- end }}
       {{- else }}

--- a/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
@@ -15,18 +15,26 @@ templates:
           requests:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "requests" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "requests" "memory" }}"
             {{ end }}
         {{- end }}
         {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
           limits:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "limits" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "limits" "memory" }}"
             {{ end }}
         {{- end }}
       {{- else }}
@@ -922,18 +930,26 @@ templates:
           requests:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "requests" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
+            {{ else if index .Values.global.proxy.resources "requests" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "requests" "memory" }}"
             {{ end }}
         {{- end }}
         {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
           limits:
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
             cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "cpu" }}
+            cpu: "{{ index .Values.global.proxy.resources "limits" "cpu" }}"
             {{ end }}
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
             memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+            {{ else if index .Values.global.proxy.resources "limits" "memory" }}
+            memory: "{{ index .Values.global.proxy.resources "limits" "memory" }}"
             {{ end }}
         {{- end }}
       {{- else }}


### PR DESCRIPTION

Signed-off-by: Faseela K <faseela.k@est.tech>

The current templates are in such a way that if all the four annotations
for resources are not set, the default values will not be set for the
remaining ones.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [X ] Configuration Infrastructure
- [ ] Docs
- [X ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure