### PR TITLE
Send only the Cluster ID in the response of debug/syncz

### DIFF
--- a/pilot/pkg/xds/statusgen.go
+++ b/pilot/pkg/xds/statusgen.go
@@ -134,8 +134,10 @@ func (sg *StatusGen) debugSyncz() model.Resources {
 			}
 			clientConfig := &status.ClientConfig{
 				Node: &core.Node{
-					Id:       con.proxy.ID,
-					Metadata: con.proxy.Metadata.ToStruct(),
+					Id: con.proxy.ID,
+					Metadata: model.NodeMetadata{
+						ClusterID: con.proxy.Metadata.ClusterID,
+					}.ToStruct(),
 				},
 				GenericXdsConfigs: xdsConfigs,
 			}


### PR DESCRIPTION
https://github.com/istio/istio/pull/36835 introduces "NodeMetadata" in the response of `debug/syncz`.
But, among the NodeMetadata, only `ClusterID` is used in [istioctl](https://github.com/istio/istio/blob/8cc2dd65d82d2ab0bc931dba9fcaefa17abf3545/istioctl/pkg/writer/pilot/status.go#L191)

Since the total size of NodeMetadata is pretty huge comparing with the required information from `istioctl x ps` command, 
this PR proposes to send only the `ClusterID` instead of the entire metadata.

Please note that the total size of xds responses was reduced to around 1/6 by this PR in my experiment.

When I ran `istioctl x ps` command with 4000 replica of `httpbin` and 10 replica of `istiod`, 
* Before this PR, 
  * Elapsed Time: 10.xxx seconds (for querying & parsing, excluding printing out)
  * Total size of XDS response: 11,596,346
* After this PR, 
  * Elapsed Time: 7.xxx seconds (for querying & parsing, excluding printing out)
  * Total size of XDS response: 1,801,165