### PR TITLE
Fix ServiceEntry endpoint port setting order (#38661)

### DIFF
--- a/pilot/pkg/serviceregistry/serviceentry/conversion.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion.go
@@ -368,20 +368,26 @@ func getTLSModeFromWorkloadEntry(wle *networking.WorkloadEntry) string {
 
 // The workload instance has pointer to the service and its service port.
 // We need to create our own but we can retain the endpoint already created.
-func convertWorkloadInstanceToServiceInstance(workloadInstance *model.IstioEndpoint, serviceEntryServices []*model.Service,
+func convertWorkloadInstanceToServiceInstance(workloadInstance *model.WorkloadInstance, serviceEntryServices []*model.Service,
 	serviceEntry *networking.ServiceEntry) []*model.ServiceInstance {
 	out := make([]*model.ServiceInstance, 0)
 	for _, service := range serviceEntryServices {
 		for _, serviceEntryPort := range serviceEntry.Ports {
-			ep := *workloadInstance
-			ep.ServicePortName = serviceEntryPort.Name
-			// if target port is set, use the target port else fallback to the service port
-			// TODO: we need a way to get the container port map from k8s
-			if serviceEntryPort.TargetPort > 0 {
-				ep.EndpointPort = serviceEntryPort.TargetPort
+			// note: this is same as workloadentry handler
+			// endpoint port will first use the port defined in wle with same port name,
+			// if not port name not match, use the targetPort specified in ServiceEntry
+			// if both not matched, fallback to ServiceEntry port number.
+			var targetPort uint32
+			if port, ok := workloadInstance.PortMap[serviceEntryPort.Name]; ok && port > 0 {
+				targetPort = port
+			} else if serviceEntryPort.TargetPort > 0 {
+				targetPort = serviceEntryPort.TargetPort
 			} else {
-				ep.EndpointPort = serviceEntryPort.Number
+				targetPort = serviceEntryPort.Number
 			}
+			ep := *workloadInstance.Endpoint
+			ep.ServicePortName = serviceEntryPort.Name
+			ep.EndpointPort = targetPort
 			ep.EnvoyEndpoint = nil
 			out = append(out, &model.ServiceInstance{
 				Endpoint:    &ep,

--- a/pilot/pkg/serviceregistry/serviceentry/servicediscovery.go
+++ b/pilot/pkg/serviceregistry/serviceentry/servicediscovery.go
@@ -504,7 +504,7 @@ func (s *Controller) WorkloadInstanceHandler(wi *model.WorkloadInstance, event m
 		}
 		seNamespacedName := types.NamespacedName{Namespace: cfg.Namespace, Name: cfg.Name}
 		services := s.services.getServices(seNamespacedName)
-		instance := convertWorkloadInstanceToServiceInstance(wi.Endpoint, services, se)
+		instance := convertWorkloadInstanceToServiceInstance(wi, services, se)
 		instances = append(instances, instance...)
 		if addressToDelete != "" {
 			for _, i := range instance {
@@ -986,7 +986,7 @@ func (s *Controller) buildServiceInstances(
 					currentServiceEntry.Hosts)
 				continue
 			}
-			instances := convertWorkloadInstanceToServiceInstance(wi.Endpoint, services, currentServiceEntry)
+			instances := convertWorkloadInstanceToServiceInstance(wi, services, currentServiceEntry)
 			serviceInstances = append(serviceInstances, instances...)
 			ckey := configKey{namespace: wi.Namespace, name: wi.Name}
 			if wi.Kind == model.PodKind {

--- a/pilot/pkg/serviceregistry/serviceregistry_test.go
+++ b/pilot/pkg/serviceregistry/serviceregistry_test.go
@@ -291,6 +291,39 @@ func TestWorkloadInstances(t *testing.T) {
 		expectServiceInstances(t, wc, expectedSvc, 80, instances)
 	})
 
+	t.Run("External only: the port name of the workloadEntry and serviceEntry does match, "+
+		"serviceEntry's targetPort not equal workloadEntry's, use workloadEntry port to override", func(t *testing.T) {
+		_, wc, store, _, _ := setupTest(t)
+		se := serviceEntry.Spec.(*networking.ServiceEntry).DeepCopy()
+		se.Ports[0].TargetPort = 8081 // respect wle port firstly, does not care about this value at all.
+
+		makeIstioObject(t, store, config.Config{
+			Meta: config.Meta{
+				Name:             "workload",
+				Namespace:        namespace,
+				GroupVersionKind: gvk.WorkloadEntry,
+				Domain:           "cluster.local",
+			},
+			Spec: &networking.WorkloadEntry{
+				Address: "2.3.4.5",
+				Labels:  labels,
+				Ports: map[string]uint32{
+					serviceEntry.Spec.(*networking.ServiceEntry).Ports[0].Name: 8080,
+				},
+			},
+		})
+
+		makeIstioObject(t, store, serviceEntry)
+
+		instances := []ServiceInstanceResponse{{
+			Hostname:   expectedSvc.Hostname,
+			Namestring: expectedSvc.Attributes.Namespace,
+			Address:    workloadEntry.Spec.(*networking.WorkloadEntry).Address,
+			Port:       8080,
+		}}
+		expectServiceInstances(t, wc, expectedSvc, 80, instances)
+	})
+
 	t.Run("External only: workloadEntry port is not set, use target port", func(t *testing.T) {
 		_, wc, store, _, _ := setupTest(t)
 		makeIstioObject(t, store, config.Config{


### PR DESCRIPTION
**Please provide a description of this PR:**

This was never back ported to 1.14 due to proximity to branch cut

manual cherry-pick of #38661