### PR TITLE
operator: handle tpath+protobuf consistently

### DIFF
--- a/operator/pkg/apis/istio/v1alpha1/validation/validation.go
+++ b/operator/pkg/apis/istio/v1alpha1/validation/validation.go
@@ -138,15 +138,7 @@ func checkDeprecatedSettings(iop *v1alpha1.IstioOperatorSpec) (util.Errors, []st
 	}
 
 	for _, d := range warningSettings {
-		// Grafana is a special case where its just an interface{}. A better fix would probably be defining
-		// the types, but since this is deprecated this is easier
-		var v interface{}
-		var f bool
-		if s := strings.SplitN(d.old, ".", 2); s[0] == "Values" {
-			v, f, _ = tpath.GetFromStructPath(valuesv1alpha1.AsMap(iop.GetValues()), s[1])
-		} else {
-			v, f, _ = tpath.GetFromStructPath(iop, d.old)
-		}
+		v, f, _ := tpath.GetFromStructPath(iop, d.old)
 		if f {
 			switch t := v.(type) {
 			// need to do conversion for bool value defined in IstioOperator component spec.
@@ -159,13 +151,7 @@ func checkDeprecatedSettings(iop *v1alpha1.IstioOperatorSpec) (util.Errors, []st
 		}
 	}
 	for _, d := range failHardSettings {
-		var v interface{}
-		var f bool
-		if s := strings.SplitN(d.old, ".", 2); s[0] == "Values" {
-			v, f, _ = tpath.GetFromStructPath(valuesv1alpha1.AsMap(iop.GetValues()), s[1])
-		} else {
-			v, f, _ = tpath.GetFromStructPath(iop, d.old)
-		}
+		v, f, _ := tpath.GetFromStructPath(iop, d.old)
 		if f {
 			switch t := v.(type) {
 			// need to do conversion for bool value defined in IstioOperator component spec.

--- a/operator/pkg/tpath/struct.go
+++ b/operator/pkg/tpath/struct.go
@@ -23,6 +23,7 @@ import (
 	"strconv"
 
 	"github.com/gogo/protobuf/types"
+
 	"istio.io/istio/operator/pkg/apis/istio/v1alpha1"
 	"istio.io/istio/operator/pkg/util"
 )

--- a/operator/pkg/tpath/struct.go
+++ b/operator/pkg/tpath/struct.go
@@ -22,6 +22,8 @@ import (
 	"reflect"
 	"strconv"
 
+	"github.com/gogo/protobuf/types"
+	"istio.io/istio/operator/pkg/apis/istio/v1alpha1"
 	"istio.io/istio/operator/pkg/util"
 )
 
@@ -37,6 +39,14 @@ func getFromStructPath(node interface{}, path util.Path) (interface{}, bool, err
 	if len(path) == 0 {
 		scope.Debugf("getFromStructPath returning node(%T)%v", node, node)
 		return node, !util.IsValueNil(node), nil
+	}
+	// For protobuf types, switch them out with standard types; otherwise we will traverse protobuf internals rather
+	// than the standard representation
+	if v, ok := node.(*types.Struct); ok {
+		node = v1alpha1.AsMap(v)
+	}
+	if v, ok := node.(*types.Value); ok {
+		node = v1alpha1.AsInterface(v)
 	}
 	val := reflect.ValueOf(node)
 	kind := reflect.TypeOf(node).Kind()


### PR DESCRIPTION
Currently, we have some higher level hacks to make this work. This drops the hacks to the lower level in tpath so we don' need special logic elsewhere