### PR TITLE
fix empty endpoints weight for AUTO_PASSTHROUGH gateway

### DIFF
--- a/pilot/pkg/xds/ep_filters.go
+++ b/pilot/pkg/xds/ep_filters.go
@@ -224,6 +224,7 @@ func (b *EndpointBuilder) EndpointsWithMTLSFilter(endpoints []*LocalityEndpoints
 			lbEndpoints.append(ep.istioEndpoints[i], lbEp)
 		}
 
+		lbEndpoints.refreshWeight()
 		filtered = append(filtered, lbEndpoints)
 	}
 


### PR DESCRIPTION
**Please provide a description of this PR:**

For AUTO_PASSTHROUGH gateway, typically istio-eastwestgateway, the endpoints of SNI-dnat cluster will be filtered by mtls checker. Yet the filtered `LocalityLbEndpoints` results have empty `LoadBalancingWeight`, that would cause LB error in sidecar.