### PR TITLE
debug: add EDS to config_dump output

### DIFF
--- a/pilot/pkg/xds/statusgen.go
+++ b/pilot/pkg/xds/statusgen.go
@@ -168,7 +168,7 @@ func (sg *StatusGen) debugConfigDump(proxyID string) (model.Resources, error) {
 		return nil, fmt.Errorf("config dump could not find connection for proxyID %q", proxyID)
 	}
 
-	dump, err := sg.Server.configDump(conn)
+	dump, err := sg.Server.configDump(conn, false)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This allows dumping EDS config, similar to Envoy's config.

As part of this, the code is changed to consistently use findGenerator,
which also makes sure the dumping works for custom generators (gRPC,
etc).

This should have no behavioral changes for standard case, as the EDS is
opt-in

**Please provide a description of this PR:**



**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
