### PR TITLE
Reduce https/http calls for getting an OCI image manifest for WASM plugin

### DIFF
--- a/pkg/wasm/cache_test.go
+++ b/pkg/wasm/cache_test.go
@@ -201,7 +201,7 @@ func TestWasmCache(t *testing.T) {
 			purgeInterval:        DefaultWasmModulePurgeInterval,
 			wasmModuleExpiry:     DefaultWasmModuleExpiry,
 			requestTimeout:       0, // Cause timeout immediately.
-			wantErrorMsgPrefix:   fmt.Sprintf("could not fetch Wasm OCI image: could not fetch image: Get \"https://%s/v2/\"", ou.Host),
+			wantErrorMsgPrefix:   fmt.Sprintf("could not fetch Wasm OCI image: could not fetch manifest: Get \"https://%s/v2/\"", ou.Host),
 		},
 		{
 			name:                 "fetch oci with wrong digest",

--- a/pkg/wasm/imagefetcher.go
+++ b/pkg/wasm/imagefetcher.go
@@ -90,14 +90,28 @@ func NewImageFetcher(ctx context.Context, opt ImageFetcherOption) *ImageFetcher 
 
 // Fetch is the entrypoint for fetching Wasm binary from Wasm Image Specification compatible images.
 func (o *ImageFetcher) Fetch(url, expManifestDigest string) (ret []byte, actualDigest string, err error) {
-	ref, err := o.parseReference(url)
+	ref, err := name.ParseReference(url)
 	if err != nil {
 		err = fmt.Errorf("could not parse url in image reference: %v", err)
 		return
 	}
 
+	// fallback to http based request, inspired by [helm](https://github.com/helm/helm/blob/12f1bc0acdeb675a8c50a78462ed3917fb7b2e37/pkg/registry/client.go#L594)
+	// only deal with https fallback instead of attributing all other type of errors to URL parsing error
+	desc, err := remote.Get(ref, o.fetchOpts...)
+	if err != nil && strings.Contains(err.Error(), "server gave HTTP response") {
+		wasmLog.Infof("fetch with plain text from %s", url)
+		ref, err = name.ParseReference(url, name.Insecure)
+		desc, err = remote.Get(ref, o.fetchOpts...)
+	}
+
+	if err != nil {
+		err = fmt.Errorf("could not fetch manifest: %v", err)
+		return
+	}
+
 	// Fetch image.
-	img, err := remote.Image(ref, o.fetchOpts...)
+	img, err := desc.Image()
 	if err != nil {
 		err = fmt.Errorf("could not fetch image: %v", err)
 		return
@@ -149,23 +163,6 @@ func (o *ImageFetcher) Fetch(url, expManifestDigest string) (ret []byte, actualD
 		),
 	)
 	return
-}
-
-func (o *ImageFetcher) parseReference(url string) (name.Reference, error) {
-	ref, err := name.ParseReference(url)
-	if err != nil {
-		return nil, err
-	}
-
-	// fallback to http based request, inspired by [helm](https://github.com/helm/helm/blob/12f1bc0acdeb675a8c50a78462ed3917fb7b2e37/pkg/registry/client.go#L594)
-	// only deal with https fallback instead of attributing all other type of errors to URL parsing error
-	_, err = remote.Get(ref, o.fetchOpts...)
-	if err != nil && strings.Contains(err.Error(), "server gave HTTP response") {
-		wasmLog.Infof("fetch with plain text from %s", url)
-		return name.ParseReference(url, name.Insecure)
-	}
-
-	return ref, nil
 }
 
 // extractDockerImage extracts the Wasm binary from the

--- a/pkg/wasm/imagefetcher.go
+++ b/pkg/wasm/imagefetcher.go
@@ -102,7 +102,9 @@ func (o *ImageFetcher) Fetch(url, expManifestDigest string) (ret []byte, actualD
 	if err != nil && strings.Contains(err.Error(), "server gave HTTP response") {
 		wasmLog.Infof("fetch with plain text from %s", url)
 		ref, err = name.ParseReference(url, name.Insecure)
-		desc, err = remote.Get(ref, o.fetchOpts...)
+		if err == nil {
+			desc, err = remote.Get(ref, o.fetchOpts...)
+		}
 	}
 
 	if err != nil {


### PR DESCRIPTION
In current implementation, to get OCI image for WASM, there are at least five times http/https calls happen.
By this patch, it is reduced to 3 times if the registry supports "https" which is usually expected. 

In details, `remote.Get` is always called two times. 
* [first](https://github.com/istio/istio/blob/7c583c4600decefc6bf7f8216dcd65edb0ed095a/pkg/wasm/imagefetcher.go#L162)
* [second](https://github.com/google/go-containerregistry/blob/570ba6c88a5041afebd4599981d849af96f5dba9/pkg/v1/remote/image.go#L53).

(each `remote.Get` calls two times http/https calls: `ping` and real request.)

- [ *] Policies and Telemetry