### PR TITLE
fix the bug when istio ingressgateway cannot be matched to a node

### DIFF
--- a/manifests/charts/gateways/istio-egress/templates/_affinity.tpl
+++ b/manifests/charts/gateways/istio-egress/templates/_affinity.tpl
@@ -13,13 +13,15 @@ nodeAffinity:
   {{- if or .global.arch $nodeSelector }}
       nodeSelectorTerms:
       - matchExpressions:
-        {{- range $key, $val := .global.arch }}
+        {{- if .global.arch }}
         - key: kubernetes.io/arch
           operator: In
           values:
+        {{- range $key, $val := .global.arch }}
           {{- if gt ($val | int) 0 }}
           - {{ $key | quote }}
           {{- end }}
+        {{- end }}
         {{- end }}
         {{- range $key, $val := $nodeSelector }}
         - key: {{ $key }}

--- a/manifests/charts/gateways/istio-ingress/templates/_affinity.tpl
+++ b/manifests/charts/gateways/istio-ingress/templates/_affinity.tpl
@@ -13,13 +13,15 @@ nodeAffinity:
   {{- if or .global.arch $nodeSelector }}
       nodeSelectorTerms:
       - matchExpressions:
-        {{- range $key, $val := .global.arch }}
+        {{- if .global.arch }}
         - key: kubernetes.io/arch
           operator: In
           values:
+        {{- range $key, $val := .global.arch }}
           {{- if gt ($val | int) 0 }}
           - {{ $key | quote }}
           {{- end }}
+        {{- end }}
         {{- end }}
         {{- range $key, $val := $nodeSelector }}
         - key: {{ $key }}

--- a/releasenotes/notes/bug-fix-for-arch-helm-templates.yaml
+++ b/releasenotes/notes/bug-fix-for-arch-helm-templates.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+
+issue:
+  - https://github.com/istio/istio/issues/40378
+
+releaseNotes:
+- |
+  **Fixed** an issue preventing the istio ingress/egress gateway from matching any nodes


### PR DESCRIPTION
**Please provide a description of this PR:**
#40378 identified an issue with the current node affinity of the istio ingress/egress gateway. Fixed so it matches the old behavior. 