### PR TITLE
Revert "Fix: allow enableNamespacesByDefault when revision tag is set"

### DIFF
--- a/releasenotes/notes/39674.yaml
+++ b/releasenotes/notes/39674.yaml
@@ -1,9 +1,0 @@
-apiVersion: release-notes/v2
-kind: bug-fix
-area: installation
-issue:
-  - https://github.com/istio/istio/issues/39604
-releaseNotes:
-  - |
-    **Fixed** if a previous installation existed and a revision was used, users
-    couldn't opt-in automatic sidecar injection by changing .Values.enableNamespacesByDefault setting.


### PR DESCRIPTION
This commit made it so that we fail installation if a previous install exists without a default tag, which we don't want to do (having an installation without a default tag shouldn't be a critical error for a new install). In addition it makes the current revision the default even if a previous default tag exists, which we also want to avoid (it should be moved with the tag command).