### PR TITLE
Create inbound listener from both sidecar and service

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -661,6 +661,12 @@ var (
 	EnableLeaderElection = env.Register("ENABLE_LEADER_ELECTION", true,
 		"If enabled (default), starts a leader election client and gains leadership before executing controllers. "+
 			"If false, it assumes that only one instance of istiod is running and skips leader election.").Get()
+
+	EnableSidecarServiceInboundListenerMerge = env.Register(
+		"PILOT_ALLOW_SIDECAR_SERVICE_INBOUND_LISTENER_MERGE",
+		false,
+		"If set, it allows creating inbound listeners for service ports and sidecar ingress listeners ",
+	).Get()
 )
 
 // EnableEndpointSliceController returns the value of the feature flag and whether it was actually specified.

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -371,7 +371,10 @@ func buildInboundLocalityLbEndpoints(bind string, port uint32) []*endpoint.Local
 	}
 }
 
-func (configgen *ConfigGeneratorImpl) buildClustersFromServiceInstances(cb *ClusterBuilder, proxy *model.Proxy, instances []*model.ServiceInstance, cp clusterPatcher, enableSidecarServiceInboundListenerMerge bool) []*cluster.Cluster {
+func (configgen *ConfigGeneratorImpl) buildClustersFromServiceInstances(cb *ClusterBuilder, proxy *model.Proxy,
+	instances []*model.ServiceInstance, cp clusterPatcher,
+	enableSidecarServiceInboundListenerMerge bool,
+) []*cluster.Cluster {
 	clusters := make([]*cluster.Cluster, 0)
 	_, actualLocalHost := getActualWildcardAndLocalHost(proxy)
 	clustersToBuild := make(map[int][]*model.ServiceInstance)

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -371,6 +371,43 @@ func buildInboundLocalityLbEndpoints(bind string, port uint32) []*endpoint.Local
 	}
 }
 
+func (configgen *ConfigGeneratorImpl) buildClustersFromServiceInstances(cb *ClusterBuilder, proxy *model.Proxy, instances []*model.ServiceInstance, cp clusterPatcher, enableSidecarServiceInboundListenerMerge bool) []*cluster.Cluster {
+	clusters := make([]*cluster.Cluster, 0)
+	_, actualLocalHost := getActualWildcardAndLocalHost(proxy)
+	clustersToBuild := make(map[int][]*model.ServiceInstance)
+	for _, instance := range instances {
+		// For service instances with the same port,
+		// we still need to capture all the instances on this port, as its required to populate telemetry metadata
+		// The first instance will be used as the "primary" instance; this means if we have an conflicts between
+		// Services the first one wins
+		ep := int(instance.Endpoint.EndpointPort)
+		clustersToBuild[ep] = append(clustersToBuild[ep], instance)
+	}
+
+	bind := actualLocalHost
+	if features.EnableInboundPassthrough {
+		bind = ""
+	}
+	// For each workload port, we will construct a cluster
+	for epPort, instances := range clustersToBuild {
+		if enableSidecarServiceInboundListenerMerge && samePortInSidecarIngressAndService(proxy, int(instances[0].Endpoint.EndpointPort)) {
+			// here if port is declared in service and sidecar ingress both, we continue to take the one on sidecar + other service ports
+			// e.g. 1,2, 3 in service and 3,4 in sidecar ingress,
+			// this will still generate listeners for 1,2,3,4 where 3 is picked from sidecar ingress
+			continue
+		}
+		// The inbound cluster port equals to endpoint port.
+		localCluster := cb.buildInboundClusterForPortOrUDS(epPort, bind, proxy, instances[0], instances)
+		// If inbound cluster match has service, we should see if it matches with any host name across all instances.
+		hosts := make([]host.Name, 0, len(instances))
+		for _, si := range instances {
+			hosts = append(hosts, si.Service.Hostname)
+		}
+		clusters = cp.conditionallyAppend(clusters, hosts, localCluster.build())
+	}
+	return clusters
+}
+
 func (configgen *ConfigGeneratorImpl) buildInboundClusters(cb *ClusterBuilder, proxy *model.Proxy, instances []*model.ServiceInstance,
 	cp clusterPatcher,
 ) []*cluster.Cluster {
@@ -394,35 +431,14 @@ func (configgen *ConfigGeneratorImpl) buildInboundClusters(cb *ClusterBuilder, p
 		if noneMode {
 			return nil
 		}
-
-		clustersToBuild := make(map[int][]*model.ServiceInstance)
-		for _, instance := range instances {
-			// For service instances with the same port,
-			// we still need to capture all the instances on this port, as its required to populate telemetry metadata
-			// The first instance will be used as the "primary" instance; this means if we have an conflicts between
-			// Services the first one wins
-			ep := int(instance.Endpoint.EndpointPort)
-			clustersToBuild[ep] = append(clustersToBuild[ep], instance)
-		}
-
-		bind := actualLocalHost
-		if features.EnableInboundPassthrough {
-			bind = ""
-		}
-		// For each workload port, we will construct a cluster
-		for epPort, instances := range clustersToBuild {
-			// The inbound cluster port equals to endpoint port.
-			localCluster := cb.buildInboundClusterForPortOrUDS(epPort, bind, proxy, instances[0], instances)
-			// If inbound cluster match has service, we should see if it matches with any host name across all instances.
-			hosts := make([]host.Name, 0, len(instances))
-			for _, si := range instances {
-				hosts = append(hosts, si.Service.Hostname)
-			}
-			clusters = cp.conditionallyAppend(clusters, hosts, localCluster.build())
-		}
+		clusters = configgen.buildClustersFromServiceInstances(cb, proxy, instances, cp, false)
 		return clusters
 	}
 
+	if features.EnableSidecarServiceInboundListenerMerge {
+		// only allow to merge inbound listeners if sidecar has ingress listener and pilot has env EnableSidecarServiceInboundListenerMerge set
+		clusters = configgen.buildClustersFromServiceInstances(cb, proxy, instances, cp, true)
+	}
 	for _, ingressListener := range sidecarScope.Sidecar.Ingress {
 		// LDS would have setup the inbound clusters
 		// as inbound|portNumber|portName|Hostname[or]SidecarScopeID
@@ -482,7 +498,6 @@ func (configgen *ConfigGeneratorImpl) buildInboundClusters(cb *ClusterBuilder, p
 				endpointAddress = actualLocalHost
 			}
 		}
-
 		// Find the service instance that corresponds to this ingress listener by looking
 		// for a service instance that matches this ingress port as this will allow us
 		// to generate the right cluster name that LDS expects inbound|portNumber|portName|Hostname
@@ -495,7 +510,6 @@ func (configgen *ConfigGeneratorImpl) buildInboundClusters(cb *ClusterBuilder, p
 		localCluster := cb.buildInboundClusterForPortOrUDS(int(ingressListener.Port.Number), endpointAddress, proxy, instance, nil)
 		clusters = cp.conditionallyAppend(clusters, []host.Name{instance.Service.Hostname}, localCluster.build())
 	}
-
 	return clusters
 }
 

--- a/releasenotes/notes/41018.yaml
+++ b/releasenotes/notes/41018.yaml
@@ -1,0 +1,16 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+
+issue:
+  - 40919
+
+releaseNotes:
+  - |
+    **Added** Allow creating inbound listeners for service ports and sidecar
+    and ingress listener both using environment variable
+    PILOT_ALLOW_SIDECAR_SERVICE_INBOUND_LISTENER_MERGE.
+    This way traffic for service port is not sent via pass-through tcp even
+    though its regular http traffic when sidecar ingress listener is defined.
+    In case same port number is defined in both sidecar ingress and service,
+    sidecar always takes precedence.


### PR DESCRIPTION
Fixes: https://github.com/istio/istio/issues/40919

Helps in cases where port is present in service as well as sidecar ingress.

As a result ports in service are not added to passthrough clusters.

If port number is same in service and sidecar ingress, sidecar takes precedence as expected for that port

Signed-off-by: Aliasgar Ginwala aginwala@ebay.com