### PR TITLE
Fix fuzzer build

### DIFF
--- a/pilot/pkg/model/fuzz_test.go
+++ b/pilot/pkg/model/fuzz_test.go
@@ -22,6 +22,7 @@ import (
 	"google.golang.org/protobuf/testing/protocmp"
 
 	"istio.io/istio/pkg/fuzz"
+	"istio.io/istio/pkg/test"
 )
 
 func FuzzDeepCopyService(f *testing.F) {
@@ -44,7 +45,7 @@ type deepCopier[T any] interface {
 	DeepCopy() T
 }
 
-func fuzzDeepCopy[T deepCopier[T]](f *testing.F, opts ...cmp.Option) {
+func fuzzDeepCopy[T deepCopier[T]](f test.Fuzzer, opts ...cmp.Option) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		fg := fuzz.New(t, data)
 		orig := fuzz.Struct[T](fg)

--- a/pkg/fuzz/util.go
+++ b/pkg/fuzz/util.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 
 	fuzzheaders "github.com/AdaLogics/go-fuzz-headers"
+
+	"istio.io/istio/pkg/test"
 )
 
 const panicPrefix = "go-fuzz-skip: "
@@ -44,7 +46,7 @@ type Validator interface {
 //		}
 //
 // To avoid needing to call BaseCases and Finalize everywhere.
-func Fuzz(f *testing.F, ff func(fg Helper)) {
+func Fuzz(f test.Fuzzer, ff func(fg Helper)) {
 	BaseCases(f)
 	f.Fuzz(func(t *testing.T, data []byte) {
 		defer Finalize()
@@ -117,7 +119,7 @@ func validate[T any](h Helper, validators []func(T) bool, r T) {
 }
 
 // BaseCases inserts a few trivial test cases to do a very brief sanity check of a test that relies on []byte inputs
-func BaseCases(f Fuzzer) {
+func BaseCases(f test.Fuzzer) {
 	for _, c := range [][]byte{
 		{},
 		[]byte("."),
@@ -125,12 +127,6 @@ func BaseCases(f Fuzzer) {
 	} {
 		f.Add(c)
 	}
-}
-
-// Fuzzer abstracts *testing.F to handle oss-fuzz's (temporary) workaround to support native fuzzing,
-// which utilizes a custom type.
-type Fuzzer interface {
-	Add(args ...any)
 }
 
 // Returns the underlying testing.T. Should be avoided where possible; in oss-fuzz many functions do not work.

--- a/pkg/test/failer.go
+++ b/pkg/test/failer.go
@@ -46,6 +46,12 @@ type Failer interface {
 	Cleanup(func())
 }
 
+// Fuzzer abstracts *testing.F
+type Fuzzer interface {
+	Fuzz(ff any)
+	Add(args ...any)
+}
+
 // errorWrapper is a Failer that can be used to just extract an `error`. This allows mixing
 // functions that take in a Failer and those that take an error.
 // The function must be called within a goroutine, or calls to Fatal will try to terminate the outer

--- a/tests/fuzz/oss_fuzz_build.sh
+++ b/tests/fuzz/oss_fuzz_build.sh
@@ -31,7 +31,7 @@ mv "${SRC}"/istio/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch_
 
 # Find all native fuzzers and compile them
 # shellcheck disable=SC2016
-grep --line-buffered --include '*.go' -Pr 'func Fuzz.*\(.* \*testing\.F' | sed -E 's/(func Fuzz(.*)\(.*)/\2/' | xargs -I{} sh -c '
+grep --line-buffered --include '*_test.go' -Pr 'func Fuzz.*\(.* \*testing\.F' | sed -E 's/(func Fuzz(.*)\(.*)/\2/' | xargs -I{} sh -c '
   fname="$(dirname $(echo "{}" | cut -d: -f1))"
   func="Fuzz$(echo "{}" | cut -d: -f2)"
   set -x


### PR DESCRIPTION
There are some issues around using `testing.F` directly due to the hacks in oss-fuzz, so replace them with interface