### PR TITLE
Fix dr dependency miss

### DIFF
--- a/pilot/pkg/model/config.go
+++ b/pilot/pkg/model/config.go
@@ -282,7 +282,7 @@ func resolveGatewayName(gwname string, meta config.Meta) string {
 
 // MostSpecificHostMatch compares the map of the stack to the needle, and returns the longest element
 // matching the needle, or false if no element in the map matches the needle.
-func MostSpecificHostMatch(needle host.Name, m map[host.Name][]*config.Config) (host.Name, bool) {
+func MostSpecificHostMatch(needle host.Name, m map[host.Name][]*consolidatedDestRule) (host.Name, bool) {
 	matches := []host.Name{}
 
 	// exact match first

--- a/pilot/pkg/model/destination_rule_test.go
+++ b/pilot/pkg/model/destination_rule_test.go
@@ -1,0 +1,149 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	"istio.io/istio/pkg/test/util/assert"
+)
+
+func TestConsolidatedDestRuleEquals(t *testing.T) {
+	testcases := []struct {
+		name     string
+		l        *consolidatedDestRule
+		r        *consolidatedDestRule
+		expected bool
+	}{
+		{
+			name:     "two nil",
+			expected: true,
+		},
+		{
+			name: "l is nil",
+			l:    nil,
+			r: &consolidatedDestRule{
+				from: []types.NamespacedName{
+					{
+						Namespace: "default",
+						Name:      "dr1",
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "r is nil",
+			l: &consolidatedDestRule{
+				from: []types.NamespacedName{
+					{
+						Namespace: "default",
+						Name:      "dr1",
+					},
+				},
+			},
+			r:        nil,
+			expected: false,
+		},
+		{
+			name: "from length not equal",
+			l: &consolidatedDestRule{
+				from: []types.NamespacedName{
+					{
+						Namespace: "default",
+						Name:      "dr1",
+					},
+				},
+			},
+			r: &consolidatedDestRule{
+				from: []types.NamespacedName{
+					{
+						Namespace: "default",
+						Name:      "dr1",
+					},
+					{
+						Namespace: "default",
+						Name:      "dr2",
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "from length equals but element is different",
+			l: &consolidatedDestRule{
+				from: []types.NamespacedName{
+					{
+						Namespace: "default",
+						Name:      "dr1",
+					},
+					{
+						Namespace: "default",
+						Name:      "dr2",
+					},
+				},
+			},
+			r: &consolidatedDestRule{
+				from: []types.NamespacedName{
+					{
+						Namespace: "default",
+						Name:      "dr1",
+					},
+					{
+						Namespace: "default",
+						Name:      "dr3",
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "all from elements equal",
+			l: &consolidatedDestRule{
+				from: []types.NamespacedName{
+					{
+						Namespace: "default",
+						Name:      "dr1",
+					},
+					{
+						Namespace: "default",
+						Name:      "dr2",
+					},
+				},
+			},
+			r: &consolidatedDestRule{
+				from: []types.NamespacedName{
+					{
+						Namespace: "default",
+						Name:      "dr1",
+					},
+					{
+						Namespace: "default",
+						Name:      "dr2",
+					},
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.l.Equals(tc.r), tc.expected)
+		})
+	}
+}

--- a/releasenotes/notes/38088.yaml
+++ b/releasenotes/notes/38088.yaml
@@ -1,0 +1,13 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 38082
+releaseNotes:
+  - |
+    **Fixed** xDS may not be updated when there are multiple destinationRules for a service are merged.
+    In this case the merged rule does only record one name/namespace pair of all the destinationRules.
+    however this meta is used to record config dependencies of a sidecar.
+
+    In this fix, we inroduce a new struct `consolidatedDestRule` and record all the destinationrules' meta.
+    And then we will not miss any destinationRule dependency.


### PR DESCRIPTION
**Please provide a description of this PR:**

Fix https://github.com/istio/istio/issues/38082

For merged DRs, currently we have only one DR meta(name/namespace) and add only one DR dependency.  
And so we will miss xds push for some update.

The pr solves this by recording all DRs' meta, and adding all dependencies. 

