### PR TITLE
Address istiooperator removal loop potential

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -98,6 +98,10 @@ const (
 	fieldManager        = "istio-kube-client"
 )
 
+var (
+	ErrNoIstiodInstances = errors.New("unable to find any Istiod instances")
+)
+
 // Client is a helper for common Kubernetes client operations. This contains various different kubernetes
 // clients using a shared config. It is expected that all of Istiod can share the same set of clients and
 // informers. Sharing informers is especially important for load on the API server/Istiod itself.
@@ -764,7 +768,7 @@ func (c *client) AllDiscoveryDo(ctx context.Context, istiodNamespace, path strin
 		return nil, err
 	}
 	if len(istiods) == 0 {
-		return nil, errors.New("unable to find any Istiod instances")
+		return nil, ErrNoIstiodInstances
 	}
 
 	result := map[string][]byte{}

--- a/releasenotes/notes/40702.yaml
+++ b/releasenotes/notes/40702.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+issue:
+  - 40702
+
+releaseNotes:
+- |
+  **Fixed** reconciliation of deleted IstioOperators getting stuck in a loop


### PR DESCRIPTION
**Please provide a description of this PR:**

Closes #40702 

If you hit the Kube API server with multiple DELETE requests, it can cause the max retires of 1 to still fail due to the IstioOperator resource changing. On the next reconcile, HelmReconciler will fail because it cannot find the istiod deployment and this leaves the IstioOperator undeleted even though the resources have been removed.

The PR changes max retires to increase the likelihood that even if the Kube API server gets multiple DELETE requests it can succeed, and also looks for the Helm Reconciler erroring due to istiod not being in the cluster any longer to remove the IstioOperator.