### PR TITLE
move maxstream duration creation inside condition

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -1094,15 +1094,18 @@ func setTimeout(action *route.RouteAction, vsTimeout *duration.Duration, node *m
 	if vsTimeout != nil {
 		action.Timeout = vsTimeout
 	}
-	action.MaxStreamDuration = &route.RouteAction_MaxStreamDuration{}
 	if node != nil && node.IsProxylessGrpc() {
 		// TODO(stevenctl) merge these paths; grpc's xDS impl will not read the deprecated value
-		action.MaxStreamDuration.MaxStreamDuration = action.Timeout
+		action.MaxStreamDuration = &route.RouteAction_MaxStreamDuration{
+			MaxStreamDuration: action.Timeout,
+		}
 	} else {
 		// Set MaxStreamDuration only for notimeout cases otherwise it wont be honored.
 		if action.Timeout.AsDuration().Nanoseconds() == 0 {
-			action.MaxStreamDuration.MaxStreamDuration = action.Timeout
-			action.MaxStreamDuration.GrpcTimeoutHeaderMax = action.Timeout
+			action.MaxStreamDuration = &route.RouteAction_MaxStreamDuration{
+				MaxStreamDuration:    notimeout,
+				GrpcTimeoutHeaderMax: notimeout,
+			}
 		} else {
 			// If not configured at all, the grpc-timeout header is not used and
 			// gRPC requests time out like any other requests using timeout or its default.


### PR DESCRIPTION
#40320 has moved the maxstream duration condition outside of condition which if it is not used assumes some defaults at HCM. this PR moves it inside.

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
