### PR TITLE
Replace strings.Cut() with strings.Index()

### DIFF
--- a/tools/docker-builder/builder/crane.go
+++ b/tools/docker-builder/builder/crane.go
@@ -248,7 +248,7 @@ func Build(b BuildSpec) error {
 			if err != nil {
 				return fmt.Errorf("failed to compute size: %w", err)
 			}
-			os, arch, _ := strings.Cut(b.Args[idx].Arch, "/")
+			index := strings.Index(b.Args[idx].Arch, "/")
 			manifest = mutate.AppendManifests(manifest, mutate.IndexAddendum{
 				Add: i,
 				Descriptor: v1.Descriptor{
@@ -256,8 +256,8 @@ func Build(b BuildSpec) error {
 					Size:      size,
 					Digest:    h,
 					Platform: &v1.Platform{
-						Architecture: arch,
-						OS:           os,
+						Architecture: b.Args[idx].Arch[index+1:],
+						OS:           b.Args[idx].Arch[:index],
 						Variant:      "", // TODO?
 					},
 				},

--- a/tools/docker-builder/common.go
+++ b/tools/docker-builder/common.go
@@ -57,9 +57,9 @@ func createArgs(args Args, target string, variant string, architecture string) m
 	}
 	// Only needed for crane - buildx does it automagically
 	if architecture != "" {
-		os, arch, _ := strings.Cut(architecture, "/")
-		m["TARGETARCH"] = arch
-		m["TARGETOS"] = os
+		index := strings.Index(architecture, "/")
+		m["TARGETARCH"] = architecture[index+1:]
+		m["TARGETOS"] = architecture[:index]
 	}
 	return m
 }

--- a/tools/docker-builder/main.go
+++ b/tools/docker-builder/main.go
@@ -268,7 +268,9 @@ func archToGoFlags(a string) []string {
 }
 
 func archToEnvMap(a string) map[string]string {
-	os, arch, _ := strings.Cut(a, "/")
+	index := strings.Index(a, "/")
+	os := a[:index]
+	arch := a[index+1:]
 	return map[string]string{
 		"TARGET_OS":        os,
 		"TARGET_ARCH":      arch,


### PR DESCRIPTION
**Please provide a description of this PR:**
Replace `strings.Cut()` with `strings.Index()`, `strings.Cut()` is a new feature in go `1.18`
This feature will not be available for the developer's go version < `1.18`, e.g: my current go version is `go1.17.6` I can't use `strings.Cut()`.

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [x] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**
none

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
