### PR TITLE
add externalIPs in helm chart gateway service

### DIFF
--- a/manifests/charts/gateway/templates/service.yaml
+++ b/manifests/charts/gateway/templates/service.yaml
@@ -40,6 +40,11 @@ spec:
 {{- else }}
 {{ .Values.service.ports | toYaml | indent 4 }}
 {{- end }}
+{{- if .Values.service.externalIPs }}
+  externalIPs: {{- range .Values.service.externalIPs }}
+    - {{.}}
+  {{- end }}
+{{- end }}
   selector:
     {{- include "gateway.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/manifests/charts/gateway/values.yaml
+++ b/manifests/charts/gateway/values.yaml
@@ -52,6 +52,7 @@ service:
   loadBalancerIP: ""
   loadBalancerSourceRanges: []
   externalTrafficPolicy: ""
+  externalIPs: []
 
 resources:
   requests:


### PR DESCRIPTION
**Please provide a description of this PR:**

Adds externalIPs to gateway service in helm chart.
Fixes #37902





Helm Chart default behaviour didn't change

I assumed there are no usecases to set externalIPs spec together with service type LoadBalancer.