### PR TITLE
EnvoyFilter is also applied to HTTP Proxy Listener

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/listener_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_builder.go
@@ -94,7 +94,6 @@ func (lb *ListenerBuilder) buildHTTPProxyListener() *ListenerBuilder {
 		return lb
 	}
 	removeListenerFilterTimeout([]*listener.Listener{httpProxy})
-	lb.patchOneListener(httpProxy, networking.EnvoyFilter_SIDECAR_OUTBOUND)
 	lb.httpProxyListener = httpProxy
 	return lb
 }
@@ -156,6 +155,7 @@ func (lb *ListenerBuilder) patchListeners() {
 
 	lb.virtualOutboundListener = lb.patchOneListener(lb.virtualOutboundListener, networking.EnvoyFilter_SIDECAR_OUTBOUND)
 	lb.virtualInboundListener = lb.patchOneListener(lb.virtualInboundListener, networking.EnvoyFilter_SIDECAR_INBOUND)
+	lb.httpProxyListener = lb.patchOneListener(lb.httpProxyListener, networking.EnvoyFilter_SIDECAR_OUTBOUND)
 	lb.inboundListeners = envoyfilter.ApplyListenerPatches(networking.EnvoyFilter_SIDECAR_INBOUND, lb.envoyFilterWrapper, lb.inboundListeners, false)
 	lb.outboundListeners = envoyfilter.ApplyListenerPatches(networking.EnvoyFilter_SIDECAR_OUTBOUND, lb.envoyFilterWrapper, lb.outboundListeners, false)
 }

--- a/pilot/pkg/networking/core/v1alpha3/listener_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_builder_test.go
@@ -394,6 +394,45 @@ func TestListenerBuilderPatchListeners(t *testing.T) {
 			},
 		},
 		{
+			name:  "remove HTTP Proxy listener",
+			proxy: sidecarProxy,
+			fields: fields{
+				httpProxyListener: &listener.Listener{
+					Name: "127.0.0.1_81",
+					Address: &core.Address{
+						Address: &core.Address_SocketAddress{
+							SocketAddress: &core.SocketAddress{
+								PortSpecifier: &core.SocketAddress_PortValue{
+									PortValue: 81,
+								},
+							},
+						},
+					},
+					FilterChains: []*listener.FilterChain{
+						{
+							Filters: []*listener.Filter{
+								{
+									Name: wellknown.HTTPConnectionManager,
+								},
+							},
+						},
+					},
+				},
+			},
+			want: fields{
+				inboundListeners: []*listener.Listener{
+					{
+						Name: "new-inbound-listener",
+					},
+				},
+				outboundListeners: []*listener.Listener{
+					{
+						Name: "new-outbound-listener",
+					},
+				},
+			},
+		},
+		{
 			name:  "patch add gateway listener",
 			proxy: gatewayProxy,
 			fields: fields{


### PR DESCRIPTION
The function _patchOneListener,_ that applies the EnvoyFilter patches in the listener, is called in [buildHTTPProxyListener()](https://github.com/istio/istio/blob/bb93b2a69c73c0b3cbdb2f262e36a3e67bb369f5/pilot/pkg/networking/core/v1alpha3/listener_builder.go#L91). However, the _envoyFilterWrapper_ is only populated in the [patchListener()](https://github.com/istio/istio/blob/bb93b2a69c73c0b3cbdb2f262e36a3e67bb369f5/pilot/pkg/networking/core/v1alpha3/listener_builder.go#L145), so the call to _patchOneListener_ in _buildHTTPProxyListener()_ do not apply any changes to the listener created for the HTTP Proxy.

So, to fix this bug, the _patchOneListener_ for the HTTP Proxy listener moved to inside the _patchListener()_, where the other listener are patched. A new test were added to ensure that the listener are indeed removed.

Closes #38673