### PR TITLE
tf: loosen restrictions on 'real stackdriver' testing

### DIFF
--- a/pkg/test/framework/components/stackdriver/stackdriver.go
+++ b/pkg/test/framework/components/stackdriver/stackdriver.go
@@ -19,7 +19,6 @@ import (
 	loggingpb "google.golang.org/genproto/googleapis/logging/v2"
 	monitoringpb "google.golang.org/genproto/googleapis/monitoring/v3"
 
-	md "istio.io/istio/pkg/bootstrap/platform"
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/cluster"
@@ -61,7 +60,7 @@ func NewOrFail(t test.Failer, ctx resource.Context, c Config, realSD bool) Insta
 }
 
 func UseRealStackdriver() bool {
-	// Use real stackdriver only if the test intends to AND the test is running on GCP.
-	// Currently real stackdriver only works if the test runs on GCP.
-	return framework.UseRealStackdriver && md.IsGCP()
+	// If the framework requests a real backend, honor that request. It is possible
+	// to configure the CA to generate GCP credentials off-GCP.
+	return framework.UseRealStackdriver
 }


### PR DESCRIPTION
This removes the requirement that testing that uses the production Cloud Monitoring endpoint be run on GCP. There are configurations of Istio that enable the CA to provide auth to GCP endpoints. This should allow testing on off-GCP platforms when configured in that manner.

- [ X ] Test and Release
- [ X ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
