### PR TITLE
fix: proxy config unmarshal mesh config failed when meshId is number

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/configmap.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/configmap.yaml
@@ -11,7 +11,7 @@
 
     defaultConfig:
       {{- if .Values.global.meshID }}
-      meshId: {{ .Values.global.meshID }}
+      meshId: "{{ .Values.global.meshID }}"
       {{- end }}
       tracing:
       {{- if eq .Values.global.proxy.tracer "lightstep" }}

--- a/manifests/charts/istiod-remote/templates/configmap.yaml
+++ b/manifests/charts/istiod-remote/templates/configmap.yaml
@@ -11,7 +11,7 @@
 
     defaultConfig:
       {{- if .Values.global.meshID }}
-      meshId: {{ .Values.global.meshID }}
+      meshId: "{{ .Values.global.meshID }}"
       {{- end }}
       tracing:
       {{- if eq .Values.global.proxy.tracer "lightstep" }}


### PR DESCRIPTION
**Please provide a description of this PR:**
When install Istio with number meshId, like 222222, istio-proxy will parse error and can't run.


    2022-04-22T03:41:51.570480Z error failed to get proxy config: failed to unmarshal mesh config from file [defaultConfig:
    discoveryAddress: istiod-1-12.istio-system.svc:15012
    extraStatTags:
    - mesh_id
    meshId: 222222
    proxyMetadata:
    ISTIO_META_DNS_AUTO_ALLOCATE: "true"
    ISTIO_META_DNS_CAPTURE: "true"
    ...


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [X] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
