### PR TITLE
[tf] Avoid potential panic in ReachedTargetClusters

### DIFF
--- a/pkg/test/framework/components/echo/check/checkers.go
+++ b/pkg/test/framework/components/echo/check/checkers.go
@@ -370,10 +370,19 @@ func URL(expected string) echo.Checker {
 	})
 }
 
+func isDNSCaptureEnabled(t framework.TestContext) bool {
+	t.Helper()
+	mc := istio.GetOrFail(t, t).MeshConfigOrFail(t)
+	if mc.DefaultConfig != nil && mc.DefaultConfig.ProxyMetadata != nil {
+		return mc.DefaultConfig.ProxyMetadata["ISTIO_META_DNS_CAPTURE"] == "true"
+	}
+	return false
+}
+
 // ReachedTargetClusters is similar to ReachedClusters, except that the set of expected clusters is
 // retrieved from the Target of the request.
 func ReachedTargetClusters(t framework.TestContext) echo.Checker {
-	dnsCaptureEnabled := istio.GetOrFail(t, t).MeshConfigOrFail(t).DefaultConfig.ProxyMetadata["ISTIO_META_DNS_CAPTURE"] == "true"
+	dnsCaptureEnabled := isDNSCaptureEnabled(t)
 	return func(result echo.CallResult, err error) error {
 		from := result.From
 		to := result.Opts.To


### PR DESCRIPTION
We recently introduced additional logic to optionally limit the clusters checked for headless services based on MeshConfig settings.

This PR adds additional protection to avoid a potential panic when inspecting the MeshConfig.

**Please provide a description of this PR:**