### PR TITLE
use deployment's namespace for AdmissionRequest in istioctl kube-inject

### DIFF
--- a/istioctl/cmd/kubeinject.go
+++ b/istioctl/cmd/kubeinject.go
@@ -71,7 +71,7 @@ type ExternalInjector struct {
 	injectorAddress string
 }
 
-func (e ExternalInjector) Inject(pod *corev1.Pod) ([]byte, error) {
+func (e ExternalInjector) Inject(pod *corev1.Pod, namespace string) ([]byte, error) {
 	cc := e.clientConfig
 	if cc == nil {
 		return nil, nil
@@ -138,6 +138,9 @@ func (e ExternalInjector) Inject(pod *corev1.Pod) ([]byte, error) {
 		},
 	}
 	podBytes, err := json.Marshal(pod)
+	if pod.Namespace != "" {
+		namespace = pod.Namespace
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -159,7 +162,7 @@ func (e ExternalInjector) Inject(pod *corev1.Pod) ([]byte, error) {
 			RequestResource:    nil,
 			RequestSubResource: "",
 			Name:               pod.Name,
-			Namespace:          pod.Namespace,
+			Namespace:          namespace,
 		},
 		Response: nil,
 	}

--- a/istioctl/cmd/kubeinject.go
+++ b/istioctl/cmd/kubeinject.go
@@ -71,7 +71,7 @@ type ExternalInjector struct {
 	injectorAddress string
 }
 
-func (e ExternalInjector) Inject(pod *corev1.Pod, namespace string) ([]byte, error) {
+func (e ExternalInjector) Inject(pod *corev1.Pod, deploymentNS string) ([]byte, error) {
 	cc := e.clientConfig
 	if cc == nil {
 		return nil, nil
@@ -139,7 +139,7 @@ func (e ExternalInjector) Inject(pod *corev1.Pod, namespace string) ([]byte, err
 	}
 	podBytes, err := json.Marshal(pod)
 	if pod.Namespace != "" {
-		namespace = pod.Namespace
+		deploymentNS = pod.Namespace
 	}
 	if err != nil {
 		return nil, err
@@ -162,7 +162,7 @@ func (e ExternalInjector) Inject(pod *corev1.Pod, namespace string) ([]byte, err
 			RequestResource:    nil,
 			RequestSubResource: "",
 			Name:               pod.Name,
-			Namespace:          namespace,
+			Namespace:          deploymentNS,
 		},
 		Response: nil,
 	}

--- a/pkg/kube/inject/inject.go
+++ b/pkg/kube/inject/inject.go
@@ -115,7 +115,7 @@ type (
 )
 
 type Injector interface {
-	Inject(pod *corev1.Pod) ([]byte, error)
+	Inject(pod *corev1.Pod, namespace string) ([]byte, error)
 }
 
 // Config specifies the sidecar injection configuration This includes
@@ -679,6 +679,10 @@ func IntoObject(injector Injector, sidecarTemplate Templates, valuesConfig Value
 	if name == "" {
 		name = deploymentMetadata.Name
 	}
+	namespace := metadata.Namespace
+	if namespace == "" {
+		namespace = deploymentMetadata.Namespace
+	}
 
 	var fullName string
 	if deploymentMetadata.Namespace != "" {
@@ -731,7 +735,7 @@ func IntoObject(injector Injector, sidecarTemplate Templates, valuesConfig Value
 	var patchBytes []byte
 	var err error
 	if injector != nil {
-		patchBytes, err = injector.Inject(pod)
+		patchBytes, err = injector.Inject(pod, namespace)
 	}
 	if err != nil {
 		return nil, err
@@ -745,6 +749,7 @@ func IntoObject(injector Injector, sidecarTemplate Templates, valuesConfig Value
 			return nil, merr
 		}
 	}
+
 	if patchBytes == nil {
 		if !injectRequired(IgnoredNamespaces.UnsortedList(), &Config{Policy: InjectionPolicyEnabled}, &pod.Spec, pod.ObjectMeta) {
 			warningStr := fmt.Sprintf("===> Skipping injection because %q has sidecar injection disabled\n", fullName)


### PR DESCRIPTION
This fix will make `istioctl kube-inject` respect proxyconfig CR if the deployment has namespace defined