### PR TITLE
Mark TestAnalysisWritesStatus as requiring custom setup

### DIFF
--- a/tests/integration/pilot/analysis/analysis_test.go
+++ b/tests/integration/pilot/analysis/analysis_test.go
@@ -32,6 +32,7 @@ import (
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/framework/features"
+	"istio.io/istio/pkg/test/framework/label"
 	"istio.io/istio/pkg/test/util/retry"
 )
 
@@ -47,6 +48,7 @@ func TestAnalysisWritesStatus(t *testing.T) {
 		// TODO: make feature labels heirarchical constants like:
 		// Label(features.Usability.Observability.Status).
 		RequiresLocalControlPlane().
+		Label(label.CustomSetup).
 		Run(func(t framework.TestContext) {
 			ns := namespace.NewOrFail(t, t, namespace.Config{
 				Prefix:   "default",


### PR DESCRIPTION
Since test setup has

```
		Setup(istio.Setup(nil, func(_ resource.Context, cfg *istio.Config) {
			cfg.ControlPlaneValues = `
values:
  pilot:
    env:
      PILOT_ENABLE_STATUS: true
  global:
    istiod:
      enableAnalysis: true
`
		})).
```

should be marked as requiring custom setup