### PR TITLE
Update header matcher to use the string match api; older api is deprecated

### DIFF
--- a/pilot/pkg/security/authz/builder/testdata/http/allow-full-rule-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/allow-full-rule-out.yaml
@@ -51,14 +51,17 @@ typedConfig:
             - orRules:
                 rules:
                 - header:
-                    exactMatch: method
                     name: :method
+                    stringMatch:
+                      exact: method
                 - header:
                     name: :method
-                    prefixMatch: method-prefix-
+                    stringMatch:
+                      prefix: method-prefix-
                 - header:
                     name: :method
-                    suffixMatch: -suffix-method
+                    stringMatch:
+                      suffix: -suffix-method
                 - header:
                     name: :method
                     presentMatch: true
@@ -66,14 +69,17 @@ typedConfig:
                 orRules:
                   rules:
                   - header:
-                      exactMatch: not-method
                       name: :method
+                      stringMatch:
+                        exact: not-method
                   - header:
                       name: :method
-                      prefixMatch: not-method-prefix-
+                      stringMatch:
+                        prefix: not-method-prefix-
                   - header:
                       name: :method
-                      suffixMatch: -not-suffix-method
+                      stringMatch:
+                        suffix: -not-suffix-method
                   - header:
                       name: :method
                       presentMatch: true
@@ -422,14 +428,17 @@ typedConfig:
             - orIds:
                 ids:
                 - header:
-                    exactMatch: header
                     name: X-header
+                    stringMatch:
+                      exact: header
                 - header:
                     name: X-header
-                    prefixMatch: header-prefix-
+                    stringMatch:
+                      prefix: header-prefix-
                 - header:
                     name: X-header
-                    suffixMatch: -suffix-header
+                    stringMatch:
+                      suffix: -suffix-header
                 - header:
                     name: X-header
                     presentMatch: true
@@ -437,14 +446,17 @@ typedConfig:
                 orIds:
                   ids:
                   - header:
-                      exactMatch: not-header
                       name: X-header
+                      stringMatch:
+                        exact: not-header
                   - header:
                       name: X-header
-                      prefixMatch: not-header-prefix-
+                      stringMatch:
+                        prefix: not-header-prefix-
                   - header:
                       name: X-header
-                      suffixMatch: -not-suffix-header
+                      stringMatch:
+                        suffix: -not-suffix-header
                   - header:
                       name: X-header
                       presentMatch: true

--- a/pilot/pkg/security/authz/builder/testdata/http/multiple-policies-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/multiple-policies-out.yaml
@@ -10,11 +10,13 @@ typedConfig:
             - orRules:
                 rules:
                 - header:
-                    exactMatch: GET
                     name: :method
+                    stringMatch:
+                      exact: GET
                 - header:
-                    exactMatch: POST
                     name: :method
+                    stringMatch:
+                      exact: POST
         principals:
         - andIds:
             ids:
@@ -154,9 +156,11 @@ typedConfig:
             - orIds:
                 ids:
                 - header:
-                    exactMatch: abc1
                     name: X-abc
+                    stringMatch:
+                      exact: abc1
                 - header:
-                    exactMatch: abc2
                     name: X-abc
+                    stringMatch:
+                      exact: abc2
   shadowRulesStatPrefix: istio_dry_run_allow_

--- a/pilot/pkg/security/authz/builder/testdata/http/simple-policy-td-aliases-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/simple-policy-td-aliases-out.yaml
@@ -10,8 +10,9 @@ typedConfig:
             - orRules:
                 rules:
                 - header:
-                    exactMatch: rule[0]-to[0]-method[0]
                     name: :method
+                    stringMatch:
+                      exact: rule[0]-to[0]-method[0]
         principals:
         - andIds:
             ids:
@@ -53,8 +54,9 @@ typedConfig:
             - orRules:
                 rules:
                 - header:
-                    exactMatch: rule[1]-to[0]-method[0]
                     name: :method
+                    stringMatch:
+                      exact: rule[1]-to[0]-method[0]
         principals:
         - andIds:
             ids:

--- a/pilot/pkg/security/authz/builder/testdata/http/single-policy-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/single-policy-out.yaml
@@ -22,11 +22,13 @@ typedConfig:
             - orRules:
                 rules:
                 - header:
-                    exactMatch: rule[0]-to[0]-method[1]
                     name: :method
+                    stringMatch:
+                      exact: rule[0]-to[0]-method[1]
                 - header:
-                    exactMatch: rule[0]-to[0]-method[2]
                     name: :method
+                    stringMatch:
+                      exact: rule[0]-to[0]-method[2]
             - orRules:
                 rules:
                 - urlPath:
@@ -64,11 +66,13 @@ typedConfig:
             - orRules:
                 rules:
                 - header:
-                    exactMatch: rule[0]-to[1]-method[1]
                     name: :method
+                    stringMatch:
+                      exact: rule[0]-to[1]-method[1]
                 - header:
-                    exactMatch: rule[0]-to[1]-method[2]
                     name: :method
+                    stringMatch:
+                      exact: rule[0]-to[1]-method[2]
             - orRules:
                 rules:
                 - urlPath:
@@ -144,14 +148,17 @@ typedConfig:
             - orIds:
                 ids:
                 - header:
-                    exactMatch: header
                     name: X-header
+                    stringMatch:
+                      exact: header
                 - header:
                     name: X-header
-                    prefixMatch: header-prefix-
+                    stringMatch:
+                      prefix: header-prefix-
                 - header:
                     name: X-header
-                    suffixMatch: -suffix-header
+                    stringMatch:
+                      suffix: -suffix-header
                 - header:
                     name: X-header
                     presentMatch: true
@@ -220,14 +227,17 @@ typedConfig:
             - orIds:
                 ids:
                 - header:
-                    exactMatch: header
                     name: X-header
+                    stringMatch:
+                      exact: header
                 - header:
                     name: X-header
-                    prefixMatch: header-prefix-
+                    stringMatch:
+                      prefix: header-prefix-
                 - header:
                     name: X-header
-                    suffixMatch: -suffix-header
+                    stringMatch:
+                      suffix: -suffix-header
                 - header:
                     name: X-header
                     presentMatch: true
@@ -258,11 +268,13 @@ typedConfig:
             - orRules:
                 rules:
                 - header:
-                    exactMatch: rule[1]-to[0]-method[1]
                     name: :method
+                    stringMatch:
+                      exact: rule[1]-to[0]-method[1]
                 - header:
-                    exactMatch: rule[1]-to[0]-method[2]
                     name: :method
+                    stringMatch:
+                      exact: rule[1]-to[0]-method[2]
             - orRules:
                 rules:
                 - urlPath:
@@ -292,11 +304,13 @@ typedConfig:
             - orRules:
                 rules:
                 - header:
-                    exactMatch: rule[1]-to[1]-method[1]
                     name: :method
+                    stringMatch:
+                      exact: rule[1]-to[1]-method[1]
                 - header:
-                    exactMatch: rule[1]-to[1]-method[2]
                     name: :method
+                    stringMatch:
+                      exact: rule[1]-to[1]-method[2]
             - orRules:
                 rules:
                 - urlPath:

--- a/pilot/pkg/security/authz/matcher/header.go
+++ b/pilot/pkg/security/authz/matcher/header.go
@@ -36,15 +36,23 @@ func HeaderMatcher(k, v string) *routepb.HeaderMatcher {
 	} else if strings.HasPrefix(v, "*") {
 		return &routepb.HeaderMatcher{
 			Name: k,
-			HeaderMatchSpecifier: &routepb.HeaderMatcher_SuffixMatch{
-				SuffixMatch: v[1:],
+			HeaderMatchSpecifier: &routepb.HeaderMatcher_StringMatch{
+				StringMatch: &matcherpb.StringMatcher{
+					MatchPattern: &matcherpb.StringMatcher_Suffix{
+						Suffix: v[1:],
+					},
+				},
 			},
 		}
 	} else if strings.HasSuffix(v, "*") {
 		return &routepb.HeaderMatcher{
 			Name: k,
-			HeaderMatchSpecifier: &routepb.HeaderMatcher_PrefixMatch{
-				PrefixMatch: v[:len(v)-1],
+			HeaderMatchSpecifier: &routepb.HeaderMatcher_StringMatch{
+				StringMatch: &matcherpb.StringMatcher{
+					MatchPattern: &matcherpb.StringMatcher_Prefix{
+						Prefix: v[:len(v)-1],
+					},
+				},
 			},
 		}
 	}

--- a/pilot/pkg/security/authz/matcher/header.go
+++ b/pilot/pkg/security/authz/matcher/header.go
@@ -58,8 +58,12 @@ func HeaderMatcher(k, v string) *routepb.HeaderMatcher {
 	}
 	return &routepb.HeaderMatcher{
 		Name: k,
-		HeaderMatchSpecifier: &routepb.HeaderMatcher_ExactMatch{
-			ExactMatch: v,
+		HeaderMatchSpecifier: &routepb.HeaderMatcher_StringMatch{
+			StringMatch: &matcherpb.StringMatcher{
+				MatchPattern: &matcherpb.StringMatcher_Exact{
+					Exact: v,
+				},
+			},
 		},
 	}
 }

--- a/pilot/pkg/security/authz/matcher/header.go
+++ b/pilot/pkg/security/authz/matcher/header.go
@@ -87,12 +87,16 @@ func HostMatcherWithRegex(k, v string) *routepb.HeaderMatcher {
 	}
 	return &routepb.HeaderMatcher{
 		Name: k,
-		HeaderMatchSpecifier: &routepb.HeaderMatcher_SafeRegexMatch{
-			SafeRegexMatch: &matcherpb.RegexMatcher{
-				EngineType: &matcherpb.RegexMatcher_GoogleRe2{
-					GoogleRe2: &matcherpb.RegexMatcher_GoogleRE2{},
+		HeaderMatchSpecifier: &routepb.HeaderMatcher_StringMatch{
+			StringMatch: &matcherpb.StringMatcher{
+				MatchPattern: &matcherpb.StringMatcher_SafeRegex{
+					SafeRegex: &matcherpb.RegexMatcher{
+						EngineType: &matcherpb.RegexMatcher_GoogleRe2{
+							GoogleRe2: &matcherpb.RegexMatcher_GoogleRE2{},
+						},
+						Regex: `(?i)` + regex,
+					},
 				},
-				Regex: `(?i)` + regex,
 			},
 		},
 	}

--- a/pilot/pkg/security/authz/matcher/header_test.go
+++ b/pilot/pkg/security/authz/matcher/header_test.go
@@ -119,12 +119,16 @@ func TestHostMatcherWithRegex(t *testing.T) {
 			V:    "*.example.com",
 			Expect: &routepb.HeaderMatcher{
 				Name: ":authority",
-				HeaderMatchSpecifier: &routepb.HeaderMatcher_SafeRegexMatch{
-					SafeRegexMatch: &matcherpb.RegexMatcher{
-						EngineType: &matcherpb.RegexMatcher_GoogleRe2{
-							GoogleRe2: &matcherpb.RegexMatcher_GoogleRE2{},
+				HeaderMatchSpecifier: &routepb.HeaderMatcher_StringMatch{
+					StringMatch: &matcherpb.StringMatcher{
+						MatchPattern: &matcherpb.StringMatcher_SafeRegex{
+							SafeRegex: &matcherpb.RegexMatcher{
+								EngineType: &matcherpb.RegexMatcher_GoogleRe2{
+									GoogleRe2: &matcherpb.RegexMatcher_GoogleRE2{},
+								},
+								Regex: `(?i).*\.example\.com`,
+							},
 						},
-						Regex: `(?i).*\.example\.com`,
 					},
 				},
 			},
@@ -135,12 +139,16 @@ func TestHostMatcherWithRegex(t *testing.T) {
 			V:    "example.*",
 			Expect: &routepb.HeaderMatcher{
 				Name: ":authority",
-				HeaderMatchSpecifier: &routepb.HeaderMatcher_SafeRegexMatch{
-					SafeRegexMatch: &matcherpb.RegexMatcher{
-						EngineType: &matcherpb.RegexMatcher_GoogleRe2{
-							GoogleRe2: &matcherpb.RegexMatcher_GoogleRE2{},
+				HeaderMatchSpecifier: &routepb.HeaderMatcher_StringMatch{
+					StringMatch: &matcherpb.StringMatcher{
+						MatchPattern: &matcherpb.StringMatcher_SafeRegex{
+							SafeRegex: &matcherpb.RegexMatcher{
+								EngineType: &matcherpb.RegexMatcher_GoogleRe2{
+									GoogleRe2: &matcherpb.RegexMatcher_GoogleRE2{},
+								},
+								Regex: `(?i)example\..*`,
+							},
 						},
-						Regex: `(?i)example\..*`,
 					},
 				},
 			},
@@ -151,12 +159,16 @@ func TestHostMatcherWithRegex(t *testing.T) {
 			V:    "example.com",
 			Expect: &routepb.HeaderMatcher{
 				Name: ":authority",
-				HeaderMatchSpecifier: &routepb.HeaderMatcher_SafeRegexMatch{
-					SafeRegexMatch: &matcherpb.RegexMatcher{
-						EngineType: &matcherpb.RegexMatcher_GoogleRe2{
-							GoogleRe2: &matcherpb.RegexMatcher_GoogleRE2{},
+				HeaderMatchSpecifier: &routepb.HeaderMatcher_StringMatch{
+					StringMatch: &matcherpb.StringMatcher{
+						MatchPattern: &matcherpb.StringMatcher_SafeRegex{
+							SafeRegex: &matcherpb.RegexMatcher{
+								EngineType: &matcherpb.RegexMatcher_GoogleRe2{
+									GoogleRe2: &matcherpb.RegexMatcher_GoogleRE2{},
+								},
+								Regex: `(?i)example\.com`,
+							},
 						},
-						Regex: `(?i)example\.com`,
 					},
 				},
 			},
@@ -168,7 +180,8 @@ func TestHostMatcherWithRegex(t *testing.T) {
 			actual := HostMatcherWithRegex(tc.K, tc.V)
 			// nolint: staticcheck
 			// Update to not use the deprecated fields later.
-			if re := actual.GetSafeRegexMatch().GetRegex(); re != "" {
+			actual.GetStringMatch().GetSafeRegex()
+			if re := actual.GetStringMatch().GetSafeRegex().GetRegex(); re != "" {
 				_, err := regexp.Compile(re)
 				if err != nil {
 					t.Errorf("failed to compile regex %s: %v", re, err)

--- a/pilot/pkg/security/authz/matcher/header_test.go
+++ b/pilot/pkg/security/authz/matcher/header_test.go
@@ -48,8 +48,12 @@ func TestHeaderMatcher(t *testing.T) {
 			V:    "*/productpage*",
 			Expect: &routepb.HeaderMatcher{
 				Name: ":path",
-				HeaderMatchSpecifier: &routepb.HeaderMatcher_SuffixMatch{
-					SuffixMatch: "/productpage*",
+				HeaderMatchSpecifier: &routepb.HeaderMatcher_StringMatch{
+					StringMatch: &matcherpb.StringMatcher{
+						MatchPattern: &matcherpb.StringMatcher_Suffix{
+							Suffix: "/productpage*",
+						},
+					},
 				},
 			},
 		},
@@ -59,8 +63,12 @@ func TestHeaderMatcher(t *testing.T) {
 			V:    "/productpage*",
 			Expect: &routepb.HeaderMatcher{
 				Name: ":path",
-				HeaderMatchSpecifier: &routepb.HeaderMatcher_PrefixMatch{
-					PrefixMatch: "/productpage",
+				HeaderMatchSpecifier: &routepb.HeaderMatcher_StringMatch{
+					StringMatch: &matcherpb.StringMatcher{
+						MatchPattern: &matcherpb.StringMatcher_Prefix{
+							Prefix: "/productpage",
+						},
+					},
 				},
 			},
 		},

--- a/pilot/pkg/security/authz/matcher/header_test.go
+++ b/pilot/pkg/security/authz/matcher/header_test.go
@@ -179,8 +179,6 @@ func TestHostMatcherWithRegex(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			actual := HostMatcherWithRegex(tc.K, tc.V)
 			// nolint: staticcheck
-			// Update to not use the deprecated fields later.
-			actual.GetStringMatch().GetSafeRegex()
 			if re := actual.GetStringMatch().GetSafeRegex().GetRegex(); re != "" {
 				_, err := regexp.Compile(re)
 				if err != nil {

--- a/pilot/pkg/security/authz/matcher/header_test.go
+++ b/pilot/pkg/security/authz/matcher/header_test.go
@@ -37,8 +37,12 @@ func TestHeaderMatcher(t *testing.T) {
 			V:    "/productpage",
 			Expect: &routepb.HeaderMatcher{
 				Name: ":path",
-				HeaderMatchSpecifier: &routepb.HeaderMatcher_ExactMatch{
-					ExactMatch: "/productpage",
+				HeaderMatchSpecifier: &routepb.HeaderMatcher_StringMatch{
+					StringMatch: &matcherpb.StringMatcher{
+						MatchPattern: &matcherpb.StringMatcher_Exact{
+							Exact: "/productpage",
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
**Please provide a description of this PR:**

Update the header matcher api to use the string_match api.

Prefix_match, suffix_match and safe_regex are deprecated in favor of this new api. See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto

* https://github.com/envoyproxy/envoy/blob/8537d2a29265e61aaa0349311e6fc5d592659b08/api/envoy/config/route/v3/route_components.proto#L2177
* https://github.com/envoyproxy/envoy/blob/8537d2a29265e61aaa0349311e6fc5d592659b08/api/envoy/config/route/v3/route_components.proto#L2164
* https://github.com/envoyproxy/envoy/blob/8537d2a29265e61aaa0349311e6fc5d592659b08/api/envoy/config/route/v3/route_components.proto#L2141

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [X] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure