### PR TITLE
tf: export external service to same namespace only

### DIFF
--- a/pkg/test/framework/components/echo/common/deployment/namespace.go
+++ b/pkg/test/framework/components/echo/common/deployment/namespace.go
@@ -252,6 +252,7 @@ kind: ServiceEntry
 metadata:
   name: external-service
 spec:
+  exportTo: [.]
   hosts:
   - {{.Hostname}}
   location: MESH_EXTERNAL

--- a/tests/integration/telemetry/stats/prometheus/stats.go
+++ b/tests/integration/telemetry/stats/prometheus/stats.go
@@ -41,6 +41,7 @@ import (
 	"istio.io/istio/pkg/test/framework/components/prometheus"
 	"istio.io/istio/pkg/test/framework/features"
 	"istio.io/istio/pkg/test/framework/resource"
+	"istio.io/istio/pkg/test/framework/resource/config/apply"
 	"istio.io/istio/pkg/test/util/retry"
 	util "istio.io/istio/tests/integration/telemetry"
 )
@@ -223,7 +224,7 @@ func TestStatsGatewayServerTCPFilter(t *testing.T, feature features.Feature) {
 
 			// The main SE is available only to app namespace, make one the egress can access.
 			t.ConfigIstio().Eval(ist.Settings().SystemNamespace, map[string]interface{}{
-				"Namespace": GetAppNamespace().Name(),
+				"Namespace": apps.External.Namespace.Name(),
 				"Hostname":  cdeployment.ExternalHostname,
 			}, `apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
@@ -241,8 +242,7 @@ spec:
   - name: https
     number: 443
     protocol: HTTPS
-    targetPort: 18443
-`)
+`).ApplyOrFail(t, apply.NoCleanup)
 			g, _ := errgroup.WithContext(context.Background())
 			for _, cltInstance := range GetClientInstances() {
 				cltInstance := cltInstance

--- a/tests/integration/telemetry/stats/prometheus/stats.go
+++ b/tests/integration/telemetry/stats/prometheus/stats.go
@@ -220,6 +220,29 @@ func TestStatsGatewayServerTCPFilter(t *testing.T, feature features.Feature) {
 			t.ConfigIstio().File(GetAppNamespace().Name(), filepath.Join(base, "istio-mtls-dest-rule.yaml")).ApplyOrFail(t)
 			t.ConfigIstio().File(GetAppNamespace().Name(), filepath.Join(base, "istio-mtls-gateway.yaml")).ApplyOrFail(t)
 			t.ConfigIstio().File(GetAppNamespace().Name(), filepath.Join(base, "istio-mtls-vs.yaml")).ApplyOrFail(t)
+
+			// The main SE is available only to app namespace, make one the egress can access.
+			t.ConfigIstio().Eval(ist.Settings().SystemNamespace, map[string]interface{}{
+				"Namespace": GetAppNamespace().Name(),
+				"Hostname":  cdeployment.ExternalHostname,
+			}, `apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: external-service
+spec:
+  exportTo: [.]
+  hosts:
+  - {{.Hostname}}
+  location: MESH_EXTERNAL
+  resolution: DNS
+  endpoints:
+  - address: external.{{.Namespace}}.svc.cluster.local
+  ports:
+  - name: https
+    number: 443
+    protocol: HTTPS
+    targetPort: 18443
+`)
 			g, _ := errgroup.WithContext(context.Background())
 			for _, cltInstance := range GetClientInstances() {
 				cltInstance := cltInstance


### PR DESCRIPTION
This avoids spammy logs about overlapping hostnames. This also makes it
so we actually send to the per-namespace external service I think. This
shouldn't really matter much in practice.

**Please provide a description of this PR:**