### PR TITLE
Add custom ErrorLog handler to webhook server

### DIFF
--- a/pilot/pkg/bootstrap/webhook.go
+++ b/pilot/pkg/bootstrap/webhook.go
@@ -16,16 +16,34 @@ package bootstrap
 
 import (
 	"crypto/tls"
+	"log"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
-	"istio.io/pkg/log"
+	istiolog "istio.io/pkg/log"
 )
 
 const (
 	HTTPSHandlerReadyPath = "/httpsReady"
 )
+
+type httpServerErrorLogWriter struct{}
+
+// Webhook http.Server.ErrorLog handler specifically to filter
+// http: TLS handshake error from 127.0.0.1:<PORT>: EOF
+// messages that occur when clients send RST while TLS handshake is still in progress.
+// httpsReadyClient can trigger this periodically when multiple concurrent probes are hitting this endpoint.
+func (*httpServerErrorLogWriter) Write(p []byte) (int, error) {
+	m := strings.TrimSuffix(string(p), "\n")
+	if strings.HasPrefix(m, "http: TLS handshake error") && strings.HasSuffix(m, ": EOF") {
+		istiolog.Debug(m)
+	} else {
+		istiolog.Info(m)
+	}
+	return len(p), nil
+}
 
 // initSSecureWebhookServer handles initialization for the HTTPS webhook server.
 // If https address is off the injection handlers will be registered on the main http endpoint, with
@@ -34,16 +52,17 @@ func (s *Server) initSecureWebhookServer(args *PilotArgs) {
 	// create the https server for hosting the k8s injectionWebhook handlers.
 	if args.ServerOptions.HTTPSAddr == "" {
 		s.httpsMux = s.httpMux
-		log.Info("HTTPS port is disabled, multiplexing webhooks on the httpAddr ", args.ServerOptions.HTTPAddr)
+		istiolog.Info("HTTPS port is disabled, multiplexing webhooks on the httpAddr ", args.ServerOptions.HTTPAddr)
 		return
 	}
 
-	log.Info("initializing secure webhook server for istiod webhooks")
+	istiolog.Info("initializing secure webhook server for istiod webhooks")
 	// create the https server for hosting the k8s injectionWebhook handlers.
 	s.httpsMux = http.NewServeMux()
 	s.httpsServer = &http.Server{
-		Addr:    args.ServerOptions.HTTPSAddr,
-		Handler: s.httpsMux,
+		Addr:     args.ServerOptions.HTTPSAddr,
+		ErrorLog: log.New(&httpServerErrorLogWriter{}, "", 0),
+		Handler:  s.httpsMux,
 		TLSConfig: &tls.Config{
 			GetCertificate: s.getIstiodCertificate,
 			MinVersion:     tls.VersionTLS12,


### PR DESCRIPTION
Signed-off-by: Faseela K <faseela.k@est.tech>

Reduce log level for the webhook server's TLS handshake error to debug to avoid flooding the log in case multiple probes are hitting :8080/ready concurrently.

Background: Pilot-discovery invokes its own webhook readiness server at :15017/httpsReady when receiving a readiness request on :8080/ready. This is done using the webhook readiness client based on http.Client.

The default behavior of http.Client is to reuse an already established TCP connection to the host if possible or otherwise to initiate one. When multiple readiness requests coincide, such as when both readiness and liveness probes are hitting the same endpoint, the webhook readiness client can encounter situations where the initial TCP connection is busy serving the first probe. In such cases http.Client will begin to open a second connection. If the first connection finishes to serve its request and subsequently becomes ready to handle another before the second connection finishes handshaking, http.Client will abort the connection setup by sending a TCP reset and reuse connection 1 also to serve probe 2.

When http.Server/the webhook server receives TCP RST during the TLS handshake, it produces the following error:

http: TLS handshake error from 127.0.0.1:<RANDOM PORT>: EOF

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
