### PR TITLE
Fix the Envoy path in docker.yaml

### DIFF
--- a/tools/docker.yaml
+++ b/tools/docker.yaml
@@ -29,7 +29,7 @@ images:
   files:
   - tools/packaging/common/envoy_bootstrap.json
   - tools/packaging/common/gcp_envoy_bootstrap.json
-  - ${TARGET_OUT_LINUX}/release/${SIDECAR}
+  - ${ISTIO_ENVOY_LINUX_RELEASE_PATH}
   - ${TARGET_OUT_LINUX}/release/stats-filter.wasm
   - ${TARGET_OUT_LINUX}/release/stats-filter.compiled.wasm
   - ${TARGET_OUT_LINUX}/release/metadata-exchange-filter.wasm


### PR DESCRIPTION
Instead of assuming its location is under `${TARGET_OUT_LINUX}/release`,
use the variable `${ISTIO_ENVOY_LINUX_RELEASE_PATH}` which is more
accurate, since the user can override it with the value of a custom
Envoy binary.