### PR TITLE
istioctl: make pc ep support internal address

### DIFF
--- a/istioctl/pkg/writer/envoy/clusters/clusters.go
+++ b/istioctl/pkg/writer/envoy/clusters/clusters.go
@@ -76,8 +76,7 @@ func retrieveEndpointAddress(host *adminapi.HostStatus) string {
 	if internal := host.Address.GetEnvoyInternalAddress(); internal != nil {
 		switch an := internal.GetAddressNameSpecifier().(type) {
 		case *core.EnvoyInternalAddress_ServerListenerName:
-			// TODO: fmt.Sprintf("envoy://%s/%s", an.ServerListenerName, internal.EndpointId) once go-control-plane updates
-			return fmt.Sprintf("envoy://%s", an.ServerListenerName)
+			return fmt.Sprintf("envoy://%s/%s", an.ServerListenerName, internal.EndpointId)
 		}
 	}
 	return "unknown"

--- a/istioctl/pkg/writer/envoy/configdump/endpoint.go
+++ b/istioctl/pkg/writer/envoy/configdump/endpoint.go
@@ -78,8 +78,7 @@ func retrieveEndpointAddress(ep *endpoint.LbEndpoint) string {
 	if internal := addr.GetEnvoyInternalAddress(); internal != nil {
 		switch an := internal.GetAddressNameSpecifier().(type) {
 		case *core.EnvoyInternalAddress_ServerListenerName:
-			// TODO: fmt.Sprintf("envoy://%s/%s", an.ServerListenerName, internal.EndpointId) once go-control-plane updates
-			return fmt.Sprintf("envoy://%s", an.ServerListenerName)
+			return fmt.Sprintf("envoy://%s/%s", an.ServerListenerName, internal.EndpointId)
 		}
 	}
 	return "unknown"


### PR DESCRIPTION
**Please provide a description of this PR:**

before:

```console
envoy://tunnel                                                    HEALTHY     OK                outbound|80||notsleep.default.svc.cluster.local
envoy://tunnel                                                    HEALTHY     OK                outbound|80||sleep.default.svc.cluster.local
envoy://tunnel                                                    HEALTHY     OK                outbound|80||sleep.sidecar.svc.cluster.local
envoy://tunnel                                                    HEALTHY     OK                outbound|9080|v1|reviews.default.svc.cluster.local
envoy://tunnel                                                    HEALTHY     OK                outbound|9080|v2|reviews.default.svc.cluster.local
envoy://tunnel                                                    HEALTHY     OK                outbound|9080|v3|reviews.default.svc.cluster.local
envoy://tunnel                                                    HEALTHY     OK                outbound|9080||details.default.svc.cluster.local
envoy://tunnel                                                    HEALTHY     OK                outbound|9080||productpage.default.svc.cluster.local
envoy://tunnel                                                    HEALTHY     OK                outbound|9080||ratings.default.svc.cluster.local
envoy://tunnel                                                    HEALTHY     OK                outbound|9080||reviews.default.svc.cluster.local
envoy://tunnel                                                    HEALTHY     OK                outbound|9080||reviews.default.svc.cluster.local
envoy://tunnel                                                    HEALTHY     OK                outbound|9080||reviews.default.svc.cluster.local
```

after:

```console
envoy://tunnel/10.244.1.18:9080                                    HEALTHY     OK                outbound|9080||ratings.default.svc.cluster.local
envoy://tunnel/10.244.1.19:80                                      HEALTHY     OK                outbound|80||notsleep.default.svc.cluster.local
envoy://tunnel/10.244.1.21:9080                                    HEALTHY     OK                outbound|9080||details.default.svc.cluster.local
envoy://tunnel/10.244.1.22:9080                                    HEALTHY     OK                outbound|9080||productpage.default.svc.cluster.local
envoy://tunnel/10.244.1.23:9080                                    HEALTHY     OK                outbound|9080|v1|reviews.default.svc.cluster.local
envoy://tunnel/10.244.1.23:9080                                    HEALTHY     OK                outbound|9080||reviews.default.svc.cluster.local
envoy://tunnel/10.244.1.24:9080                                    HEALTHY     OK                outbound|9080|v2|reviews.default.svc.cluster.local
envoy://tunnel/10.244.1.24:9080                                    HEALTHY     OK                outbound|9080||reviews.default.svc.cluster.local
envoy://tunnel/10.244.1.25:9080                                    HEALTHY     OK                outbound|9080|v3|reviews.default.svc.cluster.local
envoy://tunnel/10.244.1.25:9080                                    HEALTHY     OK                outbound|9080||reviews.default.svc.cluster.local
envoy://tunnel/10.244.1.33:80                                      HEALTHY     OK                outbound|80||sleep.default.svc.cluster.local
envoy://tunnel/10.244.1.34:80                                      HEALTHY     OK                outbound|80||sleep.sidecar.svc.cluster.local
```