### PR TITLE
Added warning for setupkind script

### DIFF
--- a/samples/kind-lb/README.md
+++ b/samples/kind-lb/README.md
@@ -1,7 +1,10 @@
 
 # Create a KinD cluster with an external load balancer
 
-This bash script sets up a k8s cluster using kind and metallb.
+This bash script sets up a k8s cluster using kind and metallb on Linux.
+
+WARNING: when it runs in an environment other than Linux, it will only
+produce an error message.
 
 The following dependencies must be installed before running the script:
   1. kubectl

--- a/samples/kind-lb/setupkind.sh
+++ b/samples/kind-lb/setupkind.sh
@@ -5,6 +5,13 @@
 #
 set -e
 
+# This script can only produce desired results on Linux systems.
+ENVOS=$(uname 2>/dev/null || true)
+if [[ "${ENVOS}" != "Linux" ]]; then
+  echo "Your environment is not supported by this script."
+  exit 1
+fi
+
 # Check prerequisites
 REQUISITES=("kubectl" "kind" "docker")
 for item in "${REQUISITES[@]}"; do


### PR DESCRIPTION
setupkind script can only successfully setup kind
with metallb in Linux environment. This PR will warn
a user if this script gets run in an envrionment other
than Linux

Signed-off-by: Tong Li <litong01@us.ibm.com>

**Please provide a description of this PR:**