### PR TITLE
Revert "The enhancement for function IsIPv6Proxy"

### DIFF
--- a/pilot/pkg/util/network/ip.go
+++ b/pilot/pkg/util/network/ip.go
@@ -144,7 +144,6 @@ func ResolveAddr(addr string, lookupIPAddr ...lookupIPAddrType) (string, error) 
 // IsIPv6Proxy check the addresses slice and returns true for all addresses are valid IPv6 address
 // for all other cases it returns false
 func IsIPv6Proxy(ipAddrs []string) bool {
-	result := false
 	for i := 0; i < len(ipAddrs); i++ {
 		addr := net.ParseIP(ipAddrs[i])
 		if addr == nil {
@@ -152,12 +151,9 @@ func IsIPv6Proxy(ipAddrs []string) bool {
 			// skip it to prevent a panic.
 			continue
 		}
-
-		// need to check that a proxy can have an IPv6 address but configuration is not configured K8s for dual-stack support.
-		// In this case an ipv6 link local address will appear, but not one that is routable to with K8s
-		if addr.To4() == nil && addr.To16() != nil && !addr.IsLinkLocalUnicast() {
-			result = true
+		if addr.To4() != nil {
+			return false
 		}
 	}
-	return result
+	return true
 }

--- a/pilot/pkg/util/network/ip_test.go
+++ b/pilot/pkg/util/network/ip_test.go
@@ -202,7 +202,7 @@ func TestIsIPv6Proxy(t *testing.T) {
 		{
 			name:     "mixed ipv4 and ipv6",
 			addrs:    []string{"1111:2222::1", "::1", "127.0.0.1", "2.2.2.2", "2222:3333::1"},
-			expected: true,
+			expected: false,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Reverts istio/istio#37654

This introduces a breaking change to pilot-agent localhost listeners. Previously, these listened on 127.0.0.1; now they listen on `::1`. This represents a non-flag protected breaking change. I do not think we should break users accessing admin interfaces over IPv4.