### PR TITLE
[1.13] Clear index on cache evict (#39435)

### DIFF
--- a/pilot/pkg/model/xds_cache.go
+++ b/pilot/pkg/model/xds_cache.go
@@ -69,20 +69,14 @@ func miss() {
 	}
 }
 
-func evict(k interface{}, v interface{}) {
-	if features.EnableXDSCacheMetrics {
-		xdsCacheEvictions.Increment()
-	}
-}
-
 func size(cs int) {
 	if features.EnableXDSCacheMetrics {
 		xdsCacheSize.Record(float64(cs))
 	}
 }
 
-func indexConfig(configIndex map[ConfigKey]sets.Set, k string, entry XdsCacheEntry) {
-	for _, config := range entry.DependentConfigs() {
+func indexConfig(configIndex map[ConfigKey]sets.Set, k string, dependentConfigs []ConfigKey) {
+	for _, config := range dependentConfigs {
 		if configIndex[config] == nil {
 			configIndex[config] = sets.NewSet()
 		}
@@ -90,12 +84,36 @@ func indexConfig(configIndex map[ConfigKey]sets.Set, k string, entry XdsCacheEnt
 	}
 }
 
-func indexType(typeIndex map[config.GroupVersionKind]sets.Set, k string, entry XdsCacheEntry) {
-	for _, t := range entry.DependentTypes() {
+func clearIndexConfig(configIndex map[ConfigKey]sets.Set, k string, dependentConfigs []ConfigKey) {
+	for _, cfg := range dependentConfigs {
+		index := configIndex[cfg]
+		if index != nil {
+			index.Delete(k)
+			if len(index) == 0 {
+				delete(configIndex, cfg)
+			}
+		}
+	}
+}
+
+func indexType(typeIndex map[config.GroupVersionKind]sets.Set, k string, dependentTypes []config.GroupVersionKind) {
+	for _, t := range dependentTypes {
 		if typeIndex[t] == nil {
 			typeIndex[t] = sets.NewSet()
 		}
 		typeIndex[t].Insert(k)
+	}
+}
+
+func clearIndexType(typeIndex map[config.GroupVersionKind]sets.Set, k string, dependentTypes []config.GroupVersionKind) {
+	for _, t := range dependentTypes {
+		index := typeIndex[t]
+		if index != nil {
+			index.Delete(k)
+			if len(index) == 0 {
+				delete(typeIndex, t)
+			}
+		}
 	}
 }
 
@@ -141,22 +159,26 @@ type XdsCache interface {
 
 // NewXdsCache returns an instance of a cache.
 func NewXdsCache() XdsCache {
-	return &lruCache{
+	cache := &lruCache{
 		enableAssertions: features.EnableUnsafeAssertions,
-		store:            newLru(),
 		configIndex:      map[ConfigKey]sets.Set{},
 		typesIndex:       map[config.GroupVersionKind]sets.Set{},
 	}
+	cache.store = newLru(cache.evict)
+
+	return cache
 }
 
 // NewLenientXdsCache returns an instance of a cache that does not validate token based get/set and enable assertions.
 func NewLenientXdsCache() XdsCache {
-	return &lruCache{
+	cache := &lruCache{
 		enableAssertions: false,
-		store:            newLru(),
 		configIndex:      map[ConfigKey]sets.Set{},
 		typesIndex:       map[config.GroupVersionKind]sets.Set{},
 	}
+	cache.store = newLru(cache.evict)
+
+	return cache
 }
 
 type lruCache struct {
@@ -172,16 +194,29 @@ type lruCache struct {
 
 var _ XdsCache = &lruCache{}
 
-func newLru() simplelru.LRUCache {
+func newLru(evictCallback simplelru.EvictCallback) simplelru.LRUCache {
 	sz := features.XDSCacheMaxSize
 	if sz <= 0 {
 		sz = 20000
 	}
-	l, err := simplelru.NewLRU(sz, evict)
+	l, err := simplelru.NewLRU(sz, evictCallback)
 	if err != nil {
 		panic(fmt.Errorf("invalid lru configuration: %v", err))
 	}
 	return l
+}
+
+func (l *lruCache) evict(k interface{}, v interface{}) {
+	if features.EnableXDSCacheMetrics {
+		xdsCacheEvictions.Increment()
+	}
+
+	key := k.(string)
+	value := v.(cacheValue)
+
+	// we don't need to acquire locks, since this function is called when we write to the store
+	clearIndexConfig(l.configIndex, key, value.dependentConfigs)
+	clearIndexType(l.typesIndex, key, value.dependentTypes)
 }
 
 // assertUnchanged checks that a cache entry is not changed. This helps catch bad cache invalidation
@@ -246,17 +281,27 @@ func (l *lruCache) Add(entry XdsCacheEntry, pushReq *PushRequest, value *discove
 		return
 	}
 
-	toWrite := cacheValue{value: value, token: token}
+	// we have to make sure we evict old entries with the same key
+	// to prevent leaking in the index maps
+	if old, ok := l.store.Get(k); ok {
+		l.evict(k, old)
+	}
+
+	dependentConfigs := entry.DependentConfigs()
+	dependentTypes := entry.DependentTypes()
+	toWrite := cacheValue{value: value, token: token, dependentConfigs: dependentConfigs, dependentTypes: dependentTypes}
 	l.store.Add(k, toWrite)
 	l.token = token
-	indexConfig(l.configIndex, k, entry)
-	indexType(l.typesIndex, k, entry)
+	indexConfig(l.configIndex, k, dependentConfigs)
+	indexType(l.typesIndex, k, dependentTypes)
 	size(l.store.Len())
 }
 
 type cacheValue struct {
-	value *discovery.Resource
-	token CacheToken
+	value            *discovery.Resource
+	token            CacheToken
+	dependentConfigs []ConfigKey
+	dependentTypes   []config.GroupVersionKind
 }
 
 func (l *lruCache) Get(entry XdsCacheEntry) (*discovery.Resource, bool) {
@@ -303,7 +348,10 @@ func (l *lruCache) ClearAll() {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	l.token = CacheToken(time.Now().UnixNano())
-	l.store.Purge()
+	// Purge with an evict function would turn up to be pretty slow since
+	// it runs the function for every key in the store, might be better to just
+	// create a new store.
+	l.store = newLru(l.evict)
 	l.configIndex = map[ConfigKey]sets.Set{}
 	l.typesIndex = map[config.GroupVersionKind]sets.Set{}
 	size(l.store.Len())

--- a/pilot/pkg/util/sets/string.go
+++ b/pilot/pkg/util/sets/string.go
@@ -33,8 +33,14 @@ func (s Set) Insert(items ...string) Set {
 	return s
 }
 
+// Delete removes an item from the set.
+func (s Set) Delete(item string) Set {
+	delete(s, item)
+	return s
+}
+
 // Delete removes items from the set.
-func (s Set) Delete(items ...string) Set {
+func (s Set) DeleteAll(items ...string) Set {
 	for _, item := range items {
 		delete(s, item)
 	}

--- a/pilot/pkg/xds/delta.go
+++ b/pilot/pkg/xds/delta.go
@@ -463,7 +463,7 @@ func (s *DiscoveryServer) pushDeltaXds(con *Connection, push *model.PushContext,
 	} else if req.Full {
 		// similar to sotw
 		subscribed := sets.NewSet(w.ResourceNames...)
-		subscribed.Delete(currentResources...)
+		subscribed.DeleteAll(currentResources...)
 		resp.RemovedResources = subscribed.SortedList()
 	}
 	if len(resp.RemovedResources) > 0 {
@@ -544,7 +544,7 @@ func deltaToSotwRequest(request *discovery.DeltaDiscoveryRequest) *discovery.Dis
 func deltaWatchedResources(existing []string, request *discovery.DeltaDiscoveryRequest) []string {
 	res := sets.NewSet(existing...)
 	res.Insert(request.ResourceNamesSubscribe...)
-	res.Delete(request.ResourceNamesUnsubscribe...)
+	res.DeleteAll(request.ResourceNamesUnsubscribe...)
 	return res.SortedList()
 }
 


### PR DESCRIPTION
* clear index on cache evict

* add comment

* provide a more efficient Delete function for string set

* create new lru store on clearall

* populate dependencies on write

* newLru takes evict callback

* avoid creating dependencies multiple times

* remove dead function

* fix merge

* add missing methods to set

* evict previous cache entry if already present

* add comment

**Please provide a description of this PR:**