### PR TITLE
Add lifecycle and terminationGracePeriodSeconds overrides to gateway(s) helm charts

### DIFF
--- a/manifests/charts/gateway/templates/deployment.yaml
+++ b/manifests/charts/gateway/templates/deployment.yaml
@@ -41,10 +41,17 @@ spec:
         - name: net.ipv4.ip_unprivileged_port_start
           value: "0"
       {{- end }}
+      {{- if .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- end }}
       containers:
         - name: istio-proxy
           # "auto" will be populated at runtime by the mutating webhook. See https://istio.io/latest/docs/setup/additional-setup/sidecar-injection/#customizing-injection
           image: auto
+          {{- if .Values.lifecycle }}
+          lifecycle:
+            {{- toYaml .Values.lifecycle | nindent 12 }}
+          {{- end }}
           securityContext:
           {{- if .Values.containerSecurityContext }}
             {{- toYaml .Values.containerSecurityContext | nindent 12 }}

--- a/manifests/charts/gateway/templates/deployment.yaml
+++ b/manifests/charts/gateway/templates/deployment.yaml
@@ -41,9 +41,6 @@ spec:
         - name: net.ipv4.ip_unprivileged_port_start
           value: "0"
       {{- end }}
-      {{- if .Values.terminationGracePeriodSeconds }}
-      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
-      {{- end }}
       containers:
         - name: istio-proxy
           # "auto" will be populated at runtime by the mutating webhook. See https://istio.io/latest/docs/setup/additional-setup/sidecar-injection/#customizing-injection

--- a/manifests/charts/gateway/values.schema.json
+++ b/manifests/charts/gateway/values.schema.json
@@ -7,7 +7,7 @@
       "type": "object"
     },
     "terminationGracePeriodSeconds": {
-      "type": "integer"
+      "type": "string"
     },
     "lifecycle": {
       "type": "object"

--- a/manifests/charts/gateway/values.schema.json
+++ b/manifests/charts/gateway/values.schema.json
@@ -6,6 +6,12 @@
     "global": {
       "type": "object"
     },
+    "terminationGracePeriodSeconds": {
+      "type": "integer"
+    },
+    "lifecycle": {
+      "type": "object"
+    },
     "affinity": {
       "type": "object"
     },

--- a/manifests/charts/gateway/values.schema.json
+++ b/manifests/charts/gateway/values.schema.json
@@ -6,9 +6,6 @@
     "global": {
       "type": "object"
     },
-    "terminationGracePeriodSeconds": {
-      "type": "string"
-    },
     "lifecycle": {
       "type": "object"
     },

--- a/manifests/charts/gateway/values.yaml
+++ b/manifests/charts/gateway/values.yaml
@@ -83,6 +83,12 @@ tolerations: []
 
 affinity: {}
 
+# if specified, the terminationGracePeriodSeconds value will override the default
+terminationGracePeriodSeconds: ""
+
+# if specified, the lifecyle values will override what is set for the global proxy lifecyle values
+lifecycle: {}
+
 # If specified, the gateway will act as a network gateway for the given network.
 networkGateway: ""
 

--- a/manifests/charts/gateway/values.yaml
+++ b/manifests/charts/gateway/values.yaml
@@ -83,9 +83,6 @@ tolerations: []
 
 affinity: {}
 
-# if specified, the terminationGracePeriodSeconds value will override the default
-terminationGracePeriodSeconds: ""
-
 # if specified, the lifecyle values will override what is set for the global proxy lifecyle values
 lifecycle: {}
 

--- a/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
@@ -87,6 +87,9 @@ spec:
             runAsNonRoot: false
             privileged: true
 {{- end }}
+      {{- if .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- end }}
       containers:
         - name: istio-proxy
 {{- if contains "/" .Values.global.proxy.image }}
@@ -94,6 +97,10 @@ spec:
 {{- else }}
           image: "{{ .Values.global.hub }}/{{ .Values.global.proxy.image | default "proxyv2" }}:{{ .Values.global.tag }}"
 {{- end }}
+          {{- if .Values.lifecycle }}
+          lifecycle:
+            {{- toYaml .Values.lifecycle | nindent 12 }}
+          {{- end }}
 {{- if .Values.global.imagePullPolicy }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
 {{- end }}

--- a/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
@@ -87,9 +87,6 @@ spec:
             runAsNonRoot: false
             privileged: true
 {{- end }}
-      {{- if .Values.terminationGracePeriodSeconds }}
-      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
-      {{- end }}
       containers:
         - name: istio-proxy
 {{- if contains "/" .Values.global.proxy.image }}

--- a/manifests/charts/gateways/istio-ingress/templates/injected-deployment.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/injected-deployment.yaml
@@ -66,9 +66,16 @@ spec:
 {{- if .Values.global.priorityClassName }}
       priorityClassName: "{{ .Values.global.priorityClassName }}"
 {{- end }}
+      {{- if .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- end }}
       containers:
         - name: istio-proxy
           image: auto
+          {{- if .Values.lifecycle }}
+          lifecycle:
+            {{- toYaml .Values.lifecycle | nindent 12 }}
+          {{- end }}
           ports:
             {{- range $key, $val := $gateway.ports }}
             - containerPort: {{ $val.targetPort | default $val.port }}

--- a/manifests/charts/gateways/istio-ingress/templates/injected-deployment.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/injected-deployment.yaml
@@ -66,9 +66,6 @@ spec:
 {{- if .Values.global.priorityClassName }}
       priorityClassName: "{{ .Values.global.priorityClassName }}"
 {{- end }}
-      {{- if .Values.terminationGracePeriodSeconds }}
-      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
-      {{- end }}
       containers:
         - name: istio-proxy
           image: auto

--- a/manifests/charts/gateways/istio-ingress/values.yaml
+++ b/manifests/charts/gateways/istio-ingress/values.yaml
@@ -315,3 +315,9 @@ meshConfig:
     #        sni:               # example: tracer.somedomain
     #        subjectAltNames: []
     # - tracer.somedomain
+
+# if specified, the terminationGracePeriodSeconds value will override the default
+terminationGracePeriodSeconds: ""
+
+# if specified, the lifecyle values will override what is set for the global proxy lifecyle values
+lifecycle: {}

--- a/manifests/charts/gateways/istio-ingress/values.yaml
+++ b/manifests/charts/gateways/istio-ingress/values.yaml
@@ -316,8 +316,5 @@ meshConfig:
     #        subjectAltNames: []
     # - tracer.somedomain
 
-# if specified, the terminationGracePeriodSeconds value will override the default
-terminationGracePeriodSeconds: ""
-
 # if specified, the lifecyle values will override what is set for the global proxy lifecyle values
 lifecycle: {}


### PR DESCRIPTION
**Please provide a description of this PR:**
https://github.com/istio/istio/issues/38245

This PR adds the following optional values override to the gateway(s) helm charts:
lifecycle

This is mainly to allow people to have different values for lifecycle:preStop that are specifically needed for cloud provider load balancers that are slow to update.