### PR TITLE
gateway conformance: enable injection namespace labels

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -97,7 +97,7 @@ require (
 	k8s.io/kubectl v0.23.5
 	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9
 	sigs.k8s.io/controller-runtime v0.11.2
-	sigs.k8s.io/gateway-api v0.4.1-0.20220411164207-d6bbc338d351
+	sigs.k8s.io/gateway-api v0.4.1-0.20220419214231-03f50b47814e
 	sigs.k8s.io/mcs-api v0.1.0
 	sigs.k8s.io/yaml v1.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -3099,8 +3099,8 @@ sigs.k8s.io/controller-runtime v0.11.2 h1:H5GTxQl0Mc9UjRJhORusqfJCIjBO8UtUxGggCw
 sigs.k8s.io/controller-runtime v0.11.2/go.mod h1:P6QCzrEjLaZGqHsfd+os7JQ+WFZhvB8MRFsn4dWF7O4=
 sigs.k8s.io/controller-tools v0.3.0/go.mod h1:enhtKGfxZD1GFEoMgP8Fdbu+uKQ/cq1/WGJhdVChfvI=
 sigs.k8s.io/controller-tools v0.7.0/go.mod h1:bpBAo0VcSDDLuWt47evLhMLPxRPxMDInTEH/YbdeMK0=
-sigs.k8s.io/gateway-api v0.4.1-0.20220411164207-d6bbc338d351 h1:4F7lwe6YevlYObT2HRPr1G4y63hb+NLyI2pxICJ3BoA=
-sigs.k8s.io/gateway-api v0.4.1-0.20220411164207-d6bbc338d351/go.mod h1:Gj2je/oOS/22fEU/U4xJ/nRH0wuQ3/kcfJUmLqtqXV4=
+sigs.k8s.io/gateway-api v0.4.1-0.20220419214231-03f50b47814e h1:PQOYjMWqURIPBmIEHw9OQAbtNb1DnwAVwAj/TC9l+24=
+sigs.k8s.io/gateway-api v0.4.1-0.20220419214231-03f50b47814e/go.mod h1:Gj2je/oOS/22fEU/U4xJ/nRH0wuQ3/kcfJUmLqtqXV4=
 sigs.k8s.io/json v0.0.0-20211020170558-c049b76a60c6 h1:fD1pz4yfdADVNfFmcP2aBEtudwUQ1AlLnRBALr33v3s=
 sigs.k8s.io/json v0.0.0-20211020170558-c049b76a60c6/go.mod h1:p4QtZmO4uMYipTQNzagwnNoseA6OxSUutVw05NhYDRs=
 sigs.k8s.io/kind v0.8.1/go.mod h1:oNKTxUVPYkV9lWzY6CVMNluVq8cBsyq+UgPJdvA3uu4=

--- a/pilot/pkg/config/kube/gateway/conditions.go
+++ b/pilot/pkg/config/kube/gateway/conditions.go
@@ -58,7 +58,7 @@ func createRouteStatus(gateways []routeParentReference, obj config.Config, curre
 		var condition metav1.Condition
 		if routeErr != nil {
 			condition = metav1.Condition{
-				Type:               string(k8s.ConditionRouteAccepted),
+				Type:               string(k8s.RouteConditionAccepted),
 				Status:             kstatus.StatusFalse,
 				ObservedGeneration: obj.Generation,
 				LastTransitionTime: metav1.Now(),
@@ -71,7 +71,7 @@ func createRouteStatus(gateways []routeParentReference, obj config.Config, curre
 				err = fmt.Sprintf("failed to bind to %d parents, last error: %v", failedCount[k], gw.DeniedReason.Error())
 			}
 			condition = metav1.Condition{
-				Type:               string(k8s.ConditionRouteAccepted),
+				Type:               string(k8s.RouteConditionAccepted),
 				Status:             kstatus.StatusFalse,
 				ObservedGeneration: obj.Generation,
 				LastTransitionTime: metav1.Now(),
@@ -80,7 +80,7 @@ func createRouteStatus(gateways []routeParentReference, obj config.Config, curre
 			}
 		} else {
 			condition = metav1.Condition{
-				Type:               string(k8s.ConditionRouteAccepted),
+				Type:               string(k8s.RouteConditionAccepted),
 				Status:             kstatus.StatusTrue,
 				ObservedGeneration: obj.Generation,
 				LastTransitionTime: metav1.Now(),

--- a/tests/integration/pilot/gateway_conformance_test.go
+++ b/tests/integration/pilot/gateway_conformance_test.go
@@ -91,7 +91,7 @@ func TestGatewayConformance(t *testing.T) {
 				Cleanup:          gatewayConformanceInputs.Cleanup,
 				RoundTripper:     nil,
 			}
-			if rev := ctx.Settings().Revision; rev != "" {
+			if rev := ctx.Settings().Revisions.Default(); rev != "" {
 				opts.NamespaceLabels = map[string]string{
 					"istio.io/rev": rev,
 				}

--- a/tests/integration/pilot/gateway_conformance_test.go
+++ b/tests/integration/pilot/gateway_conformance_test.go
@@ -84,13 +84,19 @@ func TestGatewayConformance(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			csuite := suite.New(suite.Options{
+			opts := suite.Options{
 				Client:           c,
 				GatewayClassName: "istio",
 				Debug:            scopes.Framework.DebugEnabled(),
 				Cleanup:          gatewayConformanceInputs.Cleanup,
 				RoundTripper:     nil,
-			})
+			}
+			if rev := ctx.Settings().Revision; rev != "" {
+				opts.NamespaceLabels = map[string]string{
+					"istio.io/rev": rev,
+				}
+			}
+			csuite := suite.New(opts)
 			csuite.Setup(t)
 
 			for _, ct := range tests.ConformanceTests {


### PR DESCRIPTION
Without this, the Gateway will not come up when using revisions.

This also changes the behavior - the test apps will also be injected
with sidecars. This seems like a reasonable side effect.

**Please provide a description of this PR:**