### PR TITLE
Revert "Add a flag for app container name and retry verifyTrafficMirror"

### DIFF
--- a/pkg/test/framework/components/echo/kube/flags.go
+++ b/pkg/test/framework/components/echo/kube/flags.go
@@ -20,8 +20,6 @@ var (
 	serviceTemplateFile      = "service.yaml"
 	deploymentTemplateFile   = "deployment.yaml"
 	vmDeploymentTemplateFile = "vm_deployment.yaml"
-
-	appContainerName = "app"
 )
 
 func init() {
@@ -34,6 +32,4 @@ func init() {
 	flag.StringVar(&vmDeploymentTemplateFile, "istio.test.echo.kube.template.deployment.vm", vmDeploymentTemplateFile,
 		"Specifies the default template file to be used when generating the Kubernetes Deployment to simulate an instance of echo application in a VM. "+
 			"Can be either an absolute path or relative to the templates directory under the echo test component. A default will be selected if not specified.")
-	flag.StringVar(&appContainerName, "istio.test.echo.kube.container", appContainerName,
-		"Specifies the default container name to be used for the echo application. A default will be selected if not specified.")
 }

--- a/pkg/test/framework/components/echo/kube/workload.go
+++ b/pkg/test/framework/components/echo/kube/workload.go
@@ -36,6 +36,10 @@ import (
 	"istio.io/istio/pkg/test/util/retry"
 )
 
+const (
+	appContainerName = "app"
+)
+
 var _ echo.Workload = &workload{}
 
 type workloadConfig struct {

--- a/tests/integration/pilot/mirror_test.go
+++ b/tests/integration/pilot/mirror_test.go
@@ -22,7 +22,6 @@ import (
 	"math"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/go-multierror"
 	"k8s.io/apimachinery/pkg/util/rand"
@@ -156,10 +155,9 @@ func runMirrorTest(t *testing.T, options mirrorTestOptions) {
 										if expected == nil {
 											expected = apps.C
 										}
-										return retry.UntilSuccess(func() error {
-											return verifyTrafficMirror(apps.B, expected, c, testID)
-										}, []retry.Option{retry.Timeout(20 * time.Second), retry.BackoffDelay(10 * time.Millisecond), retry.Converge(2)}...)
-									}, []retry.Option{retry.Timeout(60 * time.Second), retry.BackoffDelay(10 * time.Millisecond), retry.Converge(2)}...)
+
+										return verifyTrafficMirror(apps.B, expected, c, testID)
+									}, echo.DefaultCallRetryOptions()...)
 								})
 							}
 						})


### PR DESCRIPTION
Reverts istio/istio#40053

I don't know why but this introduced a lot of flakes

https://prow.istio.io/view/gs/istio-prow/logs/integ-k8s-123_istio_postsubmit/1550681311402790912, https://prow.istio.io/view/gs/istio-prow/logs/integ-k8s-116_istio_postsubmit/1550614369828605952, etc. Revert for now