### PR TITLE
Overwrite default tag instead of remove in non-revisioned installation

### DIFF
--- a/operator/cmd/mesh/install.go
+++ b/operator/cmd/mesh/install.go
@@ -199,10 +199,6 @@ func Install(rootArgs *RootArgs, iArgs *InstallArgs, logOpts *log.Options, stdOu
 	isDefaultInstallation := rev == "" && iop.Spec.Components.Pilot != nil && iop.Spec.Components.Pilot.Enabled.Value
 	operatorManageWebhooks := operatorManageWebhooks(iop)
 
-	if !operatorManageWebhooks && isDefaultInstallation {
-		_ = revtag.DeleteTagWebhooks(context.Background(), kubeClient.Kube(), revtag.DefaultRevisionName)
-	}
-
 	iop, err = InstallManifests(iop, iArgs.Force, rootArgs.DryRun, kubeClient, client, iArgs.ReadinessTimeout, l)
 	if err != nil {
 		return fmt.Errorf("failed to install manifests: %v", err)


### PR DESCRIPTION
**Please provide a description of this PR:**
It seems that removing default tag webhooks per every `istioctl install` without revision is not needed.
They will be overwritten later on: https://github.com/istio/istio/blob/d8e3f8cca4d97fd6e41d8d6ff640bb3638ca9fa3/operator/cmd/mesh/install.go#L225
- See also: https://github.com/istio/istio/issues/40134