### PR TITLE
Optimize double nested maps

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -89,9 +89,9 @@ type exportToDefaults struct {
 
 // virtualServiceIndex is the index of virtual services by various fields.
 type virtualServiceIndex struct {
-	exportedToNamespaceByGateway map[string]map[string][]config.Config
+	exportedToNamespaceByGateway map[types.NamespacedName][]config.Config
 	// this contains all the virtual services with exportTo "." and current namespace. The keys are namespace,gateway.
-	privateByNamespaceAndGateway map[string]map[string][]config.Config
+	privateByNamespaceAndGateway map[types.NamespacedName][]config.Config
 	// This contains all virtual services whose exportTo is "*", keyed by gateway
 	publicByGateway map[string][]config.Config
 	// root vs namespace/name ->delegate vs virtualservice gvk/namespace/name
@@ -101,8 +101,8 @@ type virtualServiceIndex struct {
 func newVirtualServiceIndex() virtualServiceIndex {
 	return virtualServiceIndex{
 		publicByGateway:              map[string][]config.Config{},
-		privateByNamespaceAndGateway: map[string]map[string][]config.Config{},
-		exportedToNamespaceByGateway: map[string]map[string][]config.Config{},
+		privateByNamespaceAndGateway: map[types.NamespacedName][]config.Config{},
+		exportedToNamespaceByGateway: map[types.NamespacedName][]config.Config{},
 		delegates:                    map[ConfigKey][]ConfigKey{},
 	}
 }
@@ -904,11 +904,15 @@ func (ps *PushContext) IsServiceVisible(service *Service, namespace string) bool
 // Instead, we pass the virtualServiceIndex directly into SelectVirtualServices
 // function.
 func (ps *PushContext) VirtualServicesForGateway(proxyNamespace, gateway string) []config.Config {
-	res := make([]config.Config, 0, len(ps.virtualServiceIndex.privateByNamespaceAndGateway[proxyNamespace][gateway])+
-		len(ps.virtualServiceIndex.exportedToNamespaceByGateway[proxyNamespace][gateway])+
+	name := types.NamespacedName{
+		Namespace: proxyNamespace,
+		Name:      gateway,
+	}
+	res := make([]config.Config, 0, len(ps.virtualServiceIndex.privateByNamespaceAndGateway[name])+
+		len(ps.virtualServiceIndex.exportedToNamespaceByGateway[name])+
 		len(ps.virtualServiceIndex.publicByGateway[gateway]))
-	res = append(res, ps.virtualServiceIndex.privateByNamespaceAndGateway[proxyNamespace][gateway]...)
-	res = append(res, ps.virtualServiceIndex.exportedToNamespaceByGateway[proxyNamespace][gateway]...)
+	res = append(res, ps.virtualServiceIndex.privateByNamespaceAndGateway[name]...)
+	res = append(res, ps.virtualServiceIndex.exportedToNamespaceByGateway[name]...)
 	res = append(res, ps.virtualServiceIndex.publicByGateway[gateway]...)
 
 	return res
@@ -1481,8 +1485,8 @@ func (ps *PushContext) initAuthnPolicies(env *Environment) error {
 
 // Caches list of virtual services
 func (ps *PushContext) initVirtualServices(env *Environment) error {
-	ps.virtualServiceIndex.exportedToNamespaceByGateway = map[string]map[string][]config.Config{}
-	ps.virtualServiceIndex.privateByNamespaceAndGateway = map[string]map[string][]config.Config{}
+	ps.virtualServiceIndex.exportedToNamespaceByGateway = map[types.NamespacedName][]config.Config{}
+	ps.virtualServiceIndex.privateByNamespaceAndGateway = map[types.NamespacedName][]config.Config{}
 	ps.virtualServiceIndex.publicByGateway = map[string][]config.Config{}
 
 	virtualServices, err := env.List(gvk.VirtualService, NamespaceAll)
@@ -1521,13 +1525,11 @@ func (ps *PushContext) initVirtualServices(env *Environment) error {
 			// No exportTo in virtualService. Use the global default
 			// We only honor ., *
 			if ps.exportToDefaults.virtualService[visibility.Private] {
-				if _, f := ps.virtualServiceIndex.privateByNamespaceAndGateway[ns]; !f {
-					ps.virtualServiceIndex.privateByNamespaceAndGateway[ns] = map[string][]config.Config{}
-				}
 				// add to local namespace only
 				private := ps.virtualServiceIndex.privateByNamespaceAndGateway
 				for _, gw := range gwNames {
-					private[ns][gw] = append(private[ns][gw], virtualService)
+					n := types.NamespacedName{Namespace: ns, Name: gw}
+					private[n] = append(private[n], virtualService)
 				}
 			} else if ps.exportToDefaults.virtualService[visibility.Public] {
 				for _, gw := range gwNames {
@@ -1554,21 +1556,17 @@ func (ps *PushContext) initVirtualServices(env *Environment) error {
 				// . or other namespaces
 				for exportTo := range exportToMap {
 					if exportTo == visibility.Private || string(exportTo) == ns {
-						if _, f := ps.virtualServiceIndex.privateByNamespaceAndGateway[ns]; !f {
-							ps.virtualServiceIndex.privateByNamespaceAndGateway[ns] = map[string][]config.Config{}
-						}
 						// add to local namespace only
 						for _, gw := range gwNames {
-							ps.virtualServiceIndex.privateByNamespaceAndGateway[ns][gw] = append(ps.virtualServiceIndex.privateByNamespaceAndGateway[ns][gw], virtualService)
+							n := types.NamespacedName{Namespace: ns, Name: gw}
+							ps.virtualServiceIndex.privateByNamespaceAndGateway[n] = append(ps.virtualServiceIndex.privateByNamespaceAndGateway[n], virtualService)
 						}
 					} else {
-						if _, f := ps.virtualServiceIndex.exportedToNamespaceByGateway[string(exportTo)]; !f {
-							ps.virtualServiceIndex.exportedToNamespaceByGateway[string(exportTo)] = map[string][]config.Config{}
-						}
 						exported := ps.virtualServiceIndex.exportedToNamespaceByGateway
 						// add to local namespace only
 						for _, gw := range gwNames {
-							exported[string(exportTo)][gw] = append(exported[string(exportTo)][gw], virtualService)
+							n := types.NamespacedName{Namespace: string(exportTo), Name: gw}
+							exported[n] = append(exported[n], virtualService)
 						}
 					}
 				}

--- a/pilot/pkg/model/virtualservice.go
+++ b/pilot/pkg/model/virtualservice.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/gogo/protobuf/jsonpb"
 	"google.golang.org/protobuf/proto"
+	"k8s.io/apimachinery/pkg/types"
 
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pkg/config"
@@ -75,8 +76,9 @@ func SelectVirtualServices(vsidx virtualServiceIndex, configNamespace string, ho
 		}
 	}
 
-	loopAndAdd(vsidx.privateByNamespaceAndGateway[configNamespace][constants.IstioMeshGateway])
-	loopAndAdd(vsidx.exportedToNamespaceByGateway[configNamespace][constants.IstioMeshGateway])
+	n := types.NamespacedName{Namespace: configNamespace, Name: constants.IstioMeshGateway}
+	loopAndAdd(vsidx.privateByNamespaceAndGateway[n])
+	loopAndAdd(vsidx.exportedToNamespaceByGateway[n])
 	loopAndAdd(vsidx.publicByGateway[constants.IstioMeshGateway])
 
 	return importedVirtualServices


### PR DESCRIPTION
In a few places, we use `map[]map[]x`. Unless we need to be able to iterate over all the inner maps, this is much slower than using a struct as a key

See tests below:

```go
func BenchmarkMulti(b *testing.B) {
	b.Run("nested-outer", func(b *testing.B) {
		var m map[string]map[string]struct{}
		for n := 0; n < b.N; n++ {
			m = map[string]map[string]struct{}{}
			for outer := 0; outer < 100; outer++ {
				o := strconv.Itoa(outer)
				for inner := 0; inner < 1; inner++ {
					i := strconv.Itoa(outer)
					if _, f := m[o]; !f {
						m[o] = map[string]struct{}{}
					}
					m[o][i] = struct{}{}
				}
			}
		}
	})
	b.Run("nested-inner", func(b *testing.B) {
		var m map[string]map[string]struct{}
		for n := 0; n < b.N; n++ {
			m = map[string]map[string]struct{}{}
			for outer := 0; outer < 1; outer++ {
				o := strconv.Itoa(outer)
				for inner := 0; inner < 100; inner++ {
					i := strconv.Itoa(outer)
					if _, f := m[o]; !f {
						m[o] = map[string]struct{}{}
					}
					m[o][i] = struct{}{}
				}
			}
		}
	})
	b.Run("nested-both", func(b *testing.B) {
		var m map[string]map[string]struct{}
		for n := 0; n < b.N; n++ {
			m = map[string]map[string]struct{}{}
			for outer := 0; outer < 100; outer++ {
				o := strconv.Itoa(outer)
				for inner := 0; inner < 100; inner++ {
					i := strconv.Itoa(outer)
					if _, f := m[o]; !f {
						m[o] = map[string]struct{}{}
					}
					m[o][i] = struct{}{}
				}
			}
		}
	})
	b.Run("tuple-outer", func(b *testing.B) {
		var m map[tuple]struct{}
		for n := 0; n < b.N; n++ {
			m = map[tuple]struct{}{}
			for outer := 0; outer < 100; outer++ {
				o := strconv.Itoa(outer)
				for inner := 0; inner < 1; inner++ {
					i := strconv.Itoa(outer)
					m[tuple{o, i}] = struct{}{}
				}
			}
		}
	})
	b.Run("tuple-inner", func(b *testing.B) {
		var m map[tuple]struct{}
		for n := 0; n < b.N; n++ {
			m = map[tuple]struct{}{}
			for outer := 0; outer < 1; outer++ {
				o := strconv.Itoa(outer)
				for inner := 0; inner < 100; inner++ {
					i := strconv.Itoa(outer)
					m[tuple{o, i}] = struct{}{}
				}
			}
		}
	})
	b.Run("tuple-both", func(b *testing.B) {
		var m map[tuple]struct{}
		for n := 0; n < b.N; n++ {
			m = map[tuple]struct{}{}
			for outer := 0; outer < 100; outer++ {
				o := strconv.Itoa(outer)
				for inner := 0; inner < 100; inner++ {
					i := strconv.Itoa(outer)
					m[tuple{o, i}] = struct{}{}
				}
			}
		}
	})
}

type tuple struct {
	a, b string
}
```

```
BenchmarkMulti
BenchmarkMulti/nested-outer
BenchmarkMulti/nested-outer-8              54590             22319 ns/op           27273 B/op        209 allocs/op
BenchmarkMulti/nested-inner
BenchmarkMulti/nested-inner-8             740229              1724 ns/op             448 B/op          4 allocs/op
BenchmarkMulti/nested-both
BenchmarkMulti/nested-both-8                4005            300571 ns/op           27282 B/op        209 allocs/op
BenchmarkMulti/tuple-outer
BenchmarkMulti/tuple-outer-8              120422              9589 ns/op           10507 B/op         11 allocs/op
BenchmarkMulti/tuple-inner
BenchmarkMulti/tuple-inner-8              631408              2026 ns/op             336 B/op          2 allocs/op
BenchmarkMulti/tuple-both
BenchmarkMulti/tuple-both-8                 5490            234907 ns/op           10516 B/op         11 allocs/op
```