### PR TITLE
gateway: set default route name

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/gateway_simulation_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway_simulation_test.go
@@ -570,6 +570,7 @@ tls:
 					Result: simulation.Result{
 						ListenerMatched:    "0.0.0.0_443",
 						VirtualHostMatched: "example.com:443",
+						RouteMatched:       "b.default:443",
 						RouteConfigMatched: "https.443.https.gateway.default",
 						ClusterMatched:     "outbound|443||b.default",
 						StrictMatch:        true,

--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -424,6 +424,13 @@ func translateRoute(
 		applyDirectResponse(out, in.DirectResponse)
 	} else {
 		applyHTTPRouteDestination(out, node, virtualService, in, mesh, authority, serviceRegistry, listenPort, hashByDestination)
+		if node.Type == model.Router {
+			c := out.GetRoute().GetCluster()
+			if out.Name == "" && model.IsValidSubsetKey(c) {
+				_, _, h, p := model.ParseSubsetKey(c)
+				out.Name = string(h) + ":" + strconv.Itoa(p)
+			}
+		}
 	}
 
 	out.Decorator = &route.Decorator{

--- a/pilot/pkg/networking/core/v1alpha3/route/route_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route_test.go
@@ -102,8 +102,8 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		g.Expect(routes[0].GetName()).To(gomega.Equal("*.example.org:8484"))
 		// Validate that when timeout is not specified, we disable it based on default value of flag.
 		g.Expect(routes[0].GetRoute().Timeout.Seconds).To(gomega.Equal(int64(0)))
-		// nolint: staticcheck
-		g.Expect(routes[0].GetRoute().MaxGrpcTimeout.Seconds).To(gomega.Equal(int64(0)))
+		g.Expect(routes[0].GetRoute().MaxStreamDuration.GrpcTimeoutHeaderMax.Seconds).To(gomega.Equal(int64(0)))
+		g.Expect(routes[0].GetRoute().MaxStreamDuration.MaxStreamDuration.Seconds).To(gomega.Equal(int64(0)))
 	})
 
 	t.Run("for virtual service with HTTP/3 discovery enabled", func(t *testing.T) {


### PR DESCRIPTION


**Please provide a description of this PR:**

this PR set default route name on `router` with destination cluster, this will be useful to practice [Local Ratelimit](https://istio.io/latest/docs/tasks/policy-enforcement/rate-limit/) on `Ingressgateway`


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [x] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
