### PR TITLE
add OTel provider validation

### DIFF
--- a/pkg/config/validation/extensionprovider.go
+++ b/pkg/config/validation/extensionprovider.go
@@ -167,16 +167,29 @@ func validateExtensionProviderTracingSkyWalking(config *meshconfig.MeshConfig_Ex
 	return
 }
 
-func validateExtensionProviderMetricsPrometheus(prometheus *meshconfig.MeshConfig_ExtensionProvider_PrometheusMetricsProvider) error {
+func validateExtensionProviderMetricsPrometheus(_ *meshconfig.MeshConfig_ExtensionProvider_PrometheusMetricsProvider) error {
 	return nil
 }
 
-func validateExtensionProviderStackdriver(stackdriver *meshconfig.MeshConfig_ExtensionProvider_StackdriverProvider) error {
+func validateExtensionProviderStackdriver(_ *meshconfig.MeshConfig_ExtensionProvider_StackdriverProvider) error {
 	return nil
 }
 
-func validateExtensionProviderEnvoyFileAccessLog(log *meshconfig.MeshConfig_ExtensionProvider_EnvoyFileAccessLogProvider) error {
+func validateExtensionProviderEnvoyFileAccessLog(_ *meshconfig.MeshConfig_ExtensionProvider_EnvoyFileAccessLogProvider) error {
 	return nil
+}
+
+func ValidateExtensionProviderEnvoyOtelAls(provider *meshconfig.MeshConfig_ExtensionProvider_EnvoyOpenTelemetryLogProvider) (errs error) {
+	if provider == nil {
+		return fmt.Errorf("nil EnvoyOpenTelemetryLogProvider")
+	}
+	if err := ValidatePort(int(provider.Port)); err != nil {
+		errs = appendErrors(errs, err)
+	}
+	if err := validateExtensionProviderService(provider.Service); err != nil {
+		errs = appendErrors(errs, err)
+	}
+	return
 }
 
 func validateExtensionProvider(config *meshconfig.MeshConfig) (errs error) {
@@ -214,6 +227,8 @@ func validateExtensionProvider(config *meshconfig.MeshConfig) (errs error) {
 			currentErrs = appendErrors(currentErrs, validateExtensionProviderStackdriver(provider.Stackdriver))
 		case *meshconfig.MeshConfig_ExtensionProvider_EnvoyFileAccessLog:
 			currentErrs = appendErrors(currentErrs, validateExtensionProviderEnvoyFileAccessLog(provider.EnvoyFileAccessLog))
+		case *meshconfig.MeshConfig_ExtensionProvider_EnvoyOtelAls:
+			currentErrs = appendErrors(currentErrs, ValidateExtensionProviderEnvoyOtelAls(provider.EnvoyOtelAls))
 		default:
 			currentErrs = appendErrors(currentErrs, fmt.Errorf("unsupported provider: %v of type %T", provider, provider))
 		}

--- a/pkg/config/validation/extensionprovider_test.go
+++ b/pkg/config/validation/extensionprovider_test.go
@@ -289,3 +289,60 @@ func TestValidateExtensionProviderTracingOpenCensusAgent(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateExtensionProviderEnvoyOtelAls(t *testing.T) {
+	cases := []struct {
+		name     string
+		provider *meshconfig.MeshConfig_ExtensionProvider_EnvoyOpenTelemetryLogProvider
+		valid    bool
+	}{
+		{
+			name: "otel normal",
+			provider: &meshconfig.MeshConfig_ExtensionProvider_EnvoyOpenTelemetryLogProvider{
+				Service: "otel.istio-syste.svc",
+				Port:    4000,
+			},
+			valid: true,
+		},
+		{
+			name: "otel service with namespace",
+			provider: &meshconfig.MeshConfig_ExtensionProvider_EnvoyOpenTelemetryLogProvider{
+				Service: "namespace/otel.istio-syste.svc",
+				Port:    4000,
+			},
+			valid: true,
+		},
+		{
+			name: "otel service with invalid namespace",
+			provider: &meshconfig.MeshConfig_ExtensionProvider_EnvoyOpenTelemetryLogProvider{
+				Service: "name/space/otel.istio-syste.svc",
+				Port:    4000,
+			},
+			valid: false,
+		},
+		{
+			name: "otel service with port",
+			provider: &meshconfig.MeshConfig_ExtensionProvider_EnvoyOpenTelemetryLogProvider{
+				Service: "otel.istio-syste.svc:4000",
+				Port:    4000,
+			},
+			valid: false,
+		},
+		{
+			name: "otel missing port",
+			provider: &meshconfig.MeshConfig_ExtensionProvider_EnvoyOpenTelemetryLogProvider{
+				Service: "otel.istio-syste.svc",
+			},
+			valid: false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := ValidateExtensionProviderEnvoyOtelAls(c.provider)
+			valid := err == nil
+			if valid != c.valid {
+				t.Errorf("Expected valid=%v, got valid=%v for %v", c.valid, valid, c.provider)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Please provide a description of this PR:**

add validation 

```console
root@ecs-istiodev:~/GoProjects/src/istio.io/istio# out/linux_amd64/istioctl --log_output_level=all:info tag set canary --revision 1-14-0 --overwrite
2022-04-20T01:41:23.110642Z	warn	validation	found invalid extension provider (can be ignored if the given extension provider is not used): invalid extension provider otel: unsupported provider: &{service:"otel-collector.istio-system.svc.cluster.local" port:4317 log_format:{labels:{fields:{key:"hostname" value:{string_value:"%HOSTNAME%"}} fields:{key:"spanID" value:{string_value:"%REQ(X-B3-Spanid)%"}} fields:{key:"traceID" value:{string_value:"%REQ(X-B3-Traceid)%"}}}}} of type *v1alpha1.MeshConfig_ExtensionProvider_EnvoyOtelAls

```


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [x] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
