### PR TITLE
[release-1.15] accesslog: not fallback to meshconfig when telemetry.spec.accesslogs is empty

### DIFF
--- a/pilot/pkg/model/telemetry.go
+++ b/pilot/pkg/model/telemetry.go
@@ -388,12 +388,14 @@ func (t *Telemetries) applicableTelemetries(proxy *Proxy) computedTelemetries {
 		if telemetry != (Telemetry{}) {
 			key.Root = NamespacedName{Name: telemetry.Name, Namespace: telemetry.Namespace}
 			ms = append(ms, telemetry.Spec.GetMetrics()...)
-			ls = append(ls, &computedAccessLogging{
-				telemetryKey: telemetryKey{
-					Root: key.Root,
-				},
-				Logging: telemetry.Spec.GetAccessLogging(),
-			})
+			if len(telemetry.Spec.GetAccessLogging()) != 0 {
+				ls = append(ls, &computedAccessLogging{
+					telemetryKey: telemetryKey{
+						Root: key.Root,
+					},
+					Logging: telemetry.Spec.GetAccessLogging(),
+				})
+			}
 			ts = append(ts, telemetry.Spec.GetTracing()...)
 		}
 	}
@@ -403,12 +405,14 @@ func (t *Telemetries) applicableTelemetries(proxy *Proxy) computedTelemetries {
 		if telemetry != (Telemetry{}) {
 			key.Namespace = NamespacedName{Name: telemetry.Name, Namespace: telemetry.Namespace}
 			ms = append(ms, telemetry.Spec.GetMetrics()...)
-			ls = append(ls, &computedAccessLogging{
-				telemetryKey: telemetryKey{
-					Namespace: key.Namespace,
-				},
-				Logging: telemetry.Spec.GetAccessLogging(),
-			})
+			if len(telemetry.Spec.GetAccessLogging()) != 0 {
+				ls = append(ls, &computedAccessLogging{
+					telemetryKey: telemetryKey{
+						Namespace: key.Namespace,
+					},
+					Logging: telemetry.Spec.GetAccessLogging(),
+				})
+			}
 			ts = append(ts, telemetry.Spec.GetTracing()...)
 		}
 	}
@@ -422,12 +426,14 @@ func (t *Telemetries) applicableTelemetries(proxy *Proxy) computedTelemetries {
 		if selector.SubsetOf(proxy.Metadata.Labels) {
 			key.Workload = NamespacedName{Name: telemetry.Name, Namespace: telemetry.Namespace}
 			ms = append(ms, spec.GetMetrics()...)
-			ls = append(ls, &computedAccessLogging{
-				telemetryKey: telemetryKey{
-					Workload: NamespacedName{Name: telemetry.Name, Namespace: telemetry.Namespace},
-				},
-				Logging: telemetry.Spec.GetAccessLogging(),
-			})
+			if len(telemetry.Spec.GetAccessLogging()) != 0 {
+				ls = append(ls, &computedAccessLogging{
+					telemetryKey: telemetryKey{
+						Workload: NamespacedName{Name: telemetry.Name, Namespace: telemetry.Namespace},
+					},
+					Logging: telemetry.Spec.GetAccessLogging(),
+				})
+			}
 			ts = append(ts, spec.GetTracing()...)
 			break
 		}

--- a/releasenotes/notes/40809.yaml
+++ b/releasenotes/notes/40809.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: telemetry
+
+releaseNotes:
+  - |
+    **Fixed** an issue when telemetry accesslogs is nil, will not fallback to use meshconfig.


### PR DESCRIPTION
**Please provide a description of this PR:**

manual cherry-pick of https://github.com/istio/istio/pull/40809

fixes: https://github.com/istio/istio/issues/40848

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [x] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
