### PR TITLE
only check for verified identify if xds auth is enabled

### DIFF
--- a/pilot/pkg/xds/ecds.go
+++ b/pilot/pkg/xds/ecds.go
@@ -21,6 +21,7 @@ import (
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 
 	credscontroller "istio.io/istio/pilot/pkg/credentials"
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/model/credentials"
 	"istio.io/istio/pilot/pkg/networking/util"
@@ -121,7 +122,7 @@ func (e *EcdsGenerator) Generate(proxy *model.Proxy, w *model.WatchedResource, r
 func (e *EcdsGenerator) GeneratePullSecrets(proxy *model.Proxy, updatedSecrets map[model.ConfigKey]struct{}, secretResources []SecretResource,
 	secretController credscontroller.Controller, req *model.PushRequest,
 ) map[string][]byte {
-	if proxy.VerifiedIdentity == nil {
+	if features.XDSAuth && features.EnableXDSIdentityCheck && proxy.VerifiedIdentity == nil {
 		log.Warnf("proxy %s is not authorized to receive secret. Ensure you are connecting over TLS port and are authenticated.", proxy.ID)
 		return nil
 	}


### PR DESCRIPTION
In ECDS we verify proxy's VerifiedIdentity for sending config for pulling secrets. But if Istiod runs behind gateway/proxy that terminates TLS, people disable XdsAuth but the proxy is still trusted. So we should only verify identity if XdsAuth is enabled.

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure