### PR TITLE
[1.13] otel: ensure stable XDS generation (#40930)

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/accesslog.go
+++ b/pilot/pkg/networking/core/v1alpha3/accesslog.go
@@ -15,6 +15,7 @@
 package v1alpha3
 
 import (
+	"sort"
 	"strings"
 	"sync"
 
@@ -566,7 +567,14 @@ func convertStructToAttributeKeyValues(labels map[string]*pbtypes.Value) []*otlp
 		return nil
 	}
 	attrList := make([]*otlpcommon.KeyValue, 0, len(labels))
-	for key, value := range labels {
+	// Sort keys to ensure stable XDS generation
+	keys := make([]string, 0, len(labels))
+	for k := range labels {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		value := labels[key]
 		kv := &otlpcommon.KeyValue{
 			Key:   key,
 			Value: &otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_StringValue{StringValue: value.GetStringValue()}},

--- a/pilot/pkg/networking/core/v1alpha3/accesslog_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/accesslog_test.go
@@ -365,7 +365,8 @@ func TestBuildAccessLogFromTelemetry(t *testing.T) {
 
 	labels := &types.Struct{
 		Fields: map[string]*types.Value{
-			"protocol": {Kind: &types.Value_StringValue{StringValue: "%PROTOCOL%"}},
+			"protocol":   {Kind: &types.Value_StringValue{StringValue: "%PROTOCOL%"}},
+			"start_time": {Kind: &structpb.Value_StringValue{StringValue: "%START_TIME%"}},
 		},
 	}
 
@@ -416,7 +417,16 @@ func TestBuildAccessLogFromTelemetry(t *testing.T) {
 			},
 		},
 		Attributes: &otlpcommon.KeyValueList{
-			Values: convertStructToAttributeKeyValues(labels.Fields),
+			Values: []*otlpcommon.KeyValue{
+				{
+					Key:   "protocol",
+					Value: &otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_StringValue{StringValue: "%PROTOCOL%"}},
+				},
+				{
+					Key:   "start_time",
+					Value: &otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_StringValue{StringValue: "%START_TIME%"}},
+				},
+			},
 		},
 	}
 

--- a/pilot/pkg/networking/core/v1alpha3/accesslog_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/accesslog_test.go
@@ -366,7 +366,7 @@ func TestBuildAccessLogFromTelemetry(t *testing.T) {
 	labels := &types.Struct{
 		Fields: map[string]*types.Value{
 			"protocol":   {Kind: &types.Value_StringValue{StringValue: "%PROTOCOL%"}},
-			"start_time": {Kind: &structpb.Value_StringValue{StringValue: "%START_TIME%"}},
+			"start_time": {Kind: &types.Value_StringValue{StringValue: "%START_TIME%"}},
 		},
 	}
 


### PR DESCRIPTION
Currently, order changes on every new push. This leads to draining all connections

(cherry picked from commit 76a8be91904b97ace6d2b18ba4c02d833a304177) (cherry picked from commit 4e46398b05e346366641b1a81a7e953de646e4ff)
Fixes https://github.com/istio/istio/issues/40931