### PR TITLE
remove unnecessary push on service add/update

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -96,7 +96,7 @@ func init() {
 	pilotVersion.With(prom.Labels{"version": version.Info.String()}).Set(1)
 }
 
-// readinessProbe defines a function that will be used indicate whether a server is ready.
+// readinessProbe defines a function that indicates whether a server is ready.
 type readinessProbe func() (bool, error)
 
 // Server contains the runtime configuration for the Pilot discovery service.

--- a/pilot/pkg/serviceregistry/kube/controller/network.go
+++ b/pilot/pkg/serviceregistry/kube/controller/network.go
@@ -169,14 +169,13 @@ func (c *Controller) NetworkGateways() []model.NetworkGateway {
 
 // extractGatewaysFromService checks if the service is a cross-network gateway
 // and if it is, updates the controller's gateways.
-func (c *Controller) extractGatewaysFromService(svc *model.Service) bool {
+func (c *Controller) extractGatewaysFromService(svc *model.Service) {
 	c.Lock()
 	changed := c.extractGatewaysInner(svc)
 	c.Unlock()
 	if changed {
 		c.NotifyGatewayHandlers()
 	}
-	return changed
 }
 
 // reloadNetworkGateways performs extractGatewaysFromService for all services registered with the controller.


### PR DESCRIPTION
We already do a full push when service is added/updated. We do not need to this additional push.

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure