### PR TITLE
fix istioctl metrics: prometheus query invalid duration

### DIFF
--- a/istioctl/cmd/metrics_test.go
+++ b/istioctl/cmd/metrics_test.go
@@ -108,24 +108,24 @@ var _ promv1.API = mockPromAPI{}
 func TestPrintMetrics(t *testing.T) {
 	mockProm := mockPromAPI{
 		cannedResponse: map[string]prometheus_model.Value{
-			"sum(rate(istio_requests_total{destination_workload=~\"details.*\", destination_workload_namespace=~\".*\",reporter=\"destination\"}[1m0s]))": prometheus_model.Vector{ // nolint: lll
+			"sum(rate(istio_requests_total{destination_workload=~\"details.*\", destination_workload_namespace=~\".*\",reporter=\"destination\"}[60s]))": prometheus_model.Vector{ // nolint: lll
 				&prometheus_model.Sample{Value: 0.04},
 			},
-			"sum(rate(istio_requests_total{destination_workload=~\"details.*\", destination_workload_namespace=~\".*\",reporter=\"destination\",response_code=~\"[45][0-9]{2}\"}[1m0s]))": prometheus_model.Vector{}, // nolint: lll
-			"histogram_quantile(0.500000, sum(rate(istio_request_duration_milliseconds_bucket{destination_workload=~\"details.*\", destination_workload_namespace=~\".*\",reporter=\"destination\"}[1m0s])) by (le))": prometheus_model.Vector{ // nolint: lll
+			"sum(rate(istio_requests_total{destination_workload=~\"details.*\", destination_workload_namespace=~\".*\",reporter=\"destination\",response_code=~\"[45][0-9]{2}\"}[60s]))": prometheus_model.Vector{}, // nolint: lll
+			"histogram_quantile(0.500000, sum(rate(istio_request_duration_milliseconds_bucket{destination_workload=~\"details.*\", destination_workload_namespace=~\".*\",reporter=\"destination\"}[60s])) by (le))": prometheus_model.Vector{ // nolint: lll
 				&prometheus_model.Sample{Value: 2.5},
 			},
-			"histogram_quantile(0.900000, sum(rate(istio_request_duration_milliseconds_bucket{destination_workload=~\"details.*\", destination_workload_namespace=~\".*\",reporter=\"destination\"}[1m0s])) by (le))": prometheus_model.Vector{ // nolint: lll
+			"histogram_quantile(0.900000, sum(rate(istio_request_duration_milliseconds_bucket{destination_workload=~\"details.*\", destination_workload_namespace=~\".*\",reporter=\"destination\"}[60s])) by (le))": prometheus_model.Vector{ // nolint: lll
 				&prometheus_model.Sample{Value: 4.5},
 			},
-			"histogram_quantile(0.990000, sum(rate(istio_request_duration_milliseconds_bucket{destination_workload=~\"details.*\", destination_workload_namespace=~\".*\",reporter=\"destination\"}[1m0s])) by (le))": prometheus_model.Vector{ // nolint: lll
+			"histogram_quantile(0.990000, sum(rate(istio_request_duration_milliseconds_bucket{destination_workload=~\"details.*\", destination_workload_namespace=~\".*\",reporter=\"destination\"}[60s])) by (le))": prometheus_model.Vector{ // nolint: lll
 				&prometheus_model.Sample{Value: 4.95},
 			},
 		},
 	}
 	workload := "details"
 
-	sm, err := metrics(mockProm, workload, time.Minute)
+	sm, err := metrics(mockProm, workload, int64(time.Minute.Seconds()))
 	if err != nil {
 		t.Fatalf("Unwanted exception %v", err)
 	}


### PR DESCRIPTION
**Please provide a description of this PR:**
fix bug: https://github.com/istio/istio/pull/36726
bug report: prometheus query was invalid
example:
```
sum(rate(istio_requests_total{destination_workload=~"details.*", destination_workload_namespace=~".*",reporter="destination"}[1m0s]))
```
error:
```
Error executing query: invalid parameter 'query': 1:127: parse error: bad duration syntax: "1m0"
```