### PR TITLE
Restore Set.InsertAll

### DIFF
--- a/pilot/pkg/config/kube/gateway/controller.go
+++ b/pilot/pkg/config/kube/gateway/controller.go
@@ -313,8 +313,8 @@ func (c *Controller) namespaceEvent(oldObj interface{}, newObj interface{}) {
 	// First, find all the label keys on the old/new namespace. We include NamespaceNameLabel
 	// since we have special logic to always allow this on namespace.
 	touchedNamespaceLabels := sets.New(NamespaceNameLabel)
-	touchedNamespaceLabels.Insert(getLabelKeys(oldObj)...)
-	touchedNamespaceLabels.Insert(getLabelKeys(newObj)...)
+	touchedNamespaceLabels.InsertAll(getLabelKeys(oldObj)...)
+	touchedNamespaceLabels.InsertAll(getLabelKeys(newObj)...)
 
 	// Next, we find all keys our Gateways actually reference.
 	c.stateMu.RLock()

--- a/pilot/pkg/config/kube/gateway/conversion.go
+++ b/pilot/pkg/config/kube/gateway/conversion.go
@@ -1213,7 +1213,7 @@ func convertGateways(r *KubernetesResources) ([]config.Config, map[parentKey]map
 		invalidListeners := []k8s.SectionName{}
 		for i, l := range kgw.Listeners {
 			i := i
-			namespaceLabelReferences.Insert(getNamespaceLabelReferences(l.AllowedRoutes)...)
+			namespaceLabelReferences.InsertAll(getNamespaceLabelReferences(l.AllowedRoutes)...)
 			server, ok := buildListener(r, obj, l, i)
 			if !ok {
 				invalidListeners = append(invalidListeners, l.Name)

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -2105,7 +2105,7 @@ func (gc GatewayContext) ResolveGatewayInstances(namespace string, gwsvcs []stri
 				foundInternal.Insert(fmt.Sprintf("%s:%d", g, port))
 				// Fetch external IPs from all clusters
 				svc.Attributes.ClusterExternalAddresses.ForEach(func(c cluster.ID, externalIPs []string) {
-					foundExternal.Insert(externalIPs...)
+					foundExternal.InsertAll(externalIPs...)
 				})
 			} else {
 				if instancesEmpty(gc.ps.ServiceIndex.instancesByPort[svcKey]) {

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -819,7 +819,7 @@ func GetServiceAccounts(svc *Service, ports []int, discovery ServiceDiscovery) [
 			sa.Insert(si.Endpoint.ServiceAccount)
 		}
 	}
-	sa.Insert(svc.ServiceAccounts...)
+	sa.InsertAll(svc.ServiceAccounts...)
 
 	return sa.UnsortedList()
 }

--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -407,7 +407,7 @@ func BuildSidecarOutboundVirtualHosts(node *model.Proxy, push *model.PushContext
 	for _, virtualHostWrapper := range virtualHostWrappers {
 		for _, svc := range virtualHostWrapper.Services {
 			name := util.DomainName(string(svc.Hostname), virtualHostWrapper.Port)
-			knownFQDN.Insert(name, string(svc.Hostname))
+			knownFQDN.InsertAll(name, string(svc.Hostname))
 		}
 	}
 

--- a/pilot/pkg/xds/delta.go
+++ b/pilot/pkg/xds/delta.go
@@ -527,7 +527,7 @@ func deltaToSotwRequest(request *discovery.DeltaDiscoveryRequest) *discovery.Dis
 
 func deltaWatchedResources(existing []string, request *discovery.DeltaDiscoveryRequest) []string {
 	res := sets.New(existing...)
-	res.Insert(request.ResourceNamesSubscribe...)
+	res.InsertAll(request.ResourceNamesSubscribe...)
 	res.Delete(request.ResourceNamesUnsubscribe...)
 	return res.SortedList()
 }

--- a/pilot/pkg/xds/deltatest.go
+++ b/pilot/pkg/xds/deltatest.go
@@ -95,7 +95,7 @@ func (s *DiscoveryServer) compareDiff(
 
 	gotDeleted := sets.New()
 	if usedDelta {
-		gotDeleted.Insert(deleted...)
+		gotDeleted.InsertAll(deleted...)
 	}
 	gotChanged := sets.New()
 	for _, v := range resp {

--- a/pkg/config/analysis/analyzers/webhook/webhook.go
+++ b/pkg/config/analysis/analyzers/webhook/webhook.go
@@ -84,7 +84,7 @@ func (a *Analyzer) Analyze(context analysis.Context) {
 		for _, h := range wh.Webhooks {
 			resources[fmt.Sprintf("%v/%v", resource.Metadata.FullName.String(), h.Name)] = resource
 		}
-		revisions.Insert(revs...)
+		revisions.InsertAll(revs...)
 		return true
 	})
 
@@ -168,7 +168,7 @@ func extractRevisions(wh *v1.MutatingWebhookConfiguration) []string {
 
 			for _, ls := range webhook.NamespaceSelector.MatchExpressions {
 				if ls.Key == label.IoIstioRev.Name {
-					revs.Insert(ls.Values...)
+					revs.InsertAll(ls.Values...)
 				}
 			}
 		}
@@ -179,7 +179,7 @@ func extractRevisions(wh *v1.MutatingWebhookConfiguration) []string {
 
 			for _, ls := range webhook.ObjectSelector.MatchExpressions {
 				if ls.Key == label.IoIstioRev.Name {
-					revs.Insert(ls.Values...)
+					revs.InsertAll(ls.Values...)
 				}
 			}
 		}

--- a/pkg/test/framework/components/echo/deployment/builder.go
+++ b/pkg/test/framework/components/echo/deployment/builder.go
@@ -390,7 +390,7 @@ func (b builder) BuildOrFail(t test.Failer) echo.Instances {
 func (b builder) validateTemplates(config echo.Config, c cluster.Cluster) bool {
 	expected := sets.New()
 	for _, subset := range config.Subsets {
-		expected.Insert(parseList(subset.Annotations.Get(echo.SidecarInjectTemplates))...)
+		expected.InsertAll(parseList(subset.Annotations.Get(echo.SidecarInjectTemplates))...)
 	}
 	if b.templates == nil || b.templates[c.Name()] == nil {
 		return len(expected) == 0

--- a/pkg/util/sets/string.go
+++ b/pkg/util/sets/string.go
@@ -26,12 +26,18 @@ func NewWithLength(l int) Set {
 
 // New creates a new Set with the given items.
 func New(items ...string) Set {
-	s := make(Set, len(items))
-	return s.Insert(items...)
+	s := NewWithLength(len(items))
+	return s.InsertAll(items...)
 }
 
-// Insert adds items to the set.
-func (s Set) Insert(items ...string) Set {
+// Insert a single item to this Set.
+func (s Set) Insert(item string) Set {
+	s[item] = struct{}{}
+	return s
+}
+
+// InsertAll adds the items to this Set.
+func (s Set) InsertAll(items ...string) Set {
 	for _, item := range items {
 		s[item] = struct{}{}
 	}

--- a/tools/docker-builder/main.go
+++ b/tools/docker-builder/main.go
@@ -344,7 +344,7 @@ func ConstructBakeFile(a Args) (map[string]string, error) {
 					}
 				}
 			}
-			allDestinations.Insert(t.Tags...)
+			allDestinations.InsertAll(t.Tags...)
 
 			// See https://docs.docker.com/engine/reference/commandline/buildx_build/#output
 			if args.Push {

--- a/tools/docker-builder/types.go
+++ b/tools/docker-builder/types.go
@@ -99,7 +99,7 @@ type BuildPlan struct {
 func (p BuildPlan) Targets() []string {
 	tgts := sets.New()
 	for _, img := range p.Images {
-		tgts.Insert(img.Targets...)
+		tgts.InsertAll(img.Targets...)
 	}
 	return tgts.SortedList()
 }


### PR DESCRIPTION
This was removed by https://github.com/istio/istio/pull/38140, but should not have been. The Insert/InsertAll separation avoids a needless array allocation for the vast majority of Insert calls.

**Please provide a description of this PR:**