### PR TITLE
Update SPIFFE-CSI driver version in SPIRE quickstart config

### DIFF
--- a/samples/security/spire/istio-spire-config.yaml
+++ b/samples/security/spire/istio-spire-config.yaml
@@ -22,6 +22,7 @@ spec:
               - name: workload-socket
                 csi:
                   driver: "csi.spiffe.io"
+                  readOnly: true
   components:
     ingressGateways:
       - name: istio-ingressgateway
@@ -39,6 +40,7 @@ spec:
                     name: workload-socket
                     csi:
                       driver: "csi.spiffe.io"
+                      readOnly: true
                 - path: spec.template.spec.containers.[name:istio-proxy].volumeMounts.[name:workload-socket]
                   value:
                     name: workload-socket

--- a/samples/security/spire/spire-quickstart.yaml
+++ b/samples/security/spire/spire-quickstart.yaml
@@ -526,7 +526,7 @@ spec:
             periodSeconds: 5
         # This is the container which runs the SPIFFE CSI driver.
         - name: spiffe-csi-driver
-          image: ghcr.io/spiffe/spiffe-csi-driver:0.1.0
+          image: ghcr.io/spiffe/spiffe-csi-driver:0.2.0
           imagePullPolicy: IfNotPresent
           args: [
               "-node-id", "CSI_NODE",


### PR DESCRIPTION
**Please provide a description of this PR:**

Update the [SPIFFE CSI driver](https://github.com/spiffe/spiffe-csi) version used in the `spire-quickstart` configuration. 

Add `readOnly` to the CSI volumes in `istio-spire-config` as the driver now enforces that the CSI volume is declared read-only in the PodSpec.


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [X] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure



Signed-off-by: Max Lambrecht <max.lambrecht@hpe.com>