### PR TITLE
Ignore port number in domain matching entirely

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -641,7 +641,7 @@ var (
 	LocalClusterSecretWatcher = env.RegisterBoolVar("LOCAL_CLUSTER_SECRET_WATCHER", false,
 		"If enabled, the cluster secret watcher will watch the namespace of the external cluster instead of config cluster").Get()
 
-	SidecarIgnorePort = env.RegisterBoolVar("SIDECAR_IGNORE_PORT", true, "If enabled, port will not be used in vhost domain matches.").Get()
+	SidecarIgnorePort = env.RegisterBoolVar("SIDECAR_IGNORE_PORT_IN_HOST_MATCH", true, "If enabled, port will not be used in vhost domain matches.").Get()
 )
 
 // EnableEndpointSliceController returns the value of the feature flag and whether it was actually specified.

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -640,6 +640,8 @@ var (
 
 	LocalClusterSecretWatcher = env.RegisterBoolVar("LOCAL_CLUSTER_SECRET_WATCHER", false,
 		"If enabled, the cluster secret watcher will watch the namespace of the external cluster instead of config cluster").Get()
+
+	SidecarIgnorePort = env.RegisterBoolVar("SIDECAR_IGNORE_PORT", true, "If enabled, port will not be used in vhost domain matches.").Get()
 )
 
 // EnableEndpointSliceController returns the value of the feature flag and whether it was actually specified.

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -531,7 +531,7 @@ var (
 
 	StripHostPort = env.RegisterBoolVar("ISTIO_GATEWAY_STRIP_HOST_PORT", false,
 		"If enabled, Gateway will remove any port from host/authority header "+
-			"before any processing of request by HTTP filters or routing.").Get()
+			"before any processing of request by HTTP filters or routing. Deprecated: in Istio 1.15+ port is ignored in domain matching.").Get()
 
 	// EnableUnsafeAssertions enables runtime checks to test assertions in our code. This should never be enabled in
 	// production; when assertions fail Istio will panic.

--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -413,7 +413,7 @@ func (configgen *ConfigGeneratorImpl) buildGatewayHTTPRouteConfig(node *model.Pr
 				} else {
 					newVHost := &route.VirtualHost{
 						Name:                       util.DomainName(string(hostname), port),
-						Domains:                    buildGatewayVirtualHostDomains(string(hostname), port),
+						Domains:                    buildGatewayVirtualHostDomains(node, string(hostname), port),
 						Routes:                     routes,
 						IncludeRequestAttemptCount: true,
 					}
@@ -437,7 +437,7 @@ func (configgen *ConfigGeneratorImpl) buildGatewayHTTPRouteConfig(node *model.Pr
 			}
 			newVHost := &route.VirtualHost{
 				Name:                       util.DomainName(hostname, port),
-				Domains:                    buildGatewayVirtualHostDomains(hostname, port),
+				Domains:                    buildGatewayVirtualHostDomains(node, hostname, port),
 				IncludeRequestAttemptCount: true,
 				RequireTls:                 route.VirtualHost_ALL,
 			}
@@ -471,6 +471,9 @@ func (configgen *ConfigGeneratorImpl) buildGatewayHTTPRouteConfig(node *model.Pr
 		Name:             routeName,
 		VirtualHosts:     virtualHosts,
 		ValidateClusters: proto.BoolFalse,
+	}
+	if util.IsIstioVersionGE115(node.IstioVersion) {
+		routeCfg.IgnorePortInHostMatching = true
 	}
 
 	return routeCfg
@@ -1012,9 +1015,9 @@ func isGatewayMatch(gateway string, gatewayNames []string) bool {
 	return false
 }
 
-func buildGatewayVirtualHostDomains(hostname string, port int) []string {
+func buildGatewayVirtualHostDomains(node *model.Proxy, hostname string, port int) []string {
 	domains := []string{hostname}
-	if features.StripHostPort || hostname == "*" {
+	if features.StripHostPort || hostname == "*" || util.IsIstioVersionGE115(node.IstioVersion) {
 		return domains
 	}
 

--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -472,7 +472,7 @@ func (configgen *ConfigGeneratorImpl) buildGatewayHTTPRouteConfig(node *model.Pr
 		VirtualHosts:     virtualHosts,
 		ValidateClusters: proto.BoolFalse,
 	}
-	if SupportsIgnorePort(node) {
+	if GatewayIgnorePort(node) {
 		routeCfg.IgnorePortInHostMatching = true
 	}
 
@@ -1017,7 +1017,7 @@ func isGatewayMatch(gateway string, gatewayNames []string) bool {
 
 func buildGatewayVirtualHostDomains(node *model.Proxy, hostname string, port int) []string {
 	domains := []string{hostname}
-	if features.StripHostPort || hostname == "*" || SupportsIgnorePort(node) {
+	if features.StripHostPort || hostname == "*" || GatewayIgnorePort(node) {
 		return domains
 	}
 

--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -472,7 +472,7 @@ func (configgen *ConfigGeneratorImpl) buildGatewayHTTPRouteConfig(node *model.Pr
 		VirtualHosts:     virtualHosts,
 		ValidateClusters: proto.BoolFalse,
 	}
-	if util.IsIstioVersionGE115(node.IstioVersion) {
+	if SupportsIgnorePort(node) {
 		routeCfg.IgnorePortInHostMatching = true
 	}
 
@@ -1017,7 +1017,7 @@ func isGatewayMatch(gateway string, gatewayNames []string) bool {
 
 func buildGatewayVirtualHostDomains(node *model.Proxy, hostname string, port int) []string {
 	domains := []string{hostname}
-	if features.StripHostPort || hostname == "*" || util.IsIstioVersionGE115(node.IstioVersion) {
+	if features.StripHostPort || hostname == "*" || SupportsIgnorePort(node) {
 		return domains
 	}
 

--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -534,7 +534,6 @@ func GatewayIgnorePort(node *model.Proxy) bool {
 	return util.IsIstioVersionGE115(node.IstioVersion) && !node.IsProxylessGrpc()
 }
 
-
 // SidecarIgnorePort determines if we can exclude ports from domain matches for sidecars specifically.
 // This differs from GatewayIgnorePort as it is flag protected to avoid breaking change risks
 func SidecarIgnorePort(node *model.Proxy) bool {

--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -640,15 +640,14 @@ func generateAltVirtualHostsForKubernetesService(hostname string, port int, prox
 					hostname[:ih] + ".svc",
 					hostname[:ih],
 				}
-			} else {
-				return []string{
-					hostname[:ns],
-					util.DomainName(hostname[:ns], port),
-					hostname[:ih] + ".svc",
-					util.DomainName(hostname[:ih]+".svc", port),
-					hostname[:ih],
-					util.DomainName(hostname[:ih], port),
-				}
+			}
+			return []string{
+				hostname[:ns],
+				util.DomainName(hostname[:ns], port),
+				hostname[:ih] + ".svc",
+				util.DomainName(hostname[:ih]+".svc", port),
+				hostname[:ih],
+				util.DomainName(hostname[:ih], port),
 			}
 		}
 		// Different namespace
@@ -657,13 +656,12 @@ func generateAltVirtualHostsForKubernetesService(hostname string, port int, prox
 				hostname[:ih],
 				hostname[:ih] + ".svc",
 			}
-		} else {
-			return []string{
-				hostname[:ih],
-				util.DomainName(hostname[:ih], port),
-				hostname[:ih] + ".svc",
-				util.DomainName(hostname[:ih]+".svc", port),
-			}
+		}
+		return []string{
+			hostname[:ih],
+			util.DomainName(hostname[:ih], port),
+			hostname[:ih] + ".svc",
+			util.DomainName(hostname[:ih]+".svc", port),
 		}
 	}
 	// Proxy is in k8s, but service isn't. No alt hosts

--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -202,7 +202,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundHTTPRouteConfig(
 		VirtualHosts:     virtualHosts,
 		ValidateClusters: proto.BoolFalse,
 	}
-	if SupportsIgnorePort(node) {
+	if SidecarIgnorePort(node) {
 		out.IgnorePortInHostMatching = true
 	}
 
@@ -401,7 +401,7 @@ func BuildSidecarOutboundVirtualHosts(node *model.Proxy, push *model.PushContext
 		var domains []string
 		var altHosts []string
 		if svc == nil {
-			if SupportsIgnorePort(node) {
+			if SidecarIgnorePort(node) {
 				domains = []string{util.IPv6Compliant(hostname)}
 			} else {
 				domains = []string{util.IPv6Compliant(hostname), name}
@@ -529,14 +529,22 @@ func getVirtualHostsForSniffedServicePort(vhosts []*route.VirtualHost, routeName
 	return virtualHosts
 }
 
-func SupportsIgnorePort(node *model.Proxy) bool {
+// GatewayIgnorePort determines if we can exclude ports from domain matches
+func GatewayIgnorePort(node *model.Proxy) bool {
 	return util.IsIstioVersionGE115(node.IstioVersion) && !node.IsProxylessGrpc()
+}
+
+
+// SidecarIgnorePort determines if we can exclude ports from domain matches for sidecars specifically.
+// This differs from GatewayIgnorePort as it is flag protected to avoid breaking change risks
+func SidecarIgnorePort(node *model.Proxy) bool {
+	return util.IsIstioVersionGE115(node.IstioVersion) && !node.IsProxylessGrpc() && features.SidecarIgnorePort
 }
 
 // generateVirtualHostDomains generates the set of domain matches for a service being accessed from
 // a proxy node
 func generateVirtualHostDomains(service *model.Service, listenerPort int, port int, node *model.Proxy) ([]string, []string) {
-	if SupportsIgnorePort(node) && listenerPort != 0 {
+	if SidecarIgnorePort(node) && listenerPort != 0 {
 		// Indicate we do not need port, as we will set IgnorePortInHostMatching
 		port = portNoAppendPortSuffix
 	}

--- a/pilot/pkg/networking/core/v1alpha3/httproute_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute_test.go
@@ -307,7 +307,7 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 	}
 
 	testFn := func(t test.Failer, service *model.Service, port int, node *model.Proxy, want []string) {
-		out, _ := generateVirtualHostDomains(service, port, node)
+		out, _ := generateVirtualHostDomains(service, port, port, node)
 		assert.Equal(t, out, want)
 	}
 
@@ -375,8 +375,8 @@ func TestSidecarOutboundHTTPRouteConfigWithDuplicateHosts(t *testing.T) {
 			map[string][]string{
 				"allow_any": {"*"},
 				// BUG: test should be below
-				"test.local:80": {"test.local", "test.local:80"},
-				"test:80":       {"test", "test:80"},
+				"test.local:80": {"test.local"},
+				"test:80":       {"test"},
 			},
 			map[string]string{
 				"allow_any":     "PassthroughCluster",
@@ -394,11 +394,11 @@ func TestSidecarOutboundHTTPRouteConfigWithDuplicateHosts(t *testing.T) {
 			map[string][]string{
 				"allow_any": {"*"},
 				"test.default.svc.cluster.local:80": {
-					"test.default.svc.cluster.local", "test.default.svc.cluster.local:80",
-					"test.default.svc", "test.default.svc:80",
-					"test.default", "test.default:80",
+					"test.default.svc.cluster.local",
+					"test.default.svc",
+					"test.default",
 				},
-				"test:80": {"test", "test:80"},
+				"test:80": {"test"},
 			},
 			map[string]string{
 				"allow_any":                         "PassthroughCluster",
@@ -415,8 +415,8 @@ func TestSidecarOutboundHTTPRouteConfigWithDuplicateHosts(t *testing.T) {
 			nil,
 			map[string][]string{
 				"allow_any":     {"*"},
-				"test.local:80": {"test.local", "test.local:80"},
-				"test:80":       {"test", "test:80"},
+				"test.local:80": {"test.local"},
+				"test:80":       {"test"},
 			},
 			map[string]string{
 				"allow_any":     "PassthroughCluster",
@@ -439,11 +439,11 @@ func TestSidecarOutboundHTTPRouteConfigWithDuplicateHosts(t *testing.T) {
 			map[string][]string{
 				"allow_any": {"*"},
 				"test-duplicate-domains.default.svc.cluster.local:80": {
-					"test-duplicate-domains.default.svc.cluster.local", "test-duplicate-domains.default.svc.cluster.local:80",
-					"test-duplicate-domains", "test-duplicate-domains:80",
-					"test-duplicate-domains.default.svc", "test-duplicate-domains.default.svc:80",
+					"test-duplicate-domains.default.svc.cluster.local",
+					"test-duplicate-domains",
+					"test-duplicate-domains.default.svc",
 				},
-				"test-duplicate-domains.default:80": {"test-duplicate-domains.default", "test-duplicate-domains.default:80"},
+				"test-duplicate-domains.default:80": {"test-duplicate-domains.default"},
 			},
 			map[string]string{
 				"allow_any": "PassthroughCluster",
@@ -467,11 +467,11 @@ func TestSidecarOutboundHTTPRouteConfigWithDuplicateHosts(t *testing.T) {
 			map[string][]string{
 				"allow_any": {"*"},
 				"test.default.svc.cluster.local:80": {
-					"test.default.svc.cluster.local", "test.default.svc.cluster.local:80",
-					"test", "test:80",
-					"test.default.svc", "test.default.svc:80",
+					"test.default.svc.cluster.local",
+					"test",
+					"test.default.svc",
 				},
-				"test.default:80": {"test.default", "test.default:80"},
+				"test.default:80": {"test.default"},
 			},
 			map[string]string{
 				"allow_any": "PassthroughCluster",
@@ -488,7 +488,7 @@ func TestSidecarOutboundHTTPRouteConfigWithDuplicateHosts(t *testing.T) {
 			nil,
 			map[string][]string{
 				"allow_any":     {"*"},
-				"test.local:80": {"test.local", "test.local:80"},
+				"test.local:80": {"test.local"},
 			},
 			map[string]string{
 				"allow_any":     "PassthroughCluster",
@@ -995,7 +995,7 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			sidecarConfig:         sidecarConfig,
 			virtualServiceConfigs: nil,
 			expectedHosts: map[string]map[string]bool{
-				"test.com:8080": {"test.com": true, "test.com:8080": true, "8.8.8.8": true, "8.8.8.8:8080": true},
+				"test.com:8080": {"test.com": true, "8.8.8.8": true},
 				"block_all": {
 					"*": true,
 				},
@@ -1009,7 +1009,7 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			virtualServiceConfigs: nil,
 			expectedHosts: map[string]map[string]bool{
 				"test-private.com:80": {
-					"test-private.com": true, "test-private.com:80": true, "9.9.9.9": true, "9.9.9.9:80": true,
+					"test-private.com": true, "9.9.9.9": true,
 				},
 				"block_all": {
 					"*": true,
@@ -1024,7 +1024,7 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			virtualServiceConfigs: nil,
 			expectedHosts: map[string]map[string]bool{
 				"test-private.com:80": {
-					"test-private.com": true, "test-private.com:80": true, "9.9.9.9": true, "9.9.9.9:80": true,
+					"test-private.com": true, "9.9.9.9": true,
 				},
 				"allow_any": {
 					"*": true,
@@ -1041,9 +1041,9 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			expectedHosts: map[string]map[string]bool{
 				// does not include `match-no-service`
 				"test-private.com:80": {
-					"test-private.com": true, "test-private.com:80": true, "9.9.9.9": true, "9.9.9.9:80": true,
+					"test-private.com": true, "9.9.9.9": true,
 				},
-				"match-no-service.not-default:80": {"match-no-service.not-default": true, "match-no-service.not-default:80": true},
+				"match-no-service.not-default:80": {"match-no-service.not-default": true},
 				"allow_any": {
 					"*": true,
 				},
@@ -1059,9 +1059,9 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			expectedHosts: map[string]map[string]bool{
 				// does not include `match-no-service`
 				"test-private.com:80": {
-					"test-private.com": true, "test-private.com:80": true, "9.9.9.9": true, "9.9.9.9:80": true,
+					"test-private.com": true, "9.9.9.9": true,
 				},
-				"match-no-service.not-default:80": {"match-no-service.not-default": true, "match-no-service.not-default:80": true},
+				"match-no-service.not-default:80": {"match-no-service.not-default": true},
 				"allow_any": {
 					"*": true,
 				},
@@ -1076,8 +1076,8 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			virtualServiceConfigs: nil,
 			expectedHosts: map[string]map[string]bool{
 				"bookinfo.com:9999": {
-					"bookinfo.com:9999": true, "bookinfo.com": true,
-					"*.bookinfo.com:9999": true, "*.bookinfo.com": true,
+					"bookinfo.com":   true,
+					"*.bookinfo.com": true,
 				},
 				"block_all": {
 					"*": true,
@@ -1092,7 +1092,7 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			virtualServiceConfigs: nil,
 			expectedHosts: map[string]map[string]bool{
 				"test-private.com:80": {
-					"test-private.com": true, "test-private.com:80": true, "9.9.9.9": true, "9.9.9.9:80": true,
+					"test-private.com": true, "9.9.9.9": true,
 				},
 				"block_all": {
 					"*": true,
@@ -1107,11 +1107,11 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			virtualServiceConfigs: nil,
 			expectedHosts: map[string]map[string]bool{
 				"test-private.com:70": {
-					"test-private.com": true, "test-private.com:70": true, "9.9.9.9": true, "9.9.9.9:70": true,
+					"test-private.com": true, "9.9.9.9": true,
 				},
 				"bookinfo.com:70": {
-					"bookinfo.com": true, "bookinfo.com:70": true,
-					"*.bookinfo.com": true, "*.bookinfo.com:70": true,
+					"bookinfo.com":   true,
+					"*.bookinfo.com": true,
 				},
 				"block_all": {
 					"*": true,
@@ -1126,8 +1126,8 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			virtualServiceConfigs: nil,
 			expectedHosts: map[string]map[string]bool{
 				"bookinfo.com:9999": {
-					"bookinfo.com:9999": true, "bookinfo.com": true,
-					"*.bookinfo.com:9999": true, "*.bookinfo.com": true,
+					"bookinfo.com":   true,
+					"*.bookinfo.com": true,
 				},
 				"block_all": {
 					"*": true,
@@ -1142,7 +1142,7 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			virtualServiceConfigs: nil,
 			expectedHosts: map[string]map[string]bool{
 				"test.com:8080": {
-					"test.com:8080": true, "test.com": true, "8.8.8.8": true, "8.8.8.8:8080": true,
+					"test.com": true, "8.8.8.8": true,
 				},
 				"block_all": {
 					"*": true,
@@ -1157,7 +1157,7 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			virtualServiceConfigs: nil,
 			expectedHosts: map[string]map[string]bool{
 				"test-private.com:80": {
-					"test-private.com": true, "test-private.com:80": true, "9.9.9.9": true, "9.9.9.9:80": true,
+					"test-private.com": true, "9.9.9.9": true,
 				},
 				"block_all": {
 					"*": true,
@@ -1172,11 +1172,11 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			virtualServiceConfigs: nil,
 			expectedHosts: map[string]map[string]bool{
 				"test-private.com:70": {
-					"test-private.com": true, "test-private.com:70": true, "9.9.9.9": true, "9.9.9.9:70": true,
+					"test-private.com": true, "9.9.9.9": true,
 				},
 				"bookinfo.com:70": {
-					"bookinfo.com": true, "bookinfo.com:70": true,
-					"*.bookinfo.com": true, "*.bookinfo.com:70": true,
+					"bookinfo.com":   true,
+					"*.bookinfo.com": true,
 				},
 				"block_all": {
 					"*": true,
@@ -1203,7 +1203,7 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			virtualServiceConfigs: nil,
 			expectedHosts: map[string]map[string]bool{
 				"test-private.com:80": {
-					"test-private.com": true, "test-private.com:80": true, "9.9.9.9": true, "9.9.9.9:80": true,
+					"test-private.com": true, "9.9.9.9": true,
 				},
 				"allow_any": {
 					"*": true,
@@ -1218,7 +1218,7 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			virtualServiceConfigs: nil,
 			expectedHosts: map[string]map[string]bool{
 				"test-private.com:80": {
-					"test-private.com": true, "test-private.com:80": true, "9.9.9.9": true, "9.9.9.9:80": true,
+					"test-private.com": true, "9.9.9.9": true,
 				},
 				"block_all": {
 					"*": true,
@@ -1233,7 +1233,7 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			virtualServiceConfigs: []*config.Config{&virtualService1, &virtualService2},
 			expectedHosts: map[string]map[string]bool{
 				"test-private-2.com:60": {
-					"test-private-2.com": true, "test-private-2.com:60": true, "9.9.9.10": true, "9.9.9.10:60": true,
+					"test-private-2.com": true, "9.9.9.10": true,
 				},
 				"block_all": {
 					"*": true,
@@ -1248,10 +1248,10 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			virtualServiceConfigs: []*config.Config{&virtualService3},
 			expectedHosts: map[string]map[string]bool{
 				"test-private.com:80": {
-					"test-private.com": true, "test-private.com:80": true, "9.9.9.9": true, "9.9.9.9:80": true,
+					"test-private.com": true, "9.9.9.9": true,
 				},
 				"test-private-3.com:80": {
-					"test-private-3.com": true, "test-private-3.com:80": true,
+					"test-private-3.com": true,
 				},
 				"block_all": {
 					"*": true,
@@ -1266,7 +1266,7 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			virtualServiceConfigs: nil,
 			expectedHosts: map[string]map[string]bool{
 				"test-headless.com:8888": {
-					"test-headless.com": true, "test-headless.com:8888": true, "*.test-headless.com": true, "*.test-headless.com:8888": true,
+					"test-headless.com": true, "*.test-headless.com": true,
 				},
 				"block_all": {
 					"*": true,
@@ -1281,10 +1281,10 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			virtualServiceConfigs: []*config.Config{&virtualService4},
 			expectedHosts: map[string]map[string]bool{
 				"test-headless.com:8888": {
-					"test-headless.com": true, "test-headless.com:8888": true, "*.test-headless.com": true, "*.test-headless.com:8888": true,
+					"test-headless.com": true, "*.test-headless.com": true,
 				},
 				"example.com:8888": {
-					"example.com": true, "example.com:8888": true,
+					"example.com": true,
 				},
 				"block_all": {
 					"*": true,
@@ -1369,16 +1369,13 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 					"*": true,
 				},
 				"service-A.default.svc.cluster.local:7777": {
-					"service-A.default.svc.cluster.local":      true,
-					"service-A.default.svc.cluster.local:7777": true,
+					"service-A.default.svc.cluster.local": true,
 				},
 				"service-A.v2:7777": {
-					"service-A.v2":      true,
-					"service-A.v2:7777": true,
+					"service-A.v2": true,
 				},
 				"service-A.v3:7777": {
-					"service-A.v3":      true,
-					"service-A.v3:7777": true,
+					"service-A.v3": true,
 				},
 			},
 			expectedRoutes: 7,

--- a/pilot/pkg/networking/core/v1alpha3/httproute_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute_test.go
@@ -34,15 +34,18 @@ import (
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/config/visibility"
+	"istio.io/istio/pkg/test"
+	"istio.io/istio/pkg/test/util/assert"
 )
 
 func TestGenerateVirtualHostDomains(t *testing.T) {
 	cases := []struct {
-		name    string
-		service *model.Service
-		port    int
-		node    *model.Proxy
-		want    []string
+		name       string
+		service    *model.Service
+		port       int
+		node       *model.Proxy
+		wantLegacy []string
+		want       []string
 	}{
 		{
 			name: "same domain",
@@ -54,9 +57,13 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 			node: &model.Proxy{
 				DNSDomain: "local.campus.net",
 			},
-			want: []string{
+			wantLegacy: []string{
 				"foo.local.campus.net", "foo.local.campus.net:80",
 				"foo", "foo:80",
+			},
+			want: []string{
+				"foo.local.campus.net",
+				"foo",
 			},
 		},
 		{
@@ -69,13 +76,18 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 			node: &model.Proxy{
 				DNSDomain: "remote.campus.net",
 			},
-			want: []string{
+			wantLegacy: []string{
 				"foo.local.campus.net",
 				"foo.local.campus.net:80",
 				"foo.local",
 				"foo.local:80",
 				"foo.local.campus",
 				"foo.local.campus:80",
+			},
+			want: []string{
+				"foo.local.campus.net",
+				"foo.local",
+				"foo.local.campus",
 			},
 		},
 		{
@@ -88,7 +100,8 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 			node: &model.Proxy{
 				DNSDomain: "example.com",
 			},
-			want: []string{"foo.local.campus.net", "foo.local.campus.net:80"},
+			wantLegacy: []string{"foo.local.campus.net", "foo.local.campus.net:80"},
+			want:       []string{"foo.local.campus.net"},
 		},
 		{
 			name: "k8s service with default domain",
@@ -100,7 +113,7 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 			node: &model.Proxy{
 				DNSDomain: "default.svc.cluster.local",
 			},
-			want: []string{
+			wantLegacy: []string{
 				"echo.default.svc.cluster.local",
 				"echo.default.svc.cluster.local:8123",
 				"echo",
@@ -109,6 +122,12 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 				"echo.default.svc:8123",
 				"echo.default",
 				"echo.default:8123",
+			},
+			want: []string{
+				"echo.default.svc.cluster.local",
+				"echo",
+				"echo.default.svc",
+				"echo.default",
 			},
 		},
 		{
@@ -121,9 +140,12 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 			node: &model.Proxy{
 				DNSDomain: "default.svc.cluster.local",
 			},
-			want: []string{
+			wantLegacy: []string{
 				"foo.default.svc.bar.baz",
 				"foo.default.svc.bar.baz:8123",
+			},
+			want: []string{
+				"foo.default.svc.bar.baz",
 			},
 		},
 		{
@@ -136,13 +158,18 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 			node: &model.Proxy{
 				DNSDomain: "mesh.svc.cluster.local",
 			},
-			want: []string{
+			wantLegacy: []string{
 				"echo.default.svc.cluster.local",
 				"echo.default.svc.cluster.local:8123",
 				"echo.default",
 				"echo.default:8123",
 				"echo.default.svc",
 				"echo.default.svc:8123",
+			},
+			want: []string{
+				"echo.default.svc.cluster.local",
+				"echo.default",
+				"echo.default.svc",
 			},
 		},
 		{
@@ -155,7 +182,8 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 			node: &model.Proxy{
 				DNSDomain: "foo.svc.custom.k8s.local",
 			},
-			want: []string{"google.local", "google.local:8123"},
+			wantLegacy: []string{"google.local", "google.local:8123"},
+			want:       []string{"google.local"},
 		},
 		{
 			name: "ipv4 domain",
@@ -167,7 +195,8 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 			node: &model.Proxy{
 				DNSDomain: "example.com",
 			},
-			want: []string{"1.2.3.4", "1.2.3.4:8123"},
+			wantLegacy: []string{"1.2.3.4", "1.2.3.4:8123"},
+			want:       []string{"1.2.3.4"},
 		},
 		{
 			name: "ipv6 domain",
@@ -179,7 +208,8 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 			node: &model.Proxy{
 				DNSDomain: "example.com",
 			},
-			want: []string{"[2406:3003:2064:35b8:864:a648:4b96:e37d]", "[2406:3003:2064:35b8:864:a648:4b96:e37d]:8123"},
+			wantLegacy: []string{"[2406:3003:2064:35b8:864:a648:4b96:e37d]", "[2406:3003:2064:35b8:864:a648:4b96:e37d]:8123"},
+			want:       []string{"[2406:3003:2064:35b8:864:a648:4b96:e37d]"},
 		},
 		{
 			name: "back subset of cluster domain in address",
@@ -191,7 +221,8 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 			node: &model.Proxy{
 				DNSDomain: "tests.svc.cluster.local",
 			},
-			want: []string{"aaa.example.local", "aaa.example.local:7777"},
+			wantLegacy: []string{"aaa.example.local", "aaa.example.local:7777"},
+			want:       []string{"aaa.example.local"},
 		},
 		{
 			name: "front subset of cluster domain in address",
@@ -203,7 +234,8 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 			node: &model.Proxy{
 				DNSDomain: "tests.svc.my.long.domain.suffix",
 			},
-			want: []string{"aaa.example.my", "aaa.example.my:7777"},
+			wantLegacy: []string{"aaa.example.my", "aaa.example.my:7777"},
+			want:       []string{"aaa.example.my"},
 		},
 		{
 			name: "large subset of cluster domain in address",
@@ -215,7 +247,8 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 			node: &model.Proxy{
 				DNSDomain: "tests.svc.my.long.domain.suffix",
 			},
-			want: []string{"aaa.example.my.long", "aaa.example.my.long:7777"},
+			wantLegacy: []string{"aaa.example.my.long", "aaa.example.my.long:7777"},
+			want:       []string{"aaa.example.my.long"},
 		},
 		{
 			name: "no overlap of cluster domain in address",
@@ -227,24 +260,68 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 			node: &model.Proxy{
 				DNSDomain: "tests.svc.cluster.local",
 			},
-			want: []string{"aaa.example.com", "aaa.example.com:7777"},
+			wantLegacy: []string{"aaa.example.com", "aaa.example.com:7777"},
+			want:       []string{"aaa.example.com"},
+		},
+		{
+			name: "wildcard",
+			service: &model.Service{
+				Hostname:     "headless.default.svc.cluster.local",
+				MeshExternal: true,
+				Resolution:   model.Passthrough,
+				Attributes:   model.ServiceAttributes{ServiceRegistry: provider.Kubernetes},
+			},
+			port: 7777,
+			node: &model.Proxy{
+				DNSDomain: "default.svc.cluster.local",
+			},
+			wantLegacy: []string{
+				"headless.default.svc.cluster.local",
+				"headless.default.svc.cluster.local:7777",
+				"headless",
+				"headless:7777",
+				"headless.default.svc",
+				"headless.default.svc:7777",
+				"headless.default",
+				"headless.default:7777",
+				"*.headless.default.svc.cluster.local",
+				"*.headless.default.svc.cluster.local:7777",
+				"*.headless",
+				"*.headless:7777",
+				"*.headless.default.svc",
+				"*.headless.default.svc:7777",
+				"*.headless.default",
+				"*.headless.default:7777",
+			},
+			want: []string{
+				"headless.default.svc.cluster.local",
+				"headless",
+				"headless.default.svc",
+				"headless.default",
+				"*.headless.default.svc.cluster.local",
+				"*.headless",
+				"*.headless.default.svc",
+				"*.headless.default",
+			},
 		},
 	}
 
-	testFn := func(service *model.Service, port int, node *model.Proxy, want []string) error {
+	testFn := func(t test.Failer, service *model.Service, port int, node *model.Proxy, want []string) {
 		out, _ := generateVirtualHostDomains(service, port, node)
-		if !reflect.DeepEqual(out, want) {
-			return fmt.Errorf("unexpected virtual hosts:\ngot  %v\nwant %v", out, want)
-		}
-		return nil
+		assert.Equal(t, out, want)
 	}
 
 	for _, c := range cases {
 		c := c
 		t.Run(c.name, func(t *testing.T) {
-			if err := testFn(c.service, c.port, c.node, c.want); err != nil {
-				t.Error(err)
-			}
+			t.Run("legacy", func(t *testing.T) {
+				c.node.IstioVersion = model.ParseIstioVersion("1.14.0")
+				testFn(t, c.service, c.port, c.node, c.wantLegacy)
+			})
+			t.Run("modern", func(t *testing.T) {
+				c.node.IstioVersion = model.ParseIstioVersion("1.15.0")
+				testFn(t, c.service, c.port, c.node, c.want)
+			})
 		})
 	}
 }

--- a/pilot/pkg/simulation/traffic.go
+++ b/pilot/pkg/simulation/traffic.go
@@ -441,6 +441,11 @@ func (sim *Simulation) matchRoute(vh *route.VirtualHost, input Call) *route.Rout
 }
 
 func (sim *Simulation) matchVirtualHost(rc *route.RouteConfiguration, host string) *route.VirtualHost {
+	if rc.GetIgnorePortInHostMatching() {
+		if h, _, err := net.SplitHostPort(host); err == nil {
+			host = h
+		}
+	}
 	// Exact match
 	for _, vh := range rc.VirtualHosts {
 		for _, d := range vh.Domains {

--- a/pkg/test/util/assert/assert.go
+++ b/pkg/test/util/assert/assert.go
@@ -32,7 +32,7 @@ func Equal(t test.Failer, a, b any, context ...string) {
 		if len(context) > 0 {
 			cs = " " + strings.Join(context, ", ") + ":"
 		}
-		t.Fatalf("found diff:%s %v", cs, cmp.Diff(a, b, protocmp.Transform()))
+		t.Fatalf("found diff:%s %v\nLeft: %v\nRight: %v", cs, cmp.Diff(a, b, protocmp.Transform()), a, b)
 	}
 }
 

--- a/releasenotes/notes/ignore-port.yaml
+++ b/releasenotes/notes/ignore-port.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issues:
+- 40474
+releaseNotes:
+- |
+  **Fixed** an issue causing traffic to not match (and return a `404`) when using wildcard domain names and including an unexpected port in the `Host` header.
+- |
+  **Fixed** an issue causing traffic to match an unexpected route when using wildcard domain names and including an port in the `Host` header.

--- a/releasenotes/notes/ignore-port.yaml
+++ b/releasenotes/notes/ignore-port.yaml
@@ -8,3 +8,5 @@ releaseNotes:
   **Fixed** an issue causing traffic to not match (and return a `404`) when using wildcard domain names and including an unexpected port in the `Host` header.
 - |
   **Fixed** an issue causing traffic to match an unexpected route when using wildcard domain names and including an port in the `Host` header.
+- |
+  **Improved** sidecar `Host` header matching to ignore port numbers by default. This can be controlled by the `SIDECAR_IGNORE_PORT_IN_HOST_MATCH` environment variable.


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/40474

This is finally available in Envoy so we can drop our hacks of adding
the port, adding `:*`, etc.

**Please provide a description of this PR:**