### PR TITLE
Adding min istio version for new features to avoid running on older revisions

### DIFF
--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -661,7 +661,8 @@ spec:
 	})
 
 	t.RunTraffic(TrafficTestCase{
-		name: "fault abort gRPC",
+		name:            "fault abort gRPC",
+		minIstioVersion: "1.15.0",
 		config: `
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
@@ -1780,8 +1781,9 @@ func hostCases(t TrafficContext) {
 		for _, h := range hosts {
 			name := strings.Replace(h, address, "ip", -1) + "/auto-http"
 			t.RunTraffic(TrafficTestCase{
-				name: name,
-				call: c.CallOrFail,
+				name:            name,
+				minIstioVersion: "1.15.0",
+				call:            c.CallOrFail,
 				opts: echo.CallOptions{
 					To:    t.Apps.Headless,
 					Count: 1,
@@ -1826,8 +1828,9 @@ func hostCases(t TrafficContext) {
 				assertion = check.OK()
 			}
 			t.RunTraffic(TrafficTestCase{
-				name: name,
-				call: c.CallOrFail,
+				name:            name,
+				minIstioVersion: "1.15.0",
+				call:            c.CallOrFail,
 				opts: echo.CallOptions{
 					To: t.Apps.Headless,
 					Port: echo.Port{
@@ -2102,10 +2105,11 @@ spec:
 				opts:   callOpts,
 			})
 			t.RunTraffic(TrafficTestCase{
-				name:   "tcp source ip " + c.Config().Service,
-				config: svc + tmpl.MustEvaluate(destRule, "useSourceIp: true"),
-				call:   c.CallOrFail,
-				opts:   tcpCallopts,
+				name:            "tcp source ip " + c.Config().Service,
+				minIstioVersion: "1.14.0",
+				config:          svc + tmpl.MustEvaluate(destRule, "useSourceIp: true"),
+				call:            c.CallOrFail,
+				opts:            tcpCallopts,
 				skip: skip{
 					skip:   c.Config().WorkloadClass() == echo.Proxyless,
 					reason: "", // TODO: is this a bug or WAI?
@@ -2123,7 +2127,7 @@ var ConsistentHostChecker echo.Checker = func(result echo.CallResult, _ error) e
 	scopes.Framework.Infof("requests landed on hostnames: %v", hostnames)
 	unique := sets.New(hostnames...).SortedList()
 	if len(unique) != 1 {
-		return fmt.Errorf("excepted only one destination, got: %v", unique)
+		return fmt.Errorf("expected only one destination, got: %v", unique)
 	}
 	return nil
 }

--- a/tests/integration/pilot/tunneling_test.go
+++ b/tests/integration/pilot/tunneling_test.go
@@ -108,6 +108,7 @@ func TestTunnelingOutboundTraffic(t *testing.T) {
 	framework.
 		NewTest(t).
 		Features("traffic.tunneling").
+		RequireIstioVersion("1.15.0").
 		Run(func(ctx framework.TestContext) {
 			meshNs := apps.A.NamespaceName()
 			externalNs := apps.External.Namespace.Name()

--- a/tests/integration/security/reachability_test.go
+++ b/tests/integration/security/reachability_test.go
@@ -33,6 +33,7 @@ import (
 	"istio.io/istio/pkg/test/framework/components/echo/echotest"
 	"istio.io/istio/pkg/test/framework/components/echo/match"
 	"istio.io/istio/pkg/test/framework/components/istio"
+	"istio.io/istio/pkg/test/framework/resource"
 )
 
 const (
@@ -113,6 +114,8 @@ func TestReachability(t *testing.T) {
 				expectCrossCluster condition
 				expectCrossNetwork condition
 				expectSuccess      condition
+				// minIstioVersion allows conditionally skipping based on required version
+				minIstioVersion string
 			}{
 				{
 					name: "global mtls strict",
@@ -130,6 +133,7 @@ func TestReachability(t *testing.T) {
 					expectCrossCluster: notFromNaked,
 					expectCrossNetwork: notNaked,
 					expectSuccess:      notNaked,
+					minIstioVersion:    "1.15.0",
 				},
 				{
 					name: "global mtls permissive",
@@ -147,6 +151,7 @@ func TestReachability(t *testing.T) {
 					expectCrossCluster: notFromNaked,
 					expectCrossNetwork: notNaked,
 					expectSuccess:      notToNaked,
+					minIstioVersion:    "1.15.0",
 				},
 				{
 					name: "global mtls disabled",
@@ -164,6 +169,7 @@ func TestReachability(t *testing.T) {
 					expectCrossCluster: notFromNaked,
 					expectCrossNetwork: never,
 					expectSuccess:      always,
+					minIstioVersion:    "1.15.0",
 				},
 				{
 					name: "global plaintext to mtls permissive",
@@ -181,6 +187,7 @@ func TestReachability(t *testing.T) {
 					expectCrossCluster: notFromNaked,
 					expectCrossNetwork: never,
 					expectSuccess:      always,
+					minIstioVersion:    "1.15.0",
 				},
 				{
 					name: "global automtls strict",
@@ -231,6 +238,7 @@ func TestReachability(t *testing.T) {
 					expectCrossCluster: and(notFromNaked, or(toHeadless, toStatefulSet)),
 					expectCrossNetwork: never,
 					expectSuccess:      always,
+					minIstioVersion:    "1.15.0",
 				},
 				{
 					name: "global no peer authn",
@@ -246,6 +254,7 @@ func TestReachability(t *testing.T) {
 					expectCrossCluster: notFromNaked,
 					expectCrossNetwork: notNaked,
 					expectSuccess:      notToNaked,
+					minIstioVersion:    "1.15.0",
 				},
 				{
 					name: "mtls strict",
@@ -377,6 +386,12 @@ func TestReachability(t *testing.T) {
 				c := c
 
 				t.NewSubTest(c.name).Run(func(t framework.TestContext) {
+					if c.minIstioVersion != "" {
+						skipMV := !t.Settings().Revisions.AtLeast(resource.IstioVersion(c.minIstioVersion))
+						if skipMV {
+							t.SkipNow()
+						}
+					}
 					// Apply the configs.
 					config.New(t).
 						Source(c.configs...).


### PR DESCRIPTION
**Please provide a description of this PR:**

We are adding min istio version for tests related to below PRs as this functionalities were not there in previous revisions :-
	a. gRPC fault
           injection(https://github.com/istio/istio/pull/39295)
	b. Ignore port number in domain
           matching(https://github.com/istio/istio/pull/40475)
	c. Tunneling outbound traffic :- new tunnel field got
           introduced(https://github.com/istio/istio/pull/37968)
	d. Fix consistent hash based on source IP for TCP
           proxy(https://github.com/istio/istio/pull/38438)
	e. Traffic policy load balancer API
           changes(https://github.com/istio/istio/pull/39742)


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [X ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [X ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
