### PR TITLE
add more debug logging to wasm image fetcher

### DIFF
--- a/pkg/wasm/cache.go
+++ b/pkg/wasm/cache.go
@@ -219,7 +219,7 @@ func (c *LocalFileCache) Get(
 
 	u, err := url.Parse(downloadURL)
 	if err != nil {
-		return "", fmt.Errorf("fail to parse Wasm module fetch url: %s", downloadURL)
+		return "", fmt.Errorf("fail to parse Wasm module fetch url: %s, error: %v", downloadURL, err)
 	}
 
 	// First check if the cache entry is already downloaded and policy does not require to pull always.
@@ -229,13 +229,9 @@ func (c *LocalFileCache) Get(
 		c.touchEntry(key)
 		return modulePath, nil
 	}
-
-	// If not, fetch images.
-
-	// Byte array of Wasm binary.
-	var b []byte
-	// Hex-Encoded sha256 checksum of binary.
-	var dChecksum string
+	// Fetch the image now as it is not available in cache.
+	var b []byte         // Byte array of Wasm binary.
+	var dChecksum string // Hex-Encoded sha256 checksum of binary.
 	var binaryFetcher func() ([]byte, error)
 	insecure := c.allowInsecure(u.Host)
 
@@ -254,19 +250,18 @@ func (c *LocalFileCache) Get(
 		sha := sha256.Sum256(b)
 		dChecksum = hex.EncodeToString(sha[:])
 	case "oci":
-		// TODO: support imagePullSecret and pass it to ImageFetcherOption.
 		imgFetcherOps := ImageFetcherOption{
 			Insecure: insecure,
 		}
 		if pullSecret != nil {
 			imgFetcherOps.PullSecret = pullSecret
 		}
-		wasmLog.Debugf("wasm oci fetch %s with options: %v", downloadURL, imgFetcherOps)
+		wasmLog.Debugf("fetching oci image from %s with options: %v", downloadURL, imgFetcherOps)
 		fetcher := NewImageFetcher(ctx, imgFetcherOps)
 		binaryFetcher, dChecksum, err = fetcher.PrepareFetch(u.Host + u.Path)
 		if err != nil {
-			wasmRemoteFetchCount.With(resultTag.Value(downloadFailure)).Increment()
-			return "", fmt.Errorf("could not fetch Wasm OCI image: %v", err)
+			wasmRemoteFetchCount.With(resultTag.Value(manifestFailure)).Increment()
+			return "", fmt.Errorf("could not fetch oci image: %v", err)
 		}
 	default:
 		return "", fmt.Errorf("unsupported Wasm module downloading URL scheme: %v", u.Scheme)

--- a/pkg/wasm/cache.go
+++ b/pkg/wasm/cache.go
@@ -261,7 +261,7 @@ func (c *LocalFileCache) Get(
 		binaryFetcher, dChecksum, err = fetcher.PrepareFetch(u.Host + u.Path)
 		if err != nil {
 			wasmRemoteFetchCount.With(resultTag.Value(manifestFailure)).Increment()
-			return "", fmt.Errorf("could not fetch oci image: %v", err)
+			return "", fmt.Errorf("could not fetch Wasm OCI image: %v", err)
 		}
 	default:
 		return "", fmt.Errorf("unsupported Wasm module downloading URL scheme: %v", u.Scheme)

--- a/pkg/wasm/convert.go
+++ b/pkg/wasm/convert.go
@@ -160,7 +160,9 @@ func convert(resource *any.Any, cache Cache) (newExtensionConfig *any.Any, sendN
 	if remote.Sha256 == "nil" {
 		remote.Sha256 = ""
 	}
-	timeout := time.Duration(0)
+	// Default timeout. Without this if user does not specify a timeout in the config, it fails with deadline exceeded
+	// while building transport in go container.
+	timeout := time.Second * 5
 	if remote.GetHttpUri().Timeout != nil {
 		timeout = remote.GetHttpUri().Timeout.AsDuration()
 	}

--- a/pkg/wasm/imagefetcher.go
+++ b/pkg/wasm/imagefetcher.go
@@ -93,12 +93,14 @@ func (o *ImageFetcher) PrepareFetch(url string) (binaryFetcher func() ([]byte, e
 		err = fmt.Errorf("could not parse url in image reference: %v", err)
 		return
 	}
+	wasmLog.Infof("fetching image %s from registry %s with tag %s", ref.Context().RepositoryStr(),
+		ref.Context().RegistryStr(), ref.Identifier())
 
 	// fallback to http based request, inspired by [helm](https://github.com/helm/helm/blob/12f1bc0acdeb675a8c50a78462ed3917fb7b2e37/pkg/registry/client.go#L594)
 	// only deal with https fallback instead of attributing all other type of errors to URL parsing error
 	desc, err := remote.Get(ref, o.fetchOpts...)
 	if err != nil && strings.Contains(err.Error(), "server gave HTTP response") {
-		wasmLog.Infof("fetch with plain text from %s", url)
+		wasmLog.Infof("fetching image with plain text from %s", url)
 		ref, err = name.ParseReference(url, name.Insecure)
 		if err == nil {
 			desc, err = remote.Get(ref, o.fetchOpts...)

--- a/pkg/wasm/monitoring.go
+++ b/pkg/wasm/monitoring.go
@@ -21,6 +21,7 @@ const (
 	// For remote fetch metric.
 	fetchSuccess     = "success"
 	downloadFailure  = "download_failure"
+	manifestFailure  = "mainfest_failure"
 	checksumMismatch = "checksum_mismatched"
 
 	// For Wasm conversion metric.

--- a/pkg/wasm/monitoring.go
+++ b/pkg/wasm/monitoring.go
@@ -21,7 +21,7 @@ const (
 	// For remote fetch metric.
 	fetchSuccess     = "success"
 	downloadFailure  = "download_failure"
-	manifestFailure  = "mainfest_failure"
+	manifestFailure  = "manifest_failure"
 	checksumMismatch = "checksum_mismatched"
 
 	// For Wasm conversion metric.


### PR DESCRIPTION
- Adds more debug logging
- Adds default timeout of 5s - without this if user does not specify timeout, getting context deadline exceeded

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure