### PR TITLE
Add test for Delta XDS vs SotW

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -545,6 +545,15 @@ var (
 			"These checks are both expensive and panic on failure. As a result, this should be used only for testing.",
 	).Get()
 
+	// EnableUnsafeDeltaTest enables runtime checks to test Delta XDS efficiency. This should never be enabled in
+	// production.
+	EnableUnsafeDeltaTest = env.RegisterBoolVar(
+		"UNSAFE_PILOT_ENABLE_DELTA_TEST",
+		false,
+		"If enabled, addition runtime tests for Delta XDS efficiency are added. "+
+			"These checks are extremely expensive, so this should be used only for testing, not production.",
+	).Get()
+
 	DeltaXds = env.RegisterBoolVar("ISTIO_DELTA_XDS", false,
 		"If enabled, pilot will only send the delta configs as opposed to the state of the world on a "+
 			"Resource Request. This feature uses the delta xds api, but does not currently send the actual deltas.").Get()

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -343,9 +343,9 @@ type WatchedResource struct {
 	// LastSent tracks the time of the generated push, to determine the time it takes the client to ack.
 	LastSent time.Time
 
-	// LastMessage tracks the contents of the last push.
+	// LastResources tracks the contents of the last push.
 	// This field is extremely expensive to maintain and is typically disabled
-	LastMessage Resources
+	LastResources Resources
 }
 
 var istioVersionRegexp = regexp.MustCompile(`^([1-9]+)\.([0-9]+)(\.([0-9]+))?`)

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -342,6 +342,10 @@ type WatchedResource struct {
 
 	// LastSent tracks the time of the generated push, to determine the time it takes the client to ack.
 	LastSent time.Time
+
+	// LastMessage tracks the contents of the last push.
+	// This field is extremely expensive to maintain and is typically disabled
+	LastMessage Resources
 }
 
 var istioVersionRegexp = regexp.MustCompile(`^([1-9]+)\.([0-9]+)(\.([0-9]+))?`)

--- a/pilot/pkg/xds/delta.go
+++ b/pilot/pkg/xds/delta.go
@@ -21,12 +21,9 @@ import (
 	"time"
 
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
-	"github.com/golang/protobuf/jsonpb"
-	"github.com/google/go-cmp/cmp"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/testing/protocmp"
 
 	"istio.io/istio/pilot/pkg/features"
 	istiogrpc "istio.io/istio/pilot/pkg/grpc"
@@ -264,7 +261,7 @@ func (conn *Connection) sendDelta(res *discovery.DeltaDiscoveryResponse) error {
 			conn.proxy.WatchedResources[res.TypeUrl].VersionSent = res.SystemVersionInfo
 			conn.proxy.WatchedResources[res.TypeUrl].LastSent = time.Now()
 			if features.EnableUnsafeDeltaTest {
-				conn.proxy.WatchedResources[res.TypeUrl].LastMessage = applyDelta(conn.proxy.WatchedResources[res.TypeUrl].LastMessage, res)
+				conn.proxy.WatchedResources[res.TypeUrl].LastResources = applyDelta(conn.proxy.WatchedResources[res.TypeUrl].LastResources, res)
 			}
 			conn.proxy.Unlock()
 		}
@@ -273,30 +270,6 @@ func (conn *Connection) sendDelta(res *discovery.DeltaDiscoveryResponse) error {
 		xdsResponseWriteTimeouts.Increment()
 	}
 	return err
-}
-
-func applyDelta(message model.Resources, resp *discovery.DeltaDiscoveryResponse) model.Resources {
-	deleted := sets.NewSet(resp.RemovedResources...)
-	byName := map[string]*discovery.Resource{}
-	for _, v := range resp.Resources {
-		byName[v.Name] = v
-	}
-	res := model.Resources{}
-	for _, m := range message {
-		if deleted.Contains(m.Name) {
-			continue
-		}
-		if replaced := byName[m.Name]; replaced != nil {
-			res = append(res, replaced)
-			delete(byName, m.Name)
-			continue
-		}
-		res = append(res, m)
-	}
-	for _, v := range byName {
-		res = append(res, v)
-	}
-	return res
 }
 
 // processDeltaRequest is handling one request. This is currently called from the 'main' thread, which also
@@ -596,127 +569,4 @@ func extractNames(res []*discovery.Resource) []string {
 		names = append(names, r.Name)
 	}
 	return names
-}
-
-// TODO: remove, just for development
-func debugRequest(req *discovery.DeltaDiscoveryRequest) {
-	if log.DebugEnabled() {
-		debug, _ := (&jsonpb.Marshaler{Indent: " "}).MarshalToString(&discovery.DeltaDiscoveryRequest{
-			TypeUrl:                  req.TypeUrl,
-			ResourceNamesSubscribe:   req.ResourceNamesSubscribe,
-			ResourceNamesUnsubscribe: req.ResourceNamesUnsubscribe,
-			InitialResourceVersions:  req.InitialResourceVersions,
-			ResponseNonce:            req.ResponseNonce,
-			ErrorDetail:              req.ErrorDetail,
-		})
-		log.Debugf("delta request: %s", debug)
-	}
-}
-
-var knownOptimizationGaps = sets.NewSet(
-	"BlackHoleCluster",
-	"InboundPassthroughClusterIpv4",
-	"InboundPassthroughClusterIpv6",
-	"PassthroughCluster",
-)
-
-// compareDiff compares a Delta and SotW XDS response. This allows checking that the Delta XDS
-// response returned the optimal result. Checks include correctness checks (e.g. if a config changed,
-// we must include it) and possible optimizations (e.g. we sent a config, but it was not changed).
-func (s *DiscoveryServer) compareDiff(
-	con *Connection,
-	w *model.WatchedResource,
-	full model.Resources,
-	resp model.Resources,
-	delete model.DeletedResources,
-	usedDelta bool,
-	generateOnly []string,
-) {
-	current := con.Watched(w.TypeUrl).LastMessage
-	if current == nil {
-		log.Debugf("ADS:%s: resources initialized", v3.GetShortType(w.TypeUrl))
-		return
-	}
-	if resp == nil && delete == nil && len(full) == 0 {
-		// TODO: it suspicious full is never nil - are there case where we should be deleting everything?
-		// Both SotW and Delta did not respond, nothing to compare
-		return
-	}
-	newByName := map[string]*discovery.Resource{}
-	for _, v := range full {
-		newByName[v.Name] = v
-	}
-	curByName := map[string]*discovery.Resource{}
-	for _, v := range current {
-		curByName[v.Name] = v
-	}
-
-	watched := sets.NewSet(w.ResourceNames...)
-
-	details := fmt.Sprintf("last:%v sotw:%v delta:%v-%v", len(current), len(full), len(resp), len(delete))
-	wantDeleted := sets.NewSet()
-	wantChanged := sets.NewSet()
-	wantUnchanged := sets.NewSet()
-	for _, c := range current {
-		n := newByName[c.Name]
-		if n == nil {
-			// We had a resource, but SotW didn't generate it.
-			if watched.Contains(c.Name) {
-				// We only need to delete it if Envoy is watching. Otherwise, it may have simply unsubscribed
-				wantDeleted.Insert(c.Name)
-			}
-		} else if diff := cmp.Diff(c.Resource, n.Resource, protocmp.Transform()); diff != "" {
-			// Resource was modified
-			wantChanged.Insert(c.Name)
-		} else {
-			// No diff. Ideally delta doesn't send any update here
-			wantUnchanged.Insert(c.Name)
-		}
-	}
-	for _, v := range full {
-		if _, f := curByName[v.Name]; !f {
-			// Resource is added. Delta doesn't distinguish add vs update, so just put it with changed
-			wantChanged.Insert(v.Name)
-		}
-	}
-
-	gotDeleted := sets.NewSet()
-	if usedDelta {
-		gotDeleted.Insert(delete...)
-	}
-	gotChanged := sets.NewSet()
-	for _, v := range resp {
-		gotChanged.Insert(v.Name)
-	}
-
-	// BUGS
-	extraDeletes := gotDeleted.Difference(wantDeleted).SortedList()
-	missedDeletes := wantDeleted.Difference(gotDeleted).SortedList()
-	missedChanges := wantChanged.Difference(gotChanged).SortedList()
-
-	// Optimization Potential
-	extraChanges := gotChanged.Difference(wantChanged).Difference(knownOptimizationGaps).SortedList()
-	if generateOnly != nil {
-		// Delta is configured to build only the request resources. Make sense we didn't build anything extra
-		if !wantChanged.SupersetOf(gotChanged) {
-			log.Errorf("%s: TEST for node:%s unexpected resources: %v %v", v3.GetShortType(w.TypeUrl), con.proxy.ID, details, wantChanged.Difference(gotChanged))
-		}
-		// Still make sure we didn't delete anything extra
-		if len(extraDeletes) > 0 {
-			log.Errorf("%s: TEST for node:%s unexpected deletions: %v %v", v3.GetShortType(w.TypeUrl), con.proxy.ID, details, extraDeletes)
-		}
-	} else {
-		if len(extraDeletes) > 0 {
-			log.Errorf("%s: TEST for node:%s unexpected deletions: %v %v", v3.GetShortType(w.TypeUrl), con.proxy.ID, details, extraDeletes)
-		}
-		if len(missedDeletes) > 0 {
-			log.Errorf("%s: TEST for node:%s missed deletions: %v %v", v3.GetShortType(w.TypeUrl), con.proxy.ID, details, missedDeletes)
-		}
-		if len(missedChanges) > 0 {
-			log.Errorf("%s: TEST for node:%s missed changes: %v %v", v3.GetShortType(w.TypeUrl), con.proxy.ID, details, missedChanges)
-		}
-		if len(extraChanges) > 0 && usedDelta { // TODO flag to log even when !usedDelta, since it means we didn't use delta where we could have
-			log.Infof("%s: TEST for node:%s missed possible optimization: %v. deleted:%v changed:%v", v3.GetShortType(w.TypeUrl), con.proxy.ID, extraChanges, len(gotDeleted), len(gotChanged))
-		}
-	}
 }

--- a/pilot/pkg/xds/delta.go
+++ b/pilot/pkg/xds/delta.go
@@ -21,9 +21,12 @@ import (
 	"time"
 
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	"github.com/golang/protobuf/jsonpb"
+	"github.com/google/go-cmp/cmp"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/testing/protocmp"
 
 	"istio.io/istio/pilot/pkg/features"
 	istiogrpc "istio.io/istio/pilot/pkg/grpc"
@@ -260,6 +263,9 @@ func (conn *Connection) sendDelta(res *discovery.DeltaDiscoveryResponse) error {
 			conn.proxy.WatchedResources[res.TypeUrl].NonceSent = res.Nonce
 			conn.proxy.WatchedResources[res.TypeUrl].VersionSent = res.SystemVersionInfo
 			conn.proxy.WatchedResources[res.TypeUrl].LastSent = time.Now()
+			if features.EnableUnsafeDeltaTest {
+				conn.proxy.WatchedResources[res.TypeUrl].LastMessage = applyDelta(conn.proxy.WatchedResources[res.TypeUrl].LastMessage, res)
+			}
 			conn.proxy.Unlock()
 		}
 	} else {
@@ -267,6 +273,30 @@ func (conn *Connection) sendDelta(res *discovery.DeltaDiscoveryResponse) error {
 		xdsResponseWriteTimeouts.Increment()
 	}
 	return err
+}
+
+func applyDelta(message model.Resources, resp *discovery.DeltaDiscoveryResponse) model.Resources {
+	deleted := sets.NewSet(resp.RemovedResources...)
+	byName := map[string]*discovery.Resource{}
+	for _, v := range resp.Resources {
+		byName[v.Name] = v
+	}
+	res := model.Resources{}
+	for _, m := range message {
+		if deleted.Contains(m.Name) {
+			continue
+		}
+		if replaced := byName[m.Name]; replaced != nil {
+			res = append(res, replaced)
+			delete(byName, m.Name)
+			continue
+		}
+		res = append(res, m)
+	}
+	for _, v := range byName {
+		res = append(res, v)
+	}
+	return res
 }
 
 // processDeltaRequest is handling one request. This is currently called from the 'main' thread, which also
@@ -429,6 +459,7 @@ func (s *DiscoveryServer) pushDeltaXds(con *Connection, push *model.PushContext,
 	}
 	t0 := time.Now()
 
+	originalW := w
 	// If subscribe is set, client is requesting specific resources. We should just generate the
 	// new resources it needs, rather than the entire set of known resources.
 	if subscribe != nil {
@@ -446,6 +477,10 @@ func (s *DiscoveryServer) pushDeltaXds(con *Connection, push *model.PushContext,
 	switch g := gen.(type) {
 	case model.XdsDeltaResourceGenerator:
 		res, deletedRes, logdata, usedDelta, err = g.GenerateDeltas(con.proxy, req, w)
+		if features.EnableUnsafeDeltaTest {
+			fullRes, _, _ := g.Generate(con.proxy, originalW, req)
+			s.compareDiff(con, originalW, fullRes, res, deletedRes, usedDelta, subscribe)
+		}
 	case model.XdsResourceGenerator:
 		res, logdata, err = g.Generate(con.proxy, w, req)
 	}
@@ -496,7 +531,6 @@ func (s *DiscoveryServer) pushDeltaXds(con *Connection, push *model.PushContext,
 	if len(logdata.AdditionalInfo) > 0 {
 		info = " " + logdata.AdditionalInfo
 	}
-
 	if err := con.sendDelta(resp); err != nil {
 		if recordSendError(w.TypeUrl, err) {
 			deltaLog.Warnf("%s: Send failure for node:%s resources:%d size:%s%s: %v",
@@ -562,4 +596,127 @@ func extractNames(res []*discovery.Resource) []string {
 		names = append(names, r.Name)
 	}
 	return names
+}
+
+// TODO: remove, just for development
+func debugRequest(req *discovery.DeltaDiscoveryRequest) {
+	if log.DebugEnabled() {
+		debug, _ := (&jsonpb.Marshaler{Indent: " "}).MarshalToString(&discovery.DeltaDiscoveryRequest{
+			TypeUrl:                  req.TypeUrl,
+			ResourceNamesSubscribe:   req.ResourceNamesSubscribe,
+			ResourceNamesUnsubscribe: req.ResourceNamesUnsubscribe,
+			InitialResourceVersions:  req.InitialResourceVersions,
+			ResponseNonce:            req.ResponseNonce,
+			ErrorDetail:              req.ErrorDetail,
+		})
+		log.Debugf("delta request: %s", debug)
+	}
+}
+
+var knownOptimizationGaps = sets.NewSet(
+	"BlackHoleCluster",
+	"InboundPassthroughClusterIpv4",
+	"InboundPassthroughClusterIpv6",
+	"PassthroughCluster",
+)
+
+// compareDiff compares a Delta and SotW XDS response. This allows checking that the Delta XDS
+// response returned the optimal result. Checks include correctness checks (e.g. if a config changed,
+// we must include it) and possible optimizations (e.g. we sent a config, but it was not changed).
+func (s *DiscoveryServer) compareDiff(
+	con *Connection,
+	w *model.WatchedResource,
+	full model.Resources,
+	resp model.Resources,
+	delete model.DeletedResources,
+	usedDelta bool,
+	generateOnly []string,
+) {
+	current := con.Watched(w.TypeUrl).LastMessage
+	if current == nil {
+		log.Debugf("ADS:%s: resources initialized", v3.GetShortType(w.TypeUrl))
+		return
+	}
+	if resp == nil && delete == nil && len(full) == 0 {
+		// TODO: it suspicious full is never nil - are there case where we should be deleting everything?
+		// Both SotW and Delta did not respond, nothing to compare
+		return
+	}
+	newByName := map[string]*discovery.Resource{}
+	for _, v := range full {
+		newByName[v.Name] = v
+	}
+	curByName := map[string]*discovery.Resource{}
+	for _, v := range current {
+		curByName[v.Name] = v
+	}
+
+	watched := sets.NewSet(w.ResourceNames...)
+
+	details := fmt.Sprintf("last:%v sotw:%v delta:%v-%v", len(current), len(full), len(resp), len(delete))
+	wantDeleted := sets.NewSet()
+	wantChanged := sets.NewSet()
+	wantUnchanged := sets.NewSet()
+	for _, c := range current {
+		n := newByName[c.Name]
+		if n == nil {
+			// We had a resource, but SotW didn't generate it.
+			if watched.Contains(c.Name) {
+				// We only need to delete it if Envoy is watching. Otherwise, it may have simply unsubscribed
+				wantDeleted.Insert(c.Name)
+			}
+		} else if diff := cmp.Diff(c.Resource, n.Resource, protocmp.Transform()); diff != "" {
+			// Resource was modified
+			wantChanged.Insert(c.Name)
+		} else {
+			// No diff. Ideally delta doesn't send any update here
+			wantUnchanged.Insert(c.Name)
+		}
+	}
+	for _, v := range full {
+		if _, f := curByName[v.Name]; !f {
+			// Resource is added. Delta doesn't distinguish add vs update, so just put it with changed
+			wantChanged.Insert(v.Name)
+		}
+	}
+
+	gotDeleted := sets.NewSet()
+	if usedDelta {
+		gotDeleted.Insert(delete...)
+	}
+	gotChanged := sets.NewSet()
+	for _, v := range resp {
+		gotChanged.Insert(v.Name)
+	}
+
+	// BUGS
+	extraDeletes := gotDeleted.Difference(wantDeleted).SortedList()
+	missedDeletes := wantDeleted.Difference(gotDeleted).SortedList()
+	missedChanges := wantChanged.Difference(gotChanged).SortedList()
+
+	// Optimization Potential
+	extraChanges := gotChanged.Difference(wantChanged).Difference(knownOptimizationGaps).SortedList()
+	if generateOnly != nil {
+		// Delta is configured to build only the request resources. Make sense we didn't build anything extra
+		if !wantChanged.SupersetOf(gotChanged) {
+			log.Errorf("%s: TEST for node:%s unexpected resources: %v %v", v3.GetShortType(w.TypeUrl), con.proxy.ID, details, wantChanged.Difference(gotChanged))
+		}
+		// Still make sure we didn't delete anything extra
+		if len(extraDeletes) > 0 {
+			log.Errorf("%s: TEST for node:%s unexpected deletions: %v %v", v3.GetShortType(w.TypeUrl), con.proxy.ID, details, extraDeletes)
+		}
+	} else {
+		if len(extraDeletes) > 0 {
+			log.Errorf("%s: TEST for node:%s unexpected deletions: %v %v", v3.GetShortType(w.TypeUrl), con.proxy.ID, details, extraDeletes)
+		}
+		if len(missedDeletes) > 0 {
+			log.Errorf("%s: TEST for node:%s missed deletions: %v %v", v3.GetShortType(w.TypeUrl), con.proxy.ID, details, missedDeletes)
+		}
+		if len(missedChanges) > 0 {
+			log.Errorf("%s: TEST for node:%s missed changes: %v %v", v3.GetShortType(w.TypeUrl), con.proxy.ID, details, missedChanges)
+		}
+		if len(extraChanges) > 0 && usedDelta { // TODO flag to log even when !usedDelta, since it means we didn't use delta where we could have
+			log.Infof("%s: TEST for node:%s missed possible optimization: %v. deleted:%v changed:%v", v3.GetShortType(w.TypeUrl), con.proxy.ID, extraChanges, len(gotDeleted), len(gotChanged))
+		}
+	}
 }

--- a/pilot/pkg/xds/deltatest.go
+++ b/pilot/pkg/xds/deltatest.go
@@ -41,7 +41,7 @@ func (s *DiscoveryServer) compareDiff(
 	w *model.WatchedResource,
 	full model.Resources,
 	resp model.Resources,
-	delete model.DeletedResources,
+	deleted model.DeletedResources,
 	usedDelta bool,
 	generateOnly []string,
 ) {
@@ -50,7 +50,7 @@ func (s *DiscoveryServer) compareDiff(
 		log.Debugf("ADS:%s: resources initialized", v3.GetShortType(w.TypeUrl))
 		return
 	}
-	if resp == nil && delete == nil && len(full) == 0 {
+	if resp == nil && deleted == nil && len(full) == 0 {
 		// TODO: it suspicious full is never nil - are there case where we should be deleting everything?
 		// Both SotW and Delta did not respond, nothing to compare
 		return
@@ -66,7 +66,7 @@ func (s *DiscoveryServer) compareDiff(
 
 	watched := sets.NewSet(w.ResourceNames...)
 
-	details := fmt.Sprintf("last:%v sotw:%v delta:%v-%v", len(current), len(full), len(resp), len(delete))
+	details := fmt.Sprintf("last:%v sotw:%v delta:%v-%v", len(current), len(full), len(resp), len(deleted))
 	wantDeleted := sets.NewSet()
 	wantChanged := sets.NewSet()
 	wantUnchanged := sets.NewSet()
@@ -95,7 +95,7 @@ func (s *DiscoveryServer) compareDiff(
 
 	gotDeleted := sets.NewSet()
 	if usedDelta {
-		gotDeleted.Insert(delete...)
+		gotDeleted.Insert(deleted...)
 	}
 	gotChanged := sets.NewSet()
 	for _, v := range resp {
@@ -130,9 +130,11 @@ func (s *DiscoveryServer) compareDiff(
 		}
 		if len(extraChanges) > 0 {
 			if usedDelta {
-				log.Infof("%s: TEST for node:%s missed possible optimization: %v. deleted:%v changed:%v", v3.GetShortType(w.TypeUrl), con.proxy.ID, extraChanges, len(gotDeleted), len(gotChanged))
+				log.Infof("%s: TEST for node:%s missed possible optimization: %v. deleted:%v changed:%v",
+					v3.GetShortType(w.TypeUrl), con.proxy.ID, extraChanges, len(gotDeleted), len(gotChanged))
 			} else {
-				log.Debugf("%s: TEST for node:%s missed possible optimization: %v. deleted:%v changed:%v", v3.GetShortType(w.TypeUrl), con.proxy.ID, extraChanges, len(gotDeleted), len(gotChanged))
+				log.Debugf("%s: TEST for node:%s missed possible optimization: %v. deleted:%v changed:%v",
+					v3.GetShortType(w.TypeUrl), con.proxy.ID, extraChanges, len(gotDeleted), len(gotChanged))
 			}
 		}
 	}

--- a/pilot/pkg/xds/deltatest.go
+++ b/pilot/pkg/xds/deltatest.go
@@ -1,0 +1,163 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package xds
+
+import (
+	"fmt"
+
+	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/testing/protocmp"
+
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/util/sets"
+	v3 "istio.io/istio/pilot/pkg/xds/v3"
+)
+
+var knownOptimizationGaps = sets.NewSet(
+	"BlackHoleCluster",
+	"InboundPassthroughClusterIpv4",
+	"InboundPassthroughClusterIpv6",
+	"PassthroughCluster",
+)
+
+// compareDiff compares a Delta and SotW XDS response. This allows checking that the Delta XDS
+// response returned the optimal result. Checks include correctness checks (e.g. if a config changed,
+// we must include it) and possible optimizations (e.g. we sent a config, but it was not changed).
+func (s *DiscoveryServer) compareDiff(
+	con *Connection,
+	w *model.WatchedResource,
+	full model.Resources,
+	resp model.Resources,
+	delete model.DeletedResources,
+	usedDelta bool,
+	generateOnly []string,
+) {
+	current := con.Watched(w.TypeUrl).LastResources
+	if current == nil {
+		log.Debugf("ADS:%s: resources initialized", v3.GetShortType(w.TypeUrl))
+		return
+	}
+	if resp == nil && delete == nil && len(full) == 0 {
+		// TODO: it suspicious full is never nil - are there case where we should be deleting everything?
+		// Both SotW and Delta did not respond, nothing to compare
+		return
+	}
+	newByName := map[string]*discovery.Resource{}
+	for _, v := range full {
+		newByName[v.Name] = v
+	}
+	curByName := map[string]*discovery.Resource{}
+	for _, v := range current {
+		curByName[v.Name] = v
+	}
+
+	watched := sets.NewSet(w.ResourceNames...)
+
+	details := fmt.Sprintf("last:%v sotw:%v delta:%v-%v", len(current), len(full), len(resp), len(delete))
+	wantDeleted := sets.NewSet()
+	wantChanged := sets.NewSet()
+	wantUnchanged := sets.NewSet()
+	for _, c := range current {
+		n := newByName[c.Name]
+		if n == nil {
+			// We had a resource, but SotW didn't generate it.
+			if watched.Contains(c.Name) {
+				// We only need to delete it if Envoy is watching. Otherwise, it may have simply unsubscribed
+				wantDeleted.Insert(c.Name)
+			}
+		} else if diff := cmp.Diff(c.Resource, n.Resource, protocmp.Transform()); diff != "" {
+			// Resource was modified
+			wantChanged.Insert(c.Name)
+		} else {
+			// No diff. Ideally delta doesn't send any update here
+			wantUnchanged.Insert(c.Name)
+		}
+	}
+	for _, v := range full {
+		if _, f := curByName[v.Name]; !f {
+			// Resource is added. Delta doesn't distinguish add vs update, so just put it with changed
+			wantChanged.Insert(v.Name)
+		}
+	}
+
+	gotDeleted := sets.NewSet()
+	if usedDelta {
+		gotDeleted.Insert(delete...)
+	}
+	gotChanged := sets.NewSet()
+	for _, v := range resp {
+		gotChanged.Insert(v.Name)
+	}
+
+	// BUGS
+	extraDeletes := gotDeleted.Difference(wantDeleted).SortedList()
+	missedDeletes := wantDeleted.Difference(gotDeleted).SortedList()
+	missedChanges := wantChanged.Difference(gotChanged).SortedList()
+
+	// Optimization Potential
+	extraChanges := gotChanged.Difference(wantChanged).Difference(knownOptimizationGaps).SortedList()
+	if generateOnly != nil {
+		// Delta is configured to build only the request resources. Make sense we didn't build anything extra
+		if !wantChanged.SupersetOf(gotChanged) {
+			log.Errorf("%s: TEST for node:%s unexpected resources: %v %v", v3.GetShortType(w.TypeUrl), con.proxy.ID, details, wantChanged.Difference(gotChanged))
+		}
+		// Still make sure we didn't delete anything extra
+		if len(extraDeletes) > 0 {
+			log.Errorf("%s: TEST for node:%s unexpected deletions: %v %v", v3.GetShortType(w.TypeUrl), con.proxy.ID, details, extraDeletes)
+		}
+	} else {
+		if len(extraDeletes) > 0 {
+			log.Errorf("%s: TEST for node:%s unexpected deletions: %v %v", v3.GetShortType(w.TypeUrl), con.proxy.ID, details, extraDeletes)
+		}
+		if len(missedDeletes) > 0 {
+			log.Errorf("%s: TEST for node:%s missed deletions: %v %v", v3.GetShortType(w.TypeUrl), con.proxy.ID, details, missedDeletes)
+		}
+		if len(missedChanges) > 0 {
+			log.Errorf("%s: TEST for node:%s missed changes: %v %v", v3.GetShortType(w.TypeUrl), con.proxy.ID, details, missedChanges)
+		}
+		if len(extraChanges) > 0 {
+			if usedDelta {
+				log.Infof("%s: TEST for node:%s missed possible optimization: %v. deleted:%v changed:%v", v3.GetShortType(w.TypeUrl), con.proxy.ID, extraChanges, len(gotDeleted), len(gotChanged))
+			} else {
+				log.Debugf("%s: TEST for node:%s missed possible optimization: %v. deleted:%v changed:%v", v3.GetShortType(w.TypeUrl), con.proxy.ID, extraChanges, len(gotDeleted), len(gotChanged))
+			}
+		}
+	}
+}
+
+func applyDelta(message model.Resources, resp *discovery.DeltaDiscoveryResponse) model.Resources {
+	deleted := sets.NewSet(resp.RemovedResources...)
+	byName := map[string]*discovery.Resource{}
+	for _, v := range resp.Resources {
+		byName[v.Name] = v
+	}
+	res := model.Resources{}
+	for _, m := range message {
+		if deleted.Contains(m.Name) {
+			continue
+		}
+		if replaced := byName[m.Name]; replaced != nil {
+			res = append(res, replaced)
+			delete(byName, m.Name)
+			continue
+		}
+		res = append(res, m)
+	}
+	for _, v := range byName {
+		res = append(res, v)
+	}
+	return res
+}


### PR DESCRIPTION
This adds a new test -- disabled by default -- which adds a bunch of consistency checks in Delta XDS by comparing responses to SotW responses. This is intended to have 0 impact on production code, as all changes are behind a `UNSAFE` flag.

These tests have found a number of bugs in the past, as I have maintained this in my fork for a while. I think its useful to upstream though.