### PR TITLE
Revert "Update BASE_VERSION to master-2022-04-25T20-21-10"

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -22,7 +22,7 @@ SHELL := /bin/bash -o pipefail
 export VERSION ?= 1.15-dev
 
 # Base version of Istio image to use
-BASE_VERSION ?= master-2022-04-25T20-21-10
+BASE_VERSION ?= master-2022-04-12T19-01-34
 
 export GO111MODULE ?= on
 export GOPROXY ?= https://proxy.golang.org


### PR DESCRIPTION
Reverts istio/istio#38572

Let's revert this so that we get a new set of build images during tomorrow's automated check. This set of base images will be based on Jammy due to https://github.com/istio/istio/pull/38577.