### PR TITLE
minor dns fix and additional tests

### DIFF
--- a/pkg/dns/client/dns.go
+++ b/pkg/dns/client/dns.go
@@ -281,7 +281,9 @@ func (h *LocalDNSServer) ServeDNS(proxy *dnsProxy, w dns.ResponseWriter, req *dn
 		// Randomize the responses; this ensures for things like headless services we can do DNS-LB
 		// This matches standard kube-dns behavior. We only do this for cached responses as the
 		// upstream DNS server would already round robin if desired.
-		roundRobinResponse(response)
+		if len(answers) > 0 {
+			roundRobinResponse(response)
+		}
 		log.Debugf("response for hostname %q (found=true): %v", hostname, response)
 	} else {
 		response = h.upstream(proxy, req, hostname)
@@ -412,7 +414,8 @@ func separateIPtypes(ips []string) (ipv4, ipv6 []net.IP) {
 }
 
 func generateAltHosts(hostname string, nameinfo *dnsProto.NameTable_NameInfo, proxyNamespace, proxyDomain string,
-	proxyDomainParts []string) map[string]struct{} {
+	proxyDomainParts []string,
+) map[string]struct{} {
 	out := make(map[string]struct{})
 	out[hostname+"."] = struct{}{}
 	// do not generate alt hostnames if the service is in a different domain (i.e. cluster) than the proxy

--- a/pkg/dns/client/dns_test.go
+++ b/pkg/dns/client/dns_test.go
@@ -175,6 +175,16 @@ func TestDNS(t *testing.T) {
 			expected: a("a.b.wildcard.", []net.IP{net.ParseIP("11.11.11.11").To4()}),
 		},
 		{
+			name:     "success: wild card with domain returns A record correctly",
+			host:     "mj-splunk.svc.mesh.company.net.",
+			expected: a("mj-splunk.svc.mesh.company.net.", []net.IP{net.ParseIP("10.1.2.3").To4()}),
+		},
+		{
+			name:     "success: wild card with namespace with domain returns A record correctly",
+			host:     "foo.foons.svc.mesh.company.net.",
+			expected: a("foo.foons.svc.mesh.company.net.", []net.IP{net.ParseIP("10.1.2.3").To4()}),
+		},
+		{
 			name:      "success: TypeAAAA query returns AAAA records only",
 			host:      "dual.localhost.",
 			queryAAAA: true,
@@ -517,6 +527,10 @@ func initDNS(t test.Failer) *LocalDNSServer {
 			},
 			"*.wildcard": {
 				Ips:      []string{"10.10.10.10"},
+				Registry: "External",
+			},
+			"*.svc.mesh.company.net": {
+				Ips:      []string{"10.1.2.3"},
 				Registry: "External",
 			},
 			"example.localhost.": {

--- a/pkg/dns/client/dns_test.go
+++ b/pkg/dns/client/dns_test.go
@@ -176,8 +176,8 @@ func TestDNS(t *testing.T) {
 		},
 		{
 			name:     "success: wild card with domain returns A record correctly",
-			host:     "mj-splunk.svc.mesh.company.net.",
-			expected: a("mj-splunk.svc.mesh.company.net.", []net.IP{net.ParseIP("10.1.2.3").To4()}),
+			host:     "foo.svc.mesh.company.net.",
+			expected: a("foo.svc.mesh.company.net.", []net.IP{net.ParseIP("10.1.2.3").To4()}),
 		},
 		{
 			name:     "success: wild card with namespace with domain returns A record correctly",


### PR DESCRIPTION
Only call roundRobinResponse when there are answers to reduce on unnecessary allocations in roundRobinResponse function and additional tests in wildcards

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure