### PR TITLE
Run update_deps on the Istio 1.14 branch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -85,8 +85,8 @@ require (
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	helm.sh/helm/v3 v3.8.2
 	istio.io/api v0.0.0-20220718152858-7bfd83f34438
-	istio.io/client-go v1.14.1-0.20220718153259-d44452ee5dba
-	istio.io/pkg v0.0.0-20220512174235-57fb311eddf1
+	istio.io/client-go v1.14.1-0.20220718153558-77785c98004d
+	istio.io/pkg v0.0.0-20220718153201-c20cb8528905
 	k8s.io/api v0.23.5
 	k8s.io/apiextensions-apiserver v0.23.5
 	k8s.io/apimachinery v0.23.5

--- a/go.sum
+++ b/go.sum
@@ -2926,10 +2926,10 @@ honnef.co/go/tools v0.0.1-2020.1.5/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9
 honnef.co/go/tools v0.2.1/go.mod h1:lPVVZ2BS5TfnjLyizF7o7hv7j9/L+8cZY2hLyjP9cGY=
 istio.io/api v0.0.0-20220718152858-7bfd83f34438 h1:EJrRqFr0moqzvmkU622bEgQkEzuag+/VBuND/6yxaYM=
 istio.io/api v0.0.0-20220718152858-7bfd83f34438/go.mod h1:00myJeQGWma4Y5pboJ+MM4P2uqEWulKA1duC8kYN5Wo=
-istio.io/client-go v1.14.1-0.20220718153259-d44452ee5dba h1:RmxebHO9h2mLSNQpdVwUEblLF58+W0+pYZLUJlPv8Fw=
-istio.io/client-go v1.14.1-0.20220718153259-d44452ee5dba/go.mod h1:bWzmzSeO+QZ0VvNCRdmoQGRifKGDF59PGBDa+KWvnHY=
-istio.io/pkg v0.0.0-20220512174235-57fb311eddf1 h1:lyJQnY5WXxG3CTxgheUNrC8OBsZcWDZOnt1RAT/Lq9w=
-istio.io/pkg v0.0.0-20220512174235-57fb311eddf1/go.mod h1:kcBYN5TiyGFM2bs4b7K81j+YeDZ4JrINP+brV9ehZe0=
+istio.io/client-go v1.14.1-0.20220718153558-77785c98004d h1:FFWiN5H9RyF8XeFlhr9L5E34KufWWUR0CqR63asaB1E=
+istio.io/client-go v1.14.1-0.20220718153558-77785c98004d/go.mod h1:bWzmzSeO+QZ0VvNCRdmoQGRifKGDF59PGBDa+KWvnHY=
+istio.io/pkg v0.0.0-20220718153201-c20cb8528905 h1:E1RMmvKUlD4HbkWr3AoDtOSNb2iKLEh77JnwqPUGtnw=
+istio.io/pkg v0.0.0-20220718153201-c20cb8528905/go.mod h1:kcBYN5TiyGFM2bs4b7K81j+YeDZ4JrINP+brV9ehZe0=
 k8s.io/api v0.0.0-20180904230853-4e7be11eab3f/go.mod h1:iuAfoD4hCxJ8Onx9kaTIt30j7jUFS00AXQi6QMi99vA=
 k8s.io/api v0.17.4/go.mod h1:5qxx6vjmwUVG2nHQTKGlLts8Tbok8PzHl4vHtVFuZCA=
 k8s.io/api v0.18.2/go.mod h1:SJCWI7OLzhZSvbY7U8zwNl9UA4o1fizoug34OV/2r78=

--- a/istio.deps
+++ b/istio.deps
@@ -4,6 +4,6 @@
     "name": "PROXY_REPO_SHA",
     "repoName": "proxy",
     "file": "",
-    "lastStableSHA": "0260205d572f35fa1af353d7e3042012331fc0be"
+    "lastStableSHA": "b17fa32c26eeff5dca3329b2238a974fb7a4bcb3"
   }
 ]

--- a/prow/release-commit.sh
+++ b/prow/release-commit.sh
@@ -32,7 +32,7 @@ DOCKER_HUB=${DOCKER_HUB:-gcr.io/istio-testing}
 GCS_BUCKET=${GCS_BUCKET:-istio-build/dev}
 
 # Use a pinned version in case breaking changes are needed
-BUILDER_SHA=6a6b59b63ca321add1a87cf3b54d412a8d7fe6a4
+BUILDER_SHA=33b0b1f9da46b5e7308bbcd698f6d17cce936a57
 
 # Reference to the next minor version of Istio
 # This will create a version like 1.4-alpha.sha


### PR DESCRIPTION
**Please provide a description of this PR:**
For Istio 1.14.2 release, run update_deps on the Istio 1.14 branch.


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [X ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [X ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
