### PR TITLE
fix filter removal for http filter

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch.go
@@ -37,8 +37,7 @@ func ApplyListenerPatches(
 	patchContext networking.EnvoyFilter_PatchContext,
 	efw *model.EnvoyFilterWrapper,
 	listeners []*xdslistener.Listener,
-	skipAdds bool,
-) (out []*xdslistener.Listener) {
+	skipAdds bool) (out []*xdslistener.Listener) {
 	defer runtime.HandleCrash(runtime.LogPanic, func(interface{}) {
 		IncrementEnvoyFilterErrorMetric(Listener)
 		log.Errorf("listeners patch caused panic, so the patches did not take effect")
@@ -57,8 +56,7 @@ func patchListeners(
 	patchContext networking.EnvoyFilter_PatchContext,
 	efw *model.EnvoyFilterWrapper,
 	listeners []*xdslistener.Listener,
-	skipAdds bool,
-) []*xdslistener.Listener {
+	skipAdds bool) []*xdslistener.Listener {
 	listenersRemoved := false
 
 	// do all the changes for a single envoy filter crd object. [including adds]
@@ -106,8 +104,7 @@ func patchListeners(
 
 func patchListener(patchContext networking.EnvoyFilter_PatchContext,
 	patches map[networking.EnvoyFilter_ApplyTo][]*model.EnvoyFilterConfigPatchWrapper,
-	listener *xdslistener.Listener, listenersRemoved *bool,
-) {
+	listener *xdslistener.Listener, listenersRemoved *bool) {
 	for _, lp := range patches[networking.EnvoyFilter_LISTENER] {
 		if !commonConditionMatch(patchContext, lp) ||
 			!listenerMatch(listener, lp) {
@@ -129,8 +126,7 @@ func patchListener(patchContext networking.EnvoyFilter_PatchContext,
 
 func patchFilterChains(patchContext networking.EnvoyFilter_PatchContext,
 	patches map[networking.EnvoyFilter_ApplyTo][]*model.EnvoyFilterConfigPatchWrapper,
-	listener *xdslistener.Listener,
-) {
+	listener *xdslistener.Listener) {
 	filterChainsRemoved := false
 	for i, fc := range listener.FilterChains {
 		if fc.Filters == nil {
@@ -170,8 +166,7 @@ func patchFilterChains(patchContext networking.EnvoyFilter_PatchContext,
 func patchFilterChain(patchContext networking.EnvoyFilter_PatchContext,
 	patches map[networking.EnvoyFilter_ApplyTo][]*model.EnvoyFilterConfigPatchWrapper,
 	listener *xdslistener.Listener,
-	fc *xdslistener.FilterChain, filterChainRemoved *bool,
-) {
+	fc *xdslistener.FilterChain, filterChainRemoved *bool) {
 	for _, lp := range patches[networking.EnvoyFilter_FILTER_CHAIN] {
 		if !commonConditionMatch(patchContext, lp) ||
 			!listenerMatch(listener, lp) ||
@@ -243,8 +238,7 @@ func mergeTransportSocketListener(fc *xdslistener.FilterChain, lp *model.EnvoyFi
 
 func patchNetworkFilters(patchContext networking.EnvoyFilter_PatchContext,
 	patches map[networking.EnvoyFilter_ApplyTo][]*model.EnvoyFilterConfigPatchWrapper,
-	listener *xdslistener.Listener, fc *xdslistener.FilterChain,
-) {
+	listener *xdslistener.Listener, fc *xdslistener.FilterChain) {
 	removedFilters := sets.NewSet()
 	for i, filter := range fc.Filters {
 		if patchNetworkFilter(patchContext, patches, listener, fc, fc.Filters[i]) {
@@ -351,8 +345,7 @@ func patchNetworkFilters(patchContext networking.EnvoyFilter_PatchContext,
 func patchNetworkFilter(patchContext networking.EnvoyFilter_PatchContext,
 	patches map[networking.EnvoyFilter_ApplyTo][]*model.EnvoyFilterConfigPatchWrapper,
 	listener *xdslistener.Listener, fc *xdslistener.FilterChain,
-	filter *xdslistener.Filter,
-) bool {
+	filter *xdslistener.Filter) bool {
 	for _, lp := range patches[networking.EnvoyFilter_NETWORK_FILTER] {
 		if !commonConditionMatch(patchContext, lp) ||
 			!listenerMatch(listener, lp) ||
@@ -411,8 +404,7 @@ func patchNetworkFilter(patchContext networking.EnvoyFilter_PatchContext,
 
 func patchHTTPFilters(patchContext networking.EnvoyFilter_PatchContext,
 	patches map[networking.EnvoyFilter_ApplyTo][]*model.EnvoyFilterConfigPatchWrapper,
-	listener *xdslistener.Listener, fc *xdslistener.FilterChain, filter *xdslistener.Filter,
-) {
+	listener *xdslistener.Listener, fc *xdslistener.FilterChain, filter *xdslistener.Filter) {
 	httpconn := &hcm.HttpConnectionManager{}
 	if filter.GetTypedConfig() != nil {
 		if err := filter.GetTypedConfig().UnmarshalTo(httpconn); err != nil {
@@ -535,8 +527,7 @@ func patchHTTPFilters(patchContext networking.EnvoyFilter_PatchContext,
 func patchHTTPFilter(patchContext networking.EnvoyFilter_PatchContext,
 	patches map[networking.EnvoyFilter_ApplyTo][]*model.EnvoyFilterConfigPatchWrapper,
 	listener *xdslistener.Listener, fc *xdslistener.FilterChain, filter *xdslistener.Filter,
-	httpFilter *hcm.HttpFilter,
-) bool {
+	httpFilter *hcm.HttpFilter) bool {
 	for _, lp := range patches[networking.EnvoyFilter_HTTP_FILTER] {
 		applied := false
 		if !commonConditionMatch(patchContext, lp) ||
@@ -722,14 +713,12 @@ func httpFilterMatch(filter *hcm.HttpFilter, lp *model.EnvoyFilterConfigPatchWra
 }
 
 func patchContextMatch(patchContext networking.EnvoyFilter_PatchContext,
-	lp *model.EnvoyFilterConfigPatchWrapper,
-) bool {
+	lp *model.EnvoyFilterConfigPatchWrapper) bool {
 	return lp.Match.Context == patchContext || lp.Match.Context == networking.EnvoyFilter_ANY
 }
 
 func commonConditionMatch(patchContext networking.EnvoyFilter_PatchContext,
-	lp *model.EnvoyFilterConfigPatchWrapper,
-) bool {
+	lp *model.EnvoyFilterConfigPatchWrapper) bool {
 	return patchContextMatch(patchContext, lp)
 }
 

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch_test.go
@@ -324,6 +324,26 @@ func TestApplyListenerPatches(t *testing.T) {
 				Value:     buildPatchStruct(`{"name": "http-filter4"}`),
 			},
 		},
+		{
+			ApplyTo: networking.EnvoyFilter_HTTP_FILTER,
+			Match: &networking.EnvoyFilter_EnvoyConfigObjectMatch{
+				Context: networking.EnvoyFilter_SIDECAR_INBOUND,
+				ObjectTypes: &networking.EnvoyFilter_EnvoyConfigObjectMatch_Listener{
+					Listener: &networking.EnvoyFilter_ListenerMatch{
+						PortNumber: 80,
+						FilterChain: &networking.EnvoyFilter_ListenerMatch_FilterChainMatch{
+							Filter: &networking.EnvoyFilter_ListenerMatch_FilterMatch{
+								Name:      wellknown.HTTPConnectionManager,
+								SubFilter: &networking.EnvoyFilter_ListenerMatch_SubFilterMatch{Name: "http-filter-to-be-removed"},
+							},
+						},
+					},
+				},
+			},
+			Patch: &networking.EnvoyFilter_Patch{
+				Operation: networking.EnvoyFilter_Patch_REMOVE,
+			},
+		},
 		// Merge v3 any with v2 any
 		{
 			ApplyTo: networking.EnvoyFilter_HTTP_FILTER,
@@ -1447,6 +1467,7 @@ func TestApplyListenerPatches(t *testing.T) {
 											ConfigType: &http_conn.HttpFilter_TypedConfig{TypedConfig: faultFilterInAny},
 										},
 										{Name: "http-filter2"},
+										{Name: "http-filter-to-be-removed"},
 									},
 								}),
 							},

--- a/releasenotes/notes/37903.yaml
+++ b/releasenotes/notes/37903.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+releaseNotes:
+  - |
+    **Fixed** an issue where removing a HTTP filter is not working properly.


### PR DESCRIPTION
Found this bug in this PR https://github.com/istio/istio/pull/36404. Http filter removal does not work correctly.

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
