### PR TITLE
fix the bug for rds failure due to duplicate entry of domain in some routes

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -277,7 +277,6 @@ func buildSidecarVirtualHostsForService(
 	routeName string,
 ) []VirtualHostWrapper {
 	out := make([]VirtualHostWrapper, 0)
-
 	needIPv6Hosts := strings.HasSuffix(routeName, constants.IPv6Suffix)
 	for _, svc := range serviceRegistry {
 		for _, port := range svc.Ports {

--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -277,6 +277,7 @@ func buildSidecarVirtualHostsForService(
 	routeName string,
 ) []VirtualHostWrapper {
 	out := make([]VirtualHostWrapper, 0)
+
 	needIPv6Hosts := strings.HasSuffix(routeName, constants.IPv6Suffix)
 	for _, svc := range serviceRegistry {
 		for _, port := range svc.Ports {


### PR DESCRIPTION
fix the bug for rds sync failure due to duplicate entry of domain in some routes

Signed-off-by: zhanghw0354 <zhanghaiwencmss@139.com>

**Please provide a description of this PR:**
Sometimes RDS may fail，It shows that RDS status is "STALE(Never Acknowledged)" 
![image](https://user-images.githubusercontent.com/8104839/179150006-e20a8072-b896-456a-8fd8-51127774a228.png)

There are warn messages in istiod logs like "ADS:RDS: ACK ERROR provider-v0-0-2-5b577b8f-jdph2.sm-11 Internal:Only unique values for domains are permitted. Duplicate entry of domain prometheus-node-exporter.kube-system.svc.cluster.local in route 9100.ipv6"
![image](https://user-images.githubusercontent.com/8104839/179150059-e2920fa9-a0f7-49c4-b398-7cf70e016983.png)

It shows that there is duplicate entry of domain prometheus-node-exporter.kube-system.svc.cluster.local in route 9100.ipv6 in the logs due to two similar virtualhosts with duplicate domain.

This PR is to fix this bug.