### PR TITLE
Rewrite `interface{}` to `any`

### DIFF
--- a/cni/pkg/install/cniconfig.go
+++ b/cni/pkg/install/cniconfig.go
@@ -274,13 +274,13 @@ func getDefaultCNINetwork(confDir string) (string, error) {
 
 // newCNIConfig = istio-cni config, that should be inserted into existingCNIConfig
 func insertCNIConfig(newCNIConfig, existingCNIConfig []byte) ([]byte, error) {
-	var istioMap map[string]interface{}
+	var istioMap map[string]any
 	err := json.Unmarshal(newCNIConfig, &istioMap)
 	if err != nil {
 		return nil, fmt.Errorf("error loading Istio CNI config (JSON error): %v", err)
 	}
 
-	var existingMap map[string]interface{}
+	var existingMap map[string]any
 	err = json.Unmarshal(existingCNIConfig, &existingMap)
 	if err != nil {
 		return nil, fmt.Errorf("error loading existing CNI config (JSON error): %v", err)
@@ -288,17 +288,17 @@ func insertCNIConfig(newCNIConfig, existingCNIConfig []byte) ([]byte, error) {
 
 	delete(istioMap, "cniVersion")
 
-	var newMap map[string]interface{}
+	var newMap map[string]any
 
 	if _, ok := existingMap["type"]; ok {
 		// Assume it is a regular network conf file
 		delete(existingMap, "cniVersion")
 
-		plugins := make([]map[string]interface{}, 2)
+		plugins := make([]map[string]any, 2)
 		plugins[0] = existingMap
 		plugins[1] = istioMap
 
-		newMap = map[string]interface{}{
+		newMap = map[string]any{
 			"name":       "k8s-pod-network",
 			"cniVersion": "0.3.1",
 			"plugins":    plugins,

--- a/cni/pkg/plugin/plugin.go
+++ b/cni/pkg/plugin/plugin.go
@@ -71,8 +71,8 @@ type Config struct {
 	// chained.
 	// If you need to modify the result before returning it, you will need
 	// to actually convert it to a concrete versioned struct.
-	RawPrevResult *map[string]interface{} `json:"prevResult"`
-	PrevResult    *cniv1.Result           `json:"-"`
+	RawPrevResult *map[string]any `json:"prevResult"`
+	PrevResult    *cniv1.Result   `json:"-"`
 
 	// Add plugin-specific flags here
 	LogLevel        string     `json:"log_level"`
@@ -177,7 +177,7 @@ func CmdAdd(args *skel.CmdArgs) (err error) {
 	}
 	log.FindScope("default").SetOutputLevel(getLogLevel(conf.LogLevel))
 
-	var loggedPrevResult interface{}
+	var loggedPrevResult any
 	if conf.PrevResult == nil {
 		loggedPrevResult = "none"
 	} else {

--- a/cni/pkg/repair/repaircontroller.go
+++ b/cni/pkg/repair/repaircontroller.go
@@ -73,10 +73,10 @@ func NewRepairController(reconciler brokenPodReconciler) (*Controller, error) {
 	)
 
 	_, c.podController = cache.NewInformer(podListWatch, &v1.Pod{}, 0, cache.ResourceEventHandlerFuncs{
-		AddFunc: func(newObj interface{}) {
+		AddFunc: func(newObj any) {
 			c.mayAddToWorkQueue(newObj)
 		},
-		UpdateFunc: func(_, newObj interface{}) {
+		UpdateFunc: func(_, newObj any) {
 			c.mayAddToWorkQueue(newObj)
 		},
 	})
@@ -84,7 +84,7 @@ func NewRepairController(reconciler brokenPodReconciler) (*Controller, error) {
 	return c, nil
 }
 
-func (rc *Controller) mayAddToWorkQueue(obj interface{}) {
+func (rc *Controller) mayAddToWorkQueue(obj any) {
 	pod, ok := obj.(*v1.Pod)
 	if !ok {
 		repairLog.Error("Cannot convert object to pod. Skip adding it to the repair working queue.")

--- a/cni/pkg/taint/taintcontroller.go
+++ b/cni/pkg/taint/taintcontroller.go
@@ -82,14 +82,14 @@ func NewTaintSetterController(ts *Setter) (*Controller, error) {
 // remove: retaint the node
 func buildPodController(c *Controller, config ConfigSettings, source cache.ListerWatcher) cache.Controller {
 	tempstore, tempcontroller := cache.NewInformer(source, &v1.Pod{}, 0, cache.ResourceEventHandlerFuncs{
-		AddFunc: func(newObj interface{}) {
+		AddFunc: func(newObj any) {
 			// remove filter condition will introduce a lot of error handling in workqueue
 			c.podWorkQueue.AddRateLimited(newObj)
 		},
-		UpdateFunc: func(_, newObj interface{}) {
+		UpdateFunc: func(_, newObj any) {
 			c.podWorkQueue.AddRateLimited(newObj)
 		},
-		DeleteFunc: func(newObj interface{}) {
+		DeleteFunc: func(newObj any) {
 			err := reTaintNodeByPod(newObj, c)
 			if err != nil {
 				log.Errorf("Error in pod remove process.")
@@ -106,7 +106,7 @@ func buildPodController(c *Controller, config ConfigSettings, source cache.Liste
 
 func buildNodeController(c *Controller, nodeListWatch cache.ListerWatcher) (cache.Store, cache.Controller) {
 	store, controller := cache.NewInformer(nodeListWatch, &v1.Node{}, 0, cache.ResourceEventHandlerFuncs{
-		AddFunc: func(newObj interface{}) {
+		AddFunc: func(newObj any) {
 			_, ok := newObj.(*v1.Node)
 			if !ok {
 				log.Errorf("Error decoding object, invalid type.")
@@ -114,14 +114,14 @@ func buildNodeController(c *Controller, nodeListWatch cache.ListerWatcher) (cach
 			}
 			c.nodeWorkQueue.AddRateLimited(newObj)
 		},
-		UpdateFunc: func(_, newObj interface{}) {
+		UpdateFunc: func(_, newObj any) {
 			c.nodeWorkQueue.AddRateLimited(newObj)
 		},
 	})
 	return store, controller
 }
 
-func reTaintNodeByPod(obj interface{}, c *Controller) error {
+func reTaintNodeByPod(obj any, c *Controller) error {
 	pod, ok := obj.(*v1.Pod)
 	if !ok {
 		log.Errorf("error decoding object, invalid type.")
@@ -185,7 +185,7 @@ func (tc *Controller) Run(stopCh <-chan struct{}) {
 }
 
 func (tc *Controller) processNextPod() bool {
-	errorHandler := func(obj interface{}, pod *v1.Pod, err error) {
+	errorHandler := func(obj any, pod *v1.Pod, err error) {
 		podName := fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
 		if err == nil {
 			log.Debugf("Removing %s from work queue", podName)

--- a/cni/pkg/util/util.go
+++ b/cni/pkg/util/util.go
@@ -82,13 +82,13 @@ func WaitForFileMod(ctx context.Context, fileModified chan bool, errChan chan er
 }
 
 // Read CNI config from file and return the unmarshalled JSON as a map
-func ReadCNIConfigMap(path string) (map[string]interface{}, error) {
+func ReadCNIConfigMap(path string) (map[string]any, error) {
 	cniConfig, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
 
-	var cniConfigMap map[string]interface{}
+	var cniConfigMap map[string]any
 	if err = json.Unmarshal(cniConfig, &cniConfigMap); err != nil {
 		return nil, fmt.Errorf("%s: %w", path, err)
 	}
@@ -97,8 +97,8 @@ func ReadCNIConfigMap(path string) (map[string]interface{}, error) {
 }
 
 // Given an unmarshalled CNI config JSON map, return the plugin list asserted as a []interface{}
-func GetPlugins(cniConfigMap map[string]interface{}) (plugins []interface{}, err error) {
-	plugins, ok := cniConfigMap["plugins"].([]interface{})
+func GetPlugins(cniConfigMap map[string]any) (plugins []any, err error) {
+	plugins, ok := cniConfigMap["plugins"].([]any)
 	if !ok {
 		err = fmt.Errorf("error reading plugin list from CNI config")
 		return
@@ -107,8 +107,8 @@ func GetPlugins(cniConfigMap map[string]interface{}) (plugins []interface{}, err
 }
 
 // Given the raw plugin interface, return the plugin asserted as a map[string]interface{}
-func GetPlugin(rawPlugin interface{}) (plugin map[string]interface{}, err error) {
-	plugin, ok := rawPlugin.(map[string]interface{})
+func GetPlugin(rawPlugin any) (plugin map[string]any, err error) {
+	plugin, ok := rawPlugin.(map[string]any)
 	if !ok {
 		err = fmt.Errorf("error reading plugin from CNI config plugin list")
 		return
@@ -117,7 +117,7 @@ func GetPlugin(rawPlugin interface{}) (plugin map[string]interface{}, err error)
 }
 
 // Marshal the CNI config map and append a new line
-func MarshalCNIConfig(cniConfigMap map[string]interface{}) ([]byte, error) {
+func MarshalCNIConfig(cniConfigMap map[string]any) ([]byte, error) {
 	cniConfig, err := json.MarshalIndent(cniConfigMap, "", "  ")
 	if err != nil {
 		return nil, err

--- a/istioctl/cmd/add-to-mesh.go
+++ b/istioctl/cmd/add-to-mesh.go
@@ -495,10 +495,10 @@ func addServiceOnVMToMesh(dynamicClient dynamic.Interface, client kubernetes.Int
 	}
 
 	u := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": collections.IstioNetworkingV1Alpha3Serviceentries.Resource().APIVersion(),
 			"kind":       collections.IstioNetworkingV1Alpha3Serviceentries.Resource().Kind(),
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"namespace": opts.Namespace,
 				"name":      resourceName(opts.Name),
 			},
@@ -579,12 +579,12 @@ func generateServiceEntry(u *unstructured.Unstructured, o *vmServiceOpts) error 
 // Because we are placing into an Unstructured, place as a map instead
 // of structured Istio types.  (The go-client can handle the structured data, but the
 // fake go-client used for mocking cannot.)
-func unstructureIstioType(spec interface{}) (map[string]interface{}, error) {
+func unstructureIstioType(spec any) (map[string]any, error) {
 	b, err := yaml.Marshal(spec)
 	if err != nil {
 		return nil, err
 	}
-	iSpec := map[string]interface{}{}
+	iSpec := map[string]any{}
 	err = yaml.Unmarshal(b, &iSpec)
 	if err != nil {
 		return nil, err

--- a/istioctl/cmd/add-to-mesh_test.go
+++ b/istioctl/cmd/add-to-mesh_test.go
@@ -111,10 +111,10 @@ var (
 	}
 	cannedDynamicConfigs = []runtime.Object{
 		&unstructured.Unstructured{
-			Object: map[string]interface{}{
+			Object: map[string]any{
 				"apiVersion": collections.IstioNetworkingV1Alpha3Serviceentries.Resource().APIVersion(),
 				"kind":       collections.IstioNetworkingV1Alpha3Serviceentries.Resource().Kind(),
-				"metadata": map[string]interface{}{
+				"metadata": map[string]any{
 					"namespace": "default",
 					"name":      "mesh-expansion-vmtest",
 				},

--- a/istioctl/cmd/config.go
+++ b/istioctl/cmd/config.go
@@ -28,7 +28,7 @@ import (
 )
 
 // settableFlags are the flags used to istioctl
-var settableFlags = map[string]interface{}{
+var settableFlags = map[string]any{
 	"istioNamespace":      env.RegisterStringVar("ISTIOCTL_ISTIONAMESPACE", constants.IstioSystemNamespace, "The istioctl --istioNamespace override"),
 	"xds-address":         env.RegisterStringVar("ISTIOCTL_XDS_ADDRESS", "", "The istioctl --xds-address override"),
 	"xds-port":            env.RegisterIntVar("ISTIOCTL_XDS_PORT", 15012, "The istioctl --xds-port override"),
@@ -84,7 +84,7 @@ func runList(writer io.Writer) error {
 	return w.Flush()
 }
 
-func configSource(flag string, v interface{}) string {
+func configSource(flag string, v any) string {
 	// Environment variables have high precedence in Viper
 	if isVarSet(v) {
 		return "$" + getVarVar(v).Name
@@ -97,7 +97,7 @@ func configSource(flag string, v interface{}) string {
 	return "default"
 }
 
-func getVarVar(v interface{}) env.Var {
+func getVarVar(v any) env.Var {
 	switch ev := v.(type) {
 	case env.StringVar:
 		return ev.Var
@@ -114,7 +114,7 @@ func getVarVar(v interface{}) env.Var {
 	}
 }
 
-func isVarSet(v interface{}) bool {
+func isVarSet(v any) bool {
 	switch ev := v.(type) {
 	case env.StringVar:
 		_, ok := ev.Lookup()

--- a/istioctl/cmd/kubeuninject.go
+++ b/istioctl/cmd/kubeuninject.go
@@ -236,7 +236,7 @@ func handleAnnotations(annotations map[string]string) map[string]string {
 }
 
 // extractObject extras the sidecar injection and return the uninjected object.
-func extractObject(in runtime.Object) (interface{}, error) {
+func extractObject(in runtime.Object) (any, error) {
 	out := in.DeepCopyObject()
 
 	var metadata *metav1.ObjectMeta

--- a/istioctl/cmd/remove-from-mesh_test.go
+++ b/istioctl/cmd/remove-from-mesh_test.go
@@ -113,10 +113,10 @@ var (
 	}
 	cannedDynamicConfig = []runtime.Object{
 		&unstructured.Unstructured{
-			Object: map[string]interface{}{
+			Object: map[string]any{
 				"apiVersion": "networking.istio.io/" + collections.IstioNetworkingV1Alpha3Serviceentries.Resource().Version(),
 				"kind":       collections.IstioNetworkingV1Alpha3Serviceentries.Resource().Kind(),
-				"metadata": map[string]interface{}{
+				"metadata": map[string]any{
 					"namespace": "default",
 					"name":      "mesh-expansion-vmtest",
 				},

--- a/istioctl/cmd/revision.go
+++ b/istioctl/cmd/revision.go
@@ -716,7 +716,7 @@ func getBasicRevisionDescription(iopCRs []*iopv1alpha1.IstioOperator,
 	return revDescription
 }
 
-func printJSON(w io.Writer, res interface{}) error {
+func printJSON(w io.Writer, res any) error {
 	out, err := json.MarshalIndent(res, "", "\t")
 	if err != nil {
 		return fmt.Errorf("error while marshaling to JSON: %v", err)
@@ -1028,11 +1028,11 @@ func getDiffs(installed *iopv1alpha1.IstioOperator, manifestsPath, profile strin
 }
 
 // TODO(su225): Improve this and write tests for it.
-func diffWalk(path, separator string, installed interface{}, base interface{}) ([]iopDiff, error) {
+func diffWalk(path, separator string, installed any, base any) ([]iopDiff, error) {
 	switch v := installed.(type) {
-	case map[string]interface{}:
+	case map[string]any:
 		accum := make([]iopDiff, 0)
-		typedOrig, ok := base.(map[string]interface{})
+		typedOrig, ok := base.(map[string]any)
 		if ok {
 			for key, vv := range v {
 				childwalk, err := diffWalk(fmt.Sprintf("%s%s%s", path, separator, pathComponent(key)), ".", vv, typedOrig[key])
@@ -1043,12 +1043,12 @@ func diffWalk(path, separator string, installed interface{}, base interface{}) (
 			}
 		}
 		return accum, nil
-	case []interface{}:
+	case []any:
 		accum := make([]iopDiff, 0)
-		typedOrig, ok := base.([]interface{})
+		typedOrig, ok := base.([]any)
 		if ok {
 			for idx, vv := range v {
-				var baseMap interface{}
+				var baseMap any
 				if idx < len(typedOrig) {
 					baseMap = typedOrig[idx]
 				}

--- a/istioctl/cmd/wait.go
+++ b/istioctl/cmd/wait.go
@@ -147,7 +147,7 @@ func waitCmd() *cobra.Command {
 	return cmd
 }
 
-func printVerbosef(cmd *cobra.Command, template string, args ...interface{}) {
+func printVerbosef(cmd *cobra.Command, template string, args ...any) {
 	if verbose {
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), template+"\n", args...)
 	}

--- a/istioctl/cmd/wait_test.go
+++ b/istioctl/cmd/wait_test.go
@@ -124,10 +124,10 @@ func setupK8Sfake() *fake.FakeDynamicClient {
 
 func newUnstructured(apiVersion, kind, namespace, name string, generation int64) *unstructured.Unstructured {
 	return &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": apiVersion,
 			"kind":       kind,
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"namespace":  namespace,
 				"name":       name,
 				"generation": generation,

--- a/istioctl/cmd/workload.go
+++ b/istioctl/cmd/workload.go
@@ -131,10 +131,10 @@ The default output is serialized YAML, which can be piped into 'kubectl apply -f
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			u := &unstructured.Unstructured{
-				Object: map[string]interface{}{
+				Object: map[string]any{
 					"apiVersion": collections.IstioNetworkingV1Alpha3Workloadgroups.Resource().APIVersion(),
 					"kind":       collections.IstioNetworkingV1Alpha3Workloadgroups.Resource().Kind(),
-					"metadata": map[string]interface{}{
+					"metadata": map[string]any{
 						"name":      name,
 						"namespace": namespace,
 					},
@@ -528,7 +528,7 @@ func createMeshConfig(kubeClient kube.ExtendedClient, wg *clientv1alpha3.Workloa
 		return nil, err
 	}
 
-	proxyYAML, err := yaml.Marshal(map[string]interface{}{"defaultConfig": proxyConfig})
+	proxyYAML, err := yaml.Marshal(map[string]any{"defaultConfig": proxyConfig})
 	if err != nil {
 		return nil, err
 	}
@@ -625,7 +625,7 @@ func extractClusterIDFromInjectionConfig(kubeClient kube.ExtendedClient) (string
 		return "", fmt.Errorf("fetch injection template: %v", err)
 	}
 
-	var injectedCMValues map[string]interface{}
+	var injectedCMValues map[string]any
 	if err := json.Unmarshal([]byte(istioInjectionCM.Data[valuesConfigMapKey]), &injectedCMValues); err != nil {
 		return "", err
 	}

--- a/istioctl/pkg/multicluster/env.go
+++ b/istioctl/pkg/multicluster/env.go
@@ -35,8 +35,8 @@ type Environment interface {
 	Stdout() io.Writer
 	Stderr() io.Writer
 	ReadFile(filename string) ([]byte, error)
-	Printf(format string, a ...interface{})
-	Errorf(format string, a ...interface{})
+	Printf(format string, a ...any)
+	Errorf(format string, a ...any)
 	Poll(interval, timeout time.Duration, condition ConditionFunc) error
 }
 
@@ -55,11 +55,11 @@ func (e *KubeEnvironment) CreateClient(context string) (kube.ExtendedClient, err
 	return kube.NewExtendedClient(kube.NewClientConfigForRestConfig(cfg), "")
 }
 
-func (e *KubeEnvironment) Printf(format string, a ...interface{}) {
+func (e *KubeEnvironment) Printf(format string, a ...any) {
 	_, _ = fmt.Fprintf(e.stdout, format, a...)
 }
 
-func (e *KubeEnvironment) Errorf(format string, a ...interface{}) {
+func (e *KubeEnvironment) Errorf(format string, a ...any) {
 	_, _ = fmt.Fprintf(e.stderr, format, a...)
 }
 

--- a/istioctl/pkg/util/configdump/secret.go
+++ b/istioctl/pkg/util/configdump/secret.go
@@ -20,7 +20,7 @@ import (
 
 	adminapi "github.com/envoyproxy/go-control-plane/envoy/admin/v3"
 	extapi "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
-	any "google.golang.org/protobuf/types/known/anypb"
+	anypb "google.golang.org/protobuf/types/known/anypb"
 )
 
 // GetSecretsConfigDump retrieves a secret dump from a config dump wrapper
@@ -38,7 +38,7 @@ func (w *Wrapper) GetSecretConfigDump() (*adminapi.SecretsConfigDump, error) {
 }
 
 // GetRootCAFromSecretConfigDump retrieves root CA from a secret config dump wrapper
-func (w *Wrapper) GetRootCAFromSecretConfigDump(anySec *any.Any) (string, error) {
+func (w *Wrapper) GetRootCAFromSecretConfigDump(anySec *anypb.Any) (string, error) {
 	var secret extapi.Secret
 	if err := anySec.UnmarshalTo(&secret); err != nil {
 		return "", fmt.Errorf("failed to unmarshall ROOTCA secret: %v", err)

--- a/istioctl/pkg/util/configdump/util.go
+++ b/istioctl/pkg/util/configdump/util.go
@@ -17,7 +17,7 @@ package configdump
 import (
 	"fmt"
 
-	any "google.golang.org/protobuf/types/known/anypb"
+	anypb "google.golang.org/protobuf/types/known/anypb"
 )
 
 type configTypeURL string
@@ -33,8 +33,8 @@ const (
 )
 
 // getSection takes a TypeURL and returns the types.Any from the config dump corresponding to that URL
-func (w *Wrapper) getSection(sectionTypeURL configTypeURL) (*any.Any, error) {
-	var dumpAny *any.Any
+func (w *Wrapper) getSection(sectionTypeURL configTypeURL) (*anypb.Any, error) {
+	var dumpAny *anypb.Any
 	for _, conf := range w.Configs {
 		if conf.TypeUrl == string(sectionTypeURL) {
 			dumpAny = conf

--- a/istioctl/pkg/validate/validate.go
+++ b/istioctl/pkg/validate/validate.go
@@ -173,11 +173,11 @@ func (v *validator) validateServicePortPrefix(istioNamespace string, un *unstruc
 	if un.GetNamespace() == handleNamespace(istioNamespace) {
 		return nil
 	}
-	spec := un.Object["spec"].(map[string]interface{})
+	spec := un.Object["spec"].(map[string]any)
 	if _, ok := spec["ports"]; ok {
-		ports := spec["ports"].([]interface{})
+		ports := spec["ports"].([]any)
 		for _, port := range ports {
-			p := port.(map[string]interface{})
+			p := port.(map[string]any)
 			if p["protocol"] != nil && strings.EqualFold(p["protocol"].(string), serviceProtocolUDP) {
 				continue
 			}
@@ -218,8 +218,8 @@ func (v *validator) validateDeploymentLabel(istioNamespace string, un *unstructu
 
 // GetTemplateLabels returns spec.template.metadata.labels from Deployment
 func GetTemplateLabels(u *unstructured.Unstructured) (map[string]string, error) {
-	if spec, ok := u.Object["spec"].(map[string]interface{}); ok {
-		if template, ok := spec["template"].(map[string]interface{}); ok {
+	if spec, ok := u.Object["spec"].(map[string]any); ok {
+		if template, ok := spec["template"].(map[string]any); ok {
 			m, _, err := unstructured.NestedStringMap(template, "metadata", "labels")
 			if err != nil {
 				return nil, err
@@ -237,7 +237,7 @@ func (v *validator) validateFile(istioNamespace *string, defaultNamespace string
 	var warnings validation.Warning
 	for {
 		// YAML allows non-string keys and the produces generic keys for nested fields
-		raw := make(map[interface{}]interface{})
+		raw := make(map[any]any)
 		err := decoder.Decode(&raw)
 		if err == io.EOF {
 			return warnings, errs
@@ -378,27 +378,27 @@ func warningToString(w validation.Warning) string {
 	return w.Error()
 }
 
-func transformInterfaceArray(in []interface{}) []interface{} {
-	out := make([]interface{}, len(in))
+func transformInterfaceArray(in []any) []any {
+	out := make([]any, len(in))
 	for i, v := range in {
 		out[i] = transformMapValue(v)
 	}
 	return out
 }
 
-func transformInterfaceMap(in map[interface{}]interface{}) map[string]interface{} {
-	out := make(map[string]interface{}, len(in))
+func transformInterfaceMap(in map[any]any) map[string]any {
+	out := make(map[string]any, len(in))
 	for k, v := range in {
 		out[fmt.Sprintf("%v", k)] = transformMapValue(v)
 	}
 	return out
 }
 
-func transformMapValue(in interface{}) interface{} {
+func transformMapValue(in any) any {
 	switch v := in.(type) {
-	case []interface{}:
+	case []any:
 		return transformInterfaceArray(v)
-	case map[interface{}]interface{}:
+	case map[any]any:
 		return transformInterfaceMap(v)
 	default:
 		return v
@@ -444,7 +444,7 @@ func convertObjectFromUnstructured(schema collection.Schema, un *unstructured.Un
 }
 
 // TODO(nmittler): Remove this once Pilot migrates to galley schema.
-func fromSchemaAndJSONMap(schema collection.Schema, data interface{}) (config.Spec, error) {
+func fromSchemaAndJSONMap(schema collection.Schema, data any) (config.Spec, error) {
 	// Marshal to json bytes
 	str, err := json.Marshal(data)
 	if err != nil {

--- a/istioctl/pkg/writer/envoy/configdump/endpoint.go
+++ b/istioctl/pkg/writer/envoy/configdump/endpoint.go
@@ -24,7 +24,7 @@ import (
 
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
-	any "github.com/golang/protobuf/ptypes/any"
+	anypb "github.com/golang/protobuf/ptypes/any"
 	"sigs.k8s.io/yaml"
 
 	protio "istio.io/istio/istioctl/pkg/util/proto"
@@ -165,7 +165,7 @@ func (c *ConfigWriter) retrieveSortedEndpointsSlice(filter EndpointFilter) ([]*e
 	return endpoints, nil
 }
 
-func retrieveEndpoint(epConfig *any.Any, filter EndpointFilter) (*endpoint.ClusterLoadAssignment, int) {
+func retrieveEndpoint(epConfig *anypb.Any, filter EndpointFilter) (*endpoint.ClusterLoadAssignment, int) {
 	cla := &endpoint.ClusterLoadAssignment{}
 	if err := epConfig.UnmarshalTo(cla); err != nil {
 		return nil, 0

--- a/istioctl/pkg/writer/envoy/configdump/route.go
+++ b/istioctl/pkg/writer/envoy/configdump/route.go
@@ -249,7 +249,7 @@ func (c *ConfigWriter) retrieveSortedRouteSlice() ([]*route.RouteConfiguration, 
 	return routes, nil
 }
 
-func isPassthrough(action interface{}) bool {
+func isPassthrough(action any) bool {
 	a, ok := action.(*route.Route_Route)
 	if !ok {
 		return false

--- a/istioctl/pkg/writer/pilot/status_test.go
+++ b/istioctl/pkg/writer/pilot/status_test.go
@@ -24,7 +24,7 @@ import (
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	status "github.com/envoyproxy/go-control-plane/envoy/service/status/v3"
 	"github.com/google/uuid"
-	any "google.golang.org/protobuf/types/known/anypb"
+	anypb "google.golang.org/protobuf/types/known/anypb"
 
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/util/protoconv"
@@ -392,7 +392,7 @@ func xdsResponseInput(istiodID string, configInputs []clientConfigInput) *xdsapi
 	}
 	identifier, _ := json.Marshal(icp)
 
-	resources := make([]*any.Any, 0)
+	resources := make([]*anypb.Any, 0)
 	for _, input := range configInputs {
 		resources = append(resources, protoconv.MessageToAny(newXdsClientConfig(input)))
 	}

--- a/istioctl/pkg/xds/google.go
+++ b/istioctl/pkg/xds/google.go
@@ -87,7 +87,7 @@ func getHubMembership(ctx context.Context, exClient kube.ExtendedClient) (*hubMe
 	if err != nil {
 		return nil, err
 	}
-	spec, ok := u.Object["spec"].(map[string]interface{})
+	spec, ok := u.Object["spec"].(map[string]any)
 	if !ok {
 		return nil, errors.New(`field "spec" is not a map`)
 	}

--- a/operator/cmd/mesh/install.go
+++ b/operator/cmd/mesh/install.go
@@ -410,7 +410,7 @@ func validateEnableNamespacesByDefault(iop *v1alpha12.IstioOperator) bool {
 		return false
 	}
 	sidecarValues := iop.Spec.Values.AsMap()["sidecarInjectorWebhook"]
-	sidecarMap, ok := sidecarValues.(map[string]interface{})
+	sidecarMap, ok := sidecarValues.(map[string]any)
 	if !ok {
 		return false
 	}

--- a/operator/cmd/mesh/profile-dump.go
+++ b/operator/cmd/mesh/profile-dump.go
@@ -103,11 +103,11 @@ func yamlToPrettyJSON(yml string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	var decoded interface{}
+	var decoded any
 	if uglyJSON[0] == '[' {
-		decoded = make([]interface{}, 0)
+		decoded = make([]any, 0)
 	} else {
-		decoded = map[string]interface{}{}
+		decoded = map[string]any{}
 	}
 	if err := json.Unmarshal(uglyJSON, &decoded); err != nil {
 		return "", err
@@ -207,16 +207,16 @@ func yamlToFlags(yml string) ([]string, error) {
 	if err != nil {
 		return []string{}, err
 	}
-	var decoded interface{}
+	var decoded any
 	if uglyJSON[0] == '[' {
-		decoded = make([]interface{}, 0)
+		decoded = make([]any, 0)
 	} else {
-		decoded = map[string]interface{}{}
+		decoded = map[string]any{}
 	}
 	if err := json.Unmarshal(uglyJSON, &decoded); err != nil {
 		return []string{}, err
 	}
-	if d, ok := decoded.(map[string]interface{}); ok {
+	if d, ok := decoded.(map[string]any); ok {
 		if v, ok := d["spec"]; ok {
 			// Fall back to showing the entire spec.
 			// (When --config-path is used there will be no spec to remove)
@@ -231,9 +231,9 @@ func yamlToFlags(yml string) ([]string, error) {
 	return setflags, nil
 }
 
-func walk(path, separator string, obj interface{}) ([]string, error) {
+func walk(path, separator string, obj any) ([]string, error) {
 	switch v := obj.(type) {
-	case map[string]interface{}:
+	case map[string]any:
 		accum := make([]string, 0)
 		for key, vv := range v {
 			childwalk, err := walk(fmt.Sprintf("%s%s%s", path, separator, pathComponent(key)), ".", vv)
@@ -243,7 +243,7 @@ func walk(path, separator string, obj interface{}) ([]string, error) {
 			accum = append(accum, childwalk...)
 		}
 		return accum, nil
-	case []interface{}:
+	case []any:
 		accum := make([]string, 0)
 		for idx, vv := range v {
 			indexwalk, err := walk(fmt.Sprintf("%s[%d]", path, idx), ".", vv)

--- a/operator/cmd/mesh/shared.go
+++ b/operator/cmd/mesh/shared.go
@@ -49,7 +49,7 @@ var (
 )
 
 type Printer interface {
-	Printf(format string, a ...interface{})
+	Printf(format string, a ...any)
 	Println(string)
 }
 
@@ -61,7 +61,7 @@ type writerPrinter struct {
 	writer io.Writer
 }
 
-func (w *writerPrinter) Printf(format string, a ...interface{}) {
+func (w *writerPrinter) Printf(format string, a ...any) {
 	_, _ = fmt.Fprintf(w.writer, format, a...)
 }
 

--- a/operator/cmd/mesh/test-util.go
+++ b/operator/cmd/mesh/test-util.go
@@ -37,7 +37,7 @@ import (
 // PathValue is a path/value type.
 type PathValue struct {
 	path  string
-	value interface{}
+	value any
 }
 
 // String implements the Stringer interface.
@@ -167,7 +167,7 @@ func hasLabel(o *object.K8sObject, label, value string) bool {
 	if !found {
 		return false
 	}
-	return got.(map[string]interface{})[label] == value
+	return got.(map[string]any)[label] == value
 }
 
 // mustGetService returns the service with the given name or fails if it's not found in objs.
@@ -199,7 +199,7 @@ func mustGetRole(g *gomega.WithT, objs *ObjectSet, name string) *object.K8sObjec
 }
 
 // mustGetContainer returns the container tree with the given name in the deployment with the given name.
-func mustGetContainer(g *gomega.WithT, objs *ObjectSet, deploymentName, containerName string) map[string]interface{} {
+func mustGetContainer(g *gomega.WithT, objs *ObjectSet, deploymentName, containerName string) map[string]any {
 	obj := mustGetDeployment(g, objs, deploymentName)
 	container := obj.Container(containerName)
 	g.Expect(container).Should(gomega.Not(gomega.BeNil()), fmt.Sprintf("Expected to get container %s in deployment %s", containerName, deploymentName))
@@ -224,7 +224,7 @@ func mustGetMutatingWebhookConfiguration(g *gomega.WithT, objs *ObjectSet, mutat
 }
 
 // HavePathValueEqual matches map[string]interface{} tree against a PathValue.
-func HavePathValueEqual(expected interface{}) types.GomegaMatcher {
+func HavePathValueEqual(expected any) types.GomegaMatcher {
 	return &HavePathValueEqualMatcher{
 		expected: expected,
 	}
@@ -232,13 +232,13 @@ func HavePathValueEqual(expected interface{}) types.GomegaMatcher {
 
 // HavePathValueEqualMatcher is a matcher type for HavePathValueEqual.
 type HavePathValueEqualMatcher struct {
-	expected interface{}
+	expected any
 }
 
 // Match implements the Matcher interface.
-func (m *HavePathValueEqualMatcher) Match(actual interface{}) (bool, error) {
+func (m *HavePathValueEqualMatcher) Match(actual any) (bool, error) {
 	pv := m.expected.(PathValue)
-	node := actual.(map[string]interface{})
+	node := actual.(map[string]any)
 	got, f, err := tpath.GetPathContext(node, util.PathFromString(pv.path), false)
 	if err != nil || !f {
 		return false, err
@@ -253,21 +253,21 @@ func (m *HavePathValueEqualMatcher) Match(actual interface{}) (bool, error) {
 }
 
 // FailureMessage implements the Matcher interface.
-func (m *HavePathValueEqualMatcher) FailureMessage(actual interface{}) string {
+func (m *HavePathValueEqualMatcher) FailureMessage(actual any) string {
 	pv := m.expected.(PathValue)
-	node := actual.(map[string]interface{})
+	node := actual.(map[string]any)
 	return fmt.Sprintf("Expected the following parseObjectSetFromManifest to have path=value %s=%v\n\n%v", pv.path, pv.value, util.ToYAML(node))
 }
 
 // NegatedFailureMessage implements the Matcher interface.
-func (m *HavePathValueEqualMatcher) NegatedFailureMessage(actual interface{}) string {
+func (m *HavePathValueEqualMatcher) NegatedFailureMessage(actual any) string {
 	pv := m.expected.(PathValue)
-	node := actual.(map[string]interface{})
+	node := actual.(map[string]any)
 	return fmt.Sprintf("Expected the following parseObjectSetFromManifest not to have path=value %s=%v\n\n%v", pv.path, pv.value, util.ToYAML(node))
 }
 
 // HavePathValueMatchRegex matches map[string]interface{} tree against a PathValue.
-func HavePathValueMatchRegex(expected interface{}) types.GomegaMatcher {
+func HavePathValueMatchRegex(expected any) types.GomegaMatcher {
 	return &HavePathValueMatchRegexMatcher{
 		expected: expected,
 	}
@@ -275,13 +275,13 @@ func HavePathValueMatchRegex(expected interface{}) types.GomegaMatcher {
 
 // HavePathValueMatchRegexMatcher is a matcher type for HavePathValueMatchRegex.
 type HavePathValueMatchRegexMatcher struct {
-	expected interface{}
+	expected any
 }
 
 // Match implements the Matcher interface.
-func (m *HavePathValueMatchRegexMatcher) Match(actual interface{}) (bool, error) {
+func (m *HavePathValueMatchRegexMatcher) Match(actual any) (bool, error) {
 	pv := m.expected.(PathValue)
-	node := actual.(map[string]interface{})
+	node := actual.(map[string]any)
 	got, f, err := tpath.GetPathContext(node, util.PathFromString(pv.path), false)
 	if err != nil || !f {
 		return false, err
@@ -302,21 +302,21 @@ func (m *HavePathValueMatchRegexMatcher) Match(actual interface{}) (bool, error)
 }
 
 // FailureMessage implements the Matcher interface.
-func (m *HavePathValueMatchRegexMatcher) FailureMessage(actual interface{}) string {
+func (m *HavePathValueMatchRegexMatcher) FailureMessage(actual any) string {
 	pv := m.expected.(PathValue)
-	node := actual.(map[string]interface{})
+	node := actual.(map[string]any)
 	return fmt.Sprintf("Expected the following parseObjectSetFromManifest to regex match path=value %s=%v\n\n%v", pv.path, pv.value, util.ToYAML(node))
 }
 
 // NegatedFailureMessage implements the Matcher interface.
-func (m *HavePathValueMatchRegexMatcher) NegatedFailureMessage(actual interface{}) string {
+func (m *HavePathValueMatchRegexMatcher) NegatedFailureMessage(actual any) string {
 	pv := m.expected.(PathValue)
-	node := actual.(map[string]interface{})
+	node := actual.(map[string]any)
 	return fmt.Sprintf("Expected the following parseObjectSetFromManifest not to regex match path=value %s=%v\n\n%v", pv.path, pv.value, util.ToYAML(node))
 }
 
 // HavePathValueContain matches map[string]interface{} tree against a PathValue.
-func HavePathValueContain(expected interface{}) types.GomegaMatcher {
+func HavePathValueContain(expected any) types.GomegaMatcher {
 	return &HavePathValueContainMatcher{
 		expected: expected,
 	}
@@ -324,13 +324,13 @@ func HavePathValueContain(expected interface{}) types.GomegaMatcher {
 
 // HavePathValueContainMatcher is a matcher type for HavePathValueContain.
 type HavePathValueContainMatcher struct {
-	expected interface{}
+	expected any
 }
 
 // Match implements the Matcher interface.
-func (m *HavePathValueContainMatcher) Match(actual interface{}) (bool, error) {
+func (m *HavePathValueContainMatcher) Match(actual any) (bool, error) {
 	pv := m.expected.(PathValue)
-	node := actual.(map[string]interface{})
+	node := actual.(map[string]any)
 	got, f, err := tpath.GetPathContext(node, util.PathFromString(pv.path), false)
 	if err != nil || !f {
 		return false, err
@@ -351,16 +351,16 @@ func (m *HavePathValueContainMatcher) Match(actual interface{}) (bool, error) {
 }
 
 // FailureMessage implements the Matcher interface.
-func (m *HavePathValueContainMatcher) FailureMessage(actual interface{}) string {
+func (m *HavePathValueContainMatcher) FailureMessage(actual any) string {
 	pv := m.expected.(PathValue)
-	node := actual.(map[string]interface{})
+	node := actual.(map[string]any)
 	return fmt.Sprintf("Expected path %s with value \n\n%v\nto be a subset of \n\n%v", pv.path, pv.value, util.ToYAML(node))
 }
 
 // NegatedFailureMessage implements the Matcher interface.
-func (m *HavePathValueContainMatcher) NegatedFailureMessage(actual interface{}) string {
+func (m *HavePathValueContainMatcher) NegatedFailureMessage(actual any) string {
 	pv := m.expected.(PathValue)
-	node := actual.(map[string]interface{})
+	node := actual.(map[string]any)
 	return fmt.Sprintf("Expected path %s with value \n\n%v\nto NOT be a subset of \n\n%v", pv.path, pv.value, util.ToYAML(node))
 }
 
@@ -383,7 +383,7 @@ func mustNotSelect(t test.Failer, selector map[string]string, labels map[string]
 func mustGetLabels(t test.Failer, obj object.K8sObject, path string) map[string]string {
 	t.Helper()
 	got := mustGetPath(t, obj, path)
-	conv, ok := got.(map[string]interface{})
+	conv, ok := got.(map[string]any)
 	if !ok {
 		t.Fatalf("could not convert %v", got)
 	}
@@ -398,7 +398,7 @@ func mustGetLabels(t test.Failer, obj object.K8sObject, path string) map[string]
 	return ret
 }
 
-func mustGetPath(t test.Failer, obj object.K8sObject, path string) interface{} {
+func mustGetPath(t test.Failer, obj object.K8sObject, path string) any {
 	t.Helper()
 	got, f, err := tpath.Find(obj.UnstructuredObject().UnstructuredContent(), util.PathFromString(path))
 	if err != nil {
@@ -431,7 +431,7 @@ func findObject(objs object.K8sObjects, name, kind string) *object.K8sObject {
 
 // mustGetValueAtPath returns the value at the given path in the unstructured tree t. Fails if the path is not found
 // in the tree.
-func mustGetValueAtPath(g *gomega.WithT, t map[string]interface{}, path string) interface{} {
+func mustGetValueAtPath(g *gomega.WithT, t map[string]any, path string) any {
 	got, f, err := tpath.GetPathContext(t, util.PathFromString(path), false)
 	g.Expect(err).Should(gomega.BeNil(), "path %s should exist (%s)", path, err)
 	g.Expect(f).Should(gomega.BeTrue(), "path %s should exist", path)
@@ -454,8 +454,8 @@ func removeDirOrFail(t *testing.T, path string) {
 }
 
 // toMap transforms a comma separated key:value list (e.g. "a:aval, b:bval") to a map.
-func toMap(s string) map[string]interface{} {
-	out := make(map[string]interface{})
+func toMap(s string) map[string]any {
+	out := make(map[string]any)
 	for _, l := range strings.Split(s, ",") {
 		l = strings.TrimSpace(l)
 		kv := strings.Split(l, ":")
@@ -471,8 +471,8 @@ func toMap(s string) map[string]interface{} {
 }
 
 // endpointSubsetAddressVal returns a map having subset address type for an endpint.
-func endpointSubsetAddressVal(hostname, ip, nodeName string) map[string]interface{} {
-	out := make(map[string]interface{})
+func endpointSubsetAddressVal(hostname, ip, nodeName string) map[string]any {
+	out := make(map[string]any)
 	if hostname != "" {
 		out["hostname"] = hostname
 	}
@@ -486,8 +486,8 @@ func endpointSubsetAddressVal(hostname, ip, nodeName string) map[string]interfac
 }
 
 // portVal returns a map having service port type. A value of -1 for port or targetPort leaves those keys unset.
-func portVal(name string, port, targetPort int64) map[string]interface{} {
-	out := make(map[string]interface{})
+func portVal(name string, port, targetPort int64) map[string]any {
+	out := make(map[string]any)
 	if name != "" {
 		out["name"] = name
 	}

--- a/operator/pkg/apis/istio/v1alpha1/common.go
+++ b/operator/pkg/apis/istio/v1alpha1/common.go
@@ -35,7 +35,7 @@ func Namespace(iops *v1alpha1.IstioOperatorSpec) string {
 	if v[globalKey] == nil {
 		return ""
 	}
-	vg := v[globalKey].(map[string]interface{})
+	vg := v[globalKey].(map[string]any)
 	n := vg[istioNamespaceKey]
 	if n == nil {
 		return ""

--- a/operator/pkg/apis/istio/v1alpha1/validation/validation.go
+++ b/operator/pkg/apis/istio/v1alpha1/validation/validation.go
@@ -38,7 +38,7 @@ type deprecatedSettings struct {
 	old string
 	new string
 	// In ordered to distinguish between unset for non-pointer values, we need to specify the default value
-	def interface{}
+	def any
 }
 
 // ValidateConfig  calls validation func for every defined element in Values

--- a/operator/pkg/apis/istio/v1alpha1/validation/validation_test.go
+++ b/operator/pkg/apis/istio/v1alpha1/validation/validation_test.go
@@ -50,8 +50,8 @@ func TestValidateConfig(t *testing.T) {
 						Enabled: &wrappers.BoolValue{Value: true},
 					},
 				},
-				Values: util.MustStruct(map[string]interface{}{
-					"grafana": map[string]interface{}{
+				Values: util.MustStruct(map[string]any{
+					"grafana": map[string]any{
 						"enabled": true,
 					},
 				}),
@@ -63,9 +63,9 @@ func TestValidateConfig(t *testing.T) {
 		{
 			name: "global",
 			value: &v1alpha12.IstioOperatorSpec{
-				Values: util.MustStruct(map[string]interface{}{
-					"global": map[string]interface{}{
-						"localityLbSetting": map[string]interface{}{"foo": "bar"},
+				Values: util.MustStruct(map[string]any{
+					"global": map[string]any{
+						"localityLbSetting": map[string]any{"foo": "bar"},
 					},
 				}),
 			},

--- a/operator/pkg/apis/istio/v1alpha1/values_types.pb.go
+++ b/operator/pkg/apis/istio/v1alpha1/values_types.pb.go
@@ -6171,7 +6171,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP() []byte {
 
 var file_pkg_apis_istio_v1alpha1_values_types_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
 var file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes = make([]protoimpl.MessageInfo, 53)
-var file_pkg_apis_istio_v1alpha1_values_types_proto_goTypes = []any{
+var file_pkg_apis_istio_v1alpha1_values_types_proto_goTypes = []interface{}{
 	(IngressControllerMode)(0),                         // 0: v1alpha1.ingressControllerMode
 	(Tracer)(0),                                        // 1: v1alpha1.tracer
 	(OutboundTrafficPolicyConfig_Mode)(0),              // 2: v1alpha1.OutboundTrafficPolicyConfig.Mode
@@ -6428,7 +6428,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 		return
 	}
 	if !protoimpl.UnsafeEnabled {
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[0].Exporter = func(v any, i int) any {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[0].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*ArchConfig); i {
 			case 0:
 				return &v.state
@@ -6440,7 +6440,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[1].Exporter = func(v any, i int) any {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[1].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*CNIConfig); i {
 			case 0:
 				return &v.state
@@ -6452,7 +6452,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[2].Exporter = func(v any, i int) any {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[2].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*CNITaintConfig); i {
 			case 0:
 				return &v.state
@@ -6464,7 +6464,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[3].Exporter = func(v any, i int) any {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[3].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*CNIRepairConfig); i {
 			case 0:
 				return &v.state
@@ -6476,7 +6476,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[4].Exporter = func(v any, i int) any {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[4].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*ResourceQuotas); i {
 			case 0:
 				return &v.state
@@ -6488,7 +6488,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[5].Exporter = func(v any, i int) any {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[5].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*CPUTargetUtilizationConfig); i {
 			case 0:
 				return &v.state
@@ -6500,7 +6500,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[6].Exporter = func(v any, i int) any {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[6].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*Resources); i {
 			case 0:
 				return &v.state
@@ -6512,7 +6512,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[7].Exporter = func(v any, i int) any {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[7].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*ServiceAccount); i {
 			case 0:
 				return &v.state
@@ -6524,7 +6524,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[8].Exporter = func(v any, i int) any {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[8].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*DefaultPodDisruptionBudgetConfig); i {
 			case 0:
 				return &v.state
@@ -6536,7 +6536,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[9].Exporter = func(v any, i int) any {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[9].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*DefaultResourcesConfig); i {
 			case 0:
 				return &v.state
@@ -6548,7 +6548,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[10].Exporter = func(v any, i int) any {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[10].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*EgressGatewayConfig); i {
 			case 0:
 				return &v.state
@@ -6560,7 +6560,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[11].Exporter = func(v any, i int) any {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[11].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*GatewaysConfig); i {
 			case 0:
 				return &v.state
@@ -6572,7 +6572,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[12].Exporter = func(v any, i int) any {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[12].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*GlobalConfig); i {
 			case 0:
 				return &v.state
@@ -6584,7 +6584,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[13].Exporter = func(v any, i int) any {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[13].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*STSConfig); i {
 			case 0:
 				return &v.state
@@ -6596,7 +6596,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[14].Exporter = func(v any, i int) any {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[14].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*IstiodConfig); i {
 			case 0:
 				return &v.state
@@ -6608,7 +6608,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[15].Exporter = func(v any, i int) any {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[15].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*GlobalLoggingConfig); i {
 			case 0:
 				return &v.state
@@ -6620,7 +6620,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[16].Exporter = func(v any, i int) any {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[16].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*IngressGatewayConfig); i {
 			case 0:
 				return &v.state
@@ -6632,7 +6632,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[17].Exporter = func(v any, i int) any {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[17].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*IngressGatewayZvpnConfig); i {
 			case 0:
 				return &v.state
@@ -6644,7 +6644,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[18].Exporter = func(v any, i int) any {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[18].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*MultiClusterConfig); i {
 			case 0:
 				return &v.state
@@ -6656,7 +6656,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[19].Exporter = func(v any, i int) any {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[19].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*OutboundTrafficPolicyConfig); i {
 			case 0:
 				return &v.state
@@ -6668,7 +6668,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[20].Exporter = func(v any, i int) any {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[20].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*PilotConfig); i {
 			case 0:
 				return &v.state
@@ -6680,7 +6680,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[21].Exporter = func(v any, i int) any {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[21].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*PilotIngressConfig); i {
 			case 0:
 				return &v.state
@@ -6692,7 +6692,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[22].Exporter = func(v any, i int) any {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[22].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*PilotPolicyConfig); i {
 			case 0:
 				return &v.state
@@ -6704,7 +6704,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[23].Exporter = func(v any, i int) any {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[23].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*TelemetryConfig); i {
 			case 0:
 				return &v.state
@@ -6716,7 +6716,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[24].Exporter = func(v any, i int) any {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[24].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*TelemetryV2Config); i {
 			case 0:
 				return &v.state
@@ -6728,7 +6728,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[25].Exporter = func(v any, i int) any {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[25].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*TelemetryV2MetadataExchangeConfig); i {
 			case 0:
 				return &v.state
@@ -6740,7 +6740,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[26].Exporter = func(v any, i int) any {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[26].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*TelemetryV2PrometheusConfig); i {
 			case 0:
 				return &v.state
@@ -6752,7 +6752,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[27].Exporter = func(v any, i int) any {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[27].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*TelemetryV2StackDriverConfig); i {
 			case 0:
 				return &v.state
@@ -6764,7 +6764,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[28].Exporter = func(v any, i int) any {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[28].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*TelemetryV2AccessLogPolicyFilterConfig); i {
 			case 0:
 				return &v.state
@@ -6776,7 +6776,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[29].Exporter = func(v any, i int) any {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[29].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*PilotConfigSource); i {
 			case 0:
 				return &v.state
@@ -6788,7 +6788,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[30].Exporter = func(v any, i int) any {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[30].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*PortsConfig); i {
 			case 0:
 				return &v.state
@@ -6800,7 +6800,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[31].Exporter = func(v any, i int) any {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[31].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*ProxyConfig); i {
 			case 0:
 				return &v.state
@@ -6812,7 +6812,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[32].Exporter = func(v any, i int) any {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[32].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*ProxyInitConfig); i {
 			case 0:
 				return &v.state
@@ -6824,7 +6824,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[33].Exporter = func(v any, i int) any {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[33].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*ResourcesRequestsConfig); i {
 			case 0:
 				return &v.state
@@ -6836,7 +6836,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[34].Exporter = func(v any, i int) any {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[34].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*SDSConfig); i {
 			case 0:
 				return &v.state
@@ -6848,7 +6848,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[35].Exporter = func(v any, i int) any {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[35].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*SecretVolume); i {
 			case 0:
 				return &v.state
@@ -6860,7 +6860,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[36].Exporter = func(v any, i int) any {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[36].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*ServiceConfig); i {
 			case 0:
 				return &v.state
@@ -6872,7 +6872,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[37].Exporter = func(v any, i int) any {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[37].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*SidecarInjectorConfig); i {
 			case 0:
 				return &v.state
@@ -6884,7 +6884,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[38].Exporter = func(v any, i int) any {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[38].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*TracerConfig); i {
 			case 0:
 				return &v.state
@@ -6896,7 +6896,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[39].Exporter = func(v any, i int) any {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[39].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*TracerDatadogConfig); i {
 			case 0:
 				return &v.state
@@ -6908,7 +6908,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[40].Exporter = func(v any, i int) any {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[40].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*TracerLightStepConfig); i {
 			case 0:
 				return &v.state
@@ -6920,7 +6920,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[41].Exporter = func(v any, i int) any {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[41].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*TracerZipkinConfig); i {
 			case 0:
 				return &v.state
@@ -6932,7 +6932,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[42].Exporter = func(v any, i int) any {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[42].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*TracerStackdriverConfig); i {
 			case 0:
 				return &v.state
@@ -6944,7 +6944,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[43].Exporter = func(v any, i int) any {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[43].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*BaseConfig); i {
 			case 0:
 				return &v.state
@@ -6956,7 +6956,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[44].Exporter = func(v any, i int) any {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[44].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*IstiodRemoteConfig); i {
 			case 0:
 				return &v.state
@@ -6968,7 +6968,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[45].Exporter = func(v any, i int) any {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[45].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*Values); i {
 			case 0:
 				return &v.state
@@ -6980,7 +6980,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[46].Exporter = func(v any, i int) any {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[46].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*ZeroVPNConfig); i {
 			case 0:
 				return &v.state
@@ -6992,7 +6992,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[47].Exporter = func(v any, i int) any {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[47].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*IntOrString); i {
 			case 0:
 				return &v.state
@@ -7004,7 +7004,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[52].Exporter = func(v any, i int) any {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[52].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*TelemetryV2PrometheusConfig_ConfigOverride); i {
 			case 0:
 				return &v.state

--- a/operator/pkg/apis/istio/v1alpha1/values_types.pb.go
+++ b/operator/pkg/apis/istio/v1alpha1/values_types.pb.go
@@ -6171,7 +6171,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP() []byte {
 
 var file_pkg_apis_istio_v1alpha1_values_types_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
 var file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes = make([]protoimpl.MessageInfo, 53)
-var file_pkg_apis_istio_v1alpha1_values_types_proto_goTypes = []interface{}{
+var file_pkg_apis_istio_v1alpha1_values_types_proto_goTypes = []any{
 	(IngressControllerMode)(0),                         // 0: v1alpha1.ingressControllerMode
 	(Tracer)(0),                                        // 1: v1alpha1.tracer
 	(OutboundTrafficPolicyConfig_Mode)(0),              // 2: v1alpha1.OutboundTrafficPolicyConfig.Mode
@@ -6428,7 +6428,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 		return
 	}
 	if !protoimpl.UnsafeEnabled {
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[0].Exporter = func(v interface{}, i int) interface{} {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[0].Exporter = func(v any, i int) any {
 			switch v := v.(*ArchConfig); i {
 			case 0:
 				return &v.state
@@ -6440,7 +6440,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[1].Exporter = func(v interface{}, i int) interface{} {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[1].Exporter = func(v any, i int) any {
 			switch v := v.(*CNIConfig); i {
 			case 0:
 				return &v.state
@@ -6452,7 +6452,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[2].Exporter = func(v interface{}, i int) interface{} {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[2].Exporter = func(v any, i int) any {
 			switch v := v.(*CNITaintConfig); i {
 			case 0:
 				return &v.state
@@ -6464,7 +6464,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[3].Exporter = func(v interface{}, i int) interface{} {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[3].Exporter = func(v any, i int) any {
 			switch v := v.(*CNIRepairConfig); i {
 			case 0:
 				return &v.state
@@ -6476,7 +6476,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[4].Exporter = func(v interface{}, i int) interface{} {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[4].Exporter = func(v any, i int) any {
 			switch v := v.(*ResourceQuotas); i {
 			case 0:
 				return &v.state
@@ -6488,7 +6488,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[5].Exporter = func(v interface{}, i int) interface{} {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[5].Exporter = func(v any, i int) any {
 			switch v := v.(*CPUTargetUtilizationConfig); i {
 			case 0:
 				return &v.state
@@ -6500,7 +6500,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[6].Exporter = func(v interface{}, i int) interface{} {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[6].Exporter = func(v any, i int) any {
 			switch v := v.(*Resources); i {
 			case 0:
 				return &v.state
@@ -6512,7 +6512,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[7].Exporter = func(v interface{}, i int) interface{} {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[7].Exporter = func(v any, i int) any {
 			switch v := v.(*ServiceAccount); i {
 			case 0:
 				return &v.state
@@ -6524,7 +6524,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[8].Exporter = func(v interface{}, i int) interface{} {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[8].Exporter = func(v any, i int) any {
 			switch v := v.(*DefaultPodDisruptionBudgetConfig); i {
 			case 0:
 				return &v.state
@@ -6536,7 +6536,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[9].Exporter = func(v interface{}, i int) interface{} {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[9].Exporter = func(v any, i int) any {
 			switch v := v.(*DefaultResourcesConfig); i {
 			case 0:
 				return &v.state
@@ -6548,7 +6548,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[10].Exporter = func(v interface{}, i int) interface{} {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[10].Exporter = func(v any, i int) any {
 			switch v := v.(*EgressGatewayConfig); i {
 			case 0:
 				return &v.state
@@ -6560,7 +6560,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[11].Exporter = func(v interface{}, i int) interface{} {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[11].Exporter = func(v any, i int) any {
 			switch v := v.(*GatewaysConfig); i {
 			case 0:
 				return &v.state
@@ -6572,7 +6572,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[12].Exporter = func(v interface{}, i int) interface{} {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[12].Exporter = func(v any, i int) any {
 			switch v := v.(*GlobalConfig); i {
 			case 0:
 				return &v.state
@@ -6584,7 +6584,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[13].Exporter = func(v interface{}, i int) interface{} {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[13].Exporter = func(v any, i int) any {
 			switch v := v.(*STSConfig); i {
 			case 0:
 				return &v.state
@@ -6596,7 +6596,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[14].Exporter = func(v interface{}, i int) interface{} {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[14].Exporter = func(v any, i int) any {
 			switch v := v.(*IstiodConfig); i {
 			case 0:
 				return &v.state
@@ -6608,7 +6608,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[15].Exporter = func(v interface{}, i int) interface{} {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[15].Exporter = func(v any, i int) any {
 			switch v := v.(*GlobalLoggingConfig); i {
 			case 0:
 				return &v.state
@@ -6620,7 +6620,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[16].Exporter = func(v interface{}, i int) interface{} {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[16].Exporter = func(v any, i int) any {
 			switch v := v.(*IngressGatewayConfig); i {
 			case 0:
 				return &v.state
@@ -6632,7 +6632,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[17].Exporter = func(v interface{}, i int) interface{} {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[17].Exporter = func(v any, i int) any {
 			switch v := v.(*IngressGatewayZvpnConfig); i {
 			case 0:
 				return &v.state
@@ -6644,7 +6644,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[18].Exporter = func(v interface{}, i int) interface{} {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[18].Exporter = func(v any, i int) any {
 			switch v := v.(*MultiClusterConfig); i {
 			case 0:
 				return &v.state
@@ -6656,7 +6656,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[19].Exporter = func(v interface{}, i int) interface{} {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[19].Exporter = func(v any, i int) any {
 			switch v := v.(*OutboundTrafficPolicyConfig); i {
 			case 0:
 				return &v.state
@@ -6668,7 +6668,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[20].Exporter = func(v interface{}, i int) interface{} {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[20].Exporter = func(v any, i int) any {
 			switch v := v.(*PilotConfig); i {
 			case 0:
 				return &v.state
@@ -6680,7 +6680,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[21].Exporter = func(v interface{}, i int) interface{} {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[21].Exporter = func(v any, i int) any {
 			switch v := v.(*PilotIngressConfig); i {
 			case 0:
 				return &v.state
@@ -6692,7 +6692,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[22].Exporter = func(v interface{}, i int) interface{} {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[22].Exporter = func(v any, i int) any {
 			switch v := v.(*PilotPolicyConfig); i {
 			case 0:
 				return &v.state
@@ -6704,7 +6704,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[23].Exporter = func(v interface{}, i int) interface{} {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[23].Exporter = func(v any, i int) any {
 			switch v := v.(*TelemetryConfig); i {
 			case 0:
 				return &v.state
@@ -6716,7 +6716,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[24].Exporter = func(v interface{}, i int) interface{} {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[24].Exporter = func(v any, i int) any {
 			switch v := v.(*TelemetryV2Config); i {
 			case 0:
 				return &v.state
@@ -6728,7 +6728,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[25].Exporter = func(v interface{}, i int) interface{} {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[25].Exporter = func(v any, i int) any {
 			switch v := v.(*TelemetryV2MetadataExchangeConfig); i {
 			case 0:
 				return &v.state
@@ -6740,7 +6740,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[26].Exporter = func(v interface{}, i int) interface{} {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[26].Exporter = func(v any, i int) any {
 			switch v := v.(*TelemetryV2PrometheusConfig); i {
 			case 0:
 				return &v.state
@@ -6752,7 +6752,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[27].Exporter = func(v interface{}, i int) interface{} {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[27].Exporter = func(v any, i int) any {
 			switch v := v.(*TelemetryV2StackDriverConfig); i {
 			case 0:
 				return &v.state
@@ -6764,7 +6764,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[28].Exporter = func(v interface{}, i int) interface{} {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[28].Exporter = func(v any, i int) any {
 			switch v := v.(*TelemetryV2AccessLogPolicyFilterConfig); i {
 			case 0:
 				return &v.state
@@ -6776,7 +6776,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[29].Exporter = func(v interface{}, i int) interface{} {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[29].Exporter = func(v any, i int) any {
 			switch v := v.(*PilotConfigSource); i {
 			case 0:
 				return &v.state
@@ -6788,7 +6788,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[30].Exporter = func(v interface{}, i int) interface{} {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[30].Exporter = func(v any, i int) any {
 			switch v := v.(*PortsConfig); i {
 			case 0:
 				return &v.state
@@ -6800,7 +6800,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[31].Exporter = func(v interface{}, i int) interface{} {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[31].Exporter = func(v any, i int) any {
 			switch v := v.(*ProxyConfig); i {
 			case 0:
 				return &v.state
@@ -6812,7 +6812,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[32].Exporter = func(v interface{}, i int) interface{} {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[32].Exporter = func(v any, i int) any {
 			switch v := v.(*ProxyInitConfig); i {
 			case 0:
 				return &v.state
@@ -6824,7 +6824,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[33].Exporter = func(v interface{}, i int) interface{} {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[33].Exporter = func(v any, i int) any {
 			switch v := v.(*ResourcesRequestsConfig); i {
 			case 0:
 				return &v.state
@@ -6836,7 +6836,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[34].Exporter = func(v interface{}, i int) interface{} {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[34].Exporter = func(v any, i int) any {
 			switch v := v.(*SDSConfig); i {
 			case 0:
 				return &v.state
@@ -6848,7 +6848,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[35].Exporter = func(v interface{}, i int) interface{} {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[35].Exporter = func(v any, i int) any {
 			switch v := v.(*SecretVolume); i {
 			case 0:
 				return &v.state
@@ -6860,7 +6860,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[36].Exporter = func(v interface{}, i int) interface{} {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[36].Exporter = func(v any, i int) any {
 			switch v := v.(*ServiceConfig); i {
 			case 0:
 				return &v.state
@@ -6872,7 +6872,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[37].Exporter = func(v interface{}, i int) interface{} {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[37].Exporter = func(v any, i int) any {
 			switch v := v.(*SidecarInjectorConfig); i {
 			case 0:
 				return &v.state
@@ -6884,7 +6884,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[38].Exporter = func(v interface{}, i int) interface{} {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[38].Exporter = func(v any, i int) any {
 			switch v := v.(*TracerConfig); i {
 			case 0:
 				return &v.state
@@ -6896,7 +6896,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[39].Exporter = func(v interface{}, i int) interface{} {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[39].Exporter = func(v any, i int) any {
 			switch v := v.(*TracerDatadogConfig); i {
 			case 0:
 				return &v.state
@@ -6908,7 +6908,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[40].Exporter = func(v interface{}, i int) interface{} {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[40].Exporter = func(v any, i int) any {
 			switch v := v.(*TracerLightStepConfig); i {
 			case 0:
 				return &v.state
@@ -6920,7 +6920,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[41].Exporter = func(v interface{}, i int) interface{} {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[41].Exporter = func(v any, i int) any {
 			switch v := v.(*TracerZipkinConfig); i {
 			case 0:
 				return &v.state
@@ -6932,7 +6932,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[42].Exporter = func(v interface{}, i int) interface{} {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[42].Exporter = func(v any, i int) any {
 			switch v := v.(*TracerStackdriverConfig); i {
 			case 0:
 				return &v.state
@@ -6944,7 +6944,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[43].Exporter = func(v interface{}, i int) interface{} {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[43].Exporter = func(v any, i int) any {
 			switch v := v.(*BaseConfig); i {
 			case 0:
 				return &v.state
@@ -6956,7 +6956,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[44].Exporter = func(v interface{}, i int) interface{} {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[44].Exporter = func(v any, i int) any {
 			switch v := v.(*IstiodRemoteConfig); i {
 			case 0:
 				return &v.state
@@ -6968,7 +6968,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[45].Exporter = func(v interface{}, i int) interface{} {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[45].Exporter = func(v any, i int) any {
 			switch v := v.(*Values); i {
 			case 0:
 				return &v.state
@@ -6980,7 +6980,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[46].Exporter = func(v interface{}, i int) interface{} {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[46].Exporter = func(v any, i int) any {
 			switch v := v.(*ZeroVPNConfig); i {
 			case 0:
 				return &v.state
@@ -6992,7 +6992,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[47].Exporter = func(v interface{}, i int) interface{} {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[47].Exporter = func(v any, i int) any {
 			switch v := v.(*IntOrString); i {
 			case 0:
 				return &v.state
@@ -7004,7 +7004,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[52].Exporter = func(v interface{}, i int) interface{} {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[52].Exporter = func(v any, i int) any {
 			switch v := v.(*TelemetryV2PrometheusConfig_ConfigOverride); i {
 			case 0:
 				return &v.state

--- a/operator/pkg/cache/cache_test.go
+++ b/operator/pkg/cache/cache_test.go
@@ -36,7 +36,7 @@ func TestFlushObjectCaches(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			unstObjs := make(map[string]interface{})
+			unstObjs := make(map[string]any)
 			tUnstructured := &unstructured.Unstructured{Object: unstObjs}
 			testCache := make(map[string]*object.K8sObject)
 			testCache["foo"] = object.NewK8sObject(tUnstructured, nil, nil)
@@ -116,10 +116,10 @@ func TestRemoveObject(t *testing.T) {
 				"cache-foo-key": {
 					Cache: map[string]*object.K8sObject{
 						"obj-foo-key": object.NewK8sObject(&unstructured.Unstructured{
-							Object: make(map[string]interface{}),
+							Object: make(map[string]any),
 						}, nil, nil),
 						"dont-touch-me-key": object.NewK8sObject(&unstructured.Unstructured{
-							Object: make(map[string]interface{}),
+							Object: make(map[string]any),
 						}, nil, nil),
 					},
 					Mu: &sync.RWMutex{},
@@ -130,7 +130,7 @@ func TestRemoveObject(t *testing.T) {
 			expectedCache: ObjectCache{
 				Cache: map[string]*object.K8sObject{
 					"dont-touch-me-key": object.NewK8sObject(&unstructured.Unstructured{
-						Object: make(map[string]interface{}),
+						Object: make(map[string]any),
 					}, nil, nil),
 				},
 				Mu: &sync.RWMutex{},

--- a/operator/pkg/compare/compare.go
+++ b/operator/pkg/compare/compare.go
@@ -35,7 +35,7 @@ import (
 // YAMLCmpReporter is a custom reporter to generate tree based diff for YAMLs, used by cmp.Equal().
 type YAMLCmpReporter struct {
 	path     cmp.Path
-	diffTree map[string]interface{}
+	diffTree map[string]any
 }
 
 // PushStep implements interface to keep track of current path by pushing.
@@ -68,7 +68,7 @@ func (r *YAMLCmpReporter) Report(rs cmp.Result) {
 			return
 		}
 		if r.diffTree == nil {
-			r.diffTree = make(map[string]interface{})
+			r.diffTree = make(map[string]any)
 		}
 		if err := tpath.WriteNode(r.diffTree, pathToStringList(r.path), dm); err != nil {
 			panic(err)
@@ -109,7 +109,7 @@ func YAMLCmp(a, b string) string {
 
 // YAMLCmpWithIgnore compares two yaml texts, and ignores paths in ignorePaths.
 func YAMLCmpWithIgnore(a, b string, ignorePaths []string, ignoreYaml string) string {
-	ao, bo := make(map[string]interface{}), make(map[string]interface{})
+	ao, bo := make(map[string]any), make(map[string]any)
 	if err := yaml.Unmarshal([]byte(a), &ao); err != nil {
 		return err.Error()
 	}
@@ -140,7 +140,7 @@ func YAMLCmpWithIgnore(a, b string, ignorePaths []string, ignoreYaml string) str
 
 // UnmarshalInlineYaml tries to unmarshal string values in obj into YAML objects
 // at a given targetPath. Side effect: this will mutate obj in place.
-func UnmarshalInlineYaml(obj map[string]interface{}, targetPath string) (err error) {
+func UnmarshalInlineYaml(obj map[string]any, targetPath string) (err error) {
 	nodeList := strings.Split(targetPath, ".")
 	if len(nodeList) == 0 {
 		return fmt.Errorf("targetPath '%v' length is zero after split", targetPath)
@@ -154,7 +154,7 @@ func UnmarshalInlineYaml(obj map[string]interface{}, targetPath string) (err err
 				targetPath, nname)
 		}
 		switch nnode := ndata.(type) {
-		case map[string]interface{}:
+		case map[string]any:
 			cur = nnode
 		default: // target path type does not match
 			return fmt.Errorf("targetPath '%v' doest not exist in obj: "+
@@ -165,7 +165,7 @@ func UnmarshalInlineYaml(obj map[string]interface{}, targetPath string) (err err
 	for dk, dv := range cur {
 		switch vnode := dv.(type) {
 		case string:
-			vo := make(map[string]interface{})
+			vo := make(map[string]any)
 			if err := yaml.Unmarshal([]byte(vnode), &vo); err != nil {
 				continue
 			}
@@ -178,7 +178,7 @@ func UnmarshalInlineYaml(obj map[string]interface{}, targetPath string) (err err
 
 // genPathIgnoreOpt returns a cmp.Option to ignore paths specified in parameter ignorePaths.
 func genYamlIgnoreOpt(yamlStr string) (cmp.Option, error) {
-	tree := make(map[string]interface{})
+	tree := make(map[string]any)
 	if err := yaml.Unmarshal([]byte(yamlStr), &tree); err != nil {
 		return nil, err
 	}
@@ -499,6 +499,6 @@ func writeStringSafe(sb io.StringWriter, s string) {
 }
 
 // IsLeafNode reports whether the given node is a leaf, assuming internal nodes can only be maps or slices.
-func IsLeafNode(node interface{}) bool {
+func IsLeafNode(node any) bool {
 	return !util.IsMap(node) && !util.IsSlice(node)
 }

--- a/operator/pkg/compare/compare_test.go
+++ b/operator/pkg/compare/compare_test.go
@@ -26,7 +26,7 @@ func TestYAMLCmp(t *testing.T) {
 		desc string
 		a    string
 		b    string
-		want interface{}
+		want any
 	}{
 		{
 			desc: "empty string into nil",
@@ -439,7 +439,7 @@ func TestYAMLCmpWithIgnore(t *testing.T) {
 		a    string
 		b    string
 		i    []string
-		want interface{}
+		want any
 	}{
 		{
 			desc: "identical",
@@ -696,7 +696,7 @@ func TestYAMLCmpWithIgnoreTree(t *testing.T) {
 		a    string
 		b    string
 		mask string
-		want interface{}
+		want any
 	}{
 		{
 			desc: "ignore masked",
@@ -787,7 +787,7 @@ func TestYAMLCmpWithYamlInline(t *testing.T) {
 		desc string
 		a    string
 		b    string
-		want interface{}
+		want any
 	}{
 		{
 			desc: "ConfigMap data order changed",

--- a/operator/pkg/component/component.go
+++ b/operator/pkg/component/component.go
@@ -83,7 +83,7 @@ type CommonComponentFields struct {
 	// index is the index of the component (only used for components with multiple instances like gateways).
 	index int
 	// componentSpec for the actual component e.g. GatewaySpec, ComponentSpec.
-	componentSpec interface{}
+	componentSpec any
 	// started reports whether the component is in initialized and running.
 	started  bool
 	renderer helm.TemplateRenderer

--- a/operator/pkg/controller/istiocontrolplane/istiocontrolplane_controller.go
+++ b/operator/pkg/controller/istiocontrolplane/istiocontrolplane_controller.go
@@ -334,9 +334,9 @@ func (r *ReconcileIstioOperator) Reconcile(_ context.Context, request reconcile.
 	scope.Info("Updating IstioOperator")
 	val := iopMerged.Spec.Values.AsMap()
 	if _, ok := val["global"]; !ok {
-		val["global"] = make(map[string]interface{})
+		val["global"] = make(map[string]any)
 	}
-	globalValues := val["global"].(map[string]interface{})
+	globalValues := val["global"].(map[string]any)
 	scope.Info("Detecting third-party JWT support")
 	var jwtPolicy util.JWTPolicy
 	if jwtPolicy, err = util.DetectSupportedJWTPolicy(r.kubeClient.Kube()); err != nil {

--- a/operator/pkg/helm/helm.go
+++ b/operator/pkg/helm/helm.go
@@ -95,7 +95,7 @@ func renderChart(namespace, values string, chrt *chart.Chart, filterFunc Templat
 		Name:      "istio",
 		Namespace: namespace,
 	}
-	valuesMap := map[string]interface{}{}
+	valuesMap := map[string]any{}
 	if err := yaml.Unmarshal([]byte(values), &valuesMap); err != nil {
 		return "", fmt.Errorf("failed to unmarshal values: %v", err)
 	}
@@ -129,7 +129,7 @@ func renderChart(namespace, values string, chrt *chart.Chart, filterFunc Templat
 		return "", err
 	}
 	if chrt.Metadata.Name == "base" {
-		base, _ := valuesMap["base"].(map[string]interface{})
+		base, _ := valuesMap["base"].(map[string]any)
 		if enableIstioConfigCRDs, ok := base["enableIstioConfigCRDs"].(bool); ok && !enableIstioConfigCRDs {
 			crdFiles = []chart.CRD{}
 		}

--- a/operator/pkg/helmreconciler/common.go
+++ b/operator/pkg/helmreconciler/common.go
@@ -63,7 +63,7 @@ func init() {
 
 // ComponentTree represents a tree of component dependencies.
 type (
-	ComponentTree          map[name.ComponentName]interface{}
+	ComponentTree          map[name.ComponentName]any
 	componentNameToListMap map[name.ComponentName][]name.ComponentName
 )
 
@@ -161,12 +161,12 @@ func createPortMap(current *unstructured.Unstructured) map[string]uint32 {
 func saveNodePorts(current, overlay *unstructured.Unstructured) {
 	portMap := createPortMap(current)
 	ports, _, _ := unstructured.NestedFieldNoCopy(overlay.Object, "spec", "ports")
-	portList, ok := ports.([]interface{})
+	portList, ok := ports.([]any)
 	if !ok {
 		return
 	}
 	for _, port := range portList {
-		m, ok := port.(map[string]interface{})
+		m, ok := port.(map[string]any)
 		if !ok {
 			continue
 		}

--- a/operator/pkg/helmreconciler/reconciler.go
+++ b/operator/pkg/helmreconciler/reconciler.go
@@ -614,7 +614,7 @@ func (h *HelmReconciler) networkName() string {
 		return ""
 	}
 	globalI := h.iop.Spec.Values.AsMap()["global"]
-	global, ok := globalI.(map[string]interface{})
+	global, ok := globalI.(map[string]any)
 	if !ok {
 		return ""
 	}

--- a/operator/pkg/manifest/shared.go
+++ b/operator/pkg/manifest/shared.go
@@ -459,7 +459,7 @@ func makeTreeFromSetList(setOverlay []string) (string, error) {
 	if len(setOverlay) == 0 {
 		return "", nil
 	}
-	tree := make(map[string]interface{})
+	tree := make(map[string]any)
 	for _, kv := range setOverlay {
 		kvv := strings.Split(kv, "=")
 		if len(kvv) != 2 {
@@ -529,13 +529,13 @@ func getInstallPackagePath(iopYAML string) (string, error) {
 
 // overlaySetFlagValues overlays each of the setFlags on top of the passed in IOP YAML string.
 func overlaySetFlagValues(iopYAML string, setFlags []string) (string, error) {
-	iop := make(map[string]interface{})
+	iop := make(map[string]any)
 	if err := yaml.Unmarshal([]byte(iopYAML), &iop); err != nil {
 		return "", err
 	}
 	// Unmarshal returns nil for empty manifests but we need something to insert into.
 	if iop == nil {
-		iop = make(map[string]interface{})
+		iop = make(map[string]any)
 	}
 
 	for _, sf := range setFlags {

--- a/operator/pkg/name/name_test.go
+++ b/operator/pkg/name/name_test.go
@@ -101,7 +101,7 @@ a:
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tree := make(map[string]interface{})
+			tree := make(map[string]any)
 			if err := yaml.Unmarshal([]byte(tt.args.inputTree), &tree); err != nil {
 				t.Fatal(err)
 			}
@@ -111,7 +111,7 @@ a:
 				return
 			}
 
-			var wantTree interface{}
+			var wantTree any
 			if err := yaml.Unmarshal([]byte(tt.want), &wantTree); err != nil {
 				t.Fatal(err)
 			}

--- a/operator/pkg/object/objects.go
+++ b/operator/pkg/object/objects.go
@@ -143,18 +143,18 @@ func (o *K8sObject) ResolveK8sConflict() *K8sObject {
 }
 
 // Unstructured exposes the raw object content, primarily for testing
-func (o *K8sObject) Unstructured() map[string]interface{} {
+func (o *K8sObject) Unstructured() map[string]any {
 	return o.UnstructuredObject().UnstructuredContent()
 }
 
 // Container returns a container subtree for Deployment objects if one is found, or nil otherwise.
-func (o *K8sObject) Container(name string) map[string]interface{} {
+func (o *K8sObject) Container(name string) map[string]any {
 	u := o.Unstructured()
 	path := fmt.Sprintf("spec.template.spec.containers.[name:%s]", name)
 	node, f, err := tpath.GetPathContext(u, util.PathFromString(path), false)
 	if err == nil && f {
 		// Must be the type from the schema.
-		return node.Node.(map[string]interface{})
+		return node.Node.(map[string]any)
 	}
 	return nil
 }
@@ -544,8 +544,8 @@ func resolvePDBConflict(o *K8sObject) *K8sObject {
 	if o.object.Object["spec"] == nil {
 		return o
 	}
-	spec := o.object.Object["spec"].(map[string]interface{})
-	isDefault := func(item interface{}) bool {
+	spec := o.object.Object["spec"].(map[string]any)
+	isDefault := func(item any) bool {
 		var ii intstr.IntOrString
 		switch item := item.(type) {
 		case int:

--- a/operator/pkg/object/objects_test.go
+++ b/operator/pkg/object/objects_test.go
@@ -532,12 +532,12 @@ spec:
 
 func TestK8sObject_Equal(t *testing.T) {
 	obj1 := K8sObject{
-		object: &unstructured.Unstructured{Object: map[string]interface{}{
+		object: &unstructured.Unstructured{Object: map[string]any{
 			"key": "value1",
 		}},
 	}
 	obj2 := K8sObject{
-		object: &unstructured.Unstructured{Object: map[string]interface{}{
+		object: &unstructured.Unstructured{Object: map[string]any{
 			"key": "value2",
 		}},
 	}

--- a/operator/pkg/patch/patch.go
+++ b/operator/pkg/patch/patch.go
@@ -173,7 +173,7 @@ func YAMLManifestPatch(baseYAML string, defaultNamespace string, overlays []*v1a
 // applyPatches applies the given patches against the given object. It returns the resulting patched YAML if successful,
 // or a list of errors otherwise.
 func applyPatches(base *object.K8sObject, patches []*v1alpha1.K8SObjectOverlay_PathValue) (outYAML string, errs util.Errors) {
-	bo := make(map[interface{}]interface{})
+	bo := make(map[any]any)
 	by, err := base.YAML()
 	if err != nil {
 		return "", util.NewErrs(err)

--- a/operator/pkg/tpath/struct.go
+++ b/operator/pkg/tpath/struct.go
@@ -28,13 +28,13 @@ import (
 )
 
 // GetFromStructPath returns the value at path from the given node, or false if the path does not exist.
-func GetFromStructPath(node interface{}, path string) (interface{}, bool, error) {
+func GetFromStructPath(node any, path string) (any, bool, error) {
 	return getFromStructPath(node, util.PathFromString(path))
 }
 
 // getFromStructPath is the internal implementation of GetFromStructPath which recurses through a tree of Go structs
 // given a path. It terminates when the end of the path is reached or a path element does not exist.
-func getFromStructPath(node interface{}, path util.Path) (interface{}, bool, error) {
+func getFromStructPath(node any, path util.Path) (any, bool, error) {
 	scope.Debugf("getFromStructPath path=%s, node(%T)", path, node)
 	if len(path) == 0 {
 		scope.Debugf("getFromStructPath returning node(%T)%v", node, node)
@@ -98,7 +98,7 @@ func getFromStructPath(node interface{}, path util.Path) (interface{}, bool, err
 // SetFromPath sets out with the value at path from node. out is not set if the path doesn't exist or the value is nil.
 // All intermediate along path must be type struct ptr. Out must be either a struct ptr or map ptr.
 // TODO: move these out to a separate package (istio/istio#15494).
-func SetFromPath(node interface{}, path string, out interface{}) (bool, error) {
+func SetFromPath(node any, path string, out any) (bool, error) {
 	val, found, err := GetFromStructPath(node, path)
 	if err != nil {
 		return false, err
@@ -111,7 +111,7 @@ func SetFromPath(node interface{}, path string, out interface{}) (bool, error) {
 }
 
 // Set sets out with the value at path from node. out is not set if the path doesn't exist or the value is nil.
-func Set(val, out interface{}) error {
+func Set(val, out any) error {
 	// Special case: map out type must be set through map ptr.
 	if util.IsMap(val) && util.IsMapPtr(out) {
 		reflect.ValueOf(out).Elem().Set(reflect.ValueOf(val))

--- a/operator/pkg/tpath/struct_test.go
+++ b/operator/pkg/tpath/struct_test.go
@@ -138,7 +138,7 @@ g:
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			rnode := make(map[string]interface{})
+			rnode := make(map[string]any)
 			if err := yaml.Unmarshal([]byte(tt.nodeYAML), &rnode); err != nil {
 				t.Fatal(err)
 			}

--- a/operator/pkg/tpath/tree.go
+++ b/operator/pkg/tpath/tree.go
@@ -44,9 +44,9 @@ type PathContext struct {
 	// Parent in the Parent of this PathContext.
 	Parent *PathContext
 	// KeyToChild is the key required to reach the child.
-	KeyToChild interface{}
+	KeyToChild any
 	// Node is the actual Node in the data tree.
-	Node interface{}
+	Node any
 }
 
 // String implements the Stringer interface.
@@ -68,12 +68,12 @@ func (nc *PathContext) String() string {
 // a malformed path.
 // It also creates a tree of PathContexts during the traversal so that Parent nodes can be updated if required. This is
 // required when (say) appending to a list, where the parent list itself must be updated.
-func GetPathContext(root interface{}, path util.Path, createMissing bool) (*PathContext, bool, error) {
+func GetPathContext(root any, path util.Path, createMissing bool) (*PathContext, bool, error) {
 	return getPathContext(&PathContext{Node: root}, path, path, createMissing)
 }
 
 // WritePathContext writes the given value to the Node in the given PathContext.
-func WritePathContext(nc *PathContext, value interface{}, merge bool) error {
+func WritePathContext(nc *PathContext, value any, merge bool) error {
 	scope.Debugf("WritePathContext PathContext=%s, value=%v", nc, value)
 
 	if !util.IsValueNil(value) {
@@ -103,7 +103,7 @@ func WritePathContext(nc *PathContext, value interface{}, merge bool) error {
 }
 
 // WriteNode writes value to the tree in root at the given path, creating any required missing internal nodes in path.
-func WriteNode(root interface{}, path util.Path, value interface{}) error {
+func WriteNode(root any, path util.Path, value any) error {
 	pc, _, err := getPathContext(&PathContext{Node: root}, path, path, true)
 	if err != nil {
 		return err
@@ -112,7 +112,7 @@ func WriteNode(root interface{}, path util.Path, value interface{}) error {
 }
 
 // MergeNode merges value to the tree in root at the given path, creating any required missing internal nodes in path.
-func MergeNode(root interface{}, path util.Path, value interface{}) error {
+func MergeNode(root any, path util.Path, value any) error {
 	pc, _, err := getPathContext(&PathContext{Node: root}, path, path, true)
 	if err != nil {
 		return err
@@ -123,7 +123,7 @@ func MergeNode(root interface{}, path util.Path, value interface{}) error {
 // Find returns the value at path from the given tree, or false if the path does not exist.
 // It behaves differently from GetPathContext in that it never creates map entries at the leaf and does not provide
 // a way to mutate the parent of the found node.
-func Find(inputTree map[string]interface{}, path util.Path) (interface{}, bool, error) {
+func Find(inputTree map[string]any, path util.Path) (any, bool, error) {
 	scope.Debugf("Find path=%s", path)
 	if len(path) == 0 {
 		return nil, false, fmt.Errorf("path is empty")
@@ -133,7 +133,7 @@ func Find(inputTree map[string]interface{}, path util.Path) (interface{}, bool, 
 }
 
 // Delete sets value at path of input untyped tree to nil
-func Delete(root map[string]interface{}, path util.Path) (bool, error) {
+func Delete(root map[string]any, path util.Path) (bool, error) {
 	pc, _, err := getPathContext(&PathContext{Node: root}, path, path, false)
 	if err != nil {
 		return false, err
@@ -155,9 +155,9 @@ func getPathContext(nc *PathContext, fullPath, remainPath util.Path, createMissi
 			return nil, false, fmt.Errorf("node %s is zero", pe)
 		}
 		if util.IsNPathElement(pe) || util.IsKVPathElement(pe) {
-			nc.Node = []interface{}{}
+			nc.Node = []any{}
 		} else {
-			nc.Node = make(map[string]interface{})
+			nc.Node = make(map[string]any)
 		}
 	}
 
@@ -169,7 +169,7 @@ func getPathContext(nc *PathContext, fullPath, remainPath util.Path, createMissi
 
 	// For list types, we need a key to identify the selected list item. This can be either a a value key of the
 	// form :matching_value in the case of a leaf list, or a matching key:value in the case of a non-leaf list.
-	if lst, ok := ncNode.([]interface{}); ok {
+	if lst, ok := ncNode.([]any); ok {
 		scope.Debug("list type")
 		// If the path element has the form [N], a list element is being selected by index. Return the element at index
 		// N if it exists.
@@ -178,13 +178,13 @@ func getPathContext(nc *PathContext, fullPath, remainPath util.Path, createMissi
 			if err != nil {
 				return nil, false, fmt.Errorf("path %s, index %s: %s", fullPath, pe, err)
 			}
-			var foundNode interface{}
+			var foundNode any
 			if idx >= len(lst) || idx < 0 {
 				if !createMissing {
 					return nil, false, fmt.Errorf("index %d exceeds list length %d at path %s", idx, len(lst), remainPath)
 				}
 				idx = len(lst)
-				foundNode = make(map[string]interface{})
+				foundNode = make(map[string]any)
 			} else {
 				foundNode = lst[idx]
 			}
@@ -200,7 +200,7 @@ func getPathContext(nc *PathContext, fullPath, remainPath util.Path, createMissi
 		// must have map type, and try to find one which has a matching key:value.
 		for idx, le := range lst {
 			// non-leaf list, expect to match item by key:value.
-			if lm, ok := le.(map[interface{}]interface{}); ok {
+			if lm, ok := le.(map[any]any); ok {
 				k, v, err := util.PathKV(pe)
 				if err != nil {
 					return nil, false, fmt.Errorf("path %s: %s", fullPath, err)
@@ -223,7 +223,7 @@ func getPathContext(nc *PathContext, fullPath, remainPath util.Path, createMissi
 			}
 			// repeat of the block above for the case where tree unmarshals to map[string]interface{}. There doesn't
 			// seem to be a way to merge this case into the above block.
-			if lm, ok := le.(map[string]interface{}); ok {
+			if lm, ok := le.(map[string]any); ok {
 				k, v, err := util.PathKV(pe)
 				if err != nil {
 					return nil, false, fmt.Errorf("path %s: %s", fullPath, err)
@@ -264,13 +264,13 @@ func getPathContext(nc *PathContext, fullPath, remainPath util.Path, createMissi
 
 	if util.IsMap(ncNode) {
 		scope.Debug("map type")
-		var nn interface{}
-		if m, ok := ncNode.(map[interface{}]interface{}); ok {
+		var nn any
+		if m, ok := ncNode.(map[any]any); ok {
 			nn, ok = m[pe]
 			if !ok {
 				// remainPath == 1 means the patch is creation of a new leaf.
 				if createMissing || len(remainPath) == 1 {
-					m[pe] = make(map[interface{}]interface{})
+					m[pe] = make(map[any]any)
 					nn = m[pe]
 				} else {
 					return nil, false, fmt.Errorf("path not found at element %s in path %s", pe, fullPath)
@@ -278,10 +278,10 @@ func getPathContext(nc *PathContext, fullPath, remainPath util.Path, createMissi
 			}
 		}
 		if reflect.ValueOf(ncNode).IsNil() {
-			ncNode = make(map[string]interface{})
+			ncNode = make(map[string]any)
 			nc.Node = ncNode
 		}
-		if m, ok := ncNode.(map[string]interface{}); ok {
+		if m, ok := ncNode.(map[string]any); ok {
 			nn, ok = m[pe]
 			if !ok {
 				// remainPath == 1 means the patch is creation of a new leaf.
@@ -289,10 +289,10 @@ func getPathContext(nc *PathContext, fullPath, remainPath util.Path, createMissi
 					nextElementNPath := len(remainPath) > 1 && util.IsNPathElement(remainPath[1])
 					if nextElementNPath {
 						scope.Debug("map type, slice child")
-						m[pe] = make([]interface{}, 0)
+						m[pe] = make([]any, 0)
 					} else {
 						scope.Debug("map type, map child")
-						m[pe] = make(map[string]interface{})
+						m[pe] = make(map[string]any)
 					}
 					nn = m[pe]
 				} else {
@@ -318,7 +318,7 @@ func getPathContext(nc *PathContext, fullPath, remainPath util.Path, createMissi
 
 // setPathContext writes the given value to the Node in the given PathContext,
 // enlarging all PathContext lists to ensure all indexes are valid.
-func setPathContext(nc *PathContext, value interface{}, merge bool) error {
+func setPathContext(nc *PathContext, value any, merge bool) error {
 	processParent, err := setValueContext(nc, value, merge)
 	if err != nil || !processParent {
 		return err
@@ -333,7 +333,7 @@ func setPathContext(nc *PathContext, value interface{}, merge bool) error {
 
 // setValueContext writes the given value to the Node in the given PathContext.
 // If setting the value requires growing the final slice, grows it.
-func setValueContext(nc *PathContext, value interface{}, merge bool) (bool, error) {
+func setValueContext(nc *PathContext, value any, merge bool) (bool, error) {
 	if nc.Parent == nil {
 		return false, nil
 	}
@@ -341,9 +341,9 @@ func setValueContext(nc *PathContext, value interface{}, merge bool) (bool, erro
 	vv, mapFromString := tryToUnmarshalStringToYAML(value)
 
 	switch parentNode := nc.Parent.Node.(type) {
-	case *interface{}:
+	case *any:
 		switch vParentNode := (*parentNode).(type) {
-		case []interface{}:
+		case []any:
 			idx := nc.Parent.KeyToChild.(int)
 			if idx == -1 {
 				// Treat -1 as insert-at-end of list
@@ -351,7 +351,7 @@ func setValueContext(nc *PathContext, value interface{}, merge bool) (bool, erro
 			}
 
 			if idx >= len(vParentNode) {
-				newElements := make([]interface{}, idx-len(vParentNode)+1)
+				newElements := make([]any, idx-len(vParentNode)+1)
 				vParentNode = append(vParentNode, newElements...)
 				*parentNode = vParentNode
 			}
@@ -366,20 +366,20 @@ func setValueContext(nc *PathContext, value interface{}, merge bool) (bool, erro
 		default:
 			return false, fmt.Errorf("don't know about vtype %T", vParentNode)
 		}
-	case map[string]interface{}:
+	case map[string]any:
 		key := nc.Parent.KeyToChild.(string)
 
 		// Update is treated differently depending on whether the value is a scalar or map type. If scalar,
 		// insert a new element into the terminal node, otherwise replace the terminal node with the new subtree.
-		if ncNode, ok := nc.Node.(*interface{}); ok && !mapFromString {
+		if ncNode, ok := nc.Node.(*any); ok && !mapFromString {
 			switch vNcNode := (*ncNode).(type) {
-			case []interface{}:
+			case []any:
 				switch vv.(type) {
-				case map[string]interface{}:
+				case map[string]any:
 					// the vv is a map, and the node is a slice
 					mergedValue := append(vNcNode, vv)
 					parentNode[key] = mergedValue
-				case *interface{}:
+				case *any:
 					merged, err := mergeConditional(vv, vNcNode, merge)
 					if err != nil {
 						return false, err
@@ -402,7 +402,7 @@ func setValueContext(nc *PathContext, value interface{}, merge bool) (bool, erro
 				if err := util.DeleteFromMap(nc.Parent.Node, nc.Parent.KeyToChild); err != nil {
 					return false, err
 				}
-				vm := vv.(map[string]interface{})
+				vm := vv.(map[string]any)
 				newKey := getTreeRoot(vm)
 				return false, util.InsertIntoMap(nc.Parent.Node, newKey, vm[newKey])
 			}
@@ -410,7 +410,7 @@ func setValueContext(nc *PathContext, value interface{}, merge bool) (bool, erro
 			nc.Node = vv
 		}
 	// TODO `map[interface{}]interface{}` is used by tests in operator/cmd/mesh, we should add our own tests
-	case map[interface{}]interface{}:
+	case map[any]any:
 		key := nc.Parent.KeyToChild.(string)
 		parentNode[key] = vv
 		nc.Node = vv
@@ -422,7 +422,7 @@ func setValueContext(nc *PathContext, value interface{}, merge bool) (bool, erro
 }
 
 // mergeConditional returns a merge of newVal and originalVal if merge is true, otherwise it returns newVal.
-func mergeConditional(newVal, originalVal interface{}, merge bool) (interface{}, error) {
+func mergeConditional(newVal, originalVal any, merge bool) (any, error) {
 	if !merge || util.IsValueNilOrDefault(originalVal) {
 		return newVal, nil
 	}
@@ -448,7 +448,7 @@ func mergeConditional(newVal, originalVal interface{}, merge bool) (interface{},
 
 	if util.IsMap(originalVal) {
 		// For JSON compatibility
-		out := make(map[string]interface{})
+		out := make(map[string]any)
 		if err := yaml.Unmarshal([]byte(mergedS), &out); err != nil {
 			return nil, err
 		}
@@ -463,12 +463,12 @@ func mergeConditional(newVal, originalVal interface{}, merge bool) (interface{},
 }
 
 // find returns the value at path from the given tree, or false if the path does not exist.
-func find(treeNode interface{}, path util.Path) (interface{}, bool) {
+func find(treeNode any, path util.Path) (any, bool) {
 	if len(path) == 0 || treeNode == nil {
 		return nil, false
 	}
 	switch nt := treeNode.(type) {
-	case map[interface{}]interface{}:
+	case map[any]any:
 		val := nt[path[0]]
 		if val == nil {
 			return nil, false
@@ -477,7 +477,7 @@ func find(treeNode interface{}, path util.Path) (interface{}, bool) {
 			return val, true
 		}
 		return find(val, path[1:])
-	case map[string]interface{}:
+	case map[string]any:
 		val := nt[path[0]]
 		if val == nil {
 			return nil, false
@@ -486,7 +486,7 @@ func find(treeNode interface{}, path util.Path) (interface{}, bool) {
 			return val, true
 		}
 		return find(val, path[1:])
-	case []interface{}:
+	case []any:
 		idx, err := strconv.Atoi(path[0])
 		if err != nil {
 			return nil, false
@@ -502,12 +502,12 @@ func find(treeNode interface{}, path util.Path) (interface{}, bool) {
 }
 
 // stringsEqual reports whether the string representations of a and b are equal. a and b may have different types.
-func stringsEqual(a, b interface{}) bool {
+func stringsEqual(a, b any) bool {
 	return fmt.Sprint(a) == fmt.Sprint(b)
 }
 
 // matchesRegex reports whether str regex matches pattern.
-func matchesRegex(pattern, str interface{}) bool {
+func matchesRegex(pattern, str any) bool {
 	match, err := regexp.MatchString(fmt.Sprint(pattern), fmt.Sprint(str))
 	if err != nil {
 		log.Errorf("bad regex expression %s", fmt.Sprint(pattern))
@@ -518,7 +518,7 @@ func matchesRegex(pattern, str interface{}) bool {
 }
 
 // isSliceOrPtrInterface reports whether v is a slice, a ptr to slice or interface to slice.
-func isSliceOrPtrInterface(v interface{}) bool {
+func isSliceOrPtrInterface(v any) bool {
 	vv := reflect.ValueOf(v)
 	if vv.Kind() == reflect.Ptr {
 		vv = vv.Elem()
@@ -530,7 +530,7 @@ func isSliceOrPtrInterface(v interface{}) bool {
 }
 
 // isMapOrInterface reports whether v is a map, or interface to a map.
-func isMapOrInterface(v interface{}) bool {
+func isMapOrInterface(v any) bool {
 	vv := reflect.ValueOf(v)
 	if vv.Kind() == reflect.Interface {
 		vv = vv.Elem()
@@ -540,7 +540,7 @@ func isMapOrInterface(v interface{}) bool {
 
 // tryToUnmarshalStringToYAML tries to unmarshal something that may be a YAML list or map into a structure. If not
 // possible, returns original scalar value.
-func tryToUnmarshalStringToYAML(s interface{}) (interface{}, bool) {
+func tryToUnmarshalStringToYAML(s any) (any, bool) {
 	// If value type is a string it could either be a literal string or a map type passed as a string. Try to unmarshal
 	// to discover it's the latter.
 	vv := s
@@ -551,7 +551,7 @@ func tryToUnmarshalStringToYAML(s interface{}) (interface{}, bool) {
 		// is different for inserts.
 		if len(sv) == 1 && strings.Contains(s.(string), ": ") ||
 			len(sv) > 1 && strings.Contains(s.(string), ":") {
-			nv := make(map[string]interface{})
+			nv := make(map[string]any)
 			if err := json.Unmarshal([]byte(vv.(string)), &nv); err == nil {
 				// treat JSON as string
 				return vv, false
@@ -566,7 +566,7 @@ func tryToUnmarshalStringToYAML(s interface{}) (interface{}, bool) {
 }
 
 // getTreeRoot returns the first key found in m. It assumes a single root tree.
-func getTreeRoot(m map[string]interface{}) string {
+func getTreeRoot(m map[string]any) string {
 	for k := range m {
 		return k
 	}

--- a/operator/pkg/tpath/tree_test.go
+++ b/operator/pkg/tpath/tree_test.go
@@ -37,7 +37,7 @@ a:
 	tests := []struct {
 		desc      string
 		path      string
-		value     interface{}
+		value     any
 		want      string
 		wantFound bool
 		wantErr   string
@@ -333,7 +333,7 @@ a: {}
 	}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			root := make(map[string]interface{})
+			root := make(map[string]any)
 			if err := yaml.Unmarshal([]byte(rootYAML), &root); err != nil {
 				t.Fatal(err)
 			}
@@ -574,7 +574,7 @@ a:
 	}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			root := make(map[string]interface{})
+			root := make(map[string]any)
 			if tt.baseYAML != "" {
 				if err := yaml.Unmarshal([]byte(tt.baseYAML), &root); err != nil {
 					t.Fatal(err)
@@ -648,14 +648,14 @@ a:
 	}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			root := make(map[string]interface{})
+			root := make(map[string]any)
 			if tt.baseYAML != "" {
 				if err := yaml.Unmarshal([]byte(tt.baseYAML), &root); err != nil {
 					t.Fatal(err)
 				}
 			}
 			p := util.PathFromString(tt.path)
-			iv := make(map[string]interface{})
+			iv := make(map[string]any)
 			err := yaml.Unmarshal([]byte(tt.value), &iv)
 			if err != nil {
 				t.Fatal(err)
@@ -689,13 +689,13 @@ values:
       istio-egressgateway:
          secretVolumes: []
 `
-	root := make(map[string]interface{})
+	root := make(map[string]any)
 	if err := yaml.Unmarshal([]byte(rootYAML), &root); err != nil {
 		t.Fatal(err)
 	}
 	overrides := []struct {
 		path  string
-		value interface{}
+		value any
 	}{
 		{
 			path:  "values.gateways.istio-egressgateway.secretVolumes[0].name",
@@ -794,7 +794,7 @@ values:
 	tests := []struct {
 		desc      string
 		path      string
-		value     interface{}
+		value     any
 		want      string
 		wantFound bool
 		wantErr   string
@@ -814,7 +814,7 @@ values:
 	}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			root := make(map[string]interface{})
+			root := make(map[string]any)
 			if err := yaml.Unmarshal([]byte(rootYAML), &root); err != nil {
 				t.Fatal(err)
 			}

--- a/operator/pkg/tpath/util.go
+++ b/operator/pkg/tpath/util.go
@@ -27,7 +27,7 @@ import (
 
 // AddSpecRoot adds a root node called "spec" to the given tree and returns the resulting tree.
 func AddSpecRoot(tree string) (string, error) {
-	t, nt := make(map[string]interface{}), make(map[string]interface{})
+	t, nt := make(map[string]any), make(map[string]any)
 	if err := yaml.Unmarshal([]byte(tree), &t); err != nil {
 		return "", err
 	}
@@ -46,7 +46,7 @@ func GetSpecSubtree(yml string) (string, error) {
 
 // GetConfigSubtree returns the subtree at the given path.
 func GetConfigSubtree(manifest, path string) (string, error) {
-	root := make(map[string]interface{})
+	root := make(map[string]any)
 	if err := yaml2.Unmarshal([]byte(manifest), &root); err != nil {
 		return "", err
 	}

--- a/operator/pkg/translate/translate.go
+++ b/operator/pkg/translate/translate.go
@@ -95,7 +95,7 @@ type ComponentMaps struct {
 }
 
 // TranslationFunc maps a yamlStr API path into a YAML values tree.
-type TranslationFunc func(t *Translation, root map[string]interface{}, valuesPath string, value interface{}) error
+type TranslationFunc func(t *Translation, root map[string]any, valuesPath string, value any) error
 
 // Translation is a mapping to an output path using a translation function.
 type Translation struct {
@@ -351,7 +351,7 @@ func checkDeprecatedHPAFields(iop *v1alpha1.IstioOperatorSpec) bool {
 // translateDeprecatedAutoscalingFields checks for existence of deprecated HPA fields, if found, set values.global.autoscalingv2API to false
 // It only needs to run the logic for the first component because we are setting the values.global field instead of per component ones.
 // we do not set per component values because we may want to avoid mixture of v2 and v2beta1 autoscaling templates usage
-func (t *Translator) translateDeprecatedAutoscalingFields(values map[string]interface{}, iop *v1alpha1.IstioOperatorSpec) error {
+func (t *Translator) translateDeprecatedAutoscalingFields(values map[string]any, iop *v1alpha1.IstioOperatorSpec) error {
 	if t.checkedDeprecatedAutoscalingFields || checkDeprecatedHPAFields(iop) {
 		path := util.PathFromString("global.autoscalingv2API")
 		if err := tpath.WriteNode(values, path, false); err != nil {
@@ -418,7 +418,7 @@ func (t *Translator) fixMergedObjectWithCustomServicePortOverlay(oo *object.K8sO
 	if err != nil {
 		return nil, err
 	}
-	var mergedPortSlice []interface{}
+	var mergedPortSlice []any
 	if err = json.Unmarshal(mpby, &mergedPortSlice); err != nil {
 		return nil, err
 	}
@@ -545,8 +545,8 @@ func (t *Translator) ProtoToValues(ii *v1alpha1.IstioOperatorSpec) (string, erro
 }
 
 // TranslateHelmValues creates a Helm values.yaml config data tree from iop using the given translator.
-func (t *Translator) TranslateHelmValues(iop *v1alpha1.IstioOperatorSpec, componentsSpec interface{}, componentName name.ComponentName) (string, error) {
-	apiVals := make(map[string]interface{})
+func (t *Translator) TranslateHelmValues(iop *v1alpha1.IstioOperatorSpec, componentsSpec any, componentName name.ComponentName) (string, error) {
+	apiVals := make(map[string]any)
 
 	// First, translate the IstioOperator API to helm Values.
 	apiValsStr, err := t.ProtoToValues(iop)
@@ -593,11 +593,11 @@ func (t *Translator) TranslateHelmValues(iop *v1alpha1.IstioOperatorSpec, compon
 
 // applyGatewayTranslations writes gateway name gwName at the appropriate values path in iop and maps k8s.service.ports
 // to values. It returns the resulting YAML tree.
-func applyGatewayTranslations(iop []byte, componentName name.ComponentName, componentSpec interface{}) ([]byte, error) {
+func applyGatewayTranslations(iop []byte, componentName name.ComponentName, componentSpec any) ([]byte, error) {
 	if !componentName.IsGateway() {
 		return iop, nil
 	}
-	iopt := make(map[string]interface{})
+	iopt := make(map[string]any)
 	if err := yaml.Unmarshal(iop, &iopt); err != nil {
 		return nil, err
 	}
@@ -626,13 +626,13 @@ func applyGatewayTranslations(iop []byte, componentName name.ComponentName, comp
 
 // setYAMLNodeByMapPath sets the value at the given path to val in treeNode. The path cannot traverse lists and
 // treeNode must be a YAML tree unmarshaled into a plain map data structure.
-func setYAMLNodeByMapPath(treeNode interface{}, path util.Path, val interface{}) {
+func setYAMLNodeByMapPath(treeNode any, path util.Path, val any) {
 	if len(path) == 0 || treeNode == nil {
 		return
 	}
 	pe := path[0]
 	switch nt := treeNode.(type) {
-	case map[interface{}]interface{}:
+	case map[any]any:
 		if len(path) == 1 {
 			nt[pe] = val
 			return
@@ -641,7 +641,7 @@ func setYAMLNodeByMapPath(treeNode interface{}, path util.Path, val interface{})
 			return
 		}
 		setYAMLNodeByMapPath(nt[pe], path[1:], val)
-	case map[string]interface{}:
+	case map[string]any:
 		if len(path) == 1 {
 			nt[pe] = val
 			return
@@ -661,17 +661,17 @@ func (t *Translator) ComponentMap(cns string) *ComponentMaps {
 	return t.ComponentMaps[cn]
 }
 
-func (t *Translator) ProtoToHelmValues2(ii *v1alpha1.IstioOperatorSpec) (map[string]interface{}, error) {
+func (t *Translator) ProtoToHelmValues2(ii *v1alpha1.IstioOperatorSpec) (map[string]any, error) {
 	by, err := json.Marshal(ii)
 	if err != nil {
 		return nil, err
 	}
-	res := map[string]interface{}{}
+	res := map[string]any{}
 	err = json.Unmarshal(by, &res)
 	if err != nil {
 		return nil, err
 	}
-	r2 := map[string]interface{}{}
+	r2 := map[string]any{}
 	errs := t.ProtoToHelmValues(res, r2, nil)
 	return r2, errs.ToError()
 }
@@ -682,7 +682,7 @@ func (t *Translator) ProtoToHelmValues2(ii *v1alpha1.IstioOperatorSpec) (map[str
 // For each leaf, if looks for a mapping from the struct data path to the corresponding YAML path and if one is
 // found, it calls the associated mapping function if one is defined to populate the values YAML path.
 // If no mapping function is defined, it uses the default mapping function.
-func (t *Translator) ProtoToHelmValues(node interface{}, root map[string]interface{}, path util.Path) (errs util.Errors) {
+func (t *Translator) ProtoToHelmValues(node any, root map[string]any, path util.Path) (errs util.Errors) {
 	scope.Debugf("ProtoToHelmValues with path %s, %v (%T)", path, node, node)
 	if util.IsValueNil(node) {
 		return nil
@@ -733,7 +733,7 @@ func (t *Translator) ProtoToHelmValues(node interface{}, root map[string]interfa
 
 // setComponentProperties translates properties (e.g., enablement and namespace) of each component
 // in the baseYAML values tree, based on feature/component inheritance relationship.
-func (t *Translator) setComponentProperties(root map[string]interface{}, iop *v1alpha1.IstioOperatorSpec) error {
+func (t *Translator) setComponentProperties(root map[string]any, iop *v1alpha1.IstioOperatorSpec) error {
 	var keys []string
 	for k := range t.ComponentMaps {
 		if k != name.IngressComponentName && k != name.EgressComponentName {
@@ -809,10 +809,10 @@ func (t *Translator) IsComponentEnabled(cn name.ComponentName, iop *v1alpha1.Ist
 }
 
 // insertLeaf inserts a leaf with value into root at path, which is first mapped using t.APIMapping.
-func (t *Translator) insertLeaf(root map[string]interface{}, path util.Path, value reflect.Value) (errs util.Errors) {
+func (t *Translator) insertLeaf(root map[string]any, path util.Path, value reflect.Value) (errs util.Errors) {
 	// Must be a scalar leaf. See if we have a mapping.
 	valuesPath, m := getValuesPathMapping(t.APIMapping, path)
-	var v interface{}
+	var v any
 	if value.Kind() == reflect.Ptr {
 		v = value.Elem().Interface()
 	} else {
@@ -898,7 +898,7 @@ func (t *Translator) renderResourceComponentPathTemplate(tmpl string, componentN
 }
 
 // defaultTranslationFunc is the default translation to values. It maps a Go data path into a YAML path.
-func defaultTranslationFunc(m *Translation, root map[string]interface{}, valuesPath string, value interface{}) error {
+func defaultTranslationFunc(m *Translation, root map[string]any, valuesPath string, value any) error {
 	var path []string
 
 	if util.IsEmptyString(value) {
@@ -924,7 +924,7 @@ func firstCharToLower(s string) string {
 // MergeK8sObject function below is used by third party for integrations and has to be public
 
 // MergeK8sObject does strategic merge for overlayNode on the base object.
-func MergeK8sObject(base *object.K8sObject, overlayNode interface{}, path util.Path) (*object.K8sObject, error) {
+func MergeK8sObject(base *object.K8sObject, overlayNode any, path util.Path) (*object.K8sObject, error) {
 	overlay, err := createPatchObjectFromPath(overlayNode, path)
 	if err != nil {
 		return nil, err
@@ -979,7 +979,7 @@ func MergeK8sObject(base *object.K8sObject, overlayNode interface{}, path util.P
 //	          env:
 //	          - name: NEW_VAR
 //	            value: new_value
-func createPatchObjectFromPath(node interface{}, path util.Path) (map[string]interface{}, error) {
+func createPatchObjectFromPath(node any, path util.Path) (map[string]any, error) {
 	if len(path) == 0 {
 		return nil, fmt.Errorf("empty path %s", path)
 	}
@@ -991,14 +991,14 @@ func createPatchObjectFromPath(node interface{}, path util.Path) (map[string]int
 		return nil, fmt.Errorf("path %s has an unexpected last element %s", path, path[length-1])
 	}
 
-	patchObj := make(map[string]interface{})
-	var currentNode, nextNode interface{}
+	patchObj := make(map[string]any)
+	var currentNode, nextNode any
 	nextNode = patchObj
 	for i, pe := range path {
 		currentNode = nextNode
 		// last path element
 		if i == length-1 {
-			currentNode, ok := currentNode.(map[string]interface{})
+			currentNode, ok := currentNode.(map[string]any)
 			if !ok {
 				return nil, fmt.Errorf("path %s has an unexpected non KV element %s", path, pe)
 			}
@@ -1007,7 +1007,7 @@ func createPatchObjectFromPath(node interface{}, path util.Path) (map[string]int
 		}
 
 		if util.IsKVPathElement(pe) {
-			currentNode, ok := currentNode.([]interface{})
+			currentNode, ok := currentNode.([]any)
 			if !ok {
 				return nil, fmt.Errorf("path %s has an unexpected KV element %s", path, pe)
 			}
@@ -1018,20 +1018,20 @@ func createPatchObjectFromPath(node interface{}, path util.Path) (map[string]int
 			if k == "" || v == "" {
 				return nil, fmt.Errorf("path %s has an invalid KV element %s", path, pe)
 			}
-			currentNode[0] = map[string]interface{}{k: v}
+			currentNode[0] = map[string]any{k: v}
 			nextNode = currentNode[0]
 			continue
 		}
 
-		currentNode, ok := currentNode.(map[string]interface{})
+		currentNode, ok := currentNode.(map[string]any)
 		if !ok {
 			return nil, fmt.Errorf("path %s has an unexpected non KV element %s", path, pe)
 		}
 		// next path element determines the next node type
 		if util.IsKVPathElement(path[i+1]) {
-			currentNode[pe] = make([]interface{}, 1)
+			currentNode[pe] = make([]any, 1)
 		} else {
-			currentNode[pe] = make(map[string]interface{})
+			currentNode[pe] = make(map[string]any)
 		}
 		nextNode = currentNode[pe]
 	}

--- a/operator/pkg/translate/translate_common.go
+++ b/operator/pkg/translate/translate_common.go
@@ -49,7 +49,7 @@ func IsComponentEnabledInSpec(componentName name.ComponentName, controlPlaneSpec
 
 // IsComponentEnabledFromValue get whether component is enabled in helm value.yaml tree.
 // valuePath points to component path in the values tree.
-func IsComponentEnabledFromValue(cn name.ComponentName, valueSpec map[string]interface{}) (enabled bool, pathExist bool, err error) {
+func IsComponentEnabledFromValue(cn name.ComponentName, valueSpec map[string]any) (enabled bool, pathExist bool, err error) {
 	t := NewTranslator()
 	cnMap, ok := t.ComponentMaps[cn]
 	if !ok {

--- a/operator/pkg/translate/translate_test.go
+++ b/operator/pkg/translate/translate_test.go
@@ -198,7 +198,7 @@ components:
 				}
 			}
 			translator := NewTranslator()
-			values := make(map[string]interface{})
+			values := make(map[string]any)
 			_ = translator.translateDeprecatedAutoscalingFields(values, iop)
 			val, found, _ := tpath.GetFromStructPath(values, "global.autoscalingv2API")
 			if tt.expectFound {

--- a/operator/pkg/translate/translate_value.go
+++ b/operator/pkg/translate/translate_value.go
@@ -158,13 +158,13 @@ func NewReverseTranslator() *ReverseTranslator {
 
 // TranslateFromValueToSpec translates from values.yaml value to IstioOperatorSpec.
 func (t *ReverseTranslator) TranslateFromValueToSpec(values []byte, force bool) (controlPlaneSpec *v1alpha1.IstioOperatorSpec, err error) {
-	yamlTree := make(map[string]interface{})
+	yamlTree := make(map[string]any)
 	err = yaml.Unmarshal(values, &yamlTree)
 	if err != nil {
 		return nil, fmt.Errorf("error when unmarshalling into untype tree %v", err)
 	}
 
-	outputTree := make(map[string]interface{})
+	outputTree := make(map[string]any)
 	err = t.TranslateTree(yamlTree, outputTree, nil)
 	if err != nil {
 		return nil, err
@@ -185,7 +185,7 @@ func (t *ReverseTranslator) TranslateFromValueToSpec(values []byte, force bool) 
 }
 
 // TranslateTree translates input value.yaml Tree to ControlPlaneSpec Tree.
-func (t *ReverseTranslator) TranslateTree(valueTree map[string]interface{}, cpSpecTree map[string]interface{}, path util.Path) error {
+func (t *ReverseTranslator) TranslateTree(valueTree map[string]any, cpSpecTree map[string]any, path util.Path) error {
 	// translate enablement and namespace
 	err := t.setEnablementFromValue(valueTree, cpSpecTree)
 	if err != nil {
@@ -214,7 +214,7 @@ func (t *ReverseTranslator) TranslateTree(valueTree map[string]interface{}, cpSp
 }
 
 // TranslateK8S is a helper function to translate k8s settings from values.yaml to IstioOperator, except for gateways.
-func (t *ReverseTranslator) TranslateK8S(valueTree map[string]interface{}, cpSpecTree map[string]interface{}) error {
+func (t *ReverseTranslator) TranslateK8S(valueTree map[string]any, cpSpecTree map[string]any) error {
 	// translate with k8s mapping
 	if err := t.initK8SMapping(); err != nil {
 		return fmt.Errorf("error when initiating k8s mapping: %v", err)
@@ -227,7 +227,7 @@ func (t *ReverseTranslator) TranslateK8S(valueTree map[string]interface{}, cpSpe
 
 // setEnablementFromValue translates the enablement value of components in the values.yaml
 // tree, based on feature/component inheritance relationship.
-func (t *ReverseTranslator) setEnablementFromValue(valueSpec map[string]interface{}, root map[string]interface{}) error {
+func (t *ReverseTranslator) setEnablementFromValue(valueSpec map[string]any, root map[string]any) error {
 	for _, cni := range t.ValuesToComponentName {
 		enabled, pathExist, err := IsComponentEnabledFromValue(cni, valueSpec)
 		if err != nil {
@@ -291,7 +291,7 @@ func (t *ReverseTranslator) WarningForGatewayK8SSettings(valuesOverlay string) (
 }
 
 // translateGateway handles translation for gateways specific configuration
-func (t *ReverseTranslator) translateGateway(valueSpec map[string]interface{}, root map[string]interface{}) error {
+func (t *ReverseTranslator) translateGateway(valueSpec map[string]any, root map[string]any) error {
 	for inPath, outPath := range gatewayPathMapping {
 		enabled, pathExist, err := IsComponentEnabledFromValue(outPath, valueSpec)
 		if err != nil {
@@ -300,8 +300,8 @@ func (t *ReverseTranslator) translateGateway(valueSpec map[string]interface{}, r
 		if !pathExist && !enabled {
 			continue
 		}
-		gwSpecs := make([]map[string]interface{}, 1)
-		gwSpec := make(map[string]interface{})
+		gwSpecs := make([]map[string]any, 1)
+		gwSpec := make(map[string]any)
 		gwSpecs[0] = gwSpec
 		gwSpec["enabled"] = enabled
 		gwSpec["name"] = util.ToYAMLPath(inPath)[1]
@@ -334,12 +334,12 @@ func (t *ReverseTranslator) TranslateK8SfromValueToIOP(userOverlayYaml string) (
 		scope.Debugf("no spec.values section from userOverlayYaml %v", err)
 		return "", nil
 	}
-	valuesOverlayTree := make(map[string]interface{})
+	valuesOverlayTree := make(map[string]any)
 	err = yaml.Unmarshal([]byte(valuesOverlay), &valuesOverlayTree)
 	if err != nil {
 		return "", fmt.Errorf("error unmarshalling values overlay yaml into untype tree %v", err)
 	}
-	iopSpecTree := make(map[string]interface{})
+	iopSpecTree := make(map[string]any)
 	iopSpecOverlay, err := tpath.GetConfigSubtree(userOverlayYaml, "spec")
 	if err != nil {
 		return "", fmt.Errorf("error getting iop spec subtree from overlay yaml %v", err)
@@ -375,7 +375,7 @@ func (t *ReverseTranslator) TranslateK8SfromValueToIOP(userOverlayYaml string) (
 }
 
 // translateStrategy translates Deployment Strategy related configurations from helm values.yaml tree.
-func translateStrategy(fieldName string, outPath string, value interface{}, cpSpecTree map[string]interface{}) error {
+func translateStrategy(fieldName string, outPath string, value any, cpSpecTree map[string]any) error {
 	fieldMap := map[string]string{
 		"rollingMaxSurge":       "maxSurge",
 		"rollingMaxUnavailable": "maxUnavailable",
@@ -395,7 +395,7 @@ func translateStrategy(fieldName string, outPath string, value interface{}, cpSp
 
 // translateHPASpec translates HPA related configurations from helm values.yaml tree.
 // do not translate if autoscaleEnabled is explicitly set to false
-func translateHPASpec(inPath string, outPath string, valueTree map[string]interface{}, cpSpecTree map[string]interface{}) error {
+func translateHPASpec(inPath string, outPath string, valueTree map[string]any, cpSpecTree map[string]any) error {
 	m, found, err := tpath.Find(valueTree, util.ToYAMLPath(inPath))
 	if err != nil {
 		return err
@@ -429,7 +429,7 @@ func translateHPASpec(inPath string, outPath string, valueTree map[string]interf
 	valPath := newPS + ".cpu.targetAverageUtilization"
 	asVal, found, err := tpath.Find(valueTree, util.ToYAMLPath(valPath))
 	if found && err == nil {
-		rs := make([]interface{}, 1)
+		rs := make([]any, 1)
 		rsVal := `
 - type: Resource
   resource:
@@ -454,7 +454,7 @@ func translateHPASpec(inPath string, outPath string, valueTree map[string]interf
 		if ok {
 			revision = rev.(string)
 		}
-		st := make(map[string]interface{})
+		st := make(map[string]any)
 		stVal := `
 apiVersion: apps/v1
 kind: Deployment
@@ -483,7 +483,7 @@ name: %s`
 }
 
 // setOutputAndClean is helper function to set value of iscp tree and clean the original value from value.yaml tree.
-func setOutputAndClean(valPath, outPath string, outVal interface{}, valueTree, cpSpecTree map[string]interface{}, clean bool) error {
+func setOutputAndClean(valPath, outPath string, outVal any, valueTree, cpSpecTree map[string]any, clean bool) error {
 	scope.Debugf("path has value in helm Value.yaml tree, mapping to output path %s", outPath)
 
 	if err := tpath.WriteNode(cpSpecTree, util.ToYAMLPath(outPath), outVal); err != nil {
@@ -499,8 +499,8 @@ func setOutputAndClean(valPath, outPath string, outVal interface{}, valueTree, c
 }
 
 // translateEnv translates env value from helm values.yaml tree.
-func translateEnv(outPath string, value interface{}, cpSpecTree map[string]interface{}) error {
-	envMap, ok := value.(map[string]interface{})
+func translateEnv(outPath string, value any, cpSpecTree map[string]any) error {
+	envMap, ok := value.(map[string]any)
 	if !ok {
 		return fmt.Errorf("expect env node type to be map[string]interface{} but got: %T", value)
 	}
@@ -515,14 +515,14 @@ func translateEnv(outPath string, value interface{}, cpSpecTree map[string]inter
 	}
 	if !found || strings.TrimSpace(string(envValStr)) == "{}" {
 		scope.Debugf("path doesn't have value in k8s setting with output path %s, override with helm Value.yaml tree", outPath)
-		outEnv := make([]map[string]interface{}, len(envMap))
+		outEnv := make([]map[string]any, len(envMap))
 		keys := make([]string, 0, len(envMap))
 		for k := range envMap {
 			keys = append(keys, k)
 		}
 		sort.Strings(keys)
 		for i, k := range keys {
-			outEnv[i] = make(map[string]interface{})
+			outEnv[i] = make(map[string]any)
 			outEnv[i]["name"] = k
 			outEnv[i]["value"] = fmt.Sprintf("%v", envMap[k])
 		}
@@ -537,7 +537,7 @@ func translateEnv(outPath string, value interface{}, cpSpecTree map[string]inter
 		}
 		sort.Strings(keys)
 		for _, k := range keys {
-			outEnv := make(map[string]interface{})
+			outEnv := make(map[string]any)
 			outEnv["name"] = k
 			outEnv["value"] = fmt.Sprintf("%v", envMap[k])
 			if err := tpath.MergeNode(cpSpecTree, util.ToYAMLPath(outPath), outEnv); err != nil {
@@ -549,8 +549,8 @@ func translateEnv(outPath string, value interface{}, cpSpecTree map[string]inter
 }
 
 // translateK8sTree is internal method for translating K8s configurations from value.yaml tree.
-func (t *ReverseTranslator) translateK8sTree(valueTree map[string]interface{},
-	cpSpecTree map[string]interface{}, mapping map[string]*Translation,
+func (t *ReverseTranslator) translateK8sTree(valueTree map[string]any,
+	cpSpecTree map[string]any, mapping map[string]*Translation,
 ) error {
 	for inPath, v := range mapping {
 		scope.Debugf("Checking for k8s path %s in helm Value.yaml tree", inPath)
@@ -620,8 +620,8 @@ func (t *ReverseTranslator) translateK8sTree(valueTree map[string]interface{},
 }
 
 // translateRemainingPaths translates remaining paths that are not available in existing mappings.
-func (t *ReverseTranslator) translateRemainingPaths(valueTree map[string]interface{},
-	cpSpecTree map[string]interface{}, path util.Path,
+func (t *ReverseTranslator) translateRemainingPaths(valueTree map[string]any,
+	cpSpecTree map[string]any, path util.Path,
 ) error {
 	for key, val := range valueTree {
 		newPath := append(path, key)
@@ -630,12 +630,12 @@ func (t *ReverseTranslator) translateRemainingPaths(valueTree map[string]interfa
 			continue
 		}
 		switch node := val.(type) {
-		case map[string]interface{}:
+		case map[string]any:
 			err := t.translateRemainingPaths(node, cpSpecTree, newPath)
 			if err != nil {
 				return err
 			}
-		case []interface{}:
+		case []any:
 			if err := tpath.WriteNode(cpSpecTree, util.ToYAMLPath("Values."+newPath.String()), node); err != nil {
 				return err
 			}
@@ -653,8 +653,8 @@ func (t *ReverseTranslator) translateRemainingPaths(valueTree map[string]interfa
 }
 
 // translateAPI is internal method for translating value.yaml tree based on API mapping.
-func (t *ReverseTranslator) translateAPI(valueTree map[string]interface{},
-	cpSpecTree map[string]interface{},
+func (t *ReverseTranslator) translateAPI(valueTree map[string]any,
+	cpSpecTree map[string]any,
 ) error {
 	for inPath, v := range t.APIMapping {
 		scope.Debugf("Checking for path %s in helm Value.yaml tree", inPath)

--- a/operator/pkg/translate/yaml_tree.go
+++ b/operator/pkg/translate/yaml_tree.go
@@ -25,11 +25,11 @@ import (
 // translations of source-path:dest-path in pkg/tpath format. It returns an output tree with paths from the input
 // tree, translated and overlaid on the output tree.
 func YAMLTree(inTreeStr, outTreeStr string, translations map[string]string) (string, error) {
-	inTree := make(map[string]interface{})
+	inTree := make(map[string]any)
 	if err := yaml.Unmarshal([]byte(inTreeStr), &inTree); err != nil {
 		return "", err
 	}
-	outTree := make(map[string]interface{})
+	outTree := make(map[string]any)
 	if err := yaml.Unmarshal([]byte(outTreeStr), &outTree); err != nil {
 		return "", err
 	}

--- a/operator/pkg/util/clog/clog.go
+++ b/operator/pkg/util/clog/clog.go
@@ -24,12 +24,12 @@ import (
 
 // Logger provides optional log taps for console and test buffer outputs.
 type Logger interface {
-	LogAndPrint(v ...interface{})
-	LogAndError(v ...interface{})
-	LogAndFatal(a ...interface{})
-	LogAndPrintf(format string, a ...interface{})
-	LogAndErrorf(format string, a ...interface{})
-	LogAndFatalf(format string, a ...interface{})
+	LogAndPrint(v ...any)
+	LogAndError(v ...any)
+	LogAndFatal(a ...any)
+	LogAndPrintf(format string, a ...any)
+	LogAndErrorf(format string, a ...any)
+	LogAndFatalf(format string, a ...any)
 	Print(s string)
 	PrintErr(s string)
 }
@@ -60,7 +60,7 @@ func NewDefaultLogger() *ConsoleLogger {
 	return NewConsoleLogger(os.Stdout, os.Stderr, nil)
 }
 
-func (l *ConsoleLogger) LogAndPrint(v ...interface{}) {
+func (l *ConsoleLogger) LogAndPrint(v ...any) {
 	if len(v) == 0 {
 		return
 	}
@@ -69,7 +69,7 @@ func (l *ConsoleLogger) LogAndPrint(v ...interface{}) {
 	l.scope.Infof(s)
 }
 
-func (l *ConsoleLogger) LogAndError(v ...interface{}) {
+func (l *ConsoleLogger) LogAndError(v ...any) {
 	if len(v) == 0 {
 		return
 	}
@@ -78,24 +78,24 @@ func (l *ConsoleLogger) LogAndError(v ...interface{}) {
 	l.scope.Infof(s)
 }
 
-func (l *ConsoleLogger) LogAndFatal(a ...interface{}) {
+func (l *ConsoleLogger) LogAndFatal(a ...any) {
 	l.LogAndError(a...)
 	os.Exit(-1)
 }
 
-func (l *ConsoleLogger) LogAndPrintf(format string, a ...interface{}) {
+func (l *ConsoleLogger) LogAndPrintf(format string, a ...any) {
 	s := fmt.Sprintf(format, a...)
 	l.Print(s + "\n")
 	l.scope.Infof(s)
 }
 
-func (l *ConsoleLogger) LogAndErrorf(format string, a ...interface{}) {
+func (l *ConsoleLogger) LogAndErrorf(format string, a ...any) {
 	s := fmt.Sprintf(format, a...)
 	l.PrintErr(s + "\n")
 	l.scope.Infof(s)
 }
 
-func (l *ConsoleLogger) LogAndFatalf(format string, a ...interface{}) {
+func (l *ConsoleLogger) LogAndFatalf(format string, a ...any) {
 	l.LogAndErrorf(format, a...)
 	os.Exit(-1)
 }

--- a/operator/pkg/util/k8s.go
+++ b/operator/pkg/util/k8s.go
@@ -65,7 +65,7 @@ func GKString(gvk schema.GroupKind) string {
 // ValidateIOPCAConfig validates if the IstioOperator CA configs are applicable to the K8s cluster
 func ValidateIOPCAConfig(client kube.Client, iop *iopv1alpha1.IstioOperator) error {
 	globalI := iop.Spec.Values.AsMap()["global"]
-	global, ok := globalI.(map[string]interface{})
+	global, ok := globalI.(map[string]any)
 	if !ok {
 		// This means no explicit global configuration. Still okay
 		return nil

--- a/operator/pkg/util/label_test.go
+++ b/operator/pkg/util/label_test.go
@@ -37,7 +37,7 @@ func TestSetLabel(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			resource := &unstructured.Unstructured{Object: make(map[string]interface{})}
+			resource := &unstructured.Unstructured{Object: make(map[string]any)}
 			gotErr := SetLabel(resource, tt.wantLabel, tt.wantValue)
 			resourceAccessor, _ := meta.Accessor(resource)
 			labels := resourceAccessor.GetLabels()

--- a/operator/pkg/util/merge_iop.go
+++ b/operator/pkg/util/merge_iop.go
@@ -89,23 +89,23 @@ type gatewaysConfig struct {
 
 // Configuration for an ingress gateway.
 type ingressGatewayConfig struct {
-	Env                              map[string]interface{}                `json:"env" patchStrategy:"merge"`
+	Env                              map[string]any                        `json:"env" patchStrategy:"merge"`
 	Labels                           map[string]string                     `json:"labels" patchStrategy:"merge"`
 	CPU                              *v1alpha12.CPUTargetUtilizationConfig `json:"cpu" patchStrategy:"replace"`
 	LoadBalancerSourceRanges         []string                              `json:"loadBalancerSourceRanges" patchStrategy:"replace"`
-	NodeSelector                     map[string]interface{}                `json:"nodeSelector" patchStrategy:"merge"`
-	PodAntiAffinityLabelSelector     []map[string]interface{}              `json:"podAntiAffinityLabelSelector" patchStrategy:"replace"`
-	PodAntiAffinityTermLabelSelector []map[string]interface{}              `json:"podAntiAffinityTermLabelSelector" patchStrategy:"replace"`
-	PodAnnotations                   map[string]interface{}                `json:"podAnnotations" patchStrategy:"merge"`
+	NodeSelector                     map[string]any                        `json:"nodeSelector" patchStrategy:"merge"`
+	PodAntiAffinityLabelSelector     []map[string]any                      `json:"podAntiAffinityLabelSelector" patchStrategy:"replace"`
+	PodAntiAffinityTermLabelSelector []map[string]any                      `json:"podAntiAffinityTermLabelSelector" patchStrategy:"replace"`
+	PodAnnotations                   map[string]any                        `json:"podAnnotations" patchStrategy:"merge"`
 	MeshExpansionPorts               []*v1alpha12.PortsConfig              `json:"meshExpansionPorts" patchStrategy:"merge" patchMergeKey:"name"`
 	Ports                            []*v1alpha12.PortsConfig              `json:"ports" patchStrategy:"merge" patchMergeKey:"name"`
 	Resources                        *resources                            `json:"resources" patchStrategy:"merge"`
 	SecretVolumes                    []*v1alpha12.SecretVolume             `json:"secretVolumes" patchStrategy:"merge" patchMergeKey:"name"`
-	ServiceAnnotations               map[string]interface{}                `json:"serviceAnnotations" patchStrategy:"merge"`
-	Tolerations                      []map[string]interface{}              `json:"tolerations" patchStrategy:"replace"`
-	IngressPorts                     []map[string]interface{}              `json:"ingressPorts" patchStrategy:"replace"`
-	AdditionalContainers             []map[string]interface{}              `json:"additionalContainers" patchStrategy:"replace"`
-	ConfigVolumes                    []map[string]interface{}              `json:"configVolumes" patchStrategy:"replace"`
+	ServiceAnnotations               map[string]any                        `json:"serviceAnnotations" patchStrategy:"merge"`
+	Tolerations                      []map[string]any                      `json:"tolerations" patchStrategy:"replace"`
+	IngressPorts                     []map[string]any                      `json:"ingressPorts" patchStrategy:"replace"`
+	AdditionalContainers             []map[string]any                      `json:"additionalContainers" patchStrategy:"replace"`
+	ConfigVolumes                    []map[string]any                      `json:"configVolumes" patchStrategy:"replace"`
 	Zvpn                             *v1alpha12.IngressGatewayZvpnConfig   `json:"zvpn" patchStrategy:"merge"`
 }
 
@@ -115,18 +115,18 @@ type resources struct {
 }
 
 type egressGatewayConfig struct {
-	Env                              map[string]interface{}    `json:"env" patchStrategy:"merge"`
+	Env                              map[string]any            `json:"env" patchStrategy:"merge"`
 	Labels                           map[string]string         `json:"labels" patchStrategy:"merge"`
-	NodeSelector                     map[string]interface{}    `json:"nodeSelector" patchStrategy:"merge"`
-	PodAntiAffinityLabelSelector     []map[string]interface{}  `json:"podAntiAffinityLabelSelector" patchStrategy:"replace"`
-	PodAntiAffinityTermLabelSelector []map[string]interface{}  `json:"podAntiAffinityTermLabelSelector" patchStrategy:"replace"`
-	PodAnnotations                   map[string]interface{}    `json:"podAnnotations" patchStrategy:"merge"`
+	NodeSelector                     map[string]any            `json:"nodeSelector" patchStrategy:"merge"`
+	PodAntiAffinityLabelSelector     []map[string]any          `json:"podAntiAffinityLabelSelector" patchStrategy:"replace"`
+	PodAntiAffinityTermLabelSelector []map[string]any          `json:"podAntiAffinityTermLabelSelector" patchStrategy:"replace"`
+	PodAnnotations                   map[string]any            `json:"podAnnotations" patchStrategy:"merge"`
 	Ports                            []*v1alpha12.PortsConfig  `json:"ports" patchStrategy:"merge" patchMergeKey:"name"`
 	Resources                        *resources                `json:"resources" patchStrategy:"merge"`
 	SecretVolumes                    []*v1alpha12.SecretVolume `json:"secretVolumes" patchStrategy:"merge" patchMergeKey:"name"`
-	Tolerations                      []map[string]interface{}  `json:"tolerations" patchStrategy:"replace"`
-	ConfigVolumes                    []map[string]interface{}  `json:"configVolumes" patchStrategy:"replace"`
-	AdditionalContainers             []map[string]interface{}  `json:"additionalContainers" patchStrategy:"replace"`
+	Tolerations                      []map[string]any          `json:"tolerations" patchStrategy:"replace"`
+	ConfigVolumes                    []map[string]any          `json:"configVolumes" patchStrategy:"replace"`
+	AdditionalContainers             []map[string]any          `json:"additionalContainers" patchStrategy:"replace"`
 	Zvpn                             *v1alpha12.ZeroVPNConfig  `json:"zvpn" patchStrategy:"replace"`
 }
 

--- a/operator/pkg/util/reflect.go
+++ b/operator/pkg/util/reflect.go
@@ -21,7 +21,7 @@ import (
 
 // kindOf returns the reflection Kind that represents the dynamic type of value.
 // If value is a nil interface value, kindOf returns reflect.Invalid.
-func kindOf(value interface{}) reflect.Kind {
+func kindOf(value any) reflect.Kind {
 	if value == nil {
 		return reflect.Invalid
 	}
@@ -29,43 +29,43 @@ func kindOf(value interface{}) reflect.Kind {
 }
 
 // IsString reports whether value is a string type.
-func IsString(value interface{}) bool {
+func IsString(value any) bool {
 	return kindOf(value) == reflect.String
 }
 
 // IsPtr reports whether value is a ptr type.
-func IsPtr(value interface{}) bool {
+func IsPtr(value any) bool {
 	return kindOf(value) == reflect.Ptr
 }
 
 // IsMap reports whether value is a map type.
-func IsMap(value interface{}) bool {
+func IsMap(value any) bool {
 	return kindOf(value) == reflect.Map
 }
 
 // IsMapPtr reports whether v is a map ptr type.
-func IsMapPtr(v interface{}) bool {
+func IsMapPtr(v any) bool {
 	t := reflect.TypeOf(v)
 	return t.Kind() == reflect.Ptr && t.Elem().Kind() == reflect.Map
 }
 
 // IsSlice reports whether value is a slice type.
-func IsSlice(value interface{}) bool {
+func IsSlice(value any) bool {
 	return kindOf(value) == reflect.Slice
 }
 
 // IsStruct reports whether value is a struct type
-func IsStruct(value interface{}) bool {
+func IsStruct(value any) bool {
 	return kindOf(value) == reflect.Struct
 }
 
 // IsSlicePtr reports whether v is a slice ptr type.
-func IsSlicePtr(v interface{}) bool {
+func IsSlicePtr(v any) bool {
 	return kindOf(v) == reflect.Ptr && reflect.TypeOf(v).Elem().Kind() == reflect.Slice
 }
 
 // IsSliceInterfacePtr reports whether v is a slice ptr type.
-func IsSliceInterfacePtr(v interface{}) bool {
+func IsSliceInterfacePtr(v any) bool {
 	// Must use ValueOf because Elem().Elem() type resolves dynamically.
 	vv := reflect.ValueOf(v)
 	return vv.Kind() == reflect.Ptr && vv.Elem().Kind() == reflect.Interface && vv.Elem().Elem().Kind() == reflect.Slice
@@ -118,7 +118,7 @@ func IsNilOrInvalidValue(v reflect.Value) bool {
 
 // IsValueNil returns true if either value is nil, or has dynamic type {ptr,
 // map, slice} with value nil.
-func IsValueNil(value interface{}) bool {
+func IsValueNil(value any) bool {
 	if value == nil {
 		return true
 	}
@@ -131,7 +131,7 @@ func IsValueNil(value interface{}) bool {
 
 // IsValueNilOrDefault returns true if either IsValueNil(value) or the default
 // value for the type.
-func IsValueNilOrDefault(value interface{}) bool {
+func IsValueNilOrDefault(value any) bool {
 	if IsValueNil(value) {
 		return true
 	}
@@ -193,7 +193,7 @@ func ValuesAreSameType(v1 reflect.Value, v2 reflect.Value) bool {
 }
 
 // IsEmptyString returns true if value is an empty string.
-func IsEmptyString(value interface{}) bool {
+func IsEmptyString(value any) bool {
 	if value == nil {
 		return true
 	}
@@ -207,7 +207,7 @@ func IsEmptyString(value interface{}) bool {
 }
 
 // DeleteFromSlicePtr deletes an entry at index from the parent, which must be a slice ptr.
-func DeleteFromSlicePtr(parentSlice interface{}, index int) error {
+func DeleteFromSlicePtr(parentSlice any, index int) error {
 	scope.Debugf("DeleteFromSlicePtr index=%d, slice=\n%v", index, parentSlice)
 	pv := reflect.ValueOf(parentSlice)
 
@@ -226,7 +226,7 @@ func DeleteFromSlicePtr(parentSlice interface{}, index int) error {
 }
 
 // UpdateSlicePtr updates an entry at index in the parent, which must be a slice ptr, with the given value.
-func UpdateSlicePtr(parentSlice interface{}, index int, value interface{}) error {
+func UpdateSlicePtr(parentSlice any, index int, value any) error {
 	scope.Debugf("UpdateSlicePtr parent=\n%v\n, index=%d, value=\n%v", parentSlice, index, value)
 	pv := reflect.ValueOf(parentSlice)
 	v := reflect.ValueOf(value)
@@ -246,7 +246,7 @@ func UpdateSlicePtr(parentSlice interface{}, index int, value interface{}) error
 }
 
 // InsertIntoMap inserts value with key into parent which must be a map, map ptr, or interface to map.
-func InsertIntoMap(parentMap interface{}, key interface{}, value interface{}) error {
+func InsertIntoMap(parentMap any, key any, value any) error {
 	scope.Debugf("InsertIntoMap key=%v, value=%v, map=\n%v", key, value, parentMap)
 	v := reflect.ValueOf(parentMap)
 	kv := reflect.ValueOf(key)
@@ -270,7 +270,7 @@ func InsertIntoMap(parentMap interface{}, key interface{}, value interface{}) er
 }
 
 // DeleteFromMap deletes an entry with the given key parent, which must be a map.
-func DeleteFromMap(parentMap interface{}, key interface{}) error {
+func DeleteFromMap(parentMap any, key any) error {
 	scope.Debugf("DeleteFromMap key=%s, parent:\n%v\n", key, parentMap)
 	pv := reflect.ValueOf(parentMap)
 
@@ -283,7 +283,7 @@ func DeleteFromMap(parentMap interface{}, key interface{}) error {
 }
 
 // ToIntValue returns 0, false if val is not a number type, otherwise it returns the int value of val.
-func ToIntValue(val interface{}) (int, bool) {
+func ToIntValue(val any) (int, bool) {
 	if IsValueNil(val) {
 		return 0, false
 	}

--- a/operator/pkg/util/reflect_test.go
+++ b/operator/pkg/util/reflect_test.go
@@ -46,7 +46,7 @@ func TestIsValueNil(t *testing.T) {
 	if !IsValueNil([]int(nil)) {
 		t.Error("got IsValueNil(slice) false, want true")
 	}
-	if !IsValueNil(interface{}(nil)) {
+	if !IsValueNil(any(nil)) {
 		t.Error("got IsValueNil(interface) false, want true")
 	}
 
@@ -59,7 +59,7 @@ func TestIsValueNil(t *testing.T) {
 	if IsValueNil([]int{1, 2, 3}) {
 		t.Error("got IsValueNil(slice) true, want false")
 	}
-	if IsValueNil(interface{}(42)) {
+	if IsValueNil(any(42)) {
 		t.Error("got IsValueNil(interface) true, want false")
 	}
 }
@@ -77,7 +77,7 @@ func TestIsValueNilOrDefault(t *testing.T) {
 	if !IsValueNilOrDefault([]int(nil)) {
 		t.Error("got IsValueNilOrDefault(slice) false, want true")
 	}
-	if !IsValueNilOrDefault(interface{}(nil)) {
+	if !IsValueNilOrDefault(any(nil)) {
 		t.Error("got IsValueNilOrDefault(interface) false, want true")
 	}
 	if !IsValueNilOrDefault(int(0)) {
@@ -104,47 +104,47 @@ func TestIsValueFuncs(t *testing.T) {
 	var testNilSlice []bool
 	var testNilMap map[bool]bool
 
-	allValues := []interface{}{nil, testInt, &testInt, testStruct, &testStruct, testNilSlice, testSlice, &testSlice, testNilMap, testMap, &testMap}
+	allValues := []any{nil, testInt, &testInt, testStruct, &testStruct, testNilSlice, testSlice, &testSlice, testNilMap, testMap, &testMap}
 
 	tests := []struct {
 		desc     string
 		function func(v reflect.Value) bool
-		okValues []interface{}
+		okValues []any
 	}{
 		{
 			desc:     "IsValuePtr",
 			function: IsValuePtr,
-			okValues: []interface{}{&testInt, &testStruct, &testSlice, &testMap},
+			okValues: []any{&testInt, &testStruct, &testSlice, &testMap},
 		},
 		{
 			desc:     "IsValueStruct",
 			function: IsValueStruct,
-			okValues: []interface{}{testStruct},
+			okValues: []any{testStruct},
 		},
 		{
 			desc:     "IsValueInterface",
 			function: IsValueInterface,
-			okValues: []interface{}{},
+			okValues: []any{},
 		},
 		{
 			desc:     "IsValueStructPtr",
 			function: IsValueStructPtr,
-			okValues: []interface{}{&testStruct},
+			okValues: []any{&testStruct},
 		},
 		{
 			desc:     "IsValueMap",
 			function: IsValueMap,
-			okValues: []interface{}{testNilMap, testMap},
+			okValues: []any{testNilMap, testMap},
 		},
 		{
 			desc:     "IsValueSlice",
 			function: IsValueSlice,
-			okValues: []interface{}{testNilSlice, testSlice},
+			okValues: []any{testNilSlice, testSlice},
 		},
 		{
 			desc:     "IsValueScalar",
 			function: IsValueScalar,
-			okValues: []interface{}{testInt, &testInt},
+			okValues: []any{testInt, &testInt},
 		},
 	}
 
@@ -162,8 +162,8 @@ func TestValuesAreSameType(t *testing.T) {
 
 	tests := []struct {
 		inDesc string
-		inV1   interface{}
-		inV2   interface{}
+		inV1   any
+		inV2   any
 		want   bool
 	}{
 		{
@@ -206,12 +206,12 @@ func TestIsTypeFuncs(t *testing.T) {
 	testInt := int(42)
 	testStruct := struct{}{}
 	testSlice := []bool{}
-	testSliceOfInterface := []interface{}{}
+	testSliceOfInterface := []any{}
 	testMap := map[bool]bool{}
 	var testNilSlice []bool
 	var testNilMap map[bool]bool
 
-	allTypes := []interface{}{
+	allTypes := []any{
 		nil, testInt, &testInt, testStruct, &testStruct, testNilSlice,
 		testSlice, &testSlice, testSliceOfInterface, testNilMap, testMap, &testMap,
 	}
@@ -219,32 +219,32 @@ func TestIsTypeFuncs(t *testing.T) {
 	tests := []struct {
 		desc     string
 		function func(v reflect.Type) bool
-		okTypes  []interface{}
+		okTypes  []any
 	}{
 		{
 			desc:     "IsTypeStructPtr",
 			function: IsTypeStructPtr,
-			okTypes:  []interface{}{&testStruct},
+			okTypes:  []any{&testStruct},
 		},
 		{
 			desc:     "IsTypeSlicePtr",
 			function: IsTypeSlicePtr,
-			okTypes:  []interface{}{&testSlice},
+			okTypes:  []any{&testSlice},
 		},
 		{
 			desc:     "IsTypeMap",
 			function: IsTypeMap,
-			okTypes:  []interface{}{testNilMap, testMap},
+			okTypes:  []any{testNilMap, testMap},
 		},
 		{
 			desc:     "IsTypeInterface",
 			function: IsTypeInterface,
-			okTypes:  []interface{}{},
+			okTypes:  []any{},
 		},
 		{
 			desc:     "IsTypeSliceOfInterface",
 			function: IsTypeSliceOfInterface,
-			okTypes:  []interface{}{testSliceOfInterface},
+			okTypes:  []any{testSliceOfInterface},
 		},
 	}
 
@@ -296,7 +296,7 @@ func TestIsTypeInterface(t *testing.T) {
 	}
 }
 
-func isInListOfInterface(lv []interface{}, v interface{}) bool {
+func isInListOfInterface(lv []any, v any) bool {
 	for _, vv := range lv {
 		if reflect.DeepEqual(vv, v) {
 			return true
@@ -307,7 +307,7 @@ func isInListOfInterface(lv []interface{}, v interface{}) bool {
 
 func TestDeleteFromSlicePtr(t *testing.T) {
 	parentSlice := []int{42, 43, 44, 45}
-	var parentSliceI interface{} = parentSlice
+	var parentSliceI any = parentSlice
 	if err := DeleteFromSlicePtr(&parentSliceI, 1); err != nil {
 		t.Fatalf("got error: %s, want error: nil", err)
 	}
@@ -325,7 +325,7 @@ func TestDeleteFromSlicePtr(t *testing.T) {
 
 func TestUpdateSlicePtr(t *testing.T) {
 	parentSlice := []int{42, 43, 44, 45}
-	var parentSliceI interface{} = parentSlice
+	var parentSliceI any = parentSlice
 	if err := UpdateSlicePtr(&parentSliceI, 1, 42); err != nil {
 		t.Fatalf("got error: %s, want error: nil", err)
 	}
@@ -361,10 +361,10 @@ func TestInsertIntoMap(t *testing.T) {
 }
 
 var (
-	allIntTypes     = []interface{}{int(-42), int8(-43), int16(-44), int32(-45), int64(-46)}
-	allUintTypes    = []interface{}{uint(42), uint8(43), uint16(44), uint32(45), uint64(46)}
+	allIntTypes     = []any{int(-42), int8(-43), int16(-44), int32(-45), int64(-46)}
+	allUintTypes    = []any{uint(42), uint8(43), uint16(44), uint32(45), uint64(46)}
 	allIntegerTypes = append(allIntTypes, allUintTypes...)
-	nonIntTypes     = []interface{}{nil, "", []int{}, map[string]bool{}}
+	nonIntTypes     = []any{nil, "", []int{}, map[string]bool{}}
 	allTypes        = append(allIntegerTypes, nonIntTypes...)
 )
 
@@ -372,7 +372,7 @@ func TestIsInteger(t *testing.T) {
 	tests := []struct {
 		desc     string
 		function func(v reflect.Kind) bool
-		want     []interface{}
+		want     []any
 	}{
 		{
 			desc:     "ints",
@@ -387,7 +387,7 @@ func TestIsInteger(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		var got []interface{}
+		var got []any
 		for _, v := range allTypes {
 			if tt.function(reflect.ValueOf(v).Kind()) {
 				got = append(got, v)

--- a/operator/pkg/util/util.go
+++ b/operator/pkg/util/util.go
@@ -87,8 +87,8 @@ func FindFiles(path string, filter FileFilter) ([]string, error) {
 }
 
 // ParseValue parses string into a value
-func ParseValue(valueStr string) interface{} {
-	var value interface{}
+func ParseValue(valueStr string) any {
+	var value any
 	if v, err := strconv.Atoi(valueStr); err == nil {
 		value = v
 	} else if v, err := strconv.ParseFloat(valueStr, 64); err == nil {
@@ -129,7 +129,7 @@ func ConsolidateLog(logMessage string) string {
 }
 
 // RenderTemplate is a helper method to render a template with the given values.
-func RenderTemplate(tmpl string, ts interface{}) (string, error) {
+func RenderTemplate(tmpl string, ts any) (string, error) {
 	t, err := template.New("").Parse(tmpl)
 	if err != nil {
 		return "", err
@@ -153,7 +153,7 @@ func ValueString(v *structpb.Value) string {
 	}
 }
 
-func MustStruct(m map[string]interface{}) *structpb.Struct {
+func MustStruct(m map[string]any) *structpb.Struct {
 	s, _ := structpb.NewStruct(m)
 	return s
 }

--- a/operator/pkg/util/util_test.go
+++ b/operator/pkg/util/util_test.go
@@ -23,7 +23,7 @@ func TestParseValue(t *testing.T) {
 	tests := []struct {
 		desc string
 		in   string
-		want interface{}
+		want any
 	}{
 		{
 			desc: "empty",

--- a/operator/pkg/util/yaml.go
+++ b/operator/pkg/util/yaml.go
@@ -33,7 +33,7 @@ import (
 	"istio.io/istio/pkg/util/protomarshal"
 )
 
-func ToYAMLGeneric(root interface{}) ([]byte, error) {
+func ToYAMLGeneric(root any) ([]byte, error) {
 	var vs []byte
 	if proto, ok := root.(proto.Message); ok {
 		v, err := protomarshal.ToYAML(proto)
@@ -51,7 +51,7 @@ func ToYAMLGeneric(root interface{}) ([]byte, error) {
 	return vs, nil
 }
 
-func MustToYAMLGeneric(root interface{}) string {
+func MustToYAMLGeneric(root any) string {
 	var vs []byte
 	if proto, ok := root.(proto.Message); ok {
 		v, err := protomarshal.ToYAML(proto)
@@ -70,7 +70,7 @@ func MustToYAMLGeneric(root interface{}) string {
 }
 
 // ToYAML returns a YAML string representation of val, or the error string if an error occurs.
-func ToYAML(val interface{}) string {
+func ToYAML(val any) string {
 	y, err := yaml.Marshal(val)
 	if err != nil {
 		return err.Error()
@@ -120,7 +120,7 @@ func UnmarshalWithJSONPB(y string, out proto.Message, allowUnknownField bool) er
 }
 
 // OverlayTrees performs a sequential JSON strategic of overlays over base.
-func OverlayTrees(base map[string]interface{}, overlays ...map[string]interface{}) (map[string]interface{}, error) {
+func OverlayTrees(base map[string]any, overlays ...map[string]any) (map[string]any, error) {
 	needsOverlay := false
 	for _, o := range overlays {
 		if len(o) > 0 {
@@ -150,7 +150,7 @@ func OverlayTrees(base map[string]interface{}, overlays ...map[string]interface{
 		}
 	}
 
-	out := make(map[string]interface{})
+	out := make(map[string]any)
 	err = yaml.Unmarshal([]byte(by), &out)
 	if err != nil {
 		return nil, err
@@ -196,7 +196,7 @@ func OverlayYAML(base, overlay string) (string, error) {
 
 // yamlDiff compares single YAML file
 func yamlDiff(a, b string) string {
-	ao, bo := make(map[string]interface{}), make(map[string]interface{})
+	ao, bo := make(map[string]any), make(map[string]any)
 	if err := yaml.Unmarshal([]byte(a), &ao); err != nil {
 		return err.Error()
 	}

--- a/operator/pkg/util/yaml_test.go
+++ b/operator/pkg/util/yaml_test.go
@@ -23,14 +23,14 @@ import (
 func TestToYAML(t *testing.T) {
 	tests := []struct {
 		desc        string
-		inVals      interface{}
+		inVals      any
 		expectedOut string
 	}{
 		{
 			desc: "valid-yaml",
-			inVals: map[string]interface{}{
+			inVals: map[string]any{
 				"foo": "bar",
-				"yo": map[string]interface{}{
+				"yo": map[string]any{
 					"istio": "bar",
 				},
 			},
@@ -41,7 +41,7 @@ yo:
 		},
 		{
 			desc: "alphabetical",
-			inVals: map[string]interface{}{
+			inVals: map[string]any{
 				"foo": "yaml",
 				"abc": "f",
 			},
@@ -67,21 +67,21 @@ foo: yaml
 func TestOverlayTrees(t *testing.T) {
 	tests := []struct {
 		desc            string
-		inBase          map[string]interface{}
-		inOverlays      map[string]interface{}
-		expectedOverlay map[string]interface{}
+		inBase          map[string]any
+		inOverlays      map[string]any
+		expectedOverlay map[string]any
 		expectedErr     error
 	}{
 		{
 			desc: "overlay-valid",
-			inBase: map[string]interface{}{
+			inBase: map[string]any{
 				"foo": "bar",
 				"baz": "naz",
 			},
-			inOverlays: map[string]interface{}{
+			inOverlays: map[string]any{
 				"foo": "laz",
 			},
-			expectedOverlay: map[string]interface{}{
+			expectedOverlay: map[string]any{
 				"baz": "naz",
 				"foo": "laz",
 			},
@@ -89,14 +89,14 @@ func TestOverlayTrees(t *testing.T) {
 		},
 		{
 			desc: "overlay-key-does-not-exist",
-			inBase: map[string]interface{}{
+			inBase: map[string]any{
 				"foo": "bar",
 				"baz": "naz",
 			},
-			inOverlays: map[string]interface{}{
+			inOverlays: map[string]any{
 				"i-dont-exist": "i-really-dont-exist",
 			},
-			expectedOverlay: map[string]interface{}{
+			expectedOverlay: map[string]any{
 				"baz":          "naz",
 				"foo":          "bar",
 				"i-dont-exist": "i-really-dont-exist",
@@ -105,13 +105,13 @@ func TestOverlayTrees(t *testing.T) {
 		},
 		{
 			desc: "remove-key-val",
-			inBase: map[string]interface{}{
+			inBase: map[string]any{
 				"foo": "bar",
 			},
-			inOverlays: map[string]interface{}{
+			inOverlays: map[string]any{
 				"foo": nil,
 			},
-			expectedOverlay: map[string]interface{}{},
+			expectedOverlay: map[string]any{},
 			expectedErr:     nil,
 		},
 	}

--- a/operator/pkg/validate/common.go
+++ b/operator/pkg/validate/common.go
@@ -90,7 +90,7 @@ var (
 )
 
 // validateWithRegex checks whether the given value matches the regexp r.
-func validateWithRegex(path util.Path, val interface{}, r *regexp.Regexp) (errs util.Errors) {
+func validateWithRegex(path util.Path, val any, r *regexp.Regexp) (errs util.Errors) {
 	valStr := fmt.Sprint(val)
 	if len(r.FindString(valStr)) != len(valStr) {
 		errs = util.AppendErr(errs, fmt.Errorf("invalid value %s: %v", path, val))
@@ -102,7 +102,7 @@ func validateWithRegex(path util.Path, val interface{}, r *regexp.Regexp) (errs 
 // validateStringList returns a validator function that works on a string list, using the supplied ValidatorFunc vf on
 // each element.
 func validateStringList(vf ValidatorFunc) ValidatorFunc {
-	return func(path util.Path, val interface{}) util.Errors {
+	return func(path util.Path, val any) util.Errors {
 		msg := fmt.Sprintf("validateStringList %v", val)
 		if !util.IsString(val) {
 			err := fmt.Errorf("validateStringList %s got %T, want string", path, val)
@@ -121,7 +121,7 @@ func validateStringList(vf ValidatorFunc) ValidatorFunc {
 }
 
 // validatePortNumberString checks if val is a string with a valid port number.
-func validatePortNumberString(path util.Path, val interface{}) util.Errors {
+func validatePortNumberString(path util.Path, val any) util.Errors {
 	scope.Debugf("validatePortNumberString %v:", val)
 	if !util.IsString(val) {
 		return util.NewErrs(fmt.Errorf("validatePortNumberString(%s) bad type %T, want string", path, val))
@@ -137,12 +137,12 @@ func validatePortNumberString(path util.Path, val interface{}) util.Errors {
 }
 
 // validatePortNumber checks whether val is an integer representing a valid port number.
-func validatePortNumber(path util.Path, val interface{}) util.Errors {
+func validatePortNumber(path util.Path, val any) util.Errors {
 	return validateIntRange(path, val, 0, 65535)
 }
 
 // validateIPRangesOrStar validates IP ranges and also allow star, examples: "1.1.0.256/16,2.2.0.257/16", "*"
-func validateIPRangesOrStar(path util.Path, val interface{}) (errs util.Errors) {
+func validateIPRangesOrStar(path util.Path, val any) (errs util.Errors) {
 	scope.Debugf("validateIPRangesOrStar at %v: %v", path, val)
 
 	if !util.IsString(val) {
@@ -159,7 +159,7 @@ func validateIPRangesOrStar(path util.Path, val interface{}) (errs util.Errors) 
 }
 
 // validateIntRange checks whether val is an integer in [min, max].
-func validateIntRange(path util.Path, val interface{}, min, max int64) util.Errors {
+func validateIntRange(path util.Path, val any, min, max int64) util.Errors {
 	k := reflect.TypeOf(val).Kind()
 	var err error
 	switch {
@@ -181,7 +181,7 @@ func validateIntRange(path util.Path, val interface{}, min, max int64) util.Erro
 }
 
 // validateCIDR checks whether val is a string with a valid CIDR.
-func validateCIDR(path util.Path, val interface{}) util.Errors {
+func validateCIDR(path util.Path, val any) util.Errors {
 	var err error
 	if !util.IsString(val) {
 		err = fmt.Errorf("validateCIDR %s got %T, want string", path, val)
@@ -204,7 +204,7 @@ func printError(err error) {
 }
 
 // logWithError prints debug log with err message
-func logWithError(err error, format string, args ...interface{}) {
+func logWithError(err error, format string, args ...any) {
 	msg := fmt.Sprintf(format, args...)
 	if err == nil {
 		msg += ": OK\n"
@@ -268,12 +268,12 @@ func anchored(res ...*regexp.Regexp) *regexp.Regexp {
 }
 
 // ValidatorFunc validates a value.
-type ValidatorFunc func(path util.Path, i interface{}) util.Errors
+type ValidatorFunc func(path util.Path, i any) util.Errors
 
 // UnmarshalIOP unmarshals a string containing IstioOperator as YAML.
 func UnmarshalIOP(iopYAML string) (*v1alpha1.IstioOperator, error) {
 	// Remove creationDate (util.UnmarshalWithJSONPB fails if present)
-	mapIOP := make(map[string]interface{})
+	mapIOP := make(map[string]any)
 	if err := yaml.Unmarshal([]byte(iopYAML), &mapIOP); err != nil {
 		return nil, err
 	}

--- a/operator/pkg/validate/validate.go
+++ b/operator/pkg/validate/validate.go
@@ -33,7 +33,7 @@ import (
 var (
 	// DefaultValidations maps a data path to a validation function.
 	DefaultValidations = map[string]ValidatorFunc{
-		"Values": func(path util.Path, i interface{}) util.Errors {
+		"Values": func(path util.Path, i any) util.Errors {
 			return CheckValues(i)
 		},
 		"MeshConfig":                 validateMeshConfig,
@@ -81,7 +81,7 @@ func Validate2(validations map[string]ValidatorFunc, iop *v1alpha1.IstioOperator
 // Validate function below is used by third party for integrations and has to be public
 
 // Validate validates the values of the tree using the supplied Func.
-func Validate(validations map[string]ValidatorFunc, structPtr interface{}, path util.Path, checkRequired bool) (errs util.Errors) {
+func Validate(validations map[string]ValidatorFunc, structPtr any, path util.Path, checkRequired bool) (errs util.Errors) {
 	scope.Debugf("validate with path %s, %v (%T)", path, structPtr, structPtr)
 	if structPtr == nil {
 		return nil
@@ -158,7 +158,7 @@ func Validate(validations map[string]ValidatorFunc, structPtr interface{}, path 
 	return errs
 }
 
-func validateLeaf(validations map[string]ValidatorFunc, path util.Path, val interface{}, checkRequired bool) util.Errors {
+func validateLeaf(validations map[string]ValidatorFunc, path util.Path, val any, checkRequired bool) util.Errors {
 	pstr := path.String()
 	msg := fmt.Sprintf("validate %s:%v(%T) ", pstr, val, val)
 	if util.IsValueNil(val) || util.IsEmptyString(val) {
@@ -181,7 +181,7 @@ func validateLeaf(validations map[string]ValidatorFunc, path util.Path, val inte
 	return vf(path, val)
 }
 
-func validateMeshConfig(path util.Path, root interface{}) util.Errors {
+func validateMeshConfig(path util.Path, root any) util.Errors {
 	vs, err := util.ToYAMLGeneric(root)
 	if err != nil {
 		return util.Errors{err}
@@ -197,18 +197,18 @@ func validateMeshConfig(path util.Path, root interface{}) util.Errors {
 	return nil
 }
 
-func validateHub(path util.Path, val interface{}) util.Errors {
+func validateHub(path util.Path, val any) util.Errors {
 	if val == "" {
 		return nil
 	}
 	return validateWithRegex(path, val, ReferenceRegexp)
 }
 
-func validateTag(path util.Path, val interface{}) util.Errors {
+func validateTag(path util.Path, val any) util.Errors {
 	return validateWithRegex(path, val.(*structpb.Value).GetStringValue(), TagRegexp)
 }
 
-func validateRevision(_ util.Path, val interface{}) util.Errors {
+func validateRevision(_ util.Path, val any) util.Errors {
 	if val == "" {
 		return nil
 	}
@@ -219,7 +219,7 @@ func validateRevision(_ util.Path, val interface{}) util.Errors {
 	return nil
 }
 
-func validateGatewayName(path util.Path, val interface{}) (errs util.Errors) {
+func validateGatewayName(path util.Path, val any) (errs util.Errors) {
 	v := val.([]*v1alpha1.GatewaySpec)
 	for _, n := range v {
 		errs = append(errs, validateWithRegex(path, n.Name, ObjectNameRegexp)...)

--- a/operator/pkg/validate/validate_values.go
+++ b/operator/pkg/validate/validate_values.go
@@ -33,7 +33,7 @@ var DefaultValuesValidations = map[string]ValidatorFunc{
 }
 
 // CheckValues validates the values in the given tree, which follows the Istio values.yaml schema.
-func CheckValues(root interface{}) util.Errors {
+func CheckValues(root any) util.Errors {
 	v := reflect.ValueOf(root)
 	if root == nil || (v.Kind() == reflect.Ptr && v.IsNil()) {
 		return nil
@@ -50,7 +50,7 @@ func CheckValues(root interface{}) util.Errors {
 }
 
 // ValuesValidate validates the values of the tree using the supplied Func
-func ValuesValidate(validations map[string]ValidatorFunc, node interface{}, path util.Path) (errs util.Errors) {
+func ValuesValidate(validations map[string]ValidatorFunc, node any, path util.Path) (errs util.Errors) {
 	pstr := path.String()
 	scope.Debugf("ValuesValidate %s", pstr)
 	vf := validations[pstr]
@@ -58,7 +58,7 @@ func ValuesValidate(validations map[string]ValidatorFunc, node interface{}, path
 		errs = util.AppendErrs(errs, vf(path, node))
 	}
 
-	nn, ok := node.(map[string]interface{})
+	nn, ok := node.(map[string]any)
 	if !ok {
 		// Leaf, nothing more to recurse.
 		return errs

--- a/operator/pkg/validate/validate_values_test.go
+++ b/operator/pkg/validate/validate_values_test.go
@@ -153,7 +153,7 @@ cni:
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			root := make(map[string]interface{})
+			root := make(map[string]any)
 			err := yaml.Unmarshal([]byte(tt.yamlStr), &root)
 			if err != nil {
 				t.Fatalf("yaml.Unmarshal(%s): got error %s", tt.desc, err)
@@ -220,7 +220,7 @@ func TestValidateValuesFromValuesYAMLs(t *testing.T) {
 		if err != nil {
 			t.Fatal(err.Error())
 		}
-		valuesTree := make(map[string]interface{})
+		valuesTree := make(map[string]any)
 		if err := yaml.Unmarshal([]byte(valuesYAML), &valuesTree); err != nil {
 			t.Fatal(err.Error())
 		}

--- a/operator/pkg/version/version.go
+++ b/operator/pkg/version/version.go
@@ -169,7 +169,7 @@ func (v *Version) String() string {
 }
 
 // UnmarshalYAML implements the Unmarshaler interface.
-func (v *Version) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (v *Version) UnmarshalYAML(unmarshal func(any) error) error {
 	s := ""
 	if err := unmarshal(&s); err != nil {
 		return err

--- a/operator/pkg/version/version_test.go
+++ b/operator/pkg/version/version_test.go
@@ -306,7 +306,7 @@ func TestVersionString(t *testing.T) {
 func TestUnmarshalYAML(t *testing.T) {
 	v := &Version{}
 	expectedErr := fmt.Errorf("test error")
-	errReturn := func(interface{}) error { return expectedErr }
+	errReturn := func(any) error { return expectedErr }
 	gotErr := v.UnmarshalYAML(errReturn)
 	if gotErr == nil {
 		t.Errorf("expected error but got nil")

--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -832,7 +832,7 @@ func (s *Server) handleNdsz(w http.ResponseWriter, r *http.Request) {
 }
 
 // writeJSONProto writes a protobuf to a json payload, handling content type, marshaling, and errors
-func writeJSONProto(w http.ResponseWriter, obj interface{}) {
+func writeJSONProto(w http.ResponseWriter, obj any) {
 	w.Header().Set("Content-Type", "application/json")
 	b, err := config.ToJSON(obj)
 	if err != nil {

--- a/pilot/pkg/autoregistration/controller.go
+++ b/pilot/pkg/autoregistration/controller.go
@@ -305,7 +305,7 @@ func (c *Controller) QueueUnregisterWorkload(proxy *model.Proxy, origConnect tim
 	}
 }
 
-func (c *Controller) unregisterWorkload(item interface{}) error {
+func (c *Controller) unregisterWorkload(item any) error {
 	workItem, ok := item.(*workItem)
 	if !ok {
 		return nil
@@ -382,7 +382,7 @@ func (c *Controller) QueueWorkloadEntryHealth(proxy *model.Proxy, event HealthEv
 
 // updateWorkloadEntryHealth updates the associated WorkloadEntries health status
 // based on the corresponding health check performed by istio-agent.
-func (c *Controller) updateWorkloadEntryHealth(obj interface{}) error {
+func (c *Controller) updateWorkloadEntryHealth(obj any) error {
 	condition := obj.(HealthCondition)
 	// get previous status
 	cfg := c.store.Get(gvk.WorkloadEntry, condition.entryName, condition.proxy.Metadata.Namespace)

--- a/pilot/pkg/config/file/store.go
+++ b/pilot/pkg/config/file/store.go
@@ -449,7 +449,7 @@ func TranslateObject(obj *unstructured.Unstructured, domainSuffix string, schema
 		panic(err)
 	}
 	if spec, ok := obj.UnstructuredContent()["spec"]; ok {
-		err = runtime.DefaultUnstructuredConverter.FromUnstructured(spec.(map[string]interface{}), mv2)
+		err = runtime.DefaultUnstructuredConverter.FromUnstructured(spec.(map[string]any), mv2)
 	} else {
 		err = runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), mv2)
 	}

--- a/pilot/pkg/config/kube/crd/config.go
+++ b/pilot/pkg/config/kube/crd/config.go
@@ -23,17 +23,17 @@ import (
 type IstioKind struct {
 	meta_v1.TypeMeta
 	meta_v1.ObjectMeta `json:"metadata"`
-	Spec               map[string]interface{} `json:"spec"`
-	Status             map[string]interface{} `json:"status,omitempty"`
+	Spec               map[string]any `json:"spec"`
+	Status             map[string]any `json:"status,omitempty"`
 }
 
 // GetSpec from a wrapper
-func (in *IstioKind) GetSpec() map[string]interface{} {
+func (in *IstioKind) GetSpec() map[string]any {
 	return in.Spec
 }
 
 // GetStatus from a wrapper
-func (in *IstioKind) GetStatus() map[string]interface{} {
+func (in *IstioKind) GetStatus() map[string]any {
 	return in.Status
 }
 
@@ -73,7 +73,7 @@ func (in *IstioKind) DeepCopyObject() runtime.Object {
 // IstioObject is a k8s wrapper interface for config objects
 type IstioObject interface {
 	runtime.Object
-	GetSpec() map[string]interface{}
-	GetStatus() map[string]interface{}
+	GetSpec() map[string]any
+	GetStatus() map[string]any
 	GetObjectMeta() meta_v1.ObjectMeta
 }

--- a/pilot/pkg/config/kube/crd/config_test.go
+++ b/pilot/pkg/config/kube/crd/config_test.go
@@ -26,13 +26,13 @@ import (
 func TestKind(t *testing.T) {
 	obj := crd.IstioKind{}
 
-	spec := map[string]interface{}{"a": "b"}
+	spec := map[string]any{"a": "b"}
 	obj.Spec = spec
 	if got := obj.GetSpec(); !reflect.DeepEqual(spec, got) {
 		t.Errorf("GetSpec() => got %v, want %v", got, spec)
 	}
 
-	status := map[string]interface{}{"yo": "lit"}
+	status := map[string]any{"yo": "lit"}
 	obj.Status = status
 	if got := obj.GetStatus(); !reflect.DeepEqual(status, got) {
 		t.Errorf("GetStatus() => got %v, want %v", got, status)

--- a/pilot/pkg/config/kube/crd/conversion.go
+++ b/pilot/pkg/config/kube/crd/conversion.go
@@ -46,7 +46,7 @@ func FromJSON(s collection.Schema, js string) (config.Spec, error) {
 	return c, nil
 }
 
-func IstioStatusJSONFromMap(jsonMap map[string]interface{}) (config.Status, error) {
+func IstioStatusJSONFromMap(jsonMap map[string]any) (config.Status, error) {
 	if jsonMap == nil {
 		return nil, nil
 	}
@@ -76,7 +76,7 @@ func FromYAML(s collection.Schema, yml string) (config.Spec, error) {
 
 // FromJSONMap converts from a generic map to a proto message using canonical JSON encoding
 // JSON encoding is specified here: https://developers.google.com/protocol-buffers/docs/proto3#json
-func FromJSONMap(s collection.Schema, data interface{}) (config.Spec, error) {
+func FromJSONMap(s collection.Schema, data any) (config.Spec, error) {
 	// Marshal to YAML bytes
 	str, err := yaml.Marshal(data)
 	if err != nil {

--- a/pilot/pkg/config/kube/crd/conversion_test.go
+++ b/pilot/pkg/config/kube/crd/conversion_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestConvert(t *testing.T) {
-	if _, err := ConvertObject(collections.IstioNetworkingV1Alpha3Virtualservices, &IstioKind{Spec: map[string]interface{}{"x": 1}}, "local"); err != nil {
+	if _, err := ConvertObject(collections.IstioNetworkingV1Alpha3Virtualservices, &IstioKind{Spec: map[string]any{"x": 1}}, "local"); err != nil {
 		t.Errorf("error for converting object: %s", err)
 	}
 	cfg := config.Config{

--- a/pilot/pkg/config/kube/crdclient/cache_handler.go
+++ b/pilot/pkg/config/kube/crdclient/cache_handler.go
@@ -36,7 +36,7 @@ type cacheHandler struct {
 	lister   func(namespace string) cache.GenericNamespaceLister
 }
 
-func (h *cacheHandler) onEvent(old interface{}, curr interface{}, event model.Event) error {
+func (h *cacheHandler) onEvent(old any, curr any, event model.Event) error {
 	if err := h.client.checkReadyForEvents(curr); err != nil {
 		return err
 	}
@@ -92,7 +92,7 @@ func createCacheHandler(cl *Client, schema collection.Schema, i informers.Generi
 	}
 	kind := schema.Resource().Kind()
 	i.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+		AddFunc: func(obj any) {
 			incrementEvent(kind, "add")
 			if !cl.beginSync.Load() {
 				return
@@ -101,7 +101,7 @@ func createCacheHandler(cl *Client, schema collection.Schema, i informers.Generi
 				return h.onEvent(nil, obj, model.EventAdd)
 			})
 		},
-		UpdateFunc: func(old, cur interface{}) {
+		UpdateFunc: func(old, cur any) {
 			incrementEvent(kind, "update")
 			if !cl.beginSync.Load() {
 				return
@@ -110,7 +110,7 @@ func createCacheHandler(cl *Client, schema collection.Schema, i informers.Generi
 				return h.onEvent(old, cur, model.EventUpdate)
 			})
 		},
-		DeleteFunc: func(obj interface{}) {
+		DeleteFunc: func(obj any) {
 			incrementEvent(kind, "delete")
 			if !cl.beginSync.Load() {
 				return

--- a/pilot/pkg/config/kube/crdclient/client.go
+++ b/pilot/pkg/config/kube/crdclient/client.go
@@ -192,7 +192,7 @@ func NewForSchemas(client kube.Client, revision, domainSuffix string, schemas co
 }
 
 // Validate we are ready to handle events. Until the informers are synced, we will block the queue
-func (cl *Client) checkReadyForEvents(curr interface{}) error {
+func (cl *Client) checkReadyForEvents(curr any) error {
 	if !cl.informerSynced() {
 		return errors.New("waiting till full synchronization")
 	}
@@ -231,7 +231,7 @@ func (cl *Client) Run(stop <-chan struct{}) {
 	scope.Info("Pilot K8S CRD controller synced ", time.Since(t0))
 
 	cl.crdMetadataInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+		AddFunc: func(obj any) {
 			crd, ok := obj.(*metav1.PartialObjectMetadata)
 			if !ok {
 				// Shouldn't happen

--- a/pilot/pkg/config/kube/gateway/controller.go
+++ b/pilot/pkg/config/kube/gateway/controller.go
@@ -98,10 +98,10 @@ func NewController(client kube.Client, c model.ConfigStoreController, options co
 	}
 
 	nsInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+		AddFunc: func(obj any) {
 			gatewayController.namespaceEvent(nil, obj)
 		},
-		UpdateFunc: func(oldObj, newObj interface{}) {
+		UpdateFunc: func(oldObj, newObj any) {
 			gatewayController.namespaceEvent(oldObj, newObj)
 		},
 	})
@@ -140,7 +140,7 @@ func (c *Controller) List(typ config.GroupVersionKind, namespace string) ([]conf
 func (c *Controller) SetStatusWrite(enabled bool, statusManager *status.Manager) {
 	c.statusEnabled.Store(enabled)
 	if enabled && features.EnableGatewayAPIStatus && statusManager != nil {
-		c.statusController = statusManager.CreateGenericController(func(status interface{}, context interface{}) status.GenerationProvider {
+		c.statusController = statusManager.CreateGenericController(func(status any, context any) status.GenerationProvider {
 			return &gatewayGeneration{context}
 		})
 	} else {
@@ -303,7 +303,7 @@ func (c *Controller) SecretAllowed(resourceName string, namespace string) bool {
 // when the labels change.
 // Note: we don't handle delete as a delete would also clean up any relevant gateway-api types which will
 // trigger its own event.
-func (c *Controller) namespaceEvent(oldObj interface{}, newObj interface{}) {
+func (c *Controller) namespaceEvent(oldObj any, newObj any) {
 	// First, find all the label keys on the old/new namespace. We include NamespaceNameLabel
 	// since we have special logic to always allow this on namespace.
 	touchedNamespaceLabels := sets.New(NamespaceNameLabel)
@@ -325,7 +325,7 @@ func (c *Controller) namespaceEvent(oldObj interface{}, newObj interface{}) {
 }
 
 // getLabelKeys extracts all label keys from a namespace object.
-func getLabelKeys(obj interface{}) []string {
+func getLabelKeys(obj any) []string {
 	if obj == nil {
 		return nil
 	}

--- a/pilot/pkg/config/kube/gateway/deploymentcontroller.go
+++ b/pilot/pkg/config/kube/gateway/deploymentcontroller.go
@@ -229,7 +229,7 @@ func (d *DeploymentController) ApplyTemplate(template string, input metav1.Objec
 	if err := d.templates.ExecuteTemplate(&buf, template, input); err != nil {
 		return err
 	}
-	data := map[string]interface{}{}
+	data := map[string]any{}
 	err := yaml.Unmarshal(buf.Bytes(), &data)
 	if err != nil {
 		return err

--- a/pilot/pkg/config/kube/gateway/generation_adapter.go
+++ b/pilot/pkg/config/kube/gateway/generation_adapter.go
@@ -17,7 +17,7 @@
 package gateway
 
 type gatewayGeneration struct {
-	inner interface{}
+	inner any
 }
 
 func (g *gatewayGeneration) SetObservedGeneration(i int64) {
@@ -27,6 +27,6 @@ func (g *gatewayGeneration) SetObservedGeneration(i int64) {
 	// of the condition functions to update.
 }
 
-func (g *gatewayGeneration) Unwrap() interface{} {
+func (g *gatewayGeneration) Unwrap() any {
 	return g.inner
 }

--- a/pilot/pkg/config/kube/ingress/controller.go
+++ b/pilot/pkg/config/kube/ingress/controller.go
@@ -323,7 +323,7 @@ func (c *controller) Get(typ config.GroupVersionKind, name, namespace string) *c
 }
 
 // sortIngressByCreationTime sorts the list of config objects in ascending order by their creation time (if available).
-func sortIngressByCreationTime(configs []interface{}) []*ingress.Ingress {
+func sortIngressByCreationTime(configs []any) []*ingress.Ingress {
 	ingr := make([]*ingress.Ingress, 0, len(configs))
 	for _, i := range configs {
 		ingr = append(ingr, i.(*ingress.Ingress))

--- a/pilot/pkg/config/kube/ingressv1/controller.go
+++ b/pilot/pkg/config/kube/ingressv1/controller.go
@@ -274,7 +274,7 @@ func (c *controller) Get(typ config.GroupVersionKind, name, namespace string) *c
 }
 
 // sortIngressByCreationTime sorts the list of config objects in ascending order by their creation time (if available).
-func sortIngressByCreationTime(configs []interface{}) []*knetworking.Ingress {
+func sortIngressByCreationTime(configs []any) []*knetworking.Ingress {
 	ingr := make([]*knetworking.Ingress, 0, len(configs))
 	for _, i := range configs {
 		ingr = append(ingr, i.(*knetworking.Ingress))

--- a/pilot/pkg/config/memory/store.go
+++ b/pilot/pkg/config/memory/store.go
@@ -102,7 +102,7 @@ func (cr *store) List(kind config.GroupVersionKind, namespace string) ([]config.
 	out := make([]config.Config, 0, len(cr.data[kind]))
 	if namespace == "" {
 		for _, ns := range data {
-			ns.Range(func(key, value interface{}) bool {
+			ns.Range(func(key, value any) bool {
 				out = append(out, value.(config.Config))
 				return true
 			})
@@ -112,7 +112,7 @@ func (cr *store) List(kind config.GroupVersionKind, namespace string) ([]config.
 		if !exists {
 			return nil, nil
 		}
-		ns.Range(func(key, value interface{}) bool {
+		ns.Range(func(key, value any) bool {
 			out = append(out, value.(config.Config))
 			return true
 		})

--- a/pilot/pkg/leaderelection/k8sleaderelection/k8sresourcelock/interface.go
+++ b/pilot/pkg/leaderelection/k8sleaderelection/k8sresourcelock/interface.go
@@ -59,7 +59,7 @@ type LeaderElectionRecord struct {
 
 // EventRecorder records a change in the ResourceLock.
 type EventRecorder interface {
-	Eventf(obj runtime.Object, eventType, reason, message string, args ...interface{})
+	Eventf(obj runtime.Object, eventType, reason, message string, args ...any)
 }
 
 // ResourceLockConfig common data that exists across different

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -29,7 +29,7 @@ import (
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"github.com/golang/protobuf/jsonpb"
-	any "google.golang.org/protobuf/types/known/anypb"
+	anypb "google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
@@ -191,7 +191,7 @@ type Resources = []*discovery.Resource
 // DeletedResources is an alias for array of strings that represent removed resources in delta.
 type DeletedResources = []string
 
-func AnyToUnnamedResources(r []*any.Any) Resources {
+func AnyToUnnamedResources(r []*anypb.Any) Resources {
 	a := make(Resources, 0, len(r))
 	for _, rr := range r {
 		a = append(a, &discovery.Resource{Resource: rr})
@@ -199,8 +199,8 @@ func AnyToUnnamedResources(r []*any.Any) Resources {
 	return a
 }
 
-func ResourcesToAny(r Resources) []*any.Any {
-	a := make([]*any.Any, 0, len(r))
+func ResourcesToAny(r Resources) []*anypb.Any {
+	a := make([]*anypb.Any, 0, len(r))
 	for _, rr := range r {
 		a = append(a, rr.Resource)
 	}

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -472,7 +472,7 @@ type Node struct {
 	// Metadata is the typed node metadata
 	Metadata *BootstrapNodeMetadata
 	// RawMetadata is the untyped node metadata
-	RawMetadata map[string]interface{}
+	RawMetadata map[string]any
 	// Locality from Envoy bootstrap
 	Locality *core.Locality
 }
@@ -648,7 +648,7 @@ type NodeMetadata struct {
 
 	// Contains a copy of the raw metadata. This is needed to lookup arbitrary values.
 	// If a value is known ahead of time it should be added to the struct rather than reading from here,
-	Raw map[string]interface{} `json:"-"`
+	Raw map[string]any `json:"-"`
 }
 
 // ProxyConfigOrDefault is a helper function to get the ProxyConfig from metadata, or fallback to a default
@@ -688,7 +688,7 @@ func (m *BootstrapNodeMetadata) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, t2); err != nil {
 		return err
 	}
-	var raw map[string]interface{}
+	var raw map[string]any
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
 	}

--- a/pilot/pkg/model/context_test.go
+++ b/pilot/pkg/model/context_test.go
@@ -44,7 +44,7 @@ func TestNodeMetadata(t *testing.T) {
 			"empty",
 			model.BootstrapNodeMetadata{},
 			"{}",
-			model.BootstrapNodeMetadata{NodeMetadata: model.NodeMetadata{Raw: map[string]interface{}{}}},
+			model.BootstrapNodeMetadata{NodeMetadata: model.NodeMetadata{Raw: map[string]any{}}},
 		},
 		{
 			"csvlists",
@@ -53,7 +53,7 @@ func TestNodeMetadata(t *testing.T) {
 			model.BootstrapNodeMetadata{
 				NodeMetadata: model.NodeMetadata{
 					InstanceIPs: []string{"abc", "1.2.3.4"},
-					Raw: map[string]interface{}{
+					Raw: map[string]any{
 						"INSTANCE_IPS": "abc,1.2.3.4",
 					},
 				},
@@ -66,8 +66,8 @@ func TestNodeMetadata(t *testing.T) {
 			model.BootstrapNodeMetadata{
 				NodeMetadata: model.NodeMetadata{
 					Labels: map[string]string{"foo": "bar"},
-					Raw: map[string]interface{}{
-						"LABELS": map[string]interface{}{
+					Raw: map[string]any{
+						"LABELS": map[string]any{
 							"foo": "bar",
 						},
 					},
@@ -106,15 +106,15 @@ func TestNodeMetadata(t *testing.T) {
 							},
 						},
 					}),
-					Raw: map[string]interface{}{
-						"PROXY_CONFIG": map[string]interface{}{
+					Raw: map[string]any{
+						"PROXY_CONFIG": map[string]any{
 							"drainDuration":          "5s",
 							"configPath":             "foo",
 							"controlPlaneAuthPolicy": "MUTUAL_TLS",
-							"envoyAccessLogService": map[string]interface{}{
+							"envoyAccessLogService": map[string]any{
 								"address": "address",
-								"tlsSettings": map[string]interface{}{
-									"subjectAltNames": []interface{}{"san"},
+								"tlsSettings": map[string]any{
+									"subjectAltNames": []any{"san"},
 								},
 							},
 						},
@@ -313,23 +313,23 @@ func TestServiceNode(t *testing.T) {
 func TestParseMetadata(t *testing.T) {
 	cases := []struct {
 		name     string
-		metadata map[string]interface{}
+		metadata map[string]any
 		out      *model.Proxy
 	}{
 		{
 			name: "Basic Case",
 			out: &model.Proxy{
 				Type: "sidecar", IPAddresses: []string{"1.1.1.1"}, DNSDomain: "domain", ID: "id", IstioVersion: model.MaxIstioVersion,
-				Metadata: &model.NodeMetadata{Raw: map[string]interface{}{}},
+				Metadata: &model.NodeMetadata{Raw: map[string]any{}},
 			},
 		},
 		{
 			name:     "Capture Arbitrary Metadata",
-			metadata: map[string]interface{}{"foo": "bar"},
+			metadata: map[string]any{"foo": "bar"},
 			out: &model.Proxy{
 				Type: "sidecar", IPAddresses: []string{"1.1.1.1"}, DNSDomain: "domain", ID: "id", IstioVersion: model.MaxIstioVersion,
 				Metadata: &model.NodeMetadata{
-					Raw: map[string]interface{}{
+					Raw: map[string]any{
 						"foo": "bar",
 					},
 				},
@@ -337,7 +337,7 @@ func TestParseMetadata(t *testing.T) {
 		},
 		{
 			name: "Capture Labels",
-			metadata: map[string]interface{}{
+			metadata: map[string]any{
 				"LABELS": map[string]string{
 					"foo": "bar",
 				},
@@ -345,8 +345,8 @@ func TestParseMetadata(t *testing.T) {
 			out: &model.Proxy{
 				Type: "sidecar", IPAddresses: []string{"1.1.1.1"}, DNSDomain: "domain", ID: "id", IstioVersion: model.MaxIstioVersion,
 				Metadata: &model.NodeMetadata{
-					Raw: map[string]interface{}{
-						"LABELS": map[string]interface{}{"foo": "bar"},
+					Raw: map[string]any{
+						"LABELS": map[string]any{"foo": "bar"},
 					},
 					Labels: map[string]string{"foo": "bar"},
 				},
@@ -354,13 +354,13 @@ func TestParseMetadata(t *testing.T) {
 		},
 		{
 			name: "Capture Pod Ports",
-			metadata: map[string]interface{}{
+			metadata: map[string]any{
 				"POD_PORTS": `[{"name":"http","containerPort":8080,"protocol":"TCP"},{"name":"grpc","containerPort":8079,"protocol":"TCP"}]`,
 			},
 			out: &model.Proxy{
 				Type: "sidecar", IPAddresses: []string{"1.1.1.1"}, DNSDomain: "domain", ID: "id", IstioVersion: model.MaxIstioVersion,
 				Metadata: &model.NodeMetadata{
-					Raw: map[string]interface{}{
+					Raw: map[string]any{
 						"POD_PORTS": `[{"name":"http","containerPort":8080,"protocol":"TCP"},{"name":"grpc","containerPort":8079,"protocol":"TCP"}]`,
 					},
 					PodPorts: []model.PodPort{
@@ -395,7 +395,7 @@ func TestParseMetadata(t *testing.T) {
 	}
 }
 
-func mapToStruct(msg map[string]interface{}) (*structpb.Struct, error) {
+func mapToStruct(msg map[string]any) (*structpb.Struct, error) {
 	if msg == nil {
 		return &structpb.Struct{}, nil
 	}

--- a/pilot/pkg/model/conversion_test.go
+++ b/pilot/pkg/model/conversion_test.go
@@ -104,17 +104,17 @@ trafficPolicy:
     simple: UNSPECIFIED
 `
 
-	wantJSONMap := map[string]interface{}{
+	wantJSONMap := map[string]any{
 		"host": "something.svc.local",
-		"trafficPolicy": map[string]interface{}{
-			"loadBalancer": map[string]interface{}{
+		"trafficPolicy": map[string]any{
+			"loadBalancer": map[string]any{
 				"simple": "UNSPECIFIED",
 			},
 		},
-		"subsets": []interface{}{
-			map[string]interface{}{
+		"subsets": []any{
+			map[string]any{
 				"name": "foo",
-				"labels": map[string]interface{}{
+				"labels": map[string]any{
 					"test": "label",
 				},
 			},

--- a/pilot/pkg/model/jwks_resolver.go
+++ b/pilot/pkg/model/jwks_resolver.go
@@ -314,7 +314,7 @@ func (r *JwksResolver) resolveJwksURIUsingOpenID(issuer string) (string, error) 
 		log.Errorf("Failed to fetch jwks_uri from %q: %v", issuer+openIDDiscoveryCfgURLSuffix, err)
 		return "", err
 	}
-	var data map[string]interface{}
+	var data map[string]any
 	if err := json.Unmarshal(body, &data); err != nil {
 		return "", err
 	}
@@ -435,7 +435,7 @@ func (r *JwksResolver) refresh() bool {
 	var wg sync.WaitGroup
 	hasChange := false
 	hasErrors := false
-	r.keyEntries.Range(func(key interface{}, value interface{}) bool {
+	r.keyEntries.Range(func(key any, value any) bool {
 		now := time.Now()
 		k := key.(jwtKey)
 		e := value.(jwtPubKeyEntry)
@@ -532,8 +532,8 @@ func compareJWKSResponse(oldKeyString string, newKeyString string) (bool, error)
 		return false, nil
 	}
 
-	var oldJWKs map[string]interface{}
-	var newJWKs map[string]interface{}
+	var oldJWKs map[string]any
+	var newJWKs map[string]any
 	if err := json.Unmarshal([]byte(newKeyString), &newJWKs); err != nil {
 		// If the new key is not parseable as JSON return an error since we will not want to use this key
 		log.Warnf("New JWKs public key JSON is not parseable: %s", newKeyString)
@@ -545,12 +545,12 @@ func compareJWKSResponse(oldKeyString string, newKeyString string) (bool, error)
 	}
 
 	// Sort both sets of keys by "kid (key ID)" to be able to directly compare
-	oldKeys, oldKeysExists := oldJWKs["keys"].([]interface{})
-	newKeys, newKeysExists := newJWKs["keys"].([]interface{})
+	oldKeys, oldKeysExists := oldJWKs["keys"].([]any)
+	newKeys, newKeysExists := newJWKs["keys"].([]any)
 	if oldKeysExists && newKeysExists {
 		sort.Slice(oldKeys, func(i, j int) bool {
-			key1, ok1 := oldKeys[i].(map[string]interface{})
-			key2, ok2 := oldKeys[j].(map[string]interface{})
+			key1, ok1 := oldKeys[i].(map[string]any)
+			key2, ok2 := oldKeys[j].(map[string]any)
 			if ok1 && ok2 {
 				key1Id, kid1Exists := key1["kid"]
 				key2Id, kid2Exists := key2["kid"]
@@ -565,8 +565,8 @@ func compareJWKSResponse(oldKeyString string, newKeyString string) (bool, error)
 			return len(key1) < len(key2)
 		})
 		sort.Slice(newKeys, func(i, j int) bool {
-			key1, ok1 := newKeys[i].(map[string]interface{})
-			key2, ok2 := newKeys[j].(map[string]interface{})
+			key1, ok1 := newKeys[i].(map[string]any)
+			key2, ok2 := newKeys[j].(map[string]any)
 			if ok1 && ok2 {
 				key1Id, kid1Exists := key1["kid"]
 				key2Id, kid2Exists := key2["kid"]

--- a/pilot/pkg/model/jwks_resolver_test.go
+++ b/pilot/pkg/model/jwks_resolver_test.go
@@ -378,7 +378,7 @@ func TestJwtRefreshIntervalRecoverFromInitialFailOnFirstHit(t *testing.T) {
 	r.Close()
 
 	i := 0
-	r.keyEntries.Range(func(_ interface{}, _ interface{}) bool {
+	r.keyEntries.Range(func(_ any, _ any) bool {
 		i++
 		return true
 	})

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -831,7 +831,7 @@ func (ep *IstioEndpoint) DeepCopy() *IstioEndpoint {
 	return copyInternal(ep).(*IstioEndpoint)
 }
 
-func copyInternal(v interface{}) interface{} {
+func copyInternal(v any) any {
 	copied, err := copystructure.Copy(v)
 	if err != nil {
 		// There are 2 locations where errors are generated in copystructure.Copy:

--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -121,7 +121,7 @@ type SidecarScope struct {
 // MarshalJSON implements json.Marshaller
 func (sc *SidecarScope) MarshalJSON() ([]byte, error) {
 	// Json cannot expose unexported fields, so copy the ones we want here
-	return json.MarshalIndent(map[string]interface{}{
+	return json.MarshalIndent(map[string]any{
 		"version":               sc.Version,
 		"rootNamespace":         sc.RootNamespace,
 		"name":                  sc.Name,

--- a/pilot/pkg/model/telemetry.go
+++ b/pilot/pkg/model/telemetry.go
@@ -74,7 +74,7 @@ type Telemetries struct {
 	// The computedMetricsFilters lifetime is bound to the Telemetries object. During a push context
 	// creation, we will preserve the Telemetries (and thus the cache) if not Telemetries are modified.
 	// As result, this cache will live until any Telemetry is modified.
-	computedMetricsFilters map[metricsKey]interface{}
+	computedMetricsFilters map[metricsKey]any
 	computedLoggingConfig  map[loggingKey]LoggingConfig
 	mu                     sync.Mutex
 }
@@ -109,7 +109,7 @@ func getTelemetries(env *Environment) (*Telemetries, error) {
 		NamespaceToTelemetries: map[string][]Telemetry{},
 		RootNamespace:          env.Mesh().GetRootNamespace(),
 		meshConfig:             env.Mesh(),
-		computedMetricsFilters: map[metricsKey]interface{}{},
+		computedMetricsFilters: map[metricsKey]any{},
 		computedLoggingConfig:  map[loggingKey]LoggingConfig{},
 	}
 
@@ -416,7 +416,7 @@ func (t *Telemetries) applicableTelemetries(proxy *Proxy) computedTelemetries {
 // set of applicable Telemetries, merges them, then translates to the appropriate filters based on the
 // extension providers in the mesh config. Where possible, the result is cached.
 // Currently, this includes metrics and access logging, as some providers are implemented in filters.
-func (t *Telemetries) telemetryFilters(proxy *Proxy, class networking.ListenerClass, protocol networking.ListenerProtocol) interface{} {
+func (t *Telemetries) telemetryFilters(proxy *Proxy, class networking.ListenerClass, protocol networking.ListenerProtocol) any {
 	if t == nil {
 		return nil
 	}
@@ -466,7 +466,7 @@ func (t *Telemetries) telemetryFilters(proxy *Proxy, class networking.ListenerCl
 		m = append(m, cfg)
 	}
 
-	var res interface{}
+	var res any
 	// Finally, compute the actual filters based on the protoc
 	switch protocol {
 	case networking.ListenerProtocolHTTP:

--- a/pilot/pkg/model/xds_cache.go
+++ b/pilot/pkg/model/xds_cache.go
@@ -188,7 +188,7 @@ func (l *lruCache) recordDependentConfigSize() {
 }
 
 // This is the callback passed to LRU, it will be called whenever a key is removed.
-func (l *lruCache) onEvict(k interface{}, v interface{}) {
+func (l *lruCache) onEvict(k any, v any) {
 	if features.EnableXDSCacheMetrics {
 		if l.evictedOnClear {
 			xdsCacheEvictsionsOnClear.Increment()

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -27,7 +27,7 @@ import (
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"github.com/golang/protobuf/ptypes/duration"
-	any "google.golang.org/protobuf/types/known/anypb"
+	anypb "google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/structpb"
 	wrappers "google.golang.org/protobuf/types/known/wrapperspb"
@@ -638,7 +638,7 @@ func (cb *ClusterBuilder) buildDefaultPassthroughCluster() *cluster.Cluster {
 		ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_ORIGINAL_DST},
 		ConnectTimeout:       cb.req.Push.Mesh.ConnectTimeout,
 		LbPolicy:             cluster.Cluster_CLUSTER_PROVIDED,
-		TypedExtensionProtocolOptions: map[string]*any.Any{
+		TypedExtensionProtocolOptions: map[string]*anypb.Any{
 			v3.HttpProtocolOptionsType: passthroughHttpProtocolOptions,
 		},
 	}
@@ -1229,7 +1229,7 @@ func (mc *MutableCluster) build() *cluster.Cluster {
 				},
 			}
 		}
-		mc.cluster.TypedExtensionProtocolOptions = map[string]*any.Any{
+		mc.cluster.TypedExtensionProtocolOptions = map[string]*anypb.Any{
 			v3.HttpProtocolOptionsType: protoconv.MessageToAny(mc.httpProtocolOptions),
 		}
 	}

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
@@ -3550,7 +3550,7 @@ func TestApplyConnectionPool(t *testing.T) {
 func TestBuildExternalSDSClusters(t *testing.T) {
 	proxy := &model.Proxy{
 		Metadata: &model.NodeMetadata{
-			Raw: map[string]interface{}{
+			Raw: map[string]any{
 				security.CredentialMetaDataName: "true",
 			},
 		},

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -2611,7 +2611,7 @@ func TestBuildStaticClusterWithCredentialSocket(t *testing.T) {
 		Services: []*model.Service{service},
 	})
 	proxy := cg.SetupProxy(nil)
-	proxy.Metadata.Raw = map[string]interface{}{
+	proxy.Metadata.Raw = map[string]any{
 		security.CredentialMetaDataName: "true",
 	}
 	// Expect sds_external cluster be added if credentialSocket exists

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/cluster_patch.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/cluster_patch.go
@@ -34,7 +34,7 @@ import (
 func ApplyClusterMerge(pctx networking.EnvoyFilter_PatchContext, efw *model.EnvoyFilterWrapper,
 	c *cluster.Cluster, hosts []host.Name,
 ) (out *cluster.Cluster) {
-	defer runtime.HandleCrash(runtime.LogPanic, func(interface{}) {
+	defer runtime.HandleCrash(runtime.LogPanic, func(any) {
 		log.Errorf("clusters patch caused panic, so the patches did not take effect")
 		IncrementEnvoyFilterErrorMetric(Cluster)
 	})

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch.go
@@ -41,7 +41,7 @@ func ApplyListenerPatches(
 	listeners []*xdslistener.Listener,
 	skipAdds bool,
 ) (out []*xdslistener.Listener) {
-	defer runtime.HandleCrash(runtime.LogPanic, func(interface{}) {
+	defer runtime.HandleCrash(runtime.LogPanic, func(any) {
 		IncrementEnvoyFilterErrorMetric(Listener)
 		log.Errorf("listeners patch caused panic, so the patches did not take effect")
 	})

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch.go
@@ -21,7 +21,7 @@ import (
 	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"google.golang.org/protobuf/proto"
-	any "google.golang.org/protobuf/types/known/anypb"
+	anypb "google.golang.org/protobuf/types/known/anypb"
 
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"
@@ -384,7 +384,7 @@ func patchNetworkFilter(patchContext networking.EnvoyFilter_PatchContext,
 			if userFilter.Name != "" {
 				filterName = userFilter.Name
 			}
-			var retVal *any.Any
+			var retVal *anypb.Any
 			if userFilter.GetTypedConfig() != nil {
 				IncrementEnvoyFilterMetric(lp.Key(), NetworkFilter, true)
 				// user has any typed struct
@@ -570,7 +570,7 @@ func patchHTTPFilter(patchContext networking.EnvoyFilter_PatchContext,
 			if userHTTPFilter.Name != "" {
 				httpFilterName = userHTTPFilter.Name
 			}
-			var retVal *any.Any
+			var retVal *anypb.Any
 			if userHTTPFilter.GetTypedConfig() != nil {
 				// user has any typed struct
 				// The type may not match up exactly. For example, if we use v2 internally but they use v3.

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch_test.go
@@ -1832,7 +1832,7 @@ func TestApplyListenerPatches(t *testing.T) {
 		ConfigNamespace: "not-default",
 		Metadata: &model.NodeMetadata{
 			IstioVersion: "1.2.2",
-			Raw: map[string]interface{}{
+			Raw: map[string]any{
 				"foo": "sidecar",
 				"bar": "proxy",
 			},
@@ -1844,7 +1844,7 @@ func TestApplyListenerPatches(t *testing.T) {
 		ConfigNamespace: "not-default",
 		Metadata: &model.NodeMetadata{
 			IstioVersion: "1.2.2",
-			Raw: map[string]interface{}{
+			Raw: map[string]any{
 				"foo": "sidecar",
 				"bar": "proxy",
 			},
@@ -1986,7 +1986,7 @@ func BenchmarkTelemetryV2Filters(b *testing.B) {
 		ConfigNamespace: "not-default",
 		Metadata: &model.NodeMetadata{
 			IstioVersion: "1.2.2",
-			Raw: map[string]interface{}{
+			Raw: map[string]any{
 				"foo": "sidecar",
 				"bar": "proxy",
 			},
@@ -1997,7 +1997,7 @@ func BenchmarkTelemetryV2Filters(b *testing.B) {
 	push := model.NewPushContext()
 	_ = push.InitContext(e, nil, nil)
 
-	var got interface{}
+	var got any
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		copied := proto.Clone(l)

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/rc_patch.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/rc_patch.go
@@ -35,7 +35,7 @@ func ApplyRouteConfigurationPatches(
 	efw *model.EnvoyFilterWrapper,
 	routeConfiguration *route.RouteConfiguration,
 ) (out *route.RouteConfiguration) {
-	defer runtime.HandleCrash(runtime.LogPanic, func(interface{}) {
+	defer runtime.HandleCrash(runtime.LogPanic, func(any) {
 		IncrementEnvoyFilterErrorMetric(Route)
 		log.Errorf("route patch caused panic, so the patches did not take effect")
 	})

--- a/pilot/pkg/networking/core/v1alpha3/fake.go
+++ b/pilot/pkg/networking/core/v1alpha3/fake.go
@@ -55,7 +55,7 @@ type TestOptions struct {
 	// If provided, the yaml string will be parsed and used as configs
 	ConfigString string
 	// If provided, the ConfigString will be treated as a go template, with this as input params
-	ConfigTemplateInput interface{}
+	ConfigTemplateInput any
 
 	// Services to pre-populate as part of the service discovery
 	Services  []*model.Service

--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -28,7 +28,7 @@ import (
 	matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	xdstype "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
-	any "google.golang.org/protobuf/types/known/anypb"
+	anypb "google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
 	wrappers "google.golang.org/protobuf/types/known/wrapperspb"
 
@@ -453,7 +453,7 @@ func translateRoute(
 		Operation: getRouteOperation(out, virtualService.Name, listenPort),
 	}
 	if in.Fault != nil {
-		out.TypedPerFilterConfig = make(map[string]*any.Any)
+		out.TypedPerFilterConfig = make(map[string]*anypb.Any)
 		out.TypedPerFilterConfig[wellknown.Fault] = protoconv.MessageToAny(translateFault(in.Fault))
 	}
 

--- a/pilot/pkg/networking/grpcgen/grpcgen_test.go
+++ b/pilot/pkg/networking/grpcgen/grpcgen_test.go
@@ -166,8 +166,8 @@ func TestGRPC(t *testing.T) {
 	// This does not attempt to resolve CDS or EDS.
 	t.Run("gRPC-resolve", func(t *testing.T) {
 		rb := xdsresolver
-		stateCh := &Channel{ch: make(chan interface{}, 1)}
-		errorCh := &Channel{ch: make(chan interface{}, 1)}
+		stateCh := &Channel{ch: make(chan any, 1)}
+		errorCh := &Channel{ch: make(chan any, 1)}
 		_, err := rb.Build(resolver.Target{URL: url.URL{
 			Scheme: "xds",
 			Path:   "/" + net.JoinHostPort(istiodSvcHost, xdsPorts),
@@ -428,11 +428,11 @@ func testRBAC(t *testing.T, grpcServer *xdsgrpc.GRPCServer, xdsresolver resolver
 }
 
 type Channel struct {
-	ch chan interface{}
+	ch chan any
 }
 
 // Send sends value on the underlying channel.
-func (c *Channel) Send(value interface{}) {
+func (c *Channel) Send(value any) {
 	c.ch <- value
 }
 

--- a/pilot/pkg/security/authz/builder/logger.go
+++ b/pilot/pkg/security/authz/builder/logger.go
@@ -32,7 +32,7 @@ type AuthzLogger struct {
 	errMsg   *multierror.Error
 }
 
-func (al *AuthzLogger) AppendDebugf(format string, args ...interface{}) {
+func (al *AuthzLogger) AppendDebugf(format string, args ...any) {
 	al.debugMsg = append(al.debugMsg, fmt.Sprintf(format, args...))
 }
 

--- a/pilot/pkg/security/authz/model/generator_test.go
+++ b/pilot/pkg/security/authz/model/generator_test.go
@@ -32,7 +32,7 @@ func TestGenerator(t *testing.T) {
 		key    string
 		value  string
 		forTCP bool
-		want   interface{}
+		want   any
 	}{
 		{
 			name:  "destIPGenerator",
@@ -276,7 +276,7 @@ func TestGenerator(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			var got interface{}
+			var got any
 			var err error
 			// nolint: gocritic
 			if _, ok := tc.want.(*rbacpb.Permission); ok {

--- a/pilot/pkg/serviceregistry/kube/controller/autoserviceexportcontroller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/autoserviceexportcontroller.go
@@ -67,7 +67,7 @@ func newAutoServiceExportController(opts autoServiceExportOptions) *autoServiceE
 
 	c.serviceInformer = opts.Client.KubeInformer().Core().V1().Services().Informer()
 	c.serviceInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) { c.onServiceAdd(obj) },
+		AddFunc: func(obj any) { c.onServiceAdd(obj) },
 
 		// Do nothing on update. The controller only acts on parts of the service
 		// that are immutable (e.g. name).
@@ -80,7 +80,7 @@ func newAutoServiceExportController(opts autoServiceExportOptions) *autoServiceE
 	return c
 }
 
-func (c *autoServiceExportController) onServiceAdd(obj interface{}) {
+func (c *autoServiceExportController) onServiceAdd(obj any) {
 	c.queue.Push(func() error {
 		if !c.mcsSupported {
 			// Don't create ServiceExport if MCS is not supported on the cluster.

--- a/pilot/pkg/serviceregistry/kube/controller/discoverycontrollers.go
+++ b/pilot/pkg/serviceregistry/kube/controller/discoverycontrollers.go
@@ -48,7 +48,7 @@ func (c *Controller) initDiscoveryNamespaceHandlers(
 ) {
 	otype := "Namespaces"
 	c.nsInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+		AddFunc: func(obj any) {
 			incrementEvent(otype, "add")
 			ns := obj.(*v1.Namespace)
 			if discoveryNamespacesFilter.NamespaceCreated(ns.ObjectMeta) {
@@ -58,7 +58,7 @@ func (c *Controller) initDiscoveryNamespaceHandlers(
 				})
 			}
 		},
-		UpdateFunc: func(old, new interface{}) {
+		UpdateFunc: func(old, new any) {
 			incrementEvent(otype, "update")
 			oldNs := old.(*v1.Namespace)
 			newNs := new.(*v1.Namespace)
@@ -79,7 +79,7 @@ func (c *Controller) initDiscoveryNamespaceHandlers(
 				c.queue.Push(handleFunc)
 			}
 		},
-		DeleteFunc: func(obj interface{}) {
+		DeleteFunc: func(obj any) {
 			incrementEvent(otype, "delete")
 			ns, ok := obj.(*v1.Namespace)
 			if !ok {

--- a/pilot/pkg/serviceregistry/kube/controller/endpointcontroller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpointcontroller.go
@@ -35,14 +35,14 @@ type kubeEndpointsController interface {
 	HasSynced() bool
 	Run(stopCh <-chan struct{})
 	getInformer() filter.FilteredSharedIndexInformer
-	onEvent(curr interface{}, event model.Event) error
+	onEvent(curr any, event model.Event) error
 	InstancesByPort(c *Controller, svc *model.Service, reqSvcPort int, labelsList labels.Instance) []*model.ServiceInstance
 	GetProxyServiceInstances(c *Controller, proxy *model.Proxy) []*model.ServiceInstance
-	buildIstioEndpoints(ep interface{}, host host.Name) []*model.IstioEndpoint
+	buildIstioEndpoints(ep any, host host.Name) []*model.IstioEndpoint
 	buildIstioEndpointsWithService(name, namespace string, host host.Name, clearCache bool) []*model.IstioEndpoint
 	// forgetEndpoint does internal bookkeeping on a deleted endpoint
-	forgetEndpoint(endpoint interface{}) map[host.Name][]*model.IstioEndpoint
-	getServiceNamespacedName(ep interface{}) types.NamespacedName
+	forgetEndpoint(endpoint any) map[host.Name][]*model.IstioEndpoint
+	getServiceNamespacedName(ep any) types.NamespacedName
 }
 
 // kubeEndpoints abstracts the common behavior across endpoint and endpoint slices.
@@ -60,7 +60,7 @@ func (e *kubeEndpoints) Run(stopCh <-chan struct{}) {
 }
 
 // processEndpointEvent triggers the config update.
-func processEndpointEvent(c *Controller, epc kubeEndpointsController, name string, namespace string, event model.Event, ep interface{}) error {
+func processEndpointEvent(c *Controller, epc kubeEndpointsController, name string, namespace string, event model.Event, ep any) error {
 	// Update internal endpoint cache no matter what kind of service, even headless service.
 	// As for gateways, the cluster discovery type is `EDS` for headless service.
 	updateEDS(c, epc, ep, event)
@@ -88,7 +88,7 @@ func processEndpointEvent(c *Controller, epc kubeEndpointsController, name strin
 	return nil
 }
 
-func updateEDS(c *Controller, epc kubeEndpointsController, ep interface{}, event model.Event) {
+func updateEDS(c *Controller, epc kubeEndpointsController, ep any, event model.Event) {
 	namespacedName := epc.getServiceNamespacedName(ep)
 	log.Debugf("Handle EDS endpoint %s %s in namespace %s", namespacedName.Name, event, namespacedName.Namespace)
 	var forgottenEndpointsByHost map[host.Name][]*model.IstioEndpoint

--- a/pilot/pkg/serviceregistry/kube/controller/endpoints.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpoints.go
@@ -138,7 +138,7 @@ func (e *endpointsController) getInformer() filter.FilteredSharedIndexInformer {
 	return e.informer
 }
 
-func (e *endpointsController) onEvent(curr interface{}, event model.Event) error {
+func (e *endpointsController) onEvent(curr any, event model.Event) error {
 	ep, ok := curr.(*v1.Endpoints)
 	if !ok {
 		tombstone, ok := curr.(cache.DeletedFinalStateUnknown)
@@ -156,7 +156,7 @@ func (e *endpointsController) onEvent(curr interface{}, event model.Event) error
 	return processEndpointEvent(e.c, e, ep.Name, ep.Namespace, event, ep)
 }
 
-func (e *endpointsController) forgetEndpoint(endpoint interface{}) map[host.Name][]*model.IstioEndpoint {
+func (e *endpointsController) forgetEndpoint(endpoint any) map[host.Name][]*model.IstioEndpoint {
 	ep := endpoint.(*v1.Endpoints)
 	key := kube.KeyFunc(ep.Name, ep.Namespace)
 	for _, ss := range ep.Subsets {
@@ -167,7 +167,7 @@ func (e *endpointsController) forgetEndpoint(endpoint interface{}) map[host.Name
 	return make(map[host.Name][]*model.IstioEndpoint)
 }
 
-func (e *endpointsController) buildIstioEndpoints(endpoint interface{}, host host.Name) []*model.IstioEndpoint {
+func (e *endpointsController) buildIstioEndpoints(endpoint any, host host.Name) []*model.IstioEndpoint {
 	var endpoints []*model.IstioEndpoint
 	ep := endpoint.(*v1.Endpoints)
 
@@ -250,14 +250,14 @@ func (e *endpointsController) buildIstioEndpointsWithService(name, namespace str
 	return e.buildIstioEndpoints(ep, host)
 }
 
-func (e *endpointsController) getServiceNamespacedName(ep interface{}) types.NamespacedName {
+func (e *endpointsController) getServiceNamespacedName(ep any) types.NamespacedName {
 	endpoint := ep.(*v1.Endpoints)
 	return kube.NamespacedNameForK8sObject(endpoint)
 }
 
 // endpointsEqual returns true if the two endpoints are the same in aspects Pilot cares about
 // This currently means only looking at "Ready" endpoints
-func endpointsEqual(first, second interface{}) bool {
+func endpointsEqual(first, second any) bool {
 	a := first.(*v1.Endpoints)
 	b := second.(*v1.Endpoints)
 	if len(a.Subsets) != len(b.Subsets) {

--- a/pilot/pkg/serviceregistry/kube/controller/endpointslice.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpointslice.go
@@ -87,18 +87,18 @@ func (esc *endpointSliceController) getInformer() filter.FilteredSharedIndexInfo
 	return esc.informer
 }
 
-func (esc *endpointSliceController) listSlices(ns string, selector klabels.Selector) (slices []interface{}, err error) {
+func (esc *endpointSliceController) listSlices(ns string, selector klabels.Selector) (slices []any, err error) {
 	if esc.useV1Resource {
 		var eps []*v1.EndpointSlice
 		eps, err = listerv1.NewEndpointSliceLister(esc.informer.GetIndexer()).EndpointSlices(ns).List(selector)
-		slices = make([]interface{}, len(eps))
+		slices = make([]any, len(eps))
 		for i, ep := range eps {
 			slices[i] = ep
 		}
 	} else {
 		var eps []*v1beta1.EndpointSlice
 		eps, err = listerv1beta1.NewEndpointSliceLister(esc.informer.GetIndexer()).EndpointSlices(ns).List(selector)
-		slices = make([]interface{}, len(eps))
+		slices = make([]any, len(eps))
 		for i, ep := range eps {
 			slices[i] = ep
 		}
@@ -106,7 +106,7 @@ func (esc *endpointSliceController) listSlices(ns string, selector klabels.Selec
 	return
 }
 
-func (esc *endpointSliceController) onEvent(curr interface{}, event model.Event) error {
+func (esc *endpointSliceController) onEvent(curr any, event model.Event) error {
 	ep, ok := curr.(metav1.Object)
 	if !ok {
 		tombstone, ok := curr.(cache.DeletedFinalStateUnknown)
@@ -150,7 +150,7 @@ func serviceNameForEndpointSlice(labels map[string]string) string {
 	return labels[v1beta1.LabelServiceName]
 }
 
-func (esc *endpointSliceController) sliceServiceInstances(c *Controller, slice interface{}, proxy *model.Proxy) []*model.ServiceInstance {
+func (esc *endpointSliceController) sliceServiceInstances(c *Controller, slice any, proxy *model.Proxy) []*model.ServiceInstance {
 	var out []*model.ServiceInstance
 	ep := wrapEndpointSlice(slice)
 	if ep.AddressType() == v1.AddressTypeFQDN {
@@ -196,7 +196,7 @@ func (esc *endpointSliceController) sliceServiceInstances(c *Controller, slice i
 	return out
 }
 
-func (esc *endpointSliceController) forgetEndpoint(endpoint interface{}) map[host.Name][]*model.IstioEndpoint {
+func (esc *endpointSliceController) forgetEndpoint(endpoint any) map[host.Name][]*model.IstioEndpoint {
 	slice := wrapEndpointSlice(endpoint)
 	key := kube.KeyFunc(slice.Name, slice.Namespace)
 	for _, e := range slice.Endpoints() {
@@ -216,12 +216,12 @@ func (esc *endpointSliceController) forgetEndpoint(endpoint interface{}) map[hos
 	return out
 }
 
-func (esc *endpointSliceController) buildIstioEndpoints(es interface{}, hostName host.Name) []*model.IstioEndpoint {
+func (esc *endpointSliceController) buildIstioEndpoints(es any, hostName host.Name) []*model.IstioEndpoint {
 	esc.updateEndpointCacheForSlice(hostName, es)
 	return esc.endpointCache.Get(hostName)
 }
 
-func (esc *endpointSliceController) updateEndpointCacheForSlice(hostName host.Name, ep interface{}) {
+func (esc *endpointSliceController) updateEndpointCacheForSlice(hostName host.Name, ep any) {
 	var endpoints []*model.IstioEndpoint
 	slice := wrapEndpointSlice(ep)
 	if slice.AddressType() == v1.AddressTypeFQDN {
@@ -286,7 +286,7 @@ func (esc *endpointSliceController) buildIstioEndpointsWithService(name, namespa
 	return esc.endpointCache.Get(hostName)
 }
 
-func (esc *endpointSliceController) getServiceNamespacedName(es interface{}) types.NamespacedName {
+func (esc *endpointSliceController) getServiceNamespacedName(es any) types.NamespacedName {
 	slice := es.(metav1.Object)
 	return types.NamespacedName{
 		Namespace: slice.GetNamespace(),
@@ -439,7 +439,7 @@ func endpointSliceSelectorForService(name string) klabels.Selector {
 	}).AsSelectorPreValidated().Add(*endpointSliceRequirement)
 }
 
-func wrapEndpointSlice(slice interface{}) *endpointSliceWrapper {
+func wrapEndpointSlice(slice any) *endpointSliceWrapper {
 	switch es := slice.(type) {
 	case *v1.EndpointSlice:
 		return &endpointSliceWrapper{ObjectMeta: es.ObjectMeta, v1: es}

--- a/pilot/pkg/serviceregistry/kube/controller/filter/discoverynamespaces.go
+++ b/pilot/pkg/serviceregistry/kube/controller/filter/discoverynamespaces.go
@@ -30,7 +30,7 @@ import (
 // It exposes a filter function used for filtering out objects that don't reside in namespaces selected for discovery.
 type DiscoveryNamespacesFilter interface {
 	// Filter returns true if the input object resides in a namespace selected for discovery
-	Filter(obj interface{}) bool
+	Filter(obj any) bool
 	// SelectorsChanged is invoked when meshConfig's discoverySelectors change, returns any newly selected namespaces and deselected namespaces
 	SelectorsChanged(discoverySelectors []*metav1.LabelSelector) (selectedNamespaces []string, deselectedNamespaces []string)
 	// SyncNamespaces is invoked when namespace informer hasSynced before other controller SyncAll
@@ -66,7 +66,7 @@ func NewDiscoveryNamespacesFilter(
 	return discoveryNamespacesFilter
 }
 
-func (d *discoveryNamespacesFilter) Filter(obj interface{}) bool {
+func (d *discoveryNamespacesFilter) Filter(obj any) bool {
 	d.lock.RLock()
 	defer d.lock.RUnlock()
 	// permit all objects if discovery selectors are not specified

--- a/pilot/pkg/serviceregistry/kube/controller/filter/informer.go
+++ b/pilot/pkg/serviceregistry/kube/controller/filter/informer.go
@@ -28,7 +28,7 @@ type FilteredSharedIndexInformer interface {
 }
 
 type filteredSharedIndexInformer struct {
-	filterFunc func(obj interface{}) bool
+	filterFunc func(obj any) bool
 	cache.SharedIndexInformer
 	filteredIndexer *filteredIndexer
 }
@@ -36,7 +36,7 @@ type filteredSharedIndexInformer struct {
 // NewFilteredSharedIndexInformer wraps a SharedIndexInformer's handlers and indexer with a filter predicate,
 // which scopes the processed objects to only those that satisfy the predicate
 func NewFilteredSharedIndexInformer(
-	filterFunc func(obj interface{}) bool,
+	filterFunc func(obj any) bool,
 	sharedIndexInformer cache.SharedIndexInformer,
 ) FilteredSharedIndexInformer {
 	_ = sharedIndexInformer.SetTransform(kube.StripUnusedFields)
@@ -50,19 +50,19 @@ func NewFilteredSharedIndexInformer(
 // AddEventHandler filters incoming objects before forwarding to event handler
 func (w *filteredSharedIndexInformer) AddEventHandler(handler cache.ResourceEventHandler) {
 	w.SharedIndexInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+		AddFunc: func(obj any) {
 			if !w.filterFunc(obj) {
 				return
 			}
 			handler.OnAdd(obj)
 		},
-		UpdateFunc: func(old, new interface{}) {
+		UpdateFunc: func(old, new any) {
 			if !w.filterFunc(new) {
 				return
 			}
 			handler.OnUpdate(old, new)
 		},
-		DeleteFunc: func(obj interface{}) {
+		DeleteFunc: func(obj any) {
 			if !w.filterFunc(obj) {
 				return
 			}
@@ -85,12 +85,12 @@ func (w *filteredSharedIndexInformer) GetIndexer() cache.Indexer {
 }
 
 type filteredIndexer struct {
-	filterFunc func(obj interface{}) bool
+	filterFunc func(obj any) bool
 	cache.Indexer
 }
 
 func newFilteredIndexer(
-	filterFunc func(obj interface{}) bool,
+	filterFunc func(obj any) bool,
 	indexer cache.Indexer,
 ) *filteredIndexer {
 	return &filteredIndexer{
@@ -99,9 +99,9 @@ func newFilteredIndexer(
 	}
 }
 
-func (w filteredIndexer) List() []interface{} {
+func (w filteredIndexer) List() []any {
 	unfiltered := w.Indexer.List()
-	var filtered []interface{}
+	var filtered []any
 	for _, obj := range unfiltered {
 		if w.filterFunc(obj) {
 			filtered = append(filtered, obj)
@@ -110,7 +110,7 @@ func (w filteredIndexer) List() []interface{} {
 	return filtered
 }
 
-func (w filteredIndexer) GetByKey(key string) (item interface{}, exists bool, err error) {
+func (w filteredIndexer) GetByKey(key string) (item any, exists bool, err error) {
 	item, exists, err = w.Indexer.GetByKey(key)
 	if !exists || err != nil {
 		return nil, exists, err

--- a/pilot/pkg/serviceregistry/kube/controller/pod.go
+++ b/pilot/pkg/serviceregistry/kube/controller/pod.go
@@ -126,7 +126,7 @@ func (pc *PodCache) labelFilter(old, cur interface{}) bool {
 }
 
 // onEvent updates the IP-based index (pc.podsByIP).
-func (pc *PodCache) onEvent(curr interface{}, ev model.Event) error {
+func (pc *PodCache) onEvent(curr any, ev model.Event) error {
 	// When a pod is deleted obj could be an *v1.Pod or a DeletionFinalStateUnknown marker item.
 	pod, ok := curr.(*v1.Pod)
 	if !ok {

--- a/pilot/pkg/serviceregistry/kube/controller/serviceexportcache.go
+++ b/pilot/pkg/serviceregistry/kube/controller/serviceexportcache.go
@@ -112,7 +112,7 @@ type serviceExportCacheImpl struct {
 	clusterSetLocalPolicySelector discoverabilityPolicySelector
 }
 
-func (ec *serviceExportCacheImpl) onServiceExportEvent(obj interface{}, event model.Event) error {
+func (ec *serviceExportCacheImpl) onServiceExportEvent(obj any, event model.Event) error {
 	se, ok := obj.(*unstructured.Unstructured)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)

--- a/pilot/pkg/serviceregistry/kube/controller/serviceimportcache.go
+++ b/pilot/pkg/serviceregistry/kube/controller/serviceimportcache.go
@@ -139,7 +139,7 @@ func (ic *serviceImportCacheImpl) onServiceEvent(svc *model.Service, event model
 	})
 }
 
-func (ic *serviceImportCacheImpl) onServiceImportEvent(obj interface{}, event model.Event) error {
+func (ic *serviceImportCacheImpl) onServiceImportEvent(obj any, event model.Event) error {
 	si, ok := obj.(*unstructured.Unstructured)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
@@ -232,8 +232,8 @@ func (ic *serviceImportCacheImpl) doFullPush(mcsHost host.Name, ns string) {
 // Exported for testing only.
 func GetServiceImportIPs(si *unstructured.Unstructured) []string {
 	var ips []string
-	if spec, ok := si.Object["spec"].(map[string]interface{}); ok {
-		if rawIPs, ok := spec["ips"].([]interface{}); ok {
+	if spec, ok := si.Object["spec"].(map[string]any); ok {
+		if rawIPs, ok := spec["ips"].([]any); ok {
 			for _, rawIP := range rawIPs {
 				ip := rawIP.(string)
 				if net.ParseIP(ip) != nil {

--- a/pilot/pkg/serviceregistry/kube/controller/serviceimportcache_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/serviceimportcache_test.go
@@ -545,7 +545,7 @@ func newServiceImport(importType mcsapi.ServiceImportType, vips []string) *unstr
 	return toUnstructured(si)
 }
 
-func toUnstructured(o interface{}) *unstructured.Unstructured {
+func toUnstructured(o any) *unstructured.Unstructured {
 	u, err := runtime.DefaultUnstructuredConverter.ToUnstructured(o)
 	if err != nil {
 		panic(err)

--- a/pilot/pkg/serviceregistry/kube/controller/util.go
+++ b/pilot/pkg/serviceregistry/kube/controller/util.go
@@ -215,7 +215,7 @@ func podKeyByProxy(proxy *model.Proxy) string {
 	return ""
 }
 
-func extractService(obj interface{}) (*v1.Service, error) {
+func extractService(obj any) (*v1.Service, error) {
 	cm, ok := obj.(*v1.Service)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)

--- a/pilot/pkg/serviceregistry/serviceentry/conversion_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion_test.go
@@ -1230,11 +1230,11 @@ func TestConvertWorkloadEntryToWorkloadInstance(t *testing.T) {
 	}
 }
 
-func compare(t testing.TB, actual, expected interface{}) error {
+func compare(t testing.TB, actual, expected any) error {
 	return util.Compare(jsonBytes(t, actual), jsonBytes(t, expected))
 }
 
-func jsonBytes(t testing.TB, v interface{}) []byte {
+func jsonBytes(t testing.TB, v any) []byte {
 	data, err := json.MarshalIndent(v, "", " ")
 	if err != nil {
 		t.Fatal(t)

--- a/pilot/pkg/serviceregistry/serviceregistry_test.go
+++ b/pilot/pkg/serviceregistry/serviceregistry_test.go
@@ -1218,7 +1218,7 @@ func expectServiceInstances(t *testing.T, sd serviceregistry.Instance, svc *mode
 	}, retry.Converge(2), retry.Timeout(time.Second*2), retry.Delay(time.Millisecond*10))
 }
 
-func compare(t *testing.T, actual, expected interface{}) error {
+func compare(t *testing.T, actual, expected any) error {
 	return util.Compare(jsonBytes(t, actual), jsonBytes(t, expected))
 }
 
@@ -1231,7 +1231,7 @@ func sortServiceInstances(instances []*model.ServiceInstance) {
 	})
 }
 
-func jsonBytes(t *testing.T, v interface{}) []byte {
+func jsonBytes(t *testing.T, v any) []byte {
 	data, err := json.MarshalIndent(v, "", " ")
 	if err != nil {
 		t.Fatal(t)

--- a/pilot/pkg/status/distribution/resourcelock.go
+++ b/pilot/pkg/status/distribution/resourcelock.go
@@ -14,4 +14,4 @@
 
 package distribution
 
-type ResourceStatus interface{}
+type ResourceStatus any

--- a/pilot/pkg/status/distribution/state.go
+++ b/pilot/pkg/status/distribution/state.go
@@ -73,7 +73,7 @@ func NewController(restConfig *rest.Config, namespace string, cs model.ConfigSto
 		StaleInterval:   time.Minute,
 		clock:           clock.RealClock{},
 		configStore:     cs,
-		workers: m.CreateIstioStatusController(func(status *v1alpha1.IstioStatus, context interface{}) *v1alpha1.IstioStatus {
+		workers: m.CreateIstioStatusController(func(status *v1alpha1.IstioStatus, context any) *v1alpha1.IstioStatus {
 			if status == nil {
 				return nil
 			}
@@ -240,15 +240,15 @@ type DistroReportHandler struct {
 	dc *Controller
 }
 
-func (drh *DistroReportHandler) OnAdd(obj interface{}) {
+func (drh *DistroReportHandler) OnAdd(obj any) {
 	drh.HandleNew(obj)
 }
 
-func (drh *DistroReportHandler) OnUpdate(oldObj, newObj interface{}) {
+func (drh *DistroReportHandler) OnUpdate(oldObj, newObj any) {
 	drh.HandleNew(newObj)
 }
 
-func (drh *DistroReportHandler) HandleNew(obj interface{}) {
+func (drh *DistroReportHandler) HandleNew(obj any) {
 	cm, ok := obj.(*v1.ConfigMap)
 	if !ok {
 		scope.Warnf("expected configmap, but received %v, discarding", obj)
@@ -264,6 +264,6 @@ func (drh *DistroReportHandler) HandleNew(obj interface{}) {
 	drh.dc.handleReport(dr)
 }
 
-func (drh *DistroReportHandler) OnDelete(obj interface{}) {
+func (drh *DistroReportHandler) OnDelete(obj any) {
 	// TODO: what do we do here?  will these ever be deleted?
 }

--- a/pilot/pkg/status/distribution/state_test.go
+++ b/pilot/pkg/status/distribution/state_test.go
@@ -151,7 +151,7 @@ func Test_getTypedStatus(t *testing.T) {
 	b, _ := json.Marshal(statusStillPropagating)
 	_ = json.Unmarshal(b, &x)
 	type args struct {
-		in interface{}
+		in any
 	}
 	tests := []struct {
 		name    string

--- a/pilot/pkg/status/manager.go
+++ b/pilot/pkg/status/manager.go
@@ -36,7 +36,7 @@ type Manager struct {
 }
 
 func NewManager(store model.ConfigStore) *Manager {
-	writeFunc := func(m *config.Config, istatus interface{}) {
+	writeFunc := func(m *config.Config, istatus any) {
 		scope.Debugf("writing status for resource %s/%s", m.Namespace, m.Name)
 		status := istatus.(GenerationProvider)
 		m.Status = status.Unwrap()
@@ -87,8 +87,8 @@ func (m *Manager) CreateGenericController(fn UpdateFunc) *Controller {
 	return result
 }
 
-func (m *Manager) CreateIstioStatusController(fn func(status *v1alpha1.IstioStatus, context interface{}) *v1alpha1.IstioStatus) *Controller {
-	wrapper := func(status interface{}, context interface{}) GenerationProvider {
+func (m *Manager) CreateIstioStatusController(fn func(status *v1alpha1.IstioStatus, context any) *v1alpha1.IstioStatus) *Controller {
+	wrapper := func(status any, context any) GenerationProvider {
 		var input *v1alpha1.IstioStatus
 		if status != nil {
 			converted := status.(*IstioGenerationProvider)
@@ -104,7 +104,7 @@ func (m *Manager) CreateIstioStatusController(fn func(status *v1alpha1.IstioStat
 	return result
 }
 
-type UpdateFunc func(status interface{}, context interface{}) GenerationProvider
+type UpdateFunc func(status any, context any) GenerationProvider
 
 type Controller struct {
 	fn      UpdateFunc
@@ -115,7 +115,7 @@ type Controller struct {
 // update the status of target, using the information in context.  Once the status
 // workers are ready to perform this update, the controller's UpdateFunc
 // will be called with target and context as input.
-func (c *Controller) EnqueueStatusUpdateResource(context interface{}, target Resource) {
+func (c *Controller) EnqueueStatusUpdateResource(context any, target Resource) {
 	// TODO: buffer this with channel
 	c.workers.Push(target, c, context)
 }

--- a/pilot/pkg/status/resource.go
+++ b/pilot/pkg/status/resource.go
@@ -109,14 +109,14 @@ func ResourceToModelConfig(c Resource) config.Meta {
 	}
 }
 
-func GetTypedStatus(in interface{}) (out *v1alpha1.IstioStatus, err error) {
+func GetTypedStatus(in any) (out *v1alpha1.IstioStatus, err error) {
 	if ret, ok := in.(*v1alpha1.IstioStatus); ok {
 		return ret, nil
 	}
 	return nil, fmt.Errorf("cannot cast %T: %v to IstioStatus", in, in)
 }
 
-func GetOGProvider(in interface{}) (out GenerationProvider, err error) {
+func GetOGProvider(in any) (out GenerationProvider, err error) {
 	if ret, ok := in.(*v1alpha1.IstioStatus); ok {
 		return &IstioGenerationProvider{ret}, nil
 	}

--- a/pilot/pkg/status/resourcelock_test.go
+++ b/pilot/pkg/status/resourcelock_test.go
@@ -50,7 +50,7 @@ func TestResourceLock_Lock(t *testing.T) {
 	x := make(chan struct{})
 	y := make(chan struct{})
 	mgr := NewManager(nil)
-	fakefunc := func(status *v1alpha1.IstioStatus, context interface{}) *v1alpha1.IstioStatus {
+	fakefunc := func(status *v1alpha1.IstioStatus, context any) *v1alpha1.IstioStatus {
 		x <- struct{}{}
 		atomic.AddInt32(&runCount, 1)
 		y <- struct{}{}
@@ -58,7 +58,7 @@ func TestResourceLock_Lock(t *testing.T) {
 	}
 	c1 := mgr.CreateIstioStatusController(fakefunc)
 	c2 := mgr.CreateIstioStatusController(fakefunc)
-	workers := NewWorkerPool(func(_ *config.Config, _ interface{}) {
+	workers := NewWorkerPool(func(_ *config.Config, _ any) {
 	}, func(resource Resource) *config.Config {
 		return &config.Config{
 			Meta: config.Meta{Generation: 11},

--- a/pilot/pkg/util/runtime/runtime.go
+++ b/pilot/pkg/util/runtime/runtime.go
@@ -21,7 +21,7 @@ import (
 )
 
 // LogPanic logs the caller tree when a panic occurs.
-func LogPanic(r interface{}) {
+func LogPanic(r any) {
 	// Same as stdlib http server code. Manually allocate stack trace buffer size
 	// to prevent excessively large logs
 	const size = 64 << 10
@@ -31,7 +31,7 @@ func LogPanic(r interface{}) {
 }
 
 // HandleCrash catches the crash and calls additional handlers.
-func HandleCrash(handlers ...func(interface{})) {
+func HandleCrash(handlers ...func(any)) {
 	if r := recover(); r != nil {
 		for _, handler := range handlers {
 			handler(r)

--- a/pilot/pkg/util/runtime/runtime_test.go
+++ b/pilot/pkg/util/runtime/runtime_test.go
@@ -41,7 +41,7 @@ func TestCustomHandleCrash(t *testing.T) {
 		}
 	}()
 
-	defer HandleCrash(func(interface{}) {
+	defer HandleCrash(func(any) {
 		ch <- struct{}{}
 	})
 

--- a/pilot/pkg/xds/bench_test.go
+++ b/pilot/pkg/xds/bench_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/Masterminds/sprig/v3"
 	cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
-	any "google.golang.org/protobuf/types/known/anypb"
+	anypb "google.golang.org/protobuf/types/known/anypb"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
@@ -283,7 +283,7 @@ func BenchmarkEndpointGeneration(b *testing.B) {
 			proxy.SetSidecarScope(push)
 			b.ResetTimer()
 			for n := 0; n < b.N; n++ {
-				loadAssignments := make([]*any.Any, 0)
+				loadAssignments := make([]*anypb.Any, 0)
 				for svc := 0; svc < tt.services; svc++ {
 					l := s.Discovery.generateEndpoints(NewEndpointBuilder(fmt.Sprintf("outbound|80||foo-%d.com", svc), proxy, push))
 					loadAssignments = append(loadAssignments, protoconv.MessageToAny(l))

--- a/pilot/pkg/xds/bootstrapds.go
+++ b/pilot/pkg/xds/bootstrapds.go
@@ -70,7 +70,7 @@ func (e *BootstrapGenerator) applyPatches(bs *bootstrapv3.Bootstrap, proxy *mode
 	if patches == nil {
 		return bs
 	}
-	defer runtime.HandleCrash(runtime.LogPanic, func(interface{}) {
+	defer runtime.HandleCrash(runtime.LogPanic, func(any) {
 		envoyfilter.IncrementEnvoyFilterErrorMetric(envoyfilter.Bootstrap)
 		log.Errorf("bootstrap patch caused panic, so the patches did not take effect")
 	})

--- a/pilot/pkg/xds/debug.go
+++ b/pilot/pkg/xds/debug.go
@@ -32,7 +32,7 @@ import (
 	tls "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"google.golang.org/protobuf/proto"
-	any "google.golang.org/protobuf/types/known/anypb"
+	anypb "google.golang.org/protobuf/types/known/anypb"
 
 	"istio.io/istio/pilot/pkg/config/kube/crd"
 	"istio.io/istio/pilot/pkg/features"
@@ -790,7 +790,7 @@ func (s *DiscoveryServer) configDump(conn *Connection, includeEds bool) (*admina
 		return nil, err
 	}
 
-	var endpointsAny *any.Any
+	var endpointsAny *anypb.Any
 	// EDS is disabled by default for compatibility with Envoy config_dump interface
 	if includeEds {
 		endpoints, err := generate(v3.EndpointType)
@@ -816,7 +816,7 @@ func (s *DiscoveryServer) configDump(conn *Connection, includeEds bool) (*admina
 	scopedRoutesAny := protoconv.MessageToAny(&adminapi.ScopedRoutesConfigDump{})
 	// The config dump must have all configs with connections specified in
 	// https://www.envoyproxy.io/docs/envoy/latest/api-v2/admin/v2alpha/config_dump.proto
-	configs := []*any.Any{
+	configs := []*anypb.Any{
 		bootstrapAny,
 		clustersAny,
 	}

--- a/pilot/pkg/xds/debug.go
+++ b/pilot/pkg/xds/debug.go
@@ -622,7 +622,7 @@ func (s *DiscoveryServer) ecdsz(w http.ResponseWriter, req *http.Request) {
 			return
 		}
 
-		wasmCfgs := make([]interface{}, 0, len(resource))
+		wasmCfgs := make([]any, 0, len(resource))
 		for _, rr := range resource {
 			if w, err := unmarshalToWasm(rr); err != nil {
 				istiolog.Warnf("failed to unmarshal wasm: %v", err)
@@ -635,7 +635,7 @@ func (s *DiscoveryServer) ecdsz(w http.ResponseWriter, req *http.Request) {
 	}
 }
 
-func unmarshalToWasm(r *discovery.Resource) (interface{}, error) {
+func unmarshalToWasm(r *discovery.Resource) (any, error) {
 	tce := &core.TypedExtensionConfig{}
 	if err := r.GetResource().UnmarshalTo(tce); err != nil {
 		return nil, err
@@ -1117,7 +1117,7 @@ func (p jsonMarshalProto) MarshalJSON() ([]byte, error) {
 }
 
 // writeJSON writes a json payload, handling content type, marshaling, and errors
-func writeJSON(w http.ResponseWriter, obj interface{}, req *http.Request) {
+func writeJSON(w http.ResponseWriter, obj any, req *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	var b []byte
 	var err error

--- a/pilot/pkg/xds/debug_test.go
+++ b/pilot/pkg/xds/debug_test.go
@@ -101,7 +101,7 @@ func verifySyncStatus(t *testing.T, s *xds.DiscoveryServer, nodeID string, wantS
 	attempts := 5
 	for i := 0; i < attempts; i++ {
 		gotStatus := getSyncStatus(t, s)
-		var errorHandler func(string, ...interface{})
+		var errorHandler func(string, ...any)
 		if i == attempts-1 {
 			errorHandler = t.Errorf
 		} else {

--- a/pilot/pkg/xds/debuggen.go
+++ b/pilot/pkg/xds/debuggen.go
@@ -23,7 +23,7 @@ import (
 	"strconv"
 
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
-	any "google.golang.org/protobuf/types/known/anypb"
+	anypb "google.golang.org/protobuf/types/known/anypb"
 
 	"istio.io/istio/pilot/pkg/model"
 )
@@ -122,7 +122,7 @@ func (dg *DebugGen) Generate(proxy *model.Proxy, w *model.WatchedResource, req *
 	buffer.Write(response.body.Bytes())
 	res = append(res, &discovery.Resource{
 		Name: resourceName,
-		Resource: &any.Any{
+		Resource: &anypb.Any{
 			TypeUrl: TypeDebug,
 			Value:   buffer.Bytes(),
 		},

--- a/pilot/pkg/xds/eds.go
+++ b/pilot/pkg/xds/eds.go
@@ -19,7 +19,7 @@ import (
 
 	endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
-	any "google.golang.org/protobuf/types/known/anypb"
+	anypb "google.golang.org/protobuf/types/known/anypb"
 
 	networkingapi "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/features"
@@ -419,7 +419,7 @@ func getOutlierDetectionAndLoadBalancerSettings(
 	return outlierDetectionEnabled, lbSettings
 }
 
-func endpointDiscoveryResponse(loadAssignments []*any.Any, version, noncePrefix string) *discovery.DiscoveryResponse {
+func endpointDiscoveryResponse(loadAssignments []*anypb.Any, version, noncePrefix string) *discovery.DiscoveryResponse {
 	out := &discovery.DiscoveryResponse{
 		TypeUrl: v3.EndpointType,
 		// Pilot does not really care for versioning. It always supplies what's currently

--- a/pilot/pkg/xds/fake.go
+++ b/pilot/pkg/xds/fake.go
@@ -80,7 +80,7 @@ type FakeOptions struct {
 	// If provided, the yaml string will be parsed and used as configs
 	ConfigString string
 	// If provided, the ConfigString will be treated as a go template, with this as input params
-	ConfigTemplateInput interface{}
+	ConfigTemplateInput any
 	// If provided, this mesh config will be used
 	MeshConfig      *meshconfig.MeshConfig
 	NetworksWatcher mesh.NetworksWatcher

--- a/pilot/pkg/xds/statusgen.go
+++ b/pilot/pkg/xds/statusgen.go
@@ -21,7 +21,7 @@ import (
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	status "github.com/envoyproxy/go-control-plane/envoy/service/status/v3"
 	"google.golang.org/protobuf/proto"
-	any "google.golang.org/protobuf/types/known/anypb"
+	anypb "google.golang.org/protobuf/types/known/anypb"
 
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/util/protoconv"
@@ -203,7 +203,7 @@ func (sg *StatusGen) pushStatusEvent(typeURL string, data []proto.Message) {
 		return
 	}
 
-	resources := make([]*any.Any, 0, len(data))
+	resources := make([]*anypb.Any, 0, len(data))
 	for _, v := range data {
 		resources = append(resources, protoconv.MessageToAny(v))
 	}

--- a/pilot/pkg/xds/xds_cache_test.go
+++ b/pilot/pkg/xds/xds_cache_test.go
@@ -23,7 +23,7 @@ import (
 
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"go.uber.org/atomic"
-	any "google.golang.org/protobuf/types/known/anypb"
+	anypb "google.golang.org/protobuf/types/known/anypb"
 
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/config"
@@ -32,8 +32,8 @@ import (
 )
 
 var (
-	any1 = &discovery.Resource{Resource: &any.Any{TypeUrl: "foo"}}
-	any2 = &discovery.Resource{Resource: &any.Any{TypeUrl: "bar"}}
+	any1 = &discovery.Resource{Resource: &anypb.Any{TypeUrl: "foo"}}
+	any2 = &discovery.Resource{Resource: &anypb.Any{TypeUrl: "bar"}}
 )
 
 // TestXdsCacheToken is a regression test to ensure that we do not write
@@ -41,7 +41,7 @@ func TestXdsCacheToken(t *testing.T) {
 	c := model.NewXdsCache()
 	n := atomic.NewInt32(0)
 	mkv := func(n int32) *discovery.Resource {
-		return &discovery.Resource{Resource: &any.Any{TypeUrl: fmt.Sprint(n)}}
+		return &discovery.Resource{Resource: &anypb.Any{TypeUrl: fmt.Sprint(n)}}
 	}
 	k := EndpointBuilder{clusterName: "key", service: &model.Service{
 		Hostname: "foo.com",

--- a/pilot/test/xdstest/extract.go
+++ b/pilot/test/xdstest/extract.go
@@ -30,7 +30,7 @@ import (
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"google.golang.org/protobuf/proto"
-	any "google.golang.org/protobuf/types/known/anypb"
+	anypb "google.golang.org/protobuf/types/known/anypb"
 
 	"istio.io/istio/pilot/pkg/util/protoconv"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
@@ -61,7 +61,7 @@ func ExtractRoutesFromListeners(ll []*listener.Listener) []string {
 }
 
 // ExtractSecretResources fetches all referenced SDS resource names from a list of clusters and listeners
-func ExtractSecretResources(t test.Failer, rs []*any.Any) []string {
+func ExtractSecretResources(t test.Failer, rs []*anypb.Any) []string {
 	resourceNames := sets.New()
 	for _, r := range rs {
 		switch r.TypeUrl {
@@ -317,7 +317,7 @@ func ExtractEdsClusterNames(cl []*cluster.Cluster) []string {
 	return res
 }
 
-func ExtractTLSSecrets(t test.Failer, secrets []*any.Any) map[string]*tls.Secret {
+func ExtractTLSSecrets(t test.Failer, secrets []*anypb.Any) map[string]*tls.Secret {
 	res := map[string]*tls.Secret{}
 	for _, a := range secrets {
 		scrt := &tls.Secret{}
@@ -329,7 +329,7 @@ func ExtractTLSSecrets(t test.Failer, secrets []*any.Any) map[string]*tls.Secret
 	return res
 }
 
-func UnmarshalRouteConfiguration(t test.Failer, resp []*any.Any) []*route.RouteConfiguration {
+func UnmarshalRouteConfiguration(t test.Failer, resp []*anypb.Any) []*route.RouteConfiguration {
 	un := make([]*route.RouteConfiguration, 0, len(resp))
 	for _, r := range resp {
 		u := &route.RouteConfiguration{}
@@ -341,7 +341,7 @@ func UnmarshalRouteConfiguration(t test.Failer, resp []*any.Any) []*route.RouteC
 	return un
 }
 
-func UnmarshalClusterLoadAssignment(t test.Failer, resp []*any.Any) []*endpoint.ClusterLoadAssignment {
+func UnmarshalClusterLoadAssignment(t test.Failer, resp []*anypb.Any) []*endpoint.ClusterLoadAssignment {
 	un := make([]*endpoint.ClusterLoadAssignment, 0, len(resp))
 	for _, r := range resp {
 		u := &endpoint.ClusterLoadAssignment{}
@@ -368,7 +368,7 @@ func ToDiscoveryResponse(p interface{}) *discovery.DiscoveryResponse {
 	if len(slice) == 0 {
 		return &discovery.DiscoveryResponse{}
 	}
-	resources := make([]*any.Any, 0, len(slice))
+	resources := make([]*anypb.Any, 0, len(slice))
 	for _, v := range slice {
 		resources = append(resources, protoconv.MessageToAny(v.(proto.Message)))
 	}

--- a/pilot/test/xdstest/extract.go
+++ b/pilot/test/xdstest/extract.go
@@ -363,7 +363,7 @@ func FilterClusters(cl []*cluster.Cluster, f func(c *cluster.Cluster) bool) []*c
 	return res
 }
 
-func ToDiscoveryResponse(p interface{}) *discovery.DiscoveryResponse {
+func ToDiscoveryResponse(p any) *discovery.DiscoveryResponse {
 	slice := InterfaceSlice(p)
 	if len(slice) == 0 {
 		return &discovery.DiscoveryResponse{}
@@ -378,13 +378,13 @@ func ToDiscoveryResponse(p interface{}) *discovery.DiscoveryResponse {
 	}
 }
 
-func InterfaceSlice(slice interface{}) []interface{} {
+func InterfaceSlice(slice any) []any {
 	s := reflect.ValueOf(slice)
 	if s.Kind() != reflect.Slice {
 		panic("InterfaceSlice() given a non-slice type")
 	}
 
-	ret := make([]interface{}, s.Len())
+	ret := make([]any, s.Len())
 
 	for i := 0; i < s.Len(); i++ {
 		ret[i] = s.Index(i).Interface()
@@ -394,7 +394,7 @@ func InterfaceSlice(slice interface{}) []interface{} {
 }
 
 // DumpList will dump a list of protos. To workaround go type issues, call DumpList(t, InterfaceSlice([]proto.Message))
-func DumpList(t test.Failer, protoList []interface{}) []string {
+func DumpList(t test.Failer, protoList []any) []string {
 	res := []string{}
 	for _, i := range protoList {
 		p, ok := i.(proto.Message)
@@ -418,7 +418,7 @@ func Dump(t test.Failer, p proto.Message) string {
 	return s
 }
 
-func MapKeys(mp interface{}) []string {
+func MapKeys(mp any) []string {
 	keys := reflect.ValueOf(mp).MapKeys()
 	res := []string{}
 	for _, k := range keys {

--- a/pilot/test/xdstest/grpc.go
+++ b/pilot/test/xdstest/grpc.go
@@ -35,7 +35,7 @@ type slowClientStream struct {
 	recv, send time.Duration
 }
 
-func (w *slowClientStream) RecvMsg(m interface{}) error {
+func (w *slowClientStream) RecvMsg(m any) error {
 	if w.recv > 0 {
 		safeSleep(w.Context(), w.recv)
 		log.Infof("delayed recv for %v", w.recv)
@@ -43,7 +43,7 @@ func (w *slowClientStream) RecvMsg(m interface{}) error {
 	return w.ClientStream.RecvMsg(m)
 }
 
-func (w *slowClientStream) SendMsg(m interface{}) error {
+func (w *slowClientStream) SendMsg(m any) error {
 	if w.send > 0 {
 		safeSleep(w.Context(), w.send)
 		log.Infof("delayed send for %v", w.send)
@@ -66,7 +66,7 @@ type slowServerStream struct {
 	recv, send time.Duration
 }
 
-func (w *slowServerStream) RecvMsg(m interface{}) error {
+func (w *slowServerStream) RecvMsg(m any) error {
 	if w.recv > 0 {
 		safeSleep(w.Context(), w.recv)
 		log.Infof("delayed recv for %v", w.recv)
@@ -74,7 +74,7 @@ func (w *slowServerStream) RecvMsg(m interface{}) error {
 	return w.ServerStream.RecvMsg(m)
 }
 
-func (w *slowServerStream) SendMsg(m interface{}) error {
+func (w *slowServerStream) SendMsg(m any) error {
 	if w.send > 0 {
 		safeSleep(w.Context(), w.send)
 		log.Infof("delayed send for %v", w.send)
@@ -84,7 +84,7 @@ func (w *slowServerStream) SendMsg(m interface{}) error {
 
 // SlowServerInterceptor is an interceptor that allows injecting delays on Send and Recv
 func SlowServerInterceptor(recv, send time.Duration) grpc.StreamServerInterceptor {
-	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+	return func(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		return handler(srv, &slowServerStream{ss, recv, send})
 	}
 }

--- a/pkg/adsc/adsc.go
+++ b/pkg/adsc/adsc.go
@@ -41,7 +41,7 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/proto"
-	any "google.golang.org/protobuf/types/known/anypb"
+	anypb "google.golang.org/protobuf/types/known/anypb"
 	pstruct "google.golang.org/protobuf/types/known/structpb"
 
 	mcp "istio.io/api/mcp/v1alpha1"
@@ -1211,7 +1211,7 @@ func (a *ADSC) GetEndpoints() map[string]*endpoint.ClusterLoadAssignment {
 	return a.eds
 }
 
-func (a *ADSC) handleMCP(gvk []string, resources []*any.Any) {
+func (a *ADSC) handleMCP(gvk []string, resources []*anypb.Any) {
 	if len(gvk) != 3 {
 		return // Not MCP
 	}

--- a/pkg/adsc/adsc_test.go
+++ b/pkg/adsc/adsc_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/testing/protocmp"
-	any "google.golang.org/protobuf/types/known/anypb"
+	anypb "google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"istio.io/api/label"
@@ -423,12 +423,12 @@ func TestADSC_handleMCP(t *testing.T) {
 
 	tests := []struct {
 		desc              string
-		resources         []*any.Any
+		resources         []*anypb.Any
 		expectedResources [][]string
 	}{
 		{
 			desc: "create-resources",
-			resources: []*any.Any{
+			resources: []*anypb.Any{
 				constructResource("foo1", "foo1.bar.com", "192.1.1.1", "1"),
 				constructResource("foo2", "foo2.bar.com", "192.1.1.2", "1"),
 			},
@@ -439,7 +439,7 @@ func TestADSC_handleMCP(t *testing.T) {
 		},
 		{
 			desc: "create-resources-rev-1",
-			resources: []*any.Any{
+			resources: []*anypb.Any{
 				constructResource("foo1", "foo1.bar.com", "192.1.1.1", "1"),
 				constructResourceWithOptions("foo2", "foo2.bar.com", "192.1.1.2", "1", func(resource *mcp.Resource) {
 					resource.Metadata.Labels = patchLabel(resource.Metadata.Labels, label.IoIstioRev.Name, rev+"wrong") // to del
@@ -455,7 +455,7 @@ func TestADSC_handleMCP(t *testing.T) {
 		},
 		{
 			desc: "create-resources-rev-2",
-			resources: []*any.Any{
+			resources: []*anypb.Any{
 				constructResource("foo1", "foo1.bar.com", "192.1.1.1", "1"),
 				constructResourceWithOptions("foo2", "foo2.bar.com", "192.1.1.2", "1", func(resource *mcp.Resource) {
 					resource.Metadata.Labels = patchLabel(resource.Metadata.Labels, label.IoIstioRev.Name, rev) // to add back
@@ -471,7 +471,7 @@ func TestADSC_handleMCP(t *testing.T) {
 		},
 		{
 			desc: "update-and-create-resources",
-			resources: []*any.Any{
+			resources: []*anypb.Any{
 				constructResource("foo1", "foo1.bar.com", "192.1.1.11", "2"),
 				constructResource("foo2", "foo2.bar.com", "192.1.1.22", "1"),
 				constructResource("foo3", "foo3.bar.com", "192.1.1.3", ""),
@@ -484,7 +484,7 @@ func TestADSC_handleMCP(t *testing.T) {
 		},
 		{
 			desc: "update-delete-and-create-resources",
-			resources: []*any.Any{
+			resources: []*anypb.Any{
 				constructResource("foo2", "foo2.bar.com", "192.1.1.222", "4"),
 				constructResource("foo4", "foo4.bar.com", "192.1.1.4", "1"),
 			},
@@ -495,7 +495,7 @@ func TestADSC_handleMCP(t *testing.T) {
 		},
 		{
 			desc: "update-and-delete-resources",
-			resources: []*any.Any{
+			resources: []*anypb.Any{
 				constructResource("foo2", "foo2.bar.com", "192.2.2.22", "3"),
 				constructResource("foo3", "foo3.bar.com", "192.1.1.33", ""),
 			},
@@ -534,12 +534,12 @@ func TestADSC_handleMCP(t *testing.T) {
 	}
 }
 
-func constructResourceWithOptions(name string, host string, address, version string, options ...func(resource *mcp.Resource)) *any.Any {
+func constructResourceWithOptions(name string, host string, address, version string, options ...func(resource *mcp.Resource)) *anypb.Any {
 	service := &networking.ServiceEntry{
 		Hosts:     []string{host},
 		Addresses: []string{address},
 	}
-	seAny, _ := any.New(service)
+	seAny, _ := anypb.New(service)
 	resource := &mcp.Resource{
 		Metadata: &mcp.Metadata{
 			Name:       "default/" + name,
@@ -553,13 +553,13 @@ func constructResourceWithOptions(name string, host string, address, version str
 		o(resource)
 	}
 
-	resAny, _ := any.New(resource)
-	return &any.Any{
+	resAny, _ := anypb.New(resource)
+	return &anypb.Any{
 		TypeUrl: resAny.TypeUrl,
 		Value:   resAny.Value,
 	}
 }
 
-func constructResource(name string, host string, address, version string) *any.Any {
+func constructResource(name string, host string, address, version string) *anypb.Any {
 	return constructResourceWithOptions(name, host, address, version)
 }

--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -72,7 +72,7 @@ type Config struct {
 }
 
 // toTemplateParams creates a new template configuration for the given configuration.
-func (cfg Config) toTemplateParams() (map[string]interface{}, error) {
+func (cfg Config) toTemplateParams() (map[string]any, error) {
 	opts := make([]option.Instance, 0)
 
 	discHost := strings.Split(cfg.Metadata.ProxyConfig.DiscoveryAddress, ":")[0]
@@ -436,9 +436,9 @@ func getInt64ValueOrDefault(src *wrapperspb.Int64Value, defaultVal int64) int64 
 	return val
 }
 
-type setMetaFunc func(m map[string]interface{}, key string, val string)
+type setMetaFunc func(m map[string]any, key string, val string)
 
-func extractMetadata(envs []string, prefix string, set setMetaFunc, meta map[string]interface{}) {
+func extractMetadata(envs []string, prefix string, set setMetaFunc, meta map[string]any) {
 	metaPrefixLen := len(prefix)
 	for _, e := range envs {
 		if !shouldExtract(e, prefix) {
@@ -524,13 +524,13 @@ type MetadataOptions struct {
 // ISTIO_META_* env variables are passed thru
 func GetNodeMetaData(options MetadataOptions) (*model.Node, error) {
 	meta := &model.BootstrapNodeMetadata{}
-	untypedMeta := map[string]interface{}{}
+	untypedMeta := map[string]any{}
 
-	extractMetadata(options.Envs, IstioMetaPrefix, func(m map[string]interface{}, key string, val string) {
+	extractMetadata(options.Envs, IstioMetaPrefix, func(m map[string]any, key string, val string) {
 		m[key] = val
 	}, untypedMeta)
 
-	extractMetadata(options.Envs, IstioMetaJSONPrefix, func(m map[string]interface{}, key string, val string) {
+	extractMetadata(options.Envs, IstioMetaJSONPrefix, func(m map[string]any, key string, val string) {
 		err := json.Unmarshal([]byte(val), &m)
 		if err != nil {
 			log.Warnf("Env variable %s [%s] failed json unmarshal: %v", key, val, err)

--- a/pkg/bootstrap/config_test.go
+++ b/pkg/bootstrap/config_test.go
@@ -120,13 +120,13 @@ func TestConvertNodeMetadata(t *testing.T) {
 			},
 			Owner: "real-owner",
 		},
-		RawMetadata: map[string]interface{}{},
+		RawMetadata: map[string]any{},
 	}
 	node.Metadata.Owner = "real-owner"
 	node.RawMetadata["OWNER"] = "fake-owner"
 	node.RawMetadata["UNKNOWN"] = "new-field"
 	node.RawMetadata["A"] = 1
-	node.RawMetadata["B"] = map[string]interface{}{"b": 1}
+	node.RawMetadata["B"] = map[string]any{"b": 1}
 
 	out := ConvertNodeToXDSNode(node)
 	{

--- a/pkg/bootstrap/instance.go
+++ b/pkg/bootstrap/instance.go
@@ -76,7 +76,7 @@ func (i *instance) WriteTo(templateFile string, w io.Writer) error {
 	return t.Execute(w, templateParams)
 }
 
-func toJSON(i interface{}) string {
+func toJSON(i any) string {
 	if i == nil {
 		return "{}"
 	}

--- a/pkg/bootstrap/option/instance.go
+++ b/pkg/bootstrap/option/instance.go
@@ -23,8 +23,8 @@ import (
 )
 
 // NewTemplateParams creates a new golang template parameter map from the given list of options.
-func NewTemplateParams(is ...Instance) (map[string]interface{}, error) {
-	params := make(map[string]interface{})
+func NewTemplateParams(is ...Instance) (map[string]any, error) {
+	params := make(map[string]any)
 
 	for _, i := range is {
 		if err := i.apply(params); err != nil {
@@ -47,14 +47,14 @@ type Instance interface {
 	Name() Name
 
 	// apply this option to the given template parameter map.
-	apply(map[string]interface{}) error
+	apply(map[string]any) error
 }
 
 var _ Instance = &instance{}
 
 type (
-	convertFunc func(*instance) (interface{}, error)
-	applyFunc   func(map[string]interface{}, *instance) error
+	convertFunc func(*instance) (any, error)
+	applyFunc   func(map[string]any, *instance) error
 )
 
 type instance struct {
@@ -73,17 +73,17 @@ func (i *instance) withConvert(fn convertFunc) *instance {
 	return &out
 }
 
-func (i *instance) apply(params map[string]interface{}) error {
+func (i *instance) apply(params map[string]any) error {
 	return i.applyFn(params, i)
 }
 
-func newOption(name Name, value interface{}) *instance {
+func newOption(name Name, value any) *instance {
 	return &instance{
 		name: name,
-		convertFn: func(i *instance) (interface{}, error) {
+		convertFn: func(i *instance) (any, error) {
 			return value, nil
 		},
-		applyFn: func(params map[string]interface{}, o *instance) error {
+		applyFn: func(params map[string]any, o *instance) error {
 			convertedValue, err := o.convertFn(o)
 			if err != nil {
 				return err
@@ -98,10 +98,10 @@ func newOption(name Name, value interface{}) *instance {
 func skipOption(name Name) *instance {
 	return &instance{
 		name: name,
-		convertFn: func(*instance) (interface{}, error) {
+		convertFn: func(*instance) (any, error) {
 			return nil, nil
 		},
-		applyFn: func(map[string]interface{}, *instance) error {
+		applyFn: func(map[string]any, *instance) error {
 			// Don't apply the option.
 			return nil
 		},
@@ -115,7 +115,7 @@ func newStringArrayOptionOrSkipIfEmpty(name Name, value []string) *instance {
 	return newOption(name, value)
 }
 
-func newOptionOrSkipIfZero(name Name, value interface{}) *instance {
+func newOptionOrSkipIfZero(name Name, value any) *instance {
 	v := reflect.ValueOf(value)
 	if v.IsZero() {
 		return skipOption(name)

--- a/pkg/bootstrap/option/instances.go
+++ b/pkg/bootstrap/option/instances.go
@@ -80,7 +80,7 @@ func SubZone(value string) Instance {
 	return newOptionOrSkipIfZero("sub_zone", value)
 }
 
-func NodeMetadata(meta *model.BootstrapNodeMetadata, rawMeta map[string]interface{}) Instance {
+func NodeMetadata(meta *model.BootstrapNodeMetadata, rawMeta map[string]any) Instance {
 	return newOptionOrSkipIfZero("meta_json_str", meta).withConvert(nodeMetadataConverter(meta, rawMeta))
 }
 

--- a/pkg/bootstrap/option/instances_test.go
+++ b/pkg/bootstrap/option/instances_test.go
@@ -34,7 +34,7 @@ func TestOptions(t *testing.T) {
 		key         string
 		option      option.Instance
 		expectError bool
-		expected    interface{}
+		expected    any
 	}{
 		{
 			testName: "proxy config",
@@ -109,7 +109,7 @@ func TestOptions(t *testing.T) {
 				NodeMetadata: model.NodeMetadata{
 					IstioVersion: "fake",
 				},
-			}, map[string]interface{}{
+			}, map[string]any{
 				"key": "value",
 			}),
 			expected: "{\"ISTIO_VERSION\":\"fake\",\"key\":\"value\"}",

--- a/pkg/bootstrap/platform/azure.go
+++ b/pkg/bootstrap/platform/azure.go
@@ -47,8 +47,8 @@ var (
 type azureEnv struct {
 	APIVersion      string
 	prefix          string
-	computeMetadata map[string]interface{}
-	networkMetadata map[string]interface{}
+	computeMetadata map[string]any
+	networkMetadata map[string]any
 }
 
 // IsAzure returns whether or not the platform for bootstrapping is Azure
@@ -66,7 +66,7 @@ func IsAzure() bool {
 func (e *azureEnv) updateAPIVersion() {
 	bodyJSON := stringToJSON(azureAPIVersionsFn())
 	if newestVersions, ok := bodyJSON["newest-versions"]; ok {
-		for _, version := range newestVersions.([]interface{}) {
+		for _, version := range newestVersions.([]any) {
 			if strings.Compare(version.(string), e.APIVersion) > 0 {
 				e.APIVersion = version.(string)
 			}
@@ -97,10 +97,10 @@ func (e *azureEnv) prefixName(name string) string {
 func (e *azureEnv) parseMetadata(metadata string) {
 	bodyJSON := stringToJSON(metadata)
 	if computeMetadata, ok := bodyJSON["compute"]; ok {
-		e.computeMetadata = computeMetadata.(map[string]interface{})
+		e.computeMetadata = computeMetadata.(map[string]any)
 	}
 	if networkMetadata, ok := bodyJSON["network"]; ok {
-		e.networkMetadata = networkMetadata.(map[string]interface{})
+		e.networkMetadata = networkMetadata.(map[string]any)
 	}
 }
 
@@ -132,8 +132,8 @@ func metadataRequest(query string) string {
 	return string(body)
 }
 
-func stringToJSON(s string) map[string]interface{} {
-	var stringJSON map[string]interface{}
+func stringToJSON(s string) map[string]any {
+	var stringJSON map[string]any
 	if err := json.Unmarshal([]byte(s), &stringJSON); err != nil {
 		log.Warnf("Could not unmarshal response: %v:", err)
 	}

--- a/pkg/channels/unbounded.go
+++ b/pkg/channels/unbounded.go
@@ -38,19 +38,19 @@ import (
 // defining a new type specific implementation of this buffer is preferred. See
 // internal/transport/transport.go for an example of this.
 type Unbounded struct {
-	c       chan interface{}
+	c       chan any
 	mu      sync.Mutex
-	backlog []interface{}
+	backlog []any
 }
 
 // NewUnbounded returns a new instance of Unbounded.
 func NewUnbounded() *Unbounded {
-	return &Unbounded{c: make(chan interface{}, 1)}
+	return &Unbounded{c: make(chan any, 1)}
 }
 
 // Put adds t to the unbounded buffer.
 // Put will never block
-func (b *Unbounded) Put(t interface{}) {
+func (b *Unbounded) Put(t any) {
 	b.mu.Lock()
 	if len(b.backlog) == 0 {
 		select {
@@ -70,7 +70,7 @@ func (b *Unbounded) Put(t interface{}) {
 func (b *Unbounded) Load() {
 	b.mu.Lock()
 	if len(b.backlog) > 0 {
-		n := new(interface{})
+		n := new(any)
 		select {
 		case b.c <- b.backlog[0]:
 			b.backlog[0] = *n
@@ -86,6 +86,6 @@ func (b *Unbounded) Load() {
 //
 // Upon reading a value from this channel, users are expected to call Load() to
 // send the next buffered value onto the channel if there is any.
-func (b *Unbounded) Get() <-chan interface{} {
+func (b *Unbounded) Get() <-chan any {
 	return b.c
 }

--- a/pkg/config/analysis/analyzers/injection/injection.go
+++ b/pkg/config/analysis/analyzers/injection/injection.go
@@ -158,11 +158,11 @@ func (a *Analyzer) Analyze(c analysis.Context) {
 // GetInjectedConfigMapValuesStruct retrieves value of sidecarInjectorWebhook.enableNamespacesByDefault
 // defined in the sidecar injector configuration.
 func GetEnableNamespacesByDefaultFromInjectedConfigMap(cm *v1.ConfigMap) bool {
-	var injectedCMValues map[string]interface{}
+	var injectedCMValues map[string]any
 	if err := json.Unmarshal([]byte(cm.Data[util.InjectionConfigMapValue]), &injectedCMValues); err != nil {
 		return false
 	}
 
-	injectionEnable := injectedCMValues[util.InjectorWebhookConfigKey].(map[string]interface{})[util.InjectorWebhookConfigValue]
+	injectionEnable := injectedCMValues[util.InjectorWebhookConfigKey].(map[string]any)[util.InjectorWebhookConfigValue]
 	return injectionEnable.(bool)
 }

--- a/pkg/config/analysis/diag/message.go
+++ b/pkg/config/analysis/diag/message.go
@@ -52,7 +52,7 @@ type Message struct {
 	Type *MessageType
 
 	// The Parameters to the message
-	Parameters []interface{}
+	Parameters []any
 
 	// Resource is the underlying resource instance associated with the
 	// message, or nil if no resource is associated with it.
@@ -66,8 +66,8 @@ type Message struct {
 }
 
 // Unstructured returns this message as a JSON-style unstructured map
-func (m *Message) Unstructured(includeOrigin bool) map[string]interface{} {
-	result := make(map[string]interface{})
+func (m *Message) Unstructured(includeOrigin bool) map[string]any {
+	result := make(map[string]any)
 
 	result["code"] = m.Type.Code()
 	result["level"] = m.Type.Level().String()
@@ -110,10 +110,10 @@ func (m *Message) AnalysisMessageBase() *v1alpha1.AnalysisMessageBase {
 
 // UnstructuredAnalysisMessageBase returns this message as a JSON-style unstructured map in AnalaysisMessageBase
 // TODO(jasonwzm): Remove once message implements AnalysisMessageBase
-func (m *Message) UnstructuredAnalysisMessageBase() map[string]interface{} {
+func (m *Message) UnstructuredAnalysisMessageBase() map[string]any {
 	mb := m.AnalysisMessageBase()
 
-	var r map[string]interface{}
+	var r map[string]any
 
 	j, err := json.Marshal(mb)
 	if err != nil {
@@ -162,7 +162,7 @@ func NewMessageType(level Level, code, template string) *MessageType {
 }
 
 // NewMessage returns a new Message instance from an existing type.
-func NewMessage(mt *MessageType, r *resource.Instance, p ...interface{}) Message {
+func NewMessage(mt *MessageType, r *resource.Instance, p ...any) Message {
 	return Message{
 		Type:       mt,
 		Resource:   r,

--- a/pkg/config/analysis/diag/message_test.go
+++ b/pkg/config/analysis/diag/message_test.go
@@ -94,7 +94,7 @@ func TestMessage_UnstructuredAnalysisMessageBase(t *testing.T) {
 	g.Expect(mb["documentationUrl"]).To(Equal(fmt.Sprintf("%s/%s/%s", url.ConfigAnalysis, "ist0042", "?ref=test-ref")))
 	g.Expect(mb["level"]).To(Equal("ERROR"))
 	g.Expect(mb["type"]).To(Equal(
-		map[string]interface{}{
+		map[string]any{
 			"code": "IST0042",
 		},
 	))

--- a/pkg/config/analysis/incluster/controller.go
+++ b/pkg/config/analysis/incluster/controller.go
@@ -62,7 +62,7 @@ func NewController(stop <-chan struct{}, rwConfigStore model.ConfigStoreControll
 	if err != nil {
 		return nil, fmt.Errorf("unable to initialize analysis controller, releasing lease: %s", err)
 	}
-	ctl := statusManager.CreateIstioStatusController(func(status *v1alpha1.IstioStatus, context interface{}) *v1alpha1.IstioStatus {
+	ctl := statusManager.CreateIstioStatusController(func(status *v1alpha1.IstioStatus, context any) *v1alpha1.IstioStatus {
 		msgs := context.(diag.Messages)
 		// zero out analysis messages, as this is the sole controller for those
 		status.ValidationMessages = []*v1alpha12.AnalysisMessageBase{}

--- a/pkg/config/legacy/testing/fixtures/expect.go
+++ b/pkg/config/legacy/testing/fixtures/expect.go
@@ -22,7 +22,7 @@ import (
 )
 
 // ExpectEqual calls CheckEqual and fails the test if it returns an error.
-func ExpectEqual(t *testing.T, o1 interface{}, o2 interface{}) {
+func ExpectEqual(t *testing.T, o1 any, o2 any) {
 	t.Helper()
 	if err := CheckEqual(o1, o2); err != nil {
 		t.Fatal(err)
@@ -30,7 +30,7 @@ func ExpectEqual(t *testing.T, o1 interface{}, o2 interface{}) {
 }
 
 // CheckEqual checks that o1 and o2 are equal. If not, returns an error with the diff.
-func CheckEqual(o1 interface{}, o2 interface{}) error {
+func CheckEqual(o1 any, o2 any) error {
 	if diff := cmp.Diff(o1, o2); diff != "" {
 		return fmt.Errorf(diff)
 	}

--- a/pkg/config/mesh/mesh.go
+++ b/pkg/config/mesh/mesh.go
@@ -159,7 +159,7 @@ func applyProxyConfig(yaml string, proxyConfig *meshconfig.ProxyConfig) (*meshco
 	return proxyConfig, nil
 }
 
-func extractYamlField(key string, mp map[string]interface{}) (string, error) {
+func extractYamlField(key string, mp map[string]any) (string, error) {
 	proxyConfig := mp[key]
 	if proxyConfig == nil {
 		return "", nil
@@ -171,8 +171,8 @@ func extractYamlField(key string, mp map[string]interface{}) (string, error) {
 	return string(bytes), nil
 }
 
-func toMap(yamlText string) (map[string]interface{}, error) {
-	mp := map[string]interface{}{}
+func toMap(yamlText string) (map[string]any, error) {
+	mp := map[string]any{}
 	if err := yaml.Unmarshal([]byte(yamlText), &mp); err != nil {
 		return nil, err
 	}

--- a/pkg/config/model.go
+++ b/pkg/config/model.go
@@ -121,7 +121,7 @@ func ObjectInRevision(o *Config, rev string) bool {
 // * golang/protobuf Message
 // * gogo/protobuf Message
 // * Able to marshal/unmarshal using json
-type Spec interface{}
+type Spec any
 
 func ToProto(s Spec) (*anypb.Any, error) {
 	// golang protobuf. Use protoreflect.ProtoMessage to distinguish from gogo
@@ -154,14 +154,14 @@ func ToProto(s Spec) (*anypb.Any, error) {
 	return anypb.New(pbs)
 }
 
-func ToMap(s Spec) (map[string]interface{}, error) {
+func ToMap(s Spec) (map[string]any, error) {
 	js, err := ToJSON(s)
 	if err != nil {
 		return nil, err
 	}
 
 	// Unmarshal from json bytes to go map
-	var data map[string]interface{}
+	var data map[string]any
 	err = json.Unmarshal(js, &data)
 	if err != nil {
 		return nil, err
@@ -202,7 +202,7 @@ func toJSON(s Spec, pretty bool) ([]byte, error) {
 }
 
 type deepCopier interface {
-	DeepCopyInterface() interface{}
+	DeepCopyInterface() any
 }
 
 func ApplyYAML(s Spec, yml string) error {
@@ -255,7 +255,7 @@ func ApplyJSON(s Spec, js string) error {
 	return json.Unmarshal([]byte(js), &s)
 }
 
-func DeepCopy(s interface{}) interface{} {
+func DeepCopy(s any) any {
 	if s == nil {
 		return nil
 	}
@@ -293,7 +293,7 @@ func DeepCopy(s interface{}) interface{} {
 	return data
 }
 
-type Status interface{}
+type Status any
 
 // Key function for the configuration objects
 func Key(grp, ver, typ, name, namespace string) string {

--- a/pkg/config/model_test.go
+++ b/pkg/config/model_test.go
@@ -296,47 +296,47 @@ func TestToJSON(t *testing.T) {
 func TestToMap(t *testing.T) {
 	cases := []struct {
 		input Spec
-		mp    map[string]interface{}
+		mp    map[string]any
 	}{
 		// Istio type
 		{
 			input: &networking.VirtualService{Gateways: []string{"foobar"}},
-			mp: map[string]interface{}{
-				"gateways": []interface{}{"foobar"},
+			mp: map[string]any{
+				"gateways": []any{"foobar"},
 			},
 		},
 		// Kubernetes type
 		{
 			input: &corev1.PodSpec{ServiceAccountName: "foobar"},
-			mp: map[string]interface{}{
+			mp: map[string]any{
 				"serviceAccountName": "foobar",
 			},
 		},
 		// gateway-api type
 		{
 			input: &v1alpha2.GatewayClassSpec{ControllerName: "foobar"},
-			mp: map[string]interface{}{
+			mp: map[string]any{
 				"controllerName": "foobar",
 			},
 		},
 		// mock type
 		{
 			input: &config.MockConfig{Key: "foobar"},
-			mp: map[string]interface{}{
+			mp: map[string]any{
 				"key": "foobar",
 			},
 		},
 		// XDS type, to test golang/proto
 		{
 			input: &cluster.Cluster{Name: "foobar"},
-			mp: map[string]interface{}{
+			mp: map[string]any{
 				"name": "foobar",
 			},
 		},
 		// Random struct
 		{
 			input: &TestStruct{Name: "foobar"},
-			mp: map[string]interface{}{
+			mp: map[string]any{
 				"name": "foobar",
 			},
 		},

--- a/pkg/config/schema/codegen/common.go
+++ b/pkg/config/schema/codegen/common.go
@@ -24,7 +24,7 @@ const (
 	commentLinePrefix = "// "
 )
 
-func applyTemplate(tmpl string, i interface{}) (string, error) {
+func applyTemplate(tmpl string, i any) (string, error) {
 	t := template.New("tmpl").Funcs(template.FuncMap{
 		"wordWrap":     wordWrap,
 		"commentBlock": commentBlock,

--- a/pkg/config/schema/gvk/resources.gen.go
+++ b/pkg/config/schema/gvk/resources.gen.go
@@ -1,4 +1,3 @@
-
 // GENERATED FILE -- DO NOT EDIT
 //
 
@@ -9,38 +8,38 @@ import (
 )
 
 var (
-	AuthorizationPolicy = config.GroupVersionKind{Group: "security.istio.io", Version: "v1beta1", Kind: "AuthorizationPolicy"}
-	ConfigMap = config.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}
-	CustomResourceDefinition = config.GroupVersionKind{Group: "apiextensions.k8s.io", Version: "v1", Kind: "CustomResourceDefinition"}
-	Deployment = config.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}
-	DestinationRule = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1alpha3", Kind: "DestinationRule"}
-	Endpoints = config.GroupVersionKind{Group: "", Version: "v1", Kind: "Endpoints"}
-	EnvoyFilter = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1alpha3", Kind: "EnvoyFilter"}
-	Gateway = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1alpha3", Kind: "Gateway"}
-	GatewayClass = config.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Kind: "GatewayClass"}
-	HTTPRoute = config.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Kind: "HTTPRoute"}
-	Ingress = config.GroupVersionKind{Group: "extensions", Version: "v1beta1", Kind: "Ingress"}
-	KubernetesGateway = config.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Kind: "Gateway"}
-	MeshConfig = config.GroupVersionKind{Group: "", Version: "v1alpha1", Kind: "MeshConfig"}
-	MeshNetworks = config.GroupVersionKind{Group: "", Version: "v1alpha1", Kind: "MeshNetworks"}
+	AuthorizationPolicy          = config.GroupVersionKind{Group: "security.istio.io", Version: "v1beta1", Kind: "AuthorizationPolicy"}
+	ConfigMap                    = config.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}
+	CustomResourceDefinition     = config.GroupVersionKind{Group: "apiextensions.k8s.io", Version: "v1", Kind: "CustomResourceDefinition"}
+	Deployment                   = config.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}
+	DestinationRule              = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1alpha3", Kind: "DestinationRule"}
+	Endpoints                    = config.GroupVersionKind{Group: "", Version: "v1", Kind: "Endpoints"}
+	EnvoyFilter                  = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1alpha3", Kind: "EnvoyFilter"}
+	Gateway                      = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1alpha3", Kind: "Gateway"}
+	GatewayClass                 = config.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Kind: "GatewayClass"}
+	HTTPRoute                    = config.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Kind: "HTTPRoute"}
+	Ingress                      = config.GroupVersionKind{Group: "extensions", Version: "v1beta1", Kind: "Ingress"}
+	KubernetesGateway            = config.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Kind: "Gateway"}
+	MeshConfig                   = config.GroupVersionKind{Group: "", Version: "v1alpha1", Kind: "MeshConfig"}
+	MeshNetworks                 = config.GroupVersionKind{Group: "", Version: "v1alpha1", Kind: "MeshNetworks"}
 	MutatingWebhookConfiguration = config.GroupVersionKind{Group: "admissionregistration.k8s.io", Version: "v1", Kind: "MutatingWebhookConfiguration"}
-	Namespace = config.GroupVersionKind{Group: "", Version: "v1", Kind: "Namespace"}
-	Node = config.GroupVersionKind{Group: "", Version: "v1", Kind: "Node"}
-	PeerAuthentication = config.GroupVersionKind{Group: "security.istio.io", Version: "v1beta1", Kind: "PeerAuthentication"}
-	Pod = config.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"}
-	ProxyConfig = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1beta1", Kind: "ProxyConfig"}
-	ReferenceGrant = config.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Kind: "ReferenceGrant"}
-	ReferencePolicy = config.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Kind: "ReferencePolicy"}
-	RequestAuthentication = config.GroupVersionKind{Group: "security.istio.io", Version: "v1beta1", Kind: "RequestAuthentication"}
-	Secret = config.GroupVersionKind{Group: "", Version: "v1", Kind: "Secret"}
-	Service = config.GroupVersionKind{Group: "", Version: "v1", Kind: "Service"}
-	ServiceEntry = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1alpha3", Kind: "ServiceEntry"}
-	Sidecar = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1alpha3", Kind: "Sidecar"}
-	TCPRoute = config.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Kind: "TCPRoute"}
-	TLSRoute = config.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Kind: "TLSRoute"}
-	Telemetry = config.GroupVersionKind{Group: "telemetry.istio.io", Version: "v1alpha1", Kind: "Telemetry"}
-	VirtualService = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1alpha3", Kind: "VirtualService"}
-	WasmPlugin = config.GroupVersionKind{Group: "extensions.istio.io", Version: "v1alpha1", Kind: "WasmPlugin"}
-	WorkloadEntry = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1alpha3", Kind: "WorkloadEntry"}
-	WorkloadGroup = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1alpha3", Kind: "WorkloadGroup"}
+	Namespace                    = config.GroupVersionKind{Group: "", Version: "v1", Kind: "Namespace"}
+	Node                         = config.GroupVersionKind{Group: "", Version: "v1", Kind: "Node"}
+	PeerAuthentication           = config.GroupVersionKind{Group: "security.istio.io", Version: "v1beta1", Kind: "PeerAuthentication"}
+	Pod                          = config.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"}
+	ProxyConfig                  = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1beta1", Kind: "ProxyConfig"}
+	ReferenceGrant               = config.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Kind: "ReferenceGrant"}
+	ReferencePolicy              = config.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Kind: "ReferencePolicy"}
+	RequestAuthentication        = config.GroupVersionKind{Group: "security.istio.io", Version: "v1beta1", Kind: "RequestAuthentication"}
+	Secret                       = config.GroupVersionKind{Group: "", Version: "v1", Kind: "Secret"}
+	Service                      = config.GroupVersionKind{Group: "", Version: "v1", Kind: "Service"}
+	ServiceEntry                 = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1alpha3", Kind: "ServiceEntry"}
+	Sidecar                      = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1alpha3", Kind: "Sidecar"}
+	TCPRoute                     = config.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Kind: "TCPRoute"}
+	TLSRoute                     = config.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Kind: "TLSRoute"}
+	Telemetry                    = config.GroupVersionKind{Group: "telemetry.istio.io", Version: "v1alpha1", Kind: "Telemetry"}
+	VirtualService               = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1alpha3", Kind: "VirtualService"}
+	WasmPlugin                   = config.GroupVersionKind{Group: "extensions.istio.io", Version: "v1alpha1", Kind: "WasmPlugin"}
+	WorkloadEntry                = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1alpha3", Kind: "WorkloadEntry"}
+	WorkloadGroup                = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1alpha3", Kind: "WorkloadGroup"}
 )

--- a/pkg/config/schema/gvk/resources.gen.go
+++ b/pkg/config/schema/gvk/resources.gen.go
@@ -1,3 +1,4 @@
+
 // GENERATED FILE -- DO NOT EDIT
 //
 
@@ -8,38 +9,38 @@ import (
 )
 
 var (
-	AuthorizationPolicy          = config.GroupVersionKind{Group: "security.istio.io", Version: "v1beta1", Kind: "AuthorizationPolicy"}
-	ConfigMap                    = config.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}
-	CustomResourceDefinition     = config.GroupVersionKind{Group: "apiextensions.k8s.io", Version: "v1", Kind: "CustomResourceDefinition"}
-	Deployment                   = config.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}
-	DestinationRule              = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1alpha3", Kind: "DestinationRule"}
-	Endpoints                    = config.GroupVersionKind{Group: "", Version: "v1", Kind: "Endpoints"}
-	EnvoyFilter                  = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1alpha3", Kind: "EnvoyFilter"}
-	Gateway                      = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1alpha3", Kind: "Gateway"}
-	GatewayClass                 = config.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Kind: "GatewayClass"}
-	HTTPRoute                    = config.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Kind: "HTTPRoute"}
-	Ingress                      = config.GroupVersionKind{Group: "extensions", Version: "v1beta1", Kind: "Ingress"}
-	KubernetesGateway            = config.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Kind: "Gateway"}
-	MeshConfig                   = config.GroupVersionKind{Group: "", Version: "v1alpha1", Kind: "MeshConfig"}
-	MeshNetworks                 = config.GroupVersionKind{Group: "", Version: "v1alpha1", Kind: "MeshNetworks"}
+	AuthorizationPolicy = config.GroupVersionKind{Group: "security.istio.io", Version: "v1beta1", Kind: "AuthorizationPolicy"}
+	ConfigMap = config.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}
+	CustomResourceDefinition = config.GroupVersionKind{Group: "apiextensions.k8s.io", Version: "v1", Kind: "CustomResourceDefinition"}
+	Deployment = config.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}
+	DestinationRule = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1alpha3", Kind: "DestinationRule"}
+	Endpoints = config.GroupVersionKind{Group: "", Version: "v1", Kind: "Endpoints"}
+	EnvoyFilter = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1alpha3", Kind: "EnvoyFilter"}
+	Gateway = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1alpha3", Kind: "Gateway"}
+	GatewayClass = config.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Kind: "GatewayClass"}
+	HTTPRoute = config.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Kind: "HTTPRoute"}
+	Ingress = config.GroupVersionKind{Group: "extensions", Version: "v1beta1", Kind: "Ingress"}
+	KubernetesGateway = config.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Kind: "Gateway"}
+	MeshConfig = config.GroupVersionKind{Group: "", Version: "v1alpha1", Kind: "MeshConfig"}
+	MeshNetworks = config.GroupVersionKind{Group: "", Version: "v1alpha1", Kind: "MeshNetworks"}
 	MutatingWebhookConfiguration = config.GroupVersionKind{Group: "admissionregistration.k8s.io", Version: "v1", Kind: "MutatingWebhookConfiguration"}
-	Namespace                    = config.GroupVersionKind{Group: "", Version: "v1", Kind: "Namespace"}
-	Node                         = config.GroupVersionKind{Group: "", Version: "v1", Kind: "Node"}
-	PeerAuthentication           = config.GroupVersionKind{Group: "security.istio.io", Version: "v1beta1", Kind: "PeerAuthentication"}
-	Pod                          = config.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"}
-	ProxyConfig                  = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1beta1", Kind: "ProxyConfig"}
-	ReferenceGrant               = config.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Kind: "ReferenceGrant"}
-	ReferencePolicy              = config.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Kind: "ReferencePolicy"}
-	RequestAuthentication        = config.GroupVersionKind{Group: "security.istio.io", Version: "v1beta1", Kind: "RequestAuthentication"}
-	Secret                       = config.GroupVersionKind{Group: "", Version: "v1", Kind: "Secret"}
-	Service                      = config.GroupVersionKind{Group: "", Version: "v1", Kind: "Service"}
-	ServiceEntry                 = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1alpha3", Kind: "ServiceEntry"}
-	Sidecar                      = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1alpha3", Kind: "Sidecar"}
-	TCPRoute                     = config.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Kind: "TCPRoute"}
-	TLSRoute                     = config.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Kind: "TLSRoute"}
-	Telemetry                    = config.GroupVersionKind{Group: "telemetry.istio.io", Version: "v1alpha1", Kind: "Telemetry"}
-	VirtualService               = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1alpha3", Kind: "VirtualService"}
-	WasmPlugin                   = config.GroupVersionKind{Group: "extensions.istio.io", Version: "v1alpha1", Kind: "WasmPlugin"}
-	WorkloadEntry                = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1alpha3", Kind: "WorkloadEntry"}
-	WorkloadGroup                = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1alpha3", Kind: "WorkloadGroup"}
+	Namespace = config.GroupVersionKind{Group: "", Version: "v1", Kind: "Namespace"}
+	Node = config.GroupVersionKind{Group: "", Version: "v1", Kind: "Node"}
+	PeerAuthentication = config.GroupVersionKind{Group: "security.istio.io", Version: "v1beta1", Kind: "PeerAuthentication"}
+	Pod = config.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"}
+	ProxyConfig = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1beta1", Kind: "ProxyConfig"}
+	ReferenceGrant = config.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Kind: "ReferenceGrant"}
+	ReferencePolicy = config.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Kind: "ReferencePolicy"}
+	RequestAuthentication = config.GroupVersionKind{Group: "security.istio.io", Version: "v1beta1", Kind: "RequestAuthentication"}
+	Secret = config.GroupVersionKind{Group: "", Version: "v1", Kind: "Secret"}
+	Service = config.GroupVersionKind{Group: "", Version: "v1", Kind: "Service"}
+	ServiceEntry = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1alpha3", Kind: "ServiceEntry"}
+	Sidecar = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1alpha3", Kind: "Sidecar"}
+	TCPRoute = config.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Kind: "TCPRoute"}
+	TLSRoute = config.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Kind: "TLSRoute"}
+	Telemetry = config.GroupVersionKind{Group: "telemetry.istio.io", Version: "v1alpha1", Kind: "Telemetry"}
+	VirtualService = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1alpha3", Kind: "VirtualService"}
+	WasmPlugin = config.GroupVersionKind{Group: "extensions.istio.io", Version: "v1alpha1", Kind: "WasmPlugin"}
+	WorkloadEntry = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1alpha3", Kind: "WorkloadEntry"}
+	WorkloadGroup = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1alpha3", Kind: "WorkloadGroup"}
 )

--- a/pkg/config/schema/kind/resources.gen.go
+++ b/pkg/config/schema/kind/resources.gen.go
@@ -1,3 +1,4 @@
+
 // GENERATED FILE -- DO NOT EDIT
 //
 

--- a/pkg/config/schema/kind/resources.gen.go
+++ b/pkg/config/schema/kind/resources.gen.go
@@ -1,4 +1,3 @@
-
 // GENERATED FILE -- DO NOT EDIT
 //
 

--- a/pkg/config/schema/resource/schema.go
+++ b/pkg/config/schema/resource/schema.go
@@ -270,7 +270,7 @@ func (s *schemaImpl) String() string {
 
 func (s *schemaImpl) NewInstance() (config.Spec, error) {
 	rt := s.reflectType
-	var instance interface{}
+	var instance any
 	if rt == nil {
 		// Use proto
 		t, err := protoMessageType(protoreflect.FullName(s.proto))

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -35,7 +35,7 @@ import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/reflect/protoregistry"
 	"google.golang.org/protobuf/types/descriptorpb"
-	any "google.golang.org/protobuf/types/known/anypb"
+	anypb "google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
 
 	"istio.io/api/annotation"
@@ -927,7 +927,7 @@ func recurseDeprecatedTypes(message protoreflect.Message) ([]string, error) {
 	message.Range(func(descriptor protoreflect.FieldDescriptor, value protoreflect.Value) bool {
 		m, isMessage := value.Interface().(protoreflect.Message)
 		if isMessage {
-			anyMessage, isAny := m.Interface().(*any.Any)
+			anyMessage, isAny := m.Interface().(*anypb.Any)
 			if isAny {
 				mt, err := protoregistry.GlobalTypes.FindMessageByURL(anyMessage.TypeUrl)
 				if err != nil {

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -149,7 +149,7 @@ type Validation struct {
 type AnalysisAwareError struct {
 	Type       string
 	Msg        string
-	Parameters []interface{}
+	Parameters []any
 }
 
 // OverlappingMatchValidationForHTTPRoute holds necessary information from virtualservice
@@ -180,7 +180,7 @@ func WrapWarning(e error) Validation {
 
 // Warningf formats according to a format specifier and returns the string as a
 // value that satisfies error. Like Errorf, but for warnings.
-func Warningf(format string, a ...interface{}) Validation {
+func Warningf(format string, a ...any) Validation {
 	return WrapWarning(fmt.Errorf(format, a...))
 }
 
@@ -2247,14 +2247,14 @@ var ValidateVirtualService = registerValidateFunc("ValidateVirtualService",
 			errs = appendValidation(errs, WrapWarning(&AnalysisAwareError{
 				Type:       "VirtualServiceUnreachableRule",
 				Msg:        fmt.Sprintf("virtualService rule %v not used (%s)", ruleno, reason),
-				Parameters: []interface{}{ruleno, reason},
+				Parameters: []any{ruleno, reason},
 			}))
 		}
 		warnIneffective := func(ruleno, matchno, dupno string) {
 			errs = appendValidation(errs, WrapWarning(&AnalysisAwareError{
 				Type:       "VirtualServiceIneffectiveMatch",
 				Msg:        fmt.Sprintf("virtualService rule %v match %v is not used (duplicate/overlapping match in rule %v)", ruleno, matchno, dupno),
-				Parameters: []interface{}{ruleno, matchno, dupno},
+				Parameters: []any{ruleno, matchno, dupno},
 			}))
 		}
 
@@ -2557,7 +2557,7 @@ func analyzeUnreachableTLSRules(routes []*networking.TLSRoute,
 }
 
 // asJSON() creates a JSON serialization of a match, to use for match comparison.  We don't use the JSON itself.
-func asJSON(data interface{}) string {
+func asJSON(data any) string {
 	// Remove the name, so we can create a serialization that only includes traffic routing config
 	switch mr := data.(type) {
 	case *networking.HTTPMatchRequest:
@@ -2576,7 +2576,7 @@ func asJSON(data interface{}) string {
 	return string(b)
 }
 
-func routeName(route interface{}, routen int) string {
+func routeName(route any, routen int) string {
 	switch r := route.(type) {
 	case *networking.HTTPRoute:
 		if r.Name != "" {
@@ -2588,7 +2588,7 @@ func routeName(route interface{}, routen int) string {
 	return fmt.Sprintf("#%d", routen)
 }
 
-func requestName(match interface{}, matchn int) string {
+func requestName(match any, matchn int) string {
 	switch mr := match.(type) {
 	case *networking.HTTPMatchRequest:
 		if mr != nil && mr.Name != "" {
@@ -3410,13 +3410,13 @@ func appendValidation(v Validation, vs ...error) Validation {
 
 // appendErrorf appends a formatted error string
 // nolint: unparam
-func appendErrorf(v Validation, format string, a ...interface{}) Validation {
+func appendErrorf(v Validation, format string, a ...any) Validation {
 	return appendValidation(v, fmt.Errorf(format, a...))
 }
 
 // appendWarningf appends a formatted warning string
 // nolint: unparam
-func appendWarningf(v Validation, format string, a ...interface{}) Validation {
+func appendWarningf(v Validation, format string, a ...any) Validation {
 	return appendValidation(v, Warningf(format, a...))
 }
 

--- a/pkg/dns/proto/nds.pb.go
+++ b/pkg/dns/proto/nds.pb.go
@@ -217,7 +217,7 @@ func file_dns_proto_nds_proto_rawDescGZIP() []byte {
 }
 
 var file_dns_proto_nds_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
-var file_dns_proto_nds_proto_goTypes = []any{
+var file_dns_proto_nds_proto_goTypes = []interface{}{
 	(*NameTable)(nil),          // 0: istio.networking.nds.v1.NameTable
 	(*NameTable_NameInfo)(nil), // 1: istio.networking.nds.v1.NameTable.NameInfo
 	nil,                        // 2: istio.networking.nds.v1.NameTable.TableEntry
@@ -238,7 +238,7 @@ func file_dns_proto_nds_proto_init() {
 		return
 	}
 	if !protoimpl.UnsafeEnabled {
-		file_dns_proto_nds_proto_msgTypes[0].Exporter = func(v any, i int) any {
+		file_dns_proto_nds_proto_msgTypes[0].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*NameTable); i {
 			case 0:
 				return &v.state
@@ -250,7 +250,7 @@ func file_dns_proto_nds_proto_init() {
 				return nil
 			}
 		}
-		file_dns_proto_nds_proto_msgTypes[1].Exporter = func(v any, i int) any {
+		file_dns_proto_nds_proto_msgTypes[1].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*NameTable_NameInfo); i {
 			case 0:
 				return &v.state

--- a/pkg/dns/proto/nds.pb.go
+++ b/pkg/dns/proto/nds.pb.go
@@ -217,7 +217,7 @@ func file_dns_proto_nds_proto_rawDescGZIP() []byte {
 }
 
 var file_dns_proto_nds_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
-var file_dns_proto_nds_proto_goTypes = []interface{}{
+var file_dns_proto_nds_proto_goTypes = []any{
 	(*NameTable)(nil),          // 0: istio.networking.nds.v1.NameTable
 	(*NameTable_NameInfo)(nil), // 1: istio.networking.nds.v1.NameTable.NameInfo
 	nil,                        // 2: istio.networking.nds.v1.NameTable.TableEntry
@@ -238,7 +238,7 @@ func file_dns_proto_nds_proto_init() {
 		return
 	}
 	if !protoimpl.UnsafeEnabled {
-		file_dns_proto_nds_proto_msgTypes[0].Exporter = func(v interface{}, i int) interface{} {
+		file_dns_proto_nds_proto_msgTypes[0].Exporter = func(v any, i int) any {
 			switch v := v.(*NameTable); i {
 			case 0:
 				return &v.state
@@ -250,7 +250,7 @@ func file_dns_proto_nds_proto_init() {
 				return nil
 			}
 		}
-		file_dns_proto_nds_proto_msgTypes[1].Exporter = func(v interface{}, i int) interface{} {
+		file_dns_proto_nds_proto_msgTypes[1].Exporter = func(v any, i int) any {
 			switch v := v.(*NameTable_NameInfo); i {
 			case 0:
 				return &v.state

--- a/pkg/envoy/agent_test.go
+++ b/pkg/envoy/agent_test.go
@@ -61,7 +61,7 @@ var downstreamCxZeroAcStats = "http.admin.downstream_cx_active: 2 \n" +
 type TestProxy struct {
 	run          func(int, <-chan error) error
 	cleanup      func(int)
-	blockChannel chan interface{}
+	blockChannel chan any
 }
 
 func (tp TestProxy) Run(epoch int, stop <-chan error) error {
@@ -106,7 +106,7 @@ func TestStartExit(t *testing.T) {
 func TestStartDrain(t *testing.T) {
 	wantEpoch := 0
 	proxiesStarted, wantProxiesStarted := 0, 1
-	blockChan := make(chan interface{})
+	blockChan := make(chan any)
 	ctx, cancel := context.WithCancel(context.Background())
 	start := func(currentEpoch int, _ <-chan error) error {
 		proxiesStarted++

--- a/pkg/envoy/instance_test.go
+++ b/pkg/envoy/instance_test.go
@@ -483,7 +483,7 @@ func absPath(path string) string {
 
 func newBootstrapFile(t *testing.T, tempDir string, adminPort, listenerPort uint16) string {
 	t.Helper()
-	data := map[string]interface{}{
+	data := map[string]any{
 		"nodeID":       t.Name(),
 		"cluster":      t.Name(),
 		"localhost":    "127.0.0.1",

--- a/pkg/hbone/util.go
+++ b/pkg/hbone/util.go
@@ -26,7 +26,7 @@ import (
 
 // createBuffer to get a buffer. io.Copy uses 32k.
 // experimental use shows ~20k max read with Firefox.
-var bufferPoolCopy = sync.Pool{New: func() interface{} {
+var bufferPoolCopy = sync.Pool{New: func() any {
 	return make([]byte, 0, 32*1024)
 }}
 

--- a/pkg/istio-agent/agent_test.go
+++ b/pkg/istio-agent/agent_test.go
@@ -838,7 +838,7 @@ func filenames(t *testing.T, dir string) []string {
 
 func proxyConfigToMetadata(t *testing.T, proxyConfig *meshconfig.ProxyConfig) model.NodeMetadata {
 	t.Helper()
-	m := map[string]interface{}{}
+	m := map[string]any{}
 	for k, v := range proxyConfig.ProxyMetadata {
 		if strings.HasPrefix(k, bootstrap.IstioMetaPrefix) {
 			m[strings.TrimPrefix(k, bootstrap.IstioMetaPrefix)] = v

--- a/pkg/istio-agent/grpcxds/grpc_bootstrap.go
+++ b/pkg/istio-agent/grpcxds/grpc_bootstrap.go
@@ -51,8 +51,8 @@ type Bootstrap struct {
 }
 
 type ChannelCreds struct {
-	Type   string      `json:"type,omitempty"`
-	Config interface{} `json:"config,omitempty"`
+	Type   string `json:"type,omitempty"`
+	Config any    `json:"config,omitempty"`
 }
 
 type XdsServer struct {
@@ -62,8 +62,8 @@ type XdsServer struct {
 }
 
 type CertificateProvider struct {
-	PluginName string      `json:"plugin_name,omitempty"`
-	Config     interface{} `json:"config,omitempty"`
+	PluginName string `json:"plugin_name,omitempty"`
+	Config     any    `json:"config,omitempty"`
 }
 
 func (cp *CertificateProvider) UnmarshalJSON(data []byte) error {
@@ -209,7 +209,7 @@ func extractMeta(node *model.Node) (*structpb.Struct, error) {
 	if err != nil {
 		return nil, err
 	}
-	rawMeta := map[string]interface{}{}
+	rawMeta := map[string]any{}
 	if err := json.Unmarshal(bytes, &rawMeta); err != nil {
 		return nil, err
 	}

--- a/pkg/istio-agent/xds_proxy.go
+++ b/pkg/istio-agent/xds_proxy.go
@@ -39,7 +39,7 @@ import (
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/reflection"
-	any "google.golang.org/protobuf/types/known/anypb"
+	anypb "google.golang.org/protobuf/types/known/anypb"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/cmd/pilot-agent/status/ready"
@@ -72,7 +72,7 @@ var connectionNumber = atomic.NewUint32(0)
 // ResponseHandler handles a XDS response in the agent. These will not be forwarded to Envoy.
 // Currently, all handlers function on a single resource per type, so the API only exposes one
 // resource.
-type ResponseHandler func(resp *any.Any) error
+type ResponseHandler func(resp *anypb.Any) error
 
 // XdsProxy proxies all XDS requests from envoy to istiod, in addition to allowing
 // subsystems inside the agent to also communicate with either istiod/envoy (eg dns, sds, etc).
@@ -157,7 +157,7 @@ func initXdsProxy(ia *Agent) (*XdsProxy, error) {
 	}
 
 	if ia.localDNSServer != nil {
-		proxy.handlers[v3.NameTableType] = func(resp *any.Any) error {
+		proxy.handlers[v3.NameTableType] = func(resp *anypb.Any) error {
 			var nt dnsProto.NameTable
 			if err := resp.UnmarshalTo(&nt); err != nil {
 				log.Errorf("failed to unmarshal name table: %v", err)
@@ -168,7 +168,7 @@ func initXdsProxy(ia *Agent) (*XdsProxy, error) {
 		}
 	}
 	if ia.cfg.EnableDynamicProxyConfig && ia.secretCache != nil {
-		proxy.handlers[v3.ProxyConfigType] = func(resp *any.Any) error {
+		proxy.handlers[v3.ProxyConfigType] = func(resp *anypb.Any) error {
 			pc := &meshconfig.ProxyConfig{}
 			if err := resp.UnmarshalTo(pc); err != nil {
 				log.Errorf("failed to unmarshal proxy config: %v", err)

--- a/pkg/istio-agent/xds_proxy_delta.go
+++ b/pkg/istio-agent/xds_proxy_delta.go
@@ -23,7 +23,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
-	any "google.golang.org/protobuf/types/known/anypb"
+	anypb "google.golang.org/protobuf/types/known/anypb"
 
 	"istio.io/istio/pilot/pkg/features"
 	istiogrpc "istio.io/istio/pilot/pkg/grpc"
@@ -270,7 +270,7 @@ func (p *XdsProxy) handleUpstreamDeltaResponse(con *ProxyConnection) {
 }
 
 func (p *XdsProxy) deltaRewriteAndForward(con *ProxyConnection, resp *discovery.DeltaDiscoveryResponse, forward func(resp *discovery.DeltaDiscoveryResponse)) {
-	resources := make([]*any.Any, 0, len(resp.Resources))
+	resources := make([]*anypb.Any, 0, len(resp.Resources))
 	for i := range resp.Resources {
 		resources = append(resources, resp.Resources[i].Resource)
 	}

--- a/pkg/kube/controllers/common.go
+++ b/pkg/kube/controllers/common.go
@@ -110,7 +110,7 @@ func EnqueueForParentHandler(q Queue, kind config.GroupVersionKind) func(obj Obj
 // ObjectHandler returns a handler that will act on the latest version of an object
 // This means Add/Update/Delete are all handled the same and are just used to trigger reconciling.
 func ObjectHandler(handler func(o Object)) cache.ResourceEventHandler {
-	h := func(obj interface{}) {
+	h := func(obj any) {
 		o := extractObject(obj)
 		if o == nil {
 			return
@@ -119,7 +119,7 @@ func ObjectHandler(handler func(o Object)) cache.ResourceEventHandler {
 	}
 	return cache.ResourceEventHandlerFuncs{
 		AddFunc: h,
-		UpdateFunc: func(oldObj, newObj interface{}) {
+		UpdateFunc: func(oldObj, newObj any) {
 			h(newObj)
 		},
 		DeleteFunc: h,
@@ -144,7 +144,7 @@ func FilteredObjectSpecHandler(handler func(o Object), filter func(o Object) boo
 }
 
 func filteredObjectHandler(handler func(o Object), onlyIncludeSpecChanges bool, filter func(o Object) bool) cache.ResourceEventHandler {
-	single := func(obj interface{}) {
+	single := func(obj any) {
 		o := extractObject(obj)
 		if o == nil {
 			return
@@ -156,7 +156,7 @@ func filteredObjectHandler(handler func(o Object), onlyIncludeSpecChanges bool, 
 	}
 	return cache.ResourceEventHandlerFuncs{
 		AddFunc: single,
-		UpdateFunc: func(oldInterface, newInterface interface{}) {
+		UpdateFunc: func(oldInterface, newInterface any) {
 			oldObj := extractObject(oldInterface)
 			if oldObj == nil {
 				return
@@ -179,7 +179,7 @@ func filteredObjectHandler(handler func(o Object), onlyIncludeSpecChanges bool, 
 	}
 }
 
-func extractObject(obj interface{}) Object {
+func extractObject(obj any) Object {
 	o, ok := obj.(Object)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)

--- a/pkg/kube/controllers/queue.go
+++ b/pkg/kube/controllers/queue.go
@@ -29,7 +29,7 @@ type Queue struct {
 	initialSync *atomic.Bool
 	name        string
 	maxAttempts int
-	workFn      func(key interface{}) error
+	workFn      func(key any) error
 	log         *istiolog.Scope
 }
 
@@ -57,16 +57,16 @@ func WithMaxAttempts(n int) func(q *Queue) {
 // WithReconciler defines the handler function to handle items in the queue.
 func WithReconciler(f func(key types.NamespacedName) error) func(q *Queue) {
 	return func(q *Queue) {
-		q.workFn = func(key interface{}) error {
+		q.workFn = func(key any) error {
 			return f(key.(types.NamespacedName))
 		}
 	}
 }
 
 // WithGenericReconciler defines the handler function to handle items in the queue that can handle any type
-func WithGenericReconciler(f func(key interface{}) error) func(q *Queue) {
+func WithGenericReconciler(f func(key any) error) func(q *Queue) {
 	return func(q *Queue) {
-		q.workFn = func(key interface{}) error {
+		q.workFn = func(key any) error {
 			return f(key)
 		}
 	}
@@ -89,7 +89,7 @@ func NewQueue(name string, options ...func(*Queue)) Queue {
 }
 
 // Add an item to the queue.
-func (q Queue) Add(item interface{}) {
+func (q Queue) Add(item any) {
 	q.queue.Add(item)
 }
 

--- a/pkg/kube/inject/inject.go
+++ b/pkg/kube/inject/inject.go
@@ -102,7 +102,7 @@ type SidecarTemplateData struct {
 	Spec                 corev1.PodSpec
 	ProxyConfig          *meshconfig.ProxyConfig
 	MeshConfig           *meshconfig.MeshConfig
-	Values               map[string]interface{}
+	Values               map[string]any
 	Revision             string
 	EstimatedConcurrency int
 	ProxyImage           string
@@ -514,7 +514,7 @@ func injectionStatus(pod *corev1.Pod) *SidecarInjectionStatus {
 	return &iStatus
 }
 
-func parseDryTemplate(tmplStr string, funcMap map[string]interface{}) (*template.Template, error) {
+func parseDryTemplate(tmplStr string, funcMap map[string]any) (*template.Template, error) {
 	temp := template.New("inject")
 	t, err := temp.Funcs(sprig.TxtFuncMap()).Funcs(funcMap).Parse(tmplStr)
 	if err != nil {
@@ -602,7 +602,7 @@ func FromRawToObject(raw []byte) (runtime.Object, error) {
 // nolint: lll
 func IntoObject(injector Injector, sidecarTemplate Templates, valuesConfig ValuesConfig,
 	revision string, meshconfig *meshconfig.MeshConfig, in runtime.Object, warningHandler func(string),
-) (interface{}, error) {
+) (any, error) {
 	out := in.DeepCopyObject()
 
 	var deploymentMetadata metav1.ObjectMeta

--- a/pkg/kube/inject/inject_test.go
+++ b/pkg/kube/inject/inject_test.go
@@ -969,7 +969,7 @@ func TestQuantityConversion(t *testing.T) {
 }
 
 func TestProxyImage(t *testing.T) {
-	val := func(hub string, tag interface{}) *opconfig.Values {
+	val := func(hub string, tag any) *opconfig.Values {
 		t, _ := structpb.NewValue(tag)
 		return &opconfig.Values{
 			Global: &opconfig.GlobalConfig{

--- a/pkg/kube/inject/template.go
+++ b/pkg/kube/inject/template.go
@@ -92,7 +92,7 @@ func flippedContains(needle, haystack string) bool {
 	return strings.Contains(haystack, needle)
 }
 
-func excludeInboundPort(port interface{}, excludedInboundPorts string) string {
+func excludeInboundPort(port any, excludedInboundPorts string) string {
 	portStr := strings.TrimSpace(fmt.Sprint(port))
 	if len(portStr) == 0 || portStr == "0" {
 		// Nothing to do.
@@ -118,7 +118,7 @@ func excludeInboundPort(port interface{}, excludedInboundPorts string) string {
 	return strings.Join(outPorts, ",")
 }
 
-func valueOrDefault(value interface{}, defaultValue interface{}) interface{} {
+func valueOrDefault(value any, defaultValue any) any {
 	if value == "" || value == nil {
 		return defaultValue
 	}
@@ -139,8 +139,8 @@ func toJSON(m map[string]string) string {
 	return string(ba)
 }
 
-func fromJSON(j string) interface{} {
-	var m interface{}
+func fromJSON(j string) any {
+	var m any
 	err := json.Unmarshal([]byte(j), &m)
 	if err != nil {
 		log.Warnf("Unable to unmarshal %s", j)
@@ -160,7 +160,7 @@ func indent(spaces int, source string) string {
 	return strings.Join(res, "\n")
 }
 
-func toYaml(value interface{}) string {
+func toYaml(value any) string {
 	y, err := yaml.Marshal(value)
 	if err != nil {
 		log.Warnf("Unable to marshal %v", value)
@@ -170,7 +170,7 @@ func toYaml(value interface{}) string {
 	return string(y)
 }
 
-func getAnnotation(meta metav1.ObjectMeta, name string, defaultValue interface{}) string {
+func getAnnotation(meta metav1.ObjectMeta, name string, defaultValue any) string {
 	value, ok := meta.Annotations[name]
 	if !ok {
 		value = fmt.Sprint(defaultValue)
@@ -185,7 +185,7 @@ func appendMultusNetwork(existingValue, istioCniNetwork string) string {
 	i := strings.LastIndex(existingValue, "]")
 	isJSON := i != -1
 	if isJSON {
-		networks := []map[string]interface{}{}
+		networks := []map[string]any{}
 		err := json.Unmarshal([]byte(existingValue), &networks)
 		if err != nil {
 			// existingValue is not valid JSON; nothing we can do but skip injection
@@ -249,7 +249,7 @@ func excludeInterfaces(s string) string {
 	return s
 }
 
-func structToJSON(v interface{}) string {
+func structToJSON(v any) string {
 	if v == nil {
 		return "{}"
 	}

--- a/pkg/kube/inject/webhook.go
+++ b/pkg/kube/inject/webhook.go
@@ -269,7 +269,7 @@ func ParseTemplates(tmpls RawTemplates) (Templates, error) {
 type ValuesConfig struct {
 	raw      string
 	asStruct *opconfig.Values
-	asMap    map[string]interface{}
+	asMap    map[string]any
 }
 
 func NewValuesConfig(v string) (ValuesConfig, error) {
@@ -280,7 +280,7 @@ func NewValuesConfig(v string) (ValuesConfig, error) {
 	}
 	c.asStruct = valuesStruct
 
-	values := map[string]interface{}{}
+	values := map[string]any{}
 	if err := yaml.Unmarshal([]byte(v), &values); err != nil {
 		return c, fmt.Errorf("could not parse configuration values: %v", err)
 	}
@@ -760,12 +760,12 @@ func applyInitContainer(target *corev1.Pod, container corev1.Container) (*corev1
 	return applyOverlay(target, overlayJSON)
 }
 
-func patchHandleUnmarshal(j []byte, unmarshal func(data []byte, v interface{}) error) (map[string]interface{}, error) {
+func patchHandleUnmarshal(j []byte, unmarshal func(data []byte, v any) error) (map[string]any, error) {
 	if j == nil {
 		j = []byte("{}")
 	}
 
-	m := map[string]interface{}{}
+	m := map[string]any{}
 	err := unmarshal(j, &m)
 	if err != nil {
 		return nil, mergepatch.ErrBadJSONDoc
@@ -775,7 +775,7 @@ func patchHandleUnmarshal(j []byte, unmarshal func(data []byte, v interface{}) e
 
 // StrategicMergePatchYAML is a small fork of strategicpatch.StrategicMergePatch to allow YAML patches
 // This avoids expensive conversion from YAML to JSON
-func StrategicMergePatchYAML(originalJSON []byte, patchYAML []byte, dataStruct interface{}) ([]byte, error) {
+func StrategicMergePatchYAML(originalJSON []byte, patchYAML []byte, dataStruct any) ([]byte, error) {
 	schema, err := strategicpatch.NewPatchMetaFromStruct(dataStruct)
 	if err != nil {
 		return nil, err
@@ -785,7 +785,7 @@ func StrategicMergePatchYAML(originalJSON []byte, patchYAML []byte, dataStruct i
 	if err != nil {
 		return nil, err
 	}
-	patchMap, err := patchHandleUnmarshal(patchYAML, func(data []byte, v interface{}) error {
+	patchMap, err := patchHandleUnmarshal(patchYAML, func(data []byte, v any) error {
 		return yaml.Unmarshal(data, v)
 	})
 	if err != nil {

--- a/pkg/kube/inject/webhook_test.go
+++ b/pkg/kube/inject/webhook_test.go
@@ -635,7 +635,7 @@ func writeInjectionSettings(t testing.TB, fname string, setFlags []string, inFil
 				t.Fatalf("error decoding object %q: %v", object, err)
 			}
 			if out.GetName() == "istio-sidecar-injector" && (out.GroupVersionKind() == schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"}) {
-				data, ok := out.Object["data"].(map[string]interface{})
+				data, ok := out.Object["data"].(map[string]any)
 				if !ok {
 					t.Fatalf("failed to convert %v", out)
 				}
@@ -654,7 +654,7 @@ func writeInjectionSettings(t testing.TB, fname string, setFlags []string, inFil
 					t.Fatal(err)
 				}
 			} else if out.GetName() == "istio" && (out.GroupVersionKind() == schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"}) {
-				data, ok := out.Object["data"].(map[string]interface{})
+				data, ok := out.Object["data"].(map[string]any)
 				if !ok {
 					t.Fatalf("failed to convert %v", out)
 				}
@@ -691,7 +691,7 @@ func splitYamlBytes(yaml []byte, t *testing.T) [][]byte {
 
 func getInjectableYamlDocs(yamlDoc string, t *testing.T) [][]byte {
 	t.Helper()
-	m := make(map[string]interface{})
+	m := make(map[string]any)
 	if err := yaml.Unmarshal([]byte(yamlDoc), &m); err != nil {
 		t.Fatal(err)
 	}
@@ -721,7 +721,7 @@ func getInjectableYamlDocs(yamlDoc string, t *testing.T) [][]byte {
 	}
 }
 
-func convertToJSON(i interface{}, t *testing.T) []byte {
+func convertToJSON(i any, t *testing.T) []byte {
 	t.Helper()
 	outputJSON, err := json.Marshal(i)
 	if err != nil {

--- a/pkg/kube/util.go
+++ b/pkg/kube/util.go
@@ -292,7 +292,7 @@ func HTTPConfigReader(req *http.Request) ([]byte, error) {
 
 // StripUnusedFields is the transform function for shared informers,
 // it removes unused fields from objects before they are stored in the cache to save memory.
-func StripUnusedFields(obj interface{}) (interface{}, error) {
+func StripUnusedFields(obj any) (any, error) {
 	t, ok := obj.(metav1.ObjectMetaAccessor)
 	if !ok {
 		// shouldn't happen

--- a/pkg/kube/util_test.go
+++ b/pkg/kube/util_test.go
@@ -303,8 +303,8 @@ func podForDeploymentConfig(deployConfigName string, hasDeployConfigLabel bool) 
 func TestStripUnusedFields(t *testing.T) {
 	tests := []struct {
 		name string
-		obj  interface{}
-		want interface{}
+		obj  any
+		want any
 	}{
 		{
 			name: "transform pods",

--- a/pkg/queue/delay.go
+++ b/pkg/queue/delay.go
@@ -50,11 +50,11 @@ func (q *pq) Swap(i, j int) {
 	(*q)[i], (*q)[j] = (*q)[j], (*q)[i]
 }
 
-func (q *pq) Push(x interface{}) {
+func (q *pq) Push(x any) {
 	*q = append(*q, x.(*delayTask))
 }
 
-func (q *pq) Pop() interface{} {
+func (q *pq) Pop() any {
 	old := *q
 	n := len(old)
 	c := cap(old)
@@ -74,7 +74,7 @@ func (q *pq) Pop() interface{} {
 }
 
 // Peek is not managed by the container/heap package, so we return the 0th element in the list.
-func (q *pq) Peek() interface{} {
+func (q *pq) Peek() any {
 	if q.Len() < 1 {
 		return nil
 	}

--- a/pkg/test/cert/ca/intermediate.go
+++ b/pkg/test/cert/ca/intermediate.go
@@ -56,7 +56,7 @@ CN = Intermediate CA
 // NewIstioConfig creates an extensions configuration for Istio, using the given system namespace in
 // the DNS SANs.
 func NewIstioConfig(systemNamespace string) (string, error) {
-	return tmpl.Evaluate(istioConfTemplate, map[string]interface{}{
+	return tmpl.Evaluate(istioConfTemplate, map[string]any{
 		"SystemNamespace": systemNamespace,
 	})
 }

--- a/pkg/test/config/mock_config.pb.go
+++ b/pkg/test/config/mock_config.pb.go
@@ -177,7 +177,7 @@ func file_pkg_test_config_mock_config_proto_rawDescGZIP() []byte {
 }
 
 var file_pkg_test_config_mock_config_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
-var file_pkg_test_config_mock_config_proto_goTypes = []interface{}{
+var file_pkg_test_config_mock_config_proto_goTypes = []any{
 	(*MockConfig)(nil), // 0: config.MockConfig
 	(*ConfigPair)(nil), // 1: config.ConfigPair
 }
@@ -196,7 +196,7 @@ func file_pkg_test_config_mock_config_proto_init() {
 		return
 	}
 	if !protoimpl.UnsafeEnabled {
-		file_pkg_test_config_mock_config_proto_msgTypes[0].Exporter = func(v interface{}, i int) interface{} {
+		file_pkg_test_config_mock_config_proto_msgTypes[0].Exporter = func(v any, i int) any {
 			switch v := v.(*MockConfig); i {
 			case 0:
 				return &v.state
@@ -208,7 +208,7 @@ func file_pkg_test_config_mock_config_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_test_config_mock_config_proto_msgTypes[1].Exporter = func(v interface{}, i int) interface{} {
+		file_pkg_test_config_mock_config_proto_msgTypes[1].Exporter = func(v any, i int) any {
 			switch v := v.(*ConfigPair); i {
 			case 0:
 				return &v.state

--- a/pkg/test/echo/proto/echo.pb.go
+++ b/pkg/test/echo/proto/echo.pb.go
@@ -760,7 +760,7 @@ func file_test_echo_proto_echo_proto_rawDescGZIP() []byte {
 }
 
 var file_test_echo_proto_echo_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
-var file_test_echo_proto_echo_proto_goTypes = []interface{}{
+var file_test_echo_proto_echo_proto_goTypes = []any{
 	(*EchoRequest)(nil),            // 0: proto.EchoRequest
 	(*EchoResponse)(nil),           // 1: proto.EchoResponse
 	(*Header)(nil),                 // 2: proto.Header
@@ -793,7 +793,7 @@ func file_test_echo_proto_echo_proto_init() {
 		return
 	}
 	if !protoimpl.UnsafeEnabled {
-		file_test_echo_proto_echo_proto_msgTypes[0].Exporter = func(v interface{}, i int) interface{} {
+		file_test_echo_proto_echo_proto_msgTypes[0].Exporter = func(v any, i int) any {
 			switch v := v.(*EchoRequest); i {
 			case 0:
 				return &v.state
@@ -805,7 +805,7 @@ func file_test_echo_proto_echo_proto_init() {
 				return nil
 			}
 		}
-		file_test_echo_proto_echo_proto_msgTypes[1].Exporter = func(v interface{}, i int) interface{} {
+		file_test_echo_proto_echo_proto_msgTypes[1].Exporter = func(v any, i int) any {
 			switch v := v.(*EchoResponse); i {
 			case 0:
 				return &v.state
@@ -817,7 +817,7 @@ func file_test_echo_proto_echo_proto_init() {
 				return nil
 			}
 		}
-		file_test_echo_proto_echo_proto_msgTypes[2].Exporter = func(v interface{}, i int) interface{} {
+		file_test_echo_proto_echo_proto_msgTypes[2].Exporter = func(v any, i int) any {
 			switch v := v.(*Header); i {
 			case 0:
 				return &v.state
@@ -829,7 +829,7 @@ func file_test_echo_proto_echo_proto_init() {
 				return nil
 			}
 		}
-		file_test_echo_proto_echo_proto_msgTypes[3].Exporter = func(v interface{}, i int) interface{} {
+		file_test_echo_proto_echo_proto_msgTypes[3].Exporter = func(v any, i int) any {
 			switch v := v.(*ForwardEchoRequest); i {
 			case 0:
 				return &v.state
@@ -841,7 +841,7 @@ func file_test_echo_proto_echo_proto_init() {
 				return nil
 			}
 		}
-		file_test_echo_proto_echo_proto_msgTypes[4].Exporter = func(v interface{}, i int) interface{} {
+		file_test_echo_proto_echo_proto_msgTypes[4].Exporter = func(v any, i int) any {
 			switch v := v.(*HBONE); i {
 			case 0:
 				return &v.state
@@ -853,7 +853,7 @@ func file_test_echo_proto_echo_proto_init() {
 				return nil
 			}
 		}
-		file_test_echo_proto_echo_proto_msgTypes[5].Exporter = func(v interface{}, i int) interface{} {
+		file_test_echo_proto_echo_proto_msgTypes[5].Exporter = func(v any, i int) any {
 			switch v := v.(*Alpn); i {
 			case 0:
 				return &v.state
@@ -865,7 +865,7 @@ func file_test_echo_proto_echo_proto_init() {
 				return nil
 			}
 		}
-		file_test_echo_proto_echo_proto_msgTypes[6].Exporter = func(v interface{}, i int) interface{} {
+		file_test_echo_proto_echo_proto_msgTypes[6].Exporter = func(v any, i int) any {
 			switch v := v.(*ForwardEchoResponse); i {
 			case 0:
 				return &v.state

--- a/pkg/test/echo/proto/echo.pb.go
+++ b/pkg/test/echo/proto/echo.pb.go
@@ -760,7 +760,7 @@ func file_test_echo_proto_echo_proto_rawDescGZIP() []byte {
 }
 
 var file_test_echo_proto_echo_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
-var file_test_echo_proto_echo_proto_goTypes = []any{
+var file_test_echo_proto_echo_proto_goTypes = []interface{}{
 	(*EchoRequest)(nil),            // 0: proto.EchoRequest
 	(*EchoResponse)(nil),           // 1: proto.EchoResponse
 	(*Header)(nil),                 // 2: proto.Header
@@ -793,7 +793,7 @@ func file_test_echo_proto_echo_proto_init() {
 		return
 	}
 	if !protoimpl.UnsafeEnabled {
-		file_test_echo_proto_echo_proto_msgTypes[0].Exporter = func(v any, i int) any {
+		file_test_echo_proto_echo_proto_msgTypes[0].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*EchoRequest); i {
 			case 0:
 				return &v.state
@@ -805,7 +805,7 @@ func file_test_echo_proto_echo_proto_init() {
 				return nil
 			}
 		}
-		file_test_echo_proto_echo_proto_msgTypes[1].Exporter = func(v any, i int) any {
+		file_test_echo_proto_echo_proto_msgTypes[1].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*EchoResponse); i {
 			case 0:
 				return &v.state
@@ -817,7 +817,7 @@ func file_test_echo_proto_echo_proto_init() {
 				return nil
 			}
 		}
-		file_test_echo_proto_echo_proto_msgTypes[2].Exporter = func(v any, i int) any {
+		file_test_echo_proto_echo_proto_msgTypes[2].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*Header); i {
 			case 0:
 				return &v.state
@@ -829,7 +829,7 @@ func file_test_echo_proto_echo_proto_init() {
 				return nil
 			}
 		}
-		file_test_echo_proto_echo_proto_msgTypes[3].Exporter = func(v any, i int) any {
+		file_test_echo_proto_echo_proto_msgTypes[3].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*ForwardEchoRequest); i {
 			case 0:
 				return &v.state
@@ -841,7 +841,7 @@ func file_test_echo_proto_echo_proto_init() {
 				return nil
 			}
 		}
-		file_test_echo_proto_echo_proto_msgTypes[4].Exporter = func(v any, i int) any {
+		file_test_echo_proto_echo_proto_msgTypes[4].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*HBONE); i {
 			case 0:
 				return &v.state
@@ -853,7 +853,7 @@ func file_test_echo_proto_echo_proto_init() {
 				return nil
 			}
 		}
-		file_test_echo_proto_echo_proto_msgTypes[5].Exporter = func(v any, i int) any {
+		file_test_echo_proto_echo_proto_msgTypes[5].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*Alpn); i {
 			case 0:
 				return &v.state
@@ -865,7 +865,7 @@ func file_test_echo_proto_echo_proto_init() {
 				return nil
 			}
 		}
-		file_test_echo_proto_echo_proto_msgTypes[6].Exporter = func(v any, i int) any {
+		file_test_echo_proto_echo_proto_msgTypes[6].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*ForwardEchoResponse); i {
 			case 0:
 				return &v.state

--- a/pkg/test/echo/proto/echo_grpc.pb.go
+++ b/pkg/test/echo/proto/echo_grpc.pb.go
@@ -84,7 +84,7 @@ func RegisterEchoTestServiceServer(s grpc.ServiceRegistrar, srv EchoTestServiceS
 	s.RegisterService(&EchoTestService_ServiceDesc, srv)
 }
 
-func _EchoTestService_Echo_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _EchoTestService_Echo_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(EchoRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -96,13 +96,13 @@ func _EchoTestService_Echo_Handler(srv interface{}, ctx context.Context, dec fun
 		Server:     srv,
 		FullMethod: "/proto.EchoTestService/Echo",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(EchoTestServiceServer).Echo(ctx, req.(*EchoRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _EchoTestService_ForwardEcho_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _EchoTestService_ForwardEcho_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(ForwardEchoRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -114,7 +114,7 @@ func _EchoTestService_ForwardEcho_Handler(srv interface{}, ctx context.Context, 
 		Server:     srv,
 		FullMethod: "/proto.EchoTestService/ForwardEcho",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(EchoTestServiceServer).ForwardEcho(ctx, req.(*ForwardEchoRequest))
 	}
 	return interceptor(ctx, in, info, handler)

--- a/pkg/test/echo/proto/echo_grpc.pb.go
+++ b/pkg/test/echo/proto/echo_grpc.pb.go
@@ -84,7 +84,7 @@ func RegisterEchoTestServiceServer(s grpc.ServiceRegistrar, srv EchoTestServiceS
 	s.RegisterService(&EchoTestService_ServiceDesc, srv)
 }
 
-func _EchoTestService_Echo_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
+func _EchoTestService_Echo_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(EchoRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -96,13 +96,13 @@ func _EchoTestService_Echo_Handler(srv any, ctx context.Context, dec func(any) e
 		Server:     srv,
 		FullMethod: "/proto.EchoTestService/Echo",
 	}
-	handler := func(ctx context.Context, req any) (any, error) {
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(EchoTestServiceServer).Echo(ctx, req.(*EchoRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _EchoTestService_ForwardEcho_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
+func _EchoTestService_ForwardEcho_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(ForwardEchoRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -114,7 +114,7 @@ func _EchoTestService_ForwardEcho_Handler(srv any, ctx context.Context, dec func
 		Server:     srv,
 		FullMethod: "/proto.EchoTestService/ForwardEcho",
 	}
-	handler := func(ctx context.Context, req any) (any, error) {
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(EchoTestServiceServer).ForwardEcho(ctx, req.(*ForwardEchoRequest))
 	}
 	return interceptor(ctx, in, info, handler)

--- a/pkg/test/failer.go
+++ b/pkg/test/failer.go
@@ -37,10 +37,10 @@ var (
 type Failer interface {
 	Fail()
 	FailNow()
-	Fatal(args ...interface{})
-	Fatalf(format string, args ...interface{})
-	Log(args ...interface{})
-	Logf(format string, args ...interface{})
+	Fatal(args ...any)
+	Fatalf(format string, args ...any)
+	Log(args ...any)
+	Logf(format string, args ...any)
 	TempDir() string
 	Helper()
 	Cleanup(func())
@@ -89,7 +89,7 @@ func (e *errorWrapper) FailNow() {
 	e.Fatal("fail now called")
 }
 
-func (e *errorWrapper) Fatal(args ...interface{}) {
+func (e *errorWrapper) Fatal(args ...any) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	if e.failed == nil {
@@ -98,7 +98,7 @@ func (e *errorWrapper) Fatal(args ...interface{}) {
 	runtime.Goexit()
 }
 
-func (e *errorWrapper) Fatalf(format string, args ...interface{}) {
+func (e *errorWrapper) Fatalf(format string, args ...any) {
 	e.Fatal(fmt.Sprintf(format, args...))
 }
 
@@ -119,12 +119,12 @@ func (e *errorWrapper) Cleanup(f func()) {
 	}
 }
 
-func (e *errorWrapper) Log(args ...interface{}) {
+func (e *errorWrapper) Log(args ...any) {
 	log.Info(args...)
 }
 
-func (e *errorWrapper) Logf(format string, args ...interface{}) {
-	ag := []interface{}{format}
+func (e *errorWrapper) Logf(format string, args ...any) {
+	ag := []any{format}
 	ag = append(ag, args...)
 	log.Infof(ag...)
 }

--- a/pkg/test/framework/components/authz/kube.go
+++ b/pkg/test/framework/components/authz/kube.go
@@ -226,9 +226,9 @@ func (s *serverImpl) Providers() []Provider {
 	return append([]Provider{}, s.providers...)
 }
 
-func (s *serverImpl) templateArgs() map[string]interface{} {
+func (s *serverImpl) templateArgs() map[string]any {
 	fqdn := fmt.Sprintf("ext-authz.%s.svc.cluster.local", s.ns.Name())
-	return map[string]interface{}{
+	return map[string]any{
 		"fqdn":     fqdn,
 		"httpName": httpName,
 		"grpcName": grpcName,

--- a/pkg/test/framework/components/authz/kubelocal.go
+++ b/pkg/test/framework/components/authz/kubelocal.go
@@ -172,8 +172,8 @@ func (s *localServerImpl) grpcHost() string {
 	return fmt.Sprintf("%s.%s.local", grpcName, s.ns.Prefix())
 }
 
-func (s *localServerImpl) templateArgs() map[string]interface{} {
-	return map[string]interface{}{
+func (s *localServerImpl) templateArgs() map[string]any {
+	return map[string]any{
 		"httpName": s.httpName(),
 		"grpcName": s.grpcName(),
 		"httpHost": s.httpHost(),

--- a/pkg/test/framework/components/cluster/clusterboot/factory_test.go
+++ b/pkg/test/framework/components/cluster/clusterboot/factory_test.go
@@ -141,7 +141,7 @@ func TestValidation(t *testing.T) {
 			{Kind: cluster.Fake, Name: "no-primary", ConfigClusterName: "does-not-exist"},
 		},
 		"vm without kube primary": {
-			{Kind: cluster.StaticVM, Name: "vm", Meta: config.Map{"deployments": []interface{}{
+			{Kind: cluster.StaticVM, Name: "vm", Meta: config.Map{"deployments": []any{
 				config.Map{
 					"service": "vm", "namespace": "echo", "instances": []config.Map{{"ip": "1.2.3.4"}},
 				},

--- a/pkg/test/framework/components/cluster/fake.go
+++ b/pkg/test/framework/components/cluster/fake.go
@@ -29,7 +29,7 @@ func init() {
 func NewFake(name, major, minor string) Cluster {
 	c, _ := newFakeCluster(
 		Config{
-			Meta: map[string]interface{}{
+			Meta: map[string]any{
 				"majorVersion": major,
 				"minorVersion": minor,
 			},

--- a/pkg/test/framework/components/echo/common/call.go
+++ b/pkg/test/framework/components/echo/common/call.go
@@ -72,7 +72,7 @@ func callInternal(srcName string, from echo.Caller, opts echo.CallOptions, send 
 	// Retry the call until it succeeds or times out.
 	var result echo.CallResult
 	var err error
-	_, _ = retry.UntilComplete(func() (interface{}, bool, error) {
+	_, _ = retry.UntilComplete(func() (any, bool, error) {
 		result, err = sendAndValidate()
 		if err != nil {
 			return nil, false, err

--- a/pkg/test/framework/components/echo/common/deployment/namespace.go
+++ b/pkg/test/framework/components/echo/common/deployment/namespace.go
@@ -225,7 +225,7 @@ func (n *EchoNamespace) loadValues(t resource.Context, echos echo.Instances, d *
 
 	// Restrict egress from this namespace to only those endpoints in the same Echos.
 	cfg := t.ConfigIstio().New()
-	cfg.Eval(ns.Name(), map[string]interface{}{
+	cfg.Eval(ns.Name(), map[string]any{
 		"Namespaces": namespaces,
 	}, `
 apiVersion: networking.istio.io/v1alpha3
@@ -243,7 +243,7 @@ spec:
 
 	// Create a ServiceEntry to allow apps in this namespace to talk to the external service.
 	if d.External.Namespace != nil {
-		cfg.Eval(ns.Name(), map[string]interface{}{
+		cfg.Eval(ns.Name(), map[string]any{
 			"Namespace": d.External.Namespace.Name(),
 			"Hostname":  ExternalHostname,
 			"Ports":     serviceEntryPorts(),

--- a/pkg/test/framework/components/echo/config.go
+++ b/pkg/test/framework/components/echo/config.go
@@ -447,7 +447,7 @@ func (c *Config) addPortIfMissing(protocol protocol.Instance) {
 	}
 }
 
-func copyInternal(v interface{}) interface{} {
+func copyInternal(v any) any {
 	copied, err := copystructure.Copy(v)
 	if err != nil {
 		// There are 2 locations where errors are generated in copystructure.Copy:
@@ -463,7 +463,7 @@ func copyInternal(v interface{}) interface{} {
 // than attempting to Claim the configured namespace.
 func ParseConfigs(bytes []byte) ([]Config, error) {
 	// parse into flexible type, so we can remove Namespace and parse that ourselves
-	raw := make([]map[string]interface{}, 0)
+	raw := make([]map[string]any, 0)
 	if err := yaml.Unmarshal(bytes, &raw); err != nil {
 		return nil, err
 	}

--- a/pkg/test/framework/components/echo/config/builder.go
+++ b/pkg/test/framework/components/echo/config/builder.go
@@ -56,7 +56,7 @@ func NewWithOutput(t framework.TestContext, out config.Plan) *Builder {
 	}
 }
 
-func checkNotNil(name string, value interface{}) {
+func checkNotNil(name string, value any) {
 	if value == nil {
 		panic(fmt.Sprintf("%s must not be nil", name))
 	}

--- a/pkg/test/framework/components/echo/config/param/params.go
+++ b/pkg/test/framework/components/echo/config/param/params.go
@@ -15,22 +15,22 @@
 package param
 
 // Params for a Template.
-type Params map[string]interface{}
+type Params map[string]any
 
 // NewParams returns a new Params instance.
 func NewParams() Params {
 	return make(Params)
 }
 
-func (p Params) Get(k string) interface{} {
+func (p Params) Get(k string) any {
 	return p[k]
 }
 
-func (p Params) GetWellKnown(k WellKnown) interface{} {
+func (p Params) GetWellKnown(k WellKnown) any {
 	return p[k.String()]
 }
 
-func (p Params) Set(k string, v interface{}) Params {
+func (p Params) Set(k string, v any) Params {
 	p[k] = v
 	return p
 }
@@ -51,7 +51,7 @@ func (p Params) SetAllNoOverwrite(other Params) Params {
 	return p
 }
 
-func (p Params) SetWellKnown(k WellKnown, v interface{}) Params {
+func (p Params) SetWellKnown(k WellKnown, v any) Params {
 	p[k.String()] = v
 	return p
 }
@@ -70,7 +70,7 @@ func (p Params) Copy() Params {
 		return NewParams()
 	}
 
-	out := make(map[string]interface{})
+	out := make(map[string]any)
 	for k, v := range p {
 		out[k] = v
 	}

--- a/pkg/test/framework/components/echo/config/source.go
+++ b/pkg/test/framework/components/echo/config/source.go
@@ -200,7 +200,7 @@ func (s sourceImpl) WithParams(params param.Params) Source {
 	mergedParams := params
 	if len(s.params) > 0 {
 		// Make a copy of params.
-		mergedParams = make(map[string]interface{}, len(params)+len(s.params))
+		mergedParams = make(map[string]any, len(params)+len(s.params))
 		for k, v := range params {
 			mergedParams[k] = v
 		}

--- a/pkg/test/framework/components/echo/deployment/flags.go
+++ b/pkg/test/framework/components/echo/deployment/flags.go
@@ -73,7 +73,7 @@ func (c *configs) Set(path string) error {
 	return nil
 }
 
-func (c *configs) SetConfig(m interface{}) error {
+func (c *configs) SetConfig(m any) error {
 	yml, err := yaml.Marshal(m)
 	if err != nil {
 		return err

--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -272,7 +272,7 @@ func getVMOverrideForIstiodDNS(ctx resource.Context, cfg echo.Config) (istioHost
 	return
 }
 
-func deploymentParams(ctx resource.Context, cfg echo.Config, settings *resource.Settings) (map[string]interface{}, error) {
+func deploymentParams(ctx resource.Context, cfg echo.Config, settings *resource.Settings) (map[string]any, error) {
 	supportStartupProbe := cfg.Cluster.MinKubeVersion(0)
 	imagePullSecretName, err := settings.Image.PullSecretName()
 	if err != nil {
@@ -280,7 +280,7 @@ func deploymentParams(ctx resource.Context, cfg echo.Config, settings *resource.
 	}
 
 	containerPorts := getContainerPorts(cfg)
-	appContainers := []map[string]interface{}{{
+	appContainers := []map[string]any{{
 		"Name":           appContainerName,
 		"ImageFullPath":  settings.EchoImage, // This overrides image hub/tag if it's not empty.
 		"ContainerPorts": getContainerPorts(cfg),
@@ -304,7 +304,7 @@ func deploymentParams(ctx resource.Context, cfg echo.Config, settings *resource.
 			Port:     grpcFallbackPort,
 		})
 		appContainers[0]["ContainerPorts"] = otherPorts
-		appContainers = append(appContainers, map[string]interface{}{
+		appContainers = append(appContainers, map[string]any{
 			"Name":           "custom-grpc-" + appContainerName,
 			"ImageFullPath":  settings.CustomGRPCEchoImage, // This overrides image hub/tag if it's not empty.
 			"ContainerPorts": grpcPorts,
@@ -312,7 +312,7 @@ func deploymentParams(ctx resource.Context, cfg echo.Config, settings *resource.
 		})
 	}
 
-	params := map[string]interface{}{
+	params := map[string]any{
 		"ImageHub":            settings.Image.Hub,
 		"ImageTag":            strings.TrimSuffix(settings.Image.Tag, "-distroless"),
 		"ImagePullPolicy":     settings.Image.PullPolicy,
@@ -353,7 +353,7 @@ func deploymentParams(ctx resource.Context, cfg echo.Config, settings *resource.
 
 		vmIstioHost, vmIstioIP = getVMOverrideForIstiodDNS(ctx, cfg)
 
-		params["VM"] = map[string]interface{}{
+		params["VM"] = map[string]any{
 			"Image":     vmImage,
 			"IstioHost": vmIstioHost,
 			"IstioIP":   vmIstioIP,
@@ -363,8 +363,8 @@ func deploymentParams(ctx resource.Context, cfg echo.Config, settings *resource.
 	return params, nil
 }
 
-func serviceParams(cfg echo.Config) map[string]interface{} {
-	return map[string]interface{}{
+func serviceParams(cfg echo.Config) map[string]any {
+	return map[string]any{
 		"Service":            cfg.Service,
 		"Headless":           cfg.Headless,
 		"ServiceAccount":     cfg.ServiceAccount,

--- a/pkg/test/framework/components/echo/kube/pod_controller.go
+++ b/pkg/test/framework/components/echo/kube/pod_controller.go
@@ -55,12 +55,12 @@ func newPodController(cfg echo.Config, handlers podHandlers) *podController {
 		})
 	q := queue.NewQueue(1 * time.Second)
 	_, informer := cache.NewInformer(podListWatch, &kubeCore.Pod{}, 0, cache.ResourceEventHandlerFuncs{
-		AddFunc: func(newObj interface{}) {
+		AddFunc: func(newObj any) {
 			q.Push(func() error {
 				return handlers.added(newObj.(*kubeCore.Pod))
 			})
 		},
-		UpdateFunc: func(old, cur interface{}) {
+		UpdateFunc: func(old, cur any) {
 			q.Push(func() error {
 				oldObj := old.(metav1.Object)
 				newObj := cur.(metav1.Object)
@@ -71,7 +71,7 @@ func newPodController(cfg echo.Config, handlers podHandlers) *podController {
 				return nil
 			})
 		},
-		DeleteFunc: func(curr interface{}) {
+		DeleteFunc: func(curr any) {
 			q.Push(func() error {
 				pod, ok := curr.(*kubeCore.Pod)
 				if !ok {

--- a/pkg/test/framework/components/echo/kube/sidecar.go
+++ b/pkg/test/framework/components/echo/kube/sidecar.go
@@ -104,7 +104,7 @@ func (s *sidecar) WaitForConfig(accept func(*envoyAdmin.ConfigDump) (bool, error
 	options = append([]retry.Option{retry.BackoffDelay(defaultConfigDelay), retry.Timeout(defaultConfigTimeout)}, options...)
 
 	var cfg *envoyAdmin.ConfigDump
-	_, err := retry.UntilComplete(func() (result interface{}, completed bool, err error) {
+	_, err := retry.UntilComplete(func() (result any, completed bool, err error) {
 		cfg, err = s.Config()
 		if err != nil {
 			if strings.Contains(err.Error(), "could not resolve Any message type") {

--- a/pkg/test/framework/components/environment/kube/flags.go
+++ b/pkg/test/framework/components/environment/kube/flags.go
@@ -241,7 +241,7 @@ func (c *configsVal) Set(s string) error {
 	return nil
 }
 
-func (c *configsVal) SetConfig(m interface{}) error {
+func (c *configsVal) SetConfig(m any) error {
 	bytes, err := yaml.Marshal(m)
 	if err != nil {
 		return err

--- a/pkg/test/framework/components/istio/ingress.go
+++ b/pkg/test/framework/components/istio/ingress.go
@@ -94,7 +94,7 @@ func (c *ingressImpl) Close() error {
 // the returned net.Addr will have the externally reachable NodePort address and port.
 func (c *ingressImpl) getAddressInner(port int) (string, int, error) {
 	attempts := 0
-	addr, err := retry.UntilComplete(func() (result interface{}, completed bool, err error) {
+	addr, err := retry.UntilComplete(func() (result any, completed bool, err error) {
 		attempts++
 		result, completed, err = getRemoteServiceAddress(c.env.Settings(), c.cluster, c.service.Namespace, c.labelSelector, c.service.Name, port)
 		if err != nil && attempts > 1 {

--- a/pkg/test/framework/components/istio/kube.go
+++ b/pkg/test/framework/components/istio/kube.go
@@ -158,7 +158,7 @@ func (i *istioImpl) RemoteDiscoveryAddressFor(cluster cluster.Cluster) (net.TCPA
 	if !primary.IsConfig() {
 		// istiod is exposed via LoadBalancer since we won't have ingress outside of a cluster;a cluster that is;
 		// a control cluster, but not config cluster is supposed to simulate istiod outside of k8s or "external"
-		address, err := retry.UntilComplete(func() (interface{}, bool, error) {
+		address, err := retry.UntilComplete(func() (any, bool, error) {
 			return getRemoteServiceAddress(i.env.Settings(), primary, i.cfg.SystemNamespace, istiodLabel,
 				istiodSvcName, discoveryPort)
 		}, getAddressTimeout, getAddressDelay)

--- a/pkg/test/framework/components/istio/util.go
+++ b/pkg/test/framework/components/istio/util.go
@@ -74,7 +74,7 @@ func waitForValidationWebhook(ctx resource.Context, cluster cluster.Cluster, cfg
 
 func getRemoteServiceAddress(s *kube.Settings, cluster cluster.Cluster, ns, label, svcName string,
 	port int,
-) (interface{}, bool, error) {
+) (any, bool, error) {
 	if !s.LoadBalancerSupported {
 		pods, err := cluster.PodsForSelector(context.TODO(), ns, label)
 		if err != nil {

--- a/pkg/test/framework/components/registryredirector/kube.go
+++ b/pkg/test/framework/components/registryredirector/kube.go
@@ -76,7 +76,7 @@ func newKube(ctx resource.Context, cfg Config) (Instance, error) {
 		return nil, fmt.Errorf("could not create %q namespace for registry redirector server install; err: %v", ns, err)
 	}
 
-	args := map[string]interface{}{}
+	args := map[string]any{}
 
 	if len(cfg.TargetRegistry) != 0 {
 		args["TargetRegistry"] = cfg.TargetRegistry

--- a/pkg/test/framework/components/zipkin/kube.go
+++ b/pkg/test/framework/components/zipkin/kube.go
@@ -268,13 +268,13 @@ func (c *kubeComponent) Close() error {
 }
 
 func extractTraces(resp []byte) ([]Trace, error) {
-	var traceObjs []interface{}
+	var traceObjs []any
 	if err := json.Unmarshal(resp, &traceObjs); err != nil {
 		return []Trace{}, err
 	}
 	var ret []Trace
 	for _, t := range traceObjs {
-		spanObjs, ok := t.([]interface{})
+		spanObjs, ok := t.([]any)
 		if !ok || len(spanObjs) == 0 {
 			scopes.Framework.Debugf("cannot parse or cannot find spans in trace object %+v", t)
 			continue
@@ -303,9 +303,9 @@ func extractTraces(resp []byte) ([]Trace, error) {
 	return []Trace{}, errors.New("cannot find any traces")
 }
 
-func buildSpan(obj interface{}) Span {
+func buildSpan(obj any) Span {
 	var s Span
-	spanSpec := obj.(map[string]interface{})
+	spanSpec := obj.(map[string]any)
 	if spanID, ok := spanSpec["id"]; ok {
 		s.SpanID = spanID.(string)
 	}
@@ -313,7 +313,7 @@ func buildSpan(obj interface{}) Span {
 		s.ParentSpanID = parentSpanID.(string)
 	}
 	if endpointObj, ok := spanSpec["localEndpoint"]; ok {
-		if em, ok := endpointObj.(map[string]interface{}); ok {
+		if em, ok := endpointObj.(map[string]any); ok {
 			s.ServiceName = em["serviceName"].(string)
 		}
 	}

--- a/pkg/test/framework/config.go
+++ b/pkg/test/framework/config.go
@@ -69,7 +69,7 @@ func (c *configFactory) YAML(ns string, yamlText ...string) config.Plan {
 	return c.New().YAML(ns, yamlText...)
 }
 
-func (c *configFactory) Eval(ns string, args interface{}, yamlTemplates ...string) config.Plan {
+func (c *configFactory) Eval(ns string, args any, yamlTemplates ...string) config.Plan {
 	return c.New().Eval(ns, args, yamlTemplates...)
 }
 
@@ -77,7 +77,7 @@ func (c *configFactory) File(ns string, filePaths ...string) config.Plan {
 	return c.New().File(ns, filePaths...)
 }
 
-func (c *configFactory) EvalFile(ns string, args interface{}, filePaths ...string) config.Plan {
+func (c *configFactory) EvalFile(ns string, args any, filePaths ...string) config.Plan {
 	return c.New().EvalFile(ns, args, filePaths...)
 }
 
@@ -219,11 +219,11 @@ func (c *configPlan) File(ns string, paths ...string) config.Plan {
 	return c.YAML(ns, yamlText...)
 }
 
-func (c *configPlan) Eval(ns string, args interface{}, templates ...string) config.Plan {
+func (c *configPlan) Eval(ns string, args any, templates ...string) config.Plan {
 	return c.YAML(ns, tmpl.MustEvaluateAll(args, templates...)...)
 }
 
-func (c *configPlan) EvalFile(ns string, args interface{}, paths ...string) config.Plan {
+func (c *configPlan) EvalFile(ns string, args any, paths ...string) config.Plan {
 	templates, err := file.AsStringArray(paths...)
 	if err != nil {
 		panic(err)

--- a/pkg/test/framework/config/config.go
+++ b/pkg/test/framework/config/config.go
@@ -41,7 +41,7 @@ func init() {
 type Value interface {
 	flag.Value
 	// SetConfig will receive either a Map or a []Map
-	SetConfig(interface{}) error
+	SetConfig(any) error
 }
 
 func Parsed() bool {

--- a/pkg/test/framework/config/map.go
+++ b/pkg/test/framework/config/map.go
@@ -20,7 +20,7 @@ import (
 	"istio.io/istio/pkg/test/scopes"
 )
 
-type Map map[string]interface{}
+type Map map[string]any
 
 func (m Map) Map(key string) Map {
 	nested, ok := m[key]
@@ -47,7 +47,7 @@ func (m Map) String(key string) string {
 }
 
 func (m Map) Slice(key string) []Map {
-	v, ok := m[key].([]interface{})
+	v, ok := m[key].([]any)
 	if !ok {
 		return nil
 	}
@@ -63,18 +63,18 @@ func (m Map) Slice(key string) []Map {
 	return out
 }
 
-func toMap(orig interface{}) (Map, bool) {
+func toMap(orig any) (Map, bool) {
 	// keys are strings, easily cast
 	if cfgMeta, ok := orig.(Map); ok {
 		return cfgMeta, true
 	}
 	// keys are interface{}, manually change to string keys
-	mapInterface, ok := orig.(map[interface{}]interface{})
+	mapInterface, ok := orig.(map[any]any)
 	if !ok {
 		// not a map at all
 		return nil, false
 	}
-	mapString := make(map[string]interface{})
+	mapString := make(map[string]any)
 	for key, value := range mapInterface {
 		mapString[fmt.Sprintf("%v", key)] = value
 	}

--- a/pkg/test/framework/errors/deprecations.go
+++ b/pkg/test/framework/errors/deprecations.go
@@ -26,7 +26,7 @@ type DeprecatedError struct {
 	msg string
 }
 
-func NewDeprecatedError(format string, args ...interface{}) error {
+func NewDeprecatedError(format string, args ...any) error {
 	return &DeprecatedError{fmt.Sprintf(format, args...)}
 }
 

--- a/pkg/test/framework/features/features.gen.go
+++ b/pkg/test/framework/features/features.gen.go
@@ -17,16 +17,16 @@
 package features
 
 const (
-	Observability	Feature = "observability"
-	Security_Certificates_Citadel	Feature = "security.certificates.citadel"
-	Security_Certificates_LetsEncrypt	Feature = "security.certificates.lets-encrypt"
-	Security_Certificates_Spire	Feature = "security.certificates.spire"
-	Security_MTLS_OnByDefault	Feature = "security.mTLS.on-by-default"
-	Traffic_CircuitBreakers_FailGracefully	Feature = "traffic.circuit-breakers.fail-gracefully"
-	Usability_Introspection_Status_Analysis_ContainsMessageWhenFalse	Feature = "usability.introspection.status.analysis.contains-message-when-false"
-	Usability_Introspection_Status_Analysis_TrueWhenWarnOnly	Feature = "usability.introspection.status.analysis.true-when-warn-only"
-	Usability_Introspection_Status_Distribution_EventuallyTrue	Feature = "usability.introspection.status.distribution.eventually-true"
-	Usability_Introspection_Status_Distribution_ImmediatelyFalse	Feature = "usability.introspection.status.distribution.immediately-false"
-	Usability_Observability_Status	Feature = "usability.observability.status"
-	Usability_Observability_Status_DefaultExists	Feature = "usability.observability.status.default-exists"
+	Observability                                                    Feature = "observability"
+	Security_Certificates_Citadel                                    Feature = "security.certificates.citadel"
+	Security_Certificates_LetsEncrypt                                Feature = "security.certificates.lets-encrypt"
+	Security_Certificates_Spire                                      Feature = "security.certificates.spire"
+	Security_MTLS_OnByDefault                                        Feature = "security.mTLS.on-by-default"
+	Traffic_CircuitBreakers_FailGracefully                           Feature = "traffic.circuit-breakers.fail-gracefully"
+	Usability_Introspection_Status_Analysis_ContainsMessageWhenFalse Feature = "usability.introspection.status.analysis.contains-message-when-false"
+	Usability_Introspection_Status_Analysis_TrueWhenWarnOnly         Feature = "usability.introspection.status.analysis.true-when-warn-only"
+	Usability_Introspection_Status_Distribution_EventuallyTrue       Feature = "usability.introspection.status.distribution.eventually-true"
+	Usability_Introspection_Status_Distribution_ImmediatelyFalse     Feature = "usability.introspection.status.distribution.immediately-false"
+	Usability_Observability_Status                                   Feature = "usability.observability.status"
+	Usability_Observability_Status_DefaultExists                     Feature = "usability.observability.status.default-exists"
 )

--- a/pkg/test/framework/features/features.go
+++ b/pkg/test/framework/features/features.go
@@ -33,7 +33,7 @@ type Checker interface {
 }
 
 type checkerImpl struct {
-	m map[string]interface{}
+	m map[string]any
 }
 
 func BuildChecker(yamlPath string) (Checker, error) {
@@ -42,14 +42,14 @@ func BuildChecker(yamlPath string) (Checker, error) {
 		log.Errorf("Error reading feature file: %s", yamlPath)
 		return nil, err
 	}
-	m := make(map[string]interface{})
+	m := make(map[string]any)
 
 	err = yaml.Unmarshal(data, &m)
 	if err != nil {
 		log.Errorf("Error parsing features file: %s", err)
 		return nil, err
 	}
-	return &checkerImpl{m["features"].(map[string]interface{})}, nil
+	return &checkerImpl{m["features"].(map[string]any)}, nil
 }
 
 // returns true if the feature is defined in features.yaml,
@@ -58,13 +58,13 @@ func (c *checkerImpl) Check(feature Feature) (check bool, scenario string) {
 	return checkPathSegment(c.m, strings.Split(string(feature), "."))
 }
 
-func checkPathSegment(m map[string]interface{}, path []string) (check bool, scenario string) {
+func checkPathSegment(m map[string]any, path []string) (check bool, scenario string) {
 	if len(path) < 1 {
 		return false, ""
 	}
 	segment := path[0]
 	if val, ok := m[segment]; ok {
-		if valmap, ok := val.(map[string]interface{}); ok {
+		if valmap, ok := val.(map[string]any); ok {
 			return checkPathSegment(valmap, path[1:])
 		} else if val == nil {
 			return true, strings.Join(path[1:], ".")

--- a/pkg/test/framework/resource/config/factory.go
+++ b/pkg/test/framework/resource/config/factory.go
@@ -26,8 +26,8 @@ type Factory interface {
 	File(ns string, paths ...string) Plan
 
 	// Eval the same as YAML, but it evaluates the template parameters.
-	Eval(ns string, args interface{}, yamlText ...string) Plan
+	Eval(ns string, args any, yamlText ...string) Plan
 
 	// EvalFile the same as File, but it evaluates the template parameters.
-	EvalFile(ns string, args interface{}, paths ...string) Plan
+	EvalFile(ns string, args any, paths ...string) Plan
 }

--- a/pkg/test/framework/resource/context.go
+++ b/pkg/test/framework/resource/context.go
@@ -34,7 +34,7 @@ type Context interface {
 	// For a slice pointer, the matching resources from this scope and its parent(s) will be appended.
 	// If ref is not a pointer, an error will be returned.
 	// If there is no match for a non-slice pointer, an error will be returned.
-	GetResource(ref interface{}) error
+	GetResource(ref any) error
 
 	// The Environment in which the tests run
 	Environment() Environment
@@ -78,7 +78,7 @@ type Context interface {
 	ConfigIstio() config.Factory
 
 	// RecordTraceEvent records an event. This is later saved to trace.yaml for analysis
-	RecordTraceEvent(key string, value interface{})
+	RecordTraceEvent(key string, value any)
 	// Id returns the name of the context
 	ID() string
 }

--- a/pkg/test/framework/resource/settings.go
+++ b/pkg/test/framework/resource/settings.go
@@ -57,7 +57,7 @@ func (s *ImageSettings) PullSecretName() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	secret := unstructured.Unstructured{Object: map[string]interface{}{}}
+	secret := unstructured.Unstructured{Object: map[string]any{}}
 	if err := yaml.Unmarshal(data, secret.Object); err != nil {
 		return "", err
 	}

--- a/pkg/test/framework/resource/version.go
+++ b/pkg/test/framework/resource/version.go
@@ -29,7 +29,7 @@ var _ config.Value = &RevVerMap{}
 // RevVerMap maps installed revisions to their Istio versions.
 type RevVerMap map[string]IstioVersion
 
-func (rv *RevVerMap) SetConfig(mi interface{}) error {
+func (rv *RevVerMap) SetConfig(mi any) error {
 	m, ok := mi.(config.Map)
 	if !ok {
 		return fmt.Errorf("revisions map: expected map but got slice")

--- a/pkg/test/framework/scope.go
+++ b/pkg/test/framework/scope.go
@@ -73,7 +73,7 @@ func (s *scope) add(r resource.Resource, id *resourceID) {
 	}
 }
 
-func (s *scope) get(ref interface{}) error {
+func (s *scope) get(ref any) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 

--- a/pkg/test/framework/suite_test.go
+++ b/pkg/test/framework/suite_test.go
@@ -426,7 +426,7 @@ func TestSuite_DoubleInit_Error(t *testing.T) {
 func TestSuite_GetResource(t *testing.T) {
 	defer cleanupRT()
 
-	act := func(refPtr interface{}, trackedResource resource.Resource) error {
+	act := func(refPtr any, trackedResource resource.Resource) error {
 		var err error
 		runFn := func(ctx *suiteContext) int {
 			err = ctx.GetResource(refPtr)

--- a/pkg/test/framework/suitecontext.go
+++ b/pkg/test/framework/suitecontext.go
@@ -167,7 +167,7 @@ func (c *suiteContext) TrackResource(r resource.Resource) resource.ID {
 	return rid
 }
 
-func (c *suiteContext) GetResource(ref interface{}) error {
+func (c *suiteContext) GetResource(ref any) error {
 	return c.globalScope.get(ref)
 }
 
@@ -272,17 +272,17 @@ func (c *suiteContext) registerOutcome(test *testImpl) {
 	c.testOutcomes = append(c.testOutcomes, newOutcome)
 }
 
-func (c *suiteContext) RecordTraceEvent(key string, value interface{}) {
+func (c *suiteContext) RecordTraceEvent(key string, value any) {
 	c.traces.Store(key, value)
 }
 
 func (c *suiteContext) marshalTraceEvent() []byte {
-	kvs := map[string]interface{}{}
-	c.traces.Range(func(key, value interface{}) bool {
+	kvs := map[string]any{}
+	c.traces.Range(func(key, value any) bool {
 		kvs[key.(string)] = value
 		return true
 	})
-	outer := map[string]interface{}{
+	outer := map[string]any{
 		fmt.Sprintf("suite/%s", c.settings.TestID): kvs,
 	}
 	d, _ := yaml.Marshal(outer)

--- a/pkg/test/framework/testcontext.go
+++ b/pkg/test/framework/testcontext.go
@@ -43,7 +43,7 @@ type TestContext interface {
 	//
 	// If this TestContext was not created by a Test or if that Test is not running, this method will panic.
 	NewSubTest(name string) Test
-	NewSubTestf(format string, a ...interface{}) Test
+	NewSubTestf(format string, a ...any) Test
 
 	// WorkDir allocated for this test.
 	WorkDir() string
@@ -59,13 +59,13 @@ type TestContext interface {
 
 	// Methods for interacting with the underlying *testing.T.
 
-	Error(args ...interface{})
-	Errorf(format string, args ...interface{})
+	Error(args ...any)
+	Errorf(format string, args ...any)
 	Failed() bool
 	Name() string
-	Skip(args ...interface{})
+	Skip(args ...any)
 	SkipNow()
-	Skipf(format string, args ...interface{})
+	Skipf(format string, args ...any)
 	Skipped() bool
 }
 
@@ -158,7 +158,7 @@ func (c *testContext) TrackResource(r resource.Resource) resource.ID {
 	return rid
 }
 
-func (c *testContext) GetResource(ref interface{}) error {
+func (c *testContext) GetResource(ref any) error {
 	return c.scope.get(ref)
 }
 
@@ -256,7 +256,7 @@ func (c *testContext) NewSubTest(name string) Test {
 	}
 }
 
-func (c *testContext) NewSubTestf(format string, a ...interface{}) Test {
+func (c *testContext) NewSubTestf(format string, a ...any) Test {
 	return c.NewSubTest(fmt.Sprintf(format, a...))
 }
 
@@ -315,12 +315,12 @@ func (c *testContext) close() {
 	scopes.Framework.Debugf("Completed cleaning up testContext: %q", c.id)
 }
 
-func (c *testContext) Error(args ...interface{}) {
+func (c *testContext) Error(args ...any) {
 	c.Helper()
 	c.T.Error(args...)
 }
 
-func (c *testContext) Errorf(format string, args ...interface{}) {
+func (c *testContext) Errorf(format string, args ...any) {
 	c.Helper()
 	c.T.Errorf(format, args...)
 }
@@ -340,22 +340,22 @@ func (c *testContext) Failed() bool {
 	return c.T.Failed()
 }
 
-func (c *testContext) Fatal(args ...interface{}) {
+func (c *testContext) Fatal(args ...any) {
 	c.Helper()
 	c.T.Fatal(args...)
 }
 
-func (c *testContext) Fatalf(format string, args ...interface{}) {
+func (c *testContext) Fatalf(format string, args ...any) {
 	c.Helper()
 	c.T.Fatalf(format, args...)
 }
 
-func (c *testContext) Log(args ...interface{}) {
+func (c *testContext) Log(args ...any) {
 	c.Helper()
 	c.T.Log(args...)
 }
 
-func (c *testContext) Logf(format string, args ...interface{}) {
+func (c *testContext) Logf(format string, args ...any) {
 	c.Helper()
 	c.T.Logf(format, args...)
 }
@@ -365,7 +365,7 @@ func (c *testContext) Name() string {
 	return c.T.Name()
 }
 
-func (c *testContext) Skip(args ...interface{}) {
+func (c *testContext) Skip(args ...any) {
 	c.Helper()
 	c.T.Skip(args...)
 }
@@ -375,7 +375,7 @@ func (c *testContext) SkipNow() {
 	c.T.SkipNow()
 }
 
-func (c *testContext) Skipf(format string, args ...interface{}) {
+func (c *testContext) Skipf(format string, args ...any) {
 	c.Helper()
 	c.T.Skipf(format, args...)
 }
@@ -400,7 +400,7 @@ func (c *closer) Close() error {
 	return c.fn()
 }
 
-func (c *testContext) RecordTraceEvent(string, interface{}) {
+func (c *testContext) RecordTraceEvent(string, any) {
 	// Currently, only supported at suite level.
 	panic("TODO: implement tracing in test context")
 }

--- a/pkg/test/framework/tools/featuresgen/cmd/root.go
+++ b/pkg/test/framework/tools/featuresgen/cmd/root.go
@@ -94,7 +94,7 @@ func init() {
 }
 
 // Parses a map in the yaml file
-func readMap(m map[interface{}]interface{}, path []string) []string {
+func readMap(m map[any]any, path []string) []string {
 	var labels []string
 	for k, v := range m {
 		// If we see "values," then the element is a root and we shouldn't put it in our label name
@@ -114,7 +114,7 @@ func readMap(m map[interface{}]interface{}, path []string) []string {
 }
 
 // Parses a slice in the yaml file
-func readSlice(slc []interface{}, path []string) []string {
+func readSlice(slc []any, path []string) []string {
 	labels := make([]string, 0)
 	for _, v := range slc {
 		labels = append(labels, readVal(v, path)...)
@@ -123,15 +123,15 @@ func readSlice(slc []interface{}, path []string) []string {
 }
 
 // Determines the type of a node in the yaml file and parses it accordingly
-func readVal(v interface{}, path []string) []string {
+func readVal(v any, path []string) []string {
 	typ := reflect.TypeOf(v).Kind()
 	if typ == reflect.Int || typ == reflect.String {
 		path = append(path, v.(string))
 		return []string{createConstantString(path)}
 	} else if typ == reflect.Slice {
-		return readSlice(v.([]interface{}), path)
+		return readSlice(v.([]any), path)
 	} else if typ == reflect.Map {
-		return readMap(v.(map[interface{}]interface{}), path)
+		return readMap(v.(map[any]any), path)
 	}
 	panic("Found invalid type in YAML file")
 }
@@ -169,7 +169,7 @@ func createLabelsFromYaml() string {
 		fmt.Println("Error running featuresgen on file: ", pwd, "/", input)
 		panic(err)
 	}
-	m := make(map[interface{}]interface{})
+	m := make(map[any]any)
 
 	err = yaml.Unmarshal(data, &m)
 	if err != nil {

--- a/pkg/test/framework/tools/featuresgen/cmd/root_test.go
+++ b/pkg/test/framework/tools/featuresgen/cmd/root_test.go
@@ -47,7 +47,7 @@ const expectedResult = `	Hello1	Feature = "hello1"
 	Key2_Val2	Feature = "key2.val2"`
 
 func TestReadVal(t *testing.T) {
-	m := make(map[interface{}]interface{})
+	m := make(map[any]any)
 
 	err := yaml.Unmarshal([]byte(testYaml), &m)
 	if err != nil {

--- a/pkg/test/loadbalancersim/loadbalancer/edf.go
+++ b/pkg/test/loadbalancersim/loadbalancer/edf.go
@@ -22,7 +22,7 @@ import (
 type Entry struct {
 	deadline float64
 	index    int64
-	value    interface{}
+	value    any
 	weight   float64
 }
 
@@ -47,13 +47,13 @@ func (pq priorityQueue) Swap(i, j int) {
 }
 
 // Push implements heap.Interface for pushing an item into the heap
-func (pq *priorityQueue) Push(x interface{}) {
+func (pq *priorityQueue) Push(x any) {
 	entry := x.(*Entry)
 	*pq = append(*pq, entry)
 }
 
 // Pop implements heap.Interface for poping an item from the heap
-func (pq *priorityQueue) Pop() interface{} {
+func (pq *priorityQueue) Pop() any {
 	old := *pq
 	n := len(old)
 	entry := old[n-1]
@@ -69,7 +69,7 @@ type EDF struct {
 }
 
 // Add a new entry for load balance
-func (e *EDF) Add(weight float64, value interface{}) {
+func (e *EDF) Add(weight float64, value any) {
 	e.currentIndex++
 	heap.Push(e.pq, &Entry{
 		value:    value,
@@ -80,7 +80,7 @@ func (e *EDF) Add(weight float64, value interface{}) {
 }
 
 // PickAndAdd picks an available entry and re-adds it with the given weight calculation
-func (e *EDF) PickAndAdd(calcWeight func(prevWeight float64, value interface{}) float64) interface{} {
+func (e *EDF) PickAndAdd(calcWeight func(prevWeight float64, value any) float64) any {
 	// if no available entry, return nil
 	if len(*e.pq) == 0 {
 		return nil

--- a/pkg/test/loadbalancersim/loadbalancer/leastrequest.go
+++ b/pkg/test/loadbalancersim/loadbalancer/leastrequest.go
@@ -116,7 +116,7 @@ func (lb *weightedLeastRequest) Request(onDone func()) {
 	lb.doRequest(selected, onDone)
 }
 
-func (lb *weightedLeastRequest) calcEDFWeight(_ float64, value interface{}) float64 {
+func (lb *weightedLeastRequest) calcEDFWeight(_ float64, value any) float64 {
 	conn := value.(*WeightedConnection)
 
 	weight := float64(conn.Weight)

--- a/pkg/test/loadbalancersim/timer/queue.go
+++ b/pkg/test/loadbalancersim/timer/queue.go
@@ -173,13 +173,13 @@ func (h timerHeap) Swap(i, j int) {
 	h[j].index = j
 }
 
-func (h *timerHeap) Push(x interface{}) {
+func (h *timerHeap) Push(x any) {
 	e := x.(*entry)
 	*h = append(*h, e)
 	e.index = len(*h) - 1
 }
 
-func (h *timerHeap) Pop() interface{} {
+func (h *timerHeap) Pop() any {
 	n := h.Len()
 	e := (*h)[n-1]
 	*h = (*h)[:n-1]

--- a/pkg/test/shell/shell.go
+++ b/pkg/test/shell/shell.go
@@ -27,7 +27,7 @@ import (
 var scope = log.RegisterScope("shell", "Shell execution scope", 0)
 
 // Execute the given command.
-func Execute(combinedOutput bool, format string, args ...interface{}) (string, error) {
+func Execute(combinedOutput bool, format string, args ...any) (string, error) {
 	s := fmt.Sprintf(format, args...)
 
 	parts, err := shlex.Split(s)

--- a/pkg/test/util/assert/assert.go
+++ b/pkg/test/util/assert/assert.go
@@ -25,7 +25,7 @@ import (
 )
 
 // Equal
-func Equal(t test.Failer, a, b interface{}, context ...string) {
+func Equal(t test.Failer, a, b any, context ...string) {
 	t.Helper()
 	if !cmp.Equal(a, b, protocmp.Transform(), cmpopts.EquateEmpty()) {
 		cs := ""

--- a/pkg/test/util/retry/retry.go
+++ b/pkg/test/util/retry/retry.go
@@ -102,11 +102,11 @@ func MaxAttempts(attempts int) Option {
 }
 
 // RetriableFunc a function that can be retried.
-type RetriableFunc func() (result interface{}, completed bool, err error)
+type RetriableFunc func() (result any, completed bool, err error)
 
 // UntilSuccess retries the given function until success, timeout, or until the passed-in function returns nil.
 func UntilSuccess(fn func() error, options ...Option) error {
-	_, e := UntilComplete(func() (interface{}, bool, error) {
+	_, e := UntilComplete(func() (any, bool, error) {
 		err := fn()
 		if err != nil {
 			return nil, false, err
@@ -161,7 +161,7 @@ func getErrorMessage(options []Option) error {
 
 // UntilComplete retries the given function, until there is a timeout, or until the function indicates that it has completed.
 // Once complete, the returned value and error are returned.
-func UntilComplete(fn RetriableFunc, options ...Option) (interface{}, error) {
+func UntilComplete(fn RetriableFunc, options ...Option) (any, error) {
 	cfg := defaultConfig
 	for _, option := range options {
 		option(&cfg)

--- a/pkg/test/util/structpath/instance.go
+++ b/pkg/test/util/structpath/instance.go
@@ -37,7 +37,7 @@ var (
 )
 
 type Instance struct {
-	structure     interface{}
+	structure     any
 	isJSON        bool
 	constraints   []constraint
 	creationError error
@@ -75,13 +75,13 @@ func newErrorInstance(err error) *Instance {
 	}
 }
 
-func protoToParsedJSON(message proto.Message) (interface{}, error) {
+func protoToParsedJSON(message proto.Message) (any, error) {
 	// Convert proto to json and then parse into struct
 	jsonText, err := protomarshal.MarshalIndent(message, "  ")
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert proto to JSON: %v", err)
 	}
-	var parsed interface{}
+	var parsed any
 	err = json.Unmarshal(jsonText, &parsed)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse into JSON struct: %v", err)
@@ -89,7 +89,7 @@ func protoToParsedJSON(message proto.Message) (interface{}, error) {
 	return parsed, nil
 }
 
-func (i *Instance) Select(path string, args ...interface{}) *Instance {
+func (i *Instance) Select(path string, args ...any) *Instance {
 	if i.creationError != nil {
 		// There was an error during the creation of this Instance. Just return the
 		// same instance since it will error on Check anyway.
@@ -117,7 +117,7 @@ func (i *Instance) appendConstraint(fn func() error) *Instance {
 	return i
 }
 
-func (i *Instance) Equals(expected interface{}, path string, args ...interface{}) *Instance {
+func (i *Instance) Equals(expected any, path string, args ...any) *Instance {
 	path = fmt.Sprintf(path, args...)
 	return i.appendConstraint(func() error {
 		typeOf := reflect.TypeOf(expected)
@@ -207,7 +207,7 @@ func (i *Instance) equalsStruct(proto proto.Message, path string) error {
 	return nil
 }
 
-func (i *Instance) Exists(path string, args ...interface{}) *Instance {
+func (i *Instance) Exists(path string, args ...any) *Instance {
 	path = fmt.Sprintf(path, args...)
 	return i.appendConstraint(func() error {
 		v, err := i.findValue(path)
@@ -221,7 +221,7 @@ func (i *Instance) Exists(path string, args ...interface{}) *Instance {
 	})
 }
 
-func (i *Instance) NotExists(path string, args ...interface{}) *Instance {
+func (i *Instance) NotExists(path string, args ...any) *Instance {
 	path = fmt.Sprintf(path, args...)
 	return i.appendConstraint(func() error {
 		parser := jsonpath.New("path")
@@ -290,7 +290,7 @@ func (i *Instance) execute(path string) (string, error) {
 	return buf.String(), nil
 }
 
-func (i *Instance) findValue(path string) (interface{}, error) {
+func (i *Instance) findValue(path string) (any, error) {
 	parser := jsonpath.New("path")
 	err := parser.Parse(i.fixPath(path))
 	if err != nil {

--- a/pkg/test/util/tmpl/evaluate.go
+++ b/pkg/test/util/tmpl/evaluate.go
@@ -22,7 +22,7 @@ import (
 )
 
 // Evaluate parses the template and then executes it with the given parameters.
-func Evaluate(tpl string, data interface{}) (string, error) {
+func Evaluate(tpl string, data any) (string, error) {
 	t, err := Parse(tpl)
 	if err != nil {
 		return "", err
@@ -31,7 +31,7 @@ func Evaluate(tpl string, data interface{}) (string, error) {
 	return Execute(t, data)
 }
 
-func EvaluateFile(filePath string, data interface{}) (string, error) {
+func EvaluateFile(filePath string, data any) (string, error) {
 	tpl, err := file.AsString(filePath)
 	if err != nil {
 		return "", err
@@ -40,7 +40,7 @@ func EvaluateFile(filePath string, data interface{}) (string, error) {
 }
 
 // EvaluateOrFail calls Evaluate and fails tests if it returns error.
-func EvaluateOrFail(t test.Failer, tpl string, data interface{}) string {
+func EvaluateOrFail(t test.Failer, tpl string, data any) string {
 	t.Helper()
 	s, err := Evaluate(tpl, data)
 	if err != nil {
@@ -49,7 +49,7 @@ func EvaluateOrFail(t test.Failer, tpl string, data interface{}) string {
 	return s
 }
 
-func EvaluateFileOrFail(t test.Failer, filePath string, data interface{}) string {
+func EvaluateFileOrFail(t test.Failer, filePath string, data any) string {
 	t.Helper()
 	s, err := EvaluateFile(filePath, data)
 	if err != nil {
@@ -59,7 +59,7 @@ func EvaluateFileOrFail(t test.Failer, filePath string, data interface{}) string
 }
 
 // MustEvaluate calls Evaluate and panics if there is an error.
-func MustEvaluate(tpl string, data interface{}) string {
+func MustEvaluate(tpl string, data any) string {
 	s, err := Evaluate(tpl, data)
 	if err != nil {
 		panic(fmt.Sprintf("tmpl.MustEvaluate: %v", err))
@@ -67,7 +67,7 @@ func MustEvaluate(tpl string, data interface{}) string {
 	return s
 }
 
-func MustEvaluateFile(filePath string, data interface{}) string {
+func MustEvaluateFile(filePath string, data any) string {
 	s, err := EvaluateFile(filePath, data)
 	if err != nil {
 		panic(fmt.Sprintf("tmpl.MustEvaluate: %v", err))
@@ -76,7 +76,7 @@ func MustEvaluateFile(filePath string, data interface{}) string {
 }
 
 // EvaluateAll calls Evaluate the same data args against each of the given templates.
-func EvaluateAll(data interface{}, templates ...string) ([]string, error) {
+func EvaluateAll(data any, templates ...string) ([]string, error) {
 	out := make([]string, 0, len(templates))
 	for _, t := range templates {
 		content, err := Evaluate(t, data)
@@ -88,7 +88,7 @@ func EvaluateAll(data interface{}, templates ...string) ([]string, error) {
 	return out, nil
 }
 
-func EvaluateAllFiles(data interface{}, filePaths ...string) ([]string, error) {
+func EvaluateAllFiles(data any, filePaths ...string) ([]string, error) {
 	templates, err := file.AsStringArray(filePaths...)
 	if err != nil {
 		return nil, err
@@ -96,7 +96,7 @@ func EvaluateAllFiles(data interface{}, filePaths ...string) ([]string, error) {
 	return EvaluateAll(data, templates...)
 }
 
-func MustEvaluateAll(data interface{}, templates ...string) []string {
+func MustEvaluateAll(data any, templates ...string) []string {
 	out, err := EvaluateAll(data, templates...)
 	if err != nil {
 		panic(fmt.Sprintf("tmpl.MustEvaluateAll: %v", err))
@@ -105,7 +105,7 @@ func MustEvaluateAll(data interface{}, templates ...string) []string {
 }
 
 // EvaluateAllOrFail calls Evaluate and fails t if an error occurs.
-func EvaluateAllOrFail(t test.Failer, data interface{}, templates ...string) []string {
+func EvaluateAllOrFail(t test.Failer, data any, templates ...string) []string {
 	t.Helper()
 	out, err := EvaluateAll(data, templates...)
 	if err != nil {
@@ -114,7 +114,7 @@ func EvaluateAllOrFail(t test.Failer, data interface{}, templates ...string) []s
 	return out
 }
 
-func EvaluateAllFilesOrFail(t test.Failer, data interface{}, filePaths ...string) []string {
+func EvaluateAllFilesOrFail(t test.Failer, data any, filePaths ...string) []string {
 	t.Helper()
 	out, err := EvaluateAllFiles(data, filePaths...)
 	if err != nil {

--- a/pkg/test/util/tmpl/execute.go
+++ b/pkg/test/util/tmpl/execute.go
@@ -22,7 +22,7 @@ import (
 )
 
 // Execute the template with the given parameters.
-func Execute(t *template.Template, data interface{}) (string, error) {
+func Execute(t *template.Template, data any) (string, error) {
 	var b bytes.Buffer
 	if err := t.Execute(&b, data); err != nil {
 		return "", err
@@ -32,7 +32,7 @@ func Execute(t *template.Template, data interface{}) (string, error) {
 }
 
 // ExecuteOrFail calls Execute and fails the test if it returns an error.
-func ExecuteOrFail(t test.Failer, t2 *template.Template, data interface{}) string {
+func ExecuteOrFail(t test.Failer, t2 *template.Template, data any) string {
 	t.Helper()
 	s, err := Execute(t2, data)
 	if err != nil {

--- a/pkg/test/util/yml/apply.go
+++ b/pkg/test/util/yml/apply.go
@@ -87,7 +87,7 @@ func MustApplyNamespace(t test.Failer, yamlText, ns string) string {
 }
 
 func applyNamespace(yamlText, ns string) (string, error) {
-	m := make(map[string]interface{})
+	m := make(map[string]any)
 	if err := yaml.Unmarshal([]byte(yamlText), &m); err != nil {
 		return "", err
 	}
@@ -109,13 +109,13 @@ func applyNamespace(yamlText, ns string) (string, error) {
 	return string(by), nil
 }
 
-func ensureChildMap(m map[string]interface{}, name string) (map[string]interface{}, error) {
+func ensureChildMap(m map[string]any, name string) (map[string]any, error) {
 	c, ok := m[name]
 	if !ok {
-		c = make(map[string]interface{})
+		c = make(map[string]any)
 	}
 
-	cm, ok := c.(map[string]interface{})
+	cm, ok := c.(map[string]any)
 	if !ok {
 		return nil, fmt.Errorf("child %q field is not a map: %v", name, reflect.TypeOf(c))
 	}

--- a/pkg/util/protomarshal/protomarshal.go
+++ b/pkg/util/protomarshal/protomarshal.go
@@ -109,14 +109,14 @@ func ToYAML(msg proto.Message) (string, error) {
 
 // ToJSONMap converts a proto message to a generic map using canonical JSON encoding
 // JSON encoding is specified here: https://developers.google.com/protocol-buffers/docs/proto3#json
-func ToJSONMap(msg proto.Message) (map[string]interface{}, error) {
+func ToJSONMap(msg proto.Message) (map[string]any, error) {
 	js, err := ToJSON(msg)
 	if err != nil {
 		return nil, err
 	}
 
 	// Unmarshal from json bytes to go map
-	var data map[string]interface{}
+	var data map[string]any
 	err = json.Unmarshal([]byte(js), &data)
 	if err != nil {
 		return nil, err

--- a/pkg/wasm/convert.go
+++ b/pkg/wasm/convert.go
@@ -23,7 +23,7 @@ import (
 	wasm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/wasm/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/conversion"
 	"go.uber.org/atomic"
-	any "google.golang.org/protobuf/types/known/anypb"
+	anypb "google.golang.org/protobuf/types/known/anypb"
 
 	extensions "istio.io/api/extensions/v1alpha1"
 	"istio.io/istio/pilot/pkg/model"
@@ -32,7 +32,7 @@ import (
 
 // MaybeConvertWasmExtensionConfig converts any presence of module remote download to local file.
 // It downloads the Wasm module and stores the module locally in the file system.
-func MaybeConvertWasmExtensionConfig(resources []*any.Any, cache Cache) bool {
+func MaybeConvertWasmExtensionConfig(resources []*anypb.Any, cache Cache) bool {
 	var wg sync.WaitGroup
 	numResources := len(resources)
 	wg.Add(numResources)
@@ -59,7 +59,7 @@ func MaybeConvertWasmExtensionConfig(resources []*any.Any, cache Cache) bool {
 	return sendNack.Load()
 }
 
-func convert(resource *any.Any, cache Cache) (newExtensionConfig *any.Any, sendNack bool) {
+func convert(resource *anypb.Any, cache Cache) (newExtensionConfig *anypb.Any, sendNack bool) {
 	ec := &core.TypedExtensionConfig{}
 	newExtensionConfig = resource
 	sendNack = false
@@ -184,7 +184,7 @@ func convert(resource *any.Any, cache Cache) (newExtensionConfig *any.Any, sendN
 		},
 	}
 
-	wasmTypedConfig, err := any.New(wasmHTTPFilterConfig)
+	wasmTypedConfig, err := anypb.New(wasmHTTPFilterConfig)
 	if err != nil {
 		status = marshalFailure
 		wasmLog.Errorf("failed to marshal new wasm HTTP filter %+v to protobuf Any: %v", wasmHTTPFilterConfig, err)
@@ -193,7 +193,7 @@ func convert(resource *any.Any, cache Cache) (newExtensionConfig *any.Any, sendN
 	ec.TypedConfig = wasmTypedConfig
 	wasmLog.Debugf("new extension config resource %+v", ec)
 
-	nec, err := any.New(ec)
+	nec, err := anypb.New(ec)
 	if err != nil {
 		status = marshalFailure
 		wasmLog.Errorf("failed to marshal new extension config resource: %v", err)

--- a/pkg/wasm/convert_test.go
+++ b/pkg/wasm/convert_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/envoyproxy/go-control-plane/pkg/conversion"
 	resource "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 	"google.golang.org/protobuf/proto"
-	any "google.golang.org/protobuf/types/known/anypb"
+	anypb "google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	extensions "istio.io/api/extensions/v1alpha1"
@@ -170,7 +170,7 @@ func TestWasmConvert(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			resources := make([]*any.Any, 0, len(c.input))
+			resources := make([]*anypb.Any, 0, len(c.input))
 			for _, i := range c.input {
 				resources = append(resources, protoconv.MessageToAny(i))
 			}

--- a/pkg/webhooks/validation/controller/controller.go
+++ b/pkg/webhooks/validation/controller/controller.go
@@ -138,7 +138,7 @@ func filterWatchedObject(obj metav1.Object) (skip bool, key string) {
 
 func makeHandler(queue workqueue.Interface, gvk schema.GroupVersionKind) *cache.ResourceEventHandlerFuncs {
 	return &cache.ResourceEventHandlerFuncs{
-		AddFunc: func(curr interface{}) {
+		AddFunc: func(curr any) {
 			obj, err := meta.Accessor(curr)
 			if err != nil {
 				return
@@ -155,7 +155,7 @@ func makeHandler(queue workqueue.Interface, gvk schema.GroupVersionKind) *cache.
 			}
 			queue.Add(req)
 		},
-		UpdateFunc: func(prev, curr interface{}) {
+		UpdateFunc: func(prev, curr any) {
 			currObj, err := meta.Accessor(curr)
 			if err != nil {
 				return

--- a/pkg/webhooks/validation/server/server_test.go
+++ b/pkg/webhooks/validation/server/server_test.go
@@ -116,7 +116,7 @@ func makePilotConfig(t *testing.T, i int, validConfig bool, includeBogusKey bool
 		t.Fatalf("Marshal(%v) failed: %v", name, err)
 	}
 	if includeBogusKey {
-		trial := make(map[string]interface{})
+		trial := make(map[string]any)
 		if err := json.Unmarshal(raw, &trial); err != nil {
 			t.Fatalf("Unmarshal(%v) failed: %v", name, err)
 		}

--- a/security/pkg/k8s/chiron/controller.go
+++ b/security/pkg/k8s/chiron/controller.go
@@ -226,7 +226,7 @@ func (wc *WebhookController) upsertSecret(secretName, dnsName, secretNamespace s
 	return nil
 }
 
-func (wc *WebhookController) scrtDeleted(obj interface{}) {
+func (wc *WebhookController) scrtDeleted(obj any) {
 	log.Debugf("enter WebhookController.scrtDeleted()")
 	scrt, ok := obj.(*v1.Secret)
 	if !ok {
@@ -252,7 +252,7 @@ func (wc *WebhookController) scrtDeleted(obj interface{}) {
 
 // scrtUpdated() is the callback function for update event. It handles
 // the certificate rotations.
-func (wc *WebhookController) scrtUpdated(oldObj, newObj interface{}) {
+func (wc *WebhookController) scrtUpdated(oldObj, newObj any) {
 	log.Debugf("enter WebhookController.scrtUpdated()")
 	scrt, ok := newObj.(*v1.Secret)
 	if !ok {

--- a/security/pkg/k8s/chiron/controller_test.go
+++ b/security/pkg/k8s/chiron/controller_test.go
@@ -375,7 +375,7 @@ func TestScrtUpdated(t *testing.T) {
 			scrt.Data[ca.RootCertFile] = []byte(exampleCACert2)
 		}
 
-		var newScrt interface{}
+		var newScrt any
 		if tc.invalidNewSecret {
 			// point to an invalid secret object
 			newScrt = &v1.ConfigMap{}

--- a/security/pkg/pki/util/generate_cert.go
+++ b/security/pkg/pki/util/generate_cert.go
@@ -134,7 +134,7 @@ func GenCertKeyFromOptions(options CertOptions) (pemCert []byte, pemKey []byte, 
 	return genCert(options, rsaPriv, &rsaPriv.PublicKey)
 }
 
-func genCert(options CertOptions, priv interface{}, key interface{}) ([]byte, []byte, error) {
+func genCert(options CertOptions, priv any, key any) ([]byte, []byte, error) {
 	template, err := genCertTemplateFromOptions(options)
 	if err != nil {
 		return nil, nil, fmt.Errorf("cert generation fails at cert template creation (%v)", err)
@@ -152,7 +152,7 @@ func genCert(options CertOptions, priv interface{}, key interface{}) ([]byte, []
 	return pemCert, pemKey, err
 }
 
-func publicKey(priv interface{}) interface{} {
+func publicKey(priv any) any {
 	switch k := priv.(type) {
 	case *rsa.PrivateKey:
 		return &k.PublicKey
@@ -220,7 +220,7 @@ func MergeCertOptions(defaultOpts, deltaOpts CertOptions) CertOptions {
 }
 
 // GenCertFromCSR generates a X.509 certificate with the given CSR.
-func GenCertFromCSR(csr *x509.CertificateRequest, signingCert *x509.Certificate, publicKey interface{},
+func GenCertFromCSR(csr *x509.CertificateRequest, signingCert *x509.Certificate, publicKey any,
 	signingKey crypto.PrivateKey, subjectIDs []string, ttl time.Duration, isCA bool,
 ) (cert []byte, err error) {
 	tmpl, err := genCertTemplateFromCSR(csr, subjectIDs, ttl, isCA)
@@ -399,7 +399,7 @@ func genSerialNum() (*big.Int, error) {
 	return serialNum, nil
 }
 
-func encodePem(isCSR bool, csrOrCert []byte, priv interface{}, pkcs8 bool) (
+func encodePem(isCSR bool, csrOrCert []byte, priv any, pkcs8 bool) (
 	csrOrCertPem []byte, privPem []byte, err error,
 ) {
 	encodeMsg := "CERTIFICATE"

--- a/security/pkg/pki/util/generate_csr.go
+++ b/security/pkg/pki/util/generate_csr.go
@@ -40,7 +40,7 @@ const minimumRsaKeySize = 2048
 
 // GenCSR generates a X.509 certificate sign request and private key with the given options.
 func GenCSR(options CertOptions) ([]byte, []byte, error) {
-	var priv interface{}
+	var priv any
 	var err error
 	if options.ECSigAlg != "" {
 		switch options.ECSigAlg {

--- a/security/pkg/stsservice/mock/faketokenmanager.go
+++ b/security/pkg/stsservice/mock/faketokenmanager.go
@@ -62,7 +62,7 @@ func (tm *FakeTokenManager) SetRespStsParam(p stsservice.StsResponseParameters) 
 
 func (tm *FakeTokenManager) SetToken(t stsservice.TokenInfo) {
 	// erase map
-	tm.tokens.Range(func(key interface{}, value interface{}) bool {
+	tm.tokens.Range(func(key any, value any) bool {
 		tm.tokens.Delete(key)
 		return true
 	})
@@ -103,7 +103,7 @@ func (tm *FakeTokenManager) DumpTokenStatus() ([]byte, error) {
 	}
 
 	tokenStatus := make([]stsservice.TokenInfo, 0)
-	tm.tokens.Range(func(k interface{}, v interface{}) bool {
+	tm.tokens.Range(func(k any, v any) bool {
 		token := v.(stsservice.TokenInfo)
 		tokenStatus = append(tokenStatus, token)
 		return true

--- a/security/pkg/stsservice/tokenmanager/google/tokenexchangeplugin.go
+++ b/security/pkg/stsservice/tokenmanager/google/tokenexchangeplugin.go
@@ -478,7 +478,7 @@ func (p *Plugin) generateSTSRespInner(token string, expire int64) ([]byte, error
 // DumpTokenStatus dumps all token status in JSON
 func (p *Plugin) DumpPluginStatus() ([]byte, error) {
 	tokenStatus := make([]stsservice.TokenInfo, 0)
-	p.tokens.Range(func(k interface{}, v interface{}) bool {
+	p.tokens.Range(func(k any, v any) bool {
 		token := v.(stsservice.TokenInfo)
 		tokenStatus = append(tokenStatus, stsservice.TokenInfo{
 			TokenType: token.TokenType, IssueTime: token.IssueTime, ExpireTime: token.ExpireTime,

--- a/security/pkg/util/jwtutil.go
+++ b/security/pkg/util/jwtutil.go
@@ -121,7 +121,7 @@ func ExtractJwtAud(jwt string) ([]string, bool) {
 	return structuredPayload.Aud, true
 }
 
-func parseJwtClaims(token string) (map[string]interface{}, error) {
+func parseJwtClaims(token string) (map[string]any, error) {
 	parts := strings.Split(token, ".")
 	if len(parts) != 3 {
 		return nil, fmt.Errorf("token contains an invalid number of segments: %d, expected: 3", len(parts))
@@ -134,7 +134,7 @@ func parseJwtClaims(token string) (map[string]interface{}, error) {
 	}
 	dec := json.NewDecoder(bytes.NewBuffer(claimBytes))
 
-	claims := make(map[string]interface{})
+	claims := make(map[string]any)
 	if err := dec.Decode(&claims); err != nil {
 		return nil, fmt.Errorf("failed to decode the JWT claims")
 	}

--- a/security/proto/providers/google/meshca.pb.go
+++ b/security/proto/providers/google/meshca.pb.go
@@ -206,7 +206,7 @@ func file_security_proto_providers_google_meshca_proto_rawDescGZIP() []byte {
 }
 
 var file_security_proto_providers_google_meshca_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
-var file_security_proto_providers_google_meshca_proto_goTypes = []interface{}{
+var file_security_proto_providers_google_meshca_proto_goTypes = []any{
 	(*MeshCertificateRequest)(nil),  // 0: google.security.meshca.v1.MeshCertificateRequest
 	(*MeshCertificateResponse)(nil), // 1: google.security.meshca.v1.MeshCertificateResponse
 	(*duration.Duration)(nil),       // 2: google.protobuf.Duration
@@ -228,7 +228,7 @@ func file_security_proto_providers_google_meshca_proto_init() {
 		return
 	}
 	if !protoimpl.UnsafeEnabled {
-		file_security_proto_providers_google_meshca_proto_msgTypes[0].Exporter = func(v interface{}, i int) interface{} {
+		file_security_proto_providers_google_meshca_proto_msgTypes[0].Exporter = func(v any, i int) any {
 			switch v := v.(*MeshCertificateRequest); i {
 			case 0:
 				return &v.state
@@ -240,7 +240,7 @@ func file_security_proto_providers_google_meshca_proto_init() {
 				return nil
 			}
 		}
-		file_security_proto_providers_google_meshca_proto_msgTypes[1].Exporter = func(v interface{}, i int) interface{} {
+		file_security_proto_providers_google_meshca_proto_msgTypes[1].Exporter = func(v any, i int) any {
 			switch v := v.(*MeshCertificateResponse); i {
 			case 0:
 				return &v.state

--- a/security/proto/providers/google/meshca_grpc.pb.go
+++ b/security/proto/providers/google/meshca_grpc.pb.go
@@ -71,7 +71,7 @@ func RegisterMeshCertificateServiceServer(s grpc.ServiceRegistrar, srv MeshCerti
 	s.RegisterService(&MeshCertificateService_ServiceDesc, srv)
 }
 
-func _MeshCertificateService_CreateCertificate_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _MeshCertificateService_CreateCertificate_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(MeshCertificateRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -83,7 +83,7 @@ func _MeshCertificateService_CreateCertificate_Handler(srv interface{}, ctx cont
 		Server:     srv,
 		FullMethod: "/google.security.meshca.v1.MeshCertificateService/CreateCertificate",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(MeshCertificateServiceServer).CreateCertificate(ctx, req.(*MeshCertificateRequest))
 	}
 	return interceptor(ctx, in, info, handler)

--- a/tests/common/jwt/jwt_token_test.go
+++ b/tests/common/jwt/jwt_token_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/lestrrat-go/jwx/jws"
 )
 
-func getKey(jwksFile string, t *testing.T) interface{} {
+func getKey(jwksFile string, t *testing.T) any {
 	t.Helper()
 
 	data, err := os.ReadFile(jwksFile)
@@ -36,7 +36,7 @@ func getKey(jwksFile string, t *testing.T) interface{} {
 	if err != nil {
 		t.Fatalf("failed to parse jwks: %s", err)
 	}
-	var key interface{}
+	var key any
 	k, _ := jwks.Get(0)
 	if err := k.Raw(&key); err != nil {
 		t.Fatalf("failed to materialize jwks: %s", err)
@@ -48,14 +48,14 @@ func TestSampleJwtToken(t *testing.T) {
 	testCases := []struct {
 		name        string
 		token       string
-		wantClaims  map[string]interface{}
+		wantClaims  map[string]any
 		wantInvalid bool
 	}{
 		{
 			name:  "TokenIssuer1",
 			token: TokenIssuer1,
-			wantClaims: map[string]interface{}{
-				"groups": []interface{}{"group-1"},
+			wantClaims: map[string]any{
+				"groups": []any{"group-1"},
 				"iss":    "test-issuer-1@istio.io",
 				"sub":    "sub-1",
 				"exp":    4715782722.0,
@@ -64,11 +64,11 @@ func TestSampleJwtToken(t *testing.T) {
 		{
 			name:  "TokenIssuer1NestedClaims1",
 			token: TokenIssuer1WithNestedClaims1,
-			wantClaims: map[string]interface{}{
-				"nested": map[string]interface{}{
-					"key1": []interface{}{"valueA", "valueB"},
-					"nested-2": map[string]interface{}{
-						"key1": []interface{}{"valueA", "valueB"},
+			wantClaims: map[string]any{
+				"nested": map[string]any{
+					"key1": []any{"valueA", "valueB"},
+					"nested-2": map[string]any{
+						"key1": []any{"valueA", "valueB"},
 					},
 				},
 				"iss": "test-issuer-1@istio.io",
@@ -79,10 +79,10 @@ func TestSampleJwtToken(t *testing.T) {
 		{
 			name:  "TokenIssuer1NestedClaims2",
 			token: TokenIssuer1WithNestedClaims2,
-			wantClaims: map[string]interface{}{
-				"nested": map[string]interface{}{
+			wantClaims: map[string]any{
+				"nested": map[string]any{
 					"key2": "valueC",
-					"nested-2": map[string]interface{}{
+					"nested-2": map[string]any{
 						"key2": "valueC",
 					},
 				},
@@ -94,8 +94,8 @@ func TestSampleJwtToken(t *testing.T) {
 		{
 			name:  "TokenIssuer2",
 			token: TokenIssuer2,
-			wantClaims: map[string]interface{}{
-				"groups": []interface{}{"group-2"},
+			wantClaims: map[string]any{
+				"groups": []any{"group-2"},
 				"iss":    "test-issuer-2@istio.io",
 				"sub":    "sub-2",
 				"exp":    4715782783.0,
@@ -104,8 +104,8 @@ func TestSampleJwtToken(t *testing.T) {
 		{
 			name:  "TokenExpired",
 			token: TokenExpired,
-			wantClaims: map[string]interface{}{
-				"groups": []interface{}{"group-1"},
+			wantClaims: map[string]any{
+				"groups": []any{"group-1"},
 				"iss":    "test-issuer-1@istio.io",
 				"sub":    "sub-1",
 				"exp":    1562182856.0,
@@ -131,7 +131,7 @@ func TestSampleJwtToken(t *testing.T) {
 			t.Fatalf("%s: failed to parse token: %v", tc.name, err)
 		}
 
-		claims := map[string]interface{}{}
+		claims := map[string]any{}
 		err = json.Unmarshal(token, &claims)
 		if err != nil {
 			t.Fatalf("%s: failed to parse payload: %v", tc.name, err)

--- a/tests/fuzz/crd_roundtrip_fuzzer.go
+++ b/tests/fuzz/crd_roundtrip_fuzzer.go
@@ -154,7 +154,7 @@ func dataAsString(data []byte) string {
 // checkForNilValues is a helper to check for nil
 // values in the runtime objects.
 // This part only converts the interface to a reflect.Value.
-func checkForNilValues(targetStruct interface{}) error {
+func checkForNilValues(targetStruct any) error {
 	v := reflect.ValueOf(targetStruct)
 	e := v.Elem()
 	err := checkForNil(e)

--- a/tests/fuzz/utils/utils.go
+++ b/tests/fuzz/utils/utils.go
@@ -26,13 +26,13 @@ func (n NopTester) Fail() {}
 
 func (n NopTester) FailNow() {}
 
-func (n NopTester) Fatal(args ...interface{}) {}
+func (n NopTester) Fatal(args ...any) {}
 
-func (n NopTester) Fatalf(format string, args ...interface{}) {}
+func (n NopTester) Fatalf(format string, args ...any) {}
 
-func (n NopTester) Log(args ...interface{}) {}
+func (n NopTester) Log(args ...any) {}
 
-func (n NopTester) Logf(format string, args ...interface{}) {}
+func (n NopTester) Logf(format string, args ...any) {}
 
 func (n NopTester) TempDir() string {
 	tempDir, _ := os.MkdirTemp("", "test")

--- a/tests/integration/operator/switch_cr_test.go
+++ b/tests/integration/operator/switch_cr_test.go
@@ -201,7 +201,7 @@ func checkInstallStatus(cs istioKube.ExtendedClient, revision string) error {
 
 			return fmt.Errorf("status not found from the istioOperator resource")
 		}
-		usIOPStatus = usIOPStatus.(map[string]interface{})
+		usIOPStatus = usIOPStatus.(map[string]any)
 		iopStatusString, err := json.Marshal(usIOPStatus)
 		if err != nil {
 			return fmt.Errorf("failed to marshal istioOperator status: %v", err)

--- a/tests/integration/pilot/analyze_test.go
+++ b/tests/integration/pilot/analyze_test.go
@@ -425,7 +425,7 @@ func expectNoMessages(t test.Failer, g *GomegaWithT, output []string) {
 func expectJSONMessages(t test.Failer, g *GomegaWithT, output string, expected ...*diag.MessageType) {
 	t.Helper()
 
-	var j []map[string]interface{}
+	var j []map[string]any
 	if err := json.Unmarshal([]byte(output), &j); err != nil {
 		t.Fatal(err)
 	}

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -707,8 +707,8 @@ spec:
 			toN:            len(split),
 			sourceMatchers: []match.Matcher{match.NotHeadless, match.NotNaked},
 			targetMatchers: []match.Matcher{match.NotHeadless, match.NotNaked, match.NotExternal, match.NotProxylessGRPC},
-			templateVars: func(_ echo.Callers, _ echo.Instances) map[string]interface{} {
-				return map[string]interface{}{
+			templateVars: func(_ echo.Callers, _ echo.Instances) map[string]any {
+				return map[string]any{
 					"split": split,
 				}
 			},
@@ -1010,12 +1010,12 @@ spec:
 }
 
 func gatewayCases(t TrafficContext) {
-	templateParams := func(protocol protocol.Instance, src echo.Callers, dests echo.Instances, ciphers []string) map[string]interface{} {
+	templateParams := func(protocol protocol.Instance, src echo.Callers, dests echo.Instances, ciphers []string) map[string]any {
 		hostName, dest, portN, cred := "*", dests[0], 80, ""
 		if protocol.IsTLS() {
 			hostName, portN, cred = dest.Config().ClusterLocalFQDN(), 443, "cred"
 		}
-		return map[string]interface{}{
+		return map[string]any{
 			"IngressNamespace":   src[0].(ingress.Instance).Namespace(),
 			"GatewayHost":        hostName,
 			"GatewayPort":        portN,
@@ -1156,9 +1156,9 @@ spec:
 			Check: check.OK(),
 		},
 		setupOpts: fqdnHostHeader,
-		templateVars: func(_ echo.Callers, dests echo.Instances) map[string]interface{} {
+		templateVars: func(_ echo.Callers, dests echo.Instances) map[string]any {
 			dest := dests[0]
-			return map[string]interface{}{
+			return map[string]any{
 				"Gateway":            "gateway",
 				"VirtualServiceHost": dest.Config().ClusterLocalFQDN(),
 				"Port":               dest.PortForName("http").ServicePort,
@@ -1169,7 +1169,7 @@ spec:
 		name: "cipher suite",
 		config: gatewayTmpl + httpVirtualServiceTmpl +
 			ingressutil.IngressKubeSecretYAML("cred", "{{.IngressNamespace}}", ingressutil.TLS, ingressutil.IngressCredentialA),
-		templateVars: func(src echo.Callers, dests echo.Instances) map[string]interface{} {
+		templateVars: func(src echo.Callers, dests echo.Instances) map[string]any {
 			// Test all cipher suites, including a fake one. Envoy should accept all of the ones on the "valid" list,
 			// and control plane should filter our invalid one.
 			return templateParams(protocol.HTTPS, src, dests, append(security.ValidCipherSuites.SortedList(), "fake"))
@@ -1216,9 +1216,9 @@ spec:
 			Check: check.Status(http.StatusMovedPermanently),
 		},
 		setupOpts: fqdnHostHeader,
-		templateVars: func(_ echo.Callers, dests echo.Instances) map[string]interface{} {
+		templateVars: func(_ echo.Callers, dests echo.Instances) map[string]any {
 			dest := dests[0]
-			return map[string]interface{}{
+			return map[string]any{
 				"Gateway":            "gateway",
 				"VirtualServiceHost": dest.Config().ClusterLocalFQDN(),
 				"Port":               443,
@@ -1287,9 +1287,9 @@ spec:
 			Check: check.Status(http.StatusBadRequest),
 		},
 		setupOpts: fqdnHostHeader,
-		templateVars: func(_ echo.Callers, dests echo.Instances) map[string]interface{} {
+		templateVars: func(_ echo.Callers, dests echo.Instances) map[string]any {
 			dest := dests[0]
-			return map[string]interface{}{
+			return map[string]any{
 				"Gateway":            "gateway",
 				"VirtualServiceHost": dest.Config().ClusterLocalFQDN(),
 				"Port":               443,
@@ -1328,9 +1328,9 @@ spec:
 				check.Protocol("HTTP/1.1")),
 		},
 		setupOpts: fqdnHostHeader,
-		templateVars: func(_ echo.Callers, dests echo.Instances) map[string]interface{} {
+		templateVars: func(_ echo.Callers, dests echo.Instances) map[string]any {
 			dest := dests[0]
-			return map[string]interface{}{
+			return map[string]any{
 				"Gateway":            "gateway",
 				"VirtualServiceHost": dest.Config().ClusterLocalFQDN(),
 				"Port":               ports.All().MustForName("auto-http").ServicePort,
@@ -1375,9 +1375,9 @@ spec:
 				check.RequestHeader("X-Envoy-Peer-Metadata", "")),
 		},
 		setupOpts: fqdnHostHeader,
-		templateVars: func(_ echo.Callers, dests echo.Instances) map[string]interface{} {
+		templateVars: func(_ echo.Callers, dests echo.Instances) map[string]any {
 			dest := dests[0]
-			return map[string]interface{}{
+			return map[string]any{
 				"Gateway":            "gateway",
 				"VirtualServiceHost": dest.Config().ClusterLocalFQDN(),
 				"Port":               ports.All().MustForName("auto-http").ServicePort,
@@ -1433,9 +1433,9 @@ spec:
 						check.RequestHeader("X-Envoy-Peer-Metadata", "")),
 				},
 				setupOpts: fqdnHostHeader,
-				templateVars: func(_ echo.Callers, dests echo.Instances) map[string]interface{} {
+				templateVars: func(_ echo.Callers, dests echo.Instances) map[string]any {
 					dest := dests[0]
-					return map[string]interface{}{
+					return map[string]any{
 						"Gateway":            "gateway",
 						"VirtualServiceHost": dest.Config().ClusterLocalFQDN(),
 						"Port":               ports.All().MustForName(port).ServicePort,
@@ -1453,7 +1453,7 @@ spec:
 		t.RunTraffic(TrafficTestCase{
 			name:   string(proto),
 			config: gatewayTmpl + httpVirtualServiceTmpl + secret,
-			templateVars: func(src echo.Callers, dests echo.Instances) map[string]interface{} {
+			templateVars: func(src echo.Callers, dests echo.Instances) map[string]any {
 				return templateParams(proto, src, dests, nil)
 			},
 			setupOpts: fqdnHostHeader,
@@ -1469,7 +1469,7 @@ spec:
 		t.RunTraffic(TrafficTestCase{
 			name:   fmt.Sprintf("%s scheme match", proto),
 			config: gatewayTmpl + httpVirtualServiceTmpl + secret,
-			templateVars: func(src echo.Callers, dests echo.Instances) map[string]interface{} {
+			templateVars: func(src echo.Callers, dests echo.Instances) map[string]any {
 				params := templateParams(proto, src, dests, nil)
 				params["MatchScheme"] = strings.ToLower(string(proto))
 				return params
@@ -1913,7 +1913,7 @@ spec:
     {{- if .Network }}
     topology.istio.io/network: {{.Network}}
 	{{- end }}
-`, map[string]interface{}{
+`, map[string]any{
 				"Service":        svcName,
 				"Network":        c.Config().Cluster.NetworkName(),
 				"Port":           ports.All().MustForName("http").ServicePort,
@@ -2414,7 +2414,7 @@ spec:
   - number: 80
     name: http
     protocol: HTTP
-`, map[string]interface{}{"IPs": ips})
+`, map[string]any{"IPs": ips})
 	}
 	ipv4 := "1.2.3.4"
 	ipv6 := "1234:1234:1234::1234:1234:1234"
@@ -2891,8 +2891,8 @@ spec:
 		workloadAgnostic: true,
 		viaIngress:       true,
 		config:           configAll,
-		templateVars: func(src echo.Callers, dest echo.Instances) map[string]interface{} {
-			return map[string]interface{}{
+		templateVars: func(src echo.Callers, dest echo.Instances) map[string]any {
+			return map[string]any{
 				"Headers": []configData{{"@request.auth.claims.nested.key1", "exact", "valueA"}},
 			}
 		},
@@ -2914,8 +2914,8 @@ spec:
 		workloadAgnostic: true,
 		viaIngress:       true,
 		config:           configAll,
-		templateVars: func(src echo.Callers, dest echo.Instances) map[string]interface{} {
-			return map[string]interface{}{
+		templateVars: func(src echo.Callers, dest echo.Instances) map[string]any {
+			return map[string]any{
 				"Headers": []configData{{"@request.auth.claims.sub", "prefix", "sub"}},
 			}
 		},
@@ -2937,8 +2937,8 @@ spec:
 		workloadAgnostic: true,
 		viaIngress:       true,
 		config:           configAll,
-		templateVars: func(src echo.Callers, dest echo.Instances) map[string]interface{} {
-			return map[string]interface{}{
+		templateVars: func(src echo.Callers, dest echo.Instances) map[string]any {
+			return map[string]any{
 				"Headers": []configData{
 					{"@request.auth.claims.nested.key1", "exact", "valueA"},
 					{"@request.auth.claims.sub", "prefix", "sub"},
@@ -2963,8 +2963,8 @@ spec:
 		workloadAgnostic: true,
 		viaIngress:       true,
 		config:           configAll,
-		templateVars: func(src echo.Callers, dest echo.Instances) map[string]interface{} {
-			return map[string]interface{}{
+		templateVars: func(src echo.Callers, dest echo.Instances) map[string]any {
+			return map[string]any{
 				"WithoutHeaders": []configData{{"@request.auth.claims.nested.key1", "exact", "value-not-matched"}},
 			}
 		},
@@ -2986,8 +2986,8 @@ spec:
 		workloadAgnostic: true,
 		viaIngress:       true,
 		config:           configAll,
-		templateVars: func(src echo.Callers, dest echo.Instances) map[string]interface{} {
-			return map[string]interface{}{
+		templateVars: func(src echo.Callers, dest echo.Instances) map[string]any {
+			return map[string]any{
 				"WithoutHeaders": []configData{{"@request.auth.claims.nested.key1", "exact", "valueA"}},
 			}
 		},
@@ -3009,8 +3009,8 @@ spec:
 		workloadAgnostic: true,
 		viaIngress:       true,
 		config:           configAll,
-		templateVars: func(src echo.Callers, dest echo.Instances) map[string]interface{} {
-			return map[string]interface{}{
+		templateVars: func(src echo.Callers, dest echo.Instances) map[string]any {
+			return map[string]any{
 				"Headers":        []configData{{"@request.auth.claims.sub", "prefix", "sub"}},
 				"WithoutHeaders": []configData{{"@request.auth.claims.nested.key1", "exact", "value-not-matched"}},
 			}
@@ -3033,8 +3033,8 @@ spec:
 		workloadAgnostic: true,
 		viaIngress:       true,
 		config:           configAll,
-		templateVars: func(src echo.Callers, dest echo.Instances) map[string]interface{} {
-			return map[string]interface{}{
+		templateVars: func(src echo.Callers, dest echo.Instances) map[string]any {
+			return map[string]any{
 				"Headers": []configData{
 					{"@request.auth.claims.nested.key1", "exact", "valueA"},
 					{"@request.auth.claims.sub", "prefix", "value-not-matched"},
@@ -3059,8 +3059,8 @@ spec:
 		workloadAgnostic: true,
 		viaIngress:       true,
 		config:           configAll,
-		templateVars: func(src echo.Callers, dest echo.Instances) map[string]interface{} {
-			return map[string]interface{}{
+		templateVars: func(src echo.Callers, dest echo.Instances) map[string]any {
+			return map[string]any{
 				"Headers": []configData{{"@request.auth.claims.sub", "exact", "value-not-matched"}},
 			}
 		},
@@ -3082,8 +3082,8 @@ spec:
 		workloadAgnostic: true,
 		viaIngress:       true,
 		config:           configAll,
-		templateVars: func(src echo.Callers, dest echo.Instances) map[string]interface{} {
-			return map[string]interface{}{
+		templateVars: func(src echo.Callers, dest echo.Instances) map[string]any {
+			return map[string]any{
 				"Headers": []configData{{"@request.auth.claims.nested.key1", "exact", "valueA"}},
 			}
 		},
@@ -3105,8 +3105,8 @@ spec:
 		workloadAgnostic: true,
 		viaIngress:       true,
 		config:           configAll,
-		templateVars: func(src echo.Callers, dest echo.Instances) map[string]interface{} {
-			return map[string]interface{}{
+		templateVars: func(src echo.Callers, dest echo.Instances) map[string]any {
+			return map[string]any{
 				"Headers": []configData{{"@request.auth.claims.nested.key1", "exact", "valueA"}},
 			}
 		},
@@ -3128,8 +3128,8 @@ spec:
 		workloadAgnostic: true,
 		viaIngress:       true,
 		config:           configAll,
-		templateVars: func(src echo.Callers, dest echo.Instances) map[string]interface{} {
-			return map[string]interface{}{
+		templateVars: func(src echo.Callers, dest echo.Instances) map[string]any {
+			return map[string]any{
 				"Headers": []configData{{"@request.auth.claims.nested.key1", "exact", "valueA"}},
 			}
 		},
@@ -3152,8 +3152,8 @@ spec:
 		workloadAgnostic: true,
 		viaIngress:       true,
 		config:           configRoute,
-		templateVars: func(src echo.Callers, dest echo.Instances) map[string]interface{} {
-			return map[string]interface{}{
+		templateVars: func(src echo.Callers, dest echo.Instances) map[string]any {
+			return map[string]any{
 				"Headers": []configData{{"@request.auth.claims.nested.key1", "exact", "valueA"}},
 			}
 		},

--- a/tests/integration/pilot/common/traffic.go
+++ b/tests/integration/pilot/common/traffic.go
@@ -81,7 +81,7 @@ type TrafficTestCase struct {
 	// comboFilters allows conditionally filtering based on pairs of apps
 	comboFilters []echotest.CombinationFilter
 	// vars given to the config template
-	templateVars func(src echo.Callers, dest echo.Instances) map[string]interface{}
+	templateVars func(src echo.Callers, dest echo.Instances) map[string]any
 
 	// minIstioVersion allows conditionally skipping based on required version
 	minIstioVersion string
@@ -112,7 +112,7 @@ func (c TrafficTestCase) RunForApps(t framework.TestContext, apps echo.Instances
 	job := func(t framework.TestContext) {
 		echoT := echotest.New(t, apps).
 			SetupForServicePair(func(t framework.TestContext, src echo.Callers, dsts echo.Services) error {
-				tmplData := map[string]interface{}{
+				tmplData := map[string]any{
 					// tests that use simple Run only need the first
 					"dst":    dsts[0],
 					"dstSvc": dsts[0][0].Config().Service,

--- a/tests/integration/pilot/istioctl_test.go
+++ b/tests/integration/pilot/istioctl_test.go
@@ -341,9 +341,9 @@ func TestProxyConfig(t *testing.T) {
 		})
 }
 
-func jsonUnmarshallOrFail(t test.Failer, context, s string) interface{} {
+func jsonUnmarshallOrFail(t test.Failer, context, s string) any {
 	t.Helper()
-	var val interface{}
+	var val any
 
 	// this is guarded by prettyPrint
 	if err := json.Unmarshal([]byte(s), &val); err != nil {

--- a/tests/integration/pilot/locality_test.go
+++ b/tests/integration/pilot/locality_test.go
@@ -266,7 +266,7 @@ func sendTrafficOrFail(t framework.TestContext, from echo.Instance, host string,
 	})
 }
 
-func runTemplate(t test.Failer, tmpl string, input interface{}) string {
+func runTemplate(t test.Failer, tmpl string, input any) string {
 	tt, err := template.New("").Funcs(sprig.TxtFuncMap()).Parse(tmpl)
 	if err != nil {
 		t.Fatal(err)

--- a/tests/integration/pilot/multicluster_test.go
+++ b/tests/integration/pilot/multicluster_test.go
@@ -107,7 +107,7 @@ spec:
         host: {{$.host}}
         subset: {{ .Config.Cluster.Name }}
 {{- end }}
-`, map[string]interface{}{"src": sources, "dst": to, "host": to.Config().ClusterLocalFQDN()})
+`, map[string]any{"src": sources, "dst": to, "host": to.Config().ClusterLocalFQDN()})
 						t.ConfigIstio().YAML(sources.Config().Namespace.Name(), cfg).ApplyOrFail(t)
 					},
 				},

--- a/tests/integration/pilot/tunneling_test.go
+++ b/tests/integration/pilot/tunneling_test.go
@@ -117,7 +117,7 @@ func TestTunnelingOutboundTraffic(t *testing.T) {
 			externalForwardProxyIP := getPodIP(ctx, externalNs, "external-forward-proxy")
 
 			for _, proxyConfig := range forwardProxyConfigurations {
-				templateParams := map[string]interface{}{
+				templateParams := map[string]any{
 					"externalNamespace":  externalNs,
 					"forwardProxyPort":   proxyConfig.Port,
 					"tlsEnabled":         proxyConfig.TLSEnabled,

--- a/tests/integration/pilot/validation_test.go
+++ b/tests/integration/pilot/validation_test.go
@@ -197,7 +197,7 @@ func TestEnsureNoMissingCRDs(t *testing.T) {
 						t.Fatalf("error loading test data: %v", err)
 					}
 
-					m := make(map[string]interface{})
+					m := make(map[string]any)
 					by, er := yaml.YAMLToJSON([]byte(yamlPart))
 					if er != nil {
 						t.Fatalf("error loading test data: %v", er)

--- a/tests/integration/security/egress_gateway_origination_test.go
+++ b/tests/integration/security/egress_gateway_origination_test.go
@@ -235,7 +235,7 @@ func TestMutualTlsOrigination(t *testing.T) {
 // routed to egress-gateway service in istio-system namespace and then from egress-gateway to server in server namespace.
 // TLS origination at Gateway happens using DestinationRule with CredentialName reading k8s secret at the gateway proxy.
 func newTLSGateway(t test.Failer, ctx resource.Context, clientNamespace namespace.Instance, to echo.Instances) {
-	args := map[string]interface{}{"to": to}
+	args := map[string]any{"to": to}
 
 	gateway := `
 apiVersion: networking.istio.io/v1beta1
@@ -313,7 +313,7 @@ spec:
 }
 
 func newTLSGatewayDestinationRule(t framework.TestContext, to echo.Instances, destinationRuleMode string, credentialName string) {
-	args := map[string]interface{}{
+	args := map[string]any{
 		"to":             to,
 		"Mode":           destinationRuleMode,
 		"CredentialName": credentialName,

--- a/tests/integration/security/external_ca/main_test.go
+++ b/tests/integration/security/external_ca/main_test.go
@@ -135,7 +135,7 @@ components:
                 name: inject-volume
                 mountPath: /var/lib/istio/inject
 {{- end }}
-`, map[string]interface{}{
+`, map[string]any{
 		"rootcert1":              cert1.Rootcert,
 		"signer1":                cert1.Signer,
 		"rootcert2":              cert2.Rootcert,

--- a/tests/integration/security/sds_ingress/util/util.go
+++ b/tests/integration/security/sds_ingress/util/util.go
@@ -469,7 +469,7 @@ spec:
     - "{{.Host}}"
 `
 
-func runTemplate(t test.Failer, tmpl string, params interface{}) string {
+func runTemplate(t test.Failer, tmpl string, params any) string {
 	tm, err := template.New("").Parse(tmpl)
 	if err != nil {
 		t.Fatalf("failed to render template: %v", err)

--- a/tests/integration/telemetry/policy/envoy_ratelimit_test.go
+++ b/tests/integration/telemetry/policy/envoy_ratelimit_test.go
@@ -174,7 +174,7 @@ func setupEnvoyFilter(ctx framework.TestContext, file string) func() {
 		ctx.Fatal(err)
 	}
 
-	con, err := tmpl.Evaluate(string(content), map[string]interface{}{
+	con, err := tmpl.Evaluate(string(content), map[string]any{
 		"EchoNamespace":      echoNsInst.Name(),
 		"RateLimitNamespace": ratelimitNs.Name(),
 	})

--- a/tests/integration/telemetry/stackdriver/common.go
+++ b/tests/integration/telemetry/stackdriver/common.go
@@ -87,7 +87,7 @@ func TestSetup(ctx resource.Context) (err error) {
 		return
 	}
 
-	err = ctx.ConfigKube().EvalFile(EchoNsInst.Name(), map[string]interface{}{
+	err = ctx.ConfigKube().EvalFile(EchoNsInst.Name(), map[string]any{
 		"StackdriverAddress": SDInst.Address(),
 		"EchoNamespace":      EchoNsInst.Name(),
 		"UseRealSD":          stackdriver.UseRealStackdriver(),
@@ -270,7 +270,7 @@ func unmarshalFromTemplateFile(file string, out proto.Message, clName, trustDoma
 	if err != nil {
 		return err
 	}
-	resource, err := tmpl.Evaluate(string(templateFile), map[string]interface{}{
+	resource, err := tmpl.Evaluate(string(templateFile), map[string]any{
 		"EchoNamespace": EchoNsInst.Name(),
 		"ClusterName":   clName,
 		"TrustDomain":   trustDomain,

--- a/tests/integration/telemetry/stackdriver/vm/main_test.go
+++ b/tests/integration/telemetry/stackdriver/vm/main_test.go
@@ -171,7 +171,7 @@ func testSetup(ctx resource.Context) error {
 	}
 	sdtest.SDInst = sdInst
 
-	if err = ctx.ConfigKube().EvalFile(ns.Name(), map[string]interface{}{
+	if err = ctx.ConfigKube().EvalFile(ns.Name(), map[string]any{
 		"StackdriverAddress": sdInst.Address(),
 		"EchoNamespace":      ns.Name(),
 	}, stackdriverBootstrapOverride).Apply(); err != nil {
@@ -258,7 +258,7 @@ func goldenRequestCounts(trustDomain string) (cltRequestCount, srvRequestCount *
 	if err != nil {
 		return
 	}
-	sr, err := tmpl.Evaluate(string(srvRequestCountTmpl), map[string]interface{}{
+	sr, err := tmpl.Evaluate(string(srvRequestCountTmpl), map[string]any{
 		"EchoNamespace": ns.Name(),
 		"TrustDomain":   trustDomain,
 	})
@@ -274,7 +274,7 @@ func goldenRequestCounts(trustDomain string) (cltRequestCount, srvRequestCount *
 	if err != nil {
 		return
 	}
-	cr, err := tmpl.Evaluate(string(cltRequestCountTmpl), map[string]interface{}{
+	cr, err := tmpl.Evaluate(string(cltRequestCountTmpl), map[string]any{
 		"EchoNamespace": ns.Name(),
 		"TrustDomain":   trustDomain,
 	})
@@ -290,7 +290,7 @@ func goldenLogEntry(trustDomain string) (srvLogEntry *loggingpb.LogEntry, err er
 	if err != nil {
 		return
 	}
-	sr, err := tmpl.Evaluate(string(srvlogEntryTmpl), map[string]interface{}{
+	sr, err := tmpl.Evaluate(string(srvlogEntryTmpl), map[string]any{
 		"EchoNamespace": ns.Name(),
 		"TrustDomain":   trustDomain,
 	})
@@ -309,7 +309,7 @@ func goldenTrace(trustDomain string) (*cloudtrace.Trace, error) {
 	if err != nil {
 		return nil, err
 	}
-	traceStr, err := tmpl.Evaluate(string(traceTmpl), map[string]interface{}{
+	traceStr, err := tmpl.Evaluate(string(traceTmpl), map[string]any{
 		"EchoNamespace": ns.Name(),
 		"TrustDomain":   trustDomain,
 	})

--- a/tests/integration/telemetry/stats/prometheus/customizemetrics/customize_metrics_test.go
+++ b/tests/integration/telemetry/stats/prometheus/customizemetrics/customize_metrics_test.go
@@ -252,7 +252,7 @@ func setupWasmExtension(ctx resource.Context) error {
 		useRemoteWasmModule = true
 	}
 
-	args := map[string]interface{}{
+	args := map[string]any{
 		"WasmRemoteLoad":  useRemoteWasmModule,
 		"AttributeGenURL": attrGenImageURL,
 		"DockerConfigJson": base64.StdEncoding.EncodeToString(

--- a/tests/integration/telemetry/stats/prometheus/nullvm/dashboard_test.go
+++ b/tests/integration/telemetry/stats/prometheus/nullvm/dashboard_test.go
@@ -356,7 +356,7 @@ func setupDashboardTest(done <-chan struct{}) {
 // Equivalent to jq command: '.panels[].targets[]?.expr'
 func extractQueries(dash string) ([]string, error) {
 	var queries []string
-	js := map[string]interface{}{}
+	js := map[string]any{}
 	if err := json.Unmarshal([]byte(dash), &js); err != nil {
 		return nil, err
 	}
@@ -364,22 +364,22 @@ func extractQueries(dash string) ([]string, error) {
 	if !f {
 		return nil, fmt.Errorf("failed to find panels in %v", dash)
 	}
-	panelsList, f := panels.([]interface{})
+	panelsList, f := panels.([]any)
 	if !f {
 		return nil, fmt.Errorf("failed to find panelsList in type %T: %v", panels, panels)
 	}
 	for _, p := range panelsList {
-		pm := p.(map[string]interface{})
+		pm := p.(map[string]any)
 		targets, f := pm["targets"]
 		if !f {
 			continue
 		}
-		targetsList, f := targets.([]interface{})
+		targetsList, f := targets.([]any)
 		if !f {
 			return nil, fmt.Errorf("failed to find targetsList in type %T: %v", targets, targets)
 		}
 		for _, t := range targetsList {
-			tm := t.(map[string]interface{})
+			tm := t.(map[string]any)
 			expr, f := tm["expr"]
 			if !f {
 				return nil, fmt.Errorf("failed to find expr in %v", t)

--- a/tests/integration/telemetry/stats/prometheus/stats.go
+++ b/tests/integration/telemetry/stats/prometheus/stats.go
@@ -226,7 +226,7 @@ func TestStatsGatewayServerTCPFilter(t *testing.T, feature features.Feature) {
 			t.ConfigIstio().File(GetAppNamespace().Name(), filepath.Join(base, "istio-mtls-vs.yaml")).ApplyOrFail(t)
 
 			// The main SE is available only to app namespace, make one the egress can access.
-			t.ConfigIstio().Eval(ist.Settings().SystemNamespace, map[string]interface{}{
+			t.ConfigIstio().Eval(ist.Settings().SystemNamespace, map[string]any{
 				"Namespace": apps.External.Namespace.Name(),
 				"Hostname":  cdeployment.ExternalHostname,
 			}, `apiVersion: networking.istio.io/v1alpha3

--- a/tests/integration/telemetry/stats/prometheus/wasm/imagepullpolicy_test.go
+++ b/tests/integration/telemetry/stats/prometheus/wasm/imagepullpolicy_test.go
@@ -155,7 +155,7 @@ func TestImagePullPolicy(t *testing.T) {
 }
 
 func installWasmExtension(ctx framework.TestContext, pluginName, wasmModuleURL, imagePullPolicy, pluginVersion string) error {
-	args := map[string]interface{}{
+	args := map[string]any{
 		"WasmPluginName":    pluginName,
 		"TestWasmModuleURL": wasmModuleURL,
 		"WasmPluginVersion": pluginVersion,
@@ -175,7 +175,7 @@ func installWasmExtension(ctx framework.TestContext, pluginName, wasmModuleURL, 
 }
 
 func uninstallWasmExtension(ctx framework.TestContext, pluginName string) error {
-	args := map[string]interface{}{
+	args := map[string]any{
 		"WasmPluginName": pluginName,
 	}
 	if err := ctx.ConfigIstio().EvalFile(common.GetAppNamespace().Name(), args, wasmConfigFile).Delete(); err != nil {

--- a/tests/integration/telemetry/stats/prometheus/wasm/testsetup.go
+++ b/tests/integration/telemetry/stats/prometheus/wasm/testsetup.go
@@ -42,7 +42,7 @@ func testSetup(ctx resource.Context) (err error) {
 		return
 	}
 
-	args := map[string]interface{}{
+	args := map[string]any{
 		"DockerConfigJson": base64.StdEncoding.EncodeToString(
 			[]byte(createDockerCredential(registryUser, registryPasswd, registry.Address()))),
 	}

--- a/tests/util/leak/check.go
+++ b/tests/util/leak/check.go
@@ -69,7 +69,7 @@ type TestingM interface {
 
 type TestingTB interface {
 	Cleanup(func())
-	Errorf(format string, args ...interface{})
+	Errorf(format string, args ...any)
 }
 
 var gracePeriod = time.Second * 5
@@ -160,10 +160,10 @@ func CheckMain(m TestingM) {
 
 // MustGarbageCollect asserts than an object was garbage collected by the end of the test.
 // The input must be a pointer to an object.
-func MustGarbageCollect(tb test.Failer, i interface{}) {
+func MustGarbageCollect(tb test.Failer, i any) {
 	tb.Helper()
 	collected := atomic.NewBool(false)
-	runtime.SetFinalizer(i, func(x interface{}) {
+	runtime.SetFinalizer(i, func(x any) {
 		collected.Store(true)
 	})
 	tb.Cleanup(func() {

--- a/tools/bug-report/pkg/cluster/cluster.go
+++ b/tools/bug-report/pkg/cluster/cluster.go
@@ -220,7 +220,7 @@ type Resources struct {
 	// Root is the first level in the cluster resource hierarchy.
 	// Each level in the hierarchy is a map[string]interface{} to the next level.
 	// The levels are: namespaces/deployments/pods/containers.
-	Root map[string]interface{}
+	Root map[string]any
 	// Labels maps a pod name to a map of labels key-values.
 	Labels map[string]map[string]string
 	// Annotations maps a pod name to a map of annotation key-values.
@@ -231,20 +231,20 @@ type Resources struct {
 
 func (r *Resources) insertContainer(namespace, deployment, pod, container string) {
 	if r.Root == nil {
-		r.Root = make(map[string]interface{})
+		r.Root = make(map[string]any)
 	}
 	if r.Root[namespace] == nil {
-		r.Root[namespace] = make(map[string]interface{})
+		r.Root[namespace] = make(map[string]any)
 	}
-	d := r.Root[namespace].(map[string]interface{})
+	d := r.Root[namespace].(map[string]any)
 	if d[deployment] == nil {
-		d[deployment] = make(map[string]interface{})
+		d[deployment] = make(map[string]any)
 	}
-	p := d[deployment].(map[string]interface{})
+	p := d[deployment].(map[string]any)
 	if p[pod] == nil {
-		p[pod] = make(map[string]interface{})
+		p[pod] = make(map[string]any)
 	}
-	c := p[pod].(map[string]interface{})
+	c := p[pod].(map[string]any)
 	c[container] = nil
 }
 
@@ -284,12 +284,12 @@ func (r *Resources) String() string {
 	return resourcesStringImpl(r.Root, "")
 }
 
-func resourcesStringImpl(node interface{}, prefix string) string {
+func resourcesStringImpl(node any, prefix string) string {
 	out := ""
 	if node == nil {
 		return ""
 	}
-	nv := node.(map[string]interface{})
+	nv := node.(map[string]any)
 	for k, n := range nv {
 		out += prefix + k + "\n"
 		out += resourcesStringImpl(n, prefix+"  ")

--- a/tools/bug-report/pkg/common/common.go
+++ b/tools/bug-report/pkg/common/common.go
@@ -121,7 +121,7 @@ func getVersionKey(clusterVersion string) string {
 	return clusterVersion
 }
 
-func LogAndPrintf(format string, a ...interface{}) {
+func LogAndPrintf(format string, a ...any) {
 	fmt.Printf(format, a...)
 	log.Info(fmt.Sprintf(format, a...))
 }

--- a/tools/bug-report/pkg/config/config.go
+++ b/tools/bug-report/pkg/config/config.go
@@ -273,7 +273,7 @@ func (d Duration) MarshalJSON() ([]byte, error) {
 }
 
 func (d *Duration) UnmarshalJSON(b []byte) error {
-	var v interface{}
+	var v any
 	if err := json.Unmarshal(b, &v); err != nil {
 		return err
 	}

--- a/tools/bug-report/pkg/filter/filter.go
+++ b/tools/bug-report/pkg/filter/filter.go
@@ -39,12 +39,12 @@ func getMatchingPathsForSpec(config *config.BugReportConfig, cluster *cluster2.R
 	return getMatchingPathsForSpecImpl(config, cluster, cluster.Root, nil, sets.New())
 }
 
-func getMatchingPathsForSpecImpl(config *config.BugReportConfig, cluster *cluster2.Resources, node map[string]interface{},
+func getMatchingPathsForSpecImpl(config *config.BugReportConfig, cluster *cluster2.Resources, node map[string]any,
 	path path.Path, matchingPaths sets.Set,
 ) (sets.Set, error) {
 	for pe, n := range node {
 		np := append(path, pe)
-		if nn, ok := n.(map[string]interface{}); ok {
+		if nn, ok := n.(map[string]any); ok {
 			// non-leaf node
 			mp, err := getMatchingPathsForSpecImpl(config, cluster, nn, np, matchingPaths)
 			if err != nil {

--- a/tools/bug-report/pkg/filter/filter_test.go
+++ b/tools/bug-report/pkg/filter/filter_test.go
@@ -88,7 +88,7 @@ ns1/p4:
 	ns1 = append(d1, d2...)
 
 	testClusterResources = &cluster2.Resources{
-		Root:        make(map[string]interface{}),
+		Root:        make(map[string]any),
 		Labels:      make(map[string]map[string]string),
 		Annotations: make(map[string]map[string]string),
 	}

--- a/tools/docker-builder/builder/crane.go
+++ b/tools/docker-builder/builder/crane.go
@@ -121,7 +121,7 @@ func ByteCount(b int64) string {
 func Build(b BuildSpec) error {
 	t0 := time.Now()
 	lt := t0
-	trace := func(d ...interface{}) {
+	trace := func(d ...any) {
 		log.WithLabels("image", b.Name, "total", time.Since(t0), "step", time.Since(lt)).Infof(d...)
 		lt = time.Now()
 	}


### PR DESCRIPTION
To align with new go 1.18 best practice

First commit: `gofmt -r 'any -> anypb' -w **/*.go`
Second commit: `gofmt -r 'interface{} -> any' -w *.go`