### PR TITLE
Respect ALPN negotiation in agent prober

### DIFF
--- a/pilot/cmd/pilot-agent/status/server_test.go
+++ b/pilot/cmd/pilot-agent/status/server_test.go
@@ -16,6 +16,7 @@ package status
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -35,6 +36,7 @@ import (
 
 	"github.com/prometheus/common/expfmt"
 	"github.com/prometheus/prometheus/model/textparse"
+	"go.uber.org/atomic"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health"
 	grpcHealth "google.golang.org/grpc/health/grpc_health_v1"
@@ -48,7 +50,11 @@ import (
 	"istio.io/pkg/log"
 )
 
-type handler struct{}
+type handler struct {
+	// LastALPN stores the most recent ALPN requested. This is needed to determine info about a request,
+	// since the appProber strips all headers/responses.
+	lastAlpn *atomic.String
+}
 
 const (
 	testHeader      = "Some-Header"
@@ -59,6 +65,7 @@ const (
 var liveServerStats = "cluster_manager.cds.update_success: 1\nlistener_manager.lds.update_success: 1\nserver.state: 0\nlistener_manager.workers_started: 1"
 
 func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	h.lastAlpn.Store(r.Proto)
 	segments := strings.Split(r.URL.Path[1:], "/")
 	switch segments[0] {
 	case "header":
@@ -611,7 +618,7 @@ func TestAppProbe(t *testing.T) {
 	if err != nil {
 		t.Errorf("failed to allocate unused port %v", err)
 	}
-	go http.Serve(listener, &handler{})
+	go http.Serve(listener, &handler{lastAlpn: atomic.NewString("")})
 	appPort := listener.Addr().(*net.TCPAddr).Port
 
 	simpleHTTPConfig := KubeAppProbers{
@@ -877,68 +884,122 @@ func TestAppProbe(t *testing.T) {
 }
 
 func TestHttpsAppProbe(t *testing.T) {
-	// Starts the application first.
-	listener, err := net.Listen("tcp", ":0")
-	if err != nil {
-		t.Errorf("failed to allocate unused port %v", err)
-	}
-	keyFile := env.IstioSrc + "/pilot/cmd/pilot-agent/status/test-cert/cert.key"
-	crtFile := env.IstioSrc + "/pilot/cmd/pilot-agent/status/test-cert/cert.crt"
-	go http.ServeTLS(listener, &handler{}, crtFile, keyFile)
-	appPort := listener.Addr().(*net.TCPAddr).Port
-
-	// Starts the pilot agent status server.
-	server, err := NewServer(Options{
-		StatusPort: 0,
-		KubeAppProbers: fmt.Sprintf(`{"/app-health/hello-world/readyz": {"httpGet": {"path": "/hello/sunnyvale", "port": %v, "scheme": "HTTPS"}},
-"/app-health/hello-world/livez": {"httpGet": {"port": %v, "scheme": "HTTPS"}}}`, appPort, appPort),
-	})
-	if err != nil {
-		t.Errorf("failed to create status server %v", err)
-		return
-	}
-	go server.Run(context.Background())
-
-	var statusPort uint16
-	if err := retry.UntilSuccess(func() error {
-		server.mutex.RLock()
-		statusPort = server.statusPort
-		server.mutex.RUnlock()
-		if statusPort == 0 {
-			return fmt.Errorf("no port allocated")
+	setupServer := func(t *testing.T, alpn []string) (uint16, func() string) {
+		// Starts the application first.
+		listener, err := net.Listen("tcp", ":0")
+		if err != nil {
+			t.Errorf("failed to allocate unused port %v", err)
 		}
-		return nil
-	}); err != nil {
-		t.Fatalf("failed to getport: %v", err)
+		t.Cleanup(func() { listener.Close() })
+		keyFile := env.IstioSrc + "/pilot/cmd/pilot-agent/status/test-cert/cert.key"
+		crtFile := env.IstioSrc + "/pilot/cmd/pilot-agent/status/test-cert/cert.crt"
+		cert, err := tls.LoadX509KeyPair(crtFile, keyFile)
+		if err != nil {
+			t.Fatalf("could not load TLS keys: %v", err)
+		}
+		serverTlsConfig := &tls.Config{
+			Certificates: []tls.Certificate{cert},
+			NextProtos:   alpn,
+		}
+		tlsListner := tls.NewListener(listener, serverTlsConfig)
+		h := &handler{lastAlpn: atomic.NewString("")}
+		srv := http.Server{Handler: h}
+		go srv.Serve(tlsListner)
+		appPort := listener.Addr().(*net.TCPAddr).Port
+
+		// Starts the pilot agent status server.
+		server, err := NewServer(Options{
+			StatusPort: 0,
+			KubeAppProbers: fmt.Sprintf(`{"/app-health/hello-world/readyz": {"httpGet": {"path": "/hello/sunnyvale", "port": %v, "scheme": "HTTPS"}},
+"/app-health/hello-world/livez": {"httpGet": {"port": %v, "scheme": "HTTPS"}}}`, appPort, appPort),
+		})
+		if err != nil {
+			t.Fatalf("failed to create status server %v", err)
+		}
+		go server.Run(context.Background())
+
+		var statusPort uint16
+		if err := retry.UntilSuccess(func() error {
+			server.mutex.RLock()
+			statusPort = server.statusPort
+			server.mutex.RUnlock()
+			if statusPort == 0 {
+				return fmt.Errorf("no port allocated")
+			}
+			return nil
+		}); err != nil {
+			t.Fatalf("failed to getport: %v", err)
+		}
+		t.Logf("status server starts at port %v, app starts at port %v", statusPort, appPort)
+		return statusPort, h.lastAlpn.Load
 	}
-	t.Logf("status server starts at port %v, app starts at port %v", statusPort, appPort)
 	testCases := []struct {
-		name       string
-		probePath  string
-		statusCode int
+		name             string
+		probePath        string
+		expectedProtocol string
+		statusCode       int
+		alpns            []string
 	}{
 		{
 			name:       "bad-path-should-be-disallowed",
-			probePath:  fmt.Sprintf(":%v/bad-path-should-be-disallowed", statusPort),
+			probePath:  "bad-path-should-be-disallowed",
 			statusCode: http.StatusNotFound,
 		},
 		{
-			name:       "readyz",
-			probePath:  fmt.Sprintf(":%v/app-health/hello-world/readyz", statusPort),
-			statusCode: http.StatusOK,
+			name:             "readyz",
+			probePath:        "app-health/hello-world/readyz",
+			statusCode:       http.StatusOK,
+			expectedProtocol: "HTTP/1.1",
+			alpns:            nil,
 		},
 		{
-			name:       "livez",
-			probePath:  fmt.Sprintf(":%v/app-health/hello-world/livez", statusPort),
-			statusCode: http.StatusOK,
+			name:             "livez",
+			probePath:        "app-health/hello-world/livez",
+			statusCode:       http.StatusOK,
+			expectedProtocol: "HTTP/1.1",
+		},
+		{
+			name:             "h1 only",
+			probePath:        "app-health/hello-world/readyz",
+			statusCode:       http.StatusOK,
+			expectedProtocol: "HTTP/1.1",
+			alpns:            []string{"http/1.1"},
+		},
+		{
+			name:             "h2 only",
+			probePath:        "app-health/hello-world/readyz",
+			statusCode:       http.StatusOK,
+			expectedProtocol: "HTTP/2.0",
+			alpns:            []string{"h2"},
+		},
+		{
+			name:             "prefer h2",
+			probePath:        "app-health/hello-world/readyz",
+			statusCode:       http.StatusOK,
+			expectedProtocol: "HTTP/2.0",
+			alpns:            []string{"h2", "http/1.1"},
+		},
+		{
+			name:             "prefer h1",
+			probePath:        "app-health/hello-world/readyz",
+			statusCode:       http.StatusOK,
+			expectedProtocol: "HTTP/2.0",
+			alpns:            []string{"h2", "http/1.1"},
+		},
+		{
+			name:       "unknown alpn",
+			probePath:  "app-health/hello-world/readyz",
+			statusCode: http.StatusInternalServerError,
+			alpns:      []string{"foo"},
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			statusPort, getAlpn := setupServer(t, tc.alpns)
 			client := http.Client{}
-			req, err := http.NewRequest("GET", fmt.Sprintf("http://localhost%s", tc.probePath), nil)
+			req, err := http.NewRequest("GET", fmt.Sprintf("http://localhost:%d/%s", statusPort, tc.probePath), nil)
 			if err != nil {
-				t.Errorf("[%v] failed to create request", tc.probePath)
+				t.Fatalf("failed to create request")
 			}
 			resp, err := client.Do(req)
 			if err != nil {
@@ -946,7 +1007,10 @@ func TestHttpsAppProbe(t *testing.T) {
 			}
 			defer resp.Body.Close()
 			if resp.StatusCode != tc.statusCode {
-				t.Errorf("[%v] unexpected status code, want = %v, got = %v", tc.probePath, tc.statusCode, resp.StatusCode)
+				t.Errorf("unexpected status code, want = %v, got = %v", tc.statusCode, resp.StatusCode)
+			}
+			if got := getAlpn(); got != tc.expectedProtocol {
+				t.Errorf("unexpected protocol, want = %v, got = %v", tc.expectedProtocol, got)
 			}
 		})
 	}

--- a/pilot/cmd/pilot-agent/status/server_test.go
+++ b/pilot/cmd/pilot-agent/status/server_test.go
@@ -897,14 +897,14 @@ func TestHttpsAppProbe(t *testing.T) {
 		if err != nil {
 			t.Fatalf("could not load TLS keys: %v", err)
 		}
-		serverTlsConfig := &tls.Config{
+		serverTLSConfig := &tls.Config{
 			Certificates: []tls.Certificate{cert},
 			NextProtos:   alpn,
 		}
-		tlsListner := tls.NewListener(listener, serverTlsConfig)
+		tlsListener := tls.NewListener(listener, serverTLSConfig)
 		h := &handler{lastAlpn: atomic.NewString("")}
 		srv := http.Server{Handler: h}
-		go srv.Serve(tlsListner)
+		go srv.Serve(tlsListener)
 		appPort := listener.Addr().(*net.TCPAddr).Port
 
 		// Starts the pilot agent status server.

--- a/pkg/test/echo/server/endpoint/http.go
+++ b/pkg/test/echo/server/endpoint/http.go
@@ -215,7 +215,7 @@ func (h *httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		epLog.Warnf("failed to get host from remote address: %s", err)
 	}
-	epLog.WithLabels("remoteAddr", remoteAddr, "method", r.Method, "url", r.URL, "host", r.Host, "headers", r.Header, "id", id).Infof("HTTP Request")
+	epLog.WithLabels("remoteAddr", remoteAddr, "method", r.Method, "url", r.URL, "host", r.Host, "headers", r.Header, "id", id).Infof("%v Request", r.Proto)
 	if h.Port == nil {
 		defer common.Metrics.HTTPRequests.With(common.PortLabel.Value("uds")).Increment()
 	} else {
@@ -273,7 +273,7 @@ func (h *httpHandler) echo(w http.ResponseWriter, r *http.Request, id uuid.UUID)
 	if _, err := w.Write(body.Bytes()); err != nil {
 		epLog.Warn(err)
 	}
-	epLog.WithLabels("code", code, "headers", w.Header(), "id", id).Infof("HTTP Response")
+	epLog.WithLabels("code", code, "headers", w.Header(), "id", id).Infof("%v Response", r.Proto)
 }
 
 func (h *httpHandler) webSocketEcho(w http.ResponseWriter, r *http.Request) {

--- a/releasenotes/notes/http2-probes.yaml
+++ b/releasenotes/notes/http2-probes.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+issues:
+- 40173
+releaseNotes:
+- |
+  **Added** support for ALPN negotiation to Istio [health checks](https://istio.io/latest/docs/ops/configuration/mesh/app-health-check/), mirroring
+  how Kubelet functions. This allows `HTTPS` type probes to use HTTP2. To revert to the old behavior, which always used HTTP/1.1, the `ISTIO_ENABLE_HTTP2_PROBING=false` variable can be set.


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/40173

This aligns with kubelet probe, to support http2 for `HTTPS` probes.

Note: the request from kubelet->agent will always be HTTP/1.1 still,
just the upstream is changed.

**Please provide a description of this PR:**