### PR TITLE
Move Fake test helpers out of core packages

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
@@ -51,6 +51,7 @@ import (
 	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/security"
 	"istio.io/istio/pkg/test"
+	"istio.io/istio/pkg/test/configgen"
 	"istio.io/istio/pkg/test/util/assert"
 )
 
@@ -507,12 +508,12 @@ func TestApplyDestinationRule(t *testing.T) {
 					Spec: tt.destRule,
 				}
 			}
-			cg := NewConfigGenTest(t, TestOptions{
+			cg := configgen.New(t, configgen.TestOptions{
 				Instances:      instances,
 				ConfigPointers: []*config.Config{cfg},
 				Services:       []*model.Service{tt.service},
 			})
-			cg.MemRegistry.WantGetProxyServiceInstances = instances
+			cg.MemRegistry().WantGetProxyServiceInstances = instances
 			proxy := cg.SetupProxy(nil)
 			cb := NewClusterBuilder(proxy, &model.PushRequest{Push: cg.PushContext()}, nil)
 

--- a/pilot/pkg/networking/core/v1alpha3/load_configgen_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/load_configgen_test.go
@@ -1,0 +1,5 @@
+package v1alpha3_test
+
+import (
+	_ "istio.io/istio/pkg/test/configgen/impl"
+)

--- a/pkg/test/configgen/fake.go
+++ b/pkg/test/configgen/fake.go
@@ -1,0 +1,103 @@
+package configgen
+
+import (
+	"sync"
+
+	cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+
+	meshconfig "istio.io/api/mesh/v1alpha1"
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/serviceregistry"
+	memregistry "istio.io/istio/pilot/pkg/serviceregistry/memory"
+	cluster2 "istio.io/istio/pkg/cluster"
+	"istio.io/istio/pkg/config"
+	"istio.io/istio/pkg/config/mesh"
+	"istio.io/istio/pkg/test"
+)
+
+type TestOptions struct {
+	// If provided, these configs will be used directly
+	Configs        []config.Config
+	ConfigPointers []*config.Config
+
+	// If provided, the yaml string will be parsed and used as configs
+	ConfigString string
+	// If provided, the ConfigString will be treated as a go template, with this as input params
+	ConfigTemplateInput any
+
+	// Services to pre-populate as part of the service discovery
+	Services  []*model.Service
+	Instances []*model.ServiceInstance
+	Gateways  []model.NetworkGateway
+
+	// If provided, this mesh config will be used
+	MeshConfig      *meshconfig.MeshConfig
+	NetworksWatcher mesh.NetworksWatcher
+
+	// Additional service registries to use. A ServiceEntry and memory registry will always be created.
+	ServiceRegistries []serviceregistry.Instance
+
+	// Additional ConfigStoreController to use
+	ConfigStoreCaches []model.ConfigStoreController
+
+	// CreateConfigStore defines a function that, given a ConfigStoreController, returns another ConfigStoreController to use
+	CreateConfigStore func(c model.ConfigStoreController) model.ConfigStoreController
+
+	// Mutex used for push context access. Should generally only be used by NewFakeDiscoveryServer
+	PushContextLock *sync.RWMutex
+
+	// If set, we will not run immediately, allowing adding event handlers, etc prior to start.
+	SkipRun bool
+
+	// Used to set the serviceentry registry's cluster id
+	ClusterID cluster2.ID
+}
+
+func (to TestOptions) FuzzValidate() bool {
+	for _, csc := range to.ConfigStoreCaches {
+		if csc == nil {
+			return false
+		}
+	}
+	for _, sr := range to.ServiceRegistries {
+		if sr == nil {
+			return false
+		}
+	}
+	return true
+}
+
+type Factory = func(t test.Failer, to TestOptions) ConfigGenTest
+
+type ConfigGenTest interface {
+	Run()
+	SetupProxy(p *model.Proxy) *model.Proxy
+	Listeners(p *model.Proxy) []*listener.Listener
+	Clusters(p *model.Proxy) []*cluster.Cluster
+	DeltaClusters(
+		p *model.Proxy,
+		configUpdated map[model.ConfigKey]struct{},
+		watched *model.WatchedResource,
+	) ([]*cluster.Cluster, []string, bool)
+	RoutesFromListeners(p *model.Proxy, l []*listener.Listener) []*route.RouteConfiguration
+	Routes(p *model.Proxy) []*route.RouteConfiguration
+	PushContext() *model.PushContext
+	Env() *model.Environment
+	Store() model.ConfigStoreController
+	MemRegistry() *memregistry.ServiceDiscovery
+}
+
+var impl Factory
+
+func SetFactory(f Factory) {
+	if impl != nil {
+		panic("multiple factories set")
+	}
+	impl = f
+}
+
+func New(t test.Failer, options TestOptions) ConfigGenTest {
+	return impl(t, options)
+}


### PR DESCRIPTION
Currently, we have our test fakes in our real core packages. This
introduces unnecesary bloat into production binaries - a non trivial
amount in some cases; with some series of changes including this one we
could drop 5mb of the agent binary size.

However, we cannot simply move this to another package. We have tests in
`v1alpha3` that depend on the Fake, and the Fake depends on `v1alpha3` -
we get a cycle. The simple fix would be to move all tests to
`v1alpha3_test` package, but that isn't viable.

Instead, we implement
https://www.cockroachlabs.com/blog/outsmarting-go-dependencies-testing-code/

**Please provide a description of this PR:**