### PR TITLE
add logging flags to istio-init container template

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -321,6 +321,10 @@ data:
             - "-k"
             - "{{ index .ObjectMeta.Annotations `traffic.sidecar.istio.io/kubevirtInterfaces` }}"
             {{ end -}}
+            - "--log_output_level={{ annotation .ObjectMeta `sidecar.istio.io/agentLogLevel` .Values.global.logging.level }}"
+            {{ if .Values.global.logAsJson -}}
+            - "--log_as_json"
+            {{ end -}}
             {{ if .Values.istio_cni.enabled -}}
             - "--run-validation"
             - "--skip-rule-apply"

--- a/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
@@ -106,6 +106,10 @@ spec:
     - "-k"
     - "{{ index .ObjectMeta.Annotations `traffic.sidecar.istio.io/kubevirtInterfaces` }}"
     {{ end -}}
+    - "--log_output_level={{ annotation .ObjectMeta `sidecar.istio.io/agentLogLevel` .Values.global.logging.level }}"
+    {{ if .Values.global.logAsJson -}}
+    - "--log_as_json"
+    {{ end -}}
     {{ if .Values.istio_cni.enabled -}}
     - "--run-validation"
     - "--skip-rule-apply"

--- a/manifests/charts/istiod-remote/files/injection-template.yaml
+++ b/manifests/charts/istiod-remote/files/injection-template.yaml
@@ -106,6 +106,10 @@ spec:
     - "-k"
     - "{{ index .ObjectMeta.Annotations `traffic.sidecar.istio.io/kubevirtInterfaces` }}"
     {{ end -}}
+    - "--log_output_level={{ annotation .ObjectMeta `sidecar.istio.io/agentLogLevel` .Values.global.logging.level }}"
+    {{ if .Values.global.logAsJson -}}
+    - "--log_as_json"
+    {{ end -}}
     {{ if .Values.istio_cni.enabled -}}
     - "--run-validation"
     - "--skip-rule-apply"

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.golden.yaml
@@ -1744,10 +1744,6 @@ data:
             - "-k"
             - "{{ index .ObjectMeta.Annotations `traffic.sidecar.istio.io/kubevirtInterfaces` }}"
             {{ end -}}
-            - "--log_output_level={{ annotation .ObjectMeta `sidecar.istio.io/agentLogLevel` .Values.global.logging.level }}"
-            {{ if .Values.global.logAsJson -}}
-            - "--log_as_json"
-            {{ end -}}
             {{ if .Values.istio_cni.enabled -}}
             - "--run-validation"
             - "--skip-rule-apply"

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.golden.yaml
@@ -1744,6 +1744,10 @@ data:
             - "-k"
             - "{{ index .ObjectMeta.Annotations `traffic.sidecar.istio.io/kubevirtInterfaces` }}"
             {{ end -}}
+            - "--log_output_level={{ annotation .ObjectMeta `sidecar.istio.io/agentLogLevel` .Values.global.logging.level }}"
+            {{ if .Values.global.logAsJson -}}
+            - "--log_as_json"
+            {{ end -}}
             {{ if .Values.istio_cni.enabled -}}
             - "--run-validation"
             - "--skip-rule-apply"

--- a/operator/cmd/mesh/testdata/manifest-generate/output/sidecar_template.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/sidecar_template.golden.yaml
@@ -276,10 +276,6 @@ data:
             - "-k"
             - "{{ index .ObjectMeta.Annotations `traffic.sidecar.istio.io/kubevirtInterfaces` }}"
             {{ end -}}
-            - "--log_output_level={{ annotation .ObjectMeta `sidecar.istio.io/agentLogLevel` .Values.global.logging.level }}"
-            {{ if .Values.global.logAsJson -}}
-            - "--log_as_json"
-            {{ end -}}
             {{ if .Values.istio_cni.enabled -}}
             - "--run-validation"
             - "--skip-rule-apply"

--- a/operator/cmd/mesh/testdata/manifest-generate/output/sidecar_template.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/sidecar_template.golden.yaml
@@ -276,6 +276,10 @@ data:
             - "-k"
             - "{{ index .ObjectMeta.Annotations `traffic.sidecar.istio.io/kubevirtInterfaces` }}"
             {{ end -}}
+            - "--log_output_level={{ annotation .ObjectMeta `sidecar.istio.io/agentLogLevel` .Values.global.logging.level }}"
+            {{ if .Values.global.logAsJson -}}
+            - "--log_as_json"
+            {{ end -}}
             {{ if .Values.istio_cni.enabled -}}
             - "--run-validation"
             - "--skip-rule-apply"

--- a/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
@@ -160,6 +160,7 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        - --log_output_level=default:info
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/auth.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/auth.yaml.injected
@@ -160,6 +160,7 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        - --log_output_level=default:info
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
@@ -154,6 +154,7 @@ spec:
             - '*'
             - -d
             - 15090,15021,15020
+            - --log_output_level=default:info
             image: gcr.io/istio-testing/proxyv2:latest
             name: istio-init
             resources:

--- a/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
@@ -158,6 +158,7 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        - --log_output_level=default:info
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/deploymentconfig-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/deploymentconfig-multi.yaml.injected
@@ -173,6 +173,7 @@ items:
           - '*'
           - -d
           - 15090,15021,15020
+          - --log_output_level=default:info
           image: gcr.io/istio-testing/proxyv2:latest
           name: istio-init
           resources:

--- a/pkg/kube/inject/testdata/inject/deploymentconfig-with-canonical-service-label.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/deploymentconfig-with-canonical-service-label.yaml.injected
@@ -158,6 +158,7 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        - --log_output_level=default:info
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/deploymentconfig.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/deploymentconfig.yaml.injected
@@ -158,6 +158,7 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        - --log_output_level=default:info
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/enable-core-dump-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/enable-core-dump-annotation.yaml.injected
@@ -161,6 +161,7 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        - --log_output_level=default:info
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
@@ -160,6 +160,7 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        - --log_output_level=default:info
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/explicit-security-context.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/explicit-security-context.yaml.injected
@@ -151,6 +151,7 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        - --log_output_level=default:info
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
@@ -160,6 +160,7 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        - --log_output_level=default:info
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/frontend.yaml.injected
@@ -177,6 +177,7 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        - --log_output_level=default:info
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
@@ -161,6 +161,7 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        - --log_output_level=default:info
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/hello-cncf-networks.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-cncf-networks.yaml.injected
@@ -165,6 +165,7 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        - --log_output_level=default:info
         - --run-validation
         - --skip-rule-apply
         image: gcr.io/istio-testing/proxyv2:latest

--- a/pkg/kube/inject/testdata/inject/hello-existing-cncf-networks-json.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-existing-cncf-networks-json.yaml.injected
@@ -165,6 +165,7 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        - --log_output_level=default:info
         - --run-validation
         - --skip-rule-apply
         image: gcr.io/istio-testing/proxyv2:latest

--- a/pkg/kube/inject/testdata/inject/hello-existing-cncf-networks.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-existing-cncf-networks.yaml.injected
@@ -165,6 +165,7 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        - --log_output_level=default:info
         - --run-validation
         - --skip-rule-apply
         image: gcr.io/istio-testing/proxyv2:latest

--- a/pkg/kube/inject/testdata/inject/hello-image-pull-secret.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-image-pull-secret.yaml.injected
@@ -162,6 +162,7 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        - --log_output_level=default:info
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/hello-image-secrets-in-values.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-image-secrets-in-values.yaml.injected
@@ -162,6 +162,7 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        - --log_output_level=default:info
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/hello-mount-mtls-certs.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-mount-mtls-certs.yaml.injected
@@ -163,6 +163,7 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        - --log_output_level=default:info
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/hello-mtls-not-ready.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-mtls-not-ready.yaml.injected
@@ -160,6 +160,7 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        - --log_output_level=default:info
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
@@ -162,6 +162,7 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        - --log_output_level=default:info
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:
@@ -379,6 +380,7 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        - --log_output_level=default:info
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/hello-multiple-image-secrets.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-multiple-image-secrets.yaml.injected
@@ -163,6 +163,7 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        - --log_output_level=default:info
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/hello-namespace.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-namespace.yaml.injected
@@ -161,6 +161,7 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        - --log_output_level=default:info
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
@@ -161,6 +161,7 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        - --log_output_level=default:info
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Never
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/hello-no-seccontext.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-no-seccontext.yaml.injected
@@ -160,6 +160,7 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        - --log_output_level=default:info
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.injected
@@ -193,6 +193,7 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        - --log_output_level=default:info
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/hello-probes-proxyHoldApplication-ProxyConfig.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-probes-proxyHoldApplication-ProxyConfig.yaml.injected
@@ -193,6 +193,7 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        - --log_output_level=default:info
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/hello-probes-with-flag-set-in-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-probes-with-flag-set-in-annotation.yaml.injected
@@ -187,6 +187,7 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        - --log_output_level=default:info
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/hello-probes-with-flag-unset-in-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-probes-with-flag-unset-in-annotation.yaml.injected
@@ -182,6 +182,7 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        - --log_output_level=default:info
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/hello-probes.proxyHoldsApplication.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-probes.proxyHoldsApplication.yaml.injected
@@ -192,6 +192,7 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        - --log_output_level=default:info
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/hello-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-probes.yaml.injected
@@ -186,6 +186,7 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        - --log_output_level=default:info
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
@@ -161,6 +161,7 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        - --log_output_level=default:info
         image: docker.io/istio/proxy2_debug:unittest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/hello-readiness.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-readiness.yaml.injected
@@ -166,6 +166,7 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        - --log_output_level=default:info
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/hello-template-in-values.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-template-in-values.yaml.injected
@@ -160,6 +160,7 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        - --log_output_level=default:info
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
@@ -162,6 +162,7 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        - --log_output_level=default:info
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/hello.proxyHoldsApplication.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello.proxyHoldsApplication.yaml.injected
@@ -166,6 +166,7 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        - --log_output_level=default:info
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/hello.yaml.cni.injected
+++ b/pkg/kube/inject/testdata/inject/hello.yaml.cni.injected
@@ -167,6 +167,7 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        - --log_output_level=default:info
         - --run-validation
         - --skip-rule-apply
         image: gcr.io/istio-testing/proxyv2:latest

--- a/pkg/kube/inject/testdata/inject/hello.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello.yaml.injected
@@ -160,6 +160,7 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        - --log_output_level=default:info
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/hello.yaml.proxyImageName.injected
+++ b/pkg/kube/inject/testdata/inject/hello.yaml.proxyImageName.injected
@@ -160,6 +160,7 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        - --log_output_level=default:info
         image: gcr.io/istio-testing/proxyTest:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/https-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/https-probes.yaml.injected
@@ -187,6 +187,7 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        - --log_output_level=default:info
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/job.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/job.yaml.injected
@@ -152,6 +152,7 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        - --log_output_level=default:info
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml.injected
@@ -163,6 +163,7 @@ spec:
         - 15090,15021,123
         - -k
         - net1
+        - --log_output_level=default:info
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml.injected
@@ -163,6 +163,7 @@ spec:
         - 15090,15021,15020
         - -k
         - net1,net2
+        - --log_output_level=default:info
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
@@ -178,6 +178,7 @@ items:
           - '*'
           - -d
           - 15090,15021,15020
+          - --log_output_level=default:info
           image: gcr.io/istio-testing/proxyv2:latest
           name: istio-init
           resources:

--- a/pkg/kube/inject/testdata/inject/list.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/list.yaml.injected
@@ -164,6 +164,7 @@ items:
           - '*'
           - -d
           - 15090,15021,15020
+          - --log_output_level=default:info
           image: gcr.io/istio-testing/proxyv2:latest
           name: istio-init
           resources:
@@ -380,6 +381,7 @@ items:
           - '*'
           - -d
           - 15090,15021,15020
+          - --log_output_level=default:info
           image: gcr.io/istio-testing/proxyv2:latest
           name: istio-init
           resources:

--- a/pkg/kube/inject/testdata/inject/multi-container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/multi-container.yaml.injected
@@ -162,6 +162,7 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        - --log_output_level=default:info
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
@@ -174,6 +174,7 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        - --log_output_level=default:info
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/multiple-templates.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/multiple-templates.yaml.injected
@@ -153,6 +153,7 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        - --log_output_level=default:info
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/named_port.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/named_port.yaml.injected
@@ -166,6 +166,7 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        - --log_output_level=default:info
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/one_container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/one_container.yaml.injected
@@ -170,6 +170,7 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        - --log_output_level=default:info
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/only-proxy-container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/only-proxy-container.yaml.injected
@@ -146,6 +146,7 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        - --log_output_level=default:info
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/pod.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/pod.yaml.injected
@@ -146,6 +146,7 @@ spec:
     - '*'
     - -d
     - 15090,15021,15020
+    - --log_output_level=default:info
     image: gcr.io/istio-testing/proxyv2:latest
     name: istio-init
     resources:

--- a/pkg/kube/inject/testdata/inject/prometheus-scrape.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/prometheus-scrape.yaml.injected
@@ -144,6 +144,7 @@ spec:
     - '*'
     - -d
     - 15090,15021,15020
+    - --log_output_level=default:info
     image: gcr.io/istio-testing/proxyv2:latest
     name: istio-init
     resources:

--- a/pkg/kube/inject/testdata/inject/prometheus-scrape2.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/prometheus-scrape2.yaml.injected
@@ -144,6 +144,7 @@ spec:
     - '*'
     - -d
     - 15090,15021,15020
+    - --log_output_level=default:info
     image: gcr.io/istio-testing/proxyv2:latest
     name: istio-init
     resources:

--- a/pkg/kube/inject/testdata/inject/proxy-override-args.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/proxy-override-args.yaml.injected
@@ -147,6 +147,7 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        - --log_output_level=default:info
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/ready_live.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/ready_live.yaml.injected
@@ -186,6 +186,7 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        - --log_output_level=default:info
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/ready_only.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/ready_only.yaml.injected
@@ -166,6 +166,7 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        - --log_output_level=default:info
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
@@ -155,6 +155,7 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        - --log_output_level=default:info
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
@@ -154,6 +154,7 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        - --log_output_level=default:info
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/resource_annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/resource_annotations.yaml.injected
@@ -160,6 +160,7 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        - --log_output_level=default:info
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/startup_live.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/startup_live.yaml.injected
@@ -186,6 +186,7 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        - --log_output_level=default:info
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/startup_only.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/startup_only.yaml.injected
@@ -166,6 +166,7 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        - --log_output_level=default:info
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/startup_ready_live.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/startup_ready_live.yaml.injected
@@ -194,6 +194,7 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        - --log_output_level=default:info
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
@@ -163,6 +163,7 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        - --log_output_level=default:info
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/status_annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/status_annotations.yaml.injected
@@ -161,6 +161,7 @@ spec:
         - '*'
         - -d
         - 15090,15021,123
+        - --log_output_level=default:info
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/status_annotations_zeroport.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/status_annotations_zeroport.yaml.injected
@@ -153,6 +153,7 @@ spec:
         - '*'
         - -d
         - 15090,15021
+        - --log_output_level=default:info
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/status_params.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/status_params.yaml.injected
@@ -156,6 +156,7 @@ spec:
         - '*'
         - -d
         - 15090,15021,123
+        - --log_output_level=default:info
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/tcp-probes-disabled.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/tcp-probes-disabled.yaml.injected
@@ -166,6 +166,7 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        - --log_output_level=default:info
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/tcp-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/tcp-probes.yaml.injected
@@ -170,6 +170,7 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        - --log_output_level=default:info
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
@@ -160,6 +160,7 @@ spec:
         - ""
         - -d
         - 15090,15021,4,5,6,15020
+        - --log_output_level=default:info
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
@@ -160,6 +160,7 @@ spec:
         - '*'
         - -d
         - 15090,15021,4,5,6,15020
+        - --log_output_level=default:info
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
@@ -170,6 +170,7 @@ spec:
         - 15090,15021,4,5,6,15020
         - -o
         - 7,8,9
+        - --log_output_level=default:info
         env:
         - name: FOO
           value: bar

--- a/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
@@ -156,6 +156,7 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        - --log_output_level=default:info
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
@@ -148,6 +148,7 @@ spec:
         - '*'
         - -d
         - 15090,15021,4,5,6
+        - --log_output_level=default:info
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/two_container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/two_container.yaml.injected
@@ -177,6 +177,7 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        - --log_output_level=default:info
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inject/user-volume.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/user-volume.yaml.injected
@@ -167,6 +167,7 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        - --log_output_level=default:info
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-init
         resources:

--- a/pkg/kube/inject/testdata/inputs/custom-template.yaml.34.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/custom-template.yaml.34.template.gen.yaml
@@ -117,6 +117,10 @@ templates:
         - "-k"
         - "{{ index .ObjectMeta.Annotations `traffic.sidecar.istio.io/kubevirtInterfaces` }}"
         {{ end -}}
+        - "--log_output_level={{ annotation .ObjectMeta `sidecar.istio.io/agentLogLevel` .Values.global.logging.level }}"
+        {{ if .Values.global.logAsJson -}}
+        - "--log_as_json"
+        {{ end -}}
         {{ if .Values.istio_cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"

--- a/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
@@ -117,6 +117,10 @@ templates:
         - "-k"
         - "{{ index .ObjectMeta.Annotations `traffic.sidecar.istio.io/kubevirtInterfaces` }}"
         {{ end -}}
+        - "--log_output_level={{ annotation .ObjectMeta `sidecar.istio.io/agentLogLevel` .Values.global.logging.level }}"
+        {{ if .Values.global.logAsJson -}}
+        - "--log_as_json"
+        {{ end -}}
         {{ if .Values.istio_cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"

--- a/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
@@ -117,6 +117,10 @@ templates:
         - "-k"
         - "{{ index .ObjectMeta.Annotations `traffic.sidecar.istio.io/kubevirtInterfaces` }}"
         {{ end -}}
+        - "--log_output_level={{ annotation .ObjectMeta `sidecar.istio.io/agentLogLevel` .Values.global.logging.level }}"
+        {{ if .Values.global.logAsJson -}}
+        - "--log_as_json"
+        {{ end -}}
         {{ if .Values.istio_cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
@@ -117,6 +117,10 @@ templates:
         - "-k"
         - "{{ index .ObjectMeta.Annotations `traffic.sidecar.istio.io/kubevirtInterfaces` }}"
         {{ end -}}
+        - "--log_output_level={{ annotation .ObjectMeta `sidecar.istio.io/agentLogLevel` .Values.global.logging.level }}"
+        {{ if .Values.global.logAsJson -}}
+        - "--log_as_json"
+        {{ end -}}
         {{ if .Values.istio_cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
@@ -117,6 +117,10 @@ templates:
         - "-k"
         - "{{ index .ObjectMeta.Annotations `traffic.sidecar.istio.io/kubevirtInterfaces` }}"
         {{ end -}}
+        - "--log_output_level={{ annotation .ObjectMeta `sidecar.istio.io/agentLogLevel` .Values.global.logging.level }}"
+        {{ if .Values.global.logAsJson -}}
+        - "--log_as_json"
+        {{ end -}}
         {{ if .Values.istio_cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"

--- a/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
@@ -117,6 +117,10 @@ templates:
         - "-k"
         - "{{ index .ObjectMeta.Annotations `traffic.sidecar.istio.io/kubevirtInterfaces` }}"
         {{ end -}}
+        - "--log_output_level={{ annotation .ObjectMeta `sidecar.istio.io/agentLogLevel` .Values.global.logging.level }}"
+        {{ if .Values.global.logAsJson -}}
+        - "--log_as_json"
+        {{ end -}}
         {{ if .Values.istio_cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"

--- a/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
@@ -117,6 +117,10 @@ templates:
         - "-k"
         - "{{ index .ObjectMeta.Annotations `traffic.sidecar.istio.io/kubevirtInterfaces` }}"
         {{ end -}}
+        - "--log_output_level={{ annotation .ObjectMeta `sidecar.istio.io/agentLogLevel` .Values.global.logging.level }}"
+        {{ if .Values.global.logAsJson -}}
+        - "--log_as_json"
+        {{ end -}}
         {{ if .Values.istio_cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"

--- a/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
@@ -117,6 +117,10 @@ templates:
         - "-k"
         - "{{ index .ObjectMeta.Annotations `traffic.sidecar.istio.io/kubevirtInterfaces` }}"
         {{ end -}}
+        - "--log_output_level={{ annotation .ObjectMeta `sidecar.istio.io/agentLogLevel` .Values.global.logging.level }}"
+        {{ if .Values.global.logAsJson -}}
+        - "--log_as_json"
+        {{ end -}}
         {{ if .Values.istio_cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
@@ -117,6 +117,10 @@ templates:
         - "-k"
         - "{{ index .ObjectMeta.Annotations `traffic.sidecar.istio.io/kubevirtInterfaces` }}"
         {{ end -}}
+        - "--log_output_level={{ annotation .ObjectMeta `sidecar.istio.io/agentLogLevel` .Values.global.logging.level }}"
+        {{ if .Values.global.logAsJson -}}
+        - "--log_as_json"
+        {{ end -}}
         {{ if .Values.istio_cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
@@ -117,6 +117,10 @@ templates:
         - "-k"
         - "{{ index .ObjectMeta.Annotations `traffic.sidecar.istio.io/kubevirtInterfaces` }}"
         {{ end -}}
+        - "--log_output_level={{ annotation .ObjectMeta `sidecar.istio.io/agentLogLevel` .Values.global.logging.level }}"
+        {{ if .Values.global.logAsJson -}}
+        - "--log_as_json"
+        {{ end -}}
         {{ if .Values.istio_cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
@@ -117,6 +117,10 @@ templates:
         - "-k"
         - "{{ index .ObjectMeta.Annotations `traffic.sidecar.istio.io/kubevirtInterfaces` }}"
         {{ end -}}
+        - "--log_output_level={{ annotation .ObjectMeta `sidecar.istio.io/agentLogLevel` .Values.global.logging.level }}"
+        {{ if .Values.global.logAsJson -}}
+        - "--log_as_json"
+        {{ end -}}
         {{ if .Values.istio_cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
@@ -117,6 +117,10 @@ templates:
         - "-k"
         - "{{ index .ObjectMeta.Annotations `traffic.sidecar.istio.io/kubevirtInterfaces` }}"
         {{ end -}}
+        - "--log_output_level={{ annotation .ObjectMeta `sidecar.istio.io/agentLogLevel` .Values.global.logging.level }}"
+        {{ if .Values.global.logAsJson -}}
+        - "--log_as_json"
+        {{ end -}}
         {{ if .Values.istio_cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
@@ -117,6 +117,10 @@ templates:
         - "-k"
         - "{{ index .ObjectMeta.Annotations `traffic.sidecar.istio.io/kubevirtInterfaces` }}"
         {{ end -}}
+        - "--log_output_level={{ annotation .ObjectMeta `sidecar.istio.io/agentLogLevel` .Values.global.logging.level }}"
+        {{ if .Values.global.logAsJson -}}
+        - "--log_as_json"
+        {{ end -}}
         {{ if .Values.istio_cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
@@ -117,6 +117,10 @@ templates:
         - "-k"
         - "{{ index .ObjectMeta.Annotations `traffic.sidecar.istio.io/kubevirtInterfaces` }}"
         {{ end -}}
+        - "--log_output_level={{ annotation .ObjectMeta `sidecar.istio.io/agentLogLevel` .Values.global.logging.level }}"
+        {{ if .Values.global.logAsJson -}}
+        - "--log_as_json"
+        {{ end -}}
         {{ if .Values.istio_cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
@@ -117,6 +117,10 @@ templates:
         - "-k"
         - "{{ index .ObjectMeta.Annotations `traffic.sidecar.istio.io/kubevirtInterfaces` }}"
         {{ end -}}
+        - "--log_output_level={{ annotation .ObjectMeta `sidecar.istio.io/agentLogLevel` .Values.global.logging.level }}"
+        {{ if .Values.global.logAsJson -}}
+        - "--log_as_json"
+        {{ end -}}
         {{ if .Values.istio_cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
@@ -117,6 +117,10 @@ templates:
         - "-k"
         - "{{ index .ObjectMeta.Annotations `traffic.sidecar.istio.io/kubevirtInterfaces` }}"
         {{ end -}}
+        - "--log_output_level={{ annotation .ObjectMeta `sidecar.istio.io/agentLogLevel` .Values.global.logging.level }}"
+        {{ if .Values.global.logAsJson -}}
+        - "--log_as_json"
+        {{ end -}}
         {{ if .Values.istio_cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
@@ -117,6 +117,10 @@ templates:
         - "-k"
         - "{{ index .ObjectMeta.Annotations `traffic.sidecar.istio.io/kubevirtInterfaces` }}"
         {{ end -}}
+        - "--log_output_level={{ annotation .ObjectMeta `sidecar.istio.io/agentLogLevel` .Values.global.logging.level }}"
+        {{ if .Values.global.logAsJson -}}
+        - "--log_as_json"
+        {{ end -}}
         {{ if .Values.istio_cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"

--- a/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
@@ -117,6 +117,10 @@ templates:
         - "-k"
         - "{{ index .ObjectMeta.Annotations `traffic.sidecar.istio.io/kubevirtInterfaces` }}"
         {{ end -}}
+        - "--log_output_level={{ annotation .ObjectMeta `sidecar.istio.io/agentLogLevel` .Values.global.logging.level }}"
+        {{ if .Values.global.logAsJson -}}
+        - "--log_as_json"
+        {{ end -}}
         {{ if .Values.istio_cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"

--- a/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
@@ -117,6 +117,10 @@ templates:
         - "-k"
         - "{{ index .ObjectMeta.Annotations `traffic.sidecar.istio.io/kubevirtInterfaces` }}"
         {{ end -}}
+        - "--log_output_level={{ annotation .ObjectMeta `sidecar.istio.io/agentLogLevel` .Values.global.logging.level }}"
+        {{ if .Values.global.logAsJson -}}
+        - "--log_as_json"
+        {{ end -}}
         {{ if .Values.istio_cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"

--- a/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
@@ -117,6 +117,10 @@ templates:
         - "-k"
         - "{{ index .ObjectMeta.Annotations `traffic.sidecar.istio.io/kubevirtInterfaces` }}"
         {{ end -}}
+        - "--log_output_level={{ annotation .ObjectMeta `sidecar.istio.io/agentLogLevel` .Values.global.logging.level }}"
+        {{ if .Values.global.logAsJson -}}
+        - "--log_as_json"
+        {{ end -}}
         {{ if .Values.istio_cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"

--- a/releasenotes/notes/39190.yaml
+++ b/releasenotes/notes/39190.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+
+releaseNotes:
+- |
+  **Improved** populate `--log_output_level` and `--log_as_json` to `istio-init` container as they are in `istio-proxy`


### PR DESCRIPTION
This pr adds the option to set the log level and format as it [could](https://github.com/istio/istio/blob/d2d6203bf8a4ae773505df0e479131947ea7affa/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml#L412-L417) for the `istio-proxy` container

Currently, it's unable to set log level/format for `istio-init` container while [pilot-agent istio-iptables](https://istio.io/latest/docs/reference/commands/pilot-agent/#pilot-agent-istio-iptables) supports `--log_as_json` and `--log_output_level` flags like [pilot-agent proxy](https://istio.io/latest/docs/reference/commands/pilot-agent/#pilot-agent-proxy). Not sure if this is by design, but having these two flags can keep the logging consistent?

**Notes:** 

Almost all changes are generated via `make gen` except `manifests/charts/istio-control/istio-discovery/files/injection-template.yaml` and `manifests/charts/istiod-remote/files/injection-template.yaml`

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [X] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
