### PR TITLE
tf: optimize config apply by reusing discovery cache

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -48,7 +48,6 @@ import (
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/discovery"
-	"k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
@@ -60,7 +59,6 @@ import (
 	metadatafake "k8s.io/client-go/metadata/fake"
 	"k8s.io/client-go/metadata/metadatainformer"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/restmapper"
 	clienttesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
@@ -367,7 +365,10 @@ func newClientInternal(clientFactory util.Factory, revision string) (*client, er
 	if err != nil {
 		return nil, err
 	}
-	c.mapper = restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(c.discoveryClient))
+	c.mapper, err = clientFactory.ToRESTMapper()
+	if err != nil {
+		return nil, err
+	}
 
 	c.Interface, err = kubernetes.NewForConfig(c.config)
 	c.kube = c.Interface

--- a/pkg/kube/client_factory.go
+++ b/pkg/kube/client_factory.go
@@ -15,6 +15,8 @@
 package kube
 
 import (
+	"sync"
+
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/discovery"
@@ -35,6 +37,13 @@ var _ util.Factory = &clientFactory{}
 type clientFactory struct {
 	clientConfig clientcmd.ClientConfig
 	factory      util.Factory
+
+	mapperOnce sync.Once
+	mapper     *restmapper.DeferredDiscoveryRESTMapper
+	expander   meta.RESTMapper
+
+	discoveryOnce   sync.Once
+	discoveryClient discovery.CachedDiscoveryInterface
 }
 
 // newClientFactory creates a new util.Factory from the given clientcmd.ClientConfig.
@@ -56,15 +65,18 @@ func (c *clientFactory) ToRESTConfig() (*rest.Config, error) {
 }
 
 func (c *clientFactory) ToDiscoveryClient() (discovery.CachedDiscoveryInterface, error) {
-	restConfig, err := c.ToRESTConfig()
-	if err != nil {
-		return nil, err
-	}
-	d, err := discovery.NewDiscoveryClientForConfig(restConfig)
-	if err != nil {
-		return nil, err
-	}
-	return memory.NewMemCacheClient(d), nil
+	c.discoveryOnce.Do(func() {
+		restConfig, err := c.ToRESTConfig()
+		if err != nil {
+			return
+		}
+		d, err := discovery.NewDiscoveryClientForConfig(restConfig)
+		if err != nil {
+			return
+		}
+		c.discoveryClient = memory.NewMemCacheClient(d)
+	})
+	return c.discoveryClient, nil
 }
 
 func (c *clientFactory) ToRESTMapper() (meta.RESTMapper, error) {
@@ -72,9 +84,11 @@ func (c *clientFactory) ToRESTMapper() (meta.RESTMapper, error) {
 	if err != nil {
 		return nil, err
 	}
-	mapper := restmapper.NewDeferredDiscoveryRESTMapper(discoveryClient)
-	expander := restmapper.NewShortcutExpander(mapper, discoveryClient)
-	return expander, nil
+	c.mapperOnce.Do(func() {
+		c.mapper = restmapper.NewDeferredDiscoveryRESTMapper(discoveryClient)
+		c.expander = restmapper.NewShortcutExpander(c.mapper, discoveryClient)
+	})
+	return c.expander, nil
 }
 
 func (c *clientFactory) ToRawKubeConfigLoader() clientcmd.ClientConfig {


### PR DESCRIPTION
Relates to https://github.com/istio/istio/pull/38024 - I think we should
do both, since each config apply still takes about 250ms on my machine
to GKE with this. With https://github.com/howardjohn/kubeconfig-proxy it
is down to 125ms; I didn't specifically measure this PR + parallel
apply.

Basically the problem is we do resource discovery on EVERY call to apply
YAML, since our discovery cache is not shared. This discovery makes like
50 API server calls each time, which is very slow.

With this caching, the following test is >10x faster:

```go

func TestApplyYAML(t *testing.T) {
  cfgs := file.ReadDirOrFail(t, filepath.Join(testenv.IstioSrc, "tests/integration/security/testdata"), ".yaml")
  client, err := NewExtendedClient(BuildClientCmd("", ""), "")
  if err != nil {
    t.Fatal(err)
  }
  t.Log(client.ApplyYAMLFiles("testns", cfgs...))
}
```

**Please provide a description of this PR:**



**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
