### PR TITLE
Simpler injectionPath format for cluster env value with / char

### DIFF
--- a/pkg/kube/inject/webhook.go
+++ b/pkg/kube/inject/webhook.go
@@ -1000,9 +1000,9 @@ func parseInjectEnvs(path string) map[string]string {
 		var newRes []string
 		if len(parts) == 3 {
 			if strings.HasPrefix(parts[2], ":ENV:") {
-				// TODO Deprecate this, because it is not recommended. It also fails validation when used to set
-				//      injectionPath (i.e., service.path in mwh). It doesn't fail validation when used to set
-				//      injectionURL, however. K8s bug maybe?
+				// Deprecated, not recommended.
+				//    Note that this systax fails validation when used to set injectionPath (i.e., service.path in mwh).
+				//    It doesn't fail validation when used to set injectionURL, however. K8s bug maybe?
 				pairs := strings.Split(parts[2], ":ENV:")
 				for i := 1; i < len(pairs); i++ { // skip the first part, it is a nil
 					pair := strings.SplitN(pairs[i], "=", 2)

--- a/pkg/kube/inject/webhook.go
+++ b/pkg/kube/inject/webhook.go
@@ -993,12 +993,8 @@ func parseInjectEnvs(path string) map[string]string {
 	path = strings.TrimSuffix(path, "/")
 	res := func(path string) []string {
 		parts := strings.SplitN(path, "/", 3)
-		// The 3rd part has to start with separator :ENV:
-		// If not, this inject path is considered using slash as separator
-		// If length is less than 3, then the path is simply "/inject",
-		// process just like before :ENV: separator is introduced.
 		var newRes []string
-		if len(parts) == 3 {
+		if len(parts) == 3 { // If length is less than 3, then the path is simply "/inject".
 			if strings.HasPrefix(parts[2], ":ENV:") {
 				// Deprecated, not recommended.
 				//    Note that this systax fails validation when used to set injectionPath (i.e., service.path in mwh).

--- a/pkg/kube/inject/webhook.go
+++ b/pkg/kube/inject/webhook.go
@@ -1000,9 +1000,9 @@ func parseInjectEnvs(path string) map[string]string {
 		var newRes []string
 		if len(parts) == 3 {
 			if strings.HasPrefix(parts[2], ":ENV:") {
-				//TODO Deprecate this, because it is not recommended. It also fails validation when used to set
-				//     injectionPath (i.e., service.path in mwh). It doesn't fail validation when used to set
-				//     injectionURL, however. K8s bug maybe?
+				// TODO Deprecate this, because it is not recommended. It also fails validation when used to set
+				//      injectionPath (i.e., service.path in mwh). It doesn't fail validation when used to set
+				//      injectionURL, however. K8s bug maybe?
 				pairs := strings.Split(parts[2], ":ENV:")
 				for i := 1; i < len(pairs); i++ { // skip the first part, it is a nil
 					pair := strings.SplitN(pairs[i], "=", 2)

--- a/pkg/kube/inject/webhook_test.go
+++ b/pkg/kube/inject/webhook_test.go
@@ -1223,6 +1223,11 @@ func TestParseInjectEnvs(t *testing.T) {
 			want: map[string]string{"ISTIO_META_CLUSTER_ID": "cluster1", "ISTIO_META_NETWORK": "network1"},
 		},
 		{
+			name: "kv-with-slashes",
+			in:   "/inject/cluster/cluster--slash--1/net/network1",
+			want: map[string]string{"ISTIO_META_CLUSTER_ID": "cluster/1", "ISTIO_META_NETWORK": "network1"},
+		},
+		{
 			name: "not-predefined-kv",
 			in:   "/inject/cluster/cluster1/custom_env/foo",
 			want: map[string]string{"ISTIO_META_CLUSTER_ID": "cluster1", "CUSTOM_ENV": "foo"},

--- a/pkg/kube/inject/webhook_test.go
+++ b/pkg/kube/inject/webhook_test.go
@@ -1224,8 +1224,8 @@ func TestParseInjectEnvs(t *testing.T) {
 		},
 		{
 			name: "kv-with-slashes",
-			in:   "/inject/cluster/cluster--slash--1/net/network1",
-			want: map[string]string{"ISTIO_META_CLUSTER_ID": "cluster/1", "ISTIO_META_NETWORK": "network1"},
+			in:   "/inject/cluster/cluster--slash--1/net/network--slash--1",
+			want: map[string]string{"ISTIO_META_CLUSTER_ID": "cluster/1", "ISTIO_META_NETWORK": "network/1"},
 		},
 		{
 			name: "not-predefined-kv",


### PR DESCRIPTION
**Please provide a description of this PR:**

Provide alternative and deprecate the `:ENV:` path syntax since it is not recommended and doesn't work when setting the path (vs URL) in the webhook.

Fixes #40116 