### PR TITLE
No need to store unconcerned ingresses.

### DIFF
--- a/pilot/pkg/config/kube/ingress/controller.go
+++ b/pilot/pkg/config/kube/ingress/controller.go
@@ -95,9 +95,6 @@ type controller struct {
 	serviceLister   listerv1.ServiceLister
 	// May be nil if ingress class is not supported in the cluster
 	classes v1beta1.IngressClassInformer
-
-	// Only use for test case.
-	eventCompletedCallback func()
 }
 
 // TODO: move to features ( and remove in 1.2 )
@@ -224,12 +221,6 @@ func (c *controller) shouldProcessIngressUpdate(ing *ingress.Ingress) (bool, err
 }
 
 func (c *controller) onEvent(item types.NamespacedName) error {
-	defer func() {
-		if c.eventCompletedCallback != nil {
-			c.eventCompletedCallback()
-		}
-	}()
-
 	event := model.EventUpdate
 	ing, err := c.ingressLister.Ingresses(item.Namespace).Get(item.Name)
 	if err != nil {

--- a/pilot/pkg/config/kube/ingress/controller_test.go
+++ b/pilot/pkg/config/kube/ingress/controller_test.go
@@ -160,7 +160,7 @@ type configHandler struct {
 	notifyCh chan config.Config
 }
 
-func newConfigHandler() *configHandler{
+func newConfigHandler() *configHandler {
 	return &configHandler{
 		notifyCh: make(chan config.Config, 2),
 	}
@@ -173,7 +173,7 @@ func (c *configHandler) handle(_, curr config.Config, _ model.Event) {
 func newFakeController(options ingressClassOptions) (model.ConfigStoreController, kube.Client) {
 	meshHolder := mesh.NewTestWatcher(&meshconfig.MeshConfig{
 		IngressControllerMode: options.mode,
-		IngressClass: options.ingressClass,
+		IngressClass:          options.ingressClass,
 	})
 	fakeClient := kube.NewFakeClient()
 	return NewController(fakeClient, meshHolder, kubecontroller.Options{}), fakeClient
@@ -255,7 +255,7 @@ func TestIngressControllerWithStrictIngressControllerMode(t *testing.T) {
 	defer close(stopCh)
 
 	options := ingressClassOptions{
-		mode: meshconfig.MeshConfig_STRICT,
+		mode:         meshconfig.MeshConfig_STRICT,
 		ingressClass: "istio",
 	}
 	controller, client := initAndStartController(options, configHandler, stopCh)

--- a/pilot/pkg/config/kube/ingress/controller_test.go
+++ b/pilot/pkg/config/kube/ingress/controller_test.go
@@ -229,7 +229,7 @@ func TestIngressControllerWithDefaultIngressControllerMode(t *testing.T) {
 	}
 
 	// This time is enough for waiting the ingress event processed.
-	<-time.After(time.Second*2)
+	<-time.After(time.Second * 2)
 
 	// We should not store unmatched ingresses
 	if len(controller.ingresses) != len(ingressWithoutClass) {
@@ -276,7 +276,7 @@ func TestIngressControllerWithStrictIngressControllerMode(t *testing.T) {
 	}
 
 	// This time is enough for waiting the ingress event processed.
-	<-time.After(time.Second*2)
+	<-time.After(time.Second * 2)
 
 	// We should not store unmatched ingresses
 	if len(controller.ingresses) != len(ingressWithClass) {

--- a/pilot/pkg/config/kube/ingress/controller_test.go
+++ b/pilot/pkg/config/kube/ingress/controller_test.go
@@ -162,7 +162,7 @@ type configHandler struct {
 
 func newConfigHandler() *configHandler {
 	return &configHandler{
-		notifyCh: make(chan config.Config, 2),
+		notifyCh: make(chan config.Config, 4),
 	}
 }
 
@@ -188,10 +188,6 @@ func initAndStartController(options ingressClassOptions, handler *configHandler,
 	client.RunAndWait(stopCh)
 
 	rawController := cacheStoreController.(*controller)
-	rawController.eventCompletedCallback = func() {
-		// Use empty config as event completed mark.
-		handler.notifyCh <- config.Config{}
-	}
 	return rawController, client
 }
 
@@ -206,20 +202,13 @@ func TestIngressControllerWithDefaultIngressControllerMode(t *testing.T) {
 	controller, client := initAndStartController(options, configHandler, stopCh)
 
 	wait := func() config.Config {
-		result := config.Config{}
-		for {
-			select {
-			case x := <-configHandler.notifyCh:
-				if x.Name != "" {
-					result = x
-				} else {
-					return result
-				}
-			case <-time.After(time.Second * 10):
-				t.Fatalf("timed out waiting for config")
-				return result
-			}
+		select {
+		case x := <-configHandler.notifyCh:
+			return x
+		case <-time.After(time.Second * 10):
+			t.Fatalf("timed out waiting for config")
 		}
+		return config.Config{}
 	}
 
 	for _, ingress := range ingressWithoutClass {
@@ -237,11 +226,10 @@ func TestIngressControllerWithDefaultIngressControllerMode(t *testing.T) {
 	// Apply unmatched ingresses
 	for _, ingress := range ingressWithClass {
 		client.NetworkingV1beta1().Ingresses(ingress.Namespace).Create(context.TODO(), &ingress, metaV1.CreateOptions{})
-		vs := wait()
-		if vs.Name != "" || vs.Namespace != "" {
-			t.Fatalf("received unecpected config %v/%v", vs.Namespace, vs.Name)
-		}
 	}
+
+	// This time is enough for waiting the ingress event processed.
+	<-time.After(time.Second*2)
 
 	// We should not store unmatched ingresses
 	if len(controller.ingresses) != len(ingressWithoutClass) {
@@ -261,20 +249,13 @@ func TestIngressControllerWithStrictIngressControllerMode(t *testing.T) {
 	controller, client := initAndStartController(options, configHandler, stopCh)
 
 	wait := func() config.Config {
-		result := config.Config{}
-		for {
-			select {
-			case x := <-configHandler.notifyCh:
-				if x.Name != "" {
-					result = x
-				} else {
-					return result
-				}
-			case <-time.After(time.Second * 10):
-				t.Fatalf("timed out waiting for config")
-				return result
-			}
+		select {
+		case x := <-configHandler.notifyCh:
+			return x
+		case <-time.After(time.Second * 10):
+			t.Fatalf("timed out waiting for config")
 		}
+		return config.Config{}
 	}
 
 	for _, ingress := range ingressWithClass {
@@ -292,11 +273,10 @@ func TestIngressControllerWithStrictIngressControllerMode(t *testing.T) {
 	// Apply unmatched ingresses
 	for _, ingress := range ingressWithoutClass {
 		client.NetworkingV1beta1().Ingresses(ingress.Namespace).Create(context.TODO(), &ingress, metaV1.CreateOptions{})
-		vs := wait()
-		if vs.Name != "" || vs.Namespace != "" {
-			t.Fatalf("received unecpected config %v/%v", vs.Namespace, vs.Name)
-		}
 	}
+
+	// This time is enough for waiting the ingress event processed.
+	<-time.After(time.Second*2)
 
 	// We should not store unmatched ingresses
 	if len(controller.ingresses) != len(ingressWithClass) {

--- a/pilot/pkg/config/kube/ingressv1/controller.go
+++ b/pilot/pkg/config/kube/ingressv1/controller.go
@@ -93,9 +93,6 @@ type controller struct {
 	serviceLister   listerv1.ServiceLister
 	// May be nil if ingress class is not supported in the cluster
 	classes ingressinformer.IngressClassInformer
-
-	// Only use for test case.
-	eventCompletedCallback func()
 }
 
 // TODO: move to features ( and remove in 1.2 )
@@ -177,12 +174,6 @@ func (c *controller) shouldProcessIngressUpdate(ing *knetworking.Ingress) (bool,
 }
 
 func (c *controller) onEvent(item types.NamespacedName) error {
-	defer func() {
-		if c.eventCompletedCallback != nil {
-			c.eventCompletedCallback()
-		}
-	}()
-
 	event := model.EventUpdate
 	ing, err := c.ingressLister.Ingresses(item.Namespace).Get(item.Name)
 	if err != nil {

--- a/pilot/pkg/config/kube/ingressv1/controller_test.go
+++ b/pilot/pkg/config/kube/ingressv1/controller_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/api/networking/v1"
+	v1 "k8s.io/api/networking/v1"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
@@ -175,7 +175,7 @@ type configHandler struct {
 	notifyCh chan config.Config
 }
 
-func newConfigHandler() *configHandler{
+func newConfigHandler() *configHandler {
 	return &configHandler{
 		notifyCh: make(chan config.Config, 2),
 	}
@@ -188,7 +188,7 @@ func (c *configHandler) handle(_, curr config.Config, _ model.Event) {
 func newFakeController(options ingressClassOptions) (model.ConfigStoreController, kube.Client) {
 	meshHolder := mesh.NewTestWatcher(&meshconfig.MeshConfig{
 		IngressControllerMode: options.mode,
-		IngressClass: options.ingressClass,
+		IngressClass:          options.ingressClass,
 	})
 	fakeClient := kube.NewFakeClient()
 	return NewController(fakeClient, meshHolder, kubecontroller.Options{}), fakeClient
@@ -270,7 +270,7 @@ func TestIngressControllerWithStrictIngressControllerMode(t *testing.T) {
 	defer close(stopCh)
 
 	options := ingressClassOptions{
-		mode: meshconfig.MeshConfig_STRICT,
+		mode:         meshconfig.MeshConfig_STRICT,
 		ingressClass: "istio",
 	}
 	controller, client := initAndStartController(options, configHandler, stopCh)
@@ -318,4 +318,3 @@ func TestIngressControllerWithStrictIngressControllerMode(t *testing.T) {
 		t.Fatalf("ingresses size should be %d, actual is %d", len(ingressWithClass), len(controller.ingresses))
 	}
 }
-

--- a/pilot/pkg/config/kube/ingressv1/controller_test.go
+++ b/pilot/pkg/config/kube/ingressv1/controller_test.go
@@ -244,7 +244,7 @@ func TestIngressControllerWithDefaultIngressControllerMode(t *testing.T) {
 	}
 
 	// This time is enough for waiting the ingress event processed.
-	<-time.After(time.Second*2)
+	<-time.After(time.Second * 2)
 
 	// We should not store unmatched ingresses
 	if len(controller.ingresses) != len(ingressWithoutClass) {
@@ -291,7 +291,7 @@ func TestIngressControllerWithStrictIngressControllerMode(t *testing.T) {
 	}
 
 	// This time is enough for waiting the ingress event processed.
-	<-time.After(time.Second*2)
+	<-time.After(time.Second * 2)
 
 	// We should not store unmatched ingresses
 	if len(controller.ingresses) != len(ingressWithClass) {


### PR DESCRIPTION
In our k8s cluster, there are so many ingress resources. The istio ingress controller running in the cluster only care a little ingress resources whose ingress class is defined as `istio`. We found the ingress controller in istio still store the other ingress resources that has different ingress class, which wastes memory. This pr fix this issue to release memory for these unconcerned ingresses.
The added unit tests will fail without this pr.

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
