### PR TITLE
fix multi WasmPlugin with different imagePullSecrets

### DIFF
--- a/pilot/pkg/xds/ecds.go
+++ b/pilot/pkg/xds/ecds.go
@@ -66,12 +66,11 @@ func (e *EcdsGenerator) Generate(proxy *model.Proxy, w *model.WatchedResource, r
 	}
 
 	secretResources := referencedSecrets(proxy, req.Push, w.ResourceNames)
-	var updatedSecrets map[model.ConfigKey]struct{}
 	// Check if the secret updates is relevant to Wasm image pull. If not relevant, skip pushing ECDS.
 	if !model.ConfigsHaveKind(req.ConfigsUpdated, kind.WasmPlugin) && !model.ConfigsHaveKind(req.ConfigsUpdated, kind.EnvoyFilter) &&
 		model.ConfigsHaveKind(req.ConfigsUpdated, kind.Secret) {
 		// Get the updated secrets
-		updatedSecrets = model.ConfigsOfKind(req.ConfigsUpdated, kind.Secret)
+		updatedSecrets := model.ConfigsOfKind(req.ConfigsUpdated, kind.Secret)
 		needsPush := false
 		for _, sr := range secretResources {
 			if _, found := updatedSecrets[model.ConfigKey{Kind: kind.Secret, Name: sr.Name, Namespace: sr.Namespace}]; found {
@@ -98,7 +97,7 @@ func (e *EcdsGenerator) Generate(proxy *model.Proxy, w *model.WatchedResource, r
 		}
 		// Inserts Wasm pull secrets in ECDS response, which will be used at xds proxy for image pull.
 		// Before forwarding to Envoy, xds proxy will remove the secret from ECDS response.
-		secrets = e.GeneratePullSecrets(proxy, updatedSecrets, secretResources, secretController, req)
+		secrets = e.GeneratePullSecrets(proxy, secretResources, secretController)
 	}
 
 	ec := e.Server.ConfigGenerator.BuildExtensionConfiguration(proxy, req.Push, w.ResourceNames, secrets)
@@ -118,8 +117,8 @@ func (e *EcdsGenerator) Generate(proxy *model.Proxy, w *model.WatchedResource, r
 	return resources, model.DefaultXdsLogDetails, nil
 }
 
-func (e *EcdsGenerator) GeneratePullSecrets(proxy *model.Proxy, updatedSecrets map[model.ConfigKey]struct{}, secretResources []SecretResource,
-	secretController credscontroller.Controller, req *model.PushRequest,
+func (e *EcdsGenerator) GeneratePullSecrets(proxy *model.Proxy, secretResources []SecretResource,
+	secretController credscontroller.Controller,
 ) map[string][]byte {
 	if proxy.VerifiedIdentity == nil {
 		log.Warnf("proxy %s is not authorized to receive secret. Ensure you are connecting over TLS port and are authenticated.", proxy.ID)
@@ -128,13 +127,6 @@ func (e *EcdsGenerator) GeneratePullSecrets(proxy *model.Proxy, updatedSecrets m
 
 	results := make(map[string][]byte)
 	for _, sr := range secretResources {
-		if updatedSecrets != nil {
-			if _, found := updatedSecrets[model.ConfigKey{Kind: kind.Secret, Name: sr.Name, Namespace: sr.Namespace}]; !found {
-				// This is an incremental update, filter out credscontroller that are not updated.
-				continue
-			}
-		}
-
 		cred, err := secretController.GetDockerCredential(sr.Name, sr.Namespace)
 		if err != nil {
 			log.Warnf("Failed to fetch docker credential %s: %v", sr.ResourceName, err)

--- a/pilot/pkg/xds/ecds_test.go
+++ b/pilot/pkg/xds/ecds_test.go
@@ -240,8 +240,10 @@ func TestECDSGenerate(t *testing.T) {
 			wantExtensions:   sets.Set{"default.default-plugin-with-sec": {}},
 			wantSecrets:      sets.Set{"default-docker-credential": {}},
 		},
+		// All the credentials should be sent to istio-agent even if one of them is only updated,
+		// because `istio-agent` does not keep the credentials.
 		{
-			name:           "multi_wasmplungin_update_secret",
+			name:           "multi_wasmplugin_update_secret",
 			proxyNamespace: "default",
 			request: &model.PushRequest{
 				Full: false,

--- a/pilot/pkg/xds/ecds_test.go
+++ b/pilot/pkg/xds/ecds_test.go
@@ -240,6 +240,19 @@ func TestECDSGenerate(t *testing.T) {
 			wantExtensions:   sets.Set{"default.default-plugin-with-sec": {}},
 			wantSecrets:      sets.Set{"default-docker-credential": {}},
 		},
+		{
+			name:           "multi_wasmplungin_update_secret",
+			proxyNamespace: "default",
+			request: &model.PushRequest{
+				Full: false,
+				ConfigsUpdated: map[model.ConfigKey]struct{}{
+					{Kind: kind.Secret, Name: "default-pull-secret", Namespace: "default"}: {},
+				},
+			},
+			watchedResources: []string{"default.default-plugin-with-sec", "istio-system.root-plugin"},
+			wantExtensions:   sets.Set{"default.default-plugin-with-sec": {}, "istio-system.root-plugin": {}},
+			wantSecrets:      sets.Set{"default-docker-credential": {}, "root-docker-credential": {}},
+		},
 	}
 
 	for _, tt := range cases {

--- a/releasenotes/notes/40093.yaml
+++ b/releasenotes/notes/40093.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: telemtry
+
+releaseNotes:
+  - |
+    **Fixed** an issue where updating secret cause `missing pulling secret`.

--- a/releasenotes/notes/40093.yaml
+++ b/releasenotes/notes/40093.yaml
@@ -1,7 +1,7 @@
 apiVersion: release-notes/v2
 kind: bug-fix
-area: telemtry
+area: telemetry
 
 releaseNotes:
   - |
-    **Fixed** an issue where updating secret cause `missing pulling secret`.
+    **Fixed** an issue where updating a secret caused a `missing pulling secret`


### PR DESCRIPTION
**Please provide a description of this PR:**

remove secret incremental update, display-metadata will fetch failed if secret `ghcr-zirain2` updated.

```yaml
apiVersion: extensions.istio.io/v1alpha1
kind: WasmPlugin
metadata:
  name: display-metadata
  namespace: default
spec:
  selector:
    matchLabels:
      app: httpbin
  url: oci://ghcr.io/zirain/display-metadata:latest
  imagePullSecret: ghcr-zirain
  imagePullPolicy: Always
  vmConfig:
    env:
      - name: POD_NAMESPACE
        valueFrom: HOST
---
apiVersion: extensions.istio.io/v1alpha1
kind: WasmPlugin
metadata:
  name: display-metadata2
  namespace: default
spec:
  selector:
    matchLabels:
      app: httpbin
  url: oci://ghcr.io/zirain/display-metadata:latest
  imagePullSecret: ghcr-zirain2
  imagePullPolicy: Always
  vmConfig:
    env:
      - name: POD_NAMESPACE
        valueFrom: HOST
```