### PR TITLE
syncz support ECDS

### DIFF
--- a/pilot/pkg/xds/debug.go
+++ b/pilot/pkg/xds/debug.go
@@ -108,18 +108,20 @@ type AdsClients struct {
 
 // SyncStatus is the synchronization status between Pilot and a given Envoy
 type SyncStatus struct {
-	ClusterID     string `json:"cluster_id,omitempty"`
-	ProxyID       string `json:"proxy,omitempty"`
-	ProxyVersion  string `json:"proxy_version,omitempty"`
-	IstioVersion  string `json:"istio_version,omitempty"`
-	ClusterSent   string `json:"cluster_sent,omitempty"`
-	ClusterAcked  string `json:"cluster_acked,omitempty"`
-	ListenerSent  string `json:"listener_sent,omitempty"`
-	ListenerAcked string `json:"listener_acked,omitempty"`
-	RouteSent     string `json:"route_sent,omitempty"`
-	RouteAcked    string `json:"route_acked,omitempty"`
-	EndpointSent  string `json:"endpoint_sent,omitempty"`
-	EndpointAcked string `json:"endpoint_acked,omitempty"`
+	ClusterID            string `json:"cluster_id,omitempty"`
+	ProxyID              string `json:"proxy,omitempty"`
+	ProxyVersion         string `json:"proxy_version,omitempty"`
+	IstioVersion         string `json:"istio_version,omitempty"`
+	ClusterSent          string `json:"cluster_sent,omitempty"`
+	ClusterAcked         string `json:"cluster_acked,omitempty"`
+	ListenerSent         string `json:"listener_sent,omitempty"`
+	ListenerAcked        string `json:"listener_acked,omitempty"`
+	RouteSent            string `json:"route_sent,omitempty"`
+	RouteAcked           string `json:"route_acked,omitempty"`
+	EndpointSent         string `json:"endpoint_sent,omitempty"`
+	EndpointAcked        string `json:"endpoint_acked,omitempty"`
+	ExtesionConfigSent   string `json:"extensionconfig_sent,omitempty"`
+	ExtensionConfigAcked string `json:"extensionconfig_acked,omitempty"`
 }
 
 // SyncedVersions shows what resourceVersion of a given resource has been acked by Envoy.
@@ -268,17 +270,19 @@ func (s *DiscoveryServer) Syncz(w http.ResponseWriter, _ *http.Request) {
 		node := con.proxy
 		if node != nil {
 			syncz = append(syncz, SyncStatus{
-				ProxyID:       node.ID,
-				ClusterID:     node.Metadata.ClusterID.String(),
-				IstioVersion:  node.Metadata.IstioVersion,
-				ClusterSent:   con.NonceSent(v3.ClusterType),
-				ClusterAcked:  con.NonceAcked(v3.ClusterType),
-				ListenerSent:  con.NonceSent(v3.ListenerType),
-				ListenerAcked: con.NonceAcked(v3.ListenerType),
-				RouteSent:     con.NonceSent(v3.RouteType),
-				RouteAcked:    con.NonceAcked(v3.RouteType),
-				EndpointSent:  con.NonceSent(v3.EndpointType),
-				EndpointAcked: con.NonceAcked(v3.EndpointType),
+				ProxyID:              node.ID,
+				ClusterID:            node.Metadata.ClusterID.String(),
+				IstioVersion:         node.Metadata.IstioVersion,
+				ClusterSent:          con.NonceSent(v3.ClusterType),
+				ClusterAcked:         con.NonceAcked(v3.ClusterType),
+				ListenerSent:         con.NonceSent(v3.ListenerType),
+				ListenerAcked:        con.NonceAcked(v3.ListenerType),
+				RouteSent:            con.NonceSent(v3.RouteType),
+				RouteAcked:           con.NonceAcked(v3.RouteType),
+				EndpointSent:         con.NonceSent(v3.EndpointType),
+				EndpointAcked:        con.NonceAcked(v3.EndpointType),
+				ExtesionConfigSent:   con.NonceSent(v3.ExtensionConfigurationType),
+				ExtensionConfigAcked: con.NonceSent(v3.ExtensionConfigurationType),
 			})
 		}
 	}


### PR DESCRIPTION
**Please provide a description of this PR:**

```json
[
    {
        "cluster_id": "Kubernetes",
        "proxy": "sleep-557747455f-ntclb.default",
        "istio_version": "1.14-dev",
        "cluster_sent": "H/Wuh8XL+DI=acda010e-b2f3-4ea3-99d7-3175f5448242",
        "cluster_acked": "H/Wuh8XL+DI=acda010e-b2f3-4ea3-99d7-3175f5448242",
        "listener_sent": "H/Wuh8XL+DI=799ac99c-1f49-45a0-9d44-b6485483c0a2",
        "listener_acked": "H/Wuh8XL+DI=799ac99c-1f49-45a0-9d44-b6485483c0a2",
        "route_sent": "H/Wuh8XL+DI=ea566798-bad5-49aa-a434-62465e4fa34d",
        "route_acked": "H/Wuh8XL+DI=ea566798-bad5-49aa-a434-62465e4fa34d",
        "endpoint_sent": "H/Wuh8XL+DI=ee385484-be99-4b39-8f43-d0b044869c5f",
        "endpoint_acked": "H/Wuh8XL+DI=ee385484-be99-4b39-8f43-d0b044869c5f"
    },
    {
        "cluster_id": "Kubernetes",
        "proxy": "fortio-deploy-687945c6dc-h9gw8.default",
        "istio_version": "1.14-dev",
        "cluster_sent": "H/Wuh8XL+DI=d59571b2-bc7b-43ec-8584-17c20769e01c",
        "cluster_acked": "H/Wuh8XL+DI=d59571b2-bc7b-43ec-8584-17c20769e01c",
        "listener_sent": "H/Wuh8XL+DI=fd5197bf-06b0-4773-9659-e745f97073e7",
        "listener_acked": "H/Wuh8XL+DI=fd5197bf-06b0-4773-9659-e745f97073e7",
        "route_sent": "H/Wuh8XL+DI=d998b8a5-f1f5-4741-bb0a-fbe849e16c02",
        "route_acked": "H/Wuh8XL+DI=d998b8a5-f1f5-4741-bb0a-fbe849e16c02",
        "endpoint_sent": "H/Wuh8XL+DI=c143b7be-9161-411a-848b-604e4d347ec1",
        "endpoint_acked": "H/Wuh8XL+DI=c143b7be-9161-411a-848b-604e4d347ec1"
    },
    {
        "cluster_id": "Kubernetes",
        "proxy": "httpbin-74fb669cc6-htg48.default",
        "istio_version": "1.14-dev",
        "cluster_sent": "H/Wuh8XL+DI=8bc66755-2f77-48ba-868e-3e2473b0524b",
        "cluster_acked": "H/Wuh8XL+DI=8bc66755-2f77-48ba-868e-3e2473b0524b",
        "listener_sent": "H/Wuh8XL+DI=07beb0d8-bcfb-46a7-9e3d-987932e7f0e5",
        "listener_acked": "H/Wuh8XL+DI=07beb0d8-bcfb-46a7-9e3d-987932e7f0e5",
        "route_sent": "H/Wuh8XL+DI=65310c6b-2feb-4c3d-b160-103f2f3a337e",
        "route_acked": "H/Wuh8XL+DI=65310c6b-2feb-4c3d-b160-103f2f3a337e",
        "endpoint_sent": "H/Wuh8XL+DI=a49e558b-0bf0-4fff-9576-ecb764df6698",
        "endpoint_acked": "H/Wuh8XL+DI=a49e558b-0bf0-4fff-9576-ecb764df6698",
        "extensionconfig_sent": "H/Wuh8XL+DI=a37bd385-91cb-4b92-8fa7-1459fcb2a2db",
        "extensionconfig_acked": "H/Wuh8XL+DI=a37bd385-91cb-4b92-8fa7-1459fcb2a2db"
    },
    {
        "cluster_id": "Kubernetes",
        "proxy": "istio-ingressgateway-86f7769fdf-f9fp9.istio-system",
        "istio_version": "1.14-dev",
        "cluster_sent": "H/Wuh8XL+DI=b6c1aba4-baa4-4f0b-ae96-c3fa9c6c71a2",
        "cluster_acked": "H/Wuh8XL+DI=b6c1aba4-baa4-4f0b-ae96-c3fa9c6c71a2",
        "listener_sent": "H/Wuh8XL+DI=09e72b72-8666-4bad-8eb9-ce54ef1b9bcc",
        "listener_acked": "H/Wuh8XL+DI=09e72b72-8666-4bad-8eb9-ce54ef1b9bcc"
    }
]
```