### PR TITLE
Enable TestTunnelingOutboundTraffic and configure access log in forward proxy

### DIFF
--- a/pkg/test/echo/server/endpoint/http.go
+++ b/pkg/test/echo/server/endpoint/http.go
@@ -211,7 +211,11 @@ type codeAndSlices struct {
 
 func (h *httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	id := uuid.New()
-	epLog.WithLabels("method", r.Method, "url", r.URL, "host", r.Host, "headers", r.Header, "id", id).Infof("HTTP Request")
+	remoteAddr, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		epLog.Warnf("failed to get host from remote address: %s", err)
+	}
+	epLog.WithLabels("remoteAddr", remoteAddr, "method", r.Method, "url", r.URL, "host", r.Host, "headers", r.Header, "id", id).Infof("HTTP Request")
 	if h.Port == nil {
 		defer common.Metrics.HTTPRequests.With(common.PortLabel.Value("uds")).Increment()
 	} else {

--- a/tests/integration/pilot/tunneling_test.go
+++ b/tests/integration/pilot/tunneling_test.go
@@ -107,7 +107,6 @@ func TestTunnelingOutboundTraffic(t *testing.T) {
 		NewTest(t).
 		Features("traffic.tunneling").
 		Run(func(ctx framework.TestContext) {
-			ctx.Skip("https://github.com/istio/istio/issues/39586")
 			meshNs := apps.A.NamespaceName()
 			externalNs := apps.External.Namespace.Name()
 


### PR DESCRIPTION
Signed-off-by: Jacek Ewertowski <jewertow@redhat.com>

**Please provide a description of this PR:**

Related issue: #39586

I investigated config dumps from few failed tests and I can't find any misconfiguration. I didn't encounter similar problem on my computer - the tests always pass. So the first step to understand the problem better is adding access log to the forward proxy. I would like to know what status code and flag are returned.
After merging this PR I will look for failing post-submit tests and will try to solve to cause of the problem (I have some ideas, but I am not sure at the moment) or disable test again.