### PR TITLE
Replace deprecated ioutil pkg with os & io

### DIFF
--- a/pkg/istio-agent/agent_test.go
+++ b/pkg/istio-agent/agent_test.go
@@ -20,7 +20,6 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path"
@@ -579,7 +578,7 @@ func TestAgent(t *testing.T) {
 	})
 	t.Run("GCP", func(t *testing.T) {
 		os.MkdirAll(filepath.Join(wd, "var/run/secrets/tokens"), 0o755)
-		ioutil.WriteFile(filepath.Join(wd, "var/run/secrets/tokens/istio-token"), []byte("test-token"), 0o644)
+		os.WriteFile(filepath.Join(wd, "var/run/secrets/tokens/istio-token"), []byte("test-token"), 0o644)
 		a := Setup(t, func(a AgentTest) AgentTest {
 			a.envoyEnable = true
 			a.enableSTS = true

--- a/pkg/test/framework/components/authz/kube.go
+++ b/pkg/test/framework/components/authz/kube.go
@@ -16,7 +16,7 @@ package authz
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"time"
 
@@ -129,7 +129,7 @@ func newKubeServer(ctx resource.Context, ns namespace.Instance) (server *serverI
 func readDeploymentYAML(ctx resource.Context) (string, error) {
 	// Read the samples file.
 	filePath := fmt.Sprintf("%s/samples/extauthz/ext-authz.yaml", env.IstioSrc)
-	data, err := ioutil.ReadFile(filePath)
+	data, err := os.ReadFile(filePath)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/wasm/httpfetcher.go
+++ b/pkg/wasm/httpfetcher.go
@@ -22,7 +22,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"time"
 
@@ -156,7 +155,7 @@ func getFileFromGZ(b []byte) []byte {
 		return nil
 	}
 
-	ret, err := ioutil.ReadAll(zr)
+	ret, err := io.ReadAll(zr)
 	if err != nil {
 		return nil
 	}

--- a/tools/docker-builder/builder/crane.go
+++ b/tools/docker-builder/builder/crane.go
@@ -19,7 +19,6 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 	"sync"
 	"time"
@@ -208,7 +207,7 @@ func Build(b BuildSpec) error {
 		sz := ByteCount(int64(buf.Len()))
 
 		l, err := tarball.LayerFromOpener(func() (io.ReadCloser, error) {
-			return ioutil.NopCloser(bytes.NewReader(buf.Bytes())), nil
+			return io.NopCloser(bytes.NewReader(buf.Bytes())), nil
 		}, tarball.WithCompressionLevel(compression))
 		if err != nil {
 			return err

--- a/tools/docker-builder/main.go
+++ b/tools/docker-builder/main.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -131,7 +130,7 @@ func ValidateArgs(a Args) error {
 }
 
 func ReadPlanTargets() ([]string, []string, error) {
-	by, err := ioutil.ReadFile(filepath.Join(testenv.IstioSrc, "tools", "docker.yaml"))
+	by, err := os.ReadFile(filepath.Join(testenv.IstioSrc, "tools", "docker.yaml"))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -152,7 +151,7 @@ func ReadPlanTargets() ([]string, []string, error) {
 }
 
 func ReadPlan(a Args) (Args, error) {
-	by, err := ioutil.ReadFile(filepath.Join(testenv.IstioSrc, "tools", "docker.yaml"))
+	by, err := os.ReadFile(filepath.Join(testenv.IstioSrc, "tools", "docker.yaml"))
 	if err != nil {
 		return a, err
 	}


### PR DESCRIPTION
**Please provide a description of this PR:**
As of Go 1.16, the same functionality is now provided by package io or
package os, and those implementations should be preferred in new code.

So replacing all usage of ioutil pkg with io & os.



More of a code quality chore.