### PR TITLE
bugfix(accesslog): allow different provider between modes

### DIFF
--- a/pilot/pkg/model/telemetry.go
+++ b/pilot/pkg/model/telemetry.go
@@ -463,7 +463,7 @@ func mergeLogs(logs []*tpb.AccessLogging, mesh *meshconfig.MeshConfig, mode tpb.
 	providerNames := mesh.GetDefaultProviders().GetAccessLogging()
 	for _, m := range logs {
 		names := getProviderNames(m.Providers)
-		if len(names) > 0 {
+		if len(names) > 0 && matchWorkloadMode(m.Match, mode) {
 			providerNames = names
 		}
 

--- a/pilot/pkg/model/telemetry_test.go
+++ b/pilot/pkg/model/telemetry_test.go
@@ -233,6 +233,30 @@ func TestAccessLogging(t *testing.T) {
 			},
 		},
 	}
+	serverAndClientDifferent := &tpb.Telemetry{
+		AccessLogging: []*tpb.AccessLogging{
+			{
+				Match: &tpb.AccessLogging_LogSelector{
+					Mode: tpb.WorkloadMode_SERVER,
+				},
+				Providers: []*tpb.ProviderRef{
+					{
+						Name: "envoy",
+					},
+				},
+			},
+			{
+				Match: &tpb.AccessLogging_LogSelector{
+					Mode: tpb.WorkloadMode_CLIENT,
+				},
+				Providers: []*tpb.ProviderRef{
+					{
+						Name: "stackdriver",
+					},
+				},
+			},
+		},
+	}
 	stackdriver := &tpb.Telemetry{
 		AccessLogging: []*tpb.AccessLogging{
 			{
@@ -403,6 +427,22 @@ func TestAccessLogging(t *testing.T) {
 			sidecar,
 			nil,
 			[]string{"envoy"},
+		},
+		{
+			"server and client different - inbound",
+			[]config.Config{newTelemetry("istio-system", serverAndClientDifferent)},
+			networking.ListenerClassSidecarInbound,
+			sidecar,
+			nil,
+			[]string{"envoy"},
+		},
+		{
+			"server and client different - outbound",
+			[]config.Config{newTelemetry("istio-system", serverAndClientDifferent)},
+			networking.ListenerClassSidecarOutbound,
+			sidecar,
+			nil,
+			[]string{"stackdriver"},
 		},
 		{
 			"override default",


### PR DESCRIPTION
**Please provide a description of this PR:**

Take workload's mode into consideration, when compute inScopeProviders.
So, we can allow user config different access log providers for different mode.

This maybe what we expected.




**Please check any characteristics that apply to this pull request.**

- [] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.