### PR TITLE
remove warnings from istioctl envoy filter analyzer during first install

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -1782,6 +1782,7 @@ metadata:
   labels:
     istio.io/rev: default
 spec:
+  priority: -1
   configPatches:
     - applyTo: HTTP_FILTER
       match:
@@ -1906,6 +1907,7 @@ metadata:
   labels:
     istio.io/rev: default
 spec:
+  priority: -1
   configPatches:
     - applyTo: NETWORK_FILTER
       match:
@@ -2022,6 +2024,7 @@ metadata:
   labels:
     istio.io/rev: default
 spec:
+  priority: -1
   configPatches:
     - applyTo: HTTP_FILTER
       match:
@@ -2146,6 +2149,7 @@ metadata:
   labels:
     istio.io/rev: default
 spec:
+  priority: -1
   configPatches:
     - applyTo: NETWORK_FILTER
       match:
@@ -2262,6 +2266,7 @@ metadata:
   labels:
     istio.io/rev: default
 spec:
+  priority: -1
   configPatches:
     - applyTo: HTTP_FILTER
       match:
@@ -2386,6 +2391,7 @@ metadata:
   labels:
     istio.io/rev: default
 spec:
+  priority: -1
   configPatches:
     - applyTo: NETWORK_FILTER
       match:
@@ -2502,6 +2508,7 @@ metadata:
   labels:
     istio.io/rev: default
 spec:
+  priority: -1
   configPatches:
     - applyTo: HTTP_FILTER
       match:
@@ -2626,6 +2633,7 @@ metadata:
   labels:
     istio.io/rev: default
 spec:
+  priority: -1
   configPatches:
     - applyTo: NETWORK_FILTER
       match:
@@ -2742,6 +2750,7 @@ metadata:
   labels:
     istio.io/rev: default
 spec:
+  priority: -1
   configPatches:
     - applyTo: HTTP_FILTER
       match:
@@ -2866,6 +2875,7 @@ metadata:
   labels:
     istio.io/rev: default
 spec:
+  priority: -1
   configPatches:
     - applyTo: NETWORK_FILTER
       match:

--- a/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.11.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.11.yaml
@@ -14,6 +14,7 @@ metadata:
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
 spec:
+  priority: -1
   configPatches:
     - applyTo: HTTP_FILTER
       match:
@@ -177,6 +178,7 @@ metadata:
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
 spec:
+  priority: -1
   configPatches:
     - applyTo: NETWORK_FILTER
       match:
@@ -333,6 +335,7 @@ metadata:
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
 spec:
+  priority: -1
   configPatches:
 {{- if not .Values.telemetry.v2.stackdriver.disableOutbound }}
     - applyTo: HTTP_FILTER
@@ -451,6 +454,7 @@ metadata:
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
 spec:
+  priority: -1
   configPatches:
   {{- if not .Values.telemetry.v2.stackdriver.disableOutbound }}
   - applyTo: NETWORK_FILTER
@@ -564,6 +568,7 @@ metadata:
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
 spec:
+  priority: -1
   configPatches:
     - applyTo: HTTP_FILTER
       match:

--- a/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.12.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.12.yaml
@@ -14,6 +14,7 @@ metadata:
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
 spec:
+  priority: -1
   configPatches:
     - applyTo: HTTP_FILTER
       match:
@@ -177,6 +178,7 @@ metadata:
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
 spec:
+  priority: -1
   configPatches:
     - applyTo: NETWORK_FILTER
       match:
@@ -333,6 +335,7 @@ metadata:
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
 spec:
+  priority: -1
   configPatches:
 {{- if not .Values.telemetry.v2.stackdriver.disableOutbound }}
     - applyTo: HTTP_FILTER
@@ -451,6 +454,7 @@ metadata:
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
 spec:
+  priority: -1
   configPatches:
   {{- if not .Values.telemetry.v2.stackdriver.disableOutbound }}
   - applyTo: NETWORK_FILTER
@@ -564,6 +568,7 @@ metadata:
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
 spec:
+  priority: -1
   configPatches:
     - applyTo: HTTP_FILTER
       match:

--- a/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.13.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.13.yaml
@@ -14,6 +14,7 @@ metadata:
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
 spec:
+  priority: -1
   configPatches:
     - applyTo: HTTP_FILTER
       match:
@@ -177,6 +178,7 @@ metadata:
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
 spec:
+  priority: -1
   configPatches:
     - applyTo: NETWORK_FILTER
       match:
@@ -333,6 +335,7 @@ metadata:
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
 spec:
+  priority: -1
   configPatches:
 {{- if not .Values.telemetry.v2.stackdriver.disableOutbound }}
     - applyTo: HTTP_FILTER
@@ -463,6 +466,7 @@ metadata:
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
 spec:
+  priority: -1
   configPatches:
   {{- if not .Values.telemetry.v2.stackdriver.disableOutbound }}
   - applyTo: NETWORK_FILTER
@@ -586,6 +590,7 @@ metadata:
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
 spec:
+  priority: -1
   configPatches:
     - applyTo: HTTP_FILTER
       match:

--- a/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.14.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.14.yaml
@@ -14,6 +14,7 @@ metadata:
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
 spec:
+  priority: -1
   configPatches:
     - applyTo: HTTP_FILTER
       match:
@@ -177,6 +178,7 @@ metadata:
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
 spec:
+  priority: -1
   configPatches:
     - applyTo: NETWORK_FILTER
       match:
@@ -333,6 +335,7 @@ metadata:
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
 spec:
+  priority: -1
   configPatches:
 {{- if not .Values.telemetry.v2.stackdriver.disableOutbound }}
     - applyTo: HTTP_FILTER
@@ -463,6 +466,7 @@ metadata:
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
 spec:
+  priority: -1
   configPatches:
   {{- if not .Values.telemetry.v2.stackdriver.disableOutbound }}
   - applyTo: NETWORK_FILTER
@@ -586,6 +590,7 @@ metadata:
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
 spec:
+  priority: -1
   configPatches:
     - applyTo: HTTP_FILTER
       match:

--- a/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.15.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.15.yaml
@@ -14,6 +14,7 @@ metadata:
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
 spec:
+  priority: -1
   configPatches:
     - applyTo: HTTP_FILTER
       match:
@@ -177,6 +178,7 @@ metadata:
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
 spec:
+  priority: -1
   configPatches:
     - applyTo: NETWORK_FILTER
       match:
@@ -333,6 +335,7 @@ metadata:
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
 spec:
+  priority: -1
   configPatches:
 {{- if not .Values.telemetry.v2.stackdriver.disableOutbound }}
     - applyTo: HTTP_FILTER
@@ -463,6 +466,7 @@ metadata:
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
 spec:
+  priority: -1
   configPatches:
   {{- if not .Values.telemetry.v2.stackdriver.disableOutbound }}
   - applyTo: NETWORK_FILTER
@@ -586,6 +590,7 @@ metadata:
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
 spec:
+  priority: -1
   configPatches:
     - applyTo: HTTP_FILTER
       match:

--- a/manifests/charts/istiod-remote/templates/telemetryv2_1.11.yaml
+++ b/manifests/charts/istiod-remote/templates/telemetryv2_1.11.yaml
@@ -14,6 +14,7 @@ metadata:
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
 spec:
+  priority: -1
   configPatches:
     - applyTo: HTTP_FILTER
       match:
@@ -177,6 +178,7 @@ metadata:
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
 spec:
+  priority: -1
   configPatches:
     - applyTo: NETWORK_FILTER
       match:
@@ -333,6 +335,7 @@ metadata:
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
 spec:
+  priority: -1
   configPatches:
 {{- if not .Values.telemetry.v2.stackdriver.disableOutbound }}
     - applyTo: HTTP_FILTER
@@ -451,6 +454,7 @@ metadata:
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
 spec:
+  priority: -1
   configPatches:
   {{- if not .Values.telemetry.v2.stackdriver.disableOutbound }}
   - applyTo: NETWORK_FILTER
@@ -564,6 +568,7 @@ metadata:
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
 spec:
+  priority: -1
   configPatches:
     - applyTo: HTTP_FILTER
       match:

--- a/manifests/charts/istiod-remote/templates/telemetryv2_1.12.yaml
+++ b/manifests/charts/istiod-remote/templates/telemetryv2_1.12.yaml
@@ -14,6 +14,7 @@ metadata:
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
 spec:
+  priority: -1
   configPatches:
     - applyTo: HTTP_FILTER
       match:
@@ -177,6 +178,7 @@ metadata:
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
 spec:
+  priority: -1
   configPatches:
     - applyTo: NETWORK_FILTER
       match:
@@ -333,6 +335,7 @@ metadata:
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
 spec:
+  priority: -1
   configPatches:
 {{- if not .Values.telemetry.v2.stackdriver.disableOutbound }}
     - applyTo: HTTP_FILTER
@@ -451,6 +454,7 @@ metadata:
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
 spec:
+  priority: -1
   configPatches:
   {{- if not .Values.telemetry.v2.stackdriver.disableOutbound }}
   - applyTo: NETWORK_FILTER
@@ -564,6 +568,7 @@ metadata:
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
 spec:
+  priority: -1
   configPatches:
     - applyTo: HTTP_FILTER
       match:

--- a/manifests/charts/istiod-remote/templates/telemetryv2_1.13.yaml
+++ b/manifests/charts/istiod-remote/templates/telemetryv2_1.13.yaml
@@ -14,6 +14,7 @@ metadata:
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
 spec:
+  priority: -1
   configPatches:
     - applyTo: HTTP_FILTER
       match:
@@ -177,6 +178,7 @@ metadata:
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
 spec:
+  priority: -1
   configPatches:
     - applyTo: NETWORK_FILTER
       match:
@@ -333,6 +335,7 @@ metadata:
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
 spec:
+  priority: -1
   configPatches:
 {{- if not .Values.telemetry.v2.stackdriver.disableOutbound }}
     - applyTo: HTTP_FILTER
@@ -463,6 +466,7 @@ metadata:
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
 spec:
+  priority: -1
   configPatches:
   {{- if not .Values.telemetry.v2.stackdriver.disableOutbound }}
   - applyTo: NETWORK_FILTER
@@ -586,6 +590,7 @@ metadata:
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
 spec:
+  priority: -1
   configPatches:
     - applyTo: HTTP_FILTER
       match:

--- a/manifests/charts/istiod-remote/templates/telemetryv2_1.14.yaml
+++ b/manifests/charts/istiod-remote/templates/telemetryv2_1.14.yaml
@@ -14,6 +14,7 @@ metadata:
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
 spec:
+  priority: -1
   configPatches:
     - applyTo: HTTP_FILTER
       match:
@@ -177,6 +178,7 @@ metadata:
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
 spec:
+  priority: -1
   configPatches:
     - applyTo: NETWORK_FILTER
       match:
@@ -333,6 +335,7 @@ metadata:
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
 spec:
+  priority: -1
   configPatches:
 {{- if not .Values.telemetry.v2.stackdriver.disableOutbound }}
     - applyTo: HTTP_FILTER
@@ -463,6 +466,7 @@ metadata:
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
 spec:
+  priority: -1
   configPatches:
   {{- if not .Values.telemetry.v2.stackdriver.disableOutbound }}
   - applyTo: NETWORK_FILTER
@@ -586,6 +590,7 @@ metadata:
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
 spec:
+  priority: -1
   configPatches:
     - applyTo: HTTP_FILTER
       match:

--- a/manifests/charts/istiod-remote/templates/telemetryv2_1.15.yaml
+++ b/manifests/charts/istiod-remote/templates/telemetryv2_1.15.yaml
@@ -14,6 +14,7 @@ metadata:
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
 spec:
+  priority: -1
   configPatches:
     - applyTo: HTTP_FILTER
       match:
@@ -177,6 +178,7 @@ metadata:
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
 spec:
+  priority: -1
   configPatches:
     - applyTo: NETWORK_FILTER
       match:
@@ -333,6 +335,7 @@ metadata:
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
 spec:
+  priority: -1
   configPatches:
 {{- if not .Values.telemetry.v2.stackdriver.disableOutbound }}
     - applyTo: HTTP_FILTER
@@ -463,6 +466,7 @@ metadata:
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
 spec:
+  priority: -1
   configPatches:
   {{- if not .Values.telemetry.v2.stackdriver.disableOutbound }}
   - applyTo: NETWORK_FILTER
@@ -586,6 +590,7 @@ metadata:
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
 spec:
+  priority: -1
   configPatches:
     - applyTo: HTTP_FILTER
       match:

--- a/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
@@ -6986,7 +6986,6 @@ metadata:
   labels:
     istio.io/rev: default
 spec:
-  priority: -1
   configPatches:
     - applyTo: HTTP_FILTER
       match:
@@ -7109,7 +7108,6 @@ metadata:
   labels:
     istio.io/rev: default
 spec:
-  priority: -1
   configPatches:
     - applyTo: HTTP_FILTER
       match:
@@ -7232,7 +7230,6 @@ metadata:
   labels:
     istio.io/rev: default
 spec:
-  priority: -1
   configPatches:
     - applyTo: HTTP_FILTER
       match:
@@ -7355,7 +7352,6 @@ metadata:
   labels:
     istio.io/rev: default
 spec:
-  priority: -1
   configPatches:
     - applyTo: HTTP_FILTER
       match:
@@ -7478,7 +7474,6 @@ metadata:
   labels:
     istio.io/rev: default
 spec:
-  priority: -1
   configPatches:
     - applyTo: HTTP_FILTER
       match:
@@ -7601,7 +7596,6 @@ metadata:
   labels:
     istio.io/rev: default
 spec:
-  priority: -1
   configPatches:
     - applyTo: NETWORK_FILTER
       match:
@@ -7716,7 +7710,6 @@ metadata:
   labels:
     istio.io/rev: default
 spec:
-  priority: -1
   configPatches:
     - applyTo: NETWORK_FILTER
       match:
@@ -7831,7 +7824,6 @@ metadata:
   labels:
     istio.io/rev: default
 spec:
-  priority: -1
   configPatches:
     - applyTo: NETWORK_FILTER
       match:
@@ -7946,7 +7938,6 @@ metadata:
   labels:
     istio.io/rev: default
 spec:
-  priority: -1
   configPatches:
     - applyTo: NETWORK_FILTER
       match:
@@ -8061,7 +8052,6 @@ metadata:
   labels:
     istio.io/rev: default
 spec:
-  priority: -1
   configPatches:
     - applyTo: NETWORK_FILTER
       match:

--- a/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
@@ -6986,6 +6986,7 @@ metadata:
   labels:
     istio.io/rev: default
 spec:
+  priority: -1
   configPatches:
     - applyTo: HTTP_FILTER
       match:
@@ -7108,6 +7109,7 @@ metadata:
   labels:
     istio.io/rev: default
 spec:
+  priority: -1
   configPatches:
     - applyTo: HTTP_FILTER
       match:
@@ -7230,6 +7232,7 @@ metadata:
   labels:
     istio.io/rev: default
 spec:
+  priority: -1
   configPatches:
     - applyTo: HTTP_FILTER
       match:
@@ -7352,6 +7355,7 @@ metadata:
   labels:
     istio.io/rev: default
 spec:
+  priority: -1
   configPatches:
     - applyTo: HTTP_FILTER
       match:
@@ -7474,6 +7478,7 @@ metadata:
   labels:
     istio.io/rev: default
 spec:
+  priority: -1
   configPatches:
     - applyTo: HTTP_FILTER
       match:
@@ -7596,6 +7601,7 @@ metadata:
   labels:
     istio.io/rev: default
 spec:
+  priority: -1
   configPatches:
     - applyTo: NETWORK_FILTER
       match:
@@ -7710,6 +7716,7 @@ metadata:
   labels:
     istio.io/rev: default
 spec:
+  priority: -1
   configPatches:
     - applyTo: NETWORK_FILTER
       match:
@@ -7824,6 +7831,7 @@ metadata:
   labels:
     istio.io/rev: default
 spec:
+  priority: -1
   configPatches:
     - applyTo: NETWORK_FILTER
       match:
@@ -7938,6 +7946,7 @@ metadata:
   labels:
     istio.io/rev: default
 spec:
+  priority: -1
   configPatches:
     - applyTo: NETWORK_FILTER
       match:
@@ -8052,6 +8061,7 @@ metadata:
   labels:
     istio.io/rev: default
 spec:
+  priority: -1
   configPatches:
     - applyTo: NETWORK_FILTER
       match:

--- a/releasenotes/notes/38676.yaml
+++ b/releasenotes/notes/38676.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+issue:
+  - 38676
+releaseNotes:
+  - |
+    **Fixed** change to add priority of -1 to envoyFilters deployed by default by istio to remove warnings from istioctl envoyFilter analyzer on first install


### PR DESCRIPTION
**Please provide a description of this PR:**
fixes #38676 

Sets the priority to -1 for envoy filters that are created by default by the initial install of istio

By setting the priority to -1 then won't trigger warning messages from the istioctl envoy filter analyzer.  

EnvoyFilters should be applied in  order of priority, creation time, fully qualified resource name. By setting the priority to -1 it should ensure the envoyFilters created by the initial install get applied first.  This should make sure no change in behavior because of the creation time should have also been first.