### PR TITLE
manifests: allow injection of volumes(Mounts)/args to pilot

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -105,6 +105,9 @@ spec:
 {{- end }}
           - --keepaliveMaxServerConnectionAge
           - "{{ .Values.pilot.keepaliveMaxServerConnectionAge }}"
+          {{- with .Values.pilot.args -}}
+          {{ toYaml . | nindent 10 }}
+          {{- end }}
           ports:
           - containerPort: 8080
             protocol: TCP
@@ -204,6 +207,9 @@ spec:
           - name: extracacerts
             mountPath: /cacerts
           {{- end }}
+          {{- with .Values.pilot.volumeMounts -}}
+          {{ toYaml . | nindent 10 }}
+          {{- end }}
       volumes:
       # Technically not needed on this pod - but it helps debugging/testing SDS
       # Should be removed after everything works.
@@ -228,6 +234,9 @@ spec:
         secret:
           secretName: istio-kubeconfig
           optional: true
+      {{- with .Values.pilot.volumes -}}
+      {{ toYaml . | nindent 6 }}
+      {{- end }}
   {{- if .Values.pilot.jwksResolverExtraRootCA }}
       - name: extracacerts
         configMap:

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -70,6 +70,10 @@ pilot:
   # Additional labels to apply on the pod level for monitoring and logging configuration.
   podLabels: {}
 
+  volumeMounts: []
+  volumes: []
+  args: []
+
 sidecarInjectorWebhook:
   # You can use the field called alwaysInjectSelector and neverInjectSelector which will always inject the sidecar or
   # always skip the injection on pods that match that label selector, regardless of the global policy.


### PR DESCRIPTION
Hi, this PR aims to make the helm chart more flexible by allowing us to inject `volumes` / `volumeMounts` / `args` to the `pilot` deployment.

My goal is to be able to do [integrate](https://github.com/cert-manager/website/blob/d3e400326e4dcdbeeef218f2957fe22d6855bbeb/content/docs/tutorials/istio-csr/example/istio-config-getting-started.yaml#L28-L57) this helm chart with `cert-manager/istio-csr` without using `kustomize` or the `istioOperater`

Tested with the following `values.yaml`:
```yaml
pilot:
  volumeMounts:
  - name: cert-manager
    mountPath: /etc/cert-manager/tls
    readOnly: true
  - name: ca-root-cert
    mountPath: /etc/cert-manager/ca
    readOnly: true
  volumes:
  - name: cert-manager
    secret:
      secretName: istiod-tls
  - name: ca-root-cert
    configMap:
      defaultMode: 420
      name: istio-ca-root-cert
  args:
  - --tlsCertFile=/etc/cert-manager/tls/tls.crt
  - --tlsKeyFile=/etc/cert-manager/tls/tls.key
  - --caCertFile=/etc/cert-manager/ca/root-cert.pem
```


**Please provide a description of this PR:**
allow injection of volumes(Mounts)/args to pilot


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**
- [X] Manifests
