### PR TITLE
WasmPlugin: Change the file path scheme of the cached wasm modules

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -557,7 +557,8 @@ func routesEqual(a, b []*route.Route) bool {
 // builds a HTTP connection manager for servers of type HTTP or HTTPS (mode: simple/mutual)
 func (configgen *ConfigGeneratorImpl) createGatewayHTTPFilterChainOpts(node *model.Proxy, port *networking.Port, server *networking.Server,
 	routeName string, proxyConfig *meshconfig.ProxyConfig, transportProtocol istionetworking.TransportProtocol,
-	push *model.PushContext) *filterChainOpts {
+	push *model.PushContext,
+) *filterChainOpts {
 	serverProto := protocol.Parse(port.Protocol)
 
 	if serverProto.IsHTTP() {
@@ -600,7 +601,8 @@ func (configgen *ConfigGeneratorImpl) createGatewayHTTPFilterChainOpts(node *mod
 }
 
 func buildGatewayConnectionManager(proxyConfig *meshconfig.ProxyConfig, node *model.Proxy, http3SupportEnabled bool,
-	push *model.PushContext) *hcm.HttpConnectionManager {
+	push *model.PushContext,
+) *hcm.HttpConnectionManager {
 	httpProtoOpts := &core.Http1ProtocolOptions{}
 	if features.HTTP10 || enableHTTP10(node.Metadata.HTTP10) {
 		httpProtoOpts.AcceptHttp_10 = true

--- a/pkg/wasm/cache.go
+++ b/pkg/wasm/cache.go
@@ -179,7 +179,7 @@ func getModulePath(baseDir string, mkey moduleKey) (string, error) {
 	hashedName := hex.EncodeToString(sha[:])
 	moduleDir := filepath.Join(baseDir, hashedName)
 	if _, err := os.Stat(moduleDir); errors.Is(err, os.ErrNotExist) {
-		err := os.Mkdir(moduleDir, 0755)
+		err := os.Mkdir(moduleDir, 0o755)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/wasm/cache_test.go
+++ b/pkg/wasm/cache_test.go
@@ -920,7 +920,7 @@ func generateModulePath(t *testing.T, baseDir, resourceName, filename string) st
 	sha := sha256.Sum256([]byte(resourceName))
 	moduleDir := filepath.Join(baseDir, hex.EncodeToString(sha[:]))
 	if _, err := os.Stat(moduleDir); errors.Is(err, os.ErrNotExist) {
-		err := os.Mkdir(moduleDir, 0755)
+		err := os.Mkdir(moduleDir, 0o755)
 		if err != nil {
 			t.Fatalf("failed to create module dir %s: %v", moduleDir, err)
 		}

--- a/pkg/wasm/cache_test.go
+++ b/pkg/wasm/cache_test.go
@@ -18,6 +18,7 @@ import (
 	"crypto/sha256"
 	"crypto/tls"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -659,7 +660,7 @@ func TestWasmCache(t *testing.T) {
 			initTime := time.Now()
 			cache.mux.Lock()
 			for k, m := range c.initialCachedModules {
-				filePath := filepath.Join(tmpDir, m.modulePath)
+				filePath := generateModulePath(t, tmpDir, k.name, m.modulePath)
 				err := os.WriteFile(filePath, []byte("data/\n"), 0o644)
 				if err != nil {
 					t.Fatalf("failed to write initial wasm module file %v", err)
@@ -684,7 +685,7 @@ func TestWasmCache(t *testing.T) {
 
 			// put the tmp dir into the module path.
 			for k, m := range c.wantCachedModules {
-				c.wantCachedModules[k].modulePath = filepath.Join(tmpDir, m.modulePath)
+				c.wantCachedModules[k].modulePath = generateModulePath(t, tmpDir, k.name, m.modulePath)
 			}
 			cache.mux.Unlock()
 
@@ -695,8 +696,19 @@ func TestWasmCache(t *testing.T) {
 			if c.checkPurgeTimeout > 0 {
 				moduleDeleted := false
 				for start := time.Now(); time.Since(start) < c.checkPurgeTimeout; {
+					fileCount := 0
+					err = filepath.Walk(tmpDir,
+						func(path string, info os.FileInfo, err error) error {
+							if err != nil {
+								return err
+							}
+							if !info.IsDir() {
+								fileCount++
+							}
+							return nil
+						})
 					// Check existence of module files. files should be deleted before timing out.
-					if files, err := os.ReadDir(tmpDir); err == nil && len(files) == 0 {
+					if err == nil && fileCount == 0 {
 						moduleDeleted = true
 						break
 					}
@@ -729,7 +741,7 @@ func TestWasmCache(t *testing.T) {
 
 			cache.mux.Unlock()
 
-			wantFilePath := filepath.Join(tmpDir, c.wantFileName)
+			wantFilePath := generateModulePath(t, tmpDir, urlAsResourceName(c.fetchURL), c.wantFileName)
 			if c.wantErrorMsgPrefix != "" {
 				if gotErr == nil {
 					t.Errorf("Wasm module cache lookup got no error, want error prefix `%v`", c.wantErrorMsgPrefix)
@@ -836,8 +848,8 @@ func TestWasmCacheMissChecksum(t *testing.T) {
 		gotNumRequest++
 	}))
 	defer ts.Close()
-	wantFilePath1 := filepath.Join(tmpDir, fmt.Sprintf("%x.wasm", sha256.Sum256(binary1)))
-	wantFilePath2 := filepath.Join(tmpDir, fmt.Sprintf("%x.wasm", sha256.Sum256(binary2)))
+	wantFilePath1 := generateModulePath(t, tmpDir, ts.URL, fmt.Sprintf("%x.wasm", sha256.Sum256(binary1)))
+	wantFilePath2 := generateModulePath(t, tmpDir, ts.URL, fmt.Sprintf("%x.wasm", sha256.Sum256(binary2)))
 	var defaultPullPolicy extensions.PullPolicy
 
 	// Get wasm module three times, since checksum is not specified, it will be fetched from module server every time.
@@ -897,8 +909,21 @@ func TestAllInsecureServer(t *testing.T) {
 		t.Fatalf("failed to download Wasm module: %v", err)
 	}
 
-	wantFilePath := filepath.Join(tmpDir, fmt.Sprintf("%s.wasm", dockerImageDigest))
+	wantFilePath := generateModulePath(t, tmpDir, urlAsResourceName(ociURLWithTag), fmt.Sprintf("%s.wasm", dockerImageDigest))
 	if gotFilePath != wantFilePath {
 		t.Errorf("Wasm module local file path got %v, want %v", gotFilePath, wantFilePath)
 	}
+}
+
+func generateModulePath(t *testing.T, baseDir, resourceName, filename string) string {
+	t.Helper()
+	sha := sha256.Sum256([]byte(resourceName))
+	moduleDir := filepath.Join(baseDir, hex.EncodeToString(sha[:]))
+	if _, err := os.Stat(moduleDir); errors.Is(err, os.ErrNotExist) {
+		err := os.Mkdir(moduleDir, 0755)
+		if err != nil {
+			t.Fatalf("failed to create module dir %s: %v", moduleDir, err)
+		}
+	}
+	return filepath.Join(moduleDir, filename)
 }


### PR DESCRIPTION
This PR proposes to change the file path scheme of the cached wasm module.

Currently, the filename of the wasm module is determined by its checksum.
But, the cache itself uses checksum & canonicalized URL as a key of the cached module, there might be inconsistency.

For example, if the same image is downloaded from the different URL, the wasm file can be purged while one of the cache entry is still pointing the wasm file.

This solves the first issue in https://github.com/istio/istio/issues/39063:
https://prow.istio.io/view/gs/istio-prow/logs/unit-tests_istio_postsubmit/1527648505185701888