### PR TITLE
Replace anypb.New with MessageToAny

### DIFF
--- a/istioctl/pkg/util/configdump/route.go
+++ b/istioctl/pkg/util/configdump/route.go
@@ -20,8 +20,8 @@ import (
 
 	adminapi "github.com/envoyproxy/go-control-plane/envoy/admin/v3"
 	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
-	"google.golang.org/protobuf/types/known/anypb"
 
+	"istio.io/istio/pilot/pkg/util/protoconv"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
 )
 
@@ -85,10 +85,7 @@ func (w *Wrapper) GetDynamicRouteDump(stripVersions bool) (*adminapi.RoutesConfi
 		sort.Slice(route.VirtualHosts, func(i, j int) bool {
 			return route.VirtualHosts[i].Name < route.VirtualHosts[j].Name
 		})
-		drc[i].RouteConfig, err = anypb.New(route)
-		if err != nil {
-			return nil, err
-		}
+		drc[i].RouteConfig = protoconv.MessageToAny(route)
 	}
 
 	if stripVersions {

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch_test.go
@@ -36,7 +36,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
-	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
@@ -1451,12 +1450,12 @@ func TestApplyListenerPatches(t *testing.T) {
 	faultFilterIn := &fault.HTTPFault{
 		UpstreamCluster: "foobar",
 	}
-	faultFilterInAny, _ := anypb.New(faultFilterIn)
+	faultFilterInAny := protoconv.MessageToAny(faultFilterIn)
 	faultFilterOut := &fault.HTTPFault{
 		UpstreamCluster: "scooby",
 		DownstreamNodes: []string{"foo"},
 	}
-	faultFilterOutAny, _ := anypb.New(faultFilterOut)
+	faultFilterOutAny := protoconv.MessageToAny(faultFilterOut)
 
 	gatewayIn := []*listener.Listener{
 		{

--- a/pilot/pkg/networking/core/v1alpha3/extension/wasmplugin.go
+++ b/pilot/pkg/networking/core/v1alpha3/extension/wasmplugin.go
@@ -19,15 +19,14 @@ import (
 	extensionsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/wasm/v3"
 	hcm_filter "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
 
 	extensions "istio.io/api/extensions/v1alpha1"
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/util/protoconv"
 	"istio.io/istio/pkg/config/xds"
 	"istio.io/istio/pkg/util/sets"
 	_ "istio.io/istio/pkg/wasm" // include for registering wasm logging scope
-	"istio.io/pkg/log"
 )
 
 var defaultConfigSource = &envoy_config_core_v3.ConfigSource{
@@ -96,11 +95,7 @@ func InsertedExtensionConfigurations(
 					envs[model.WasmSecretEnv] = ""
 				}
 			}
-			typedConfig, err := anypb.New(wasmExtensionConfig)
-			if err != nil {
-				log.Warnf("wasmplugin %s/%s failed to marshal to TypedExtensionConfig: %s", p.Namespace, p.Name, err)
-				continue
-			}
+			typedConfig := protoconv.MessageToAny(wasmExtensionConfig)
 			ec := &envoy_config_core_v3.TypedExtensionConfig{
 				Name:        p.ResourceName,
 				TypedConfig: typedConfig,

--- a/pilot/pkg/networking/core/v1alpha3/extension/wasmplugin_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/extension/wasmplugin_test.go
@@ -22,10 +22,10 @@ import (
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/protobuf/testing/protocmp"
-	"google.golang.org/protobuf/types/known/anypb"
 
 	extensions "istio.io/api/extensions/v1alpha1"
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/util/protoconv"
 )
 
 var (
@@ -48,7 +48,7 @@ var (
 )
 
 func TestInsertedExtensionConfigurations(t *testing.T) {
-	wasm, _ := anypb.New(&extensionsv3.Wasm{})
+	wasm := protoconv.MessageToAny(&extensionsv3.Wasm{})
 	testCases := []struct {
 		name        string
 		wasmPlugins map[extensions.PluginPhase][]*model.WasmPluginWrapper

--- a/pilot/pkg/networking/core/v1alpha3/tracing.go
+++ b/pilot/pkg/networking/core/v1alpha3/tracing.go
@@ -146,7 +146,7 @@ func configureFromProviderConfig(pushCtx *model.PushContext, meta *model.NodeMet
 					CollectorCluster: clusterName,
 					AccessTokenFile:  provider.Lightstep.AccessToken,
 				}
-				return protoconv.MessageToAny(lc), nil
+				return protoconv.MessageToAnyWithError(lc)
 			})
 
 	case *meshconfig.MeshConfig_ExtensionProvider_Opencensus:
@@ -158,7 +158,7 @@ func configureFromProviderConfig(pushCtx *model.PushContext, meta *model.NodeMet
 				OutgoingTraceContext:   convert(provider.Opencensus.Context),
 			}
 
-			return protoconv.MessageToAny(oc), nil
+			return protoconv.MessageToAnyWithError(oc)
 		})
 
 	case *meshconfig.MeshConfig_ExtensionProvider_Skywalking:
@@ -175,7 +175,7 @@ func configureFromProviderConfig(pushCtx *model.PushContext, meta *model.NodeMet
 					},
 				}
 
-				return protoconv.MessageToAny(s), nil
+				return protoconv.MessageToAnyWithError(s)
 			})
 
 		rfCtx = &xdsfilters.RouterFilterContext{
@@ -252,7 +252,7 @@ func configureFromProviderConfig(pushCtx *model.PushContext, meta *model.NodeMet
 			if provider.Stackdriver.MaxNumberOfMessageEvents != nil {
 				sd.TraceConfig.MaxNumberOfMessageEvents = provider.Stackdriver.MaxNumberOfMessageEvents.Value
 			}
-			return protoconv.MessageToAny(sd), nil
+			return protoconv.MessageToAnyWithError(sd)
 		})
 	}
 
@@ -270,14 +270,14 @@ func zipkinConfigGen(hostname, cluster string) (*anypb.Any, error) {
 		TraceId_128Bit:           true,
 		SharedSpanContext:        wrapperspb.Bool(false),
 	}
-	return protoconv.MessageToAny(zc), nil
+	return protoconv.MessageToAnyWithError(zc)
 }
 
 func datadogConfigGen(hostname, cluster string) (*anypb.Any, error) {
 	dc := &tracingcfg.DatadogConfig{
 		CollectorCluster: cluster,
 	}
-	return protoconv.MessageToAny(dc), nil
+	return protoconv.MessageToAnyWithError(dc)
 }
 
 type typedConfigGenFn func() (*anypb.Any, error)

--- a/pilot/pkg/networking/core/v1alpha3/tracing.go
+++ b/pilot/pkg/networking/core/v1alpha3/tracing.go
@@ -37,6 +37,7 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking"
 	authz_model "istio.io/istio/pilot/pkg/security/authz/model"
+	"istio.io/istio/pilot/pkg/util/protoconv"
 	xdsfilters "istio.io/istio/pilot/pkg/xds/filters"
 	"istio.io/istio/pilot/pkg/xds/requestidextension"
 	"istio.io/istio/pkg/bootstrap/platform"
@@ -145,7 +146,7 @@ func configureFromProviderConfig(pushCtx *model.PushContext, meta *model.NodeMet
 					CollectorCluster: clusterName,
 					AccessTokenFile:  provider.Lightstep.AccessToken,
 				}
-				return anypb.New(lc)
+				return protoconv.MessageToAny(lc), nil
 			})
 
 	case *meshconfig.MeshConfig_ExtensionProvider_Opencensus:
@@ -157,7 +158,7 @@ func configureFromProviderConfig(pushCtx *model.PushContext, meta *model.NodeMet
 				OutgoingTraceContext:   convert(provider.Opencensus.Context),
 			}
 
-			return anypb.New(oc)
+			return protoconv.MessageToAny(oc), nil
 		})
 
 	case *meshconfig.MeshConfig_ExtensionProvider_Skywalking:
@@ -174,7 +175,7 @@ func configureFromProviderConfig(pushCtx *model.PushContext, meta *model.NodeMet
 					},
 				}
 
-				return anypb.New(s)
+				return protoconv.MessageToAny(s), nil
 			})
 
 		rfCtx = &xdsfilters.RouterFilterContext{
@@ -251,7 +252,7 @@ func configureFromProviderConfig(pushCtx *model.PushContext, meta *model.NodeMet
 			if provider.Stackdriver.MaxNumberOfMessageEvents != nil {
 				sd.TraceConfig.MaxNumberOfMessageEvents = provider.Stackdriver.MaxNumberOfMessageEvents.Value
 			}
-			return anypb.New(sd)
+			return protoconv.MessageToAny(sd), nil
 		})
 	}
 
@@ -269,14 +270,14 @@ func zipkinConfigGen(hostname, cluster string) (*anypb.Any, error) {
 		TraceId_128Bit:           true,
 		SharedSpanContext:        wrapperspb.Bool(false),
 	}
-	return anypb.New(zc)
+	return protoconv.MessageToAny(zc), nil
 }
 
 func datadogConfigGen(hostname, cluster string) (*anypb.Any, error) {
 	dc := &tracingcfg.DatadogConfig{
 		CollectorCluster: cluster,
 	}
-	return anypb.New(dc)
+	return protoconv.MessageToAny(dc), nil
 }
 
 type typedConfigGenFn func() (*anypb.Any, error)

--- a/pilot/pkg/networking/core/v1alpha3/tracing_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/tracing_test.go
@@ -24,7 +24,6 @@ import (
 	xdstype "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/protobuf/testing/protocmp"
-	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
@@ -32,6 +31,7 @@ import (
 	"istio.io/istio/pilot/pkg/extensionproviders"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking"
+	"istio.io/istio/pilot/pkg/util/protoconv"
 	xdsfilters "istio.io/istio/pilot/pkg/xds/filters"
 	"istio.io/istio/pilot/pkg/xds/requestidextension"
 )
@@ -521,7 +521,7 @@ func fakeZipkinProvider(expectClusterName, expectAuthority, expectProviderName s
 		TraceId_128Bit:           true,
 		SharedSpanContext:        wrapperspb.Bool(false),
 	}
-	fakeZipkinAny, _ := anypb.New(fakeZipkinProviderConfig)
+	fakeZipkinAny := protoconv.MessageToAny(fakeZipkinProviderConfig)
 	return &tracingcfg.Tracing_Http{
 		Name:       expectProviderName,
 		ConfigType: &tracingcfg.Tracing_Http_TypedConfig{TypedConfig: fakeZipkinAny},
@@ -539,7 +539,7 @@ func fakeSkywalkingProvider(expectClusterName, expectAuthority, expectProviderNa
 			},
 		},
 	}
-	fakeSkywalkingAny, _ := anypb.New(fakeSkywalkingProviderConfig)
+	fakeSkywalkingAny := protoconv.MessageToAny(fakeSkywalkingProviderConfig)
 	return &tracingcfg.Tracing_Http{
 		Name:       expectProviderName,
 		ConfigType: &tracingcfg.Tracing_Http_TypedConfig{TypedConfig: fakeSkywalkingAny},

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -39,6 +39,7 @@ import (
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	istionetworking "istio.io/istio/pilot/pkg/networking"
+	"istio.io/istio/pilot/pkg/util/protoconv"
 	"istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/labels"
@@ -414,12 +415,9 @@ func MergeAnyWithAny(dst *anypb.Any, src *anypb.Any) (*anypb.Any, error) {
 
 	// Merge the two typed protos
 	merge.Merge(dstX, srcX)
-	var retVal *anypb.Any
 
 	// Convert the merged proto back to dst
-	if retVal, err = anypb.New(dstX); err != nil {
-		return nil, err
-	}
+	retVal := protoconv.MessageToAny(dstX)
 
 	return retVal, nil
 }

--- a/pkg/adsc/adsc_test.go
+++ b/pkg/adsc/adsc_test.go
@@ -40,6 +40,7 @@ import (
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/config/memory"
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/util/protoconv"
 	"istio.io/istio/pkg/config/schema/collections"
 )
 
@@ -539,7 +540,7 @@ func constructResourceWithOptions(name string, host string, address, version str
 		Hosts:     []string{host},
 		Addresses: []string{address},
 	}
-	seAny, _ := anypb.New(service)
+	seAny := protoconv.MessageToAny(service)
 	resource := &mcp.Resource{
 		Metadata: &mcp.Metadata{
 			Name:       "default/" + name,
@@ -553,7 +554,7 @@ func constructResourceWithOptions(name string, host string, address, version str
 		o(resource)
 	}
 
-	resAny, _ := anypb.New(resource)
+	resAny := protoconv.MessageToAny(resource)
 	return &anypb.Any{
 		TypeUrl: resAny.TypeUrl,
 		Value:   resAny.Value,

--- a/pkg/config/model.go
+++ b/pkg/config/model.go
@@ -35,6 +35,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"istio.io/api/label"
+	"istio.io/istio/pilot/pkg/util/protoconv"
 	"istio.io/istio/pkg/util/gogoprotomarshal"
 	"istio.io/istio/pkg/util/protomarshal"
 )
@@ -128,7 +129,7 @@ func ToProto(s Spec) (*anypb.Any, error) {
 	// golang/protobuf 1.4+ will have this interface. Older golang/protobuf are gogo compatible
 	// but also not used by Istio at all.
 	if pb, ok := s.(protoreflect.ProtoMessage); ok {
-		return anypb.New(pb)
+		return protoconv.MessageToAny(pb), nil
 	}
 
 	// gogo protobuf
@@ -151,7 +152,7 @@ func ToProto(s Spec) (*anypb.Any, error) {
 	if err := jsonpb.Unmarshal(bytes.NewReader(js), pbs); err != nil {
 		return nil, err
 	}
-	return anypb.New(pbs)
+	return protoconv.MessageToAny(pbs), nil
 }
 
 func ToMap(s Spec) (map[string]any, error) {

--- a/pkg/config/model.go
+++ b/pkg/config/model.go
@@ -129,7 +129,7 @@ func ToProto(s Spec) (*anypb.Any, error) {
 	// golang/protobuf 1.4+ will have this interface. Older golang/protobuf are gogo compatible
 	// but also not used by Istio at all.
 	if pb, ok := s.(protoreflect.ProtoMessage); ok {
-		return protoconv.MessageToAny(pb), nil
+		return protoconv.MessageToAnyWithError(pb)
 	}
 
 	// gogo protobuf
@@ -152,7 +152,7 @@ func ToProto(s Spec) (*anypb.Any, error) {
 	if err := jsonpb.Unmarshal(bytes.NewReader(js), pbs); err != nil {
 		return nil, err
 	}
-	return protoconv.MessageToAny(pbs), nil
+	return protoconv.MessageToAnyWithError(pbs)
 }
 
 func ToMap(s Spec) (map[string]any, error) {


### PR DESCRIPTION
**Please provide a description of this PR:**

Use the `MessageToAny `function defined by Istio to convert other proto type messages into Any types, thereby simplifying the code and unifying the interface