### PR TITLE
Fix Makefile missing target for go-junit-report

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -442,7 +442,15 @@ istioctl-install-container: istioctl
 
 .PHONY: test
 
+# This target sets JUNIT_REPORT to the location of the  go-junit-report binary.
+# This binary is provided in the build container. If it is not found, the build
+# container is not being used, so ask the user to install go-junit-report.
 JUNIT_REPORT := $(shell which go-junit-report 2> /dev/null || echo "${ISTIO_BIN}/go-junit-report")
+
+${ISTIO_BIN}/go-junit-report:
+	@echo "go-junit-report was not found in the build environment."
+	@echo "Please install go-junit-report (ex. go install github.com/jstemmer/go-junit-report@latest)"
+	@exit 1
 
 # This is just an alias for racetest now
 test: racetest ## Runs all unit tests


### PR DESCRIPTION
**Please provide a description of this PR:**

Fixes https://github.com/istio/istio/issues/38216

Doing some investigation on the subject issue, and debated about simply including the earlier removed snippet. One issue with just including the earlier snippet is it uses `go get` which no longer installs the binary. This was a change in Go 1.18. The new method is to use `go install`.

Another con to simply replacing the snippet is we are updating the host environment. This may or may not be a good thing.

This only affects users who are doing builds outside of our build container which includes the binary.

I propose that in the case where the `go-junit-report` is not found we instead ask the user to install it.

If the binary is missing:
```
BUILD_WITH_CONTAINER=0 make racetest
go-junit-report was not found in the build environment.
Please install go-junit-report (ex. go install github.com/jstemmer/go-junit-report@latest)
```
as opposed to the before:
```
BUILD_WITH_CONTAINER=0 make clean racetest
rm -rf /Users/ericvn/work/go/src/istio.io/istio/out/darwin_amd64 /Users/ericvn/work/go/src/istio.io/istio/out/linux_amd64
make: *** No rule to make target `/Users/ericvn/work/go/bin/go-junit-report', needed by `racetest'.  Stop.
```