### PR TITLE
tf: filter extra workloads after test filters run

### DIFF
--- a/pkg/test/framework/components/echo/echotest/filters.go
+++ b/pkg/test/framework/components/echo/echotest/filters.go
@@ -32,9 +32,7 @@ type (
 //       Run()
 func (t *T) From(filters ...Filter) *T {
 	for _, filter := range filters {
-		log.Errorf("howardjohn: filter before %v", len(t.sources))
 		t.sources = filter(t.sources)
-		log.Errorf("howardjohn: filter after %v", len(t.sources))
 	}
 	return t
 }

--- a/pkg/test/framework/components/echo/echotest/filters.go
+++ b/pkg/test/framework/components/echo/echotest/filters.go
@@ -17,7 +17,6 @@ package echotest
 import (
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/echo/match"
-	"istio.io/pkg/log"
 )
 
 type (

--- a/pkg/test/framework/components/echo/echotest/filters_test.go
+++ b/pkg/test/framework/components/echo/echotest/filters_test.go
@@ -133,7 +133,7 @@ func TestFilters(t *testing.T) {
 		filter func(echo.Instances) echo.Instances
 		expect echo.Instances
 	}{
-		"SingleSimplePodServiceAndAllSpecial": {
+		"SimplePodServiceAndAllSpecial": {
 			filter: echotest.SingleSimplePodServiceAndAllSpecial(),
 			expect: echo.Instances{
 				// Keep pods for one regular service per namespace.

--- a/pkg/test/framework/components/echo/echotest/filters_test.go
+++ b/pkg/test/framework/components/echo/echotest/filters_test.go
@@ -223,7 +223,7 @@ func TestRun(t *testing.T) {
 			"Run_WithDefaultFilters": {
 				run: func(t framework.TestContext, testTopology map[string]map[string]int) {
 					echotest.New(t, all).
-						WithDefaultFilters().
+						WithDefaultFilters(1, 1).
 						Run(func(ctx framework.TestContext, from echo.Instance, to echo.Target) {
 							// TODO if the destinations would change based on which cluster then add cluster to srCkey
 							fromKey := from.Config().ClusterLocalFQDN()
@@ -273,7 +273,7 @@ func TestRun(t *testing.T) {
 			"RunToN": {
 				run: func(t framework.TestContext, testTopology map[string]map[string]int) {
 					echotest.New(t, all).
-						WithDefaultFilters().
+						WithDefaultFilters(1, 1).
 						FromMatch(match.And(match.NotNaked, match.NotHeadless)).
 						ToMatch(match.NotHeadless).
 						RunToN(3, func(ctx framework.TestContext, from echo.Instance, dsts echo.Services) {

--- a/tests/integration/pilot/common/traffic.go
+++ b/tests/integration/pilot/common/traffic.go
@@ -135,10 +135,10 @@ func (c TrafficTestCase) RunForApps(t framework.TestContext, apps echo.Instances
 				// we only apply to config clusters
 				return t.ConfigIstio().YAML("", cfg).Apply()
 			}).
-			WithDefaultFilters().
 			FromMatch(match.And(c.sourceMatchers...)).
 			// TODO mainly testing proxyless features as a client for now
 			ToMatch(match.And(append(c.targetMatchers, match.NotProxylessGRPC)...)).
+			WithDefaultFilters(1, c.toN).
 			ConditionallyTo(c.comboFilters...)
 
 		doTest := func(t framework.TestContext, from echo.Caller, to echo.Services) {

--- a/tests/integration/pilot/mcs/discoverability/discoverability_test.go
+++ b/tests/integration/pilot/mcs/discoverability/discoverability_test.go
@@ -206,7 +206,7 @@ func runForAllClusterCombinations(
 ) {
 	t.Helper()
 	echotest.New(t, echos.Instances).
-		WithDefaultFilters().
+		WithDefaultFilters(1, 1).
 		FromMatch(serviceA).
 		ToMatch(serviceB).
 		Run(fn)

--- a/tests/integration/security/authz/authz_test.go
+++ b/tests/integration/security/authz/authz_test.go
@@ -1622,7 +1622,7 @@ func newTrafficTest(t framework.TestContext, echos ...echo.Instances) *echotest.
 	}
 
 	return echotest.New(t, all).
-		WithDefaultFilters().
+		WithDefaultFilters(1, 1).
 		FromMatch(match.And(
 			match.NotNaked,
 			match.NotProxylessGRPC)).

--- a/tests/integration/security/egress_gateway_origination_test.go
+++ b/tests/integration/security/egress_gateway_origination_test.go
@@ -380,7 +380,7 @@ func MustReadCert(t test.Failer, f string) string {
 
 func newGatewayTest(t framework.TestContext) *echotest.T {
 	return echotest.New(t, apps.All).
-		WithDefaultFilters().
+		WithDefaultFilters(1, 1).
 		FromMatch(match.And(
 			match.NotNaked,
 			match.Or(

--- a/tests/integration/security/external_ca/reachability_test.go
+++ b/tests/integration/security/external_ca/reachability_test.go
@@ -44,7 +44,7 @@ func TestReachability(t *testing.T) {
 			fromAndTo := from.Append(to)
 
 			echotest.New(t, fromAndTo).
-				WithDefaultFilters().
+				WithDefaultFilters(1, 1).
 				FromMatch(match.ServiceName(from.NamespacedName())).
 				ToMatch(match.ServiceName(to.NamespacedName())).
 				Run(func(t framework.TestContext, from echo.Instance, to echo.Target) {

--- a/tests/integration/security/sds_ingress/util/util.go
+++ b/tests/integration/security/sds_ingress/util/util.go
@@ -511,7 +511,7 @@ func RunTestMultiMtlsGateways(ctx framework.TestContext, inst istio.Instance, ap
 			SetupConfig(ctx, apps.ServerNs, tests...)
 			return nil
 		}).
-		To(echotest.SingleSimplePodServiceAndAllSpecial()).
+		To(echotest.SingleSimplePodServiceAndAllSpecial(1)).
 		RunFromClusters(func(ctx framework.TestContext, fromCluster cluster.Cluster, to echo.Target) {
 			for _, cn := range credNames {
 				CreateIngressKubeSecret(ctx, cn, Mtls, IngressCredentialA, false)
@@ -558,7 +558,7 @@ func RunTestMultiTLSGateways(t framework.TestContext, inst istio.Instance, apps 
 			SetupConfig(t, apps.ServerNs, tests...)
 			return nil
 		}).
-		To(echotest.SingleSimplePodServiceAndAllSpecial()).
+		To(echotest.SingleSimplePodServiceAndAllSpecial(1)).
 		RunFromClusters(func(t framework.TestContext, fromCluster cluster.Cluster, to echo.Target) {
 			for _, cn := range credNames {
 				CreateIngressKubeSecret(t, cn, TLS, IngressCredentialA, false)
@@ -607,7 +607,7 @@ func RunTestMultiQUICGateways(ctx framework.TestContext, inst istio.Instance, ca
 			SetupConfig(ctx, apps.ServerNs, tests...)
 			return nil
 		}).
-		To(echotest.SingleSimplePodServiceAndAllSpecial()).
+		To(echotest.SingleSimplePodServiceAndAllSpecial(1)).
 		RunFromClusters(func(ctx framework.TestContext, fromCluster cluster.Cluster, to echo.Target) {
 			for _, cn := range credNames {
 				CreateIngressKubeSecret(ctx, cn, TLS, IngressCredentialA, false)

--- a/tests/integration/security/sds_ingress/util/util.go
+++ b/tests/integration/security/sds_ingress/util/util.go
@@ -511,7 +511,7 @@ func RunTestMultiMtlsGateways(ctx framework.TestContext, inst istio.Instance, ap
 			SetupConfig(ctx, apps.ServerNs, tests...)
 			return nil
 		}).
-		To(echotest.SingleSimplePodServiceAndAllSpecial(1)).
+		To(echotest.SimplePodServiceAndAllSpecial(1)).
 		RunFromClusters(func(ctx framework.TestContext, fromCluster cluster.Cluster, to echo.Target) {
 			for _, cn := range credNames {
 				CreateIngressKubeSecret(ctx, cn, Mtls, IngressCredentialA, false)
@@ -558,7 +558,7 @@ func RunTestMultiTLSGateways(t framework.TestContext, inst istio.Instance, apps 
 			SetupConfig(t, apps.ServerNs, tests...)
 			return nil
 		}).
-		To(echotest.SingleSimplePodServiceAndAllSpecial(1)).
+		To(echotest.SimplePodServiceAndAllSpecial(1)).
 		RunFromClusters(func(t framework.TestContext, fromCluster cluster.Cluster, to echo.Target) {
 			for _, cn := range credNames {
 				CreateIngressKubeSecret(t, cn, TLS, IngressCredentialA, false)
@@ -607,7 +607,7 @@ func RunTestMultiQUICGateways(ctx framework.TestContext, inst istio.Instance, ca
 			SetupConfig(ctx, apps.ServerNs, tests...)
 			return nil
 		}).
-		To(echotest.SingleSimplePodServiceAndAllSpecial(1)).
+		To(echotest.SimplePodServiceAndAllSpecial(1)).
 		RunFromClusters(func(ctx framework.TestContext, fromCluster cluster.Cluster, to echo.Target) {
 			for _, cn := range credNames {
 				CreateIngressKubeSecret(ctx, cn, TLS, IngressCredentialA, false)


### PR DESCRIPTION
We currently have some logic to filter out "not useful" tests (a->b and
b->c are the same). However, we have some tests that need many
source/destinations. If we filter out these too early, we may lose the
ability to run the test at all.

Instead, we run this filter last and ensure we leave enough
destinations.

Change-Id: I12496b05c20b5b3a1333076e164ea76dba3779a2

**Please provide a description of this PR:**