### PR TITLE
move `/debug/ecdsz` to `/debug/config_dump?types=ecds`

### DIFF
--- a/pilot/pkg/xds/debug.go
+++ b/pilot/pkg/xds/debug.go
@@ -50,6 +50,7 @@ import (
 	"istio.io/istio/pkg/network"
 	"istio.io/istio/pkg/security"
 	"istio.io/istio/pkg/util/protomarshal"
+	"istio.io/istio/pkg/util/sets"
 	istiolog "istio.io/pkg/log"
 )
 
@@ -610,12 +611,20 @@ func (s *DiscoveryServer) ecdsz(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	wasmCfgs, err := s.getExtensionConfiguration(con)
+	if err != nil {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(err.Error()))
+		return
+	}
+	writeJSON(w, wasmCfgs, req)
+}
+
+func (s *DiscoveryServer) getExtensionConfiguration(con *Connection) ([]proto.Message, error) {
 	if s.Generators[v3.ExtensionConfigurationType] != nil {
 		r, ok := con.proxy.WatchedResources[v3.ExtensionConfigurationType]
 		if !ok {
-			w.WriteHeader(http.StatusNotFound)
-			_, _ = w.Write([]byte(fmt.Sprintf("no watched ExtensionConfigurationType found, proxyID: %s\n", proxyID)))
-			return
+			return nil, fmt.Errorf("no watched ExtensionConfigurationType found, proxyID: %s", con.proxy.ID)
 		}
 
 		resource, _, _ := s.Generators[v3.ExtensionConfigurationType].Generate(con.proxy, r, &model.PushRequest{
@@ -623,12 +632,10 @@ func (s *DiscoveryServer) ecdsz(w http.ResponseWriter, req *http.Request) {
 			Push: con.proxy.LastPushContext,
 		})
 		if len(resource) == 0 {
-			w.WriteHeader(http.StatusNotFound)
-			_, _ = w.Write([]byte(fmt.Sprintf("ExtensionConfigurationType not found, proxyID: %s\n", proxyID)))
-			return
+			return nil, fmt.Errorf("no ExtensionConfigurationType found, proxyID: %s", con.proxy.ID)
 		}
 
-		wasmCfgs := make([]any, 0, len(resource))
+		wasmCfgs := make([]proto.Message, 0, len(resource))
 		for _, rr := range resource {
 			if w, err := unmarshalToWasm(rr); err != nil {
 				istiolog.Warnf("failed to unmarshal wasm: %v", err)
@@ -637,11 +644,18 @@ func (s *DiscoveryServer) ecdsz(w http.ResponseWriter, req *http.Request) {
 			}
 		}
 
-		writeJSON(w, wasmCfgs, req)
+		return wasmCfgs, nil
 	}
+
+	return nil, nil
 }
 
-func unmarshalToWasm(r *discovery.Resource) (any, error) {
+const (
+	apiTypePrefix      = "type.googleapis.com/"
+	wasmHTTPFilterType = apiTypePrefix + "envoy.extensions.filters.http.wasm.v3.Wasm"
+)
+
+func unmarshalToWasm(r *discovery.Resource) (proto.Message, error) {
 	tce := &core.TypedExtensionConfig{}
 	if err := r.GetResource().UnmarshalTo(tce); err != nil {
 		return nil, err
@@ -675,6 +689,12 @@ func (s *DiscoveryServer) ConfigDump(w http.ResponseWriter, req *http.Request) {
 		s.errorHandler(w, proxyID, con)
 		return
 	}
+	if ts := s.getResourceTypes(req); len(ts) != 0 {
+		dump := s.getConfigDumpByResourceType(con, ts)
+		writeJSON(w, dump, req)
+		return
+	}
+
 	includeEds := req.URL.Query().Get("include_eds") == "true"
 	dump, err := s.configDump(con, includeEds)
 	if err != nil {
@@ -682,6 +702,35 @@ func (s *DiscoveryServer) ConfigDump(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 	writeJSON(w, dump, req)
+}
+
+func (s *DiscoveryServer) getResourceTypes(req *http.Request) []string {
+	if shortTypes := req.URL.Query().Get("types"); shortTypes != "" {
+		ts := strings.Split(shortTypes, ",")
+
+		resourceTypes := sets.New[string]()
+		for _, t := range ts {
+			resourceTypes.Insert(v3.GetResourceType(t))
+		}
+
+		return resourceTypes.UnsortedList()
+	}
+	return nil
+}
+
+func (s *DiscoveryServer) getConfigDumpByResourceType(conn *Connection, ts []string) map[string][]proto.Message {
+	dumps := make(map[string][]proto.Message)
+
+	for _, resourceType := range ts {
+		switch resourceType {
+		case v3.ExtensionConfigurationType:
+			if cfgs, err := s.getExtensionConfiguration(conn); err == nil {
+				dumps[v3.ExtensionConfigurationType] = cfgs
+			}
+		}
+	}
+
+	return dumps
 }
 
 // configDump converts the connection internal state into an Envoy Admin API config dump proto

--- a/pilot/pkg/xds/debug.go
+++ b/pilot/pkg/xds/debug.go
@@ -650,11 +650,6 @@ func (s *DiscoveryServer) getExtensionConfiguration(con *Connection) ([]proto.Me
 	return nil, nil
 }
 
-const (
-	apiTypePrefix      = "type.googleapis.com/"
-	wasmHTTPFilterType = apiTypePrefix + "envoy.extensions.filters.http.wasm.v3.Wasm"
-)
-
 func unmarshalToWasm(r *discovery.Resource) (proto.Message, error) {
 	tce := &core.TypedExtensionConfig{}
 	if err := r.GetResource().UnmarshalTo(tce); err != nil {

--- a/pilot/pkg/xds/v3/model.go
+++ b/pilot/pkg/xds/v3/model.go
@@ -91,6 +91,31 @@ func GetMetricType(typeURL string) string {
 	}
 }
 
+// GetResourceType returns resource form of an abbreviated form
+func GetResourceType(shortType string) string {
+	s := strings.ToUpper(shortType)
+	switch s {
+	case "CDS":
+		return ClusterType
+	case "LDS":
+		return ListenerType
+	case "RDS":
+		return RouteType
+	case "EDS":
+		return EndpointType
+	case "SDS":
+		return SecretType
+	case "NDS":
+		return NameTableType
+	case "PCDS":
+		return ProxyConfigType
+	case "ECDS":
+		return ExtensionConfigurationType
+	default:
+		return shortType
+	}
+}
+
 // IsEnvoyType checks whether the typeURL is a valid Envoy type.
 func IsEnvoyType(typeURL string) bool {
 	return strings.HasPrefix(typeURL, envoyTypePrefix)


### PR DESCRIPTION
**Please provide a description of this PR:**

follow up: https://github.com/istio/istio/issues/37504

```console
root@ecs-zirain:~/go/src/playground/go/wasm-extensions/display-metadata# kubectl exec -it `kubectl get po -nistio-system| grep istiod | grep Running | awk '{print $1}'` -nistio-system -- pilot-discovery request get '/debug/ecdsz?proxyID=httpbin-847f64cc8d-kmlxg'
[{"config":{"name":"default.display-metadata","Vm":{"VmConfig":{"runtime":"envoy.wasm.runtime.v8","code":{"Specifier":{"Remote":{"http_uri":{"uri":"oci://ghcr.io/zirain/display-metadata:latest","HttpUpstreamType":{"Cluster":"_"},"timeout":{"seconds":30}}}}},"environment_variables":{"host_env_keys":["POD_NAMESPACE"],"key_values":{"ISTIO_META_WASM_PLUGIN_RESOURCE_VERSION":"4333"}}}},"configuration":{"type_url":"type.googleapis.com/google.protobuf.StringValue","value":"CjZ7ImhlYWRlcl8xIjoic29tZV92YWx1ZV8xIiwiaGVhZGVyXzIiOiJhbm90aGVyX3ZhbHVlIn0="}}}]
root@ecs-zirain:~/go/src/playground/go/wasm-extensions/display-metadata# kubectl exec -it `kubectl get po -nistio-system| grep istiod | grep Running | awk '{print $1}'` -nistio-system -- pilot-discovery request get '/debug/config_dump?types=ecds&proxyID=httpbin-847f64cc8d-kmlxg'
{"type.googleapis.com/envoy.config.core.v3.TypedExtensionConfig":[{"config":{"name":"default.display-metadata","Vm":{"VmConfig":{"runtime":"envoy.wasm.runtime.v8","code":{"Specifier":{"Remote":{"http_uri":{"uri":"oci://ghcr.io/zirain/display-metadata:latest","HttpUpstreamType":{"Cluster":"_"},"timeout":{"seconds":30}}}}},"environment_variables":{"host_env_keys":["POD_NAMESPACE"],"key_values":{"ISTIO_META_WASM_PLUGIN_RESOURCE_VERSION":"4333"}}}},"configuration":{"type_url":"type.googleapis.com/google.protobuf.StringValue","value":"CjZ7ImhlYWRlcl8xIjoic29tZV92YWx1ZV8xIiwiaGVhZGVyXzIiOiJhbm90aGVyX3ZhbHVlIn0="}}}]}
```

cc @howardjohn 