### PR TITLE
Support pulling multi-arch envoy binaries

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -146,6 +146,7 @@ default: init build test
 .PHONY: init
 # Downloads envoy, based on the SHA defined in the base pilot Dockerfile
 init: $(TARGET_OUT)/istio_is_init
+	echo ISTIO_ENVOY_LINUX_RELEASE_PATH=$(ISTIO_ENVOY_LINUX_RELEASE_PATH) TARGET_OUT_LINUX=$(TARGET_OUT_LINUX)
 	@mkdir -p ${TARGET_OUT}/logs
 	@mkdir -p ${TARGET_OUT}/release
 

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -26,6 +26,13 @@ if [[ "${TARGET_OUT_LINUX:-}" == "" ]]; then
   exit 1
 fi
 
+# Setup arch suffix for envoy binary. For backwards compatibility, amd64 has no suffix.
+if [[ "${TARGET_ARCH}" == "amd64" ]]; then
+	ISTIO_ENVOY_ARCH_SUFFIX=""
+else
+	ISTIO_ENVOY_ARCH_SUFFIX="-${TARGET_ARCH}"
+fi
+
 # Populate the git version for istio/proxy (i.e. Envoy)
 PROXY_REPO_SHA="${PROXY_REPO_SHA:-$(grep PROXY_REPO_SHA istio.deps  -A 4 | grep lastStableSHA | cut -f 4 -d '"')}"
 
@@ -36,9 +43,9 @@ SIDECAR="${SIDECAR:-envoy}"
 
 # OS-neutral vars. These currently only work for linux.
 ISTIO_ENVOY_VERSION="${ISTIO_ENVOY_VERSION:-${PROXY_REPO_SHA}}"
-ISTIO_ENVOY_DEBUG_URL="${ISTIO_ENVOY_DEBUG_URL:-${ISTIO_ENVOY_BASE_URL}/envoy-debug-${ISTIO_ENVOY_VERSION}.tar.gz}"
+ISTIO_ENVOY_DEBUG_URL="${ISTIO_ENVOY_DEBUG_URL:-${ISTIO_ENVOY_BASE_URL}/envoy-debug-${ISTIO_ENVOY_VERSION}${ISTIO_ENVOY_ARCH_SUFFIX}.tar.gz}"
 ISTIO_ENVOY_CENTOS_DEBUG_URL="${ISTIO_ENVOY_CENTOS_DEBUG_URL:-${ISTIO_ENVOY_BASE_URL}/envoy-centos-debug-${ISTIO_ENVOY_VERSION}.tar.gz}"
-ISTIO_ENVOY_RELEASE_URL="${ISTIO_ENVOY_RELEASE_URL:-${ISTIO_ENVOY_BASE_URL}/envoy-alpha-${ISTIO_ENVOY_VERSION}.tar.gz}"
+ISTIO_ENVOY_RELEASE_URL="${ISTIO_ENVOY_RELEASE_URL:-${ISTIO_ENVOY_BASE_URL}/envoy-alpha-${ISTIO_ENVOY_VERSION}${ISTIO_ENVOY_ARCH_SUFFIX}.tar.gz}"
 ISTIO_ENVOY_CENTOS_RELEASE_URL="${ISTIO_ENVOY_CENTOS_RELEASE_URL:-${ISTIO_ENVOY_BASE_URL}/envoy-centos-alpha-${ISTIO_ENVOY_VERSION}.tar.gz}"
 
 # Envoy Linux vars.

--- a/pkg/test/echo/docker/Dockerfile.app_sidecar
+++ b/pkg/test/echo/docker/Dockerfile.app_sidecar
@@ -8,7 +8,8 @@ COPY certs/                           /var/lib/istio/
 COPY certs/default/                   /var/run/secrets/istio/
 
 # Install the sidecar components
-COPY istio-sidecar.deb  /tmp/istio-sidecar.deb
+ARG TARGETARCH
+COPY ${TARGETARCH:-amd64}/istio-sidecar.deb  /tmp/istio-sidecar.deb
 RUN dpkg -i /tmp/istio-sidecar.deb && rm /tmp/istio-sidecar.deb
 
 # Sudoers used to allow tcpdump and other debug utilities.
@@ -16,7 +17,6 @@ COPY sudoers /etc/sudoers
 
 # Install the Echo application
 COPY echo-start.sh /usr/local/bin/echo-start.sh
-ARG TARGETARCH
 COPY ${TARGETARCH:-amd64}/client /usr/local/bin/client
 COPY ${TARGETARCH:-amd64}/server /usr/local/bin/server
 

--- a/prow/integ-suite-kind.sh
+++ b/prow/integ-suite-kind.sh
@@ -106,7 +106,7 @@ done
 
 if [ -f /proc/cpuinfo ]; then
   echo "Checking CPU..."
-  grep 'model' /proc/cpuinfo
+  grep -q 'model' /proc/cpuinfo
 fi
 
 # Default IP family of the cluster is IPv4

--- a/prow/integ-suite-kind.sh
+++ b/prow/integ-suite-kind.sh
@@ -37,7 +37,7 @@ setup_and_export_git_sha
 source "${ROOT}/common/scripts/kind_provisioner.sh"
 
 TOPOLOGY=SINGLE_CLUSTER
-NODE_IMAGE="gcr.io/istio-testing/kind-node:v1.24.0-0.13.0"
+NODE_IMAGE="gcr.io/istio-testing/kind-node:v1.24.3"
 KIND_CONFIG=""
 CLUSTER_TOPOLOGY_CONFIG_FILE="${ROOT}/prow/config/topology/multicluster.json"
 

--- a/prow/integ-suite-kind.sh
+++ b/prow/integ-suite-kind.sh
@@ -106,7 +106,7 @@ done
 
 if [ -f /proc/cpuinfo ]; then
   echo "Checking CPU..."
-  grep -q 'model' /proc/cpuinfo
+  grep 'model' /proc/cpuinfo || true
 fi
 
 # Default IP family of the cluster is IPv4

--- a/prow/integ-suite-kind.sh
+++ b/prow/integ-suite-kind.sh
@@ -169,7 +169,10 @@ fi
 
 if [[ -z "${SKIP_BUILD:-}" ]]; then
   trace "setup kind registry" setup_kind_registry
-  trace "build images" build_images "${PARAMS[*]}"
+  trace "build images" build_images "${PARAMS[*]}" || {
+    tools/dump-docker-logs.sh
+    exit 1
+  }
 fi
 
 # If a variant is defined, update the tag accordingly

--- a/prow/integ-suite-kind.sh
+++ b/prow/integ-suite-kind.sh
@@ -169,10 +169,7 @@ fi
 
 if [[ -z "${SKIP_BUILD:-}" ]]; then
   trace "setup kind registry" setup_kind_registry
-  trace "build images" build_images "${PARAMS[*]}" || {
-    tools/dump-docker-logs.sh
-    exit 1
-  }
+  trace "build images" build_images "${PARAMS[*]}"
 fi
 
 # If a variant is defined, update the tag accordingly

--- a/prow/lib.sh
+++ b/prow/lib.sh
@@ -126,10 +126,10 @@ function build_images() {
   fi
   targets+="docker.install-cni "
   if [[ "${VARIANT:-default}" == "distroless" ]]; then
-    DOCKER_BUILD_VARIANTS="distroless" DOCKER_TARGETS="${targets}" make dockerx.pushx
-    DOCKER_BUILD_VARIANTS="default" DOCKER_TARGETS="${nonDistrolessTargets}" make dockerx.pushx
+    DOCKER_ARCHITECTURES="linux/${TARGET_ARCH}" DOCKER_BUILD_VARIANTS="distroless" DOCKER_TARGETS="${targets}" make dockerx.pushx
+    DOCKER_ARCHITECTURES="linux/${TARGET_ARCH}" DOCKER_BUILD_VARIANTS="default" DOCKER_TARGETS="${nonDistrolessTargets}" make dockerx.pushx
   else
-    DOCKER_BUILD_VARIANTS="${VARIANT:-default}" DOCKER_TARGETS="${targets} ${nonDistrolessTargets}" make dockerx.pushx
+   DOCKER_ARCHITECTURES="linux/${TARGET_ARCH}"  DOCKER_BUILD_VARIANTS="${VARIANT:-default}" DOCKER_TARGETS="${targets} ${nonDistrolessTargets}" make dockerx.pushx
   fi
 }
 

--- a/prow/lib.sh
+++ b/prow/lib.sh
@@ -125,6 +125,7 @@ function build_images() {
     targets+="docker.operator "
   fi
   targets+="docker.install-cni "
+  # Integration tests are always running on local architecture (no cross compiling), so find out what that is.
   arch="linux/amd64"
   if [[ "$(uname -m)" == "aarch64" ]]; then
       arch="linux/arm64"

--- a/prow/lib.sh
+++ b/prow/lib.sh
@@ -125,11 +125,15 @@ function build_images() {
     targets+="docker.operator "
   fi
   targets+="docker.install-cni "
+  arch="linux/amd64"
+  if [[ "$(uname -m)" == arm* ]]; then
+      arch="linux/arm64"
+  fi
   if [[ "${VARIANT:-default}" == "distroless" ]]; then
-    DOCKER_ARCHITECTURES="linux/${TARGET_ARCH}" DOCKER_BUILD_VARIANTS="distroless" DOCKER_TARGETS="${targets}" make dockerx.pushx
-    DOCKER_ARCHITECTURES="linux/${TARGET_ARCH}" DOCKER_BUILD_VARIANTS="default" DOCKER_TARGETS="${nonDistrolessTargets}" make dockerx.pushx
+    DOCKER_ARCHITECTURES="${arch}" DOCKER_BUILD_VARIANTS="distroless" DOCKER_TARGETS="${targets}" make dockerx.pushx
+    DOCKER_ARCHITECTURES="${arch}" DOCKER_BUILD_VARIANTS="default" DOCKER_TARGETS="${nonDistrolessTargets}" make dockerx.pushx
   else
-   DOCKER_ARCHITECTURES="linux/${TARGET_ARCH}"  DOCKER_BUILD_VARIANTS="${VARIANT:-default}" DOCKER_TARGETS="${targets} ${nonDistrolessTargets}" make dockerx.pushx
+   DOCKER_ARCHITECTURES="${arch}"  DOCKER_BUILD_VARIANTS="${VARIANT:-default}" DOCKER_TARGETS="${targets} ${nonDistrolessTargets}" make dockerx.pushx
   fi
 }
 

--- a/prow/lib.sh
+++ b/prow/lib.sh
@@ -126,7 +126,7 @@ function build_images() {
   fi
   targets+="docker.install-cni "
   arch="linux/amd64"
-  if [[ "$(uname -m)" == arm* ]]; then
+  if [[ "$(uname -m)" == "aarch64" ]]; then
       arch="linux/arm64"
   fi
   if [[ "${VARIANT:-default}" == "distroless" ]]; then

--- a/prow/release-commit.sh
+++ b/prow/release-commit.sh
@@ -75,6 +75,7 @@ ${DEPENDENCIES:-$(cat <<EOD
   release-builder:
     git: https://github.com/istio/release-builder
     sha: ${BUILDER_SHA}
+architectures: [linux/amd64, linux/arm64]
 EOD
 )}
 dashboards:

--- a/prow/release-commit.sh
+++ b/prow/release-commit.sh
@@ -32,7 +32,7 @@ DOCKER_HUB=${DOCKER_HUB:-gcr.io/istio-testing}
 GCS_BUCKET=${GCS_BUCKET:-istio-build/dev}
 
 # Use a pinned version in case breaking changes are needed
-BUILDER_SHA=49c3b9df16351ca44455c8a12be5829c7eef3a25
+BUILDER_SHA=55c3306e83172818e87af7911756c249f142a4b1
 
 # Reference to the next minor version of Istio
 # This will create a version like 1.4-alpha.sha

--- a/samples/jwt-server/jwt-server.yaml
+++ b/samples/jwt-server/jwt-server.yaml
@@ -106,7 +106,7 @@ spec:
         app: jwt-server
     spec:
       containers:
-      - image: gcr.io/istio-testing/jwt-server:0.6
+      - image: gcr.io/istio-testing/jwt-server:0.7
         imagePullPolicy: IfNotPresent
         name: jwt-server
         volumeMounts:

--- a/samples/jwt-server/src/Dockerfile
+++ b/samples/jwt-server/src/Dockerfile
@@ -13,12 +13,12 @@
 #   limitations under the License.
 
 # build a jwt-server binary using the golang container
-FROM golang:1.15 as builder
+FROM golang:1.19 as builder
 WORKDIR /go/src/istio.io/jwt-server/
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -o jwt-server main.go
 
-FROM gcr.io/distroless/static-debian10@sha256:4433370ec2b3b97b338674b4de5ffaef8ce5a38d1c9c0cb82403304b8718cde9 as distroless
+FROM gcr.io/distroless/static-debian11@sha256:21d3f84a4f37c36199fd07ad5544dcafecc17776e3f3628baf9a57c8c0181b3f as distroless
 
 WORKDIR /bin/
 # copy the jwt-server binary to a separate container based on BASE_DISTRIBUTION

--- a/samples/jwt-server/src/Makefile
+++ b/samples/jwt-server/src/Makefile
@@ -13,10 +13,7 @@
 # limitations under the License.
 
 HUB ?= gcr.io/istio-testing/jwt-server
-TAG ?= 0.6
+TAG ?= 0.7
 
-build: main.go Dockerfile
-	docker build . -t $(HUB):$(TAG)
-
-push: build
-	docker push $(HUB):$(TAG)
+push: main.go Dockerfile
+	docker buildx build --push --platform=linux/amd64,linux/arm64 . -t $(HUB):$(TAG)

--- a/tools/docker-builder/builder/crane.go
+++ b/tools/docker-builder/builder/crane.go
@@ -31,6 +31,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
+	"github.com/google/go-containerregistry/pkg/v1/types"
 
 	"istio.io/pkg/log"
 )
@@ -257,6 +258,7 @@ func Build(b BuildSpec) error {
 	} else {
 		// Multiple, we need to create an index
 		var manifest v1.ImageIndex = empty.Index
+		manifest = mutate.IndexMediaType(manifest, types.DockerManifestList)
 		for idx, i := range images {
 			img := i
 			mt, err := img.MediaType()

--- a/tools/docker-builder/builder/crane.go
+++ b/tools/docker-builder/builder/crane.go
@@ -79,7 +79,7 @@ func WarmBase(architectures []string, baseImages ...string) {
 	basesMu.Lock()
 	wg := sync.WaitGroup{}
 	wg.Add(len(baseImages) * len(architectures))
-	resolvedBaseImages := make([]v1.Image, len(baseImages))
+	resolvedBaseImages := make([]v1.Image, len(baseImages) * len(architectures))
 	keys := []baseKey{}
 	for _, a := range architectures {
 		for _, b := range baseImages {

--- a/tools/docker-builder/builder/crane.go
+++ b/tools/docker-builder/builder/crane.go
@@ -65,35 +65,50 @@ type Args struct {
 	FilesBase string
 }
 
+type baseKey struct {
+	arch string
+	name string
+}
+
 var (
-	bases   = map[string]v1.Image{}
+	bases   = map[baseKey]v1.Image{}
 	basesMu sync.RWMutex
 )
 
-func WarmBase(baseImages ...string) {
+func WarmBase(architectures []string, baseImages ...string) {
 	basesMu.Lock()
 	wg := sync.WaitGroup{}
-	wg.Add(len(baseImages))
+	wg.Add(len(baseImages) * len(architectures))
 	resolvedBaseImages := make([]v1.Image, len(baseImages))
+	keys := []baseKey{}
+	for _, a := range architectures {
+		for _, b := range baseImages {
+			keys = append(keys, baseKey{toPlatform(a).Architecture, b})
+		}
+	}
 	go func() {
 		wg.Wait()
 		for i, rbi := range resolvedBaseImages {
-			bases[baseImages[i]] = rbi
+			bases[keys[i]] = rbi
 		}
 		basesMu.Unlock()
 	}()
 
 	t0 := time.Now()
-	for i, b := range baseImages {
+	for i, b := range keys {
 		b, i := b, i
 		go func() {
 			defer wg.Done()
-			ref, err := name.ParseReference(b)
+			ref, err := name.ParseReference(b.name)
 			if err != nil {
 				log.WithLabels("image", b).Warnf("base failed: %v", err)
 				return
 			}
-			bi, err := remote.Image(ref, remote.WithProgress(CreateProgress(fmt.Sprintf("base %v", ref))))
+			plat := v1.Platform{
+				Architecture: b.arch,
+				OS:           "linux",
+			}
+			bi, err := remote.Image(ref, remote.WithPlatform(plat), remote.WithProgress(CreateProgress(fmt.Sprintf("base %v", ref))))
 			if err != nil {
 				log.WithLabels("image", b).Warnf("base failed: %v", err)
 				return
@@ -140,10 +155,11 @@ func Build(b BuildSpec) error {
 
 	var images []v1.Image
 	for _, args := range b.Args {
+		plat := toPlatform(args.Arch)
 		baseImage := empty.Image
 		if args.Base != "" {
 			basesMu.RLock()
-			baseImage = bases[args.Base]
+			baseImage = bases[baseKey{arch: plat.Architecture, name: args.Base}] // todo per-arch base
 			basesMu.RUnlock()
 		}
 		if baseImage == nil {
@@ -152,7 +168,11 @@ func Build(b BuildSpec) error {
 			if err != nil {
 				return err
 			}
-			bi, err := remote.Image(ref, remote.WithProgress(CreateProgress(fmt.Sprintf("base %v", ref))))
+			bi, err := remote.Image(
+				ref,
+				remote.WithPlatform(plat),
+				remote.WithProgress(CreateProgress(fmt.Sprintf("base %v", ref))),
+			)
 			if err != nil {
 				return err
 			}
@@ -166,6 +186,11 @@ func Build(b BuildSpec) error {
 		}
 
 		trace("base config")
+
+		// Set our platform on the image. This is largely for empty.Image only; others should already have correct default.
+		cfgFile = cfgFile.DeepCopy()
+		cfgFile.OS = plat.OS
+		cfgFile.Architecture = plat.Architecture
 
 		cfg := cfgFile.Config
 		for k, v := range args.Env {
@@ -248,18 +273,14 @@ func Build(b BuildSpec) error {
 			if err != nil {
 				return fmt.Errorf("failed to compute size: %w", err)
 			}
-			os, arch, _ := strings.Cut(b.Args[idx].Arch, "/")
+			plat := toPlatform(b.Args[idx].Arch)
 			manifest = mutate.AppendManifests(manifest, mutate.IndexAddendum{
 				Add: i,
 				Descriptor: v1.Descriptor{
 					MediaType: mt,
 					Size:      size,
 					Digest:    h,
-					Platform: &v1.Platform{
-						Architecture: arch,
-						OS:           os,
-						Variant:      "", // TODO?
-					},
+					Platform:  &plat,
 				},
 			})
 		}
@@ -297,6 +318,15 @@ func Build(b BuildSpec) error {
 	}
 
 	return nil
+}
+
+func toPlatform(archString string) v1.Platform {
+	os, arch, _ := strings.Cut(archString, "/")
+	return v1.Platform{
+		Architecture: arch,
+		OS:           os,
+		Variant:      "", // TODO?
+	}
 }
 
 func CreateProgress(name string) chan v1.Update {

--- a/tools/docker-builder/builder/crane.go
+++ b/tools/docker-builder/builder/crane.go
@@ -79,7 +79,7 @@ func WarmBase(architectures []string, baseImages ...string) {
 	basesMu.Lock()
 	wg := sync.WaitGroup{}
 	wg.Add(len(baseImages) * len(architectures))
-	resolvedBaseImages := make([]v1.Image, len(baseImages) * len(architectures))
+	resolvedBaseImages := make([]v1.Image, len(baseImages)*len(architectures))
 	keys := []baseKey{}
 	for _, a := range architectures {
 		for _, b := range baseImages {

--- a/tools/docker-builder/common.go
+++ b/tools/docker-builder/common.go
@@ -25,13 +25,13 @@ func extractTags(a Args, target, variant string, hasDoubleDefault bool) []string
 		for _, tg := range a.Tags {
 			if variant == DefaultVariant {
 				// For default, we have no suffix
-				tags = append(tags, fmt.Sprintf("%s/%s:%s", h, target, tg))
+				tags = append(tags, fmt.Sprintf("%s/%s:%s%s", h, target, tg, a.suffix))
 			} else {
 				// Otherwise, we have a suffix with the variant
-				tags = append(tags, fmt.Sprintf("%s/%s:%s-%s", h, target, tg, variant))
+				tags = append(tags, fmt.Sprintf("%s/%s:%s-%s%s", h, target, tg, variant, a.suffix))
 				// If we need a default as well, add it as a second tag for the same image to avoid building twice
 				if variant == PrimaryVariant && hasDoubleDefault {
-					tags = append(tags, fmt.Sprintf("%s/%s:%s", h, target, tg))
+					tags = append(tags, fmt.Sprintf("%s/%s:%s%s", h, target, tg, a.suffix))
 				}
 			}
 		}

--- a/tools/docker-builder/crane.go
+++ b/tools/docker-builder/crane.go
@@ -65,7 +65,11 @@ func RunCrane(a Args) error {
 				Dests: extractTags(a, t, v, hasDoubleDefault),
 			}
 			for _, arch := range a.Architectures {
-				df := a.PlanFor(arch).Find(t).Dockerfile
+				p := a.PlanFor(arch).Find(t)
+				if p == nil {
+					continue
+				}
+				df := p.Dockerfile
 				dargs := createArgs(a, t, v, arch)
 				args, err := dockerfile.Parse(df, dockerfile.WithArgs(dargs), dockerfile.IgnoreRuns())
 				if err != nil {
@@ -76,6 +80,9 @@ func RunCrane(a Args) error {
 				// args.Files provides a mapping from final destination -> docker context source
 				// docker context is virtual, so we need to rewrite the "docker context source" to the real path of disk
 				plan := a.PlanFor(arch).Find(args.Name)
+				if plan == nil {
+					continue
+				}
 				// Plan is a list of real file paths, but we don't have a strong mapping from "docker context source"
 				// to "real path on disk". We do have a weak mapping though, by reproducing docker-copy.sh
 				for dest, src := range args.Files {

--- a/tools/docker-builder/crane.go
+++ b/tools/docker-builder/crane.go
@@ -94,7 +94,7 @@ func RunCrane(a Args) error {
 
 	// Warm up our base images while we are building everything. This isn't pulling them -- we actually
 	// never pull them -- but it is pulling the config file from the remote registry.
-	builder.WarmBase(bases.SortedList()...)
+	builder.WarmBase(a.Architectures, bases.SortedList()...)
 
 	// Build all dependencies
 	makeStart := time.Now()

--- a/tools/docker-builder/docker.go
+++ b/tools/docker-builder/docker.go
@@ -48,6 +48,29 @@ import (
 // Once we have these staged folders, we just construct a docker bakefile and pass it to `buildx
 // bake` and let it do its work.
 func RunDocker(args Args) error {
+	requiresSplitBuild := len(args.Architectures) > 1 && (args.Save || !args.Push)
+	if !requiresSplitBuild {
+		return runDocker(args)
+	}
+	// https://github.com/docker/buildx/issues/59 - load and save are not supported for multi-arch
+	// To workaround, we do a build per-arch, and suffix with the architecture
+	for _, arch := range args.Architectures {
+		args.Architectures = []string{arch}
+		args.suffix = ""
+		if arch != "linux/amd64" {
+			// For backwards compatibility, we do not suffix linux/amd64
+			_, arch, _ := strings.Cut(arch, "/")
+			args.suffix = "-" + arch
+		}
+		log.Infof("building for arch %v", arch)
+		if err := runDocker(args); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func runDocker(args Args) error {
 	tarFiles, err := ConstructBakeFile(args)
 	if err != nil {
 		return err
@@ -222,11 +245,11 @@ func ConstructBakeFile(a Args) (map[string]string, error) {
 					n += "-" + variant
 				}
 
-				tarFiles[n] = ""
+				tarFiles[n+a.suffix] = ""
 				if variant == PrimaryVariant && hasDoubleDefault {
-					tarFiles[n] = target
+					tarFiles[n+a.suffix] = target+a.suffix
 				}
-				t.Outputs = []string{"type=docker,dest=" + filepath.Join(testenv.LocalOut, "release", "docker", n+".tar")}
+				t.Outputs = []string{"type=docker,dest=" + filepath.Join(testenv.LocalOut, "release", "docker", n+a.suffix+".tar")}
 			} else {
 				t.Outputs = []string{"type=docker"}
 			}

--- a/tools/docker-builder/docker.go
+++ b/tools/docker-builder/docker.go
@@ -50,6 +50,7 @@ import (
 func RunDocker(args Args) error {
 	requiresSplitBuild := len(args.Architectures) > 1 && (args.Save || !args.Push)
 	if !requiresSplitBuild {
+		log.Infof("building for architectures: %v", args.Architectures)
 		return runDocker(args)
 	}
 	// https://github.com/docker/buildx/issues/59 - load and save are not supported for multi-arch

--- a/tools/docker-builder/docker.go
+++ b/tools/docker-builder/docker.go
@@ -103,6 +103,9 @@ func CopyInputs(a Args) error {
 	for _, target := range a.Targets {
 		for _, arch := range a.Architectures {
 			bp := a.PlanFor(arch).Find(target)
+			if bp == nil {
+				continue
+			}
 			args := bp.Dependencies()
 			args = append(args, filepath.Join(testenv.LocalOut, "dockerx_build", fmt.Sprintf("build.docker.%s", target)))
 			if err := RunCommand(a, "tools/docker-copy.sh", args...); err != nil {
@@ -217,6 +220,9 @@ func ConstructBakeFile(a Args) (map[string]string, error) {
 		for _, target := range a.Targets {
 			// Just for Dockerfile, so do not worry about architecture
 			bp := a.PlanFor(a.Architectures[0]).Find(target)
+			if bp == nil {
+				continue
+			}
 			if variant == DefaultVariant && hasDoubleDefault {
 				// This will be process by the PrimaryVariant, skip it here
 				continue
@@ -248,7 +254,7 @@ func ConstructBakeFile(a Args) (map[string]string, error) {
 
 				tarFiles[n+a.suffix] = ""
 				if variant == PrimaryVariant && hasDoubleDefault {
-					tarFiles[n+a.suffix] = target+a.suffix
+					tarFiles[n+a.suffix] = target + a.suffix
 				}
 				t.Outputs = []string{"type=docker,dest=" + filepath.Join(testenv.LocalOut, "release", "docker", n+a.suffix+".tar")}
 			} else {

--- a/tools/docker-builder/main.go
+++ b/tools/docker-builder/main.go
@@ -221,7 +221,22 @@ func StandardEnv(args Args) []string {
 		// Build should already run in container, having multiple layers of docker causes issues
 		"BUILD_WITH_CONTAINER=0",
 	)
-	return env
+	// Ignore a few env vars. These cause problems because they are set once to a pinned value in the outer make,
+	// then refuse to be updated in the inner make.
+	ignoredEnvs := sets.New(
+		"CONTAINER_TARGET_OUT",
+		"CONTAINER_TARGET_OUT_LINUX",
+		"ISTIO_ENVOY_LINUX_RELEASE_DIR",
+		"ISTIO_ENVOY_LINUX_RELEASE_PATH",
+	)
+	res := make([]string, 0, len(env))
+	for _, vr := range env {
+		k, _, _ := strings.Cut(vr, "=")
+		if !ignoredEnvs.Contains(k) {
+			res = append(res, vr)
+		}
+	}
+	return res
 }
 
 var SkipMake = os.Getenv("SKIP_MAKE")

--- a/tools/docker-builder/main.go
+++ b/tools/docker-builder/main.go
@@ -229,26 +229,7 @@ func StandardEnv(args Args) []string {
 		// Build should already run in container, having multiple layers of docker causes issues
 		"BUILD_WITH_CONTAINER=0",
 	)
-	// Ignore a few env vars. These cause problems because they are set once to a pinned value in the outer make,
-	// then refuse to be updated in the inner make.
-	ignoredEnvs := sets.New(
-		"CONTAINER_TARGET_OUT",
-		"CONTAINER_TARGET_OUT_LINUX",
-		"ISTIO_ENVOY_LINUX_RELEASE_DIR",
-		"ISTIO_ENVOY_LINUX_RELEASE_PATH",
-		"ISTIO_ENVOY_ARCH_SUFFIX",
-		"ISTIO_ENVOY_DEBUG_URL",
-		"ISTIO_ENVOY_RELEASE_URL",
-		"ISTIO_ENVOY_LINUX_RELEASE_URL",
-	)
-	res := make([]string, 0, len(env))
-	for _, vr := range env {
-		k, _, _ := strings.Cut(vr, "=")
-		if !ignoredEnvs.Contains(k) {
-			res = append(res, vr)
-		}
-	}
-	return res
+	return env
 }
 
 var SkipMake = os.Getenv("SKIP_MAKE")

--- a/tools/docker-builder/main.go
+++ b/tools/docker-builder/main.go
@@ -228,6 +228,10 @@ func StandardEnv(args Args) []string {
 		"CONTAINER_TARGET_OUT_LINUX",
 		"ISTIO_ENVOY_LINUX_RELEASE_DIR",
 		"ISTIO_ENVOY_LINUX_RELEASE_PATH",
+		"ISTIO_ENVOY_ARCH_SUFFIX",
+		"ISTIO_ENVOY_DEBUG_URL",
+		"ISTIO_ENVOY_RELEASE_URL",
+		"ISTIO_ENVOY_LINUX_RELEASE_URL",
 	)
 	res := make([]string, 0, len(env))
 	for _, vr := range env {

--- a/tools/docker-builder/types.go
+++ b/tools/docker-builder/types.go
@@ -71,6 +71,8 @@ type Args struct {
 	IstioVersion  string
 	Tags          []string
 	Hubs          []string
+	// Suffix on artifacts, used for multi-arch images where we cannot use manifests
+	suffix string
 
 	// Plan describes the build plan, read from file.
 	// This is a map of architecture -> plan, as the plan is arch specific.

--- a/tools/docker-builder/types.go
+++ b/tools/docker-builder/types.go
@@ -219,6 +219,8 @@ func DefaultArgs() Args {
 		builder = b
 	}
 
+	// TODO: consider automatically detecting Qemu support
+
 	return Args{
 		Push:          false,
 		Save:          false,

--- a/tools/docker-builder/types.go
+++ b/tools/docker-builder/types.go
@@ -57,20 +57,20 @@ type Target struct {
 }
 
 type Args struct {
-	Push          bool
-	Save          bool
-	Builder       string
-	KindLoad      bool
-	NoClobber     bool
-	NoCache       bool
-	Targets       []string
-	Variants      []string
-	Architectures []string
-	BaseVersion   string
-	ProxyVersion  string
-	IstioVersion  string
-	Tags          []string
-	Hubs          []string
+	Push              bool
+	Save              bool
+	Builder           string
+	SupportsEmulation bool
+	NoClobber         bool
+	NoCache           bool
+	Targets           []string
+	Variants          []string
+	Architectures     []string
+	BaseVersion       string
+	ProxyVersion      string
+	IstioVersion      string
+	Tags              []string
+	Hubs              []string
 	// Suffix on artifacts, used for multi-arch images where we cannot use manifests
 	suffix string
 
@@ -112,6 +112,10 @@ type ImagePlan struct {
 	Targets []string `json:"targets"`
 	// Base indicates if this is a base image or not
 	Base bool `json:"base"`
+	// EmulationRequired indicates if emulation is required when cross-compiling. It typically is not,
+	// as most building in Istio is done outside of docker.
+	// When this is set, cross-compile is disabled for components unless emulation is epxlicitly specified
+	EmulationRequired bool `json:"emulationRequired"`
 }
 
 func (p ImagePlan) Dependencies() []string {
@@ -133,13 +137,13 @@ func (p BuildPlan) Targets() []string {
 	return tgts.SortedList()
 }
 
-func (p BuildPlan) Find(n string) ImagePlan {
+func (p BuildPlan) Find(n string) *ImagePlan {
 	for _, i := range p.Images {
 		if i.Name == n {
-			return i
+			return &i
 		}
 	}
-	panic("couldn't find target " + n)
+	return nil
 }
 
 // Define variants, which control the base image of an image.

--- a/tools/docker-copy.sh
+++ b/tools/docker-copy.sh
@@ -49,8 +49,10 @@ function may_copy_into_arch_named_sub_dir() {
   local FILE=${1}
   local COPY_ARCH_RELATED=${COPY_ARCH_RELATED:-1}
 
-  local arch="$(detect_arch "${FILE}")"
-  local FILE_INFO=$(file "${FILE}" || true)
+  local arch
+  arch="$(detect_arch "${FILE}")"
+  local FILE_INFO
+  FILE_INFO=$(file "${FILE}" || true)
 
   if [[ "${arch}" != "" && ${COPY_ARCH_RELATED} == 1 ]]; then
     # if other arch files exists, should copy too.

--- a/tools/docker-copy.sh
+++ b/tools/docker-copy.sh
@@ -46,16 +46,11 @@ function detect_arch() {
 }
 
 function may_copy_into_arch_named_sub_dir() {
-  FILE=${1}
-  COPY_ARCH_RELATED=${COPY_ARCH_RELATED:-1}
+  local FILE=${1}
+  local COPY_ARCH_RELATED=${COPY_ARCH_RELATED:-1}
 
-  arch="$(detect_arch "${FILE}")"
-  FILE_INFO=$(file "${FILE}" || true)
-  echo "File: ${FILE}, arch=${arch}"
-  # will put an arch named sub dir
-  # like
-  #   arm64/
-  #   amd64/
+  local arch="$(detect_arch "${FILE}")"
+  local FILE_INFO=$(file "${FILE}" || true)
 
   if [[ "${arch}" != "" && ${COPY_ARCH_RELATED} == 1 ]]; then
     # if other arch files exists, should copy too.
@@ -63,7 +58,7 @@ function may_copy_into_arch_named_sub_dir() {
       # like file `out/linux_amd64/pilot-discovery`
       # should check  `out/linux_arm64/pilot-discovery` exists then do copy
 
-      FILE_ARCH_RELATED=${FILE/linux_${TARGET_ARCH}/linux_${ARCH}}
+      local FILE_ARCH_RELATED=${FILE/linux_${TARGET_ARCH}/linux_${ARCH}}
 
       if [[ ${FILE_ARCH_RELATED} != "${FILE}" && -f ${FILE_ARCH_RELATED} ]]; then
         COPY_ARCH_RELATED=0 may_copy_into_arch_named_sub_dir "${FILE_ARCH_RELATED}"

--- a/tools/docker-copy.sh
+++ b/tools/docker-copy.sh
@@ -21,56 +21,74 @@ FILES=("${INPUTS[@]:0:${#INPUTS[@]}-1}")
 
 set -eu;
 
+# detect_arch returns "amd64", "arm64", or "" depending on if the file is arch specific
+function detect_arch() {
+  FILE=${1}
+  extension="${FILE##*.}"
+  if [[ "${extension}" == "deb" ]]; then
+    arch="$(dpkg-deb --info "${FILE}" | grep Arch | cut -d: -f 2 | cut -c 2-)"
+    echo "${arch}"
+    return 0
+  fi
+  FILE_INFO=$(file "${FILE}" || true)
+  if [[ ${FILE_INFO} == *"ELF 64-bit LSB"* ]]; then
+    case ${FILE_INFO} in
+      *x86-64*)
+        echo "amd64"
+        return 0
+        ;;
+      *aarch64*)
+        echo "arm64"
+        return 0
+        ;;
+    esac
+  fi
+}
+
 function may_copy_into_arch_named_sub_dir() {
   FILE=${1}
   COPY_ARCH_RELATED=${COPY_ARCH_RELATED:-1}
 
+  arch="$(detect_arch "${FILE}")"
   FILE_INFO=$(file "${FILE}" || true)
-  # when file is an `ELF 64-bit LSB`,
+  echo "File: ${FILE}, arch=${arch}"
   # will put an arch named sub dir
   # like
   #   arm64/
   #   amd64/
-  if [[ ${FILE_INFO} == *"ELF 64-bit LSB"* ]]; then
-    case ${FILE_INFO} in
-      *x86-64*)
-        mkdir -p "${DOCKER_WORKING_DIR}/amd64/" && cp -rp "${FILE}" "${DOCKER_WORKING_DIR}/amd64/"
-        chmod 755 "${DOCKER_WORKING_DIR}/amd64/$(basename "${FILE}")"
-        ;;
-      *aarch64*)
-        mkdir -p "${DOCKER_WORKING_DIR}/arm64/" && cp -rp "${FILE}" "${DOCKER_WORKING_DIR}/arm64/"
-        chmod 755 "${DOCKER_WORKING_DIR}/arm64/$(basename "${FILE}")"
-        ;;
-      *)
-        cp -rp "${FILE}" "${DOCKER_WORKING_DIR}"
-        chmod 755 "${DOCKER_WORKING_DIR}/$(basename "${FILE}")"
-        ;;
-    esac
 
+  if [[ "${arch}" != "" && ${COPY_ARCH_RELATED} == 1 ]]; then
+    # if other arch files exists, should copy too.
+    for ARCH in "amd64" "arm64"; do
+      # like file `out/linux_amd64/pilot-discovery`
+      # should check  `out/linux_arm64/pilot-discovery` exists then do copy
 
-    if [[ ${COPY_ARCH_RELATED} == 1 ]]; then
-      # if other arch files exists, should copy too.
-      for ARCH in "amd64" "arm64"; do
-        # like file `out/linux_amd64/pilot-discovery`
-        # should check  `out/linux_arm64/pilot-discovery` exists then do copy
+      FILE_ARCH_RELATED=${FILE/linux_${TARGET_ARCH}/linux_${ARCH}}
 
-        FILE_ARCH_RELATED=${FILE/linux_${TARGET_ARCH}/linux_${ARCH}}
+      if [[ ${FILE_ARCH_RELATED} != "${FILE}" && -f ${FILE_ARCH_RELATED} ]]; then
+        COPY_ARCH_RELATED=0 may_copy_into_arch_named_sub_dir "${FILE_ARCH_RELATED}"
+      fi
+    done
+  fi
 
-        if [[ ${FILE_ARCH_RELATED} != "${FILE}" && -f ${FILE_ARCH_RELATED} ]]; then
-          COPY_ARCH_RELATED=0 may_copy_into_arch_named_sub_dir "${FILE_ARCH_RELATED}"
-        fi
-      done
-    fi
+  # For arch specific, will put an arch named sub dir like
+  #   arm64/
+  #   amd64/
+  dst="${DOCKER_WORKING_DIR}"
+  if [[ "${arch}" != "" ]]; then
+    dst+="/${arch}/"
+  fi
+  mkdir -p "${dst}"
+  cp -rp "${FILE}" "${dst}"
 
+  # Based on type, explicit set permissions. These may differ on host machine due to umask, so always override.
+  out="${dst}/$(basename "${FILE}")"
+  if [[ -d "${out}" ]]; then
+    chmod -R a+r "${out}"
+  elif [[ -x "${out}" ]]; then
+    chmod 755 "${out}"
   else
-    cp -rp "${FILE}" "${DOCKER_WORKING_DIR}"
-    file="${DOCKER_WORKING_DIR}/$(basename "${FILE}")"
-    if [[ -d ${file} ]]
-    then
-      chmod -R a+r "${file}"
-    else
-      chmod a+r "${file}"
-    fi
+    chmod a+r "${out}"
   fi
 }
 

--- a/tools/docker.yaml
+++ b/tools/docker.yaml
@@ -104,6 +104,7 @@ images:
   - ${TARGET_OUT_LINUX}/release/istio-sidecar-centos-7.rpm
   - ${TARGET_OUT_LINUX}/client
   - ${TARGET_OUT_LINUX}/server
+  emulationRequired: true
 - name: app_sidecar_debian_11
   dockerfile: pkg/test/echo/docker/Dockerfile.app_sidecar
   files:
@@ -115,6 +116,7 @@ images:
   - ${TARGET_OUT_LINUX}/release/istio-sidecar.deb
   - ${TARGET_OUT_LINUX}/client
   - ${TARGET_OUT_LINUX}/server
+  emulationRequired: true
 - name: app_sidecar_ubuntu_jammy
   dockerfile: pkg/test/echo/docker/Dockerfile.app_sidecar
   files:
@@ -126,6 +128,7 @@ images:
   - ${TARGET_OUT_LINUX}/release/istio-sidecar.deb
   - ${TARGET_OUT_LINUX}/client
   - ${TARGET_OUT_LINUX}/server
+  emulationRequired: true
 - name: app_sidecar_ubuntu_xenial
   dockerfile: pkg/test/echo/docker/Dockerfile.app_sidecar
   files:
@@ -137,6 +140,7 @@ images:
   - ${TARGET_OUT_LINUX}/release/istio-sidecar.deb
   - ${TARGET_OUT_LINUX}/client
   - ${TARGET_OUT_LINUX}/server
+  emulationRequired: true
 
 # Test base images
 - name: app_sidecar_base_debian_11 # latest debian

--- a/tools/packaging/packaging.mk
+++ b/tools/packaging/packaging.mk
@@ -80,6 +80,7 @@ rpm/fpm:
 	fpm -s dir -t rpm -n ${SIDECAR_PACKAGE_NAME} -p ${TARGET_OUT_LINUX}/release/istio-sidecar.rpm --version $(PACKAGE_VERSION) -f \
 		--url http://istio.io  \
 		--license Apache \
+		--architecture "${TARGET_ARCH}" \
 		--vendor istio.io \
 		--maintainer istio@istio.io \
 		--after-install tools/packaging/postinst.sh \
@@ -99,6 +100,7 @@ rpm-7/fpm:
 		--url http://istio.io  \
 		--license Apache \
 		--vendor istio.io \
+		--architecture "${TARGET_ARCH}" \
 		--maintainer istio@istio.io \
 		--after-install tools/packaging/postinst.sh \
 		--config-files /var/lib/istio/envoy/envoy_bootstrap_tmpl.json \
@@ -117,6 +119,7 @@ deb/fpm:
 		--url http://istio.io  \
 		--license Apache \
 		--vendor istio.io \
+		--architecture "${TARGET_ARCH}" \
 		--maintainer istio@istio.io \
 		--after-install tools/packaging/postinst.sh \
 		--config-files /var/lib/istio/envoy/envoy_bootstrap_tmpl.json \


### PR DESCRIPTION
For https://github.com/istio/istio/issues/26652#issuecomment-1155682106

This PR nearly finalizes arm64 support in Istio. With this, release-builder will publish amd64 and arm64 builds. We also have e2e tests using arm64 which works as well.

Changes required to get this to work:
* Refactor env vars (split into https://github.com/istio/istio/pull/40252)
* Update kind image to multi-arch one
* Update jwt-server to be multi-arch
* Update docker build to pull the correct base image per-arch for crane builder, as well as tag the final image with the correct architecture
* Update docker builder to allow building for multiple platforms without multi-arch builds. For --load and --save, multi-arch is not supported. Instead, if these cases are detect we will make single-arch images with an `-arch` suffix. Note: this is fairly internal facing -- once we publish them we will merge them back into a single multi-arch image.
* Update integration tests to dynamically pick architecture based on current arch. Integration tests are always using local arch, not cross compile
* Update app_sidecar test images to support multi-arch. Most of this was in docker-copy.sh, which was updated to also support detecting .deb architecture, which came with some refactoring.
* app_sidecar has RUN commands, requiring qemu for cross compile. This technically works now, but IMO we don't want/need this. For release, we can just skip arm64 app_sidecar builds since they are just test images, for simplicity. We can revisit this in the future if needed. To support this, add a new `--qemu` flag. If its not set, we will skip cross-compiling images that are labeled as requiring emulation.
