### PR TITLE
[release-1.14] Fix release-commit.sh to use release-1.14 branch instead of master

### DIFF
--- a/prow/release-commit.sh
+++ b/prow/release-commit.sh
@@ -65,13 +65,13 @@ ${DEPENDENCIES:-$(cat <<EOD
     auto: modules
   client-go:
     git: https://github.com/istio/client-go
-    branch: master
+    branch: release-1.14
   test-infra:
     git: https://github.com/istio/test-infra
-    branch: master
+    branch: release-1.14
   tools:
     git: https://github.com/istio/tools
-    branch: master
+    branch: release-1.14
   release-builder:
     git: https://github.com/istio/release-builder
     sha: ${BUILDER_SHA}

--- a/prow/release-commit.sh
+++ b/prow/release-commit.sh
@@ -68,7 +68,7 @@ ${DEPENDENCIES:-$(cat <<EOD
     branch: release-1.14
   test-infra:
     git: https://github.com/istio/test-infra
-    branch: release-1.14
+    branch: master
   tools:
     git: https://github.com/istio/tools
     branch: release-1.14


### PR DESCRIPTION
**Please provide a description of this PR:**

Release integration test uses this file and it should be updated to use the proper branches