### PR TITLE
adsc: Skip to ack for debug type responses 

### DIFF
--- a/pkg/adsc/adsc.go
+++ b/pkg/adsc/adsc.go
@@ -1149,6 +1149,13 @@ func (a *ADSC) sendRsc(typeurl string, rsc []string) {
 
 func (a *ADSC) ack(msg *discovery.DiscoveryResponse) {
 	var resources []string
+
+	if strings.HasPrefix(msg.TypeUrl, v3.DebugType) {
+		// If the response is for istio.io/debug or istio.io/debug/*,
+		// skip to send ACK.
+		return
+	}
+
 	if msg.TypeUrl == v3.EndpointType {
 		for c := range a.edsClusters {
 			resources = append(resources, c)


### PR DESCRIPTION
Regarding https://github.com/istio/istio/issues/40824, to prevent the infinite "ack" loop, 
this PR proposes to skip to "ack" for the debug type response.

Please note that, currently, the debug type is handled with the special way in `pilot`, so `pilot` generates responses  regardless of whether it is a request or ack.

Alternative way is that `pilot` does not send any responses if "nonce" is prefixed by `pilot` own way, because ADSC generates a nonce for a request (not ack) with a form of "date/time".
