### PR TITLE
feat(crdclient): crdclient take tombstone into consideration

### DIFF
--- a/pilot/pkg/bootstrap/certcontroller.go
+++ b/pilot/pkg/bootstrap/certcontroller.go
@@ -54,7 +54,7 @@ func (s *Server) initCertController(args *PilotArgs) error {
 	var secretNames, dnsNames []string
 
 	meshConfig := s.environment.Mesh()
-	if meshConfig.GetCertificates() == nil || len(meshConfig.GetCertificates()) == 0 {
+	if len(meshConfig.GetCertificates()) == 0 {
 		// TODO: if the provider is set to Citadel, use that instead of k8s so the API is still preserved.
 		log.Info("No certificates specified, skipping K8S DNS certificate controller")
 		return nil

--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -74,9 +74,9 @@ func (s *Server) initConfigController(args *PilotArgs) error {
 		}
 		s.ConfigStores = append(s.ConfigStores, configController)
 	} else {
-		err2 := s.initK8SConfigStore(args)
-		if err2 != nil {
-			return err2
+		err := s.initK8SConfigStore(args)
+		if err != nil {
+			return err
 		}
 	}
 


### PR DESCRIPTION
Thanks to istio and related work. It helped us a lot.
I found some points that maybe could be optimized while reading the code,
and sorry for not being able to provide case to verify.

**Please provide a description of this PR:**
- With crdclient, we should take tombstone into consideration?
- When init kube config controller, why use err2? I don't find reason for releated pr.