### PR TITLE
Place `istio.metadata_exchange` before RBAC filters for network and HTTP filters

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -1304,6 +1304,9 @@ func buildHTTPConnectionManager(listenerOpts buildListenerOpts, httpOpts *httpLi
 
 	var filters []*hcm.HttpFilter
 
+	// Metadata exchange filter needs to be added before any other http filters are added. This is done to
+	// ensure that mx filter comes before HTTP RBAC filter (present in httpFilters object). This is related to
+	// https://github.com/tetrateio/tetrate/issues/13093
 	if features.MetadataExchange && util.CheckProxyVerionForMX(listenerOpts.push, listenerOpts.proxy.IstioVersion) {
 		filters = append(filters, xdsfilters.HTTPMx)
 	}

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -1302,12 +1302,13 @@ func buildHTTPConnectionManager(listenerOpts buildListenerOpts, httpOpts *httpLi
 
 	routerFilterCtx := configureTracing(listenerOpts, connectionManager)
 
-	filters := make([]*hcm.HttpFilter, len(httpFilters))
-	copy(filters, httpFilters)
+	var filters []*hcm.HttpFilter
 
 	if features.MetadataExchange && util.CheckProxyVerionForMX(listenerOpts.push, listenerOpts.proxy.IstioVersion) {
 		filters = append(filters, xdsfilters.HTTPMx)
 	}
+
+	filters = append(filters, httpFilters...)
 
 	if httpOpts.addGRPCWebFilter {
 		filters = append(filters, xdsfilters.GrpcWeb)


### PR DESCRIPTION
**Please provide a description of this PR:**
Fixes #41066 
In istio 1.12, RBAC filter shows up before metadata exchange filter for both network and HTTP (subfilters of `http_connection_manager`) filters. This was preventing the metadata to be populated for requests that were denied (403 in case of HTTP or dial failed for TCP) in OAP access logs. This PR fixes the order by putting RBAC filter(both network and http) before `istio.metadata_exchange` filter while generating network or http filters.

This exists even in istio 1.15 and will need a separate fix because a lot of code changed around plugins between 1.12 and 1.15.