### PR TITLE
resovle redundant match for build_push_update_images.sh

### DIFF
--- a/samples/bookinfo/build_push_update_images.sh
+++ b/samples/bookinfo/build_push_update_images.sh
@@ -112,5 +112,5 @@ do
 done
 
 # Update image references in the yaml files
-find . -name "*bookinfo*.yaml" -exec sed -i.bak "s#image:.*\\(\\/examples-bookinfo-.*\\):.*#image: ${PREFIX//\//\\/}\\1:$VERSION#g" {} +
+find ./platform -name "*bookinfo*.yaml" -exec sed -i.bak "s#image:.*\\(\\/examples-bookinfo-.*\\):.*#image: ${PREFIX//\//\\/}\\1:$VERSION#g" {} +
 


### PR DESCRIPTION
**Please provide a description of this PR:**
The files that should be replaced are all located in the platform directory. If they all match, other files will be affected, such as networking/bookinfo-gateway.yaml
<img width="365" alt="image" src="https://user-images.githubusercontent.com/76980726/184899587-8438a7ae-4c7f-4c60-9cd3-425d016225b8.png">