### PR TITLE
fix handling of the deprecated autoscaling settings

### DIFF
--- a/operator/cmd/mesh/manifest-generate_test.go
+++ b/operator/cmd/mesh/manifest-generate_test.go
@@ -435,6 +435,16 @@ func TestManifestGeneratePilot(t *testing.T) {
 			diffSelect: "HorizontalPodAutoscaler:*:istiod,HorizontalPodAutoscaler:*:istio-ingressgateway",
 			fileSelect: []string{"templates/autoscale.yaml"},
 		},
+		{
+			desc:       "autoscaling_v2beta1_k8s_and_values",
+			diffSelect: "HorizontalPodAutoscaler:*:istiod,HorizontalPodAutoscaler:*:istio-ingressgateway",
+			fileSelect: []string{"templates/autoscale.yaml"},
+		},
+		{
+			desc:       "autoscaling_v2",
+			diffSelect: "HorizontalPodAutoscaler:*:istiod,HorizontalPodAutoscaler:*:istio-ingressgateway",
+			fileSelect: []string{"templates/autoscale.yaml"},
+		},
 	})
 }
 

--- a/operator/cmd/mesh/testdata/manifest-generate/input/autoscaling_v2.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/input/autoscaling_v2.yaml
@@ -1,0 +1,11 @@
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+spec:
+  components:
+    ingressGateways:
+    - enabled: true
+      name: istio-ingressgateway
+  values:
+    pilot:
+      cpu:
+        targetAverageUtilization: 90

--- a/operator/cmd/mesh/testdata/manifest-generate/input/autoscaling_v2beta1_k8s_and_values.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/input/autoscaling_v2beta1_k8s_and_values.yaml
@@ -1,0 +1,18 @@
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+spec:
+  components:
+    ingressGateways:
+    - enabled: true
+      k8s:
+        hpaSpec:
+          metrics:
+          - resource:
+              name: cpu
+              targetAverageUtilization: 70
+            type: Resource
+      name: istio-ingressgateway
+  values:
+    pilot:
+      cpu:
+        targetAverageUtilization: 90

--- a/operator/cmd/mesh/testdata/manifest-generate/output/autoscaling_v2.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/autoscaling_v2.golden.yaml
@@ -1,0 +1,55 @@
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: istio-ingressgateway
+  namespace: istio-system
+  labels:
+    app: istio-ingressgateway
+    istio: ingressgateway
+    release: istio
+    istio.io/rev: default
+    install.operator.istio.io/owning-resource: unknown
+    operator.istio.io/component: "IngressGateways"
+spec:
+  maxReplicas: 5
+  minReplicas: 1
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: istio-ingressgateway
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 80
+---
+
+
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: istiod
+  namespace: istio-system
+  labels:
+    app: istiod
+    release: istio
+    istio.io/rev: default
+    install.operator.istio.io/owning-resource: unknown
+    operator.istio.io/component: "Pilot"
+spec:
+  maxReplicas: 5
+  minReplicas: 1
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: istiod
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 90
+---

--- a/operator/cmd/mesh/testdata/manifest-generate/output/autoscaling_v2beta1_k8s_and_values.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/autoscaling_v2beta1_k8s_and_values.golden.yaml
@@ -1,0 +1,51 @@
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  labels:
+    app: istio-ingressgateway
+    install.operator.istio.io/owning-resource: unknown
+    istio: ingressgateway
+    istio.io/rev: default
+    operator.istio.io/component: IngressGateways
+    release: istio
+  name: istio-ingressgateway
+  namespace: istio-system
+spec:
+  maxReplicas: 5
+  metrics:
+  - resource:
+      name: cpu
+      targetAverageUtilization: 70
+    type: Resource
+  minReplicas: 1
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: istio-ingressgateway
+---
+
+
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: istiod
+  namespace: istio-system
+  labels:
+    app: istiod
+    release: istio
+    istio.io/rev: default
+    install.operator.istio.io/owning-resource: unknown
+    operator.istio.io/component: "Pilot"
+spec:
+  maxReplicas: 5
+  minReplicas: 1
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: istiod
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      targetAverageUtilization: 90
+---

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_override_values.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_override_values.golden.yaml
@@ -148,26 +148,26 @@ spec:
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
-  labels:
-    app: istiod
-    install.operator.istio.io/owning-resource: unknown
-    istio.io/rev: default
-    operator.istio.io/component: Pilot
-    release: istio
   name: istiod
   namespace: istio-control
+  labels:
+    app: istiod
+    release: istio
+    istio.io/rev: default
+    install.operator.istio.io/owning-resource: unknown
+    operator.istio.io/component: "Pilot"
 spec:
   maxReplicas: 8
-  metrics:
-  - resource:
-      name: cpu
-      target:
-        averageUtilization: 80
-        type: Utilization
-    type: Resource
   minReplicas: 2
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
     name: istiod
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 80
 ---

--- a/operator/pkg/translate/translate_value.go
+++ b/operator/pkg/translate/translate_value.go
@@ -393,95 +393,6 @@ func translateStrategy(fieldName string, outPath string, value any, cpSpecTree m
 	return nil
 }
 
-// translateHPASpec translates HPA related configurations from helm values.yaml tree.
-// do not translate if autoscaleEnabled is explicitly set to false
-func translateHPASpec(inPath string, outPath string, valueTree map[string]any, cpSpecTree map[string]any) error {
-	m, found, err := tpath.Find(valueTree, util.ToYAMLPath(inPath))
-	if err != nil {
-		return err
-	}
-	if found {
-		asEnabled, ok := m.(bool)
-		if !ok {
-			return fmt.Errorf("expect autoscaleEnabled node type to be bool but got: %T", m)
-		}
-		if !asEnabled {
-			return nil
-		}
-	}
-
-	newP := util.PathFromString(inPath)
-	// last path element is k8s setting name
-	newPS := newP[:len(newP)-1].String()
-	valMap := map[string]string{
-		".autoscaleMin": ".minReplicas",
-		".autoscaleMax": ".maxReplicas",
-	}
-	for key, newVal := range valMap {
-		valPath := newPS + key
-		asVal, found, err := tpath.Find(valueTree, util.ToYAMLPath(valPath))
-		if found && err == nil {
-			if err := setOutputAndClean(valPath, outPath+newVal, asVal, valueTree, cpSpecTree, true); err != nil {
-				return err
-			}
-		}
-	}
-	valPath := newPS + ".cpu.targetAverageUtilization"
-	asVal, found, err := tpath.Find(valueTree, util.ToYAMLPath(valPath))
-	if found && err == nil {
-		rs := make([]any, 1)
-		rsVal := `
-- type: Resource
-  resource:
-    name: cpu
-    target:
-      type: Utilization
-      averageUtilization: %f`
-
-		rsString := fmt.Sprintf(rsVal, asVal)
-		if err = yaml.Unmarshal([]byte(rsString), &rs); err != nil {
-			return err
-		}
-		if err := setOutputAndClean(valPath, outPath+".metrics", rs, valueTree, cpSpecTree, true); err != nil {
-			return err
-		}
-	}
-
-	// There is no direct source from value.yaml for scaleTargetRef value, we need to construct from component name
-	if found {
-		revision := ""
-		rev, ok := cpSpecTree["revision"]
-		if ok {
-			revision = rev.(string)
-		}
-		st := make(map[string]any)
-		stVal := `
-apiVersion: apps/v1
-kind: Deployment
-name: %s`
-
-		// need to do special handling for gateways
-		if specialComponentPath[newPS] && len(newP) > 2 {
-			newPS = newP[1 : len(newP)-1].String()
-		}
-		// convert from values component name to correct deployment target
-		if newPS == "pilot" {
-			newPS = "istiod"
-			if revision != "" {
-				newPS = newPS + "-" + revision
-			}
-		}
-		stString := fmt.Sprintf(stVal, newPS)
-		if err := yaml.Unmarshal([]byte(stString), &st); err != nil {
-			return err
-		}
-		if err := setOutputAndClean(valPath, outPath+".scaleTargetRef", st, valueTree, cpSpecTree, false); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 // setOutputAndClean is helper function to set value of iscp tree and clean the original value from value.yaml tree.
 func setOutputAndClean(valPath, outPath string, outVal any, valueTree, cpSpecTree map[string]any, clean bool) error {
 	scope.Debugf("path has value in helm Value.yaml tree, mapping to output path %s", outPath)
@@ -560,10 +471,6 @@ func (t *ReverseTranslator) translateK8sTree(valueTree map[string]any,
 			k8sSettingName = path[len(path)-1]
 		}
 		if k8sSettingName == "autoscaleEnabled" {
-			if err := translateHPASpec(inPath, v.OutPath, valueTree, cpSpecTree); err != nil {
-				return fmt.Errorf("error in translating K8s HPA spec: %s", err)
-			}
-			metrics.LegacyPathTranslationTotal.Increment()
 			continue
 		}
 		m, found, err := tpath.Find(valueTree, util.ToYAMLPath(inPath))

--- a/operator/pkg/translate/translate_value.go
+++ b/operator/pkg/translate/translate_value.go
@@ -393,22 +393,6 @@ func translateStrategy(fieldName string, outPath string, value any, cpSpecTree m
 	return nil
 }
 
-// setOutputAndClean is helper function to set value of iscp tree and clean the original value from value.yaml tree.
-func setOutputAndClean(valPath, outPath string, outVal any, valueTree, cpSpecTree map[string]any, clean bool) error {
-	scope.Debugf("path has value in helm Value.yaml tree, mapping to output path %s", outPath)
-
-	if err := tpath.WriteNode(cpSpecTree, util.ToYAMLPath(outPath), outVal); err != nil {
-		return err
-	}
-	if !clean {
-		return nil
-	}
-	if _, err := tpath.Delete(valueTree, util.ToYAMLPath(valPath)); err != nil {
-		return err
-	}
-	return nil
-}
-
 // translateEnv translates env value from helm values.yaml tree.
 func translateEnv(outPath string, value any, cpSpecTree map[string]any) error {
 	envMap, ok := value.(map[string]any)

--- a/operator/pkg/translate/translate_value_test.go
+++ b/operator/pkg/translate/translate_value_test.go
@@ -79,20 +79,6 @@ components:
        env:
        - name: GODEBUG
          value: gctrace=1
-       hpaSpec:
-          maxReplicas: 3
-          minReplicas: 1
-          scaleTargetRef:
-            apiVersion: apps/v1
-            kind: Deployment
-            name: istiod
-          metrics:
-           - resource:
-               name: cpu
-               target:
-                 averageUtilization: 80
-                 type: Utilization
-             type: Resource
        nodeSelector:
           kubernetes.io/os: linux
        tolerations:
@@ -117,6 +103,10 @@ values:
   pilot:
     image: pilot
     autoscaleEnabled: true
+    autoscaleMax: 3
+    autoscaleMin: 1
+    cpu:
+      targetAverageUtilization: 80
     traceSampling: 1
 `,
 		},
@@ -281,20 +271,6 @@ spec:
           value: kubernetes.io/legacy-unknown
         - name: GODEBUG
           value: gctrace=1
-        hpaSpec:
-          minReplicas: 1
-          maxReplicas: 3
-          scaleTargetRef:
-            apiVersion: apps/v1
-            kind: Deployment
-            name: istiod
-          metrics:
-          - type: Resource
-            resource:
-              name: cpu
-              target:
-                averageUtilization: 80
-                type: Utilization
         nodeSelector:
           master: "true"
           kubernetes.io/os: linux
@@ -399,20 +375,6 @@ spec:
         env:
         - name: GODEBUG
           value: gctrace=1
-        hpaSpec:
-          minReplicas: 1
-          maxReplicas: 3
-          scaleTargetRef:
-            apiVersion: apps/v1
-            kind: Deployment
-            name: istiod
-          metrics:
-          - type: Resource
-            resource:
-              name: cpu
-              target:
-                averageUtilization: 80
-                type: Utilization
         nodeSelector:
           master: "true"
           kubernetes.io/os: linux
@@ -519,20 +481,6 @@ spec:
         env:
         - name: SPIFFE_BUNDLE_ENDPOINTS
           value: "SPIFFE_BUNDLE_ENDPOINT"
-        hpaSpec:
-          minReplicas: 1
-          maxReplicas: 3
-          scaleTargetRef:
-            apiVersion: apps/v1
-            kind: Deployment
-            name: istiod
-          metrics:
-          - type: Resource
-            resource:
-              name: cpu
-              target:
-                averageUtilization: 80
-                type: Utilization
         nodeSelector:
           master: "true"
           kubernetes.io/os: linux
@@ -642,20 +590,6 @@ spec:
           value: "false"
         - name: PROXY_XDS_DEBUG_VIA_AGENT
           value: "false"
-        hpaSpec:
-          minReplicas: 1
-          maxReplicas: 3
-          scaleTargetRef:
-            apiVersion: apps/v1
-            kind: Deployment
-            name: istiod
-          metrics:
-          - resource:
-              name: cpu
-              target:
-                averageUtilization: 80
-                type: Utilization
-            type: Resource
         nodeSelector:
           master: "true"
           kubernetes.io/os: linux
@@ -773,20 +707,6 @@ spec:
           value: "false"
         - name: PROXY_XDS_DEBUG_VIA_AGENT
           value: "false"
-        hpaSpec:
-          minReplicas: 1
-          maxReplicas: 3
-          scaleTargetRef:
-            apiVersion: apps/v1
-            kind: Deployment
-            name: istiod
-          metrics:
-          - resource:
-              name: cpu
-              target:
-                averageUtilization: 80
-                type: Utilization
-            type: Resource
         nodeSelector:
           master: "true"
           kubernetes.io/os: linux
@@ -924,21 +844,6 @@ spec:
   components:
     pilot:
       enabled: true
-      k8s:
-        hpaSpec:
-          maxReplicas: 3
-          minReplicas: 1
-          scaleTargetRef:
-            apiVersion: apps/v1
-            kind: Deployment
-            name: istiod-canary
-          metrics:
-          - resource:
-              name: cpu
-              target:
-                averageUtilization: 80
-                type: Utilization
-            type: Resource
   values:
     pilot:
       autoscaleMin: 1


### PR DESCRIPTION
Fix: #41011 

The root cause is that: 
1. we recently made a change which does #37872 : select the API version of the templates based on the values.autoscalingv2 field, which is set to false if any of the deprecated autoscaling fields are detected in the K8S sections of IOP during the K8S overlay logic, 
2. however the legacy logic in the translate_values.go would also override the K8S sections of the IOP by doing a reverse translation from .values section, which resulted in an inconsistency, i.e. using v2 fields under v2beta1 template. Actually, this part of logic is not needed anymore, we can just remove that and pass it as it is in .values section.

Actually a bunch of similar conversion in the translate_values.go are not needed anymore, I would remove them later as well.

Another possible fix is just to convert the deprecated settings to the corresponding fields in v2 during installation code, all of the deprecated settings actually have corresponding fields in new API(but different locations), so that we can just get rid of the v2beta1 template part entirely. But it may cause confusion if users have direct advanced K8S override that manipulate based on the old API paths 