### PR TITLE
Fix creating configmap and service in TestTunnelingOutboundTraffic

### DIFF
--- a/tests/integration/pilot/testdata/forward-proxy/configmap.tmpl.yaml
+++ b/tests/integration/pilot/testdata/forward-proxy/configmap.tmpl.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: external-forward-proxy-config
+data:
+  envoy.yaml: |-
+{{ .envoyYaml | indent 4 }}
+  external-forward-proxy-key.pem: |-
+{{ .keyPem | indent 4 }}
+  external-forward-proxy-cert.pem: |-
+{{ .certPem | indent 4 }}

--- a/tests/integration/pilot/testdata/forward-proxy/service.tmpl.yaml
+++ b/tests/integration/pilot/testdata/forward-proxy/service.tmpl.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: external-forward-proxy
+spec:
+  selector:
+    app: external-forward-proxy
+  ports:
+{{- range $idx, $port := .ports }}
+  - name: {{$port.Name}}
+    port: {{$port.Port}}
+    targetPort: {{$port.TargetPort}}
+    protocol: TCP
+{{- end }}


### PR DESCRIPTION
Signed-off-by: Jacek Ewertowski <jewertow@redhat.com>

**Please provide a description of this PR:**

This change fixes TestTunnelingOutboundTraffic that sometimes fails with the following error:
```
{Failed      tunneling_test.go:234: failed to create config map external-forward-proxy-config: configmaps "external-forward-proxy-config" already exists}
```
It was not necessary to create configmap and service from file to fix this error, but I did it for the sake of consistency.

**Related issue:** #40812 