### PR TITLE
Add support for custom proxy config to waypoints

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -1432,7 +1432,8 @@ data:
                 - name: ISTIO_META_MESH_ID
                   value: cluster.local
                 - name: PROXY_CONFIG
-                  value: {{.ProxyConfig}}
+                  value: |
+                         {{ protoToJSON .ProxyConfig }}
                 image: {{.Image}}
                 {{with .ImagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
                 name: istio-proxy

--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -1431,6 +1431,8 @@ data:
                   value: kubernetes://apis/apps/v1/namespaces/default/deployments/proxy
                 - name: ISTIO_META_MESH_ID
                   value: cluster.local
+                - name: PROXY_CONFIG
+                  value: {{.ProxyConfig}}
                 image: {{.Image}}
                 {{with .ImagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
                 name: istio-proxy

--- a/manifests/charts/istio-control/istio-discovery/files/waypoint.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/waypoint.yaml
@@ -110,7 +110,8 @@ spec:
         - name: ISTIO_META_MESH_ID
           value: cluster.local
         - name: PROXY_CONFIG
-          value: {{.ProxyConfig}}
+          value: |
+                 {{ protoToJSON .ProxyConfig }}
         image: {{.Image}}
         {{with .ImagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
         name: istio-proxy

--- a/manifests/charts/istio-control/istio-discovery/files/waypoint.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/waypoint.yaml
@@ -109,6 +109,8 @@ spec:
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/proxy
         - name: ISTIO_META_MESH_ID
           value: cluster.local
+        - name: PROXY_CONFIG
+          value: {{.ProxyConfig}}
         image: {{.Image}}
         {{with .ImagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
         name: istio-proxy

--- a/pilot/pkg/ambient/controller/waypoint_controller.go
+++ b/pilot/pkg/ambient/controller/waypoint_controller.go
@@ -15,9 +15,13 @@
 package controller
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"strconv"
+	"text/template"
 
+	"google.golang.org/protobuf/proto"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	klabels "k8s.io/apimachinery/pkg/labels"
@@ -29,6 +33,7 @@ import (
 	gwlister "sigs.k8s.io/gateway-api/pkg/client/listers/apis/v1alpha2"
 	"sigs.k8s.io/yaml"
 
+	meshconfig "istio.io/api/mesh/v1alpha1"
 	istiogw "istio.io/istio/pilot/pkg/config/kube/gateway"
 	"istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/config"
@@ -184,6 +189,20 @@ func (rc *WaypointProxyController) Reconcile(name types.NamespacedName) error {
 			ServiceAccount: k,
 			Cluster:        rc.cluster.String(),
 		}
+
+		// Setting non-default mesh config (if set) as the proxy config for the waypoint
+		tmpl, _ := template.New("proxyConfigInject").Funcs(inject.InjectionFuncmap).Parse("{{protoToJSON .}}")
+		pc := proto.Clone(rc.injectConfig().MeshConfig.GetDefaultConfig()).(*meshconfig.ProxyConfig)
+		if pc != nil {
+			pc.ProxyMetadata = nil
+		}
+		buf := new(bytes.Buffer)
+		if err := tmpl.Execute(buf, pc); err == nil {
+			input.ProxyConfig = strconv.Quote(buf.String())
+		} else {
+			log.Errorf("failed to execute template function protoToJSON on default config: %v", err)
+		}
+
 		proxyDeploy, err := rc.RenderDeploymentMerged(input)
 		if err != nil {
 			return err
@@ -308,4 +327,5 @@ type MergedInput struct {
 	Cluster         string
 	Image           string
 	ImagePullPolicy string
+	ProxyConfig     string
 }

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -116,7 +116,7 @@ func (configgen *ConfigGeneratorImpl) BuildListeners(node *model.Proxy,
 
 	builder.patchListeners()
 	l := builder.getListeners()
-	if node.EnableHBONE() {
+	if node.EnableHBONE() && !node.IsWaypointProxy() {
 		l = append(l, outboundTunnelListener(push, node))
 	}
 	return l

--- a/pkg/kube/inject/testdata/inputs/custom-template.yaml.34.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/custom-template.yaml.34.template.gen.yaml
@@ -1235,7 +1235,8 @@ templates:
             - name: ISTIO_META_MESH_ID
               value: cluster.local
             - name: PROXY_CONFIG
-              value: {{.ProxyConfig}}
+              value: |
+                     {{ protoToJSON .ProxyConfig }}
             image: {{.Image}}
             {{with .ImagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             name: istio-proxy

--- a/pkg/kube/inject/testdata/inputs/custom-template.yaml.34.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/custom-template.yaml.34.template.gen.yaml
@@ -1234,6 +1234,8 @@ templates:
               value: kubernetes://apis/apps/v1/namespaces/default/deployments/proxy
             - name: ISTIO_META_MESH_ID
               value: cluster.local
+            - name: PROXY_CONFIG
+              value: {{.ProxyConfig}}
             image: {{.Image}}
             {{with .ImagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             name: istio-proxy

--- a/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
@@ -1235,7 +1235,8 @@ templates:
             - name: ISTIO_META_MESH_ID
               value: cluster.local
             - name: PROXY_CONFIG
-              value: {{.ProxyConfig}}
+              value: |
+                     {{ protoToJSON .ProxyConfig }}
             image: {{.Image}}
             {{with .ImagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             name: istio-proxy

--- a/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
@@ -1234,6 +1234,8 @@ templates:
               value: kubernetes://apis/apps/v1/namespaces/default/deployments/proxy
             - name: ISTIO_META_MESH_ID
               value: cluster.local
+            - name: PROXY_CONFIG
+              value: {{.ProxyConfig}}
             image: {{.Image}}
             {{with .ImagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             name: istio-proxy

--- a/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
@@ -1235,7 +1235,8 @@ templates:
             - name: ISTIO_META_MESH_ID
               value: cluster.local
             - name: PROXY_CONFIG
-              value: {{.ProxyConfig}}
+              value: |
+                     {{ protoToJSON .ProxyConfig }}
             image: {{.Image}}
             {{with .ImagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             name: istio-proxy

--- a/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
@@ -1234,6 +1234,8 @@ templates:
               value: kubernetes://apis/apps/v1/namespaces/default/deployments/proxy
             - name: ISTIO_META_MESH_ID
               value: cluster.local
+            - name: PROXY_CONFIG
+              value: {{.ProxyConfig}}
             image: {{.Image}}
             {{with .ImagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             name: istio-proxy

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
@@ -1235,7 +1235,8 @@ templates:
             - name: ISTIO_META_MESH_ID
               value: cluster.local
             - name: PROXY_CONFIG
-              value: {{.ProxyConfig}}
+              value: |
+                     {{ protoToJSON .ProxyConfig }}
             image: {{.Image}}
             {{with .ImagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             name: istio-proxy

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
@@ -1234,6 +1234,8 @@ templates:
               value: kubernetes://apis/apps/v1/namespaces/default/deployments/proxy
             - name: ISTIO_META_MESH_ID
               value: cluster.local
+            - name: PROXY_CONFIG
+              value: {{.ProxyConfig}}
             image: {{.Image}}
             {{with .ImagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             name: istio-proxy

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
@@ -1235,7 +1235,8 @@ templates:
             - name: ISTIO_META_MESH_ID
               value: cluster.local
             - name: PROXY_CONFIG
-              value: {{.ProxyConfig}}
+              value: |
+                     {{ protoToJSON .ProxyConfig }}
             image: {{.Image}}
             {{with .ImagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             name: istio-proxy

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
@@ -1234,6 +1234,8 @@ templates:
               value: kubernetes://apis/apps/v1/namespaces/default/deployments/proxy
             - name: ISTIO_META_MESH_ID
               value: cluster.local
+            - name: PROXY_CONFIG
+              value: {{.ProxyConfig}}
             image: {{.Image}}
             {{with .ImagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             name: istio-proxy

--- a/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
@@ -1235,7 +1235,8 @@ templates:
             - name: ISTIO_META_MESH_ID
               value: cluster.local
             - name: PROXY_CONFIG
-              value: {{.ProxyConfig}}
+              value: |
+                     {{ protoToJSON .ProxyConfig }}
             image: {{.Image}}
             {{with .ImagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             name: istio-proxy

--- a/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
@@ -1234,6 +1234,8 @@ templates:
               value: kubernetes://apis/apps/v1/namespaces/default/deployments/proxy
             - name: ISTIO_META_MESH_ID
               value: cluster.local
+            - name: PROXY_CONFIG
+              value: {{.ProxyConfig}}
             image: {{.Image}}
             {{with .ImagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             name: istio-proxy

--- a/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
@@ -1235,7 +1235,8 @@ templates:
             - name: ISTIO_META_MESH_ID
               value: cluster.local
             - name: PROXY_CONFIG
-              value: {{.ProxyConfig}}
+              value: |
+                     {{ protoToJSON .ProxyConfig }}
             image: {{.Image}}
             {{with .ImagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             name: istio-proxy

--- a/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
@@ -1234,6 +1234,8 @@ templates:
               value: kubernetes://apis/apps/v1/namespaces/default/deployments/proxy
             - name: ISTIO_META_MESH_ID
               value: cluster.local
+            - name: PROXY_CONFIG
+              value: {{.ProxyConfig}}
             image: {{.Image}}
             {{with .ImagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             name: istio-proxy

--- a/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
@@ -1235,7 +1235,8 @@ templates:
             - name: ISTIO_META_MESH_ID
               value: cluster.local
             - name: PROXY_CONFIG
-              value: {{.ProxyConfig}}
+              value: |
+                     {{ protoToJSON .ProxyConfig }}
             image: {{.Image}}
             {{with .ImagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             name: istio-proxy

--- a/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
@@ -1234,6 +1234,8 @@ templates:
               value: kubernetes://apis/apps/v1/namespaces/default/deployments/proxy
             - name: ISTIO_META_MESH_ID
               value: cluster.local
+            - name: PROXY_CONFIG
+              value: {{.ProxyConfig}}
             image: {{.Image}}
             {{with .ImagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             name: istio-proxy

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
@@ -1235,7 +1235,8 @@ templates:
             - name: ISTIO_META_MESH_ID
               value: cluster.local
             - name: PROXY_CONFIG
-              value: {{.ProxyConfig}}
+              value: |
+                     {{ protoToJSON .ProxyConfig }}
             image: {{.Image}}
             {{with .ImagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             name: istio-proxy

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
@@ -1234,6 +1234,8 @@ templates:
               value: kubernetes://apis/apps/v1/namespaces/default/deployments/proxy
             - name: ISTIO_META_MESH_ID
               value: cluster.local
+            - name: PROXY_CONFIG
+              value: {{.ProxyConfig}}
             image: {{.Image}}
             {{with .ImagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             name: istio-proxy

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
@@ -1235,7 +1235,8 @@ templates:
             - name: ISTIO_META_MESH_ID
               value: cluster.local
             - name: PROXY_CONFIG
-              value: {{.ProxyConfig}}
+              value: |
+                     {{ protoToJSON .ProxyConfig }}
             image: {{.Image}}
             {{with .ImagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             name: istio-proxy

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
@@ -1234,6 +1234,8 @@ templates:
               value: kubernetes://apis/apps/v1/namespaces/default/deployments/proxy
             - name: ISTIO_META_MESH_ID
               value: cluster.local
+            - name: PROXY_CONFIG
+              value: {{.ProxyConfig}}
             image: {{.Image}}
             {{with .ImagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             name: istio-proxy

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
@@ -1235,7 +1235,8 @@ templates:
             - name: ISTIO_META_MESH_ID
               value: cluster.local
             - name: PROXY_CONFIG
-              value: {{.ProxyConfig}}
+              value: |
+                     {{ protoToJSON .ProxyConfig }}
             image: {{.Image}}
             {{with .ImagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             name: istio-proxy

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
@@ -1234,6 +1234,8 @@ templates:
               value: kubernetes://apis/apps/v1/namespaces/default/deployments/proxy
             - name: ISTIO_META_MESH_ID
               value: cluster.local
+            - name: PROXY_CONFIG
+              value: {{.ProxyConfig}}
             image: {{.Image}}
             {{with .ImagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             name: istio-proxy

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
@@ -1235,7 +1235,8 @@ templates:
             - name: ISTIO_META_MESH_ID
               value: cluster.local
             - name: PROXY_CONFIG
-              value: {{.ProxyConfig}}
+              value: |
+                     {{ protoToJSON .ProxyConfig }}
             image: {{.Image}}
             {{with .ImagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             name: istio-proxy

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
@@ -1234,6 +1234,8 @@ templates:
               value: kubernetes://apis/apps/v1/namespaces/default/deployments/proxy
             - name: ISTIO_META_MESH_ID
               value: cluster.local
+            - name: PROXY_CONFIG
+              value: {{.ProxyConfig}}
             image: {{.Image}}
             {{with .ImagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             name: istio-proxy

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
@@ -1235,7 +1235,8 @@ templates:
             - name: ISTIO_META_MESH_ID
               value: cluster.local
             - name: PROXY_CONFIG
-              value: {{.ProxyConfig}}
+              value: |
+                     {{ protoToJSON .ProxyConfig }}
             image: {{.Image}}
             {{with .ImagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             name: istio-proxy

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
@@ -1234,6 +1234,8 @@ templates:
               value: kubernetes://apis/apps/v1/namespaces/default/deployments/proxy
             - name: ISTIO_META_MESH_ID
               value: cluster.local
+            - name: PROXY_CONFIG
+              value: {{.ProxyConfig}}
             image: {{.Image}}
             {{with .ImagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             name: istio-proxy

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
@@ -1235,7 +1235,8 @@ templates:
             - name: ISTIO_META_MESH_ID
               value: cluster.local
             - name: PROXY_CONFIG
-              value: {{.ProxyConfig}}
+              value: |
+                     {{ protoToJSON .ProxyConfig }}
             image: {{.Image}}
             {{with .ImagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             name: istio-proxy

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
@@ -1234,6 +1234,8 @@ templates:
               value: kubernetes://apis/apps/v1/namespaces/default/deployments/proxy
             - name: ISTIO_META_MESH_ID
               value: cluster.local
+            - name: PROXY_CONFIG
+              value: {{.ProxyConfig}}
             image: {{.Image}}
             {{with .ImagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             name: istio-proxy

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
@@ -1235,7 +1235,8 @@ templates:
             - name: ISTIO_META_MESH_ID
               value: cluster.local
             - name: PROXY_CONFIG
-              value: {{.ProxyConfig}}
+              value: |
+                     {{ protoToJSON .ProxyConfig }}
             image: {{.Image}}
             {{with .ImagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             name: istio-proxy

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
@@ -1234,6 +1234,8 @@ templates:
               value: kubernetes://apis/apps/v1/namespaces/default/deployments/proxy
             - name: ISTIO_META_MESH_ID
               value: cluster.local
+            - name: PROXY_CONFIG
+              value: {{.ProxyConfig}}
             image: {{.Image}}
             {{with .ImagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             name: istio-proxy

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
@@ -1235,7 +1235,8 @@ templates:
             - name: ISTIO_META_MESH_ID
               value: cluster.local
             - name: PROXY_CONFIG
-              value: {{.ProxyConfig}}
+              value: |
+                     {{ protoToJSON .ProxyConfig }}
             image: {{.Image}}
             {{with .ImagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             name: istio-proxy

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
@@ -1234,6 +1234,8 @@ templates:
               value: kubernetes://apis/apps/v1/namespaces/default/deployments/proxy
             - name: ISTIO_META_MESH_ID
               value: cluster.local
+            - name: PROXY_CONFIG
+              value: {{.ProxyConfig}}
             image: {{.Image}}
             {{with .ImagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             name: istio-proxy

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
@@ -1235,7 +1235,8 @@ templates:
             - name: ISTIO_META_MESH_ID
               value: cluster.local
             - name: PROXY_CONFIG
-              value: {{.ProxyConfig}}
+              value: |
+                     {{ protoToJSON .ProxyConfig }}
             image: {{.Image}}
             {{with .ImagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             name: istio-proxy

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
@@ -1234,6 +1234,8 @@ templates:
               value: kubernetes://apis/apps/v1/namespaces/default/deployments/proxy
             - name: ISTIO_META_MESH_ID
               value: cluster.local
+            - name: PROXY_CONFIG
+              value: {{.ProxyConfig}}
             image: {{.Image}}
             {{with .ImagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             name: istio-proxy

--- a/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
@@ -1235,7 +1235,8 @@ templates:
             - name: ISTIO_META_MESH_ID
               value: cluster.local
             - name: PROXY_CONFIG
-              value: {{.ProxyConfig}}
+              value: |
+                     {{ protoToJSON .ProxyConfig }}
             image: {{.Image}}
             {{with .ImagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             name: istio-proxy

--- a/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
@@ -1234,6 +1234,8 @@ templates:
               value: kubernetes://apis/apps/v1/namespaces/default/deployments/proxy
             - name: ISTIO_META_MESH_ID
               value: cluster.local
+            - name: PROXY_CONFIG
+              value: {{.ProxyConfig}}
             image: {{.Image}}
             {{with .ImagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             name: istio-proxy

--- a/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
@@ -1235,7 +1235,8 @@ templates:
             - name: ISTIO_META_MESH_ID
               value: cluster.local
             - name: PROXY_CONFIG
-              value: {{.ProxyConfig}}
+              value: |
+                     {{ protoToJSON .ProxyConfig }}
             image: {{.Image}}
             {{with .ImagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             name: istio-proxy

--- a/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
@@ -1234,6 +1234,8 @@ templates:
               value: kubernetes://apis/apps/v1/namespaces/default/deployments/proxy
             - name: ISTIO_META_MESH_ID
               value: cluster.local
+            - name: PROXY_CONFIG
+              value: {{.ProxyConfig}}
             image: {{.Image}}
             {{with .ImagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             name: istio-proxy

--- a/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
@@ -1235,7 +1235,8 @@ templates:
             - name: ISTIO_META_MESH_ID
               value: cluster.local
             - name: PROXY_CONFIG
-              value: {{.ProxyConfig}}
+              value: |
+                     {{ protoToJSON .ProxyConfig }}
             image: {{.Image}}
             {{with .ImagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             name: istio-proxy

--- a/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
@@ -1234,6 +1234,8 @@ templates:
               value: kubernetes://apis/apps/v1/namespaces/default/deployments/proxy
             - name: ISTIO_META_MESH_ID
               value: cluster.local
+            - name: PROXY_CONFIG
+              value: {{.ProxyConfig}}
             image: {{.Image}}
             {{with .ImagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             name: istio-proxy


### PR DESCRIPTION
**Please provide a description of this PR:**

This PR add supports for setting custom proxy config that will be consumed by the deployed waypoints.
E.g.: Supports setting the `meshConfig.defaultConfig.envoyMetricsService.address` for the L7 metrics from the waypoint to be pushed to metrics service.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [X] Ambient
- [X] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
