### PR TITLE
Add new well known pilot dns TLS cert loading - making it zero config for istio-csr installation

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -1732,6 +1732,10 @@ spec:
           - name: istio-kubeconfig
             mountPath: /var/run/secrets/remote
             readOnly: true
+          - name: istio-csr-dns-cert
+            mountPath: /var/run/secrets/istiod/tls
+          - name: istio-csr-ca-configmap
+            mountPath: /var/run/secrets/istiod/ca
       volumes:
       # Technically not needed on this pod - but it helps debugging/testing SDS
       # Should be removed after everything works.

--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -1760,6 +1760,16 @@ spec:
         secret:
           secretName: istio-kubeconfig
           optional: true
+      # Optional: istio-csr dns pilot certs
+      - name: istio-csr-dns-cert
+        secret:
+          secretName: istiod-tls
+          optional: true
+      - name: istio-csr-ca-configmap
+        configMap:
+          name: istio-ca-root-cert
+          defaultMode: 420
+          optional: true
 ---
 # Source: istiod/templates/autoscale.yaml
 apiVersion: autoscaling/v2

--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -1734,8 +1734,10 @@ spec:
             readOnly: true
           - name: istio-csr-dns-cert
             mountPath: /var/run/secrets/istiod/tls
+            readOnly: true
           - name: istio-csr-ca-configmap
             mountPath: /var/run/secrets/istiod/ca
+            readOnly: true
       volumes:
       # Technically not needed on this pod - but it helps debugging/testing SDS
       # Should be removed after everything works.

--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -206,8 +206,10 @@ spec:
           {{- end }}
           - name: istio-csr-dns-cert
             mountPath: /var/run/secrets/istiod/tls
+            readOnly: true
           - name: istio-csr-ca-configmap
             mountPath: /var/run/secrets/istiod/ca
+            readOnly: true
       volumes:
       # Technically not needed on this pod - but it helps debugging/testing SDS
       # Should be removed after everything works.

--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -243,7 +243,7 @@ spec:
           optional: true
       - name: istio-csr-ca-configmap
         configMap:
-          name: istio-ca-root-configmap
+          name: istio-ca-root-cert
           defaultMode: 420
         optional": true
   {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -245,6 +245,6 @@ spec:
         configMap:
           name: istio-ca-root-cert
           defaultMode: 420
-        optional": true
+          optional: true
   {{- end }}
 ---

--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -243,7 +243,7 @@ spec:
           optional: true
       - name: istio-csr-ca-configmap
         configMap:
-          name: istio-ca-root-cert
+          name: istio-ca-root-configmap
           defaultMode: 420
         optional": true
   {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -234,10 +234,6 @@ spec:
         secret:
           secretName: istio-kubeconfig
           optional: true
-  {{- if .Values.pilot.jwksResolverExtraRootCA }}
-      - name: extracacerts
-        configMap:
-          name: pilot-jwks-extra-cacerts{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
       # Optional: istio-csr dns pilot certs
       - name: istio-csr-dns-cert
         secret:
@@ -248,5 +244,10 @@ spec:
           name: istio-ca-root-cert
           defaultMode: 420
           optional: true
+  {{- if .Values.pilot.jwksResolverExtraRootCA }}
+      - name: extracacerts
+        configMap:
+          name: pilot-jwks-extra-cacerts{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- end }}
+
 ---

--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -204,6 +204,10 @@ spec:
           - name: extracacerts
             mountPath: /cacerts
           {{- end }}
+          - name: istio-csr-dns-cert
+            mountPath: /var/run/secrets/istiod/tls
+          - name: istio-csr-ca-configmap
+            mountPath: /var/run/secrets/istiod/ca
       volumes:
       # Technically not needed on this pod - but it helps debugging/testing SDS
       # Should be removed after everything works.
@@ -232,5 +236,15 @@ spec:
       - name: extracacerts
         configMap:
           name: pilot-jwks-extra-cacerts{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
+      # Optional: istio-csr dns pilot certs
+      - name: istio-csr-dns-cert
+        secret:
+          secretName: istiod-tls
+          optional: true
+      - name: istio-csr-ca-configmap
+        configMap:
+          name: istio-ca-root-cert
+          defaultMode: 420
+        optional": true
   {{- end }}
 ---

--- a/pilot/pkg/bootstrap/certcontroller.go
+++ b/pilot/pkg/bootstrap/certcontroller.go
@@ -237,7 +237,7 @@ func (s *Server) initCertificateWatches(tlsOptions TLSOptions) error {
 				select {
 				case <-keyCertTimerC:
 					keyCertTimerC = nil
-					if err := s.istiodCertBundleWatcher.SetFromFilesAndNotify(tlsOptions.KeyFile, tlsOptions.CertFile,  tlsOptions.CaCertFile); err != nil {
+					if err := s.istiodCertBundleWatcher.SetFromFilesAndNotify(tlsOptions.KeyFile, tlsOptions.CertFile, tlsOptions.CaCertFile); err != nil {
 						log.Errorf("Setting keyCertBundle failed: %v", err)
 					}
 				case <-s.fileWatcher.Events(tlsOptions.CertFile):

--- a/pilot/pkg/bootstrap/certcontroller.go
+++ b/pilot/pkg/bootstrap/certcontroller.go
@@ -219,7 +219,7 @@ func (s *Server) updatePluggedinRootCertAndGenKeyCert() error {
 }
 
 // initCertificateWatches sets up watches for the plugin dns certs.
-func (s *Server) initCertificateWatches(keyFilePath, certFilePath, caCertFilePath string) error {
+func (s *Server) initCertificateWatches(certFilePath, keyFilePath, caCertFilePath string) error {
 	if err := s.istiodCertBundleWatcher.SetFromFilesAndNotify(keyFilePath, certFilePath, caCertFilePath); err != nil {
 		return fmt.Errorf("set keyCertBundle failed: %v", err)
 	}

--- a/pilot/pkg/bootstrap/certcontroller.go
+++ b/pilot/pkg/bootstrap/certcontroller.go
@@ -219,12 +219,12 @@ func (s *Server) updatePluggedinRootCertAndGenKeyCert() error {
 }
 
 // initCertificateWatches sets up watches for the plugin dns certs.
-func (s *Server) initCertificateWatches(certFilePath, keyFilePath, caCertFilePath string) error {
-	if err := s.istiodCertBundleWatcher.SetFromFilesAndNotify(keyFilePath, certFilePath, caCertFilePath); err != nil {
+func (s *Server) initCertificateWatches(tlsOptions TLSOptions) error {
+	if err := s.istiodCertBundleWatcher.SetFromFilesAndNotify(tlsOptions.KeyFile, tlsOptions.CertFile, tlsOptions.CaCertFile); err != nil {
 		return fmt.Errorf("set keyCertBundle failed: %v", err)
 	}
 	// TODO: Setup watcher for root and restart server if it changes.
-	for _, file := range []string{certFilePath, keyFilePath} {
+	for _, file := range []string{tlsOptions.CertFile, tlsOptions.KeyFile} {
 		log.Infof("adding watcher for certificate %s", file)
 		if err := s.fileWatcher.Add(file); err != nil {
 			return fmt.Errorf("could not watch %v: %v", file, err)
@@ -237,21 +237,21 @@ func (s *Server) initCertificateWatches(certFilePath, keyFilePath, caCertFilePat
 				select {
 				case <-keyCertTimerC:
 					keyCertTimerC = nil
-					if err := s.istiodCertBundleWatcher.SetFromFilesAndNotify(keyFilePath, certFilePath, caCertFilePath); err != nil {
+					if err := s.istiodCertBundleWatcher.SetFromFilesAndNotify(tlsOptions.KeyFile, tlsOptions.CertFile,  tlsOptions.CaCertFile); err != nil {
 						log.Errorf("Setting keyCertBundle failed: %v", err)
 					}
-				case <-s.fileWatcher.Events(certFilePath):
+				case <-s.fileWatcher.Events(tlsOptions.CertFile):
 					if keyCertTimerC == nil {
 						keyCertTimerC = time.After(watchDebounceDelay)
 					}
-				case <-s.fileWatcher.Events(keyFilePath):
+				case <-s.fileWatcher.Events(tlsOptions.KeyFile):
 					if keyCertTimerC == nil {
 						keyCertTimerC = time.After(watchDebounceDelay)
 					}
-				case err := <-s.fileWatcher.Errors(certFilePath):
-					log.Errorf("error watching %v: %v", certFilePath, err)
-				case err := <-s.fileWatcher.Errors(keyFilePath):
-					log.Errorf("error watching %v: %v", keyFilePath, err)
+				case err := <-s.fileWatcher.Errors(tlsOptions.CertFile):
+					log.Errorf("error watching %v: %v", tlsOptions.CertFile, err)
+				case err := <-s.fileWatcher.Errors(tlsOptions.KeyFile):
+					log.Errorf("error watching %v: %v", tlsOptions.KeyFile, err)
 				case <-stop:
 					return
 				}

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -951,8 +951,9 @@ func (s *Server) initIstiodCerts(args *PilotArgs, host string) error {
 		// Use the DNS certificate provided via args or in well known location.
 		err = s.initCertificateWatches(TLSOptions{
 			CaCertFile: caCertPath,
-			KeyFile: tlsKeyPath,
-			CertFile: tlsCertPath})
+			KeyFile:    tlsKeyPath,
+			CertFile:   tlsCertPath,
+		})
 
 		if err != nil {
 			// Not crashing istiod - This typically happens if certs are missing and in tests.

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -947,7 +947,7 @@ func (s *Server) initIstiodCerts(args *PilotArgs, host string) error {
 	var err error
 
 	s.dnsNames = getDNSNames(args, host)
-	if hasCustomCertArgsOrWellKnown, tlsCertPath, tlsKeyPath, caCertPath := hasCustomTLSCerts(args.ServerOptions.TLSOptions) ; hasCustomCertArgsOrWellKnown {
+	if hasCustomCertArgsOrWellKnown, tlsCertPath, tlsKeyPath, caCertPath := hasCustomTLSCerts(args.ServerOptions.TLSOptions); hasCustomCertArgsOrWellKnown {
 		// Use the DNS certificate provided via args or in well known location.
 		err = s.initCertificateWatches(tlsCertPath, tlsKeyPath, caCertPath)
 
@@ -1060,27 +1060,27 @@ func (s *Server) createPeerCertVerifier(tlsOptions TLSOptions) (*spiffe.PeerCert
 	return peerCertVerifier, nil
 }
 
-func checkPathsExist(paths ...string) (bool) {
-		for _ , path := range paths {
-			fInfo, err = os.Stat(path)
+func checkPathsExist(paths ...string) bool {
+	for _, path := range paths {
+		fInfo, err = os.Stat(path)
 
-			if err != nil && !fInfo.IsDir() {
-				return true	
-			}		
+		if err != nil && !fInfo.IsDir() {
+			return true
 		}
-		return false
+	}
+	return false
 }
 
 // hasCustomTLSCerts returns true if custom TLS certificates are configured via args.
 func hasCustomTLSCerts(tlsOptions TLSOptions) (ok bool, tlsCertPath, tlsKeyPath, caCertPath string) {
 	// load from tls args as priority
 	if tlsOptions.CaCertFile != "" && tlsOptions.CertFile != "" && tlsOptions.KeyFile != "" {
-		return true,  tlsOptions.CertFile, tlsOptions.KeyFile, tlsOptions.CaCertFile
+		return true, tlsOptions.CertFile, tlsOptions.KeyFile, tlsOptions.CaCertFile
 	} else {
 		if ok = checkPathsExist(constants.DefaultPilotTLSCert, constants.DefaultPilotTLSKey, constants.DefaultPilotTLSCaCert); ok {
 			tlsCertPath = constants.DefaultPilotTLSCert
-			tlsKeyPath =  constants.DefaultPilotTLSKey
-			caCertPath =  constants.DefaultPilotTLSCaCert
+			tlsKeyPath = constants.DefaultPilotTLSKey
+			caCertPath = constants.DefaultPilotTLSCaCert
 			return
 		}
 	}

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -1062,7 +1062,7 @@ func (s *Server) createPeerCertVerifier(tlsOptions TLSOptions) (*spiffe.PeerCert
 
 func checkPathsExist(paths ...string) bool {
 	for _, path := range paths {
-		fInfo, err = os.Stat(path)
+		fInfo, err := os.Stat(path)
 
 		if err != nil && !fInfo.IsDir() {
 			return true

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -1064,7 +1064,7 @@ func checkPathsExist(paths ...string) bool {
 	for _, path := range paths {
 		fInfo, err := os.Stat(path)
 
-		if err != nil || !fInfo.IsDir() {
+		if err != nil || fInfo.IsDir() {
 			return false
 		}
 	}

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -1077,14 +1077,15 @@ func hasCustomTLSCerts(tlsOptions TLSOptions) (ok bool, tlsCertPath, tlsKeyPath,
 	// load from tls args as priority
 	if hasCustomTLSCertArgs(tlsOptions) {
 		return true, tlsOptions.CertFile, tlsOptions.KeyFile, tlsOptions.CaCertFile
-	} else {
-		if ok = checkPathsExist(constants.DefaultPilotTLSCert, constants.DefaultPilotTLSKey, constants.DefaultPilotTLSCaCert); ok {
-			tlsCertPath = constants.DefaultPilotTLSCert
-			tlsKeyPath = constants.DefaultPilotTLSKey
-			caCertPath = constants.DefaultPilotTLSCaCert
-			return
-		}
 	}
+
+	if ok = checkPathsExist(constants.DefaultPilotTLSCert, constants.DefaultPilotTLSKey, constants.DefaultPilotTLSCaCert); ok {
+		tlsCertPath = constants.DefaultPilotTLSCert
+		tlsKeyPath = constants.DefaultPilotTLSKey
+		caCertPath = constants.DefaultPilotTLSCaCert
+		return
+	}
+
 	return
 }
 

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -1086,6 +1086,13 @@ func hasCustomTLSCerts(tlsOptions TLSOptions) (ok bool, tlsCertPath, tlsKeyPath,
 		return
 	}
 
+	if ok = checkPathsExist(constants.DefaultPilotTLSCert, constants.DefaultPilotTLSKey, constants.DefaultPilotTLSCaCertAlternatePath); ok {
+		tlsCertPath = constants.DefaultPilotTLSCert
+		tlsKeyPath = constants.DefaultPilotTLSKey
+		caCertPath = constants.DefaultPilotTLSCaCertAlternatePath
+		return
+	}
+
 	return
 }
 

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -949,7 +949,10 @@ func (s *Server) initIstiodCerts(args *PilotArgs, host string) error {
 	s.dnsNames = getDNSNames(args, host)
 	if hasCustomCertArgsOrWellKnown, tlsCertPath, tlsKeyPath, caCertPath := hasCustomTLSCerts(args.ServerOptions.TLSOptions); hasCustomCertArgsOrWellKnown {
 		// Use the DNS certificate provided via args or in well known location.
-		err = s.initCertificateWatches(tlsCertPath, tlsKeyPath, caCertPath)
+		err = s.initCertificateWatches(TLSOptions{
+			CaCertFile: caCertPath,
+			KeyFile: tlsKeyPath,
+			CertFile: tlsCertPath})
 
 		if err != nil {
 			// Not crashing istiod - This typically happens if certs are missing and in tests.

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -1064,11 +1064,11 @@ func checkPathsExist(paths ...string) bool {
 	for _, path := range paths {
 		fInfo, err := os.Stat(path)
 
-		if err != nil && !fInfo.IsDir() {
-			return true
+		if err != nil || !fInfo.IsDir() {
+			return false
 		}
 	}
-	return false
+	return true
 }
 
 // hasCustomTLSCerts returns the tls cert paths, used both if custom TLS certificates are configured via args or by mounting in well known.

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -1071,10 +1071,11 @@ func checkPathsExist(paths ...string) bool {
 	return false
 }
 
-// hasCustomTLSCerts returns true if custom TLS certificates are configured via args.
+// hasCustomTLSCerts returns the tls cert paths, used both if custom TLS certificates are configured via args or by mounting in well known.
+// while tls args should still take precedence the aim is to encourage loading the DNS tls cert in the well known path locations.
 func hasCustomTLSCerts(tlsOptions TLSOptions) (ok bool, tlsCertPath, tlsKeyPath, caCertPath string) {
 	// load from tls args as priority
-	if tlsOptions.CaCertFile != "" && tlsOptions.CertFile != "" && tlsOptions.KeyFile != "" {
+	if hasCustomTLSCertArgs(tlsOptions) {
 		return true, tlsOptions.CertFile, tlsOptions.KeyFile, tlsOptions.CaCertFile
 	} else {
 		if ok = checkPathsExist(constants.DefaultPilotTLSCert, constants.DefaultPilotTLSKey, constants.DefaultPilotTLSCaCert); ok {

--- a/pilot/pkg/bootstrap/server_test.go
+++ b/pilot/pkg/bootstrap/server_test.go
@@ -179,11 +179,16 @@ func TestNewServerCertInit(t *testing.T) {
 			test.SetForTest(t, &features.PilotCertProvider, c.certProvider)
 			test.SetForTest(t, &features.EnableCAServer, c.enableCA)
 
-			err := loadCertFilesAtPaths(c.FSCertsPaths)
-			if err != nil {
-				t.Fatal(err.Error())
+			// check if we have some tls assets to write for test
+			if c.FSCertsPaths != (TLSFSLoadPaths{}) {
+				err := loadCertFilesAtPaths(c.FSCertsPaths)
+				if err != nil {
+					t.Fatal(err.Error())
+				}
+
+				defer cleanupCertFSFles(c.FSCertsPaths)
 			}
-			defer cleanupCertFSFles(c.FSCertsPaths)
+
 			args := NewPilotArgs(func(p *PilotArgs) {
 				p.Namespace = "istio-system"
 				p.ServerOptions = DiscoveryServerOptions{

--- a/pilot/pkg/bootstrap/server_test.go
+++ b/pilot/pkg/bootstrap/server_test.go
@@ -68,7 +68,7 @@ func loadCertFilesAtPaths(t TLSFSLoadPaths) error {
 	return nil
 }
 
-func cleanupCertFSFles(t TLSFSLoadPaths) error {
+func cleanupCertFileSystemFiles(t TLSFSLoadPaths) error {
 	if err := os.Remove(t.testTLSCertFilePath); err != nil {
 		return fmt.Errorf("Test cleanup failed, could not delete %s", t.testTLSCertFilePath)
 	}
@@ -200,7 +200,7 @@ func TestNewServerCertInit(t *testing.T) {
 					t.Fatal(err.Error())
 				}
 
-				defer cleanupCertFSFles(c.FSCertsPaths)
+				defer cleanupCertFileSystemFiles(c.FSCertsPaths)
 			}
 
 			args := NewPilotArgs(func(p *PilotArgs) {

--- a/pilot/pkg/bootstrap/server_test.go
+++ b/pilot/pkg/bootstrap/server_test.go
@@ -140,8 +140,8 @@ func TestNewServerCertInit(t *testing.T) {
 			enableCA:     false,
 			certProvider: constants.CertProviderIstiod,
 			expNewCert:   false,
-			expCert:      []byte{},
-			expKey:       []byte{},
+			expCert:            testcerts.ServerCert,
+			expKey:             testcerts.ServerKey,
 		},
 		{
 			name:               "No cert provider",
@@ -150,8 +150,8 @@ func TestNewServerCertInit(t *testing.T) {
 			enableCA:           true,
 			certProvider:       constants.CertProviderNone,
 			expNewCert:         false,
-			expCert:            testcerts.ServerCert,
-			expKey:             testcerts.ServerKey,
+			expCert:      []byte{},
+			expKey:       []byte{},
 		},
 	}
 
@@ -248,7 +248,7 @@ func TestReloadIstiodCert(t *testing.T) {
 	}
 
 	// setup cert watches.
-	if err := s.initCertificateWatches(tlsOptions); err != nil {
+	if err := s.initCertificateWatches(tlsOptions.CertFile,tlsOptions.KeyFile,tlsOptions.CaCertFile); err != nil {
 		t.Fatalf("initCertificateWatches failed: %v", err)
 	}
 

--- a/pilot/pkg/bootstrap/server_test.go
+++ b/pilot/pkg/bootstrap/server_test.go
@@ -163,6 +163,20 @@ func TestNewServerCertInit(t *testing.T) {
 			expKey:       testcerts.ServerKey,
 		},
 		{
+			name: "DNS cert loaded from known location, even if CA is Disabled, with a fallback CA path",
+			FSCertsPaths: TLSFSLoadPaths{
+				constants.DefaultPilotTLSCert,
+				constants.DefaultPilotTLSKey,
+				constants.DefaultPilotTLSCaCertAlternatePath,
+			},
+			tlsOptions:   &TLSOptions{},
+			enableCA:     false,
+			certProvider: constants.CertProviderNone,
+			expNewCert:   false,
+			expCert:      testcerts.ServerCert,
+			expKey:       testcerts.ServerKey,
+		},
+		{
 			name:         "No cert provider",
 			FSCertsPaths: TLSFSLoadPaths{},
 			tlsOptions:   &TLSOptions{},

--- a/pilot/pkg/bootstrap/server_test.go
+++ b/pilot/pkg/bootstrap/server_test.go
@@ -140,8 +140,8 @@ func TestNewServerCertInit(t *testing.T) {
 			enableCA:     false,
 			certProvider: constants.CertProviderIstiod,
 			expNewCert:   false,
-			expCert:            testcerts.ServerCert,
-			expKey:             testcerts.ServerKey,
+			expCert:      testcerts.ServerCert,
+			expKey:       testcerts.ServerKey,
 		},
 		{
 			name:               "No cert provider",
@@ -150,8 +150,8 @@ func TestNewServerCertInit(t *testing.T) {
 			enableCA:           true,
 			certProvider:       constants.CertProviderNone,
 			expNewCert:         false,
-			expCert:      []byte{},
-			expKey:       []byte{},
+			expCert:            []byte{},
+			expKey:             []byte{},
 		},
 	}
 
@@ -248,7 +248,7 @@ func TestReloadIstiodCert(t *testing.T) {
 	}
 
 	// setup cert watches.
-	if err := s.initCertificateWatches(tlsOptions.CertFile,tlsOptions.KeyFile,tlsOptions.CaCertFile); err != nil {
+	if err := s.initCertificateWatches(tlsOptions.CertFile, tlsOptions.KeyFile, tlsOptions.CaCertFile); err != nil {
 		t.Fatalf("initCertificateWatches failed: %v", err)
 	}
 

--- a/pilot/pkg/bootstrap/server_test.go
+++ b/pilot/pkg/bootstrap/server_test.go
@@ -138,7 +138,7 @@ func TestNewServerCertInit(t *testing.T) {
 			}),
 			tlsOptions:   &TLSOptions{},
 			enableCA:     false,
-			certProvider: constants.CertProviderIstiod,
+			certProvider: constants.CertProviderNone,
 			expNewCert:   false,
 			expCert:      testcerts.ServerCert,
 			expKey:       testcerts.ServerKey,

--- a/pilot/pkg/bootstrap/server_test.go
+++ b/pilot/pkg/bootstrap/server_test.go
@@ -150,8 +150,8 @@ func TestNewServerCertInit(t *testing.T) {
 			enableCA:           true,
 			certProvider:       constants.CertProviderNone,
 			expNewCert:         false,
-			expCert:            []byte{},
-			expKey:             []byte{},
+			expCert:            testcerts.ServerCert,
+			expKey:             testcerts.ServerKey,
 		},
 	}
 

--- a/pilot/pkg/bootstrap/server_test.go
+++ b/pilot/pkg/bootstrap/server_test.go
@@ -42,39 +42,39 @@ import (
 
 func loadCertFilesAtPaths(t TLSFSLoadPaths) error {
 	// create cert directories if not existing
-	if err := os.MkdirAll(filepath.Dir(t.testTlsCertFilePath), os.ModePerm); err != nil {
-		return fmt.Errorf("Mkdirall(%v) failed: %v", t.tlscertFilePath, err)
+	if err := os.MkdirAll(filepath.Dir(t.testTLSCertFilePath), os.ModePerm); err != nil {
+		return fmt.Errorf("Mkdirall(%v) failed: %v", t.testTLSCertFilePath, err)
 	}
 
-	if err := os.MkdirAll(filepath.Dir(t.testTlsKeyFilePath), os.ModePerm); err != nil {
-		return fmt.Errorf("Mkdirall(%v) failed: %v", t.tlskeyFilePath, err)
+	if err := os.MkdirAll(filepath.Dir(t.testTLSKeyFilePath), os.ModePerm); err != nil {
+		return fmt.Errorf("Mkdirall(%v) failed: %v", t.testTLSKeyFilePath, err)
 	}
 
 	if err := os.MkdirAll(filepath.Dir(t.testCaCertFilePath), os.ModePerm); err != nil {
-		return fmt.Errorf("Mkdirall(%v) failed: %v", t.tlsCaCertFilePath, err)
+		return fmt.Errorf("Mkdirall(%v) failed: %v", t.testCaCertFilePath, err)
 	}
 
 	// load key and cert files.
-	if err := os.WriteFile(t.testTlsCertFilePath, testcerts.ServerCert, 0o644); err != nil { // nolint: vetshadow
-		return fmt.Errorf("WriteFile(%v) failed: %v", t.tlscertFilePath, err)
+	if err := os.WriteFile(t.testTLSCertFilePath, testcerts.ServerCert, 0o644); err != nil { // nolint: vetshadow
+		return fmt.Errorf("WriteFile(%v) failed: %v", t.testTLSCertFilePath, err)
 	}
-	if err := os.WriteFile(t.testTlsKeyFilePath, testcerts.ServerKey, 0o644); err != nil { // nolint: vetshadow
-		return fmt.Errorf("WriteFile(%v) failed: %v", t.tlskeyFilePath, err)
+	if err := os.WriteFile(t.testTLSKeyFilePath, testcerts.ServerKey, 0o644); err != nil { // nolint: vetshadow
+		return fmt.Errorf("WriteFile(%v) failed: %v", t.testTLSKeyFilePath, err)
 	}
 	if err := os.WriteFile(t.testCaCertFilePath, testcerts.CACert, 0o644); err != nil { // nolint: vetshadow
-		return fmt.Errorf("WriteFile(%v) failed: %v", t.tlsCaCertFilePath, err)
+		return fmt.Errorf("WriteFile(%v) failed: %v", t.testCaCertFilePath, err)
 	}
 
 	return nil
 }
 
 func cleanupCertFSFles(t TLSFSLoadPaths) error {
-	if err := os.Remove(t.testTlsCertFilePath); err != nil {
-		return fmt.Errorf("Test cleanup failed, could not delete %s", t.testTlsCertFilePath)
+	if err := os.Remove(t.testTLSCertFilePath); err != nil {
+		return fmt.Errorf("Test cleanup failed, could not delete %s", t.testTLSCertFilePath)
 	}
 
-	if err := os.Remove(t.testTlsKeyFilePath); err != nil {
-		return fmt.Errorf("Test cleanup failed, could not delete %s", t.testTlsKeyFilePath)
+	if err := os.Remove(t.testTLSKeyFilePath); err != nil {
+		return fmt.Errorf("Test cleanup failed, could not delete %s", t.testTLSKeyFilePath)
 	}
 
 	if err := os.Remove(t.testCaCertFilePath); err != nil {
@@ -86,8 +86,8 @@ func cleanupCertFSFles(t TLSFSLoadPaths) error {
 // This struct will indicate for each test case
 // where tls assets will be loaded on disk
 type TLSFSLoadPaths struct {
-	testTlsCertFilePath string
-	testTlsKeyFilePath  string
+	testTLSCertFilePath string
+	testTLSKeyFilePath  string
 	testCaCertFilePath  string
 }
 
@@ -179,7 +179,7 @@ func TestNewServerCertInit(t *testing.T) {
 			test.SetForTest(t, &features.PilotCertProvider, c.certProvider)
 			test.SetForTest(t, &features.EnableCAServer, c.enableCA)
 
-			err := loadFSCertsAtPaths(c.FSCertsPaths)
+			err := loadCertFilesAtPaths(c.FSCertsPaths)
 			if err != nil {
 				t.Fatal(err.Error())
 			}

--- a/pilot/pkg/bootstrap/server_test.go
+++ b/pilot/pkg/bootstrap/server_test.go
@@ -43,26 +43,26 @@ import (
 func loadCertFilesAtPaths(t TLSFSLoadPaths) error {
 	// create cert directories if not existing
 	if err := os.MkdirAll(filepath.Dir(t.testTlsCertFilePath), os.ModePerm); err != nil {
-		return fmt.Errorf("Mkdirall(%v) failed: %v", tlscertFilePath, err)
+		return fmt.Errorf("Mkdirall(%v) failed: %v", t.tlscertFilePath, err)
 	}
 
 	if err := os.MkdirAll(filepath.Dir(t.testTlsKeyFilePath), os.ModePerm); err != nil {
-		return fmt.Errorf("Mkdirall(%v) failed: %v", tlskeyFilePath, err)
+		return fmt.Errorf("Mkdirall(%v) failed: %v", t.tlskeyFilePath, err)
 	}
 
 	if err := os.MkdirAll(filepath.Dir(t.testCaCertFilePath), os.ModePerm); err != nil {
-		return fmt.Errorf("Mkdirall(%v) failed: %v", tlsCaCertFilePath, err)
+		return fmt.Errorf("Mkdirall(%v) failed: %v", t.tlsCaCertFilePath, err)
 	}
 
 	// load key and cert files.
 	if err := os.WriteFile(t.testTlsCertFilePath, testcerts.ServerCert, 0o644); err != nil { // nolint: vetshadow
-		return fmt.Errorf("WriteFile(%v) failed: %v", tlscertFilePath, err)
+		return fmt.Errorf("WriteFile(%v) failed: %v", t.tlscertFilePath, err)
 	}
 	if err := os.WriteFile(t.testTlsKeyFilePath, testcerts.ServerKey, 0o644); err != nil { // nolint: vetshadow
-		return fmt.Errorf("WriteFile(%v) failed: %v", tlskeyFilePath, err)
+		return fmt.Errorf("WriteFile(%v) failed: %v", t.tlskeyFilePath, err)
 	}
 	if err := os.WriteFile(t.testCaCertFilePath, testcerts.CACert, 0o644); err != nil { // nolint: vetshadow
-		return fmt.Errorf("WriteFile(%v) failed: %v", tlsCaCertFilePath, err)
+		return fmt.Errorf("WriteFile(%v) failed: %v", t.tlsCaCertFilePath, err)
 	}
 
 	return nil
@@ -80,6 +80,7 @@ func cleanupCertFSFles(t TLSFSLoadPaths) error {
 	if err := os.Remove(t.testCaCertFilePath); err != nil {
 		return fmt.Errorf("Test cleanup failed, could not delete %s", t.testCaCertFilePath)
 	}
+	return nil
 }
 
 // This struct will indicate for each test case
@@ -178,11 +179,11 @@ func TestNewServerCertInit(t *testing.T) {
 			test.SetForTest(t, &features.PilotCertProvider, c.certProvider)
 			test.SetForTest(t, &features.EnableCAServer, c.enableCA)
 
-			err := loadFSCertsAtPaths(c.loadFSCertsAtPaths)
+			err := loadFSCertsAtPaths(c.FSCertsPaths)
 			if err != nil {
 				t.Fatal(err.Error())
 			}
-			defer cleanupCertFSFles(c.loadFSCertsAtPaths)
+			defer cleanupCertFSFles(c.FSCertsPaths)
 			args := NewPilotArgs(func(p *PilotArgs) {
 				p.Namespace = "istio-system"
 				p.ServerOptions = DiscoveryServerOptions{

--- a/pilot/pkg/bootstrap/server_test.go
+++ b/pilot/pkg/bootstrap/server_test.go
@@ -40,35 +40,35 @@ import (
 	"istio.io/pkg/filewatcher"
 )
 
-func loadCertFilesAtPaths(tlscertFilePath, tlskeyFilePath,tlsCaCertFilePath string) (error) {
-				// create cert directories if not existing
-		    if err := os.MkdirAll(filepath.Dir(tlscertFilePath), os.ModePerm); err != nil {
-		      return fmt.Errorf("Mkdirall(%v) failed: %v", tlscertFilePath, err)
-		    }
+func loadCertFilesAtPaths(tlscertFilePath, tlskeyFilePath, tlsCaCertFilePath string) error {
+	// create cert directories if not existing
+	if err := os.MkdirAll(filepath.Dir(tlscertFilePath), os.ModePerm); err != nil {
+		return fmt.Errorf("Mkdirall(%v) failed: %v", tlscertFilePath, err)
+	}
 
-		    if err := os.MkdirAll(filepath.Dir(tlskeyFilePath), os.ModePerm); err != nil {
-		      return fmt.Errorf("Mkdirall(%v) failed: %v", tlskeyFilePath, err)
-		    }
+	if err := os.MkdirAll(filepath.Dir(tlskeyFilePath), os.ModePerm); err != nil {
+		return fmt.Errorf("Mkdirall(%v) failed: %v", tlskeyFilePath, err)
+	}
 
-		    if err := os.MkdirAll(filepath.Dir(tlsCaCertFilePath), os.ModePerm); err != nil {
-		        return fmt.Errorf("Mkdirall(%v) failed: %v", tlsCaCertFilePath, err)
-		    }
+	if err := os.MkdirAll(filepath.Dir(tlsCaCertFilePath), os.ModePerm); err != nil {
+		return fmt.Errorf("Mkdirall(%v) failed: %v", tlsCaCertFilePath, err)
+	}
 
-				// load key and cert files.
-				if err := os.WriteFile(tlscertFilePath, testcerts.ServerCert, 0o644); err != nil { // nolint: vetshadow
-					return fmt.Errorf("WriteFile(%v) failed: %v", tlscertFilePath, err)
-				}
-				if err := os.WriteFile(tlskeyFilePath, testcerts.ServerKey, 0o644); err != nil { // nolint: vetshadow
-					return fmt.Errorf("WriteFile(%v) failed: %v", tlskeyFilePath, err)
-				}
-				if err := os.WriteFile(tlsCaCertFilePath, testcerts.CACert, 0o644); err != nil { // nolint: vetshadow
-					return fmt.Errorf("WriteFile(%v) failed: %v", tlsCaCertFilePath, err)
-				}
+	// load key and cert files.
+	if err := os.WriteFile(tlscertFilePath, testcerts.ServerCert, 0o644); err != nil { // nolint: vetshadow
+		return fmt.Errorf("WriteFile(%v) failed: %v", tlscertFilePath, err)
+	}
+	if err := os.WriteFile(tlskeyFilePath, testcerts.ServerKey, 0o644); err != nil { // nolint: vetshadow
+		return fmt.Errorf("WriteFile(%v) failed: %v", tlskeyFilePath, err)
+	}
+	if err := os.WriteFile(tlsCaCertFilePath, testcerts.CACert, 0o644); err != nil { // nolint: vetshadow
+		return fmt.Errorf("WriteFile(%v) failed: %v", tlsCaCertFilePath, err)
+	}
 
-				return nil
-		}
+	return nil
+}
 
-func nilCertWriter () error {
+func nilCertWriter() error {
 	return nil
 }
 
@@ -82,19 +82,18 @@ func TestNewServerCertInit(t *testing.T) {
 	tlsArgcaCertFile := filepath.Join(tlsArgCertsDir, "ca-cert.pem")
 
 	cases := []struct {
-		name         string
-		loadFSCertsAtPaths func() (error)
-		tlsOptions   *TLSOptions
-		enableCA     bool
-		certProvider string
-		expNewCert   bool
-		expCert      []byte
-		expKey       []byte
+		name               string
+		loadFSCertsAtPaths func() error
+		tlsOptions         *TLSOptions
+		enableCA           bool
+		certProvider       string
+		expNewCert         bool
+		expCert            []byte
+		expKey             []byte
 	}{
-
 		{
 			name: "Load from existing DNS cert",
-			loadFSCertsAtPaths: (func() (error) {
+			loadFSCertsAtPaths: (func() error {
 				return loadCertFilesAtPaths(tlsArgcertFile, tlsArgkeyFile, tlsArgcaCertFile)
 			}),
 			tlsOptions: &TLSOptions{
@@ -109,7 +108,7 @@ func TestNewServerCertInit(t *testing.T) {
 			expKey:       testcerts.ServerKey,
 		},
 		{
-			name: "Create new DNS cert using Istiod",
+			name:               "Create new DNS cert using Istiod",
 			loadFSCertsAtPaths: nilCertWriter,
 			tlsOptions: &TLSOptions{
 				CertFile:   "",
@@ -123,19 +122,19 @@ func TestNewServerCertInit(t *testing.T) {
 			expKey:       []byte{},
 		},
 		{
-			name:         "No DNS cert created because CA is disabled",
+			name:               "No DNS cert created because CA is disabled",
 			loadFSCertsAtPaths: nilCertWriter,
-			tlsOptions:   &TLSOptions{},
-			enableCA:     false,
-			certProvider: constants.CertProviderIstiod,
-			expNewCert:   false,
-			expCert:      []byte{},
-			expKey:       []byte{},
+			tlsOptions:         &TLSOptions{},
+			enableCA:           false,
+			certProvider:       constants.CertProviderIstiod,
+			expNewCert:         false,
+			expCert:            []byte{},
+			expKey:             []byte{},
 		},
 		{
-			name:         "DNS cert loaded because it is in known even if CA is Disabled",
-			loadFSCertsAtPaths: (func() (error) {
-				return loadCertFilesAtPaths(constants.DefaultPilotTLSCert , constants.DefaultPilotTLSKey, constants.DefaultPilotTLSCaCert)
+			name: "DNS cert loaded because it is in known even if CA is Disabled",
+			loadFSCertsAtPaths: (func() error {
+				return loadCertFilesAtPaths(constants.DefaultPilotTLSCert, constants.DefaultPilotTLSKey, constants.DefaultPilotTLSCaCert)
 			}),
 			tlsOptions:   &TLSOptions{},
 			enableCA:     false,
@@ -145,14 +144,14 @@ func TestNewServerCertInit(t *testing.T) {
 			expKey:       []byte{},
 		},
 		{
-			name:         "No cert provider",
+			name:               "No cert provider",
 			loadFSCertsAtPaths: nilCertWriter,
-			tlsOptions:   &TLSOptions{},
-			enableCA:     true,
-			certProvider: constants.CertProviderNone,
-			expNewCert:   false,
-			expCert:      []byte{},
-			expKey:       []byte{},
+			tlsOptions:         &TLSOptions{},
+			enableCA:           true,
+			certProvider:       constants.CertProviderNone,
+			expNewCert:         false,
+			expCert:            []byte{},
+			expKey:             []byte{},
 		},
 	}
 

--- a/pilot/pkg/bootstrap/server_test.go
+++ b/pilot/pkg/bootstrap/server_test.go
@@ -287,7 +287,7 @@ func TestReloadIstiodCert(t *testing.T) {
 	}
 
 	// setup cert watches.
-	if err := s.initCertificateWatches(tlsOptions.CertFile, tlsOptions.KeyFile, tlsOptions.CaCertFile); err != nil {
+	if err := s.initCertificateWatches(tlsOptions); err != nil {
 		t.Fatalf("initCertificateWatches failed: %v", err)
 	}
 

--- a/pkg/config/constants/constants.go
+++ b/pkg/config/constants/constants.go
@@ -22,8 +22,8 @@ const (
 	AuthCertsPath = "/etc/certs/"
 
 	// PilotWellKnownDNSCertPath is the path location for Pilot dns serving cert, often used with custom CA integrations
-	PilotWellKnownDNSCertPath   = "/etc/pilot/tls/"
-	PilotWellKnownDNSCaCertPath = "/etc/pilot/ca/"
+	PilotWellKnownDNSCertPath   = "/var/run/secrets/istiod/tls/"
+	PilotWellKnownDNSCaCertPath = "/var/run/secrets/istiod/ca/"
 
 	DefaultPilotTLSCert                = PilotWellKnownDNSCertPath + "tls.crt"
 	DefaultPilotTLSKey                 = PilotWellKnownDNSCertPath + "tls.key"

--- a/pkg/config/constants/constants.go
+++ b/pkg/config/constants/constants.go
@@ -22,7 +22,7 @@ const (
 	AuthCertsPath = "/etc/certs/"
 
 	// PilotWellKnownDNSCertPath is the path location for Pilot dns serving cert, often used with custom CA integrations
-	PilotWellKnownDNSCertPath   = "/var/run/secrets/istiod/tls/"
+	PilotWellKnownDNSCertPath   = "./var/run/secrets/istiod/tls/"
 	PilotWellKnownDNSCaCertPath = "/var/run/secrets/istiod/ca/"
 
 	DefaultPilotTLSCert                = PilotWellKnownDNSCertPath + "tls.crt"

--- a/pkg/config/constants/constants.go
+++ b/pkg/config/constants/constants.go
@@ -25,9 +25,10 @@ const (
 	PilotWellKnownDNSCertPath   = "/etc/pilot/tls/"
 	PilotWellKnownDNSCaCertPath = "/etc/pilot/ca/"
 
-	DefaultPilotTLSCert   = PilotWellKnownDNSCertPath + "tls.crt"
-	DefaultPilotTLSKey    = PilotWellKnownDNSCertPath + "tls.key"
-	DefaultPilotTLSCaCert = PilotWellKnownDNSCaCertPath + "root-cert.pem"
+	DefaultPilotTLSCert                = PilotWellKnownDNSCertPath + "tls.crt"
+	DefaultPilotTLSKey                 = PilotWellKnownDNSCertPath + "tls.key"
+	DefaultPilotTLSCaCert              = PilotWellKnownDNSCaCertPath + "root-cert.pem"
+	DefaultPilotTLSCaCertAlternatePath = PilotWellKnownDNSCertPath + "ca.crt"
 
 	// CertChainFilename is mTLS chain file
 	CertChainFilename = "cert-chain.pem"

--- a/pkg/config/constants/constants.go
+++ b/pkg/config/constants/constants.go
@@ -21,6 +21,14 @@ const (
 	// AuthCertsPath is the path location for mTLS certificates
 	AuthCertsPath = "/etc/certs/"
 
+	// PilotWellKnownDNSCertPath is the path location for Pilot dns serving cert, often used with custom CA integrations
+	PilotWellKnownDNSCertPath   = "/etc/pilot/tls/"
+	PilotWellKnownDNSCaCertPath = "/etc/pilot/ca/"
+
+	DefaultPilotTLSCert   = PilotWellKnownDNSCertPath + "tls.crt"
+	DefaultPilotTLSKey    = PilotWellKnownDNSCertPath + "tls.key"
+	DefaultPilotTLSCaCert = PilotWellKnownDNSCaCertPath + "root-cert.pem"
+
 	// CertChainFilename is mTLS chain file
 	CertChainFilename = "cert-chain.pem"
 

--- a/pkg/config/constants/constants.go
+++ b/pkg/config/constants/constants.go
@@ -23,7 +23,7 @@ const (
 
 	// PilotWellKnownDNSCertPath is the path location for Pilot dns serving cert, often used with custom CA integrations
 	PilotWellKnownDNSCertPath   = "./var/run/secrets/istiod/tls/"
-	PilotWellKnownDNSCaCertPath = "/var/run/secrets/istiod/ca/"
+	PilotWellKnownDNSCaCertPath = "./var/run/secrets/istiod/ca/"
 
 	DefaultPilotTLSCert                = PilotWellKnownDNSCertPath + "tls.crt"
 	DefaultPilotTLSKey                 = PilotWellKnownDNSCertPath + "tls.key"

--- a/releasenotes/notes/pilot-load-dns-cert-known-location-deprecate-flags.yaml
+++ b/releasenotes/notes/pilot-load-dns-cert-known-location-deprecate-flags.yaml
@@ -1,0 +1,46 @@
+apiVersion: release-notes/v2
+
+# This YAML file describes the format for specifying a release notes entry for Istio.
+# This should be filled in for all user facing changes.
+
+# kind describes the type of change that this represents.
+# Valid Values are:
+# - bug-fix -- Used to specify that this change represents a bug fix.
+# - security-fix -- Used to specify that this change represents a vulnerability fix.
+# - feature -- Used to specify a new feature that has been added.
+# - test -- Used to describe additional testing added. This file is optional for
+#   tests, but included for completeness.
+kind: feature
+# area describes the area that this change affects.
+# Valid values are:
+# - traffic-management
+# - security
+# - telemetry
+# - installation
+# - istioctl
+# - documentation
+area: security
+
+# issue is a list of GitHub issues resolved in this note.
+# If issue is not in the current repo, specify its full URL instead.
+issue:
+  - 36916
+
+
+# releaseNotes is a markdown listing of any user facing changes. This will appear in the
+# release notes.
+releaseNotes:
+- |
+  **Changed** Pilot will now load its DNS serving certificate from well known locations:
+```
+/etc/pilot/tls/tls.crt
+/etc/pilot/tls/tls.key
+/etc/pilot/ca/root-cert.pem
+```
+The CA path will alternatively be loaded from: `/etc/pilot/tls/ca.crt`
+
+It also automatically loads any secret called istiod-tls and the istio-root-ca-configmap into those paths.
+
+This method is preferred to use those well known paths than to set the tls args.
+This will allow for an easier installation process for istio-csr as well as any other external issuer that needs to modify
+the Pilot DNS serving certificate.

--- a/releasenotes/notes/pilot-load-dns-cert-known-location-deprecate-flags.yaml
+++ b/releasenotes/notes/pilot-load-dns-cert-known-location-deprecate-flags.yaml
@@ -33,11 +33,11 @@ releaseNotes:
 - |
   **Changed** Pilot will now load its DNS serving certificate from well known locations:
 ```
-/etc/pilot/tls/tls.crt
-/etc/pilot/tls/tls.key
-/etc/pilot/ca/root-cert.pem
+/var/run/secrets/istiod/tls/tls.crt
+/var/run/secrets/istiod/tls/tls.key
+/var/run/secrets/istiod/ca/root-cert.pem
 ```
-The CA path will alternatively be loaded from: `/etc/pilot/tls/ca.crt`
+The CA path will alternatively be loaded from: `/var/run/secrets/tls/ca.crt`
 
 It also automatically loads any secret called istiod-tls and the istio-root-ca-configmap into those paths.
 

--- a/releasenotes/notes/pilot-load-dns-cert-known-location-deprecate-flags.yaml
+++ b/releasenotes/notes/pilot-load-dns-cert-known-location-deprecate-flags.yaml
@@ -31,7 +31,7 @@ issue:
 # release notes.
 releaseNotes:
 - |
-  **Changed** Pilot will now load its DNS serving certificate from well known locations:
+  **Improved** Pilot will now load its DNS serving certificate from well known locations:
   ```
   /var/run/secrets/istiod/tls/tls.crt
   /var/run/secrets/istiod/tls/tls.key

--- a/releasenotes/notes/pilot-load-dns-cert-known-location-deprecate-flags.yaml
+++ b/releasenotes/notes/pilot-load-dns-cert-known-location-deprecate-flags.yaml
@@ -32,15 +32,13 @@ issue:
 releaseNotes:
 - |
   **Changed** Pilot will now load its DNS serving certificate from well known locations:
-```
-/var/run/secrets/istiod/tls/tls.crt
-/var/run/secrets/istiod/tls/tls.key
-/var/run/secrets/istiod/ca/root-cert.pem
-```
-The CA path will alternatively be loaded from: `/var/run/secrets/tls/ca.crt`
-
-It also automatically loads any secret called istiod-tls and the istio-root-ca-configmap into those paths.
-
-This method is preferred to use those well known paths than to set the tls args.
-This will allow for an easier installation process for istio-csr as well as any other external issuer that needs to modify
-the Pilot DNS serving certificate.
+  ```
+  /var/run/secrets/istiod/tls/tls.crt
+  /var/run/secrets/istiod/tls/tls.key
+  /var/run/secrets/istiod/ca/root-cert.pem
+  ```
+  The CA path will alternatively be loaded from: `/var/run/secrets/tls/ca.crt`
+  It also automatically loads any secret called istiod-tls and the istio-root-ca-configmap into those paths.
+  This method is preferred to use those well known paths than to set the tls args.
+  This will allow for an easier installation process for istio-csr as well as any other external issuer that needs to modify
+  the Pilot DNS serving certificate.


### PR DESCRIPTION
This approach takes an alternative approach to loading pilot DNS certs from secrets for pilot on initialisation proposed by @costinm here.
We had previously opted for trying to load these through the existing tls arguments mechanism in Pilot, demonstrated in PRs (#38845 and #37264 ), 
the previous approach required some extra volume mounts in the helm manifest, it made the UX more difficult for installing istio-csr.
The current approach is to load the TLS certs from known locations if args are not set, and mount those volumes in anyways as `optional: true` volumes.

Well known path locations:
```
	PilotWellKnownDNSCertPath   = "/etc/pilot/tls/"
	PilotWellKnownDNSCaCertPath = "/etc/pilot/ca/"

	DefaultPilotTLSCert   = PilotWellKnownDNSCertPath + "tls.crt"
	DefaultPilotTLSKey    = PilotWellKnownDNSCertPath + "tls.key"
	DefaultPilotTLSCaCert = PilotWellKnownDNSCaCertPath + "root-cert.pem"
```
These match how istio-csr for example (custom plugin CA solution) mounts volumes to those paths (it loads the tls secret from an `istiod-tls` secret and trust anchor from `istio-ca-root-configmap`)