### PR TITLE
tests: update deployment.yaml for gRPC C++ PSM tests

### DIFF
--- a/pkg/test/env/istio.go
+++ b/pkg/test/env/istio.go
@@ -50,6 +50,10 @@ var (
 	// nolint: golint, revive, stylecheck
 	PULL_POLICY Variable = "PULL_POLICY"
 
+	// TEST_ECHO_IMAGE is the image to use when deploying echo services.
+	// nolint: golint, revive, stylecheck
+	TEST_ECHO_IMAGE Variable = "TEST_ECHO_IMAGE"
+
 	// KUBECONFIG is the list of Kubernetes configuration files. If configuration files are specified on
 	// the command-line, that takes precedence.
 	// nolint: golint, revive, stylecheck

--- a/pkg/test/env/istio.go
+++ b/pkg/test/env/istio.go
@@ -50,9 +50,9 @@ var (
 	// nolint: golint, revive, stylecheck
 	PULL_POLICY Variable = "PULL_POLICY"
 
-	// TEST_ECHO_IMAGE is the image to use when deploying echo services.
+	// ECHO_IMAGE is the image to use when deploying echo services.
 	// nolint: golint, revive, stylecheck
-	TEST_ECHO_IMAGE Variable = "TEST_ECHO_IMAGE"
+	ECHO_IMAGE Variable = "ECHO_IMAGE"
 
 	// KUBECONFIG is the list of Kubernetes configuration files. If configuration files are specified on
 	// the command-line, that takes precedence.

--- a/pkg/test/framework/components/echo/cmd/echogen/testdata/golden.yaml
+++ b/pkg/test/framework/components/echo/cmd/echogen/testdata/golden.yaml
@@ -78,52 +78,32 @@ spec:
           readOnlyRootFilesystem: false
       - args:
         - --metrics=15014
-        - --cluster
-        - fake
-        - --port
-        - "18080"
-        - --grpc
-        - "17070"
-        - --port
-        - "18085"
-        - --tcp
-        - "19090"
-        - --port
-        - "18443"
+        - --cluster="fake"
+        - --port=18080
+        - --grpc=17070
+        - --port=18085
+        - --tcp=19090
+        - --port=18443
         - --tls=18443
-        - --tcp
-        - "16060"
+        - --tcp=16060
         - --server-first=16060
-        - --tcp
-        - "19091"
-        - --tcp
-        - "16061"
+        - --tcp=19091
+        - --tcp=16061
         - --server-first=16061
-        - --port
-        - "18081"
-        - --grpc
-        - "17071"
-        - --port
-        - "19443"
+        - --port=18081
+        - --grpc=17071
+        - --port=19443
         - --tls=19443
-        - --port
-        - "18082"
+        - --port=18082
         - --bind-ip=18082
-        - --port
-        - "18084"
+        - --port=18084
         - --bind-localhost=18084
-        - --tcp
-        - "19092"
-        - --port
-        - "18083"
-        - --port
-        - "8080"
-        - --port
-        - "3333"
-        - --version
-        - v1
-        - --istio-version
-        - ""
+        - --tcp=19092
+        - --port=18083
+        - --port=8080
+        - --port=3333
+        - --version="v1"
+        - --istio-version=""
         - --crt=/cert.crt
         - --key=/cert.key
         env:

--- a/pkg/test/framework/components/echo/cmd/echogen/testdata/golden.yaml
+++ b/pkg/test/framework/components/echo/cmd/echogen/testdata/golden.yaml
@@ -78,7 +78,7 @@ spec:
           readOnlyRootFilesystem: false
       - args:
         - --metrics=15014
-        - --cluster="fake"
+        - --cluster=fake
         - --port=18080
         - --grpc=17070
         - --port=18085
@@ -102,8 +102,8 @@ spec:
         - --port=18083
         - --port=8080
         - --port=3333
-        - --version="v1"
-        - --istio-version=""
+        - --version=v1
+        - --istio-version=
         - --crt=/cert.crt
         - --key=/cert.key
         env:

--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -671,7 +671,7 @@ func templateParams(cfg echo.Config, settings *resource.Settings) (map[string]in
 		"ImageTag":            strings.TrimSuffix(settings.Image.Tag, "-distroless"),
 		"ImagePullPolicy":     settings.Image.PullPolicy,
 		"ImagePullSecretName": imagePullSecretName,
-		"ImageFullPath":       settings.TestEchoImage, // This overrides image hub/tag if it's not empty.
+		"ImageFullPath":       settings.EchoImage, // This overrides image hub/tag if it's not empty.
 		"Service":             cfg.Service,
 		"Version":             cfg.Version,
 		"Headless":            cfg.Headless,

--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -182,7 +182,7 @@ spec:
           runAsGroup: 1338
         args:
           - --metrics=15014
-          - --cluster="{{ $cluster }}"
+          - --cluster={{ $cluster }}
 {{- range $i, $p := $.ContainerPorts }}
 {{- if eq .Protocol "GRPC" }}
 {{- if and $.ProxylessGRPC (ne $p.Port $.GRPCMagicPort) }}
@@ -207,8 +207,8 @@ spec:
           - --bind-localhost={{ $p.Port }}
 {{- end }}
 {{- end }}
-          - --version="{{ $subset.Version }}"
-          - --istio-version="{{ $version }}"
+          - --version={{ $subset.Version }}
+          - --istio-version={{ $version }}
 {{- if $.TLSSettings }}
           - --crt=/etc/certs/custom/cert-chain.pem
           - --key=/etc/certs/custom/key.pem

--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -235,7 +235,6 @@ spec:
         - name: EXPOSE_GRPC_ADMIN
           value: "true"
 {{- end }}
-{{- if $.ImageFullPath }}
         readinessProbe:
 {{- if $.ReadinessTCPPort }}
           tcpSocket:
@@ -243,6 +242,9 @@ spec:
 {{- else if $.ReadinessGRPCPort }}
           grpc:
             port: {{ $.ReadinessGRPCPort }}			
+{{- else if $.ImageFullPath }}
+          tcpSocket:
+            port: tcp-health-port
 {{- else }}
           httpGet:
             path: /
@@ -251,7 +253,6 @@ spec:
           initialDelaySeconds: 1
           periodSeconds: 2
           failureThreshold: 10
-{{- end }}
         livenessProbe:
           tcpSocket:
             port: tcp-health-port

--- a/pkg/test/framework/components/echo/kube/testdata/basic.yaml
+++ b/pkg/test/framework/components/echo/kube/testdata/basic.yaml
@@ -52,13 +52,13 @@ spec:
           runAsGroup: 1338
         args:
           - --metrics=15014
-          - --cluster="cluster-0"
+          - --cluster=cluster-0
           - --grpc=7070
           - --port=8090
           - --port=8080
           - --port=3333
-          - --version="bar"
-          - --istio-version=""
+          - --version=bar
+          - --istio-version=
           - --crt=/cert.crt
           - --key=/cert.key
         ports:

--- a/pkg/test/framework/components/echo/kube/testdata/basic.yaml
+++ b/pkg/test/framework/components/echo/kube/testdata/basic.yaml
@@ -52,20 +52,13 @@ spec:
           runAsGroup: 1338
         args:
           - --metrics=15014
-          - --cluster
-          - "cluster-0"
-          - --grpc
-          - "7070"
-          - --port
-          - "8090"
-          - --port
-          - "8080"
-          - --port
-          - "3333"
-          - --version
-          - "bar"
-          - --istio-version
-          - ""
+          - --cluster="cluster-0"
+          - --grpc=7070
+          - --port=8090
+          - --port=8080
+          - --port=3333
+          - --version="bar"
+          - --istio-version=""
           - --crt=/cert.crt
           - --key=/cert.key
         ports:

--- a/pkg/test/framework/components/echo/kube/testdata/healthcheck-rewrite.yaml
+++ b/pkg/test/framework/components/echo/kube/testdata/healthcheck-rewrite.yaml
@@ -53,18 +53,12 @@ spec:
           runAsGroup: 1338
         args:
           - --metrics=15014
-          - --cluster
-          - "cluster-0"
-          - --grpc
-          - "7070"
-          - --port
-          - "8080"
-          - --port
-          - "3333"
-          - --version
-          - "v1"
-          - --istio-version
-          - ""
+          - --cluster="cluster-0"
+          - --grpc=7070
+          - --port=8080
+          - --port=3333
+          - --version="v1"
+          - --istio-version=""
           - --crt=/cert.crt
           - --key=/cert.key
         ports:

--- a/pkg/test/framework/components/echo/kube/testdata/healthcheck-rewrite.yaml
+++ b/pkg/test/framework/components/echo/kube/testdata/healthcheck-rewrite.yaml
@@ -53,12 +53,12 @@ spec:
           runAsGroup: 1338
         args:
           - --metrics=15014
-          - --cluster="cluster-0"
+          - --cluster=cluster-0
           - --grpc=7070
           - --port=8080
           - --port=3333
-          - --version="v1"
-          - --istio-version=""
+          - --version=v1
+          - --istio-version=
           - --crt=/cert.crt
           - --key=/cert.key
         ports:

--- a/pkg/test/framework/components/echo/kube/testdata/multiple-istio-versions-no-proxy.yaml
+++ b/pkg/test/framework/components/echo/kube/testdata/multiple-istio-versions-no-proxy.yaml
@@ -48,20 +48,13 @@ spec:
           runAsGroup: 1338
         args:
           - --metrics=15014
-          - --cluster
-          - "cluster-0"
-          - --grpc
-          - "7070"
-          - --port
-          - "8090"
-          - --port
-          - "8080"
-          - --port
-          - "3333"
-          - --version
-          - "bar"
-          - --istio-version
-          - "1.8.2"
+          - --cluster="cluster-0"
+          - --grpc=7070
+          - --port=8090
+          - --port=8080
+          - --port=3333
+          - --version="bar"
+          - --istio-version="1.8.2"
           - --crt=/cert.crt
           - --key=/cert.key
         ports:
@@ -126,20 +119,13 @@ spec:
           runAsGroup: 1338
         args:
           - --metrics=15014
-          - --cluster
-          - "cluster-0"
-          - --grpc
-          - "7070"
-          - --port
-          - "8090"
-          - --port
-          - "8080"
-          - --port
-          - "3333"
-          - --version
-          - "bar"
-          - --istio-version
-          - "1.9.0"
+          - --cluster="cluster-0"
+          - --grpc=7070
+          - --port=8090
+          - --port=8080
+          - --port=3333
+          - --version="bar"
+          - --istio-version="1.9.0"
           - --crt=/cert.crt
           - --key=/cert.key
         ports:

--- a/pkg/test/framework/components/echo/kube/testdata/multiple-istio-versions-no-proxy.yaml
+++ b/pkg/test/framework/components/echo/kube/testdata/multiple-istio-versions-no-proxy.yaml
@@ -48,13 +48,13 @@ spec:
           runAsGroup: 1338
         args:
           - --metrics=15014
-          - --cluster="cluster-0"
+          - --cluster=cluster-0
           - --grpc=7070
           - --port=8090
           - --port=8080
           - --port=3333
-          - --version="bar"
-          - --istio-version="1.8.2"
+          - --version=bar
+          - --istio-version=1.8.2
           - --crt=/cert.crt
           - --key=/cert.key
         ports:
@@ -119,13 +119,13 @@ spec:
           runAsGroup: 1338
         args:
           - --metrics=15014
-          - --cluster="cluster-0"
+          - --cluster=cluster-0
           - --grpc=7070
           - --port=8090
           - --port=8080
           - --port=3333
-          - --version="bar"
-          - --istio-version="1.9.0"
+          - --version=bar
+          - --istio-version=1.9.0
           - --crt=/cert.crt
           - --key=/cert.key
         ports:

--- a/pkg/test/framework/components/echo/kube/testdata/multiple-istio-versions.yaml
+++ b/pkg/test/framework/components/echo/kube/testdata/multiple-istio-versions.yaml
@@ -53,13 +53,13 @@ spec:
           runAsGroup: 1338
         args:
           - --metrics=15014
-          - --cluster="cluster-0"
+          - --cluster=cluster-0
           - --grpc=7070
           - --port=8090
           - --port=8080
           - --port=3333
-          - --version="bar"
-          - --istio-version="1.9.0"
+          - --version=bar
+          - --istio-version=1.9.0
           - --crt=/cert.crt
           - --key=/cert.key
         ports:
@@ -129,13 +129,13 @@ spec:
           runAsGroup: 1338
         args:
           - --metrics=15014
-          - --cluster="cluster-0"
+          - --cluster=cluster-0
           - --grpc=7070
           - --port=8090
           - --port=8080
           - --port=3333
-          - --version="bar"
-          - --istio-version="1.10.0"
+          - --version=bar
+          - --istio-version=1.10.0
           - --crt=/cert.crt
           - --key=/cert.key
         ports:

--- a/pkg/test/framework/components/echo/kube/testdata/multiple-istio-versions.yaml
+++ b/pkg/test/framework/components/echo/kube/testdata/multiple-istio-versions.yaml
@@ -53,20 +53,13 @@ spec:
           runAsGroup: 1338
         args:
           - --metrics=15014
-          - --cluster
-          - "cluster-0"
-          - --grpc
-          - "7070"
-          - --port
-          - "8090"
-          - --port
-          - "8080"
-          - --port
-          - "3333"
-          - --version
-          - "bar"
-          - --istio-version
-          - "1.9.0"
+          - --cluster="cluster-0"
+          - --grpc=7070
+          - --port=8090
+          - --port=8080
+          - --port=3333
+          - --version="bar"
+          - --istio-version="1.9.0"
           - --crt=/cert.crt
           - --key=/cert.key
         ports:
@@ -136,20 +129,13 @@ spec:
           runAsGroup: 1338
         args:
           - --metrics=15014
-          - --cluster
-          - "cluster-0"
-          - --grpc
-          - "7070"
-          - --port
-          - "8090"
-          - --port
-          - "8080"
-          - --port
-          - "3333"
-          - --version
-          - "bar"
-          - --istio-version
-          - "1.10.0"
+          - --cluster="cluster-0"
+          - --grpc=7070
+          - --port=8090
+          - --port=8080
+          - --port=3333
+          - --version="bar"
+          - --istio-version="1.10.0"
           - --crt=/cert.crt
           - --key=/cert.key
         ports:

--- a/pkg/test/framework/components/echo/kube/testdata/multiversion.yaml
+++ b/pkg/test/framework/components/echo/kube/testdata/multiversion.yaml
@@ -55,14 +55,14 @@ spec:
           runAsGroup: 1338
         args:
           - --metrics=15014
-          - --cluster="cluster-0"
+          - --cluster=cluster-0
           - --port=8090
           - --tcp=9000
           - --grpc=9090
           - --port=8080
           - --port=3333
-          - --version="v-istio"
-          - --istio-version=""
+          - --version=v-istio
+          - --istio-version=
           - --crt=/cert.crt
           - --key=/cert.key
         ports:
@@ -128,14 +128,14 @@ spec:
           runAsGroup: 1338
         args:
           - --metrics=15014
-          - --cluster="cluster-0"
+          - --cluster=cluster-0
           - --port=8090
           - --tcp=9000
           - --grpc=9090
           - --port=8080
           - --port=3333
-          - --version="v-legacy"
-          - --istio-version=""
+          - --version=v-legacy
+          - --istio-version=
           - --crt=/cert.crt
           - --key=/cert.key
         ports:

--- a/pkg/test/framework/components/echo/kube/testdata/multiversion.yaml
+++ b/pkg/test/framework/components/echo/kube/testdata/multiversion.yaml
@@ -55,22 +55,14 @@ spec:
           runAsGroup: 1338
         args:
           - --metrics=15014
-          - --cluster
-          - "cluster-0"
-          - --port
-          - "8090"
-          - --tcp
-          - "9000"
-          - --grpc
-          - "9090"
-          - --port
-          - "8080"
-          - --port
-          - "3333"
-          - --version
-          - "v-istio"
-          - --istio-version
-          - ""
+          - --cluster="cluster-0"
+          - --port=8090
+          - --tcp=9000
+          - --grpc=9090
+          - --port=8080
+          - --port=3333
+          - --version="v-istio"
+          - --istio-version=""
           - --crt=/cert.crt
           - --key=/cert.key
         ports:
@@ -136,22 +128,14 @@ spec:
           runAsGroup: 1338
         args:
           - --metrics=15014
-          - --cluster
-          - "cluster-0"
-          - --port
-          - "8090"
-          - --tcp
-          - "9000"
-          - --grpc
-          - "9090"
-          - --port
-          - "8080"
-          - --port
-          - "3333"
-          - --version
-          - "v-legacy"
-          - --istio-version
-          - ""
+          - --cluster="cluster-0"
+          - --port=8090
+          - --tcp=9000
+          - --grpc=9090
+          - --port=8080
+          - --port=3333
+          - --version="v-legacy"
+          - --istio-version=""
           - --crt=/cert.crt
           - --key=/cert.key
         ports:

--- a/pkg/test/framework/components/echo/kube/testdata/two-workloads-one-nosidecar.yaml
+++ b/pkg/test/framework/components/echo/kube/testdata/two-workloads-one-nosidecar.yaml
@@ -52,13 +52,13 @@ spec:
           runAsGroup: 1338
         args:
           - --metrics=15014
-          - --cluster="cluster-0"
+          - --cluster=cluster-0
           - --grpc=7070
           - --port=8090
           - --port=8080
           - --port=3333
-          - --version="v1"
-          - --istio-version=""
+          - --version=v1
+          - --istio-version=
           - --crt=/cert.crt
           - --key=/cert.key
         ports:
@@ -123,13 +123,13 @@ spec:
           runAsGroup: 1338
         args:
           - --metrics=15014
-          - --cluster="cluster-0"
+          - --cluster=cluster-0
           - --grpc=7070
           - --port=8090
           - --port=8080
           - --port=3333
-          - --version="nosidecar"
-          - --istio-version=""
+          - --version=nosidecar
+          - --istio-version=
           - --crt=/cert.crt
           - --key=/cert.key
         ports:

--- a/pkg/test/framework/components/echo/kube/testdata/two-workloads-one-nosidecar.yaml
+++ b/pkg/test/framework/components/echo/kube/testdata/two-workloads-one-nosidecar.yaml
@@ -52,20 +52,13 @@ spec:
           runAsGroup: 1338
         args:
           - --metrics=15014
-          - --cluster
-          - "cluster-0"
-          - --grpc
-          - "7070"
-          - --port
-          - "8090"
-          - --port
-          - "8080"
-          - --port
-          - "3333"
-          - --version
-          - "v1"
-          - --istio-version
-          - ""
+          - --cluster="cluster-0"
+          - --grpc=7070
+          - --port=8090
+          - --port=8080
+          - --port=3333
+          - --version="v1"
+          - --istio-version=""
           - --crt=/cert.crt
           - --key=/cert.key
         ports:
@@ -130,20 +123,13 @@ spec:
           runAsGroup: 1338
         args:
           - --metrics=15014
-          - --cluster
-          - "cluster-0"
-          - --grpc
-          - "7070"
-          - --port
-          - "8090"
-          - --port
-          - "8080"
-          - --port
-          - "3333"
-          - --version
-          - "nosidecar"
-          - --istio-version
-          - ""
+          - --cluster="cluster-0"
+          - --grpc=7070
+          - --port=8090
+          - --port=8080
+          - --port=3333
+          - --version="nosidecar"
+          - --istio-version=""
           - --crt=/cert.crt
           - --key=/cert.key
         ports:

--- a/pkg/test/framework/resource/flags.go
+++ b/pkg/test/framework/resource/flags.go
@@ -71,8 +71,8 @@ func SettingsFromCommandLine(testID string) (*Settings, error) {
 		s.Image.PullPolicy = env.PULL_POLICY.ValueOrDefault("Always")
 	}
 
-	if s.TestEchoImage == "" {
-		s.TestEchoImage = env.TEST_ECHO_IMAGE.ValueOrDefault("")
+	if s.EchoImage == "" {
+		s.EchoImage = env.ECHO_IMAGE.ValueOrDefault("")
 	}
 
 	if err = validate(s); err != nil {

--- a/pkg/test/framework/resource/flags.go
+++ b/pkg/test/framework/resource/flags.go
@@ -71,6 +71,10 @@ func SettingsFromCommandLine(testID string) (*Settings, error) {
 		s.Image.PullPolicy = env.PULL_POLICY.ValueOrDefault("Always")
 	}
 
+	if s.TestEchoImage == "" {
+		s.TestEchoImage = env.TEST_ECHO_IMAGE.ValueOrDefault("")
+	}
+
 	if err = validate(s); err != nil {
 		return nil, err
 	}

--- a/pkg/test/framework/resource/settings.go
+++ b/pkg/test/framework/resource/settings.go
@@ -150,6 +150,9 @@ type Settings struct {
 
 	// Image settings
 	Image ImageSettings
+
+	// TestEchoImage is the app image to be used by echo deployments.
+	TestEchoImage string
 }
 
 func (s Settings) Skip(class string) bool {

--- a/pkg/test/framework/resource/settings.go
+++ b/pkg/test/framework/resource/settings.go
@@ -151,8 +151,8 @@ type Settings struct {
 	// Image settings
 	Image ImageSettings
 
-	// TestEchoImage is the app image to be used by echo deployments.
-	TestEchoImage string
+	// EchoImage is the app image to be used by echo deployments.
+	EchoImage string
 }
 
 func (s Settings) Skip(class string) bool {


### PR DESCRIPTION
**Please provide a description of this PR:**

This PR updates the integration tests to prepare for tests with gRPC C++
- Changed the flag format because C++'s flag parsing library only supports `--a=b`.
- Added a new environment variable `ECHO_IMAGE` for echo image, so it can be changed to point to the C++ image
  - Changed readiness probe to use TCP instead of HTTP when echo image is set because C++ doesn't have an easy way to start an HTTP server