### PR TITLE
Add istioctl analyzer for envoyFilter patch operation

### DIFF
--- a/pkg/config/analysis/analyzers/all.go
+++ b/pkg/config/analysis/analyzers/all.go
@@ -62,7 +62,7 @@ func All() []analysis.Analyzer {
 		&destinationrule.CaCertificateAnalyzer{},
 		&serviceentry.ProtocolAdressesAnalyzer{},
 		&webhook.Analyzer{},
-		&envoyfilter.EnvoyFilterAnalyzer{},
+		&envoyfilter.EnvoyPatchAnalyzer{},
 	}
 
 	analyzers = append(analyzers, schema.AllValidationAnalyzers()...)

--- a/pkg/config/analysis/analyzers/all.go
+++ b/pkg/config/analysis/analyzers/all.go
@@ -21,6 +21,7 @@ import (
 	"istio.io/istio/pkg/config/analysis/analyzers/deployment"
 	"istio.io/istio/pkg/config/analysis/analyzers/deprecation"
 	"istio.io/istio/pkg/config/analysis/analyzers/destinationrule"
+	"istio.io/istio/pkg/config/analysis/analyzers/envoyfilter"
 	"istio.io/istio/pkg/config/analysis/analyzers/gateway"
 	"istio.io/istio/pkg/config/analysis/analyzers/injection"
 	"istio.io/istio/pkg/config/analysis/analyzers/multicluster"
@@ -61,6 +62,7 @@ func All() []analysis.Analyzer {
 		&destinationrule.CaCertificateAnalyzer{},
 		&serviceentry.ProtocolAdressesAnalyzer{},
 		&webhook.Analyzer{},
+		&envoyfilter.EnvoyFilterAnalyzer{},
 	}
 
 	analyzers = append(analyzers, schema.AllValidationAnalyzers()...)

--- a/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/pkg/config/analysis/analyzers/analyzers_test.go
@@ -30,6 +30,7 @@ import (
 	"istio.io/istio/pkg/config/analysis/analyzers/deployment"
 	"istio.io/istio/pkg/config/analysis/analyzers/deprecation"
 	"istio.io/istio/pkg/config/analysis/analyzers/destinationrule"
+	"istio.io/istio/pkg/config/analysis/analyzers/envoyfilter"
 	"istio.io/istio/pkg/config/analysis/analyzers/gateway"
 	"istio.io/istio/pkg/config/analysis/analyzers/injection"
 	"istio.io/istio/pkg/config/analysis/analyzers/maturity"
@@ -629,6 +630,23 @@ var testGrid = []testCase{
 		analyzer:   &service.PortNameAnalyzer{},
 		expected:   []message{
 			// Test no messages are received for correct port name
+		},
+	},
+	{
+		name:       "EnvoyFilterUsesRelativeOperation",
+		inputFiles: []string{"testdata/relative-envoy-filter-operation.yaml"},
+		analyzer:   &envoyfilter.EnvoyFilterAnalyzer{},
+		expected: []message{
+			{msg.EnvoyFilterUsesRelativeOperation, "EnvoyFilter bookinfo/test-reviews-lua-1"},
+			{msg.EnvoyFilterUsesRelativeOperation, "EnvoyFilter bookinfo/test-reviews-lua-2"},
+		},
+	},
+	{
+		name:       "EnvoyFilterUsesAbsoluteOperation",
+		inputFiles: []string{"testdata/absolute-envoy-filter-operation.yaml"},
+		analyzer:   &envoyfilter.EnvoyFilterAnalyzer{},
+		expected:   []message{
+			// Test no messages are received for absolute operation usage
 		},
 	},
 }

--- a/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/pkg/config/analysis/analyzers/analyzers_test.go
@@ -635,7 +635,7 @@ var testGrid = []testCase{
 	{
 		name:       "EnvoyFilterUsesRelativeOperation",
 		inputFiles: []string{"testdata/relative-envoy-filter-operation.yaml"},
-		analyzer:   &envoyfilter.EnvoyFilterAnalyzer{},
+		analyzer:   &envoyfilter.EnvoyPatchAnalyzer{},
 		expected: []message{
 			{msg.EnvoyFilterUsesRelativeOperation, "EnvoyFilter bookinfo/test-reviews-lua-1"},
 			{msg.EnvoyFilterUsesRelativeOperation, "EnvoyFilter bookinfo/test-reviews-lua-2"},
@@ -644,7 +644,7 @@ var testGrid = []testCase{
 	{
 		name:       "EnvoyFilterUsesAbsoluteOperation",
 		inputFiles: []string{"testdata/absolute-envoy-filter-operation.yaml"},
-		analyzer:   &envoyfilter.EnvoyFilterAnalyzer{},
+		analyzer:   &envoyfilter.EnvoyPatchAnalyzer{},
 		expected:   []message{
 			// Test no messages are received for absolute operation usage
 		},

--- a/pkg/config/analysis/analyzers/envoyfilter/envoyfilter.go
+++ b/pkg/config/analysis/analyzers/envoyfilter/envoyfilter.go
@@ -26,16 +26,16 @@ import (
 	"istio.io/istio/pkg/config/schema/collections"
 )
 
-// EnvoyFilterAnalyzer checks envoyFilters to see if the patch section is okay
-type EnvoyFilterAnalyzer struct{}
+// EnvoyPatchAnalyzer checks envoyFilters to see if the patch section is okay
+type EnvoyPatchAnalyzer struct{}
 
 // (compile-time check that we implement the interface)
-var _ analysis.Analyzer = &EnvoyFilterAnalyzer{}
+var _ analysis.Analyzer = &EnvoyPatchAnalyzer{}
 
 // Metadata implements analysis.Analyzer
-func (*EnvoyFilterAnalyzer) Metadata() analysis.Metadata {
+func (*EnvoyPatchAnalyzer) Metadata() analysis.Metadata {
 	return analysis.Metadata{
-		Name:        "envoyfilter.EnvoyFilterAnalyzer",
+		Name:        "envoyfilter.EnvoyPatchAnalyzer",
 		Description: "Checks an envoyFilters ",
 		Inputs: collection.Names{
 			collections.IstioNetworkingV1Alpha3Envoyfilters.Name(),
@@ -44,14 +44,14 @@ func (*EnvoyFilterAnalyzer) Metadata() analysis.Metadata {
 }
 
 // Analyze implements analysis.Analyzer
-func (s *EnvoyFilterAnalyzer) Analyze(c analysis.Context) {
+func (s *EnvoyPatchAnalyzer) Analyze(c analysis.Context) {
 	c.ForEach(collections.IstioNetworkingV1Alpha3Envoyfilters.Name(), func(r *resource.Instance) bool {
-		s.analyzeEnvoyFilter(r, c)
+		s.analyzeEnvoyFilterPatch(r, c)
 		return true
 	})
 }
 
-func (*EnvoyFilterAnalyzer) analyzeEnvoyFilter(r *resource.Instance, c analysis.Context) {
+func (*EnvoyPatchAnalyzer) analyzeEnvoyFilterPatch(r *resource.Instance, c analysis.Context) {
 	ef := r.Message.(*network.EnvoyFilter)
 
 	// if the envoyFilter does not have a priority and it uses the INSERT_BEFORE or INSERT_AFTER

--- a/pkg/config/analysis/analyzers/envoyfilter/envoyfilter.go
+++ b/pkg/config/analysis/analyzers/envoyfilter/envoyfilter.go
@@ -1,0 +1,77 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package envoyfilter
+
+import (
+	"fmt"
+
+	network "istio.io/api/networking/v1alpha3"
+	"istio.io/istio/pkg/config/analysis"
+	"istio.io/istio/pkg/config/analysis/analyzers/util"
+	"istio.io/istio/pkg/config/analysis/msg"
+	"istio.io/istio/pkg/config/resource"
+	"istio.io/istio/pkg/config/schema/collection"
+	"istio.io/istio/pkg/config/schema/collections"
+)
+
+// EnvoyFilterAnalyzer checks envoyFilters to see if the patch section is okay
+type EnvoyFilterAnalyzer struct{}
+
+// (compile-time check that we implement the interface)
+var _ analysis.Analyzer = &EnvoyFilterAnalyzer{}
+
+// Metadata implements analysis.Analyzer
+func (*EnvoyFilterAnalyzer) Metadata() analysis.Metadata {
+	return analysis.Metadata{
+		Name:        "envoyfilter.EnvoyFilterAnalyzer",
+		Description: "Checks an envoyFilters ",
+		Inputs: collection.Names{
+			collections.IstioNetworkingV1Alpha3Envoyfilters.Name(),
+		},
+	}
+}
+
+// Analyze implements analysis.Analyzer
+func (s *EnvoyFilterAnalyzer) Analyze(c analysis.Context) {
+	c.ForEach(collections.IstioNetworkingV1Alpha3Envoyfilters.Name(), func(r *resource.Instance) bool {
+		s.analyzeEnvoyFilter(r, c)
+		return true
+	})
+}
+
+func (*EnvoyFilterAnalyzer) analyzeEnvoyFilter(r *resource.Instance, c analysis.Context) {
+	ef := r.Message.(*network.EnvoyFilter)
+
+	// if the envoyFilter does not have a priority and it uses the INSERT_BEFORE or INSERT_AFTER
+	// then it can have issues if its using an operation that is relative to another filter.
+	// the default priority for an envoyFilter is 0
+	if ef.Priority == 0 {
+		for index, patch := range ef.ConfigPatches {
+			if patch.Patch.Operation == network.EnvoyFilter_Patch_INSERT_BEFORE || patch.Patch.Operation == network.EnvoyFilter_Patch_INSERT_AFTER {
+				// indicate that this envoy filter does not have a priority and has a relative patch
+				// operation set which can cause issues. Indicate a warning to the use to use a
+				// priority to ensure its placed after something or use the INSERT_FIRST option to
+				//  ensure its always done first
+				message := msg.NewEnvoyFilterUsesRelativeOperation(r)
+
+				if line, ok := util.ErrorLine(r, fmt.Sprintf(util.EnvoyFilterConfigPath, index)); ok {
+					message.Line = line
+				}
+
+				c.Report(collections.IstioNetworkingV1Alpha3Envoyfilters.Name(), message)
+			}
+		}
+	}
+}

--- a/pkg/config/analysis/analyzers/testdata/absolute-envoy-filter-operation.yaml
+++ b/pkg/config/analysis/analyzers/testdata/absolute-envoy-filter-operation.yaml
@@ -1,0 +1,129 @@
+# If the patch operation is INSERT_FIRST or priority is set, then the analyzer will not do anything
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: test-reviews-lua-1
+  namespace: bookinfo
+spec:
+  workloadSelector:
+    labels:
+      app: reviews
+  configPatches:
+    # The first patch adds the lua filter to the listener/http connection manager
+  - applyTo: HTTP_FILTER
+    match:
+      context: SIDECAR_INBOUND
+      listener:
+        portNumber: 8080
+        filterChain:
+          filter:
+            name: "envoy.filters.network.http_connection_manager"
+            subFilter:
+              name: "envoy.filters.http.router"
+    patch:
+      operation: INSERT_FIRST
+      value: # lua filter specification
+       name: envoy.lua
+       typed_config:
+          "@type": "type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua"
+          inlineCode: |
+            function envoy_on_request(request_handle)
+              -- Make an HTTP call to an upstream host with the following headers, body, and timeout.
+              local headers, body = request_handle:httpCall(
+               "lua_cluster",
+               {
+                [":method"] = "POST",
+                [":path"] = "/acl",
+                [":authority"] = "internal.org.net"
+               },
+              "authorize call",
+              5000)
+            end
+  # The second patch adds the cluster that is referenced by the lua code
+  # cds match is omitted as a new cluster is being added
+  - applyTo: CLUSTER
+    match:
+      context: SIDECAR_OUTBOUND
+    patch:
+      operation: ADD
+      value: # cluster specification
+        name: "lua_cluster"
+        type: STRICT_DNS
+        connect_timeout: 0.5s
+        lb_policy: ROUND_ROBIN
+        load_assignment:
+          cluster_name: lua_cluster
+          endpoints:
+          - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    protocol: TCP
+                    address: "internal.org.net"
+                    port_value: 8888
+
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: test-reviews-lua-2
+  namespace: bookinfo
+spec:
+  workloadSelector:
+    labels:
+      app: reviews
+  priority: 10
+  configPatches:
+    # The first patch adds the lua filter to the listener/http connection manager
+  - applyTo: HTTP_FILTER
+    match:
+      context: SIDECAR_INBOUND
+      listener:
+        portNumber: 8080
+        filterChain:
+          filter:
+            name: "envoy.filters.network.http_connection_manager"
+            subFilter:
+              name: "envoy.filters.http.router"
+    patch:
+      operation: INSERT_BEFORE
+      value: # lua filter specification
+       name: envoy.lua
+       typed_config:
+          "@type": "type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua"
+          inlineCode: |
+            function envoy_on_request(request_handle)
+              -- Make an HTTP call to an upstream host with the following headers, body, and timeout.
+              local headers, body = request_handle:httpCall(
+               "lua_cluster",
+               {
+                [":method"] = "POST",
+                [":path"] = "/acl",
+                [":authority"] = "internal.org.net"
+               },
+              "authorize call",
+              5000)
+            end
+  # The second patch adds the cluster that is referenced by the lua code
+  # cds match is omitted as a new cluster is being added
+  - applyTo: CLUSTER
+    match:
+      context: SIDECAR_OUTBOUND
+    patch:
+      operation: ADD
+      value: # cluster specification
+        name: "lua_cluster"
+        type: STRICT_DNS
+        connect_timeout: 0.5s
+        lb_policy: ROUND_ROBIN
+        load_assignment:
+          cluster_name: lua_cluster
+          endpoints:
+          - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    protocol: TCP
+                    address: "internal.org.net"
+                    port_value: 8888
+---

--- a/pkg/config/analysis/analyzers/testdata/relative-envoy-filter-operation.yaml
+++ b/pkg/config/analysis/analyzers/testdata/relative-envoy-filter-operation.yaml
@@ -1,0 +1,129 @@
+# If the patch operation is INSERT_FIRST or priority is set, then the analyzer will not do anything
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: test-reviews-lua-1
+  namespace: bookinfo
+spec:
+  workloadSelector:
+    labels:
+      app: reviews
+  configPatches:
+    # The first patch adds the lua filter to the listener/http connection manager
+  - applyTo: HTTP_FILTER
+    match:
+      context: SIDECAR_INBOUND
+      listener:
+        portNumber: 8080
+        filterChain:
+          filter:
+            name: "envoy.filters.network.http_connection_manager"
+            subFilter:
+              name: "envoy.filters.http.router"
+    patch:
+      operation: INSERT_BEFORE
+      value: # lua filter specification
+       name: envoy.lua
+       typed_config:
+          "@type": "type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua"
+          inlineCode: |
+            function envoy_on_request(request_handle)
+              -- Make an HTTP call to an upstream host with the following headers, body, and timeout.
+              local headers, body = request_handle:httpCall(
+               "lua_cluster",
+               {
+                [":method"] = "POST",
+                [":path"] = "/acl",
+                [":authority"] = "internal.org.net"
+               },
+              "authorize call",
+              5000)
+            end
+  # The second patch adds the cluster that is referenced by the lua code
+  # cds match is omitted as a new cluster is being added
+  - applyTo: CLUSTER
+    match:
+      context: SIDECAR_OUTBOUND
+    patch:
+      operation: ADD
+      value: # cluster specification
+        name: "lua_cluster"
+        type: STRICT_DNS
+        connect_timeout: 0.5s
+        lb_policy: ROUND_ROBIN
+        load_assignment:
+          cluster_name: lua_cluster
+          endpoints:
+          - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    protocol: TCP
+                    address: "internal.org.net"
+                    port_value: 8888
+
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: test-reviews-lua-2
+  namespace: bookinfo
+spec:
+  workloadSelector:
+    labels:
+      app: reviews
+  configPatches:
+    # The first patch adds the lua filter to the listener/http connection manager
+  - applyTo: HTTP_FILTER
+    match:
+      context: SIDECAR_INBOUND
+      listener:
+        portNumber: 8080
+        filterChain:
+          filter:
+            name: "envoy.filters.network.http_connection_manager"
+            subFilter:
+              name: "envoy.filters.http.router"
+    patch:
+      operation: INSERT_AFTER
+      value: # lua filter specification
+       name: envoy.lua
+       typed_config:
+          "@type": "type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua"
+          inlineCode: |
+            function envoy_on_request(request_handle)
+              -- Make an HTTP call to an upstream host with the following headers, body, and timeout.
+              local headers, body = request_handle:httpCall(
+               "lua_cluster",
+               {
+                [":method"] = "POST",
+                [":path"] = "/acl",
+                [":authority"] = "internal.org.net"
+               },
+              "authorize call",
+              5000)
+            end
+  # The second patch adds the cluster that is referenced by the lua code
+  # cds match is omitted as a new cluster is being added
+  - applyTo: CLUSTER
+    match:
+      context: SIDECAR_OUTBOUND
+    patch:
+      operation: ADD
+      value: # cluster specification
+        name: "lua_cluster"
+        type: STRICT_DNS
+        connect_timeout: 0.5s
+        lb_policy: ROUND_ROBIN
+        load_assignment:
+          cluster_name: lua_cluster
+          endpoints:
+          - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    protocol: TCP
+                    address: "internal.org.net"
+                    port_value: 8888
+
+

--- a/pkg/config/analysis/analyzers/util/find_errorline_utils.go
+++ b/pkg/config/analysis/analyzers/util/find_errorline_utils.go
@@ -101,6 +101,10 @@ const (
 	// Path for DestinationRule port-level tls certificate.
 	// Required parameters: portLevelSettings index.
 	DestinationRuleTLSPortLevelCert = "{.spec.trafficPolicy.portLevelSettings[%d].tls.caCertificates}"
+
+	// Path for ConfigPatch in envoyFilter
+	// Required parameters: envoyFilter config patch index
+	EnvoyFilterConfigPath = "{.spec.configPatches[%d].patch.value}"
 )
 
 // ErrorLine returns the line number of the input path key in the resource

--- a/pkg/config/analysis/analyzers/util/find_errorline_utils_test.go
+++ b/pkg/config/analysis/analyzers/util/find_errorline_utils_test.go
@@ -43,6 +43,7 @@ var fieldMap = map[string]int{
 	"{.networks.test.endpoints[0]}":                                 1,
 	"{.spec.trafficPolicy.tls.caCertificates}":                      1,
 	"{.spec.trafficPolicy.portLevelSettings[0].tls.caCertificates}": 1,
+	"{.spec.configPatches[0].patch.value}":                          1,
 }
 
 func TestExtractLabelFromSelectorString(t *testing.T) {
@@ -84,6 +85,7 @@ func TestConstants(t *testing.T) {
 		MetadataNamespace,
 		MetadataName,
 		DestinationRuleTLSCert,
+		fmt.Sprintf(EnvoyFilterConfigPath, 0),
 	}
 
 	for _, v := range constantsPath {

--- a/pkg/config/analysis/msg/messages.gen.go
+++ b/pkg/config/analysis/msg/messages.gen.go
@@ -196,6 +196,10 @@ var (
 	// ExternalNameServiceTypeInvalidPortName defines a diag.MessageType for message "ExternalNameServiceTypeInvalidPortName".
 	// Description: Proxy may prevent tcp named ports and unmatched traffic for ports serving TCP protocol from being forwarded correctly for ExternalName services.
 	ExternalNameServiceTypeInvalidPortName = diag.NewMessageType(diag.Warning, "IST0150", "Port name for ExternalName service is invalid. Proxy may prevent tcp named ports and unmatched traffic for ports serving TCP protocol from being forwarded correctly")
+
+	// EnvoyFilterUsesRelativeOperation defines a diag.MessageType for message "EnvoyFilterUsesRelativeOperation".
+	// Description: This envoy filter does not have a priority and has a relative patch operation set which can cause the envoyFilter not to be applied. Using the INSERT_FIRST option or setting the priority may help in ensuring the envoyFilter is applied correctly
+	EnvoyFilterUsesRelativeOperation = diag.NewMessageType(diag.Warning, "IST0151", "This envoy filter does not have a priority and has a relative patch operation set which can cause the envoyFilter not to be applied. Using the INSERT_FIRST option or setting the priority may help in ensuring the envoyFilter is applied correctly")
 )
 
 // All returns a list of all known message types.
@@ -248,6 +252,7 @@ func All() []*diag.MessageType {
 		NamespaceInjectionEnabledByDefault,
 		JwtClaimBasedRoutingWithoutRequestAuthN,
 		ExternalNameServiceTypeInvalidPortName,
+		EnvoyFilterUsesRelativeOperation,
 	}
 }
 
@@ -717,6 +722,14 @@ func NewJwtClaimBasedRoutingWithoutRequestAuthN(r *resource.Instance, key string
 func NewExternalNameServiceTypeInvalidPortName(r *resource.Instance) diag.Message {
 	return diag.NewMessage(
 		ExternalNameServiceTypeInvalidPortName,
+		r,
+	)
+}
+
+// NewEnvoyFilterUsesRelativeOperation returns a new diag.Message based on EnvoyFilterUsesRelativeOperation.
+func NewEnvoyFilterUsesRelativeOperation(r *resource.Instance) diag.Message {
+	return diag.NewMessage(
+		EnvoyFilterUsesRelativeOperation,
 		r,
 	)
 }

--- a/pkg/config/analysis/msg/messages.yaml
+++ b/pkg/config/analysis/msg/messages.yaml
@@ -556,3 +556,10 @@ messages:
     level: Warning
     description: "Proxy may prevent tcp named ports and unmatched traffic for ports serving TCP protocol from being forwarded correctly for ExternalName services."
     template: "Port name for ExternalName service is invalid. Proxy may prevent tcp named ports and unmatched traffic for ports serving TCP protocol from being forwarded correctly"
+
+  - name: "EnvoyFilterUsesRelativeOperation"
+    code: IST0151
+    level: Warning
+    description: "This envoy filter does not have a priority and has a relative patch operation set which can cause the envoyFilter not to be applied. Using the INSERT_FIRST option or setting the priority may help in ensuring the envoyFilter is applied correctly"
+    template: "This envoy filter does not have a priority and has a relative patch operation set which can cause the envoyFilter not to be applied. Using the INSERT_FIRST option or setting the priority may help in ensuring the envoyFilter is applied correctly"
+   

--- a/releasenotes/notes/37415.yaml
+++ b/releasenotes/notes/37415.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: istioctl
+releaseNotes:
+- |
+  **Added** a new analyzer for envoy filter patch operations to address issue 37415

--- a/releasenotes/notes/37415.yaml
+++ b/releasenotes/notes/37415.yaml
@@ -1,6 +1,8 @@
 apiVersion: release-notes/v2
 kind: feature
 area: istioctl
+issue:
+  - 37415
 releaseNotes:
 - |
   **Added** a new analyzer for envoy filter patch operations to address issue 37415


### PR DESCRIPTION
**Please provide a description of this PR:**
Fixes #37415 

Checks an envoy filter patch operation to see if the envoy filter has a priority set or if its using a relative instead of absolute patch operation.  It issues a warning if a relative patch operation (INSERT_BEFORE/INSERT_AFTER) is being used and no priority is being set.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [x] User Experience
- [ ] Developer Infrastructure