### PR TITLE
eds: fix regression in removing healthy pods

### DIFF
--- a/pilot/pkg/xds/eds_test.go
+++ b/pilot/pkg/xds/eds_test.go
@@ -24,18 +24,19 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
-	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	uatomic "go.uber.org/atomic"
 
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking"
+	"istio.io/istio/pilot/pkg/util/sets"
 	"istio.io/istio/pilot/pkg/xds"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
 	"istio.io/istio/pilot/test/xdstest"
@@ -368,11 +369,40 @@ func TestEDSUnhealthyEndpoints(t *testing.T) {
 		t.Fatalf("Error in push %v", err)
 	}
 
-	// Validate that we do not send initial unhealthy endpoints.
-	lbe := adscon.GetEndpoints()["outbound|53||unhealthy.svc.cluster.local"]
-	if lbe != nil && len(lbe.Endpoints) != 0 {
-		t.Fatalf("initial unhealthy endpoints are not expected to be sent %s,  but got %v", "unhealthy.svc.cluster.local", adscon.EndpointsJSON())
+	validateEndpoints := func(expectPush bool, healthy []string, unhealthy []string) {
+		t.Helper()
+		// Normalize lists to make comparison easier
+		if healthy == nil {
+			healthy = []string{}
+		}
+		if unhealthy == nil {
+			unhealthy = []string{}
+		}
+		sort.Strings(healthy)
+		sort.Strings(unhealthy)
+		if expectPush {
+			upd, _ := adscon.Wait(5*time.Second, v3.EndpointType)
+
+			if len(upd) > 0 && !contains(upd, v3.EndpointType) {
+				t.Fatalf("Expecting EDS push as endpoint health is changed. But received %v", upd)
+			}
+		}
+
+		// Validate that endpoints are pushed.
+		lbe := adscon.GetEndpoints()["outbound|53||unhealthy.svc.cluster.local"]
+		eh, euh := xdstest.ExtractHealthEndpoints(lbe)
+		gotHealthy := sets.NewSet(eh...).SortedList()
+		gotUnhealthy := sets.NewSet(euh...).SortedList()
+		if !reflect.DeepEqual(gotHealthy, healthy) {
+			t.Fatalf("did not get expected endpoints: want %v, got %v", gotHealthy, healthy)
+		}
+		if !reflect.DeepEqual(gotUnhealthy, unhealthy) {
+			t.Fatalf("did not get expected unhealthy endpoints: want %v, got %v", gotUnhealthy, unhealthy)
+		}
 	}
+
+	// Validate that we do not send initial unhealthy endpoints.
+	validateEndpoints(false, nil, nil)
 	adscon.WaitClear()
 
 	// Set additional unhealthy endpoint and validate Eds update is not triggered.
@@ -393,10 +423,7 @@ func TestEDSUnhealthyEndpoints(t *testing.T) {
 		})
 
 	// Validate that endpoint is not pushed.
-	lbe = adscon.GetEndpoints()["outbound|53||unhealthy.svc.cluster.local"]
-	if lbe != nil && len(lbe.Endpoints) == 1 && len(lbe.Endpoints[0].LbEndpoints) > 1 {
-		t.Fatalf("one endpoint is expected for  %s,  but got %v", "unhealthy.svc.cluster.local", adscon.EndpointsJSON())
-	}
+	validateEndpoints(false, nil, nil)
 
 	// Change the status of endpoint to Healthy and validate Eds is pushed.
 	s.Discovery.MemRegistry.SetEndpoints("unhealthy.svc.cluster.local", "",
@@ -415,17 +442,8 @@ func TestEDSUnhealthyEndpoints(t *testing.T) {
 			},
 		})
 
-	upd, _ := adscon.Wait(5*time.Second, v3.EndpointType)
-
-	if len(upd) > 0 && !contains(upd, v3.EndpointType) {
-		t.Fatalf("Expecting EDS push as endpoint health is changed. But received %v", upd)
-	}
-
 	// Validate that endpoints are pushed.
-	lbe = adscon.GetEndpoints()["outbound|53||unhealthy.svc.cluster.local"]
-	if lbe != nil && len(lbe.Endpoints[0].LbEndpoints) != 2 {
-		t.Fatalf("two endpoints expected for  %s,  but got %v", "unhealthy.svc.cluster.local", adscon.EndpointsJSON())
-	}
+	validateEndpoints(true, []string{"10.0.0.53:53", "10.0.0.54:53"}, nil)
 
 	// Now change the status of endpoint to UnHealthy and validate Eds is pushed.
 	s.Discovery.MemRegistry.SetEndpoints("unhealthy.svc.cluster.local", "",
@@ -444,25 +462,40 @@ func TestEDSUnhealthyEndpoints(t *testing.T) {
 			},
 		})
 
-	upd, _ = adscon.Wait(5*time.Second, v3.EndpointType)
-
-	if len(upd) > 0 && !contains(upd, v3.EndpointType) {
-		t.Fatalf("Expecting EDS push as endpoint health is changed. But received %v", upd)
-	}
-
 	// Validate that endpoints are pushed.
-	lbe = adscon.GetEndpoints()["outbound|53||unhealthy.svc.cluster.local"]
-	if lbe != nil && len(lbe.Endpoints[0].LbEndpoints) != 2 {
-		t.Fatalf("two endpoints expected for  %s,  but got %v", "unhealthy.svc.cluster.local", adscon.EndpointsJSON())
-	}
+	validateEndpoints(true, []string{"10.0.0.54:53"}, []string{"10.0.0.53:53"})
 
-	// Validate that health status is updated correctly.
-	lbendpoints := lbe.Endpoints[0].LbEndpoints
-	for _, lbe := range lbendpoints {
-		if lbe.GetEndpoint().Address.GetSocketAddress().Address == "10.0.0.53" && lbe.HealthStatus != envoy_config_core_v3.HealthStatus_UNHEALTHY {
-			t.Fatal("expected endpoint to be unhealthy, but got healthy")
-		}
-	}
+	// Change the status of endpoint to Healthy and validate Eds is pushed.
+	s.Discovery.MemRegistry.SetEndpoints("unhealthy.svc.cluster.local", "",
+		[]*model.IstioEndpoint{
+			{
+				Address:         "10.0.0.53",
+				EndpointPort:    53,
+				ServicePortName: "tcp-dns",
+				HealthStatus:    model.Healthy,
+			},
+			{
+				Address:         "10.0.0.54",
+				EndpointPort:    53,
+				ServicePortName: "tcp-dns",
+				HealthStatus:    model.Healthy,
+			},
+		})
+
+	validateEndpoints(true, []string{"10.0.0.54:53", "10.0.0.53:53"}, nil)
+
+	// Remove a healthy endpoint
+	s.Discovery.MemRegistry.SetEndpoints("unhealthy.svc.cluster.local", "",
+		[]*model.IstioEndpoint{
+			{
+				Address:         "10.0.0.53",
+				EndpointPort:    53,
+				ServicePortName: "tcp-dns",
+				HealthStatus:    model.Healthy,
+			},
+		})
+
+	validateEndpoints(true, []string{"10.0.0.53:53"}, nil)
 }
 
 // Validates the behavior when Service resolution type is updated after initial EDS push.

--- a/pilot/test/xdstest/extract.go
+++ b/pilot/test/xdstest/extract.go
@@ -219,21 +219,38 @@ func ExtractLoadAssignments(cla []*endpoint.ClusterLoadAssignment) map[string][]
 	return got
 }
 
-func ExtractEndpoints(cla *endpoint.ClusterLoadAssignment) []string {
+// ExtractHealthEndpoints returns all health and unhealth endpoints
+func ExtractHealthEndpoints(cla *endpoint.ClusterLoadAssignment) ([]string, []string) {
 	if cla == nil {
-		return nil
+		return nil, nil
 	}
-	got := []string{}
+	healthy := []string{}
+	unhealthy := []string{}
 	for _, ep := range cla.Endpoints {
 		for _, lb := range ep.LbEndpoints {
-			if lb.GetEndpoint().Address.GetSocketAddress() != nil {
-				got = append(got, fmt.Sprintf("%s:%d", lb.GetEndpoint().Address.GetSocketAddress().Address, lb.GetEndpoint().Address.GetSocketAddress().GetPortValue()))
+			if lb.HealthStatus == core.HealthStatus_HEALTHY {
+				if lb.GetEndpoint().Address.GetSocketAddress() != nil {
+					healthy = append(healthy, fmt.Sprintf("%s:%d", lb.GetEndpoint().Address.GetSocketAddress().Address, lb.GetEndpoint().Address.GetSocketAddress().GetPortValue()))
+				} else {
+					healthy = append(healthy, lb.GetEndpoint().Address.GetPipe().Path)
+				}
 			} else {
-				got = append(got, lb.GetEndpoint().Address.GetPipe().Path)
+				if lb.GetEndpoint().Address.GetSocketAddress() != nil {
+					unhealthy = append(unhealthy, fmt.Sprintf("%s:%d", lb.GetEndpoint().Address.GetSocketAddress().Address, lb.GetEndpoint().Address.GetSocketAddress().GetPortValue()))
+				} else {
+					unhealthy = append(unhealthy, lb.GetEndpoint().Address.GetPipe().Path)
+				}
 			}
 		}
 	}
-	return got
+	return healthy, unhealthy
+}
+
+// ExtractEndpoints returns all endpoints in the load assignment (including unhealthy endpoints)
+func ExtractEndpoints(cla *endpoint.ClusterLoadAssignment) []string {
+	h, uh := ExtractHealthEndpoints(cla)
+	h = append(h, uh...)
+	return h
 }
 
 func ExtractClusters(cc []*cluster.Cluster) map[string]*cluster.Cluster {


### PR DESCRIPTION
There is a currently an issue where if a endpoint goes from Healthy to
deleted, we do not trigger a push. This manifests in our CI as 503s.

Added a test which triggers this case.

**Please provide a description of this PR:**



**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
