### PR TITLE
WasmPlugin: Add httpimageproxy integration test component

### DIFF
--- a/pkg/test/env/istio.go
+++ b/pkg/test/env/istio.go
@@ -80,6 +80,9 @@ var (
 
 	// RegistryRedirectorServerInstallFilePath is the registry redirector installation file.
 	RegistryRedirectorServerInstallFilePath = path.Join(IstioSrc, getInstallationFile("registryredirector/registry_redirector_server.yaml"))
+
+	// HTTPImageProxyInstallFilePath is the httpimageproxy installation file.
+	HTTPImageProxyInstallFilePath = path.Join(IstioSrc, getInstallationFile("httpimageproxy/httpimageproxy.yaml"))
 )
 
 var (

--- a/pkg/test/fakes/httpimageproxy/Dockerfile
+++ b/pkg/test/fakes/httpimageproxy/Dockerfile
@@ -1,0 +1,3 @@
+FROM scratch
+COPY ./main /proxy
+ENTRYPOINT ["/proxy"]

--- a/pkg/test/fakes/httpimageproxy/Makefile
+++ b/pkg/test/fakes/httpimageproxy/Makefile
@@ -1,0 +1,40 @@
+# Copyright Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+.PHONY: build build_and_push clean all
+
+MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
+MD_PATH := $(dir $(MKFILE_PATH))
+HUB ?= gcr.io/istio-testing
+IMG := $(HUB)/httpimageproxy
+BIN_NAME := main
+
+# NOTE: TAG should be updated whenever changes are made in this directory
+# This should also be updated in dependent components
+TAG := 1.0
+
+all: build_and_push clean
+
+$(MD_PATH)/$(BIN_NAME): $(MD_PATH)/main.go
+	cd $(MD_PATH) && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o $(BIN_NAME) -a -tags netgo -ldflags '-w -extldflags "-static"' main.go
+
+build: $(MD_PATH)/$(BIN_NAME)
+
+build_and_push:  $(MD_PATH)/$(BIN_NAME)
+	docker buildx build $(MD_PATH) -t $(IMG):$(TAG) --push
+	docker tag $(IMG):$(TAG) $(IMG):latest
+	docker push $(IMG):latest
+
+clean:
+	rm $(MD_PATH)/$(BIN_NAME)

--- a/pkg/test/fakes/httpimageproxy/main.go
+++ b/pkg/test/fakes/httpimageproxy/main.go
@@ -24,11 +24,12 @@ import (
 	"net/http"
 	"regexp"
 
+	"istio.io/pkg/log"
+
 	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/google/go-containerregistry/pkg/v1/cache"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
-	"istio.io/pkg/log"
 )
 
 var (
@@ -64,7 +65,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ref := matches[re.SubexpIndex("Reference")] + ":" + matches[re.SubexpIndex("Tag")]
 	filePath := matches[re.SubexpIndex("FilePath")]
 
-	log.Debugf("Retreive file from oci://%v:%v", ref, filePath)
+	log.Debugf("Retrieve file from oci://%v:%v", ref, filePath)
 
 	reader, err := h.extractFile(ref, filePath)
 	if err != nil {

--- a/pkg/test/fakes/httpimageproxy/main.go
+++ b/pkg/test/fakes/httpimageproxy/main.go
@@ -1,0 +1,139 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"archive/tar"
+	"crypto/tls"
+	"flag"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"regexp"
+
+	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/google/go-containerregistry/pkg/v1/cache"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"istio.io/pkg/log"
+)
+
+var (
+	port      = flag.Int("port", 8080, "port to run proxy on")
+	cachePath = flag.String("cachepath", "", "directory for image cache. If it is an empty string, create/use a temp dir.")
+)
+
+var re = regexp.MustCompile(`^/(?P<Reference>.+)/tag/(?P<Tag>[^/]+)/(?P<FilePath>.+)$`)
+
+type Handler struct {
+	cache cache.Cache
+}
+
+type readerCloser struct {
+	io.Reader
+	io.Closer
+}
+
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path == "/ready" {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	log.Debugf("requested URL: %v", r.URL)
+	matches := re.FindStringSubmatch(r.URL.Path)
+	if matches == nil {
+		log.Errorf("%q is not matched with regex scheme %q", r.URL.Path, re)
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	ref := matches[re.SubexpIndex("Reference")] + ":" + matches[re.SubexpIndex("Tag")]
+	filePath := matches[re.SubexpIndex("FilePath")]
+
+	log.Debugf("Retreive file from oci://%v:%v", ref, filePath)
+
+	reader, err := h.extractFile(ref, filePath)
+	if err != nil {
+		w.WriteHeader(http.StatusBadGateway)
+		log.Errorf("failed to extract the file %q from %q: %v", filePath, ref, err)
+		return
+	}
+	defer reader.Close()
+
+	w.Header().Set("Content-Type", "application/octet-stream")
+	w.WriteHeader(http.StatusOK)
+	if _, err = io.Copy(w, reader); err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		log.Errorf("failed to copy the contents of the file to the response writer: %v", err)
+		return
+	}
+}
+
+func (h *Handler) extractFile(ref string, filePath string) (io.ReadCloser, error) {
+	t := remote.DefaultTransport.Clone()
+	t.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	img, err := crane.Pull(ref, crane.WithTransport(t))
+	if err != nil {
+		return nil, fmt.Errorf("failed to pull the image %q: %v", ref, err)
+	}
+
+	img = cache.Image(img, h.cache)
+
+	ir := mutate.Extract(img)
+	tr := tar.NewReader(ir)
+
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return nil, err
+		}
+		if hdr.Name == filePath {
+			return readerCloser{
+				Reader: tr,
+				Closer: ir,
+			}, nil
+		}
+	}
+	return nil, fmt.Errorf("%s not found in the archive", filePath)
+}
+
+func main() {
+	flag.Parse()
+	cpath := *cachePath
+	var err error
+	if cpath == "" {
+		cpath, err = ioutil.TempDir("", "")
+		if err != nil {
+			log.Fatal(err)
+			return
+		}
+	}
+
+	s := &http.Server{
+		Addr: fmt.Sprintf(":%d", *port),
+		Handler: &Handler{
+			cache.NewFilesystemCache(cpath),
+		},
+	}
+
+	log.Infof("httpimageproxy is starting at %d", *port)
+	if err := s.ListenAndServe(); err != nil {
+		log.Error(err)
+	}
+}

--- a/pkg/test/framework/components/httpimageproxy/httpimageproxy.go
+++ b/pkg/test/framework/components/httpimageproxy/httpimageproxy.go
@@ -1,0 +1,52 @@
+//  Copyright Istio Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+// Package httpimageproxy provides configurating a httpimageproxy
+package httpimageproxy
+
+import (
+	"istio.io/istio/pkg/test"
+	"istio.io/istio/pkg/test/framework/components/cluster"
+	"istio.io/istio/pkg/test/framework/resource"
+)
+
+// Instance represents a deployed httpimageproxy app instance.
+type Instance interface {
+	// Address is the address of the service provided by the
+	// httpimageproxy.
+	Address() string
+}
+
+// Config defines the options for creating an httpimageproxy component.
+type Config struct {
+	// Cluster to be used in a multicluster environment
+	Cluster cluster.Cluster
+	// Image to set the alternative http server image
+	Image string
+}
+
+// New returns a new instance of a httpimageproxy.
+func New(ctx resource.Context, c Config) (i Instance, err error) {
+	return newKube(ctx, c)
+}
+
+// NewOrFail returns a new httpimageproxy instance or fails test.
+func NewOrFail(t test.Failer, ctx resource.Context, c Config) Instance {
+	t.Helper()
+	i, err := New(ctx, c)
+	if err != nil {
+		t.Fatalf("httpimageproxy.NewOrFail: %v", err)
+	}
+	return i
+}

--- a/pkg/test/framework/components/httpimageproxy/httpimageproxy.yaml
+++ b/pkg/test/framework/components/httpimageproxy/httpimageproxy.yaml
@@ -1,0 +1,60 @@
+# Copyright Istio Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+apiVersion: v1
+kind: Service
+metadata:
+  name: httpimageproxy
+  labels:
+    app: httpimageproxy
+spec:
+  ports:
+  - name: http
+    port: 8080
+  selector:
+    app: httpimageproxy
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: httpimageproxy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: httpimageproxy
+  template:
+    metadata:
+      labels:
+        app: httpimageproxy
+    spec:
+      containers:
+      - image: {{ or .Image "gcr.io/istio-testing/httpimageproxy:1.0"}}
+        name: httpimageproxy
+        ports:
+        - containerPort: 8080
+        args: ["--cachepath", "/cache"]
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 1
+          periodSeconds: 1
+          failureThreshold: 10
+        volumeMounts:
+        - mountPath: /cache
+          name: cache-volume
+      volumes:
+      - name: cache-volume
+        emptyDir: {}
+---

--- a/pkg/test/framework/components/httpimageproxy/kube.go
+++ b/pkg/test/framework/components/httpimageproxy/kube.go
@@ -1,0 +1,104 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpimageproxy
+
+import (
+	"fmt"
+	"io"
+	"net"
+
+	"istio.io/istio/pkg/test/env"
+	"istio.io/istio/pkg/test/framework/components/cluster"
+	"istio.io/istio/pkg/test/framework/components/namespace"
+	"istio.io/istio/pkg/test/framework/resource"
+	testKube "istio.io/istio/pkg/test/kube"
+	"istio.io/istio/pkg/test/scopes"
+)
+
+const (
+	service = "httpimageproxy"
+	ns      = "httpimageproxy"
+)
+
+var (
+	_ Instance  = &kubeComponent{}
+	_ io.Closer = &kubeComponent{}
+)
+
+type kubeComponent struct {
+	id      resource.ID
+	ns      namespace.Instance
+	cluster cluster.Cluster
+	address string
+}
+
+func newKube(ctx resource.Context, cfg Config) (Instance, error) {
+	c := &kubeComponent{
+		cluster: ctx.Clusters().GetOrDefault(cfg.Cluster),
+	}
+	c.id = ctx.TrackResource(c)
+	var err error
+	scopes.Framework.Info("=== BEGIN: Deploy httpimageproxy ===")
+	defer func() {
+		if err != nil {
+			err = fmt.Errorf("httpimageproxy deployment failed: %v", err)
+			scopes.Framework.Infof("=== FAILED: Deploy httpimageproxy ===")
+			_ = c.Close()
+		} else {
+			scopes.Framework.Info("=== SUCCEEDED: Deploy httpimageproxy ===")
+		}
+	}()
+
+	c.ns, err = namespace.New(ctx, namespace.Config{
+		Prefix: ns,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("could not create %q namespace for httpimageproxy install; err: %v", ns, err)
+	}
+
+	args := map[string]interface{}{}
+
+	if len(cfg.Image) != 0 {
+		args["Image"] = cfg.Image
+	}
+
+	// apply YAML
+	if err := ctx.ConfigKube(c.cluster).EvalFile(c.ns.Name(), args, env.HTTPImageProxyInstallFilePath).Apply(); err != nil {
+		return nil, fmt.Errorf("failed to apply rendered %s, err: %v", env.HTTPImageProxyInstallFilePath, err)
+	}
+
+	if _, _, err = testKube.WaitUntilServiceEndpointsAreReady(c.cluster.Kube(), c.ns.Name(), service); err != nil {
+		scopes.Framework.Infof("Error waiting for httpimageproxy to be available: %v", err)
+		return nil, err
+	}
+
+	c.address = net.JoinHostPort(fmt.Sprintf("%s.%s", service, c.ns.Name()), "8080")
+	scopes.Framework.Infof("httpimageproxy in-cluster address: %s", c.address)
+
+	return c, nil
+}
+
+func (c *kubeComponent) ID() resource.ID {
+	return c.id
+}
+
+// Close implements io.Closer.
+func (c *kubeComponent) Close() error {
+	return nil
+}
+
+func (c *kubeComponent) Address() string {
+	return c.address
+}


### PR DESCRIPTION
This PR proposes to introduce a new component "httpimageproxy" for testing Wasm Remote Loading via HTTP.

httpimageproxy works as a proxy returning a file by extracting it from a docker image pulled from a docker registry upstream.

In details,
- If a user makes a request "get" with a URL path "/gcr.io/awesome-wasm/tag/v1.0/plugin.wasm"
- `httpimageproxy` pulls the image "gcr.io/awesome-wasm:v1.0"
- `/plugin.wasm` is extracted from the image
- `plugin.wasm` is returned to the user in octet-stream.

We have https://github.com/istio/istio/issues/38877 issue, but at this time there is no direction decided, so add this as a separate image/binary with ad-hoc build script.
