### PR TITLE
Using tag/digest trimmed URL for OCI images and having tagged URL to digest

### DIFF
--- a/pkg/wasm/cache.go
+++ b/pkg/wasm/cache.go
@@ -28,9 +28,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/go-containerregistry/pkg/name"
 	"istio.io/istio/pkg/util/sets"
 	"istio.io/pkg/log"
+
+	"github.com/google/go-containerregistry/pkg/name"
 )
 
 var wasmLog = log.RegisterScope("wasm", "", 0)

--- a/pkg/wasm/cache.go
+++ b/pkg/wasm/cache.go
@@ -28,10 +28,10 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/go-containerregistry/pkg/name"
+
 	"istio.io/istio/pkg/util/sets"
 	"istio.io/pkg/log"
-
-	"github.com/google/go-containerregistry/pkg/name"
 )
 
 var wasmLog = log.RegisterScope("wasm", "", 0)

--- a/pkg/wasm/cache.go
+++ b/pkg/wasm/cache.go
@@ -86,7 +86,7 @@ var _ Cache = &LocalFileCache{}
 type moduleKey struct {
 	// Identifier for the module. It should be neutral for the checksum.
 	// e.g.) oci://docker.io/test@sha256:0123456789 is not allowed.
-	//       oci://docker.io/test@latest (tagged form) is allowed.
+	//       oci://docker.io/test:latest (tagged form) is allowed.
 	name     string
 	checksum string
 }

--- a/pkg/wasm/cache.go
+++ b/pkg/wasm/cache.go
@@ -24,9 +24,11 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
+	"github.com/google/go-containerregistry/pkg/name"
 	"istio.io/istio/pkg/util/sets"
 	"istio.io/pkg/log"
 )
@@ -39,6 +41,12 @@ const (
 
 	// DefaultWasmModuleExpiry is the default duration for least recently touched Wasm module to become stale.
 	DefaultWasmModuleExpiry = 24 * time.Hour
+
+	// oci URL prefix
+	ociURLPrefix = "oci://"
+
+	// sha256 scheme prefix
+	sha256SchemePrefix = "sha256:"
 )
 
 // Cache models a Wasm module cache.
@@ -50,7 +58,9 @@ type Cache interface {
 // LocalFileCache for downloaded Wasm modules. Currently it stores the Wasm module as local file.
 type LocalFileCache struct {
 	// Map from Wasm module checksum to cache entry.
-	modules map[cacheKey]*cacheEntry
+	modules map[moduleKey]*cacheEntry
+	// Map from tagged URL to checksum
+	checksums map[string]string
 
 	// http fetcher fetches Wasm module with HTTP get.
 	httpFetcher *HTTPFetcher
@@ -72,25 +82,35 @@ type LocalFileCache struct {
 
 var _ Cache = &LocalFileCache{}
 
+type moduleKey struct {
+	// Identifier for the module. It should be neutral for the checksum.
+	// e.g.) oci://docker.io/test@sha256:0123456789 is not allowed.
+	//       oci://docker.io/test@latest (tagged form) is allowed.
+	name     string
+	checksum string
+}
+
 type cacheKey struct {
+	moduleKey
 	downloadURL string
-	checksum    string
 }
 
 // cacheEntry contains information about a Wasm module cache entry.
 type cacheEntry struct {
 	// File path to the downloaded wasm modules.
 	modulePath string
-
 	// Last time that this local Wasm module is referenced.
 	last time.Time
+	// set of URLs referencing this entry
+	referencingURLs sets.Set
 }
 
 // NewLocalFileCache create a new Wasm module cache which downloads and stores Wasm module files locally.
 func NewLocalFileCache(dir string, purgeInterval, moduleExpiry time.Duration, insecureRegistries []string) *LocalFileCache {
 	cache := &LocalFileCache{
 		httpFetcher:        NewHTTPFetcher(),
-		modules:            make(map[cacheKey]*cacheEntry),
+		modules:            make(map[moduleKey]*cacheEntry),
+		checksums:          make(map[string]string),
 		dir:                dir,
 		purgeInterval:      purgeInterval,
 		wasmModuleExpiry:   moduleExpiry,
@@ -103,12 +123,25 @@ func NewLocalFileCache(dir string, purgeInterval, moduleExpiry time.Duration, in
 	return cache
 }
 
+func urlAsResourceName(fullURLStr string) string {
+	if strings.HasPrefix(fullURLStr, ociURLPrefix) {
+		if tag, err := name.ParseReference(fullURLStr[len(ociURLPrefix):]); err == nil {
+			// remove tag or sha
+			return ociURLPrefix + tag.Context().Name()
+		}
+	}
+	return fullURLStr
+}
+
 // Get returns path the local Wasm module file.
 func (c *LocalFileCache) Get(downloadURL, checksum string, timeout time.Duration, pullSecret []byte) (string, error) {
 	// Construct Wasm cache key with downloading URL and provided checksum of the module.
 	key := cacheKey{
 		downloadURL: downloadURL,
-		checksum:    checksum,
+		moduleKey: moduleKey{
+			name:     urlAsResourceName(downloadURL),
+			checksum: checksum,
+		},
 	}
 
 	// First check if the cache entry is already downloaded.
@@ -206,13 +239,23 @@ func (c *LocalFileCache) Cleanup() {
 }
 
 func (c *LocalFileCache) addEntry(key cacheKey, wasmModule []byte, f string) error {
+	// If OCI URL having a tag, we need to update checksum.
+	needChecksumUpdate := strings.HasPrefix(key.downloadURL, ociURLPrefix) && !strings.Contains(key.downloadURL, "@")
+
 	c.mux.Lock()
 	defer c.mux.Unlock()
 
+	if needChecksumUpdate {
+		c.checksums[key.downloadURL] = key.checksum
+	}
+
 	// Check if the module has already been added. If so, avoid writing the file again.
-	if ce, ok := c.modules[key]; ok {
+	if ce, ok := c.modules[key.moduleKey]; ok {
 		// Update last touched time.
 		ce.last = time.Now()
+		if needChecksumUpdate {
+			ce.referencingURLs.Insert(key.downloadURL)
+		}
 		return nil
 	}
 
@@ -222,10 +265,14 @@ func (c *LocalFileCache) addEntry(key cacheKey, wasmModule []byte, f string) err
 	}
 
 	ce := cacheEntry{
-		modulePath: f,
-		last:       time.Now(),
+		modulePath:      f,
+		last:            time.Now(),
+		referencingURLs: sets.New(),
 	}
-	c.modules[key] = &ce
+	if needChecksumUpdate {
+		ce.referencingURLs.Insert(key.downloadURL)
+	}
+	c.modules[key.moduleKey] = &ce
 	wasmCacheEntries.Record(float64(len(c.modules)))
 	return nil
 }
@@ -233,9 +280,28 @@ func (c *LocalFileCache) addEntry(key cacheKey, wasmModule []byte, f string) err
 func (c *LocalFileCache) getEntry(key cacheKey) string {
 	modulePath := ""
 	cacheHit := false
+
+	// Only apply this for OCI image, not http/https because OCI image has ImagePullPolicy
+	// to control the pull policy, but http/https currently rely on existence of checksum.
+	// At this point, we don't need to break the current behavior for http/https.
+	if len(key.checksum) == 0 && strings.HasPrefix(key.downloadURL, ociURLPrefix) {
+		if d, err := name.NewDigest(key.downloadURL[len(ociURLPrefix):]); err == nil {
+			// If there is no checksum and the digest is suffixed in URL, use the digest.
+			dstr := d.DigestStr()
+			if strings.HasPrefix(dstr, sha256SchemePrefix) {
+				key.checksum = dstr[len(sha256SchemePrefix):]
+			}
+			// For other digest scheme, give up to use cache.
+		} else {
+			// If no checksum, try the checksum cache.
+			// If the image was pulled before, there should be a checksum of the most recently pulled image.
+			key.checksum = c.checksums[key.downloadURL]
+		}
+	}
+
 	c.mux.Lock()
 	defer c.mux.Unlock()
-	if ce, ok := c.modules[key]; ok {
+	if ce, ok := c.modules[key.moduleKey]; ok {
 		// Update last touched time.
 		ce.last = time.Now()
 		modulePath = ce.modulePath
@@ -259,6 +325,9 @@ func (c *LocalFileCache) purge() {
 					if err := os.Remove(m.modulePath); err != nil {
 						wasmLog.Errorf("failed to purge Wasm module %v: %v", m.modulePath, err)
 					} else {
+						for downloadURL := range m.referencingURLs {
+							delete(c.checksums, downloadURL)
+						}
 						delete(c.modules, k)
 						wasmLog.Debugf("successfully removed stale Wasm module %v", m.modulePath)
 					}

--- a/pkg/wasm/cache_test.go
+++ b/pkg/wasm/cache_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/types"
+	"istio.io/istio/pkg/util/sets"
 )
 
 // Wasm header = magic number (4 bytes) + Wasm spec version (4 bytes).
@@ -58,174 +59,277 @@ func TestWasmCache(t *testing.T) {
 	invalidHTTPDataSha := sha256.Sum256(invalidHTTPData)
 	invalidHTTPDataCheckSum := hex.EncodeToString(invalidHTTPDataSha[:])
 
+	reg := registry.New()
+	registryVisited := false
 	// Set up a fake registry for OCI images.
-	tos := httptest.NewServer(registry.New())
+	tos := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		registryVisited = true
+		reg.ServeHTTP(w, r)
+	}))
 	defer tos.Close()
 	ou, err := url.Parse(tos.URL)
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	_, dockerImageDigest, invalidOCIImageDigest := setupOCIRegistry(t, ou.Host)
+
+	ociURLWithTag := fmt.Sprintf("oci://%s/test/valid/docker:v0.1.0", ou.Host)
+	ociURLWithDigest := fmt.Sprintf("oci://%s/test/valid/docker@sha256:%s", ou.Host, dockerImageDigest)
 
 	// Calculate cachehit sum.
 	cacheHitSha := sha256.Sum256([]byte("cachehit"))
 	cacheHitSum := hex.EncodeToString(cacheHitSha[:])
 
 	cases := []struct {
-		name                 string
-		initialCachedModules map[cacheKey]cacheEntry
-		fetchURL             string
-		purgeInterval        time.Duration
-		wasmModuleExpiry     time.Duration
-		checkPurgeTimeout    time.Duration
-		checksum             string // Hex-encoded string.
-		requestTimeout       time.Duration
-		wantFileName         string
-		wantErrorMsgPrefix   string
-		wantServerReqNum     int
+		name                   string
+		initialCachedModules   map[moduleKey]cacheEntry
+		initialCachedChecksums map[string]string
+		fetchURL               string
+		purgeInterval          time.Duration
+		wasmModuleExpiry       time.Duration
+		checkPurgeTimeout      time.Duration
+		checksum               string // Hex-encoded string.
+		requestTimeout         time.Duration
+		wantFileName           string
+		wantErrorMsgPrefix     string
+		wantServerReqNum       int
+		wantVisitRegistry      bool
+		wantURLPurged          string
 	}{
 		{
-			name:                 "cache miss",
-			initialCachedModules: map[cacheKey]cacheEntry{},
-			fetchURL:             ts.URL,
-			purgeInterval:        DefaultWasmModulePurgeInterval,
-			wasmModuleExpiry:     DefaultWasmModuleExpiry,
-			checksum:             httpDataCheckSum,
-			wantFileName:         fmt.Sprintf("%s.wasm", httpDataCheckSum),
-			wantServerReqNum:     1,
+			name:                   "cache miss",
+			initialCachedModules:   map[moduleKey]cacheEntry{},
+			initialCachedChecksums: map[string]string{},
+			fetchURL:               ts.URL,
+			purgeInterval:          DefaultWasmModulePurgeInterval,
+			wasmModuleExpiry:       DefaultWasmModuleExpiry,
+			checksum:               httpDataCheckSum,
+			wantFileName:           fmt.Sprintf("%s.wasm", httpDataCheckSum),
+			wantServerReqNum:       1,
 		},
 		{
 			name: "cache hit",
-			initialCachedModules: map[cacheKey]cacheEntry{
-				{downloadURL: ts.URL, checksum: cacheHitSum}: {modulePath: "test.wasm"},
+			initialCachedModules: map[moduleKey]cacheEntry{
+				{name: urlAsResourceName(ts.URL), checksum: cacheHitSum}: {modulePath: "test.wasm"},
 			},
-			fetchURL:         ts.URL,
-			purgeInterval:    DefaultWasmModulePurgeInterval,
-			wasmModuleExpiry: DefaultWasmModuleExpiry,
-			checksum:         cacheHitSum,
-			wantFileName:     "test.wasm",
-			wantServerReqNum: 0,
+			initialCachedChecksums: map[string]string{},
+			fetchURL:               ts.URL,
+			purgeInterval:          DefaultWasmModulePurgeInterval,
+			wasmModuleExpiry:       DefaultWasmModuleExpiry,
+			checksum:               cacheHitSum,
+			wantFileName:           "test.wasm",
+			wantServerReqNum:       0,
 		},
 		{
-			name:                 "invalid scheme",
-			initialCachedModules: map[cacheKey]cacheEntry{},
-			fetchURL:             "foo://abc",
-			purgeInterval:        DefaultWasmModulePurgeInterval,
-			wasmModuleExpiry:     DefaultWasmModuleExpiry,
-			checksum:             httpDataCheckSum,
-			wantFileName:         fmt.Sprintf("%s.wasm", httpDataCheckSum),
-			wantErrorMsgPrefix:   "unsupported Wasm module downloading URL scheme: foo",
-			wantServerReqNum:     0,
+			name:                   "invalid scheme",
+			initialCachedModules:   map[moduleKey]cacheEntry{},
+			initialCachedChecksums: map[string]string{},
+			fetchURL:               "foo://abc",
+			purgeInterval:          DefaultWasmModulePurgeInterval,
+			wasmModuleExpiry:       DefaultWasmModuleExpiry,
+			checksum:               httpDataCheckSum,
+			wantFileName:           fmt.Sprintf("%s.wasm", httpDataCheckSum),
+			wantErrorMsgPrefix:     "unsupported Wasm module downloading URL scheme: foo",
+			wantServerReqNum:       0,
 		},
 		{
-			name:                 "download failure",
-			initialCachedModules: map[cacheKey]cacheEntry{},
-			fetchURL:             "https://dummyurl",
-			purgeInterval:        DefaultWasmModulePurgeInterval,
-			wasmModuleExpiry:     DefaultWasmModuleExpiry,
-			wantErrorMsgPrefix:   "wasm module download failed, last error: Get \"https://dummyurl\"",
-			wantServerReqNum:     0,
+			name:                   "download failure",
+			initialCachedModules:   map[moduleKey]cacheEntry{},
+			initialCachedChecksums: map[string]string{},
+			fetchURL:               "https://dummyurl",
+			purgeInterval:          DefaultWasmModulePurgeInterval,
+			wasmModuleExpiry:       DefaultWasmModuleExpiry,
+			wantErrorMsgPrefix:     "wasm module download failed, last error: Get \"https://dummyurl\"",
+			wantServerReqNum:       0,
 		},
 		{
-			name:                 "wrong checksum",
-			initialCachedModules: map[cacheKey]cacheEntry{},
-			fetchURL:             ts.URL,
-			purgeInterval:        DefaultWasmModulePurgeInterval,
-			wasmModuleExpiry:     DefaultWasmModuleExpiry,
-			checksum:             "wrongchecksum\n",
-			wantErrorMsgPrefix:   fmt.Sprintf("module downloaded from %v has checksum %s, which does not match", ts.URL, httpDataCheckSum),
-			wantServerReqNum:     1,
+			name:                   "wrong checksum",
+			initialCachedModules:   map[moduleKey]cacheEntry{},
+			initialCachedChecksums: map[string]string{},
+			fetchURL:               ts.URL,
+			purgeInterval:          DefaultWasmModulePurgeInterval,
+			wasmModuleExpiry:       DefaultWasmModuleExpiry,
+			checksum:               "wrongchecksum\n",
+			wantErrorMsgPrefix:     fmt.Sprintf("module downloaded from %v has checksum %s, which does not match", ts.URL, httpDataCheckSum),
+			wantServerReqNum:       1,
 		},
 		{
 			// this might be common error in user configuration, that url was updated, but not checksum.
 			// Test that downloading still proceeds and error returns.
 			name: "different url same checksum",
-			initialCachedModules: map[cacheKey]cacheEntry{
-				{downloadURL: ts.URL, checksum: httpDataCheckSum}: {modulePath: fmt.Sprintf("%s.wasm", httpDataCheckSum)},
+			initialCachedModules: map[moduleKey]cacheEntry{
+				{name: urlAsResourceName(ts.URL), checksum: httpDataCheckSum}: {modulePath: fmt.Sprintf("%s.wasm", httpDataCheckSum)},
 			},
-			fetchURL:           ts.URL + "/different-url",
-			purgeInterval:      DefaultWasmModulePurgeInterval,
-			wasmModuleExpiry:   DefaultWasmModuleExpiry,
-			checksum:           httpDataCheckSum,
-			wantErrorMsgPrefix: fmt.Sprintf("module downloaded from %v/different-url has checksum", ts.URL),
-			wantServerReqNum:   1,
+			initialCachedChecksums: map[string]string{},
+			fetchURL:               ts.URL + "/different-url",
+			purgeInterval:          DefaultWasmModulePurgeInterval,
+			wasmModuleExpiry:       DefaultWasmModuleExpiry,
+			checksum:               httpDataCheckSum,
+			wantErrorMsgPrefix:     fmt.Sprintf("module downloaded from %v/different-url has checksum", ts.URL),
+			wantServerReqNum:       1,
 		},
 		{
 			name: "invalid wasm header",
-			initialCachedModules: map[cacheKey]cacheEntry{
-				{downloadURL: ts.URL, checksum: httpDataCheckSum}: {modulePath: fmt.Sprintf("%s.wasm", httpDataCheckSum)},
+			initialCachedModules: map[moduleKey]cacheEntry{
+				{name: urlAsResourceName(ts.URL), checksum: httpDataCheckSum}: {modulePath: fmt.Sprintf("%s.wasm", httpDataCheckSum)},
 			},
-			fetchURL:           ts.URL + "/invalid-wasm-header",
-			purgeInterval:      DefaultWasmModulePurgeInterval,
-			wasmModuleExpiry:   DefaultWasmModuleExpiry,
-			checksum:           invalidHTTPDataCheckSum,
-			wantErrorMsgPrefix: fmt.Sprintf("fetched Wasm binary from %s is invalid", ts.URL+"/invalid-wasm-header"),
-			wantServerReqNum:   1,
+			initialCachedChecksums: map[string]string{},
+			fetchURL:               ts.URL + "/invalid-wasm-header",
+			purgeInterval:          DefaultWasmModulePurgeInterval,
+			wasmModuleExpiry:       DefaultWasmModuleExpiry,
+			checksum:               invalidHTTPDataCheckSum,
+			wantErrorMsgPrefix:     fmt.Sprintf("fetched Wasm binary from %s is invalid", ts.URL+"/invalid-wasm-header"),
+			wantServerReqNum:       1,
 		},
 		{
 			name: "purge on expiry",
-			initialCachedModules: map[cacheKey]cacheEntry{
-				{downloadURL: ts.URL, checksum: httpDataCheckSum}: {modulePath: fmt.Sprintf("%s.wasm", httpDataCheckSum)},
+			initialCachedModules: map[moduleKey]cacheEntry{
+				{name: urlAsResourceName(ts.URL), checksum: httpDataCheckSum}: {modulePath: fmt.Sprintf("%s.wasm", httpDataCheckSum)},
 			},
-			fetchURL:          ts.URL,
+			initialCachedChecksums: map[string]string{},
+			fetchURL:               ts.URL,
+			purgeInterval:          1 * time.Millisecond,
+			wasmModuleExpiry:       1 * time.Millisecond,
+			checkPurgeTimeout:      5 * time.Second,
+			checksum:               httpDataCheckSum,
+			wantFileName:           fmt.Sprintf("%s.wasm", httpDataCheckSum),
+			wantServerReqNum:       1,
+		},
+		{
+			name:                   "fetch oci without digest",
+			initialCachedModules:   map[moduleKey]cacheEntry{},
+			initialCachedChecksums: map[string]string{},
+			fetchURL:               ociURLWithTag,
+			purgeInterval:          DefaultWasmModulePurgeInterval,
+			wasmModuleExpiry:       DefaultWasmModuleExpiry,
+			requestTimeout:         time.Second * 10,
+			wantFileName:           fmt.Sprintf("%s.wasm", dockerImageDigest),
+			wantVisitRegistry:      true,
+		},
+		{
+			name:                   "fetch oci with digest",
+			initialCachedModules:   map[moduleKey]cacheEntry{},
+			initialCachedChecksums: map[string]string{},
+			fetchURL:               ociURLWithTag,
+			purgeInterval:          DefaultWasmModulePurgeInterval,
+			wasmModuleExpiry:       DefaultWasmModuleExpiry,
+			requestTimeout:         time.Second * 10,
+			checksum:               dockerImageDigest,
+			wantFileName:           fmt.Sprintf("%s.wasm", dockerImageDigest),
+			wantVisitRegistry:      true,
+		},
+		{
+			name: "cache hit for tagged oci url with digest",
+			initialCachedModules: map[moduleKey]cacheEntry{
+				{name: urlAsResourceName(ociURLWithTag), checksum: dockerImageDigest}: {modulePath: fmt.Sprintf("%s.wasm", dockerImageDigest)},
+			},
+			initialCachedChecksums: map[string]string{},
+			fetchURL:               ociURLWithTag,
+			purgeInterval:          DefaultWasmModulePurgeInterval,
+			wasmModuleExpiry:       DefaultWasmModuleExpiry,
+			requestTimeout:         time.Second * 10,
+			checksum:               dockerImageDigest,
+			wantFileName:           fmt.Sprintf("%s.wasm", dockerImageDigest),
+			wantVisitRegistry:      false,
+		},
+		{
+			name: "cache hit for tagged oci url without digest",
+			initialCachedModules: map[moduleKey]cacheEntry{
+				{name: urlAsResourceName(ociURLWithTag), checksum: dockerImageDigest}: {modulePath: fmt.Sprintf("%s.wasm", dockerImageDigest)},
+			},
+			initialCachedChecksums: map[string]string{
+				ociURLWithTag: dockerImageDigest,
+			},
+			fetchURL:          ociURLWithTag,
+			purgeInterval:     DefaultWasmModulePurgeInterval,
+			wasmModuleExpiry:  DefaultWasmModuleExpiry,
+			requestTimeout:    time.Second * 10,
+			wantFileName:      fmt.Sprintf("%s.wasm", dockerImageDigest),
+			wantVisitRegistry: false,
+		},
+		{
+			name: "cache miss for tagged oci url without digest",
+			initialCachedModules: map[moduleKey]cacheEntry{
+				{name: urlAsResourceName(ociURLWithTag), checksum: dockerImageDigest}: {modulePath: fmt.Sprintf("%s.wasm", dockerImageDigest)},
+			},
+			initialCachedChecksums: map[string]string{},
+			fetchURL:               ociURLWithTag,
+			purgeInterval:          DefaultWasmModulePurgeInterval,
+			wasmModuleExpiry:       DefaultWasmModuleExpiry,
+			requestTimeout:         time.Second * 10,
+			wantFileName:           fmt.Sprintf("%s.wasm", dockerImageDigest),
+			wantVisitRegistry:      true,
+		},
+		{
+			name: "cache hit for oci url suffixed by digest",
+			initialCachedModules: map[moduleKey]cacheEntry{
+				{name: urlAsResourceName(ociURLWithTag), checksum: dockerImageDigest}: {modulePath: fmt.Sprintf("%s.wasm", dockerImageDigest)},
+			},
+			initialCachedChecksums: map[string]string{},
+			fetchURL:               ociURLWithDigest,
+			purgeInterval:          DefaultWasmModulePurgeInterval,
+			wasmModuleExpiry:       DefaultWasmModuleExpiry,
+			requestTimeout:         time.Second * 10,
+			wantFileName:           fmt.Sprintf("%s.wasm", dockerImageDigest),
+			wantVisitRegistry:      false,
+		},
+		{
+			name: "purge OCI image on expiry",
+			initialCachedModules: map[moduleKey]cacheEntry{
+				{name: urlAsResourceName(ociURLWithTag), checksum: dockerImageDigest}: {modulePath: fmt.Sprintf("%s.wasm", dockerImageDigest), referencingURLs: sets.New(ociURLWithTag)},
+			},
+			initialCachedChecksums: map[string]string{
+				ociURLWithTag: dockerImageDigest,
+				"test-url":    "test-checksum",
+			},
+			fetchURL:          ociURLWithDigest,
 			purgeInterval:     1 * time.Millisecond,
 			wasmModuleExpiry:  1 * time.Millisecond,
+			requestTimeout:    time.Second * 10,
 			checkPurgeTimeout: 5 * time.Second,
-			checksum:          httpDataCheckSum,
-			wantFileName:      fmt.Sprintf("%s.wasm", httpDataCheckSum),
-			wantServerReqNum:  1,
+			wantFileName:      fmt.Sprintf("%s.wasm", dockerImageDigest),
+			wantVisitRegistry: true,
+			wantURLPurged:     ociURLWithTag,
 		},
 		{
-			name:                 "fetch oci without digest",
-			initialCachedModules: map[cacheKey]cacheEntry{},
-			fetchURL:             fmt.Sprintf("oci://%s/test/valid/docker:v0.1.0", ou.Host),
-			purgeInterval:        DefaultWasmModulePurgeInterval,
-			wasmModuleExpiry:     DefaultWasmModuleExpiry,
-			requestTimeout:       time.Second * 10,
-			wantFileName:         fmt.Sprintf("%s.wasm", dockerImageDigest),
+			name:                   "fetch oci timed out",
+			initialCachedModules:   map[moduleKey]cacheEntry{},
+			initialCachedChecksums: map[string]string{},
+			fetchURL:               ociURLWithTag,
+			purgeInterval:          DefaultWasmModulePurgeInterval,
+			wasmModuleExpiry:       DefaultWasmModuleExpiry,
+			requestTimeout:         0, // Cause timeout immediately.
+			wantErrorMsgPrefix:     fmt.Sprintf("could not fetch Wasm OCI image: could not fetch manifest: Get \"https://%s/v2/\"", ou.Host),
+			wantVisitRegistry:      false,
 		},
 		{
-			name:                 "fetch oci with digest",
-			initialCachedModules: map[cacheKey]cacheEntry{},
-			fetchURL:             fmt.Sprintf("oci://%s/test/valid/docker:v0.1.0", ou.Host),
-			purgeInterval:        DefaultWasmModulePurgeInterval,
-			wasmModuleExpiry:     DefaultWasmModuleExpiry,
-			requestTimeout:       time.Second * 10,
-			checksum:             dockerImageDigest,
-			wantFileName:         fmt.Sprintf("%s.wasm", dockerImageDigest),
-		},
-		{
-			name:                 "fetch oci timed out",
-			initialCachedModules: map[cacheKey]cacheEntry{},
-			fetchURL:             fmt.Sprintf("oci://%s/test/invalid", ou.Host),
-			purgeInterval:        DefaultWasmModulePurgeInterval,
-			wasmModuleExpiry:     DefaultWasmModuleExpiry,
-			requestTimeout:       0, // Cause timeout immediately.
-			wantErrorMsgPrefix:   fmt.Sprintf("could not fetch Wasm OCI image: could not fetch manifest: Get \"https://%s/v2/\"", ou.Host),
-		},
-		{
-			name:                 "fetch oci with wrong digest",
-			initialCachedModules: map[cacheKey]cacheEntry{},
-			fetchURL:             fmt.Sprintf("oci://%s/test/valid/docker:v0.1.0", ou.Host),
-			purgeInterval:        DefaultWasmModulePurgeInterval,
-			wasmModuleExpiry:     DefaultWasmModuleExpiry,
-			requestTimeout:       time.Second * 10,
-			checksum:             "wrongdigest",
+			name:                   "fetch oci with wrong digest",
+			initialCachedModules:   map[moduleKey]cacheEntry{},
+			initialCachedChecksums: map[string]string{},
+			fetchURL:               ociURLWithTag,
+			purgeInterval:          DefaultWasmModulePurgeInterval,
+			wasmModuleExpiry:       DefaultWasmModuleExpiry,
+			requestTimeout:         time.Second * 10,
+			checksum:               "wrongdigest",
 			wantErrorMsgPrefix: fmt.Sprintf(
 				"module downloaded from %v has checksum %v, which does not match:", fmt.Sprintf("oci://%s/test/valid/docker:v0.1.0", ou.Host), dockerImageDigest,
 			),
+			wantVisitRegistry: true,
 		},
 		{
-			name:                 "fetch invalid oci",
-			initialCachedModules: map[cacheKey]cacheEntry{},
-			fetchURL:             fmt.Sprintf("oci://%s/test/invalid", ou.Host),
-			purgeInterval:        DefaultWasmModulePurgeInterval,
-			wasmModuleExpiry:     DefaultWasmModuleExpiry,
-			checksum:             invalidOCIImageDigest,
-			requestTimeout:       time.Second * 10,
+			name:                   "fetch invalid oci",
+			initialCachedModules:   map[moduleKey]cacheEntry{},
+			initialCachedChecksums: map[string]string{},
+			fetchURL:               fmt.Sprintf("oci://%s/test/invalid", ou.Host),
+			purgeInterval:          DefaultWasmModulePurgeInterval,
+			wasmModuleExpiry:       DefaultWasmModuleExpiry,
+			checksum:               invalidOCIImageDigest,
+			requestTimeout:         time.Second * 10,
 			wantErrorMsgPrefix: `could not fetch Wasm binary: the given image is in invalid format as an OCI image: 2 errors occurred:
 	* could not parse as compat variant: invalid media type application/vnd.oci.image.layer.v1.tar (expect application/vnd.oci.image.layer.v1.tar+gzip)
 	* could not parse as oci variant: number of layers must be 2 but got 1`,
+			wantVisitRegistry: true,
 		},
 	}
 
@@ -236,8 +340,9 @@ func TestWasmCache(t *testing.T) {
 			cache.httpFetcher.initialBackoff = time.Microsecond
 			defer close(cache.stopChan)
 			tsNumRequest = 0
+			registryVisited = false
 
-			var cacheHitKey *cacheKey
+			var cacheHitKey *moduleKey
 			initTime := time.Now()
 			cache.mux.Lock()
 			for k, m := range c.initialCachedModules {
@@ -246,11 +351,22 @@ func TestWasmCache(t *testing.T) {
 				if err != nil {
 					t.Fatalf("failed to write initial wasm module file %v", err)
 				}
-				key := cacheKey{downloadURL: k.downloadURL, checksum: k.checksum}
-				cache.modules[key] = &cacheEntry{modulePath: filePath, last: initTime}
-				if c.fetchURL == k.downloadURL && c.checksum == k.checksum {
-					cacheHitKey = &key
+				mkey := moduleKey{name: k.name, checksum: k.checksum}
+
+				cache.modules[mkey] = &cacheEntry{modulePath: filePath, last: initTime}
+				if m.referencingURLs != nil {
+					cache.modules[mkey].referencingURLs = m.referencingURLs.Copy()
+				} else {
+					cache.modules[mkey].referencingURLs = sets.New()
 				}
+
+				if urlAsResourceName(c.fetchURL) == k.name && c.checksum == k.checksum {
+					cacheHitKey = &mkey
+				}
+			}
+
+			for k, m := range c.initialCachedChecksums {
+				cache.checksums[k] = m
 			}
 			cache.mux.Unlock()
 
@@ -263,6 +379,14 @@ func TestWasmCache(t *testing.T) {
 						break
 					}
 				}
+
+				cache.mux.Lock()
+				_, ok := cache.checksums[c.wantURLPurged]
+				cache.mux.Unlock()
+				if ok {
+					t.Fatalf("the checksum cache for %v is not purged before purge timeout", c.wantURLPurged)
+				}
+
 				if !moduleDeleted {
 					t.Fatalf("Wasm modules are not purged before purge timeout")
 				}
@@ -291,6 +415,9 @@ func TestWasmCache(t *testing.T) {
 			}
 			if c.wantServerReqNum != tsNumRequest {
 				t.Errorf("test server request number got %v, want %v", tsNumRequest, c.wantServerReqNum)
+			}
+			if c.wantVisitRegistry != registryVisited {
+				t.Errorf("test OCI registry encountered the unexpected visiting status got %v, want %v", registryVisited, c.wantVisitRegistry)
 			}
 		})
 	}
@@ -402,7 +529,7 @@ func TestWasmCacheMissChecksum(t *testing.T) {
 		t.Fatalf("failed to download Wasm module: %v", err)
 	}
 	if gotFilePath != wantFilePath2 {
-		t.Errorf("wasm download path got %v want %v", gotFilePath, wantFilePath2)
+		t.Errorf("wasm download path got %v want %v (1st: %v)", gotFilePath, wantFilePath2, wantFilePath1)
 	}
 
 	wantNumRequest := 3

--- a/pkg/wasm/cache_test.go
+++ b/pkg/wasm/cache_test.go
@@ -28,13 +28,13 @@ import (
 	"testing"
 	"time"
 
-	"istio.io/istio/pkg/util/sets"
-
 	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/google/go-containerregistry/pkg/registry"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/types"
+
+	"istio.io/istio/pkg/util/sets"
 )
 
 // Wasm header = magic number (4 bytes) + Wasm spec version (4 bytes).

--- a/pkg/wasm/cache_test.go
+++ b/pkg/wasm/cache_test.go
@@ -529,7 +529,7 @@ func TestWasmCacheMissChecksum(t *testing.T) {
 		t.Fatalf("failed to download Wasm module: %v", err)
 	}
 	if gotFilePath != wantFilePath2 {
-		t.Errorf("wasm download path got %v want %v (1st: %v)", gotFilePath, wantFilePath2, wantFilePath1)
+		t.Errorf("wasm download path got %v want %v", gotFilePath, wantFilePath2)
 	}
 
 	wantNumRequest := 3

--- a/releasenotes/notes/wasm-cache-with-tag-stripped-url.yaml
+++ b/releasenotes/notes/wasm-cache-with-tag-stripped-url.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: feature
+area: extensibility
+issue: []
+releaseNotes:
+  - |
+    **Improved** Use tag-stripped URL + checksum as a Wasm module cachekey, and the tagged URL is seperately cached. 
+    This may increase the chance of cache hit (e.g., trying to find the same image with both of the tagged and digest URLs.)
+    In addition, this will be a base to implement ImagePullPolicy.


### PR DESCRIPTION
This PR is proposing use of URL which the tag or digest suffix is trimmed as a cache key in terms of OCI image cache.

In terms of URL for OCI images, two forms can be used.
- tagged form: docker.io/foo/image:bar
- digest form: docker.io/foo/image@sha256:1234567890abcdef

Basically, since the tag is just an alias for a specific version or digest, using (URL having no tag/digest + Digest) is much natural approach. Even in current implementation, the cached file is named with the digest.
Of course, to provide cache functionality for tagged URL as well, we additionally need to keep the map from the tagged URL to the digest according to the original meaning of tag.

Practically, there are two benefits:

1. In current implementation, without use of the digest(sha256) field in WasmPlugin, tagged OCI URL has "Always" pull policy because we don't keep any recently used digest.
But, with this PR, we can easily implement "IfNotPresent" on the top of it, because the map from the tag to the digest can provide the cached digest which was used recently.

2. Let's assume that an image was pulled with a URL suffixed by a digest. If the tagged URL is used and the tag is pointing the image having "the digest", then the image might be found in cache with this PR.

Note that this is a part of implementing PullPolicy of WasmPlugin, this will be followed the other PR including https://github.com/istio/istio/pull/38475.