### PR TITLE
xds: always respond to EDS request after CDS requests

### DIFF
--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -355,6 +355,11 @@ type WatchedResource struct {
 	// NonceNacked is the last nacked message. This is reset following a successful ACK
 	NonceNacked string
 
+	// AlwaysRespond, if true, will ensure that even when a request would otherwise be treated as an
+	// ACK, it will be responded to. Typically, this should be set to 'false' after response; keeping it
+	// true would likely result in an endless loop.
+	AlwaysRespond bool
+
 	// LastSent tracks the time of the generated push, to determine the time it takes the client to ack.
 	LastSent time.Time
 

--- a/pilot/pkg/xds/ads_test.go
+++ b/pilot/pkg/xds/ads_test.go
@@ -97,6 +97,45 @@ func TestAdsReconnectAfterRestart(t *testing.T) {
 	})
 }
 
+// TestAdsReconnectRequests provides a regression test for a case where Envoy sends an EDS request as the first
+// request on a connection.
+func TestAdsReconnectRequests(t *testing.T) {
+	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
+
+	ads := s.ConnectADS()
+	// Send normal CDS and EDS requests
+	_ = ads.RequestResponseAck(t, &discovery.DiscoveryRequest{TypeUrl: v3.ClusterType})
+	eres := ads.RequestResponseAck(t, &discovery.DiscoveryRequest{TypeUrl: v3.EndpointType, ResourceNames: []string{"my-resource"}})
+
+	// A push should get a response for both
+	s.Discovery.ConfigUpdate(&model.PushRequest{Full: true})
+	ads.ExpectResponse(t)
+	ads.ExpectResponse(t)
+	// Close the connection and reconnect
+	ads.Cleanup()
+	ads = s.ConnectADS()
+
+	// Send a request for EDS version 1 - we do not explicitly ACK this.
+	ads.Request(t, &discovery.DiscoveryRequest{
+		TypeUrl:       v3.EndpointType,
+		ResourceNames: []string{"my-resource"},
+		ResponseNonce: eres.Nonce,
+	})
+	// We should get a response
+	eres3 := ads.ExpectResponse(t)
+	// Now send our CDS request
+	ads.RequestResponseAck(t, &discovery.DiscoveryRequest{
+		TypeUrl:       v3.ClusterType,
+		ResponseNonce: eres.Nonce,
+	})
+	// Send another request. This is essentially an ACK of eres3. However, envoy expects a response
+	ads.RequestResponseAck(t, &discovery.DiscoveryRequest{
+		TypeUrl:       v3.EndpointType,
+		ResourceNames: []string{"my-resource"},
+		ResponseNonce: eres3.Nonce,
+	})
+}
+
 // TestAdsDoubleNonce tests the PushOnRepeatNonce flag. If enabled, we should see a response to our repeated request.
 func TestAdsDoubleNonce(t *testing.T) {
 	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})

--- a/pilot/pkg/xds/discovery_test.go
+++ b/pilot/pkg/xds/discovery_test.go
@@ -365,6 +365,27 @@ func TestShouldRespond(t *testing.T) {
 			response: false,
 		},
 		{
+			name: "ack forced",
+			connection: &Connection{
+				proxy: &model.Proxy{
+					WatchedResources: map[string]*model.WatchedResource{
+						v3.EndpointType: {
+							VersionSent:   "v1",
+							NonceSent:     "nonce",
+							AlwaysRespond: true,
+						},
+					},
+				},
+			},
+			request: &discovery.DiscoveryRequest{
+				TypeUrl:       v3.EndpointType,
+				VersionInfo:   "v1",
+				ResponseNonce: "nonce",
+				ResourceNames: []string{"my-resource"},
+			},
+			response: true,
+		},
+		{
 			name: "nack",
 			connection: &Connection{
 				proxy: &model.Proxy{


### PR DESCRIPTION
This fixes an edge case that happens to be triggering many test flakes. https://prow.istio.io/view/gs/istio-prow/pr-logs/pull/istio_istio/39896/integ-security-multicluster_istio/1547605105740615680 for example.

What happens is:

```
1. Envoy connect
2. Envoy REQ EDS, nonce=e1
3. Istiod pushes EDS, nonce=e2
4. Envoy REQ CDS
5. Istio pushes CDS
6. Envoy REQ EDS, nonce=e2
7. Istiod treats this as an ACK (from push (3))
```

Then envoy cluster is struck warming.

This solution seems super hacky, but it seems to work (in https://github.com/istio/istio/pull/39896 tested 6x without flakes - prior to this it fails like 50%+ of the time). Basically, if we get a CDS request, we always respond to the next EDS request. This ONLY occurs when EDS is the first request and at worst causes 1 extra EDS push (which I don't even think its "extra" - AFAIK its required in all cases).

I will be retesting https://github.com/istio/istio/pull/39896  overnight so should give us about 10 more trials before tomorrow morning if we want more validation this fixes this issue.

BTW - the reason this is suddenly an issue is because we started testing a lower max connection age. These bugs were always present, but they only happened on xds reconnects which never happened in our test environments.