### PR TITLE
refactor endpointshards index into model

### DIFF
--- a/pilot/pkg/model/endpointshards.go
+++ b/pilot/pkg/model/endpointshards.go
@@ -15,9 +15,7 @@
 package model
 
 import (
-	"fmt"
 	"istio.io/istio/pkg/config/schema/gvk"
-	"strings"
 	"sync"
 
 	"istio.io/istio/pilot/pkg/serviceregistry/provider"
@@ -31,24 +29,15 @@ type shardRegistry interface {
 	Provider() provider.ID
 }
 
-func NewShardKey(cluster cluster.ID, provider provider.ID) ShardKey {
-	return ShardKey(fmt.Sprintf("%s/%s", cluster, provider))
-}
-
 // ShardKeyFromRegistry computes the shard key based on provider type and cluster id.
 func ShardKeyFromRegistry(instance shardRegistry) ShardKey {
-	return NewShardKey(instance.Cluster(), instance.Provider())
+	return ShardKey{Cluster: instance.Cluster(), Provider: instance.Provider()}
 }
 
 // ShardKey is the key for EndpointShards made of a key with the format "cluster/provider"
-type ShardKey string
-
-func (sk ShardKey) Cluster() cluster.ID {
-	p := strings.Split(string(sk), "/")
-	if len(p) < 1 {
-		return ""
-	}
-	return cluster.ID(p[0])
+type ShardKey struct {
+	Cluster  cluster.ID
+	Provider provider.ID
 }
 
 // EndpointShards holds the set of endpoint shards of a service. Registries update

--- a/pilot/pkg/model/endpointshards.go
+++ b/pilot/pkg/model/endpointshards.go
@@ -19,8 +19,8 @@ import (
 	"sync"
 
 	"istio.io/istio/pilot/pkg/serviceregistry/provider"
-	"istio.io/istio/pilot/pkg/util/sets"
 	"istio.io/istio/pkg/cluster"
+	"istio.io/istio/pkg/util/sets"
 )
 
 // shardRegistry is a simplified interface for registries that can produce a shard key

--- a/pilot/pkg/model/endpointshards.go
+++ b/pilot/pkg/model/endpointshards.go
@@ -1,0 +1,199 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"fmt"
+	"istio.io/istio/pkg/config/schema/gvk"
+	"strings"
+	"sync"
+
+	"istio.io/istio/pilot/pkg/serviceregistry/provider"
+	"istio.io/istio/pilot/pkg/util/sets"
+	"istio.io/istio/pkg/cluster"
+)
+
+// shardRegistry is a simplified interface for registries that can produce a shard key
+type shardRegistry interface {
+	Cluster() cluster.ID
+	Provider() provider.ID
+}
+
+func NewShardKey(cluster cluster.ID, provider provider.ID) ShardKey {
+	return ShardKey(fmt.Sprintf("%s/%s", cluster, provider))
+}
+
+// ShardKeyFromRegistry computes the shard key based on provider type and cluster id.
+func ShardKeyFromRegistry(instance shardRegistry) ShardKey {
+	return NewShardKey(instance.Cluster(), instance.Provider())
+}
+
+// ShardKey is the key for EndpointShards made of a key with the format "cluster/provider"
+type ShardKey string
+
+func (sk ShardKey) Cluster() cluster.ID {
+	p := strings.Split(string(sk), "/")
+	if len(p) < 1 {
+		return ""
+	}
+	return cluster.ID(p[0])
+}
+
+// EndpointShards holds the set of endpoint shards of a service. Registries update
+// individual shards incrementally. The shards are aggregated and split into
+// clusters when a push for the specific cluster is needed.
+type EndpointShards struct {
+	// mutex protecting below map.
+	sync.RWMutex
+
+	// Shards is used to track the shards. EDS updates are grouped by shard.
+	// Current implementation uses the registry name as key - in multicluster this is the
+	// name of the k8s cluster, derived from the config (secret).
+	Shards map[ShardKey][]*IstioEndpoint
+
+	// ServiceAccounts has the concatenation of all service accounts seen so far in endpoints.
+	// This is updated on push, based on shards. If the previous list is different than
+	// current list, a full push will be forced, to trigger a secure naming update.
+	// Due to the larger time, it is still possible that connection errors will occur while
+	// CDS is updated.
+	ServiceAccounts sets.Set
+}
+
+// EndpointIndex is a mutex protected index of endpoint shards
+type EndpointIndex struct {
+	mu sync.RWMutex
+	// keyed by svc then ns
+	shardsBySvc map[string]map[string]*EndpointShards
+	// We'll need to clear the cache in-sync with endpoint shards modifications.
+	cache XdsCache
+}
+
+func NewEndpointIndex() *EndpointIndex {
+	return &EndpointIndex{
+		shardsBySvc: make(map[string]map[string]*EndpointShards),
+	}
+}
+
+func (e *EndpointIndex) SetCache(cache XdsCache) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.cache = cache
+}
+
+func (e *EndpointIndex) clearCacheForService(svc, ns string) {
+	if e.cache == nil {
+		return
+	}
+	e.cache.Clear(map[ConfigKey]struct{}{{
+		Kind:      gvk.ServiceEntry,
+		Name:      svc,
+		Namespace: ns,
+	}: {}})
+}
+
+// Shardz returns a copy of the global map of shards but does NOT copy the underlying individual EndpointShards.
+func (e *EndpointIndex) Shardz() map[string]map[string]*EndpointShards {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	out := make(map[string]map[string]*EndpointShards, len(e.shardsBySvc))
+	for svcKey, v := range e.shardsBySvc {
+		out[svcKey] = make(map[string]*EndpointShards, len(v))
+		for nsKey, v := range v {
+			out[svcKey][nsKey] = v
+		}
+	}
+	return out
+}
+
+// ShardsForService returns the shards and true if they are found, or returns nil, false.
+func (e *EndpointIndex) ShardsForService(serviceName, namespace string) (*EndpointShards, bool) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	byNs, ok := e.shardsBySvc[serviceName]
+	if !ok {
+		return nil, false
+	}
+	shards, ok := byNs[namespace]
+	return shards, ok
+}
+
+// GetOrCreateEndpointShard returns the shards. The second return parameter will be true if this service was seen
+// for the first time.
+func (e *EndpointIndex) GetOrCreateEndpointShard(serviceName, namespace string) (*EndpointShards, bool) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if _, exists := e.shardsBySvc[serviceName]; !exists {
+		e.shardsBySvc[serviceName] = map[string]*EndpointShards{}
+	}
+	if ep, exists := e.shardsBySvc[serviceName][namespace]; exists {
+		return ep, false
+	}
+	// This endpoint is for a service that was not previously loaded.
+	ep := &EndpointShards{
+		Shards:          map[ShardKey][]*IstioEndpoint{},
+		ServiceAccounts: sets.Set{},
+	}
+	e.shardsBySvc[serviceName][namespace] = ep
+	// Clear the cache here to avoid race in cache writes.
+	e.clearCacheForService(serviceName, namespace)
+	return ep, true
+}
+
+func (e *EndpointIndex) DeleteServiceShard(shard ShardKey, serviceName, namespace string, preserveKeys bool) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.deleteServiceInner(shard, serviceName, namespace, preserveKeys)
+}
+
+func (e *EndpointIndex) DeleteShard(shardKey ShardKey) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	for svc, shardsByNamespace := range e.shardsBySvc {
+		for ns := range shardsByNamespace {
+			e.deleteServiceInner(shardKey, svc, ns, false)
+		}
+	}
+	e.cache.ClearAll()
+}
+
+func (e *EndpointIndex) deleteServiceInner(shard ShardKey, serviceName, namespace string, preserveKeys bool) {
+	if e.shardsBySvc[serviceName] == nil ||
+		e.shardsBySvc[serviceName][namespace] == nil {
+		return
+	}
+	epShards := e.shardsBySvc[serviceName][namespace]
+	epShards.Lock()
+	delete(epShards.Shards, shard)
+	epShards.ServiceAccounts = sets.Set{}
+	for _, shard := range epShards.Shards {
+		for _, ep := range shard {
+			if ep.ServiceAccount != "" {
+				epShards.ServiceAccounts.Insert(ep.ServiceAccount)
+			}
+		}
+	}
+	// Clear the cache here to avoid race in cache writes.
+	e.clearCacheForService(serviceName, namespace)
+	epShards.Unlock()
+	if !preserveKeys {
+		if len(epShards.Shards) == 0 {
+			delete(e.shardsBySvc[serviceName], namespace)
+		}
+		if len(e.shardsBySvc[serviceName]) == 0 {
+			delete(e.shardsBySvc, serviceName)
+		}
+	}
+}

--- a/pilot/pkg/model/endpointshards.go
+++ b/pilot/pkg/model/endpointshards.go
@@ -71,6 +71,8 @@ type EndpointShards struct {
 // Keys gives a sorted list of keys for EndpointShards.Shards.
 // Calls to Keys should be guarded with a lock on the EndpointShards.
 func (es *EndpointShards) Keys() []ShardKey {
+	// len(shards) ~= number of remote clusters which isn't too large, doing this sort frequently
+	// shouldn't be too problematic. If it becomes an issue we can cache it in the EndpointShards struct.
 	keys := make([]ShardKey, 0, len(es.Shards))
 	for k := range es.Shards {
 		keys = append(keys, k)

--- a/pilot/pkg/model/endpointshards.go
+++ b/pilot/pkg/model/endpointshards.go
@@ -64,8 +64,6 @@ type EndpointShards struct {
 	// Due to the larger time, it is still possible that connection errors will occur while
 	// CDS is updated.
 	ServiceAccounts sets.Set
-
-	sortedKeys []ShardKey
 }
 
 // Keys gives a sorted list of keys for EndpointShards.Shards.

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -31,7 +31,6 @@ import (
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/features"
-	"istio.io/istio/pilot/pkg/serviceregistry/provider"
 	"istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/constants"
@@ -305,32 +304,6 @@ type XDSUpdater interface {
 
 	// RemoveShard removes all endpoints for the given shard key
 	RemoveShard(shardKey ShardKey)
-}
-
-// shardRegistry is a simplified interface for registries that can produce a shard key
-type shardRegistry interface {
-	Cluster() cluster.ID
-	Provider() provider.ID
-}
-
-func NewShardKey(cluster cluster.ID, provider provider.ID) ShardKey {
-	return ShardKey(fmt.Sprintf("%s/%s", cluster, provider))
-}
-
-// ShardKeyFromRegistry computes the shard key based on provider type and cluster id.
-func ShardKeyFromRegistry(instance shardRegistry) ShardKey {
-	return NewShardKey(instance.Cluster(), instance.Provider())
-}
-
-// ShardKey is the key for EndpointShards made of a key with the format "cluster/provider"
-type ShardKey string
-
-func (sk ShardKey) Cluster() cluster.ID {
-	p := strings.Split(string(sk), "/")
-	if len(p) < 1 {
-		return ""
-	}
-	return cluster.ID(p[0])
 }
 
 // PushRequest defines a request to push to proxies

--- a/pilot/pkg/networking/core/v1alpha3/fake.go
+++ b/pilot/pkg/networking/core/v1alpha3/fake.go
@@ -137,7 +137,7 @@ func NewConfigGenTest(t test.Failer, opts TestOptions) *ConfigGenTest {
 		msd.AddInstance(instance.Service.Hostname, instance)
 	}
 	msd.AddGateways(opts.Gateways...)
-	msd.ClusterID = string(provider.Mock)
+	msd.ClusterID = cluster2.ID(provider.Mock)
 	serviceDiscovery.AddRegistry(serviceregistry.Simple{
 		ClusterID:        cluster2.ID(provider.Mock),
 		ProviderID:       provider.Mock,

--- a/pilot/pkg/serviceregistry/kube/controller/fake.go
+++ b/pilot/pkg/serviceregistry/kube/controller/fake.go
@@ -109,7 +109,7 @@ func (fx *FakeXdsUpdater) SvcUpdate(_ model.ShardKey, hostname string, _ string,
 
 func (fx *FakeXdsUpdater) RemoveShard(shardKey model.ShardKey) {
 	select {
-	case fx.Events <- FakeXdsEvent{Type: "removeShard", ID: string(shardKey)}:
+	case fx.Events <- FakeXdsEvent{Type: "removeShard", ID: shardKey.String()}:
 	default:
 	}
 }

--- a/pilot/pkg/serviceregistry/memory/discovery.go
+++ b/pilot/pkg/serviceregistry/memory/discovery.go
@@ -16,11 +16,11 @@ package memory
 
 import (
 	"fmt"
-	"istio.io/istio/pkg/cluster"
 	"sync"
 
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry/provider"
+	"istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/protocol"

--- a/pilot/pkg/serviceregistry/memory/discovery.go
+++ b/pilot/pkg/serviceregistry/memory/discovery.go
@@ -16,11 +16,11 @@ package memory
 
 import (
 	"fmt"
+	"istio.io/istio/pkg/cluster"
 	"sync"
 
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry/provider"
-	"istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/protocol"
@@ -68,7 +68,7 @@ type ServiceDiscovery struct {
 	WantGetProxyServiceInstances []*model.ServiceInstance
 	InstancesError               error
 	Controller                   model.Controller
-	ClusterID                    string
+	ClusterID                    cluster.ID
 
 	// Used by GetProxyWorkloadLabels
 	ip2workloadLabels map[string]*labels.Instance
@@ -99,7 +99,7 @@ func NewServiceDiscovery(services ...*model.Service) *ServiceDiscovery {
 }
 
 func (sd *ServiceDiscovery) shardKey() model.ShardKey {
-	return model.NewShardKey(cluster.ID(sd.ClusterID), provider.Mock)
+	return model.ShardKey{Cluster: sd.ClusterID, Provider: provider.Mock}
 }
 
 func (sd *ServiceDiscovery) AddWorkload(ip string, labels labels.Instance) {

--- a/pilot/pkg/xds/debug.go
+++ b/pilot/pkg/xds/debug.go
@@ -297,9 +297,7 @@ func (s *DiscoveryServer) registryz(w http.ResponseWriter, req *http.Request) {
 // the full push.
 func (s *DiscoveryServer) endpointShardz(w http.ResponseWriter, req *http.Request) {
 	w.Header().Add("Content-Type", "application/json")
-	s.mutex.RLock()
-	out, _ := json.MarshalIndent(s.EndpointShardsByService, " ", " ")
-	s.mutex.RUnlock()
+	out, _ := json.MarshalIndent(s.EndpointIndex.Shardz, " ", " ")
 	_, _ = w.Write(out)
 }
 

--- a/pilot/pkg/xds/debug.go
+++ b/pilot/pkg/xds/debug.go
@@ -297,7 +297,7 @@ func (s *DiscoveryServer) registryz(w http.ResponseWriter, req *http.Request) {
 // the full push.
 func (s *DiscoveryServer) endpointShardz(w http.ResponseWriter, req *http.Request) {
 	w.Header().Add("Content-Type", "application/json")
-	out, _ := json.MarshalIndent(s.EndpointIndex.Shardz, " ", " ")
+	out, _ := json.MarshalIndent(s.EndpointIndex.Shardz(), " ", " ")
 	_, _ = w.Write(out)
 }
 

--- a/pilot/pkg/xds/discovery.go
+++ b/pilot/pkg/xds/discovery.go
@@ -109,11 +109,9 @@ type DiscoveryServer struct {
 	// the push context, which means that the next push to a proxy will receive this configuration.
 	CommittedUpdates *atomic.Int64
 
-	// mutex used for protecting shards.
-	mutex sync.RWMutex
 	// EndpointShards for a service. This is a global (per-server) list, built from
 	// incremental updates. This is keyed by service and namespace
-	EndpointShardsByService map[string]map[string]*EndpointShards
+	EndpointIndex *model.EndpointIndex
 
 	// pushChannel is the buffer used for debouncing.
 	// after debouncing the pushRequest will be sent to pushQueue
@@ -162,42 +160,22 @@ type DiscoveryServer struct {
 	ClusterAliases map[cluster.ID]cluster.ID
 }
 
-// EndpointShards holds the set of endpoint shards of a service. Registries update
-// individual shards incrementally. The shards are aggregated and split into
-// clusters when a push for the specific cluster is needed.
-type EndpointShards struct {
-	// mutex protecting below map.
-	mutex sync.RWMutex
-
-	// Shards is used to track the shards. EDS updates are grouped by shard.
-	// Current implementation uses the registry name as key - in multicluster this is the
-	// name of the k8s cluster, derived from the config (secret).
-	Shards map[model.ShardKey][]*model.IstioEndpoint
-
-	// ServiceAccounts has the concatenation of all service accounts seen so far in endpoints.
-	// This is updated on push, based on shards. If the previous list is different than
-	// current list, a full push will be forced, to trigger a secure naming update.
-	// Due to the larger time, it is still possible that connection errors will occur while
-	// CDS is updated.
-	ServiceAccounts sets.Set
-}
-
 // NewDiscoveryServer creates DiscoveryServer that sources data from Pilot's internal mesh data structures
 func NewDiscoveryServer(env *model.Environment, plugins []string, instanceID string, systemNameSpace string,
 	clusterAliases map[string]string) *DiscoveryServer {
 	out := &DiscoveryServer{
-		Env:                     env,
-		Generators:              map[string]model.XdsResourceGenerator{},
-		ProxyNeedsPush:          DefaultProxyNeedsPush,
-		EndpointShardsByService: map[string]map[string]*EndpointShards{},
-		concurrentPushLimit:     make(chan struct{}, features.PushThrottle),
-		requestRateLimit:        rate.NewLimiter(rate.Limit(features.RequestLimit), 1),
-		InboundUpdates:          atomic.NewInt64(0),
-		CommittedUpdates:        atomic.NewInt64(0),
-		pushChannel:             make(chan *model.PushRequest, 10),
-		pushQueue:               NewPushQueue(),
-		debugHandlers:           map[string]string{},
-		adsClients:              map[string]*Connection{},
+		Env:                 env,
+		Generators:          map[string]model.XdsResourceGenerator{},
+		ProxyNeedsPush:      DefaultProxyNeedsPush,
+		EndpointIndex:       model.NewEndpointIndex(),
+		concurrentPushLimit: make(chan struct{}, features.PushThrottle),
+		requestRateLimit:    rate.NewLimiter(rate.Limit(features.RequestLimit), 1),
+		InboundUpdates:      atomic.NewInt64(0),
+		CommittedUpdates:    atomic.NewInt64(0),
+		pushChannel:         make(chan *model.PushRequest, 10),
+		pushQueue:           NewPushQueue(),
+		debugHandlers:       map[string]string{},
+		adsClients:          map[string]*Connection{},
 		debounceOptions: debounceOptions{
 			debounceAfter:     features.DebounceAfter,
 			debounceMax:       features.DebounceMax,
@@ -216,6 +194,8 @@ func NewDiscoveryServer(env *model.Environment, plugins []string, instanceID str
 
 	if features.EnableXDSCaching {
 		out.Cache = model.NewXdsCache()
+		// clear the cache as endpoint shards are modified to avoid cache write race
+		out.EndpointIndex.SetCache(out.Cache)
 	}
 
 	out.ConfigGenerator = core.NewConfigGenerator(plugins, out.Cache)

--- a/pilot/pkg/xds/discovery.go
+++ b/pilot/pkg/xds/discovery.go
@@ -41,7 +41,6 @@ import (
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
 	"istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/security"
-	"istio.io/istio/pkg/util/sets"
 )
 
 var (

--- a/pilot/pkg/xds/eds.go
+++ b/pilot/pkg/xds/eds.go
@@ -87,11 +87,11 @@ func (s *DiscoveryServer) UpdateServiceShards(push *model.PushContext) error {
 
 // SvcUpdate is a callback from service discovery when service info changes.
 func (s *DiscoveryServer) SvcUpdate(shard model.ShardKey, hostname string, namespace string, event model.Event) {
-	// When a service deleted, we should cleanup the endpoint shards and also remove keys from EndpointShardsByService to
+	// When a service deleted, we should cleanup the endpoint shards and also remove keys from EndpointIndex to
 	// prevent memory leaks.
 	if event == model.EventDelete {
 		inboundServiceDeletes.Increment()
-		s.deleteService(shard, hostname, namespace)
+		s.EndpointIndex.DeleteServiceShard(shard, hostname, namespace, false)
 	} else {
 		inboundServiceUpdates.Increment()
 	}
@@ -142,25 +142,25 @@ func (s *DiscoveryServer) edsCacheUpdate(shard model.ShardKey, hostname string, 
 	istioEndpoints []*model.IstioEndpoint) PushType {
 	if len(istioEndpoints) == 0 {
 		// Should delete the service EndpointShards when endpoints become zero to prevent memory leak,
-		// but we should not delete the keys from EndpointShardsByService map - that will trigger
+		// but we should not delete the keys from EndpointIndex map - that will trigger
 		// unnecessary full push which can become a real problem if a pod is in crashloop and thus endpoints
 		// flip flopping between 1 and 0.
-		s.deleteEndpointShards(shard, hostname, namespace)
+		s.EndpointIndex.DeleteServiceShard(shard, hostname, namespace, true)
 		log.Infof("Incremental push, service %s at shard %v has no endpoints", hostname, shard)
 		return IncrementalPush
 	}
 
 	pushType := IncrementalPush
 	// Find endpoint shard for this service, if it is available - otherwise create a new one.
-	ep, created := s.getOrCreateEndpointShard(hostname, namespace)
+	ep, created := s.EndpointIndex.GetOrCreateEndpointShard(hostname, namespace)
 	// If we create a new endpoint shard, that means we have not seen the service earlier. We should do a full push.
 	if created {
 		log.Infof("Full push, new service %s/%s", namespace, hostname)
 		pushType = FullPush
 	}
 
-	ep.mutex.Lock()
-	defer ep.mutex.Unlock()
+	ep.Lock()
+	defer ep.Unlock()
 	newIstioEndpoints := istioEndpoints
 	if features.SendUnhealthyEndpoints {
 		oldIstioEndpoints := ep.Shards[shard]
@@ -241,104 +241,12 @@ func (s *DiscoveryServer) edsCacheUpdate(shard model.ShardKey, hostname string, 
 }
 
 func (s *DiscoveryServer) RemoveShard(shardKey model.ShardKey) {
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
-	for svc, shardsByNamespace := range s.EndpointShardsByService {
-		for ns := range shardsByNamespace {
-			s.deleteServiceInner(shardKey, svc, ns)
-		}
-	}
-	s.Cache.ClearAll()
-}
-
-func (s *DiscoveryServer) getOrCreateEndpointShard(serviceName, namespace string) (*EndpointShards, bool) {
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
-
-	if _, exists := s.EndpointShardsByService[serviceName]; !exists {
-		s.EndpointShardsByService[serviceName] = map[string]*EndpointShards{}
-	}
-	if ep, exists := s.EndpointShardsByService[serviceName][namespace]; exists {
-		return ep, false
-	}
-	// This endpoint is for a service that was not previously loaded.
-	ep := &EndpointShards{
-		Shards:          map[model.ShardKey][]*model.IstioEndpoint{},
-		ServiceAccounts: sets.Set{},
-	}
-	s.EndpointShardsByService[serviceName][namespace] = ep
-	// Clear the cache here to avoid race in cache writes (see edsCacheUpdate for details).
-	s.Cache.Clear(map[model.ConfigKey]struct{}{{
-		Kind:      gvk.ServiceEntry,
-		Name:      serviceName,
-		Namespace: namespace,
-	}: {}})
-	return ep, true
-}
-
-// deleteEndpointShards deletes matching endpoint shards from EndpointShardsByService map. This is called when
-// endpoints are deleted.
-func (s *DiscoveryServer) deleteEndpointShards(shard model.ShardKey, serviceName, namespace string) {
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
-	if s.EndpointShardsByService[serviceName] != nil &&
-		s.EndpointShardsByService[serviceName][namespace] != nil {
-		epShards := s.EndpointShardsByService[serviceName][namespace]
-		epShards.mutex.Lock()
-		delete(epShards.Shards, shard)
-		epShards.ServiceAccounts = sets.Set{}
-		for _, shard := range epShards.Shards {
-			for _, ep := range shard {
-				if ep.ServiceAccount != "" {
-					epShards.ServiceAccounts.Insert(ep.ServiceAccount)
-				}
-			}
-		}
-		// Clear the cache here to avoid race in cache writes (see edsCacheUpdate for details).
-		s.Cache.Clear(map[model.ConfigKey]struct{}{{
-			Kind:      gvk.ServiceEntry,
-			Name:      serviceName,
-			Namespace: namespace,
-		}: {}})
-		epShards.mutex.Unlock()
-	}
-}
-
-// deleteService deletes all service related references from EndpointShardsByService. This is called
-// when a service is deleted.
-func (s *DiscoveryServer) deleteService(shard model.ShardKey, serviceName, namespace string) {
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
-	s.deleteServiceInner(shard, serviceName, namespace)
-}
-
-func (s *DiscoveryServer) deleteServiceInner(shard model.ShardKey, serviceName, namespace string) {
-	if s.EndpointShardsByService[serviceName] != nil &&
-		s.EndpointShardsByService[serviceName][namespace] != nil {
-		epShards := s.EndpointShardsByService[serviceName][namespace]
-		epShards.mutex.Lock()
-		delete(epShards.Shards, shard)
-		shardsLen := len(epShards.Shards)
-		s.UpdateServiceAccount(epShards, serviceName)
-		// Clear the cache here to avoid race in cache writes (see edsCacheUpdate for details).
-		s.Cache.Clear(map[model.ConfigKey]struct{}{{
-			Kind:      gvk.ServiceEntry,
-			Name:      serviceName,
-			Namespace: namespace,
-		}: {}})
-		epShards.mutex.Unlock()
-		if shardsLen == 0 {
-			delete(s.EndpointShardsByService[serviceName], namespace)
-		}
-		if len(s.EndpointShardsByService[serviceName]) == 0 {
-			delete(s.EndpointShardsByService, serviceName)
-		}
-	}
+	s.EndpointIndex.DeleteShard(shardKey)
 }
 
 // UpdateServiceAccount updates the service endpoints' sa when service/endpoint event happens.
 // Note: it is not concurrent safe.
-func (s *DiscoveryServer) UpdateServiceAccount(shards *EndpointShards, serviceName string) bool {
+func (s *DiscoveryServer) UpdateServiceAccount(shards *model.EndpointShards, serviceName string) bool {
 	oldServiceAccount := shards.ServiceAccounts
 	serviceAccounts := sets.Set{}
 	for _, epShards := range shards.Shards {
@@ -388,9 +296,7 @@ func (s *DiscoveryServer) llbEndpointAndOptionsForCluster(b EndpointBuilder) ([]
 		return nil, nil
 	}
 
-	s.mutex.RLock()
-	epShards, f := s.EndpointShardsByService[string(b.hostname)][b.service.Attributes.Namespace]
-	s.mutex.RUnlock()
+	epShards, f := s.EndpointIndex.ShardsForService(string(b.hostname), b.service.Attributes.Namespace)
 	if !f {
 		// Shouldn't happen here
 		log.Debugf("can not find the endpointShards for cluster %s", b.clusterName)

--- a/pilot/pkg/xds/eds_test.go
+++ b/pilot/pkg/xds/eds_test.go
@@ -623,6 +623,11 @@ func TestDeleteService(t *testing.T) {
 	}
 }
 
+var (
+	c1Key = model.ShardKey{Cluster: "c1"}
+	c2Key = model.ShardKey{Cluster: "c2"}
+)
+
 func TestUpdateServiceAccount(t *testing.T) {
 	cluster1Endppoints := []*model.IstioEndpoint{
 		{Address: "10.172.0.1", ServiceAccount: "sa1"},
@@ -637,19 +642,19 @@ func TestUpdateServiceAccount(t *testing.T) {
 	}{
 		{
 			name:      "added new endpoint",
-			shardKey:  "c1",
+			shardKey:  c1Key,
 			endpoints: append(cluster1Endppoints, &model.IstioEndpoint{Address: "10.172.0.3", ServiceAccount: "sa1"}),
 			expect:    false,
 		},
 		{
 			name:      "added new sa",
-			shardKey:  "c1",
+			shardKey:  c1Key,
 			endpoints: append(cluster1Endppoints, &model.IstioEndpoint{Address: "10.172.0.3", ServiceAccount: "sa2"}),
 			expect:    true,
 		},
 		{
 			name:     "updated endpoints address",
-			shardKey: "c1",
+			shardKey: c1Key,
 			endpoints: []*model.IstioEndpoint{
 				{Address: "10.172.0.5", ServiceAccount: "sa1"},
 				{Address: "10.172.0.2", ServiceAccount: "sa-vm1"},
@@ -658,7 +663,7 @@ func TestUpdateServiceAccount(t *testing.T) {
 		},
 		{
 			name:     "deleted one endpoint with unique sa",
-			shardKey: "c1",
+			shardKey: c1Key,
 			endpoints: []*model.IstioEndpoint{
 				{Address: "10.172.0.1", ServiceAccount: "sa1"},
 			},
@@ -666,7 +671,7 @@ func TestUpdateServiceAccount(t *testing.T) {
 		},
 		{
 			name:     "deleted one endpoint with duplicate sa",
-			shardKey: "c1",
+			shardKey: c1Key,
 			endpoints: []*model.IstioEndpoint{
 				{Address: "10.172.0.2", ServiceAccount: "sa-vm1"},
 			},
@@ -674,7 +679,7 @@ func TestUpdateServiceAccount(t *testing.T) {
 		},
 		{
 			name:      "deleted endpoints",
-			shardKey:  "c1",
+			shardKey:  c1Key,
 			endpoints: nil,
 			expect:    true,
 		},
@@ -685,8 +690,8 @@ func TestUpdateServiceAccount(t *testing.T) {
 			s := new(xds.DiscoveryServer)
 			originalEndpointsShard := &model.EndpointShards{
 				Shards: map[model.ShardKey][]*model.IstioEndpoint{
-					"c1": cluster1Endppoints,
-					"c2": {{Address: "10.244.0.1", ServiceAccount: "sa1"}, {Address: "10.244.0.2", ServiceAccount: "sa-vm2"}},
+					c1Key: cluster1Endppoints,
+					c2Key: {{Address: "10.244.0.1", ServiceAccount: "sa1"}, {Address: "10.244.0.2", ServiceAccount: "sa-vm2"}},
 				},
 				ServiceAccounts: map[string]struct{}{
 					"sa1":    {},
@@ -712,12 +717,12 @@ func TestZeroEndpointShardSA(t *testing.T) {
 	s.EndpointIndex = model.NewEndpointIndex()
 	originalEndpointsShard, _ := s.EndpointIndex.GetOrCreateEndpointShard("test", "test")
 	originalEndpointsShard.Shards = map[model.ShardKey][]*model.IstioEndpoint{
-		"c1": cluster1Endppoints,
+		c1Key: cluster1Endppoints,
 	}
 	originalEndpointsShard.ServiceAccounts = map[string]struct{}{
 		"sa1": {},
 	}
-	s.EDSCacheUpdate("c1", "test", "test", []*model.IstioEndpoint{})
+	s.EDSCacheUpdate(c1Key, "test", "test", []*model.IstioEndpoint{})
 	modifiedShard, _ := s.EndpointIndex.GetOrCreateEndpointShard("test", "test")
 	if len(modifiedShard.ServiceAccounts) != 0 {
 		t.Errorf("endpoint shard service accounts got %v want 0", len(modifiedShard.ServiceAccounts))

--- a/pilot/pkg/xds/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoint_builder.go
@@ -278,7 +278,7 @@ func (b *EndpointBuilder) buildLocalityLbEndpointsFromShards(
 	// and should, therefore, not be accessed from outside the cluster.
 	isClusterLocal := b.clusterLocal
 
-	shards.RLock()
+	shards.Lock()
 	// Extract shard keys so we can iterate in order. This ensures a stable EDS output.
 	keys := shards.Keys()
 	// The shards are updated independently, now need to filter and merge for this cluster
@@ -333,7 +333,7 @@ func (b *EndpointBuilder) buildLocalityLbEndpointsFromShards(
 			locLbEps.append(ep, ep.EnvoyEndpoint, ep.TunnelAbility)
 		}
 	}
-	shards.RUnlock()
+	shards.Unlock()
 
 	locEps := make([]*LocLbEndpointsAndOptions, 0, len(localityEpMap))
 	locs := make([]string, 0, len(localityEpMap))

--- a/pilot/pkg/xds/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoint_builder.go
@@ -279,9 +279,7 @@ func (b *EndpointBuilder) buildLocalityLbEndpointsFromShards(
 	isClusterLocal := b.clusterLocal
 
 	shards.RLock()
-	// Extract shard keys so we can iterate in order. This ensures a stable EDS output. Since
-	// len(shards) ~= number of remote clusters which isn't too large, doing this sort shouldn't be
-	// too problematic. If it becomes an issue we can cache it in the EndpointShards struct.
+	// Extract shard keys so we can iterate in order. This ensures a stable EDS output.
 	keys := shards.Keys()
 	// The shards are updated independently, now need to filter and merge for this cluster
 	for _, shardKey := range keys {

--- a/pilot/pkg/xds/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoint_builder.go
@@ -267,7 +267,7 @@ func (e *LocLbEndpointsAndOptions) AssertInvarianceInTest() {
 
 // build LocalityLbEndpoints for a cluster from existing EndpointShards.
 func (b *EndpointBuilder) buildLocalityLbEndpointsFromShards(
-	shards *EndpointShards,
+	shards *model.EndpointShards,
 	svcPort *model.Port,
 ) []*LocLbEndpointsAndOptions {
 	localityEpMap := make(map[string]*LocLbEndpointsAndOptions)
@@ -278,7 +278,7 @@ func (b *EndpointBuilder) buildLocalityLbEndpointsFromShards(
 	// and should, therefore, not be accessed from outside the cluster.
 	isClusterLocal := b.clusterLocal
 
-	shards.mutex.Lock()
+	shards.Lock()
 	// Extract shard keys so we can iterate in order. This ensures a stable EDS output. Since
 	// len(shards) ~= number of remote clusters which isn't too large, doing this sort shouldn't be
 	// too problematic. If it becomes an issue we can cache it in the EndpointShards struct.
@@ -343,7 +343,7 @@ func (b *EndpointBuilder) buildLocalityLbEndpointsFromShards(
 			locLbEps.append(ep, ep.EnvoyEndpoint, ep.TunnelAbility)
 		}
 	}
-	shards.mutex.Unlock()
+	shards.Unlock()
 
 	locEps := make([]*LocLbEndpointsAndOptions, 0, len(localityEpMap))
 	locs := make([]string, 0, len(localityEpMap))

--- a/pilot/pkg/xds/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoint_builder.go
@@ -296,7 +296,7 @@ func (b *EndpointBuilder) buildLocalityLbEndpointsFromShards(
 		endpoints := shards.Shards[shardKey]
 		// If the downstream service is configured as cluster-local, only include endpoints that
 		// reside in the same cluster.
-		if isClusterLocal && (shardKey.Cluster() != b.clusterID) {
+		if isClusterLocal && (shardKey.Cluster != b.clusterID) {
 			continue
 		}
 		for _, ep := range endpoints {

--- a/pilot/pkg/xds/ep_filters_test.go
+++ b/pilot/pkg/xds/ep_filters_test.go
@@ -736,8 +736,8 @@ func environment(t test.Failer, c ...config.Config) *FakeDiscoveryServer {
 //  - 1 endpoints in network4
 //
 // All endpoints are part of service example.ns.svc.cluster.local on port 80 (http).
-func testShards() *EndpointShards {
-	shards := &EndpointShards{Shards: map[model.ShardKey][]*model.IstioEndpoint{
+func testShards() *model.EndpointShards {
+	shards := &model.EndpointShards{Shards: map[model.ShardKey][]*model.IstioEndpoint{
 		// network1 has one endpoint in each cluster
 		"cluster1a": {
 			{Network: "network1", Address: "10.0.0.1"},

--- a/pilot/pkg/xds/ep_filters_test.go
+++ b/pilot/pkg/xds/ep_filters_test.go
@@ -739,18 +739,18 @@ func environment(t test.Failer, c ...config.Config) *FakeDiscoveryServer {
 func testShards() *model.EndpointShards {
 	shards := &model.EndpointShards{Shards: map[model.ShardKey][]*model.IstioEndpoint{
 		// network1 has one endpoint in each cluster
-		"cluster1a": {
+		model.ShardKey{Cluster: "cluster1a"}: {
 			{Network: "network1", Address: "10.0.0.1"},
 		},
-		"cluster1b": {
+		model.ShardKey{Cluster: "cluster1b"}: {
 			{Network: "network1", Address: "10.0.0.2"},
 		},
 
 		// network2 has an imbalance of endpoints between its clusters
-		"cluster2a": {
+		model.ShardKey{Cluster: "cluster2a"}: {
 			{Network: "network2", Address: "20.0.0.1"},
 		},
-		"cluster2b": {
+		model.ShardKey{Cluster: "cluster2b"}: {
 			{Network: "network2", Address: "20.0.0.2"},
 			{Network: "network2", Address: "20.0.0.3"},
 		},
@@ -759,12 +759,12 @@ func testShards() *model.EndpointShards {
 
 		// network4 has a single endpoint, but not gateway so it will always
 		// be considered directly reachable.
-		"cluster4": {
+		model.ShardKey{Cluster: "cluster4"}: {
 			{Network: "network4", Address: "40.0.0.1"},
 		},
 	}}
 	// apply common properties
-	for clusterID, shard := range shards.Shards {
+	for sk, shard := range shards.Shards {
 		for i, ep := range shard {
 			ep.ServicePortName = "http"
 			ep.Namespace = "ns"
@@ -772,8 +772,8 @@ func testShards() *model.EndpointShards {
 			ep.EndpointPort = 8080
 			ep.TLSMode = "istio"
 			ep.Labels = map[string]string{"app": "example"}
-			ep.Locality.ClusterID = cluster.ID(clusterID)
-			shards.Shards[clusterID][i] = ep
+			ep.Locality.ClusterID = sk.Cluster
+			shards.Shards[sk][i] = ep
 		}
 	}
 	return shards

--- a/pilot/pkg/xds/ep_filters_test.go
+++ b/pilot/pkg/xds/ep_filters_test.go
@@ -739,18 +739,18 @@ func environment(t test.Failer, c ...config.Config) *FakeDiscoveryServer {
 func testShards() *model.EndpointShards {
 	shards := &model.EndpointShards{Shards: map[model.ShardKey][]*model.IstioEndpoint{
 		// network1 has one endpoint in each cluster
-		model.ShardKey{Cluster: "cluster1a"}: {
+		{Cluster: "cluster1a"}: {
 			{Network: "network1", Address: "10.0.0.1"},
 		},
-		model.ShardKey{Cluster: "cluster1b"}: {
+		{Cluster: "cluster1b"}: {
 			{Network: "network1", Address: "10.0.0.2"},
 		},
 
 		// network2 has an imbalance of endpoints between its clusters
-		model.ShardKey{Cluster: "cluster2a"}: {
+		{Cluster: "cluster2a"}: {
 			{Network: "network2", Address: "20.0.0.1"},
 		},
-		model.ShardKey{Cluster: "cluster2b"}: {
+		{Cluster: "cluster2b"}: {
 			{Network: "network2", Address: "20.0.0.2"},
 			{Network: "network2", Address: "20.0.0.3"},
 		},
@@ -759,7 +759,7 @@ func testShards() *model.EndpointShards {
 
 		// network4 has a single endpoint, but not gateway so it will always
 		// be considered directly reachable.
-		model.ShardKey{Cluster: "cluster4"}: {
+		{Cluster: "cluster4"}: {
 			{Network: "network4", Address: "40.0.0.1"},
 		},
 	}}


### PR DESCRIPTION
1. Allows passing a reference to the formerly names EndpointShardsByService to generators living outside `xds` package. 
2. Prework for https://github.com/istio/istio/issues/36365. This will help in creating some way to write to one set of shards and swap in the new ones after sync (in updating remote secret). 

not 100% convinced this is needed for the latter case; hope the cleanup is worthwhile regardless. Only concern is some indirection that preserves some concurrency cache invalidation behavior. 