### PR TITLE
[release-1.12] Fix mutatingwebhook analysis

### DIFF
--- a/pkg/config/schema/collections/collections.gen.go
+++ b/pkg/config/schema/collections/collections.gen.go
@@ -329,7 +329,7 @@ var (
 			Proto:         "k8s.io.api.admissionregistration.v1.MutatingWebhookConfiguration",
 			ReflectType:   reflect.TypeOf(&k8sioapiadmissionregistrationv1.MutatingWebhookConfiguration{}).Elem(),
 			ProtoPackage:  "k8s.io/api/admissionregistration/v1",
-			ClusterScoped: false,
+			ClusterScoped: true,
 			ValidateProto: validation.EmptyValidate,
 		}.MustBuild(),
 	}.MustBuild()

--- a/pkg/config/schema/metadata.gen.go
+++ b/pkg/config/schema/metadata.gen.go
@@ -332,6 +332,7 @@ resources:
     plural: "mutatingwebhookconfigurations"
     group: "admissionregistration.k8s.io"
     version: "v1"
+    clusterScoped: true
     proto: "k8s.io.api.admissionregistration.v1.MutatingWebhookConfiguration"
     protoPackage: "k8s.io/api/admissionregistration/v1"
 

--- a/pkg/config/schema/metadata.yaml
+++ b/pkg/config/schema/metadata.yaml
@@ -277,6 +277,7 @@ resources:
     plural: "mutatingwebhookconfigurations"
     group: "admissionregistration.k8s.io"
     version: "v1"
+    clusterScoped: true
     proto: "k8s.io.api.admissionregistration.v1.MutatingWebhookConfiguration"
     protoPackage: "k8s.io/api/admissionregistration/v1"
 

--- a/releasenotes/notes/38496.yaml
+++ b/releasenotes/notes/38496.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+issue:
+  - https://github.com/istio/istio/issues/36114
+releaseNotes:
+  - |
+    **Fixed** an issue in webhook analysis which would make helm reconciler complain about overlapping webhooks


### PR DESCRIPTION
**Please provide a description of this PR:**
fixes: #36114

This is a manual change instead of clean cherry-pick because this is a fix in the galley code which got removed with the[ removal of legacy galley code in 1.13](https://github.com/istio/istio/commit/d0748d7c46c02e1fddf77d7a38f90cb3620e4358)


- Reconcile invokes [analyzeWebhooks](https://github.com/istio/istio/blob/1.12.6/operator/pkg/helmreconciler/reconciler.go#L168) 
- analyzeWebhooks creates an instance of source analyzer, `sa`, with config schema, resources read from[ `metadata.yaml`](https://github.com/istio/istio/blob/a0c7a3355331ef20354e3e1682dc13b7e6bcf4c1/pkg/config/schema/metadata.yaml#L276-L281). In this file, webhooks are not mentioned as `clusterScoped: true` and this is the cause of the issue. 
- [`sa.AddReaderKubeSource()`](https://github.com/istio/istio/blob/a0c7a3355331ef20354e3e1682dc13b7e6bcf4c1/operator/pkg/helmreconciler/reconciler.go#L591) then  tries to add config sources based on metadata file. In this call flow eventually from [here](https://github.com/istio/istio/blob/1.12.6/galley/pkg/config/source/kube/inmemory/kubesource.go#L306-L310), it ended up prefixing `istio-system` in the webhook name. IOW, in the analyzer's snapshot, webhook gets stored by key `istio-system/<webhook-name>`
-  analyzer also runs a k8s watcher. In the initial cache sync itself, this watcher inserts, along with other resources, webhook as well into the buffer queue. [But here `istio-system` is not added as the prefix.](https://github.com/istio/istio/blob/1.12.6/galley/pkg/config/source/kube/apiserver/watcher.go#L72) Eventually, analyzer's snapshot is having two entries for the same webhook, `webhook-name` and `istio-system/<webhook-name>`. Naturally, it then fails with `Webhook overlaps with others` 
**log from analyzer's [`Snapshotter.publish`]**(https://github.com/istio/istio/blob/1.12.6/galley/pkg/config/processing/snapshotter/snapshotter.go#L224):
```
2022-04-12T08:23:07.254608Z	debug	processing	InmemoryDistributor.Distribute: localAnalysis: [0] istio/mesh/v1alpha1/MeshConfig (@istio/mesh/v1alpha1/MeshConfig/1)
  ......
[10] k8s/admissionregistration.k8s.io/v1/mutatingwebhookconfigurations (@k8s/admissionregistration.k8s.io/v1/mutatingwebhookconfigurations/8)
  [0] istio-system/istio-sidecar-injector-stable <-----  SEE THIS
  [1] istio-sidecar-injector-stable                      <---- AND THIS
  [2] onboarding-operator
  

```