### PR TITLE
remove redundant todo

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -785,7 +785,6 @@ func (ps *PushContext) GatewayServices(proxy *Proxy) []*Service {
 }
 
 // add services from MeshConfig.ExtensionProviders
-// TODO: include cluster from EnvoyFilter such as global ratelimit [demo](https://istio.io/latest/docs/tasks/policy-enforcement/rate-limit/#global-rate-limit)
 func getHostsFromMeshConfig(ps *PushContext) sets.Set {
 	hostsFromMeshConfig := sets.New()
 


### PR DESCRIPTION
**Please provide a description of this PR:**

cluster will send to Gateway when enable `PILOT_FILTER_GATEWAY_CLUSTER_CONFIG`

```console
root@ecs-zirain:~/go/src/istio.io/istio# istioctl pc c istio-ingressgateway-5768d85bb8-tgqfm -nistio-system  | grep rate_limit_cluster
rate_limit_cluster     -        -          -             STRICT_DNS   

root@ecs-zirain:~/go/src/istio.io/istio# k get deploy istiod -nistio-system -oyaml | grep PILOT_FILTER_GATEWAY_CLUSTER_CONFIG -A5
        - name: PILOT_FILTER_GATEWAY_CLUSTER_CONFIG
          value: "true"
        - name: REVISION
          value: default
        - name: JWT_POLICY
          value: third-party-jwt
```

```yaml
apiVersion: networking.istio.io/v1alpha3
kind: EnvoyFilter
metadata:
  name: filter-ratelimit
  namespace: istio-system
spec:
  workloadSelector:
    # select by label in the same namespace
    labels:
      istio: ingressgateway
  configPatches:
    - applyTo: CLUSTER
      patch:
        operation: ADD
        # Adds the rate limit service cluster for rate limit service defined in step 1.
        value:
          name: rate_limit_cluster
          type: STRICT_DNS
          connect_timeout: 10s
          lb_policy: ROUND_ROBIN
          http2_protocol_options: {}
          load_assignment:
            cluster_name: rate_limit_cluster
            endpoints:
              - lb_endpoints:
                  - endpoint:
                      address:
                        socket_address:
                          address: ratelimit.default.svc.cluster.local
                          port_value: 8081

```