### PR TITLE
Convert deprecated filter names to canonical one

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch.go
@@ -246,7 +246,8 @@ func patchNetworkFilters(patchContext networking.EnvoyFilter_PatchContext,
 		}
 	}
 	for _, lp := range patches[networking.EnvoyFilter_NETWORK_FILTER] {
-		if !commonConditionMatch(patchContext, lp) ||
+		if lp.Operation == networking.EnvoyFilter_Patch_REMOVE ||
+			!commonConditionMatch(patchContext, lp) ||
 			!listenerMatch(listener, lp) ||
 			!filterChainMatch(listener, fc, lp) {
 			IncrementEnvoyFilterMetric(lp.Key(), NetworkFilter, false)
@@ -421,7 +422,8 @@ func patchHTTPFilters(patchContext networking.EnvoyFilter_PatchContext,
 	}
 	for _, lp := range patches[networking.EnvoyFilter_HTTP_FILTER] {
 		applied := false
-		if !commonConditionMatch(patchContext, lp) ||
+		if lp.Operation == networking.EnvoyFilter_Patch_REMOVE ||
+			!commonConditionMatch(patchContext, lp) ||
 			!listenerMatch(listener, lp) ||
 			!filterChainMatch(listener, fc, lp) ||
 			!networkFilterMatch(filter, lp) {

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch_test.go
@@ -390,7 +390,7 @@ func TestApplyListenerPatches(t *testing.T) {
 			},
 			Patch: &networking.EnvoyFilter_Patch{
 				Operation: networking.EnvoyFilter_Patch_INSERT_FIRST,
-				Value:     buildPatchStruct(`{"name": "http-filter0"}`),
+				Value:     buildPatchStruct(`{"name": "envoy.rate_limit"}`), // deprecated name
 			},
 		},
 		{
@@ -1045,7 +1045,7 @@ func TestApplyListenerPatches(t *testing.T) {
 				{
 					Filters: []*listener.Filter{
 						{
-							Name: "envoy.redis_proxy",
+							Name: wellknown.RedisProxy,
 							ConfigType: &listener.Filter_TypedConfig{
 								TypedConfig: util.MessageToAny(&redis_proxy.RedisProxy{
 									StatPrefix: "redis_stats",
@@ -1585,7 +1585,7 @@ func TestApplyListenerPatches(t *testing.T) {
 									MergeSlashes:                 true,
 									AlwaysSetRequestIdInResponse: true,
 									HttpFilters: []*http_conn.HttpFilter{
-										{Name: "http-filter0"},
+										{Name: wellknown.HTTPRateLimit},
 										{
 											Name:       wellknown.Fault,
 											ConfigType: &http_conn.HttpFilter_TypedConfig{TypedConfig: faultFilterOutAny},
@@ -1626,7 +1626,7 @@ func TestApplyListenerPatches(t *testing.T) {
 					},
 					Filters: []*listener.Filter{
 						{
-							Name: "envoy.redis_proxy",
+							Name: wellknown.RedisProxy,
 							ConfigType: &listener.Filter_TypedConfig{
 								TypedConfig: util.MessageToAny(&redis_proxy.RedisProxy{
 									StatPrefix: "redis_stats",

--- a/pilot/pkg/xds/lds_test.go
+++ b/pilot/pkg/xds/lds_test.go
@@ -344,7 +344,7 @@ func expectLuaFilter(t *testing.T, l *listener.Listener, expected bool) {
 		}
 		found := false
 		for _, filter := range connectionManagerCfg.HttpFilters {
-			if filter.Name == "envoy.lua" {
+			if filter.Name == wellknown.Lua {
 				found = true
 			}
 		}


### PR DESCRIPTION
**Please provide a description of this PR:**

Currently we can get a deprecated name in listener.  Below is an example

```
apiVersion: networking.istio.io/v1alpha3
kind: EnvoyFilter
metadata:
  name: size-limit
  namespace: istio-system
spec:
  workloadSelector:
    labels:
      istio: ingressgateway
  configPatches:
    - applyTo: HTTP_FILTER
      match:
        context: GATEWAY
        listener:
          filterChain:
            filter:
              name: envoy.filters.network.http_connection_manager
      patch:
        operation: INSERT_BEFORE
        value:
          name: envoy.buffer
          typed_config:
            '@type': type.googleapis.com/udpa.type.v1.TypedStruct
            value:
              maxRequestBytes: 1073741824
```