### PR TITLE
[tf] Optimize scope close

### DIFF
--- a/pkg/test/framework/resource/context.go
+++ b/pkg/test/framework/resource/context.go
@@ -112,7 +112,7 @@ type Context interface {
 
 	// Cleanup runs the given function when the test context completes.
 	// This function will always run, regardless of -istio.test.nocleanup. To run only when cleanup is enabled,
-	// use WhenDone.
+	// use ConditionalCleanup.
 	// This function may not (safely) access the test context.
 	Cleanup(fn func())
 


### PR DESCRIPTION
We currently synchronously run all added closers, which can take a long time. Common use case for a closer is deleting a YAML file that was applied during a test.

This PR runs all closers in parallel. Significantly improves shutdown time on hosted k8s (e.g. GKE).

**Please provide a description of this PR:**