### PR TITLE
Generate grpc bootstrap only when DISABLE_ENVOY=true and GRPC_XDS_BOO…

### DIFF
--- a/pilot/cmd/pilot-agent/options/options.go
+++ b/pilot/cmd/pilot-agent/options/options.go
@@ -113,7 +113,7 @@ var (
 
 	// Defined by https://github.com/grpc/proposal/blob/c5722a35e71f83f07535c6c7c890cf0c58ec90c0/A27-xds-global-load-balancing.md#xdsclient-and-bootstrap-file
 	grpcBootstrapEnv = env.RegisterStringVar("GRPC_XDS_BOOTSTRAP", filepath.Join(constants.ConfigPathDir, "grpc-bootstrap.json"),
-		"Path where gRPC expects to read a bootstrap file. Agent will generate one if set.").Get()
+		"Path where gRPC expects to read a bootstrap file. Agent will generate one if set and DISABLE_ENVOY = true.").Get()
 
 	disableEnvoyEnv = env.RegisterBoolVar("DISABLE_ENVOY", false,
 		"Disables all Envoy agent features.").Get()

--- a/pkg/istio-agent/agent.go
+++ b/pkg/istio-agent/agent.go
@@ -425,7 +425,7 @@ func (a *Agent) Run(ctx context.Context) (func(), error) {
 		}
 	}
 
-	if a.cfg.GRPCBootstrapPath != "" {
+	if a.EnvoyDisabled() && a.cfg.GRPCBootstrapPath != "" {
 		if err := a.generateGRPCBootstrap(); err != nil {
 			return nil, fmt.Errorf("failed generating gRPC XDS bootstrap: %v", err)
 		}


### PR DESCRIPTION
…TSTRAP set

**Please provide a description of this PR:**

Without this, it always generate grpc bootstrap for sidecar.

```
k exec -ti sleep-557747455f-n4lf8 -c istio-proxy -- ls etc/istio/proxy/
SDS  XDS  envoy-rev0.json  grpc-bootstrap.json

```


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
