### PR TITLE
`istioctl x proxy-status` via istio agents.

### DIFF
--- a/istioctl/cmd/internal-debug.go
+++ b/istioctl/cmd/internal-debug.go
@@ -43,7 +43,7 @@ func HandlerForRetrieveDebugList(kubeClient kube.CLIClient,
 		TypeUrl: v3.DebugType,
 	}
 	xdsResponses, respErr := multixds.AllRequestAndProcessXds(&xdsRequest, centralOpts, istioNamespace,
-		namespace, serviceAccount, kubeClient)
+		namespace, serviceAccount, kubeClient, multixds.DefaultOptions)
 	if respErr != nil {
 		return xdsResponses, respErr
 	}
@@ -133,7 +133,7 @@ By default it will use the default serviceAccount from (istio-system) namespace 
 			}
 
 			xdsResponses, err := multixds.MultiRequestAndProcessXds(internalDebugAllIstiod, &xdsRequest, centralOpts, istioNamespace,
-				namespace, serviceAccount, kubeClient)
+				namespace, serviceAccount, kubeClient, multixds.DefaultOptions)
 			if err != nil {
 				return err
 			}

--- a/istioctl/cmd/proxystatus.go
+++ b/istioctl/cmd/proxystatus.go
@@ -227,7 +227,6 @@ Retrieves last sent and last acknowledged xDS sync from Istiod to each Envoy in 
 				}
 				return c.Diff()
 			}
-
 			xdsRequest := xdsapi.DiscoveryRequest{
 				TypeUrl: pilotxds.TypeDebugSyncronization,
 			}
@@ -244,6 +243,8 @@ Retrieves last sent and last acknowledged xDS sync from Istiod to each Envoy in 
 	centralOpts.AttachControlPlaneFlags(statusCmd)
 	statusCmd.PersistentFlags().StringVarP(&configDumpFile, "file", "f", "",
 		"Envoy config dump JSON file")
+	statusCmd.PersistentFlags().BoolVar(&centralOpts.XdsViaAgents, "xds-via-agents", false,
+		"Access Istiod via the tap service of each agent.")
 
 	return statusCmd
 }

--- a/istioctl/cmd/proxystatus.go
+++ b/istioctl/cmd/proxystatus.go
@@ -244,7 +244,10 @@ Retrieves last sent and last acknowledged xDS sync from Istiod to each Envoy in 
 	statusCmd.PersistentFlags().StringVarP(&configDumpFile, "file", "f", "",
 		"Envoy config dump JSON file")
 	statusCmd.PersistentFlags().BoolVar(&centralOpts.XdsViaAgents, "xds-via-agents", false,
-		"Access Istiod via the tap service of each agent.")
+		"Access Istiod via the tap service of each agent")
+	statusCmd.PersistentFlags().IntVar(&centralOpts.XdsViaAgentsLimit, "xds-via-agents-limit", 100,
+		"Maximum number of pods being visited by istioctl when `xds-via-agent` flag is true."+
+			"To iterate all the agent pods without limit, set to 0")
 
 	return statusCmd
 }

--- a/istioctl/cmd/proxystatus.go
+++ b/istioctl/cmd/proxystatus.go
@@ -157,6 +157,7 @@ func newKubeClient(kubeconfig, configContext string) (kube.CLIClient, error) {
 func xdsStatusCommand() *cobra.Command {
 	var opts clioptions.ControlPlaneOptions
 	var centralOpts clioptions.CentralControlPlaneOptions
+	var multiXdsOpts multixds.Options
 
 	statusCmd := &cobra.Command{
 		Use:   "proxy-status [<type>/]<name>[.<namespace>]",
@@ -194,6 +195,7 @@ Retrieves last sent and last acknowledged xDS sync from Istiod to each Envoy in 
 			if err != nil {
 				return err
 			}
+			multiXdsOpts.MessageWriter = c.OutOrStdout()
 
 			if len(args) > 0 {
 				podName, ns, err := handlers.InferPodInfoFromTypedResource(args[0],
@@ -217,7 +219,7 @@ Retrieves last sent and last acknowledged xDS sync from Istiod to each Envoy in 
 					ResourceNames: []string{fmt.Sprintf("%s.%s", podName, ns)},
 					TypeUrl:       pilotxds.TypeDebugConfigDump,
 				}
-				xdsResponses, err := multixds.FirstRequestAndProcessXds(&xdsRequest, centralOpts, istioNamespace, "", "", kubeClient)
+				xdsResponses, err := multixds.FirstRequestAndProcessXds(&xdsRequest, centralOpts, istioNamespace, "", "", kubeClient, multiXdsOpts)
 				if err != nil {
 					return err
 				}
@@ -230,7 +232,7 @@ Retrieves last sent and last acknowledged xDS sync from Istiod to each Envoy in 
 			xdsRequest := xdsapi.DiscoveryRequest{
 				TypeUrl: pilotxds.TypeDebugSyncronization,
 			}
-			xdsResponses, err := multixds.AllRequestAndProcessXds(&xdsRequest, centralOpts, istioNamespace, "", "", kubeClient)
+			xdsResponses, err := multixds.AllRequestAndProcessXds(&xdsRequest, centralOpts, istioNamespace, "", "", kubeClient, multiXdsOpts)
 			if err != nil {
 				return err
 			}
@@ -243,9 +245,9 @@ Retrieves last sent and last acknowledged xDS sync from Istiod to each Envoy in 
 	centralOpts.AttachControlPlaneFlags(statusCmd)
 	statusCmd.PersistentFlags().StringVarP(&configDumpFile, "file", "f", "",
 		"Envoy config dump JSON file")
-	statusCmd.PersistentFlags().BoolVar(&centralOpts.XdsViaAgents, "xds-via-agents", false,
+	statusCmd.PersistentFlags().BoolVar(&multiXdsOpts.XdsViaAgents, "xds-via-agents", false,
 		"Access Istiod via the tap service of each agent")
-	statusCmd.PersistentFlags().IntVar(&centralOpts.XdsViaAgentsLimit, "xds-via-agents-limit", 100,
+	statusCmd.PersistentFlags().IntVar(&multiXdsOpts.XdsViaAgentsLimit, "xds-via-agents-limit", 100,
 		"Maximum number of pods being visited by istioctl when `xds-via-agent` flag is true."+
 			"To iterate all the agent pods without limit, set to 0")
 

--- a/istioctl/pkg/clioptions/central.go
+++ b/istioctl/pkg/clioptions/central.go
@@ -58,6 +58,11 @@ type CentralControlPlaneOptions struct {
 	// XdsViaAgents accesses Istiod via the tap service of each agent.
 	// This is only used in `proxy-status` command.
 	XdsViaAgents bool
+
+	// XdsViaAgentsLimit is the maximum number of pods being visited by istioctl,
+	// when `XdsViaAgents` is true. This is only used in `proxy-status` command.
+	// 0 means that there is no limit.
+	XdsViaAgentsLimit int
 }
 
 // AttachControlPlaneFlags attaches control-plane flags to a Cobra command.

--- a/istioctl/pkg/clioptions/central.go
+++ b/istioctl/pkg/clioptions/central.go
@@ -54,6 +54,10 @@ type CentralControlPlaneOptions struct {
 
 	// Istiod address. For MCP may be different than Xds.
 	IstiodAddr string
+
+	// XdsViaAgents accesses Istiod via the tap service of each agent.
+	// This is only used in `proxy-status` command.
+	XdsViaAgents bool
 }
 
 // AttachControlPlaneFlags attaches control-plane flags to a Cobra command.

--- a/istioctl/pkg/clioptions/central.go
+++ b/istioctl/pkg/clioptions/central.go
@@ -54,15 +54,6 @@ type CentralControlPlaneOptions struct {
 
 	// Istiod address. For MCP may be different than Xds.
 	IstiodAddr string
-
-	// XdsViaAgents accesses Istiod via the tap service of each agent.
-	// This is only used in `proxy-status` command.
-	XdsViaAgents bool
-
-	// XdsViaAgentsLimit is the maximum number of pods being visited by istioctl,
-	// when `XdsViaAgents` is true. This is only used in `proxy-status` command.
-	// 0 means that there is no limit.
-	XdsViaAgentsLimit int
 }
 
 // AttachControlPlaneFlags attaches control-plane flags to a Cobra command.

--- a/istioctl/pkg/multixds/gather.go
+++ b/istioctl/pkg/multixds/gather.go
@@ -75,7 +75,7 @@ func queryEachShard(all bool, dr *xdsapi.DiscoveryRequest, istioNamespace string
 	}
 	pods, err := kubeClient.GetIstioPods(context.TODO(), istioNamespace, map[string]string{
 		"labelSelector": labelSelector,
-		"fieldSelector": "status.phase=Running",
+		"fieldSelector": kube.RunningStatus,
 	})
 	if err != nil {
 		return nil, err

--- a/istioctl/pkg/multixds/gather.go
+++ b/istioctl/pkg/multixds/gather.go
@@ -94,6 +94,7 @@ func queryEachShard(all bool, dr *xdsapi.DiscoveryRequest, istioNamespace string
 	if err != nil {
 		return nil, err
 	}
+
 	for _, pod := range pods {
 		fw, err := kubeClient.NewPortForwarder(pod.Name, pod.Namespace, "localhost", 0, centralOpts.XdsPodPort)
 		if err != nil {
@@ -123,7 +124,8 @@ func queryEachShard(all bool, dr *xdsapi.DiscoveryRequest, istioNamespace string
 // If `all` is true, `queryDebugSynczViaAgents` iterates all the pod having a proxy
 // except the pods of which status information is already queried.
 func queryDebugSynczViaAgents(all bool, dr *xdsapi.DiscoveryRequest, istioNamespace string, kubeClient kube.CLIClient,
-	centralOpts clioptions.CentralControlPlaneOptions) ([]*xdsapi.DiscoveryResponse, error) {
+	centralOpts clioptions.CentralControlPlaneOptions,
+) ([]*xdsapi.DiscoveryResponse, error) {
 	xdsOpts := clioptions.CentralControlPlaneOptions{
 		XDSSAN:  makeSan(istioNamespace, kubeClient.Revision()),
 		CertDir: centralOpts.CertDir,

--- a/istioctl/pkg/multixds/gather.go
+++ b/istioctl/pkg/multixds/gather.go
@@ -122,7 +122,8 @@ func queryEachShard(all bool, dr *xdsapi.DiscoveryRequest, istioNamespace string
 // `istioctl` can access the debug endpoint.
 // If `all` is true, `queryDebugSynczViaAgents` iterates all the pod having a proxy
 // except the pods of which status information is already queried.
-func queryDebugSynczViaAgents(all bool, dr *xdsapi.DiscoveryRequest, istioNamespace string, kubeClient kube.CLIClient, centralOpts clioptions.CentralControlPlaneOptions) ([]*xdsapi.DiscoveryResponse, error) {
+func queryDebugSynczViaAgents(all bool, dr *xdsapi.DiscoveryRequest, istioNamespace string, kubeClient kube.CLIClient,
+	centralOpts clioptions.CentralControlPlaneOptions) ([]*xdsapi.DiscoveryResponse, error) {
 	xdsOpts := clioptions.CentralControlPlaneOptions{
 		XDSSAN:  makeSan(istioNamespace, kubeClient.Revision()),
 		CertDir: centralOpts.CertDir,
@@ -310,8 +311,10 @@ func MultiRequestAndProcessXds(all bool, dr *xdsapi.DiscoveryRequest, centralOpt
 		}, nil
 	}
 
-	var responses []*xdsapi.DiscoveryResponse
-	var err error
+	var (
+		responses []*xdsapi.DiscoveryResponse
+		err       error
+	)
 
 	if centralOpts.XdsViaAgents {
 		responses, err = queryDebugSynczViaAgents(all, dr, istioNamespace, kubeClient, centralOpts)

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -908,7 +908,7 @@ func (c *client) GetProxyPods(ctx context.Context, limit int64, token string) (*
 		opts.LabelSelector = fmt.Sprintf("%s,%s=%s", label.ServiceCanonicalName.Name, label.IoIstioRev.Name, c.revision)
 	}
 	// get pods from all the namespaces.
-	list, err := c.kube.CoreV1().Pods("").List(ctx, opts)
+	list, err := c.kube.CoreV1().Pods(metav1.NamespaceAll).List(ctx, opts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get the pod list: %v", err)
 	}

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"os"
 	"reflect"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -177,6 +178,9 @@ type CLIClient interface {
 
 	// GetIstioPods retrieves the pod objects for Istio deployments
 	GetIstioPods(ctx context.Context, namespace string, params map[string]string) ([]v1.Pod, error)
+
+	// GetProxyPods retrieves all the proxy pod objects: sidecar injected pods and gateway pods.
+	GetProxyPods(ctx context.Context, limit int, token string) (*v1.PodList, error)
 
 	// PodExecCommands takes a list of commands and the pod data to run the commands in the specified pod.
 	PodExecCommands(podName, podNamespace, container string, commands []string) (stdout string, stderr string, err error)
@@ -892,6 +896,39 @@ func (c *client) GetIstioVersions(ctx context.Context, namespace string) (*versi
 		}
 	}
 	return &res, errs
+}
+
+func (c *client) GetProxyPods(ctx context.Context, limit int, token string) (*v1.PodList, error) {
+	params := make(map[string]string)
+	if c.revision != "" {
+		params["labelSelector"] = fmt.Sprintf("%s,%s=%s", label.ServiceCanonicalName.Name, label.IoIstioRev.Name, c.revision)
+	} else {
+		params["labelSelector"] = label.ServiceCanonicalName.Name
+	}
+	params["fieldSelector"] = "status.phase=Running"
+	// At this moment, just using a fixed limit.
+	params["limit"] = strconv.Itoa(limit)
+	if len(token) > 0 {
+		params["continue"] = token
+	}
+
+	req := c.restClient.Get().
+		Resource("pods")
+	for k, v := range params {
+		req.Param(k, v)
+	}
+
+	res := req.Do(ctx)
+	if res.Error() != nil {
+		return nil, fmt.Errorf("unable to retrieve Pods: %v", res.Error())
+	}
+
+	list := &v1.PodList{}
+	if err := res.Into(list); err != nil {
+		return nil, fmt.Errorf("unable to parse PodList: %v", res.Error())
+	}
+
+	return list, nil
 }
 
 func (c *client) getIstioVersionUsingExec(pod *v1.Pod) (*version.BuildInfo, error) {

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -96,6 +96,7 @@ import (
 const (
 	defaultLocalAddress = "localhost"
 	fieldManager        = "istio-kube-client"
+	RunningStatus       = "status.phase=Running"
 )
 
 // Client is a helper for common Kubernetes client operations. This contains various different kubernetes
@@ -761,7 +762,7 @@ func (c *client) PodLogs(ctx context.Context, podName, podNamespace, container s
 func (c *client) AllDiscoveryDo(ctx context.Context, istiodNamespace, path string) (map[string][]byte, error) {
 	istiods, err := c.GetIstioPods(ctx, istiodNamespace, map[string]string{
 		"labelSelector": "app=istiod",
-		"fieldSelector": "status.phase=Running",
+		"fieldSelector": RunningStatus,
 	})
 	if err != nil {
 		return nil, err
@@ -856,7 +857,7 @@ func (c *client) GetIstioPods(ctx context.Context, namespace string, params map[
 func (c *client) GetIstioVersions(ctx context.Context, namespace string) (*version.MeshInfo, error) {
 	pods, err := c.GetIstioPods(ctx, namespace, map[string]string{
 		"labelSelector": "app=istiod",
-		"fieldSelector": "status.phase=Running",
+		"fieldSelector": RunningStatus,
 	})
 	if err != nil {
 		return nil, err
@@ -900,7 +901,7 @@ func (c *client) GetIstioVersions(ctx context.Context, namespace string) (*versi
 func (c *client) GetProxyPods(ctx context.Context, limit int64, token string) (*v1.PodList, error) {
 	opts := metav1.ListOptions{
 		LabelSelector: label.ServiceCanonicalName.Name,
-		FieldSelector: "status.phase=Running",
+		FieldSelector: RunningStatus,
 		Limit:         limit,
 		Continue:      token,
 	}

--- a/pkg/kube/mock_client.go
+++ b/pkg/kube/mock_client.go
@@ -256,7 +256,7 @@ func (c MockClient) GetIstioPods(_ context.Context, _ string, _ map[string]strin
 	return nil, fmt.Errorf("TODO MockClient doesn't implement IstioPods")
 }
 
-func (c MockClient) GetProxyPods(ctx context.Context, limit int, token string) (*v1.PodList, error) {
+func (c MockClient) GetProxyPods(ctx context.Context, limit int64, token string) (*v1.PodList, error) {
 	return nil, fmt.Errorf("TODO MockClient doesn't implement GetProxyPods")
 }
 

--- a/pkg/kube/mock_client.go
+++ b/pkg/kube/mock_client.go
@@ -256,6 +256,10 @@ func (c MockClient) GetIstioPods(_ context.Context, _ string, _ map[string]strin
 	return nil, fmt.Errorf("TODO MockClient doesn't implement IstioPods")
 }
 
+func (c MockClient) GetProxyPods(ctx context.Context, limit int, token string) (*v1.PodList, error) {
+	return nil, fmt.Errorf("TODO MockClient doesn't implement GetProxyPods")
+}
+
 func (c MockClient) PodExecCommands(podName, podNamespace, container string, commands []string) (stdout string, stderr string, err error) {
 	return "", "", fmt.Errorf("TODO MockClient doesn't implement exec")
 }


### PR DESCRIPTION
This PR proposes an experimental option `--xds-via-agents` only for `istioctl x proxy-status` command, which sends a query for `istioctl x proxy-status` via istio agents, instead of direct query to `istiod`.

`istioctl x proxy-status` try to find all the istiod instances by searching pods in `istio-system` namespace.
But, if we use the external istiods, this way may not work.

For example, `istiod` can be deployed in the other cluster or out of K8S. Moreover, in front of the istiod instances, some sort of load balancer can be set to distribute the connections to multiple istiods. This kind of configuration may happen when the customer want to isolate their control plane from the workloads, or when they are using some managed control plane.

In such case, `istioctl x proxy-status` cannot enumerate and access to each istiod instance directly. So, this PR proposes to access `istiod` via "istio agent".

Please note that, by https://github.com/istio/istio/pull/40566, we can make a query to istiod via istio agents efficiently.
