### PR TITLE
Add image variable for gateway and keep auto as default

### DIFF
--- a/manifests/charts/gateway/templates/deployment.yaml
+++ b/manifests/charts/gateway/templates/deployment.yaml
@@ -44,7 +44,7 @@ spec:
       containers:
         - name: istio-proxy
           # "auto" will be populated at runtime by the mutating webhook. See https://istio.io/latest/docs/setup/additional-setup/sidecar-injection/#customizing-injection
-          image: auto
+          image: {{ .Values.image | default "auto" }}
           securityContext:
           {{- if .Values.containerSecurityContext }}
             {{- toYaml .Values.containerSecurityContext | nindent 12 }}

--- a/manifests/charts/gateway/values.yaml
+++ b/manifests/charts/gateway/values.yaml
@@ -90,4 +90,6 @@ affinity: {}
 # If specified, the gateway will act as a network gateway for the given network.
 networkGateway: ""
 
+image: ""
+
 imagePullSecrets: []


### PR DESCRIPTION
**Please provide a description of this PR:**
We are using istio for enterprise and we keep asm image in our private gcr. 
if we dont mention image explicitly it shows as a auto and our validation fails to verify the deployment for gateway. 
Just want to add the image variable in values.yaml. Still kept auto as default so nothing breaks for any existing setup. 


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ X] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ X] User Experience
- [ ] Developer Infrastructure