### PR TITLE
fix proxy_init.resources missed in sidecar injection

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
@@ -19,7 +19,7 @@
         {{ end }}
     {{- end }}
   {{- else }}
-    {{- if .Values.global.proxy.resources }}
+      {{- if .Values.global.proxy.resources }}
       {{ toYaml .Values.global.proxy.resources | indent 6 }}
     {{- end }}
   {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -368,6 +368,8 @@ global:
   proxy_init:
     # Base name for the proxy_init container, used to configure iptables.
     image: proxyv2
+    # Deprecated
+    # proxy_init.resources is same as .values.global.proxy.resources
     resources:
       limits:
         cpu: 2000m


### PR DESCRIPTION
Signed-off-by: spwangxp <wangshengpeng@cestc.cn>

**Please provide a description of this PR:**
although [proxy_init.resources defined](https://github.com/istio/istio/blob/master/manifests/charts/istio-control/istio-discovery/values.yaml#L371), but sidecar injection template didn't use it. that's why no matter how to change it, the initContainer.resources are same as istio-proxy.resources.