### PR TITLE
Make docker-copy Mac friendly and more executable correct

### DIFF
--- a/tools/docker-copy.sh
+++ b/tools/docker-copy.sh
@@ -32,6 +32,7 @@ function may_copy_into_arch_named_sub_dir() {
   #   arm64/
   #   amd64/
   if [[ ${FILE_INFO} == *"ELF 64-bit LSB"* ]]; then
+    chmod 755 "${FILE}"
     case ${FILE_INFO} in
       *x86-64*)
         mkdir -p "${DOCKER_WORKING_DIR}/amd64/" && cp -rp "${FILE}" "${DOCKER_WORKING_DIR}/amd64/"
@@ -60,6 +61,7 @@ function may_copy_into_arch_named_sub_dir() {
     fi
 
   else
+    chmod 644 "${FILE}"
     cp -rp "${FILE}" "${DOCKER_WORKING_DIR}"
   fi
 }
@@ -68,5 +70,3 @@ mkdir -p "${DOCKER_WORKING_DIR}"
 for FILE in "${FILES[@]}"; do
   may_copy_into_arch_named_sub_dir "${FILE}"
 done
-find "${DOCKER_WORKING_DIR}" -type f -executable -exec chmod 755 {} \;
-find "${DOCKER_WORKING_DIR}" -type f ! -executable -exec chmod 644 {} \;


### PR DESCRIPTION
**Please provide a description of this PR:**

https://github.com/istio/istio/pull/38068 contains `find -executable` which is not Mac friendly. This PR removes that code and instead does a chmod 644 on the non `ELF 64-bit LSB` files.

The original code just made sure to chmod 755 ELF files and other files might have been left with the read flag unset. This code chmod 644's the non-ELF files, so all files will be readable.

Looking into the behavior of `-executable` when looking for a Mac equivalent, `-executable` doesn't actually check that the file is an executable, just that the various executable attributes are set such that the current user can execute it.