### PR TITLE
istioctl x envoy-stats --output prom-merged

### DIFF
--- a/istioctl/cmd/proxyconfig.go
+++ b/istioctl/cmd/proxyconfig.go
@@ -35,10 +35,11 @@ import (
 )
 
 const (
-	jsonOutput       = "json"
-	yamlOutput       = "yaml"
-	summaryOutput    = "short"
-	prometheusOutput = "prom"
+	jsonOutput             = "json"
+	yamlOutput             = "yaml"
+	summaryOutput          = "short"
+	prometheusOutput       = "prom"
+	prometheusMergedOutput = "prom-merged"
 )
 
 var (
@@ -232,14 +233,19 @@ func setupEnvoyServerStatsConfig(podName, podNamespace string, outputFormat stri
 		return "", fmt.Errorf("failed to create Kubernetes client: %v", err)
 	}
 	path := "stats"
+	port := 15000
 	if outputFormat == jsonOutput || outputFormat == yamlOutput {
 		// for yaml output we will convert the json to yaml when printed
 		path += "?format=json"
-	}
-	if outputFormat == prometheusOutput {
+	} else if outputFormat == prometheusOutput {
 		path += "/prometheus"
+	} else if outputFormat == prometheusMergedOutput {
+		path += "/prometheus"
+		port = 15020
 	}
-	result, err := kubeClient.EnvoyDo(context.Background(), podName, podNamespace, "GET", path)
+
+	result, err := kubeClient.EnvoyDoWithPort(context.Background(), podName, podNamespace, "GET", path, port)
+
 	if err != nil {
 		return "", fmt.Errorf("failed to execute command on Envoy: %v", err)
 	}
@@ -598,6 +604,9 @@ func statsConfigCmd() *cobra.Command {
 
   # Retrieve Envoy server metrics in prometheus format
   istioctl experimental envoy-stats <pod-name[.namespace]> --output prom
+
+  # Retrieve Envoy server metrics in prometheus format with merged application metrics
+  istioctl experimental envoy-stats <pod-name[.namespace]> --output prom-merged
 
   # Retrieve Envoy cluster metrics
   istioctl experimental envoy-stats <pod-name[.namespace]> --type clusters

--- a/istioctl/cmd/proxyconfig.go
+++ b/istioctl/cmd/proxyconfig.go
@@ -245,7 +245,6 @@ func setupEnvoyServerStatsConfig(podName, podNamespace string, outputFormat stri
 	}
 
 	result, err := kubeClient.EnvoyDoWithPort(context.Background(), podName, podNamespace, "GET", path, port)
-
 	if err != nil {
 		return "", fmt.Errorf("failed to execute command on Envoy: %v", err)
 	}

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -155,6 +155,9 @@ type ExtendedClient interface {
 	// EnvoyDo makes an http request to the Envoy in the specified pod.
 	EnvoyDo(ctx context.Context, podName, podNamespace, method, path string) ([]byte, error)
 
+	// EnvoyDoWithPort makes an http request to the Envoy in the specified pod and port.
+	EnvoyDoWithPort(ctx context.Context, podName, podNamespace, method, path string, port int) ([]byte, error)
+
 	// AllDiscoveryDo makes an http request to each Istio discovery instance.
 	AllDiscoveryDo(ctx context.Context, namespace, path string) (map[string][]byte, error)
 
@@ -742,6 +745,10 @@ func (c *client) AllDiscoveryDo(ctx context.Context, istiodNamespace, path strin
 
 func (c *client) EnvoyDo(ctx context.Context, podName, podNamespace, method, path string) ([]byte, error) {
 	return c.portForwardRequest(ctx, podName, podNamespace, method, path, 15000)
+}
+
+func (c *client) EnvoyDoWithPort(ctx context.Context, podName, podNamespace, method, path string, port int) ([]byte, error) {
+	return c.portForwardRequest(ctx, podName, podNamespace, method, path, port)
 }
 
 func (c *client) portForwardRequest(ctx context.Context, podName, podNamespace, method, path string, port int) ([]byte, error) {

--- a/pkg/kube/mock_client.go
+++ b/pkg/kube/mock_client.go
@@ -151,6 +151,14 @@ func (c MockClient) EnvoyDo(ctx context.Context, podName, podNamespace, method, 
 	return results, nil
 }
 
+func (c MockClient) EnvoyDoWithPort(ctx context.Context, podName, podNamespace, method, path string, port int) ([]byte, error) {
+	results, ok := c.Results[podName]
+	if !ok {
+		return nil, fmt.Errorf("unable to retrieve Pod: pods %q not found", podName)
+	}
+	return results, nil
+}
+
 func (c MockClient) RESTConfig() *rest.Config {
 	return c.ConfigValue
 }

--- a/releasenotes/notes/istioctl-proxy-config-stats-prom-merged.yaml
+++ b/releasenotes/notes/istioctl-proxy-config-stats-prom-merged.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: feature
+area: istioctl
+
+releaseNotes:
+- |
+  **Added** stats command `istioctl experimental envoy-stats` for retrieving istio-proxy envoy metrics.

--- a/releasenotes/notes/istioctl-proxy-config-stats-prom-merged.yaml
+++ b/releasenotes/notes/istioctl-proxy-config-stats-prom-merged.yaml
@@ -4,4 +4,4 @@ area: istioctl
 
 releaseNotes:
 - |
-  **Added** stats command `istioctl experimental envoy-stats` for retrieving istio-proxy envoy metrics.
+  **Added** `istioctl experimental envoy-stats -o prom-merged` for retrieving istio-proxy merged metrics from prometheus.

--- a/releasenotes/notes/istioctl-proxy-config-stats-prom-merged.yaml
+++ b/releasenotes/notes/istioctl-proxy-config-stats-prom-merged.yaml
@@ -1,7 +1,8 @@
 apiVersion: release-notes/v2
 kind: feature
 area: istioctl
-
+issue:
+  - 39454
 releaseNotes:
 - |
   **Added** `istioctl experimental envoy-stats -o prom-merged` for retrieving istio-proxy merged metrics from prometheus.


### PR DESCRIPTION
**Please provide a description of this PR:**

Adds support for pulling Prometheus merged metrics via `istioctl x envoy-stats --output prom-merged <pod_name>.<namespace>`

https://github.com/istio/istio/issues/39454


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [X] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
