### PR TITLE
TestBadRemoteSecret: wait for containers to ready before status check

### DIFF
--- a/tests/integration/pilot/multicluster_test.go
+++ b/tests/integration/pilot/multicluster_test.go
@@ -20,12 +20,12 @@ package pilot
 import (
 	"context"
 	"fmt"
-	"sigs.k8s.io/yaml"
 	"testing"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
 
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/cluster"

--- a/tests/integration/pilot/multicluster_test.go
+++ b/tests/integration/pilot/multicluster_test.go
@@ -288,7 +288,7 @@ stringData:
 				status := pod.Status.ContainerStatuses
 				if len(status) < 1 || !status[0].Ready {
 					conditions, _ := yaml.Marshal(pod.Status.ContainerStatuses)
-					return fmt.Errorf("%s not ready: %s", conditions)
+					return fmt.Errorf("%s not ready: %s", pod.Name, conditions)
 				}
 				return nil
 			}, retry.Timeout(time.Minute), retry.Delay(time.Second))

--- a/tests/integration/pilot/multicluster_test.go
+++ b/tests/integration/pilot/multicluster_test.go
@@ -20,6 +20,7 @@ package pilot
 import (
 	"context"
 	"fmt"
+	"sigs.k8s.io/yaml"
 	"testing"
 	"time"
 
@@ -265,6 +266,19 @@ stringData:
 				}
 			})
 
+			retry.UntilSuccessOrFail(t, func() error {
+				pod, err := pods.Get(context.TODO(), pod, metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+				for _, status := range pod.Status.ContainerStatuses {
+					if status.Started != nil && !*status.Started {
+						return fmt.Errorf("container %s in %s is not started", status.Name, pod)
+					}
+				}
+				return nil
+			}, retry.Timeout(5*time.Minute), retry.Delay(time.Second))
+
 			// make sure the pod comes up healthy
 			retry.UntilSuccessOrFail(t, func() error {
 				pod, err := pods.Get(context.TODO(), pod, metav1.GetOptions{})
@@ -273,7 +287,8 @@ stringData:
 				}
 				status := pod.Status.ContainerStatuses
 				if len(status) < 1 || !status[0].Ready {
-					return fmt.Errorf("%s not ready", pod)
+					conditions, _ := yaml.Marshal(pod.Status.ContainerStatuses)
+					return fmt.Errorf("%s not ready: %s", conditions)
 				}
 				return nil
 			}, retry.Timeout(time.Minute), retry.Delay(time.Second))


### PR DESCRIPTION
In some environments outside of KinD, just getting to the container start step may be delayed. This waits for that first before imposing the smaller timeout on readiness. 