### PR TITLE
add kind on Mac M1 to known not to work in Ambient README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The following environments are known to not work currently:
 
 * GKE with Calico CNI
 * GKE with Dataplane V2 CNI
+* `kind` on Mac M1
 
 All other environments are unknown currently.
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The following environments are known to not work currently:
 
 * GKE with Calico CNI
 * GKE with Dataplane V2 CNI
-* `kind` on Mac M1
+* `kind` on Mac computers with Apple silicon
 
 All other environments are unknown currently.
 


### PR DESCRIPTION
**Please provide a description of this PR:**

We know that Ambient on kind on Mac M1s does not work, even if you build and use ARM images. For example:

```
+ ip rule add priority 20000 fwmark 0x400/0xfff lookup 100
Cannot talk to rtnetlink: Operation not supported
```