### PR TITLE
Fixes #31946 Allow external Istiod to watch for local secret resources

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -622,6 +622,9 @@ var (
 	CanonicalServiceForMeshExternalServiceEntry = env.RegisterBoolVar("LABEL_CANONICAL_SERVICES_FOR_MESH_EXTERNAL_SERVICE_ENTRIES", false,
 		"If enabled, metadata representing canonical services for ServiceEntry resources with a location of mesh_external will be populated"+
 			"in the cluster metadata for those endpoints.").Get()
+
+	LocalClusterSecretWatcher = env.RegisterBoolVar("LOCAL_CLUSTER_SECERT_WATCHER", false,
+		"If enabled, the cluster secret watcher will watch the namespace of the external cluster instead of config cluster").Get()
 )
 
 // EnableEndpointSliceController returns the value of the feature flag and whether it was actually specified.

--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -764,12 +764,11 @@ func getTargetClusterListForCluster(targetClusters []cluster.Cluster, c cluster.
 	var outClusters []cluster.Cluster
 	scopes.Framework.Infof("Secret from cluster: %s will be placed in following clusters", c.Name())
 	for _, cc := range targetClusters {
-		if c.IsConfig() && !cc.IsConfig() && !cc.IsRemote() {
-			// if cc is an external cluster, config cluster's secret should have already been
-			// placed on the cluster.
-			continue
-		} else if c.Name() != cc.Name() {
-			// if the given cluster is not the same as the cluster in the target list.
+		// if cc is an external cluster, config cluster's secret should have already been
+		// placed on the cluster, or the given cluster is the same as the cluster in
+		// the target list. Only when c is not config cluster, cc is not external cluster
+		// and the given cluster is not the same as the target, c's secret goes onto cc.
+		if (!c.IsConfig() || !cc.IsExternalControlPlane()) && c.Name() != cc.Name() {
 			scopes.Framework.Infof("Target cluster: %s", cc.Name())
 			outClusters = append(outClusters, cc)
 		}

--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -367,15 +367,29 @@ func deploy(ctx resource.Context, env *kube.Environment, cfg Config) (Instance, 
 		}
 	}
 
+	// Need to determine if there is a setting to watch cluster secret in config cluster
+	// or in external cluster. The flag is named LOCAL_CLUSTER_SECERT_WATCHER and set as
+	// an environment variable for istiod.
+	watchLocalNamespace := false
+	if istioctlConfigFiles.operatorSpec != nil && istioctlConfigFiles.operatorSpec.Values != nil {
+		localClusterSecretWatcher := GetConfigValue("pilot.env.LOCAL_CLUSTER_SECERT_WATCHER",
+			istioctlConfigFiles.operatorSpec.Values.Fields)
+		if localClusterSecretWatcher.GetStringValue() == "true" && i.isExternalControlPlane() {
+			watchLocalNamespace = true
+		}
+	}
+
+	if ctx.Clusters().IsMulticluster() {
+		if err := i.configureDirectAPIServerAccess(ctx, cfg, watchLocalNamespace); err != nil {
+			return nil, err
+		}
+	}
+
 	// Install (non-config) remote clusters.
 	errG = multierror.Group{}
 	for _, c := range ctx.Clusters().Kube().Remotes(ctx.Clusters().Configs()...) {
 		c := c
 		errG.Go(func() error {
-			// Configure API server access for the remote cluster's primary cluster control plane.
-			if err := i.configureDirectAPIServiceAccessBetweenClusters(ctx, cfg, c, c.Config()); err != nil {
-				return fmt.Errorf("failed providing primary cluster access for remote cluster %s: %v", c.Name(), err)
-			}
 			if err := installRemoteCluster(s, i, cfg, c, istioctlConfigFiles.remoteIopFile); err != nil {
 				return fmt.Errorf("failed installing remote cluster %s: %v", c.Name(), err)
 			}
@@ -384,13 +398,6 @@ func deploy(ctx resource.Context, env *kube.Environment, cfg Config) (Instance, 
 	}
 	if errs := errG.Wait(); errs != nil {
 		return nil, fmt.Errorf("%d errors occurred deploying remote clusters: %v", errs.Len(), errs.ErrorOrNil())
-	}
-
-	// For multicluster, configure direct access so each control plane can get endpoints from all API servers.
-	if ctx.Clusters().IsMulticluster() {
-		if err := i.configureDirectAPIServerAccess(ctx, cfg); err != nil {
-			return nil, err
-		}
 	}
 
 	// Configure gateways for remote clusters.
@@ -735,28 +742,8 @@ func waitForIstioReady(ctx resource.Context, c cluster.Cluster, cfg Config) erro
 	return nil
 }
 
-func (i *operatorComponent) configureDirectAPIServerAccess(ctx resource.Context, cfg Config) error {
-	// Configure direct access for each control plane to each APIServer. This allows each control plane to
-	// automatically discover endpoints in remote clusters.
-	for _, c := range ctx.Clusters().Kube() {
-		if err := i.configureDirectAPIServiceAccessForCluster(ctx, cfg, c); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (i *operatorComponent) configureDirectAPIServiceAccessForCluster(ctx resource.Context, cfg Config,
-	c cluster.Cluster,
-) error {
-	clusters := ctx.Clusters().Configs(c.Config())
-	if len(clusters) == 0 {
-		// giving 0 clusters to ctx.ConfigKube() means using all clusters
-		return nil
-	}
-	return i.configureDirectAPIServiceAccessBetweenClusters(ctx, cfg, c, clusters...)
-}
-
+// configureDirectAPIServiceAccessBetweenClusters - create a remote secret of cluster `c`` and place
+// the secret in all `from` clusters
 func (i *operatorComponent) configureDirectAPIServiceAccessBetweenClusters(ctx resource.Context, cfg Config,
 	c cluster.Cluster, from ...cluster.Cluster,
 ) error {
@@ -769,6 +756,47 @@ func (i *operatorComponent) configureDirectAPIServiceAccessBetweenClusters(ctx r
 		YAML(cfg.SystemNamespace, secret).
 		Apply(apply.NoCleanup); err != nil {
 		return fmt.Errorf("failed applying remote secret to clusters: %v", err)
+	}
+	return nil
+}
+
+func getTargetClusterListForCluster(targetClusters []cluster.Cluster, c cluster.Cluster) []cluster.Cluster {
+	var outClusters []cluster.Cluster
+	scopes.Framework.Infof("Secret from cluster: %s will be placed in following clusters", c.Name())
+	for _, cc := range targetClusters {
+		if c.IsConfig() && !cc.IsConfig() && !cc.IsRemote() {
+			// if cc is an external cluster, config cluster's secret should have already been
+			// placed on the cluster.
+			continue
+		} else if c.Name() != cc.Name() {
+			// if the given cluster is not the same as the cluster in the target list.
+			scopes.Framework.Infof("Target cluster: %s", cc.Name())
+			outClusters = append(outClusters, cc)
+		}
+	}
+	return outClusters
+}
+
+func (i *operatorComponent) configureDirectAPIServerAccess(ctx resource.Context, cfg Config, watchLocalNamespace bool) error {
+	var targetClusters []cluster.Cluster
+	if watchLocalNamespace {
+		// when configured to watch istiod local namespace, secrets go to the external cluster
+		// and primary clusters
+		targetClusters = ctx.AllClusters().Primaries()
+	} else {
+		// when configured to watch istiod config namespace, secrets go to config clusters
+		targetClusters = ctx.AllClusters().Configs()
+	}
+
+	// Now look through entire mesh, create secret for every cluster other than external control plane and
+	// place the secret into the target clusters.
+	for _, c := range ctx.Clusters().Kube().MeshClusters() {
+		theTargetClusters := getTargetClusterListForCluster(targetClusters, c)
+		if len(theTargetClusters) > 0 {
+			if err := i.configureDirectAPIServiceAccessBetweenClusters(ctx, cfg, c, theTargetClusters...); err != nil {
+				return fmt.Errorf("failed providing primary cluster access for remote cluster %s: %v", c.Name(), err)
+			}
+		}
 	}
 	return nil
 }

--- a/pkg/test/framework/components/istio/util.go
+++ b/pkg/test/framework/components/istio/util.go
@@ -18,11 +18,14 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"regexp"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
+	"google.golang.org/protobuf/types/known/structpb"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -282,4 +285,40 @@ func PatchMeshConfigOrFail(t framework.TestContext, ns string, clusters cluster.
 	if err := PatchMeshConfig(t, ns, clusters, patch); err != nil {
 		t.Fatal(err)
 	}
+}
+
+// This regular expression matches list object index selection expression such as
+// abc[100], Tba_a[0].
+var listObjRex = regexp.MustCompile(`^([a-zA-Z]?[a-z_A-Z\d]*)\[([ ]*[\d]+)[ ]*\]$`)
+
+func getConfigValue(path []string, val map[string]*structpb.Value) *structpb.Value {
+	retVal := structpb.NewNullValue()
+	if len(path) > 0 {
+		match := listObjRex.FindStringSubmatch(path[0])
+		// valid list index
+		switch len(match) {
+		case 0: // does not match list object selection, should be name of a field, should be struct value
+			thisVal := val[path[0]]
+			// If it is a struct and looking for more down the path
+			if thisVal.GetStructValue() != nil && len(path) > 1 {
+				return getConfigValue(path[1:], thisVal.GetStructValue().Fields)
+			}
+			retVal = thisVal
+		case 3: // match somthing like aaa[100]
+			thisVal := val[match[1]]
+			// If it is a list and looking for more down the path
+			if thisVal.GetListValue() != nil && len(path) > 1 {
+				index, _ := strconv.Atoi(match[2])
+				return getConfigValue(path[1:], thisVal.GetListValue().Values[index].GetStructValue().Fields)
+			}
+			retVal = thisVal
+		}
+	}
+	return retVal
+}
+
+// This is method is to get a structpb value from a structpb map by
+// using a dotted path such as `pilot.env.LOCAL_CLUSTER_SECRET_WATCHER`.
+func GetConfigValue(path string, val map[string]*structpb.Value) *structpb.Value {
+	return getConfigValue(strings.Split(path, "."), val)
 }

--- a/releasenotes/notes/31946.yaml
+++ b/releasenotes/notes/31946.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+issue:
+- 31946
+releaseNotes:
+- |
+  **Added** support to watch local secret resource updates for external istiod

--- a/tests/integration/pilot/localwatcher/localsecretwatcher_test.go
+++ b/tests/integration/pilot/localwatcher/localsecretwatcher_test.go
@@ -1,0 +1,63 @@
+//go:build integ
+// +build integ
+
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package localwatcher
+
+import (
+	"testing"
+
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/echo/common/deployment"
+	"istio.io/istio/pkg/test/framework/components/istio"
+	"istio.io/istio/pkg/test/framework/resource"
+	"istio.io/istio/tests/integration/pilot/common"
+)
+
+var (
+	i istio.Instance
+
+	// Below are various preconfigured echo deployments. Whenever possible, tests should utilize these
+	// to avoid excessive creation/tear down of deployments. In general, a test should only deploy echo if
+	// its doing something unique to that specific test.
+	apps = deployment.SingleNamespaceView{}
+)
+
+func TestMain(m *testing.M) {
+	// nolint: staticcheck
+	framework.
+		NewSuite(m).
+		RequireMinVersion(17).
+		RequireMinClusters(2).
+		Setup(istio.Setup(&i, func(t resource.Context, cfg *istio.Config) {
+			cfg.ControlPlaneValues = `
+values:
+  pilot:
+    env:
+      LOCAL_CLUSTER_SECERT_WATCHER: "true"`
+		})).
+		Setup(deployment.SetupSingleNamespace(&apps, deployment.Config{})).
+		Run()
+}
+
+func TestTraffic(t *testing.T) {
+	framework.
+		NewTest(t).
+		Features("traffic.routing", "traffic.reachability", "traffic.shifting").
+		Run(func(t framework.TestContext) {
+			common.RunAllTrafficTests(t, i, apps)
+		})
+}


### PR DESCRIPTION
Fixes #31946 Allow Istiod to watch for local secret resources

Currently when Istiod runs as an external control plane, Istiod
only watches for secrets in a namespace of the config cluster. This
fix will also allow Istiod to watch for the secrets created in the
namespace where Istiod is actually running on the external control
plane cluster.

Signed-off-by: Tong Li <litong01@us.ibm.com>