### PR TITLE
Fix ServiceEntry endpoint port setting order

### DIFF
--- a/pilot/pkg/serviceregistry/serviceentry/controller.go
+++ b/pilot/pkg/serviceregistry/serviceentry/controller.go
@@ -491,7 +491,7 @@ func (s *Controller) WorkloadInstanceHandler(wi *model.WorkloadInstance, event m
 		}
 		seNamespacedName := types.NamespacedName{Namespace: cfg.Namespace, Name: cfg.Name}
 		services := s.services.getServices(seNamespacedName)
-		instance := convertWorkloadInstanceToServiceInstance(wi.Endpoint, services, se)
+		instance := convertWorkloadInstanceToServiceInstance(wi, services, se)
 		instances = append(instances, instance...)
 		if addressToDelete != "" {
 			for _, i := range instance {
@@ -927,7 +927,7 @@ func (s *Controller) buildServiceInstances(
 					currentServiceEntry.Hosts)
 				continue
 			}
-			instances := convertWorkloadInstanceToServiceInstance(wi.Endpoint, services, currentServiceEntry)
+			instances := convertWorkloadInstanceToServiceInstance(wi, services, currentServiceEntry)
 			serviceInstances = append(serviceInstances, instances...)
 			ckey := configKey{namespace: wi.Namespace, name: wi.Name}
 			if wi.Kind == model.PodKind {

--- a/pilot/pkg/serviceregistry/serviceregistry_test.go
+++ b/pilot/pkg/serviceregistry/serviceregistry_test.go
@@ -291,6 +291,39 @@ func TestWorkloadInstances(t *testing.T) {
 		expectServiceInstances(t, wc, expectedSvc, 80, instances)
 	})
 
+	t.Run("External only: the port name of the workloadEntry and serviceEntry does match, "+
+		"serviceEntry's targetPort not equal workloadEntry's, use workloadEntry port to override", func(t *testing.T) {
+		_, wc, store, _, _ := setupTest(t)
+		se := serviceEntry.Spec.(*networking.ServiceEntry).DeepCopy()
+		se.Ports[0].TargetPort = 8081 // respect wle port firstly, does not care about this value at all.
+
+		makeIstioObject(t, store, config.Config{
+			Meta: config.Meta{
+				Name:             "workload",
+				Namespace:        namespace,
+				GroupVersionKind: gvk.WorkloadEntry,
+				Domain:           "cluster.local",
+			},
+			Spec: &networking.WorkloadEntry{
+				Address: "2.3.4.5",
+				Labels:  labels,
+				Ports: map[string]uint32{
+					serviceEntry.Spec.(*networking.ServiceEntry).Ports[0].Name: 8080,
+				},
+			},
+		})
+
+		makeIstioObject(t, store, serviceEntry)
+
+		instances := []ServiceInstanceResponse{{
+			Hostname:   expectedSvc.Hostname,
+			Namestring: expectedSvc.Attributes.Namespace,
+			Address:    workloadEntry.Spec.(*networking.WorkloadEntry).Address,
+			Port:       8080,
+		}}
+		expectServiceInstances(t, wc, expectedSvc, 80, instances)
+	})
+
 	t.Run("External only: workloadEntry port is not set, use target port", func(t *testing.T) {
 		_, wc, store, _, _ := setupTest(t)
 		makeIstioObject(t, store, config.Config{


### PR DESCRIPTION
**Please provide a description of this PR:**

Fix https://github.com/istio/istio/issues/38642

This is to make a determined order consistent with workload handler.

The priority is:

1. when see port name = wle port name. use the wle port.
2. use se target port
3. use se port number.