### PR TITLE
Enable locality failover without outlier detection if unready endpoints are sent to Envoy

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -850,11 +850,10 @@ func ApplyRingHashLoadBalancer(c *cluster.Cluster, lb *networking.LoadBalancerSe
 func applyLocalityLBSetting(locality *core.Locality, proxyLabels map[string]string, cluster *cluster.Cluster,
 	localityLB *networking.LocalityLoadBalancerSetting,
 ) {
-	// Failover should only be applied with outlier detection, or traffic will never failover.
-	enabledFailover := cluster.OutlierDetection != nil
+	// Failover should only be applied with outlier detection or SendUnhealthyEndpoints, or traffic will never failover.
+	odEnabled := cluster.OutlierDetection != nil
 	if cluster.LoadAssignment != nil {
-		// TODO: enable failoverPriority for `STRICT_DNS` cluster type
-		loadbalancer.ApplyLocalityLBSetting(cluster.LoadAssignment, nil, locality, proxyLabels, localityLB, enabledFailover)
+		loadbalancer.ApplyLocalityLBSetting(cluster.LoadAssignment, nil, locality, proxyLabels, localityLB, odEnabled)
 	}
 }
 

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -1136,6 +1136,14 @@ func TestDuplicateClusters(t *testing.T) {
 }
 
 func TestSidecarLocalityLB(t *testing.T) {
+	sendUnhealthyEndpoints := features.SendUnhealthyEndpoints.Load()
+	testSidecarLocalityLB(t, sendUnhealthyEndpoints)
+	testSidecarLocalityLB(t, !sendUnhealthyEndpoints)
+}
+
+func testSidecarLocalityLB(t *testing.T, sendUnhealthyEndpoints bool) {
+	test.SetAtomicBoolForTest(t, features.SendUnhealthyEndpoints, sendUnhealthyEndpoints)
+
 	g := NewWithT(t)
 	// Distribute locality loadbalancing setting
 	mesh := testMesh()
@@ -1172,7 +1180,12 @@ func TestSidecarLocalityLB(t *testing.T) {
 	if c.CommonLbConfig == nil {
 		t.Fatalf("CommonLbConfig should be set for cluster %+v", c)
 	}
-	g.Expect(c.CommonLbConfig.HealthyPanicThreshold.GetValue()).To(Equal(float64(10)))
+
+	expectedPanicThreshold := float64(10)
+	if sendUnhealthyEndpoints {
+		expectedPanicThreshold = 0
+	}
+	g.Expect(c.CommonLbConfig.HealthyPanicThreshold.GetValue()).To(Equal(expectedPanicThreshold))
 
 	g.Expect(len(c.LoadAssignment.Endpoints)).To(Equal(3))
 	for _, localityLbEndpoint := range c.LoadAssignment.Endpoints {
@@ -1215,7 +1228,7 @@ func TestSidecarLocalityLB(t *testing.T) {
 	if c.CommonLbConfig == nil {
 		t.Fatalf("CommonLbConfig should be set for cluster %+v", c)
 	}
-	g.Expect(c.CommonLbConfig.HealthyPanicThreshold.GetValue()).To(Equal(float64(10)))
+	g.Expect(c.CommonLbConfig.HealthyPanicThreshold.GetValue()).To(Equal(expectedPanicThreshold))
 
 	g.Expect(len(c.LoadAssignment.Endpoints)).To(Equal(3))
 	for _, localityLbEndpoint := range c.LoadAssignment.Endpoints {
@@ -1231,6 +1244,14 @@ func TestSidecarLocalityLB(t *testing.T) {
 }
 
 func TestLocalityLBDestinationRuleOverride(t *testing.T) {
+	sendUnhealthyEndpoints := features.SendUnhealthyEndpoints.Load()
+	testLocalityLBDestinationRuleOverride(t, sendUnhealthyEndpoints)
+	testLocalityLBDestinationRuleOverride(t, !sendUnhealthyEndpoints)
+}
+
+func testLocalityLBDestinationRuleOverride(t *testing.T, sendUnhealthyEndpoints bool) {
+	test.SetAtomicBoolForTest(t, features.SendUnhealthyEndpoints, sendUnhealthyEndpoints)
+
 	g := NewWithT(t)
 	mesh := testMesh()
 	// Distribute locality loadbalancing setting
@@ -1278,7 +1299,12 @@ func TestLocalityLBDestinationRuleOverride(t *testing.T) {
 	if c.CommonLbConfig == nil {
 		t.Fatalf("CommonLbConfig should be set for cluster %+v", c)
 	}
-	g.Expect(c.CommonLbConfig.HealthyPanicThreshold.GetValue()).To(Equal(float64(10)))
+
+	expectedPanicThreshold := float64(10)
+	if sendUnhealthyEndpoints {
+		expectedPanicThreshold = 0
+	}
+	g.Expect(c.CommonLbConfig.HealthyPanicThreshold.GetValue()).To(Equal(expectedPanicThreshold))
 
 	g.Expect(len(c.LoadAssignment.Endpoints)).To(Equal(3))
 	for _, localityLbEndpoint := range c.LoadAssignment.Endpoints {
@@ -1298,6 +1324,14 @@ func TestLocalityLBDestinationRuleOverride(t *testing.T) {
 }
 
 func TestGatewayLocalityLB(t *testing.T) {
+	sendUnhealthyEndpoints := features.SendUnhealthyEndpoints.Load()
+	testGatewayLocalityLB(t, sendUnhealthyEndpoints)
+	testGatewayLocalityLB(t, !sendUnhealthyEndpoints)
+}
+
+func testGatewayLocalityLB(t *testing.T, sendUnhealthyEndpoints bool) {
+	test.SetAtomicBoolForTest(t, features.SendUnhealthyEndpoints, sendUnhealthyEndpoints)
+
 	g := NewWithT(t)
 
 	// Test distribute
@@ -1339,7 +1373,13 @@ func TestGatewayLocalityLB(t *testing.T) {
 	if c.CommonLbConfig == nil {
 		t.Errorf("CommonLbConfig should be set for cluster %+v", c)
 	}
-	g.Expect(c.CommonLbConfig.HealthyPanicThreshold.GetValue()).To(Equal(float64(10)))
+
+	expectedPanicThreshold := float64(10)
+	if sendUnhealthyEndpoints {
+		expectedPanicThreshold = 0
+	}
+	g.Expect(c.CommonLbConfig.HealthyPanicThreshold.GetValue()).To(Equal(expectedPanicThreshold))
+
 	g.Expect(len(c.LoadAssignment.Endpoints)).To(Equal(3))
 	for _, localityLbEndpoint := range c.LoadAssignment.Endpoints {
 		locality := localityLbEndpoint.Locality
@@ -1382,7 +1422,7 @@ func TestGatewayLocalityLB(t *testing.T) {
 	if c.CommonLbConfig == nil {
 		t.Fatalf("CommonLbConfig should be set for cluster %+v", c)
 	}
-	g.Expect(c.CommonLbConfig.HealthyPanicThreshold.GetValue()).To(Equal(float64(10)))
+	g.Expect(c.CommonLbConfig.HealthyPanicThreshold.GetValue()).To(Equal(expectedPanicThreshold))
 
 	g.Expect(len(c.LoadAssignment.Endpoints)).To(Equal(3))
 	for _, localityLbEndpoint := range c.LoadAssignment.Endpoints {

--- a/pilot/pkg/networking/core/v1alpha3/loadbalancer/loadbalancer.go
+++ b/pilot/pkg/networking/core/v1alpha3/loadbalancer/loadbalancer.go
@@ -24,6 +24,7 @@ import (
 	wrappers "google.golang.org/protobuf/types/known/wrapperspb"
 
 	"istio.io/api/networking/v1alpha3"
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/util"
 )
@@ -63,11 +64,13 @@ func ApplyLocalityLBSetting(
 	locality *core.Locality,
 	proxyLabels map[string]string,
 	localityLB *v1alpha3.LocalityLoadBalancerSetting,
-	enableFailover bool,
+	outlierDetectionEnabled bool,
 ) {
 	if localityLB == nil || loadAssignment == nil {
 		return
 	}
+
+	enableFailover := outlierDetectionEnabled || features.SendUnhealthyEndpoints.Load()
 
 	// one of Distribute or Failover settings can be applied.
 	if localityLB.GetDistribute() != nil {

--- a/pilot/pkg/xds/eds_test.go
+++ b/pilot/pkg/xds/eds_test.go
@@ -175,8 +175,8 @@ func TestSAUpdate(t *testing.T) {
 	}
 }
 
-func TestEds(t *testing.T) {
-	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{
+func newFakeDiscoveryServerForEDSTests(t *testing.T) *xds.FakeDiscoveryServer {
+	return xds.NewFakeDiscoveryServer(t, xds.FakeOptions{
 		ConfigString: mustReadFile(t, "tests/testdata/config/destination-rule-locality.yaml"),
 		DiscoveryServerModifier: func(s *xds.DiscoveryServer) {
 			addUdsEndpoint(s)
@@ -193,18 +193,18 @@ func TestEds(t *testing.T) {
 				newEndpointWithAccount("127.0.0.1", "hello-sa", "v1"))
 		},
 	})
+}
+
+func TestEds(t *testing.T) {
+	s := newFakeDiscoveryServerForEDSTests(t)
 
 	adscConn := s.Connect(&model.Proxy{IPAddresses: []string{"10.10.10.10"}}, nil, watchAll)
-	adscConn2 := s.Connect(&model.Proxy{IPAddresses: []string{"10.10.10.11"}}, nil, watchAll)
 
 	t.Run("TCPEndpoints", func(t *testing.T) {
 		testTCPEndpoints("127.0.0.1", adscConn, t)
 	})
 	t.Run("edsz", func(t *testing.T) {
 		testEdsz(t, s, "test-1.default")
-	})
-	t.Run("LocalityPrioritizedEndpoints", func(t *testing.T) {
-		testLocalityPrioritizedEndpoints(adscConn, adscConn2, t)
 	})
 	t.Run("UDSEndpoints", func(t *testing.T) {
 		testUdsEndpoints(adscConn, t)
@@ -229,6 +229,27 @@ func TestEds(t *testing.T) {
 			t.Error("No clusters in ADS response")
 		}
 	})
+}
+
+// We should test both cases - when features.SendUnhealthyEndpoints is enabled and disabled.
+// Different instances of the fake xDS server are required for each case to test properly.
+func dotestLocalityPrioritizedEndpoints(t *testing.T, sendUnhealthyEndpoints bool) {
+	test.SetAtomicBoolForTest(t, features.SendUnhealthyEndpoints, sendUnhealthyEndpoints)
+
+	s := newFakeDiscoveryServerForEDSTests(t)
+
+	adscConn := s.Connect(&model.Proxy{IPAddresses: []string{"10.10.10.10"}}, nil, watchAll)
+	adscConn2 := s.Connect(&model.Proxy{IPAddresses: []string{"10.10.10.11"}}, nil, watchAll)
+
+	t.Run("LocalityPrioritizedEndpoints", func(t *testing.T) {
+		testLocalityPrioritizedEndpoints(adscConn, adscConn2, t)
+	})
+}
+
+func TestEDSLocalityPrioritizedEndpoints(t *testing.T) {
+	sendUnhealthyEndpoints := features.SendUnhealthyEndpoints.Load()
+	dotestLocalityPrioritizedEndpoints(t, sendUnhealthyEndpoints)
+	dotestLocalityPrioritizedEndpoints(t, !sendUnhealthyEndpoints)
 }
 
 // newEndpointWithAccount is a helper for IstioEndpoint creation. Creates endpoints with
@@ -777,9 +798,15 @@ func testLocalityPrioritizedEndpoints(adsc *adsc.ADSC, adsc2 *adsc.ADSC, t *test
 	verifyLocalityPriorities(asdcLocality, endpoints1["outbound|80||locality.cluster.local"].GetEndpoints(), t)
 	verifyLocalityPriorities(asdc2Locality, endpoints2["outbound|80||locality.cluster.local"].GetEndpoints(), t)
 
-	// No outlier detection specified for this cluster, so we shouldn't apply priority.
-	verifyNoLocalityPriorities(endpoints1["outbound|80||locality-no-outlier-detection.cluster.local"].GetEndpoints(), t)
-	verifyNoLocalityPriorities(endpoints2["outbound|80||locality-no-outlier-detection.cluster.local"].GetEndpoints(), t)
+	// No outlier detection specified for this cluster.
+	// Priority should only be applied if features.SendUnhealthyEndpoints is enabled.
+	if features.SendUnhealthyEndpoints.Load() {
+		verifyLocalityPriorities(asdcLocality, endpoints1["outbound|80||locality-no-outlier-detection.cluster.local"].GetEndpoints(), t)
+		verifyLocalityPriorities(asdc2Locality, endpoints2["outbound|80||locality-no-outlier-detection.cluster.local"].GetEndpoints(), t)
+	} else {
+		verifyNoLocalityPriorities(endpoints1["outbound|80||locality-no-outlier-detection.cluster.local"].GetEndpoints(), t)
+		verifyNoLocalityPriorities(endpoints2["outbound|80||locality-no-outlier-detection.cluster.local"].GetEndpoints(), t)
+	}
 }
 
 // Tests that Services with multiple ports sharing the same port number are properly sent endpoints.

--- a/releasenotes/notes/locality-lb-failover-with-unready-eds.yaml
+++ b/releasenotes/notes/locality-lb-failover-with-unready-eds.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+releaseNotes:
+- |
+  **Added** Locality load balancing failover is now automatically enabled if the control plane
+  is configured to send unready endpoints (PILOT_SEND_UNHEALTHY_ENDPOINTS feature flag)
+  unless explictly disabled, even if no outlier detection is configured for target services.


### PR DESCRIPTION
**Please provide a description of this PR:**

At the moment locality failover on load balancing is enabled by default but is only applied if there is outlier detection configured for the destination service, as originally there was no other way for the sidecar Envoy to know when upstream endpoints are unhealthy and perform the actual failover (since unready endpoints were just excluded from the EDS updates).

That behavior led to some unwanted effects like the locality failover not actually working as expected, sending all the traffic to a single locality unless that locality failed completely (see e.g. #18367) and was one of the reasons to implement support for sending unready endpoints to sidecars, besides support for gradual service warmup (#36274, #37122).

As now we have the ability to configure the control plane to send unready endpoints, there is no requirement for outlier detection to enable locality failover in that case.

In my situation we would like to have locality failover enabled to have traffic pinned within the same AZ to prevent extra costs of unchecked cross-zone data transfer in a public cloud, but don't want to have outlier detection necessarily configured for our services (some workloads for example can be unhealthy without returning 500 errors, which could be caught by custom readiness probes).

This PR implements necessary changes with related tests covering both cases of enabled and disabled unready EDS (since the feature flag is currently disabled by default) and some refactoring to make the code more clear on the implementation.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [x] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
