### PR TITLE
echo: avoid filling defaults twice

### DIFF
--- a/pkg/test/echo/server/forwarder/util.go
+++ b/pkg/test/echo/server/forwarder/util.go
@@ -77,10 +77,6 @@ func newResolver(timeout time.Duration, protocol, dnsServer string) *net.Resolve
 
 // doForward sends the requests and collect the responses.
 func doForward(ctx context.Context, cfg *Config, e *executor, doReq func(context.Context, *Config, int) (string, error)) (*proto.ForwardEchoResponse, error) {
-	if err := cfg.fillDefaults(); err != nil {
-		return nil, err
-	}
-
 	// make the timeout apply to the entire set of requests
 	ctx, cancel := context.WithTimeout(ctx, cfg.timeout)
 	defer cancel()


### PR DESCRIPTION
We already do this at a higher level in `(i *Instance) ForwardEcho`
So I think https://github.com/istio/istio/pull/39645 had issues since although this always was called 2x, only in that PR is it not idempotent. I will see if that part is fixable as well.