### PR TITLE
Create topology flag to proxy only kubectl traffic through HTTPProxy

### DIFF
--- a/pkg/test/framework/components/cluster/cluster.go
+++ b/pkg/test/framework/components/cluster/cluster.go
@@ -84,4 +84,9 @@ type Cluster interface {
 	// Metadata returns the value for a given metadata key for the cluster.
 	// If the key is not found in the cluster metadata, an empty string is returned.
 	MetadataValue(key string) string
+
+	// ProxyKubectlOnly returns a boolean value to indicate whether all traffic
+	// should route through the HTTP proxy or only Kubectl traffic. (Useful
+	// in topologies where the API server is private but the ingress is public).
+	ProxyKubectlOnly() bool
 }

--- a/pkg/test/framework/components/cluster/config.go
+++ b/pkg/test/framework/components/cluster/config.go
@@ -33,6 +33,7 @@ type Config struct {
 	Name               string     `yaml:"clusterName,omitempty"`
 	Network            string     `yaml:"network,omitempty"`
 	HTTPProxy          string     `yaml:"httpProxy,omitempty"`
+	ProxyKubectlOnly   bool       `yaml:"proxyKubectlOnly,omitempty"`
 	PrimaryClusterName string     `yaml:"primaryClusterName,omitempty"`
 	ConfigClusterName  string     `yaml:"configClusterName,omitempty"`
 	Meta               config.Map `yaml:"meta,omitempty"`

--- a/pkg/test/framework/components/cluster/topology.go
+++ b/pkg/test/framework/components/cluster/topology.go
@@ -28,28 +28,30 @@ type Map = map[string]Cluster
 
 func NewTopology(config Config, allClusters Map) Topology {
 	return Topology{
-		ClusterName:        config.Name,
-		ClusterKind:        config.Kind,
-		Network:            config.Network,
-		ClusterHTTPProxy:   config.HTTPProxy,
-		PrimaryClusterName: config.PrimaryClusterName,
-		ConfigClusterName:  config.ConfigClusterName,
-		AllClusters:        allClusters,
-		Index:              len(allClusters),
-		ConfigMetadata:     config.Meta,
+		ClusterName:             config.Name,
+		ClusterKind:             config.Kind,
+		Network:                 config.Network,
+		ClusterHTTPProxy:        config.HTTPProxy,
+		PrimaryClusterName:      config.PrimaryClusterName,
+		ConfigClusterName:       config.ConfigClusterName,
+		ClusterProxyKubectlOnly: config.ProxyKubectlOnly,
+		AllClusters:             allClusters,
+		Index:                   len(allClusters),
+		ConfigMetadata:          config.Meta,
 	}
 }
 
 // Topology gives information about the relationship between clusters.
 // Cluster implementations can embed this struct to include common functionality.
 type Topology struct {
-	ClusterName        string
-	ClusterKind        Kind
-	Network            string
-	ClusterHTTPProxy   string
-	PrimaryClusterName string
-	ConfigClusterName  string
-	Index              int
+	ClusterName             string
+	ClusterKind             Kind
+	Network                 string
+	ClusterHTTPProxy        string
+	PrimaryClusterName      string
+	ConfigClusterName       string
+	ClusterProxyKubectlOnly bool
+	Index                   int
 	// AllClusters should contain all AllClusters in the context
 	AllClusters    Map
 	ConfigMetadata config.Map
@@ -73,6 +75,10 @@ func (c Topology) Name() string {
 // HTTPProxy to connect to the cluster
 func (c Topology) HTTPProxy() string {
 	return c.ClusterHTTPProxy
+}
+
+func (c Topology) ProxyKubectlOnly() bool {
+	return c.ClusterProxyKubectlOnly
 }
 
 // knownClusterNames maintains a well-known set of cluster names. These will always be used with
@@ -195,7 +201,8 @@ func (c Topology) String() string {
 	_, _ = fmt.Fprintf(buf, "PrimaryCluster:     %s\n", c.Primary().Name())
 	_, _ = fmt.Fprintf(buf, "ConfigCluster:      %s\n", c.Config().Name())
 	_, _ = fmt.Fprintf(buf, "Network:            %s\n", c.NetworkName())
-	_, _ = fmt.Fprintf(buf, "HTTPProxy:            %s\n", c.HTTPProxy())
+	_, _ = fmt.Fprintf(buf, "HTTPProxy:          %s\n", c.HTTPProxy())
+	_, _ = fmt.Fprintf(buf, "ProxyKubectlOnly:   %t\n", c.ProxyKubectlOnly())
 
 	return buf.String()
 }

--- a/pkg/test/framework/components/istio/ingress.go
+++ b/pkg/test/framework/components/istio/ingress.go
@@ -224,7 +224,7 @@ func (c *ingressImpl) callEcho(opts echo.CallOptions) (echo.CallResult, error) {
 	if host := opts.GetHost(); len(host) > 0 {
 		opts.HTTP.Headers.Set(headers.Host, host)
 	}
-	if len(c.cluster.HTTPProxy()) > 0 {
+	if len(c.cluster.HTTPProxy()) > 0 && !c.cluster.ProxyKubectlOnly() {
 		opts.HTTP.HTTPProxy = c.cluster.HTTPProxy()
 	}
 	return c.caller.CallEcho(c, opts)


### PR DESCRIPTION
**Please provide a description of this PR:**

PR to create a new test framework flag. This flag toggles the behavior for HTTPProxy so that only kubectl traffic (that which needs to connect to the API server) traverses the proxy.

This is useful in situations where the API server of the kubernetes cluster under test is not directly accessible, but a publicly accessible ingress gateway can be reached during the actual test runs.