### PR TITLE
update golang to 1.19 for tcp-echo

### DIFF
--- a/samples/tcp-echo/src/Dockerfile
+++ b/samples/tcp-echo/src/Dockerfile
@@ -16,7 +16,7 @@
 ARG BASE_DISTRIBUTION=default
 
 # build a tcp-echo binary using the golang container
-FROM golang:1.14.2 as builder
+FROM golang:1.19 as builder
 WORKDIR /go/src/istio.io/tcp-echo-server/
 COPY main.go .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o tcp-echo main.go


### PR DESCRIPTION
**Please provide a description of this PR:**
update golang to 1.19 for tcp-echo