### PR TITLE
use ipv4 for platform discovery for dual stack

### DIFF
--- a/pilot/cmd/pilot-agent/options/agent.go
+++ b/pilot/cmd/pilot-agent/options/agent.go
@@ -45,7 +45,7 @@ func NewAgentOptions(proxy *model.Proxy, cfg *meshconfig.ProxyConfig) *istioagen
 		EnvoyPrometheusPort:         envoyPrometheusPortEnv,
 		MinimumDrainDuration:        minimumDrainDurationEnv,
 		ExitOnZeroActiveConnections: exitOnZeroActiveConnectionsEnv,
-		Platform:                    platform.Discover(proxy.SupportsIPv6()),
+		Platform:                    platform.Discover(proxy.SupportsIPv4(), proxy.SupportsIPv6()),
 		GRPCBootstrapPath:           grpcBootstrapEnv,
 		DisableEnvoy:                disableEnvoyEnv,
 		ProxyXDSDebugViaAgent:       proxyXDSDebugViaAgent,

--- a/pkg/bootstrap/platform/aws_test.go
+++ b/pkg/bootstrap/platform/aws_test.go
@@ -49,7 +49,7 @@ func TestAWSLocality(t *testing.T) {
 			server, url := setupHTTPServer(v.handlers)
 			defer server.Close()
 			awsMetadataIPv4URL = url.String()
-			locality := NewAWS(false).Locality()
+			locality := NewAWS(true, false).Locality()
 			if !reflect.DeepEqual(locality, v.want) {
 				t.Errorf("unexpected locality. want :%v, got :%v", v.want, locality)
 			}
@@ -72,7 +72,7 @@ func TestIsAWS(t *testing.T) {
 			server, url := setupHTTPServer(v.handlers)
 			defer server.Close()
 			awsMetadataIPv4URL = url.String()
-			aws := IsAWS(false)
+			aws := IsAWS(true, false)
 			if !reflect.DeepEqual(aws, v.want) {
 				t.Errorf("unexpected iam info. want :%v, got :%v", v.want, aws)
 			}

--- a/pkg/bootstrap/platform/discovery.go
+++ b/pkg/bootstrap/platform/discovery.go
@@ -33,7 +33,7 @@ var CloudPlatform = env.RegisterStringVar("CLOUD_PLATFORM", "", "Cloud Platform 
 
 // Discover attempts to discover the host platform, defaulting to
 // `Unknown` if a platform cannot be discovered.
-func Discover(ipv6 bool) Environment {
+func Discover(ipv4, ipv6 bool) Environment {
 	// First check if user has specified platform - use it if provided.
 	if len(CloudPlatform) > 0 {
 		switch strings.ToLower(CloudPlatform) {
@@ -53,7 +53,7 @@ func Discover(ipv6 bool) Environment {
 
 // DiscoverWithTimeout attempts to discover the host platform, defaulting to
 // `Unknown` after the provided timeout.
-func DiscoverWithTimeout(timeout time.Duration, ipv6 bool) Environment {
+func DiscoverWithTimeout(timeout time.Duration, ipv4, ipv6 bool) Environment {
 	plat := make(chan Environment, numPlatforms) // sized to match number of platform goroutines
 	done := make(chan bool)
 

--- a/pkg/bootstrap/platform/discovery.go
+++ b/pkg/bootstrap/platform/discovery.go
@@ -48,7 +48,7 @@ func Discover(ipv4, ipv6 bool) Environment {
 		}
 	}
 	// Discover the platform if user has not specified.
-	return DiscoverWithTimeout(defaultTimeout, ipv6)
+	return DiscoverWithTimeout(defaultTimeout, ipv4, ipv6)
 }
 
 // DiscoverWithTimeout attempts to discover the host platform, defaulting to

--- a/pkg/bootstrap/platform/discovery.go
+++ b/pkg/bootstrap/platform/discovery.go
@@ -38,7 +38,7 @@ func Discover(ipv4, ipv6 bool) Environment {
 	if len(CloudPlatform) > 0 {
 		switch strings.ToLower(CloudPlatform) {
 		case "aws":
-			return NewAWS(ipv6)
+			return NewAWS(ipv4, ipv6)
 		case "azure":
 			return NewAzure()
 		case "gcp":
@@ -69,9 +69,9 @@ func DiscoverWithTimeout(timeout time.Duration, ipv4, ipv6 bool) Environment {
 	}()
 
 	go func() {
-		if IsAWS(ipv6) {
+		if IsAWS(ipv4, ipv6) {
 			log.Info("platform detected is AWS")
-			plat <- NewAWS(ipv6)
+			plat <- NewAWS(ipv4, ipv6)
 		}
 		wg.Done()
 	}()


### PR DESCRIPTION
Follow up https://github.com/istio/istio/pull/37874, use ipv4 address to get aws metadata when dual stack is detected. This should provide better compability. For example, we have ipv6 interface available but have not enable ipv6 for our cluster, the proxy would be using the ipv6 address for AWS metadata discovery and it fails.


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure