### PR TITLE
Add well known credential uds socket to allow plugin external UDS SDS server

### DIFF
--- a/manifests/charts/gateways/istio-egress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-egress/templates/deployment.yaml
@@ -227,6 +227,8 @@ spec:
           volumeMounts:
           - name: workload-socket
             mountPath: /var/run/secrets/workload-spiffe-uds
+          - name: credential-socket
+            mountPath: /var/run/secrets/credential-uds
           - name: workload-certs
             mountPath: /var/run/secrets/workload-spiffe-credentials
           - name: istio-envoy
@@ -270,6 +272,8 @@ spec:
       volumes:
       - emptyDir: {}
         name: workload-socket
+      - emptyDir: {}
+        name: credential-socket
       - emptyDir: {}
         name: workload-certs
 {{- if eq .Values.global.pilotCertProvider "istiod" }}

--- a/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
@@ -227,6 +227,8 @@ spec:
           volumeMounts:
           - name: workload-socket
             mountPath: /var/run/secrets/workload-spiffe-uds
+          - name: credential-socket
+            mountPath: /var/run/secrets/credential-uds
           - name: workload-certs
             mountPath: /var/run/secrets/workload-spiffe-credentials
           - name: istio-envoy
@@ -270,6 +272,8 @@ spec:
       volumes:
       - emptyDir: {}
         name: workload-socket
+      - emptyDir: {}
+        name: credential-socket
       - emptyDir: {}
         name: workload-certs
 {{- if eq .Values.global.pilotCertProvider "istiod" }}

--- a/manifests/charts/istio-control/istio-discovery/files/gateway-injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gateway-injection-template.yaml
@@ -133,6 +133,8 @@ spec:
     volumeMounts:
     - name: workload-socket
       mountPath: /var/run/secrets/workload-spiffe-uds
+    - name: credential-socket
+      mountPath: /var/run/secrets/credential-uds
     {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
     - name: gke-workload-certificate
       mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -165,6 +167,8 @@ spec:
   volumes:
   - emptyDir: {}
     name: workload-socket
+  - emptyDir: {}
+    name: credential-socket
   {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
   - name: gke-workload-certificate
     csi:

--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -586,6 +586,8 @@ data:
             volumeMounts:
             - name: workload-socket
               mountPath: /var/run/secrets/workload-spiffe-uds
+            - name: credential-socket
+              mountPath: /var/run/secrets/credential-uds
             {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
             - name: gke-workload-certificate
               mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -633,6 +635,8 @@ data:
           volumes:
           - emptyDir:
             name: workload-socket
+          - emptyDir:
+            name: credential-socket
           {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
           - name: gke-workload-certificate
             csi:
@@ -844,6 +848,8 @@ data:
             volumeMounts:
             - name: workload-socket
               mountPath: /var/run/secrets/workload-spiffe-uds
+            - name: credential-socket
+              mountPath: /var/run/secrets/credential-uds
             {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
             - name: gke-workload-certificate
               mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -876,6 +882,8 @@ data:
           volumes:
           - emptyDir: {}
             name: workload-socket
+          - emptyDir: {}
+            name: credential-socket
           {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
           - name: gke-workload-certificate
             csi:

--- a/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
@@ -371,6 +371,8 @@ spec:
     volumeMounts:
     - name: workload-socket
       mountPath: /var/run/secrets/workload-spiffe-uds
+    - name: credential-socket
+      mountPath: /var/run/secrets/credential-uds
     {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
     - name: gke-workload-certificate
       mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -418,6 +420,8 @@ spec:
   volumes:
   - emptyDir:
     name: workload-socket
+  - emptyDir:
+    name: credential-socket
   {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
   - name: gke-workload-certificate
     csi:

--- a/manifests/charts/istiod-remote/files/gateway-injection-template.yaml
+++ b/manifests/charts/istiod-remote/files/gateway-injection-template.yaml
@@ -133,6 +133,8 @@ spec:
     volumeMounts:
     - name: workload-socket
       mountPath: /var/run/secrets/workload-spiffe-uds
+    - name: credential-socket
+      mountPath: /var/run/secrets/credential-uds
     {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
     - name: gke-workload-certificate
       mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -165,6 +167,8 @@ spec:
   volumes:
   - emptyDir: {}
     name: workload-socket
+  - emptyDir: {}
+    name: credential-socket
   {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
   - name: gke-workload-certificate
     csi:

--- a/manifests/charts/istiod-remote/files/injection-template.yaml
+++ b/manifests/charts/istiod-remote/files/injection-template.yaml
@@ -371,6 +371,8 @@ spec:
     volumeMounts:
     - name: workload-socket
       mountPath: /var/run/secrets/workload-spiffe-uds
+    - name: credential-socket
+      mountPath: /var/run/secrets/credential-uds
     {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
     - name: gke-workload-certificate
       mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -418,6 +420,8 @@ spec:
   volumes:
   - emptyDir:
     name: workload-socket
+  - emptyDir:
+    name: credential-socket
   {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
   - name: gke-workload-certificate
     csi:

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -42,6 +42,7 @@ import (
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/config/schema/kind"
+	"istio.io/istio/pkg/security"
 	"istio.io/istio/pkg/util/sets"
 )
 
@@ -179,7 +180,10 @@ func (configgen *ConfigGeneratorImpl) buildClusters(proxy *model.Proxy, req *mod
 		}
 		clusters = append(clusters, patcher.insertedClusters()...)
 	}
-
+	// if credential socket exists, create a cluster for it
+	if proxy.Metadata != nil && proxy.Metadata.Raw[security.CredentialMetaDataName] == "true" {
+		clusters = append(clusters, cb.buildExternalSDSCluster(security.CredentialNameSocketPath))
+	}
 	for _, c := range clusters {
 		resources = append(resources, &discovery.Resource{Name: c.Name, Resource: util.MessageToAny(c)})
 	}

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -103,8 +103,9 @@ type ClusterBuilder struct {
 	proxyIPAddresses  []string                 // IP addresses on which proxy is listening on.
 	configNamespace   string                   // Proxy config namespace.
 	// PushRequest to look for updates.
-	req   *model.PushRequest
-	cache model.XdsCache
+	req                   *model.PushRequest
+	cache                 model.XdsCache
+	credentialSocketExist bool
 }
 
 // NewClusterBuilder builds an instance of ClusterBuilder.
@@ -135,6 +136,9 @@ func NewClusterBuilder(proxy *model.Proxy, req *model.PushRequest, cache model.X
 			}
 		}
 		cb.clusterID = string(proxy.Metadata.ClusterID)
+		if proxy.Metadata.Raw[security.CredentialMetaDataName] == "true" {
+			cb.credentialSocketExist = true
+		}
 	}
 	return cb
 }
@@ -995,7 +999,7 @@ func (cb *ClusterBuilder) buildUpstreamClusterTLSContext(opts *buildClusterOpts,
 		if tls.CredentialName != "" {
 			// If  credential name is specified at Destination Rule config and originating node is egress gateway, create
 			// SDS config for egress gateway to fetch key/cert at gateway agent.
-			authn_model.ApplyCustomSDSToClientCommonTLSContext(tlsContext.CommonTlsContext, tls)
+			authn_model.ApplyCustomSDSToClientCommonTLSContext(tlsContext.CommonTlsContext, tls, cb.credentialSocketExist)
 		} else {
 			// If CredentialName is not set fallback to files specified in DR.
 			res := security.SdsCertificateConfig{
@@ -1034,7 +1038,7 @@ func (cb *ClusterBuilder) buildUpstreamClusterTLSContext(opts *buildClusterOpts,
 		if tls.CredentialName != "" {
 			// If  credential name is specified at Destination Rule config and originating node is egress gateway, create
 			// SDS config for egress gateway to fetch key/cert at gateway agent.
-			authn_model.ApplyCustomSDSToClientCommonTLSContext(tlsContext.CommonTlsContext, tls)
+			authn_model.ApplyCustomSDSToClientCommonTLSContext(tlsContext.CommonTlsContext, tls, cb.credentialSocketExist)
 		} else {
 			// If CredentialName is not set fallback to file based approach
 			if tls.ClientCertificate == "" || tls.PrivateKey == "" {
@@ -1272,4 +1276,35 @@ func defaultTransportSocketMatch() *cluster.Cluster_TransportSocketMatch {
 		Match:           &structpb.Struct{},
 		TransportSocket: xdsfilters.RawBufferTransportSocket,
 	}
+}
+
+// buildExternalSDSCluster generates a cluster that acts as external SDS server
+func (cb *ClusterBuilder) buildExternalSDSCluster(addr string) *cluster.Cluster {
+	ep := &endpoint.LbEndpoint{
+		HostIdentifier: &endpoint.LbEndpoint_Endpoint{
+			Endpoint: &endpoint.Endpoint{
+				Address: &core.Address{
+					Address: &core.Address_Pipe{
+						Pipe: &core.Pipe{
+							Path: addr,
+						},
+					},
+				},
+			},
+		},
+	}
+	c := &cluster.Cluster{
+		Name:                 security.SDSExternalClusterName,
+		ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_STATIC},
+		ConnectTimeout:       cb.req.Push.Mesh.ConnectTimeout,
+		LoadAssignment: &endpoint.ClusterLoadAssignment{
+			ClusterName: security.SDSExternalClusterName,
+			Endpoints: []*endpoint.LocalityLbEndpoints{
+				{
+					LbEndpoints: []*endpoint.LbEndpoint{ep},
+				},
+			},
+		},
+	}
+	return c
 }

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
@@ -49,6 +49,7 @@ import (
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/config/schema/gvk"
+	"istio.io/istio/pkg/security"
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/util/assert"
 )
@@ -3504,6 +3505,42 @@ func TestApplyConnectionPool(t *testing.T) {
 				tt.expectedHTTPPOpt.CommonHttpProtocolOptions.IdleTimeout)
 			assert.Equal(t, opts.mutable.httpProtocolOptions.CommonHttpProtocolOptions.MaxRequestsPerConnection,
 				tt.expectedHTTPPOpt.CommonHttpProtocolOptions.MaxRequestsPerConnection)
+		})
+	}
+}
+
+func TestBuildExternalSDSClusters(t *testing.T) {
+	proxy := &model.Proxy{
+		Metadata: &model.NodeMetadata{
+			Raw: map[string]interface{}{
+				security.CredentialMetaDataName: "true",
+			},
+		},
+	}
+
+	cases := []struct {
+		name         string
+		expectedName string
+		expectedPath string
+	}{
+		{
+			name:         "uds",
+			expectedName: security.SDSExternalClusterName,
+			expectedPath: security.CredentialNameSocketPath,
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			cg := NewConfigGenTest(t, TestOptions{})
+			cb := NewClusterBuilder(cg.SetupProxy(proxy), &model.PushRequest{Push: cg.PushContext()}, nil)
+			cluster := cb.buildExternalSDSCluster(security.CredentialNameSocketPath)
+			path := cluster.LoadAssignment.Endpoints[0].LbEndpoints[0].GetEndpoint().Address.GetPipe().Path
+			if cluster.Name != tt.expectedName {
+				t.Errorf("Unexpected cluster name, got: %v, want: %v", cluster.Name, tt.expectedName)
+			}
+			if path != tt.expectedPath {
+				t.Errorf("Unexpected path, got: %v, want: %v", path, tt.expectedPath)
+			}
 		})
 	}
 }

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -48,6 +48,7 @@ import (
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/config/schema/kind"
+	"istio.io/istio/pkg/security"
 	"istio.io/istio/pkg/test"
 )
 
@@ -2558,4 +2559,45 @@ func TestBuildDeltaClusters(t *testing.T) {
 			g.Expect(xdstest.MapKeys(xdstest.ExtractClusters(clusters))).To(Equal(tc.expectedClusters))
 		})
 	}
+}
+
+func TestBuildStaticClusterWithCredentialSocket(t *testing.T) {
+	g := NewWithT(t)
+
+	service := &model.Service{
+		Hostname: host.Name("static.test"),
+		Ports: []*model.Port{
+			{
+				Name:     "default",
+				Port:     8080,
+				Protocol: protocol.HTTP,
+			},
+		},
+		Resolution:   model.DNSLB,
+		MeshExternal: true,
+		Attributes: model.ServiceAttributes{
+			Namespace: TestServiceNamespace,
+		},
+	}
+	cg := NewConfigGenTest(t, TestOptions{
+		Services: []*model.Service{service},
+	})
+	proxy := cg.SetupProxy(nil)
+	proxy.Metadata.Raw = map[string]interface{}{
+		security.CredentialMetaDataName: "true",
+	}
+	// Expect sds_external cluster be added if credentialSocket exists
+	clusters := cg.Clusters(proxy)
+	xdstest.ValidateClusters(t, clusters)
+	g.Expect(xdstest.MapKeys(xdstest.ExtractClusters(clusters))).To(Equal([]string{
+		"BlackHoleCluster", "InboundPassthroughClusterIpv4", "PassthroughCluster", security.SDSExternalClusterName,
+	}))
+
+	// Expect no sds_external cluster be added if if credentialSocket does NOT exists
+	proxy = cg.SetupProxy(nil)
+	clusters = cg.Clusters(proxy)
+	xdstest.ValidateClusters(t, clusters)
+	g.Expect(xdstest.MapKeys(xdstest.ExtractClusters(clusters))).To(Equal([]string{
+		"BlackHoleCluster", "InboundPassthroughClusterIpv4", "PassthroughCluster",
+	}))
 }

--- a/pkg/istio-agent/agent.go
+++ b/pkg/istio-agent/agent.go
@@ -267,8 +267,11 @@ func (a *Agent) generateNodeMetadata() (*model.Node, error) {
 	})
 }
 
-func (a *Agent) initializeEnvoyAgent(ctx context.Context) error {
+func (a *Agent) initializeEnvoyAgent(ctx context.Context, credentialSocketExists bool) error {
 	node, err := a.generateNodeMetadata()
+	if credentialSocketExists {
+		node.RawMetadata[security.CredentialMetaDataName] = "true"
+	}
 	if err != nil {
 		return fmt.Errorf("failed to generate bootstrap metadata: %v", err)
 	}
@@ -422,15 +425,21 @@ func (a *Agent) Run(ctx context.Context) (func(), error) {
 	}
 
 	if socketExists {
-		log.Info("SDS socket found. Istio SDS Server won't be started")
+		log.Info("Workload SDS socket found. Istio SDS Server won't be started")
 	} else {
-		log.Info("SDS socket not found. Starting Istio SDS Server")
+		log.Info("Workload SDS socket not found. Starting Istio SDS Server")
 		err = a.initSdsServer()
 		if err != nil {
 			return nil, fmt.Errorf("failed to start SDS server: %v", err)
 		}
 	}
-
+	credentialSocketExists, err := checkSocket(ctx, security.CredentialNameSocketPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check credential SDS socket: %v", err)
+	}
+	if credentialSocketExists {
+		log.Info("Credential SDS socket found")
+	}
 	a.xdsProxy, err = initXdsProxy(a)
 	if err != nil {
 		return nil, fmt.Errorf("failed to start xds proxy: %v", err)
@@ -443,11 +452,10 @@ func (a *Agent) Run(ctx context.Context) (func(), error) {
 	}
 
 	if a.cfg.GRPCBootstrapPath != "" {
-		if err := a.generateGRPCBootstrap(); err != nil {
+		if err := a.generateGRPCBootstrap(credentialSocketExists); err != nil {
 			return nil, fmt.Errorf("failed generating gRPC XDS bootstrap: %v", err)
 		}
 	}
-
 	rootCAForXDS, err := a.FindRootCAForXDS()
 	if err != nil {
 		return nil, fmt.Errorf("failed to find root XDS CA: %v", err)
@@ -455,7 +463,7 @@ func (a *Agent) Run(ctx context.Context) (func(), error) {
 	go a.caFileWatcherHandler(ctx, rootCAForXDS)
 
 	if !a.EnvoyDisabled() {
-		err = a.initializeEnvoyAgent(ctx)
+		err = a.initializeEnvoyAgent(ctx, credentialSocketExists)
 		if err != nil {
 			return nil, fmt.Errorf("failed to start envoy agent: %v", err)
 		}
@@ -592,9 +600,13 @@ func (a *Agent) initLocalDNSServer() (err error) {
 	return nil
 }
 
-func (a *Agent) generateGRPCBootstrap() error {
+func (a *Agent) generateGRPCBootstrap(credentialSocketExists bool) error {
 	// generate metadata
 	node, err := a.generateNodeMetadata()
+	if credentialSocketExists {
+		node.RawMetadata[security.CredentialMetaDataName] = "true"
+	}
+
 	if err != nil {
 		return fmt.Errorf("failed generating node metadata: %v", err)
 	}

--- a/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
@@ -19,7 +19,7 @@ spec:
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
-        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
       creationTimestamp: null
       labels:
         app: hello
@@ -129,6 +129,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -188,6 +190,7 @@ spec:
       serviceAccountName: non-default
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/auth.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/auth.yaml.injected
@@ -19,7 +19,7 @@ spec:
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
-        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
       creationTimestamp: null
       labels:
         app: hello
@@ -129,6 +129,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -187,6 +189,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
@@ -12,7 +12,7 @@ spec:
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
-        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
       creationTimestamp: null
       labels:
         security.istio.io/tlsMode: istio
@@ -123,6 +123,8 @@ spec:
             volumeMounts:
             - mountPath: /var/run/secrets/workload-spiffe-uds
               name: workload-socket
+            - mountPath: /var/run/secrets/credential-uds
+              name: credential-socket
             - mountPath: /var/run/secrets/workload-spiffe-credentials
               name: workload-certs
             - mountPath: /var/run/secrets/istio
@@ -182,6 +184,7 @@ spec:
             fsGroup: 1337
           volumes:
           - name: workload-socket
+          - name: credential-socket
           - name: workload-certs
           - emptyDir:
               medium: Memory

--- a/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
@@ -17,7 +17,7 @@ spec:
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
-        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
       creationTimestamp: null
       labels:
         app: hello
@@ -127,6 +127,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -185,6 +187,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/deploymentconfig-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/deploymentconfig-multi.yaml.injected
@@ -32,7 +32,7 @@ items:
           prometheus.io/path: /stats/prometheus
           prometheus.io/port: "15020"
           prometheus.io/scrape: "true"
-          sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+          sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
         creationTimestamp: null
         labels:
           app: hello
@@ -142,6 +142,8 @@ items:
           volumeMounts:
           - mountPath: /var/run/secrets/workload-spiffe-uds
             name: workload-socket
+          - mountPath: /var/run/secrets/credential-uds
+            name: credential-socket
           - mountPath: /var/run/secrets/workload-spiffe-credentials
             name: workload-certs
           - mountPath: /var/run/secrets/istio
@@ -200,6 +202,7 @@ items:
           fsGroup: 1337
         volumes:
         - name: workload-socket
+        - name: credential-socket
         - name: workload-certs
         - emptyDir:
             medium: Memory

--- a/pkg/kube/inject/testdata/inject/deploymentconfig-with-canonical-service-label.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/deploymentconfig-with-canonical-service-label.yaml.injected
@@ -17,7 +17,7 @@ spec:
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
-        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
       creationTimestamp: null
       labels:
         app: hello
@@ -127,6 +127,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -185,6 +187,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/deploymentconfig.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/deploymentconfig.yaml.injected
@@ -17,7 +17,7 @@ spec:
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
-        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
       creationTimestamp: null
       labels:
         app: hello
@@ -127,6 +127,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -185,6 +187,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/enable-core-dump-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/enable-core-dump-annotation.yaml.injected
@@ -20,7 +20,7 @@ spec:
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
         sidecar.istio.io/enableCoreDump: "true"
-        sidecar.istio.io/status: '{"initContainers":["istio-init","enable-core-dump"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init","enable-core-dump"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
       creationTimestamp: null
       labels:
         app: hello
@@ -130,6 +130,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -215,6 +217,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
@@ -19,7 +19,7 @@ spec:
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
-        sidecar.istio.io/status: '{"initContainers":["istio-init","enable-core-dump"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init","enable-core-dump"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
       creationTimestamp: null
       labels:
         app: hello
@@ -129,6 +129,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -214,6 +216,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/explicit-security-context.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/explicit-security-context.yaml.injected
@@ -16,7 +16,7 @@ spec:
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
-        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
       creationTimestamp: null
       labels:
         app: hello
@@ -120,6 +120,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -178,6 +180,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
@@ -19,7 +19,7 @@ spec:
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
-        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
       creationTimestamp: null
       labels:
         app: hello
@@ -129,6 +129,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -187,6 +189,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/frontend.yaml.injected
@@ -33,7 +33,7 @@ spec:
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
-        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
       creationTimestamp: null
       labels:
         app: hello
@@ -146,6 +146,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -204,6 +206,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/grpc-agent.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/grpc-agent.yaml.injected
@@ -19,7 +19,7 @@ spec:
         prometheus.io/scrape: "true"
         proxy.istio.io/overrides: '{"containers":[{"name":"traffic","image":"fake.docker.io/google-samples/traffic-go-gke:1.0","resources":{},"readinessProbe":{"httpGet":{"port":80}}}]}'
         sidecar.istio.io/rewriteAppHTTPProbers: "false"
-        sidecar.istio.io/status: '{"initContainers":null,"containers":["istio-proxy","traffic"],"volumes":["workload-socket","credential-socket","workload-certs","istio-xds","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":null,"containers":["istio-proxy","traffic"],"volumes":["workload-socket","workload-certs","istio-xds","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
       creationTimestamp: null
       labels:
         app: grpc
@@ -138,8 +138,6 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
-        - mountPath: /var/run/secrets/credential-uds
-          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -156,7 +154,6 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
-      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/grpc-agent.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/grpc-agent.yaml.injected
@@ -19,7 +19,7 @@ spec:
         prometheus.io/scrape: "true"
         proxy.istio.io/overrides: '{"containers":[{"name":"traffic","image":"fake.docker.io/google-samples/traffic-go-gke:1.0","resources":{},"readinessProbe":{"httpGet":{"port":80}}}]}'
         sidecar.istio.io/rewriteAppHTTPProbers: "false"
-        sidecar.istio.io/status: '{"initContainers":null,"containers":["istio-proxy","traffic"],"volumes":["workload-socket","workload-certs","istio-xds","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":null,"containers":["istio-proxy","traffic"],"volumes":["workload-socket","credential-socket","workload-certs","istio-xds","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
       creationTimestamp: null
       labels:
         app: grpc
@@ -138,6 +138,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -154,6 +156,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
@@ -19,7 +19,7 @@ spec:
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
-        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
       creationTimestamp: null
       labels:
         app: hello
@@ -130,6 +130,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -189,6 +191,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/hello-cncf-networks.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-cncf-networks.yaml.injected
@@ -21,7 +21,7 @@ spec:
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
         sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"initContainers":["istio-validation"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-validation"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
         traffic.sidecar.istio.io/excludeInboundPorts: "15020"
         traffic.sidecar.istio.io/includeInboundPorts: '*'
         traffic.sidecar.istio.io/includeOutboundIPRanges: '*'
@@ -134,6 +134,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -191,6 +193,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/hello-existing-cncf-networks-json.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-existing-cncf-networks-json.yaml.injected
@@ -21,7 +21,7 @@ spec:
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
         sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"initContainers":["istio-validation"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-validation"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
         traffic.sidecar.istio.io/excludeInboundPorts: "15020"
         traffic.sidecar.istio.io/includeInboundPorts: '*'
         traffic.sidecar.istio.io/includeOutboundIPRanges: '*'
@@ -134,6 +134,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -191,6 +193,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/hello-existing-cncf-networks.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-existing-cncf-networks.yaml.injected
@@ -21,7 +21,7 @@ spec:
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
         sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"initContainers":["istio-validation"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-validation"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
         traffic.sidecar.istio.io/excludeInboundPorts: "15020"
         traffic.sidecar.istio.io/includeInboundPorts: '*'
         traffic.sidecar.istio.io/includeOutboundIPRanges: '*'
@@ -134,6 +134,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -191,6 +193,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/hello-image-pull-secret.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-image-pull-secret.yaml.injected
@@ -19,7 +19,7 @@ spec:
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
-        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
       creationTimestamp: null
       labels:
         app: hello
@@ -129,6 +129,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -189,6 +191,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/hello-image-secrets-in-values.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-image-secrets-in-values.yaml.injected
@@ -19,7 +19,7 @@ spec:
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
-        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":["barSecret"],"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":["barSecret"],"revision":"default"}'
       creationTimestamp: null
       labels:
         app: hello
@@ -129,6 +129,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -189,6 +191,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/hello-mount-mtls-certs.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-mount-mtls-certs.yaml.injected
@@ -19,7 +19,7 @@ spec:
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
-        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert","istio-certs"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert","istio-certs"],"imagePullSecrets":null,"revision":"default"}'
       creationTimestamp: null
       labels:
         app: hello
@@ -129,6 +129,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -190,6 +192,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/hello-mtls-not-ready.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-mtls-not-ready.yaml.injected
@@ -19,7 +19,7 @@ spec:
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
-        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
       creationTimestamp: null
       labels:
         app: hello
@@ -129,6 +129,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -187,6 +189,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
@@ -20,7 +20,7 @@ spec:
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
-        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
       creationTimestamp: null
       labels:
         app: hello
@@ -131,6 +131,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -189,6 +191,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory
@@ -238,7 +241,7 @@ spec:
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
-        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
       creationTimestamp: null
       labels:
         app: hello
@@ -349,6 +352,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -407,6 +412,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/hello-multiple-image-secrets.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-multiple-image-secrets.yaml.injected
@@ -19,7 +19,7 @@ spec:
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
-        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":["barSecret"],"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":["barSecret"],"revision":"default"}'
       creationTimestamp: null
       labels:
         app: hello
@@ -129,6 +129,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -190,6 +192,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/hello-namespace.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-namespace.yaml.injected
@@ -20,7 +20,7 @@ spec:
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
-        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
       creationTimestamp: null
       labels:
         app: hello
@@ -130,6 +130,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -188,6 +190,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
@@ -19,7 +19,7 @@ spec:
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
-        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
       creationTimestamp: null
       labels:
         app: hello
@@ -130,6 +130,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -189,6 +191,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/hello-no-seccontext.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-no-seccontext.yaml.injected
@@ -19,7 +19,7 @@ spec:
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
-        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
       creationTimestamp: null
       labels:
         app: hello
@@ -129,6 +129,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -185,6 +187,7 @@ spec:
           runAsUser: 0
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.injected
@@ -20,7 +20,7 @@ spec:
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
         proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": false }'
-        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
       creationTimestamp: null
       labels:
         app: hello
@@ -133,6 +133,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -220,6 +222,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/hello-probes-proxyHoldApplication-ProxyConfig.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-probes-proxyHoldApplication-ProxyConfig.yaml.injected
@@ -20,7 +20,7 @@ spec:
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
         proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
-        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
       creationTimestamp: null
       labels:
         app: hello
@@ -133,6 +133,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -220,6 +222,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/hello-probes-with-flag-set-in-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-probes-with-flag-set-in-annotation.yaml.injected
@@ -20,7 +20,7 @@ spec:
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
         sidecar.istio.io/rewriteAppHTTPProbers: "true"
-        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
       creationTimestamp: null
       labels:
         app: hello
@@ -156,6 +156,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -214,6 +216,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/hello-probes-with-flag-unset-in-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-probes-with-flag-unset-in-annotation.yaml.injected
@@ -20,7 +20,7 @@ spec:
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
         sidecar.istio.io/rewriteAppHTTPProbers: "false"
-        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
       creationTimestamp: null
       labels:
         app: hello
@@ -151,6 +151,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -209,6 +211,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/hello-probes.proxyHoldsApplication.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-probes.proxyHoldsApplication.yaml.injected
@@ -19,7 +19,7 @@ spec:
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
-        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
       creationTimestamp: null
       labels:
         app: hello
@@ -132,6 +132,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -219,6 +221,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/hello-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-probes.yaml.injected
@@ -19,7 +19,7 @@ spec:
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
-        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
       creationTimestamp: null
       labels:
         app: hello
@@ -155,6 +155,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -213,6 +215,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
@@ -20,7 +20,7 @@ spec:
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
         sidecar.istio.io/proxyImage: docker.io/istio/proxy2_debug:unittest
-        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
       creationTimestamp: null
       labels:
         app: hello
@@ -130,6 +130,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -188,6 +190,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/hello-readiness.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-readiness.yaml.injected
@@ -19,7 +19,7 @@ spec:
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
-        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
       creationTimestamp: null
       labels:
         app: hello
@@ -135,6 +135,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -193,6 +195,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/hello-template-in-values.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-template-in-values.yaml.injected
@@ -19,7 +19,7 @@ spec:
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
-        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
       creationTimestamp: null
       labels:
         app: hello
@@ -129,6 +129,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -187,6 +189,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
@@ -19,7 +19,7 @@ spec:
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
-        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
       creationTimestamp: null
       labels:
         app: hello
@@ -131,6 +131,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -189,6 +191,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/hello.proxyHoldsApplication.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello.proxyHoldsApplication.yaml.injected
@@ -19,7 +19,7 @@ spec:
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
-        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
       creationTimestamp: null
       labels:
         app: hello
@@ -129,6 +129,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -193,6 +195,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/hello.yaml.cni.injected
+++ b/pkg/kube/inject/testdata/inject/hello.yaml.cni.injected
@@ -20,7 +20,7 @@ spec:
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
         sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"initContainers":["istio-validation"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-validation"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
         traffic.sidecar.istio.io/excludeInboundPorts: "15020"
         traffic.sidecar.istio.io/includeInboundPorts: '*'
         traffic.sidecar.istio.io/includeOutboundIPRanges: '*'
@@ -136,6 +136,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -193,6 +195,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/hello.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello.yaml.injected
@@ -19,7 +19,7 @@ spec:
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
-        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
       creationTimestamp: null
       labels:
         app: hello
@@ -129,6 +129,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -187,6 +189,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/hello.yaml.proxyImageName.injected
+++ b/pkg/kube/inject/testdata/inject/hello.yaml.proxyImageName.injected
@@ -19,7 +19,7 @@ spec:
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
-        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
       creationTimestamp: null
       labels:
         app: hello
@@ -129,6 +129,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -187,6 +189,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/https-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/https-probes.yaml.injected
@@ -19,7 +19,7 @@ spec:
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
-        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
       creationTimestamp: null
       labels:
         app: hello
@@ -156,6 +156,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -214,6 +216,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/job.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/job.yaml.injected
@@ -12,7 +12,7 @@ spec:
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
-        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
       creationTimestamp: null
       labels:
         security.istio.io/tlsMode: istio
@@ -121,6 +121,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -180,6 +182,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml.injected
@@ -19,7 +19,7 @@ spec:
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
-        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
         traffic.sidecar.istio.io/kubevirtInterfaces: net1
       creationTimestamp: null
       labels:
@@ -130,6 +130,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -190,6 +192,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml.injected
@@ -19,7 +19,7 @@ spec:
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
-        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
         traffic.sidecar.istio.io/kubevirtInterfaces: net1,net2
       creationTimestamp: null
       labels:
@@ -130,6 +130,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -190,6 +192,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
@@ -34,7 +34,7 @@ items:
           prometheus.io/path: /stats/prometheus
           prometheus.io/port: "15020"
           prometheus.io/scrape: "true"
-          sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+          sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
         creationTimestamp: null
         labels:
           app: hello
@@ -147,6 +147,8 @@ items:
           volumeMounts:
           - mountPath: /var/run/secrets/workload-spiffe-uds
             name: workload-socket
+          - mountPath: /var/run/secrets/credential-uds
+            name: credential-socket
           - mountPath: /var/run/secrets/workload-spiffe-credentials
             name: workload-certs
           - mountPath: /var/run/secrets/istio
@@ -205,6 +207,7 @@ items:
           fsGroup: 1337
         volumes:
         - name: workload-socket
+        - name: credential-socket
         - name: workload-certs
         - emptyDir:
             medium: Memory

--- a/pkg/kube/inject/testdata/inject/list.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/list.yaml.injected
@@ -22,7 +22,7 @@ items:
           prometheus.io/path: /stats/prometheus
           prometheus.io/port: "15020"
           prometheus.io/scrape: "true"
-          sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+          sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
         creationTimestamp: null
         labels:
           app: hello
@@ -133,6 +133,8 @@ items:
           volumeMounts:
           - mountPath: /var/run/secrets/workload-spiffe-uds
             name: workload-socket
+          - mountPath: /var/run/secrets/credential-uds
+            name: credential-socket
           - mountPath: /var/run/secrets/workload-spiffe-credentials
             name: workload-certs
           - mountPath: /var/run/secrets/istio
@@ -191,6 +193,7 @@ items:
           fsGroup: 1337
         volumes:
         - name: workload-socket
+        - name: credential-socket
         - name: workload-certs
         - emptyDir:
             medium: Memory
@@ -239,7 +242,7 @@ items:
           prometheus.io/path: /stats/prometheus
           prometheus.io/port: "15020"
           prometheus.io/scrape: "true"
-          sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+          sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
         creationTimestamp: null
         labels:
           app: hello
@@ -350,6 +353,8 @@ items:
           volumeMounts:
           - mountPath: /var/run/secrets/workload-spiffe-uds
             name: workload-socket
+          - mountPath: /var/run/secrets/credential-uds
+            name: credential-socket
           - mountPath: /var/run/secrets/workload-spiffe-credentials
             name: workload-certs
           - mountPath: /var/run/secrets/istio
@@ -408,6 +413,7 @@ items:
           fsGroup: 1337
         volumes:
         - name: workload-socket
+        - name: credential-socket
         - name: workload-certs
         - emptyDir:
             medium: Memory

--- a/pkg/kube/inject/testdata/inject/multi-container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/multi-container.yaml.injected
@@ -17,7 +17,7 @@ spec:
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
-        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
       creationTimestamp: null
       labels:
         app: app
@@ -131,6 +131,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -189,6 +191,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
@@ -19,7 +19,7 @@ spec:
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
-        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
       creationTimestamp: null
       labels:
         app: hello
@@ -129,6 +129,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -201,6 +203,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/multiple-templates.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/multiple-templates.yaml.injected
@@ -18,7 +18,7 @@ spec:
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
         proxy.istio.io/overrides: '{"containers":[{"name":"istio-proxy","image":"foo/bar","resources":{}}]}'
-        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
       creationTimestamp: null
       labels:
         app: hello
@@ -122,6 +122,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -180,6 +182,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/named_port.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/named_port.yaml.injected
@@ -19,7 +19,7 @@ spec:
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
-        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
       creationTimestamp: null
       labels:
         app: hello
@@ -135,6 +135,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -193,6 +195,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/one_container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/one_container.yaml.injected
@@ -19,7 +19,7 @@ spec:
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
-        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
       creationTimestamp: null
       labels:
         app: hello
@@ -139,6 +139,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -197,6 +199,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/only-proxy-container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/only-proxy-container.yaml.injected
@@ -15,7 +15,7 @@ spec:
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
         proxy.istio.io/overrides: '{"containers":[{"name":"istio-proxy","resources":{}}]}'
-        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
       creationTimestamp: null
       labels:
         istio: ingressgateway
@@ -115,6 +115,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -173,6 +175,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/pod.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/pod.yaml.injected
@@ -7,7 +7,7 @@ metadata:
     prometheus.io/path: /stats/prometheus
     prometheus.io/port: "15020"
     prometheus.io/scrape: "true"
-    sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+    sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
   creationTimestamp: null
   labels:
     security.istio.io/tlsMode: istio
@@ -115,6 +115,8 @@ spec:
     volumeMounts:
     - mountPath: /var/run/secrets/workload-spiffe-uds
       name: workload-socket
+    - mountPath: /var/run/secrets/credential-uds
+      name: credential-socket
     - mountPath: /var/run/secrets/workload-spiffe-credentials
       name: workload-certs
     - mountPath: /var/run/secrets/istio
@@ -173,6 +175,7 @@ spec:
     fsGroup: 1337
   volumes:
   - name: workload-socket
+  - name: credential-socket
   - name: workload-certs
   - emptyDir:
       medium: Memory

--- a/pkg/kube/inject/testdata/inject/prometheus-scrape.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/prometheus-scrape.yaml.injected
@@ -5,7 +5,7 @@ metadata:
     kubectl.kubernetes.io/default-container: hello
     kubectl.kubernetes.io/default-logs-container: hello
     prometheus.io/scrape: "false"
-    sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+    sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
   creationTimestamp: null
   labels:
     security.istio.io/tlsMode: istio
@@ -113,6 +113,8 @@ spec:
     volumeMounts:
     - mountPath: /var/run/secrets/workload-spiffe-uds
       name: workload-socket
+    - mountPath: /var/run/secrets/credential-uds
+      name: credential-socket
     - mountPath: /var/run/secrets/workload-spiffe-credentials
       name: workload-certs
     - mountPath: /var/run/secrets/istio
@@ -171,6 +173,7 @@ spec:
     fsGroup: 1337
   volumes:
   - name: workload-socket
+  - name: credential-socket
   - name: workload-certs
   - emptyDir:
       medium: Memory

--- a/pkg/kube/inject/testdata/inject/prometheus-scrape2.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/prometheus-scrape2.yaml.injected
@@ -5,7 +5,7 @@ metadata:
     kubectl.kubernetes.io/default-container: hello
     kubectl.kubernetes.io/default-logs-container: hello
     prometheus.io.scrape: "false"
-    sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+    sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
   creationTimestamp: null
   labels:
     security.istio.io/tlsMode: istio
@@ -113,6 +113,8 @@ spec:
     volumeMounts:
     - mountPath: /var/run/secrets/workload-spiffe-uds
       name: workload-socket
+    - mountPath: /var/run/secrets/credential-uds
+      name: credential-socket
     - mountPath: /var/run/secrets/workload-spiffe-credentials
       name: workload-certs
     - mountPath: /var/run/secrets/istio
@@ -171,6 +173,7 @@ spec:
     fsGroup: 1337
   volumes:
   - name: workload-socket
+  - name: credential-socket
   - name: workload-certs
   - emptyDir:
       medium: Memory

--- a/pkg/kube/inject/testdata/inject/proxy-override-args.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/proxy-override-args.yaml.injected
@@ -17,7 +17,7 @@ spec:
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
         proxy.istio.io/overrides: '{"containers":[{"name":"istio-proxy","command":["envoy"],"args":["-c","my-config.yaml"],"resources":{}}]}'
-        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
       creationTimestamp: null
       labels:
         app: hello
@@ -116,6 +116,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -174,6 +176,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/proxy-override.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/proxy-override.yaml.injected
@@ -17,7 +17,7 @@ spec:
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
         proxy.istio.io/overrides: '{"containers":[{"name":"istio-proxy","resources":{"requests":{"cpu":"123m"}},"volumeMounts":[{"name":"certs","mountPath":"/etc/certs"}],"livenessProbe":{"httpGet":{"path":"/healthz/ready","port":15021},"initialDelaySeconds":10,"timeoutSeconds":3,"periodSeconds":2,"failureThreshold":30},"lifecycle":{"preStop":{"exec":{"command":["sleep","10"]}}},"terminationMessagePath":"/foo/bar","securityContext":{"readOnlyRootFilesystem":false,"allowPrivilegeEscalation":true},"tty":true}],"initContainers":[{"name":"istio-init","image":"fake/custom-image","args":["my","custom","args"],"resources":{}}]}'
-        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
       creationTimestamp: null
       labels:
         app: hello
@@ -137,6 +137,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -182,6 +184,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/ready_live.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/ready_live.yaml.injected
@@ -19,7 +19,7 @@ spec:
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
-        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
       creationTimestamp: null
       labels:
         app: hello
@@ -155,6 +155,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -213,6 +215,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/ready_only.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/ready_only.yaml.injected
@@ -19,7 +19,7 @@ spec:
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
-        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
       creationTimestamp: null
       labels:
         app: hello
@@ -135,6 +135,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -193,6 +195,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
@@ -16,7 +16,7 @@ spec:
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
-        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
       creationTimestamp: null
       labels:
         app: hello
@@ -124,6 +124,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -182,6 +184,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
@@ -15,7 +15,7 @@ spec:
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
-        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
       creationTimestamp: null
       labels:
         app: nginx
@@ -123,6 +123,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -181,6 +183,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/resource_annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/resource_annotations.yaml.injected
@@ -21,7 +21,7 @@ spec:
         sidecar.istio.io/proxyCPULimit: 1000m
         sidecar.istio.io/proxyMemory: 1Gi
         sidecar.istio.io/proxyMemoryLimit: 2Gi
-        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
       creationTimestamp: null
       labels:
         app: resource
@@ -129,6 +129,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -187,6 +189,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/startup_live.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/startup_live.yaml.injected
@@ -19,7 +19,7 @@ spec:
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
-        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
       creationTimestamp: null
       labels:
         app: hello
@@ -155,6 +155,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -213,6 +215,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/startup_only.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/startup_only.yaml.injected
@@ -19,7 +19,7 @@ spec:
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
-        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
       creationTimestamp: null
       labels:
         app: hello
@@ -135,6 +135,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -193,6 +195,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/startup_ready_live.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/startup_ready_live.yaml.injected
@@ -19,7 +19,7 @@ spec:
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
-        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
       creationTimestamp: null
       labels:
         app: hello
@@ -163,6 +163,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -221,6 +223,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
@@ -19,7 +19,7 @@ spec:
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
-        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
       creationTimestamp: null
       labels:
         app: hello
@@ -132,6 +132,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -190,6 +192,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/status_annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/status_annotations.yaml.injected
@@ -21,7 +21,7 @@ spec:
         readiness.status.sidecar.istio.io/failureThreshold: "300"
         readiness.status.sidecar.istio.io/initialDelaySeconds: "100"
         readiness.status.sidecar.istio.io/periodSeconds: "200"
-        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
         status.sidecar.istio.io/port: "123"
       creationTimestamp: null
       labels:
@@ -130,6 +130,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -188,6 +190,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/status_annotations_zeroport.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/status_annotations_zeroport.yaml.injected
@@ -21,7 +21,7 @@ spec:
         readiness.status.sidecar.istio.io/failureThreshold: "300"
         readiness.status.sidecar.istio.io/initialDelaySeconds: "100"
         readiness.status.sidecar.istio.io/periodSeconds: "200"
-        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
         status.sidecar.istio.io/port: "0"
       creationTimestamp: null
       labels:
@@ -122,6 +122,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -180,6 +182,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/status_params.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/status_params.yaml.injected
@@ -17,7 +17,7 @@ spec:
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
-        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
       creationTimestamp: null
       labels:
         app: status
@@ -125,6 +125,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -183,6 +185,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/tcp-probes-disabled.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/tcp-probes-disabled.yaml.injected
@@ -19,7 +19,7 @@ spec:
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
-        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
       creationTimestamp: null
       labels:
         app: hello
@@ -135,6 +135,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -193,6 +195,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/tcp-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/tcp-probes.yaml.injected
@@ -19,7 +19,7 @@ spec:
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
-        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
       creationTimestamp: null
       labels:
         app: hello
@@ -139,6 +139,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -197,6 +199,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
@@ -17,7 +17,7 @@ spec:
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
-        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
         traffic.sidecar.istio.io/excludeInboundPorts: 4,5,6
         traffic.sidecar.istio.io/excludeOutboundIPRanges: 10.96.0.2/24,10.96.0.3/24
         traffic.sidecar.istio.io/includeInboundPorts: ""
@@ -129,6 +129,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -187,6 +189,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
@@ -17,7 +17,7 @@ spec:
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
-        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
         traffic.sidecar.istio.io/excludeInboundPorts: 4,5,6
         traffic.sidecar.istio.io/excludeOutboundIPRanges: 10.96.0.2/24,10.96.0.3/24
         traffic.sidecar.istio.io/includeInboundPorts: '*'
@@ -129,6 +129,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -187,6 +189,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
@@ -24,7 +24,7 @@ spec:
             FOO: bar
             ISTIO_META_TLS_CLIENT_KEY: /etc/identity2/client/keys/client-key.pem
         sidecar.istio.io/proxyCPU: 4000m
-        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
         traffic.sidecar.istio.io/excludeInboundPorts: 4,5,6
         traffic.sidecar.istio.io/excludeOutboundIPRanges: 10.96.0.2/24,10.96.0.3/24
         traffic.sidecar.istio.io/excludeOutboundPorts: 7,8,9
@@ -137,6 +137,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -198,6 +200,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
@@ -17,7 +17,7 @@ spec:
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
-        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
       creationTimestamp: null
       labels:
         app: traffic
@@ -125,6 +125,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -183,6 +185,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
@@ -17,7 +17,7 @@ spec:
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
-        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
       creationTimestamp: null
       labels:
         app: traffic
@@ -117,6 +117,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -175,6 +177,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/two_container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/two_container.yaml.injected
@@ -19,7 +19,7 @@ spec:
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
-        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
       creationTimestamp: null
       labels:
         app: hello
@@ -146,6 +146,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -204,6 +206,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/user-volume.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/user-volume.yaml.injected
@@ -19,7 +19,7 @@ spec:
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
-        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert","user-volume-1","user-volume-2"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert","user-volume-1","user-volume-2"],"imagePullSecrets":null,"revision":"default"}'
         sidecar.istio.io/userVolume: '{"user-volume-1":{"persistentVolumeClaim":{"claimName":"pvc-claim"}},"user-volume-2":{"configMap":{"name":"configmap-volume","items":[{"key":"some-key","path":"/some-path"}]}}}'
         sidecar.istio.io/userVolumeMount: '{"user-volume-1":{"mountPath":"/mnt/volume-1","readOnly":true},"user-volume-2":{"mountPath":"/mnt/volume-2"}}'
       creationTimestamp: null
@@ -131,6 +131,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -194,6 +196,7 @@ spec:
         fsGroup: 1337
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inputs/custom-template.yaml.34.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/custom-template.yaml.34.template.gen.yaml
@@ -382,6 +382,8 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
+        - name: credential-socket
+          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -429,6 +431,8 @@ templates:
       volumes:
       - emptyDir:
         name: workload-socket
+      - emptyDir:
+        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -640,6 +644,8 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
+        - name: credential-socket
+          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -672,6 +678,8 @@ templates:
       volumes:
       - emptyDir: {}
         name: workload-socket
+      - emptyDir: {}
+        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -979,6 +987,8 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
+        - name: credential-socket
+          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -1042,6 +1052,8 @@ templates:
       volumes:
       - emptyDir:
         name: workload-socket
+      - emptyDir:
+        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:

--- a/pkg/kube/inject/testdata/inputs/custom-template.yaml.34.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/custom-template.yaml.34.template.gen.yaml
@@ -987,8 +987,6 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
-        - name: credential-socket
-          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -1052,8 +1050,6 @@ templates:
       volumes:
       - emptyDir:
         name: workload-socket
-      - emptyDir:
-        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:

--- a/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
@@ -382,6 +382,8 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
+        - name: credential-socket
+          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -429,6 +431,8 @@ templates:
       volumes:
       - emptyDir:
         name: workload-socket
+      - emptyDir:
+        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -640,6 +644,8 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
+        - name: credential-socket
+          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -672,6 +678,8 @@ templates:
       volumes:
       - emptyDir: {}
         name: workload-socket
+      - emptyDir: {}
+        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -979,6 +987,8 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
+        - name: credential-socket
+          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -1042,6 +1052,8 @@ templates:
       volumes:
       - emptyDir:
         name: workload-socket
+      - emptyDir:
+        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:

--- a/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
@@ -987,8 +987,6 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
-        - name: credential-socket
-          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -1052,8 +1050,6 @@ templates:
       volumes:
       - emptyDir:
         name: workload-socket
-      - emptyDir:
-        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:

--- a/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
@@ -382,6 +382,8 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
+        - name: credential-socket
+          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -429,6 +431,8 @@ templates:
       volumes:
       - emptyDir:
         name: workload-socket
+      - emptyDir:
+        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -640,6 +644,8 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
+        - name: credential-socket
+          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -672,6 +678,8 @@ templates:
       volumes:
       - emptyDir: {}
         name: workload-socket
+      - emptyDir: {}
+        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -979,6 +987,8 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
+        - name: credential-socket
+          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -1042,6 +1052,8 @@ templates:
       volumes:
       - emptyDir:
         name: workload-socket
+      - emptyDir:
+        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:

--- a/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
@@ -987,8 +987,6 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
-        - name: credential-socket
-          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -1052,8 +1050,6 @@ templates:
       volumes:
       - emptyDir:
         name: workload-socket
-      - emptyDir:
-        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
@@ -382,6 +382,8 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
+        - name: credential-socket
+          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -429,6 +431,8 @@ templates:
       volumes:
       - emptyDir:
         name: workload-socket
+      - emptyDir:
+        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -640,6 +644,8 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
+        - name: credential-socket
+          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -672,6 +678,8 @@ templates:
       volumes:
       - emptyDir: {}
         name: workload-socket
+      - emptyDir: {}
+        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -979,6 +987,8 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
+        - name: credential-socket
+          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -1042,6 +1052,8 @@ templates:
       volumes:
       - emptyDir:
         name: workload-socket
+      - emptyDir:
+        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
@@ -987,8 +987,6 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
-        - name: credential-socket
-          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -1052,8 +1050,6 @@ templates:
       volumes:
       - emptyDir:
         name: workload-socket
-      - emptyDir:
-        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
@@ -382,6 +382,8 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
+        - name: credential-socket
+          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -429,6 +431,8 @@ templates:
       volumes:
       - emptyDir:
         name: workload-socket
+      - emptyDir:
+        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -640,6 +644,8 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
+        - name: credential-socket
+          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -672,6 +678,8 @@ templates:
       volumes:
       - emptyDir: {}
         name: workload-socket
+      - emptyDir: {}
+        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -979,6 +987,8 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
+        - name: credential-socket
+          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -1042,6 +1052,8 @@ templates:
       volumes:
       - emptyDir:
         name: workload-socket
+      - emptyDir:
+        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
@@ -987,8 +987,6 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
-        - name: credential-socket
-          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -1052,8 +1050,6 @@ templates:
       volumes:
       - emptyDir:
         name: workload-socket
-      - emptyDir:
-        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:

--- a/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
@@ -382,6 +382,8 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
+        - name: credential-socket
+          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -429,6 +431,8 @@ templates:
       volumes:
       - emptyDir:
         name: workload-socket
+      - emptyDir:
+        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -640,6 +644,8 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
+        - name: credential-socket
+          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -672,6 +678,8 @@ templates:
       volumes:
       - emptyDir: {}
         name: workload-socket
+      - emptyDir: {}
+        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -979,6 +987,8 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
+        - name: credential-socket
+          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -1042,6 +1052,8 @@ templates:
       volumes:
       - emptyDir:
         name: workload-socket
+      - emptyDir:
+        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:

--- a/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
@@ -987,8 +987,6 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
-        - name: credential-socket
-          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -1052,8 +1050,6 @@ templates:
       volumes:
       - emptyDir:
         name: workload-socket
-      - emptyDir:
-        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:

--- a/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
@@ -382,6 +382,8 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
+        - name: credential-socket
+          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -429,6 +431,8 @@ templates:
       volumes:
       - emptyDir:
         name: workload-socket
+      - emptyDir:
+        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -640,6 +644,8 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
+        - name: credential-socket
+          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -672,6 +678,8 @@ templates:
       volumes:
       - emptyDir: {}
         name: workload-socket
+      - emptyDir: {}
+        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -979,6 +987,8 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
+        - name: credential-socket
+          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -1042,6 +1052,8 @@ templates:
       volumes:
       - emptyDir:
         name: workload-socket
+      - emptyDir:
+        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:

--- a/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
@@ -987,8 +987,6 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
-        - name: credential-socket
-          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -1052,8 +1050,6 @@ templates:
       volumes:
       - emptyDir:
         name: workload-socket
-      - emptyDir:
-        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:

--- a/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
@@ -382,6 +382,8 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
+        - name: credential-socket
+          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -429,6 +431,8 @@ templates:
       volumes:
       - emptyDir:
         name: workload-socket
+      - emptyDir:
+        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -640,6 +644,8 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
+        - name: credential-socket
+          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -672,6 +678,8 @@ templates:
       volumes:
       - emptyDir: {}
         name: workload-socket
+      - emptyDir: {}
+        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -979,6 +987,8 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
+        - name: credential-socket
+          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -1042,6 +1052,8 @@ templates:
       volumes:
       - emptyDir:
         name: workload-socket
+      - emptyDir:
+        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:

--- a/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
@@ -987,8 +987,6 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
-        - name: credential-socket
-          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -1052,8 +1050,6 @@ templates:
       volumes:
       - emptyDir:
         name: workload-socket
-      - emptyDir:
-        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
@@ -382,6 +382,8 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
+        - name: credential-socket
+          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -429,6 +431,8 @@ templates:
       volumes:
       - emptyDir:
         name: workload-socket
+      - emptyDir:
+        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -640,6 +644,8 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
+        - name: credential-socket
+          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -672,6 +678,8 @@ templates:
       volumes:
       - emptyDir: {}
         name: workload-socket
+      - emptyDir: {}
+        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -979,6 +987,8 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
+        - name: credential-socket
+          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -1042,6 +1052,8 @@ templates:
       volumes:
       - emptyDir:
         name: workload-socket
+      - emptyDir:
+        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
@@ -987,8 +987,6 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
-        - name: credential-socket
-          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -1052,8 +1050,6 @@ templates:
       volumes:
       - emptyDir:
         name: workload-socket
-      - emptyDir:
-        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
@@ -382,6 +382,8 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
+        - name: credential-socket
+          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -429,6 +431,8 @@ templates:
       volumes:
       - emptyDir:
         name: workload-socket
+      - emptyDir:
+        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -640,6 +644,8 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
+        - name: credential-socket
+          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -672,6 +678,8 @@ templates:
       volumes:
       - emptyDir: {}
         name: workload-socket
+      - emptyDir: {}
+        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -979,6 +987,8 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
+        - name: credential-socket
+          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -1042,6 +1052,8 @@ templates:
       volumes:
       - emptyDir:
         name: workload-socket
+      - emptyDir:
+        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
@@ -987,8 +987,6 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
-        - name: credential-socket
-          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -1052,8 +1050,6 @@ templates:
       volumes:
       - emptyDir:
         name: workload-socket
-      - emptyDir:
-        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
@@ -382,6 +382,8 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
+        - name: credential-socket
+          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -429,6 +431,8 @@ templates:
       volumes:
       - emptyDir:
         name: workload-socket
+      - emptyDir:
+        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -640,6 +644,8 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
+        - name: credential-socket
+          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -672,6 +678,8 @@ templates:
       volumes:
       - emptyDir: {}
         name: workload-socket
+      - emptyDir: {}
+        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -979,6 +987,8 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
+        - name: credential-socket
+          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -1042,6 +1052,8 @@ templates:
       volumes:
       - emptyDir:
         name: workload-socket
+      - emptyDir:
+        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
@@ -987,8 +987,6 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
-        - name: credential-socket
-          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -1052,8 +1050,6 @@ templates:
       volumes:
       - emptyDir:
         name: workload-socket
-      - emptyDir:
-        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
@@ -382,6 +382,8 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
+        - name: credential-socket
+          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -429,6 +431,8 @@ templates:
       volumes:
       - emptyDir:
         name: workload-socket
+      - emptyDir:
+        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -640,6 +644,8 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
+        - name: credential-socket
+          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -672,6 +678,8 @@ templates:
       volumes:
       - emptyDir: {}
         name: workload-socket
+      - emptyDir: {}
+        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -979,6 +987,8 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
+        - name: credential-socket
+          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -1042,6 +1052,8 @@ templates:
       volumes:
       - emptyDir:
         name: workload-socket
+      - emptyDir:
+        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
@@ -987,8 +987,6 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
-        - name: credential-socket
-          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -1052,8 +1050,6 @@ templates:
       volumes:
       - emptyDir:
         name: workload-socket
-      - emptyDir:
-        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
@@ -382,6 +382,8 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
+        - name: credential-socket
+          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -429,6 +431,8 @@ templates:
       volumes:
       - emptyDir:
         name: workload-socket
+      - emptyDir:
+        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -640,6 +644,8 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
+        - name: credential-socket
+          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -672,6 +678,8 @@ templates:
       volumes:
       - emptyDir: {}
         name: workload-socket
+      - emptyDir: {}
+        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -979,6 +987,8 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
+        - name: credential-socket
+          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -1042,6 +1052,8 @@ templates:
       volumes:
       - emptyDir:
         name: workload-socket
+      - emptyDir:
+        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
@@ -987,8 +987,6 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
-        - name: credential-socket
-          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -1052,8 +1050,6 @@ templates:
       volumes:
       - emptyDir:
         name: workload-socket
-      - emptyDir:
-        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
@@ -382,6 +382,8 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
+        - name: credential-socket
+          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -429,6 +431,8 @@ templates:
       volumes:
       - emptyDir:
         name: workload-socket
+      - emptyDir:
+        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -640,6 +644,8 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
+        - name: credential-socket
+          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -672,6 +678,8 @@ templates:
       volumes:
       - emptyDir: {}
         name: workload-socket
+      - emptyDir: {}
+        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -979,6 +987,8 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
+        - name: credential-socket
+          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -1042,6 +1052,8 @@ templates:
       volumes:
       - emptyDir:
         name: workload-socket
+      - emptyDir:
+        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
@@ -987,8 +987,6 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
-        - name: credential-socket
-          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -1052,8 +1050,6 @@ templates:
       volumes:
       - emptyDir:
         name: workload-socket
-      - emptyDir:
-        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
@@ -382,6 +382,8 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
+        - name: credential-socket
+          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -429,6 +431,8 @@ templates:
       volumes:
       - emptyDir:
         name: workload-socket
+      - emptyDir:
+        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -640,6 +644,8 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
+        - name: credential-socket
+          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -672,6 +678,8 @@ templates:
       volumes:
       - emptyDir: {}
         name: workload-socket
+      - emptyDir: {}
+        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -979,6 +987,8 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
+        - name: credential-socket
+          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -1042,6 +1052,8 @@ templates:
       volumes:
       - emptyDir:
         name: workload-socket
+      - emptyDir:
+        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
@@ -987,8 +987,6 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
-        - name: credential-socket
-          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -1052,8 +1050,6 @@ templates:
       volumes:
       - emptyDir:
         name: workload-socket
-      - emptyDir:
-        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
@@ -382,6 +382,8 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
+        - name: credential-socket
+          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -429,6 +431,8 @@ templates:
       volumes:
       - emptyDir:
         name: workload-socket
+      - emptyDir:
+        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -640,6 +644,8 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
+        - name: credential-socket
+          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -672,6 +678,8 @@ templates:
       volumes:
       - emptyDir: {}
         name: workload-socket
+      - emptyDir: {}
+        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -979,6 +987,8 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
+        - name: credential-socket
+          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -1042,6 +1052,8 @@ templates:
       volumes:
       - emptyDir:
         name: workload-socket
+      - emptyDir:
+        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
@@ -987,8 +987,6 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
-        - name: credential-socket
-          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -1052,8 +1050,6 @@ templates:
       volumes:
       - emptyDir:
         name: workload-socket
-      - emptyDir:
-        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
@@ -382,6 +382,8 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
+        - name: credential-socket
+          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -429,6 +431,8 @@ templates:
       volumes:
       - emptyDir:
         name: workload-socket
+      - emptyDir:
+        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -640,6 +644,8 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
+        - name: credential-socket
+          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -672,6 +678,8 @@ templates:
       volumes:
       - emptyDir: {}
         name: workload-socket
+      - emptyDir: {}
+        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -979,6 +987,8 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
+        - name: credential-socket
+          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -1042,6 +1052,8 @@ templates:
       volumes:
       - emptyDir:
         name: workload-socket
+      - emptyDir:
+        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
@@ -987,8 +987,6 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
-        - name: credential-socket
-          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -1052,8 +1050,6 @@ templates:
       volumes:
       - emptyDir:
         name: workload-socket
-      - emptyDir:
-        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:

--- a/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
@@ -382,6 +382,8 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
+        - name: credential-socket
+          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -429,6 +431,8 @@ templates:
       volumes:
       - emptyDir:
         name: workload-socket
+      - emptyDir:
+        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -640,6 +644,8 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
+        - name: credential-socket
+          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -672,6 +678,8 @@ templates:
       volumes:
       - emptyDir: {}
         name: workload-socket
+      - emptyDir: {}
+        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -979,6 +987,8 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
+        - name: credential-socket
+          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -1042,6 +1052,8 @@ templates:
       volumes:
       - emptyDir:
         name: workload-socket
+      - emptyDir:
+        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:

--- a/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
@@ -987,8 +987,6 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
-        - name: credential-socket
-          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -1052,8 +1050,6 @@ templates:
       volumes:
       - emptyDir:
         name: workload-socket
-      - emptyDir:
-        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:

--- a/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
@@ -382,6 +382,8 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
+        - name: credential-socket
+          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -429,6 +431,8 @@ templates:
       volumes:
       - emptyDir:
         name: workload-socket
+      - emptyDir:
+        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -640,6 +644,8 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
+        - name: credential-socket
+          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -672,6 +678,8 @@ templates:
       volumes:
       - emptyDir: {}
         name: workload-socket
+      - emptyDir: {}
+        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -979,6 +987,8 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
+        - name: credential-socket
+          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -1042,6 +1052,8 @@ templates:
       volumes:
       - emptyDir:
         name: workload-socket
+      - emptyDir:
+        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:

--- a/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
@@ -987,8 +987,6 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
-        - name: credential-socket
-          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -1052,8 +1050,6 @@ templates:
       volumes:
       - emptyDir:
         name: workload-socket
-      - emptyDir:
-        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:

--- a/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
@@ -382,6 +382,8 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
+        - name: credential-socket
+          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -429,6 +431,8 @@ templates:
       volumes:
       - emptyDir:
         name: workload-socket
+      - emptyDir:
+        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -640,6 +644,8 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
+        - name: credential-socket
+          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -672,6 +678,8 @@ templates:
       volumes:
       - emptyDir: {}
         name: workload-socket
+      - emptyDir: {}
+        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -979,6 +987,8 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
+        - name: credential-socket
+          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -1042,6 +1052,8 @@ templates:
       volumes:
       - emptyDir:
         name: workload-socket
+      - emptyDir:
+        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:

--- a/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
@@ -987,8 +987,6 @@ templates:
         volumeMounts:
         - name: workload-socket
           mountPath: /var/run/secrets/workload-spiffe-uds
-        - name: credential-socket
-          mountPath: /var/run/secrets/credential-uds
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -1052,8 +1050,6 @@ templates:
       volumes:
       - emptyDir:
         name: workload-socket
-      - emptyDir:
-        name: credential-socket
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:

--- a/pkg/security/security.go
+++ b/pkg/security/security.go
@@ -45,6 +45,18 @@ const (
 	// WorkloadIdentitySocketPath is the well-known path to the Unix Domain Socket for SDS.
 	WorkloadIdentitySocketPath = "./var/run/secrets/workload-spiffe-uds/socket"
 
+	// CredentialNameSocketPath is the well-known path to the Unix Domain Socket for Credential Name.
+	CredentialNameSocketPath = "./var/run/secrets/credential-uds/socket"
+
+	// CredentialMetaDataName is the name in node meta data.
+	CredentialMetaDataName = "credential"
+
+	// SDSExternalClusterName is the name of the cluster for external SDS connections which is defined via CredentialNameSocketPath
+	SDSExternalClusterName = "sds-external"
+
+	// SDSExternalCredentialPrefix is the prefix for the credentialName which will utilize external SDS connections defined via CredentialNameSocketPath
+	SDSExternalCredentialPrefix = "sds://"
+
 	// WorkloadIdentityCredentialsPath is the well-known path to a folder with workload certificate files.
 	WorkloadIdentityCredentialsPath = "./var/run/secrets/workload-spiffe-credentials"
 


### PR DESCRIPTION
- add a well know credential uds socket path to to allow plug in external UDS SDS server
- create a static cluster if the credential uds socket exists
- if credential is named as sds://xxxx  and the credential uds socket exists it will use the external SDS server. otherwise, follow original flow