### PR TITLE
Fix consistent hash based on source IP for TCP proxy

### DIFF
--- a/pilot/pkg/xds/lds.go
+++ b/pilot/pkg/xds/lds.go
@@ -39,11 +39,11 @@ var skippedLdsConfigs = map[model.NodeType]map[config.GroupVersionKind]struct{}{
 		gvk.ProxyConfig:   {},
 	},
 	model.SidecarProxy: {
-		gvk.Gateway:         {},
-		gvk.WorkloadGroup:   {},
-		gvk.WorkloadEntry:   {},
-		gvk.Secret:          {},
-		gvk.ProxyConfig:     {},
+		gvk.Gateway:       {},
+		gvk.WorkloadGroup: {},
+		gvk.WorkloadEntry: {},
+		gvk.Secret:        {},
+		gvk.ProxyConfig:   {},
 	},
 }
 

--- a/pilot/pkg/xds/lds.go
+++ b/pilot/pkg/xds/lds.go
@@ -40,7 +40,6 @@ var skippedLdsConfigs = map[model.NodeType]map[config.GroupVersionKind]struct{}{
 	},
 	model.SidecarProxy: {
 		gvk.Gateway:         {},
-		gvk.DestinationRule: {},
 		gvk.WorkloadGroup:   {},
 		gvk.WorkloadEntry:   {},
 		gvk.Secret:          {},

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -1987,22 +1987,22 @@ spec:
 			// TODO: it may be necessary to vary the inputs of the hash and ensure we get a different backend
 			// But its pretty hard to test that, so for now just ensure we hit the same one.
 			cases = append(cases, TrafficTestCase{
-				name:   "source ip",
+				name:   "source ip " + c.Config().Service,
 				config: svc + tmpl.MustEvaluate(destRule, "useSourceIp: true"),
 				call:   c.CallOrFail,
 				opts:   callOpts,
 			}, TrafficTestCase{
-				name:   "query param",
+				name:   "query param"+ c.Config().Service,
 				config: svc + tmpl.MustEvaluate(destRule, "httpQueryParameterName: some-query-param"),
 				call:   c.CallOrFail,
 				opts:   callOpts,
 			}, TrafficTestCase{
-				name:   "http header",
+				name:   "http header"+ c.Config().Service,
 				config: svc + tmpl.MustEvaluate(destRule, "httpHeaderName: x-some-header"),
 				call:   c.CallOrFail,
 				opts:   callOpts,
 			}, TrafficTestCase{
-				name:   "source ip",
+				name:   "tcp source ip "+ c.Config().Service,
 				config: svc + tmpl.MustEvaluate(destRule, "useSourceIp: true"),
 				call:   c.CallOrFail,
 				opts:   tcpCallopts,

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -1992,17 +1992,17 @@ spec:
 				call:   c.CallOrFail,
 				opts:   callOpts,
 			}, TrafficTestCase{
-				name:   "query param"+ c.Config().Service,
+				name:   "query param" + c.Config().Service,
 				config: svc + tmpl.MustEvaluate(destRule, "httpQueryParameterName: some-query-param"),
 				call:   c.CallOrFail,
 				opts:   callOpts,
 			}, TrafficTestCase{
-				name:   "http header"+ c.Config().Service,
+				name:   "http header" + c.Config().Service,
 				config: svc + tmpl.MustEvaluate(destRule, "httpHeaderName: x-some-header"),
 				call:   c.CallOrFail,
 				opts:   callOpts,
 			}, TrafficTestCase{
-				name:   "tcp source ip "+ c.Config().Service,
+				name:   "tcp source ip " + c.Config().Service,
 				config: svc + tmpl.MustEvaluate(destRule, "useSourceIp: true"),
 				call:   c.CallOrFail,
 				opts:   tcpCallopts,


### PR DESCRIPTION
Fixes test flakes like
https://prow.istio.io/view/gs/istio-prow/logs/integ-ipv6_istio_postsubmit/1514637916112949248

We recently added TCP sourceIP consistent hash. Even more recently, this
test started to fail often. I believe this is due to a change to apply
YAML in parallel, exposing this bug.

The root cause is that we do not push LDS for DR changes, but the config
impacts LDS.

**Please provide a description of this PR:**