### PR TITLE
fix aws platform detection

### DIFF
--- a/pkg/bootstrap/platform/aws.go
+++ b/pkg/bootstrap/platform/aws.go
@@ -15,6 +15,7 @@
 package platform
 
 import (
+	"strings"
 	"time"
 
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -40,8 +41,8 @@ var (
 
 // IsAWS returns whether or not the platform for bootstrapping is Amazon Web Services.
 func IsAWS(ipv6 bool) bool {
-	_, err := getAWSInfo("instance-id", ipv6)
-	return err == nil
+	info, err := getAWSInfo("iam/info", ipv6)
+	return err == nil && strings.Contains(info, "arn:aws:iam")
 }
 
 type awsEnv struct {

--- a/pkg/bootstrap/platform/aws_test.go
+++ b/pkg/bootstrap/platform/aws_test.go
@@ -96,6 +96,7 @@ func zoneHandler(writer http.ResponseWriter, _ *http.Request) {
 
 func iamInfoHandler(writer http.ResponseWriter, _ *http.Request) {
 	writer.WriteHeader(http.StatusOK)
+	// nolint: lll
 	writer.Write([]byte("{\n\"Code\" : \"Success\",\n\"LastUpdated\" : \"2022-03-18T05:04:31Z\",\n\"InstanceProfileArn\" : \"arn:aws:iam::614624372165:instance-profile/sam-processing0000120190916053337315200000004\",\n\"InstanceProfileId\" : \"AIPAY6GTXUXC3LLJY7OG7\"\n\t  }"))
 }
 

--- a/pkg/bootstrap/platform/aws_test.go
+++ b/pkg/bootstrap/platform/aws_test.go
@@ -63,8 +63,8 @@ func TestIsAWS(t *testing.T) {
 		handlers map[string]handlerFunc
 		want     bool
 	}{
-		{"not aws", map[string]handlerFunc{"/instance-id": errorHandler}, false},
-		{"aws", map[string]handlerFunc{"/instance-id": instanceHandler}, true},
+		{"not aws", map[string]handlerFunc{"/iam/info": errorHandler}, false},
+		{"aws", map[string]handlerFunc{"/iam/info": iamInfoHandler}, true},
 	}
 
 	for _, v := range cases {
@@ -74,7 +74,7 @@ func TestIsAWS(t *testing.T) {
 			awsMetadataIPv4URL = url.String()
 			aws := IsAWS(false)
 			if !reflect.DeepEqual(aws, v.want) {
-				t.Errorf("unexpected locality. want :%v, got :%v", v.want, aws)
+				t.Errorf("unexpected iam info. want :%v, got :%v", v.want, aws)
 			}
 		})
 	}
@@ -94,9 +94,9 @@ func zoneHandler(writer http.ResponseWriter, _ *http.Request) {
 	writer.Write([]byte("us-west-2b"))
 }
 
-func instanceHandler(writer http.ResponseWriter, _ *http.Request) {
+func iamInfoHandler(writer http.ResponseWriter, _ *http.Request) {
 	writer.WriteHeader(http.StatusOK)
-	writer.Write([]byte("i-0a26ab14a846dbf6f"))
+	writer.Write([]byte("{\n\"Code\" : \"Success\",\n\"LastUpdated\" : \"2022-03-18T05:04:31Z\",\n\"InstanceProfileArn\" : \"arn:aws:iam::614624372165:instance-profile/sam-processing0000120190916053337315200000004\",\n\"InstanceProfileId\" : \"AIPAY6GTXUXC3LLJY7OG7\"\n\t  }"))
 }
 
 func setupHTTPServer(handlers map[string]handlerFunc) (*httptest.Server, *url.URL) {


### PR DESCRIPTION
Looks like in some other cloud provider the same instance-id url is used. This PR actually verifies "aws" exists in arnInfo from "/iam/info" endpoint.

Fixes https://github.com/istio/istio/issues/37995

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure