### PR TITLE
Refactor gateway server tls adjugement 

### DIFF
--- a/pilot/pkg/model/gateway.go
+++ b/pilot/pkg/model/gateway.go
@@ -293,7 +293,7 @@ func MergeGateways(gateways []gatewayWithInstances, proxy *Proxy, ps *PushContex
 				} else {
 					// This is a new gateway on this port. Create MergedServers for it.
 					gatewayPorts[resolvedPort] = true
-					if !gateway.IsTLSServerForNonHTTP(s) {
+					if !gateway.IsNonHTTPTLSServer(s) {
 						plainTextServers[serverPort.Number] = serverPort
 					}
 					if gateway.IsHTTPServer(s) {

--- a/pilot/pkg/model/gateway.go
+++ b/pilot/pkg/model/gateway.go
@@ -293,7 +293,7 @@ func MergeGateways(gateways []gatewayWithInstances, proxy *Proxy, ps *PushContex
 				} else {
 					// This is a new gateway on this port. Create MergedServers for it.
 					gatewayPorts[resolvedPort] = true
-					if !gateway.IsTLSServer(s) {
+					if !gateway.IsTLSServerForNonHTTP(s) {
 						plainTextServers[serverPort.Number] = serverPort
 					}
 					if gateway.IsHTTPServer(s) {

--- a/pilot/pkg/model/gateway_test.go
+++ b/pilot/pkg/model/gateway_test.go
@@ -142,14 +142,12 @@ func TestMergeGateways(t *testing.T) {
 				t.Errorf("Incorrect number of routes. Expected: %v Got: %d", len(tt.serversForRouteNum), len(mgw.ServersByRouteName))
 			}
 			for k, v := range mgw.ServersByRouteName {
-				fmt.Println("----route  ", k, "servers ", v)
 				if tt.serversForRouteNum[k] != len(v) {
 					t.Errorf("for route %v expected %v servers got %v", k, tt.serversForRouteNum[k], len(v))
 				}
 			}
 			ns := 0
 			for _, ms := range mgw.MergedServers {
-				fmt.Println("-----", ms.Servers)
 				ns += len(ms.Servers)
 			}
 			if ns != tt.serverNum {

--- a/pilot/pkg/model/gateway_test.go
+++ b/pilot/pkg/model/gateway_test.go
@@ -142,12 +142,14 @@ func TestMergeGateways(t *testing.T) {
 				t.Errorf("Incorrect number of routes. Expected: %v Got: %d", len(tt.serversForRouteNum), len(mgw.ServersByRouteName))
 			}
 			for k, v := range mgw.ServersByRouteName {
+				fmt.Println("----route  ", k, "servers ", v)
 				if tt.serversForRouteNum[k] != len(v) {
 					t.Errorf("for route %v expected %v servers got %v", k, tt.serversForRouteNum[k], len(v))
 				}
 			}
 			ns := 0
 			for _, ms := range mgw.MergedServers {
+				fmt.Println("-----", ms.Servers)
 				ns += len(ms.Servers)
 			}
 			if ns != tt.serverNum {

--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -209,7 +209,7 @@ func (configgen *ConfigGeneratorImpl) buildGatewayTCPBasedFilterChains(
 		// This process typically yields multiple filter chain matches (with SNI) [if TLS is used]
 		tcpFilterChainOpts := make([]*filterChainOpts, 0)
 		for _, server := range serversForPort.Servers {
-			if gateway.IsTLSServer(server) && gateway.IsHTTPServer(server) {
+			if gateway.IsHTTPSServerWithTLSTermination(server) {
 				routeName := mergedGateway.TLSServerInfo[server].RouteName
 				// This is a HTTPS server, where we are doing TLS termination. Build a http connection manager with TLS context
 				tcpFilterChainOpts = append(tcpFilterChainOpts, configgen.createGatewayHTTPFilterChainOpts(builder.node, server.Port, server,

--- a/pkg/config/gateway/gateway.go
+++ b/pkg/config/gateway/gateway.go
@@ -20,15 +20,15 @@ import (
 	"istio.io/istio/pkg/config/protocol"
 )
 
-// IsTLSServerForNonHTTP returns true if this server is non HTTP, with some TLS settings for termination/passthrough
-func IsTLSServerForNonHTTP(server *v1alpha3.Server) bool {
+// IsNonHTTPTLSServer returns true if this server is non HTTP, but with some TLS settings for termination/passthrough
+func IsNonHTTPTLSServer(server *v1alpha3.Server) bool {
 	if server.Tls != nil && !protocol.Parse(server.Port.Protocol).IsHTTP() {
 		return true
 	}
 	return false
 }
 
-// IsHTTPSServerWithTLSTermination returs true if the server is HTTPS with TLS termination
+// IsHTTPSServerWithTLSTermination returns true if the server is HTTPS with TLS termination
 func IsHTTPSServerWithTLSTermination(server *v1alpha3.Server) bool {
 	if server.Tls != nil {
 		p := protocol.Parse(server.Port.Protocol)

--- a/pkg/config/gateway/gateway.go
+++ b/pkg/config/gateway/gateway.go
@@ -20,10 +20,21 @@ import (
 	"istio.io/istio/pkg/config/protocol"
 )
 
-// IsTLSServer returns true if this server is non HTTP, with some TLS settings for termination/passthrough
-func IsTLSServer(server *v1alpha3.Server) bool {
+// IsTLSServerForNonHTTP returns true if this server is non HTTP, with some TLS settings for termination/passthrough
+func IsTLSServerForNonHTTP(server *v1alpha3.Server) bool {
 	if server.Tls != nil && !protocol.Parse(server.Port.Protocol).IsHTTP() {
 		return true
+	}
+	return false
+}
+
+// IsHTTPSServerWithTLSTermination returs true if the server is HTTPS with TLS termination
+func IsHTTPSServerWithTLSTermination(server *v1alpha3.Server) bool {
+	if server.Tls != nil {
+		p := protocol.Parse(server.Port.Protocol)
+		if p == protocol.HTTPS && !IsPassThroughServer(server) {
+			return true
+		}
 	}
 	return false
 }

--- a/pkg/config/gateway/gateway.go
+++ b/pkg/config/gateway/gateway.go
@@ -69,9 +69,11 @@ func IsPassThroughServer(server *v1alpha3.Server) bool {
 
 // IsTCPServerWithTLSTermination returns true if this server is TCP(non-HTTP) server with some TLS settings for termination
 func IsTCPServerWithTLSTermination(server *v1alpha3.Server) bool {
-	if IsTLSServer(server) && !IsHTTPServer(server) && !IsPassThroughServer(server) {
-		return true
+	if server.Tls != nil && !IsPassThroughServer(server) {
+		p := protocol.Parse(server.Port.Protocol)
+		if !p.IsHTTP() && !p.IsHTTPS() {
+			return true
+		}
 	}
-
 	return false
 }

--- a/pkg/config/gateway/gateway_test.go
+++ b/pkg/config/gateway/gateway_test.go
@@ -23,7 +23,7 @@ import (
 	"istio.io/istio/pkg/test"
 )
 
-func TestIsTLSServerForNonHTTP(t *testing.T) {
+func TestIsNonHTTPTLSServer(t *testing.T) {
 	cases := []struct {
 		name     string
 		server   *v1alpha3.Server
@@ -39,7 +39,7 @@ func TestIsTLSServerForNonHTTP(t *testing.T) {
 				},
 				Tls: &v1alpha3.ServerTLSSettings{HttpsRedirect: true},
 			},
-			expected: true,
+			expected: false,
 		},
 		{
 			name: "tls non nil and TCP as transport protocol",

--- a/pkg/config/gateway/gateway_test.go
+++ b/pkg/config/gateway/gateway_test.go
@@ -23,7 +23,7 @@ import (
 	"istio.io/istio/pkg/test"
 )
 
-func TestIsTLSServer(t *testing.T) {
+func TestIsTLSServerForNonHTTP(t *testing.T) {
 	cases := []struct {
 		name     string
 		server   *v1alpha3.Server
@@ -39,7 +39,7 @@ func TestIsTLSServer(t *testing.T) {
 				},
 				Tls: &v1alpha3.ServerTLSSettings{HttpsRedirect: true},
 			},
-			expected: false,
+			expected: true,
 		},
 		{
 			name: "tls non nil and TCP as transport protocol",
@@ -78,9 +78,9 @@ func TestIsTLSServer(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			actual := IsTLSServer(tc.server)
+			actual := IsTLSServerForNonHTTP(tc.server)
 			if actual != tc.expected {
-				t.Errorf("IsTLSServer(%s) => %t, want %t",
+				t.Errorf("IsTLSServerForNonHTTP(%s) => %t, want %t",
 					tc.server, actual, tc.expected)
 			}
 		})
@@ -145,6 +145,72 @@ func TestIsHTTPServer(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			actual := IsHTTPServer(tc.server)
+			if actual != tc.expected {
+				t.Errorf("IsHTTPServer(%s) => %t, want %t",
+					tc.server, actual, tc.expected)
+			}
+		})
+	}
+}
+
+func TestIsHTTPSServerWithTLSTermination(t *testing.T) {
+	cases := []struct {
+		name     string
+		server   *v1alpha3.Server
+		expected bool
+	}{
+		{
+			name: "HTTP as transport protocol",
+			server: &v1alpha3.Server{
+				Port: &v1alpha3.Port{
+					Number:   80,
+					Protocol: string(protocol.HTTP),
+					Name:     "http",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "HTTPS traffic with passthrough ServerTLS mode",
+			server: &v1alpha3.Server{
+				Port: &v1alpha3.Port{
+					Number:   80,
+					Protocol: string(protocol.HTTPS),
+					Name:     "https",
+				},
+				Tls: &v1alpha3.ServerTLSSettings{Mode: v1alpha3.ServerTLSSettings_PASSTHROUGH},
+			},
+			expected: false,
+		},
+		{
+			name: "HTTP traffic with tls termination",
+			server: &v1alpha3.Server{
+				Port: &v1alpha3.Port{
+					Number:   80,
+					Protocol: string(protocol.HTTP),
+					Name:     "http",
+				},
+				Tls: &v1alpha3.ServerTLSSettings{Mode: v1alpha3.ServerTLSSettings_MUTUAL},
+			},
+			expected: false,
+		},
+		{
+			name: "HTTPS traffic with istio mutual ServerTLS mode",
+			server: &v1alpha3.Server{
+				Port: &v1alpha3.Port{
+					Number:   80,
+					Protocol: string(protocol.HTTPS),
+					Name:     "https",
+				},
+				Tls: &v1alpha3.ServerTLSSettings{Mode: v1alpha3.ServerTLSSettings_ISTIO_MUTUAL},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := IsHTTPSServerWithTLSTermination(tc.server)
 			if actual != tc.expected {
 				t.Errorf("IsHTTPServer(%s) => %t, want %t",
 					tc.server, actual, tc.expected)
@@ -282,6 +348,95 @@ func TestIsPassThroughServer(t *testing.T) {
 			actual := IsPassThroughServer(tc.server)
 			if actual != tc.expected {
 				t.Errorf("IsPassThroughServer(%s) => %t, want %t",
+					tc.server, actual, tc.expected)
+			}
+		})
+	}
+}
+
+func TestIsTCPServerWithTLSTermination(t *testing.T) {
+	cases := []struct {
+		name     string
+		server   *v1alpha3.Server
+		expected bool
+	}{
+		{
+			name: "nil tls and HTTP",
+			server: &v1alpha3.Server{
+				Port: &v1alpha3.Port{
+					Number:   80,
+					Protocol: string(protocol.HTTP),
+					Name:     "http",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "passthrough ServerTLS mode",
+			server: &v1alpha3.Server{
+				Port: &v1alpha3.Port{
+					Number:   80,
+					Protocol: string(protocol.TCP),
+					Name:     "tcp",
+				},
+				Tls: &v1alpha3.ServerTLSSettings{Mode: v1alpha3.ServerTLSSettings_PASSTHROUGH},
+			},
+			expected: false,
+		},
+		{
+			name: "auto passthrough ServerTLS mode",
+			server: &v1alpha3.Server{
+				Port: &v1alpha3.Port{
+					Number:   80,
+					Protocol: string(protocol.TCP),
+					Name:     "tcp",
+				},
+				Tls: &v1alpha3.ServerTLSSettings{Mode: v1alpha3.ServerTLSSettings_AUTO_PASSTHROUGH},
+			},
+			expected: false,
+		},
+		{
+			name: "tls and HTTPS",
+			server: &v1alpha3.Server{
+				Port: &v1alpha3.Port{
+					Number:   80,
+					Protocol: string(protocol.HTTPS),
+					Name:     "https",
+				},
+				Tls: &v1alpha3.ServerTLSSettings{CredentialName: "cert", Mode: v1alpha3.ServerTLSSettings_MUTUAL},
+			},
+			expected: false,
+		},
+		{
+			name: "tls and HTTP",
+			server: &v1alpha3.Server{
+				Port: &v1alpha3.Port{
+					Number:   80,
+					Protocol: string(protocol.HTTP),
+					Name:     "https",
+				},
+				Tls: &v1alpha3.ServerTLSSettings{CredentialName: "cert", Mode: v1alpha3.ServerTLSSettings_MUTUAL},
+			},
+			expected: false,
+		},
+		{
+			name: "tls and TLS",
+			server: &v1alpha3.Server{
+				Port: &v1alpha3.Port{
+					Number:   80,
+					Protocol: string(protocol.TLS),
+					Name:     "tls",
+				},
+				Tls: &v1alpha3.ServerTLSSettings{CredentialName: "cert", Mode: v1alpha3.ServerTLSSettings_MUTUAL},
+			},
+			expected: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := IsTCPServerWithTLSTermination(tc.server)
+			if actual != tc.expected {
+				t.Errorf("IsTCPServerWithTLSTermination(%s) => %t, want %t",
 					tc.server, actual, tc.expected)
 			}
 		})

--- a/pkg/config/gateway/gateway_test.go
+++ b/pkg/config/gateway/gateway_test.go
@@ -78,9 +78,9 @@ func TestIsTLSServerForNonHTTP(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			actual := IsTLSServerForNonHTTP(tc.server)
+			actual := IsNonHTTPTLSServer(tc.server)
 			if actual != tc.expected {
-				t.Errorf("IsTLSServerForNonHTTP(%s) => %t, want %t",
+				t.Errorf("IsNonHTTPTLSServer(%s) => %t, want %t",
 					tc.server, actual, tc.expected)
 			}
 		})


### PR DESCRIPTION
**Please provide a description of this PR:**

1,  IsTLSServer is very hard to understand.  Rename to IsTLSServerForNonHTTP
2. Add IsHTTPSServerWithTLSTermination to replace gateway.IsTLSServer(server) && gateway.IsHTTPServer(server) 