### PR TITLE
Missing space causing post submit test failures

### DIFF
--- a/prow/lib.sh
+++ b/prow/lib.sh
@@ -114,7 +114,7 @@ function build_images() {
   targets="docker.pilot docker.proxyv2 "
 
   # use ubuntu:jammy to test vms by default
-  nonDistrolessTargets="docker.app docker.app_sidecar_ubuntu_jammy docker.ext-authz"
+  nonDistrolessTargets="docker.app docker.app_sidecar_ubuntu_jammy docker.ext-authz "
   if [[ "${JOB_TYPE:-presubmit}" == "postsubmit" ]]; then
     # We run tests across all VM types only in postsubmit
     nonDistrolessTargets+="docker.app_sidecar_ubuntu_xenial docker.app_sidecar_debian_11  docker.app_sidecar_centos_7 "


### PR DESCRIPTION
**Please provide a description of this PR:**

Post submit tests are failing:
```
+ DOCKER_TARGETS='docker.pilot docker.proxyv2 docker.operator docker.install-cni  docker.app docker.app_sidecar_ubuntu_jammy docker.ext-authzdocker.app_sidecar_ubuntu_xenial docker.app_sidecar_debian_11  docker.app_sidecar_centos_7 '
```
Note the lack of a space, and two targets being concatenated: `docker.ext-authzdocker.app_sidecar_ubuntu_xenial docker.app`
