### PR TITLE
Improve test runtime by improve sync wait function

### DIFF
--- a/cni/pkg/repair/repaircontroller.go
+++ b/cni/pkg/repair/repaircontroller.go
@@ -26,6 +26,8 @@ import (
 	client "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
+
+	"istio.io/istio/pkg/kube"
 )
 
 type Controller struct {
@@ -95,7 +97,7 @@ func (rc *Controller) mayAddToWorkQueue(obj interface{}) {
 
 func (rc *Controller) Run(stopCh <-chan struct{}) {
 	go rc.podController.Run(stopCh)
-	if !cache.WaitForCacheSync(stopCh, rc.podController.HasSynced) {
+	if !kube.WaitForCacheSync(stopCh, rc.podController.HasSynced) {
 		repairLog.Error("timed out waiting for pod caches to sync")
 		return
 	}

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -38,7 +38,6 @@ import (
 	"google.golang.org/grpc/reflection"
 	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/cache"
 
 	"istio.io/api/security/v1beta1"
 	kubecredentials "istio.io/istio/pilot/pkg/credentials/kube"
@@ -816,7 +815,7 @@ func (s *Server) addTerminatingStartFunc(fn server.Component) {
 func (s *Server) waitForCacheSync(stop <-chan struct{}) bool {
 	start := time.Now()
 	log.Info("Waiting for caches to be synced")
-	if !cache.WaitForCacheSync(stop, s.cachesSynced) {
+	if !kubelib.WaitForCacheSync(stop, s.cachesSynced) {
 		log.Errorf("Failed waiting for cache sync")
 		return false
 	}
@@ -827,7 +826,7 @@ func (s *Server) waitForCacheSync(stop <-chan struct{}) bool {
 	// condition where we are marked ready prior to updating the push context, leading to incomplete
 	// pushes.
 	expected := s.XDSServer.InboundUpdates.Load()
-	if !cache.WaitForCacheSync(stop, func() bool { return s.pushContextReady(expected) }) {
+	if !kubelib.WaitForCacheSync(stop, func() bool { return s.pushContextReady(expected) }) {
 		log.Errorf("Failed waiting for push context initialization")
 		return false
 	}

--- a/pilot/pkg/config/kube/crdclient/client.go
+++ b/pilot/pkg/config/kube/crdclient/client.go
@@ -225,7 +225,7 @@ func (cl *Client) Run(stop <-chan struct{}) {
 	t0 := time.Now()
 	scope.Info("Starting Pilot K8S CRD controller")
 
-	if !cache.WaitForCacheSync(stop, cl.informerSynced) {
+	if !kube.WaitForCacheSync(stop, cl.informerSynced) {
 		scope.Error("Failed to sync Pilot K8S CRD controller cache")
 		return
 	}

--- a/pilot/pkg/config/kube/crdclient/client_test.go
+++ b/pilot/pkg/config/kube/crdclient/client_test.go
@@ -25,7 +25,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	metadatafake "k8s.io/client-go/metadata/fake"
-	"k8s.io/client-go/tools/cache"
 
 	"istio.io/api/meta/v1alpha1"
 	"istio.io/api/networking/v1alpha3"
@@ -51,7 +50,7 @@ func makeClient(t *testing.T, schemas collection.Schemas) (model.ConfigStoreCont
 	}
 	go config.Run(stop)
 	fake.RunAndWait(stop)
-	cache.WaitForCacheSync(stop, config.HasSynced)
+	kube.WaitForCacheSync(stop, config.HasSynced)
 	t.Cleanup(func() {
 		close(stop)
 	})

--- a/pilot/pkg/config/kube/gateway/controller.go
+++ b/pilot/pkg/config/kube/gateway/controller.go
@@ -279,7 +279,7 @@ func (c *Controller) Run(stop <-chan struct{}) {
 			gcc.Run(stop)
 		}
 	}()
-	cache.WaitForCacheSync(stop, c.namespaceInformer.HasSynced)
+	kube.WaitForCacheSync(stop, c.namespaceInformer.HasSynced)
 }
 
 func (c *Controller) SetWatchErrorHandler(handler func(r *cache.Reflector, err error)) error {

--- a/pilot/pkg/config/kube/ingress/conversion_test.go
+++ b/pilot/pkg/config/kube/ingress/conversion_test.go
@@ -33,7 +33,6 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
 	listerv1 "k8s.io/client-go/listers/core/v1"
-	"k8s.io/client-go/tools/cache"
 	"sigs.k8s.io/yaml"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
@@ -42,6 +41,7 @@ import (
 	"istio.io/istio/pilot/test/util"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/mesh"
+	"istio.io/istio/pkg/kube"
 )
 
 func TestGoldenConversion(t *testing.T) {
@@ -486,6 +486,6 @@ func createFakeLister(ctx context.Context, objects ...runtime.Object) listerv1.S
 	informerFactory := informers.NewSharedInformerFactory(client, time.Hour)
 	svcInformer := informerFactory.Core().V1().Services().Informer()
 	go svcInformer.Run(ctx.Done())
-	cache.WaitForCacheSync(ctx.Done(), svcInformer.HasSynced)
+	kube.WaitForCacheSync(ctx.Done(), svcInformer.HasSynced)
 	return informerFactory.Core().V1().Services().Lister()
 }

--- a/pilot/pkg/config/kube/ingressv1/conversion_test.go
+++ b/pilot/pkg/config/kube/ingressv1/conversion_test.go
@@ -33,7 +33,6 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
 	listerv1 "k8s.io/client-go/listers/core/v1"
-	"k8s.io/client-go/tools/cache"
 	"sigs.k8s.io/yaml"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
@@ -42,6 +41,7 @@ import (
 	"istio.io/istio/pilot/test/util"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/mesh"
+	"istio.io/istio/pkg/kube"
 )
 
 func TestGoldenConversion(t *testing.T) {
@@ -504,6 +504,6 @@ func createFakeLister(ctx context.Context, objects ...runtime.Object) listerv1.S
 	informerFactory := informers.NewSharedInformerFactory(client, time.Hour)
 	svcInformer := informerFactory.Core().V1().Services().Informer()
 	go svcInformer.Run(ctx.Done())
-	cache.WaitForCacheSync(ctx.Done(), svcInformer.HasSynced)
+	kube.WaitForCacheSync(ctx.Done(), svcInformer.HasSynced)
 	return informerFactory.Core().V1().Services().Lister()
 }

--- a/pilot/pkg/serviceregistry/kube/controller/autoserviceexportcontroller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/autoserviceexportcontroller.go
@@ -106,7 +106,7 @@ func (c *autoServiceExportController) onServiceAdd(obj interface{}) {
 }
 
 func (c *autoServiceExportController) Run(stopCh <-chan struct{}) {
-	if !cache.WaitForCacheSync(stopCh, c.serviceInformer.HasSynced) {
+	if !kube.WaitForCacheSync(stopCh, c.serviceInformer.HasSynced) {
 		log.Errorf("%s failed to sync cache", c.logPrefix())
 		return
 	}

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -826,7 +826,7 @@ func (c *Controller) Run(stop <-chan struct{}) {
 	}
 	c.informerInit.Store(true)
 
-	cache.WaitForCacheSync(stop, c.informersSynced)
+	kubelib.WaitForCacheSync(stop, c.informersSynced)
 	// after informer caches sync the first time, process resources in order
 	if err := c.SyncAll(); err != nil {
 		log.Errorf("one or more errors force-syncing resources: %v", err)

--- a/pilot/pkg/serviceregistry/kube/controller/endpointslice_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpointslice_test.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	coreV1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/tools/cache"
 	mcs "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 
 	"istio.io/api/label"
@@ -77,10 +76,7 @@ func TestEndpointSliceFromMCSShouldBeIgnored(t *testing.T) {
 		appName = "prod-app"
 	)
 
-	controller, fx := NewFakeControllerWithOptions(FakeControllerOptions{Mode: EndpointSliceOnly})
-	go controller.Run(controller.stop)
-	cache.WaitForCacheSync(controller.stop, controller.HasSynced)
-	defer controller.Stop()
+	controller, fx := NewFakeControllerWithOptions(t, FakeControllerOptions{Mode: EndpointSliceOnly})
 
 	node := generateNode("node1", map[string]string{
 		NodeZoneLabel:              "zone1",

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster_test.go
@@ -21,7 +21,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/tools/cache"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/pkg/features"
@@ -82,7 +81,7 @@ func initController(client kube.ExtendedClient, ns string, stop <-chan struct{},
 	sc := multicluster.NewController(client, ns, "cluster-1")
 	sc.AddHandler(mc)
 	_ = sc.Run(stop)
-	cache.WaitForCacheSync(stop, sc.HasSynced)
+	kube.WaitForCacheSync(stop, sc.HasSynced)
 }
 
 func Test_KubeSecretController(t *testing.T) {

--- a/pilot/pkg/serviceregistry/kube/controller/namespacecontroller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/namespacecontroller.go
@@ -82,7 +82,7 @@ func NewNamespaceController(kubeClient kube.Client, caBundleWatcher *keycertbund
 
 // Run starts the NamespaceController until a value is sent to stopCh.
 func (nc *NamespaceController) Run(stopCh <-chan struct{}) {
-	if !cache.WaitForCacheSync(stopCh, nc.namespacesInformer.HasSynced, nc.configMapInformer.HasSynced) {
+	if !kube.WaitForCacheSync(stopCh, nc.namespacesInformer.HasSynced, nc.configMapInformer.HasSynced) {
 		log.Error("Failed to sync namespace controller cache")
 		return
 	}

--- a/pilot/pkg/serviceregistry/kube/controller/network_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/network_test.go
@@ -35,11 +35,7 @@ import (
 
 func TestNetworkUpdateTriggers(t *testing.T) {
 	meshNetworks := mesh.NewFixedNetworksWatcher(nil)
-	c, _ := NewFakeControllerWithOptions(FakeControllerOptions{ClusterID: "Kubernetes", NetworksWatcher: meshNetworks, DomainSuffix: "cluster.local"})
-	defer close(c.stop)
-	go func() {
-		c.Run(c.stop)
-	}()
+	c, _ := NewFakeControllerWithOptions(t, FakeControllerOptions{ClusterID: "Kubernetes", NetworksWatcher: meshNetworks, DomainSuffix: "cluster.local"})
 
 	if len(c.NetworkGateways()) != 0 {
 		t.Fatal("did not expect any gateways yet")
@@ -76,7 +72,7 @@ func TestNetworkUpdateTriggers(t *testing.T) {
 				return fmt.Errorf("expected %d gateways but got %d", expectedGws, n)
 			}
 			return nil
-		}, retry.Timeout(5*time.Second), retry.Delay(500*time.Millisecond))
+		}, retry.Timeout(5*time.Second), retry.Delay(10*time.Millisecond))
 	}
 
 	t.Run("add meshnetworks", func(t *testing.T) {

--- a/pilot/pkg/serviceregistry/kube/controller/pod_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/pod_test.go
@@ -24,7 +24,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/cache"
 
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/config/labels"
@@ -109,10 +108,7 @@ func TestPodCache(t *testing.T) {
 }
 
 func TestHostNetworkPod(t *testing.T) {
-	c, fx := NewFakeControllerWithOptions(FakeControllerOptions{Mode: EndpointsOnly})
-	go c.Run(c.stop)
-	cache.WaitForCacheSync(c.stop, c.HasSynced)
-	defer c.Stop()
+	c, fx := NewFakeControllerWithOptions(t, FakeControllerOptions{Mode: EndpointsOnly})
 	initTestEnv(t, c.client, fx)
 	createPod := func(ip, name string) {
 		addPods(t, c, fx, generatePod(ip, name, "ns", "1", "", map[string]string{}, map[string]string{}))
@@ -136,10 +132,7 @@ func TestHostNetworkPod(t *testing.T) {
 
 // Regression test for https://github.com/istio/istio/issues/20676
 func TestIPReuse(t *testing.T) {
-	c, fx := NewFakeControllerWithOptions(FakeControllerOptions{Mode: EndpointsOnly})
-	go c.Run(c.stop)
-	cache.WaitForCacheSync(c.stop, c.HasSynced)
-	defer c.Stop()
+	c, fx := NewFakeControllerWithOptions(t, FakeControllerOptions{Mode: EndpointsOnly})
 	initTestEnv(t, c.client, fx)
 
 	createPod := func(ip, name string) {
@@ -205,13 +198,10 @@ func waitForNode(c *FakeController, name string) error {
 }
 
 func testPodCache(t *testing.T) {
-	c, fx := NewFakeControllerWithOptions(FakeControllerOptions{
+	c, fx := NewFakeControllerWithOptions(t, FakeControllerOptions{
 		Mode:              EndpointsOnly,
 		WatchedNamespaces: "nsa,nsb",
 	})
-	go c.Run(c.stop)
-	cache.WaitForCacheSync(c.stop, c.HasSynced)
-	defer c.Stop()
 
 	initTestEnv(t, c.client, fx)
 
@@ -258,10 +248,7 @@ func testPodCache(t *testing.T) {
 // Checks that events from the watcher create the proper internal structures
 func TestPodCacheEvents(t *testing.T) {
 	t.Parallel()
-	c, _ := NewFakeControllerWithOptions(FakeControllerOptions{Mode: EndpointsOnly})
-	go c.Run(c.stop)
-	cache.WaitForCacheSync(c.stop, c.HasSynced)
-	defer c.Stop()
+	c, _ := NewFakeControllerWithOptions(t, FakeControllerOptions{Mode: EndpointsOnly})
 
 	ns := "default"
 	podCache := c.pods

--- a/pilot/pkg/serviceregistry/kube/controller/serviceexportcache_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/serviceexportcache_test.go
@@ -24,7 +24,6 @@ import (
 	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/tools/cache"
 	mcsapi "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 
 	"istio.io/api/label"
@@ -134,20 +133,13 @@ func newServiceExport() *unstructured.Unstructured {
 func newTestServiceExportCache(t *testing.T, clusterLocalMode ClusterLocalMode, endpointMode EndpointMode) (ec *serviceExportCacheImpl) {
 	t.Helper()
 
-	stopCh := make(chan struct{})
 	istiotest.SetBoolForTest(t, &features.EnableMCSServiceDiscovery, true)
 	istiotest.SetBoolForTest(t, &features.EnableMCSClusterLocal, clusterLocalMode == alwaysClusterLocal)
-	t.Cleanup(func() {
-		close(stopCh)
-	})
 
-	c, _ := NewFakeControllerWithOptions(FakeControllerOptions{
-		Stop:      stopCh,
+	c, _ := NewFakeControllerWithOptions(t, FakeControllerOptions{
 		ClusterID: testCluster,
 		Mode:      endpointMode,
 	})
-	go c.Run(c.stop)
-	cache.WaitForCacheSync(c.stop, c.HasSynced)
 
 	// Create the test service and endpoints.
 	createService(c, serviceExportName, serviceExportNamespace, map[string]string{},

--- a/pilot/pkg/xds/fake.go
+++ b/pilot/pkg/xds/fake.go
@@ -32,7 +32,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/tools/cache"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/pkg/config/kube/gateway"
@@ -180,7 +179,7 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 		if opts.KubeClientModifier != nil {
 			opts.KubeClientModifier(client)
 		}
-		k8s, _ := kube.NewFakeControllerWithOptions(kube.FakeControllerOptions{
+		k8s, _ := kube.NewFakeControllerWithOptions(t, kube.FakeControllerOptions{
 			ServiceHandler:  serviceHandler,
 			Client:          client,
 			ClusterID:       k8sCluster,
@@ -320,7 +319,7 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 	cg.ServiceEntryRegistry.XdsUpdater = s
 	// Now that handlers are added, get everything started
 	cg.Run()
-	cache.WaitForCacheSync(stop,
+	kubelib.WaitForCacheSync(stop,
 		cg.Registry.HasSynced,
 		cg.Store().HasSynced)
 	cg.ServiceEntryRegistry.ResyncEDS()

--- a/pkg/config/analysis/local/istiod_analyze.go
+++ b/pkg/config/analysis/local/istiod_analyze.go
@@ -127,8 +127,7 @@ func (sa *IstiodAnalyzer) ReAnalyze(cancel <-chan struct{}) (AnalysisResult, err
 	result.ExecutedAnalyzers = sa.analyzer.AnalyzerNames()
 	result.SkippedAnalyzers = sa.analyzer.RemoveSkipped(store.Schemas())
 
-	cache.WaitForCacheSync(cancel,
-		store.HasSynced)
+	kubelib.WaitForCacheSync(cancel, store.HasSynced)
 
 	ctx := NewContext(store, cancel, sa.collectionReporter)
 

--- a/pkg/config/mesh/kubemesh/watcher.go
+++ b/pkg/config/mesh/kubemesh/watcher.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/tools/cache"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pkg/config/mesh"
@@ -58,7 +57,7 @@ func NewConfigMapWatcher(client kube.Client, namespace, name, key string, multiW
 	go c.Run(stop)
 
 	// Ensure the ConfigMap is initially loaded if present.
-	if !cache.WaitForCacheSync(stop, c.HasSynced) {
+	if !kube.WaitForCacheSync(stop, c.HasSynced) {
 		log.Error("failed to wait for cache sync")
 	}
 	return w
@@ -71,7 +70,7 @@ func AddUserMeshConfig(client kube.Client, watcher mesh.Watcher, namespace, key,
 	})
 
 	go c.Run(stop)
-	if !cache.WaitForCacheSync(stop, c.HasSynced) {
+	if !kube.WaitForCacheSync(stop, c.HasSynced) {
 		log.Error("failed to wait for cache sync")
 	}
 }

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -143,9 +143,6 @@ type Client interface {
 
 	// GetKubernetesVersion returns the Kubernetes server version
 	GetKubernetesVersion() (*kubeVersion.Info, error)
-
-	// WaitForCacheSync waits for
-	// WaitForCacheSync(stopCh <-chan struct{}, cacheSyncs ...func() bool)
 }
 
 // ExtendedClient is an extended client with additional helpers/functionality for Istioctl and testing.

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -143,6 +143,9 @@ type Client interface {
 
 	// GetKubernetesVersion returns the Kubernetes server version
 	GetKubernetesVersion() (*kubeVersion.Info, error)
+
+	// WaitForCacheSync waits for
+	// WaitForCacheSync(stopCh <-chan struct{}, cacheSyncs ...func() bool)
 }
 
 // ExtendedClient is an extended client with additional helpers/functionality for Istioctl and testing.
@@ -574,6 +577,48 @@ func fastWaitForCacheSync(stop <-chan struct{}, informerFactory reflectInformerS
 	})
 }
 
+// WaitForCacheSync waits until all caches are synced. This will return true only if things synced
+// successfully before the stop channel is closed. This function also lives in the Kubernetes cache
+// library. However, that library will poll with 100ms fixed interval. Often the cache syncs in a few
+// ms, but we are delayed a full 100ms. This is especially apparent in tests, which previously spent
+// most of their time just in the 100ms wait interval.
+//
+// To optimize this, this function performs exponential backoff. This is generally safe because
+// cache.InformerSynced functions are ~always quick to run. However, if the sync functions do perform
+// expensive checks this function may not be suitable.
+func WaitForCacheSync(stop <-chan struct{}, cacheSyncs ...cache.InformerSynced) bool {
+	max := time.Millisecond * 100
+	delay := time.Millisecond
+	f := func() bool {
+		for _, syncFunc := range cacheSyncs {
+			if !syncFunc() {
+				return false
+			}
+		}
+		return true
+	}
+	for {
+		select {
+		case <-stop:
+			return false
+		default:
+		}
+		res := f()
+		if res {
+			return true
+		}
+		delay *= 2
+		if delay > max {
+			delay = max
+		}
+		select {
+		case <-stop:
+			return false
+		case <-time.After(delay):
+		}
+	}
+}
+
 func fastWaitForCacheSyncDynamic(stop <-chan struct{}, informerFactory dynamicInformerSync) {
 	returnImmediately := make(chan struct{})
 	close(returnImmediately)
@@ -590,21 +635,6 @@ func fastWaitForCacheSyncDynamic(stop <-chan struct{}, informerFactory dynamicIn
 		}
 		return true, nil
 	})
-}
-
-// WaitForCacheSyncInterval waits for caches to populate, with explicitly configured interval
-func WaitForCacheSyncInterval(stopCh <-chan struct{}, interval time.Duration, cacheSyncs ...cache.InformerSynced) bool {
-	err := wait.PollImmediateUntil(interval,
-		func() (bool, error) {
-			for _, syncFunc := range cacheSyncs {
-				if !syncFunc() {
-					return false, nil
-				}
-			}
-			return true, nil
-		},
-		stopCh)
-	return err == nil
 }
 
 func (c *client) Revision() string {

--- a/pkg/kube/configmapwatcher/configmapwatcher.go
+++ b/pkg/kube/configmapwatcher/configmapwatcher.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/informers"
 	informersv1 "k8s.io/client-go/informers/core/v1"
-	"k8s.io/client-go/tools/cache"
 
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/controllers"
@@ -74,7 +73,7 @@ func NewController(client kube.Client, namespace, name string, callback func(*v1
 
 func (c *Controller) Run(stop <-chan struct{}) {
 	go c.informer.Informer().Run(stop)
-	if !cache.WaitForCacheSync(stop, c.informer.Informer().HasSynced) {
+	if !kube.WaitForCacheSync(stop, c.informer.Informer().HasSynced) {
 		log.Error("failed to wait for cache sync")
 		return
 	}

--- a/pkg/kube/configmapwatcher/configmapwatcher_test.go
+++ b/pkg/kube/configmapwatcher/configmapwatcher_test.go
@@ -24,7 +24,6 @@ import (
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/tools/cache"
 
 	"istio.io/istio/pkg/kube"
 )
@@ -100,7 +99,7 @@ func Test_ConfigMapWatcher(t *testing.T) {
 	stop := make(chan struct{})
 	c := NewController(client, configMapNamespace, configMapName, callback)
 	go c.Run(stop)
-	cache.WaitForCacheSync(stop, c.HasSynced)
+	kube.WaitForCacheSync(stop, c.HasSynced)
 
 	cms := client.Kube().CoreV1().ConfigMaps(configMapNamespace)
 	for i, step := range steps {

--- a/pkg/kube/inject/watcher_test.go
+++ b/pkg/kube/inject/watcher_test.go
@@ -24,7 +24,6 @@ import (
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/tools/cache"
 
 	"istio.io/istio/pkg/kube"
 )
@@ -86,7 +85,7 @@ func TestNewConfigMapWatcher(t *testing.T) {
 	stop := make(chan struct{})
 	go w.Run(stop)
 	controller := w.(*configMapWatcher).c
-	cache.WaitForCacheSync(stop, controller.HasSynced)
+	kube.WaitForCacheSync(stop, controller.HasSynced)
 	client.RunAndWait(stop)
 
 	cms := client.Kube().CoreV1().ConfigMaps(namespace)

--- a/pkg/kube/multicluster/secretcontroller_test.go
+++ b/pkg/kube/multicluster/secretcontroller_test.go
@@ -147,7 +147,7 @@ func Test_SecretController(t *testing.T) {
 	t.Run("sync timeout", func(t *testing.T) {
 		retry.UntilOrFail(t, c.HasSynced, retry.Timeout(2*time.Second))
 	})
-	kube.WaitForCacheSyncInterval(stopCh, time.Microsecond, c.informer.HasSynced)
+	kube.WaitForCacheSync(stopCh, c.informer.HasSynced)
 	clientset.RunAndWait(stopCh)
 
 	for i, step := range steps {

--- a/pkg/revisions/default_watcher.go
+++ b/pkg/revisions/default_watcher.go
@@ -16,7 +16,6 @@ package revisions
 
 import (
 	"sync"
-	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -67,7 +66,7 @@ func NewDefaultWatcher(client kube.Client, revision string) DefaultWatcher {
 }
 
 func (p *defaultWatcher) Run(stopCh <-chan struct{}) {
-	if !kube.WaitForCacheSyncInterval(stopCh, time.Second, p.webhookInformer.HasSynced) {
+	if !kube.WaitForCacheSync(stopCh, p.webhookInformer.HasSynced) {
 		log.Errorf("failed to sync default watcher")
 		return
 	}

--- a/pkg/test/framework/components/echo/kube/pod_controller.go
+++ b/pkg/test/framework/components/echo/kube/pod_controller.go
@@ -21,6 +21,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 
+	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/queue"
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/pkg/log"
@@ -98,7 +99,7 @@ func newPodController(cfg echo.Config, handlers podHandlers) *podController {
 
 func (c *podController) Run(stop <-chan struct{}) {
 	go c.informer.Run(stop)
-	cache.WaitForCacheSync(stop, c.HasSynced)
+	kube.WaitForCacheSync(stop, c.HasSynced)
 	go c.q.Run(stop)
 }
 

--- a/pkg/webhooks/validation/controller/controller.go
+++ b/pkg/webhooks/validation/controller/controller.go
@@ -218,7 +218,7 @@ func newController(
 func (c *Controller) Run(stop <-chan struct{}) {
 	defer c.queue.ShutDown()
 	go c.webhookInformer.Run(stop)
-	if !cache.WaitForCacheSync(stop, c.webhookInformer.HasSynced) {
+	if !kube.WaitForCacheSync(stop, c.webhookInformer.HasSynced) {
 		return
 	}
 	go c.startCaBundleWatcher(stop)

--- a/security/pkg/k8s/chiron/controller.go
+++ b/security/pkg/k8s/chiron/controller.go
@@ -30,6 +30,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 
+	"istio.io/istio/pkg/kube"
 	"istio.io/istio/security/pkg/pki/ca"
 	"istio.io/istio/security/pkg/pki/util"
 	certutil "istio.io/istio/security/pkg/util"
@@ -162,7 +163,7 @@ func (wc *WebhookController) Run(stopCh <-chan struct{}) {
 		// upsertSecret to update and insert secret
 		// it throws error if the secret cache is not synchronized, but the secret exists in the system.
 		// Hence waiting for the cache is synced.
-		if !cache.WaitForCacheSync(stopCh, wc.scrtController.HasSynced) {
+		if !kube.WaitForCacheSync(stopCh, wc.scrtController.HasSynced) {
 			log.Error("failed to wait for cache sync")
 		}
 	}

--- a/security/pkg/k8s/configutil_test.go
+++ b/security/pkg/k8s/configutil_test.go
@@ -30,9 +30,9 @@ import (
 	informersv1 "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes/fake"
 	ktesting "k8s.io/client-go/testing"
-	"k8s.io/client-go/tools/cache"
 
 	"istio.io/istio/pkg/config/constants"
+	"istio.io/istio/pkg/kube"
 )
 
 const (
@@ -303,6 +303,6 @@ func createFakeLister(kubeClient *fake.Clientset) informersv1.ConfigMapInformer 
 	informerFactory := informers.NewSharedInformerFactory(kubeClient, time.Second)
 	configmapInformer := informerFactory.Core().V1().ConfigMaps().Informer()
 	go configmapInformer.Run(ctx.Done())
-	cache.WaitForCacheSync(ctx.Done(), configmapInformer.HasSynced)
+	kube.WaitForCacheSync(ctx.Done(), configmapInformer.HasSynced)
 	return informerFactory.Core().V1().ConfigMaps()
 }


### PR DESCRIPTION
Currently, we are spending a lot of time just waiting in
WaitForCacheSync. Mostly in tests, but also in real code for fast sync
paths. This changes this to an exponential backoff. This improves the
controller unit tests from 20s to 2s - similar gains in other places

**Please provide a description of this PR:**