### PR TITLE
Make use protobuf codec for k8s api resources

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -374,6 +374,8 @@ func newClientInternal(clientFactory util.Factory, revision string) (*client, er
 		return nil, err
 	}
 
+	config := rest.CopyConfig(c.config)
+	config.ContentType = runtime.ContentTypeProtobuf
 	c.Interface, err = kubernetes.NewForConfig(c.config)
 	c.kube = c.Interface
 	if err != nil {


### PR DESCRIPTION
**Please provide a description of this PR:**

Protobuf is more efficient compared to json. Currently crd does not support protobuf  content type.