### PR TITLE
prow: disable EndpointSlice feature flag

### DIFF
--- a/prow/config/default.yaml
+++ b/prow/config/default.yaml
@@ -4,7 +4,6 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 featureGates:
   MixedProtocolLBService: true
-  EndpointSlice: true
   GRPCContainerProbe: true
 kubeadmConfigPatches:
   - |


### PR DESCRIPTION
The flag is now removed, blocking startup on 1.25+

This is not needed since its been default for many versions, and older
verisons that *do* need the flag are using another config which does
have it set still.

**Please provide a description of this PR:**