### PR TITLE
Wasm: Fix improper stringify, which was omitted in previous commit

### DIFF
--- a/tests/integration/telemetry/stats/prometheus/wasm/wasm_modules/header_injector/plugin.cc
+++ b/tests/integration/telemetry/stats/prometheus/wasm/wasm_modules/header_injector/plugin.cc
@@ -18,6 +18,7 @@
 #error INJECTION_VERSION must be defined
 #endif // INJECTION_VERSION
 
+#define xstr(s) str(s)
 #define str(s) #s
 
 // Boilderplate code to register the extension implementation.
@@ -27,11 +28,11 @@ static RegisterContextFactory register_HeaderInjector(CONTEXT_FACTORY(HeaderInje
 bool HeaderInjectorRootContext::onConfigure(size_t) { return true; }
 
 FilterHeadersStatus HeaderInjectorContext::onRequestHeaders(uint32_t, bool) {
-  addRequestHeader("X-Req-Injection", str(INJECTION_VERSION));
+  addRequestHeader("X-Req-Injection", xstr(INJECTION_VERSION));
   return FilterHeadersStatus::Continue;
 }
 
 FilterHeadersStatus HeaderInjectorContext::onResponseHeaders(uint32_t, bool) {
-  addResponseHeader("X-Resp-Injection", str(INJECTION_VERSION));
+  addResponseHeader("X-Resp-Injection", xstr(INJECTION_VERSION));
   return FilterHeadersStatus::Continue;
 }


### PR DESCRIPTION
Fix the wrong stringify macro. It was mistakenly not included in the previous PR.