### PR TITLE
Fix typo of InsertDataToConfigMap func description

### DIFF
--- a/security/pkg/k8s/configutil.go
+++ b/security/pkg/k8s/configutil.go
@@ -29,10 +29,9 @@ import (
 
 // InsertDataToConfigMap inserts a data to a configmap in a namespace.
 // client: the k8s client interface.
-// namespace: the namespace of the configmap.
-// value: the value of the data to insert.
-// configName: the name of the configmap.
-// dataName: the name of the data in the configmap.
+// lister: the configmap lister.
+// meta: the metadata of configmap.
+// caBundle: ca cert data bytes.
 func InsertDataToConfigMap(client corev1.ConfigMapsGetter, lister listerv1.ConfigMapLister, meta metav1.ObjectMeta, caBundle []byte) error {
 	configmap, err := lister.ConfigMaps(meta.Namespace).Get(meta.Name)
 	if err != nil && !errors.IsNotFound(err) {


### PR DESCRIPTION
**Please provide a description of this PR:**

Fix typo of InsertDataToConfigMap func description which is stale and not suitable for current implementation.


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
