### PR TITLE
[Dual Stack] Fixed issues for IPv4 and IPv6 compat for prometheus and applications stats metrics scraping

### DIFF
--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -341,8 +341,8 @@ func (s *Server) Run(ctx context.Context) {
 	}
 	// for testing.
 	if s.statusPort == 0 {
-		addrs := strings.Split(l.Addr().String(), ":")
-		allocatedPort, _ := strconv.Atoi(addrs[len(addrs)-1])
+		_, hostPort, _ := net.SplitHostPort(l.Addr().String())
+		allocatedPort, _ := strconv.Atoi(hostPort)
 		s.mutex.Lock()
 		s.statusPort = uint16(allocatedPort)
 		s.mutex.Unlock()

--- a/pilot/cmd/pilot-agent/status/util/stats.go
+++ b/pilot/cmd/pilot-agent/status/util/stats.go
@@ -17,6 +17,7 @@ package util
 import (
 	"bytes"
 	"fmt"
+	"net"
 	"strconv"
 	"strings"
 	"time"
@@ -73,7 +74,9 @@ func GetReadinessStats(localHostAddr string, adminPort uint16) (*uint64, bool, e
 		localHostAddr = "localhost"
 	}
 
-	readinessURL := fmt.Sprintf("http://%s:%d/stats?usedonly&filter=%s", localHostAddr, adminPort, readyStatsRegex)
+	strPort := strconv.Itoa(int(adminPort))
+	hostPort := net.JoinHostPort(localHostAddr, strPort)
+	readinessURL := fmt.Sprintf("http://%s/stats?usedonly&filter=%s", hostPort, readyStatsRegex)
 	stats, err := http.DoHTTPGetWithTimeout(readinessURL, readinessTimeout)
 	if err != nil {
 		return nil, false, err
@@ -105,7 +108,9 @@ func GetUpdateStatusStats(localHostAddr string, adminPort uint16) (*Stats, error
 		localHostAddr = "localhost"
 	}
 
-	stats, err := http.DoHTTPGet(fmt.Sprintf("http://%s:%d/stats?usedonly&filter=%s", localHostAddr, adminPort, updateStatsRegex))
+	strPort := strconv.Itoa(int(adminPort))
+	hostPort := net.JoinHostPort(localHostAddr, strPort)
+	stats, err := http.DoHTTPGet(fmt.Sprintf("http://%s/stats?usedonly&filter=%s", hostPort, updateStatsRegex))
 	if err != nil {
 		return nil, err
 	}

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -514,17 +514,17 @@ func (configgen *ConfigGeneratorImpl) buildInboundClusters(cb *ClusterBuilder, p
 			endpointAddresses = append(endpointAddresses, ingressListener.DefaultEndpoint)
 		} else if len(ingressListener.DefaultEndpoint) > 0 {
 			// parse the ip, port. Validation guarantees presence of :
-			parts := strings.Split(ingressListener.DefaultEndpoint, ":")
-			if len(parts) < 2 {
+			hostIP, hostPort, hostErr := net.SplitHostPort(ingressListener.DefaultEndpoint)
+			if hostPort == "" || hostErr != nil {
 				continue
 			}
 			var err error
-			if port, err = strconv.Atoi(parts[1]); err != nil {
+			if port, err = strconv.Atoi(hostPort); err != nil {
 				continue
 			}
-			if parts[0] == model.PodIPAddressPrefix {
+			if hostIP == model.PodIPAddressPrefix {
 				endpointAddresses = append(endpointAddresses, cb.proxyIPAddresses[0])
-			} else if parts[0] == LocalhostAddress || parts[0] == LocalhostIPv6Address {
+			} else if hostIP == LocalhostAddress || hostIP == LocalhostIPv6Address {
 				for _, wildcard := range wildCards {
 					endpointAddresses = append(endpointAddresses, wildcard[1])
 				}

--- a/pilot/pkg/security/authn/v1beta1/policy_applier.go
+++ b/pilot/pkg/security/authn/v1beta1/policy_applier.go
@@ -16,6 +16,7 @@ package v1beta1
 
 import (
 	"fmt"
+	"net"
 	"net/url"
 	"sort"
 	"strconv"
@@ -240,13 +241,13 @@ func convertToEnvoyJwtConfig(jwtRules []*v1beta1.JWTRule, push *model.PushContex
 			// TODO: Implement the logic to auto-generate the cluster so that when the flag is enabled,
 			// it will always let envoy to fetch the jwks for consistent behavior.
 			u, _ := url.Parse(jwtRule.JwksUri)
-			hostAndPort := strings.Split(u.Host, ":")
-			host := hostAndPort[0]
+			hostIP, hostPort, _ := net.SplitHostPort(u.Host)
+			host := hostIP
 			// TODO: Default port based on scheme ?
 			port := 80
-			if len(hostAndPort) == 2 {
+			if hostPort != "" {
 				var err error
-				if port, err = strconv.Atoi(hostAndPort[1]); err != nil {
+				if port, err = strconv.Atoi(hostPort); err != nil {
 					port = 80 // If port is not specified or there is an error in parsing default to 80.
 				}
 			}


### PR DESCRIPTION
Fixed issues for IPv4 and IPv6 compat for prometheus and applications stats metrics scraping
Get following error when enable pilot-agent stats metrics scraping:

```
2022-06-07T03:43:01.067302Z     error   failed scraping envoy metrics: error scraping http://localhost:15090/stats/prometheus: Get "http://localhost:15090/stats/prometheus": dial tcp [::1]:15090: connect: connection refused\
2022-06-07T03:43:14.939616Z     error   failed scraping envoy metrics: error scraping http://localhost:15090/stats/prometheus: Get "http://localhost:15090/stats/prometheus": dial tcp [::1]:15090: connect: connection refused\
2022-06-07T03:43:26.783580Z     info    Agent draining Proxy\
2022-06-07T03:43:26.783582Z     info    Status server has successfully terminated\
```