### PR TITLE
[Dual Stack] Fix the bug for installing Istio in IPv4 only k8s cluster with dual stack feature is enabled

### DIFF
--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -128,7 +128,7 @@ func (cfg Config) toTemplateParams() (map[string]interface{}, error) {
 			option.Localhost(option.LocalhostIPv4),
 			option.IPv4Wildcard(option.WildcardIPv4))
 			if network.AllIPv4(cfg.Metadata.InstanceIPs) {
-				option.DNSLookupFamily(option.DNSLookupFamilyIPv4)
+				opts = append(opts, option.DNSLookupFamily(option.DNSLookupFamilyIPv4))
 			}
 	}
 


### PR DESCRIPTION
**Please provide a description of this PR:**
Fix the bug for installing Istio in IPv4 only k8s cluster and the ingress gateway pod can not be running if dual stack feature is enabled.

Before this PR, Istio ingress gateway pod can not be running in IPv4 only k8s cluster due to the invalid argument for **dns_lookup_family**, the error message may be like below:
![image](https://user-images.githubusercontent.com/4101246/177302421-bcebce5f-edeb-41bf-bc4a-869d9fc9ff43.png)