### PR TITLE
Fix cert rotation for proxyless, don't start SDS

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -1174,7 +1174,7 @@ data:
             volumeMounts:
             - name: workload-socket
               mountPath: /var/run/secrets/workload-spiffe-uds
-            {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
+            {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
             - name: gke-workload-certificate
               mountPath: /var/run/secrets/workload-spiffe-credentials
               readOnly: true
@@ -1224,7 +1224,7 @@ data:
               # UDS channel between istioagent and gRPC client for XDS/SDS
               - mountPath: /etc/istio/proxy
                 name: istio-xds
-              {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
+              {{- if eq $.Values.global.caName "GkeWorkloadCertificate" }}
               - name: gke-workload-certificate
                 mountPath: /var/run/secrets/workload-spiffe-credentials
                 readOnly: true

--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -1037,22 +1037,6 @@ data:
           }
         spec:
           containers:
-          {{- range $index, $container := .Spec.Containers  }}
-          {{ if not (eq $container.Name "istio-proxy") }}
-          - name: {{ $container.Name }}
-            env:
-            - name: "GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT"
-              value: "true"
-            - name: "GRPC_XDS_BOOTSTRAP"
-              value: "/etc/istio/proxy/grpc-bootstrap.json"
-            volumeMounts:
-            - mountPath: /var/lib/istio/data
-              name: istio-data
-            # UDS channel between istioagent and gRPC client for XDS/SDS
-            - mountPath: /etc/istio/proxy
-              name: istio-xds
-          {{- end }}
-          {{- end }}
           - name: istio-proxy
           {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
             image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
@@ -1060,9 +1044,9 @@ data:
             image: "{{ .ProxyImage }}"
           {{- end }}
             ports:
-            - containerPort: 15090
+            - containerPort: 15020
               protocol: TCP
-              name: http-envoy-prom
+              name: mesh-metrics
             args:
             - proxy
             - sidecar
@@ -1190,7 +1174,7 @@ data:
             volumeMounts:
             - name: workload-socket
               mountPath: /var/run/secrets/workload-spiffe-uds
-            {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
+            {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
             - name: gke-workload-certificate
               mountPath: /var/run/secrets/workload-spiffe-credentials
               readOnly: true
@@ -1226,6 +1210,30 @@ data:
               {{ toYaml $value | indent 6 }}
               {{ end }}
               {{- end }}
+        {{- range $index, $container := .Spec.Containers  }}
+        {{ if not (eq $container.Name "istio-proxy") }}
+          - name: {{ $container.Name }}
+            env:
+              - name: "GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT"
+                value: "true"
+              - name: "GRPC_XDS_BOOTSTRAP"
+                value: "/etc/istio/proxy/grpc-bootstrap.json"
+            volumeMounts:
+              - mountPath: /var/lib/istio/data
+                name: istio-data
+              # UDS channel between istioagent and gRPC client for XDS/SDS
+              - mountPath: /etc/istio/proxy
+                name: istio-xds
+              {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
+              - name: gke-workload-certificate
+                mountPath: /var/run/secrets/workload-spiffe-credentials
+                readOnly: true
+              {{- else }}
+              - name: workload-certs
+                mountPath: /var/run/secrets/workload-spiffe-credentials
+              {{- end }}
+        {{- end }}
+        {{- end }}
           volumes:
           - emptyDir:
             name: workload-socket

--- a/manifests/charts/istio-control/istio-discovery/files/grpc-agent.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/grpc-agent.yaml
@@ -44,22 +44,6 @@ metadata:
   }
 spec:
   containers:
-  {{- range $index, $container := .Spec.Containers  }}
-  {{ if not (eq $container.Name "istio-proxy") }}
-  - name: {{ $container.Name }}
-    env:
-    - name: "GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT"
-      value: "true"
-    - name: "GRPC_XDS_BOOTSTRAP"
-      value: "/etc/istio/proxy/grpc-bootstrap.json"
-    volumeMounts:
-    - mountPath: /var/lib/istio/data
-      name: istio-data
-    # UDS channel between istioagent and gRPC client for XDS/SDS
-    - mountPath: /etc/istio/proxy
-      name: istio-xds
-  {{- end }}
-  {{- end }}
   - name: istio-proxy
   {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
     image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
@@ -67,9 +51,9 @@ spec:
     image: "{{ .ProxyImage }}"
   {{- end }}
     ports:
-    - containerPort: 15090
+    - containerPort: 15020
       protocol: TCP
-      name: http-envoy-prom
+      name: metrics
     args:
     - proxy
     - sidecar
@@ -197,7 +181,7 @@ spec:
     volumeMounts:
     - name: workload-socket
       mountPath: /var/run/secrets/workload-spiffe-uds
-    {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
+    {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
     - name: gke-workload-certificate
       mountPath: /var/run/secrets/workload-spiffe-credentials
       readOnly: true
@@ -233,6 +217,31 @@ spec:
       {{ toYaml $value | indent 6 }}
       {{ end }}
       {{- end }}
+{{- range $index, $container := .Spec.Containers  }}
+{{ if not (eq $container.Name "istio-proxy") }}
+  - name: {{ $container.Name }}
+    env:
+      - name: "GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT"
+        value: "true"
+      - name: "GRPC_XDS_BOOTSTRAP"
+        value: "/etc/istio/proxy/grpc-bootstrap.json"
+    volumeMounts:
+      - mountPath: /var/lib/istio/data
+        name: istio-data
+      # UDS channel between istioagent and gRPC client for XDS/SDS
+      - mountPath: /etc/istio/proxy
+        name: istio-xds
+      {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
+      - name: gke-workload-certificate
+        mountPath: /var/run/secrets/workload-spiffe-credentials
+        readOnly: true
+      {{- else }}
+      - name: workload-certs
+        mountPath: /var/run/secrets/workload-spiffe-credentials
+      {{- end }}
+
+{{- end }}
+{{- end }}
   volumes:
   - emptyDir:
     name: workload-socket

--- a/manifests/charts/istio-control/istio-discovery/files/grpc-agent.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/grpc-agent.yaml
@@ -53,7 +53,7 @@ spec:
     ports:
     - containerPort: 15020
       protocol: TCP
-      name: metrics
+      name: mesh-metrics
     args:
     - proxy
     - sidecar

--- a/manifests/charts/istio-control/istio-discovery/files/grpc-agent.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/grpc-agent.yaml
@@ -239,7 +239,6 @@ spec:
       - name: workload-certs
         mountPath: /var/run/secrets/workload-spiffe-credentials
       {{- end }}
-
 {{- end }}
 {{- end }}
   volumes:

--- a/manifests/charts/istio-control/istio-discovery/files/grpc-agent.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/grpc-agent.yaml
@@ -181,7 +181,7 @@ spec:
     volumeMounts:
     - name: workload-socket
       mountPath: /var/run/secrets/workload-spiffe-uds
-    {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
+    {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
     - name: gke-workload-certificate
       mountPath: /var/run/secrets/workload-spiffe-credentials
       readOnly: true
@@ -231,7 +231,7 @@ spec:
       # UDS channel between istioagent and gRPC client for XDS/SDS
       - mountPath: /etc/istio/proxy
         name: istio-xds
-      {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
+      {{- if eq $.Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         mountPath: /var/run/secrets/workload-spiffe-credentials
         readOnly: true

--- a/pkg/istio-agent/agent.go
+++ b/pkg/istio-agent/agent.go
@@ -548,9 +548,7 @@ func (a *Agent) getWorkloadCerts(st *cache.SecretManagerClient) (sk *security.Se
 			break
 		}
 		log.Warnf("failed to get certificate: %v", err)
-		select {
-		case <-time.After(b.NextBackOff()):
-		}
+		time.Sleep(b.NextBackOff())
 	}
 	for {
 		_, err := st.GenerateSecret(security.RootCertReqResourceName)
@@ -558,9 +556,7 @@ func (a *Agent) getWorkloadCerts(st *cache.SecretManagerClient) (sk *security.Se
 			break
 		}
 		log.Warnf("failed to get root certificate: %v", err)
-		select {
-		case <-time.After(b.NextBackOff()):
-		}
+		time.Sleep(b.NextBackOff())
 	}
 	return
 }

--- a/pkg/istio-agent/agent.go
+++ b/pkg/istio-agent/agent.go
@@ -28,6 +28,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	bootstrapv3 "github.com/envoyproxy/go-control-plane/envoy/config/bootstrap/v3"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"github.com/golang/protobuf/proto"
@@ -508,11 +509,60 @@ func (a *Agent) initSdsServer() error {
 	if err != nil {
 		return fmt.Errorf("failed to start workload secret manager %v", err)
 	}
-	pkpConf := a.proxyConfig.GetPrivateKeyProvider()
-	a.sdsServer = sds.NewServer(a.secOpts, a.secretCache, pkpConf)
-	a.secretCache.RegisterSecretHandler(a.sdsServer.OnSecretUpdate)
+	if a.cfg.DisableEnvoy {
+		// For proxyless we don't need an SDS server, but still need the keys and
+		// we need them refreshed periodically.
+		//
+		// This is based on the code from newSDSService, but customized to have explicit rotation.
+		go func() {
+			st := a.secretCache
+			st.RegisterSecretHandler(func(resourceName string) {
+				// The secret handler is called when a secret should be renewed, after invalidating the cache.
+				// The handler does not call GenerateSecret - it is a side-effect of the SDS generate() method, which
+				// is called by sdsServer.OnSecretUpdate, which triggers a push and eventually calls sdsservice.Generate
+				// TODO: extract the logic to detect expiration time, and use a simpler code to rotate to files.
+				_, _ = a.getWorkloadCerts(st)
+			})
+			_, _ = a.getWorkloadCerts(st)
+		}()
+	} else {
+		pkpConf := a.proxyConfig.GetPrivateKeyProvider()
+		a.sdsServer = sds.NewServer(a.secOpts, a.secretCache, pkpConf)
+		a.secretCache.RegisterSecretHandler(a.sdsServer.OnSecretUpdate)
+	}
 
 	return nil
+}
+
+// getWorkloadCerts will attempt to get a cert, with infinite exponential backoff
+// It will not return until both workload cert and root cert are generated.
+//
+// TODO: evaluate replacing the STS server with a file data source, to simplify Envoy config
+func (a *Agent) getWorkloadCerts(st *cache.SecretManagerClient) (sk *security.SecretItem, err error) {
+	b := backoff.NewExponentialBackOff()
+	b.MaxElapsedTime = 0
+
+	for {
+		sk, err = st.GenerateSecret(security.WorkloadKeyCertResourceName)
+		if err == nil {
+			break
+		}
+		log.Warnf("failed to get certificate: %v", err)
+		select {
+		case <-time.After(b.NextBackOff()):
+		}
+	}
+	for {
+		_, err := st.GenerateSecret(security.RootCertReqResourceName)
+		if err == nil {
+			break
+		}
+		log.Warnf("failed to get root certificate: %v", err)
+		select {
+		case <-time.After(b.NextBackOff()):
+		}
+	}
+	return
 }
 
 func (a *Agent) caFileWatcherHandler(ctx context.Context, caFile string) {

--- a/pkg/kube/inject/testdata/inject/grpc-agent.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/grpc-agent.yaml.injected
@@ -19,7 +19,7 @@ spec:
         prometheus.io/scrape: "true"
         proxy.istio.io/overrides: '{"containers":[{"name":"traffic","image":"fake.docker.io/google-samples/traffic-go-gke:1.0","resources":{},"readinessProbe":{"httpGet":{"port":80}}}]}'
         sidecar.istio.io/rewriteAppHTTPProbers: "false"
-        sidecar.istio.io/status: '{"initContainers":null,"containers":["traffic","istio-proxy"],"volumes":["workload-socket","workload-certs","istio-xds","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":null,"containers":["istio-proxy","traffic"],"volumes":["workload-socket","workload-certs","istio-xds","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
       creationTimestamp: null
       labels:
         app: grpc
@@ -43,6 +43,8 @@ spec:
           name: istio-data
         - mountPath: /etc/istio/proxy
           name: istio-xds
+        - mountPath: /var/run/secrets/workload-spiffe-credentials
+          name: workload-certs
       - args:
         - proxy
         - sidecar
@@ -115,8 +117,8 @@ spec:
               - --url=http://localhost:15020/healthz/ready
         name: istio-proxy
         ports:
-        - containerPort: 15090
-          name: http-envoy-prom
+        - containerPort: 15020
+          name: mesh-metrics
           protocol: TCP
         readinessProbe:
           failureThreshold: 30

--- a/pkg/kube/inject/testdata/inputs/custom-template.yaml.34.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/custom-template.yaml.34.template.gen.yaml
@@ -970,7 +970,7 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
-        {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
+        {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
           readOnly: true
@@ -1020,7 +1020,7 @@ templates:
           # UDS channel between istioagent and gRPC client for XDS/SDS
           - mountPath: /etc/istio/proxy
             name: istio-xds
-          {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
+          {{- if eq $.Values.global.caName "GkeWorkloadCertificate" }}
           - name: gke-workload-certificate
             mountPath: /var/run/secrets/workload-spiffe-credentials
             readOnly: true

--- a/pkg/kube/inject/testdata/inputs/custom-template.yaml.34.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/custom-template.yaml.34.template.gen.yaml
@@ -833,22 +833,6 @@ templates:
       }
     spec:
       containers:
-      {{- range $index, $container := .Spec.Containers  }}
-      {{ if not (eq $container.Name "istio-proxy") }}
-      - name: {{ $container.Name }}
-        env:
-        - name: "GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT"
-          value: "true"
-        - name: "GRPC_XDS_BOOTSTRAP"
-          value: "/etc/istio/proxy/grpc-bootstrap.json"
-        volumeMounts:
-        - mountPath: /var/lib/istio/data
-          name: istio-data
-        # UDS channel between istioagent and gRPC client for XDS/SDS
-        - mountPath: /etc/istio/proxy
-          name: istio-xds
-      {{- end }}
-      {{- end }}
       - name: istio-proxy
       {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
         image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
@@ -856,9 +840,9 @@ templates:
         image: "{{ .ProxyImage }}"
       {{- end }}
         ports:
-        - containerPort: 15090
+        - containerPort: 15020
           protocol: TCP
-          name: http-envoy-prom
+          name: mesh-metrics
         args:
         - proxy
         - sidecar
@@ -986,7 +970,7 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
-        {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
+        {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
           readOnly: true
@@ -1022,6 +1006,30 @@ templates:
           {{ toYaml $value | indent 6 }}
           {{ end }}
           {{- end }}
+    {{- range $index, $container := .Spec.Containers  }}
+    {{ if not (eq $container.Name "istio-proxy") }}
+      - name: {{ $container.Name }}
+        env:
+          - name: "GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT"
+            value: "true"
+          - name: "GRPC_XDS_BOOTSTRAP"
+            value: "/etc/istio/proxy/grpc-bootstrap.json"
+        volumeMounts:
+          - mountPath: /var/lib/istio/data
+            name: istio-data
+          # UDS channel between istioagent and gRPC client for XDS/SDS
+          - mountPath: /etc/istio/proxy
+            name: istio-xds
+          {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
+          - name: gke-workload-certificate
+            mountPath: /var/run/secrets/workload-spiffe-credentials
+            readOnly: true
+          {{- else }}
+          - name: workload-certs
+            mountPath: /var/run/secrets/workload-spiffe-credentials
+          {{- end }}
+    {{- end }}
+    {{- end }}
       volumes:
       - emptyDir:
         name: workload-socket

--- a/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
@@ -970,7 +970,7 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
-        {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
+        {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
           readOnly: true
@@ -1020,7 +1020,7 @@ templates:
           # UDS channel between istioagent and gRPC client for XDS/SDS
           - mountPath: /etc/istio/proxy
             name: istio-xds
-          {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
+          {{- if eq $.Values.global.caName "GkeWorkloadCertificate" }}
           - name: gke-workload-certificate
             mountPath: /var/run/secrets/workload-spiffe-credentials
             readOnly: true

--- a/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
@@ -833,22 +833,6 @@ templates:
       }
     spec:
       containers:
-      {{- range $index, $container := .Spec.Containers  }}
-      {{ if not (eq $container.Name "istio-proxy") }}
-      - name: {{ $container.Name }}
-        env:
-        - name: "GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT"
-          value: "true"
-        - name: "GRPC_XDS_BOOTSTRAP"
-          value: "/etc/istio/proxy/grpc-bootstrap.json"
-        volumeMounts:
-        - mountPath: /var/lib/istio/data
-          name: istio-data
-        # UDS channel between istioagent and gRPC client for XDS/SDS
-        - mountPath: /etc/istio/proxy
-          name: istio-xds
-      {{- end }}
-      {{- end }}
       - name: istio-proxy
       {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
         image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
@@ -856,9 +840,9 @@ templates:
         image: "{{ .ProxyImage }}"
       {{- end }}
         ports:
-        - containerPort: 15090
+        - containerPort: 15020
           protocol: TCP
-          name: http-envoy-prom
+          name: mesh-metrics
         args:
         - proxy
         - sidecar
@@ -986,7 +970,7 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
-        {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
+        {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
           readOnly: true
@@ -1022,6 +1006,30 @@ templates:
           {{ toYaml $value | indent 6 }}
           {{ end }}
           {{- end }}
+    {{- range $index, $container := .Spec.Containers  }}
+    {{ if not (eq $container.Name "istio-proxy") }}
+      - name: {{ $container.Name }}
+        env:
+          - name: "GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT"
+            value: "true"
+          - name: "GRPC_XDS_BOOTSTRAP"
+            value: "/etc/istio/proxy/grpc-bootstrap.json"
+        volumeMounts:
+          - mountPath: /var/lib/istio/data
+            name: istio-data
+          # UDS channel between istioagent and gRPC client for XDS/SDS
+          - mountPath: /etc/istio/proxy
+            name: istio-xds
+          {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
+          - name: gke-workload-certificate
+            mountPath: /var/run/secrets/workload-spiffe-credentials
+            readOnly: true
+          {{- else }}
+          - name: workload-certs
+            mountPath: /var/run/secrets/workload-spiffe-credentials
+          {{- end }}
+    {{- end }}
+    {{- end }}
       volumes:
       - emptyDir:
         name: workload-socket

--- a/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
@@ -970,7 +970,7 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
-        {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
+        {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
           readOnly: true
@@ -1020,7 +1020,7 @@ templates:
           # UDS channel between istioagent and gRPC client for XDS/SDS
           - mountPath: /etc/istio/proxy
             name: istio-xds
-          {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
+          {{- if eq $.Values.global.caName "GkeWorkloadCertificate" }}
           - name: gke-workload-certificate
             mountPath: /var/run/secrets/workload-spiffe-credentials
             readOnly: true

--- a/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
@@ -833,22 +833,6 @@ templates:
       }
     spec:
       containers:
-      {{- range $index, $container := .Spec.Containers  }}
-      {{ if not (eq $container.Name "istio-proxy") }}
-      - name: {{ $container.Name }}
-        env:
-        - name: "GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT"
-          value: "true"
-        - name: "GRPC_XDS_BOOTSTRAP"
-          value: "/etc/istio/proxy/grpc-bootstrap.json"
-        volumeMounts:
-        - mountPath: /var/lib/istio/data
-          name: istio-data
-        # UDS channel between istioagent and gRPC client for XDS/SDS
-        - mountPath: /etc/istio/proxy
-          name: istio-xds
-      {{- end }}
-      {{- end }}
       - name: istio-proxy
       {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
         image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
@@ -856,9 +840,9 @@ templates:
         image: "{{ .ProxyImage }}"
       {{- end }}
         ports:
-        - containerPort: 15090
+        - containerPort: 15020
           protocol: TCP
-          name: http-envoy-prom
+          name: mesh-metrics
         args:
         - proxy
         - sidecar
@@ -986,7 +970,7 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
-        {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
+        {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
           readOnly: true
@@ -1022,6 +1006,30 @@ templates:
           {{ toYaml $value | indent 6 }}
           {{ end }}
           {{- end }}
+    {{- range $index, $container := .Spec.Containers  }}
+    {{ if not (eq $container.Name "istio-proxy") }}
+      - name: {{ $container.Name }}
+        env:
+          - name: "GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT"
+            value: "true"
+          - name: "GRPC_XDS_BOOTSTRAP"
+            value: "/etc/istio/proxy/grpc-bootstrap.json"
+        volumeMounts:
+          - mountPath: /var/lib/istio/data
+            name: istio-data
+          # UDS channel between istioagent and gRPC client for XDS/SDS
+          - mountPath: /etc/istio/proxy
+            name: istio-xds
+          {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
+          - name: gke-workload-certificate
+            mountPath: /var/run/secrets/workload-spiffe-credentials
+            readOnly: true
+          {{- else }}
+          - name: workload-certs
+            mountPath: /var/run/secrets/workload-spiffe-credentials
+          {{- end }}
+    {{- end }}
+    {{- end }}
       volumes:
       - emptyDir:
         name: workload-socket

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
@@ -970,7 +970,7 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
-        {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
+        {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
           readOnly: true
@@ -1020,7 +1020,7 @@ templates:
           # UDS channel between istioagent and gRPC client for XDS/SDS
           - mountPath: /etc/istio/proxy
             name: istio-xds
-          {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
+          {{- if eq $.Values.global.caName "GkeWorkloadCertificate" }}
           - name: gke-workload-certificate
             mountPath: /var/run/secrets/workload-spiffe-credentials
             readOnly: true

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
@@ -833,22 +833,6 @@ templates:
       }
     spec:
       containers:
-      {{- range $index, $container := .Spec.Containers  }}
-      {{ if not (eq $container.Name "istio-proxy") }}
-      - name: {{ $container.Name }}
-        env:
-        - name: "GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT"
-          value: "true"
-        - name: "GRPC_XDS_BOOTSTRAP"
-          value: "/etc/istio/proxy/grpc-bootstrap.json"
-        volumeMounts:
-        - mountPath: /var/lib/istio/data
-          name: istio-data
-        # UDS channel between istioagent and gRPC client for XDS/SDS
-        - mountPath: /etc/istio/proxy
-          name: istio-xds
-      {{- end }}
-      {{- end }}
       - name: istio-proxy
       {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
         image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
@@ -856,9 +840,9 @@ templates:
         image: "{{ .ProxyImage }}"
       {{- end }}
         ports:
-        - containerPort: 15090
+        - containerPort: 15020
           protocol: TCP
-          name: http-envoy-prom
+          name: mesh-metrics
         args:
         - proxy
         - sidecar
@@ -986,7 +970,7 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
-        {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
+        {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
           readOnly: true
@@ -1022,6 +1006,30 @@ templates:
           {{ toYaml $value | indent 6 }}
           {{ end }}
           {{- end }}
+    {{- range $index, $container := .Spec.Containers  }}
+    {{ if not (eq $container.Name "istio-proxy") }}
+      - name: {{ $container.Name }}
+        env:
+          - name: "GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT"
+            value: "true"
+          - name: "GRPC_XDS_BOOTSTRAP"
+            value: "/etc/istio/proxy/grpc-bootstrap.json"
+        volumeMounts:
+          - mountPath: /var/lib/istio/data
+            name: istio-data
+          # UDS channel between istioagent and gRPC client for XDS/SDS
+          - mountPath: /etc/istio/proxy
+            name: istio-xds
+          {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
+          - name: gke-workload-certificate
+            mountPath: /var/run/secrets/workload-spiffe-credentials
+            readOnly: true
+          {{- else }}
+          - name: workload-certs
+            mountPath: /var/run/secrets/workload-spiffe-credentials
+          {{- end }}
+    {{- end }}
+    {{- end }}
       volumes:
       - emptyDir:
         name: workload-socket

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
@@ -970,7 +970,7 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
-        {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
+        {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
           readOnly: true
@@ -1020,7 +1020,7 @@ templates:
           # UDS channel between istioagent and gRPC client for XDS/SDS
           - mountPath: /etc/istio/proxy
             name: istio-xds
-          {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
+          {{- if eq $.Values.global.caName "GkeWorkloadCertificate" }}
           - name: gke-workload-certificate
             mountPath: /var/run/secrets/workload-spiffe-credentials
             readOnly: true

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
@@ -833,22 +833,6 @@ templates:
       }
     spec:
       containers:
-      {{- range $index, $container := .Spec.Containers  }}
-      {{ if not (eq $container.Name "istio-proxy") }}
-      - name: {{ $container.Name }}
-        env:
-        - name: "GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT"
-          value: "true"
-        - name: "GRPC_XDS_BOOTSTRAP"
-          value: "/etc/istio/proxy/grpc-bootstrap.json"
-        volumeMounts:
-        - mountPath: /var/lib/istio/data
-          name: istio-data
-        # UDS channel between istioagent and gRPC client for XDS/SDS
-        - mountPath: /etc/istio/proxy
-          name: istio-xds
-      {{- end }}
-      {{- end }}
       - name: istio-proxy
       {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
         image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
@@ -856,9 +840,9 @@ templates:
         image: "{{ .ProxyImage }}"
       {{- end }}
         ports:
-        - containerPort: 15090
+        - containerPort: 15020
           protocol: TCP
-          name: http-envoy-prom
+          name: mesh-metrics
         args:
         - proxy
         - sidecar
@@ -986,7 +970,7 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
-        {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
+        {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
           readOnly: true
@@ -1022,6 +1006,30 @@ templates:
           {{ toYaml $value | indent 6 }}
           {{ end }}
           {{- end }}
+    {{- range $index, $container := .Spec.Containers  }}
+    {{ if not (eq $container.Name "istio-proxy") }}
+      - name: {{ $container.Name }}
+        env:
+          - name: "GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT"
+            value: "true"
+          - name: "GRPC_XDS_BOOTSTRAP"
+            value: "/etc/istio/proxy/grpc-bootstrap.json"
+        volumeMounts:
+          - mountPath: /var/lib/istio/data
+            name: istio-data
+          # UDS channel between istioagent and gRPC client for XDS/SDS
+          - mountPath: /etc/istio/proxy
+            name: istio-xds
+          {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
+          - name: gke-workload-certificate
+            mountPath: /var/run/secrets/workload-spiffe-credentials
+            readOnly: true
+          {{- else }}
+          - name: workload-certs
+            mountPath: /var/run/secrets/workload-spiffe-credentials
+          {{- end }}
+    {{- end }}
+    {{- end }}
       volumes:
       - emptyDir:
         name: workload-socket

--- a/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
@@ -970,7 +970,7 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
-        {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
+        {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
           readOnly: true
@@ -1020,7 +1020,7 @@ templates:
           # UDS channel between istioagent and gRPC client for XDS/SDS
           - mountPath: /etc/istio/proxy
             name: istio-xds
-          {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
+          {{- if eq $.Values.global.caName "GkeWorkloadCertificate" }}
           - name: gke-workload-certificate
             mountPath: /var/run/secrets/workload-spiffe-credentials
             readOnly: true

--- a/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
@@ -833,22 +833,6 @@ templates:
       }
     spec:
       containers:
-      {{- range $index, $container := .Spec.Containers  }}
-      {{ if not (eq $container.Name "istio-proxy") }}
-      - name: {{ $container.Name }}
-        env:
-        - name: "GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT"
-          value: "true"
-        - name: "GRPC_XDS_BOOTSTRAP"
-          value: "/etc/istio/proxy/grpc-bootstrap.json"
-        volumeMounts:
-        - mountPath: /var/lib/istio/data
-          name: istio-data
-        # UDS channel between istioagent and gRPC client for XDS/SDS
-        - mountPath: /etc/istio/proxy
-          name: istio-xds
-      {{- end }}
-      {{- end }}
       - name: istio-proxy
       {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
         image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
@@ -856,9 +840,9 @@ templates:
         image: "{{ .ProxyImage }}"
       {{- end }}
         ports:
-        - containerPort: 15090
+        - containerPort: 15020
           protocol: TCP
-          name: http-envoy-prom
+          name: mesh-metrics
         args:
         - proxy
         - sidecar
@@ -986,7 +970,7 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
-        {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
+        {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
           readOnly: true
@@ -1022,6 +1006,30 @@ templates:
           {{ toYaml $value | indent 6 }}
           {{ end }}
           {{- end }}
+    {{- range $index, $container := .Spec.Containers  }}
+    {{ if not (eq $container.Name "istio-proxy") }}
+      - name: {{ $container.Name }}
+        env:
+          - name: "GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT"
+            value: "true"
+          - name: "GRPC_XDS_BOOTSTRAP"
+            value: "/etc/istio/proxy/grpc-bootstrap.json"
+        volumeMounts:
+          - mountPath: /var/lib/istio/data
+            name: istio-data
+          # UDS channel between istioagent and gRPC client for XDS/SDS
+          - mountPath: /etc/istio/proxy
+            name: istio-xds
+          {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
+          - name: gke-workload-certificate
+            mountPath: /var/run/secrets/workload-spiffe-credentials
+            readOnly: true
+          {{- else }}
+          - name: workload-certs
+            mountPath: /var/run/secrets/workload-spiffe-credentials
+          {{- end }}
+    {{- end }}
+    {{- end }}
       volumes:
       - emptyDir:
         name: workload-socket

--- a/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
@@ -970,7 +970,7 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
-        {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
+        {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
           readOnly: true
@@ -1020,7 +1020,7 @@ templates:
           # UDS channel between istioagent and gRPC client for XDS/SDS
           - mountPath: /etc/istio/proxy
             name: istio-xds
-          {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
+          {{- if eq $.Values.global.caName "GkeWorkloadCertificate" }}
           - name: gke-workload-certificate
             mountPath: /var/run/secrets/workload-spiffe-credentials
             readOnly: true

--- a/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
@@ -833,22 +833,6 @@ templates:
       }
     spec:
       containers:
-      {{- range $index, $container := .Spec.Containers  }}
-      {{ if not (eq $container.Name "istio-proxy") }}
-      - name: {{ $container.Name }}
-        env:
-        - name: "GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT"
-          value: "true"
-        - name: "GRPC_XDS_BOOTSTRAP"
-          value: "/etc/istio/proxy/grpc-bootstrap.json"
-        volumeMounts:
-        - mountPath: /var/lib/istio/data
-          name: istio-data
-        # UDS channel between istioagent and gRPC client for XDS/SDS
-        - mountPath: /etc/istio/proxy
-          name: istio-xds
-      {{- end }}
-      {{- end }}
       - name: istio-proxy
       {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
         image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
@@ -856,9 +840,9 @@ templates:
         image: "{{ .ProxyImage }}"
       {{- end }}
         ports:
-        - containerPort: 15090
+        - containerPort: 15020
           protocol: TCP
-          name: http-envoy-prom
+          name: mesh-metrics
         args:
         - proxy
         - sidecar
@@ -986,7 +970,7 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
-        {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
+        {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
           readOnly: true
@@ -1022,6 +1006,30 @@ templates:
           {{ toYaml $value | indent 6 }}
           {{ end }}
           {{- end }}
+    {{- range $index, $container := .Spec.Containers  }}
+    {{ if not (eq $container.Name "istio-proxy") }}
+      - name: {{ $container.Name }}
+        env:
+          - name: "GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT"
+            value: "true"
+          - name: "GRPC_XDS_BOOTSTRAP"
+            value: "/etc/istio/proxy/grpc-bootstrap.json"
+        volumeMounts:
+          - mountPath: /var/lib/istio/data
+            name: istio-data
+          # UDS channel between istioagent and gRPC client for XDS/SDS
+          - mountPath: /etc/istio/proxy
+            name: istio-xds
+          {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
+          - name: gke-workload-certificate
+            mountPath: /var/run/secrets/workload-spiffe-credentials
+            readOnly: true
+          {{- else }}
+          - name: workload-certs
+            mountPath: /var/run/secrets/workload-spiffe-credentials
+          {{- end }}
+    {{- end }}
+    {{- end }}
       volumes:
       - emptyDir:
         name: workload-socket

--- a/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
@@ -970,7 +970,7 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
-        {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
+        {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
           readOnly: true
@@ -1020,7 +1020,7 @@ templates:
           # UDS channel between istioagent and gRPC client for XDS/SDS
           - mountPath: /etc/istio/proxy
             name: istio-xds
-          {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
+          {{- if eq $.Values.global.caName "GkeWorkloadCertificate" }}
           - name: gke-workload-certificate
             mountPath: /var/run/secrets/workload-spiffe-credentials
             readOnly: true

--- a/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
@@ -833,22 +833,6 @@ templates:
       }
     spec:
       containers:
-      {{- range $index, $container := .Spec.Containers  }}
-      {{ if not (eq $container.Name "istio-proxy") }}
-      - name: {{ $container.Name }}
-        env:
-        - name: "GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT"
-          value: "true"
-        - name: "GRPC_XDS_BOOTSTRAP"
-          value: "/etc/istio/proxy/grpc-bootstrap.json"
-        volumeMounts:
-        - mountPath: /var/lib/istio/data
-          name: istio-data
-        # UDS channel between istioagent and gRPC client for XDS/SDS
-        - mountPath: /etc/istio/proxy
-          name: istio-xds
-      {{- end }}
-      {{- end }}
       - name: istio-proxy
       {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
         image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
@@ -856,9 +840,9 @@ templates:
         image: "{{ .ProxyImage }}"
       {{- end }}
         ports:
-        - containerPort: 15090
+        - containerPort: 15020
           protocol: TCP
-          name: http-envoy-prom
+          name: mesh-metrics
         args:
         - proxy
         - sidecar
@@ -986,7 +970,7 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
-        {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
+        {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
           readOnly: true
@@ -1022,6 +1006,30 @@ templates:
           {{ toYaml $value | indent 6 }}
           {{ end }}
           {{- end }}
+    {{- range $index, $container := .Spec.Containers  }}
+    {{ if not (eq $container.Name "istio-proxy") }}
+      - name: {{ $container.Name }}
+        env:
+          - name: "GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT"
+            value: "true"
+          - name: "GRPC_XDS_BOOTSTRAP"
+            value: "/etc/istio/proxy/grpc-bootstrap.json"
+        volumeMounts:
+          - mountPath: /var/lib/istio/data
+            name: istio-data
+          # UDS channel between istioagent and gRPC client for XDS/SDS
+          - mountPath: /etc/istio/proxy
+            name: istio-xds
+          {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
+          - name: gke-workload-certificate
+            mountPath: /var/run/secrets/workload-spiffe-credentials
+            readOnly: true
+          {{- else }}
+          - name: workload-certs
+            mountPath: /var/run/secrets/workload-spiffe-credentials
+          {{- end }}
+    {{- end }}
+    {{- end }}
       volumes:
       - emptyDir:
         name: workload-socket

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
@@ -970,7 +970,7 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
-        {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
+        {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
           readOnly: true
@@ -1020,7 +1020,7 @@ templates:
           # UDS channel between istioagent and gRPC client for XDS/SDS
           - mountPath: /etc/istio/proxy
             name: istio-xds
-          {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
+          {{- if eq $.Values.global.caName "GkeWorkloadCertificate" }}
           - name: gke-workload-certificate
             mountPath: /var/run/secrets/workload-spiffe-credentials
             readOnly: true

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
@@ -833,22 +833,6 @@ templates:
       }
     spec:
       containers:
-      {{- range $index, $container := .Spec.Containers  }}
-      {{ if not (eq $container.Name "istio-proxy") }}
-      - name: {{ $container.Name }}
-        env:
-        - name: "GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT"
-          value: "true"
-        - name: "GRPC_XDS_BOOTSTRAP"
-          value: "/etc/istio/proxy/grpc-bootstrap.json"
-        volumeMounts:
-        - mountPath: /var/lib/istio/data
-          name: istio-data
-        # UDS channel between istioagent and gRPC client for XDS/SDS
-        - mountPath: /etc/istio/proxy
-          name: istio-xds
-      {{- end }}
-      {{- end }}
       - name: istio-proxy
       {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
         image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
@@ -856,9 +840,9 @@ templates:
         image: "{{ .ProxyImage }}"
       {{- end }}
         ports:
-        - containerPort: 15090
+        - containerPort: 15020
           protocol: TCP
-          name: http-envoy-prom
+          name: mesh-metrics
         args:
         - proxy
         - sidecar
@@ -986,7 +970,7 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
-        {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
+        {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
           readOnly: true
@@ -1022,6 +1006,30 @@ templates:
           {{ toYaml $value | indent 6 }}
           {{ end }}
           {{- end }}
+    {{- range $index, $container := .Spec.Containers  }}
+    {{ if not (eq $container.Name "istio-proxy") }}
+      - name: {{ $container.Name }}
+        env:
+          - name: "GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT"
+            value: "true"
+          - name: "GRPC_XDS_BOOTSTRAP"
+            value: "/etc/istio/proxy/grpc-bootstrap.json"
+        volumeMounts:
+          - mountPath: /var/lib/istio/data
+            name: istio-data
+          # UDS channel between istioagent and gRPC client for XDS/SDS
+          - mountPath: /etc/istio/proxy
+            name: istio-xds
+          {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
+          - name: gke-workload-certificate
+            mountPath: /var/run/secrets/workload-spiffe-credentials
+            readOnly: true
+          {{- else }}
+          - name: workload-certs
+            mountPath: /var/run/secrets/workload-spiffe-credentials
+          {{- end }}
+    {{- end }}
+    {{- end }}
       volumes:
       - emptyDir:
         name: workload-socket

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
@@ -970,7 +970,7 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
-        {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
+        {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
           readOnly: true
@@ -1020,7 +1020,7 @@ templates:
           # UDS channel between istioagent and gRPC client for XDS/SDS
           - mountPath: /etc/istio/proxy
             name: istio-xds
-          {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
+          {{- if eq $.Values.global.caName "GkeWorkloadCertificate" }}
           - name: gke-workload-certificate
             mountPath: /var/run/secrets/workload-spiffe-credentials
             readOnly: true

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
@@ -833,22 +833,6 @@ templates:
       }
     spec:
       containers:
-      {{- range $index, $container := .Spec.Containers  }}
-      {{ if not (eq $container.Name "istio-proxy") }}
-      - name: {{ $container.Name }}
-        env:
-        - name: "GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT"
-          value: "true"
-        - name: "GRPC_XDS_BOOTSTRAP"
-          value: "/etc/istio/proxy/grpc-bootstrap.json"
-        volumeMounts:
-        - mountPath: /var/lib/istio/data
-          name: istio-data
-        # UDS channel between istioagent and gRPC client for XDS/SDS
-        - mountPath: /etc/istio/proxy
-          name: istio-xds
-      {{- end }}
-      {{- end }}
       - name: istio-proxy
       {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
         image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
@@ -856,9 +840,9 @@ templates:
         image: "{{ .ProxyImage }}"
       {{- end }}
         ports:
-        - containerPort: 15090
+        - containerPort: 15020
           protocol: TCP
-          name: http-envoy-prom
+          name: mesh-metrics
         args:
         - proxy
         - sidecar
@@ -986,7 +970,7 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
-        {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
+        {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
           readOnly: true
@@ -1022,6 +1006,30 @@ templates:
           {{ toYaml $value | indent 6 }}
           {{ end }}
           {{- end }}
+    {{- range $index, $container := .Spec.Containers  }}
+    {{ if not (eq $container.Name "istio-proxy") }}
+      - name: {{ $container.Name }}
+        env:
+          - name: "GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT"
+            value: "true"
+          - name: "GRPC_XDS_BOOTSTRAP"
+            value: "/etc/istio/proxy/grpc-bootstrap.json"
+        volumeMounts:
+          - mountPath: /var/lib/istio/data
+            name: istio-data
+          # UDS channel between istioagent and gRPC client for XDS/SDS
+          - mountPath: /etc/istio/proxy
+            name: istio-xds
+          {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
+          - name: gke-workload-certificate
+            mountPath: /var/run/secrets/workload-spiffe-credentials
+            readOnly: true
+          {{- else }}
+          - name: workload-certs
+            mountPath: /var/run/secrets/workload-spiffe-credentials
+          {{- end }}
+    {{- end }}
+    {{- end }}
       volumes:
       - emptyDir:
         name: workload-socket

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
@@ -970,7 +970,7 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
-        {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
+        {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
           readOnly: true
@@ -1020,7 +1020,7 @@ templates:
           # UDS channel between istioagent and gRPC client for XDS/SDS
           - mountPath: /etc/istio/proxy
             name: istio-xds
-          {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
+          {{- if eq $.Values.global.caName "GkeWorkloadCertificate" }}
           - name: gke-workload-certificate
             mountPath: /var/run/secrets/workload-spiffe-credentials
             readOnly: true

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
@@ -833,22 +833,6 @@ templates:
       }
     spec:
       containers:
-      {{- range $index, $container := .Spec.Containers  }}
-      {{ if not (eq $container.Name "istio-proxy") }}
-      - name: {{ $container.Name }}
-        env:
-        - name: "GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT"
-          value: "true"
-        - name: "GRPC_XDS_BOOTSTRAP"
-          value: "/etc/istio/proxy/grpc-bootstrap.json"
-        volumeMounts:
-        - mountPath: /var/lib/istio/data
-          name: istio-data
-        # UDS channel between istioagent and gRPC client for XDS/SDS
-        - mountPath: /etc/istio/proxy
-          name: istio-xds
-      {{- end }}
-      {{- end }}
       - name: istio-proxy
       {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
         image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
@@ -856,9 +840,9 @@ templates:
         image: "{{ .ProxyImage }}"
       {{- end }}
         ports:
-        - containerPort: 15090
+        - containerPort: 15020
           protocol: TCP
-          name: http-envoy-prom
+          name: mesh-metrics
         args:
         - proxy
         - sidecar
@@ -986,7 +970,7 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
-        {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
+        {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
           readOnly: true
@@ -1022,6 +1006,30 @@ templates:
           {{ toYaml $value | indent 6 }}
           {{ end }}
           {{- end }}
+    {{- range $index, $container := .Spec.Containers  }}
+    {{ if not (eq $container.Name "istio-proxy") }}
+      - name: {{ $container.Name }}
+        env:
+          - name: "GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT"
+            value: "true"
+          - name: "GRPC_XDS_BOOTSTRAP"
+            value: "/etc/istio/proxy/grpc-bootstrap.json"
+        volumeMounts:
+          - mountPath: /var/lib/istio/data
+            name: istio-data
+          # UDS channel between istioagent and gRPC client for XDS/SDS
+          - mountPath: /etc/istio/proxy
+            name: istio-xds
+          {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
+          - name: gke-workload-certificate
+            mountPath: /var/run/secrets/workload-spiffe-credentials
+            readOnly: true
+          {{- else }}
+          - name: workload-certs
+            mountPath: /var/run/secrets/workload-spiffe-credentials
+          {{- end }}
+    {{- end }}
+    {{- end }}
       volumes:
       - emptyDir:
         name: workload-socket

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
@@ -970,7 +970,7 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
-        {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
+        {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
           readOnly: true
@@ -1020,7 +1020,7 @@ templates:
           # UDS channel between istioagent and gRPC client for XDS/SDS
           - mountPath: /etc/istio/proxy
             name: istio-xds
-          {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
+          {{- if eq $.Values.global.caName "GkeWorkloadCertificate" }}
           - name: gke-workload-certificate
             mountPath: /var/run/secrets/workload-spiffe-credentials
             readOnly: true

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
@@ -833,22 +833,6 @@ templates:
       }
     spec:
       containers:
-      {{- range $index, $container := .Spec.Containers  }}
-      {{ if not (eq $container.Name "istio-proxy") }}
-      - name: {{ $container.Name }}
-        env:
-        - name: "GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT"
-          value: "true"
-        - name: "GRPC_XDS_BOOTSTRAP"
-          value: "/etc/istio/proxy/grpc-bootstrap.json"
-        volumeMounts:
-        - mountPath: /var/lib/istio/data
-          name: istio-data
-        # UDS channel between istioagent and gRPC client for XDS/SDS
-        - mountPath: /etc/istio/proxy
-          name: istio-xds
-      {{- end }}
-      {{- end }}
       - name: istio-proxy
       {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
         image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
@@ -856,9 +840,9 @@ templates:
         image: "{{ .ProxyImage }}"
       {{- end }}
         ports:
-        - containerPort: 15090
+        - containerPort: 15020
           protocol: TCP
-          name: http-envoy-prom
+          name: mesh-metrics
         args:
         - proxy
         - sidecar
@@ -986,7 +970,7 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
-        {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
+        {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
           readOnly: true
@@ -1022,6 +1006,30 @@ templates:
           {{ toYaml $value | indent 6 }}
           {{ end }}
           {{- end }}
+    {{- range $index, $container := .Spec.Containers  }}
+    {{ if not (eq $container.Name "istio-proxy") }}
+      - name: {{ $container.Name }}
+        env:
+          - name: "GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT"
+            value: "true"
+          - name: "GRPC_XDS_BOOTSTRAP"
+            value: "/etc/istio/proxy/grpc-bootstrap.json"
+        volumeMounts:
+          - mountPath: /var/lib/istio/data
+            name: istio-data
+          # UDS channel between istioagent and gRPC client for XDS/SDS
+          - mountPath: /etc/istio/proxy
+            name: istio-xds
+          {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
+          - name: gke-workload-certificate
+            mountPath: /var/run/secrets/workload-spiffe-credentials
+            readOnly: true
+          {{- else }}
+          - name: workload-certs
+            mountPath: /var/run/secrets/workload-spiffe-credentials
+          {{- end }}
+    {{- end }}
+    {{- end }}
       volumes:
       - emptyDir:
         name: workload-socket

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
@@ -970,7 +970,7 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
-        {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
+        {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
           readOnly: true
@@ -1020,7 +1020,7 @@ templates:
           # UDS channel between istioagent and gRPC client for XDS/SDS
           - mountPath: /etc/istio/proxy
             name: istio-xds
-          {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
+          {{- if eq $.Values.global.caName "GkeWorkloadCertificate" }}
           - name: gke-workload-certificate
             mountPath: /var/run/secrets/workload-spiffe-credentials
             readOnly: true

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
@@ -833,22 +833,6 @@ templates:
       }
     spec:
       containers:
-      {{- range $index, $container := .Spec.Containers  }}
-      {{ if not (eq $container.Name "istio-proxy") }}
-      - name: {{ $container.Name }}
-        env:
-        - name: "GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT"
-          value: "true"
-        - name: "GRPC_XDS_BOOTSTRAP"
-          value: "/etc/istio/proxy/grpc-bootstrap.json"
-        volumeMounts:
-        - mountPath: /var/lib/istio/data
-          name: istio-data
-        # UDS channel between istioagent and gRPC client for XDS/SDS
-        - mountPath: /etc/istio/proxy
-          name: istio-xds
-      {{- end }}
-      {{- end }}
       - name: istio-proxy
       {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
         image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
@@ -856,9 +840,9 @@ templates:
         image: "{{ .ProxyImage }}"
       {{- end }}
         ports:
-        - containerPort: 15090
+        - containerPort: 15020
           protocol: TCP
-          name: http-envoy-prom
+          name: mesh-metrics
         args:
         - proxy
         - sidecar
@@ -986,7 +970,7 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
-        {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
+        {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
           readOnly: true
@@ -1022,6 +1006,30 @@ templates:
           {{ toYaml $value | indent 6 }}
           {{ end }}
           {{- end }}
+    {{- range $index, $container := .Spec.Containers  }}
+    {{ if not (eq $container.Name "istio-proxy") }}
+      - name: {{ $container.Name }}
+        env:
+          - name: "GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT"
+            value: "true"
+          - name: "GRPC_XDS_BOOTSTRAP"
+            value: "/etc/istio/proxy/grpc-bootstrap.json"
+        volumeMounts:
+          - mountPath: /var/lib/istio/data
+            name: istio-data
+          # UDS channel between istioagent and gRPC client for XDS/SDS
+          - mountPath: /etc/istio/proxy
+            name: istio-xds
+          {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
+          - name: gke-workload-certificate
+            mountPath: /var/run/secrets/workload-spiffe-credentials
+            readOnly: true
+          {{- else }}
+          - name: workload-certs
+            mountPath: /var/run/secrets/workload-spiffe-credentials
+          {{- end }}
+    {{- end }}
+    {{- end }}
       volumes:
       - emptyDir:
         name: workload-socket

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
@@ -970,7 +970,7 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
-        {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
+        {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
           readOnly: true
@@ -1020,7 +1020,7 @@ templates:
           # UDS channel between istioagent and gRPC client for XDS/SDS
           - mountPath: /etc/istio/proxy
             name: istio-xds
-          {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
+          {{- if eq $.Values.global.caName "GkeWorkloadCertificate" }}
           - name: gke-workload-certificate
             mountPath: /var/run/secrets/workload-spiffe-credentials
             readOnly: true

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
@@ -833,22 +833,6 @@ templates:
       }
     spec:
       containers:
-      {{- range $index, $container := .Spec.Containers  }}
-      {{ if not (eq $container.Name "istio-proxy") }}
-      - name: {{ $container.Name }}
-        env:
-        - name: "GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT"
-          value: "true"
-        - name: "GRPC_XDS_BOOTSTRAP"
-          value: "/etc/istio/proxy/grpc-bootstrap.json"
-        volumeMounts:
-        - mountPath: /var/lib/istio/data
-          name: istio-data
-        # UDS channel between istioagent and gRPC client for XDS/SDS
-        - mountPath: /etc/istio/proxy
-          name: istio-xds
-      {{- end }}
-      {{- end }}
       - name: istio-proxy
       {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
         image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
@@ -856,9 +840,9 @@ templates:
         image: "{{ .ProxyImage }}"
       {{- end }}
         ports:
-        - containerPort: 15090
+        - containerPort: 15020
           protocol: TCP
-          name: http-envoy-prom
+          name: mesh-metrics
         args:
         - proxy
         - sidecar
@@ -986,7 +970,7 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
-        {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
+        {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
           readOnly: true
@@ -1022,6 +1006,30 @@ templates:
           {{ toYaml $value | indent 6 }}
           {{ end }}
           {{- end }}
+    {{- range $index, $container := .Spec.Containers  }}
+    {{ if not (eq $container.Name "istio-proxy") }}
+      - name: {{ $container.Name }}
+        env:
+          - name: "GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT"
+            value: "true"
+          - name: "GRPC_XDS_BOOTSTRAP"
+            value: "/etc/istio/proxy/grpc-bootstrap.json"
+        volumeMounts:
+          - mountPath: /var/lib/istio/data
+            name: istio-data
+          # UDS channel between istioagent and gRPC client for XDS/SDS
+          - mountPath: /etc/istio/proxy
+            name: istio-xds
+          {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
+          - name: gke-workload-certificate
+            mountPath: /var/run/secrets/workload-spiffe-credentials
+            readOnly: true
+          {{- else }}
+          - name: workload-certs
+            mountPath: /var/run/secrets/workload-spiffe-credentials
+          {{- end }}
+    {{- end }}
+    {{- end }}
       volumes:
       - emptyDir:
         name: workload-socket

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
@@ -970,7 +970,7 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
-        {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
+        {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
           readOnly: true
@@ -1020,7 +1020,7 @@ templates:
           # UDS channel between istioagent and gRPC client for XDS/SDS
           - mountPath: /etc/istio/proxy
             name: istio-xds
-          {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
+          {{- if eq $.Values.global.caName "GkeWorkloadCertificate" }}
           - name: gke-workload-certificate
             mountPath: /var/run/secrets/workload-spiffe-credentials
             readOnly: true

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
@@ -833,22 +833,6 @@ templates:
       }
     spec:
       containers:
-      {{- range $index, $container := .Spec.Containers  }}
-      {{ if not (eq $container.Name "istio-proxy") }}
-      - name: {{ $container.Name }}
-        env:
-        - name: "GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT"
-          value: "true"
-        - name: "GRPC_XDS_BOOTSTRAP"
-          value: "/etc/istio/proxy/grpc-bootstrap.json"
-        volumeMounts:
-        - mountPath: /var/lib/istio/data
-          name: istio-data
-        # UDS channel between istioagent and gRPC client for XDS/SDS
-        - mountPath: /etc/istio/proxy
-          name: istio-xds
-      {{- end }}
-      {{- end }}
       - name: istio-proxy
       {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
         image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
@@ -856,9 +840,9 @@ templates:
         image: "{{ .ProxyImage }}"
       {{- end }}
         ports:
-        - containerPort: 15090
+        - containerPort: 15020
           protocol: TCP
-          name: http-envoy-prom
+          name: mesh-metrics
         args:
         - proxy
         - sidecar
@@ -986,7 +970,7 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
-        {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
+        {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
           readOnly: true
@@ -1022,6 +1006,30 @@ templates:
           {{ toYaml $value | indent 6 }}
           {{ end }}
           {{- end }}
+    {{- range $index, $container := .Spec.Containers  }}
+    {{ if not (eq $container.Name "istio-proxy") }}
+      - name: {{ $container.Name }}
+        env:
+          - name: "GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT"
+            value: "true"
+          - name: "GRPC_XDS_BOOTSTRAP"
+            value: "/etc/istio/proxy/grpc-bootstrap.json"
+        volumeMounts:
+          - mountPath: /var/lib/istio/data
+            name: istio-data
+          # UDS channel between istioagent and gRPC client for XDS/SDS
+          - mountPath: /etc/istio/proxy
+            name: istio-xds
+          {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
+          - name: gke-workload-certificate
+            mountPath: /var/run/secrets/workload-spiffe-credentials
+            readOnly: true
+          {{- else }}
+          - name: workload-certs
+            mountPath: /var/run/secrets/workload-spiffe-credentials
+          {{- end }}
+    {{- end }}
+    {{- end }}
       volumes:
       - emptyDir:
         name: workload-socket

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
@@ -970,7 +970,7 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
-        {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
+        {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
           readOnly: true
@@ -1020,7 +1020,7 @@ templates:
           # UDS channel between istioagent and gRPC client for XDS/SDS
           - mountPath: /etc/istio/proxy
             name: istio-xds
-          {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
+          {{- if eq $.Values.global.caName "GkeWorkloadCertificate" }}
           - name: gke-workload-certificate
             mountPath: /var/run/secrets/workload-spiffe-credentials
             readOnly: true

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
@@ -833,22 +833,6 @@ templates:
       }
     spec:
       containers:
-      {{- range $index, $container := .Spec.Containers  }}
-      {{ if not (eq $container.Name "istio-proxy") }}
-      - name: {{ $container.Name }}
-        env:
-        - name: "GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT"
-          value: "true"
-        - name: "GRPC_XDS_BOOTSTRAP"
-          value: "/etc/istio/proxy/grpc-bootstrap.json"
-        volumeMounts:
-        - mountPath: /var/lib/istio/data
-          name: istio-data
-        # UDS channel between istioagent and gRPC client for XDS/SDS
-        - mountPath: /etc/istio/proxy
-          name: istio-xds
-      {{- end }}
-      {{- end }}
       - name: istio-proxy
       {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
         image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
@@ -856,9 +840,9 @@ templates:
         image: "{{ .ProxyImage }}"
       {{- end }}
         ports:
-        - containerPort: 15090
+        - containerPort: 15020
           protocol: TCP
-          name: http-envoy-prom
+          name: mesh-metrics
         args:
         - proxy
         - sidecar
@@ -986,7 +970,7 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
-        {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
+        {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
           readOnly: true
@@ -1022,6 +1006,30 @@ templates:
           {{ toYaml $value | indent 6 }}
           {{ end }}
           {{- end }}
+    {{- range $index, $container := .Spec.Containers  }}
+    {{ if not (eq $container.Name "istio-proxy") }}
+      - name: {{ $container.Name }}
+        env:
+          - name: "GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT"
+            value: "true"
+          - name: "GRPC_XDS_BOOTSTRAP"
+            value: "/etc/istio/proxy/grpc-bootstrap.json"
+        volumeMounts:
+          - mountPath: /var/lib/istio/data
+            name: istio-data
+          # UDS channel between istioagent and gRPC client for XDS/SDS
+          - mountPath: /etc/istio/proxy
+            name: istio-xds
+          {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
+          - name: gke-workload-certificate
+            mountPath: /var/run/secrets/workload-spiffe-credentials
+            readOnly: true
+          {{- else }}
+          - name: workload-certs
+            mountPath: /var/run/secrets/workload-spiffe-credentials
+          {{- end }}
+    {{- end }}
+    {{- end }}
       volumes:
       - emptyDir:
         name: workload-socket

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
@@ -970,7 +970,7 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
-        {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
+        {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
           readOnly: true
@@ -1020,7 +1020,7 @@ templates:
           # UDS channel between istioagent and gRPC client for XDS/SDS
           - mountPath: /etc/istio/proxy
             name: istio-xds
-          {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
+          {{- if eq $.Values.global.caName "GkeWorkloadCertificate" }}
           - name: gke-workload-certificate
             mountPath: /var/run/secrets/workload-spiffe-credentials
             readOnly: true

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
@@ -833,22 +833,6 @@ templates:
       }
     spec:
       containers:
-      {{- range $index, $container := .Spec.Containers  }}
-      {{ if not (eq $container.Name "istio-proxy") }}
-      - name: {{ $container.Name }}
-        env:
-        - name: "GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT"
-          value: "true"
-        - name: "GRPC_XDS_BOOTSTRAP"
-          value: "/etc/istio/proxy/grpc-bootstrap.json"
-        volumeMounts:
-        - mountPath: /var/lib/istio/data
-          name: istio-data
-        # UDS channel between istioagent and gRPC client for XDS/SDS
-        - mountPath: /etc/istio/proxy
-          name: istio-xds
-      {{- end }}
-      {{- end }}
       - name: istio-proxy
       {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
         image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
@@ -856,9 +840,9 @@ templates:
         image: "{{ .ProxyImage }}"
       {{- end }}
         ports:
-        - containerPort: 15090
+        - containerPort: 15020
           protocol: TCP
-          name: http-envoy-prom
+          name: mesh-metrics
         args:
         - proxy
         - sidecar
@@ -986,7 +970,7 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
-        {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
+        {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
           readOnly: true
@@ -1022,6 +1006,30 @@ templates:
           {{ toYaml $value | indent 6 }}
           {{ end }}
           {{- end }}
+    {{- range $index, $container := .Spec.Containers  }}
+    {{ if not (eq $container.Name "istio-proxy") }}
+      - name: {{ $container.Name }}
+        env:
+          - name: "GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT"
+            value: "true"
+          - name: "GRPC_XDS_BOOTSTRAP"
+            value: "/etc/istio/proxy/grpc-bootstrap.json"
+        volumeMounts:
+          - mountPath: /var/lib/istio/data
+            name: istio-data
+          # UDS channel between istioagent and gRPC client for XDS/SDS
+          - mountPath: /etc/istio/proxy
+            name: istio-xds
+          {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
+          - name: gke-workload-certificate
+            mountPath: /var/run/secrets/workload-spiffe-credentials
+            readOnly: true
+          {{- else }}
+          - name: workload-certs
+            mountPath: /var/run/secrets/workload-spiffe-credentials
+          {{- end }}
+    {{- end }}
+    {{- end }}
       volumes:
       - emptyDir:
         name: workload-socket

--- a/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
@@ -970,7 +970,7 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
-        {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
+        {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
           readOnly: true
@@ -1020,7 +1020,7 @@ templates:
           # UDS channel between istioagent and gRPC client for XDS/SDS
           - mountPath: /etc/istio/proxy
             name: istio-xds
-          {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
+          {{- if eq $.Values.global.caName "GkeWorkloadCertificate" }}
           - name: gke-workload-certificate
             mountPath: /var/run/secrets/workload-spiffe-credentials
             readOnly: true

--- a/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
@@ -833,22 +833,6 @@ templates:
       }
     spec:
       containers:
-      {{- range $index, $container := .Spec.Containers  }}
-      {{ if not (eq $container.Name "istio-proxy") }}
-      - name: {{ $container.Name }}
-        env:
-        - name: "GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT"
-          value: "true"
-        - name: "GRPC_XDS_BOOTSTRAP"
-          value: "/etc/istio/proxy/grpc-bootstrap.json"
-        volumeMounts:
-        - mountPath: /var/lib/istio/data
-          name: istio-data
-        # UDS channel between istioagent and gRPC client for XDS/SDS
-        - mountPath: /etc/istio/proxy
-          name: istio-xds
-      {{- end }}
-      {{- end }}
       - name: istio-proxy
       {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
         image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
@@ -856,9 +840,9 @@ templates:
         image: "{{ .ProxyImage }}"
       {{- end }}
         ports:
-        - containerPort: 15090
+        - containerPort: 15020
           protocol: TCP
-          name: http-envoy-prom
+          name: mesh-metrics
         args:
         - proxy
         - sidecar
@@ -986,7 +970,7 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
-        {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
+        {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
           readOnly: true
@@ -1022,6 +1006,30 @@ templates:
           {{ toYaml $value | indent 6 }}
           {{ end }}
           {{- end }}
+    {{- range $index, $container := .Spec.Containers  }}
+    {{ if not (eq $container.Name "istio-proxy") }}
+      - name: {{ $container.Name }}
+        env:
+          - name: "GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT"
+            value: "true"
+          - name: "GRPC_XDS_BOOTSTRAP"
+            value: "/etc/istio/proxy/grpc-bootstrap.json"
+        volumeMounts:
+          - mountPath: /var/lib/istio/data
+            name: istio-data
+          # UDS channel between istioagent and gRPC client for XDS/SDS
+          - mountPath: /etc/istio/proxy
+            name: istio-xds
+          {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
+          - name: gke-workload-certificate
+            mountPath: /var/run/secrets/workload-spiffe-credentials
+            readOnly: true
+          {{- else }}
+          - name: workload-certs
+            mountPath: /var/run/secrets/workload-spiffe-credentials
+          {{- end }}
+    {{- end }}
+    {{- end }}
       volumes:
       - emptyDir:
         name: workload-socket

--- a/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
@@ -970,7 +970,7 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
-        {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
+        {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
           readOnly: true
@@ -1020,7 +1020,7 @@ templates:
           # UDS channel between istioagent and gRPC client for XDS/SDS
           - mountPath: /etc/istio/proxy
             name: istio-xds
-          {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
+          {{- if eq $.Values.global.caName "GkeWorkloadCertificate" }}
           - name: gke-workload-certificate
             mountPath: /var/run/secrets/workload-spiffe-credentials
             readOnly: true

--- a/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
@@ -833,22 +833,6 @@ templates:
       }
     spec:
       containers:
-      {{- range $index, $container := .Spec.Containers  }}
-      {{ if not (eq $container.Name "istio-proxy") }}
-      - name: {{ $container.Name }}
-        env:
-        - name: "GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT"
-          value: "true"
-        - name: "GRPC_XDS_BOOTSTRAP"
-          value: "/etc/istio/proxy/grpc-bootstrap.json"
-        volumeMounts:
-        - mountPath: /var/lib/istio/data
-          name: istio-data
-        # UDS channel between istioagent and gRPC client for XDS/SDS
-        - mountPath: /etc/istio/proxy
-          name: istio-xds
-      {{- end }}
-      {{- end }}
       - name: istio-proxy
       {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
         image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
@@ -856,9 +840,9 @@ templates:
         image: "{{ .ProxyImage }}"
       {{- end }}
         ports:
-        - containerPort: 15090
+        - containerPort: 15020
           protocol: TCP
-          name: http-envoy-prom
+          name: mesh-metrics
         args:
         - proxy
         - sidecar
@@ -986,7 +970,7 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
-        {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
+        {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
           readOnly: true
@@ -1022,6 +1006,30 @@ templates:
           {{ toYaml $value | indent 6 }}
           {{ end }}
           {{- end }}
+    {{- range $index, $container := .Spec.Containers  }}
+    {{ if not (eq $container.Name "istio-proxy") }}
+      - name: {{ $container.Name }}
+        env:
+          - name: "GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT"
+            value: "true"
+          - name: "GRPC_XDS_BOOTSTRAP"
+            value: "/etc/istio/proxy/grpc-bootstrap.json"
+        volumeMounts:
+          - mountPath: /var/lib/istio/data
+            name: istio-data
+          # UDS channel between istioagent and gRPC client for XDS/SDS
+          - mountPath: /etc/istio/proxy
+            name: istio-xds
+          {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
+          - name: gke-workload-certificate
+            mountPath: /var/run/secrets/workload-spiffe-credentials
+            readOnly: true
+          {{- else }}
+          - name: workload-certs
+            mountPath: /var/run/secrets/workload-spiffe-credentials
+          {{- end }}
+    {{- end }}
+    {{- end }}
       volumes:
       - emptyDir:
         name: workload-socket

--- a/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
@@ -970,7 +970,7 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
-        {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
+        {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
           readOnly: true
@@ -1020,7 +1020,7 @@ templates:
           # UDS channel between istioagent and gRPC client for XDS/SDS
           - mountPath: /etc/istio/proxy
             name: istio-xds
-          {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
+          {{- if eq $.Values.global.caName "GkeWorkloadCertificate" }}
           - name: gke-workload-certificate
             mountPath: /var/run/secrets/workload-spiffe-credentials
             readOnly: true

--- a/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
@@ -833,22 +833,6 @@ templates:
       }
     spec:
       containers:
-      {{- range $index, $container := .Spec.Containers  }}
-      {{ if not (eq $container.Name "istio-proxy") }}
-      - name: {{ $container.Name }}
-        env:
-        - name: "GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT"
-          value: "true"
-        - name: "GRPC_XDS_BOOTSTRAP"
-          value: "/etc/istio/proxy/grpc-bootstrap.json"
-        volumeMounts:
-        - mountPath: /var/lib/istio/data
-          name: istio-data
-        # UDS channel between istioagent and gRPC client for XDS/SDS
-        - mountPath: /etc/istio/proxy
-          name: istio-xds
-      {{- end }}
-      {{- end }}
       - name: istio-proxy
       {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
         image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
@@ -856,9 +840,9 @@ templates:
         image: "{{ .ProxyImage }}"
       {{- end }}
         ports:
-        - containerPort: 15090
+        - containerPort: 15020
           protocol: TCP
-          name: http-envoy-prom
+          name: mesh-metrics
         args:
         - proxy
         - sidecar
@@ -986,7 +970,7 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
-        {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
+        {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
           readOnly: true
@@ -1022,6 +1006,30 @@ templates:
           {{ toYaml $value | indent 6 }}
           {{ end }}
           {{- end }}
+    {{- range $index, $container := .Spec.Containers  }}
+    {{ if not (eq $container.Name "istio-proxy") }}
+      - name: {{ $container.Name }}
+        env:
+          - name: "GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT"
+            value: "true"
+          - name: "GRPC_XDS_BOOTSTRAP"
+            value: "/etc/istio/proxy/grpc-bootstrap.json"
+        volumeMounts:
+          - mountPath: /var/lib/istio/data
+            name: istio-data
+          # UDS channel between istioagent and gRPC client for XDS/SDS
+          - mountPath: /etc/istio/proxy
+            name: istio-xds
+          {{- if or (isset .ObjectMeta.Annotations `security.cloud.google.com/use-workload-certificates`) (eq .Values.global.caName "GkeWorkloadCertificate") }}
+          - name: gke-workload-certificate
+            mountPath: /var/run/secrets/workload-spiffe-credentials
+            readOnly: true
+          {{- else }}
+          - name: workload-certs
+            mountPath: /var/run/secrets/workload-spiffe-credentials
+          {{- end }}
+    {{- end }}
+    {{- end }}
       volumes:
       - emptyDir:
         name: workload-socket


### PR DESCRIPTION
The change also moves the injection template - istio-proxy will be first ( for readability and to avoid confusing people - it is reordered by injector anyways ), and handles the case where GKE cert provider is enabled by user via annotation.