### PR TITLE
tf: skip VM suite when VM is disabled

### DIFF
--- a/pkg/test/framework/resource/setup.go
+++ b/pkg/test/framework/resource/setup.go
@@ -16,3 +16,7 @@ package resource
 
 // SetupFn is a function used for performing setup actions.
 type SetupFn func(ctx Context) error
+
+// ShouldSkipFn is a function used for performing skip actions; if it returns true a job is skipped
+// Note: function may be called multiple times during the setup process.
+type ShouldSkipFn func(ctx Context) bool

--- a/tests/integration/telemetry/stackdriver/vm/main_test.go
+++ b/tests/integration/telemetry/stackdriver/vm/main_test.go
@@ -121,6 +121,9 @@ func TestMain(m *testing.M) {
 		// https://github.com/istio/istio/issues/35923. Since IPv6 has no external connectivity, we are "not on GCP"
 		// in the sense that we cannot access the metadata server
 		Label(label.IPv4).
+		SkipIf("test requires VMs", func(ctx resource.Context) bool {
+			return ctx.Settings().Skip(echo.VM)
+		}).
 		RequireMultiPrimary().
 		Setup(func(ctx resource.Context) error {
 			var err error


### PR DESCRIPTION
This test only makes sense when VMs are enabled. Currently it will fail in weird ways otherwise