### PR TITLE
draft: support passing Secret source over MCP

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -533,6 +533,8 @@ func (s *Server) initSDSServer() {
 			ecdsGen.(*xds.EcdsGenerator).SetCredController(creds)
 		}
 	} else {
+		// TODO: introduce another custom secect controller interface?
+		// to provide the Authorize method for secret resources.
 		s.XDSServer.Generators[v3.SecretType] = xds.NewSecretGen(nil, s.XDSServer.Cache, s.clusterID, s.environment.Mesh())
 	}
 }

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -507,7 +507,7 @@ func (s *Server) initSDSServer() {
 	if s.kubeClient == nil && !features.EnableSecretOverMCP {
 		return
 	}
-	if !features.EnableXDSIdentityCheck && !features.EnableSecretOverMCP {
+	if !features.EnableXDSIdentityCheck {
 		// Make sure we have security
 		log.Warnf("skipping Kubernetes credential reader; PILOT_ENABLE_XDS_IDENTITY_CHECK must be set to true for this feature.")
 		return

--- a/pilot/pkg/credentials/kube/secrets.go
+++ b/pilot/pkg/credentials/kube/secrets.go
@@ -182,7 +182,7 @@ func (s *CredentialsController) GetKeyAndCert(name, namespace string) (key []byt
 		return nil, nil, fmt.Errorf("secret %v/%v not found", namespace, name)
 	}
 
-	return extractKeyAndCert(k8sSecret)
+	return ExtractKeyAndCert(k8sSecret)
 }
 
 func (s *CredentialsController) GetCaCert(name, namespace string) (cert []byte, err error) {
@@ -194,9 +194,9 @@ func (s *CredentialsController) GetCaCert(name, namespace string) (cert []byte, 
 		if caCertErr != nil {
 			return nil, fmt.Errorf("secret %v/%v not found", namespace, strippedName)
 		}
-		return extractRoot(k8sSecret)
+		return ExtractRoot(k8sSecret)
 	}
-	return extractRoot(k8sSecret)
+	return ExtractRoot(k8sSecret)
 }
 
 func (s *CredentialsController) GetDockerCredential(name, namespace string) ([]byte, error) {
@@ -233,8 +233,8 @@ func hasValue(d map[string][]byte, keys ...string) bool {
 	return true
 }
 
-// extractKeyAndCert extracts server key, certificate
-func extractKeyAndCert(scrt *v1.Secret) (key, cert []byte, err error) {
+// ExtractKeyAndCert extracts server key, certificate
+func ExtractKeyAndCert(scrt *v1.Secret) (key, cert []byte, err error) {
 	if hasValue(scrt.Data, GenericScrtCert, GenericScrtKey) {
 		return scrt.Data[GenericScrtKey], scrt.Data[GenericScrtCert], nil
 	}
@@ -265,8 +265,8 @@ func truncatedKeysMessage(data map[string][]byte) string {
 	return fmt.Sprintf("%s, and %d more...", strings.Join(keys[:3], ", "), len(keys)-3)
 }
 
-// extractRoot extracts the root certificate
-func extractRoot(scrt *v1.Secret) (cert []byte, err error) {
+// ExtractRoot extracts the root certificate
+func ExtractRoot(scrt *v1.Secret) (cert []byte, err error) {
 	if hasValue(scrt.Data, GenericScrtCaCert) {
 		return scrt.Data[GenericScrtCaCert], nil
 	}

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -406,6 +406,12 @@ var (
 		"If enabled, pilot will authorize XDS clients, to ensure they are acting only as namespaces they have permissions for.",
 	).Get()
 
+	EnableSecretOverMCP = env.RegisterBoolVar(
+		"PILOT_ENABLE_SECRET_OVER_MCP",
+		true,
+		"If enabled, pilot will accept secret resouces over MCP",
+	).Get()
+
 	// TODO: Move this to proper API.
 	trustedGatewayCIDR = env.RegisterStringVar(
 		"TRUSTED_GATEWAY_CIDR",

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -16,7 +16,6 @@ package model
 
 import (
 	"encoding/json"
-	v1 "k8s.io/api/core/v1"
 	"math"
 	"sort"
 	"strings"
@@ -24,6 +23,7 @@ import (
 	"time"
 
 	"go.uber.org/atomic"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	extensions "istio.io/api/extensions/v1alpha1"

--- a/pilot/pkg/xds/sds.go
+++ b/pilot/pkg/xds/sds.go
@@ -18,7 +18,6 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"istio.io/istio/pilot/pkg/credentials/kube"
 	"strings"
 	"time"
 
@@ -31,6 +30,7 @@ import (
 
 	mesh "istio.io/api/mesh/v1alpha1"
 	credscontroller "istio.io/istio/pilot/pkg/credentials"
+	"istio.io/istio/pilot/pkg/credentials/kube"
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/model/credentials"
@@ -144,7 +144,6 @@ func (s *SecretGen) generateFromPushContext(sr SecretResource, proxy *model.Prox
 	}
 	res := toEnvoyKeyCertSecret(sr.ResourceName, key, cert, proxy, s.meshConfig)
 	return res
-
 }
 
 func (s *SecretGen) generateMCP(proxy *model.Proxy, w *model.WatchedResource, req *model.PushRequest) (model.Resources, model.XdsLogDetails, error) {

--- a/pkg/config/schema/collections/collections.gen.go
+++ b/pkg/config/schema/collections/collections.gen.go
@@ -771,6 +771,7 @@ var (
 		MustAdd(IstioSecurityV1Beta1Peerauthentications).
 		MustAdd(IstioSecurityV1Beta1Requestauthentications).
 		MustAdd(IstioTelemetryV1Alpha1Telemetries).
+		MustAdd(K8SCoreV1Secrets).
 		Build()
 
 	// PilotGatewayAPI contains only collections used by Pilot, including experimental Service Api.
@@ -789,6 +790,7 @@ var (
 			MustAdd(IstioSecurityV1Beta1Peerauthentications).
 			MustAdd(IstioSecurityV1Beta1Requestauthentications).
 			MustAdd(IstioTelemetryV1Alpha1Telemetries).
+			MustAdd(K8SCoreV1Secrets).
 			MustAdd(K8SGatewayApiV1Alpha2Gatewayclasses).
 			MustAdd(K8SGatewayApiV1Alpha2Gateways).
 			MustAdd(K8SGatewayApiV1Alpha2Httproutes).

--- a/pkg/config/schema/metadata.yaml
+++ b/pkg/config/schema/metadata.yaml
@@ -140,6 +140,7 @@ collections:
     kind: "Secret"
     group: ""
     builtin: true
+    pilot: true
 
   - name: "k8s/core/v1/services"
     kind: "Service"


### PR DESCRIPTION
It's a draft for #40325 , and using k8s `core.v1.Secret` according to @howardjohn 's suggestion.

TODO:
1. need to authorize secret resources, simply skip for now, since the current authorize way depends on k8s, but the original intention is to bypass k8s; I haven't figured out a way for it yet.
2. tests and doc.

@howardjohn @hzxuzhonghu  Could you please take a look? Just want to make sure it's in the right direction.
Any feedbacks are welcome, thanks!