### PR TITLE
Creating image pull secrets for GatewayConformance test namespaces.

### DIFF
--- a/pkg/test/framework/components/namespace/kube.go
+++ b/pkg/test/framework/components/namespace/kube.go
@@ -239,6 +239,14 @@ func (n *kubeNamespace) createInCluster(c cluster.Cluster, cfg Config) error {
 		if err := c.ApplyYAMLFiles(n.name, s.Image.PullSecret); err != nil {
 			return err
 		}
+		_, err := c.Kube().CoreV1().ServiceAccounts(n.name).Patch(context.TODO(),
+			"default",
+			types.JSONPatchType,
+			[]byte(`[{"op": "add", "path": "/imagePullSecrets", "value": [{"name": "test-gcr-secret"}]}]`),
+			metav1.PatchOptions{})
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/tests/integration/pilot/gateway_conformance_test.go
+++ b/tests/integration/pilot/gateway_conformance_test.go
@@ -79,6 +79,16 @@ func TestGatewayConformance(t *testing.T) {
 		Run(func(ctx framework.TestContext) {
 			DeployGatewayAPICRD(ctx)
 
+			// Precreate the GatewayConformance namespaces, and apply the Image Pull Secret to them.
+			if ctx.Settings().Image.PullSecret != "" {
+				for _, ns := range conformanceNamespaces {
+					namespace.Claim(ctx, namespace.Config{
+						Prefix: ns,
+						Inject: false,
+					})
+				}
+			}
+
 			mapper, _ := gatewayConformanceInputs.Client.UtilFactory().ToRESTMapper()
 			c, err := client.New(gatewayConformanceInputs.Client.RESTConfig(), client.Options{
 				Scheme: kube.IstioScheme,


### PR DESCRIPTION
Precreates the namespaces used by the GatewayConformance tests (which are sourced from upstream Kubernetes). Then creates the ImagePullSecrets for each of the GC namespaces, and modifies the default ServiceAccount to use them.

This allows the test to correctly work when the images under test are stored in a private docker registry.
