### PR TITLE
allow regex in delegates

### DIFF
--- a/pilot/pkg/model/virtualservice.go
+++ b/pilot/pkg/model/virtualservice.go
@@ -483,9 +483,17 @@ func stringMatchConflict(root, leaf *networking.StringMatch) bool {
 	if root == nil || leaf == nil {
 		return false
 	}
-	// regex match is not allowed
-	if root.GetRegex() != "" || leaf.GetRegex() != "" {
-		return true
+	// If root regex match is specified, delegate should not have other matches.
+	if root.GetRegex() != "" {
+		if leaf.GetRegex() != "" || leaf.GetPrefix() != "" || leaf.GetExact() != "" {
+			return true
+		}
+	}
+	// If delgate regex match is specified, root should not have other matches.
+	if leaf.GetRegex() != "" {
+		if root.GetRegex() != "" || root.GetPrefix() != "" || root.GetExact() != "" {
+			return true
+		}
 	}
 	// root is exact match
 	if exact := root.GetExact(); exact != "" {

--- a/pilot/pkg/model/virtualservice_test.go
+++ b/pilot/pkg/model/virtualservice_test.go
@@ -1084,6 +1084,44 @@ func TestMergeHTTPMatchRequests(t *testing.T) {
 			},
 		},
 		{
+			name: "url regex noconflict",
+			root: []*networking.HTTPMatchRequest{
+				{
+					Uri: &networking.StringMatch{
+						MatchType: &networking.StringMatch_Regex{Regex: "^/productpage"},
+					},
+				},
+			},
+			delegate: []*networking.HTTPMatchRequest{
+				{},
+			},
+			expected: []*networking.HTTPMatchRequest{
+				{
+					Uri: &networking.StringMatch{
+						MatchType: &networking.StringMatch_Regex{Regex: "^/productpage"},
+					},
+				},
+			},
+		},
+		{
+			name: "url regex conflict",
+			root: []*networking.HTTPMatchRequest{
+				{
+					Uri: &networking.StringMatch{
+						MatchType: &networking.StringMatch_Regex{Regex: "^/productpage"},
+					},
+				},
+			},
+			delegate: []*networking.HTTPMatchRequest{
+				{
+					Uri: &networking.StringMatch{
+						MatchType: &networking.StringMatch_Prefix{Prefix: "/productpage"},
+					},
+				},
+			},
+			expected: nil,
+		},
+		{
 			name: "multi url match",
 			root: []*networking.HTTPMatchRequest{
 				{
@@ -1445,6 +1483,54 @@ func TestHasConflict(t *testing.T) {
 			leaf: &networking.HTTPMatchRequest{
 				Uri: &networking.StringMatch{
 					MatchType: &networking.StringMatch_Prefix{Prefix: "/productpage/v2"},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "regex uri in root and delegate does not have uri",
+			root: &networking.HTTPMatchRequest{
+				Uri: &networking.StringMatch{
+					MatchType: &networking.StringMatch_Regex{Regex: "^/productpage"},
+				},
+			},
+			leaf:     &networking.HTTPMatchRequest{},
+			expected: false,
+		},
+		{
+			name: "regex uri in delegate and root does not have uri",
+			root: &networking.HTTPMatchRequest{},
+			leaf: &networking.HTTPMatchRequest{
+				Uri: &networking.StringMatch{
+					MatchType: &networking.StringMatch_Regex{Regex: "^/productpage"},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "regex uri in root and delegate has conflicting uri match",
+			root: &networking.HTTPMatchRequest{
+				Uri: &networking.StringMatch{
+					MatchType: &networking.StringMatch_Regex{Regex: "^/productpage"},
+				},
+			},
+			leaf: &networking.HTTPMatchRequest{
+				Uri: &networking.StringMatch{
+					MatchType: &networking.StringMatch_Prefix{Prefix: "/productpage"},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "regex uri in delegate and root has conflicting uri match",
+			root: &networking.HTTPMatchRequest{
+				Uri: &networking.StringMatch{
+					MatchType: &networking.StringMatch_Prefix{Prefix: "/productpage"},
+				},
+			},
+			leaf: &networking.HTTPMatchRequest{
+				Uri: &networking.StringMatch{
+					MatchType: &networking.StringMatch_Regex{Regex: "^/productpage"},
 				},
 			},
 			expected: true,

--- a/pkg/config/validation/virtualservice.go
+++ b/pkg/config/validation/virtualservice.go
@@ -156,25 +156,9 @@ func validateHTTPRouteMatchRequest(http *networking.HTTPRoute, routeType HTTPRou
 	} else {
 		for _, match := range http.Match {
 			if match != nil {
-				if containRegexMatch(match.Uri) {
-					errs = appendErrors(errs, errors.New("url match does not support regex match for delegating"))
-				}
-				if containRegexMatch(match.Scheme) {
-					errs = appendErrors(errs, errors.New("scheme match does not support regex match for delegating"))
-				}
-				if containRegexMatch(match.Method) {
-					errs = appendErrors(errs, errors.New("method match does not support regex match for delegating"))
-				}
-				if containRegexMatch(match.Authority) {
-					errs = appendErrors(errs, errors.New("authority match does not support regex match for delegating"))
-				}
-
 				for name, header := range match.Headers {
 					if header == nil {
 						errs = appendErrors(errs, fmt.Errorf("header match %v cannot be null", name))
-					}
-					if containRegexMatch(header) {
-						errs = appendErrors(errs, fmt.Errorf("header match %v does not support regex match for delegating", name))
 					}
 					errs = appendErrors(errs, ValidateHTTPHeaderName(name))
 				}
@@ -182,16 +166,10 @@ func validateHTTPRouteMatchRequest(http *networking.HTTPRoute, routeType HTTPRou
 					if param == nil {
 						errs = appendErrors(errs, fmt.Errorf("query param match %v cannot be null", name))
 					}
-					if containRegexMatch(param) {
-						errs = appendErrors(errs, fmt.Errorf("query param match %v does not support regex match for delegating", name))
-					}
 				}
 				for name, header := range match.WithoutHeaders {
 					if header == nil {
 						errs = appendErrors(errs, fmt.Errorf("withoutHeaders match %v cannot be null", name))
-					}
-					if containRegexMatch(header) {
-						errs = appendErrors(errs, fmt.Errorf("withoutHeaders match %v does not support regex match for delegating", name))
 					}
 					errs = appendErrors(errs, ValidateHTTPHeaderName(name))
 				}
@@ -256,18 +234,6 @@ func validateHTTPRouteConflict(http *networking.HTTPRoute, routeType HTTPRouteTy
 	}
 
 	return errs
-}
-
-func containRegexMatch(config *networking.StringMatch) bool {
-	if config == nil {
-		return false
-	}
-	switch config.GetMatchType().(type) {
-	case *networking.StringMatch_Regex:
-		return true
-	default:
-		return false
-	}
 }
 
 // isInternalHeader returns true if a header refers to an internal value that cannot be modified by Envoy

--- a/pkg/config/validation/virtualservice_test.go
+++ b/pkg/config/validation/virtualservice_test.go
@@ -247,7 +247,7 @@ func TestValidateRootHTTPRoute(t *testing.T) {
 					},
 				},
 			}},
-		}, valid: false},
+		}, valid: true},
 		{name: "regex uri match", route: &networking.HTTPRoute{
 			Delegate: &networking.Delegate{
 				Name:      "test",
@@ -258,7 +258,7 @@ func TestValidateRootHTTPRoute(t *testing.T) {
 					MatchType: &networking.StringMatch_Regex{Regex: "test"},
 				},
 			}},
-		}, valid: false},
+		}, valid: true},
 		{name: "prefix uri match", route: &networking.HTTPRoute{
 			Delegate: &networking.Delegate{
 				Name:      "test",
@@ -323,7 +323,7 @@ func TestValidateRootHTTPRoute(t *testing.T) {
 					},
 				},
 			}},
-		}, valid: false},
+		}, valid: true},
 		{name: "empty regex match in method", route: &networking.HTTPRoute{
 			Match: []*networking.HTTPMatchRequest{{
 				Method: &networking.StringMatch{
@@ -362,17 +362,6 @@ func TestValidateRootHTTPRoute(t *testing.T) {
 		{name: "empty regex match in scheme", route: &networking.HTTPRoute{
 			Match: []*networking.HTTPMatchRequest{{
 				Scheme: &networking.StringMatch{
-					MatchType: &networking.StringMatch_Regex{Regex: ""},
-				},
-			}},
-			Redirect: &networking.HTTPRedirect{
-				Uri:       "/",
-				Authority: "foo.biz",
-			},
-		}, valid: false},
-		{name: "empty regex match in scheme", route: &networking.HTTPRoute{
-			Match: []*networking.HTTPMatchRequest{{
-				Authority: &networking.StringMatch{
 					MatchType: &networking.StringMatch_Regex{Regex: ""},
 				},
 			}},


### PR DESCRIPTION
This PR allows regex in delegates when there is one regex either at root or delegate and if regex is specified in either delegate or root, no other matching condition can be specified.

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure