### PR TITLE
Support double authentication in istioctl

### DIFF
--- a/istioctl/cmd/google.go
+++ b/istioctl/cmd/google.go
@@ -1,0 +1,41 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+)
+
+func isMCPAddr(addr string) bool {
+	// A bit inexact but should be good enough.
+	return strings.Contains(addr, ".googleapis.com/") || strings.Contains(addr, ".googleapis.com:443/")
+}
+
+func mcpTransport(ctx context.Context, tr http.RoundTripper) (http.RoundTripper, error) {
+	creds, err := google.FindDefaultCredentials(ctx, "https://www.googleapis.com/auth/cloud-platform")
+	if err != nil {
+		return nil, fmt.Errorf("finding default GCP credentials: %w", err)
+	}
+	return &oauth2.Transport{
+		Base:   tr,
+		Source: creds.TokenSource,
+	}, nil
+}

--- a/istioctl/cmd/kubeinject.go
+++ b/istioctl/cmd/kubeinject.go
@@ -92,6 +92,12 @@ func (e ExternalInjector) Inject(pod *corev1.Pod, deploymentNS string) ([]byte, 
 		}
 	}
 	tlsClientConfig := &tls.Config{RootCAs: certPool}
+	client := http.Client{
+		Timeout: time.Second * 5,
+		Transport: &http.Transport{
+			TLSClientConfig: tlsClientConfig,
+		},
+	}
 	if cc.Service != nil {
 		svc, err := e.client.Kube().CoreV1().Services(cc.Service.Namespace).Get(context.Background(), cc.Service.Name, metav1.GetOptions{})
 		if err != nil {
@@ -130,12 +136,12 @@ func (e ExternalInjector) Inject(pod *corev1.Pod, deploymentNS string) ([]byte, 
 			}()
 		}
 		tlsClientConfig.ServerName = fmt.Sprintf("%s.%s.%s", cc.Service.Name, cc.Service.Namespace, "svc")
-	}
-	client := http.Client{
-		Timeout: time.Second * 5,
-		Transport: &http.Transport{
-			TLSClientConfig: tlsClientConfig,
-		},
+	} else if isMCPAddr(address) {
+		var err error
+		client.Transport, err = mcpTransport(context.TODO(), client.Transport)
+		if err != nil {
+			return nil, err
+		}
 	}
 	podBytes, err := json.Marshal(pod)
 	if pod.Namespace != "" {

--- a/istioctl/pkg/clioptions/central.go
+++ b/istioctl/pkg/clioptions/central.go
@@ -48,6 +48,12 @@ type CentralControlPlaneOptions struct {
 
 	// Plaintext forces plain text communication (for talking to port 15010)
 	Plaintext bool
+
+	// GCP project number or ID to use for XDS calls, if any.
+	GCPProject string
+
+	// Istiod address. For MCP may be different than Xds.
+	IstiodAddr string
 }
 
 // AttachControlPlaneFlags attaches control-plane flags to a Cobra command.

--- a/istioctl/pkg/multixds/gather.go
+++ b/istioctl/pkg/multixds/gather.go
@@ -152,22 +152,32 @@ func FirstRequestAndProcessXds(dr *xdsapi.DiscoveryRequest, centralOpts clioptio
 	return MultiRequestAndProcessXds(false, dr, centralOpts, istioNamespace, ns, serviceAccount, kubeClient)
 }
 
-func getXdsAddressFromWebhooks(client kube.ExtendedClient) (string, error) {
+type xdsAddr struct {
+	gcpProject, host, istiod string
+}
+
+func getXdsAddressFromWebhooks(client kube.ExtendedClient) (*xdsAddr, error) {
 	webhooks, err := client.Kube().AdmissionregistrationV1().MutatingWebhookConfigurations().List(context.Background(), metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("%s=%s,!istio.io/tag", label.IoIstioRev.Name, client.Revision()),
 	})
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	for _, whc := range webhooks.Items {
 		for _, wh := range whc.Webhooks {
 			if wh.ClientConfig.URL != nil {
-				u, _ := url.Parse(*wh.ClientConfig.URL)
-				return u.Host, nil
+				u, err := url.Parse(*wh.ClientConfig.URL)
+				if err != nil {
+					return nil, fmt.Errorf("parsing webhook URL: %w", err)
+				}
+				if isMCPAddr(u) {
+					return parseMCPAddr(u)
+				}
+				return &xdsAddr{host: u.Host}, nil
 			}
 		}
 	}
-	return "", errors.New("xds address not found")
+	return nil, errors.New("xds address not found")
 }
 
 // nolint: lll
@@ -202,7 +212,9 @@ func MultiRequestAndProcessXds(all bool, dr *xdsapi.DiscoveryRequest, centralOpt
 			// Attempt to get the XDS address from the webhook and try again
 			addr, err := getXdsAddressFromWebhooks(kubeClient)
 			if err == nil {
-				centralOpts.Xds = addr
+				centralOpts.Xds = addr.host
+				centralOpts.GCPProject = addr.gcpProject
+				centralOpts.IstiodAddr = addr.istiod
 				dialOpts, err := xds.DialOptions(centralOpts, istioNamespace, tokenServiceAccount, kubeClient)
 				if err != nil {
 					return nil, err

--- a/istioctl/pkg/multixds/google.go
+++ b/istioctl/pkg/multixds/google.go
@@ -1,0 +1,53 @@
+// Copyright Istio Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multixds
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+func isMCPAddr(u *url.URL) bool {
+	return strings.HasSuffix(u.Host, ".googleapis.com") || strings.HasSuffix(u.Host, ".googleapis.com:443")
+}
+
+func parseMCPAddr(u *url.URL) (*xdsAddr, error) {
+	ret := &xdsAddr{host: u.Host}
+	if !strings.HasSuffix(ret.host, ":443") {
+		ret.host += ":443"
+	}
+	const projSeg = "/projects/"
+	i := strings.Index(u.Path, projSeg)
+	if i == -1 {
+		return nil, fmt.Errorf("webhook URL %s doesn't contain the projects segment", u)
+	}
+	i += len(projSeg)
+	j := strings.IndexByte(u.Path[i:], '/')
+	if j == -1 {
+		return nil, fmt.Errorf("webhook URL %s is malformed", u)
+	}
+	ret.gcpProject = u.Path[i : i+j]
+
+	const crSeg = "/ISTIO_META_CLOUDRUN_ADDR/"
+	i += j
+	j = strings.Index(u.Path[i:], crSeg)
+	if j == -1 {
+		return nil, fmt.Errorf("webhook URL %s is missing %s", u, crSeg)
+	}
+	ret.istiod = u.Path[i+j+len(crSeg):]
+
+	return ret, nil
+}

--- a/istioctl/pkg/xds/client.go
+++ b/istioctl/pkg/xds/client.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"strings"
 
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"google.golang.org/grpc"
@@ -48,6 +49,7 @@ func GetXdsResponse(dr *xdsapi.DiscoveryRequest, ns string, serviceAccount strin
 			Generator:      "event",
 			ServiceAccount: serviceAccount,
 			Namespace:      ns,
+			CloudrunAddr:   opts.IstiodAddr,
 		}.ToStruct(),
 		CertDir:            opts.CertDir,
 		InsecureSkipVerify: opts.InsecureSkipVerify,
@@ -72,16 +74,30 @@ func GetXdsResponse(dr *xdsapi.DiscoveryRequest, ns string, serviceAccount strin
 
 // DialOptions constructs gRPC dial options from command line configuration
 func DialOptions(opts clioptions.CentralControlPlaneOptions,
-	ns string, serviceAccount string, kubeClient kube.ExtendedClient,
+	ns, serviceAccount string, kubeClient kube.ExtendedClient,
 ) ([]grpc.DialOption, error) {
+	ctx := context.TODO()
 	// If we are using the insecure 15010 don't bother getting a token
 	if opts.Plaintext || opts.CertDir != "" {
 		return make([]grpc.DialOption, 0), nil
 	}
 	// Use bearer token
-	supplier, err := kubeClient.CreatePerRPCCredentials(context.TODO(), ns, serviceAccount, tokenAudiences, defaultExpirationSeconds)
+	aud := tokenAudiences
+	isMCP := strings.HasSuffix(opts.Xds, ".googleapis.com") || strings.HasSuffix(opts.Xds, ".googleapis.com:443")
+	if isMCP {
+		// Special credentials handling when using ASM Managed Control Plane.
+		mem, err := getHubMembership(ctx, kubeClient)
+		if err != nil {
+			return nil, fmt.Errorf("failed to query Hub membership: %w", err)
+		}
+		aud = []string{mem.WorkloadIdentityPool}
+	}
+	k8sCreds, err := kubeClient.CreatePerRPCCredentials(ctx, ns, serviceAccount, aud, defaultExpirationSeconds)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create RPC credentials for \"%s.%s\": %w", serviceAccount, ns, err)
+	}
+	if isMCP {
+		return mcpDialOptions(ctx, opts.GCPProject, k8sCreds)
 	}
 	return []grpc.DialOption{
 		grpc.WithTransportCredentials(credentials.NewTLS(
@@ -90,6 +106,6 @@ func DialOptions(opts clioptions.CentralControlPlaneOptions,
 				// We don't set the XDSSAN for the same reason.
 				InsecureSkipVerify: true,
 			})),
-		grpc.WithPerRPCCredentials(supplier),
-	}, err
+		grpc.WithPerRPCCredentials(k8sCreds),
+	}, nil
 }

--- a/istioctl/pkg/xds/google.go
+++ b/istioctl/pkg/xds/google.go
@@ -1,0 +1,122 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package xds
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"strings"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/oauth"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"istio.io/istio/pkg/kube"
+)
+
+type meshAuthCredentials struct {
+	k8sCreds credentials.PerRPCCredentials
+	gcpCreds credentials.PerRPCCredentials
+	project  string
+}
+
+func (c *meshAuthCredentials) GetRequestMetadata(ctx context.Context, uri ...string) (map[string]string, error) {
+	ret := map[string]string{
+		"x-goog-user-project": c.project,
+	}
+	if err := updateAuthHdrs(ctx, uri, "k8s", c.k8sCreds, ret, "x-mesh-authorization"); err != nil {
+		return nil, err
+	}
+	if err := updateAuthHdrs(ctx, uri, "gcp", c.gcpCreds, ret, "authorization"); err != nil {
+		return nil, err
+	}
+	return ret, nil
+}
+
+func (*meshAuthCredentials) RequireTransportSecurity() bool {
+	return true
+}
+
+func updateAuthHdrs(ctx context.Context, uri []string, kind string, creds credentials.PerRPCCredentials, dst map[string]string, dstHdr string) error {
+	ret, err := creds.GetRequestMetadata(ctx, uri...)
+	if err != nil {
+		return err
+	}
+	for k, v := range ret {
+		if !strings.EqualFold(k, "authorization") {
+			if _, ok := dst[k]; ok {
+				return fmt.Errorf("underlying %s credentials contain a %s header which is already present in the combined credentials", kind, k)
+			}
+			dst[k] = v
+		} else {
+			dst[dstHdr] = v
+		}
+	}
+	return nil
+}
+
+type hubMembership struct {
+	WorkloadIdentityPool string
+}
+
+func getHubMembership(ctx context.Context, exClient kube.ExtendedClient) (*hubMembership, error) {
+	client := exClient.Dynamic()
+	gvr := schema.GroupVersionResource{
+		Group:    "hub.gke.io",
+		Version:  "v1",
+		Resource: "memberships",
+	}
+	u, err := client.Resource(gvr).Get(ctx, "membership", metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	spec, ok := u.Object["spec"].(map[string]interface{})
+	if !ok {
+		return nil, errors.New(`field "spec" is not a map`)
+	}
+	var mem hubMembership
+	mem.WorkloadIdentityPool, ok = spec["workload_identity_pool"].(string)
+	if !ok {
+		return nil, errors.New(`field "spec.workload_identity_pool" is not a string`)
+	}
+	return &mem, nil
+}
+
+func mcpDialOptions(ctx context.Context, gcpProject string, k8sCreds credentials.PerRPCCredentials) ([]grpc.DialOption, error) {
+	systemRoots, err := x509.SystemCertPool()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get system cert pool: %w", err)
+	}
+	gcpCreds, err := oauth.NewApplicationDefault(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get application default credentials: %w", err)
+	}
+
+	return []grpc.DialOption{
+		grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
+			RootCAs: systemRoots,
+		})),
+		grpc.WithPerRPCCredentials(&meshAuthCredentials{
+			k8sCreds: k8sCreds,
+			gcpCreds: gcpCreds,
+			project:  gcpProject,
+		}),
+	}, nil
+}

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -630,6 +630,9 @@ type NodeMetadata struct {
 	// redirected tcp listeners. This does not change the virtualOutbound listener.
 	OutboundListenerExactBalance StringBool `json:"OUTBOUND_LISTENER_EXACT_BALANCE,omitempty"`
 
+	// The istiod address when running ASM Managed Control Plane.
+	CloudrunAddr string `json:"CLOUDRUN_ADDR,omitempty"`
+
 	// Contains a copy of the raw metadata. This is needed to lookup arbitrary values.
 	// If a value is known ahead of time it should be added to the struct rather than reading from here,
 	Raw map[string]interface{} `json:"-"`


### PR DESCRIPTION
This makes istioctl:
a) Recognize proxied ASM Managed Control Plane webhook URLs
b) Use both ADC and K8s credentials to call ADS when proxied by ASM Managed Control Plane
c) Pass the Cloud Run URL in proxied ADS requests
d) Use ADS to call webhook when proxied by the ASM Managed Control Plane