### PR TITLE
make KinD multi-cluster better on Mac

### DIFF
--- a/pkg/test/framework/components/cluster/kube/cluster.go
+++ b/pkg/test/framework/components/cluster/kube/cluster.go
@@ -30,6 +30,9 @@ type Cluster struct {
 	// filename is the path to the kubeconfig file for this cluster.
 	filename string
 
+	// serverIP used to generate multi-cluster secrets
+	serverIP string
+
 	// vmSupport indicates the cluster is being used for fake VMs
 	vmSupport bool
 
@@ -38,6 +41,11 @@ type Cluster struct {
 
 	// Topology is embedded to include common functionality.
 	cluster.Topology
+}
+
+// APIServerIP for kubernetes. Can be used in multi-cluster access secrets.
+func (c *Cluster) APIServerIP() string {
+	return c.serverIP
 }
 
 // CanDeploy for a kube cluster returns true if the config is a non-vm, or if the cluster supports

--- a/pkg/test/framework/components/cluster/kube/factory.go
+++ b/pkg/test/framework/components/cluster/kube/factory.go
@@ -28,6 +28,7 @@ import (
 
 const (
 	kubeconfigMetaKey = "kubeconfig"
+	serverIPKey       = "serverIP"
 	vmSupportMetaKey  = "fakeVM"
 )
 
@@ -72,6 +73,7 @@ func buildKube(origCfg cluster.Config, topology cluster.Topology) (cluster.Clust
 
 	return &Cluster{
 		filename:       kubeconfigPath,
+		serverIP:       cfg.Meta.String(serverIPKey),
 		ExtendedClient: client,
 		vmSupport:      vmSupport,
 		Topology:       topology,

--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -848,6 +848,10 @@ func CreateRemoteSecret(ctx resource.Context, c cluster.Cluster, cfg Config, opt
 		"--namespace", cfg.SystemNamespace,
 		"--manifests", filepath.Join(testenv.IstioSrc, "manifests"),
 	}
+	if c, ok := c.(*kubecluster.Cluster); ok && c.APIServerIP() != "" {
+		cmd = append(cmd, "--server", c.APIServerIP())
+	}
+
 	cmd = append(cmd, opts...)
 
 	scopes.Framework.Infof("Creating remote secret for cluster %s %v", c.Name(), cmd)

--- a/prow/integ-suite-kind.sh
+++ b/prow/integ-suite-kind.sh
@@ -104,7 +104,11 @@ while (( "$#" )); do
 done
 
 echo "Checking CPU..."
-grep 'model' /proc/cpuinfo
+if [[ "${OSTYPE}" != 'darwin'* ]]; then
+  grep 'model' /proc/cpuinfo
+else
+  sysctl -a | grep brand_string
+fi
 
 # Default IP family of the cluster is IPv4
 export IP_FAMILY="${IP_FAMILY:-ipv4}"
@@ -151,7 +155,8 @@ if [[ -z "${SKIP_SETUP:-}" ]]; then
     for i in $(seq 0 $((${#CLUSTER_NAMES[@]} - 1))); do
       CLUSTER="${CLUSTER_NAMES[i]}"
       KCONFIG="${KUBECONFIGS[i]}"
-      TOPOLOGY_JSON=$(set_topology_value "${TOPOLOGY_JSON}" "${CLUSTER}" "meta.kubeconfig" "${KCONFIG}")
+      CLUSTER_IP="${CLUSTER_IPS[i]}"
+      TOPOLOGY_JSON=$(set_topology_value "${TOPOLOGY_JSON}" "${CLUSTER}" "meta.kubeconfig" "${KCONFIG}" "meta.serverIP", "${CLUSTER_IP}")
     done
     RUNTIME_TOPOLOGY_CONFIG_FILE="${ARTIFACTS}/topology-config.json"
     echo "${TOPOLOGY_JSON}" > "${RUNTIME_TOPOLOGY_CONFIG_FILE}"


### PR DESCRIPTION
This is WIP, haven't finished testing yet (pulling envoy, build-tools, etc is very slow for me on my current internet connection). 

Rather than modifying the kubeconfigs, here we pass the docker IPs to the framework, and the framework forwards them to the `create-remote-secret` command


Background:

We need the docker IP in the kubeconfig files since we use the kubeconfig file's server IP in `create-remote-secret`. 
The test runner also uses those files to apply configs and control the tests. 
A mac-hosted test-runner won't be able to use docker IPs. 


