### PR TITLE
Support mounting volumes to gateway via Helm chart

### DIFF
--- a/manifests/charts/gateway/templates/deployment.yaml
+++ b/manifests/charts/gateway/templates/deployment.yaml
@@ -86,6 +86,10 @@ spec:
             name: http-envoy-prom
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -96,5 +100,9 @@ spec:
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.volumes }}
+      volumes:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/manifests/charts/gateway/values.schema.json
+++ b/manifests/charts/gateway/values.schema.json
@@ -188,6 +188,26 @@
           }
         }
       }
+    },
+    "volumes": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "volumeMounts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "mountPath": {
+            "type": "string"
+          }
+        }
+      }
     }
   }
 }

--- a/manifests/charts/gateway/values.yaml
+++ b/manifests/charts/gateway/values.yaml
@@ -87,3 +87,7 @@ affinity: {}
 networkGateway: ""
 
 imagePullSecrets: []
+
+volumeMounts: []
+
+volumes: []

--- a/releasenotes/notes/36999.yaml
+++ b/releasenotes/notes/36999.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+issue:
+  - 36999
+
+releaseNotes:
+  - |
+    **Added** volumeMount and volumes values for istio/gateway Helm chart. Fixes (#36999)[https://github.com/istio/istio/issues/36999).


### PR DESCRIPTION
**Please provide a description of this PR:**
This PR enables the mounting of volumes to a gateway via the Helm chart 'istio/gateway'. Mounting a volume is for instance necessary to supply the needed tokens for the oauth2 filter, such as described in issue #36999