### PR TITLE
create istio-ca-root-cert cm in namespaces selected by discoverySelectors

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -667,8 +667,8 @@ var (
 	SidecarIgnorePort = env.Register("SIDECAR_IGNORE_PORT_IN_HOST_MATCH", true, "If enabled, port will not be used in vhost domain matches.").Get()
 
 	EnableEnhancedResourceScoping = env.Register("ENABLE_ENHANCED_RESOURCE_SCOPING", false,
-		"If enabled, meshConfig.discoverySelectors will also limit the configurations(like Gateway,VirtualService,DestinationRule,Ingress, etc)"+
-			"that can be processed by pilot.").Get()
+		"If enabled, meshConfig.discoverySelectors will limit the CustomResource configurations(like Gateway,VirtualService,DestinationRule,Ingress, etc)"+
+			"that can be processed by pilot. This will also restrict the root-ca certificate distribution.").Get()
 
 	EnableLeaderElection = env.Register("ENABLE_LEADER_ELECTION", true,
 		"If enabled (default), starts a leader election client and gains leadership before executing controllers. "+

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -39,6 +39,7 @@ import (
 	"istio.io/istio/pkg/config/schema/collections"
 	kubelib "istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/multicluster"
+	"istio.io/istio/pkg/kube/namespace"
 	"istio.io/istio/pkg/webhooks"
 )
 
@@ -256,6 +257,12 @@ func (m *Multicluster) initializeCluster(cluster *multicluster.Cluster, kubeCont
 		}
 	}
 
+	// namespacecontroller requires discoverySelectors only if EnableEnhancedResourceScoping feature flag is set.
+	discoveryNamespacesFilter := namespace.DiscoveryNamespacesFilter(nil)
+	if features.EnableEnhancedResourceScoping {
+		discoveryNamespacesFilter = kubeRegistry.opts.DiscoveryNamespacesFilter
+	}
+
 	// run after WorkloadHandler is added
 	m.opts.MeshServiceController.AddRegistryAndRun(kubeRegistry, clusterStopCh)
 
@@ -271,7 +278,7 @@ func (m *Multicluster) initializeCluster(cluster *multicluster.Cluster, kubeCont
 				NewLeaderElectionMulticluster(options.SystemNamespace, m.serverID, leaderelection.NamespaceController, m.revision, !configCluster, client).
 				AddRunFunction(func(leaderStop <-chan struct{}) {
 					log.Infof("starting namespace controller for cluster %s", cluster.ID)
-					nc := NewNamespaceController(client, m.caBundleWatcher, kubeRegistry.opts.DiscoveryNamespacesFilter)
+					nc := NewNamespaceController(client, m.caBundleWatcher, discoveryNamespacesFilter)
 					// Start informers again. This fixes the case where informers for namespace do not start,
 					// as we create them only after acquiring the leader lock
 					// Note: stop here should be the overall pilot stop, NOT the leader election stop. We are

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -271,7 +271,7 @@ func (m *Multicluster) initializeCluster(cluster *multicluster.Cluster, kubeCont
 				NewLeaderElectionMulticluster(options.SystemNamespace, m.serverID, leaderelection.NamespaceController, m.revision, !configCluster, client).
 				AddRunFunction(func(leaderStop <-chan struct{}) {
 					log.Infof("starting namespace controller for cluster %s", cluster.ID)
-					nc := NewNamespaceController(client, m.caBundleWatcher)
+					nc := NewNamespaceController(client, m.caBundleWatcher, kubeRegistry.opts.DiscoveryNamespacesFilter)
 					// Start informers again. This fixes the case where informers for namespace do not start,
 					// as we create them only after acquiring the leader lock
 					// Note: stop here should be the overall pilot stop, NOT the leader election stop. We are

--- a/pilot/pkg/serviceregistry/kube/controller/namespacecontroller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/namespacecontroller.go
@@ -158,5 +158,9 @@ func (nc *NamespaceController) syncNamespace(ns string) {
 	if inject.IgnoredNamespaces.Contains(ns) {
 		return
 	}
+	// skip namespaces we don't watch
+	if features.EnableEnhancedResourceScoping && !nc.DiscoveryNamespacesFilter.FilterNamespace(ns) {
+		return
+	}
 	nc.queue.Add(types.NamespacedName{Name: ns})
 }

--- a/pilot/pkg/serviceregistry/kube/controller/namespacecontroller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/namespacecontroller.go
@@ -25,10 +25,10 @@ import (
 
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/keycertbundle"
-	"istio.io/istio/pilot/pkg/serviceregistry/kube/controller/filter"
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/controllers"
 	"istio.io/istio/pkg/kube/inject"
+	filter "istio.io/istio/pkg/kube/namespace"
 	"istio.io/istio/security/pkg/k8s"
 )
 

--- a/pilot/pkg/serviceregistry/kube/controller/namespacecontroller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/namespacecontroller.go
@@ -75,12 +75,12 @@ func NewNamespaceController(kubeClient kube.Client, caBundleWatcher *keycertbund
 			// This is a change to a configmap we don't watch, ignore it
 			return false
 		}
-		if features.EnableEnhancedResourceScoping && !c.DiscoveryNamespacesFilter.Filter(o.GetNamespace()) {
-			// This is a change to a configmap we don't watch, ignore it
-			return false
-		}
 		if inject.IgnoredNamespaces.Contains(o.GetNamespace()) {
 			// skip special kubernetes system namespaces
+			return false
+		}
+		if features.EnableEnhancedResourceScoping && !c.DiscoveryNamespacesFilter.Filter(o) {
+			// This is a change to a configmap we don't watch, ignore it
 			return false
 		}
 		return true
@@ -90,7 +90,7 @@ func NewNamespaceController(kubeClient kube.Client, caBundleWatcher *keycertbund
 			// skip special kubernetes system namespaces
 			return false
 		}
-		if features.EnableEnhancedResourceScoping && !c.DiscoveryNamespacesFilter.Filter(o.GetName()) {
+		if features.EnableEnhancedResourceScoping && !c.DiscoveryNamespacesFilter.FilterNamespace(o.GetName()) {
 			// This is a change to a namespace we don't watch, ignore it
 			return false
 		}

--- a/pilot/pkg/serviceregistry/kube/controller/namespacecontroller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/namespacecontroller.go
@@ -56,7 +56,8 @@ type NamespaceController struct {
 
 // NewNamespaceController returns a pointer to a newly constructed NamespaceController instance.
 func NewNamespaceController(kubeClient kube.Client, caBundleWatcher *keycertbundle.Watcher,
-	discoveryNamespacesFilter filter.DiscoveryNamespacesFilter) *NamespaceController {
+	discoveryNamespacesFilter filter.DiscoveryNamespacesFilter,
+) *NamespaceController {
 	c := &NamespaceController{
 		client:                    kubeClient.Kube().CoreV1(),
 		caBundleWatcher:           caBundleWatcher,

--- a/pilot/pkg/serviceregistry/kube/controller/namespacecontroller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/namespacecontroller_test.go
@@ -21,6 +21,11 @@ import (
 	"testing"
 	"time"
 
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	listerv1 "k8s.io/client-go/listers/core/v1"
+
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/keycertbundle"
@@ -31,10 +36,6 @@ import (
 	"istio.io/istio/pkg/kube/inject"
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/util/retry"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
-	listerv1 "k8s.io/client-go/listers/core/v1"
 )
 
 func TestNamespaceController(t *testing.T) {

--- a/pilot/pkg/serviceregistry/kube/controller/namespacecontroller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/namespacecontroller_test.go
@@ -32,7 +32,6 @@ import (
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/util/retry"
 	v1 "k8s.io/api/core/v1"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	listerv1 "k8s.io/client-go/listers/core/v1"
@@ -97,7 +96,8 @@ func TestNamespaceControllerWithDiscoverySelectors(t *testing.T) {
 					"discovery-selectors": "enabled",
 				},
 			},
-		}})
+		},
+	})
 	discoveryNamespacesFilter := filter.NewDiscoveryNamespacesFilter(
 		client.KubeInformer().Core().V1().Namespaces().Lister(),
 		meshWatcher.Mesh().DiscoverySelectors,
@@ -118,8 +118,8 @@ func TestNamespaceControllerWithDiscoverySelectors(t *testing.T) {
 
 	createNamespace(t, client.Kube(), nsA, map[string]string{"discovery-selectors": "enabled"})
 	createNamespace(t, client.Kube(), nsB, map[string]string{})
-	ns1, _ := client.Kube().CoreV1().Namespaces().Get(context.TODO(), nsA, metaV1.GetOptions{})
-	ns2, _ := client.Kube().CoreV1().Namespaces().Get(context.TODO(), nsB, metaV1.GetOptions{})
+	ns1, _ := client.Kube().CoreV1().Namespaces().Get(context.TODO(), nsA, metav1.GetOptions{})
+	ns2, _ := client.Kube().CoreV1().Namespaces().Get(context.TODO(), nsB, metav1.GetOptions{})
 	discoveryNamespacesFilter.NamespaceCreated(ns1.ObjectMeta)
 	discoveryNamespacesFilter.NamespaceCreated(ns2.ObjectMeta)
 	expectConfigMap(t, nc.configmapLister, CACertNamespaceConfigMap, nsA, expectedData)

--- a/pilot/pkg/serviceregistry/kube/controller/namespacecontroller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/namespacecontroller_test.go
@@ -29,11 +29,11 @@ import (
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/keycertbundle"
-	"istio.io/istio/pilot/pkg/serviceregistry/kube/controller/filter"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/inject"
+	filter "istio.io/istio/pkg/kube/namespace"
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/util/retry"
 )

--- a/pkg/kube/namespace/filter.go
+++ b/pkg/kube/namespace/filter.go
@@ -32,7 +32,7 @@ type DiscoveryNamespacesFilter interface {
 	// Filter returns true if the input object resides in a namespace selected for discovery
 	Filter(obj any) bool
 	// FilterNamespace returns true if the input namespace is a namespace selected for discovery
-	FilterNamespace(namespace string) bool
+	FilterNamespace(nsMeta metav1.ObjectMeta) bool
 	// SelectorsChanged is invoked when meshConfig's discoverySelectors change, returns any newly selected namespaces and deselected namespaces
 	SelectorsChanged(discoverySelectors []*metav1.LabelSelector) (selectedNamespaces []string, deselectedNamespaces []string)
 	// SyncNamespaces is invoked when namespace informer hasSynced before other controller SyncAll
@@ -93,16 +93,8 @@ func (d *discoveryNamespacesFilter) Filter(obj any) bool {
 	return d.discoveryNamespaces.Contains(object.GetNamespace())
 }
 
-func (d *discoveryNamespacesFilter) FilterNamespace(namespace string) bool {
-	d.lock.RLock()
-	defer d.lock.RUnlock()
-
-	// permit all namespaces if discovery selectors are not specified
-	if len(d.discoverySelectors) == 0 {
-		return true
-	}
-
-	return d.discoveryNamespaces.Contains(namespace)
+func (d *discoveryNamespacesFilter) FilterNamespace(nsMeta metav1.ObjectMeta) bool {
+	return d.isSelected(nsMeta.Labels)
 }
 
 // SelectorsChanged initializes the discovery filter state with the discovery selectors and selected namespaces

--- a/pkg/kube/namespace/filter.go
+++ b/pkg/kube/namespace/filter.go
@@ -73,6 +73,7 @@ func (d *discoveryNamespacesFilter) Filter(obj any) bool {
 	if len(d.discoverySelectors) == 0 {
 		return true
 	}
+
 	// When an object is deleted, obj could be a DeletionFinalStateUnknown marker item.
 	object, ok := obj.(metav1.Object)
 	if !ok {

--- a/releasenotes/notes/scope-root-ca-configmap.yaml
+++ b/releasenotes/notes/scope-root-ca-configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+releaseNotes:
+   - |
+     **Updated** `meshConfig.discoverySelectors` to dynamically restrict the set of namespaces where istiod create istio-ca-root-cert configmap.
+docs:
+   - https://docs.google.com/document/d/1y4liRJbQW0NCMeQtqMma46flVqs-izV1/

--- a/releasenotes/notes/scope-root-ca-configmap.yaml
+++ b/releasenotes/notes/scope-root-ca-configmap.yaml
@@ -3,6 +3,7 @@ kind: feature
 area: traffic-management
 releaseNotes:
    - |
-     **Updated** `meshConfig.discoverySelectors` to dynamically restrict the set of namespaces where istiod create istio-ca-root-cert configmap.
+     **Updated** `meshConfig.discoverySelectors` to dynamically restrict the set of namespaces where istiod creates istio-ca-root-cert configmap
+     if `ENABLE_ENHANCED_RESOURCE_SCOPING` feature flag is enabled.
 docs:
    - https://docs.google.com/document/d/1y4liRJbQW0NCMeQtqMma46flVqs-izV1/


### PR DESCRIPTION
For more details see : https://github.com/istio/istio/pull/36639#issuecomment-1249854121

In order to support multiple istio deployments in the same k8s cluster as mentioned in the [RFC](https://docs.google.com/document/d/1y4liRJbQW0NCMeQtqMma46flVqs-izV1/edit), it is needed to have a mechanism to scope the root-ca config map creation appropriately.

Signed-off-by: Faseela K <faseela.k@est.tech>