### PR TITLE
Fix egress gateway tls origination test

### DIFF
--- a/tests/integration/security/egress_gateway_origination_test.go
+++ b/tests/integration/security/egress_gateway_origination_test.go
@@ -369,7 +369,6 @@ func newTLSGatewayTest(t framework.TestContext) *echotest.T {
 		WithDefaultFilters(1, 1).
 		FromMatch(match.And(
 			match.Namespace(apps.Ns1.Namespace),
-			match.NotNaked,
-			match.NotProxylessGRPC)).
+			match.RegularPod)).
 		ToMatch(match.ServiceName(apps.External.All.NamespacedName()))
 }

--- a/tests/integration/security/egress_gateway_origination_test.go
+++ b/tests/integration/security/egress_gateway_origination_test.go
@@ -46,6 +46,7 @@ import (
 func TestSimpleTlsOrigination(t *testing.T) {
 	// nolint: staticcheck
 	framework.NewTest(t).
+		RequiresSingleNetwork(). // https://github.com/istio/istio/issues/37134
 		Features("security.egress.tls.sds").
 		Run(func(t framework.TestContext) {
 			var (
@@ -121,6 +122,7 @@ func TestSimpleTlsOrigination(t *testing.T) {
 func TestMutualTlsOrigination(t *testing.T) {
 	// nolint: staticcheck
 	framework.NewTest(t).
+		RequiresSingleNetwork(). // https://github.com/istio/istio/issues/37134
 		Features("security.egress.mtls.sds").
 		Run(func(t framework.TestContext) {
 			var (

--- a/tests/integration/security/egress_gateway_origination_test.go
+++ b/tests/integration/security/egress_gateway_origination_test.go
@@ -365,7 +365,7 @@ func newTLSGatewayCallOpts(to echo.Target, host string, statusCode int, useGatew
 }
 
 func newTLSGatewayTest(t framework.TestContext) *echotest.T {
-	return echotest.New(t, apps.Ns1.All.Instances()).
+	return echotest.New(t, apps.All.Instances()).
 		WithDefaultFilters(1, 1).
 		FromMatch(match.And(
 			match.Namespace(apps.Ns1.Namespace),

--- a/tests/integration/security/egress_gateway_origination_test.go
+++ b/tests/integration/security/egress_gateway_origination_test.go
@@ -371,6 +371,7 @@ func newTLSGatewayTest(t framework.TestContext) *echotest.T {
 		WithDefaultFilters(1, 1).
 		FromMatch(match.And(
 			match.Namespace(apps.Ns1.Namespace),
-			match.RegularPod)).
+			match.NotNaked,
+			match.NotProxylessGRPC)).
 		ToMatch(match.ServiceName(apps.External.All.NamespacedName()))
 }


### PR DESCRIPTION
Signed-off-by: Faseela K <faseela.k@est.tech>

Previously the targets were always empty, and test was not really running.
Fixes https://github.com/istio/istio/issues/41048