### PR TITLE
Reduce []ConfigKey slice allocate numbers during xds caching 

### DIFF
--- a/pilot/pkg/model/xds_cache.go
+++ b/pilot/pkg/model/xds_cache.go
@@ -173,10 +173,6 @@ type LruCache struct {
 
 	// dependantsPool simply stores dependentConfigs of XdsCacheEntry to avoid additional memory allocations
 	// by caching allocated but unused items for later reuse, relieving pressure on the garbage collector.
-	//
-	// Usage:
-	//  memoryAllocator := runtime.AllocatorPool.Get().(*runtime.Allocator)
-	//  defer runtime.AllocatorPool.Put(memoryAllocator)
 	dependantsPool *sync.Pool
 }
 
@@ -226,7 +222,7 @@ func (l *LruCache) handleEvicted(stopCh <-chan struct{}) {
 		case <-l.evictCh:
 			l.clearEvicted()
 		case <-stopCh:
-			log.Infof("LruCache has been stopped")
+			log.Debug("LruCache has been stopped")
 			return
 		}
 	}

--- a/pilot/pkg/model/xds_cache_allocator.go
+++ b/pilot/pkg/model/xds_cache_allocator.go
@@ -1,0 +1,40 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+// Note: referenced kubernetes optimization: staging/src/k8s.io/apimachinery/pkg/runtime/allocator.go
+
+// Allocator knows how to allocate memory
+// It exists to make the cost of xds cache Add cheaper.
+// In some cases, it allows for allocating memory only once and then reusing it.
+// This approach puts less load on GC and leads to less fragmented memory in general.
+type Allocator struct {
+	configs []ConfigKey
+}
+
+// Allocate reserves memory for n configs only if the underlying array doesn't have enough capacity
+// otherwise it returns previously allocated block of memory.
+//
+// Note that the returned array is not zeroed, it is the caller's
+// responsibility to clean the memory if needed.
+func (a *Allocator) Allocate(n int) []ConfigKey {
+	if cap(a.configs) >= n {
+		return a.configs[:0]
+	}
+	// grow the buffer
+	size := 2*cap(a.configs) + n
+	a.configs = make([]ConfigKey, 0, size)
+	return a.configs
+}

--- a/pilot/pkg/networking/core/v1alpha3/cluster_cache.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_cache.go
@@ -121,8 +121,14 @@ func (t *clusterCache) Key() string {
 	return hex.EncodeToString(sum)
 }
 
-func (t clusterCache) DependentConfigs() []model.ConfigKey {
-	configs := []model.ConfigKey{}
+func (t clusterCache) DependentConfigs(allocator *model.Allocator) []model.ConfigKey {
+	var configs []model.ConfigKey
+	n := len(t.envoyFilterKeys) + 2
+	if allocator != nil {
+		configs = allocator.Allocate(n)
+	} else {
+		configs = make([]model.ConfigKey, 0, n)
+	}
 	if t.destinationRule != nil {
 		configs = append(configs, model.ConfigKey{Kind: kind.DestinationRule, Name: t.destinationRule.Name, Namespace: t.destinationRule.Namespace})
 	}

--- a/pilot/pkg/xds/bench_test.go
+++ b/pilot/pkg/xds/bench_test.go
@@ -640,7 +640,6 @@ func BenchmarkDependentConfigs(b *testing.B) {
 
 		for n := 0; n < b.N; n++ {
 			memoryAllocator := dependentPool.Get().(*model.Allocator)
-			// fmt.Printf("%p\n", memoryAllocator)
 			key.DependentConfigs(memoryAllocator)
 			dependentPool.Put(memoryAllocator)
 		}

--- a/pilot/pkg/xds/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoint_builder.go
@@ -63,6 +63,8 @@ func GetTunnelBuilderType(_ string, proxy *model.Proxy, _ *model.PushContext) ne
 	return networking.NoTunnel
 }
 
+var _ model.XdsCacheEntry = EndpointBuilder{}
+
 type EndpointBuilder struct {
 	// These fields define the primary key for an endpoint, and can be used as a cache key
 	clusterName     string
@@ -177,8 +179,13 @@ func (b EndpointBuilder) Cacheable() bool {
 	return b.service != nil
 }
 
-func (b EndpointBuilder) DependentConfigs() []model.ConfigKey {
-	configs := []model.ConfigKey{}
+func (b EndpointBuilder) DependentConfigs(allocator *model.Allocator) []model.ConfigKey {
+	var configs []model.ConfigKey
+	if allocator != nil {
+		configs = allocator.Allocate(2)
+	} else {
+		configs = make([]model.ConfigKey, 0, 2)
+	}
 	if b.destinationRule != nil {
 		configs = append(configs, model.ConfigKey{Kind: kind.DestinationRule, Name: b.destinationRule.Name, Namespace: b.destinationRule.Namespace})
 	}

--- a/pilot/pkg/xds/sds.go
+++ b/pilot/pkg/xds/sds.go
@@ -51,7 +51,7 @@ func (sr SecretResource) DependentTypes() []kind.Kind {
 	return nil
 }
 
-func (sr SecretResource) DependentConfigs() []model.ConfigKey {
+func (sr SecretResource) DependentConfigs(_ *model.Allocator) []model.ConfigKey {
 	return relatedConfigs(model.ConfigKey{Kind: kind.Secret, Name: sr.Name, Namespace: sr.Namespace})
 }
 

--- a/pilot/pkg/xds/xds_cache_test.go
+++ b/pilot/pkg/xds/xds_cache_test.go
@@ -287,7 +287,7 @@ func TestXdsCacheEvict(t *testing.T) {
 			if exist {
 				return fmt.Errorf("key %s should be evicted", key.Key())
 			}
-			dependents := key.DependentConfigs()
+			dependents := key.DependentConfigs(nil)
 			for _, config := range dependents {
 				if lruCache.GetKeysByConfigKey(config) != nil {
 					return fmt.Errorf("config %s should be evicted", config)


### PR DESCRIPTION
**Please provide a description of this PR:**

This is making use of sync.Pool to relieve pressure on the garbage collector.

```
BenchmarkDependentConfigs
BenchmarkDependentConfigs/rds_cache_using_mem_pool
BenchmarkDependentConfigs/rds_cache_using_mem_pool-8         	  390069	      2903 ns/op	      96 B/op	       3 allocs/op
BenchmarkDependentConfigs/rds_cache_not_use_mem_pool
BenchmarkDependentConfigs/rds_cache_not_use_mem_pool-8       	  125289	      9862 ns/op	    8288 B/op	       4 allocs/op
```

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
