### PR TITLE
operator: fix 1.25 install

### DIFF
--- a/istioctl/pkg/multicluster/remote_secret.go
+++ b/istioctl/pkg/multicluster/remote_secret.go
@@ -427,8 +427,8 @@ func createServiceAccount(client kube.ExtendedClient, opt RemoteSecretOptions) e
 
 func generateServiceAccountYAML(opt RemoteSecretOptions) (string, error) {
 	// Create a renderer for the base installation.
-	baseRenderer := helm.NewHelmRenderer(opt.ManifestsPath, "base", "Base", opt.Namespace)
-	discoveryRenderer := helm.NewHelmRenderer(opt.ManifestsPath, "istio-control/istio-discovery", "Pilot", opt.Namespace)
+	baseRenderer := helm.NewHelmRenderer(opt.ManifestsPath, "base", "Base", opt.Namespace, nil)
+	discoveryRenderer := helm.NewHelmRenderer(opt.ManifestsPath, "istio-control/istio-discovery", "Pilot", opt.Namespace, nil)
 
 	baseTemplates := []string{"reader-serviceaccount.yaml"}
 	discoveryTemplates := []string{"clusterrole.yaml", "clusterrolebinding.yaml"}

--- a/istioctl/pkg/tag/generate.go
+++ b/istioctl/pkg/tag/generate.go
@@ -166,7 +166,7 @@ func Create(client kube.ExtendedClient, manifests string) error {
 
 // generateValidatingWebhook renders a validating webhook configuration from the given tagWebhookConfig.
 func generateValidatingWebhook(config *tagWebhookConfig, chartPath string) (string, error) {
-	r := helm.NewHelmRenderer(chartPath, defaultChart, "Pilot", config.IstioNamespace)
+	r := helm.NewHelmRenderer(chartPath, defaultChart, "Pilot", config.IstioNamespace, nil)
 
 	if err := r.Run(); err != nil {
 		return "", fmt.Errorf("failed running Helm renderer: %v", err)
@@ -216,7 +216,7 @@ base:
 
 // generateMutatingWebhook renders a mutating webhook configuration from the given tagWebhookConfig.
 func generateMutatingWebhook(config *tagWebhookConfig, webhookName, chartPath string, autoInjectNamespaces bool) (string, error) {
-	r := helm.NewHelmRenderer(chartPath, pilotDiscoveryChart, "Pilot", config.IstioNamespace)
+	r := helm.NewHelmRenderer(chartPath, pilotDiscoveryChart, "Pilot", config.IstioNamespace, nil)
 
 	if err := r.Run(); err != nil {
 		return "", fmt.Errorf("failed running Helm renderer: %v", err)

--- a/istioctl/pkg/verifier/verifier.go
+++ b/istioctl/pkg/verifier/verifier.go
@@ -214,8 +214,11 @@ func (v *StatusVerifier) verifyInstall() error {
 
 func (v *StatusVerifier) verifyPostInstallIstioOperator(iop *v1alpha1.IstioOperator, filename string) (int, int, error) {
 	t := translate.NewTranslator()
-
-	cp, err := controlplane.NewIstioControlPlane(iop.Spec, t, nil)
+	ver, err := v.client.GetKubernetesVersion()
+	if err != nil {
+		return 0, 0, err
+	}
+	cp, err := controlplane.NewIstioControlPlane(iop.Spec, t, nil, ver)
 	if err != nil {
 		return 0, 0, err
 	}

--- a/operator/cmd/mesh/manifest_shared_test.go
+++ b/operator/cmd/mesh/manifest_shared_test.go
@@ -24,6 +24,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -71,7 +72,7 @@ var (
 	testClient            client.Client
 	testReconcileOperator *istiocontrolplane.ReconcileIstioOperator
 
-	allNamespacedGVKs = append(helmreconciler.NamespacedResources,
+	allNamespacedGVKs = append(helmreconciler.NamespacedResources(&version.Info{Major: "1", Minor: "25"}),
 		schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Endpoints"})
 	// CRDs are not in the prune list, but must be considered for tests.
 	allClusterGVKs = append(helmreconciler.ClusterResources,
@@ -205,7 +206,7 @@ func fakeApplyExtraResources(inFile string) error {
 }
 
 func fakeControllerReconcile(inFile string, chartSource chartSourceType, opts *helmreconciler.Options) (*ObjectSet, error) {
-	c := kube.NewFakeClient()
+	c := kube.NewFakeClientWithVersion("25")
 	l := clog.NewDefaultLogger()
 	_, iop, err := manifest.GenerateConfig(
 		[]string{inFileAbsolutePath(inFile)},

--- a/operator/cmd/mesh/operator-common.go
+++ b/operator/cmd/mesh/operator-common.go
@@ -72,7 +72,7 @@ func renderOperatorManifest(_ *RootArgs, ocArgs *operatorCommonArgs) (string, st
 	if err != nil {
 		return "", "", err
 	}
-	r := helm.NewHelmRenderer(installPackagePath, "istio-operator", string(name.IstioOperatorComponentName), ocArgs.operatorNamespace)
+	r := helm.NewHelmRenderer(installPackagePath, "istio-operator", string(name.IstioOperatorComponentName), ocArgs.operatorNamespace, nil)
 
 	if err := r.Run(); err != nil {
 		return "", "", err

--- a/operator/pkg/component/component.go
+++ b/operator/pkg/component/component.go
@@ -22,6 +22,7 @@ package component
 import (
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/version"
 	"sigs.k8s.io/yaml"
 
 	"istio.io/api/operator/v1alpha1"
@@ -53,6 +54,8 @@ type Options struct {
 	Namespace string
 	// Filter is the filenames to render
 	Filter sets.Set
+	// Version is the Kubernetes version information.
+	Version *version.Info
 }
 
 // IstioComponent defines the interface for a component.
@@ -478,7 +481,7 @@ func createHelmRenderer(c *CommonComponentFields) helm.TemplateRenderer {
 	iop := c.InstallSpec
 	cns := string(c.ComponentName)
 	helmSubdir := c.Translator.ComponentMap(cns).HelmSubdir
-	return helm.NewHelmRenderer(iop.InstallPackagePath, helmSubdir, cns, c.Namespace)
+	return helm.NewHelmRenderer(iop.InstallPackagePath, helmSubdir, cns, c.Namespace, c.Version)
 }
 
 func isCoreComponentEnabled(c *CommonComponentFields) bool {

--- a/operator/pkg/controlplane/control_plane.go
+++ b/operator/pkg/controlplane/control_plane.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 	"sort"
 
+	"k8s.io/apimachinery/pkg/version"
+
 	"istio.io/api/operator/v1alpha1"
 	iop "istio.io/istio/operator/pkg/apis/istio/v1alpha1"
 	"istio.io/istio/operator/pkg/component"
@@ -35,12 +37,13 @@ type IstioControlPlane struct {
 }
 
 // NewIstioControlPlane creates a new IstioControlPlane and returns a pointer to it.
-func NewIstioControlPlane(installSpec *v1alpha1.IstioOperatorSpec, translator *translate.Translator, filter []string) (*IstioControlPlane, error) {
+func NewIstioControlPlane(installSpec *v1alpha1.IstioOperatorSpec, translator *translate.Translator, filter []string, ver *version.Info) (*IstioControlPlane, error) {
 	out := &IstioControlPlane{}
 	opts := &component.Options{
 		InstallSpec: installSpec,
 		Translator:  translator,
 		Filter:      sets.New(filter...),
+		Version:     ver,
 	}
 	for _, c := range name.AllCoreComponentNames {
 		o := *opts

--- a/operator/pkg/controlplane/control_plane.go
+++ b/operator/pkg/controlplane/control_plane.go
@@ -37,7 +37,12 @@ type IstioControlPlane struct {
 }
 
 // NewIstioControlPlane creates a new IstioControlPlane and returns a pointer to it.
-func NewIstioControlPlane(installSpec *v1alpha1.IstioOperatorSpec, translator *translate.Translator, filter []string, ver *version.Info) (*IstioControlPlane, error) {
+func NewIstioControlPlane(
+	installSpec *v1alpha1.IstioOperatorSpec,
+	translator *translate.Translator,
+	filter []string,
+	ver *version.Info,
+) (*IstioControlPlane, error) {
 	out := &IstioControlPlane{}
 	opts := &component.Options{
 		InstallSpec: installSpec,

--- a/operator/pkg/controlplane/control_plane_test.go
+++ b/operator/pkg/controlplane/control_plane_test.go
@@ -115,7 +115,7 @@ func TestNewIstioOperator(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			gotOperator, err := NewIstioControlPlane(tt.inInstallSpec, tt.inTranslator, nil)
+			gotOperator, err := NewIstioControlPlane(tt.inInstallSpec, tt.inTranslator, nil, nil)
 			if ((err != nil && tt.wantErr == nil) || (err == nil && tt.wantErr != nil)) || !gotOperator.componentsEqual(tt.wantIstioOperator.components) {
 				t.Errorf("%s: wanted components & err %+v %v, got components & err %+v %v",
 					tt.desc, tt.wantIstioOperator.components, tt.wantErr, gotOperator.components, err)

--- a/operator/pkg/helm/helm.go
+++ b/operator/pkg/helm/helm.go
@@ -24,6 +24,7 @@ import (
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chartutil"
 	"helm.sh/helm/v3/pkg/engine"
+	"k8s.io/apimachinery/pkg/version"
 	"sigs.k8s.io/yaml"
 
 	"istio.io/istio/manifests"
@@ -62,9 +63,9 @@ type TemplateRenderer interface {
 // NewHelmRenderer creates a new helm renderer with the given parameters and returns an interface to it.
 // The format of helmBaseDir and profile strings determines the type of helm renderer returned (compiled-in, file,
 // HTTP etc.)
-func NewHelmRenderer(operatorDataDir, helmSubdir, componentName, namespace string) TemplateRenderer {
+func NewHelmRenderer(operatorDataDir, helmSubdir, componentName, namespace string, version *version.Info) TemplateRenderer {
 	dir := strings.Join([]string{ChartsSubdirName, helmSubdir}, "/")
-	return NewGenericRenderer(manifests.BuiltinOrDir(operatorDataDir), dir, componentName, namespace)
+	return NewGenericRenderer(manifests.BuiltinOrDir(operatorDataDir), dir, componentName, namespace, version)
 }
 
 // ReadProfileYAML reads the YAML values associated with the given profile. It uses an appropriate reader for the
@@ -89,7 +90,7 @@ func ReadProfileYAML(profile, manifestsPath string) (string, error) {
 }
 
 // renderChart renders the given chart with the given values and returns the resulting YAML manifest string.
-func renderChart(namespace, values string, chrt *chart.Chart, filterFunc TemplateFilterFunc) (string, error) {
+func renderChart(namespace, values string, chrt *chart.Chart, filterFunc TemplateFilterFunc, version *version.Info) (string, error) {
 	options := chartutil.ReleaseOptions{
 		Name:      "istio",
 		Namespace: namespace,
@@ -100,6 +101,13 @@ func renderChart(namespace, values string, chrt *chart.Chart, filterFunc Templat
 	}
 
 	caps := *chartutil.DefaultCapabilities
+	if version != nil {
+		caps.KubeVersion = chartutil.KubeVersion{
+			Version: version.GitVersion,
+			Major:   version.Major,
+			Minor:   version.Minor,
+		}
+	}
 	vals, err := chartutil.ToRenderValues(chrt, valuesMap, options, &caps)
 	if err != nil {
 		return "", err

--- a/operator/pkg/helmreconciler/render.go
+++ b/operator/pkg/helmreconciler/render.go
@@ -34,8 +34,11 @@ func (h *HelmReconciler) RenderCharts() (name.ManifestMap, error) {
 	}
 
 	t := translate.NewTranslator()
-
-	cp, err := controlplane.NewIstioControlPlane(iopSpec, t, nil)
+	ver, err := h.kubeClient.GetKubernetesVersion()
+	if err != nil {
+		return nil, err
+	}
+	cp, err := controlplane.NewIstioControlPlane(iopSpec, t, nil, ver)
 	if err != nil {
 		return nil, err
 	}

--- a/operator/pkg/manifest/shared.go
+++ b/operator/pkg/manifest/shared.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/version"
 	"sigs.k8s.io/yaml"
 
 	"istio.io/api/operator/v1alpha1"
@@ -62,8 +63,14 @@ func GenManifests(inFilename []string, setFlags []string, force bool, filter []s
 	}
 
 	t := translate.NewTranslator()
-
-	cp, err := controlplane.NewIstioControlPlane(mergedIOPS.Spec, t, filter)
+	var ver *version.Info
+	if client != nil {
+		ver, err = client.GetKubernetesVersion()
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+	cp, err := controlplane.NewIstioControlPlane(mergedIOPS.Spec, t, filter, ver)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pilot/test/util/diff.go
+++ b/pilot/test/util/diff.go
@@ -107,7 +107,7 @@ func StripVersion(yaml []byte) []byte {
 
 // RefreshGoldenFile updates the golden file with the given content
 func RefreshGoldenFile(t test.Failer, content []byte, goldenFile string) {
-	if Refresh() {
+	if Refresh() || true {
 		t.Logf("Refreshing golden file %s", goldenFile)
 		if err := file.AtomicWrite(goldenFile, content, os.FileMode(0o644)); err != nil {
 			t.Fatal(err.Error())

--- a/pilot/test/util/diff.go
+++ b/pilot/test/util/diff.go
@@ -107,7 +107,7 @@ func StripVersion(yaml []byte) []byte {
 
 // RefreshGoldenFile updates the golden file with the given content
 func RefreshGoldenFile(t test.Failer, content []byte, goldenFile string) {
-	if Refresh() || true {
+	if Refresh() {
 		t.Logf("Refreshing golden file %s", goldenFile)
 		if err := file.AtomicWrite(goldenFile, content, os.FileMode(0o644)); err != nil {
 			t.Fatal(err.Error())

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -288,7 +288,7 @@ func NewFakeClientWithVersion(minor string, objects ...runtime.Object) ExtendedC
 	c := NewFakeClient(objects...).(*client)
 	if minor != "" && minor != "latest" {
 		c.versionOnce.Do(func() {
-			c.version = &kubeVersion.Info{Major: "1", Minor: minor}
+			c.version = &kubeVersion.Info{Major: "1", Minor: minor, GitVersion: fmt.Sprintf("v1.%v.0", minor)}
 		})
 	}
 	return c

--- a/tests/fuzz/misc_fuzzers.go
+++ b/tests/fuzz/misc_fuzzers.go
@@ -142,7 +142,7 @@ func FuzzNewControlplane(data []byte) int {
 		return 0
 	}
 	inTranslator.ComponentMaps[name.PilotComponentName] = cm
-	_, _ = controlplane.NewIstioControlPlane(inInstallSpec, inTranslator, nil)
+	_, _ = controlplane.NewIstioControlPlane(inInstallSpec, inTranslator, nil, nil)
 	return 1
 }
 

--- a/tests/integration/pilot/revisions/uninstall_test.go
+++ b/tests/integration/pilot/revisions/uninstall_test.go
@@ -28,6 +28,7 @@ import (
 	kubeApiMeta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/version"
 
 	"istio.io/istio/operator/pkg/helmreconciler"
 	"istio.io/istio/operator/pkg/name"
@@ -48,6 +49,8 @@ const (
 
 var ManifestPath = filepath.Join(env.IstioSrc, "manifests")
 
+var allGVKs = append(helmreconciler.NamespacedResources(&version.Info{Major: "1", Minor: "24"}), helmreconciler.ClusterCPResources...)
+
 func TestUninstallByRevision(t *testing.T) {
 	framework.
 		NewTest(t).
@@ -65,7 +68,7 @@ func TestUninstallByRevision(t *testing.T) {
 				}
 				cs := t.Clusters().Default()
 				ls := fmt.Sprintf("istio.io/rev=%s", stableRevision)
-				checkCPResourcesUninstalled(t, cs, append(helmreconciler.NamespacedResources, helmreconciler.ClusterCPResources...), ls, false)
+				checkCPResourcesUninstalled(t, cs, allGVKs, ls, false)
 			})
 		})
 }
@@ -87,7 +90,7 @@ func TestUninstallWithSetFlag(t *testing.T) {
 				}
 				cs := t.Clusters().Default()
 				ls := fmt.Sprintf("istio.io/rev=%s", stableRevision)
-				checkCPResourcesUninstalled(t, cs, append(helmreconciler.NamespacedResources, helmreconciler.ClusterCPResources...), ls, false)
+				checkCPResourcesUninstalled(t, cs, allGVKs, ls, false)
 			})
 		})
 }
@@ -104,8 +107,7 @@ func TestUninstallPurge(t *testing.T) {
 			}
 			istioCtl.InvokeOrFail(t, uninstallCmd)
 			cs := t.Clusters().Default()
-			checkCPResourcesUninstalled(t, cs, append(helmreconciler.NamespacedResources, helmreconciler.AllClusterResources...),
-				helmreconciler.IstioComponentLabelStr, true)
+			checkCPResourcesUninstalled(t, cs, allGVKs, helmreconciler.IstioComponentLabelStr, true)
 		})
 }
 


### PR DESCRIPTION
There were a few issues here:
* We always used the old versions for prune, and only sometimes added
  the new ones. This means on 1.25 we get a bunch of errors
* We never based the version to the helm renderer, so its ignored and we
  always use the old API versions.

This PR fixes both of these. A lot of plumbing to get the version
through

**Please provide a description of this PR:**