### PR TITLE
fix: Fix the link address

### DIFF
--- a/cni/README.md
+++ b/cni/README.md
@@ -101,7 +101,7 @@ $ gcloud logging read "resource.type=k8s_node AND jsonPayload.SYSLOG_IDENTIFIER=
 ## Reference
 
 The framework for this implementation of the CNI plugin is based on the
-[containernetworking sample plugin](https://github.com/containernetworking/plugins/tree/master/plugins/sample)
+[containernetworking sample plugin](https://github.com/containernetworking/plugins/tree/main/plugins/sample)
 
 The details for the deployment & installation of this plugin were pretty much lifted directly from the
 [Calico CNI plugin](https://github.com/projectcalico/cni-plugin).


### PR DESCRIPTION
**Please provide a description of this PR:**

The CNI plugin repo is not correct because its branch is renamed from master to main