### PR TITLE
[For-testing-purpose-only, do-not-review] Ignore L7 deny authz policy on tcp ports

### DIFF
--- a/pilot/pkg/security/authz/builder/testdata/tcp/custom-both-http-tcp-out1.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/tcp/custom-both-http-tcp-out1.yaml
@@ -4,15 +4,6 @@ typedConfig:
   shadowRules:
     action: DENY
     policies:
-      istio-ext-authz-ns[foo]-policy[httpbin-deny]-rule[0]:
-        permissions:
-        - andRules:
-            rules:
-            - any: true
-        principals:
-        - andIds:
-            ids:
-            - any: true
       istio-ext-authz-ns[foo]-policy[httpbin-deny]-rule[1]:
         permissions:
         - andRules:
@@ -41,15 +32,6 @@ typedConfig:
                 - directRemoteIp:
                     addressPrefix: 1.2.3.4
                     prefixLen: 32
-      istio-ext-authz-ns[foo]-policy[httpbin-deny]-rule[3]:
-        permissions:
-        - andRules:
-            rules:
-            - any: true
-        principals:
-        - andIds:
-            ids:
-            - any: true
       istio-ext-authz-ns[foo]-policy[httpbin-deny]-rule[4]:
         permissions:
         - andRules:

--- a/pilot/pkg/security/authz/builder/testdata/tcp/deny-both-http-tcp-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/tcp/deny-both-http-tcp-out.yaml
@@ -4,33 +4,6 @@ typedConfig:
   rules:
     action: DENY
     policies:
-      ns[foo]-policy[httpbin-deny]-rule[0]:
-        permissions:
-        - andRules:
-            rules:
-            - any: true
-        principals:
-        - andIds:
-            ids:
-            - any: true
-      ns[foo]-policy[httpbin-deny]-rule[1]:
-        permissions:
-        - andRules:
-            rules:
-            - any: true
-        principals:
-        - andIds:
-            ids:
-            - any: true
-      ns[foo]-policy[httpbin-deny]-rule[2]:
-        permissions:
-        - andRules:
-            rules:
-            - any: true
-        principals:
-        - andIds:
-            ids:
-            - any: true
       ns[foo]-policy[httpbin-deny]-rule[3]:
         permissions:
         - andRules:
@@ -102,15 +75,6 @@ typedConfig:
                       safeRegex:
                         googleRe2: {}
                         regex: .*/ns/ns-1/.*
-      ns[foo]-policy[httpbin-deny]-rule[8]:
-        permissions:
-        - andRules:
-            rules:
-            - any: true
-        principals:
-        - andIds:
-            ids:
-            - any: true
       ns[foo]-policy[httpbin-deny]-rule[9]:
         permissions:
         - andRules:


### PR DESCRIPTION
**Whenever port is considered  as TCP and authz deny policy has just http attributes, no need to apply this kind of policy on tcp ports. This is a test PR, no reviews required at this point**