### PR TITLE
Set ENABLE_LEGACY_FSGROUP_INJECTION to false by default

### DIFF
--- a/operator/pkg/manifest/shared.go
+++ b/operator/pkg/manifest/shared.go
@@ -430,8 +430,8 @@ func getClusterSpecificValues(client kube.Client, force bool, l clog.Logger) (st
 }
 
 func getFSGroupOverlay(config kube.Client) string {
-	if kube.IsAtLeastVersion(config, 19) {
-		return "values.pilot.env.ENABLE_LEGACY_FSGROUP_INJECTION=false"
+	if kube.IsLessThanVersion(config, 19) {
+		return "values.pilot.env.ENABLE_LEGACY_FSGROUP_INJECTION=true"
 	}
 	return ""
 }

--- a/operator/pkg/manifest/shared.go
+++ b/operator/pkg/manifest/shared.go
@@ -430,7 +430,12 @@ func getClusterSpecificValues(client kube.Client, force bool, l clog.Logger) (st
 }
 
 func getFSGroupOverlay(config kube.Client) string {
-	if kube.IsLessThanVersion(config, 19) {
+	// ENABLE_LEGACY_FSGROUP_INJECTION has first-party-jwt as allowed because we only
+	// need the fsGroup configuration for the projected service account volume mount,
+	// which is only used by first-party-jwt. The installer will automatically
+	// configure this on Kubernetes 1.18 or older.
+	jwtPolicy, _ := util.DetectSupportedJWTPolicy(config)
+	if kube.IsLessThanVersion(config, 19) && jwtPolicy != util.FirstPartyJWT {
 		return "values.pilot.env.ENABLE_LEGACY_FSGROUP_INJECTION=true"
 	}
 	return ""

--- a/operator/pkg/manifest/shared.go
+++ b/operator/pkg/manifest/shared.go
@@ -430,10 +430,9 @@ func getClusterSpecificValues(client kube.Client, force bool, l clog.Logger) (st
 }
 
 func getFSGroupOverlay(config kube.Client) string {
-	// ENABLE_LEGACY_FSGROUP_INJECTION has first-party-jwt as allowed because we only
-	// need the fsGroup configuration for the projected service account volume mount,
-	// which is only used by first-party-jwt. The installer will automatically
-	// configure this on Kubernetes 1.18 or older.
+	// Set ENABLE_LEGACY_FSGROUP_INJECTION to true only for Kubernetes 1.18 or older,
+	// together with third-party-jwt, as we need the fsGroup configuration for the projected
+	// service account volume mount, which is only used by third-party-jwt.
 	jwtPolicy, _ := util.DetectSupportedJWTPolicy(config)
 	if kube.IsLessThanVersion(config, 19) && jwtPolicy != util.FirstPartyJWT {
 		return "values.pilot.env.ENABLE_LEGACY_FSGROUP_INJECTION=true"

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -448,7 +448,7 @@ var (
 	// which is only used by first-party-jwt. The installer will automatically
 	// configure this on Kubernetes 1.19+.
 	// Note: while this appears unused in the go code, this sets a default which is used in the injection template.
-	EnableLegacyFSGroupInjection = env.RegisterBoolVar("ENABLE_LEGACY_FSGROUP_INJECTION", JwtPolicy != jwt.PolicyFirstParty,
+	EnableLegacyFSGroupInjection = env.RegisterBoolVar("ENABLE_LEGACY_FSGROUP_INJECTION", false,
 		"If true, Istiod will set the pod fsGroup to 1337 on injection. This is required for Kubernetes 1.18 and older "+
 			`(see https://github.com/kubernetes/kubernetes/issues/57923 for details) unless JWT_POLICY is "first-party-jwt".`).Get()
 

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -443,10 +443,6 @@ var (
 	XDSCacheMaxSize = env.RegisterIntVar("PILOT_XDS_CACHE_SIZE", 60000,
 		"The maximum number of cache entries for the XDS cache.").Get()
 
-	// EnableLegacyFSGroupInjection has first-party-jwt as allowed because we only
-	// need the fsGroup configuration for the projected service account volume mount,
-	// which is only used by first-party-jwt. The installer will automatically
-	// configure this on Kubernetes 1.19+.
 	// Note: while this appears unused in the go code, this sets a default which is used in the injection template.
 	EnableLegacyFSGroupInjection = env.RegisterBoolVar("ENABLE_LEGACY_FSGROUP_INJECTION", false,
 		"If true, Istiod will set the pod fsGroup to 1337 on injection. This is required for Kubernetes 1.18 and older "+

--- a/releasenotes/notes/disable-fs-group-injection.yaml
+++ b/releasenotes/notes/disable-fs-group-injection.yaml
@@ -3,5 +3,6 @@ kind: feature
 area: installation
 releaseNotes:
 - |
-  **Updated** default value of the feature flag `ENABLE_LEGACY_FSGROUP_INJECTION` to false
+  **Updated** default value of the feature flag `ENABLE_LEGACY_FSGROUP_INJECTION` to false.
+  This may cause issues with sidecars when installing on Helm on Kubernetes versions prior to 1.19.
 

--- a/releasenotes/notes/disable-fs-group-injection.yaml
+++ b/releasenotes/notes/disable-fs-group-injection.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+releaseNotes:
+- |
+  **Updated** default value of the feature flag `ENABLE_LEGACY_FSGROUP_INJECTION` to false
+


### PR DESCRIPTION
Signed-off-by: Faseela K <faseela.k@est.tech>

**Please provide a description of this PR:**

Since k8s 1.18 is outside of the official istio support window,
changing the default value of the feature flag, though the changes
to automatically detect the version and set the flag are retained.



**Please check any characteristics that apply to this pull request.**

- [] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.