### PR TITLE
Echo Test: Use 17171 as the port for probes for custom grpc app

### DIFF
--- a/common/scripts/kind_provisioner.sh
+++ b/common/scripts/kind_provisioner.sh
@@ -416,7 +416,7 @@ function cidr_to_ips() {
     python3 - <<EOF
 from ipaddress import ip_network;
 from itertools import islice;
-[print(str(ip) + "/" + str(ip.max_prefixlen)) for ip in islice(ip_network('$CIDR').hosts(), 1000, 1100)]
+[print(str(ip) + "/" + str(ip.max_prefixlen)) for ip in islice(ip_network('$CIDR').hosts(), 200, 1100)]
 EOF
 }
 

--- a/common/scripts/kind_provisioner.sh
+++ b/common/scripts/kind_provisioner.sh
@@ -416,7 +416,7 @@ function cidr_to_ips() {
     python3 - <<EOF
 from ipaddress import ip_network;
 from itertools import islice;
-[print(str(ip) + "/" + str(ip.max_prefixlen)) for ip in islice(ip_network('$CIDR').hosts(), 200, 1100)]
+[print(str(ip) + "/" + str(ip.max_prefixlen)) for ip in islice(ip_network('$CIDR').hosts(), 1000, 1100)]
 EOF
 }
 

--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -232,6 +232,8 @@ spec:
         - containerPort: {{ $p.Port }}
 {{- if eq .Port 3333 }}
           name: tcp-health-port
+{{- else if and ($appContainer.ImageFullPath) (eq .Port 17171) }}
+          name: tcp-health-port
 {{- end }}
 {{- end }}
         env:
@@ -252,7 +254,7 @@ spec:
             port: {{ $.ReadinessGRPCPort }}			
 {{- else if $appContainer.ImageFullPath }}
           tcpSocket:
-            port: 3333
+            port: tcp-health-port
 {{- else }}
           httpGet:
             path: /
@@ -263,14 +265,14 @@ spec:
           failureThreshold: 10
         livenessProbe:
           tcpSocket:
-            port: 3333
+            port: tcp-health-port
           initialDelaySeconds: 10
           periodSeconds: 10
           failureThreshold: 10
 {{- if $.StartupProbe }}
         startupProbe:
           tcpSocket:
-            port: 3333
+            port: tcp-health-port
           periodSeconds: 1
           failureThreshold: 10
 {{- end }}

--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -250,9 +250,9 @@ spec:
 {{- else if $.ReadinessGRPCPort }}
           grpc:
             port: {{ $.ReadinessGRPCPort }}			
-{{- else if $.ImageFullPath }}
+{{- else if $appContainer.ImageFullPath }}
           tcpSocket:
-            port: tcp-health-port
+            port: 3333
 {{- else }}
           httpGet:
             path: /
@@ -263,14 +263,14 @@ spec:
           failureThreshold: 10
         livenessProbe:
           tcpSocket:
-            port: tcp-health-port
+            port: 3333
           initialDelaySeconds: 10
           periodSeconds: 10
           failureThreshold: 10
 {{- if $.StartupProbe }}
         startupProbe:
           tcpSocket:
-            port: tcp-health-port
+            port: 3333
           periodSeconds: 1
           failureThreshold: 10
 {{- end }}

--- a/pkg/test/framework/components/echo/kube/testdata/proxyless-custom-image.yaml
+++ b/pkg/test/framework/components/echo/kube/testdata/proxyless-custom-image.yaml
@@ -108,6 +108,7 @@ spec:
         ports:
         - containerPort: 7070
         - containerPort: 17171
+          name: tcp-health-port
         env:
         - name: INSTANCE_IP
           valueFrom:
@@ -116,9 +117,8 @@ spec:
         - name: EXPOSE_GRPC_ADMIN
           value: "true"
         readinessProbe:
-          httpGet:
-            path: /
-            port: 8080
+          tcpSocket:
+            port: tcp-health-port
           initialDelaySeconds: 1
           periodSeconds: 2
           failureThreshold: 10


### PR DESCRIPTION
Use 17171 as the port for probes for the custom grpc app, since 3333 would be listened on by the Go server