### PR TITLE
do not complain about conflict if service instance ports are same

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -1317,6 +1317,11 @@ func (c *Controller) getProxyServiceInstancesByPod(pod *v1.Pod,
 	var out []*model.ServiceInstance
 
 	for _, svc := range c.servicesForNamespacedName(kube.NamespacedNameForK8sObject(service)) {
+		// Check if service is visible. Service can be invisible if exportTo is set to '~' for example.
+		// We should consider service instances that are only visible to pod.
+		if proxy.LastPushContext != nil && !proxy.LastPushContext.IsServiceVisible(svc, pod.Namespace) {
+			continue
+		}
 		discoverabilityPolicy := c.exports.EndpointDiscoverabilityPolicy(svc)
 
 		tps := make(map[model.Port]*model.Port)

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -1317,11 +1317,6 @@ func (c *Controller) getProxyServiceInstancesByPod(pod *v1.Pod,
 	var out []*model.ServiceInstance
 
 	for _, svc := range c.servicesForNamespacedName(kube.NamespacedNameForK8sObject(service)) {
-		// Check if service is visible. Service can be invisible if exportTo is set to '~' for example.
-		// We should consider service instances that are only visible to pod.
-		if proxy.LastPushContext != nil && !proxy.LastPushContext.IsServiceVisible(svc, pod.Namespace) {
-			continue
-		}
 		discoverabilityPolicy := c.exports.EndpointDiscoverabilityPolicy(svc)
 
 		tps := make(map[model.Port]*model.Port)


### PR DESCRIPTION
Service Instance creation does not consider visibility rules of service.

We have a two services in the same namespace, one is the actual service and other is created for [external ips](https://kubernetes.io/docs/concepts/services-networking/service/#external-ips) using same selector for providing access outside of cluster by some other tools. In this case, Istio complains of inbound listener conflict because it sees two service instances.

This PR reuses the same service instance port (existing behaviour) instead of complaining (new behaviour - skips reporting conflict in this case).

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
