### PR TITLE
Guarding nil-pointer for MeshConfig.ServiceSettings.Settings

### DIFF
--- a/pilot/pkg/model/cluster_local.go
+++ b/pilot/pkg/model/cluster_local.go
@@ -95,16 +95,13 @@ func (c *clusterLocalProvider) onMeshUpdated(e *Environment) {
 	// Collect the cluster-local hosts.
 	hosts := make(ClusterLocalHosts, 0)
 	for _, serviceSettings := range e.Mesh().ServiceSettings {
-		if serviceSettings == nil {
-			continue
-		}
-		if serviceSettings.Settings.GetClusterLocal() {
-			for _, h := range serviceSettings.Hosts {
+		if serviceSettings.GetSettings().GetClusterLocal() {
+			for _, h := range serviceSettings.GetHosts() {
 				hosts[host.Name(h)] = struct{}{}
 			}
 		} else {
 			// Remove defaults if specified to be non-cluster-local.
-			for _, h := range serviceSettings.Hosts {
+			for _, h := range serviceSettings.GetHosts() {
 				for i, defaultClusterLocalHost := range defaultClusterLocalHosts {
 					if len(defaultClusterLocalHost) > 0 {
 						if h == string(defaultClusterLocalHost) ||

--- a/pilot/pkg/model/cluster_local.go
+++ b/pilot/pkg/model/cluster_local.go
@@ -95,7 +95,10 @@ func (c *clusterLocalProvider) onMeshUpdated(e *Environment) {
 	// Collect the cluster-local hosts.
 	hosts := make(ClusterLocalHosts, 0)
 	for _, serviceSettings := range e.Mesh().ServiceSettings {
-		if serviceSettings.Settings.ClusterLocal {
+		if serviceSettings == nil {
+			continue
+		}
+		if serviceSettings.Settings.GetClusterLocal() {
 			for _, h := range serviceSettings.Hosts {
 				hosts[host.Name(h)] = struct{}{}
 			}


### PR DESCRIPTION
To avoid nil-pointer exception, this PR guards the nil-pointer for MeshConfig.ServiceSettings.Settings.

