### PR TITLE
xds: fix issue when skipping first request

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -472,8 +472,12 @@ func (pr *PushRequest) CopyMerge(other *PushRequest) *PushRequest {
 	return merged
 }
 
+func (pr *PushRequest) IsRequest() bool {
+	return len(pr.Reason) == 1 && pr.Reason[0] == ProxyRequest
+}
+
 func (pr *PushRequest) PushReason() string {
-	if len(pr.Reason) == 1 && pr.Reason[0] == ProxyRequest {
+	if pr.IsRequest() {
 		return " request"
 	}
 	return ""

--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -340,7 +340,11 @@ func (configgen *ConfigGeneratorImpl) buildGatewayHTTPRouteConfig(node *model.Pr
 
 		// This can happen when a gateway has recently been deleted. Envoy will still request route
 		// information due to the draining of listeners, so we should not return an error.
-		return nil
+		return &route.RouteConfiguration{
+			Name:             routeName,
+			VirtualHosts:     []*route.VirtualHost{},
+			ValidateClusters: proto.BoolFalse,
+		}
 	}
 
 	servers := merged.ServersByRouteName[routeName]

--- a/pilot/pkg/xds/xdsgen.go
+++ b/pilot/pkg/xds/xdsgen.go
@@ -114,13 +114,27 @@ func (s *DiscoveryServer) pushXds(con *Connection, w *model.WatchedResource, req
 		}
 	}
 	res, logdata, err := gen.Generate(con.proxy, w, req)
+	info := ""
+	if len(logdata.AdditionalInfo) > 0 {
+		info = " " + logdata.AdditionalInfo
+	}
+	if len(logFiltered) > 0 {
+		info += logFiltered
+	}
 	if err != nil || res == nil {
 		// If we have nothing to send, report that we got an ACK for this version.
 		if s.StatusReporter != nil {
 			s.StatusReporter.RegisterEvent(con.conID, w.TypeUrl, req.Push.LedgerVersion)
 		}
 		if log.DebugEnabled() {
-			log.Debugf("%s: SKIP%s for node:%s", v3.GetShortType(w.TypeUrl), req.PushReason(), con.proxy.ID)
+			log.Debugf("%s: SKIP%s for node:%s%s", v3.GetShortType(w.TypeUrl), req.PushReason(), con.proxy.ID, info)
+		}
+
+		// If we are sending a request, we must respond or we can get Envoy stuck. Assert we do.
+		// One exception is if Envoy is simply unsubscribing from some resources, in which case we can skip.
+		isUnsubscribe := features.PartialFullPushes && !req.Delta.IsEmpty() && req.Delta.Subscribed.IsEmpty()
+		if features.EnableUnsafeAssertions && err == nil && res == nil && req.IsRequest() && !isUnsubscribe {
+			log.Fatalf("%s: SKIPPED%s for node:%s%s but expected a response for request", v3.GetShortType(w.TypeUrl), req.PushReason(), con.proxy.ID, info)
 		}
 		return err
 	}
@@ -139,15 +153,8 @@ func (s *DiscoveryServer) pushXds(con *Connection, w *model.WatchedResource, req
 	configSizeBytes.With(typeTag.Value(w.TypeUrl)).Record(float64(configSize))
 
 	ptype := "PUSH"
-	info := ""
 	if logdata.Incremental {
 		ptype = "PUSH INC"
-	}
-	if len(logdata.AdditionalInfo) > 0 {
-		info = " " + logdata.AdditionalInfo
-	}
-	if len(logFiltered) > 0 {
-		info += logFiltered
 	}
 
 	if err := con.send(resp); err != nil {


### PR DESCRIPTION
The bug (example failure:
https://prow.istio.io/view/gs/istio-prow/pr-logs/pull/istio_istio/39896/integ-cni_istio/1546984256612339712)
* ingressgateway has 1 Gateway
* Gateway is removed
* envoy disconnects
* Envoy reconnects, requests RDS. This hits the INIT/RECONNECT flow.
* RDS hits 'Gateway missing for route' path and gives no response at all
* Next RDS request, we get a "stale nonce" since we have no previously
  sent nonce
* Envoy stuck forever

The fix:
* Remove code path to return empty route instead of no route (matching
  other paths)
* Add assertions to ensure that we don't send empty response to requests
  and that we never count a "stale nonce" if we somehow have no
previously sent nonce, to ensure there aren't any other issues

**Please provide a description of this PR:**