### PR TITLE
[Dual Stack] Fix issues for gateway to make dual stack enable

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -419,9 +419,9 @@ func (configgen *ConfigGeneratorImpl) buildGatewayHTTPRouteConfig(node *model.Pr
 				hashByDestination := istio_route.GetConsistentHashForVirtualService(push, node, virtualService, nameToServiceMap)
 				routes, err = istio_route.BuildHTTPRoutesForVirtualService(node, virtualService, nameToServiceMap,
 					hashByDestination, port, map[string]bool{gatewayName: true}, isH3DiscoveryNeeded, push.Mesh, vskey)
-				if err != nil {
+				if err != nil || len(routes) == 0 {
 					log.Debugf("%s omitting routes for virtual service %v/%v due to error: %v", node.ID, virtualService.Namespace, virtualService.Name, err)
-					continue
+					return nil
 				}
 				gatewayRoutes[gatewayName][vskey] = routes
 			}

--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -475,6 +475,7 @@ func (configgen *ConfigGeneratorImpl) buildGatewayHTTPRouteConfig(node *model.Pr
 	for gwName, _ := range gatewayRoutes {
 		if len(gatewayRoutes[gwName]) > 0 {
 			noInvalidGWRoutes = false
+			break
 		}
 	}
 	// no any route configuration for all gateways based on given ports and virtual services

--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -340,15 +340,22 @@ func GetDestinationCluster(destination *networking.Destination, service *model.S
 	}
 
 	var clusterNames []string
-	clusterNames = append(clusterNames, model.BuildSubsetKey(model.TrafficDirectionOutbound, destination.Subset, host.Name(destination.Host), port))
-	if service != nil && len(service.DefaultAddresses) > 1 {
+	if service != nil {
 		for _, addr := range service.DefaultAddresses {
-			if net.ParseIP(addr) != nil && net.ParseIP(addr).To4() == nil && net.ParseIP(addr).To16() != nil {
-				clusterNames = append(clusterNames, model.BuildSubsetKey(model.TrafficDirectionOutbound6, destination.Subset, host.Name(destination.Host), port))
+			netIP := net.ParseIP(addr)
+			if netIP != nil && netIP.To4() == nil && netIP.To16() != nil {
+				// if dual stack enable, IPv6 only service should use 'outbound6',
+				// otherwise, keep the same behavior as IPv4 service
+				if features.EnableDualStack {
+					clusterNames = append(clusterNames, model.BuildSubsetKey(model.TrafficDirectionOutbound6, destination.Subset, host.Name(destination.Host), port))
+				} else {
+					clusterNames = append(clusterNames, model.BuildSubsetKey(model.TrafficDirectionOutbound, destination.Subset, host.Name(destination.Host), port))
+				}
+			} else {
+				clusterNames = append(clusterNames, model.BuildSubsetKey(model.TrafficDirectionOutbound, destination.Subset, host.Name(destination.Host), port))
 			}
 		}
 	}
-
 	return clusterNames
 }
 
@@ -482,6 +489,10 @@ func translateRoute(
 		applyRedirect(out, in.Redirect, listenPort)
 	} else {
 		applyHTTPRouteDestination(out, node, in, mesh, authority, serviceRegistry, listenPort, hashByDestination, vskey)
+		if out.Action == nil {
+			log.Infof("Action is nil")
+			return nil
+		}
 	}
 
 	out.Decorator = &route.Decorator{
@@ -652,6 +663,7 @@ func applyHTTPRouteDestination(
 			}
 		}
 	} else if len(weighted) == 0 {
+		out.Action = nil
 		return
 	} else {
 		action.ClusterSpecifier = &route.RouteAction_WeightedClusters{


### PR DESCRIPTION
**Please provide a description of this PR:**
Fix issues for gateway to make dual stack enable. 
If dual stack is enable in k8s cluster, but deploy applications are deployed without setting the IP families (the service of applications would be single stack as IPv4 by default)

Old version:
the route configuration of applications  virtual service may randomly be 404 which depends on the RDS sync situation, showing as below:
![image](https://user-images.githubusercontent.com/4101246/171825925-a04ddc26-c3ec-4fc2-b768-d185b5eddc08.png)

It is fixed in new version,
![image](https://user-images.githubusercontent.com/4101246/171826321-3e2e0537-bc8a-4bdc-82f7-29e27eb5f416.png)