### PR TITLE
tf: allow CSV inputs to skip workloads

### DIFF
--- a/pkg/test/framework/resource/flags.go
+++ b/pkg/test/framework/resource/flags.go
@@ -18,6 +18,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 
 	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/pkg/test/framework/config"
@@ -58,6 +59,12 @@ func SettingsFromCommandLine(testID string) (*Settings, error) {
 		// TODO we may also want to trigger this if we have an old verion
 		s.SkipWorkloadClasses = append(s.SkipWorkloadClasses, "delta")
 	}
+	// Allow passing a single CSV flag as well
+	normalized := make(ArrayFlags, 0)
+	for _, sk := range s.SkipWorkloadClasses {
+		normalized = append(normalized, strings.Split(sk, ",")...)
+	}
+	s.SkipWorkloadClasses = normalized
 
 	if s.Image.Hub == "" {
 		s.Image.Hub = env.HUB.ValueOrDefault("gcr.io/istio-testing")


### PR DESCRIPTION
Otherwise something like `--istio.test.skipWorkloads=vm,tproxy,delta`
will not work which leads to obscure errors

**Please provide a description of this PR:**