### PR TITLE
Update the clusterMatch port match condition

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/cluster_patch.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/cluster_patch.go
@@ -185,9 +185,8 @@ func clusterMatch(cluster *cluster.Cluster, cp *model.EnvoyFilterConfigPatchWrap
 		return false
 	}
 
-	// FIXME: Ports on a cluster can be 0. the API only takes uint32 for ports
 	// We should either make that field in API as a wrapper type or switch to int
-	if cMatch.PortNumber != 0 && int(cMatch.PortNumber) != port {
+	if int(cMatch.PortNumber) != port {
 		return false
 	}
 	return true


### PR DESCRIPTION
**Please provide a description of this PR:**
```go
// FIXME: Ports on a cluster can be 0. the API only takes uint32 for ports
```
the cluster port can be set to 0，so update the match condition

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [x] Networking

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
