### PR TITLE
istioctl: initial eds dump

### DIFF
--- a/istioctl/cmd/proxyconfig.go
+++ b/istioctl/cmd/proxyconfig.go
@@ -151,12 +151,15 @@ var (
 	reset             = false
 )
 
-func extractConfigDump(podName, podNamespace string) ([]byte, error) {
+func extractConfigDump(podName, podNamespace string, eds bool) ([]byte, error) {
 	kubeClient, err := kubeClient(kubeconfig, configContext)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create k8s client: %v", err)
 	}
 	path := "config_dump"
+	if eds {
+		path += "?include_eds=true"
+	}
 	debug, err := kubeClient.EnvoyDo(context.TODO(), podName, podNamespace, "GET", path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute command on %s.%s sidecar: %v", podName, podNamespace, err)
@@ -164,8 +167,8 @@ func extractConfigDump(podName, podNamespace string) ([]byte, error) {
 	return debug, err
 }
 
-func setupPodConfigdumpWriter(podName, podNamespace string, out io.Writer) (*configdump.ConfigWriter, error) {
-	debug, err := extractConfigDump(podName, podNamespace)
+func setupPodConfigdumpWriter(podName, podNamespace string, includeEds bool, out io.Writer) (*configdump.ConfigWriter, error) {
+	debug, err := extractConfigDump(podName, podNamespace, includeEds)
 	if err != nil {
 		return nil, err
 	}
@@ -355,7 +358,7 @@ func clusterConfigCmd() *cobra.Command {
 				if podName, podNamespace, err = getPodName(args[0]); err != nil {
 					return err
 				}
-				configWriter, err = setupPodConfigdumpWriter(podName, podNamespace, c.OutOrStdout())
+				configWriter, err = setupPodConfigdumpWriter(podName, podNamespace, false, c.OutOrStdout())
 			} else {
 				configWriter, err = setupFileConfigdumpWriter(configDumpFile, c.OutOrStdout())
 			}
@@ -427,7 +430,7 @@ func allConfigCmd() *cobra.Command {
 					if err != nil {
 						return err
 					}
-					dump, err = extractConfigDump(podName, podNamespace)
+					dump, err = extractConfigDump(podName, podNamespace, false)
 					if err != nil {
 						return err
 					}
@@ -451,7 +454,7 @@ func allConfigCmd() *cobra.Command {
 					if err != nil {
 						return err
 					}
-					configWriter, err = setupPodConfigdumpWriter(podName, podNamespace, c.OutOrStdout())
+					configWriter, err = setupPodConfigdumpWriter(podName, podNamespace, true, c.OutOrStdout())
 					if err != nil {
 						return err
 					}
@@ -546,7 +549,7 @@ func listenerConfigCmd() *cobra.Command {
 				if podName, podNamespace, err = getPodName(args[0]); err != nil {
 					return err
 				}
-				configWriter, err = setupPodConfigdumpWriter(podName, podNamespace, c.OutOrStdout())
+				configWriter, err = setupPodConfigdumpWriter(podName, podNamespace, false, c.OutOrStdout())
 			} else {
 				configWriter, err = setupFileConfigdumpWriter(configDumpFile, c.OutOrStdout())
 			}
@@ -827,7 +830,7 @@ func routeConfigCmd() *cobra.Command {
 				if podName, podNamespace, err = getPodName(args[0]); err != nil {
 					return err
 				}
-				configWriter, err = setupPodConfigdumpWriter(podName, podNamespace, c.OutOrStdout())
+				configWriter, err = setupPodConfigdumpWriter(podName, podNamespace, false, c.OutOrStdout())
 			} else {
 				configWriter, err = setupFileConfigdumpWriter(configDumpFile, c.OutOrStdout())
 			}
@@ -937,6 +940,89 @@ func endpointConfigCmd() *cobra.Command {
 	return endpointConfigCmd
 }
 
+// edsConfigCmd is a command to dump EDS output. This differs from "endpoints" which pulls from /clusters.
+// Notably, this shows metadata and locality, while clusters shows outlier health status
+func edsConfigCmd() *cobra.Command {
+	var podName, podNamespace string
+
+	endpointConfigCmd := &cobra.Command{
+		Use: "eds [<type>/]<name>[.<namespace>]",
+		// Currently, we have an "endpoints" and "eds" command. While for simple use cases these are nearly identical, they give
+		// pretty different outputs for the full JSON output. This makes it a useful command for developers, but may be overwhelming
+		// for basic usage. For now, hide to avoid confusion.
+		Hidden: true,
+		Short:  "Retrieves endpoint configuration for the Envoy in the specified pod",
+		Long:   `Retrieve information about endpoint configuration for the Envoy instance in the specified pod.`,
+		Example: `  # Retrieve full endpoint configuration for a given pod from Envoy.
+  istioctl proxy-config eds <pod-name[.namespace]>
+
+  # Retrieve endpoint summary for endpoint with port 9080.
+  istioctl proxy-config eds <pod-name[.namespace]> --port 9080
+
+  # Retrieve full endpoint with a address (172.17.0.2).
+  istioctl proxy-config eds <pod-name[.namespace]> --address 172.17.0.2 -o json
+
+  # Retrieve full endpoint with a cluster name (outbound|9411||zipkin.istio-system.svc.cluster.local).
+  istioctl proxy-config eds <pod-name[.namespace]> --cluster "outbound|9411||zipkin.istio-system.svc.cluster.local" -o json
+  # Retrieve full endpoint with the status (healthy).
+  istioctl proxy-config eds <pod-name[.namespace]> --status healthy -ojson
+
+  # Retrieve endpoint summary without using Kubernetes API
+  ssh <user@hostname> 'curl localhost:15000/config_dump?include_eds=true' > envoy-config.json
+  istioctl proxy-config eds --file envoy-config.json
+`,
+		Args: func(cmd *cobra.Command, args []string) error {
+			if (len(args) == 1) != (configDumpFile == "") {
+				cmd.Println(cmd.UsageString())
+				return fmt.Errorf("eds requires pod name or --file parameter")
+			}
+			return nil
+		},
+		RunE: func(c *cobra.Command, args []string) error {
+			var configWriter *configdump.ConfigWriter
+			var err error
+			if len(args) == 1 {
+				if podName, podNamespace, err = getPodName(args[0]); err != nil {
+					return err
+				}
+				configWriter, err = setupPodConfigdumpWriter(podName, podNamespace, true, c.OutOrStdout())
+			} else {
+				configWriter, err = setupFileConfigdumpWriter(configDumpFile, c.OutOrStdout())
+			}
+			if err != nil {
+				return err
+			}
+
+			filter := configdump.EndpointFilter{
+				Address: address,
+				Port:    uint32(port),
+				Cluster: clusterName,
+				Status:  status,
+			}
+
+			switch outputFormat {
+			case summaryOutput:
+				return configWriter.PrintEndpointsSummary(filter)
+			case jsonOutput, yamlOutput:
+				return configWriter.PrintEndpoints(filter, outputFormat)
+			default:
+				return fmt.Errorf("output format %q not supported", outputFormat)
+			}
+		},
+		ValidArgsFunction: validPodsNameArgs,
+	}
+
+	endpointConfigCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", summaryOutput, "Output format: one of json|yaml|short")
+	endpointConfigCmd.PersistentFlags().StringVar(&address, "address", "", "Filter endpoints by address field")
+	endpointConfigCmd.PersistentFlags().IntVar(&port, "port", 0, "Filter endpoints by Port field")
+	endpointConfigCmd.PersistentFlags().StringVar(&clusterName, "cluster", "", "Filter endpoints by cluster name field")
+	endpointConfigCmd.PersistentFlags().StringVar(&status, "status", "", "Filter endpoints by status field")
+	endpointConfigCmd.PersistentFlags().StringVarP(&configDumpFile, "file", "f", "",
+		"Envoy config dump JSON file")
+
+	return endpointConfigCmd
+}
+
 func bootstrapConfigCmd() *cobra.Command {
 	var podName, podNamespace string
 
@@ -972,7 +1058,7 @@ func bootstrapConfigCmd() *cobra.Command {
 				if podName, podNamespace, err = getPodName(args[0]); err != nil {
 					return err
 				}
-				configWriter, err = setupPodConfigdumpWriter(podName, podNamespace, c.OutOrStdout())
+				configWriter, err = setupPodConfigdumpWriter(podName, podNamespace, false, c.OutOrStdout())
 			} else {
 				configWriter, err = setupFileConfigdumpWriter(configDumpFile, c.OutOrStdout())
 			}
@@ -1027,7 +1113,7 @@ func secretConfigCmd() *cobra.Command {
 				if podName, podNamespace, err = getPodName(args[0]); err != nil {
 					return err
 				}
-				configWriter, err = setupPodConfigdumpWriter(podName, podNamespace, c.OutOrStdout())
+				configWriter, err = setupPodConfigdumpWriter(podName, podNamespace, false, c.OutOrStdout())
 			} else {
 				configWriter, err = setupFileConfigdumpWriter(configDumpFile, c.OutOrStdout())
 			}
@@ -1077,7 +1163,7 @@ func rootCACompareConfigCmd() *cobra.Command {
 				if podName1, podNamespace1, err = getPodName(args[0]); err != nil {
 					return err
 				}
-				configWriter1, err = setupPodConfigdumpWriter(podName1, podNamespace1, c.OutOrStdout())
+				configWriter1, err = setupPodConfigdumpWriter(podName1, podNamespace1, false, c.OutOrStdout())
 				if err != nil {
 					return err
 				}
@@ -1085,7 +1171,7 @@ func rootCACompareConfigCmd() *cobra.Command {
 				if podName2, podNamespace2, err = getPodName(args[1]); err != nil {
 					return err
 				}
-				configWriter2, err = setupPodConfigdumpWriter(podName2, podNamespace2, c.OutOrStdout())
+				configWriter2, err = setupPodConfigdumpWriter(podName2, podNamespace2, false, c.OutOrStdout())
 				if err != nil {
 					return err
 				}
@@ -1142,6 +1228,7 @@ func proxyConfig() *cobra.Command {
 	configCmd.AddCommand(routeConfigCmd())
 	configCmd.AddCommand(bootstrapConfigCmd())
 	configCmd.AddCommand(endpointConfigCmd())
+	configCmd.AddCommand(edsConfigCmd())
 	configCmd.AddCommand(secretConfigCmd())
 	configCmd.AddCommand(rootCACompareConfigCmd())
 

--- a/istioctl/pkg/util/configdump/endpoint.go
+++ b/istioctl/pkg/util/configdump/endpoint.go
@@ -1,3 +1,17 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package configdump
 
 import (

--- a/istioctl/pkg/util/configdump/endpoint.go
+++ b/istioctl/pkg/util/configdump/endpoint.go
@@ -1,0 +1,21 @@
+package configdump
+
+import (
+	"fmt"
+
+	adminapi "github.com/envoyproxy/go-control-plane/envoy/admin/v3"
+)
+
+// GetEndpointsConfigDump retrieves the listener config dump from the ConfigDump
+func (w *Wrapper) GetEndpointsConfigDump() (*adminapi.EndpointsConfigDump, error) {
+	endpointsDumpAny, err := w.getSection(endpoints)
+	if err != nil {
+		return nil, fmt.Errorf("endpoints not found (was include_eds=true used?): %v", err)
+	}
+	endpointsDump := &adminapi.EndpointsConfigDump{}
+	err = endpointsDumpAny.UnmarshalTo(endpointsDump)
+	if err != nil {
+		return nil, err
+	}
+	return endpointsDump, nil
+}

--- a/istioctl/pkg/util/configdump/util.go
+++ b/istioctl/pkg/util/configdump/util.go
@@ -26,6 +26,7 @@ type configTypeURL string
 const (
 	bootstrap configTypeURL = "type.googleapis.com/envoy.admin.v3.BootstrapConfigDump"
 	listeners configTypeURL = "type.googleapis.com/envoy.admin.v3.ListenersConfigDump"
+	endpoints configTypeURL = "type.googleapis.com/envoy.admin.v3.EndpointsConfigDump"
 	clusters  configTypeURL = "type.googleapis.com/envoy.admin.v3.ClustersConfigDump"
 	routes    configTypeURL = "type.googleapis.com/envoy.admin.v3.RoutesConfigDump"
 	secrets   configTypeURL = "type.googleapis.com/envoy.admin.v3.SecretsConfigDump"

--- a/istioctl/pkg/writer/envoy/configdump/endpoint.go
+++ b/istioctl/pkg/writer/envoy/configdump/endpoint.go
@@ -1,3 +1,17 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package configdump
 
 import (

--- a/istioctl/pkg/writer/envoy/configdump/endpoint.go
+++ b/istioctl/pkg/writer/envoy/configdump/endpoint.go
@@ -1,0 +1,173 @@
+package configdump
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+
+	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+	"sigs.k8s.io/yaml"
+
+	protio "istio.io/istio/istioctl/pkg/util/proto"
+	"istio.io/istio/pilot/pkg/networking/util"
+)
+
+type EndpointFilter struct {
+	Address string
+	Port    uint32
+	Cluster string
+	Status  string
+}
+
+// Verify returns true if the passed host matches the filter fields
+func (e *EndpointFilter) Verify(ep *endpoint.LbEndpoint, cluster string) bool {
+	if e.Address == "" && e.Port == 0 && e.Cluster == "" && e.Status == "" {
+		return true
+	}
+	if e.Address != "" && !strings.EqualFold(retrieveEndpointAddress(ep), e.Address) {
+		return false
+	}
+	if e.Port != 0 && retrieveEndpointPort(ep) != e.Port {
+		return false
+	}
+	if e.Cluster != "" && !strings.EqualFold(cluster, e.Cluster) {
+		return false
+	}
+	status := retrieveEndpointStatus(ep)
+	if e.Status != "" && !strings.EqualFold(core.HealthStatus_name[int32(status)], e.Status) {
+		return false
+	}
+	return true
+}
+
+func retrieveEndpointStatus(ep *endpoint.LbEndpoint) core.HealthStatus {
+	return ep.GetHealthStatus()
+}
+
+func retrieveEndpointPort(ep *endpoint.LbEndpoint) uint32 {
+	return ep.GetEndpoint().GetAddress().GetSocketAddress().GetPortValue()
+}
+
+func retrieveEndpointAddress(ep *endpoint.LbEndpoint) string {
+	addr := ep.GetEndpoint().GetAddress()
+	if addr := addr.GetSocketAddress(); addr != nil {
+		return addr.Address + ":" + strconv.Itoa(int(addr.GetPortValue()))
+	}
+	if addr := addr.GetPipe(); addr != nil {
+		return addr.GetPath()
+	}
+	return ""
+}
+
+func (c *ConfigWriter) PrintEndpoints(filter EndpointFilter, outputFormat string) error {
+	if c.configDump == nil {
+		return fmt.Errorf("config writer has not been primed")
+	}
+	dump, err := c.retrieveSortedEndpointsSlice(filter)
+	if err != nil {
+		return err
+	}
+	marshaller := make(protio.MessageSlice, 0, len(dump))
+	for _, eds := range dump {
+		marshaller = append(marshaller, eds)
+	}
+	out, err := json.MarshalIndent(marshaller, "", "    ")
+	if err != nil {
+		return err
+	}
+	if outputFormat == "yaml" {
+		if out, err = yaml.JSONToYAML(out); err != nil {
+			return err
+		}
+	}
+	_, _ = fmt.Fprintln(c.Stdout, string(out))
+	return nil
+}
+
+func (c *ConfigWriter) PrintEndpointsSummary(filter EndpointFilter) error {
+	w := new(tabwriter.Writer).Init(c.Stdout, 0, 8, 5, ' ', 0)
+
+	fmt.Fprintln(w, "ENDPOINT\tSTATUS\tLOCALITY\tCLUSTER")
+	dump, err := c.retrieveSortedEndpointsSlice(filter)
+	if err != nil {
+		return err
+	}
+	for _, eds := range dump {
+		for _, llb := range eds.Endpoints {
+			for _, ep := range llb.LbEndpoints {
+				fmt.Fprintf(w, "%v\t%v\t%v\t%v\n",
+					retrieveEndpointAddress(ep),
+					ep.GetHealthStatus().String(),
+					util.LocalityToString(llb.Locality),
+					eds.ClusterName,
+				)
+			}
+		}
+	}
+
+	return w.Flush()
+}
+
+func (c *ConfigWriter) retrieveSortedEndpointsSlice(filter EndpointFilter) ([]*endpoint.ClusterLoadAssignment, error) {
+	if c.configDump == nil {
+		return nil, fmt.Errorf("config writer has not been primed")
+	}
+	dump, err := c.configDump.GetEndpointsConfigDump()
+	if err != nil {
+		return nil, err
+	}
+	endpoints := make([]*endpoint.ClusterLoadAssignment, 0, len(dump.DynamicEndpointConfigs))
+	for _, e := range dump.GetDynamicEndpointConfigs() {
+		cla := &endpoint.ClusterLoadAssignment{}
+		if err := e.EndpointConfig.UnmarshalTo(cla); err != nil {
+			return nil, err
+		}
+		for _, llb := range cla.Endpoints {
+			filtered := make([]*endpoint.LbEndpoint, 0, len(llb.LbEndpoints))
+			for _, ep := range llb.LbEndpoints {
+				if !filter.Verify(ep, cla.ClusterName) {
+					continue
+				}
+				filtered = append(filtered, ep)
+			}
+			llb.LbEndpoints = filtered
+		}
+		endpoints = append(endpoints, cla)
+	}
+	for _, e := range dump.GetStaticEndpointConfigs() {
+		cla := &endpoint.ClusterLoadAssignment{}
+		if err := e.EndpointConfig.UnmarshalTo(cla); err != nil {
+			return nil, err
+		}
+		for _, llb := range cla.Endpoints {
+			filtered := make([]*endpoint.LbEndpoint, 0, len(llb.LbEndpoints))
+			for _, ep := range llb.LbEndpoints {
+				if !filter.Verify(ep, cla.ClusterName) {
+					continue
+				}
+				filtered = append(filtered, ep)
+			}
+			llb.LbEndpoints = filtered
+		}
+		endpoints = append(endpoints, cla)
+	}
+	sort.Slice(endpoints, func(i, j int) bool {
+		iDirection, iSubset, iName, iPort := safelyParseSubsetKey(endpoints[i].ClusterName)
+		jDirection, jSubset, jName, jPort := safelyParseSubsetKey(endpoints[j].ClusterName)
+		if iName == jName {
+			if iSubset == jSubset {
+				if iPort == jPort {
+					return iDirection < jDirection
+				}
+				return iPort < jPort
+			}
+			return iSubset < jSubset
+		}
+		return iName < jName
+	})
+	return endpoints, nil
+}


### PR DESCRIPTION
This introduces new functionality into `istioctl proxy-config` to pull from EDS. This is subtly different from the current `endpoints` which pulls from /clusters. Unfortunately, neither is a superset of the other -- `/clusters` has the Outlier Detection status which we output, while EDS has locality, metadata, etc. To avoid breaking changes by simply moving, or confusion by two similar commands, this introduces a new `eds` mode but _hides it_ - open to other ideas here.