### PR TITLE
PILOT_FILTER_GATEWAY_CLUSTER_CONFIG: Handle route change gracefuly

### DIFF
--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -332,6 +332,8 @@ type Proxy struct {
 	// LastPushContext; the XDS cache depends on knowing the time of the PushContext to determine if a
 	// key is stale or not.
 	LastPushTime time.Time
+
+	LastPushedCDS []*discovery.Resource
 }
 
 // WatchedResource tracks an active DiscoveryRequest subscription.
@@ -352,6 +354,9 @@ type WatchedResource struct {
 
 	// NonceAcked is the last acked message.
 	NonceAcked string
+
+	VersionSent  string
+	VersionAcked string
 
 	// AlwaysRespond, if true, will ensure that even when a request would otherwise be treated as an
 	// ACK, it will be responded to. This typically happens when a proxy reconnects to another instance of

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -333,7 +333,13 @@ type Proxy struct {
 	// key is stale or not.
 	LastPushTime time.Time
 
-	LastPushedCDS []*discovery.Resource
+	// LastPushedResources contains the list of resources that were last time to the proxy,
+	// keyed by the DiscoveryRequest TypeUrl. Currently it is used only for CDS
+	LastPushedResources map[string][]*discovery.Resource
+
+	// ResourceVersionWaitingForAck holds the latest versions sent to the proxy for which ack is not received yet
+	// from the proxy. Keyed by the DiscoveryRequest TypeUrl.
+	ResourceVersionWaitingForAck map[string]string
 }
 
 // WatchedResource tracks an active DiscoveryRequest subscription.

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -350,7 +350,8 @@ type PushRequest struct {
 
 	// Delta defines the resources that were added or removed as part of this push request.
 	// This is set only on requests from the client which change the set of resources they (un)subscribe from.
-	Delta ResourceDelta
+	Delta       ResourceDelta
+	VersionInfo string
 }
 
 // ResourceDelta records the difference in requested resources by an XDS client

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -188,7 +188,7 @@ func (configgen *ConfigGeneratorImpl) buildClusters(proxy *model.Proxy, req *mod
 	for _, c := range clusters {
 		resources = append(resources, &discovery.Resource{Name: c.Name, Resource: protoconv.MessageToAny(c)})
 	}
-	resources = cb.normalizeClusters(resources)
+	resources = cb.normalizeClusters(resources, proxy)
 
 	if cacheStats.empty() {
 		return resources, model.DefaultXdsLogDetails

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -1188,8 +1188,8 @@ func (cb *ClusterBuilder) normalizeClusters(clusters []*discovery.Resource, prox
 	if !features.FilterGatewayClusterConfig {
 		return out
 	}
-	lastPushed := proxy.LastPushedCDS
-	proxy.LastPushedCDS = out
+	lastPushed := proxy.LastPushedResources[v3.ClusterType]
+	proxy.LastPushedResources[v3.ClusterType] = out
 
 	for _, c := range lastPushed {
 		if !have.InsertContains(c.Name) {

--- a/pilot/pkg/xds/util.go
+++ b/pilot/pkg/xds/util.go
@@ -15,6 +15,10 @@
 package xds
 
 import (
+	"strconv"
+	"strings"
+	"time"
+
 	networkingapi "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pkg/config/labels"
 )
@@ -40,4 +44,40 @@ func getSubSetLabels(dr *networkingapi.DestinationRule, subsetName string) label
 	}
 
 	return nil
+}
+
+func IsThisVersionOlderThanThat(this, that string) (bool, error) {
+	//format is "time.Now().Format(time.RFC3339) + "/" + strconv.FormatUint(versionNum.Inc(), 10)"
+	thisParts := strings.Split(this, "/")
+	thatParts := strings.Split(this, "/")
+	thisTimeString := thisParts[0]
+	thisVersionNum := thisParts[1]
+
+	thatTimeString := thatParts[0]
+	thatVersionNum := thatParts[1]
+	thisTime, err := time.Parse(time.RFC3339, thisTimeString)
+	if err != nil {
+		return false, err
+	}
+	thatTime, err := time.Parse(time.RFC3339, thatTimeString)
+	if err != nil {
+		return false, err
+	}
+	if thisTime.Before(thatTime) {
+		return true, nil
+	}
+	if thisTime == thatTime {
+		thisVersionNumInt, err := strconv.Atoi(thisVersionNum)
+		if err != nil {
+			return false, err
+		}
+		thatVersionNumInt, err := strconv.Atoi(thatVersionNum)
+		if err != nil {
+			return false, err
+		}
+		if thisVersionNumInt < thatVersionNumInt {
+			return true, nil
+		}
+	}
+	return false, nil
 }


### PR DESCRIPTION
**Please provide a description of this PR:**
Fixing (4) from [Re-enable PILOT_FILTER_GATEWAY_CLUSTER_CONFIG](https://github.com/istio/istio/issues/29131#top)

When this feature is enabled, Istiod pushes only the clusters(cds) which are routed to by the routes attached to the gateway proxy. In the past when PILOT_FILTER_GATEWAY_CLUSTER_CONFIG was enabled by default, 
[503 during VirtualService update in 1.8](https://github.com/istio/istio/issues/29310#top) was reported. That time we closed this issue by disabling PILOT_FILTER_GATEWAY_CLUSTER_CONFIG by default. This PR is now actually fixing #29310.

Let say, for the same hostname foo.com,  route r1 routes to the cluster c1 and route r2 routes to the cluster c2. Assume initially there was r1 loaded at the gateway proxy. Now consider the event that virtual service change happens and Istiod determines to push r2 and c2. Istiod already enforces the sequence while pushing xds, cds -> eds -> lds -> rds. But still,  there are two situations in which changing the routes to use virtual service(r2/c2) can result into 503 at datapath:
**1. Removal of old cluster(c1), while older route(r1) is in place:**
    cds updates c2 at the proxy. c2 gets added and c1 gets removed. Any requests coming at the proxy until new route r2 gets loaded will be failed because the cluster c1 is gone which is routed to by route r1.
This PR is solving this case by always pushing the union of currently referred clusters and clusters sent to the proxy last time. Clusters backed up(stored) for the next cds push are only the "currently referred clusters". For example when cds is pushed for the r2 route change, c1 and c2 both clusters are pushed and c2 is saved to take the union with the clusters determined next time.

**2. Loading of new route r2 before the cluster c2 has warmed up**
Though Istiod follows the order of cds->eds->lds->rds, If cluster c2 warming is not complete and r2 has got loaded, requests will fail.
Envoy acks cds only after cluster warming is done(https://github.com/envoyproxy/envoy/pull/23321). This PR is adding changes to push rds only after cds ack is received. This will make sure that when r2 gets loaded, for sure, c2 would be there. 
 

I have tested the changes with the reproducing steps mentioned in #29310. 503 does not happen at all with changes in the PR and the envoy PR. I see 503s if any of the changes are missing.