### PR TITLE
Fix race-condition with istio-ca-cert creation

### DIFF
--- a/security/pkg/pki/ca/ca.go
+++ b/security/pkg/pki/ca/ca.go
@@ -187,9 +187,8 @@ func NewSelfSignedIstioCAOptions(ctx context.Context,
 			if caSecret, scrtErr = client.Secrets(namespace).Get(context.TODO(), CASecret, metav1.GetOptions{}); scrtErr != nil {
 				pkiCaLog.Errorf("Failed to write secret to CA (error: %s). Abort.", err)
 				return nil, fmt.Errorf("failed to create CA due to secret write error")
-			} else {
-				pkiCaLog.Infof("Secret created by another replica, reusing the same.")
 			}
+			pkiCaLog.Infof("Secret created by another replica, reusing the same.")
 		} else {
 			pkiCaLog.Infof("Using self-generated public key: %v", string(rootCerts))
 		}


### PR DESCRIPTION
When you deploy multiple controller replicas, all of them will try
to create the istio-ca-secret secret if it is not found on the cluster.
A race condition on "if istio-ca-secret not exists -> create" can
lead to all (or a subset) of the replicas to try to create the secret
but only one of them will succeed. The other replicas will fail as the
secret was already written by the one lucky replica and will fail the
readiness probe as a consequence.

Once the readiness fail, the affected replicas are restarted and then they
will boot successfully as the race-condition for the secret creation is no longer there.
This does not seem to be a very severe issue as all the replicas will be
ready after one restart. On the other end it would be nice if Istio did not
restart if it fails in writing a istio-ca-secret which has been created
in the meantime by someone else.

This is the type of message you will find in the discovery containers before the restart has took place:
```
2022-08-24T14:52:05.495464Z info    pkica   Failed to get secret (error: secrets "istio-ca-secret" not found), will create one
2022-08-24T14:52:10.722863Z error   pkica   Failed to write secret to CA (error: secrets "istio-ca-secret" already exists). Abort.Error: failed to create discovery service: failed to create CA: failed to create a self-signed istiod CA: failed to create CA due to secret write error
```
The issue can be reproduced by the below steps:

LOOP UNTIL RESTART OF ONE REPLICA:
    $helm install istiod istio/istiod -n istio-system --set pilot.replicaCount=2 --set pilot.autoscaleEnabled=false --create-namespace 
    $helm uninstall istiod -n istio-system
    $kubectl delete ns istio-system

Signed-off-by: Faseela K <faseela.k@est.tech>