### PR TITLE
[Dual Stack] Fixed bug for istio-agent status server

### DIFF
--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -288,6 +288,10 @@ func initProxy(args []string) (*model.Proxy, error) {
 	// After IP addresses are set, let us discover IPMode.
 	proxy.DiscoverIPMode()
 
+	if proxy.SupportsIPv4() && proxy.SupportsIPv6() && !options.DualStackEnv {
+		log.Info("proxy has both an IPv6 and IPv4 address, but ISTIO_AGENT_DUAL_STACK not set to true")
+	}
+
 	// Extract pod variables.
 	podName := options.PodNameVar.Get()
 	podNamespace := options.PodNamespaceVar.Get()

--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -164,6 +164,14 @@ func NewServer(config Options) (*Server, error) {
 	if config.IPv6 {
 		localhost = localHostIPv6
 		upstreamLocalAddress = UpstreamLocalAddressIPv6
+	} else {
+		// if not ipv6-only, it can be ipv4-only or dual-stack
+		// let InstanceIP decide the localhost
+		netIP := net.ParseIP(config.PodIP)
+		if netIP.To4() == nil && netIP.To16() != nil && !netIP.IsLinkLocalUnicast() {
+			localhost = localHostIPv6
+			upstreamLocalAddress = UpstreamLocalAddressIPv6
+		}
 	}
 	probes := make([]ready.Prober, 0)
 	if !config.NoEnvoy {


### PR DESCRIPTION
Fixed bug for istio-agent status server, should respect the value of InstanceIP for the pod when new a status server.