### PR TITLE
Allow tolerations in istiod helm chart

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -61,6 +61,10 @@ spec:
       nodeSelector:
 {{ toYaml .Values.pilot.nodeSelector | indent 8 }}
 {{- end }}
+{{- if .Values.pilot.tolerations }}
+      tolerations:
+{{ toYaml .Values.pilot.tolerations | indent 8 }}
+{{- end }}
 {{- with .Values.pilot.affinity }}
       affinity:
 {{- toYaml . | nindent 8 }}

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -33,6 +33,7 @@ pilot:
   enableProtocolSniffingForInbound: true
 
   nodeSelector: {}
+  tolerations: {}
   podAnnotations: {}
   serviceAnnotations: {}
 


### PR DESCRIPTION
**Please provide a description of this PR:**
This commits allows users to specify tolerations for the istiod chart. This can be leverated to schedule istiod on the Kubernetes control plane, for example. 

The default is "no tolerations (`{}`)", so the bahavior does not change.