### PR TITLE
tf: disable wait on YAML

### DIFF
--- a/pkg/test/framework/resource/config/apply/option.go
+++ b/pkg/test/framework/resource/config/apply/option.go
@@ -41,6 +41,7 @@ var CleanupConditionally Option = OptionFunc(func(opts *Options) {
 })
 
 // Wait configures the Options to wait for configuration to propagate.
+// This method currently does nothing, due to https://github.com/istio/istio/issues/37148
 var Wait Option = OptionFunc(func(opts *Options) {
-	opts.Wait = true
+	// opts.Wait = true
 })


### PR DESCRIPTION
If we do this long term we should probably remove the option entirely.
For now, just hack it out to see the impact.

Currently wait is broken, so each wait waits 5s. This adds up 14minutes on security MC tests