### PR TITLE
service entry: add canonical service information

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -627,6 +627,10 @@ var (
 
 	VerifySDSCertificate = env.RegisterBoolVar("VERIFY_SDS_CERTIFICATE", true,
 		"If enabled, certificates fetched from SDS server will be verified before sending back to proxy.").Get()
+
+	CanonicalServiceForMeshExternalServiceEntry = env.RegisterBoolVar("LABEL_CANONICAL_SERVICES_FOR_MESH_EXTERNAL_SERVICE_ENTRIES", false,
+		"If enabled, metadata representing canonical services for ServiceEntry resources with a location of mesh_external will be populated"+
+			"in the cluster metadata for those endpoints.").Get()
 )
 
 // EnableEndpointSliceController returns the value of the feature flag and whether it was actually specified.

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -595,8 +595,26 @@ func (cb *ClusterBuilder) buildLocalityLbEndpoints(proxyView model.ProxyView, se
 				Value: instance.Endpoint.GetLoadBalancingWeight(),
 			},
 		}
+
+		labels := instance.Endpoint.Labels
+		ns := instance.Endpoint.Namespace
+		if service.MeshExternal {
+			ns = "mesh-external:" + service.Attributes.Namespace
+			svcLabels := service.Attributes.Labels
+			if _, ok := svcLabels[model.IstioCanonicalServiceLabelName]; ok {
+				labels = map[string]string{
+					model.IstioCanonicalServiceLabelName:         svcLabels[model.IstioCanonicalServiceLabelName],
+					model.IstioCanonicalServiceRevisionLabelName: svcLabels[model.IstioCanonicalServiceRevisionLabelName],
+				}
+				for k, v := range instance.Endpoint.Labels {
+					labels[k] = v
+				}
+			}
+		}
+
 		ep.Metadata = util.BuildLbEndpointMetadata(instance.Endpoint.Network, instance.Endpoint.TLSMode, instance.Endpoint.WorkloadName,
-			instance.Endpoint.Namespace, instance.Endpoint.Locality.ClusterID, instance.Endpoint.Labels)
+			ns, instance.Endpoint.Locality.ClusterID, labels)
+
 		locality := instance.Endpoint.Locality.Label
 		lbEndpoints[locality] = append(lbEndpoints[locality], ep)
 	}

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -598,8 +598,8 @@ func (cb *ClusterBuilder) buildLocalityLbEndpoints(proxyView model.ProxyView, se
 
 		labels := instance.Endpoint.Labels
 		ns := instance.Endpoint.Namespace
-		if service.MeshExternal {
-			ns = "mesh-external:" + service.Attributes.Namespace
+		if features.CanonicalServiceForMeshExternalServiceEntry && service.MeshExternal {
+			ns = service.Attributes.Namespace
 			svcLabels := service.Attributes.Labels
 			if _, ok := svcLabels[model.IstioCanonicalServiceLabelName]; ok {
 				labels = map[string]string{

--- a/pilot/pkg/serviceregistry/serviceentry/conversion.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion.go
@@ -31,6 +31,7 @@ import (
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/config/visibility"
+	"istio.io/istio/pkg/kube/labels"
 	"istio.io/istio/pkg/network"
 	"istio.io/istio/pkg/spiffe"
 )
@@ -199,14 +200,15 @@ func convertServices(cfg config.Config) []*model.Service {
 		}
 	}
 
-	return buildServices(hostAddresses, cfg.Namespace, svcPorts, serviceEntry.Location, resolution,
+	return buildServices(hostAddresses, cfg.Name, cfg.Namespace, svcPorts, serviceEntry.Location, resolution,
 		exportTo, labelSelectors, serviceEntry.SubjectAltNames, creationTime, cfg.Labels)
 }
 
-func buildServices(hostAddresses []*HostAddress, namespace string, ports model.PortList, location networking.ServiceEntry_Location,
+func buildServices(hostAddresses []*HostAddress, name, namespace string, ports model.PortList, location networking.ServiceEntry_Location,
 	resolution model.Resolution, exportTo map[visibility.Instance]bool, selectors map[string]string, saccounts []string,
 	ctime time.Time, labels map[string]string) []*model.Service {
 	out := make([]*model.Service, 0, len(hostAddresses))
+	lbls := ensureCanonicalServiceLabels(name, labels)
 	for _, ha := range hostAddresses {
 		out = append(out, &model.Service{
 			CreationTime:   ctime,
@@ -219,7 +221,7 @@ func buildServices(hostAddresses []*HostAddress, namespace string, ports model.P
 				ServiceRegistry: provider.External,
 				Name:            ha.host,
 				Namespace:       namespace,
-				Labels:          labels,
+				Labels:          lbls,
 				ExportTo:        exportTo,
 				LabelSelectors:  selectors,
 			},
@@ -227,6 +229,17 @@ func buildServices(hostAddresses []*HostAddress, namespace string, ports model.P
 		})
 	}
 	return out
+}
+
+func ensureCanonicalServiceLabels(name string, srcLabels map[string]string) map[string]string {
+	_, svcLabelFound := srcLabels[model.IstioCanonicalServiceLabelName]
+	_, revLabelFound := srcLabels[model.IstioCanonicalServiceRevisionLabelName]
+	if svcLabelFound && revLabelFound {
+		return srcLabels
+	}
+
+	srcLabels[model.IstioCanonicalServiceLabelName], srcLabels[model.IstioCanonicalServiceRevisionLabelName] = labels.CanonicalService(srcLabels, name)
+	return srcLabels
 }
 
 func (s *Controller) convertEndpoint(service *model.Service, servicePort *networking.Port,

--- a/pilot/pkg/serviceregistry/serviceentry/conversion.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion.go
@@ -232,6 +232,9 @@ func buildServices(hostAddresses []*HostAddress, name, namespace string, ports m
 }
 
 func ensureCanonicalServiceLabels(name string, srcLabels map[string]string) map[string]string {
+	if srcLabels == nil {
+		srcLabels = make(map[string]string)
+	}
 	_, svcLabelFound := srcLabels[model.IstioCanonicalServiceLabelName]
 	_, revLabelFound := srcLabels[model.IstioCanonicalServiceRevisionLabelName]
 	if svcLabelFound && revLabelFound {

--- a/pilot/pkg/serviceregistry/serviceentry/conversion.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion.go
@@ -21,6 +21,7 @@ import (
 
 	"istio.io/api/label"
 	networking "istio.io/api/networking/v1alpha3"
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry/provider"
 	labelutil "istio.io/istio/pilot/pkg/serviceregistry/util/label"
@@ -208,7 +209,10 @@ func buildServices(hostAddresses []*HostAddress, name, namespace string, ports m
 	resolution model.Resolution, exportTo map[visibility.Instance]bool, selectors map[string]string, saccounts []string,
 	ctime time.Time, labels map[string]string) []*model.Service {
 	out := make([]*model.Service, 0, len(hostAddresses))
-	lbls := ensureCanonicalServiceLabels(name, labels)
+	lbls := labels
+	if features.CanonicalServiceForMeshExternalServiceEntry && location == networking.ServiceEntry_MESH_EXTERNAL {
+		lbls = ensureCanonicalServiceLabels(name, labels)
+	}
 	for _, ha := range hostAddresses {
 		out = append(out, &model.Service{
 			CreationTime:   ctime,

--- a/pilot/pkg/serviceregistry/serviceentry/conversion_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion_test.go
@@ -36,6 +36,7 @@ import (
 	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/network"
 	"istio.io/istio/pkg/spiffe"
+	"istio.io/istio/pkg/test"
 )
 
 var (
@@ -571,10 +572,7 @@ func makeInstance(cfg *config.Config, address string, port int,
 
 func TestConvertService(t *testing.T) {
 	testConvertServiceBody(t)
-	features.CanonicalServiceForMeshExternalServiceEntry = true
-	defer func() {
-		features.CanonicalServiceForMeshExternalServiceEntry = false
-	}()
+	test.SetBoolForTest(t, &features.CanonicalServiceForMeshExternalServiceEntry, true)
 	testConvertServiceBody(t)
 }
 

--- a/releasenotes/notes/38650.yaml
+++ b/releasenotes/notes/38650.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: feature
+area: telemetry
+
+releaseNotes:
+  - |
+    **Added** initial flag-protected support for exporting canonical service labels for ServiceEntry resources with a location of MESH_EXTERNAL.


### PR DESCRIPTION
This CL attempts to ensure that the metadata for outgoing traffic to mesh-external services represented by ServiceEntry includes canonical service information. This will allow treatment (in client-side metrics/logs/etc.) of external services with Service Entries as proper "Istio Canonical Services" (in a fashion). NOTE: the labeling is not applied to the ServiceEntries themselves.

Here is a worked example with this code:

In a 1.13.3 mesh, with no service entry, using a sleep pod with queries like:

`k exec -it deploy/sleep -- curl http://httpbin.org/status/202`

Base: Without a ServiceEntry and Without this CL (unimportant labels redacted):

```
istio_requests_total{
  response_code="202",
  reporter="source",
  source_workload="sleep",...
  destination_workload_namespace="unknown",
  destination_service="httpbin.org",
  destination_service_name="PassthroughCluster",
  destination_service_namespace="unknown",...
  destination_canonical_service="unknown",...
  destination_canonical_revision="latest"} 1
```

With just a ServiceEntry (changes from `Base` marked with `**`):

ServiceEntry:
```
apiVersion: networking.istio.io/v1beta1
kind: ServiceEntry
metadata:
  name: external-svc-httpbin
spec:
  hosts:
  - httpbin.org
  location: MESH_EXTERNAL
  ports:
  - number: 80
    name: http
    protocol: HTTP
  resolution: DNS
```

```
istio_requests_total{
  response_code="202",
  reporter="source",
  source_workload="sleep",...
  destination_workload_namespace="unknown",
  destination_service="httpbin.org",
  ** destination_service_name="httpbin.org", **
  destination_service_namespace="unknown",...
  destination_canonical_service="unknown",...
  destination_canonical_revision="latest"} 1
```

With a ServiceEntry **AND** this CL (changes from `Base` marked with `**`):

```
istio_requests_total{
  response_code="202",
  reporter="source",
  source_workload="sleep",...
  ** destination_workload_namespace="default", **
  destination_service="httpbin.org",
  ** destination_service_name="httpbin.org", **
  ** destination_service_namespace="default" ** ...
  ** destination_canonical_service="external-svc-httpbin" ** ...
  destination_canonical_revision="latest"} 1
```

- [ x ] Networking
- [ X ] Policies and Telemetry
