### PR TITLE
telemetry: add support for the OTel provider

### DIFF
--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -215,6 +215,12 @@ func IsIstioVersionGE115(version *model.IstioVersion) bool {
 		version.Compare(&model.IstioVersion{Major: 1, Minor: 15, Patch: -1}) >= 0
 }
 
+// IsIstioVersionGE116 checks whether the given Istio version is greater than or equals 1.16.
+func IsIstioVersionGE116(version *model.IstioVersion) bool {
+	return version == nil ||
+		version.Compare(&model.IstioVersion{Major: 1, Minor: 16, Patch: -1}) >= 0
+}
+
 func IsProtocolSniffingEnabledForPort(port *model.Port) bool {
 	return features.EnableProtocolSniffingForOutbound && port.Protocol.IsUnsupported()
 }

--- a/releasenotes/notes/40032.yaml
+++ b/releasenotes/notes/40032.yaml
@@ -1,7 +1,9 @@
 apiVersion: release-notes/v2
 kind: feature
 area: telemetry
+issue:
+  - 40027
 
 releaseNotes:
   - |
-    **Added** support for use of the OpenTelemetry provider with the Telemetry API.
+    **Added** support for use of the OpenTelemetry tracing provider with the Telemetry API.

--- a/releasenotes/notes/40032.yaml
+++ b/releasenotes/notes/40032.yaml
@@ -4,4 +4,4 @@ area: telemetry
 
 releaseNotes:
   - |
-    **Added** support for OpenTelemetry provider for use with the Telemetry API.
+    **Added** support for use of the OpenTelemetry provider with the Telemetry API.

--- a/releasenotes/notes/40032.yaml
+++ b/releasenotes/notes/40032.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: feature
+area: telemetry
+
+releaseNotes:
+  - |
+    **Added** support for OpenTelemetry provider for use with the Telemetry API.

--- a/tests/integration/telemetry/tracing/otelcollector/tracing_test.go
+++ b/tests/integration/telemetry/tracing/otelcollector/tracing_test.go
@@ -15,7 +15,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package opencensusagent
+// Package otelcollector allows testing a variety of tracing solutions by
+// employing an OpenTelemetry collector that exposes receiver endpoints for
+// various protocols and forwards the spans to a Zipkin backend (for further
+// querying and inspection).
+package otelcollector
 
 import (
 	"errors"
@@ -32,12 +36,9 @@ import (
 	"istio.io/istio/tests/integration/telemetry/tracing"
 )
 
-// TestProxyTracing exercises the trace generation features of Istio, based on
-// the Envoy Trace driver for OpenCensusAgent. This test creates an
-// OpenTelemetry collector and a zipkin instance. Spans are forwarded from the
-// envoy proxy through the opentelemetry collector to zipkin. The test verifies
-// that the resulting traces are correctly reconstructed.
-func TestProxyTracing(t *testing.T) {
+// TestProxyTracingOpenCensusMeshConfig exercises the trace generation features of Istio, based on
+// the Envoy Trace driver for OpenCensusAgent.
+func TestProxyTracingOpenCensusMeshConfig(t *testing.T) {
 	framework.NewTest(t).
 		Features("observability.telemetry.tracing.server").
 		Run(func(t framework.TestContext) {
@@ -67,6 +68,59 @@ func TestProxyTracing(t *testing.T) {
 		})
 }
 
+// TestProxyTracingOpenTelemetryProvider validates that Telemetry API configuration
+// referencing an OpenTelemetry provider will generate traces appropriately.
+// NOTE: This test relies on the priority of Telemetry API over MeshConfig tracing
+// configuration. In the future, these two approaches should likely be separated
+// into two distinct test suites.
+func TestProxyTracingOpenTelemetryProvider(t *testing.T) {
+	framework.NewTest(t).
+		Features("observability.telemetry.tracing.api").
+		Run(func(t framework.TestContext) {
+			appNsInst := tracing.GetAppNamespace()
+
+			// apply Telemetry resource with OTel provider
+
+			config := `apiVersion: telemetry.istio.io/v1alpha1
+kind: Telemetry
+metadata:
+  name: logs
+spec:
+  tracing:
+  - providers:
+    - name: test-otel
+    randomSamplingPercentage: 100.0
+`
+			t.ConfigIstio().YAML(appNsInst.Name(), config).ApplyOrFail(t)
+
+			// TODO fix tracing tests in multi-network https://github.com/istio/istio/issues/28890
+			for _, cluster := range t.Clusters().ByNetwork()[t.Clusters().Default().NetworkName()] {
+				cluster := cluster
+				t.NewSubTest(cluster.StableName()).Run(func(ctx framework.TestContext) {
+					retry.UntilSuccessOrFail(t, func() error {
+						err := tracing.SendTraffic(ctx, nil, cluster)
+						if err != nil {
+							return fmt.Errorf("cannot send traffic from cluster %s: %v", cluster.Name(), err)
+						}
+
+						// the OTel collector exports to Zipkin
+						traces, err := tracing.GetZipkinInstance().QueryTraces(300,
+							fmt.Sprintf("server.%s.svc.cluster.local:80/*", appNsInst.Name()), "")
+						if err != nil {
+							return fmt.Errorf("cannot get traces from zipkin: %v", err)
+						}
+						if !tracing.VerifyEchoTraces(ctx, appNsInst.Name(), cluster.Name(), traces) {
+							return errors.New("cannot find expected traces")
+						}
+						return nil
+					}, retry.Delay(3*time.Second), retry.Timeout(80*time.Second))
+				})
+			}
+
+			t.ConfigIstio().YAML(appNsInst.Name(), config).DeleteOrFail(t)
+		})
+}
+
 func TestMain(m *testing.M) {
 	framework.NewSuite(m).
 		Label(label.CustomSetup).
@@ -76,6 +130,7 @@ func TestMain(m *testing.M) {
 		Run()
 }
 
+// TODO: convert test to Telemetry API for both scenarios
 func setupConfig(_ resource.Context, cfg *istio.Config) {
 	if cfg == nil {
 		return
@@ -88,6 +143,11 @@ meshConfig:
       openCensusAgent:
         address: "dns:opentelemetry-collector.istio-system.svc:55678"
         context: [B3]
+  extensionProviders:
+  - name: test-otel
+    opentelemetry:
+      service: opentelemetry-collector.istio-system.svc.cluster.local
+      port: 4317
 `
 	cfg.Values["pilot.traceSampling"] = "100.0"
 	cfg.Values["global.proxy.tracer"] = "openCensusAgent"

--- a/tests/integration/telemetry/tracing/otelcollector/tracing_test.go
+++ b/tests/integration/telemetry/tracing/otelcollector/tracing_test.go
@@ -75,7 +75,7 @@ func TestProxyTracingOpenCensusMeshConfig(t *testing.T) {
 // into two distinct test suites.
 func TestProxyTracingOpenTelemetryProvider(t *testing.T) {
 	framework.NewTest(t).
-		Features("observability.telemetry.tracing.api").
+		Features("observability.telemetry.tracing.server").
 		Run(func(t framework.TestContext) {
 			appNsInst := tracing.GetAppNamespace()
 


### PR DESCRIPTION
This PR adds support for the new OpenTelemetry tracer extension in Envoy. At the same time, it migrates Lightstep providers to the new OpenTelemetry provider (as the Lightstep tracer extension has been removed from Envoy) for future versions of Istio 1.16+.

In pursuit of this goal, the PR also updates the generated tracing config to match envoy documentation (envoy configuration provider name should match envoy extension name), and refactors an existing test suite for OpenCensus agents to also handle OTLP integrations. Additionally, the OTel collector testing component is updated to a more recent version.

To support OTel integrations, an Envoy gRPC endpoint is configured with the cluster name derived from the service/port specification in the provider config.

Issue: https://github.com/istio/istio/issues/40027

- [X] Policies and Telemetry
