### PR TITLE
use mesh config defaults when log formatter is not specified

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/accesslog.go
+++ b/pilot/pkg/networking/core/v1alpha3/accesslog.go
@@ -187,7 +187,7 @@ func buildAccessLogFromTelemetry(push *model.PushContext, spec *model.LoggingCon
 		var al *accesslog.AccessLog
 		switch prov := p.Provider.(type) {
 		case *meshconfig.MeshConfig_ExtensionProvider_EnvoyFileAccessLog:
-			// For default provider, fallback to Mesh Config for formatting options.
+			// For built-in provider, fallback to Mesh Config for formatting options.
 			if p.Name == defaultEnvoyAccessLogProvider {
 				al = fileAccessLogFromMeshConfig(prov.EnvoyFileAccessLog.Path, push.Mesh)
 			} else {

--- a/pilot/pkg/networking/core/v1alpha3/accesslog.go
+++ b/pilot/pkg/networking/core/v1alpha3/accesslog.go
@@ -142,9 +142,9 @@ type AccessLogBuilder struct {
 
 func newAccessLogBuilder() *AccessLogBuilder {
 	return &AccessLogBuilder{
-		tcpGrpcAccessLog:         buildTCPGrpcAccessLog(false),
-		httpGrpcAccessLog:        buildHTTPGrpcAccessLog(),
-		tcpGrpcListenerAccessLog: buildTCPGrpcAccessLog(true),
+		tcpGrpcAccessLog:         tcpGrpcAccessLog(false),
+		httpGrpcAccessLog:        httpGrpcAccessLog(),
+		tcpGrpcListenerAccessLog: tcpGrpcAccessLog(true),
 	}
 }
 
@@ -185,13 +185,13 @@ func buildAccessLogFromTelemetry(push *model.PushContext, spec *model.LoggingCon
 		var al *accesslog.AccessLog
 		switch prov := p.Provider.(type) {
 		case *meshconfig.MeshConfig_ExtensionProvider_EnvoyFileAccessLog:
-			al = buildEnvoyFileAccessLogHelper(prov.EnvoyFileAccessLog)
+			al = fileAccessLogFromTelemetry(prov.EnvoyFileAccessLog, push.Mesh)
 		case *meshconfig.MeshConfig_ExtensionProvider_EnvoyHttpAls:
-			al = buildHTTPGrpcAccessLogHelper(push, prov.EnvoyHttpAls)
+			al = httpGrpcAccessLogFromTelemetry(push, prov.EnvoyHttpAls)
 		case *meshconfig.MeshConfig_ExtensionProvider_EnvoyTcpAls:
-			al = buildTCPGrpcAccessLogHelper(push, prov.EnvoyTcpAls)
+			al = tcpGrpcAccessLogFromTelemetry(push, prov.EnvoyTcpAls)
 		case *meshconfig.MeshConfig_ExtensionProvider_EnvoyOtelAls:
-			al = buildOpenTelemetryLogHelper(push, prov.EnvoyOtelAls)
+			al = openTelemetryLog(push, prov.EnvoyOtelAls)
 		}
 		if al == nil {
 			continue
@@ -272,7 +272,7 @@ func (b *AccessLogBuilder) setListenerAccessLog(push *model.PushContext, proxy *
 	}
 }
 
-func buildTCPGrpcAccessLogHelper(push *model.PushContext, prov *meshconfig.MeshConfig_ExtensionProvider_EnvoyTcpGrpcV3LogProvider) *accesslog.AccessLog {
+func tcpGrpcAccessLogFromTelemetry(push *model.PushContext, prov *meshconfig.MeshConfig_ExtensionProvider_EnvoyTcpGrpcV3LogProvider) *accesslog.AccessLog {
 	logName := tcpEnvoyAccessLogFriendlyName
 	if prov != nil && prov.LogName != "" {
 		logName = prov.LogName
@@ -311,7 +311,9 @@ func buildTCPGrpcAccessLogHelper(push *model.PushContext, prov *meshconfig.MeshC
 	}
 }
 
-func buildEnvoyFileAccessLogHelper(prov *meshconfig.MeshConfig_ExtensionProvider_EnvoyFileAccessLogProvider) *accesslog.AccessLog {
+func fileAccessLogFromTelemetry(prov *meshconfig.MeshConfig_ExtensionProvider_EnvoyFileAccessLogProvider,
+	mesh *meshconfig.MeshConfig,
+) *accesslog.AccessLog {
 	p := prov.Path
 	if p == "" {
 		p = devStdout
@@ -329,7 +331,9 @@ func buildEnvoyFileAccessLogHelper(prov *meshconfig.MeshConfig_ExtensionProvider
 			fl.AccessLogFormat, needsFormatter = buildFileAccessJSONLogFormat(logFormat)
 		}
 	} else {
-		fl.AccessLogFormat, needsFormatter = buildFileAccessTextLogFormat("")
+		// Provider did not specify formatter. Fallback to Mesh Config. This is useful
+		// in using the default "envoy" provider which does not have formatter specified.
+		return fileAccessLogFromMeshConfig(p, mesh)
 	}
 	if needsFormatter {
 		fl.GetLogFormat().Formatters = accessLogFormatters
@@ -391,7 +395,7 @@ func buildFileAccessJSONLogFormat(
 	}, needsFormatter
 }
 
-func buildHTTPGrpcAccessLogHelper(push *model.PushContext, prov *meshconfig.MeshConfig_ExtensionProvider_EnvoyHttpGrpcV3LogProvider) *accesslog.AccessLog {
+func httpGrpcAccessLogFromTelemetry(push *model.PushContext, prov *meshconfig.MeshConfig_ExtensionProvider_EnvoyHttpGrpcV3LogProvider) *accesslog.AccessLog {
 	logName := httpEnvoyAccessLogFriendlyName
 	if prov != nil && prov.LogName != "" {
 		logName = prov.LogName
@@ -433,7 +437,7 @@ func buildHTTPGrpcAccessLogHelper(push *model.PushContext, prov *meshconfig.Mesh
 	}
 }
 
-func buildFileAccessLogHelper(path string, mesh *meshconfig.MeshConfig) *accesslog.AccessLog {
+func fileAccessLogFromMeshConfig(path string, mesh *meshconfig.MeshConfig) *accesslog.AccessLog {
 	// We need to build access log. This is needed either on first access or when mesh config changes.
 	fl := &fileaccesslog.FileAccessLog{
 		Path: path,
@@ -494,7 +498,7 @@ func buildFileAccessLogHelper(path string, mesh *meshconfig.MeshConfig) *accessl
 	return al
 }
 
-func buildOpenTelemetryLogHelper(pushCtx *model.PushContext,
+func openTelemetryLog(pushCtx *model.PushContext,
 	provider *meshconfig.MeshConfig_ExtensionProvider_EnvoyOpenTelemetryLogProvider,
 ) *accesslog.AccessLog {
 	hostname, cluster, err := clusterLookupFn(pushCtx, provider.Service, int(provider.Port))
@@ -581,7 +585,7 @@ func (b *AccessLogBuilder) buildFileAccessLog(mesh *meshconfig.MeshConfig) *acce
 	}
 
 	// We need to build access log. This is needed either on first access or when mesh config changes.
-	al := buildFileAccessLogHelper(mesh.AccessLogFile, mesh)
+	al := fileAccessLogFromMeshConfig(mesh.AccessLogFile, mesh)
 
 	b.mutex.Lock()
 	defer b.mutex.Unlock()
@@ -622,7 +626,7 @@ func (b *AccessLogBuilder) buildListenerFileAccessLog(mesh *meshconfig.MeshConfi
 	}
 
 	// We need to build access log. This is needed either on first access or when mesh config changes.
-	lal := buildFileAccessLogHelper(mesh.AccessLogFile, mesh)
+	lal := fileAccessLogFromMeshConfig(mesh.AccessLogFile, mesh)
 	// We add ResponseFlagFilter here, as we want to get listener access logs only on scenarios where we might
 	// not get filter Access Logs like in cases like NR to upstream.
 	lal.Filter = addAccessLogFilter()
@@ -646,7 +650,7 @@ func (b *AccessLogBuilder) cachedListenerFileAccessLog() *accesslog.AccessLog {
 	return b.listenerFileAccessLog
 }
 
-func buildTCPGrpcAccessLog(isListener bool) *accesslog.AccessLog {
+func tcpGrpcAccessLog(isListener bool) *accesslog.AccessLog {
 	accessLogFriendlyName := tcpEnvoyAccessLogFriendlyName
 	if isListener {
 		accessLogFriendlyName = listenerEnvoyAccessLogFriendlyName
@@ -677,7 +681,7 @@ func buildTCPGrpcAccessLog(isListener bool) *accesslog.AccessLog {
 	}
 }
 
-func buildHTTPGrpcAccessLog() *accesslog.AccessLog {
+func httpGrpcAccessLog() *accesslog.AccessLog {
 	fl := &grpcaccesslog.HttpGrpcAccessLogConfig{
 		CommonConfig: &grpcaccesslog.CommonGrpcAccessLogConfig{
 			LogName: httpEnvoyAccessLogFriendlyName,

--- a/pilot/pkg/networking/core/v1alpha3/accesslog_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/accesslog_test.go
@@ -391,6 +391,19 @@ func TestBuildAccessLogFromTelemetry(t *testing.T) {
 		},
 	}
 
+	defaultEnvoyProvider := &model.LoggingConfig{
+		Providers: []*meshconfig.MeshConfig_ExtensionProvider{
+			{
+				Name: "envoy",
+				Provider: &meshconfig.MeshConfig_ExtensionProvider_EnvoyFileAccessLog{
+					EnvoyFileAccessLog: &meshconfig.MeshConfig_ExtensionProvider_EnvoyFileAccessLogProvider{
+						Path: "/dev/stdout",
+					},
+				},
+			},
+		},
+	}
+
 	grpcBackendClusterName := "outbound|9811||grpc-als.foo.svc.cluster.local"
 	grpcBackendAuthority := "grpc-als.foo.svc.cluster.local"
 	otelCfg := &otelaccesslog.OpenTelemetryAccessLogConfig{
@@ -548,6 +561,8 @@ func TestBuildAccessLogFromTelemetry(t *testing.T) {
 			FilterStateObjectsToLog: fakeFilterStateObjects,
 		},
 	}
+
+	defaultFormatJSON, _ := protomarshal.ToJSON(EnvoyJSONLogFormatIstio)
 
 	ctx := model.NewPushContext()
 	ctx.ServiceIndex.HostnameAndNamespace["otel-collector.foo.svc.cluster.local"] = map[string]*model.Service{
@@ -807,9 +822,40 @@ func TestBuildAccessLogFromTelemetry(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "default-envoy-provider",
+			ctx:  ctx,
+			meshConfig: &meshconfig.MeshConfig{
+				AccessLogEncoding: meshconfig.MeshConfig_JSON,
+				AccessLogFormat:   defaultFormatJSON,
+				ExtensionProviders: []*meshconfig.MeshConfig_ExtensionProvider{
+					{
+						Name: "envoy",
+						Provider: &meshconfig.MeshConfig_ExtensionProvider_EnvoyFileAccessLog{
+							EnvoyFileAccessLog: &meshconfig.MeshConfig_ExtensionProvider_EnvoyFileAccessLogProvider{
+								Path: "/dev/stdout",
+							},
+						},
+					},
+				},
+			},
+			spec:        defaultEnvoyProvider,
+			forListener: false,
+			expected: []*accesslog.AccessLog{
+				{
+					Name:       wellknown.FileAccessLog,
+					ConfigType: &accesslog.AccessLog_TypedConfig{TypedConfig: util.MessageToAny(defaultJSONLabelsOut)},
+				},
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			got := buildAccessLogFromTelemetry(tc.ctx, tc.spec, tc.forListener)
+			ctx := tc.ctx
+			if ctx == nil {
+				ctx = model.NewPushContext()
+			}
+			ctx.Mesh = tc.meshConfig
+			got := buildAccessLogFromTelemetry(ctx, tc.spec, tc.forListener)
 
 			assert.Equal(t, tc.expected, got)
 		})


### PR DESCRIPTION
As mentioned https://github.com/istio/istio/pull/36604#issuecomment-1165182725 Istio behaviour is changed when telemetry specifies default accesslog provider("envoy"). We loose the benefit of using mesh config defaults when logFormat is not specified.

This PR brings back that behaviour.

Also changed some function names to avoid confusion.

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure