### PR TITLE
[tf] allow using custom image for echo gRPC

### DIFF
--- a/pkg/test/env/istio.go
+++ b/pkg/test/env/istio.go
@@ -54,6 +54,10 @@ var (
 	// nolint: golint, revive, stylecheck
 	ECHO_IMAGE Variable = "ECHO_IMAGE"
 
+	// GRPC_ECHO_IMAGE is the image to use for a separate gRPC-only container in echo Pods.
+	// nolint: golint, revive, stylecheck
+	GRPC_ECHO_IMAGE Variable = "GRPC_ECHO_IMAGE"
+
 	// KUBECONFIG is the list of Kubernetes configuration files. If configuration files are specified on
 	// the command-line, that takes precedence.
 	// nolint: revive, stylecheck

--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -764,6 +764,7 @@ func deploymentParams(ctx resource.Context, cfg echo.Config, settings *resource.
 		"Locality":            cfg.Locality,
 		"ServiceAccount":      cfg.ServiceAccount,
 		"AppContainers":       appContainers,
+		"ContainerPorts":      getContainerPorts(cfg),
 		"Subsets":             cfg.Subsets,
 		"TLSSettings":         cfg.TLSSettings,
 		"Cluster":             cfg.Cluster.Name(),

--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -56,6 +56,8 @@ import (
 const (
 	// for proxyless we add a special gRPC server that doesn't get configured with xDS for test-runner use
 	grpcMagicPort = 17171
+	// for non-Go implementations of gRPC echo, this is the port used to forward non-gRPC requests to the Go server
+	grpcFallbackPort = 17777
 
 	serviceYAML = `
 {{- if .ServiceAccount }}
@@ -173,9 +175,10 @@ spec:
         - containerPort: 8000
         - containerPort: 9000
 {{- end }}
-      - name: app
-{{- if $.ImageFullPath }}
-        image: {{ $.ImageFullPath }}
+{{- range $i, $appContainer := $.AppContainers }}
+      - name: {{ $appContainer.Name }}
+{{- if $appContainer.ImageFullPath }}
+        image: {{ $appContainer.ImageFullPath }}
 {{- else }}
         image: {{ $.ImageHub }}/app:{{ $.ImageTag }}
 {{- end }}
@@ -184,13 +187,15 @@ spec:
           runAsUser: 1338
           runAsGroup: 1338
         args:
+{{- if $appContainer.FallbackPort }}
+          - --forwarding_address=0.0.0.0:{{ $appContainer.FallbackPort }}
+{{- end }}
           - --metrics=15014
           - --cluster={{ $cluster }}
-{{- range $i, $p := $.ContainerPorts }}
-{{- if eq .Protocol "GRPC" }}
-{{- if and $.ProxylessGRPC (ne $p.Port $.GRPCMagicPort) }}
+{{- range $i, $p := $appContainer.ContainerPorts }}
+{{- if and $p.XDSServer (eq .Protocol "GRPC") }}
           - --xds-grpc-server={{ $p.Port }}
-{{- end }}
+{{- else if eq .Protocol "GRPC" }}
           - --grpc={{ $p.Port }}
 {{- else if eq .Protocol "TCP" }}
           - --tcp={{ $p.Port }}
@@ -223,7 +228,7 @@ spec:
           - --key=/cert.key
 {{- end }}
         ports:
-{{- range $i, $p := $.ContainerPorts }}
+{{- range $i, $p := $appContainer.ContainerPorts }}
         - containerPort: {{ $p.Port }}
 {{- if eq .Port 3333 }}
           name: tcp-health-port
@@ -273,6 +278,9 @@ spec:
         volumeMounts:
         - mountPath: /etc/certs/custom
           name: custom-certs
+{{- end }}
+{{- end }}
+{{- if $.TLSSettings }}
       volumes:
 {{- if $.TLSSettings.ProxyProvision }}
       - emptyDir:
@@ -710,19 +718,52 @@ func deploymentParams(ctx resource.Context, cfg echo.Config, settings *resource.
 	if err != nil {
 		return nil, err
 	}
+
+	containerPorts := getContainerPorts(cfg)
+	appContainers := []map[string]interface{}{{
+		"Name":           appContainerName,
+		"ImageFullPath":  settings.EchoImage, // This overrides image hub/tag if it's not empty.
+		"ContainerPorts": getContainerPorts(cfg),
+	}}
+
+	// Only use the custom image for proxyless gRPC instances. This will bind the gRPC ports on one container
+	// and all other ports on another. Additionally, we bind one port for communication between the custom image
+	// container, and the regular Go server.
+	if cfg.IsProxylessGRPC() && settings.CustomGRPCEchoImage != "" {
+		var grpcPorts, otherPorts echoCommon.PortList
+		for _, port := range containerPorts {
+			if port.Protocol == protocol.GRPC {
+				grpcPorts = append(grpcPorts, port)
+			} else {
+				otherPorts = append(otherPorts, port)
+			}
+		}
+		otherPorts = append(otherPorts, &echoCommon.Port{
+			Name:     "grpc-fallback",
+			Protocol: protocol.GRPC,
+			Port:     grpcFallbackPort,
+		})
+		appContainers[0]["ContainerPorts"] = otherPorts
+		appContainers = append(appContainers, map[string]interface{}{
+			"Name":           "custom-grpc-" + appContainerName,
+			"ImageFullPath":  settings.CustomGRPCEchoImage, // This overrides image hub/tag if it's not empty.
+			"ContainerPorts": grpcPorts,
+			"FallbackPort":   grpcFallbackPort,
+		})
+	}
+
 	params := map[string]interface{}{
 		"ImageHub":            settings.Image.Hub,
 		"ImageTag":            strings.TrimSuffix(settings.Image.Tag, "-distroless"),
 		"ImagePullPolicy":     settings.Image.PullPolicy,
 		"ImagePullSecretName": imagePullSecretName,
-		"ImageFullPath":       settings.EchoImage, // This overrides image hub/tag if it's not empty.
 		"Service":             cfg.Service,
 		"StatefulSet":         cfg.StatefulSet,
 		"ProxylessGRPC":       cfg.IsProxylessGRPC(),
 		"GRPCMagicPort":       grpcMagicPort,
 		"Locality":            cfg.Locality,
 		"ServiceAccount":      cfg.ServiceAccount,
-		"ContainerPorts":      getContainerPorts(cfg),
+		"AppContainers":       appContainers,
 		"Subsets":             cfg.Subsets,
 		"TLSSettings":         cfg.TLSSettings,
 		"Cluster":             cfg.Cluster.Name(),
@@ -1015,6 +1056,9 @@ func getContainerPorts(cfg echo.Config) echoCommon.PortList {
 
 		switch p.Protocol {
 		case protocol.GRPC:
+			if cfg.IsProxylessGRPC() {
+				cport.XDSServer = true
+			}
 			continue
 		case protocol.HTTP:
 			if p.WorkloadPort == httpReadinessPort {
@@ -1042,6 +1086,8 @@ func getContainerPorts(cfg echo.Config) echoCommon.PortList {
 			Port:     tcpHealthPort,
 		})
 	}
+
+	// gives something the test runner to connect to without being in the mesh
 	if cfg.IsProxylessGRPC() {
 		containerPorts = append(containerPorts, &echoCommon.Port{
 			Name:        "grpc-magic-port",

--- a/pkg/test/framework/components/echo/kube/testdata/proxyless-custom-image.yaml
+++ b/pkg/test/framework/components/echo/kube/testdata/proxyless-custom-image.yaml
@@ -49,7 +49,6 @@ spec:
           runAsUser: 1338
           runAsGroup: 1338
         args:
-          - --forwarding_address=0.0.0.0:17777
           - --metrics=15014
           - --cluster=cluster-0
           - --port=8080
@@ -96,6 +95,7 @@ spec:
           runAsUser: 1338
           runAsGroup: 1338
         args:
+          - --forwarding_address=0.0.0.0:17777
           - --metrics=15014
           - --cluster=cluster-0
           - --xds-grpc-server=7070

--- a/pkg/test/framework/components/echo/kube/testdata/proxyless-custom-image.yaml
+++ b/pkg/test/framework/components/echo/kube/testdata/proxyless-custom-image.yaml
@@ -1,0 +1,136 @@
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: foo
+  labels:
+    app: foo
+spec:
+  ports:
+  - name: grpc
+    port: 7070
+    targetPort: 7070
+  selector:
+    app: foo
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: foo-bar
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: foo
+      version: bar
+  template:
+    metadata:
+      labels:
+        app: foo
+        version: bar
+        test.istio.io/class: proxyless
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "15014"
+        inject.istio.io/templates: "grpc-agent"
+    spec:
+      imagePullSecrets:
+      - name: myregistrykey
+      containers:
+      - name: istio-proxy
+        image: auto
+        imagePullPolicy: Always
+        securityContext: # to allow core dumps
+          readOnlyRootFilesystem: false
+      - name: app
+        image: testing.hub/app:latest
+        imagePullPolicy: Always
+        securityContext:
+          runAsUser: 1338
+          runAsGroup: 1338
+        args:
+          - --forwarding_address=0.0.0.0:17777
+          - --metrics=15014
+          - --cluster=cluster-0
+          - --port=8080
+          - --port=3333
+          - --grpc=17777
+          - --version=bar
+          - --istio-version=
+          - --crt=/cert.crt
+          - --key=/cert.key
+        ports:
+        - containerPort: 8080
+        - containerPort: 3333
+          name: tcp-health-port
+        - containerPort: 17777
+        env:
+        - name: INSTANCE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: EXPOSE_GRPC_ADMIN
+          value: "true"
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 1
+          periodSeconds: 2
+          failureThreshold: 10
+        livenessProbe:
+          tcpSocket:
+            port: tcp-health-port
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          failureThreshold: 10
+        startupProbe:
+          tcpSocket:
+            port: tcp-health-port
+          periodSeconds: 1
+          failureThreshold: 10
+      - name: custom-grpc-app
+        image: grpc/echo:cpp
+        imagePullPolicy: Always
+        securityContext:
+          runAsUser: 1338
+          runAsGroup: 1338
+        args:
+          - --metrics=15014
+          - --cluster=cluster-0
+          - --xds-grpc-server=7070
+          - --grpc=17171
+          - --bind-localhost=17171
+          - --version=bar
+          - --istio-version=
+          - --crt=/cert.crt
+          - --key=/cert.key
+        ports:
+        - containerPort: 7070
+        - containerPort: 17171
+        env:
+        - name: INSTANCE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: EXPOSE_GRPC_ADMIN
+          value: "true"
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 1
+          periodSeconds: 2
+          failureThreshold: 10
+        livenessProbe:
+          tcpSocket:
+            port: tcp-health-port
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          failureThreshold: 10
+        startupProbe:
+          tcpSocket:
+            port: tcp-health-port
+          periodSeconds: 1
+          failureThreshold: 10
+---

--- a/pkg/test/framework/components/echo/kube/testdata/proxyless.yaml
+++ b/pkg/test/framework/components/echo/kube/testdata/proxyless.yaml
@@ -1,0 +1,94 @@
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: foo
+  labels:
+    app: foo
+spec:
+  ports:
+  - name: grpc
+    port: 7070
+    targetPort: 7070
+  selector:
+    app: foo
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: foo-bar
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: foo
+      version: bar
+  template:
+    metadata:
+      labels:
+        app: foo
+        version: bar
+        test.istio.io/class: proxyless
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "15014"
+        inject.istio.io/templates: "grpc-agent"
+    spec:
+      imagePullSecrets:
+      - name: myregistrykey
+      containers:
+      - name: istio-proxy
+        image: auto
+        imagePullPolicy: Always
+        securityContext: # to allow core dumps
+          readOnlyRootFilesystem: false
+      - name: app
+        image: testing.hub/app:latest
+        imagePullPolicy: Always
+        securityContext:
+          runAsUser: 1338
+          runAsGroup: 1338
+        args:
+          - --metrics=15014
+          - --cluster=cluster-0
+          - --xds-grpc-server=7070
+          - --port=8080
+          - --port=3333
+          - --grpc=17171
+          - --bind-localhost=17171
+          - --version=bar
+          - --istio-version=
+          - --crt=/cert.crt
+          - --key=/cert.key
+        ports:
+        - containerPort: 7070
+        - containerPort: 8080
+        - containerPort: 3333
+          name: tcp-health-port
+        - containerPort: 17171
+        env:
+        - name: INSTANCE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: EXPOSE_GRPC_ADMIN
+          value: "true"
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 1
+          periodSeconds: 2
+          failureThreshold: 10
+        livenessProbe:
+          tcpSocket:
+            port: tcp-health-port
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          failureThreshold: 10
+        startupProbe:
+          tcpSocket:
+            port: tcp-health-port
+          periodSeconds: 1
+          failureThreshold: 10
+---

--- a/pkg/test/framework/resource/flags.go
+++ b/pkg/test/framework/resource/flags.go
@@ -82,6 +82,10 @@ func SettingsFromCommandLine(testID string) (*Settings, error) {
 		s.EchoImage = env.ECHO_IMAGE.ValueOrDefault("")
 	}
 
+	if s.CustomGRPCEchoImage == "" {
+		s.CustomGRPCEchoImage = env.GRPC_ECHO_IMAGE.ValueOrDefault("")
+	}
+
 	if err = validate(s); err != nil {
 		return nil, err
 	}

--- a/pkg/test/framework/resource/settings.go
+++ b/pkg/test/framework/resource/settings.go
@@ -154,6 +154,9 @@ type Settings struct {
 	// EchoImage is the app image to be used by echo deployments.
 	EchoImage string
 
+	// CustomGRPCEchoImage if specified will run an extra container in the echo Pods responsible for gRPC ports
+	CustomGRPCEchoImage string
+
 	// MaxDumps is the maximum number of full test dumps that are allowed to occur within a test suite.
 	MaxDumps uint64
 }


### PR DESCRIPTION
Usage: Set `GRPC_ECHO_IMAGE` env to some image that implements `echo` + a special flag --forwarding_address (https://github.com/grpc/grpc/pull/30005).
Effect: Any proxyless gRPC echo app will split the Echo across two containers, one for gRPC, one for everthing else. 




---

This is to support testing Proxyless gRPC implementations in other languages (C++, Java). We have to implement `echo` to use Istio's integration tests, but it would be a burden to implement all of the echo protocols in these languages and keep implementations in sync across languages. 

What we do here is described in this [doc](https://docs.google.com/document/d/1YVod8JoQhQ3zRRM1mVsuy006bjEMIm71dGx_PX2V2B4/edit#). TL;DR: running a second container with the the normal Go app to handle non-gRPC. 

cc @yashykt