### PR TITLE
validate workloadSelector's empty value

### DIFF
--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -775,6 +775,10 @@ func validateAlphaWorkloadSelector(selector *networking.WorkloadSelector) error 
 				errs = appendErrors(errs,
 					fmt.Errorf("empty key is not supported in selector: %q", fmt.Sprintf("%s=%s", k, v)))
 			}
+			if v == "" {
+				errs = appendErrors(errs,
+					fmt.Errorf("empty value is not supported in selector: %q", fmt.Sprintf("%s=%s", k, v)))
+			}
 			if strings.Contains(k, "*") || strings.Contains(v, "*") {
 				errs = appendErrors(errs,
 					fmt.Errorf("wildcard is not supported in selector: %q", fmt.Sprintf("%s=%s", k, v)))


### PR DESCRIPTION
**Please provide a description of this PR:**

This pr is to solve this problem

apply a enovyfilter with workloadSelector in test ns

```
  workloadSelector:
    labels:
      app: ""
```
all labels of pods in test ns are not included "app" labels,

according to the logic of the current code, this enovyfilter will apply to all pods in ns test.

```
// SubsetOf is true if the label has identical values for the keys
func (i Instance) SubsetOf(that Instance) bool {
	if len(i) == 0 {
		return true
	}

	if len(that) == 0 || len(that) < len(i) {
		return false
	}

	for k, v := range i {
		if that[k] != v {
			return false
		}
	}
	return true
}
```

so we should ensure that the value is not empty