### PR TITLE
bootstrap: make file path `/var/run/secrets/tokens/istio-token` relative

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/tracing.go
+++ b/pilot/pkg/networking/core/v1alpha3/tracing.go
@@ -39,6 +39,7 @@ import (
 	xdsfilters "istio.io/istio/pilot/pkg/xds/filters"
 	"istio.io/istio/pilot/pkg/xds/requestidextension"
 	"istio.io/istio/pkg/bootstrap/platform"
+	"istio.io/istio/pkg/config/constants"
 	"istio.io/pkg/log"
 )
 
@@ -210,7 +211,7 @@ func configureFromProviderConfig(pushCtx *model.PushContext, meta *model.NodeMet
 									CredentialSpecifier: &envoy_config_core_v3.GrpcService_GoogleGrpc_CallCredentials_StsService_{
 										StsService: &envoy_config_core_v3.GrpcService_GoogleGrpc_CallCredentials_StsService{
 											TokenExchangeServiceUri: fmt.Sprintf("http://localhost:%d/token", stsPort),
-											SubjectTokenPath:        "/var/run/secrets/tokens/istio-token",
+											SubjectTokenPath:        constants.TrustworthyJWTPath,
 											SubjectTokenType:        "urn:ietf:params:oauth:token-type:jwt",
 											Scope:                   "https://www.googleapis.com/auth/cloud-platform",
 										},

--- a/pkg/bootstrap/instance_test.go
+++ b/pkg/bootstrap/instance_test.go
@@ -212,7 +212,7 @@ func TestGolden(t *testing.T) {
 										CredentialSpecifier: &core.GrpcService_GoogleGrpc_CallCredentials_StsService_{
 											StsService: &core.GrpcService_GoogleGrpc_CallCredentials_StsService{
 												TokenExchangeServiceUri: "http://localhost:15463/token",
-												SubjectTokenPath:        "/var/run/secrets/tokens/istio-token",
+												SubjectTokenPath:        "./var/run/secrets/tokens/istio-token",
 												SubjectTokenType:        "urn:ietf:params:oauth:token-type:jwt",
 												Scope:                   "https://www.googleapis.com/auth/cloud-platform",
 											},

--- a/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
+++ b/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
@@ -519,7 +519,7 @@
           "call_credentials": [{
             "sts_service": {
               "token_exchange_service_uri": "http://localhost:15463/token",
-              "subject_token_path": "/var/run/secrets/tokens/istio-token",
+              "subject_token_path": "./var/run/secrets/tokens/istio-token",
               "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
               "scope": "https://www.googleapis.com/auth/cloud-platform"
             }

--- a/tools/packaging/common/envoy_bootstrap.json
+++ b/tools/packaging/common/envoy_bootstrap.json
@@ -632,7 +632,7 @@
           "call_credentials": [{
             "sts_service": {
               "token_exchange_service_uri": "http://localhost:{{ .sts_port }}/token",
-              "subject_token_path": "/var/run/secrets/tokens/istio-token",
+              "subject_token_path": "./var/run/secrets/tokens/istio-token",
               "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
               "scope": "https://www.googleapis.com/auth/cloud-platform"
             }

--- a/tools/packaging/common/gcp_envoy_bootstrap.json
+++ b/tools/packaging/common/gcp_envoy_bootstrap.json
@@ -43,7 +43,7 @@
             {{ if .sts }}
               "sts_service": {
                 "token_exchange_service_uri": "http://localhost:{{ .sts_port }}/token",
-                "subject_token_path": "/var/run/secrets/tokens/istio-token",
+                "subject_token_path": "./var/run/secrets/tokens/istio-token",
                 "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
                 "scope": "https://www.googleapis.com/auth/cloud-platform"
               }
@@ -95,7 +95,7 @@
             {{ if .sts }}
               "sts_service": {
                 "token_exchange_service_uri": "http://localhost:{{ .sts_port }}/token",
-                "subject_token_path": "/var/run/secrets/tokens/istio-token",
+                "subject_token_path": "./var/run/secrets/tokens/istio-token",
                 "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
                 "scope": "https://www.googleapis.com/auth/cloud-platform"
               }
@@ -160,7 +160,7 @@
           "call_credentials": [{
             "sts_service": {
               "token_exchange_service_uri": "http://localhost:{{ .sts_port }}/token",
-              "subject_token_path": "/var/run/secrets/tokens/istio-token",
+              "subject_token_path": "./var/run/secrets/tokens/istio-token",
               "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
               "scope": "https://www.googleapis.com/auth/cloud-platform"
             }


### PR DESCRIPTION
Signed-off-by: Yaroslav Skopets <yaroslav@tetrate.io>

**Please provide a description of this PR:**

This PR refactors Envoy config to make file path `/var/run/secrets/tokens/istio-token` relative.