### PR TITLE
Enable hostNetwork support in istiod Helm chart

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -75,6 +75,9 @@ spec:
 {{- end }}
       securityContext:
         fsGroup: 1337
+      {{- if .Values.pilot.enableHostNetwork }}
+      hostNetwork: true
+      {{- end }}
       containers:
         - name: discovery
 {{- if contains "/" .Values.pilot.image }}

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -121,7 +121,7 @@ sidecarInjectorWebhook:
 
   # Default templates specifies a set of default templates that are used in sidecar injection.
   # By default, a template `sidecar` is always provided, which contains the template of default sidecar. 
-  # To inject other additional templates, define it using the `templates` option, and add it to
+  # To inject other additional templates, define it using the `templates` option, and add it to 
   # the default templates list.
   # For example:
   #

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -120,9 +120,9 @@ sidecarInjectorWebhook:
   templates: {}
 
   # Default templates specifies a set of default templates that are used in sidecar injection.
-  # By default, a template `sidecar` is always provided, which contains the template of default sidecar.
+  # By default, a template `sidecar` is always provided, which contains the template of default sidecar. 
   # To inject other additional templates, define it using the `templates` option, and add it to
-  # the default templates list.
+  # the default templates list. 
   # For example:
   #
   # templates:

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -122,7 +122,7 @@ sidecarInjectorWebhook:
   # Default templates specifies a set of default templates that are used in sidecar injection.
   # By default, a template `sidecar` is always provided, which contains the template of default sidecar. 
   # To inject other additional templates, define it using the `templates` option, and add it to
-  # the default templates list. 
+  # the default templates list.
   # For example:
   #
   # templates:

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -67,6 +67,10 @@ pilot:
   # Additional labels to apply on the pod level for monitoring and logging configuration.
   podLabels: {}
 
+  # When running on EKS with a 3rd-party CNI provider this has to be set to
+  # allow webhook injection of the sidecar.
+  enableHostNetwork: false
+
 
 sidecarInjectorWebhook:
   # You can use the field called alwaysInjectSelector and neverInjectSelector which will always inject the sidecar or
@@ -116,8 +120,8 @@ sidecarInjectorWebhook:
   templates: {}
 
   # Default templates specifies a set of default templates that are used in sidecar injection.
-  # By default, a template `sidecar` is always provided, which contains the template of default sidecar. 
-  # To inject other additional templates, define it using the `templates` option, and add it to 
+  # By default, a template `sidecar` is always provided, which contains the template of default sidecar.
+  # To inject other additional templates, define it using the `templates` option, and add it to
   # the default templates list.
   # For example:
   #


### PR DESCRIPTION
When running in EKS and using a 3rd-party CNI provider like Weave Net the control plane is unable to call services inside the cluster. This prevents webhooks from working. Running istiod on the host network fixes this issue.

- [ ] Configuration Infrastructure
- [ ] Docs
- [X] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
