### PR TITLE
[WIP][experimental] UDP support at the gateways

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -241,3 +241,5 @@ require (
 	sigs.k8s.io/kustomize/kyaml v0.13.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
 )
+
+replace istio.io/api => github.com/su225/api v0.0.0-20220311171230-df8456ce5e8b

--- a/manifests/charts/base/crds/crd-all.gen.yaml
+++ b/manifests/charts/base/crds/crd-all.gen.yaml
@@ -4507,6 +4507,49 @@ spec:
                       type: array
                   type: object
                 type: array
+              udp:
+                items:
+                  properties:
+                    match:
+                      items:
+                        properties:
+                          gateways:
+                            items:
+                              type: string
+                            type: array
+                          port:
+                            type: integer
+                        type: object
+                      type: array
+                    route:
+                      items:
+                        properties:
+                          destination:
+                            properties:
+                              host:
+                                description: The name of a service from the service
+                                  registry.
+                                type: string
+                              port:
+                                description: Specifies the port on the host that is
+                                  being addressed.
+                                properties:
+                                  number:
+                                    type: integer
+                                type: object
+                              subset:
+                                description: The name of a subset within the service.
+                                type: string
+                            type: object
+                          weight:
+                            description: Weight specifies the relative proportion
+                              of traffic to be forwarded to the destination.
+                            format: int32
+                            type: integer
+                        type: object
+                      type: array
+                  type: object
+                type: array
             type: object
           status:
             type: object
@@ -5228,6 +5271,49 @@ spec:
                     route:
                       description: The destination to which the connection should
                         be forwarded to.
+                      items:
+                        properties:
+                          destination:
+                            properties:
+                              host:
+                                description: The name of a service from the service
+                                  registry.
+                                type: string
+                              port:
+                                description: Specifies the port on the host that is
+                                  being addressed.
+                                properties:
+                                  number:
+                                    type: integer
+                                type: object
+                              subset:
+                                description: The name of a subset within the service.
+                                type: string
+                            type: object
+                          weight:
+                            description: Weight specifies the relative proportion
+                              of traffic to be forwarded to the destination.
+                            format: int32
+                            type: integer
+                        type: object
+                      type: array
+                  type: object
+                type: array
+              udp:
+                items:
+                  properties:
+                    match:
+                      items:
+                        properties:
+                          gateways:
+                            items:
+                              type: string
+                            type: array
+                          port:
+                            type: integer
+                        type: object
+                      type: array
+                    route:
                       items:
                         properties:
                           destination:

--- a/pilot/pkg/model/gateway.go
+++ b/pilot/pkg/model/gateway.go
@@ -218,13 +218,15 @@ func MergeGateways(gateways []gatewayWithInstances, proxy *Proxy, ps *PushContex
 				// Envoy does not support "quic_inspector" listener filter
 				if isUDPServer {
 					if gatewayUDPPorts[resolvedPort] {
+						// TODO(su225): Consider bind address differences as valid before rejecting
 						log.Infof("skipping UDP server on gateway %s port %s.%d.%s. Multiple UDP services cannot "+
 							"be run on the same UDP port", gatewayName, s.Port.Name, resolvedPort, s.Port.Protocol)
 						RecordRejectedConfig(gatewayName)
 					} else {
 						gatewayUDPPorts[resolvedPort] = true
-						log.Debugf("MergedGateways: [su225-debug] UDP server at port %d (resolved=%d) added",
-							s.Port.Number, resolvedPort)
+						log.Debugf("MergedGateways: [su225-debug] UDP server at port %+v (resolved=%d) added: %+v",
+							s.Port, resolvedPort, s)
+						serverPorts = append(serverPorts, serverPort)
 						mergedUDPServers[serverPort] = &MergedServers{Servers: []*networking.Server{s}}
 					}
 					continue

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -36,7 +36,6 @@ import (
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/labels"
-	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/config/visibility"
 	"istio.io/istio/pkg/util/sets"
@@ -1426,9 +1425,6 @@ func (ps *PushContext) initServiceAccounts(env *Environment, services []*Service
 			ps.ServiceAccounts[svc.Hostname] = map[int][]string{}
 		}
 		for _, port := range svc.Ports {
-			if port.Protocol == protocol.UDP {
-				continue
-			}
 			ps.ServiceAccounts[svc.Hostname][port.Port] = env.GetIstioServiceAccounts(svc, []int{port.Port})
 		}
 	}

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -672,7 +672,7 @@ func (ports PortList) Get(name string) (*Port, bool) {
 // GetByPort retrieves a port declaration by port value
 func (ports PortList) GetByPort(num int) (*Port, bool) {
 	for _, port := range ports {
-		if port.Port == num && port.Protocol != protocol.UDP {
+		if port.Port == num {
 			return port, true
 		}
 	}

--- a/pilot/pkg/model/virtualservice.go
+++ b/pilot/pkg/model/virtualservice.go
@@ -131,6 +131,19 @@ func resolveVirtualServiceShortnames(rule *networking.VirtualService, meta confi
 			}
 		}
 	}
+	// resolve host in udp route.destination
+	for _, d := range rule.Udp {
+		for _, m := range d.Match {
+			for i, g := range m.Gateways {
+				if g != constants.IstioMeshGateway {
+					m.Gateways[i] = resolveGatewayName(g, meta)
+				}
+			}
+		}
+		for _, w := range d.Route {
+			w.Destination.Host = string(ResolveShortnameToFQDN(w.Destination.Host, meta))
+		}
+	}
 	// resolve host in tls route.destination
 	for _, tls := range rule.Tls {
 		for _, m := range tls.Match {

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -246,9 +246,6 @@ func (configgen *ConfigGeneratorImpl) buildOutboundClusters(cb *ClusterBuilder, 
 	hit, miss := 0, 0
 	for _, service := range services {
 		for _, port := range service.Ports {
-			if port.Protocol == protocol.UDP {
-				continue
-			}
 			clusterKey := buildClusterKey(service, port, cb, proxy, efKeys)
 			cached, allFound := cb.getAllCachedSubsetClusters(*clusterKey)
 			if allFound && !features.EnableUnsafeAssertions {
@@ -356,9 +353,6 @@ func (configgen *ConfigGeneratorImpl) buildOutboundSniDnatClusters(proxy *model.
 
 		destRule := proxy.SidecarScope.DestinationRule(model.TrafficDirectionOutbound, proxy, service.Hostname)
 		for _, port := range service.Ports {
-			if port.Protocol == protocol.UDP {
-				continue
-			}
 			lbEndpoints := cb.buildLocalityLbEndpoints(networkView, service, port.Port, nil)
 
 			// create default cluster

--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -90,6 +90,7 @@ func (configgen *ConfigGeneratorImpl) buildGatewayListeners(builder *ListenerBui
 		transportToServers := map[istionetworking.TransportProtocol]map[model.ServerPort]*model.MergedServers{
 			istionetworking.TransportProtocolTCP:  mergedGateway.MergedServers,
 			istionetworking.TransportProtocolQUIC: mergedGateway.MergedQUICTransportServers,
+			istionetworking.ListenerProtocolUDP:   mergedGateway.MergedUDPTransportServers,
 		}
 
 		for transport, gwServers := range transportToServers {
@@ -122,6 +123,9 @@ func (configgen *ConfigGeneratorImpl) buildGatewayListeners(builder *ListenerBui
 			switch transport {
 			case istionetworking.TransportProtocolTCP:
 				newFilterChains = configgen.buildGatewayTCPBasedFilterChains(builder, p, port, opts, serversForPort, proxyConfig, mergedGateway)
+			case istionetworking.TransportProtocolUDP:
+				log.Debugf("buildGatewayListeners: [su225-debug] generating filter chain for UDP gateway port "+
+					"is not yet implemented. Port=%d", port.Number)
 			case istionetworking.TransportProtocolQUIC:
 				// Currently, we just assume that QUIC is HTTP/3 although that does not
 				// have to be the case (it is just the most common case now, in the future

--- a/pilot/pkg/networking/networking.go
+++ b/pilot/pkg/networking/networking.go
@@ -85,6 +85,8 @@ const (
 	TransportProtocolTCP = iota
 	// TransportProtocolQUIC is a QUIC listener
 	TransportProtocolQUIC
+	// TransportProtocolUDP is a UDP listener
+	TransportProtocolUDP
 )
 
 func (tp TransportProtocol) String() string {
@@ -98,7 +100,7 @@ func (tp TransportProtocol) String() string {
 }
 
 func (tp TransportProtocol) ToEnvoySocketProtocol() core.SocketAddress_Protocol {
-	if tp == TransportProtocolQUIC {
+	if tp == TransportProtocolQUIC || tp == TransportProtocolUDP {
 		return core.SocketAddress_UDP
 	}
 	return core.SocketAddress_TCP

--- a/pilot/pkg/networking/networking.go
+++ b/pilot/pkg/networking/networking.go
@@ -42,6 +42,8 @@ const (
 	ListenerProtocolHTTP
 	// ListenerProtocolAuto enables auto protocol detection
 	ListenerProtocolAuto
+	// ListenerProtocolUDP is a UDP listener.
+	ListenerProtocolUDP
 )
 
 // ModelProtocolToListenerProtocol converts from a config.Protocol to its corresponding plugin.ListenerProtocol
@@ -54,7 +56,7 @@ func ModelProtocolToListenerProtocol(p protocol.Instance,
 		protocol.Mongo, protocol.Redis, protocol.MySQL:
 		return ListenerProtocolTCP
 	case protocol.UDP:
-		return ListenerProtocolUnknown
+		return ListenerProtocolUDP
 	case protocol.Unsupported:
 		// If protocol sniffing is not enabled, the default value is TCP
 		switch trafficDirection {

--- a/pilot/pkg/networking/networking.go
+++ b/pilot/pkg/networking/networking.go
@@ -95,6 +95,8 @@ func (tp TransportProtocol) String() string {
 		return "tcp"
 	case TransportProtocolQUIC:
 		return "quic"
+	case TransportProtocolUDP:
+		return "udp"
 	}
 	return "unknown"
 }

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -1116,10 +1116,6 @@ func (c *Controller) serviceInstancesFromWorkloadInstance(si *model.WorkloadInst
 			}
 
 			for _, servicePort := range service.Ports {
-				if servicePort.Protocol == protocol.UDP {
-					continue
-				}
-
 				// Now get the target Port for this service port
 				targetPort := findServiceTargetPort(servicePort, k8sSvc)
 				if targetPort.num == 0 {

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -44,7 +44,6 @@ import (
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/mesh"
-	"istio.io/istio/pkg/config/protocol"
 	kubelib "istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/network"
 	"istio.io/istio/pkg/queue"
@@ -1171,9 +1170,6 @@ func (c *Controller) WorkloadInstanceHandler(si *model.WorkloadInstance, event m
 			// We need one endpoint object for each service port
 			endpoints := make([]*model.IstioEndpoint, 0)
 			for _, port := range service.Ports {
-				if port.Protocol == protocol.UDP {
-					continue
-				}
 				// Similar code as UpdateServiceShards in eds.go
 				instances := c.InstancesByPort(service, port.Port, labels.Collection{})
 				for _, inst := range instances {

--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -283,6 +283,9 @@ func extractRuntimeFlags(cfg *model.NodeMetaProxyConfig) map[string]string {
 		"envoy.reloadable_features.require_strict_1xx_and_204_response_headers":                                "false",
 		"re2.max_program_size.error_level":                                                                     "32768",
 		"envoy.reloadable_features.http_reject_path_with_fragment":                                             "false",
+
+		// TODO(su225): Enable only when UDP feature is enabled
+		"envoy.reloadable_features.udp_listener_updates_filter_chain_in_place": "true",
 	}
 	if !StripFragment {
 		// Note: the condition here is basically backwards. This was a mistake in the initial commit and cannot be reverted

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -2098,8 +2098,9 @@ var ValidateVirtualService = registerValidateFunc("ValidateVirtualService",
 			}
 		}
 
-		if len(virtualService.Http) == 0 && len(virtualService.Tcp) == 0 && len(virtualService.Tls) == 0 {
-			errs = appendValidation(errs, errors.New("http, tcp or tls must be provided in virtual service"))
+		if len(virtualService.Http) == 0 && len(virtualService.Tcp) == 0 &&
+			len(virtualService.Tls) == 0 && len(virtualService.Udp) == 0 {
+			errs = appendValidation(errs, errors.New("http, udp, tcp or tls must be provided in virtual service"))
 		}
 		for _, httpRoute := range virtualService.Http {
 			if httpRoute == nil {


### PR DESCRIPTION
**Please provide a description of this PR:**
Part of https://github.com/istio/istio/issues/1430

This PR adds a feature to support routing UDP traffic at the gateway. The VirtualService API is also enhanced with a new `udp` section. Here is the demo of it. All files used are available here - https://github.com/su225/istio-udp.

For full configs - see https://github.com/su225/istio-udp/blob/main/istio-configs.yaml
The corresponding API branch in my fork - https://github.com/su225/api/tree/udp-api (Commit: https://github.com/su225/api/commit/e25f95a6b25b5d95f26745f94e819e24e0095582)

Gateway 
```yaml
apiVersion: networking.istio.io/v1alpha3
kind: Gateway
metadata:
  name: udp-echo-gateway
  namespace: istio-system
spec:
  selector:
    app: istio-ingressgateway
  servers:
  - port:
      number: 5000
      name: udp-echo
      protocol: UDP
    hosts:
    - echo.com
  - port:
      number: 5000
      name: tcp-echo
      protocol: TCP
    hosts:
    - echo.com
```

VirtualService
```yaml
apiVersion: networking.istio.io/v1alpha3
kind: VirtualService
metadata:
  name: udp-routes
  namespace: istio-system
spec:
  hosts:
  - echo.com
  gateways:
  - udp-echo-gateway
  exportTo:
  - "*"
  tcp:
  - route:
    - destination:
        host: echo.udp-echo.svc.cluster.local
        subset: v1
        port:
          number: 2020
      weight: 80
    - destination:
        host: echo.udp-echo.svc.cluster.local
        subset: v2
        port:
          number: 2020
      weight: 20
  udp:
  - match:
    - port: 5000
    route:
    - destination:
        host: echo.udp-echo.svc.cluster.local
        port:
          number: 2020
```
Now, peeking into gateway config
```
$ istioctl proxy-config listeners istio-ingressgateway-768bd4c6d8-t5m6v.istio-system --port 5000 -o json
[
    {
        "name": "udp_0.0.0.0_5000",
        "address": {
            "socketAddress": {
                "protocol": "UDP",
                "address": "0.0.0.0",
                "portValue": 5000
            }
        },
        "listenerFilters": [
            {
                "name": "envoy.filters.udp_listener.udp_proxy",
                "typedConfig": {
                    "@type": "type.googleapis.com/envoy.extensions.filters.udp.udp_proxy.v3.UdpProxyConfig",
                    "statPrefix": "outbound|2020|v1|echo.udp-echo.svc.cluster.local",
                    "cluster": "outbound|2020|v1|echo.udp-echo.svc.cluster.local",
                    "upstreamSocketConfig": {
                        "preferGro": true
                    }
                }
            }
        ],
        "trafficDirection": "OUTBOUND",
        "udpListenerConfig": {
            "downstreamSocketConfig": {}
        },
        "enableReusePort": true,

// lots of other stuffs here
```

Let us route some traffic now
```
$ nc -v -u 172.18.210.1 5000
Ncat: Version 7.80 ( https://nmap.org/ncat )
Ncat: Connected to 172.18.210.1:5000.
hello
v1:b'hello\n'world
v1:b'world\n'[from istio] hello udp  
v1:b'[from istio] hello udp\n'Ncat: 35 bytes sent, 56 bytes received in 23.34 seconds.

$ nc -v -u 172.18.210.1 5000
Ncat: Version 7.80 ( https://nmap.org/ncat )
Ncat: Connected to 172.18.210.1:5000.
hello
v2:b'hello\n'hello
v2:b'hello\n'hello
v2:b'hello\n'hello
v2:b'hello\n'Ncat: 24 bytes sent, 52 bytes received in 8.82 seconds.
```
And it works. Notice `v1` and `v2` prefixes here - per-session stickiness and load balancing can be observed here...The `v1:b'<message>` is the reply from the server. 

From server logs
```
$ kubectl -n udp-echo logs udp-echo-v1-5cd457ddcd-dc4j2 -c udp-echo 
listening on 0.0.0.0:2000
received from ('10.244.0.42', 59898): b'hello\n'
received from ('10.244.0.42', 59898): b'world\n'
received from ('10.244.0.42', 59898): b'[from istio] hello udp\n'

$ kubectl -n udp-echo logs udp-echo-v2-6b68f8d9cd-z6fbw -c udp-echo 
listening on 0.0.0.0:2000
received from ('10.244.0.42', 54366): b'hello\n'
received from ('10.244.0.42', 54366): b'hello\n'
received from ('10.244.0.42', 54366): b'hello\n'
received from ('10.244.0.42', 54366): b'hello\n'
```
The IP `10.244.0.42` is that of the ingress gateway pod
```
$ kubectl -n istio-system get pods istio-ingressgateway-768bd4c6d8-t5m6v -o wide
NAME                                    READY   STATUS    RESTARTS   AGE    IP            NODE                    NOMINATED NODE   READINESS GATES
istio-ingressgateway-768bd4c6d8-t5m6v   1/1     Running   0          103m   10.244.0.42   istio-0-control-plane   <none>           <none>
```

Notice that TCP on the same port works (case where TCP and UDP ports are the same. Istio should handle it correctly)
```
$ echo hello | nc -v 172.18.210.1 5000
Ncat: Version 7.80 ( https://nmap.org/ncat )
Ncat: Connected to 172.18.210.1:5000.
v1  hello
Ncat: 6 bytes sent, 10 bytes received in 0.03 seconds.
```

**NOTE:** Currently, the UDP support is **very limited** in Envoy and comes with several caveats. Due to the limitations, we don't support many of the service-mesh features just yet. It is just a dumb UDP proxy which forwards traffic upstream. See [Envoy's UDP proxy documentation](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/udp/udp_proxy/v3/udp_proxy.proto).
* No support for traffic splitting/subset-based routing. Notice the difference between `tcp_proxy` and `udp_proxy` - the `udp_proxy` does not even have `weighted_clusters` field that is present in `tcp_proxy` and `http_connection_manager`. While there are workarounds like messing around [load balancing weights](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/endpoint/v3/endpoint_components.proto#config-endpoint-v3-localitylbendpoints), for the moment I'm not going that way. This could be fixable although I don't know much about Envoy internals.
* When I tested, access logging does not seem to work (what does that even mean in this context?)
* No network filter chains - just a `udp_proxy` listener filter. If the UDP listener is not QUIC (hence considered connectionless), then Envoy rejects configuration with filter chains complaining of its existence.
* `istioctl` tool doesn't seem to show UDP listener (but this is fixable) - but for later.
* Load balancing options look a bit different than for TCP based ones. It might need a separate section like `udpLoadBalancerSettings` with its own consistent hashing and `is_per_packet_balance` fields along with simple modes. This way, while specifying port-level settings we can configure both TCP and UDP ports in the same item. This is not yet done. Actually, **they are two different ports** - Here 5000/TCP and 5000/UDP.
* No `AuthorizationPolicy` support. Source IP can spoofed after all! 

This PR has a lot of work to be done on testing, validation, code quality front. As of opening the PR, it was littered with debug statements, there were no unit or integration tests, validations etc. The purpose was to make it work first.

**Areas**
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure