### PR TITLE
tf: improve dumping

### DIFF
--- a/pkg/kube/mock_client.go
+++ b/pkg/kube/mock_client.go
@@ -80,6 +80,9 @@ type MockClient struct {
 	IstiodVersion     string
 }
 
+func (c MockClient) SetPortManager(manager PortManager) {
+}
+
 func (c MockClient) WaitForCacheSync(stop <-chan struct{}, cacheSyncs ...cache.InformerSynced) bool {
 	return WaitForCacheSync(stop, cacheSyncs...)
 }

--- a/pkg/kube/portforwarder.go
+++ b/pkg/kube/portforwarder.go
@@ -106,13 +106,13 @@ func (f *forwarder) WaitForStop() {
 	<-f.stopCh
 }
 
-func newPortForwarder(restConfig *rest.Config, podName, ns, localAddress string, localPort, podPort int) (PortForwarder, error) {
+func newPortForwarder(c *client, podName, ns, localAddress string, localPort, podPort int) (PortForwarder, error) {
 	if localAddress == "" {
 		localAddress = defaultLocalAddress
 	}
 	f := &forwarder{
 		stopCh:       make(chan struct{}),
-		restConfig:   restConfig,
+		restConfig:   c.config,
 		podName:      podName,
 		ns:           ns,
 		localAddress: localAddress,
@@ -121,10 +121,11 @@ func newPortForwarder(restConfig *rest.Config, podName, ns, localAddress string,
 	}
 	if f.localPort == 0 {
 		var err error
-		f.localPort, err = availablePort(f.localAddress)
+		reserved, err := c.portManager()
 		if err != nil {
 			return nil, fmt.Errorf("failure allocating port: %v", err)
 		}
+		f.localPort = int(reserved)
 	}
 
 	sLocalPort := fmt.Sprintf("%d", f.localPort)
@@ -175,18 +176,4 @@ func (f *forwarder) buildK8sPortForwarder(readyCh chan struct{}) (*portforward.P
 	}
 
 	return fw, nil
-}
-
-func availablePort(localAddr string) (int, error) {
-	addr, err := net.ResolveTCPAddr("tcp", net.JoinHostPort(localAddr, "0"))
-	if err != nil {
-		return 0, err
-	}
-
-	l, err := net.ListenTCP("tcp", addr)
-	if err != nil {
-		return 0, err
-	}
-	port := l.Addr().(*net.TCPAddr).Port
-	return port, l.Close()
 }

--- a/pkg/test/framework/components/cluster/kube/factory.go
+++ b/pkg/test/framework/components/cluster/kube/factory.go
@@ -24,6 +24,7 @@ import (
 	istioKube "istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/test/framework/components/cluster"
 	"istio.io/istio/pkg/test/util/file"
+	"istio.io/istio/pkg/test/util/reserveport"
 )
 
 const (
@@ -63,6 +64,11 @@ func buildKube(origCfg cluster.Config, topology cluster.Topology) (cluster.Clust
 			return nil, err
 		}
 	}
+	m, err := reserveport.NewPortManager()
+	if err != nil {
+		return nil, err
+	}
+	client.SetPortManager(m.ReservePortNumber)
 
 	// support fake VMs by default
 	vmSupport := true

--- a/pkg/test/framework/components/istio/config.go
+++ b/pkg/test/framework/components/istio/config.go
@@ -337,6 +337,8 @@ func ClaimSystemNamespace(ctx resource.Context) (namespace.Instance, error) {
 	nsCfg := namespace.Config{
 		Prefix: istioCfg.SystemNamespace,
 		Inject: false,
+		// Already handled directly
+		SkipDump: true,
 	}
 	return namespace.Claim(ctx, nsCfg)
 }

--- a/pkg/test/framework/components/namespace/kube.go
+++ b/pkg/test/framework/components/namespace/kube.go
@@ -51,9 +51,14 @@ type kubeNamespace struct {
 	prefix       string
 	cleanupMutex sync.Mutex
 	cleanupFuncs []func() error
+	skipDump     bool
 }
 
 func (n *kubeNamespace) Dump(ctx resource.Context) {
+	if n.skipDump {
+		scopes.Framework.Debugf("=== Skip dumping Namespace %s State...", n.name)
+		return
+	}
 	scopes.Framework.Errorf("=== Dumping Namespace %s State...", n.name)
 
 	d, err := ctx.CreateTmpDirectory(n.name + "-state")
@@ -143,9 +148,10 @@ func (n *kubeNamespace) Close() error {
 func claimKube(ctx resource.Context, cfg Config) (Instance, error) {
 	name := cfg.Prefix
 	n := &kubeNamespace{
-		ctx:    ctx,
-		prefix: name,
-		name:   name,
+		ctx:      ctx,
+		prefix:   name,
+		name:     name,
+		skipDump: cfg.SkipDump,
 	}
 
 	id := ctx.TrackResource(n)

--- a/pkg/test/framework/components/namespace/namespace.go
+++ b/pkg/test/framework/components/namespace/namespace.go
@@ -32,6 +32,9 @@ type Config struct {
 	Revision string
 	// Labels to be applied to namespace
 	Labels map[string]string
+	// SkipDump, if enabled, will disable dumping the namespace. This is useful to avoid duplicate
+	// dumping of istio-system.
+	SkipDump bool
 }
 
 func (c *Config) overwriteRevisionIfEmpty(revision string) {

--- a/pkg/test/framework/resource/context.go
+++ b/pkg/test/framework/resource/context.go
@@ -80,5 +80,5 @@ type Context interface {
 	// RecordTraceEvent records an event. This is later saved to trace.yaml for analysis
 	RecordTraceEvent(key string, value interface{})
 	// Id returns the name of the context
-	Id() string
+	ID() string
 }

--- a/pkg/test/framework/resource/context.go
+++ b/pkg/test/framework/resource/context.go
@@ -79,4 +79,6 @@ type Context interface {
 
 	// RecordTraceEvent records an event. This is later saved to trace.yaml for analysis
 	RecordTraceEvent(key string, value interface{})
+	// Id returns the name of the context
+	Id() string
 }

--- a/pkg/test/framework/scope.go
+++ b/pkg/test/framework/scope.go
@@ -191,7 +191,7 @@ func (s *scope) dump(ctx resource.Context, recursive bool) {
 	}
 	st := time.Now()
 	defer func() {
-		scopes.Framework.Debugf("Done dumping: %s for %s (%v)", s.id, ctx.Id(), time.Since(st))
+		scopes.Framework.Debugf("Done dumping: %s for %s (%v)", s.id, ctx.ID(), time.Since(st))
 	}()
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/pkg/test/framework/scope.go
+++ b/pkg/test/framework/scope.go
@@ -191,7 +191,7 @@ func (s *scope) dump(ctx resource.Context, recursive bool) {
 	}
 	st := time.Now()
 	defer func() {
-		scopes.Framework.Debugf("Done dumping scope: %s (%v)", s.id, time.Since(st))
+		scopes.Framework.Debugf("Done dumping: %s for %s (%v)", s.id, ctx.Id(), time.Since(st))
 	}()
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/pkg/test/framework/suitecontext.go
+++ b/pkg/test/framework/suitecontext.go
@@ -232,7 +232,7 @@ func (c *suiteContext) RequestTestDump() bool {
 	return c.dumpCount.Inc() < c.settings.MaxDumps
 }
 
-func (c *suiteContext) Id() string {
+func (c *suiteContext) ID() string {
 	return c.globalScope.id
 }
 

--- a/pkg/test/framework/suitecontext.go
+++ b/pkg/test/framework/suitecontext.go
@@ -232,6 +232,10 @@ func (c *suiteContext) RequestTestDump() bool {
 	return c.dumpCount.Inc() < c.settings.MaxDumps
 }
 
+func (c *suiteContext) Id() string {
+	return c.globalScope.id
+}
+
 type Outcome string
 
 const (

--- a/pkg/test/framework/testcontext.go
+++ b/pkg/test/framework/testcontext.go
@@ -385,7 +385,7 @@ func (c *testContext) Skipped() bool {
 	return c.T.Skipped()
 }
 
-func (c *testContext) Id() string {
+func (c *testContext) ID() string {
 	return c.id
 }
 

--- a/pkg/test/framework/testcontext.go
+++ b/pkg/test/framework/testcontext.go
@@ -385,6 +385,10 @@ func (c *testContext) Skipped() bool {
 	return c.T.Skipped()
 }
 
+func (c *testContext) Id() string {
+	return c.id
+}
+
 var _ io.Closer = &closer{}
 
 type closer struct {

--- a/pkg/test/kube/dump.go
+++ b/pkg/test/kube/dump.go
@@ -15,6 +15,7 @@
 package kube
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -480,9 +481,9 @@ func dumpProxyCommand(c cluster.Cluster, fw kube.PortForwarder, pod corev1.Pod, 
 					path, c.Name(), pod.Namespace, pod.Name, container.Name, err)
 			}
 			if filename == "proxy-config.json" {
-				cds := strings.Contains(cfgDump, "dynamic_warming_clusters")
-				sds := strings.Contains(cfgDump, "dynamic_warming_secrets")
-				lds := strings.Contains(cfgDump, "warming_state")
+				cds := bytes.Contains(cfgDump, []byte("dynamic_warming_clusters"))
+				sds := bytes.Contains(cfgDump, []byte("dynamic_warming_secrets"))
+				lds := bytes.Contains(cfgDump, []byte("warming_state"))
 				// Add extra logs if we have anything warming. FAIL syntax is import to make prow highlight
 				// it. Note: this doesn't make the test fail, just adds logging; if we hit this code the test
 				// already failed.

--- a/pkg/test/kube/dump.go
+++ b/pkg/test/kube/dump.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"path"
 	"path/filepath"
@@ -26,11 +28,13 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"go.uber.org/atomic"
+	"golang.org/x/sync/errgroup"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 
 	"istio.io/api/annotation"
+	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/test/framework/components/cluster"
 	"istio.io/istio/pkg/test/framework/components/istioctl"
 	"istio.io/istio/pkg/test/framework/resource"
@@ -271,6 +275,12 @@ func DumpPodEvents(_ resource.Context, c cluster.Cluster, workDir, namespace str
 			return
 		}
 
+		for i := range list.Items {
+			e := list.Items[i]
+			e.ManagedFields = nil
+			list.Items[i] = e
+		}
+
 		out, err := yaml.Marshal(list.Items)
 		if err != nil {
 			scopes.Framework.Warnf("Error marshaling pod event for output: %v", err)
@@ -408,17 +418,54 @@ func DumpPodLogs(_ resource.Context, c cluster.Cluster, workDir, namespace strin
 // or all pods in the namespace if none are provided.
 func DumpPodProxies(_ resource.Context, c cluster.Cluster, workDir, namespace string, pods ...corev1.Pod) {
 	pods = podsOrFetch(c, pods, namespace)
+	g := errgroup.Group{}
 	for _, pod := range pods {
+		pod := pod
 		if !hasEnvoy(pod) {
 			continue
 		}
-		dumpProxyCommand(c, pod, workDir, "proxy-config.json", "pilot-agent request GET config_dump?include_eds=true")
-		dumpProxyCommand(c, pod, workDir, "proxy-clusters.txt", "pilot-agent request GET clusters")
-		dumpProxyCommand(c, pod, workDir, "proxy-stats.txt", "pilot-agent request GET stats/prometheus")
+
+		g.Go(func() error {
+			fw, err := c.NewPortForwarder(pod.Name, pod.Namespace, "127.0.0.1", 0, 15000)
+			if err != nil {
+				return err
+			}
+			if err = fw.Start(); err != nil {
+				return err
+			}
+			defer fw.Close()
+			dumpProxyCommand(c, fw, pod, workDir, "proxy-config.json", "config_dump?include_eds=true")
+			dumpProxyCommand(c, fw, pod, workDir, "proxy-clusters.txt", "clusters")
+			dumpProxyCommand(c, fw, pod, workDir, "proxy-stats.txt", "stats/prometheus")
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		scopes.Framework.Errorf("dump failed: %v", err)
 	}
 }
 
-func dumpProxyCommand(c cluster.Cluster, pod corev1.Pod, workDir, filename, command string) {
+func portForwardRequest(fw kube.PortForwarder, method, path string) ([]byte, error) {
+	req, err := http.NewRequest(method, fmt.Sprintf("http://%s/%s", fw.Address(), path), nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+	out, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}
+
+func dumpProxyCommand(c cluster.Cluster, fw kube.PortForwarder, pod corev1.Pod, workDir, filename, path string) {
 	containers := append(pod.Spec.Containers, pod.Spec.InitContainers...)
 	for _, container := range containers {
 		if !proxyContainer.IsContainer(container) {
@@ -426,11 +473,11 @@ func dumpProxyCommand(c cluster.Cluster, pod corev1.Pod, workDir, filename, comm
 			continue
 		}
 
-		if cfgDump, _, err := c.PodExec(pod.Name, pod.Namespace, container.Name, command); err == nil {
+		if cfgDump, err := portForwardRequest(fw, "GET", path); err == nil {
 			fname := podOutputPath(workDir, c, pod, filename)
-			if err = os.WriteFile(fname, []byte(cfgDump), os.ModePerm); err != nil {
+			if err = os.WriteFile(fname, cfgDump, os.ModePerm); err != nil {
 				scopes.Framework.Errorf("Unable to write output for command %q on cluster/pod/container: %s/%s/%s: %v",
-					command, c.Name(), pod.Namespace, pod.Name, container.Name, err)
+					path, c.Name(), pod.Namespace, pod.Name, container.Name, err)
 			}
 			if filename == "proxy-config.json" {
 				cds := strings.Contains(cfgDump, "dynamic_warming_clusters")
@@ -446,7 +493,7 @@ func dumpProxyCommand(c cluster.Cluster, pod corev1.Pod, workDir, filename, comm
 			}
 		} else {
 			scopes.Framework.Errorf("Unable to get execute command %q on cluster/pod: %s/%s/%s for: %v",
-				command, c.Name(), pod.Namespace, pod.Name, err)
+				path, c.Name(), pod.Namespace, pod.Name, err)
 		}
 	}
 }
@@ -516,7 +563,23 @@ func DumpDebug(ctx resource.Context, c cluster.Cluster, workDir string, endpoint
 }
 
 func DumpNdsz(_ resource.Context, c cluster.Cluster, workDir string, _ string, pods ...corev1.Pod) {
+	g := errgroup.Group{}
 	for _, pod := range pods {
-		dumpProxyCommand(c, pod, workDir, "ndsz.json", "pilot-agent request --debug-port 15020 GET /debug/ndsz")
+		pod := pod
+		g.Go(func() error {
+			fw, err := c.NewPortForwarder(pod.Name, pod.Namespace, "127.0.0.1", 0, 15020)
+			if err != nil {
+				return err
+			}
+			if err = fw.Start(); err != nil {
+				return err
+			}
+			defer fw.Close()
+			dumpProxyCommand(c, fw, pod, workDir, "ndsz.json", "debug/ndsz")
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		scopes.Framework.Errorf("failed to dump ndsz: %v", err)
 	}
 }


### PR DESCRIPTION
This was initially a bug fix but then I realized I was misguided.
However, along the way I made some improvements to the dumping logic.

* We were dumping istio-system 2x; fix that
* We were using PodExec which is slow. Switch to port forward which is
  10x+ faster. Also use a more robust mechanism to resrve ports
* Dump in parallel
* Add some better logging around dumping
* Clear managedFields from events for size/readability

**Please provide a description of this PR:**