### PR TITLE
Fix logging in getProxyServiceInstancesFromMetadata

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -1249,7 +1249,7 @@ func (c *Controller) getProxyServiceInstancesFromMetadata(proxy *model.Proxy) ([
 		return nil, fmt.Errorf("error getting instances for %s: %v", proxy.ID, err)
 	}
 	if len(services) == 0 {
-		return nil, fmt.Errorf("no instances found for %s: %v", proxy.ID, err)
+		return nil, fmt.Errorf("no instances found for %s", proxy.ID)
 	}
 
 	out := make([]*model.ServiceInstance, 0)


### PR DESCRIPTION
Signed-off-by: Jacek Ewertowski <jewertow@redhat.com>

**Please provide a description of this PR:**

This change removes `err` variable from returned error, because it's always `nil`.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [X] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
