### PR TITLE
Abstract gateway context implement outside of model package

### DIFF
--- a/pilot/pkg/config/kube/gateway/context.go
+++ b/pilot/pkg/config/kube/gateway/context.go
@@ -1,0 +1,119 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gateway
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	networking "istio.io/api/networking/v1alpha3"
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/cluster"
+	"istio.io/istio/pkg/config/host"
+	"istio.io/istio/pkg/util/sets"
+)
+
+// GatewayContext contains a minimal subset of push context functionality to be exposed to GatewayAPIControllers
+type GatewayContext struct {
+	ps *model.PushContext
+}
+
+func NewGatewayContext(ps *model.PushContext) GatewayContext {
+	return GatewayContext{ps}
+}
+
+// ResolveGatewayInstances attempts to resolve all instances that a gateway will be exposed on.
+// Note: this function considers *all* instances of the service; its possible those instances will not actually be properly functioning
+// gateways, so this is not 100% accurate, but sufficient to expose intent to users.
+// The actual configuration generation is done on a per-workload basis and will get the exact set of matched instances for that workload.
+// Three sets are exposed:
+// * Internal addresses (ie istio-ingressgateway.istio-system.svc.cluster.local:80).
+// * External addresses (ie 1.2.3.4), this comes from LoadBalancer services. There may be multiple in some cases (especially multi cluster).
+// * Warnings for references that could not be resolved. These are intended to be user facing.
+func (gc GatewayContext) ResolveGatewayInstances(namespace string, gwsvcs []string, servers []*networking.Server) (internal, external, warns []string) {
+	ports := map[int]struct{}{}
+	for _, s := range servers {
+		ports[int(s.Port.Number)] = struct{}{}
+	}
+	foundInternal := sets.New()
+	foundExternal := sets.New()
+	warnings := []string{}
+	for _, g := range gwsvcs {
+		svc, f := gc.ps.ServiceIndex.HostnameAndNamespace[host.Name(g)][namespace]
+		if !f {
+			otherNamespaces := []string{}
+			for ns := range gc.ps.ServiceIndex.HostnameAndNamespace[host.Name(g)] {
+				otherNamespaces = append(otherNamespaces, `"`+ns+`"`) // Wrap in quotes for output
+			}
+			if len(otherNamespaces) > 0 {
+				sort.Strings(otherNamespaces)
+				warnings = append(warnings, fmt.Sprintf("hostname %q not found in namespace %q, but it was found in namespace(s) %v",
+					g, namespace, strings.Join(otherNamespaces, ", ")))
+			} else {
+				warnings = append(warnings, fmt.Sprintf("hostname %q not found", g))
+			}
+			continue
+		}
+		svcKey := svc.Key()
+		for port := range ports {
+			instances := gc.ps.ServiceInstancesByPort(svc, port, nil)
+			if len(instances) > 0 {
+				foundInternal.Insert(fmt.Sprintf("%s:%d", g, port))
+				// Fetch external IPs from all clusters
+				svc.Attributes.ClusterExternalAddresses.ForEach(func(c cluster.ID, externalIPs []string) {
+					foundExternal.InsertAll(externalIPs...)
+				})
+			} else {
+				instancesByPort := gc.ps.ServiceInstances(svcKey)
+				if instancesEmpty(instancesByPort) {
+					warnings = append(warnings, fmt.Sprintf("no instances found for hostname %q", g))
+				} else {
+					hintPort := sets.New()
+					for _, instances := range instancesByPort {
+						for _, i := range instances {
+							if i.Endpoint.EndpointPort == uint32(port) {
+								hintPort.Insert(strconv.Itoa(i.ServicePort.Port))
+							}
+						}
+					}
+					if len(hintPort) > 0 {
+						warnings = append(warnings, fmt.Sprintf(
+							"port %d not found for hostname %q (hint: the service port should be specified, not the workload port. Did you mean one of these ports: %v?)",
+							port, g, hintPort.SortedList()))
+					} else {
+						warnings = append(warnings, fmt.Sprintf("port %d not found for hostname %q", port, g))
+					}
+				}
+			}
+		}
+	}
+	sort.Strings(warnings)
+	return foundInternal.SortedList(), foundExternal.SortedList(), warnings
+}
+
+func (gc GatewayContext) GetService(hostname, namespace string) *model.Service {
+	return gc.ps.ServiceIndex.HostnameAndNamespace[host.Name(hostname)][namespace]
+}
+
+func instancesEmpty(m map[int][]*model.ServiceInstance) bool {
+	for _, instances := range m {
+		if len(instances) > 0 {
+			return false
+		}
+	}
+	return true
+}

--- a/pilot/pkg/config/kube/gateway/controller.go
+++ b/pilot/pkg/config/kube/gateway/controller.go
@@ -150,7 +150,7 @@ func (c *Controller) SetStatusWrite(enabled bool, statusManager *status.Manager)
 
 // Recompute takes in a current snapshot of the gateway-api configs, and regenerates our internal state.
 // Any status updates required will be enqueued as well.
-func (c *Controller) Recompute(context model.GatewayContext) error {
+func (c *Controller) Recompute(ps *model.PushContext) error {
 	t0 := time.Now()
 	defer func() {
 		log.Debugf("recompute complete in %v", time.Since(t0))
@@ -193,7 +193,7 @@ func (c *Controller) Recompute(context model.GatewayContext) error {
 		ReferencePolicy: referencePolicy,
 		ReferenceGrant:  referenceGrant,
 		Domain:          c.domain,
-		Context:         context,
+		Context:         NewGatewayContext(ps),
 	}
 
 	if !anyApisUsed(input) {

--- a/pilot/pkg/config/kube/gateway/controller_test.go
+++ b/pilot/pkg/config/kube/gateway/controller_test.go
@@ -22,7 +22,6 @@ import (
 
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/config/memory"
-	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/core/v1alpha3"
 	"istio.io/istio/pilot/pkg/serviceregistry/kube/controller"
 	"istio.io/istio/pkg/config"
@@ -125,7 +124,7 @@ func TestListGatewayResourceType(t *testing.T) {
 	})
 
 	cg := v1alpha3.NewConfigGenTest(t, v1alpha3.TestOptions{})
-	g.Expect(controller.Recompute(model.NewGatewayContext(cg.PushContext()))).ToNot(HaveOccurred())
+	g.Expect(controller.Recompute(cg.PushContext())).ToNot(HaveOccurred())
 	cfg, err := controller.List(gvk.Gateway, "ns1")
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(cfg).To(HaveLen(1))
@@ -170,7 +169,7 @@ func TestListVirtualServiceResourceType(t *testing.T) {
 	})
 
 	cg := v1alpha3.NewConfigGenTest(t, v1alpha3.TestOptions{})
-	g.Expect(controller.Recompute(model.NewGatewayContext(cg.PushContext()))).ToNot(HaveOccurred())
+	g.Expect(controller.Recompute(cg.PushContext())).ToNot(HaveOccurred())
 	cfg, err := controller.List(gvk.VirtualService, "ns1")
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(cfg).To(HaveLen(1))

--- a/pilot/pkg/config/kube/gateway/conversion.go
+++ b/pilot/pkg/config/kube/gateway/conversion.go
@@ -58,7 +58,7 @@ type KubernetesResources struct {
 
 	// Domain for the cluster. Typically, cluster.local
 	Domain  string
-	Context model.GatewayContext
+	Context GatewayContext
 }
 
 type AllowedReferences map[Reference]map[Reference]*ReferenceAllowance

--- a/pilot/pkg/config/kube/gateway/conversion_test.go
+++ b/pilot/pkg/config/kube/gateway/conversion_test.go
@@ -327,7 +327,7 @@ func TestConvertResources(t *testing.T) {
 				Instances: instances,
 			})
 			kr := splitInput(input)
-			kr.Context = model.NewGatewayContext(cg.PushContext())
+			kr.Context = NewGatewayContext(cg.PushContext())
 			output := convertResources(kr)
 			output.AllowedReferences = AllowedReferences{} // Not tested here
 			output.ReferencedNamespaceKeys = nil           // Not tested here
@@ -518,7 +518,7 @@ spec:
 			input := readConfigString(t, tt.config, validator)
 			cg := v1alpha3.NewConfigGenTest(t, v1alpha3.TestOptions{})
 			kr := splitInput(input)
-			kr.Context = model.NewGatewayContext(cg.PushContext())
+			kr.Context = NewGatewayContext(cg.PushContext())
 			output := convertResources(kr)
 			c := &Controller{
 				state: output,
@@ -736,7 +736,7 @@ func BenchmarkBuildHTTPVirtualServices(b *testing.B) {
 	validator := crdvalidation.NewIstioValidator(b)
 	input := readConfig(b, "testdata/benchmark-httproute.yaml", validator)
 	kr := splitInput(input)
-	kr.Context = model.NewGatewayContext(cg.PushContext())
+	kr.Context = NewGatewayContext(cg.PushContext())
 	ctx := ConfigContext{
 		KubernetesResources: kr,
 		AllowedReferences:   convertReferencePolicies(kr),

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -1112,7 +1112,7 @@ type GatewayController interface {
 	ConfigStoreController
 	// Recompute updates the internal state of the gateway controller for a given input. This should be
 	// called before any List/Get calls if the state has changed
-	Recompute(GatewayContext) error
+	Recompute(ctx *PushContext) error
 	// SecretAllowed determines if a SDS credential is accessible to a given namespace.
 	// For example, for resourceName of `kubernetes-gateway://ns-name/secret-name` and namespace of `ingress-ns`,
 	// this would return true only if there was a policy allowing `ingress-ns` to access Secrets in the `ns-name` namespace.

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -16,10 +16,8 @@ package model
 
 import (
 	"encoding/json"
-	"fmt"
 	"math"
 	"sort"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -2052,96 +2050,6 @@ func (ps *PushContext) mergeGateways(proxy *Proxy) *MergedGateway {
 	return MergeGateways(gatewayInstances, proxy, ps)
 }
 
-// GatewayContext contains a minimal subset of push context functionality to be exposed to GatewayAPIControllers
-type GatewayContext struct {
-	ps *PushContext
-}
-
-func NewGatewayContext(ps *PushContext) GatewayContext {
-	return GatewayContext{ps}
-}
-
-func (gc GatewayContext) GetService(hostname, namespace string) *Service {
-	return gc.ps.ServiceIndex.HostnameAndNamespace[host.Name(hostname)][namespace]
-}
-
-// ResolveGatewayInstances attempts to resolve all instances that a gateway will be exposed on.
-// Note: this function considers *all* instances of the service; its possible those instances will not actually be properly functioning
-// gateways, so this is not 100% accurate, but sufficient to expose intent to users.
-// The actual configuration generation is done on a per-workload basis and will get the exact set of matched instances for that workload.
-// Three sets are exposed:
-// * Internal addresses (ie istio-ingressgateway.istio-system.svc.cluster.local:80).
-// * External addresses (ie 1.2.3.4), this comes from LoadBalancer services. There may be multiple in some cases (especially multi cluster).
-// * Warnings for references that could not be resolved. These are intended to be user facing.
-func (gc GatewayContext) ResolveGatewayInstances(namespace string, gwsvcs []string, servers []*networking.Server) (internal, external, warns []string) {
-	ports := map[int]struct{}{}
-	for _, s := range servers {
-		ports[int(s.Port.Number)] = struct{}{}
-	}
-	foundInternal := sets.New()
-	foundExternal := sets.New()
-	warnings := []string{}
-	for _, g := range gwsvcs {
-		svc, f := gc.ps.ServiceIndex.HostnameAndNamespace[host.Name(g)][namespace]
-		if !f {
-			otherNamespaces := []string{}
-			for ns := range gc.ps.ServiceIndex.HostnameAndNamespace[host.Name(g)] {
-				otherNamespaces = append(otherNamespaces, `"`+ns+`"`) // Wrap in quotes for output
-			}
-			if len(otherNamespaces) > 0 {
-				sort.Strings(otherNamespaces)
-				warnings = append(warnings, fmt.Sprintf("hostname %q not found in namespace %q, but it was found in namespace(s) %v",
-					g, namespace, strings.Join(otherNamespaces, ", ")))
-			} else {
-				warnings = append(warnings, fmt.Sprintf("hostname %q not found", g))
-			}
-			continue
-		}
-		svcKey := svc.Key()
-		for port := range ports {
-			instances := gc.ps.ServiceIndex.instancesByPort[svcKey][port]
-			if len(instances) > 0 {
-				foundInternal.Insert(fmt.Sprintf("%s:%d", g, port))
-				// Fetch external IPs from all clusters
-				svc.Attributes.ClusterExternalAddresses.ForEach(func(c cluster.ID, externalIPs []string) {
-					foundExternal.InsertAll(externalIPs...)
-				})
-			} else {
-				if instancesEmpty(gc.ps.ServiceIndex.instancesByPort[svcKey]) {
-					warnings = append(warnings, fmt.Sprintf("no instances found for hostname %q", g))
-				} else {
-					hintPort := sets.New()
-					for _, instances := range gc.ps.ServiceIndex.instancesByPort[svcKey] {
-						for _, i := range instances {
-							if i.Endpoint.EndpointPort == uint32(port) {
-								hintPort.Insert(strconv.Itoa(i.ServicePort.Port))
-							}
-						}
-					}
-					if len(hintPort) > 0 {
-						warnings = append(warnings, fmt.Sprintf(
-							"port %d not found for hostname %q (hint: the service port should be specified, not the workload port. Did you mean one of these ports: %v?)",
-							port, g, hintPort.SortedList()))
-					} else {
-						warnings = append(warnings, fmt.Sprintf("port %d not found for hostname %q", port, g))
-					}
-				}
-			}
-		}
-	}
-	sort.Strings(warnings)
-	return foundInternal.SortedList(), foundExternal.SortedList(), warnings
-}
-
-func instancesEmpty(m map[int][]*ServiceInstance) bool {
-	for _, instances := range m {
-		if len(instances) > 0 {
-			return false
-		}
-	}
-	return true
-}
-
 func (ps *PushContext) NetworkManager() *NetworkManager {
 	return ps.networkMgr
 }
@@ -2205,11 +2113,20 @@ func (ps *PushContext) ServiceInstancesByPort(svc *Service, port int, labels lab
 	return out
 }
 
+// ServiceInstances returns the cached instances by svc it exists.
+func (ps *PushContext) ServiceInstances(svcKey string) map[int][]*ServiceInstance {
+	if instances, exists := ps.ServiceIndex.instancesByPort[svcKey]; exists {
+		return instances
+	}
+
+	return nil
+}
+
 // initKubernetesGateways initializes Kubernetes gateway-api objects
 func (ps *PushContext) initKubernetesGateways(env *Environment) error {
 	if env.GatewayAPIController != nil {
 		ps.GatewayAPIController = env.GatewayAPIController
-		return env.GatewayAPIController.Recompute(GatewayContext{ps})
+		return env.GatewayAPIController.Recompute(ps)
 	}
 	return nil
 }


### PR DESCRIPTION
**Please provide a description of this PR:**

`GatewayContext` should be private to k8s gateway implement, so this pr does a refactor of move it from pilot/pkg/model to pilot/pkg/config/kube/gateway