### PR TITLE
CNI UDS logger should accept log level of sender

### DIFF
--- a/cni/pkg/log/uds.go
+++ b/cni/pkg/log/uds.go
@@ -47,6 +47,7 @@ func NewUDSLogger() *UDSLogger {
 		Handler: mux,
 	}
 	l.loggingServer = loggingServer
+	pluginLog.SetOutputLevel(log.DebugLevel)
 	return l
 }
 

--- a/cni/pkg/log/uds_test.go
+++ b/cni/pkg/log/uds_test.go
@@ -42,7 +42,6 @@ func TestUDSLog(t *testing.T) {
 	loggingOptions.WithTeeToUDS(udsSock, constants.UDSLogPath)
 	log.Configure(loggingOptions)
 	log.FindScope("default").SetOutputLevel(log.DebugLevel)
-	log.FindScope("cni").SetOutputLevel(log.DebugLevel)
 	log.Debug("debug log")
 	log.Info("info log")
 	log.Warn("warn log")


### PR DESCRIPTION
Currently the UDS logger defaults to `info` logs and is not configurable to increase the logging level.  Because the UDS logger is simply a relay for the CNI plugin, it should default to the highest level the plugins allows (`debug`).

This PR sets the UDS logger to debug by default.

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [x] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure