### PR TITLE
Revert "Update BASE_VERSION to master-2022-04-25T21-27-27"

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -22,7 +22,7 @@ SHELL := /bin/bash -o pipefail
 export VERSION ?= 1.14-dev
 
 # Base version of Istio image to use
-BASE_VERSION ?= master-2022-04-25T21-27-27
+BASE_VERSION ?= master-2022-04-12T19-01-34
 
 export GO111MODULE ?= on
 export GOPROXY ?= https://proxy.golang.org


### PR DESCRIPTION
Based on an offline discussion with @ericvn @GregHanson, due to the 1.14 release timeline and the fact that Ubuntu Jammy is only released a week ago, we plan to leaving the transition to Ubuntu Jammy for Istio 1.15. The Ubuntu Focal currently used has an EOL until April 2025. Hence this PR to revert istio/istio#38575.