### PR TITLE
install: autodetect cniBinDir on GKE

### DIFF
--- a/manifests/charts/istio-cni/templates/configmap-cni.yaml
+++ b/manifests/charts/istio-cni/templates/configmap-cni.yaml
@@ -1,3 +1,8 @@
+{{- $defaultBinDir :=
+    (.Capabilities.KubeVersion.GitVersion | contains "-gke") | ternary
+      "/home/kubernetes/bin"
+      "/opt/cni/bin"
+}}
 kind: ConfigMap
 apiVersion: v1
 metadata:
@@ -21,7 +26,7 @@ data:
           "log_uds_address": "__LOG_UDS_ADDRESS__", 
           "kubernetes": {
               "kubeconfig": "__KUBECONFIG_FILEPATH__",
-              "cni_bin_dir": {{ quote .Values.cni.cniBinDir }},
+              "cni_bin_dir": {{ .Values.cni.cniBinDir | default $defaultBinDir | quote }},
               "exclude_namespaces": [ {{ range $idx, $ns := .Values.cni.excludeNamespaces }}{{ if $idx }}, {{ end }}{{ quote $ns }}{{ end }} ]
           }
         }

--- a/manifests/charts/istio-cni/templates/daemonset.yaml
+++ b/manifests/charts/istio-cni/templates/daemonset.yaml
@@ -1,6 +1,11 @@
 # This manifest installs the Istio install-cni container, as well
 # as the Istio CNI plugin and config on
 # each master and worker node in a Kubernetes cluster.
+{{- $defaultBinDir :=
+    (.Capabilities.KubeVersion.GitVersion | contains "-gke") | ternary
+      "/home/kubernetes/bin"
+      "/opt/cni/bin"
+}}
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
@@ -164,7 +169,7 @@ spec:
         # Used to install CNI.
         - name: cni-bin-dir
           hostPath:
-            path: {{ default "/opt/cni/bin" .Values.cni.cniBinDir }}
+            path: {{ .Values.cni.cniBinDir | default $defaultBinDir }}
         - name: cni-net-dir
           hostPath:
             path: {{ default "/etc/cni/net.d" .Values.cni.cniConfDir }}

--- a/manifests/charts/istio-cni/values.yaml
+++ b/manifests/charts/istio-cni/values.yaml
@@ -16,7 +16,7 @@ cni:
 
   # CNI bin and conf dir override settings
   # defaults:
-  cniBinDir: /opt/cni/bin
+  cniBinDir: "" # Auto-detected based on version; defaults to /opt/cni/bin.
   cniConfDir: /etc/cni/net.d
   cniConfFileName: ""
 

--- a/operator/pkg/manifest/shared.go
+++ b/operator/pkg/manifest/shared.go
@@ -445,7 +445,7 @@ func getClusterSpecificValues(client kube.Client, force bool, l clog.Logger) (st
 }
 
 // getCNISettings gets auto-detected values based on the Kubernetes environment.
-// Note: there are other settings as well; however, these are detect inline in the helm chart.
+// Note: there are other settings as well; however, these are detected inline in the helm chart.
 // This ensures helm users also get them.
 func getCNISettings(client kube.Client) string {
 	ver, err := client.GetKubernetesVersion()
@@ -458,16 +458,6 @@ func getCNISettings(client kube.Client) string {
 		return "components.cni.namespace=kube-system"
 	}
 	// TODO: OpenShift
-	return ""
-}
-
-func getFSGroupOverlay(config kube.Client, jwtPolicy util.JWTPolicy) string {
-	// Set ENABLE_LEGACY_FSGROUP_INJECTION to true only for Kubernetes 1.18 or older,
-	// together with third-party-jwt, as we need the fsGroup configuration for the projected
-	// service account volume mount, which is only used by third-party-jwt.
-	if kube.IsLessThanVersion(config, 19) && jwtPolicy == util.ThirdPartyJWT {
-		return "values.pilot.env.ENABLE_LEGACY_FSGROUP_INJECTION=true"
-	}
 	return ""
 }
 

--- a/releasenotes/notes/detect-cni.yaml
+++ b/releasenotes/notes/detect-cni.yaml
@@ -1,5 +1,5 @@
 apiVersion: release-notes/v2
-kind: enhancement
+kind: feature
 area: installation
 releaseNotes:
 - |

--- a/releasenotes/notes/detect-cni.yaml
+++ b/releasenotes/notes/detect-cni.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: enhancement
+area: installation
+releaseNotes:
+- |
+  **Added** auto-detection of [GKE specific installation steps](https://istio.io/latest/docs/setup/additional-setup/cni/#hosted-kubernetes-settings) when using CNI to `istioctl install` and `helm install`. 


### PR DESCRIPTION
Makes users not need
https://istio.io/latest/docs/setup/additional-setup/cni/#hosted-kubernetes-settings
when installing via `helm install` or `istioctl install`.

Note: `helm template` and `istioctl manifest generate` do not use
version information, so this is still needed for those cases.

This adds GKE detection. OpenShift detection is possible as well, I just
don't have a test cluster or know how to detect OpenShift
