### PR TITLE
move gomod to 1.19

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module istio.io/istio
 
-go 1.18
+go 1.19
 
 // https://github.com/containerd/containerd/issues/5781
 exclude k8s.io/kubernetes v1.13.0


### PR DESCRIPTION
**Please provide a description of this PR:**

master and release-1.15 are built in go1.19, keep gomod same with build image

https://github.com/istio/tools/blob/8ca918567e0c0178e98df7c78f0425ef21885be5/docker/build-tools/Dockerfile#L28