### PR TITLE
chore: fixes httpbin yaml samples.

### DIFF
--- a/samples/httpbin/httpbin-gateway.yaml
+++ b/samples/httpbin/httpbin-gateway.yaml
@@ -6,12 +6,12 @@ spec:
   selector:
     istio: ingressgateway
   servers:
-  - port:
-      number: 80
-      name: http
-      protocol: HTTP
-    hosts:
-    - "*"
+    - port:
+        number: 80
+        name: http
+        protocol: HTTP
+      hosts:
+        - "*"
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
@@ -19,12 +19,12 @@ metadata:
   name: httpbin
 spec:
   hosts:
-  - "*"
+    - "*"
   gateways:
-  - httpbin-gateway
+    - httpbin-gateway
   http:
-  - route:
-    - destination:
-        host: httpbin
-        port:
-          number: 8000
+    - route:
+        - destination:
+            host: httpbin
+            port:
+              number: 8000

--- a/samples/httpbin/httpbin-nodeport.yaml
+++ b/samples/httpbin/httpbin-nodeport.yaml
@@ -25,9 +25,9 @@ metadata:
 spec:
   type: NodePort
   ports:
-  - name: http
-    port: 8000
-    targetPort: 80
+    - name: http
+      port: 8000
+      targetPort: 80
   selector:
     app: httpbin
 ---
@@ -48,8 +48,8 @@ spec:
         version: v1
     spec:
       containers:
-      - image: docker.io/kennethreitz/httpbin
-        imagePullPolicy: IfNotPresent
-        name: httpbin
-        ports:
-        - containerPort: 80
+        - image: docker.io/kennethreitz/httpbin
+          imagePullPolicy: IfNotPresent
+          name: httpbin
+          ports:
+            - containerPort: 80

--- a/samples/httpbin/httpbin-vault.yaml
+++ b/samples/httpbin/httpbin-vault.yaml
@@ -24,9 +24,9 @@ metadata:
     service: httpbin
 spec:
   ports:
-  - name: http
-    port: 8000
-    targetPort: 80
+    - name: http
+      port: 8000
+      targetPort: 80
   selector:
     app: httpbin
 ---
@@ -46,10 +46,10 @@ spec:
         app: httpbin
         version: v1
     spec:
-      serviceAccountName: vault-citadel-sa    
+      serviceAccountName: vault-citadel-sa
       containers:
-      - image: docker.io/kennethreitz/httpbin
-        imagePullPolicy: IfNotPresent
-        name: httpbin
-        ports:
-        - containerPort: 80
+        - image: docker.io/kennethreitz/httpbin
+          imagePullPolicy: IfNotPresent
+          name: httpbin
+          ports:
+            - containerPort: 80

--- a/samples/httpbin/httpbin.yaml
+++ b/samples/httpbin/httpbin.yaml
@@ -29,9 +29,9 @@ metadata:
     service: httpbin
 spec:
   ports:
-  - name: http
-    port: 8000
-    targetPort: 80
+    - name: http
+      port: 8000
+      targetPort: 80
   selector:
     app: httpbin
 ---
@@ -53,8 +53,8 @@ spec:
     spec:
       serviceAccountName: httpbin
       containers:
-      - image: docker.io/kennethreitz/httpbin
-        imagePullPolicy: IfNotPresent
-        name: httpbin
-        ports:
-        - containerPort: 80
+        - image: docker.io/kennethreitz/httpbin
+          imagePullPolicy: IfNotPresent
+          name: httpbin
+          ports:
+            - containerPort: 80

--- a/samples/httpbin/sample-client/fortio-deploy.yaml
+++ b/samples/httpbin/sample-client/fortio-deploy.yaml
@@ -7,8 +7,8 @@ metadata:
     service: fortio
 spec:
   ports:
-  - port: 8080
-    name: http
+    - port: 8080
+      name: http
   selector:
     app: fortio
 ---
@@ -39,11 +39,11 @@ spec:
         app: fortio
     spec:
       containers:
-      - name: fortio
-        image: fortio/fortio:latest_release
-        imagePullPolicy: Always
-        ports:
-        - containerPort: 8080
-          name: http-fortio
-        - containerPort: 8079
-          name: grpc-ping
+        - name: fortio
+          image: fortio/fortio:latest_release
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8080
+              name: http-fortio
+            - containerPort: 8079
+              name: grpc-ping


### PR DESCRIPTION
**Please provide a description of this PR:**

YAML files aren't right when it comes to indentation, for example simply running `kubectl apply -f https://github.com/istio/istio/blob/master/samples/httpbin/httpbin-gateway.yaml` would return an error 'error converting YAML to JSON: yaml: line 25: mapping values are not allowed in this context' which can be fixed if the list values have the right identation.