### PR TITLE
EDS: send incremental pushes on full with only services changed

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -545,6 +545,10 @@ var (
 		"If enabled, pilot will only send the delta configs as opposed to the state of the world on a "+
 			"Resource Request. This feature uses the delta xds api, but does not currently send the actual deltas.").Get()
 
+	PartialFullPushes = env.RegisterBoolVar("PILOT_PARTIAL_FULL_PUSHES", true,
+		"If enabled, pilot will send partial pushes in for child resources (RDS, EDS, etc) when possible. "+
+			"This occurs for EDS in many cases regardless of this setting.").Get()
+
 	EnableLegacyIstioMutualCredentialName = env.RegisterBoolVar("PILOT_ENABLE_LEGACY_ISTIO_MUTUAL_CREDENTIAL_NAME",
 		false,
 		"If enabled, Gateway's with ISTIO_MUTUAL mode and credentialName configured will use simple TLS. "+

--- a/pilot/pkg/xds/eds.go
+++ b/pilot/pkg/xds/eds.go
@@ -568,8 +568,7 @@ func (eds *EdsGenerator) buildEndpoints(proxy *model.Proxy,
 	// ConfigsUpdated=ALL, so in this case we would not enable a partial push.
 	// Despite this code existing on the SotW code path, sending these partial pushes is still allowed;
 	// see https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol#grouping-resources-into-responses
-	canSendPartialFullPushes := features.PartialFullPushes && onlyEndpointsChanged(req)
-	if !req.Full || canSendPartialFullPushes {
+	if !req.Full || (features.PartialFullPushes && onlyEndpointsChanged(req)) {
 		edsUpdatedServices = model.ConfigNamesOfKind(req.ConfigsUpdated, gvk.ServiceEntry)
 	}
 	resources := make(model.Resources, 0)


### PR DESCRIPTION
This mirrors the Delta EDS code.

Basically, this allows the case of a Full push for a service to only
send the endpoints request. This happens when we create a new Service,
for example.

Note: "Delta EDS" and "Incremental EDS" are essentially exactly
identical other than the gRPC service. In both cases, its impossible to
remove resources (its all based on parent Cluster being removed). In
both cases, we can chose to send as many or as few resources as we want.

The same applies to RDS I believe.

**Please provide a description of this PR:**