### PR TITLE
do not apply rate limits for sds server

### DIFF
--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -147,17 +147,13 @@ func (s *DiscoveryServer) receive(con *Connection, identities []string) {
 		req, err := con.stream.Recv()
 		if err != nil {
 			if istiogrpc.IsExpectedGRPCError(err) {
-				if req != nil && req.TypeUrl == v3.SecretType {
-					log.Infof("ADS: connection terminated for secrets:%v", strings.Join(req.ResourceNames, ","))
-				} else {
+				if req != nil && req.TypeUrl != v3.SecretType {
 					log.Infof("ADS: %q %s terminated", con.peerAddr, con.conID)
 				}
 				return
 			}
 			con.errorChan <- err
-			if req != nil && req.TypeUrl == v3.SecretType {
-				log.Infof("ADS:connection terminated for secrets %v, with error:%v", strings.Join(req.ResourceNames, ","), err)
-			} else {
+			if req != nil && req.TypeUrl != v3.SecretType {
 				log.Errorf("ADS: %q %s terminated with error: %v", con.peerAddr, con.conID, err)
 			}
 			totalXDSInternalErrors.Increment()
@@ -180,9 +176,7 @@ func (s *DiscoveryServer) receive(con *Connection, identities []string) {
 				return
 			}
 			defer s.closeConnection(con)
-			if req != nil && req.TypeUrl == v3.SecretType {
-				log.Infof("ADS: new connection for secrets:%v", strings.Join(req.ResourceNames, ","))
-			} else {
+			if req != nil && req.TypeUrl != v3.SecretType {
 				log.Infof("ADS: new connection for node:%s", con.conID)
 			}
 		}

--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -148,7 +148,11 @@ func (s *DiscoveryServer) receive(con *Connection, identities []string) {
 		if err != nil {
 			if istiogrpc.IsExpectedGRPCError(err) {
 				if s.SdsServer {
-					log.Infof("ADS: connection terminated for secrets:%v", req.ResourceNames)
+					secrets := ""
+					if req != nil {
+						secrets = strings.Join(req.ResourceNames, ",")
+					}
+					log.Infof("ADS: connection terminated for secrets:%v", secrets)
 				} else {
 					log.Infof("ADS: %q %s terminated", con.peerAddr, con.conID)
 				}
@@ -156,7 +160,11 @@ func (s *DiscoveryServer) receive(con *Connection, identities []string) {
 			}
 			con.errorChan <- err
 			if s.SdsServer {
-				log.Infof("ADS:connection terminated for secrets %v, with error:%v", req.ResourceNames, err)
+				secrets := ""
+				if req != nil {
+					secrets = strings.Join(req.ResourceNames, ",")
+				}
+				log.Infof("ADS:connection terminated for secrets %v, with error:%v", secrets, err)
 			} else {
 				log.Errorf("ADS: %q %s terminated with error: %v", con.peerAddr, con.conID, err)
 			}

--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -147,15 +147,11 @@ func (s *DiscoveryServer) receive(con *Connection, identities []string) {
 		req, err := con.stream.Recv()
 		if err != nil {
 			if istiogrpc.IsExpectedGRPCError(err) {
-				if req != nil && req.TypeUrl != v3.SecretType {
-					log.Infof("ADS: %q %s terminated", con.peerAddr, con.conID)
-				}
+				log.Infof("ADS: %q %s terminated", con.peerAddr, con.conID)
 				return
 			}
 			con.errorChan <- err
-			if req != nil && req.TypeUrl != v3.SecretType {
-				log.Errorf("ADS: %q %s terminated with error: %v", con.peerAddr, con.conID, err)
-			}
+			log.Errorf("ADS: %q %s terminated with error: %v", con.peerAddr, con.conID, err)
 			totalXDSInternalErrors.Increment()
 			return
 		}
@@ -176,9 +172,7 @@ func (s *DiscoveryServer) receive(con *Connection, identities []string) {
 				return
 			}
 			defer s.closeConnection(con)
-			if req != nil && req.TypeUrl != v3.SecretType {
-				log.Infof("ADS: new connection for node:%s", con.conID)
-			}
+			log.Infof("ADS: new connection for node:%s", con.conID)
 		}
 
 		select {

--- a/pilot/pkg/xds/discovery.go
+++ b/pilot/pkg/xds/discovery.go
@@ -154,6 +154,9 @@ type DiscoveryServer struct {
 	// ClusterAliases are aliase names for cluster. When a proxy connects with a cluster ID
 	// and if it has a different alias we should use that a cluster ID for proxy.
 	ClusterAliases map[cluster.ID]cluster.ID
+
+	// Indicates this is running as an Sds Server.
+	SdsServer bool
 }
 
 // NewDiscoveryServer creates DiscoveryServer that sources data from Pilot's internal mesh data structures

--- a/security/pkg/nodeagent/sds/sdsservice.go
+++ b/security/pkg/nodeagent/sds/sdsservice.go
@@ -18,7 +18,6 @@ package sds
 import (
 	"context"
 	"fmt"
-	"math"
 	"time"
 
 	cryptomb "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/private_key_providers/cryptomb/v3alpha"
@@ -61,7 +60,7 @@ var _ model.XdsResourceGenerator = &sdsservice{}
 func NewXdsServer(stop chan struct{}, gen model.XdsResourceGenerator) *xds.DiscoveryServer {
 	s := xds.NewXDS(stop)
 	// No ratelimit for SDS calls in agent.
-	s.DiscoveryServer.RequestRateLimit = rate.NewLimiter(rate.Limit(math.MaxInt), 1)
+	s.DiscoveryServer.RequestRateLimit = rate.NewLimiter(rate.Inf, 1)
 	s.DiscoveryServer.Generators = map[string]model.XdsResourceGenerator{
 		v3.SecretType: gen,
 	}

--- a/security/pkg/nodeagent/sds/sdsservice.go
+++ b/security/pkg/nodeagent/sds/sdsservice.go
@@ -58,6 +58,7 @@ var _ model.XdsResourceGenerator = &sdsservice{}
 
 func NewXdsServer(stop chan struct{}, gen model.XdsResourceGenerator) *xds.DiscoveryServer {
 	s := xds.NewXDS(stop)
+	s.DiscoveryServer.SdsServer = true
 	s.DiscoveryServer.Generators = map[string]model.XdsResourceGenerator{
 		v3.SecretType: gen,
 	}

--- a/security/pkg/nodeagent/sds/sdsservice.go
+++ b/security/pkg/nodeagent/sds/sdsservice.go
@@ -60,7 +60,7 @@ var _ model.XdsResourceGenerator = &sdsservice{}
 func NewXdsServer(stop chan struct{}, gen model.XdsResourceGenerator) *xds.DiscoveryServer {
 	s := xds.NewXDS(stop)
 	// No ratelimit for SDS calls in agent.
-	s.DiscoveryServer.RequestRateLimit = rate.NewLimiter(rate.Inf, 1)
+	s.DiscoveryServer.RequestRateLimit = rate.NewLimiter(0, 1)
 	s.DiscoveryServer.Generators = map[string]model.XdsResourceGenerator{
 		v3.SecretType: gen,
 	}


### PR DESCRIPTION
When DiscoveryServer is instantiated as a SDS Service in agent, it applies default rate limit of 1 which prints log lines like this in agent
```
2022-09-29T03:33:23.234076Z	warn	ads	ADS: "@" exceeded rate limit: rate: Wait(n=1) would exceed context deadline
2022-09-29T03:33:23.234092Z	warn	ads	ADS: "@" exceeded rate limit: rate: Wait(n=1) would exceed context deadline
2022-09-29T03:33:23.234052Z	warn	ads	ADS: "@" exceeded rate limit: rate: Wait(n=1) would exceed context deadline
2022-09-29T03:33:23.234060Z	warn	ads	ADS: "@" exceeded rate limit: rate: Wait(n=1) would exceed context deadline
2022-09-29T03:33:23.234010Z	warn	ads	ADS: "@" exceeded rate limit: rate: Wait(n=1) would exceed context deadline
2022-09-29T03:33:23.234077Z	warn	ads	ADS: "@" exceeded rate limit: rate: Wait(n=1) would exceed context deadline
2022-09-29T03:33:23.234125Z	warn	ads	ADS: "@" exceeded rate limit: rate: Wait(n=1) would exceed context deadline
2022-09-29T03:33:23.234132Z	warn	ads	ADS: "@" exceeded rate limit: rate: Wait(n=1) would exceed context deadline
2022-09-29T03:33:23.234033Z	warn	ads	ADS: "@" exceeded rate limit: rate: Wait(n=1) would exceed context deadline
2022-09-29T03:33:23.234041Z	warn	ads	ADS: "@" exceeded rate limit: rate: Wait(n=1) would exceed context deadline
2022-09-29T03:33:23.234067Z	warn	ads	ADS: "@" exceeded rate limit: rate: Wait(n=1) would exceed context deadline
2022-09-29T03:33:23.234010Z	warn	ads	ADS: "@" exceeded rate limit: rate: Wait(n=1) would exceed context deadline
2022-09-29T03:33:23.234096Z	warn	ads	ADS: "@" exceeded rate limit: rate: Wait(n=1) would exceed context deadline
2022-09-29T03:33:23.234179Z	warn	ads	ADS: "@" exceeded rate limit: rate: Wait(n=1) would exceed context deadline
2022-09-29T03:33:23.234183Z	warn	ads	ADS: "@" exceeded rate limit: rate: Wait(n=1) would exceed context deadline
2022-09-29T03:33:23.234042Z	warn	ads	ADS: "@" exceeded rate limit: rate: Wait(n=1) would exceed context deadline
```

Also the log lines like 
```
2022-09-29T03:33:23.515201Z	info	ads	ADS: new connection for node:istio-ingressgateway-processing-us-west-2c-6c74f945bc-6cpvz.sfproxy-13
```
for every secret request is confusing.

This PR fixes both


- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure