### PR TITLE
Revert "remove feature flags for se selecting pods (#37374)"

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -411,6 +411,10 @@ var (
 		"If enabled, service entries with selectors will select pods from the cluster. "+
 			"It is safe to disable it if you are quite sure you don't need this feature").Get()
 
+	EnableK8SServiceSelectWorkloadEntries = env.RegisterBoolVar("PILOT_ENABLE_K8S_SELECT_WORKLOAD_ENTRIES", true,
+		"If enabled, Kubernetes services with selectors will select workload entries with matching labels. "+
+			"It is safe to disable it if you are quite sure you don't need this feature").Get()
+
 	InjectionWebhookConfigName = env.RegisterStringVar("INJECTION_WEBHOOK_CONFIG_NAME", "istio-sidecar-injector",
 		"Name of the mutatingwebhookconfiguration to patch, if istioctl is not used.").Get()
 

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -576,9 +576,11 @@ func (c *Controller) addOrUpdateService(svc *v1.Service, svcConv *model.Service,
 	// We also need to update when the Service changes. For Kubernetes, a service change will result in Endpoint updates,
 	// but workload entries will also need to be updated.
 	// TODO(nmittler): Build different sets of endpoints for cluster.local and clusterset.local.
-	endpoints := c.buildEndpointsForService(svcConv, updateEDSCache)
-	if len(endpoints) > 0 {
-		c.opts.XDSUpdater.EDSCacheUpdate(shard, string(svcConv.Hostname), ns, endpoints)
+	if updateEDSCache || features.EnableK8SServiceSelectWorkloadEntries {
+		endpoints := c.buildEndpointsForService(svcConv, updateEDSCache)
+		if len(endpoints) > 0 {
+			c.opts.XDSUpdater.EDSCacheUpdate(shard, string(svcConv.Hostname), ns, endpoints)
+		}
 	}
 
 	c.opts.XDSUpdater.SvcUpdate(shard, string(svcConv.Hostname), ns, event)
@@ -588,8 +590,10 @@ func (c *Controller) addOrUpdateService(svc *v1.Service, svcConv *model.Service,
 
 func (c *Controller) buildEndpointsForService(svc *model.Service, updateCache bool) []*model.IstioEndpoint {
 	endpoints := c.endpoints.buildIstioEndpointsWithService(svc.Attributes.Name, svc.Attributes.Namespace, svc.Hostname, updateCache)
-	fep := c.collectWorkloadInstanceEndpoints(svc)
-	endpoints = append(endpoints, fep...)
+	if features.EnableK8SServiceSelectWorkloadEntries {
+		fep := c.collectWorkloadInstanceEndpoints(svc)
+		endpoints = append(endpoints, fep...)
+	}
 	return endpoints
 }
 

--- a/pilot/pkg/serviceregistry/kube/controller/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller_test.go
@@ -38,6 +38,7 @@ import (
 	"istio.io/api/annotation"
 	"istio.io/api/label"
 	meshconfig "istio.io/api/mesh/v1alpha1"
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry/kube"
 	"istio.io/istio/pilot/pkg/serviceregistry/kube/controller/filter"
@@ -2690,10 +2691,24 @@ func TestUpdateEdsCacheOnServiceUpdate(t *testing.T) {
 		"app": "prod-app",
 		"foo": "bar",
 	}
+	// set `K8SServiceSelectWorkloadEntries` to false temporarily
+	tmp := features.EnableK8SServiceSelectWorkloadEntries
+	features.EnableK8SServiceSelectWorkloadEntries = false
+	defer func() {
+		features.EnableK8SServiceSelectWorkloadEntries = tmp
+	}()
+	svc = updateService(controller, svc, t)
+	// don't update eds cache if `K8S_SELECT_WORKLOAD_ENTRIES` is disabled
+	if ev := fx.Wait("eds cache"); ev != nil {
+		t.Fatal("Update eds cache unexpectedly")
+	}
+
+	features.EnableK8SServiceSelectWorkloadEntries = true
 	svc.Spec.Selector = map[string]string{
 		"app": "prod-app",
 	}
 	updateService(controller, svc, t)
+	// update eds cache if `K8S_SELECT_WORKLOAD_ENTRIES` is enabled
 	if ev := fx.Wait("eds cache"); ev == nil {
 		t.Fatal("Timeout updating eds cache")
 	}

--- a/pilot/pkg/serviceregistry/kube/controller/endpointcontroller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpointcontroller.go
@@ -106,13 +106,15 @@ func updateEDS(c *Controller, epc kubeEndpointsController, ep interface{}, event
 			endpoints = epc.buildIstioEndpoints(ep, hostName)
 		}
 
-		svc := c.GetService(hostName)
-		if svc != nil {
-			fep := c.collectWorkloadInstanceEndpoints(svc)
-			endpoints = append(endpoints, fep...)
-		} else {
-			log.Debugf("Handle EDS endpoint: skip collecting workload entry endpoints, service %s/%s has not been populated",
-				namespacedName.Namespace, namespacedName.Name)
+		if features.EnableK8SServiceSelectWorkloadEntries {
+			svc := c.GetService(hostName)
+			if svc != nil {
+				fep := c.collectWorkloadInstanceEndpoints(svc)
+				endpoints = append(endpoints, fep...)
+			} else {
+				log.Debugf("Handle EDS endpoint: skip collecting workload entry endpoints, service %s/%s has not been populated",
+					namespacedName.Namespace, namespacedName.Name)
+			}
 		}
 
 		c.opts.XDSUpdater.EDSUpdate(shard, string(hostName), namespacedName.Namespace, endpoints)

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -177,24 +177,26 @@ func (m *Multicluster) ClusterAdded(cluster *multicluster.Cluster, clusterStopCh
 	}
 
 	// TODO implement deduping in aggregate registry to allow multiple k8s registries to handle WorkloadEntry
-	if m.serviceEntryController != nil && localCluster {
-		// Add an instance handler in the service entry store to notify kubernetes about workload entry events
-		m.serviceEntryController.AppendWorkloadHandler(kubeRegistry.WorkloadInstanceHandler)
-	} else if features.WorkloadEntryCrossCluster {
-		// TODO only do this for non-remotes, can't guarantee CRDs in remotes (depends on https://github.com/istio/istio/pull/29824)
-		if configStore, err := createWleConfigStore(client, m.revision, options); err == nil {
-			m.remoteKubeControllers[cluster.ID].workloadEntryController = serviceentry.NewWorkloadEntryController(
-				configStore, model.MakeIstioStore(configStore), options.XDSUpdater,
-				serviceentry.WithClusterID(cluster.ID),
-				serviceentry.WithNetworkIDCb(kubeRegistry.Network))
-			// Services can select WorkloadEntry from the same cluster. We only duplicate the Service to configure kube-dns.
-			m.remoteKubeControllers[cluster.ID].workloadEntryController.AppendWorkloadHandler(kubeRegistry.WorkloadInstanceHandler)
-			// ServiceEntry selects WorkloadEntry from remote cluster
-			m.remoteKubeControllers[cluster.ID].workloadEntryController.AppendWorkloadHandler(m.serviceEntryController.WorkloadInstanceHandler)
-			m.opts.MeshServiceController.AddRegistryAndRun(m.remoteKubeControllers[cluster.ID].workloadEntryController, clusterStopCh)
-			go configStore.Run(clusterStopCh)
-		} else {
-			return fmt.Errorf("failed creating config configStore for cluster %s: %v", cluster.ID, err)
+	if features.EnableK8SServiceSelectWorkloadEntries {
+		if m.serviceEntryController != nil && localCluster {
+			// Add an instance handler in the service entry store to notify kubernetes about workload entry events
+			m.serviceEntryController.AppendWorkloadHandler(kubeRegistry.WorkloadInstanceHandler)
+		} else if features.WorkloadEntryCrossCluster {
+			// TODO only do this for non-remotes, can't guarantee CRDs in remotes (depends on https://github.com/istio/istio/pull/29824)
+			if configStore, err := createWleConfigStore(client, m.revision, options); err == nil {
+				m.remoteKubeControllers[cluster.ID].workloadEntryController = serviceentry.NewWorkloadEntryController(
+					configStore, model.MakeIstioStore(configStore), options.XDSUpdater,
+					serviceentry.WithClusterID(cluster.ID),
+					serviceentry.WithNetworkIDCb(kubeRegistry.Network))
+				// Services can select WorkloadEntry from the same cluster. We only duplicate the Service to configure kube-dns.
+				m.remoteKubeControllers[cluster.ID].workloadEntryController.AppendWorkloadHandler(kubeRegistry.WorkloadInstanceHandler)
+				// ServiceEntry selects WorkloadEntry from remote cluster
+				m.remoteKubeControllers[cluster.ID].workloadEntryController.AppendWorkloadHandler(m.serviceEntryController.WorkloadInstanceHandler)
+				m.opts.MeshServiceController.AddRegistryAndRun(m.remoteKubeControllers[cluster.ID].workloadEntryController, clusterStopCh)
+				go configStore.Run(clusterStopCh)
+			} else {
+				return fmt.Errorf("failed creating config configStore for cluster %s: %v", cluster.ID, err)
+			}
 		}
 	}
 


### PR DESCRIPTION
This reverts commit 2ffbf677e1b0bd202dfaa44783494279848fda5e.

**Please provide a description of this PR:**

feature flags `PILOT_ENABLE_SERVICEENTRY_SELECT_PODS` and `PILOT_ENABLE_K8S_SELECT_WORKLOAD_ENTRIES` were removed in https://github.com/istio/istio/pull/37374.  `PILOT_ENABLE_SERVICEENTRY_SELECT_PODS` was re-added in https://github.com/istio/istio/pull/37407.  This PR re-adds `PILOT_ENABLE_K8S_SELECT_WORKLOAD_ENTRIES`