### PR TITLE
[release-1.15] fix empty endpoints weight for AUTO_PASSTHROUGH gateway

### DIFF
--- a/pilot/pkg/xds/ep_filters.go
+++ b/pilot/pkg/xds/ep_filters.go
@@ -224,6 +224,7 @@ func (b *EndpointBuilder) EndpointsWithMTLSFilter(endpoints []*LocLbEndpointsAnd
 			lbEndpoints.append(ep.istioEndpoints[i], lbEp)
 		}
 
+		lbEndpoints.refreshWeight()
 		filtered = append(filtered, lbEndpoints)
 	}
 

--- a/pilot/pkg/xds/ep_filters_test.go
+++ b/pilot/pkg/xds/ep_filters_test.go
@@ -628,7 +628,7 @@ func runNetworkFilterTest(t *testing.T, ds *FakeDiscoveryServer, tests []network
 	}
 }
 
-func compareEndpoints(t *testing.T, got []*LocalityEndpoints, want []LocLbEpInfo) {
+func compareEndpoints(t *testing.T, got []*LocLbEndpointsAndOptions, want []LocLbEpInfo) {
 	if len(got) != len(want) {
 		t.Errorf("Unexpected number of filtered endpoints: got %v, want %v", len(got), len(want))
 		return


### PR DESCRIPTION
**Please provide a description of this PR:**

Manual cherrypick of #40243

This cannot be done by a bot because there are different struct names on the two branches, according to #40226 , which changes `LocLbEndpointsAndOptions` to `LocalityEndpoints` on master branch.