### PR TITLE
Update to do chmod on files after copy. Add read for non ELF files.

### DIFF
--- a/tools/docker-copy.sh
+++ b/tools/docker-copy.sh
@@ -35,9 +35,11 @@ function may_copy_into_arch_named_sub_dir() {
     case ${FILE_INFO} in
       *x86-64*)
         mkdir -p "${DOCKER_WORKING_DIR}/amd64/" && cp -rp "${FILE}" "${DOCKER_WORKING_DIR}/amd64/"
+        chmod 755 "${DOCKER_WORKING_DIR}/amd64/$(basename "${FILE}")"
         ;;
       *aarch64*)
         mkdir -p "${DOCKER_WORKING_DIR}/arm64/" && cp -rp "${FILE}" "${DOCKER_WORKING_DIR}/arm64/"
+        chmod 755 "${DOCKER_WORKING_DIR}/arm64/$(basename "${FILE}")"
         ;;
       *)
         cp -rp "${FILE}" "${DOCKER_WORKING_DIR}"
@@ -62,7 +64,13 @@ function may_copy_into_arch_named_sub_dir() {
 
   else
     cp -rp "${FILE}" "${DOCKER_WORKING_DIR}"
-    chmod a+r "${DOCKER_WORKING_DIR}/$(basename "${FILE}")"
+    file="${DOCKER_WORKING_DIR}/$(basename "${FILE}")"
+    if [[ -d ${file} ]]
+    then
+      chmod -R a+r "${file}"
+    else
+      chmod a+r "${file}"
+    fi
   fi
 }
 

--- a/tools/docker-copy.sh
+++ b/tools/docker-copy.sh
@@ -32,7 +32,6 @@ function may_copy_into_arch_named_sub_dir() {
   #   arm64/
   #   amd64/
   if [[ ${FILE_INFO} == *"ELF 64-bit LSB"* ]]; then
-    chmod 755 "${FILE}"
     case ${FILE_INFO} in
       *x86-64*)
         mkdir -p "${DOCKER_WORKING_DIR}/amd64/" && cp -rp "${FILE}" "${DOCKER_WORKING_DIR}/amd64/"
@@ -42,6 +41,7 @@ function may_copy_into_arch_named_sub_dir() {
         ;;
       *)
         cp -rp "${FILE}" "${DOCKER_WORKING_DIR}"
+        chmod 755 "${DOCKER_WORKING_DIR}/$(basename "${FILE}")"
         ;;
     esac
 
@@ -61,8 +61,8 @@ function may_copy_into_arch_named_sub_dir() {
     fi
 
   else
-    chmod 644 "${FILE}"
     cp -rp "${FILE}" "${DOCKER_WORKING_DIR}"
+    chmod a+r "${DOCKER_WORKING_DIR}/$(basename "${FILE}")"
   fi
 }
 


### PR DESCRIPTION
**Please provide a description of this PR:**

Running release-builder locally, I ran into a problem:
```
cp: cannot stat 'tests/testdata/certs/README.md': Permission denied
cp: cannot stat 'tests/testdata/certs/cert.crt': Permission denied
cp: cannot stat 'tests/testdata/certs/cert.key': Permission denied
cp: cannot stat 'tests/testdata/certs/default': Permission denied
cp: cannot stat 'tests/testdata/certs/dns': Permission denied
cp: cannot stat 'tests/testdata/certs/generate.sh': Permission denied
cp: cannot stat 'tests/testdata/certs/mountedcerts-client': Permission denied
cp: cannot stat 'tests/testdata/certs/mountedcerts-server': Permission denied
cp: cannot stat 'tests/testdata/certs/pilot': Permission denied
```

The issue is that we are removing the execute attribute on a directory. Update to do a `a+r` to set the read attribute on the files and update to do it on the destination files, not the source.

One possible issue is that if specifying a sub-directory, we only update the read attributes on the subdirectory, and not recursively. We could add the -R and do all the files (since we have already set the read attributes on the ELF files).