### PR TITLE
pilot: do not add ALPN filter to inbound filters

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/listener_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_builder.go
@@ -568,6 +568,7 @@ func buildInboundCatchAllFilterChains(configgen *ConfigGeneratorImpl,
 				Port:     15006,
 				Protocol: protocol.HTTP,
 			},
+			class:    istionetworking.ListenerClassSidecarInbound,
 			protocol: istionetworking.ListenerProtocolAuto,
 		}
 		// Call plugins to get mtls policies.

--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -2359,7 +2359,6 @@ func verifyOutboundTCPListenerHostname(t *testing.T, l *listener.Listener, hostn
 func verifyFilterChainMatch(t *testing.T, listener *listener.Listener) {
 	httpFilters := []string{
 		xdsfilters.MxFilterName,
-		xdsfilters.AlpnFilterName, // TODO(https://github.com/istio/istio/pull/38482)
 		xdsfilters.Fault.Name,
 		xdsfilters.Cors.Name,
 		xdsfilters.Router.Name,


### PR DESCRIPTION
This is fixing a small regression in
https://github.com/istio/istio/pull/37198, which has not been shipped in
any Istio versions yet. Basically that accidentally added the ALPN
filter to inbound. This technically does nothing, since it only impacts
TLS origination which we don't do for inbound, but still better to keep
it out to retain old state + smaller config.

**Please provide a description of this PR:**