### PR TITLE
introduce new feature flag for auto_sni

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -612,6 +612,9 @@ var (
 	EnableTLSOnSidecarIngress = env.RegisterBoolVar("ENABLE_TLS_ON_SIDECAR_INGRESS", false,
 		"If enabled, the TLS configuration on Sidecar.ingress will take effect").Get()
 
+	EnableAutoSni = env.RegisterBoolVar("ENABLE_AUTO_SNI", false,
+		"If enabled, automatically set SNI when `DestinationRules` do not specify the same").Get()
+
 	InsecureKubeConfigOptions = func() sets.Set {
 		v := env.RegisterStringVar(
 			"PILOT_INSECURE_MULTICLUSTER_KUBECONFIG_OPTIONS",

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -1143,7 +1143,7 @@ func (cb *ClusterBuilder) buildUpstreamClusterTLSContext(opts *buildClusterOpts,
 }
 
 func (cb *ClusterBuilder) setAutoSni(mc *MutableCluster, tls *networking.ClientTLSSettings) {
-	if mc != nil && features.VerifyCertAtClient && len(tls.Sni) == 0 {
+	if mc != nil && features.EnableAutoSni && len(tls.Sni) == 0 {
 		if mc.httpProtocolOptions == nil {
 			mc.httpProtocolOptions = &http.HttpProtocolOptions{}
 		}

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
@@ -1779,13 +1779,13 @@ func TestBuildUpstreamClusterTLSContext(t *testing.T) {
 	credentialName := "some-fake-credential"
 
 	testCases := []struct {
-		name                     string
-		opts                     *buildClusterOpts
-		tls                      *networking.ClientTLSSettings
-		h2                       bool
-		router                   bool
-		result                   expectedResult
-		enableVerifyCertAtClient bool
+		name          string
+		opts          *buildClusterOpts
+		tls           *networking.ClientTLSSettings
+		h2            bool
+		router        bool
+		result        expectedResult
+		enableAutoSni bool
 	}{
 		{
 			name: "tls mode disabled",
@@ -1995,7 +1995,7 @@ func TestBuildUpstreamClusterTLSContext(t *testing.T) {
 				},
 				err: nil,
 			},
-			enableVerifyCertAtClient: true,
+			enableAutoSni: true,
 		},
 		{
 			name: "tls mode SIMPLE, with VerifyCert enabled and sni specified in tls",
@@ -2021,7 +2021,7 @@ func TestBuildUpstreamClusterTLSContext(t *testing.T) {
 				},
 				err: nil,
 			},
-			enableVerifyCertAtClient: true,
+			enableAutoSni: true,
 		},
 		{
 			name: "tls mode SIMPLE, with certs specified in tls",
@@ -2648,7 +2648,7 @@ func TestBuildUpstreamClusterTLSContext(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			test.SetBoolForTest(t, &features.VerifyCertAtClient, tc.enableVerifyCertAtClient)
+			test.SetBoolForTest(t, &features.EnableAutoSni, tc.enableAutoSni)
 			var proxy *model.Proxy
 			if tc.router {
 				proxy = newGatewayProxy()
@@ -2665,7 +2665,7 @@ func TestBuildUpstreamClusterTLSContext(t *testing.T) {
 			} else if diff := cmp.Diff(tc.result.tlsContext, ret, protocmp.Transform()); diff != "" {
 				t.Errorf("got diff: `%v", diff)
 			}
-			if tc.enableVerifyCertAtClient {
+			if tc.enableAutoSni {
 				if len(tc.tls.Sni) == 0 {
 					assert.Equal(t, tc.opts.mutable.httpProtocolOptions.UpstreamHttpProtocolOptions.AutoSni, true)
 				} else if tc.opts.mutable.httpProtocolOptions != nil {

--- a/releasenotes/notes/auto-sni-support.yaml
+++ b/releasenotes/notes/auto-sni-support.yaml
@@ -4,6 +4,6 @@ area: traffic-management
 releaseNotes:
    - |
      **Added** the ability to configure automatically set SNI when `DestinationRules`
-     do not specify it and `VERIFY_CERTIFICATE_AT_CLIENT` is enabled.
+     do not specify it and `ENABLE_AUTO_SNI` is enabled.
 docs:
    - https://docs.google.com/document/d/1pTUl-Ng3nXAWJb7UGJtalftznpxQEfID/


### PR DESCRIPTION
A later discussion concluded that it makes better sense
to introduce a new feature flag for enabling auto_sni,
and only auto_san_validation should be clubbed with existing VERIFY_CERT_AT_CLIENT feature flag.
[RFC](https://docs.google.com/document/d/1pTUl-Ng3nXAWJb7UGJtalftznpxQEfID/) has been updated accordingly.

Signed-off-by: Faseela K <faseela.k@est.tech>

**Please provide a description of this PR:**



**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ X] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
