### PR TITLE
[TF] Support multi-namespace in echotest

### DIFF
--- a/pkg/test/framework/components/echo/config.go
+++ b/pkg/test/framework/components/echo/config.go
@@ -251,6 +251,16 @@ func (c Config) IsDelta() bool {
 	return len(c.Subsets) > 0 && c.Subsets[0].Annotations != nil && strings.Contains(c.Subsets[0].Annotations.Get(SidecarProxyConfig), "ISTIO_DELTA_XDS")
 }
 
+// IsRegularPod returns true if the echo pod is not any of the following:
+// - VM
+// - Naked
+// - Headless
+// - TProxy
+// - Multi-Subset
+func (c Config) IsRegularPod() bool {
+	return len(c.Subsets) == 1 && !c.IsVM() && !c.IsTProxy() && !c.IsNaked() && !c.IsHeadless() && !c.IsStatefulSet() && !c.IsProxylessGRPC()
+}
+
 // DeepCopy creates a clone of IstioEndpoint.
 func (c Config) DeepCopy() Config {
 	newc := c

--- a/pkg/test/framework/components/echo/echotest/echotest.go
+++ b/pkg/test/framework/components/echo/echotest/echotest.go
@@ -42,7 +42,7 @@ func New(ctx framework.TestContext, instances echo.Instances) *T {
 	copy(d, instances)
 	t := &T{rootCtx: ctx, sources: s, destinations: d}
 	if ctx.Settings().Skip(echo.VM) {
-		t = t.FromMatch(match.IsNotVM).ToMatch(match.IsNotVM)
+		t = t.FromMatch(match.NotVM).ToMatch(match.NotVM)
 	}
 	return t
 }

--- a/pkg/test/framework/components/echo/echotest/filters_test.go
+++ b/pkg/test/framework/components/echo/echotest/filters_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package echotest
+package echotest_test
 
 import (
 	"fmt"
@@ -28,6 +28,7 @@ import (
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/cluster"
 	"istio.io/istio/pkg/test/framework/components/echo"
+	"istio.io/istio/pkg/test/framework/components/echo/echotest"
 	"istio.io/istio/pkg/test/framework/components/echo/match"
 	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/framework/resource"
@@ -36,98 +37,94 @@ import (
 var (
 	// TODO set this up with echobuilder/cluster builder in Fake mode
 
+	echo1NS = namespace.Static("echo1")
+	echo2NS = namespace.Static("echo2")
+
 	// 2 clusters on 2 networks
 	cls1 = &cluster.FakeCluster{Topology: cluster.Topology{ClusterName: "cls1", Network: "n1", Index: 0, ClusterKind: cluster.Fake}}
 	cls2 = &cluster.FakeCluster{Topology: cluster.Topology{ClusterName: "cls2", Network: "n2", Index: 1, ClusterKind: cluster.Fake}}
 
 	// simple pod
-	a1 = &fakeInstance{Cluster: cls1, Namespace: namespace.Static("echo"), Service: "a"}
-	a2 = &fakeInstance{Cluster: cls2, Namespace: namespace.Static("echo"), Service: "a"}
+	a1 = &fakeInstance{Cluster: cls1, Namespace: echo1NS, Service: "a"}
+	a2 = &fakeInstance{Cluster: cls2, Namespace: echo1NS, Service: "a"}
 	// simple pod with different svc
-	b1 = &fakeInstance{Cluster: cls1, Namespace: namespace.Static("echo"), Service: "b"}
-	b2 = &fakeInstance{Cluster: cls2, Namespace: namespace.Static("echo"), Service: "b"}
+	b1 = &fakeInstance{Cluster: cls1, Namespace: echo1NS, Service: "b"}
+	b2 = &fakeInstance{Cluster: cls2, Namespace: echo1NS, Service: "b"}
 	// another simple pod with different svc
-	c1 = &fakeInstance{Cluster: cls1, Namespace: namespace.Static("echo"), Service: "c"}
-	c2 = &fakeInstance{Cluster: cls2, Namespace: namespace.Static("echo"), Service: "c"}
+	c1 = &fakeInstance{Cluster: cls1, Namespace: echo1NS, Service: "c"}
+	c2 = &fakeInstance{Cluster: cls2, Namespace: echo1NS, Service: "c"}
 	// simple pod with a different namespace
-	aNs1 = &fakeInstance{Cluster: cls1, Namespace: namespace.Static("echo2"), Service: "a"}
-	aNs2 = &fakeInstance{Cluster: cls2, Namespace: namespace.Static("echo2"), Service: "a"}
+	a1Ns2 = &fakeInstance{Cluster: cls1, Namespace: echo2NS, Service: "a"}
+	a2Ns2 = &fakeInstance{Cluster: cls2, Namespace: echo2NS, Service: "a"}
 	// virtual machine
-	vm1 = &fakeInstance{Cluster: cls1, Namespace: namespace.Static("echo"), Service: "vm", DeployAsVM: true}
-	vm2 = &fakeInstance{Cluster: cls2, Namespace: namespace.Static("echo"), Service: "vm", DeployAsVM: true}
+	vm1 = &fakeInstance{Cluster: cls1, Namespace: echo1NS, Service: "vm", DeployAsVM: true}
+	vm2 = &fakeInstance{Cluster: cls2, Namespace: echo1NS, Service: "vm", DeployAsVM: true}
 	// headless
-	headless1 = &fakeInstance{Cluster: cls1, Namespace: namespace.Static("echo"), Service: "headless", Headless: true}
-	headless2 = &fakeInstance{Cluster: cls2, Namespace: namespace.Static("echo"), Service: "headless", Headless: true}
+	headless1 = &fakeInstance{Cluster: cls1, Namespace: echo1NS, Service: "headless", Headless: true}
+	headless2 = &fakeInstance{Cluster: cls2, Namespace: echo1NS, Service: "headless", Headless: true}
 	// naked pod (uninjected)
-	naked1 = &fakeInstance{Cluster: cls1, Namespace: namespace.Static("echo"), Service: "naked", Subsets: []echo.SubsetConfig{{
+	naked1 = &fakeInstance{Cluster: cls1, Namespace: echo1NS, Service: "naked", Subsets: []echo.SubsetConfig{{
 		Annotations: echo.NewAnnotations().SetBool(echo.SidecarInject, false),
 	}}}
-	naked2 = &fakeInstance{Cluster: cls2, Namespace: namespace.Static("echo"), Service: "naked", Subsets: []echo.SubsetConfig{{
+	naked2 = &fakeInstance{Cluster: cls2, Namespace: echo1NS, Service: "naked", Subsets: []echo.SubsetConfig{{
 		Annotations: echo.NewAnnotations().SetBool(echo.SidecarInject, false),
 	}}}
 	// external svc
 	external1 = &fakeInstance{
-		Cluster: cls1, Namespace: namespace.Static("echo"), Service: "external", DefaultHostHeader: "external.com", Subsets: []echo.SubsetConfig{{
+		Cluster: cls1, Namespace: echo1NS, Service: "external", DefaultHostHeader: "external.com", Subsets: []echo.SubsetConfig{{
 			Annotations: map[echo.Annotation]*echo.AnnotationValue{echo.SidecarInject: {Value: strconv.FormatBool(false)}},
 		}},
 	}
 	external2 = &fakeInstance{
-		Cluster: cls2, Namespace: namespace.Static("echo"), Service: "external", DefaultHostHeader: "external.com", Subsets: []echo.SubsetConfig{{
+		Cluster: cls2, Namespace: echo1NS, Service: "external", DefaultHostHeader: "external.com", Subsets: []echo.SubsetConfig{{
 			Annotations: map[echo.Annotation]*echo.AnnotationValue{echo.SidecarInject: {Value: strconv.FormatBool(false)}},
 		}},
 	}
 
-	all = echo.Instances{a1, a2, b1, b2, c1, c2, aNs1, aNs2, vm1, vm2, headless1, headless2, naked1, naked2, external1, external2}
+	all = echo.Instances{a1, a2, b1, b2, c1, c2, a1Ns2, a2Ns2, vm1, vm2, headless1, headless2, naked1, naked2, external1, external2}
 )
 
 func TestMain(m *testing.M) {
 	framework.NewSuite(m).EnvironmentFactory(resource.NilEnvironmentFactory).Run()
 }
 
-func TestIsRegularPod(t *testing.T) {
-	tests := []struct {
-		app    echo.Instance
-		expect bool
-	}{
-		{app: a1, expect: true},
-		{app: b1, expect: true},
-		{app: vm1, expect: false},
-		{app: naked1, expect: false},
-		{app: external1, expect: false},
-		{app: headless1, expect: false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.app.Config().Service, func(t *testing.T) {
-			if got := RegularPod(tt.app); got != tt.expect {
-				t.Errorf("got %v expected %v", got, tt.expect)
-			}
-		})
-	}
-}
-
-func TestIsNaked(t *testing.T) {
-	tests := []struct {
-		app    echo.Instance
-		expect bool
-	}{
-		{app: a1, expect: false},
-		{app: headless1, expect: false},
-		{app: naked1, expect: true},
-		{app: external1, expect: true},
-	}
-	for _, tt := range tests {
-		t.Run(tt.app.Config().Service, func(t *testing.T) {
-			if got := tt.app.Config().IsNaked(); got != tt.expect {
-				t.Errorf("got %v expected %v", got, tt.expect)
-			}
-		})
-	}
-}
-
 func TestDeployments(t *testing.T) {
 	if diff := cmp.Diff(
-		all.Services().Services(),
-		[]string{"a", "a", "b", "c", "external", "headless", "naked", "vm"},
+		all.Services().ServiceNames(),
+		echo.ServiceNameList{
+			{
+				Name:      "a",
+				Namespace: echo1NS.Name(),
+			},
+			{
+				Name:      "a",
+				Namespace: echo2NS.Name(),
+			},
+			{
+				Name:      "b",
+				Namespace: echo1NS.Name(),
+			},
+			{
+				Name:      "c",
+				Namespace: echo1NS.Name(),
+			},
+			{
+				Name:      "external",
+				Namespace: echo1NS.Name(),
+			},
+			{
+				Name:      "headless",
+				Namespace: echo1NS.Name(),
+			},
+			{
+				Name:      "naked",
+				Namespace: echo1NS.Name(),
+			},
+			{
+				Name:      "vm",
+				Namespace: echo1NS.Name(),
+			},
+		},
 	); diff != "" {
 		t.Fatal(diff)
 	}
@@ -139,10 +136,10 @@ func TestFilters(t *testing.T) {
 		expect echo.Instances
 	}{
 		"SingleSimplePodServiceAndAllSpecial": {
-			filter: SingleSimplePodServiceAndAllSpecial(),
+			filter: echotest.SingleSimplePodServiceAndAllSpecial(),
 			expect: echo.Instances{
-				// keep all instances of this pod-based service
-				a1, a2,
+				// Keep pods for one regular service per namespace.
+				a1, a2, a1Ns2, a2Ns2,
 				// keep the special cases
 				vm1, vm2,
 				headless1, headless2,
@@ -152,31 +149,31 @@ func TestFilters(t *testing.T) {
 		},
 		"ReachableDestinations from pod": {
 			filter: func(instances echo.Instances) echo.Instances {
-				return ReachableDestinations(a1, instances)
+				return echotest.ReachableDestinations(a1, instances)
 			},
 			expect: echo.Instances{
 				// all instances
-				a1, a2, aNs1, aNs2, b1, b2, c1, c2, vm1, vm2, external1, external2,
+				a1, a2, a1Ns2, a2Ns2, b1, b2, c1, c2, vm1, vm2, external1, external2,
 				// only same network/cluster
 				headless1, naked1,
 			},
 		},
 		"ReachableDestinations from naked": {
 			filter: func(instances echo.Instances) echo.Instances {
-				return ReachableDestinations(naked1, instances)
+				return echotest.ReachableDestinations(naked1, instances)
 			},
 			expect: echo.Instances{
 				// only same network/cluster, no VMs
-				a1, aNs1, b1, c1, headless1, naked1, external1,
+				a1, a1Ns2, b1, c1, headless1, naked1, external1,
 			},
 		},
 		"ReachableDestinations from vm": {
 			filter: func(instances echo.Instances) echo.Instances {
-				return ReachableDestinations(vm1, instances)
+				return echotest.ReachableDestinations(vm1, instances)
 			},
 			expect: echo.Instances{
 				// all pods/vms, no external
-				a1, a2, aNs1, aNs2, b1, b2, c1, c2, vm1, vm2,
+				a1, a2, a1Ns2, a2Ns2, b1, b2, c1, c2, vm1, vm2,
 				// only same network/cluster
 				headless1, naked1,
 			},
@@ -192,7 +189,7 @@ func TestFilters(t *testing.T) {
 
 func compare(t *testing.T, got echo.Instances, want echo.Instances) {
 	if len(got) != len(want) {
-		t.Errorf("got %d instnaces but expected %d", len(got), len(want))
+		t.Errorf("got %d instances but expected %d", len(got), len(want))
 	}
 	expected := map[string]struct{}{}
 	for _, i := range want {
@@ -227,7 +224,7 @@ func TestRun(t *testing.T) {
 		}{
 			"Run_WithDefaultFilters": {
 				run: func(t framework.TestContext, testTopology map[string]map[string]int) {
-					New(t, all).
+					echotest.New(t, all).
 						WithDefaultFilters().
 						Run(func(ctx framework.TestContext, from echo.Instance, to echo.Target) {
 							// TODO if the destinations would change based on which cluster then add cluster to srCkey
@@ -240,40 +237,47 @@ func TestRun(t *testing.T) {
 						})
 				},
 				expect: map[string]map[string]int{
-					"a.echo.svc.cluster.local": {
-						"b.echo.svc.cluster.local":        2,
-						"external.echo.svc.cluster.local": 2,
-						"headless.echo.svc.cluster.local": 2,
-						"naked.echo.svc.cluster.local":    2,
-						"vm.echo.svc.cluster.local":       2,
+					"a.echo1.svc.cluster.local": {
+						"b.echo1.svc.cluster.local":        2,
+						"external.echo1.svc.cluster.local": 2,
+						"headless.echo1.svc.cluster.local": 2,
+						"naked.echo1.svc.cluster.local":    2,
+						"vm.echo1.svc.cluster.local":       2,
 					},
-					"headless.echo.svc.cluster.local": {
-						"b.echo.svc.cluster.local":        2,
-						"external.echo.svc.cluster.local": 2,
-						"headless.echo.svc.cluster.local": 2,
-						"naked.echo.svc.cluster.local":    2,
-						"vm.echo.svc.cluster.local":       2,
+					"a.echo2.svc.cluster.local": {
+						"b.echo1.svc.cluster.local":        2,
+						"external.echo1.svc.cluster.local": 2,
+						"headless.echo1.svc.cluster.local": 2,
+						"naked.echo1.svc.cluster.local":    2,
+						"vm.echo1.svc.cluster.local":       2,
 					},
-					"naked.echo.svc.cluster.local": {
-						"b.echo.svc.cluster.local":        2,
-						"external.echo.svc.cluster.local": 2,
-						"headless.echo.svc.cluster.local": 2,
-						"naked.echo.svc.cluster.local":    2,
+					"headless.echo1.svc.cluster.local": {
+						"b.echo1.svc.cluster.local":        2,
+						"external.echo1.svc.cluster.local": 2,
+						"headless.echo1.svc.cluster.local": 2,
+						"naked.echo1.svc.cluster.local":    2,
+						"vm.echo1.svc.cluster.local":       2,
 					},
-					"vm.echo.svc.cluster.local": {
-						"b.echo.svc.cluster.local":        2,
-						"headless.echo.svc.cluster.local": 2,
-						"naked.echo.svc.cluster.local":    2,
-						"vm.echo.svc.cluster.local":       2,
+					"naked.echo1.svc.cluster.local": {
+						"b.echo1.svc.cluster.local":        2,
+						"external.echo1.svc.cluster.local": 2,
+						"headless.echo1.svc.cluster.local": 2,
+						"naked.echo1.svc.cluster.local":    2,
+					},
+					"vm.echo1.svc.cluster.local": {
+						"b.echo1.svc.cluster.local":        2,
+						"headless.echo1.svc.cluster.local": 2,
+						"naked.echo1.svc.cluster.local":    2,
+						"vm.echo1.svc.cluster.local":       2,
 					},
 				},
 			},
 			"RunToN": {
 				run: func(t framework.TestContext, testTopology map[string]map[string]int) {
-					New(t, all).
+					echotest.New(t, all).
 						WithDefaultFilters().
-						FromMatch(match.And(match.IsNotNaked, match.IsNotHeadless)).
-						ToMatch(match.IsNotHeadless).
+						FromMatch(match.And(match.NotNaked, match.NotHeadless)).
+						ToMatch(match.NotHeadless).
 						RunToN(3, func(ctx framework.TestContext, from echo.Instance, dsts echo.Services) {
 							srcKey := from.Config().ClusterLocalFQDN()
 							if testTopology[srcKey] == nil {
@@ -288,13 +292,17 @@ func TestRun(t *testing.T) {
 						})
 				},
 				expect: map[string]map[string]int{
-					"a.echo.svc.cluster.local": {
-						"b.echo.svc.cluster.local_external.echo.svc.cluster.local_naked.echo.svc.cluster.local":  2,
-						"external.echo.svc.cluster.local_naked.echo.svc.cluster.local_vm.echo.svc.cluster.local": 2,
+					"a.echo1.svc.cluster.local": {
+						"b.echo1.svc.cluster.local_external.echo1.svc.cluster.local_naked.echo1.svc.cluster.local":  2,
+						"external.echo1.svc.cluster.local_naked.echo1.svc.cluster.local_vm.echo1.svc.cluster.local": 2,
 					},
-					"vm.echo.svc.cluster.local": {
+					"a.echo2.svc.cluster.local": {
+						"b.echo1.svc.cluster.local_external.echo1.svc.cluster.local_naked.echo1.svc.cluster.local":  2,
+						"external.echo1.svc.cluster.local_naked.echo1.svc.cluster.local_vm.echo1.svc.cluster.local": 2,
+					},
+					"vm.echo1.svc.cluster.local": {
 						// VM cannot hit external services (https://github.com/istio/istio/issues/27154)
-						"b.echo.svc.cluster.local_naked.echo.svc.cluster.local_vm.echo.svc.cluster.local": 2,
+						"b.echo1.svc.cluster.local_naked.echo1.svc.cluster.local_vm.echo1.svc.cluster.local": 2,
 					},
 				},
 			},

--- a/pkg/test/framework/components/echo/instances.go
+++ b/pkg/test/framework/components/echo/instances.go
@@ -147,3 +147,9 @@ func (i Instances) Services() Services {
 	sort.Stable(out)
 	return out
 }
+
+// Append the given instances together at the end of this Instances and return a new Instances.
+// Does not modify this Instances.
+func (i Instances) Append(instances ...Instance) Instances {
+	return append(append(Instances{}, i...), instances...)
+}

--- a/pkg/test/framework/components/echo/match/matchers_test.go
+++ b/pkg/test/framework/components/echo/match/matchers_test.go
@@ -1,0 +1,156 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package match_test
+
+import (
+	"strconv"
+	"testing"
+
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/test"
+	echoClient "istio.io/istio/pkg/test/echo"
+	"istio.io/istio/pkg/test/framework/components/cluster"
+	"istio.io/istio/pkg/test/framework/components/echo"
+	"istio.io/istio/pkg/test/framework/components/echo/match"
+	"istio.io/istio/pkg/test/framework/components/namespace"
+	"istio.io/istio/pkg/test/framework/resource"
+)
+
+var (
+	// 2 clusters on 2 networks
+	cls1 = &cluster.FakeCluster{Topology: cluster.Topology{ClusterName: "cls1", Network: "n1", Index: 0, ClusterKind: cluster.Fake}}
+
+	// simple pod
+	a1 = &fakeInstance{Cluster: cls1, Namespace: namespace.Static("echo"), Service: "a"}
+	// simple pod with different svc
+	b1 = &fakeInstance{Cluster: cls1, Namespace: namespace.Static("echo"), Service: "b"}
+	// virtual machine
+	vm1 = &fakeInstance{Cluster: cls1, Namespace: namespace.Static("echo"), Service: "vm", DeployAsVM: true}
+	// headless
+	headless1 = &fakeInstance{Cluster: cls1, Namespace: namespace.Static("echo"), Service: "headless", Headless: true}
+	// naked pod (uninjected)
+	naked1 = &fakeInstance{Cluster: cls1, Namespace: namespace.Static("echo"), Service: "naked", Subsets: []echo.SubsetConfig{{
+		Annotations: echo.NewAnnotations().SetBool(echo.SidecarInject, false),
+	}}}
+	// external svc
+	external1 = &fakeInstance{
+		Cluster: cls1, Namespace: namespace.Static("echo"), Service: "external", DefaultHostHeader: "external.com", Subsets: []echo.SubsetConfig{{
+			Annotations: map[echo.Annotation]*echo.AnnotationValue{echo.SidecarInject: {Value: strconv.FormatBool(false)}},
+		}},
+	}
+)
+
+func TestRegularPod(t *testing.T) {
+	tests := []struct {
+		app    echo.Instance
+		expect bool
+	}{
+		{app: a1, expect: true},
+		{app: b1, expect: true},
+		{app: vm1, expect: false},
+		{app: naked1, expect: false},
+		{app: external1, expect: false},
+		{app: headless1, expect: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.app.Config().Service, func(t *testing.T) {
+			if got := match.RegularPod(tt.app); got != tt.expect {
+				t.Errorf("got %v expected %v", got, tt.expect)
+			}
+		})
+	}
+}
+
+func TestNaked(t *testing.T) {
+	tests := []struct {
+		app    echo.Instance
+		expect bool
+	}{
+		{app: a1, expect: false},
+		{app: headless1, expect: false},
+		{app: naked1, expect: true},
+		{app: external1, expect: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.app.Config().Service, func(t *testing.T) {
+			if got := tt.app.Config().IsNaked(); got != tt.expect {
+				t.Errorf("got %v expected %v", got, tt.expect)
+			}
+		})
+	}
+}
+
+var _ echo.Instance = fakeInstance{}
+
+// fakeInstance wraps echo.Config for test-framework internals tests where we don't actually make calls
+type fakeInstance echo.Config
+
+func (f fakeInstance) Instances() echo.Instances {
+	return echo.Instances{f}
+}
+
+func (f fakeInstance) ID() resource.ID {
+	panic("implement me")
+}
+
+func (f fakeInstance) NamespacedName() model.NamespacedName {
+	return f.Config().NamespacedName()
+}
+
+func (f fakeInstance) PortForName(name string) echo.Port {
+	return f.Config().Ports.MustForName(name)
+}
+
+func (f fakeInstance) Config() echo.Config {
+	cfg := echo.Config(f)
+	_ = cfg.FillDefaults(nil)
+	return cfg
+}
+
+func (f fakeInstance) Address() string {
+	panic("implement me")
+}
+
+func (f fakeInstance) Addresses() []string {
+	panic("implement me")
+}
+
+func (f fakeInstance) Workloads() (echo.Workloads, error) {
+	panic("implement me")
+}
+
+func (f fakeInstance) WorkloadsOrFail(test.Failer) echo.Workloads {
+	panic("implement me")
+}
+
+func (f fakeInstance) MustWorkloads() echo.Workloads {
+	panic("implement me")
+}
+
+func (f fakeInstance) Clusters() cluster.Clusters {
+	panic("implement me")
+}
+
+func (f fakeInstance) Call(echo.CallOptions) (echoClient.Responses, error) {
+	panic("implement me")
+}
+
+func (f fakeInstance) CallOrFail(test.Failer, echo.CallOptions) echoClient.Responses {
+	panic("implement me")
+}
+
+func (f fakeInstance) Restart() error {
+	panic("implement me")
+}

--- a/tests/integration/pilot/common/apps.go
+++ b/tests/integration/pilot/common/apps.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 
+	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/echo/common/ports"
 	"istio.io/istio/pkg/test/framework/components/echo/deployment"
@@ -247,20 +248,20 @@ func SetupApps(t resource.Context, i istio.Instance, apps *EchoDeployments) erro
 		return err
 	}
 	apps.All = echos
-	apps.PodA = match.Service(PodASvc).GetMatches(echos)
-	apps.PodB = match.Service(PodBSvc).GetMatches(echos)
-	apps.PodC = match.Service(PodCSvc).GetMatches(echos)
-	apps.PodTproxy = match.Service(PodTproxySvc).GetMatches(echos)
-	apps.Headless = match.Service(HeadlessSvc).GetMatches(echos)
-	apps.StatefulSet = match.Service(StatefulSetSvc).GetMatches(echos)
-	apps.Naked = match.Service(NakedSvc).GetMatches(echos)
-	apps.External = match.Service(ExternalSvc).GetMatches(echos)
-	apps.ProxylessGRPC = match.Service(ProxylessGRPCSvc).GetMatches(echos)
+	apps.PodA = match.ServiceName(model.NamespacedName{Name: PodASvc, Namespace: apps.Namespace.Name()}).GetMatches(echos)
+	apps.PodB = match.ServiceName(model.NamespacedName{Name: PodBSvc, Namespace: apps.Namespace.Name()}).GetMatches(echos)
+	apps.PodC = match.ServiceName(model.NamespacedName{Name: PodCSvc, Namespace: apps.Namespace.Name()}).GetMatches(echos)
+	apps.PodTproxy = match.ServiceName(model.NamespacedName{Name: PodTproxySvc, Namespace: apps.Namespace.Name()}).GetMatches(echos)
+	apps.Headless = match.ServiceName(model.NamespacedName{Name: HeadlessSvc, Namespace: apps.Namespace.Name()}).GetMatches(echos)
+	apps.StatefulSet = match.ServiceName(model.NamespacedName{Name: StatefulSetSvc, Namespace: apps.Namespace.Name()}).GetMatches(echos)
+	apps.Naked = match.ServiceName(model.NamespacedName{Name: NakedSvc, Namespace: apps.Namespace.Name()}).GetMatches(echos)
+	apps.External = match.ServiceName(model.NamespacedName{Name: ExternalSvc, Namespace: apps.ExternalNamespace.Name()}).GetMatches(echos)
+	apps.ProxylessGRPC = match.ServiceName(model.NamespacedName{Name: ProxylessGRPCSvc, Namespace: apps.Namespace.Name()}).GetMatches(echos)
 	if !t.Settings().Skip(echo.VM) {
-		apps.VM = match.Service(VMSvc).GetMatches(echos)
+		apps.VM = match.ServiceName(model.NamespacedName{Name: VMSvc, Namespace: apps.Namespace.Name()}).GetMatches(echos)
 	}
 	if !skipDelta {
-		apps.DeltaXDS = match.Service(DeltaSvc).GetMatches(echos)
+		apps.DeltaXDS = match.ServiceName(model.NamespacedName{Name: DeltaSvc, Namespace: apps.Namespace.Name()}).GetMatches(echos)
 	}
 
 	if err := t.ConfigIstio().YAML(`

--- a/tests/integration/pilot/common/traffic.go
+++ b/tests/integration/pilot/common/traffic.go
@@ -123,7 +123,7 @@ func (c TrafficTestCase) RunForApps(t framework.TestContext, apps echo.Instances
 					"dstSvc": dsts[0][0].Config().Service,
 					// tests that use RunForN need all destination deployments
 					"dsts":    dsts,
-					"dstSvcs": dsts.Services(),
+					"dstSvcs": dsts.ServiceNames().Names(),
 				}
 				if len(src) > 0 {
 					tmplData["src"] = src
@@ -143,7 +143,7 @@ func (c TrafficTestCase) RunForApps(t framework.TestContext, apps echo.Instances
 			WithDefaultFilters().
 			FromMatch(match.And(c.sourceMatchers...)).
 			// TODO mainly testing proxyless features as a client for now
-			ToMatch(match.And(append(c.targetMatchers, match.IsNotProxylessGRPC)...)).
+			ToMatch(match.And(append(c.targetMatchers, match.NotProxylessGRPC)...)).
 			ConditionallyTo(c.comboFilters...)
 
 		doTest := func(t framework.TestContext, from echo.Caller, to echo.Services) {

--- a/tests/integration/pilot/mcs/autoexport/autoexport_test.go
+++ b/tests/integration/pilot/mcs/autoexport/autoexport_test.go
@@ -27,6 +27,7 @@ import (
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo/match"
 	"istio.io/istio/pkg/test/framework/components/istio"
@@ -62,7 +63,8 @@ func TestAutoExport(t *testing.T) {
 			// Verify that ServiceExport is created automatically for services.
 			ctx.NewSubTest("exported").RunParallel(
 				func(ctx framework.TestContext) {
-					for _, cluster := range match.Service(common.ServiceB).GetMatches(echos.Instances).Clusters() {
+					serviceB := match.ServiceName(model.NamespacedName{Name: common.ServiceB, Namespace: echos.Namespace})
+					for _, cluster := range serviceB.GetMatches(echos.Instances).Clusters() {
 						cluster := cluster
 						ctx.NewSubTest(cluster.StableName()).RunParallel(func(ctx framework.TestContext) {
 							// Verify that the ServiceExport was created.

--- a/tests/integration/pilot/revisions/revisions_test.go
+++ b/tests/integration/pilot/revisions/revisions_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/test/echo/check"
 	"istio.io/istio/pkg/test/framework"
@@ -106,7 +107,7 @@ func TestMultiRevision(t *testing.T) {
 
 			echotest.New(t, echos).
 				ConditionallyTo(echotest.ReachableDestinations).
-				ToMatch(match.Service("server")).
+				ToMatch(match.ServiceName(model.NamespacedName{Name: "server", Namespace: canary.Name()})).
 				Run(func(t framework.TestContext, from echo.Instance, to echo.Target) {
 					retry.UntilSuccessOrFail(t, func() error {
 						resp, err := from.Call(echo.CallOptions{

--- a/tests/integration/pilot/vm_test.go
+++ b/tests/integration/pilot/vm_test.go
@@ -99,7 +99,7 @@ func TestVMRegistrationLifecycle(t *testing.T) {
 				t.Skip()
 			}
 			scaleDeploymentOrFail(t, "istiod", i.Settings().SystemNamespace, 2)
-			client := match.InCluster(t.Clusters().Default()).FirstOrFail(t, apps.PodA)
+			client := match.Cluster(t.Clusters().Default()).FirstOrFail(t, apps.PodA)
 			// TODO test multi-network (must be shared control plane but on different networks)
 			var autoVM echo.Instance
 			_ = deployment.New(t).

--- a/tests/integration/security/authorization_test.go
+++ b/tests/integration/security/authorization_test.go
@@ -66,8 +66,8 @@ func TestAuthorization_mTLS(t *testing.T) {
 				}, "testdata/authz/v1beta1-mtls.yaml.tmpl").ApplyOrFail(t, apps.Namespace1.Name(), resource.Wait)
 				callCount := util.CallsPerCluster * to.WorkloadsOrFail(t).Len()
 				for _, cluster := range t.Clusters() {
-					a := match.And(match.InCluster(cluster), match.Namespace(apps.Namespace1.Name())).GetMatches(apps.A)
-					c := match.And(match.InCluster(cluster), match.Namespace(apps.Namespace2.Name())).GetMatches(apps.C)
+					a := match.And(match.Cluster(cluster), match.Namespace(apps.Namespace1.Name())).GetMatches(apps.A)
+					c := match.And(match.Cluster(cluster), match.Namespace(apps.Namespace2.Name())).GetMatches(apps.C)
 					if len(a) == 0 || len(c) == 0 {
 						continue
 					}
@@ -132,7 +132,7 @@ func TestAuthorization_JWT(t *testing.T) {
 				}
 				t.ConfigIstio().EvalFile(args, "testdata/authz/v1beta1-jwt.yaml.tmpl").ApplyOrFail(t, ns.Name(), resource.Wait)
 				for _, srcCluster := range t.Clusters() {
-					a := match.And(match.InCluster(srcCluster), match.Namespace(ns.Name())).GetMatches(apps.A)
+					a := match.And(match.Cluster(srcCluster), match.Namespace(ns.Name())).GetMatches(apps.A)
 					if len(a) == 0 {
 						continue
 					}
@@ -257,7 +257,7 @@ func TestAuthorization_WorkloadSelector(t *testing.T) {
 			}
 
 			for _, srcCluster := range t.Clusters() {
-				a := match.And(match.InCluster(srcCluster), match.Namespace(apps.Namespace1.Name())).GetMatches(apps.A)
+				a := match.And(match.Cluster(srcCluster), match.Namespace(apps.Namespace1.Name())).GetMatches(apps.A)
 				if len(a) == 0 {
 					continue
 				}
@@ -366,7 +366,7 @@ func TestAuthorization_Deny(t *testing.T) {
 			applyPolicy("testdata/authz/v1beta1-deny.yaml.tmpl", ns)
 			applyPolicy("testdata/authz/v1beta1-deny-ns-root.yaml.tmpl", rootns)
 			for _, srcCluster := range t.Clusters() {
-				a := match.And(match.InCluster(srcCluster), match.Namespace(apps.Namespace1.Name())).GetMatches(apps.A)
+				a := match.And(match.Cluster(srcCluster), match.Namespace(apps.Namespace1.Name())).GetMatches(apps.A)
 				if len(a) == 0 {
 					continue
 				}
@@ -456,8 +456,8 @@ func TestAuthorization_NegativeMatch(t *testing.T) {
 			}, "testdata/authz/v1beta1-negative-match.yaml.tmpl").ApplyOrFail(t, "")
 
 			for _, srcCluster := range t.Clusters() {
-				a := match.And(match.InCluster(srcCluster), match.Namespace(apps.Namespace1.Name())).GetMatches(apps.A)
-				bInNS2 := match.And(match.InCluster(srcCluster), match.Namespace(apps.Namespace2.Name())).GetMatches(apps.B)
+				a := match.And(match.Cluster(srcCluster), match.Namespace(apps.Namespace1.Name())).GetMatches(apps.A)
+				bInNS2 := match.And(match.Cluster(srcCluster), match.Namespace(apps.Namespace2.Name())).GetMatches(apps.B)
 				if len(a) == 0 || len(bInNS2) == 0 {
 					continue
 				}
@@ -1033,7 +1033,7 @@ func TestAuthorization_Conditions(t *testing.T) {
 				to := to
 				for _, a := range match.Namespace(nsA.Name()).GetMatches(apps.A) {
 					a := a
-					bs := match.And(match.InCluster(a.Config().Cluster), match.Namespace(nsB.Name())).GetMatches(apps.B)
+					bs := match.And(match.Cluster(a.Config().Cluster), match.Namespace(nsB.Name())).GetMatches(apps.B)
 					if len(bs) < 1 {
 						t.Skip()
 					}
@@ -1228,7 +1228,7 @@ func TestAuthorization_Path(t *testing.T) {
 			vm := match.Namespace(ns.Name()).GetMatches(apps.VM)
 			for _, a := range []echo.Instances{a, vm} {
 				for _, srcCluster := range t.Clusters() {
-					b := match.And(match.InCluster(srcCluster), match.Namespace(ns.Name())).GetMatches(apps.B)
+					b := match.And(match.Cluster(srcCluster), match.Namespace(ns.Name())).GetMatches(apps.B)
 					if len(b) == 0 {
 						continue
 					}

--- a/tests/integration/security/ca_custom_root/main_test.go
+++ b/tests/integration/security/ca_custom_root/main_test.go
@@ -26,6 +26,7 @@ import (
 	"path"
 	"testing"
 
+	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/test/echo/common"
 	"istio.io/istio/pkg/test/env"
@@ -249,14 +250,14 @@ func SetupApps(ctx resource.Context, apps *EchoDeployments) error {
 	if err != nil {
 		return err
 	}
-	apps.A = match.Service(ASvc).GetMatches(echos)
-	apps.B = match.Service(BSvc).GetMatches(echos)
-	apps.Client = match.Service("client").GetMatches(echos)
-	apps.ServerNakedFoo = match.Service("server-naked-foo").GetMatches(echos)
-	apps.ServerNakedBar = match.Service("server-naked-bar").GetMatches(echos)
-	apps.ServerNakedFooAlt = match.Service("server-naked-foo-alt").GetMatches(echos)
-	apps.Naked = match.Service("naked").GetMatches(echos)
-	apps.Server = match.Service("server").GetMatches(echos)
+	apps.A = match.ServiceName(model.NamespacedName{Name: ASvc, Namespace: apps.Namespace.Name()}).GetMatches(echos)
+	apps.B = match.ServiceName(model.NamespacedName{Name: BSvc, Namespace: apps.Namespace.Name()}).GetMatches(echos)
+	apps.Client = match.ServiceName(model.NamespacedName{Name: "client", Namespace: apps.Namespace.Name()}).GetMatches(echos)
+	apps.ServerNakedFoo = match.ServiceName(model.NamespacedName{Name: "server-naked-foo", Namespace: apps.Namespace.Name()}).GetMatches(echos)
+	apps.ServerNakedBar = match.ServiceName(model.NamespacedName{Name: "server-naked-bar", Namespace: apps.Namespace.Name()}).GetMatches(echos)
+	apps.ServerNakedFooAlt = match.ServiceName(model.NamespacedName{Name: "server-naked-foo-alt", Namespace: apps.Namespace.Name()}).GetMatches(echos)
+	apps.Naked = match.ServiceName(model.NamespacedName{Name: "naked", Namespace: apps.Namespace.Name()}).GetMatches(echos)
+	apps.Server = match.ServiceName(model.NamespacedName{Name: "server", Namespace: apps.Namespace.Name()}).GetMatches(echos)
 	return nil
 }
 

--- a/tests/integration/security/ca_custom_root/multi_root_test.go
+++ b/tests/integration/security/ca_custom_root/multi_root_test.go
@@ -61,7 +61,7 @@ func TestMultiRootSetup(t *testing.T) {
 						})
 					}
 
-					client := match.InCluster(cluster).FirstOrFail(t, apps.Client)
+					client := match.Cluster(cluster).FirstOrFail(t, apps.Client)
 					cases := []struct {
 						from   echo.Instance
 						to     echo.Instances

--- a/tests/integration/security/ca_custom_root/secure_naming_test.go
+++ b/tests/integration/security/ca_custom_root/secure_naming_test.go
@@ -121,8 +121,8 @@ func TestSecureNaming(t *testing.T) {
 			callCount := util.CallsPerCluster * to.WorkloadsOrFail(t).Len()
 			for _, cluster := range t.Clusters() {
 				t.NewSubTest(fmt.Sprintf("From %s", cluster.StableName())).Run(func(t framework.TestContext) {
-					a := match.And(match.InCluster(cluster), match.Namespace(testNamespace.Name())).GetMatches(apps.A)[0]
-					b := match.And(match.InCluster(cluster), match.Namespace(testNamespace.Name())).GetMatches(apps.B)[0]
+					a := match.And(match.Cluster(cluster), match.Namespace(testNamespace.Name())).GetMatches(apps.A)[0]
+					b := match.And(match.Cluster(cluster), match.Namespace(testNamespace.Name())).GetMatches(apps.B)[0]
 					t.NewSubTest("mTLS cert validation with plugin CA").
 						Run(func(t framework.TestContext) {
 							// Verify that the certificate issued to the sidecar is as expected.

--- a/tests/integration/security/ca_custom_root/trust_domain_alias_secure_naming_test.go
+++ b/tests/integration/security/ca_custom_root/trust_domain_alias_secure_naming_test.go
@@ -105,7 +105,7 @@ func TestTrustDomainAliasSecureNaming(t *testing.T) {
 						})
 					}
 
-					client := match.InCluster(cluster).FirstOrFail(t, apps.Client)
+					client := match.Cluster(cluster).FirstOrFail(t, apps.Client)
 					cases := []struct {
 						src    echo.Instance
 						dest   echo.Instances

--- a/tests/integration/security/ca_custom_root/trust_domain_validation_test.go
+++ b/tests/integration/security/ca_custom_root/trust_domain_validation_test.go
@@ -123,9 +123,9 @@ func TestTrustDomainValidation(t *testing.T) {
 					// naked: only test app without sidecar, send requests from trust domain aliases
 					// client: app with sidecar, send request from cluster.local
 					// server: app with sidecar, verify requests from cluster.local or trust domain aliases
-					client := match.InCluster(cluster).FirstOrFail(t, apps.Client)
-					naked := match.InCluster(cluster).FirstOrFail(t, apps.Naked)
-					server := match.InCluster(cluster).FirstOrFail(t, apps.Server)
+					client := match.Cluster(cluster).FirstOrFail(t, apps.Client)
+					naked := match.Cluster(cluster).FirstOrFail(t, apps.Naked)
+					server := match.Cluster(cluster).FirstOrFail(t, apps.Server)
 					verify := func(ctx framework.TestContext, from echo.Instance, td, port string, s scheme.Instance, allow bool) {
 						ctx.Helper()
 						want := "allow"

--- a/tests/integration/security/ecc_signature_algorithm/main_test.go
+++ b/tests/integration/security/ecc_signature_algorithm/main_test.go
@@ -20,6 +20,7 @@ package eccsignaturealgorithm
 import (
 	"testing"
 
+	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
@@ -100,12 +101,12 @@ func SetupApps(ctx resource.Context, apps *EchoDeployments) error {
 	if err != nil {
 		return err
 	}
-	apps.Client, err = match.Service("client").First(echos)
+	apps.Client, err = match.ServiceName(model.NamespacedName{Name: "client", Namespace: apps.Namespace.Name()}).First(echos)
 	if err != nil {
 		return err
 	}
 
-	apps.Server, err = match.Service("server").First(echos)
+	apps.Server, err = match.ServiceName(model.NamespacedName{Name: "server", Namespace: apps.Namespace.Name()}).First(echos)
 	if err != nil {
 		return err
 	}

--- a/tests/integration/security/egress_gateway_origination_test.go
+++ b/tests/integration/security/egress_gateway_origination_test.go
@@ -68,7 +68,7 @@ func TestSimpleTlsOrigination(t *testing.T) {
 			ingressutil.CreateIngressKubeSecret(t, fakeCredName, ingressutil.TLS, CredentialB, false)
 
 			// Set up Host Namespace
-			host := util.ExternalSvc + "." + apps.Namespace1.Name() + ".svc.cluster.local"
+			host := apps.External.Config().ClusterLocalFQDN()
 
 			testCases := []TLSTestCase{
 				// Use CA certificate stored as k8s secret with the same issuing CA as server's CA.
@@ -98,14 +98,11 @@ func TestSimpleTlsOrigination(t *testing.T) {
 				},
 			}
 
-			CreateGateway(t, t, apps.Namespace1, apps.Namespace1)
+			CreateGateway(t, t, apps.Namespace1, apps.External)
 			for _, tc := range testCases {
 				t.NewSubTest(tc.Name).Run(func(t framework.TestContext) {
-					CreateDestinationRule(t, apps.Namespace1, "SIMPLE", tc.CredentialToUse)
-					echotest.New(t, apps.All).
-						WithDefaultFilters().
-						FromMatch(match.IsNotNaked).
-						ToMatch(match.Service(util.ExternalSvc)).
+					CreateDestinationRule(t, apps.External, "SIMPLE", tc.CredentialToUse)
+					newGatewayTest(t).
 						Run(func(t framework.TestContext, from echo.Instance, to echo.Target) {
 							callOpt := CallOpts(to, host, tc)
 							from.CallOrFail(t, callOpt)
@@ -164,7 +161,7 @@ func TestMutualTlsOrigination(t *testing.T) {
 			}, false)
 
 			// Set up Host Namespace
-			host := util.ExternalSvc + "." + apps.Namespace1.Name() + ".svc.cluster.local"
+			host := apps.External.Config().ClusterLocalFQDN()
 
 			testCases := []TLSTestCase{
 				// Use CA certificate and client certs stored as k8s secret with the same issuing CA as server's CA.
@@ -211,14 +208,11 @@ func TestMutualTlsOrigination(t *testing.T) {
 				},
 			}
 
-			CreateGateway(t, t, apps.Namespace1, apps.Namespace1)
+			CreateGateway(t, t, apps.Namespace1, apps.External)
 			for _, tc := range testCases {
 				t.NewSubTest(tc.Name).Run(func(t framework.TestContext) {
-					CreateDestinationRule(t, apps.Namespace1, "MUTUAL", tc.CredentialToUse)
-					echotest.New(t, apps.All).
-						WithDefaultFilters().
-						FromMatch(match.IsNotNaked).
-						ToMatch(match.Service(util.ExternalSvc)).
+					CreateDestinationRule(t, apps.External, "MUTUAL", tc.CredentialToUse)
+					newGatewayTest(t).
 						Run(func(t framework.TestContext, from echo.Instance, to echo.Target) {
 							callOpt := CallOpts(to, host, tc)
 							from.CallOrFail(t, callOpt)
@@ -230,7 +224,7 @@ func TestMutualTlsOrigination(t *testing.T) {
 
 const (
 	Gateway = `
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1beta1
 kind: Gateway
 metadata:
   name: istio-egressgateway-sds
@@ -243,11 +237,11 @@ spec:
         name: https-sds
         protocol: HTTPS
       hosts:
-      - external.{{.ServerNamespace}}.svc.cluster.local
+      - {{ .to.Config.ClusterLocalFQDN }}
       tls:
         mode: ISTIO_MUTUAL
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1beta1
 kind: DestinationRule
 metadata:
   name: egressgateway-for-server-sds
@@ -261,16 +255,16 @@ spec:
           number: 443
         tls:
           mode: ISTIO_MUTUAL
-          sni: external.{{.ServerNamespace}}.svc.cluster.local
+          sni: {{ .to.Config.ClusterLocalFQDN }}
 `
 	VirtualService = `
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
   name: route-via-egressgateway-sds
 spec:
   hosts:
-    - external.{{.ServerNamespace}}.svc.cluster.local
+    - {{ .to.Config.ClusterLocalFQDN }}
   gateways:
     - istio-egressgateway-sds
     - mesh
@@ -292,7 +286,7 @@ spec:
           port: 443
       route:
         - destination:
-            host: external.{{.ServerNamespace}}.svc.cluster.local
+            host: {{ .to.Config.ClusterLocalFQDN }}
             port:
               number: 443
           weight: 100
@@ -306,8 +300,8 @@ spec:
 // We want to test out TLS origination at Gateway, to do so traffic from client in client namespace is first
 // routed to egress-gateway service in istio-system namespace and then from egress-gateway to server in server namespace.
 // TLS origination at Gateway happens using DestinationRule with CredentialName reading k8s secret at the gateway proxy.
-func CreateGateway(t test.Failer, ctx resource.Context, clientNamespace namespace.Instance, serverNamespace namespace.Instance) {
-	args := map[string]string{"ServerNamespace": serverNamespace.Name()}
+func CreateGateway(t test.Failer, ctx resource.Context, clientNamespace namespace.Instance, to echo.Instances) {
+	args := map[string]interface{}{"to": to}
 
 	ctx.ConfigIstio().Eval(args, Gateway, VirtualService).ApplyOrFail(t, clientNamespace.Name())
 }
@@ -320,7 +314,7 @@ kind: DestinationRule
 metadata:
   name: originate-tls-for-server-sds-{{.CredentialName}}
 spec:
-  host: "external.{{.ServerNamespace}}.svc.cluster.local"
+  host: "{{ .to.Config.ClusterLocalFQDN }}"
   trafficPolicy:
     portLevelSettings:
       - port:
@@ -328,16 +322,17 @@ spec:
         tls:
           mode: {{.Mode}}
           credentialName: {{.CredentialName}}
-          sni: external.{{.ServerNamespace}}.svc.cluster.local
+          sni: {{ .to.Config.ClusterLocalFQDN }}
 `
 )
 
 // Create the DestinationRule for TLS origination at Gateway by reading secret in istio-system namespace.
-func CreateDestinationRule(t framework.TestContext, serverNamespace namespace.Instance,
+func CreateDestinationRule(t framework.TestContext, to echo.Instances,
 	destinationRuleMode string, credentialName string) {
-	args := map[string]string{
-		"ServerNamespace": serverNamespace.Name(),
-		"Mode":            destinationRuleMode, "CredentialName": credentialName,
+	args := map[string]interface{}{
+		"to":             to,
+		"Mode":           destinationRuleMode,
+		"CredentialName": credentialName,
 	}
 
 	// Get namespace for gateway pod.
@@ -365,15 +360,13 @@ func CallOpts(to echo.Target, host string, tc TLSTestCase) echo.CallOptions {
 			Headers: headers.New().WithHost(host).Build(),
 		},
 		Check: check.And(
-			check.NoError(),
-			check.And(
-				check.Status(tc.StatusCode),
-				check.Each(func(r echoClient.Response) error {
-					if _, f := r.RequestHeaders["Handled-By-Egress-Gateway"]; tc.Gateway && !f {
-						return fmt.Errorf("expected to be handled by gateway. response: %s", r)
-					}
-					return nil
-				}))),
+			check.NoErrorAndStatus(tc.StatusCode),
+			check.Each(func(r echoClient.Response) error {
+				if _, f := r.RequestHeaders["Handled-By-Egress-Gateway"]; tc.Gateway && !f {
+					return fmt.Errorf("expected to be handled by gateway. response: %s", r)
+				}
+				return nil
+			})),
 	}
 }
 
@@ -383,4 +376,15 @@ func MustReadCert(t test.Failer, f string) string {
 		t.Fatalf("failed to read %v: %v", f, err)
 	}
 	return string(b)
+}
+
+func newGatewayTest(t framework.TestContext) *echotest.T {
+	return echotest.New(t, apps.All).
+		WithDefaultFilters().
+		FromMatch(match.And(
+			match.NotNaked,
+			match.Or(
+				match.ServiceName(apps.A.NamespacedName()),
+				match.Not(match.RegularPod)))).
+		ToMatch(match.ServiceName(apps.External.NamespacedName()))
 }

--- a/tests/integration/security/external_ca/main_test.go
+++ b/tests/integration/security/external_ca/main_test.go
@@ -20,6 +20,7 @@ package externalca
 import (
 	"testing"
 
+	"istio.io/istio/pilot/pkg/model"
 	csrctrl "istio.io/istio/pkg/test/csrctrl/controllers"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
@@ -70,8 +71,8 @@ func SetupApps(ctx resource.Context, apps *EchoDeployments) error {
 	if err != nil {
 		return err
 	}
-	apps.A = match.Service(ASvc).GetMatches(echos)
-	apps.B = match.Service(BSvc).GetMatches(echos)
+	apps.A = match.ServiceName(model.NamespacedName{Name: ASvc, Namespace: apps.Namespace.Name()}).GetMatches(echos)
+	apps.B = match.ServiceName(model.NamespacedName{Name: BSvc, Namespace: apps.Namespace.Name()}).GetMatches(echos)
 	return nil
 }
 

--- a/tests/integration/security/external_ca/reachability_test.go
+++ b/tests/integration/security/external_ca/reachability_test.go
@@ -56,7 +56,7 @@ func TestReachability(t *testing.T) {
 			callCount := util.CallsPerCluster * to.WorkloadsOrFail(t).Len()
 			for _, cluster := range t.Clusters() {
 				t.NewSubTest(fmt.Sprintf("From %s", cluster.StableName())).Run(func(t framework.TestContext) {
-					a := match.And(match.InCluster(cluster), match.Namespace(testNamespace.Name())).GetMatches(apps.A)[0]
+					a := match.And(match.Cluster(cluster), match.Namespace(testNamespace.Name())).GetMatches(apps.A)[0]
 					t.NewSubTest("Basic reachability with external ca").
 						Run(func(t framework.TestContext) {
 							// Verify mTLS works between a and b

--- a/tests/integration/security/jwt_test.go
+++ b/tests/integration/security/jwt_test.go
@@ -421,7 +421,7 @@ func TestIngressRequestAuthentication(t *testing.T) {
 						FromMatch(util.SourceMatcher(ns.Name(), false)).
 						ConditionallyTo(echotest.ReachableDestinations).
 						ConditionallyTo(func(from echo.Instance, to echo.Instances) echo.Instances {
-							return match.InCluster(from.Config().Cluster).GetMatches(to)
+							return match.Cluster(from.Config().Cluster).GetMatches(to)
 						}).
 						ToMatch(util.DestMatcher(ns.Name(), false)).
 						Run(func(t framework.TestContext, from echo.Instance, to echo.Target) {

--- a/tests/integration/security/mtls_first_party_jwt/strict_test.go
+++ b/tests/integration/security/mtls_first_party_jwt/strict_test.go
@@ -89,7 +89,7 @@ func TestMtlsStrictK8sCA(t *testing.T) {
 					},
 					ExpectDestinations: func(from echo.Instance, to echo.Target) echo.Instances {
 						// Without TLS we can't perform SNI routing required for multi-network
-						return match.InNetwork(from.Config().Cluster.NetworkName()).GetMatches(to.Instances())
+						return match.Network(from.Config().Cluster.NetworkName()).GetMatches(to.Instances())
 					},
 					ExpectMTLS: func(src echo.Instance, opts echo.CallOptions) bool {
 						return false

--- a/tests/integration/security/mtlsk8sca/strict_test.go
+++ b/tests/integration/security/mtlsk8sca/strict_test.go
@@ -90,7 +90,7 @@ func TestMtlsStrictK8sCA(t *testing.T) {
 					},
 					ExpectDestinations: func(from echo.Instance, to echo.Target) echo.Instances {
 						// Without TLS we can't perform SNI routing required for multi-network
-						return match.InNetwork(from.Config().Cluster.NetworkName()).GetMatches(to.Instances())
+						return match.Network(from.Config().Cluster.NetworkName()).GetMatches(to.Instances())
 					},
 					ExpectMTLS: func(src echo.Instance, opts echo.CallOptions) bool {
 						return false

--- a/tests/integration/security/pass_through_filter_chain_test.go
+++ b/tests/integration/security/pass_through_filter_chain_test.go
@@ -546,15 +546,15 @@ spec:
 
 			// TODO(slandow) replace this with built-in framework filters (blocked by https://github.com/istio/istio/pull/31565)
 			srcMatcher := match.Or(
-				match.NamespacedName(model.NamespacedName{
+				match.ServiceName(model.NamespacedName{
 					Name:      util.NakedSvc,
 					Namespace: ns.Name(),
 				}),
-				match.NamespacedName(model.NamespacedName{
+				match.ServiceName(model.NamespacedName{
 					Name:      util.BSvc,
 					Namespace: ns.Name(),
 				}),
-				match.NamespacedName(model.NamespacedName{
+				match.ServiceName(model.NamespacedName{
 					Name:      util.VMSvc,
 					Namespace: ns.Name(),
 				}))
@@ -624,9 +624,9 @@ spec:
 							echotest.SingleSimplePodServiceAndAllSpecial(),
 							echotest.FilterMatch(match.And(
 								match.Namespace(ns.Name()),
-								match.IsNotHeadless,
-								match.IsNotNaked,
-								match.IsNotExternal,
+								match.NotHeadless,
+								match.NotNaked,
+								match.NotExternal,
 								util.IsNotMultiversion))).
 						Run(func(t framework.TestContext, from echo.Instance, to echo.Target) {
 							clusterName := from.Config().Cluster.StableName()

--- a/tests/integration/security/reachability_test.go
+++ b/tests/integration/security/reachability_test.go
@@ -164,7 +164,7 @@ func TestReachability(t *testing.T) {
 					Namespace:  systemNM,
 					ExpectDestinations: func(from echo.Instance, to echo.Target) echo.Instances {
 						// Without TLS we can't perform SNI routing required for multi-network
-						return match.InNetwork(from.Config().Cluster.NetworkName()).GetMatches(to.Instances())
+						return match.Network(from.Config().Cluster.NetworkName()).GetMatches(to.Instances())
 					},
 					ExpectSuccess: Always,
 					ExpectMTLS:    Never,

--- a/tests/integration/security/util/framework.go
+++ b/tests/integration/security/util/framework.go
@@ -291,17 +291,25 @@ func SetupApps(ctx resource.Context, _ istio.Instance, apps *EchoDeployments, bu
 		return err
 	}
 	apps.All = echos
-	apps.A = match.Service(ASvc).GetMatches(echos)
-	apps.B = match.Service(BSvc).GetMatches(echos)
-	apps.C = match.Service(CSvc).GetMatches(echos)
-	apps.D = match.Service(DSvc).GetMatches(echos)
-	apps.E = match.Service(ESvc).GetMatches(echos)
 
-	apps.Multiversion = match.Service(MultiversionSvc).GetMatches(echos)
-	apps.Headless = match.Service(HeadlessSvc).GetMatches(echos)
-	apps.Naked = match.Service(NakedSvc).GetMatches(echos)
-	apps.VM = match.Service(VMSvc).GetMatches(echos)
-	apps.HeadlessNaked = match.Service(HeadlessNakedSvc).GetMatches(echos)
+	anyNamespace := func(svcName string) match.Matcher {
+		return func(i echo.Instance) bool {
+			return i.Config().Service == svcName
+		}
+	}
+	apps.A = anyNamespace(ASvc).GetMatches(echos)
+	apps.B = anyNamespace(BSvc).GetMatches(echos)
+	apps.C = anyNamespace(CSvc).GetMatches(echos)
+	apps.D = anyNamespace(DSvc).GetMatches(echos)
+	apps.E = anyNamespace(ESvc).GetMatches(echos)
+
+	apps.Multiversion = anyNamespace(MultiversionSvc).GetMatches(echos)
+	apps.Headless = anyNamespace(HeadlessSvc).GetMatches(echos)
+	apps.Naked = anyNamespace(NakedSvc).GetMatches(echos)
+	apps.VM = anyNamespace(VMSvc).GetMatches(echos)
+	apps.HeadlessNaked = anyNamespace(HeadlessNakedSvc).GetMatches(echos)
+
+	apps.External = anyNamespace(ExternalSvc).GetMatches(echos)
 
 	return nil
 }
@@ -338,13 +346,13 @@ var IsNotMultiversion = match.Not(IsMultiversion)
 
 // SourceMatcher matches workload pod A with sidecar injected and VM
 func SourceMatcher(ns string, skipVM bool) match.Matcher {
-	m := match.NamespacedName(model.NamespacedName{
+	m := match.ServiceName(model.NamespacedName{
 		Name:      ASvc,
 		Namespace: ns,
 	})
 
 	if !skipVM {
-		m = match.Or(m, match.NamespacedName(model.NamespacedName{
+		m = match.Or(m, match.ServiceName(model.NamespacedName{
 			Name:      VMSvc,
 			Namespace: ns,
 		}))
@@ -355,13 +363,13 @@ func SourceMatcher(ns string, skipVM bool) match.Matcher {
 
 // DestMatcher matches workload pod B with sidecar injected and VM
 func DestMatcher(ns string, skipVM bool) match.Matcher {
-	m := match.NamespacedName(model.NamespacedName{
+	m := match.ServiceName(model.NamespacedName{
 		Name:      BSvc,
 		Namespace: ns,
 	})
 
 	if !skipVM {
-		m = match.Or(m, match.NamespacedName(model.NamespacedName{
+		m = match.Or(m, match.ServiceName(model.NamespacedName{
 			Name:      VMSvc,
 			Namespace: ns,
 		}))

--- a/tests/integration/security/util/reachability/context.go
+++ b/tests/integration/security/util/reachability/context.go
@@ -125,11 +125,11 @@ func Run(testCases []TestCase, t framework.TestContext, apps *util.EchoDeploymen
 							apps.A,
 							apps.B,
 							// only hit same network headless services
-							match.InNetwork(from.Config().Cluster.NetworkName()).GetMatches(apps.Headless),
+							match.Network(from.Config().Cluster.NetworkName()).GetMatches(apps.Headless),
 							// only hit same cluster multiversion services
-							match.InCluster(from.Config().Cluster).GetMatches(apps.Multiversion),
+							match.Cluster(from.Config().Cluster).GetMatches(apps.Multiversion),
 							// only hit same cluster naked services
-							match.InCluster(from.Config().Cluster).GetMatches(apps.Naked),
+							match.Cluster(from.Config().Cluster).GetMatches(apps.Naked),
 							apps.VM,
 						}
 

--- a/tests/integration/telemetry/stats/prometheus/customizemetrics/customize_metrics_test.go
+++ b/tests/integration/telemetry/stats/prometheus/customizemetrics/customize_metrics_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/pkg/test/framework"
@@ -158,8 +159,8 @@ proxyMetadata:
 	if err != nil {
 		return err
 	}
-	client = match.Service("client").GetMatches(echos)
-	server = match.Service("server").GetMatches(echos)
+	client = match.ServiceName(model.NamespacedName{Name: "client", Namespace: appNsInst.Name()}).GetMatches(echos)
+	server = match.ServiceName(model.NamespacedName{Name: "server", Namespace: appNsInst.Name()}).GetMatches(echos)
 	promInst, err = prometheus.New(ctx, prometheus.Config{})
 	if err != nil {
 		return

--- a/tests/integration/telemetry/stats/prometheus/stats.go
+++ b/tests/integration/telemetry/stats/prometheus/stats.go
@@ -24,6 +24,7 @@ import (
 
 	"golang.org/x/sync/errgroup"
 
+	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/test/echo/check"
 	"istio.io/istio/pkg/test/echo/common"
@@ -149,7 +150,7 @@ func TestStatsFilter(t *testing.T, feature features.Feature) {
 
 			// In addition, verifies that mocked prometheus could call metrics endpoint with proxy provisioned certs
 			for _, prom := range mockProm {
-				st := match.InCluster(prom.Config().Cluster).FirstOrFail(t, server)
+				st := match.Cluster(prom.Config().Cluster).FirstOrFail(t, server)
 				prom.CallOrFail(t, echo.CallOptions{
 					Address: st.WorkloadsOrFail(t)[0].Address(),
 					Scheme:  scheme.HTTPS,
@@ -309,10 +310,10 @@ proxyMetadata:
 	for _, c := range ctx.Clusters() {
 		ingr = append(ingr, ist.IngressFor(c))
 	}
-	client = match.Service("client").GetMatches(echos)
-	server = match.Service("server").GetMatches(echos)
-	nonInjectedServer = match.Service("server-no-sidecar").GetMatches(echos)
-	mockProm = match.Service("mock-prom").GetMatches(echos)
+	client = match.ServiceName(model.NamespacedName{Name: "client", Namespace: appNsInst.Name()}).GetMatches(echos)
+	server = match.ServiceName(model.NamespacedName{Name: "server", Namespace: appNsInst.Name()}).GetMatches(echos)
+	nonInjectedServer = match.ServiceName(model.NamespacedName{Name: "server-no-sidecar", Namespace: appNsInst.Name()}).GetMatches(echos)
+	mockProm = match.ServiceName(model.NamespacedName{Name: "mock-prom", Namespace: appNsInst.Name()}).GetMatches(echos)
 	promInst, err = prometheus.New(ctx, prometheus.Config{})
 	if err != nil {
 		return

--- a/tests/integration/telemetry/stats/prometheus/wasm/bad_wasm_filter_test.go
+++ b/tests/integration/telemetry/stats/prometheus/wasm/bad_wasm_filter_test.go
@@ -40,7 +40,7 @@ func TestBadWasmRemoteLoad(t *testing.T) {
 		Run(func(t framework.TestContext) {
 			// Test bad wasm remote load in only one cluster.
 			// There is no need to repeat the same testing logic in multiple clusters.
-			cltInstance := match.InCluster(t.Clusters().Default()).FirstOrFail(t, common.GetClientInstances())
+			cltInstance := match.Cluster(t.Clusters().Default()).FirstOrFail(t, common.GetClientInstances())
 			// Verify that echo server could return 200
 			retry.UntilSuccessOrFail(t, func() error {
 				if err := common.SendTraffic(cltInstance); err != nil {


### PR DESCRIPTION
The current echotest tooling doesn't support multiple namespaces very well.  This changes a number of things:

- Include namespace prefix when multiple namepaces are used across source and destinations.
- Adding `RegularPod` logic as top-level property of config.
- Updating logic for selecting one regular pod to include one per namespace.
- Renaming `match.NamespacedName` to `match.SameService` and deprecating `match.Service`.
- Cleaning up naming of matchers.

**Please provide a description of this PR:**