### PR TITLE
Correct service matching logic of sidecar egress listeners

### DIFF
--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -605,8 +605,10 @@ func (ilw *IstioEgressListenerWrapper) selectServices(services []*Service, confi
 		if importedHosts, nsFound := hosts[configNamespace]; nsFound {
 			if svc := matchingService(importedHosts, s, ilw); svc != nil {
 				importedServices = append(importedServices, svc)
+				continue
 			}
-		} else if wnsFound { // Check if there is an import of form */host or */*
+		}
+		if wnsFound { // Check if there is an import of form */host or */*
 			if svc := matchingService(wildcardHosts, s, ilw); svc != nil {
 				importedServices = append(importedServices, svc)
 			}

--- a/pilot/pkg/model/sidecar_test.go
+++ b/pilot/pkg/model/sidecar_test.go
@@ -1808,6 +1808,13 @@ func TestIstioEgressListenerWrapper(t *testing.T) {
 			expected:      []*Service{serviceA8000},
 			namespace:     "a",
 		},
+		{
+			name:          "fall back to wildcard namespace",
+			listenerHosts: map[string][]host.Name{wildcardNamespace: {"host"}, "a": {"alt"}},
+			services:      allServices,
+			expected:      []*Service{serviceA8000, serviceA9000, serviceAalt},
+			namespace:     "a",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
**Please provide a description of this PR:**
If a service does not match the egress with an explicit namespace, fall back to match the wildcard one
Fixes #38556