### PR TITLE
Add protocol check for empty address in Service Entry

### DIFF
--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -3208,6 +3208,11 @@ var ValidateServiceEntry = registerValidateFunc("ValidateServiceEntry",
 			if port.TargetPort != 0 {
 				errs = appendValidation(errs, ValidatePort(int(port.TargetPort)))
 			}
+			if len(serviceEntry.Addresses) == 0 {
+				if port.Protocol == "" || port.Protocol == "TCP" {
+					errs = appendValidation(errs, WrapWarning(fmt.Errorf("one or more protocol invalid in service entry with addresses empty.")))
+				}
+			}
 			errs = appendValidation(errs,
 				ValidatePortName(port.Name),
 				ValidateProtocol(port.Protocol),

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -3210,7 +3210,7 @@ var ValidateServiceEntry = registerValidateFunc("ValidateServiceEntry",
 			}
 			if len(serviceEntry.Addresses) == 0 {
 				if port.Protocol == "" || port.Protocol == "TCP" {
-					errs = appendValidation(errs, WrapWarning(fmt.Errorf("one or more protocol empty in service entry with addresses empty")))
+					errs = appendValidation(errs, WrapWarning(fmt.Errorf("addresses are required for ports serving TCP (or unset) protocol")))
 				}
 			}
 			errs = appendValidation(errs,

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -3210,7 +3210,7 @@ var ValidateServiceEntry = registerValidateFunc("ValidateServiceEntry",
 			}
 			if len(serviceEntry.Addresses) == 0 {
 				if port.Protocol == "" || port.Protocol == "TCP" {
-					errs = appendValidation(errs, WrapWarning(fmt.Errorf("one or more protocol invalid in service entry with addresses empty.")))
+					errs = appendValidation(errs, WrapWarning(fmt.Errorf("one or more protocol empty in service entry with addresses empty")))
 				}
 			}
 			errs = appendValidation(errs,

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -4769,6 +4769,32 @@ func TestValidateServiceEntries(t *testing.T) {
 			},
 			valid: false,
 		},
+		{
+			name: "protocol unset for addresses empty", in: &networking.ServiceEntry{
+				Hosts:     []string{"google.com"},
+				Addresses: []string{},
+				Ports: []*networking.Port{
+					{Number: 80, Protocol: "http", Name: "http-valid1"},
+					{Number: 8080, Name: "http-valid2"},
+				},
+				Resolution: networking.ServiceEntry_NONE,
+			},
+			valid:   true,
+			warning: true,
+		},
+		{
+			name: "protocol is TCP for addresses empty", in: &networking.ServiceEntry{
+				Hosts:     []string{"google.com"},
+				Addresses: []string{},
+				Ports: []*networking.Port{
+					{Number: 80, Protocol: "http", Name: "http-valid1"},
+					{Number: 81, Protocol: "TCP", Name: "tcp-valid1"},
+				},
+				Resolution: networking.ServiceEntry_NONE,
+			},
+			valid:   true,
+			warning: true,
+		},
 	}
 
 	for _, c := range cases {

--- a/releasenotes/notes/27990.yaml
+++ b/releasenotes/notes/27990.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 27990
+releaseNotes:
+  - |
+    **Added** add a validation warning when protocol is unset and address is also unset.


### PR DESCRIPTION
Signed-off-by: LexusLee <lexuscyborg103@gmail.com>

**Please provide a description of this PR:**
Considering empty protocol might remove PassthroughCluster routing, add protocol validation when address is unset in ServiceEntry

![image](https://user-images.githubusercontent.com/10649416/174220900-9f029a98-bd36-4ea0-b30e-ff659db6d524.png)

Issue related: 
- https://github.com/istio/istio/issues/27990

we already have an analyzer for this case, I think we should also add a validation.

[x] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure

Pull Request Attributes
Please check any characteristics that apply to this pull request.
[x] Does not have any changes that may affect Istio users.