### PR TITLE
operator: should not call `SetWatchErrorHandler` if store has started

### DIFF
--- a/pilot/pkg/config/aggregate/config.go
+++ b/pilot/pkg/config/aggregate/config.go
@@ -172,6 +172,16 @@ type storeCache struct {
 	caches []model.ConfigStoreController
 }
 
+func (cr *storeCache) HasStarted() bool {
+	for _, cache := range cr.caches {
+		if !cache.HasStarted() {
+			return false
+		}
+	}
+
+	return true
+}
+
 func (cr *storeCache) HasSynced() bool {
 	for _, cache := range cr.caches {
 		if !cache.HasSynced() {

--- a/pilot/pkg/config/file/store.go
+++ b/pilot/pkg/config/file/store.go
@@ -112,6 +112,10 @@ func (s *KubeSource) SetWatchErrorHandler(f func(r *cache.Reflector, err error))
 	panic("implement me")
 }
 
+func (s *KubeSource) HasStarted() bool {
+	return true
+}
+
 func (s *KubeSource) HasSynced() bool {
 	return true
 }

--- a/pilot/pkg/config/kube/crdclient/client.go
+++ b/pilot/pkg/config/kube/crdclient/client.go
@@ -260,6 +260,10 @@ func (cl *Client) informerSynced() bool {
 	return true
 }
 
+func (cl *Client) HasStarted() bool {
+	return cl.client.HasStarted()
+}
+
 func (cl *Client) HasSynced() bool {
 	return cl.initialSync.Load()
 }

--- a/pilot/pkg/config/kube/gateway/controller.go
+++ b/pilot/pkg/config/kube/gateway/controller.go
@@ -78,6 +78,8 @@ type Controller struct {
 	// is only the case when we are the leader.
 	statusController *status.Controller
 	statusEnabled    *atomic.Bool
+
+	started atomic.Bool
 }
 
 var _ model.GatewayController = &Controller{}
@@ -274,7 +276,12 @@ func (c *Controller) RegisterEventHandler(typ config.GroupVersionKind, handler m
 	// For all other types, do nothing as c.cache has been registered
 }
 
+func (c *Controller) HasStarted() bool {
+	return c.started.Load()
+}
+
 func (c *Controller) Run(stop <-chan struct{}) {
+	c.started.Store(true)
 	go func() {
 		if crdclient.WaitForCRD(gvk.GatewayClass, stop) {
 			gcc := NewClassController(c.client)

--- a/pilot/pkg/config/kube/ingress/controller.go
+++ b/pilot/pkg/config/kube/ingress/controller.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"sort"
 	"sync"
+	"sync/atomic"
 
 	"github.com/hashicorp/go-multierror"
 	ingress "k8s.io/api/networking/v1beta1"
@@ -95,6 +96,8 @@ type controller struct {
 	serviceLister   listerv1.ServiceLister
 	// May be nil if ingress class is not supported in the cluster
 	classes v1beta1.IngressClassInformer
+
+	started atomic.Bool
 }
 
 // TODO: move to features ( and remove in 1.2 )
@@ -180,7 +183,12 @@ func NewController(client kube.Client, meshWatcher mesh.Holder,
 	return c
 }
 
+func (c *controller) HasStarted() bool {
+	return c.started.Load()
+}
+
 func (c *controller) Run(stop <-chan struct{}) {
+	c.started.Store(true)
 	c.queue.Run(stop)
 }
 

--- a/pilot/pkg/config/memory/controller.go
+++ b/pilot/pkg/config/memory/controller.go
@@ -17,6 +17,7 @@ package memory
 import (
 	"errors"
 	"fmt"
+	"sync/atomic"
 
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
@@ -31,6 +32,8 @@ type Controller struct {
 	monitor     Monitor
 	configStore model.ConfigStore
 	hasSynced   func() bool
+
+	started atomic.Bool
 }
 
 // NewController return an implementation of ConfigStoreController
@@ -64,6 +67,10 @@ func (c *Controller) RegisterEventHandler(kind config.GroupVersionKind, f model.
 
 func (c *Controller) SetWatchErrorHandler(handler func(r *cache.Reflector, err error)) error {
 	return nil
+}
+
+func (c *Controller) HasStarted() bool {
+	return c.started.Load()
 }
 
 // HasSynced return whether store has synced

--- a/pilot/pkg/model/config.go
+++ b/pilot/pkg/model/config.go
@@ -194,7 +194,12 @@ type ConfigStoreController interface {
 
 	// Run until a signal is received
 	Run(stop <-chan struct{})
+
+	// SetWatchErrorHandler should be call if store has started
 	SetWatchErrorHandler(func(r *cache.Reflector, err error)) error
+
+	// HasStarted return treu after store started.
+	HasStarted() bool
 
 	// HasSynced returns true after initial cache synchronization is complete
 	HasSynced() bool

--- a/pilot/pkg/model/config.go
+++ b/pilot/pkg/model/config.go
@@ -198,7 +198,7 @@ type ConfigStoreController interface {
 	// SetWatchErrorHandler should be call if store has started
 	SetWatchErrorHandler(func(r *cache.Reflector, err error)) error
 
-	// HasStarted return treu after store started.
+	// HasStarted return ture after store started.
 	HasStarted() bool
 
 	// HasSynced returns true after initial cache synchronization is complete

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -553,15 +553,13 @@ func (c *client) RunAndWait(stop <-chan struct{}) {
 }
 
 func (c *client) startInformer(stop <-chan struct{}) {
-	if !c.HasStarted() {
-		c.started.Store(true)
-		c.kubeInformer.Start(stop)
-		c.dynamicInformer.Start(stop)
-		c.metadataInformer.Start(stop)
-		c.istioInformer.Start(stop)
-		c.gatewayapiInformer.Start(stop)
-		c.extInformer.Start(stop)
-	}
+	c.started.Store(true)
+	c.kubeInformer.Start(stop)
+	c.dynamicInformer.Start(stop)
+	c.metadataInformer.Start(stop)
+	c.istioInformer.Start(stop)
+	c.gatewayapiInformer.Start(stop)
+	c.extInformer.Start(stop)
 }
 
 func (c *client) GetKubernetesVersion() (*kubeVersion.Info, error) {

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -553,13 +553,13 @@ func (c *client) RunAndWait(stop <-chan struct{}) {
 }
 
 func (c *client) startInformer(stop <-chan struct{}) {
-	c.started.Store(true)
 	c.kubeInformer.Start(stop)
 	c.dynamicInformer.Start(stop)
 	c.metadataInformer.Start(stop)
 	c.istioInformer.Start(stop)
 	c.gatewayapiInformer.Start(stop)
 	c.extInformer.Start(stop)
+	c.started.Store(true)
 }
 
 func (c *client) GetKubernetesVersion() (*kubeVersion.Info, error) {

--- a/pkg/kube/mock_client.go
+++ b/pkg/kube/mock_client.go
@@ -131,6 +131,10 @@ func (c MockClient) MetadataInformer() metadatainformer.SharedInformerFactory {
 	panic("not used in mock")
 }
 
+func (c MockClient) HasStarted() bool {
+	panic("not used in mock")
+}
+
 func (c MockClient) RunAndWait(stop <-chan struct{}) {
 	panic("not used in mock")
 }

--- a/releasenotes/notes/40727.yaml
+++ b/releasenotes/notes/40727.yaml
@@ -2,6 +2,9 @@ apiVersion: release-notes/v2
 kind: bug-fix
 area: installation
 
+issue:
+  - 39599
+
 releaseNotes:
   - |
     **Fixed** an issue `AddRunningKubeSourceWithRevision` return error cause Istio Operator going to error loops.

--- a/releasenotes/notes/40727.yaml
+++ b/releasenotes/notes/40727.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+
+releaseNotes:
+  - |
+    **Fixed** an issue `AddRunningKubeSourceWithRevision` return error cause Istio Operator going to error loops.

--- a/releasenotes/notes/40727.yaml
+++ b/releasenotes/notes/40727.yaml
@@ -7,4 +7,4 @@ issue:
 
 releaseNotes:
   - |
-    **Fixed** an issue `AddRunningKubeSourceWithRevision` return error cause Istio Operator going to error loops.
+    **Fixed** an issue where `AddRunningKubeSourceWithRevision` returns an error causing the Istio Operator to go into an error loop.


### PR DESCRIPTION
Signed-off-by: hejianpeng <hejianpeng2@huawei.com>

**Please provide a description of this PR:**

1. add `HasStarted() bool` to model.ConfigStoreController
2. do not can SetWatchErrorHandler if it's started