### PR TITLE
[tf] Limit number of test dumps

### DIFF
--- a/pkg/test/framework/resource/flags.go
+++ b/pkg/test/framework/resource/flags.go
@@ -179,4 +179,7 @@ func init() {
 	flag.StringVar(&settingsFromCommandLine.Image.PullSecret, "istio.test.imagePullSecret", settingsFromCommandLine.Image.PullSecret,
 		"Path to a file containing a DockerConfig secret use for test apps. This will be pushed to all created namespaces."+
 			"Secret should already exist when used with istio.test.stableNamespaces.")
+
+	flag.Uint64Var(&settingsFromCommandLine.MaxDumps, "istio.test.maxDumps", settingsFromCommandLine.MaxDumps,
+		"Maximum number of full test dumps that are allowed to occur within a test suite.")
 }

--- a/pkg/test/framework/resource/settings.go
+++ b/pkg/test/framework/resource/settings.go
@@ -153,6 +153,9 @@ type Settings struct {
 
 	// EchoImage is the app image to be used by echo deployments.
 	EchoImage string
+
+	// MaxDumps is the maximum number of full test dumps that are allowed to occur within a test suite.
+	MaxDumps uint64
 }
 
 func (s Settings) Skip(class string) bool {
@@ -186,7 +189,8 @@ func (s *Settings) Clone() *Settings {
 // DefaultSettings returns a default settings instance.
 func DefaultSettings() *Settings {
 	return &Settings{
-		RunID: uuid.New(),
+		RunID:    uuid.New(),
+		MaxDumps: 10,
 	}
 }
 
@@ -211,6 +215,7 @@ func (s *Settings) String() string {
 	result += fmt.Sprintf("Tag:               %s\n", s.Image.Tag)
 	result += fmt.Sprintf("PullPolicy:        %s\n", s.Image.PullPolicy)
 	result += fmt.Sprintf("PullSecret:        %s\n", s.Image.PullSecret)
+	result += fmt.Sprintf("MaxDumps:          %d\n", s.MaxDumps)
 	return result
 }
 

--- a/pkg/test/framework/runtime.go
+++ b/pkg/test/framework/runtime.go
@@ -41,11 +41,12 @@ func newRuntime(s *resource.Settings, fn resource.EnvironmentFactory, labels lab
 
 // Dump state for all allocated resources.
 func (i *runtime) Dump(ctx resource.Context) {
-	i.context.globalScope.dump(ctx, true)
+	i.DumpCustom(ctx, true)
 }
 
-func (i *runtime) DumpShallow(ctx resource.Context) {
-	i.context.globalScope.dump(ctx, false)
+// DumpCustom provides custom control over how the global scope is dumped.
+func (i *runtime) DumpCustom(ctx resource.Context, recursive bool) {
+	i.context.globalScope.dump(ctx, recursive)
 }
 
 // suiteContext returns the suiteContext.

--- a/pkg/test/framework/suitecontext.go
+++ b/pkg/test/framework/suitecontext.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"sync"
 
+	"go.uber.org/atomic"
 	"sigs.k8s.io/yaml"
 
 	"istio.io/istio/pkg/test/framework/components/cluster"
@@ -63,6 +64,8 @@ type suiteContext struct {
 	outcomeMu    sync.RWMutex
 	testOutcomes []TestOutcome
 
+	dumpCount *atomic.Uint64
+
 	traces sync.Map
 }
 
@@ -80,6 +83,7 @@ func newSuiteContext(s *resource.Settings, envFn resource.EnvironmentFactory, la
 		FileWriter:   yml.NewFileWriter(workDir),
 		suiteLabels:  labels,
 		contextNames: sets.New(),
+		dumpCount:    atomic.NewUint64(0),
 	}
 
 	env, err := envFn(c)
@@ -219,6 +223,13 @@ func (c *suiteContext) ConfigKube(clusters ...cluster.Cluster) config.Factory {
 
 func (c *suiteContext) ConfigIstio() config.Factory {
 	return newConfigFactory(c, c.Clusters().Configs())
+}
+
+// RequestTestDump is called by the test context for a failed test to request a full
+// dump of the system state. Returns true if the dump may proceed, or false if the
+// maximum number of dumps has been exceeded for this suite.
+func (c *suiteContext) RequestTestDump() bool {
+	return c.dumpCount.Inc() < c.settings.MaxDumps
 }
 
 type Outcome string

--- a/pkg/test/framework/testcontext.go
+++ b/pkg/test/framework/testcontext.go
@@ -286,13 +286,21 @@ func (c *testContext) CleanupStrategy(strategy cleanup.Strategy, fn func()) {
 	}
 }
 
-func (c *testContext) close() {
-	if c.Failed() && c.Settings().CIMode {
+func (c *testContext) dump() {
+	if c.suite.RequestTestDump() {
 		scopes.Framework.Debugf("Begin dumping testContext: %q", c.id)
 		// make sure we dump suite-level resources, but don't dump sibling tests or their children
-		rt.DumpShallow(c)
+		rt.DumpCustom(c, false)
 		c.scope.dump(c, true)
 		scopes.Framework.Debugf("Completed dumping testContext: %q", c.id)
+	} else {
+		scopes.Framework.Debugf("Begin skipping dump of testContext: %q. Maximum number of test dumps exceeded", c.id)
+	}
+}
+
+func (c *testContext) close() {
+	if c.Failed() && c.Settings().CIMode {
+		c.dump()
 	}
 
 	scopes.Framework.Debugf("Begin cleaning up testContext: %q", c.id)


### PR DESCRIPTION
When a suite has a lot of tests and there is some change that causes a number of tests to fail, the test output can be so large that prow will fail to show the results.

This PR limits the maximum number of test dumps allowed per test suite to 10 by default (settable via a new flag).

**Please provide a description of this PR:**