### PR TITLE
This fixes `make precommit` failing on a Mac

### DIFF
--- a/cni/pkg/cmd/root.go
+++ b/cni/pkg/cmd/root.go
@@ -85,14 +85,13 @@ var rootCmd = &cobra.Command{
 
 		repair.StartRepair(ctx, &cfg.RepairConfig)
 
-		if err = installer.Run(ctx); err != nil {
-			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-				log.Infof("Installer exits with %v", err)
-				// Error was caused by interrupt/termination signal
-				err = nil
-			} else {
-				log.Errorf("Installer exits with %v", err)
-			}
+		err = installer.Run(ctx)
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			log.Infof("Installer exits with %v", err)
+			// Error was caused by interrupt/termination signal
+			err = nil
+		} else {
+			log.Errorf("Installer exits with %v", err)
 		}
 
 		if cleanErr := installer.Cleanup(); cleanErr != nil {

--- a/cni/pkg/cmd/root.go
+++ b/cni/pkg/cmd/root.go
@@ -85,13 +85,15 @@ var rootCmd = &cobra.Command{
 
 		repair.StartRepair(ctx, &cfg.RepairConfig)
 
-		err = installer.Run(ctx)
-		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-			log.Infof("Installer exits with %v", err)
-			// Error was caused by interrupt/termination signal
-			err = nil
-		} else {
-			log.Errorf("Installer exits with %v", err)
+		//nolint: structcheck // Fixes SA4023: installer.Run never returns a nil interface value
+		if err = installer.Run(ctx); err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				log.Infof("Installer exits with %v", err)
+				// Error was caused by interrupt/termination signal
+				err = nil
+			} else {
+				log.Errorf("Installer exits with %v", err)
+			}
 		}
 
 		if cleanErr := installer.Cleanup(); cleanErr != nil {


### PR DESCRIPTION
**Please provide a description of this PR:**

This fixes a failure in `make precommit` on a Mac.

Currently this yields an error:
```
...
INFO [runner] linters took 4.100221257s with stages: goanalysis_metalinter: 2.83420288s, structcheck: 113.212µs
cni/pkg/cmd/root.go:88:32: SA4023: this comparison is always true (staticcheck)
		if err = installer.Run(ctx); err != nil {
		                             ^
cni/pkg/install/install.go:80:22: SA4023(related information): (*istio.io/istio/cni/pkg/install.Installer).Run never returns a nil interface value (staticcheck)
func (in *Installer) Run(ctx context.Context) (err error) {
                     ^
...
```

I'm not sure why the pipeline doesn't see the same issue since the same build-tools image should be used in both places.