### PR TITLE
Fix for Traffic tests which are not running

### DIFF
--- a/tests/integration/pilot/common/traffic.go
+++ b/tests/integration/pilot/common/traffic.go
@@ -104,9 +104,12 @@ func (c TrafficTestCase) RunForApps(t framework.TestContext, apps echo.Instances
 		t.Fatal("TrafficTestCase.RunForApps: call must not be specified")
 	}
 	// just check if any of the required fields are set
-	optsSpecified := c.opts.Port.Name != "" || c.opts.Scheme != ""
+	optsSpecified := c.opts.Port.Name != "" || c.opts.Port.Protocol != "" || c.opts.Scheme != ""
 	if optsSpecified && len(c.children) > 0 {
 		t.Fatal("TrafficTestCase: must not specify both opts and children")
+	}
+	if !optsSpecified && len(c.children) == 0 {
+		t.Fatal("TrafficTestCase: must specify either opts or children")
 	}
 
 	job := func(t framework.TestContext) {


### PR DESCRIPTION
Some tests in routing.go uses echo.Port.Protocol only. But in traffic.go it doesn't check for that to identify as optsSpecified. So added a check to allow protocol as well. 
Also it allows tests to have neither optsSpecified nor children which will show as the test passed even if it did not run. Added a check for that as well.

**Please provide a description of this PR:**



**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [x] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
