### PR TITLE
tf: make requests a bit more leniant

### DIFF
--- a/pkg/test/framework/components/echo/flags.go
+++ b/pkg/test/framework/components/echo/flags.go
@@ -22,11 +22,11 @@ import (
 )
 
 var (
-	callTimeout      = 20 * time.Second
-	callDelay        = 10 * time.Millisecond
+	callTimeout      = 30 * time.Second
+	callDelay        = 20 * time.Millisecond
 	callConverge     = 3
 	readinessTimeout = 10 * time.Minute
-	callsPerWorkload = 5
+	callsPerWorkload = 3
 )
 
 // init registers the command-line flags that we can exposed for "go test".


### PR DESCRIPTION
We have seen substantial flakes recently. These are partially due to
loaded systems (for example, we have seen issues where XDS takes >20s to
update. This is not a bug, Envoy is just slow (likely CPU overloaded)).
Other legitimate bugs don't typically recover at all, so I don't think
we will ignore many legitimate issues (other than
https://github.com/istio/istio/issues/38982, which we already know about
and cannot do much about).

This bumps the timeout a big, increases retry interval a bit as well to
reduce load, and reduces the total requests sent. 3 should still be
sufficient to get cross-X load balancing, as we send `requests*clusters`
already so we have 9 requests.

**Please provide a description of this PR:**