### PR TITLE
Support TLSVerifySkip in http fetcher, and use context-based timeout

### DIFF
--- a/pilot/cmd/pilot-agent/options/options.go
+++ b/pilot/cmd/pilot-agent/options/options.go
@@ -102,7 +102,7 @@ var (
 		"If set to true, agent retrieves dynamic proxy-config updates via xds channel").Get()
 
 	wasmInsecureRegistries = env.RegisterStringVar("WASM_INSECURE_REGISTRIES", "",
-		"allow agent pull wasm plugin from insecure registries, for example: 'localhost:5000,docker-registry:5000'").Get()
+		"allow agent pull wasm plugin from insecure registries or https server, for example: 'localhost:5000,docker-registry:5000'").Get()
 
 	// Ability of istio-agent to retrieve bootstrap via XDS
 	enableBootstrapXdsEnv = env.RegisterBoolVar("BOOTSTRAP_XDS_AGENT", false,

--- a/pkg/wasm/cache.go
+++ b/pkg/wasm/cache.go
@@ -201,7 +201,7 @@ func (c *LocalFileCache) Get(
 	switch u.Scheme {
 	case "http", "https":
 		// Download the Wasm module with http fetcher.
-		b, err = NewHTTPFetcher(insecure).Fetch(ctx, downloadURL)
+		b, err = DefaultHTTPFetcher().Fetch(ctx, downloadURL, insecure)
 		if err != nil {
 			wasmRemoteFetchCount.With(resultTag.Value(downloadFailure)).Increment()
 			return "", err

--- a/pkg/wasm/cache.go
+++ b/pkg/wasm/cache.go
@@ -44,6 +44,13 @@ const (
 	// DefaultWasmModuleExpiry is the default duration for least recently touched Wasm module to become stale.
 	DefaultWasmModuleExpiry = 24 * time.Hour
 
+	// Default timeout per a HTTP/HTTPS request for HTTP/HTTPS-based wasm pulling.
+	DefaultWasmHTTPRequestTimeout = 5 * time.Second
+
+	// Default maximum number of HTTP/HTTPS request retries for HTTP/HTTPS-based wasm pulling.
+	// Note that, if the timeout specified in WasmPlugin is reaching out, then the pulling is stopped even though the retry count is still less than this value.
+	DefaultWasmHTTPRequestMaxRetries = 5
+
 	// oci URL prefix
 	ociURLPrefix = "oci://"
 
@@ -121,7 +128,7 @@ type cacheEntry struct {
 // NewLocalFileCache create a new Wasm module cache which downloads and stores Wasm module files locally.
 func NewLocalFileCache(dir string, purgeInterval, moduleExpiry time.Duration, insecureRegistries []string) *LocalFileCache {
 	cache := &LocalFileCache{
-		httpFetcher:        NewHTTPFetcher(5 * time.Second),
+		httpFetcher:        NewHTTPFetcher(DefaultWasmHTTPRequestTimeout),
 		modules:            make(map[moduleKey]*cacheEntry),
 		checksums:          make(map[string]*checksumEntry),
 		dir:                dir,

--- a/pkg/wasm/cache.go
+++ b/pkg/wasm/cache.go
@@ -202,10 +202,7 @@ func (c *LocalFileCache) Get(
 	// Hex-Encoded sha256 checksum of binary.
 	var dChecksum string
 	var binaryFetcher func() ([]byte, error)
-	insecure := false
-	if c.insecureRegistries.Contains(u.Host) {
-		insecure = true
-	}
+	insecure := c.insecureRegistries.Contains(u.Host)
 
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()

--- a/pkg/wasm/cache.go
+++ b/pkg/wasm/cache.go
@@ -121,7 +121,7 @@ type cacheEntry struct {
 // NewLocalFileCache create a new Wasm module cache which downloads and stores Wasm module files locally.
 func NewLocalFileCache(dir string, purgeInterval, moduleExpiry time.Duration, insecureRegistries []string) *LocalFileCache {
 	cache := &LocalFileCache{
-		httpFetcher:        NewHTTPFetcher(),
+		httpFetcher:        NewHTTPFetcher(5 * time.Second),
 		modules:            make(map[moduleKey]*cacheEntry),
 		checksums:          make(map[string]*checksumEntry),
 		dir:                dir,

--- a/pkg/wasm/cache_test.go
+++ b/pkg/wasm/cache_test.go
@@ -87,9 +87,6 @@ func TestWasmCache(t *testing.T) {
 	cacheHitSha := sha256.Sum256([]byte("cachehit"))
 	cacheHitSum := hex.EncodeToString(cacheHitSha[:])
 
-	// Shorten the initial backoff for testing
-	httpInitialBackoff = time.Microsecond
-
 	cases := []struct {
 		name                   string
 		initialCachedModules   map[moduleKey]cacheEntry
@@ -481,6 +478,7 @@ func TestWasmCache(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			tmpDir := t.TempDir()
 			cache := NewLocalFileCache(tmpDir, c.purgeInterval, c.wasmModuleExpiry, nil)
+			cache.httpFetcher.initialBackoff = time.Microsecond
 			defer close(cache.stopChan)
 
 			var cacheHitKey *moduleKey

--- a/pkg/wasm/cache_test.go
+++ b/pkg/wasm/cache_test.go
@@ -152,7 +152,7 @@ func TestWasmCache(t *testing.T) {
 			purgeInterval:          DefaultWasmModulePurgeInterval,
 			wasmModuleExpiry:       DefaultWasmModuleExpiry,
 			requestTimeout:         time.Second * 10,
-			wantErrorMsgPrefix:     "wasm module download failed, last error: Get \"https://dummyurl\"",
+			wantErrorMsgPrefix:     "wasm module download failed after 5 attempts, last error: Get \"https://dummyurl\"",
 			wantVisitServer:        false,
 		},
 		{

--- a/pkg/wasm/httpfetcher.go
+++ b/pkg/wasm/httpfetcher.go
@@ -74,6 +74,10 @@ func (f *HTTPFetcher) Fetch(ctx context.Context, url string, allowInsecure bool)
 		if err != nil {
 			lastError = err
 			wasmLog.Debugf("wasm module download request failed: %v", err)
+			if ctx.Err() != nil {
+				// If there is context timeout, exit this loop.
+				return nil, fmt.Errorf("wasm module download failed after %v attempts, last error: %v", attempts, lastError)
+			}
 			time.Sleep(b.NextBackOff())
 			continue
 		}
@@ -93,7 +97,7 @@ func (f *HTTPFetcher) Fetch(ctx context.Context, url string, allowInsecure bool)
 		resp.Body.Close()
 		break
 	}
-	return nil, fmt.Errorf("wasm module download failed, last error: %v", lastError)
+	return nil, fmt.Errorf("wasm module download failed after %v attempts, last error: %v", attempts, lastError)
 }
 
 func retryable(code int) bool {

--- a/pkg/wasm/httpfetcher.go
+++ b/pkg/wasm/httpfetcher.go
@@ -63,7 +63,7 @@ func (f *HTTPFetcher) Fetch(ctx context.Context, url string, allowInsecure bool)
 	b.InitialInterval = f.initialBackoff
 	b.Reset()
 	var lastError error
-	for attempts < 5 {
+	for attempts < DefaultWasmHTTPRequestMaxRetries {
 		attempts++
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 		if err != nil {

--- a/pkg/wasm/httpfetcher.go
+++ b/pkg/wasm/httpfetcher.go
@@ -67,7 +67,6 @@ func (f *HTTPFetcher) Fetch(ctx context.Context, url string, allowInsecure bool)
 		attempts++
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 		if err != nil {
-			lastError = err
 			wasmLog.Debugf("wasm module download request failed: %v", err)
 			return nil, err
 		}

--- a/pkg/wasm/httpfetcher.go
+++ b/pkg/wasm/httpfetcher.go
@@ -33,12 +33,19 @@ type HTTPFetcher struct {
 }
 
 // NewHTTPFetcher create a new HTTP remote wasm module fetcher.
-func NewHTTPFetcher() *HTTPFetcher {
+// requestTimeout is a timeout for each HTTP/HTTPS request.
+func NewHTTPFetcher(requestTimeout time.Duration) *HTTPFetcher {
+	if requestTimeout == 0 {
+		requestTimeout = 5 * time.Second
+	}
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	return &HTTPFetcher{
-		client: &http.Client{},
+		client: &http.Client{
+			Timeout: requestTimeout,
+		},
 		insecureClient: &http.Client{
+			Timeout:   requestTimeout,
 			Transport: transport,
 		},
 		initialBackoff: time.Millisecond * 500,

--- a/pkg/wasm/httpfetcher_test.go
+++ b/pkg/wasm/httpfetcher_test.go
@@ -102,7 +102,7 @@ func TestWasmHTTPInsecureServer(t *testing.T) {
 		wantErrorSuffix string
 	}{
 		{
-			name: "download ok",
+			name: "download fail",
 			handler: func(w http.ResponseWriter, r *http.Request, num int) {
 				fmt.Fprintln(w, "wasm")
 			},

--- a/pkg/wasm/httpfetcher_test.go
+++ b/pkg/wasm/httpfetcher_test.go
@@ -62,7 +62,7 @@ func TestWasmHTTPFetch(t *testing.T) {
 			},
 			timeout:        5 * time.Second,
 			wantNumRequest: 5,
-			wantErrorRegex: "wasm module download failed, last error: wasm module download request failed: status code 500",
+			wantErrorRegex: "wasm module download failed after 5 attempts, last error: wasm module download request failed: status code 500",
 		},
 		{
 			name: "download is never tried by immediate context timeout",
@@ -71,7 +71,7 @@ func TestWasmHTTPFetch(t *testing.T) {
 			},
 			timeout:        0, // Immediately timeout in the context level.
 			wantNumRequest: 0, // Should not retried because it is already timed out.
-			wantErrorRegex: "wasm module download failed, last error: Get \".*\": context deadline exceeded",
+			wantErrorRegex: "wasm module download failed after 1 attempts, last error: Get \"[^\"]+\": context deadline exceeded",
 		},
 	}
 
@@ -95,7 +95,7 @@ func TestWasmHTTPFetch(t *testing.T) {
 			if c.wantErrorRegex != "" {
 				if err == nil {
 					t.Errorf("Wasm download got no error, want error regex `%v`", c.wantErrorRegex)
-				} else if matched, err := regexp.MatchString(c.wantErrorRegex, err.Error()); err != nil || !matched {
+				} else if matched, regexErr := regexp.MatchString(c.wantErrorRegex, err.Error()); regexErr != nil || !matched {
 					t.Errorf("Wasm download got error `%v`, want error regex `%v`", err, c.wantErrorRegex)
 				}
 			} else if string(b) != wantWasmModule {

--- a/pkg/wasm/httpfetcher_test.go
+++ b/pkg/wasm/httpfetcher_test.go
@@ -27,9 +27,6 @@ import (
 func TestWasmHTTPFetch(t *testing.T) {
 	var ts *httptest.Server
 
-	// Shorten the initial backoff for testing
-	httpInitialBackoff = time.Microsecond
-
 	cases := []struct {
 		name           string
 		handler        func(http.ResponseWriter, *http.Request, int)
@@ -74,6 +71,7 @@ func TestWasmHTTPFetch(t *testing.T) {
 			}))
 			defer ts.Close()
 			fetcher := NewHTTPFetcher()
+			fetcher.initialBackoff = time.Microsecond
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 			b, err := fetcher.Fetch(ctx, ts.URL, false)
@@ -95,9 +93,6 @@ func TestWasmHTTPFetch(t *testing.T) {
 
 func TestWasmHTTPInsecureServer(t *testing.T) {
 	var ts *httptest.Server
-
-	// Shorten the initial backoff for testing
-	httpInitialBackoff = time.Microsecond
 
 	cases := []struct {
 		name            string
@@ -135,6 +130,7 @@ func TestWasmHTTPInsecureServer(t *testing.T) {
 			}))
 			defer ts.Close()
 			fetcher := NewHTTPFetcher()
+			fetcher.initialBackoff = time.Microsecond
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 			b, err := fetcher.Fetch(ctx, ts.URL, c.insecure)

--- a/pkg/wasm/httpfetcher_test.go
+++ b/pkg/wasm/httpfetcher_test.go
@@ -72,10 +72,10 @@ func TestWasmHTTPFetch(t *testing.T) {
 				gotNumRequest++
 			}))
 			defer ts.Close()
-			fetcher := NewHTTPFetcher(true)
+			fetcher := NewHTTPFetcher()
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
-			b, err := fetcher.Fetch(ctx, ts.URL)
+			b, err := fetcher.Fetch(ctx, ts.URL, false)
 			if c.wantNumRequest != gotNumRequest {
 				t.Errorf("Wasm download request got %v, want %v", gotNumRequest, c.wantNumRequest)
 			}

--- a/releasenotes/notes/wasm-https-insecure-support.yaml
+++ b/releasenotes/notes/wasm-https-insecure-support.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: feature
+area: extensibility
+issue: []
+releaseNotes:
+  - |
+    **Added** WASM_INSECURE_REGISTRIES environment variable of istio-agent is also honored when the WasmPlugin is pointing http/https server.


### PR DESCRIPTION
Supports InsecureSkipVerify of TLSClientConfig option in http fetcher as well.
In addition, instead of setting timeout on HTTP Client, use context-based timeout in order to match the API pattern with image fetcher.

- [ * ] Policies and Telemetry