### PR TITLE
docker: enable GC

### DIFF
--- a/tools/docker
+++ b/tools/docker
@@ -32,4 +32,4 @@ if [[ -f ${LOCAL_OUT}/docker-builder ]]; then
 else
   GOOS=${LOCAL_GO_OS} GOARCH=${LOCAL_GO_ARCH} ./common/scripts/gobuild.sh ${LOCAL_OUT}/docker-builder ./tools/docker-builder
 fi
-GOGC=off ${LOCAL_OUT}/docker-builder "$@"
+${LOCAL_OUT}/docker-builder "$@"


### PR DESCRIPTION
This was original turned off to fine-tune the crane builder; the thought
was size of RAM > size on images, so we don't really need to GC and we
shave off a few ms. However, this actually propogates down to a lot of
other calls, including the buildx call. This results in OOMs in some
environments trying to build. IMO the perf improvements are so small its
not really worth keeping it at all.

**Please provide a description of this PR:**