### PR TITLE
Replace Split with Cut to get path/value

### DIFF
--- a/operator/pkg/manifest/shared.go
+++ b/operator/pkg/manifest/shared.go
@@ -575,10 +575,9 @@ func GetValueForSetFlag(setFlags []string, path string) string {
 
 // getPV returns the path and value components for the given set flag string, which must be in path=value format.
 func getPV(setFlag string) (path string, value string) {
-	pv := strings.Split(setFlag, "=")
-	if len(pv) != 2 {
-		return setFlag, ""
+	p, v, found := strings.Cut(setFlag, "=")
+	if found {
+		path, value = strings.TrimSpace(p), strings.TrimSpace(v)
 	}
-	path, value = strings.TrimSpace(pv[0]), strings.TrimSpace(pv[1])
 	return
 }


### PR DESCRIPTION
**Please provide a description of this PR:**

Replace `Split()` with `Cut()` to get `path/value`, `Cut()` is better for splitting `path=value`.


**Please check any characteristics that apply to this pull request.**
NONE

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.