### PR TITLE
Refactor resolution of network gateway names for more efficiency

### DIFF
--- a/pilot/pkg/model/network.go
+++ b/pilot/pkg/model/network.go
@@ -540,7 +540,12 @@ func (n *networkGatewayNameCache) resolve(name string) ([]string, time.Duration)
 		mu.Lock()
 		defer mu.Unlock()
 		for _, rr := range res.Answer {
-			out = append(out, rr.String())
+			switch dnsType {
+			case dns.TypeA:
+				out = append(out, rr.(*dns.A).A.String())
+			case dns.TypeAAAA:
+				out = append(out, rr.(*dns.AAAA).AAAA.String())
+			}
 			if nextTTL := rr.Header().Ttl; nextTTL < ttl {
 				ttl = nextTTL
 			}

--- a/pilot/pkg/model/network.go
+++ b/pilot/pkg/model/network.go
@@ -529,7 +529,7 @@ func (n *networkGatewayNameCache) resolve(name string) ([]string, time.Duration)
 
 	var mu sync.Mutex
 	var wg sync.WaitGroup
-	var doResolve = func(dnsType uint16) {
+	doResolve := func(dnsType uint16) {
 		defer wg.Done()
 
 		res := n.client.Query(new(dns.Msg).SetQuestion(dns.Fqdn(name), dnsType))

--- a/pilot/pkg/model/network.go
+++ b/pilot/pkg/model/network.go
@@ -524,45 +524,34 @@ func stringSliceEqual(a, b []string) bool {
 
 // resolve gets all the A and AAAA records for the given name
 func (n *networkGatewayNameCache) resolve(name string) ([]string, time.Duration) {
-	var resA, resAAAA *dns.Msg
-	resA = n.client.Query(new(dns.Msg).SetQuestion(dns.Fqdn(name), dns.TypeA))
-	resAAAA = n.client.Query(new(dns.Msg).SetQuestion(dns.Fqdn(name), dns.TypeAAAA))
-
-	numRRs := 0
-	if resA != nil {
-		numRRs += len(resA.Answer)
-	}
-	if resAAAA != nil {
-		numRRs += len(resAAAA.Answer)
-	}
-	if numRRs == 0 {
-		return nil, 0
-	}
-	allRRs := make([]dns.RR, 0, numRRs)
-	if resA != nil {
-		allRRs = append(allRRs, resA.Answer...)
-	}
-	if resAAAA != nil {
-		allRRs = append(allRRs, resAAAA.Answer...)
-	}
-
 	ttl := uint32(math.MaxUint32)
 	var out []string
-	for _, rr := range allRRs {
-		switch v := rr.(type) {
-		case *dns.A:
-			out = append(out, v.A.String())
-		case *dns.AAAA:
-			// TODO may not always want ipv6t?
-			out = append(out, v.AAAA.String())
-		default:
-			// not a valid record, don't inspect TTL
-			continue
+
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	var doResolve = func(dnsType uint16) {
+		defer wg.Done()
+
+		res := n.client.Query(new(dns.Msg).SetQuestion(dns.Fqdn(name), dnsType))
+		if len(res.Answer) == 0 {
+			return
 		}
-		if nextTTL := rr.Header().Ttl; nextTTL < ttl {
-			ttl = nextTTL
+
+		mu.Lock()
+		defer mu.Unlock()
+		for _, rr := range res.Answer {
+			out = append(out, rr.String())
+			if nextTTL := rr.Header().Ttl; nextTTL < ttl {
+				ttl = nextTTL
+			}
 		}
 	}
+
+	wg.Add(2)
+	go doResolve(dns.TypeA)
+	go doResolve(dns.TypeAAAA)
+	wg.Wait()
+
 	sort.Strings(out)
 	return out, time.Duration(ttl) * time.Second
 }


### PR DESCRIPTION
**Please provide a description of this PR:**

This is a follow-up to https://github.com/istio/istio/pull/38781

This PR refactors the function that performs the resolution of network gateway hostnames:
* removes redundant nil checks and slice allocations introduced in the previous PR, to improve code readability
* replaces the type switch with type assertions, as we now always know what type of the DNS record we receive in a reply
* reintroduces parallel DNS resolution for A and AAAA records

As for the parallel resolution that was a point of concern in the previous PR: on each [DNS request](https://github.com/istio/istio/blob/1.14.1/pilot/pkg/model/network.go#L550) to an upstream DNS server, [when connecting](https://github.com/miekg/dns/blob/v1.1.50/client.go#L164) to that upstream, the DNS client instance [creates a new](https://github.com/miekg/dns/blob/v1.1.50/client.go#L114) net.Dialer (unless there is a [fixed predefined dialer](https://github.com/miekg/dns/blob/v1.1.50/client.go#L116) that can be passed when creating the DNS client instance, which [is not the case](https://github.com/istio/istio/blob/1.14.1/pilot/pkg/model/network.go#L536)). Since the new net.Dialer does not have a LocalAddr specified on creation, it binds to a random local port ([see LocalAddr](https://pkg.go.dev/net#Dialer)), and therefore all parallel DNS requests use different local ports and cannot interfere with each other, so they are safe to use.

The tests are not changed because there is no effective change in the implemented behaviour, only refactoring.

**To help us figure out who should review this PR, please put an  in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
