### PR TITLE
add help output for gen-helloworld

### DIFF
--- a/samples/helloworld/README.md
+++ b/samples/helloworld/README.md
@@ -40,6 +40,7 @@ arguments:
 
 Argument | Default | Description
 -------- | ------- | -----------
+`-h`,`--help` | | Prints usage information.
 `--version` | `v1` | Specifies the version that will be returned by the helloworld service.
 `--includeService` | `true` | If `true` the service will be included in the YAML.
 `--includeDeployment` | `true` | If `true` the deployment will be included in the YAML.

--- a/samples/helloworld/gen-helloworld.sh
+++ b/samples/helloworld/gen-helloworld.sh
@@ -16,11 +16,25 @@
 
 set -euo pipefail
 
+display_usage() {
+    echo
+    echo "USAGE: ./gen-helloworld.sh [--version] [--includeService value] [--includeDeployment value]"
+    echo "    -h|--help: Prints usage information"
+    echo "    --version: Specifies the version that will be returned by the helloworld service, default: 'v1'"
+    echo "    --includeService: If 'true' the service will be included in the YAML, default: 'true'"
+    echo "    --includeDeployment: If 'true' the deployment will be included in the YAML, default: 'true'"
+    exit 1
+}
+
 INCLUDE_SERVICE=${INCLUDE_SERVICE:-"true"}
 INCLUDE_DEPLOYMENT=${INCLUDE_DEPLOYMENT:-"true"}
 SERVICE_VERSION=${SERVICE_VERSION:-"v1"}
 while (( "$#" )); do
   case "$1" in
+    -h|--help)
+      display_usage
+      ;;
+
     --version)
       SERVICE_VERSION=$2
       shift 2
@@ -38,7 +52,7 @@ while (( "$#" )); do
 
     *)
       echo "Error: Unsupported flag $1" >&2
-      exit 1
+      display_usage
       ;;
   esac
 done


### PR DESCRIPTION
**Please provide a description of this PR:**
Add help output for gen-helloworld

The test result:
```shell
 $ ./gen-helloworld.sh -h

USAGE: ./gen-helloworld.sh [--version] [--includeService value] [--includeDeployment value]
    -h|--help: Prints usage information
    --version: Specifies the version that will be returned by the helloworld service, default: 'v1'
    --includeService: If 'true' the service will be included in the YAML, default: 'true'
    --includeDeployment: If 'true' the deployment will be included in the YAML, default: 'true'
```