### PR TITLE
Implement WasmPlugin image pull policy

### DIFF
--- a/pilot/pkg/model/extensions.go
+++ b/pilot/pkg/model/extensions.go
@@ -163,7 +163,10 @@ func buildDataSource(u *url.URL, wasmPlugin *extensions.WasmPlugin) *envoyCoreV3
 	}
 }
 
-func buildVMConfig(datasource *envoyCoreV3.AsyncDataSource, resourceVersion string, wasmPlugin *extensions.WasmPlugin) *envoyExtensionsWasmV3.PluginConfig_VmConfig {
+func buildVMConfig(
+	datasource *envoyCoreV3.AsyncDataSource,
+	resourceVersion string,
+	wasmPlugin *extensions.WasmPlugin) *envoyExtensionsWasmV3.PluginConfig_VmConfig {
 	cfg := &envoyExtensionsWasmV3.PluginConfig_VmConfig{
 		VmConfig: &envoyExtensionsWasmV3.VmConfig{
 			Runtime: defaultRuntime,

--- a/pilot/pkg/model/extensions.go
+++ b/pilot/pkg/model/extensions.go
@@ -42,6 +42,8 @@ const (
 	WasmSecretEnv = "ISTIO_META_WASM_IMAGE_PULL_SECRET"
 	// name of environment variable at Wasm VM, which will carry the Wasm image pull policy.
 	WasmPolicyEnv = "ISTIO_META_WASM_IMAGE_PULL_POLICY"
+	// name of environment variable at Wasm VM, which will carry the resource version of WasmPlugin.
+	WasmResourceVersionEnv = "ISTIO_META_WASM_PLUGIN_RESOURCE_VERSION"
 )
 
 type WasmPluginWrapper struct {
@@ -93,7 +95,7 @@ func convertToWasmPluginWrapper(originPlugin config.Config) *WasmPluginWrapper {
 			Name:          plugin.Namespace + "." + plugin.Name,
 			RootId:        wasmPlugin.PluginName,
 			Configuration: cfg,
-			Vm:            buildVMConfig(datasource, wasmPlugin.VmConfig, wasmPlugin.ImagePullSecret, wasmPlugin.ImagePullPolicy),
+			Vm:            buildVMConfig(datasource, plugin.ResourceVersion, wasmPlugin),
 		},
 	}
 	if err != nil {
@@ -161,7 +163,7 @@ func buildDataSource(u *url.URL, wasmPlugin *extensions.WasmPlugin) *envoyCoreV3
 	}
 }
 
-func buildVMConfig(datasource *envoyCoreV3.AsyncDataSource, vm *extensions.VmConfig, secretName string, policy extensions.PullPolicy) *envoyExtensionsWasmV3.PluginConfig_VmConfig {
+func buildVMConfig(datasource *envoyCoreV3.AsyncDataSource, resourceVersion string, wasmPlugin *extensions.WasmPlugin) *envoyExtensionsWasmV3.PluginConfig_VmConfig {
 	cfg := &envoyExtensionsWasmV3.PluginConfig_VmConfig{
 		VmConfig: &envoyExtensionsWasmV3.VmConfig{
 			Runtime: defaultRuntime,
@@ -172,14 +174,17 @@ func buildVMConfig(datasource *envoyCoreV3.AsyncDataSource, vm *extensions.VmCon
 		},
 	}
 
-	if secretName != "" {
-		cfg.VmConfig.EnvironmentVariables.KeyValues[WasmSecretEnv] = secretName
+	if wasmPlugin.ImagePullSecret != "" {
+		cfg.VmConfig.EnvironmentVariables.KeyValues[WasmSecretEnv] = wasmPlugin.ImagePullSecret
 	}
 
-	if policy != extensions.PullPolicy_UNSPECIFIED_POLICY {
-		cfg.VmConfig.EnvironmentVariables.KeyValues[WasmPolicyEnv] = policy.String()
+	if wasmPlugin.ImagePullPolicy != extensions.PullPolicy_UNSPECIFIED_POLICY {
+		cfg.VmConfig.EnvironmentVariables.KeyValues[WasmPolicyEnv] = wasmPlugin.ImagePullPolicy.String()
 	}
 
+	cfg.VmConfig.EnvironmentVariables.KeyValues[WasmResourceVersionEnv] = resourceVersion
+
+	vm := wasmPlugin.VmConfig
 	if vm != nil && len(vm.Env) != 0 {
 		hostEnvKeys := make([]string, 0, len(vm.Env))
 		for _, e := range vm.Env {

--- a/pilot/pkg/model/extensions_test.go
+++ b/pilot/pkg/model/extensions_test.go
@@ -153,7 +153,11 @@ func TestBuildVMConfig(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
-			got := buildVMConfig(nil, tc.vm, "secret-name", tc.policy)
+			got := buildVMConfig(nil, "dummy-resource-version", &extensions.WasmPlugin{
+				VmConfig:        tc.vm,
+				ImagePullSecret: "secret-name",
+				ImagePullPolicy: tc.policy,
+			})
 			assert.Equal(t, tc.expected, got)
 		})
 	}

--- a/pilot/pkg/model/extensions_test.go
+++ b/pilot/pkg/model/extensions_test.go
@@ -99,7 +99,8 @@ func TestBuildVMConfig(t *testing.T) {
 					Runtime: defaultRuntime,
 					EnvironmentVariables: &envoyExtensionsWasmV3.EnvironmentVariables{
 						KeyValues: map[string]string{
-							WasmSecretEnv: "secret-name",
+							WasmSecretEnv:          "secret-name",
+							WasmResourceVersionEnv: "dummy-resource-version",
 						},
 					},
 				},
@@ -126,8 +127,9 @@ func TestBuildVMConfig(t *testing.T) {
 					EnvironmentVariables: &envoyExtensionsWasmV3.EnvironmentVariables{
 						HostEnvKeys: []string{"POD_NAME"},
 						KeyValues: map[string]string{
-							"ENV1":        "VAL1",
-							WasmSecretEnv: "secret-name",
+							"ENV1":                 "VAL1",
+							WasmSecretEnv:          "secret-name",
+							WasmResourceVersionEnv: "dummy-resource-version",
 						},
 					},
 				},
@@ -142,8 +144,9 @@ func TestBuildVMConfig(t *testing.T) {
 					Runtime: defaultRuntime,
 					EnvironmentVariables: &envoyExtensionsWasmV3.EnvironmentVariables{
 						KeyValues: map[string]string{
-							WasmSecretEnv: "secret-name",
-							WasmPolicyEnv: extensions.PullPolicy_name[int32(extensions.PullPolicy_IfNotPresent)],
+							WasmSecretEnv:          "secret-name",
+							WasmPolicyEnv:          extensions.PullPolicy_name[int32(extensions.PullPolicy_IfNotPresent)],
+							WasmResourceVersionEnv: "dummy-resource-version",
 						},
 					},
 				},

--- a/pkg/istio-agent/xds_proxy_test.go
+++ b/pkg/istio-agent/xds_proxy_test.go
@@ -444,14 +444,14 @@ func TestXdsProxyReconnects(t *testing.T) {
 
 type fakeAckCache struct{}
 
-func (f *fakeAckCache) Get(string, string, time.Duration, []byte, extensions.PullPolicy) (string, error) {
+func (f *fakeAckCache) Get(string, string, string, string, time.Duration, []byte, extensions.PullPolicy) (string, error) {
 	return "test", nil
 }
 func (f *fakeAckCache) Cleanup() {}
 
 type fakeNackCache struct{}
 
-func (f *fakeNackCache) Get(string, string, time.Duration, []byte, extensions.PullPolicy) (string, error) {
+func (f *fakeNackCache) Get(string, string, string, string, time.Duration, []byte, extensions.PullPolicy) (string, error) {
 	return "", errors.New("errror")
 }
 func (f *fakeNackCache) Cleanup() {}

--- a/pkg/istio-agent/xds_proxy_test.go
+++ b/pkg/istio-agent/xds_proxy_test.go
@@ -36,6 +36,7 @@ import (
 	"google.golang.org/grpc/test/bufconn"
 	"google.golang.org/protobuf/proto"
 
+	extensions "istio.io/api/extensions/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/model/status"
@@ -443,14 +444,14 @@ func TestXdsProxyReconnects(t *testing.T) {
 
 type fakeAckCache struct{}
 
-func (f *fakeAckCache) Get(string, string, time.Duration, []byte) (string, error) {
+func (f *fakeAckCache) Get(string, string, time.Duration, []byte, extensions.PullPolicy) (string, error) {
 	return "test", nil
 }
 func (f *fakeAckCache) Cleanup() {}
 
 type fakeNackCache struct{}
 
-func (f *fakeNackCache) Get(string, string, time.Duration, []byte) (string, error) {
+func (f *fakeNackCache) Get(string, string, time.Duration, []byte, extensions.PullPolicy) (string, error) {
 	return "", errors.New("errror")
 }
 func (f *fakeNackCache) Cleanup() {}

--- a/pkg/wasm/cache.go
+++ b/pkg/wasm/cache.go
@@ -162,7 +162,9 @@ func pullIfNotPresent(pullPolicy extensions.PullPolicy, u *url.URL) bool {
 }
 
 // Get returns path the local Wasm module file.
-func (c *LocalFileCache) Get(downloadURL, checksum, resourceName, resourceVersion string, timeout time.Duration, pullSecret []byte, pullPolicy extensions.PullPolicy) (string, error) {
+func (c *LocalFileCache) Get(
+	downloadURL, checksum, resourceName, resourceVersion string,
+	timeout time.Duration, pullSecret []byte, pullPolicy extensions.PullPolicy) (string, error) {
 	// Construct Wasm cache key with downloading URL and provided checksum of the module.
 	key := cacheKey{
 		downloadURL: downloadURL,

--- a/pkg/wasm/convert.go
+++ b/pkg/wasm/convert.go
@@ -25,6 +25,7 @@ import (
 	"go.uber.org/atomic"
 	any "google.golang.org/protobuf/types/known/anypb"
 
+	extensions "istio.io/api/extensions/v1alpha1"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/config/xds"
 )
@@ -117,6 +118,7 @@ func convert(resource *any.Any, cache Cache) (newExtensionConfig *any.Any, sendN
 	vm := wasmHTTPFilterConfig.Config.GetVmConfig()
 	envs := vm.GetEnvironmentVariables()
 	var pullSecret []byte
+	pullPolicy := extensions.PullPolicy_UNSPECIFIED_POLICY
 	if envs != nil {
 		if sec, found := envs.KeyValues[model.WasmSecretEnv]; found {
 			if sec == "" {
@@ -137,6 +139,12 @@ func convert(resource *any.Any, cache Cache) (newExtensionConfig *any.Any, sendN
 				envs.KeyValues = nil
 			}
 		}
+
+		if ps, found := envs.KeyValues[model.WasmPolicyEnv]; found {
+			if p, found := extensions.PullPolicy_value[ps]; found {
+				pullPolicy = extensions.PullPolicy(p)
+			}
+		}
 	}
 	remote := vm.GetCode().GetRemote()
 	httpURI := remote.GetHttpUri()
@@ -153,7 +161,7 @@ func convert(resource *any.Any, cache Cache) (newExtensionConfig *any.Any, sendN
 	if remote.GetHttpUri().Timeout != nil {
 		timeout = remote.GetHttpUri().Timeout.AsDuration()
 	}
-	f, err := cache.Get(httpURI.GetUri(), remote.Sha256, timeout, pullSecret)
+	f, err := cache.Get(httpURI.GetUri(), remote.Sha256, timeout, pullSecret, pullPolicy)
 	if err != nil {
 		status = fetchFailure
 		wasmLog.Errorf("cannot fetch Wasm module %v: %v", remote.GetHttpUri().GetUri(), err)

--- a/pkg/wasm/convert.go
+++ b/pkg/wasm/convert.go
@@ -119,6 +119,7 @@ func convert(resource *any.Any, cache Cache) (newExtensionConfig *any.Any, sendN
 	envs := vm.GetEnvironmentVariables()
 	var pullSecret []byte
 	pullPolicy := extensions.PullPolicy_UNSPECIFIED_POLICY
+	resourceVersion := ""
 	if envs != nil {
 		if sec, found := envs.KeyValues[model.WasmSecretEnv]; found {
 			if sec == "" {
@@ -145,6 +146,8 @@ func convert(resource *any.Any, cache Cache) (newExtensionConfig *any.Any, sendN
 				pullPolicy = extensions.PullPolicy(p)
 			}
 		}
+
+		resourceVersion = envs.KeyValues[model.WasmResourceVersionEnv]
 	}
 	remote := vm.GetCode().GetRemote()
 	httpURI := remote.GetHttpUri()
@@ -161,7 +164,7 @@ func convert(resource *any.Any, cache Cache) (newExtensionConfig *any.Any, sendN
 	if remote.GetHttpUri().Timeout != nil {
 		timeout = remote.GetHttpUri().Timeout.AsDuration()
 	}
-	f, err := cache.Get(httpURI.GetUri(), remote.Sha256, timeout, pullSecret, pullPolicy)
+	f, err := cache.Get(httpURI.GetUri(), remote.Sha256, wasmHTTPFilterConfig.Config.Name, resourceVersion, timeout, pullSecret, pullPolicy)
 	if err != nil {
 		status = fetchFailure
 		wasmLog.Errorf("cannot fetch Wasm module %v: %v", remote.GetHttpUri().GetUri(), err)

--- a/pkg/wasm/convert_test.go
+++ b/pkg/wasm/convert_test.go
@@ -43,7 +43,9 @@ type mockCache struct {
 	wantPolicy extensions.PullPolicy
 }
 
-func (c *mockCache) Get(downloadURL, checksum, resourceName, resourceVersion string, timeout time.Duration, pullSecret []byte, pullPolicy extensions.PullPolicy) (string, error) {
+func (c *mockCache) Get(
+	downloadURL, checksum, resourceName, resourceVersion string,
+	timeout time.Duration, pullSecret []byte, pullPolicy extensions.PullPolicy) (string, error) {
 	url, _ := url.Parse(downloadURL)
 	query := url.Query()
 

--- a/pkg/wasm/convert_test.go
+++ b/pkg/wasm/convert_test.go
@@ -43,7 +43,7 @@ type mockCache struct {
 	wantPolicy extensions.PullPolicy
 }
 
-func (c *mockCache) Get(downloadURL, checksum string, timeout time.Duration, pullSecret []byte, pullPolicy extensions.PullPolicy) (string, error) {
+func (c *mockCache) Get(downloadURL, checksum, resourceName, resourceVersion string, timeout time.Duration, pullSecret []byte, pullPolicy extensions.PullPolicy) (string, error) {
 	url, _ := url.Parse(downloadURL)
 	query := url.Query()
 

--- a/pkg/wasm/convert_test.go
+++ b/pkg/wasm/convert_test.go
@@ -32,6 +32,7 @@ import (
 	any "google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/structpb"
 
+	extensions "istio.io/api/extensions/v1alpha1"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pkg/config/xds"
@@ -39,9 +40,10 @@ import (
 
 type mockCache struct {
 	wantSecret []byte
+	wantPolicy extensions.PullPolicy
 }
 
-func (c *mockCache) Get(downloadURL, checksum string, timeout time.Duration, pullSecret []byte) (string, error) {
+func (c *mockCache) Get(downloadURL, checksum string, timeout time.Duration, pullSecret []byte, pullPolicy extensions.PullPolicy) (string, error) {
 	url, _ := url.Parse(downloadURL)
 	query := url.Query()
 
@@ -54,6 +56,10 @@ func (c *mockCache) Get(downloadURL, checksum string, timeout time.Duration, pul
 	if c.wantSecret != nil && !reflect.DeepEqual(c.wantSecret, pullSecret) {
 		return "", fmt.Errorf("wrong secret for %v, got %q want %q", downloadURL, string(pullSecret), c.wantSecret)
 	}
+	if c.wantPolicy != pullPolicy {
+		return "", fmt.Errorf("wrong pull policy for %v, got %v want %v", downloadURL, pullPolicy, c.wantPolicy)
+	}
+
 	return module, err
 }
 func (c *mockCache) Cleanup() {}

--- a/releasenotes/notes/wasm-pull-policy.yaml
+++ b/releasenotes/notes/wasm-pull-policy.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: feature
+area: extensibility
+issue: []
+releaseNotes:
+  - |
+    **Added** support for Istio WasmPlugin API


### PR DESCRIPTION
https://github.com/istio/istio/issues/35607

Implement [WasmPlugin image pull policy ](https://github.com/istio/api/blob/b6a03a9e477eb918b7e3105aaa00529183e4f82a/extensions/v1alpha1/wasm.proto#L241).

Similar with [ImagePullSecret of Wasm](https://github.com/istio/istio/pull/37161), ImagePullPolicy of Wasm is sent to istio-agent through the environment variables of ECDS. 
The policy is used in the internal Wasm binary cache of istio-agent to follow the [definition](https://github.com/istio/api/blob/b6a03a9e477eb918b7e3105aaa00529183e4f82a/extensions/v1alpha1/wasm.proto#L234-L240)

- [ X ] Policies and Telemetry