### PR TITLE
Revert "do not cache dependent configs in xds cache store (#39688)"

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/route/route_cache_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route_cache_test.go
@@ -28,10 +28,7 @@ import (
 )
 
 func TestClearRDSCacheOnDelegateUpdate(t *testing.T) {
-	stop := make(chan struct{})
-	defer close(stop)
 	xdsCache := model.NewXdsCache()
-	go xdsCache.Run(stop)
 	// root virtual service
 	root := config.Config{
 		Meta: config.Meta{Name: "root", Namespace: "default"},

--- a/pilot/pkg/xds/bench_test.go
+++ b/pilot/pkg/xds/bench_test.go
@@ -572,7 +572,7 @@ func makeCacheKey(n int) model.XdsCacheEntry {
 			Hostname:   host.Name(ns + "some" + index + ".example.com"),
 			Attributes: model.ServiceAttributes{Namespace: "test" + index},
 		})
-		drs = append(drs, &config.Config{Meta: config.Meta{Name: ns + "some" + index, Namespace: "test" + index}})
+		drs = append(drs, &config.Config{Meta: config.Meta{Name: index, Namespace: index}})
 	}
 
 	key := &route.Cache{
@@ -601,10 +601,7 @@ func BenchmarkCache(b *testing.B) {
 		}
 	})
 	b.Run("insert", func(b *testing.B) {
-		stop := make(chan struct{})
-		defer close(stop)
 		c := model.NewXdsCache()
-		go c.Run(stop)
 
 		for n := 0; n < b.N; n++ {
 			key := makeCacheKey(n)
@@ -613,10 +610,7 @@ func BenchmarkCache(b *testing.B) {
 		}
 	})
 	b.Run("get", func(b *testing.B) {
-		stop := make(chan struct{})
-		defer close(stop)
 		c := model.NewXdsCache()
-		go c.Run(stop)
 
 		key := makeCacheKey(1)
 		req := &model.PushRequest{Start: zeroTime.Add(time.Duration(1))}

--- a/pilot/pkg/xds/discovery.go
+++ b/pilot/pkg/xds/discovery.go
@@ -238,9 +238,6 @@ func (s *DiscoveryServer) IsServerReady() bool {
 }
 
 func (s *DiscoveryServer) Start(stopCh <-chan struct{}) {
-	if s.Cache != nil {
-		go s.Cache.Run(stopCh)
-	}
 	go s.WorkloadEntryController.Run(stopCh)
 	go s.handleUpdates(stopCh)
 	go s.periodicRefreshMetrics(stopCh)


### PR DESCRIPTION
This reverts commit 898d16769875b7241a37ebfa9b087a7e911547b9.

**Please provide a description of this PR:**

This is base on now we have made use of hash code to represent dependents, assume in the case of 60_000 keys, each key has 100 dependents, the whole additional memory is very low about 6MB.


And keeps the `evicted` flag to indicate whether it is actively cleared to prevent clearing twice.