### PR TITLE
Do not use HPA when the user has specified a DamonSet for a gateway

### DIFF
--- a/manifests/charts/gateway/templates/hpa.yaml
+++ b/manifests/charts/gateway/templates/hpa.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.autoscaling.enabled }}
+{{- if and (.Values.autoscaling.enabled) (eq .Values.kind "Deployment") }}
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -24,5 +24,4 @@ spec:
           averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
           type: Utilization
     {{- end }}
-
 {{- end }}


### PR DESCRIPTION
**Please provide a description of this PR:**

Follow up to https://github.com/istio/istio/pull/38142

Only deploy HPA when the user has set auto-scaling and is using a Deployment. This should make it easier for users.