### PR TITLE
tf: enable core dumps even if the pod has restarted

### DIFF
--- a/pkg/test/kube/dump.go
+++ b/pkg/test/kube/dump.go
@@ -189,7 +189,7 @@ func DumpCoreDumps(_ resource.Context, c cluster.Cluster, workDir string, namesp
 			}
 			restarts := containerRestarts(pod, proxyContainer.Name())
 			crashed, _ := containerCrashed(pod, proxyContainer.Name())
-			if !crashed || restarts == 0 {
+			if !crashed && restarts == 0 {
 				// no need to store this dump
 				continue
 			}


### PR DESCRIPTION
Currently our logic is too restrictive, making it so we will only grab
core dumps if the container hasn't restarted yet.

Example miss:
https://prow.istio.io/view/gs/istio-prow/logs/integ-security-multicluster_istio_postsubmit/1542617360051998720

**Please provide a description of this PR:**