### PR TITLE
Skip forward when the proxy connection is closed

### DIFF
--- a/pkg/istio-agent/xds_proxy.go
+++ b/pkg/istio-agent/xds_proxy.go
@@ -277,6 +277,15 @@ func (con *ProxyConnection) sendRequest(req *discovery.DiscoveryRequest) {
 	con.requestsChan.Put(req)
 }
 
+func (con *ProxyConnection) isClosed() bool {
+	select {
+	case <-con.stopChan:
+		return true
+	default:
+		return false
+	}
+}
+
 type adsStream interface {
 	Send(*discovery.DiscoveryResponse) error
 	Recv() (*discovery.DiscoveryRequest, error)
@@ -584,6 +593,10 @@ func (p *XdsProxy) forwardToTap(resp *discovery.DiscoveryResponse) {
 func forwardToEnvoy(con *ProxyConnection, resp *discovery.DiscoveryResponse) {
 	if !v3.IsEnvoyType(resp.TypeUrl) {
 		proxyLog.Errorf("Skipping forwarding type url %s to Envoy as is not a valid Envoy type", resp.TypeUrl)
+		return
+	}
+	if con.isClosed() {
+		// TODO: do we need to redirect to the new connection
 		return
 	}
 	if err := sendDownstream(con.downstream, resp); err != nil {

--- a/pkg/istio-agent/xds_proxy.go
+++ b/pkg/istio-agent/xds_proxy.go
@@ -596,7 +596,7 @@ func forwardToEnvoy(con *ProxyConnection, resp *discovery.DiscoveryResponse) {
 		return
 	}
 	if con.isClosed() {
-		// TODO: do we need to redirect to the new connection
+		proxyLog.Errorf("downstream [%d] dropped xds push to Envoy, connection already closed", con.conID)
 		return
 	}
 	if err := sendDownstream(con.downstream, resp); err != nil {


### PR DESCRIPTION
**Please provide a description of this PR:**
When debugging the CDs warming issue, there are spammy logs sending response to closed proxy connection
```
2022-07-15T23:16:14.575052Z	error	xdsproxy	downstream [6] send error: rpc error: code = Canceled desc = context canceled
2022-07-15T23:16:16.718426Z	info	xdsproxy	connected to upstream XDS server: istiod.istio-system.svc:15012
2022-07-15T23:18:19.791902Z	error	xdsproxy	downstream [7] send error: rpc error: code = Canceled desc = context canceled
2022-07-15T23:18:19.792239Z	error	xdsproxy	downstream [7] send error: rpc error: code = Canceled desc = context canceled
2022-07-15T23:18:20.690916Z	info	xdsproxy	connected to upstream XDS server: istiod.istio-system.svc:15012
```


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
