### PR TITLE
Set started bool for memory controller

### DIFF
--- a/pilot/pkg/config/memory/controller.go
+++ b/pilot/pkg/config/memory/controller.go
@@ -84,6 +84,7 @@ func (c *Controller) HasSynced() bool {
 }
 
 func (c *Controller) Run(stop <-chan struct{}) {
+	c.started.Store(true)
 	c.monitor.Run(stop)
 }
 


### PR DESCRIPTION
**Please provide a description of this PR:**

The `started` bool in the controller struct currently does not get set when the controller run function is called