### PR TITLE
Refactor: renaming localCluster to configCluster

### DIFF
--- a/pilot/pkg/model/virtualservice.go
+++ b/pilot/pkg/model/virtualservice.go
@@ -17,7 +17,7 @@ package model
 import (
 	"strings"
 
-	"github.com/gogo/protobuf/jsonpb"
+	"github.com/golang/protobuf/jsonpb"
 	"google.golang.org/protobuf/proto"
 
 	networking "istio.io/api/networking/v1alpha3"

--- a/pilot/pkg/model/virtualservice.go
+++ b/pilot/pkg/model/virtualservice.go
@@ -17,7 +17,7 @@ package model
 import (
 	"strings"
 
-	"github.com/golang/protobuf/jsonpb"
+	"github.com/gogo/protobuf/jsonpb"
 	"google.golang.org/protobuf/proto"
 
 	networking "istio.io/api/networking/v1alpha3"

--- a/pkg/kube/multicluster/secretcontroller.go
+++ b/pkg/kube/multicluster/secretcontroller.go
@@ -78,11 +78,11 @@ type ClusterHandler interface {
 
 // Controller is the controller implementation for Secret resources
 type Controller struct {
-	namespace          string
-	localClusterID     cluster.ID
-	localClusterClient kube.Client
-	queue              controllers.Queue
-	informer           cache.SharedIndexInformer
+	namespace            string
+	primaryClusterID     cluster.ID
+	primaryClusterClient kube.Client
+	queue                controllers.Queue
+	informer             cache.SharedIndexInformer
 
 	cs *ClusterStore
 
@@ -90,7 +90,7 @@ type Controller struct {
 }
 
 // NewController returns a new secret controller
-func NewController(kubeclientset kube.Client, namespace string, localClusterID cluster.ID) *Controller {
+func NewController(kubeclientset kube.Client, namespace string, clusterID cluster.ID) *Controller {
 	secretsInformer := cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
@@ -110,11 +110,11 @@ func NewController(kubeclientset kube.Client, namespace string, localClusterID c
 	remoteClusters.Record(0.0)
 
 	controller := &Controller{
-		namespace:          namespace,
-		localClusterID:     localClusterID,
-		localClusterClient: kubeclientset,
-		cs:                 newClustersStore(),
-		informer:           secretsInformer,
+		namespace:            namespace,
+		primaryClusterID:     clusterID,
+		primaryClusterClient: kubeclientset,
+		cs:                   newClustersStore(),
+		informer:             secretsInformer,
 	}
 	controller.queue = controllers.NewQueue("multicluster secret", controllers.WithReconciler(controller.processItem))
 
@@ -128,11 +128,11 @@ func (c *Controller) AddHandler(h ClusterHandler) {
 
 // Run starts the controller until it receives a message over stopCh
 func (c *Controller) Run(stopCh <-chan struct{}) error {
-	// run handlers for the local cluster; do not store this *Cluster in the ClusterStore or give it a SyncTimeout
+	// run handlers for the primary cluster; do not store this *Cluster in the ClusterStore or give it a SyncTimeout
 	// this is done outside the goroutine, we should block other Run/startFuncs until this is registered
-	localCluster := &Cluster{Client: c.localClusterClient, ID: c.localClusterID}
-	if err := c.handleAdd(localCluster, stopCh); err != nil {
-		return fmt.Errorf("failed initializing local cluster %s: %v", c.localClusterID, err)
+	primaryCluster := &Cluster{Client: c.primaryClusterClient, ID: c.primaryClusterID}
+	if err := c.handleAdd(primaryCluster, stopCh); err != nil {
+		return fmt.Errorf("failed initializing primary cluster %s: %v", c.primaryClusterID, err)
 	}
 	go func() {
 		t0 := time.Now()
@@ -320,8 +320,8 @@ func (c *Controller) addSecret(name types.NamespacedName, s *corev1.Secret) {
 	}
 
 	for clusterID, kubeConfig := range s.Data {
-		if cluster.ID(clusterID) == c.localClusterID {
-			log.Infof("ignoring cluster %v from secret %v as it would overwrite the local cluster", clusterID, secretKey)
+		if cluster.ID(clusterID) == c.primaryClusterID {
+			log.Infof("ignoring cluster %v from secret %v as it would overwrite the primary cluster", clusterID, secretKey)
 			continue
 		}
 
@@ -361,8 +361,8 @@ func (c *Controller) addSecret(name types.NamespacedName, s *corev1.Secret) {
 
 func (c *Controller) deleteSecret(secretKey string) {
 	for _, cluster := range c.cs.GetExistingClustersFor(secretKey) {
-		if cluster.ID == c.localClusterID {
-			log.Infof("ignoring delete cluster %v from secret %v as it would overwrite the local cluster", c.localClusterID, secretKey)
+		if cluster.ID == c.primaryClusterID {
+			log.Infof("ignoring delete cluster %v from secret %v as it would overwrite the primary cluster", c.primaryClusterID, secretKey)
 			continue
 		}
 		log.Infof("Deleting cluster_id=%v configured by secret=%v", cluster.ID, secretKey)


### PR DESCRIPTION
**Please provide a description of this PR:**

The `localCluster` is confusing in external istiod model.  #38654 is trying to add local secret watch, which makes the` localCluster `especially confusing.

Actually, local cluster means primary cluster. And primary is also widely used in official docs.