### PR TITLE
Pilot: Add a guard against empty TRUSTED_GATEWAY_CIDR feature

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -415,7 +415,14 @@ var (
 	)
 
 	TrustedGatewayCIDR = func() []string {
-		return strings.Split(trustedGatewayCIDR.Get(), ",")
+		cidr := trustedGatewayCIDR.Get()
+
+		// splitting the empty string will result [""]
+		if cidr == "" {
+			return []string{}
+		}
+
+		return strings.Split(cidr, ",")
 	}()
 
 	EnableServiceEntrySelectPods = env.Register("PILOT_ENABLE_SERVICEENTRY_SELECT_PODS", true,

--- a/releasenotes/notes/41171.yaml
+++ b/releasenotes/notes/41171.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: security
+issue: []
+releaseNotes:
+- |
+  **Updated** the default value for TRUSTED_GATEWAY_CIDR.
+
+  Previously this was empty which implicitly caused the
+  XfccAuthenticator to disallow non-loopback requests.


### PR DESCRIPTION
What
----

Pilot: Add a guard against empty value for `TRUSTED_GATEWAY_CIDR` feature

Refer to original implementation PR #39405

Context
--------

In my multi cluster istio set up on 1.15 I observe logs with the following error

```
caller from [an RFC 1918 IP address from one of my clusters] is not in the trusted network
```

In Go, splitting the empty string will result in a string slice of length 1, ie `[""]` and splitting the delimiter string (eg `strings.Split(",", ",")`) will result in a string slice of length 2, ie `["", ""]`. Refer to playground https://go.dev/play/p/mFXBRg-AnkL

If this environment variable `TRUSTED_GATEWAY_CIDR` is not set, then `features.TrustedGatewayCIDR` defaults to `[""]`

Later this feature is used in the following code:
```
# security/pkg/server/ca/authenticate/xfcc_authenticator.go
  if !isTrustedAddress(peerInfo.Addr.String(), features.TrustedGatewayCIDR) {
    return nil, fmt.Errorf("caller from %s is not in the trusted network. XfccAuthenticator can not be used", peerInfo.Addr.String())
```
which I observe in my multi cluster istio set up

because of the function isTrustedAddress which wraps isInRange:
```
# security/pkg/server/ca/authenticate/xfcc_authenticator.go
  if strings.Contains(cidr, "/") { // empty string will not match here
    ...
  }
  return false # always false for empty string then
```

As such this means only loopback (refer to `isTrustedAddress`) is allowed via `XfccAuthenticator`, which does not seem like the desired outcome given the `len(features.TrustedGatewayCIDR)` check in `pilot/pkg/bootstrap/server.go`

---




_I believe this does have security implications. Right now XfccAuthenticator is denying any non-local cluster interaction, and this code change will disable it unless `TRUSTED_GATEWAY_CIDR` is configured_