### PR TITLE
[Dual Stack] Fixed issues for inbound and outbound routes and clusters configurations

### DIFF
--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -703,8 +703,8 @@ func BuildSubsetKey(direction TrafficDirection, subsetName string, hostname host
 }
 
 // BuildInboundSubsetKey generates a unique string referencing service instances with port for dual-stack enable.
-func BuildInboundSubsetKey(port int, dualIpv6 bool) string {
-	if dualIpv6 {
+func BuildInboundSubsetKey(port int, isIpv6 bool) string {
+	if isIpv6 {
 		return BuildSubsetKey(TrafficDirectionInbound6, "", "", port)
 	}
 	return BuildSubsetKey(TrafficDirectionInbound, "", "", port)

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -492,7 +492,10 @@ func (t clusterCache) Cacheable() bool {
 func (cb *ClusterBuilder) buildInboundClusterForPortOrUDS(clusterPort int, bind string,
 	proxy *model.Proxy, instance *model.ServiceInstance, allInstance []*model.ServiceInstance) *MutableCluster {
 	dualIP := false
-	if proxy != nil && proxy.SupportsIPv6() && proxy.SupportsIPv4() && bind == LocalhostIPv6Address {
+	// features.EnableDualStack is required to make sure that
+	// there is no any impact if dual stack is disable
+	if features.EnableDualStack && proxy != nil && proxy.SupportsIPv6() &&
+		proxy.SupportsIPv4() && bind == LocalhostIPv6Address {
 		dualIP = true
 	}
 	clusterName := model.BuildInboundSubsetKey(clusterPort, dualIP)


### PR DESCRIPTION
**Please provide a description of this PR:**
Fixed issues:
1. Symbols of `inbound6` and `outbound6` can only be used by IPv6 only service if dual stack is enable
2. Symbols of `inbound` and `outbound` can be used by IPv4/IPv6 only service if dual stack is disable

Old version with dual stack enabled:
![image](https://user-images.githubusercontent.com/4101246/171596660-0d2df6ce-7365-46bc-8665-8c3f30293daf.png)

New version with dual stack enabled:
![image](https://user-images.githubusercontent.com/4101246/171596975-2593932d-707f-42d9-823c-8157678b8a87.png)

As seen above, both the ipv4(simpleserver-ipv4) and ipv6(simpleserver-ipv6) services use the same symbols `outbound6` for the cluster resource in old version, and they use the different symbols in new version.