### PR TITLE
pilot: use correct Request.Start for Delta XDS

### DIFF
--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -234,6 +234,9 @@ func (s *DiscoveryServer) processRequest(req *discovery.DiscoveryRequest, con *C
 	}
 
 	request.Reason = append(request.Reason, model.ProxyRequest)
+	// The usage of LastPushTime (rather than time.Now()), is critical here for correctness; This time
+	// is used by the XDS cache to determine if a entry is stale. If we use Now() with an old push context,
+	// we may end up overriding active cache entries with stale ones.
 	request.Start = con.proxy.LastPushTime
 	// SidecarScope for the proxy may not have been updated based on this pushContext.
 	// It can happen when `processRequest` comes after push context has been updated(s.initPushContext),

--- a/pilot/pkg/xds/delta.go
+++ b/pilot/pkg/xds/delta.go
@@ -310,7 +310,10 @@ func (s *DiscoveryServer) processDeltaRequest(req *discovery.DeltaDiscoveryReque
 	}
 
 	request.Reason = append(request.Reason, model.ProxyRequest)
-	request.Start = time.Now()
+	// The usage of LastPushTime (rather than time.Now()), is critical here for correctness; This time
+	// is used by the XDS cache to determine if a entry is stale. If we use Now() with an old push context,
+	// we may end up overriding active cache entries with stale ones.
+	request.Start = con.proxy.LastPushTime
 	// SidecarScope for the proxy may has not been updated based on this pushContext.
 	// It can happen when `processRequest` comes after push context has been updated(s.initPushContext),
 	// but before proxy's SidecarScope has been updated(s.updateProxy).


### PR DESCRIPTION
https://github.com/istio/istio/pull/37800 changed which PushContext we
use; however, it had a bug which caused some rare test instability,
primarily in TestTraffic. In the initiate attempt at the change above, a
similar issue occurred, but with a much higher rate of error
(https://github.com/istio/istio/pull/37604).

Unfortunately, we forgot to apply the same fix to the Delta code path.
This PR does that, eliminating the last test flakes.

I ran this PR and `master` against the assertion tests 100s of times
overnight. Without this change it failed about 5% of the time; with it
0% (due to this issue - a few unrelated test flakes did occur).

Long term, this split code path with Delta and SotW is a risk. This was
a known risk, intentionally favoring possible code drift over
destabilizing the primary code (SotW). I think now that we are on Go
1.18 we can move over to generics fairly soon, and much of this risk
  will be mitigated.

**Please provide a description of this PR:**