### PR TITLE
Add Tap gRPC handler to Istio Agent.

### DIFF
--- a/pkg/istio-agent/tap_proxy.go
+++ b/pkg/istio-agent/tap_proxy.go
@@ -22,6 +22,7 @@ import (
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
+
 	istiogrpc "istio.io/istio/pilot/pkg/grpc"
 	"istio.io/istio/pilot/pkg/xds"
 	istiokeepalive "istio.io/istio/pkg/keepalive"

--- a/pkg/istio-agent/tap_proxy.go
+++ b/pkg/istio-agent/tap_proxy.go
@@ -1,0 +1,69 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package istioagent
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/reflection"
+	istiogrpc "istio.io/istio/pilot/pkg/grpc"
+	"istio.io/istio/pilot/pkg/xds"
+	istiokeepalive "istio.io/istio/pkg/keepalive"
+	"istio.io/pkg/log"
+)
+
+type tapProxy struct {
+	xdsProxy *XdsProxy
+}
+
+func NewTapGrpcHandler(xdsProxy *XdsProxy) (*grpc.Server, error) {
+	proxy := &tapProxy{
+		xdsProxy: xdsProxy,
+	}
+	grpcs := grpc.NewServer(istiogrpc.ServerOptions(istiokeepalive.DefaultOption())...)
+	discovery.RegisterAggregatedDiscoveryServiceServer(grpcs, proxy)
+	reflection.Register(grpcs)
+	return grpcs, nil
+}
+
+func (p *tapProxy) StreamAggregatedResources(downstream xds.DiscoveryStream) error {
+	timeout := time.Second * 15
+	req, err := downstream.Recv()
+	if err != nil {
+		log.Errorf("failed to recv: %v", err)
+		return err
+	}
+	if strings.HasPrefix(req.TypeUrl, "istio.io/debug/") {
+		if resp, err := p.xdsProxy.tapRequest(req, timeout); err == nil {
+			err := downstream.Send(resp)
+			if err != nil {
+				log.Errorf("failed to send: %v", err)
+				return err
+			}
+		} else {
+			log.Errorf("failed to call tap request: %v", err)
+			return err
+		}
+	}
+	return nil
+}
+
+func (p *tapProxy) DeltaAggregatedResources(downstream xds.DeltaDiscoveryStream) error {
+	return fmt.Errorf("not implemented")
+}

--- a/pkg/istio-agent/xds_proxy.go
+++ b/pkg/istio-agent/xds_proxy.go
@@ -31,6 +31,8 @@ import (
 
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"go.uber.org/atomic"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
 	google_rpc "google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -870,14 +872,27 @@ func (p *XdsProxy) makeTapHandler() func(w http.ResponseWriter, req *http.Reques
 func (p *XdsProxy) initDebugInterface(port int) error {
 	p.tapResponseChannel = make(chan *discovery.DiscoveryResponse)
 
+	tapGrpcHandler, err := NewTapGrpcHandler(p)
+	if err != nil {
+		log.Errorf("failed to start Tap XDS Proxy: %v", err)
+	}
+
 	httpMux := http.NewServeMux()
 	handler := p.makeTapHandler()
 	httpMux.HandleFunc("/debug/", handler)
 	httpMux.HandleFunc("/debug", handler) // For 1.10 Istiod which uses istio.io/debug
 
+	mixedHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.ProtoMajor == 2 && strings.HasPrefix(r.Header.Get("content-type"), "application/grpc") {
+			tapGrpcHandler.ServeHTTP(w, r)
+			return
+		}
+		httpMux.ServeHTTP(w, r)
+	})
+
 	p.httpTapServer = &http.Server{
 		Addr:        fmt.Sprintf("localhost:%d", port),
-		Handler:     httpMux,
+		Handler:     h2c.NewHandler(mixedHandler, &http2.Server{}),
 		IdleTimeout: 90 * time.Second, // matches http.DefaultTransport keep-alive timeout
 		ReadTimeout: 30 * time.Second,
 	}

--- a/tests/integration/pilot/piggyback_test.go
+++ b/tests/integration/pilot/piggyback_test.go
@@ -19,11 +19,13 @@ package pilot
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 
 	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/istioctl"
 	"istio.io/istio/pkg/test/util/retry"
 	"istio.io/istio/pkg/util/protomarshal"
 )
@@ -60,6 +62,35 @@ func TestPiggyback(t *testing.T) {
 					return fmt.Errorf("resources[0] doesn't contain expected typeURL: %s", out)
 				}
 				return nil
+			})
+
+			expectSubstrings := func(have string, wants ...string) error {
+				for _, want := range wants {
+					if !strings.Contains(have, want) {
+						return fmt.Errorf("substring %q not found; have %q", want, have)
+					}
+				}
+				return nil
+			}
+
+			// Test gRPC-based Tap Service using istioctl.
+			retry.UntilSuccessOrFail(t, func() error {
+				podName := apps.A[0].WorkloadsOrFail(t)[0].PodName()
+				nsName := apps.A.Config().Namespace.Name()
+				pf, err := t.Clusters()[0].NewPortForwarder(podName, nsName, "localhost", 0, 15004)
+				if err != nil {
+					return fmt.Errorf("failed to create the port forwarder: %v", err)
+				}
+				pf.Start()
+				defer pf.Close()
+
+				istioCtl := istioctl.NewOrFail(t, t, istioctl.Config{Cluster: t.Clusters().Default()})
+				args := []string{"x", "proxy-status", "--plaintext", "--xds-address", pf.Address()}
+				output, _ := istioCtl.InvokeOrFail(t, args)
+
+				// Just verify pod A is known to Pilot; implicitly this verifies that
+				// the printing code printed it.
+				return expectSubstrings(output, fmt.Sprintf("%s.%s", podName, nsName))
 			})
 		})
 }


### PR DESCRIPTION
https://github.com/istio/istio/pull/31749 introduced that the ability to tap into istio-agent to route debug messages to istiod.

While https://github.com/istio/istio/pull/31749 uses gRPC to `Istiod`, 
it uses HTTP + JSONPB to send the `DiscoveryResponse` to the downstreams.
But, we can also use gRPC to the downstreams.
This may have following benefits:
 * istioctl can be used to access the endpoint. For example,
   ```
   kubectl port-forward -n httpbin httpbin-788cfbd7d5-flrm4 15004:15004
   istioctl x ps --plaintext --xds-address localhost:15004
   ```
 * Much faster/lighter than HTTP+JSONPB because JSONPB is pretty slow.

So, this PR proposes to add gRPC tap handler which has the same functionality with https://github.com/istio/istio/pull/31749, but just uses gRPC instead of HTTP+JSONPB.

