### PR TITLE
fix bug for the istio-agent wait command to make sure that it is really timeout

### DIFF
--- a/pilot/cmd/pilot-agent/app/wait.go
+++ b/pilot/cmd/pilot-agent/app/wait.go
@@ -44,10 +44,11 @@ var (
 			timeout := time.After(time.Duration(timeoutSeconds) * time.Second)
 
 			for {
+				duration := time.After(time.Duration(periodMillis) * time.Second)
 				select {
 				case <-timeout:
 					return fmt.Errorf("timeout waiting for Envoy proxy to become ready. Last error: %v", err)
-				case <-time.After(time.Duration(periodMillis) * time.Second):
+				case <-duration:
 					err = checkIfReady(client, url)
 					if err == nil {
 						log.Infof("Envoy is ready!")

--- a/pilot/cmd/pilot-agent/app/wait.go
+++ b/pilot/cmd/pilot-agent/app/wait.go
@@ -44,11 +44,10 @@ var (
 			timeout := time.After(time.Duration(timeoutSeconds) * time.Second)
 
 			for {
-				duration := time.After(time.Duration(periodMillis) * time.Second)
 				select {
 				case <-timeout:
 					return fmt.Errorf("timeout waiting for Envoy proxy to become ready. Last error: %v", err)
-				case <-duration:
+				case <-time.After(time.Duration(periodMillis) * time.Milliseconds):
 					err = checkIfReady(client, url)
 					if err == nil {
 						log.Infof("Envoy is ready!")

--- a/pilot/cmd/pilot-agent/app/wait.go
+++ b/pilot/cmd/pilot-agent/app/wait.go
@@ -45,9 +45,9 @@ var (
 
 			for {
 				select {
-				case <- timeout:
+				case <-timeout:
 					return fmt.Errorf("timeout waiting for Envoy proxy to become ready. Last error: %v", err)
-				case <- time.After(time.Duration(periodMillis) * time.Second):
+				case <-time.After(time.Duration(periodMillis) * time.Second):
 					err = checkIfReady(client, url)
 					if err == nil {
 						log.Infof("Envoy is ready!")

--- a/pilot/cmd/pilot-agent/app/wait.go
+++ b/pilot/cmd/pilot-agent/app/wait.go
@@ -47,7 +47,7 @@ var (
 				select {
 				case <-timeout:
 					return fmt.Errorf("timeout waiting for Envoy proxy to become ready. Last error: %v", err)
-				case <-time.After(time.Duration(periodMillis) * time.Milliseconds):
+				case <-time.After(time.Duration(periodMillis) * time.Millisecond):
 					err = checkIfReady(client, url)
 					if err == nil {
 						log.Infof("Envoy is ready!")


### PR DESCRIPTION
**Please provide a description of this PR:**

Fix bug for the istio-agent wait command to make sure that it is really timeout.
In old code, both `time.Now().Before(timeoutAt)` and `time.Sleep(time.Duration(periodMillis) * time.Millisecond)` determine the istio-agent wait command is time out or not. Whatever the `periodMillis` user sets, there may be a situation that wait command is not really timeout, but timeout because current time may be `After` the `timeoutAt` due to `time.Sleep`

In new code, introduce a channel for time counter and `select` for this timeout check, then remove `periodMillis` option.