### PR TITLE
Enable VERIFY_CERTIFICATE_AT_CLIENT by default

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -597,11 +597,11 @@ var (
 		"If false, TCP probes will not be rewritten and therefor always succeed when a sidecar is used.",
 	).Get()
 
-	EnableQUICListeners = env.RegisterBoolVar("PILOT_ENABLE_QUIC_LISTENERS", true,
+	EnableQUICListeners = env.RegisterBoolVar("PILOT_ENABLE_QUIC_LISTENERS", false,
 		"If true, QUIC listeners will be generated wherever there are listeners terminating TLS on gateways "+
 			"if the gateway service exposes a UDP port with the same number (for example 443/TCP and 443/UDP)").Get()
 
-	VerifyCertAtClient = env.RegisterBoolVar("VERIFY_CERTIFICATE_AT_CLIENT", false,
+	VerifyCertAtClient = env.RegisterBoolVar("VERIFY_CERTIFICATE_AT_CLIENT", true,
 		"If enabled, certificates received by the proxy will be verified against the OS CA certificate bundle.").Get()
 
 	PrioritizedLeaderElection = env.RegisterBoolVar("PRIORITIZED_LEADER_ELECTION", true,

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -597,7 +597,7 @@ var (
 		"If false, TCP probes will not be rewritten and therefor always succeed when a sidecar is used.",
 	).Get()
 
-	EnableQUICListeners = env.RegisterBoolVar("PILOT_ENABLE_QUIC_LISTENERS", false,
+	EnableQUICListeners = env.RegisterBoolVar("PILOT_ENABLE_QUIC_LISTENERS", true,
 		"If true, QUIC listeners will be generated wherever there are listeners terminating TLS on gateways "+
 			"if the gateway service exposes a UDP port with the same number (for example 443/TCP and 443/UDP)").Get()
 

--- a/releasenotes/verify-certificate-at-client-enabled-by-default.yaml
+++ b/releasenotes/verify-certificate-at-client-enabled-by-default.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: feature
+area: security
+issue: 25652
+releaseNotes:
+- |
+  **Enabled** `VERIFY_CERTIFICATE_AT_CLIENT` by default. istio-proxy will automatically generate Server Name Indication and use the first detected Certificate Authority bundle. If undetected, no Certificate Authority bundle will be used by default.


### PR DESCRIPTION
Enable proxies using their OS CA certificate bundle by default.

Enable `VERIFY_CERTIFICATE_AT_CLIENT` by default.