### PR TITLE
improve  CheckAutoScaleAndReplicaCount

### DIFF
--- a/operator/pkg/apis/istio/v1alpha1/validation/validation.go
+++ b/operator/pkg/apis/istio/v1alpha1/validation/validation.go
@@ -187,7 +187,7 @@ func validateFeatures(values *valuesv1alpha1.Values, spec *v1alpha1.IstioOperato
 
 // CheckAutoScaleAndReplicaCount warns when autoscaleEnabled is true and k8s replicaCount is set.
 func CheckAutoScaleAndReplicaCount(values *valuesv1alpha1.Values, spec *v1alpha1.IstioOperatorSpec) (errs util.Errors, warnings []string) {
-	if values.GetPilot().GetAutoscaleEnabled().GetValue() && spec.GetComponents().GetPilot().GetK8S().GetReplicaCount() != 0 {
+	if values.GetPilot().GetAutoscaleEnabled().GetValue() && spec.GetComponents().GetPilot().GetK8S().GetReplicaCount() > 1 {
 		warnings = append(warnings,
 			"components.pilot.k8s.replicaCount should not be set when values.pilot.autoscaleEnabled is true")
 	}

--- a/operator/pkg/apis/istio/v1alpha1/validation/validation_test.go
+++ b/operator/pkg/apis/istio/v1alpha1/validation/validation_test.go
@@ -226,6 +226,24 @@ components.ingressGateways[name=istio-ingressgateway].k8s.replicaCount should no
 components.egressGateways[name=istio-egressgateway].k8s.replicaCount should not be set when values.gateways.istio-egressgateway.autoscaleEnabled is true
 `),
 		},
+		{
+			name: "pilot.k8s.replicaCount is default value set when autoscaleEnabled is true",
+			values: `
+values:
+  pilot:
+    autoscaleEnabled: true
+  gateways:
+    istio-ingressgateway:
+      autoscaleEnabled: true
+    istio-egressgateway:
+      autoscaleEnabled: true
+components:
+  pilot:
+    k8s:
+      replicaCount: 1
+`,
+			warnings: strings.TrimSpace(``),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/releasenotes/notes/40297.yaml
+++ b/releasenotes/notes/40297.yaml
@@ -5,4 +5,4 @@ issue:
   - https://github.com/istio/istio/issues/40246
 releaseNotes:
   - |
-    **Fixed** istioctl install show warn message when `values.pilot.replicaCount` equal to default value.
+    **Fixed** istioctl install to not show a warning message when `values.pilot.replicaCount` is set equal to its default value.

--- a/releasenotes/notes/40297.yaml
+++ b/releasenotes/notes/40297.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: istioctl
+issue:
+  - https://github.com/istio/istio/issues/40246
+releaseNotes:
+  - |
+    **Fixed** istioctl install show warn message when `values.pilot.replicaCount` equal to default value.


### PR DESCRIPTION
**Please provide a description of this PR:**

fix: #40246 

we should not send warn message when `values.pilot.replicaCount` equal to the default value


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [x] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
