### PR TITLE
gateway-api: add lock when reading `AllowedReferences`

### DIFF
--- a/pilot/pkg/config/kube/gateway/controller.go
+++ b/pilot/pkg/config/kube/gateway/controller.go
@@ -298,7 +298,9 @@ func (c *Controller) SecretAllowed(resourceName string, namespace string) bool {
 	}
 	from := Reference{Kind: gvk.KubernetesGateway, Namespace: k8s.Namespace(namespace)}
 	to := Reference{Kind: gvk.Secret, Namespace: k8s.Namespace(p.Namespace)}
+	c.stateMu.RLock()
 	allow := c.state.AllowedReferences[from][to]
+	c.stateMu.RUnlock()
 	if allow == nil {
 		return false
 	}


### PR DESCRIPTION
**Please provide a description of this PR:**
Fix the race condition


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [x] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
