### PR TITLE
PushRequest start time merge

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -448,16 +448,16 @@ func (pr *PushRequest) CopyMerge(other *PushRequest) *PushRequest {
 		reason = append(reason, pr.Reason...)
 		reason = append(reason, other.Reason...)
 	}
-
+	startTime := pr.Start
 	if pr.Start.IsZero() {
-		pr.Start = other.Start
+		startTime = other.Start
 	} else if !other.Start.IsZero() && pr.Start.After(other.Start) {
-		pr.Start = other.Start
+		startTime = other.Start
 	}
 
 	merged := &PushRequest{
 		// Keep the first (older) start time
-		Start: pr.Start,
+		Start: startTime,
 
 		// If either is full we need a full push
 		Full: pr.Full || other.Full,

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -413,6 +413,12 @@ func (pr *PushRequest) Merge(other *PushRequest) *PushRequest {
 		pr.Push = other.Push
 	}
 
+	if pr.Start.IsZero() {
+		pr.Start = other.Start
+	} else if !other.Start.IsZero() && pr.Start.After(other.Start) {
+		pr.Start = other.Start
+	}
+
 	// Do not merge when any one is empty
 	if len(pr.ConfigsUpdated) == 0 || len(other.ConfigsUpdated) == 0 {
 		pr.ConfigsUpdated = nil
@@ -442,6 +448,13 @@ func (pr *PushRequest) CopyMerge(other *PushRequest) *PushRequest {
 		reason = append(reason, pr.Reason...)
 		reason = append(reason, other.Reason...)
 	}
+
+	if pr.Start.IsZero() {
+		pr.Start = other.Start
+	} else if !other.Start.IsZero() && pr.Start.After(other.Start) {
+		pr.Start = other.Start
+	}
+
 	merged := &PushRequest{
 		// Keep the first (older) start time
 		Start: pr.Start,

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -54,7 +54,7 @@ func TestMergeUpdateRequest(t *testing.T) {
 	// trivially different push contexts just for testing
 	push1 := &PushContext{ProxyStatus: make(map[string]map[string]ProxyPushStatus)}
 
-	var t0 time.Time
+	t0 := time.Now()
 	t1 := t0.Add(time.Minute)
 
 	cases := []struct {
@@ -113,6 +113,18 @@ func TestMergeUpdateRequest(t *testing.T) {
 				Kind: config.GroupVersionKind{Kind: "cfg2"},
 			}: {}}},
 			PushRequest{Full: true, ConfigsUpdated: nil, Reason: nil},
+		},
+		{
+			"time merge: left is zero",
+			&PushRequest{Full: true, ConfigsUpdated: nil},
+			&PushRequest{Full: true, ConfigsUpdated: nil, Start: t1},
+			PushRequest{Full: true, ConfigsUpdated: nil, Reason: nil, Start: t1},
+		},
+		{
+			"time merge: right is zero",
+			&PushRequest{Full: true, ConfigsUpdated: nil, Start: t1},
+			&PushRequest{Full: true, ConfigsUpdated: nil},
+			PushRequest{Full: true, ConfigsUpdated: nil, Reason: nil, Start: t1},
 		},
 	}
 


### PR DESCRIPTION
**Please provide a description of this PR:**
when two push request merged , PushRequest.Start should keep the older one & non-zero one;

| t0 | t1 | result |
| -- | -- | -- |
| time.Now() | t0.Add(time.Minute) | t1 |
| nil | time.Now() | t1 |
| time.Now() | nil | t0 |