### PR TITLE
[tf] Refactor cleanup

### DIFF
--- a/pkg/test/framework/components/authz/kubelocal.go
+++ b/pkg/test/framework/components/authz/kubelocal.go
@@ -23,6 +23,7 @@ import (
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/framework/resource"
+	"istio.io/istio/pkg/test/framework/resource/config/apply"
 	"istio.io/istio/pkg/test/scopes"
 	"istio.io/istio/pkg/test/util/tmpl"
 )
@@ -193,5 +194,7 @@ func (s *localServerImpl) installProviders(ctx resource.Context) error {
 }
 
 func (s *localServerImpl) installServiceEntries(ctx resource.Context) error {
-	return ctx.ConfigIstio().Eval(s.ns.Name(), s.templateArgs(), localServiceEntryTemplate).Apply()
+	return ctx.ConfigIstio().
+		Eval(s.ns.Name(), s.templateArgs(), localServiceEntryTemplate).
+		Apply(apply.CleanupConditionally)
 }

--- a/pkg/test/framework/components/authz/server.go
+++ b/pkg/test/framework/components/authz/server.go
@@ -60,8 +60,16 @@ func NewLocalOrFail(t framework.TestContext, ns namespace.Instance) Server {
 	return s
 }
 
+var nilNamespaceFunc = func() namespace.Instance {
+	return nil
+}
+
 // Setup is a utility function for configuring a global authz Server.
 func Setup(server *Server, ns func() namespace.Instance) resource.SetupFn {
+	if ns == nil {
+		ns = nilNamespaceFunc
+	}
+
 	return func(ctx resource.Context) error {
 		s, err := New(ctx, ns())
 		if err != nil {
@@ -76,6 +84,10 @@ func Setup(server *Server, ns func() namespace.Instance) resource.SetupFn {
 
 // SetupLocal is a utility function for setting a global variable for a local Server.
 func SetupLocal(server *Server, ns func() namespace.Instance) resource.SetupFn {
+	if ns == nil {
+		ns = nilNamespaceFunc
+	}
+
 	return func(ctx resource.Context) error {
 		s, err := NewLocal(ctx, ns())
 		if err != nil {

--- a/pkg/test/framework/components/echo/common/deployment/namespace.go
+++ b/pkg/test/framework/components/echo/common/deployment/namespace.go
@@ -24,6 +24,7 @@ import (
 	"istio.io/istio/pkg/test/framework/components/echo/match"
 	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/framework/resource"
+	"istio.io/istio/pkg/test/framework/resource/config/apply"
 )
 
 const (
@@ -268,5 +269,5 @@ spec:
 `)
 	}
 
-	return cfg.Apply(resource.NoCleanup)
+	return cfg.Apply(apply.NoCleanup)
 }

--- a/pkg/test/framework/components/echo/deployment/builder.go
+++ b/pkg/test/framework/components/echo/deployment/builder.go
@@ -36,6 +36,7 @@ import (
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/framework/resource"
+	"istio.io/istio/pkg/test/framework/resource/config/apply"
 	"istio.io/istio/pkg/test/scopes"
 	"istio.io/istio/pkg/util/sets"
 )
@@ -326,7 +327,7 @@ func (b builder) deployServices() (err error) {
 		cfg.YAML(ns, svcYaml)
 	}
 
-	return cfg.Apply(resource.NoCleanup)
+	return cfg.Apply(apply.NoCleanup)
 }
 
 func (b builder) deployInstances() (instances echo.Instances, err error) {

--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -42,6 +42,7 @@ import (
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/components/istioctl"
 	"istio.io/istio/pkg/test/framework/resource"
+	"istio.io/istio/pkg/test/framework/resource/config/apply"
 	"istio.io/istio/pkg/test/scopes"
 	"istio.io/istio/pkg/test/shell"
 	"istio.io/istio/pkg/test/util/retry"
@@ -500,7 +501,9 @@ func newDeployment(ctx resource.Context, cfg echo.Config) (*deployment, error) {
 	}
 
 	// Apply the deployment to the configured cluster.
-	if err = ctx.ConfigKube(cfg.Cluster).YAML(cfg.Namespace.Name(), deploymentYAML).Apply(resource.NoCleanup); err != nil {
+	if err = ctx.ConfigKube(cfg.Cluster).
+		YAML(cfg.Namespace.Name(), deploymentYAML).
+		Apply(apply.NoCleanup); err != nil {
 		return nil, fmt.Errorf("failed deploying echo %s to cluster %s: %v",
 			cfg.ClusterLocalFQDN(), cfg.Cluster.Name(), err)
 	}
@@ -550,7 +553,9 @@ func (d *deployment) WorkloadReady(w *workload) {
 
 	// Deploy the workload entry to the primary cluster. We will read WorkloadEntry across clusters.
 	wle := d.workloadEntryYAML(w)
-	if err := d.ctx.ConfigKube(d.cfg.Cluster.Primary()).YAML(d.cfg.Namespace.Name(), wle).Apply(resource.NoCleanup); err != nil {
+	if err := d.ctx.ConfigKube(d.cfg.Cluster.Primary()).
+		YAML(d.cfg.Namespace.Name(), wle).
+		Apply(apply.NoCleanup); err != nil {
 		log.Warnf("failed deploying echo WLE for %s/%s to primary cluster: %v",
 			d.cfg.Namespace.Name(),
 			d.cfg.Service,
@@ -755,7 +760,9 @@ spec:
 
 	// Push the WorkloadGroup for auto-registration
 	if cfg.AutoRegisterVM {
-		if err := ctx.ConfigKube(cfg.Cluster).YAML(cfg.Namespace.Name(), wg).Apply(resource.NoCleanup); err != nil {
+		if err := ctx.ConfigKube(cfg.Cluster).
+			YAML(cfg.Namespace.Name(), wg).
+			Apply(apply.NoCleanup); err != nil {
 			return err
 		}
 	}

--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -49,6 +49,7 @@ import (
 	"istio.io/istio/pkg/test/framework/components/istio/ingress"
 	"istio.io/istio/pkg/test/framework/components/istioctl"
 	"istio.io/istio/pkg/test/framework/resource"
+	"istio.io/istio/pkg/test/framework/resource/config/apply"
 	kube2 "istio.io/istio/pkg/test/kube"
 	"istio.io/istio/pkg/test/scopes"
 	"istio.io/istio/pkg/test/util/file"
@@ -813,7 +814,9 @@ func (i *operatorComponent) configureDirectAPIServiceAccessForCluster(ctx resour
 	if err != nil {
 		return fmt.Errorf("failed creating remote secret for cluster %s: %v", c.Name(), err)
 	}
-	if err := ctx.ConfigKube(clusters...).YAML(cfg.SystemNamespace, secret).Apply(resource.NoCleanup); err != nil {
+	if err := ctx.ConfigKube(clusters...).
+		YAML(cfg.SystemNamespace, secret).
+		Apply(apply.NoCleanup); err != nil {
 		return fmt.Errorf("failed applying remote secret to clusters: %v", err)
 	}
 	return nil

--- a/pkg/test/framework/components/prometheus/kube.go
+++ b/pkg/test/framework/components/prometheus/kube.go
@@ -34,6 +34,7 @@ import (
 	"istio.io/istio/pkg/test/framework/components/cluster"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/resource"
+	"istio.io/istio/pkg/test/framework/resource/config/apply"
 	testKube "istio.io/istio/pkg/test/kube"
 	"istio.io/istio/pkg/test/scopes"
 )
@@ -73,10 +74,10 @@ func installPrometheus(ctx resource.Context, ns string) error {
 	if err != nil {
 		return err
 	}
-	if err := ctx.ConfigKube().YAML(ns, yaml).Apply(resource.NoCleanup); err != nil {
+	if err := ctx.ConfigKube().YAML(ns, yaml).Apply(apply.NoCleanup); err != nil {
 		return err
 	}
-	ctx.ConditionalCleanup(func() {
+	ctx.CleanupConditionally(func() {
 		_ = ctx.ConfigKube().YAML(ns, yaml).Delete()
 	})
 	return nil

--- a/pkg/test/framework/config.go
+++ b/pkg/test/framework/config.go
@@ -27,25 +27,28 @@ import (
 	"istio.io/istio/pkg/test/framework/components/cluster"
 	"istio.io/istio/pkg/test/framework/components/istioctl"
 	"istio.io/istio/pkg/test/framework/resource"
+	"istio.io/istio/pkg/test/framework/resource/config"
+	"istio.io/istio/pkg/test/framework/resource/config/apply"
+	"istio.io/istio/pkg/test/framework/resource/config/cleanup"
 	"istio.io/istio/pkg/test/scopes"
 	"istio.io/istio/pkg/test/util/file"
 	"istio.io/istio/pkg/test/util/tmpl"
 	"istio.io/istio/pkg/test/util/yml"
 )
 
-var _ resource.ConfigManager = &configManager{}
+var _ config.Factory = &configFactory{}
 
-type configManager struct {
+type configFactory struct {
 	ctx      resource.Context
 	clusters []cluster.Cluster
 	prefix   string
 }
 
-func newConfigManager(ctx resource.Context, clusters cluster.Clusters) resource.ConfigManager {
+func newConfigFactory(ctx resource.Context, clusters cluster.Clusters) config.Factory {
 	if len(clusters) == 0 {
 		clusters = ctx.Clusters()
 	}
-	return &configManager{
+	return &configFactory{
 		ctx:      ctx,
 		clusters: clusters.Kube(),
 	}
@@ -55,32 +58,32 @@ func newConfigManager(ctx resource.Context, clusters cluster.Clusters) resource.
 // Note: go tests are distinct binaries per test suite, so this is the suite level number of calls
 var GlobalYAMLWrites = atomic.NewUint64(0)
 
-func (c *configManager) New() resource.Config {
-	return &configImpl{
-		configManager: c,
+func (c *configFactory) New() config.Plan {
+	return &configPlan{
+		configFactory: c,
 		yamlText:      make(map[string][]string),
 	}
 }
 
-func (c *configManager) YAML(ns string, yamlText ...string) resource.Config {
+func (c *configFactory) YAML(ns string, yamlText ...string) config.Plan {
 	return c.New().YAML(ns, yamlText...)
 }
 
-func (c *configManager) Eval(ns string, args interface{}, yamlTemplates ...string) resource.Config {
+func (c *configFactory) Eval(ns string, args interface{}, yamlTemplates ...string) config.Plan {
 	return c.New().Eval(ns, args, yamlTemplates...)
 }
 
-func (c *configManager) File(ns string, filePaths ...string) resource.Config {
+func (c *configFactory) File(ns string, filePaths ...string) config.Plan {
 	return c.New().File(ns, filePaths...)
 }
 
-func (c *configManager) EvalFile(ns string, args interface{}, filePaths ...string) resource.Config {
+func (c *configFactory) EvalFile(ns string, args interface{}, filePaths ...string) config.Plan {
 	return c.New().EvalFile(ns, args, filePaths...)
 }
 
-func (c *configManager) applyYAML(cleanup bool, ns string, yamlText ...string) error {
+func (c *configFactory) applyYAML(cleanupStrategy cleanup.Strategy, ns string, yamlText ...string) error {
 	if len(c.prefix) == 0 {
-		return c.WithFilePrefix("apply").(*configManager).applyYAML(cleanup, ns, yamlText...)
+		return c.withFilePrefix("apply").(*configFactory).applyYAML(cleanupStrategy, ns, yamlText...)
 	}
 	GlobalYAMLWrites.Add(uint64(len(yamlText)))
 
@@ -98,23 +101,21 @@ func (c *configManager) applyYAML(cleanup bool, ns string, yamlText ...string) e
 			if err := cl.ApplyYAMLFiles(ns, yamlFiles...); err != nil {
 				return fmt.Errorf("failed applying YAML files %v to ns %s in cluster %s: %v", yamlFiles, ns, cl.Name(), err)
 			}
-			if cleanup {
-				c.ctx.Cleanup(func() {
-					scopes.Framework.Debugf("Deleting from %s: %s", cl.StableName(), strings.Join(yamlFiles, ", "))
-					if err := cl.DeleteYAMLFiles(ns, yamlFiles...); err != nil {
-						scopes.Framework.Errorf("failed deleting YAML files %v from ns %s in cluster %s: %v", yamlFiles, ns, cl.Name(), err)
-					}
-				})
-			}
+			c.ctx.CleanupStrategy(cleanupStrategy, func() {
+				scopes.Framework.Debugf("Deleting from %s: %s", cl.StableName(), strings.Join(yamlFiles, ", "))
+				if err := cl.DeleteYAMLFiles(ns, yamlFiles...); err != nil {
+					scopes.Framework.Errorf("failed deleting YAML files %v from ns %s in cluster %s: %v", yamlFiles, ns, cl.Name(), err)
+				}
+			})
 			return nil
 		})
 	}
 	return g.Wait()
 }
 
-func (c *configManager) deleteYAML(ns string, yamlText ...string) error {
+func (c *configFactory) deleteYAML(ns string, yamlText ...string) error {
 	if len(c.prefix) == 0 {
-		return c.WithFilePrefix("delete").(*configManager).deleteYAML(ns, yamlText...)
+		return c.withFilePrefix("delete").(*configFactory).deleteYAML(ns, yamlText...)
 	}
 
 	// Convert the content to files.
@@ -136,7 +137,7 @@ func (c *configManager) deleteYAML(ns string, yamlText ...string) error {
 	return g.Wait()
 }
 
-func (c *configManager) WaitForConfig(ctx resource.Context, ns string, yamlText ...string) error {
+func (c *configFactory) WaitForConfig(ctx resource.Context, ns string, yamlText ...string) error {
 	var outErr error
 	for _, c := range c.ctx.Clusters() {
 		ik, err := istioctl.New(ctx, istioctl.Config{Cluster: c})
@@ -144,14 +145,14 @@ func (c *configManager) WaitForConfig(ctx resource.Context, ns string, yamlText 
 			return err
 		}
 
-		for _, config := range yamlText {
-			config := config
+		for _, cfg := range yamlText {
+			cfg := cfg
 
 			// TODO(https://github.com/istio/istio/issues/37324): It's currently unsafe
 			// to call istioctl concurrently since it relies on the istioctl library
 			// (rather than calling the binary from the command line) which uses a number
 			// of global variables, which will be overwritten for each call.
-			if err := ik.WaitForConfig(ns, config); err != nil {
+			if err := ik.WaitForConfig(ns, cfg); err != nil {
 				// Get proxy status for additional debugging
 				s, _, _ := ik.Invoke([]string{"ps"})
 				outErr = multierror.Append(err, fmt.Errorf("failed waiting for config for cluster %s: err=%v. Proxy status: %v",
@@ -162,7 +163,7 @@ func (c *configManager) WaitForConfig(ctx resource.Context, ns string, yamlText 
 	return outErr
 }
 
-func (c *configManager) WaitForConfigOrFail(ctx resource.Context, t test.Failer, ns string, yamlText ...string) {
+func (c *configFactory) WaitForConfigOrFail(ctx resource.Context, t test.Failer, ns string, yamlText ...string) {
 	err := c.WaitForConfig(ctx, ns, yamlText...)
 	if err != nil {
 		// TODO(https://github.com/istio/istio/issues/37148) fail hard in this case
@@ -170,33 +171,33 @@ func (c *configManager) WaitForConfigOrFail(ctx resource.Context, t test.Failer,
 	}
 }
 
-func (c *configManager) WithFilePrefix(prefix string) resource.ConfigManager {
-	return &configManager{
+func (c *configFactory) withFilePrefix(prefix string) config.Factory {
+	return &configFactory{
 		ctx:      c.ctx,
 		prefix:   prefix,
 		clusters: c.clusters,
 	}
 }
 
-var _ resource.Config = &configImpl{}
+var _ config.Plan = &configPlan{}
 
-type configImpl struct {
-	*configManager
+type configPlan struct {
+	*configFactory
 	yamlText map[string][]string
 }
 
-func (c *configImpl) Copy() resource.Config {
+func (c *configPlan) Copy() config.Plan {
 	yamlText := make(map[string][]string, len(c.yamlText))
 	for k, v := range c.yamlText {
 		yamlText[k] = append([]string{}, v...)
 	}
-	return &configImpl{
-		configManager: c.configManager,
+	return &configPlan{
+		configFactory: c.configFactory,
 		yamlText:      yamlText,
 	}
 }
 
-func (c *configImpl) YAML(ns string, yamlText ...string) resource.Config {
+func (c *configPlan) YAML(ns string, yamlText ...string) config.Plan {
 	c.yamlText[ns] = append(c.yamlText[ns], splitYAML(yamlText...)...)
 	return c
 }
@@ -209,7 +210,7 @@ func splitYAML(yamlText ...string) []string {
 	return out
 }
 
-func (c *configImpl) File(ns string, paths ...string) resource.Config {
+func (c *configPlan) File(ns string, paths ...string) config.Plan {
 	yamlText, err := file.AsStringArray(paths...)
 	if err != nil {
 		panic(err)
@@ -218,11 +219,11 @@ func (c *configImpl) File(ns string, paths ...string) resource.Config {
 	return c.YAML(ns, yamlText...)
 }
 
-func (c *configImpl) Eval(ns string, args interface{}, templates ...string) resource.Config {
+func (c *configPlan) Eval(ns string, args interface{}, templates ...string) config.Plan {
 	return c.YAML(ns, tmpl.MustEvaluateAll(args, templates...)...)
 }
 
-func (c *configImpl) EvalFile(ns string, args interface{}, paths ...string) resource.Config {
+func (c *configPlan) EvalFile(ns string, args interface{}, paths ...string) config.Plan {
 	templates, err := file.AsStringArray(paths...)
 	if err != nil {
 		panic(err)
@@ -231,11 +232,11 @@ func (c *configImpl) EvalFile(ns string, args interface{}, paths ...string) reso
 	return c.Eval(ns, args, templates...)
 }
 
-func (c *configImpl) Apply(opts ...resource.ConfigOption) error {
+func (c *configPlan) Apply(opts ...apply.Option) error {
 	// Apply the options.
-	options := resource.ConfigOptions{}
+	options := apply.Options{}
 	for _, o := range opts {
-		o(&options)
+		o.Set(&options)
 	}
 
 	// Apply for each namespace concurrently.
@@ -243,7 +244,7 @@ func (c *configImpl) Apply(opts ...resource.ConfigOption) error {
 	for ns, y := range c.yamlText {
 		ns, y := ns, y
 		g.Go(func() error {
-			return c.applyYAML(!options.NoCleanup, ns, y...)
+			return c.applyYAML(options.Cleanup, ns, y...)
 		})
 	}
 
@@ -265,14 +266,14 @@ func (c *configImpl) Apply(opts ...resource.ConfigOption) error {
 	return nil
 }
 
-func (c *configImpl) ApplyOrFail(t test.Failer, opts ...resource.ConfigOption) {
+func (c *configPlan) ApplyOrFail(t test.Failer, opts ...apply.Option) {
 	t.Helper()
 	if err := c.Apply(opts...); err != nil {
 		t.Fatal(err)
 	}
 }
 
-func (c *configImpl) Delete() error {
+func (c *configPlan) Delete() error {
 	// Delete for each namespace concurrently.
 	g, _ := errgroup.WithContext(context.TODO())
 	for ns, y := range c.yamlText {
@@ -286,7 +287,7 @@ func (c *configImpl) Delete() error {
 	return g.Wait()
 }
 
-func (c *configImpl) DeleteOrFail(t test.Failer) {
+func (c *configPlan) DeleteOrFail(t test.Failer) {
 	t.Helper()
 	if err := c.Delete(); err != nil {
 		t.Fatal(err)

--- a/pkg/test/framework/resource/config/apply/option.go
+++ b/pkg/test/framework/resource/config/apply/option.go
@@ -1,0 +1,46 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apply
+
+import "istio.io/istio/pkg/test/framework/resource/config/cleanup"
+
+// Option is a strategy for updating Options.
+type Option interface {
+	// Set this option on the provided Options
+	Set(*Options)
+}
+
+// OptionFunc is a function-based Option.
+type OptionFunc func(*Options)
+
+// Set just invokes this function to update the Options.
+func (f OptionFunc) Set(opts *Options) {
+	f(opts)
+}
+
+// NoCleanup is an Option that disables config cleanup.
+var NoCleanup Option = OptionFunc(func(opts *Options) {
+	opts.Cleanup = cleanup.None
+})
+
+// CleanupConditionally is an Option that sets Cleanup = cleanup.Conditionally.
+var CleanupConditionally Option = OptionFunc(func(opts *Options) {
+	opts.Cleanup = cleanup.Conditionally
+})
+
+// Wait configures the Options to wait for configuration to propagate.
+var Wait Option = OptionFunc(func(opts *Options) {
+	opts.Wait = true
+})

--- a/pkg/test/framework/resource/config/apply/options.go
+++ b/pkg/test/framework/resource/config/apply/options.go
@@ -1,0 +1,26 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apply
+
+import "istio.io/istio/pkg/test/framework/resource/config/cleanup"
+
+// Options provide options for applying configuration
+type Options struct {
+	// Cleanup strategy
+	Cleanup cleanup.Strategy
+
+	// Wait for configuration to be propagated.
+	Wait bool
+}

--- a/pkg/test/framework/resource/config/cleanup/strategy.go
+++ b/pkg/test/framework/resource/config/cleanup/strategy.go
@@ -1,0 +1,31 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cleanup
+
+// Strategy enumerates the options for configuration cleanup behavior.
+type Strategy int
+
+const (
+	// Always will trigger a cleanup operation the test context completes.
+	Always Strategy = iota
+
+	// Conditionally will trigger a cleanup operation the test context
+	// completes, unless -istio.test.nocleanup is set.
+	Conditionally
+
+	// None will not configure a cleanup operation to be performed when the
+	// context terminates.
+	None
+)

--- a/pkg/test/framework/resource/config/factory.go
+++ b/pkg/test/framework/resource/config/factory.go
@@ -1,0 +1,33 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+// Factory for config Plan resources.
+type Factory interface {
+	// New return an empty config Plan.
+	New() Plan
+
+	// YAML returns a Plan with the given YAML and target namespace.
+	YAML(ns string, yamlText ...string) Plan
+
+	// File reads the given files and calls YAML.
+	File(ns string, paths ...string) Plan
+
+	// Eval the same as YAML, but it evaluates the template parameters.
+	Eval(ns string, args interface{}, yamlText ...string) Plan
+
+	// EvalFile the same as File, but it evaluates the template parameters.
+	EvalFile(ns string, args interface{}, paths ...string) Plan
+}

--- a/pkg/test/framework/resource/config/plan.go
+++ b/pkg/test/framework/resource/config/plan.go
@@ -1,0 +1,39 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"istio.io/istio/pkg/test"
+	"istio.io/istio/pkg/test/framework/resource/config/apply"
+)
+
+// Plan for configuration that can be applied or deleted as an atomic unit.
+// A Plan is initially created by a Factory, but then can continually be
+// appended to before finally calling Apply or Delete.
+type Plan interface {
+	// Factory for appending to this Config.
+	Factory
+
+	// Copy returns a deep copy of this Plan.
+	Copy() Plan
+
+	// Apply this config.
+	Apply(opts ...apply.Option) error
+	ApplyOrFail(t test.Failer, opts ...apply.Option)
+
+	// Delete this config.
+	Delete() error
+	DeleteOrFail(t test.Failer)
+}

--- a/pkg/test/framework/resource/context.go
+++ b/pkg/test/framework/resource/context.go
@@ -15,71 +15,11 @@
 package resource
 
 import (
-	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/framework/components/cluster"
+	"istio.io/istio/pkg/test/framework/resource/config"
+	"istio.io/istio/pkg/test/framework/resource/config/cleanup"
 	"istio.io/istio/pkg/test/util/yml"
 )
-
-type ConfigOptions struct {
-	NoCleanup bool
-	Wait      bool
-}
-
-type ConfigOption func(o *ConfigOptions)
-
-// NoCleanup does not delete the applied Config once it goes out of scope.
-var NoCleanup ConfigOption = func(o *ConfigOptions) {
-	o.NoCleanup = true
-}
-
-// Wait for the Config to be applied everywhere.
-var Wait ConfigOption = func(o *ConfigOptions) {
-	o.Wait = true
-}
-
-// ConfigFactory is a factory for creating new Config resources.
-type ConfigFactory interface {
-	// YAML adds YAML content to this config for the given namespace.
-	YAML(ns string, yamlText ...string) Config
-
-	// File reads the given YAML files and adds their content to this config
-	// for the given namespace.
-	File(ns string, paths ...string) Config
-
-	// Eval the same as YAML, but it evaluates the template parameters.
-	Eval(ns string, args interface{}, yamlText ...string) Config
-
-	// EvalFile the same as File, but it evaluates the template parameters.
-	EvalFile(ns string, args interface{}, paths ...string) Config
-}
-
-// Config builds a configuration that can be applied or deleted as a single
-type Config interface {
-	// ConfigFactory for appending to this Config
-	ConfigFactory
-
-	// Copy this Config
-	Copy() Config
-
-	// Apply this config to all clusters within the ConfigManager
-	Apply(opts ...ConfigOption) error
-	ApplyOrFail(t test.Failer, opts ...ConfigOption)
-
-	// Delete this config from all clusters within the ConfigManager
-	Delete() error
-	DeleteOrFail(t test.Failer)
-}
-
-// ConfigManager is an interface for applying/deleting yaml resources.
-type ConfigManager interface {
-	ConfigFactory
-
-	// New empty Config.
-	New() Config
-
-	// WithFilePrefix sets the prefix used for intermediate files.
-	WithFilePrefix(prefix string) ConfigManager
-}
 
 // Context is the core context interface that is used by resources.
 type Context interface {
@@ -108,16 +48,21 @@ type Context interface {
 	// Settings returns common settings
 	Settings() *Settings
 
-	// ConditionalCleanup runs the given function when the test context completes.
-	// If -istio.test.nocleanup is set, this function will not be executed. To unconditionally cleanup, use Cleanup.
-	// This function may not (safely) access the test context.
-	ConditionalCleanup(fn func())
-
-	// Cleanup runs the given function when the test context completes.
-	// This function will always run, regardless of -istio.test.nocleanup. To run only when cleanup is enabled,
-	// use WhenDone.
+	// Cleanup will trigger the provided cleanup function after the test context
+	// completes. This is identical to CleanupStrategy(Always).
 	// This function may not (safely) access the test context.
 	Cleanup(fn func())
+
+	// CleanupConditionally will trigger a cleanup operation the test context
+	// completes, unless -istio.test.nocleanup is set. This is identical to
+	// CleanupStrategy(Conditionally).
+	// This function may not (safely) access the test context.
+	CleanupConditionally(fn func())
+
+	// CleanupStrategy runs the given cleanup function after the test context completes,
+	// depending on the provided strategy.
+	// This function may not (safely) access the test context.
+	CleanupStrategy(strategy cleanup.Strategy, fn func())
 
 	// CreateDirectory creates a new subdirectory within this context.
 	CreateDirectory(name string) (string, error)
@@ -125,12 +70,12 @@ type Context interface {
 	// CreateTmpDirectory creates a new temporary directory within this context.
 	CreateTmpDirectory(prefix string) (string, error)
 
-	// ConfigKube returns a ConfigManager that writes config to the provided clusers. If
+	// ConfigKube returns a Context that writes config to the provided clusters. If
 	// no clusters are provided, writes to all clusters in the mesh.
-	ConfigKube(clusters ...cluster.Cluster) ConfigManager
+	ConfigKube(clusters ...cluster.Cluster) config.Factory
 
-	// ConfigIstio returns a ConfigManager that writes config to all Istio config clusters.
-	ConfigIstio() ConfigManager
+	// ConfigIstio returns a Context that writes config to all Istio config clusters.
+	ConfigIstio() config.Factory
 
 	// RecordTraceEvent records an event. This is later saved to trace.yaml for analysis
 	RecordTraceEvent(key string, value interface{})

--- a/pkg/test/framework/suite_test.go
+++ b/pkg/test/framework/suite_test.go
@@ -330,7 +330,7 @@ func TestSuite_Cleanup(t *testing.T) {
 			ctx.Cleanup(func() {
 				cleanupCalled = true
 			})
-			ctx.ConditionalCleanup(func() {
+			ctx.CleanupConditionally(func() {
 				conditionalCleanupCalled = true
 			})
 			return nil
@@ -361,7 +361,7 @@ func TestSuite_Cleanup(t *testing.T) {
 			ctx.Cleanup(func() {
 				cleanupCalled = true
 			})
-			ctx.ConditionalCleanup(func() {
+			ctx.CleanupConditionally(func() {
 				conditionalCleanupCalled = true
 			})
 			return nil

--- a/pkg/test/framework/suitecontext.go
+++ b/pkg/test/framework/suitecontext.go
@@ -28,6 +28,8 @@ import (
 	"istio.io/istio/pkg/test/framework/features"
 	"istio.io/istio/pkg/test/framework/label"
 	"istio.io/istio/pkg/test/framework/resource"
+	"istio.io/istio/pkg/test/framework/resource/config"
+	"istio.io/istio/pkg/test/framework/resource/config/cleanup"
 	"istio.io/istio/pkg/test/scopes"
 	"istio.io/istio/pkg/test/util/yml"
 	"istio.io/istio/pkg/util/sets"
@@ -92,15 +94,15 @@ func newSuiteContext(s *resource.Settings, envFn resource.EnvironmentFactory, la
 
 // allocateContextID allocates a unique context id for TestContexts. Useful for creating unique names to help with
 // debugging
-func (s *suiteContext) allocateContextID(prefix string) string {
-	s.contextMu.Lock()
-	defer s.contextMu.Unlock()
+func (c *suiteContext) allocateContextID(prefix string) string {
+	c.contextMu.Lock()
+	defer c.contextMu.Unlock()
 
 	candidate := prefix
 	discriminator := 0
 	for {
-		if !s.contextNames.Contains(candidate) {
-			s.contextNames.Insert(candidate)
+		if !c.contextNames.Contains(candidate) {
+			c.contextNames.Insert(candidate)
 			return candidate
 		}
 
@@ -109,16 +111,16 @@ func (s *suiteContext) allocateContextID(prefix string) string {
 	}
 }
 
-func (s *suiteContext) allocateResourceID(contextID string, r resource.Resource) string {
-	s.contextMu.Lock()
-	defer s.contextMu.Unlock()
+func (c *suiteContext) allocateResourceID(contextID string, r resource.Resource) string {
+	c.contextMu.Lock()
+	defer c.contextMu.Unlock()
 
 	t := reflect.TypeOf(r)
 	candidate := fmt.Sprintf("%s/[%s]", contextID, t.String())
 	discriminator := 0
 	for {
-		if !s.contextNames.Contains(candidate) {
-			s.contextNames.Insert(candidate)
+		if !c.contextNames.Contains(candidate) {
+			c.contextNames.Insert(candidate)
 			return candidate
 		}
 
@@ -127,84 +129,96 @@ func (s *suiteContext) allocateResourceID(contextID string, r resource.Resource)
 	}
 }
 
-func (s *suiteContext) ConditionalCleanup(fn func()) {
-	s.globalScope.addCloser(&closer{fn: func() error {
-		fn()
-		return nil
-	}, noskip: true})
+func (c *suiteContext) CleanupConditionally(fn func()) {
+	c.CleanupStrategy(cleanup.Conditionally, fn)
 }
 
-func (s *suiteContext) Cleanup(fn func()) {
-	s.globalScope.addCloser(&closer{fn: func() error {
-		fn()
-		return nil
-	}})
+func (c *suiteContext) Cleanup(fn func()) {
+	c.CleanupStrategy(cleanup.Always, fn)
+}
+
+func (c *suiteContext) CleanupStrategy(strategy cleanup.Strategy, fn func()) {
+	switch strategy {
+	case cleanup.Always:
+		c.globalScope.addCloser(&closer{fn: func() error {
+			fn()
+			return nil
+		}})
+	case cleanup.Conditionally:
+		c.globalScope.addCloser(&closer{fn: func() error {
+			fn()
+			return nil
+		}, noskip: true})
+	default:
+		// No cleanup.
+		return
+	}
 }
 
 // TrackResource adds a new resource to track to the context at this level.
-func (s *suiteContext) TrackResource(r resource.Resource) resource.ID {
-	id := s.allocateResourceID(s.globalScope.id, r)
+func (c *suiteContext) TrackResource(r resource.Resource) resource.ID {
+	id := c.allocateResourceID(c.globalScope.id, r)
 	rid := &resourceID{id: id}
-	s.globalScope.add(r, rid)
+	c.globalScope.add(r, rid)
 	return rid
 }
 
-func (s *suiteContext) GetResource(ref interface{}) error {
-	return s.globalScope.get(ref)
+func (c *suiteContext) GetResource(ref interface{}) error {
+	return c.globalScope.get(ref)
 }
 
-func (s *suiteContext) Environment() resource.Environment {
-	return s.environment
+func (c *suiteContext) Environment() resource.Environment {
+	return c.environment
 }
 
-func (s *suiteContext) Clusters() cluster.Clusters {
-	return s.Environment().Clusters()
+func (c *suiteContext) Clusters() cluster.Clusters {
+	return c.Environment().Clusters()
 }
 
-func (s *suiteContext) AllClusters() cluster.Clusters {
-	return s.Environment().AllClusters()
+func (c *suiteContext) AllClusters() cluster.Clusters {
+	return c.Environment().AllClusters()
 }
 
 // Settings returns the current runtime.Settings.
-func (s *suiteContext) Settings() *resource.Settings {
-	return s.settings
+func (c *suiteContext) Settings() *resource.Settings {
+	return c.settings
 }
 
 // CreateDirectory creates a new subdirectory within this context.
-func (s *suiteContext) CreateDirectory(name string) (string, error) {
-	dir, err := os.MkdirTemp(s.workDir, name)
+func (c *suiteContext) CreateDirectory(name string) (string, error) {
+	dir, err := os.MkdirTemp(c.workDir, name)
 	if err != nil {
 		scopes.Framework.Errorf("Error creating temp dir: runID='%s', prefix='%s', workDir='%v', err='%v'",
-			s.settings.RunID, name, s.workDir, err)
+			c.settings.RunID, name, c.workDir, err)
 	} else {
-		scopes.Framework.Debugf("Created a temp dir: runID='%s', name='%s'", s.settings.RunID, dir)
+		scopes.Framework.Debugf("Created a temp dir: runID='%s', name='%s'", c.settings.RunID, dir)
 	}
 	return dir, err
 }
 
 // CreateTmpDirectory creates a new temporary directory with the given prefix.
-func (s *suiteContext) CreateTmpDirectory(prefix string) (string, error) {
+func (c *suiteContext) CreateTmpDirectory(prefix string) (string, error) {
 	if len(prefix) != 0 && !strings.HasSuffix(prefix, "-") {
 		prefix += "-"
 	}
 
-	dir, err := os.MkdirTemp(s.workDir, prefix)
+	dir, err := os.MkdirTemp(c.workDir, prefix)
 	if err != nil {
 		scopes.Framework.Errorf("Error creating temp dir: runID='%s', prefix='%s', workDir='%v', err='%v'",
-			s.settings.RunID, prefix, s.workDir, err)
+			c.settings.RunID, prefix, c.workDir, err)
 	} else {
-		scopes.Framework.Debugf("Created a temp dir: runID='%s', Name='%s'", s.settings.RunID, dir)
+		scopes.Framework.Debugf("Created a temp dir: runID='%s', Name='%s'", c.settings.RunID, dir)
 	}
 
 	return dir, err
 }
 
-func (s *suiteContext) ConfigKube(clusters ...cluster.Cluster) resource.ConfigManager {
-	return newConfigManager(s, clusters)
+func (c *suiteContext) ConfigKube(clusters ...cluster.Cluster) config.Factory {
+	return newConfigFactory(c, clusters)
 }
 
-func (s *suiteContext) ConfigIstio() resource.ConfigManager {
-	return newConfigManager(s, s.Clusters().Configs())
+func (c *suiteContext) ConfigIstio() config.Factory {
+	return newConfigFactory(c, c.Clusters().Configs())
 }
 
 type Outcome string
@@ -223,7 +237,7 @@ type TestOutcome struct {
 	FeatureLabels map[features.Feature][]string
 }
 
-func (s *suiteContext) registerOutcome(test *testImpl) {
+func (c *suiteContext) registerOutcome(test *testImpl) {
 	o := Passed
 	if test.notImplemented {
 		o = NotImplemented
@@ -238,23 +252,23 @@ func (s *suiteContext) registerOutcome(test *testImpl) {
 		Outcome:       o,
 		FeatureLabels: test.featureLabels,
 	}
-	s.contextMu.Lock()
-	defer s.contextMu.Unlock()
-	s.testOutcomes = append(s.testOutcomes, newOutcome)
+	c.contextMu.Lock()
+	defer c.contextMu.Unlock()
+	c.testOutcomes = append(c.testOutcomes, newOutcome)
 }
 
-func (s *suiteContext) RecordTraceEvent(key string, value interface{}) {
-	s.traces.Store(key, value)
+func (c *suiteContext) RecordTraceEvent(key string, value interface{}) {
+	c.traces.Store(key, value)
 }
 
-func (s *suiteContext) marshalTraceEvent() []byte {
+func (c *suiteContext) marshalTraceEvent() []byte {
 	kvs := map[string]interface{}{}
-	s.traces.Range(func(key, value interface{}) bool {
+	c.traces.Range(func(key, value interface{}) bool {
 		kvs[key.(string)] = value
 		return true
 	})
 	outer := map[string]interface{}{
-		fmt.Sprintf("suite/%s", s.settings.TestID): kvs,
+		fmt.Sprintf("suite/%s", c.settings.TestID): kvs,
 	}
 	d, _ := yaml.Marshal(outer)
 	return d

--- a/tests/integration/helm/upgrade/util.go
+++ b/tests/integration/helm/upgrade/util.go
@@ -160,7 +160,7 @@ func performInPlaceUpgradeFunc(previousVersion string) func(framework.TestContex
 		cs := t.Clusters().Default().(*kubecluster.Cluster)
 		h := helm.New(cs.Filename())
 
-		t.ConditionalCleanup(func() {
+		t.CleanupConditionally(func() {
 			// only need to do call this once as helm doesn't need to remove
 			// all versions
 			err := deleteIstio(cs, h, true)
@@ -213,7 +213,7 @@ func performRevisionUpgradeFunc(previousVersion, previousValidatingWebhookName s
 		cs := t.Clusters().Default().(*kubecluster.Cluster)
 		h := helm.New(cs.Filename())
 
-		t.ConditionalCleanup(func() {
+		t.CleanupConditionally(func() {
 			err := deleteIstioRevision(h, canaryTag)
 			if err != nil {
 				t.Fatalf("could not delete istio: %v", err)
@@ -272,7 +272,7 @@ func performRevisionTagsUpgradeFunc(previousVersion, previousValidatingWebhookNa
 		cs := t.Clusters().Default().(*kubecluster.Cluster)
 		h := helm.New(cs.Filename())
 
-		t.ConditionalCleanup(func() {
+		t.CleanupConditionally(func() {
 			err := deleteIstioRevision(h, latestRevisionTag)
 			if err != nil {
 				t.Fatalf("could not delete istio revision (%v): %v", latestRevisionTag, err)

--- a/tests/integration/pilot/gateway_conformance_test.go
+++ b/tests/integration/pilot/gateway_conformance_test.go
@@ -42,7 +42,7 @@ import (
 
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/test/framework"
-	"istio.io/istio/pkg/test/framework/resource"
+	"istio.io/istio/pkg/test/framework/resource/config/apply"
 	"istio.io/istio/pkg/test/scopes"
 	"istio.io/istio/pkg/test/util/retry"
 )
@@ -66,7 +66,9 @@ func TestGatewayConformance(t *testing.T) {
 			if !supportsCRDv1(ctx) {
 				t.Skip("Not supported; requires CRDv1 support.")
 			}
-			if err := ctx.ConfigIstio().File("", "testdata/gateway-api-crd.yaml").Apply(resource.NoCleanup); err != nil {
+			if err := ctx.ConfigIstio().
+				File("", "testdata/gateway-api-crd.yaml").
+				Apply(apply.NoCleanup); err != nil {
 				ctx.Fatal(err)
 			}
 			// Wait until our GatewayClass is ready

--- a/tests/integration/pilot/ingress_test.go
+++ b/tests/integration/pilot/ingress_test.go
@@ -42,7 +42,7 @@ import (
 	"istio.io/istio/pkg/test/framework/components/environment/kube"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/components/namespace"
-	"istio.io/istio/pkg/test/framework/resource"
+	"istio.io/istio/pkg/test/framework/resource/config/apply"
 	"istio.io/istio/pkg/test/helm"
 	kubetest "istio.io/istio/pkg/test/kube"
 	"istio.io/istio/pkg/test/util/retry"
@@ -57,7 +57,9 @@ func TestGateway(t *testing.T) {
 			if !supportsCRDv1(t) {
 				t.Skip("Not supported; requires CRDv1 support.")
 			}
-			if err := t.ConfigIstio().File("", "testdata/gateway-api-crd.yaml").Apply(resource.NoCleanup); err != nil {
+			if err := t.ConfigIstio().
+				File("", "testdata/gateway-api-crd.yaml").
+				Apply(apply.NoCleanup); err != nil {
 				t.Fatal(err)
 			}
 			ingressutil.CreateIngressKubeSecret(t, "test-gateway-cert-same", ingressutil.TLS, ingressutil.IngressCredentialA,
@@ -796,7 +798,7 @@ spec:
         host: {{ .host }}
         port:
           number: 80
-`).Apply(resource.NoCleanup)
+`).Apply(apply.NoCleanup)
 				cs := t.Clusters().Default().(*kubecluster.Cluster)
 				retry.UntilSuccessOrFail(t, func() error {
 					_, err := kubetest.CheckPodsAreReady(kubetest.NewPodFetch(cs, gatewayNs.Name(), "istio=custom"))
@@ -874,7 +876,7 @@ spec:
         host: %s
         port:
           number: 80
-`, apps.A.Config().ClusterLocalFQDN())).Apply(resource.NoCleanup)
+`, apps.A.Config().ClusterLocalFQDN())).Apply(apply.NoCleanup)
 				apps.B[0].CallOrFail(t, echo.CallOptions{
 					Port:    echo.Port{ServicePort: 80},
 					Scheme:  scheme.HTTP,
@@ -941,7 +943,7 @@ spec:
         host: %s
         port:
           number: 80
-`, apps.A.Config().ClusterLocalFQDN())).Apply(resource.NoCleanup)
+`, apps.A.Config().ClusterLocalFQDN())).Apply(apply.NoCleanup)
 				apps.B[0].CallOrFail(t, echo.CallOptions{
 					Port:    echo.Port{ServicePort: 80},
 					Scheme:  scheme.HTTP,

--- a/tests/integration/pilot/locality_test.go
+++ b/tests/integration/pilot/locality_test.go
@@ -209,7 +209,8 @@ func TestLocality(t *testing.T) {
 				t.NewSubTest(tt.name).Run(func(t framework.TestContext) {
 					hostname := fmt.Sprintf("%s-fake-locality.example.com", strings.ToLower(strings.ReplaceAll(tt.name, "/", "-")))
 					tt.input.Host = hostname
-					t.ConfigIstio().YAML(apps.Namespace.Name(), runTemplate(t, localityTemplate, tt.input)).ApplyOrFail(t)
+					t.ConfigIstio().YAML(apps.Namespace.Name(), runTemplate(t, localityTemplate, tt.input)).
+						ApplyOrFail(t)
 					sendTrafficOrFail(t, apps.A[0], hostname, tt.expected)
 				})
 			}

--- a/tests/integration/pilot/mcs/common/common.go
+++ b/tests/integration/pilot/mcs/common/common.go
@@ -31,6 +31,7 @@ import (
 	"istio.io/istio/pkg/test/framework/components/environment/kube"
 	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/framework/resource"
+	"istio.io/istio/pkg/test/framework/resource/config/apply"
 	"istio.io/istio/pkg/test/util/tmpl"
 )
 
@@ -78,7 +79,7 @@ func InstallMCSCRDs(t resource.Context) error {
 
 			// Add/Update the CRD in this cluster...
 			if t.Settings().NoCleanup {
-				if err := t.ConfigKube(c).YAML("", crdYAML).Apply(resource.NoCleanup); err != nil {
+				if err := t.ConfigKube(c).YAML("", crdYAML).Apply(apply.NoCleanup); err != nil {
 					return err
 				}
 			} else {

--- a/tests/integration/pilot/mirror_test.go
+++ b/tests/integration/pilot/mirror_test.go
@@ -138,7 +138,8 @@ func runMirrorTest(t *testing.T, options mirrorTestOptions) {
 					}
 
 					// we only apply to config clusters
-					t.ConfigIstio().EvalFile(apps.Namespace.Name(), vsc, "testdata/traffic-mirroring-template.yaml").ApplyOrFail(t)
+					t.ConfigIstio().EvalFile(apps.Namespace.Name(), vsc, "testdata/traffic-mirroring-template.yaml").
+						ApplyOrFail(t)
 
 					for _, podA := range apps.A {
 						podA := podA

--- a/tests/integration/pilot/multi_version_revision_test.go
+++ b/tests/integration/pilot/multi_version_revision_test.go
@@ -32,7 +32,7 @@ import (
 	"istio.io/istio/pkg/test/framework/components/echo/deployment"
 	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/framework/label"
-	"istio.io/istio/pkg/test/framework/resource"
+	"istio.io/istio/pkg/test/framework/resource/config/apply"
 	"istio.io/istio/pkg/test/util/file"
 	"istio.io/istio/pkg/test/util/retry"
 )
@@ -67,7 +67,7 @@ func TestMultiVersionRevision(t *testing.T) {
 
 			// keep track of applied configurations and clean up after the test
 			configs := make(map[string]string)
-			t.ConditionalCleanup(func() {
+			t.CleanupConditionally(func() {
 				for _, config := range configs {
 					_ = t.ConfigIstio().YAML("istio-system", config).Delete()
 				}
@@ -169,7 +169,7 @@ func installRevisionOrFail(t framework.TestContext, version string, configs map[
 		t.Fatalf("could not read installation config: %v", err)
 	}
 	configs[version] = config
-	if err := t.ConfigIstio().YAML(i.Settings().SystemNamespace, config).Apply(resource.NoCleanup); err != nil {
+	if err := t.ConfigIstio().YAML(i.Settings().SystemNamespace, config).Apply(apply.NoCleanup); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/tests/integration/pilot/revisioned_upgrade_test.go
+++ b/tests/integration/pilot/revisioned_upgrade_test.go
@@ -69,7 +69,7 @@ func TestRevisionedUpgrade(t *testing.T) {
 // TODO(monkeyanator) pass this a generic UpgradeFunc allowing for reuse across in-place and revisioned upgrades
 func testUpgradeFromVersion(t framework.TestContext, fromVersion string) {
 	configs := make(map[string]string)
-	t.ConditionalCleanup(func() {
+	t.CleanupConditionally(func() {
 		for _, config := range configs {
 			_ = t.ConfigIstio().YAML("istio-system", config).Delete()
 		}

--- a/tests/integration/pilot/validation_test.go
+++ b/tests/integration/pilot/validation_test.go
@@ -121,7 +121,7 @@ func TestValidation(t *testing.T) {
 						}
 
 						wetRunErr := cluster.ApplyYAMLFiles(ns.Name(), applyFiles...)
-						t.ConditionalCleanup(func() {
+						t.CleanupConditionally(func() {
 							cluster.DeleteYAMLFiles(ns.Name(), applyFiles...)
 						})
 

--- a/tests/integration/security/authorization_test.go
+++ b/tests/integration/security/authorization_test.go
@@ -37,7 +37,7 @@ import (
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/framework/label"
-	"istio.io/istio/pkg/test/framework/resource"
+	"istio.io/istio/pkg/test/framework/resource/config/apply"
 	"istio.io/istio/tests/common/jwt"
 	"istio.io/istio/tests/integration/security/util"
 	"istio.io/istio/tests/integration/security/util/scheck"
@@ -60,7 +60,7 @@ func TestAuthorization_mTLS(t *testing.T) {
 					"Namespace":  apps.Namespace1.Name(),
 					"Namespace2": apps.Namespace2.Name(),
 					"dst":        to.Config().Service,
-				}, "testdata/authz/v1beta1-mtls.yaml.tmpl").ApplyOrFail(t, resource.Wait)
+				}, "testdata/authz/v1beta1-mtls.yaml.tmpl").ApplyOrFail(t, apply.Wait)
 				callCount := util.CallsPerCluster * to.WorkloadsOrFail(t).Len()
 				for _, cluster := range t.Clusters() {
 					a := match.And(match.Cluster(cluster), match.Namespace(apps.Namespace1)).GetMatches(apps.A)
@@ -127,7 +127,8 @@ func TestAuthorization_JWT(t *testing.T) {
 					"Namespace2": apps.Namespace2.Name(),
 					"dst":        dst[0].Config().Service,
 				}
-				t.ConfigIstio().EvalFile(ns.Name(), args, "testdata/authz/v1beta1-jwt.yaml.tmpl").ApplyOrFail(t, resource.Wait)
+				t.ConfigIstio().EvalFile(ns.Name(), args, "testdata/authz/v1beta1-jwt.yaml.tmpl").
+					ApplyOrFail(t, apply.Wait)
 				for _, srcCluster := range t.Clusters() {
 					a := match.And(match.Cluster(srcCluster), match.Namespace(ns)).GetMatches(apps.A)
 					if len(a) == 0 {
@@ -269,7 +270,7 @@ func TestAuthorization_WorkloadSelector(t *testing.T) {
 							"RootNamespace": rootns.Name(),
 							"b":             util.BSvc,
 							"c":             util.CSvc,
-						}, filename).ApplyOrFail(t, resource.Wait)
+						}, filename).ApplyOrFail(t, apply.Wait)
 					}
 					applyPolicy("testdata/authz/v1beta1-workload-ns1.yaml.tmpl", ns1)
 					applyPolicy("testdata/authz/v1beta1-workload-ns2.yaml.tmpl", ns2)
@@ -315,7 +316,7 @@ func TestAuthorization_WorkloadSelector(t *testing.T) {
 							"RootNamespace": rootns.Name(),
 							"b":             util.VMSvc, // This is the only difference from standard args.
 							"c":             util.CSvc,
-						}, filename).ApplyOrFail(t, resource.Wait)
+						}, filename).ApplyOrFail(t, apply.Wait)
 					}
 					applyPolicy("testdata/authz/v1beta1-workload-ns1.yaml.tmpl", ns1)
 					applyPolicy("testdata/authz/v1beta1-workload-ns2.yaml.tmpl", ns2)
@@ -360,7 +361,7 @@ func TestAuthorization_Deny(t *testing.T) {
 					"b":             b[0].Config().Service,
 					"c":             c[0].Config().Service,
 					"vm":            vm[0].Config().Service,
-				}, filename).ApplyOrFail(t, resource.Wait)
+				}, filename).ApplyOrFail(t, apply.Wait)
 			}
 			applyPolicy("testdata/authz/v1beta1-deny.yaml.tmpl", ns)
 			applyPolicy("testdata/authz/v1beta1-deny-ns-root.yaml.tmpl", rootns)
@@ -1082,7 +1083,8 @@ func TestAuthorization_Conditions(t *testing.T) {
 								"b":          util.BSvc,
 							}
 
-							t.ConfigIstio().EvalFile("", args, "testdata/authz/v1beta1-conditions.yaml.tmpl").ApplyOrFail(t)
+							t.ConfigIstio().EvalFile("", args, "testdata/authz/v1beta1-conditions.yaml.tmpl").
+								ApplyOrFail(t)
 							callCount := util.CallsPerCluster * to.WorkloadsOrFail(t).Len()
 							newTestCase := func(from echo.Instance, path string, headers http.Header, expectAllowed bool) func(t framework.TestContext) {
 								return func(t framework.TestContext) {
@@ -1200,7 +1202,7 @@ func TestAuthorization_GRPC(t *testing.T) {
 								"c":         c[0].Config().Service,
 								"d":         d[0].Config().Service,
 							}
-							t.ConfigIstio().EvalFile(ns.Name(), args, "testdata/authz/v1beta1-grpc.yaml.tmpl").ApplyOrFail(t, resource.Wait)
+							t.ConfigIstio().EvalFile(ns.Name(), args, "testdata/authz/v1beta1-grpc.yaml.tmpl").ApplyOrFail(t, apply.Wait)
 							newTestCase := func(from echo.Instance, to echo.Target, expectAllowed bool) func(t framework.TestContext) {
 								return func(t framework.TestContext) {
 									opts := echo.CallOptions{
@@ -1258,7 +1260,7 @@ func TestAuthorization_Path(t *testing.T) {
 							"Namespace": ns.Name(),
 							"a":         a[0].Config().Service,
 						}
-						t.ConfigIstio().EvalFile(ns.Name(), args, "testdata/authz/v1beta1-path.yaml.tmpl").ApplyOrFail(t, resource.Wait)
+						t.ConfigIstio().EvalFile(ns.Name(), args, "testdata/authz/v1beta1-path.yaml.tmpl").ApplyOrFail(t, apply.Wait)
 
 						newTestCase := func(from echo.Instance, to echo.Target, path string, expectAllowed bool) func(t framework.TestContext) {
 							callCount := util.CallsPerCluster * to.WorkloadsOrFail(t).Len()
@@ -1328,7 +1330,7 @@ func TestAuthorization_Audit(t *testing.T) {
 						"d":             d[0].Config().Service,
 						"Namespace":     ns.Name(),
 						"RootNamespace": istio.GetOrFail(t, t).Settings().SystemNamespace,
-					}, filename).ApplyOrFail(t, resource.Wait)
+					}, filename).ApplyOrFail(t, apply.Wait)
 				}
 			}
 
@@ -1337,7 +1339,7 @@ func TestAuthorization_Audit(t *testing.T) {
 					t.ConfigIstio().EvalFile(ns.Name(), map[string]string{
 						"Namespace": ns.Name(),
 						"dst":       vm[0].Config().Service,
-					}, filename).ApplyOrFail(t, resource.Wait)
+					}, filename).ApplyOrFail(t, apply.Wait)
 				}
 			}
 
@@ -1433,7 +1435,8 @@ func TestAuthorization_Custom(t *testing.T) {
 					args["LocalGRPCProviderName"] = p.Name()
 				}
 			}
-			t.ConfigIstio().EvalFile("", args, "testdata/authz/v1beta1-custom.yaml.tmpl").ApplyOrFail(t)
+			t.ConfigIstio().EvalFile("", args, "testdata/authz/v1beta1-custom.yaml.tmpl").
+				ApplyOrFail(t)
 			ports := []echo.Port{
 				{
 					Name:         "tcp-8092",

--- a/tests/integration/security/ecc_signature_algorithm/mtls_strict_test.go
+++ b/tests/integration/security/ecc_signature_algorithm/mtls_strict_test.go
@@ -26,7 +26,7 @@ import (
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/echo/check"
-	"istio.io/istio/pkg/test/framework/resource"
+	"istio.io/istio/pkg/test/framework/resource/config/apply"
 	"istio.io/istio/tests/integration/security/util/cert"
 )
 
@@ -63,8 +63,8 @@ func TestStrictMTLS(t *testing.T) {
 		Run(func(t framework.TestContext) {
 			ns := apps.Namespace.Name()
 			args := map[string]string{"AppNamespace": ns}
-			t.ConfigIstio().Eval(ns, args, PeerAuthenticationConfig).ApplyOrFail(t, resource.Wait)
-			t.ConfigIstio().Eval(ns, args, DestinationRuleConfigIstioMutual).ApplyOrFail(t, resource.Wait)
+			t.ConfigIstio().Eval(ns, args, PeerAuthenticationConfig).ApplyOrFail(t, apply.Wait)
+			t.ConfigIstio().Eval(ns, args, DestinationRuleConfigIstioMutual).ApplyOrFail(t, apply.Wait)
 
 			apps.Client.CallOrFail(t, echo.CallOptions{
 				To: apps.Server,

--- a/tests/integration/security/egress_gateway_origination_test.go
+++ b/tests/integration/security/egress_gateway_origination_test.go
@@ -339,7 +339,8 @@ func CreateDestinationRule(t framework.TestContext, to echo.Instances,
 	istioCfg := istio.DefaultConfigOrFail(t, t)
 	systemNS := namespace.ClaimOrFail(t, t, istioCfg.SystemNamespace)
 
-	t.ConfigKube(t.Clusters().Default()).Eval(systemNS.Name(), args, DestinationRuleConfig).ApplyOrFail(t)
+	t.ConfigKube(t.Clusters().Default()).Eval(systemNS.Name(), args, DestinationRuleConfig).
+		ApplyOrFail(t)
 }
 
 type TLSTestCase struct {

--- a/tests/integration/security/https_jwt/https_jwt_test.go
+++ b/tests/integration/security/https_jwt/https_jwt_test.go
@@ -30,6 +30,7 @@ import (
 	"istio.io/istio/pkg/test/framework/components/echo/echotest"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/resource"
+	"istio.io/istio/pkg/test/framework/resource/config/apply"
 	"istio.io/istio/pkg/test/kube"
 	"istio.io/istio/tests/common/jwt"
 	"istio.io/istio/tests/integration/security/util"
@@ -98,8 +99,7 @@ func TestJWTHTTPS(t *testing.T) {
 								"Namespace": ns.Name(),
 								"dst":       to.Config().Service,
 							}
-							return t.ConfigIstio().EvalFile(ns.Name(), args, c.policyFile).
-								Apply(resource.Wait)
+							return t.ConfigIstio().EvalFile(ns.Name(), args, c.policyFile).Apply(apply.Wait)
 						}).
 						FromMatch(
 							// TODO(JimmyCYJ): enable VM for all test cases.

--- a/tests/integration/security/jwt_test.go
+++ b/tests/integration/security/jwt_test.go
@@ -32,6 +32,7 @@ import (
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/label"
 	"istio.io/istio/pkg/test/framework/resource"
+	"istio.io/istio/pkg/test/framework/resource/config/apply"
 	"istio.io/istio/tests/common/jwt"
 	"istio.io/istio/tests/integration/security/util"
 	"istio.io/istio/tests/integration/security/util/scheck"
@@ -64,7 +65,7 @@ func TestRequestAuthentication(t *testing.T) {
 									"Namespace": ns.Name(),
 									"dst":       to.Config().Service,
 								}
-								return t.ConfigIstio().EvalFile(ns.Name(), args, policy).Apply(resource.Wait)
+								return t.ConfigIstio().EvalFile(ns.Name(), args, policy).Apply(apply.Wait)
 							}
 							return nil
 						}).
@@ -398,7 +399,7 @@ func TestIngressRequestAuthentication(t *testing.T) {
 			t.ConfigIstio().EvalFile(newRootNS(t).Name(), map[string]string{
 				"Namespace":     ns.Name(),
 				"RootNamespace": istio.GetOrFail(t, t).Settings().SystemNamespace,
-			}, "testdata/requestauthn/global-jwt.yaml.tmpl").ApplyOrFail(t, resource.Wait)
+			}, "testdata/requestauthn/global-jwt.yaml.tmpl").ApplyOrFail(t, apply.Wait)
 
 			type testCase struct {
 				name          string
@@ -414,7 +415,7 @@ func TestIngressRequestAuthentication(t *testing.T) {
 									"Namespace": ns.Name(),
 									"dst":       to.Config().Service,
 								}
-								return t.ConfigIstio().EvalFile(ns.Name(), args, policy).Apply(resource.Wait)
+								return t.ConfigIstio().EvalFile(ns.Name(), args, policy).Apply(apply.Wait)
 							}
 							return nil
 						}).

--- a/tests/integration/security/sds_ingress/util/util.go
+++ b/tests/integration/security/sds_ingress/util/util.go
@@ -132,7 +132,7 @@ func CreateIngressKubeSecretInNamespace(t framework.TestContext, credName string
 	ingressType CallType, ingressCred IngressCredential, isCompoundAndNotGeneric bool, ns string, clusters ...cluster.Cluster) {
 	t.Helper()
 
-	t.ConditionalCleanup(func() {
+	t.CleanupConditionally(func() {
 		deleteKubeSecret(t, credName)
 	})
 
@@ -477,11 +477,11 @@ func runTemplate(t test.Failer, tmpl string, params interface{}) string {
 }
 
 func SetupConfig(ctx framework.TestContext, ns namespace.Instance, config ...TestConfig) {
-	var apply []string
+	var cfg []string
 	for _, c := range config {
-		apply = append(apply, runTemplate(ctx, vsTemplate, c), runTemplate(ctx, gwTemplate, c))
+		cfg = append(cfg, runTemplate(ctx, vsTemplate, c), runTemplate(ctx, gwTemplate, c))
 	}
-	ctx.ConfigIstio().YAML(ns.Name(), apply...).ApplyOrFail(ctx)
+	ctx.ConfigIstio().YAML(ns.Name(), cfg...).ApplyOrFail(ctx)
 }
 
 // RunTestMultiMtlsGateways deploys multiple mTLS gateways with SDS enabled, and creates kubernetes secret that stores

--- a/tests/integration/security/util/reachability/context.go
+++ b/tests/integration/security/util/reachability/context.go
@@ -29,7 +29,7 @@ import (
 	"istio.io/istio/pkg/test/framework/components/echo/check"
 	"istio.io/istio/pkg/test/framework/components/echo/match"
 	"istio.io/istio/pkg/test/framework/components/namespace"
-	"istio.io/istio/pkg/test/framework/resource"
+	"istio.io/istio/pkg/test/framework/resource/config/apply"
 	"istio.io/istio/pkg/test/util/retry"
 	"istio.io/istio/tests/integration/security/util"
 	"istio.io/istio/tests/integration/security/util/scheck"
@@ -114,7 +114,7 @@ func Run(testCases []TestCase, t framework.TestContext, apps *util.EchoDeploymen
 			retry.UntilSuccessOrFail(t, func() error {
 				t.Logf("[%s] [%v] Apply config %s", testName, time.Now(), c.ConfigFile)
 				// TODO(https://github.com/istio/istio/issues/20460) We shouldn't need a retry loop
-				return cfg.Apply(resource.Wait)
+				return cfg.Apply(apply.Wait)
 			})
 			for _, clients := range []echo.Instances{apps.A, match.Namespace(apps.Namespace1).GetMatches(apps.B), apps.Headless, apps.Naked, apps.HeadlessNaked} {
 				for _, from := range clients {

--- a/tests/integration/telemetry/policy/envoy_ratelimit_test.go
+++ b/tests/integration/telemetry/policy/envoy_ratelimit_test.go
@@ -149,7 +149,8 @@ func testSetup(ctx resource.Context) (err error) {
 		return
 	}
 
-	err = ctx.ConfigIstio().File(ratelimitNs.Name(), filepath.Join(env.IstioSrc, "samples/ratelimit/rate-limit-service.yaml")).Apply()
+	err = ctx.ConfigIstio().File(ratelimitNs.Name(), filepath.Join(env.IstioSrc, "samples/ratelimit/rate-limit-service.yaml")).
+		Apply()
 	if err != nil {
 		return
 	}

--- a/tests/integration/telemetry/stackdriver/stackdriver_filter_dry_run_test.go
+++ b/tests/integration/telemetry/stackdriver/stackdriver_filter_dry_run_test.go
@@ -27,7 +27,7 @@ import (
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/stackdriver"
-	"istio.io/istio/pkg/test/framework/resource"
+	"istio.io/istio/pkg/test/framework/resource/config/apply"
 	"istio.io/istio/pkg/test/util/retry"
 	"istio.io/istio/tests/integration/telemetry"
 )
@@ -197,7 +197,7 @@ func createDryRunPolicy(t framework.TestContext, authz string) {
 	t.Helper()
 	ns := EchoNsInst.Name()
 	args := map[string]string{"Namespace": ns}
-	t.ConfigIstio().EvalFile(ns, args, authz).ApplyOrFail(t, resource.Wait)
+	t.ConfigIstio().EvalFile(ns, args, authz).ApplyOrFail(t, apply.Wait)
 }
 
 func verifyAccessLog(t framework.TestContext, cltInstance echo.Instance, wantLog string) error {

--- a/tests/integration/telemetry/stats/prometheus/customizemetrics/customize_metrics_test.go
+++ b/tests/integration/telemetry/stats/prometheus/customizemetrics/customize_metrics_test.go
@@ -37,6 +37,7 @@ import (
 	"istio.io/istio/pkg/test/framework/components/prometheus"
 	"istio.io/istio/pkg/test/framework/label"
 	"istio.io/istio/pkg/test/framework/resource"
+	"istio.io/istio/pkg/test/framework/resource/config/apply"
 	"istio.io/istio/pkg/test/util/retry"
 	util "istio.io/istio/tests/integration/telemetry"
 	common "istio.io/istio/tests/integration/telemetry/stats/prometheus"
@@ -134,7 +135,7 @@ spec:
           - regex: "(custom_dimension=\\.=(.*?);\\.;)"
             tag_name: "custom_dimension"
 `
-	if err := ctx.ConfigIstio().YAML("istio-system", bootstrapPatch).Apply(resource.Wait); err != nil {
+	if err := ctx.ConfigIstio().YAML("istio-system", bootstrapPatch).Apply(apply.Wait); err != nil {
 		return err
 	}
 
@@ -255,7 +256,8 @@ func setupWasmExtension(ctx resource.Context) error {
 		"DockerConfigJson": base64.StdEncoding.EncodeToString(
 			[]byte(createDockerCredential(registryUser, registryPasswd, registry.Address()))),
 	}
-	if err := ctx.ConfigIstio().EvalFile(appNsInst.Name(), args, "testdata/attributegen_envoy_filter.yaml").Apply(); err != nil {
+	if err := ctx.ConfigIstio().EvalFile(appNsInst.Name(), args, "testdata/attributegen_envoy_filter.yaml").
+		Apply(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
We currently have 3 strategies for cleaning up config in the test framework:

1. no cleanup
2. always cleanup after the context completes
3. cleanup after the context completes if `noCleanup` was not specified.

This PR tries to make these options more clear and consistent across the test infra. It also add the strategy for an option to MeshConfig changes.

**Please provide a description of this PR:**