### PR TITLE
Exclude system namespaces from auto.sidecar-injector.istio.io namespaceSele…

### DIFF
--- a/manifests/charts/default/templates/mutatingwebhook.yaml
+++ b/manifests/charts/default/templates/mutatingwebhook.yaml
@@ -113,6 +113,9 @@ webhooks:
       operator: DoesNotExist
     - key: istio.io/rev
       operator: DoesNotExist
+    - key: "kubernetes.io/metadata.name"
+      operator: "NotIn"
+      values: [ "kube-system" ]  
   objectSelector:
     matchExpressions:
     - key: sidecar.istio.io/inject

--- a/manifests/charts/default/templates/mutatingwebhook.yaml
+++ b/manifests/charts/default/templates/mutatingwebhook.yaml
@@ -115,7 +115,7 @@ webhooks:
       operator: DoesNotExist
     - key: "kubernetes.io/metadata.name"
       operator: "NotIn"
-      values: [ "kube-system" ]  
+      values: ["kube-system","kube-public","kube-node-lease","local-path-storage"]
   objectSelector:
     matchExpressions:
     - key: sidecar.istio.io/inject

--- a/manifests/charts/istio-control/istio-discovery/templates/mutatingwebhook.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/mutatingwebhook.yaml
@@ -137,6 +137,9 @@ webhooks:
       operator: DoesNotExist
     - key: istio.io/rev
       operator: DoesNotExist
+    - key: "kubernetes.io/metadata.name"
+      operator: "NotIn"
+      values: [ "kube-system" ]
   objectSelector:
     matchExpressions:
     - key: sidecar.istio.io/inject

--- a/manifests/charts/istio-control/istio-discovery/templates/mutatingwebhook.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/mutatingwebhook.yaml
@@ -139,7 +139,7 @@ webhooks:
       operator: DoesNotExist
     - key: "kubernetes.io/metadata.name"
       operator: "NotIn"
-      values: [ "kube-system" ]
+      values: ["kube-system","kube-public","kube-node-lease","local-path-storage"]
   objectSelector:
     matchExpressions:
     - key: sidecar.istio.io/inject

--- a/manifests/charts/istio-control/istio-discovery/templates/revision-tags.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/revision-tags.yaml
@@ -124,6 +124,9 @@ webhooks:
       operator: DoesNotExist
     - key: istio.io/rev
       operator: DoesNotExist
+    - key: "kubernetes.io/metadata.name"
+      operator: "NotIn"
+      values: [ "kube-system" ]
   objectSelector:
     matchExpressions:
     - key: sidecar.istio.io/inject

--- a/manifests/charts/istio-control/istio-discovery/templates/revision-tags.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/revision-tags.yaml
@@ -126,7 +126,7 @@ webhooks:
       operator: DoesNotExist
     - key: "kubernetes.io/metadata.name"
       operator: "NotIn"
-      values: [ "kube-system" ]
+      values: ["kube-system","kube-public","kube-node-lease","local-path-storage"]
   objectSelector:
     matchExpressions:
     - key: sidecar.istio.io/inject

--- a/manifests/charts/istiod-remote/templates/mutatingwebhook.yaml
+++ b/manifests/charts/istiod-remote/templates/mutatingwebhook.yaml
@@ -137,6 +137,9 @@ webhooks:
       operator: DoesNotExist
     - key: istio.io/rev
       operator: DoesNotExist
+    - key: "kubernetes.io/metadata.name"
+      operator: "NotIn"
+      values: [ "kube-system" ]
   objectSelector:
     matchExpressions:
     - key: sidecar.istio.io/inject

--- a/manifests/charts/istiod-remote/templates/mutatingwebhook.yaml
+++ b/manifests/charts/istiod-remote/templates/mutatingwebhook.yaml
@@ -139,7 +139,7 @@ webhooks:
       operator: DoesNotExist
     - key: "kubernetes.io/metadata.name"
       operator: "NotIn"
-      values: [ "kube-system" ]
+      values: ["kube-system","kube-public","kube-node-lease","local-path-storage"]
   objectSelector:
     matchExpressions:
     - key: sidecar.istio.io/inject

--- a/operator/cmd/mesh/testdata/manifest-generate/input-extra-resources/duplicate_mwc.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/input-extra-resources/duplicate_mwc.yaml
@@ -180,6 +180,9 @@ webhooks:
       operator: DoesNotExist
     - key: istio.io/rev
       operator: DoesNotExist
+    - key: "kubernetes.io/metadata.name"
+      operator: "NotIn"
+      values: [ "kube-system" ]
   objectSelector:
     matchExpressions:
     - key: sidecar.istio.io/inject

--- a/operator/cmd/mesh/testdata/manifest-generate/input-extra-resources/duplicate_mwc.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/input-extra-resources/duplicate_mwc.yaml
@@ -182,7 +182,7 @@ webhooks:
       operator: DoesNotExist
     - key: "kubernetes.io/metadata.name"
       operator: "NotIn"
-      values: [ "kube-system" ]
+      values: ["kube-system","kube-public","kube-node-lease","local-path-storage"]
   objectSelector:
     matchExpressions:
     - key: sidecar.istio.io/inject

--- a/releasenotes/notes/41020.yaml
+++ b/releasenotes/notes/41020.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+issue:
+  - https://github.com/istio/istio/issues/40984
+releaseNotes:
+  - |
+    **Fixed** an issue when auto.sidecar-injector.istio.io namespaceSelector caused problems with cluster maintenance.


### PR DESCRIPTION
**Please provide a description of this PR:**
Since Kubernetes v1.21, it is possible to exclude namespaces by label "kubernetes.io/metadata.name".
Fixes:
- https://github.com/istio/istio/issues/40984