### PR TITLE
Add description to admin log, and reformat the display

### DIFF
--- a/istioctl/cmd/istiodconfig_test.go
+++ b/istioctl/cmd/istiodconfig_test.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -26,7 +27,9 @@ import (
 
 func TestCtlPlaneConfig(t *testing.T) {
 	istiodConfigMap := map[string][]byte{
-		"istiod-7b69ff6f8c-fvjvw": []byte("Active scopes:\n  ads:info"),
+		"istiod-7b69ff6f8c-fvjvw": []byte(`ACTIVE SCOPE                  DESCRIPTION                                  LOG LEVEL
+ads                    ads debugging                                info
+`),
 	}
 
 	cases := []execTestCase{
@@ -252,7 +255,6 @@ func Test_flagState_run(t *testing.T) {
 		{
 			name:    "resetState.run() should throw an error if the /scopej endpoint is missing",
 			state:   &resetState{client: ctrzClientNoScopejHandler},
-			want:    "",
 			wantErr: true,
 		},
 		{
@@ -261,7 +263,6 @@ func Test_flagState_run(t *testing.T) {
 				client:         ctrzClientNoScopejHandler,
 				outputLogLevel: "test:debug",
 			},
-			want:    "",
 			wantErr: true,
 		},
 		{
@@ -270,19 +271,15 @@ func Test_flagState_run(t *testing.T) {
 				client:          ctrzClientNoScopejHandler,
 				stackTraceLevel: "test:debug",
 			},
-			want:    "",
 			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := tt.state.run()
+			err := tt.state.run(os.Stdout)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("run() error = %v, wantErr %v", err, tt.wantErr)
 				return
-			}
-			if got != tt.want {
-				t.Errorf("run() got = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/releasenotes/notes/desc-to-admin-log-scope.yaml
+++ b/releasenotes/notes/desc-to-admin-log-scope.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: istioctl
+releaseNotes:
+  - |
+    **Added** description to `admin log`
+  - |
+    **Improved** output format of the active logging levels.


### PR DESCRIPTION
**Please provide a description of this PR:**
To make the scopes in `admin log` better understanding like the controlZ.

From 
```
Active scopes:
  ads:info
  adsc:info
  analysis:info
```
To
```
SCOPE                  DESCRIPTION                                  LOG LEVEL
ads                    ads debugging                                info
adsc                   adsc debugging                               info
analysis               Scope for configuration analysis runtime     info
```