### PR TITLE
Fix the init target so users can use their own Envoy

### DIFF
--- a/bin/init.sh
+++ b/bin/init.sh
@@ -80,6 +80,13 @@ function download_envoy_if_necessary () {
     echo "Copying $2 to $(dirname "$2")/${3}"
     cp -f "$2" "$(dirname "$2")/${3}"
     popd
+
+  else
+    # The Envoy binary already exists; this is the case when user overrides the
+    # ISTIO_ENVOY_LINUX_RELEASE_PATH variable to use their own Envoy.
+    # In this case, we must copy it to the release directory
+    mkdir -p "${ISTIO_ENVOY_LINUX_RELEASE_DIR}"
+    cp -f "$2" "${ISTIO_ENVOY_LINUX_RELEASE_DIR}"
   fi
 }
 


### PR DESCRIPTION
If users override the variable `ISTIO_ENVOY_LINUX_RELEASE_PATH` in an
attempt to use their own version of Envoy, they will face an error in
the docker build stage, because it expects the binary to be in the
`ISTIO_ENVOY_LINUX_RELEASE_DIR` location (aka
`out/linux_amd64/release`).

This change makes sure we copy it to the expected place.