### PR TITLE
Allow all the insecure servers when WASM_INSECURE_REGISTRIES has a "*"

### DIFF
--- a/releasenotes/notes/wasm-insecure-all.yaml
+++ b/releasenotes/notes/wasm-insecure-all.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: feature
+area: extensibility
+issue: []
+releaseNotes:
+  - |
+    **Added** allow all insecure servers when one of the host name in the environment variable WASM_INSECURE_REGISTRIES is *.


### PR DESCRIPTION
This PR proposes to add a feature to allow all insecure servers when one of the host name in the environment variable WASM_INSECURE_REGISTRIES is *.

Originally proposed as a part of https://github.com/istio/istio/pull/38918, but split as a feature PR.

cc: @zirain 