### PR TITLE
Fixes panic during injection from ConfigMap fallback

### DIFF
--- a/istioctl/cmd/kubeinject.go
+++ b/istioctl/cmd/kubeinject.go
@@ -393,8 +393,9 @@ func setupKubeInjectParameters(sidecarTemplate *inject.RawTemplates, valuesConfi
 			if *sidecarTemplate, err = getInjectConfigFromConfigMap(kubeconfig, revision); err != nil {
 				return nil, nil, err
 			}
+		} else {
+			return injector, nil, nil
 		}
-		return injector, nil, nil
 	}
 
 	// Get configs from IOP files firstly, and if not exists, get configs from files and configmaps.


### PR DESCRIPTION
Fixes issue #38083 

The issue is actually more broad than the issue suggests.
As far as I can tell istio will always panic at
https://github.com/istio/istio/blob/72aa6cb678025fb34a82ab21e0a68df80f4aa25c/istioctl/cmd/kubeinject.go#L393-L398

Since it returns an injector with a nil config and nil for its meshconfig. (See issue for full explanation)
Change will require to actually grab a non nil meshconfig to use during fallback and prevent panic.

Alternate solutions would be to get rid of the fallback entirely and just display an error message, as the fallback itself in its current state seems to always fail to inject.