### PR TITLE
Revert changes to always notify XdsUpdater in mem discovery

### DIFF
--- a/pilot/pkg/xds/delta_test.go
+++ b/pilot/pkg/xds/delta_test.go
@@ -24,6 +24,7 @@ import (
 	"istio.io/istio/pilot/pkg/xds"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
 	"istio.io/istio/pilot/test/xdstest"
+	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/config/schema/kind"
 )
 
@@ -108,6 +109,11 @@ func TestDeltaEDS(t *testing.T) {
 
 	// update svc, only send the eds for this service
 	s.Discovery.MemRegistry.AddHTTPService(edsIncSvc, "10.10.1.3", 8080)
+	s.Discovery.ConfigUpdate(&model.PushRequest{Full: true, ConfigsUpdated: map[model.ConfigKey]struct{}{{
+		Kind:      gvk.ServiceEntry,
+		Name:      edsIncSvc,
+		Namespace: "",
+	}: {}}})
 
 	resp = ads.ExpectResponse()
 	if len(resp.Resources) != 1 || resp.Resources[0].Name != "outbound|8080||"+edsIncSvc {

--- a/pilot/pkg/xds/delta_test.go
+++ b/pilot/pkg/xds/delta_test.go
@@ -24,7 +24,6 @@ import (
 	"istio.io/istio/pilot/pkg/xds"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
 	"istio.io/istio/pilot/test/xdstest"
-	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/config/schema/kind"
 )
 
@@ -110,7 +109,7 @@ func TestDeltaEDS(t *testing.T) {
 	// update svc, only send the eds for this service
 	s.Discovery.MemRegistry.AddHTTPService(edsIncSvc, "10.10.1.3", 8080)
 	s.Discovery.ConfigUpdate(&model.PushRequest{Full: true, ConfigsUpdated: map[model.ConfigKey]struct{}{{
-		Kind:      gvk.ServiceEntry,
+		Kind:      kind.ServiceEntry,
 		Name:      edsIncSvc,
 		Namespace: "",
 	}: {}}})

--- a/pilot/pkg/xds/eds_test.go
+++ b/pilot/pkg/xds/eds_test.go
@@ -150,7 +150,7 @@ func TestSAUpdate(t *testing.T) {
 		Ports:    ports,
 		Hostname: host.Name("test1"),
 	}
-	s.MemRegistry.AddService(svc)
+	s.MemRegistry.AddServiceNotify(svc)
 	if _, err := ads.Wait(time.Second*10, watchAll...); err != nil {
 		t.Fatal(err)
 	}
@@ -163,7 +163,7 @@ func TestSAUpdate(t *testing.T) {
 			HealthStatus:   model.UnHealthy,
 		},
 	}
-	s.MemRegistry.AddInstance("test1", i)
+	s.MemRegistry.AddInstanceNotify("test1", i)
 	if _, err := ads.Wait(time.Second*10, v3.EndpointType); err != nil {
 		t.Fatal(err)
 	}
@@ -323,39 +323,8 @@ func TestEDSOverlapping(t *testing.T) {
 }
 
 func TestEDSUnhealthyEndpoints(t *testing.T) {
-	svc := &model.Service{
-		Hostname: "unhealthy.svc.cluster.local",
-		Ports: model.PortList{
-			{
-				Name:     "tcp-dns",
-				Port:     53,
-				Protocol: protocol.TCP,
-			},
-		},
-	}
-	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{
-		Services: []*model.Service{svc},
-		Instances: []*model.ServiceInstance{{
-			Endpoint: &model.IstioEndpoint{
-				Address:         "10.0.0.53",
-				EndpointPort:    53,
-				ServicePortName: "tcp-dns",
-				HealthStatus:    model.UnHealthy,
-			},
-			ServicePort: svc.Ports[0],
-			Service:     svc,
-		}},
-	})
-	s.MemRegistry.AddInstance(svc.Hostname, &model.ServiceInstance{
-		Endpoint: &model.IstioEndpoint{
-			Address:         "10.0.0.53",
-			EndpointPort:    53,
-			ServicePortName: "tcp-dns",
-			HealthStatus:    model.UnHealthy,
-		},
-		ServicePort: svc.Ports[0],
-		Service:     svc,
-	})
+	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
+	addUnhealthyCluster(s)
 	adscon := s.Connect(nil, nil, watchEds)
 	_, err := adscon.Wait(5 * time.Second)
 	if err != nil {
@@ -524,18 +493,14 @@ func TestEDSUnhealthyEndpoints(t *testing.T) {
 func TestEDSServiceResolutionUpdate(t *testing.T) {
 	for _, resolution := range []model.Resolution{model.DNSLB, model.DNSRoundRobinLB} {
 		t.Run(fmt.Sprintf("resolution_%s", resolution), func(t *testing.T) {
-			s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{
-				DiscoveryServerModifier: func(s *xds.DiscoveryServer) {
-					addEdsCluster(s, "edsdns.svc.cluster.local", "http", "10.0.0.53", 8080)
-					addEdsCluster(s, "other.local", "http", "1.1.1.1", 8080)
-				},
-			})
+			s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
+			addEdsCluster(s, "edsdns.svc.cluster.local", "http", "10.0.0.53", 8080)
+			addEdsCluster(s, "other.local", "http", "1.1.1.1", 8080)
 
 			adscConn := s.Connect(nil, nil, watchAll)
 
 			// Validate that endpoints are pushed correctly.
 			testEndpoints("10.0.0.53", "outbound|8080||edsdns.svc.cluster.local", adscConn, t)
-			adscConn.WaitClear()
 
 			// Now update the service resolution to DNSLB/DNSRRLB with a DNS endpoint.
 			updateServiceResolution(s, resolution)
@@ -556,7 +521,7 @@ func TestEDSServiceResolutionUpdate(t *testing.T) {
 // Validate that when endpoints of a service flipflop between 1 and 0 does not trigger a full push.
 func TestEndpointFlipFlops(t *testing.T) {
 	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
-	addEdsCluster(s.Discovery, "flipflop.com", "http", "10.0.0.53", 8080)
+	addEdsCluster(s, "flipflop.com", "http", "10.0.0.53", 8080)
 
 	adscConn := s.Connect(nil, nil, watchAll)
 
@@ -612,7 +577,7 @@ func TestEndpointFlipFlops(t *testing.T) {
 // Validate that deleting a service clears entries from EndpointIndex.
 func TestDeleteService(t *testing.T) {
 	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
-	addEdsCluster(s.Discovery, "removeservice.com", "http", "10.0.0.53", 8080)
+	addEdsCluster(s, "removeservice.com", "http", "10.0.0.53", 8080)
 
 	adscConn := s.Connect(nil, nil, watchEds)
 
@@ -733,8 +698,8 @@ func TestZeroEndpointShardSA(t *testing.T) {
 	}
 }
 
-func fullPush(s *xds.DiscoveryServer) {
-	s.Push(&model.PushRequest{Full: true})
+func fullPush(s *xds.FakeDiscoveryServer) {
+	s.Discovery.Push(&model.PushRequest{Full: true})
 }
 
 func addTestClientEndpoints(server *xds.DiscoveryServer) {
@@ -1197,8 +1162,8 @@ func addLocalityEndpoints(server *xds.DiscoveryServer, hostname host.Name) {
 }
 
 // nolint: unparam
-func addEdsCluster(s *xds.DiscoveryServer, hostName string, portName string, address string, port int) {
-	s.MemRegistry.AddService(&model.Service{
+func addEdsCluster(s *xds.FakeDiscoveryServer, hostName string, portName string, address string, port int) {
+	s.Discovery.MemRegistry.AddService(&model.Service{
 		Hostname: host.Name(hostName),
 		Ports: model.PortList{
 			{
@@ -1209,7 +1174,7 @@ func addEdsCluster(s *xds.DiscoveryServer, hostName string, portName string, add
 		},
 	})
 
-	s.MemRegistry.AddInstance(host.Name(hostName), &model.ServiceInstance{
+	s.Discovery.MemRegistry.AddInstance(host.Name(hostName), &model.ServiceInstance{
 		Endpoint: &model.IstioEndpoint{
 			Address:         address,
 			EndpointPort:    uint32(port),
@@ -1250,7 +1215,7 @@ func updateServiceResolution(s *xds.FakeDiscoveryServer, resolution model.Resolu
 		},
 	})
 
-	fullPush(s.Discovery)
+	fullPush(s)
 }
 
 func addOverlappingEndpoints(s *xds.FakeDiscoveryServer) {
@@ -1281,7 +1246,34 @@ func addOverlappingEndpoints(s *xds.FakeDiscoveryServer) {
 			Protocol: protocol.TCP,
 		},
 	})
-	fullPush(s.Discovery)
+	fullPush(s)
+}
+
+func addUnhealthyCluster(s *xds.FakeDiscoveryServer) {
+	s.Discovery.MemRegistry.AddService(&model.Service{
+		Hostname: "unhealthy.svc.cluster.local",
+		Ports: model.PortList{
+			{
+				Name:     "tcp-dns",
+				Port:     53,
+				Protocol: protocol.TCP,
+			},
+		},
+	})
+	s.Discovery.MemRegistry.AddInstance("unhealthy.svc.cluster.local", &model.ServiceInstance{
+		Endpoint: &model.IstioEndpoint{
+			Address:         "10.0.0.53",
+			EndpointPort:    53,
+			ServicePortName: "tcp-dns",
+			HealthStatus:    model.UnHealthy,
+		},
+		ServicePort: &model.Port{
+			Name:     "tcp-dns",
+			Port:     53,
+			Protocol: protocol.TCP,
+		},
+	})
+	fullPush(s)
 }
 
 // Verify the endpoint debug interface is installed and returns some string.

--- a/pilot/pkg/xds/fake.go
+++ b/pilot/pkg/xds/fake.go
@@ -102,7 +102,6 @@ type FakeOptions struct {
 	EnableFakeXDSUpdater       bool
 	DisableSecretAuthorization bool
 	Services                   []*model.Service
-	Instances                  []*model.ServiceInstance
 	Gateways                   []model.NetworkGateway
 }
 
@@ -229,7 +228,6 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 		SkipRun:   true,
 		ClusterID: defaultKubeController.Cluster(),
 		Services:  opts.Services,
-		Instances: opts.Instances,
 		Gateways:  opts.Gateways,
 	})
 	cg.ServiceEntryRegistry.AppendServiceHandler(serviceHandler)
@@ -242,6 +240,7 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 	// Disable debounce to reduce test times
 	s.debounceOptions.debounceAfter = opts.DebounceTime
 	s.MemRegistry = cg.MemRegistry
+	s.MemRegistry.XdsUpdater = s
 	s.updateMutex.Unlock()
 
 	// Setup config handlers
@@ -316,7 +315,6 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 	// Start the discovery server
 	s.Start(stop)
 	cg.ServiceEntryRegistry.XdsUpdater = s
-	s.MemRegistry.XdsUpdater = s
 	// Now that handlers are added, get everything started
 	cg.Run()
 	kubelib.WaitForCacheSync(stop,


### PR DESCRIPTION
This impacts tests only.
In https://github.com/istio/istio/pull/39133 we changed to notify on
writes; this ended up triggering a ton of test flake. Instead, just add
explicit functions to notify (new test needs them) and revert the other changes

**Please provide a description of this PR:**