### PR TITLE
Fix typo in auto-sni-support releasenotes

### DIFF
--- a/releasenotes/notes/auto-sni-support.yaml
+++ b/releasenotes/notes/auto-sni-support.yaml
@@ -4,6 +4,6 @@ area: traffic-management
 releaseNotes:
    - |
      **Added** the ability to configure automatically set SNI when `DestinationRules`
-     do not specify it and `VERIFY_CLIENT_AT_CERT` is enabled.
+     do not specify it and `VERIFY_CERTIFICATE_AT_CLIENT` is enabled.
 docs:
    - https://docs.google.com/document/d/1pTUl-Ng3nXAWJb7UGJtalftznpxQEfID/


### PR DESCRIPTION
Signed-off-by: Faseela K <faseela.k@est.tech>

The environment variable was wrongly spelled in the release notes.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ X ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
