### PR TITLE
Add PodDisruptionBudget to gateway chart

### DIFF
--- a/manifests/charts/gateway/templates/poddisruptionbudget.yaml
+++ b/manifests/charts/gateway/templates/poddisruptionbudget.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+{{- if (semverCompare ">=1.21-0" .Capabilities.KubeVersion.GitVersion) }}
+apiVersion: policy/v1
+{{- else }}
+apiVersion: policy/v1beta1
+{{- end }}
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "gateway.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "gateway.labels" . | nindent 4 }}
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      {{- include "gateway.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/manifests/charts/gateway/values.schema.json
+++ b/manifests/charts/gateway/values.schema.json
@@ -45,6 +45,14 @@
         }
       }
     },
+    "podDisruptionBudget": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      }
+    },
     "env": {
       "type": "object"
     },

--- a/manifests/charts/gateway/values.yaml
+++ b/manifests/charts/gateway/values.yaml
@@ -70,6 +70,10 @@ autoscaling:
   maxReplicas: 5
   targetCPUUtilizationPercentage: 80
 
+# pod disruption budget which is used to ensure that the gateway are gradually upgraded or recovered
+podDisruptionBudget:
+  enabled: false
+
 # Pod environment variables
 env: {}
 


### PR DESCRIPTION
**Please provide a description of this PR:**

Adding the `PodDisruptionBudget` manifest to the `gateway` chart. We already have it in the old gateways chart.