### PR TITLE
CA client tls config ServerName first set to CAEndpoint host

### DIFF
--- a/pkg/istio-agent/agent.go
+++ b/pkg/istio-agent/agent.go
@@ -61,24 +61,6 @@ import (
 	"istio.io/pkg/log"
 )
 
-// To debug:
-// curl -X POST localhost:15000/logging?config=trace - to see SendingDiscoveryRequest
-
-// Breakpoints in secretcache.go GenerateSecret..
-
-// Note that istiod currently can't validate the JWT token unless it runs on k8s
-// Main problem is the JWT validation check which hardcodes the k8s server address and token location.
-//
-// To test on a local machine, for debugging:
-//
-// kis exec $POD -- cat /run/secrets/istio-token/istio-token > var/run/secrets/tokens/istio-token
-// kis port-forward $POD 15010:15010 &
-//
-// You can also copy the K8S CA and a token to be used to connect to k8s - but will need removing the hardcoded addr
-// kis exec $POD -- cat /run/secrets/kubernetes.io/serviceaccount/{ca.crt,token} > var/run/secrets/kubernetes.io/serviceaccount/
-//
-// Or disable the jwt validation while debugging SDS problems.
-
 const (
 	// Location of K8S CA root.
 	k8sCAPath = "./var/run/secrets/kubernetes.io/serviceaccount/ca.crt"

--- a/pkg/istio-agent/xds_proxy.go
+++ b/pkg/istio-agent/xds_proxy.go
@@ -722,13 +722,13 @@ func (p *XdsProxy) getTLSDialOption(agent *Agent) (grpc.DialOption, error) {
 			}
 			return &certificate, nil
 		},
-		RootCAs: rootCert,
+		RootCAs:    rootCert,
+		MinVersion: tls.VersionTLS12,
 	}
 
-	// strip the port from the address
-	parts := strings.Split(agent.proxyConfig.DiscoveryAddress, ":")
-	config.ServerName = parts[0]
-
+	if host, _, err := net.SplitHostPort(agent.proxyConfig.DiscoveryAddress); err != nil {
+		config.ServerName = host
+	}
 	// For debugging on localhost (with port forward)
 	// This matches the logic for the CA; this code should eventually be shared
 	if strings.Contains(config.ServerName, "localhost") {
@@ -738,9 +738,6 @@ func (p *XdsProxy) getTLSDialOption(agent *Agent) (grpc.DialOption, error) {
 	if p.istiodSAN != "" {
 		config.ServerName = p.istiodSAN
 	}
-	// TODO: if istiodSAN starts with spiffe://, use custom validation.
-
-	config.MinVersion = tls.VersionTLS12
 	transportCreds := credentials.NewTLS(&config)
 	return grpc.WithTransportCredentials(transportCreds), nil
 }

--- a/security/pkg/nodeagent/caclient/providers/citadel/client.go
+++ b/security/pkg/nodeagent/caclient/providers/citadel/client.go
@@ -150,6 +150,9 @@ func (c *CitadelClient) getTLSDialOption() (grpc.DialOption, error) {
 		RootCAs: certPool,
 	}
 
+	// strip the port from the address
+	parts := strings.Split(c.opts.CAEndpoint, ":")
+	config.ServerName = parts[0]
 	// For debugging on localhost (with port forward)
 	// TODO: remove once istiod is stable and we have a way to validate JWTs locally
 	if strings.Contains(c.opts.CAEndpoint, "localhost") {

--- a/security/pkg/nodeagent/caclient/providers/citadel/client.go
+++ b/security/pkg/nodeagent/caclient/providers/citadel/client.go
@@ -21,6 +21,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"strings"
 	"time"
@@ -147,12 +148,13 @@ func (c *CitadelClient) getTLSDialOption() (grpc.DialOption, error) {
 			}
 			return &certificate, nil
 		},
-		RootCAs: certPool,
+		RootCAs:    certPool,
+		MinVersion: tls.VersionTLS12,
 	}
 
-	// strip the port from the address
-	parts := strings.Split(c.opts.CAEndpoint, ":")
-	config.ServerName = parts[0]
+	if host, _, err := net.SplitHostPort(c.opts.CAEndpoint); err != nil {
+		config.ServerName = host
+	}
 	// For debugging on localhost (with port forward)
 	// TODO: remove once istiod is stable and we have a way to validate JWTs locally
 	if strings.Contains(c.opts.CAEndpoint, "localhost") {


### PR DESCRIPTION
**Please provide a description of this PR:**

Fix when CAEndpoint uses a different address, the ServerName will be empty

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
