### PR TITLE
Revert "multi-network: fix eastwest gateway endpoint filtering (#38762) (#39275)"

### DIFF
--- a/pilot/pkg/xds/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoint_builder.go
@@ -103,11 +103,10 @@ func NewEndpointBuilder(clusterName string, proxy *model.Proxy, push *model.Push
 		port:       port,
 	}
 
-	passthroughMode := model.IsDNSSrvSubsetKey(clusterName)
 	// We need this for multi-network, or for clusters meant for use with AUTO_PASSTHROUGH.
 	if features.EnableAutomTLSCheckPolicies ||
-		b.push.NetworkManager().IsMultiNetworkEnabled() || passthroughMode {
-		b.mtlsChecker = newMtlsChecker(push, port, dr, passthroughMode)
+		b.push.NetworkManager().IsMultiNetworkEnabled() || model.IsDNSSrvSubsetKey(clusterName) {
+		b.mtlsChecker = newMtlsChecker(push, port, dr)
 	}
 	return b
 }
@@ -436,18 +435,11 @@ type mtlsChecker struct {
 	rootPolicyMode *networkingapi.ClientTLSSettings_TLSmode
 }
 
-func newMtlsChecker(push *model.PushContext, svcPort int, dr *config.Config, passthroughMode bool) *mtlsChecker {
-	var rootPolicyMode *networkingapi.ClientTLSSettings_TLSmode
+func newMtlsChecker(push *model.PushContext, svcPort int, dr *config.Config) *mtlsChecker {
 	var drSpec *networkingapi.DestinationRule
-
-	// tcp passthrough gateways don't care about client settings
-	if !passthroughMode {
-		rootPolicyMode = mtlsModeForDefaultTrafficPolicy(dr, svcPort)
-		if dr != nil {
-			drSpec = dr.Spec.(*networkingapi.DestinationRule)
-		}
+	if dr != nil {
+		drSpec = dr.Spec.(*networkingapi.DestinationRule)
 	}
-
 	return &mtlsChecker{
 		push:                 push,
 		svcPort:              svcPort,
@@ -455,7 +447,7 @@ func newMtlsChecker(push *model.PushContext, svcPort int, dr *config.Config, pas
 		mtlsDisabledHosts:    map[string]struct{}{},
 		peerAuthDisabledMTLS: map[string]bool{},
 		subsetPolicyMode:     map[string]*networkingapi.ClientTLSSettings_TLSmode{},
-		rootPolicyMode:       rootPolicyMode,
+		rootPolicyMode:       mtlsModeForDefaultTrafficPolicy(dr, svcPort),
 	}
 }
 

--- a/releasenotes/notes/38704.yaml
+++ b/releasenotes/notes/38704.yaml
@@ -1,7 +1,0 @@
-apiVersion: release-notes/v2
-kind: bug-fix
-area: traffic-management
-issue: [38704]
-releaseNotes:
-- |
-  **Fixed** improper filtering of endpoints from East-West Gateway caused by `DestinationRule` TLS settings.


### PR DESCRIPTION
This reverts commit 097fed9817564fbb9ee33c55db245c2c226f52b9.
Fix https://github.com/istio/istio/issues/39334.
