### PR TITLE
fix istio operator reconciliation

### DIFF
--- a/operator/pkg/controller/istiocontrolplane/istiocontrolplane_controller.go
+++ b/operator/pkg/controller/istiocontrolplane/istiocontrolplane_controller.go
@@ -55,6 +55,7 @@ import (
 	"istio.io/istio/operator/pkg/util"
 	"istio.io/istio/operator/pkg/util/clog"
 	"istio.io/istio/operator/pkg/util/progress"
+	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/errdict"
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/proxy"
@@ -289,7 +290,7 @@ func (r *ReconcileIstioOperator) Reconcile(_ context.Context, request reconcile.
 			// Check to see if istiod was already deleted, if so, we can move to delete finalizer
 			ns := iopv1alpha1.Namespace(iopMerged.Spec)
 			if ns == "" {
-				ns = name.IstioDefaultNamespace
+				ns = constants.IstioSystemNamespace
 			}
 			if _, proxyerr := proxy.GetProxyInfo("", "", iopMerged.Spec.Revision, ns); proxyerr != nil {
 				if !strings.Contains(proxyerr.Error(), "unable to find any Istiod instances") {

--- a/releasenotes/notes/40702.yaml
+++ b/releasenotes/notes/40702.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+issue:
+  - 18152
+
+releaseNotes:
+- |
+  **Fixed** listeners to balance between Envoy worker threads. Fixes (#18152)[https://github.com/istio/istio/issues/18152).

--- a/releasenotes/notes/40702.yaml
+++ b/releasenotes/notes/40702.yaml
@@ -1,9 +1,9 @@
 apiVersion: release-notes/v2
-kind: feature
-area: traffic-management
+kind: bug-fix
+area: installation
 issue:
-  - 18152
+  - 40702
 
 releaseNotes:
 - |
-  **Fixed** listeners to balance between Envoy worker threads. Fixes (#18152)[https://github.com/istio/istio/issues/18152).
+  **Fixed** reconciliation of deleted IstioOperators getting stuck in a loop


### PR DESCRIPTION
**Please provide a description of this PR:**

Fixes an edge case where if the K8s API Server is hammered with a number of delete requests for the IstioOperator, longer than the current retry duration, the IstioOperator will get stuck with a finalizer but the Helm Reconciliation will fail because the objects were already removed.

Closes #40702 

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [X] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure