### PR TITLE
Update xargs removing -n1 when using -I

### DIFF
--- a/pkg/config/xds/filter_types.go
+++ b/pkg/config/xds/filter_types.go
@@ -30,9 +30,9 @@
 //go:generate sh -c "echo '// limitations under the License.\n' >> filter_types.gen.go"
 //go:generate sh -c "echo '//  GENERATED FILE -- DO NOT EDIT\n' >> filter_types.gen.go"
 //go:generate sh -c "echo 'package xds\n\nimport (' >> filter_types.gen.go"
-//go:generate sh -c "go list github.com/envoyproxy/go-control-plane/... | grep 'v[2-9]' | grep -v /pkg/ | xargs -n1 -I{} echo '\t_ \"{}\"' >> filter_types.gen.go"
+//go:generate sh -c "go list github.com/envoyproxy/go-control-plane/... | grep 'v[2-9]' | grep -v /pkg/ | xargs -I{} echo '\t_ \"{}\"' >> filter_types.gen.go"
 //go:generate sh -c "echo '\n\t// Istio-specific Envoy filters' >> filter_types.gen.go"
-//go:generate sh -c "go list istio.io/api/envoy/config/filter/... | grep 'v[2-9]' | xargs -n1 -I{} echo '\t_ \"{}\"' >> filter_types.gen.go"
+//go:generate sh -c "go list istio.io/api/envoy/config/filter/... | grep 'v[2-9]' | xargs -I{} echo '\t_ \"{}\"' >> filter_types.gen.go"
 //go:generate sh -c "echo ')' >> filter_types.gen.go"
 package xds
 


### PR DESCRIPTION
**Please provide a description of this PR:**

Fix for error message which appears when using Ubuntu `jammy`:
```
xargs: warning: options --max-args and --replace/-I/-i are mutually exclusive, ignoring previous --max-args value
xargs: warning: options --max-args and --replace/-I/-i are mutually exclusive, ignoring previous --max-args value
```

This still works with `focal`.