### PR TITLE
Add split DRs to rds/cds/eds dependent configs

### DIFF
--- a/pilot/pkg/model/config.go
+++ b/pilot/pkg/model/config.go
@@ -271,7 +271,7 @@ func resolveGatewayName(gwname string, meta config.Meta) string {
 
 // MostSpecificHostMatch compares the map of the stack to the needle, and returns the longest element
 // matching the needle, or false if no element in the map matches the needle.
-func MostSpecificHostMatch(needle host.Name, m map[host.Name][]*consolidatedDestRule) (host.Name, bool) {
+func MostSpecificHostMatch(needle host.Name, m map[host.Name][]*ConsolidatedDestRule) (host.Name, bool) {
 	matches := []host.Name{}
 
 	// exact match first

--- a/pilot/pkg/model/destination_rule.go
+++ b/pilot/pkg/model/destination_rule.go
@@ -100,17 +100,17 @@ func (ps *PushContext) mergeDestinationRule(p *consolidatedDestRules, destRuleCo
 			}
 		}
 		if addRuleToProcessedDestRules {
-			p.destRules[resolvedHost] = append(p.destRules[resolvedHost], convertConsolidatedDestRule(&destRuleConfig))
+			p.destRules[resolvedHost] = append(p.destRules[resolvedHost], ConvertConsolidatedDestRule(&destRuleConfig))
 		}
 		return
 	}
 	// DestinationRule does not exist for the resolved host so add it
-	p.destRules[resolvedHost] = append(p.destRules[resolvedHost], convertConsolidatedDestRule(&destRuleConfig))
+	p.destRules[resolvedHost] = append(p.destRules[resolvedHost], ConvertConsolidatedDestRule(&destRuleConfig))
 	p.exportTo[resolvedHost] = exportToMap
 }
 
 // inheritDestinationRule child config inherits settings from parent mesh/namespace
-func (ps *PushContext) inheritDestinationRule(parent, child *consolidatedDestRule) *consolidatedDestRule {
+func (ps *PushContext) inheritDestinationRule(parent, child *ConsolidatedDestRule) *ConsolidatedDestRule {
 	if parent == nil {
 		return child
 	}
@@ -140,15 +140,15 @@ func (ps *PushContext) inheritDestinationRule(parent, child *consolidatedDestRul
 		mergedDR := merged.Spec.(*networking.DestinationRule)
 		mergedDR.TrafficPolicy.Tls = childDR.TrafficPolicy.Tls.DeepCopy()
 	}
-	out := &consolidatedDestRule{}
+	out := &ConsolidatedDestRule{}
 	out.rule = &merged
 	out.from = append(out.from, parent.from...)
 	out.from = append(out.from, child.from...)
 	return out
 }
 
-func convertConsolidatedDestRule(cfg *config.Config) *consolidatedDestRule {
-	return &consolidatedDestRule{
+func ConvertConsolidatedDestRule(cfg *config.Config) *ConsolidatedDestRule {
+	return &ConsolidatedDestRule{
 		rule: cfg,
 		from: []types.NamespacedName{
 			{
@@ -160,7 +160,7 @@ func convertConsolidatedDestRule(cfg *config.Config) *consolidatedDestRule {
 }
 
 // Equals compare l equals r consolidatedDestRule or not.
-func (l *consolidatedDestRule) Equals(r *consolidatedDestRule) bool {
+func (l *ConsolidatedDestRule) Equals(r *ConsolidatedDestRule) bool {
 	if l == r {
 		return true
 	}
@@ -178,4 +178,18 @@ func (l *consolidatedDestRule) Equals(r *consolidatedDestRule) bool {
 		}
 	}
 	return true
+}
+
+func (l *ConsolidatedDestRule) GetRule() *config.Config {
+	if l == nil {
+		return nil
+	}
+	return l.rule
+}
+
+func (l *ConsolidatedDestRule) GetFrom() []types.NamespacedName {
+	if l == nil {
+		return nil
+	}
+	return l.from
 }

--- a/pilot/pkg/model/destination_rule_test.go
+++ b/pilot/pkg/model/destination_rule_test.go
@@ -25,8 +25,8 @@ import (
 func TestConsolidatedDestRuleEquals(t *testing.T) {
 	testcases := []struct {
 		name     string
-		l        *consolidatedDestRule
-		r        *consolidatedDestRule
+		l        *ConsolidatedDestRule
+		r        *ConsolidatedDestRule
 		expected bool
 	}{
 		{
@@ -36,7 +36,7 @@ func TestConsolidatedDestRuleEquals(t *testing.T) {
 		{
 			name: "l is nil",
 			l:    nil,
-			r: &consolidatedDestRule{
+			r: &ConsolidatedDestRule{
 				from: []types.NamespacedName{
 					{
 						Namespace: "default",
@@ -48,7 +48,7 @@ func TestConsolidatedDestRuleEquals(t *testing.T) {
 		},
 		{
 			name: "r is nil",
-			l: &consolidatedDestRule{
+			l: &ConsolidatedDestRule{
 				from: []types.NamespacedName{
 					{
 						Namespace: "default",
@@ -61,7 +61,7 @@ func TestConsolidatedDestRuleEquals(t *testing.T) {
 		},
 		{
 			name: "from length not equal",
-			l: &consolidatedDestRule{
+			l: &ConsolidatedDestRule{
 				from: []types.NamespacedName{
 					{
 						Namespace: "default",
@@ -69,7 +69,7 @@ func TestConsolidatedDestRuleEquals(t *testing.T) {
 					},
 				},
 			},
-			r: &consolidatedDestRule{
+			r: &ConsolidatedDestRule{
 				from: []types.NamespacedName{
 					{
 						Namespace: "default",
@@ -85,7 +85,7 @@ func TestConsolidatedDestRuleEquals(t *testing.T) {
 		},
 		{
 			name: "from length equals but element is different",
-			l: &consolidatedDestRule{
+			l: &ConsolidatedDestRule{
 				from: []types.NamespacedName{
 					{
 						Namespace: "default",
@@ -97,7 +97,7 @@ func TestConsolidatedDestRuleEquals(t *testing.T) {
 					},
 				},
 			},
-			r: &consolidatedDestRule{
+			r: &ConsolidatedDestRule{
 				from: []types.NamespacedName{
 					{
 						Namespace: "default",
@@ -113,7 +113,7 @@ func TestConsolidatedDestRuleEquals(t *testing.T) {
 		},
 		{
 			name: "all from elements equal",
-			l: &consolidatedDestRule{
+			l: &ConsolidatedDestRule{
 				from: []types.NamespacedName{
 					{
 						Namespace: "default",
@@ -125,7 +125,7 @@ func TestConsolidatedDestRuleEquals(t *testing.T) {
 					},
 				},
 			},
-			r: &consolidatedDestRule{
+			r: &ConsolidatedDestRule{
 				from: []types.NamespacedName{
 					{
 						Namespace: "default",

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -946,7 +946,7 @@ func TestInitPushContext(t *testing.T) {
 		// Allow looking into exported fields for parts of push context
 		cmp.AllowUnexported(PushContext{}, exportToDefaults{}, serviceIndex{}, virtualServiceIndex{},
 			destinationRuleIndex{}, gatewayIndex{}, consolidatedDestRules{}, IstioEgressListenerWrapper{}, SidecarScope{},
-			AuthenticationPolicies{}, NetworkManager{}, sidecarIndex{}, Telemetries{}, ProxyConfigs{}, consolidatedDestRule{}),
+			AuthenticationPolicies{}, NetworkManager{}, sidecarIndex{}, Telemetries{}, ProxyConfigs{}, ConsolidatedDestRule{}),
 		// These are not feasible/worth comparing
 		cmpopts.IgnoreTypes(sync.RWMutex{}, localServiceDiscovery{}, FakeStore{}, atomic.Bool{}, sync.Mutex{}),
 		cmpopts.IgnoreInterfaces(struct{ mesh.Holder }{}),

--- a/pilot/pkg/model/sidecar_test.go
+++ b/pilot/pkg/model/sidecar_test.go
@@ -1925,7 +1925,7 @@ func TestCreateSidecarScope(t *testing.T) {
 					&Proxy{
 						Metadata:        &NodeMetadata{Labels: tt.sidecarConfig.Labels},
 						ConfigNamespace: tt.sidecarConfig.Namespace,
-					}, host.Name("httpbin.org"))
+					}, host.Name("httpbin.org")).GetRule()
 				assert.Equal(t, dr, tt.expectedDr)
 			}
 		})

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -242,7 +242,7 @@ func (configgen *ConfigGeneratorImpl) buildOutboundClusters(cb *ClusterBuilder, 
 			}
 
 			subsetClusters := cb.applyDestinationRule(defaultCluster, DefaultClusterMode, service, port,
-				clusterKey.proxyView, clusterKey.destinationRule, clusterKey.serviceAccounts)
+				clusterKey.proxyView, clusterKey.destinationRule.GetRule(), clusterKey.serviceAccounts)
 
 			if patched := cp.patch(nil, defaultCluster.build()); patched != nil {
 				resources = append(resources, patched)
@@ -322,7 +322,7 @@ func (configgen *ConfigGeneratorImpl) buildOutboundSniDnatClusters(proxy *model.
 			continue
 		}
 
-		destRule := proxy.SidecarScope.DestinationRule(model.TrafficDirectionOutbound, proxy, service.Hostname)
+		destRule := proxy.SidecarScope.DestinationRule(model.TrafficDirectionOutbound, proxy, service.Hostname).GetRule()
 		for _, port := range service.Ports {
 			if port.Protocol == protocol.UDP {
 				continue

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -442,7 +442,7 @@ func (cb *ClusterBuilder) buildInboundClusterForPortOrUDS(clusterPort int, bind 
 	// (not the defaults) to handle the increased traffic volume
 	// TODO: This is not foolproof - if instance is part of multiple services listening on same port,
 	// choice of inbound cluster is arbitrary. So the connection pool settings may not apply cleanly.
-	cfg := proxy.SidecarScope.DestinationRule(model.TrafficDirectionInbound, proxy, instance.Service.Hostname)
+	cfg := proxy.SidecarScope.DestinationRule(model.TrafficDirectionInbound, proxy, instance.Service.Hostname).GetRule()
 	if cfg != nil {
 		destinationRule := cfg.Spec.(*networking.DestinationRule)
 		opts.isDrWithSelector = destinationRule.GetWorkloadSelector() != nil
@@ -1186,7 +1186,7 @@ func (cb *ClusterBuilder) getAllCachedSubsetClusters(clusterKey clusterCache) ([
 	if !features.EnableCDSCaching {
 		return nil, false
 	}
-	destinationRule := CastDestinationRule(clusterKey.destinationRule)
+	destinationRule := CastDestinationRule(clusterKey.destinationRule.GetRule())
 	res := make([]*discovery.Resource, 0, 1+len(destinationRule.GetSubsets()))
 	cachedCluster, f := cb.cache.Get(&clusterKey)
 	allFound := f

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
@@ -516,7 +516,7 @@ func TestApplyDestinationRule(t *testing.T) {
 			cb := NewClusterBuilder(proxy, &model.PushRequest{Push: cg.PushContext()}, nil)
 
 			ec := NewMutableCluster(tt.cluster)
-			destRule := proxy.SidecarScope.DestinationRule(model.TrafficDirectionOutbound, proxy, tt.service.Hostname)
+			destRule := proxy.SidecarScope.DestinationRule(model.TrafficDirectionOutbound, proxy, tt.service.Hostname).GetRule()
 
 			subsetClusters := cb.applyDestinationRule(ec, tt.clusterMode, tt.service, tt.port, tt.proxyView, destRule, nil)
 			if len(subsetClusters) != len(tt.expectedSubsetClusters) {
@@ -3330,7 +3330,7 @@ func TestApplyDestinationRuleOSCACert(t *testing.T) {
 			cb := NewClusterBuilder(proxy, &model.PushRequest{Push: cg.PushContext()}, nil)
 
 			ec := NewMutableCluster(tt.cluster)
-			destRule := proxy.SidecarScope.DestinationRule(model.TrafficDirectionOutbound, proxy, tt.service.Hostname)
+			destRule := proxy.SidecarScope.DestinationRule(model.TrafficDirectionOutbound, proxy, tt.service.Hostname).GetRule()
 
 			// ACT
 			_ = cb.applyDestinationRule(ec, tt.clusterMode, tt.service, tt.port, tt.proxyView, destRule, nil)

--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -891,7 +891,7 @@ func builtAutoPassthroughFilterChains(push *model.PushContext, proxy *model.Prox
 				statPrefix = telemetry.BuildStatPrefix(push.Mesh.OutboundClusterStatName, string(service.Hostname), "", port, &service.Attributes)
 			}
 			destinationRule := CastDestinationRule(proxy.SidecarScope.DestinationRule(
-				model.TrafficDirectionOutbound, proxy, service.Hostname))
+				model.TrafficDirectionOutbound, proxy, service.Hostname).GetRule())
 
 			// First, we build the standard cluster. We match on the SNI matching the cluster name
 			// (per the spec of AUTO_PASSTHROUGH), as well as all possible Istio mTLS ALPNs. This,

--- a/pilot/pkg/networking/core/v1alpha3/networkfilter.go
+++ b/pilot/pkg/networking/core/v1alpha3/networkfilter.go
@@ -221,7 +221,7 @@ func buildOutboundNetworkFilters(node *model.Proxy,
 	service := push.ServiceForHostname(node, host.Name(routes[0].Destination.Host))
 	var destinationRule *networking.DestinationRule
 	if service != nil {
-		destinationRule = CastDestinationRule(node.SidecarScope.DestinationRule(model.TrafficDirectionOutbound, node, service.Hostname))
+		destinationRule = CastDestinationRule(node.SidecarScope.DestinationRule(model.TrafficDirectionOutbound, node, service.Hostname).GetRule())
 	}
 	if len(routes) == 1 {
 		clusterName := istioroute.GetDestinationCluster(routes[0].Destination, service, port.Port)

--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -97,7 +97,7 @@ func BuildSidecarVirtualHostWrapper(routeCache *Cache, node *model.Proxy, push *
 	out := make([]VirtualHostWrapper, 0)
 
 	// dependentDestinationRules includes all the destinationrules referenced by the virtualservices, which have consistent hash policy.
-	dependentDestinationRules := []*config.Config{}
+	dependentDestinationRules := []*model.ConsolidatedDestRule{}
 	// consistent hash policies for the http route destinations
 	hashByDestination := map[*networking.HTTPRouteDestination]*networking.LoadBalancerSettings_ConsistentHashLB{}
 	for _, virtualService := range virtualServices {
@@ -1196,11 +1196,12 @@ func consistentHashToHashPolicy(consistentHash *networking.LoadBalancerSettings_
 
 func getHashForService(node *model.Proxy, push *model.PushContext,
 	svc *model.Service, port *model.Port,
-) (*networking.LoadBalancerSettings_ConsistentHashLB, *config.Config) {
+) (*networking.LoadBalancerSettings_ConsistentHashLB, *model.ConsolidatedDestRule) {
 	if push == nil {
 		return nil, nil
 	}
-	destinationRule := node.SidecarScope.DestinationRule(model.TrafficDirectionOutbound, node, svc.Hostname)
+	mergedDR := node.SidecarScope.DestinationRule(model.TrafficDirectionOutbound, node, svc.Hostname)
+	destinationRule := mergedDR.GetRule()
 	if destinationRule == nil {
 		return nil, nil
 	}
@@ -1217,7 +1218,7 @@ func getHashForService(node *model.Proxy, push *model.PushContext,
 		}
 	}
 
-	return consistentHash, destinationRule
+	return consistentHash, mergedDR
 }
 
 func GetConsistentHashForVirtualService(push *model.PushContext, node *model.Proxy,
@@ -1247,13 +1248,14 @@ func GetConsistentHashForVirtualService(push *model.PushContext, node *model.Pro
 // GetHashForHTTPDestination return the ConsistentHashLB and the DestinationRule associated with HTTP route destination.
 func GetHashForHTTPDestination(push *model.PushContext, node *model.Proxy, dst *networking.HTTPRouteDestination,
 	configNamespace string,
-) (*networking.LoadBalancerSettings_ConsistentHashLB, *config.Config) {
+) (*networking.LoadBalancerSettings_ConsistentHashLB, *model.ConsolidatedDestRule) {
 	if push == nil {
 		return nil, nil
 	}
 
 	destination := dst.GetDestination()
-	destinationRule := node.SidecarScope.DestinationRule(model.TrafficDirectionOutbound, node, host.Name(destination.Host))
+	mergedDR := node.SidecarScope.DestinationRule(model.TrafficDirectionOutbound, node, host.Name(destination.Host))
+	destinationRule := mergedDR.GetRule()
 	if destinationRule == nil {
 		return nil, nil
 	}
@@ -1282,7 +1284,7 @@ func GetHashForHTTPDestination(push *model.PushContext, node *model.Proxy, dst *
 	case plsHash != nil:
 		consistentHash = plsHash
 	}
-	return consistentHash, destinationRule
+	return consistentHash, mergedDR
 }
 
 // isCatchAll returns true if HTTPMatchRequest is a catchall match otherwise

--- a/pilot/pkg/networking/core/v1alpha3/tls.go
+++ b/pilot/pkg/networking/core/v1alpha3/tls.go
@@ -201,7 +201,7 @@ func buildSidecarOutboundTLSFilterChainOpts(node *model.Proxy, push *model.PushC
 			sniHosts = []string{string(service.Hostname)}
 		}
 		destinationRule := CastDestinationRule(node.SidecarScope.DestinationRule(
-			model.TrafficDirectionOutbound, node, service.Hostname))
+			model.TrafficDirectionOutbound, node, service.Hostname).GetRule())
 		out = append(out, &filterChainOpts{
 			sniHosts:         sniHosts,
 			destinationCIDRs: []string{destinationCIDR},
@@ -306,7 +306,7 @@ TcpLoop:
 		clusterName := model.BuildSubsetKey(model.TrafficDirectionOutbound, "", service.Hostname, port)
 		statPrefix := clusterName
 		destinationRule := CastDestinationRule(node.SidecarScope.DestinationRule(
-			model.TrafficDirectionOutbound, node, service.Hostname))
+			model.TrafficDirectionOutbound, node, service.Hostname).GetRule())
 		// If stat name is configured, use it to build the stat prefix.
 		if len(push.Mesh.OutboundClusterStatName) != 0 {
 			statPrefix = telemetry.BuildStatPrefix(push.Mesh.OutboundClusterStatName, string(service.Hostname), "", &model.Port{Port: port}, &service.Attributes)

--- a/pilot/pkg/networking/grpcgen/cds.go
+++ b/pilot/pkg/networking/grpcgen/cds.go
@@ -177,7 +177,7 @@ func (b *clusterBuilder) applyDestinationRule(defaultCluster *cluster.Cluster) (
 
 	// resolve policy from context
 	destinationRule := corexds.CastDestinationRule(b.node.SidecarScope.DestinationRule(
-		model.TrafficDirectionOutbound, b.node, b.svc.Hostname))
+		model.TrafficDirectionOutbound, b.node, b.svc.Hostname).GetRule())
 	trafficPolicy := corexds.MergeTrafficPolicy(nil, destinationRule.GetTrafficPolicy(), b.port)
 
 	// setup default cluster

--- a/pilot/pkg/xds/bench_test.go
+++ b/pilot/pkg/xds/bench_test.go
@@ -565,14 +565,14 @@ func makeCacheKey(n int) model.XdsCacheEntry {
 	// 100 services
 	services := make([]*model.Service, 0, 100)
 	// 100 destinationrules
-	drs := make([]*config.Config, 0, 100)
+	drs := make([]*model.ConsolidatedDestRule, 0, 100)
 	for i := 0; i < 100; i++ {
 		index := strconv.Itoa(i)
 		services = append(services, &model.Service{
 			Hostname:   host.Name(ns + "some" + index + ".example.com"),
 			Attributes: model.ServiceAttributes{Namespace: "test" + index},
 		})
-		drs = append(drs, &config.Config{Meta: config.Meta{Name: index, Namespace: index}})
+		drs = append(drs, model.ConvertConsolidatedDestRule(&config.Config{Meta: config.Meta{Name: index, Namespace: index}}))
 	}
 
 	key := &route.Cache{

--- a/pilot/pkg/xds/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoint_builder.go
@@ -70,7 +70,7 @@ type EndpointBuilder struct {
 	proxyView       model.ProxyView
 	clusterID       cluster.ID
 	locality        *core.Locality
-	destinationRule *config.Config
+	destinationRule *model.ConsolidatedDestRule
 	service         *model.Service
 	clusterLocal    bool
 	tunnelType      networking.TunnelType
@@ -89,7 +89,7 @@ func NewEndpointBuilder(clusterName string, proxy *model.Proxy, push *model.Push
 	_, subsetName, hostname, port := model.ParseSubsetKey(clusterName)
 	svc := push.ServiceForHostname(proxy, hostname)
 
-	var dr *config.Config
+	var dr *model.ConsolidatedDestRule
 	if svc != nil {
 		dr = proxy.SidecarScope.DestinationRule(model.TrafficDirectionOutbound, proxy, svc.Hostname)
 	}
@@ -114,16 +114,16 @@ func NewEndpointBuilder(clusterName string, proxy *model.Proxy, push *model.Push
 	// We need this for multi-network, or for clusters meant for use with AUTO_PASSTHROUGH.
 	if features.EnableAutomTLSCheckPolicies ||
 		b.push.NetworkManager().IsMultiNetworkEnabled() || model.IsDNSSrvSubsetKey(clusterName) {
-		b.mtlsChecker = newMtlsChecker(push, port, dr)
+		b.mtlsChecker = newMtlsChecker(push, port, dr.GetRule())
 	}
 	return b
 }
 
 func (b EndpointBuilder) DestinationRule() *networkingapi.DestinationRule {
-	if b.destinationRule == nil {
-		return nil
+	if dr := b.destinationRule.GetRule(); dr != nil {
+		return dr.Spec.(*networkingapi.DestinationRule)
 	}
-	return b.destinationRule.Spec.(*networkingapi.DestinationRule)
+	return nil
 }
 
 // Key provides the eds cache key and should include any information that could change the way endpoints are generated.
@@ -147,10 +147,10 @@ func (b EndpointBuilder) Key() string {
 	}
 	hash.Write(Separator)
 
-	if b.destinationRule != nil {
-		hash.Write([]byte(b.destinationRule.Name))
+	for _, dr := range b.destinationRule.GetFrom() {
+		hash.Write([]byte(dr.Name))
 		hash.Write(Slash)
-		hash.Write([]byte(b.destinationRule.Namespace))
+		hash.Write([]byte(dr.Namespace))
 	}
 	hash.Write(Separator)
 
@@ -178,12 +178,15 @@ func (b EndpointBuilder) Cacheable() bool {
 }
 
 func (b EndpointBuilder) DependentConfigs() []model.ConfigHash {
-	configs := []model.ConfigHash{}
+	drs := b.destinationRule.GetFrom()
+	configs := make([]model.ConfigHash, 0, len(drs)+1)
 	if b.destinationRule != nil {
-		configs = append(configs, model.ConfigKey{
-			Kind: kind.DestinationRule,
-			Name: b.destinationRule.Name, Namespace: b.destinationRule.Namespace,
-		}.HashCode())
+		for _, dr := range drs {
+			configs = append(configs, model.ConfigKey{
+				Kind: kind.DestinationRule,
+				Name: dr.Name, Namespace: dr.Namespace,
+			}.HashCode())
+		}
 	}
 	if b.service != nil {
 		configs = append(configs, model.ConfigKey{

--- a/pilot/pkg/xds/xds_cache_test.go
+++ b/pilot/pkg/xds/xds_cache_test.go
@@ -135,9 +135,9 @@ func TestXdsCache(t *testing.T) {
 		c := model.NewLenientXdsCache()
 
 		ep1 := ep1
-		ep1.destinationRule = &config.Config{Meta: config.Meta{Name: "a", Namespace: "b"}}
+		ep1.destinationRule = model.ConvertConsolidatedDestRule(&config.Config{Meta: config.Meta{Name: "a", Namespace: "b"}})
 		ep2 := ep2
-		ep2.destinationRule = &config.Config{Meta: config.Meta{Name: "b", Namespace: "b"}}
+		ep2.destinationRule = model.ConvertConsolidatedDestRule(&config.Config{Meta: config.Meta{Name: "b", Namespace: "b"}})
 		start := time.Now()
 		c.Add(ep1, &model.PushRequest{Start: start}, any1)
 		c.Add(ep2, &model.PushRequest{Start: start}, any2)

--- a/releasenotes/notes/39726.yaml
+++ b/releasenotes/notes/39726.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+
+issue:
+  - 39726
+
+releaseNotes:
+- |
+  **Fixed** an issue where updating split DestinationRules does not take effect if the rds/cds/eds cache is enabled.


### PR DESCRIPTION
**Please provide a description of this PR:**
Fixes https://github.com/istio/istio/issues/39726

If there are multiple DRs getting merged, only the "first" one will be added to RDS/CDS/EDS dependent configs
Instead we should add all of them