### PR TITLE
wips(accesslog): support config omit_empty_values

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -249,3 +249,5 @@ require (
 	sigs.k8s.io/kustomize/kyaml v0.13.6 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
 )
+
+replace istio.io/api => ../api

--- a/go.sum
+++ b/go.sum
@@ -3212,8 +3212,6 @@ honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.5/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.2.1/go.mod h1:lPVVZ2BS5TfnjLyizF7o7hv7j9/L+8cZY2hLyjP9cGY=
-istio.io/api v0.0.0-20220629214140-a0e89271b7ce h1:yKIlJY7rm/3kTZRCLscn7otyxoWQ2RT+DkzjWiKOjs0=
-istio.io/api v0.0.0-20220629214140-a0e89271b7ce/go.mod h1:SJ6R+VKPZwpWnQsNlQL5cVGjAUNm/alk0D/6P5tV+tM=
 istio.io/client-go v1.12.0-alpha.5.0.20220629214839-4675efe7811a h1:g5pUFBZ/Kgke5kJsxfVo2eoMXF0czo8Qi8/A1En+IgU=
 istio.io/client-go v1.12.0-alpha.5.0.20220629214839-4675efe7811a/go.mod h1:XVjAHQhYPrJf14ZvBpNCxbuyA6jeAqX62qmFnyz7ayc=
 istio.io/pkg v0.0.0-20220624133336-1397c6e07673 h1:iQhmf5jj+0mJAHSi9O2aV38z9X6ZdgXA8XMeTuZs0Qc=


### PR DESCRIPTION
**Please provide a description of this PR:**

Allow user config Envoy's [omit_empty_values](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/substitution_format_string.proto#envoy-v3-api-msg-config-core-v3-substitutionformatstring) for accessLog.


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [x] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [x] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [x] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
