### PR TITLE
Fix bug(#39963) that causes istio-init container failure

### DIFF
--- a/tools/istio-iptables/pkg/capture/run_unspecified.go
+++ b/tools/istio-iptables/pkg/capture/run_unspecified.go
@@ -35,3 +35,8 @@ func configureTProxyRoutes(cfg *config.Config) error {
 func ConfigureRoutes(cfg *config.Config, ext dep.Dependencies) error {
 	return ErrNotImplemented
 }
+
+// Gets kernel version - not implemented for unspecified OS
+func getKVersion() []byte {
+	return nil
+}

--- a/tools/istio-iptables/pkg/constants/constants.go
+++ b/tools/istio-iptables/pkg/constants/constants.go
@@ -172,4 +172,5 @@ const (
 
 const (
 	CommandConfigureRoutes = "configure-routes"
+	IP                     = "ip"
 )


### PR DESCRIPTION
While configuring IPV6 address for loopback device, netlink.LinkByName("lo")
fails with "protocol not available" for Linux Kernel < 4.x.x.
(https://github.com/vishvananda/netlink/issues/791)
Running "ip -6" command to add lo addr if Kernel release is <4.

Signed-off-by: Vasanth Sundaravelu <vasanth.sundaravelu@rakuten.com>

**Please provide a description of this PR:**
Fix bug(#39963) that causes istio-init container failure


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
-  [ ] Installation
- [x] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
