### PR TITLE
sets: add `InsertContains` to handle common dedupe cases

### DIFF
--- a/pilot/pkg/config/aggregate/config.go
+++ b/pilot/pkg/config/aggregate/config.go
@@ -123,9 +123,8 @@ func (cr *store) List(typ config.GroupVersionKind, namespace string) ([]config.C
 		}
 		for _, cfg := range storeConfigs {
 			key := cfg.GroupVersionKind.Kind + cfg.Namespace + cfg.Name
-			if !configMap.Contains(key) {
+			if !configMap.InsertContains(key) {
 				configs = append(configs, cfg)
-				configMap.Insert(key)
 			}
 		}
 	}

--- a/pilot/pkg/model/gateway.go
+++ b/pilot/pkg/model/gateway.go
@@ -153,11 +153,9 @@ func MergeGateways(gateways []gatewayWithInstances, proxy *Proxy, ps *PushContex
 		snames := sets.Set{}
 		for _, s := range gatewayCfg.Servers {
 			if len(s.Name) > 0 {
-				if snames.Contains(s.Name) {
+				if snames.InsertContains(s.Name) {
 					log.Warnf("Server name %s is not unique in gateway %s and may create possible issues like stat prefix collision ",
 						s.Name, gatewayName)
-				} else {
-					snames.Insert(s.Name)
 				}
 			}
 			if s.Port == nil {

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -1176,13 +1176,12 @@ func (cb *ClusterBuilder) normalizeClusters(clusters []*discovery.Resource) []*d
 	have := sets.Set{}
 	out := make([]*discovery.Resource, 0, len(clusters))
 	for _, c := range clusters {
-		if !have.Contains(c.Name) {
+		if !have.InsertContains(c.Name) {
 			out = append(out, c)
 		} else {
 			cb.req.Push.AddMetric(model.DuplicatedClusters, c.Name, cb.proxyID,
 				fmt.Sprintf("Duplicate cluster %s found while pushing CDS", c.Name))
 		}
-		have.Insert(c.Name)
 	}
 	return out
 }

--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -1042,9 +1042,8 @@ func filteredGatewayCipherSuites(server *networking.Server) []string {
 	validCiphers := sets.New()
 	for _, s := range suites {
 		if security.IsValidCipherSuite(s) {
-			if !validCiphers.Contains(s) {
+			if !validCiphers.InsertContains(s) {
 				ret = append(ret, s)
-				validCiphers = validCiphers.Insert(s)
 			} else if log.DebugEnabled() {
 				log.Debugf("ignoring duplicated cipherSuite: %q for server %s", s, server.String())
 			}

--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -391,7 +391,7 @@ func BuildSidecarOutboundVirtualHosts(node *model.Proxy, push *model.PushContext
 
 	buildVirtualHost := func(hostname string, vhwrapper istio_route.VirtualHostWrapper, svc *model.Service) *route.VirtualHost {
 		name := util.DomainName(hostname, vhwrapper.Port)
-		if duplicateVirtualHost(name, vhosts) {
+		if vhosts.InsertContains(name) {
 			// This means this virtual host has caused duplicate virtual host name.
 			var msg string
 			if svc == nil {
@@ -473,15 +473,6 @@ func BuildSidecarOutboundVirtualHosts(node *model.Proxy, push *model.PushContext
 	}
 
 	return out, nil, routeCache
-}
-
-// duplicateVirtualHost checks whether the virtual host with the same name exists in the route.
-func duplicateVirtualHost(vhost string, vhosts sets.Set) bool {
-	if vhosts.Contains(vhost) {
-		return true
-	}
-	vhosts.Insert(vhost)
-	return false
 }
 
 // dedupeDomains removes the duplicate domains from the passed in domains.

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -206,9 +206,8 @@ func filteredSidecarCipherSuites(suites []string) []string {
 	validCiphers := sets.New()
 	for _, s := range suites {
 		if security.IsValidCipherSuite(s) {
-			if !validCiphers.Contains(s) {
+			if !validCiphers.InsertContains(s) {
 				ret = append(ret, s)
-				validCiphers = validCiphers.Insert(s)
 			} else if log.DebugEnabled() {
 				log.Debugf("ignoring duplicated cipherSuite: %q", s)
 			}

--- a/pilot/pkg/networking/plugin/authn/util.go
+++ b/pilot/pkg/networking/plugin/authn/util.go
@@ -34,8 +34,7 @@ func dedupTrustDomains(tds []string) []string {
 	deduped := make([]string, 0, len(tds))
 
 	for _, td := range tds {
-		if td != "" && !known.Contains(td) {
-			known.Insert(td)
+		if td != "" && !known.InsertContains(td) {
 			deduped = append(deduped, td)
 		}
 	}

--- a/pilot/pkg/trustbundle/trustbundle.go
+++ b/pilot/pkg/trustbundle/trustbundle.go
@@ -141,8 +141,7 @@ func (tb *TrustBundle) mergeInternal() {
 
 	for _, configSource := range tb.sourceConfig {
 		for _, cert := range configSource.Certs {
-			if !certMap.Contains(cert) {
-				certMap.Insert(cert)
+			if !certMap.InsertContains(cert) {
 				mergeCerts = append(mergeCerts, cert)
 			}
 		}

--- a/pilot/test/xdstest/validate.go
+++ b/pilot/test/xdstest/validate.go
@@ -33,10 +33,9 @@ func ValidateListeners(t testing.TB, ls []*listener.Listener) {
 	t.Helper()
 	found := sets.New()
 	for _, l := range ls {
-		if found.Contains(l.Name) {
+		if found.InsertContains(l.Name) {
 			t.Errorf("duplicate listener name %v", l.Name)
 		}
-		found.Insert(l.Name)
 		ValidateListener(t, l)
 	}
 }
@@ -56,11 +55,10 @@ func ValidateListener(t testing.TB, l *listener.Listener) {
 func validateListenerFilters(t testing.TB, l *listener.Listener) {
 	found := sets.New()
 	for _, lf := range l.GetListenerFilters() {
-		if found.Contains(lf.GetName()) {
+		if found.InsertContains(lf.GetName()) {
 			// Technically legal in Envoy but should always be a bug when done in Istio based on our usage
 			t.Errorf("listener contains duplicate listener filter: %v", lf.GetName())
 		}
-		found.Insert(lf.GetName())
 	}
 }
 
@@ -220,10 +218,9 @@ func ValidateRoute(t testing.TB, r *route.Route) {
 func ValidateRouteConfigurations(t testing.TB, ls []*route.RouteConfiguration) {
 	found := sets.New()
 	for _, l := range ls {
-		if found.Contains(l.Name) {
+		if found.InsertContains(l.Name) {
 			t.Errorf("duplicate route config name %v", l.Name)
 		}
-		found.Insert(l.Name)
 		ValidateRouteConfiguration(t, l)
 	}
 }
@@ -242,15 +239,13 @@ func validateRouteConfigurationDomains(t testing.TB, l *route.RouteConfiguration
 	vhosts := sets.New()
 	domains := sets.New()
 	for _, vhost := range l.VirtualHosts {
-		if vhosts.Contains(vhost.Name) {
+		if vhosts.InsertContains(vhost.Name) {
 			t.Errorf("duplicate virtual host found %s", vhost.Name)
 		}
-		vhosts.Insert(vhost.Name)
 		for _, domain := range vhost.Domains {
-			if domains.Contains(domain) {
+			if domains.InsertContains(domain) {
 				t.Errorf("duplicate virtual host domain found %s", domain)
 			}
-			domains.Insert(domain)
 		}
 	}
 }

--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -759,8 +759,7 @@ func removeDuplicates(values []string) []string {
 	set := sets.New()
 	newValues := make([]string, 0, len(values))
 	for _, v := range values {
-		if !set.Contains(v) {
-			set.Insert(v)
+		if !set.InsertContains(v) {
 			newValues = append(newValues, v)
 		}
 	}

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -580,10 +580,8 @@ func validateTLSOptions(tls *networking.ServerTLSSettings) (v Validation) {
 	for _, cs := range tls.CipherSuites {
 		if !security.IsValidCipherSuite(cs) {
 			invalidCiphers.Insert(cs)
-		} else {
-			if validCiphers.InsertContains(cs) {
-				duplicateCiphers.Insert(cs)
-			}
+		} else if validCiphers.InsertContains(cs) {
+			duplicateCiphers.Insert(cs)
 		}
 	}
 

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -581,9 +581,7 @@ func validateTLSOptions(tls *networking.ServerTLSSettings) (v Validation) {
 		if !security.IsValidCipherSuite(cs) {
 			invalidCiphers.Insert(cs)
 		} else {
-			if !validCiphers.Contains(cs) {
-				validCiphers.Insert(cs)
-			} else {
+			if validCiphers.InsertContains(cs) {
 				duplicateCiphers.Insert(cs)
 			}
 		}
@@ -3842,10 +3840,9 @@ func validateWasmPluginVMConfig(vm *extensions.VmConfig) error {
 			return fmt.Errorf("spec.vmConfig.env invalid")
 		}
 
-		if keys.Contains(env.Name) {
+		if keys.InsertContains(env.Name) {
 			return fmt.Errorf("duplicate env")
 		}
-		keys.Insert(env.Name)
 	}
 
 	return nil

--- a/pkg/test/framework/components/echo/namespacedname.go
+++ b/pkg/test/framework/components/echo/namespacedname.go
@@ -88,14 +88,9 @@ func (n NamespacedNames) NamesWithNamespacePrefix() []string {
 
 func (n NamespacedNames) uniqueSortedNames(getName func(NamespacedName) string) []string {
 	set := sets.NewWithLength(n.Len())
-	out := make([]string, 0, n.Len())
 	for _, nn := range n {
 		name := getName(nn)
-		if !set.Contains(name) {
-			set.Insert(name)
-			out = append(out, name)
-		}
+		set.Insert(name)
 	}
-	sort.Strings(out)
-	return out
+	return set.SortedList()
 }

--- a/pkg/test/framework/suitecontext.go
+++ b/pkg/test/framework/suitecontext.go
@@ -105,8 +105,7 @@ func (c *suiteContext) allocateContextID(prefix string) string {
 	candidate := prefix
 	discriminator := 0
 	for {
-		if !c.contextNames.Contains(candidate) {
-			c.contextNames.Insert(candidate)
+		if !c.contextNames.InsertContains(candidate) {
 			return candidate
 		}
 

--- a/pkg/util/sets/string.go
+++ b/pkg/util/sets/string.go
@@ -150,6 +150,20 @@ func (s Set) SortedList() []string {
 	return res
 }
 
+// InsertContains inserts the item into the set and returns if it was already present.
+// Example:
+//
+//		if !set.InsertContains(item) {
+//			fmt.Println("Added item for the first time", item)
+//	  }
+func (s Set) InsertContains(item string) bool {
+	if s.Contains(item) {
+		return true
+	}
+	s[item] = struct{}{}
+	return false
+}
+
 // Contains returns whether the given item is in the set.
 func (s Set) Contains(item string) bool {
 	_, ok := s[item]

--- a/pkg/util/sets/string_test.go
+++ b/pkg/util/sets/string_test.go
@@ -209,3 +209,11 @@ func TestInsertAll(t *testing.T) {
 		})
 	}
 }
+
+func TestInsertContains(t *testing.T) {
+	s := New()
+	assert.Equal(t, s.InsertContains("k1"), false)
+	assert.Equal(t, s.InsertContains("k1"), true)
+	assert.Equal(t, s.InsertContains("k2"), false)
+	assert.Equal(t, s.InsertContains("k2"), true)
+}

--- a/security/pkg/nodeagent/caclient/providers/google-cas/client.go
+++ b/security/pkg/nodeagent/caclient/providers/google-cas/client.go
@@ -133,9 +133,7 @@ func (r *GoogleCASClient) GetRootCertBundle() ([]string, error) {
 	for _, certChain := range resp.CaCerts {
 		certs := certChain.Certificates
 		rootCert := certs[len(certs)-1]
-		if !rootCertSet.Contains(rootCert) {
-			rootCertSet.Insert(rootCert)
-		}
+		rootCertSet.Insert(rootCert)
 	}
 
 	return rootCertSet.SortedList(), nil

--- a/tests/fuzz/regression_test.go
+++ b/tests/fuzz/regression_test.go
@@ -167,10 +167,9 @@ func TestFuzzers(t *testing.T) {
 		{"FuzzCRDRoundtrip", FuzzCRDRoundtrip},
 	}
 	for _, tt := range cases {
-		if testedFuzzers.Contains(tt.name) {
+		if testedFuzzers.InsertContains(tt.name) {
 			t.Fatalf("dupliate fuzzer test %v", tt.name)
 		}
-		testedFuzzers.Insert(tt.name)
 		t.Run(tt.name, func(t *testing.T) {
 			runRegressionTest(t, tt.name, tt.fuzzer)
 		})

--- a/tests/integration/telemetry/stackdriver/common.go
+++ b/tests/integration/telemetry/stackdriver/common.go
@@ -359,10 +359,9 @@ func logDiff(t test.Failer, tp string, query map[string]string, entries []map[st
 	for _, s := range entries {
 		b, _ := json.Marshal(s)
 		ss := string(b)
-		if seen.Contains(ss) {
+		if seen.InsertContains(ss) {
 			continue
 		}
-		seen.Insert(ss)
 		misMatched := map[string]string{}
 		for k, want := range query {
 			got := s[k]


### PR DESCRIPTION
it is a common pattern to build a set as we iterate, to check for
duplicates. This introduces a new function to ease this pattern.
No behavior change expected, just simpler code.