### PR TITLE
Fix cluster and kube controller sync

### DIFF
--- a/pilot/pkg/bootstrap/servicecontroller.go
+++ b/pilot/pkg/bootstrap/servicecontroller.go
@@ -17,6 +17,7 @@ package bootstrap
 import (
 	"fmt"
 
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/serviceregistry/aggregate"
 	kubecontroller "istio.io/istio/pilot/pkg/serviceregistry/kube/controller"
 	"istio.io/istio/pilot/pkg/serviceregistry/provider"
@@ -75,6 +76,7 @@ func (s *Server) initKubeRegistry(args *PilotArgs) (err error) {
 	args.RegistryOptions.KubeOptions.MeshWatcher = s.environment.Watcher
 	args.RegistryOptions.KubeOptions.SystemNamespace = args.Namespace
 	args.RegistryOptions.KubeOptions.MeshServiceController = s.ServiceController()
+	args.RegistryOptions.KubeOptions.SyncTimeout = features.RemoteClusterTimeout
 
 	s.multiclusterController.AddHandler(kubecontroller.NewMulticluster(args.PodName,
 		s.kubeClient,

--- a/pilot/pkg/bootstrap/servicecontroller.go
+++ b/pilot/pkg/bootstrap/servicecontroller.go
@@ -17,7 +17,6 @@ package bootstrap
 import (
 	"fmt"
 
-	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/serviceregistry/aggregate"
 	kubecontroller "istio.io/istio/pilot/pkg/serviceregistry/kube/controller"
 	"istio.io/istio/pilot/pkg/serviceregistry/provider"
@@ -76,7 +75,6 @@ func (s *Server) initKubeRegistry(args *PilotArgs) (err error) {
 	args.RegistryOptions.KubeOptions.MeshWatcher = s.environment.Watcher
 	args.RegistryOptions.KubeOptions.SystemNamespace = args.Namespace
 	args.RegistryOptions.KubeOptions.MeshServiceController = s.ServiceController()
-	args.RegistryOptions.KubeOptions.SyncTimeout = features.RemoteClusterTimeout
 
 	s.multiclusterController.AddHandler(kubecontroller.NewMulticluster(args.PodName,
 		s.kubeClient,

--- a/pilot/pkg/config/kube/crdclient/client.go
+++ b/pilot/pkg/config/kube/crdclient/client.go
@@ -426,7 +426,7 @@ func knownCRDs(crdClient apiextensionsclient.Interface) (map[string]struct{}, er
 	var res *crd.CustomResourceDefinitionList
 	b := backoff.NewExponentialBackOff()
 	b.InitialInterval = time.Second
-	b.MaxElapsedTime = time.Minute
+	b.MaxElapsedTime = 20 * time.Second
 	err := backoff.Retry(func() error {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -155,8 +155,6 @@ func (m *Multicluster) ClusterAdded(cluster *multicluster.Cluster, clusterStopCh
 	// clusterStopCh is a channel that will be closed when this cluster removed.
 	options := m.opts
 	options.ClusterID = cluster.ID
-	// the aggregate registry's HasSynced will use the k8s controller's HasSynced, so we reference the same timeout
-	options.SyncTimeout = cluster.SyncTimeout
 	// different clusters may have different k8s version, re-apply conditional default
 	options.EndpointMode = DetectEndpointMode(client)
 

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -151,20 +151,22 @@ func (m *Multicluster) ClusterAdded(cluster *multicluster.Cluster, clusterStopCh
 	}
 
 	client := cluster.Client
+	// localCluster may also be the "config" cluster, in an external-istiod setup.
+	localCluster := m.opts.ClusterID == cluster.ID
 
 	// clusterStopCh is a channel that will be closed when this cluster removed.
 	options := m.opts
 	options.ClusterID = cluster.ID
 	// different clusters may have different k8s version, re-apply conditional default
 	options.EndpointMode = DetectEndpointMode(client)
-
+	if !localCluster {
+		options.SyncTimeout = features.RemoteClusterTimeout
+	}
 	log.Infof("Initializing Kubernetes service registry %q", options.ClusterID)
 	kubeRegistry := NewController(client, options)
 	m.remoteKubeControllers[cluster.ID] = &kubeController{
 		Controller: kubeRegistry,
 	}
-	// localCluster may also be the "config" cluster, in an external-istiod setup.
-	localCluster := m.opts.ClusterID == cluster.ID
 
 	m.m.Unlock()
 

--- a/pkg/kube/multicluster/cluster.go
+++ b/pkg/kube/multicluster/cluster.go
@@ -1,0 +1,61 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multicluster
+
+import (
+	"crypto/sha256"
+
+	"go.uber.org/atomic"
+
+	"istio.io/istio/pkg/cluster"
+	"istio.io/istio/pkg/kube"
+)
+
+// Cluster defines cluster struct
+type Cluster struct {
+	// ID of the cluster.
+	ID cluster.ID
+	// SyncTimeout is marked after features.RemoteClusterTimeout.
+	SyncTimeout *atomic.Bool
+	// Client for accessing the cluster.
+	Client kube.Client
+
+	kubeConfigSha [sha256.Size]byte
+
+	stop chan struct{}
+	// initialSync is marked when RunAndWait completes
+	initialSync *atomic.Bool
+}
+
+// Stop channel which is closed when the cluster is removed or the Controller that created the client is stopped.
+// Client.RunAndWait is called using this channel.
+func (r *Cluster) Stop() <-chan struct{} {
+	return r.stop
+}
+
+// Run starts the cluster's informers and waits for caches to sync. Once caches are synced, we mark the cluster synced.
+// This should be called after each of the handlers have registered informers, and should be run in a goroutine.
+func (r *Cluster) Run() {
+	r.Client.RunAndWait(r.Stop())
+	r.initialSync.Store(true)
+}
+
+func (r *Cluster) HasSynced() bool {
+	return r.initialSync.Load() || r.SyncTimeout.Load()
+}
+
+func (r *Cluster) SyncDidTimeout() bool {
+	return r.SyncTimeout.Load() && !r.HasSynced()
+}

--- a/pkg/kube/multicluster/cluster.go
+++ b/pkg/kube/multicluster/cluster.go
@@ -66,7 +66,22 @@ func (r *Cluster) Run() {
 }
 
 func (r *Cluster) HasSynced() bool {
+	// It could happen when a wrong crendential provide, this cluster has no chance to run.
+	// In this case, the `initialSyncTimeout` will never be set
+	// In order not block istiod start up, check close as well.
+	if r.Closed() {
+		return true
+	}
 	return r.initialSync.Load() || r.initialSyncTimeout.Load()
+}
+
+func (r *Cluster) Closed() bool {
+	select {
+	case <-r.stop:
+		return true
+	default:
+		return false
+	}
 }
 
 func (r *Cluster) SyncDidTimeout() bool {

--- a/pkg/kube/multicluster/cluster.go
+++ b/pkg/kube/multicluster/cluster.go
@@ -16,19 +16,20 @@ package multicluster
 
 import (
 	"crypto/sha256"
+	"time"
 
 	"go.uber.org/atomic"
 
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/kube"
+	"istio.io/pkg/log"
 )
 
 // Cluster defines cluster struct
 type Cluster struct {
 	// ID of the cluster.
 	ID cluster.ID
-	// SyncTimeout is marked after features.RemoteClusterTimeout.
-	SyncTimeout *atomic.Bool
 	// Client for accessing the cluster.
 	Client kube.Client
 
@@ -37,6 +38,8 @@ type Cluster struct {
 	stop chan struct{}
 	// initialSync is marked when RunAndWait completes
 	initialSync *atomic.Bool
+	// initialSyncTimeout is set when RunAndWait timed out
+	initialSyncTimeout *atomic.Bool
 }
 
 // Stop channel which is closed when the cluster is removed or the Controller that created the client is stopped.
@@ -48,14 +51,24 @@ func (r *Cluster) Stop() <-chan struct{} {
 // Run starts the cluster's informers and waits for caches to sync. Once caches are synced, we mark the cluster synced.
 // This should be called after each of the handlers have registered informers, and should be run in a goroutine.
 func (r *Cluster) Run() {
+	if features.RemoteClusterTimeout > 0 {
+		time.AfterFunc(features.RemoteClusterTimeout, func() {
+			if !r.initialSync.Load() {
+				log.Errorf("remote cluster %s failed to sync after %v", r.ID, features.RemoteClusterTimeout)
+				timeouts.Increment()
+			}
+			r.initialSyncTimeout.Store(true)
+		})
+	}
+
 	r.Client.RunAndWait(r.Stop())
 	r.initialSync.Store(true)
 }
 
 func (r *Cluster) HasSynced() bool {
-	return r.initialSync.Load() || r.SyncTimeout.Load()
+	return r.initialSync.Load() || r.initialSyncTimeout.Load()
 }
 
 func (r *Cluster) SyncDidTimeout() bool {
-	return r.SyncTimeout.Load() && !r.HasSynced()
+	return !r.initialSync.Load() && r.initialSyncTimeout.Load()
 }

--- a/pkg/kube/multicluster/clusterstore.go
+++ b/pkg/kube/multicluster/clusterstore.go
@@ -1,0 +1,124 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multicluster
+
+import (
+	"sync"
+
+	"istio.io/istio/pkg/cluster"
+	"istio.io/istio/pkg/util/sets"
+)
+
+// ClusterStore is a collection of clusters
+type ClusterStore struct {
+	sync.RWMutex
+	// keyed by secret key(ns/name)->clusterID
+	remoteClusters map[string]map[cluster.ID]*Cluster
+	clusters       sets.Set
+}
+
+// newClustersStore initializes data struct to store clusters information
+func newClustersStore() *ClusterStore {
+	return &ClusterStore{
+		remoteClusters: make(map[string]map[cluster.ID]*Cluster),
+		clusters:       sets.New(),
+	}
+}
+
+func (c *ClusterStore) Store(secretKey string, clusterID cluster.ID, value *Cluster) {
+	c.Lock()
+	defer c.Unlock()
+	if _, ok := c.remoteClusters[secretKey]; !ok {
+		c.remoteClusters[secretKey] = make(map[cluster.ID]*Cluster)
+	}
+	c.remoteClusters[secretKey][clusterID] = value
+	c.clusters.Insert(string(clusterID))
+}
+
+func (c *ClusterStore) Delete(secretKey string, clusterID cluster.ID) {
+	c.Lock()
+	defer c.Unlock()
+	delete(c.remoteClusters[secretKey], clusterID)
+	c.clusters.Delete(string(clusterID))
+	if len(c.remoteClusters[secretKey]) == 0 {
+		delete(c.remoteClusters, secretKey)
+	}
+}
+
+func (c *ClusterStore) Get(secretKey string, clusterID cluster.ID) *Cluster {
+	c.RLock()
+	defer c.RUnlock()
+	if _, ok := c.remoteClusters[secretKey]; !ok {
+		return nil
+	}
+	return c.remoteClusters[secretKey][clusterID]
+}
+
+func (c *ClusterStore) Contains(clusterID cluster.ID) bool {
+	c.RLock()
+	defer c.RUnlock()
+	return c.clusters.Contains(string(clusterID))
+}
+
+func (c *ClusterStore) GetByID(clusterID cluster.ID) *Cluster {
+	c.RLock()
+	defer c.RUnlock()
+	for _, clusters := range c.remoteClusters {
+		c, ok := clusters[clusterID]
+		if ok {
+			return c
+		}
+	}
+	return nil
+}
+
+// All returns a copy of the current remote clusters.
+func (c *ClusterStore) All() map[string]map[cluster.ID]*Cluster {
+	if c == nil {
+		return nil
+	}
+	c.RLock()
+	defer c.RUnlock()
+	out := make(map[string]map[cluster.ID]*Cluster, len(c.remoteClusters))
+	for secret, clusters := range c.remoteClusters {
+		out[secret] = make(map[cluster.ID]*Cluster, len(clusters))
+		for cid, c := range clusters {
+			outCluster := *c
+			out[secret][cid] = &outCluster
+		}
+	}
+	return out
+}
+
+// GetExistingClustersFor return existing clusters registered for the given secret
+func (c *ClusterStore) GetExistingClustersFor(secretKey string) []*Cluster {
+	c.RLock()
+	defer c.RUnlock()
+	out := make([]*Cluster, 0, len(c.remoteClusters[secretKey]))
+	for _, cluster := range c.remoteClusters[secretKey] {
+		out = append(out, cluster)
+	}
+	return out
+}
+
+func (c *ClusterStore) Len() int {
+	c.Lock()
+	defer c.Unlock()
+	out := 0
+	for _, clusterMap := range c.remoteClusters {
+		out += len(clusterMap)
+	}
+	return out
+}

--- a/pkg/kube/multicluster/secretcontroller.go
+++ b/pkg/kube/multicluster/secretcontroller.go
@@ -20,7 +20,6 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
-	"sync"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
@@ -89,7 +88,6 @@ type Controller struct {
 
 	handlers []ClusterHandler
 
-	once         sync.Once
 	syncInterval time.Duration
 }
 

--- a/pkg/kube/multicluster/secretcontroller.go
+++ b/pkg/kube/multicluster/secretcontroller.go
@@ -87,8 +87,6 @@ type Controller struct {
 	cs *ClusterStore
 
 	handlers []ClusterHandler
-
-	syncInterval time.Duration
 }
 
 // NewController returns a new secret controller

--- a/pkg/kube/multicluster/secretcontroller.go
+++ b/pkg/kube/multicluster/secretcontroller.go
@@ -157,7 +157,7 @@ func (c *Controller) close() {
 	defer c.cs.Unlock()
 	for _, clusterMap := range c.cs.remoteClusters {
 		for _, cluster := range clusterMap {
-			close(cluster.stop)
+			cluster.Stop()
 		}
 	}
 }
@@ -350,7 +350,7 @@ func (c *Controller) addSecret(name types.NamespacedName, s *corev1.Secret) {
 		}
 		c.cs.Store(secretKey, remoteCluster.ID, remoteCluster)
 		if err := callback(remoteCluster, remoteCluster.stop); err != nil {
-			close(remoteCluster.stop)
+			remoteCluster.Stop()
 			log.Errorf("%s cluster_id from secret=%v: %s %v", action, clusterID, secretKey, err)
 			continue
 		}
@@ -368,7 +368,7 @@ func (c *Controller) deleteSecret(secretKey string) {
 			continue
 		}
 		log.Infof("Deleting cluster_id=%v configured by secret=%v", cluster.ID, secretKey)
-		close(cluster.stop)
+		cluster.Stop()
 		err := c.handleDelete(cluster.ID)
 		if err != nil {
 			log.Errorf("Error removing cluster_id=%v configured by secret=%v: %v",
@@ -387,7 +387,7 @@ func (c *Controller) deleteCluster(secretKey string, clusterID cluster.ID) {
 		log.Infof("Number of remote clusters: %d", c.cs.Len())
 	}()
 	log.Infof("Deleting cluster_id=%v configured by secret=%v", clusterID, secretKey)
-	close(c.cs.remoteClusters[secretKey][clusterID].stop)
+	c.cs.remoteClusters[secretKey][clusterID].Stop()
 	err := c.handleDelete(clusterID)
 	if err != nil {
 		log.Errorf("Error removing cluster_id=%v configured by secret=%v: %v",


### PR DESCRIPTION
**Please provide a description of this PR:**

Before, every cluster use the same timeout boolean value, this is not right, thinking that a cluster can be added after the the boolean has been set

This pr also split the cluster and clusterstore out from secret controller, for good readability.


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
