### PR TITLE
[tf] don't allow new single cluster suites

### DIFF
--- a/pkg/test/framework/analyzer-allowlist.yaml
+++ b/pkg/test/framework/analyzer-allowlist.yaml
@@ -1,0 +1,8 @@
+suites:
+  supportMultipleClusters:
+  - helm
+  - helm_upgrade
+  - operator
+  - pilot_revisioncmd
+  - security_file_mounted_certs
+  - security_sds_egress

--- a/pkg/test/framework/analyzer.go
+++ b/pkg/test/framework/analyzer.go
@@ -16,6 +16,9 @@ package framework
 
 import (
 	"fmt"
+	"gopkg.in/yaml.v3"
+	"istio.io/istio/pkg/util/sets"
+	"os"
 	"strings"
 	"testing"
 
@@ -133,8 +136,17 @@ func (s *suiteAnalyzer) run() int {
 	defer finishAnalysis()
 	scopes.Framework.Infof("=== Begin: Analysis of %s ===", analysis.SuiteID)
 
+	err := s.validate()
+	ret := s.mRun(nil)
+	if err != nil {
+		scopes.Framework.Error(err)
+		if ret == 0 {
+			ret = 1
+		}
+	}
+
 	// tests will add their results to the suiteAnalysis during mRun
-	return s.mRun(nil)
+	return ret
 }
 
 // track generates the final analysis for this suite. track should not be called if more
@@ -148,6 +160,54 @@ func (s *suiteAnalyzer) track() *suiteAnalysis {
 		MultiClusterOnly: s.minCusters > 1,
 		Tests:            map[string]*testAnalysis{},
 	}
+}
+
+var analyzerAllowlist = loadAllowlist(env.IstioSrc + "/pkg/test/framework/analyzer-allowlist.txt")
+
+type allowlist struct {
+	Suites map[string][]string `yaml:"suites"`
+}
+
+func loadAllowlist(path string) *allowlist {
+	out := &allowlist{Suites: map[string][]string{}}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		scopes.Framework.Warnf("failed reading suite analyzer allowlist from %s: %v", path, err)
+		return out
+	}
+	if err := yaml.Unmarshal(data, out); err != nil {
+		scopes.Framework.Warnf("failed unmarshalling suite analyzer allowlist from %s: %v", path, err)
+		return out
+	}
+	return out
+}
+
+// validate must be called after initAnalysis/track
+func (s *suiteAnalyzer) validate() error {
+	var err *multierror.Error
+	for name, validator := range sutieValidators {
+		if sets.New(analyzerAllowlist.Suites[name]...).Contains(s.testID) {
+			continue
+		}
+		if vErr := validator(s); vErr !=nil {
+			err = multierror.Append(err, vErr)
+		}
+	}
+	// add any other suite-level validation here
+	return err.ErrorOrNil()
+}
+
+var sutieValidators = map[string]func(s *suiteAnalyzer) error{
+	"supportMultipleClusters": func(s *suiteAnalyzer) error {
+		if s.maxClusters < 3 {
+			return fmt.Errorf(
+				"%s is supports a maximum of %d clusters; "+
+					"suites must be compatible with an arbitrary number of clusters",
+				s.testID, s.maxClusters,
+			)
+		}
+		return nil
+	},
 }
 
 func newTestAnalyzer(t *testing.T) Test {

--- a/pkg/test/framework/analyzer.go
+++ b/pkg/test/framework/analyzer.go
@@ -16,19 +16,19 @@ package framework
 
 import (
 	"fmt"
-	"gopkg.in/yaml.v3"
-	"istio.io/istio/pkg/util/sets"
 	"os"
 	"strings"
 	"testing"
 
 	"github.com/hashicorp/go-multierror"
+	"gopkg.in/yaml.v3"
 
 	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/pkg/test/framework/features"
 	"istio.io/istio/pkg/test/framework/label"
 	"istio.io/istio/pkg/test/framework/resource"
 	"istio.io/istio/pkg/test/scopes"
+	"istio.io/istio/pkg/util/sets"
 	"istio.io/pkg/log"
 )
 
@@ -162,7 +162,7 @@ func (s *suiteAnalyzer) track() *suiteAnalysis {
 	}
 }
 
-var analyzerAllowlist = loadAllowlist(env.IstioSrc + "/pkg/test/framework/analyzer-allowlist.txt")
+var analyzerAllowlist = loadAllowlist(env.IstioSrc + "/pkg/test/framework/analyzer-allowlist.yaml")
 
 type allowlist struct {
 	Suites map[string][]string `yaml:"suites"`
@@ -189,7 +189,7 @@ func (s *suiteAnalyzer) validate() error {
 		if sets.New(analyzerAllowlist.Suites[name]...).Contains(s.testID) {
 			continue
 		}
-		if vErr := validator(s); vErr !=nil {
+		if vErr := validator(s); vErr != nil {
 			err = multierror.Append(err, vErr)
 		}
 	}
@@ -199,9 +199,9 @@ func (s *suiteAnalyzer) validate() error {
 
 var sutieValidators = map[string]func(s *suiteAnalyzer) error{
 	"supportMultipleClusters": func(s *suiteAnalyzer) error {
-		if s.maxClusters < 3 {
+		if s.maxClusters >= 0 && s.maxClusters < 3 {
 			return fmt.Errorf(
-				"%s is supports a maximum of %d clusters; "+
+				"%s supports a maximum of %d clusters; "+
 					"suites must be compatible with an arbitrary number of clusters",
 				s.testID, s.maxClusters,
 			)


### PR DESCRIPTION
This can't catch `if len(clusters) > 1 {skip}` but its a step