### PR TITLE
Let the double-layer loop deep copy object of large array change to once

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/rc_patch.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/rc_patch.go
@@ -151,6 +151,8 @@ func patchHTTPRoutes(patchContext networking.EnvoyFilter_PatchContext,
 	routeConfiguration *route.RouteConfiguration, virtualHost *route.VirtualHost, portMap model.GatewayPortMap,
 ) {
 	routesRemoved := false
+	// different virtualHosts may share same routes pointer
+	virtualHost.Routes = cloneVhostRoutes(virtualHost.Routes)
 	// Apply the route level removes/merges if any.
 	for index := range virtualHost.Routes {
 		patchHTTPRoute(patchContext, patches, routeConfiguration, virtualHost, index, &routesRemoved, portMap)
@@ -249,9 +251,6 @@ func patchHTTPRoute(patchContext networking.EnvoyFilter_PatchContext,
 			routeConfigurationMatch(patchContext, routeConfiguration, rp, portMap) &&
 			virtualHostMatch(virtualHost, rp) &&
 			routeMatch(virtualHost.Routes[routeIndex], rp) {
-
-			// different virtualHosts may share same routes pointer
-			virtualHost.Routes = cloneVhostRoutes(virtualHost.Routes)
 			if rp.Operation == networking.EnvoyFilter_Patch_REMOVE {
 				virtualHost.Routes[routeIndex] = nil
 				*routesRemoved = true

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/rc_patch.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/rc_patch.go
@@ -254,7 +254,7 @@ func patchHTTPRoute(patchContext networking.EnvoyFilter_PatchContext,
 				*routesRemoved = true
 				return
 			} else if rp.Operation == networking.EnvoyFilter_Patch_MERGE {
-				cloneVhostRouteByRouteIndex(virtualHost.Routes,routeIndex)
+				cloneVhostRouteByRouteIndex(virtualHost,routeIndex)
 				merge.Merge(virtualHost.Routes[routeIndex], rp.Value)
 			}
 			applied = true

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/rc_patch.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/rc_patch.go
@@ -254,7 +254,7 @@ func patchHTTPRoute(patchContext networking.EnvoyFilter_PatchContext,
 				*routesRemoved = true
 				return
 			} else if rp.Operation == networking.EnvoyFilter_Patch_MERGE {
-				cloneVhostRouteByRouteIndex(virtualHost,routeIndex)
+				cloneVhostRouteByRouteIndex(virtualHost, routeIndex)
 				merge.Merge(virtualHost.Routes[routeIndex], rp.Value)
 			}
 			applied = true
@@ -389,6 +389,6 @@ func routeMatch(httpRoute *route.Route, rp *model.EnvoyFilterConfigPatchWrapper)
 	return true
 }
 
-func cloneVhostRouteByRouteIndex(virtualHost *route.VirtualHost,routeIndex int) {
+func cloneVhostRouteByRouteIndex(virtualHost *route.VirtualHost, routeIndex int) {
 	virtualHost.Routes[routeIndex] = proto.Clone(virtualHost.Routes[routeIndex]).(*route.Route)
 }

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/rc_patch_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/rc_patch_test.go
@@ -960,7 +960,7 @@ func TestPatchHTTPRoute(t *testing.T) {
 		portMap            model.GatewayPortMap
 	}
 	obj := &route.Route{}
-	if err := xds.GogoStructToMessage(buildPatchStruct(`{"route": { "prefix_rewrite": "/foo"}}`), obj, false); err != nil {
+	if err := xds.StructToMessage(buildPatchStruct(`{"route": { "prefix_rewrite": "/foo"}}`), obj, false); err != nil {
 		t.Errorf("GogoStructToMessage error %v", err)
 	}
 	tests := []struct {

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/rc_patch_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/rc_patch_test.go
@@ -24,6 +24,7 @@ import (
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry/memory"
+	"istio.io/istio/pkg/config/xds"
 )
 
 func Test_virtualHostMatch(t *testing.T) {
@@ -943,6 +944,148 @@ func Test_routeMatch(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := routeMatch(tt.args.httpRoute, tt.args.cp); got != tt.want {
 				t.Errorf("routeMatch() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPatchHTTPRoute(t *testing.T) {
+	type args struct {
+		patchContext       networking.EnvoyFilter_PatchContext
+		patches            map[networking.EnvoyFilter_ApplyTo][]*model.EnvoyFilterConfigPatchWrapper
+		routeConfiguration *route.RouteConfiguration
+		virtualHost        *route.VirtualHost
+		routeIndex         int
+		routesRemoved      *bool
+		portMap            model.GatewayPortMap
+	}
+	obj := &route.Route{}
+	if err := xds.GogoStructToMessage(buildPatchStruct(`{"route": { "prefix_rewrite": "/foo"}}`), obj, false); err != nil {
+		t.Errorf("GogoStructToMessage error %v", err)
+	}
+	tests := []struct {
+		name string
+		args args
+		want *route.VirtualHost
+	}{
+		{
+			name: "normal",
+			args: args{
+				patchContext: networking.EnvoyFilter_GATEWAY,
+				patches: map[networking.EnvoyFilter_ApplyTo][]*model.EnvoyFilterConfigPatchWrapper{
+					networking.EnvoyFilter_HTTP_ROUTE: {
+						{
+							ApplyTo: networking.EnvoyFilter_HTTP_ROUTE,
+							Match: &networking.EnvoyFilter_EnvoyConfigObjectMatch{
+								ObjectTypes: &networking.EnvoyFilter_EnvoyConfigObjectMatch_RouteConfiguration{
+									RouteConfiguration: &networking.EnvoyFilter_RouteConfigurationMatch{
+										Vhost: &networking.EnvoyFilter_RouteConfigurationMatch_VirtualHostMatch{
+											Name: "normal",
+											Route: &networking.EnvoyFilter_RouteConfigurationMatch_RouteMatch{
+												Action: networking.EnvoyFilter_RouteConfigurationMatch_RouteMatch_ROUTE,
+											},
+										},
+									},
+								},
+							},
+							Operation: networking.EnvoyFilter_Patch_MERGE,
+							Value:     obj,
+						},
+					},
+				},
+				routeConfiguration: &route.RouteConfiguration{Name: "normal"},
+				virtualHost: &route.VirtualHost{
+					Name:    "normal",
+					Domains: []string{"*"},
+					Routes: []*route.Route{
+						{
+							Name: "normal",
+							Action: &route.Route_Route{
+								Route: &route.RouteAction{
+									PrefixRewrite: "/normal",
+								},
+							},
+						},
+					},
+				},
+				routeIndex: 0,
+				portMap: map[int]map[int]struct{}{
+					8080: {},
+				},
+			},
+			want: &route.VirtualHost{
+				Name:    "normal",
+				Domains: []string{"*"},
+				Routes: []*route.Route{
+					{
+						Name: "normal",
+						Action: &route.Route_Route{
+							Route: &route.RouteAction{
+								PrefixRewrite: "/foo",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			patchHTTPRoute(tt.args.patchContext, tt.args.patches, tt.args.routeConfiguration,
+				tt.args.virtualHost, tt.args.routeIndex, tt.args.routesRemoved, tt.args.portMap)
+			if diff := cmp.Diff(tt.want, tt.args.virtualHost, protocmp.Transform()); diff != "" {
+				t.Errorf("PatchHTTPRoute(): %s mismatch (-want +got):\n%s", tt.name, diff)
+			}
+		})
+	}
+}
+
+func TestCloneVhostRouteByRouteIndex(t *testing.T) {
+	type args struct {
+		vh1 *route.VirtualHost
+		vh2 *route.VirtualHost
+	}
+	cloneRouter := route.Route{
+		Name: "clone",
+		Action: &route.Route_Route{
+			Route: &route.RouteAction{
+				PrefixRewrite: "/clone",
+			},
+		},
+	}
+	tests := []struct {
+		name      string
+		args      args
+		wantClone bool
+	}{
+		{
+			name: "clone",
+			args: args{
+				vh1: &route.VirtualHost{
+					Name:    "vh1",
+					Domains: []string{"*"},
+					Routes: []*route.Route{
+						&cloneRouter,
+					},
+				},
+				vh2: &route.VirtualHost{
+					Name:    "vh2",
+					Domains: []string{"*"},
+					Routes: []*route.Route{
+						&cloneRouter,
+					},
+				},
+			},
+			wantClone: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cloneRouter.Name = "test"
+			cloneVhostRouteByRouteIndex(tt.args.vh1, 0)
+			if tt.args.vh1.Routes[0].Name != tt.args.vh2.Routes[0].Name && tt.wantClone {
+				t.Errorf("CloneVhostRouteByRouteIndex(): %s (-wantClone +got):%v", tt.name, tt.wantClone)
 			}
 		})
 	}


### PR DESCRIPTION
fix https://github.com/istio/istio/issues/40950
In our scenario, there are more than 5000 routers. When the router is in the merge filter, it will use proto.clone in a loop nested in the large array of routers. This modification moves the deep copy method to the outside of a loop,I think it is unnecessary to deep copy every time in the inner loop, a full deep copy can be made before the loop, so that the original A large number of calculations of n*n become n times