### PR TITLE
Add the prefix to td mesh name in gcp_envoy_bootstrap.json

### DIFF
--- a/tools/packaging/common/gcp_envoy_bootstrap.json
+++ b/tools/packaging/common/gcp_envoy_bootstrap.json
@@ -1,7 +1,7 @@
 {
   "node": {
     {{ if (index .metadata.Labels "td.networking.gke.io/mesh-name") }}
-      "id": "projects/{{ .gcp_project_number }}/networks/{{ (index .metadata.Labels "td.networking.gke.io/mesh-name") }}/nodes/{{ .nodeID}}",
+      "id": "projects/{{ .gcp_project_number }}/networks/mesh:{{ (index .metadata.Labels "td.networking.gke.io/mesh-name") }}/nodes/{{ .nodeID}}",
     {{ else }}
       "id": "projects/{{ .gcp_project_number }}/networks/default/nodes/{{ .nodeID}}",
     {{ end }}


### PR DESCRIPTION
**Please provide a description of this PR:**
TD use the following format for mesh resource and gateway resource respectively
 - mesh: /projects/project-name/networks/mesh:mesh-name/nodes/<node>
 - gateway: /projects/project-name/networks/scope:scope-name/nodes/<node>

However a valid k8s label must be an empty string or consist of alphanumeric characters, '-', '_' or '.' Thus we could not include the entire string `mesh:mesh-name`. The workaround is to add `mesh:` prefix here. And only include mesh-name in the label.