### PR TITLE
Fix ist0103 msg incorrect displaying when injection label is set to false

### DIFF
--- a/pkg/config/analysis/analyzers/injection/injection.go
+++ b/pkg/config/analysis/analyzers/injection/injection.go
@@ -135,7 +135,11 @@ func (a *Analyzer) Analyze(c analysis.Context) {
 		}
 
 		// If a pod has injection explicitly disabled, no need to check further
-		if val := r.Metadata.Annotations[annotation.SidecarInject.Name]; strings.EqualFold(val, "false") {
+		inj := r.Metadata.Annotations[annotation.SidecarInject.Name]
+		if v, ok := r.Metadata.Labels[annotation.SidecarInject.Name]; ok {
+			inj = v
+		}
+		if strings.EqualFold(inj, "false") {
 			return true
 		}
 

--- a/pkg/config/analysis/analyzers/testdata/injection.yaml
+++ b/pkg/config/analysis/analyzers/testdata/injection.yaml
@@ -117,7 +117,7 @@ spec:
 apiVersion: v1
 kind: Pod
 metadata:
-  name: podinjectiondisabled-label
+  name: podinjectiondisabled-label-and-anno
   namespace: default
   annotations:
     sidecar.istio.io/inject: "true"

--- a/pkg/config/analysis/analyzers/testdata/injection.yaml
+++ b/pkg/config/analysis/analyzers/testdata/injection.yaml
@@ -99,3 +99,31 @@ spec:
   containers:
   - image: gcr.io/google-samples/microservices-demo/adservice:v0.1.1
     name: server
+---
+# Pod that explicitly disables injection with label. Should not generate a warning.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: podinjectiondisabled-label
+  namespace: default
+  labels:
+    sidecar.istio.io/inject: "false"
+spec:
+  containers:
+    - image: gcr.io/google-samples/microservices-demo/adservice:v0.1.1
+      name: server
+---
+# Pod that explicitly disables injection with label. Should not generate a warning.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: podinjectiondisabled-label
+  namespace: default
+  annotations:
+    sidecar.istio.io/inject: "true"
+  labels:
+    sidecar.istio.io/inject: "false"
+spec:
+  containers:
+    - image: gcr.io/google-samples/microservices-demo/adservice:v0.1.1
+      name: server


### PR DESCRIPTION
**Please provide a description of this PR:**
```
Warning [IST0103] (Pod default/reviews-v2-5b5dc658c5-z4c9s) The pod default/reviews-v2-5b5dc658c5-z4c9s is missing the Istio proxy. This can often be resolved by restarting or redeploying the workload.
Error: Analyzers found issues when analyzing namespace: default.
```
```
kubectl get deploy reviews-v2 -oyaml | grep sidecar. -B2
      labels:
        app: reviews
        sidecar.istio.io/inject: "false"
```


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [x] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
