### PR TITLE
Fix API group in distribution report configmap ownerReference

### DIFF
--- a/pilot/pkg/status/distribution/reporter.go
+++ b/pilot/pkg/status/distribution/reporter.go
@@ -105,7 +105,7 @@ func (r *Reporter) Start(clientSet kubernetes.Interface, namespace string, podna
 		scope.Errorf("can't identify pod %s context: %s", podname, err)
 	} else {
 		r.cm.OwnerReferences = []metav1.OwnerReference{
-			*metav1.NewControllerRef(x, metav1.SchemeGroupVersion.WithKind("Pod")),
+			*metav1.NewControllerRef(x, corev1.SchemeGroupVersion.WithKind("Pod")),
 		}
 	}
 	go func() {


### PR DESCRIPTION
Prior to this commit, the status reporter tried to create an ownerReference with an invalid API group, causing the following error:

Error writing Distribution Report: unable to create ConfigMap: configmaps "istiod-78c5bd88d-72m8k-distribution" is forbidden: cannot set blockOwnerDeletion in this case because cannot find RESTMapping for APIVersion meta.k8s.io/v1 Kind Pod: no matches for kind "Pod" in version "meta.k8s.io/v1"

This commit fixes the API group/version to "v1"