### PR TITLE
ambient l4: reduce pod ip chains from SA*Pod to per-SA

### DIFF
--- a/pilot/pkg/networking/ambientgen/ztunnelgen.go
+++ b/pilot/pkg/networking/ambientgen/ztunnelgen.go
@@ -423,7 +423,6 @@ func (g *ZTunnelConfigGenerator) buildPodOutboundCaptureListener(proxy *model.Pr
 				// TODO2: this is still broken even with custom orig_dst. the listener sets the orig_src mark
 				// If we
 
-				name := sourceWl.Identity() + "_to_" + wl.PodIP
 				tunnel := &tcp.TcpProxy_TunnelingConfig{
 					Hostname: "%DOWNSTREAM_LOCAL_ADDRESS%",
 					HeadersToAdd: []*core.HeaderValueOption{
@@ -443,6 +442,7 @@ func (g *ZTunnelConfigGenerator) buildPodOutboundCaptureListener(proxy *model.Pr
 					tunnel = nil
 				}
 
+				name := "fc-" + cluster
 				chain = &listener.FilterChain{
 					Name: name,
 					Filters: []*listener.Filter{


### PR DESCRIPTION
The chains have no real differences. Naming them identically will dedupe them (line 464)