### PR TITLE
Validate all local IPs of service proxy in dual-stack clusters

### DIFF
--- a/tools/istio-iptables/pkg/cmd/root.go
+++ b/tools/istio-iptables/pkg/cmd/root.go
@@ -85,8 +85,8 @@ var rootCmd = &cobra.Command{
 				panic(err)
 			}
 
-			for _, hostIP := range hostIPs {
-				validator := validation.NewValidator(cfg, hostIP)
+			if len(hostIPs) > 0 {
+				validator := validation.NewValidator(cfg, hostIPs[0])
 				if err := validator.Run(); err != nil {
 					handleErrorWithCode(err, constants.ValidationErrorCode)
 				}
@@ -175,6 +175,7 @@ func constructConfig() *config.Config {
 	for _, podIP := range podIPs {
 		arrPodIPs = append(arrPodIPs, podIP.String())
 	}
+	// TODO(zhlsunshine): this assertion logic should be changed if Istio dual-stack is ready
 	if networkutil.AllIPv6(arrPodIPs) {
 		cfg.EnableInboundIPv6 = true
 	}

--- a/tools/istio-iptables/pkg/cmd/root.go
+++ b/tools/istio-iptables/pkg/cmd/root.go
@@ -25,6 +25,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
+	networkutil "istio.io/istio/pilot/pkg/util/network"
 	"istio.io/istio/tools/istio-iptables/pkg/capture"
 	"istio.io/istio/tools/istio-iptables/pkg/config"
 	"istio.io/istio/tools/istio-iptables/pkg/constants"
@@ -78,16 +79,19 @@ var rootCmd = &cobra.Command{
 			}
 		}
 		if cfg.RunValidation {
-			hostIP, err := getLocalIP()
+			hostIPs, err := getLocalIP()
 			if err != nil {
 				// Assume it is not handled by istio-cni and won't reuse the ValidationErrorCode
 				panic(err)
 			}
-			validator := validation.NewValidator(cfg, hostIP)
 
-			if err := validator.Run(); err != nil {
-				handleErrorWithCode(err, constants.ValidationErrorCode)
+			for _, hostIP := range hostIPs {
+				validator := validation.NewValidator(cfg, hostIP)
+				if err := validator.Run(); err != nil {
+					handleErrorWithCode(err, constants.ValidationErrorCode)
+				}
 			}
+
 		}
 	},
 }
@@ -162,11 +166,18 @@ func constructConfig() *config.Config {
 	}
 
 	// Detect whether IPv6 is enabled by checking if the pod's IP address is IPv4 or IPv6.
-	podIP, err := getLocalIP()
+	podIPs, err := getLocalIP()
 	if err != nil {
 		panic(err)
 	}
-	cfg.EnableInboundIPv6 = podIP.To4() == nil
+
+	var arrPodIPs []string
+	for _, podIP := range podIPs {
+		arrPodIPs = append(arrPodIPs, podIP.String())
+	}
+	if networkutil.AllIPv6(arrPodIPs) {
+		cfg.EnableInboundIPv6 = true
+	}
 
 	// Lookup DNS nameservers. We only do this if DNS is enabled in case of some obscure theoretical
 	// case where reading /etc/resolv.conf could fail.
@@ -183,18 +194,22 @@ func constructConfig() *config.Config {
 }
 
 // getLocalIP returns the local IP address
-func getLocalIP() (net.IP, error) {
+func getLocalIP() ([]net.IP, error) {
 	addrs, err := LocalIPAddrs()
 	if err != nil {
 		return nil, err
 	}
 
+	var netip []net.IP
 	for _, a := range addrs {
 		if ipnet, ok := a.(*net.IPNet); ok && !ipnet.IP.IsLoopback() && !ipnet.IP.IsLinkLocalUnicast() && !ipnet.IP.IsLinkLocalMulticast() {
-			return ipnet.IP, nil
+			netip = append(netip, ipnet.IP)
 		}
 	}
-	return nil, fmt.Errorf("no valid local IP address found")
+	if len(netip) != 0 {
+		return netip, nil
+	}
+	return netip, fmt.Errorf("no valid local IP address found")
 }
 
 func handleError(err error) {

--- a/tools/istio-iptables/pkg/cmd/root.go
+++ b/tools/istio-iptables/pkg/cmd/root.go
@@ -70,8 +70,8 @@ var rootCmd = &cobra.Command{
 			}
 		}
 
-		iptConfigurator := capture.NewIptablesConfigurator(cfg, ext)
 		if !cfg.SkipRuleApply {
+			iptConfigurator := capture.NewIptablesConfigurator(cfg, ext)
 			iptConfigurator.Run()
 			if err := capture.ConfigureRoutes(cfg, ext); err != nil {
 				log.Errorf("failed to configure routes: ")

--- a/tools/istio-iptables/pkg/cmd/root.go
+++ b/tools/istio-iptables/pkg/cmd/root.go
@@ -84,22 +84,8 @@ var rootCmd = &cobra.Command{
 				// Assume it is not handled by istio-cni and won't reuse the ValidationErrorCode
 				panic(err)
 			}
-			var checkIPv4, checkIPv6 bool
-			for _, hostIP := range hostIPs {
-				// it's unnecessary to check all IP, only one of IPv4 and IPv6 should be validated
-				// if it's dual-stack cluster
-				if checkIPv4 && checkIPv6 {
-					break
-				}
-				if checkIPv4 || checkIPv6 {
-					continue
-				}
-				if hostIP.To4() != nil {
-					checkIPv4 = true
-				} else {
-					checkIPv6 = true
-				}
-				validator := validation.NewValidator(cfg, hostIP)
+			if len(hostIPs) > 0 {
+				validator := validation.NewValidator(cfg, hostIPs[0])
 				if err := validator.Run(); err != nil {
 					handleErrorWithCode(err, constants.ValidationErrorCode)
 				}


### PR DESCRIPTION
**Please provide a description of this PR:**

Fixed [issue#35310](https://github.com/istio/istio/issues/35310) after [PR#38218](https://github.com/istio/istio/pull/38218) has been merged.
1. Validate all local IPs in service proxy, especially in dual stack cluster
2. Check all local IPs in service proxy, but keep the original logic for enabling IPv6 iptables only if all local IPs are IPv6