### PR TITLE
fix pilot  ENABLE_WASM_TELEMETRY flag

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -1699,6 +1699,8 @@ spec:
             value: /var/run/secrets/remote/config
           - name: PILOT_TRACE_SAMPLING
             value: "1"
+          - name: ENABLE_WASM_TELEMETRY
+            value: "false"
           - name: PILOT_ENABLE_PROTOCOL_SNIFFING_FOR_OUTBOUND
             value: "true"
           - name: PILOT_ENABLE_PROTOCOL_SNIFFING_FOR_INBOUND

--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -153,6 +153,8 @@ spec:
           - name: PILOT_TRACE_SAMPLING
             value: "{{ .Values.pilot.traceSampling }}"
 {{- end }}
+          - name: ENABLE_WASM_TELEMETRY
+            value: "{{ .Values.telemetry.v2.prometheus.wasmEnabled }}"
           - name: PILOT_ENABLE_PROTOCOL_SNIFFING_FOR_OUTBOUND
             value: "{{ .Values.pilot.enableProtocolSniffingForOutbound }}"
           - name: PILOT_ENABLE_PROTOCOL_SNIFFING_FOR_INBOUND


### PR DESCRIPTION
**Please provide a description of this PR:**



**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

ConstructVMConfig should respect `ENABLE_WASM_TELEMETRY`

https://github.com/istio/istio/blob/0f92d7f2048ce09954becb897cd849d6c196e147/pilot/pkg/model/wasm.go#L28

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [x] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure