### PR TITLE
fix sampling default value

### DIFF
--- a/pilot/pkg/model/telemetry.go
+++ b/pilot/pkg/model/telemetry.go
@@ -33,6 +33,7 @@ import (
 	"istio.io/api/envoy/extensions/stats"
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	tpb "istio.io/api/telemetry/v1alpha1"
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/networking"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/schema/collections"
@@ -230,6 +231,12 @@ func (t *Telemetries) Tracing(proxy *Proxy) *TracingConfig {
 		cfg.Disabled = true
 		return &cfg
 	}
+
+	cfg.RandomSamplingPercentage = features.TraceSampling // default provider sampling should be 1%
+	if len(ct.Tracing) != 0 {
+		cfg.RandomSamplingPercentage = 0 // telemetry default sampling should be 0%
+	}
+
 	for _, m := range ct.Tracing {
 		names := getProviderNames(m.Providers)
 

--- a/pilot/pkg/model/telemetry_test.go
+++ b/pilot/pkg/model/telemetry_test.go
@@ -28,6 +28,7 @@ import (
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	tpb "istio.io/api/telemetry/v1alpha1"
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/networking"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/mesh"
@@ -357,6 +358,15 @@ func newTracingConfig(providerName string, disabled bool) *TracingConfig {
 	}
 }
 
+func newTracingConfigWithSampling(providerName string, disabled bool, sampling float64) *TracingConfig {
+	return &TracingConfig{
+		Provider:                     &meshconfig.MeshConfig_ExtensionProvider{Name: providerName},
+		Disabled:                     disabled,
+		RandomSamplingPercentage:     sampling,
+		UseRequestIDForTraceSampling: true,
+	}
+}
+
 const (
 	reportingEnabled  = false
 	reportingDisabled = !reportingEnabled
@@ -460,7 +470,7 @@ func TestTracing(t *testing.T) {
 			nil,
 			sidecar,
 			[]string{"envoy"},
-			newTracingConfig("envoy", reportingEnabled),
+			newTracingConfigWithSampling("envoy", reportingEnabled, features.TraceSampling),
 		},
 		{
 			"provider only",


### PR DESCRIPTION
**Please provide a description of this PR:**

with https://github.com/istio/istio/pull/36751, when there's no `Telemetry` cfg but exits defaultProviders, sampling should be 1%

@douglas-reid PTAL.