### PR TITLE
feat: helm-chart/gateway Apply all labels to pods also

### DIFF
--- a/manifests/charts/gateway/templates/deployment.yaml
+++ b/manifests/charts/gateway/templates/deployment.yaml
@@ -25,7 +25,7 @@ spec:
         {{- with .Values.revision }}
         istio.io/rev: {{ . }}
         {{- end }}
-        {{- include "gateway.selectorLabels" . | nindent 8 }}
+        {{- include "gateway.labels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:


### PR DESCRIPTION
**Please provide a description of this PR:**

Currently when using the Helm chart for deploying Istio gateway the deployment resource is nicely labelled with all Kubernetes recommended labels, however, the actual pod is only labelled with the selector labels. Would be nice to have all labels on the actual pod also.