### PR TITLE
Changes log level to debug while fetching AWS info and typo fix

### DIFF
--- a/pkg/bootstrap/platform/aws.go
+++ b/pkg/bootstrap/platform/aws.go
@@ -98,7 +98,7 @@ func getAWSInfo(path string, ipv6 bool) (string, error) {
 
 	resp, err := http.DoHTTPGetWithTimeout(url, time.Millisecond*100)
 	if err != nil {
-		log.Errorf("error in getting aws info for %s : %v", path, err)
+		log.Warnf("error in getting aws info for %s : %v", path, err)
 		return "", err
 	}
 	return resp.String(), nil

--- a/pkg/bootstrap/platform/aws.go
+++ b/pkg/bootstrap/platform/aws.go
@@ -98,7 +98,7 @@ func getAWSInfo(path string, ipv6 bool) (string, error) {
 
 	resp, err := http.DoHTTPGetWithTimeout(url, time.Millisecond*100)
 	if err != nil {
-		log.Warnf("error in getting aws info for %s : %v", path, err)
+		log.Debugf("error in getting aws info for %s : %v", path, err)
 		return "", err
 	}
 	return resp.String(), nil

--- a/pkg/bootstrap/platform/discovery.go
+++ b/pkg/bootstrap/platform/discovery.go
@@ -28,8 +28,8 @@ const (
 	numPlatforms   = 3
 )
 
-var CloudPlatform = env.RegisterStringVar("CLOUD_PLATFORM", "", "Clound Platform on which proxy is running, if not specified,"+
-	"Istio will try to discover the platform. Valid platform values aws,azure,gcp,none.").Get()
+var CloudPlatform = env.RegisterStringVar("CLOUD_PLATFORM", "", "Cloud Platform on which proxy is running, if not specified, "+
+	"Istio will try to discover the platform. Valid platform values are aws, azure, gcp, none").Get()
 
 // Discover attempts to discover the host platform, defaulting to
 // `Unknown` if a platform cannot be discovered.


### PR DESCRIPTION
This PR changes the log level from error to 'debug' for AWSInfo error messages. It is not preferred to see these error logs everytime during startup. 
Fixed typo in "Cloud Platform"