### PR TITLE
Fix x wait example

### DIFF
--- a/istioctl/cmd/wait.go
+++ b/istioctl/cmd/wait.go
@@ -61,7 +61,7 @@ func waitCmd() *cobra.Command {
   istioctl experimental wait --for=distribution virtualservice bookinfo.default
 
   # Wait until 99% of the proxies receive the distribution, timing out after 5 minutes
-  istioctl experimental wait --for=distribution --threshold=.99 --timeout=300 virtualservice bookinfo.default
+  istioctl experimental wait --for=distribution --threshold=.99 --timeout=300s virtualservice bookinfo.default
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			printVerbosef(cmd, "kubeconfig %s", kubeconfig)


### PR DESCRIPTION
**Please provide a description of this PR:**
Running the example will have the error:
```
istioctl experimental wait --for=distribution --threshold=.99 --timeout=300 virtualservice bookinfo.default
Error: invalid argument "300" for "--timeout" flag: time: missing unit in duration "300"
```


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [x] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
