### PR TITLE
Add a flag for app container name and retry verifyTrafficMirror

### DIFF
--- a/pkg/test/framework/components/echo/kube/flags.go
+++ b/pkg/test/framework/components/echo/kube/flags.go
@@ -20,6 +20,8 @@ var (
 	serviceTemplateFile      = "service.yaml"
 	deploymentTemplateFile   = "deployment.yaml"
 	vmDeploymentTemplateFile = "vm_deployment.yaml"
+
+	appContainerName = "app"
 )
 
 func init() {
@@ -32,4 +34,6 @@ func init() {
 	flag.StringVar(&vmDeploymentTemplateFile, "istio.test.echo.kube.template.deployment.vm", vmDeploymentTemplateFile,
 		"Specifies the default template file to be used when generating the Kubernetes Deployment to simulate an instance of echo application in a VM. "+
 			"Can be either an absolute path or relative to the templates directory under the echo test component. A default will be selected if not specified.")
+	flag.StringVar(&appContainerName, "istio.test.echo.kube.container", appContainerName,
+		"Specifies the default container name to be used for the echo application. A default will be selected if not specified.")
 }

--- a/pkg/test/framework/components/echo/kube/workload.go
+++ b/pkg/test/framework/components/echo/kube/workload.go
@@ -36,10 +36,6 @@ import (
 	"istio.io/istio/pkg/test/util/retry"
 )
 
-const (
-	appContainerName = "app"
-)
-
 var _ echo.Workload = &workload{}
 
 type workloadConfig struct {

--- a/tests/integration/pilot/mirror_test.go
+++ b/tests/integration/pilot/mirror_test.go
@@ -22,6 +22,7 @@ import (
 	"math"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/go-multierror"
 	"k8s.io/apimachinery/pkg/util/rand"
@@ -155,9 +156,10 @@ func runMirrorTest(t *testing.T, options mirrorTestOptions) {
 										if expected == nil {
 											expected = apps.C
 										}
-
-										return verifyTrafficMirror(apps.B, expected, c, testID)
-									}, echo.DefaultCallRetryOptions()...)
+										return retry.UntilSuccess(func() error {
+											return verifyTrafficMirror(apps.B, expected, c, testID)
+										}, []retry.Option{retry.Timeout(20 * time.Second), retry.BackoffDelay(10 * time.Millisecond), retry.Converge(2)}...)
+									}, []retry.Option{retry.Timeout(60 * time.Second), retry.BackoffDelay(10 * time.Millisecond), retry.Converge(2)}...)
 								})
 							}
 						})


### PR DESCRIPTION
For some workloads the container name is different and the logs are written slower. So the verification of mirroring test cases is retried for 20 seconds.

**Please provide a description of this PR:**