### PR TITLE
Propagate SkyWalking tracing header in sample application

### DIFF
--- a/samples/bookinfo/src/details/details.rb
+++ b/samples/bookinfo/src/details/details.rb
@@ -172,6 +172,9 @@ def get_forward_headers(request)
       'x-b3-sampled',
       'x-b3-flags',
 
+      # SkyWalking trace headers.
+      'sw8',
+
       # Application-specific headers to forward.
       'end-user',
       'user-agent',

--- a/samples/bookinfo/src/productpage/productpage.py
+++ b/samples/bookinfo/src/productpage/productpage.py
@@ -219,6 +219,9 @@ def getForwardHeaders(request):
         # 'x-b3-sampled',
         # 'x-b3-flags',
 
+        # SkyWalking trace headers.
+        'sw8',
+
         # Application-specific headers to forward.
         'user-agent',
 

--- a/samples/bookinfo/src/productpage/tests/unit/test_productpage.py
+++ b/samples/bookinfo/src/productpage/tests/unit/test_productpage.py
@@ -41,7 +41,8 @@ class ApplianceTest(unittest.TestCase):
             'x-request-id': '34eeb41d-d267-9e49-8b84-dde403fc5b72',
             'x-b3-traceid': '40c7fdf104e3de67',
             'x-b3-spanid': '40c7fdf104e3de67',
-            'x-b3-sampled': '1'
+            'x-b3-sampled': '1',
+            'sw8': '40c7fdf104e3de67'
         }
         m.get("http://reviews:9080/reviews/%d" % product_id, text='{}',
               request_headers=expected_headers)
@@ -51,7 +52,8 @@ class ApplianceTest(unittest.TestCase):
             'x-request-id': '34eeb41d-d267-9e49-8b84-dde403fc5b72',
             'x-b3-traceid': '40c7fdf104e3de67',
             'x-b3-spanid': '40c7fdf104e3de67',
-            'x-b3-sampled': '1'
+            'x-b3-sampled': '1',
+            'sw8': '40c7fdf104e3de67'
         }
         actual = self.app.get(uri, headers=headers)
         self.assertEqual(200, actual.status_code)
@@ -67,7 +69,8 @@ class ApplianceTest(unittest.TestCase):
             'x-request-id': '34eeb41d-d267-9e49-8b84-dde403fc5b73',
             'x-b3-traceid': '30c7fdf104e3de66',
             'x-b3-spanid': '30c7fdf104e3de66',
-            'x-b3-sampled': '1'
+            'x-b3-sampled': '1',
+            'sw8': '40c7fdf104e3de67'
         }
         m.get("http://ratings:9080/ratings/%d" % product_id, text='{}',
               request_headers=expected_headers)
@@ -77,7 +80,8 @@ class ApplianceTest(unittest.TestCase):
             'x-request-id': '34eeb41d-d267-9e49-8b84-dde403fc5b73',
             'x-b3-traceid': '30c7fdf104e3de66',
             'x-b3-spanid': '30c7fdf104e3de66',
-            'x-b3-sampled': '1'
+            'x-b3-sampled': '1',
+            'sw8': '40c7fdf104e3de67'
         }
         actual = self.app.get(uri, headers=headers)
         self.assertEqual(200, actual.status_code)

--- a/samples/bookinfo/src/reviews/reviews-application/src/main/java/application/rest/LibertyRestEndpoint.java
+++ b/samples/bookinfo/src/reviews/reviews-application/src/main/java/application/rest/LibertyRestEndpoint.java
@@ -87,6 +87,9 @@ public class LibertyRestEndpoint extends Application {
         "x-b3-sampled",
         "x-b3-flags",
 
+        // SkyWalking trace headers.
+        "sw8",
+
         // Application-specific headers to forward.
         "end-user",
         "user-agent",
@@ -117,7 +120,7 @@ public class LibertyRestEndpoint extends Application {
         }
       }
     	result += "},";
-    	
+
     	// reviewer 2:
     	result += "{";
     	result += "  \"reviewer\": \"Reviewer2\",";
@@ -131,13 +134,13 @@ public class LibertyRestEndpoint extends Application {
         }
       }
     	result += "}";
-    	
+
     	result += "]";
     	result += "}";
 
     	return result;
     }
-    
+
     private JsonObject getRatings(String productId, HttpHeaders requestHeaders) {
       ClientBuilder cb = ClientBuilder.newBuilder();
       Integer timeout = star_color.equals("black") ? 10000 : 2500;
@@ -196,7 +199,7 @@ public class LibertyRestEndpoint extends Application {
             }
           }
         }
-      } 
+      }
 
       String jsonResStr = getJsonResponse(Integer.toString(productId), starsReviewer1, starsReviewer2);
       return Response.ok().type(MediaType.APPLICATION_JSON).entity(jsonResStr).build();


### PR DESCRIPTION
**Please provide a description of this PR:**

SkyWalking has its own tracing context header `sw8`, this patch adds propagation of this header to sample application