### PR TITLE
pilot: unify and improve sub/unsub in delta and sotw

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -357,15 +357,17 @@ type PushRequest struct {
 	// classifying a single trigger as having multiple reasons.
 	Reason []TriggerReason
 
+	// Delta defines the resources that were added or removed as part of this push request.
+	// This is set only on requests from the client which change the set of resources they (un)subscribe from.
 	Delta ResourceDelta
 }
 
 // ResourceDelta records the difference in requested resources by an XDS client
 type ResourceDelta struct {
 	// Subscribed indicates the client requested these additional resources
-	Subscribed []string
+	Subscribed sets.Set
 	// Unsubscribed indicates the client no longer requires these resources
-	Unsubscribed []string
+	Unsubscribed sets.Set
 }
 
 func (rd ResourceDelta) IsEmpty() bool {

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -356,6 +356,20 @@ type PushRequest struct {
 	// There should only be multiple reasons if the push request is the result of two distinct triggers, rather than
 	// classifying a single trigger as having multiple reasons.
 	Reason []TriggerReason
+
+	Delta ResourceDelta
+}
+
+// ResourceDelta records the difference in requested resources by an XDS client
+type ResourceDelta struct {
+	// Subscribed indicates the client requested these additional resources
+	Subscribed []string
+	// Unsubscribed indicates the client no longer requires these resources
+	Unsubscribed []string
+}
+
+func (rd ResourceDelta) IsEmpty() bool {
+	return len(rd.Subscribed) == 0 && len(rd.Unsubscribed) == 0
 }
 
 type TriggerReason string

--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -50,7 +50,7 @@ func (configgen *ConfigGeneratorImpl) BuildHTTPRoutes(
 	req *model.PushRequest,
 	routeNames []string,
 ) ([]*discovery.Resource, model.XdsLogDetails) {
-	routeConfigurations := make([]*discovery.Resource, 0)
+	var routeConfigurations model.Resources
 
 	efw := req.Push.EnvoyFilters(node)
 	hit, miss := 0, 0

--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -395,7 +395,10 @@ func (s *DiscoveryServer) shouldRespond(con *Connection, request *discovery.Disc
 	con.proxy.WatchedResources[request.TypeUrl].ResourceNames = request.ResourceNames
 	con.proxy.Unlock()
 
-	removed, added := sets.NewSet(previousResources...).Diff(sets.NewSet(request.ResourceNames...))
+	prev := sets.NewWith(previousResources...)
+	cur := sets.NewWith(request.ResourceNames...)
+	removed := prev.Difference(cur)
+	added := cur.Difference(prev)
 	// Envoy can send two DiscoveryRequests with same version and nonce
 	// when it detects a new resource. We should respond if they change.
 	if len(removed) == 0 && len(added) == 0 {

--- a/pilot/pkg/xds/delta.go
+++ b/pilot/pkg/xds/delta.go
@@ -274,8 +274,8 @@ func (s *DiscoveryServer) processDeltaRequest(req *discovery.DeltaDiscoveryReque
 		// we may end up overriding active cache entries with stale ones.
 		Start: con.proxy.LastPushTime,
 		Delta: model.ResourceDelta{
-			Subscribed:   req.ResourceNamesSubscribe,
-			Unsubscribed: req.ResourceNamesUnsubscribe,
+			Subscribed:   sets.NewWith(req.ResourceNamesSubscribe...),
+			Unsubscribed: sets.NewWith(req.ResourceNamesUnsubscribe...),
 		},
 	}
 	// SidecarScope for the proxy may has not been updated based on this pushContext.
@@ -398,13 +398,13 @@ func (s *DiscoveryServer) pushDeltaXds(con *Connection,
 	// new resources it needs, rather than the entire set of known resources.
 	// Note: we do not need to account for unsubscribed resources as these are handled by parent removal;
 	// See https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol#deleting-resources.
-	// This means if there are only removals, we will send an empty response.
+	// This means if there are only removals, we will not respond.
 	var logFiltered string
 	if !req.Delta.IsEmpty() {
 		logFiltered = " filtered:" + strconv.Itoa(len(w.ResourceNames)-len(req.Delta.Subscribed))
 		w = &model.WatchedResource{
 			TypeUrl:       w.TypeUrl,
-			ResourceNames: req.Delta.Subscribed,
+			ResourceNames: req.Delta.Subscribed.UnsortedList(),
 		}
 	}
 

--- a/pilot/pkg/xds/delta_test.go
+++ b/pilot/pkg/xds/delta_test.go
@@ -54,8 +54,11 @@ func TestDeltaAdsClusterUpdate(t *testing.T) {
 	sendEDSReqAndVerify([]string{"outbound|80||local.default.svc.cluster.local"}, nil, []string{"outbound|80||local.default.svc.cluster.local"})
 	// Only send the one that is requested
 	sendEDSReqAndVerify([]string{"outbound|81||local.default.svc.cluster.local"}, nil, []string{"outbound|81||local.default.svc.cluster.local"})
-	// TODO: should we just respond with nothing here? Probably...
-	sendEDSReqAndVerify(nil, []string{"outbound|81||local.default.svc.cluster.local"}, []string{"outbound|80||local.default.svc.cluster.local"})
+	ads.Request(&discovery.DeltaDiscoveryRequest{
+		ResponseNonce:            nonce,
+		ResourceNamesUnsubscribe: []string{"outbound|81||local.default.svc.cluster.local"},
+	})
+	ads.ExpectNoResponse()
 }
 
 func TestDeltaEDS(t *testing.T) {

--- a/pilot/pkg/xds/deltatest.go
+++ b/pilot/pkg/xds/deltatest.go
@@ -43,7 +43,7 @@ func (s *DiscoveryServer) compareDiff(
 	resp model.Resources,
 	deleted model.DeletedResources,
 	usedDelta bool,
-	generateOnly []string,
+	delta model.ResourceDelta,
 ) {
 	current := con.Watched(w.TypeUrl).LastResources
 	if current == nil {
@@ -109,7 +109,7 @@ func (s *DiscoveryServer) compareDiff(
 
 	// Optimization Potential
 	extraChanges := gotChanged.Difference(wantChanged).Difference(knownOptimizationGaps).SortedList()
-	if generateOnly != nil {
+	if len(delta.Subscribed) > 0 {
 		// Delta is configured to build only the request resources. Make sense we didn't build anything extra
 		if !wantChanged.SupersetOf(gotChanged) {
 			log.Errorf("%s: TEST for node:%s unexpected resources: %v %v", v3.GetShortType(w.TypeUrl), con.proxy.ID, details, wantChanged.Difference(gotChanged))

--- a/pilot/pkg/xds/discovery_test.go
+++ b/pilot/pkg/xds/discovery_test.go
@@ -465,7 +465,7 @@ func TestShouldRespond(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := NewFakeDiscoveryServer(t, FakeOptions{})
-			if response := s.Discovery.shouldRespond(tt.connection, tt.request); response != tt.response {
+			if response, _ := s.Discovery.shouldRespond(tt.connection, tt.request); response != tt.response {
 				t.Fatalf("Unexpected value for response, expected %v, got %v", tt.response, response)
 			}
 			if tt.name != "reconnect" && tt.response {

--- a/pilot/pkg/xds/eds.go
+++ b/pilot/pkg/xds/eds.go
@@ -582,7 +582,7 @@ func (eds *EdsGenerator) buildEndpoints(proxy *model.Proxy,
 	if !req.Full || (features.PartialFullPushes && onlyEndpointsChanged(req)) {
 		edsUpdatedServices = model.ConfigNamesOfKind(req.ConfigsUpdated, gvk.ServiceEntry)
 	}
-	resources := make(model.Resources, 0)
+	var resources model.Resources
 	empty := 0
 	cached := 0
 	regenerated := 0

--- a/pilot/pkg/xds/eds_test.go
+++ b/pilot/pkg/xds/eds_test.go
@@ -71,13 +71,6 @@ func TestIncrementalPush(t *testing.T) {
 			t.Fatal(err)
 		}
 	})
-	t.Run("Incremental Push", func(t *testing.T) {
-		ads.WaitClear()
-		s.Discovery.Push(&model.PushRequest{Full: false})
-		if err := ads.WaitSingle(time.Second*5, v3.EndpointType, v3.ClusterType); err != nil {
-			t.Fatal(err)
-		}
-	})
 	t.Run("Incremental Push with updated services", func(t *testing.T) {
 		ads.WaitClear()
 		s.Discovery.Push(&model.PushRequest{

--- a/pilot/pkg/xds/lds_test.go
+++ b/pilot/pkg/xds/lds_test.go
@@ -165,7 +165,7 @@ func TestLDSWithIngressGateway(t *testing.T) {
 		Metadata:        &model.NodeMetadata{Labels: labels},
 		IPAddresses:     []string{"99.1.1.1"},
 		Type:            model.Router,
-	}, nil, watchAll)
+	}, nil, []string{v3.ClusterType, v3.EndpointType, v3.ListenerType})
 
 	// Expect 2 listeners : 1 for 80, 1 for 443
 	// where 443 listener has 3 filter chains

--- a/pilot/pkg/xds/xdsgen.go
+++ b/pilot/pkg/xds/xdsgen.go
@@ -16,12 +16,14 @@ package xds
 
 import (
 	"encoding/json"
+	"strconv"
 	"strings"
 	"time"
 
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/util"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
@@ -97,6 +99,20 @@ func (s *DiscoveryServer) pushXds(con *Connection, w *model.WatchedResource, req
 
 	t0 := time.Now()
 
+	// If delta is set, client is requesting new resources or removing old ones. We should just generate the
+	// new resources it needs, rather than the entire set of known resources.
+	// Note: we do not need to account for unsubscribed resources as these are handled by parent removal;
+	// See https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol#deleting-resources.
+	// This means if there are only removals, we will send an empty response.
+	var logFiltered string
+	if !req.Delta.IsEmpty() && features.PartialFullPushes {
+		logFiltered = " filtered:" + strconv.Itoa(len(w.ResourceNames)-len(req.Delta.Subscribed))
+		w = &model.WatchedResource{
+			TypeUrl:       w.TypeUrl,
+			ResourceNames: req.Delta.Subscribed,
+		}
+	}
+
 	res, logdata, err := gen.Generate(con.proxy, w, req)
 	if err != nil || res == nil {
 		// If we have nothing to send, report that we got an ACK for this version.
@@ -126,6 +142,9 @@ func (s *DiscoveryServer) pushXds(con *Connection, w *model.WatchedResource, req
 	}
 	if len(logdata.AdditionalInfo) > 0 {
 		info = " " + logdata.AdditionalInfo
+	}
+	if len(logFiltered) > 0 {
+		info += logFiltered
 	}
 
 	if err := con.send(resp); err != nil {

--- a/pilot/pkg/xds/xdsgen.go
+++ b/pilot/pkg/xds/xdsgen.go
@@ -103,13 +103,13 @@ func (s *DiscoveryServer) pushXds(con *Connection, w *model.WatchedResource, req
 	// new resources it needs, rather than the entire set of known resources.
 	// Note: we do not need to account for unsubscribed resources as these are handled by parent removal;
 	// See https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol#deleting-resources.
-	// This means if there are only removals, we will send an empty response.
+	// This means if there are only removals, we will not respond.
 	var logFiltered string
 	if !req.Delta.IsEmpty() && features.PartialFullPushes {
 		logFiltered = " filtered:" + strconv.Itoa(len(w.ResourceNames)-len(req.Delta.Subscribed))
 		w = &model.WatchedResource{
 			TypeUrl:       w.TypeUrl,
-			ResourceNames: req.Delta.Subscribed,
+			ResourceNames: req.Delta.Subscribed.UnsortedList(),
 		}
 	}
 

--- a/pkg/util/sets/string.go
+++ b/pkg/util/sets/string.go
@@ -183,3 +183,18 @@ func (s Set) Len() int {
 func (s Set) IsEmpty() bool {
 	return len(s) == 0
 }
+
+// Diff takes a pair of Sets, and returns the elements that occur only on the left and right set.
+func (s Set) Diff(other Set) (left []string, right []string) {
+	for k := range s {
+		if _, f := other[k]; !f {
+			left = append(left, k)
+		}
+	}
+	for k := range other {
+		if _, f := s[k]; !f {
+			right = append(right, k)
+		}
+	}
+	return
+}

--- a/security/pkg/nodeagent/sds/sdsservice_test.go
+++ b/security/pkg/nodeagent/sds/sdsservice_test.go
@@ -144,7 +144,7 @@ func TestSDS(t *testing.T) {
 		s.Verify(c.RequestResponseAck(t, &discovery.DiscoveryRequest{
 			ResourceNames: []string{testResourceName, rootResourceName},
 			ResponseNonce: resp.Nonce,
-		}), expectCert, expectRoot)
+		}), expectRoot)
 		c.ExpectNoResponse(t)
 	})
 	t.Run("multiplexed root first", func(t *testing.T) {


### PR DESCRIPTION
Currently:
* SotW always does a full push on request
* Delta does a partial push only on subscribe, but not on unsubscribe.
* SotW will never skip a push, and will instead send a push with 0
  resources. Delta will skip a push only for EDS

New behavior:
* Both Delta and SotW will do partial pushes for subscribes.
* Both Delta and SotW, If there are only unsubcribes, we will not send a response at all

This optimizes request cases. For example, say we have 100 listeners and
remove 10. 45s later, those listeners will drain. This results in an XDS
requests with 99 routes, 98, 97 ... 90 routes - about 1000 routes
generated in total. With this optimization, we will send 0.

On the other side, say we add 1 listener. Before, we would push RDS
(100), and then immediately get a RDS request and send all 101 again.
With this change, we would send the same 100 in the initial RDS push,
but on the request we would just send the new 1 requested.

note: this builds on https://github.com/istio/istio/pull/37974

TODO:
* Add more tests
* Make sure all types are consistent with sending no response vs empty response. And get response from Envoy which is best
* Fix ADSC to support this
* Flag protect new behavior