### PR TITLE
Manual revert of #38344

### DIFF
--- a/docker/Dockerfile.distroless
+++ b/docker/Dockerfile.distroless
@@ -1,3 +1,20 @@
-# istio-static image is prebuilt with 1337:1337.
-# https://github.com/istio/distroless/tree/iptables/istio
-FROM gcr.io/istio-release/distroless/istio-static@sha256:d6fa9db9548b5772860fecddb11d84f9ebd7e0321c0cb3c02870402680cc315f as distroless_source
+# prepare a distroless source context to copy files from
+FROM gcr.io/distroless/static-debian11@sha256:d6fa9db9548b5772860fecddb11d84f9ebd7e0321c0cb3c02870402680cc315f as distroless_source
+
+# prepare a base dev to modify file contents
+FROM ubuntu:focal as ubuntu_source
+
+# Modify contents of container
+COPY --from=distroless_source /etc/ /home/etc
+COPY --from=distroless_source /home/nonroot /home/nonroot
+RUN echo istio-proxy:x:1337: >> /home/etc/group
+RUN echo istio-proxy:x:1337:1337:istio-proxy:/nonexistent:/sbin/nologin >> /home/etc/passwd
+
+# Customize distroless with the following:
+# - password file
+# - groups file
+# - /home/nonroot directory
+FROM distroless_source
+COPY --from=ubuntu_source /home/etc/passwd /etc/passwd
+COPY --from=ubuntu_source /home/etc/group /etc/group
+COPY --from=ubuntu_source /home/nonroot /home/nonroot


### PR DESCRIPTION
**Please provide a description of this PR:**

Changes in #38344  result in a failure when building new pause images, pushing them to gcr.

Ex: https://storage.googleapis.com/istio-prow/logs/build-base-images_release-builder_periodic/1515042325611417600/build-log.txt
```
 > [distroless-default] exporting to image:
------
error: failed to solve: failed commit on ref "index-sha256:d6409fdd8268333f8ed10ec1e07810e759278eee0c4c5cf78222228bb7d9e94a": cannot reuse body, request must be retried
```