### PR TITLE
add support for skipping server header

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -344,11 +344,15 @@ var (
 		" Pilot will use to keep configuration status up to date.  Smaller numbers will result in higher status latency, "+
 		"but larger numbers may impact CPU in high scale environments.").Get()
 
-	// IstiodServiceCustomHost allow user to bring a custom address or multiple custom addresses for istiod server
+	// IstiodServiceCustomHost allows user to bring a custom address or multiple custom addresses for istiod server
 	// for examples: 1. istiod.mycompany.com  2. istiod.mycompany.com,istiod-canary.mycompany.com
 	IstiodServiceCustomHost = env.RegisterStringVar("ISTIOD_CUSTOM_HOST", "",
 		"Custom host name of istiod that istiod signs the server cert. "+
 			"Multiple custom host names are supported, and multiple values are separated by commas.").Get()
+
+	// IstiodServerHeader allows users to specify/skip server header.
+	IstiodServerHeader = env.Register("ISTIOD_SERVER_HEADER", "istio-envoy",
+		"Server header value to be used. If it is empty, server header is not set and returned in the response headers").Get()
 
 	PilotCertProvider = env.RegisterStringVar("PILOT_CERT_PROVIDER", constants.CertProviderIstiod,
 		"The provider of Pilot DNS certificate.").Get()

--- a/pilot/pkg/networking/core/v1alpha3/accesslog.go
+++ b/pilot/pkg/networking/core/v1alpha3/accesslog.go
@@ -34,9 +34,6 @@ import (
 )
 
 const (
-	// EnvoyServerName for istio's envoy
-	EnvoyServerName = "istio-envoy"
-
 	celFilter                          = "envoy.access_loggers.extension_filters.cel"
 	listenerEnvoyAccessLogFriendlyName = "listener_envoy_accesslog"
 

--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -640,9 +640,13 @@ func buildGatewayConnectionManager(proxyConfig *meshconfig.ProxyConfig, node *mo
 			Uri:     true,
 			Dns:     true,
 		},
-		ServerName:          EnvoyServerName,
 		HttpProtocolOptions: httpProtoOpts,
 		StripPortMode:       stripPortMode,
+	}
+	if len(features.IstiodServerHeader) > 0 {
+		httpConnManager.ServerName = features.IstiodServerHeader
+	} else {
+		httpConnManager.ServerHeaderTransformation = hcm.HttpConnectionManager_PASS_THROUGH
 	}
 	if http3SupportEnabled {
 		httpConnManager.Http3ProtocolOptions = &core.Http3ProtocolOptions{}

--- a/pilot/pkg/networking/core/v1alpha3/listener_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_builder.go
@@ -317,6 +317,12 @@ func (lb *ListenerBuilder) buildHTTPConnectionManager(httpOpts *httpListenerOpts
 		connectionManager.UseRemoteAddress = proto.BoolFalse
 	}
 
+	if len(features.IstiodServerHeader) > 0 {
+		httpOpts.connectionManager.ServerName = features.IstiodServerHeader
+	} else {
+		httpOpts.connectionManager.ServerHeaderTransformation = hcm.HttpConnectionManager_PASS_THROUGH
+	}
+
 	// Allow websocket upgrades
 	websocketUpgrade := &hcm.HttpConnectionManager_UpgradeConfig{UpgradeType: "websocket"}
 	connectionManager.UpgradeConfigs = []*hcm.HttpConnectionManager_UpgradeConfig{websocketUpgrade}

--- a/pilot/pkg/networking/core/v1alpha3/listener_inbound.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_inbound.go
@@ -643,11 +643,15 @@ func buildSidecarInboundHTTPOpts(lb *ListenerBuilder, cc inboundChainConfig) *ht
 				Uri:     true,
 				Dns:     true,
 			},
-			ServerName: EnvoyServerName,
 		},
 		protocol:   cc.port.Protocol,
 		class:      istionetworking.ListenerClassSidecarInbound,
 		statPrefix: cc.StatPrefix(),
+	}
+	if len(features.IstiodServerHeader) > 0 {
+		httpOpts.connectionManager.ServerName = features.IstiodServerHeader
+	} else {
+		httpOpts.connectionManager.ServerHeaderTransformation = hcm.HttpConnectionManager_PASS_THROUGH
 	}
 	// See https://github.com/grpc/grpc-web/tree/master/net/grpc/gateway/examples/helloworld#configure-the-proxy
 	if cc.port.Protocol.IsHTTP2() {

--- a/releasenotes/notes/13861.yaml
+++ b/releasenotes/notes/13861.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+issue:
+  - 13861
+
+releaseNotes:
+- |
+  **Added** support for specifying server header via Istiod environment variable ISTIOD_SERVER_HEADER.
+  If set empty, server header will not be generated in response headers.


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/13861. As discussed in the issue, we want to default the ServerHeaderTransformation to 'PASSTHROUGH'. However for BC, added env var so that people can specify empty. We can change the default in future releases.

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure