### PR TITLE
Fix min k8s version supported

### DIFF
--- a/istioctl/pkg/install/k8sversion/version.go
+++ b/istioctl/pkg/install/k8sversion/version.go
@@ -28,7 +28,7 @@ import (
 const (
 	// MinK8SVersion is the minimum k8s version required to run this version of Istio
 	// https://istio.io/docs/setup/platform-setup/
-	MinK8SVersion               = 19
+	MinK8SVersion               = 21
 	UnSupportedK8SVersionLogMsg = "\nThe Kubernetes version %s is not supported by Istio %s. The minimum supported Kubernetes version is 1.%d.\n" +
 		"Proceeding with the installation, but you might experience problems. " +
 		"See https://istio.io/latest/docs/setup/platform-setup/ for a list of supported versions.\n"

--- a/istioctl/pkg/install/k8sversion/version_test.go
+++ b/istioctl/pkg/install/k8sversion/version_test.go
@@ -54,6 +54,11 @@ var (
 		Minor:      "20",
 		GitVersion: "v1.20.2",
 	}
+	version1_21 = &version.Info{
+		Major:      "1",
+		Minor:      "21",
+		GitVersion: "v1.21.2",
+	}
 	version1_19RC = &version.Info{
 		Major:      "1",
 		Minor:      "19",
@@ -188,6 +193,11 @@ func TestIsK8VersionSupported(t *testing.T) {
 		},
 		{
 			version: version1_20,
+			logMsg:  fmt.Sprintf(UnSupportedK8SVersionLogMsg, version1_20.GitVersion, pkgVersion.Info.Version, MinK8SVersion),
+			isValid: false,
+		},
+		{
+			version: version1_21,
 			isValid: true,
 		},
 	}


### PR DESCRIPTION
**Please provide a description of this PR:**
Based on https://istio.io/latest/docs/releases/supported-releases/#support-status-of-istio-releases.
Officially supported k8s version from 1.21-1.24


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [x] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
