### PR TITLE
Fix regressions in using plaintext control plane without kubeclient

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -337,8 +337,10 @@ func NewServer(args *PilotArgs, initFuncs ...func(*Server)) (*Server, error) {
 	}
 	// The k8s JWT authenticator requires the multicluster registry to be initialized,
 	// so we build it later.
-	authenticators = append(authenticators,
-		kubeauth.NewKubeJWTAuthenticator(s.environment.Watcher, s.kubeClient.Kube(), s.clusterID, s.multiclusterController.GetRemoteKubeClient, features.JwtPolicy))
+	if s.kubeClient != nil {
+		authenticators = append(authenticators,
+			kubeauth.NewKubeJWTAuthenticator(s.environment.Watcher, s.kubeClient.Kube(), s.clusterID, s.multiclusterController.GetRemoteKubeClient, features.JwtPolicy))
+	}
 	if len(features.TrustedGatewayCIDR) > 0 {
 		authenticators = append(authenticators, &authenticate.XfccAuthenticator{})
 	}

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -509,9 +509,6 @@ type BootstrapNodeMetadata struct {
 	// OutlierLogPath is the cluster manager outlier event log path.
 	OutlierLogPath string `json:"OUTLIER_LOG_PATH,omitempty"`
 
-	// ProvCertDir is the directory containing pre-provisioned certs.
-	ProvCert string `json:"PROV_CERT,omitempty"`
-
 	// AppContainers is the list of containers in the pod.
 	AppContainers string `json:"APP_CONTAINERS,omitempty"`
 

--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -91,7 +91,6 @@ func (cfg Config) toTemplateParams() (map[string]any, error) {
 		option.NodeType(cfg.ID),
 		option.PilotSubjectAltName(cfg.Metadata.PilotSubjectAltName),
 		option.OutlierLogPath(cfg.Metadata.OutlierLogPath),
-		option.ProvCert(cfg.Metadata.ProvCert),
 		option.DiscoveryHost(discHost),
 		option.Metadata(cfg.Metadata),
 		option.XdsType(xdsType))
@@ -515,7 +514,6 @@ type MetadataOptions struct {
 	CredentialSocketExists      bool
 	XDSRootCert                 string
 	OutlierLogPath              string
-	ProvCert                    string
 	annotationFilePath          string
 	EnvoyStatusPort             int
 	EnvoyPrometheusPort         int
@@ -633,7 +631,6 @@ func GetNodeMetaData(options MetadataOptions) (*model.Node, error) {
 	meta.PilotSubjectAltName = options.PilotSubjectAltName
 	meta.XDSRootCert = options.XDSRootCert
 	meta.OutlierLogPath = options.OutlierLogPath
-	meta.ProvCert = options.ProvCert
 	if options.CredentialSocketExists {
 		untypedMeta[security.CredentialMetaDataName] = "true"
 	}

--- a/pkg/bootstrap/option/instances.go
+++ b/pkg/bootstrap/option/instances.go
@@ -244,10 +244,6 @@ func STSEnabled(value bool) Instance {
 	return newOption("sts", value)
 }
 
-func ProvCert(value string) Instance {
-	return newOption("provisioned_cert", value)
-}
-
 func DiscoveryHost(value string) Instance {
 	return newOption("discovery_host", value)
 }


### PR DESCRIPTION
This (obscure) setup was broken recently:
https://blog.howardjohn.info/posts/local-gateway/

This fixes it. See https://github.com/istio/istio/issues/40867

**Please provide a description of this PR:**