### PR TITLE
Add failover priorities to eds cache key

### DIFF
--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -15,6 +15,7 @@
 package util
 
 import (
+	"bytes"
 	"fmt"
 	"net"
 	"sort"
@@ -254,6 +255,18 @@ func LocalityToString(l *core.Locality) string {
 	}
 	resp += "/" + l.SubZone
 	return resp
+}
+
+// GetFailoverPriorityLabels returns a byte array which contains failover priorities of the proxy.
+func GetFailoverPriorityLabels(proxyLabels map[string]string, priorities []string) []byte {
+	var b bytes.Buffer
+	for _, key := range priorities {
+		b.WriteString(key)
+		b.WriteRune(':')
+		b.WriteString(proxyLabels[key])
+		b.WriteRune(' ')
+	}
+	return b.Bytes()
 }
 
 // IsLocalityEmpty checks if a locality is empty (checking region is good enough, based on how its initialized)

--- a/pilot/pkg/xds/endpoint_builder_test.go
+++ b/pilot/pkg/xds/endpoint_builder_test.go
@@ -1,0 +1,244 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package xds
+
+import (
+	"reflect"
+	"testing"
+
+	wrappers "github.com/golang/protobuf/ptypes/wrappers"
+
+	meshconfig "istio.io/api/mesh/v1alpha1"
+	networking "istio.io/api/networking/v1alpha3"
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/config"
+)
+
+func TestPopulateFailoverPriorityLabels(t *testing.T) {
+	tests := []struct {
+		name           string
+		dr             *config.Config
+		mesh           *meshconfig.MeshConfig
+		expectedLabels []byte
+	}{
+		{
+			name:           "no dr",
+			expectedLabels: nil,
+		},
+		{
+			name: "simple",
+			dr: &config.Config{
+				Spec: &networking.DestinationRule{
+					TrafficPolicy: &networking.TrafficPolicy{
+						OutlierDetection: &networking.OutlierDetection{
+							ConsecutiveErrors: 5,
+						},
+						LoadBalancer: &networking.LoadBalancerSettings{
+							LocalityLbSetting: &networking.LocalityLoadBalancerSetting{
+								FailoverPriority: []string{
+									"a",
+									"b",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedLabels: []byte("a:a b:b "),
+		},
+		{
+			name: "no outlier detection",
+			dr: &config.Config{
+				Spec: &networking.DestinationRule{
+					TrafficPolicy: &networking.TrafficPolicy{
+						LoadBalancer: &networking.LoadBalancerSettings{
+							LocalityLbSetting: &networking.LocalityLoadBalancerSetting{
+								FailoverPriority: []string{
+									"a",
+									"b",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedLabels: nil,
+		},
+		{
+			name: "no failover priority",
+			dr: &config.Config{
+				Spec: &networking.DestinationRule{
+					TrafficPolicy: &networking.TrafficPolicy{
+						OutlierDetection: &networking.OutlierDetection{
+							ConsecutiveErrors: 5,
+						},
+					},
+				},
+			},
+			expectedLabels: nil,
+		},
+		{
+			name: "failover priority disabled",
+			dr: &config.Config{
+				Spec: &networking.DestinationRule{
+					TrafficPolicy: &networking.TrafficPolicy{
+						OutlierDetection: &networking.OutlierDetection{
+							ConsecutiveErrors: 5,
+						},
+						LoadBalancer: &networking.LoadBalancerSettings{
+							LocalityLbSetting: &networking.LocalityLoadBalancerSetting{
+								FailoverPriority: []string{
+									"a",
+									"b",
+								},
+								Enabled: &wrappers.BoolValue{Value: false},
+							},
+						},
+					},
+				},
+			},
+			expectedLabels: nil,
+		},
+		{
+			name: "mesh LocalityLoadBalancerSetting",
+			dr: &config.Config{
+				Spec: &networking.DestinationRule{
+					TrafficPolicy: &networking.TrafficPolicy{
+						OutlierDetection: &networking.OutlierDetection{
+							ConsecutiveErrors: 5,
+						},
+					},
+				},
+			},
+			mesh: &meshconfig.MeshConfig{
+				LocalityLbSetting: &networking.LocalityLoadBalancerSetting{
+					FailoverPriority: []string{
+						"a",
+						"b",
+					},
+				},
+			},
+			expectedLabels: []byte("a:a b:b "),
+		},
+		{
+			name: "mesh LocalityLoadBalancerSetting(no outlier detection)",
+			dr: &config.Config{
+				Spec: &networking.DestinationRule{
+					TrafficPolicy: &networking.TrafficPolicy{},
+				},
+			},
+			mesh: &meshconfig.MeshConfig{
+				LocalityLbSetting: &networking.LocalityLoadBalancerSetting{
+					FailoverPriority: []string{
+						"a",
+						"b",
+					},
+				},
+			},
+			expectedLabels: nil,
+		},
+		{
+			name: "mesh LocalityLoadBalancerSetting(no failover priority)",
+			dr: &config.Config{
+				Spec: &networking.DestinationRule{
+					TrafficPolicy: &networking.TrafficPolicy{
+						OutlierDetection: &networking.OutlierDetection{
+							ConsecutiveErrors: 5,
+						},
+					},
+				},
+			},
+			mesh: &meshconfig.MeshConfig{
+				LocalityLbSetting: &networking.LocalityLoadBalancerSetting{},
+			},
+			expectedLabels: nil,
+		},
+		{
+			name: "mesh LocalityLoadBalancerSetting(failover priority disabled)",
+			dr: &config.Config{
+				Spec: &networking.DestinationRule{
+					TrafficPolicy: &networking.TrafficPolicy{
+						OutlierDetection: &networking.OutlierDetection{
+							ConsecutiveErrors: 5,
+						},
+					},
+				},
+			},
+			mesh: &meshconfig.MeshConfig{
+				LocalityLbSetting: &networking.LocalityLoadBalancerSetting{
+					FailoverPriority: []string{
+						"a",
+						"b",
+					},
+					Enabled: &wrappers.BoolValue{Value: false},
+				},
+			},
+			expectedLabels: nil,
+		},
+		{
+			name: "both dr and mesh LocalityLoadBalancerSetting",
+			dr: &config.Config{
+				Spec: &networking.DestinationRule{
+					TrafficPolicy: &networking.TrafficPolicy{
+						OutlierDetection: &networking.OutlierDetection{
+							ConsecutiveErrors: 5,
+						},
+						LoadBalancer: &networking.LoadBalancerSettings{
+							LocalityLbSetting: &networking.LocalityLoadBalancerSetting{
+								FailoverPriority: []string{
+									"a",
+									"b",
+								},
+							},
+						},
+					},
+				},
+			},
+			mesh: &meshconfig.MeshConfig{
+				LocalityLbSetting: &networking.LocalityLoadBalancerSetting{
+					FailoverPriority: []string{
+						"c",
+					},
+				},
+			},
+			expectedLabels: []byte("a:a b:b "),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := EndpointBuilder{
+				proxy: &model.Proxy{
+					Metadata: &model.NodeMetadata{
+						Labels: map[string]string{
+							"app": "foo",
+							"a":   "a",
+							"b":   "b",
+						},
+					},
+				},
+				push: &model.PushContext{
+					Mesh: tt.mesh,
+				},
+			}
+			if tt.dr != nil {
+				b.destinationRule = model.ConvertConsolidatedDestRule(tt.dr)
+			}
+			b.populateFailoverPriorityLabels()
+			if !reflect.DeepEqual(b.failoverPriorityLabels, tt.expectedLabels) {
+				t.Fatalf("expected priorityLabels %v but got %v", tt.expectedLabels, b.failoverPriorityLabels)
+			}
+		})
+	}
+}

--- a/releasenotes/notes/40198.yaml
+++ b/releasenotes/notes/40198.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+issue:
+  - 40198
+releaseNotes:
+  - |
+    **Fixed** LocalityLoadBalancerSetting.failoverPriority not working properly if xds cache is enabled.


### PR DESCRIPTION
**Please provide a description of this PR:**
Fixes https://github.com/istio/istio/issues/40198
The root cause is that istiod caches the same endpoints regardless of failover priority labels of each proxy, this pr adds them to eds cache key