### PR TITLE
Fixes#39007 x uninstall not removing everything (#39612)

### DIFF
--- a/operator/pkg/helmreconciler/prune.go
+++ b/operator/pkg/helmreconciler/prune.go
@@ -260,6 +260,7 @@ func (h *HelmReconciler) GetPrunedResources(revision string, includeClusterResou
 				string(name.PilotComponentName),
 				string(name.IngressComponentName), string(name.EgressComponentName),
 				string(name.CNIComponentName), string(name.IstioOperatorComponentName),
+				string(name.IstiodRemoteComponentName),
 			}
 			includeRequirement, err := klabels.NewRequirement(IstioComponentLabelStr, selection.In, includeCN)
 			if err != nil {


### PR DESCRIPTION
istioctl uninstall command missing component marked as IstiodRemote

Signed-off-by: Tong Li <litong01@us.ibm.com>

**Please provide a description of this PR:**