### PR TITLE
renamed DefaultClusterLocalDomain from DefaultKubernetesDomain

### DIFF
--- a/istioctl/cmd/add-to-mesh.go
+++ b/istioctl/cmd/add-to-mesh.go
@@ -555,7 +555,7 @@ func generateServiceEntry(u *unstructured.Unstructured, o *vmServiceOpts) error 
 			Labels:  o.Labels,
 		})
 	}
-	host := fmt.Sprintf("%v.%v.svc.%s", o.Name, o.Namespace, constants.DefaultKubernetesDomain)
+	host := fmt.Sprintf("%v.%v.svc.%s", o.Name, o.Namespace, constants.DefaultClusterLocalDomain)
 	spec := &v1alpha3.ServiceEntry{
 		Hosts:      []string{host},
 		Ports:      ports,

--- a/istioctl/cmd/describe.go
+++ b/istioctl/cmd/describe.go
@@ -69,7 +69,7 @@ type myProtoValue struct {
 }
 
 const (
-	k8sSuffix = ".svc." + constants.DefaultKubernetesDomain
+	k8sSuffix = ".svc." + constants.DefaultClusterLocalDomain
 )
 
 var (

--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -236,7 +236,7 @@ func initStsServer(proxy *model.Proxy, tokenManager security.TokenManager) (*sts
 
 func getDNSDomain(podNamespace, domain string) string {
 	if len(domain) == 0 {
-		domain = podNamespace + ".svc." + constants.DefaultKubernetesDomain
+		domain = podNamespace + ".svc." + constants.DefaultClusterLocalDomain
 	}
 	return domain
 }

--- a/pilot/cmd/pilot-discovery/app/cmd.go
+++ b/pilot/cmd/pilot-discovery/app/cmd.go
@@ -141,7 +141,7 @@ func addFlags(c *cobra.Command) {
 	// RegistryOptions Controller options
 	c.PersistentFlags().StringVar(&serverArgs.RegistryOptions.FileDir, "configDir", "",
 		"Directory to watch for updates to config yaml files. If specified, the files will be used as the source of config, rather than a CRD client.")
-	c.PersistentFlags().StringVar(&serverArgs.RegistryOptions.KubeOptions.DomainSuffix, "domain", constants.DefaultKubernetesDomain,
+	c.PersistentFlags().StringVar(&serverArgs.RegistryOptions.KubeOptions.DomainSuffix, "domain", constants.DefaultClusterLocalDomain,
 		"DNS domain suffix")
 	c.PersistentFlags().StringVar((*string)(&serverArgs.RegistryOptions.KubeOptions.ClusterID), "clusterID", features.ClusterName,
 		"The ID of the cluster that this Istiod instance resides")

--- a/pilot/pkg/bootstrap/server_test.go
+++ b/pilot/pkg/bootstrap/server_test.go
@@ -249,12 +249,12 @@ func TestNewServer(t *testing.T) {
 		{
 			name:           "default domain",
 			domain:         "",
-			expectedDomain: constants.DefaultKubernetesDomain,
+			expectedDomain: constants.DefaultClusterLocalDomain,
 		},
 		{
 			name:           "default domain with JwtRule",
 			domain:         "",
-			expectedDomain: constants.DefaultKubernetesDomain,
+			expectedDomain: constants.DefaultClusterLocalDomain,
 			jwtRule:        `{"issuer": "foo", "jwks_uri": "baz", "audiences": ["aud1", "aud2"]}`,
 		},
 		{
@@ -265,7 +265,7 @@ func TestNewServer(t *testing.T) {
 		{
 			name:             "override default secured grpc port",
 			domain:           "",
-			expectedDomain:   constants.DefaultKubernetesDomain,
+			expectedDomain:   constants.DefaultClusterLocalDomain,
 			enableSecureGRPC: true,
 		},
 	}

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -143,7 +143,7 @@ func (e *Environment) Version() string {
 func (e *Environment) Init() {
 	// Use a default DomainSuffix, if none was provided.
 	if len(e.DomainSuffix) == 0 {
-		e.DomainSuffix = constants.DefaultKubernetesDomain
+		e.DomainSuffix = constants.DefaultClusterLocalDomain
 	}
 
 	// Create the cluster-local service registry.

--- a/pilot/pkg/security/trustdomain/bundle.go
+++ b/pilot/pkg/security/trustdomain/bundle.go
@@ -67,7 +67,7 @@ func (t Bundle) ReplaceTrustDomainAliases(principals []string) []string {
 		// Only generate configuration if the extracted trust domain from the policy is part of the trust domain list,
 		// or if the extracted/existing trust domain is "cluster.local", which is a pointer to the local trust domain
 		// and its aliases.
-		if stringMatch(trustDomainFromPrincipal, t.TrustDomains) || trustDomainFromPrincipal == constants.DefaultKubernetesDomain {
+		if stringMatch(trustDomainFromPrincipal, t.TrustDomains) || trustDomainFromPrincipal == constants.DefaultClusterLocalDomain {
 			// Generate configuration for trust domain and trust domain aliases.
 			principalsIncludingAliases = append(principalsIncludingAliases, t.replaceTrustDomains(principal, trustDomainFromPrincipal)...)
 		} else {

--- a/pkg/adsc/adsc.go
+++ b/pkg/adsc/adsc.go
@@ -293,7 +293,7 @@ func New(discoveryAddr string, opts *Config) (*ADSC, error) {
 	adsc.Locality = opts.Locality
 
 	adsc.nodeID = fmt.Sprintf("%s~%s~%s.%s~%s.svc.%s", opts.NodeType, opts.IP,
-		opts.Workload, opts.Namespace, opts.Namespace, constants.DefaultKubernetesDomain)
+		opts.Workload, opts.Namespace, opts.Namespace, constants.DefaultClusterLocalDomain)
 
 	if err := adsc.Dial(); err != nil {
 		return nil, err

--- a/pkg/config/analysis/analyzers/util/constants.go
+++ b/pkg/config/analysis/analyzers/util/constants.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	DefaultKubernetesDomain    = "svc." + constants.DefaultKubernetesDomain
+	DefaultClusterLocalDomain  = "svc." + constants.DefaultClusterLocalDomain
 	ExportToNamespaceLocal     = "."
 	ExportToAllNamespaces      = "*"
 	IstioProxyName             = "istio-proxy"

--- a/pkg/config/analysis/analyzers/util/hosts.go
+++ b/pkg/config/analysis/analyzers/util/hosts.go
@@ -78,7 +78,7 @@ func ConvertHostToFQDN(namespace resource.Namespace, host string) string {
 	// Convert to FQDN only if host is not a wildcard or a FQDN
 	if !strings.HasPrefix(host, "*") &&
 		!strings.Contains(host, ".") {
-		fqdn = host + "." + string(namespace) + "." + DefaultKubernetesDomain
+		fqdn = host + "." + string(namespace) + "." + DefaultClusterLocalDomain
 	}
 	return fqdn
 }

--- a/pkg/config/constants/constants.go
+++ b/pkg/config/constants/constants.go
@@ -59,10 +59,9 @@ const (
 	// IstioIngressNamespace is the namespace where Istio ingress controller is deployed
 	IstioIngressNamespace = "istio-system"
 
-	// DefaultKubernetesDomain the default service domain suffix for Kubernetes, if not overridden in config.
-	// TODO(nmittler): Rename this to DefaultClusterLocalDomain.
-	// TODO(nmittler): Search/replace explicit usages of the string with this constant.
-	DefaultKubernetesDomain = "cluster.local"
+	// DefaultClusterLocalDomain the default service domain suffix for Kubernetes, if not overridden in config.
+	// TODO(nmittler): Renamed DefaultKubernetesDomain to DefaultClusterLocalDomain
+	DefaultClusterLocalDomain = "cluster.local"
 
 	// DefaultClusterSetLocalDomain is the default domain suffix for Kubernetes Multi-Cluster Services (MCS)
 	// used for load balancing requests against endpoints across the ClusterSet (i.e. mesh).

--- a/pkg/config/mesh/mesh.go
+++ b/pkg/config/mesh/mesh.go
@@ -86,7 +86,7 @@ func DefaultMeshConfig() *meshconfig.MeshConfig {
 		IngressService:              "istio-ingressgateway",
 		IngressControllerMode:       meshconfig.MeshConfig_STRICT,
 		IngressClass:                "istio",
-		TrustDomain:                 constants.DefaultKubernetesDomain,
+		TrustDomain:                 constants.DefaultClusterLocalDomain,
 		TrustDomainAliases:          []string{},
 		EnableAutoMtls:              &wrappers.BoolValue{Value: true},
 		OutboundTrafficPolicy:       &meshconfig.MeshConfig_OutboundTrafficPolicy{Mode: meshconfig.MeshConfig_OutboundTrafficPolicy_ALLOW_ANY},

--- a/pkg/spiffe/spiffe.go
+++ b/pkg/spiffe/spiffe.go
@@ -40,7 +40,7 @@ const (
 	URIPrefixLen = len(URIPrefix)
 
 	// The default SPIFFE URL value for trust domain
-	defaultTrustDomain = constants.DefaultKubernetesDomain
+	defaultTrustDomain = constants.DefaultClusterLocalDomain
 
 	ServiceAccountSegment = "sa"
 	NamespaceSegment      = "ns"

--- a/pkg/test/framework/components/echo/config.go
+++ b/pkg/test/framework/components/echo/config.go
@@ -289,7 +289,7 @@ const (
 	defaultService   = "echo"
 	defaultVersion   = "v1"
 	defaultNamespace = "echo"
-	defaultDomain    = constants.DefaultKubernetesDomain
+	defaultDomain    = constants.DefaultClusterLocalDomain
 )
 
 func (c *Config) FillDefaults(ctx resource.Context) (err error) {


### PR DESCRIPTION
**Please provide a description of this PR:**
Renamed DefaultClusterLocalDomain from DefaultKubernetesDomain as mentioned TODO in the **istio/pkg/config/constants/constants.go**