### PR TITLE
avoid unnecessary copy virtual services for sidecar scope calculation

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -898,6 +898,11 @@ func (ps *PushContext) IsServiceVisible(service *Service, namespace string) bool
 // VirtualServicesForGateway lists all virtual services bound to the specified gateways
 // This replaces store.VirtualServices. Used only by the gateways
 // Sidecars use the egressListener.VirtualServices().
+//
+// Note that for generating the imported virtual services of sidecar egress
+// listener, we don't call this function to copy configs for performance issues.
+// Instead, we pass the virtualServiceIndex directly into SelectVirtualServices
+// function.
 func (ps *PushContext) VirtualServicesForGateway(proxyNamespace, gateway string) []config.Config {
 	res := make([]config.Config, 0, len(ps.virtualServiceIndex.privateByNamespaceAndGateway[proxyNamespace][gateway])+
 		len(ps.virtualServiceIndex.exportedToNamespaceByGateway[proxyNamespace][gateway])+

--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -463,8 +463,7 @@ func convertIstioListenerToWrapper(ps *PushContext, configNamespace string,
 		out.listenerHosts[parts[0]] = append(out.listenerHosts[parts[0]], host.Name(parts[1]))
 	}
 
-	vses := ps.VirtualServicesForGateway(configNamespace, constants.IstioMeshGateway)
-	out.virtualServices = SelectVirtualServices(vses, out.listenerHosts)
+	out.virtualServices = SelectVirtualServices(ps.virtualServiceIndex, configNamespace, out.listenerHosts)
 	svces := ps.servicesExportedToNamespace(configNamespace)
 	out.services = out.selectServices(svces, configNamespace, out.listenerHosts)
 

--- a/pilot/pkg/model/virtualservice.go
+++ b/pilot/pkg/model/virtualservice.go
@@ -30,8 +30,8 @@ import (
 )
 
 // SelectVirtualServices selects the virtual services by matching given services' host names.
-// This is a common function used by both sidecar converter and http route.
-func SelectVirtualServices(virtualServices []config.Config, hosts map[string][]host.Name) []config.Config {
+// This function is used by sidecar converter.
+func SelectVirtualServices(vsidx virtualServiceIndex, configNamespace string, hosts map[string][]host.Name) []config.Config {
 	importedVirtualServices := make([]config.Config, 0)
 
 	vsset := sets.New[string]()
@@ -54,23 +54,30 @@ func SelectVirtualServices(virtualServices []config.Config, hosts map[string][]h
 			}
 		}
 	}
-	for _, c := range virtualServices {
-		configNamespace := c.Namespace
-		// Selection algorithm:
-		// virtualservices have a list of hosts in the API spec
-		// if any host in the list matches one service hostname, select the virtual service
-		// and break out of the loop.
 
-		// Check if there is an explicit import of form ns/* or ns/host
-		if importedHosts, nsFound := hosts[configNamespace]; nsFound {
-			addVirtualService(c, importedHosts)
-		}
+	loopAndAdd := func(vses []config.Config) {
+		for _, c := range vses {
+			configNamespace := c.Namespace
+			// Selection algorithm:
+			// virtualservices have a list of hosts in the API spec
+			// if any host in the list matches one service hostname, select the virtual service
+			// and break out of the loop.
 
-		// Check if there is an import of form */host or */*
-		if importedHosts, wnsFound := hosts[wildcardNamespace]; wnsFound {
-			addVirtualService(c, importedHosts)
+			// Check if there is an explicit import of form ns/* or ns/host
+			if importedHosts, nsFound := hosts[configNamespace]; nsFound {
+				addVirtualService(c, importedHosts)
+			}
+
+			// Check if there is an import of form */host or */*
+			if importedHosts, wnsFound := hosts[wildcardNamespace]; wnsFound {
+				addVirtualService(c, importedHosts)
+			}
 		}
 	}
+
+	loopAndAdd(vsidx.privateByNamespaceAndGateway[configNamespace][constants.IstioMeshGateway])
+	loopAndAdd(vsidx.exportedToNamespaceByGateway[configNamespace][constants.IstioMeshGateway])
+	loopAndAdd(vsidx.publicByGateway[constants.IstioMeshGateway])
 
 	return importedVirtualServices
 }

--- a/pilot/pkg/model/virtualservice_test.go
+++ b/pilot/pkg/model/virtualservice_test.go
@@ -26,6 +26,7 @@ import (
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/serviceregistry/provider"
 	"istio.io/istio/pkg/config"
+	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/config/schema/collections"
@@ -2124,9 +2125,22 @@ func TestSelectVirtualService(t *testing.T) {
 		},
 		Spec: virtualServiceSpec7,
 	}
-	configs := SelectVirtualServices(
-		[]config.Config{virtualService1, virtualService2, virtualService3, virtualService4, virtualService5, virtualService6, virtualService7},
-		hostsByNamespace)
+
+	index := virtualServiceIndex{
+		publicByGateway: map[string][]config.Config{
+			constants.IstioMeshGateway: {
+				virtualService1,
+				virtualService2,
+				virtualService3,
+				virtualService4,
+				virtualService5,
+				virtualService6,
+				virtualService7,
+			},
+		},
+	}
+
+	configs := SelectVirtualServices(index, "some-ns", hostsByNamespace)
 	expectedVS := []string{virtualService1.Name, virtualService2.Name, virtualService4.Name, virtualService7.Name}
 	if len(expectedVS) != len(configs) {
 		t.Fatalf("Unexpected virtualService, got %d, epxected %d", len(configs), len(expectedVS))


### PR DESCRIPTION
**Please provide a description of this PR:**
Our production init push context time is very long (roughly 40s), and CPU profile shows that more than 20% of cpu time is spent on the VirtualServicesForGateway function:
https://github.com/istio/istio/blob/1.14.4/pilot/pkg/model/push_context.go#L863-L875

This function is called for every sidecar's egress host, for calculating the virtual services that are imported by the egress host. We have more than 10k sidecars and suppose each sidecar has 10 egress hosts, this function is called 100k times. This "make slice" and "slice copy" are expansive on such magnitude.

Such copy is unnecessary though. Instead of passing in the copied and merged version of the virtual services, just pass the virtualServiceIndex into the select function directly. From our testing, this improves the init context time to roughly 25s.


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [x] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
