### PR TITLE
Use constants for "istio.io/debug" strings

### DIFF
--- a/pilot/pkg/xds/debuggen.go
+++ b/pilot/pkg/xds/debuggen.go
@@ -24,13 +24,9 @@ import (
 
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	anypb "google.golang.org/protobuf/types/known/anypb"
+	v3 "istio.io/istio/pilot/pkg/xds/v3"
 
 	"istio.io/istio/pilot/pkg/model"
-)
-
-const (
-	// TypeDebug requests debug info from istio, a secured implementation for istio debug interface
-	TypeDebug = "istio.io/debug"
 )
 
 var activeNamespaceDebuggers = map[string]struct{}{
@@ -124,7 +120,7 @@ func (dg *DebugGen) Generate(proxy *model.Proxy, w *model.WatchedResource, req *
 	res = append(res, &discovery.Resource{
 		Name: resourceName,
 		Resource: &anypb.Any{
-			TypeUrl: TypeDebug,
+			TypeUrl: v3.DebugType,
 			Value:   buffer.Bytes(),
 		},
 	})

--- a/pilot/pkg/xds/debuggen.go
+++ b/pilot/pkg/xds/debuggen.go
@@ -24,9 +24,9 @@ import (
 
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	anypb "google.golang.org/protobuf/types/known/anypb"
-	v3 "istio.io/istio/pilot/pkg/xds/v3"
 
 	"istio.io/istio/pilot/pkg/model"
+	v3 "istio.io/istio/pilot/pkg/xds/v3"
 )
 
 var activeNamespaceDebuggers = map[string]struct{}{

--- a/pilot/pkg/xds/discovery.go
+++ b/pilot/pkg/xds/discovery.go
@@ -585,7 +585,7 @@ func (s *DiscoveryServer) InitGenerators(env *model.Environment, systemNameSpace
 	s.Generators["api/"+TypeURLConnect] = s.StatusGen
 
 	s.Generators["event"] = s.StatusGen
-	s.Generators[TypeDebug] = NewDebugGen(s, systemNameSpace, internalDebugMux)
+	s.Generators[v3.DebugType] = NewDebugGen(s, systemNameSpace, internalDebugMux)
 	s.Generators[v3.BootstrapType] = &BootstrapGenerator{Server: s}
 }
 

--- a/pilot/pkg/xds/statusgen.go
+++ b/pilot/pkg/xds/statusgen.go
@@ -40,11 +40,13 @@ const (
 	// This includes all the info that envoy (client) provides.
 	TypeURLNACK = "istio.io/nack"
 
+	TypeDebugPrefix = v3.DebugType + "/"
+
 	// TypeDebugSyncronization requests Envoy CSDS for proxy sync status
-	TypeDebugSyncronization = "istio.io/debug/syncz"
+	TypeDebugSyncronization = v3.DebugType + "/syncz"
 
 	// TypeDebugConfigDump requests Envoy configuration for a proxy without creating one
-	TypeDebugConfigDump = "istio.io/debug/config_dump"
+	TypeDebugConfigDump = v3.DebugType + "/config_dump"
 
 	// TODO: TypeURLReady - readiness events for endpoints, agent can propagate
 )

--- a/pilot/pkg/xds/xdsgen.go
+++ b/pilot/pkg/xds/xdsgen.go
@@ -75,7 +75,7 @@ func (s *DiscoveryServer) findGenerator(typeURL string, con *Connection) model.X
 	// some types to use custom generators - for example EDS.
 	g := con.proxy.XdsResourceGenerator
 	if g == nil {
-		if strings.HasPrefix(typeURL, "istio.io/debug/") {
+		if strings.HasPrefix(typeURL, TypeDebugPrefix) {
 			g = s.Generators["event"]
 		} else {
 			// TODO move this to just directly using the resource TypeUrl

--- a/pkg/istio-agent/tap_proxy.go
+++ b/pkg/istio-agent/tap_proxy.go
@@ -50,7 +50,7 @@ func (p *tapProxy) StreamAggregatedResources(downstream xds.DiscoveryStream) err
 		log.Errorf("failed to recv: %v", err)
 		return err
 	}
-	if strings.HasPrefix(req.TypeUrl, "istio.io/debug/") {
+	if strings.HasPrefix(req.TypeUrl, xds.TypeDebugPrefix) {
 		if resp, err := p.xdsProxy.tapRequest(req, timeout); err == nil {
 			err := downstream.Send(resp)
 			if err != nil {

--- a/pkg/istio-agent/xds_proxy.go
+++ b/pkg/istio-agent/xds_proxy.go
@@ -553,7 +553,7 @@ func (p *XdsProxy) handleUpstreamResponse(con *ProxyConnection) {
 					forwardToEnvoy(con, resp)
 				}
 			default:
-				if strings.HasPrefix(resp.TypeUrl, "istio.io/debug") {
+				if strings.HasPrefix(resp.TypeUrl, v3.DebugType) {
 					p.forwardToTap(resp)
 				} else {
 					forwardToEnvoy(con, resp)

--- a/tests/integration/pilot/piggyback_test.go
+++ b/tests/integration/pilot/piggyback_test.go
@@ -24,6 +24,7 @@ import (
 
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 
+	"istio.io/istio/pilot/pkg/xds"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/istioctl"
 	"istio.io/istio/pkg/test/util/retry"
@@ -52,7 +53,7 @@ func TestPiggyback(t *testing.T) {
 				if err := protomarshal.Unmarshal([]byte(out), &dr); err != nil {
 					return fmt.Errorf("unmarshal: %v", err)
 				}
-				if dr.TypeUrl != "istio.io/debug/syncz" {
+				if dr.TypeUrl != xds.TypeDebugSyncronization {
 					return fmt.Errorf("the output doesn't contain expected typeURL: %s", out)
 				}
 				if len(dr.Resources) < 1 {


### PR DESCRIPTION
Use constants instead of hard coded "istio.io/debug*" string.