### PR TITLE
[Dual Stack] Fix the bugs for gateway listeners and routes configuration generation for IPv6 to allow external traffic outside the service mesh with IPv6 package

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -96,7 +96,7 @@ func (configgen *ConfigGeneratorImpl) buildGatewayListeners(builder *ListenerBui
 			}
 			for _, wildcard := range wildCards {
 				bind := wildcard[0]
-				if len(port.Bind) > 0 {
+				if len(port.Bind) > 0 && !features.EnableDualStack {
 					bind = port.Bind
 				}
 
@@ -508,10 +508,9 @@ func (configgen *ConfigGeneratorImpl) buildGatewayHTTPRouteConfig(node *model.Pr
 	}
 
 	util.SortVirtualHosts(virtualHosts)
-
 	routeCfg := &route.RouteConfiguration{
-		// Retain the adjustedRouteName as its used by EnvoyFilter patching logic
-		Name:             adjustedRouteName,
+		// Retain the routeName as its used by EnvoyFilter patching logic
+		Name:             routeName,
 		VirtualHosts:     virtualHosts,
 		ValidateClusters: proto.BoolFalse,
 	}


### PR DESCRIPTION
**Please provide a description of this PR:**

Fix the bugs for gateway listeners and routes configuration generation for IPv6 to allow external traffic outside the service mesh with IPv6 package

**Original listeners and routes configuration for ingress gateway (incorrect version):**
![istioctl_invalid](https://user-images.githubusercontent.com/4101246/173819591-0bf6667e-6b93-45a0-ad47-0e3ba278c6a3.png)

**New listeners and routes configuration for ingress gateway (correct version):**
![istioctl_valid](https://user-images.githubusercontent.com/4101246/173819833-bd476fac-6176-4072-bf58-d8ea4f3d38e7.png)