### PR TITLE
feat(charts/istio-discovery): add meshConfig.trustDomainAliases list

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -202,6 +202,8 @@ meshConfig:
   # Refer to https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE-ID.md#21-trust-domain
   trustDomain: "cluster.local"
 
+  trustDomainAliases: []
+
   # TODO: the intent is to eventually have this enabled by default when security is used.
   # It is not clear if user should normally need to configure - the metadata is typically
   # used as an escape and to control testing and rollout, but it is not intended as a long-term


### PR DESCRIPTION
Signed-off-by: Leandro Carneiro <leandro@carnei.ro>

Add missing field meshConfig.trustDomainAliases to chart istio-discovery.

- [ ] Configuration Infrastructure
- [ ] Docs
- [X] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
