### PR TITLE
Synchronize MCS even handling

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/serviceimportcache.go
+++ b/pilot/pkg/serviceregistry/kube/controller/serviceimportcache.go
@@ -101,35 +101,40 @@ func (ic *serviceImportCacheImpl) onServiceEvent(svc *model.Service, event model
 		return
 	}
 
-	namespacedName := namespacedNameForService(svc)
+	// This method is called concurrently from each cluster's queue. Process it in `this` cluster's queue
+	// in order to synchronize event processing.
+	ic.queue.Push(func() error {
+		namespacedName := namespacedNameForService(svc)
 
-	// Lookup the previous MCS service if there was one.
-	mcsHost := serviceClusterSetLocalHostname(namespacedName)
-	prevMcsService := ic.GetService(mcsHost)
+		// Lookup the previous MCS service if there was one.
+		mcsHost := serviceClusterSetLocalHostname(namespacedName)
+		prevMcsService := ic.GetService(mcsHost)
 
-	// Get the ClusterSet VIPs for this service in this cluster. Will only be populated if the
-	// service has a ServiceImport in this cluster.
-	vips := ic.getClusterSetIPs(namespacedName)
-	name := namespacedName.Name
-	ns := namespacedName.Namespace
+		// Get the ClusterSet VIPs for this service in this cluster. Will only be populated if the
+		// service has a ServiceImport in this cluster.
+		vips := ic.getClusterSetIPs(namespacedName)
+		name := namespacedName.Name
+		ns := namespacedName.Namespace
 
-	if len(vips) == 0 || (event == model.EventDelete &&
-		ic.opts.MeshServiceController.GetService(kube.ServiceHostname(name, ns, ic.opts.DomainSuffix)) == nil) {
-		if prevMcsService != nil {
-			// There are no vips in this cluster. Just delete the MCS service now.
-			ic.deleteService(prevMcsService)
+		if len(vips) == 0 || (event == model.EventDelete &&
+			ic.opts.MeshServiceController.GetService(kube.ServiceHostname(name, ns, ic.opts.DomainSuffix)) == nil) {
+			if prevMcsService != nil {
+				// There are no vips in this cluster. Just delete the MCS service now.
+				ic.deleteService(prevMcsService)
+			}
+			return nil
 		}
-		return
-	}
 
-	if prevMcsService != nil {
-		event = model.EventUpdate
-	} else {
-		event = model.EventAdd
-	}
+		if prevMcsService != nil {
+			event = model.EventUpdate
+		} else {
+			event = model.EventAdd
+		}
 
-	mcsService := ic.genMCSService(svc, mcsHost, vips)
-	ic.addOrUpdateService(nil, mcsService, event, false)
+		mcsService := ic.genMCSService(svc, mcsHost, vips)
+		ic.addOrUpdateService(nil, mcsService, event, false)
+		return nil
+	})
 }
 
 func (ic *serviceImportCacheImpl) onServiceImportEvent(obj interface{}, event model.Event) error {


### PR DESCRIPTION
The MCS serviceImportCacheImpl.onServiceEvent is called concurrently from every service update in the mesh. This logic needs to be processed synchronously as a unit to avoid races.

This PR moves the processing for this method onto the local cluster's queue.

**Please provide a description of this PR:**