### PR TITLE
rollback QUIC tests to previous configuration

### DIFF
--- a/tests/integration/iop-remote-integration-test-gateways.yaml
+++ b/tests/integration/iop-remote-integration-test-gateways.yaml
@@ -40,11 +40,6 @@ spec:
               - port: 31400
                 targetPort: 31400
                 name: tcp
-              ## Port used for QUIC
-              - name: http3
-                port: 443
-                targetPort: 8443
-                protocol: UDP
     # Enable the egressgateway for all tests by default.
     egressGateways:
       - name: istio-egressgateway

--- a/tests/integration/security/sds_ingress/quic/ingress_test.go
+++ b/tests/integration/security/sds_ingress/quic/ingress_test.go
@@ -38,7 +38,7 @@ func TestMain(m *testing.M) {
 		NewSuite(m).
 		// Need support for MixedProtocolLBService
 		RequireMinVersion(20).
-		SkipExternalControlPlaneTopology().
+		RequireMultiPrimary().
 		Setup(istio.Setup(&inst, func(_ resource.Context, cfg *istio.Config) {
 			cfg.PrimaryClusterIOPFile = istio.IntegrationTestDefaultsIOPWithQUIC
 		})).
@@ -55,6 +55,7 @@ func TestTlsGatewaysWithQUIC(t *testing.T) {
 	// nolint: staticcheck
 	framework.
 		NewTest(t).
+		RequiresSingleCluster().
 		Features("security.ingress.quic.sds.tls").
 		Run(func(t framework.TestContext) {
 			t.NewSubTest("tcp").Run(func(t framework.TestContext) {
@@ -73,6 +74,7 @@ func TestMtlsGatewaysWithQUIC(t *testing.T) {
 	// nolint: staticcheck
 	framework.
 		NewTest(t).
+		RequiresSingleCluster().
 		Features("security.ingress.quic.sds.mtls").
 		Run(func(t framework.TestContext) {
 			t.NewSubTest("tcp").Run(func(t framework.TestContext) {


### PR DESCRIPTION
**QUIC based tests are failing for GKE 1.21, reverting it to the original configuration**