### PR TITLE
Add leader election to protect mutatingwebhookconfiguration

### DIFF
--- a/pilot/pkg/bootstrap/sidecarinjector.go
+++ b/pilot/pkg/bootstrap/sidecarinjector.go
@@ -31,8 +31,6 @@ import (
 )
 
 const (
-	// Name of the webhook config in the config - no need to change it.
-	webhookName = "sidecar-injector.istio.io"
 	// defaultInjectorConfigMapName is the default name of the ConfigMap with the injection config
 	// The actual name can be different - use getInjectorConfigMapName
 	defaultInjectorConfigMapName = "istio-sidecar-injector"
@@ -93,7 +91,7 @@ func (s *Server) initSidecarInjector(args *PilotArgs) (*inject.Webhook, error) {
 		s.addStartFunc(func(stop <-chan struct{}) error {
 			// No leader election - different istiod revisions will patch their own cert.
 			// update webhook configuration by watching the cabundle
-			patcher, err := webhooks.NewWebhookCertPatcher(s.kubeClient, args.Revision, webhookName, s.istiodCertBundleWatcher)
+			patcher, err := webhooks.NewWebhookCertPatcher(s.kubeClient, args.Revision, s.istiodCertBundleWatcher)
 			if err != nil {
 				log.Errorf("failed to create webhook cert patcher: %v", err)
 				return nil

--- a/pilot/pkg/bootstrap/sidecarinjector.go
+++ b/pilot/pkg/bootstrap/sidecarinjector.go
@@ -99,7 +99,7 @@ func (s *Server) initSidecarInjector(args *PilotArgs) (*inject.Webhook, error) {
 						return
 					}
 					patcher.Run(leaderStop)
-				})
+				}).Run(stop)
 			return nil
 		})
 	}

--- a/pilot/pkg/bootstrap/sidecarinjector.go
+++ b/pilot/pkg/bootstrap/sidecarinjector.go
@@ -90,7 +90,8 @@ func (s *Server) initSidecarInjector(args *PilotArgs) (*inject.Webhook, error) {
 	// operator or CI/CD
 	if features.InjectionWebhookConfigName != "" {
 		s.addStartFunc(func(stop <-chan struct{}) error {
-			elector := leaderelection.NewLeaderElection(args.Namespace, args.PodName, leaderelection.SidecarInjectorController, args.Revision, s.kubeClient).
+			electionID := leaderelection.SidecarInjectorController + "-" + args.Revision
+			elector := leaderelection.NewLeaderElection(args.Namespace, args.PodName, electionID, args.Revision, s.kubeClient).
 				AddRunFunction(func(leaderStop <-chan struct{}) {
 					// update webhook configuration by watching the cabundle
 					patcher, err := webhooks.NewWebhookCertPatcher(s.kubeClient, args.Revision, s.istiodCertBundleWatcher)

--- a/pilot/pkg/leaderelection/leaderelection.go
+++ b/pilot/pkg/leaderelection/leaderelection.go
@@ -36,8 +36,9 @@ import (
 
 // Various locks used throughout the code
 const (
-	NamespaceController     = "istio-namespace-controller-election"
-	ServiceExportController = "istio-serviceexport-controller-election"
+	NamespaceController       = "istio-namespace-controller-election"
+	SidecarInjectorController = "istio-sidecar-injector-election"
+	ServiceExportController   = "istio-serviceexport-controller-election"
 	// This holds the legacy name to not conflict with older control plane deployments which are just
 	// doing the ingress syncing.
 	IngressController = "istio-leader"

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -287,8 +287,9 @@ func (m *Multicluster) initializeCluster(cluster *multicluster.Cluster, kubeRegi
 		// This requires RBAC permissions - a low-priv Istiod should not attempt to patch but rely on
 		// operator or CI/CD
 		if features.InjectionWebhookConfigName != "" {
+			electionID := leaderelection.SidecarInjectorController + "-" + m.revision
 			election := leaderelection.
-				NewLeaderElectionMulticluster(options.SystemNamespace, m.serverID, leaderelection.SidecarInjectorController, m.revision, true, client).
+				NewLeaderElectionMulticluster(options.SystemNamespace, m.serverID, electionID, m.revision, true, client).
 				AddRunFunction(func(leaderStop <-chan struct{}) {
 					log.Infof("initializing injection webhook cert patcher for cluster %s", cluster.ID)
 					patcher, err := webhooks.NewWebhookCertPatcher(client, m.revision, m.caBundleWatcher)

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -287,7 +287,7 @@ func (m *Multicluster) initializeCluster(cluster *multicluster.Cluster, kubeRegi
 		// This requires RBAC permissions - a low-priv Istiod should not attempt to patch but rely on
 		// operator or CI/CD
 		if features.InjectionWebhookConfigName != "" {
-			leaderelection.
+			election := leaderelection.
 				NewLeaderElectionMulticluster(options.SystemNamespace, m.serverID, leaderelection.SidecarInjectorController, m.revision, true, client).
 				AddRunFunction(func(leaderStop <-chan struct{}) {
 					log.Infof("initializing injection webhook cert patcher for cluster %s", cluster.ID)
@@ -303,7 +303,8 @@ func (m *Multicluster) initializeCluster(cluster *multicluster.Cluster, kubeRegi
 						client.RunAndWait(clusterStopCh)
 						patcher.Run(leaderStop)
 					}
-				}).Run(clusterStopCh)
+				})
+			go election.Run(clusterStopCh)
 		}
 	}
 

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -303,7 +303,7 @@ func (m *Multicluster) initializeCluster(cluster *multicluster.Cluster, kubeRegi
 						client.RunAndWait(clusterStopCh)
 						patcher.Run(leaderStop)
 					}
-				})
+				}).Run(clusterStopCh)
 		}
 	}
 

--- a/pkg/webhooks/webhookpatch_test.go
+++ b/pkg/webhooks/webhookpatch_test.go
@@ -57,20 +57,18 @@ func TestMutatingWebhookPatch(t *testing.T) {
 	watcher := &keycertbundle.Watcher{}
 	watcher.SetAndNotify(nil, nil, caBundle0)
 	ts := []struct {
-		name        string
-		configs     admissionregistrationv1.MutatingWebhookConfigurationList
-		revision    string
-		configName  string
-		webhookName string
-		pemData     []byte
-		err         string
+		name       string
+		configs    admissionregistrationv1.MutatingWebhookConfigurationList
+		revision   string
+		configName string
+		pemData    []byte
+		err        string
 	}{
 		{
 			"WebhookConfigNotFound",
 			admissionregistrationv1.MutatingWebhookConfigurationList{},
 			testRevision,
 			"config1",
-			"webhook1",
 			caBundle0,
 			errNotFound.Error(),
 		},
@@ -88,7 +86,6 @@ func TestMutatingWebhookPatch(t *testing.T) {
 			},
 			testRevision,
 			"config1",
-			"webhook1",
 			caBundle0,
 			errNoWebhookWithName.Error(),
 		},
@@ -112,7 +109,6 @@ func TestMutatingWebhookPatch(t *testing.T) {
 			},
 			testRevision,
 			"config1",
-			"webhook1",
 			caBundle0,
 			"",
 		},
@@ -136,7 +132,6 @@ func TestMutatingWebhookPatch(t *testing.T) {
 			},
 			testRevision,
 			"config1",
-			"webhook1",
 			caBundle0,
 			"",
 		},
@@ -159,7 +154,6 @@ func TestMutatingWebhookPatch(t *testing.T) {
 			},
 			testRevision,
 			"config1",
-			"webhook1",
 			caBundle0,
 			errNotFound.Error(),
 		},
@@ -183,7 +177,6 @@ func TestMutatingWebhookPatch(t *testing.T) {
 			},
 			testRevision,
 			"config1",
-			"webhook1",
 			caBundle0,
 			errNotFound.Error(),
 		},
@@ -202,7 +195,7 @@ func TestMutatingWebhookPatch(t *testing.T) {
 								ClientConfig: admissionregistrationv1.WebhookClientConfig{},
 							},
 							{
-								Name:         "should not be changed",
+								Name:         "obj-webhook1",
 								ClientConfig: admissionregistrationv1.WebhookClientConfig{},
 							},
 						},
@@ -211,7 +204,6 @@ func TestMutatingWebhookPatch(t *testing.T) {
 			},
 			testRevision,
 			"config1",
-			"webhook1",
 			caBundle0,
 			"",
 		},
@@ -228,7 +220,7 @@ func TestMutatingWebhookPatch(t *testing.T) {
 
 			watcher := keycertbundle.NewWatcher()
 			watcher.SetAndNotify(nil, nil, tc.pemData)
-			whPatcher, err := NewWebhookCertPatcher(client, tc.revision, tc.webhookName, watcher)
+			whPatcher, err := NewWebhookCertPatcher(client, tc.revision, watcher)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -254,15 +246,8 @@ func TestMutatingWebhookPatch(t *testing.T) {
 					t.Fatal(err)
 				}
 				for _, w := range obj.Webhooks {
-					if strings.HasSuffix(w.Name, tc.webhookName) {
-						if !bytes.Equal(w.ClientConfig.CABundle, tc.pemData) {
-							t.Fatalf("Incorrect CA bundle: expect %s got %s", tc.pemData, w.ClientConfig.CABundle)
-						}
-					}
-					if !strings.HasSuffix(w.Name, tc.webhookName) {
-						if bytes.Equal(w.ClientConfig.CABundle, tc.pemData) {
-							t.Fatalf("Non-matching webhook \"%s\" CA bundle updated to %v", w.Name, w.ClientConfig.CABundle)
-						}
+					if !bytes.Equal(w.ClientConfig.CABundle, tc.pemData) {
+						t.Fatalf("Incorrect CA bundle: expect %s got %s", tc.pemData, w.ClientConfig.CABundle)
 					}
 				}
 			}


### PR DESCRIPTION
**Please provide a description of this PR:**

The motivation is to prevent back and forth when multi-instance istiod updating the mutatingwebhookconfig when their caBundle are not consistent