### PR TITLE
Helm Charts: add Pod Topology Spread Constraints

### DIFF
--- a/manifests/charts/gateways/istio-egress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-egress/templates/deployment.yaml
@@ -332,4 +332,8 @@ spec:
       tolerations:
 {{ toYaml .Values.global.defaultTolerations | indent 6 }}
 {{- end }}
+{{- if $gateway.topologySpreadConstraints }}
+      topologySpreadConstraints:
+{{- toYaml $gateway.topologySpreadConstraints | nindent 6 }}
+{{- end }}
 {{- end }}

--- a/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
@@ -332,4 +332,8 @@ spec:
       tolerations:
 {{ toYaml .Values.global.defaultTolerations | indent 6 }}
 {{- end }}
+{{- if $gateway.topologySpreadConstraints }}
+      topologySpreadConstraints:
+{{- toYaml $gateway.topologySpreadConstraints | nindent 6 }}
+{{- end }}
 {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -69,6 +69,10 @@ spec:
       tolerations:
 {{- toYaml . | nindent 8 }}
 {{- end }}
+{{- with .Values.pilot.topologySpreadConstraints }}
+      topologySpreadConstraints:
+{{- toYaml . | nindent 8 }}
+{{- end }}
       serviceAccountName: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
 {{- if .Values.global.priorityClassName }}
       priorityClassName: "{{ .Values.global.priorityClassName }}"

--- a/manifests/charts/istio-operator/templates/deployment.yaml
+++ b/manifests/charts/istio-operator/templates/deployment.yaml
@@ -68,4 +68,8 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 ---

--- a/manifests/charts/istio-operator/values.yaml
+++ b/manifests/charts/istio-operator/values.yaml
@@ -37,6 +37,9 @@ tolerations: []
 # Affinity for pod assignment
 affinity: {}
 
+# Topology Spread Constraints for pod assignment
+topologySpreadConstraints: []
+
 # Additional labels and annotations to apply on the pod level for monitoring and logging configuration.
 podLabels: {}
 podAnnotations: {}


### PR DESCRIPTION
**Please provide a description of this PR:**

Added [Pod Topology Spread Constraints](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/) to the following Helm Charts:

- gateways (istio-ingress & istio-egress)
- istio-control/istio-discovery
- istio-operator

It simply extends the deployment.yaml templated manifests with `topologySpreadConstraints`. In istio-operator an empty array was added to the default values to match with related configs (affinity, nodeSelector).