### PR TITLE
pilot: fix issue with TLS and TCP order dependency

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -984,6 +984,7 @@ func (lb *ListenerBuilder) buildSidecarOutboundListenerForPortOrUDS(listenerOpts
 		if currentListenerEntry != nil {
 			currentListenerEntry.listener.FilterChains = mergeTCPFilterChains(mutable.Listener.FilterChains,
 				listenerOpts, listenerMapKey, listenerMap)
+			currentListenerEntry.listener.ListenerFilters = mergeListenerFilters(currentListenerEntry.listener.ListenerFilters, mutable.Listener.ListenerFilters)
 		} else {
 			listenerMap[listenerMapKey] = &outboundListenerEntry{
 				services:    []*model.Service{listenerOpts.service},
@@ -1009,10 +1010,12 @@ func (lb *ListenerBuilder) buildSidecarOutboundListenerForPortOrUDS(listenerOpts
 		// Merge two TCP filter chains. HTTP filter chain will not conflict with TCP filter chain because HTTP filter chain match for
 		// HTTP filter chain is different from TCP filter chain's.
 		currentListenerEntry.listener.FilterChains = mergeTCPFilterChains(mutable.Listener.FilterChains, listenerOpts, listenerMapKey, listenerMap)
+		currentListenerEntry.listener.ListenerFilters = mergeListenerFilters(currentListenerEntry.listener.ListenerFilters, mutable.Listener.ListenerFilters)
 	case TCPOverAuto:
 		// Merge two TCP filter chains. HTTP filter chain will not conflict with TCP filter chain because HTTP filter chain match for
 		// HTTP filter chain is different from TCP filter chain's.
 		currentListenerEntry.listener.FilterChains = mergeTCPFilterChains(mutable.Listener.FilterChains, listenerOpts, listenerMapKey, listenerMap)
+		currentListenerEntry.listener.ListenerFilters = mergeListenerFilters(currentListenerEntry.listener.ListenerFilters, mutable.Listener.ListenerFilters)
 
 	case AutoOverHTTP:
 		listenerMap[listenerMapKey] = &outboundListenerEntry{
@@ -1537,6 +1540,29 @@ func isConflictWithWellKnownPort(incoming, existing protocol.Instance, conflict 
 	}
 
 	return true
+}
+
+func mergeListenerFilters(a, b []*listener.ListenerFilter) []*listener.ListenerFilter {
+	alreadyHasTLSInspector := false
+	alreadyHasHTTPInspector := false
+	for _, f := range a {
+		alreadyHasTLSInspector = alreadyHasTLSInspector || f.Name == wellknown.TlsInspector
+		alreadyHasHTTPInspector = alreadyHasHTTPInspector || f.Name == wellknown.HttpInspector
+	}
+	wantTLSInspector := false
+	wantHTTPInspector := false
+	for _, f := range b {
+		wantTLSInspector = wantTLSInspector || f.Name == wellknown.TlsInspector
+		wantHTTPInspector = wantHTTPInspector || f.Name == wellknown.HttpInspector
+	}
+
+	if !alreadyHasTLSInspector && wantTLSInspector {
+		a = append(a, xdsfilters.TLSInspector)
+	}
+	if !alreadyHasHTTPInspector && wantHTTPInspector {
+		a = append(a, xdsfilters.HTTPInspector)
+	}
+	return a
 }
 
 func appendListenerFilters(filters []*listener.ListenerFilter) []*listener.ListenerFilter {

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -978,13 +978,16 @@ func (lb *ListenerBuilder) buildSidecarOutboundListenerForPortOrUDS(listenerOpts
 	//  Type 7 can be resolved by appending service to existing services
 	//  Type 8 can be resolved by merging TCP filter chains
 	//  Type 9 can be resolved by merging TCP and HTTP filter chains
-
+	if currentListenerEntry != nil {
+		// Listener filters enable inspecting TLS or HTTP. If either filter chain depends on it, our final listener
+		// must also have the inspector.
+		currentListenerEntry.listener.ListenerFilters = mergeListenerFilters(currentListenerEntry.listener.ListenerFilters, mutable.Listener.ListenerFilters)
+	}
 	switch conflictType {
 	case NoConflict:
 		if currentListenerEntry != nil {
 			currentListenerEntry.listener.FilterChains = mergeTCPFilterChains(mutable.Listener.FilterChains,
 				listenerOpts, listenerMapKey, listenerMap)
-			currentListenerEntry.listener.ListenerFilters = mergeListenerFilters(currentListenerEntry.listener.ListenerFilters, mutable.Listener.ListenerFilters)
 		} else {
 			listenerMap[listenerMapKey] = &outboundListenerEntry{
 				services:    []*model.Service{listenerOpts.service},
@@ -998,24 +1001,20 @@ func (lb *ListenerBuilder) buildSidecarOutboundListenerForPortOrUDS(listenerOpts
 		// Merge HTTP filter chain to TCP filter chain
 		currentListenerEntry.listener.FilterChains = mergeFilterChains(mutable.Listener.FilterChains, currentListenerEntry.listener.FilterChains)
 		currentListenerEntry.protocol = protocol.Unsupported
-		currentListenerEntry.listener.ListenerFilters = appendListenerFilters(currentListenerEntry.listener.ListenerFilters)
 		currentListenerEntry.services = append(currentListenerEntry.services, listenerOpts.service)
 
 	case TCPOverHTTP:
 		// Merge TCP filter chain to HTTP filter chain
 		currentListenerEntry.listener.FilterChains = mergeFilterChains(currentListenerEntry.listener.FilterChains, mutable.Listener.FilterChains)
 		currentListenerEntry.protocol = protocol.Unsupported
-		currentListenerEntry.listener.ListenerFilters = appendListenerFilters(currentListenerEntry.listener.ListenerFilters)
 	case TCPOverTCP:
 		// Merge two TCP filter chains. HTTP filter chain will not conflict with TCP filter chain because HTTP filter chain match for
 		// HTTP filter chain is different from TCP filter chain's.
 		currentListenerEntry.listener.FilterChains = mergeTCPFilterChains(mutable.Listener.FilterChains, listenerOpts, listenerMapKey, listenerMap)
-		currentListenerEntry.listener.ListenerFilters = mergeListenerFilters(currentListenerEntry.listener.ListenerFilters, mutable.Listener.ListenerFilters)
 	case TCPOverAuto:
 		// Merge two TCP filter chains. HTTP filter chain will not conflict with TCP filter chain because HTTP filter chain match for
 		// HTTP filter chain is different from TCP filter chain's.
 		currentListenerEntry.listener.FilterChains = mergeTCPFilterChains(mutable.Listener.FilterChains, listenerOpts, listenerMapKey, listenerMap)
-		currentListenerEntry.listener.ListenerFilters = mergeListenerFilters(currentListenerEntry.listener.ListenerFilters, mutable.Listener.ListenerFilters)
 
 	case AutoOverHTTP:
 		listenerMap[listenerMapKey] = &outboundListenerEntry{
@@ -1025,7 +1024,6 @@ func (lb *ListenerBuilder) buildSidecarOutboundListenerForPortOrUDS(listenerOpts
 			listener:    mutable.Listener,
 			protocol:    protocol.Unsupported,
 		}
-		currentListenerEntry.listener.ListenerFilters = appendListenerFilters(currentListenerEntry.listener.ListenerFilters)
 
 	case AutoOverTCP:
 		// Merge two TCP filter chains. HTTP filter chain will not conflict with TCP filter chain because HTTP filter chain match for
@@ -1033,7 +1031,6 @@ func (lb *ListenerBuilder) buildSidecarOutboundListenerForPortOrUDS(listenerOpts
 		currentListenerEntry.listener.FilterChains = mergeTCPFilterChains(mutable.Listener.FilterChains,
 			listenerOpts, listenerMapKey, listenerMap)
 		currentListenerEntry.protocol = protocol.Unsupported
-		currentListenerEntry.listener.ListenerFilters = appendListenerFilters(currentListenerEntry.listener.ListenerFilters)
 
 	default:
 		// Covered previously - in this case we return early to prevent creating listeners that we end up throwing away
@@ -1542,6 +1539,8 @@ func isConflictWithWellKnownPort(incoming, existing protocol.Instance, conflict 
 	return true
 }
 
+// mergeListenerFilters appends a TLS and/or HTTP inspector to `a` if `a` does not yet have it but `n` does.
+// This is used when merging filter chains - the listener filters should be the union.
 func mergeListenerFilters(a, b []*listener.ListenerFilter) []*listener.ListenerFilter {
 	alreadyHasTLSInspector := false
 	alreadyHasHTTPInspector := false
@@ -1563,26 +1562,6 @@ func mergeListenerFilters(a, b []*listener.ListenerFilter) []*listener.ListenerF
 		a = append(a, xdsfilters.HTTPInspector)
 	}
 	return a
-}
-
-func appendListenerFilters(filters []*listener.ListenerFilter) []*listener.ListenerFilter {
-	hasTLSInspector := false
-	hasHTTPInspector := false
-
-	for _, f := range filters {
-		hasTLSInspector = hasTLSInspector || f.Name == wellknown.TlsInspector
-		hasHTTPInspector = hasHTTPInspector || f.Name == wellknown.HttpInspector
-	}
-
-	if !hasTLSInspector {
-		filters = append(filters, xdsfilters.TLSInspector)
-	}
-
-	if !hasHTTPInspector {
-		filters = append(filters, xdsfilters.HTTPInspector)
-	}
-
-	return filters
 }
 
 // nolint: interfacer

--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -300,6 +300,30 @@ func TestOutboundListenerConflict_TCPWithCurrentHTTP(t *testing.T) {
 		buildService("test3.com", wildcardIP, protocol.TCP, tnow.Add(2*time.Second)))
 }
 
+func TestOutboundListenerConflict_TCPWithTLS(t *testing.T) {
+	run := func(t *testing.T, s []*model.Service) {
+		proxy := getProxy()
+		proxy.DiscoverIPMode()
+		listeners := buildOutboundListeners(t, getProxy(), nil, nil, s...)
+		if len(listeners) != 1 {
+			t.Fatalf("expected %d listeners, found %d", 1, len(listeners))
+		}
+		listenertest.VerifyListener(t, listeners[0], listenertest.ListenerTest{Filters: []string{wellknown.TlsInspector}})
+	}
+	t.Run("tcp older", func(t *testing.T) {
+		run(t, []*model.Service{
+			buildService("test1.com", wildcardIP, protocol.TCP, tnow.Add(-1*time.Second)),
+			buildService("test2.com", wildcardIP, protocol.TLS, tnow),
+		})
+	})
+	t.Run("tls older", func(t *testing.T) {
+		run(t, []*model.Service{
+			buildService("test2.com", wildcardIP, protocol.TLS, tnow),
+			buildService("test1.com", wildcardIP, protocol.TCP, tnow.Add(1*time.Second)),
+		})
+	})
+}
+
 func TestOutboundListenerConflict_TCPWithCurrentTCP(t *testing.T) {
 	services := []*model.Service{
 		buildService("test1.com", "1.2.3.4", protocol.TCP, tnow.Add(1*time.Second)),

--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -300,7 +300,7 @@ func TestOutboundListenerConflict_TCPWithCurrentHTTP(t *testing.T) {
 		buildService("test3.com", wildcardIP, protocol.TCP, tnow.Add(2*time.Second)))
 }
 
-func TestOutboundListenerConflict_TCPWithTLS(t *testing.T) {
+func TestOutboundListenerConflict(t *testing.T) {
 	run := func(t *testing.T, s []*model.Service) {
 		proxy := getProxy()
 		proxy.DiscoverIPMode()
@@ -308,20 +308,20 @@ func TestOutboundListenerConflict_TCPWithTLS(t *testing.T) {
 		if len(listeners) != 1 {
 			t.Fatalf("expected %d listeners, found %d", 1, len(listeners))
 		}
-		listenertest.VerifyListener(t, listeners[0], listenertest.ListenerTest{Filters: []string{wellknown.TlsInspector}})
 	}
-	t.Run("tcp older", func(t *testing.T) {
-		run(t, []*model.Service{
-			buildService("test1.com", wildcardIP, protocol.TCP, tnow.Add(-1*time.Second)),
-			buildService("test2.com", wildcardIP, protocol.TLS, tnow),
-		})
-	})
-	t.Run("tls older", func(t *testing.T) {
-		run(t, []*model.Service{
-			buildService("test2.com", wildcardIP, protocol.TLS, tnow),
-			buildService("test1.com", wildcardIP, protocol.TCP, tnow.Add(1*time.Second)),
-		})
-	})
+	// Iterate over all protocol pairs and generate listeners
+	// ValidateListeners will be called on all of them ensuring they are valid
+	protos := []protocol.Instance{protocol.TCP, protocol.TLS, protocol.HTTP, protocol.Unsupported}
+	for _, older := range protos {
+		for _, newer := range protos {
+			t.Run(fmt.Sprintf("%v then %v", older, newer), func(t *testing.T) {
+				run(t, []*model.Service{
+					buildService("test1.com", wildcardIP, older, tnow.Add(-1*time.Second)),
+					buildService("test2.com", wildcardIP, newer, tnow),
+				})
+			})
+		}
+	}
 }
 
 func TestOutboundListenerConflict_TCPWithCurrentTCP(t *testing.T) {

--- a/releasenotes/notes/tls-tcp-conflict.yaml
+++ b/releasenotes/notes/tls-tcp-conflict.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+releaseNotes:
+- |
+  **Fixed** an issue causing TLS `ServiceEntries` to sometimes not work when created after TCP ones.


### PR DESCRIPTION
Currently, tls_inspector is only added if its the first Service. If its
after TCP, it is missed.

example config:

```yaml
apiVersion: networking.istio.io/v1beta1
kind: ServiceEntry
metadata:
  name: tcp
spec:
  addresses:
  - 10.10.10.10/24
  exportTo:
  - .
  hosts:
  - '*.tcp'
  ports:
  - name: tcp-443
    number: 443
    protocol: TCP
---
apiVersion: networking.istio.io/v1beta1
kind: ServiceEntry
metadata:
  name: tls
spec:
  exportTo:
  - .
  hosts:
  - tls.example.com
  location: MESH_EXTERNAL
  ports:
  - name: https-443
    number: 443
    protocol: HTTPS
  resolution: DNS
```

depending on the order of creation it will work/not work.

**Please provide a description of this PR:**