### PR TITLE
Allow reconciliation to resolve transient finalizer conflict errors

### DIFF
--- a/operator/pkg/controller/istiocontrolplane/istiocontrolplane_controller.go
+++ b/operator/pkg/controller/istiocontrolplane/istiocontrolplane_controller.go
@@ -288,6 +288,7 @@ func (r *ReconcileIstioOperator) Reconcile(_ context.Context, request reconcile.
 				return reconcile.Result{}, nil
 			} else if errors.IsConflict(finalizerError) {
 				scope.Infof("Could not remove finalizer from %s due to conflict. Operation will be retried in next reconcile attempt.", iopName)
+				return reconcile.Result{}, finalizerError
 			}
 			scope.Errorf(errdict.OperatorFailedToRemoveFinalizer, "error removing finalizer: %s", finalizerError)
 			return reconcile.Result{}, finalizerError
@@ -305,6 +306,7 @@ func (r *ReconcileIstioOperator) Reconcile(_ context.Context, request reconcile.
 				return reconcile.Result{}, nil
 			} else if errors.IsConflict(err) {
 				scope.Infof("Could not add finalizer to %s due to conflict. Operation will be retried in next reconcile attempt.", iopName)
+				return reconcile.Result{}, err
 			}
 			scope.Errorf(errdict.OperatorFailedToAddFinalizer, "Failed to add finalizer to IstioOperator CR %s: %s", iopName, err)
 			return reconcile.Result{}, err

--- a/operator/pkg/controller/istiocontrolplane/istiocontrolplane_controller.go
+++ b/operator/pkg/controller/istiocontrolplane/istiocontrolplane_controller.go
@@ -288,7 +288,7 @@ func (r *ReconcileIstioOperator) Reconcile(_ context.Context, request reconcile.
 				return reconcile.Result{}, nil
 			} else if errors.IsConflict(finalizerError) {
 				scope.Infof("Could not remove finalizer from %s due to conflict. Operation will be retried in next reconcile attempt.", iopName)
-				return reconcile.Result{}, finalizerError
+				return reconcile.Result{}, nil
 			}
 			scope.Errorf(errdict.OperatorFailedToRemoveFinalizer, "error removing finalizer: %s", finalizerError)
 			return reconcile.Result{}, finalizerError

--- a/operator/pkg/controller/istiocontrolplane/istiocontrolplane_controller.go
+++ b/operator/pkg/controller/istiocontrolplane/istiocontrolplane_controller.go
@@ -288,7 +288,6 @@ func (r *ReconcileIstioOperator) Reconcile(_ context.Context, request reconcile.
 				return reconcile.Result{}, nil
 			} else if errors.IsConflict(finalizerError) {
 				scope.Infof("Could not remove finalizer from %s due to conflict. Operation will be retried in next reconcile attempt.", iopName)
-				return reconcile.Result{}, nil
 			}
 			scope.Errorf(errdict.OperatorFailedToRemoveFinalizer, "error removing finalizer: %s", finalizerError)
 			return reconcile.Result{}, finalizerError
@@ -306,7 +305,6 @@ func (r *ReconcileIstioOperator) Reconcile(_ context.Context, request reconcile.
 				return reconcile.Result{}, nil
 			} else if errors.IsConflict(err) {
 				scope.Infof("Could not add finalizer to %s due to conflict. Operation will be retried in next reconcile attempt.", iopName)
-				return reconcile.Result{}, nil
 			}
 			scope.Errorf(errdict.OperatorFailedToAddFinalizer, "Failed to add finalizer to IstioOperator CR %s: %s", iopName, err)
 			return reconcile.Result{}, err

--- a/operator/pkg/controller/istiocontrolplane/istiocontrolplane_controller.go
+++ b/operator/pkg/controller/istiocontrolplane/istiocontrolplane_controller.go
@@ -306,7 +306,6 @@ func (r *ReconcileIstioOperator) Reconcile(_ context.Context, request reconcile.
 				return reconcile.Result{}, nil
 			} else if errors.IsConflict(err) {
 				scope.Infof("Could not add finalizer to %s due to conflict. Operation will be retried in next reconcile attempt.", iopName)
-				return reconcile.Result{}, err
 			}
 			scope.Errorf(errdict.OperatorFailedToAddFinalizer, "Failed to add finalizer to IstioOperator CR %s: %s", iopName, err)
 			return reconcile.Result{}, err


### PR DESCRIPTION
Do not return 'nil' when transient conflict is detected when adding finalizer - this prevents subsequent reconciliation attempts on the istiooperator resource.

Resolves https://github.com/istio/istio/issues/38591

Signed-off-by: Rob Mason <robmie@gmail.com>

**Please provide a description of this PR:**