### PR TITLE
Fix Typo in istioctl proxystatus

### DIFF
--- a/istioctl/cmd/proxystatus.go
+++ b/istioctl/cmd/proxystatus.go
@@ -139,7 +139,7 @@ func readConfigFile(filename string) ([]byte, error) {
 
 func newKubeClientWithRevision(kubeconfig, configContext string, revision string) (kube.CLIClient, error) {
 	rc, err := kube.DefaultRestConfig(kubeconfig, configContext, func(config *rest.Config) {
-		// We are running a one-off command locally, so we don't need to worry too much about rate limitting
+		// We are running a one-off command locally, so we don't need to worry too much about rate limiting
 		// Bumping this up greatly decreases install time
 		config.QPS = 50
 		config.Burst = 100


### PR DESCRIPTION
**Please provide a description of this PR:**
Just a small typo
limitting -> limiting
Typo is located in the comment


**Please check any characteristics that apply to this pull request.**

- [√] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.