### PR TITLE
Fix BUILD_WITH_CONTAINER=0 make docker.*

### DIFF
--- a/tools/istio-docker.mk
+++ b/tools/istio-docker.mk
@@ -57,7 +57,7 @@ dockerx: docker
 # Support individual images like `dockerx.pilot`
 
 # Docker commands defines some convenience targets
-define DOCKER_COMMANDS =
+define DOCKER_COMMANDS
 # Build individual docker image and push it. Ex: push.docker.pilot
 push.$(1): DOCKER_TARGETS=$(1)
 push.$(1): docker.push


### PR DESCRIPTION
**Please provide a description of this PR:**

BUILD_WITH_CONTAINER=0 make docker.* on a Mac (and maybe other platforms) yields:
```
make: *** No rule to make target `docker.*'.  Stop.
```
It seems the various docker targets aren't being created when run locally.

I notice an extra `=` on the new define, and removing that fixes the issue on the Mac.