### PR TITLE
test: use `T.Setenv` to set env vars in tests

### DIFF
--- a/cni/pkg/plugin/plugin_dryrun_test.go
+++ b/cni/pkg/plugin/plugin_dryrun_test.go
@@ -173,14 +173,13 @@ func TestIPTablesRuleGeneration(t *testing.T) {
 			if _, err := os.Create(outputFilePath); err != nil {
 				t.Fatalf("Failed to create temp file for IPTables rule output: %v", err)
 			}
-			os.Setenv(dryRunFilePath.Name, outputFilePath)
+			t.Setenv(dryRunFilePath.Name, outputFilePath)
 			_, _, err := testutils.CmdAddWithArgs(
 				&skel.CmdArgs{
 					Netns:     sandboxDirectory,
 					IfName:    ifname,
 					StdinData: []byte(cniConf),
 				}, func() error { return CmdAdd(args) })
-			os.Unsetenv(dryRunFilePath.Name)
 			if err != nil {
 				t.Fatalf("CNI cmdAdd failed with error: %v", err)
 			}

--- a/pilot/pkg/config/kube/ingress/status_test.go
+++ b/pilot/pkg/config/kube/ingress/status_test.go
@@ -16,7 +16,6 @@ package ingress
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	coreV1 "k8s.io/api/core/v1"
@@ -110,9 +109,7 @@ func fakeMeshHolder(ingressService string) mesh.Holder {
 }
 
 func makeStatusSyncer(t *testing.T) *StatusSyncer {
-	oldEnvs := setAndRestoreEnv(t, map[string]string{"POD_NAME": pod, "POD_NAMESPACE": testNamespace})
-	// Restore env settings
-	defer setAndRestoreEnv(t, oldEnvs)
+	setEnvs(t, map[string]string{"POD_NAME": pod, "POD_NAMESPACE": testNamespace})
 
 	client := kubelib.NewFakeClient()
 	setupFake(t, client)
@@ -122,17 +119,11 @@ func makeStatusSyncer(t *testing.T) *StatusSyncer {
 	return sync
 }
 
-// setAndRestoreEnv set the envs with given value, and return the old setting.
-func setAndRestoreEnv(t *testing.T, inputs map[string]string) map[string]string {
-	oldEnvs := map[string]string{}
+// setEnvs set the envs with given value.
+func setEnvs(t *testing.T, inputs map[string]string) {
 	for k, v := range inputs {
-		oldEnvs[k] = os.Getenv(k)
-		if err := os.Setenv(k, v); err != nil {
-			t.Error(err)
-		}
+		t.Setenv(k, v)
 	}
-
-	return oldEnvs
 }
 
 func TestRunningAddresses(t *testing.T) {

--- a/pilot/pkg/config/kube/ingressv1/status_test.go
+++ b/pilot/pkg/config/kube/ingressv1/status_test.go
@@ -16,7 +16,6 @@ package ingress
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	coreV1 "k8s.io/api/core/v1"
@@ -110,9 +109,7 @@ func fakeMeshHolder(ingressService string) mesh.Holder {
 }
 
 func makeStatusSyncer(t *testing.T) *StatusSyncer {
-	oldEnvs := setAndRestoreEnv(t, map[string]string{"POD_NAME": pod, "POD_NAMESPACE": testNamespace})
-	// Restore env settings
-	defer setAndRestoreEnv(t, oldEnvs)
+	setEnvs(t, map[string]string{"POD_NAME": pod, "POD_NAMESPACE": testNamespace})
 
 	client := kubelib.NewFakeClient()
 	setupFake(t, client)
@@ -121,17 +118,11 @@ func makeStatusSyncer(t *testing.T) *StatusSyncer {
 	return sync
 }
 
-// setAndRestoreEnv set the envs with given value, and return the old setting.
-func setAndRestoreEnv(t *testing.T, inputs map[string]string) map[string]string {
-	oldEnvs := map[string]string{}
+// setEnvs set the envs with given value.
+func setEnvs(t *testing.T, inputs map[string]string) {
 	for k, v := range inputs {
-		oldEnvs[k] = os.Getenv(k)
-		if err := os.Setenv(k, v); err != nil {
-			t.Error(err)
-		}
+		t.Setenv(k, v)
 	}
-
-	return oldEnvs
 }
 
 func TestRunningAddresses(t *testing.T) {

--- a/pilot/pkg/networking/core/v1alpha3/route/route_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route_test.go
@@ -15,7 +15,6 @@
 package route_test
 
 import (
-	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -71,8 +70,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		g := gomega.NewWithT(t)
 		cg := v1alpha3.NewConfigGenTest(t, v1alpha3.TestOptions{})
 
-		os.Setenv("ISTIO_DEFAULT_REQUEST_TIMEOUT", "0ms")
-		defer os.Unsetenv("ISTIO_DEFAULT_REQUEST_TIMEOUT")
+		t.Setenv("ISTIO_DEFAULT_REQUEST_TIMEOUT", "0ms")
 
 		routes, err := route.BuildHTTPRoutesForVirtualService(node(cg), virtualServicePlain, serviceRegistry, nil, 8080, gatewayNames, false, nil)
 		xdstest.ValidateRoutes(t, routes)

--- a/pkg/bootstrap/config_test.go
+++ b/pkg/bootstrap/config_test.go
@@ -89,8 +89,8 @@ func TestGetNodeMetaData(t *testing.T) {
 	expectWorkloadName := "workload"
 	expectExitOnZeroActiveConnections := model.StringBool(true)
 
-	os.Setenv(IstioMetaPrefix+"OWNER", inputOwner)
-	os.Setenv(IstioMetaPrefix+"WORKLOAD_NAME", inputWorkloadName)
+	t.Setenv(IstioMetaPrefix+"OWNER", inputOwner)
+	t.Setenv(IstioMetaPrefix+"WORKLOAD_NAME", inputWorkloadName)
 
 	node, err := GetNodeMetaData(MetadataOptions{
 		ID:                          "test",

--- a/pkg/bootstrap/instance_test.go
+++ b/pkg/bootstrap/instance_test.go
@@ -166,13 +166,12 @@ func TestGolden(t *testing.T) {
 				if err != nil {
 					t.Fatalf("Unable to parse mock server url: %v", err)
 				}
-				_ = os.Setenv("GCE_METADATA_HOST", u.Host)
+				t.Setenv("GCE_METADATA_HOST", u.Host)
 			},
 			teardown: func() {
 				if ts != nil {
 					ts.Close()
 				}
-				_ = os.Unsetenv("GCE_METADATA_HOST")
 			},
 			check: func(got *bootstrap.Bootstrap, t *testing.T) {
 				// nolint: staticcheck

--- a/pkg/bootstrap/platform/gcp_test.go
+++ b/pkg/bootstrap/platform/gcp_test.go
@@ -17,7 +17,6 @@ package platform
 import (
 	"errors"
 	"fmt"
-	"os"
 	"reflect"
 	"sync"
 	"testing"
@@ -236,7 +235,7 @@ func TestGCPMetadata(t *testing.T) {
 	for idx, tt := range tests {
 		t.Run(fmt.Sprintf("[%d] %s", idx, tt.name), func(t *testing.T) {
 			for e, v := range tt.env {
-				os.Setenv(e, v)
+				t.Setenv(e, v)
 				if e == "GCP_METADATA" {
 					GCPMetadata = v
 				}
@@ -250,7 +249,6 @@ func TestGCPMetadata(t *testing.T) {
 				t.Errorf("gcpEnv.Metadata() => '%v'; want '%v'", got, tt.want)
 			}
 			for e := range tt.env {
-				os.Unsetenv(e)
 				if e == "GCP_METADATA" {
 					GCPMetadata = ""
 				}

--- a/pkg/kube/util_test.go
+++ b/pkg/kube/util_test.go
@@ -86,12 +86,7 @@ func TestBuildClientConfig(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			currentEnv := os.Getenv("KUBECONFIG")
-			err := os.Setenv("KUBECONFIG", tt.envKubeconfig)
-			if err != nil {
-				t.Fatalf("Failed to set KUBECONFIG environment variable")
-			}
-			defer os.Setenv("KUBECONFIG", currentEnv)
+			t.Setenv("KUBECONFIG", tt.envKubeconfig)
 
 			resp, err := BuildClientConfig(tt.explicitKubeconfig, tt.context)
 			if (err != nil) != tt.wantErr {

--- a/security/pkg/nodeagent/caclient/providers/google/client_test.go
+++ b/security/pkg/nodeagent/caclient/providers/google/client_test.go
@@ -16,7 +16,6 @@ package caclient
 
 import (
 	"fmt"
-	"os"
 	"reflect"
 	"testing"
 
@@ -28,10 +27,7 @@ const mockServerAddress = "localhost:0"
 var fakeCert = []string{"foo", "bar"}
 
 func TestGoogleCAClient(t *testing.T) {
-	os.Setenv("GKE_CLUSTER_URL", "https://container.googleapis.com/v1/projects/testproj/locations/us-central1-c/clusters/cluster1")
-	defer func() {
-		os.Unsetenv("GKE_CLUSTER_URL")
-	}()
+	t.Setenv("GKE_CLUSTER_URL", "https://container.googleapis.com/v1/projects/testproj/locations/us-central1-c/clusters/cluster1")
 
 	testCases := map[string]struct {
 		service      mock.CAService


### PR DESCRIPTION
This PR replaces `os.Setenv` with `t.Setenv`. Starting from Go 1.17, we can use `t.Setenv` to set environment variable in test. The environment variable is automatically restored to its original value when the test and all its subtests complete. This ensures that each test does not start with leftover environment variables from previous completed tests.

This saves us at least 2 lines (error check, and unsetting the env var) on every instance.