### PR TITLE
Decompress or untar the wasm binary if it is needed when pulling it via HTTP/HTTPS

### DIFF
--- a/pkg/wasm/cache_test.go
+++ b/pkg/wasm/cache_test.go
@@ -695,17 +695,17 @@ func TestWasmCache(t *testing.T) {
 				}
 			}
 
-			if diff := cmp.Diff(cache.modules, c.wantCachedModules,
+			if diff := cmp.Diff(c.wantCachedModules, cache.modules,
 				cmpopts.IgnoreFields(cacheEntry{}, "last", "referencingURLs"),
 				cmp.AllowUnexported(cacheEntry{}),
 			); diff != "" {
-				t.Errorf("unexpected module cache: (+want, -got)\n%v", diff)
+				t.Errorf("unexpected module cache: (-want, +got)\n%v", diff)
 			}
 
-			if diff := cmp.Diff(cache.checksums, c.wantCachedChecksums,
+			if diff := cmp.Diff(c.wantCachedChecksums, cache.checksums,
 				cmp.AllowUnexported(checksumEntry{}),
 			); diff != "" {
-				t.Errorf("unexpected checksums: (+want, -got)\n%v", diff)
+				t.Errorf("unexpected checksums: (-want, +got)\n%v", diff)
 			}
 
 			cache.mux.Unlock()

--- a/pkg/wasm/httpfetcher.go
+++ b/pkg/wasm/httpfetcher.go
@@ -15,15 +15,22 @@
 package wasm
 
 import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
 	"context"
 	"crypto/tls"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
 )
+
+var tarMagicNumber = []byte{0x75, 0x73, 0x74, 0x61, 0x72}
+var gzMagicNumber = []byte{0x1f, 0x8b}
 
 // HTTPFetcher fetches remote wasm module with HTTP get.
 type HTTPFetcher struct {
@@ -87,7 +94,7 @@ func (f *HTTPFetcher) Fetch(ctx context.Context, url string, allowInsecure bool)
 		if resp.StatusCode == http.StatusOK {
 			body, err := io.ReadAll(resp.Body)
 			resp.Body.Close()
-			return body, err
+			return unboxIfPossible(body), err
 		}
 		lastError = fmt.Errorf("wasm module download request failed: status code %v", resp.StatusCode)
 		if retryable(resp.StatusCode) {
@@ -108,4 +115,67 @@ func retryable(code int) bool {
 		!(code == http.StatusNotImplemented ||
 			code == http.StatusHTTPVersionNotSupported ||
 			code == http.StatusNetworkAuthenticationRequired)
+}
+
+func isPosixTar(b []byte) bool {
+	return len(b) > 262 && bytes.Equal(b[257:262], tarMagicNumber)
+}
+
+func getFirstFileFromTar(b []byte) []byte {
+	buf := bytes.NewBuffer(b)
+
+	tr := tar.NewReader(buf)
+
+	h, err := tr.Next()
+	if err != nil {
+		return nil
+	}
+
+	ret := make([]byte, h.Size)
+	_, err = io.ReadFull(tr, ret)
+	if err != nil {
+		return nil
+	}
+	return ret
+}
+
+func isGZ(b []byte) bool {
+	return len(b) > 2 && bytes.Equal(b[:2], gzMagicNumber)
+}
+
+func getFileFromGZ(b []byte) []byte {
+	buf := bytes.NewBuffer(b)
+
+	zr, err := gzip.NewReader(buf)
+	if err != nil {
+		return nil
+	}
+
+	ret, err := ioutil.ReadAll(zr)
+	if err != nil {
+		return nil
+	}
+	return ret
+}
+
+// Just do the best effort.
+// If an error is encountered, just return the original bytes.
+// Errors will be handled upper layers.
+func unboxIfPossible(origin []byte) []byte {
+	b := origin
+	for {
+		if isValidWasmBinary(b) {
+			return b
+		} else if isGZ(b) {
+			if b = getFileFromGZ(b); b == nil {
+				return origin
+			}
+		} else if isPosixTar(b) {
+			if b = getFirstFileFromTar(b); b == nil {
+				return origin
+			}
+		} else {
+			return origin
+		}
+	}
 }

--- a/pkg/wasm/httpfetcher.go
+++ b/pkg/wasm/httpfetcher.go
@@ -121,6 +121,7 @@ func isPosixTar(b []byte) bool {
 	return len(b) > 262 && bytes.Equal(b[257:262], tarMagicNumber)
 }
 
+// wasm plugin should be the only file in the tarball.
 func getFirstFileFromTar(b []byte) []byte {
 	buf := bytes.NewBuffer(b)
 

--- a/pkg/wasm/httpfetcher.go
+++ b/pkg/wasm/httpfetcher.go
@@ -29,8 +29,10 @@ import (
 	"github.com/cenkalti/backoff/v4"
 )
 
-var tarMagicNumber = []byte{0x75, 0x73, 0x74, 0x61, 0x72}
-var gzMagicNumber = []byte{0x1f, 0x8b}
+var (
+	tarMagicNumber = []byte{0x75, 0x73, 0x74, 0x61, 0x72}
+	gzMagicNumber  = []byte{0x1f, 0x8b}
+)
 
 // HTTPFetcher fetches remote wasm module with HTTP get.
 type HTTPFetcher struct {

--- a/pkg/wasm/httpfetcher.go
+++ b/pkg/wasm/httpfetcher.go
@@ -30,8 +30,10 @@ import (
 )
 
 var (
+	// Referred to https://en.wikipedia.org/wiki/Tar_(computing)#UStar_format
 	tarMagicNumber = []byte{0x75, 0x73, 0x74, 0x61, 0x72}
-	gzMagicNumber  = []byte{0x1f, 0x8b}
+	// Referred to https://en.wikipedia.org/wiki/Gzip#File_format
+	gzMagicNumber = []byte{0x1f, 0x8b}
 )
 
 // HTTPFetcher fetches remote wasm module with HTTP get.

--- a/pkg/wasm/httpfetcher_test.go
+++ b/pkg/wasm/httpfetcher_test.go
@@ -15,6 +15,9 @@
 package wasm
 
 import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
 	"context"
 	"fmt"
 	"net/http"
@@ -23,6 +26,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestWasmHTTPFetch(t *testing.T) {
@@ -159,6 +164,104 @@ func TestWasmHTTPInsecureServer(t *testing.T) {
 				}
 			} else if string(b) != wantWasmModule {
 				t.Errorf("downloaded wasm module got %v, want wasm", string(b))
+			}
+		})
+	}
+}
+
+func createTar(t *testing.T, b []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	hdr := &tar.Header{
+		Name: "plugin.wasm",
+		Mode: 0600,
+		Size: int64(len(b)),
+	}
+	if err := tw.WriteHeader(hdr); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write(b); err != nil {
+		t.Fatal(err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func createGZ(t *testing.T, b []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := gzip.NewWriter(&buf)
+	if _, err := zw.Write(b); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	return buf.Bytes()
+}
+
+func TestWasmHTTPFetchCompressedOrTarFile(t *testing.T) {
+	wasmBinary := append(wasmMagicNumber, 0x00, 0x00, 0x00, 0x00)
+	tarball := createTar(t, wasmBinary)
+	gz := createGZ(t, wasmBinary)
+	gzTarball := createGZ(t, tarball)
+	cases := []struct {
+		name    string
+		handler func(http.ResponseWriter, *http.Request, int)
+	}{
+		{
+			name: "plain wasm binary",
+			handler: func(w http.ResponseWriter, r *http.Request, num int) {
+				w.Write(wasmBinary)
+			},
+		},
+		{
+			name: "tarball of wasm binary",
+			handler: func(w http.ResponseWriter, r *http.Request, num int) {
+				w.Write(tarball)
+			},
+		},
+		{
+			name: "gzipped wasm binary",
+			handler: func(w http.ResponseWriter, r *http.Request, num int) {
+				w.Write(gz)
+			},
+		},
+		{
+			name: "gzipped tarball of wasm binary",
+			handler: func(w http.ResponseWriter, r *http.Request, num int) {
+				w.Write(gzTarball)
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			gotNumRequest := 0
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				c.handler(w, r, gotNumRequest)
+				gotNumRequest++
+			}))
+			defer ts.Close()
+			fetcher := NewHTTPFetcher(DefaultHTTPRequestTimeout, DefaultHTTPRequestMaxRetries)
+			fetcher.initialBackoff = time.Microsecond
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			b, err := fetcher.Fetch(ctx, ts.URL, false)
+			if err != nil {
+				t.Errorf("Wasm download got an unexpected error: %v", err)
+			}
+
+			if diff := cmp.Diff(wasmBinary, b); diff != "" {
+				if len(diff) > 500 {
+					diff = diff[:500]
+				}
+				t.Errorf("unexpected binary: (-want, +got)\n%v", diff)
 			}
 		})
 	}

--- a/pkg/wasm/httpfetcher_test.go
+++ b/pkg/wasm/httpfetcher_test.go
@@ -175,7 +175,7 @@ func createTar(t *testing.T, b []byte) []byte {
 	tw := tar.NewWriter(&buf)
 	hdr := &tar.Header{
 		Name: "plugin.wasm",
-		Mode: 0600,
+		Mode: 0o600,
 		Size: int64(len(b)),
 	}
 	if err := tw.WriteHeader(hdr); err != nil {

--- a/releasenotes/notes/wasm-decompress.yaml
+++ b/releasenotes/notes/wasm-decompress.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: feature
+area: extensibility
+issue: []
+releaseNotes:
+  - |
+    **Added** Decompress or/and untar the wasm binary when it is pulled via HTTP/HTTPS.


### PR DESCRIPTION
Decompress or/and untar the wasm binary when it is pulled via HTTP/HTTPS.
By this, we can support the compressed stream as well (even with the wrong `content-type`)

In details, when pulling bytes from HTTP/HTTPS server, if the bytes do not have proper magic number for Wasm Binary, 
tries to ungzip or untar based on the magic numbers of each fileformat.

In case of `untar`, this PR assumes that there is only one file in the same sense that OCI Image specification for Wasm binary.

Basically, it does the best effort based on the magic number of bytes.
If it fails to decompress or untar, just uses the original bytes.

Basically, the original idea came from https://github.com/istio/istio/pull/39225#issuecomment-1144207752.
