### PR TITLE
WasmPlugin: Add the integration test for remote load of Wasm & image pull policy through HTTP

### DIFF
--- a/pkg/test/framework/components/registryredirector/registry_redirector_server.yaml
+++ b/pkg/test/framework/components/registryredirector/registry_redirector_server.yaml
@@ -39,7 +39,7 @@ spec:
         app: registry-redirector
     spec:
       containers:
-      - image: {{ or .Image "gcr.io/istio-testing/fake-registry:1.1"}}
+      - image: {{ or .Image "gcr.io/istio-testing/fake-registry:1.2"}}
         name: registry-redirector
         {{- if .TargetRegistry }}
         args: ["--registry", {{ .TargetRegistry }}]

--- a/tests/integration/telemetry/stats/prometheus/wasm/imagepullpolicy_test.go
+++ b/tests/integration/telemetry/stats/prometheus/wasm/imagepullpolicy_test.go
@@ -30,10 +30,9 @@ import (
 )
 
 const (
-	imageName         = "istio-testing/wasm/header-injector"
-	injectedHeader    = "x-resp-injection"
-	wasmConfigFile    = "testdata/wasm-filter.yaml"
-	imageRegistryName = "gcr.io"
+	imageName      = "istio-testing/wasm/header-injector"
+	injectedHeader = "x-resp-injection"
+	wasmConfigFile = "testdata/wasm-filter.yaml"
 )
 
 type wasmTestConfigs struct {

--- a/tests/integration/telemetry/stats/prometheus/wasm/imagepullpolicy_test.go
+++ b/tests/integration/telemetry/stats/prometheus/wasm/imagepullpolicy_test.go
@@ -30,9 +30,10 @@ import (
 )
 
 const (
-	imageName      = "istio-testing/wasm/header-injector"
-	injectedHeader = "x-resp-injection"
-	wasmConfigFile = "testdata/wasm-filter.yaml"
+	imageName         = "istio-testing/wasm/header-injector"
+	injectedHeader    = "x-resp-injection"
+	wasmConfigFile    = "testdata/wasm-filter.yaml"
+	imageRegistryName = "gcr.io"
 )
 
 type wasmTestConfigs struct {
@@ -55,13 +56,14 @@ func mapTagToVersionOrFail(t framework.TestContext, tag, version string) {
 	}
 }
 
-func applyAndTestWasm(ctx framework.TestContext, c wasmTestConfigs) {
-	ctx.NewSubTest(c.desc).Run(func(t framework.TestContext) {
+func applyAndTestWasmWithOCI(ctx framework.TestContext, c wasmTestConfigs) {
+	ctx.NewSubTest("OCI_" + c.desc).Run(func(t framework.TestContext) {
 		defer func() {
 			generation++
 		}()
 		mapTagToVersionOrFail(t, c.tag, c.upstreamVersion)
-		if err := installWasmExtension(t, c.name, c.tag, c.policy, fmt.Sprintf("g-%d", generation)); err != nil {
+		wasmModuleURL := fmt.Sprintf("oci://%v/%v:%v", registry.Address(), imageName, c.tag)
+		if err := installWasmExtension(t, c.name, wasmModuleURL, c.policy, fmt.Sprintf("g-%d", generation)); err != nil {
 			t.Fatalf("failed to install WasmPlugin: %v", err)
 		}
 		sendTraffic(t, check.ResponseHeader(injectedHeader, c.expectedVersion))
@@ -82,7 +84,7 @@ func TestImagePullPolicy(t *testing.T) {
 		Features("extensibility.wasm.image-pull-policy").
 		Features("extensibility.wasm.remote-load").
 		Run(func(t framework.TestContext) {
-			applyAndTestWasm(t, wasmTestConfigs{
+			applyAndTestWasmWithOCI(t, wasmTestConfigs{
 				desc:            "initial creation with latest",
 				name:            "wasm-test-module",
 				tag:             "latest",
@@ -92,7 +94,7 @@ func TestImagePullPolicy(t *testing.T) {
 			})
 
 			resetWasm(t, "wasm-test-module")
-			applyAndTestWasm(t, wasmTestConfigs{
+			applyAndTestWasmWithOCI(t, wasmTestConfigs{
 				desc:            "upstream is upgraded to 0.0.2. 0.0.1 is already present and policy is IfNotPresent, so should not pull",
 				name:            "wasm-test-module",
 				tag:             "latest",
@@ -102,7 +104,7 @@ func TestImagePullPolicy(t *testing.T) {
 			})
 
 			// Intentionally, do not reset here to see the upgrade from 0.0.1.
-			applyAndTestWasm(t, wasmTestConfigs{
+			applyAndTestWasmWithOCI(t, wasmTestConfigs{
 				desc:            "upstream is upgraded to 0.0.2. 0.0.1 is already present. But policy is default and tag is latest, so pull the image",
 				name:            "wasm-test-module",
 				tag:             "latest",
@@ -112,7 +114,7 @@ func TestImagePullPolicy(t *testing.T) {
 			})
 			resetWasm(t, "wasm-test-module")
 
-			applyAndTestWasm(t, wasmTestConfigs{
+			applyAndTestWasmWithOCI(t, wasmTestConfigs{
 				desc:            "initial creation with 0.0.1",
 				name:            "wasm-test-module-test-tag-1",
 				tag:             "test-tag-1",
@@ -122,7 +124,7 @@ func TestImagePullPolicy(t *testing.T) {
 			})
 
 			resetWasm(t, "wasm-test-module-test-tag-1")
-			applyAndTestWasm(t, wasmTestConfigs{
+			applyAndTestWasmWithOCI(t, wasmTestConfigs{
 				desc:            "upstream is upgraded to 0.0.2, but 0.0.1 is already present and policy is IfNotPresent",
 				name:            "wasm-test-module-test-tag-1",
 				tag:             "test-tag-1",
@@ -132,7 +134,7 @@ func TestImagePullPolicy(t *testing.T) {
 			})
 
 			resetWasm(t, "wasm-test-module-test-tag-1")
-			applyAndTestWasm(t, wasmTestConfigs{
+			applyAndTestWasmWithOCI(t, wasmTestConfigs{
 				desc:            "upstream is upgraded to 0.0.2, but 0.0.1 is already present and policy is default",
 				name:            "wasm-test-module-test-tag-1",
 				tag:             "test-tag-1",
@@ -142,7 +144,7 @@ func TestImagePullPolicy(t *testing.T) {
 			})
 
 			// Intentionally, do not reset here to see the upgrade from 0.0.1.
-			applyAndTestWasm(t, wasmTestConfigs{
+			applyAndTestWasmWithOCI(t, wasmTestConfigs{
 				desc:            "upstream is upgraded to 0.0.2. 0.0.1 is already present but policy is Always, so pull 0.0.2",
 				name:            "wasm-test-module-test-tag-1",
 				tag:             "test-tag-1",
@@ -153,8 +155,7 @@ func TestImagePullPolicy(t *testing.T) {
 		})
 }
 
-func installWasmExtension(ctx framework.TestContext, pluginName, tag, imagePullPolicy, pluginVersion string) error {
-	wasmModuleURL := fmt.Sprintf("oci://%v/%v:%v", registry.Address(), imageName, tag)
+func installWasmExtension(ctx framework.TestContext, pluginName, wasmModuleURL, imagePullPolicy, pluginVersion string) error {
 	args := map[string]interface{}{
 		"WasmPluginName":    pluginName,
 		"TestWasmModuleURL": wasmModuleURL,
@@ -209,4 +210,68 @@ func sendTraffic(ctx framework.TestContext, checker echo.Checker, options ...ret
 	}
 
 	_ = cltInstance.CallOrFail(ctx, httpOpts)
+}
+
+func applyAndTestWasmWithHTTP(ctx framework.TestContext, c wasmTestConfigs) {
+	ctx.NewSubTest("HTTP_" + c.desc).Run(func(t framework.TestContext) {
+		defer func() {
+			generation++
+		}()
+		mapTagToVersionOrFail(t, c.tag, c.upstreamVersion)
+		// registry-redirector will redirect to the gzipped tarball of the first layer with this request.
+		// The gzipped tarball should have a wasm module.
+		wasmModuleURL := fmt.Sprintf("http://%v/layer/v1/%v:%v", registry.Address(), imageName, c.tag)
+		t.Logf("Trying to get a wasm file from %v", wasmModuleURL)
+		if err := installWasmExtension(t, c.name, wasmModuleURL, c.policy, fmt.Sprintf("g-%d", generation)); err != nil {
+			t.Fatalf("failed to install WasmPlugin: %v", err)
+		}
+		sendTraffic(t, check.ResponseHeader(injectedHeader, c.expectedVersion))
+	})
+}
+
+// TestImagePullPolicyWithHTTP tests pulling Wasm Binary via HTTP and ImagePullPolicy.
+func TestImagePullPolicyWithHTTP(t *testing.T) {
+	framework.NewTest(t).
+		Features("extensibility.wasm.image-pull-policy").
+		Features("extensibility.wasm.remote-load").
+		Run(func(t framework.TestContext) {
+			applyAndTestWasmWithHTTP(t, wasmTestConfigs{
+				desc:            "initial creation with 0.0.1",
+				name:            "wasm-test-module-http",
+				tag:             "test-tag-http",
+				policy:          "",
+				upstreamVersion: "0.0.1",
+				expectedVersion: "0.0.1",
+			})
+
+			resetWasm(t, "wasm-test-module-http")
+			applyAndTestWasmWithHTTP(t, wasmTestConfigs{
+				desc:            "upstream is upgraded to 0.0.2, but 0.0.1 is already present and policy is IfNotPresent",
+				name:            "wasm-test-module-http",
+				tag:             "test-tag-http",
+				policy:          "IfNotPresent",
+				upstreamVersion: "0.0.2",
+				expectedVersion: "0.0.1",
+			})
+
+			resetWasm(t, "wasm-test-module-http")
+			applyAndTestWasmWithHTTP(t, wasmTestConfigs{
+				desc:            "upstream is upgraded to 0.0.2, but 0.0.1 is already present and policy is default",
+				name:            "wasm-test-module-http",
+				tag:             "test-tag-http",
+				policy:          "",
+				upstreamVersion: "0.0.2",
+				expectedVersion: "0.0.1",
+			})
+
+			// Intentionally, do not reset here to see the upgrade from 0.0.1.
+			applyAndTestWasmWithHTTP(t, wasmTestConfigs{
+				desc:            "upstream is upgraded to 0.0.2. 0.0.1 is already present but policy is Always, so pull 0.0.2",
+				name:            "wasm-test-module-http",
+				tag:             "test-tag-http",
+				policy:          "Always",
+				upstreamVersion: "0.0.2",
+				expectedVersion: "0.0.2",
+			})
+		})
 }

--- a/tests/integration/telemetry/stats/prometheus/wasm/stats_wasm_filter_test.go
+++ b/tests/integration/telemetry/stats/prometheus/wasm/stats_wasm_filter_test.go
@@ -42,7 +42,7 @@ func TestMain(m *testing.M) {
 		Label(label.IPv4). // https://github.com/istio/istio/issues/35915
 		Setup(istio.Setup(common.GetIstioInstance(), setupConfig)).
 		Setup(common.TestSetup).
-		Setup(registrySetup).
+		Setup(testSetup).
 		Run()
 }
 

--- a/tests/integration/telemetry/stats/prometheus/wasm/testsetup.go
+++ b/tests/integration/telemetry/stats/prometheus/wasm/testsetup.go
@@ -34,7 +34,7 @@ const (
 	registryPasswd = "passwd"
 )
 
-func registrySetup(ctx resource.Context) (err error) {
+func testSetup(ctx resource.Context) (err error) {
 	registry, err = registryredirector.New(ctx, registryredirector.Config{
 		Cluster: ctx.AllClusters().Default(),
 	})
@@ -50,6 +50,7 @@ func registrySetup(ctx resource.Context) (err error) {
 		Apply(); err != nil {
 		return err
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
Adding new integration test case for testing the remote load of Wasm and Image Pull Policy when using HTTP.
Basically, the test scenario is exactly the same with OCI Image case except consideration of `latest` tag.
