### PR TITLE
Use absolute path when adding file watcher

### DIFF
--- a/security/pkg/nodeagent/cache/secretcache.go
+++ b/security/pkg/nodeagent/cache/secretcache.go
@@ -343,7 +343,11 @@ func (sc *SecretManagerClient) tryAddFileWatcher(file string, resourceName strin
 	// avoid processing duplicate events for the same file.
 	sc.certMutex.Lock()
 	defer sc.certMutex.Unlock()
-	file = filepath.Clean(file)
+	file, err := filepath.Abs(file)
+	if err != nil {
+		cacheLog.Errorf("%v: error finding absolute path of %s, retrying watches [%s] %v", resourceName, file, err)
+		return err
+	}
 	key := FileCert{
 		ResourceName: resourceName,
 		Filename:     file,


### PR DESCRIPTION
**Please provide a description of this PR:**
Fixes: https://github.com/istio/istio/issues/39985

Given there exists a DestinationRule with mode: MUTUAL, and paths for the private key, certificate and ca certificate of the form:
```
apiVersion: networking.istio.io/v1beta1
kind: DestinationRule
metadata:
  name: bad-dr
  namespace: foobar
spec:
  exportTo:
  - .
  host: service-mesh-debug
  trafficPolicy:
    tls:
      caCertificates: /etc/certs/root-cert.pem
      clientCertificate: /etc/certs/cert-chain.pem
      mode: MUTUAL
      privateKey: /etc/certs/key.pem
```

When the listeners are configured to listen on `etc/certs/cert-chain.pem` (notice there is no slash `/` before etc), then there are two sets of file watch add events:
1. One for files with path starting from `etc/certs`
2. and another for files with path starting from `/etc/certs`

When these files are removed, and re-added as part of certificate rotation, the operating system will only send one notification event, and that will be responsible for doing an SDS push. But given that the paths are different, and there is only one inotify event, only one set of SDS pushes will happen. Which means that this condition - https://github.com/istio/istio/blob/9a896c99db0ee9300651a08fb5cf410da7026bc9/security/pkg/nodeagent/cache/secretcache.go#L684 will only be met once. Resulting in just one of the sets (either one starting with `/` or one starting without `/`) of certificates being pushed to envoy via SDS