### PR TITLE
Apply WasmPlugin to Outbound traffic by the feature toggle

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -647,8 +647,9 @@ var (
 
 	SidecarIgnorePort = env.Register("SIDECAR_IGNORE_PORT_IN_HOST_MATCH", true, "If enabled, port will not be used in vhost domain matches.").Get()
 
-	ApplyWasmPluginsToOutbound = env.Register("APPLY_WASM_PLUGINS_TO_OUTBOUND", true, "If enabled, Wasm Plugins are applied to the outbound traffic of sidecars, too."+
-		"In other words, Wasm Plugins are applied to all the traffic directions.").Get()
+	ApplyWasmPluginsToOutbound = env.Register("APPLY_WASM_PLUGINS_TO_OUTBOUND", true,
+		"If enabled, Wasm Plugins are applied to the outbound traffic of sidecars, too."+
+			"In other words, Wasm Plugins are applied to all the traffic directions.").Get()
 )
 
 // EnableEndpointSliceController returns the value of the feature flag and whether it was actually specified.

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -646,6 +646,9 @@ var (
 		"If enabled, the cluster secret watcher will watch the namespace of the external cluster instead of config cluster").Get()
 
 	SidecarIgnorePort = env.Register("SIDECAR_IGNORE_PORT_IN_HOST_MATCH", true, "If enabled, port will not be used in vhost domain matches.").Get()
+
+	ApplyWasmPluginsToOutbound = env.Register("APPLY_WASM_PLUGINS_TO_OUTBOUND", true, "If enabled, Wasm Plugins are applied to the outbound traffic of sidecars, too."+
+		"In other words, Wasm Plugins are applied to all the traffic directions.").Get()
 )
 
 // EnableEndpointSliceController returns the value of the feature flag and whether it was actually specified.

--- a/pilot/pkg/networking/core/v1alpha3/listener_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_builder.go
@@ -354,7 +354,12 @@ func (lb *ListenerBuilder) buildHTTPConnectionManager(httpOpts *httpListenerOpts
 	routerFilterCtx, reqIDExtensionCtx := configureTracing(lb.push, lb.node, connectionManager, httpOpts.class)
 
 	filters := []*hcm.HttpFilter{}
-	wasm := lb.push.WasmPlugins(lb.node)
+	var wasm map[extensions.PluginPhase][]*model.WasmPluginWrapper
+	if features.ApplyWasmPluginsToOutbound || httpOpts.class != istionetworking.ListenerClassSidecarOutbound {
+		wasm = lb.push.WasmPlugins(lb.node)
+	} else {
+		wasm = make(map[extensions.PluginPhase][]*model.WasmPluginWrapper)
+	}
 	// TODO: how to deal with ext-authz? It will be in the ordering twice
 	filters = append(filters, lb.authzCustomBuilder.BuildHTTP(httpOpts.class)...)
 	filters = extension.PopAppend(filters, wasm, extensions.PluginPhase_AUTHN)


### PR DESCRIPTION
After https://github.com/istio/istio/pull/38595, WasmPlugin filter is injected for both inbound and outbound of sidecar traffic. 

This PR provides a feature toggle `APPLY_WASM_PLUGINS_TO_OUTBOUND` to select if apply WasmPlugin to outbound traffic or just inbound only. 

In case of Gateway, WasmPlugin is applied regardless of this toggle.