### PR TITLE
Fix: allow enableNamespacesByDefault when revision tag is set

### DIFF
--- a/operator/cmd/mesh/install.go
+++ b/operator/cmd/mesh/install.go
@@ -215,7 +215,7 @@ func Install(rootArgs *RootArgs, iArgs *InstallArgs, logOpts *log.Options, stdOu
 	if !exists || rev == "" && pilotEnabled {
 		p.Println("Making this installation the default for injection and validation.")
 		if rev == "" {
-			rev = revtag.DefaultRevisionName
+			o.Revision = revtag.DefaultRevisionName
 		}
 	}
 

--- a/operator/cmd/mesh/install.go
+++ b/operator/cmd/mesh/install.go
@@ -207,7 +207,7 @@ func Install(rootArgs *RootArgs, iArgs *InstallArgs, logOpts *log.Options, stdOu
 		rev = revtag.DefaultRevisionName
 	}
 
-	if exists {
+	if exists && pilotEnabled {
 		whs, err := revtag.GetWebhooksWithTag(context.Background(), kubeClient.Kube(), revtag.DefaultRevisionName)
 		if err != nil {
 			return fmt.Errorf("failed to get webhook with default tag: %v", err)

--- a/releasenotes/notes/39674.yaml
+++ b/releasenotes/notes/39674.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+issue:
+  - https://github.com/istio/istio/issues/39604
+releaseNotes:
+  - |
+    **Fixed** if a previous installation existed and a revision was used, users
+    couldn't opt-in automatic sidecar injection by changing .Values.enableNamespacesByDefault setting.


### PR DESCRIPTION
**Please provide a description of this PR:**
If a previous installation existed and revision tag is used, users can't change the _enableNamespacesByDefault_ setting.
- https://github.com/istio/istio/issues/39604