### PR TITLE
[TF] Make Echo resolve DNS for each request

### DIFF
--- a/pkg/test/echo/server/endpoint/grpc.go
+++ b/pkg/test/echo/server/endpoint/grpc.go
@@ -295,12 +295,11 @@ func (h *EchoGrpcHandler) ForwardEcho(ctx context.Context, req *proto.ForwardEch
 	t0 := time.Now()
 	instance, err := forwarder.New(forwarder.Config{
 		Request: req,
-		Dialer:  h.Dialer,
 	})
 	if err != nil {
 		return nil, err
 	}
-	defer instance.Close()
+	defer func() { _ = instance.Close() }()
 
 	ret, err := instance.Run(ctx)
 	if err == nil {

--- a/pkg/test/echo/server/forwarder/config.go
+++ b/pkg/test/echo/server/forwarder/config.go
@@ -1,0 +1,173 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package forwarder
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"istio.io/istio/pkg/test/echo/common"
+	"istio.io/istio/pkg/test/echo/common/scheme"
+	"istio.io/istio/pkg/test/echo/proto"
+)
+
+type Config struct {
+	Request *proto.ForwardEchoRequest
+	UDS     string
+	// XDSTestBootstrap, for gRPC forwarders, is used to set the bootstrap without using a global one defined in the env
+	XDSTestBootstrap []byte
+	// Http proxy used for connection
+	Proxy string
+
+	// Filled in values.
+	scheme               scheme.Instance
+	tlsConfig            *tls.Config
+	getClientCertificate func(info *tls.CertificateRequestInfo) (*tls.Certificate, error)
+	checkRedirect        func(req *http.Request, via []*http.Request) error
+	proxyURL             func(*http.Request) (*url.URL, error)
+	timeout              time.Duration
+	count                int
+	headers              http.Header
+}
+
+func (c *Config) fillDefaults() error {
+	c.checkRedirect = checkRedirectFunc(c.Request)
+	c.timeout = common.GetTimeout(c.Request)
+	c.count = common.GetCount(c.Request)
+	c.headers = common.GetHeaders(c.Request)
+
+	if i := strings.IndexByte(c.Request.Url, ':'); i > 0 {
+		c.scheme = scheme.Instance(strings.ToLower(c.Request.Url[0:i]))
+	} else {
+		return fmt.Errorf("missing protocol scheme in the request URL: %s", c.Request.Url)
+	}
+
+	var err error
+	c.getClientCertificate, err = getClientCertificateFunc(c.Request)
+	if err != nil {
+		return err
+	}
+	c.tlsConfig, err = newTLSConfig(c.Request, c.getClientCertificate)
+	if err != nil {
+		return err
+	}
+
+	// Parse the proxy if specified.
+	if len(c.Proxy) > 0 {
+		proxyURL, err := url.Parse(c.Proxy)
+		if err != nil {
+			return err
+		}
+
+		c.proxyURL = http.ProxyURL(proxyURL)
+	}
+
+	return nil
+}
+
+func getClientCertificateFunc(r *proto.ForwardEchoRequest) (func(info *tls.CertificateRequestInfo) (*tls.Certificate, error), error) {
+	if r.KeyFile != "" && r.CertFile != "" {
+		certData, err := os.ReadFile(r.CertFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load client certificate: %v", err)
+		}
+		r.Cert = string(certData)
+		keyData, err := os.ReadFile(r.KeyFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load client certificate key: %v", err)
+		}
+		r.Key = string(keyData)
+	}
+
+	if r.Cert != "" && r.Key != "" {
+		cert, err := tls.X509KeyPair([]byte(r.Cert), []byte(r.Key))
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse x509 key pair: %v", err)
+		}
+
+		for _, c := range cert.Certificate {
+			cert, err := x509.ParseCertificate(c)
+			if err != nil {
+				fwLog.Errorf("Failed to parse client certificate: %v", err)
+			}
+			fwLog.Debugf("Using client certificate [%s] issued by %s", cert.SerialNumber, cert.Issuer)
+			for _, uri := range cert.URIs {
+				fwLog.Debugf("  URI SAN: %s", uri)
+			}
+		}
+		// nolint: unparam
+		return func(info *tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			fwLog.Debugf("Peer asking for client certificate")
+			for i, ca := range info.AcceptableCAs {
+				x := &pkix.RDNSequence{}
+				if _, err := asn1.Unmarshal(ca, x); err != nil {
+					fwLog.Errorf("Failed to decode AcceptableCA[%d]: %v", i, err)
+				} else {
+					name := &pkix.Name{}
+					name.FillFromRDNSequence(x)
+					fwLog.Debugf("  AcceptableCA[%d]: %s", i, name)
+				}
+			}
+
+			return &cert, nil
+		}, nil
+	}
+
+	return nil, nil
+}
+
+func newTLSConfig(r *proto.ForwardEchoRequest, getClientCertificate func(info *tls.CertificateRequestInfo) (*tls.Certificate, error)) (*tls.Config, error) {
+	tlsConfig := &tls.Config{
+		GetClientCertificate: getClientCertificate,
+		NextProtos:           r.GetAlpn().GetValue(),
+		ServerName:           r.ServerName,
+	}
+	if r.CaCertFile != "" {
+		certData, err := os.ReadFile(r.CaCertFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load client certificate: %v", err)
+		}
+		r.CaCert = string(certData)
+	}
+	if r.InsecureSkipVerify || r.CaCert == "" {
+		tlsConfig.InsecureSkipVerify = true
+	} else if r.CaCert != "" {
+		certPool := x509.NewCertPool()
+		if !certPool.AppendCertsFromPEM([]byte(r.CaCert)) {
+			return nil, fmt.Errorf("failed to create cert pool")
+		}
+		tlsConfig.RootCAs = certPool
+	}
+	return tlsConfig, nil
+}
+
+func checkRedirectFunc(req *proto.ForwardEchoRequest) func(req *http.Request, via []*http.Request) error {
+	if req.FollowRedirects {
+		return nil
+	}
+
+	return func(req *http.Request, via []*http.Request) error {
+		// Disable redirects
+		return http.ErrUseLastResponse
+	}
+}

--- a/pkg/test/echo/server/forwarder/dns.go
+++ b/pkg/test/echo/server/forwarder/dns.go
@@ -76,23 +76,7 @@ func (c *dnsProtocol) makeRequest(ctx context.Context, rreq *request) (string, e
 	if err != nil {
 		return "", err
 	}
-	r := &net.Resolver{
-		PreferGo: true,
-		Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
-			d := net.Dialer{
-				Timeout: rreq.Timeout,
-			}
-			nt := req.protocol
-			if nt == "" {
-				nt = network
-			}
-			addr := req.dnsServer
-			if addr == "" {
-				addr = address
-			}
-			return d.DialContext(ctx, nt, addr)
-		},
-	}
+	r := newResolver(rreq.Timeout, req.protocol, req.dnsServer)
 	nt := func() string {
 		switch req.query {
 		case "A":

--- a/pkg/test/echo/server/forwarder/protocol.go
+++ b/pkg/test/echo/server/forwarder/protocol.go
@@ -18,32 +18,13 @@ package forwarder
 
 import (
 	"context"
-	"crypto/tls"
-	"crypto/x509"
-	"crypto/x509/pkix"
-	"encoding/asn1"
 	"fmt"
-	"net"
 	"net/http"
-	"net/url"
-	"os"
-	"strings"
 	"time"
 
-	"github.com/gorilla/websocket"
-	"github.com/lucas-clemente/quic-go"
-	"github.com/lucas-clemente/quic-go/http3"
-	"golang.org/x/net/http2"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/grpc/credentials/xds"
-	xdsresolver "google.golang.org/grpc/xds"
 	wrappers "google.golang.org/protobuf/types/known/wrapperspb"
 
-	"istio.io/istio/pkg/test/echo/common"
 	"istio.io/istio/pkg/test/echo/common/scheme"
-	"istio.io/istio/pkg/test/echo/proto"
 )
 
 type request struct {
@@ -62,253 +43,23 @@ type protocol interface {
 	Close() error
 }
 
-func newProtocol(cfg Config) (protocol, error) {
-	var httpDialContext func(ctx context.Context, network, addr string) (net.Conn, error)
-	var wsDialContext func(network, addr string) (net.Conn, error)
-	if len(cfg.UDS) > 0 {
-		httpDialContext = func(_ context.Context, _, _ string) (net.Conn, error) {
-			return net.Dial("unix", cfg.UDS)
-		}
-
-		wsDialContext = func(_, _ string) (net.Conn, error) {
-			return net.Dial("unix", cfg.UDS)
-		}
-	}
-
-	// Do not use url.Parse() as it will fail to parse paths with invalid encoding that we intentionally used in the test.
-	rawURL := cfg.Request.Url
-	var urlScheme string
-	if i := strings.IndexByte(rawURL, ':'); i > 0 {
-		urlScheme = strings.ToLower(rawURL[0:i])
-	} else {
-		return nil, fmt.Errorf("missing protocol scheme in the request URL: %s", rawURL)
-	}
-
-	timeout := common.GetTimeout(cfg.Request)
-	headers := common.GetHeaders(cfg.Request)
-
-	var getClientCertificate func(info *tls.CertificateRequestInfo) (*tls.Certificate, error)
-	if cfg.Request.KeyFile != "" && cfg.Request.CertFile != "" {
-		certData, err := os.ReadFile(cfg.Request.CertFile)
-		if err != nil {
-			return nil, fmt.Errorf("failed to load client certificate: %v", err)
-		}
-		cfg.Request.Cert = string(certData)
-		keyData, err := os.ReadFile(cfg.Request.KeyFile)
-		if err != nil {
-			return nil, fmt.Errorf("failed to load client certificate key: %v", err)
-		}
-		cfg.Request.Key = string(keyData)
-	}
-	if cfg.Request.Cert != "" && cfg.Request.Key != "" {
-		cert, err := tls.X509KeyPair([]byte(cfg.Request.Cert), []byte(cfg.Request.Key))
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse x509 key pair: %v", err)
-		}
-
-		for _, c := range cert.Certificate {
-			cert, err := x509.ParseCertificate(c)
-			if err != nil {
-				fwLog.Errorf("Failed to parse client certificate: %v", err)
-			}
-			fwLog.Debugf("Using client certificate [%s] issued by %s", cert.SerialNumber, cert.Issuer)
-			for _, uri := range cert.URIs {
-				fwLog.Debugf("  URI SAN: %s", uri)
-			}
-		}
-		// nolint: unparam
-		getClientCertificate = func(info *tls.CertificateRequestInfo) (*tls.Certificate, error) {
-			fwLog.Debugf("Peer asking for client certificate")
-			for i, ca := range info.AcceptableCAs {
-				x := &pkix.RDNSequence{}
-				if _, err := asn1.Unmarshal(ca, x); err != nil {
-					fwLog.Errorf("Failed to decode AcceptableCA[%d]: %v", i, err)
-				} else {
-					name := &pkix.Name{}
-					name.FillFromRDNSequence(x)
-					fwLog.Debugf("  AcceptableCA[%d]: %s", i, name)
-				}
-			}
-
-			return &cert, nil
-		}
-	}
-	tlsConfig := &tls.Config{
-		GetClientCertificate: getClientCertificate,
-		NextProtos:           cfg.Request.GetAlpn().GetValue(),
-		ServerName:           cfg.Request.ServerName,
-	}
-	if cfg.Request.CaCertFile != "" {
-		certData, err := os.ReadFile(cfg.Request.CaCertFile)
-		if err != nil {
-			return nil, fmt.Errorf("failed to load client certificate: %v", err)
-		}
-		cfg.Request.CaCert = string(certData)
-	}
-	if cfg.Request.InsecureSkipVerify || cfg.Request.CaCert == "" {
-		tlsConfig.InsecureSkipVerify = true
-	} else if cfg.Request.CaCert != "" {
-		certPool := x509.NewCertPool()
-		if !certPool.AppendCertsFromPEM([]byte(cfg.Request.CaCert)) {
-			return nil, fmt.Errorf("failed to create cert pool")
-		}
-		tlsConfig.RootCAs = certPool
-	}
-
-	// Disable redirects
-	redirectFn := func(req *http.Request, via []*http.Request) error {
-		return http.ErrUseLastResponse
-	}
-	if cfg.Request.FollowRedirects {
-		redirectFn = nil
-	}
-	switch s := scheme.Instance(urlScheme); s {
+func newProtocol(cfg *Config) (protocol, error) {
+	switch cfg.scheme {
 	case scheme.HTTP, scheme.HTTPS:
-		if cfg.Request.Alpn == nil {
-			tlsConfig.NextProtos = []string{"http/1.1"}
-		}
-		proto := &httpProtocol{
-			client: &http.Client{
-				CheckRedirect: redirectFn,
-				Transport: &http.Transport{
-					// We are creating a Transport on each ForwardEcho request. Transport is what holds connections,
-					// so this means every ForwardEcho request will create a new connection. Without setting an idle timeout,
-					// we would never close these connections.
-					IdleConnTimeout: time.Second,
-					TLSClientConfig: tlsConfig,
-					DialContext:     httpDialContext,
-					Proxy:           http.ProxyFromEnvironment,
-				},
-				Timeout: timeout,
-			},
-			do: cfg.Dialer.HTTP,
-		}
-		if len(cfg.Proxy) > 0 {
-			proxyURL, err := url.Parse(cfg.Proxy)
-			if err != nil {
-				return nil, err
-			}
-			proto.client.Transport.(*http.Transport).Proxy = http.ProxyURL(proxyURL)
-		}
-		if cfg.Request.Http3 && scheme.Instance(urlScheme) == scheme.HTTP {
-			return nil, fmt.Errorf("http3 requires HTTPS")
-		} else if cfg.Request.Http3 {
-			proto.client.Transport = &http3.RoundTripper{
-				TLSClientConfig: tlsConfig,
-				QuicConfig:      &quic.Config{},
-			}
-		} else if cfg.Request.Http2 && scheme.Instance(urlScheme) == scheme.HTTPS {
-			if cfg.Request.Alpn == nil {
-				tlsConfig.NextProtos = []string{"h2"}
-			}
-			proto.client.Transport = &http2.Transport{
-				TLSClientConfig: tlsConfig,
-				DialTLS: func(network, addr string, cfg *tls.Config) (net.Conn, error) {
-					return tls.Dial(network, addr, cfg)
-				},
-			}
-		} else if cfg.Request.Http2 {
-			proto.client.Transport = &http2.Transport{
-				// Golang doesn't have first class support for h2c, so we provide some workarounds
-				// See https://www.mailgun.com/blog/http-2-cleartext-h2c-client-example-go/
-				// So http2.Transport doesn't complain the URL scheme isn't 'https'
-				AllowHTTP: true,
-				// Pretend we are dialing a TLS endpoint. (Note, we ignore the passed tls.Config)
-				DialTLS: func(network, addr string, cfg *tls.Config) (net.Conn, error) {
-					return net.Dial(network, addr)
-				},
-			}
-		}
-		return proto, nil
-	case scheme.GRPC, scheme.XDS:
-		// NOTE: XDS load-balancing happens per-ForwardEchoRequest since we create a new client each time
-
-		var opts []grpc.DialOption
-		// grpc-go sets incorrect authority header
-
-		// transport security
-		security := grpc.WithTransportCredentials(insecure.NewCredentials())
-		if s == scheme.XDS {
-			creds, err := xds.NewClientCredentials(xds.ClientOptions{FallbackCreds: insecure.NewCredentials()})
-			if err != nil {
-				return nil, err
-			}
-			security = grpc.WithTransportCredentials(creds)
-			if len(cfg.XDSTestBootstrap) > 0 {
-				resolver, err := xdsresolver.NewXDSResolverWithConfigForTesting(cfg.XDSTestBootstrap)
-				if err != nil {
-					return nil, err
-				}
-				opts = append(opts, grpc.WithResolvers(resolver))
-			}
-		}
-
-		if getClientCertificate != nil {
-			security = grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))
-		}
-
-		// Strip off the scheme from the address (for regular gRPC).
-		address := rawURL
-		if urlScheme == string(scheme.GRPC) {
-			address = rawURL[len(urlScheme+"://"):]
-		}
-
-		// Connect to the GRPC server.
-		ctx, cancel := context.WithTimeout(context.Background(), common.ConnectionTimeout)
-		defer cancel()
-		opts = append(opts, security, grpc.WithAuthority(headers.Get(hostHeader)))
-		grpcConn, err := cfg.Dialer.GRPC(ctx, address, opts...)
-		if err != nil {
-			return nil, err
-		}
-		return &grpcProtocol{
-			conn:   grpcConn,
-			client: proto.NewEchoTestServiceClient(grpcConn),
-		}, nil
+		return newHTTPProtocol(cfg)
+	case scheme.GRPC:
+		return newGRPCProtocol(cfg)
+	case scheme.XDS:
+		return newXDSProtocol(cfg)
 	case scheme.WebSocket:
-		dialer := &websocket.Dialer{
-			TLSClientConfig:  tlsConfig,
-			NetDial:          wsDialContext,
-			HandshakeTimeout: timeout,
-		}
-		return &websocketProtocol{
-			dialer: dialer,
-		}, nil
+		return newWebsocketProtocol(cfg)
 	case scheme.DNS:
 		return &dnsProtocol{}, nil
 	case scheme.TCP:
-		return &tcpProtocol{
-			conn: func() (net.Conn, error) {
-				dialer := net.Dialer{
-					Timeout: timeout,
-				}
-				address := rawURL[len(urlScheme+"://"):]
-
-				ctx, cancel := context.WithTimeout(context.Background(), common.ConnectionTimeout)
-				defer cancel()
-
-				if getClientCertificate == nil {
-					return cfg.Dialer.TCP(dialer, ctx, address)
-				}
-				return tls.Dial("tcp", address, tlsConfig)
-			},
-		}, nil
+		return newTCPProtocol(cfg)
 	case scheme.TLS:
-		return &tlsProtocol{
-			conn: func() (*tls.Conn, error) {
-				dialer := net.Dialer{
-					Timeout: timeout,
-				}
-				address := rawURL[len(urlScheme+"://"):]
-
-				con, err := tls.DialWithDialer(&dialer, "tcp", address, tlsConfig)
-				if err != nil {
-					return nil, err
-				}
-				return con, nil
-			},
-		}, nil
+		return newTLSProtocol(cfg)
+	default:
+		return nil, fmt.Errorf("unrecognized protocol %q", cfg.scheme)
 	}
-
-	return nil, fmt.Errorf("unrecognized protocol %q", urlScheme)
 }

--- a/pkg/test/echo/server/forwarder/xds.go
+++ b/pkg/test/echo/server/forwarder/xds.go
@@ -1,0 +1,79 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package forwarder
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/credentials/xds"
+	xdsresolver "google.golang.org/grpc/xds"
+
+	"istio.io/istio/pkg/test/echo/common"
+)
+
+var _ protocol = &grpcProtocol{}
+
+type xdsProtocol struct {
+	conn *grpc.ClientConn
+}
+
+func newXDSProtocol(r *Config) (protocol, error) {
+	var opts []grpc.DialOption
+	// grpc-go sets incorrect authority header
+
+	// transport security
+	creds, err := xds.NewClientCredentials(xds.ClientOptions{FallbackCreds: insecure.NewCredentials()})
+	if err != nil {
+		return nil, err
+	}
+	security := grpc.WithTransportCredentials(creds)
+	if len(r.XDSTestBootstrap) > 0 {
+		r, err := xdsresolver.NewXDSResolverWithConfigForTesting(r.XDSTestBootstrap)
+		if err != nil {
+			return nil, err
+		}
+		opts = append(opts, grpc.WithResolvers(r))
+	}
+
+	if r.getClientCertificate != nil {
+		security = grpc.WithTransportCredentials(credentials.NewTLS(r.tlsConfig))
+	}
+
+	address := r.Request.Url
+
+	// Connect to the GRPC server.
+	ctx, cancel := context.WithTimeout(context.Background(), common.ConnectionTimeout)
+	defer cancel()
+	opts = append(opts, security, grpc.WithAuthority(r.headers.Get(hostHeader)))
+	conn, err := grpc.DialContext(ctx, address, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return &xdsProtocol{
+		conn: conn,
+	}, nil
+}
+
+func (c *xdsProtocol) makeRequest(ctx context.Context, req *request) (string, error) {
+	return makeGRPCRequest(ctx, c.conn, req)
+}
+
+func (c *xdsProtocol) Close() error {
+	return c.conn.Close()
+}


### PR DESCRIPTION
Headless tests fail for multicluster in #37914 because only the headless workload in the local cluster is reached.

When making individual forward requests from the command line, the requests toggle properly. This means that there must be some caching of DNS lookup within the Dialer.

This change forces the creation of a new Dialer and Resolver for each request.

With this change, the headless tests correctly reach all clusters.

Fixes #38023

**Please provide a description of this PR:**