### PR TITLE
accesslog: fallback to meshconfig when built-in provider's format is unset

### DIFF
--- a/pilot/pkg/model/telemetry_logging.go
+++ b/pilot/pkg/model/telemetry_logging.go
@@ -58,7 +58,7 @@ const (
 
 	DevStdout = "/dev/stdout"
 
-	defaultEnvoyAccessLogProvider = "envoy"
+	builtinEnvoyAccessLogProvider = "envoy"
 )
 
 var (
@@ -116,8 +116,8 @@ func telemetryAccessLog(push *PushContext, fp *meshconfig.MeshConfig_ExtensionPr
 	var al *accesslog.AccessLog
 	switch prov := fp.Provider.(type) {
 	case *meshconfig.MeshConfig_ExtensionProvider_EnvoyFileAccessLog:
-		// For built-in provider, fallback to Mesh Config for formatting options.
-		if fp.Name == defaultEnvoyAccessLogProvider {
+		// For built-in provider, fallback to MeshConfig for formatting options when LogFormat unset.
+		if fp.Name == builtinEnvoyAccessLogProvider && prov.EnvoyFileAccessLog.LogFormat == nil {
 			al = FileAccessLogFromMeshConfig(prov.EnvoyFileAccessLog.Path, push.Mesh)
 		} else {
 			al = fileAccessLogFromTelemetry(prov.EnvoyFileAccessLog)

--- a/releasenotes/notes/40851.yaml
+++ b/releasenotes/notes/40851.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: telemetry
+
+releaseNotes:
+  - |
+    **Fixed** an issue that built-in provider should fallback to meshconfig when format is unset.


### PR DESCRIPTION
**Please provide a description of this PR:**

this's a follow up of https://github.com/istio/istio/pull/39521#discussion_r920547732

cc @douglas-reid @ramaraochavali 