### PR TITLE
Mitigate TestDNS flakes

### DIFF
--- a/pkg/dns/client/proxy.go
+++ b/pkg/dns/client/proxy.go
@@ -77,6 +77,18 @@ func (p *dnsProxy) close() {
 	}
 }
 
+func (p *dnsProxy) Address() string {
+	if p.server != nil {
+		if p.server.Listener != nil {
+			return p.server.Listener.Addr().String()
+		}
+		if p.server.PacketConn != nil {
+			return p.server.PacketConn.LocalAddr().String()
+		}
+	}
+	return ""
+}
+
 func (p *dnsProxy) ServeDNS(w dns.ResponseWriter, req *dns.Msg) {
 	p.resolver.ServeDNS(p, w, req)
 }


### PR DESCRIPTION
Two issues:
* Port conflict on 15053. Pretty simple, bind to port 0
* We want to test servers supporting TCP+UDP on one port, but we cannot
  atomically reserve a free tcp and udp port. Currently we reserve UDP
first then bind to TCP. This just swaps the order. In practice we have
less UDP listeners, so much less chance of conflict. This dropped flakes
from 1/10 to 1/1000 on my machine

**Please provide a description of this PR:**