### PR TITLE
Stop previous remote cluster when updating secret

### DIFF
--- a/releasenotes/notes/39366.yaml
+++ b/releasenotes/notes/39366.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 39366
+releaseNotes:
+  - |
+    **Fixed** bug when updating a multicluster secret, the previous cluster is not stopped. Even delete the secret can not stop the previous cluster


### PR DESCRIPTION
**Please provide a description of this PR:**

Fix: #39366

The root cause is that we never stop the previous remote cluster when updating the secret.




**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
