### PR TITLE
Fix PushContext.sidecarIndex.rootConfig flipping issue

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -1352,7 +1352,11 @@ func (ps *PushContext) updateContext(
 			return err
 		}
 	} else {
-		ps.sidecarIndex.sidecarsByNamespace = oldPushContext.sidecarIndex.sidecarsByNamespace
+		// new ADS connection may insert new entry to computedSidecarsByNamespace/gatewayDefaultSidecarsByNamespace
+		oldPushContext.sidecarIndex.defaultSidecarMu.Lock()
+		defer oldPushContext.sidecarIndex.defaultSidecarMu.Unlock()
+
+		ps.sidecarIndex = oldPushContext.sidecarIndex
 	}
 
 	return nil

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -904,6 +904,19 @@ func TestInitPushContext(t *testing.T) {
 			ExportTo: []string{".", "ns1"},
 		},
 	})
+	_, _ = configStore.Create(config.Config{
+		Meta: config.Meta{
+			Name:             "default",
+			Namespace:        "istio-system",
+			GroupVersionKind: gvk.Sidecar,
+		},
+		Spec: &networking.Sidecar{
+			Egress: []*networking.IstioEgressListener{
+				{Hosts: []string{"test1/*"}},
+			},
+		},
+	})
+
 	store := istioConfigStore{ConfigStore: configStore}
 
 	env.ConfigStore = &store


### PR DESCRIPTION
When a PushRequest doesn't have Service/VirtualService/DestinationRule/Sidecar change,
in PushContext.updateContext(), initSidecarScopes() will not be invoked, new PushContext
only copies sidecarIndex.sidecarsByNamespace from old one, sidecarIndex.rootConfig becomes
nil.

When workload namespace doesn't have Sidecar resource, this causes new ADS connection's
SidecarScope being created by DefaultSidecarScopeForNamespace(), the global default
sidecar in istio root namespace is not respected.