### PR TITLE
rm deprecated  parameters objectSelector  in charts

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -190,10 +190,6 @@ data:
         "enableNamespacesByDefault": false,
         "injectedAnnotations": {},
         "neverInjectSelector": [],
-        "objectSelector": {
-          "autoInject": true,
-          "enabled": true
-        },
         "rewriteAppHTTPProbe": true,
         "templates": {}
       }

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -94,12 +94,6 @@ sidecarInjectorWebhook:
   # Only one environment should have this enabled.
   enableNamespacesByDefault: false
 
-  # Enable objectSelector to filter out pods with no need for sidecar before calling istiod.
-  # It is enabled by default as the minimum supported Kubernetes version is 1.15+
-  objectSelector:
-    enabled: true
-    autoInject: true
-
   rewriteAppHTTPProbe: true
 
   # Templates defines a set of custom injection templates that can be used. For example, defining:

--- a/manifests/charts/istiod-remote/values.yaml
+++ b/manifests/charts/istiod-remote/values.yaml
@@ -74,11 +74,6 @@ sidecarInjectorWebhook:
   # with the exception of namespaces with "istio-injection:disabled" annotation
   # Only one environment should have this enabled.
   enableNamespacesByDefault: false
-  # Enable objectSelector to filter out pods with no need for sidecar before calling istiod.
-  # It is enabled by default as the minimum supported Kubernetes version is 1.15+
-  objectSelector:
-    enabled: true
-    autoInject: true
   rewriteAppHTTPProbe: true
   # Templates defines a set of custom injection templates that can be used. For example, defining:
   #

--- a/pkg/kube/inject/testdata/inputs/custom-template.yaml.34.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/custom-template.yaml.34.values.gen.yaml
@@ -125,10 +125,6 @@
     "enableNamespacesByDefault": false,
     "injectedAnnotations": {},
     "neverInjectSelector": [],
-    "objectSelector": {
-      "autoInject": true,
-      "enabled": true
-    },
     "rewriteAppHTTPProbe": true,
     "templates": {
       "custom": "metadata:\n  annotations:\n    # Disable the built-in transformations. In the future we may want a template-level API\n    prometheus.istio.io/merge-metrics: \"false\"\n    sidecar.istio.io/rewriteAppHTTPProbers: \"false\"\n    foo: bar\nspec:\n  containers:\n  {{- range $index, $container := .Spec.Containers }}\n  - name: {{ $container.Name }}\n    env:\n    - name: SOME_ENV\n      value: \"true\"\n    - name: SOME_FILE\n      value: /var/lib/data/foo.json\n    volumeMounts:\n    - mountPath: /var/lib/data/foo.json\n      subPath: foo.json\n      name: some-injected-file\n  {{- end}}\n  volumes:\n  - name: some-injected-file\n    downwardAPI:\n      items:\n      - path: foo.json\n        fieldRef:\n          fieldPath: \"metadata.annotations['foo']\"\n"

--- a/pkg/kube/inject/testdata/inputs/default.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/default.values.gen.yaml
@@ -125,10 +125,6 @@
     "enableNamespacesByDefault": false,
     "injectedAnnotations": {},
     "neverInjectSelector": [],
-    "objectSelector": {
-      "autoInject": true,
-      "enabled": true
-    },
     "rewriteAppHTTPProbe": true,
     "templates": {}
   }

--- a/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.values.gen.yaml
@@ -125,10 +125,6 @@
     "enableNamespacesByDefault": false,
     "injectedAnnotations": {},
     "neverInjectSelector": [],
-    "objectSelector": {
-      "autoInject": true,
-      "enabled": true
-    },
     "rewriteAppHTTPProbe": true,
     "templates": {}
   }

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.values.gen.yaml
@@ -126,10 +126,6 @@
     "enableNamespacesByDefault": false,
     "injectedAnnotations": {},
     "neverInjectSelector": [],
-    "objectSelector": {
-      "autoInject": true,
-      "enabled": true
-    },
     "rewriteAppHTTPProbe": true,
     "templates": {}
   }

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.values.gen.yaml
@@ -126,10 +126,6 @@
     "enableNamespacesByDefault": false,
     "injectedAnnotations": {},
     "neverInjectSelector": [],
-    "objectSelector": {
-      "autoInject": true,
-      "enabled": true
-    },
     "rewriteAppHTTPProbe": true,
     "templates": {}
   }

--- a/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.values.gen.yaml
@@ -127,10 +127,6 @@
     "enableNamespacesByDefault": false,
     "injectedAnnotations": {},
     "neverInjectSelector": [],
-    "objectSelector": {
-      "autoInject": true,
-      "enabled": true
-    },
     "rewriteAppHTTPProbe": true,
     "templates": {}
   }

--- a/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.values.gen.yaml
@@ -125,10 +125,6 @@
     "enableNamespacesByDefault": false,
     "injectedAnnotations": {},
     "neverInjectSelector": [],
-    "objectSelector": {
-      "autoInject": true,
-      "enabled": true
-    },
     "rewriteAppHTTPProbe": true,
     "templates": {}
   }

--- a/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.values.gen.yaml
@@ -125,10 +125,6 @@
     "enableNamespacesByDefault": false,
     "injectedAnnotations": {},
     "neverInjectSelector": [],
-    "objectSelector": {
-      "autoInject": true,
-      "enabled": true
-    },
     "rewriteAppHTTPProbe": true,
     "templates": {}
   }

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.0.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.0.values.gen.yaml
@@ -126,10 +126,6 @@
     "enableNamespacesByDefault": false,
     "injectedAnnotations": {},
     "neverInjectSelector": [],
-    "objectSelector": {
-      "autoInject": true,
-      "enabled": true
-    },
     "rewriteAppHTTPProbe": true,
     "templates": {}
   }

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.1.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.1.values.gen.yaml
@@ -125,10 +125,6 @@
     "enableNamespacesByDefault": false,
     "injectedAnnotations": {},
     "neverInjectSelector": [],
-    "objectSelector": {
-      "autoInject": true,
-      "enabled": true
-    },
     "rewriteAppHTTPProbe": true,
     "templates": {}
   }

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.10.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.10.values.gen.yaml
@@ -127,10 +127,6 @@
     "enableNamespacesByDefault": false,
     "injectedAnnotations": {},
     "neverInjectSelector": [],
-    "objectSelector": {
-      "autoInject": true,
-      "enabled": true
-    },
     "rewriteAppHTTPProbe": true,
     "templates": {}
   }

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.12.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.12.values.gen.yaml
@@ -129,10 +129,6 @@
     "enableNamespacesByDefault": false,
     "injectedAnnotations": {},
     "neverInjectSelector": [],
-    "objectSelector": {
-      "autoInject": true,
-      "enabled": true
-    },
     "rewriteAppHTTPProbe": true,
     "templates": {}
   }

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.13.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.13.values.gen.yaml
@@ -125,10 +125,6 @@
     "enableNamespacesByDefault": false,
     "injectedAnnotations": {},
     "neverInjectSelector": [],
-    "objectSelector": {
-      "autoInject": true,
-      "enabled": true
-    },
     "rewriteAppHTTPProbe": true,
     "templates": {}
   }

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.14.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.14.values.gen.yaml
@@ -126,10 +126,6 @@
     "enableNamespacesByDefault": false,
     "injectedAnnotations": {},
     "neverInjectSelector": [],
-    "objectSelector": {
-      "autoInject": true,
-      "enabled": true
-    },
     "rewriteAppHTTPProbe": true,
     "templates": {}
   }

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.17.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.17.values.gen.yaml
@@ -125,10 +125,6 @@
     "enableNamespacesByDefault": false,
     "injectedAnnotations": {},
     "neverInjectSelector": [],
-    "objectSelector": {
-      "autoInject": true,
-      "enabled": true
-    },
     "rewriteAppHTTPProbe": true,
     "templates": {}
   }

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.3.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.3.values.gen.yaml
@@ -125,10 +125,6 @@
     "enableNamespacesByDefault": false,
     "injectedAnnotations": {},
     "neverInjectSelector": [],
-    "objectSelector": {
-      "autoInject": true,
-      "enabled": true
-    },
     "rewriteAppHTTPProbe": true,
     "templates": {}
   }

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.4.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.4.values.gen.yaml
@@ -125,10 +125,6 @@
     "enableNamespacesByDefault": false,
     "injectedAnnotations": {},
     "neverInjectSelector": [],
-    "objectSelector": {
-      "autoInject": true,
-      "enabled": true
-    },
     "rewriteAppHTTPProbe": true,
     "templates": {}
   }

--- a/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.values.gen.yaml
@@ -125,10 +125,6 @@
     "enableNamespacesByDefault": false,
     "injectedAnnotations": {},
     "neverInjectSelector": [],
-    "objectSelector": {
-      "autoInject": true,
-      "enabled": true
-    },
     "rewriteAppHTTPProbe": true,
     "templates": {}
   }

--- a/pkg/kube/inject/testdata/inputs/status_params.yaml.8.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/status_params.yaml.8.values.gen.yaml
@@ -125,10 +125,6 @@
     "enableNamespacesByDefault": false,
     "injectedAnnotations": {},
     "neverInjectSelector": [],
-    "objectSelector": {
-      "autoInject": true,
-      "enabled": true
-    },
     "rewriteAppHTTPProbe": true,
     "templates": {}
   }

--- a/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.values.gen.yaml
@@ -125,10 +125,6 @@
     "enableNamespacesByDefault": false,
     "injectedAnnotations": {},
     "neverInjectSelector": [],
-    "objectSelector": {
-      "autoInject": true,
-      "enabled": true
-    },
     "rewriteAppHTTPProbe": true,
     "templates": {}
   }


### PR DESCRIPTION
**Please provide a description of this PR:**

 parameters objectSelector.enable objectSelector.autoInject  already deprecated  in charts 

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [X] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure