### PR TITLE
[tf] re-enable authz tests except for egress

### DIFF
--- a/tests/integration/security/authz/authz_test.go
+++ b/tests/integration/security/authz/authz_test.go
@@ -1119,6 +1119,8 @@ func TestAuthz_EgressGateway(t *testing.T) {
 		Label(label.IPv4). // https://github.com/istio/istio/issues/35835
 		Features("security.authorization.egress-gateway").
 		Run(func(t framework.TestContext) {
+			t.Skip("https://github.com/istio/istio/issues/39255")
+
 			allowed := apps.Ns1.A
 			denied := apps.Ns2.A
 

--- a/tests/integration/security/authz/main_test.go
+++ b/tests/integration/security/authz/main_test.go
@@ -37,7 +37,6 @@ var (
 func TestMain(m *testing.M) {
 	framework.
 		NewSuite(m).
-		Skip("https://github.com/istio/istio/issues/39255").
 		Setup(istio.Setup(nil, func(_ resource.Context, cfg *istio.Config) {
 			cfg.ControlPlaneValues = `
 values:


### PR DESCRIPTION
Based on [recent flakes](https://github.com/istio/istio/issues/39255) the egress test appears to be very flaky.

As a temporary fix, we accidentally [disabled](https://github.com/istio/istio/pull/39280) all authz tests.

This PR re-enables the authz test suite, but disables only the egress test.

**Please provide a description of this PR:**