### PR TITLE
[BugFix] WasmPlugin: Call forwardToEnvoy in the same thread

### DIFF
--- a/pkg/istio-agent/xds_proxy.go
+++ b/pkg/istio-agent/xds_proxy.go
@@ -533,7 +533,7 @@ func (p *XdsProxy) handleUpstreamResponse(con *ProxyConnection) {
 						// to prevent concurrent access to forwardToEnvoy
 						select {
 						case forwardEnvoyCh <- resp:
-							proxyLog.Infof("wasm send resp to forwardEnvoCh: %v", resp.TypeUrl)
+							proxyLog.Debugf("wasm send response: %v", resp.TypeUrl)
 						case <-con.stopChan:
 						}
 					})

--- a/pkg/istio-agent/xds_proxy.go
+++ b/pkg/istio-agent/xds_proxy.go
@@ -494,6 +494,7 @@ func (p *XdsProxy) handleUpstreamRequest(con *ProxyConnection) {
 }
 
 func (p *XdsProxy) handleUpstreamResponse(con *ProxyConnection) {
+	forwardEnvoyCh := make(chan *discovery.DiscoveryResponse, 1)
 	for {
 		select {
 		case resp := <-con.responsesChan:
@@ -527,7 +528,15 @@ func (p *XdsProxy) handleUpstreamResponse(con *ProxyConnection) {
 			case v3.ExtensionConfigurationType:
 				if features.WasmRemoteLoadConversion {
 					// If Wasm remote load conversion feature is enabled, rewrite and send.
-					go p.rewriteAndForward(con, resp)
+					go p.rewriteAndForward(con, resp, func(resp *discovery.DiscoveryResponse) {
+						// Forward the response using the thread of `handleUpstreamResponse`
+						// to prevent concurrent access to forwardToEnvoy
+						select {
+						case forwardEnvoyCh <- resp:
+							proxyLog.Infof("wasm send resp to forwardEnvoCh: %v", resp.TypeUrl)
+						case <-con.stopChan:
+						}
+					})
 				} else {
 					// Otherwise, forward ECDS resource update directly to Envoy.
 					forwardToEnvoy(con, resp)
@@ -539,13 +548,15 @@ func (p *XdsProxy) handleUpstreamResponse(con *ProxyConnection) {
 					forwardToEnvoy(con, resp)
 				}
 			}
+		case resp := <-forwardEnvoyCh:
+			forwardToEnvoy(con, resp)
 		case <-con.stopChan:
 			return
 		}
 	}
 }
 
-func (p *XdsProxy) rewriteAndForward(con *ProxyConnection, resp *discovery.DiscoveryResponse) {
+func (p *XdsProxy) rewriteAndForward(con *ProxyConnection, resp *discovery.DiscoveryResponse, forward func(resp *discovery.DiscoveryResponse)) {
 	sendNack := wasm.MaybeConvertWasmExtensionConfig(resp.Resources, p.wasmCache)
 	if sendNack {
 		proxyLog.Debugf("sending NACK for ECDS resources %+v", resp.Resources)
@@ -561,7 +572,7 @@ func (p *XdsProxy) rewriteAndForward(con *ProxyConnection, resp *discovery.Disco
 		return
 	}
 	proxyLog.Debugf("forward ECDS resources %+v", resp.Resources)
-	forwardToEnvoy(con, resp)
+	forward(resp)
 }
 
 func (p *XdsProxy) forwardToTap(resp *discovery.DiscoveryResponse) {


### PR DESCRIPTION
This PR prevent using `forwardToEnvoy` function in multiple threads.

Potentially, calling from multiple threads may cause blocking the loop in `handleUpstreamResponse`.

In details, as commented in https://github.com/grpc/grpc-go/blob/e41f868588c99493b35169e258a11b2ce128e139/stream.go#L1416-L1418, we should not call `SendMsg`, which is called by `forwardToEnvoy` at last, in multiple threads.

This fixes the second/third issues in https://github.com/istio/istio/issues/39063 .

