### PR TITLE
make use of go generics to remove MostSpecificHostMatch2

### DIFF
--- a/pilot/pkg/model/cluster_local.go
+++ b/pilot/pkg/model/cluster_local.go
@@ -33,7 +33,7 @@ type ClusterLocalHosts map[host.Name]struct{}
 // IsClusterLocal indicates whether the given host should be treated as a
 // cluster-local destination.
 func (c ClusterLocalHosts) IsClusterLocal(h host.Name) bool {
-	_, ok := MostSpecificHostMatch2(h, c)
+	_, ok := MostSpecificHostMatch(h, c)
 	return ok
 }
 

--- a/pilot/pkg/model/config.go
+++ b/pilot/pkg/model/config.go
@@ -275,55 +275,8 @@ func resolveGatewayName(gwname string, meta config.Meta) string {
 
 // MostSpecificHostMatch compares the map of the stack to the needle, and returns the longest element
 // matching the needle, or false if no element in the map matches the needle.
-func MostSpecificHostMatch(needle host.Name, m map[host.Name][]*ConsolidatedDestRule) (host.Name, bool) {
+func MostSpecificHostMatch[V any](needle host.Name, m map[host.Name]V) (host.Name, bool) {
 	matches := []host.Name{}
-
-	// exact match first
-	if m != nil {
-		if _, ok := m[needle]; ok {
-			return needle, true
-		}
-	}
-
-	if needle.IsWildCarded() {
-		for h := range m {
-			// both needle and h are wildcards
-			if h.IsWildCarded() {
-				if len(needle) < len(h) {
-					continue
-				}
-				if strings.HasSuffix(string(needle[1:]), string(h[1:])) {
-					matches = append(matches, h)
-				}
-			}
-		}
-	} else {
-		for h := range m {
-			// only n is wildcard
-			if h.IsWildCarded() {
-				if strings.HasSuffix(string(needle), string(h[1:])) {
-					matches = append(matches, h)
-				}
-			}
-		}
-	}
-	if len(matches) > 1 {
-		// Sort the host names, find the most specific one.
-		sort.Sort(host.Names(matches))
-	}
-	if len(matches) > 0 {
-		// TODO: return closest match out of all non-exact matching hosts
-		return matches[0], true
-	}
-	return "", false
-}
-
-// MostSpecificHostMatch2 compares the map of the stack to the needle, and returns the longest element
-// matching the needle, or false if no element in the map matches the needle.
-// TODO: merge with MostSpecificHostMatch once go 1.18 is used
-func MostSpecificHostMatch2(needle host.Name, m map[host.Name]struct{}) (host.Name, bool) {
-	matches := []host.Name{}
-
 	// exact match first
 	if m != nil {
 		if _, ok := m[needle]; ok {

--- a/pilot/pkg/model/config_test.go
+++ b/pilot/pkg/model/config_test.go
@@ -304,7 +304,7 @@ func TestMostSpecificHostMatch(t *testing.T) {
 		}
 
 		t.Run(fmt.Sprintf("[%d] %s", idx, tt.needle), func(t *testing.T) {
-			actual, found := model.MostSpecificHostMatch2(tt.needle, m)
+			actual, found := model.MostSpecificHostMatch(tt.needle, m)
 			if tt.want != "" && !found {
 				t.Fatalf("model.MostSpecificHostMatch(%q, %v) = %v, %t; want: %v", tt.needle, tt.in, actual, found, tt.want)
 			} else if actual != tt.want {
@@ -351,7 +351,7 @@ func BenchmarkMostSpecificHostMatch(b *testing.B) {
 		}
 		b.Run(bm.name, func(b *testing.B) {
 			for n := 0; n < b.N; n++ {
-				_, _ = model.MostSpecificHostMatch2(bm.needle, bm.hostsMap)
+				_, _ = model.MostSpecificHostMatch(bm.needle, bm.hostsMap)
 			}
 		})
 	}


### PR DESCRIPTION
**Please provide a description of this PR:**



**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
