### PR TITLE
Configure MaxConcurrentReconciles for istio-operator

### DIFF
--- a/operator/cmd/mesh/root.go
+++ b/operator/cmd/mesh/root.go
@@ -45,14 +45,14 @@ const (
 If set to true, the user is not prompted and a Yes response is assumed in all cases.`
 	filenameFlagHelpStr = `Path to file containing IstioOperator custom resource
 This flag can be specified multiple times to overlay multiple files. Multiple files are overlaid in left to right order.`
-	installationCompleteStr = `Installation complete`
-	ForceFlagHelpStr        = `Proceed even with validation errors.`
-	MaxConcurrentReconcilesFlagHelpStr  = `Defines the concurrency limit for operator to reconcile IstioOperatorSpec in parallel. Default value is 1.`
-	KubeConfigFlagHelpStr   = `Path to kube config.`
-	ContextFlagHelpStr      = `The name of the kubeconfig context to use.`
-	HubFlagHelpStr          = `The hub for the operator controller image.`
-	TagFlagHelpStr          = `The tag for the operator controller image.`
-	ImagePullSecretsHelpStr = `The imagePullSecrets are used to pull the operator image from the private registry,
+	installationCompleteStr            = `Installation complete`
+	ForceFlagHelpStr                   = `Proceed even with validation errors.`
+	MaxConcurrentReconcilesFlagHelpStr = `Defines the concurrency limit for operator to reconcile IstioOperatorSpec in parallel. Default value is 1.`
+	KubeConfigFlagHelpStr              = `Path to kube config.`
+	ContextFlagHelpStr                 = `The name of the kubeconfig context to use.`
+	HubFlagHelpStr                     = `The hub for the operator controller image.`
+	TagFlagHelpStr                     = `The tag for the operator controller image.`
+	ImagePullSecretsHelpStr            = `The imagePullSecrets are used to pull the operator image from the private registry,
 could be secret list separated by comma, eg. '--imagePullSecrets imagePullSecret1,imagePullSecret2'`
 	OperatorNamespaceHelpstr = `The namespace the operator controller is installed into.`
 	OperatorRevFlagHelpStr   = `Target revision for the operator.`

--- a/operator/cmd/mesh/root.go
+++ b/operator/cmd/mesh/root.go
@@ -47,6 +47,7 @@ If set to true, the user is not prompted and a Yes response is assumed in all ca
 This flag can be specified multiple times to overlay multiple files. Multiple files are overlaid in left to right order.`
 	installationCompleteStr = `Installation complete`
 	ForceFlagHelpStr        = `Proceed even with validation errors.`
+	MaxConcurrentReconcilesFlagHelpStr  = `Defines the concurrency limit for operator to reconcile IstioOperatorSpec in parallel. Default value is 1.`
 	KubeConfigFlagHelpStr   = `Path to kube config.`
 	ContextFlagHelpStr      = `The name of the kubeconfig context to use.`
 	HubFlagHelpStr          = `The hub for the operator controller image.`

--- a/operator/cmd/operator/server.go
+++ b/operator/cmd/operator/server.go
@@ -50,7 +50,7 @@ const (
 type serverArgs struct {
 	// force proceeds even if there are validation errors
 	force bool
-
+	// maxConcurrentReconciles defines the concurrency limit for operator to reconcile IstioOperatorSpec in parallel
 	maxConcurrentReconciles int
 }
 

--- a/operator/cmd/operator/server.go
+++ b/operator/cmd/operator/server.go
@@ -50,10 +50,13 @@ const (
 type serverArgs struct {
 	// force proceeds even if there are validation errors
 	force bool
+
+	maxConcurrentReconciles int
 }
 
 func addServerFlags(cmd *cobra.Command, args *serverArgs) {
 	cmd.PersistentFlags().BoolVar(&args.force, "force", false, root.ForceFlagHelpStr)
+	cmd.PersistentFlags().IntVar(&args.maxConcurrentReconciles, "max-concurrent-reconciles", 1, root.MaxConcurrentReconcilesFlagHelpStr)
 }
 
 func serverCmd() *cobra.Command {
@@ -195,7 +198,7 @@ func run(sArgs *serverArgs) {
 	}
 
 	// Setup all Controllers
-	options := &istiocontrolplane.Options{Force: sArgs.force}
+	options := &istiocontrolplane.Options{Force: sArgs.force, MaxConcurrentReconciles: sArgs.maxConcurrentReconciles}
 	if err := controller.AddToManager(mgr, options); err != nil {
 		log.Fatalf("Could not add all controllers to operator manager: %v", err)
 	}

--- a/operator/pkg/controller/istiocontrolplane/istiocontrolplane_controller.go
+++ b/operator/pkg/controller/istiocontrolplane/istiocontrolplane_controller.go
@@ -77,6 +77,7 @@ var (
 
 type Options struct {
 	Force bool
+	MaxConcurrentReconciles int
 }
 
 const (
@@ -455,7 +456,7 @@ func Add(mgr manager.Manager, options *Options) error {
 func add(mgr manager.Manager, r *ReconcileIstioOperator) error {
 	scope.Info("Adding controller for IstioOperator.")
 	// Create a new controller
-	c, err := controller.New("istiocontrolplane-controller", mgr, controller.Options{Reconciler: r})
+	c, err := controller.New("istiocontrolplane-controller", mgr, controller.Options{Reconciler: r, MaxConcurrentReconciles: r.options.MaxConcurrentReconciles})
 	if err != nil {
 		return err
 	}

--- a/operator/pkg/controller/istiocontrolplane/istiocontrolplane_controller.go
+++ b/operator/pkg/controller/istiocontrolplane/istiocontrolplane_controller.go
@@ -449,14 +449,14 @@ func Add(mgr manager.Manager, options *Options) error {
 	if err != nil {
 		return fmt.Errorf("create Kubernetes client: %v", err)
 	}
-	return add(mgr, &ReconcileIstioOperator{client: mgr.GetClient(), scheme: mgr.GetScheme(), kubeClient: kubeClient, options: options})
+	return add(mgr, &ReconcileIstioOperator{client: mgr.GetClient(), scheme: mgr.GetScheme(), kubeClient: kubeClient, options: options}, options)
 }
 
-// add adds a new Controller to mgr with r as the reconcile.Reconciler
-func add(mgr manager.Manager, r *ReconcileIstioOperator) error {
+// add adds a new Controller to mgr with r as the reconcile.Reconciler along with options for additional configuration.
+func add(mgr manager.Manager, r *ReconcileIstioOperator, options *Options) error {
 	scope.Info("Adding controller for IstioOperator.")
 	// Create a new controller
-	c, err := controller.New("istiocontrolplane-controller", mgr, controller.Options{Reconciler: r, MaxConcurrentReconciles: r.options.MaxConcurrentReconciles})
+	c, err := controller.New("istiocontrolplane-controller", mgr, controller.Options{Reconciler: r, MaxConcurrentReconciles: options.MaxConcurrentReconciles})
 	if err != nil {
 		return err
 	}

--- a/operator/pkg/controller/istiocontrolplane/istiocontrolplane_controller.go
+++ b/operator/pkg/controller/istiocontrolplane/istiocontrolplane_controller.go
@@ -76,7 +76,7 @@ var (
 )
 
 type Options struct {
-	Force bool
+	Force                   bool
 	MaxConcurrentReconciles int
 }
 

--- a/releasenotes/notes/operator-max-concurrent-reconcile-40810.yaml
+++ b/releasenotes/notes/operator-max-concurrent-reconcile-40810.yaml
@@ -1,0 +1,34 @@
+apiVersion: release-notes/v2
+
+# This YAML file describes the format for specifying a release notes entry for Istio.
+# This should be filled in for all user facing changes.
+
+# kind describes the type of change that this represents.
+# Valid Values are:
+# - bug-fix -- Used to specify that this change represents a bug fix.
+# - security-fix -- Used to specify that this change represents a vulnerability fix.
+# - feature -- Used to specify a new feature that has been added.
+# - test -- Used to describe additional testing added. This file is optional for
+#   tests, but included for completeness.
+kind: feature
+
+# area describes the area that this change affects.
+# Valid values are:
+# - traffic-management
+# - security
+# - telemetry
+# - installation
+# - istioctl
+# - documentation
+area: installation
+
+# issue is a list of GitHub issues resolved in this note.
+# If issue is not in the current repo, specify its full URL instead.
+issue:
+- https://github.com/istio/istio/issues/40827
+
+# releaseNotes is a markdown listing of any user facing changes. This will appear in the
+# release notes.
+releaseNotes:
+- |
+  **Added** support for configuring NaxConcurrentReconciles in istio-operator.

--- a/releasenotes/notes/operator-max-concurrent-reconcile-40810.yaml
+++ b/releasenotes/notes/operator-max-concurrent-reconcile-40810.yaml
@@ -1,34 +1,8 @@
 apiVersion: release-notes/v2
-
-# This YAML file describes the format for specifying a release notes entry for Istio.
-# This should be filled in for all user facing changes.
-
-# kind describes the type of change that this represents.
-# Valid Values are:
-# - bug-fix -- Used to specify that this change represents a bug fix.
-# - security-fix -- Used to specify that this change represents a vulnerability fix.
-# - feature -- Used to specify a new feature that has been added.
-# - test -- Used to describe additional testing added. This file is optional for
-#   tests, but included for completeness.
 kind: feature
-
-# area describes the area that this change affects.
-# Valid values are:
-# - traffic-management
-# - security
-# - telemetry
-# - installation
-# - istioctl
-# - documentation
 area: installation
-
-# issue is a list of GitHub issues resolved in this note.
-# If issue is not in the current repo, specify its full URL instead.
 issue:
 - https://github.com/istio/istio/issues/40827
-
-# releaseNotes is a markdown listing of any user facing changes. This will appear in the
-# release notes.
 releaseNotes:
 - |
   **Added** support for configuring NaxConcurrentReconciles in istio-operator.

--- a/releasenotes/notes/operator-max-concurrent-reconcile-40810.yaml
+++ b/releasenotes/notes/operator-max-concurrent-reconcile-40810.yaml
@@ -5,4 +5,4 @@ issue:
 - https://github.com/istio/istio/issues/40827
 releaseNotes:
 - |
-  **Added** support for configuring NaxConcurrentReconciles in istio-operator.
+  **Added** support for configuring MaxConcurrentReconciles in istio-operator.


### PR DESCRIPTION
**Please provide a description of this PR:**
Currently we don't have the ability to configure `MaxConcurrentReconciles` hence it default to 1. This configuration knob allows > 1 IOPs to be processed in parallel.

Issue -> https://github.com/istio/istio/issues/40827