### PR TITLE
helm: add custom volume mounts

### DIFF
--- a/manifests/charts/gateway/templates/deployment.yaml
+++ b/manifests/charts/gateway/templates/deployment.yaml
@@ -86,6 +86,10 @@ spec:
             name: http-envoy-prom
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.extraVolumeMounts }}
+          volumeMounts:
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -101,4 +105,8 @@ spec:
       {{- with .Values.topologySpreadConstraints }}
       topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.extraVolumes }}
+      volumes:
+      {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/manifests/charts/gateway/values.schema.json
+++ b/manifests/charts/gateway/values.schema.json
@@ -195,6 +195,16 @@
           }
         }
       }
+    },
+    "extraVolumeMounts": {
+      "description": "Mount additional volumes into pods",
+      "type": "array",
+      "default": []
+    },
+    "extraVolumes": {
+      "description": "Mount additional volumes into pods",
+      "type": "array",
+      "default": []
     }
   }
 }

--- a/manifests/charts/gateway/values.schema.json
+++ b/manifests/charts/gateway/values.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
   "additionalProperties": false,
   "properties": {

--- a/manifests/charts/gateway/values.yaml
+++ b/manifests/charts/gateway/values.yaml
@@ -91,3 +91,13 @@ affinity: {}
 networkGateway: ""
 
 imagePullSecrets: []
+
+extraVolumes: []
+#  - name: xds-certificate-rotation-secrets
+#    secret:
+#      secretName: xds-certificate-rotation-secrets
+
+extraVolumeMounts: []
+#  - name: xds-certificate-rotation-secrets
+#    mountPath: /etc/envoy/validation_context_sds_secret.yaml
+#    subPath: validation_context_sds_secret.yaml

--- a/releasenotes/notes/39493.yaml
+++ b/releasenotes/notes/39493.yaml
@@ -1,0 +1,12 @@
+apiVersion: release-notes/v2
+
+kind: feature
+
+area: installation
+
+issue:
+  - 39493
+
+releaseNotes:
+  - |
+    **Added** values to the Istio Gateway Helm chart for configuring [volumes/volumeMounts](https://kubernetes.io/docs/concepts/storage/volumes/#secret) on the Deployment. Can be used to mount secrets and configs for envoy filter configurations.


### PR DESCRIPTION
Hi there,

Similar to how we had it in the old ingress charts, adds this pr custom volume mounts to the new gateway.

Without this change, secrets are difficult to add in Envoy Filters.