### PR TITLE
Fix ProxyConfig merge impacting shared state

### DIFF
--- a/pilot/pkg/model/proxy_config.go
+++ b/pilot/pkg/model/proxy_config.go
@@ -16,6 +16,7 @@ package model
 
 import (
 	"google.golang.org/protobuf/proto"
+	wrappers "google.golang.org/protobuf/types/known/wrapperspb"
 
 	"istio.io/api/annotation"
 	meshconfig "istio.io/api/mesh/v1alpha1"
@@ -134,10 +135,10 @@ func mergeWithPrecedence(pcs ...*meshconfig.ProxyConfig) *meshconfig.ProxyConfig
 		// telemetry code does with shallowMerge?
 		proto.Merge(merged, pcs[i])
 		if pcs[i].GetConcurrency() != nil {
-			merged.Concurrency = pcs[i].GetConcurrency()
+			merged.Concurrency = wrappers.Int32(pcs[i].GetConcurrency().GetValue())
 		}
 		if pcs[i].GetImage() != nil {
-			merged.Image = pcs[i].GetImage()
+			merged.Image = pcs[i].GetImage().DeepCopy()
 		}
 	}
 	return merged

--- a/releasenotes/notes/proxyconfig-global-mutate.yaml
+++ b/releasenotes/notes/proxyconfig-global-mutate.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+issue:
+- 40445
+releaseNotes:
+- |
+  **Fixed** an issue where `ProxyConfig` overrides could unexpectedly apply to other workloads.


### PR DESCRIPTION
The issue was we were overriding things by setting them to pointers.
These pointers are then shared, and when `proto.merge` is used they are
all mutated.

Instead, take deepcopies and add a test
Fixes https://github.com/istio/istio/issues/40445