### PR TITLE
Agent: Unified use of NewSecretManager func

### DIFF
--- a/pkg/istio-agent/agent.go
+++ b/pkg/istio-agent/agent.go
@@ -504,7 +504,8 @@ func (a *Agent) initSdsServer() error {
 		a.secOpts.FileMountedCerts = true
 	}
 
-	if a.secretCache, err = a.newSecretManager(); err != nil {
+	a.secretCache, err = a.newSecretManager()
+	if err != nil {
 		return fmt.Errorf("failed to start workload secret manager %v", err)
 	}
 

--- a/pkg/istio-agent/agent.go
+++ b/pkg/istio-agent/agent.go
@@ -501,15 +501,13 @@ func (a *Agent) initSdsServer() error {
 		a.secOpts.RootCertFilePath = security.WorkloadIdentityRootCertPath
 		a.secOpts.CertChainFilePath = security.WorkloadIdentityCertChainPath
 		a.secOpts.KeyFilePath = security.WorkloadIdentityKeyPath
-
-		a.secretCache, err = cache.NewSecretManagerClient(nil, a.secOpts)
-	} else {
-		a.secretCache, err = a.newSecretManager()
+		a.secOpts.FileMountedCerts = true
 	}
 
-	if err != nil {
+	if a.secretCache, err = a.newSecretManager(); err != nil {
 		return fmt.Errorf("failed to start workload secret manager %v", err)
 	}
+
 	if a.cfg.DisableEnvoy {
 		// For proxyless we don't need an SDS server, but still need the keys and
 		// we need them refreshed periodically.


### PR DESCRIPTION
**Please provide a description of this PR:**

If there is currently a FileMounted Certificate and Key, we only need to enable the `secretManagerClient` in Istio, and this can still can be implemented by calling the `newSecretManager` uniformly, which can unify the interface to provide better encapsulation.