### PR TITLE
Let the double-layer loop deep copy object of large array change to once

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/rc_patch.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/rc_patch.go
@@ -151,6 +151,8 @@ func patchHTTPRoutes(patchContext networking.EnvoyFilter_PatchContext,
 	routeConfiguration *route.RouteConfiguration, virtualHost *route.VirtualHost, portMap model.GatewayPortMap,
 ) {
 	routesRemoved := false
+	// different virtualHosts may share same routes pointer
+	virtualHost.Routes = cloneVhostRoutes(virtualHost.Routes)
 	// Apply the route level removes/merges if any.
 	for index := range virtualHost.Routes {
 		patchHTTPRoute(patchContext, patches, routeConfiguration, virtualHost, index, &routesRemoved, portMap)
@@ -249,9 +251,6 @@ func patchHTTPRoute(patchContext networking.EnvoyFilter_PatchContext,
 			routeConfigurationMatch(patchContext, routeConfiguration, rp, portMap) &&
 			virtualHostMatch(virtualHost, rp) &&
 			routeMatch(virtualHost.Routes[routeIndex], rp) {
-
-			// different virtualHosts may share same routes pointer
-			virtualHost.Routes = cloneVhostRoutes(virtualHost.Routes)
 			if rp.Operation == networking.EnvoyFilter_Patch_REMOVE {
 				virtualHost.Routes[routeIndex] = nil
 				*routesRemoved = true


### PR DESCRIPTION
fix [#40950](https://github.com/istio/istio/issues/40950)
In our scenario, there are more than 5000 routers. When the router is in the merge filter, it will use proto.clone in a loop nested in the large array of routers. This modification moves the deep copy method to the outside of a loop,I think it is unnecessary to deep copy every time in the inner loop, a full deep copy can be made before the loop, so that the original A large number of calculations of n*n become n times

now:
<img width="1406" alt="pilot " src="https://user-images.githubusercontent.com/43161619/189890054-01c071c4-af36-41d4-adca-5a65e3c6c23c.png">
fixed:
![fix](https://user-images.githubusercontent.com/43161619/189890685-77303bff-f749-40a4-b251-70e40102a9e0.png)

