### PR TITLE
istio: improve deep copy for ServiceAttribute

### DIFF
--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -566,7 +566,47 @@ func (s *ServiceAttributes) DeepCopy() ServiceAttributes {
 	// Nested mutexes are configured to be ignored by copystructure.Copy.
 	// Disabling `go vet` warning since this is actually safe in this case.
 	// nolint: vet
-	return copyInternal(*s).(ServiceAttributes)
+	out := *s
+
+	if s.Labels != nil {
+		out.Labels = make(map[string]string, len(s.Labels))
+		for k, v := range s.Labels {
+			out.Labels[k] = v
+		}
+	}
+
+	if s.ExportTo != nil {
+		out.ExportTo = make(map[visibility.Instance]bool, len(s.ExportTo))
+		for k, v := range s.ExportTo {
+			out.ExportTo[k] = v
+		}
+	}
+
+	if s.LabelSelectors != nil {
+		out.LabelSelectors = make(map[string]string, len(s.LabelSelectors))
+		for k, v := range s.LabelSelectors {
+			out.LabelSelectors[k] = v
+		}
+	}
+
+	out.ClusterExternalAddresses = s.ClusterExternalAddresses.DeepCopy()
+
+	if s.ClusterExternalPorts != nil {
+		out.ClusterExternalPorts = make(map[cluster.ID]map[uint32]uint32, len(s.ClusterExternalPorts))
+		for k, m := range s.ClusterExternalPorts {
+			if m == nil {
+				out.ClusterExternalPorts[k] = nil
+				continue
+			}
+
+			out.ClusterExternalPorts[k] = make(map[uint32]uint32, len(m))
+			for sp, np := range m {
+				out.ClusterExternalPorts[k][sp] = np
+			}
+		}
+	}
+
+	return out
 }
 
 // ServiceDiscovery enumerates Istio service instances.

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -606,6 +606,8 @@ func (s *ServiceAttributes) DeepCopy() ServiceAttributes {
 		}
 	}
 
+	// AddressMap contains a mutex, which is safe to return a copy in this case.
+	// nolint: govet
 	return out
 }
 


### PR DESCRIPTION

**Please provide a description of this PR:**

our istiod CPU profile shows that 10% of time is spent on DeepCopy of ServiceAttribute, so removing the use of copystructure. We already have fuzz test and benchmark for Service DeepCopy, which covers this part since ServiceAttribute is part of Service.

Benchmark results:
(before)
```goos: darwin
goarch: amd64
pkg: istio.io/istio/pilot/pkg/model
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
BenchmarkServiceDeepCopy
BenchmarkServiceDeepCopy-16    	  132760	      8190 ns/op
PASS
```
(after)
```goos: darwin
goarch: amd64
pkg: istio.io/istio/pilot/pkg/model
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
BenchmarkServiceDeepCopy
BenchmarkServiceDeepCopy-16    	 1213035	      1019 ns/op
PASS
```