### PR TITLE
rm EXTERNAL_ISTIOD

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -382,9 +382,6 @@ var (
 	ClusterName = env.RegisterStringVar("CLUSTER_ID", "Kubernetes",
 		"Defines the cluster and service registry that this Istiod instance is belongs to").Get()
 
-	ExternalIstiod = env.RegisterBoolVar("EXTERNAL_ISTIOD", true,
-		"If this is set to true, one Istiod will control remote clusters including CA.").Get()
-
 	EnableCAServer = env.RegisterBoolVar("ENABLE_CA_SERVER", true,
 		"If this is set to false, will not create CA server in istiod.").Get()
 

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -200,7 +200,7 @@ func (m *Multicluster) ClusterAdded(cluster *multicluster.Cluster, clusterStopCh
 	// run after WorkloadHandler is added
 	m.opts.MeshServiceController.AddRegistryAndRun(kubeRegistry, clusterStopCh)
 
-	if m.startNsController && (features.ExternalIstiod || localCluster) {
+	if m.startNsController && localCluster {
 		// Block server exit on graceful termination of the leader controller.
 		m.s.RunComponentAsyncAndWait(func(_ <-chan struct{}) error {
 			log.Infof("joining leader-election for %s in %s on cluster %s",
@@ -224,7 +224,7 @@ func (m *Multicluster) ClusterAdded(cluster *multicluster.Cluster, clusterStopCh
 	}
 	// Set up injection webhook patching for remote clusters we are controlling.
 	// The local cluster has this patching set up elsewhere. We may eventually want to move it here.
-	if features.ExternalIstiod && !localCluster && m.caBundleWatcher != nil {
+	if !localCluster && m.caBundleWatcher != nil {
 		// Patch injection webhook cert
 		// This requires RBAC permissions - a low-priv Istiod should not attempt to patch but rely on
 		// operator or CI/CD

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster_test.go
@@ -132,7 +132,6 @@ func Test_KubeSecretController(t *testing.T) {
 }
 
 func Test_KubeSecretController_ExternalIstiod_MultipleClusters(t *testing.T) {
-	test.SetBoolForTest(t, &features.ExternalIstiod, true)
 	test.SetStringForTest(t, &features.InjectionWebhookConfigName, "")
 	clientset := kube.NewFakeClient()
 	multicluster.BuildClientsFromConfig = func(kubeConfig []byte) (kube.Client, error) {


### PR DESCRIPTION
**Please provide a description of this PR:**

The env was used to distinguish external istiod, however, it is now not needed as the external istiod is almost same as other models.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
