### PR TITLE
Change update_deps.sh to use docker (default) or crane

### DIFF
--- a/bin/update_deps.sh
+++ b/bin/update_deps.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -ex
+set -e
 
 UPDATE_BRANCH=${UPDATE_BRANCH:-"master"}
 


### PR DESCRIPTION
**Please provide a description of this PR:**

This change is to better support developers on MacOS on silicon devices.

On Apple devices, commands like `sed` and `grep` behave differently. Some of the Istio scripts, like update_deps.sh, use these commands and fail when run on the MacOS. One can install software to make the commands work as they do on Linux. Another option is to simply to do `make shell`  to get a Linux command line. From this Linux command line, the scripts can be run.

One issue right now is that the `crane` command segfaults when run in the `make shell` container. An issue with qemu? 

This PR reverts a change that solely uses `crane` in `update_deps.sh`, instead allowing the developer to export `ISTIO_DOCKER_BUILDER=crane` to use `crane`. I made `docker` the default to mimic the behavior in `docker-builder`. 