### PR TITLE
fixed the multicluster tests failure for ca custom root tests

### DIFF
--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -912,15 +912,11 @@ func deployCACerts(workDir string, env *kube.Environment, cfg Config) error {
 		// Create the secret for the cacerts.
 		if _, err := c.CoreV1().Secrets(cfg.SystemNamespace).Create(context.TODO(), secret,
 			kubeApiMeta.CreateOptions{}); err != nil {
-			if errors.IsAlreadyExists(err) {
-				if _, err := c.CoreV1().Secrets(cfg.SystemNamespace).Update(context.TODO(), secret,
-					kubeApiMeta.UpdateOptions{}); err != nil {
-					scopes.Framework.Errorf("failed to create CA secrets on cluster %s. This can happen when deploying "+
-						"multiple control planes. Error: %v", c.Name(), err)
-				}
-			} else {
+			// no need to do anything if cacerts is already present
+			if !errors.IsAlreadyExists(err) {
 				scopes.Framework.Errorf("failed to create CA secrets on cluster %s. This can happen when deploying "+
 					"multiple control planes. Error: %v", c.Name(), err)
+
 			}
 		}
 	}

--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -910,15 +910,17 @@ func deployCACerts(workDir string, env *kube.Environment, cfg Config) error {
 		}
 
 		// Create the secret for the cacerts.
-		// if _, err := c.CoreV1().Secrets(cfg.SystemNamespace).Create(context.TODO(), secret,
-		// 	kubeApiMeta.CreateOptions{}); err != nil {
-		// 	// no need to do anything if cacerts is already present
-		// 	if !errors.IsAlreadyExists(err) {
-		// 		fmt.Println("---cacerts is there---")
-		// 		scopes.Framework.Errorf("failed to create CA secrets on cluster %s. This can happen when deploying "+
-		// 			"multiple control planes. Error: %v", c.Name(), err)
-		// 	}
-		// }
+		if _, err := c.CoreV1().Secrets(cfg.SystemNamespace).Create(context.TODO(), secret,
+			kubeApiMeta.CreateOptions{}); err != nil {
+			// no need to do anything if cacerts is already present
+			if !errors.IsAlreadyExists(err) {
+				fmt.Println("---cacerts is there---")
+				scopes.Framework.Errorf("failed to create CA secrets on cluster %s. This can happen when deploying "+
+					"multiple control planes. Error: %v", c.Name(), err)
+			} else {
+				fmt.Println("---cacerts is not there---")
+			}
+		}
 	}
 	return nil
 }

--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -52,7 +52,6 @@ import (
 	"istio.io/istio/pkg/test/framework/resource/config/apply"
 	kube2 "istio.io/istio/pkg/test/kube"
 	"istio.io/istio/pkg/test/scopes"
-	"istio.io/istio/pkg/test/shell"
 	"istio.io/istio/pkg/test/util/file"
 	"istio.io/istio/pkg/test/util/retry"
 	"istio.io/istio/pkg/test/util/yml"
@@ -917,17 +916,6 @@ func deployCACerts(workDir string, env *kube.Environment, cfg Config) error {
 			if !errors.IsAlreadyExists(err) {
 				scopes.Framework.Errorf("failed to create CA secrets on cluster %s. This can happen when deploying "+
 					"multiple control planes. Error: %v", c.Name(), err)
-			} else {
-				fmt.Println("---cacerts is there---")
-				cmd1 := "kubectl get secret cacerts -n istio-system -o jsonpath='{.data}'"
-				output, err := shell.Execute(false, cmd1)
-				if err != nil {
-					fmt.Println("unable to install oc", err)
-				} else {
-					fmt.Println("----output-----", output)
-					fmt.Println("---cluster----", c)
-				}
-
 			}
 		}
 	}

--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -918,11 +918,6 @@ func deployCACerts(workDir string, env *kube.Environment, cfg Config) error {
 				scopes.Framework.Errorf("failed to create CA secrets on cluster %s. This can happen when deploying "+
 					"multiple control planes. Error: %v", c.Name(), err)
 			} else {
-				if _, err := c.CoreV1().Secrets(cfg.SystemNamespace).Update(context.TODO(), secret,
-					kubeApiMeta.UpdateOptions{}); err != nil {
-					scopes.Framework.Errorf("failed to create CA secrets on cluster %s. This can happen when deploying "+
-						"multiple control planes. Error: %v", c.Name(), err)
-				}
 				fmt.Println("---cacerts is there---")
 				cmd1 := "kubectl get secret cacerts -n istio-system -o jsonpath='{.data}'"
 				output, err := shell.Execute(false, cmd1)

--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -910,15 +910,15 @@ func deployCACerts(workDir string, env *kube.Environment, cfg Config) error {
 		}
 
 		// Create the secret for the cacerts.
-		if _, err := c.CoreV1().Secrets(cfg.SystemNamespace).Create(context.TODO(), secret,
-			kubeApiMeta.CreateOptions{}); err != nil {
-			// no need to do anything if cacerts is already present
-			if !errors.IsAlreadyExists(err) {
-				scopes.Framework.Errorf("failed to create CA secrets on cluster %s. This can happen when deploying "+
-					"multiple control planes. Error: %v", c.Name(), err)
-
-			}
-		}
+		// if _, err := c.CoreV1().Secrets(cfg.SystemNamespace).Create(context.TODO(), secret,
+		// 	kubeApiMeta.CreateOptions{}); err != nil {
+		// 	// no need to do anything if cacerts is already present
+		// 	if !errors.IsAlreadyExists(err) {
+		// 		fmt.Println("---cacerts is there---")
+		// 		scopes.Framework.Errorf("failed to create CA secrets on cluster %s. This can happen when deploying "+
+		// 			"multiple control planes. Error: %v", c.Name(), err)
+		// 	}
+		// }
 	}
 	return nil
 }

--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -915,10 +915,14 @@ func deployCACerts(workDir string, env *kube.Environment, cfg Config) error {
 			kubeApiMeta.CreateOptions{}); err != nil {
 			// no need to do anything if cacerts is already present
 			if !errors.IsAlreadyExists(err) {
-				fmt.Println("---cacerts is not there---")
 				scopes.Framework.Errorf("failed to create CA secrets on cluster %s. This can happen when deploying "+
 					"multiple control planes. Error: %v", c.Name(), err)
 			} else {
+				if _, err := c.CoreV1().Secrets(cfg.SystemNamespace).Update(context.TODO(), secret,
+					kubeApiMeta.UpdateOptions{}); err != nil {
+					scopes.Framework.Errorf("failed to create CA secrets on cluster %s. This can happen when deploying "+
+						"multiple control planes. Error: %v", c.Name(), err)
+				}
 				fmt.Println("---cacerts is there---")
 				cmd1 := "kubectl get secret cacerts -n istio-system -o jsonpath='{.data}'"
 				output, err := shell.Execute(false, cmd1)

--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -52,6 +52,7 @@ import (
 	"istio.io/istio/pkg/test/framework/resource/config/apply"
 	kube2 "istio.io/istio/pkg/test/kube"
 	"istio.io/istio/pkg/test/scopes"
+	"istio.io/istio/pkg/test/shell"
 	"istio.io/istio/pkg/test/util/file"
 	"istio.io/istio/pkg/test/util/retry"
 	"istio.io/istio/pkg/test/util/yml"
@@ -914,11 +915,20 @@ func deployCACerts(workDir string, env *kube.Environment, cfg Config) error {
 			kubeApiMeta.CreateOptions{}); err != nil {
 			// no need to do anything if cacerts is already present
 			if !errors.IsAlreadyExists(err) {
-				fmt.Println("---cacerts is there---")
+				fmt.Println("---cacerts is not there---")
 				scopes.Framework.Errorf("failed to create CA secrets on cluster %s. This can happen when deploying "+
 					"multiple control planes. Error: %v", c.Name(), err)
 			} else {
-				fmt.Println("---cacerts is not there---")
+				fmt.Println("---cacerts is there---")
+				cmd1 := "kubectl get secret cacerts -n istio-system -o jsonpath='{.data}'"
+				output, err := shell.Execute(false, cmd1)
+				if err != nil {
+					fmt.Println("unable to install oc", err)
+				} else {
+					fmt.Println("----output-----", output)
+					fmt.Println("---cluster----", c)
+				}
+
 			}
 		}
 	}

--- a/tests/integration/security/ca_custom_root/secure_naming_test.go
+++ b/tests/integration/security/ca_custom_root/secure_naming_test.go
@@ -229,11 +229,9 @@ func checkCACert(t framework.TestContext, testNamespace namespace.Instance) erro
 	}
 	t.Logf("CA certificate %v found", constants.CACertNamespaceConfigMapDataName)
 	if pluginCert, err = cert.ReadSampleCertFromFile("root-cert.pem"); err != nil {
-		fmt.Println("plugin cert issue")
 		return err
 	}
 	if string(pluginCert) != certData {
-		fmt.Println("data mismatch")
 		return fmt.Errorf("CA certificate (%v) not matching plugin cert (%v)", certData, string(pluginCert))
 	}
 

--- a/tests/integration/security/ca_custom_root/secure_naming_test.go
+++ b/tests/integration/security/ca_custom_root/secure_naming_test.go
@@ -106,10 +106,8 @@ func TestSecureNaming(t *testing.T) {
 	framework.NewTest(t).
 		Features("security.peer.secure-naming").
 		Run(func(t framework.TestContext) {
-			if t.AllClusters().IsMulticluster() {
-				t.Skip("https://github.com/istio/istio/issues/37307")
-			}
 			istioCfg := istio.DefaultConfigOrFail(t, t)
+
 			testNamespace := apps.Namespace
 			namespace.ClaimOrFail(t, t, istioCfg.SystemNamespace)
 			// Check that the CA certificate in the configmap of each namespace is as expected, which
@@ -231,9 +229,11 @@ func checkCACert(t framework.TestContext, testNamespace namespace.Instance) erro
 	}
 	t.Logf("CA certificate %v found", constants.CACertNamespaceConfigMapDataName)
 	if pluginCert, err = cert.ReadSampleCertFromFile("root-cert.pem"); err != nil {
+		fmt.Println("plugin cert issue")
 		return err
 	}
 	if string(pluginCert) != certData {
+		fmt.Println("data mismatch")
 		return fmt.Errorf("CA certificate (%v) not matching plugin cert (%v)", certData, string(pluginCert))
 	}
 

--- a/tests/integration/security/ca_custom_root/trust_domain_alias_secure_naming_test.go
+++ b/tests/integration/security/ca_custom_root/trust_domain_alias_secure_naming_test.go
@@ -70,9 +70,6 @@ func TestTrustDomainAliasSecureNaming(t *testing.T) {
 	framework.NewTest(t).
 		Features("security.peer.trust-domain-alias-secure-naming").
 		Run(func(t framework.TestContext) {
-			if t.AllClusters().IsMulticluster() {
-				t.Skip("https://github.com/istio/istio/issues/37307")
-			}
 			testNS := apps.Namespace
 
 			t.ConfigIstio().YAML(testNS.Name(), POLICY).ApplyOrFail(t)

--- a/tests/integration/security/ca_custom_root/trust_domain_validation_test.go
+++ b/tests/integration/security/ca_custom_root/trust_domain_validation_test.go
@@ -90,10 +90,6 @@ spec:
 func TestTrustDomainValidation(t *testing.T) {
 	framework.NewTest(t).Features("security.peer.trust-domain-validation").Run(
 		func(ctx framework.TestContext) {
-			if ctx.AllClusters().IsMulticluster() {
-				ctx.Skip("https://github.com/istio/istio/issues/37307")
-			}
-
 			testNS := apps.Namespace
 
 			ctx.ConfigIstio().YAML(testNS.Name(), fmt.Sprintf(policy, testNS.Name())).ApplyOrFail(ctx)

--- a/tests/integration/security/util/cert/cert.go
+++ b/tests/integration/security/util/cert/cert.go
@@ -20,9 +20,11 @@ package cert
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path"
 
+	kubeApiCore "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -97,6 +99,18 @@ func CreateCASecret(ctx resource.Context) error {
 				ca.CertChainFile:    certChain,
 				ca.RootCertFile:     rootCert,
 			},
+		}
+
+		if _, err := cluster.CoreV1().Namespaces().Create(context.TODO(), &kubeApiCore.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: systemNs.Name(),
+			},
+		}, metav1.CreateOptions{}); err != nil {
+			if !errors.IsAlreadyExists(err) {
+				return err
+			} else {
+				fmt.Println("istio-system is already there")
+			}
 		}
 
 		if _, err := cluster.CoreV1().Secrets(systemNs.Name()).Create(context.TODO(), secret, metav1.CreateOptions{}); err != nil {

--- a/tests/integration/security/util/cert/cert.go
+++ b/tests/integration/security/util/cert/cert.go
@@ -20,11 +20,9 @@ package cert
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"os"
 	"path"
 
-	kubeApiCore "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -87,7 +85,7 @@ func CreateCASecret(ctx resource.Context) error {
 		return err
 	}
 
-	for _, cluster := range ctx.Clusters() {
+	for _, cluster := range ctx.AllClusters() {
 		secret := &v1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
@@ -99,18 +97,6 @@ func CreateCASecret(ctx resource.Context) error {
 				ca.CertChainFile:    certChain,
 				ca.RootCertFile:     rootCert,
 			},
-		}
-
-		if _, err := cluster.CoreV1().Namespaces().Create(context.TODO(), &kubeApiCore.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: systemNs.Name(),
-			},
-		}, metav1.CreateOptions{}); err != nil {
-			if !errors.IsAlreadyExists(err) {
-				return err
-			} else {
-				fmt.Println("istio-system is already there")
-			}
 		}
 
 		if _, err := cluster.CoreV1().Secrets(systemNs.Name()).Create(context.TODO(), secret, metav1.CreateOptions{}); err != nil {


### PR DESCRIPTION
**We are updating the cacerts even if it is present in istiod, that creates conflict and the main reason for a lot of ca custom root multicluster test failure. In this PR, I have removed the logic for updating the cacerts if it is present in the istio-system**