### PR TITLE
Don't include hostNetwork pods in ztunnel's config

### DIFF
--- a/pilot/pkg/ambient/ambient.go
+++ b/pilot/pkg/ambient/ambient.go
@@ -42,6 +42,7 @@ type Workload struct {
 	NodeName       string
 	PodIP          string
 	PodIPs         []string
+	HostNetwork    bool
 
 	WorkloadMetadata
 

--- a/pilot/pkg/ambient/ambientpod/podutil.go
+++ b/pilot/pkg/ambient/ambientpod/podutil.go
@@ -49,6 +49,7 @@ func WorkloadFromPod(pod *corev1.Pod) ambient.Workload {
 		Labels:            pod.Labels, // TODO copy?
 		ServiceAccount:    pod.Spec.ServiceAccountName,
 		NodeName:          pod.Spec.NodeName,
+		HostNetwork:       pod.Spec.HostNetwork,
 		PodIP:             pod.Status.PodIP,
 		PodIPs:            ips,
 		CreationTimestamp: pod.CreationTimestamp.Time,

--- a/pilot/pkg/networking/ambientgen/ztunnelgen.go
+++ b/pilot/pkg/networking/ambientgen/ztunnelgen.go
@@ -1097,6 +1097,11 @@ func (g *ZTunnelConfigGenerator) buildInboundCaptureListener(proxy *model.Proxy,
 	}
 
 	for _, workload := range push.AmbientIndex.Workloads.NodeLocal(proxy.Metadata.NodeName) {
+		// Skip workloads in the host network
+		if workload.HostNetwork {
+			continue
+		}
+
 		if workload.Labels[model.TunnelLabel] != model.TunnelH2 {
 			dummy := &model.Proxy{
 				ConfigNamespace: workload.Namespace,
@@ -1245,6 +1250,11 @@ func (g *ZTunnelConfigGenerator) buildInboundPlaintextCaptureListener(proxy *mod
 	}
 
 	for _, workload := range push.AmbientIndex.Workloads.NodeLocal(proxy.Metadata.NodeName) {
+		// Skip workloads in the host network
+		if workload.HostNetwork {
+			continue
+		}
+
 		dummy := &model.Proxy{
 			ConfigNamespace: workload.Namespace,
 			Labels:          workload.Labels,


### PR DESCRIPTION
**Please provide a description of this PR:**

Fixes #41097 by skipping workload's with hostNetwork: true when building listeners for ztunnel.