### PR TITLE
support ipv6 is yes, then let's skip ipv4 test

### DIFF
--- a/tests/integration/tests.mk
+++ b/tests/integration/tests.mk
@@ -41,12 +41,12 @@ endif
 support_ipv6 =
 ifeq ($(IP_FAMILY),ipv6)
 	support_ipv6 = yes
-	_INTEGRATION_TEST_SELECT_FLAGS:="$(_INTEGRATION_TEST_SELECT_FLAGS),-ipv4"
 else ifeq ($(IP_FAMILY),dual)
 	support_ipv6 = yes
 	_INTEGRATION_TEST_FLAGS += --istio.test.enableDualStack
 endif
 ifdef support_ipv6
+	_INTEGRATION_TEST_SELECT_FLAGS:="$(_INTEGRATION_TEST_SELECT_FLAGS),-ipv4"
 	# Fundamentally, VMs should support IPv6. However, our test framework uses a contrived setup to test VMs
 	# such that they run in the cluster. In particular, they configure DNS to a public DNS server.
 	# For CI, our nodes do not have IPv6 external connectivity. This means the cluster *cannot* reach these external


### PR DESCRIPTION
**Please provide a description of this PR:**
if support ipv6 is yes, then let's skip ipv4 test which may lead to the job failed.