### PR TITLE
Update yq commands for v4

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -379,11 +379,7 @@ copy-templates:
 
 	# copy istio-discovery values, but apply some local customizations
 	cp manifests/charts/istio-control/istio-discovery/values.yaml manifests/charts/istiod-remote/
-	yq w manifests/charts/istiod-remote/values.yaml telemetry.enabled false -i
-	yq w manifests/charts/istiod-remote/values.yaml global.externalIstiod true -i
-	yq w manifests/charts/istiod-remote/values.yaml global.omitSidecarInjectorConfigMap true -i
-	yq w manifests/charts/istiod-remote/values.yaml pilot.configMap false -i
-
+	yq -i '.telemetry.enabled=false | .global.externalIstiod=true | .global.omitSidecarInjectorConfigMap=true | .pilot.configMap=false' manifests/charts/istiod-remote/values.yaml
 # Generate kustomize templates.
 gen-kustomize:
 	helm3 template istio --namespace istio-system --include-crds manifests/charts/base > manifests/charts/base/files/gen-istio-cluster.yaml

--- a/manifests/charts/istiod-remote/values.yaml
+++ b/manifests/charts/istiod-remote/values.yaml
@@ -177,9 +177,9 @@ meshConfig:
   # It is not clear if user should normally need to configure - the metadata is typically
   # used as an escape and to control testing and rollout, but it is not intended as a long-term
   # stable API.
-# What we may configure in mesh config is the ".global" - and use of other suffixes.
-# No hurry to do this in 1.6, we're trying to prove the code.
 
+  # What we may configure in mesh config is the ".global" - and use of other suffixes.
+  # No hurry to do this in 1.6, we're trying to prove the code.
 global:
   # Used to locate istiod.
   istioNamespace: istio-system
@@ -196,10 +196,10 @@ global:
   defaultResources:
     requests:
       cpu: 10m
-      #   memory: 128Mi
-      # limits:
-      #   cpu: 100m
-      #   memory: 128Mi
+    #   memory: 128Mi
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
   # Default hub for Istio images.
   # Releases are published to docker hub under 'istio' project.
   # Dev builds from prow are on gcr.io


### PR DESCRIPTION
**Please provide a description of this PR:**

Updated yq in tooling to v4 since `v3 is now deprecated, critical bug fixes and security fixes will still be applied until August 2021.` 

This needs an update our Makefile for the newer command syntax.