### PR TITLE
tf: drop unused feature in external_ca

### DIFF
--- a/tests/integration/security/external_ca/main_test.go
+++ b/tests/integration/security/external_ca/main_test.go
@@ -73,7 +73,6 @@ values:
   meshConfig:
     defaultConfig:
       proxyMetadata:
-        PROXY_CONFIG_XDS_AGENT: "true"
         ISTIO_META_CERT_SIGNER: signer1
     trustDomainAliases: [some-other, trust-domain-foo]
     caCertificates:


### PR DESCRIPTION
This flag requires the control plane to also have support, and its not
enabled. This also breaks a (test only) assertion added in
https://github.com/istio/istio/pull/39916.

**Please provide a description of this PR:**