### PR TITLE
telemetry tests: use standard deployment for echo

### DIFF
--- a/tests/integration/telemetry/stats/prometheus/customizemetrics/customize_metrics_test.go
+++ b/tests/integration/telemetry/stats/prometheus/customizemetrics/customize_metrics_test.go
@@ -85,14 +85,16 @@ func TestCustomizeMetrics(t *testing.T) {
 				}
 				var err error
 				if !httpChecked {
-					httpMetricVal, err = common.QueryPrometheus(t, t.Clusters().Default(), httpDestinationQuery, promInst)
+					httpMetricVal, err = common.QueryPrometheus(t, cluster, httpDestinationQuery, promInst)
 					if err != nil {
+						util.PromDiff(t, promInst, cluster, httpDestinationQuery)
 						return err
 					}
 					httpChecked = true
 				}
-				_, err = common.QueryPrometheus(t, t.Clusters().Default(), grpcDestinationQuery, promInst)
+				_, err = common.QueryPrometheus(t, cluster, grpcDestinationQuery, promInst)
 				if err != nil {
+					util.PromDiff(t, promInst, cluster, grpcDestinationQuery)
 					return err
 				}
 				return nil

--- a/tests/integration/telemetry/stats/prometheus/nullvm/dashboard_test.go
+++ b/tests/integration/telemetry/stats/prometheus/nullvm/dashboard_test.go
@@ -291,7 +291,7 @@ spec:
     - destination:
         host: server
         port:
-          number: 9000
+          number: 9090
 `
 
 func setupDashboardTest(done <-chan struct{}) {

--- a/tests/integration/telemetry/stats/prometheus/nullvm/dashboard_test.go
+++ b/tests/integration/telemetry/stats/prometheus/nullvm/dashboard_test.go
@@ -281,7 +281,7 @@ spec:
         exact: /echo-%s
     route:
     - destination:
-        host: server
+        host: b
         port:
           number: 80
   tcp:
@@ -289,7 +289,7 @@ spec:
     - port: 31400
     route:
     - destination:
-        host: server
+        host: b
         port:
           number: 9090
 `

--- a/tests/integration/telemetry/stats/prometheus/nullvm/istioctl_metrics_test.go
+++ b/tests/integration/telemetry/stats/prometheus/nullvm/istioctl_metrics_test.go
@@ -40,7 +40,7 @@ func TestIstioctlMetrics(t *testing.T) {
 				if err := common.SendTraffic(common.GetClientInstances()[0]); err != nil {
 					return err
 				}
-				return validateDefaultOutput(t, "server")
+				return validateDefaultOutput(t, common.GetTarget().Config().Service)
 			}, retry.Delay(framework.TelemetryRetryDelay), retry.Timeout(framework.TelemetryRetryTimeout))
 		})
 }

--- a/tests/integration/telemetry/stats/prometheus/stats.go
+++ b/tests/integration/telemetry/stats/prometheus/stats.go
@@ -19,17 +19,17 @@ package prometheus
 
 import (
 	"context"
-	"strconv"
 	"testing"
 
 	"golang.org/x/sync/errgroup"
 
-	"istio.io/istio/pkg/config/protocol"
+	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/echo/common"
 	"istio.io/istio/pkg/test/echo/common/scheme"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/echo/check"
+	cdeployment "istio.io/istio/pkg/test/framework/components/echo/common/deployment"
 	"istio.io/istio/pkg/test/framework/components/echo/deployment"
 	"istio.io/istio/pkg/test/framework/components/echo/match"
 	"istio.io/istio/pkg/test/framework/components/istio"
@@ -43,13 +43,13 @@ import (
 )
 
 var (
-	client, server    echo.Instances
-	nonInjectedServer echo.Instances
-	mockProm          echo.Instances
-	ist               istio.Instance
-	appNsInst         namespace.Instance
-	promInst          prometheus.Instance
-	ingr              []ingress.Instance
+	apps cdeployment.SingleNamespaceView
+
+	mockProm  echo.Instances
+	ist       istio.Instance
+	appNsInst namespace.Instance
+	promInst  prometheus.Instance
+	ingr      []ingress.Instance
 )
 
 var PeerAuthenticationConfig = `
@@ -69,7 +69,7 @@ func GetIstioInstance() *istio.Instance {
 
 // GetAppNamespace gets bookinfo instance.
 func GetAppNamespace() namespace.Instance {
-	return appNsInst
+	return apps.Namespace
 }
 
 // GetPromInstance gets prometheus instance.
@@ -83,11 +83,11 @@ func GetIngressInstance() []ingress.Instance {
 }
 
 func GetClientInstances() echo.Instances {
-	return client
+	return apps.A
 }
 
 func GetTarget() echo.Target {
-	return server
+	return apps.B
 }
 
 // TestStatsFilter includes common test logic for stats and metadataexchange filters running
@@ -99,7 +99,7 @@ func TestStatsFilter(t *testing.T, feature features.Feature) {
 			// Enable strict mTLS. This is needed for mock secured prometheus scraping test.
 			t.ConfigIstio().YAML(ist.Settings().SystemNamespace, PeerAuthenticationConfig).ApplyOrFail(t)
 			g, _ := errgroup.WithContext(context.Background())
-			for _, cltInstance := range client {
+			for _, cltInstance := range GetClientInstances() {
 				cltInstance := cltInstance
 				g.Go(func() error {
 					err := retry.UntilSuccess(func() error {
@@ -149,7 +149,7 @@ func TestStatsFilter(t *testing.T, feature features.Feature) {
 
 			// In addition, verifies that mocked prometheus could call metrics endpoint with proxy provisioned certs
 			for _, prom := range mockProm {
-				st := match.Cluster(prom.Config().Cluster).FirstOrFail(t, server)
+				st := match.Cluster(prom.Config().Cluster).FirstOrFail(t, GetTarget().Instances())
 				prom.CallOrFail(t, echo.CallOptions{
 					ToWorkload: st,
 					Scheme:     scheme.HTTPS,
@@ -175,7 +175,7 @@ func TestStatsTCPFilter(t *testing.T, feature features.Feature) {
 		Features(feature).
 		Run(func(t framework.TestContext) {
 			g, _ := errgroup.WithContext(context.Background())
-			for _, cltInstance := range client {
+			for _, cltInstance := range GetClientInstances() {
 				cltInstance := cltInstance
 				g.Go(func() error {
 					err := retry.UntilSuccess(func() error {
@@ -209,12 +209,8 @@ func TestStatsTCPFilter(t *testing.T, feature features.Feature) {
 
 // TestSetup set up echo app for stats testing.
 func TestSetup(ctx resource.Context) (err error) {
-	appNsInst, err = namespace.New(ctx, namespace.Config{
-		Prefix: "echo",
-		Inject: true,
-	})
-	if err != nil {
-		return
+	if err := cdeployment.SetupSingleNamespace(&apps, cdeployment.Config{})(ctx); err != nil {
+		return err
 	}
 
 	outputCertAnnot := `
@@ -223,58 +219,6 @@ proxyMetadata:
 
 	echos, err := deployment.New(ctx).
 		WithClusters(ctx.Clusters()...).
-		With(nil, echo.Config{
-			Service:   "client",
-			Namespace: appNsInst,
-			Ports:     nil,
-			Subsets:   []echo.SubsetConfig{{}},
-		}).
-		With(nil, echo.Config{
-			Service:   "server",
-			Namespace: appNsInst,
-			Subsets:   []echo.SubsetConfig{{}},
-			Ports: []echo.Port{
-				{
-					Name:         "http",
-					Protocol:     protocol.HTTP,
-					WorkloadPort: 8090,
-				},
-				{
-					Name:     "tcp",
-					Protocol: protocol.TCP,
-					// We use a port > 1024 to not require root
-					WorkloadPort: 9000,
-					ServicePort:  9000,
-				},
-			},
-		}).
-		With(nil, echo.Config{
-			Service:   "server-no-sidecar",
-			Namespace: appNsInst,
-			Subsets: []echo.SubsetConfig{
-				{
-					Annotations: map[echo.Annotation]*echo.AnnotationValue{
-						echo.SidecarInject: {
-							Value: strconv.FormatBool(false),
-						},
-					},
-				},
-			},
-			Ports: []echo.Port{
-				{
-					Name:         "http",
-					Protocol:     protocol.HTTP,
-					WorkloadPort: 8090,
-				},
-				{
-					Name:     "tcp",
-					Protocol: protocol.TCP,
-					// We use a port > 1024 to not require root
-					WorkloadPort: 9000,
-					ServicePort:  9000,
-				},
-			},
-		}).
 		With(nil, echo.Config{
 			// mock prom instance is used to mock a prometheus server, which will visit other echo instance /metrics
 			// endpoint with proxy provisioned certs.
@@ -309,9 +253,6 @@ proxyMetadata:
 	for _, c := range ctx.Clusters() {
 		ingr = append(ingr, ist.IngressFor(c))
 	}
-	client = match.ServiceName(echo.NamespacedName{Name: "client", Namespace: appNsInst}).GetMatches(echos)
-	server = match.ServiceName(echo.NamespacedName{Name: "server", Namespace: appNsInst}).GetMatches(echos)
-	nonInjectedServer = match.ServiceName(echo.NamespacedName{Name: "server-no-sidecar", Namespace: appNsInst}).GetMatches(echos)
 	mockProm = match.ServiceName(echo.NamespacedName{Name: "mock-prom", Namespace: appNsInst}).GetMatches(echos)
 	promInst, err = prometheus.New(ctx, prometheus.Config{})
 	if err != nil {
@@ -321,13 +262,13 @@ proxyMetadata:
 }
 
 // SendTraffic makes a client call to the "server" service on the http port.
-func SendTraffic(cltInstance echo.Instance) error {
-	_, err := cltInstance.Call(echo.CallOptions{
-		To: server,
+func SendTraffic(from echo.Instance) error {
+	_, err := from.Call(echo.CallOptions{
+		To: GetTarget(),
 		Port: echo.Port{
 			Name: "http",
 		},
-		Count: util.RequestCountMultipler * server.MustWorkloads().Len(),
+		Count: util.RequestCountMultipler * GetTarget().MustWorkloads().Len(),
 		Check: check.OK(),
 		Retry: echo.Retry{
 			NoRetry: true,
@@ -336,12 +277,12 @@ func SendTraffic(cltInstance echo.Instance) error {
 	if err != nil {
 		return err
 	}
-	_, err = cltInstance.Call(echo.CallOptions{
-		To: nonInjectedServer,
+	_, err = from.Call(echo.CallOptions{
+		To: apps.Naked,
 		Port: echo.Port{
 			Name: "http",
 		},
-		Count: util.RequestCountMultipler * nonInjectedServer.MustWorkloads().Len(),
+		Count: util.RequestCountMultipler * apps.Naked.MustWorkloads().Len(),
 		Retry: echo.Retry{
 			NoRetry: true,
 		},
@@ -352,14 +293,35 @@ func SendTraffic(cltInstance echo.Instance) error {
 	return nil
 }
 
+func SendTrafficOrFail(t test.Failer, from echo.Instance) {
+	from.CallOrFail(t, echo.CallOptions{
+		To: GetTarget(),
+		Port: echo.Port{
+			Name: "http",
+		},
+		Count: util.RequestCountMultipler * GetTarget().MustWorkloads().Len(),
+		Check: check.OK(),
+	})
+	from.CallOrFail(t, echo.CallOptions{
+		To: apps.Naked,
+		Port: echo.Port{
+			Name: "http",
+		},
+		Count: util.RequestCountMultipler * apps.Naked.MustWorkloads().Len(),
+		Retry: echo.Retry{
+			NoRetry: true,
+		},
+	})
+}
+
 // SendTCPTraffic makes a client call to the "server" service on the tcp port.
-func SendTCPTraffic(cltInstance echo.Instance) error {
-	_, err := cltInstance.Call(echo.CallOptions{
-		To: server,
+func SendTCPTraffic(from echo.Instance) error {
+	_, err := from.Call(echo.CallOptions{
+		To: GetTarget(),
 		Port: echo.Port{
 			Name: "tcp",
 		},
-		Count: util.RequestCountMultipler * server.MustWorkloads().Len(),
+		Count: util.RequestCountMultipler * GetTarget().MustWorkloads().Len(),
 		Retry: echo.Retry{
 			NoRetry: true,
 		},
@@ -399,15 +361,15 @@ func buildQuery(sourceCluster string) (sourceQuery, destinationQuery, appQuery p
 	labels := map[string]string{
 		"request_protocol":               "http",
 		"response_code":                  "200",
-		"destination_app":                "server",
+		"destination_app":                "b",
 		"destination_version":            "v1",
-		"destination_service":            "server." + ns.Name() + ".svc.cluster.local",
-		"destination_service_name":       "server",
+		"destination_service":            "b." + ns.Name() + ".svc.cluster.local",
+		"destination_service_name":       "b",
 		"destination_workload_namespace": ns.Name(),
 		"destination_service_namespace":  ns.Name(),
-		"source_app":                     "client",
+		"source_app":                     "a",
 		"source_version":                 "v1",
-		"source_workload":                "client-v1",
+		"source_workload":                "a-v1",
 		"source_workload_namespace":      ns.Name(),
 		"source_cluster":                 sourceCluster,
 	}
@@ -426,13 +388,13 @@ func buildOutOfMeshServerQuery(sourceCluster string) prometheus.Query {
 		// Thus destination_app and destination_version labels are unknown.
 		"destination_app":                "unknown",
 		"destination_version":            "unknown",
-		"destination_service":            "server-no-sidecar." + ns.Name() + ".svc.cluster.local",
-		"destination_service_name":       "server-no-sidecar",
+		"destination_service":            "naked." + ns.Name() + ".svc.cluster.local",
+		"destination_service_name":       "naked",
 		"destination_workload_namespace": ns.Name(),
 		"destination_service_namespace":  ns.Name(),
-		"source_app":                     "client",
+		"source_app":                     "a",
 		"source_version":                 "v1",
-		"source_workload":                "client-v1",
+		"source_workload":                "a-v1",
 		"source_workload_namespace":      ns.Name(),
 		"source_cluster":                 sourceCluster,
 	}
@@ -445,16 +407,16 @@ func buildTCPQuery(sourceCluster string) (destinationQuery prometheus.Query) {
 	ns := GetAppNamespace()
 	labels := map[string]string{
 		"request_protocol":               "tcp",
-		"destination_service_name":       "server",
+		"destination_service_name":       "b",
 		"destination_canonical_revision": "v1",
-		"destination_canonical_service":  "server",
-		"destination_app":                "server",
+		"destination_canonical_service":  "b",
+		"destination_app":                "b",
 		"destination_version":            "v1",
 		"destination_workload_namespace": ns.Name(),
 		"destination_service_namespace":  ns.Name(),
-		"source_app":                     "client",
+		"source_app":                     "a",
 		"source_version":                 "v1",
-		"source_workload":                "client-v1",
+		"source_workload":                "a-v1",
 		"source_workload_namespace":      ns.Name(),
 		"source_cluster":                 sourceCluster,
 		"reporter":                       "destination",

--- a/tests/integration/telemetry/stats/prometheus/wasm/stats_wasm_filter_test.go
+++ b/tests/integration/telemetry/stats/prometheus/wasm/stats_wasm_filter_test.go
@@ -42,6 +42,7 @@ func TestMain(m *testing.M) {
 		Label(label.IPv4). // https://github.com/istio/istio/issues/35915
 		Setup(istio.Setup(common.GetIstioInstance(), setupConfig)).
 		Setup(common.TestSetup).
+		Setup(registrySetup).
 		Run()
 }
 

--- a/tests/integration/telemetry/stats/prometheus/wasm/stats_wasm_filter_test.go
+++ b/tests/integration/telemetry/stats/prometheus/wasm/stats_wasm_filter_test.go
@@ -22,7 +22,6 @@ import (
 
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/istio"
-	"istio.io/istio/pkg/test/framework/features"
 	"istio.io/istio/pkg/test/framework/label"
 	"istio.io/istio/pkg/test/framework/resource"
 	common "istio.io/istio/tests/integration/telemetry/stats/prometheus"
@@ -34,7 +33,7 @@ import (
 // proxy bootstrap config with Wasm runtime. To avoid flake, it does not verify correctness
 // of metrics, which should be covered by integration test in proxy repo.
 func TestWasmStatsFilter(t *testing.T) {
-	common.TestStatsFilter(t, features.Feature("observability.telemetry.stats.prometheus.http.wasm"))
+	common.TestStatsFilter(t, "observability.telemetry.stats.prometheus.http.wasm")
 }
 
 func TestMain(m *testing.M) {

--- a/tests/integration/telemetry/stats/prometheus/wasm/stats_wasm_filter_test.go
+++ b/tests/integration/telemetry/stats/prometheus/wasm/stats_wasm_filter_test.go
@@ -42,7 +42,6 @@ func TestMain(m *testing.M) {
 		Label(label.IPv4). // https://github.com/istio/istio/issues/35915
 		Setup(istio.Setup(common.GetIstioInstance(), setupConfig)).
 		Setup(common.TestSetup).
-		Setup(registrySetup).
 		Run()
 }
 

--- a/tests/integration/telemetry/util.go
+++ b/tests/integration/telemetry/util.go
@@ -19,6 +19,7 @@ package telemetry
 
 import (
 	"context"
+	"sort"
 
 	"github.com/prometheus/common/model"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -62,6 +63,9 @@ func PromDiff(t test.Failer, prom prometheus.Instance, cluster cluster.Cluster, 
 			t.Logf("no diff found")
 			return
 		}
+		sort.Slice(allMismatches, func(i, j int) bool {
+			return len(allMismatches[i]) < len(allMismatches[j])
+		})
 		t.Logf("query %q returned %v series, but none matched our query exactly.", query.Metric, len(value))
 		t.Logf("Original query: %v", query.String())
 		for i, m := range allMismatches {


### PR DESCRIPTION
This brings consistency with the security and pilot tests of using the
same core deployment everywhere. In particular, I was motivated by
https://github.com/istio/istio/pull/38495/files#diff-b3848f393e9a44a4e5f8cdb34f9f5715eab5fa22f975870ddce60ee29cddab86R224
which is doing external traffic -- the common deployment has a
standardized (and, IMO, safer) way of doing this that can easily be
utilized with this change.

**Please provide a description of this PR:**