### PR TITLE
Update SE instances on WE change

### DIFF
--- a/pilot/pkg/serviceregistry/serviceentry/controller.go
+++ b/pilot/pkg/serviceregistry/serviceentry/controller.go
@@ -264,6 +264,11 @@ func (s *Controller) workloadEntryHandler(old, curr config.Config, event model.E
 		}
 		instance := s.convertWorkloadEntryToServiceInstances(wle, services, se, &key, s.Cluster())
 		instancesUpdated = append(instancesUpdated, instance...)
+		if event == model.EventDelete {
+			s.serviceInstances.deleteServiceEntryInstances(namespacedName, key)
+		} else {
+			s.serviceInstances.updateServiceEntryInstancesPerConfig(namespacedName, key, instance)
+		}
 		addConfigs(se, services)
 	}
 
@@ -278,6 +283,7 @@ func (s *Controller) workloadEntryHandler(old, curr config.Config, event model.E
 		}
 		instance := s.convertWorkloadEntryToServiceInstances(wle, services, se, &key, s.Cluster())
 		instancesDeleted = append(instancesDeleted, instance...)
+		s.serviceInstances.deleteServiceEntryInstances(namespacedName, key)
 		addConfigs(se, services)
 	}
 

--- a/releasenotes/notes/update-se-instances.yaml
+++ b/releasenotes/notes/update-se-instances.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+releaseNotes:
+  - |
+    **Fixed** potential memory leak when updating service entries hostname.


### PR DESCRIPTION
**Please provide a description of this PR:**
Now we don't update service instances per SE in `workloadEntryHandler`, causing we are not able to [clean up old instances](https://github.com/istio/istio/blob/84d9f86021c64c65bc5cdc0b236da85d2f525907/pilot/pkg/serviceregistry/serviceentry/controller.go#L356-L359) on SE update, which potentially leaks memory