### PR TITLE
> fix pilot panic with vm workload entry: assignment to entry in nil map

### DIFF
--- a/pilot/pkg/autoregistration/controller.go
+++ b/pilot/pkg/autoregistration/controller.go
@@ -198,6 +198,9 @@ type workItem struct {
 }
 
 func setConnectMeta(c *config.Config, controller string, conTime time.Time) {
+	if c.Annotations == nil {
+		c.Annotations = map[string]string{}
+	}
 	c.Annotations[WorkloadControllerAnnotation] = controller
 	c.Annotations[ConnectedAtAnnotation] = conTime.Format(timeFormat)
 	delete(c.Annotations, DisconnectedAtAnnotation)

--- a/releasenotes/notes/39201.yaml
+++ b/releasenotes/notes/39201.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 39201
+releaseNotes:
+  - |
+    **Fixed** WorkloadEntry.Annotations is nil and then lead to abnormal exit of pilot.


### PR DESCRIPTION
**Please provide a description of this PR:**
when WorkloadEntry.Annotations is nil , pilot panic

The premise condition：
Istio official recommended workloadEntry automatic registration, but also supports user-defined.
When the user custom WorkloadEntry and WorkloadEntry.Annotations is nil , then cause the pilot panic.


test release > 1.10+
![image](https://user-images.githubusercontent.com/44200120/171080516-44fbed17-fae0-43fe-9fd3-f173df53063a.png)