### PR TITLE
Fix VM postsubmit jobs

### DIFF
--- a/prow/lib.sh
+++ b/prow/lib.sh
@@ -115,9 +115,9 @@ function build_images() {
   # Build just the images needed for tests
   targets="docker.pilot docker.proxyv2 "
 
-  # use ubuntu:bionic to test vms by default
+  # use ubuntu:jammy to test vms by default
   nonDistrolessTargets="docker.app docker.app_sidecar_ubuntu_jammy "
-  if [[ "${SELECT_TEST}" == "test.integration.pilot.kube" && "${JOB_TYPE:-presubmit}" == "postsubmit" ]]; then
+  if [[ "${JOB_TYPE:-presubmit}" == "postsubmit" ]]; then
     # We run tests across all VM types only in postsubmit
     nonDistrolessTargets+="docker.app_sidecar_ubuntu_xenial docker.app_sidecar_debian_11  docker.app_sidecar_centos_7 docker.app_sidecar_rockylinux_8 "
   fi


### PR DESCRIPTION
In a recent PR, we fixed the VM tests to actually run the different
images - previously they always ran the same image. This exposed another
bug, that we skipped building these images entirely as well. Start
building them again.

**Please provide a description of this PR:**