### PR TITLE
pilot: fix remote JWKS endpoint host assignment

### DIFF
--- a/releasenotes/notes/40997.yaml
+++ b/releasenotes/notes/40997.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+releaseNotes:
+  - |
+    **Fixed** an issue where Remote JWKS URI's without a host port fail to parse into their host and port components.


### PR DESCRIPTION
**Please provide a description of this PR:**

Fixes a bug where remote JWKS URI's specified without a host port fail to parse into their host and port components.

Example: https://go.dev/play/p/vtXEUwF8s7S
- jwtRule.JwksUri = "http://istio.io/jwks"
  - net.SplitHostPort would error, and host would be empty.