### PR TITLE
stats: correct response_code regex

### DIFF
--- a/pkg/bootstrap/testdata/all_golden.json
+++ b/pkg/bootstrap/testdata/all_golden.json
@@ -30,7 +30,11 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)",
+        "tag_name": "response_code"
+      },
+      {
+        "regex": "_rq(_(\\d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/pkg/bootstrap/testdata/all_golden.json
+++ b/pkg/bootstrap/testdata/all_golden.json
@@ -30,7 +30,7 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/pkg/bootstrap/testdata/auth_golden.json
+++ b/pkg/bootstrap/testdata/auth_golden.json
@@ -30,7 +30,11 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)",
+        "tag_name": "response_code"
+      },
+      {
+        "regex": "_rq(_(\\d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/pkg/bootstrap/testdata/auth_golden.json
+++ b/pkg/bootstrap/testdata/auth_golden.json
@@ -30,7 +30,7 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/pkg/bootstrap/testdata/authsds_golden.json
+++ b/pkg/bootstrap/testdata/authsds_golden.json
@@ -30,7 +30,11 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)",
+        "tag_name": "response_code"
+      },
+      {
+        "regex": "_rq(_(\\d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/pkg/bootstrap/testdata/authsds_golden.json
+++ b/pkg/bootstrap/testdata/authsds_golden.json
@@ -30,7 +30,7 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/pkg/bootstrap/testdata/default_golden.json
+++ b/pkg/bootstrap/testdata/default_golden.json
@@ -30,7 +30,11 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)",
+        "tag_name": "response_code"
+      },
+      {
+        "regex": "_rq(_(\\d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/pkg/bootstrap/testdata/default_golden.json
+++ b/pkg/bootstrap/testdata/default_golden.json
@@ -30,7 +30,7 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/pkg/bootstrap/testdata/metrics_no_statsd_golden.json
+++ b/pkg/bootstrap/testdata/metrics_no_statsd_golden.json
@@ -30,7 +30,11 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)",
+        "tag_name": "response_code"
+      },
+      {
+        "regex": "_rq(_(\\d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/pkg/bootstrap/testdata/metrics_no_statsd_golden.json
+++ b/pkg/bootstrap/testdata/metrics_no_statsd_golden.json
@@ -30,7 +30,7 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/pkg/bootstrap/testdata/running_golden.json
+++ b/pkg/bootstrap/testdata/running_golden.json
@@ -35,7 +35,7 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/pkg/bootstrap/testdata/running_golden.json
+++ b/pkg/bootstrap/testdata/running_golden.json
@@ -35,7 +35,11 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)",
+        "tag_name": "response_code"
+      },
+      {
+        "regex": "_rq(_(\\d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/pkg/bootstrap/testdata/runningsds_golden.json
+++ b/pkg/bootstrap/testdata/runningsds_golden.json
@@ -35,7 +35,7 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/pkg/bootstrap/testdata/runningsds_golden.json
+++ b/pkg/bootstrap/testdata/runningsds_golden.json
@@ -35,7 +35,11 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)",
+        "tag_name": "response_code"
+      },
+      {
+        "regex": "_rq(_(\\d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/pkg/bootstrap/testdata/stats_inclusion_golden.json
+++ b/pkg/bootstrap/testdata/stats_inclusion_golden.json
@@ -30,7 +30,11 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)",
+        "tag_name": "response_code"
+      },
+      {
+        "regex": "_rq(_(\\d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/pkg/bootstrap/testdata/stats_inclusion_golden.json
+++ b/pkg/bootstrap/testdata/stats_inclusion_golden.json
@@ -30,7 +30,7 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/pkg/bootstrap/testdata/tracing_datadog_golden.json
+++ b/pkg/bootstrap/testdata/tracing_datadog_golden.json
@@ -30,7 +30,11 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)",
+        "tag_name": "response_code"
+      },
+      {
+        "regex": "_rq(_(\\d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/pkg/bootstrap/testdata/tracing_datadog_golden.json
+++ b/pkg/bootstrap/testdata/tracing_datadog_golden.json
@@ -30,7 +30,7 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/pkg/bootstrap/testdata/tracing_lightstep_golden.json
+++ b/pkg/bootstrap/testdata/tracing_lightstep_golden.json
@@ -30,7 +30,11 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)",
+        "tag_name": "response_code"
+      },
+      {
+        "regex": "_rq(_(\\d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/pkg/bootstrap/testdata/tracing_lightstep_golden.json
+++ b/pkg/bootstrap/testdata/tracing_lightstep_golden.json
@@ -30,7 +30,7 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/pkg/bootstrap/testdata/tracing_opencensusagent_golden.json
+++ b/pkg/bootstrap/testdata/tracing_opencensusagent_golden.json
@@ -30,7 +30,11 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)",
+        "tag_name": "response_code"
+      },
+      {
+        "regex": "_rq(_(\\d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/pkg/bootstrap/testdata/tracing_opencensusagent_golden.json
+++ b/pkg/bootstrap/testdata/tracing_opencensusagent_golden.json
@@ -30,7 +30,7 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
+++ b/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
@@ -30,7 +30,11 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)",
+        "tag_name": "response_code"
+      },
+      {
+        "regex": "_rq(_(\\d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
+++ b/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
@@ -30,7 +30,7 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/pkg/bootstrap/testdata/tracing_tls_custom_sni_golden.json
+++ b/pkg/bootstrap/testdata/tracing_tls_custom_sni_golden.json
@@ -30,7 +30,11 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)",
+        "tag_name": "response_code"
+      },
+      {
+        "regex": "_rq(_(\\d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/pkg/bootstrap/testdata/tracing_tls_custom_sni_golden.json
+++ b/pkg/bootstrap/testdata/tracing_tls_custom_sni_golden.json
@@ -30,7 +30,7 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/pkg/bootstrap/testdata/tracing_tls_golden.json
+++ b/pkg/bootstrap/testdata/tracing_tls_golden.json
@@ -30,7 +30,11 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)",
+        "tag_name": "response_code"
+      },
+      {
+        "regex": "_rq(_(\\d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/pkg/bootstrap/testdata/tracing_tls_golden.json
+++ b/pkg/bootstrap/testdata/tracing_tls_golden.json
@@ -30,7 +30,7 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/pkg/bootstrap/testdata/tracing_zipkin_golden.json
+++ b/pkg/bootstrap/testdata/tracing_zipkin_golden.json
@@ -30,7 +30,11 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)",
+        "tag_name": "response_code"
+      },
+      {
+        "regex": "_rq(_(\\d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/pkg/bootstrap/testdata/tracing_zipkin_golden.json
+++ b/pkg/bootstrap/testdata/tracing_zipkin_golden.json
@@ -30,7 +30,7 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/pkg/bootstrap/testdata/xdsproxy_golden.json
+++ b/pkg/bootstrap/testdata/xdsproxy_golden.json
@@ -30,7 +30,11 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)",
+        "tag_name": "response_code"
+      },
+      {
+        "regex": "_rq(_(\\d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/pkg/bootstrap/testdata/xdsproxy_golden.json
+++ b/pkg/bootstrap/testdata/xdsproxy_golden.json
@@ -30,7 +30,7 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/releasenotes/notes/40729.yaml
+++ b/releasenotes/notes/40729.yaml
@@ -7,4 +7,4 @@ issue:
 
 releaseNotes:
   - |
-    **Fixed** an issue that allow multiple regexes with same tag name.
+    **Fixed** an issue to allow multiple regular expressions with the same tag name.

--- a/releasenotes/notes/40729.yaml
+++ b/releasenotes/notes/40729.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: telemetry
+
+issue:
+  - 39903
+
+releaseNotes:
+  - |
+    **Fixed** an issue that allow multiple regexes with same tag name.

--- a/tools/packaging/common/envoy_bootstrap.json
+++ b/tools/packaging/common/envoy_bootstrap.json
@@ -45,7 +45,7 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/tools/packaging/common/envoy_bootstrap.json
+++ b/tools/packaging/common/envoy_bootstrap.json
@@ -45,7 +45,11 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)",
+        "tag_name": "response_code"
+      },
+      {
+        "regex": "_rq(_(\\d{3}))$",
         "tag_name": "response_code"
       },
       {


### PR DESCRIPTION
**Please provide a description of this PR:**

fixes: #39903 
wait for ~~https://github.com/envoyproxy/envoy/pull/22791~~ https://github.com/envoyproxy/envoy/pull/23024

support multiple regexes to populate the same tag name.

before:

```
envoy_cluster_internal_upstream_rq_200{cluster_name="xds-grpc"} 1
envoy_cluster_internal_upstream_rq{response_code_class="2xx",cluster_name="xds-grpc"} 1
envoy_cluster_upstream_rq{response_code_class="2xx",cluster_name="xds-grpc"} 1
istio_requests_total{response_code="200",reporter="source",source_workload="sleep",source_workload_namespace="default",source_principal="spiffe://cluster.local/ns/default/sa/sleep",source_app="sleep",source_version="unknown",source_cluster="Kubernetes",destination_workload="httpbin",destination_workload_namespace="default",destination_principal="spiffe://cluster.local/ns/default/sa/httpbin",destination_app="httpbin",destination_version="v1",destination_service="httpbin.default.svc.cluster.local",destination_service_name="httpbin",destination_service_namespace="default",destination_cluster="Kubernetes",request_protocol="http",response_flags="-",grpc_response_status="",connection_security_policy="unknown",source_canonical_service="sleep",destination_canonical_service="httpbin",source_canonical_revision="latest",destination_canonical_revision="v1"} 1
```


after:

```
envoy_cluster_internal_upstream_rq{response_code="200",cluster_name="xds-grpc"} 1
envoy_cluster_internal_upstream_rq{response_code_class="2xx",cluster_name="xds-grpc"} 1
envoy_cluster_upstream_rq{response_code="200",cluster_name="xds-grpc"} 1
envoy_cluster_upstream_rq{response_code_class="2xx",cluster_name="xds-grpc"} 1
istio_requests_total{response_code="200",reporter="source",source_workload="sleep",source_workload_namespace="default",source_principal="spiffe://cluster.local/ns/default/sa/sleep",source_app="sleep",source_version="unknown",source_cluster="Kubernetes",destination_workload="httpbin",destination_workload_namespace="default",destination_principal="spiffe://cluster.local/ns/default/sa/httpbin",destination_app="httpbin",destination_version="v1",destination_service="httpbin.default.svc.cluster.local",destination_service_name="httpbin",destination_service_namespace="default",destination_cluster="Kubernetes",request_protocol="http",response_flags="-",grpc_response_status="",connection_security_policy="unknown",source_canonical_service="sleep",destination_canonical_service="httpbin",source_canonical_revision="latest",destination_canonical_revision="v1"} 1
```