### PR TITLE
Verify distroless base images before building

### DIFF
--- a/tools/istio-docker.mk
+++ b/tools/istio-docker.mk
@@ -250,6 +250,7 @@ build.docker.install-cni: cni/deployments/kubernetes/Dockerfile.install-cni
 build.docker.base: docker/Dockerfile.base
 	$(DOCKER_RULE)
 build.docker.distroless: docker/Dockerfile.distroless
+	grep gcr.io/distroless ./docker/Dockerfile.distroless  | awk '{print $$2}' | xargs -L1 cosign verify --key https://raw.githubusercontent.com/GoogleContainerTools/distroless/main/cosign.pub
 	$(DOCKER_RULE)
 
 # VM Base images


### PR DESCRIPTION
**Please provide a description of this PR:**

Based on
https://www.cncf.io/blog/2021/09/14/how-to-secure-containers-with-cosign-and-distroless-images/
we should verify the distroless images before we build images from them.