### PR TITLE
Add validations for workload selector

### DIFF
--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -798,6 +798,12 @@ var ValidateEnvoyFilter = registerValidateFunc("ValidateEnvoyFilter",
 			return nil, err
 		}
 
+		// If workloadSelector is defined and labels are not set, it is most likely
+		// an user error. Marking it as a warning to keep it backwards compatible.
+		if rule.WorkloadSelector != nil && len(rule.WorkloadSelector.Labels) == 0 {
+			errs = appendValidation(errs, WrapWarning(fmt.Errorf("Envoy filter: labels not defined in workload selector"))) // nolint: stylecheck
+		}
+
 		for _, cp := range rule.ConfigPatches {
 			if cp == nil {
 				errs = appendValidation(errs, fmt.Errorf("Envoy filter: null config patch")) // nolint: stylecheck

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -767,8 +767,10 @@ func validateExportTo(namespace string, exportTo []string, isServiceEntry bool, 
 	return
 }
 
-func validateAlphaWorkloadSelector(selector *networking.WorkloadSelector) error {
+func validateAlphaWorkloadSelector(selector *networking.WorkloadSelector) (Warning, error) {
 	var errs error
+	var warning Warning
+
 	if selector != nil {
 		for k, v := range selector.Labels {
 			if k == "" {
@@ -780,9 +782,12 @@ func validateAlphaWorkloadSelector(selector *networking.WorkloadSelector) error 
 					fmt.Errorf("wildcard is not supported in selector: %q", fmt.Sprintf("%s=%s", k, v)))
 			}
 		}
+		if len(selector.Labels) == 0 {
+			warning = fmt.Errorf("workload selector specified without labels") // nolint: stylecheck
+		}
 	}
 
-	return errs
+	return warning, errs
 }
 
 // ValidateEnvoyFilter checks envoy filter config supplied by user
@@ -794,14 +799,16 @@ var ValidateEnvoyFilter = registerValidateFunc("ValidateEnvoyFilter",
 			return nil, fmt.Errorf("cannot cast to Envoy filter")
 		}
 
-		if err := validateAlphaWorkloadSelector(rule.WorkloadSelector); err != nil {
+		warning, err := validateAlphaWorkloadSelector(rule.WorkloadSelector)
+		if err != nil {
 			return nil, err
 		}
 
 		// If workloadSelector is defined and labels are not set, it is most likely
 		// an user error. Marking it as a warning to keep it backwards compatible.
-		if rule.WorkloadSelector != nil && len(rule.WorkloadSelector.Labels) == 0 {
-			errs = appendValidation(errs, WrapWarning(fmt.Errorf("Envoy filter: labels not defined in workload selector"))) // nolint: stylecheck
+		if warning != nil {
+			errs = appendValidation(errs, WrapWarning(fmt.Errorf("Envoy filter: %s, will be applied to all services in namespace",
+				warning))) // nolint: stylecheck
 		}
 
 		for _, cp := range rule.ConfigPatches {
@@ -1096,8 +1103,16 @@ var ValidateSidecar = registerValidateFunc("ValidateSidecar",
 			return nil, fmt.Errorf("cannot cast to Sidecar")
 		}
 
-		if err := validateAlphaWorkloadSelector(rule.WorkloadSelector); err != nil {
+		warning, err := validateAlphaWorkloadSelector(rule.WorkloadSelector)
+		if err != nil {
 			return nil, err
+		}
+
+		// If workloadSelector is defined and labels are not set, it is most likely
+		// an user error. Marking it as a warning to keep it backwards compatible.
+		if warning != nil {
+			errs = appendValidation(errs, WrapWarning(fmt.Errorf("sidecar: %s, will be applied to all services in namespace",
+				warning))) // nolint: stylecheck
 		}
 
 		if len(rule.Egress) == 0 && len(rule.Ingress) == 0 && rule.OutboundTrafficPolicy == nil {
@@ -3217,11 +3232,19 @@ var ValidateServiceEntry = registerValidateFunc("ValidateServiceEntry",
 			return nil, fmt.Errorf("cannot cast to service entry")
 		}
 
-		if err := validateAlphaWorkloadSelector(serviceEntry.WorkloadSelector); err != nil {
+		errs := Validation{}
+
+		warning, err := validateAlphaWorkloadSelector(serviceEntry.WorkloadSelector)
+		if err != nil {
 			return nil, err
 		}
 
-		errs := Validation{}
+		// If workloadSelector is defined and labels are not set, it is most likely
+		// an user error. Marking it as a warning to keep it backwards compatible.
+		if warning != nil {
+			errs = appendValidation(errs, WrapWarning(fmt.Errorf("service entry: %s, will be applied to all services in namespace",
+				warning))) // nolint: stylecheck
+		}
 
 		if serviceEntry.WorkloadSelector != nil && serviceEntry.Endpoints != nil {
 			errs = appendValidation(errs, fmt.Errorf("only one of WorkloadSelector or Endpoints is allowed in Service Entry"))

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -807,8 +807,7 @@ var ValidateEnvoyFilter = registerValidateFunc("ValidateEnvoyFilter",
 		// If workloadSelector is defined and labels are not set, it is most likely
 		// an user error. Marking it as a warning to keep it backwards compatible.
 		if warning != nil {
-			errs = appendValidation(errs, WrapWarning(fmt.Errorf("Envoy filter: %s, will be applied to all services in namespace",
-				warning))) // nolint: stylecheck
+			errs = appendValidation(errs, WrapWarning(fmt.Errorf("Envoy filter: %s, will be applied to all services in namespace", warning))) // nolint: stylecheck
 		}
 
 		for _, cp := range rule.ConfigPatches {

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -3997,7 +3997,9 @@ func TestValidateEnvoyFilter(t *testing.T) {
 		warning string
 	}{
 		{name: "empty filters", in: &networking.EnvoyFilter{}, error: ""},
-
+		{name: "labels not defined in workload selector", in: &networking.EnvoyFilter{
+			WorkloadSelector: &networking.WorkloadSelector{},
+		}, error: "", warning: "Envoy filter: labels not defined in workload selector"},
 		{name: "invalid applyTo", in: &networking.EnvoyFilter{
 			ConfigPatches: []*networking.EnvoyFilter_EnvoyConfigObjectPatch{
 				{

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -5817,7 +5817,7 @@ func TestValidateSidecar(t *testing.T) {
 					Hosts: []string{"*/*"},
 				},
 			},
-		}, true, true},
+		}, true, false},
 		{"workload selector without labels", &networking.Sidecar{
 			Egress: []*networking.IstioEgressListener{
 				{
@@ -5825,7 +5825,7 @@ func TestValidateSidecar(t *testing.T) {
 				},
 			},
 			WorkloadSelector: &networking.WorkloadSelector{},
-		}, true, false},
+		}, true, true},
 		{"import local namespace with wildcard", &networking.Sidecar{
 			Egress: []*networking.IstioEgressListener{
 				{


### PR DESCRIPTION
**Please provide a description of this PR:**
Istio CRDs like EF, SE, Sidecar allows specifying workloadSelector without labels - which could be unintentional. The present behavior is to apply CRDs to all proxies in the namespace. This PR does not change that behavior, but adds a warning if a workload selector is specified without the labels.