### PR TITLE
Disable full push on scale from 1->0->1

### DIFF
--- a/pilot/pkg/model/endpointshards.go
+++ b/pilot/pkg/model/endpointshards.go
@@ -199,14 +199,6 @@ func (e *EndpointIndex) deleteServiceInner(shard ShardKey, serviceName, namespac
 	epShards := e.shardsBySvc[serviceName][namespace]
 	epShards.Lock()
 	delete(epShards.Shards, shard)
-	epShards.ServiceAccounts = sets.Set{}
-	for _, shard := range epShards.Shards {
-		for _, ep := range shard {
-			if ep.ServiceAccount != "" {
-				epShards.ServiceAccounts.Insert(ep.ServiceAccount)
-			}
-		}
-	}
 	// Clear the cache here to avoid race in cache writes.
 	e.clearCacheForService(serviceName, namespace)
 	if !preserveKeys {

--- a/pilot/pkg/xds/eds_test.go
+++ b/pilot/pkg/xds/eds_test.go
@@ -559,6 +559,7 @@ func TestEndpointFlipFlops(t *testing.T) {
 				Address:         "10.10.1.1",
 				ServicePortName: "http",
 				EndpointPort:    8080,
+				ServiceAccount:  "sa",
 			},
 		})
 
@@ -675,27 +676,6 @@ func TestUpdateServiceAccount(t *testing.T) {
 				t.Errorf("expect UpdateServiceAccount %v, but got %v", tc.expect, ret)
 			}
 		})
-	}
-}
-
-func TestZeroEndpointShardSA(t *testing.T) {
-	cluster1Endppoints := []*model.IstioEndpoint{
-		{Address: "10.172.0.1", ServiceAccount: "sa1"},
-	}
-	s := new(xds.DiscoveryServer)
-	s.Cache = model.DisabledCache{}
-	s.Env = model.NewEnvironment()
-	originalEndpointsShard, _ := s.Env.EndpointIndex.GetOrCreateEndpointShard("test", "test")
-	originalEndpointsShard.Shards = map[model.ShardKey][]*model.IstioEndpoint{
-		c1Key: cluster1Endppoints,
-	}
-	originalEndpointsShard.ServiceAccounts = map[string]struct{}{
-		"sa1": {},
-	}
-	s.EDSCacheUpdate(c1Key, "test", "test", []*model.IstioEndpoint{})
-	modifiedShard, _ := s.Env.EndpointIndex.GetOrCreateEndpointShard("test", "test")
-	if len(modifiedShard.ServiceAccounts) != 0 {
-		t.Errorf("endpoint shard service accounts got %v want 0", len(modifiedShard.ServiceAccounts))
 	}
 }
 
@@ -1180,6 +1160,7 @@ func addEdsCluster(s *xds.FakeDiscoveryServer, hostName string, portName string,
 			Address:         address,
 			EndpointPort:    uint32(port),
 			ServicePortName: portName,
+			ServiceAccount:  "sa",
 		},
 		ServicePort: &model.Port{
 			Name:     portName,

--- a/releasenotes/notes/full-push-regression.yaml
+++ b/releasenotes/notes/full-push-regression.yaml
@@ -1,6 +1,6 @@
 apiVersion: release-notes/v2
 kind: bug-fix
-area: networking
+area: traffic-management
 issue: [39652]
 releaseNotes:
 - |

--- a/releasenotes/notes/full-push-regression.yaml
+++ b/releasenotes/notes/full-push-regression.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: networking
+issue: [39652]
+releaseNotes:
+- |
+  **Improved** xDS pushing to trigger partial pushes when scaling workloads down to zero instances and back up.


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/39652

This reverts https://github.com/istio/istio/pull/36882. At the time,
that PR was needed because EDS ServiceAccounts and CDS ServiceAccounts
were decoupled; Since https://github.com/istio/istio/pull/39133, this is
no longer true, and the fix in 36882 is not needed any longer.

This PR *removes* the test added in 36882 (since it tests low level
details that are not relevant anymore). It improves the existing
TestEndpointFlipFlops test -- while that test *would* have caught the
regression, it didn't actually set any service accounts so it was
missed. The update changes it to correctly detect the behavior (it now
fails without this PR, passes with it).