### PR TITLE
[tf] flag to only deploy specific apps istio.test.onlyWorkloads

### DIFF
--- a/pkg/test/framework/components/echo/deployment/builder.go
+++ b/pkg/test/framework/components/echo/deployment/builder.go
@@ -132,11 +132,6 @@ func (b builder) With(i *echo.Instance, cfg echo.Config) Builder {
 		return b
 	}
 
-	if !filterConfig(cfg) {
-		scopes.Framework.Infof("filtered echo config %s due to istio.test.echo.filter.match", cfg)
-		return b
-	}
-
 	cfg = cfg.DeepCopy()
 	if err := cfg.FillDefaults(b.ctx); err != nil {
 		b.errs = multierror.Append(b.errs, err)

--- a/pkg/test/framework/components/echo/deployment/builder.go
+++ b/pkg/test/framework/components/echo/deployment/builder.go
@@ -138,6 +138,11 @@ func (b builder) With(i *echo.Instance, cfg echo.Config) Builder {
 		return b
 	}
 
+	shouldSkip := b.ctx.Settings().Skip(cfg.WorkloadClass())
+	if shouldSkip {
+		return b
+	}
+
 	// cache the namespace, so manually added echo.Configs can be a part of it
 	b.namespaces[cfg.Namespace.Prefix()] = cfg.Namespace
 
@@ -146,8 +151,6 @@ func (b builder) With(i *echo.Instance, cfg echo.Config) Builder {
 		targetClusters = cluster.Clusters{cfg.Cluster}
 	}
 
-	// If we didn't deploy VMs, but we don't care about VMs, we can ignore this.
-	shouldSkip := b.ctx.Settings().Skip(echo.VM) && cfg.IsVM()
 	deployedTo := 0
 	for idx, c := range targetClusters {
 		ec, ok := c.(echo.Cluster)

--- a/pkg/test/framework/components/echo/deployment/builder.go
+++ b/pkg/test/framework/components/echo/deployment/builder.go
@@ -132,6 +132,11 @@ func (b builder) With(i *echo.Instance, cfg echo.Config) Builder {
 		return b
 	}
 
+	if !filterConfig(cfg) {
+		scopes.Framework.Infof("filtered echo config %s due to istio.test.echo.filter.match", cfg)
+		return b
+	}
+
 	cfg = cfg.DeepCopy()
 	if err := cfg.FillDefaults(b.ctx); err != nil {
 		b.errs = multierror.Append(b.errs, err)

--- a/pkg/test/framework/components/echo/deployment/flags.go
+++ b/pkg/test/framework/components/echo/deployment/flags.go
@@ -18,49 +18,20 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"gopkg.in/yaml.v3"
-	"istio.io/istio/pkg/test/scopes"
-	"istio.io/istio/pkg/test/util/tmpl"
 	"os"
-	"regexp"
+
+	"gopkg.in/yaml.v3"
 
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/config"
 	"istio.io/istio/pkg/test/util/file"
 )
 
-const defaultEchoConfigFilterTmpl = "{{.Service}}"
-
-var (
-	additionalConfigs = &configs{}
-
-	configFilter, configFilterTmpl string
-)
+var additionalConfigs = &configs{}
 
 func init() {
 	flag.Var(additionalConfigs, "istio.test.echo.configs", "The path to a file containing a list of "+
 		"echo.Config in YAML which will be added to the set of echos for every suite.")
-	flag.StringVar(&configFilter, "istio.test.echo.filter.match", "", "A regex that all echo configs must match "+
-		"or deployment will be skipped.")
-	flag.StringVar(&configFilterTmpl, "istio.test.echo.filter.matchTemplate", defaultEchoConfigFilterTmpl, "Template rendered from the echo.Config that "+
-		"builds a string for istio.test.echo.filter.match to check against.")
-}
-
-func filterConfig(config echo.Config) bool {
-	if configFilter == "" {
-		return true
-	}
-	configFilterRe, err := regexp.Compile(configFilter)
-	if err != nil {
-		scopes.Framework.Errorf("failed to compile regexp for istio.test.echo.filter.match: %v", err)
-		return true
-	}
-	filterStr, err := tmpl.Evaluate(configFilterTmpl, config)
-	if err != nil {
-		scopes.Framework.Errorf("failed evaluating template for istio.test.echo.filter.matchTemplate: %v", err)
-		return true
-	}
-	return configFilterRe.MatchString(filterStr)
 }
 
 // configs wraps a slice of echo.Config to implement the config.Value interface, allowing

--- a/pkg/test/framework/resource/flags.go
+++ b/pkg/test/framework/resource/flags.go
@@ -144,6 +144,9 @@ func init() {
 	flag.Var(&settingsFromCommandLine.SkipWorkloadClasses, "istio.test.skipWorkloads",
 		"Skips deploying and using workloads of the given comma-separated classes (e.g. vm, proxyless, etc.)")
 
+	flag.Var(&settingsFromCommandLine.OnlyWorkloadClasses, "istio.test.onlyWorkloads",
+		"Skips deploying and using workloads not included in the given comma-separated classes (e.g. vm, proxyless, etc.)")
+
 	flag.IntVar(&settingsFromCommandLine.Retries, "istio.test.retries", settingsFromCommandLine.Retries,
 		"Number of times to retry tests")
 

--- a/pkg/test/framework/resource/settings.go
+++ b/pkg/test/framework/resource/settings.go
@@ -114,6 +114,9 @@ type Settings struct {
 	// SkipWorkloadClasses can be used to skip deploying special workload types like TPROXY, VMs, etc.
 	SkipWorkloadClasses ArrayFlags
 
+	// OnlyWorkloadClasses can be used to only deploy specific workload types like TPROXY, VMs, etc.
+	OnlyWorkloadClasses ArrayFlags
+
 	// The label selector, in parsed form.
 	Selector label.Selector
 
@@ -159,11 +162,21 @@ type Settings struct {
 }
 
 func (s Settings) Skip(class string) bool {
-	return s.SkipWorkloadClassesAsSet().Contains(class)
+	if s.SkipWorkloadClassesAsSet().Contains(class) {
+		return true
+	}
+	if len(s.OnlyWorkloadClasses) > 0 && !s.OnlyWorkloadClassesAsSet().Contains(class) {
+		return true
+	}
+	return false
 }
 
 func (s *Settings) SkipWorkloadClassesAsSet() sets.Set {
 	return sets.New(s.SkipWorkloadClasses...)
+}
+
+func (s *Settings) OnlyWorkloadClassesAsSet() sets.Set {
+	return sets.New(s.OnlyWorkloadClasses...)
 }
 
 // RunDir is the name of the dir to output, for this particular run.

--- a/prow/integ-suite-kind.sh
+++ b/prow/integ-suite-kind.sh
@@ -104,8 +104,10 @@ while (( "$#" )); do
   esac
 done
 
-echo "Checking CPU..."
-grep 'model' /proc/cpuinfo
+if [ -f /proc/cpuinfo ]; then
+  echo "Checking CPU..."
+  grep 'model' /proc/cpuinfo
+fi
 
 # Default IP family of the cluster is IPv4
 export IP_FAMILY="${IP_FAMILY:-ipv4}"


### PR DESCRIPTION
For workload agnostic tests, this allows targeting specific types of deployments. Example usage:

```
go test tests/integration/pilot/... --istio.test.onlyWorkloads proxyless
```

Not very useful on it's own without ways to skip tests that aren't workload agnostic