### PR TITLE
Fix multi cluster sync

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -156,7 +156,7 @@ func (m *Multicluster) ClusterAdded(cluster *multicluster.Cluster, clusterStopCh
 	options := m.opts
 	options.ClusterID = cluster.ID
 	// the aggregate registry's HasSynced will use the k8s controller's HasSynced, so we reference the same timeout
-	options.SyncTimeout = cluster.SyncTimeout
+	options.SyncCtx = cluster.SyncCtx
 	// different clusters may have different k8s version, re-apply conditional default
 	options.EndpointMode = DetectEndpointMode(client)
 


### PR DESCRIPTION
**Please provide a description of this PR:**

We mark istiod ready before serving connections with this check

https://github.com/istio/istio/blob/8a5f8e115b3dd6c78b83d60359a17fb63a86053b/pilot/pkg/bootstrap/server.go#L849-L860


But ServiceController().HasSynced() respect `SyncTimeout`, this is not right, we spent a lot of effort to stop serving before cache and xds synced(CommittedUpdates).  This conflicts with our effort.