### PR TITLE
Update envoy and pilot tests to use TARGET_OUT instead of LOCAL_OUT

### DIFF
--- a/common/scripts/setup_env.sh
+++ b/common/scripts/setup_env.sh
@@ -176,16 +176,13 @@ fi
 # This is used when we need to run a build artifact during tests or later as part of another
 # target.
 if [[ "${FOR_BUILD_CONTAINER:-0}" -eq "1" ]]; then
-  LOCAL_OUT="${TARGET_OUT_LINUX}"
-else
-  LOCAL_OUT="${TARGET_OUT}"
-fi
-
-if [[ "${FOR_BUILD_CONTAINER:-0}" -eq "1" ]]; then
   # Override variables with container specific
   TARGET_OUT=${CONTAINER_TARGET_OUT}
   TARGET_OUT_LINUX=${CONTAINER_TARGET_OUT_LINUX}
+  LOCAL_OUT="${TARGET_OUT_LINUX}"
   REPO_ROOT=/work
+else
+  LOCAL_OUT="${TARGET_OUT}"
 fi
 
 go_os_arch=${LOCAL_OUT##*/}

--- a/common/scripts/setup_env.sh
+++ b/common/scripts/setup_env.sh
@@ -176,13 +176,16 @@ fi
 # This is used when we need to run a build artifact during tests or later as part of another
 # target.
 if [[ "${FOR_BUILD_CONTAINER:-0}" -eq "1" ]]; then
+  LOCAL_OUT="${TARGET_OUT_LINUX}"
+else
+  LOCAL_OUT="${TARGET_OUT}"
+fi
+
+if [[ "${FOR_BUILD_CONTAINER:-0}" -eq "1" ]]; then
   # Override variables with container specific
   TARGET_OUT=${CONTAINER_TARGET_OUT}
   TARGET_OUT_LINUX=${CONTAINER_TARGET_OUT_LINUX}
-  LOCAL_OUT="${TARGET_OUT_LINUX}"
   REPO_ROOT=/work
-else
-  LOCAL_OUT="${TARGET_OUT}"
 fi
 
 go_os_arch=${LOCAL_OUT##*/}

--- a/pkg/istio-agent/agent_test.go
+++ b/pkg/istio-agent/agent_test.go
@@ -653,7 +653,7 @@ func Setup(t *testing.T, opts ...func(a AgentTest) AgentTest) *AgentTest {
 	// Set-up envoy defaults
 	resp.ProxyConfig.ProxyBootstrapTemplatePath = filepath.Join(env.IstioSrc, "./tools/packaging/common/envoy_bootstrap.json")
 	resp.ProxyConfig.ConfigPath = d
-	resp.ProxyConfig.BinaryPath = filepath.Join(env.LocalOut, "envoy")
+	resp.ProxyConfig.BinaryPath = filepath.Join(env.IstioOut, "envoy")
 	if path, exists := pkgenv.RegisterStringVar("ENVOY_PATH", "", "Specifies the path to an Envoy binary.").Lookup(); exists {
 		resp.ProxyConfig.BinaryPath = path
 	}

--- a/pkg/test/envoy/binary.go
+++ b/pkg/test/envoy/binary.go
@@ -58,7 +58,7 @@ func FindBinaryOrFail(t test.Failer) string {
 
 func findBinaries() ([]string, error) {
 	binPaths := make([]string, 0)
-	err := filepath.Walk(env.LocalOut, func(path string, f os.FileInfo, err error) error {
+	err := filepath.Walk(env.IstioOut, func(path string, f os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
**Please provide a description of this PR:**

Looking to fix https://github.com/istio/istio/issues/39828

A particular test istio.io/istio/pkg/dns/server TestNewWithDuplicateOptionsShouldFail is failing as the binary.go code is using LOCAL_OUT to try and find the binaries (https://github.com/istio/istio/blob/master/pkg/test/envoy/binary.go#L61). This fails when run inside a container as LOCAL_OUT is pointing to the host directory paths.

We don't see a failure in the pipeline as the pipeline does not use a container for testing (BUILD_WITH_CONTAINER=0).

This updates the test to point at TARGET_OUT (which should be the same as LOCAL_OUT when run without a container), and set to the container directories inside a container. 