### PR TITLE
Add automatic setting logic for ENABLE_LEGACY_FSGROUP_INJECTION

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -149,6 +149,10 @@ spec:
             value: "{{ $val }}"
           {{- end }}
           {{- end }}
+{{- if semverCompare "<1.19" .Capabilities.KubeVersion.GitVersion }}
+          - name: ENABLE_LEGACY_FSGROUP_INJECTION
+            value: "true"
+{{- end }}
 {{- if .Values.pilot.traceSampling }}
           - name: PILOT_TRACE_SAMPLING
             value: "{{ .Values.pilot.traceSampling }}"


### PR DESCRIPTION
The previous logic was available only for IstioOperator,
hence helm based integration tests on k8s 1.16 were failing.

Signed-off-by: Faseela K <faseela.k@est.tech>

**Please provide a description of this PR:**



**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [X] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure