### PR TITLE
[tf] Fix max file descriptors for VM

### DIFF
--- a/pilot/cmd/pilot-agent/app/cmd.go
+++ b/pilot/cmd/pilot-agent/app/cmd.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"os/exec"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
@@ -101,6 +103,8 @@ func newProxyCommand() *cobra.Command {
 		RunE: func(c *cobra.Command, args []string) error {
 			cmd.PrintFlags(c.Flags())
 			log.Infof("Version %s", version.Info.String())
+
+			logLimits()
 
 			proxy, err := initProxy(args)
 			if err != nil {
@@ -300,4 +304,14 @@ func initProxy(args []string) (*model.Proxy, error) {
 	log.WithLabels("ips", proxy.IPAddresses, "type", proxy.Type, "id", proxy.ID, "domain", proxy.DNSDomain).Info("Proxy role")
 
 	return proxy, nil
+}
+
+func logLimits() {
+	out, err := exec.Command("bash", "-c", "ulimit -n").Output()
+	outStr := strings.TrimSpace(string(out))
+	if err != nil {
+		log.Warnf("failed running ulimit command: %v", outStr)
+	} else {
+		log.Infof("Maximum file descriptors (ulimit -n): %v", outStr)
+	}
 }


### PR DESCRIPTION
The test VM pods have occasionally been crashing under heavy load. The envoy logs show that the crash is due to exhaustion of file descriptors.

Comments and code in `istio-start.sh` points to the problem. When you run sudo, the forked process ends up with a very small (1024) ulimit for file descriptors.

The TF startup logic for the VM (in `deployment.go`) introduces a second level of sudo that does not take ulimit into consideration, so the work-around inside `istio-start.sh` does not help.

This PR changes the call site of `istio-start.sh` to use the same `ulimit` workaround. It also adds logging within the echo application to indicate both the maximum number of file descriptors as well as current usage.

**Please provide a description of this PR:**