### PR TITLE
fix log line in aggregate controller

### DIFF
--- a/pilot/pkg/serviceregistry/aggregate/controller.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller.go
@@ -129,7 +129,7 @@ func (c *Controller) DeleteRegistry(clusterID cluster.ID, providerID provider.ID
 	}
 	index, ok := c.getRegistryIndex(clusterID, providerID)
 	if !ok {
-		log.Warnf("Registry %s/%s is not found in the registries list, nothing to delete", providerID, clusterID)
+		log.Warnf("Registry %s/%s is not found in the registries list, nothing to delete", string(providerID), clusterID)
 		return
 	}
 	c.registries[index] = nil

--- a/pilot/pkg/serviceregistry/aggregate/controller.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller.go
@@ -134,7 +134,7 @@ func (c *Controller) DeleteRegistry(clusterID cluster.ID, providerID provider.ID
 	}
 	c.registries[index] = nil
 	c.registries = append(c.registries[:index], c.registries[index+1:]...)
-	log.Infof("%s registry for the cluster %s has been deleted.", providerID, clusterID)
+	log.Infof("%s registry for the cluster %s has been deleted.", string(providerID), clusterID)
 }
 
 // GetRegistries returns a copy of all registries


### PR DESCRIPTION
Without this log does not include providerID
2022-05-19T00:59:28.748040Z	info	Registry for the cluster processing-cluster has been deleted.


- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure