### PR TITLE
Add qemulation to release builder

### DIFF
--- a/prow/release-commit.sh
+++ b/prow/release-commit.sh
@@ -25,6 +25,10 @@ source "${ROOT}/prow/lib.sh"
 
 setup_gcloud_credentials
 
+# Enable emulation required for cross compiling a few images (VMs)
+docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+export ISTIO_DOCKER_QEMU=true
+
 # Old prow image does not set this, so needed explicitly here as this is not called through make
 export GO111MODULE=on
 

--- a/prow/release-commit.sh
+++ b/prow/release-commit.sh
@@ -26,7 +26,7 @@ source "${ROOT}/prow/lib.sh"
 setup_gcloud_credentials
 
 # Enable emulation required for cross compiling a few images (VMs)
-docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+docker run --rm --privileged gcr.io/istio-testing/qemu-user-static --reset -p yes
 export ISTIO_DOCKER_QEMU=true
 
 # Old prow image does not set this, so needed explicitly here as this is not called through make

--- a/tools/docker-builder/types.go
+++ b/tools/docker-builder/types.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"k8s.io/utils/env"
@@ -220,20 +221,28 @@ func DefaultArgs() Args {
 	}
 
 	// TODO: consider automatically detecting Qemu support
+	qemu := false
+	if b, f := os.LookupEnv("ISTIO_DOCKER_QEMU"); f {
+		q, err := strconv.ParseBool(b)
+		if err == nil {
+			qemu = q
+		}
+	}
 
 	return Args{
-		Push:          false,
-		Save:          false,
-		NoCache:       false,
-		Hubs:          hub,
-		Tags:          tag,
-		BaseVersion:   fetchBaseVersion(),
-		IstioVersion:  fetchIstioVersion(),
-		ProxyVersion:  pv,
-		Architectures: arch,
-		Targets:       targets,
-		Variants:      variants,
-		Builder:       builder,
+		Push:              false,
+		Save:              false,
+		NoCache:           false,
+		Hubs:              hub,
+		Tags:              tag,
+		BaseVersion:       fetchBaseVersion(),
+		IstioVersion:      fetchIstioVersion(),
+		ProxyVersion:      pv,
+		Architectures:     arch,
+		Targets:           targets,
+		Variants:          variants,
+		Builder:           builder,
+		SupportsEmulation: qemu,
 	}
 }
 


### PR DESCRIPTION
VMs currently require emulation to cross compile. We previously just
skipped them, but then you cannot simply run `go test
./tests/integration/...` with `gcr.io/istio-testing` since we don't have
the VM images.

Instead, try emulation.

**Please provide a description of this PR:**