### PR TITLE
Fix failing tunneling tests on IPv6 stack

### DIFF
--- a/tests/integration/pilot/forwardproxy/envoy_config_generator.go
+++ b/tests/integration/pilot/forwardproxy/envoy_config_generator.go
@@ -81,7 +81,7 @@ func GenerateForwardProxyBootstrapConfig(listeners []ListenerSettings) (string, 
 		hcm := createHTTPConnectionManager(listenerSettings.HTTPVersion)
 		bootstrap.StaticResources.Listeners = append(bootstrap.StaticResources.Listeners, &envoy_listener.Listener{
 			Name:    fmt.Sprintf("http_forward_proxy_%d", listenerSettings.Port),
-			Address: createSocketAddress("0.0.0.0", listenerSettings.Port),
+			Address: createSocketAddress("::", listenerSettings.Port),
 			FilterChains: []*envoy_listener.FilterChain{
 				{
 					Filters: []*envoy_listener.Filter{
@@ -216,6 +216,7 @@ func createSocketAddress(addr string, port uint32) *envoy_core.Address {
 				PortSpecifier: &envoy_core.SocketAddress_PortValue{
 					PortValue: port,
 				},
+				Ipv4Compat: true,
 			},
 		},
 	}

--- a/tests/integration/pilot/testdata/tunneling/destination-rule.tmpl.yaml
+++ b/tests/integration/pilot/testdata/tunneling/destination-rule.tmpl.yaml
@@ -9,13 +9,13 @@ spec:
     trafficPolicy:
       tunnel:
         protocol: CONNECT
-        targetHost: external.{{ .externalNamespace }}.svc.cluster.local
+        targetHost: external.{{ .externalNamespace }}
         targetPort: {{ .externalSvcTcpPort }}
   - name: external-svc-tls
     trafficPolicy:
       tunnel:
         protocol: CONNECT
-        targetHost: external.{{ .externalNamespace }}.svc.cluster.local
+        targetHost: external.{{ .externalNamespace }}
         targetPort: {{ .externalSvcTlsPort }}
 ---
 {{ if .tlsEnabled }}

--- a/tests/integration/pilot/tunneling_test.go
+++ b/tests/integration/pilot/tunneling_test.go
@@ -167,7 +167,7 @@ func TestTunnelingOutboundTraffic(t *testing.T) {
 
 func testConnectivity(from, to echo.Instance, p protocol.Instance, portName, testName string) error {
 	res, err := from.Call(echo.CallOptions{
-		Address: apps.External.All[0].ClusterLocalFQDN(),
+		Address: to.ClusterLocalFQDN(),
 		Port: echo.Port{
 			Protocol:    p,
 			ServicePort: to.PortForName(portName).ServicePort,


### PR DESCRIPTION
Signed-off-by: Jacek Ewertowski <jewertow@redhat.com>

This change aims to fix failing [integ-ipv6_istio_postsubmit](https://prow.istio.io/view/gs/istio-prow/logs/integ-ipv6_istio_postsubmit/1537798303050108928). My previous PR was not enough to fix broken tests, but I dived deeper and tested it locally, and now I'm sure that this change will fix failing tests.

There were 2 reasons why tunneling was failing on dual stack:
1. Envoy should listen on `::` when dual-stack is enabled.
2. DNS lookup works differently for IPv4 and IPv6 - I am not sure why, but I captured DNS queries with wireshark and I observed that for IPv6 address the DNS resolver sends queries for all search domains, but not for the received FQDN as is. On the other hand, when IPv4 is used, the DNS resolver query for all search domains and then it sends query for received FQDN as is. The screenshots below illustrate the difference:
![ipv4-dns-lookup](https://user-images.githubusercontent.com/17457695/174437233-14184dce-da20-47d8-b1de-818ef4950362.png)
![ipv6-dns-lookup](https://user-images.githubusercontent.com/17457695/174437235-c9a2f85f-c01a-474d-a7f9-7384d7ad8c7c.png)
To fix it, I used `<service-name>.<namespace>` instead of FQDN as the target host in the CONNECT specification.