### PR TITLE
Revert "remove feature flags for se selecting pods (#37374)"

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -422,6 +422,10 @@ var (
 		"If enabled, service entries with selectors will select pods from the cluster. "+
 			"It is safe to disable it if you are quite sure you don't need this feature").Get()
 
+	EnableK8SServiceSelectWorkloadEntries = env.RegisterBoolVar("PILOT_ENABLE_K8S_SELECT_WORKLOAD_ENTRIES", true,
+		"If enabled, Kubernetes services with selectors will select workload entries with matching labels. "+
+			"It is safe to disable it if you are quite sure you don't need this feature").Get()
+
 	InjectionWebhookConfigName = env.Register("INJECTION_WEBHOOK_CONFIG_NAME", "istio-sidecar-injector",
 		"Name of the mutatingwebhookconfiguration to patch, if istioctl is not used.").Get()
 

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -582,9 +582,11 @@ func (c *Controller) addOrUpdateService(svc *v1.Service, svcConv *model.Service,
 	// We also need to update when the Service changes. For Kubernetes, a service change will result in Endpoint updates,
 	// but workload entries will also need to be updated.
 	// TODO(nmittler): Build different sets of endpoints for cluster.local and clusterset.local.
-	endpoints := c.buildEndpointsForService(svcConv, updateEDSCache)
-	if len(endpoints) > 0 {
-		c.opts.XDSUpdater.EDSCacheUpdate(shard, string(svcConv.Hostname), ns, endpoints)
+	if updateEDSCache || features.EnableK8SServiceSelectWorkloadEntries {
+		endpoints := c.buildEndpointsForService(svcConv, updateEDSCache)
+		if len(endpoints) > 0 {
+			c.opts.XDSUpdater.EDSCacheUpdate(shard, string(svcConv.Hostname), ns, endpoints)
+		}
 	}
 
 	c.opts.XDSUpdater.SvcUpdate(shard, string(svcConv.Hostname), ns, event)
@@ -594,8 +596,10 @@ func (c *Controller) addOrUpdateService(svc *v1.Service, svcConv *model.Service,
 
 func (c *Controller) buildEndpointsForService(svc *model.Service, updateCache bool) []*model.IstioEndpoint {
 	endpoints := c.endpoints.buildIstioEndpointsWithService(svc.Attributes.Name, svc.Attributes.Namespace, svc.Hostname, updateCache)
-	fep := c.collectWorkloadInstanceEndpoints(svc)
-	endpoints = append(endpoints, fep...)
+	if features.EnableK8SServiceSelectWorkloadEntries {
+		fep := c.collectWorkloadInstanceEndpoints(svc)
+		endpoints = append(endpoints, fep...)
+	}
 	return endpoints
 }
 

--- a/pilot/pkg/serviceregistry/kube/controller/endpointcontroller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpointcontroller.go
@@ -106,13 +106,15 @@ func updateEDS(c *Controller, epc kubeEndpointsController, ep any, event model.E
 			endpoints = epc.buildIstioEndpoints(ep, hostName)
 		}
 
-		svc := c.GetService(hostName)
-		if svc != nil {
-			fep := c.collectWorkloadInstanceEndpoints(svc)
-			endpoints = append(endpoints, fep...)
-		} else {
-			log.Debugf("Handle EDS endpoint: skip collecting workload entry endpoints, service %s/%s has not been populated",
-				namespacedName.Namespace, namespacedName.Name)
+		if features.EnableK8SServiceSelectWorkloadEntries {
+			svc := c.GetService(hostName)
+			if svc != nil {
+				fep := c.collectWorkloadInstanceEndpoints(svc)
+				endpoints = append(endpoints, fep...)
+			} else {
+				log.Debugf("Handle EDS endpoint: skip collecting workload entry endpoints, service %s/%s has not been populated",
+					namespacedName.Namespace, namespacedName.Name)
+			}
 		}
 
 		c.opts.XDSUpdater.EDSUpdate(shard, string(hostName), namespacedName.Namespace, endpoints)

--- a/releasenotes/notes/workload-entry-service-select.yaml
+++ b/releasenotes/notes/workload-entry-service-select.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+releaseNotes:
+ - |
+   **Added** `PILOT_ENABLE_K8S_SELECT_WORKLOAD_ENTRIES` feature back to Istio which was removed in 1.14.
+   Will persist until usecase is clarified and more permanent API added.


### PR DESCRIPTION
This reverts commit 2ffbf677e1b0bd202dfaa44783494279848fda5e.

**Please provide a description of this PR:**

feature flags `PILOT_ENABLE_SERVICEENTRY_SELECT_PODS` and `PILOT_ENABLE_K8S_SELECT_WORKLOAD_ENTRIES` were removed in https://github.com/istio/istio/pull/37374.  `PILOT_ENABLE_SERVICEENTRY_SELECT_PODS` was re-added in https://github.com/istio/istio/pull/37407.  This PR re-adds `PILOT_ENABLE_K8S_SELECT_WORKLOAD_ENTRIES`

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ X ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure