### PR TITLE
remove ratings build warning

### DIFF
--- a/samples/bookinfo/src/ratings/package.json
+++ b/samples/bookinfo/src/ratings/package.json
@@ -6,5 +6,6 @@
     "httpdispatcher": "1.0.0",
     "mongodb": "^3.6.0",
     "mysql": "^2.15.0"
-  }
+  },
+  "private": true
 }


### PR DESCRIPTION
Signed-off-by: xin.li <xin.li@daocloud.io>

**Please provide a description of this PR:**
There is a warning, when build the bookinfo/rating image. This PR for remove the warning:
<img width="773" alt="image" src="https://user-images.githubusercontent.com/76980726/174694673-2b276a3d-af65-4bcf-a1d5-dd1e4055a65c.png">