### PR TITLE
added a fix to resolve cross cluster traffic

### DIFF
--- a/pkg/test/framework/components/echo/check/checkers.go
+++ b/pkg/test/framework/components/echo/check/checkers.go
@@ -431,9 +431,19 @@ func ReachedTargetClusters(t framework.TestContext) echo.Checker {
 // For multi-network configurations, verifies the current (limited) Istio load balancing behavior when going through
 // a gateway. Ensures that all expected networks were reached, and that all clusters on the same network as the
 // client were reached.
-func ReachedClusters(allClusters cluster.Clusters, expectedClusters cluster.Clusters) echo.Checker {
+func ReachedClusters(allClusters cluster.Clusters, expectedClusters cluster.Clusters, t framework.TestContext) echo.Checker {
 	expectedByNetwork := expectedClusters.ByNetwork()
 	return func(result echo.CallResult, err error) error {
+		dnsCaptureEnabled := isDNSCaptureEnabled(t)
+		to := result.Opts.To
+		if !dnsCaptureEnabled && to.Config().IsHeadless() {
+			// Headless services rely on DNS resolution. If DNS capture is
+			// enabled, DNS will return all endpoints in the mesh, which will
+			// allow requests to go cross-cluster. Otherwise, k8s DNS will
+			// only return the endpoints within the same cluster as the source
+			// pod.
+			return checkReachedSourceClusterOnly(result, allClusters)
+		}
 		return checkReachedClusters(result, allClusters, expectedByNetwork)
 	}
 }

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -760,7 +760,7 @@ spec:
 								// Conditionally check reached clusters to work around connection load balancing issues
 								// See https://github.com/istio/istio/issues/32208 for details
 								// We want to skip this for requests from the cross-network pod
-								if err := check.ReachedClusters(t.AllClusters(), toClusters).Check(echo.CallResult{
+								if err := check.ReachedClusters(t.AllClusters(), toClusters, t).Check(echo.CallResult{
 									From:      result.From,
 									Opts:      result.Opts,
 									Responses: hostResponses,

--- a/tests/integration/pilot/ingress_test.go
+++ b/tests/integration/pilot/ingress_test.go
@@ -385,7 +385,7 @@ spec:
 `
 			}
 
-			successChecker := check.And(check.OK(), check.ReachedClusters(t.AllClusters(), apps.B.Clusters()))
+			successChecker := check.And(check.OK(), check.ReachedClusters(t.AllClusters(), apps.B.Clusters(), t))
 			failureChecker := check.Status(http.StatusNotFound)
 			count := 2 * t.Clusters().Len()
 

--- a/tests/integration/pilot/mcs/discoverability/discoverability_test.go
+++ b/tests/integration/pilot/mcs/discoverability/discoverability_test.go
@@ -105,7 +105,7 @@ func TestClusterLocal(t *testing.T) {
 						if ht == hostTypeClusterLocal {
 							// For calls to cluster.local, ensure that all requests stay in the same cluster
 							expectedClusters := cluster.Clusters{from.Config().Cluster}
-							checker = checkClustersReached(t.AllClusters(), expectedClusters)
+							checker = checkClustersReached(t.AllClusters(), expectedClusters, t)
 						} else {
 							// For calls to clusterset.local, we should fail DNS lookup. The clusterset.local host
 							// is only available for a service when it is exported in at least one cluster.
@@ -136,7 +136,7 @@ func TestMeshWide(t *testing.T) {
 							// Ensure that requests to clusterset.local reach all destination clusters.
 							expectedClusters = to.Clusters()
 						}
-						callAndValidate(t, ht, from, to, checkClustersReached(t.AllClusters(), expectedClusters))
+						callAndValidate(t, ht, from, to, checkClustersReached(t.AllClusters(), expectedClusters, t))
 					})
 				})
 			}
@@ -177,7 +177,7 @@ func TestServiceExportedInOneCluster(t *testing.T) {
 											expectedClusters = append(expectedClusters, from.Config().Cluster)
 										}
 									}
-									callAndValidate(t, ht, from, to, checkClustersReached(t.AllClusters(), expectedClusters))
+									callAndValidate(t, ht, from, to, checkClustersReached(t.AllClusters(), expectedClusters, t))
 								})
 							})
 						}
@@ -226,10 +226,10 @@ func newServiceExport(service string, serviceExportGVR schema.GroupVersionResour
 	}
 }
 
-func checkClustersReached(allClusters cluster.Clusters, clusters cluster.Clusters) echo.Checker {
+func checkClustersReached(allClusters cluster.Clusters, clusters cluster.Clusters, t framework.TestContext) echo.Checker {
 	return check.And(
 		check.OK(),
-		check.ReachedClusters(allClusters, clusters))
+		check.ReachedClusters(allClusters, clusters, t))
 }
 
 func checkDNSLookupFailed() echo.Checker {

--- a/tests/integration/pilot/multicluster_test.go
+++ b/tests/integration/pilot/multicluster_test.go
@@ -127,7 +127,7 @@ spec:
 								},
 								Check: check.And(
 									check.OK(),
-									check.ReachedClusters(t.AllClusters(), cluster.Clusters{source.Config().Cluster}),
+									check.ReachedClusters(t.AllClusters(), cluster.Clusters{source.Config().Cluster}, t),
 								),
 								Retry: echo.Retry{
 									Options: []retry.Option{multiclusterRetryDelay, multiclusterRetryTimeout},

--- a/tests/integration/security/reachability_test.go
+++ b/tests/integration/security/reachability_test.go
@@ -451,11 +451,11 @@ func TestReachability(t *testing.T) {
 									} else if c.expectCrossCluster(from, opts) {
 										// Expect to stay in the same network as the source pod.
 										expectedClusters := to.Clusters().ForNetworks(from.Config().Cluster.NetworkName())
-										opts.Check = check.And(opts.Check, check.ReachedClusters(t.Clusters(), expectedClusters))
+										opts.Check = check.And(opts.Check, check.ReachedClusters(t.Clusters(), expectedClusters, t))
 									} else {
 										// Expect to stay in the same cluster as the source pod.
 										expectedClusters := cluster.Clusters{from.Config().Cluster}
-										opts.Check = check.And(opts.Check, check.ReachedClusters(t.Clusters(), expectedClusters))
+										opts.Check = check.And(opts.Check, check.ReachedClusters(t.Clusters(), expectedClusters, t))
 									}
 								} else {
 									successStr = "fail"


### PR DESCRIPTION
**Cross cluster communication in headless services won't work without DNS Proxying, adding a check while running the tests**