### PR TITLE
Make top level pkg/ default to T&R

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -24,6 +24,7 @@ Makefile*                                                        @istio/wg-test-
 /pilot/pkg/networking/core                                       @istio/wg-networking-maintainers-pilot
 /pilot/pkg/proxy                                                 @istio/wg-networking-maintainers-pilot
 /pkg/adsc/                                                       @istio/wg-networking-maintainers
+/pkg/                                                            @istio/wg-test-and-release-maintainers
 /pkg/bootstrap/                                                  @istio/wg-networking-maintainers
 /pkg/config/                                                     @istio/wg-networking-maintainers
 /pkg/dns/                                                        @istio/wg-networking-maintainers


### PR DESCRIPTION
This avoids all of the smaller helper libraries we have been adding
lately requiring top level owner approval. Most of these are generic
utils that seem reasonable to be under T&R. For anything not, they
should be explicily catagorized anyways - not top level.

**Please provide a description of this PR:**