### PR TITLE
Make istio-cni compatible with Talos Linux (go netns implementation + added ca cert path)

### DIFF
--- a/cni/cmd/istio-cni/main.go
+++ b/cni/cmd/istio-cni/main.go
@@ -42,11 +42,16 @@ func main() {
 		_ = log.Sync()
 	}()
 
-	// configure-routes allows setting up the iproute2 configuration. This is called standalone because
-	// we cannot change network namespaces safely within a go program (see https://www.weave.works/blog/linux-namespaces-and-go-don-t-mix).
+	// configure-routes allows setting up the iproute2 configuration.
+	// This is an old workaround and kept in place to preserve old behavior.
+	// It is called standalone when HostNSEnterExec=true.
+	// Default behavior is to use go netns, which is not in need for this:
+
+	// Older versions of Go < 1.10 cannot change network namespaces safely within a go program
+	// (see https://www.weave.works/blog/linux-namespaces-and-go-don-t-mix).
 	// As a result, the flow is:
 	// * CNI plugin is called with no args, skipping this section.
-	// * CNI code invokes iptables code with CNIMode=true. This in turn runs nsenter -- istio-cni configure-routes
+	// * CNI code invokes iptables code with CNIMode=true. This in turn runs 'nsenter -- istio-cni configure-routes'
 	if len(os.Args) > 1 && os.Args[1] == constants.CommandConfigureRoutes {
 		if err := cmd.GetRouteCommand().Execute(); err != nil {
 			log.Errorf("failed to configure routes: %v", err)

--- a/cni/pkg/config/config.go
+++ b/cni/pkg/config/config.go
@@ -79,6 +79,9 @@ type InstallConfig struct {
 
 	// The UDS server address that CNI plugin will send log to.
 	LogUDSAddress string
+
+	// Use the external nsenter command for network namespace switching
+	HostNSEnterExec bool
 }
 
 // RepairConfig struct defines the Istio CNI race repair configuration
@@ -140,6 +143,8 @@ func (c InstallConfig) String() string {
 	b.WriteString("SkipCNIBinaries: " + fmt.Sprint(c.SkipCNIBinaries) + "\n")
 	b.WriteString("MonitoringPort: " + fmt.Sprint(c.MonitoringPort) + "\n")
 	b.WriteString("LogUDSAddress: " + fmt.Sprint(c.LogUDSAddress) + "\n")
+	b.WriteString("HostNSEnterExec: " + fmt.Sprint(c.HostNSEnterExec) + "\n")
+
 	return b.String()
 }
 

--- a/cni/pkg/plugin/iptables_linux.go
+++ b/cni/pkg/plugin/iptables_linux.go
@@ -34,6 +34,7 @@ var getNs = ns.GetNS
 // provided in Redirect.
 func (ipt *iptables) Program(podName, netns string, rdrct *Redirect) error {
 	viper.Set(constants.CNIMode, true)
+	viper.Set(constants.HostNSEnterExec, rdrct.hostNSEnterExec)
 	viper.Set(constants.NetworkNamespace, netns)
 	viper.Set(constants.EnvoyPort, rdrct.targetPort)
 	viper.Set(constants.ProxyUID, rdrct.noRedirectUID)

--- a/cni/pkg/plugin/plugin.go
+++ b/cni/pkg/plugin/plugin.go
@@ -75,9 +75,10 @@ type Config struct {
 	PrevResult    *cniv1.Result           `json:"-"`
 
 	// Add plugin-specific flags here
-	LogLevel      string     `json:"log_level"`
-	LogUDSAddress string     `json:"log_uds_address"`
-	Kubernetes    Kubernetes `json:"kubernetes"`
+	LogLevel        string     `json:"log_level"`
+	LogUDSAddress   string     `json:"log_uds_address"`
+	Kubernetes      Kubernetes `json:"kubernetes"`
+	HostNSEnterExec bool       `json:"hostNSEnterExec"`
 }
 
 // K8sArgs is the valid CNI_ARGS used for Kubernetes
@@ -271,6 +272,7 @@ func CmdAdd(args *skel.CmdArgs) (err error) {
 							log.Errorf("Pod redirect failed due to unavailable InterceptRuleMgr of type %s",
 								interceptRuleMgrType)
 						} else {
+							redirect.hostNSEnterExec = conf.HostNSEnterExec
 							rulesMgr := interceptMgrCtor()
 							if err := rulesMgr.Program(podName, args.Netns, redirect); err != nil {
 								return err

--- a/cni/pkg/plugin/redirect.go
+++ b/cni/pkg/plugin/redirect.go
@@ -85,6 +85,7 @@ type Redirect struct {
 	excludeInterfaces    string
 	dnsRedirect          bool
 	invalidDrop          bool
+	hostNSEnterExec      bool
 }
 
 type annotationValidationFunc func(value string) error

--- a/pkg/security/security.go
+++ b/pkg/security/security.go
@@ -443,6 +443,7 @@ func GetOSRootFilePath() string {
 		"/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem", // CentOS/RHEL 7
 		"/etc/ssl/cert.pem",                                 // Alpine Linux
 		"/usr/local/etc/ssl/cert.pem",                       // FreeBSD
+		"/etc/ssl/certs/ca-certificates",                    // Talos Linux
 	}
 
 	for _, cert := range certFiles {

--- a/releasenotes/notes/39699.yaml
+++ b/releasenotes/notes/39699.yaml
@@ -1,0 +1,35 @@
+apiVersion: release-notes/v2
+
+# This YAML file describes the format for specifying a release notes entry for Istio.
+# This should be filled in for all user facing changes.
+
+# kind describes the type of change that this represents.
+# Valid Values are:
+# - bug-fix -- Used to specify that this change represents a bug fix.
+# - security-fix -- Used to specify that this change represents a vulnerability fix.
+# - feature -- Used to specify a new feature that has been added.
+# - test -- Used to describe additional testing added. This file is optional for
+#   tests, but included for completeness.
+kind: feature
+
+# area describes the area that this change affects.
+# Valid values are:
+# - traffic-management
+# - security
+# - telemetry
+# - installation
+# - istioctl
+# - documentation
+area: traffic-management
+
+# issue is a list of GitHub issues resolved in this note.
+# If issue is not in the current repo, specify its full URL instead.
+issue:
+  - 38794
+
+# releaseNotes is a markdown listing of any user facing changes. This will appear in the
+# release notes.
+releaseNotes:
+- |
+  **Improved** compatibility with minimal host OSses like Talos OS (without nsenter binary). Changes Network namespaces with internal go routines.
+  cni.conf flag HostNSEnterExec reverts to old behavior with use of nsenter.

--- a/tools/istio-iptables/pkg/cmd/root.go
+++ b/tools/istio-iptables/pkg/cmd/root.go
@@ -65,6 +65,7 @@ var rootCmd = &cobra.Command{
 		} else {
 			ext = &dep.RealDependencies{
 				CNIMode:          cfg.CNIMode,
+				HostNSEnterExec:  cfg.HostNSEnterExec,
 				NetworkNamespace: cfg.NetworkNamespace,
 			}
 		}
@@ -142,6 +143,7 @@ func constructConfig() *config.Config {
 		OutputPath:              viper.GetString(constants.OutputPath),
 		NetworkNamespace:        viper.GetString(constants.NetworkNamespace),
 		CNIMode:                 viper.GetBool(constants.CNIMode),
+		HostNSEnterExec:         viper.GetBool(constants.HostNSEnterExec),
 	}
 
 	// TODO: Make this more configurable, maybe with an allowlist of users to be captured for output instead of a denylist.
@@ -372,6 +374,11 @@ func bindFlags(cmd *cobra.Command, args []string) {
 		handleError(err)
 	}
 	viper.SetDefault(constants.CNIMode, false)
+
+	if err := viper.BindPFlag(constants.HostNSEnterExec, cmd.Flags().Lookup(constants.HostNSEnterExec)); err != nil {
+		handleError(err)
+	}
+	viper.SetDefault(constants.HostNSEnterExec, false)
 }
 
 // https://github.com/spf13/viper/issues/233.
@@ -458,6 +465,8 @@ func bindCmdlineFlags(rootCmd *cobra.Command) {
 	rootCmd.Flags().String(constants.NetworkNamespace, "", "The network namespace that iptables rules should be applied to.")
 
 	rootCmd.Flags().Bool(constants.CNIMode, false, "Whether to run as CNI plugin.")
+
+	rootCmd.Flags().Bool(constants.HostNSEnterExec, false, "Instead of using the internal go netns, use the nsenter command for switching network namespaces.")
 }
 
 func GetCommand() *cobra.Command {

--- a/tools/istio-iptables/pkg/config/config.go
+++ b/tools/istio-iptables/pkg/config/config.go
@@ -60,6 +60,7 @@ type Config struct {
 	OutputPath              string        `json:"OUTPUT_PATH"`
 	NetworkNamespace        string        `json:"NETWORK_NAMESPACE"`
 	CNIMode                 bool          `json:"CNI_MODE"`
+	HostNSEnterExec         bool          `json:"HOST_NSENTER_EXEC"`
 	TraceLogging            bool          `json:"IPTABLES_TRACE_LOGGING"`
 }
 
@@ -98,6 +99,7 @@ func (c *Config) Print() {
 	b.WriteString(fmt.Sprintf("OUTPUT_PATH=%s\n", c.OutputPath))
 	b.WriteString(fmt.Sprintf("NETWORK_NAMESPACE=%s\n", c.NetworkNamespace))
 	b.WriteString(fmt.Sprintf("CNI_MODE=%s\n", strconv.FormatBool(c.CNIMode)))
+	b.WriteString(fmt.Sprintf("HOST_NSENTER_EXEC=%s\n", strconv.FormatBool(c.HostNSEnterExec)))
 	b.WriteString(fmt.Sprintf("EXCLUDE_INTERFACES=%s\n", c.ExcludeInterfaces))
 	log.Infof("Istio iptables variables:\n%s", b.String())
 }

--- a/tools/istio-iptables/pkg/constants/constants.go
+++ b/tools/istio-iptables/pkg/constants/constants.go
@@ -108,6 +108,7 @@ const (
 	OutputPath                = "output-paths"
 	NetworkNamespace          = "network-namespace"
 	CNIMode                   = "cni-mode"
+	HostNSEnterExec           = "host-nsenter-exec"
 )
 
 // Environment variables that deliberately have no equivalent command-line flags.


### PR DESCRIPTION
Talos Linux is a purpose build K8s distro is shipped without nsenter, and their ca cert path is different.

This PR adds the correct ca-certificates path for Talos Linux and implements netns in go. This removes the dependency for nsenter entirely.

closes #38794