### PR TITLE
Print usage information for help

### DIFF
--- a/samples/bookinfo/build_push_update_images.sh
+++ b/samples/bookinfo/build_push_update_images.sh
@@ -26,6 +26,11 @@ display_usage() {
     exit 1
 }
 
+# Print usage information for help
+if [[ "$1" == "-h" || "$1" == "--help" ]]; then
+        display_usage
+fi
+
 # Check if there is atleast one input argument
 if [[ -z "$1" ]] ; then
 	echo "Missing version parameter"


### PR DESCRIPTION
Signed-off-by: xin.li <xin.li@daocloud.io>

**Please provide a description of this PR:**

This script seems to be missing instructions for "--help" and "-h"
```shell
# ./build_push_update_images.sh -h

~/istio/samples/bookinfo/src/productpage ~/istio/samples/bookinfo
invalid argument "istio/examples-bookinfo-productpage-v1:-h" for "-t, --tag" flag: invalid reference format
See 'docker build --help'.
```

Below is the modified test result:
```shell
$ ./build_push_update_images.sh -h

USAGE: ./build_push_update_images.sh <version> [-h|--help] [--prefix=value] [--scan-images]
        version : Version of the sample app images (Required)
        -h|--help : Prints usage information
        --prefix: Use the value as the prefix for image names. By default, 'istio' is used
        --scan-images : Enable security vulnerability scans for docker images 
                        related to bookinfo sample apps. By default, this feature 
                        is disabled.

$ ./build_push_update_images.sh --help

USAGE: ./build_push_update_images.sh <version> [-h|--help] [--prefix=value] [--scan-images]
        version : Version of the sample app images (Required)
        -h|--help : Prints usage information
        --prefix: Use the value as the prefix for image names. By default, 'istio' is used
        --scan-images : Enable security vulnerability scans for docker images 
                        related to bookinfo sample apps. By default, this feature 
                        is disabled.

$ ./build_push_update_images.sh test

~/istio/samples/bookinfo/src/productpage ~/istio/samples/bookinfo
Sending build context to Docker daemon  1.218MB
Step 1/17 : FROM python:3.7.7-slim
.......
```