### PR TITLE
added new TCP based test for deny policies

### DIFF
--- a/tests/integration/security/testdata/authz/tcp-L7-rule.yaml.tmpl
+++ b/tests/integration/security/testdata/authz/tcp-L7-rule.yaml.tmpl
@@ -1,0 +1,17 @@
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: {{ .To.ServiceName }}
+spec:
+  selector:
+    matchLabels:
+      "app": "{{ .To.ServiceName }}"
+  action: DENY
+  rules:
+    - to:
+        - operation: # HTTP L7 only rule
+            methods: [ "GET" ]
+    - to:
+        - operation: # HTTP and TCP
+            methods: [ "GET" ]
+            ports: [ "9000" ]

--- a/tests/integration/security/testdata/authz/tcp-mixed-rule.yaml.tmpl
+++ b/tests/integration/security/testdata/authz/tcp-mixed-rule.yaml.tmpl
@@ -1,0 +1,14 @@
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: {{ .To.ServiceName }}
+spec:
+  selector:
+    matchLabels:
+      "app": "{{ .To.ServiceName }}"
+  action: DENY
+  rules:
+    - to:
+        - operation: # HTTP and TCP
+            methods: [ "GET" ]
+            ports: [ "9000" ]


### PR DESCRIPTION
**Behavior of deny policies on TCP Ports in the following scenarios**
1) When we have any L7 rule (only http attributes)
2) When we don't have a pure L7 rule i.e. mixed rule (L7 + L4)