### PR TITLE
Fix injector list has duplicate namespace

### DIFF
--- a/istioctl/cmd/injector-list.go
+++ b/istioctl/cmd/injector-list.go
@@ -241,6 +241,8 @@ func getInjectedRevision(namespace *v1.Namespace, hooks []admit_v1.MutatingWebho
 
 func getMatchingNamespaces(hook *admit_v1.MutatingWebhookConfiguration, namespaces []v1.Namespace) []v1.Namespace {
 	retval := make([]v1.Namespace, 0)
+
+	matched := map[string]bool{}
 	for _, webhook := range hook.Webhooks {
 		nsSelector, err := metav1.LabelSelectorAsSelector(webhook.NamespaceSelector)
 		if err != nil {
@@ -248,7 +250,8 @@ func getMatchingNamespaces(hook *admit_v1.MutatingWebhookConfiguration, namespac
 		}
 
 		for _, namespace := range namespaces {
-			if nsSelector.Matches(api_pkg_labels.Set(namespace.Labels)) {
+			if nsSelector.Matches(api_pkg_labels.Set(namespace.Labels)) && !matched[namespace.Name] {
+				matched[namespace.Name] = true
 				retval = append(retval, namespace)
 			}
 		}

--- a/istioctl/cmd/injector-list_test.go
+++ b/istioctl/cmd/injector-list_test.go
@@ -16,7 +16,7 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	admit_v1 "k8s.io/api/admissionregistration/v1"
@@ -120,7 +120,7 @@ func Test_getMatchingNamespacesWithDefaultAndRevInjector(t *testing.T) {
 			expectedInjectorTotal: 1,
 		},
 	}
-	defaultFile, err := ioutil.ReadFile("testdata/default-injector.yaml")
+	defaultFile, err := os.ReadFile("testdata/default-injector.yaml")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -128,7 +128,7 @@ func Test_getMatchingNamespacesWithDefaultAndRevInjector(t *testing.T) {
 	if err := yaml.Unmarshal(defaultFile, &defaultWh); err != nil {
 		t.Fatal(err)
 	}
-	revFile, err := ioutil.ReadFile("testdata/rev-16-injector.yaml")
+	revFile, err := os.ReadFile("testdata/rev-16-injector.yaml")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/istioctl/cmd/testdata/default-injector.yaml
+++ b/istioctl/cmd/testdata/default-injector.yaml
@@ -1,0 +1,181 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"admissionregistration.k8s.io/v1","kind":"MutatingWebhookConfiguration","metadata":{"annotations":{},"labels":{"app":"sidecar-injector","install.operator.istio.io/owning-resource":"example-istiocontrolplane","install.operator.istio.io/owning-resource-namespace":"istio-system","istio.io/rev":"default","operator.istio.io/component":"Pilot","operator.istio.io/managed":"Reconcile","operator.istio.io/version":"1.14.0","release":"istio"},"name":"istio-sidecar-injector"},"webhooks":[{"admissionReviewVersions":["v1beta1","v1"],"clientConfig":{"service":{"name":"istiod","namespace":"istio-system","path":"/inject","port":443}},"failurePolicy":"Fail","name":"rev.namespace.sidecar-injector.istio.io","namespaceSelector":{"matchExpressions":[{"key":"istio.io/rev","operator":"In","values":["default"]},{"key":"istio-injection","operator":"DoesNotExist"}]},"objectSelector":{"matchExpressions":[{"key":"sidecar.istio.io/inject","operator":"NotIn","values":["false"]}]},"rules":[{"apiGroups":[""],"apiVersions":["v1"],"operations":["CREATE"],"resources":["pods"]}],"sideEffects":"None"},{"admissionReviewVersions":["v1beta1","v1"],"clientConfig":{"service":{"name":"istiod","namespace":"istio-system","path":"/inject","port":443}},"failurePolicy":"Fail","name":"rev.object.sidecar-injector.istio.io","namespaceSelector":{"matchExpressions":[{"key":"istio.io/rev","operator":"DoesNotExist"},{"key":"istio-injection","operator":"DoesNotExist"}]},"objectSelector":{"matchExpressions":[{"key":"sidecar.istio.io/inject","operator":"NotIn","values":["false"]},{"key":"istio.io/rev","operator":"In","values":["default"]}]},"rules":[{"apiGroups":[""],"apiVersions":["v1"],"operations":["CREATE"],"resources":["pods"]}],"sideEffects":"None"},{"admissionReviewVersions":["v1beta1","v1"],"clientConfig":{"service":{"name":"istiod","namespace":"istio-system","path":"/inject","port":443}},"failurePolicy":"Fail","name":"namespace.sidecar-injector.istio.io","namespaceSelector":{"matchExpressions":[{"key":"istio-injection","operator":"In","values":["enabled"]}]},"objectSelector":{"matchExpressions":[{"key":"sidecar.istio.io/inject","operator":"NotIn","values":["false"]}]},"rules":[{"apiGroups":[""],"apiVersions":["v1"],"operations":["CREATE"],"resources":["pods"]}],"sideEffects":"None"},{"admissionReviewVersions":["v1beta1","v1"],"clientConfig":{"service":{"name":"istiod","namespace":"istio-system","path":"/inject","port":443}},"failurePolicy":"Fail","name":"object.sidecar-injector.istio.io","namespaceSelector":{"matchExpressions":[{"key":"istio-injection","operator":"DoesNotExist"},{"key":"istio.io/rev","operator":"DoesNotExist"}]},"objectSelector":{"matchExpressions":[{"key":"sidecar.istio.io/inject","operator":"In","values":["true"]},{"key":"istio.io/rev","operator":"DoesNotExist"}]},"rules":[{"apiGroups":[""],"apiVersions":["v1"],"operations":["CREATE"],"resources":["pods"]}],"sideEffects":"None"}]}
+  creationTimestamp: "2022-07-01T02:46:14Z"
+  generation: 2
+  labels:
+    app: sidecar-injector
+    install.operator.istio.io/owning-resource: example-istiocontrolplane
+    install.operator.istio.io/owning-resource-namespace: istio-system
+    istio.io/rev: default
+    operator.istio.io/component: Pilot
+    operator.istio.io/managed: Reconcile
+    operator.istio.io/version: 1.14.0
+    release: istio
+  name: istio-sidecar-injector
+  resourceVersion: "10312433"
+  uid: 92899629-9349-47f6-93b9-a4d52d6c4c43
+webhooks:
+  - admissionReviewVersions:
+      - v1beta1
+      - v1
+    clientConfig:
+      caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUMvRENDQWVTZ0F3SUJBZ0lRQ01NczNvOExKd3FiR2NaMXczeEY1ekFOQmdrcWhraUc5dzBCQVFzRkFEQVkKTVJZd0ZBWURWUVFLRXcxamJIVnpkR1Z5TG14dlkyRnNNQjRYRFRJeU1ETXlOREV4TWpJeE1Gb1hEVE15TURNeQpNVEV4TWpJeE1Gb3dHREVXTUJRR0ExVUVDaE1OWTJ4MWMzUmxjaTVzYjJOaGJEQ0NBU0l3RFFZSktvWklodmNOCkFRRUJCUUFEZ2dFUEFEQ0NBUW9DZ2dFQkFMZDhISEZCYUZtMndFZzFsSllZYy9BVHdpR0FpSXQrOXl0Q2gwUEUKSkdsbTR4bXJyU2RLdmllcVlmYzJINm1RNWJ0aTMyMS9OS0oxNkFvWDBhWUFNUzkrb2VkS0tlRVZHNmNxTkVHRwpmM2VhV0pCWnZGa0NlSUkzbCtSRlBuNlhEM3hxUUVpbzhQeldpSmo2eFBUMjk5UUJQZnUwYXRBQTRQaFRsZ1dDCm1HdjQxcTNkREUzR1FuV0xOWlJsZ2xEVmtHUjlCVHppWDBLTmxEYit4NGhISkYzSkkwWFlzYkNJR1dRYVlSUnIKaDRXanJUVG1aUkNVZ2M3VWNDaVJIMjJOTzJBRXVONXhPUDRSdjZ0QXRKNXl2dFczSTlpUGlHYzh0cjdneFZ4WQpucjRrWSt2SDFYVHdWbmFMSFdsMUdCNUdTVmhWeDY0dURJUW9MVmxabUdJaWZMMENBd0VBQWFOQ01FQXdEZ1lEClZSMFBBUUgvQkFRREFnSUVNQThHQTFVZEV3RUIvd1FGTUFNQkFmOHdIUVlEVlIwT0JCWUVGS0NRUzJoRE4wQ2cKb2prbGhNRjR6SENqUTlnYU1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQXZSeWpRSmFjL2J1YUVOaXloMTZEbwovRFlJSmpJd2lJWVNabm9rS1czdDdUUlBmTlZlUXZSSFJKZUZCa3lHWFVkK2NDcCtkcVV2Mmt4ZWUvRWpRSW1YCkdjeCtGUWRjaC9uTGtwMDhnOTdzZjB2S1llOUc2RG1sVEdJVTlYNjV4ZHZqcHlRaUkyMnMyWlIzVThsVFFrUmEKbDFXZjNaT3ZYMVdWbGxOd0VHcWkyT28weXBFQUo1VmpmTnEvSzFJYjVYTHZya2dBNjdJY1YvNitoMURLK2x3NAo4Qmx5dUNnTDRVR1pPbnNCNHVXclJvSkZvWm1YOWRVK1hONTVuWUluS0JEMEtoQ295cXBwOG43TnJZZ1FyV3pyClcyUHFOb2diNVFFTFpUVTZsYU14MDNCQkxaM0pUQWV2L1lhN1VhUm00cnVLdkNWYXVjc1BkdkRvaVFoNmk3Z2MKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
+      service:
+        name: istiod
+        namespace: istio-system
+        path: /inject
+        port: 443
+    failurePolicy: Fail
+    matchPolicy: Equivalent
+    name: rev.namespace.sidecar-injector.istio.io
+    namespaceSelector:
+      matchExpressions:
+        - key: istio.io/rev
+          operator: In
+          values:
+            - default
+        - key: istio-injection
+          operator: DoesNotExist
+    objectSelector:
+      matchExpressions:
+        - key: sidecar.istio.io/inject
+          operator: NotIn
+          values:
+            - "false"
+    reinvocationPolicy: Never
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+        scope: '*'
+    sideEffects: None
+    timeoutSeconds: 10
+  - admissionReviewVersions:
+      - v1beta1
+      - v1
+    clientConfig:
+      caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUMvRENDQWVTZ0F3SUJBZ0lRQ01NczNvOExKd3FiR2NaMXczeEY1ekFOQmdrcWhraUc5dzBCQVFzRkFEQVkKTVJZd0ZBWURWUVFLRXcxamJIVnpkR1Z5TG14dlkyRnNNQjRYRFRJeU1ETXlOREV4TWpJeE1Gb1hEVE15TURNeQpNVEV4TWpJeE1Gb3dHREVXTUJRR0ExVUVDaE1OWTJ4MWMzUmxjaTVzYjJOaGJEQ0NBU0l3RFFZSktvWklodmNOCkFRRUJCUUFEZ2dFUEFEQ0NBUW9DZ2dFQkFMZDhISEZCYUZtMndFZzFsSllZYy9BVHdpR0FpSXQrOXl0Q2gwUEUKSkdsbTR4bXJyU2RLdmllcVlmYzJINm1RNWJ0aTMyMS9OS0oxNkFvWDBhWUFNUzkrb2VkS0tlRVZHNmNxTkVHRwpmM2VhV0pCWnZGa0NlSUkzbCtSRlBuNlhEM3hxUUVpbzhQeldpSmo2eFBUMjk5UUJQZnUwYXRBQTRQaFRsZ1dDCm1HdjQxcTNkREUzR1FuV0xOWlJsZ2xEVmtHUjlCVHppWDBLTmxEYit4NGhISkYzSkkwWFlzYkNJR1dRYVlSUnIKaDRXanJUVG1aUkNVZ2M3VWNDaVJIMjJOTzJBRXVONXhPUDRSdjZ0QXRKNXl2dFczSTlpUGlHYzh0cjdneFZ4WQpucjRrWSt2SDFYVHdWbmFMSFdsMUdCNUdTVmhWeDY0dURJUW9MVmxabUdJaWZMMENBd0VBQWFOQ01FQXdEZ1lEClZSMFBBUUgvQkFRREFnSUVNQThHQTFVZEV3RUIvd1FGTUFNQkFmOHdIUVlEVlIwT0JCWUVGS0NRUzJoRE4wQ2cKb2prbGhNRjR6SENqUTlnYU1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQXZSeWpRSmFjL2J1YUVOaXloMTZEbwovRFlJSmpJd2lJWVNabm9rS1czdDdUUlBmTlZlUXZSSFJKZUZCa3lHWFVkK2NDcCtkcVV2Mmt4ZWUvRWpRSW1YCkdjeCtGUWRjaC9uTGtwMDhnOTdzZjB2S1llOUc2RG1sVEdJVTlYNjV4ZHZqcHlRaUkyMnMyWlIzVThsVFFrUmEKbDFXZjNaT3ZYMVdWbGxOd0VHcWkyT28weXBFQUo1VmpmTnEvSzFJYjVYTHZya2dBNjdJY1YvNitoMURLK2x3NAo4Qmx5dUNnTDRVR1pPbnNCNHVXclJvSkZvWm1YOWRVK1hONTVuWUluS0JEMEtoQ295cXBwOG43TnJZZ1FyV3pyClcyUHFOb2diNVFFTFpUVTZsYU14MDNCQkxaM0pUQWV2L1lhN1VhUm00cnVLdkNWYXVjc1BkdkRvaVFoNmk3Z2MKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
+      service:
+        name: istiod
+        namespace: istio-system
+        path: /inject
+        port: 443
+    failurePolicy: Fail
+    matchPolicy: Equivalent
+    name: rev.object.sidecar-injector.istio.io
+    namespaceSelector:
+      matchExpressions:
+        - key: istio.io/rev
+          operator: DoesNotExist
+        - key: istio-injection
+          operator: DoesNotExist
+    objectSelector:
+      matchExpressions:
+        - key: sidecar.istio.io/inject
+          operator: NotIn
+          values:
+            - "false"
+        - key: istio.io/rev
+          operator: In
+          values:
+            - default
+    reinvocationPolicy: Never
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+        scope: '*'
+    sideEffects: None
+    timeoutSeconds: 10
+  - admissionReviewVersions:
+      - v1beta1
+      - v1
+    clientConfig:
+      caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUMvRENDQWVTZ0F3SUJBZ0lRQ01NczNvOExKd3FiR2NaMXczeEY1ekFOQmdrcWhraUc5dzBCQVFzRkFEQVkKTVJZd0ZBWURWUVFLRXcxamJIVnpkR1Z5TG14dlkyRnNNQjRYRFRJeU1ETXlOREV4TWpJeE1Gb1hEVE15TURNeQpNVEV4TWpJeE1Gb3dHREVXTUJRR0ExVUVDaE1OWTJ4MWMzUmxjaTVzYjJOaGJEQ0NBU0l3RFFZSktvWklodmNOCkFRRUJCUUFEZ2dFUEFEQ0NBUW9DZ2dFQkFMZDhISEZCYUZtMndFZzFsSllZYy9BVHdpR0FpSXQrOXl0Q2gwUEUKSkdsbTR4bXJyU2RLdmllcVlmYzJINm1RNWJ0aTMyMS9OS0oxNkFvWDBhWUFNUzkrb2VkS0tlRVZHNmNxTkVHRwpmM2VhV0pCWnZGa0NlSUkzbCtSRlBuNlhEM3hxUUVpbzhQeldpSmo2eFBUMjk5UUJQZnUwYXRBQTRQaFRsZ1dDCm1HdjQxcTNkREUzR1FuV0xOWlJsZ2xEVmtHUjlCVHppWDBLTmxEYit4NGhISkYzSkkwWFlzYkNJR1dRYVlSUnIKaDRXanJUVG1aUkNVZ2M3VWNDaVJIMjJOTzJBRXVONXhPUDRSdjZ0QXRKNXl2dFczSTlpUGlHYzh0cjdneFZ4WQpucjRrWSt2SDFYVHdWbmFMSFdsMUdCNUdTVmhWeDY0dURJUW9MVmxabUdJaWZMMENBd0VBQWFOQ01FQXdEZ1lEClZSMFBBUUgvQkFRREFnSUVNQThHQTFVZEV3RUIvd1FGTUFNQkFmOHdIUVlEVlIwT0JCWUVGS0NRUzJoRE4wQ2cKb2prbGhNRjR6SENqUTlnYU1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQXZSeWpRSmFjL2J1YUVOaXloMTZEbwovRFlJSmpJd2lJWVNabm9rS1czdDdUUlBmTlZlUXZSSFJKZUZCa3lHWFVkK2NDcCtkcVV2Mmt4ZWUvRWpRSW1YCkdjeCtGUWRjaC9uTGtwMDhnOTdzZjB2S1llOUc2RG1sVEdJVTlYNjV4ZHZqcHlRaUkyMnMyWlIzVThsVFFrUmEKbDFXZjNaT3ZYMVdWbGxOd0VHcWkyT28weXBFQUo1VmpmTnEvSzFJYjVYTHZya2dBNjdJY1YvNitoMURLK2x3NAo4Qmx5dUNnTDRVR1pPbnNCNHVXclJvSkZvWm1YOWRVK1hONTVuWUluS0JEMEtoQ295cXBwOG43TnJZZ1FyV3pyClcyUHFOb2diNVFFTFpUVTZsYU14MDNCQkxaM0pUQWV2L1lhN1VhUm00cnVLdkNWYXVjc1BkdkRvaVFoNmk3Z2MKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
+      service:
+        name: istiod
+        namespace: istio-system
+        path: /inject
+        port: 443
+    failurePolicy: Fail
+    matchPolicy: Equivalent
+    name: namespace.sidecar-injector.istio.io
+    namespaceSelector:
+      matchExpressions:
+        - key: istio-injection
+          operator: In
+          values:
+            - enabled
+    objectSelector:
+      matchExpressions:
+        - key: sidecar.istio.io/inject
+          operator: NotIn
+          values:
+            - "false"
+    reinvocationPolicy: Never
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+        scope: '*'
+    sideEffects: None
+    timeoutSeconds: 10
+  - admissionReviewVersions:
+      - v1beta1
+      - v1
+    clientConfig:
+      caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUMvRENDQWVTZ0F3SUJBZ0lRQ01NczNvOExKd3FiR2NaMXczeEY1ekFOQmdrcWhraUc5dzBCQVFzRkFEQVkKTVJZd0ZBWURWUVFLRXcxamJIVnpkR1Z5TG14dlkyRnNNQjRYRFRJeU1ETXlOREV4TWpJeE1Gb1hEVE15TURNeQpNVEV4TWpJeE1Gb3dHREVXTUJRR0ExVUVDaE1OWTJ4MWMzUmxjaTVzYjJOaGJEQ0NBU0l3RFFZSktvWklodmNOCkFRRUJCUUFEZ2dFUEFEQ0NBUW9DZ2dFQkFMZDhISEZCYUZtMndFZzFsSllZYy9BVHdpR0FpSXQrOXl0Q2gwUEUKSkdsbTR4bXJyU2RLdmllcVlmYzJINm1RNWJ0aTMyMS9OS0oxNkFvWDBhWUFNUzkrb2VkS0tlRVZHNmNxTkVHRwpmM2VhV0pCWnZGa0NlSUkzbCtSRlBuNlhEM3hxUUVpbzhQeldpSmo2eFBUMjk5UUJQZnUwYXRBQTRQaFRsZ1dDCm1HdjQxcTNkREUzR1FuV0xOWlJsZ2xEVmtHUjlCVHppWDBLTmxEYit4NGhISkYzSkkwWFlzYkNJR1dRYVlSUnIKaDRXanJUVG1aUkNVZ2M3VWNDaVJIMjJOTzJBRXVONXhPUDRSdjZ0QXRKNXl2dFczSTlpUGlHYzh0cjdneFZ4WQpucjRrWSt2SDFYVHdWbmFMSFdsMUdCNUdTVmhWeDY0dURJUW9MVmxabUdJaWZMMENBd0VBQWFOQ01FQXdEZ1lEClZSMFBBUUgvQkFRREFnSUVNQThHQTFVZEV3RUIvd1FGTUFNQkFmOHdIUVlEVlIwT0JCWUVGS0NRUzJoRE4wQ2cKb2prbGhNRjR6SENqUTlnYU1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQXZSeWpRSmFjL2J1YUVOaXloMTZEbwovRFlJSmpJd2lJWVNabm9rS1czdDdUUlBmTlZlUXZSSFJKZUZCa3lHWFVkK2NDcCtkcVV2Mmt4ZWUvRWpRSW1YCkdjeCtGUWRjaC9uTGtwMDhnOTdzZjB2S1llOUc2RG1sVEdJVTlYNjV4ZHZqcHlRaUkyMnMyWlIzVThsVFFrUmEKbDFXZjNaT3ZYMVdWbGxOd0VHcWkyT28weXBFQUo1VmpmTnEvSzFJYjVYTHZya2dBNjdJY1YvNitoMURLK2x3NAo4Qmx5dUNnTDRVR1pPbnNCNHVXclJvSkZvWm1YOWRVK1hONTVuWUluS0JEMEtoQ295cXBwOG43TnJZZ1FyV3pyClcyUHFOb2diNVFFTFpUVTZsYU14MDNCQkxaM0pUQWV2L1lhN1VhUm00cnVLdkNWYXVjc1BkdkRvaVFoNmk3Z2MKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
+      service:
+        name: istiod
+        namespace: istio-system
+        path: /inject
+        port: 443
+    failurePolicy: Fail
+    matchPolicy: Equivalent
+    name: object.sidecar-injector.istio.io
+    namespaceSelector:
+      matchExpressions:
+        - key: istio-injection
+          operator: DoesNotExist
+        - key: istio.io/rev
+          operator: DoesNotExist
+    objectSelector:
+      matchExpressions:
+        - key: sidecar.istio.io/inject
+          operator: In
+          values:
+            - "true"
+        - key: istio.io/rev
+          operator: DoesNotExist
+    reinvocationPolicy: Never
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+        scope: '*'
+    sideEffects: None
+    timeoutSeconds: 10

--- a/istioctl/cmd/testdata/rev-16-injector.yaml
+++ b/istioctl/cmd/testdata/rev-16-injector.yaml
@@ -1,0 +1,103 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"admissionregistration.k8s.io/v1","kind":"MutatingWebhookConfiguration","metadata":{"annotations":{},"labels":{"app":"sidecar-injector","install.operator.istio.io/owning-resource":"unknown","install.operator.istio.io/owning-resource-namespace":"istio-system","istio.io/rev":"1-16","operator.istio.io/component":"Pilot","operator.istio.io/managed":"Reconcile","operator.istio.io/version":"1.16-alpha.91e471de3e8fc93ebb545cedf396ddbd550b996c","release":"istio"},"name":"istio-sidecar-injector-1-16"},"webhooks":[{"admissionReviewVersions":["v1beta1","v1"],"clientConfig":{"service":{"name":"istiod-1-16","namespace":"istio-system","path":"/inject","port":443}},"failurePolicy":"Fail","name":"rev.namespace.sidecar-injector.istio.io","namespaceSelector":{"matchExpressions":[{"key":"istio.io/rev","operator":"In","values":["1-16"]},{"key":"istio-injection","operator":"DoesNotExist"}]},"objectSelector":{"matchExpressions":[{"key":"sidecar.istio.io/inject","operator":"NotIn","values":["false"]}]},"rules":[{"apiGroups":[""],"apiVersions":["v1"],"operations":["CREATE"],"resources":["pods"]}],"sideEffects":"None"},{"admissionReviewVersions":["v1beta1","v1"],"clientConfig":{"service":{"name":"istiod-1-16","namespace":"istio-system","path":"/inject","port":443}},"failurePolicy":"Fail","name":"rev.object.sidecar-injector.istio.io","namespaceSelector":{"matchExpressions":[{"key":"istio.io/rev","operator":"DoesNotExist"},{"key":"istio-injection","operator":"DoesNotExist"}]},"objectSelector":{"matchExpressions":[{"key":"sidecar.istio.io/inject","operator":"NotIn","values":["false"]},{"key":"istio.io/rev","operator":"In","values":["1-16"]}]},"rules":[{"apiGroups":[""],"apiVersions":["v1"],"operations":["CREATE"],"resources":["pods"]}],"sideEffects":"None"}]}
+  creationTimestamp: "2022-08-05T08:38:13Z"
+  generation: 2
+  labels:
+    app: sidecar-injector
+    install.operator.istio.io/owning-resource: unknown
+    install.operator.istio.io/owning-resource-namespace: istio-system
+    istio.io/rev: 1-16
+    operator.istio.io/component: Pilot
+    operator.istio.io/managed: Reconcile
+    operator.istio.io/version: 1.16-alpha.91e471de3e8fc93ebb545cedf396ddbd550b996c
+    release: istio
+  name: istio-sidecar-injector-1-16
+  resourceVersion: "10340853"
+  uid: 192c166b-6d64-4ed9-91a4-954573314f61
+webhooks:
+  - admissionReviewVersions:
+      - v1beta1
+      - v1
+    clientConfig:
+      caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUMvRENDQWVTZ0F3SUJBZ0lRQ01NczNvOExKd3FiR2NaMXczeEY1ekFOQmdrcWhraUc5dzBCQVFzRkFEQVkKTVJZd0ZBWURWUVFLRXcxamJIVnpkR1Z5TG14dlkyRnNNQjRYRFRJeU1ETXlOREV4TWpJeE1Gb1hEVE15TURNeQpNVEV4TWpJeE1Gb3dHREVXTUJRR0ExVUVDaE1OWTJ4MWMzUmxjaTVzYjJOaGJEQ0NBU0l3RFFZSktvWklodmNOCkFRRUJCUUFEZ2dFUEFEQ0NBUW9DZ2dFQkFMZDhISEZCYUZtMndFZzFsSllZYy9BVHdpR0FpSXQrOXl0Q2gwUEUKSkdsbTR4bXJyU2RLdmllcVlmYzJINm1RNWJ0aTMyMS9OS0oxNkFvWDBhWUFNUzkrb2VkS0tlRVZHNmNxTkVHRwpmM2VhV0pCWnZGa0NlSUkzbCtSRlBuNlhEM3hxUUVpbzhQeldpSmo2eFBUMjk5UUJQZnUwYXRBQTRQaFRsZ1dDCm1HdjQxcTNkREUzR1FuV0xOWlJsZ2xEVmtHUjlCVHppWDBLTmxEYit4NGhISkYzSkkwWFlzYkNJR1dRYVlSUnIKaDRXanJUVG1aUkNVZ2M3VWNDaVJIMjJOTzJBRXVONXhPUDRSdjZ0QXRKNXl2dFczSTlpUGlHYzh0cjdneFZ4WQpucjRrWSt2SDFYVHdWbmFMSFdsMUdCNUdTVmhWeDY0dURJUW9MVmxabUdJaWZMMENBd0VBQWFOQ01FQXdEZ1lEClZSMFBBUUgvQkFRREFnSUVNQThHQTFVZEV3RUIvd1FGTUFNQkFmOHdIUVlEVlIwT0JCWUVGS0NRUzJoRE4wQ2cKb2prbGhNRjR6SENqUTlnYU1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQXZSeWpRSmFjL2J1YUVOaXloMTZEbwovRFlJSmpJd2lJWVNabm9rS1czdDdUUlBmTlZlUXZSSFJKZUZCa3lHWFVkK2NDcCtkcVV2Mmt4ZWUvRWpRSW1YCkdjeCtGUWRjaC9uTGtwMDhnOTdzZjB2S1llOUc2RG1sVEdJVTlYNjV4ZHZqcHlRaUkyMnMyWlIzVThsVFFrUmEKbDFXZjNaT3ZYMVdWbGxOd0VHcWkyT28weXBFQUo1VmpmTnEvSzFJYjVYTHZya2dBNjdJY1YvNitoMURLK2x3NAo4Qmx5dUNnTDRVR1pPbnNCNHVXclJvSkZvWm1YOWRVK1hONTVuWUluS0JEMEtoQ295cXBwOG43TnJZZ1FyV3pyClcyUHFOb2diNVFFTFpUVTZsYU14MDNCQkxaM0pUQWV2L1lhN1VhUm00cnVLdkNWYXVjc1BkdkRvaVFoNmk3Z2MKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
+      service:
+        name: istiod-1-16
+        namespace: istio-system
+        path: /inject
+        port: 443
+    failurePolicy: Fail
+    matchPolicy: Equivalent
+    name: rev.namespace.sidecar-injector.istio.io
+    namespaceSelector:
+      matchExpressions:
+        - key: istio.io/rev
+          operator: In
+          values:
+            - 1-16
+        - key: istio-injection
+          operator: DoesNotExist
+    objectSelector:
+      matchExpressions:
+        - key: sidecar.istio.io/inject
+          operator: NotIn
+          values:
+            - "false"
+    reinvocationPolicy: Never
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+        scope: '*'
+    sideEffects: None
+    timeoutSeconds: 10
+  - admissionReviewVersions:
+      - v1beta1
+      - v1
+    clientConfig:
+      caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUMvRENDQWVTZ0F3SUJBZ0lRQ01NczNvOExKd3FiR2NaMXczeEY1ekFOQmdrcWhraUc5dzBCQVFzRkFEQVkKTVJZd0ZBWURWUVFLRXcxamJIVnpkR1Z5TG14dlkyRnNNQjRYRFRJeU1ETXlOREV4TWpJeE1Gb1hEVE15TURNeQpNVEV4TWpJeE1Gb3dHREVXTUJRR0ExVUVDaE1OWTJ4MWMzUmxjaTVzYjJOaGJEQ0NBU0l3RFFZSktvWklodmNOCkFRRUJCUUFEZ2dFUEFEQ0NBUW9DZ2dFQkFMZDhISEZCYUZtMndFZzFsSllZYy9BVHdpR0FpSXQrOXl0Q2gwUEUKSkdsbTR4bXJyU2RLdmllcVlmYzJINm1RNWJ0aTMyMS9OS0oxNkFvWDBhWUFNUzkrb2VkS0tlRVZHNmNxTkVHRwpmM2VhV0pCWnZGa0NlSUkzbCtSRlBuNlhEM3hxUUVpbzhQeldpSmo2eFBUMjk5UUJQZnUwYXRBQTRQaFRsZ1dDCm1HdjQxcTNkREUzR1FuV0xOWlJsZ2xEVmtHUjlCVHppWDBLTmxEYit4NGhISkYzSkkwWFlzYkNJR1dRYVlSUnIKaDRXanJUVG1aUkNVZ2M3VWNDaVJIMjJOTzJBRXVONXhPUDRSdjZ0QXRKNXl2dFczSTlpUGlHYzh0cjdneFZ4WQpucjRrWSt2SDFYVHdWbmFMSFdsMUdCNUdTVmhWeDY0dURJUW9MVmxabUdJaWZMMENBd0VBQWFOQ01FQXdEZ1lEClZSMFBBUUgvQkFRREFnSUVNQThHQTFVZEV3RUIvd1FGTUFNQkFmOHdIUVlEVlIwT0JCWUVGS0NRUzJoRE4wQ2cKb2prbGhNRjR6SENqUTlnYU1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQXZSeWpRSmFjL2J1YUVOaXloMTZEbwovRFlJSmpJd2lJWVNabm9rS1czdDdUUlBmTlZlUXZSSFJKZUZCa3lHWFVkK2NDcCtkcVV2Mmt4ZWUvRWpRSW1YCkdjeCtGUWRjaC9uTGtwMDhnOTdzZjB2S1llOUc2RG1sVEdJVTlYNjV4ZHZqcHlRaUkyMnMyWlIzVThsVFFrUmEKbDFXZjNaT3ZYMVdWbGxOd0VHcWkyT28weXBFQUo1VmpmTnEvSzFJYjVYTHZya2dBNjdJY1YvNitoMURLK2x3NAo4Qmx5dUNnTDRVR1pPbnNCNHVXclJvSkZvWm1YOWRVK1hONTVuWUluS0JEMEtoQ295cXBwOG43TnJZZ1FyV3pyClcyUHFOb2diNVFFTFpUVTZsYU14MDNCQkxaM0pUQWV2L1lhN1VhUm00cnVLdkNWYXVjc1BkdkRvaVFoNmk3Z2MKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
+      service:
+        name: istiod-1-16
+        namespace: istio-system
+        path: /inject
+        port: 443
+    failurePolicy: Fail
+    matchPolicy: Equivalent
+    name: rev.object.sidecar-injector.istio.io
+    namespaceSelector:
+      matchExpressions:
+        - key: istio.io/rev
+          operator: DoesNotExist
+        - key: istio-injection
+          operator: DoesNotExist
+    objectSelector:
+      matchExpressions:
+        - key: sidecar.istio.io/inject
+          operator: NotIn
+          values:
+            - "false"
+        - key: istio.io/rev
+          operator: In
+          values:
+            - 1-16
+    reinvocationPolicy: Never
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+        scope: '*'
+    sideEffects: None
+    timeoutSeconds: 10


### PR DESCRIPTION
**Please provide a description of this PR:**
Checking only `NamespaceSelector ` leads to duplicate namespaces, since there are two webhooks with exact same `NamespaceSelector`.

Before filtering, we have dup namespaces if no injection label is set like:
```
NAMESPACES     INJECTOR-HOOK               ISTIO-REVISION SIDECAR-IMAGE
istio-operator istio-sidecar-injector      default        ghcr.io/resf/istio/proxyv2:1.14.0
test2          istio-sidecar-injector      default        ghcr.io/resf/istio/proxyv2:1.14.0
default        istio-sidecar-injector      default        ghcr.io/resf/istio/proxyv2:1.14.0
test           istio-sidecar-injector      default        ghcr.io/resf/istio/proxyv2:1.14.0
istio-operator istio-sidecar-injector      default        ghcr.io/resf/istio/proxyv2:1.14.0
test2          istio-sidecar-injector      default        ghcr.io/resf/istio/proxyv2:1.14.0
istio-operator istio-sidecar-injector-1-16 1-16           gcr.io/istio-testing/proxyv2:1.16-alpha.bb781decd5dbb2492bd0b90bd6b0273fba8c0b0e
test2          istio-sidecar-injector-1-16 1-16           gcr.io/istio-testing/proxyv2:1.16-alpha.bb781decd5dbb2492bd0b90bd6b0273fba8c0b0e
```