### PR TITLE
Convert mockprom to metrics endpoint test to a subtest

### DIFF
--- a/tests/integration/telemetry/stats/prometheus/stats.go
+++ b/tests/integration/telemetry/stats/prometheus/stats.go
@@ -150,23 +150,26 @@ func TestStatsFilter(t *testing.T, feature features.Feature) {
 			}
 
 			// In addition, verifies that mocked prometheus could call metrics endpoint with proxy provisioned certs
-			for _, prom := range mockProm {
-				st := match.Cluster(prom.Config().Cluster).FirstOrFail(t, GetTarget().Instances())
-				prom.CallOrFail(t, echo.CallOptions{
-					ToWorkload: st,
-					Scheme:     scheme.HTTPS,
-					Port:       echo.Port{ServicePort: 15014},
-					HTTP: echo.HTTP{
-						Path: "/metrics",
-					},
-					TLS: echo.TLS{
-						CertFile:           "/etc/certs/custom/cert-chain.pem",
-						KeyFile:            "/etc/certs/custom/key.pem",
-						CaCertFile:         "/etc/certs/custom/root-cert.pem",
-						InsecureSkipVerify: true,
-					},
+			t.NewSubTest("mockprom-to-metrics").Run(
+				func(t framework.TestContext) {
+					for _, prom := range mockProm {
+						st := match.Cluster(prom.Config().Cluster).FirstOrFail(t, GetTarget().Instances())
+						prom.CallOrFail(t, echo.CallOptions{
+							ToWorkload: st,
+							Scheme:     scheme.HTTPS,
+							Port:       echo.Port{ServicePort: 15014},
+							HTTP: echo.HTTP{
+								Path: "/metrics",
+							},
+							TLS: echo.TLS{
+								CertFile:           "/etc/certs/custom/cert-chain.pem",
+								KeyFile:            "/etc/certs/custom/key.pem",
+								CaCertFile:         "/etc/certs/custom/root-cert.pem",
+								InsecureSkipVerify: true,
+							},
+						})
+					}
 				})
-			}
 		})
 }
 


### PR DESCRIPTION
Previous to this PR, the TestStatsFilter testcase checks the stats filter and also tests if a mocked prometheus app can call the app metrics endpoint.
This PR moves the mocked prometheus test to a subtest so that it can be skipped if required.

**Please provide a description of this PR:**



**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [x] Policies and Telemetry
- [ ] Security
- [x] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
