### PR TITLE
[release-1.15] Fix release-commit to use 1.15 instead of master

### DIFF
--- a/prow/release-commit.sh
+++ b/prow/release-commit.sh
@@ -65,13 +65,13 @@ ${DEPENDENCIES:-$(cat <<EOD
     auto: modules
   client-go:
     git: https://github.com/istio/client-go
-    branch: master
+    branch: release-1.15
   test-infra:
     git: https://github.com/istio/test-infra
     branch: master
   tools:
     git: https://github.com/istio/tools
-    branch: master
+    branch: release-1.15
   release-builder:
     git: https://github.com/istio/release-builder
     sha: ${BUILDER_SHA}


### PR DESCRIPTION
**Please provide a description of this PR:**

Update release-commit to use the release-1.15 branches instead of master.