### PR TITLE
Fix proxyconfig annotation lead to kube-inject panic

### DIFF
--- a/istioctl/cmd/kubeinject.go
+++ b/istioctl/cmd/kubeinject.go
@@ -384,6 +384,23 @@ func setupKubeInjectParameters(sidecarTemplate *inject.RawTemplates, valuesConfi
 	revision, injectorAddress string,
 ) (*ExternalInjector, *meshconfig.MeshConfig, error) {
 	var err error
+	// Get configs from IOP files firstly, and if not exists, get configs from files and configmaps.
+	values, meshConfig, err := getIOPConfigs()
+	if err != nil {
+		return nil, nil, err
+	}
+	if meshConfig == nil {
+		if meshConfigFile != "" {
+			if meshConfig, err = mesh.ReadMeshConfig(meshConfigFile); err != nil {
+				return nil, nil, err
+			}
+		} else {
+			if meshConfig, err = getMeshConfigFromConfigMap(kubeconfig, "kube-inject", revision); err != nil {
+				return nil, nil, err
+			}
+		}
+	}
+
 	injector := &ExternalInjector{}
 	if injectConfigFile != "" {
 		injectionConfig, err := os.ReadFile(injectConfigFile) // nolint: vetshadow
@@ -404,24 +421,7 @@ func setupKubeInjectParameters(sidecarTemplate *inject.RawTemplates, valuesConfi
 				return nil, nil, err
 			}
 		}
-		return injector, nil, nil
-	}
-
-	// Get configs from IOP files firstly, and if not exists, get configs from files and configmaps.
-	values, meshConfig, err := getIOPConfigs()
-	if err != nil {
-		return nil, nil, err
-	}
-	if meshConfig == nil {
-		if meshConfigFile != "" {
-			if meshConfig, err = mesh.ReadMeshConfig(meshConfigFile); err != nil {
-				return nil, nil, err
-			}
-		} else {
-			if meshConfig, err = getMeshConfigFromConfigMap(kubeconfig, "kube-inject", revision); err != nil {
-				return nil, nil, err
-			}
-		}
+		return injector, meshConfig, nil
 	}
 
 	if values != "" {

--- a/istioctl/cmd/kubeinject_test.go
+++ b/istioctl/cmd/kubeinject_test.go
@@ -71,6 +71,14 @@ func TestKubeInject(t *testing.T) {
 				" "),
 			goldenFilename: "testdata/deployment/hello.yaml.iop.injected",
 		},
+		{ // case 7
+			args: strings.Split(
+				"kube-inject --meshConfigFile testdata/mesh-config.yaml"+
+					" --injectConfigFile testdata/inject-config.yaml -f testdata/deployment/hello-with-proxyconfig-anno.yaml"+
+					" --valuesFile testdata/inject-values.yaml",
+				" "),
+			goldenFilename: "testdata/deployment/hello-with-proxyconfig-anno.yaml.injected",
+		},
 	}
 
 	for i, c := range cases {

--- a/istioctl/cmd/testdata/deployment/hello-with-proxyconfig-anno.yaml
+++ b/istioctl/cmd/testdata/deployment/hello-with-proxyconfig-anno.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hello
+spec:
+  replicas: 7
+  selector:
+    matchLabels:
+      app: hello
+      tier: backend
+      track: stable
+  template:
+    metadata:
+      annotations:
+        proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
+      labels:
+        app: hello
+        tier: backend
+        track: stable
+    spec:
+      containers:
+        - name: hello
+          image: "fake.docker.io/google-samples/hello-go-gke:1.0"
+          ports:
+            - name: http
+              containerPort: 80

--- a/istioctl/cmd/testdata/deployment/hello-with-proxyconfig-anno.yaml.injected
+++ b/istioctl/cmd/testdata/deployment/hello-with-proxyconfig-anno.yaml.injected
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  name: hello
+spec:
+  replicas: 7
+  selector:
+    matchLabels:
+      app: hello
+      tier: backend
+      track: stable
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        prometheus.io/path: /stats/prometheus
+        prometheus.io/port: "15020"
+        prometheus.io/scrape: "true"
+        proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":null,"imagePullSecrets":null,"revision":"default"}'
+      creationTimestamp: null
+      labels:
+        app: hello
+        tier: backend
+        track: stable
+    spec:
+      containers:
+      - image: docker.io/istio/proxy_debug:unittest
+        name: istio-proxy
+        resources: {}
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: hello
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
+      initContainers:
+      - image: docker.io/istio/proxy_init:unittest-test
+        name: istio-init
+        resources: {}
+status: {}
+---

--- a/pkg/config/mesh/mesh.go
+++ b/pkg/config/mesh/mesh.go
@@ -141,11 +141,6 @@ func DefaultMeshConfig() *meshconfig.MeshConfig {
 // will not be modified.
 func ApplyProxyConfig(yaml string, meshConfig *meshconfig.MeshConfig) (*meshconfig.MeshConfig, error) {
 	mc := proto.Clone(meshConfig).(*meshconfig.MeshConfig)
-	if mc == nil {
-		mc = &meshconfig.MeshConfig{
-			DefaultConfig: DefaultProxyConfig(),
-		}
-	}
 	pc, err := applyProxyConfig(yaml, mc.DefaultConfig)
 	if err != nil {
 		return nil, err

--- a/pkg/config/mesh/mesh.go
+++ b/pkg/config/mesh/mesh.go
@@ -141,6 +141,11 @@ func DefaultMeshConfig() *meshconfig.MeshConfig {
 // will not be modified.
 func ApplyProxyConfig(yaml string, meshConfig *meshconfig.MeshConfig) (*meshconfig.MeshConfig, error) {
 	mc := proto.Clone(meshConfig).(*meshconfig.MeshConfig)
+	if mc == nil {
+		mc = &meshconfig.MeshConfig{
+			DefaultConfig: DefaultProxyConfig(),
+		}
+	}
 	pc, err := applyProxyConfig(yaml, mc.DefaultConfig)
 	if err != nil {
 		return nil, err

--- a/releasenotes/notes/40778.yaml
+++ b/releasenotes/notes/40778.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: istioctl
+releaseNotes:
+  - |
+    **Fixed** `kube-inject` crashes when the pod annotation `proxy.istio.io/config` is set.


### PR DESCRIPTION
**Please provide a description of this PR:**
MeshConfig is nil if injector exists. Set it to default proxyconfig to avoid of nil pointer panic.