### PR TITLE
Avoid use of `interface{}` in controllers where possible

### DIFF
--- a/pilot/pkg/config/kube/gateway/deploymentcontroller.go
+++ b/pilot/pkg/config/kube/gateway/deploymentcontroller.go
@@ -143,8 +143,7 @@ func (d *DeploymentController) Run(stop <-chan struct{}) {
 }
 
 // Reconcile takes in the name of a Gateway and ensures the cluster is in the desired state
-func (d *DeploymentController) Reconcile(key interface{}) error {
-	req := key.(types.NamespacedName)
+func (d *DeploymentController) Reconcile(req types.NamespacedName) error {
 	log := log.WithLabels("gateway", req)
 
 	gw, err := d.gatewayLister.Gateways(req.Namespace).Get(req.Name)

--- a/pilot/pkg/config/kube/gateway/gatewayclass.go
+++ b/pilot/pkg/config/kube/gateway/gatewayclass.go
@@ -62,7 +62,7 @@ func (c *ClassController) Run(stop <-chan struct{}) {
 	c.queue.Run(stop)
 }
 
-func (c *ClassController) Reconcile(_ interface{}) error {
+func (c *ClassController) Reconcile(name types.NamespacedName) error {
 	_, err := c.classes.Get(DefaultClassName)
 	if err := controllers.IgnoreNotFound(err); err != nil {
 		log.Errorf("unable to fetch GatewayClass: %v", err)

--- a/pilot/pkg/config/kube/ingress/controller.go
+++ b/pilot/pkg/config/kube/ingress/controller.go
@@ -222,8 +222,7 @@ func (c *controller) shouldProcessIngressUpdate(ing *ingress.Ingress) (bool, err
 	return preProcessed, nil
 }
 
-func (c *controller) onEvent(key interface{}) error {
-	item := key.(types.NamespacedName)
+func (c *controller) onEvent(item types.NamespacedName) error {
 	event := model.EventUpdate
 	ing, err := c.ingressLister.Ingresses(item.Namespace).Get(item.Name)
 	if err != nil {

--- a/pilot/pkg/config/kube/ingressv1/controller.go
+++ b/pilot/pkg/config/kube/ingressv1/controller.go
@@ -175,8 +175,7 @@ func (c *controller) shouldProcessIngressUpdate(ing *knetworking.Ingress) (bool,
 	return preProcessed, nil
 }
 
-func (c *controller) onEvent(key interface{}) error {
-	item := key.(types.NamespacedName)
+func (c *controller) onEvent(item types.NamespacedName) error {
 	event := model.EventUpdate
 	ing, err := c.ingressLister.Ingresses(item.Namespace).Get(item.Name)
 	if err != nil {

--- a/pilot/pkg/controller/workloadentry/workloadentry_controller.go
+++ b/pilot/pkg/controller/workloadentry/workloadentry_controller.go
@@ -166,10 +166,10 @@ func NewController(store model.ConfigStoreCache, instanceID string, maxConnAge t
 		}
 		c.queue = controllers.NewQueue("unregister_workloadentry",
 			controllers.WithMaxAttempts(maxRetries),
-			controllers.WithReconciler(c.unregisterWorkload))
+			controllers.WithGenericReconciler(c.unregisterWorkload))
 		c.healthCondition = controllers.NewQueue("healthcheck",
 			controllers.WithMaxAttempts(maxRetries),
-			controllers.WithReconciler(c.updateWorkloadEntryHealth))
+			controllers.WithGenericReconciler(c.updateWorkloadEntryHealth))
 		return c
 	}
 	return nil

--- a/pilot/pkg/serviceregistry/kube/controller/namespacecontroller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/namespacecontroller.go
@@ -110,8 +110,7 @@ func (nc *NamespaceController) startCaBundleWatcher(stop <-chan struct{}) {
 // insertDataForNamespace will add data into the configmap for the specified namespace
 // If the configmap is not found, it will be created.
 // If you know the current contents of the configmap, using UpdateDataInConfigMap is more efficient.
-func (nc *NamespaceController) insertDataForNamespace(key interface{}) error {
-	o := key.(types.NamespacedName)
+func (nc *NamespaceController) insertDataForNamespace(o types.NamespacedName) error {
 	ns := o.Namespace
 	if ns == "" {
 		// For Namespace object, it will not have o.Namespace field set

--- a/pkg/kube/configmapwatcher/configmapwatcher.go
+++ b/pkg/kube/configmapwatcher/configmapwatcher.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/informers"
 	informersv1 "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/tools/cache"
@@ -85,7 +86,7 @@ func (c *Controller) HasSynced() bool {
 	return c.queue.HasSynced()
 }
 
-func (c *Controller) processItem(interface{}) error {
+func (c *Controller) processItem(name types.NamespacedName) error {
 	cm, err := c.informer.Lister().ConfigMaps(c.configMapNamespace).Get(c.configMapName)
 	if err != nil {
 		if !errors.IsNotFound(err) {

--- a/pkg/kube/controllers/queue.go
+++ b/pkg/kube/controllers/queue.go
@@ -55,7 +55,16 @@ func WithMaxAttempts(n int) func(q *Queue) {
 }
 
 // WithReconciler defines the handler function to handle items in the queue.
-func WithReconciler(f func(key interface{}) error) func(q *Queue) {
+func WithReconciler(f func(key types.NamespacedName) error) func(q *Queue) {
+	return func(q *Queue) {
+		q.workFn = func(key interface{}) error {
+			return f(key.(types.NamespacedName))
+		}
+	}
+}
+
+// WithGenericReconciler defines the handler function to handle items in the queue that can handle any type
+func WithGenericReconciler(f func(key interface{}) error) func(q *Queue) {
 	return func(q *Queue) {
 		q.workFn = func(key interface{}) error {
 			return f(key)

--- a/pkg/kube/controllers/queue_test.go
+++ b/pkg/kube/controllers/queue_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestQueue(t *testing.T) {
 	handles := atomic.NewInt32(0)
-	q := NewQueue("custom", WithReconciler(func(key interface{}) error {
+	q := NewQueue("custom", WithReconciler(func(key types.NamespacedName) error {
 		handles.Inc()
 		return nil
 	}))

--- a/pkg/kube/multicluster/secretcontroller.go
+++ b/pkg/kube/multicluster/secretcontroller.go
@@ -347,8 +347,7 @@ func (c *Controller) HasSynced() bool {
 	return synced
 }
 
-func (c *Controller) processItem(item interface{}) error {
-	key := item.(types.NamespacedName)
+func (c *Controller) processItem(key types.NamespacedName) error {
 	log.Infof("processing secret event for secret %s", key)
 	obj, exists, err := c.informer.GetIndexer().GetByKey(key.String())
 	if err != nil {

--- a/pkg/revisions/default_watcher.go
+++ b/pkg/revisions/default_watcher.go
@@ -100,8 +100,7 @@ func (p *defaultWatcher) notifyHandlers() {
 	}
 }
 
-func (p *defaultWatcher) setDefault(item interface{}) error {
-	key := item.(types.NamespacedName)
+func (p *defaultWatcher) setDefault(key types.NamespacedName) error {
 	revision := ""
 	wh, _, _ := p.webhookInformer.GetIndexer().GetByKey(key.Name)
 	if wh != nil {

--- a/pkg/webhooks/webhookpatch.go
+++ b/pkg/webhooks/webhookpatch.go
@@ -95,8 +95,7 @@ func (w *WebhookCertPatcher) HasSynced() bool {
 }
 
 // webhookPatchTask takes the result of patchMutatingWebhookConfig and modifies the result for use in task queue
-func (w *WebhookCertPatcher) webhookPatchTask(key interface{}) error {
-	o := key.(types.NamespacedName)
+func (w *WebhookCertPatcher) webhookPatchTask(o types.NamespacedName) error {
 	reportWebhookPatchAttempts(o.Name)
 	err := w.patchMutatingWebhookConfig(
 		w.client.AdmissionregistrationV1().MutatingWebhookConfigurations(),


### PR DESCRIPTION
Partial revert of https://github.com/istio/istio/pull/38232/. Keep it
flexible for the rare case of `interface{}` key, without impacting all
other users that are using it the typical way.

Long term we can use go generics

**Please provide a description of this PR:**