### PR TITLE
Update build-base-images.sh to use python3

### DIFF
--- a/tools/build-base-images.sh
+++ b/tools/build-base-images.sh
@@ -24,7 +24,7 @@ ROOT=$(dirname "$WD")
 set -ex
 
 toJson () {
-        python -c '
+        python3 -c '
 import sys, yaml, json
 yml = list(y for y in yaml.safe_load_all(sys.stdin) if y)
 if len(yml) == 1: yml = yml[0]


### PR DESCRIPTION
**Please provide a description of this PR:**

Update build-base-images.sh to use python3.

The current periodic `build-base-images_release-builder_periodic` is failing (see defaultTargets is empty):
```
++ jq '[.images[] | select(.base) | .name] | join(",")' -r
tools/build-base-images.sh: line 27: python: command not found
tools/build-base-images.sh: line 27: python: command not found
+ defaultTargets=
```
The build-tools image only has python3 installed:
```
make shell
build-tools:/work$ python
bash: python: command not found
build-tools:/work$ python3
Python 3.8.10 (default, Mar 15 2022, 12:22:08)
[GCC 9.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>>
build-tools:/work$ python
bash: python: command not found
build-tools:/work$ exit
exit
make: *** [shell] Error 127
```
Testing in `make shell`:
```
++ toJson
++ python3 -c '
import sys, yaml, json
yml = list(y for y in yaml.safe_load_all(sys.stdin) if y)
if len(yml) == 1: yml = yml[0]
json.dump(yml, sys.stdout, indent=4)
'
++ jq '[.images[] | select(.base) | .name] | join(",")' -r
++ python3 -c '
import sys, yaml, json
yml = list(y for y in yaml.safe_load_all(sys.stdin) if y)
if len(yml) == 1: yml = yml[0]
json.dump(yml, sys.stdout, indent=4)
'
+ defaultTargets=base,distroless,app_sidecar_base_debian_11,app_sidecar_base_ubuntu_jammy,app_sidecar_base_ubuntu_xenial,app_sidecar_base_centos_7
+ DOCKER_TARGETS=base,distroless,app_sidecar_base_debian_11,app_sidecar_base_ubuntu_jammy,app_sidecar_base_ubuntu_xenial,app_sidecar_base_centos_7
```