### PR TITLE
Not really evict a key that is added later after LRU evict bt before the evict handler run by istio

### DIFF
--- a/pilot/pkg/model/xds_cache.go
+++ b/pilot/pkg/model/xds_cache.go
@@ -230,7 +230,7 @@ func (l *LruCache) clearEvicted() {
 		return
 	}
 	// Do not evict keys that are added again after evicted
-	for _, key := range l.evictedKeys {
+	for key := range l.evictedKeys {
 		_, ok := l.store.Get(key)
 		if ok {
 			delete(l.evictedKeys, key)

--- a/pilot/pkg/model/xds_cache.go
+++ b/pilot/pkg/model/xds_cache.go
@@ -229,6 +229,13 @@ func (l *LruCache) clearEvicted() {
 	if len(l.evictedKeys) < 100 {
 		return
 	}
+	// Do not evict keys that are added again after evicted
+	for _, key := range l.evictedKeys {
+		_, ok := l.store.Get(key)
+		if ok {
+			delete(l.evictedKeys, key)
+		}
+	}
 
 	for configKey, index := range l.configIndex {
 		evicted := index.Intersection(l.evictedKeys)


### PR DESCRIPTION
**Please provide a description of this PR:**

Otherwise the key's configIndex is not right, and later if a `Clear` call to clear a stale key may do nothing

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
