### PR TITLE
[tf] Fix deadlock for Parallel tests

### DIFF
--- a/pkg/test/framework/suitecontext.go
+++ b/pkg/test/framework/suitecontext.go
@@ -33,7 +33,7 @@ import (
 	"istio.io/istio/pkg/util/sets"
 )
 
-// suiteContext contains suite-level items used during runtime.
+// SuiteContext contains suite-level items used during runtime.
 type SuiteContext interface {
 	resource.Context
 }
@@ -224,8 +224,6 @@ type TestOutcome struct {
 }
 
 func (s *suiteContext) registerOutcome(test *testImpl) {
-	s.outcomeMu.Lock()
-	defer s.outcomeMu.Unlock()
 	o := Passed
 	if test.notImplemented {
 		o = NotImplemented


### PR DESCRIPTION
I ran into a deadlock condition when running a number of nested parallel tests. Basically, some tests were stuck logging `Stuck waiting for parent test suites to terminate...`.

I recreated the issue in framework_test.go and the fix in this PR also fixes this test.

**Please provide a description of this PR:**