### PR TITLE
[1.14] docker: support proper multi-architecture builds (#39278)

### DIFF
--- a/tools/docker-builder/builder/crane.go
+++ b/tools/docker-builder/builder/crane.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"strings"
 	"sync"
 	"time"
 
@@ -35,9 +36,19 @@ import (
 	"istio.io/pkg/log"
 )
 
+type BuildSpec struct {
+	// Name is optional, for logging
+	Name  string
+	Dests []string
+	Args  []Args
+}
+
 type Args struct {
 	// Name is optional, for logging
 	Name string
+
+	// Image architecture. Required only when multiple images present
+	Arch string
 
 	Env        map[string]string
 	Labels     map[string]string
@@ -77,6 +88,7 @@ func WarmBase(baseImages ...string) {
 	for i, b := range baseImages {
 		b, i := b, i
 		go func() {
+			defer wg.Done()
 			ref, err := name.ParseReference(b)
 			if err != nil {
 				log.WithLabels("image", b).Warnf("base failed: %v", err)
@@ -89,7 +101,6 @@ func WarmBase(baseImages ...string) {
 			}
 			log.WithLabels("image", b, "step", time.Since(t0)).Infof("base loaded")
 			resolvedBaseImages[i] = bi
-			wg.Done()
 		}()
 	}
 }
@@ -108,104 +119,159 @@ func ByteCount(b int64) string {
 		float64(b)/float64(div), "kMGTPE"[exp])
 }
 
-func Build(args Args, dests []string) error {
+func Build(b BuildSpec) error {
 	t0 := time.Now()
 	lt := t0
 	trace := func(d ...interface{}) {
-		log.WithLabels("image", args.Name, "total", time.Since(t0), "step", time.Since(lt)).Infof(d...)
+		log.WithLabels("image", b.Name, "total", time.Since(t0), "step", time.Since(lt)).Infof(d...)
 		lt = time.Now()
 	}
-	if len(dests) == 0 {
+	if len(b.Dests) == 0 {
 		return fmt.Errorf("dest required")
 	}
 
-	baseImage := empty.Image
-	if args.Base != "" {
-		basesMu.RLock()
-		baseImage = bases[args.Base]
-		basesMu.RUnlock()
+	// Over localhost, compression CPU can be the bottleneck. With remotes, compressing usually saves a lot of time.
+	compression := gzip.NoCompression
+	for _, d := range b.Dests {
+		if !strings.HasPrefix(d, "localhost") {
+			compression = gzip.BestSpeed
+			break
+		}
 	}
-	if baseImage == nil {
-		log.Warnf("on demand loading base image %q", args.Base)
-		ref, err := name.ParseReference(args.Base)
+
+	var images []v1.Image
+	for _, args := range b.Args {
+		baseImage := empty.Image
+		if args.Base != "" {
+			basesMu.RLock()
+			baseImage = bases[args.Base]
+			basesMu.RUnlock()
+		}
+		if baseImage == nil {
+			log.Warnf("on demand loading base image %q", args.Base)
+			ref, err := name.ParseReference(args.Base)
+			if err != nil {
+				return err
+			}
+			bi, err := remote.Image(ref, remote.WithProgress(CreateProgress(fmt.Sprintf("base %v", ref))))
+			if err != nil {
+				return err
+			}
+			baseImage = bi
+		}
+		trace("create base")
+
+		cfgFile, err := baseImage.ConfigFile()
 		if err != nil {
 			return err
 		}
-		bi, err := remote.Image(ref, remote.WithProgress(CreateProgress(fmt.Sprintf("base %v", ref))))
+
+		trace("base config")
+
+		cfg := cfgFile.Config
+		for k, v := range args.Env {
+			cfg.Env = append(cfg.Env, fmt.Sprintf("%v=%v", k, v))
+		}
+		if args.User != "" {
+			cfg.User = args.User
+		}
+		if len(args.Entrypoint) > 0 {
+			cfg.Entrypoint = args.Entrypoint
+			cfg.Cmd = nil
+		}
+		if len(args.Cmd) > 0 {
+			cfg.Cmd = args.Cmd
+			cfg.Entrypoint = nil
+		}
+		if args.WorkDir != "" {
+			cfg.WorkingDir = args.WorkDir
+		}
+		if len(args.Labels) > 0 && cfg.Labels == nil {
+			cfg.Labels = map[string]string{}
+		}
+		for k, v := range args.Labels {
+			cfg.Labels[k] = v
+		}
+
+		updated, err := mutate.Config(baseImage, cfg)
 		if err != nil {
 			return err
 		}
-		baseImage = bi
-	}
-	trace("create base")
+		trace("config")
 
-	cfgFile, err := baseImage.ConfigFile()
-	if err != nil {
-		return err
-	}
+		// Pre-allocated 100mb
+		// TODO: cache the size of images, use exactish size
+		buf := bytes.NewBuffer(make([]byte, 0, 100*1024*1024))
+		if err := WriteArchiveFromFiles(args.FilesBase, args.Files, buf); err != nil {
+			return err
+		}
+		sz := ByteCount(int64(buf.Len()))
 
-	trace("base config")
+		l, err := tarball.LayerFromOpener(func() (io.ReadCloser, error) {
+			return ioutil.NopCloser(bytes.NewReader(buf.Bytes())), nil
+		}, tarball.WithCompressionLevel(compression))
+		if err != nil {
+			return err
+		}
+		trace("read layer of size %v", sz)
 
-	cfg := cfgFile.Config
-	for k, v := range args.Env {
-		cfg.Env = append(cfg.Env, fmt.Sprintf("%v=%v", k, v))
-	}
-	if args.User != "" {
-		cfg.User = args.User
-	}
-	if len(args.Entrypoint) > 0 {
-		cfg.Entrypoint = args.Entrypoint
-		cfg.Cmd = nil
-	}
-	if len(args.Cmd) > 0 {
-		cfg.Cmd = args.Cmd
-		cfg.Entrypoint = nil
-	}
-	if args.WorkDir != "" {
-		cfg.WorkingDir = args.WorkDir
-	}
-	if len(args.Labels) > 0 && cfg.Labels == nil {
-		cfg.Labels = map[string]string{}
-	}
-	for k, v := range args.Labels {
-		cfg.Labels[k] = v
-	}
+		image, err := mutate.AppendLayers(updated, l)
+		if err != nil {
+			return err
+		}
 
-	updated, err := mutate.Config(baseImage, cfg)
-	if err != nil {
-		return err
+		trace("layer")
+		images = append(images, image)
 	}
-	trace("config")
-
-	// Pre-allocated 100mb
-	// TODO: cache the size of images, use exactish size
-	buf := bytes.NewBuffer(make([]byte, 0, 100*1024*1024))
-	if err := WriteArchiveFromFiles(args.FilesBase, args.Files, buf); err != nil {
-		return err
-	}
-	sz := ByteCount(int64(buf.Len()))
-	l, err := tarball.LayerFromOpener(func() (io.ReadCloser, error) {
-		return ioutil.NopCloser(bytes.NewReader(buf.Bytes())), nil
-	}, tarball.WithCompressionLevel(gzip.NoCompression))
-	if err != nil {
-		return err
-	}
-	trace("read layer of size %v", sz)
-
-	files, err := mutate.AppendLayers(updated, l)
-	if err != nil {
-		return err
-	}
-
-	trace("layer")
 
 	// Write Remote
+
+	var artifact remote.Taggable
+	if len(images) == 1 {
+		// Single image, just push that
+		artifact = images[0]
+	} else {
+		// Multiple, we need to create an index
+		var manifest v1.ImageIndex = empty.Index
+		for idx, i := range images {
+			img := i
+			mt, err := img.MediaType()
+			if err != nil {
+				return fmt.Errorf("failed to get mediatype: %w", err)
+			}
+
+			h, err := img.Digest()
+			if err != nil {
+				return fmt.Errorf("failed to compute digest: %w", err)
+			}
+
+			size, err := img.Size()
+			if err != nil {
+				return fmt.Errorf("failed to compute size: %w", err)
+			}
+			os, arch, _ := strings.Cut(b.Args[idx].Arch, "/")
+			manifest = mutate.AppendManifests(manifest, mutate.IndexAddendum{
+				Add: i,
+				Descriptor: v1.Descriptor{
+					MediaType: mt,
+					Size:      size,
+					Digest:    h,
+					Platform: &v1.Platform{
+						Architecture: arch,
+						OS:           os,
+						Variant:      "", // TODO?
+					},
+				},
+			})
+		}
+		artifact = manifest
+	}
 
 	// MultiWrite takes a Reference -> Taggable, but won't handle writing to multiple Repos. So we keep
 	// a map of Repository -> MultiWrite args.
 	remoteTargets := map[name.Repository]map[name.Reference]remote.Taggable{}
 
-	for _, dest := range dests {
+	for _, dest := range b.Dests {
 		destRef, err := name.ParseReference(dest)
 		if err != nil {
 			return err
@@ -214,7 +280,7 @@ func Build(args Args, dests []string) error {
 		if remoteTargets[repo] == nil {
 			remoteTargets[repo] = map[name.Reference]remote.Taggable{}
 		}
-		remoteTargets[repo][destRef] = files
+		remoteTargets[repo][destRef] = artifact
 	}
 
 	for repo, mw := range remoteTargets {
@@ -222,7 +288,13 @@ func Build(args Args, dests []string) error {
 		if err := remote.MultiWrite(mw, remote.WithProgress(prog), remote.WithAuthFromKeychain(authn.DefaultKeychain)); err != nil {
 			return err
 		}
-		trace("upload %v", repo.String())
+		s := repo.String()
+		if len(mw) == 1 {
+			for tag := range mw {
+				s = tag.String()
+			}
+		}
+		trace("upload %v", s)
 	}
 
 	return nil

--- a/tools/docker-builder/common.go
+++ b/tools/docker-builder/common.go
@@ -39,12 +39,12 @@ func extractTags(a Args, target, variant string, hasDoubleDefault bool) []string
 	return tags
 }
 
-func createArgs(args Args, target string, variant string) map[string]string {
+func createArgs(args Args, target string, variant string, architecture string) map[string]string {
 	baseDist := variant
 	if baseDist == DefaultVariant {
 		baseDist = PrimaryVariant
 	}
-	return map[string]string{
+	m := map[string]string{
 		// Base version defines the tag of the base image to use. Typically, set in the Makefile and not overridden.
 		"BASE_VERSION": args.BaseVersion,
 		// Base distribution picks which variant to build
@@ -55,6 +55,13 @@ func createArgs(args Args, target string, variant string) map[string]string {
 		"VM_IMAGE_NAME":    vmImageName(target),
 		"VM_IMAGE_VERSION": vmImageVersion(target),
 	}
+	// Only needed for crane - buildx does it automagically
+	if architecture != "" {
+		os, arch, _ := strings.Cut(architecture, "/")
+		m["TARGETARCH"] = arch
+		m["TARGETOS"] = os
+	}
+	return m
 }
 
 func vmImageName(target string) string {

--- a/tools/docker-builder/types.go
+++ b/tools/docker-builder/types.go
@@ -72,8 +72,13 @@ type Args struct {
 	Tags          []string
 	Hubs          []string
 
-	// Plan describes the build plan, read from file
-	Plan BuildPlan
+	// Plan describes the build plan, read from file.
+	// This is a map of architecture -> plan, as the plan is arch specific.
+	Plan map[string]BuildPlan
+}
+
+func (a Args) PlanFor(arch string) BuildPlan {
+	return a.Plan[arch]
 }
 
 func (a Args) String() string {


### PR DESCRIPTION
This introduces support in the docker builder to orchestrate multi-arch
docker builds. Previously, it was required to call the builder twice
with each arch; this doesn't allow aggregating into a single multi-arch
image though.

For docker builder, this is fairly straightforward. We mostly need
changes to allow plan file to be arch-specific, and to call make
multiple times per-arch.

For crane builder, a little more complex since we need to allow passing
multiple plans to it and then deciding whether to make a Index or direct
Image.

(cherry picked from commit 13de462d7adbeff491d89e7ac17684adedf80ce8)
Fixes https://github.com/istio/istio/issues/39557