### PR TITLE
unify timeout logic across service and virtual service

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -28,6 +28,7 @@ import (
 	matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	xdstype "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
+	"github.com/golang/protobuf/ptypes/duration"
 	anypb "google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
 	wrappers "google.golang.org/protobuf/types/known/wrapperspb"
@@ -64,6 +65,8 @@ const DefaultRouteName = "default"
 // prefixMatchRegex optionally matches "/..." at the end of a path.
 // regex taken from https://github.com/projectcontour/contour/blob/2b3376449bedfea7b8cea5fbade99fb64009c0f6/internal/envoy/v3/route.go#L59
 const prefixMatchRegex = `((\/).*)?`
+
+var notimeout = durationpb.New(0)
 
 // VirtualHostWrapper is a context-dependent virtual host entry with guarded routes.
 // Note: Currently we are not fully utilizing this structure. We could invoke this logic
@@ -489,19 +492,11 @@ func applyHTTPRouteDestination(
 		RetryPolicy: retry.ConvertPolicy(policy),
 	}
 
-	// Configure timeouts specified by Virtual Service if they are provided, otherwise set it to defaults.
-	action.Timeout = features.DefaultRequestTimeout
-	if in.Timeout != nil {
-		action.Timeout = in.Timeout
+	if in.Retries != nil {
+		action.RetryPolicy = retry.ConvertPolicy(in.Retries)
 	}
-	if node.IsProxylessGrpc() {
-		// TODO(stevenctl) merge these paths; grpc's xDS impl will not read the deprecated value
-		action.MaxStreamDuration = &route.RouteAction_MaxStreamDuration{MaxStreamDuration: action.Timeout}
-	} else {
-		// Use deprecated value for now as the replacement MaxStreamDuration has some regressions.
-		// nolint: staticcheck
-		action.MaxGrpcTimeout = action.Timeout
-	}
+
+	setTimeouts(action, features.DefaultRequestTimeout, in.Timeout, node)
 
 	if model.UseGatewaySemantics(vs) && util.IsIstioVersionGE115(node.IstioVersion) {
 		// return 500 for invalid backends
@@ -1066,16 +1061,15 @@ func getRouteOperation(in *route.Route, vsName string, port int) string {
 
 // BuildDefaultHTTPInboundRoute builds a default inbound route.
 func BuildDefaultHTTPInboundRoute(clusterName string, operation string) *route.Route {
-	notimeout := durationpb.New(0)
+	out := buildDefaultHTTPRoute(clusterName, operation)
+	// For inbound, configure with notimeout.
+	setTimeouts(out.GetRoute(), notimeout, nil, nil)
+	return out
+}
+
+func buildDefaultHTTPRoute(clusterName string, operation string) *route.Route {
 	routeAction := &route.RouteAction{
 		ClusterSpecifier: &route.RouteAction_Cluster{Cluster: clusterName},
-		Timeout:          notimeout,
-	}
-	routeAction.MaxStreamDuration = &route.RouteAction_MaxStreamDuration{
-		MaxStreamDuration: notimeout,
-		// If not configured at all, the grpc-timeout header is not used and
-		// gRPC requests time out like any other requests using timeout or its default.
-		GrpcTimeoutHeaderMax: notimeout,
 	}
 	val := &route.Route{
 		Match: translateRouteMatch(nil, config.Config{}, nil),
@@ -1091,13 +1085,44 @@ func BuildDefaultHTTPInboundRoute(clusterName string, operation string) *route.R
 	return val
 }
 
+func setTimeouts(action *route.RouteAction, defaultTimeout *duration.Duration,
+	vsTimeout *duration.Duration, node *model.Proxy,
+) {
+	// If default request timeout or virtual service timeout is not set, default to no timeout.
+	if defaultTimeout.AsDuration().Nanoseconds() == 0 && vsTimeout == nil {
+		action.Timeout = notimeout
+		action.MaxStreamDuration = &route.RouteAction_MaxStreamDuration{
+			MaxStreamDuration: notimeout,
+			// If not configured at all, the grpc-timeout header is not used and
+			// gRPC requests time out like any other requests using timeout or its default.
+			GrpcTimeoutHeaderMax: notimeout,
+		}
+		return
+	}
+	// Configure timeouts specified by Virtual Service if they are provided, otherwise set it to defaults.
+	action.Timeout = features.DefaultRequestTimeout
+	if vsTimeout != nil {
+		action.Timeout = vsTimeout
+	}
+	if node != nil && node.IsProxylessGrpc() {
+		// TODO(stevenctl) merge these paths; grpc's xDS impl will not read the deprecated value
+		action.MaxStreamDuration.MaxStreamDuration = action.Timeout
+	} else {
+		// If not configured at all, the grpc-timeout header is not used and
+		// gRPC requests time out like any other requests using timeout or its default.
+		// Use deprecated value for now as the replacement MaxStreamDuration has some regressions.
+		// nolint: staticcheck
+		action.MaxGrpcTimeout = action.Timeout
+	}
+}
+
 // BuildDefaultHTTPOutboundRoute builds a default outbound route, including a retry policy.
 func BuildDefaultHTTPOutboundRoute(clusterName string, operation string, mesh *meshconfig.MeshConfig) *route.Route {
-	// Start with the same configuration as for inbound.
-	out := BuildDefaultHTTPInboundRoute(clusterName, operation)
+	out := buildDefaultHTTPRoute(clusterName, operation)
 
 	// Add a default retry policy for outbound routes.
 	out.GetRoute().RetryPolicy = retry.ConvertPolicy(mesh.GetDefaultHttpRetryPolicy())
+	setTimeouts(out.GetRoute(), features.DefaultRequestTimeout, nil, nil)
 	return out
 }
 

--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -492,11 +492,7 @@ func applyHTTPRouteDestination(
 		RetryPolicy: retry.ConvertPolicy(policy),
 	}
 
-	if in.Retries != nil {
-		action.RetryPolicy = retry.ConvertPolicy(in.Retries)
-	}
-
-	setTimeouts(action, features.DefaultRequestTimeout, in.Timeout, node)
+	setTimeout(action, features.DefaultRequestTimeout, in.Timeout, node)
 
 	if model.UseGatewaySemantics(vs) && util.IsIstioVersionGE115(node.IstioVersion) {
 		// return 500 for invalid backends
@@ -1063,7 +1059,7 @@ func getRouteOperation(in *route.Route, vsName string, port int) string {
 func BuildDefaultHTTPInboundRoute(clusterName string, operation string) *route.Route {
 	out := buildDefaultHTTPRoute(clusterName, operation)
 	// For inbound, configure with notimeout.
-	setTimeouts(out.GetRoute(), notimeout, nil, nil)
+	setTimeout(out.GetRoute(), notimeout, nil, nil)
 	return out
 }
 
@@ -1085,7 +1081,9 @@ func buildDefaultHTTPRoute(clusterName string, operation string) *route.Route {
 	return val
 }
 
-func setTimeouts(action *route.RouteAction, defaultTimeout *duration.Duration,
+// setTimeout sets timeout for a route.
+// defaultTimeout is the timeout to be used if vsTimeout is not specified.
+func setTimeout(action *route.RouteAction, defaultTimeout *duration.Duration,
 	vsTimeout *duration.Duration, node *model.Proxy,
 ) {
 	// If default request timeout or virtual service timeout is not set, default to no timeout.
@@ -1122,7 +1120,7 @@ func BuildDefaultHTTPOutboundRoute(clusterName string, operation string, mesh *m
 
 	// Add a default retry policy for outbound routes.
 	out.GetRoute().RetryPolicy = retry.ConvertPolicy(mesh.GetDefaultHttpRetryPolicy())
-	setTimeouts(out.GetRoute(), features.DefaultRequestTimeout, nil, nil)
+	setTimeout(out.GetRoute(), features.DefaultRequestTimeout, nil, nil)
 	return out
 }
 

--- a/pilot/pkg/networking/core/v1alpha3/route/route_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route_test.go
@@ -145,8 +145,8 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 		g.Expect(len(routes)).To(gomega.Equal(1))
 		g.Expect(routes[0].GetRoute().Timeout.Seconds).To(gomega.Equal(int64(0)))
-		// nolint: staticcheck
-		g.Expect(routes[0].GetRoute().MaxGrpcTimeout.Seconds).To(gomega.Equal(int64(0)))
+		g.Expect(routes[0].GetRoute().MaxStreamDuration.MaxStreamDuration.Seconds).To(gomega.Equal(int64(0)))
+		g.Expect(routes[0].GetRoute().MaxStreamDuration.GrpcTimeoutHeaderMax.Seconds).To(gomega.Equal(int64(0)))
 	})
 
 	t.Run("for virtual service with catch all route", func(t *testing.T) {

--- a/pilot/pkg/networking/core/v1alpha3/route/route_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route_test.go
@@ -79,8 +79,8 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		g.Expect(len(routes)).To(gomega.Equal(1))
 		// Validate that when timeout is not specified, we disable it based on default value of flag.
 		g.Expect(routes[0].GetRoute().Timeout.Seconds).To(gomega.Equal(int64(0)))
-		// nolint: staticcheck
-		g.Expect(routes[0].GetRoute().MaxGrpcTimeout.Seconds).To(gomega.Equal(int64(0)))
+		g.Expect(routes[0].GetRoute().MaxStreamDuration.GrpcTimeoutHeaderMax.Seconds).To(gomega.Equal(int64(0)))
+		g.Expect(routes[0].GetRoute().MaxStreamDuration.MaxStreamDuration.Seconds).To(gomega.Equal(int64(0)))
 	})
 
 	t.Run("for virtual service with HTTP/3 discovery enabled", func(t *testing.T) {

--- a/releasenotes/notes/40299.yaml
+++ b/releasenotes/notes/40299.yaml
@@ -1,0 +1,11 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+
+issue:
+  - 40299
+
+releaseNotes:
+- |
+  **Fixed** an issue where a service with and witout Virtual Service with no timeouts specified,
+  is incorrectly setting the timeouts.


### PR DESCRIPTION
There is discrepancy in how we set timeout when a VS is defined (without timeout) and VS is not defined at all. We should be consistently setting the timeouts to `notimeout` in both cases.

This PR fixes it.
Fixes https://github.com/istio/istio/issues/40299

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure