### PR TITLE
[Dual Stack] Fixed bug for stats metrics scraping errors when using different IP families

### DIFF
--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -224,6 +224,13 @@ func initStsServer(proxy *model.Proxy, tokenManager security.TokenManager) (*sts
 	localHostAddr := localHostIPv4
 	if proxy.IsIPv6() {
 		localHostAddr = localHostIPv6
+	} else {
+		// if not ipv6-only, it can be ipv4-only or dual-stack
+		// let InstanceIP decide the localhost
+		netIP := net.ParseIP(options.InstanceIPVar.Get())
+		if netIP.To4() == nil && netIP.To16() != nil && !netIP.IsLinkLocalUnicast() {
+			localHostAddr = localHostIPv6
+		}
 	}
 	stsServer, err := stsserver.NewServer(stsserver.Config{
 		LocalHostAddr: localHostAddr,

--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -164,6 +164,14 @@ func NewServer(config Options) (*Server, error) {
 	if config.IPv6 {
 		localhost = localHostIPv6
 		upstreamLocalAddress = UpstreamLocalAddressIPv6
+	} else {
+		// if not ipv6-only, it can be ipv4-only or dual-stack
+		// let InstanceIP decide the localhost
+		netIP := net.ParseIP(config.PodIP)
+		if netIP.To4() == nil && netIP.To16() != nil && !netIP.IsLinkLocalUnicast() {
+			localhost = localHostIPv6
+			upstreamLocalAddress = UpstreamLocalAddressIPv6
+		}
 	}
 	probes := make([]ready.Prober, 0)
 	if !config.NoEnvoy {
@@ -341,8 +349,8 @@ func (s *Server) Run(ctx context.Context) {
 	}
 	// for testing.
 	if s.statusPort == 0 {
-		addrs := strings.Split(l.Addr().String(), ":")
-		allocatedPort, _ := strconv.Atoi(addrs[len(addrs)-1])
+		_, hostPort, _ := net.SplitHostPort(l.Addr().String())
+		allocatedPort, _ := strconv.Atoi(hostPort)
 		s.mutex.Lock()
 		s.statusPort = uint16(allocatedPort)
 		s.mutex.Unlock()


### PR DESCRIPTION
Fixed bug for stats metrics scraping errors when using different IP families, InstanceIP is the pod ip the gateway pod IP, such as ingress gateway
1. Let InstanceIP decide the IP family when initializing the StsServer
2. Let InstanceIP decide the IP family when initializing the Status Server

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
