### PR TITLE
Backport gRPC fixes to 1.14 branch

### DIFF
--- a/pilot/pkg/xds/xdsgen.go
+++ b/pilot/pkg/xds/xdsgen.go
@@ -105,7 +105,8 @@ func (s *DiscoveryServer) pushXds(con *Connection, w *model.WatchedResource, req
 	// See https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol#deleting-resources.
 	// This means if there are only removals, we will not respond.
 	var logFiltered string
-	if !req.Delta.IsEmpty() && features.PartialFullPushes {
+	if !req.Delta.IsEmpty() && features.PartialFullPushes &&
+		!con.proxy.IsProxylessGrpc() {
 		logFiltered = " filtered:" + strconv.Itoa(len(w.ResourceNames)-len(req.Delta.Subscribed))
 		w = &model.WatchedResource{
 			TypeUrl:       w.TypeUrl,

--- a/pkg/istio-agent/agent.go
+++ b/pkg/istio-agent/agent.go
@@ -28,6 +28,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	bootstrapv3 "github.com/envoyproxy/go-control-plane/envoy/config/bootstrap/v3"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"github.com/golang/protobuf/proto"
@@ -505,11 +506,59 @@ func (a *Agent) initSdsServer() error {
 		}
 	}
 
-	pkpConf := a.proxyConfig.GetPrivateKeyProvider()
-	a.sdsServer = sds.NewServer(a.secOpts, a.secretCache, pkpConf)
-	a.secretCache.RegisterSecretHandler(a.sdsServer.OnSecretUpdate)
+	if err != nil {
+		return fmt.Errorf("failed to start workload secret manager %v", err)
+	}
+	if a.cfg.DisableEnvoy {
+		// For proxyless we don't need an SDS server, but still need the keys and
+		// we need them refreshed periodically.
+		//
+		// This is based on the code from newSDSService, but customized to have explicit rotation.
+		go func() {
+			st := a.secretCache
+			st.RegisterSecretHandler(func(resourceName string) {
+				// The secret handler is called when a secret should be renewed, after invalidating the cache.
+				// The handler does not call GenerateSecret - it is a side-effect of the SDS generate() method, which
+				// is called by sdsServer.OnSecretUpdate, which triggers a push and eventually calls sdsservice.Generate
+				// TODO: extract the logic to detect expiration time, and use a simpler code to rotate to files.
+				_, _ = a.getWorkloadCerts(st)
+			})
+			_, _ = a.getWorkloadCerts(st)
+		}()
+	} else {
+		pkpConf := a.proxyConfig.GetPrivateKeyProvider()
+		a.sdsServer = sds.NewServer(a.secOpts, a.secretCache, pkpConf)
+		a.secretCache.RegisterSecretHandler(a.sdsServer.OnSecretUpdate)
+	}
 
 	return nil
+}
+
+// getWorkloadCerts will attempt to get a cert, with infinite exponential backoff
+// It will not return until both workload cert and root cert are generated.
+//
+// TODO: evaluate replacing the STS server with a file data source, to simplify Envoy config
+func (a *Agent) getWorkloadCerts(st *cache.SecretManagerClient) (sk *security.SecretItem, err error) {
+	b := backoff.NewExponentialBackOff()
+	b.MaxElapsedTime = 0
+
+	for {
+		sk, err = st.GenerateSecret(security.WorkloadKeyCertResourceName)
+		if err == nil {
+			break
+		}
+		log.Warnf("failed to get certificate: %v", err)
+		time.Sleep(b.NextBackOff())
+	}
+	for {
+		_, err := st.GenerateSecret(security.RootCertReqResourceName)
+		if err == nil {
+			break
+		}
+		log.Warnf("failed to get root certificate: %v", err)
+		time.Sleep(b.NextBackOff())
+	}
+	return
 }
 
 func (a *Agent) caFileWatcherHandler(ctx context.Context, caFile string) {


### PR DESCRIPTION
Change-Id: I8c9d3a77bb59f19fe223b291781b8d5e102f4bd0

**Please provide a description of this PR:**

Fix few critical gRPC bugs:

- no certificate rotation
- attempt to send delta which is not supported by gRPC, resulting in lost listener.

Less critical:

- keep scraping envoy which doesn't exist.

Merged manually since cherry-pick didn't work.