### PR TITLE
XDS: remove unused DependentTypes

### DIFF
--- a/pilot/pkg/model/xds_cache.go
+++ b/pilot/pkg/model/xds_cache.go
@@ -25,7 +25,6 @@ import (
 	"google.golang.org/protobuf/testing/protocmp"
 
 	"istio.io/istio/pilot/pkg/features"
-	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/util/sets"
 	"istio.io/pkg/monitoring"
 )
@@ -132,7 +131,6 @@ func NewXdsCache() XdsCache {
 		enableAssertions: features.EnableUnsafeAssertions,
 		store:            newLru(),
 		configIndex:      map[ConfigKey]sets.Set{},
-		typesIndex:       map[config.GroupVersionKind]sets.Set{},
 	}
 }
 
@@ -142,7 +140,6 @@ func NewLenientXdsCache() XdsCache {
 		enableAssertions: false,
 		store:            newLru(),
 		configIndex:      map[ConfigKey]sets.Set{},
-		typesIndex:       map[config.GroupVersionKind]sets.Set{},
 	}
 }
 
@@ -154,7 +151,6 @@ type lruCache struct {
 	token       CacheToken
 	mu          sync.RWMutex
 	configIndex map[ConfigKey]sets.Set
-	typesIndex  map[config.GroupVersionKind]sets.Set
 }
 
 var _ XdsCache = &lruCache{}
@@ -266,11 +262,6 @@ func (l *lruCache) Clear(configs map[ConfigKey]struct{}) {
 		for key := range referenced {
 			l.store.Remove(key)
 		}
-		tReferenced := l.typesIndex[ckey.Kind]
-		delete(l.typesIndex, ckey.Kind)
-		for key := range tReferenced {
-			l.store.Remove(key)
-		}
 	}
 	size(l.store.Len())
 }
@@ -281,7 +272,6 @@ func (l *lruCache) ClearAll() {
 	l.token = CacheToken(time.Now().UnixNano())
 	l.store.Purge()
 	l.configIndex = map[ConfigKey]sets.Set{}
-	l.typesIndex = map[config.GroupVersionKind]sets.Set{}
 	size(l.store.Len())
 }
 

--- a/pilot/pkg/model/xds_cache.go
+++ b/pilot/pkg/model/xds_cache.go
@@ -90,24 +90,11 @@ func indexConfig(configIndex map[ConfigKey]sets.Set, k string, entry XdsCacheEnt
 	}
 }
 
-func indexType(typeIndex map[config.GroupVersionKind]sets.Set, k string, entry XdsCacheEntry) {
-	for _, t := range entry.DependentTypes() {
-		if typeIndex[t] == nil {
-			typeIndex[t] = sets.New()
-		}
-		typeIndex[t].Insert(k)
-	}
-}
-
 // XdsCacheEntry interface defines functions that should be implemented by
 // resources that can be cached.
 type XdsCacheEntry interface {
 	// Key is the key to be used in cache.
 	Key() string
-	// DependentTypes are config types that this cache key is dependant on.
-	// Whenever any configs of this type changes, we should invalidate this cache entry.
-	// Note: DependentConfigs should be preferred wherever possible.
-	DependentTypes() []config.GroupVersionKind
 	// DependentConfigs is config items that this cache key is dependent on.
 	// Whenever these configs change, we should invalidate this cache entry.
 	DependentConfigs() []ConfigKey
@@ -240,7 +227,6 @@ func (l *lruCache) Add(entry XdsCacheEntry, pushReq *PushRequest, value *discove
 	l.store.Add(k, toWrite)
 	l.token = token
 	indexConfig(l.configIndex, k, entry)
-	indexType(l.typesIndex, k, entry)
 	size(l.store.Len())
 }
 

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -474,10 +474,6 @@ func (t clusterCache) DependentConfigs() []model.ConfigKey {
 	return configs
 }
 
-func (t *clusterCache) DependentTypes() []config.GroupVersionKind {
-	return nil
-}
-
 func (t clusterCache) Cacheable() bool {
 	return true
 }

--- a/pilot/pkg/networking/core/v1alpha3/route/route_cache.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route_cache.go
@@ -97,10 +97,6 @@ func (r *Cache) DependentConfigs() []model.ConfigKey {
 	return configs
 }
 
-func (r *Cache) DependentTypes() []config.GroupVersionKind {
-	return nil
-}
-
 func (r *Cache) Key() string {
 	params := []string{
 		r.RouteName, r.ProxyVersion, r.ClusterID, r.DNSDomain,

--- a/pilot/pkg/xds/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoint_builder.go
@@ -170,12 +170,6 @@ func (b EndpointBuilder) DependentConfigs() []model.ConfigKey {
 	return configs
 }
 
-var edsDependentTypes = []config.GroupVersionKind{gvk.PeerAuthentication}
-
-func (b EndpointBuilder) DependentTypes() []config.GroupVersionKind {
-	return edsDependentTypes
-}
-
 // TODO(lambdai): Receive port value(15009 by default), builder to cover wide cases.
 type EndpointTunnelApplier interface {
 	// Mutate LbEndpoint in place. Return non-nil on failure.

--- a/pilot/pkg/xds/sds.go
+++ b/pilot/pkg/xds/sds.go
@@ -36,7 +36,6 @@ import (
 	"istio.io/istio/pilot/pkg/networking/util"
 	securitymodel "istio.io/istio/pilot/pkg/security/model"
 	"istio.io/istio/pkg/cluster"
-	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/gvk"
 )
 
@@ -46,11 +45,6 @@ type SecretResource struct {
 }
 
 var _ model.XdsCacheEntry = SecretResource{}
-
-// DependentTypes is not needed; we know exactly which configs impact SDS, so we can scope at DependentConfigs level
-func (sr SecretResource) DependentTypes() []config.GroupVersionKind {
-	return nil
-}
 
 func (sr SecretResource) DependentConfigs() []model.ConfigKey {
 	return relatedConfigs(model.ConfigKey{Kind: gvk.Secret, Name: sr.Name, Namespace: sr.Namespace})


### PR DESCRIPTION

**Please provide a description of this PR:**

XDS: remove unused DependentTypes since DependentConfigs can replace its functionality.