### PR TITLE
Fix(injection-template): [istio/istio#41167] Add support for the proxy-init resources parameter

### DIFF
--- a/manifests/charts/istiod-remote/files/injection-template.yaml
+++ b/manifests/charts/istiod-remote/files/injection-template.yaml
@@ -128,7 +128,11 @@ spec:
     {{- end }}
   {{- end }}
     resources:
-  {{ template "resources" . }}
+    {{- if .Values.global.proxy_init.resources }}
+      {{ toYaml .Values.global.proxy_init.resources | indent 6 }}
+    {{ else }}
+      {{ template "resources" . }}
+    {{- end }}
     securityContext:
       allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
       privileged: {{ .Values.global.proxy.privileged }}


### PR DESCRIPTION

This is to address the issue #41167 , so adding the proxy-init resources support in the injector to be able to define a different value for the istio-proxy resources and the istio-init. 