### PR TITLE
install: add `--cluster-specific` flag to generate

### DIFF
--- a/releasenotes/notes/cluster-specific-generate.yaml
+++ b/releasenotes/notes/cluster-specific-generate.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+releaseNotes:
+- |
+  **Added** a `--cluster-specific` flag to `istioctl manifest generate`. When this is set, the current cluster context will be used to determine dynamic default settings, mirroring `istioctl install`.
+


### PR DESCRIPTION
This allows `manifest generate` to use cluster specific settings as
well.

The only install method left is `helm template`; I have a bug filed in
https://github.com/helm/helm/issues/11240.

**Please provide a description of this PR:**