### PR TITLE
register init push context metric

### DIFF
--- a/pilot/pkg/xds/monitoring.go
+++ b/pilot/pkg/xds/monitoring.go
@@ -292,6 +292,7 @@ func init() {
 		xdsClients,
 		xdsResponseWriteTimeouts,
 		pushes,
+		pushContextInitTime,
 		pushTime,
 		proxiesConvergeDelay,
 		proxiesQueueTime,


### PR DESCRIPTION
pushContextInitTime metric is missing because it is not registered,
this CL registers it.