### PR TITLE
Add lifecycle + terminationgracepriod to GW Chart

### DIFF
--- a/manifests/charts/gateway/templates/deployment.yaml
+++ b/manifests/charts/gateway/templates/deployment.yaml
@@ -41,6 +41,9 @@ spec:
         - name: net.ipv4.ip_unprivileged_port_start
           value: "0"
       {{- end }}
+{{- if .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds}}
+{{- end }}
       containers:
         - name: istio-proxy
           # "auto" will be populated at runtime by the mutating webhook. See https://istio.io/latest/docs/setup/additional-setup/sidecar-injection/#customizing-injection
@@ -79,6 +82,9 @@ spec:
           {{- range $key, $val := .Values.env }}
           - name: {{ $key }}
             value: {{ $val | quote }}
+          {{- end }}
+          {{- if .Values.lifecycle }}
+          lifecycle: {{ toYaml .Values.lifecycle | nindent 12 }}
           {{- end }}
           ports:
           - containerPort: 15090

--- a/manifests/charts/gateway/values.schema.json
+++ b/manifests/charts/gateway/values.schema.json
@@ -195,6 +195,12 @@
           }
         }
       }
+    },
+    "terminationGracePeriodSeconds": {
+      "type": "integer"
+    },
+    "lifecycle": {
+      "type": "object"
     }
   }
 }

--- a/manifests/charts/gateway/values.yaml
+++ b/manifests/charts/gateway/values.yaml
@@ -91,3 +91,6 @@ affinity: {}
 networkGateway: ""
 
 imagePullSecrets: []
+
+terminationGracePeriodSeconds:
+lifecycle: {}

--- a/releasenotes/notes/helm_chart_gateway_lifecycle.yaml
+++ b/releasenotes/notes/helm_chart_gateway_lifecycle.yaml
@@ -1,0 +1,17 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+
+# issue is a list of GitHub issues resolved in this note.
+issue: []
+
+docs: []
+
+releaseNotes:
+- |
+  **Added** values to the Istio Gateway Helm chart for configuring [lifecycle](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/) on the Deployment. Can be used to allow configuration of preStop hooks.
+
+
+upgradeNotes: []
+
+securityNotes: []

--- a/releasenotes/notes/helm_chart_gateway_terminationGracePeriodSeconds.yaml
+++ b/releasenotes/notes/helm_chart_gateway_terminationGracePeriodSeconds.yaml
@@ -1,0 +1,16 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+
+# issue is a list of GitHub issues resolved in this note.
+issue: []
+
+docs: []
+
+releaseNotes:
+- |
+  **Added** values to the Istio Gateway Helm chart for configuring [terminationGracePeriodSeconds](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/) on the Deployment. Can be used to allow graceful termination of connections before pods are terminated.
+
+upgradeNotes: []
+
+securityNotes: []


### PR DESCRIPTION
**Please provide a description of this PR:**

The intention of this PR is to provide support for lifecycle (preStop hooks) and terminationGracePeriodSeconds to the Gateway deployment Helm chart.