### PR TITLE
Respect GA topology label first

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/util.go
+++ b/pilot/pkg/serviceregistry/kube/controller/util.go
@@ -45,7 +45,7 @@ func hasProxyIP(addresses []v1.EndpointAddress, proxyIP string) bool {
 	return false
 }
 
-func getLabelValue(metadata metav1.Object, label string, fallBackLabel string) string {
+func getLabelValue(metadata metav1.ObjectMeta, label string, fallBackLabel string) string {
 	metaLabels := metadata.GetLabels()
 	val := metaLabels[label]
 	if val != "" {

--- a/pilot/pkg/serviceregistry/kube/controller/util_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/util_test.go
@@ -86,7 +86,7 @@ func TestGetLabelValue(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := getLabelValue(test.node, NodeRegionLabel, NodeRegionLabelGA)
+			got := getLabelValue(test.node.ObjectMeta, NodeRegionLabel, NodeRegionLabelGA)
 			if test.expectedLabelValue != got {
 				t.Errorf("Expected %v, but got %v", test.expectedLabelValue, got)
 			}


### PR DESCRIPTION
**Please provide a description of this PR:**


node topology label has been GA and beta has been deprecated since k8s 1.17, we can safely do this.