### PR TITLE
pilot: drop tunnel-ability implementation

### DIFF
--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -32,7 +32,6 @@ import (
 	"github.com/mitchellh/copystructure"
 
 	"istio.io/api/label"
-	"istio.io/istio/pilot/pkg/networking"
 	"istio.io/istio/pilot/pkg/serviceregistry/provider"
 	"istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/config/constants"
@@ -460,11 +459,6 @@ type IstioEndpoint struct {
 
 	// If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>".
 	SubDomain string
-
-	// The ingress tunnel supportability of this endpoint.
-	// If this endpoint sidecar proxy does not support h2 tunnel, this endpoint will not show up in the EDS clusters
-	// which are generated for h2 tunnel.
-	TunnelAbility networking.TunnelAbility
 
 	// Determines the discoverability of this endpoint throughout the mesh.
 	DiscoverabilityPolicy EndpointDiscoverabilityPolicy `json:"-"`

--- a/pilot/pkg/xds/eds.go
+++ b/pilot/pkg/xds/eds.go
@@ -324,8 +324,6 @@ func (s *DiscoveryServer) generateEndpoints(b EndpointBuilder) *endpoint.Cluster
 		// To ensure we allow traffic only to mTLS endpoints, we filter out non-mTLS endpoints for these cluster types.
 		llbOpts = b.EndpointsWithMTLSFilter(llbOpts)
 	}
-	llbOpts = b.ApplyTunnelSetting(llbOpts, b.tunnelType)
-
 	l := b.createClusterLoadAssignment(llbOpts)
 
 	// If locality aware routing is enabled, prioritize endpoints or set their lb weight.

--- a/pilot/pkg/xds/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoint_builder.go
@@ -22,7 +22,6 @@ import (
 
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
-	"google.golang.org/protobuf/proto"
 	wrappers "google.golang.org/protobuf/types/known/wrapperspb"
 
 	networkingapi "istio.io/api/networking/v1alpha3"
@@ -195,62 +194,15 @@ func (b EndpointBuilder) DependentTypes() []config.GroupVersionKind {
 	return edsDependentTypes
 }
 
-// TODO(lambdai): Receive port value(15009 by default), builder to cover wide cases.
-type EndpointTunnelApplier interface {
-	// Mutate LbEndpoint in place. Return non-nil on failure.
-	ApplyTunnel(lep *endpoint.LbEndpoint, tunnelType networking.TunnelType) (*endpoint.LbEndpoint, error)
-}
-
-type EndpointNoTunnelApplier struct{}
-
-// Note that this will not return error if another tunnel typs requested.
-func (t *EndpointNoTunnelApplier) ApplyTunnel(lep *endpoint.LbEndpoint, _ networking.TunnelType) (*endpoint.LbEndpoint, error) {
-	return lep, nil
-}
-
-type EndpointH2TunnelApplier struct{}
-
-// TODO(lambdai): Set original port if the default cluster original port is not the same.
-func (t *EndpointH2TunnelApplier) ApplyTunnel(lep *endpoint.LbEndpoint, tunnelType networking.TunnelType) (*endpoint.LbEndpoint, error) {
-	switch tunnelType {
-	case networking.H2Tunnel:
-		if ep := lep.GetEndpoint(); ep != nil {
-			if ep.Address.GetSocketAddress().GetPortValue() != 0 {
-				newEp := proto.Clone(lep).(*endpoint.LbEndpoint)
-				newEp.GetEndpoint().Address.GetSocketAddress().PortSpecifier = &core.SocketAddress_PortValue{
-					PortValue: 15009,
-				}
-				return newEp, nil
-			}
-		}
-		return lep, nil
-	case networking.NoTunnel:
-		return lep, nil
-	default:
-		panic("supported tunnel type")
-	}
-}
-
 type LocLbEndpointsAndOptions struct {
 	istioEndpoints []*model.IstioEndpoint
 	// The protobuf message which contains LbEndpoint slice.
 	llbEndpoints endpoint.LocalityLbEndpoints
-	// The runtime information of the LbEndpoint slice. Each LbEndpoint has individual metadata at the same index.
-	tunnelMetadata []EndpointTunnelApplier
 }
 
-// Return prefer H2 tunnel metadata.
-func MakeTunnelApplier(_ *endpoint.LbEndpoint, tunnelOpt networking.TunnelAbility) EndpointTunnelApplier {
-	if tunnelOpt.SupportH2Tunnel() {
-		return &EndpointH2TunnelApplier{}
-	}
-	return &EndpointNoTunnelApplier{}
-}
-
-func (e *LocLbEndpointsAndOptions) append(ep *model.IstioEndpoint, le *endpoint.LbEndpoint, tunnelOpt networking.TunnelAbility) {
+func (e *LocLbEndpointsAndOptions) append(ep *model.IstioEndpoint, le *endpoint.LbEndpoint) {
 	e.istioEndpoints = append(e.istioEndpoints, ep)
 	e.llbEndpoints.LbEndpoints = append(e.llbEndpoints.LbEndpoints, le)
-	e.tunnelMetadata = append(e.tunnelMetadata, MakeTunnelApplier(le, tunnelOpt))
 }
 
 func (e *LocLbEndpointsAndOptions) refreshWeight() {
@@ -267,7 +219,7 @@ func (e *LocLbEndpointsAndOptions) refreshWeight() {
 }
 
 func (e *LocLbEndpointsAndOptions) AssertInvarianceInTest() {
-	if len(e.llbEndpoints.LbEndpoints) != len(e.tunnelMetadata) {
+	if len(e.llbEndpoints.LbEndpoints) != len(e.istioEndpoints) {
 		panic(" len(e.llbEndpoints.LbEndpoints) != len(e.tunnelMetadata)")
 	}
 }
@@ -316,7 +268,6 @@ func (b *EndpointBuilder) buildLocalityLbEndpointsFromShards(
 						Locality:    util.ConvertLocality(ep.Locality.Label),
 						LbEndpoints: make([]*endpoint.LbEndpoint, 0, len(endpoints)),
 					},
-					tunnelMetadata: make([]EndpointTunnelApplier, 0, len(endpoints)),
 				}
 				localityEpMap[ep.Locality.Label] = locLbEps
 			}
@@ -337,7 +288,7 @@ func (b *EndpointBuilder) buildLocalityLbEndpointsFromShards(
 					}
 				}
 			}
-			locLbEps.append(ep, ep.EnvoyEndpoint, ep.TunnelAbility)
+			locLbEps.append(ep, ep.EnvoyEndpoint)
 		}
 	}
 	shards.Unlock()
@@ -367,21 +318,6 @@ func (b *EndpointBuilder) buildLocalityLbEndpointsFromShards(
 	}
 
 	return locEps
-}
-
-// TODO(lambdai): Handle ApplyTunnel error return value by filter out the failed endpoint.
-func (b *EndpointBuilder) ApplyTunnelSetting(llbOpts []*LocLbEndpointsAndOptions, tunnelType networking.TunnelType) []*LocLbEndpointsAndOptions {
-	for _, llb := range llbOpts {
-		for i, ep := range llb.llbEndpoints.LbEndpoints {
-			newEp, err := llb.tunnelMetadata[i].ApplyTunnel(ep, tunnelType)
-			if err != nil {
-				panic("not implemented yet on failing to apply tunnel")
-			} else {
-				llb.llbEndpoints.LbEndpoints[i] = newEp
-			}
-		}
-	}
-	return llbOpts
 }
 
 // Create the CLusterLoadAssignment. At this moment the options must have been applied to the locality lb endpoints.

--- a/pilot/pkg/xds/ep_filters.go
+++ b/pilot/pkg/xds/ep_filters.go
@@ -22,7 +22,6 @@ import (
 	wrappers "google.golang.org/protobuf/types/known/wrapperspb"
 
 	"istio.io/istio/pilot/pkg/model"
-	"istio.io/istio/pilot/pkg/networking"
 	"istio.io/istio/pilot/pkg/networking/util"
 	labelutil "istio.io/istio/pilot/pkg/serviceregistry/util/label"
 	"istio.io/istio/pkg/cluster"
@@ -94,7 +93,7 @@ func (b *EndpointBuilder) EndpointsByNetworkFilter(endpoints []*LocLbEndpointsAn
 			// directly from the local network.
 			if b.proxy.InNetwork(epNetwork) || len(gateways) == 0 {
 				// The endpoint is directly reachable - just add it.
-				lbEndpoints.append(ep.istioEndpoints[i], lbEp, ep.istioEndpoints[i].TunnelAbility)
+				lbEndpoints.append(ep.istioEndpoints[i], lbEp)
 				continue
 			}
 
@@ -148,7 +147,7 @@ func (b *EndpointBuilder) EndpointsByNetworkFilter(endpoints []*LocLbEndpointsAn
 			gwEp.Metadata = util.BuildLbEndpointMetadata(gw.Network, model.IstioMutualTLSModeLabel,
 				"", "", b.clusterID, labels.Instance{})
 			// Currently gateway endpoint does not support tunnel.
-			lbEndpoints.append(gwIstioEp, gwEp, networking.MakeTunnelAbility())
+			lbEndpoints.append(gwIstioEp, gwEp)
 		}
 
 		// Endpoint members could be stripped or aggregated by network. Adjust weight value here.
@@ -222,7 +221,7 @@ func (b *EndpointBuilder) EndpointsWithMTLSFilter(endpoints []*LocLbEndpointsAnd
 				// no mTLS, skip it
 				continue
 			}
-			lbEndpoints.append(ep.istioEndpoints[i], lbEp, ep.istioEndpoints[i].TunnelAbility)
+			lbEndpoints.append(ep.istioEndpoints[i], lbEp)
 		}
 
 		filtered = append(filtered, lbEndpoints)


### PR DESCRIPTION
This was initially added to support HBONE, but hasn't been used since implemented. I think the real implementation direction is going for a different approach, so we can clean this up.

Essentially reverts https://github.com/istio/istio/commit/86b87f2f923c62344a1887b47adbc69bd6c2ddaa