### PR TITLE
tf: add explicit loggs when stuck in warming state

### DIFF
--- a/pkg/test/kube/dump.go
+++ b/pkg/test/kube/dump.go
@@ -432,6 +432,18 @@ func dumpProxyCommand(c cluster.Cluster, pod corev1.Pod, workDir, filename, comm
 				scopes.Framework.Errorf("Unable to write output for command %q on cluster/pod/container: %s/%s/%s: %v",
 					command, c.Name(), pod.Namespace, pod.Name, container.Name, err)
 			}
+			if filename == "proxy-config.json" {
+				cds := strings.Contains(cfgDump, "dynamic_warming_clusters")
+				sds := strings.Contains(cfgDump, "dynamic_warming_secrets")
+				lds := strings.Contains(cfgDump, "warming_state")
+				// Add extra logs if we have anything warming. FAIL syntax is import to make prow highlight
+				// it. Note: this doesn't make the test fail, just adds logging; if we hit this code the test
+				// already failed.
+				if cds || lds || sds {
+					scopes.Framework.Warnf("FAIL: cluster/pod %s/%s/%s found warming resources",
+						c.Name(), pod.Namespace, pod.Name)
+				}
+			}
 		} else {
 			scopes.Framework.Errorf("Unable to get execute command %q on cluster/pod: %s/%s/%s for: %v",
 				command, c.Name(), pod.Namespace, pod.Name, err)


### PR DESCRIPTION
Lately a bunch of issues have been caused by things stuck warming. This
makes these obvious to see without poking through 10000s of lines of
artifacts

**Please provide a description of this PR:**