### PR TITLE
Add new contains match for Authorization Policy

### DIFF
--- a/pilot/pkg/security/authz/matcher/header.go
+++ b/pilot/pkg/security/authz/matcher/header.go
@@ -24,13 +24,20 @@ import (
 
 // HeaderMatcher converts a key, value string pair to a corresponding HeaderMatcher.
 func HeaderMatcher(k, v string) *routepb.HeaderMatcher {
-	// We must check "*" first to make sure we'll generate a non empty value in the prefix/suffix case.
+	// We must check "*" first to make sure we'll generate a non empty value in the contains/prefix/suffix case.
 	// Empty prefix/suffix value is invalid in HeaderMatcher.
 	if v == "*" {
 		return &routepb.HeaderMatcher{
 			Name: k,
 			HeaderMatchSpecifier: &routepb.HeaderMatcher_PresentMatch{
 				PresentMatch: true,
+			},
+		}
+	} else if strings.HasPrefix(v, "*") && strings.HasSuffix(v, "*") {
+		return &routepb.HeaderMatcher{
+			Name: k,
+			HeaderMatchSpecifier: &routepb.HeaderMatcher_ContainsMatch{
+				ContainsMatch: v[1 : len(v)-1],
 			},
 		}
 	} else if strings.HasPrefix(v, "*") {

--- a/pilot/pkg/security/authz/matcher/header_test.go
+++ b/pilot/pkg/security/authz/matcher/header_test.go
@@ -43,13 +43,35 @@ func TestHeaderMatcher(t *testing.T) {
 			},
 		},
 		{
-			Name: "suffix match",
+			Name: "contains match",
 			K:    ":path",
 			V:    "*/productpage*",
 			Expect: &routepb.HeaderMatcher{
 				Name: ":path",
+				HeaderMatchSpecifier: &routepb.HeaderMatcher_ContainsMatch{
+					ContainsMatch: "/productpage",
+				},
+			},
+		},
+		{
+			Name: "suffix match",
+			K:    ":path",
+			V:    "*/productpage",
+			Expect: &routepb.HeaderMatcher{
+				Name: ":path",
 				HeaderMatchSpecifier: &routepb.HeaderMatcher_SuffixMatch{
-					SuffixMatch: "/productpage*",
+					SuffixMatch: "/productpage",
+				},
+			},
+		},
+		{
+			Name: "prefix match",
+			K:    ":path",
+			V:    "/productpage*",
+			Expect: &routepb.HeaderMatcher{
+				Name: ":path",
+				HeaderMatchSpecifier: &routepb.HeaderMatcher_PrefixMatch{
+					PrefixMatch: "/productpage",
 				},
 			},
 		},

--- a/releasenotes/notes/40784.yaml
+++ b/releasenotes/notes/40784.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: security
+issue:
+  - 40784
+releaseNotes:
+  - |
+    **Added** contains matching to Authorization Policy HeaderMatcher

--- a/releasenotes/notes/40784.yaml
+++ b/releasenotes/notes/40784.yaml
@@ -5,4 +5,9 @@ issue:
   - 40784
 releaseNotes:
   - |
-    **Added** contains matching to Authorization Policy HeaderMatcher
+    **Added** contains matching to Authorization Policy HeaderMatcher.
+  - |
+    **Improved** behavior where headers that were bracketed by two wildcards 
+    would match as suffix matches with the trailing wildcard being matched 
+    with the string in the header. New behavior will match the string between 
+    two wildcards as a contains match.


### PR DESCRIPTION
**Please provide a description of this PR:**
Adds a contains match to Authorization Policy header matching.

If a user wants to match on part of the header when the string to match is not either the prefix or suffix of the string, user can provide the match as `*<header-string-to-match>*` and these changes will check if the header contains the provided string which has been bounded with `*`. 

This change will replace the previous behavior of headers being bounded with `*` only matching on the suffix.  So instead of `*/productpage*` returning matches for `/productpage*`, it will instead return matches for `/productpage` and suffix matches are more strictly defined as `*/productpage`.

Fix Issue: https://github.com/istio/istio/issues/40784

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [x] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [x] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
