### PR TITLE
[1.14] otel: ensure stable XDS generation (#40930)

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/accesslog.go
+++ b/pilot/pkg/networking/core/v1alpha3/accesslog.go
@@ -15,6 +15,7 @@
 package v1alpha3
 
 import (
+	"sort"
 	"strings"
 	"sync"
 
@@ -562,7 +563,14 @@ func convertStructToAttributeKeyValues(labels map[string]*structpb.Value) []*otl
 		return nil
 	}
 	attrList := make([]*otlpcommon.KeyValue, 0, len(labels))
-	for key, value := range labels {
+	// Sort keys to ensure stable XDS generation
+	keys := make([]string, 0, len(labels))
+	for k := range labels {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		value := labels[key]
 		kv := &otlpcommon.KeyValue{
 			Key:   key,
 			Value: &otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_StringValue{StringValue: value.GetStringValue()}},

--- a/pilot/pkg/networking/core/v1alpha3/accesslog_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/accesslog_test.go
@@ -362,7 +362,8 @@ func TestBuildAccessLogFromTelemetry(t *testing.T) {
 
 	labels := &structpb.Struct{
 		Fields: map[string]*structpb.Value{
-			"protocol": {Kind: &structpb.Value_StringValue{StringValue: "%PROTOCOL%"}},
+			"protocol":   {Kind: &structpb.Value_StringValue{StringValue: "%PROTOCOL%"}},
+			"start_time": {Kind: &structpb.Value_StringValue{StringValue: "%START_TIME%"}},
 		},
 	}
 
@@ -413,7 +414,16 @@ func TestBuildAccessLogFromTelemetry(t *testing.T) {
 			},
 		},
 		Attributes: &otlpcommon.KeyValueList{
-			Values: convertStructToAttributeKeyValues(labels.Fields),
+			Values: []*otlpcommon.KeyValue{
+				{
+					Key:   "protocol",
+					Value: &otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_StringValue{StringValue: "%PROTOCOL%"}},
+				},
+				{
+					Key:   "start_time",
+					Value: &otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_StringValue{StringValue: "%START_TIME%"}},
+				},
+			},
 		},
 	}
 


### PR DESCRIPTION
Currently, order changes on every new push. This leads to draining all connections

(cherry picked from commit 76a8be91904b97ace6d2b18ba4c02d833a304177)

Fixes https://github.com/istio/istio/issues/40932