### PR TITLE
Optimize test so that some tests can be skipped

### DIFF
--- a/pkg/test/framework/analyzer.go
+++ b/pkg/test/framework/analyzer.go
@@ -112,6 +112,10 @@ func (s *suiteAnalyzer) SkipExternalControlPlaneTopology() Suite {
 	return s
 }
 
+func (s *suiteAnalyzer) RequireExternalControlPlaneTopology() Suite {
+	return s
+}
+
 func (s *suiteAnalyzer) RequireMinVersion(minorVersion uint) Suite {
 	return s
 }

--- a/tests/integration/pilot/localwatcher/localsecretwatcher_test.go
+++ b/tests/integration/pilot/localwatcher/localsecretwatcher_test.go
@@ -40,6 +40,7 @@ func TestMain(m *testing.M) {
 	// nolint: staticcheck
 	framework.
 		NewSuite(m).
+		RequireExternalControlPlaneTopology().
 		RequireMinVersion(17).
 		RequireMinClusters(2).
 		Setup(istio.Setup(&i, func(t resource.Context, cfg *istio.Config) {


### PR DESCRIPTION
Added RequireExternalControlPlaneTopology method so that only
the tests which test external control plane will run, other
tests can be skipped to save some CPU cycles.

Signed-off-by: Tong Li <litong01@us.ibm.com>

**Please provide a description of this PR:**