### PR TITLE
Prevent unknown fields set during translate

### DIFF
--- a/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
@@ -7881,7 +7881,6 @@ data:
             "cpu": "10m"
           }
         },
-        "enabled": true,
         "externalIstiod": false,
         "hub": "gcr.io/istio-testing",
         "imagePullPolicy": "",
@@ -7902,7 +7901,6 @@ data:
           "clusterName": "",
           "enabled": false
         },
-        "namespace": "istio-system",
         "network": "",
         "omitSidecarInjectorConfigMap": false,
         "oneNamespace": false,

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.golden.yaml
@@ -1263,7 +1263,6 @@ data:
             "cpu": "10m"
           }
         },
-        "enabled": false,
         "externalIstiod": false,
         "hub": "docker.io/istio",
         "imagePullPolicy": "",
@@ -1284,7 +1283,6 @@ data:
           "clusterName": "",
           "enabled": false
         },
-        "namespace": "istio-system",
         "network": "",
         "omitSidecarInjectorConfigMap": false,
         "oneNamespace": false,

--- a/operator/cmd/mesh/testdata/manifest-generate/output/sidecar_template.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/sidecar_template.golden.yaml
@@ -26,7 +26,6 @@ data:
             "cpu": "10m"
           }
         },
-        "enabled": true,
         "externalIstiod": false,
         "hub": "gcr.io/istio-testing",
         "imagePullPolicy": "",
@@ -47,7 +46,6 @@ data:
           "clusterName": "",
           "enabled": false
         },
-        "namespace": "istio-system",
         "network": "",
         "omitSidecarInjectorConfigMap": false,
         "oneNamespace": false,

--- a/pkg/kube/inject/testdata/inputs/custom-template.yaml.34.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/custom-template.yaml.34.values.gen.yaml
@@ -13,7 +13,6 @@
         "cpu": "10m"
       }
     },
-    "enabled": false,
     "externalIstiod": false,
     "hub": "gcr.io/istio-testing",
     "imagePullPolicy": "",
@@ -34,7 +33,6 @@
       "clusterName": "",
       "enabled": false
     },
-    "namespace": "istio-system",
     "network": "",
     "omitSidecarInjectorConfigMap": false,
     "oneNamespace": false,

--- a/pkg/kube/inject/testdata/inputs/default.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/default.values.gen.yaml
@@ -13,7 +13,6 @@
         "cpu": "10m"
       }
     },
-    "enabled": false,
     "externalIstiod": false,
     "hub": "gcr.io/istio-testing",
     "imagePullPolicy": "",
@@ -34,7 +33,6 @@
       "clusterName": "",
       "enabled": false
     },
-    "namespace": "istio-system",
     "network": "",
     "omitSidecarInjectorConfigMap": false,
     "oneNamespace": false,

--- a/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.values.gen.yaml
@@ -13,7 +13,6 @@
         "cpu": "10m"
       }
     },
-    "enabled": false,
     "externalIstiod": false,
     "hub": "gcr.io/istio-testing",
     "imagePullPolicy": "",
@@ -34,7 +33,6 @@
       "clusterName": "",
       "enabled": false
     },
-    "namespace": "istio-system",
     "network": "",
     "omitSidecarInjectorConfigMap": false,
     "oneNamespace": false,

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.values.gen.yaml
@@ -13,7 +13,6 @@
         "cpu": "10m"
       }
     },
-    "enabled": false,
     "externalIstiod": false,
     "hub": "gcr.io/istio-testing",
     "imagePullPolicy": "",
@@ -34,7 +33,6 @@
       "clusterName": "",
       "enabled": false
     },
-    "namespace": "istio-system",
     "network": "",
     "omitSidecarInjectorConfigMap": false,
     "oneNamespace": false,

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.values.gen.yaml
@@ -13,7 +13,6 @@
         "cpu": "10m"
       }
     },
-    "enabled": false,
     "externalIstiod": false,
     "hub": "gcr.io/istio-testing",
     "imagePullPolicy": "",
@@ -34,7 +33,6 @@
       "clusterName": "",
       "enabled": false
     },
-    "namespace": "istio-system",
     "network": "",
     "omitSidecarInjectorConfigMap": false,
     "oneNamespace": false,

--- a/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.values.gen.yaml
@@ -13,7 +13,6 @@
         "cpu": "10m"
       }
     },
-    "enabled": false,
     "externalIstiod": false,
     "hub": "gcr.io/istio-testing",
     "imagePullPolicy": "",
@@ -36,7 +35,6 @@
       "clusterName": "",
       "enabled": false
     },
-    "namespace": "istio-system",
     "network": "",
     "omitSidecarInjectorConfigMap": false,
     "oneNamespace": false,

--- a/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.values.gen.yaml
@@ -13,7 +13,6 @@
         "cpu": "10m"
       }
     },
-    "enabled": false,
     "externalIstiod": false,
     "hub": "gcr.io/istio-testing",
     "imagePullPolicy": "",
@@ -34,7 +33,6 @@
       "clusterName": "",
       "enabled": false
     },
-    "namespace": "istio-system",
     "network": "",
     "omitSidecarInjectorConfigMap": false,
     "oneNamespace": false,

--- a/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.values.gen.yaml
@@ -13,7 +13,6 @@
         "cpu": "10m"
       }
     },
-    "enabled": false,
     "externalIstiod": false,
     "hub": "gcr.io/istio-testing",
     "imagePullPolicy": "",
@@ -34,7 +33,6 @@
       "clusterName": "",
       "enabled": false
     },
-    "namespace": "istio-system",
     "network": "",
     "omitSidecarInjectorConfigMap": false,
     "oneNamespace": false,

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.0.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.0.values.gen.yaml
@@ -13,7 +13,6 @@
         "cpu": "10m"
       }
     },
-    "enabled": false,
     "externalIstiod": false,
     "hub": "gcr.io/istio-testing",
     "imagePullPolicy": "",
@@ -34,7 +33,6 @@
       "clusterName": "",
       "enabled": false
     },
-    "namespace": "istio-system",
     "network": "network1",
     "omitSidecarInjectorConfigMap": false,
     "oneNamespace": false,

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.1.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.1.values.gen.yaml
@@ -13,7 +13,6 @@
         "cpu": "10m"
       }
     },
-    "enabled": false,
     "externalIstiod": false,
     "hub": "gcr.io/istio-testing",
     "imagePullPolicy": "",
@@ -34,7 +33,6 @@
       "clusterName": "",
       "enabled": false
     },
-    "namespace": "istio-system",
     "network": "",
     "omitSidecarInjectorConfigMap": false,
     "oneNamespace": false,

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.10.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.10.values.gen.yaml
@@ -13,7 +13,6 @@
         "cpu": "10m"
       }
     },
-    "enabled": false,
     "externalIstiod": false,
     "hub": "gcr.io/istio-testing",
     "imagePullPolicy": "",
@@ -36,7 +35,6 @@
       "clusterName": "",
       "enabled": false
     },
-    "namespace": "istio-system",
     "network": "",
     "omitSidecarInjectorConfigMap": false,
     "oneNamespace": false,

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.12.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.12.values.gen.yaml
@@ -13,7 +13,6 @@
         "cpu": "10m"
       }
     },
-    "enabled": false,
     "externalIstiod": false,
     "hub": "gcr.io/istio-testing",
     "imagePullPolicy": "",
@@ -34,7 +33,6 @@
       "clusterName": "",
       "enabled": false
     },
-    "namespace": "istio-system",
     "network": "",
     "omitSidecarInjectorConfigMap": false,
     "oneNamespace": false,

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.13.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.13.values.gen.yaml
@@ -13,7 +13,6 @@
         "cpu": "10m"
       }
     },
-    "enabled": false,
     "externalIstiod": false,
     "hub": "gcr.io/istio-testing",
     "imagePullPolicy": "",
@@ -34,7 +33,6 @@
       "clusterName": "",
       "enabled": false
     },
-    "namespace": "istio-system",
     "network": "",
     "omitSidecarInjectorConfigMap": false,
     "oneNamespace": false,

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.14.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.14.values.gen.yaml
@@ -13,7 +13,6 @@
         "cpu": "10m"
       }
     },
-    "enabled": false,
     "externalIstiod": false,
     "hub": "gcr.io/istio-testing",
     "imagePullPolicy": "",
@@ -34,7 +33,6 @@
       "clusterName": "",
       "enabled": false
     },
-    "namespace": "istio-system",
     "network": "",
     "omitSidecarInjectorConfigMap": false,
     "oneNamespace": false,

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.17.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.17.values.gen.yaml
@@ -13,7 +13,6 @@
         "cpu": "10m"
       }
     },
-    "enabled": false,
     "externalIstiod": false,
     "hub": "gcr.io/istio-testing",
     "imagePullPolicy": "",
@@ -34,7 +33,6 @@
       "clusterName": "",
       "enabled": false
     },
-    "namespace": "istio-system",
     "network": "",
     "omitSidecarInjectorConfigMap": false,
     "oneNamespace": false,

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.3.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.3.values.gen.yaml
@@ -13,7 +13,6 @@
         "cpu": "10m"
       }
     },
-    "enabled": false,
     "externalIstiod": false,
     "hub": "gcr.io/istio-testing",
     "imagePullPolicy": "Always",
@@ -34,7 +33,6 @@
       "clusterName": "",
       "enabled": false
     },
-    "namespace": "istio-system",
     "network": "",
     "omitSidecarInjectorConfigMap": false,
     "oneNamespace": false,

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.4.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.4.values.gen.yaml
@@ -13,7 +13,6 @@
         "cpu": "10m"
       }
     },
-    "enabled": false,
     "externalIstiod": false,
     "hub": "gcr.io/istio-testing",
     "imagePullPolicy": "Never",
@@ -34,7 +33,6 @@
       "clusterName": "",
       "enabled": false
     },
-    "namespace": "istio-system",
     "network": "",
     "omitSidecarInjectorConfigMap": false,
     "oneNamespace": false,

--- a/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.values.gen.yaml
@@ -13,7 +13,6 @@
         "cpu": "10m"
       }
     },
-    "enabled": false,
     "externalIstiod": false,
     "hub": "gcr.io/istio-testing",
     "imagePullPolicy": "",
@@ -34,7 +33,6 @@
       "clusterName": "",
       "enabled": false
     },
-    "namespace": "istio-system",
     "network": "",
     "omitSidecarInjectorConfigMap": false,
     "oneNamespace": false,

--- a/pkg/kube/inject/testdata/inputs/status_params.yaml.8.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/status_params.yaml.8.values.gen.yaml
@@ -13,7 +13,6 @@
         "cpu": "10m"
       }
     },
-    "enabled": false,
     "externalIstiod": false,
     "hub": "gcr.io/istio-testing",
     "imagePullPolicy": "",
@@ -34,7 +33,6 @@
       "clusterName": "",
       "enabled": false
     },
-    "namespace": "istio-system",
     "network": "",
     "omitSidecarInjectorConfigMap": false,
     "oneNamespace": false,

--- a/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.values.gen.yaml
@@ -13,7 +13,6 @@
         "cpu": "10m"
       }
     },
-    "enabled": false,
     "externalIstiod": false,
     "hub": "gcr.io/istio-testing",
     "imagePullPolicy": "",
@@ -34,7 +33,6 @@
       "clusterName": "",
       "enabled": false
     },
-    "namespace": "istio-system",
     "network": "",
     "omitSidecarInjectorConfigMap": false,
     "oneNamespace": false,


### PR DESCRIPTION
**Please provide a description of this PR:**

During translate phase, some fields are set unconditionally (for example, "enabled" is not allowed in "GlobalConfig"), and thus decode the protobuf twice, for example:

```
Failed to decode proto: "unknown field \"enabled\" in v1alpha1.GlobalConfig". Trying decode with AllowUnknownFields=true
```