### PR TITLE
Make use of Proxy.Labels instead of Meatdata.Labels

### DIFF
--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -278,10 +278,6 @@ type Proxy struct {
 	// while NodeMetadata.Labels are set during bootstrap.
 	Labels map[string]string
 
-	// IstioMetaLabels contains the labels specified by ISTIO_METAJSON_LABELS and platform instance,
-	// so we can support pod labels update by plus the fundamental labels.
-	IstioMetaLabels map[string]string
-
 	// Metadata key-value pairs extending the Node identifier
 	Metadata *NodeMetadata
 

--- a/pilot/pkg/xds/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoint_builder.go
@@ -222,7 +222,7 @@ func (b *EndpointBuilder) populateFailoverPriorityLabels() {
 		lbSetting := loadbalancer.GetLocalityLbSetting(b.push.Mesh.GetLocalityLbSetting(), lb.GetLocalityLbSetting())
 		if lbSetting != nil && lbSetting.Distribute == nil &&
 			len(lbSetting.FailoverPriority) > 0 && (lbSetting.Enabled == nil || lbSetting.Enabled.Value) {
-			b.failoverPriorityLabels = util.GetFailoverPriorityLabels(b.proxy.Metadata.Labels, lbSetting.FailoverPriority)
+			b.failoverPriorityLabels = util.GetFailoverPriorityLabels(b.proxy.Labels, lbSetting.FailoverPriority)
 		}
 	}
 }

--- a/pilot/pkg/xds/endpoint_builder_test.go
+++ b/pilot/pkg/xds/endpoint_builder_test.go
@@ -220,12 +220,11 @@ func TestPopulateFailoverPriorityLabels(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			b := EndpointBuilder{
 				proxy: &model.Proxy{
-					Metadata: &model.NodeMetadata{
-						Labels: map[string]string{
-							"app": "foo",
-							"a":   "a",
-							"b":   "b",
-						},
+					Metadata: &model.NodeMetadata{},
+					Labels: map[string]string{
+						"app": "foo",
+						"a":   "a",
+						"b":   "b",
 					},
 				},
 				push: &model.PushContext{


### PR DESCRIPTION
**Please provide a description of this PR:**

This is to fix misuse of labels because of rebase issue