### PR TITLE
Remove meaningless CA authentication check at agent unit test.

### DIFF
--- a/pkg/istio-agent/agent_test.go
+++ b/pkg/istio-agent/agent_test.go
@@ -278,11 +278,6 @@ func TestAgent(t *testing.T) {
 				return a
 			})
 			a.Check(t, security.WorkloadKeyCertResourceName, security.RootCertReqResourceName)
-
-			// Switch out our auth to only allow mTLS. In practice, the real server would allow JWT, but we
-			// don't have a good way to expire JWTs here. Instead, we just deny all JWTs to ensure mTLS is used
-			a.CaAuthenticator.Set("", filepath.Join(dir, "cert-chain.pem"))
-			a.Check(t, security.WorkloadKeyCertResourceName, security.RootCertReqResourceName)
 		})
 		t.Run("reboot", func(t *testing.T) {
 			// Switch the JWT to a bogus path, to simulate the VM being rebooted


### PR DESCRIPTION
This check is both wrong (input of fake ca authenticator expects an identity instead of a file) and meaningless (since cert will be fetched from the cache instead of connecting to the CA). IIUC the `reboot` case below will test out mTLS based authentication, so no need to deal with it in the `initial run` case, which has no way to clean up cache at secret client.

cc @stevenctl 