### PR TITLE
separate webhook patching from namespace controller

### DIFF
--- a/pilot/pkg/leaderelection/leaderelection.go
+++ b/pilot/pkg/leaderelection/leaderelection.go
@@ -37,6 +37,7 @@ import (
 // Various locks used throughout the code
 const (
 	NamespaceController     = "istio-namespace-controller-election"
+	WebhookPatcher          = "istio-webhook-patcher-election"
 	ServiceExportController = "istio-serviceexport-controller-election"
 	// This holds the legacy name to not conflict with older control plane deployments which are just
 	// doing the ingress syncing.

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -218,28 +218,36 @@ func (m *Multicluster) ClusterAdded(cluster *multicluster.Cluster, clusterStopCh
 					client.RunAndWait(clusterStopCh)
 					nc.Run(leaderStop)
 				})
-			// Set up injection webhook patching for remote clusters we are controlling.
-			// The local cluster has this patching set up elsewhere. We may eventually want to move it here.
-			if features.ExternalIstiod && !localCluster && m.caBundleWatcher != nil {
-				// Patch injection webhook cert
-				// This requires RBAC permissions - a low-priv Istiod should not attempt to patch but rely on
-				// operator or CI/CD
-				if features.InjectionWebhookConfigName != "" {
-					election = election.
-						AddRunFunction(func(leaderStop <-chan struct{}) {
-							log.Infof("initializing webhook cert patch for cluster %s", cluster.ID)
-							patcher, err := webhooks.NewWebhookCertPatcher(client, m.revision, webhookName, m.caBundleWatcher)
-							if err != nil {
-								log.Errorf("could not initialize webhook cert patcher: %v", err)
-							} else {
-								patcher.Run(leaderStop)
-							}
-						})
-				}
-			}
 			election.Run(clusterStopCh)
 			return nil
 		})
+	}
+	// Set up injection webhook patching for remote clusters we are controlling.
+	// The local cluster has this patching set up elsewhere. We may eventually want to move it here.
+	if features.ExternalIstiod && !localCluster && m.caBundleWatcher != nil {
+		// Patch injection webhook cert
+		// This requires RBAC permissions - a low-priv Istiod should not attempt to patch but rely on
+		// operator or CI/CD
+		if features.InjectionWebhookConfigName != "" {
+			// Block server exit on graceful termination of the leader controller.
+			m.s.RunComponentAsyncAndWait(func(_ <-chan struct{}) error {
+				log.Infof("joining leader-election for %s in %s on cluster %s",
+					leaderelection.WebhookPatcher, options.SystemNamespace, options.ClusterID)
+				election := leaderelection.
+					NewLeaderElectionMulticluster(options.SystemNamespace, m.serverID, leaderelection.WebhookPatcher, m.revision, !localCluster, client).
+					AddRunFunction(func(leaderStop <-chan struct{}) {
+						log.Infof("initializing webhook cert patch for cluster %s", cluster.ID)
+						patcher, err := webhooks.NewWebhookCertPatcher(client, m.revision, webhookName, m.caBundleWatcher)
+						if err != nil {
+							log.Errorf("could not initialize webhook cert patcher: %v", err)
+						} else {
+							patcher.Run(leaderStop)
+						}
+					})
+				election.Run(clusterStopCh)
+				return nil
+			})
+		}
 	}
 
 	// setting up the serviceexport controller if and only if it is turned on in the meshconfig.


### PR DESCRIPTION
Namespace controller is an optional component only started when kubernetes CA is used but webhook patching is needed in all cases.
https://github.com/istio/istio/pull/38283 combined both of them. 

This PR fixes it.

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure