### PR TITLE
Fix TestExtraConfigmap test flakes

### DIFF
--- a/pkg/config/mesh/kubemesh/watcher.go
+++ b/pkg/config/mesh/kubemesh/watcher.go
@@ -57,7 +57,7 @@ func NewConfigMapWatcher(client kube.Client, namespace, name, key string, multiW
 	go c.Run(stop)
 
 	// Ensure the ConfigMap is initially loaded if present.
-	if !kube.WaitForCacheSync(stop, c.HasSynced) {
+	if !client.WaitForCacheSync(stop, c.HasSynced) {
 		log.Error("failed to wait for cache sync")
 	}
 	return w
@@ -70,7 +70,7 @@ func AddUserMeshConfig(client kube.Client, watcher mesh.Watcher, namespace, key,
 	})
 
 	go c.Run(stop)
-	if !kube.WaitForCacheSync(stop, c.HasSynced) {
+	if !client.WaitForCacheSync(stop, c.HasSynced) {
 		log.Error("failed to wait for cache sync")
 	}
 }

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -142,6 +142,9 @@ type Client interface {
 	// Warning: this must be called AFTER .Informer() is called, which will register the informer.
 	RunAndWait(stop <-chan struct{})
 
+	// WaitForCacheSync waits for all cache functions to sync, as well as all informers started by the *fake* client.
+	WaitForCacheSync(stop <-chan struct{}, cacheSyncs ...cache.InformerSynced) bool
+
 	// GetKubernetesVersion returns the Kubernetes server version
 	GetKubernetesVersion() (*kubeVersion.Info, error)
 }
@@ -616,6 +619,16 @@ func WaitForCacheSync(stop <-chan struct{}, cacheSyncs ...cache.InformerSynced) 
 		case <-time.After(delay):
 		}
 	}
+}
+
+// WaitForCacheSync is a specialized version of the general WaitForCacheSync function which also
+// handles fake client syncing.
+// This is only required in cases where fake clients are used without RunAndWait.
+func (c *client) WaitForCacheSync(stop <-chan struct{}, cacheSyncs ...cache.InformerSynced) bool {
+	syncFns := append(cacheSyncs, func() bool {
+		return c.informerWatchesPending.Load() == 0
+	})
+	return WaitForCacheSync(stop, syncFns...)
 }
 
 func fastWaitForCacheSyncDynamic(stop <-chan struct{}, informerFactory dynamicInformerSync) {

--- a/pkg/kube/mock_client.go
+++ b/pkg/kube/mock_client.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/client-go/metadata/metadatainformer"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/rest/fake"
+	"k8s.io/client-go/tools/cache"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
 	"k8s.io/kubectl/pkg/cmd/util"
 	serviceapisclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
@@ -77,6 +78,10 @@ type MockClient struct {
 	IstioVersions     *version.MeshInfo
 	KubernetesVersion uint
 	IstiodVersion     string
+}
+
+func (c MockClient) WaitForCacheSync(stop <-chan struct{}, cacheSyncs ...cache.InformerSynced) bool {
+	return WaitForCacheSync(stop, cacheSyncs...)
 }
 
 func (c MockClient) ExtInformer() kubeExtInformers.SharedInformerFactory {


### PR DESCRIPTION
The problem is k8s fake client has race conditions; we have a workaround
that applies ~everywhere else, but since this informer is only watching
a single configmap by name it doesn't use RunAndWait so it misses our
fix.

Fixes https://github.com/istio/istio/issues/39620

**Please provide a description of this PR:**



**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
