### PR TITLE
[tf] Support echo egress to ext-authz

### DIFF
--- a/pkg/test/framework/components/echo/common/deployment/echos.go
+++ b/pkg/test/framework/components/echo/common/deployment/echos.go
@@ -17,7 +17,6 @@ package deployment
 import (
 	"context"
 	"fmt"
-	"sort"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
@@ -265,25 +264,6 @@ func (e *Echos) TwoNamespaceView() TwoNamespaceView {
 		All:       ns1AndNs2.Append(e.External.All.Services()),
 		echos:     e,
 	}
-}
-
-func (e Echos) namespaces(excludes ...namespace.Instance) []string {
-	var out []string
-	for _, n := range e.NS {
-		include := true
-		for _, e := range excludes {
-			if n.Namespace.Name() == e.Name() {
-				include = false
-				break
-			}
-		}
-		if include {
-			out = append(out, n.Namespace.Name())
-		}
-	}
-
-	sort.Strings(out)
-	return out
 }
 
 func serviceEntryPorts() []echo.Port {

--- a/pkg/test/framework/components/echo/common/deployment/namespace.go
+++ b/pkg/test/framework/components/echo/common/deployment/namespace.go
@@ -15,6 +15,7 @@
 package deployment
 
 import (
+	"fmt"
 	"strconv"
 
 	"istio.io/istio/pkg/test/framework/components/echo"
@@ -210,10 +211,15 @@ func (n *EchoNamespace) loadValues(t resource.Context, echos echo.Instances, d *
 		n.DeltaXDS = all(match.ServiceName(echo.NamespacedName{Name: DeltaSvc, Namespace: ns}).GetMatches(echos))
 	}
 
+	namespaces, err := namespace.GetAll(t)
+	if err != nil {
+		return fmt.Errorf("failed retrieving list of namespaces: %v", err)
+	}
+
 	// Restrict egress from this namespace to only those endpoints in the same Echos.
 	cfg := t.ConfigIstio().New()
 	cfg.Eval(ns.Name(), map[string]interface{}{
-		"otherNS": d.namespaces(n.Namespace),
+		"Namespaces": namespaces,
 	}, `
 apiVersion: networking.istio.io/v1alpha3
 kind: Sidecar
@@ -222,10 +228,9 @@ metadata:
 spec:
   egress:
   - hosts:
-    - "./*"
     - "istio-system/*"
-{{ range $ns := .otherNS }}
-    - "{{ $ns }}/*"
+{{ range $ns := .Namespaces }}
+    - "{{ $ns.Name }}/*"
 {{ end }}
 `)
 

--- a/pkg/test/framework/components/namespace/namespace.go
+++ b/pkg/test/framework/components/namespace/namespace.go
@@ -79,6 +79,15 @@ func NewOrFail(t test.Failer, ctx resource.Context, nsConfig Config) Instance {
 	return i
 }
 
+// GetAll returns all namespaces that have exist in the context.
+func GetAll(ctx resource.Context) ([]Instance, error) {
+	var out []Instance
+	if err := ctx.GetResource(&out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func overwriteRevisionIfEmpty(nsConfig *Config, revision string) {
 	// Overwrite the default namespace label (istio-injection=enabled)
 	// with istio.io/rev=XXX. If a revision label is already provided,


### PR DESCRIPTION
The echos are currently restricted to just the other echo namespaces, which prevents egress to the external authz server, if it's in another namespace.

This PR changes the logic so that egress is allowed to any namespace that has been allocated by the test framework up to the point the echos are created.

Fixes #38451

**Please provide a description of this PR:**