### PR TITLE
Ensure the read permission to all the regular files and directories.

### DIFF
--- a/tools/docker-copy.sh
+++ b/tools/docker-copy.sh
@@ -62,6 +62,8 @@ function may_copy_into_arch_named_sub_dir() {
     fi
 
   else
+    # For the regular files, give a read permission to all
+    chmod o+r ${FILE}
     cp -rp "${FILE}" "${DOCKER_WORKING_DIR}"
   fi
 }


### PR DESCRIPTION
Since `git` stores only the executable permission, all the other permissions of each file in git are affected by `umask`.
For example, if a user set umask with "027", then the normal files will be git-cloned with the permission like "-rw-r-----" (640). 

In current docker build of Istio, the file permission on docker images heavily depend on the permission on local filesystem, so the umask setting directly affects the file permission on docker images.
For details, please look at https://github.com/istio/istio/issues/37151

This PR proposes to add the read permission to all the non-executable files when copying the file to the docker build directory. By this way, the read permission can be ensured regardless of umask. 

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ * ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ * ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
