### PR TITLE
add pod and cluster information for reviews

### DIFF
--- a/releasenotes/notes/38429.yaml
+++ b/releasenotes/notes/38429.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: feature
+area: istioctl
+issue: []
+releaseNotes:
+- |
+  **Added** pod name and cluster name to bookinfo's reviews. Cluster is defined by `CLUSTER_NAME` environment variable on the reviews deployments. 

--- a/samples/bookinfo/src/productpage/templates/productpage.html
+++ b/samples/bookinfo/src/productpage/templates/productpage.html
@@ -147,6 +147,13 @@
         {% endif %}
       </blockquote>
       {% endfor %}
+      <dl>
+        <dt>Reviews served by:</dt>
+        <u>{{ reviews.podname }}</u>
+        {% if reviews.clustername != "null" %}
+        on cluster <u>{{ reviews.clustername }}</u>
+        {% endif %}
+      </dl>
       {% else %}
       <h4 class="text-center text-primary">Error fetching product reviews!</h4>
       {% if reviews: %}

--- a/samples/bookinfo/src/reviews/reviews-application/src/main/java/application/rest/LibertyRestEndpoint.java
+++ b/samples/bookinfo/src/reviews/reviews-application/src/main/java/application/rest/LibertyRestEndpoint.java
@@ -40,7 +40,9 @@ public class LibertyRestEndpoint extends Application {
     private final static String star_color = System.getenv("STAR_COLOR") == null ? "black" : System.getenv("STAR_COLOR");
     private final static String services_domain = System.getenv("SERVICES_DOMAIN") == null ? "" : ("." + System.getenv("SERVICES_DOMAIN"));
     private final static String ratings_hostname = System.getenv("RATINGS_HOSTNAME") == null ? "ratings" : System.getenv("RATINGS_HOSTNAME");
-    private final static String ratings_service = "http://" + ratings_hostname + services_domain + ":9080/ratings";
+    private final static String ratings_service = String.format("http://%s%s:9080/ratings", ratings_hostname, services_domain);
+    private final static String pod_hostname = System.getenv("HOSTNAME");
+    private final static String clustername = System.getenv("CLUSTER_NAME");
     // HTTP headers to propagate for distributed tracing are documented at
     // https://istio.io/docs/tasks/telemetry/distributed-tracing/overview/#trace-context-propagation
     private final static String[] headers_to_propagate = {
@@ -93,6 +95,8 @@ public class LibertyRestEndpoint extends Application {
     private String getJsonResponse (String productId, int starsReviewer1, int starsReviewer2) {
     	String result = "{";
     	result += "\"id\": \"" + productId + "\",";
+        result += "\"podname\": \"" + pod_hostname + "\",";
+        result += "\"clustername\": \"" + clustername + "\",";
     	result += "\"reviews\": [";
 
     	// reviewer 1:


### PR DESCRIPTION
**Please provide a description of this PR:**

Closes #38429 

Useful for multicluster setups, this has reviews pass its pod name as well as a cluster name (taken from the environment variable `CLUSTER_NAME`) in its response. Productpage will display this information (if no cluster name, it's omitted) below the reviews.