### PR TITLE
Fix potentional deadlock between xdsproxy and Istiod

### DIFF
--- a/pkg/channels/unbounded.go
+++ b/pkg/channels/unbounded.go
@@ -1,0 +1,91 @@
+// Package buffer provides an implementation of an unbounded buffer.
+package channels
+
+// Heavily inspired by the private library from gRPC (https://raw.githubusercontent.com/grpc/grpc-go/master/internal/buffer/unbounded.go)
+// Since it cannot be imported directly it is mirror here. Original license:
+/*
+ * Copyright 2019 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import (
+	"sync"
+)
+
+// Unbounded is an implementation of an unbounded buffer which does not use
+// extra goroutines. This is typically used for passing updates from one entity
+// to another within gRPC.
+//
+// All methods on this type are thread-safe and don't block on anything except
+// the underlying mutex used for synchronization.
+//
+// Unbounded supports values of any type to be stored in it by using a channel
+// of `interface{}`. This means that a call to Put() incurs an extra memory
+// allocation, and also that users need a type assertion while reading. For
+// performance critical code paths, using Unbounded is strongly discouraged and
+// defining a new type specific implementation of this buffer is preferred. See
+// internal/transport/transport.go for an example of this.
+type Unbounded struct {
+	c       chan interface{}
+	mu      sync.Mutex
+	backlog []interface{}
+}
+
+// NewUnbounded returns a new instance of Unbounded.
+func NewUnbounded() *Unbounded {
+	return &Unbounded{c: make(chan interface{}, 1)}
+}
+
+// Put adds t to the unbounded buffer.
+// Put will never block
+func (b *Unbounded) Put(t interface{}) {
+	b.mu.Lock()
+	if len(b.backlog) == 0 {
+		select {
+		case b.c <- t:
+			b.mu.Unlock()
+			return
+		default:
+		}
+	}
+	b.backlog = append(b.backlog, t)
+	b.mu.Unlock()
+}
+
+// Load sends the earliest buffered data, if any, onto the read channel
+// returned by Get(). Users are expected to call this every time they read a
+// value from the read channel.
+func (b *Unbounded) Load() {
+	b.mu.Lock()
+	if len(b.backlog) > 0 {
+		n := new(interface{})
+		select {
+		case b.c <- b.backlog[0]:
+			b.backlog[0] = *n
+			b.backlog = b.backlog[1:]
+		default:
+		}
+	}
+	b.mu.Unlock()
+}
+
+// Get returns a read channel on which values added to the buffer, via Put(),
+// are sent on.
+//
+// Upon reading a value from this channel, users are expected to call Load() to
+// send the next buffered value onto the channel if there is any.
+func (b *Unbounded) Get() <-chan interface{} {
+	return b.c
+}

--- a/pkg/channels/unbounded_test.go
+++ b/pkg/channels/unbounded_test.go
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2019 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package channels
+
+import (
+	"reflect"
+	"sort"
+	"sync"
+	"testing"
+)
+
+const (
+	numWriters = 10
+	numWrites  = 10
+)
+
+// wantReads contains the set of values expected to be read by the reader
+// goroutine in the tests.
+var wantReads []int
+
+func init() {
+	for i := 0; i < numWriters; i++ {
+		for j := 0; j < numWrites; j++ {
+			wantReads = append(wantReads, i)
+		}
+	}
+}
+
+// TestSingleWriter starts one reader and one writer goroutine and makes sure
+// that the reader gets all the value added to the buffer by the writer.
+func TestSingleWriter(t *testing.T) {
+	ub := NewUnbounded[int]()
+	reads := []int{}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		ch := ub.Get()
+		for i := 0; i < numWriters*numWrites; i++ {
+			r := <-ch
+			reads = append(reads, r)
+			ub.Load()
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < numWriters; i++ {
+			for j := 0; j < numWrites; j++ {
+				ub.Put(i)
+			}
+		}
+	}()
+
+	wg.Wait()
+	if !reflect.DeepEqual(reads, wantReads) {
+		t.Errorf("reads: %#v, wantReads: %#v", reads, wantReads)
+	}
+}
+
+// TestMultipleWriters starts multiple writers and one reader goroutine and
+// makes sure that the reader gets all the data written by all writers.
+func TestMultipleWriters(t *testing.T) {
+	ub := NewUnbounded[int]()
+	reads := []int{}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		ch := ub.Get()
+		for i := 0; i < numWriters*numWrites; i++ {
+			r := <-ch
+			reads = append(reads, r)
+			ub.Load()
+		}
+	}()
+
+	wg.Add(numWriters)
+	for i := 0; i < numWriters; i++ {
+		go func(index int) {
+			defer wg.Done()
+			for j := 0; j < numWrites; j++ {
+				ub.Put(index)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	sort.Ints(reads)
+	if !reflect.DeepEqual(reads, wantReads) {
+		t.Errorf("reads: %#v, wantReads: %#v", reads, wantReads)
+	}
+}

--- a/pkg/channels/unbounded_test.go
+++ b/pkg/channels/unbounded_test.go
@@ -44,7 +44,7 @@ func init() {
 // TestSingleWriter starts one reader and one writer goroutine and makes sure
 // that the reader gets all the value added to the buffer by the writer.
 func TestSingleWriter(t *testing.T) {
-	ub := NewUnbounded[int]()
+	ub := NewUnbounded()
 	reads := []int{}
 
 	var wg sync.WaitGroup
@@ -54,7 +54,7 @@ func TestSingleWriter(t *testing.T) {
 		ch := ub.Get()
 		for i := 0; i < numWriters*numWrites; i++ {
 			r := <-ch
-			reads = append(reads, r)
+			reads = append(reads, r.(int))
 			ub.Load()
 		}
 	}()
@@ -78,7 +78,7 @@ func TestSingleWriter(t *testing.T) {
 // TestMultipleWriters starts multiple writers and one reader goroutine and
 // makes sure that the reader gets all the data written by all writers.
 func TestMultipleWriters(t *testing.T) {
-	ub := NewUnbounded[int]()
+	ub := NewUnbounded()
 	reads := []int{}
 
 	var wg sync.WaitGroup
@@ -88,7 +88,7 @@ func TestMultipleWriters(t *testing.T) {
 		ch := ub.Get()
 		for i := 0; i < numWriters*numWrites; i++ {
 			r := <-ch
-			reads = append(reads, r)
+			reads = append(reads, r.(int))
 			ub.Load()
 		}
 	}()

--- a/pkg/istio-agent/xds_proxy.go
+++ b/pkg/istio-agent/xds_proxy.go
@@ -272,7 +272,7 @@ type ProxyConnection struct {
 	downstreamError    chan error
 	requestsChan       *channels.Unbounded
 	responsesChan      chan *discovery.DiscoveryResponse
-	deltaRequestsChan  chan *discovery.DeltaDiscoveryRequest
+	deltaRequestsChan  *channels.Unbounded
 	deltaResponsesChan chan *discovery.DeltaDiscoveryResponse
 	stopChan           chan struct{}
 	downstream         adsStream

--- a/pkg/istio-agent/xds_proxy.go
+++ b/pkg/istio-agent/xds_proxy.go
@@ -238,7 +238,7 @@ func initXdsProxy(ia *Agent) (*XdsProxy, error) {
 func (p *XdsProxy) PersistRequest(req *discovery.DiscoveryRequest) {
 	p.connectedMutex.Lock()
 	// Immediately send if we are currently connect
-	if p.connected != nil {
+	if p.connected != nil && p.connected.requestsChan != nil {
 		p.connected.requestsChan.Put(req)
 	}
 	// Otherwise place it as our initial request for new connections

--- a/pkg/istio-agent/xds_proxy.go
+++ b/pkg/istio-agent/xds_proxy.go
@@ -47,6 +47,7 @@ import (
 	istiogrpc "istio.io/istio/pilot/pkg/grpc"
 	"istio.io/istio/pilot/pkg/xds"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
+	"istio.io/istio/pkg/channels"
 	"istio.io/istio/pkg/config/constants"
 	dnsProto "istio.io/istio/pkg/dns/proto"
 	"istio.io/istio/pkg/istio-agent/health"
@@ -235,24 +236,14 @@ func initXdsProxy(ia *Agent) (*XdsProxy, error) {
 // PersistRequest sends a request to the currently connected proxy. Additionally, on any reconnection
 // to the upstream XDS request we will resend this request.
 func (p *XdsProxy) PersistRequest(req *discovery.DiscoveryRequest) {
-	var ch chan *discovery.DiscoveryRequest
-	var stop chan struct{}
-
 	p.connectedMutex.Lock()
+	// Immediately send if we are currently connect
 	if p.connected != nil {
-		ch = p.connected.requestsChan
-		stop = p.connected.stopChan
+		p.connected.requestsChan.Put(req)
 	}
+	// Otherwise place it as our initial request for new connections
 	p.initialRequest = req
 	p.connectedMutex.Unlock()
-
-	// Immediately send if we are currently connect
-	if ch != nil {
-		select {
-		case ch <- req:
-		case <-stop:
-		}
-	}
 }
 
 func (p *XdsProxy) unregisterStream(c *ProxyConnection) {
@@ -279,7 +270,7 @@ type ProxyConnection struct {
 	conID              uint32
 	upstreamError      chan error
 	downstreamError    chan error
-	requestsChan       chan *discovery.DiscoveryRequest
+	requestsChan       *channels.Unbounded
 	responsesChan      chan *discovery.DiscoveryResponse
 	deltaRequestsChan  chan *discovery.DeltaDiscoveryRequest
 	deltaResponsesChan chan *discovery.DeltaDiscoveryResponse
@@ -293,10 +284,7 @@ type ProxyConnection struct {
 // sendRequest is a small wrapper around sending to con.requestsChan. This ensures that we do not
 // block forever on
 func (con *ProxyConnection) sendRequest(req *discovery.DiscoveryRequest) {
-	select {
-	case con.requestsChan <- req:
-	case <-con.stopChan:
-	}
+	con.requestsChan.Put(req)
 }
 
 type adsStream interface {
@@ -319,10 +307,29 @@ func (p *XdsProxy) handleStream(downstream adsStream) error {
 		conID:           connectionNumber.Inc(),
 		upstreamError:   make(chan error, 2), // can be produced by recv and send
 		downstreamError: make(chan error, 2), // can be produced by recv and send
-		requestsChan:    make(chan *discovery.DiscoveryRequest, 10),
-		responsesChan:   make(chan *discovery.DiscoveryResponse, 10),
-		stopChan:        make(chan struct{}),
-		downstream:      downstream,
+		// Requests channel is unbounded. The Envoy<->XDS Proxy<->Istiod system produces a natural
+		// looping of Recv and Send. Due to backpressure introduce by gRPC natively (that is, Send() can
+		// only send so much data without being Recv'd before it starts blocking), along with the
+		// backpressure provided by our channels, we have a risk of deadlock where both xdsproxy and
+		// Istiod are trying to Send, but both are blocked by gRPC backpressure until Recv() is called.
+		// However, Recv can fail to be called by Send being blocked. This can be triggered by the two
+		// sources in our system (Envoy request and Istiod pushes) producing more events than we can keep
+		// up with.
+		// See https://github.com/istio/istio/issues/39209 for more information
+		//
+		// To prevent these issues, we need to either:
+		// 1. Apply backpressure directly to Envoy requests or Istiod pushes
+		// 2. Make part of the system unbounded
+		//
+		// (1) is challenging because we cannot do a conditional Recv (for Envoy requests), and changing
+		// the control plane requires substantial changes. Instead, we make the requests channel
+		// unbounded. This is the least likely to cause issues as the messages we store here are the
+		// smallest relative to other channels.
+		requestsChan: channels.NewUnbounded(),
+		// Allow a buffer of 1. This ensures we queue up at most 2 (one in process, 1 pending) responses before forwarding.
+		responsesChan: make(chan *discovery.DiscoveryResponse, 1),
+		stopChan:      make(chan struct{}),
+		downstream:    downstream,
 	}
 
 	p.registerStream(con)
@@ -469,7 +476,9 @@ func (p *XdsProxy) handleUpstreamRequest(con *ProxyConnection) {
 	defer con.upstream.CloseSend() // nolint
 	for {
 		select {
-		case req := <-con.requestsChan:
+		case requ := <-con.requestsChan.Get():
+			con.requestsChan.Load()
+			req := requ.(*discovery.DiscoveryRequest)
 			if req.TypeUrl == v3.HealthInfoType && !initialRequestsSent.Load() {
 				// only send healthcheck probe after LDS request has been sent
 				continue

--- a/pkg/istio-agent/xds_proxy_delta.go
+++ b/pkg/istio-agent/xds_proxy_delta.go
@@ -318,7 +318,7 @@ func sendDownstreamDelta(deltaDownstream discovery.AggregatedDiscoveryService_De
 func (p *XdsProxy) persistDeltaRequest(req *discovery.DeltaDiscoveryRequest) {
 	p.connectedMutex.Lock()
 	// Immediately send if we are currently connect
-	if p.connected != nil {
+	if p.connected != nil && p.connected.deltaRequestsChan != nil {
 		p.connected.deltaRequestsChan.Put(req)
 	}
 	// Otherwise place it as our initial request for new connections

--- a/pkg/istio-agent/xds_proxy_delta.go
+++ b/pkg/istio-agent/xds_proxy_delta.go
@@ -28,6 +28,7 @@ import (
 	"istio.io/istio/pilot/pkg/features"
 	istiogrpc "istio.io/istio/pilot/pkg/grpc"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
+	"istio.io/istio/pkg/channels"
 	"istio.io/istio/pkg/istio-agent/metrics"
 	"istio.io/istio/pkg/wasm"
 )
@@ -35,10 +36,7 @@ import (
 // sendDeltaRequest is a small wrapper around sending to con.requestsChan. This ensures that we do not
 // block forever on
 func (con *ProxyConnection) sendDeltaRequest(req *discovery.DeltaDiscoveryRequest) {
-	select {
-	case con.deltaRequestsChan <- req:
-	case <-con.stopChan:
-	}
+	con.deltaRequestsChan.Put(req)
 }
 
 // DeltaAggregatedResources is an implementation of Delta XDS API used for proxying between Istiod and Envoy.
@@ -49,10 +47,11 @@ func (p *XdsProxy) DeltaAggregatedResources(downstream discovery.AggregatedDisco
 	proxyLog.Debugf("accepted delta xds connection from envoy, forwarding to upstream")
 
 	con := &ProxyConnection{
-		upstreamError:      make(chan error, 2), // can be produced by recv and send
-		downstreamError:    make(chan error, 2), // can be produced by recv and send
-		deltaRequestsChan:  make(chan *discovery.DeltaDiscoveryRequest, 10),
-		deltaResponsesChan: make(chan *discovery.DeltaDiscoveryResponse, 10),
+		upstreamError:     make(chan error, 2), // can be produced by recv and send
+		downstreamError:   make(chan error, 2), // can be produced by recv and send
+		deltaRequestsChan: channels.NewUnbounded(),
+		// Allow a buffer of 1. This ensures we queue up at most 2 (one in process, 1 pending) responses before forwarding.
+		deltaResponsesChan: make(chan *discovery.DeltaDiscoveryResponse, 1),
 		stopChan:           make(chan struct{}),
 		downstreamDeltas:   downstream,
 	}
@@ -193,7 +192,9 @@ func (p *XdsProxy) handleUpstreamDeltaRequest(con *ProxyConnection) {
 	}()
 	for {
 		select {
-		case req := <-con.deltaRequestsChan:
+		case requ := <-con.deltaRequestsChan.Get():
+			con.deltaRequestsChan.Load()
+			req := requ.(*discovery.DeltaDiscoveryRequest)
 			proxyLog.Debugf("delta request for type url %s", req.TypeUrl)
 			metrics.XdsProxyRequests.Increment()
 			if req.TypeUrl == v3.ExtensionConfigurationType {
@@ -315,22 +316,12 @@ func sendDownstreamDelta(deltaDownstream discovery.AggregatedDiscoveryService_De
 }
 
 func (p *XdsProxy) persistDeltaRequest(req *discovery.DeltaDiscoveryRequest) {
-	var ch chan *discovery.DeltaDiscoveryRequest
-	var stop chan struct{}
-
 	p.connectedMutex.Lock()
+	// Immediately send if we are currently connect
 	if p.connected != nil {
-		ch = p.connected.deltaRequestsChan
-		stop = p.connected.stopChan
+		p.connected.deltaRequestsChan.Put(req)
 	}
+	// Otherwise place it as our initial request for new connections
 	p.initialDeltaRequest = req
 	p.connectedMutex.Unlock()
-
-	// Immediately send if we are currently connect
-	if ch != nil {
-		select {
-		case ch <- req:
-		case <-stop:
-		}
-	}
 }

--- a/releasenotes/notes/xds-push-deadlock.yaml
+++ b/releasenotes/notes/xds-push-deadlock.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue: [39209]
+releaseNotes:
+- |
+  **Fixed** any issue that can cause xDS configuration updates to be blocked during high traffic.


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/39209.

This is a pretty complex issue; see the comments in the PR and the
original issue for more discussion

I had a really hard time adding a test for this. I tried for a while. What I did manually was to deploy 8 test namespaces at once (this is a large load, XDS is like 5mb each...). Before, it was almost always 5-10 pods stuck. With this, only delta pods got stuck because I hadn't yet fixed delta xds.