### PR TITLE
Optimize: make use of string pointer map to reduce mem cost of xds keys

### DIFF
--- a/pilot/pkg/model/xds_cache.go
+++ b/pilot/pkg/model/xds_cache.go
@@ -81,19 +81,19 @@ func size(cs int) {
 	}
 }
 
-func indexConfig(configIndex map[ConfigKey]sets.Set, k string, entry XdsCacheEntry) {
+func indexConfig(configIndex map[ConfigKey]sets.StringPointerSet, k *string, entry XdsCacheEntry) {
 	for _, cfg := range entry.DependentConfigs() {
 		if configIndex[cfg] == nil {
-			configIndex[cfg] = sets.New()
+			configIndex[cfg] = sets.NewStringPointerSet()
 		}
 		configIndex[cfg].Insert(k)
 	}
 }
 
-func indexType(typeIndex map[config.GroupVersionKind]sets.Set, k string, entry XdsCacheEntry) {
+func indexType(typeIndex map[config.GroupVersionKind]sets.StringPointerSet, k *string, entry XdsCacheEntry) {
 	for _, t := range entry.DependentTypes() {
 		if typeIndex[t] == nil {
-			typeIndex[t] = sets.New()
+			typeIndex[t] = sets.NewStringPointerSet()
 		}
 		typeIndex[t].Insert(k)
 	}
@@ -144,8 +144,8 @@ func NewXdsCache() XdsCache {
 	return &lruCache{
 		enableAssertions: features.EnableUnsafeAssertions,
 		store:            newLru(),
-		configIndex:      map[ConfigKey]sets.Set{},
-		typesIndex:       map[config.GroupVersionKind]sets.Set{},
+		configIndex:      map[ConfigKey]sets.StringPointerSet{},
+		typesIndex:       map[config.GroupVersionKind]sets.StringPointerSet{},
 	}
 }
 
@@ -154,8 +154,8 @@ func NewLenientXdsCache() XdsCache {
 	return &lruCache{
 		enableAssertions: false,
 		store:            newLru(),
-		configIndex:      map[ConfigKey]sets.Set{},
-		typesIndex:       map[config.GroupVersionKind]sets.Set{},
+		configIndex:      map[ConfigKey]sets.StringPointerSet{},
+		typesIndex:       map[config.GroupVersionKind]sets.StringPointerSet{},
 	}
 }
 
@@ -164,10 +164,14 @@ type lruCache struct {
 	store            simplelru.LRUCache
 	// token stores the latest token of the store, used to prevent stale data overwrite.
 	// It is refreshed when Clear or ClearAll are called
-	token       CacheToken
-	mu          sync.RWMutex
-	configIndex map[ConfigKey]sets.Set
-	typesIndex  map[config.GroupVersionKind]sets.Set
+	token CacheToken
+	mu    sync.RWMutex
+	// configIndex and typesIndex stores the xds key pointer,
+	// because different configs or different kinds of resources can be part of a same xds key.
+	// Say route `80` can be influenced by hundreds of services with port 80.
+	// Thus, we can largely decrease the string memory.
+	configIndex map[ConfigKey]sets.StringPointerSet
+	typesIndex  map[config.GroupVersionKind]sets.StringPointerSet
 }
 
 var _ XdsCache = &lruCache{}
@@ -239,8 +243,8 @@ func (l *lruCache) Add(entry XdsCacheEntry, pushReq *PushRequest, value *discove
 	toWrite := cacheValue{value: value, token: token}
 	l.store.Add(k, toWrite)
 	l.token = token
-	indexConfig(l.configIndex, k, entry)
-	indexType(l.typesIndex, k, entry)
+	indexConfig(l.configIndex, &k, entry)
+	indexType(l.typesIndex, &k, entry)
 	size(l.store.Len())
 }
 
@@ -278,12 +282,12 @@ func (l *lruCache) Clear(configs map[ConfigKey]struct{}) {
 		referenced := l.configIndex[ckey]
 		delete(l.configIndex, ckey)
 		for key := range referenced {
-			l.store.Remove(key)
+			l.store.Remove(*key)
 		}
 		tReferenced := l.typesIndex[ckey.Kind]
 		delete(l.typesIndex, ckey.Kind)
 		for key := range tReferenced {
-			l.store.Remove(key)
+			l.store.Remove(*key)
 		}
 	}
 	size(l.store.Len())
@@ -294,8 +298,8 @@ func (l *lruCache) ClearAll() {
 	defer l.mu.Unlock()
 	l.token = CacheToken(time.Now().UnixNano())
 	l.store.Purge()
-	l.configIndex = map[ConfigKey]sets.Set{}
-	l.typesIndex = map[config.GroupVersionKind]sets.Set{}
+	l.configIndex = map[ConfigKey]sets.StringPointerSet{}
+	l.typesIndex = map[config.GroupVersionKind]sets.StringPointerSet{}
 	size(l.store.Len())
 }
 

--- a/pilot/pkg/xds/bench_test.go
+++ b/pilot/pkg/xds/bench_test.go
@@ -560,22 +560,30 @@ func BenchmarkPushRequest(b *testing.B) {
 
 func makeCacheKey(n int) model.XdsCacheEntry {
 	ns := strconv.Itoa(n)
+
+	// 100 services
+	services := make([]*model.Service, 0, 100)
+	// 100 destinationrules
+	drs := make([]*config.Config, 0, 100)
+	for i := 0; i < 100; i++ {
+		index := strconv.Itoa(i)
+		services = append(services, &model.Service{
+			Hostname:   host.Name(ns + "some" + index + ".example.com"),
+			Attributes: model.ServiceAttributes{Namespace: "test" + index},
+		})
+		drs = append(drs, &config.Config{Meta: config.Meta{Name: index, Namespace: index}})
+	}
+
 	key := &route.Cache{
-		RouteName:       "something",
-		ClusterID:       "my-cluster",
-		DNSDomain:       "some.domain.example.com",
-		DNSCapture:      true,
-		DNSAutoAllocate: false,
-		ListenerPort:    1234,
-		Services: []*model.Service{
-			{Hostname: host.Name(ns + "some1.example.com"), Attributes: model.ServiceAttributes{Namespace: "test1"}},
-			{Hostname: host.Name(ns + "some2.example.com"), Attributes: model.ServiceAttributes{Namespace: "test2"}},
-		},
-		DestinationRules: []*config.Config{
-			{Meta: config.Meta{Name: ns + "a", Namespace: "b"}},
-			{Meta: config.Meta{Name: ns + "d", Namespace: "e"}},
-		},
-		EnvoyFilterKeys: []string{ns + "1/a", ns + "2/b", ns + "3/c"},
+		RouteName:        "something",
+		ClusterID:        "my-cluster",
+		DNSDomain:        "some.domain.example.com",
+		DNSCapture:       true,
+		DNSAutoAllocate:  false,
+		ListenerPort:     1234,
+		Services:         services,
+		DestinationRules: drs,
+		EnvoyFilterKeys:  []string{ns + "1/a", ns + "2/b", ns + "3/c"},
 	}
 	return key
 }

--- a/pkg/util/sets/string_pointer.go
+++ b/pkg/util/sets/string_pointer.go
@@ -1,0 +1,49 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sets
+
+type StringPointerSet map[*string]struct{}
+
+// NewStringPointerSetWithLength returns an empty Set with the given capacity.
+// It's only a hint, not a limitation.
+func NewStringPointerSetWithLength(l int) StringPointerSet {
+	return make(StringPointerSet, l)
+}
+
+// NewStringPointerSet creates a new Set with the given items.
+func NewStringPointerSet(items ...*string) StringPointerSet {
+	s := NewStringPointerSetWithLength(len(items))
+	return s.InsertAll(items...)
+}
+
+// Insert a single item to this Set.
+func (s StringPointerSet) Insert(item *string) StringPointerSet {
+	s[item] = struct{}{}
+	return s
+}
+
+// InsertAll adds the items to this Set.
+func (s StringPointerSet) InsertAll(items ...*string) StringPointerSet {
+	for _, item := range items {
+		s.Insert(item)
+	}
+	return s
+}
+
+// Contains returns whether the given item is in the set.
+func (s StringPointerSet) Contains(item *string) bool {
+	_, ok := s[item]
+	return ok
+}

--- a/pkg/util/sets/string_pointer_test.go
+++ b/pkg/util/sets/string_pointer_test.go
@@ -1,0 +1,56 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sets
+
+import (
+	"testing"
+)
+
+func TestNewStringPointerSet(t *testing.T) {
+	a := "1"
+	b := "2"
+	c := "3"
+	elements := []*string{&a, &b, &c}
+	set := NewStringPointerSet(elements...)
+
+	if len(set) != len(elements) {
+		t.Errorf("Expected length %d != %d", len(set), len(elements))
+	}
+
+	for _, e := range elements {
+		if _, exist := set[e]; !exist {
+			t.Errorf("%s is not in set %v", *e, set)
+		}
+	}
+}
+
+func TestStringPointerSetContains(t *testing.T) {
+	a := "1"
+	b := "2"
+	c := "3"
+	elements := []*string{&a, &b, &c}
+	nonElement := "4"
+	set := NewStringPointerSet(elements...)
+
+	for _, e := range elements {
+		if !set.Contains(e) {
+			t.Errorf("%d is not in set %v", e, set)
+		}
+	}
+
+	if set.Contains(&nonElement) {
+		t.Errorf("%s should not be in set %v, but Contains returned true", nonElement, set)
+	}
+}


### PR DESCRIPTION
**Please provide a description of this PR:**


This reduces memory for case when n configs influence one xds key.

Inner struct is 👍 

C(0)->key0(copied)
C(1)->key1(copied)
C(n-1)->key n-1(copied)

A string struct holds 16 bytes, and here the total mem is n * 16 bytes

With the patch, the total mem will be n * 8 




**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
