### PR TITLE
[Dual Stack] Make istio-proxy's sub-server and prober can be uniform and compatible both for IPv4 and IPv6

### DIFF
--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -47,7 +47,7 @@ import (
 
 const (
 	localHostIPv4 = "127.0.0.1"
-	localHostIPv6 = "[::1]"
+	localHostIPv6 = "::1"
 )
 
 // TODO: Move most of this to pkg options.

--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -71,7 +71,7 @@ const (
 	KubeAppProberEnvName = "ISTIO_KUBE_APP_PROBERS"
 
 	localHostIPv4 = "127.0.0.1"
-	localHostIPv6 = "[::1]"
+	localHostIPv6 = "::1"
 )
 
 var (
@@ -183,7 +183,7 @@ func NewServer(config Options) (*Server, error) {
 	s := &Server{
 		statusPort:            config.StatusPort,
 		ready:                 probes,
-		appProbersDestination: wrapIPv6(config.PodIP),
+		appProbersDestination: config.PodIP,
 		envoyStatsPort:        config.EnvoyPrometheusPort,
 		fetchDNS:              config.FetchDNS,
 		upstreamLocalAddress:  upstreamLocalAddress,
@@ -650,10 +650,12 @@ func (s *Server) handleAppProbeHTTPGet(w http.ResponseWriter, req *http.Request,
 		proberPath = "/" + proberPath
 	}
 	var url string
+
+	hostPort := net.JoinHostPort(s.appProbersDestination, strconv.Itoa(prober.HTTPGet.Port.IntValue()))
 	if prober.HTTPGet.Scheme == apimirror.URISchemeHTTPS {
-		url = fmt.Sprintf("https://%s:%v%s", s.appProbersDestination, prober.HTTPGet.Port.IntValue(), proberPath)
+		url = fmt.Sprintf("https://%s%s", hostPort, proberPath)
 	} else {
-		url = fmt.Sprintf("http://%s:%v%s", s.appProbersDestination, prober.HTTPGet.Port.IntValue(), proberPath)
+		url = fmt.Sprintf("http://%s%s", hostPort, proberPath)
 	}
 	appReq, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
@@ -712,7 +714,6 @@ func (s *Server) handleAppProbeHTTPGet(w http.ResponseWriter, req *http.Request,
 }
 
 func (s *Server) handleAppProbeTCPSocket(w http.ResponseWriter, prober *Prober) {
-	port := prober.TCPSocket.Port.IntValue()
 	timeout := time.Duration(prober.TimeoutSeconds) * time.Second
 
 	d := &net.Dialer{
@@ -720,7 +721,7 @@ func (s *Server) handleAppProbeTCPSocket(w http.ResponseWriter, prober *Prober) 
 		Timeout:   timeout,
 	}
 
-	conn, err := d.Dial("tcp", fmt.Sprintf("%s:%d", s.appProbersDestination, port))
+	conn, err := d.Dial("tcp", net.JoinHostPort(s.appProbersDestination, strconv.Itoa(prober.TCPSocket.Port.IntValue())))
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 	} else {
@@ -754,7 +755,7 @@ func (s *Server) handleAppProbeGRPC(w http.ResponseWriter, req *http.Request, pr
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	addr := fmt.Sprintf("%s:%d", s.appProbersDestination, prober.GRPC.Port)
+	addr := net.JoinHostPort(s.appProbersDestination, strconv.Itoa(int(prober.GRPC.Port)))
 	conn, err := grpc.DialContext(ctx, addr, opts...)
 	if err != nil {
 		log.Errorf("Failed to create grpc connection to probe app: %v", err)
@@ -836,16 +837,4 @@ func notifyExit() {
 	if err := p.Signal(syscall.SIGTERM); err != nil {
 		log.Errorf("failed to send SIGTERM to self: %v", err)
 	}
-}
-
-// wrapIPv6 wraps the ip into "[]" in case of ipv6
-func wrapIPv6(ipAddr string) string {
-	addr := net.ParseIP(ipAddr)
-	if addr == nil {
-		return ipAddr
-	}
-	if addr.To4() != nil {
-		return ipAddr
-	}
-	return fmt.Sprintf("[%s]", ipAddr)
 }

--- a/pilot/cmd/pilot-agent/status/server_test.go
+++ b/pilot/cmd/pilot-agent/status/server_test.go
@@ -663,14 +663,6 @@ func TestAppProbe(t *testing.T) {
 			ipv6:       true,
 		},
 		{
-			name:       "tcp-livez-wrapped-ipv6",
-			probePath:  "app-health/hello-world/livez",
-			config:     simpleTCPConfig,
-			statusCode: http.StatusOK,
-			podIP:      "[::1]",
-			ipv6:       true,
-		},
-		{
 			name:       "tcp-livez-localhost",
 			probePath:  "app-health/hello-world/livez",
 			config:     simpleTCPConfig,
@@ -737,6 +729,8 @@ func TestAppProbe(t *testing.T) {
 		defer cancel()
 		go server.Run(ctx)
 
+		// make sure the upstreamLocalAddress would not be nil
+		server.upstreamLocalAddress = &net.TCPAddr{IP: net.ParseIP("127.0.0.1")}
 		if tc.ipv6 {
 			server.upstreamLocalAddress = &net.TCPAddr{IP: net.ParseIP("::1")} // required because ::6 is NOT a loopback address (IPv6 only has ::1)
 		}

--- a/pilot/cmd/pilot-agent/status/server_test.go
+++ b/pilot/cmd/pilot-agent/status/server_test.go
@@ -663,6 +663,14 @@ func TestAppProbe(t *testing.T) {
 			ipv6:       true,
 		},
 		{
+			name:       "tcp-livez-wrapped-ipv6",
+			probePath:  "app-health/hello-world/livez",
+			config:     simpleTCPConfig,
+			statusCode: http.StatusInternalServerError,
+			podIP:      "[::1]",
+			ipv6:       true,
+		},
+		{
 			name:       "tcp-livez-localhost",
 			probePath:  "app-health/hello-world/livez",
 			config:     simpleTCPConfig,
@@ -729,8 +737,6 @@ func TestAppProbe(t *testing.T) {
 		defer cancel()
 		go server.Run(ctx)
 
-		// make sure the upstreamLocalAddress would not be nil
-		server.upstreamLocalAddress = &net.TCPAddr{IP: net.ParseIP("127.0.0.1")}
 		if tc.ipv6 {
 			server.upstreamLocalAddress = &net.TCPAddr{IP: net.ParseIP("::1")} // required because ::6 is NOT a loopback address (IPv6 only has ::1)
 		}

--- a/pilot/cmd/pilot-agent/status/util/stats.go
+++ b/pilot/cmd/pilot-agent/status/util/stats.go
@@ -17,6 +17,7 @@ package util
 import (
 	"bytes"
 	"fmt"
+	"net"
 	"strconv"
 	"strings"
 	"time"
@@ -73,7 +74,8 @@ func GetReadinessStats(localHostAddr string, adminPort uint16) (*uint64, bool, e
 		localHostAddr = "localhost"
 	}
 
-	readinessURL := fmt.Sprintf("http://%s:%d/stats?usedonly&filter=%s", localHostAddr, adminPort, readyStatsRegex)
+	hostPort := net.JoinHostPort(localHostAddr, strconv.Itoa(int(adminPort)))
+	readinessURL := fmt.Sprintf("http://%s/stats?usedonly&filter=%s", hostPort, readyStatsRegex)
 	stats, err := http.DoHTTPGetWithTimeout(readinessURL, readinessTimeout)
 	if err != nil {
 		return nil, false, err
@@ -105,7 +107,8 @@ func GetUpdateStatusStats(localHostAddr string, adminPort uint16) (*Stats, error
 		localHostAddr = "localhost"
 	}
 
-	stats, err := http.DoHTTPGet(fmt.Sprintf("http://%s:%d/stats?usedonly&filter=%s", localHostAddr, adminPort, updateStatsRegex))
+	hostPort := net.JoinHostPort(localHostAddr, strconv.Itoa(int(adminPort)))
+	stats, err := http.DoHTTPGet(fmt.Sprintf("http://%s/stats?usedonly&filter=%s", hostPort, updateStatsRegex))
 	if err != nil {
 		return nil, err
 	}

--- a/pilot/pkg/security/authn/v1beta1/policy_applier.go
+++ b/pilot/pkg/security/authn/v1beta1/policy_applier.go
@@ -16,6 +16,7 @@ package v1beta1
 
 import (
 	"fmt"
+	"net"
 	"net/url"
 	"sort"
 	"strconv"
@@ -240,13 +241,12 @@ func convertToEnvoyJwtConfig(jwtRules []*v1beta1.JWTRule, push *model.PushContex
 			// TODO: Implement the logic to auto-generate the cluster so that when the flag is enabled,
 			// it will always let envoy to fetch the jwks for consistent behavior.
 			u, _ := url.Parse(jwtRule.JwksUri)
-			hostAndPort := strings.Split(u.Host, ":")
-			host := hostAndPort[0]
+			host, hostPort, _ := net.SplitHostPort(u.Host)
 			// TODO: Default port based on scheme ?
 			port := 80
-			if len(hostAndPort) == 2 {
+			if hostPort != "" {
 				var err error
-				if port, err = strconv.Atoi(hostAndPort[1]); err != nil {
+				if port, err = strconv.Atoi(hostPort); err != nil {
 					port = 80 // If port is not specified or there is an error in parsing default to 80.
 				}
 			}

--- a/pkg/istio-agent/health/health_probers.go
+++ b/pkg/istio-agent/health/health_probers.go
@@ -151,7 +151,8 @@ var _ Prober = &TCPProber{}
 
 func (t *TCPProber) Probe(timeout time.Duration) (ProbeResult, error) {
 	// if we cant connect, count as fail
-	conn, err := net.DialTimeout("tcp", fmt.Sprintf("%s:%v", t.Config.Host, t.Config.Port), timeout)
+	hostPort := net.JoinHostPort(t.Config.Host, strconv.Itoa(int(t.Config.Port)))
+	conn, err := net.DialTimeout("tcp", hostPort, timeout)
 	if err != nil {
 		return Unhealthy, err
 	}

--- a/pkg/istio-agent/xds_proxy.go
+++ b/pkg/istio-agent/xds_proxy.go
@@ -123,7 +123,7 @@ var proxyLog = log.RegisterScope("xdsproxy", "XDS Proxy in Istio Agent", 0)
 
 const (
 	localHostIPv4 = "127.0.0.1"
-	localHostIPv6 = "[::1]"
+	localHostIPv6 = "::1"
 )
 
 func initXdsProxy(ia *Agent) (*XdsProxy, error) {

--- a/security/pkg/stsservice/server/server.go
+++ b/security/pkg/stsservice/server/server.go
@@ -22,6 +22,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httputil"
+	"strconv"
 	"time"
 
 	"istio.io/istio/pkg/security"
@@ -81,13 +82,14 @@ func NewServer(config Config, tokenManager security.TokenManager) (*Server, erro
 	mux := http.NewServeMux()
 	mux.HandleFunc(TokenPath, s.ServeStsRequests)
 	mux.HandleFunc(StsStatusPath, s.DumpStsStatus)
+	hostPort := net.JoinHostPort(config.LocalHostAddr, strconv.Itoa(config.LocalPort))
 	s.stsServer = &http.Server{
-		Addr:        fmt.Sprintf("%s:%d", config.LocalHostAddr, config.LocalPort),
+		Addr:        hostPort,
 		Handler:     mux,
 		IdleTimeout: 90 * time.Second, // matches http.DefaultTransport keep-alive timeout
 		ReadTimeout: 30 * time.Second,
 	}
-	ln, err := net.Listen("tcp", fmt.Sprintf("%s:%d", config.LocalHostAddr, config.LocalPort))
+	ln, err := net.Listen("tcp", hostPort)
 	if err != nil {
 		log.Errorf("Server failed to listen %v", err)
 		return nil, err


### PR DESCRIPTION
**Please provide a description of this PR:**
1. Make istio-proxy's sub-server can be compatible both for IPv4 and IPv6

>  status server
>  sts server
>  prober for health checking, readiness and liveness

2. Remove unnecessary wrapped IPv6 localhost

> Change wrapped IPv6 localhost from `[::1]` to `::1`,  this wrapped IPv6 localhost is specified as node.IPaddresses in some place , and then this IP address will be parsed by `net.ParseIP`, this will caused a IPv6 address can not be detected.