### PR TITLE
fix incorect sds logs

### DIFF
--- a/pkg/istio-agent/agent.go
+++ b/pkg/istio-agent/agent.go
@@ -505,16 +505,13 @@ func (a *Agent) initSdsServer() error {
 		a.secOpts.KeyFilePath = security.WorkloadIdentityKeyPath
 
 		a.secretCache, err = cache.NewSecretManagerClient(nil, a.secOpts)
-		if err != nil {
-			return fmt.Errorf("failed to start workload secret manager %v", err)
-		}
 	} else {
 		a.secretCache, err = a.newSecretManager()
-		if err != nil {
-			return fmt.Errorf("failed to start workload secret manager %v", err)
-		}
 	}
 
+	if err != nil {
+		return fmt.Errorf("failed to start workload secret manager %v", err)
+	}
 	pkpConf := a.proxyConfig.GetPrivateKeyProvider()
 	a.sdsServer = sds.NewServer(a.secOpts, a.secretCache, pkpConf)
 	a.secretCache.RegisterSecretHandler(a.sdsServer.OnSecretUpdate)

--- a/pkg/istio-agent/agent.go
+++ b/pkg/istio-agent/agent.go
@@ -494,11 +494,7 @@ func (a *Agent) Run(ctx context.Context) (func(), error) {
 
 func (a *Agent) initSdsServer() error {
 	var err error
-	// If proxy is using file mounted certs, we do not have to connect to CA.
-	if a.secOpts.FileMountedCerts {
-		log.Info("Workload is using file mounted certificates. Skipping connecting to CA")
-		a.secretCache, err = cache.NewSecretManagerClient(nil, a.secOpts)
-	} else if security.CheckWorkloadCertificate(security.WorkloadIdentityCertChainPath, security.WorkloadIdentityKeyPath, security.WorkloadIdentityRootCertPath) {
+	if security.CheckWorkloadCertificate(security.WorkloadIdentityCertChainPath, security.WorkloadIdentityKeyPath, security.WorkloadIdentityRootCertPath) {
 		log.Info("workload certificate files detected, creating secret manager without caClient")
 		a.secOpts.RootCertFilePath = security.WorkloadIdentityRootCertPath
 		a.secOpts.CertChainFilePath = security.WorkloadIdentityCertChainPath
@@ -796,6 +792,11 @@ func getKeyCertInner(certPath string) (string, string) {
 
 // newSecretManager creates the SecretManager for workload secrets
 func (a *Agent) newSecretManager() (*cache.SecretManagerClient, error) {
+	// If proxy is using file mounted certs, we do not have to connect to CA.
+	if a.secOpts.FileMountedCerts {
+		log.Info("Workload is using file mounted certificates. Skipping connecting to CA")
+		return cache.NewSecretManagerClient(nil, a.secOpts)
+	}
 	log.Infof("CA Endpoint %s, provider %s", a.secOpts.CAEndpoint, a.secOpts.CAProviderName)
 
 	// TODO: this should all be packaged in a plugin, possibly with optional compilation.

--- a/pkg/istio-agent/agent.go
+++ b/pkg/istio-agent/agent.go
@@ -494,7 +494,11 @@ func (a *Agent) Run(ctx context.Context) (func(), error) {
 
 func (a *Agent) initSdsServer() error {
 	var err error
-	if security.CheckWorkloadCertificate(security.WorkloadIdentityCertChainPath, security.WorkloadIdentityKeyPath, security.WorkloadIdentityRootCertPath) {
+	// If proxy is using file mounted certs, we do not have to connect to CA.
+	if a.secOpts.FileMountedCerts {
+		log.Info("Workload is using file mounted certificates. Skipping connecting to CA")
+		a.secretCache, err = cache.NewSecretManagerClient(nil, a.secOpts)
+	} else if security.CheckWorkloadCertificate(security.WorkloadIdentityCertChainPath, security.WorkloadIdentityKeyPath, security.WorkloadIdentityRootCertPath) {
 		log.Info("workload certificate files detected, creating secret manager without caClient")
 		a.secOpts.RootCertFilePath = security.WorkloadIdentityRootCertPath
 		a.secOpts.CertChainFilePath = security.WorkloadIdentityCertChainPath
@@ -795,12 +799,6 @@ func getKeyCertInner(certPath string) (string, string) {
 
 // newSecretManager creates the SecretManager for workload secrets
 func (a *Agent) newSecretManager() (*cache.SecretManagerClient, error) {
-	// If proxy is using file mounted certs, we do not have to connect to CA.
-	if a.secOpts.FileMountedCerts {
-		log.Info("Workload is using file mounted certificates. Skipping connecting to CA")
-		return cache.NewSecretManagerClient(nil, a.secOpts)
-	}
-
 	log.Infof("CA Endpoint %s, provider %s", a.secOpts.CAEndpoint, a.secOpts.CAProviderName)
 
 	// TODO: this should all be packaged in a plugin, possibly with optional compilation.

--- a/security/pkg/nodeagent/sds/server.go
+++ b/security/pkg/nodeagent/sds/server.go
@@ -85,6 +85,7 @@ func (s *Server) initWorkloadSdsService() {
 	s.grpcWorkloadServer = grpc.NewServer(s.grpcServerOptions()...)
 	s.workloadSds.register(s.grpcWorkloadServer)
 	var err error
+	s.grpcWorkloadListener, err = uds.NewListener(security.WorkloadIdentitySocketPath)
 	go func() {
 		sdsServiceLog.Info("Starting SDS grpc server")
 		waitTime := time.Second

--- a/security/pkg/nodeagent/sds/server.go
+++ b/security/pkg/nodeagent/sds/server.go
@@ -48,7 +48,6 @@ func NewServer(options *security.Options, workloadSecretCache security.SecretMan
 	s := &Server{stopped: atomic.NewBool(false)}
 	s.workloadSds = newSDSService(workloadSecretCache, options, pkpConf)
 	s.initWorkloadSdsService()
-	sdsServiceLog.Infof("SDS server for workload certificates started, listening on %q", security.WorkloadIdentitySocketPath)
 	return s
 }
 
@@ -85,13 +84,7 @@ func (s *Server) Stop() {
 func (s *Server) initWorkloadSdsService() {
 	s.grpcWorkloadServer = grpc.NewServer(s.grpcServerOptions()...)
 	s.workloadSds.register(s.grpcWorkloadServer)
-
 	var err error
-	s.grpcWorkloadListener, err = uds.NewListener(security.WorkloadIdentitySocketPath)
-	if err != nil {
-		sdsServiceLog.Errorf("Failed to set up UDS path: %v", err)
-	}
-
 	go func() {
 		sdsServiceLog.Info("Starting SDS grpc server")
 		waitTime := time.Second
@@ -115,7 +108,7 @@ func (s *Server) initWorkloadSdsService() {
 				}
 			}
 			if serverOk && setUpUdsOK {
-				sdsServiceLog.Info("SDS grpc server started")
+				sdsServiceLog.Infof("SDS server for workload certificates started, listening on %q", security.WorkloadIdentitySocketPath)
 				started = true
 				break
 			}


### PR DESCRIPTION
initWorkloadSdsService checks for uds path async and before it returns we log the message "SDS server started". This PR fixes that along with other minor refactor.

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [x] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure