### PR TITLE
Update api (via client-go) and ignore deprecated method calls

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -84,8 +84,8 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 	helm.sh/helm/v3 v3.9.4
-	istio.io/api v0.0.0-20220912132053-71fdbd6f17e8
-	istio.io/client-go v1.12.0-alpha.5.0.20220907231137-ad718817214e
+	istio.io/api v0.0.0-20220913213654-8b21004e4347
+	istio.io/client-go v1.12.0-alpha.5.0.20220913214154-68a7059866e0
 	istio.io/pkg v0.0.0-20220912132454-a8115803196f
 	k8s.io/api v0.25.0
 	k8s.io/apiextensions-apiserver v0.25.0

--- a/go.sum
+++ b/go.sum
@@ -1959,10 +1959,10 @@ honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.2.1/go.mod h1:lPVVZ2BS5TfnjLyizF7o7hv7j9/L+8cZY2hLyjP9cGY=
-istio.io/api v0.0.0-20220912132053-71fdbd6f17e8 h1:5d7ndk80sMLiR+Nbe2PQBVBxjguhwjZB44LPlLqQUfw=
-istio.io/api v0.0.0-20220912132053-71fdbd6f17e8/go.mod h1:hQkF0Q19MCmfOTre/Sg4KvrwwETq45oaFplnBm2p4j8=
-istio.io/client-go v1.12.0-alpha.5.0.20220907231137-ad718817214e h1:QwGm6k1+Qr93yr6DEO1Pvr6Bh530qTPKvQDHc6pMfEs=
-istio.io/client-go v1.12.0-alpha.5.0.20220907231137-ad718817214e/go.mod h1:8D3jMnFzgfMz0yzHJ6n09Z8mPUOM52deHe3BjOQSh6Y=
+istio.io/api v0.0.0-20220913213654-8b21004e4347 h1:H0f89DdWcGL2nSwAC6be2PpZil1VMdPSXX7vnFRJUVo=
+istio.io/api v0.0.0-20220913213654-8b21004e4347/go.mod h1:hQkF0Q19MCmfOTre/Sg4KvrwwETq45oaFplnBm2p4j8=
+istio.io/client-go v1.12.0-alpha.5.0.20220913214154-68a7059866e0 h1:GY34X4X1kczX0S40opzyrwu+KyNoX887q+gaUn1zjL0=
+istio.io/client-go v1.12.0-alpha.5.0.20220913214154-68a7059866e0/go.mod h1:WjXgBLSBl9c3FdxuAeTVzdMyD4MJG0njFFP0qAmnWE4=
 istio.io/pkg v0.0.0-20220912132454-a8115803196f h1:VxInp5aA/skf4kAJ9Fd5y6FcVygJLrQ0BQOKFvosPTg=
 istio.io/pkg v0.0.0-20220912132454-a8115803196f/go.mod h1:Rom8KLVw76XZdvGZet+54VPZswL/XqX8x4MBH6khECw=
 k8s.io/api v0.18.2/go.mod h1:SJCWI7OLzhZSvbY7U8zwNl9UA4o1fizoug34OV/2r78=

--- a/pilot/pkg/networking/core/v1alpha3/tracing.go
+++ b/pilot/pkg/networking/core/v1alpha3/tracing.go
@@ -305,12 +305,15 @@ func configureFromProviderConfig(pushCtx *model.PushContext, meta *model.NodeMet
 			// - max number of message events
 			// The following code block allows control for a single configuration once during the lifecycle of a
 			// mesh.
+			// nolint: staticcheck
 			if provider.Stackdriver.GetMaxNumberOfAnnotations() != nil {
 				sd.TraceConfig.MaxNumberOfAnnotations = provider.Stackdriver.GetMaxNumberOfAnnotations().GetValue()
 			}
+			// nolint: staticcheck
 			if provider.Stackdriver.GetMaxNumberOfAttributes() != nil {
 				sd.TraceConfig.MaxNumberOfAttributes = provider.Stackdriver.GetMaxNumberOfAttributes().GetValue()
 			}
+			// nolint: staticcheck
 			if provider.Stackdriver.GetMaxNumberOfMessageEvents() != nil {
 				sd.TraceConfig.MaxNumberOfMessageEvents = provider.Stackdriver.GetMaxNumberOfMessageEvents().GetValue()
 			}


### PR DESCRIPTION
**Please provide a description of this PR:**

Possible fix for https://github.com/istio/istio/pull/40965 failing lint test. This ignores the lint message about calling a deprecated method.

@douglas-reid 