### PR TITLE
[Release-1.14] Stop previous remote cluster when updating secret 

### DIFF
--- a/pkg/kube/multicluster/secretcontroller.go
+++ b/pkg/kube/multicluster/secretcontroller.go
@@ -301,16 +301,6 @@ func (c *Controller) Run(stopCh <-chan struct{}) error {
 	return nil
 }
 
-func (c *Controller) close() {
-	c.cs.Lock()
-	defer c.cs.Unlock()
-	for _, clusterMap := range c.cs.remoteClusters {
-		for _, cluster := range clusterMap {
-			close(cluster.stop)
-		}
-	}
-}
-
 func (c *Controller) hasSynced() bool {
 	if !c.queue.HasSynced() {
 		log.Debug("secret controller did not sync secrets presented at startup")
@@ -493,6 +483,8 @@ func (c *Controller) addSecret(name types.NamespacedName, s *corev1.Secret) {
 				log.Infof("skipping update of cluster_id=%v from secret=%v: (kubeconfig are identical)", clusterID, secretKey)
 				continue
 			}
+			// stop previous remote cluster
+			prev.Stop()
 		} else if c.cs.Contains(cluster.ID(clusterID)) {
 			// if the cluster has been registered before by another secret, ignore the new one.
 			log.Warnf("cluster %d from secret %s has already been registered", clusterID, secretKey)

--- a/releasenotes/notes/39366.yaml
+++ b/releasenotes/notes/39366.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 39366
+releaseNotes:
+  - |
+    **Fixed** bug when updating a multicluster secret, the previous cluster is not stopped. Even delete the secret can not stop the previous cluster


### PR DESCRIPTION
**Please provide a description of this PR:**

Fix #39391

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [x ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure