### PR TITLE
tf: make Ingress component more flexible

### DIFF
--- a/pkg/test/framework/components/istio/eastwest.go
+++ b/pkg/test/framework/components/istio/eastwest.go
@@ -35,8 +35,9 @@ import (
 )
 
 const (
-	eastWestIngressIstioLabel  = "eastwestgateway"
-	eastWestIngressServiceName = "istio-" + eastWestIngressIstioLabel
+	eastWestIngressIstioNameLabel = "eastwestgateway"
+	eastWestIngressIstioLabel     = "istio=" + eastWestIngressIstioNameLabel
+	eastWestIngressServiceName    = "istio-" + eastWestIngressIstioNameLabel
 )
 
 var (
@@ -112,7 +113,7 @@ func (i *operatorComponent) deployEastWestGateway(cluster cluster.Cluster, revis
 	// wait for a ready pod
 	if err := retry.UntilSuccess(func() error {
 		pods, err := cluster.Kube().CoreV1().Pods(i.settings.SystemNamespace).List(context.TODO(), v1.ListOptions{
-			LabelSelector: "istio=" + eastWestIngressIstioLabel,
+			LabelSelector: eastWestIngressIstioLabel,
 		})
 		if err != nil {
 			return err
@@ -122,7 +123,7 @@ func (i *operatorComponent) deployEastWestGateway(cluster cluster.Cluster, revis
 				return nil
 			}
 		}
-		return fmt.Errorf("no ready pods for istio=" + eastWestIngressIstioLabel)
+		return fmt.Errorf("no ready pods for " + eastWestIngressIstioLabel)
 	}, componentDeployTimeout, componentDeployDelay); err != nil {
 		return fmt.Errorf("failed waiting for %s to become ready: %v", eastWestIngressServiceName, err)
 	}

--- a/pkg/test/framework/components/istio/ingress.go
+++ b/pkg/test/framework/components/istio/ingress.go
@@ -16,12 +16,13 @@ package istio
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net"
 	"strconv"
 	"time"
+
+	"k8s.io/apimachinery/pkg/types"
 
 	"istio.io/istio/pkg/http/headers"
 	"istio.io/istio/pkg/test"
@@ -37,12 +38,11 @@ import (
 )
 
 const (
-	defaultIngressIstioLabel  = "ingressgateway"
-	defaultIngressServiceName = "istio-" + defaultIngressIstioLabel
+	defaultIngressIstioNameLabel = "ingressgateway"
+	defaultIngressIstioLabel     = "istio=" + defaultIngressIstioNameLabel
+	defaultIngressServiceName    = "istio-" + defaultIngressIstioNameLabel
 
-	proxyContainerName = "istio-proxy"
-	proxyAdminPort     = 15000
-	discoveryPort      = 15012
+	discoveryPort = 15012
 )
 
 var (
@@ -54,39 +54,32 @@ var (
 )
 
 type ingressConfig struct {
-	// ServiceName is the kubernetes Service name for the cluster
-	ServiceName string
-	// Namespace the ingress can be found in
-	Namespace string
-	// IstioLabel is the value for the "istio" label on the ingress kubernetes objects
-	IstioLabel string
+	// Service is the kubernetes Service name for the cluster
+	Service types.NamespacedName
+	// LabelSelector is the value for the label on the ingress kubernetes objects
+	LabelSelector string
 
 	// Cluster to be used in a multicluster environment
 	Cluster cluster.Cluster
 }
 
 func newIngress(ctx resource.Context, cfg ingressConfig) (i ingress.Instance) {
-	if cfg.ServiceName == "" {
-		cfg.ServiceName = defaultIngressServiceName
-	}
-	if cfg.IstioLabel == "" {
-		cfg.IstioLabel = defaultIngressIstioLabel
+	if cfg.LabelSelector == "" {
+		cfg.LabelSelector = defaultIngressIstioLabel
 	}
 	c := &ingressImpl{
-		serviceName: cfg.ServiceName,
-		istioLabel:  cfg.IstioLabel,
-		namespace:   cfg.Namespace,
-		env:         ctx.Environment().(*kube.Environment),
-		cluster:     ctx.Clusters().GetOrDefault(cfg.Cluster),
-		caller:      common.NewCaller(),
+		service:       cfg.Service,
+		labelSelector: cfg.LabelSelector,
+		env:           ctx.Environment().(*kube.Environment),
+		cluster:       ctx.Clusters().GetOrDefault(cfg.Cluster),
+		caller:        common.NewCaller(),
 	}
 	return c
 }
 
 type ingressImpl struct {
-	serviceName string
-	istioLabel  string
-	namespace   string
+	service       types.NamespacedName
+	labelSelector string
 
 	env     *kube.Environment
 	cluster cluster.Cluster
@@ -103,7 +96,7 @@ func (c *ingressImpl) getAddressInner(port int) (string, int, error) {
 	attempts := 0
 	addr, err := retry.UntilComplete(func() (result interface{}, completed bool, err error) {
 		attempts++
-		result, completed, err = getRemoteServiceAddress(c.env.Settings(), c.cluster, c.namespace, c.istioLabel, c.serviceName, port)
+		result, completed, err = getRemoteServiceAddress(c.env.Settings(), c.cluster, c.service.Namespace, c.labelSelector, c.service.Name, port)
 		if err != nil && attempts > 1 {
 			// Log if we fail more than once to avoid test appearing to hang
 			// LB provision be slow, so timeout here needs to be long we should give context
@@ -249,17 +242,8 @@ func (c *ingressImpl) schemeFor(opts echo.CallOptions) (scheme.Instance, error) 
 	return opts.Port.Scheme()
 }
 
-func (c *ingressImpl) ProxyStats() (map[string]int, error) {
-	var stats map[string]int
-	statsJSON, err := c.adminRequest("stats?format=json")
-	if err != nil {
-		return stats, fmt.Errorf("failed to get response from admin port: %v", err)
-	}
-	return c.unmarshalStats(statsJSON)
-}
-
 func (c *ingressImpl) PodID(i int) (string, error) {
-	pods, err := c.env.Clusters().Default().PodsForSelector(context.TODO(), c.namespace, "istio=ingressgateway")
+	pods, err := c.env.Clusters().Default().PodsForSelector(context.TODO(), c.service.Namespace, c.labelSelector)
 	if err != nil {
 		return "", fmt.Errorf("unable to get ingressImpl gateway stats: %v", err)
 	}
@@ -269,48 +253,6 @@ func (c *ingressImpl) PodID(i int) (string, error) {
 	return pods.Items[i].Name, nil
 }
 
-// adminRequest makes a call to admin port at ingress gateway proxy and returns error on request failure.
-func (c *ingressImpl) adminRequest(path string) (string, error) {
-	pods, err := c.env.Clusters().Default().PodsForSelector(context.TODO(), c.namespace, "istio=ingressgateway")
-	if err != nil {
-		return "", fmt.Errorf("unable to get ingressImpl gateway stats: %v", err)
-	}
-	podNs, podName := pods.Items[0].Namespace, pods.Items[0].Name
-	// Exec onto the pod and make a curl request to the admin port
-	command := fmt.Sprintf("curl http://127.0.0.1:%d/%s", proxyAdminPort, path)
-	stdout, stderr, err := c.env.Clusters().Default().PodExec(podName, podNs, proxyContainerName, command)
-	return stdout + stderr, err
-}
-
-type statEntry struct {
-	Name  string      `json:"name"`
-	Value json.Number `json:"value"`
-}
-
-type stats struct {
-	StatList []statEntry `json:"stats"`
-}
-
-// unmarshalStats unmarshals Envoy stats from JSON format into a map, where stats name is
-// key, and stats value is value.
-func (c *ingressImpl) unmarshalStats(statsJSON string) (map[string]int, error) {
-	statsMap := make(map[string]int)
-
-	var statsArray stats
-	if err := json.Unmarshal([]byte(statsJSON), &statsArray); err != nil {
-		return statsMap, fmt.Errorf("unable to unmarshal stats from json: %v", err)
-	}
-
-	for _, v := range statsArray.StatList {
-		if v.Value == "" {
-			continue
-		}
-		tmp, _ := v.Value.Float64()
-		statsMap[v.Name] = int(tmp)
-	}
-	return statsMap, nil
-}
-
 func (c *ingressImpl) Namespace() string {
-	return c.namespace
+	return c.service.Namespace
 }

--- a/pkg/test/framework/components/istio/ingress/interface.go
+++ b/pkg/test/framework/components/istio/ingress/interface.go
@@ -50,9 +50,6 @@ type Instance interface {
 	// when in an environment that doesn't support LoadBalancer) for the given port.
 	AddressForPort(port int) (string, int)
 
-	// ProxyStats returns proxy stats, or error if failure happens.
-	ProxyStats() (map[string]int, error)
-
 	// PodID returns the name of the ingress gateway pod of index i. Returns error if failed to get the pod
 	// or the index is out of boundary.
 	PodID(i int) (string, error)

--- a/pkg/test/framework/components/istio/istio.go
+++ b/pkg/test/framework/components/istio/istio.go
@@ -18,6 +18,8 @@ import (
 	"net"
 	"time"
 
+	"k8s.io/apimachinery/pkg/types"
+
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/framework/components/cluster"
 	"istio.io/istio/pkg/test/framework/components/environment/kube"
@@ -40,7 +42,7 @@ type Instance interface {
 	EastWestGatewayFor(cluster cluster.Cluster) ingress.Instance
 	// CustomIngressFor returns an ingress with a specific service name and "istio" label used for reaching workloads
 	// in the given cluster.
-	CustomIngressFor(cluster cluster.Cluster, serviceName, istioLabel string) ingress.Instance
+	CustomIngressFor(cluster cluster.Cluster, service types.NamespacedName, istioLabel string) ingress.Instance
 
 	// RemoteDiscoveryAddressFor returns the external address of the discovery server that controls
 	// the given cluster. This allows access to the discovery server from

--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -144,12 +144,12 @@ func (i *operatorComponent) Ingresses() ingress.Instances {
 }
 
 func (i *operatorComponent) IngressFor(c cluster.Cluster) ingress.Instance {
-	name := types.NamespacedName{Namespace: defaultIngressServiceName, Name: i.settings.SystemNamespace}
+	name := types.NamespacedName{Name: defaultIngressServiceName, Namespace: i.settings.SystemNamespace}
 	return i.CustomIngressFor(c, name, defaultIngressIstioLabel)
 }
 
 func (i *operatorComponent) EastWestGatewayFor(c cluster.Cluster) ingress.Instance {
-	name := types.NamespacedName{Namespace: eastWestIngressServiceName, Name: i.settings.SystemNamespace}
+	name := types.NamespacedName{Name: eastWestIngressServiceName, Namespace: i.settings.SystemNamespace}
 	return i.CustomIngressFor(c, name, eastWestIngressIstioLabel)
 }
 
@@ -418,7 +418,7 @@ func deploy(ctx resource.Context, env *kube.Environment, cfg Config) (Instance, 
 			}
 
 			// Wait for the eastwestgateway to have a public IP.
-			name := types.NamespacedName{eastWestIngressServiceName, i.settings.SystemNamespace}
+			name := types.NamespacedName{Name: eastWestIngressServiceName, Namespace: i.settings.SystemNamespace}
 			_ = i.CustomIngressFor(c, name, eastWestIngressIstioLabel).DiscoveryAddress()
 		}
 	}

--- a/pkg/test/framework/components/istio/util.go
+++ b/pkg/test/framework/components/istio/util.go
@@ -97,7 +97,7 @@ func (i *operatorComponent) RemoteDiscoveryAddressFor(cluster cluster.Cluster) (
 		}
 		addr = address.(net.TCPAddr)
 	} else {
-		name := types.NamespacedName{Namespace: eastWestIngressServiceName, Name: i.settings.SystemNamespace}
+		name := types.NamespacedName{Name: eastWestIngressServiceName, Namespace: i.settings.SystemNamespace}
 		addr = i.CustomIngressFor(primary, name, eastWestIngressIstioLabel).DiscoveryAddress()
 	}
 	if addr.IP.String() == "<nil>" {
@@ -110,7 +110,7 @@ func getRemoteServiceAddress(s *kube.Settings, cluster cluster.Cluster, ns, labe
 	port int,
 ) (interface{}, bool, error) {
 	if !s.LoadBalancerSupported {
-		pods, err := cluster.PodsForSelector(context.TODO(), ns, fmt.Sprintf("%s", label))
+		pods, err := cluster.PodsForSelector(context.TODO(), ns, label)
 		if err != nil {
 			return nil, false, err
 		}

--- a/pkg/test/framework/components/istio/util.go
+++ b/pkg/test/framework/components/istio/util.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pkg/test/framework"
@@ -96,7 +97,8 @@ func (i *operatorComponent) RemoteDiscoveryAddressFor(cluster cluster.Cluster) (
 		}
 		addr = address.(net.TCPAddr)
 	} else {
-		addr = i.CustomIngressFor(primary, eastWestIngressServiceName, eastWestIngressIstioLabel).DiscoveryAddress()
+		name := types.NamespacedName{Namespace: eastWestIngressServiceName, Name: i.settings.SystemNamespace}
+		addr = i.CustomIngressFor(primary, name, eastWestIngressIstioLabel).DiscoveryAddress()
 	}
 	if addr.IP.String() == "<nil>" {
 		return net.TCPAddr{}, fmt.Errorf("failed to get ingress IP for %s", primary.Name())
@@ -108,7 +110,7 @@ func getRemoteServiceAddress(s *kube.Settings, cluster cluster.Cluster, ns, labe
 	port int,
 ) (interface{}, bool, error) {
 	if !s.LoadBalancerSupported {
-		pods, err := cluster.PodsForSelector(context.TODO(), ns, fmt.Sprintf("istio=%s", label))
+		pods, err := cluster.PodsForSelector(context.TODO(), ns, fmt.Sprintf("%s", label))
 		if err != nil {
 			return nil, false, err
 		}


### PR DESCRIPTION
Right now it can only be used in istio-system with the `istio=...`
label. This allows arbitrary namespaces and labels to be used. Also
cleans up some dead code.

**Please provide a description of this PR:**