### PR TITLE
Disable CONFIG_DISTRIBUTION_TRACKING

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -220,7 +220,7 @@ var (
 
 	EnableDistributionTracking = env.RegisterBoolVar(
 		"PILOT_ENABLE_CONFIG_DISTRIBUTION_TRACKING",
-		true,
+		false,
 		"If enabled, Pilot will assign meaningful nonces to each Envoy configuration message, and allow "+
 			"users to interrogate which envoy has which config from the debug interface.",
 	).Get()


### PR DESCRIPTION
**Please provide a description of this PR:**

This is to disable config distribution tracking, which is not mature, especially on CPU andMem cost.

https://github.com/istio/istio/issues/24521
https://github.com/istio/istio/issues/38716#issuecomment-1119187983


It is used for debug interface, so I think not much risk

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
