### PR TITLE
create-remote-secret: handle k8s 1.24+ sa token behavior

### DIFF
--- a/istioctl/pkg/multicluster/env_test.go
+++ b/istioctl/pkg/multicluster/env_test.go
@@ -102,7 +102,7 @@ type fakeEnvironment struct {
 	wErr                    bytes.Buffer
 }
 
-func newFakeEnvironmentOrDie(t *testing.T, config *api.Config, objs ...runtime.Object) *fakeEnvironment {
+func newFakeEnvironmentOrDie(t *testing.T, minor string, config *api.Config, objs ...runtime.Object) *fakeEnvironment {
 	t.Helper()
 
 	var wOut, wErr bytes.Buffer
@@ -114,7 +114,7 @@ func newFakeEnvironmentOrDie(t *testing.T, config *api.Config, objs ...runtime.O
 			stderr:     &wErr,
 			kubeconfig: "unused",
 		},
-		client:     kube.NewFakeClient(objs...),
+		client:     kube.NewFakeClientWithVersion(minor, objs...),
 		kubeconfig: "unused",
 		wOut:       wOut,
 		wErr:       wErr,

--- a/istioctl/pkg/multicluster/remote_secret.go
+++ b/istioctl/pkg/multicluster/remote_secret.go
@@ -238,6 +238,74 @@ func getServiceAccountSecret(client kube.ExtendedClient, opt RemoteSecretOptions
 		return nil, err
 	}
 
+	if !kube.IsAtLeastVersion(client, 24) {
+		return legacyGetServiceAccountSecret(serviceAccount, client, opt)
+	}
+	return getOrCreateServiceAccountSecret(serviceAccount, client, opt)
+
+}
+
+// In 1.24+ we can't assume the secrets will be referenced in the ServiceAccount or be created automatically.
+// See https://github.com/istio/istio/issues/38246
+func getOrCreateServiceAccountSecret(
+	serviceAccount *v1.ServiceAccount,
+	client kube.ExtendedClient,
+	opt RemoteSecretOptions,
+) (*v1.Secret, error) {
+	ctx := context.TODO()
+
+	// manually specified secret, make sure it references the ServiceAccount
+	if opt.SecretName != "" {
+		secret, err := client.CoreV1().Secrets(opt.Namespace).Get(ctx, opt.SecretName, metav1.GetOptions{})
+		if err != nil {
+			return nil, fmt.Errorf("could not get specified secret %s/%s: %v",
+				opt.Namespace, opt.SecretName, err)
+		}
+		if err := validateServiceAccountSecret(serviceAccount, secret); err != nil {
+			return nil, err
+		}
+		return secret, nil
+	}
+
+	// first try to find an existing secret that references the SA
+	// TODO will the SA have any reference to secrets anymore, can we avoid this list?
+	allSecrets, err := client.CoreV1().Secrets(opt.Namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed listing secrets in %s: %v", opt.Namespace, err)
+	}
+	for _, item := range allSecrets.Items {
+		secret := item
+		if validateServiceAccountSecret(serviceAccount, &secret) == nil {
+			return &secret, nil
+		}
+	}
+
+	// finally, create the sa token secret manually
+	// https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#manually-create-a-service-account-api-token
+	// TODO ephemeral time-based tokens are preferred; we should re-think this
+	return client.CoreV1().Secrets(opt.Namespace).Create(ctx, &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        serviceAccount.Name + "-istio-remote-secret-token",
+			Annotations: map[string]string{v1.ServiceAccountNameKey: serviceAccount.Name},
+		},
+		Type: v1.SecretTypeServiceAccountToken,
+	}, metav1.CreateOptions{})
+}
+
+func validateServiceAccountSecret(serviceAccount *v1.ServiceAccount, secret *v1.Secret) error {
+	if secret.Type != v1.SecretTypeServiceAccountToken ||
+		secret.Annotations[v1.ServiceAccountNameKey] != serviceAccount.Name {
+		return fmt.Errorf("secret %s/%s does not reference ServiceAccount %s",
+			secret.Namespace, secret.Name, serviceAccount.Name)
+	}
+	return nil
+}
+
+func legacyGetServiceAccountSecret(
+	serviceAccount *v1.ServiceAccount,
+	client kube.ExtendedClient,
+	opt RemoteSecretOptions,
+) (*v1.Secret, error) {
 	if len(serviceAccount.Secrets) == 0 {
 		return nil, fmt.Errorf("no secret found in the service account: %s", serviceAccount)
 	}

--- a/istioctl/pkg/multicluster/remote_secret.go
+++ b/istioctl/pkg/multicluster/remote_secret.go
@@ -245,7 +245,7 @@ func getServiceAccountSecret(client kube.ExtendedClient, opt RemoteSecretOptions
 
 }
 
-// In 1.24+ we can't assume the secrets will be referenced in the ServiceAccount or be created automatically.
+// In Kubernetes 1.24+ we can't assume the secrets will be referenced in the ServiceAccount or be created automatically.
 // See https://github.com/istio/istio/issues/38246
 func getOrCreateServiceAccountSecret(
 	serviceAccount *v1.ServiceAccount,

--- a/istioctl/pkg/multicluster/remote_secret.go
+++ b/istioctl/pkg/multicluster/remote_secret.go
@@ -242,7 +242,6 @@ func getServiceAccountSecret(client kube.ExtendedClient, opt RemoteSecretOptions
 		return legacyGetServiceAccountSecret(serviceAccount, client, opt)
 	}
 	return getOrCreateServiceAccountSecret(serviceAccount, client, opt)
-
 }
 
 // In Kubernetes 1.24+ we can't assume the secrets will be referenced in the ServiceAccount or be created automatically.
@@ -285,11 +284,15 @@ func getOrCreateServiceAccountSecret(
 	// TODO ephemeral time-based tokens are preferred; we should re-think this
 	return client.CoreV1().Secrets(opt.Namespace).Create(ctx, &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        serviceAccount.Name + "-istio-remote-secret-token",
+			Name:        tokenSecretName(serviceAccount.Name),
 			Annotations: map[string]string{v1.ServiceAccountNameKey: serviceAccount.Name},
 		},
 		Type: v1.SecretTypeServiceAccountToken,
 	}, metav1.CreateOptions{})
+}
+
+func tokenSecretName(saName string) string {
+	return saName + "-istio-remote-secret-token"
 }
 
 func validateServiceAccountSecret(serviceAccount *v1.ServiceAccount, secret *v1.Secret) error {

--- a/pkg/config/analysis/analyzers/multicluster/istio_reader.go
+++ b/pkg/config/analysis/analyzers/multicluster/istio_reader.go
@@ -1,0 +1,1 @@
+package multicluster

--- a/pkg/config/analysis/analyzers/multicluster/istio_reader.go
+++ b/pkg/config/analysis/analyzers/multicluster/istio_reader.go
@@ -1,1 +1,0 @@
-package multicluster


### PR DESCRIPTION
A fix for https://github.com/istio/istio/issues/38246 that maintains current behavior. 

IIUC, this part doesn't break us:

> In 1.21+ secret-based tokens are no longer used for mounting into pods (ephemeral time-limited tokens are).

wip: need to add tests and release note