### PR TITLE
Improve HasSynced of ADSC

### DIFF
--- a/pkg/adsc/adsc.go
+++ b/pkg/adsc/adsc.go
@@ -446,7 +446,7 @@ func (a *ADSC) HasSynced() bool {
 	defer a.mutex.RUnlock()
 
 	for _, req := range a.cfg.InitialDiscoveryRequests {
-		_, isMCP := convertTypeUrlToMCPGVK(req.TypeUrl)
+		_, isMCP := convertTypeURLToMCPGVK(req.TypeUrl)
 		if !isMCP {
 			continue
 		}
@@ -502,7 +502,7 @@ func (a *ADSC) handleRecv() {
 		}
 
 		// Group-value-kind - used for high level api generator.
-		gvk, isMCP := convertTypeUrlToMCPGVK(msg.TypeUrl)
+		gvk, isMCP := convertTypeURLToMCPGVK(msg.TypeUrl)
 
 		adscLog.Info("Received ", a.url, " type ", msg.TypeUrl,
 			" cnt=", len(msg.Resources), " nonce=", msg.Nonce)

--- a/pkg/adsc/adsc_test.go
+++ b/pkg/adsc/adsc_test.go
@@ -15,11 +15,10 @@
 package adsc
 
 import (
-	"fmt"
+	"errors"
 	"log"
 	"net"
 	"os"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -41,6 +40,7 @@ import (
 	"istio.io/istio/pilot/pkg/config/memory"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/util/protoconv"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/collections"
 )
 
@@ -68,88 +68,61 @@ func TestADSC_Run(t *testing.T) {
 
 	type testDesc struct {
 		desc             string
-		reqTypeUrls      []string
-		expectedTypeUrls []string // nil means equals to requested
+		initialRequests  []*xdsapi.DiscoveryRequest
+		excludedResource string
 		validator        func(testCase) error
 	}
 
 	descs := []testDesc{
 		{
 			desc:        "stream-no-resources",
-			reqTypeUrls: []string{},
+			initialRequests: []*xdsapi.DiscoveryRequest{},
 		},
 		{
 			desc:        "stream-2-unnamed-resources",
-			reqTypeUrls: []string{"foo", "bar"},
+			initialRequests: []*xdsapi.DiscoveryRequest{
+				{
+					TypeUrl: "foo",
+				},
+				{
+					TypeUrl: "bar",
+				},
+			},
 		},
-		// todo tests for listeners, clusters, eds, and routes, not sure how to do this.
-	}
-
-	initTypeUrls := func() []string {
-		var ret []string
-		for _, req := range ConfigInitialRequests() {
-			ret = append(ret, req.TypeUrl)
-		}
-		return ret
-	}()
-	incompleteTypeUrls := func() []string {
-		var ret []string
-		for idx, item := range initTypeUrls {
-			if strings.Count(item, "/") == 3 {
-				ret = append(ret, initTypeUrls[:idx]...)
-				ret = append(ret, initTypeUrls[idx+1:]...)
-				break
-			}
-		}
-		if ret == nil {
-			ret = initTypeUrls
-		}
-		return ret
-	}()
-	descs = append(descs, testDesc{
-		desc:        "mcp-should-hasSynced",
-		reqTypeUrls: initTypeUrls,
-		validator: func(tc testCase) error {
-			if !tc.inAdsc.HasSynced() {
-				return fmt.Errorf("adsc not synced")
-			}
-			return nil
-		},
-	})
-	if len(incompleteTypeUrls) != len(initTypeUrls) {
-		descs = append(descs, testDesc{
-			desc:             "mcp-should-not-hasSynced",
-			reqTypeUrls:      initTypeUrls,
-			expectedTypeUrls: incompleteTypeUrls,
-			validator: func(tc testCase) error {
-				if tc.inAdsc.HasSynced() {
-					return fmt.Errorf("adsc synced but should not")
+		{
+			desc:        "stream-3-completed-mcp-resources",
+			initialRequests: ConfigInitialRequests(),
+			validator: func(testCase testCase) error {
+				if !testCase.inAdsc.HasSynced() {
+					return errors.New("ADSC should be synced")
 				}
 				return nil
 			},
-		})
+		},
+		{
+			desc:        "stream-4-uncompleted-mcp-resources",
+			initialRequests: ConfigInitialRequests(),
+			// XDS Server don't push this kind resource.
+			excludedResource: collections.IstioNetworkingV1Alpha3Serviceentries.Resource().GroupVersionKind().String(),
+			validator: func(testCase testCase) error {
+				if testCase.inAdsc.HasSynced() {
+					return errors.New("ADSC should not be synced")
+				}
+				return nil
+			},
+		},
+		// todo tests for listeners, clusters, eds, and routes, not sure how to do this.
 	}
 
 	for _, item := range descs {
 		desc := item // avoid refer to on-stack-var
 		expected := map[string]*xdsapi.DiscoveryResponse{}
-		if desc.expectedTypeUrls == nil {
-			desc.expectedTypeUrls = desc.reqTypeUrls
-		}
-		var initReqs []*xdsapi.DiscoveryRequest
-		for _, typeURL := range desc.reqTypeUrls {
-			initReqs = append(initReqs, &xdsapi.DiscoveryRequest{TypeUrl: typeURL})
-		}
-		for _, typeURL := range desc.expectedTypeUrls {
-			expected[typeURL] = &xdsapi.DiscoveryResponse{TypeUrl: typeURL}
-		}
-
-		if desc.validator == nil {
-			desc.validator = func(tc testCase) error {
-				if !cmp.Equal(tc.inAdsc.Received, tc.expectedADSResources.Received, protocmp.Transform()) {
-					return fmt.Errorf("%s: expected recv %v got %v", tc.desc, tc.expectedADSResources.Received, tc.inAdsc.Received)
-				}
-				return nil
+		for _, request := range desc.initialRequests {
+			if desc.excludedResource != "" && request.TypeUrl == desc.excludedResource {
+				continue
+			}
+			expected[request.TypeUrl] = &xdsapi.DiscoveryResponse{
+				TypeUrl: request.TypeUrl,
 			}
 		}
 
@@ -161,15 +134,15 @@ func TestADSC_Run(t *testing.T) {
 				XDSUpdates: make(chan *xdsapi.DiscoveryResponse),
 				RecvWg:     sync.WaitGroup{},
 				cfg: &Config{
-					InitialDiscoveryRequests: initReqs,
+					InitialDiscoveryRequests: desc.initialRequests,
 				},
 				VersionInfo: map[string]string{},
 				sync:        map[string]time.Time{},
 			},
 			streamHandler: func(stream xdsapi.AggregatedDiscoveryService_StreamAggregatedResourcesServer) error {
-				for _, typeURL := range desc.expectedTypeUrls {
+				for _, resource := range expected {
 					_ = stream.Send(&xdsapi.DiscoveryResponse{
-						TypeUrl: typeURL,
+						TypeUrl: resource.TypeUrl,
 					})
 				}
 				return nil
@@ -216,8 +189,14 @@ func TestADSC_Run(t *testing.T) {
 			}
 			tt.inAdsc.RecvWg.Wait()
 
-			if err := tt.validator(tt); err != nil {
-				t.Error(err)
+			if tt.validator != nil {
+				if err := tt.validator(tt); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			if !cmp.Equal(tt.inAdsc.Received, tt.expectedADSResources.Received, protocmp.Transform()) {
+				t.Errorf("%s: expected recv %v got %v", tt.desc, tt.expectedADSResources.Received, tt.inAdsc.Received)
 			}
 		})
 	}
@@ -508,7 +487,11 @@ func TestADSC_handleMCP(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			gvk := []string{"networking.istio.io", "v1alpha3", "ServiceEntry"}
+			gvk := config.GroupVersionKind{
+				Group: "networking.istio.io",
+				Version: "v1alpha3",
+				Kind: "ServiceEntry",
+			}
 			adsc.handleMCP(gvk, tt.resources)
 			configs, _ := adsc.Store.List(collections.IstioNetworkingV1Alpha3Serviceentries.Resource().GroupVersionKind(), "")
 			if len(configs) != len(tt.expectedResources) {

--- a/pkg/adsc/adsc_test.go
+++ b/pkg/adsc/adsc_test.go
@@ -75,11 +75,11 @@ func TestADSC_Run(t *testing.T) {
 
 	descs := []testDesc{
 		{
-			desc:        "stream-no-resources",
+			desc:            "stream-no-resources",
 			initialRequests: []*xdsapi.DiscoveryRequest{},
 		},
 		{
-			desc:        "stream-2-unnamed-resources",
+			desc: "stream-2-unnamed-resources",
 			initialRequests: []*xdsapi.DiscoveryRequest{
 				{
 					TypeUrl: "foo",
@@ -90,7 +90,7 @@ func TestADSC_Run(t *testing.T) {
 			},
 		},
 		{
-			desc:        "stream-3-completed-mcp-resources",
+			desc:            "stream-3-completed-mcp-resources",
 			initialRequests: ConfigInitialRequests(),
 			validator: func(testCase testCase) error {
 				if !testCase.inAdsc.HasSynced() {
@@ -100,7 +100,7 @@ func TestADSC_Run(t *testing.T) {
 			},
 		},
 		{
-			desc:        "stream-4-uncompleted-mcp-resources",
+			desc:            "stream-4-uncompleted-mcp-resources",
 			initialRequests: ConfigInitialRequests(),
 			// XDS Server don't push this kind resource.
 			excludedResource: collections.IstioNetworkingV1Alpha3Serviceentries.Resource().GroupVersionKind().String(),
@@ -488,9 +488,9 @@ func TestADSC_handleMCP(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			gvk := config.GroupVersionKind{
-				Group: "networking.istio.io",
+				Group:   "networking.istio.io",
 				Version: "v1alpha3",
-				Kind: "ServiceEntry",
+				Kind:    "ServiceEntry",
 			}
 			adsc.handleMCP(gvk, tt.resources)
 			configs, _ := adsc.Store.List(collections.IstioNetworkingV1Alpha3Serviceentries.Resource().GroupVersionKind(), "")

--- a/pkg/adsc/util.go
+++ b/pkg/adsc/util.go
@@ -51,8 +51,8 @@ func getClientCertFn(config *Config) func(requestInfo *tls.CertificateRequestInf
 	return nil
 }
 
-func convertTypeURLToMCPGVK(typeUrl string) (config.GroupVersionKind, bool) {
-	parts := strings.SplitN(typeUrl, "/", 3)
+func convertTypeURLToMCPGVK(typeURL string) (config.GroupVersionKind, bool) {
+	parts := strings.SplitN(typeURL, "/", 3)
 	if len(parts) != 3 {
 		return config.GroupVersionKind{}, false
 	}

--- a/pkg/adsc/util.go
+++ b/pkg/adsc/util.go
@@ -51,7 +51,7 @@ func getClientCertFn(config *Config) func(requestInfo *tls.CertificateRequestInf
 	return nil
 }
 
-func convertTypeUrlToMCPGVK(typeUrl string) (config.GroupVersionKind, bool) {
+func convertTypeURLToMCPGVK(typeUrl string) (config.GroupVersionKind, bool) {
 	parts := strings.SplitN(typeUrl, "/", 3)
 	if len(parts) != 3 {
 		return config.GroupVersionKind{}, false

--- a/pkg/adsc/util.go
+++ b/pkg/adsc/util.go
@@ -16,10 +16,10 @@ package adsc
 
 import (
 	"crypto/tls"
-	"istio.io/istio/pkg/config/schema/collections"
 	"strings"
 
 	"istio.io/istio/pkg/config"
+	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/security"
 )
 
@@ -58,9 +58,9 @@ func convertTypeUrlToMCPGVK(typeUrl string) (config.GroupVersionKind, bool) {
 	}
 
 	gvk := config.GroupVersionKind{
-		Group: parts[0],
+		Group:   parts[0],
 		Version: parts[1],
-		Kind: parts[2],
+		Kind:    parts[2],
 	}
 
 	_, isMCP := collections.Pilot.FindByGroupVersionKind(gvk)

--- a/pkg/adsc/util.go
+++ b/pkg/adsc/util.go
@@ -16,7 +16,10 @@ package adsc
 
 import (
 	"crypto/tls"
+	"istio.io/istio/pkg/config/schema/collections"
+	"strings"
 
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/security"
 )
 
@@ -46,4 +49,24 @@ func getClientCertFn(config *Config) func(requestInfo *tls.CertificateRequestInf
 	}
 
 	return nil
+}
+
+func convertTypeUrlToMCPGVK(typeUrl string) (config.GroupVersionKind, bool) {
+	parts := strings.SplitN(typeUrl, "/", 3)
+	if len(parts) != 3 {
+		return config.GroupVersionKind{}, false
+	}
+
+	gvk := config.GroupVersionKind{
+		Group: parts[0],
+		Version: parts[1],
+		Kind: parts[2],
+	}
+
+	_, isMCP := collections.Pilot.FindByGroupVersionKind(gvk)
+	if isMCP {
+		return gvk, true
+	}
+
+	return config.GroupVersionKind{}, false
 }


### PR DESCRIPTION
Currently, the HasSynced of ADSC doesn't work. When the istio starts running, the adsc has synced immediately even if the adsc hasn't received any mcp resources.  The logic of the following code trying to determine whether the MCP resource is ready is wrong.
https://github.com/istio/istio/blob/e062bfd7025369d4aca5a1fe6711faca01ea5bdd/pkg/adsc/adsc.go#L449
The type url of mcp resource, such as ServiceEntry, is `networking.istio.io/v1alpha3/ServiceEntry`. So the result of above code is always not equal to 3. All MCP resources will be ignored by the above code. Besides, checking the mcp resources by the count of '/' in type url is tricky.  Instead, we should check whether the type url is mcp resource explicitly.
This pr try to fix this issue to make sure the istio turn to be synced after all mcp resources are received.