### PR TITLE
fix issue#35310 to enable ip6tables interception in dual-stack clusters

### DIFF
--- a/pilot/pkg/util/network/ip.go
+++ b/pilot/pkg/util/network/ip.go
@@ -141,7 +141,7 @@ func ResolveAddr(addr string, lookupIPAddr ...lookupIPAddrType) (string, error) 
 	return resolvedAddr, nil
 }
 
-// IsIPv6Proxy check the addresses slice and returns true for all addresses are valid IPv6 address
+// IsIPv6Proxy check the addresses slice and returns true for a valid IPv6 address
 // for all other cases it returns false
 func IsIPv6Proxy(ipAddrs []string) bool {
 	for i := 0; i < len(ipAddrs); i++ {
@@ -151,9 +151,20 @@ func IsIPv6Proxy(ipAddrs []string) bool {
 			// skip it to prevent a panic.
 			continue
 		}
-		if addr.To4() != nil {
-			return false
-		}
+		result = IsIPv6Address(addr)
 	}
 	return true
+}
+
+// IsIPv6Address check an address is valid IPv6 address or not
+func IsIPv6Address(addr net.IP) bool {
+	if addr == nil {
+		return false
+	}
+	// need to check that a proxy can have an IPv6 address but configuration is not configured K8s for dual-stack support.
+	// In this case an ipv6 link local address will appear, but not one that is routable to with K8s
+	if addr.To4() == nil && addr.To16() != nil && !addr.IsLinkLocalUnicast() {
+		return true
+	}
+	return false
 }

--- a/pilot/pkg/util/network/ip.go
+++ b/pilot/pkg/util/network/ip.go
@@ -144,6 +144,7 @@ func ResolveAddr(addr string, lookupIPAddr ...lookupIPAddrType) (string, error) 
 // IsIPv6Proxy check the addresses slice and returns true for a valid IPv6 address
 // for all other cases it returns false
 func IsIPv6Proxy(ipAddrs []string) bool {
+	result := false
 	for i := 0; i < len(ipAddrs); i++ {
 		addr := net.ParseIP(ipAddrs[i])
 		if addr == nil {
@@ -153,7 +154,7 @@ func IsIPv6Proxy(ipAddrs []string) bool {
 		}
 		result = IsIPv6Address(addr)
 	}
-	return true
+	return result
 }
 
 // IsIPv6Address check an address is valid IPv6 address or not

--- a/pilot/pkg/util/network/ip.go
+++ b/pilot/pkg/util/network/ip.go
@@ -141,10 +141,9 @@ func ResolveAddr(addr string, lookupIPAddr ...lookupIPAddrType) (string, error) 
 	return resolvedAddr, nil
 }
 
-// IsIPv6Proxy check the addresses slice and returns true for a valid IPv6 address
+// IsIPv6Proxy check the addresses slice and returns true for all addresses are valid IPv6 address
 // for all other cases it returns false
 func IsIPv6Proxy(ipAddrs []string) bool {
-	result := false
 	for i := 0; i < len(ipAddrs); i++ {
 		addr := net.ParseIP(ipAddrs[i])
 		if addr == nil {
@@ -152,9 +151,11 @@ func IsIPv6Proxy(ipAddrs []string) bool {
 			// skip it to prevent a panic.
 			continue
 		}
-		result = IsIPv6Address(addr)
+		if addr.To4() != nil {
+			return false
+		}
 	}
-	return result
+	return true
 }
 
 // IsIPv6Address check an address is valid IPv6 address or not

--- a/pilot/pkg/util/network/ip_test.go
+++ b/pilot/pkg/util/network/ip_test.go
@@ -229,6 +229,11 @@ func TestIsIPv6Address(t *testing.T) {
 			addr:     net.ParseIP("2001:db8::68"),
 			expected: true,
 		},
+		{
+			name:     "ipv6 linklocalunicast",
+			addr:     net.ParseIP("fe80::9656:d028:8652:66b6"),
+			expected: false,
+		},
 	}
 	for _, tt := range tests {
 		result := IsIPv6Address(tt.addr)

--- a/pilot/pkg/util/network/ip_test.go
+++ b/pilot/pkg/util/network/ip_test.go
@@ -212,3 +212,28 @@ func TestIsIPv6Proxy(t *testing.T) {
 		}
 	}
 }
+
+func TestIsIPv6Address(t *testing.T) {
+	tests := []struct {
+		name     string
+		addr     net.IP
+		expected bool
+	}{
+		{
+			name:     "ipv4",
+			addr:     net.IPv4(1, 2, 3, 4),
+			expected: false,
+		},
+		{
+			name:     "ipv6",
+			addr:     net.ParseIP("2001:db8::68"),
+			expected: true,
+		},
+	}
+	for _, tt := range tests {
+		result := IsIPv6Address(tt.addr)
+		if result != tt.expected {
+			t.Errorf("Test %s failed, expected: %t got: %t", tt.name, tt.expected, result)
+		}
+	}
+}

--- a/tools/istio-iptables/pkg/cmd/root.go
+++ b/tools/istio-iptables/pkg/cmd/root.go
@@ -73,15 +73,16 @@ var rootCmd = &cobra.Command{
 			}
 		}
 		if cfg.RunValidation {
-			hostIP, err := getLocalIP()
+			hostIPs, err := getLocalIP()
 			if err != nil {
 				// Assume it is not handled by istio-cni and won't reuse the ValidationErrorCode
 				panic(err)
 			}
-			validator := validation.NewValidator(cfg, hostIP)
-
-			if err := validator.Run(); err != nil {
-				handleErrorWithCode(err, constants.ValidationErrorCode)
+			for _, hostIP := range hostIPs {
+				validator := validation.NewValidator(cfg, hostIP)
+				if err := validator.Run(); err != nil {
+					handleErrorWithCode(err, constants.ValidationErrorCode)
+				}
 			}
 		}
 	},
@@ -157,11 +158,18 @@ func constructConfig() *config.Config {
 	}
 
 	// Detect whether IPv6 is enabled by checking if the pod's IP address is IPv4 or IPv6.
-	podIP, err := getLocalIP()
+	podIPs, err := getLocalIP()
 	if err != nil {
 		panic(err)
 	}
-	cfg.EnableInboundIPv6 = podIP.To4() == nil
+	for _, podIP := range podIPs {
+		// need to check that a proxy can have an IPv6 address but configuration is not configured K8s for dual-stack support.
+		// In this case an ipv6 link local address will appear, but not one that is routable to with K8s
+		if podIP.To4() == nil && podIP.To16() != nil && !podIP.IsLinkLocalUnicast() {
+			cfg.EnableInboundIPv6 = true
+			break
+		}
+	}
 
 	// Lookup DNS nameservers. We only do this if DNS is enabled in case of some obscure theoretical
 	// case where reading /etc/resolv.conf could fail.
@@ -178,18 +186,23 @@ func constructConfig() *config.Config {
 }
 
 // getLocalIP returns the local IP address
-func getLocalIP() (net.IP, error) {
+func getLocalIP() ([]net.IP, error) {
 	addrs, err := net.InterfaceAddrs()
 	if err != nil {
 		return nil, err
 	}
 
+	var netip []net.IP
 	for _, a := range addrs {
 		if ipnet, ok := a.(*net.IPNet); ok && !ipnet.IP.IsLoopback() && !ipnet.IP.IsLinkLocalUnicast() && !ipnet.IP.IsLinkLocalMulticast() {
-			return ipnet.IP, nil
+			netip = append(netip, ipnet.IP)
 		}
 	}
-	return nil, fmt.Errorf("no valid local IP address found")
+
+	if len(netip) != 0 {
+		return netip, nil
+	}
+	return netip, fmt.Errorf("no valid local IP address found")
 }
 
 func handleError(err error) {

--- a/tools/istio-iptables/pkg/cmd/root_test.go
+++ b/tools/istio-iptables/pkg/cmd/root_test.go
@@ -1,0 +1,78 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"net"
+	"testing"
+	"unsafe"
+)
+
+var tesrLocalIPAddrs = func(ips []net.IP) ([]net.Addr, error) {
+	var IPAddrs []net.Addr
+	for i := 0; i < len(ips); i++ {
+		ipNetAddr := (*net.Addr)(unsafe.Pointer(&net.IPNet{IP: ips[i]}))
+		IPAddrs = append(IPAddrs, *ipNetAddr)
+	}
+	return IPAddrs, nil
+}
+
+func TestGetLocalIP(t *testing.T) {
+	tests := []struct {
+		name     string
+		lipas    func() ([]net.Addr, error)
+		expected bool
+	}{
+		{
+			name: "ipv4 only local ip addresses",
+			lipas: func() ([]net.Addr, error) {
+				return tesrLocalIPAddrs([]net.IP{
+					net.ParseIP("127.0.0.1"),
+					net.ParseIP("1.2.3.5"),
+				})
+			},
+			expected: false,
+		},
+		{
+			name: "ipv6 only local ip addresses",
+			lipas: func() ([]net.Addr, error) {
+				return tesrLocalIPAddrs([]net.IP{
+					net.ParseIP("::1"),
+					net.ParseIP("2222:3333::1"),
+				})
+			},
+			expected: true,
+		},
+		{
+			name: "mixed ipv4 and ipv6 local ip addresses",
+			lipas: func() ([]net.Addr, error) {
+				return tesrLocalIPAddrs([]net.IP{
+					net.ParseIP("::1"),
+					net.ParseIP("127.0.0.1"),
+					net.ParseIP("1.2.3.5"),
+					net.ParseIP("2222:3333::1"),
+				})
+			},
+			expected: true,
+		},
+	}
+	for _, tt := range tests {
+		LocalIPAddrs = tt.lipas
+		result := constructConfig()
+		if result.EnableInboundIPv6 != tt.expected {
+			t.Errorf("Test %s failed, expected: %t got: %t", tt.name, tt.expected, result.EnableInboundIPv6)
+		}
+	}
+}

--- a/tools/istio-iptables/pkg/cmd/root_test.go
+++ b/tools/istio-iptables/pkg/cmd/root_test.go
@@ -17,14 +17,15 @@ package cmd
 import (
 	"net"
 	"testing"
-	"unsafe"
 )
 
 var tesrLocalIPAddrs = func(ips []net.IP) ([]net.Addr, error) {
 	var IPAddrs []net.Addr
 	for i := 0; i < len(ips); i++ {
-		ipNetAddr := (*net.Addr)(unsafe.Pointer(&net.IPNet{IP: ips[i]}))
-		IPAddrs = append(IPAddrs, *ipNetAddr)
+		var ipAddr net.Addr
+		ipNetAddr := &net.IPNet{IP: ips[i]}
+		ipAddr = ipNetAddr
+		IPAddrs = append(IPAddrs, ipAddr)
 	}
 	return IPAddrs, nil
 }

--- a/tools/istio-iptables/pkg/validation/validator.go
+++ b/tools/istio-iptables/pkg/validation/validator.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"time"
 
+	"istio.io/istio/pilot/pkg/util/network"
 	"istio.io/istio/tools/istio-iptables/pkg/config"
 	"istio.io/pkg/log"
 )
@@ -105,14 +106,9 @@ func NewValidator(config *config.Config, hostIP net.IP) *Validator {
 	// It's tricky here:
 	// Connect to 127.0.0.6 will redirect to 127.0.0.1
 	// Connect to ::6       will redirect to ::1
-	isIpv6 := false
-	// need to check that a proxy can have an IPv6 address but configuration is not configured K8s for dual-stack support.
-	// In this case an ipv6 link local address will appear, but not one that is routable to with K8s
-	if hostIP.To4() == nil && hostIP.To16() != nil && !hostIP.IsLinkLocalUnicast() {
-		isIpv6 = true
-	}
 	listenIP := net.IPv4(127, 0, 0, 1)
 	serverIP := net.IPv4(127, 0, 0, 6)
+	isIpv6 := network.IsIPv6Address(hostIP)
 	if isIpv6 {
 		listenIP = net.IPv6loopback
 		serverIP = istioLocalIPv6

--- a/tools/istio-iptables/pkg/validation/validator.go
+++ b/tools/istio-iptables/pkg/validation/validator.go
@@ -105,7 +105,12 @@ func NewValidator(config *config.Config, hostIP net.IP) *Validator {
 	// It's tricky here:
 	// Connect to 127.0.0.6 will redirect to 127.0.0.1
 	// Connect to ::6       will redirect to ::1
-	isIpv6 := hostIP.To4() == nil
+	isIpv6 := false
+	// need to check that a proxy can have an IPv6 address but configuration is not configured K8s for dual-stack support.
+	// In this case an ipv6 link local address will appear, but not one that is routable to with K8s
+	if hostIP.To4() == nil && hostIP.To16() != nil && !hostIP.IsLinkLocalUnicast() {
+		isIpv6 = true
+	}
 	listenIP := net.IPv4(127, 0, 0, 1)
 	serverIP := net.IPv4(127, 0, 0, 6)
 	if isIpv6 {


### PR DESCRIPTION
**Please provide a description of this PR:**
Fix [issue#35310](https://github.com/istio/istio/issues/35310) to enable ip6tables interception in dual-stack clusters.