### PR TITLE
authz: add logging back

### DIFF
--- a/pilot/pkg/networking/plugin/authz/authorization.go
+++ b/pilot/pkg/networking/plugin/authz/authorization.go
@@ -46,7 +46,6 @@ func NewBuilder(actionType ActionType, push *model.PushContext, proxy *model.Pro
 	tdBundle := trustdomain.NewBundle(push.Mesh.TrustDomain, push.Mesh.TrustDomainAliases)
 	option := builder.Option{
 		IsCustomBuilder: actionType == Custom,
-		Logger:          &builder.AuthzLogger{},
 	}
 	policies := push.AuthzPolicies.ListAuthorizationPolicies(proxy.ConfigNamespace, proxy.Labels)
 	b := builder.New(tdBundle, push, policies, option)

--- a/pilot/pkg/security/authz/builder/builder_test.go
+++ b/pilot/pkg/security/authz/builder/builder_test.go
@@ -254,11 +254,9 @@ func TestGenerator_GenerateHTTP(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			option := Option{
 				IsCustomBuilder: tc.meshConfig != nil,
-				Logger:          &AuthzLogger{},
 			}
 			push := push(t, baseDir+tc.input, tc.meshConfig)
 			proxy := node(tc.version)
-			defer option.Logger.Report(proxy)
 			policies := push.AuthzPolicies.ListAuthorizationPolicies(proxy.ConfigNamespace, proxy.Labels)
 			g := New(tc.tdBundle, push, policies, option)
 			if g == nil {
@@ -322,11 +320,9 @@ func TestGenerator_GenerateTCP(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			option := Option{
 				IsCustomBuilder: tc.meshConfig != nil,
-				Logger:          &AuthzLogger{},
 			}
 			push := push(t, baseDir+tc.input, tc.meshConfig)
 			proxy := node(nil)
-			defer option.Logger.Report(proxy)
 			policies := push.AuthzPolicies.ListAuthorizationPolicies(proxy.ConfigNamespace, proxy.Labels)
 			g := New(tc.tdBundle, push, policies, option)
 			if g == nil {

--- a/pilot/pkg/security/authz/builder/logger.go
+++ b/pilot/pkg/security/authz/builder/logger.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 
-	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/util/istiomultierror"
 	"istio.io/pkg/log"
 )
@@ -40,15 +39,15 @@ func (al *AuthzLogger) AppendError(err error) {
 	al.errMsg = multierror.Append(al.errMsg, err)
 }
 
-func (al *AuthzLogger) Report(node *model.Proxy) {
+func (al *AuthzLogger) Report() {
 	if al.errMsg != nil {
 		al.errMsg.ErrorFormat = istiomultierror.MultiErrorFormat()
-		authzLog.Errorf("Processed authorization policy for %s, %s", node.ID, al.errMsg)
+		authzLog.Errorf("Processed authorization policy: %s", al.errMsg)
 	}
 	if authzLog.DebugEnabled() && len(al.debugMsg) != 0 {
 		out := strings.Join(al.debugMsg, "\n\t* ")
-		authzLog.Debugf("Processed authorization policy for %s with details:\n\t* %v", node.ID, out)
+		authzLog.Debugf("Processed authorization policy with details:\n\t* %v", out)
 	} else {
-		authzLog.Debugf("Processed authorization policy for %s", node.ID)
+		authzLog.Debugf("Processed authorization policy")
 	}
 }


### PR DESCRIPTION
We were building the log but never reporting it. This was lost in a refactoring that moved authz building from per-proxy to being more cached and reused. This required a bit more refactoring since we build HTTP/TCP once and parse it.

**Please provide a description of this PR:**