### PR TITLE
tf: avoid using pointer when no mutation is used

### DIFF
--- a/tests/integration/security/ca_custom_root/multi_root_test.go
+++ b/tests/integration/security/ca_custom_root/multi_root_test.go
@@ -56,7 +56,7 @@ func TestMultiRootSetup(t *testing.T) {
 								Address: to.Config().Service,
 								Scheme:  s,
 							}
-							opts.Check = check.And(check.OK(), scheck.ReachedClusters(t, &opts))
+							opts.Check = check.And(check.OK(), scheck.ReachedClusters(t, opts))
 
 							from.CallOrFail(t, opts)
 						})

--- a/tests/integration/security/ca_custom_root/secure_naming_test.go
+++ b/tests/integration/security/ca_custom_root/secure_naming_test.go
@@ -99,7 +99,9 @@ spec:
 // - The certificate issued by CA to the sidecar is as expected and that strict mTLS works as expected.
 // - The plugin CA certs are correctly used in workload mTLS.
 // - The CA certificate in the configmap of each namespace is as expected, which
-//   is used for data plane to control plane TLS authentication.
+//
+//	is used for data plane to control plane TLS authentication.
+//
 // - Secure naming information is respected in the mTLS handshake.
 func TestSecureNaming(t *testing.T) {
 	framework.NewTest(t).
@@ -132,7 +134,7 @@ func TestSecureNaming(t *testing.T) {
 									Name: "http",
 								},
 							}
-							opts.Check = check.And(check.OK(), scheck.ReachedClusters(t, &opts))
+							opts.Check = check.And(check.OK(), scheck.ReachedClusters(t, opts))
 							a.CallOrFail(t, opts)
 						})
 
@@ -175,7 +177,7 @@ func TestSecureNaming(t *testing.T) {
 									},
 								}
 								if tc.expectSuccess {
-									opts.Check = check.And(check.OK(), scheck.ReachedClusters(t, &opts))
+									opts.Check = check.And(check.OK(), scheck.ReachedClusters(t, opts))
 								} else {
 									opts.Check = scheck.NotOK()
 								}

--- a/tests/integration/security/ca_custom_root/trust_domain_alias_secure_naming_test.go
+++ b/tests/integration/security/ca_custom_root/trust_domain_alias_secure_naming_test.go
@@ -56,7 +56,9 @@ spec:
 //
 // Setup:
 // 1. Setup Istio with custom CA cert. This is because we need to use that root cert to sign customized
-//    certificate for server workloads to give them different trust domains.
+//
+//	certificate for server workloads to give them different trust domains.
+//
 // 2. One client workload with sidecar injected.
 // 3. Two naked server workloads with custom certs whose URI SAN have different SPIFFE trust domains.
 // 4. PeerAuthentication with strict mtls, to enforce the mtls connection.
@@ -94,7 +96,7 @@ func TestTrustDomainAliasSecureNaming(t *testing.T) {
 								Scheme:  s,
 							}
 							if success {
-								opts.Check = check.And(check.OK(), scheck.ReachedClusters(t, &opts))
+								opts.Check = check.And(check.OK(), scheck.ReachedClusters(t, opts))
 							} else {
 								opts.Check = scheck.NotOK()
 							}

--- a/tests/integration/security/external_ca/reachability_test.go
+++ b/tests/integration/security/external_ca/reachability_test.go
@@ -55,7 +55,7 @@ func TestReachability(t *testing.T) {
 							Name: "http",
 						},
 					}
-					opts.Check = check.And(check.OK(), scheck.ReachedClusters(t, &opts))
+					opts.Check = check.And(check.OK(), scheck.ReachedClusters(t, opts))
 
 					from.CallOrFail(t, opts)
 				})

--- a/tests/integration/security/https_jwt/https_jwt_test.go
+++ b/tests/integration/security/https_jwt/https_jwt_test.go
@@ -79,7 +79,7 @@ func TestJWTHTTPS(t *testing.T) {
 						opts.HTTP.Headers = headers.New().WithAuthz(jwt.TokenIssuer1).Build()
 						opts.Check = check.And(
 							check.OK(),
-							scheck.ReachedClusters(t, opts),
+							scheck.ReachedClusters(t, *opts),
 							check.RequestHeaders(map[string]string{
 								headers.Authorization: "Bearer " + jwt.TokenIssuer1,
 								"X-Test-Payload":      payload1,

--- a/tests/integration/security/jwt_test.go
+++ b/tests/integration/security/jwt_test.go
@@ -121,7 +121,7 @@ func TestRequestAuthentication(t *testing.T) {
 						opts.HTTP.Headers = headers.New().WithAuthz(jwt.TokenIssuer1).Build()
 						opts.Check = check.And(
 							check.OK(),
-							scheck.ReachedClusters(t, opts),
+							scheck.ReachedClusters(t, *opts),
 							check.RequestHeaders(map[string]string{
 								headers.Authorization: "",
 								"X-Test-Payload":      payload1,
@@ -135,7 +135,7 @@ func TestRequestAuthentication(t *testing.T) {
 						opts.HTTP.Headers = headers.New().WithAuthz(jwt.TokenIssuer2).Build()
 						opts.Check = check.And(
 							check.OK(),
-							scheck.ReachedClusters(t, opts),
+							scheck.ReachedClusters(t, *opts),
 							check.RequestHeaders(map[string]string{
 								headers.Authorization: "",
 								"X-Test-Payload":      payload2,
@@ -162,7 +162,7 @@ func TestRequestAuthentication(t *testing.T) {
 							Build()
 						opts.Check = check.And(
 							check.OK(),
-							scheck.ReachedClusters(t, opts))
+							scheck.ReachedClusters(t, *opts))
 					},
 				},
 				{
@@ -184,7 +184,7 @@ func TestRequestAuthentication(t *testing.T) {
 						opts.HTTP.Path = "/no-token-noauthz"
 						opts.Check = check.And(
 							check.OK(),
-							scheck.ReachedClusters(t, opts))
+							scheck.ReachedClusters(t, *opts))
 					},
 				},
 			}))
@@ -197,7 +197,7 @@ func TestRequestAuthentication(t *testing.T) {
 						opts.HTTP.Headers = headers.New().WithAuthz(jwt.TokenIssuer1).Build()
 						opts.Check = check.And(
 							check.OK(),
-							scheck.ReachedClusters(t, opts),
+							scheck.ReachedClusters(t, *opts),
 							check.RequestHeader(headers.Authorization, ""))
 					},
 				},
@@ -225,7 +225,7 @@ func TestRequestAuthentication(t *testing.T) {
 						opts.HTTP.Path = "/no-authn-authz"
 						opts.Check = check.And(
 							check.OK(),
-							scheck.ReachedClusters(t, opts))
+							scheck.ReachedClusters(t, *opts))
 					},
 				},
 			}))
@@ -238,7 +238,7 @@ func TestRequestAuthentication(t *testing.T) {
 						opts.HTTP.Headers = headers.New().WithAuthz(jwt.TokenIssuer1).Build()
 						opts.Check = check.And(
 							check.OK(),
-							scheck.ReachedClusters(t, opts),
+							scheck.ReachedClusters(t, *opts),
 							check.RequestHeaders(map[string]string{
 								headers.Authorization: "Bearer " + jwt.TokenIssuer1,
 								"X-Test-Payload":      payload1,
@@ -255,7 +255,7 @@ func TestRequestAuthentication(t *testing.T) {
 						opts.HTTP.Headers = headers.New().WithAuthz(jwt.TokenIssuer1).Build()
 						opts.Check = check.And(
 							check.OK(),
-							scheck.ReachedClusters(t, opts),
+							scheck.ReachedClusters(t, *opts),
 							check.RequestHeaders(map[string]string{
 								headers.Authorization: "Bearer " + jwt.TokenIssuer1,
 								"X-Test-Payload":      payload1,
@@ -280,7 +280,7 @@ func TestRequestAuthentication(t *testing.T) {
 						opts.HTTP.Headers = headers.New().WithAuthz(jwt.TokenIssuer1WithAud).Build()
 						opts.Check = check.And(
 							check.OK(),
-							scheck.ReachedClusters(t, opts))
+							scheck.ReachedClusters(t, *opts))
 					},
 				},
 				{
@@ -290,7 +290,7 @@ func TestRequestAuthentication(t *testing.T) {
 						opts.HTTP.Headers = headers.New().WithAuthz(jwt.TokenIssuer2).Build()
 						opts.Check = check.And(
 							check.OK(),
-							scheck.ReachedClusters(t, opts))
+							scheck.ReachedClusters(t, *opts))
 					},
 				},
 			}))
@@ -318,7 +318,7 @@ func TestRequestAuthentication(t *testing.T) {
 						opts.HTTP.Path = "/invalid-jwks-no-token-noauthz"
 						opts.Check = check.And(
 							check.OK(),
-							scheck.ReachedClusters(t, opts))
+							scheck.ReachedClusters(t, *opts))
 					},
 				},
 			}))
@@ -330,7 +330,7 @@ func TestRequestAuthentication(t *testing.T) {
 						opts.HTTP.Path = "/valid-token?token=" + jwt.TokenIssuer1
 						opts.Check = check.And(
 							check.OK(),
-							scheck.ReachedClusters(t, opts))
+							scheck.ReachedClusters(t, *opts))
 					},
 				},
 				{
@@ -339,7 +339,7 @@ func TestRequestAuthentication(t *testing.T) {
 						opts.HTTP.Path = "/valid-token?secondary_token=" + jwt.TokenIssuer1
 						opts.Check = check.And(
 							check.OK(),
-							scheck.ReachedClusters(t, opts))
+							scheck.ReachedClusters(t, *opts))
 					},
 				},
 				{
@@ -355,7 +355,7 @@ func TestRequestAuthentication(t *testing.T) {
 						opts.HTTP.Path = "/valid-token?token=" + jwt.TokenIssuer1 + "&secondary_token=" + jwt.TokenIssuer1
 						opts.Check = check.And(
 							check.OK(),
-							scheck.ReachedClusters(t, opts))
+							scheck.ReachedClusters(t, *opts))
 					},
 				},
 				{
@@ -374,7 +374,7 @@ func TestRequestAuthentication(t *testing.T) {
 							Build()
 						opts.Check = check.And(
 							check.OK(),
-							scheck.ReachedClusters(t, opts))
+							scheck.ReachedClusters(t, *opts))
 					},
 				},
 				{
@@ -386,7 +386,7 @@ func TestRequestAuthentication(t *testing.T) {
 							Build()
 						opts.Check = check.And(
 							check.OK(),
-							scheck.ReachedClusters(t, opts))
+							scheck.ReachedClusters(t, *opts))
 					},
 				},
 				{
@@ -476,7 +476,7 @@ func TestIngressRequestAuthentication(t *testing.T) {
 					customizeCall: func(t framework.TestContext, from echo.Instance, opts *echo.CallOptions) {
 						opts.Check = check.And(
 							check.OK(),
-							scheck.ReachedClusters(t, opts))
+							scheck.ReachedClusters(t, *opts))
 					},
 				},
 			}))

--- a/tests/integration/security/util/reachability/context.go
+++ b/tests/integration/security/util/reachability/context.go
@@ -171,7 +171,7 @@ func Run(testCases []TestCase, t framework.TestContext, apps *util.EchoDeploymen
 									tpe = "positive"
 									opts.Check = check.And(
 										check.OK(),
-										scheck.ReachedClusters(t, &opts))
+										scheck.ReachedClusters(t, opts))
 									if expectMTLS {
 										opts.Check = check.And(opts.Check,
 											check.MTLSForHTTP())

--- a/tests/integration/security/util/scheck/checkers.go
+++ b/tests/integration/security/util/scheck/checkers.go
@@ -39,7 +39,7 @@ func NotOK() echo.Checker {
 	}))
 }
 
-func ReachedClusters(t framework.TestContext, opts *echo.CallOptions) echo.Checker {
+func ReachedClusters(t framework.TestContext, opts echo.CallOptions) echo.Checker {
 	// TODO(https://github.com/istio/istio/issues/37307): Investigate why we don't reach all clusters.
 	if opts.To.Clusters().IsMulticluster() && opts.Count > 1 && opts.Scheme != scheme.GRPC && !opts.To.Config().IsHeadless() {
 		return check.ReachedTargetClusters(t)


### PR DESCRIPTION
Just minor formatting. This is less of a good idea than I originally
thought since we are often passing from customizeCall which has a
pointer, but I still think its useful to pass a non-pointer since
otherwise it looks like we are going to mutate things.

**Please provide a description of this PR:**