### PR TITLE
[charts] Allow to configure a sleep command to let the main app stop properly

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -521,6 +521,12 @@ data:
               value: "{{ $value }}"
             {{- end }}
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+            {{- if (isset .ObjectMeta.Annotations `sidecar.istio.io/preStopSleep`) }}
+            lifecycle:
+              preStop:
+                exec:
+                  command: ["/bin/sleep", "{{ annotation .ObjectMeta `sidecar.istio.io/preStopSleep` '5' }}"]
+            {{- end }}
             {{ if ne (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) `0` }}
             readinessProbe:
               httpGet:

--- a/releasenotes/notes/prestopsleep-annotations.yaml
+++ b/releasenotes/notes/prestopsleep-annotations.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+releaseNotes:
+  - |
+    **Added** Add a 5 seconds sleep by default on the istio-proxy to let the main container handle the last requests. The default value can be overwritten with an annotation on the pods.


### PR DESCRIPTION
**Please provide a description of this PR:**

This command add a short sleep by default to the istio-proxy when the pod shutdowns. 
It can be overwritten with the annotation `sidecar.istio.io/preStopSleep` on each pods.
This can be useful for apps that takes some time to shutdown and needs to handle last requests.