### PR TITLE
Support CredentialName configuration in DR for sidecars

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -595,6 +595,8 @@ type buildClusterOpts struct {
 	serviceMTLSMode model.MutualTLSMode
 	// Indicates the service registry of the cluster being built.
 	serviceRegistry provider.ID
+	// Indicates if the destionationRule has a workloadSelector
+	isDrWithSelector bool
 }
 
 type upgradeTuple struct {

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -215,6 +215,11 @@ func (cb *ClusterBuilder) buildSubsetCluster(opts buildClusterOpts, destRule *co
 
 	// If subset has a traffic policy, apply it so that it overrides the destination rule traffic policy.
 	opts.policy = MergeTrafficPolicy(opts.policy, subset.TrafficPolicy, opts.port)
+
+	if destRule != nil {
+		destinationRule := CastDestinationRule(destRule)
+		opts.isDrWithSelector = destinationRule.GetWorkloadSelector() != nil
+	}
 	// Apply traffic policy for the subset cluster.
 	cb.applyTrafficPolicy(opts)
 
@@ -254,6 +259,10 @@ func (cb *ClusterBuilder) applyDestinationRule(mc *MutableCluster, clusterMode C
 		opts.meshExternal = service.MeshExternal
 		opts.serviceRegistry = service.Attributes.ServiceRegistry
 		opts.serviceMTLSMode = cb.req.Push.BestEffortInferServiceMTLSMode(destinationRule.GetTrafficPolicy(), service, port)
+	}
+
+	if destRule != nil {
+		opts.isDrWithSelector = destinationRule.GetWorkloadSelector() != nil
 	}
 	// Apply traffic policy for the main default cluster.
 	cb.applyTrafficPolicy(opts)
@@ -527,6 +536,7 @@ func (cb *ClusterBuilder) buildInboundClusterForPortOrUDS(clusterPort int, bind 
 	cfg := proxy.SidecarScope.DestinationRule(model.TrafficDirectionInbound, proxy, instance.Service.Hostname)
 	if cfg != nil {
 		destinationRule := cfg.Spec.(*networking.DestinationRule)
+		opts.isDrWithSelector = destinationRule.GetWorkloadSelector() != nil
 		if destinationRule.TrafficPolicy != nil {
 			opts.policy = MergeTrafficPolicy(opts.policy, destinationRule.TrafficPolicy, instance.ServicePort)
 			util.AddConfigInfoMetadata(localCluster.cluster.Metadata, cfg.Meta)
@@ -989,16 +999,18 @@ func (cb *ClusterBuilder) applyUpstreamTLSSettings(opts *buildClusterOpts, tls *
 }
 
 func (cb *ClusterBuilder) buildUpstreamClusterTLSContext(opts *buildClusterOpts, tls *networking.ClientTLSSettings) (*auth.UpstreamTlsContext, error) {
-	c := opts.mutable
-
 	// Hack to avoid egress sds cluster config generation for sidecar when
-	// CredentialName is set in DestinationRule
-	if tls.CredentialName != "" && cb.sidecarProxy() {
+	// CredentialName is set in DestinationRule without a workloadSelector.
+	// We do not want to support CredentialName setting in non workloadSelector based DestinationRules, because
+	// that would result in the CredentialName being supplied to all the sidecars which the DestinationRule is scoped to,
+	// resulting in delayed startup of sidecars who do not have access to the credentials.
+	if tls.CredentialName != "" && cb.sidecarProxy() && !opts.isDrWithSelector {
 		if tls.Mode == networking.ClientTLSSettings_SIMPLE || tls.Mode == networking.ClientTLSSettings_MUTUAL {
 			return nil, nil
 		}
 	}
 
+	c := opts.mutable
 	var tlsContext *auth.UpstreamTlsContext
 
 	switch tls.Mode {

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
@@ -2597,6 +2597,49 @@ func TestBuildUpstreamClusterTLSContext(t *testing.T) {
 				err: nil,
 			},
 		},
+		{
+			name: "tls mode MUTUAL, CredentialName is set with proxy type Sidecar and destinationRule has workload Selector",
+			opts: &buildClusterOpts{
+				mutable:          newTestCluster(),
+				isDrWithSelector: true,
+			},
+			tls: &networking.ClientTLSSettings{
+				Mode:            networking.ClientTLSSettings_MUTUAL,
+				CredentialName:  credentialName,
+				SubjectAltNames: []string{"SAN"},
+				Sni:             "some-sni.com",
+			},
+			result: expectedResult{
+				tlsContext: &tls.UpstreamTlsContext{
+					CommonTlsContext: &tls.CommonTlsContext{
+						TlsParams: &tls.TlsParameters{
+							// if not specified, envoy use TLSv1_2 as default for client.
+							TlsMaximumProtocolVersion: tls.TlsParameters_TLSv1_3,
+							TlsMinimumProtocolVersion: tls.TlsParameters_TLSv1_2,
+						},
+						TlsCertificateSdsSecretConfigs: []*tls.SdsSecretConfig{
+							{
+								Name:      "kubernetes://" + credentialName,
+								SdsConfig: authn_model.SDSAdsConfig,
+							},
+						},
+						ValidationContextType: &tls.CommonTlsContext_CombinedValidationContext{
+							CombinedValidationContext: &tls.CommonTlsContext_CombinedCertificateValidationContext{
+								DefaultValidationContext: &tls.CertificateValidationContext{
+									MatchSubjectAltNames: util.StringToExactMatch([]string{"SAN"}),
+								},
+								ValidationContextSdsSecretConfig: &tls.SdsSecretConfig{
+									Name:      "kubernetes://" + credentialName + authn_model.SdsCaSuffix,
+									SdsConfig: authn_model.SDSAdsConfig,
+								},
+							},
+						},
+					},
+					Sni: "some-sni.com",
+				},
+				err: nil,
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
@@ -2560,6 +2560,43 @@ func TestBuildUpstreamClusterTLSContext(t *testing.T) {
 				nil,
 			},
 		},
+		{
+			name: "tls mode SIMPLE, CredentialName is set with proxy type Sidecar and destinationRule has workload Selector",
+			opts: &buildClusterOpts{
+				mutable:          newTestCluster(),
+				isDrWithSelector: true,
+			},
+			tls: &networking.ClientTLSSettings{
+				Mode:            networking.ClientTLSSettings_SIMPLE,
+				CredentialName:  credentialName,
+				SubjectAltNames: []string{"SAN"},
+				Sni:             "some-sni.com",
+			},
+			result: expectedResult{
+				tlsContext: &tls.UpstreamTlsContext{
+					CommonTlsContext: &tls.CommonTlsContext{
+						TlsParams: &tls.TlsParameters{
+							// if not specified, envoy use TLSv1_2 as default for client.
+							TlsMaximumProtocolVersion: tls.TlsParameters_TLSv1_3,
+							TlsMinimumProtocolVersion: tls.TlsParameters_TLSv1_2,
+						},
+						ValidationContextType: &tls.CommonTlsContext_CombinedValidationContext{
+							CombinedValidationContext: &tls.CommonTlsContext_CombinedCertificateValidationContext{
+								DefaultValidationContext: &tls.CertificateValidationContext{
+									MatchSubjectAltNames: util.StringToExactMatch([]string{"SAN"}),
+								},
+								ValidationContextSdsSecretConfig: &tls.SdsSecretConfig{
+									Name:      "kubernetes://" + credentialName + authn_model.SdsCaSuffix,
+									SdsConfig: authn_model.SDSAdsConfig,
+								},
+							},
+						},
+					},
+					Sni: "some-sni.com",
+				},
+				err: nil,
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pilot/pkg/xds/sds.go
+++ b/pilot/pkg/xds/sds.go
@@ -60,10 +60,7 @@ func (sr SecretResource) Cacheable() bool {
 	return true
 }
 
-func sdsNeedsPush(proxy *model.Proxy, updates model.XdsUpdates) bool {
-	if proxy.Type != model.Router {
-		return false
-	}
+func sdsNeedsPush(updates model.XdsUpdates) bool {
 	if len(updates) == 0 {
 		return true
 	}
@@ -94,7 +91,7 @@ func (s *SecretGen) Generate(proxy *model.Proxy, w *model.WatchedResource, req *
 		log.Warnf("proxy %s is not authorized to receive credscontroller. Ensure you are connecting over TLS port and are authenticated.", proxy.ID)
 		return nil, model.DefaultXdsLogDetails, nil
 	}
-	if req == nil || !sdsNeedsPush(proxy, req.ConfigsUpdated) {
+	if req == nil || !sdsNeedsPush(req.ConfigsUpdated) {
 		return nil, model.DefaultXdsLogDetails, nil
 	}
 	var updatedSecrets map[model.ConfigKey]struct{}

--- a/pilot/pkg/xds/sds_test.go
+++ b/pilot/pkg/xds/sds_test.go
@@ -114,7 +114,12 @@ func TestGenerate(t *testing.T) {
 			proxy:     &model.Proxy{VerifiedIdentity: &spiffe.Identity{Namespace: "istio-system"}},
 			resources: []string{"kubernetes://generic"},
 			request:   &model.PushRequest{Full: true},
-			expect:    map[string]Expected{},
+			expect: map[string]Expected{
+				"kubernetes://generic": {
+					Key:  string(genericCert.Data[credentials.GenericScrtKey]),
+					Cert: string(genericCert.Data[credentials.GenericScrtCert]),
+				},
+			},
 		},
 		{
 			name:      "unauthenticated",

--- a/releasenotes/notes/credential-name-support-egress-sidecar.yaml
+++ b/releasenotes/notes/credential-name-support-egress-sidecar.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+releaseNotes:
+   - |
+     **Added** the ability to set credentialName based secret configuration
+     at sidecars for egress TLS traffic when WorkloadSelector is specified in `DestinationRule`
+docs:
+   - https://docs.google.com/document/d/1UXpT3rZpE2uFeMh5KffAZAPAoZBLNSHc/

--- a/releasenotes/notes/credential-name-support-egress-sidecar.yaml
+++ b/releasenotes/notes/credential-name-support-egress-sidecar.yaml
@@ -4,6 +4,7 @@ area: traffic-management
 releaseNotes:
    - |
      **Added** the ability to set credentialName based secret configuration
-     at sidecars for egress TLS traffic when WorkloadSelector is specified in `DestinationRule`
+     at sidecars for egress TLS traffic when WorkloadSelector is specified in `DestinationRule`,
+     provided the sidecar has permission to list secrets in the namespace where it resides.
 docs:
    - https://docs.google.com/document/d/1UXpT3rZpE2uFeMh5KffAZAPAoZBLNSHc/


### PR DESCRIPTION
Signed-off-by: Faseela K <faseela.k@est.tech>

RFC: [Simplify sidecar egress mTLS](https://docs.google.com/document/d/1UXpT3rZpE2uFeMh5KffAZAPAoZBLNSHc/)

Currently egress mTLS configuration on sidecar does not allow supplying credentialName. This PR
tries to allow the same, provided the credentials are available in the same namespace as the workload with
proper RBAC.
Phase 2 of the solution would allow cross namespace access of secrets, which would be pursued later.

I had pursued the work in a previous PR at https://github.com/istio/istio/pull/36746.
However there were comments from the maintainers about performance concerns on the PR, as the changes introduced
would delay the pod bring up time for pods who are not having access to the secrets specified in the DR.
A suggestion was given to implement workloadSelector in DR, so that the above mentioned problem can be resolved.
Now that workload selector implementation is completed for DR, trying to enhance the above work by making use of the DR workload selector concept.



**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [X ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure