### PR TITLE
strengthen the confirmation function

### DIFF
--- a/operator/cmd/mesh/shared.go
+++ b/operator/cmd/mesh/shared.go
@@ -101,19 +101,20 @@ func kubeBuilderInstalled() bool {
 
 // confirm waits for a user to confirm with the supplied message.
 func confirm(msg string, writer io.Writer) bool {
-	_, _ = fmt.Fprintf(writer, "%s ", msg)
-
-	var response string
-	_, err := fmt.Scanln(&response)
-	if err != nil {
-		return false
+	for {
+		_, _ = fmt.Fprintf(writer, "%s ", msg)
+		var response string
+		_, err := fmt.Scanln(&response)
+		if err != nil {
+			return false
+		}
+		switch strings.ToUpper(response) {
+		case "Y", "YES":
+			return true
+		case "N", "NO":
+			return false
+		}
 	}
-	response = strings.ToUpper(response)
-	if response == "Y" || response == "YES" {
-		return true
-	}
-
-	return false
 }
 
 func KubernetesClients(kubeConfigPath, context string, l clog.Logger) (kube.ExtendedClient, client.Client, error) {


### PR DESCRIPTION
**Please provide a description of this PR:**
improve the `istio install`  confirmation function

```shell
$ go run istioctl/cmd/istioctl/main.go install

The Kubernetes version v1.18.20 is not supported by Istio unknown. The minimum supported Kubernetes version is 1.19.
Proceeding with the installation, but you might experience problems. See https://istio.io/latest/docs/setup/platform-setup/ for a list of supported versions.

Detected that your cluster does not support third party JWT authentication. Falling back to less secure first party JWT. See https://istio.io/v1.16/docs/ops/best-practices/security/#configure-third-party-service-account-tokens for details.
! values.global.jwtPolicy is deprecated; use Values.global.jwtPolicy=third-party-jwt. See https://istio.io/latest/docs/ops/best-practices/security/#configure-third-party-service-account-tokens for more information instead
WARNING: Istio control planes installed: 1.13.3.
WARNING: A newer installed version of Istio has been detected. Running this command will overwrite it.
This will install the Istio 1.16.0 default profile with ["Istio core" "Istiod" "Ingress gateways"] components into the cluster. Proceed? (y/N) 12
This will install the Istio 1.16.0 default profile with ["Istio core" "Istiod" "Ingress gateways"] components into the cluster. Proceed? (y/N) j
This will install the Istio 1.16.0 default profile with ["Istio core" "Istiod" "Ingress gateways"] components into the cluster. Proceed? (y/N) y
✔ Istio core installed
```