### PR TITLE
Fix Sidecarscope service and destinationrule map

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -860,14 +860,14 @@ func (ps *PushContext) GetAllServices() []*Service {
 }
 
 // ServiceForHostname returns the service associated with a given hostname following SidecarScope
-// It returns the service in the proxy namespace in high priority.
+// It returns the service in the proxy namespace if available otherwise returns a service from any other namespace.
 func (ps *PushContext) ServiceForHostname(proxy *Proxy, hostname host.Name) *Service {
 	if proxy != nil && proxy.SidecarScope != nil {
 		// first return the service from proxy namespace
 		if proxy.SidecarScope.servicesByHostname[hostname][proxy.ConfigNamespace] != nil {
 			return proxy.SidecarScope.servicesByHostname[hostname][proxy.ConfigNamespace]
 		}
-		// return arbitrary service
+		// return the service from other namespace
 		for _, svc := range proxy.SidecarScope.servicesByHostname[hostname] {
 			return svc
 		}

--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -594,16 +594,16 @@ func (sc *SidecarScope) DestinationRule(direction TrafficDirection, proxy *Proxy
 		if destinationRule.GetWorkloadSelector() == nil {
 			proxyNamespaceDrs = append(proxyNamespaceDrs, destRule)
 		}
+		// 1. same namespace as the proxy, and with workload selector
 		if destinationRule.GetWorkloadSelector() != nil && direction == TrafficDirectionOutbound {
 			workloadSelector := labels.Instance(destinationRule.GetWorkloadSelector().GetMatchLabels())
 			// return destination rule if workload selector matches
 			if workloadSelector.SubsetOf(proxy.Labels) {
-				// 1
 				return destRule
 			}
 		}
 	}
-	// 2
+	// 2. same namespace as the proxy but without workload selector
 	if len(proxyNamespaceDrs) > 0 {
 		return proxyNamespaceDrs[0]
 	}

--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -587,7 +587,7 @@ func (sc *SidecarScope) DestinationRule(direction TrafficDirection, proxy *Proxy
 	// select destinationrule with priority order:
 	// 1. same namespace as the proxy, and with workload selector
 	// 2. same namespace as the proxy
-	var proxyNamespaceDrs, svcNamespaceDrs, catchAllDrs []*ConsolidatedDestRule
+	var proxyNamespaceDrs []*ConsolidatedDestRule
 	destinationRules := sc.destinationRules[svc.Hostname][sc.Namespace]
 	for _, destRule := range destinationRules {
 		destinationRule := destRule.rule.Spec.(*networking.DestinationRule)

--- a/pilot/pkg/model/sidecar_test.go
+++ b/pilot/pkg/model/sidecar_test.go
@@ -1130,9 +1130,9 @@ var (
 			},
 		},
 	}
-	nonWorkloadSelectorDr = config.Config{
+	destinationRule4 = config.Config{
 		Meta: config.Meta{
-			Name:      "drRule3",
+			Name:      "drRule4",
 			Namespace: "mynamespace",
 		},
 		Spec: &networking.DestinationRule{
@@ -1145,6 +1145,23 @@ var (
 					Tcp: &networking.ConnectionPoolSettings_TCPSettings{
 						ConnectTimeout: &durationpb.Duration{Seconds: 33},
 					},
+				},
+			},
+		},
+	}
+	destinationRule5 = config.Config{
+		Meta: config.Meta{
+			Name:      "drRule5",
+			Namespace: "anotherNs",
+		},
+		Spec: &networking.DestinationRule{
+			Host: "httpbin.org",
+			Subsets: []*networking.Subset{
+				{
+					Name: "subset5-0",
+				},
+				{
+					Name: "subset5-1",
 				},
 			},
 		},
@@ -1779,7 +1796,7 @@ func TestCreateSidecarScope(t *testing.T) {
 					},
 				},
 			},
-			&nonWorkloadSelectorDr,
+			&destinationRule4,
 		},
 		{
 			"sidecar-scope-same-workloadselector-labels-drs-should-be-merged",
@@ -1850,7 +1867,7 @@ func TestCreateSidecarScope(t *testing.T) {
 			ps := NewPushContext()
 			meshConfig := mesh.DefaultMeshConfig()
 			ps.Mesh = meshConfig
-			ps.setDestinationRules([]config.Config{destinationRule1, destinationRule2, destinationRule3, nonWorkloadSelectorDr})
+			ps.setDestinationRules([]config.Config{destinationRule1, destinationRule2, destinationRule3, destinationRule4})
 			if tt.services != nil {
 				ps.ServiceIndex.public = append(ps.ServiceIndex.public, tt.services...)
 
@@ -1926,7 +1943,7 @@ func TestCreateSidecarScope(t *testing.T) {
 						Labels:          tt.sidecarConfig.Labels,
 						Metadata:        &NodeMetadata{Labels: tt.sidecarConfig.Labels},
 						ConfigNamespace: tt.sidecarConfig.Namespace,
-					}, host.Name("httpbin.org")).GetRule()
+					}, services20[0]).GetRule()
 				assert.Equal(t, dr, tt.expectedDr)
 			}
 		})

--- a/pilot/pkg/model/sidecar_test.go
+++ b/pilot/pkg/model/sidecar_test.go
@@ -1867,7 +1867,7 @@ func TestCreateSidecarScope(t *testing.T) {
 			ps := NewPushContext()
 			meshConfig := mesh.DefaultMeshConfig()
 			ps.Mesh = meshConfig
-			ps.setDestinationRules([]config.Config{destinationRule1, destinationRule2, destinationRule3, destinationRule4})
+			ps.setDestinationRules([]config.Config{destinationRule1, destinationRule2, destinationRule3, destinationRule4, destinationRule5})
 			if tt.services != nil {
 				ps.ServiceIndex.public = append(ps.ServiceIndex.public, tt.services...)
 

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -327,7 +327,7 @@ func (configgen *ConfigGeneratorImpl) buildOutboundSniDnatClusters(proxy *model.
 			continue
 		}
 
-		destRule := proxy.SidecarScope.DestinationRule(model.TrafficDirectionOutbound, proxy, service.Hostname).GetRule()
+		destRule := proxy.SidecarScope.DestinationRule(model.TrafficDirectionOutbound, proxy, service).GetRule()
 		for _, port := range service.Ports {
 			if port.Protocol == protocol.UDP {
 				continue

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -450,7 +450,7 @@ func (cb *ClusterBuilder) buildInboundClusterForPortOrUDS(clusterPort int, bind 
 	// (not the defaults) to handle the increased traffic volume
 	// TODO: This is not foolproof - if instance is part of multiple services listening on same port,
 	// choice of inbound cluster is arbitrary. So the connection pool settings may not apply cleanly.
-	cfg := proxy.SidecarScope.DestinationRule(model.TrafficDirectionInbound, proxy, instance.Service.Hostname).GetRule()
+	cfg := proxy.SidecarScope.DestinationRule(model.TrafficDirectionInbound, proxy, instance.Service).GetRule()
 	if cfg != nil {
 		destinationRule := cfg.Spec.(*networking.DestinationRule)
 		opts.isDrWithSelector = destinationRule.GetWorkloadSelector() != nil

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
@@ -519,7 +519,7 @@ func TestApplyDestinationRule(t *testing.T) {
 			tt.cluster.CommonLbConfig = &cluster.Cluster_CommonLbConfig{}
 
 			ec := NewMutableCluster(tt.cluster)
-			destRule := proxy.SidecarScope.DestinationRule(model.TrafficDirectionOutbound, proxy, tt.service.Hostname).GetRule()
+			destRule := proxy.SidecarScope.DestinationRule(model.TrafficDirectionOutbound, proxy, tt.service).GetRule()
 
 			subsetClusters := cb.applyDestinationRule(ec, tt.clusterMode, tt.service, tt.port, tt.proxyView, destRule, nil)
 			if len(subsetClusters) != len(tt.expectedSubsetClusters) {
@@ -3334,7 +3334,7 @@ func TestApplyDestinationRuleOSCACert(t *testing.T) {
 			tt.cluster.CommonLbConfig = &cluster.Cluster_CommonLbConfig{}
 
 			ec := NewMutableCluster(tt.cluster)
-			destRule := proxy.SidecarScope.DestinationRule(model.TrafficDirectionOutbound, proxy, tt.service.Hostname).GetRule()
+			destRule := proxy.SidecarScope.DestinationRule(model.TrafficDirectionOutbound, proxy, tt.service).GetRule()
 
 			// ACT
 			_ = cb.applyDestinationRule(ec, tt.clusterMode, tt.service, tt.port, tt.proxyView, destRule, nil)

--- a/pilot/pkg/networking/core/v1alpha3/cluster_cache.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_cache.go
@@ -175,7 +175,7 @@ func buildClusterKey(service *model.Service, port *model.Port, cb *ClusterBuilde
 		downstreamAuto:  cb.sidecarProxy() && util.IsProtocolSniffingEnabledForOutboundPort(port),
 		supportsIPv4:    cb.supportsIPv4,
 		service:         service,
-		destinationRule: proxy.SidecarScope.DestinationRule(model.TrafficDirectionOutbound, proxy, service.Hostname),
+		destinationRule: proxy.SidecarScope.DestinationRule(model.TrafficDirectionOutbound, proxy, service),
 		envoyFilterKeys: efKeys,
 		metadataCerts:   cb.metadataCerts,
 		peerAuthVersion: cb.req.Push.AuthnPolicies.GetVersion(),

--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -890,7 +890,7 @@ func builtAutoPassthroughFilterChains(push *model.PushContext, proxy *model.Prox
 				statPrefix = telemetry.BuildStatPrefix(push.Mesh.OutboundClusterStatName, string(service.Hostname), "", port, &service.Attributes)
 			}
 			destinationRule := CastDestinationRule(proxy.SidecarScope.DestinationRule(
-				model.TrafficDirectionOutbound, proxy, service.Hostname).GetRule())
+				model.TrafficDirectionOutbound, proxy, service).GetRule())
 
 			// First, we build the standard cluster. We match on the SNI matching the cluster name
 			// (per the spec of AUTO_PASSTHROUGH), as well as all possible Istio mTLS ALPNs. This,

--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -286,16 +286,8 @@ func buildNameToServiceMapForHTTPRoutes(node *model.Proxy, push *model.PushConte
 		if _, exist := nameToServiceMap[hostname]; exist {
 			return
 		}
-
-		var service *model.Service
 		// First, we obtain the service which has the same namespace as virtualService
-		s, exist := push.ServiceIndex.HostnameAndNamespace[hostname][virtualService.Namespace]
-		if exist {
-			// We should check whether the selected service is visible to the proxy node.
-			if push.IsServiceVisible(s, node.ConfigNamespace) {
-				service = s
-			}
-		}
+		service := push.ServiceForHostnameAndNamespace(node, hostname, virtualService.Namespace)
 		// If we find no service for the namespace of virtualService or the selected service is not visible to the proxy node,
 		// we should fallback to pick one service which is visible to the ConfigNamespace of node.
 		if service == nil {

--- a/pilot/pkg/networking/core/v1alpha3/networkfilter.go
+++ b/pilot/pkg/networking/core/v1alpha3/networkfilter.go
@@ -230,7 +230,7 @@ func buildOutboundNetworkFilters(node *model.Proxy,
 	service := push.ServiceForHostnameAndNamespace(node, host.Name(routes[0].Destination.Host), configMeta.Namespace)
 	var destinationRule *networking.DestinationRule
 	if service != nil {
-		destinationRule = CastDestinationRule(node.SidecarScope.DestinationRule(model.TrafficDirectionOutbound, node, service.Hostname).GetRule())
+		destinationRule = CastDestinationRule(node.SidecarScope.DestinationRule(model.TrafficDirectionOutbound, node, service).GetRule())
 	}
 	if len(routes) == 1 {
 		clusterName := istioroute.GetDestinationCluster(routes[0].Destination, service, port.Port)

--- a/pilot/pkg/networking/core/v1alpha3/networkfilter.go
+++ b/pilot/pkg/networking/core/v1alpha3/networkfilter.go
@@ -135,7 +135,7 @@ func buildOutboundNetworkFiltersWithWeightedClusters(node *model.Proxy, routes [
 	}
 
 	for _, route := range routes {
-		service := push.ServiceForHostname(node, host.Name(route.Destination.Host))
+		service := push.ServiceForHostnameAndNamespace(node, host.Name(route.Destination.Host), configMeta.Namespace)
 		if route.Weight > 0 {
 			clusterName := istioroute.GetDestinationCluster(route.Destination, service, port.Port)
 			clusterSpecifier.WeightedClusters.Clusters = append(clusterSpecifier.WeightedClusters.Clusters, &tcp.TcpProxy_WeightedCluster_ClusterWeight{
@@ -227,7 +227,7 @@ func buildOutboundNetworkFilters(node *model.Proxy,
 	routes []*networking.RouteDestination, push *model.PushContext,
 	port *model.Port, configMeta config.Meta,
 ) []*listener.Filter {
-	service := push.ServiceForHostname(node, host.Name(routes[0].Destination.Host))
+	service := push.ServiceForHostnameAndNamespace(node, host.Name(routes[0].Destination.Host), configMeta.Namespace)
 	var destinationRule *networking.DestinationRule
 	if service != nil {
 		destinationRule = CastDestinationRule(node.SidecarScope.DestinationRule(model.TrafficDirectionOutbound, node, service.Hostname).GetRule())

--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -1241,7 +1241,7 @@ func hashForService(push *model.PushContext,
 	if push == nil {
 		return nil, nil
 	}
-	mergedDR := node.SidecarScope.DestinationRule(model.TrafficDirectionOutbound, node, svc.Hostname)
+	mergedDR := node.SidecarScope.DestinationRule(model.TrafficDirectionOutbound, node, svc)
 	destinationRule := mergedDR.GetRule()
 	if destinationRule == nil {
 		return nil, nil
@@ -1294,7 +1294,11 @@ func hashForHTTPDestination(push *model.PushContext, node *model.Proxy,
 	}
 
 	destination := dst.GetDestination()
-	mergedDR := node.SidecarScope.DestinationRule(model.TrafficDirectionOutbound, node, host.Name(destination.Host))
+	mergedDR := node.SidecarScope.DestinationRule(model.TrafficDirectionOutbound, node,
+		&model.Service{
+			Hostname:   host.Name(destination.Host),
+			Attributes: model.ServiceAttributes{Namespace: node.ConfigNamespace},
+		})
 	destinationRule := mergedDR.GetRule()
 	if destinationRule == nil {
 		return nil, nil

--- a/pilot/pkg/networking/core/v1alpha3/tls.go
+++ b/pilot/pkg/networking/core/v1alpha3/tls.go
@@ -201,7 +201,7 @@ func buildSidecarOutboundTLSFilterChainOpts(node *model.Proxy, push *model.PushC
 			sniHosts = []string{string(service.Hostname)}
 		}
 		destinationRule := CastDestinationRule(node.SidecarScope.DestinationRule(
-			model.TrafficDirectionOutbound, node, service.Hostname).GetRule())
+			model.TrafficDirectionOutbound, node, service).GetRule())
 		out = append(out, &filterChainOpts{
 			sniHosts:         sniHosts,
 			destinationCIDRs: []string{destinationCIDR},
@@ -306,7 +306,7 @@ TcpLoop:
 		clusterName := model.BuildSubsetKey(model.TrafficDirectionOutbound, "", service.Hostname, port)
 		statPrefix := clusterName
 		destinationRule := CastDestinationRule(node.SidecarScope.DestinationRule(
-			model.TrafficDirectionOutbound, node, service.Hostname).GetRule())
+			model.TrafficDirectionOutbound, node, service).GetRule())
 		// If stat name is configured, use it to build the stat prefix.
 		if len(push.Mesh.OutboundClusterStatName) != 0 {
 			statPrefix = telemetry.BuildStatPrefix(push.Mesh.OutboundClusterStatName, string(service.Hostname), "", &model.Port{Port: port}, &service.Attributes)

--- a/pilot/pkg/networking/grpcgen/cds.go
+++ b/pilot/pkg/networking/grpcgen/cds.go
@@ -177,7 +177,7 @@ func (b *clusterBuilder) applyDestinationRule(defaultCluster *cluster.Cluster) (
 
 	// resolve policy from context
 	destinationRule := corexds.CastDestinationRule(b.node.SidecarScope.DestinationRule(
-		model.TrafficDirectionOutbound, b.node, b.svc.Hostname).GetRule())
+		model.TrafficDirectionOutbound, b.node, b.svc).GetRule())
 	trafficPolicy := corexds.MergeTrafficPolicy(nil, destinationRule.GetTrafficPolicy(), b.port)
 
 	// setup default cluster

--- a/pilot/pkg/xds/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoint_builder.go
@@ -71,7 +71,7 @@ func NewEndpointBuilder(clusterName string, proxy *model.Proxy, push *model.Push
 
 	var dr *model.ConsolidatedDestRule
 	if svc != nil {
-		dr = proxy.SidecarScope.DestinationRule(model.TrafficDirectionOutbound, proxy, svc.Hostname)
+		dr = proxy.SidecarScope.DestinationRule(model.TrafficDirectionOutbound, proxy, svc)
 	}
 	b := EndpointBuilder{
 		clusterName:     clusterName,


### PR DESCRIPTION
**Please provide a description of this PR:**


Added namespace key for service and dr map, without namespace, istio can ignore some configs if there are many for same hostname but reside in different namespace

Fix #40952


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
