### PR TITLE
accesslog: not fallback to meshconfig when telemetry.spec.accesslogs is empty

### DIFF
--- a/pilot/pkg/model/telemetry.go
+++ b/pilot/pkg/model/telemetry.go
@@ -388,12 +388,14 @@ func (t *Telemetries) applicableTelemetries(proxy *Proxy) computedTelemetries {
 		if telemetry != (Telemetry{}) {
 			key.Root = NamespacedName{Name: telemetry.Name, Namespace: telemetry.Namespace}
 			ms = append(ms, telemetry.Spec.GetMetrics()...)
-			ls = append(ls, &computedAccessLogging{
-				telemetryKey: telemetryKey{
-					Root: key.Root,
-				},
-				Logging: telemetry.Spec.GetAccessLogging(),
-			})
+			if len(telemetry.Spec.GetAccessLogging()) != 0 {
+				ls = append(ls, &computedAccessLogging{
+					telemetryKey: telemetryKey{
+						Root: key.Root,
+					},
+					Logging: telemetry.Spec.GetAccessLogging(),
+				})
+			}
 			ts = append(ts, telemetry.Spec.GetTracing()...)
 		}
 	}
@@ -403,12 +405,14 @@ func (t *Telemetries) applicableTelemetries(proxy *Proxy) computedTelemetries {
 		if telemetry != (Telemetry{}) {
 			key.Namespace = NamespacedName{Name: telemetry.Name, Namespace: telemetry.Namespace}
 			ms = append(ms, telemetry.Spec.GetMetrics()...)
-			ls = append(ls, &computedAccessLogging{
-				telemetryKey: telemetryKey{
-					Namespace: key.Namespace,
-				},
-				Logging: telemetry.Spec.GetAccessLogging(),
-			})
+			if len(telemetry.Spec.GetAccessLogging()) != 0 {
+				ls = append(ls, &computedAccessLogging{
+					telemetryKey: telemetryKey{
+						Namespace: key.Namespace,
+					},
+					Logging: telemetry.Spec.GetAccessLogging(),
+				})
+			}
 			ts = append(ts, telemetry.Spec.GetTracing()...)
 		}
 	}
@@ -422,12 +426,14 @@ func (t *Telemetries) applicableTelemetries(proxy *Proxy) computedTelemetries {
 		if selector.SubsetOf(proxy.Labels) {
 			key.Workload = NamespacedName{Name: telemetry.Name, Namespace: telemetry.Namespace}
 			ms = append(ms, spec.GetMetrics()...)
-			ls = append(ls, &computedAccessLogging{
-				telemetryKey: telemetryKey{
-					Workload: NamespacedName{Name: telemetry.Name, Namespace: telemetry.Namespace},
-				},
-				Logging: telemetry.Spec.GetAccessLogging(),
-			})
+			if len(telemetry.Spec.GetAccessLogging()) != 0 {
+				ls = append(ls, &computedAccessLogging{
+					telemetryKey: telemetryKey{
+						Workload: NamespacedName{Name: telemetry.Name, Namespace: telemetry.Namespace},
+					},
+					Logging: telemetry.Spec.GetAccessLogging(),
+				})
+			}
 			ts = append(ts, spec.GetTracing()...)
 			break
 		}

--- a/pilot/pkg/model/telemetry_logging_test.go
+++ b/pilot/pkg/model/telemetry_logging_test.go
@@ -78,6 +78,17 @@ func TestAccessLogging(t *testing.T) {
 		Labels:          labels,
 		Metadata:        &NodeMetadata{Labels: labels},
 	}
+	prometheus := &tpb.Telemetry{
+		Metrics: []*tpb.Metrics{
+			{
+				Providers: []*tpb.ProviderRef{
+					{
+						Name: "envoy",
+					},
+				},
+			},
+		},
+	}
 	envoy := &tpb.Telemetry{
 		AccessLogging: []*tpb.AccessLogging{
 			{
@@ -371,6 +382,43 @@ func TestAccessLogging(t *testing.T) {
 		{
 			"empty",
 			nil,
+			networking.ListenerClassSidecarOutbound,
+			sidecar,
+			nil,
+			nil, // No Telemetry API configured, fall back to legacy mesh config setting
+		},
+		{
+			"prometheus-mesh",
+			[]config.Config{newTelemetry("istio-system", prometheus)},
+			networking.ListenerClassSidecarOutbound,
+			sidecar,
+			nil,
+			nil, // No Telemetry API configured, fall back to legacy mesh config setting
+		},
+		{
+			"prometheus-namespace",
+			[]config.Config{newTelemetry("default", prometheus)},
+			networking.ListenerClassSidecarOutbound,
+			sidecar,
+			nil,
+			nil, // No Telemetry API configured, fall back to legacy mesh config setting
+		},
+		{
+			"prometheus-workload",
+			[]config.Config{newTelemetry("default", &tpb.Telemetry{
+				Selector: &v1beta1.WorkloadSelector{
+					MatchLabels: labels,
+				},
+				Metrics: []*tpb.Metrics{
+					{
+						Providers: []*tpb.ProviderRef{
+							{
+								Name: "envoy",
+							},
+						},
+					},
+				},
+			})},
 			networking.ListenerClassSidecarOutbound,
 			sidecar,
 			nil,

--- a/releasenotes/notes/40809.yaml
+++ b/releasenotes/notes/40809.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: telemetry
+
+releaseNotes:
+  - |
+    **Fixed** an issue when telemetry accesslogs is nil, will not fallback to use meshconfig.


### PR DESCRIPTION
**Please provide a description of this PR:**

bring in https://github.com/istio/istio/pull/39521