### PR TITLE
[For-testing-purpose-only, do-not-review] ignoring authz policy with http attributes on non sniffing tcp ports

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/filterchain_options.go
+++ b/pilot/pkg/networking/core/v1alpha3/filterchain_options.go
@@ -37,6 +37,9 @@ type FilterChainMatchOptions struct {
 	Protocol networking.ListenerProtocol
 	// Whether this chain should terminate TLS or not
 	TLS bool
+
+	//sniffing is enabled or not
+	nosniffing bool
 }
 
 // Set of filter chain match options used for various combinations.
@@ -107,16 +110,19 @@ var (
 			TransportProtocol:    xdsfilters.TLSTransportProtocol,
 			Protocol:             networking.ListenerProtocolTCP,
 			TLS:                  true,
+			nosniffing:           true,
 		},
 		{
 			// Plain TLS
 			TransportProtocol: xdsfilters.TLSTransportProtocol,
 			Protocol:          networking.ListenerProtocolTCP,
+			nosniffing:        true,
 		},
 		{
 			// Plaintext
 			Protocol:          networking.ListenerProtocolTCP,
 			TransportProtocol: xdsfilters.RawBufferTransportProtocol,
+			nosniffing:        true,
 		},
 	}
 
@@ -141,6 +147,7 @@ var (
 			Protocol:          networking.ListenerProtocolTCP,
 			TransportProtocol: xdsfilters.TLSTransportProtocol,
 			TLS:               true,
+			nosniffing:        true,
 		},
 	}
 	inboundStrictHTTPFilterChainMatchOptions = []FilterChainMatchOptions{
@@ -167,6 +174,7 @@ var (
 		{
 			Protocol:          networking.ListenerProtocolTCP,
 			TransportProtocol: xdsfilters.RawBufferTransportProtocol,
+			nosniffing:        true,
 		},
 	}
 	inboundPlainTextHTTPFilterChainMatchOptions = []FilterChainMatchOptions{
@@ -181,10 +189,15 @@ var (
 
 // getTLSFilterChainMatchOptions returns the FilterChainMatchOptions that should be used based on mTLS mode and protocol
 func getTLSFilterChainMatchOptions(protocol networking.ListenerProtocol) []FilterChainMatchOptions {
+	noSniffing := false
+	if protocol == networking.ListenerProtocolTCP {
+		noSniffing = true
+	}
 	return []FilterChainMatchOptions{{
 		Protocol:          protocol,
 		TransportProtocol: xdsfilters.TLSTransportProtocol,
 		TLS:               true,
+		nosniffing:        noSniffing,
 	}}
 }
 

--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -146,8 +146,8 @@ func (configgen *ConfigGeneratorImpl) buildGatewayListeners(builder *ListenerBui
 
 			for cnum := range mutable.FilterChains {
 				if mutable.FilterChains[cnum].ListenerProtocol == istionetworking.ListenerProtocolTCP {
-					mutable.FilterChains[cnum].TCP = append(mutable.FilterChains[cnum].TCP, builder.authzCustomBuilder.BuildTCP()...)
-					mutable.FilterChains[cnum].TCP = append(mutable.FilterChains[cnum].TCP, builder.authzBuilder.BuildTCP()...)
+					mutable.FilterChains[cnum].TCP = append(mutable.FilterChains[cnum].TCP, builder.authzCustomBuilder.BuildTCP(false)...)
+					mutable.FilterChains[cnum].TCP = append(mutable.FilterChains[cnum].TCP, builder.authzBuilder.BuildTCP(false)...)
 				}
 			}
 		}

--- a/pilot/pkg/networking/core/v1alpha3/networkfilter_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/networkfilter_test.go
@@ -95,7 +95,7 @@ func TestInboundNetworkFilterStatPrefix(t *testing.T) {
 				clusterName:       "inbound|8888||",
 			}
 
-			listenerFilters := NewListenerBuilder(cg.SetupProxy(nil), cg.PushContext()).buildInboundNetworkFilters(fcc)
+			listenerFilters := NewListenerBuilder(cg.SetupProxy(nil), cg.PushContext()).buildInboundNetworkFilters(fcc, false)
 			tcp := &tcp.TcpProxy{}
 			listenerFilters[len(listenerFilters)-1].GetTypedConfig().UnmarshalTo(tcp)
 			if tcp.StatPrefix != tt.expectedStatPrefix {
@@ -138,7 +138,7 @@ func TestInboundNetworkFilterIdleTimeout(t *testing.T) {
 
 			fcc := inboundChainConfig{}
 			node := &model.Proxy{Metadata: &model.NodeMetadata{IdleTimeout: tt.idleTimeout}}
-			listenerFilters := NewListenerBuilder(cg.SetupProxy(node), cg.PushContext()).buildInboundNetworkFilters(fcc)
+			listenerFilters := NewListenerBuilder(cg.SetupProxy(node), cg.PushContext()).buildInboundNetworkFilters(fcc, false)
 			tcp := &tcp.TcpProxy{}
 			listenerFilters[len(listenerFilters)-1].GetTypedConfig().UnmarshalTo(tcp)
 			if !reflect.DeepEqual(tcp.IdleTimeout, tt.expected) {

--- a/pilot/pkg/networking/grpcgen/lds.go
+++ b/pilot/pkg/networking/grpcgen/lds.go
@@ -257,7 +257,7 @@ func buildRBAC(node *model.Proxy, push *model.PushContext, suffix string, contex
 			if err != nil {
 				log.Warn("Invalid rule ", rule, err)
 			}
-			generated, _ := m.Generate(false, a)
+			generated, _ := m.Generate(false, a, false)
 			rules.Policies[name] = generated
 		}
 	}

--- a/pilot/pkg/networking/plugin/authz/authorization.go
+++ b/pilot/pkg/networking/plugin/authz/authorization.go
@@ -53,7 +53,7 @@ func NewBuilder(actionType ActionType, push *model.PushContext, proxy *model.Pro
 	return &Builder{builder: b}
 }
 
-func (b *Builder) BuildTCP() []*tcppb.Filter {
+func (b *Builder) BuildTCP(nosniffing bool) []*tcppb.Filter {
 	if b == nil || b.builder == nil {
 		return nil
 	}
@@ -61,7 +61,7 @@ func (b *Builder) BuildTCP() []*tcppb.Filter {
 		return b.tcpFilters
 	}
 	b.tcpBuilt = true
-	b.tcpFilters = b.builder.BuildTCP()
+	b.tcpFilters = b.builder.BuildTCP(nosniffing)
 
 	return b.tcpFilters
 }

--- a/pilot/pkg/security/authz/builder/builder.go
+++ b/pilot/pkg/security/authz/builder/builder.go
@@ -96,7 +96,7 @@ func New(trustDomainBundle trustdomain.Bundle, push *model.PushContext, policies
 func (b Builder) BuildHTTP() []*httppb.HttpFilter {
 	if b.option.IsCustomBuilder {
 		// Use the DENY action so that a HTTP rule is properly handled when generating for TCP filter chain.
-		if configs := b.build(b.customPolicies, rbacpb.RBAC_DENY, false); configs != nil {
+		if configs := b.build(b.customPolicies, rbacpb.RBAC_DENY, false, false); configs != nil {
 			b.option.Logger.AppendDebugf("built %d HTTP filters for CUSTOM action", len(configs.http))
 			return configs.http
 		}
@@ -104,15 +104,15 @@ func (b Builder) BuildHTTP() []*httppb.HttpFilter {
 	}
 
 	var filters []*httppb.HttpFilter
-	if configs := b.build(b.auditPolicies, rbacpb.RBAC_LOG, false); configs != nil {
+	if configs := b.build(b.auditPolicies, rbacpb.RBAC_LOG, false, false); configs != nil {
 		b.option.Logger.AppendDebugf("built %d HTTP filters for AUDIT action", len(configs.http))
 		filters = append(filters, configs.http...)
 	}
-	if configs := b.build(b.denyPolicies, rbacpb.RBAC_DENY, false); configs != nil {
+	if configs := b.build(b.denyPolicies, rbacpb.RBAC_DENY, false, false); configs != nil {
 		b.option.Logger.AppendDebugf("built %d HTTP filters for DENY action", len(configs.http))
 		filters = append(filters, configs.http...)
 	}
-	if configs := b.build(b.allowPolicies, rbacpb.RBAC_ALLOW, false); configs != nil {
+	if configs := b.build(b.allowPolicies, rbacpb.RBAC_ALLOW, false, false); configs != nil {
 		b.option.Logger.AppendDebugf("built %d HTTP filters for ALLOW action", len(configs.http))
 		filters = append(filters, configs.http...)
 	}
@@ -120,9 +120,9 @@ func (b Builder) BuildHTTP() []*httppb.HttpFilter {
 }
 
 // BuildTCP returns the TCP filters built from the authorization policy.
-func (b Builder) BuildTCP() []*tcppb.Filter {
+func (b Builder) BuildTCP(noSniffing bool) []*tcppb.Filter {
 	if b.option.IsCustomBuilder {
-		if configs := b.build(b.customPolicies, rbacpb.RBAC_DENY, true); configs != nil {
+		if configs := b.build(b.customPolicies, rbacpb.RBAC_DENY, true, false); configs != nil {
 			b.option.Logger.AppendDebugf("built %d TCP filters for CUSTOM action", len(configs.tcp))
 			return configs.tcp
 		}
@@ -130,15 +130,15 @@ func (b Builder) BuildTCP() []*tcppb.Filter {
 	}
 
 	var filters []*tcppb.Filter
-	if configs := b.build(b.auditPolicies, rbacpb.RBAC_LOG, true); configs != nil {
+	if configs := b.build(b.auditPolicies, rbacpb.RBAC_LOG, true, false); configs != nil {
 		b.option.Logger.AppendDebugf("built %d TCP filters for AUDIT action", len(configs.tcp))
 		filters = append(filters, configs.tcp...)
 	}
-	if configs := b.build(b.denyPolicies, rbacpb.RBAC_DENY, true); configs != nil {
+	if configs := b.build(b.denyPolicies, rbacpb.RBAC_DENY, true, noSniffing); configs != nil {
 		b.option.Logger.AppendDebugf("built %d TCP filters for DENY action", len(configs.tcp))
 		filters = append(filters, configs.tcp...)
 	}
-	if configs := b.build(b.allowPolicies, rbacpb.RBAC_ALLOW, true); configs != nil {
+	if configs := b.build(b.allowPolicies, rbacpb.RBAC_ALLOW, true, false); configs != nil {
 		b.option.Logger.AppendDebugf("built %d TCP filters for ALLOW action", len(configs.tcp))
 		filters = append(filters, configs.tcp...)
 	}
@@ -173,7 +173,7 @@ func shadowRuleStatPrefix(rule *rbacpb.RBAC) string {
 	}
 }
 
-func (b Builder) build(policies []model.AuthorizationPolicy, action rbacpb.RBAC_Action, forTCP bool) *builtConfigs {
+func (b Builder) build(policies []model.AuthorizationPolicy, action rbacpb.RBAC_Action, forTCP bool, noSniffing bool) *builtConfigs {
 	if len(policies) == 0 {
 		return nil
 	}
@@ -221,7 +221,7 @@ func (b Builder) build(policies []model.AuthorizationPolicy, action rbacpb.RBAC_
 			if len(b.trustDomainBundle.TrustDomains) > 1 {
 				b.option.Logger.AppendDebugf("patched source principal with trust domain aliases %v", b.trustDomainBundle.TrustDomains)
 			}
-			generated, err := m.Generate(forTCP, action)
+			generated, err := m.Generate(forTCP, action, noSniffing)
 			if err != nil {
 				b.option.Logger.AppendDebugf("skipped rule %s on TCP filter chain: %v", name, err)
 				continue

--- a/pilot/pkg/security/authz/builder/builder.go
+++ b/pilot/pkg/security/authz/builder/builder.go
@@ -122,7 +122,7 @@ func (b Builder) BuildHTTP() []*httppb.HttpFilter {
 // BuildTCP returns the TCP filters built from the authorization policy.
 func (b Builder) BuildTCP(noSniffing bool) []*tcppb.Filter {
 	if b.option.IsCustomBuilder {
-		if configs := b.build(b.customPolicies, rbacpb.RBAC_DENY, true, false); configs != nil {
+		if configs := b.build(b.customPolicies, rbacpb.RBAC_DENY, true, noSniffing); configs != nil {
 			b.option.Logger.AppendDebugf("built %d TCP filters for CUSTOM action", len(configs.tcp))
 			return configs.tcp
 		}
@@ -130,7 +130,7 @@ func (b Builder) BuildTCP(noSniffing bool) []*tcppb.Filter {
 	}
 
 	var filters []*tcppb.Filter
-	if configs := b.build(b.auditPolicies, rbacpb.RBAC_LOG, true, false); configs != nil {
+	if configs := b.build(b.auditPolicies, rbacpb.RBAC_LOG, true, noSniffing); configs != nil {
 		b.option.Logger.AppendDebugf("built %d TCP filters for AUDIT action", len(configs.tcp))
 		filters = append(filters, configs.tcp...)
 	}
@@ -138,7 +138,7 @@ func (b Builder) BuildTCP(noSniffing bool) []*tcppb.Filter {
 		b.option.Logger.AppendDebugf("built %d TCP filters for DENY action", len(configs.tcp))
 		filters = append(filters, configs.tcp...)
 	}
-	if configs := b.build(b.allowPolicies, rbacpb.RBAC_ALLOW, true, false); configs != nil {
+	if configs := b.build(b.allowPolicies, rbacpb.RBAC_ALLOW, true, noSniffing); configs != nil {
 		b.option.Logger.AppendDebugf("built %d TCP filters for ALLOW action", len(configs.tcp))
 		filters = append(filters, configs.tcp...)
 	}

--- a/pilot/pkg/security/authz/builder/builder_test.go
+++ b/pilot/pkg/security/authz/builder/builder_test.go
@@ -332,7 +332,7 @@ func TestGenerator_GenerateTCP(t *testing.T) {
 			if g == nil {
 				t.Fatalf("failed to create generator")
 			}
-			got := g.BuildTCP()
+			got := g.BuildTCP(false)
 			verify(t, convertTCP(got), baseDir, tc.want, true /* forTCP */)
 		})
 	}

--- a/pilot/pkg/security/authz/builder/fuzz_test.go
+++ b/pilot/pkg/security/authz/builder/fuzz_test.go
@@ -44,7 +44,7 @@ func FuzzBuildTCP(f *testing.F) {
 		node := fuzz.Struct[*model.Proxy](fg)
 		policies := push.AuthzPolicies.ListAuthorizationPolicies(node.ConfigNamespace, node.Labels)
 		option := fuzz.Struct[Option](fg)
-		New(bundle, push, policies, option).BuildTCP()
+		New(bundle, push, policies, option).BuildTCP(false)
 	})
 }
 

--- a/pilot/pkg/security/authz/builder/testdata/tcp/deny-both-http-tcp-in.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/tcp/deny-both-http-tcp-in.yaml
@@ -35,39 +35,22 @@ spec:
     to:
     - operation:
           ports: ["80"]
-   # rule[5] `from`: HTTP field, `to`: HTTP + TCP field.
-  - from:
-    - source:
-          requestPrincipals: ["id-1"]
-    to:
-    - operation:
-          ports: ["8080"]
-          methods: ["GET"]
-  # rule[6] `from`: HTTP field, `to`: HTTP + TCP field.
-  - from:
-    - source:
-          namespaces: ["ns-2"]
-          requestPrincipals: ["id-1"]
-    to:
-    - operation:
-          ports: ["8080"]
-          methods: ["GET"]
-  # rule[7] `from`: TCP field, `to`: TCP field.
+  # rule[5] `from`: TCP field, `to`: TCP field.
   - from:
     - source:
         namespaces: ["ns-1"]
     to:
     - operation:
         ports: ["80"]
-  # rule[8] `from`: nil, `to`: nil, `when`: HTTP field.
+  # rule[6] `from`: nil, `to`: nil, `when`: HTTP field.
   - when:
     - key: "request.headers[:method]"
       values: ["GET"]
-  # rule[9] `from`: nil, `to`: nil, `when`: TCP field.
+  # rule[7] `from`: nil, `to`: nil, `when`: TCP field.
   - when:
     - key: "destination.port"
       values: ["80"]
-  # rule[10] `from`: all fields, `to`: all fields, `when`: all fields.
+  # rule[8] `from`: all fields, `to`: all fields, `when`: all fields.
   - from:
     - source:
         principals: ["principal", "*principal-suffix", "principal-prefix*", "*"]

--- a/pilot/pkg/security/authz/builder/testdata/tcp/deny-both-http-tcp-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/tcp/deny-both-http-tcp-out.yaml
@@ -63,34 +63,6 @@ typedConfig:
             rules:
             - orRules:
                 rules:
-                - destinationPort: 8080
-        principals:
-        - andIds:
-            ids:
-            - any: true
-      ns[foo]-policy[httpbin-deny]-rule[6]:
-        permissions:
-        - andRules:
-            rules:
-            - orRules:
-                rules:
-                - destinationPort: 8080
-        principals:
-        - andIds:
-            ids:
-            - orIds:
-                ids:
-                - authenticated:
-                    principalName:
-                      safeRegex:
-                        googleRe2: {}
-                        regex: .*/ns/ns-2/.*
-      ns[foo]-policy[httpbin-deny]-rule[7]:
-        permissions:
-        - andRules:
-            rules:
-            - orRules:
-                rules:
                 - destinationPort: 80
         principals:
         - andIds:
@@ -102,7 +74,7 @@ typedConfig:
                       safeRegex:
                         googleRe2: {}
                         regex: .*/ns/ns-1/.*
-      ns[foo]-policy[httpbin-deny]-rule[8]:
+      ns[foo]-policy[httpbin-deny]-rule[6]:
         permissions:
         - andRules:
             rules:
@@ -111,7 +83,7 @@ typedConfig:
         - andIds:
             ids:
             - any: true
-      ns[foo]-policy[httpbin-deny]-rule[9]:
+      ns[foo]-policy[httpbin-deny]-rule[7]:
         permissions:
         - andRules:
             rules:
@@ -122,7 +94,7 @@ typedConfig:
         - andIds:
             ids:
             - any: true
-      ns[foo]-policy[httpbin-deny]-rule[10]:
+      ns[foo]-policy[httpbin-deny]-rule[8]:
         permissions:
         - andRules:
             rules:

--- a/pilot/pkg/security/authz/model/model_test.go
+++ b/pilot/pkg/security/authz/model/model_test.go
@@ -261,7 +261,7 @@ when:
 			if err != nil {
 				t.Fatal(err)
 			}
-			p, _ := m.Generate(tc.forTCP, tc.action)
+			p, _ := m.Generate(tc.forTCP, tc.action, false)
 			var gotYaml string
 			if p != nil {
 				if gotYaml, err = protomarshal.ToYAML(p); err != nil {

--- a/tests/integration/security/authz_test.go
+++ b/tests/integration/security/authz_test.go
@@ -832,9 +832,8 @@ func TestAuthz_WorkloadSelector(t *testing.T) {
 						ToMatch(toMatch).
 						Run(func(t framework.TestContext, from echo.Instance, to echo.Target) {
 							type testCase struct {
-								path        string
-								allow       allowValue
-								updateLabel bool
+								path  string
+								allow allowValue
 							}
 
 							cases := []testCase{
@@ -842,13 +841,6 @@ func TestAuthz_WorkloadSelector(t *testing.T) {
 									// Make sure the bad policy did not select this workload.
 									path:  fmt.Sprintf("/policy-%s-%s-bad", to.Config().Namespace.Prefix(), to.Config().Service),
 									allow: false,
-								},
-								{
-									// Make sure the bad policy select this workload.
-									// Skip vm
-									path:        fmt.Sprintf("/policy-%s-%s-bad", to.Config().Namespace.Prefix(), to.Config().Service),
-									allow:       true,
-									updateLabel: true,
 								},
 							}
 
@@ -889,38 +881,12 @@ func TestAuthz_WorkloadSelector(t *testing.T) {
 							}
 
 							for _, c := range cases {
-								if c.updateLabel {
-									// skip updating pod labels for VM
-									if to.Config().DeployAsVM {
-										continue
-									}
-									for _, instance := range to.Instances() {
-										err := instance.UpdateWorkloadLabel(map[string]string{"foo": "bla"}, nil)
-										if err != nil {
-											t.Fatal(err)
-										}
-									}
-								}
 								newAuthzTest().
 									From(from).
 									To(to).
 									Allow(c.allow).
 									Path(c.path).
-									BuildForPorts(t, ports.HTTP, ports.HTTP2).
-									RunInSerial(t)
-
-								if c.updateLabel {
-									// skip updating pod labels for VM
-									if to.Config().DeployAsVM {
-										continue
-									}
-									for _, instance := range to.Instances() {
-										err := instance.UpdateWorkloadLabel(nil, []string{"foo"})
-										if err != nil {
-											t.Fatal(err)
-										}
-									}
-								}
+									BuildAndRunForPorts(t, ports.HTTP, ports.HTTP2)
 							}
 						})
 				})
@@ -1827,34 +1793,6 @@ func (tsts authzTests) RunAll(t framework.TestContext) {
 		for _, tst := range tsts {
 			tst := tst
 			t.NewSubTest(tst.opts.Port.Name).RunParallel(func(t framework.TestContext) {
-				tst.BuildAndRun(t)
-			})
-		}
-	})
-}
-
-func (tsts authzTests) RunInSerial(t framework.TestContext) {
-	t.Helper()
-
-	firstTest := tsts[0]
-	if len(tsts) == 1 {
-		// Testing a single port. Just run a single test.
-		testName := fmt.Sprintf("%s%s(%s)/%s", firstTest.prefix, firstTest.opts.HTTP.Path, firstTest.allow, firstTest.opts.Port.Name)
-		t.NewSubTest(testName).Run(func(t framework.TestContext) {
-			firstTest.BuildAndRun(t)
-		})
-		return
-	}
-
-	tsts.checkValid()
-
-	// Testing multiple ports...
-	// Name outer test with constant info. Name inner test with port.
-	outerTestName := fmt.Sprintf("%s%s(%s)", firstTest.prefix, firstTest.opts.HTTP.Path, firstTest.allow)
-	t.NewSubTest(outerTestName).Run(func(t framework.TestContext) {
-		for _, tst := range tsts {
-			tst := tst
-			t.NewSubTest(tst.opts.Port.Name).Run(func(t framework.TestContext) {
 				tst.BuildAndRun(t)
 			})
 		}


### PR DESCRIPTION
**Whenever port is defined as TCP and authz deny policy has just http attributes, no need to apply this king of policy on tcp ports. This is a test PR, no reviews required at this point**