### PR TITLE
Consider the health of remote endpoints when applying the Split Horizon EDS

### DIFF
--- a/pilot/pkg/xds/ep_filters.go
+++ b/pilot/pkg/xds/ep_filters.go
@@ -66,7 +66,7 @@ func (b *EndpointBuilder) EndpointsByNetworkFilter(endpoints []*LocalityEndpoint
 		gatewayWeights := make(map[model.NetworkGateway]uint32)
 
 		// Create a map to keep track of aggregate health of the gateways.
-		gatewayHealth := make(map[model.NetworkGateway]bool)
+		gatewayHealth := make(map[model.NetworkGateway]struct{})
 
 		// Process all of the endpoints.
 		for i, lbEp := range ep.llbEndpoints.LbEndpoints {
@@ -110,7 +110,7 @@ func (b *EndpointBuilder) EndpointsByNetworkFilter(endpoints []*LocalityEndpoint
 			// A gateway is considered healthy only if it has any healthy endpoints reachable.
 			if istioEndpoint.HealthStatus == model.Healthy {
 				for _, gw := range gateways {
-					gatewayHealth[gw] = true
+					gatewayHealth[gw] = struct{}{}
 				}
 			}
 
@@ -138,7 +138,7 @@ func (b *EndpointBuilder) EndpointsByNetworkFilter(endpoints []*LocalityEndpoint
 			healthStatus := core.HealthStatus_UNHEALTHY
 			epHealthStatus := model.UnHealthy
 
-			if gatewayHealth[gw] {
+			if _, healthy := gatewayHealth[gw]; healthy {
 				healthStatus = core.HealthStatus_HEALTHY
 				epHealthStatus = model.Healthy
 			}

--- a/releasenotes/notes/network-gateway-unhealthy-eds.yaml
+++ b/releasenotes/notes/network-gateway-unhealthy-eds.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: networking
+releaseNotes:
+- |
+  **Fixed** an issue when Envoy could send traffic to unready endpoints on a remote network in
+  a multi-network configuration if PILOT_SEND_UNHEALTHY_ENDPOINTS is enabled and all endpoints
+  in a remote network are unready.

--- a/releasenotes/notes/network-gateway-unhealthy-eds.yaml
+++ b/releasenotes/notes/network-gateway-unhealthy-eds.yaml
@@ -1,6 +1,6 @@
 apiVersion: release-notes/v2
 kind: bug-fix
-area: networking
+area: traffic-management
 releaseNotes:
 - |
   **Fixed** an issue when Envoy could send traffic to unready endpoints on a remote network in


### PR DESCRIPTION
**Please provide a description of this PR:**

I have discovered a bug when `PILOT_SEND_UNHEALTHY_ENDPOINTS` is set to `true` and in a multi-cluster, multi-network configuration for a multi-cluster service the cluster endpoints of remote network gateways are neither removed nor marked UNHEALTHY if all endpoints of that service in the respective remote network are UNHEALTHY.

This leads to Envoy sending traffic to unready remote pods if e.g. the locality failover is disabled or set to distribute or local pods of that service are also all unready. It also obviously breaks the contract of Kubernetes of not sending traffic to unready  pods under those conditions.

The current implementation of the split horizon EDS filter is not aware of the SendUnhealthyEndpoints feature and does not handle the case when all endpoints for a service in a remote network are unhealthy. I suppose the proper behavior would be marking the remote gateway endpoints unhealthy if all endpoints in that network are unhealthy.

This patch implements the corresponding fix.