### PR TITLE
Time: Compound literals should use key-value fields

### DIFF
--- a/pilot/pkg/leaderelection/k8sleaderelection/k8sresourcelock/leaselock.go
+++ b/pilot/pkg/leaderelection/k8sleaderelection/k8sresourcelock/leaselock.go
@@ -118,10 +118,10 @@ func LeaseSpecToLeaderElectionRecord(spec *coordinationv1.LeaseSpec) *LeaderElec
 		r.LeaderTransitions = int(*spec.LeaseTransitions)
 	}
 	if spec.AcquireTime != nil {
-		r.AcquireTime = metav1.Time{spec.AcquireTime.Time}
+		r.AcquireTime = metav1.Time{Time: spec.AcquireTime.Time}
 	}
 	if spec.RenewTime != nil {
-		r.RenewTime = metav1.Time{spec.RenewTime.Time}
+		r.RenewTime = metav1.Time{Time: spec.RenewTime.Time}
 	}
 	return &r
 }
@@ -132,8 +132,8 @@ func LeaderElectionRecordToLeaseSpec(ler *LeaderElectionRecord) coordinationv1.L
 	return coordinationv1.LeaseSpec{
 		HolderIdentity:       &ler.HolderIdentity,
 		LeaseDurationSeconds: &leaseDurationSeconds,
-		AcquireTime:          &metav1.MicroTime{ler.AcquireTime.Time},
-		RenewTime:            &metav1.MicroTime{ler.RenewTime.Time},
+		AcquireTime:          &metav1.MicroTime{Time: ler.AcquireTime.Time},
+		RenewTime:            &metav1.MicroTime{Time: ler.RenewTime.Time},
 		LeaseTransitions:     &leaseTransitions,
 	}
 }

--- a/pilot/pkg/leaderelection/k8sleaderelection/leaderelection_test.go
+++ b/pilot/pkg/leaderelection/k8sleaderelection/leaderelection_test.go
@@ -442,8 +442,8 @@ func TestLeaseSpecToLeaderElectionRecordRoundTrip(t *testing.T) {
 	oldSpec := coordinationv1.LeaseSpec{
 		HolderIdentity:       &holderIdentity,
 		LeaseDurationSeconds: &leaseDurationSeconds,
-		AcquireTime:          &metav1.MicroTime{time.Now()},
-		RenewTime:            &metav1.MicroTime{time.Now()},
+		AcquireTime:          &metav1.MicroTime{Time: time.Now()},
+		RenewTime:            &metav1.MicroTime{Time: time.Now()},
 		LeaseTransitions:     &leaseTransitions,
 	}
 


### PR DESCRIPTION
**Please provide a description of this PR:**

Time: Compound literals should use key-value fields