### PR TITLE
Fix x injector ns pod info not accurate when use default

### DIFF
--- a/istioctl/cmd/injector-list.go
+++ b/istioctl/cmd/injector-list.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"sort"
@@ -36,6 +37,7 @@ import (
 	analyzer_util "istio.io/istio/pkg/config/analysis/analyzers/util"
 	"istio.io/istio/pkg/config/resource"
 	"istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/kube/inject"
 )
 
 type revisionCount struct {
@@ -284,17 +286,10 @@ func getInjectedImages(ctx context.Context, client kube.ExtendedClient) (map[str
 func podCountByRevision(pods []v1.Pod, expectedRevision string) map[string]revisionCount {
 	retval := map[string]revisionCount{}
 	for _, pod := range pods {
-		revision := pod.ObjectMeta.GetLabels()[label.IoIstioRev.Name]
+		revision := extractRevisionFromPod(&pod)
 		revisionLabel := revision
-		// if expectedRevision is "default", which is the injector revision default value,
-		// we should recognize it instead of treating it unrecognized.
 		if revision == "" {
-			if expectedRevision == "default" {
-				revisionLabel = expectedRevision
-				revision = expectedRevision
-			} else {
-				revisionLabel = "<non-Istio>"
-			}
+			revisionLabel = "<non-Istio>"
 		}
 		counts := retval[revisionLabel]
 		counts.pods++
@@ -306,6 +301,22 @@ func podCountByRevision(pods []v1.Pod, expectedRevision string) map[string]revis
 		retval[revisionLabel] = counts
 	}
 	return retval
+}
+
+func extractRevisionFromPod(pod *v1.Pod) string {
+	rev := pod.GetLabels()[label.IoIstioRev.Name]
+	if rev != "" {
+		return rev
+	}
+	statusAnno, ok := pod.GetAnnotations()[annotation.SidecarStatus.Name]
+	if !ok {
+		return ""
+	}
+	var sidecarinjection inject.SidecarInjectionStatus
+	if err := json.Unmarshal([]byte(statusAnno), &sidecarinjection); err != nil {
+		return ""
+	}
+	return sidecarinjection.Revision
 }
 
 func hideFromOutput(ns resource.Namespace) bool {

--- a/istioctl/cmd/injector-list.go
+++ b/istioctl/cmd/injector-list.go
@@ -286,8 +286,15 @@ func podCountByRevision(pods []v1.Pod, expectedRevision string) map[string]revis
 	for _, pod := range pods {
 		revision := pod.ObjectMeta.GetLabels()[label.IoIstioRev.Name]
 		revisionLabel := revision
+		// if expectedRevision is "default", which is the injector revision default value,
+		// we should recognize it instead of treating it unrecognized.
 		if revision == "" {
-			revisionLabel = "<non-Istio>"
+			if expectedRevision == "default" {
+				revisionLabel = expectedRevision
+				revision = expectedRevision
+			} else {
+				revisionLabel = "<non-Istio>"
+			}
 		}
 		counts := retval[revisionLabel]
 		counts.pods++

--- a/istioctl/cmd/injector-list.go
+++ b/istioctl/cmd/injector-list.go
@@ -304,10 +304,6 @@ func podCountByRevision(pods []v1.Pod, expectedRevision string) map[string]revis
 }
 
 func extractRevisionFromPod(pod *v1.Pod) string {
-	rev := pod.GetLabels()[label.IoIstioRev.Name]
-	if rev != "" {
-		return rev
-	}
 	statusAnno, ok := pod.GetAnnotations()[annotation.SidecarStatus.Name]
 	if !ok {
 		return ""

--- a/istioctl/cmd/injector-list_test.go
+++ b/istioctl/cmd/injector-list_test.go
@@ -33,17 +33,6 @@ func Test_extractRevisionFromPod(t *testing.T) {
 		expectedRevision string
 	}{
 		{
-			name: "has rev label",
-			pod: &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						label.IoIstioRev.Name: "test",
-					},
-				},
-			},
-			expectedRevision: "test",
-		},
-		{
 			name:             "no rev",
 			pod:              &corev1.Pod{},
 			expectedRevision: "",
@@ -64,14 +53,14 @@ func Test_extractRevisionFromPod(t *testing.T) {
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						label.IoIstioRev.Name: "test-label",
+						label.IoIstioRev.Name: "test-label", // don't care about the label
 					},
 					Annotations: map[string]string{
 						annotation.SidecarStatus.Name: `{"revision":"test-anno"}`,
 					},
 				},
 			},
-			expectedRevision: "test-label",
+			expectedRevision: "test-anno",
 		},
 	}
 	for i, c := range cases {

--- a/istioctl/cmd/injector-list_test.go
+++ b/istioctl/cmd/injector-list_test.go
@@ -1,0 +1,82 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"istio.io/api/annotation"
+	"istio.io/api/label"
+	"istio.io/istio/pkg/test/util/assert"
+)
+
+func Test_extractRevisionFromPod(t *testing.T) {
+	cases := []struct {
+		name             string
+		pod              *corev1.Pod
+		expectedRevision string
+	}{
+		{
+			name: "has rev label",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						label.IoIstioRev.Name: "test",
+					},
+				},
+			},
+			expectedRevision: "test",
+		},
+		{
+			name:             "no rev",
+			pod:              &corev1.Pod{},
+			expectedRevision: "",
+		},
+		{
+			name: "has rev annotation",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						annotation.SidecarStatus.Name: `{"revision": "test-anno"}`,
+					},
+				},
+			},
+			expectedRevision: "test-anno",
+		},
+		{
+			name: "has both rev label and annotation, use label",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						label.IoIstioRev.Name: "test-label",
+					},
+					Annotations: map[string]string{
+						annotation.SidecarStatus.Name: `{"revision":"test-anno"}`,
+					},
+				},
+			},
+			expectedRevision: "test-label",
+		},
+	}
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("case %d %s", i, c.name), func(t *testing.T) {
+			assert.Equal(t, c.expectedRevision, extractRevisionFromPod(c.pod))
+		})
+	}
+}

--- a/releasenotes/notes/39525.yaml
+++ b/releasenotes/notes/39525.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: istioctl
+releaseNotes:
+  - |
+    **Fixed** `x injector list` provides wrong pods info when revision is not set.

--- a/releasenotes/notes/39525.yaml
+++ b/releasenotes/notes/39525.yaml
@@ -3,4 +3,4 @@ kind: bug-fix
 area: istioctl
 releaseNotes:
   - |
-    **Fixed** `x injector list` provides wrong pods info when revision is not set.
+    **Fixed** `x injector list` provides wrong pods information.


### PR DESCRIPTION
**Please provide a description of this PR:**
The pod revision was compared wrong, which lead to inaccurate info. Actually those pods are injected and the control plane is the default:
```
istioctl x injector list
NAMESPACE                     ISTIO-REVISION POD-REVISIONS
default                       default        <non-Istio>: 8 NEEDS RESTART: 8
istio-io-tcp-traffic-shifting default        <non-Istio>: 3 NEEDS RESTART: 3
istio-operator                default        <no pods>
sample-namespace              MISSING/1-14-0 <no pods>
test                          default        <non-Istio>: 3 NEEDS RESTART: 3
```
After the revision it will be like:
```
istioctl x injector list
NAMESPACE                     ISTIO-REVISION POD-REVISIONS
default                       default        default: 8
istio-io-tcp-traffic-shifting default        default: 3
istio-operator                default        <no pods>
sample-namespace              MISSING/1-14-0 <no pods>
test                          default        default: 3
```