### PR TITLE
Optimize config apply and delete

### DIFF
--- a/pkg/test/framework/components/echo/deployment/builder.go
+++ b/pkg/test/framework/components/echo/deployment/builder.go
@@ -322,7 +322,7 @@ func (b builder) deployServices() error {
 		svcYaml := svcYaml
 		ns := strings.Split(svcNs, ".")[1]
 		errG.Go(func() error {
-			return b.ctx.ConfigKube().YAML(svcYaml).Apply(ns, resource.NoCleanup)
+			return b.ctx.ConfigKube().YAML(ns, svcYaml).Apply(resource.NoCleanup)
 		})
 	}
 	return errG.Wait().ErrorOrNil()

--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -493,7 +493,7 @@ func newDeployment(ctx resource.Context, cfg echo.Config) (*deployment, error) {
 	}
 
 	// Apply the deployment to the configured cluster.
-	if err = ctx.ConfigKube(cfg.Cluster).YAML(deploymentYAML).Apply(cfg.Namespace.Name(), resource.NoCleanup); err != nil {
+	if err = ctx.ConfigKube(cfg.Cluster).YAML(cfg.Namespace.Name(), deploymentYAML).Apply(resource.NoCleanup); err != nil {
 		return nil, fmt.Errorf("failed deploying echo %s to cluster %s: %v",
 			cfg.ClusterLocalFQDN(), cfg.Cluster.Name(), err)
 	}
@@ -543,7 +543,7 @@ func (d *deployment) WorkloadReady(w *workload) {
 
 	// Deploy the workload entry to the primary cluster. We will read WorkloadEntry across clusters.
 	wle := d.workloadEntryYAML(w)
-	if err := d.ctx.ConfigKube(d.cfg.Cluster.Primary()).YAML(wle).Apply(d.cfg.Namespace.Name(), resource.NoCleanup); err != nil {
+	if err := d.ctx.ConfigKube(d.cfg.Cluster.Primary()).YAML(d.cfg.Namespace.Name(), wle).Apply(resource.NoCleanup); err != nil {
 		log.Warnf("failed deploying echo WLE for %s/%s to primary cluster: %v",
 			d.cfg.Namespace.Name(),
 			d.cfg.Service,
@@ -557,7 +557,7 @@ func (d *deployment) WorkloadNotReady(w *workload) {
 	}
 
 	wle := d.workloadEntryYAML(w)
-	if err := d.ctx.ConfigKube(d.cfg.Cluster.Primary()).YAML(wle).Delete(d.cfg.Namespace.Name()); err != nil {
+	if err := d.ctx.ConfigKube(d.cfg.Cluster.Primary()).YAML(d.cfg.Namespace.Name(), wle).Delete(); err != nil {
 		log.Warnf("failed deleting echo WLE for %s/%s from primary cluster: %v",
 			d.cfg.Namespace.Name(),
 			d.cfg.Service,
@@ -737,7 +737,7 @@ spec:
 
 	// Push the WorkloadGroup for auto-registration
 	if cfg.AutoRegisterVM {
-		if err := ctx.ConfigKube(cfg.Cluster).YAML(wg).Apply(cfg.Namespace.Name(), resource.NoCleanup); err != nil {
+		if err := ctx.ConfigKube(cfg.Cluster).YAML(cfg.Namespace.Name(), wg).Apply(resource.NoCleanup); err != nil {
 			return err
 		}
 	}

--- a/pkg/test/framework/components/istio/eastwest.go
+++ b/pkg/test/framework/components/istio/eastwest.go
@@ -143,5 +143,5 @@ func (i *operatorComponent) applyIstiodGateway(cluster cluster.Cluster, revision
 	if err != nil {
 		return fmt.Errorf("failed running template %s: %v", exposeIstiodGatewayRev, err)
 	}
-	return i.ctx.ConfigKube(cluster).YAML(out).Apply(i.settings.SystemNamespace)
+	return i.ctx.ConfigKube(cluster).YAML(i.settings.SystemNamespace, out).Apply()
 }

--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -201,7 +201,7 @@ func (i *operatorComponent) Close() error {
 func (i *operatorComponent) cleanupCluster(c cluster.Cluster, errG *multierror.Group) {
 	scopes.Framework.Infof("clean up cluster %s", c.Name())
 	errG.Go(func() (err error) {
-		if e := i.ctx.ConfigKube(c).YAML(removeCRDsSlice(i.installManifest[c.Name()])).Delete(""); e != nil {
+		if e := i.ctx.ConfigKube(c).YAML("", removeCRDsSlice(i.installManifest[c.Name()])).Delete(); e != nil {
 			err = multierror.Append(err, e)
 		}
 		// Cleanup all secrets and configmaps - these are dynamically created by tests and/or istiod so they are not captured above
@@ -829,7 +829,7 @@ func (i *operatorComponent) configureDirectAPIServiceAccessForCluster(ctx resour
 	if err != nil {
 		return fmt.Errorf("failed creating remote secret for cluster %s: %v", c.Name(), err)
 	}
-	if err := ctx.ConfigKube(clusters...).YAML(secret).Apply(cfg.SystemNamespace, resource.NoCleanup); err != nil {
+	if err := ctx.ConfigKube(clusters...).YAML(cfg.SystemNamespace, secret).Apply(resource.NoCleanup); err != nil {
 		return fmt.Errorf("failed applying remote secret to clusters: %v", err)
 	}
 	return nil

--- a/pkg/test/framework/components/istio/util.go
+++ b/pkg/test/framework/components/istio/util.go
@@ -63,7 +63,7 @@ spec:
 func waitForValidationWebhook(ctx resource.Context, cluster cluster.Cluster, cfg Config) error {
 	dummyValidationVirtualService := fmt.Sprintf(dummyValidationVirtualServiceTemplate, cfg.SystemNamespace)
 	defer func() {
-		e := ctx.ConfigKube(cluster).YAML(dummyValidationVirtualService).Delete("")
+		e := ctx.ConfigKube(cluster).YAML("", dummyValidationVirtualService).Delete()
 		if e != nil {
 			scopes.Framework.Warnf("error deleting dummy virtual service for waiting the validation webhook: %v", e)
 		}
@@ -71,7 +71,7 @@ func waitForValidationWebhook(ctx resource.Context, cluster cluster.Cluster, cfg
 
 	scopes.Framework.Info("Creating dummy virtual service to check for validation webhook readiness")
 	return retry.UntilSuccess(func() error {
-		err := ctx.ConfigKube(cluster).YAML(dummyValidationVirtualService).Apply("")
+		err := ctx.ConfigKube(cluster).YAML("", dummyValidationVirtualService).Apply()
 		if err == nil {
 			return nil
 		}

--- a/pkg/test/framework/components/opentelemetry/kube.go
+++ b/pkg/test/framework/components/opentelemetry/kube.go
@@ -128,19 +128,19 @@ func install(ctx resource.Context, ns string) error {
 	if err != nil {
 		return err
 	}
-	return ctx.ConfigKube().YAML(y).Apply(ns)
+	return ctx.ConfigKube().YAML(ns, y).Apply()
 }
 
 func installServiceEntry(ctx resource.Context, ns, ingressAddr string) error {
 	// Setup remote access to zipkin in cluster
 	yaml := strings.ReplaceAll(remoteOtelEntry, "{INGRESS_DOMAIN}", ingressAddr)
-	if err := ctx.ConfigIstio().YAML(yaml).Apply(ns); err != nil {
+	if err := ctx.ConfigIstio().YAML(ns, yaml).Apply(); err != nil {
 		return err
 	}
 	// For all other clusters, add a service entry so that can access
 	// zipkin in cluster installed.
 	yaml = strings.ReplaceAll(extServiceEntry, "{INGRESS_DOMAIN}", ingressAddr)
-	if err := ctx.ConfigIstio().YAML(yaml).Apply(ns); err != nil {
+	if err := ctx.ConfigIstio().YAML(ns, yaml).Apply(); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/test/framework/components/prometheus/kube.go
+++ b/pkg/test/framework/components/prometheus/kube.go
@@ -73,11 +73,11 @@ func installPrometheus(ctx resource.Context, ns string) error {
 	if err != nil {
 		return err
 	}
-	if err := ctx.ConfigKube().YAML(yaml).Apply(ns, resource.NoCleanup); err != nil {
+	if err := ctx.ConfigKube().YAML(ns, yaml).Apply(resource.NoCleanup); err != nil {
 		return err
 	}
 	ctx.ConditionalCleanup(func() {
-		_ = ctx.ConfigKube().YAML(yaml).Delete(ns)
+		_ = ctx.ConfigKube().YAML(ns, yaml).Delete()
 	})
 	return nil
 }

--- a/pkg/test/framework/components/zipkin/kube.go
+++ b/pkg/test/framework/components/zipkin/kube.go
@@ -161,18 +161,18 @@ func installZipkin(ctx resource.Context, ns string) error {
 	if err != nil {
 		return err
 	}
-	return ctx.ConfigKube().YAML(yaml).Apply(ns)
+	return ctx.ConfigKube().YAML(ns, yaml).Apply()
 }
 
 func installServiceEntry(ctx resource.Context, ns, ingressAddr string) error {
 	// Setup remote access to zipkin in cluster
 	yaml := strings.ReplaceAll(remoteZipkinEntry, "{INGRESS_DOMAIN}", ingressAddr)
-	err := ctx.ConfigIstio().YAML(yaml).Apply(ns)
+	err := ctx.ConfigIstio().YAML(ns, yaml).Apply()
 	if err != nil {
 		return err
 	}
 	yaml = strings.ReplaceAll(extServiceEntry, "{INGRESS_DOMAIN}", ingressAddr)
-	err = ctx.ConfigIstio().YAML(yaml).Apply(ns)
+	err = ctx.ConfigIstio().YAML(ns, yaml).Apply()
 	if err != nil {
 		return err
 	}

--- a/pkg/test/framework/config.go
+++ b/pkg/test/framework/config.go
@@ -15,11 +15,13 @@
 package framework
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
 	"go.uber.org/atomic"
+	"golang.org/x/sync/errgroup"
 
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/framework/components/cluster"
@@ -52,43 +54,20 @@ func newConfigManager(ctx resource.Context, clusters cluster.Clusters) resource.
 // Note: go tests are distinct binaries per test suite, so this is the suite level number of calls
 var GlobalYAMLWrites = atomic.NewUint64(0)
 
-func (c *configManager) YAML(yamlText ...string) resource.Config {
-	return &yamlConfig{
-		configManager: c,
-		yamlText:      yamlText,
-	}
+func (c *configManager) YAML(ns string, yamlText ...string) resource.Config {
+	return newConfig(c).YAML(ns, yamlText...)
 }
 
-func (c *configManager) Eval(args interface{}, yamlTemplates ...string) resource.Config {
-	return c.YAML(tmpl.MustEvaluateAll(args, yamlTemplates...)...)
+func (c *configManager) Eval(ns string, args interface{}, yamlTemplates ...string) resource.Config {
+	return newConfig(c).Eval(ns, args, yamlTemplates...)
 }
 
-func (c *configManager) File(filePaths ...string) resource.Config {
-	yamlText, err := file.AsStringArray(filePaths...)
-	if err != nil {
-		panic(err)
-	}
-
-	return &yamlConfig{
-		configManager: c,
-		filePaths:     filePaths,
-		yamlText:      yamlText,
-	}
+func (c *configManager) File(ns string, filePaths ...string) resource.Config {
+	return newConfig(c).File(ns, filePaths...)
 }
 
-func (c *configManager) EvalFile(args interface{}, filePaths ...string) resource.Config {
-	yamlTemplates, err := file.AsStringArray(filePaths...)
-	if err != nil {
-		panic(err)
-	}
-
-	yamlText := tmpl.MustEvaluateAll(args, yamlTemplates...)
-
-	return &yamlConfig{
-		configManager: c,
-		filePaths:     filePaths,
-		yamlText:      yamlText,
-	}
+func (c *configManager) EvalFile(ns string, args interface{}, filePaths ...string) resource.Config {
+	return newConfig(c).EvalFile(ns, args, filePaths...)
 }
 
 func (c *configManager) applyYAML(cleanup bool, ns string, yamlText ...string) error {
@@ -103,22 +82,26 @@ func (c *configManager) applyYAML(cleanup bool, ns string, yamlText ...string) e
 		return err
 	}
 
+	g, _ := errgroup.WithContext(context.TODO())
 	for _, cl := range c.clusters {
 		cl := cl
-		scopes.Framework.Debugf("Applying to %s to namespace %v: %s", cl.StableName(), ns, strings.Join(yamlFiles, ", "))
-		if err := cl.ApplyYAMLFiles(ns, yamlFiles...); err != nil {
-			return fmt.Errorf("failed applying YAML to cluster %s: %v", cl.Name(), err)
-		}
-		if cleanup {
-			c.ctx.Cleanup(func() {
-				scopes.Framework.Debugf("Deleting from %s: %s", cl.StableName(), strings.Join(yamlFiles, ", "))
-				if err := cl.DeleteYAMLFiles(ns, yamlFiles...); err != nil {
-					scopes.Framework.Errorf("failed deleting YAML from cluster %s: %v", cl.Name(), err)
-				}
-			})
-		}
+		g.Go(func() error {
+			scopes.Framework.Debugf("Applying to %s to namespace %v: %s", cl.StableName(), ns, strings.Join(yamlFiles, ", "))
+			if err := cl.ApplyYAMLFiles(ns, yamlFiles...); err != nil {
+				return fmt.Errorf("failed applying YAML files %v to ns %s in cluster %s: %v", yamlFiles, ns, cl.Name(), err)
+			}
+			if cleanup {
+				c.ctx.Cleanup(func() {
+					scopes.Framework.Debugf("Deleting from %s: %s", cl.StableName(), strings.Join(yamlFiles, ", "))
+					if err := cl.DeleteYAMLFiles(ns, yamlFiles...); err != nil {
+						scopes.Framework.Errorf("failed deleting YAML files %v from ns %s in cluster %s: %v", yamlFiles, ns, cl.Name(), err)
+					}
+				})
+			}
+			return nil
+		})
 	}
-	return nil
+	return g.Wait()
 }
 
 func (c *configManager) deleteYAML(ns string, yamlText ...string) error {
@@ -132,12 +115,17 @@ func (c *configManager) deleteYAML(ns string, yamlText ...string) error {
 		return err
 	}
 
+	g, _ := errgroup.WithContext(context.TODO())
 	for _, c := range c.clusters {
-		if err := c.DeleteYAMLFiles(ns, yamlFiles...); err != nil {
-			return fmt.Errorf("failed deleting YAML from cluster %s: %v", c.Name(), err)
-		}
+		c := c
+		g.Go(func() error {
+			if err := c.DeleteYAMLFiles(ns, yamlFiles...); err != nil {
+				return fmt.Errorf("failed deleting YAML from cluster %s: %v", c.Name(), err)
+			}
+			return nil
+		})
 	}
-	return nil
+	return g.Wait()
 }
 
 func (c *configManager) WaitForConfig(ctx resource.Context, ns string, yamlText ...string) error {
@@ -182,60 +170,105 @@ func (c *configManager) WithFilePrefix(prefix string) resource.ConfigManager {
 	}
 }
 
-var _ resource.Config = &yamlConfig{}
+var _ resource.Config = &configImpl{}
 
-type yamlConfig struct {
-	*configManager
-	filePaths []string
-	yamlText  []string
-}
-
-func (c *yamlConfig) contentForError() []string {
-	// Use filename in the log if available.
-	if len(c.filePaths) > 0 {
-		return c.filePaths
+func newConfig(m *configManager) *configImpl {
+	return &configImpl{
+		configManager: m,
+		yamlText:      make(map[string][]string),
 	}
-	return c.yamlText
 }
 
-func (c *yamlConfig) Apply(ns string, opts ...resource.ConfigOption) error {
+type configImpl struct {
+	*configManager
+	yamlText map[string][]string
+}
+
+func (c *configImpl) YAML(ns string, yamlText ...string) resource.Config {
+	c.yamlText[ns] = append(c.yamlText[ns], yamlText...)
+	return c
+}
+
+func (c *configImpl) File(ns string, paths ...string) resource.Config {
+	yamlText, err := file.AsStringArray(paths...)
+	if err != nil {
+		panic(err)
+	}
+
+	return c.YAML(ns, yamlText...)
+}
+
+func (c *configImpl) Eval(ns string, args interface{}, templates ...string) resource.Config {
+	return c.YAML(ns, tmpl.MustEvaluateAll(args, templates...)...)
+}
+
+func (c *configImpl) EvalFile(ns string, args interface{}, paths ...string) resource.Config {
+	templates, err := file.AsStringArray(paths...)
+	if err != nil {
+		panic(err)
+	}
+
+	return c.Eval(ns, args, templates...)
+}
+
+func (c *configImpl) Apply(opts ...resource.ConfigOption) error {
 	// Apply the options.
 	options := resource.ConfigOptions{}
 	for _, o := range opts {
 		o(&options)
 	}
 
-	if err := c.applyYAML(!options.NoCleanup, ns, c.yamlText...); err != nil {
-		return fmt.Errorf("failed applying YAML %v: %v", c.contentForError(), err)
+	// Apply for each namespace concurrently.
+	g, _ := errgroup.WithContext(context.TODO())
+	for ns, y := range c.yamlText {
+		ns, y := ns, y
+		g.Go(func() error {
+			return c.applyYAML(!options.NoCleanup, ns, y...)
+		})
+	}
+
+	// Wait for all each apply to complete.
+	if err := g.Wait(); err != nil {
+		return err
 	}
 
 	if options.Wait {
-		if err := c.WaitForConfig(c.ctx, ns, c.yamlText...); err != nil {
-			// TODO(https://github.com/istio/istio/issues/37148) fail hard in this case
-			scopes.Framework.Warnf("(Ignored until https://github.com/istio/istio/issues/37148 is fixed) "+
-				"failed waiting for YAML %v: %v", c.contentForError(), err)
+		// TODO: wait for each namespace concurrently once WaitForConfig supports concurrency.
+		for ns, y := range c.yamlText {
+			if err := c.WaitForConfig(c.ctx, ns, y...); err != nil {
+				// TODO(https://github.com/istio/istio/issues/37148) fail hard in this case
+				scopes.Framework.Warnf("(Ignored until https://github.com/istio/istio/issues/37148 is fixed) "+
+					"failed waiting for YAML %v: %v", y, err)
+			}
 		}
 	}
 	return nil
 }
 
-func (c *yamlConfig) ApplyOrFail(t test.Failer, ns string, opts ...resource.ConfigOption) {
+func (c *configImpl) ApplyOrFail(t test.Failer, opts ...resource.ConfigOption) {
 	t.Helper()
-	if err := c.Apply(ns, opts...); err != nil {
+	if err := c.Apply(opts...); err != nil {
 		t.Fatal(err)
 	}
 }
 
-func (c *yamlConfig) Delete(ns string) error {
-	if err := c.deleteYAML(ns, c.yamlText...); err != nil {
-		return fmt.Errorf("failed deleting YAML %v: %v", c.contentForError(), err)
+func (c *configImpl) Delete() error {
+	// Delete for each namespace concurrently.
+	g, _ := errgroup.WithContext(context.TODO())
+	for ns, y := range c.yamlText {
+		ns, y := ns, y
+		g.Go(func() error {
+			return c.deleteYAML(ns, y...)
+		})
 	}
-	return nil
+
+	// Wait for all each delete to complete.
+	return g.Wait()
 }
 
-func (c *yamlConfig) DeleteOrFail(t test.Failer, ns string) {
+func (c *configImpl) DeleteOrFail(t test.Failer) {
 	t.Helper()
-	if err := c.Delete(ns); err != nil {
+	if err := c.Delete(); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/pkg/test/framework/scope.go
+++ b/pkg/test/framework/scope.go
@@ -69,7 +69,7 @@ func (s *scope) add(r resource.Resource, id *resourceID) {
 	s.resources = append(s.resources, r)
 
 	if c, ok := r.(io.Closer); ok {
-		s.addCloser(c)
+		s.closers = append(s.closers, c)
 	}
 }
 
@@ -119,6 +119,8 @@ func (s *scope) get(ref interface{}) error {
 }
 
 func (s *scope) addCloser(c io.Closer) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.closers = append(s.closers, c)
 }
 

--- a/tests/integration/helm/util.go
+++ b/tests/integration/helm/util.go
@@ -213,7 +213,7 @@ func SetRevisionTag(ctx framework.TestContext, h *helm.Helm, fileSuffix, revisio
 		ctx.Fatalf("failed to install istio %s chart", DiscoveryChart)
 	}
 
-	err = ctx.ConfigIstio().YAML(template).Apply(IstioNamespace)
+	err = ctx.ConfigIstio().YAML(IstioNamespace, template).Apply()
 	if err != nil {
 		ctx.Fatalf("failed to apply templated revision tags yaml: %v", err)
 	}

--- a/tests/integration/pilot/analysis/analysis_test.go
+++ b/tests/integration/pilot/analysis/analysis_test.go
@@ -53,7 +53,7 @@ func TestAnalysisWritesStatus(t *testing.T) {
 				Revision: "",
 				Labels:   nil,
 			})
-			t.ConfigIstio().YAML(`
+			t.ConfigIstio().YAML(ns.Name(), `
 apiVersion: v1
 kind: Service
 metadata:
@@ -67,9 +67,9 @@ spec:
     port: 15014
     protocol: TCP
     targetPort: 15014
-`).ApplyOrFail(t, ns.Name())
+`).ApplyOrFail(t)
 			// Apply bad config (referencing invalid host)
-			t.ConfigIstio().YAML(`
+			t.ConfigIstio().YAML(ns.Name(), `
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
@@ -82,13 +82,13 @@ spec:
   - route:
     - destination: 
         host: reviews
-`).ApplyOrFail(t, ns.Name())
+`).ApplyOrFail(t)
 			// Status should report error
 			retry.UntilSuccessOrFail(t, func() error {
 				return expectVirtualServiceStatus(t, ns, true)
 			}, retry.Timeout(time.Minute*5))
 			// Apply config to make this not invalid
-			t.ConfigIstio().YAML(`
+			t.ConfigIstio().YAML(ns.Name(), `
 apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
@@ -103,7 +103,7 @@ spec:
       protocol: HTTP
     hosts:
     - "*"
-`).ApplyOrFail(t, ns.Name())
+`).ApplyOrFail(t)
 			// Status should no longer report error
 			retry.UntilSuccessOrFail(t, func() error {
 				return expectVirtualServiceStatus(t, ns, false)
@@ -123,14 +123,14 @@ func TestWorkloadEntryUpdatesStatus(t *testing.T) {
 			})
 
 			// create WorkloadEntry
-			t.ConfigIstio().YAML(`
+			t.ConfigIstio().YAML(ns.Name(), `
 apiVersion: networking.istio.io/v1alpha3
 kind: WorkloadEntry
 metadata:
   name: vm-1
 spec:
   address: 127.0.0.1
-`).ApplyOrFail(t, ns.Name())
+`).ApplyOrFail(t)
 
 			retry.UntilSuccessOrFail(t, func() error {
 				// we should expect an empty array not nil

--- a/tests/integration/pilot/cni/cniversionskew_test.go
+++ b/tests/integration/pilot/cni/cniversionskew_test.go
@@ -114,5 +114,5 @@ func installCNIOrFail(t framework.TestContext, ver string) {
 	if err != nil {
 		t.Fatalf("Failed to read CNI manifest %v", err)
 	}
-	t.ConfigIstio().YAML(config).ApplyOrFail(t, "")
+	t.ConfigIstio().YAML("", config).ApplyOrFail(t)
 }

--- a/tests/integration/pilot/common/apps.go
+++ b/tests/integration/pilot/common/apps.go
@@ -264,7 +264,7 @@ func SetupApps(t resource.Context, i istio.Instance, apps *EchoDeployments) erro
 		apps.DeltaXDS = match.ServiceName(model.NamespacedName{Name: DeltaSvc, Namespace: apps.Namespace.Name()}).GetMatches(echos)
 	}
 
-	if err := t.ConfigIstio().YAML(`
+	if err := t.ConfigIstio().YAML(apps.Namespace.Name(), `
 apiVersion: networking.istio.io/v1alpha3
 kind: Sidecar
 metadata:
@@ -274,7 +274,7 @@ spec:
   - hosts:
     - "./*"
     - "istio-system/*"
-`).Apply(apps.Namespace.Name(), resource.NoCleanup); err != nil {
+`).Apply(resource.NoCleanup); err != nil {
 		return err
 	}
 
@@ -307,7 +307,7 @@ spec:
 	if err != nil {
 		return err
 	}
-	if err := t.ConfigIstio().YAML(se).Apply(apps.Namespace.Name(), resource.NoCleanup); err != nil {
+	if err := t.ConfigIstio().YAML(apps.Namespace.Name(), se).Apply(resource.NoCleanup); err != nil {
 		return err
 	}
 	return nil

--- a/tests/integration/pilot/common/traffic.go
+++ b/tests/integration/pilot/common/traffic.go
@@ -138,7 +138,7 @@ func (c TrafficTestCase) RunForApps(t framework.TestContext, apps echo.Instances
 				}
 				cfg := yml.MustApplyNamespace(t, tmpl.MustEvaluate(c.config, tmplData), namespace)
 				// we only apply to config clusters
-				return t.ConfigIstio().YAML(cfg).Apply("")
+				return t.ConfigIstio().YAML("", cfg).Apply()
 			}).
 			WithDefaultFilters().
 			FromMatch(match.And(c.sourceMatchers...)).
@@ -210,7 +210,7 @@ func (c TrafficTestCase) Run(t framework.TestContext, namespace string) {
 		if len(c.config) > 0 {
 			cfg := yml.MustApplyNamespace(t, c.config, namespace)
 			// we only apply to config clusters
-			t.ConfigIstio().YAML(cfg).ApplyOrFail(t, "")
+			t.ConfigIstio().YAML("", cfg).ApplyOrFail(t)
 		}
 
 		if c.call != nil && len(c.children) > 0 {

--- a/tests/integration/pilot/cross_revision_test.go
+++ b/tests/integration/pilot/cross_revision_test.go
@@ -58,7 +58,7 @@ func TestRevisionTraffic(t *testing.T) {
 				})
 			}
 			// Allow all namespaces so we do not hit passthrough cluster
-			t.ConfigIstio().YAML(`apiVersion: networking.istio.io/v1alpha3
+			t.ConfigIstio().YAML(apps.Namespace.Name(), `apiVersion: networking.istio.io/v1alpha3
 kind: Sidecar
 metadata:
   name: allow-cross-namespaces
@@ -68,7 +68,7 @@ spec:
       app: a
   egress:
   - hosts:
-    - "*/*"`).ApplyOrFail(t, apps.Namespace.Name())
+    - "*/*"`).ApplyOrFail(t)
 			// create an echo instance in each revisioned namespace, all these echo
 			// instances will be injected with proxies from their respective versions
 			builder := deployment.New(t).WithClusters(t.Clusters()...)

--- a/tests/integration/pilot/grpc_probe_test.go
+++ b/tests/integration/pilot/grpc_probe_test.go
@@ -18,7 +18,6 @@
 package pilot
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -39,15 +38,14 @@ func TestGRPCProbe(t *testing.T) {
 
 			ns := namespace.NewOrFail(t, t, namespace.Config{Prefix: "grpc-probe", Inject: true})
 			// apply strict mtls
-			t.ConfigKube().YAML(fmt.Sprintf(`
+			t.ConfigKube().YAML(ns.Name(), `
 apiVersion: security.istio.io/v1beta1
 kind: PeerAuthentication
 metadata:
   name: grpc-probe-mtls
-  namespace: %s
 spec:
   mtls:
-    mode: STRICT`, ns.Name())).ApplyOrFail(t, ns.Name())
+    mode: STRICT`).ApplyOrFail(t)
 
 			for _, testCase := range []struct {
 				name     string

--- a/tests/integration/pilot/gw_topology_test.go
+++ b/tests/integration/pilot/gw_topology_test.go
@@ -48,7 +48,7 @@ func TestXFFGateway(t *testing.T) {
 			}
 
 			// we only apply to config clusters
-			t.ConfigIstio().Eval(templateParams, `apiVersion: v1
+			t.ConfigIstio().Eval(gatewayNs.Name(), templateParams, `apiVersion: v1
 kind: Service
 metadata:
   name: custom-gateway
@@ -90,7 +90,7 @@ spec:
         image: auto
         imagePullPolicy: {{ .imagePullPolicy }}
 ---
-`).ApplyOrFail(t, gatewayNs.Name())
+`).ApplyOrFail(t)
 			cs := t.Clusters().Default().(*kubecluster.Cluster)
 			retry.UntilSuccessOrFail(t, func() error {
 				_, err := kubetest.CheckPodsAreReady(kubetest.NewPodFetch(cs, gatewayNs.Name(), "istio=ingressgateway"))

--- a/tests/integration/pilot/ingress_test.go
+++ b/tests/integration/pilot/ingress_test.go
@@ -57,7 +57,7 @@ func TestGateway(t *testing.T) {
 			if !supportsCRDv1(t) {
 				t.Skip("Not supported; requires CRDv1 support.")
 			}
-			if err := t.ConfigIstio().File("testdata/gateway-api-crd.yaml").Apply("", resource.NoCleanup); err != nil {
+			if err := t.ConfigIstio().File("", "testdata/gateway-api-crd.yaml").Apply(resource.NoCleanup); err != nil {
 				t.Fatal(err)
 			}
 			ingressutil.CreateIngressKubeSecret(t, "test-gateway-cert-same", ingressutil.TLS, ingressutil.IngressCredentialA,
@@ -66,7 +66,7 @@ func TestGateway(t *testing.T) {
 				false, t.Clusters().Configs()...)
 
 			retry.UntilSuccessOrFail(t, func() error {
-				err := t.ConfigIstio().YAML(fmt.Sprintf(`
+				err := t.ConfigIstio().YAML("", fmt.Sprintf(`
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: GatewayClass
 metadata:
@@ -123,11 +123,11 @@ spec:
       certificateRefs:
       - kind: Secret
         name: test-gateway-cert-same
----`, apps.Namespace.Name())).Apply("")
+---`, apps.Namespace.Name())).Apply()
 				return err
 			}, retry.Delay(time.Second*10), retry.Timeout(time.Second*90))
 			retry.UntilSuccessOrFail(t, func() error {
-				err := t.ConfigIstio().YAML(`
+				err := t.ConfigIstio().YAML(apps.Namespace.Name(), `
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: HTTPRoute
 metadata:
@@ -184,7 +184,7 @@ spec:
     backendRefs:
     - name: b
       port: 80
-`).Apply(apps.Namespace.Name())
+`).Apply()
 				return err
 			}, retry.Delay(time.Second*10), retry.Timeout(time.Second*90))
 			for _, ingr := range apps.Ingresses {
@@ -244,7 +244,7 @@ spec:
 				})
 			}
 			t.NewSubTest("managed").Run(func(t framework.TestContext) {
-				t.ConfigIstio().YAML(`apiVersion: gateway.networking.k8s.io/v1alpha2
+				t.ConfigIstio().YAML(apps.Namespace.Name(), `apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: Gateway
 metadata:
   name: gateway
@@ -267,7 +267,7 @@ spec:
   - backendRefs:
     - name: b
       port: 80
-`).ApplyOrFail(t, apps.Namespace.Name())
+`).ApplyOrFail(t)
 				apps.PodB[0].CallOrFail(t, echo.CallOptions{
 					Port:   echo.Port{ServicePort: 80},
 					Scheme: scheme.HTTP,
@@ -563,9 +563,9 @@ spec:
 					for _, c := range cases {
 						c := c
 						t.NewSubTest(c.name).Run(func(t framework.TestContext) {
-							if err := t.ConfigIstio().YAML(ingressClassConfig,
+							if err := t.ConfigIstio().YAML(apps.Namespace.Name(), ingressClassConfig,
 								fmt.Sprintf(ingressConfigTemplate, "ingress", "istio-test", c.path, c.path, c.prefixPath)).
-								Apply(apps.Namespace.Name()); err != nil {
+								Apply(); err != nil {
 								t.Fatal(err)
 							}
 							c.call.Retry.Options = []retry.Option{
@@ -582,9 +582,9 @@ spec:
 				if !t.Environment().(*kube.Environment).Settings().LoadBalancerSupported {
 					t.Skip("ingress status not supported without load balancer")
 				}
-				if err := t.ConfigIstio().YAML(ingressClassConfig,
+				if err := t.ConfigIstio().YAML(apps.Namespace.Name(), ingressClassConfig,
 					fmt.Sprintf(ingressConfigTemplate, "ingress", "istio-test", "/test", "/test", "/test")).
-					Apply(apps.Namespace.Name()); err != nil {
+					Apply(); err != nil {
 					t.Fatal(err)
 				}
 
@@ -628,9 +628,9 @@ spec:
 
 			// setup another ingress pointing to a different route; the ingress will have an ingress class that should be targeted at first
 			const updateIngressName = "update-test-ingress"
-			if err := t.ConfigIstio().YAML(ingressClassConfig,
+			if err := t.ConfigIstio().YAML(apps.Namespace.Name(), ingressClassConfig,
 				fmt.Sprintf(ingressConfigTemplate, updateIngressName, "istio-test", "/update-test", "/update-test", "/update-test")).
-				Apply(apps.Namespace.Name()); err != nil {
+				Apply(); err != nil {
 				t.Fatal(err)
 			}
 			// these cases make sure that when new Ingress configs are applied our controller picks up on them
@@ -697,7 +697,7 @@ spec:
 			for _, c := range ingressUpdateCases {
 				c := c
 				updatedIngress := fmt.Sprintf(ingressConfigTemplate, updateIngressName, c.ingressClass, c.path, c.path, c.path)
-				t.ConfigIstio().YAML(updatedIngress).ApplyOrFail(t, apps.Namespace.Name())
+				t.ConfigIstio().YAML(apps.Namespace.Name(), updatedIngress).ApplyOrFail(t)
 				t.NewSubTest(c.name).Run(func(t framework.TestContext) {
 					c.call.Retry.Options = []retry.Option{retry.Timeout(time.Minute)}
 					apps.Ingress.CallOrFail(t, c.call)
@@ -726,7 +726,7 @@ func TestCustomGateway(t *testing.T) {
 
 			t.NewSubTest("minimal").Run(func(t framework.TestContext) {
 				gatewayNs := namespace.NewOrFail(t, t, namespace.Config{Prefix: "custom-gateway-minimal"})
-				_ = t.ConfigIstio().Eval(templateParams, `apiVersion: v1
+				_ = t.ConfigIstio().Eval(gatewayNs.Name(), templateParams, `apiVersion: v1
 kind: Service
 metadata:
   name: custom-gateway
@@ -795,7 +795,7 @@ spec:
         host: {{ .host }}
         port:
           number: 80
-`).Apply(gatewayNs.Name(), resource.NoCleanup)
+`).Apply(resource.NoCleanup)
 				cs := t.Clusters().Default().(*kubecluster.Cluster)
 				retry.UntilSuccessOrFail(t, func() error {
 					_, err := kubetest.CheckPodsAreReady(kubetest.NewPodFetch(cs, gatewayNs.Name(), "istio=custom"))
@@ -843,7 +843,7 @@ gateways:
 					_, err := kubetest.CheckPodsAreReady(kubetest.NewPodFetch(cs, gatewayNs.Name(), "istio=custom-gateway-helm"))
 					return err
 				}, retry.Timeout(time.Minute*2), retry.Delay(time.Millisecond*500))
-				_ = t.ConfigIstio().YAML(fmt.Sprintf(`apiVersion: networking.istio.io/v1alpha3
+				_ = t.ConfigIstio().YAML(gatewayNs.Name(), fmt.Sprintf(`apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
   name: app
@@ -873,7 +873,7 @@ spec:
         host: %s
         port:
           number: 80
-`, apps.PodA[0].Config().ClusterLocalFQDN())).Apply(gatewayNs.Name(), resource.NoCleanup)
+`, apps.PodA[0].Config().ClusterLocalFQDN())).Apply(resource.NoCleanup)
 				apps.PodB[0].CallOrFail(t, echo.CallOptions{
 					Port:    echo.Port{ServicePort: 80},
 					Scheme:  scheme.HTTP,
@@ -910,7 +910,7 @@ resources:
 					_, err := kubetest.CheckPodsAreReady(kubetest.NewPodFetch(cs, gatewayNs.Name(), "istio=helm-simple"))
 					return err
 				}, retry.Timeout(time.Minute*2), retry.Delay(time.Millisecond*500))
-				_ = t.ConfigIstio().YAML(fmt.Sprintf(`apiVersion: networking.istio.io/v1alpha3
+				_ = t.ConfigIstio().YAML(gatewayNs.Name(), fmt.Sprintf(`apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
   name: app
@@ -940,7 +940,7 @@ spec:
         host: %s
         port:
           number: 80
-`, apps.PodA[0].Config().ClusterLocalFQDN())).Apply(gatewayNs.Name(), resource.NoCleanup)
+`, apps.PodA[0].Config().ClusterLocalFQDN())).Apply(resource.NoCleanup)
 				apps.PodB[0].CallOrFail(t, echo.CallOptions{
 					Port:    echo.Port{ServicePort: 80},
 					Scheme:  scheme.HTTP,

--- a/tests/integration/pilot/istioctl_test.go
+++ b/tests/integration/pilot/istioctl_test.go
@@ -73,7 +73,7 @@ func TestWait(t *testing.T) {
 				Prefix: "default",
 				Inject: true,
 			})
-			t.ConfigIstio().YAML(`
+			t.ConfigIstio().YAML(ns.Name(), `
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
@@ -86,7 +86,7 @@ spec:
   - route:
     - destination: 
         host: reviews
-`).ApplyOrFail(t, ns.Name())
+`).ApplyOrFail(t)
 			istioCtl := istioctl.NewOrFail(t, t, istioctl.Config{Cluster: t.Clusters().Default()})
 			istioCtl.InvokeOrFail(t, []string{"x", "wait", "-v", "VirtualService", "reviews." + ns.Name()})
 		})
@@ -146,7 +146,7 @@ func TestDescribe(t *testing.T) {
 	framework.NewTest(t).Features("usability.observability.describe").
 		RequiresSingleCluster().
 		Run(func(t framework.TestContext) {
-			t.ConfigIstio().File("testdata/a.yaml").ApplyOrFail(t, apps.Namespace.Name())
+			t.ConfigIstio().File(apps.Namespace.Name(), "testdata/a.yaml").ApplyOrFail(t)
 
 			istioCtl := istioctl.NewOrFail(t, t, istioctl.Config{})
 
@@ -474,8 +474,8 @@ func TestAuthZCheck(t *testing.T) {
 	framework.NewTest(t).Features("usability.observability.authz-check").
 		RequiresSingleCluster().
 		Run(func(t framework.TestContext) {
-			t.ConfigIstio().File("testdata/authz-a.yaml").ApplyOrFail(t, apps.Namespace.Name())
-			t.ConfigIstio().File("testdata/authz-b.yaml").ApplyOrFail(t, i.Settings().SystemNamespace)
+			t.ConfigIstio().File(apps.Namespace.Name(), "testdata/authz-a.yaml").ApplyOrFail(t)
+			t.ConfigIstio().File(i.Settings().SystemNamespace, "testdata/authz-b.yaml").ApplyOrFail(t)
 
 			gwPod, err := i.IngressFor(t.Clusters().Default()).PodID(0)
 			if err != nil {

--- a/tests/integration/pilot/locality_test.go
+++ b/tests/integration/pilot/locality_test.go
@@ -210,7 +210,7 @@ func TestLocality(t *testing.T) {
 				t.NewSubTest(tt.name).Run(func(t framework.TestContext) {
 					hostname := fmt.Sprintf("%s-fake-locality.example.com", strings.ToLower(strings.ReplaceAll(tt.name, "/", "-")))
 					tt.input.Host = hostname
-					t.ConfigIstio().YAML(runTemplate(t, localityTemplate, tt.input)).ApplyOrFail(t, apps.Namespace.Name())
+					t.ConfigIstio().YAML(apps.Namespace.Name(), runTemplate(t, localityTemplate, tt.input)).ApplyOrFail(t)
 					sendTrafficOrFail(t, apps.PodA[0], hostname, tt.expected)
 				})
 			}

--- a/tests/integration/pilot/mcs/common/common.go
+++ b/tests/integration/pilot/mcs/common/common.go
@@ -78,11 +78,11 @@ func InstallMCSCRDs(t resource.Context) error {
 
 			// Add/Update the CRD in this cluster...
 			if t.Settings().NoCleanup {
-				if err := t.ConfigKube(c).YAML(crdYAML).Apply("", resource.NoCleanup); err != nil {
+				if err := t.ConfigKube(c).YAML("", crdYAML).Apply(resource.NoCleanup); err != nil {
 					return err
 				}
 			} else {
-				if err := t.ConfigKube(c).YAML(crdYAML).Apply(""); err != nil {
+				if err := t.ConfigKube(c).YAML("", crdYAML).Apply(); err != nil {
 					return err
 				}
 			}

--- a/tests/integration/pilot/mirror_test.go
+++ b/tests/integration/pilot/mirror_test.go
@@ -138,7 +138,7 @@ func runMirrorTest(t *testing.T, options mirrorTestOptions) {
 					}
 
 					// we only apply to config clusters
-					t.ConfigIstio().EvalFile(vsc, "testdata/traffic-mirroring-template.yaml").ApplyOrFail(t, apps.Namespace.Name())
+					t.ConfigIstio().EvalFile(apps.Namespace.Name(), vsc, "testdata/traffic-mirroring-template.yaml").ApplyOrFail(t)
 
 					for _, podA := range apps.PodA {
 						podA := podA

--- a/tests/integration/pilot/multi_version_revision_test.go
+++ b/tests/integration/pilot/multi_version_revision_test.go
@@ -69,7 +69,7 @@ func TestMultiVersionRevision(t *testing.T) {
 			configs := make(map[string]string)
 			t.ConditionalCleanup(func() {
 				for _, config := range configs {
-					_ = t.ConfigIstio().YAML(config).Delete("istio-system")
+					_ = t.ConfigIstio().YAML("istio-system", config).Delete()
 				}
 			})
 
@@ -169,7 +169,7 @@ func installRevisionOrFail(t framework.TestContext, version string, configs map[
 		t.Fatalf("could not read installation config: %v", err)
 	}
 	configs[version] = config
-	if err := t.ConfigIstio().YAML(config).Apply(i.Settings().SystemNamespace, resource.NoCleanup); err != nil {
+	if err := t.ConfigIstio().YAML(i.Settings().SystemNamespace, config).Apply(resource.NoCleanup); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/tests/integration/pilot/multicluster_test.go
+++ b/tests/integration/pilot/multicluster_test.go
@@ -109,7 +109,7 @@ spec:
         subset: {{ .Config.Cluster.Name }}
 {{- end }}
 `, map[string]interface{}{"src": sources, "dst": to, "host": to.Config().ClusterLocalFQDN()})
-						t.ConfigIstio().YAML(cfg).ApplyOrFail(t, sources.Config().Namespace.Name())
+						t.ConfigIstio().YAML(sources.Config().Namespace.Name(), cfg).ApplyOrFail(t)
 					},
 				},
 			}
@@ -207,11 +207,11 @@ func TestBadRemoteSecret(t *testing.T) {
 					return err
 				}, retry.Timeout(15*time.Second))
 
-				t.ConfigKube().YAML(secret).ApplyOrFail(t, ns)
+				t.ConfigKube().YAML(ns, secret).ApplyOrFail(t)
 			}
 			// Test exec auth
 			// CreateRemoteSecret can never generate this, so create it manually
-			t.ConfigIstio().YAML(`apiVersion: v1
+			t.ConfigIstio().YAML(ns, `apiVersion: v1
 kind: Secret
 metadata:
   annotations:
@@ -241,7 +241,7 @@ stringData:
           command: /bin/sh
           args: ["-c", "hello world!"]
 ---
-`).ApplyOrFail(t, ns)
+`).ApplyOrFail(t)
 
 			// create a new istiod pod using the template from the deployment, but not managed by the deployment
 			t.Logf("creating pod %s/%s", ns, pod)

--- a/tests/integration/pilot/proxyconfig/proxyconfig_test.go
+++ b/tests/integration/pilot/proxyconfig/proxyconfig_test.go
@@ -205,7 +205,7 @@ func checkInjectedValues(t framework.TestContext, instances echo.Instances, valu
 
 func applyProxyConfigs(ctx framework.TestContext, configs []proxyConfigInstance) {
 	for _, config := range configs {
-		ctx.ConfigIstio().YAML(config.config).ApplyOrFail(ctx, config.namespace)
+		ctx.ConfigIstio().YAML(config.namespace, config.config).ApplyOrFail(ctx)
 	}
 	// TODO(Monkeyanator) give a few seconds for PC to propagate
 	// shouldn't be required but multicluster seems to have some issues with echo instance restart.
@@ -214,7 +214,7 @@ func applyProxyConfigs(ctx framework.TestContext, configs []proxyConfigInstance)
 
 func deleteProxyConfigs(ctx framework.TestContext, configs []proxyConfigInstance) {
 	for _, config := range configs {
-		ctx.ConfigIstio().YAML(config.config).DeleteOrFail(ctx, config.namespace)
+		ctx.ConfigIstio().YAML(config.namespace, config.config).DeleteOrFail(ctx)
 	}
 }
 

--- a/tests/integration/pilot/revisioned_upgrade_test.go
+++ b/tests/integration/pilot/revisioned_upgrade_test.go
@@ -71,7 +71,7 @@ func testUpgradeFromVersion(t framework.TestContext, fromVersion string) {
 	configs := make(map[string]string)
 	t.ConditionalCleanup(func() {
 		for _, config := range configs {
-			_ = t.ConfigIstio().YAML(config).Delete("istio-system")
+			_ = t.ConfigIstio().YAML("istio-system", config).Delete()
 		}
 	})
 

--- a/tests/integration/security/ca_custom_root/multi_root_test.go
+++ b/tests/integration/security/ca_custom_root/multi_root_test.go
@@ -35,7 +35,7 @@ func TestMultiRootSetup(t *testing.T) {
 		Run(func(t framework.TestContext) {
 			testNS := apps.Namespace
 
-			t.ConfigIstio().YAML(POLICY).ApplyOrFail(t, testNS.Name())
+			t.ConfigIstio().YAML(testNS.Name(), POLICY).ApplyOrFail(t)
 
 			for _, cluster := range t.Clusters() {
 				t.NewSubTest(fmt.Sprintf("From %s", cluster.StableName())).Run(func(t framework.TestContext) {

--- a/tests/integration/security/ca_custom_root/secure_naming_test.go
+++ b/tests/integration/security/ca_custom_root/secure_naming_test.go
@@ -171,7 +171,7 @@ func TestSecureNaming(t *testing.T) {
 						t.NewSubTest(tc.name).
 							Run(func(t framework.TestContext) {
 								dr := strings.ReplaceAll(tc.destinationRule, "NS", testNamespace.Name())
-								t.ConfigIstio().YAML(dr).ApplyOrFail(t, testNamespace.Name())
+								t.ConfigIstio().YAML(testNamespace.Name(), dr).ApplyOrFail(t)
 								// Verify mTLS works between a and b
 								opts := echo.CallOptions{
 									To: to,

--- a/tests/integration/security/ca_custom_root/trust_domain_alias_secure_naming_test.go
+++ b/tests/integration/security/ca_custom_root/trust_domain_alias_secure_naming_test.go
@@ -75,7 +75,7 @@ func TestTrustDomainAliasSecureNaming(t *testing.T) {
 			}
 			testNS := apps.Namespace
 
-			t.ConfigIstio().YAML(POLICY).ApplyOrFail(t, testNS.Name())
+			t.ConfigIstio().YAML(testNS.Name(), POLICY).ApplyOrFail(t)
 
 			for _, cluster := range t.Clusters() {
 				t.NewSubTest(fmt.Sprintf("From %s", cluster.StableName())).Run(func(t framework.TestContext) {

--- a/tests/integration/security/ca_custom_root/trust_domain_validation_test.go
+++ b/tests/integration/security/ca_custom_root/trust_domain_validation_test.go
@@ -102,7 +102,7 @@ func TestTrustDomainValidation(t *testing.T) {
 
 			testNS := apps.Namespace
 
-			ctx.ConfigIstio().YAML(fmt.Sprintf(policy, testNS.Name())).ApplyOrFail(ctx, testNS.Name())
+			ctx.ConfigIstio().YAML(testNS.Name(), fmt.Sprintf(policy, testNS.Name())).ApplyOrFail(ctx)
 
 			trustDomains := map[string]struct {
 				cert string

--- a/tests/integration/security/ecc_signature_algorithm/mtls_strict_test.go
+++ b/tests/integration/security/ecc_signature_algorithm/mtls_strict_test.go
@@ -63,8 +63,8 @@ func TestStrictMTLS(t *testing.T) {
 		Run(func(t framework.TestContext) {
 			ns := apps.Namespace.Name()
 			args := map[string]string{"AppNamespace": ns}
-			t.ConfigIstio().Eval(args, PeerAuthenticationConfig).ApplyOrFail(t, ns, resource.Wait)
-			t.ConfigIstio().Eval(args, DestinationRuleConfigIstioMutual).ApplyOrFail(t, ns, resource.Wait)
+			t.ConfigIstio().Eval(ns, args, PeerAuthenticationConfig).ApplyOrFail(t, resource.Wait)
+			t.ConfigIstio().Eval(ns, args, DestinationRuleConfigIstioMutual).ApplyOrFail(t, resource.Wait)
 
 			apps.Client.CallOrFail(t, echo.CallOptions{
 				To: apps.Server,

--- a/tests/integration/security/egress_gateway_origination_test.go
+++ b/tests/integration/security/egress_gateway_origination_test.go
@@ -303,7 +303,7 @@ spec:
 func CreateGateway(t test.Failer, ctx resource.Context, clientNamespace namespace.Instance, to echo.Instances) {
 	args := map[string]interface{}{"to": to}
 
-	ctx.ConfigIstio().Eval(args, Gateway, VirtualService).ApplyOrFail(t, clientNamespace.Name())
+	ctx.ConfigIstio().Eval(clientNamespace.Name(), args, Gateway, VirtualService).ApplyOrFail(t)
 }
 
 const (
@@ -339,7 +339,7 @@ func CreateDestinationRule(t framework.TestContext, to echo.Instances,
 	istioCfg := istio.DefaultConfigOrFail(t, t)
 	systemNS := namespace.ClaimOrFail(t, t, istioCfg.SystemNamespace)
 
-	t.ConfigKube(t.Clusters().Default()).Eval(args, DestinationRuleConfig).ApplyOrFail(t, systemNS.Name())
+	t.ConfigKube(t.Clusters().Default()).Eval(systemNS.Name(), args, DestinationRuleConfig).ApplyOrFail(t)
 }
 
 type TLSTestCase struct {

--- a/tests/integration/security/file_mounted_certs/p2p_mtls_test.go
+++ b/tests/integration/security/file_mounted_certs/p2p_mtls_test.go
@@ -102,7 +102,7 @@ spec:
 
 func createObject(ctx framework.TestContext, serviceNamespace string, yamlManifest string) {
 	args := map[string]string{"AppNamespace": serviceNamespace}
-	ctx.ConfigIstio().Eval(args, yamlManifest).ApplyOrFail(ctx, serviceNamespace)
+	ctx.ConfigIstio().Eval(serviceNamespace, args, yamlManifest).ApplyOrFail(ctx)
 }
 
 // setupEcho creates an `istio-fd-sds` namespace and brings up two echo instances server and

--- a/tests/integration/security/filebased_tls_origination/destination_rule_tls_test.go
+++ b/tests/integration/security/filebased_tls_origination/destination_rule_tls_test.go
@@ -54,7 +54,7 @@ func TestDestinationRuleTls(t *testing.T) {
 			})
 
 			// Setup our destination rule, enforcing TLS to "server". These certs will be created/mounted below.
-			t.ConfigIstio().YAML(`
+			t.ConfigIstio().YAML(ns.Name(), `
 apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
@@ -68,7 +68,7 @@ spec:
       clientCertificate: /etc/certs/custom/cert-chain.pem
       privateKey: /etc/certs/custom/key.pem
       caCertificates: /etc/certs/custom/root-cert.pem
-`).ApplyOrFail(t, ns.Name())
+`).ApplyOrFail(t)
 
 			var client, server echo.Instance
 			deployment.New(t).

--- a/tests/integration/security/filebased_tls_origination/egress_gateway_origination_test.go
+++ b/tests/integration/security/filebased_tls_origination/egress_gateway_origination_test.go
@@ -126,7 +126,7 @@ func TestEgressGatewayTls(t *testing.T) {
 						istioCfg := istio.DefaultConfigOrFail(t, t)
 						systemNamespace := namespace.ClaimOrFail(t, t, istioCfg.SystemNamespace)
 
-						t.ConfigIstio().YAML(bufDestinationRule.String()).ApplyOrFail(t, systemNamespace.Name())
+						t.ConfigIstio().YAML(systemNamespace.Name(), bufDestinationRule.String()).ApplyOrFail(t)
 
 						opts := echo.CallOptions{
 							To: externalServer,
@@ -401,7 +401,7 @@ func createGateway(t test.Failer, ctx resource.Context, appsNamespace namespace.
 	if err := tmplGateway.Execute(&bufGateway, map[string]string{"ServerNamespace": serviceNamespace.Name()}); err != nil {
 		t.Fatalf("failed to create template: %v", err)
 	}
-	if err := ctx.ConfigIstio().YAML(bufGateway.String()).Apply(appsNamespace.Name()); err != nil {
+	if err := ctx.ConfigIstio().YAML(appsNamespace.Name(), bufGateway.String()).Apply(); err != nil {
 		t.Fatalf("failed to apply gateway: %v. template: %v", err, bufGateway.String())
 	}
 
@@ -418,7 +418,7 @@ func createGateway(t test.Failer, ctx resource.Context, appsNamespace namespace.
 	if err := tmplVS.Execute(&bufVS, map[string]string{"ServerNamespace": serviceNamespace.Name()}); err != nil {
 		t.Fatalf("failed to create template: %v", err)
 	}
-	if err := ctx.ConfigIstio().YAML(bufVS.String()).Apply(appsNamespace.Name()); err != nil {
+	if err := ctx.ConfigIstio().YAML(appsNamespace.Name(), bufVS.String()).Apply(); err != nil {
 		t.Fatalf("failed to apply virtualservice: %v. template: %v", err, bufVS.String())
 	}
 }

--- a/tests/integration/security/fuzz/fuzz_test.go
+++ b/tests/integration/security/fuzz/fuzz_test.go
@@ -94,7 +94,7 @@ var (
 )
 
 func deploy(t framework.TestContext, name, ns, yaml string) {
-	t.ConfigIstio().File(yaml).ApplyOrFail(t, ns)
+	t.ConfigIstio().File(ns, yaml).ApplyOrFail(t)
 	if _, err := kube.WaitUntilPodsAreReady(kube.NewPodFetch(t.Clusters().Default(), ns, "app="+name)); err != nil {
 		t.Fatalf("Wait for pod %s failed: %v", name, err)
 	}
@@ -216,11 +216,11 @@ func TestFuzzAuthorization(t *testing.T) {
 			ns := "fuzz-authz"
 			namespace.ClaimOrFail(t, t, ns)
 
-			t.ConfigIstio().YAML(authzDenyPolicy).ApplyOrFail(t, ns)
+			t.ConfigIstio().YAML(ns, authzDenyPolicy).ApplyOrFail(t)
 			t.Logf("authorization policy applied")
 
 			deploy(t, dotdotpwn, ns, "fuzzers/dotdotpwn/dotdotpwn.yaml")
-			t.ConfigIstio().File("fuzzers/wfuzz/wordlist.yaml").ApplyOrFail(t, ns)
+			t.ConfigIstio().File(ns, "fuzzers/wfuzz/wordlist.yaml").ApplyOrFail(t)
 			deploy(t, wfuzz, ns, "fuzzers/wfuzz/wfuzz.yaml")
 
 			deploy(t, apacheServer, ns, "backends/apache/apache.yaml")
@@ -301,7 +301,7 @@ func TestRequestAuthentication(t *testing.T) {
 			ns := "fuzz-jwt"
 			namespace.ClaimOrFail(t, t, ns)
 
-			t.ConfigIstio().YAML(requestAuthnPolicy).ApplyOrFail(t, ns)
+			t.ConfigIstio().YAML(ns, requestAuthnPolicy).ApplyOrFail(t)
 			t.Logf("request authentication policy applied")
 
 			// We don't care about the actual backend for JWT test, one backend is good enough.

--- a/tests/integration/security/https_jwt/https_jwt_test.go
+++ b/tests/integration/security/https_jwt/https_jwt_test.go
@@ -50,9 +50,9 @@ func TestJWTHTTPS(t *testing.T) {
 			ns := apps.Namespace1
 			istioSystemNS := istio.ClaimSystemNamespaceOrFail(t, t)
 
-			t.ConfigKube().EvalFile(map[string]string{
+			t.ConfigKube().EvalFile(istioSystemNS.Name(), map[string]string{
 				"Namespace": istioSystemNS.Name(),
-			}, filepath.Join(env.IstioSrc, "samples/jwt-server", "jwt-server.yaml")).ApplyOrFail(t, istioSystemNS.Name())
+			}, filepath.Join(env.IstioSrc, "samples/jwt-server", "jwt-server.yaml")).ApplyOrFail(t)
 
 			for _, cluster := range t.AllClusters() {
 				fetchFn := kube.NewSinglePodFetch(cluster, istioSystemNS.Name(), "app=jwt-server")
@@ -98,8 +98,8 @@ func TestJWTHTTPS(t *testing.T) {
 								"Namespace": ns.Name(),
 								"dst":       to.Config().Service,
 							}
-							return t.ConfigIstio().EvalFile(args, c.policyFile).
-								Apply(ns.Name(), resource.Wait)
+							return t.ConfigIstio().EvalFile(ns.Name(), args, c.policyFile).
+								Apply(resource.Wait)
 						}).
 						FromMatch(
 							// TODO(JimmyCYJ): enable VM for all test cases.

--- a/tests/integration/security/jwt_test.go
+++ b/tests/integration/security/jwt_test.go
@@ -46,9 +46,9 @@ func TestRequestAuthentication(t *testing.T) {
 		Features("security.authentication.jwt").
 		Run(func(t framework.TestContext) {
 			ns := apps.Namespace1
-			t.ConfigKube().EvalFile(map[string]string{
+			t.ConfigKube().EvalFile(ns.Name(), map[string]string{
 				"Namespace": ns.Name(),
-			}, "../../../samples/jwt-server/jwt-server.yaml").ApplyOrFail(t, ns.Name())
+			}, "../../../samples/jwt-server/jwt-server.yaml").ApplyOrFail(t)
 
 			type testCase struct {
 				name          string
@@ -64,7 +64,7 @@ func TestRequestAuthentication(t *testing.T) {
 									"Namespace": ns.Name(),
 									"dst":       to.Config().Service,
 								}
-								return t.ConfigIstio().EvalFile(args, policy).Apply(ns.Name(), resource.Wait)
+								return t.ConfigIstio().EvalFile(ns.Name(), args, policy).Apply(resource.Wait)
 							}
 							return nil
 						}).
@@ -395,10 +395,10 @@ func TestIngressRequestAuthentication(t *testing.T) {
 			ns := apps.Namespace1
 
 			// Apply the policy.
-			t.ConfigIstio().EvalFile(map[string]string{
+			t.ConfigIstio().EvalFile(newRootNS(t).Name(), map[string]string{
 				"Namespace":     ns.Name(),
 				"RootNamespace": istio.GetOrFail(t, t).Settings().SystemNamespace,
-			}, "testdata/requestauthn/global-jwt.yaml.tmpl").ApplyOrFail(t, newRootNS(t).Name(), resource.Wait)
+			}, "testdata/requestauthn/global-jwt.yaml.tmpl").ApplyOrFail(t, resource.Wait)
 
 			type testCase struct {
 				name          string
@@ -414,7 +414,7 @@ func TestIngressRequestAuthentication(t *testing.T) {
 									"Namespace": ns.Name(),
 									"dst":       to.Config().Service,
 								}
-								return t.ConfigIstio().EvalFile(args, policy).Apply(ns.Name(), resource.Wait)
+								return t.ConfigIstio().EvalFile(ns.Name(), args, policy).Apply(resource.Wait)
 							}
 							return nil
 						}).
@@ -466,10 +466,10 @@ func TestIngressRequestAuthentication(t *testing.T) {
 
 			t.NewSubTest("ingress-authn").Run(func(t framework.TestContext) {
 				// TODO(JimmyCYJ): add workload-agnostic test pattern to support ingress gateway tests.
-				t.ConfigIstio().EvalFile(map[string]string{
+				t.ConfigIstio().EvalFile(ns.Name(), map[string]string{
 					"Namespace": ns.Name(),
 					"dst":       util.BSvc,
-				}, "testdata/requestauthn/ingress.yaml.tmpl").ApplyOrFail(t, ns.Name())
+				}, "testdata/requestauthn/ingress.yaml.tmpl").ApplyOrFail(t)
 
 				for _, cluster := range t.Clusters() {
 					ingr := ist.IngressFor(cluster)

--- a/tests/integration/security/mtls_healthcheck_test.go
+++ b/tests/integration/security/mtls_healthcheck_test.go
@@ -66,7 +66,7 @@ spec:
   mtls:
     mode: STRICT
 `, name, name)
-	ctx.ConfigIstio().YAML(policyYAML).ApplyOrFail(ctx, ns.Name())
+	ctx.ConfigIstio().YAML(ns.Name(), policyYAML).ApplyOrFail(ctx)
 
 	var healthcheck echo.Instance
 	cfg := echo.Config{

--- a/tests/integration/security/pass_through_filter_chain_test.go
+++ b/tests/integration/security/pass_through_filter_chain_test.go
@@ -616,7 +616,7 @@ spec:
 									"IP": to.WorkloadsOrFail(t)[0].Address(),
 								},
 							), ns.Name())
-							return t.ConfigIstio().YAML(cfg, fakesvc).Apply(ns.Name())
+							return t.ConfigIstio().YAML(ns.Name(), cfg, fakesvc).Apply()
 						}).
 						FromMatch(srcMatcher).
 						ConditionallyTo(echotest.ReachableDestinations).

--- a/tests/integration/security/sds_egress/sds_istio_mutual_egress_test.go
+++ b/tests/integration/security/sds_egress/sds_istio_mutual_egress_test.go
@@ -93,7 +93,7 @@ func doIstioMutualTest(
 	deployment.New(ctx).
 		With(&client, util.EchoConfig("client", ns, false, nil)).
 		BuildOrFail(ctx)
-	ctx.ConfigIstio().File(configPath).ApplyOrFail(ctx, ns.Name())
+	ctx.ConfigIstio().File(ns.Name(), configPath).ApplyOrFail(ctx)
 
 	// give the configuration a moment to kick in
 	time.Sleep(time.Second * 20)
@@ -133,7 +133,7 @@ func applySetupConfig(ctx framework.TestContext, ns namespace.Instance) {
 	}
 
 	for _, c := range configFiles {
-		if err := ctx.ConfigIstio().File(c).Apply(ns.Name()); err != nil {
+		if err := ctx.ConfigIstio().File(ns.Name(), c).Apply(); err != nil {
 			ctx.Fatalf("failed to apply configuration file %s; err: %v", c, err)
 		}
 	}

--- a/tests/integration/security/sds_ingress/util/util.go
+++ b/tests/integration/security/sds_ingress/util/util.go
@@ -482,7 +482,7 @@ func SetupConfig(ctx framework.TestContext, ns namespace.Instance, config ...Tes
 	for _, c := range config {
 		apply = append(apply, runTemplate(ctx, vsTemplate, c), runTemplate(ctx, gwTemplate, c))
 	}
-	ctx.ConfigIstio().YAML(apply...).ApplyOrFail(ctx, ns.Name())
+	ctx.ConfigIstio().YAML(ns.Name(), apply...).ApplyOrFail(ctx)
 }
 
 // RunTestMultiMtlsGateways deploys multiple mTLS gateways with SDS enabled, and creates kubernetes secret that stores

--- a/tests/integration/security/util/reachability/context.go
+++ b/tests/integration/security/util/reachability/context.go
@@ -110,11 +110,11 @@ func Run(testCases []TestCase, t framework.TestContext, apps *util.EchoDeploymen
 			}
 
 			// Apply the policy.
-			cfg := t.ConfigIstio().File(filepath.Join("./testdata", c.ConfigFile))
+			cfg := t.ConfigIstio().File(c.Namespace.Name(), filepath.Join("./testdata", c.ConfigFile))
 			retry.UntilSuccessOrFail(t, func() error {
 				t.Logf("[%s] [%v] Apply config %s", testName, time.Now(), c.ConfigFile)
 				// TODO(https://github.com/istio/istio/issues/20460) We shouldn't need a retry loop
-				return cfg.Apply(c.Namespace.Name(), resource.Wait)
+				return cfg.Apply(resource.Wait)
 			})
 			for _, clients := range []echo.Instances{apps.A, match.Namespace(apps.Namespace1.Name()).GetMatches(apps.B), apps.Headless, apps.Naked, apps.HeadlessNaked} {
 				for _, from := range clients {

--- a/tests/integration/telemetry/outboundtrafficpolicy/helper.go
+++ b/tests/integration/telemetry/outboundtrafficpolicy/helper.go
@@ -178,7 +178,7 @@ func (t TrafficPolicy) String() string {
 // we can import only the service namespace, so the apps are not known
 func createSidecarScope(t framework.TestContext, tPolicy TrafficPolicy, appsNamespace namespace.Instance, serviceNamespace namespace.Instance) {
 	args := map[string]string{"ImportNamespace": serviceNamespace.Name(), "TrafficPolicyMode": tPolicy.String()}
-	if err := t.ConfigIstio().Eval(args, SidecarScope).Apply(appsNamespace.Name()); err != nil {
+	if err := t.ConfigIstio().Eval(appsNamespace.Name(), args, SidecarScope).Apply(); err != nil {
 		t.Errorf("failed to apply service entries: %v", err)
 	}
 }
@@ -197,7 +197,7 @@ func mustReadCert(t framework.TestContext, f string) string {
 func createGateway(t framework.TestContext, appsNamespace namespace.Instance, serviceNamespace namespace.Instance) {
 	t.Helper()
 	b := tmpl.EvaluateOrFail(t, Gateway, map[string]string{"AppNamespace": appsNamespace.Name()})
-	if err := t.ConfigIstio().YAML(b).Apply(serviceNamespace.Name()); err != nil {
+	if err := t.ConfigIstio().YAML(serviceNamespace.Name(), b).Apply(); err != nil {
 		t.Fatalf("failed to apply gateway: %v. template: %v", err, b)
 	}
 }
@@ -359,7 +359,7 @@ func setupEcho(t framework.TestContext, mode TrafficPolicy) (echo.Instance, echo
 			},
 		}).BuildOrFail(t)
 
-	if err := t.ConfigIstio().YAML(ServiceEntry).Apply(serviceNamespace.Name()); err != nil {
+	if err := t.ConfigIstio().YAML(serviceNamespace.Name(), ServiceEntry).Apply(); err != nil {
 		t.Errorf("failed to apply service entries: %v", err)
 	}
 

--- a/tests/integration/telemetry/policy/envoy_ratelimit_test.go
+++ b/tests/integration/telemetry/policy/envoy_ratelimit_test.go
@@ -144,12 +144,12 @@ func testSetup(ctx resource.Context) (err error) {
 		return
 	}
 
-	err = ctx.ConfigIstio().File("testdata/rate-limit-configmap.yaml").Apply(ratelimitNs.Name())
+	err = ctx.ConfigIstio().File(ratelimitNs.Name(), "testdata/rate-limit-configmap.yaml").Apply()
 	if err != nil {
 		return
 	}
 
-	err = ctx.ConfigIstio().File(filepath.Join(env.IstioSrc, "samples/ratelimit/rate-limit-service.yaml")).Apply(ratelimitNs.Name())
+	err = ctx.ConfigIstio().File(ratelimitNs.Name(), filepath.Join(env.IstioSrc, "samples/ratelimit/rate-limit-service.yaml")).Apply()
 	if err != nil {
 		return
 	}
@@ -181,12 +181,12 @@ func setupEnvoyFilter(ctx framework.TestContext, file string) func() {
 		ctx.Fatal(err)
 	}
 
-	err = ctx.ConfigIstio().YAML(con).Apply(ist.Settings().SystemNamespace)
+	err = ctx.ConfigIstio().YAML(ist.Settings().SystemNamespace, con).Apply()
 	if err != nil {
 		ctx.Fatal(err)
 	}
 	return func() {
-		ctx.ConfigIstio().YAML(con).DeleteOrFail(ctx, ist.Settings().SystemNamespace)
+		ctx.ConfigIstio().YAML(ist.Settings().SystemNamespace, con).DeleteOrFail(ctx)
 	}
 }
 

--- a/tests/integration/telemetry/stackdriver/api/stackdriver_filter_test.go
+++ b/tests/integration/telemetry/stackdriver/api/stackdriver_filter_test.go
@@ -105,7 +105,7 @@ func TestMain(m *testing.M) {
 			if err != nil {
 				return err
 			}
-			return ctx.ConfigIstio().YAML(`
+			return ctx.ConfigIstio().YAML(i.Settings().SystemNamespace, `
 apiVersion: telemetry.istio.io/v1alpha1
 kind: Telemetry
 metadata:
@@ -118,7 +118,7 @@ spec:
   metrics:
   - providers:
     - name: stackdriver
-`).Apply(i.Settings().SystemNamespace)
+`).Apply()
 		}).
 		Setup(stackdrivertest.TestSetup).
 		Run()

--- a/tests/integration/telemetry/stackdriver/common.go
+++ b/tests/integration/telemetry/stackdriver/common.go
@@ -88,11 +88,11 @@ func TestSetup(ctx resource.Context) (err error) {
 		return
 	}
 
-	err = ctx.ConfigKube().EvalFile(map[string]interface{}{
+	err = ctx.ConfigKube().EvalFile(EchoNsInst.Name(), map[string]interface{}{
 		"StackdriverAddress": SDInst.Address(),
 		"EchoNamespace":      EchoNsInst.Name(),
 		"UseRealSD":          stackdriver.UseRealStackdriver(),
-	}, filepath.Join(env.IstioSrc, stackdriverBootstrapOverride)).Apply(EchoNsInst.Name())
+	}, filepath.Join(env.IstioSrc, stackdriverBootstrapOverride)).Apply()
 	if err != nil {
 		return
 	}

--- a/tests/integration/telemetry/stackdriver/stackdriver_filter_audit_test.go
+++ b/tests/integration/telemetry/stackdriver/stackdriver_filter_audit_test.go
@@ -56,7 +56,7 @@ func TestStackdriverHTTPAuditLogging(t *testing.T) {
 			args := map[string]string{
 				"Namespace": ns,
 			}
-			t.ConfigIstio().EvalFile(args, filepath.Join(env.IstioSrc, auditPolicyForLogEntry)).ApplyOrFail(t, ns)
+			t.ConfigIstio().EvalFile(ns, args, filepath.Join(env.IstioSrc, auditPolicyForLogEntry)).ApplyOrFail(t)
 			t.Logf("Audit policy deployed to namespace %v", ns)
 
 			for _, cltInstance := range Clt {

--- a/tests/integration/telemetry/stackdriver/stackdriver_filter_dry_run_test.go
+++ b/tests/integration/telemetry/stackdriver/stackdriver_filter_dry_run_test.go
@@ -197,7 +197,7 @@ func createDryRunPolicy(t framework.TestContext, authz string) {
 	t.Helper()
 	ns := EchoNsInst.Name()
 	args := map[string]string{"Namespace": ns}
-	t.ConfigIstio().EvalFile(args, authz).ApplyOrFail(t, ns, resource.Wait)
+	t.ConfigIstio().EvalFile(ns, args, authz).ApplyOrFail(t, resource.Wait)
 }
 
 func verifyAccessLog(t framework.TestContext, cltInstance echo.Instance, wantLog string) error {

--- a/tests/integration/telemetry/stackdriver/vm/main_test.go
+++ b/tests/integration/telemetry/stackdriver/vm/main_test.go
@@ -171,10 +171,10 @@ func testSetup(ctx resource.Context) error {
 	}
 	sdtest.SDInst = sdInst
 
-	if err = ctx.ConfigKube().EvalFile(map[string]interface{}{
+	if err = ctx.ConfigKube().EvalFile(ns.Name(), map[string]interface{}{
 		"StackdriverAddress": sdInst.Address(),
 		"EchoNamespace":      ns.Name(),
-	}, stackdriverBootstrapOverride).Apply(ns.Name()); err != nil {
+	}, stackdriverBootstrapOverride).Apply(); err != nil {
 		return err
 	}
 

--- a/tests/integration/telemetry/stackdriver/vm/vm_test.go
+++ b/tests/integration/telemetry/stackdriver/vm/vm_test.go
@@ -44,7 +44,7 @@ func TestVMTelemetry(t *testing.T) {
 		Run(func(t framework.TestContext) {
 			// Set up strict mTLS. This gives a bit more assurance the calls are actually going through envoy,
 			// and certs are set up correctly.
-			t.ConfigIstio().YAML(enforceMTLS).ApplyOrFail(t, ns.Name())
+			t.ConfigIstio().YAML(ns.Name(), enforceMTLS).ApplyOrFail(t)
 
 			clientBuilder.BuildOrFail(t)
 			serverBuilder.BuildOrFail(t)

--- a/tests/integration/telemetry/stats/prometheus/api/stats_wasm_filter_test.go
+++ b/tests/integration/telemetry/stats/prometheus/api/stats_wasm_filter_test.go
@@ -46,7 +46,7 @@ func TestMain(m *testing.M) {
 			if err != nil {
 				return err
 			}
-			return ctx.ConfigIstio().YAML(`
+			return ctx.ConfigIstio().YAML(i.Settings().SystemNamespace, `
 apiVersion: telemetry.istio.io/v1alpha1
 kind: Telemetry
 metadata:
@@ -55,7 +55,7 @@ spec:
   metrics:
   - providers:
     - name: prometheus
-`).Apply(i.Settings().SystemNamespace)
+`).Apply()
 		}).
 		Setup(common.TestSetup).
 		Run()

--- a/tests/integration/telemetry/stats/prometheus/customizemetrics/customize_metrics_test.go
+++ b/tests/integration/telemetry/stats/prometheus/customizemetrics/customize_metrics_test.go
@@ -217,7 +217,7 @@ func setupEnvoyFilter(ctx resource.Context) error {
 		"WasmRemoteLoad":  useRemoteWasmModule,
 		"AttributeGenURL": attrGenURL,
 	}
-	if err := ctx.ConfigIstio().EvalFile(args, "testdata/attributegen_envoy_filter.yaml").Apply(appNsInst.Name()); err != nil {
+	if err := ctx.ConfigIstio().EvalFile(appNsInst.Name(), args, "testdata/attributegen_envoy_filter.yaml").Apply(); err != nil {
 		return err
 	}
 
@@ -239,7 +239,7 @@ spec:
             - regex: "(custom_dimension=\\.=(.*?);\\.;)"
               tag_name: "custom_dimension"
 `
-	if err := ctx.ConfigIstio().YAML(bootstrapPatch).Apply("istio-system", resource.Wait); err != nil {
+	if err := ctx.ConfigIstio().YAML("istio-system", bootstrapPatch).Apply(resource.Wait); err != nil {
 		return err
 	}
 	return nil

--- a/tests/integration/telemetry/stats/prometheus/nullvm/accesslogs_test.go
+++ b/tests/integration/telemetry/stats/prometheus/nullvm/accesslogs_test.go
@@ -69,7 +69,7 @@ spec:
   accessLogging:
   - disabled: %v
 `, !expectLogs)
-	t.ConfigIstio().YAML(config).ApplyOrFail(t, common.GetAppNamespace().Name())
+	t.ConfigIstio().YAML(common.GetAppNamespace().Name(), config).ApplyOrFail(t)
 	testID := rand.String(16)
 	to := common.GetTarget()
 	callCount := util.CallsPerCluster * to.WorkloadsOrFail(t).Len()

--- a/tests/integration/telemetry/stats/prometheus/nullvm/dashboard_test.go
+++ b/tests/integration/telemetry/stats/prometheus/nullvm/dashboard_test.go
@@ -138,15 +138,15 @@ func TestDashboard(t *testing.T) {
 		Run(func(t framework.TestContext) {
 			p := common.GetPromInstance()
 
-			t.ConfigIstio().YAML(fmt.Sprintf(gatewayConfig, common.GetAppNamespace().Name())).
-				ApplyOrFail(t, common.GetAppNamespace().Name())
+			t.ConfigIstio().YAML(common.GetAppNamespace().Name(), fmt.Sprintf(gatewayConfig, common.GetAppNamespace().Name())).
+				ApplyOrFail(t)
 
 			// Apply just the grafana dashboards
 			cfg, err := os.ReadFile(filepath.Join(env.IstioSrc, "samples/addons/grafana.yaml"))
 			if err != nil {
 				t.Fatal(err)
 			}
-			t.ConfigKube().YAML(yml.SplitYamlByKind(string(cfg))["ConfigMap"]).ApplyOrFail(t, "istio-system")
+			t.ConfigKube().YAML("istio-system", yml.SplitYamlByKind(string(cfg))["ConfigMap"]).ApplyOrFail(t)
 
 			// We will send a bunch of requests until the test exits. This ensures we are continuously
 			// getting new metrics ingested. If we just send a bunch at once, Prometheus may scrape them

--- a/tests/integration/telemetry/stats/prometheus/stats.go
+++ b/tests/integration/telemetry/stats/prometheus/stats.go
@@ -98,7 +98,7 @@ func TestStatsFilter(t *testing.T, feature features.Feature) {
 		Features(feature).
 		Run(func(t framework.TestContext) {
 			// Enable strict mTLS. This is needed for mock secured prometheus scraping test.
-			t.ConfigIstio().YAML(PeerAuthenticationConfig).ApplyOrFail(t, ist.Settings().SystemNamespace)
+			t.ConfigIstio().YAML(ist.Settings().SystemNamespace, PeerAuthenticationConfig).ApplyOrFail(t)
 			g, _ := errgroup.WithContext(context.Background())
 			for _, cltInstance := range client {
 				cltInstance := cltInstance

--- a/tests/integration/telemetry/stats/prometheus/wasm/bad_wasm_filter_test.go
+++ b/tests/integration/telemetry/stats/prometheus/wasm/bad_wasm_filter_test.go
@@ -51,7 +51,7 @@ func TestBadWasmRemoteLoad(t *testing.T) {
 			t.Log("echo server returns OK, apply bad wasm remote load filter.")
 
 			// Apply bad filter config
-			t.ConfigIstio().File("testdata/bad-filter.yaml").ApplyOrFail(t, common.GetAppNamespace().Name())
+			t.ConfigIstio().File(common.GetAppNamespace().Name(), "testdata/bad-filter.yaml").ApplyOrFail(t)
 
 			// Wait until there is agent metrics for wasm download failure
 			retry.UntilSuccessOrFail(t, func() error {


### PR DESCRIPTION
When pushing config to real clusters, each push can take several seconds. These times can stack pretty quickly when pushing a lot of config, which happens from some tests.

The new authz tests in https://github.com/istio/istio/pull/37914, push a lot of config at once. With this change, the config push time on GKE goes from ~1 minute to 5 seconds.

**Please provide a description of this PR:**