### PR TITLE
Authorization policy: support inline multi-values header semantics

### DIFF
--- a/pilot/pkg/security/authz/builder/testdata/http/allow-full-rule-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/allow-full-rule-out.yaml
@@ -422,14 +422,20 @@ typedConfig:
             - orIds:
                 ids:
                 - header:
-                    exactMatch: header
                     name: X-header
+                    safeRegexMatch:
+                      googleRe2: {}
+                      regex: ^header$|^header,.*|.*,header,.*|.*,header$
                 - header:
                     name: X-header
-                    prefixMatch: header-prefix-
+                    safeRegexMatch:
+                      googleRe2: {}
+                      regex: ^header-prefix-.*$|^header-prefix-.*,.*|.*,header-prefix-.*,.*|.*,header-prefix-.*$
                 - header:
                     name: X-header
-                    suffixMatch: -suffix-header
+                    safeRegexMatch:
+                      googleRe2: {}
+                      regex: ^.*-suffix-header$|^.*-suffix-header,.*|.*,.*-suffix-header,.*|.*,.*-suffix-header$
                 - header:
                     name: X-header
                     presentMatch: true
@@ -437,14 +443,20 @@ typedConfig:
                 orIds:
                   ids:
                   - header:
-                      exactMatch: not-header
                       name: X-header
+                      safeRegexMatch:
+                        googleRe2: {}
+                        regex: ^not-header$|^not-header,.*|.*,not-header,.*|.*,not-header$
                   - header:
                       name: X-header
-                      prefixMatch: not-header-prefix-
+                      safeRegexMatch:
+                        googleRe2: {}
+                        regex: ^not-header-prefix-.*$|^not-header-prefix-.*,.*|.*,not-header-prefix-.*,.*|.*,not-header-prefix-.*$
                   - header:
                       name: X-header
-                      suffixMatch: -not-suffix-header
+                      safeRegexMatch:
+                        googleRe2: {}
+                        regex: ^.*-not-suffix-header$|^.*-not-suffix-header,.*|.*,.*-not-suffix-header,.*|.*,.*-not-suffix-header$
                   - header:
                       name: X-header
                       presentMatch: true

--- a/pilot/pkg/security/authz/builder/testdata/http/multiple-policies-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/multiple-policies-out.yaml
@@ -156,7 +156,7 @@ typedConfig:
                 - header:
                     name: X-abc
                     safeRegexMatch:
-                      googleRe2: { }
+                      googleRe2: {}
                       regex: ^abc1$|^abc1,.*|.*,abc1,.*|.*,abc1$
                 - header:
                     name: X-abc

--- a/pilot/pkg/security/authz/builder/testdata/http/multiple-policies-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/multiple-policies-out.yaml
@@ -154,9 +154,13 @@ typedConfig:
             - orIds:
                 ids:
                 - header:
-                    exactMatch: abc1
                     name: X-abc
+                    safeRegexMatch:
+                      googleRe2: { }
+                      regex: ^abc1$|^abc1,.*|.*,abc1,.*|.*,abc1$
                 - header:
-                    exactMatch: abc2
                     name: X-abc
+                    safeRegexMatch:
+                      googleRe2: {}
+                      regex: ^abc2$|^abc2,.*|.*,abc2,.*|.*,abc2$
   shadowRulesStatPrefix: istio_dry_run_allow_

--- a/pilot/pkg/security/authz/builder/testdata/http/single-policy-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/single-policy-out.yaml
@@ -144,14 +144,20 @@ typedConfig:
             - orIds:
                 ids:
                 - header:
-                    exactMatch: header
                     name: X-header
+                    safeRegexMatch:
+                        googleRe2: {}
+                        regex: ^header$|^header,.*|.*,header,.*|.*,header$
                 - header:
                     name: X-header
-                    prefixMatch: header-prefix-
+                    safeRegexMatch:
+                        googleRe2: {}
+                        regex: ^header-prefix-.*$|^header-prefix-.*,.*|.*,header-prefix-.*,.*|.*,header-prefix-.*$
                 - header:
                     name: X-header
-                    suffixMatch: -suffix-header
+                    safeRegexMatch:
+                        googleRe2: {}
+                        regex: ^.*-suffix-header$|^.*-suffix-header,.*|.*,.*-suffix-header,.*|.*,.*-suffix-header$
                 - header:
                     name: X-header
                     presentMatch: true
@@ -220,14 +226,20 @@ typedConfig:
             - orIds:
                 ids:
                 - header:
-                    exactMatch: header
                     name: X-header
+                    safeRegexMatch:
+                        googleRe2: {}
+                        regex: ^header$|^header,.*|.*,header,.*|.*,header$
                 - header:
                     name: X-header
-                    prefixMatch: header-prefix-
+                    safeRegexMatch:
+                        googleRe2: {}
+                        regex: ^header-prefix-.*$|^header-prefix-.*,.*|.*,header-prefix-.*,.*|.*,header-prefix-.*$
                 - header:
                     name: X-header
-                    suffixMatch: -suffix-header
+                    safeRegexMatch:
+                        googleRe2: {}
+                        regex: ^.*-suffix-header$|^.*-suffix-header,.*|.*,.*-suffix-header,.*|.*,.*-suffix-header$
                 - header:
                     name: X-header
                     presentMatch: true

--- a/pilot/pkg/security/authz/builder/testdata/http/single-policy-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/single-policy-out.yaml
@@ -146,18 +146,18 @@ typedConfig:
                 - header:
                     name: X-header
                     safeRegexMatch:
-                        googleRe2: {}
-                        regex: ^header$|^header,.*|.*,header,.*|.*,header$
+                      googleRe2: {}
+                      regex: ^header$|^header,.*|.*,header,.*|.*,header$
                 - header:
                     name: X-header
                     safeRegexMatch:
-                        googleRe2: {}
-                        regex: ^header-prefix-.*$|^header-prefix-.*,.*|.*,header-prefix-.*,.*|.*,header-prefix-.*$
+                      googleRe2: {}
+                      regex: ^header-prefix-.*$|^header-prefix-.*,.*|.*,header-prefix-.*,.*|.*,header-prefix-.*$
                 - header:
                     name: X-header
                     safeRegexMatch:
-                        googleRe2: {}
-                        regex: ^.*-suffix-header$|^.*-suffix-header,.*|.*,.*-suffix-header,.*|.*,.*-suffix-header$
+                      googleRe2: {}
+                      regex: ^.*-suffix-header$|^.*-suffix-header,.*|.*,.*-suffix-header,.*|.*,.*-suffix-header$
                 - header:
                     name: X-header
                     presentMatch: true
@@ -228,18 +228,18 @@ typedConfig:
                 - header:
                     name: X-header
                     safeRegexMatch:
-                        googleRe2: {}
-                        regex: ^header$|^header,.*|.*,header,.*|.*,header$
+                      googleRe2: {}
+                      regex: ^header$|^header,.*|.*,header,.*|.*,header$
                 - header:
                     name: X-header
                     safeRegexMatch:
-                        googleRe2: {}
-                        regex: ^header-prefix-.*$|^header-prefix-.*,.*|.*,header-prefix-.*,.*|.*,header-prefix-.*$
+                      googleRe2: {}
+                      regex: ^header-prefix-.*$|^header-prefix-.*,.*|.*,header-prefix-.*,.*|.*,header-prefix-.*$
                 - header:
                     name: X-header
                     safeRegexMatch:
-                        googleRe2: {}
-                        regex: ^.*-suffix-header$|^.*-suffix-header,.*|.*,.*-suffix-header,.*|.*,.*-suffix-header$
+                      googleRe2: {}
+                      regex: ^.*-suffix-header$|^.*-suffix-header,.*|.*,.*-suffix-header,.*|.*,.*-suffix-header$
                 - header:
                     name: X-header
                     presentMatch: true

--- a/pilot/pkg/security/authz/matcher/header.go
+++ b/pilot/pkg/security/authz/matcher/header.go
@@ -15,6 +15,7 @@
 package matcher
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 
@@ -52,6 +53,40 @@ func HeaderMatcher(k, v string) *routepb.HeaderMatcher {
 		Name: k,
 		HeaderMatchSpecifier: &routepb.HeaderMatcher_ExactMatch{
 			ExactMatch: v,
+		},
+	}
+}
+
+// HeaderMatcherWithRegex converts a key, value string pair to a corresponding
+// HeaderMatcher using regex to support the inline multi-values header that is
+// concatenated by commas, as per RFC7230.
+func HeaderMatcherWithRegex(k, v string) *routepb.HeaderMatcher {
+	// We must check "*" first to make sure we'll generate a non empty value in the prefix/suffix case.
+	// Empty prefix/suffix value is invalid in HeaderMatcher.
+	var regex string
+	if v == "*" {
+		return &routepb.HeaderMatcher{
+			Name: k,
+			HeaderMatchSpecifier: &routepb.HeaderMatcher_PresentMatch{
+				PresentMatch: true,
+			},
+		}
+	} else if strings.HasPrefix(v, "*") {
+		regex = `.*` + regexp.QuoteMeta(v[1:])
+	} else if strings.HasSuffix(v, "*") {
+		regex = regexp.QuoteMeta(v[:len(v)-1]) + `.*`
+	} else {
+		regex = regexp.QuoteMeta(v)
+	}
+	return &routepb.HeaderMatcher{
+		Name: k,
+		HeaderMatchSpecifier: &routepb.HeaderMatcher_SafeRegexMatch{
+			SafeRegexMatch: &matcherpb.RegexMatcher{
+				EngineType: &matcherpb.RegexMatcher_GoogleRe2{
+					GoogleRe2: &matcherpb.RegexMatcher_GoogleRE2{},
+				},
+				Regex: fmt.Sprintf(`^%s$|^%s,.*|.*,%s,.*|.*,%s$`, regex, regex, regex, regex),
+			},
 		},
 	}
 }

--- a/pilot/pkg/security/authz/matcher/header_test.go
+++ b/pilot/pkg/security/authz/matcher/header_test.go
@@ -63,6 +63,55 @@ func TestHeaderMatcher(t *testing.T) {
 	}
 }
 
+func TestHeaderMatcherWithRegex(t *testing.T) {
+	testCases := []struct {
+		Name   string
+		K      string
+		V      string
+		Expect *routepb.HeaderMatcher
+	}{
+		{
+			Name: "exact match",
+			K:    ":path",
+			V:    "/productpage",
+			Expect: &routepb.HeaderMatcher{
+				Name: ":path",
+				HeaderMatchSpecifier: &routepb.HeaderMatcher_SafeRegexMatch{
+					SafeRegexMatch: &matcherpb.RegexMatcher{
+						EngineType: &matcherpb.RegexMatcher_GoogleRe2{
+							GoogleRe2: &matcherpb.RegexMatcher_GoogleRE2{},
+						},
+						Regex: "^/productpage$|^/productpage,.*|.*,/productpage,.*|.*,/productpage$",
+					},
+				},
+			},
+		},
+		{
+			Name: "suffix match",
+			K:    ":path",
+			V:    "*/productpage*",
+			Expect: &routepb.HeaderMatcher{
+				Name: ":path",
+				HeaderMatchSpecifier: &routepb.HeaderMatcher_SafeRegexMatch{
+					SafeRegexMatch: &matcherpb.RegexMatcher{
+						EngineType: &matcherpb.RegexMatcher_GoogleRe2{
+							GoogleRe2: &matcherpb.RegexMatcher_GoogleRE2{},
+						},
+						Regex: `^.*/productpage\*$|^.*/productpage\*,.*|.*,.*/productpage\*,.*|.*,.*/productpage\*$`,
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		actual := HeaderMatcherWithRegex(tc.K, tc.V)
+		if !cmp.Equal(tc.Expect, actual, protocmp.Transform()) {
+			t.Errorf("expecting %v, but got %v", tc.Expect, actual)
+		}
+	}
+}
+
 func TestHostMatcherWithRegex(t *testing.T) {
 	testCases := []struct {
 		Name   string

--- a/pilot/pkg/security/authz/model/generator.go
+++ b/pilot/pkg/security/authz/model/generator.go
@@ -194,7 +194,7 @@ func (requestHeaderGenerator) principal(key, value string, forTCP bool) (*rbacpb
 	if err != nil {
 		return nil, err
 	}
-	m := matcher.HeaderMatcher(header, value)
+	m := matcher.HeaderMatcherWithRegex(header, value)
 	return principalHeader(m), nil
 }
 

--- a/pilot/pkg/security/authz/model/generator_test.go
+++ b/pilot/pkg/security/authz/model/generator_test.go
@@ -204,9 +204,11 @@ func TestGenerator(t *testing.T) {
 			key:   "request.headers[x-foo]",
 			value: "foo",
 			want: yamlPrincipal(t, `
-         header:
-          exactMatch: foo
-          name: x-foo`),
+        header:
+          name: x-foo
+          safeRegexMatch:
+            googleRe2: {}
+            regex: ^foo$|^foo,.*|.*,foo,.*|.*,foo$`),
 		},
 		{
 			name:  "requestClaimGenerator",

--- a/releasenotes/notes/inline-header-authz-support.yaml
+++ b/releasenotes/notes/inline-header-authz-support.yaml
@@ -1,0 +1,83 @@
+apiVersion: release-notes/v2
+
+kind: feature
+area: security
+issue:
+  - 39680
+
+releaseNotes:
+- |
+  **Support** inline multi-values header format by using safe regex in AuthorizationPolicy.Condition header match.
+
+# upgradeNotes is a markdown listing of any changes that will affect the upgrade
+# process. This will appear in the release notes.
+upgradeNotes:
+  - title: Support Inline Multi-values Header Match in Authz
+    content:
+      While multiple-valued headers to matchers have been taken care of by [GHSA-2v25-cjjq-5f4w](https://github.com/envoyproxy/envoy/security/advisories/GHSA-2v25-cjjq-5f4w), Istio
+      does not support matching on this multiple-valued header.
+      Because of this lack of support, current semantics in AuthorizationPolicy is inconsistent and non-deterministic,
+      Here are some examples,
+      Given the following policy and request, it's denied.
+      ```
+      Policy: ALLOW x-foo: bar
+      Request: curl -H "x-foo: bar" -H "x-foo: not-bar"
+      ```
+      Result: Denied
+
+      However, if the policy changes to use prefix match, the same request will be allowed.
+      ```
+      Policy: ALLOW x-foo: bar*
+      Request: curl -H "x-foo: bar" -H "x-foo: not-bar"
+      ```
+      Result: Allowed
+
+      What's more, if the headers order is changed in the request, the same policy will deny it.
+      ```
+      Policy: ALLOW x-foo: bar*
+      Request: curl -H "x-foo: not-bar" -H "x-foo: bar"
+      ```
+      Result: Denied
+
+      To solve this inconsistency, this change supports matching on multiple-valued headers by using safe regex match to split the header values
+      concatenated by commas when matching.
+      Note that the match logic for per header value is not changed, it still supports exact match, prefix match, suffix match and present match
+      as usual.
+      For example, given an allow policy `{ key: x-foo, value: [a, b]}`, the request with header `{key: x-foo value: "a,b,c"}` will be allowed
+      after this change, while before this change, this is not allowed.
+
+
+# securityNotes is a markdown listing of any changes related to the security of
+# Istio.
+securityNotes:
+  While multiple-valued headers to matchers have been taken care of by [GHSA-2v25-cjjq-5f4w](https://github.com/envoyproxy/envoy/security/advisories/GHSA-2v25-cjjq-5f4w), Istio
+  does not support matching on this multiple-valued header.
+  Because of this lack of support, current semantics in AuthorizationPolicy is inconsistent and non-deterministic,
+  Here are some examples,
+  Given the following policy and request, it's denied.
+  ```
+  Policy: ALLOW x-foo: bar
+  Request: curl -H "x-foo: bar" -H "x-foo: not-bar"
+  ```
+  Result: Denied
+
+  However, if the policy changes to use prefix match, the same request will be allowed.
+  ```
+  Policy: ALLOW x-foo: bar*
+  Request: curl -H "x-foo: bar" -H "x-foo: not-bar"
+  ```
+  Result: Allowed
+
+  What's more, if the headers order is changed in the request, the same policy will deny it.
+  ```
+  Policy: ALLOW x-foo: bar*
+  Request: curl -H "x-foo: not-bar" -H "x-foo: bar"
+  ```
+  Result: Denied
+
+  To solve this inconsistency, this change supports matching on multiple-valued headers by using safe regex match to split the header values
+  concatenated by commas when matching.
+  Note that the match logic for per header value is not changed, it still supports exact match, prefix match, suffix match and present match
+  as usual.
+  For example, given an allow policy `{ key: x-foo, value: [a, b]}`, the request with header `{key: x-foo value: "a,b,c"}` will be allowed
+  after this change, while before this change, this is not allowed.

--- a/releasenotes/notes/inline-header-authz-support.yaml
+++ b/releasenotes/notes/inline-header-authz-support.yaml
@@ -13,31 +13,28 @@ releaseNotes:
 # process. This will appear in the release notes.
 upgradeNotes:
   - title: Support Inline Multi-values Header Match in Authz
-    content:
+    content: |
       While multiple-valued headers to matchers have been taken care of by [GHSA-2v25-cjjq-5f4w](https://github.com/envoyproxy/envoy/security/advisories/GHSA-2v25-cjjq-5f4w), Istio
       does not support matching on this multiple-valued header.
       Because of this lack of support, current semantics in AuthorizationPolicy is inconsistent and non-deterministic,
       Here are some examples,
       Given the following policy and request, it's denied.
       ```
-      Policy: ALLOW x-foo: bar
-      Request: curl -H "x-foo: bar" -H "x-foo: not-bar"
+      Policy: "ALLOW x-foo: bar"
+      Request: "curl -H x-foo: bar -H x-foo: not-bar"
       ```
-      Result: Denied
-
+    
       However, if the policy changes to use prefix match, the same request will be allowed.
       ```
-      Policy: ALLOW x-foo: bar*
-      Request: curl -H "x-foo: bar" -H "x-foo: not-bar"
+      Policy: "ALLOW x-foo: bar*"
+      Request: "curl -H x-foo: bar -H x-foo: not-bar"
       ```
-      Result: Allowed
-
+    
       What's more, if the headers order is changed in the request, the same policy will deny it.
       ```
-      Policy: ALLOW x-foo: bar*
-      Request: curl -H "x-foo: not-bar" -H "x-foo: bar"
+      Policy: "ALLOW x-foo: bar*"
+      Request: "curl -H x-foo: not-bar -H x-foo: bar"
       ```
-      Result: Denied
 
       To solve this inconsistency, this change supports matching on multiple-valued headers by using safe regex match to split the header values
       concatenated by commas when matching.
@@ -49,31 +46,28 @@ upgradeNotes:
 
 # securityNotes is a markdown listing of any changes related to the security of
 # Istio.
-securityNotes:
+securityNotes: |
   While multiple-valued headers to matchers have been taken care of by [GHSA-2v25-cjjq-5f4w](https://github.com/envoyproxy/envoy/security/advisories/GHSA-2v25-cjjq-5f4w), Istio
   does not support matching on this multiple-valued header.
   Because of this lack of support, current semantics in AuthorizationPolicy is inconsistent and non-deterministic,
   Here are some examples,
   Given the following policy and request, it's denied.
   ```
-  Policy: ALLOW x-foo: bar
-  Request: curl -H "x-foo: bar" -H "x-foo: not-bar"
+  Policy: "ALLOW x-foo: bar"
+  Request: "curl -H x-foo: bar -H x-foo: not-bar"
   ```
-  Result: Denied
 
   However, if the policy changes to use prefix match, the same request will be allowed.
   ```
-  Policy: ALLOW x-foo: bar*
-  Request: curl -H "x-foo: bar" -H "x-foo: not-bar"
+  Policy: "ALLOW x-foo: bar*"
+  Request: "curl -H x-foo: bar -H x-foo: not-bar"
   ```
-  Result: Allowed
 
   What's more, if the headers order is changed in the request, the same policy will deny it.
   ```
-  Policy: ALLOW x-foo: bar*
-  Request: curl -H "x-foo: not-bar" -H "x-foo: bar"
+  Policy: "ALLOW x-foo: bar*"
+  Request: "curl -H x-foo: not-bar -H x-foo: bar"
   ```
-  Result: Denied
 
   To solve this inconsistency, this change supports matching on multiple-valued headers by using safe regex match to split the header values
   concatenated by commas when matching.


### PR DESCRIPTION
**Please provide a description of this PR:**

Fix issue: https://github.com/istio/istio/issues/39680
This PR adds support in Authorization Policy to recognize inline multi-values header format by using safe regex match.

For example:
given the allowed header { key: x-foo, value: [a, b]} the request with header {key: x-foo value: "a,b,c"} will be allowed after this fix. Before this fix, this is not allowed.