### PR TITLE
Remove dep reference from Makefile.core.mk

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -227,8 +227,7 @@ ${ISTIO_ENVOY_LINUX_DEBUG_PATH}: init
 ${ISTIO_ENVOY_LINUX_RELEASE_PATH}: init
 ${ISTIO_ENVOY_MACOS_RELEASE_PATH}: init
 
-# Pull dependencies, based on the checked in Gopkg.lock file.
-# Developers must manually run `dep ensure` if adding new deps
+# Pull dependencies such as envoy
 depend: init | $(TARGET_OUT)
 
 DIRS_TO_CLEAN := $(TARGET_OUT)


### PR DESCRIPTION
**Please provide a description of this PR:**

Removes a comment referencing `dep` in the Makefile.

I noticed this while trying to understand the Makefile, there isn't any Gopkg.lock file presumably since the repo was migrated from dep to go.mod at some point. The target just seems to be an alias for `init` now.