### PR TITLE
minor renaming of function

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/autoserviceexportcontroller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/autoserviceexportcontroller.go
@@ -88,7 +88,7 @@ func (c *autoServiceExportController) onServiceAdd(obj interface{}) {
 			return nil
 		}
 
-		svc, err := convertToService(obj)
+		svc, err := extractService(obj)
 		if err != nil {
 			log.Warnf("%s failed converting service: %v", c.logPrefix(), err)
 			return err

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -497,7 +497,7 @@ func (c *Controller) Cleanup() error {
 }
 
 func (c *Controller) onServiceEvent(curr interface{}, event model.Event) error {
-	svc, err := convertToService(curr)
+	svc, err := extractService(curr)
 	if err != nil {
 		log.Errorf(err)
 		return nil

--- a/pilot/pkg/serviceregistry/kube/controller/util.go
+++ b/pilot/pkg/serviceregistry/kube/controller/util.go
@@ -215,7 +215,7 @@ func podKeyByProxy(proxy *model.Proxy) string {
 	return ""
 }
 
-func convertToService(obj interface{}) (*v1.Service, error) {
+func extractService(obj interface{}) (*v1.Service, error) {
 	cm, ok := obj.(*v1.Service)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)


### PR DESCRIPTION
It is confusing to see `convertToService` (which extracts obj from interface) and `CovertService` which actually converts to istio service called one after the other. This PR renames the first one as "extractService"

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure