### PR TITLE
Simplify configs for TestTunnelingOutboundTraffic

### DIFF
--- a/tests/integration/pilot/testdata/tunneling/gateway/tls/istio-mutual/mtls.tmpl.yaml
+++ b/tests/integration/pilot/testdata/tunneling/gateway/tls/istio-mutual/mtls.tmpl.yaml
@@ -1,20 +1,10 @@
 apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
-  name: originate-tls-for-external-svc
+  name: originate-mtls-for-egress-gateway
 spec:
   host: istio-egressgateway.istio-system.svc.cluster.local
-  subsets:
-  - name: originate-tls-for-external-svc
-    trafficPolicy:
-      portLevelSettings:
-      - port:
-          number: 80
-        tls:
-          mode: ISTIO_MUTUAL
-          sni: external.{{ .externalNamespace }}.svc.cluster.local
-      - port:
-          number: 443
-        tls:
-          mode: ISTIO_MUTUAL
-          sni: external.{{ .externalNamespace }}.svc.cluster.local
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+      sni: external.{{ .externalNamespace }}.svc.cluster.local

--- a/tests/integration/pilot/testdata/tunneling/gateway/tls/istio-mutual/virtual-service.tmpl.yaml
+++ b/tests/integration/pilot/testdata/tunneling/gateway/tls/istio-mutual/virtual-service.tmpl.yaml
@@ -13,7 +13,6 @@ spec:
     route:
     - destination:
         host: istio-egressgateway.istio-system.svc.cluster.local
-        subset: originate-tls-for-external-svc
         port:
           number: 80
   tls:
@@ -24,7 +23,6 @@ spec:
     route:
     - destination:
         host: istio-egressgateway.istio-system.svc.cluster.local
-        subset: originate-tls-for-external-svc
         port:
           number: 443
 ---


### PR DESCRIPTION
This change just simplifies two configs used in `TestTunnelingOutboundTraffic` which are unnecessarily complicated.

Signed-off-by: Jacek Ewertowski <jewertow@redhat.com>