### PR TITLE
support failover service in DestinationRule

### DIFF
--- a/releasenotes/notes/39445.yaml
+++ b/releasenotes/notes/39445.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+issue:
+  - https://github.com/istio/istio/issues/39445
+releaseNotes:
+  - |
+    **Add** annotations"traffic.istio.io/failoverService","traffic.istio.io/failoverServicePort" and "traffic.istio.io/failoverServiceOverProvisioningFactor"
+    in DestinationRule, if the failoverService configured and the upstream cluster is down, instead of responding 503 no healthy upstream, traffic
+    will be routed to the failover service.


### PR DESCRIPTION
Try to implement https://github.com/istio/istio/issues/39445

Introduced 3 annotations in DestinationRule and Leverage envoy[Priority levels](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/load_balancing/priority#priority-levels) to achieve the failover.

With failover service specified, eds will merge the upstream service endpoints with the failover service endpoints and do traffic failover based on the overprovisioning factor.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [x] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
