### PR TITLE
[1.15] gateway-api: update types to read v1beta1 if present

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -98,7 +98,7 @@ require (
 	k8s.io/kubectl v0.24.2
 	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9
 	sigs.k8s.io/controller-runtime v0.12.2
-	sigs.k8s.io/gateway-api v0.5.1-0.20220815164014-854e2bfc5276
+	sigs.k8s.io/gateway-api v0.5.1-0.20220921185115-ee7a83814203
 	sigs.k8s.io/mcs-api v0.1.0
 	sigs.k8s.io/yaml v1.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2539,8 +2539,8 @@ sigs.k8s.io/controller-runtime v0.6.1/go.mod h1:XRYBPdbf5XJu9kpS84VJiZ7h/u1hF3gE
 sigs.k8s.io/controller-runtime v0.12.2 h1:nqV02cvhbAj7tbt21bpPpTByrXGn2INHRsi39lXy9sE=
 sigs.k8s.io/controller-runtime v0.12.2/go.mod h1:qKsk4WE6zW2Hfj0G4v10EnNB2jMG1C+NTb8h+DwCoU0=
 sigs.k8s.io/controller-tools v0.3.0/go.mod h1:enhtKGfxZD1GFEoMgP8Fdbu+uKQ/cq1/WGJhdVChfvI=
-sigs.k8s.io/gateway-api v0.5.1-0.20220815164014-854e2bfc5276 h1:7L9X/IkG9/Ww8Glcbtf8KTZde8kReC3m2e1RGRytANQ=
-sigs.k8s.io/gateway-api v0.5.1-0.20220815164014-854e2bfc5276/go.mod h1:x0AP6gugkFV8fC/oTlnOMU0pnmuzIR8LfIPRVUjxSqA=
+sigs.k8s.io/gateway-api v0.5.1-0.20220921185115-ee7a83814203 h1:t53lCjyZa7bsj1vZbAboYAH0p0OpqdGpGeM30IZIew8=
+sigs.k8s.io/gateway-api v0.5.1-0.20220921185115-ee7a83814203/go.mod h1:x0AP6gugkFV8fC/oTlnOMU0pnmuzIR8LfIPRVUjxSqA=
 sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 h1:kDi4JBNAsJWfz1aEXhO8Jg87JJaPNLh5tIzYHgStQ9Y=
 sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2/go.mod h1:B+TnT182UBxE84DiCz4CVE26eOSDAeYCpfDnC2kdKMY=
 sigs.k8s.io/kind v0.8.1/go.mod h1:oNKTxUVPYkV9lWzY6CVMNluVq8cBsyq+UgPJdvA3uu4=

--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -160,7 +160,7 @@ func (s *Server) initK8SConfigStore(args *PilotArgs) error {
 		if s.statusManager == nil && features.EnableGatewayAPIStatus {
 			s.initStatusManager(args)
 		}
-		gwc := gateway.NewController(s.kubeClient, configController, args.RegistryOptions.KubeOptions)
+		gwc := gateway.NewController(s.kubeClient, configController, configController.ClusterVersionFor, args.RegistryOptions.KubeOptions)
 		s.environment.GatewayAPIController = gwc
 		s.ConfigStores = append(s.ConfigStores, s.environment.GatewayAPIController)
 		s.addTerminatingStartFunc(func(stop <-chan struct{}) error {
@@ -189,7 +189,7 @@ func (s *Server) initK8SConfigStore(args *PilotArgs) error {
 					AddRunFunction(func(leaderStop <-chan struct{}) {
 						// We can only run this if the Gateway CRD is created
 						if crdclient.WaitForCRD(gvk.KubernetesGateway, leaderStop) {
-							controller := gateway.NewDeploymentController(s.kubeClient)
+							controller := gateway.NewDeploymentController(s.kubeClient, configController.ClusterVersionFor(gvk.KubernetesGateway).Version)
 							// Start informers again. This fixes the case where informers for namespace do not start,
 							// as we create them only after acquiring the leader lock
 							// Note: stop here should be the overall pilot stop, NOT the leader election stop. We are
@@ -342,7 +342,7 @@ func (s *Server) initStatusController(args *PilotArgs, writeStatus bool) {
 	}
 }
 
-func (s *Server) makeKubeConfigController(args *PilotArgs) (model.ConfigStoreController, error) {
+func (s *Server) makeKubeConfigController(args *PilotArgs) (*crdclient.Client, error) {
 	return crdclient.New(s.kubeClient, args.Revision, args.RegistryOptions.KubeOptions.DomainSuffix)
 }
 

--- a/pilot/pkg/config/aggregate/config_test.go
+++ b/pilot/pkg/config/aggregate/config_test.go
@@ -36,8 +36,8 @@ import (
 func TestAggregateStoreBasicMake(t *testing.T) {
 	g := gomega.NewWithT(t)
 
-	schema1 := collections.K8SGatewayApiV1Alpha2Httproutes
-	schema2 := collections.K8SGatewayApiV1Alpha2Gatewayclasses
+	schema1 := collections.K8SGatewayApiV1Beta1Httproutes
+	schema2 := collections.K8SGatewayApiV1Beta1Gatewayclasses
 	store1 := memory.Make(collection.SchemasFor(schema1))
 	store2 := memory.Make(collection.SchemasFor(schema2))
 
@@ -66,8 +66,8 @@ func TestAggregateStoreMakeValidationFailure(t *testing.T) {
 func TestAggregateStoreGet(t *testing.T) {
 	g := gomega.NewWithT(t)
 
-	store1 := memory.Make(collection.SchemasFor(collections.K8SGatewayApiV1Alpha2Gatewayclasses))
-	store2 := memory.Make(collection.SchemasFor(collections.K8SGatewayApiV1Alpha2Gatewayclasses))
+	store1 := memory.Make(collection.SchemasFor(collections.K8SGatewayApiV1Beta1Gatewayclasses))
+	store2 := memory.Make(collection.SchemasFor(collections.K8SGatewayApiV1Beta1Gatewayclasses))
 
 	configReturn := &config.Config{
 		Meta: config.Meta{
@@ -91,8 +91,8 @@ func TestAggregateStoreGet(t *testing.T) {
 func TestAggregateStoreList(t *testing.T) {
 	g := gomega.NewWithT(t)
 
-	store1 := memory.Make(collection.SchemasFor(collections.K8SGatewayApiV1Alpha2Httproutes))
-	store2 := memory.Make(collection.SchemasFor(collections.K8SGatewayApiV1Alpha2Httproutes))
+	store1 := memory.Make(collection.SchemasFor(collections.K8SGatewayApiV1Beta1Httproutes))
+	store2 := memory.Make(collection.SchemasFor(collections.K8SGatewayApiV1Beta1Httproutes))
 
 	if _, err := store1.Create(config.Config{
 		Meta: config.Meta{
@@ -124,8 +124,8 @@ func TestAggregateStoreList(t *testing.T) {
 func TestAggregateStoreWrite(t *testing.T) {
 	g := gomega.NewWithT(t)
 
-	store1 := memory.Make(collection.SchemasFor(collections.K8SGatewayApiV1Alpha2Httproutes))
-	store2 := memory.Make(collection.SchemasFor(collections.K8SGatewayApiV1Alpha2Httproutes))
+	store1 := memory.Make(collection.SchemasFor(collections.K8SGatewayApiV1Beta1Httproutes))
+	store2 := memory.Make(collection.SchemasFor(collections.K8SGatewayApiV1Beta1Httproutes))
 
 	stores := []model.ConfigStore{store1, store2}
 
@@ -162,8 +162,8 @@ func TestAggregateStoreWrite(t *testing.T) {
 func TestAggregateStoreWriteWithoutWriter(t *testing.T) {
 	g := gomega.NewWithT(t)
 
-	store1 := memory.Make(collection.SchemasFor(collections.K8SGatewayApiV1Alpha2Httproutes))
-	store2 := memory.Make(collection.SchemasFor(collections.K8SGatewayApiV1Alpha2Httproutes))
+	store1 := memory.Make(collection.SchemasFor(collections.K8SGatewayApiV1Beta1Httproutes))
+	store2 := memory.Make(collection.SchemasFor(collections.K8SGatewayApiV1Beta1Httproutes))
 
 	stores := []model.ConfigStore{store1, store2}
 
@@ -218,11 +218,11 @@ func TestAggregateStoreCache(t *testing.T) {
 	stop := make(chan struct{})
 	defer func() { close(stop) }()
 
-	store1 := memory.Make(collection.SchemasFor(collections.K8SGatewayApiV1Alpha2Httproutes))
+	store1 := memory.Make(collection.SchemasFor(collections.K8SGatewayApiV1Beta1Httproutes))
 	controller1 := memory.NewController(store1)
 	go controller1.Run(stop)
 
-	store2 := memory.Make(collection.SchemasFor(collections.K8SGatewayApiV1Alpha2Gatewayclasses))
+	store2 := memory.Make(collection.SchemasFor(collections.K8SGatewayApiV1Beta1Httproutes))
 	controller2 := memory.NewController(store2)
 	go controller2.Run(stop)
 

--- a/pilot/pkg/config/kube/crdclient/cache_handler.go
+++ b/pilot/pkg/config/kube/crdclient/cache_handler.go
@@ -23,7 +23,6 @@ import (
 
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/config"
-	"istio.io/istio/pkg/config/schema/collection"
 	"istio.io/pkg/log"
 )
 
@@ -32,8 +31,14 @@ import (
 type cacheHandler struct {
 	client   *Client
 	informer cache.SharedIndexInformer
-	schema   collection.Schema
-	lister   func(namespace string) cache.GenericNamespaceLister
+	// preferredGvk is the GVK we use internally. This is typically the same as clusterGvk, unless
+	// we support multiple versions and the cluster we are connected to does not support or preferred version.
+	// All calls to the client will come in as preferredGvk types.
+	preferredGvk config.GroupVersionKind
+	// clusterGvk is the actually GVK in the cluster. This may differ from preferredGvk when using multiple versions.
+	// All reads and writes to the cluster will use this GVK.
+	clusterGvk config.GroupVersionKind
+	lister     func(namespace string) cache.GenericNamespaceLister
 }
 
 func (h *cacheHandler) onEvent(old any, curr any, event model.Event) error {
@@ -58,7 +63,7 @@ func (h *cacheHandler) onEvent(old any, curr any, event model.Event) error {
 		return nil
 	}
 
-	currConfig := TranslateObject(currItem, h.schema.Resource().GroupVersionKind(), h.client.domainSuffix)
+	currConfig := TranslateObject(currItem, h.clusterGvk, h.client.domainSuffix)
 
 	var oldConfig config.Config
 	if old != nil {
@@ -67,30 +72,34 @@ func (h *cacheHandler) onEvent(old any, curr any, event model.Event) error {
 			log.Warnf("Old Object can not be converted to runtime Object %v, is type %T", old, old)
 			return nil
 		}
-		oldConfig = TranslateObject(oldItem, h.schema.Resource().GroupVersionKind(), h.client.domainSuffix)
+		oldConfig = TranslateObject(oldItem, h.clusterGvk, h.client.domainSuffix)
 	}
 
 	// TODO we may consider passing a pointer to handlers instead of the value. While spec is a pointer, the meta will be copied
-	for _, f := range h.client.handlers[h.schema.Resource().GroupVersionKind()] {
+	for _, f := range h.client.handlers[h.clusterGvk] {
 		f(oldConfig, currConfig, event)
 	}
 	return nil
 }
 
-func createCacheHandler(cl *Client, schema collection.Schema, i informers.GenericInformer) *cacheHandler {
-	scope.Debugf("registered CRD %v", schema.Resource().GroupVersionKind())
+func createCacheHandler(cl *Client, i informers.GenericInformer, preferredGvk, clusterGvk config.GroupVersionKind, clusterScoped bool) *cacheHandler {
+	scope.Debugf("registered CRD %v", preferredGvk)
 	h := &cacheHandler{
-		client:   cl,
-		schema:   schema,
-		informer: i.Informer(),
+		client:       cl,
+		clusterGvk:   clusterGvk,
+		preferredGvk: preferredGvk,
+		informer:     i.Informer(),
+	}
+	if preferredGvk != clusterGvk {
+		scope.Infof("preferred version %v is not available, reading %v", preferredGvk, clusterGvk)
 	}
 	h.lister = func(namespace string) cache.GenericNamespaceLister {
-		if schema.Resource().IsClusterScoped() {
+		if clusterScoped {
 			return i.Lister()
 		}
 		return i.Lister().ByNamespace(namespace)
 	}
-	kind := schema.Resource().Kind()
+	kind := preferredGvk.Kind
 	i.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj any) {
 			incrementEvent(kind, "add")

--- a/pilot/pkg/config/kube/crdclient/client.go
+++ b/pilot/pkg/config/kube/crdclient/client.go
@@ -54,8 +54,10 @@ import (
 	"istio.io/istio/pkg/config/schema/collection"
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/config/schema/gvk"
+	"istio.io/istio/pkg/config/schema/resource"
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/queue"
+	"istio.io/istio/pkg/util/sets"
 	"istio.io/pkg/log"
 )
 
@@ -99,7 +101,7 @@ type Client struct {
 
 var _ model.ConfigStoreController = &Client{}
 
-func New(client kube.Client, revision, domainSuffix string) (model.ConfigStoreController, error) {
+func New(client kube.Client, revision, domainSuffix string) (*Client, error) {
 	schemas := collections.Pilot
 	if features.EnableGatewayAPI {
 		schemas = collections.PilotGatewayAPI
@@ -130,7 +132,7 @@ func newWaiter() *waiter {
 func WaitForCRD(k config.GroupVersionKind, stop <-chan struct{}) bool {
 	ch, f := crdWatches[k]
 	if !f {
-		log.Warnf("waiting for CRD that is not registered")
+		log.Warnf("waiting for CRD %s that is not registered", k.String())
 		return false
 	}
 	select {
@@ -141,7 +143,7 @@ func WaitForCRD(k config.GroupVersionKind, stop <-chan struct{}) bool {
 	}
 }
 
-func NewForSchemas(client kube.Client, revision, domainSuffix string, schemas collection.Schemas) (model.ConfigStoreController, error) {
+func NewForSchemas(client kube.Client, revision, domainSuffix string, schemas collection.Schemas) (*Client, error) {
 	schemasByCRDName := map[string]collection.Schema{}
 	for _, s := range schemas.All() {
 		// From the spec: "Its name MUST be in the format <.spec.name>.<.spec.group>."
@@ -178,10 +180,10 @@ func NewForSchemas(client kube.Client, revision, domainSuffix string, schemas co
 			crd = false
 		}
 		if !crd {
-			handleCRDAdd(out, name, nil)
+			handleCRDAdd(out, name, nil, nil)
 		} else {
-			if _, f := known[name]; f {
-				handleCRDAdd(out, name, nil)
+			if knownVersions, f := known[name]; f {
+				handleCRDAdd(out, name, knownVersions, nil)
 			} else {
 				scope.Warnf("Skipping CRD %v as it is not present", s.Resource().GroupVersionKind())
 			}
@@ -238,7 +240,7 @@ func (cl *Client) Run(stop <-chan struct{}) {
 				scope.Errorf("wrong type %T: %v", obj, obj)
 				return
 			}
-			handleCRDAdd(cl, crd.Name, stop)
+			handleCRDAdd(cl, crd.Name, nil, stop)
 		},
 		UpdateFunc: nil,
 		DeleteFunc: nil,
@@ -251,7 +253,7 @@ func (cl *Client) Run(stop <-chan struct{}) {
 func (cl *Client) informerSynced() bool {
 	for _, ctl := range cl.allKinds() {
 		if !ctl.informer.HasSynced() {
-			scope.Infof("controller %q is syncing...", ctl.schema.Resource().GroupVersionKind())
+			scope.Infof("controller %q is syncing...", ctl.clusterGvk)
 			return false
 		}
 	}
@@ -271,7 +273,7 @@ func (cl *Client) SyncAll() {
 	cl.beginSync.Store(true)
 	wg := sync.WaitGroup{}
 	for _, h := range cl.allKinds() {
-		handlers := cl.handlers[h.schema.Resource().GroupVersionKind()]
+		handlers := cl.handlers[h.clusterGvk]
 		if len(handlers) == 0 {
 			continue
 		}
@@ -286,7 +288,7 @@ func (cl *Client) SyncAll() {
 					scope.Warnf("New Object can not be converted to runtime Object %v, is type %T", object, object)
 					continue
 				}
-				currConfig := TranslateObject(currItem, h.schema.Resource().GroupVersionKind(), h.client.domainSuffix)
+				currConfig := TranslateObject(currItem, h.clusterGvk, h.client.domainSuffix)
 				for _, f := range handlers {
 					f(config.Config{}, currConfig, model.EventAdd)
 				}
@@ -328,6 +330,7 @@ func (cl *Client) Create(cfg config.Config) (string, error) {
 	if cfg.Spec == nil {
 		return "", fmt.Errorf("nil spec for %v/%v", cfg.Name, cfg.Namespace)
 	}
+	cfg.GroupVersionKind = cl.ClusterVersionFor(cfg.GroupVersionKind)
 
 	meta, err := create(cl.istioClient, cl.gatewayAPIClient, cfg, getObjectMetadata(cfg))
 	if err != nil {
@@ -341,6 +344,7 @@ func (cl *Client) Update(cfg config.Config) (string, error) {
 	if cfg.Spec == nil {
 		return "", fmt.Errorf("nil spec for %v/%v", cfg.Name, cfg.Namespace)
 	}
+	cfg.GroupVersionKind = cl.ClusterVersionFor(cfg.GroupVersionKind)
 
 	meta, err := update(cl.istioClient, cl.gatewayAPIClient, cfg, getObjectMetadata(cfg))
 	if err != nil {
@@ -353,6 +357,7 @@ func (cl *Client) UpdateStatus(cfg config.Config) (string, error) {
 	if cfg.Status == nil {
 		return "", fmt.Errorf("nil status for %v/%v on updateStatus()", cfg.Name, cfg.Namespace)
 	}
+	cfg.GroupVersionKind = cl.ClusterVersionFor(cfg.GroupVersionKind)
 
 	meta, err := updateStatus(cl.istioClient, cl.gatewayAPIClient, cfg, getObjectMetadata(cfg))
 	if err != nil {
@@ -364,6 +369,7 @@ func (cl *Client) UpdateStatus(cfg config.Config) (string, error) {
 // Patch applies only the modifications made in the PatchFunc rather than doing a full replace. Useful to avoid
 // read-modify-write conflicts when there are many concurrent-writers to the same resource.
 func (cl *Client) Patch(orig config.Config, patchFn config.PatchFunc) (string, error) {
+	orig.GroupVersionKind = cl.ClusterVersionFor(orig.GroupVersionKind)
 	modified, patchType := patchFn(orig.DeepCopy())
 
 	meta, err := patch(cl.istioClient, cl.gatewayAPIClient, orig, getObjectMetadata(orig), modified, getObjectMetadata(modified), patchType)
@@ -376,7 +382,21 @@ func (cl *Client) Patch(orig config.Config, patchFn config.PatchFunc) (string, e
 // Delete implements store interface
 // `resourceVersion` must be matched before deletion is carried out. If not possible, a 409 Conflict status will be
 func (cl *Client) Delete(typ config.GroupVersionKind, name, namespace string, resourceVersion *string) error {
+	typ = cl.ClusterVersionFor(typ)
 	return delete(cl.istioClient, cl.gatewayAPIClient, typ, name, namespace, resourceVersion)
+}
+
+// ClusterVersionFor translates a preferred GVK to the cluster GVK. This allows users of
+// the client to call `crdclient.Create(PreferredGvk)`, and internally we will call
+// `k8sclient.Create(ClusterGVK)`.
+func (cl *Client) ClusterVersionFor(typ config.GroupVersionKind) config.GroupVersionKind {
+	k, f := cl.kind(typ)
+	if !f {
+		// We don't know this kind, nothing to translate
+		return typ
+	}
+	typ.Version = k.clusterGvk.Version
+	return typ
 }
 
 // List implements store interface
@@ -423,7 +443,7 @@ func (cl *Client) kind(r config.GroupVersionKind) (*cacheHandler, bool) {
 }
 
 // knownCRDs returns all CRDs present in the cluster, with timeout and retries.
-func knownCRDs(crdClient apiextensionsclient.Interface) (map[string]struct{}, error) {
+func knownCRDs(crdClient apiextensionsclient.Interface) (map[string]sets.Set, error) {
 	var res *crd.CustomResourceDefinitionList
 	b := backoff.NewExponentialBackOff()
 	b.InitialInterval = time.Second
@@ -443,11 +463,21 @@ func knownCRDs(crdClient apiextensionsclient.Interface) (map[string]struct{}, er
 		return nil, err
 	}
 
-	mp := map[string]struct{}{}
+	mp := map[string]sets.Set{}
 	for _, r := range res.Items {
-		mp[r.Name] = struct{}{}
+		mp[r.Name] = extractCRDVersions(&r)
 	}
 	return mp, nil
+}
+
+func extractCRDVersions(r *crd.CustomResourceDefinition) sets.Set {
+	res := sets.New()
+	for _, v := range r.Spec.Versions {
+		if v.Served {
+			res.Insert(v.Name)
+		}
+	}
+	return res
 }
 
 func TranslateObject(r runtime.Object, gvk config.GroupVersionKind, domainSuffix string) config.Config {
@@ -496,20 +526,21 @@ func genPatchBytes(oldRes, modRes runtime.Object, patchType types.PatchType) ([]
 	}
 }
 
-func handleCRDAdd(cl *Client, name string, stop <-chan struct{}) {
+func handleCRDAdd(cl *Client, name string, knownVersions sets.Set, stop <-chan struct{}) {
 	scope.Debugf("adding CRD %q", name)
 	s, f := cl.schemasByCRDName[name]
 	if !f {
 		scope.Debugf("added resource that we are not watching: %v", name)
 		return
 	}
-	resourceGVK := s.Resource().GroupVersionKind()
+	preferredGvk := s.Resource().GroupVersionKind()
+	clusterGvk := preferredGvk
 	gvr := s.Resource().GroupVersionResource()
 
 	cl.kindsMu.Lock()
 	defer cl.kindsMu.Unlock()
-	if _, f := cl.kinds[resourceGVK]; f {
-		scope.Debugf("added resource that already exists: %v", resourceGVK)
+	if _, f := cl.kinds[preferredGvk]; f {
+		scope.Debugf("added resource that already exists: %v", preferredGvk)
 		return
 	}
 	var i informers.GenericInformer
@@ -518,6 +549,26 @@ func handleCRDAdd(cl *Client, name string, stop <-chan struct{}) {
 	switch s.Resource().Group() {
 	case gvk.KubernetesGateway.Group:
 		ifactory = cl.client.GatewayAPIInformer()
+
+		// Only Gateway has dual version logic. Supporting multiple versions depends on types being typecast-able.
+		if knownVersions == nil { // Not provided, fetch from the real cluster
+			knownVersions = fetchKnownVersions(cl, s.Resource())
+		}
+
+		// Find the version we will actually use.
+		var version string
+		// Go through all versions we known about. They are ordered by preference.
+		ss := s.Resource().GroupVersionAliasKinds()
+		for _, v := range ss {
+			if knownVersions.Contains(v.Version) {
+				version = v.Version
+				break
+			}
+		}
+
+		scope.Debugf("for %v, have versions %v, will use %v", s.Resource().Kind(), knownVersions.SortedList(), version)
+		gvr.Version = version
+		clusterGvk.Version = version
 		i, err = cl.client.GatewayAPIInformer().ForResource(gvr)
 	case gvk.Pod.Group, gvk.Deployment.Group, gvk.MutatingWebhookConfiguration.Group:
 		ifactory = cl.client.KubeInformer()
@@ -532,14 +583,14 @@ func handleCRDAdd(cl *Client, name string, stop <-chan struct{}) {
 
 	if err != nil {
 		// Shouldn't happen
-		scope.Errorf("failed to create informer for %v: %v", resourceGVK, err)
+		scope.Errorf("failed to create informer for %v: %v", preferredGvk, err)
 		return
 	}
 	_ = i.Informer().SetTransform(kube.StripUnusedFields)
 
-	cl.kinds[resourceGVK] = createCacheHandler(cl, s, i)
-	if w, f := crdWatches[resourceGVK]; f {
-		scope.Infof("notifying watchers %v was created", resourceGVK)
+	cl.kinds[preferredGvk] = createCacheHandler(cl, i, preferredGvk, clusterGvk, s.Resource().IsClusterScoped())
+	if w, f := crdWatches[preferredGvk]; f {
+		scope.Infof("notifying watchers %v was created", preferredGvk)
 		w.once.Do(func() {
 			close(w.stop)
 		})
@@ -550,6 +601,17 @@ func handleCRDAdd(cl *Client, name string, stop <-chan struct{}) {
 		// For dynamically added CRDs, we need to start immediately though
 		ifactory.Start(stop)
 	}
+}
+
+// fetchKnownVersions fetches the known versions of a resource rfom the cluster
+func fetchKnownVersions(cl *Client, r resource.Schema) sets.Set {
+	// From the spec: "Its name MUST be in the format <.spec.name>.<.spec.group>."
+	name := fmt.Sprintf("%s.%s", r.Plural(), r.Group())
+	c, err := cl.client.Ext().ApiextensionsV1().CustomResourceDefinitions().Get(context.Background(), name, metav1.GetOptions{})
+	if err != nil {
+		return nil
+	}
+	return extractCRDVersions(c)
 }
 
 type starter interface {

--- a/pilot/pkg/config/kube/crdclient/gen/main.go
+++ b/pilot/pkg/config/kube/crdclient/gen/main.go
@@ -25,8 +25,10 @@ import (
 	"log"
 	"os"
 	"path"
+	"strings"
 	"text/template"
 
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/collection"
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/test/env"
@@ -44,6 +46,8 @@ type ConfigData struct {
 	StatusAPIImport string
 	StatusKind      string
 
+	Gvk config.GroupVersionKind
+
 	// Support gateway-api, which require a custom client and the Spec suffix
 	Client string
 
@@ -51,6 +55,14 @@ type ConfigData struct {
 
 	Readonly bool
 	NoSpec   bool
+	TypeName string
+
+	// MultiVersion indicates this type supports multiple different versions in the cluster.
+	MultiVersion bool
+	// PreferredClientImport, only present if MultiVersion, indicates the ClientImport of the preferred version.
+	PreferredClientImport string
+	// Versions, only present if MultiVersion, indicates all possible ClientImports.
+	Versions []string
 }
 
 var (
@@ -59,35 +71,61 @@ var (
 )
 
 // MakeConfigData prepare data for code generation for the given schema.
-func MakeConfigData(schema collection.Schema) ConfigData {
-	out := ConfigData{
-		Namespaced:      !schema.Resource().IsClusterScoped(),
-		VariableName:    schema.VariableName(),
-		APIImport:       apiImport[schema.Resource().ProtoPackage()],
-		ClientImport:    clientGoImport[schema.Resource().ProtoPackage()],
-		ClientGroupPath: clientGoAccessPath[schema.Resource().ProtoPackage()],
-		ClientTypePath:  clientGoTypePath[schema.Resource().Plural()],
-		Kind:            schema.Resource().Kind(),
-		Client:          "ic",
-		StatusAPIImport: apiImport[schema.Resource().StatusPackage()],
-		StatusKind:      schema.Resource().StatusKind(),
+func MakeConfigData(schema collection.Schema) []ConfigData {
+	res := []ConfigData{}
+	_, gatewayApi := GatewayAPITypes.Find(schema.Name().String())
+	primary := schema.Resource().GroupVersionKind()
+	gvks := []config.GroupVersionKind{primary}
+	if gatewayApi {
+		gvks = schema.Resource().GroupVersionAliasKinds()
 	}
-	out.ClientType = out.Kind
-	if _, f := GatewayAPITypes.Find(schema.Name().String()); f {
-		out.Client = "sc"
-		out.ClientType += "Spec"
-	} else if _, f := NonIstioTypes.Find(schema.Name().String()); f {
-		out.ClientType += "Spec"
-		out.Readonly = true
+	for _, gvk := range gvks {
+		out := ConfigData{
+			Namespaced:      !schema.Resource().IsClusterScoped(),
+			VariableName:    schema.VariableName(),
+			APIImport:       apiImport[schema.Resource().ProtoPackage()],
+			ClientImport:    clientGoImport[schema.Resource().ProtoPackage()],
+			ClientGroupPath: clientGoAccessPath[gvk.GroupVersion()],
+			ClientTypePath:  clientGoTypePath[schema.Resource().Plural()],
+			Kind:            schema.Resource().Kind(),
+			Gvk:             gvk,
+			// MultiVersion relies on not only having two versions present, but those being typecast-able to one another.
+			// If we wanted to support, for example, Istio dual version types, we would need more robust (and expensive) conversion logic.
+			// However, there are no plans to remove Istio alpha types.
+			MultiVersion:    gatewayApi && len(schema.Resource().GroupVersionAliasKinds()) > 1,
+			TypeName:        strings.ReplaceAll(strings.ReplaceAll(gvk.String(), "/", "_"), ".", "_"),
+			Client:          "ic",
+			StatusAPIImport: apiImport[schema.Resource().StatusPackage()],
+			StatusKind:      schema.Resource().StatusKind(),
+		}
+		if out.MultiVersion {
+			// If we are a MultiVersion we need some extra info to handle the type casts
+			out.PreferredClientImport = strings.ReplaceAll(out.ClientImport, primary.Version, gvk.Version)
+			for _, v := range schema.Resource().GroupVersionAliasKinds() {
+				out.Versions = append(out.Versions, strings.ReplaceAll(out.ClientImport, primary.Version, v.Version))
+			}
+		}
+		out.ClientType = out.Kind
+		if _, f := GatewayAPITypes.Find(schema.Name().String()); f {
+			out.Client = "sc"
+			out.ClientType += "Spec"
+		} else if _, f := NonIstioTypes.Find(schema.Name().String()); f {
+			out.ClientType += "Spec"
+			out.Readonly = true
+		}
+		if o, f := clientGoTypeOverrides[out.Kind]; f {
+			out.ClientType = o
+		}
+		if _, f := noSpec[schema.Resource().Plural()]; f {
+			out.NoSpec = true
+		}
+		log.Printf("Generating Istio type %s for %s/%s CRD\n", out.VariableName, out.APIImport, out.Kind)
+		if out.ClientGroupPath == "" || out.ClientTypePath == "" || out.ClientImport == "" {
+			log.Fatalf("invalid config %+v", out)
+		}
+		res = append(res, out)
 	}
-	if o, f := clientGoTypeOverrides[out.Kind]; f {
-		out.ClientType = o
-	}
-	if _, f := noSpec[schema.Resource().Plural()]; f {
-		out.NoSpec = true
-	}
-	log.Printf("Generating Istio type %s for %s/%s CRD\n", out.VariableName, out.APIImport, out.Kind)
-	return out
+	return res
 }
 
 var (
@@ -98,6 +136,7 @@ var (
 		"istio.io/api/security/v1beta1":                            "securityv1beta1",
 		"istio.io/api/telemetry/v1alpha1":                          "telemetryv1alpha1",
 		"sigs.k8s.io/gateway-api/apis/v1alpha2":                    "gatewayv1alpha2",
+		"sigs.k8s.io/gateway-api/apis/v1beta1":                     "gatewayv1beta1",
 		"istio.io/api/meta/v1alpha1":                               "metav1alpha1",
 		"istio.io/api/extensions/v1alpha1":                         "extensionsv1alpha1",
 		"k8s.io/api/admissionregistration/v1":                      "admissionregistrationv1",
@@ -113,6 +152,7 @@ var (
 		"istio.io/api/security/v1beta1":                            "clientsecurityv1beta1",
 		"istio.io/api/telemetry/v1alpha1":                          "clienttelemetryv1alpha1",
 		"sigs.k8s.io/gateway-api/apis/v1alpha2":                    "gatewayv1alpha2",
+		"sigs.k8s.io/gateway-api/apis/v1beta1":                     "gatewayv1beta1",
 		"istio.io/api/extensions/v1alpha1":                         "clientextensionsv1alpha1",
 		"k8s.io/api/admissionregistration/v1":                      "admissionregistrationv1",
 		"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1": "apiextensionsv1",
@@ -122,17 +162,18 @@ var (
 	}
 	// Translates an api import path to the top level path in client-go
 	clientGoAccessPath = map[string]string{
-		"istio.io/api/networking/v1alpha3":                         "NetworkingV1alpha3",
-		"istio.io/api/networking/v1beta1":                          "NetworkingV1beta1",
-		"istio.io/api/security/v1beta1":                            "SecurityV1beta1",
-		"istio.io/api/telemetry/v1alpha1":                          "TelemetryV1alpha1",
-		"sigs.k8s.io/gateway-api/apis/v1alpha2":                    "GatewayV1alpha2",
-		"istio.io/api/extensions/v1alpha1":                         "ExtensionsV1alpha1",
-		"k8s.io/api/admissionregistration/v1":                      "admissionregistrationv1",
-		"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1": "apiextensionsv1",
-		"k8s.io/api/apps/v1":                                       "appsv1",
-		"k8s.io/api/core/v1":                                       "corev1",
-		"k8s.io/api/extensions/v1beta1":                            "extensionsv1beta1",
+		"networking.istio.io/v1alpha3":       "NetworkingV1alpha3",
+		"networking.istio.io/v1beta1":        "NetworkingV1beta1",
+		"security.istio.io/v1beta1":          "SecurityV1beta1",
+		"telemetry.istio.io/v1alpha1":        "TelemetryV1alpha1",
+		"extensions.istio.io/v1alpha1":       "ExtensionsV1alpha1",
+		"gateway.networking.k8s.io/v1alpha2": "GatewayV1alpha2",
+		"gateway.networking.k8s.io/v1beta1":  "GatewayV1beta1",
+		"admissionregistration.k8s.io/v1":    "admissionregistrationv1",
+		"apiextensions.k8s.io/v1":            "apiextensionsv1",
+		"apps/v1":                            "appsv1",
+		"v1":                                 "corev1",
+		"extensions/v1beta1":                 "extensionsv1beta1",
 	}
 	// Translates a plural type name to the type path in client-go
 	// TODO: can we automatically derive this? I don't think we can, its internal to the kubegen
@@ -192,10 +233,7 @@ func main() {
 	typeList := []ConfigData{}
 	for _, s := range collections.PilotGatewayAPI.Union(collections.Kube).All() {
 		c := MakeConfigData(s)
-		if c.ClientGroupPath == "" || c.ClientTypePath == "" || c.ClientImport == "" {
-			log.Fatalf("invalid config %+v", c)
-		}
-		typeList = append(typeList, c)
+		typeList = append(typeList, c...)
 	}
 	var buffer bytes.Buffer
 	if err := tmpl.Execute(&buffer, typeList); err != nil {

--- a/pilot/pkg/config/kube/crdclient/gen/main.go
+++ b/pilot/pkg/config/kube/crdclient/gen/main.go
@@ -73,10 +73,10 @@ var (
 // MakeConfigData prepare data for code generation for the given schema.
 func MakeConfigData(schema collection.Schema) []ConfigData {
 	res := []ConfigData{}
-	_, gatewayApi := GatewayAPITypes.Find(schema.Name().String())
+	_, gatewayAPI := GatewayAPITypes.Find(schema.Name().String())
 	primary := schema.Resource().GroupVersionKind()
 	gvks := []config.GroupVersionKind{primary}
-	if gatewayApi {
+	if gatewayAPI {
 		gvks = schema.Resource().GroupVersionAliasKinds()
 	}
 	for _, gvk := range gvks {
@@ -92,7 +92,7 @@ func MakeConfigData(schema collection.Schema) []ConfigData {
 			// MultiVersion relies on not only having two versions present, but those being typecast-able to one another.
 			// If we wanted to support, for example, Istio dual version types, we would need more robust (and expensive) conversion logic.
 			// However, there are no plans to remove Istio alpha types.
-			MultiVersion:    gatewayApi && len(schema.Resource().GroupVersionAliasKinds()) > 1,
+			MultiVersion:    gatewayAPI && len(schema.Resource().GroupVersionAliasKinds()) > 1,
 			TypeName:        strings.ReplaceAll(strings.ReplaceAll(gvk.String(), "/", "_"), ".", "_"),
 			Client:          "ic",
 			StatusAPIImport: apiImport[schema.Resource().StatusPackage()],

--- a/pilot/pkg/config/kube/crdclient/gen/types.go.tmpl
+++ b/pilot/pkg/config/kube/crdclient/gen/types.go.tmpl
@@ -34,6 +34,7 @@ import (
     	"k8s.io/apimachinery/pkg/runtime"
     	"k8s.io/apimachinery/pkg/types"
     	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+    	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
     	gatewayapiclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
 
     	extensionsv1alpha1 "istio.io/api/extensions/v1alpha1"
@@ -56,11 +57,18 @@ func create(ic versionedclient.Interface, sc gatewayapiclient.Interface, cfg con
 	switch cfg.GroupVersionKind {
 {{- range . }}
   {{- if not .Readonly }}
-	case collections.{{ .VariableName }}.Resource().GroupVersionKind():
+	case {{.TypeName}}:
+	{{- if .MultiVersion }}
+		return {{.Client}}.{{ .ClientGroupPath }}().{{ .ClientTypePath }}({{if .Namespaced}}cfg.Namespace{{end}}).Create(context.TODO(), (*{{.PreferredClientImport}}.{{ .Kind }})(&{{ .ClientImport }}.{{ .Kind }}{
+			ObjectMeta: objMeta,
+			Spec:       *(cfg.Spec.(*{{ .APIImport }}.{{ .ClientType }})),
+		}), metav1.CreateOptions{})
+	{{- else }}
 		return {{.Client}}.{{ .ClientGroupPath }}().{{ .ClientTypePath }}({{if .Namespaced}}cfg.Namespace{{end}}).Create(context.TODO(), &{{ .ClientImport }}.{{ .Kind }}{
 			ObjectMeta: objMeta,
 			Spec:       *(cfg.Spec.(*{{ .APIImport }}.{{ .ClientType }})),
 		}, metav1.CreateOptions{})
+  {{- end }}
   {{- end }}
 {{- end }}
 	default:
@@ -72,11 +80,18 @@ func update(ic versionedclient.Interface, sc gatewayapiclient.Interface, cfg con
 	switch cfg.GroupVersionKind {
 {{- range . }}
   {{- if not .Readonly }}
-	case collections.{{ .VariableName }}.Resource().GroupVersionKind():
+	case {{.TypeName}}:
+	{{- if .MultiVersion }}
+		return {{.Client}}.{{ .ClientGroupPath }}().{{ .ClientTypePath }}({{if .Namespaced}}cfg.Namespace{{end}}).Update(context.TODO(), (*{{.PreferredClientImport}}.{{ .Kind }})(&{{ .ClientImport }}.{{ .Kind }}{
+			ObjectMeta: objMeta,
+			Spec:       *(cfg.Spec.(*{{ .APIImport }}.{{ .ClientType }})),
+		}), metav1.UpdateOptions{})
+	{{- else }}
 		return {{.Client}}.{{ .ClientGroupPath }}().{{ .ClientTypePath }}({{if .Namespaced}}cfg.Namespace{{end}}).Update(context.TODO(), &{{ .ClientImport }}.{{ .Kind }}{
 			ObjectMeta: objMeta,
 			Spec:       *(cfg.Spec.(*{{ .APIImport }}.{{ .ClientType }})),
 		}, metav1.UpdateOptions{})
+  {{- end }}
   {{- end }}
 {{- end }}
 	default:
@@ -89,11 +104,18 @@ func updateStatus(ic versionedclient.Interface, sc gatewayapiclient.Interface, c
     {{- range . }}
       {{- if not .Readonly }}
       {{ if .StatusKind }}
-    	case collections.{{ .VariableName }}.Resource().GroupVersionKind():
+        case {{.TypeName}}:
+        {{- if .MultiVersion }}
+          return {{.Client}}.{{ .ClientGroupPath }}().{{ .ClientTypePath }}({{if .Namespaced}}cfg.Namespace{{end}}).UpdateStatus(context.TODO(), (*{{.PreferredClientImport}}.{{ .Kind }})(&{{ .ClientImport }}.{{ .Kind }}{
+            ObjectMeta: objMeta,
+            Status:       *(cfg.Status.(*{{ .StatusAPIImport }}.{{ .StatusKind }})),
+          }), metav1.UpdateOptions{})
+        {{- else }}
     		return {{.Client}}.{{ .ClientGroupPath }}().{{ .ClientTypePath }}({{if .Namespaced}}cfg.Namespace{{end}}).UpdateStatus(context.TODO(), &{{ .ClientImport }}.{{ .Kind }}{
     			ObjectMeta: objMeta,
     			Status:     *(cfg.Status.(*{{ .StatusAPIImport }}.{{ .StatusKind }})),
     		}, metav1.UpdateOptions{})
+        {{- end }}
       {{- end }}
       {{- end }}
     {{- end }}
@@ -110,7 +132,23 @@ func patch(ic versionedclient.Interface, sc gatewayapiclient.Interface, orig con
 	switch orig.GroupVersionKind {
 {{- range . }}
   {{- if not .Readonly }}
-    case collections.{{ .VariableName }}.Resource().GroupVersionKind():
+    case {{.TypeName}}:
+        {{- if .MultiVersion }}
+        oldRes := &{{ .PreferredClientImport }}.{{ .Kind }}{
+            ObjectMeta: origMeta,
+            Spec:       *(orig.Spec.(*{{ .APIImport }}.{{ .ClientType }})),
+        }
+        modRes := &{{ .PreferredClientImport }}.{{ .Kind }}{
+            ObjectMeta: modMeta,
+            Spec:       *(mod.Spec.(*{{ .APIImport }}.{{ .ClientType }})),
+        }
+        patchBytes, err := genPatchBytes(oldRes, modRes, typ)
+        if err != nil {
+            return nil, err
+        }
+        return {{.Client}}.{{ .ClientGroupPath }}().{{ .ClientTypePath }}({{if .Namespaced}}orig.Namespace{{end}}).
+            Patch(context.TODO(), orig.Name, typ, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+        {{- else }}
         oldRes := &{{ .ClientImport }}.{{ .Kind }}{
             ObjectMeta: origMeta,
             Spec:       *(orig.Spec.(*{{ .APIImport }}.{{ .ClientType }})),
@@ -125,6 +163,7 @@ func patch(ic versionedclient.Interface, sc gatewayapiclient.Interface, orig con
         }
         return {{.Client}}.{{ .ClientGroupPath }}().{{ .ClientTypePath }}({{if .Namespaced}}orig.Namespace{{end}}).
             Patch(context.TODO(), orig.Name, typ, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+        {{- end }}
   {{- end }}
 {{- end }}
 	default:
@@ -141,7 +180,7 @@ func delete(ic versionedclient.Interface, sc gatewayapiclient.Interface, typ con
 	switch typ {
 {{- range . }}
   {{- if not .Readonly }}
-	case collections.{{ .VariableName }}.Resource().GroupVersionKind():
+  case {{.TypeName}}:
 		return {{.Client}}.{{ .ClientGroupPath }}().{{ .ClientTypePath }}({{if .Namespaced}}namespace{{end}}).Delete(context.TODO(), name, deleteOptions)
   {{- end }}
 {{- end }}
@@ -150,13 +189,31 @@ func delete(ic versionedclient.Interface, sc gatewayapiclient.Interface, typ con
 	}
 }
 
+{{- range . }}
+var {{.TypeName}} = config.GroupVersionKind{Group: "{{.Gvk.Group}}", Version: "{{.Gvk.Version}}", Kind: "{{.Gvk.Kind}}"}
+{{- end }}
+
 var translationMap = map[config.GroupVersionKind]func(r runtime.Object) config.Config{
 {{- range . }}
-	collections.{{ .VariableName }}.Resource().GroupVersionKind(): func(r runtime.Object) config.Config {
-		obj := r.(*{{ .ClientImport }}.{{ .Kind }})
+  {{ $tl := . }}
+	{{.TypeName}}: func(r runtime.Object) config.Config {
+    {{- if .MultiVersion }}
+    // Not primary
+    var obj *{{ .ClientImport }}.{{ .Kind }}
+    switch v := r.(type) {
+    {{- range $ver := .Versions }}
+      case *{{ $ver }}.{{ $tl.Kind }}:
+        obj = (*{{ $tl.ClientImport }}.{{ $tl.Kind }})(v)
+    {{- end }}
+      default:
+        panic(fmt.Sprintf("unknown type %T", v))
+    }
+    {{- else }}
+    obj := r.(*{{ .ClientImport }}.{{ .Kind }})
+    {{- end }}
 		return config.Config{
 		  Meta: config.Meta{
-		  	GroupVersionKind:  collections.{{ .VariableName }}.Resource().GroupVersionKind(),
+		  	GroupVersionKind:  {{.TypeName}},
 		  	Name:              obj.Name,
 		  	Namespace:         obj.Namespace,
 		  	Labels:            obj.Labels,

--- a/pilot/pkg/config/kube/crdclient/gen/types.go.tmpl
+++ b/pilot/pkg/config/kube/crdclient/gen/types.go.tmpl
@@ -50,7 +50,6 @@ import (
     	clienttelemetryv1alpha1 "istio.io/client-go/pkg/apis/telemetry/v1alpha1"
     	versionedclient "istio.io/client-go/pkg/clientset/versioned"
     	"istio.io/istio/pkg/config"
-    	"istio.io/istio/pkg/config/schema/collections"
 )
 
 func create(ic versionedclient.Interface, sc gatewayapiclient.Interface, cfg config.Config, objMeta metav1.ObjectMeta) (metav1.Object, error) {

--- a/pilot/pkg/config/kube/crdclient/types.gen.go
+++ b/pilot/pkg/config/kube/crdclient/types.gen.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 	gatewayapiclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
 
 	extensionsv1alpha1 "istio.io/api/extensions/v1alpha1"
@@ -49,116 +50,130 @@ import (
 	clienttelemetryv1alpha1 "istio.io/client-go/pkg/apis/telemetry/v1alpha1"
 	versionedclient "istio.io/client-go/pkg/clientset/versioned"
 	"istio.io/istio/pkg/config"
-	"istio.io/istio/pkg/config/schema/collections"
 )
 
 func create(ic versionedclient.Interface, sc gatewayapiclient.Interface, cfg config.Config, objMeta metav1.ObjectMeta) (metav1.Object, error) {
 	switch cfg.GroupVersionKind {
-	case collections.IstioExtensionsV1Alpha1Wasmplugins.Resource().GroupVersionKind():
+	case extensions_istio_io_v1alpha1_WasmPlugin:
 		return ic.ExtensionsV1alpha1().WasmPlugins(cfg.Namespace).Create(context.TODO(), &clientextensionsv1alpha1.WasmPlugin{
 			ObjectMeta: objMeta,
 			Spec:       *(cfg.Spec.(*extensionsv1alpha1.WasmPlugin)),
 		}, metav1.CreateOptions{})
-	case collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind():
+	case networking_istio_io_v1alpha3_DestinationRule:
 		return ic.NetworkingV1alpha3().DestinationRules(cfg.Namespace).Create(context.TODO(), &clientnetworkingv1alpha3.DestinationRule{
 			ObjectMeta: objMeta,
 			Spec:       *(cfg.Spec.(*networkingv1alpha3.DestinationRule)),
 		}, metav1.CreateOptions{})
-	case collections.IstioNetworkingV1Alpha3Envoyfilters.Resource().GroupVersionKind():
+	case networking_istio_io_v1alpha3_EnvoyFilter:
 		return ic.NetworkingV1alpha3().EnvoyFilters(cfg.Namespace).Create(context.TODO(), &clientnetworkingv1alpha3.EnvoyFilter{
 			ObjectMeta: objMeta,
 			Spec:       *(cfg.Spec.(*networkingv1alpha3.EnvoyFilter)),
 		}, metav1.CreateOptions{})
-	case collections.IstioNetworkingV1Alpha3Gateways.Resource().GroupVersionKind():
+	case networking_istio_io_v1alpha3_Gateway:
 		return ic.NetworkingV1alpha3().Gateways(cfg.Namespace).Create(context.TODO(), &clientnetworkingv1alpha3.Gateway{
 			ObjectMeta: objMeta,
 			Spec:       *(cfg.Spec.(*networkingv1alpha3.Gateway)),
 		}, metav1.CreateOptions{})
-	case collections.IstioNetworkingV1Alpha3Serviceentries.Resource().GroupVersionKind():
+	case networking_istio_io_v1alpha3_ServiceEntry:
 		return ic.NetworkingV1alpha3().ServiceEntries(cfg.Namespace).Create(context.TODO(), &clientnetworkingv1alpha3.ServiceEntry{
 			ObjectMeta: objMeta,
 			Spec:       *(cfg.Spec.(*networkingv1alpha3.ServiceEntry)),
 		}, metav1.CreateOptions{})
-	case collections.IstioNetworkingV1Alpha3Sidecars.Resource().GroupVersionKind():
+	case networking_istio_io_v1alpha3_Sidecar:
 		return ic.NetworkingV1alpha3().Sidecars(cfg.Namespace).Create(context.TODO(), &clientnetworkingv1alpha3.Sidecar{
 			ObjectMeta: objMeta,
 			Spec:       *(cfg.Spec.(*networkingv1alpha3.Sidecar)),
 		}, metav1.CreateOptions{})
-	case collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind():
+	case networking_istio_io_v1alpha3_VirtualService:
 		return ic.NetworkingV1alpha3().VirtualServices(cfg.Namespace).Create(context.TODO(), &clientnetworkingv1alpha3.VirtualService{
 			ObjectMeta: objMeta,
 			Spec:       *(cfg.Spec.(*networkingv1alpha3.VirtualService)),
 		}, metav1.CreateOptions{})
-	case collections.IstioNetworkingV1Alpha3Workloadentries.Resource().GroupVersionKind():
+	case networking_istio_io_v1alpha3_WorkloadEntry:
 		return ic.NetworkingV1alpha3().WorkloadEntries(cfg.Namespace).Create(context.TODO(), &clientnetworkingv1alpha3.WorkloadEntry{
 			ObjectMeta: objMeta,
 			Spec:       *(cfg.Spec.(*networkingv1alpha3.WorkloadEntry)),
 		}, metav1.CreateOptions{})
-	case collections.IstioNetworkingV1Alpha3Workloadgroups.Resource().GroupVersionKind():
+	case networking_istio_io_v1alpha3_WorkloadGroup:
 		return ic.NetworkingV1alpha3().WorkloadGroups(cfg.Namespace).Create(context.TODO(), &clientnetworkingv1alpha3.WorkloadGroup{
 			ObjectMeta: objMeta,
 			Spec:       *(cfg.Spec.(*networkingv1alpha3.WorkloadGroup)),
 		}, metav1.CreateOptions{})
-	case collections.IstioNetworkingV1Beta1Proxyconfigs.Resource().GroupVersionKind():
+	case networking_istio_io_v1beta1_ProxyConfig:
 		return ic.NetworkingV1beta1().ProxyConfigs(cfg.Namespace).Create(context.TODO(), &clientnetworkingv1beta1.ProxyConfig{
 			ObjectMeta: objMeta,
 			Spec:       *(cfg.Spec.(*networkingv1beta1.ProxyConfig)),
 		}, metav1.CreateOptions{})
-	case collections.IstioSecurityV1Beta1Authorizationpolicies.Resource().GroupVersionKind():
+	case security_istio_io_v1beta1_AuthorizationPolicy:
 		return ic.SecurityV1beta1().AuthorizationPolicies(cfg.Namespace).Create(context.TODO(), &clientsecurityv1beta1.AuthorizationPolicy{
 			ObjectMeta: objMeta,
 			Spec:       *(cfg.Spec.(*securityv1beta1.AuthorizationPolicy)),
 		}, metav1.CreateOptions{})
-	case collections.IstioSecurityV1Beta1Peerauthentications.Resource().GroupVersionKind():
+	case security_istio_io_v1beta1_PeerAuthentication:
 		return ic.SecurityV1beta1().PeerAuthentications(cfg.Namespace).Create(context.TODO(), &clientsecurityv1beta1.PeerAuthentication{
 			ObjectMeta: objMeta,
 			Spec:       *(cfg.Spec.(*securityv1beta1.PeerAuthentication)),
 		}, metav1.CreateOptions{})
-	case collections.IstioSecurityV1Beta1Requestauthentications.Resource().GroupVersionKind():
+	case security_istio_io_v1beta1_RequestAuthentication:
 		return ic.SecurityV1beta1().RequestAuthentications(cfg.Namespace).Create(context.TODO(), &clientsecurityv1beta1.RequestAuthentication{
 			ObjectMeta: objMeta,
 			Spec:       *(cfg.Spec.(*securityv1beta1.RequestAuthentication)),
 		}, metav1.CreateOptions{})
-	case collections.IstioTelemetryV1Alpha1Telemetries.Resource().GroupVersionKind():
+	case telemetry_istio_io_v1alpha1_Telemetry:
 		return ic.TelemetryV1alpha1().Telemetries(cfg.Namespace).Create(context.TODO(), &clienttelemetryv1alpha1.Telemetry{
 			ObjectMeta: objMeta,
 			Spec:       *(cfg.Spec.(*telemetryv1alpha1.Telemetry)),
 		}, metav1.CreateOptions{})
-	case collections.K8SGatewayApiV1Alpha2Gatewayclasses.Resource().GroupVersionKind():
-		return sc.GatewayV1alpha2().GatewayClasses().Create(context.TODO(), &gatewayv1alpha2.GatewayClass{
-			ObjectMeta: objMeta,
-			Spec:       *(cfg.Spec.(*gatewayv1alpha2.GatewayClassSpec)),
-		}, metav1.CreateOptions{})
-	case collections.K8SGatewayApiV1Alpha2Gateways.Resource().GroupVersionKind():
-		return sc.GatewayV1alpha2().Gateways(cfg.Namespace).Create(context.TODO(), &gatewayv1alpha2.Gateway{
-			ObjectMeta: objMeta,
-			Spec:       *(cfg.Spec.(*gatewayv1alpha2.GatewaySpec)),
-		}, metav1.CreateOptions{})
-	case collections.K8SGatewayApiV1Alpha2Httproutes.Resource().GroupVersionKind():
-		return sc.GatewayV1alpha2().HTTPRoutes(cfg.Namespace).Create(context.TODO(), &gatewayv1alpha2.HTTPRoute{
-			ObjectMeta: objMeta,
-			Spec:       *(cfg.Spec.(*gatewayv1alpha2.HTTPRouteSpec)),
-		}, metav1.CreateOptions{})
-	case collections.K8SGatewayApiV1Alpha2Referencegrants.Resource().GroupVersionKind():
+	case gateway_networking_k8s_io_v1alpha2_ReferenceGrant:
 		return sc.GatewayV1alpha2().ReferenceGrants(cfg.Namespace).Create(context.TODO(), &gatewayv1alpha2.ReferenceGrant{
 			ObjectMeta: objMeta,
 			Spec:       *(cfg.Spec.(*gatewayv1alpha2.ReferenceGrantSpec)),
 		}, metav1.CreateOptions{})
-	case collections.K8SGatewayApiV1Alpha2Referencepolicies.Resource().GroupVersionKind():
+	case gateway_networking_k8s_io_v1alpha2_ReferencePolicy:
 		return sc.GatewayV1alpha2().ReferencePolicies(cfg.Namespace).Create(context.TODO(), &gatewayv1alpha2.ReferencePolicy{
 			ObjectMeta: objMeta,
 			Spec:       *(cfg.Spec.(*gatewayv1alpha2.ReferenceGrantSpec)),
 		}, metav1.CreateOptions{})
-	case collections.K8SGatewayApiV1Alpha2Tcproutes.Resource().GroupVersionKind():
+	case gateway_networking_k8s_io_v1alpha2_TCPRoute:
 		return sc.GatewayV1alpha2().TCPRoutes(cfg.Namespace).Create(context.TODO(), &gatewayv1alpha2.TCPRoute{
 			ObjectMeta: objMeta,
 			Spec:       *(cfg.Spec.(*gatewayv1alpha2.TCPRouteSpec)),
 		}, metav1.CreateOptions{})
-	case collections.K8SGatewayApiV1Alpha2Tlsroutes.Resource().GroupVersionKind():
+	case gateway_networking_k8s_io_v1alpha2_TLSRoute:
 		return sc.GatewayV1alpha2().TLSRoutes(cfg.Namespace).Create(context.TODO(), &gatewayv1alpha2.TLSRoute{
 			ObjectMeta: objMeta,
 			Spec:       *(cfg.Spec.(*gatewayv1alpha2.TLSRouteSpec)),
 		}, metav1.CreateOptions{})
+	case gateway_networking_k8s_io_v1beta1_GatewayClass:
+		return sc.GatewayV1beta1().GatewayClasses().Create(context.TODO(), (*gatewayv1beta1.GatewayClass)(&gatewayv1beta1.GatewayClass{
+			ObjectMeta: objMeta,
+			Spec:       *(cfg.Spec.(*gatewayv1beta1.GatewayClassSpec)),
+		}), metav1.CreateOptions{})
+	case gateway_networking_k8s_io_v1alpha2_GatewayClass:
+		return sc.GatewayV1alpha2().GatewayClasses().Create(context.TODO(), (*gatewayv1alpha2.GatewayClass)(&gatewayv1beta1.GatewayClass{
+			ObjectMeta: objMeta,
+			Spec:       *(cfg.Spec.(*gatewayv1beta1.GatewayClassSpec)),
+		}), metav1.CreateOptions{})
+	case gateway_networking_k8s_io_v1beta1_Gateway:
+		return sc.GatewayV1beta1().Gateways(cfg.Namespace).Create(context.TODO(), (*gatewayv1beta1.Gateway)(&gatewayv1beta1.Gateway{
+			ObjectMeta: objMeta,
+			Spec:       *(cfg.Spec.(*gatewayv1beta1.GatewaySpec)),
+		}), metav1.CreateOptions{})
+	case gateway_networking_k8s_io_v1alpha2_Gateway:
+		return sc.GatewayV1alpha2().Gateways(cfg.Namespace).Create(context.TODO(), (*gatewayv1alpha2.Gateway)(&gatewayv1beta1.Gateway{
+			ObjectMeta: objMeta,
+			Spec:       *(cfg.Spec.(*gatewayv1beta1.GatewaySpec)),
+		}), metav1.CreateOptions{})
+	case gateway_networking_k8s_io_v1beta1_HTTPRoute:
+		return sc.GatewayV1beta1().HTTPRoutes(cfg.Namespace).Create(context.TODO(), (*gatewayv1beta1.HTTPRoute)(&gatewayv1beta1.HTTPRoute{
+			ObjectMeta: objMeta,
+			Spec:       *(cfg.Spec.(*gatewayv1beta1.HTTPRouteSpec)),
+		}), metav1.CreateOptions{})
+	case gateway_networking_k8s_io_v1alpha2_HTTPRoute:
+		return sc.GatewayV1alpha2().HTTPRoutes(cfg.Namespace).Create(context.TODO(), (*gatewayv1alpha2.HTTPRoute)(&gatewayv1beta1.HTTPRoute{
+			ObjectMeta: objMeta,
+			Spec:       *(cfg.Spec.(*gatewayv1beta1.HTTPRouteSpec)),
+		}), metav1.CreateOptions{})
 	default:
 		return nil, fmt.Errorf("unsupported type: %v", cfg.GroupVersionKind)
 	}
@@ -166,111 +181,126 @@ func create(ic versionedclient.Interface, sc gatewayapiclient.Interface, cfg con
 
 func update(ic versionedclient.Interface, sc gatewayapiclient.Interface, cfg config.Config, objMeta metav1.ObjectMeta) (metav1.Object, error) {
 	switch cfg.GroupVersionKind {
-	case collections.IstioExtensionsV1Alpha1Wasmplugins.Resource().GroupVersionKind():
+	case extensions_istio_io_v1alpha1_WasmPlugin:
 		return ic.ExtensionsV1alpha1().WasmPlugins(cfg.Namespace).Update(context.TODO(), &clientextensionsv1alpha1.WasmPlugin{
 			ObjectMeta: objMeta,
 			Spec:       *(cfg.Spec.(*extensionsv1alpha1.WasmPlugin)),
 		}, metav1.UpdateOptions{})
-	case collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind():
+	case networking_istio_io_v1alpha3_DestinationRule:
 		return ic.NetworkingV1alpha3().DestinationRules(cfg.Namespace).Update(context.TODO(), &clientnetworkingv1alpha3.DestinationRule{
 			ObjectMeta: objMeta,
 			Spec:       *(cfg.Spec.(*networkingv1alpha3.DestinationRule)),
 		}, metav1.UpdateOptions{})
-	case collections.IstioNetworkingV1Alpha3Envoyfilters.Resource().GroupVersionKind():
+	case networking_istio_io_v1alpha3_EnvoyFilter:
 		return ic.NetworkingV1alpha3().EnvoyFilters(cfg.Namespace).Update(context.TODO(), &clientnetworkingv1alpha3.EnvoyFilter{
 			ObjectMeta: objMeta,
 			Spec:       *(cfg.Spec.(*networkingv1alpha3.EnvoyFilter)),
 		}, metav1.UpdateOptions{})
-	case collections.IstioNetworkingV1Alpha3Gateways.Resource().GroupVersionKind():
+	case networking_istio_io_v1alpha3_Gateway:
 		return ic.NetworkingV1alpha3().Gateways(cfg.Namespace).Update(context.TODO(), &clientnetworkingv1alpha3.Gateway{
 			ObjectMeta: objMeta,
 			Spec:       *(cfg.Spec.(*networkingv1alpha3.Gateway)),
 		}, metav1.UpdateOptions{})
-	case collections.IstioNetworkingV1Alpha3Serviceentries.Resource().GroupVersionKind():
+	case networking_istio_io_v1alpha3_ServiceEntry:
 		return ic.NetworkingV1alpha3().ServiceEntries(cfg.Namespace).Update(context.TODO(), &clientnetworkingv1alpha3.ServiceEntry{
 			ObjectMeta: objMeta,
 			Spec:       *(cfg.Spec.(*networkingv1alpha3.ServiceEntry)),
 		}, metav1.UpdateOptions{})
-	case collections.IstioNetworkingV1Alpha3Sidecars.Resource().GroupVersionKind():
+	case networking_istio_io_v1alpha3_Sidecar:
 		return ic.NetworkingV1alpha3().Sidecars(cfg.Namespace).Update(context.TODO(), &clientnetworkingv1alpha3.Sidecar{
 			ObjectMeta: objMeta,
 			Spec:       *(cfg.Spec.(*networkingv1alpha3.Sidecar)),
 		}, metav1.UpdateOptions{})
-	case collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind():
+	case networking_istio_io_v1alpha3_VirtualService:
 		return ic.NetworkingV1alpha3().VirtualServices(cfg.Namespace).Update(context.TODO(), &clientnetworkingv1alpha3.VirtualService{
 			ObjectMeta: objMeta,
 			Spec:       *(cfg.Spec.(*networkingv1alpha3.VirtualService)),
 		}, metav1.UpdateOptions{})
-	case collections.IstioNetworkingV1Alpha3Workloadentries.Resource().GroupVersionKind():
+	case networking_istio_io_v1alpha3_WorkloadEntry:
 		return ic.NetworkingV1alpha3().WorkloadEntries(cfg.Namespace).Update(context.TODO(), &clientnetworkingv1alpha3.WorkloadEntry{
 			ObjectMeta: objMeta,
 			Spec:       *(cfg.Spec.(*networkingv1alpha3.WorkloadEntry)),
 		}, metav1.UpdateOptions{})
-	case collections.IstioNetworkingV1Alpha3Workloadgroups.Resource().GroupVersionKind():
+	case networking_istio_io_v1alpha3_WorkloadGroup:
 		return ic.NetworkingV1alpha3().WorkloadGroups(cfg.Namespace).Update(context.TODO(), &clientnetworkingv1alpha3.WorkloadGroup{
 			ObjectMeta: objMeta,
 			Spec:       *(cfg.Spec.(*networkingv1alpha3.WorkloadGroup)),
 		}, metav1.UpdateOptions{})
-	case collections.IstioNetworkingV1Beta1Proxyconfigs.Resource().GroupVersionKind():
+	case networking_istio_io_v1beta1_ProxyConfig:
 		return ic.NetworkingV1beta1().ProxyConfigs(cfg.Namespace).Update(context.TODO(), &clientnetworkingv1beta1.ProxyConfig{
 			ObjectMeta: objMeta,
 			Spec:       *(cfg.Spec.(*networkingv1beta1.ProxyConfig)),
 		}, metav1.UpdateOptions{})
-	case collections.IstioSecurityV1Beta1Authorizationpolicies.Resource().GroupVersionKind():
+	case security_istio_io_v1beta1_AuthorizationPolicy:
 		return ic.SecurityV1beta1().AuthorizationPolicies(cfg.Namespace).Update(context.TODO(), &clientsecurityv1beta1.AuthorizationPolicy{
 			ObjectMeta: objMeta,
 			Spec:       *(cfg.Spec.(*securityv1beta1.AuthorizationPolicy)),
 		}, metav1.UpdateOptions{})
-	case collections.IstioSecurityV1Beta1Peerauthentications.Resource().GroupVersionKind():
+	case security_istio_io_v1beta1_PeerAuthentication:
 		return ic.SecurityV1beta1().PeerAuthentications(cfg.Namespace).Update(context.TODO(), &clientsecurityv1beta1.PeerAuthentication{
 			ObjectMeta: objMeta,
 			Spec:       *(cfg.Spec.(*securityv1beta1.PeerAuthentication)),
 		}, metav1.UpdateOptions{})
-	case collections.IstioSecurityV1Beta1Requestauthentications.Resource().GroupVersionKind():
+	case security_istio_io_v1beta1_RequestAuthentication:
 		return ic.SecurityV1beta1().RequestAuthentications(cfg.Namespace).Update(context.TODO(), &clientsecurityv1beta1.RequestAuthentication{
 			ObjectMeta: objMeta,
 			Spec:       *(cfg.Spec.(*securityv1beta1.RequestAuthentication)),
 		}, metav1.UpdateOptions{})
-	case collections.IstioTelemetryV1Alpha1Telemetries.Resource().GroupVersionKind():
+	case telemetry_istio_io_v1alpha1_Telemetry:
 		return ic.TelemetryV1alpha1().Telemetries(cfg.Namespace).Update(context.TODO(), &clienttelemetryv1alpha1.Telemetry{
 			ObjectMeta: objMeta,
 			Spec:       *(cfg.Spec.(*telemetryv1alpha1.Telemetry)),
 		}, metav1.UpdateOptions{})
-	case collections.K8SGatewayApiV1Alpha2Gatewayclasses.Resource().GroupVersionKind():
-		return sc.GatewayV1alpha2().GatewayClasses().Update(context.TODO(), &gatewayv1alpha2.GatewayClass{
-			ObjectMeta: objMeta,
-			Spec:       *(cfg.Spec.(*gatewayv1alpha2.GatewayClassSpec)),
-		}, metav1.UpdateOptions{})
-	case collections.K8SGatewayApiV1Alpha2Gateways.Resource().GroupVersionKind():
-		return sc.GatewayV1alpha2().Gateways(cfg.Namespace).Update(context.TODO(), &gatewayv1alpha2.Gateway{
-			ObjectMeta: objMeta,
-			Spec:       *(cfg.Spec.(*gatewayv1alpha2.GatewaySpec)),
-		}, metav1.UpdateOptions{})
-	case collections.K8SGatewayApiV1Alpha2Httproutes.Resource().GroupVersionKind():
-		return sc.GatewayV1alpha2().HTTPRoutes(cfg.Namespace).Update(context.TODO(), &gatewayv1alpha2.HTTPRoute{
-			ObjectMeta: objMeta,
-			Spec:       *(cfg.Spec.(*gatewayv1alpha2.HTTPRouteSpec)),
-		}, metav1.UpdateOptions{})
-	case collections.K8SGatewayApiV1Alpha2Referencegrants.Resource().GroupVersionKind():
+	case gateway_networking_k8s_io_v1alpha2_ReferenceGrant:
 		return sc.GatewayV1alpha2().ReferenceGrants(cfg.Namespace).Update(context.TODO(), &gatewayv1alpha2.ReferenceGrant{
 			ObjectMeta: objMeta,
 			Spec:       *(cfg.Spec.(*gatewayv1alpha2.ReferenceGrantSpec)),
 		}, metav1.UpdateOptions{})
-	case collections.K8SGatewayApiV1Alpha2Referencepolicies.Resource().GroupVersionKind():
+	case gateway_networking_k8s_io_v1alpha2_ReferencePolicy:
 		return sc.GatewayV1alpha2().ReferencePolicies(cfg.Namespace).Update(context.TODO(), &gatewayv1alpha2.ReferencePolicy{
 			ObjectMeta: objMeta,
 			Spec:       *(cfg.Spec.(*gatewayv1alpha2.ReferenceGrantSpec)),
 		}, metav1.UpdateOptions{})
-	case collections.K8SGatewayApiV1Alpha2Tcproutes.Resource().GroupVersionKind():
+	case gateway_networking_k8s_io_v1alpha2_TCPRoute:
 		return sc.GatewayV1alpha2().TCPRoutes(cfg.Namespace).Update(context.TODO(), &gatewayv1alpha2.TCPRoute{
 			ObjectMeta: objMeta,
 			Spec:       *(cfg.Spec.(*gatewayv1alpha2.TCPRouteSpec)),
 		}, metav1.UpdateOptions{})
-	case collections.K8SGatewayApiV1Alpha2Tlsroutes.Resource().GroupVersionKind():
+	case gateway_networking_k8s_io_v1alpha2_TLSRoute:
 		return sc.GatewayV1alpha2().TLSRoutes(cfg.Namespace).Update(context.TODO(), &gatewayv1alpha2.TLSRoute{
 			ObjectMeta: objMeta,
 			Spec:       *(cfg.Spec.(*gatewayv1alpha2.TLSRouteSpec)),
 		}, metav1.UpdateOptions{})
+	case gateway_networking_k8s_io_v1beta1_GatewayClass:
+		return sc.GatewayV1beta1().GatewayClasses().Update(context.TODO(), (*gatewayv1beta1.GatewayClass)(&gatewayv1beta1.GatewayClass{
+			ObjectMeta: objMeta,
+			Spec:       *(cfg.Spec.(*gatewayv1beta1.GatewayClassSpec)),
+		}), metav1.UpdateOptions{})
+	case gateway_networking_k8s_io_v1alpha2_GatewayClass:
+		return sc.GatewayV1alpha2().GatewayClasses().Update(context.TODO(), (*gatewayv1alpha2.GatewayClass)(&gatewayv1beta1.GatewayClass{
+			ObjectMeta: objMeta,
+			Spec:       *(cfg.Spec.(*gatewayv1beta1.GatewayClassSpec)),
+		}), metav1.UpdateOptions{})
+	case gateway_networking_k8s_io_v1beta1_Gateway:
+		return sc.GatewayV1beta1().Gateways(cfg.Namespace).Update(context.TODO(), (*gatewayv1beta1.Gateway)(&gatewayv1beta1.Gateway{
+			ObjectMeta: objMeta,
+			Spec:       *(cfg.Spec.(*gatewayv1beta1.GatewaySpec)),
+		}), metav1.UpdateOptions{})
+	case gateway_networking_k8s_io_v1alpha2_Gateway:
+		return sc.GatewayV1alpha2().Gateways(cfg.Namespace).Update(context.TODO(), (*gatewayv1alpha2.Gateway)(&gatewayv1beta1.Gateway{
+			ObjectMeta: objMeta,
+			Spec:       *(cfg.Spec.(*gatewayv1beta1.GatewaySpec)),
+		}), metav1.UpdateOptions{})
+	case gateway_networking_k8s_io_v1beta1_HTTPRoute:
+		return sc.GatewayV1beta1().HTTPRoutes(cfg.Namespace).Update(context.TODO(), (*gatewayv1beta1.HTTPRoute)(&gatewayv1beta1.HTTPRoute{
+			ObjectMeta: objMeta,
+			Spec:       *(cfg.Spec.(*gatewayv1beta1.HTTPRouteSpec)),
+		}), metav1.UpdateOptions{})
+	case gateway_networking_k8s_io_v1alpha2_HTTPRoute:
+		return sc.GatewayV1alpha2().HTTPRoutes(cfg.Namespace).Update(context.TODO(), (*gatewayv1alpha2.HTTPRoute)(&gatewayv1beta1.HTTPRoute{
+			ObjectMeta: objMeta,
+			Spec:       *(cfg.Spec.(*gatewayv1beta1.HTTPRouteSpec)),
+		}), metav1.UpdateOptions{})
 	default:
 		return nil, fmt.Errorf("unsupported type: %v", cfg.GroupVersionKind)
 	}
@@ -279,119 +309,137 @@ func update(ic versionedclient.Interface, sc gatewayapiclient.Interface, cfg con
 func updateStatus(ic versionedclient.Interface, sc gatewayapiclient.Interface, cfg config.Config, objMeta metav1.ObjectMeta) (metav1.Object, error) {
 	switch cfg.GroupVersionKind {
 
-	case collections.IstioExtensionsV1Alpha1Wasmplugins.Resource().GroupVersionKind():
+	case extensions_istio_io_v1alpha1_WasmPlugin:
 		return ic.ExtensionsV1alpha1().WasmPlugins(cfg.Namespace).UpdateStatus(context.TODO(), &clientextensionsv1alpha1.WasmPlugin{
 			ObjectMeta: objMeta,
 			Status:     *(cfg.Status.(*metav1alpha1.IstioStatus)),
 		}, metav1.UpdateOptions{})
 
-	case collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind():
+	case networking_istio_io_v1alpha3_DestinationRule:
 		return ic.NetworkingV1alpha3().DestinationRules(cfg.Namespace).UpdateStatus(context.TODO(), &clientnetworkingv1alpha3.DestinationRule{
 			ObjectMeta: objMeta,
 			Status:     *(cfg.Status.(*metav1alpha1.IstioStatus)),
 		}, metav1.UpdateOptions{})
 
-	case collections.IstioNetworkingV1Alpha3Envoyfilters.Resource().GroupVersionKind():
+	case networking_istio_io_v1alpha3_EnvoyFilter:
 		return ic.NetworkingV1alpha3().EnvoyFilters(cfg.Namespace).UpdateStatus(context.TODO(), &clientnetworkingv1alpha3.EnvoyFilter{
 			ObjectMeta: objMeta,
 			Status:     *(cfg.Status.(*metav1alpha1.IstioStatus)),
 		}, metav1.UpdateOptions{})
 
-	case collections.IstioNetworkingV1Alpha3Gateways.Resource().GroupVersionKind():
+	case networking_istio_io_v1alpha3_Gateway:
 		return ic.NetworkingV1alpha3().Gateways(cfg.Namespace).UpdateStatus(context.TODO(), &clientnetworkingv1alpha3.Gateway{
 			ObjectMeta: objMeta,
 			Status:     *(cfg.Status.(*metav1alpha1.IstioStatus)),
 		}, metav1.UpdateOptions{})
 
-	case collections.IstioNetworkingV1Alpha3Serviceentries.Resource().GroupVersionKind():
+	case networking_istio_io_v1alpha3_ServiceEntry:
 		return ic.NetworkingV1alpha3().ServiceEntries(cfg.Namespace).UpdateStatus(context.TODO(), &clientnetworkingv1alpha3.ServiceEntry{
 			ObjectMeta: objMeta,
 			Status:     *(cfg.Status.(*metav1alpha1.IstioStatus)),
 		}, metav1.UpdateOptions{})
 
-	case collections.IstioNetworkingV1Alpha3Sidecars.Resource().GroupVersionKind():
+	case networking_istio_io_v1alpha3_Sidecar:
 		return ic.NetworkingV1alpha3().Sidecars(cfg.Namespace).UpdateStatus(context.TODO(), &clientnetworkingv1alpha3.Sidecar{
 			ObjectMeta: objMeta,
 			Status:     *(cfg.Status.(*metav1alpha1.IstioStatus)),
 		}, metav1.UpdateOptions{})
 
-	case collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind():
+	case networking_istio_io_v1alpha3_VirtualService:
 		return ic.NetworkingV1alpha3().VirtualServices(cfg.Namespace).UpdateStatus(context.TODO(), &clientnetworkingv1alpha3.VirtualService{
 			ObjectMeta: objMeta,
 			Status:     *(cfg.Status.(*metav1alpha1.IstioStatus)),
 		}, metav1.UpdateOptions{})
 
-	case collections.IstioNetworkingV1Alpha3Workloadentries.Resource().GroupVersionKind():
+	case networking_istio_io_v1alpha3_WorkloadEntry:
 		return ic.NetworkingV1alpha3().WorkloadEntries(cfg.Namespace).UpdateStatus(context.TODO(), &clientnetworkingv1alpha3.WorkloadEntry{
 			ObjectMeta: objMeta,
 			Status:     *(cfg.Status.(*metav1alpha1.IstioStatus)),
 		}, metav1.UpdateOptions{})
 
-	case collections.IstioNetworkingV1Alpha3Workloadgroups.Resource().GroupVersionKind():
+	case networking_istio_io_v1alpha3_WorkloadGroup:
 		return ic.NetworkingV1alpha3().WorkloadGroups(cfg.Namespace).UpdateStatus(context.TODO(), &clientnetworkingv1alpha3.WorkloadGroup{
 			ObjectMeta: objMeta,
 			Status:     *(cfg.Status.(*metav1alpha1.IstioStatus)),
 		}, metav1.UpdateOptions{})
 
-	case collections.IstioNetworkingV1Beta1Proxyconfigs.Resource().GroupVersionKind():
+	case networking_istio_io_v1beta1_ProxyConfig:
 		return ic.NetworkingV1beta1().ProxyConfigs(cfg.Namespace).UpdateStatus(context.TODO(), &clientnetworkingv1beta1.ProxyConfig{
 			ObjectMeta: objMeta,
 			Status:     *(cfg.Status.(*metav1alpha1.IstioStatus)),
 		}, metav1.UpdateOptions{})
 
-	case collections.IstioSecurityV1Beta1Authorizationpolicies.Resource().GroupVersionKind():
+	case security_istio_io_v1beta1_AuthorizationPolicy:
 		return ic.SecurityV1beta1().AuthorizationPolicies(cfg.Namespace).UpdateStatus(context.TODO(), &clientsecurityv1beta1.AuthorizationPolicy{
 			ObjectMeta: objMeta,
 			Status:     *(cfg.Status.(*metav1alpha1.IstioStatus)),
 		}, metav1.UpdateOptions{})
 
-	case collections.IstioSecurityV1Beta1Peerauthentications.Resource().GroupVersionKind():
+	case security_istio_io_v1beta1_PeerAuthentication:
 		return ic.SecurityV1beta1().PeerAuthentications(cfg.Namespace).UpdateStatus(context.TODO(), &clientsecurityv1beta1.PeerAuthentication{
 			ObjectMeta: objMeta,
 			Status:     *(cfg.Status.(*metav1alpha1.IstioStatus)),
 		}, metav1.UpdateOptions{})
 
-	case collections.IstioSecurityV1Beta1Requestauthentications.Resource().GroupVersionKind():
+	case security_istio_io_v1beta1_RequestAuthentication:
 		return ic.SecurityV1beta1().RequestAuthentications(cfg.Namespace).UpdateStatus(context.TODO(), &clientsecurityv1beta1.RequestAuthentication{
 			ObjectMeta: objMeta,
 			Status:     *(cfg.Status.(*metav1alpha1.IstioStatus)),
 		}, metav1.UpdateOptions{})
 
-	case collections.IstioTelemetryV1Alpha1Telemetries.Resource().GroupVersionKind():
+	case telemetry_istio_io_v1alpha1_Telemetry:
 		return ic.TelemetryV1alpha1().Telemetries(cfg.Namespace).UpdateStatus(context.TODO(), &clienttelemetryv1alpha1.Telemetry{
 			ObjectMeta: objMeta,
 			Status:     *(cfg.Status.(*metav1alpha1.IstioStatus)),
 		}, metav1.UpdateOptions{})
 
-	case collections.K8SGatewayApiV1Alpha2Gatewayclasses.Resource().GroupVersionKind():
-		return sc.GatewayV1alpha2().GatewayClasses().UpdateStatus(context.TODO(), &gatewayv1alpha2.GatewayClass{
-			ObjectMeta: objMeta,
-			Status:     *(cfg.Status.(*gatewayv1alpha2.GatewayClassStatus)),
-		}, metav1.UpdateOptions{})
-
-	case collections.K8SGatewayApiV1Alpha2Gateways.Resource().GroupVersionKind():
-		return sc.GatewayV1alpha2().Gateways(cfg.Namespace).UpdateStatus(context.TODO(), &gatewayv1alpha2.Gateway{
-			ObjectMeta: objMeta,
-			Status:     *(cfg.Status.(*gatewayv1alpha2.GatewayStatus)),
-		}, metav1.UpdateOptions{})
-
-	case collections.K8SGatewayApiV1Alpha2Httproutes.Resource().GroupVersionKind():
-		return sc.GatewayV1alpha2().HTTPRoutes(cfg.Namespace).UpdateStatus(context.TODO(), &gatewayv1alpha2.HTTPRoute{
-			ObjectMeta: objMeta,
-			Status:     *(cfg.Status.(*gatewayv1alpha2.HTTPRouteStatus)),
-		}, metav1.UpdateOptions{})
-
-	case collections.K8SGatewayApiV1Alpha2Tcproutes.Resource().GroupVersionKind():
+	case gateway_networking_k8s_io_v1alpha2_TCPRoute:
 		return sc.GatewayV1alpha2().TCPRoutes(cfg.Namespace).UpdateStatus(context.TODO(), &gatewayv1alpha2.TCPRoute{
 			ObjectMeta: objMeta,
 			Status:     *(cfg.Status.(*gatewayv1alpha2.TCPRouteStatus)),
 		}, metav1.UpdateOptions{})
 
-	case collections.K8SGatewayApiV1Alpha2Tlsroutes.Resource().GroupVersionKind():
+	case gateway_networking_k8s_io_v1alpha2_TLSRoute:
 		return sc.GatewayV1alpha2().TLSRoutes(cfg.Namespace).UpdateStatus(context.TODO(), &gatewayv1alpha2.TLSRoute{
 			ObjectMeta: objMeta,
 			Status:     *(cfg.Status.(*gatewayv1alpha2.TLSRouteStatus)),
 		}, metav1.UpdateOptions{})
+
+	case gateway_networking_k8s_io_v1beta1_GatewayClass:
+		return sc.GatewayV1beta1().GatewayClasses().UpdateStatus(context.TODO(), (*gatewayv1beta1.GatewayClass)(&gatewayv1beta1.GatewayClass{
+			ObjectMeta: objMeta,
+			Status:     *(cfg.Status.(*gatewayv1beta1.GatewayClassStatus)),
+		}), metav1.UpdateOptions{})
+
+	case gateway_networking_k8s_io_v1alpha2_GatewayClass:
+		return sc.GatewayV1alpha2().GatewayClasses().UpdateStatus(context.TODO(), (*gatewayv1alpha2.GatewayClass)(&gatewayv1beta1.GatewayClass{
+			ObjectMeta: objMeta,
+			Status:     *(cfg.Status.(*gatewayv1beta1.GatewayClassStatus)),
+		}), metav1.UpdateOptions{})
+
+	case gateway_networking_k8s_io_v1beta1_Gateway:
+		return sc.GatewayV1beta1().Gateways(cfg.Namespace).UpdateStatus(context.TODO(), (*gatewayv1beta1.Gateway)(&gatewayv1beta1.Gateway{
+			ObjectMeta: objMeta,
+			Status:     *(cfg.Status.(*gatewayv1beta1.GatewayStatus)),
+		}), metav1.UpdateOptions{})
+
+	case gateway_networking_k8s_io_v1alpha2_Gateway:
+		return sc.GatewayV1alpha2().Gateways(cfg.Namespace).UpdateStatus(context.TODO(), (*gatewayv1alpha2.Gateway)(&gatewayv1beta1.Gateway{
+			ObjectMeta: objMeta,
+			Status:     *(cfg.Status.(*gatewayv1beta1.GatewayStatus)),
+		}), metav1.UpdateOptions{})
+
+	case gateway_networking_k8s_io_v1beta1_HTTPRoute:
+		return sc.GatewayV1beta1().HTTPRoutes(cfg.Namespace).UpdateStatus(context.TODO(), (*gatewayv1beta1.HTTPRoute)(&gatewayv1beta1.HTTPRoute{
+			ObjectMeta: objMeta,
+			Status:     *(cfg.Status.(*gatewayv1beta1.HTTPRouteStatus)),
+		}), metav1.UpdateOptions{})
+
+	case gateway_networking_k8s_io_v1alpha2_HTTPRoute:
+		return sc.GatewayV1alpha2().HTTPRoutes(cfg.Namespace).UpdateStatus(context.TODO(), (*gatewayv1alpha2.HTTPRoute)(&gatewayv1beta1.HTTPRoute{
+			ObjectMeta: objMeta,
+			Status:     *(cfg.Status.(*gatewayv1beta1.HTTPRouteStatus)),
+		}), metav1.UpdateOptions{})
 	default:
 		return nil, fmt.Errorf("unsupported type: %v", cfg.GroupVersionKind)
 	}
@@ -403,7 +451,7 @@ func patch(ic versionedclient.Interface, sc gatewayapiclient.Interface, orig con
 	}
 	// TODO support setting field manager
 	switch orig.GroupVersionKind {
-	case collections.IstioExtensionsV1Alpha1Wasmplugins.Resource().GroupVersionKind():
+	case extensions_istio_io_v1alpha1_WasmPlugin:
 		oldRes := &clientextensionsv1alpha1.WasmPlugin{
 			ObjectMeta: origMeta,
 			Spec:       *(orig.Spec.(*extensionsv1alpha1.WasmPlugin)),
@@ -418,7 +466,7 @@ func patch(ic versionedclient.Interface, sc gatewayapiclient.Interface, orig con
 		}
 		return ic.ExtensionsV1alpha1().WasmPlugins(orig.Namespace).
 			Patch(context.TODO(), orig.Name, typ, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
-	case collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind():
+	case networking_istio_io_v1alpha3_DestinationRule:
 		oldRes := &clientnetworkingv1alpha3.DestinationRule{
 			ObjectMeta: origMeta,
 			Spec:       *(orig.Spec.(*networkingv1alpha3.DestinationRule)),
@@ -433,7 +481,7 @@ func patch(ic versionedclient.Interface, sc gatewayapiclient.Interface, orig con
 		}
 		return ic.NetworkingV1alpha3().DestinationRules(orig.Namespace).
 			Patch(context.TODO(), orig.Name, typ, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
-	case collections.IstioNetworkingV1Alpha3Envoyfilters.Resource().GroupVersionKind():
+	case networking_istio_io_v1alpha3_EnvoyFilter:
 		oldRes := &clientnetworkingv1alpha3.EnvoyFilter{
 			ObjectMeta: origMeta,
 			Spec:       *(orig.Spec.(*networkingv1alpha3.EnvoyFilter)),
@@ -448,7 +496,7 @@ func patch(ic versionedclient.Interface, sc gatewayapiclient.Interface, orig con
 		}
 		return ic.NetworkingV1alpha3().EnvoyFilters(orig.Namespace).
 			Patch(context.TODO(), orig.Name, typ, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
-	case collections.IstioNetworkingV1Alpha3Gateways.Resource().GroupVersionKind():
+	case networking_istio_io_v1alpha3_Gateway:
 		oldRes := &clientnetworkingv1alpha3.Gateway{
 			ObjectMeta: origMeta,
 			Spec:       *(orig.Spec.(*networkingv1alpha3.Gateway)),
@@ -463,7 +511,7 @@ func patch(ic versionedclient.Interface, sc gatewayapiclient.Interface, orig con
 		}
 		return ic.NetworkingV1alpha3().Gateways(orig.Namespace).
 			Patch(context.TODO(), orig.Name, typ, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
-	case collections.IstioNetworkingV1Alpha3Serviceentries.Resource().GroupVersionKind():
+	case networking_istio_io_v1alpha3_ServiceEntry:
 		oldRes := &clientnetworkingv1alpha3.ServiceEntry{
 			ObjectMeta: origMeta,
 			Spec:       *(orig.Spec.(*networkingv1alpha3.ServiceEntry)),
@@ -478,7 +526,7 @@ func patch(ic versionedclient.Interface, sc gatewayapiclient.Interface, orig con
 		}
 		return ic.NetworkingV1alpha3().ServiceEntries(orig.Namespace).
 			Patch(context.TODO(), orig.Name, typ, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
-	case collections.IstioNetworkingV1Alpha3Sidecars.Resource().GroupVersionKind():
+	case networking_istio_io_v1alpha3_Sidecar:
 		oldRes := &clientnetworkingv1alpha3.Sidecar{
 			ObjectMeta: origMeta,
 			Spec:       *(orig.Spec.(*networkingv1alpha3.Sidecar)),
@@ -493,7 +541,7 @@ func patch(ic versionedclient.Interface, sc gatewayapiclient.Interface, orig con
 		}
 		return ic.NetworkingV1alpha3().Sidecars(orig.Namespace).
 			Patch(context.TODO(), orig.Name, typ, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
-	case collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind():
+	case networking_istio_io_v1alpha3_VirtualService:
 		oldRes := &clientnetworkingv1alpha3.VirtualService{
 			ObjectMeta: origMeta,
 			Spec:       *(orig.Spec.(*networkingv1alpha3.VirtualService)),
@@ -508,7 +556,7 @@ func patch(ic versionedclient.Interface, sc gatewayapiclient.Interface, orig con
 		}
 		return ic.NetworkingV1alpha3().VirtualServices(orig.Namespace).
 			Patch(context.TODO(), orig.Name, typ, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
-	case collections.IstioNetworkingV1Alpha3Workloadentries.Resource().GroupVersionKind():
+	case networking_istio_io_v1alpha3_WorkloadEntry:
 		oldRes := &clientnetworkingv1alpha3.WorkloadEntry{
 			ObjectMeta: origMeta,
 			Spec:       *(orig.Spec.(*networkingv1alpha3.WorkloadEntry)),
@@ -523,7 +571,7 @@ func patch(ic versionedclient.Interface, sc gatewayapiclient.Interface, orig con
 		}
 		return ic.NetworkingV1alpha3().WorkloadEntries(orig.Namespace).
 			Patch(context.TODO(), orig.Name, typ, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
-	case collections.IstioNetworkingV1Alpha3Workloadgroups.Resource().GroupVersionKind():
+	case networking_istio_io_v1alpha3_WorkloadGroup:
 		oldRes := &clientnetworkingv1alpha3.WorkloadGroup{
 			ObjectMeta: origMeta,
 			Spec:       *(orig.Spec.(*networkingv1alpha3.WorkloadGroup)),
@@ -538,7 +586,7 @@ func patch(ic versionedclient.Interface, sc gatewayapiclient.Interface, orig con
 		}
 		return ic.NetworkingV1alpha3().WorkloadGroups(orig.Namespace).
 			Patch(context.TODO(), orig.Name, typ, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
-	case collections.IstioNetworkingV1Beta1Proxyconfigs.Resource().GroupVersionKind():
+	case networking_istio_io_v1beta1_ProxyConfig:
 		oldRes := &clientnetworkingv1beta1.ProxyConfig{
 			ObjectMeta: origMeta,
 			Spec:       *(orig.Spec.(*networkingv1beta1.ProxyConfig)),
@@ -553,7 +601,7 @@ func patch(ic versionedclient.Interface, sc gatewayapiclient.Interface, orig con
 		}
 		return ic.NetworkingV1beta1().ProxyConfigs(orig.Namespace).
 			Patch(context.TODO(), orig.Name, typ, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
-	case collections.IstioSecurityV1Beta1Authorizationpolicies.Resource().GroupVersionKind():
+	case security_istio_io_v1beta1_AuthorizationPolicy:
 		oldRes := &clientsecurityv1beta1.AuthorizationPolicy{
 			ObjectMeta: origMeta,
 			Spec:       *(orig.Spec.(*securityv1beta1.AuthorizationPolicy)),
@@ -568,7 +616,7 @@ func patch(ic versionedclient.Interface, sc gatewayapiclient.Interface, orig con
 		}
 		return ic.SecurityV1beta1().AuthorizationPolicies(orig.Namespace).
 			Patch(context.TODO(), orig.Name, typ, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
-	case collections.IstioSecurityV1Beta1Peerauthentications.Resource().GroupVersionKind():
+	case security_istio_io_v1beta1_PeerAuthentication:
 		oldRes := &clientsecurityv1beta1.PeerAuthentication{
 			ObjectMeta: origMeta,
 			Spec:       *(orig.Spec.(*securityv1beta1.PeerAuthentication)),
@@ -583,7 +631,7 @@ func patch(ic versionedclient.Interface, sc gatewayapiclient.Interface, orig con
 		}
 		return ic.SecurityV1beta1().PeerAuthentications(orig.Namespace).
 			Patch(context.TODO(), orig.Name, typ, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
-	case collections.IstioSecurityV1Beta1Requestauthentications.Resource().GroupVersionKind():
+	case security_istio_io_v1beta1_RequestAuthentication:
 		oldRes := &clientsecurityv1beta1.RequestAuthentication{
 			ObjectMeta: origMeta,
 			Spec:       *(orig.Spec.(*securityv1beta1.RequestAuthentication)),
@@ -598,7 +646,7 @@ func patch(ic versionedclient.Interface, sc gatewayapiclient.Interface, orig con
 		}
 		return ic.SecurityV1beta1().RequestAuthentications(orig.Namespace).
 			Patch(context.TODO(), orig.Name, typ, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
-	case collections.IstioTelemetryV1Alpha1Telemetries.Resource().GroupVersionKind():
+	case telemetry_istio_io_v1alpha1_Telemetry:
 		oldRes := &clienttelemetryv1alpha1.Telemetry{
 			ObjectMeta: origMeta,
 			Spec:       *(orig.Spec.(*telemetryv1alpha1.Telemetry)),
@@ -613,52 +661,7 @@ func patch(ic versionedclient.Interface, sc gatewayapiclient.Interface, orig con
 		}
 		return ic.TelemetryV1alpha1().Telemetries(orig.Namespace).
 			Patch(context.TODO(), orig.Name, typ, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
-	case collections.K8SGatewayApiV1Alpha2Gatewayclasses.Resource().GroupVersionKind():
-		oldRes := &gatewayv1alpha2.GatewayClass{
-			ObjectMeta: origMeta,
-			Spec:       *(orig.Spec.(*gatewayv1alpha2.GatewayClassSpec)),
-		}
-		modRes := &gatewayv1alpha2.GatewayClass{
-			ObjectMeta: modMeta,
-			Spec:       *(mod.Spec.(*gatewayv1alpha2.GatewayClassSpec)),
-		}
-		patchBytes, err := genPatchBytes(oldRes, modRes, typ)
-		if err != nil {
-			return nil, err
-		}
-		return sc.GatewayV1alpha2().GatewayClasses().
-			Patch(context.TODO(), orig.Name, typ, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
-	case collections.K8SGatewayApiV1Alpha2Gateways.Resource().GroupVersionKind():
-		oldRes := &gatewayv1alpha2.Gateway{
-			ObjectMeta: origMeta,
-			Spec:       *(orig.Spec.(*gatewayv1alpha2.GatewaySpec)),
-		}
-		modRes := &gatewayv1alpha2.Gateway{
-			ObjectMeta: modMeta,
-			Spec:       *(mod.Spec.(*gatewayv1alpha2.GatewaySpec)),
-		}
-		patchBytes, err := genPatchBytes(oldRes, modRes, typ)
-		if err != nil {
-			return nil, err
-		}
-		return sc.GatewayV1alpha2().Gateways(orig.Namespace).
-			Patch(context.TODO(), orig.Name, typ, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
-	case collections.K8SGatewayApiV1Alpha2Httproutes.Resource().GroupVersionKind():
-		oldRes := &gatewayv1alpha2.HTTPRoute{
-			ObjectMeta: origMeta,
-			Spec:       *(orig.Spec.(*gatewayv1alpha2.HTTPRouteSpec)),
-		}
-		modRes := &gatewayv1alpha2.HTTPRoute{
-			ObjectMeta: modMeta,
-			Spec:       *(mod.Spec.(*gatewayv1alpha2.HTTPRouteSpec)),
-		}
-		patchBytes, err := genPatchBytes(oldRes, modRes, typ)
-		if err != nil {
-			return nil, err
-		}
-		return sc.GatewayV1alpha2().HTTPRoutes(orig.Namespace).
-			Patch(context.TODO(), orig.Name, typ, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
-	case collections.K8SGatewayApiV1Alpha2Referencegrants.Resource().GroupVersionKind():
+	case gateway_networking_k8s_io_v1alpha2_ReferenceGrant:
 		oldRes := &gatewayv1alpha2.ReferenceGrant{
 			ObjectMeta: origMeta,
 			Spec:       *(orig.Spec.(*gatewayv1alpha2.ReferenceGrantSpec)),
@@ -673,7 +676,7 @@ func patch(ic versionedclient.Interface, sc gatewayapiclient.Interface, orig con
 		}
 		return sc.GatewayV1alpha2().ReferenceGrants(orig.Namespace).
 			Patch(context.TODO(), orig.Name, typ, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
-	case collections.K8SGatewayApiV1Alpha2Referencepolicies.Resource().GroupVersionKind():
+	case gateway_networking_k8s_io_v1alpha2_ReferencePolicy:
 		oldRes := &gatewayv1alpha2.ReferencePolicy{
 			ObjectMeta: origMeta,
 			Spec:       *(orig.Spec.(*gatewayv1alpha2.ReferenceGrantSpec)),
@@ -688,7 +691,7 @@ func patch(ic versionedclient.Interface, sc gatewayapiclient.Interface, orig con
 		}
 		return sc.GatewayV1alpha2().ReferencePolicies(orig.Namespace).
 			Patch(context.TODO(), orig.Name, typ, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
-	case collections.K8SGatewayApiV1Alpha2Tcproutes.Resource().GroupVersionKind():
+	case gateway_networking_k8s_io_v1alpha2_TCPRoute:
 		oldRes := &gatewayv1alpha2.TCPRoute{
 			ObjectMeta: origMeta,
 			Spec:       *(orig.Spec.(*gatewayv1alpha2.TCPRouteSpec)),
@@ -703,7 +706,7 @@ func patch(ic versionedclient.Interface, sc gatewayapiclient.Interface, orig con
 		}
 		return sc.GatewayV1alpha2().TCPRoutes(orig.Namespace).
 			Patch(context.TODO(), orig.Name, typ, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
-	case collections.K8SGatewayApiV1Alpha2Tlsroutes.Resource().GroupVersionKind():
+	case gateway_networking_k8s_io_v1alpha2_TLSRoute:
 		oldRes := &gatewayv1alpha2.TLSRoute{
 			ObjectMeta: origMeta,
 			Spec:       *(orig.Spec.(*gatewayv1alpha2.TLSRouteSpec)),
@@ -718,6 +721,96 @@ func patch(ic versionedclient.Interface, sc gatewayapiclient.Interface, orig con
 		}
 		return sc.GatewayV1alpha2().TLSRoutes(orig.Namespace).
 			Patch(context.TODO(), orig.Name, typ, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+	case gateway_networking_k8s_io_v1beta1_GatewayClass:
+		oldRes := &gatewayv1beta1.GatewayClass{
+			ObjectMeta: origMeta,
+			Spec:       *(orig.Spec.(*gatewayv1beta1.GatewayClassSpec)),
+		}
+		modRes := &gatewayv1beta1.GatewayClass{
+			ObjectMeta: modMeta,
+			Spec:       *(mod.Spec.(*gatewayv1beta1.GatewayClassSpec)),
+		}
+		patchBytes, err := genPatchBytes(oldRes, modRes, typ)
+		if err != nil {
+			return nil, err
+		}
+		return sc.GatewayV1beta1().GatewayClasses().
+			Patch(context.TODO(), orig.Name, typ, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+	case gateway_networking_k8s_io_v1alpha2_GatewayClass:
+		oldRes := &gatewayv1alpha2.GatewayClass{
+			ObjectMeta: origMeta,
+			Spec:       *(orig.Spec.(*gatewayv1beta1.GatewayClassSpec)),
+		}
+		modRes := &gatewayv1alpha2.GatewayClass{
+			ObjectMeta: modMeta,
+			Spec:       *(mod.Spec.(*gatewayv1beta1.GatewayClassSpec)),
+		}
+		patchBytes, err := genPatchBytes(oldRes, modRes, typ)
+		if err != nil {
+			return nil, err
+		}
+		return sc.GatewayV1alpha2().GatewayClasses().
+			Patch(context.TODO(), orig.Name, typ, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+	case gateway_networking_k8s_io_v1beta1_Gateway:
+		oldRes := &gatewayv1beta1.Gateway{
+			ObjectMeta: origMeta,
+			Spec:       *(orig.Spec.(*gatewayv1beta1.GatewaySpec)),
+		}
+		modRes := &gatewayv1beta1.Gateway{
+			ObjectMeta: modMeta,
+			Spec:       *(mod.Spec.(*gatewayv1beta1.GatewaySpec)),
+		}
+		patchBytes, err := genPatchBytes(oldRes, modRes, typ)
+		if err != nil {
+			return nil, err
+		}
+		return sc.GatewayV1beta1().Gateways(orig.Namespace).
+			Patch(context.TODO(), orig.Name, typ, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+	case gateway_networking_k8s_io_v1alpha2_Gateway:
+		oldRes := &gatewayv1alpha2.Gateway{
+			ObjectMeta: origMeta,
+			Spec:       *(orig.Spec.(*gatewayv1beta1.GatewaySpec)),
+		}
+		modRes := &gatewayv1alpha2.Gateway{
+			ObjectMeta: modMeta,
+			Spec:       *(mod.Spec.(*gatewayv1beta1.GatewaySpec)),
+		}
+		patchBytes, err := genPatchBytes(oldRes, modRes, typ)
+		if err != nil {
+			return nil, err
+		}
+		return sc.GatewayV1alpha2().Gateways(orig.Namespace).
+			Patch(context.TODO(), orig.Name, typ, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+	case gateway_networking_k8s_io_v1beta1_HTTPRoute:
+		oldRes := &gatewayv1beta1.HTTPRoute{
+			ObjectMeta: origMeta,
+			Spec:       *(orig.Spec.(*gatewayv1beta1.HTTPRouteSpec)),
+		}
+		modRes := &gatewayv1beta1.HTTPRoute{
+			ObjectMeta: modMeta,
+			Spec:       *(mod.Spec.(*gatewayv1beta1.HTTPRouteSpec)),
+		}
+		patchBytes, err := genPatchBytes(oldRes, modRes, typ)
+		if err != nil {
+			return nil, err
+		}
+		return sc.GatewayV1beta1().HTTPRoutes(orig.Namespace).
+			Patch(context.TODO(), orig.Name, typ, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+	case gateway_networking_k8s_io_v1alpha2_HTTPRoute:
+		oldRes := &gatewayv1alpha2.HTTPRoute{
+			ObjectMeta: origMeta,
+			Spec:       *(orig.Spec.(*gatewayv1beta1.HTTPRouteSpec)),
+		}
+		modRes := &gatewayv1alpha2.HTTPRoute{
+			ObjectMeta: modMeta,
+			Spec:       *(mod.Spec.(*gatewayv1beta1.HTTPRouteSpec)),
+		}
+		patchBytes, err := genPatchBytes(oldRes, modRes, typ)
+		if err != nil {
+			return nil, err
+		}
+		return sc.GatewayV1alpha2().HTTPRoutes(orig.Namespace).
+			Patch(context.TODO(), orig.Name, typ, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
 	default:
 		return nil, fmt.Errorf("unsupported type: %v", orig.GroupVersionKind)
 	}
@@ -729,59 +822,102 @@ func delete(ic versionedclient.Interface, sc gatewayapiclient.Interface, typ con
 		deleteOptions.Preconditions = &metav1.Preconditions{ResourceVersion: resourceVersion}
 	}
 	switch typ {
-	case collections.IstioExtensionsV1Alpha1Wasmplugins.Resource().GroupVersionKind():
+	case extensions_istio_io_v1alpha1_WasmPlugin:
 		return ic.ExtensionsV1alpha1().WasmPlugins(namespace).Delete(context.TODO(), name, deleteOptions)
-	case collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind():
+	case networking_istio_io_v1alpha3_DestinationRule:
 		return ic.NetworkingV1alpha3().DestinationRules(namespace).Delete(context.TODO(), name, deleteOptions)
-	case collections.IstioNetworkingV1Alpha3Envoyfilters.Resource().GroupVersionKind():
+	case networking_istio_io_v1alpha3_EnvoyFilter:
 		return ic.NetworkingV1alpha3().EnvoyFilters(namespace).Delete(context.TODO(), name, deleteOptions)
-	case collections.IstioNetworkingV1Alpha3Gateways.Resource().GroupVersionKind():
+	case networking_istio_io_v1alpha3_Gateway:
 		return ic.NetworkingV1alpha3().Gateways(namespace).Delete(context.TODO(), name, deleteOptions)
-	case collections.IstioNetworkingV1Alpha3Serviceentries.Resource().GroupVersionKind():
+	case networking_istio_io_v1alpha3_ServiceEntry:
 		return ic.NetworkingV1alpha3().ServiceEntries(namespace).Delete(context.TODO(), name, deleteOptions)
-	case collections.IstioNetworkingV1Alpha3Sidecars.Resource().GroupVersionKind():
+	case networking_istio_io_v1alpha3_Sidecar:
 		return ic.NetworkingV1alpha3().Sidecars(namespace).Delete(context.TODO(), name, deleteOptions)
-	case collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind():
+	case networking_istio_io_v1alpha3_VirtualService:
 		return ic.NetworkingV1alpha3().VirtualServices(namespace).Delete(context.TODO(), name, deleteOptions)
-	case collections.IstioNetworkingV1Alpha3Workloadentries.Resource().GroupVersionKind():
+	case networking_istio_io_v1alpha3_WorkloadEntry:
 		return ic.NetworkingV1alpha3().WorkloadEntries(namespace).Delete(context.TODO(), name, deleteOptions)
-	case collections.IstioNetworkingV1Alpha3Workloadgroups.Resource().GroupVersionKind():
+	case networking_istio_io_v1alpha3_WorkloadGroup:
 		return ic.NetworkingV1alpha3().WorkloadGroups(namespace).Delete(context.TODO(), name, deleteOptions)
-	case collections.IstioNetworkingV1Beta1Proxyconfigs.Resource().GroupVersionKind():
+	case networking_istio_io_v1beta1_ProxyConfig:
 		return ic.NetworkingV1beta1().ProxyConfigs(namespace).Delete(context.TODO(), name, deleteOptions)
-	case collections.IstioSecurityV1Beta1Authorizationpolicies.Resource().GroupVersionKind():
+	case security_istio_io_v1beta1_AuthorizationPolicy:
 		return ic.SecurityV1beta1().AuthorizationPolicies(namespace).Delete(context.TODO(), name, deleteOptions)
-	case collections.IstioSecurityV1Beta1Peerauthentications.Resource().GroupVersionKind():
+	case security_istio_io_v1beta1_PeerAuthentication:
 		return ic.SecurityV1beta1().PeerAuthentications(namespace).Delete(context.TODO(), name, deleteOptions)
-	case collections.IstioSecurityV1Beta1Requestauthentications.Resource().GroupVersionKind():
+	case security_istio_io_v1beta1_RequestAuthentication:
 		return ic.SecurityV1beta1().RequestAuthentications(namespace).Delete(context.TODO(), name, deleteOptions)
-	case collections.IstioTelemetryV1Alpha1Telemetries.Resource().GroupVersionKind():
+	case telemetry_istio_io_v1alpha1_Telemetry:
 		return ic.TelemetryV1alpha1().Telemetries(namespace).Delete(context.TODO(), name, deleteOptions)
-	case collections.K8SGatewayApiV1Alpha2Gatewayclasses.Resource().GroupVersionKind():
-		return sc.GatewayV1alpha2().GatewayClasses().Delete(context.TODO(), name, deleteOptions)
-	case collections.K8SGatewayApiV1Alpha2Gateways.Resource().GroupVersionKind():
-		return sc.GatewayV1alpha2().Gateways(namespace).Delete(context.TODO(), name, deleteOptions)
-	case collections.K8SGatewayApiV1Alpha2Httproutes.Resource().GroupVersionKind():
-		return sc.GatewayV1alpha2().HTTPRoutes(namespace).Delete(context.TODO(), name, deleteOptions)
-	case collections.K8SGatewayApiV1Alpha2Referencegrants.Resource().GroupVersionKind():
+	case gateway_networking_k8s_io_v1alpha2_ReferenceGrant:
 		return sc.GatewayV1alpha2().ReferenceGrants(namespace).Delete(context.TODO(), name, deleteOptions)
-	case collections.K8SGatewayApiV1Alpha2Referencepolicies.Resource().GroupVersionKind():
+	case gateway_networking_k8s_io_v1alpha2_ReferencePolicy:
 		return sc.GatewayV1alpha2().ReferencePolicies(namespace).Delete(context.TODO(), name, deleteOptions)
-	case collections.K8SGatewayApiV1Alpha2Tcproutes.Resource().GroupVersionKind():
+	case gateway_networking_k8s_io_v1alpha2_TCPRoute:
 		return sc.GatewayV1alpha2().TCPRoutes(namespace).Delete(context.TODO(), name, deleteOptions)
-	case collections.K8SGatewayApiV1Alpha2Tlsroutes.Resource().GroupVersionKind():
+	case gateway_networking_k8s_io_v1alpha2_TLSRoute:
 		return sc.GatewayV1alpha2().TLSRoutes(namespace).Delete(context.TODO(), name, deleteOptions)
+	case gateway_networking_k8s_io_v1beta1_GatewayClass:
+		return sc.GatewayV1beta1().GatewayClasses().Delete(context.TODO(), name, deleteOptions)
+	case gateway_networking_k8s_io_v1alpha2_GatewayClass:
+		return sc.GatewayV1alpha2().GatewayClasses().Delete(context.TODO(), name, deleteOptions)
+	case gateway_networking_k8s_io_v1beta1_Gateway:
+		return sc.GatewayV1beta1().Gateways(namespace).Delete(context.TODO(), name, deleteOptions)
+	case gateway_networking_k8s_io_v1alpha2_Gateway:
+		return sc.GatewayV1alpha2().Gateways(namespace).Delete(context.TODO(), name, deleteOptions)
+	case gateway_networking_k8s_io_v1beta1_HTTPRoute:
+		return sc.GatewayV1beta1().HTTPRoutes(namespace).Delete(context.TODO(), name, deleteOptions)
+	case gateway_networking_k8s_io_v1alpha2_HTTPRoute:
+		return sc.GatewayV1alpha2().HTTPRoutes(namespace).Delete(context.TODO(), name, deleteOptions)
 	default:
 		return fmt.Errorf("unsupported type: %v", typ)
 	}
 }
 
+var extensions_istio_io_v1alpha1_WasmPlugin = config.GroupVersionKind{Group: "extensions.istio.io", Version: "v1alpha1", Kind: "WasmPlugin"}
+var networking_istio_io_v1alpha3_DestinationRule = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1alpha3", Kind: "DestinationRule"}
+var networking_istio_io_v1alpha3_EnvoyFilter = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1alpha3", Kind: "EnvoyFilter"}
+var networking_istio_io_v1alpha3_Gateway = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1alpha3", Kind: "Gateway"}
+var networking_istio_io_v1alpha3_ServiceEntry = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1alpha3", Kind: "ServiceEntry"}
+var networking_istio_io_v1alpha3_Sidecar = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1alpha3", Kind: "Sidecar"}
+var networking_istio_io_v1alpha3_VirtualService = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1alpha3", Kind: "VirtualService"}
+var networking_istio_io_v1alpha3_WorkloadEntry = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1alpha3", Kind: "WorkloadEntry"}
+var networking_istio_io_v1alpha3_WorkloadGroup = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1alpha3", Kind: "WorkloadGroup"}
+var networking_istio_io_v1beta1_ProxyConfig = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1beta1", Kind: "ProxyConfig"}
+var security_istio_io_v1beta1_AuthorizationPolicy = config.GroupVersionKind{Group: "security.istio.io", Version: "v1beta1", Kind: "AuthorizationPolicy"}
+var security_istio_io_v1beta1_PeerAuthentication = config.GroupVersionKind{Group: "security.istio.io", Version: "v1beta1", Kind: "PeerAuthentication"}
+var security_istio_io_v1beta1_RequestAuthentication = config.GroupVersionKind{Group: "security.istio.io", Version: "v1beta1", Kind: "RequestAuthentication"}
+var telemetry_istio_io_v1alpha1_Telemetry = config.GroupVersionKind{Group: "telemetry.istio.io", Version: "v1alpha1", Kind: "Telemetry"}
+var gateway_networking_k8s_io_v1alpha2_ReferenceGrant = config.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Kind: "ReferenceGrant"}
+var gateway_networking_k8s_io_v1alpha2_ReferencePolicy = config.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Kind: "ReferencePolicy"}
+var gateway_networking_k8s_io_v1alpha2_TCPRoute = config.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Kind: "TCPRoute"}
+var gateway_networking_k8s_io_v1alpha2_TLSRoute = config.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Kind: "TLSRoute"}
+var gateway_networking_k8s_io_v1beta1_GatewayClass = config.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1beta1", Kind: "GatewayClass"}
+var gateway_networking_k8s_io_v1alpha2_GatewayClass = config.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Kind: "GatewayClass"}
+var gateway_networking_k8s_io_v1beta1_Gateway = config.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1beta1", Kind: "Gateway"}
+var gateway_networking_k8s_io_v1alpha2_Gateway = config.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Kind: "Gateway"}
+var gateway_networking_k8s_io_v1beta1_HTTPRoute = config.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1beta1", Kind: "HTTPRoute"}
+var gateway_networking_k8s_io_v1alpha2_HTTPRoute = config.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Kind: "HTTPRoute"}
+var admissionregistration_k8s_io_v1_MutatingWebhookConfiguration = config.GroupVersionKind{Group: "admissionregistration.k8s.io", Version: "v1", Kind: "MutatingWebhookConfiguration"}
+var apiextensions_k8s_io_v1_CustomResourceDefinition = config.GroupVersionKind{Group: "apiextensions.k8s.io", Version: "v1", Kind: "CustomResourceDefinition"}
+var apps_v1_Deployment = config.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}
+var core_v1_ConfigMap = config.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}
+var core_v1_Endpoints = config.GroupVersionKind{Group: "", Version: "v1", Kind: "Endpoints"}
+var core_v1_Namespace = config.GroupVersionKind{Group: "", Version: "v1", Kind: "Namespace"}
+var core_v1_Node = config.GroupVersionKind{Group: "", Version: "v1", Kind: "Node"}
+var core_v1_Pod = config.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"}
+var core_v1_Secret = config.GroupVersionKind{Group: "", Version: "v1", Kind: "Secret"}
+var core_v1_Service = config.GroupVersionKind{Group: "", Version: "v1", Kind: "Service"}
+var extensions_v1beta1_Ingress = config.GroupVersionKind{Group: "extensions", Version: "v1beta1", Kind: "Ingress"}
+
 var translationMap = map[config.GroupVersionKind]func(r runtime.Object) config.Config{
-	collections.IstioExtensionsV1Alpha1Wasmplugins.Resource().GroupVersionKind(): func(r runtime.Object) config.Config {
+
+	extensions_istio_io_v1alpha1_WasmPlugin: func(r runtime.Object) config.Config {
 		obj := r.(*clientextensionsv1alpha1.WasmPlugin)
 		return config.Config{
 			Meta: config.Meta{
-				GroupVersionKind:  collections.IstioExtensionsV1Alpha1Wasmplugins.Resource().GroupVersionKind(),
+				GroupVersionKind:  extensions_istio_io_v1alpha1_WasmPlugin,
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
 				Labels:            obj.Labels,
@@ -796,11 +932,12 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) config.C
 			Status: &obj.Status,
 		}
 	},
-	collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind(): func(r runtime.Object) config.Config {
+
+	networking_istio_io_v1alpha3_DestinationRule: func(r runtime.Object) config.Config {
 		obj := r.(*clientnetworkingv1alpha3.DestinationRule)
 		return config.Config{
 			Meta: config.Meta{
-				GroupVersionKind:  collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind(),
+				GroupVersionKind:  networking_istio_io_v1alpha3_DestinationRule,
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
 				Labels:            obj.Labels,
@@ -815,11 +952,12 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) config.C
 			Status: &obj.Status,
 		}
 	},
-	collections.IstioNetworkingV1Alpha3Envoyfilters.Resource().GroupVersionKind(): func(r runtime.Object) config.Config {
+
+	networking_istio_io_v1alpha3_EnvoyFilter: func(r runtime.Object) config.Config {
 		obj := r.(*clientnetworkingv1alpha3.EnvoyFilter)
 		return config.Config{
 			Meta: config.Meta{
-				GroupVersionKind:  collections.IstioNetworkingV1Alpha3Envoyfilters.Resource().GroupVersionKind(),
+				GroupVersionKind:  networking_istio_io_v1alpha3_EnvoyFilter,
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
 				Labels:            obj.Labels,
@@ -834,11 +972,12 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) config.C
 			Status: &obj.Status,
 		}
 	},
-	collections.IstioNetworkingV1Alpha3Gateways.Resource().GroupVersionKind(): func(r runtime.Object) config.Config {
+
+	networking_istio_io_v1alpha3_Gateway: func(r runtime.Object) config.Config {
 		obj := r.(*clientnetworkingv1alpha3.Gateway)
 		return config.Config{
 			Meta: config.Meta{
-				GroupVersionKind:  collections.IstioNetworkingV1Alpha3Gateways.Resource().GroupVersionKind(),
+				GroupVersionKind:  networking_istio_io_v1alpha3_Gateway,
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
 				Labels:            obj.Labels,
@@ -853,11 +992,12 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) config.C
 			Status: &obj.Status,
 		}
 	},
-	collections.IstioNetworkingV1Alpha3Serviceentries.Resource().GroupVersionKind(): func(r runtime.Object) config.Config {
+
+	networking_istio_io_v1alpha3_ServiceEntry: func(r runtime.Object) config.Config {
 		obj := r.(*clientnetworkingv1alpha3.ServiceEntry)
 		return config.Config{
 			Meta: config.Meta{
-				GroupVersionKind:  collections.IstioNetworkingV1Alpha3Serviceentries.Resource().GroupVersionKind(),
+				GroupVersionKind:  networking_istio_io_v1alpha3_ServiceEntry,
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
 				Labels:            obj.Labels,
@@ -872,11 +1012,12 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) config.C
 			Status: &obj.Status,
 		}
 	},
-	collections.IstioNetworkingV1Alpha3Sidecars.Resource().GroupVersionKind(): func(r runtime.Object) config.Config {
+
+	networking_istio_io_v1alpha3_Sidecar: func(r runtime.Object) config.Config {
 		obj := r.(*clientnetworkingv1alpha3.Sidecar)
 		return config.Config{
 			Meta: config.Meta{
-				GroupVersionKind:  collections.IstioNetworkingV1Alpha3Sidecars.Resource().GroupVersionKind(),
+				GroupVersionKind:  networking_istio_io_v1alpha3_Sidecar,
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
 				Labels:            obj.Labels,
@@ -891,11 +1032,12 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) config.C
 			Status: &obj.Status,
 		}
 	},
-	collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(): func(r runtime.Object) config.Config {
+
+	networking_istio_io_v1alpha3_VirtualService: func(r runtime.Object) config.Config {
 		obj := r.(*clientnetworkingv1alpha3.VirtualService)
 		return config.Config{
 			Meta: config.Meta{
-				GroupVersionKind:  collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
+				GroupVersionKind:  networking_istio_io_v1alpha3_VirtualService,
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
 				Labels:            obj.Labels,
@@ -910,11 +1052,12 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) config.C
 			Status: &obj.Status,
 		}
 	},
-	collections.IstioNetworkingV1Alpha3Workloadentries.Resource().GroupVersionKind(): func(r runtime.Object) config.Config {
+
+	networking_istio_io_v1alpha3_WorkloadEntry: func(r runtime.Object) config.Config {
 		obj := r.(*clientnetworkingv1alpha3.WorkloadEntry)
 		return config.Config{
 			Meta: config.Meta{
-				GroupVersionKind:  collections.IstioNetworkingV1Alpha3Workloadentries.Resource().GroupVersionKind(),
+				GroupVersionKind:  networking_istio_io_v1alpha3_WorkloadEntry,
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
 				Labels:            obj.Labels,
@@ -929,11 +1072,12 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) config.C
 			Status: &obj.Status,
 		}
 	},
-	collections.IstioNetworkingV1Alpha3Workloadgroups.Resource().GroupVersionKind(): func(r runtime.Object) config.Config {
+
+	networking_istio_io_v1alpha3_WorkloadGroup: func(r runtime.Object) config.Config {
 		obj := r.(*clientnetworkingv1alpha3.WorkloadGroup)
 		return config.Config{
 			Meta: config.Meta{
-				GroupVersionKind:  collections.IstioNetworkingV1Alpha3Workloadgroups.Resource().GroupVersionKind(),
+				GroupVersionKind:  networking_istio_io_v1alpha3_WorkloadGroup,
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
 				Labels:            obj.Labels,
@@ -948,11 +1092,12 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) config.C
 			Status: &obj.Status,
 		}
 	},
-	collections.IstioNetworkingV1Beta1Proxyconfigs.Resource().GroupVersionKind(): func(r runtime.Object) config.Config {
+
+	networking_istio_io_v1beta1_ProxyConfig: func(r runtime.Object) config.Config {
 		obj := r.(*clientnetworkingv1beta1.ProxyConfig)
 		return config.Config{
 			Meta: config.Meta{
-				GroupVersionKind:  collections.IstioNetworkingV1Beta1Proxyconfigs.Resource().GroupVersionKind(),
+				GroupVersionKind:  networking_istio_io_v1beta1_ProxyConfig,
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
 				Labels:            obj.Labels,
@@ -967,11 +1112,12 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) config.C
 			Status: &obj.Status,
 		}
 	},
-	collections.IstioSecurityV1Beta1Authorizationpolicies.Resource().GroupVersionKind(): func(r runtime.Object) config.Config {
+
+	security_istio_io_v1beta1_AuthorizationPolicy: func(r runtime.Object) config.Config {
 		obj := r.(*clientsecurityv1beta1.AuthorizationPolicy)
 		return config.Config{
 			Meta: config.Meta{
-				GroupVersionKind:  collections.IstioSecurityV1Beta1Authorizationpolicies.Resource().GroupVersionKind(),
+				GroupVersionKind:  security_istio_io_v1beta1_AuthorizationPolicy,
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
 				Labels:            obj.Labels,
@@ -986,11 +1132,12 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) config.C
 			Status: &obj.Status,
 		}
 	},
-	collections.IstioSecurityV1Beta1Peerauthentications.Resource().GroupVersionKind(): func(r runtime.Object) config.Config {
+
+	security_istio_io_v1beta1_PeerAuthentication: func(r runtime.Object) config.Config {
 		obj := r.(*clientsecurityv1beta1.PeerAuthentication)
 		return config.Config{
 			Meta: config.Meta{
-				GroupVersionKind:  collections.IstioSecurityV1Beta1Peerauthentications.Resource().GroupVersionKind(),
+				GroupVersionKind:  security_istio_io_v1beta1_PeerAuthentication,
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
 				Labels:            obj.Labels,
@@ -1005,11 +1152,12 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) config.C
 			Status: &obj.Status,
 		}
 	},
-	collections.IstioSecurityV1Beta1Requestauthentications.Resource().GroupVersionKind(): func(r runtime.Object) config.Config {
+
+	security_istio_io_v1beta1_RequestAuthentication: func(r runtime.Object) config.Config {
 		obj := r.(*clientsecurityv1beta1.RequestAuthentication)
 		return config.Config{
 			Meta: config.Meta{
-				GroupVersionKind:  collections.IstioSecurityV1Beta1Requestauthentications.Resource().GroupVersionKind(),
+				GroupVersionKind:  security_istio_io_v1beta1_RequestAuthentication,
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
 				Labels:            obj.Labels,
@@ -1024,11 +1172,12 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) config.C
 			Status: &obj.Status,
 		}
 	},
-	collections.IstioTelemetryV1Alpha1Telemetries.Resource().GroupVersionKind(): func(r runtime.Object) config.Config {
+
+	telemetry_istio_io_v1alpha1_Telemetry: func(r runtime.Object) config.Config {
 		obj := r.(*clienttelemetryv1alpha1.Telemetry)
 		return config.Config{
 			Meta: config.Meta{
-				GroupVersionKind:  collections.IstioTelemetryV1Alpha1Telemetries.Resource().GroupVersionKind(),
+				GroupVersionKind:  telemetry_istio_io_v1alpha1_Telemetry,
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
 				Labels:            obj.Labels,
@@ -1043,68 +1192,12 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) config.C
 			Status: &obj.Status,
 		}
 	},
-	collections.K8SGatewayApiV1Alpha2Gatewayclasses.Resource().GroupVersionKind(): func(r runtime.Object) config.Config {
-		obj := r.(*gatewayv1alpha2.GatewayClass)
-		return config.Config{
-			Meta: config.Meta{
-				GroupVersionKind:  collections.K8SGatewayApiV1Alpha2Gatewayclasses.Resource().GroupVersionKind(),
-				Name:              obj.Name,
-				Namespace:         obj.Namespace,
-				Labels:            obj.Labels,
-				Annotations:       obj.Annotations,
-				ResourceVersion:   obj.ResourceVersion,
-				CreationTimestamp: obj.CreationTimestamp.Time,
-				OwnerReferences:   obj.OwnerReferences,
-				UID:               string(obj.UID),
-				Generation:        obj.Generation,
-			},
-			Spec:   &obj.Spec,
-			Status: &obj.Status,
-		}
-	},
-	collections.K8SGatewayApiV1Alpha2Gateways.Resource().GroupVersionKind(): func(r runtime.Object) config.Config {
-		obj := r.(*gatewayv1alpha2.Gateway)
-		return config.Config{
-			Meta: config.Meta{
-				GroupVersionKind:  collections.K8SGatewayApiV1Alpha2Gateways.Resource().GroupVersionKind(),
-				Name:              obj.Name,
-				Namespace:         obj.Namespace,
-				Labels:            obj.Labels,
-				Annotations:       obj.Annotations,
-				ResourceVersion:   obj.ResourceVersion,
-				CreationTimestamp: obj.CreationTimestamp.Time,
-				OwnerReferences:   obj.OwnerReferences,
-				UID:               string(obj.UID),
-				Generation:        obj.Generation,
-			},
-			Spec:   &obj.Spec,
-			Status: &obj.Status,
-		}
-	},
-	collections.K8SGatewayApiV1Alpha2Httproutes.Resource().GroupVersionKind(): func(r runtime.Object) config.Config {
-		obj := r.(*gatewayv1alpha2.HTTPRoute)
-		return config.Config{
-			Meta: config.Meta{
-				GroupVersionKind:  collections.K8SGatewayApiV1Alpha2Httproutes.Resource().GroupVersionKind(),
-				Name:              obj.Name,
-				Namespace:         obj.Namespace,
-				Labels:            obj.Labels,
-				Annotations:       obj.Annotations,
-				ResourceVersion:   obj.ResourceVersion,
-				CreationTimestamp: obj.CreationTimestamp.Time,
-				OwnerReferences:   obj.OwnerReferences,
-				UID:               string(obj.UID),
-				Generation:        obj.Generation,
-			},
-			Spec:   &obj.Spec,
-			Status: &obj.Status,
-		}
-	},
-	collections.K8SGatewayApiV1Alpha2Referencegrants.Resource().GroupVersionKind(): func(r runtime.Object) config.Config {
+
+	gateway_networking_k8s_io_v1alpha2_ReferenceGrant: func(r runtime.Object) config.Config {
 		obj := r.(*gatewayv1alpha2.ReferenceGrant)
 		return config.Config{
 			Meta: config.Meta{
-				GroupVersionKind:  collections.K8SGatewayApiV1Alpha2Referencegrants.Resource().GroupVersionKind(),
+				GroupVersionKind:  gateway_networking_k8s_io_v1alpha2_ReferenceGrant,
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
 				Labels:            obj.Labels,
@@ -1118,11 +1211,12 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) config.C
 			Spec: &obj.Spec,
 		}
 	},
-	collections.K8SGatewayApiV1Alpha2Referencepolicies.Resource().GroupVersionKind(): func(r runtime.Object) config.Config {
+
+	gateway_networking_k8s_io_v1alpha2_ReferencePolicy: func(r runtime.Object) config.Config {
 		obj := r.(*gatewayv1alpha2.ReferencePolicy)
 		return config.Config{
 			Meta: config.Meta{
-				GroupVersionKind:  collections.K8SGatewayApiV1Alpha2Referencepolicies.Resource().GroupVersionKind(),
+				GroupVersionKind:  gateway_networking_k8s_io_v1alpha2_ReferencePolicy,
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
 				Labels:            obj.Labels,
@@ -1136,11 +1230,12 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) config.C
 			Spec: &obj.Spec,
 		}
 	},
-	collections.K8SGatewayApiV1Alpha2Tcproutes.Resource().GroupVersionKind(): func(r runtime.Object) config.Config {
+
+	gateway_networking_k8s_io_v1alpha2_TCPRoute: func(r runtime.Object) config.Config {
 		obj := r.(*gatewayv1alpha2.TCPRoute)
 		return config.Config{
 			Meta: config.Meta{
-				GroupVersionKind:  collections.K8SGatewayApiV1Alpha2Tcproutes.Resource().GroupVersionKind(),
+				GroupVersionKind:  gateway_networking_k8s_io_v1alpha2_TCPRoute,
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
 				Labels:            obj.Labels,
@@ -1155,11 +1250,12 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) config.C
 			Status: &obj.Status,
 		}
 	},
-	collections.K8SGatewayApiV1Alpha2Tlsroutes.Resource().GroupVersionKind(): func(r runtime.Object) config.Config {
+
+	gateway_networking_k8s_io_v1alpha2_TLSRoute: func(r runtime.Object) config.Config {
 		obj := r.(*gatewayv1alpha2.TLSRoute)
 		return config.Config{
 			Meta: config.Meta{
-				GroupVersionKind:  collections.K8SGatewayApiV1Alpha2Tlsroutes.Resource().GroupVersionKind(),
+				GroupVersionKind:  gateway_networking_k8s_io_v1alpha2_TLSRoute,
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
 				Labels:            obj.Labels,
@@ -1174,11 +1270,186 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) config.C
 			Status: &obj.Status,
 		}
 	},
-	collections.K8SAdmissionregistrationK8SIoV1Mutatingwebhookconfigurations.Resource().GroupVersionKind(): func(r runtime.Object) config.Config {
+
+	gateway_networking_k8s_io_v1beta1_GatewayClass: func(r runtime.Object) config.Config {
+		// Not primary
+		var obj *gatewayv1beta1.GatewayClass
+		switch v := r.(type) {
+		case *gatewayv1beta1.GatewayClass:
+			obj = (*gatewayv1beta1.GatewayClass)(v)
+		case *gatewayv1alpha2.GatewayClass:
+			obj = (*gatewayv1beta1.GatewayClass)(v)
+		default:
+			panic(fmt.Sprintf("unknown type %T", v))
+		}
+		return config.Config{
+			Meta: config.Meta{
+				GroupVersionKind:  gateway_networking_k8s_io_v1beta1_GatewayClass,
+				Name:              obj.Name,
+				Namespace:         obj.Namespace,
+				Labels:            obj.Labels,
+				Annotations:       obj.Annotations,
+				ResourceVersion:   obj.ResourceVersion,
+				CreationTimestamp: obj.CreationTimestamp.Time,
+				OwnerReferences:   obj.OwnerReferences,
+				UID:               string(obj.UID),
+				Generation:        obj.Generation,
+			},
+			Spec:   &obj.Spec,
+			Status: &obj.Status,
+		}
+	},
+
+	gateway_networking_k8s_io_v1alpha2_GatewayClass: func(r runtime.Object) config.Config {
+		// Not primary
+		var obj *gatewayv1beta1.GatewayClass
+		switch v := r.(type) {
+		case *gatewayv1beta1.GatewayClass:
+			obj = (*gatewayv1beta1.GatewayClass)(v)
+		case *gatewayv1alpha2.GatewayClass:
+			obj = (*gatewayv1beta1.GatewayClass)(v)
+		default:
+			panic(fmt.Sprintf("unknown type %T", v))
+		}
+		return config.Config{
+			Meta: config.Meta{
+				GroupVersionKind:  gateway_networking_k8s_io_v1alpha2_GatewayClass,
+				Name:              obj.Name,
+				Namespace:         obj.Namespace,
+				Labels:            obj.Labels,
+				Annotations:       obj.Annotations,
+				ResourceVersion:   obj.ResourceVersion,
+				CreationTimestamp: obj.CreationTimestamp.Time,
+				OwnerReferences:   obj.OwnerReferences,
+				UID:               string(obj.UID),
+				Generation:        obj.Generation,
+			},
+			Spec:   &obj.Spec,
+			Status: &obj.Status,
+		}
+	},
+
+	gateway_networking_k8s_io_v1beta1_Gateway: func(r runtime.Object) config.Config {
+		// Not primary
+		var obj *gatewayv1beta1.Gateway
+		switch v := r.(type) {
+		case *gatewayv1beta1.Gateway:
+			obj = (*gatewayv1beta1.Gateway)(v)
+		case *gatewayv1alpha2.Gateway:
+			obj = (*gatewayv1beta1.Gateway)(v)
+		default:
+			panic(fmt.Sprintf("unknown type %T", v))
+		}
+		return config.Config{
+			Meta: config.Meta{
+				GroupVersionKind:  gateway_networking_k8s_io_v1beta1_Gateway,
+				Name:              obj.Name,
+				Namespace:         obj.Namespace,
+				Labels:            obj.Labels,
+				Annotations:       obj.Annotations,
+				ResourceVersion:   obj.ResourceVersion,
+				CreationTimestamp: obj.CreationTimestamp.Time,
+				OwnerReferences:   obj.OwnerReferences,
+				UID:               string(obj.UID),
+				Generation:        obj.Generation,
+			},
+			Spec:   &obj.Spec,
+			Status: &obj.Status,
+		}
+	},
+
+	gateway_networking_k8s_io_v1alpha2_Gateway: func(r runtime.Object) config.Config {
+		// Not primary
+		var obj *gatewayv1beta1.Gateway
+		switch v := r.(type) {
+		case *gatewayv1beta1.Gateway:
+			obj = (*gatewayv1beta1.Gateway)(v)
+		case *gatewayv1alpha2.Gateway:
+			obj = (*gatewayv1beta1.Gateway)(v)
+		default:
+			panic(fmt.Sprintf("unknown type %T", v))
+		}
+		return config.Config{
+			Meta: config.Meta{
+				GroupVersionKind:  gateway_networking_k8s_io_v1alpha2_Gateway,
+				Name:              obj.Name,
+				Namespace:         obj.Namespace,
+				Labels:            obj.Labels,
+				Annotations:       obj.Annotations,
+				ResourceVersion:   obj.ResourceVersion,
+				CreationTimestamp: obj.CreationTimestamp.Time,
+				OwnerReferences:   obj.OwnerReferences,
+				UID:               string(obj.UID),
+				Generation:        obj.Generation,
+			},
+			Spec:   &obj.Spec,
+			Status: &obj.Status,
+		}
+	},
+
+	gateway_networking_k8s_io_v1beta1_HTTPRoute: func(r runtime.Object) config.Config {
+		// Not primary
+		var obj *gatewayv1beta1.HTTPRoute
+		switch v := r.(type) {
+		case *gatewayv1beta1.HTTPRoute:
+			obj = (*gatewayv1beta1.HTTPRoute)(v)
+		case *gatewayv1alpha2.HTTPRoute:
+			obj = (*gatewayv1beta1.HTTPRoute)(v)
+		default:
+			panic(fmt.Sprintf("unknown type %T", v))
+		}
+		return config.Config{
+			Meta: config.Meta{
+				GroupVersionKind:  gateway_networking_k8s_io_v1beta1_HTTPRoute,
+				Name:              obj.Name,
+				Namespace:         obj.Namespace,
+				Labels:            obj.Labels,
+				Annotations:       obj.Annotations,
+				ResourceVersion:   obj.ResourceVersion,
+				CreationTimestamp: obj.CreationTimestamp.Time,
+				OwnerReferences:   obj.OwnerReferences,
+				UID:               string(obj.UID),
+				Generation:        obj.Generation,
+			},
+			Spec:   &obj.Spec,
+			Status: &obj.Status,
+		}
+	},
+
+	gateway_networking_k8s_io_v1alpha2_HTTPRoute: func(r runtime.Object) config.Config {
+		// Not primary
+		var obj *gatewayv1beta1.HTTPRoute
+		switch v := r.(type) {
+		case *gatewayv1beta1.HTTPRoute:
+			obj = (*gatewayv1beta1.HTTPRoute)(v)
+		case *gatewayv1alpha2.HTTPRoute:
+			obj = (*gatewayv1beta1.HTTPRoute)(v)
+		default:
+			panic(fmt.Sprintf("unknown type %T", v))
+		}
+		return config.Config{
+			Meta: config.Meta{
+				GroupVersionKind:  gateway_networking_k8s_io_v1alpha2_HTTPRoute,
+				Name:              obj.Name,
+				Namespace:         obj.Namespace,
+				Labels:            obj.Labels,
+				Annotations:       obj.Annotations,
+				ResourceVersion:   obj.ResourceVersion,
+				CreationTimestamp: obj.CreationTimestamp.Time,
+				OwnerReferences:   obj.OwnerReferences,
+				UID:               string(obj.UID),
+				Generation:        obj.Generation,
+			},
+			Spec:   &obj.Spec,
+			Status: &obj.Status,
+		}
+	},
+
+	admissionregistration_k8s_io_v1_MutatingWebhookConfiguration: func(r runtime.Object) config.Config {
 		obj := r.(*admissionregistrationv1.MutatingWebhookConfiguration)
 		return config.Config{
 			Meta: config.Meta{
-				GroupVersionKind:  collections.K8SAdmissionregistrationK8SIoV1Mutatingwebhookconfigurations.Resource().GroupVersionKind(),
+				GroupVersionKind:  admissionregistration_k8s_io_v1_MutatingWebhookConfiguration,
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
 				Labels:            obj.Labels,
@@ -1192,11 +1463,12 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) config.C
 			Spec: obj,
 		}
 	},
-	collections.K8SApiextensionsK8SIoV1Customresourcedefinitions.Resource().GroupVersionKind(): func(r runtime.Object) config.Config {
+
+	apiextensions_k8s_io_v1_CustomResourceDefinition: func(r runtime.Object) config.Config {
 		obj := r.(*apiextensionsv1.CustomResourceDefinition)
 		return config.Config{
 			Meta: config.Meta{
-				GroupVersionKind:  collections.K8SApiextensionsK8SIoV1Customresourcedefinitions.Resource().GroupVersionKind(),
+				GroupVersionKind:  apiextensions_k8s_io_v1_CustomResourceDefinition,
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
 				Labels:            obj.Labels,
@@ -1210,11 +1482,12 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) config.C
 			Spec: &obj.Spec,
 		}
 	},
-	collections.K8SAppsV1Deployments.Resource().GroupVersionKind(): func(r runtime.Object) config.Config {
+
+	apps_v1_Deployment: func(r runtime.Object) config.Config {
 		obj := r.(*appsv1.Deployment)
 		return config.Config{
 			Meta: config.Meta{
-				GroupVersionKind:  collections.K8SAppsV1Deployments.Resource().GroupVersionKind(),
+				GroupVersionKind:  apps_v1_Deployment,
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
 				Labels:            obj.Labels,
@@ -1228,11 +1501,12 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) config.C
 			Spec: &obj.Spec,
 		}
 	},
-	collections.K8SCoreV1Configmaps.Resource().GroupVersionKind(): func(r runtime.Object) config.Config {
+
+	core_v1_ConfigMap: func(r runtime.Object) config.Config {
 		obj := r.(*corev1.ConfigMap)
 		return config.Config{
 			Meta: config.Meta{
-				GroupVersionKind:  collections.K8SCoreV1Configmaps.Resource().GroupVersionKind(),
+				GroupVersionKind:  core_v1_ConfigMap,
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
 				Labels:            obj.Labels,
@@ -1246,11 +1520,12 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) config.C
 			Spec: obj,
 		}
 	},
-	collections.K8SCoreV1Endpoints.Resource().GroupVersionKind(): func(r runtime.Object) config.Config {
+
+	core_v1_Endpoints: func(r runtime.Object) config.Config {
 		obj := r.(*corev1.Endpoints)
 		return config.Config{
 			Meta: config.Meta{
-				GroupVersionKind:  collections.K8SCoreV1Endpoints.Resource().GroupVersionKind(),
+				GroupVersionKind:  core_v1_Endpoints,
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
 				Labels:            obj.Labels,
@@ -1264,11 +1539,12 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) config.C
 			Spec: obj,
 		}
 	},
-	collections.K8SCoreV1Namespaces.Resource().GroupVersionKind(): func(r runtime.Object) config.Config {
+
+	core_v1_Namespace: func(r runtime.Object) config.Config {
 		obj := r.(*corev1.Namespace)
 		return config.Config{
 			Meta: config.Meta{
-				GroupVersionKind:  collections.K8SCoreV1Namespaces.Resource().GroupVersionKind(),
+				GroupVersionKind:  core_v1_Namespace,
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
 				Labels:            obj.Labels,
@@ -1282,11 +1558,12 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) config.C
 			Spec: &obj.Spec,
 		}
 	},
-	collections.K8SCoreV1Nodes.Resource().GroupVersionKind(): func(r runtime.Object) config.Config {
+
+	core_v1_Node: func(r runtime.Object) config.Config {
 		obj := r.(*corev1.Node)
 		return config.Config{
 			Meta: config.Meta{
-				GroupVersionKind:  collections.K8SCoreV1Nodes.Resource().GroupVersionKind(),
+				GroupVersionKind:  core_v1_Node,
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
 				Labels:            obj.Labels,
@@ -1300,11 +1577,12 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) config.C
 			Spec: &obj.Spec,
 		}
 	},
-	collections.K8SCoreV1Pods.Resource().GroupVersionKind(): func(r runtime.Object) config.Config {
+
+	core_v1_Pod: func(r runtime.Object) config.Config {
 		obj := r.(*corev1.Pod)
 		return config.Config{
 			Meta: config.Meta{
-				GroupVersionKind:  collections.K8SCoreV1Pods.Resource().GroupVersionKind(),
+				GroupVersionKind:  core_v1_Pod,
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
 				Labels:            obj.Labels,
@@ -1318,11 +1596,12 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) config.C
 			Spec: &obj.Spec,
 		}
 	},
-	collections.K8SCoreV1Secrets.Resource().GroupVersionKind(): func(r runtime.Object) config.Config {
+
+	core_v1_Secret: func(r runtime.Object) config.Config {
 		obj := r.(*corev1.Secret)
 		return config.Config{
 			Meta: config.Meta{
-				GroupVersionKind:  collections.K8SCoreV1Secrets.Resource().GroupVersionKind(),
+				GroupVersionKind:  core_v1_Secret,
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
 				Labels:            obj.Labels,
@@ -1336,11 +1615,12 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) config.C
 			Spec: obj,
 		}
 	},
-	collections.K8SCoreV1Services.Resource().GroupVersionKind(): func(r runtime.Object) config.Config {
+
+	core_v1_Service: func(r runtime.Object) config.Config {
 		obj := r.(*corev1.Service)
 		return config.Config{
 			Meta: config.Meta{
-				GroupVersionKind:  collections.K8SCoreV1Services.Resource().GroupVersionKind(),
+				GroupVersionKind:  core_v1_Service,
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
 				Labels:            obj.Labels,
@@ -1354,11 +1634,12 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) config.C
 			Spec: &obj.Spec,
 		}
 	},
-	collections.K8SExtensionsV1Beta1Ingresses.Resource().GroupVersionKind(): func(r runtime.Object) config.Config {
+
+	extensions_v1beta1_Ingress: func(r runtime.Object) config.Config {
 		obj := r.(*extensionsv1beta1.Ingress)
 		return config.Config{
 			Meta: config.Meta{
-				GroupVersionKind:  collections.K8SExtensionsV1Beta1Ingresses.Resource().GroupVersionKind(),
+				GroupVersionKind:  extensions_v1beta1_Ingress,
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
 				Labels:            obj.Labels,

--- a/pilot/pkg/config/kube/gateway/controller.go
+++ b/pilot/pkg/config/kube/gateway/controller.go
@@ -62,6 +62,8 @@ type Controller struct {
 	// cache provides access to the underlying gateway-configs
 	cache model.ConfigStoreController
 
+	clusterVersionTranslator func(typ config.GroupVersionKind) config.GroupVersionKind
+
 	// Gateway-api types reference namespace labels directly, so we need access to these
 	namespaceLister   listerv1.NamespaceLister
 	namespaceInformer cache.SharedIndexInformer
@@ -84,17 +86,18 @@ type Controller struct {
 
 var _ model.GatewayController = &Controller{}
 
-func NewController(client kube.Client, c model.ConfigStoreController, options controller.Options) *Controller {
+func NewController(client kube.Client, c model.ConfigStoreController, clusterVersionTranslator func(typ config.GroupVersionKind) config.GroupVersionKind, options controller.Options) *Controller {
 	var ctl *status.Controller
 
 	nsInformer := client.KubeInformer().Core().V1().Namespaces().Informer()
 	gatewayController := &Controller{
-		client:            client,
-		cache:             c,
-		namespaceLister:   client.KubeInformer().Core().V1().Namespaces().Lister(),
-		namespaceInformer: nsInformer,
-		domain:            options.DomainSuffix,
-		statusController:  ctl,
+		client:                   client,
+		cache:                    c,
+		clusterVersionTranslator: clusterVersionTranslator,
+		namespaceLister:          client.KubeInformer().Core().V1().Namespaces().Lister(),
+		namespaceInformer:        nsInformer,
+		domain:                   options.DomainSuffix,
+		statusController:         ctl,
 		// Disabled by default, we will enable only if we win the leader election
 		statusEnabled: atomic.NewBool(false),
 	}
@@ -284,7 +287,7 @@ func (c *Controller) Run(stop <-chan struct{}) {
 	c.started.Store(true)
 	go func() {
 		if crdclient.WaitForCRD(gvk.GatewayClass, stop) {
-			gcc := NewClassController(c.client)
+			gcc := NewClassController(c.client, c.clusterVersionTranslator(gvk.GatewayClass).Version)
 			c.client.RunAndWait(stop)
 			gcc.Run(stop)
 		}

--- a/pilot/pkg/config/kube/gateway/controller.go
+++ b/pilot/pkg/config/kube/gateway/controller.go
@@ -86,7 +86,12 @@ type Controller struct {
 
 var _ model.GatewayController = &Controller{}
 
-func NewController(client kube.Client, c model.ConfigStoreController, clusterVersionTranslator func(typ config.GroupVersionKind) config.GroupVersionKind, options controller.Options) *Controller {
+func NewController(
+	client kube.Client,
+	c model.ConfigStoreController,
+	clusterVersionTranslator func(typ config.GroupVersionKind) config.GroupVersionKind,
+	options controller.Options,
+) *Controller {
 	var ctl *status.Controller
 
 	nsInformer := client.KubeInformer().Core().V1().Namespaces().Informer()

--- a/pilot/pkg/config/kube/gateway/controller_test.go
+++ b/pilot/pkg/config/kube/gateway/controller_test.go
@@ -77,11 +77,15 @@ var (
 	}
 )
 
+var StaticVersionTranslator = func(typ config.GroupVersionKind) config.GroupVersionKind {
+	return typ
+}
+
 func TestListInvalidGroupVersionKind(t *testing.T) {
 	g := NewWithT(t)
 	clientSet := kube.NewFakeClient()
 	store := memory.NewController(memory.Make(collections.All))
-	controller := NewController(clientSet, store, controller.Options{})
+	controller := NewController(clientSet, store, StaticVersionTranslator, controller.Options{})
 
 	typ := config.GroupVersionKind{Kind: "wrong-kind"}
 	c, err := controller.List(typ, "ns1")
@@ -94,7 +98,7 @@ func TestListGatewayResourceType(t *testing.T) {
 
 	clientSet := kube.NewFakeClient()
 	store := memory.NewController(memory.Make(collections.All))
-	controller := NewController(clientSet, store, controller.Options{})
+	controller := NewController(clientSet, store, StaticVersionTranslator, controller.Options{})
 
 	store.Create(config.Config{
 		Meta: config.Meta{
@@ -141,7 +145,7 @@ func TestListVirtualServiceResourceType(t *testing.T) {
 
 	clientSet := kube.NewFakeClient()
 	store := memory.NewController(memory.Make(collections.All))
-	controller := NewController(clientSet, store, controller.Options{})
+	controller := NewController(clientSet, store, StaticVersionTranslator, controller.Options{})
 
 	store.Create(config.Config{
 		Meta: config.Meta{

--- a/pilot/pkg/config/kube/gateway/deploymentcontroller_v1alpha2.go
+++ b/pilot/pkg/config/kube/gateway/deploymentcontroller_v1alpha2.go
@@ -33,8 +33,9 @@ import (
 	appsinformersv1 "k8s.io/client-go/informers/apps/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
-	gateway "sigs.k8s.io/gateway-api/apis/v1beta1"
-	lister "sigs.k8s.io/gateway-api/pkg/client/listers/apis/v1beta1"
+	gateway "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewaybeta "sigs.k8s.io/gateway-api/apis/v1beta1"
+	lister "sigs.k8s.io/gateway-api/pkg/client/listers/apis/v1alpha2"
 	"sigs.k8s.io/yaml"
 
 	"istio.io/istio/pkg/config"
@@ -44,7 +45,7 @@ import (
 	istiolog "istio.io/pkg/log"
 )
 
-// DeploymentController implements a controller that materializes a Gateway into an in cluster gateway proxy
+// DeploymentControllerV1Alpha2 implements a controller that materializes a Gateway into an in cluster gateway proxy
 // to serve requests from. This is implemented with a Deployment and Service today.
 // The implementation makes a few non-obvious choices - namely using Server Side Apply from go templates
 // and not using controller-runtime.
@@ -67,7 +68,7 @@ import (
 //     do not provide these libraries.
 //   - SSA using standard API types doesn't work well either: https://github.com/kubernetes-sigs/controller-runtime/issues/1669
 //   - This leaves YAML templates, converted to unstructured types and Applied with the dynamic client.
-type DeploymentController struct {
+type DeploymentControllerV1Alpha2 struct {
 	client             kube.Client
 	queue              controllers.Queue
 	templates          *template.Template
@@ -76,27 +77,12 @@ type DeploymentController struct {
 	gatewayClassLister lister.GatewayClassLister
 }
 
-type DeploymentControllerInterface interface {
-	Run(stop <-chan struct{})
-}
-
-// Patcher is a function that abstracts patching logic. This is largely because client-go fakes do not handle patching
-type patcher func(gvr schema.GroupVersionResource, name string, namespace string, data []byte, subresources ...string) error
-
 // NewDeploymentController constructs a DeploymentController and registers required informers.
 // The controller will not start until Run() is called.
-func NewDeploymentController(client kube.Client, version string) DeploymentControllerInterface {
-	log.Infof("gateway deployment controller reading version %v", version)
-	if version == "v1alpha2" {
-		return NewDeploymentControllerV1Alpha2(client)
-	}
-	return NewDeploymentControllerV1beta1(client)
-}
-
-func NewDeploymentControllerV1beta1(client kube.Client) *DeploymentController {
-	gw := client.GatewayAPIInformer().Gateway().V1beta1().Gateways()
-	gwc := client.GatewayAPIInformer().Gateway().V1beta1().GatewayClasses()
-	dc := &DeploymentController{
+func NewDeploymentControllerV1Alpha2(client kube.Client) *DeploymentControllerV1Alpha2 {
+	gw := client.GatewayAPIInformer().Gateway().V1alpha2().Gateways()
+	gwc := client.GatewayAPIInformer().Gateway().V1alpha2().GatewayClasses()
+	dc := &DeploymentControllerV1Alpha2{
 		client:    client,
 		templates: processTemplates(),
 		patcher: func(gvr schema.GroupVersionResource, name string, namespace string, data []byte, subresources ...string) error {
@@ -152,12 +138,12 @@ func NewDeploymentControllerV1beta1(client kube.Client) *DeploymentController {
 	return dc
 }
 
-func (d *DeploymentController) Run(stop <-chan struct{}) {
+func (d *DeploymentControllerV1Alpha2) Run(stop <-chan struct{}) {
 	d.queue.Run(stop)
 }
 
 // Reconcile takes in the name of a Gateway and ensures the cluster is in the desired state
-func (d *DeploymentController) Reconcile(req types.NamespacedName) error {
+func (d *DeploymentControllerV1Alpha2) Reconcile(req types.NamespacedName) error {
 	log := log.WithLabels("gateway", req)
 
 	gw, err := d.gatewayLister.Gateways(req.Namespace).Get(req.Name)
@@ -189,7 +175,7 @@ func (d *DeploymentController) Reconcile(req types.NamespacedName) error {
 	return d.configureIstioGateway(log, *gw)
 }
 
-func (d *DeploymentController) configureIstioGateway(log *istiolog.Scope, gw gateway.Gateway) error {
+func (d *DeploymentControllerV1Alpha2) configureIstioGateway(log *istiolog.Scope, gw gateway.Gateway) error {
 	// If user explicitly sets addresses, we are assuming they are pointing to an existing deployment.
 	// We will not manage it in this case
 	if !IsManaged(&gw.Spec) {
@@ -198,13 +184,13 @@ func (d *DeploymentController) configureIstioGateway(log *istiolog.Scope, gw gat
 	}
 	log.Info("reconciling")
 
-	svc := serviceInput{Gateway: &gw, Ports: extractServicePorts(gw)}
+	svc := serviceInputV1Alpha2{Gateway: &gw, Ports: extractServicePorts((gatewaybeta.Gateway)(gw))}
 	if err := d.ApplyTemplate("service.yaml", svc); err != nil {
 		return fmt.Errorf("update service: %v", err)
 	}
 	log.Info("service updated")
 
-	dep := deploymentInput{Gateway: &gw, KubeVersion122: kube.IsAtLeastVersion(d.client, 22)}
+	dep := deploymentInputV1Alpha2{Gateway: &gw, KubeVersion122: kube.IsAtLeastVersion(d.client, 22)}
 	if err := d.ApplyTemplate("deployment.yaml", dep); err != nil {
 		return fmt.Errorf("update deployment: %v", err)
 	}
@@ -236,7 +222,7 @@ func (d *DeploymentController) configureIstioGateway(log *istiolog.Scope, gw gat
 }
 
 // ApplyTemplate renders a template with the given input and (server-side) applies the results to the cluster.
-func (d *DeploymentController) ApplyTemplate(template string, input metav1.Object, subresources ...string) error {
+func (d *DeploymentControllerV1Alpha2) ApplyTemplate(template string, input metav1.Object, subresources ...string) error {
 	var buf bytes.Buffer
 	if err := d.templates.ExecuteTemplate(&buf, template, input); err != nil {
 		return err
@@ -261,7 +247,7 @@ func (d *DeploymentController) ApplyTemplate(template string, input metav1.Objec
 }
 
 // ApplyObject renders an object with the given input and (server-side) applies the results to the cluster.
-func (d *DeploymentController) ApplyObject(obj controllers.Object, subresources ...string) error {
+func (d *DeploymentControllerV1Alpha2) ApplyObject(obj controllers.Object, subresources ...string) error {
 	j, err := config.ToJSON(obj)
 	if err != nil {
 		return err
@@ -276,31 +262,17 @@ func (d *DeploymentController) ApplyObject(obj controllers.Object, subresources 
 	return d.patcher(gvr, obj.GetName(), obj.GetNamespace(), j, subresources...)
 }
 
-// Merge maps merges multiple maps. Latter maps take precedence over previous maps on overlapping fields
-func mergeMaps(maps ...map[string]string) map[string]string {
-	if len(maps) == 0 {
-		return nil
-	}
-	res := make(map[string]string, len(maps[0]))
-	for _, m := range maps {
-		for k, v := range m {
-			res[k] = v
-		}
-	}
-	return res
-}
-
-type serviceInput struct {
+type serviceInputV1Alpha2 struct {
 	*gateway.Gateway
 	Ports []corev1.ServicePort
 }
 
-type deploymentInput struct {
+type deploymentInputV1Alpha2 struct {
 	*gateway.Gateway
 	KubeVersion122 bool
 }
 
-func extractServicePorts(gw gateway.Gateway) []corev1.ServicePort {
+func extractServicePortsV1Alpha2(gw gateway.Gateway) []corev1.ServicePort {
 	svcPorts := make([]corev1.ServicePort, 0, len(gw.Spec.Listeners)+1)
 	svcPorts = append(svcPorts, corev1.ServicePort{
 		Name: "status-port",

--- a/pilot/pkg/config/kube/gateway/deploymentcontroller_v1alpha2_test.go
+++ b/pilot/pkg/config/kube/gateway/deploymentcontroller_v1alpha2_test.go
@@ -22,7 +22,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/gateway-api/apis/v1beta1"
+	"sigs.k8s.io/gateway-api/apis/v1alpha2"
 	"sigs.k8s.io/yaml"
 
 	"istio.io/istio/pilot/test/util"
@@ -30,31 +30,31 @@ import (
 	istiolog "istio.io/pkg/log"
 )
 
-func TestConfigureIstioGateway(t *testing.T) {
+func TestConfigureIstioGatewayV1Alpha2(t *testing.T) {
 	tests := []struct {
 		name string
-		gw   v1beta1.Gateway
+		gw   v1alpha2.Gateway
 	}{
 		{
 			"simple",
-			v1beta1.Gateway{
+			v1alpha2.Gateway{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "default",
 					Namespace: "default",
 				},
-				Spec: v1beta1.GatewaySpec{},
+				Spec: v1alpha2.GatewaySpec{},
 			},
 		},
 		{
 			"manual-ip",
-			v1beta1.Gateway{
+			v1alpha2.Gateway{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "default",
 					Namespace: "default",
 				},
-				Spec: v1beta1.GatewaySpec{
-					Addresses: []v1beta1.GatewayAddress{{
-						Type:  func() *v1beta1.AddressType { x := v1beta1.IPAddressType; return &x }(),
+				Spec: v1alpha2.GatewaySpec{
+					Addresses: []v1alpha2.GatewayAddress{{
+						Type:  func() *v1alpha2.AddressType { x := v1alpha2.IPAddressType; return &x }(),
 						Value: "1.2.3.4",
 					}},
 				},
@@ -62,32 +62,32 @@ func TestConfigureIstioGateway(t *testing.T) {
 		},
 		{
 			"cluster-ip",
-			v1beta1.Gateway{
+			v1alpha2.Gateway{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "default",
 					Namespace:   "default",
 					Annotations: map[string]string{"networking.istio.io/service-type": string(corev1.ServiceTypeClusterIP)},
 				},
-				Spec: v1beta1.GatewaySpec{
-					Listeners: []v1beta1.Listener{{
+				Spec: v1alpha2.GatewaySpec{
+					Listeners: []v1alpha2.Listener{{
 						Name: "http",
-						Port: v1beta1.PortNumber(80),
+						Port: v1alpha2.PortNumber(80),
 					}},
 				},
 			},
 		},
 		{
 			"multinetwork",
-			v1beta1.Gateway{
+			v1alpha2.Gateway{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "default",
 					Namespace: "default",
 					Labels:    map[string]string{"topology.istio.io/network": "network-1"},
 				},
-				Spec: v1beta1.GatewaySpec{
-					Listeners: []v1beta1.Listener{{
+				Spec: v1alpha2.GatewaySpec{
+					Listeners: []v1alpha2.Listener{{
 						Name: "http",
-						Port: v1beta1.PortNumber(80),
+						Port: v1alpha2.PortNumber(80),
 					}},
 				},
 			},
@@ -96,7 +96,7 @@ func TestConfigureIstioGateway(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			buf := &bytes.Buffer{}
-			d := &DeploymentController{
+			d := &DeploymentControllerV1Alpha2{
 				client:    kube.NewFakeClient(),
 				templates: processTemplates(),
 				patcher: func(gvr schema.GroupVersionResource, name string, namespace string, data []byte, subresources ...string) error {

--- a/pilot/pkg/config/kube/gateway/gatewayclass_v1alpha2_test.go
+++ b/pilot/pkg/config/kube/gateway/gatewayclass_v1alpha2_test.go
@@ -22,7 +22,7 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	gateway "sigs.k8s.io/gateway-api/apis/v1beta1"
+	gateway "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/controllers"
@@ -30,9 +30,9 @@ import (
 	"istio.io/istio/pkg/test/util/retry"
 )
 
-func TestClassController(t *testing.T) {
+func TestClassControllerV1Alpha2(t *testing.T) {
 	client := kube.NewFakeClient()
-	cc := NewClassController(client, "v1beta1")
+	cc := NewClassController(client, "v1alpha2")
 	stop := test.NewStop(t)
 	client.RunAndWait(stop)
 	go cc.Run(stop)
@@ -45,18 +45,18 @@ func TestClassController(t *testing.T) {
 				ControllerName: gateway.GatewayController(controller),
 			},
 		}
-		_, err := client.GatewayAPI().GatewayV1beta1().GatewayClasses().Create(context.Background(), gc, metav1.CreateOptions{})
+		_, err := client.GatewayAPI().GatewayV1alpha2().GatewayClasses().Create(context.Background(), gc, metav1.CreateOptions{})
 		if apierrors.IsAlreadyExists(err) {
-			_, _ = client.GatewayAPI().GatewayV1beta1().GatewayClasses().Update(context.Background(), gc, metav1.UpdateOptions{})
+			_, _ = client.GatewayAPI().GatewayV1alpha2().GatewayClasses().Update(context.Background(), gc, metav1.UpdateOptions{})
 		}
 	}
 	deleteClass := func(name string) {
-		client.GatewayAPI().GatewayV1beta1().GatewayClasses().Delete(context.Background(), name, metav1.DeleteOptions{})
+		client.GatewayAPI().GatewayV1alpha2().GatewayClasses().Delete(context.Background(), name, metav1.DeleteOptions{})
 	}
 	expectClass := func(name, controller string) {
 		t.Helper()
 		retry.UntilSuccessOrFail(t, func() error {
-			gc, err := client.GatewayAPI().GatewayV1beta1().GatewayClasses().Get(context.Background(), name, metav1.GetOptions{})
+			gc, err := client.GatewayAPI().GatewayV1alpha2().GatewayClasses().Get(context.Background(), name, metav1.GetOptions{})
 			if controllers.IgnoreNotFound(err) != nil {
 				return err
 			}

--- a/pilot/pkg/config/kube/gateway/testdata/alias.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/alias.status.yaml.golden
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: GatewayClass
 metadata:
   creationTimestamp: null
@@ -13,7 +13,7 @@ status:
     status: "True"
     type: Accepted
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: Gateway
 metadata:
   creationTimestamp: null
@@ -21,7 +21,7 @@ metadata:
   namespace: istio-system
 spec: null
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: Gateway
 metadata:
   creationTimestamp: null
@@ -71,7 +71,7 @@ status:
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/config/kube/gateway/testdata/delegated.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/delegated.status.yaml.golden
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: GatewayClass
 metadata:
   creationTimestamp: null
@@ -13,7 +13,7 @@ status:
     status: "True"
     type: Accepted
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: Gateway
 metadata:
   creationTimestamp: null
@@ -89,7 +89,7 @@ status:
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   creationTimestamp: null
@@ -114,7 +114,7 @@ status:
       name: gateway
       namespace: istio-system
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/cluster-ip.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/cluster-ip.yaml
@@ -82,7 +82,7 @@ spec:
         - name: net.ipv4.ip_unprivileged_port_start
           value: "0"
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: Gateway
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/manual-ip.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/manual-ip.yaml
@@ -77,7 +77,7 @@ spec:
         - name: net.ipv4.ip_unprivileged_port_start
           value: "0"
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: Gateway
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/multinetwork.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/multinetwork.yaml
@@ -85,7 +85,7 @@ spec:
         - name: net.ipv4.ip_unprivileged_port_start
           value: "0"
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: Gateway
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/simple.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/simple.yaml
@@ -76,7 +76,7 @@ spec:
         - name: net.ipv4.ip_unprivileged_port_start
           value: "0"
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: Gateway
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/config/kube/gateway/testdata/eastwest.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/eastwest.status.yaml.golden
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: Gateway
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/config/kube/gateway/testdata/http.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/http.status.yaml.golden
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: GatewayClass
 metadata:
   creationTimestamp: null
@@ -13,7 +13,7 @@ status:
     status: "True"
     type: Accepted
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: Gateway
 metadata:
   creationTimestamp: null
@@ -63,7 +63,7 @@ status:
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   creationTimestamp: null
@@ -88,7 +88,7 @@ status:
       name: gateway
       namespace: istio-system
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   creationTimestamp: null
@@ -113,7 +113,7 @@ status:
       name: gateway
       namespace: istio-system
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   creationTimestamp: null
@@ -138,7 +138,7 @@ status:
       name: gateway
       namespace: istio-system
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   creationTimestamp: null
@@ -163,7 +163,7 @@ status:
       name: gateway
       namespace: istio-system
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   creationTimestamp: null
@@ -188,7 +188,7 @@ status:
       name: gateway
       namespace: istio-system
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/config/kube/gateway/testdata/invalid.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/invalid.status.yaml.golden
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: GatewayClass
 metadata:
   creationTimestamp: null
@@ -13,7 +13,7 @@ status:
     status: "True"
     type: Accepted
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: Gateway
 metadata:
   creationTimestamp: null
@@ -63,7 +63,7 @@ status:
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: Gateway
 metadata:
   creationTimestamp: null
@@ -111,7 +111,7 @@ status:
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: Gateway
 metadata:
   creationTimestamp: null
@@ -161,7 +161,7 @@ status:
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: Gateway
 metadata:
   creationTimestamp: null
@@ -209,7 +209,7 @@ status:
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: Gateway
 metadata:
   creationTimestamp: null
@@ -258,7 +258,7 @@ status:
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   creationTimestamp: null
@@ -283,7 +283,7 @@ status:
       name: gateway
       namespace: istio-system
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   creationTimestamp: null
@@ -308,7 +308,7 @@ status:
       name: gateway
       namespace: istio-system
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   creationTimestamp: null
@@ -333,7 +333,7 @@ status:
       name: gateway
       namespace: istio-system
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   creationTimestamp: null
@@ -358,7 +358,7 @@ status:
       name: gateway
       namespace: istio-system
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/config/kube/gateway/testdata/mcs.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/mcs.status.yaml.golden
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: Gateway
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/config/kube/gateway/testdata/mesh.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/mesh.status.yaml.golden
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: GatewayClass
 metadata:
   creationTimestamp: null
@@ -13,7 +13,7 @@ status:
     status: "True"
     type: Accepted
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: Gateway
 metadata:
   creationTimestamp: null
@@ -63,7 +63,7 @@ status:
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   creationTimestamp: null
@@ -103,7 +103,7 @@ status:
       name: gateway
       namespace: istio-system
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   creationTimestamp: null
@@ -128,7 +128,7 @@ status:
       kind: Mesh
       name: istio
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/config/kube/gateway/testdata/mismatch.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/mismatch.status.yaml.golden
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: GatewayClass
 metadata:
   creationTimestamp: null
@@ -13,7 +13,7 @@ status:
     status: "True"
     type: Accepted
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: Gateway
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/config/kube/gateway/testdata/multi-gateway.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/multi-gateway.status.yaml.golden
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: GatewayClass
 metadata:
   creationTimestamp: null
@@ -13,7 +13,7 @@ status:
     status: "True"
     type: Accepted
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: Gateway
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/config/kube/gateway/testdata/reference-policy-service.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/reference-policy-service.status.yaml.golden
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: Gateway
 metadata:
   creationTimestamp: null
@@ -48,7 +48,7 @@ status:
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   creationTimestamp: null
@@ -74,7 +74,7 @@ status:
       name: gateway
       namespace: istio-system
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/config/kube/gateway/testdata/reference-policy-tls.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/reference-policy-tls.status.yaml.golden
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: GatewayClass
 metadata:
   creationTimestamp: null
@@ -13,7 +13,7 @@ status:
     status: "True"
     type: Accepted
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: Gateway
 metadata:
   creationTimestamp: null
@@ -87,7 +87,7 @@ status:
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/config/kube/gateway/testdata/route-binding.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/route-binding.status.yaml.golden
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: GatewayClass
 metadata:
   creationTimestamp: null
@@ -13,7 +13,7 @@ status:
     status: "True"
     type: Accepted
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: Gateway
 metadata:
   creationTimestamp: null
@@ -165,7 +165,7 @@ status:
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   creationTimestamp: null
@@ -190,7 +190,7 @@ status:
       name: gateway
       namespace: istio-system
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   creationTimestamp: null
@@ -216,7 +216,7 @@ status:
       namespace: istio-system
       sectionName: foobar
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   creationTimestamp: null
@@ -243,7 +243,7 @@ status:
       namespace: istio-system
       sectionName: namespace-selector
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   creationTimestamp: null
@@ -270,7 +270,7 @@ status:
       namespace: istio-system
       sectionName: same-namespace
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   creationTimestamp: null
@@ -296,7 +296,7 @@ status:
       namespace: istio-system
       sectionName: foobar
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   creationTimestamp: null
@@ -322,7 +322,7 @@ status:
       namespace: istio-system
       sectionName: namespace-selector
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   creationTimestamp: null
@@ -348,7 +348,7 @@ status:
       namespace: istio-system
       sectionName: namespace-selector
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/config/kube/gateway/testdata/route-precedence.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/route-precedence.status.yaml.golden
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: GatewayClass
 metadata:
   creationTimestamp: null
@@ -13,7 +13,7 @@ status:
     status: "True"
     type: Accepted
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: Gateway
 metadata:
   creationTimestamp: null
@@ -63,7 +63,7 @@ status:
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   creationTimestamp: null
@@ -103,7 +103,7 @@ status:
       name: gateway
       namespace: istio-system
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   creationTimestamp: null
@@ -143,7 +143,7 @@ status:
       name: gateway
       namespace: istio-system
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/config/kube/gateway/testdata/serviceentry.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/serviceentry.status.yaml.golden
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: Gateway
 metadata:
   creationTimestamp: null
@@ -46,7 +46,7 @@ status:
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/config/kube/gateway/testdata/tcp.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/tcp.status.yaml.golden
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: GatewayClass
 metadata:
   creationTimestamp: null
@@ -13,7 +13,7 @@ status:
     status: "True"
     type: Accepted
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: Gateway
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/config/kube/gateway/testdata/tls.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/tls.status.yaml.golden
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: GatewayClass
 metadata:
   creationTimestamp: null
@@ -13,7 +13,7 @@ status:
     status: "True"
     type: Accepted
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: Gateway
 metadata:
   creationTimestamp: null
@@ -89,7 +89,7 @@ status:
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/config/kube/gateway/testdata/weighted.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/weighted.status.yaml.golden
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: GatewayClass
 metadata:
   creationTimestamp: null
@@ -13,7 +13,7 @@ status:
     status: "True"
     type: Accepted
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: Gateway
 metadata:
   creationTimestamp: null
@@ -90,7 +90,7 @@ status:
     - group: gateway.networking.k8s.io
       kind: TCPRoute
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/config/kube/gateway/testdata/zero.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/zero.status.yaml.golden
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: GatewayClass
 metadata:
   creationTimestamp: null
@@ -13,7 +13,7 @@ status:
     status: "True"
     type: Accepted
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: Gateway
 metadata:
   creationTimestamp: null
@@ -63,7 +63,7 @@ status:
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/xds/fake.go
+++ b/pilot/pkg/xds/fake.go
@@ -219,7 +219,9 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 		PushContextLock:     &s.updateMutex,
 		ConfigStoreCaches:   []model.ConfigStoreController{ingr},
 		CreateConfigStore: func(c model.ConfigStoreController) model.ConfigStoreController {
-			g := gateway.NewController(defaultKubeClient, c, kube.Options{
+			g := gateway.NewController(defaultKubeClient, c, func(typ config.GroupVersionKind) config.GroupVersionKind {
+				return typ
+			}, kube.Options{
 				DomainSuffix: "cluster.local",
 			})
 			gwc = g

--- a/pkg/config/schema/codegen/collections.go
+++ b/pkg/config/schema/codegen/collections.go
@@ -203,7 +203,7 @@ type colEntry struct {
 func WriteGvk(packageName string, m *ast.Metadata) (string, error) {
 	entries := make([]colEntry, 0, len(m.Collections))
 	customNames := map[string]string{
-		"k8s/gateway_api/v1alpha2/gateways": "KubernetesGateway",
+		"k8s/gateway_api/v1beta1/gateways": "KubernetesGateway",
 	}
 	for _, c := range m.Collections {
 		r := m.FindResourceForGroupKind(c.Group, c.Kind)
@@ -240,7 +240,7 @@ func WriteGvk(packageName string, m *ast.Metadata) (string, error) {
 func WriteKind(packageName string, m *ast.Metadata) (string, error) {
 	entries := make([]colEntry, 0, len(m.Collections))
 	customNames := map[string]string{
-		"k8s/gateway_api/v1alpha2/gateways": "KubernetesGateway",
+		"k8s/gateway_api/v1beta1/gateways": "KubernetesGateway",
 	}
 	for _, c := range m.Collections {
 		r := m.FindResourceForGroupKind(c.Group, c.Kind)

--- a/pkg/config/schema/collections/collections.gen.go
+++ b/pkg/config/schema/collections/collections.gen.go
@@ -15,6 +15,7 @@ import (
 	k8sioapiextensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	k8sioapiextensionsapiserverpkgapisapiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	sigsk8siogatewayapiapisv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	sigsk8siogatewayapiapisv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	istioioapiextensionsv1alpha1 "istio.io/api/extensions/v1alpha1"
 	istioioapimeshv1alpha1 "istio.io/api/mesh/v1alpha1"
@@ -533,60 +534,6 @@ var (
 		}.MustBuild(),
 	}.MustBuild()
 
-	// K8SGatewayApiV1Alpha2Gatewayclasses describes the collection
-	// k8s/gateway_api/v1alpha2/gatewayclasses
-	K8SGatewayApiV1Alpha2Gatewayclasses = collection.Builder{
-		Name:         "k8s/gateway_api/v1alpha2/gatewayclasses",
-		VariableName: "K8SGatewayApiV1Alpha2Gatewayclasses",
-		Resource: resource.Builder{
-			Group:   "gateway.networking.k8s.io",
-			Kind:    "GatewayClass",
-			Plural:  "gatewayclasses",
-			Version: "v1alpha2",
-			Proto:   "k8s.io.gateway_api.api.v1alpha1.GatewayClassSpec", StatusProto: "k8s.io.gateway_api.api.v1alpha1.GatewayClassStatus",
-			ReflectType: reflect.TypeOf(&sigsk8siogatewayapiapisv1alpha2.GatewayClassSpec{}).Elem(), StatusType: reflect.TypeOf(&sigsk8siogatewayapiapisv1alpha2.GatewayClassStatus{}).Elem(),
-			ProtoPackage: "sigs.k8s.io/gateway-api/apis/v1alpha2", StatusPackage: "sigs.k8s.io/gateway-api/apis/v1alpha2",
-			ClusterScoped: true,
-			ValidateProto: validation.EmptyValidate,
-		}.MustBuild(),
-	}.MustBuild()
-
-	// K8SGatewayApiV1Alpha2Gateways describes the collection
-	// k8s/gateway_api/v1alpha2/gateways
-	K8SGatewayApiV1Alpha2Gateways = collection.Builder{
-		Name:         "k8s/gateway_api/v1alpha2/gateways",
-		VariableName: "K8SGatewayApiV1Alpha2Gateways",
-		Resource: resource.Builder{
-			Group:   "gateway.networking.k8s.io",
-			Kind:    "Gateway",
-			Plural:  "gateways",
-			Version: "v1alpha2",
-			Proto:   "k8s.io.gateway_api.api.v1alpha1.GatewaySpec", StatusProto: "k8s.io.gateway_api.api.v1alpha1.GatewayStatus",
-			ReflectType: reflect.TypeOf(&sigsk8siogatewayapiapisv1alpha2.GatewaySpec{}).Elem(), StatusType: reflect.TypeOf(&sigsk8siogatewayapiapisv1alpha2.GatewayStatus{}).Elem(),
-			ProtoPackage: "sigs.k8s.io/gateway-api/apis/v1alpha2", StatusPackage: "sigs.k8s.io/gateway-api/apis/v1alpha2",
-			ClusterScoped: false,
-			ValidateProto: validation.EmptyValidate,
-		}.MustBuild(),
-	}.MustBuild()
-
-	// K8SGatewayApiV1Alpha2Httproutes describes the collection
-	// k8s/gateway_api/v1alpha2/httproutes
-	K8SGatewayApiV1Alpha2Httproutes = collection.Builder{
-		Name:         "k8s/gateway_api/v1alpha2/httproutes",
-		VariableName: "K8SGatewayApiV1Alpha2Httproutes",
-		Resource: resource.Builder{
-			Group:   "gateway.networking.k8s.io",
-			Kind:    "HTTPRoute",
-			Plural:  "httproutes",
-			Version: "v1alpha2",
-			Proto:   "k8s.io.gateway_api.api.v1alpha1.HTTPRouteSpec", StatusProto: "k8s.io.gateway_api.api.v1alpha1.HTTPRouteStatus",
-			ReflectType: reflect.TypeOf(&sigsk8siogatewayapiapisv1alpha2.HTTPRouteSpec{}).Elem(), StatusType: reflect.TypeOf(&sigsk8siogatewayapiapisv1alpha2.HTTPRouteStatus{}).Elem(),
-			ProtoPackage: "sigs.k8s.io/gateway-api/apis/v1alpha2", StatusPackage: "sigs.k8s.io/gateway-api/apis/v1alpha2",
-			ClusterScoped: false,
-			ValidateProto: validation.EmptyValidate,
-		}.MustBuild(),
-	}.MustBuild()
-
 	// K8SGatewayApiV1Alpha2Referencegrants describes the collection
 	// k8s/gateway_api/v1alpha2/referencegrants
 	K8SGatewayApiV1Alpha2Referencegrants = collection.Builder{
@@ -659,6 +606,69 @@ var (
 		}.MustBuild(),
 	}.MustBuild()
 
+	// K8SGatewayApiV1Beta1Gatewayclasses describes the collection
+	// k8s/gateway_api/v1beta1/gatewayclasses
+	K8SGatewayApiV1Beta1Gatewayclasses = collection.Builder{
+		Name:         "k8s/gateway_api/v1beta1/gatewayclasses",
+		VariableName: "K8SGatewayApiV1Beta1Gatewayclasses",
+		Resource: resource.Builder{
+			Group:   "gateway.networking.k8s.io",
+			Kind:    "GatewayClass",
+			Plural:  "gatewayclasses",
+			Version: "v1beta1",
+			VersionAliases: []string{
+				"v1alpha2",
+			},
+			Proto: "k8s.io.gateway_api.api.v1alpha1.GatewayClassSpec", StatusProto: "k8s.io.gateway_api.api.v1alpha1.GatewayClassStatus",
+			ReflectType: reflect.TypeOf(&sigsk8siogatewayapiapisv1beta1.GatewayClassSpec{}).Elem(), StatusType: reflect.TypeOf(&sigsk8siogatewayapiapisv1beta1.GatewayClassStatus{}).Elem(),
+			ProtoPackage: "sigs.k8s.io/gateway-api/apis/v1beta1", StatusPackage: "sigs.k8s.io/gateway-api/apis/v1beta1",
+			ClusterScoped: true,
+			ValidateProto: validation.EmptyValidate,
+		}.MustBuild(),
+	}.MustBuild()
+
+	// K8SGatewayApiV1Beta1Gateways describes the collection
+	// k8s/gateway_api/v1beta1/gateways
+	K8SGatewayApiV1Beta1Gateways = collection.Builder{
+		Name:         "k8s/gateway_api/v1beta1/gateways",
+		VariableName: "K8SGatewayApiV1Beta1Gateways",
+		Resource: resource.Builder{
+			Group:   "gateway.networking.k8s.io",
+			Kind:    "Gateway",
+			Plural:  "gateways",
+			Version: "v1beta1",
+			VersionAliases: []string{
+				"v1alpha2",
+			},
+			Proto: "k8s.io.gateway_api.api.v1alpha1.GatewaySpec", StatusProto: "k8s.io.gateway_api.api.v1alpha1.GatewayStatus",
+			ReflectType: reflect.TypeOf(&sigsk8siogatewayapiapisv1beta1.GatewaySpec{}).Elem(), StatusType: reflect.TypeOf(&sigsk8siogatewayapiapisv1beta1.GatewayStatus{}).Elem(),
+			ProtoPackage: "sigs.k8s.io/gateway-api/apis/v1beta1", StatusPackage: "sigs.k8s.io/gateway-api/apis/v1beta1",
+			ClusterScoped: false,
+			ValidateProto: validation.EmptyValidate,
+		}.MustBuild(),
+	}.MustBuild()
+
+	// K8SGatewayApiV1Beta1Httproutes describes the collection
+	// k8s/gateway_api/v1beta1/httproutes
+	K8SGatewayApiV1Beta1Httproutes = collection.Builder{
+		Name:         "k8s/gateway_api/v1beta1/httproutes",
+		VariableName: "K8SGatewayApiV1Beta1Httproutes",
+		Resource: resource.Builder{
+			Group:   "gateway.networking.k8s.io",
+			Kind:    "HTTPRoute",
+			Plural:  "httproutes",
+			Version: "v1beta1",
+			VersionAliases: []string{
+				"v1alpha2",
+			},
+			Proto: "k8s.io.gateway_api.api.v1alpha1.HTTPRouteSpec", StatusProto: "k8s.io.gateway_api.api.v1alpha1.HTTPRouteStatus",
+			ReflectType: reflect.TypeOf(&sigsk8siogatewayapiapisv1beta1.HTTPRouteSpec{}).Elem(), StatusType: reflect.TypeOf(&sigsk8siogatewayapiapisv1beta1.HTTPRouteStatus{}).Elem(),
+			ProtoPackage: "sigs.k8s.io/gateway-api/apis/v1beta1", StatusPackage: "sigs.k8s.io/gateway-api/apis/v1beta1",
+			ClusterScoped: false,
+			ValidateProto: validation.EmptyValidate,
+		}.MustBuild(),
+	}.MustBuild()
+
 	// All contains all collections in the system.
 	All = collection.NewSchemasBuilder().
 		MustAdd(IstioExtensionsV1Alpha1Wasmplugins).
@@ -688,13 +698,13 @@ var (
 		MustAdd(K8SCoreV1Secrets).
 		MustAdd(K8SCoreV1Services).
 		MustAdd(K8SExtensionsV1Beta1Ingresses).
-		MustAdd(K8SGatewayApiV1Alpha2Gatewayclasses).
-		MustAdd(K8SGatewayApiV1Alpha2Gateways).
-		MustAdd(K8SGatewayApiV1Alpha2Httproutes).
 		MustAdd(K8SGatewayApiV1Alpha2Referencegrants).
 		MustAdd(K8SGatewayApiV1Alpha2Referencepolicies).
 		MustAdd(K8SGatewayApiV1Alpha2Tcproutes).
 		MustAdd(K8SGatewayApiV1Alpha2Tlsroutes).
+		MustAdd(K8SGatewayApiV1Beta1Gatewayclasses).
+		MustAdd(K8SGatewayApiV1Beta1Gateways).
+		MustAdd(K8SGatewayApiV1Beta1Httproutes).
 		Build()
 
 	// Istio contains only Istio collections.
@@ -730,13 +740,13 @@ var (
 		MustAdd(K8SCoreV1Secrets).
 		MustAdd(K8SCoreV1Services).
 		MustAdd(K8SExtensionsV1Beta1Ingresses).
-		MustAdd(K8SGatewayApiV1Alpha2Gatewayclasses).
-		MustAdd(K8SGatewayApiV1Alpha2Gateways).
-		MustAdd(K8SGatewayApiV1Alpha2Httproutes).
 		MustAdd(K8SGatewayApiV1Alpha2Referencegrants).
 		MustAdd(K8SGatewayApiV1Alpha2Referencepolicies).
 		MustAdd(K8SGatewayApiV1Alpha2Tcproutes).
 		MustAdd(K8SGatewayApiV1Alpha2Tlsroutes).
+		MustAdd(K8SGatewayApiV1Beta1Gatewayclasses).
+		MustAdd(K8SGatewayApiV1Beta1Gateways).
+		MustAdd(K8SGatewayApiV1Beta1Httproutes).
 		Build()
 
 	// Builtin contains only native Kubernetes collections. This differs from Kube, which has
@@ -789,13 +799,13 @@ var (
 			MustAdd(IstioSecurityV1Beta1Peerauthentications).
 			MustAdd(IstioSecurityV1Beta1Requestauthentications).
 			MustAdd(IstioTelemetryV1Alpha1Telemetries).
-			MustAdd(K8SGatewayApiV1Alpha2Gatewayclasses).
-			MustAdd(K8SGatewayApiV1Alpha2Gateways).
-			MustAdd(K8SGatewayApiV1Alpha2Httproutes).
 			MustAdd(K8SGatewayApiV1Alpha2Referencegrants).
 			MustAdd(K8SGatewayApiV1Alpha2Referencepolicies).
 			MustAdd(K8SGatewayApiV1Alpha2Tcproutes).
 			MustAdd(K8SGatewayApiV1Alpha2Tlsroutes).
+			MustAdd(K8SGatewayApiV1Beta1Gatewayclasses).
+			MustAdd(K8SGatewayApiV1Beta1Gateways).
+			MustAdd(K8SGatewayApiV1Beta1Httproutes).
 			Build()
 
 	// Deprecated contains only collections used by that will soon be used by nothing.

--- a/pkg/config/schema/gvk/resources.gen.go
+++ b/pkg/config/schema/gvk/resources.gen.go
@@ -17,10 +17,10 @@ var (
 	Endpoints = config.GroupVersionKind{Group: "", Version: "v1", Kind: "Endpoints"}
 	EnvoyFilter = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1alpha3", Kind: "EnvoyFilter"}
 	Gateway = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1alpha3", Kind: "Gateway"}
-	GatewayClass = config.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Kind: "GatewayClass"}
-	HTTPRoute = config.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Kind: "HTTPRoute"}
+	GatewayClass = config.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1beta1", Kind: "GatewayClass"}
+	HTTPRoute = config.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1beta1", Kind: "HTTPRoute"}
 	Ingress = config.GroupVersionKind{Group: "extensions", Version: "v1beta1", Kind: "Ingress"}
-	KubernetesGateway = config.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Kind: "Gateway"}
+	KubernetesGateway = config.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1beta1", Kind: "Gateway"}
 	MeshConfig = config.GroupVersionKind{Group: "", Version: "v1alpha1", Kind: "MeshConfig"}
 	MeshNetworks = config.GroupVersionKind{Group: "", Version: "v1alpha1", Kind: "MeshNetworks"}
 	MutatingWebhookConfiguration = config.GroupVersionKind{Group: "admissionregistration.k8s.io", Version: "v1", Kind: "MutatingWebhookConfiguration"}

--- a/pkg/config/schema/kind/resources.gen.go
+++ b/pkg/config/schema/kind/resources.gen.go
@@ -145,16 +145,16 @@ func FromGvk(gvk config.GroupVersionKind) Kind {
 	if gvk.Kind == "Gateway" && gvk.Group == "networking.istio.io" && gvk.Version == "v1alpha3" {
 		return Gateway
 	}
-	if gvk.Kind == "GatewayClass" && gvk.Group == "gateway.networking.k8s.io" && gvk.Version == "v1alpha2" {
+	if gvk.Kind == "GatewayClass" && gvk.Group == "gateway.networking.k8s.io" && gvk.Version == "v1beta1" {
 		return GatewayClass
 	}
-	if gvk.Kind == "HTTPRoute" && gvk.Group == "gateway.networking.k8s.io" && gvk.Version == "v1alpha2" {
+	if gvk.Kind == "HTTPRoute" && gvk.Group == "gateway.networking.k8s.io" && gvk.Version == "v1beta1" {
 		return HTTPRoute
 	}
 	if gvk.Kind == "Ingress" && gvk.Group == "extensions" && gvk.Version == "v1beta1" {
 		return Ingress
 	}
-	if gvk.Kind == "Gateway" && gvk.Group == "gateway.networking.k8s.io" && gvk.Version == "v1alpha2" {
+	if gvk.Kind == "Gateway" && gvk.Group == "gateway.networking.k8s.io" && gvk.Version == "v1beta1" {
 		return KubernetesGateway
 	}
 	if gvk.Kind == "MeshConfig" && gvk.Group == "" && gvk.Version == "v1alpha1" {

--- a/pkg/config/schema/metadata.yaml
+++ b/pkg/config/schema/metadata.yaml
@@ -157,15 +157,15 @@ collections:
     builtin: true
 
   - kind: "GatewayClass"
-    name: "k8s/gateway_api/v1alpha2/gatewayclasses"
+    name: "k8s/gateway_api/v1beta1/gatewayclasses"
     group: "gateway.networking.k8s.io"
 
   - kind: "Gateway"
-    name: "k8s/gateway_api/v1alpha2/gateways"
+    name: "k8s/gateway_api/v1beta1/gateways"
     group: "gateway.networking.k8s.io"
 
   - kind: "HTTPRoute"
-    name: "k8s/gateway_api/v1alpha2/httproutes"
+    name: "k8s/gateway_api/v1beta1/httproutes"
     group: "gateway.networking.k8s.io"
 
   - kind: "TCPRoute"
@@ -264,31 +264,37 @@ resources:
   - kind: "GatewayClass"
     plural: "gatewayclasses"
     group: "gateway.networking.k8s.io"
-    version: "v1alpha2"
+    version: "v1beta1"
+    versionAliases:
+    - "v1alpha2"
     clusterScoped: true
-    protoPackage: "sigs.k8s.io/gateway-api/apis/v1alpha2"
+    protoPackage: "sigs.k8s.io/gateway-api/apis/v1beta1"
     proto: "k8s.io.gateway_api.api.v1alpha1.GatewayClassSpec"
     statusProto: "k8s.io.gateway_api.api.v1alpha1.GatewayClassStatus"
-    statusProtoPackage: "sigs.k8s.io/gateway-api/apis/v1alpha2"
+    statusProtoPackage: "sigs.k8s.io/gateway-api/apis/v1beta1"
 
   - kind: "Gateway"
     plural: "gateways"
     group: "gateway.networking.k8s.io"
-    version: "v1alpha2"
-    protoPackage: "sigs.k8s.io/gateway-api/apis/v1alpha2"
+    version: "v1beta1"
+    versionAliases:
+    - "v1alpha2"
+    protoPackage: "sigs.k8s.io/gateway-api/apis/v1beta1"
     proto: "k8s.io.gateway_api.api.v1alpha1.GatewaySpec"
     validate: "EmptyValidate"
     statusProto: "k8s.io.gateway_api.api.v1alpha1.GatewayStatus"
-    statusProtoPackage: "sigs.k8s.io/gateway-api/apis/v1alpha2"
+    statusProtoPackage: "sigs.k8s.io/gateway-api/apis/v1beta1"
 
   - kind: "HTTPRoute"
     plural: "httproutes"
     group: "gateway.networking.k8s.io"
-    version: "v1alpha2"
-    protoPackage: "sigs.k8s.io/gateway-api/apis/v1alpha2"
+    version: "v1beta1"
+    versionAliases:
+    - "v1alpha2"
+    protoPackage: "sigs.k8s.io/gateway-api/apis/v1beta1"
     proto: "k8s.io.gateway_api.api.v1alpha1.HTTPRouteSpec"
     statusProto: "k8s.io.gateway_api.api.v1alpha1.HTTPRouteStatus"
-    statusProtoPackage: "sigs.k8s.io/gateway-api/apis/v1alpha2"
+    statusProtoPackage: "sigs.k8s.io/gateway-api/apis/v1beta1"
 
   - kind: "TCPRoute"
     plural: "tcproutes"

--- a/pkg/config/schema/resource/schema.go
+++ b/pkg/config/schema/resource/schema.go
@@ -226,12 +226,13 @@ func (s *schemaImpl) Version() string {
 }
 
 func (s *schemaImpl) GroupVersionAliasKinds() []config.GroupVersionKind {
-	gvks := make([]config.GroupVersionKind, len(s.versionAliases))
-	for i, va := range s.versionAliases {
-		gvks[i] = s.gvk
-		gvks[i].Version = va
-	}
+	gvks := make([]config.GroupVersionKind, 0, len(s.versionAliases)+1)
 	gvks = append(gvks, s.GroupVersionKind())
+	for _, va := range s.versionAliases {
+		gvk := s.gvk
+		gvk.Version = va
+		gvks = append(gvks, gvk)
+	}
 	return gvks
 }
 

--- a/releasenotes/notes/gateway-v1beta1.yaml
+++ b/releasenotes/notes/gateway-v1beta1.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+releaseNotes:
+- |
+  **Upgraded** the gateway-api integration to read `v1beta1` resources for `HTTPRoute`, `Gateway`, and `GatewayClass`. Users of the gateway-api must be on v0.5.0+ before upgrading Istio.

--- a/tests/integration/pilot/gateway_conformance_test.go
+++ b/tests/integration/pilot/gateway_conformance_test.go
@@ -68,7 +68,10 @@ var conformanceNamespaces = []string{
 	"gateway-conformance-web-backend",
 }
 
-var skippedTests = map[string]string{}
+var skippedTests = map[string]string{
+	"GatewaySecretMissingReferencedSecret": "Not supported in this version of Istio",
+	"GatewayUnsupportedRouteKind":          "Not supported in this version of Istio",
+}
 
 func TestGatewayConformance(t *testing.T) {
 	// nolint: staticcheck
@@ -136,7 +139,7 @@ func DeployGatewayAPICRD(ctx framework.TestContext) {
 	// Wait until our GatewayClass is ready
 	retry.UntilSuccessOrFail(ctx, func() error {
 		for _, c := range ctx.Clusters().Configs() {
-			_, err := c.GatewayAPI().GatewayV1alpha2().GatewayClasses().Get(context.Background(), "istio", metav1.GetOptions{})
+			_, err := c.GatewayAPI().GatewayV1beta1().GatewayClasses().Get(context.Background(), "istio", metav1.GetOptions{})
 			if err != nil {
 				return err
 			}

--- a/tests/integration/pilot/ingress_test.go
+++ b/tests/integration/pilot/ingress_test.go
@@ -228,7 +228,7 @@ spec:
 					})
 					t.NewSubTest("status").Run(func(t framework.TestContext) {
 						retry.UntilSuccessOrFail(t, func() error {
-							gwc, err := t.Clusters().Kube().Default().GatewayAPI().GatewayV1alpha2().GatewayClasses().Get(context.Background(), "istio", metav1.GetOptions{})
+							gwc, err := t.Clusters().Kube().Default().GatewayAPI().GatewayV1beta1().GatewayClasses().Get(context.Background(), "istio", metav1.GetOptions{})
 							if err != nil {
 								return err
 							}

--- a/tests/integration/pilot/testdata/gateway-api-crd.yaml
+++ b/tests/integration/pilot/testdata/gateway-api-crd.yaml
@@ -1,10 +1,10 @@
-# Generated with `kustomize build "https://github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v0.5.0-rc1"`
+# Generated with `kubectl kustomize "https://github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=57cefb9268f6090bbdf2da59b131f7ba8c28c2f9"`
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/1086
-    gateway.networking.k8s.io/bundle-version: v0.5.0
+    gateway.networking.k8s.io/bundle-version: v0.6.0-dev
     gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: gatewayclasses.gateway.networking.k8s.io
@@ -218,8 +218,8 @@ spec:
         required:
         - spec
         type: object
-    served: true
-    storage: true
+    served: false
+    storage: false
     subresources:
       status: {}
   - additionalPrinterColumns:
@@ -420,7 +420,7 @@ spec:
         - spec
         type: object
     served: true
-    storage: false
+    storage: true
     subresources:
       status: {}
 status:
@@ -435,7 +435,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/1086
-    gateway.networking.k8s.io/bundle-version: v0.5.0
+    gateway.networking.k8s.io/bundle-version: v0.6.0-dev
     gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: gateways.gateway.networking.k8s.io
@@ -809,12 +809,11 @@ spec:
                               namespace:
                                 description: "Namespace is the namespace of the backend.
                                   When unspecified, the local namespace is inferred.
-                                  \n Note that when a different namespace is specified,
-                                  a ReferenceGrant object with ReferenceGrantTo.Kind=Secret
-                                  is required in the referent namespace to allow that
-                                  namespace's owner to accept the reference. See the
-                                  ReferenceGrant documentation for details. \n Support:
-                                  Core"
+                                  \n Note that when a namespace is specified, a ReferenceGrant
+                                  object is required in the referent namespace to
+                                  allow that namespace's owner to accept the reference.
+                                  See the ReferenceGrant documentation for details.
+                                  \n Support: Core"
                                 maxLength: 63
                                 minLength: 1
                                 pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -1143,8 +1142,8 @@ spec:
         required:
         - spec
         type: object
-    served: true
-    storage: true
+    served: false
+    storage: false
     subresources:
       status: {}
   - additionalPrinterColumns:
@@ -1838,7 +1837,7 @@ spec:
         - spec
         type: object
     served: true
-    storage: false
+    storage: true
     subresources:
       status: {}
 status:
@@ -1853,19 +1852,19 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/1086
-    gateway.networking.k8s.io/bundle-version: v0.5.0
+    gateway.networking.k8s.io/bundle-version: v0.6.0-dev
     gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
-  name: httproutes.gateway.networking.k8s.io
+  name: grpcroutes.gateway.networking.k8s.io
 spec:
   group: gateway.networking.k8s.io
   names:
     categories:
     - gateway-api
-    kind: HTTPRoute
-    listKind: HTTPRouteList
-    plural: httproutes
-    singular: httproute
+    kind: GRPCRoute
+    listKind: GRPCRouteList
+    plural: grpcroutes
+    singular: grpcroute
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
@@ -1878,10 +1877,30 @@ spec:
     name: v1alpha2
     schema:
       openAPIV3Schema:
-        description: HTTPRoute provides a way to route HTTP requests. This includes
-          the capability to match requests by hostname, path, header, or query param.
-          Filters can be used to specify additional processing steps. Backends specify
-          where matching requests should be routed.
+        description: "GRPCRoute provides a way to route gRPC requests. This includes
+          the capability to match requests by hostname, gRPC service, gRPC method,
+          or HTTP/2 header. Filters can be used to specify additional processing steps.
+          Backends specify where matching requests will be routed. \n GRPCRoute falls
+          under extended support within the Gateway API. Within the following specification,
+          the word \"MUST\" indicates that an implementation supporting GRPCRoute
+          must conform to the indicated requirement, but an implementation not supporting
+          need not follow the requirement unless explicitly indicated. \n Virtually
+          all existing gRPC connections happen directly over HTTP/2 without first
+          upgrading from HTTP/1. Nearly no server implementations support the upgrade
+          and next to no clients start with HTTP/1. As such, certain restrictions
+          are placed on implementations that claim support for GRPCRoute. \n Implementations
+          supporting `GRPCRoute` with the `HTTPS` `ProtocolType` MUST accept HTTP/2
+          connections without an initial upgrade from HTTP/1.1, i.e. via ALPN. If
+          the implementation does not support this, then it MUST raise a \"Detached\"
+          condition for the affected listener with a reason of \"UnsupportedProtocol\".
+          Note that a compliant implementation MAY also accept HTTP/2 connections
+          with an upgrade from HTTP/1. \n Implementations supporting `GRPCRoute` with
+          the `HTTP` `ProtocolType` MUST support cleartext HTTP/2 without an initial
+          upgrade from HTTP/1.1. If the implementation does not support this, then
+          it MUST raise a \"Detached\" condition for the affected listener with a
+          reason of \"UnsupportedProtocol\". Note that a compliant implementation
+          MAY also accept HTTP/2 connections with an upgrade from HTTP/1. \n Support:
+          Extended"
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -1896,38 +1915,46 @@ spec:
           metadata:
             type: object
           spec:
-            description: Spec defines the desired state of HTTPRoute.
+            description: Spec defines the desired state of GRPCRoute.
             properties:
               hostnames:
-                description: "Hostnames defines a set of hostname that should match
-                  against the HTTP Host header to select a HTTPRoute to process the
-                  request. This matches the RFC 1123 definition of a hostname with
-                  2 notable exceptions: \n 1. IPs are not allowed. 2. A hostname may
-                  be prefixed with a wildcard label (`*.`). The wildcard    label
-                  must appear by itself as the first label. \n If a hostname is specified
-                  by both the Listener and HTTPRoute, there must be at least one intersecting
-                  hostname for the HTTPRoute to be attached to the Listener. For example:
+                description: "Hostnames defines a set of hostname to match against
+                  the GRPC Host header to select a GRPCRoute to process the request.
+                  This matches the RFC 1123 definition of a hostname with 2 notable
+                  exceptions: \n 1. IPs are not allowed. 2. A hostname may be prefixed
+                  with a wildcard label (`*.`). The wildcard    label MUST appear
+                  by itself as the first label. \n If a hostname is specified by both
+                  the Listener and GRPCRoute, there MUST be at least one intersecting
+                  hostname for the GRPCRoute to be attached to the Listener. For example:
                   \n * A Listener with `test.example.com` as the hostname matches
-                  HTTPRoutes   that have either not specified any hostnames, or have
+                  GRPCRoutes   that have either not specified any hostnames, or have
                   specified at   least one of `test.example.com` or `*.example.com`.
-                  * A Listener with `*.example.com` as the hostname matches HTTPRoutes
+                  * A Listener with `*.example.com` as the hostname matches GRPCRoutes
                   \  that have either not specified any hostnames or have specified
                   at least   one hostname that matches the Listener hostname. For
-                  example,   `*.example.com`, `test.example.com`, and `foo.test.example.com`
-                  would   all match. On the other hand, `example.com` and `test.example.net`
-                  would   not match. \n Hostnames that are prefixed with a wildcard
-                  label (`*.`) are interpreted as a suffix match. That means that
-                  a match for `*.example.com` would match both `test.example.com`,
-                  and `foo.test.example.com`, but not `example.com`. \n If both the
-                  Listener and HTTPRoute have specified hostnames, any HTTPRoute hostnames
-                  that do not match the Listener hostname MUST be ignored. For example,
-                  if a Listener specified `*.example.com`, and the HTTPRoute specified
-                  `test.example.com` and `test.example.net`, `test.example.net` must
-                  not be considered for a match. \n If both the Listener and HTTPRoute
-                  have specified hostnames, and none match with the criteria above,
-                  then the HTTPRoute is not accepted. The implementation must raise
-                  an 'Accepted' Condition with a status of `False` in the corresponding
-                  RouteParentStatus. \n Support: Core"
+                  example,   `test.example.com` and `*.example.com` would both match.
+                  On the other   hand, `example.com` and `test.example.net` would
+                  not match. \n Hostnames that are prefixed with a wildcard label
+                  (`*.`) are interpreted as a suffix match. That means that a match
+                  for `*.example.com` would match both `test.example.com`, and `foo.test.example.com`,
+                  but not `example.com`. \n If both the Listener and GRPCRoute have
+                  specified hostnames, any GRPCRoute hostnames that do not match the
+                  Listener hostname MUST be ignored. For example, if a Listener specified
+                  `*.example.com`, and the GRPCRoute specified `test.example.com`
+                  and `test.example.net`, `test.example.net` MUST NOT be considered
+                  for a match. \n If both the Listener and GRPCRoute have specified
+                  hostnames, and none match with the criteria above, then the GRPCRoute
+                  is not accepted. The implementation MUST raise an 'Accepted' Condition
+                  with a status of `False` in the corresponding RouteParentStatus.
+                  \n If a Route (A) of type HTTPRoute or GRPCRoute is attached to
+                  a Listener and that listener already has another Route (B) of the
+                  other type attached and the intersection of the hostnames of A and
+                  B is non-empty, then the implementation MUST accept exactly one
+                  of these two routes, determined by the following criteria, in order:
+                  \n * The oldest Route based on creation timestamp. * The Route appearing
+                  first in alphabetical order by   \"{namespace}/{name}\". \n The
+                  rejected Route MUST raise an 'Accepted' condition with a status
+                  of 'False' in the corresponding RouteParentStatus. \n Support: Core"
                 items:
                   description: "Hostname is the fully qualified domain name of a network
                     host. This matches the RFC 1123 definition of a hostname with
@@ -1994,8 +2021,8 @@ spec:
                       type: string
                     namespace:
                       description: "Namespace is the namespace of the referent. When
-                        unspecified (or empty string), this refers to the local namespace
-                        of the Route. \n Support: Core"
+                        unspecified, this refers to the local namespace of the Route.
+                        \n Support: Core"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -2057,12 +2084,11 @@ spec:
               rules:
                 default:
                 - matches:
-                  - path:
-                      type: PathPrefix
-                      value: /
-                description: Rules are a list of HTTP matchers, filters and actions.
+                  - method:
+                      type: Exact
+                description: Rules are a list of GRPC matchers, filters and actions.
                 items:
-                  description: HTTPRouteRule defines semantics for matching an HTTP
+                  description: GRPCRouteRule defines semantics for matching an gRPC
                     request based on conditions (matches), processing it (filters),
                     and forwarding the request to an API object (backendRefs).
                   properties:
@@ -2072,33 +2098,33 @@ spec:
                         on how many BackendRefs are specified and how many are invalid.
                         \n If *all* entries in BackendRefs are invalid, and there
                         are also no filters specified in this route rule, *all* traffic
-                        which matches this rule MUST receive a 500 status code. \n
-                        See the HTTPBackendRef definition for the rules about what
-                        makes a single HTTPBackendRef invalid. \n When a HTTPBackendRef
-                        is invalid, 500 status codes MUST be returned for requests
+                        which matches this rule MUST receive an `UNAVAILABLE` status.
+                        \n See the GRPCBackendRef definition for the rules about what
+                        makes a single GRPCBackendRef invalid. \n When a GRPCBackendRef
+                        is invalid, `UNAVAILABLE` statuses MUST be returned for requests
                         that would have otherwise been routed to an invalid backend.
                         If multiple backends are specified, and some are invalid,
                         the proportion of requests that would otherwise have been
-                        routed to an invalid backend MUST receive a 500 status code.
-                        \n For example, if two backends are specified with equal weights,
-                        and one is invalid, 50 percent of traffic must receive a 500.
-                        Implementations may choose how that 50 percent is determined.
-                        \n Support: Core for Kubernetes Service \n Support: Custom
-                        for any other resource \n Support for weight: Core"
+                        routed to an invalid backend MUST receive an `UNAVAILABLE`
+                        status. \n For example, if two backends are specified with
+                        equal weights, and one is invalid, 50 percent of traffic MUST
+                        receive an `UNAVAILABLE` status. Implementations may choose
+                        how that 50 percent is determined. \n Support: Core for Kubernetes
+                        Service \n Support: Custom for any other resource \n Support
+                        for weight: Core"
                       items:
-                        description: HTTPBackendRef defines how a HTTPRoute should
-                          forward an HTTP request.
+                        description: GRPCBackendRef defines how a GRPCRoute forwards
+                          a gRPC request.
                         properties:
                           filters:
-                            description: "Filters defined at this level should be
-                              executed if and only if the request is being forwarded
-                              to the backend defined here. \n Support: Custom (For
-                              broader support of filters, use the Filters field in
-                              HTTPRouteRule.)"
+                            description: "Filters defined at this level MUST be executed
+                              if and only if the request is being forwarded to the
+                              backend defined here. \n Support: Custom (For broader
+                              support of filters, use the Filters field in GRPCRouteRule.)"
                             items:
-                              description: HTTPRouteFilter defines processing steps
+                              description: GRPCRouteFilter defines processing steps
                                 that must be completed during the request or response
-                                lifecycle. HTTPRouteFilters are meant as an extension
+                                lifecycle. GRPCRouteFilters are meant as an extension
                                 point to express processing that may be done in Gateway
                                 implementations. Some examples include request or
                                 response modification, implementing authentication
@@ -2300,9 +2326,8 @@ spec:
                                           description: "Namespace is the namespace
                                             of the backend. When unspecified, the
                                             local namespace is inferred. \n Note that
-                                            when a different namespace is specified,
-                                            a ReferenceGrant object with ReferenceGrantTo.Kind=Service
-                                            is required in the referent namespace
+                                            when a namespace is specified, a ReferenceGrant
+                                            object is required in the referent namespace
                                             to allow that namespace's owner to accept
                                             the reference. See the ReferenceGrant
                                             documentation for details. \n Support:
@@ -2315,7 +2340,9 @@ spec:
                                           description: Port specifies the destination
                                             port number to use for this resource.
                                             Port is required when the referent is
-                                            a Kubernetes Service. For other resources,
+                                            a Kubernetes Service. In this case, the
+                                            port number is the service port number,
+                                            not the target port. For other resources,
                                             destination port might be derived from
                                             the referent resource or this field.
                                           format: int32
@@ -2328,110 +2355,6 @@ spec:
                                   required:
                                   - backendRef
                                   type: object
-                                requestRedirect:
-                                  description: "RequestRedirect defines a schema for
-                                    a filter that responds to the request with an
-                                    HTTP redirection. \n Support: Core"
-                                  properties:
-                                    hostname:
-                                      description: "Hostname is the hostname to be
-                                        used in the value of the `Location` header
-                                        in the response. When empty, the hostname
-                                        of the request is used. \n Support: Core"
-                                      maxLength: 253
-                                      minLength: 1
-                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                                      type: string
-                                    path:
-                                      description: "Path defines parameters used to
-                                        modify the path of the incoming request. The
-                                        modified path is then used to construct the
-                                        `Location` header. When empty, the request
-                                        path is used as-is. \n Support: Extended \n
-                                        <gateway:experimental>"
-                                      properties:
-                                        replaceFullPath:
-                                          description: "ReplaceFullPath specifies
-                                            the value with which to replace the full
-                                            path of a request during a rewrite or
-                                            redirect. \n <gateway:experimental>"
-                                          maxLength: 1024
-                                          type: string
-                                        replacePrefixMatch:
-                                          description: "ReplacePrefixMatch specifies
-                                            the value with which to replace the prefix
-                                            match of a request during a rewrite or
-                                            redirect. For example, a request to \"/foo/bar\"
-                                            with a prefix match of \"/foo\" would
-                                            be modified to \"/bar\". \n Note that
-                                            this matches the behavior of the PathPrefix
-                                            match type. This matches full path elements.
-                                            A path element refers to the list of labels
-                                            in the path split by the `/` separator.
-                                            When specified, a trailing `/` is ignored.
-                                            For example, the paths `/abc`, `/abc/`,
-                                            and `/abc/def` would all match the prefix
-                                            `/abc`, but the path `/abcd` would not.
-                                            \n <gateway:experimental>"
-                                          maxLength: 1024
-                                          type: string
-                                        type:
-                                          description: "Type defines the type of path
-                                            modifier. Additional types may be added
-                                            in a future release of the API. \n Note
-                                            that values may be added to this enum,
-                                            implementations must ensure that unknown
-                                            values will not cause a crash. \n Unknown
-                                            values here must result in the implementation
-                                            setting the Attached Condition for the
-                                            Route to `status: False`, with a Reason
-                                            of `UnsupportedValue`. \n <gateway:experimental>"
-                                          enum:
-                                          - ReplaceFullPath
-                                          - ReplacePrefixMatch
-                                          type: string
-                                      required:
-                                      - type
-                                      type: object
-                                    port:
-                                      description: "Port is the port to be used in
-                                        the value of the `Location` header in the
-                                        response. When empty, port (if specified)
-                                        of the request is used. \n Support: Extended"
-                                      format: int32
-                                      maximum: 65535
-                                      minimum: 1
-                                      type: integer
-                                    scheme:
-                                      description: "Scheme is the scheme to be used
-                                        in the value of the `Location` header in the
-                                        response. When empty, the scheme of the request
-                                        is used. \n Support: Extended \n Note that
-                                        values may be added to this enum, implementations
-                                        must ensure that unknown values will not cause
-                                        a crash. \n Unknown values here must result
-                                        in the implementation setting the Attached
-                                        Condition for the Route to `status: False`,
-                                        with a Reason of `UnsupportedValue`."
-                                      enum:
-                                      - http
-                                      - https
-                                      type: string
-                                    statusCode:
-                                      default: 302
-                                      description: "StatusCode is the HTTP status
-                                        code to be used in response. \n Support: Core
-                                        \n Note that values may be added to this enum,
-                                        implementations must ensure that unknown values
-                                        will not cause a crash. \n Unknown values
-                                        here must result in the implementation setting
-                                        the Attached Condition for the Route to `status:
-                                        False`, with a Reason of `UnsupportedValue`."
-                                      enum:
-                                      - 301
-                                      - 302
-                                      type: integer
-                                  type: object
                                 type:
                                   description: "Type identifies the type of filter
                                     to apply. As with other API fields, types are
@@ -2439,99 +2362,31 @@ spec:
                                     Core: Filter types and their corresponding configuration
                                     defined by   \"Support: Core\" in this package,
                                     e.g. \"RequestHeaderModifier\". All   implementations
-                                    must support core filters. \n - Extended: Filter
-                                    types and their corresponding configuration defined
-                                    by   \"Support: Extended\" in this package, e.g.
-                                    \"RequestMirror\". Implementers   are encouraged
-                                    to support extended filters. \n - Custom: Filters
-                                    that are defined and supported by specific vendors.
-                                    \  In the future, filters showing convergence
-                                    in behavior across multiple   implementations
-                                    will be considered for inclusion in extended or
-                                    core   conformance levels. Filter-specific configuration
-                                    for such filters   is specified using the ExtensionRef
-                                    field. `Type` should be set to   \"ExtensionRef\"
-                                    for custom filters. \n Implementers are encouraged
-                                    to define custom implementation types to extend
-                                    the core API with implementation-specific behavior.
-                                    \n If a reference to a custom filter type cannot
-                                    be resolved, the filter MUST NOT be skipped. Instead,
-                                    requests that would have been processed by that
-                                    filter MUST receive a HTTP error response. \n
-                                    Note that values may be added to this enum, implementations
-                                    must ensure that unknown values will not cause
-                                    a crash. \n Unknown values here must result in
-                                    the implementation setting the Attached Condition
-                                    for the Route to `status: False`, with a Reason
-                                    of `UnsupportedValue`. \n "
+                                    supporting GRPCRoute MUST support core filters.
+                                    \n - Extended: Filter types and their corresponding
+                                    configuration defined by   \"Support: Extended\"
+                                    in this package, e.g. \"RequestMirror\". Implementers
+                                    \  are encouraged to support extended filters.
+                                    \n - Custom: Filters that are defined and supported
+                                    by specific vendors.   In the future, filters
+                                    showing convergence in behavior across multiple
+                                    \  implementations will be considered for inclusion
+                                    in extended or core   conformance levels. Filter-specific
+                                    configuration for such filters   is specified
+                                    using the ExtensionRef field. `Type` MUST be set
+                                    to   \"ExtensionRef\" for custom filters. \n Implementers
+                                    are encouraged to define custom implementation
+                                    types to extend the core API with implementation-specific
+                                    behavior. \n If a reference to a custom filter
+                                    type cannot be resolved, the filter MUST NOT be
+                                    skipped. Instead, requests that would have been
+                                    processed by that filter MUST receive a HTTP error
+                                    response. \n "
                                   enum:
                                   - RequestHeaderModifier
                                   - RequestMirror
-                                  - RequestRedirect
-                                  - URLRewrite
                                   - ExtensionRef
                                   type: string
-                                urlRewrite:
-                                  description: "URLRewrite defines a schema for a
-                                    filter that modifies a request during forwarding.
-                                    \n Support: Extended \n <gateway:experimental>"
-                                  properties:
-                                    hostname:
-                                      description: "Hostname is the value to be used
-                                        to replace the Host header value during forwarding.
-                                        \n Support: Extended \n <gateway:experimental>"
-                                      maxLength: 253
-                                      minLength: 1
-                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                                      type: string
-                                    path:
-                                      description: "Path defines a path rewrite. \n
-                                        Support: Extended \n <gateway:experimental>"
-                                      properties:
-                                        replaceFullPath:
-                                          description: "ReplaceFullPath specifies
-                                            the value with which to replace the full
-                                            path of a request during a rewrite or
-                                            redirect. \n <gateway:experimental>"
-                                          maxLength: 1024
-                                          type: string
-                                        replacePrefixMatch:
-                                          description: "ReplacePrefixMatch specifies
-                                            the value with which to replace the prefix
-                                            match of a request during a rewrite or
-                                            redirect. For example, a request to \"/foo/bar\"
-                                            with a prefix match of \"/foo\" would
-                                            be modified to \"/bar\". \n Note that
-                                            this matches the behavior of the PathPrefix
-                                            match type. This matches full path elements.
-                                            A path element refers to the list of labels
-                                            in the path split by the `/` separator.
-                                            When specified, a trailing `/` is ignored.
-                                            For example, the paths `/abc`, `/abc/`,
-                                            and `/abc/def` would all match the prefix
-                                            `/abc`, but the path `/abcd` would not.
-                                            \n <gateway:experimental>"
-                                          maxLength: 1024
-                                          type: string
-                                        type:
-                                          description: "Type defines the type of path
-                                            modifier. Additional types may be added
-                                            in a future release of the API. \n Note
-                                            that values may be added to this enum,
-                                            implementations must ensure that unknown
-                                            values will not cause a crash. \n Unknown
-                                            values here must result in the implementation
-                                            setting the Attached Condition for the
-                                            Route to `status: False`, with a Reason
-                                            of `UnsupportedValue`. \n <gateway:experimental>"
-                                          enum:
-                                          - ReplaceFullPath
-                                          - ReplacePrefixMatch
-                                          type: string
-                                      required:
-                                      - type
-                                      type: object
-                                  type: object
                               required:
                               - type
                               type: object
@@ -2562,11 +2417,11 @@ spec:
                           namespace:
                             description: "Namespace is the namespace of the backend.
                               When unspecified, the local namespace is inferred. \n
-                              Note that when a different namespace is specified, a
-                              ReferenceGrant object with ReferenceGrantTo.Kind=Service
-                              is required in the referent namespace to allow that
-                              namespace's owner to accept the reference. See the ReferenceGrant
-                              documentation for details. \n Support: Core"
+                              Note that when a namespace is specified, a ReferenceGrant
+                              object is required in the referent namespace to allow
+                              that namespace's owner to accept the reference. See
+                              the ReferenceGrant documentation for details. \n Support:
+                              Core"
                             maxLength: 63
                             minLength: 1
                             pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -2574,9 +2429,10 @@ spec:
                           port:
                             description: Port specifies the destination port number
                               to use for this resource. Port is required when the
-                              referent is a Kubernetes Service. For other resources,
-                              destination port might be derived from the referent
-                              resource or this field.
+                              referent is a Kubernetes Service. In this case, the
+                              port number is the service port number, not the target
+                              port. For other resources, destination port might be
+                              derived from the referent resource or this field.
                             format: int32
                             maximum: 65535
                             minimum: 1
@@ -2616,17 +2472,11 @@ spec:
                         extended filters. - Implementation-specific custom filters
                         have no API guarantees across   implementations. \n Specifying
                         a core filter multiple times has unspecified or custom conformance.
-                        \n All filters are expected to be compatible with each other
-                        except for the URLRewrite and RequestRedirect filters, which
-                        may not be combined. If an implementation can not support
-                        other combinations of filters, they must clearly document
-                        that limitation. In all cases where incompatible or unsupported
-                        filters are specified, implementations MUST add a warning
-                        condition to status. \n Support: Core"
+                        Support: Core"
                       items:
-                        description: HTTPRouteFilter defines processing steps that
+                        description: GRPCRouteFilter defines processing steps that
                           must be completed during the request or response lifecycle.
-                          HTTPRouteFilters are meant as an extension point to express
+                          GRPCRouteFilters are meant as an extension point to express
                           processing that may be done in Gateway implementations.
                           Some examples include request or response modification,
                           implementing authentication strategies, rate-limiting, and
@@ -2815,12 +2665,11 @@ spec:
                                   namespace:
                                     description: "Namespace is the namespace of the
                                       backend. When unspecified, the local namespace
-                                      is inferred. \n Note that when a different namespace
-                                      is specified, a ReferenceGrant object with ReferenceGrantTo.Kind=Service
-                                      is required in the referent namespace to allow
-                                      that namespace's owner to accept the reference.
-                                      See the ReferenceGrant documentation for details.
-                                      \n Support: Core"
+                                      is inferred. \n Note that when a namespace is
+                                      specified, a ReferenceGrant object is required
+                                      in the referent namespace to allow that namespace's
+                                      owner to accept the reference. See the ReferenceGrant
+                                      documentation for details. \n Support: Core"
                                     maxLength: 63
                                     minLength: 1
                                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -2828,9 +2677,11 @@ spec:
                                   port:
                                     description: Port specifies the destination port
                                       number to use for this resource. Port is required
-                                      when the referent is a Kubernetes Service. For
-                                      other resources, destination port might be derived
-                                      from the referent resource or this field.
+                                      when the referent is a Kubernetes Service. In
+                                      this case, the port number is the service port
+                                      number, not the target port. For other resources,
+                                      destination port might be derived from the referent
+                                      resource or this field.
                                     format: int32
                                     maximum: 65535
                                     minimum: 1
@@ -2841,196 +2692,36 @@ spec:
                             required:
                             - backendRef
                             type: object
-                          requestRedirect:
-                            description: "RequestRedirect defines a schema for a filter
-                              that responds to the request with an HTTP redirection.
-                              \n Support: Core"
-                            properties:
-                              hostname:
-                                description: "Hostname is the hostname to be used
-                                  in the value of the `Location` header in the response.
-                                  When empty, the hostname of the request is used.
-                                  \n Support: Core"
-                                maxLength: 253
-                                minLength: 1
-                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                                type: string
-                              path:
-                                description: "Path defines parameters used to modify
-                                  the path of the incoming request. The modified path
-                                  is then used to construct the `Location` header.
-                                  When empty, the request path is used as-is. \n Support:
-                                  Extended \n <gateway:experimental>"
-                                properties:
-                                  replaceFullPath:
-                                    description: "ReplaceFullPath specifies the value
-                                      with which to replace the full path of a request
-                                      during a rewrite or redirect. \n <gateway:experimental>"
-                                    maxLength: 1024
-                                    type: string
-                                  replacePrefixMatch:
-                                    description: "ReplacePrefixMatch specifies the
-                                      value with which to replace the prefix match
-                                      of a request during a rewrite or redirect. For
-                                      example, a request to \"/foo/bar\" with a prefix
-                                      match of \"/foo\" would be modified to \"/bar\".
-                                      \n Note that this matches the behavior of the
-                                      PathPrefix match type. This matches full path
-                                      elements. A path element refers to the list
-                                      of labels in the path split by the `/` separator.
-                                      When specified, a trailing `/` is ignored. For
-                                      example, the paths `/abc`, `/abc/`, and `/abc/def`
-                                      would all match the prefix `/abc`, but the path
-                                      `/abcd` would not. \n <gateway:experimental>"
-                                    maxLength: 1024
-                                    type: string
-                                  type:
-                                    description: "Type defines the type of path modifier.
-                                      Additional types may be added in a future release
-                                      of the API. \n Note that values may be added
-                                      to this enum, implementations must ensure that
-                                      unknown values will not cause a crash. \n Unknown
-                                      values here must result in the implementation
-                                      setting the Attached Condition for the Route
-                                      to `status: False`, with a Reason of `UnsupportedValue`.
-                                      \n <gateway:experimental>"
-                                    enum:
-                                    - ReplaceFullPath
-                                    - ReplacePrefixMatch
-                                    type: string
-                                required:
-                                - type
-                                type: object
-                              port:
-                                description: "Port is the port to be used in the value
-                                  of the `Location` header in the response. When empty,
-                                  port (if specified) of the request is used. \n Support:
-                                  Extended"
-                                format: int32
-                                maximum: 65535
-                                minimum: 1
-                                type: integer
-                              scheme:
-                                description: "Scheme is the scheme to be used in the
-                                  value of the `Location` header in the response.
-                                  When empty, the scheme of the request is used. \n
-                                  Support: Extended \n Note that values may be added
-                                  to this enum, implementations must ensure that unknown
-                                  values will not cause a crash. \n Unknown values
-                                  here must result in the implementation setting the
-                                  Attached Condition for the Route to `status: False`,
-                                  with a Reason of `UnsupportedValue`."
-                                enum:
-                                - http
-                                - https
-                                type: string
-                              statusCode:
-                                default: 302
-                                description: "StatusCode is the HTTP status code to
-                                  be used in response. \n Support: Core \n Note that
-                                  values may be added to this enum, implementations
-                                  must ensure that unknown values will not cause a
-                                  crash. \n Unknown values here must result in the
-                                  implementation setting the Attached Condition for
-                                  the Route to `status: False`, with a Reason of `UnsupportedValue`."
-                                enum:
-                                - 301
-                                - 302
-                                type: integer
-                            type: object
                           type:
                             description: "Type identifies the type of filter to apply.
                               As with other API fields, types are classified into
                               three conformance levels: \n - Core: Filter types and
                               their corresponding configuration defined by   \"Support:
                               Core\" in this package, e.g. \"RequestHeaderModifier\".
-                              All   implementations must support core filters. \n
-                              - Extended: Filter types and their corresponding configuration
-                              defined by   \"Support: Extended\" in this package,
-                              e.g. \"RequestMirror\". Implementers   are encouraged
-                              to support extended filters. \n - Custom: Filters that
-                              are defined and supported by specific vendors.   In
-                              the future, filters showing convergence in behavior
-                              across multiple   implementations will be considered
-                              for inclusion in extended or core   conformance levels.
-                              Filter-specific configuration for such filters   is
-                              specified using the ExtensionRef field. `Type` should
-                              be set to   \"ExtensionRef\" for custom filters. \n
-                              Implementers are encouraged to define custom implementation
-                              types to extend the core API with implementation-specific
-                              behavior. \n If a reference to a custom filter type
-                              cannot be resolved, the filter MUST NOT be skipped.
-                              Instead, requests that would have been processed by
-                              that filter MUST receive a HTTP error response. \n Note
-                              that values may be added to this enum, implementations
-                              must ensure that unknown values will not cause a crash.
-                              \n Unknown values here must result in the implementation
-                              setting the Attached Condition for the Route to `status:
-                              False`, with a Reason of `UnsupportedValue`. \n "
+                              All   implementations supporting GRPCRoute MUST support
+                              core filters. \n - Extended: Filter types and their
+                              corresponding configuration defined by   \"Support:
+                              Extended\" in this package, e.g. \"RequestMirror\".
+                              Implementers   are encouraged to support extended filters.
+                              \n - Custom: Filters that are defined and supported
+                              by specific vendors.   In the future, filters showing
+                              convergence in behavior across multiple   implementations
+                              will be considered for inclusion in extended or core
+                              \  conformance levels. Filter-specific configuration
+                              for such filters   is specified using the ExtensionRef
+                              field. `Type` MUST be set to   \"ExtensionRef\" for
+                              custom filters. \n Implementers are encouraged to define
+                              custom implementation types to extend the core API with
+                              implementation-specific behavior. \n If a reference
+                              to a custom filter type cannot be resolved, the filter
+                              MUST NOT be skipped. Instead, requests that would have
+                              been processed by that filter MUST receive a HTTP error
+                              response. \n "
                             enum:
                             - RequestHeaderModifier
                             - RequestMirror
-                            - RequestRedirect
-                            - URLRewrite
                             - ExtensionRef
                             type: string
-                          urlRewrite:
-                            description: "URLRewrite defines a schema for a filter
-                              that modifies a request during forwarding. \n Support:
-                              Extended \n <gateway:experimental>"
-                            properties:
-                              hostname:
-                                description: "Hostname is the value to be used to
-                                  replace the Host header value during forwarding.
-                                  \n Support: Extended \n <gateway:experimental>"
-                                maxLength: 253
-                                minLength: 1
-                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                                type: string
-                              path:
-                                description: "Path defines a path rewrite. \n Support:
-                                  Extended \n <gateway:experimental>"
-                                properties:
-                                  replaceFullPath:
-                                    description: "ReplaceFullPath specifies the value
-                                      with which to replace the full path of a request
-                                      during a rewrite or redirect. \n <gateway:experimental>"
-                                    maxLength: 1024
-                                    type: string
-                                  replacePrefixMatch:
-                                    description: "ReplacePrefixMatch specifies the
-                                      value with which to replace the prefix match
-                                      of a request during a rewrite or redirect. For
-                                      example, a request to \"/foo/bar\" with a prefix
-                                      match of \"/foo\" would be modified to \"/bar\".
-                                      \n Note that this matches the behavior of the
-                                      PathPrefix match type. This matches full path
-                                      elements. A path element refers to the list
-                                      of labels in the path split by the `/` separator.
-                                      When specified, a trailing `/` is ignored. For
-                                      example, the paths `/abc`, `/abc/`, and `/abc/def`
-                                      would all match the prefix `/abc`, but the path
-                                      `/abcd` would not. \n <gateway:experimental>"
-                                    maxLength: 1024
-                                    type: string
-                                  type:
-                                    description: "Type defines the type of path modifier.
-                                      Additional types may be added in a future release
-                                      of the API. \n Note that values may be added
-                                      to this enum, implementations must ensure that
-                                      unknown values will not cause a crash. \n Unknown
-                                      values here must result in the implementation
-                                      setting the Attached Condition for the Route
-                                      to `status: False`, with a Reason of `UnsupportedValue`.
-                                      \n <gateway:experimental>"
-                                    enum:
-                                    - ReplaceFullPath
-                                    - ReplacePrefixMatch
-                                    type: string
-                                required:
-                                - type
-                                type: object
-                            type: object
                         required:
                         - type
                         type: object
@@ -3038,94 +2729,78 @@ spec:
                       type: array
                     matches:
                       default:
-                      - path:
-                          type: PathPrefix
-                          value: /
+                      - method:
+                          type: Exact
                       description: "Matches define conditions used for matching the
-                        rule against incoming HTTP requests. Each match is independent,
+                        rule against incoming gRPC requests. Each match is independent,
                         i.e. this rule will be matched if **any** one of the matches
                         is satisfied. \n For example, take the following matches configuration:
-                        \n ``` matches: - path:     value: \"/foo\"   headers:   -
-                        name: \"version\"     value: \"v2\" - path:     value: \"/v2/foo\"
-                        ``` \n For a request to match against this rule, a request
-                        must satisfy EITHER of the two conditions: \n - path prefixed
-                        with `/foo` AND contains the header `version: v2` - path prefix
-                        of `/v2/foo` \n See the documentation for HTTPRouteMatch on
-                        how to specify multiple match conditions that should be ANDed
-                        together. \n If no matches are specified, the default is a
-                        prefix path match on \"/\", which has the effect of matching
-                        every HTTP request. \n Proxy or Load Balancer routing configuration
-                        generated from HTTPRoutes MUST prioritize rules based on the
-                        following criteria, continuing on ties. Precedence must be
-                        given to the Rule with the largest number of: \n * Characters
-                        in a matching non-wildcard hostname. * Characters in a matching
-                        hostname. * Characters in a matching path. * Header matches.
-                        * Query param matches. \n If ties still exist across multiple
+                        \n ``` matches: - method:     service: foo.bar   headers:
+                        \    values:       version: 2 - method:     service: foo.bar.v2
+                        ``` \n For a request to match against this rule, it MUST satisfy
+                        EITHER of the two conditions: \n - service of foo.bar AND
+                        contains the header `version: 2` - service of foo.bar.v2 \n
+                        See the documentation for GRPCRouteMatch on how to specify
+                        multiple match conditions to be ANDed together. \n If no matches
+                        are specified, the implementation MUST match every gRPC request.
+                        \n Proxy or Load Balancer routing configuration generated
+                        from GRPCRoutes MUST prioritize rules based on the following
+                        criteria, continuing on ties. Merging MUST not be done between
+                        GRPCRoutes and HTTPRoutes. Precedence MUST be given to the
+                        rule with the largest number of: \n * Characters in a matching
+                        non-wildcard hostname. * Characters in a matching hostname.
+                        * Characters in a matching service. * Characters in a matching
+                        method. * Header matches. \n If ties still exist across multiple
                         Routes, matching precedence MUST be determined in order of
                         the following criteria, continuing on ties: \n * The oldest
                         Route based on creation timestamp. * The Route appearing first
                         in alphabetical order by   \"{namespace}/{name}\". \n If ties
                         still exist within the Route that has been given precedence,
                         matching precedence MUST be granted to the first matching
-                        rule meeting the above criteria. \n When no rules matching
-                        a request have been successfully attached to the parent a
-                        request is coming from, a HTTP 404 status code MUST be returned."
+                        rule meeting the above criteria."
                       items:
-                        description: "HTTPRouteMatch defines the predicate used to
+                        description: "GRPCRouteMatch defines the predicate used to
                           match requests to a given action. Multiple match types are
                           ANDed together, i.e. the match will evaluate to true only
                           if all conditions are satisfied. \n For example, the match
-                          below will match a HTTP request only if its path starts
-                          with `/foo` AND it contains the `version: v1` header: \n
-                          ``` match:   path:     value: \"/foo\"   headers:   - name:
-                          \"version\"     value \"v1\" ```"
+                          below will match a gRPC request only if its service is `foo`
+                          AND it contains the `version: v1` header: \n ``` matches:
+                          - method:    type: Exact    service: \"foo\"   headers:
+                          \  - name: \"version\"     value \"v1\" ```"
                         properties:
                           headers:
-                            description: Headers specifies HTTP request header matchers.
+                            description: Headers specifies gRPC request header matchers.
                               Multiple match values are ANDed together, meaning, a
-                              request must match all the specified headers to select
+                              request MUST match all the specified headers to select
                               the route.
                             items:
-                              description: HTTPHeaderMatch describes how to select
-                                a HTTP route by matching HTTP request headers.
+                              description: GRPCHeaderMatch describes how to select
+                                a gRPC route by matching gRPC request headers.
                               properties:
                                 name:
-                                  description: "Name is the name of the HTTP Header
-                                    to be matched. Name matching MUST be case insensitive.
-                                    (See https://tools.ietf.org/html/rfc7230#section-3.2).
-                                    \n If multiple entries specify equivalent header
-                                    names, only the first entry with an equivalent
-                                    name MUST be considered for a match. Subsequent
-                                    entries with an equivalent header name MUST be
-                                    ignored. Due to the case-insensitivity of header
-                                    names, \"foo\" and \"Foo\" are considered equivalent.
-                                    \n When a header is repeated in an HTTP request,
-                                    it is implementation-specific behavior as to how
-                                    this is represented. Generally, proxies should
-                                    follow the guidance from the RFC: https://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2
-                                    regarding processing a repeated header, with special
-                                    handling for \"Set-Cookie\"."
+                                  description: "Name is the name of the gRPC Header
+                                    to be matched. \n If multiple entries specify
+                                    equivalent header names, only the first entry
+                                    with an equivalent name MUST be considered for
+                                    a match. Subsequent entries with an equivalent
+                                    header name MUST be ignored. Due to the case-insensitivity
+                                    of header names, \"foo\" and \"Foo\" are considered
+                                    equivalent."
                                   maxLength: 256
                                   minLength: 1
                                   pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                   type: string
                                 type:
                                   default: Exact
-                                  description: "Type specifies how to match against
-                                    the value of the header. \n Support: Core (Exact)
-                                    \n Support: Custom (RegularExpression) \n Since
-                                    RegularExpression HeaderMatchType has custom conformance,
-                                    implementations can support POSIX, PCRE or any
-                                    other dialects of regular expressions. Please
-                                    read the implementation's documentation to determine
-                                    the supported dialect."
+                                  description: Type specifies how to match against
+                                    the value of the header.
                                   enum:
                                   - Exact
                                   - RegularExpression
                                   type: string
                                 value:
-                                  description: Value is the value of HTTP Header to
-                                    be matched.
+                                  description: Value is the value of the gRPC Header
+                                    to be matched.
                                   maxLength: 4096
                                   minLength: 1
                                   type: string
@@ -3139,94 +2814,42 @@ spec:
                             - name
                             x-kubernetes-list-type: map
                           method:
-                            description: "Method specifies HTTP method matcher. When
-                              specified, this route will be matched only if the request
-                              has the specified method. \n Support: Extended"
-                            enum:
-                            - GET
-                            - HEAD
-                            - POST
-                            - PUT
-                            - DELETE
-                            - CONNECT
-                            - OPTIONS
-                            - TRACE
-                            - PATCH
-                            type: string
-                          path:
                             default:
-                              type: PathPrefix
-                              value: /
-                            description: Path specifies a HTTP request path matcher.
-                              If this field is not specified, a default prefix match
-                              on the "/" path is provided.
+                              type: Exact
+                            description: Path specifies a gRPC request service/method
+                              matcher. If this field is not specified, all services
+                              and methods will match.
                             properties:
+                              method:
+                                default: ""
+                                description: "Value of the method to match against.
+                                  If left empty or omitted, will match all services.
+                                  \n At least one of Service and Method MUST be a
+                                  non-empty string."
+                                maxLength: 1024
+                                pattern: ^[^\/]*$
+                                type: string
+                              service:
+                                default: ""
+                                description: "Value of the service to match against.
+                                  If left empty or omitted, will match all services.
+                                  \n At least one of Service and Method MUST be a
+                                  non-empty string."
+                                maxLength: 1024
+                                pattern: ^[^\/]*$
+                                type: string
                               type:
-                                default: PathPrefix
+                                default: Exact
                                 description: "Type specifies how to match against
-                                  the path Value. \n Support: Core (Exact, PathPrefix)
+                                  the service and/or method. Support: Core (Exact
+                                  with service and method specified) \n Support Custom
+                                  (Exact with method specified but no service specified)
                                   \n Support: Custom (RegularExpression)"
                                 enum:
                                 - Exact
-                                - PathPrefix
                                 - RegularExpression
                                 type: string
-                              value:
-                                default: /
-                                description: Value of the HTTP path to match against.
-                                maxLength: 1024
-                                type: string
                             type: object
-                          queryParams:
-                            description: QueryParams specifies HTTP query parameter
-                              matchers. Multiple match values are ANDed together,
-                              meaning, a request must match all the specified query
-                              parameters to select the route.
-                            items:
-                              description: HTTPQueryParamMatch describes how to select
-                                a HTTP route by matching HTTP query parameters.
-                              properties:
-                                name:
-                                  description: "Name is the name of the HTTP query
-                                    param to be matched. This must be an exact string
-                                    match. (See https://tools.ietf.org/html/rfc7230#section-2.7.3).
-                                    \n If multiple entries specify equivalent query
-                                    param names, only the first entry with an equivalent
-                                    name MUST be considered for a match. Subsequent
-                                    entries with an equivalent query param name MUST
-                                    be ignored."
-                                  maxLength: 256
-                                  minLength: 1
-                                  type: string
-                                type:
-                                  default: Exact
-                                  description: "Type specifies how to match against
-                                    the value of the query parameter. \n Support:
-                                    Extended (Exact) \n Support: Custom (RegularExpression)
-                                    \n Since RegularExpression QueryParamMatchType
-                                    has custom conformance, implementations can support
-                                    POSIX, PCRE or any other dialects of regular expressions.
-                                    Please read the implementation's documentation
-                                    to determine the supported dialect."
-                                  enum:
-                                  - Exact
-                                  - RegularExpression
-                                  type: string
-                                value:
-                                  description: Value is the value of HTTP query param
-                                    to be matched.
-                                  maxLength: 1024
-                                  minLength: 1
-                                  type: string
-                              required:
-                              - name
-                              - value
-                              type: object
-                            maxItems: 16
-                            type: array
-                            x-kubernetes-list-map-keys:
-                            - name
-                            x-kubernetes-list-type: map
                         type: object
                       maxItems: 8
                       type: array
@@ -3235,7 +2858,7 @@ spec:
                 type: array
             type: object
           status:
-            description: Status defines the current state of HTTPRoute.
+            description: Status defines the current state of GRPCRoute.
             properties:
               parents:
                 description: "Parents is a list of parent resources (usually Gateways)
@@ -3390,8 +3013,8 @@ spec:
                           type: string
                         namespace:
                           description: "Namespace is the namespace of the referent.
-                            When unspecified (or empty string), this refers to the
-                            local namespace of the Route. \n Support: Core"
+                            When unspecified, this refers to the local namespace of
+                            the Route. \n Support: Core"
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -3460,13 +3083,38 @@ spec:
             required:
             - parents
             type: object
-        required:
-        - spec
         type: object
     served: true
     storage: true
     subresources:
       status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/1086
+    gateway.networking.k8s.io/bundle-version: v0.6.0-dev
+    gateway.networking.k8s.io/channel: experimental
+  creationTimestamp: null
+  name: httproutes.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    categories:
+    - gateway-api
+    kind: HTTPRoute
+    listKind: HTTPRouteList
+    plural: httproutes
+    singular: httproute
+  scope: Namespaced
+  versions:
   - additionalPrinterColumns:
     - jsonPath: .spec.hostnames
       name: Hostnames
@@ -3474,7 +3122,7 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
-    name: v1beta1
+    name: v1alpha2
     schema:
       openAPIV3Schema:
         description: HTTPRoute provides a way to route HTTP requests. This includes
@@ -3593,8 +3241,8 @@ spec:
                       type: string
                     namespace:
                       description: "Namespace is the namespace of the referent. When
-                        unspecified (or empty string), this refers to the local namespace
-                        of the Route. \n Support: Core"
+                        unspecified, this refers to the local namespace of the Route.
+                        \n Support: Core"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -3913,7 +3561,9 @@ spec:
                                           description: Port specifies the destination
                                             port number to use for this resource.
                                             Port is required when the referent is
-                                            a Kubernetes Service. For other resources,
+                                            a Kubernetes Service. In this case, the
+                                            port number is the service port number,
+                                            not the target port. For other resources,
                                             destination port might be derived from
                                             the referent resource or this field.
                                           format: int32
@@ -4172,9 +3822,10 @@ spec:
                           port:
                             description: Port specifies the destination port number
                               to use for this resource. Port is required when the
-                              referent is a Kubernetes Service. For other resources,
-                              destination port might be derived from the referent
-                              resource or this field.
+                              referent is a Kubernetes Service. In this case, the
+                              port number is the service port number, not the target
+                              port. For other resources, destination port might be
+                              derived from the referent resource or this field.
                             format: int32
                             maximum: 65535
                             minimum: 1
@@ -4425,9 +4076,11 @@ spec:
                                   port:
                                     description: Port specifies the destination port
                                       number to use for this resource. Port is required
-                                      when the referent is a Kubernetes Service. For
-                                      other resources, destination port might be derived
-                                      from the referent resource or this field.
+                                      when the referent is a Kubernetes Service. In
+                                      this case, the port number is the service port
+                                      number, not the target port. For other resources,
+                                      destination port might be derived from the referent
+                                      resource or this field.
                                     format: int32
                                     maximum: 65535
                                     minimum: 1
@@ -4663,10 +4316,11 @@ spec:
                         Route based on creation timestamp. * The Route appearing first
                         in alphabetical order by   \"{namespace}/{name}\". \n If ties
                         still exist within the Route that has been given precedence,
-                        matching precedence MUST be granted to the first matching
-                        rule meeting the above criteria. \n When no rules matching
-                        a request have been successfully attached to the parent a
-                        request is coming from, a HTTP 404 status code MUST be returned."
+                        matching precedence MUST be granted to the FIRST matching
+                        rule (in list order) meeting the above criteria. \n When no
+                        rules matching a request have been successfully attached to
+                        the parent a request is coming from, a HTTP 404 status code
+                        MUST be returned."
                       items:
                         description: "HTTPRouteMatch defines the predicate used to
                           match requests to a given action. Multiple match types are
@@ -4791,7 +4445,17 @@ spec:
                                     param names, only the first entry with an equivalent
                                     name MUST be considered for a match. Subsequent
                                     entries with an equivalent query param name MUST
-                                    be ignored."
+                                    be ignored. \n If a query param is repeated in
+                                    an HTTP request, the behavior is purposely left
+                                    undefined, since different data planes have different
+                                    capabilities. However, it's *recommended* that
+                                    implementations should match against the first
+                                    value of the param if the data plane supports
+                                    it, as this behavior is expected in other load
+                                    balancing contexts outside of the Gateway API.
+                                    Users should not route traffic based on repeated
+                                    query params to guard themselves against potential
+                                    differences in the implementations."
                                   maxLength: 256
                                   minLength: 1
                                   type: string
@@ -4987,8 +4651,1621 @@ spec:
                           type: string
                         namespace:
                           description: "Namespace is the namespace of the referent.
-                            When unspecified (or empty string), this refers to the
-                            local namespace of the Route. \n Support: Core"
+                            When unspecified, this refers to the local namespace of
+                            the Route. \n Support: Core"
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        port:
+                          description: "Port is the network port this Route targets.
+                            It can be interpreted differently based on the type of
+                            parent resource. \n When the parent resource is a Gateway,
+                            this targets all listeners listening on the specified
+                            port that also support this kind of Route(and select this
+                            Route). It's not recommended to set `Port` unless the
+                            networking behaviors specified in a Route must apply to
+                            a specific port as opposed to a listener(s) whose port(s)
+                            may be changed. When both Port and SectionName are specified,
+                            the name and port of the selected listener must match
+                            both specified values. \n Implementations MAY choose to
+                            support other parent resources. Implementations supporting
+                            other types of parent resources MUST clearly document
+                            how/if Port is interpreted. \n For the purpose of status,
+                            an attachment is considered successful as long as the
+                            parent resource accepts it partially. For example, Gateway
+                            listeners can restrict which Routes can attach to them
+                            by Route kind, namespace, or hostname. If 1 of 2 Gateway
+                            listeners accept attachment from the referencing Route,
+                            the Route MUST be considered successfully attached. If
+                            no Gateway listeners accept attachment from this Route,
+                            the Route MUST be considered detached from the Gateway.
+                            \n Support: Extended \n <gateway:experimental>"
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        sectionName:
+                          description: "SectionName is the name of a section within
+                            the target resource. In the following resources, SectionName
+                            is interpreted as the following: \n * Gateway: Listener
+                            Name. When both Port (experimental) and SectionName are
+                            specified, the name and port of the selected listener
+                            must match both specified values. \n Implementations MAY
+                            choose to support attaching Routes to other resources.
+                            If that is the case, they MUST clearly document how SectionName
+                            is interpreted. \n When unspecified (empty string), this
+                            will reference the entire resource. For the purpose of
+                            status, an attachment is considered successful if at least
+                            one section in the parent resource accepts it. For example,
+                            Gateway listeners can restrict which Routes can attach
+                            to them by Route kind, namespace, or hostname. If 1 of
+                            2 Gateway listeners accept attachment from the referencing
+                            Route, the Route MUST be considered successfully attached.
+                            If no Gateway listeners accept attachment from this Route,
+                            the Route MUST be considered detached from the Gateway.
+                            \n Support: Core"
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - controllerName
+                  - parentRef
+                  type: object
+                maxItems: 32
+                type: array
+            required:
+            - parents
+            type: object
+        required:
+        - spec
+        type: object
+    served: false
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.hostnames
+      name: Hostnames
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: HTTPRoute provides a way to route HTTP requests. This includes
+          the capability to match requests by hostname, path, header, or query param.
+          Filters can be used to specify additional processing steps. Backends specify
+          where matching requests should be routed.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of HTTPRoute.
+            properties:
+              hostnames:
+                description: "Hostnames defines a set of hostname that should match
+                  against the HTTP Host header to select a HTTPRoute to process the
+                  request. This matches the RFC 1123 definition of a hostname with
+                  2 notable exceptions: \n 1. IPs are not allowed. 2. A hostname may
+                  be prefixed with a wildcard label (`*.`). The wildcard    label
+                  must appear by itself as the first label. \n If a hostname is specified
+                  by both the Listener and HTTPRoute, there must be at least one intersecting
+                  hostname for the HTTPRoute to be attached to the Listener. For example:
+                  \n * A Listener with `test.example.com` as the hostname matches
+                  HTTPRoutes   that have either not specified any hostnames, or have
+                  specified at   least one of `test.example.com` or `*.example.com`.
+                  * A Listener with `*.example.com` as the hostname matches HTTPRoutes
+                  \  that have either not specified any hostnames or have specified
+                  at least   one hostname that matches the Listener hostname. For
+                  example,   `*.example.com`, `test.example.com`, and `foo.test.example.com`
+                  would   all match. On the other hand, `example.com` and `test.example.net`
+                  would   not match. \n Hostnames that are prefixed with a wildcard
+                  label (`*.`) are interpreted as a suffix match. That means that
+                  a match for `*.example.com` would match both `test.example.com`,
+                  and `foo.test.example.com`, but not `example.com`. \n If both the
+                  Listener and HTTPRoute have specified hostnames, any HTTPRoute hostnames
+                  that do not match the Listener hostname MUST be ignored. For example,
+                  if a Listener specified `*.example.com`, and the HTTPRoute specified
+                  `test.example.com` and `test.example.net`, `test.example.net` must
+                  not be considered for a match. \n If both the Listener and HTTPRoute
+                  have specified hostnames, and none match with the criteria above,
+                  then the HTTPRoute is not accepted. The implementation must raise
+                  an 'Accepted' Condition with a status of `False` in the corresponding
+                  RouteParentStatus. \n Support: Core"
+                items:
+                  description: "Hostname is the fully qualified domain name of a network
+                    host. This matches the RFC 1123 definition of a hostname with
+                    2 notable exceptions: \n 1. IPs are not allowed. 2. A hostname
+                    may be prefixed with a wildcard label (`*.`). The wildcard    label
+                    must appear by itself as the first label. \n Hostname can be \"precise\"
+                    which is a domain name without the terminating dot of a network
+                    host (e.g. \"foo.example.com\") or \"wildcard\", which is a domain
+                    name prefixed with a single wildcard label (e.g. `*.example.com`).
+                    \n Note that as per RFC1035 and RFC1123, a *label* must consist
+                    of lower case alphanumeric characters or '-', and must start and
+                    end with an alphanumeric character. No other punctuation is allowed."
+                  maxLength: 253
+                  minLength: 1
+                  pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                  type: string
+                maxItems: 16
+                type: array
+              parentRefs:
+                description: "ParentRefs references the resources (usually Gateways)
+                  that a Route wants to be attached to. Note that the referenced parent
+                  resource needs to allow this for the attachment to be complete.
+                  For Gateways, that means the Gateway needs to allow attachment from
+                  Routes of this kind and namespace. \n The only kind of parent resource
+                  with \"Core\" support is Gateway. This API may be extended in the
+                  future to support additional kinds of parent resources such as one
+                  of the route kinds. \n It is invalid to reference an identical parent
+                  more than once. It is valid to reference multiple distinct sections
+                  within the same parent resource, such as 2 Listeners within a Gateway.
+                  \n It is possible to separately reference multiple distinct objects
+                  that may be collapsed by an implementation. For example, some implementations
+                  may choose to merge compatible Gateway Listeners together. If that
+                  is the case, the list of routes attached to those resources should
+                  also be merged."
+                items:
+                  description: "ParentReference identifies an API object (usually
+                    a Gateway) that can be considered a parent of this resource (usually
+                    a route). The only kind of parent resource with \"Core\" support
+                    is Gateway. This API may be extended in the future to support
+                    additional kinds of parent resources, such as HTTPRoute. \n The
+                    API object must be valid in the cluster; the Group and Kind must
+                    be registered in the cluster for this reference to be valid."
+                  properties:
+                    group:
+                      default: gateway.networking.k8s.io
+                      description: "Group is the group of the referent. \n Support:
+                        Core"
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      default: Gateway
+                      description: "Kind is kind of the referent. \n Support: Core
+                        (Gateway) \n Support: Custom (Other Resources)"
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: "Name is the name of the referent. \n Support:
+                        Core"
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: "Namespace is the namespace of the referent. When
+                        unspecified, this refers to the local namespace of the Route.
+                        \n Support: Core"
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                    port:
+                      description: "Port is the network port this Route targets. It
+                        can be interpreted differently based on the type of parent
+                        resource. \n When the parent resource is a Gateway, this targets
+                        all listeners listening on the specified port that also support
+                        this kind of Route(and select this Route). It's not recommended
+                        to set `Port` unless the networking behaviors specified in
+                        a Route must apply to a specific port as opposed to a listener(s)
+                        whose port(s) may be changed. When both Port and SectionName
+                        are specified, the name and port of the selected listener
+                        must match both specified values. \n Implementations MAY choose
+                        to support other parent resources. Implementations supporting
+                        other types of parent resources MUST clearly document how/if
+                        Port is interpreted. \n For the purpose of status, an attachment
+                        is considered successful as long as the parent resource accepts
+                        it partially. For example, Gateway listeners can restrict
+                        which Routes can attach to them by Route kind, namespace,
+                        or hostname. If 1 of 2 Gateway listeners accept attachment
+                        from the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this
+                        Route, the Route MUST be considered detached from the Gateway.
+                        \n Support: Extended \n <gateway:experimental>"
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    sectionName:
+                      description: "SectionName is the name of a section within the
+                        target resource. In the following resources, SectionName is
+                        interpreted as the following: \n * Gateway: Listener Name.
+                        When both Port (experimental) and SectionName are specified,
+                        the name and port of the selected listener must match both
+                        specified values. \n Implementations MAY choose to support
+                        attaching Routes to other resources. If that is the case,
+                        they MUST clearly document how SectionName is interpreted.
+                        \n When unspecified (empty string), this will reference the
+                        entire resource. For the purpose of status, an attachment
+                        is considered successful if at least one section in the parent
+                        resource accepts it. For example, Gateway listeners can restrict
+                        which Routes can attach to them by Route kind, namespace,
+                        or hostname. If 1 of 2 Gateway listeners accept attachment
+                        from the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this
+                        Route, the Route MUST be considered detached from the Gateway.
+                        \n Support: Core"
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 32
+                type: array
+              rules:
+                default:
+                - matches:
+                  - path:
+                      type: PathPrefix
+                      value: /
+                description: Rules are a list of HTTP matchers, filters and actions.
+                items:
+                  description: HTTPRouteRule defines semantics for matching an HTTP
+                    request based on conditions (matches), processing it (filters),
+                    and forwarding the request to an API object (backendRefs).
+                  properties:
+                    backendRefs:
+                      description: "BackendRefs defines the backend(s) where matching
+                        requests should be sent. \n Failure behavior here depends
+                        on how many BackendRefs are specified and how many are invalid.
+                        \n If *all* entries in BackendRefs are invalid, and there
+                        are also no filters specified in this route rule, *all* traffic
+                        which matches this rule MUST receive a 500 status code. \n
+                        See the HTTPBackendRef definition for the rules about what
+                        makes a single HTTPBackendRef invalid. \n When a HTTPBackendRef
+                        is invalid, 500 status codes MUST be returned for requests
+                        that would have otherwise been routed to an invalid backend.
+                        If multiple backends are specified, and some are invalid,
+                        the proportion of requests that would otherwise have been
+                        routed to an invalid backend MUST receive a 500 status code.
+                        \n For example, if two backends are specified with equal weights,
+                        and one is invalid, 50 percent of traffic must receive a 500.
+                        Implementations may choose how that 50 percent is determined.
+                        \n Support: Core for Kubernetes Service \n Support: Custom
+                        for any other resource \n Support for weight: Core"
+                      items:
+                        description: HTTPBackendRef defines how a HTTPRoute should
+                          forward an HTTP request.
+                        properties:
+                          filters:
+                            description: "Filters defined at this level should be
+                              executed if and only if the request is being forwarded
+                              to the backend defined here. \n Support: Custom (For
+                              broader support of filters, use the Filters field in
+                              HTTPRouteRule.)"
+                            items:
+                              description: HTTPRouteFilter defines processing steps
+                                that must be completed during the request or response
+                                lifecycle. HTTPRouteFilters are meant as an extension
+                                point to express processing that may be done in Gateway
+                                implementations. Some examples include request or
+                                response modification, implementing authentication
+                                strategies, rate-limiting, and traffic shaping. API
+                                guarantee/conformance is defined based on the type
+                                of the filter.
+                              properties:
+                                extensionRef:
+                                  description: "ExtensionRef is an optional, implementation-specific
+                                    extension to the \"filter\" behavior.  For example,
+                                    resource \"myroutefilter\" in group \"networking.example.net\").
+                                    ExtensionRef MUST NOT be used for core and extended
+                                    filters. \n Support: Implementation-specific"
+                                  properties:
+                                    group:
+                                      description: Group is the group of the referent.
+                                        For example, "networking.k8s.io". When unspecified
+                                        (empty string), core API group is inferred.
+                                      maxLength: 253
+                                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    kind:
+                                      description: Kind is kind of the referent. For
+                                        example "HTTPRoute" or "Service".
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                      type: string
+                                    name:
+                                      description: Name is the name of the referent.
+                                      maxLength: 253
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - group
+                                  - kind
+                                  - name
+                                  type: object
+                                requestHeaderModifier:
+                                  description: "RequestHeaderModifier defines a schema
+                                    for a filter that modifies request headers. \n
+                                    Support: Core"
+                                  properties:
+                                    add:
+                                      description: "Add adds the given header(s) (name,
+                                        value) to the request before the action. It
+                                        appends to any existing values associated
+                                        with the header name. \n Input:   GET /foo
+                                        HTTP/1.1   my-header: foo \n Config:   add:
+                                        \  - name: \"my-header\"     value: \"bar\"
+                                        \n Output:   GET /foo HTTP/1.1   my-header:
+                                        foo   my-header: bar"
+                                      items:
+                                        description: HTTPHeader represents an HTTP
+                                          Header name and value as defined by RFC
+                                          7230.
+                                        properties:
+                                          name:
+                                            description: "Name is the name of the
+                                              HTTP Header to be matched. Name matching
+                                              MUST be case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                              \n If multiple entries specify equivalent
+                                              header names, the first entry with an
+                                              equivalent name MUST be considered for
+                                              a match. Subsequent entries with an
+                                              equivalent header name MUST be ignored.
+                                              Due to the case-insensitivity of header
+                                              names, \"foo\" and \"Foo\" are considered
+                                              equivalent."
+                                            maxLength: 256
+                                            minLength: 1
+                                            pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                            type: string
+                                          value:
+                                            description: Value is the value of HTTP
+                                              Header to be matched.
+                                            maxLength: 4096
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    remove:
+                                      description: "Remove the given header(s) from
+                                        the HTTP request before the action. The value
+                                        of Remove is a list of HTTP header names.
+                                        Note that the header names are case-insensitive
+                                        (see https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
+                                        \n Input:   GET /foo HTTP/1.1   my-header1:
+                                        foo   my-header2: bar   my-header3: baz \n
+                                        Config:   remove: [\"my-header1\", \"my-header3\"]
+                                        \n Output:   GET /foo HTTP/1.1   my-header2:
+                                        bar"
+                                      items:
+                                        type: string
+                                      maxItems: 16
+                                      type: array
+                                    set:
+                                      description: "Set overwrites the request with
+                                        the given header (name, value) before the
+                                        action. \n Input:   GET /foo HTTP/1.1   my-header:
+                                        foo \n Config:   set:   - name: \"my-header\"
+                                        \    value: \"bar\" \n Output:   GET /foo
+                                        HTTP/1.1   my-header: bar"
+                                      items:
+                                        description: HTTPHeader represents an HTTP
+                                          Header name and value as defined by RFC
+                                          7230.
+                                        properties:
+                                          name:
+                                            description: "Name is the name of the
+                                              HTTP Header to be matched. Name matching
+                                              MUST be case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                              \n If multiple entries specify equivalent
+                                              header names, the first entry with an
+                                              equivalent name MUST be considered for
+                                              a match. Subsequent entries with an
+                                              equivalent header name MUST be ignored.
+                                              Due to the case-insensitivity of header
+                                              names, \"foo\" and \"Foo\" are considered
+                                              equivalent."
+                                            maxLength: 256
+                                            minLength: 1
+                                            pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                            type: string
+                                          value:
+                                            description: Value is the value of HTTP
+                                              Header to be matched.
+                                            maxLength: 4096
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                  type: object
+                                requestMirror:
+                                  description: "RequestMirror defines a schema for
+                                    a filter that mirrors requests. Requests are sent
+                                    to the specified destination, but responses from
+                                    that destination are ignored. \n Support: Extended"
+                                  properties:
+                                    backendRef:
+                                      description: "BackendRef references a resource
+                                        where mirrored requests are sent. \n If the
+                                        referent cannot be found, this BackendRef
+                                        is invalid and must be dropped from the Gateway.
+                                        The controller must ensure the \"ResolvedRefs\"
+                                        condition on the Route status is set to `status:
+                                        False` and not configure this backend in the
+                                        underlying implementation. \n If there is
+                                        a cross-namespace reference to an *existing*
+                                        object that is not allowed by a ReferenceGrant,
+                                        the controller must ensure the \"ResolvedRefs\"
+                                        \ condition on the Route is set to `status:
+                                        False`, with the \"RefNotPermitted\" reason
+                                        and not configure this backend in the underlying
+                                        implementation. \n In either error case, the
+                                        Message of the `ResolvedRefs` Condition should
+                                        be used to provide more detail about the problem.
+                                        \n Support: Extended for Kubernetes Service
+                                        \n Support: Custom for any other resource"
+                                      properties:
+                                        group:
+                                          default: ""
+                                          description: Group is the group of the referent.
+                                            For example, "networking.k8s.io". When
+                                            unspecified (empty string), core API group
+                                            is inferred.
+                                          maxLength: 253
+                                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        kind:
+                                          default: Service
+                                          description: Kind is kind of the referent.
+                                            For example "HTTPRoute" or "Service".
+                                            Defaults to "Service" when not specified.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                          type: string
+                                        name:
+                                          description: Name is the name of the referent.
+                                          maxLength: 253
+                                          minLength: 1
+                                          type: string
+                                        namespace:
+                                          description: "Namespace is the namespace
+                                            of the backend. When unspecified, the
+                                            local namespace is inferred. \n Note that
+                                            when a namespace is specified, a ReferenceGrant
+                                            object is required in the referent namespace
+                                            to allow that namespace's owner to accept
+                                            the reference. See the ReferenceGrant
+                                            documentation for details. \n Support:
+                                            Core"
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                        port:
+                                          description: Port specifies the destination
+                                            port number to use for this resource.
+                                            Port is required when the referent is
+                                            a Kubernetes Service. In this case, the
+                                            port number is the service port number,
+                                            not the target port. For other resources,
+                                            destination port might be derived from
+                                            the referent resource or this field.
+                                          format: int32
+                                          maximum: 65535
+                                          minimum: 1
+                                          type: integer
+                                      required:
+                                      - name
+                                      type: object
+                                  required:
+                                  - backendRef
+                                  type: object
+                                requestRedirect:
+                                  description: "RequestRedirect defines a schema for
+                                    a filter that responds to the request with an
+                                    HTTP redirection. \n Support: Core"
+                                  properties:
+                                    hostname:
+                                      description: "Hostname is the hostname to be
+                                        used in the value of the `Location` header
+                                        in the response. When empty, the hostname
+                                        of the request is used. \n Support: Core"
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    path:
+                                      description: "Path defines parameters used to
+                                        modify the path of the incoming request. The
+                                        modified path is then used to construct the
+                                        `Location` header. When empty, the request
+                                        path is used as-is. \n Support: Extended \n
+                                        <gateway:experimental>"
+                                      properties:
+                                        replaceFullPath:
+                                          description: "ReplaceFullPath specifies
+                                            the value with which to replace the full
+                                            path of a request during a rewrite or
+                                            redirect. \n <gateway:experimental>"
+                                          maxLength: 1024
+                                          type: string
+                                        replacePrefixMatch:
+                                          description: "ReplacePrefixMatch specifies
+                                            the value with which to replace the prefix
+                                            match of a request during a rewrite or
+                                            redirect. For example, a request to \"/foo/bar\"
+                                            with a prefix match of \"/foo\" would
+                                            be modified to \"/bar\". \n Note that
+                                            this matches the behavior of the PathPrefix
+                                            match type. This matches full path elements.
+                                            A path element refers to the list of labels
+                                            in the path split by the `/` separator.
+                                            When specified, a trailing `/` is ignored.
+                                            For example, the paths `/abc`, `/abc/`,
+                                            and `/abc/def` would all match the prefix
+                                            `/abc`, but the path `/abcd` would not.
+                                            \n <gateway:experimental>"
+                                          maxLength: 1024
+                                          type: string
+                                        type:
+                                          description: "Type defines the type of path
+                                            modifier. Additional types may be added
+                                            in a future release of the API. \n Note
+                                            that values may be added to this enum,
+                                            implementations must ensure that unknown
+                                            values will not cause a crash. \n Unknown
+                                            values here must result in the implementation
+                                            setting the Attached Condition for the
+                                            Route to `status: False`, with a Reason
+                                            of `UnsupportedValue`. \n <gateway:experimental>"
+                                          enum:
+                                          - ReplaceFullPath
+                                          - ReplacePrefixMatch
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                    port:
+                                      description: "Port is the port to be used in
+                                        the value of the `Location` header in the
+                                        response. When empty, port (if specified)
+                                        of the request is used. \n Support: Extended"
+                                      format: int32
+                                      maximum: 65535
+                                      minimum: 1
+                                      type: integer
+                                    scheme:
+                                      description: "Scheme is the scheme to be used
+                                        in the value of the `Location` header in the
+                                        response. When empty, the scheme of the request
+                                        is used. \n Support: Extended \n Note that
+                                        values may be added to this enum, implementations
+                                        must ensure that unknown values will not cause
+                                        a crash. \n Unknown values here must result
+                                        in the implementation setting the Attached
+                                        Condition for the Route to `status: False`,
+                                        with a Reason of `UnsupportedValue`."
+                                      enum:
+                                      - http
+                                      - https
+                                      type: string
+                                    statusCode:
+                                      default: 302
+                                      description: "StatusCode is the HTTP status
+                                        code to be used in response. \n Support: Core
+                                        \n Note that values may be added to this enum,
+                                        implementations must ensure that unknown values
+                                        will not cause a crash. \n Unknown values
+                                        here must result in the implementation setting
+                                        the Attached Condition for the Route to `status:
+                                        False`, with a Reason of `UnsupportedValue`."
+                                      enum:
+                                      - 301
+                                      - 302
+                                      type: integer
+                                  type: object
+                                type:
+                                  description: "Type identifies the type of filter
+                                    to apply. As with other API fields, types are
+                                    classified into three conformance levels: \n -
+                                    Core: Filter types and their corresponding configuration
+                                    defined by   \"Support: Core\" in this package,
+                                    e.g. \"RequestHeaderModifier\". All   implementations
+                                    must support core filters. \n - Extended: Filter
+                                    types and their corresponding configuration defined
+                                    by   \"Support: Extended\" in this package, e.g.
+                                    \"RequestMirror\". Implementers   are encouraged
+                                    to support extended filters. \n - Custom: Filters
+                                    that are defined and supported by specific vendors.
+                                    \  In the future, filters showing convergence
+                                    in behavior across multiple   implementations
+                                    will be considered for inclusion in extended or
+                                    core   conformance levels. Filter-specific configuration
+                                    for such filters   is specified using the ExtensionRef
+                                    field. `Type` should be set to   \"ExtensionRef\"
+                                    for custom filters. \n Implementers are encouraged
+                                    to define custom implementation types to extend
+                                    the core API with implementation-specific behavior.
+                                    \n If a reference to a custom filter type cannot
+                                    be resolved, the filter MUST NOT be skipped. Instead,
+                                    requests that would have been processed by that
+                                    filter MUST receive a HTTP error response. \n
+                                    Note that values may be added to this enum, implementations
+                                    must ensure that unknown values will not cause
+                                    a crash. \n Unknown values here must result in
+                                    the implementation setting the Attached Condition
+                                    for the Route to `status: False`, with a Reason
+                                    of `UnsupportedValue`. \n "
+                                  enum:
+                                  - RequestHeaderModifier
+                                  - RequestMirror
+                                  - RequestRedirect
+                                  - URLRewrite
+                                  - ExtensionRef
+                                  type: string
+                                urlRewrite:
+                                  description: "URLRewrite defines a schema for a
+                                    filter that modifies a request during forwarding.
+                                    \n Support: Extended \n <gateway:experimental>"
+                                  properties:
+                                    hostname:
+                                      description: "Hostname is the value to be used
+                                        to replace the Host header value during forwarding.
+                                        \n Support: Extended \n <gateway:experimental>"
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    path:
+                                      description: "Path defines a path rewrite. \n
+                                        Support: Extended \n <gateway:experimental>"
+                                      properties:
+                                        replaceFullPath:
+                                          description: "ReplaceFullPath specifies
+                                            the value with which to replace the full
+                                            path of a request during a rewrite or
+                                            redirect. \n <gateway:experimental>"
+                                          maxLength: 1024
+                                          type: string
+                                        replacePrefixMatch:
+                                          description: "ReplacePrefixMatch specifies
+                                            the value with which to replace the prefix
+                                            match of a request during a rewrite or
+                                            redirect. For example, a request to \"/foo/bar\"
+                                            with a prefix match of \"/foo\" would
+                                            be modified to \"/bar\". \n Note that
+                                            this matches the behavior of the PathPrefix
+                                            match type. This matches full path elements.
+                                            A path element refers to the list of labels
+                                            in the path split by the `/` separator.
+                                            When specified, a trailing `/` is ignored.
+                                            For example, the paths `/abc`, `/abc/`,
+                                            and `/abc/def` would all match the prefix
+                                            `/abc`, but the path `/abcd` would not.
+                                            \n <gateway:experimental>"
+                                          maxLength: 1024
+                                          type: string
+                                        type:
+                                          description: "Type defines the type of path
+                                            modifier. Additional types may be added
+                                            in a future release of the API. \n Note
+                                            that values may be added to this enum,
+                                            implementations must ensure that unknown
+                                            values will not cause a crash. \n Unknown
+                                            values here must result in the implementation
+                                            setting the Attached Condition for the
+                                            Route to `status: False`, with a Reason
+                                            of `UnsupportedValue`. \n <gateway:experimental>"
+                                          enum:
+                                          - ReplaceFullPath
+                                          - ReplacePrefixMatch
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                  type: object
+                              required:
+                              - type
+                              type: object
+                            maxItems: 16
+                            type: array
+                          group:
+                            default: ""
+                            description: Group is the group of the referent. For example,
+                              "networking.k8s.io". When unspecified (empty string),
+                              core API group is inferred.
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            default: Service
+                            description: Kind is kind of the referent. For example
+                              "HTTPRoute" or "Service". Defaults to "Service" when
+                              not specified.
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                          name:
+                            description: Name is the name of the referent.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: "Namespace is the namespace of the backend.
+                              When unspecified, the local namespace is inferred. \n
+                              Note that when a namespace is specified, a ReferenceGrant
+                              object is required in the referent namespace to allow
+                              that namespace's owner to accept the reference. See
+                              the ReferenceGrant documentation for details. \n Support:
+                              Core"
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          port:
+                            description: Port specifies the destination port number
+                              to use for this resource. Port is required when the
+                              referent is a Kubernetes Service. In this case, the
+                              port number is the service port number, not the target
+                              port. For other resources, destination port might be
+                              derived from the referent resource or this field.
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          weight:
+                            default: 1
+                            description: "Weight specifies the proportion of requests
+                              forwarded to the referenced backend. This is computed
+                              as weight/(sum of all weights in this BackendRefs list).
+                              For non-zero values, there may be some epsilon from
+                              the exact proportion defined here depending on the precision
+                              an implementation supports. Weight is not a percentage
+                              and the sum of weights does not need to equal 100. \n
+                              If only one backend is specified and it has a weight
+                              greater than 0, 100% of the traffic is forwarded to
+                              that backend. If weight is set to 0, no traffic should
+                              be forwarded for this entry. If unspecified, weight
+                              defaults to 1. \n Support for this field varies based
+                              on the context where used."
+                            format: int32
+                            maximum: 1000000
+                            minimum: 0
+                            type: integer
+                        required:
+                        - name
+                        type: object
+                      maxItems: 16
+                      type: array
+                    filters:
+                      description: "Filters define the filters that are applied to
+                        requests that match this rule. \n The effects of ordering
+                        of multiple behaviors are currently unspecified. This can
+                        change in the future based on feedback during the alpha stage.
+                        \n Conformance-levels at this level are defined based on the
+                        type of filter: \n - ALL core filters MUST be supported by
+                        all implementations. - Implementers are encouraged to support
+                        extended filters. - Implementation-specific custom filters
+                        have no API guarantees across   implementations. \n Specifying
+                        a core filter multiple times has unspecified or custom conformance.
+                        \n All filters are expected to be compatible with each other
+                        except for the URLRewrite and RequestRedirect filters, which
+                        may not be combined. If an implementation can not support
+                        other combinations of filters, they must clearly document
+                        that limitation. In all cases where incompatible or unsupported
+                        filters are specified, implementations MUST add a warning
+                        condition to status. \n Support: Core"
+                      items:
+                        description: HTTPRouteFilter defines processing steps that
+                          must be completed during the request or response lifecycle.
+                          HTTPRouteFilters are meant as an extension point to express
+                          processing that may be done in Gateway implementations.
+                          Some examples include request or response modification,
+                          implementing authentication strategies, rate-limiting, and
+                          traffic shaping. API guarantee/conformance is defined based
+                          on the type of the filter.
+                        properties:
+                          extensionRef:
+                            description: "ExtensionRef is an optional, implementation-specific
+                              extension to the \"filter\" behavior.  For example,
+                              resource \"myroutefilter\" in group \"networking.example.net\").
+                              ExtensionRef MUST NOT be used for core and extended
+                              filters. \n Support: Implementation-specific"
+                            properties:
+                              group:
+                                description: Group is the group of the referent. For
+                                  example, "networking.k8s.io". When unspecified (empty
+                                  string), core API group is inferred.
+                                maxLength: 253
+                                pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                              kind:
+                                description: Kind is kind of the referent. For example
+                                  "HTTPRoute" or "Service".
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                type: string
+                              name:
+                                description: Name is the name of the referent.
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                            required:
+                            - group
+                            - kind
+                            - name
+                            type: object
+                          requestHeaderModifier:
+                            description: "RequestHeaderModifier defines a schema for
+                              a filter that modifies request headers. \n Support:
+                              Core"
+                            properties:
+                              add:
+                                description: "Add adds the given header(s) (name,
+                                  value) to the request before the action. It appends
+                                  to any existing values associated with the header
+                                  name. \n Input:   GET /foo HTTP/1.1   my-header:
+                                  foo \n Config:   add:   - name: \"my-header\"     value:
+                                  \"bar\" \n Output:   GET /foo HTTP/1.1   my-header:
+                                  foo   my-header: bar"
+                                items:
+                                  description: HTTPHeader represents an HTTP Header
+                                    name and value as defined by RFC 7230.
+                                  properties:
+                                    name:
+                                      description: "Name is the name of the HTTP Header
+                                        to be matched. Name matching MUST be case
+                                        insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                        \n If multiple entries specify equivalent
+                                        header names, the first entry with an equivalent
+                                        name MUST be considered for a match. Subsequent
+                                        entries with an equivalent header name MUST
+                                        be ignored. Due to the case-insensitivity
+                                        of header names, \"foo\" and \"Foo\" are considered
+                                        equivalent."
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    value:
+                                      description: Value is the value of HTTP Header
+                                        to be matched.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              remove:
+                                description: "Remove the given header(s) from the
+                                  HTTP request before the action. The value of Remove
+                                  is a list of HTTP header names. Note that the header
+                                  names are case-insensitive (see https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
+                                  \n Input:   GET /foo HTTP/1.1   my-header1: foo
+                                  \  my-header2: bar   my-header3: baz \n Config:
+                                  \  remove: [\"my-header1\", \"my-header3\"] \n Output:
+                                  \  GET /foo HTTP/1.1   my-header2: bar"
+                                items:
+                                  type: string
+                                maxItems: 16
+                                type: array
+                              set:
+                                description: "Set overwrites the request with the
+                                  given header (name, value) before the action. \n
+                                  Input:   GET /foo HTTP/1.1   my-header: foo \n Config:
+                                  \  set:   - name: \"my-header\"     value: \"bar\"
+                                  \n Output:   GET /foo HTTP/1.1   my-header: bar"
+                                items:
+                                  description: HTTPHeader represents an HTTP Header
+                                    name and value as defined by RFC 7230.
+                                  properties:
+                                    name:
+                                      description: "Name is the name of the HTTP Header
+                                        to be matched. Name matching MUST be case
+                                        insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                        \n If multiple entries specify equivalent
+                                        header names, the first entry with an equivalent
+                                        name MUST be considered for a match. Subsequent
+                                        entries with an equivalent header name MUST
+                                        be ignored. Due to the case-insensitivity
+                                        of header names, \"foo\" and \"Foo\" are considered
+                                        equivalent."
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    value:
+                                      description: Value is the value of HTTP Header
+                                        to be matched.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                            type: object
+                          requestMirror:
+                            description: "RequestMirror defines a schema for a filter
+                              that mirrors requests. Requests are sent to the specified
+                              destination, but responses from that destination are
+                              ignored. \n Support: Extended"
+                            properties:
+                              backendRef:
+                                description: "BackendRef references a resource where
+                                  mirrored requests are sent. \n If the referent cannot
+                                  be found, this BackendRef is invalid and must be
+                                  dropped from the Gateway. The controller must ensure
+                                  the \"ResolvedRefs\" condition on the Route status
+                                  is set to `status: False` and not configure this
+                                  backend in the underlying implementation. \n If
+                                  there is a cross-namespace reference to an *existing*
+                                  object that is not allowed by a ReferenceGrant,
+                                  the controller must ensure the \"ResolvedRefs\"
+                                  \ condition on the Route is set to `status: False`,
+                                  with the \"RefNotPermitted\" reason and not configure
+                                  this backend in the underlying implementation. \n
+                                  In either error case, the Message of the `ResolvedRefs`
+                                  Condition should be used to provide more detail
+                                  about the problem. \n Support: Extended for Kubernetes
+                                  Service \n Support: Custom for any other resource"
+                                properties:
+                                  group:
+                                    default: ""
+                                    description: Group is the group of the referent.
+                                      For example, "networking.k8s.io". When unspecified
+                                      (empty string), core API group is inferred.
+                                    maxLength: 253
+                                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                    type: string
+                                  kind:
+                                    default: Service
+                                    description: Kind is kind of the referent. For
+                                      example "HTTPRoute" or "Service". Defaults to
+                                      "Service" when not specified.
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                    type: string
+                                  name:
+                                    description: Name is the name of the referent.
+                                    maxLength: 253
+                                    minLength: 1
+                                    type: string
+                                  namespace:
+                                    description: "Namespace is the namespace of the
+                                      backend. When unspecified, the local namespace
+                                      is inferred. \n Note that when a namespace is
+                                      specified, a ReferenceGrant object is required
+                                      in the referent namespace to allow that namespace's
+                                      owner to accept the reference. See the ReferenceGrant
+                                      documentation for details. \n Support: Core"
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                    type: string
+                                  port:
+                                    description: Port specifies the destination port
+                                      number to use for this resource. Port is required
+                                      when the referent is a Kubernetes Service. In
+                                      this case, the port number is the service port
+                                      number, not the target port. For other resources,
+                                      destination port might be derived from the referent
+                                      resource or this field.
+                                    format: int32
+                                    maximum: 65535
+                                    minimum: 1
+                                    type: integer
+                                required:
+                                - name
+                                type: object
+                            required:
+                            - backendRef
+                            type: object
+                          requestRedirect:
+                            description: "RequestRedirect defines a schema for a filter
+                              that responds to the request with an HTTP redirection.
+                              \n Support: Core"
+                            properties:
+                              hostname:
+                                description: "Hostname is the hostname to be used
+                                  in the value of the `Location` header in the response.
+                                  When empty, the hostname of the request is used.
+                                  \n Support: Core"
+                                maxLength: 253
+                                minLength: 1
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                              path:
+                                description: "Path defines parameters used to modify
+                                  the path of the incoming request. The modified path
+                                  is then used to construct the `Location` header.
+                                  When empty, the request path is used as-is. \n Support:
+                                  Extended \n <gateway:experimental>"
+                                properties:
+                                  replaceFullPath:
+                                    description: "ReplaceFullPath specifies the value
+                                      with which to replace the full path of a request
+                                      during a rewrite or redirect. \n <gateway:experimental>"
+                                    maxLength: 1024
+                                    type: string
+                                  replacePrefixMatch:
+                                    description: "ReplacePrefixMatch specifies the
+                                      value with which to replace the prefix match
+                                      of a request during a rewrite or redirect. For
+                                      example, a request to \"/foo/bar\" with a prefix
+                                      match of \"/foo\" would be modified to \"/bar\".
+                                      \n Note that this matches the behavior of the
+                                      PathPrefix match type. This matches full path
+                                      elements. A path element refers to the list
+                                      of labels in the path split by the `/` separator.
+                                      When specified, a trailing `/` is ignored. For
+                                      example, the paths `/abc`, `/abc/`, and `/abc/def`
+                                      would all match the prefix `/abc`, but the path
+                                      `/abcd` would not. \n <gateway:experimental>"
+                                    maxLength: 1024
+                                    type: string
+                                  type:
+                                    description: "Type defines the type of path modifier.
+                                      Additional types may be added in a future release
+                                      of the API. \n Note that values may be added
+                                      to this enum, implementations must ensure that
+                                      unknown values will not cause a crash. \n Unknown
+                                      values here must result in the implementation
+                                      setting the Attached Condition for the Route
+                                      to `status: False`, with a Reason of `UnsupportedValue`.
+                                      \n <gateway:experimental>"
+                                    enum:
+                                    - ReplaceFullPath
+                                    - ReplacePrefixMatch
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                              port:
+                                description: "Port is the port to be used in the value
+                                  of the `Location` header in the response. When empty,
+                                  port (if specified) of the request is used. \n Support:
+                                  Extended"
+                                format: int32
+                                maximum: 65535
+                                minimum: 1
+                                type: integer
+                              scheme:
+                                description: "Scheme is the scheme to be used in the
+                                  value of the `Location` header in the response.
+                                  When empty, the scheme of the request is used. \n
+                                  Support: Extended \n Note that values may be added
+                                  to this enum, implementations must ensure that unknown
+                                  values will not cause a crash. \n Unknown values
+                                  here must result in the implementation setting the
+                                  Attached Condition for the Route to `status: False`,
+                                  with a Reason of `UnsupportedValue`."
+                                enum:
+                                - http
+                                - https
+                                type: string
+                              statusCode:
+                                default: 302
+                                description: "StatusCode is the HTTP status code to
+                                  be used in response. \n Support: Core \n Note that
+                                  values may be added to this enum, implementations
+                                  must ensure that unknown values will not cause a
+                                  crash. \n Unknown values here must result in the
+                                  implementation setting the Attached Condition for
+                                  the Route to `status: False`, with a Reason of `UnsupportedValue`."
+                                enum:
+                                - 301
+                                - 302
+                                type: integer
+                            type: object
+                          type:
+                            description: "Type identifies the type of filter to apply.
+                              As with other API fields, types are classified into
+                              three conformance levels: \n - Core: Filter types and
+                              their corresponding configuration defined by   \"Support:
+                              Core\" in this package, e.g. \"RequestHeaderModifier\".
+                              All   implementations must support core filters. \n
+                              - Extended: Filter types and their corresponding configuration
+                              defined by   \"Support: Extended\" in this package,
+                              e.g. \"RequestMirror\". Implementers   are encouraged
+                              to support extended filters. \n - Custom: Filters that
+                              are defined and supported by specific vendors.   In
+                              the future, filters showing convergence in behavior
+                              across multiple   implementations will be considered
+                              for inclusion in extended or core   conformance levels.
+                              Filter-specific configuration for such filters   is
+                              specified using the ExtensionRef field. `Type` should
+                              be set to   \"ExtensionRef\" for custom filters. \n
+                              Implementers are encouraged to define custom implementation
+                              types to extend the core API with implementation-specific
+                              behavior. \n If a reference to a custom filter type
+                              cannot be resolved, the filter MUST NOT be skipped.
+                              Instead, requests that would have been processed by
+                              that filter MUST receive a HTTP error response. \n Note
+                              that values may be added to this enum, implementations
+                              must ensure that unknown values will not cause a crash.
+                              \n Unknown values here must result in the implementation
+                              setting the Attached Condition for the Route to `status:
+                              False`, with a Reason of `UnsupportedValue`. \n "
+                            enum:
+                            - RequestHeaderModifier
+                            - RequestMirror
+                            - RequestRedirect
+                            - URLRewrite
+                            - ExtensionRef
+                            type: string
+                          urlRewrite:
+                            description: "URLRewrite defines a schema for a filter
+                              that modifies a request during forwarding. \n Support:
+                              Extended \n <gateway:experimental>"
+                            properties:
+                              hostname:
+                                description: "Hostname is the value to be used to
+                                  replace the Host header value during forwarding.
+                                  \n Support: Extended \n <gateway:experimental>"
+                                maxLength: 253
+                                minLength: 1
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                              path:
+                                description: "Path defines a path rewrite. \n Support:
+                                  Extended \n <gateway:experimental>"
+                                properties:
+                                  replaceFullPath:
+                                    description: "ReplaceFullPath specifies the value
+                                      with which to replace the full path of a request
+                                      during a rewrite or redirect. \n <gateway:experimental>"
+                                    maxLength: 1024
+                                    type: string
+                                  replacePrefixMatch:
+                                    description: "ReplacePrefixMatch specifies the
+                                      value with which to replace the prefix match
+                                      of a request during a rewrite or redirect. For
+                                      example, a request to \"/foo/bar\" with a prefix
+                                      match of \"/foo\" would be modified to \"/bar\".
+                                      \n Note that this matches the behavior of the
+                                      PathPrefix match type. This matches full path
+                                      elements. A path element refers to the list
+                                      of labels in the path split by the `/` separator.
+                                      When specified, a trailing `/` is ignored. For
+                                      example, the paths `/abc`, `/abc/`, and `/abc/def`
+                                      would all match the prefix `/abc`, but the path
+                                      `/abcd` would not. \n <gateway:experimental>"
+                                    maxLength: 1024
+                                    type: string
+                                  type:
+                                    description: "Type defines the type of path modifier.
+                                      Additional types may be added in a future release
+                                      of the API. \n Note that values may be added
+                                      to this enum, implementations must ensure that
+                                      unknown values will not cause a crash. \n Unknown
+                                      values here must result in the implementation
+                                      setting the Attached Condition for the Route
+                                      to `status: False`, with a Reason of `UnsupportedValue`.
+                                      \n <gateway:experimental>"
+                                    enum:
+                                    - ReplaceFullPath
+                                    - ReplacePrefixMatch
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                            type: object
+                        required:
+                        - type
+                        type: object
+                      maxItems: 16
+                      type: array
+                    matches:
+                      default:
+                      - path:
+                          type: PathPrefix
+                          value: /
+                      description: "Matches define conditions used for matching the
+                        rule against incoming HTTP requests. Each match is independent,
+                        i.e. this rule will be matched if **any** one of the matches
+                        is satisfied. \n For example, take the following matches configuration:
+                        \n ``` matches: - path:     value: \"/foo\"   headers:   -
+                        name: \"version\"     value: \"v2\" - path:     value: \"/v2/foo\"
+                        ``` \n For a request to match against this rule, a request
+                        must satisfy EITHER of the two conditions: \n - path prefixed
+                        with `/foo` AND contains the header `version: v2` - path prefix
+                        of `/v2/foo` \n See the documentation for HTTPRouteMatch on
+                        how to specify multiple match conditions that should be ANDed
+                        together. \n If no matches are specified, the default is a
+                        prefix path match on \"/\", which has the effect of matching
+                        every HTTP request. \n Proxy or Load Balancer routing configuration
+                        generated from HTTPRoutes MUST prioritize rules based on the
+                        following criteria, continuing on ties. Precedence must be
+                        given to the Rule with the largest number of: \n * Characters
+                        in a matching non-wildcard hostname. * Characters in a matching
+                        hostname. * Characters in a matching path. * Header matches.
+                        * Query param matches. \n If ties still exist across multiple
+                        Routes, matching precedence MUST be determined in order of
+                        the following criteria, continuing on ties: \n * The oldest
+                        Route based on creation timestamp. * The Route appearing first
+                        in alphabetical order by   \"{namespace}/{name}\". \n If ties
+                        still exist within the Route that has been given precedence,
+                        matching precedence MUST be granted to the FIRST matching
+                        rule (in list order) meeting the above criteria. \n When no
+                        rules matching a request have been successfully attached to
+                        the parent a request is coming from, a HTTP 404 status code
+                        MUST be returned."
+                      items:
+                        description: "HTTPRouteMatch defines the predicate used to
+                          match requests to a given action. Multiple match types are
+                          ANDed together, i.e. the match will evaluate to true only
+                          if all conditions are satisfied. \n For example, the match
+                          below will match a HTTP request only if its path starts
+                          with `/foo` AND it contains the `version: v1` header: \n
+                          ``` match:   path:     value: \"/foo\"   headers:   - name:
+                          \"version\"     value \"v1\" ```"
+                        properties:
+                          headers:
+                            description: Headers specifies HTTP request header matchers.
+                              Multiple match values are ANDed together, meaning, a
+                              request must match all the specified headers to select
+                              the route.
+                            items:
+                              description: HTTPHeaderMatch describes how to select
+                                a HTTP route by matching HTTP request headers.
+                              properties:
+                                name:
+                                  description: "Name is the name of the HTTP Header
+                                    to be matched. Name matching MUST be case insensitive.
+                                    (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                    \n If multiple entries specify equivalent header
+                                    names, only the first entry with an equivalent
+                                    name MUST be considered for a match. Subsequent
+                                    entries with an equivalent header name MUST be
+                                    ignored. Due to the case-insensitivity of header
+                                    names, \"foo\" and \"Foo\" are considered equivalent.
+                                    \n When a header is repeated in an HTTP request,
+                                    it is implementation-specific behavior as to how
+                                    this is represented. Generally, proxies should
+                                    follow the guidance from the RFC: https://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2
+                                    regarding processing a repeated header, with special
+                                    handling for \"Set-Cookie\"."
+                                  maxLength: 256
+                                  minLength: 1
+                                  pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                  type: string
+                                type:
+                                  default: Exact
+                                  description: "Type specifies how to match against
+                                    the value of the header. \n Support: Core (Exact)
+                                    \n Support: Custom (RegularExpression) \n Since
+                                    RegularExpression HeaderMatchType has custom conformance,
+                                    implementations can support POSIX, PCRE or any
+                                    other dialects of regular expressions. Please
+                                    read the implementation's documentation to determine
+                                    the supported dialect."
+                                  enum:
+                                  - Exact
+                                  - RegularExpression
+                                  type: string
+                                value:
+                                  description: Value is the value of HTTP Header to
+                                    be matched.
+                                  maxLength: 4096
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            maxItems: 16
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          method:
+                            description: "Method specifies HTTP method matcher. When
+                              specified, this route will be matched only if the request
+                              has the specified method. \n Support: Extended"
+                            enum:
+                            - GET
+                            - HEAD
+                            - POST
+                            - PUT
+                            - DELETE
+                            - CONNECT
+                            - OPTIONS
+                            - TRACE
+                            - PATCH
+                            type: string
+                          path:
+                            default:
+                              type: PathPrefix
+                              value: /
+                            description: Path specifies a HTTP request path matcher.
+                              If this field is not specified, a default prefix match
+                              on the "/" path is provided.
+                            properties:
+                              type:
+                                default: PathPrefix
+                                description: "Type specifies how to match against
+                                  the path Value. \n Support: Core (Exact, PathPrefix)
+                                  \n Support: Custom (RegularExpression)"
+                                enum:
+                                - Exact
+                                - PathPrefix
+                                - RegularExpression
+                                type: string
+                              value:
+                                default: /
+                                description: Value of the HTTP path to match against.
+                                maxLength: 1024
+                                type: string
+                            type: object
+                          queryParams:
+                            description: QueryParams specifies HTTP query parameter
+                              matchers. Multiple match values are ANDed together,
+                              meaning, a request must match all the specified query
+                              parameters to select the route.
+                            items:
+                              description: HTTPQueryParamMatch describes how to select
+                                a HTTP route by matching HTTP query parameters.
+                              properties:
+                                name:
+                                  description: "Name is the name of the HTTP query
+                                    param to be matched. This must be an exact string
+                                    match. (See https://tools.ietf.org/html/rfc7230#section-2.7.3).
+                                    \n If multiple entries specify equivalent query
+                                    param names, only the first entry with an equivalent
+                                    name MUST be considered for a match. Subsequent
+                                    entries with an equivalent query param name MUST
+                                    be ignored. \n If a query param is repeated in
+                                    an HTTP request, the behavior is purposely left
+                                    undefined, since different data planes have different
+                                    capabilities. However, it's *recommended* that
+                                    implementations should match against the first
+                                    value of the param if the data plane supports
+                                    it, as this behavior is expected in other load
+                                    balancing contexts outside of the Gateway API.
+                                    Users should not route traffic based on repeated
+                                    query params to guard themselves against potential
+                                    differences in the implementations."
+                                  maxLength: 256
+                                  minLength: 1
+                                  type: string
+                                type:
+                                  default: Exact
+                                  description: "Type specifies how to match against
+                                    the value of the query parameter. \n Support:
+                                    Extended (Exact) \n Support: Custom (RegularExpression)
+                                    \n Since RegularExpression QueryParamMatchType
+                                    has custom conformance, implementations can support
+                                    POSIX, PCRE or any other dialects of regular expressions.
+                                    Please read the implementation's documentation
+                                    to determine the supported dialect."
+                                  enum:
+                                  - Exact
+                                  - RegularExpression
+                                  type: string
+                                value:
+                                  description: Value is the value of HTTP query param
+                                    to be matched.
+                                  maxLength: 1024
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            maxItems: 16
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                        type: object
+                      maxItems: 8
+                      type: array
+                  type: object
+                maxItems: 16
+                type: array
+            type: object
+          status:
+            description: Status defines the current state of HTTPRoute.
+            properties:
+              parents:
+                description: "Parents is a list of parent resources (usually Gateways)
+                  that are associated with the route, and the status of the route
+                  with respect to each parent. When this route attaches to a parent,
+                  the controller that manages the parent must add an entry to this
+                  list when the controller first sees the route and should update
+                  the entry as appropriate when the route or gateway is modified.
+                  \n Note that parent references that cannot be resolved by an implementation
+                  of this API will not be added to this list. Implementations of this
+                  API can only populate Route status for the Gateways/parent resources
+                  they are responsible for. \n A maximum of 32 Gateways will be represented
+                  in this list. An empty list means the route has not been attached
+                  to any Gateway."
+                items:
+                  description: RouteParentStatus describes the status of a route with
+                    respect to an associated Parent.
+                  properties:
+                    conditions:
+                      description: "Conditions describes the status of the route with
+                        respect to the Gateway. Note that the route's availability
+                        is also subject to the Gateway's own status conditions and
+                        listener status. \n If the Route's ParentRef specifies an
+                        existing Gateway that supports Routes of this kind AND that
+                        Gateway's controller has sufficient access, then that Gateway's
+                        controller MUST set the \"Accepted\" condition on the Route,
+                        to indicate whether the route has been accepted or rejected
+                        by the Gateway, and why. \n A Route MUST be considered \"Accepted\"
+                        if at least one of the Route's rules is implemented by the
+                        Gateway. \n There are a number of cases where the \"Accepted\"
+                        condition may not be set due to lack of controller visibility,
+                        that includes when: \n * The Route refers to a non-existent
+                        parent. * The Route is of a type that the controller does
+                        not support. * The Route is in a namespace the controller
+                        does not have access to."
+                      items:
+                        description: "Condition contains details for one aspect of
+                          the current state of this API Resource. --- This struct
+                          is intended for direct use as an array at the field path
+                          .status.conditions.  For example, type FooStatus struct{
+                          \    // Represents the observations of a foo's current state.
+                          \    // Known .status.conditions.type are: \"Available\",
+                          \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
+                          \    // +patchStrategy=merge     // +listType=map     //
+                          +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                          patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                          \n     // other fields }"
+                        properties:
+                          lastTransitionTime:
+                            description: lastTransitionTime is the last time the condition
+                              transitioned from one status to another. This should
+                              be when the underlying condition changed.  If that is
+                              not known, then using the time when the API field changed
+                              is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: message is a human readable message indicating
+                              details about the transition. This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: observedGeneration represents the .metadata.generation
+                              that the condition was set based upon. For instance,
+                              if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                              is 9, the condition is out of date with respect to the
+                              current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: reason contains a programmatic identifier
+                              indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected
+                              values and meanings for this field, and whether the
+                              values are considered a guaranteed API. The value should
+                              be a CamelCase string. This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                              --- Many .condition.type values are consistent across
+                              resources like Available, but because arbitrary conditions
+                              can be useful (see .node.status.conditions), the ability
+                              to deconflict is important. The regex it matches is
+                              (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: "ControllerName is a domain/path string that indicates
+                        the name of the controller that wrote this status. This corresponds
+                        with the controllerName field on GatewayClass. \n Example:
+                        \"example.net/gateway-controller\". \n The format of this
+                        field is DOMAIN \"/\" PATH, where DOMAIN and PATH are valid
+                        Kubernetes names (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+                        \n Controllers MUST populate this field when writing status.
+                        Controllers should ensure that entries to status populated
+                        with their ControllerName are cleaned up when they are no
+                        longer necessary."
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                    parentRef:
+                      description: ParentRef corresponds with a ParentRef in the spec
+                        that this RouteParentStatus struct describes the status of.
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: "Group is the group of the referent. \n Support:
+                            Core"
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Gateway
+                          description: "Kind is kind of the referent. \n Support:
+                            Core (Gateway) \n Support: Custom (Other Resources)"
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: "Name is the name of the referent. \n Support:
+                            Core"
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: "Namespace is the namespace of the referent.
+                            When unspecified, this refers to the local namespace of
+                            the Route. \n Support: Core"
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -5061,7 +6338,7 @@ spec:
         - spec
         type: object
     served: true
-    storage: false
+    storage: true
     subresources:
       status: {}
 status:
@@ -5076,7 +6353,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/1086
-    gateway.networking.k8s.io/bundle-version: v0.5.0
+    gateway.networking.k8s.io/bundle-version: v0.6.0-dev
     gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: referencegrants.gateway.networking.k8s.io
@@ -5226,7 +6503,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/1086
-    gateway.networking.k8s.io/bundle-version: v0.5.0
+    gateway.networking.k8s.io/bundle-version: v0.6.0-dev
     gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: referencepolicies.gateway.networking.k8s.io
@@ -5381,7 +6658,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/1086
-    gateway.networking.k8s.io/bundle-version: v0.5.0
+    gateway.networking.k8s.io/bundle-version: v0.6.0-dev
     gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: tcproutes.gateway.networking.k8s.io
@@ -5470,8 +6747,8 @@ spec:
                       type: string
                     namespace:
                       description: "Namespace is the namespace of the referent. When
-                        unspecified (or empty string), this refers to the local namespace
-                        of the Route. \n Support: Core"
+                        unspecified, this refers to the local namespace of the Route.
+                        \n Support: Core"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -5578,11 +6855,11 @@ spec:
                           namespace:
                             description: "Namespace is the namespace of the backend.
                               When unspecified, the local namespace is inferred. \n
-                              Note that when a different namespace is specified, a
-                              ReferenceGrant object with ReferenceGrantTo.Kind=Service
-                              is required in the referent namespace to allow that
-                              namespace's owner to accept the reference. See the ReferenceGrant
-                              documentation for details. \n Support: Core"
+                              Note that when a namespace is specified, a ReferenceGrant
+                              object is required in the referent namespace to allow
+                              that namespace's owner to accept the reference. See
+                              the ReferenceGrant documentation for details. \n Support:
+                              Core"
                             maxLength: 63
                             minLength: 1
                             pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -5590,9 +6867,10 @@ spec:
                           port:
                             description: Port specifies the destination port number
                               to use for this resource. Port is required when the
-                              referent is a Kubernetes Service. For other resources,
-                              destination port might be derived from the referent
-                              resource or this field.
+                              referent is a Kubernetes Service. In this case, the
+                              port number is the service port number, not the target
+                              port. For other resources, destination port might be
+                              derived from the referent resource or this field.
                             format: int32
                             maximum: 65535
                             minimum: 1
@@ -5785,8 +7063,8 @@ spec:
                           type: string
                         namespace:
                           description: "Namespace is the namespace of the referent.
-                            When unspecified (or empty string), this refers to the
-                            local namespace of the Route. \n Support: Core"
+                            When unspecified, this refers to the local namespace of
+                            the Route. \n Support: Core"
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -5874,7 +7152,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/1086
-    gateway.networking.k8s.io/bundle-version: v0.5.0
+    gateway.networking.k8s.io/bundle-version: v0.6.0-dev
     gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: tlsroutes.gateway.networking.k8s.io
@@ -6009,8 +7287,8 @@ spec:
                       type: string
                     namespace:
                       description: "Namespace is the namespace of the referent. When
-                        unspecified (or empty string), this refers to the local namespace
-                        of the Route. \n Support: Core"
+                        unspecified, this refers to the local namespace of the Route.
+                        \n Support: Core"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -6120,11 +7398,11 @@ spec:
                           namespace:
                             description: "Namespace is the namespace of the backend.
                               When unspecified, the local namespace is inferred. \n
-                              Note that when a different namespace is specified, a
-                              ReferenceGrant object with ReferenceGrantTo.Kind=Service
-                              is required in the referent namespace to allow that
-                              namespace's owner to accept the reference. See the ReferenceGrant
-                              documentation for details. \n Support: Core"
+                              Note that when a namespace is specified, a ReferenceGrant
+                              object is required in the referent namespace to allow
+                              that namespace's owner to accept the reference. See
+                              the ReferenceGrant documentation for details. \n Support:
+                              Core"
                             maxLength: 63
                             minLength: 1
                             pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -6132,9 +7410,10 @@ spec:
                           port:
                             description: Port specifies the destination port number
                               to use for this resource. Port is required when the
-                              referent is a Kubernetes Service. For other resources,
-                              destination port might be derived from the referent
-                              resource or this field.
+                              referent is a Kubernetes Service. In this case, the
+                              port number is the service port number, not the target
+                              port. For other resources, destination port might be
+                              derived from the referent resource or this field.
                             format: int32
                             maximum: 65535
                             minimum: 1
@@ -6327,8 +7606,8 @@ spec:
                           type: string
                         namespace:
                           description: "Namespace is the namespace of the referent.
-                            When unspecified (or empty string), this refers to the
-                            local namespace of the Route. \n Support: Core"
+                            When unspecified, this refers to the local namespace of
+                            the Route. \n Support: Core"
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -6416,7 +7695,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/1086
-    gateway.networking.k8s.io/bundle-version: v0.5.0
+    gateway.networking.k8s.io/bundle-version: v0.6.0-dev
     gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: udproutes.gateway.networking.k8s.io
@@ -6505,8 +7784,8 @@ spec:
                       type: string
                     namespace:
                       description: "Namespace is the namespace of the referent. When
-                        unspecified (or empty string), this refers to the local namespace
-                        of the Route. \n Support: Core"
+                        unspecified, this refers to the local namespace of the Route.
+                        \n Support: Core"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -6613,11 +7892,11 @@ spec:
                           namespace:
                             description: "Namespace is the namespace of the backend.
                               When unspecified, the local namespace is inferred. \n
-                              Note that when a different namespace is specified, a
-                              ReferenceGrant object with ReferenceGrantTo.Kind=Service
-                              is required in the referent namespace to allow that
-                              namespace's owner to accept the reference. See the ReferenceGrant
-                              documentation for details. \n Support: Core"
+                              Note that when a namespace is specified, a ReferenceGrant
+                              object is required in the referent namespace to allow
+                              that namespace's owner to accept the reference. See
+                              the ReferenceGrant documentation for details. \n Support:
+                              Core"
                             maxLength: 63
                             minLength: 1
                             pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -6625,9 +7904,10 @@ spec:
                           port:
                             description: Port specifies the destination port number
                               to use for this resource. Port is required when the
-                              referent is a Kubernetes Service. For other resources,
-                              destination port might be derived from the referent
-                              resource or this field.
+                              referent is a Kubernetes Service. In this case, the
+                              port number is the service port number, not the target
+                              port. For other resources, destination port might be
+                              derived from the referent resource or this field.
                             format: int32
                             maximum: 65535
                             minimum: 1
@@ -6820,8 +8100,8 @@ spec:
                           type: string
                         namespace:
                           description: "Namespace is the namespace of the referent.
-                            When unspecified (or empty string), this refers to the
-                            local namespace of the Route. \n Support: Core"
+                            When unspecified, this refers to the local namespace of
+                            the Route. \n Support: Core"
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$

--- a/tests/integration/pilot/testdata/gateway-api-crd.yaml
+++ b/tests/integration/pilot/testdata/gateway-api-crd.yaml
@@ -1,4 +1,4 @@
-# Generated with `kubectl kustomize "https://github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=57cefb9268f6090bbdf2da59b131f7ba8c28c2f9"`
+# Generated with `kubectl kustomize "https://github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=c664ae6012b09d474914a22ff6e854220c47749e"`
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -35,6 +35,9 @@ spec:
       name: Description
       priority: 1
       type: string
+    deprecated: true
+    deprecationWarning: The v1alpha2 version of GatewayClass has been deprecated and
+      will be removed in a future release of the API. Please upgrade to v1beta1.
     name: v1alpha2
     schema:
       openAPIV3Schema:
@@ -218,7 +221,7 @@ spec:
         required:
         - spec
         type: object
-    served: false
+    served: true
     storage: false
     subresources:
       status: {}
@@ -465,6 +468,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: The v1alpha2 version of Gateway has been deprecated and will
+      be removed in a future release of the API. Please upgrade to v1beta1.
     name: v1alpha2
     schema:
       openAPIV3Schema:
@@ -1142,7 +1148,7 @@ spec:
         required:
         - spec
         type: object
-    served: false
+    served: true
     storage: false
     subresources:
       status: {}
@@ -3122,6 +3128,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: The v1alpha2 version of HTTPRoute has been deprecated and
+      will be removed in a future release of the API. Please upgrade to v1beta1.
     name: v1alpha2
     schema:
       openAPIV3Schema:
@@ -3174,7 +3183,13 @@ spec:
                   have specified hostnames, and none match with the criteria above,
                   then the HTTPRoute is not accepted. The implementation must raise
                   an 'Accepted' Condition with a status of `False` in the corresponding
-                  RouteParentStatus. \n Support: Core"
+                  RouteParentStatus. \n In the event that multiple HTTPRoutes specify
+                  intersecting hostnames (e.g. overlapping wildcard matching and exact
+                  matching hostnames), precedence must be given to rules from the
+                  HTTPRoute with the largest number of: \n * Characters in a matching
+                  non-wildcard hostname. * Characters in a matching hostname. \n If
+                  ties exist across multiple Routes, the matching precedence rules
+                  for HTTPRouteMatches takes over. \n Support: Core"
                 items:
                   description: "Hostname is the fully qualified domain name of a network
                     host. This matches the RFC 1123 definition of a hostname with
@@ -3680,6 +3695,115 @@ spec:
                                       - 302
                                       type: integer
                                   type: object
+                                responseHeaderModifier:
+                                  description: "ResponseHeaderModifier defines a schema
+                                    for a filter that modifies response headers. \n
+                                    Support: Extended \n <gateway:experimental>"
+                                  properties:
+                                    add:
+                                      description: "Add adds the given header(s) (name,
+                                        value) to the request before the action. It
+                                        appends to any existing values associated
+                                        with the header name. \n Input:   GET /foo
+                                        HTTP/1.1   my-header: foo \n Config:   add:
+                                        \  - name: \"my-header\"     value: \"bar\"
+                                        \n Output:   GET /foo HTTP/1.1   my-header:
+                                        foo   my-header: bar"
+                                      items:
+                                        description: HTTPHeader represents an HTTP
+                                          Header name and value as defined by RFC
+                                          7230.
+                                        properties:
+                                          name:
+                                            description: "Name is the name of the
+                                              HTTP Header to be matched. Name matching
+                                              MUST be case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                              \n If multiple entries specify equivalent
+                                              header names, the first entry with an
+                                              equivalent name MUST be considered for
+                                              a match. Subsequent entries with an
+                                              equivalent header name MUST be ignored.
+                                              Due to the case-insensitivity of header
+                                              names, \"foo\" and \"Foo\" are considered
+                                              equivalent."
+                                            maxLength: 256
+                                            minLength: 1
+                                            pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                            type: string
+                                          value:
+                                            description: Value is the value of HTTP
+                                              Header to be matched.
+                                            maxLength: 4096
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    remove:
+                                      description: "Remove the given header(s) from
+                                        the HTTP request before the action. The value
+                                        of Remove is a list of HTTP header names.
+                                        Note that the header names are case-insensitive
+                                        (see https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
+                                        \n Input:   GET /foo HTTP/1.1   my-header1:
+                                        foo   my-header2: bar   my-header3: baz \n
+                                        Config:   remove: [\"my-header1\", \"my-header3\"]
+                                        \n Output:   GET /foo HTTP/1.1   my-header2:
+                                        bar"
+                                      items:
+                                        type: string
+                                      maxItems: 16
+                                      type: array
+                                    set:
+                                      description: "Set overwrites the request with
+                                        the given header (name, value) before the
+                                        action. \n Input:   GET /foo HTTP/1.1   my-header:
+                                        foo \n Config:   set:   - name: \"my-header\"
+                                        \    value: \"bar\" \n Output:   GET /foo
+                                        HTTP/1.1   my-header: bar"
+                                      items:
+                                        description: HTTPHeader represents an HTTP
+                                          Header name and value as defined by RFC
+                                          7230.
+                                        properties:
+                                          name:
+                                            description: "Name is the name of the
+                                              HTTP Header to be matched. Name matching
+                                              MUST be case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                              \n If multiple entries specify equivalent
+                                              header names, the first entry with an
+                                              equivalent name MUST be considered for
+                                              a match. Subsequent entries with an
+                                              equivalent header name MUST be ignored.
+                                              Due to the case-insensitivity of header
+                                              names, \"foo\" and \"Foo\" are considered
+                                              equivalent."
+                                            maxLength: 256
+                                            minLength: 1
+                                            pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                            type: string
+                                          value:
+                                            description: Value is the value of HTTP
+                                              Header to be matched.
+                                            maxLength: 4096
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                  type: object
                                 type:
                                   description: "Type identifies the type of filter
                                     to apply. As with other API fields, types are
@@ -3714,6 +3838,7 @@ spec:
                                     of `UnsupportedValue`. \n "
                                   enum:
                                   - RequestHeaderModifier
+                                  - ResponseHeaderModifier
                                   - RequestMirror
                                   - RequestRedirect
                                   - URLRewrite
@@ -4188,6 +4313,107 @@ spec:
                                 - 302
                                 type: integer
                             type: object
+                          responseHeaderModifier:
+                            description: "ResponseHeaderModifier defines a schema
+                              for a filter that modifies response headers. \n Support:
+                              Extended \n <gateway:experimental>"
+                            properties:
+                              add:
+                                description: "Add adds the given header(s) (name,
+                                  value) to the request before the action. It appends
+                                  to any existing values associated with the header
+                                  name. \n Input:   GET /foo HTTP/1.1   my-header:
+                                  foo \n Config:   add:   - name: \"my-header\"     value:
+                                  \"bar\" \n Output:   GET /foo HTTP/1.1   my-header:
+                                  foo   my-header: bar"
+                                items:
+                                  description: HTTPHeader represents an HTTP Header
+                                    name and value as defined by RFC 7230.
+                                  properties:
+                                    name:
+                                      description: "Name is the name of the HTTP Header
+                                        to be matched. Name matching MUST be case
+                                        insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                        \n If multiple entries specify equivalent
+                                        header names, the first entry with an equivalent
+                                        name MUST be considered for a match. Subsequent
+                                        entries with an equivalent header name MUST
+                                        be ignored. Due to the case-insensitivity
+                                        of header names, \"foo\" and \"Foo\" are considered
+                                        equivalent."
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    value:
+                                      description: Value is the value of HTTP Header
+                                        to be matched.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              remove:
+                                description: "Remove the given header(s) from the
+                                  HTTP request before the action. The value of Remove
+                                  is a list of HTTP header names. Note that the header
+                                  names are case-insensitive (see https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
+                                  \n Input:   GET /foo HTTP/1.1   my-header1: foo
+                                  \  my-header2: bar   my-header3: baz \n Config:
+                                  \  remove: [\"my-header1\", \"my-header3\"] \n Output:
+                                  \  GET /foo HTTP/1.1   my-header2: bar"
+                                items:
+                                  type: string
+                                maxItems: 16
+                                type: array
+                              set:
+                                description: "Set overwrites the request with the
+                                  given header (name, value) before the action. \n
+                                  Input:   GET /foo HTTP/1.1   my-header: foo \n Config:
+                                  \  set:   - name: \"my-header\"     value: \"bar\"
+                                  \n Output:   GET /foo HTTP/1.1   my-header: bar"
+                                items:
+                                  description: HTTPHeader represents an HTTP Header
+                                    name and value as defined by RFC 7230.
+                                  properties:
+                                    name:
+                                      description: "Name is the name of the HTTP Header
+                                        to be matched. Name matching MUST be case
+                                        insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                        \n If multiple entries specify equivalent
+                                        header names, the first entry with an equivalent
+                                        name MUST be considered for a match. Subsequent
+                                        entries with an equivalent header name MUST
+                                        be ignored. Due to the case-insensitivity
+                                        of header names, \"foo\" and \"Foo\" are considered
+                                        equivalent."
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    value:
+                                      description: Value is the value of HTTP Header
+                                        to be matched.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                            type: object
                           type:
                             description: "Type identifies the type of filter to apply.
                               As with other API fields, types are classified into
@@ -4219,6 +4445,7 @@ spec:
                               False`, with a Reason of `UnsupportedValue`. \n "
                             enum:
                             - RequestHeaderModifier
+                            - ResponseHeaderModifier
                             - RequestMirror
                             - RequestRedirect
                             - URLRewrite
@@ -4305,22 +4532,21 @@ spec:
                         together. \n If no matches are specified, the default is a
                         prefix path match on \"/\", which has the effect of matching
                         every HTTP request. \n Proxy or Load Balancer routing configuration
-                        generated from HTTPRoutes MUST prioritize rules based on the
-                        following criteria, continuing on ties. Precedence must be
-                        given to the Rule with the largest number of: \n * Characters
-                        in a matching non-wildcard hostname. * Characters in a matching
-                        hostname. * Characters in a matching path. * Header matches.
-                        * Query param matches. \n If ties still exist across multiple
-                        Routes, matching precedence MUST be determined in order of
-                        the following criteria, continuing on ties: \n * The oldest
-                        Route based on creation timestamp. * The Route appearing first
-                        in alphabetical order by   \"{namespace}/{name}\". \n If ties
-                        still exist within the Route that has been given precedence,
-                        matching precedence MUST be granted to the FIRST matching
-                        rule (in list order) meeting the above criteria. \n When no
-                        rules matching a request have been successfully attached to
-                        the parent a request is coming from, a HTTP 404 status code
-                        MUST be returned."
+                        generated from HTTPRoutes MUST prioritize matches based on
+                        the following criteria, continuing on ties. Across all rules
+                        specified on applicable Routes, precedence must be given to
+                        the match with the largest number of: \n * Characters in a
+                        matching path. * Header matches. * Query param matches. \n
+                        If ties still exist across multiple Routes, matching precedence
+                        MUST be determined in order of the following criteria, continuing
+                        on ties: \n * The oldest Route based on creation timestamp.
+                        * The Route appearing first in alphabetical order by   \"{namespace}/{name}\".
+                        \n If ties still exist within an HTTPRoute, matching precedence
+                        MUST be granted to the FIRST matching rule (in list order)
+                        with a match meeting the above criteria. \n When no rules
+                        matching a request have been successfully attached to the
+                        parent a request is coming from, a HTTP 404 status code MUST
+                        be returned."
                       items:
                         description: "HTTPRouteMatch defines the predicate used to
                           match requests to a given action. Multiple match types are
@@ -4724,7 +4950,7 @@ spec:
         required:
         - spec
         type: object
-    served: false
+    served: true
     storage: false
     subresources:
       status: {}
@@ -4787,7 +5013,13 @@ spec:
                   have specified hostnames, and none match with the criteria above,
                   then the HTTPRoute is not accepted. The implementation must raise
                   an 'Accepted' Condition with a status of `False` in the corresponding
-                  RouteParentStatus. \n Support: Core"
+                  RouteParentStatus. \n In the event that multiple HTTPRoutes specify
+                  intersecting hostnames (e.g. overlapping wildcard matching and exact
+                  matching hostnames), precedence must be given to rules from the
+                  HTTPRoute with the largest number of: \n * Characters in a matching
+                  non-wildcard hostname. * Characters in a matching hostname. \n If
+                  ties exist across multiple Routes, the matching precedence rules
+                  for HTTPRouteMatches takes over. \n Support: Core"
                 items:
                   description: "Hostname is the fully qualified domain name of a network
                     host. This matches the RFC 1123 definition of a hostname with
@@ -5293,6 +5525,115 @@ spec:
                                       - 302
                                       type: integer
                                   type: object
+                                responseHeaderModifier:
+                                  description: "ResponseHeaderModifier defines a schema
+                                    for a filter that modifies response headers. \n
+                                    Support: Extended \n <gateway:experimental>"
+                                  properties:
+                                    add:
+                                      description: "Add adds the given header(s) (name,
+                                        value) to the request before the action. It
+                                        appends to any existing values associated
+                                        with the header name. \n Input:   GET /foo
+                                        HTTP/1.1   my-header: foo \n Config:   add:
+                                        \  - name: \"my-header\"     value: \"bar\"
+                                        \n Output:   GET /foo HTTP/1.1   my-header:
+                                        foo   my-header: bar"
+                                      items:
+                                        description: HTTPHeader represents an HTTP
+                                          Header name and value as defined by RFC
+                                          7230.
+                                        properties:
+                                          name:
+                                            description: "Name is the name of the
+                                              HTTP Header to be matched. Name matching
+                                              MUST be case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                              \n If multiple entries specify equivalent
+                                              header names, the first entry with an
+                                              equivalent name MUST be considered for
+                                              a match. Subsequent entries with an
+                                              equivalent header name MUST be ignored.
+                                              Due to the case-insensitivity of header
+                                              names, \"foo\" and \"Foo\" are considered
+                                              equivalent."
+                                            maxLength: 256
+                                            minLength: 1
+                                            pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                            type: string
+                                          value:
+                                            description: Value is the value of HTTP
+                                              Header to be matched.
+                                            maxLength: 4096
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    remove:
+                                      description: "Remove the given header(s) from
+                                        the HTTP request before the action. The value
+                                        of Remove is a list of HTTP header names.
+                                        Note that the header names are case-insensitive
+                                        (see https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
+                                        \n Input:   GET /foo HTTP/1.1   my-header1:
+                                        foo   my-header2: bar   my-header3: baz \n
+                                        Config:   remove: [\"my-header1\", \"my-header3\"]
+                                        \n Output:   GET /foo HTTP/1.1   my-header2:
+                                        bar"
+                                      items:
+                                        type: string
+                                      maxItems: 16
+                                      type: array
+                                    set:
+                                      description: "Set overwrites the request with
+                                        the given header (name, value) before the
+                                        action. \n Input:   GET /foo HTTP/1.1   my-header:
+                                        foo \n Config:   set:   - name: \"my-header\"
+                                        \    value: \"bar\" \n Output:   GET /foo
+                                        HTTP/1.1   my-header: bar"
+                                      items:
+                                        description: HTTPHeader represents an HTTP
+                                          Header name and value as defined by RFC
+                                          7230.
+                                        properties:
+                                          name:
+                                            description: "Name is the name of the
+                                              HTTP Header to be matched. Name matching
+                                              MUST be case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                              \n If multiple entries specify equivalent
+                                              header names, the first entry with an
+                                              equivalent name MUST be considered for
+                                              a match. Subsequent entries with an
+                                              equivalent header name MUST be ignored.
+                                              Due to the case-insensitivity of header
+                                              names, \"foo\" and \"Foo\" are considered
+                                              equivalent."
+                                            maxLength: 256
+                                            minLength: 1
+                                            pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                            type: string
+                                          value:
+                                            description: Value is the value of HTTP
+                                              Header to be matched.
+                                            maxLength: 4096
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                  type: object
                                 type:
                                   description: "Type identifies the type of filter
                                     to apply. As with other API fields, types are
@@ -5327,6 +5668,7 @@ spec:
                                     of `UnsupportedValue`. \n "
                                   enum:
                                   - RequestHeaderModifier
+                                  - ResponseHeaderModifier
                                   - RequestMirror
                                   - RequestRedirect
                                   - URLRewrite
@@ -5801,6 +6143,107 @@ spec:
                                 - 302
                                 type: integer
                             type: object
+                          responseHeaderModifier:
+                            description: "ResponseHeaderModifier defines a schema
+                              for a filter that modifies response headers. \n Support:
+                              Extended \n <gateway:experimental>"
+                            properties:
+                              add:
+                                description: "Add adds the given header(s) (name,
+                                  value) to the request before the action. It appends
+                                  to any existing values associated with the header
+                                  name. \n Input:   GET /foo HTTP/1.1   my-header:
+                                  foo \n Config:   add:   - name: \"my-header\"     value:
+                                  \"bar\" \n Output:   GET /foo HTTP/1.1   my-header:
+                                  foo   my-header: bar"
+                                items:
+                                  description: HTTPHeader represents an HTTP Header
+                                    name and value as defined by RFC 7230.
+                                  properties:
+                                    name:
+                                      description: "Name is the name of the HTTP Header
+                                        to be matched. Name matching MUST be case
+                                        insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                        \n If multiple entries specify equivalent
+                                        header names, the first entry with an equivalent
+                                        name MUST be considered for a match. Subsequent
+                                        entries with an equivalent header name MUST
+                                        be ignored. Due to the case-insensitivity
+                                        of header names, \"foo\" and \"Foo\" are considered
+                                        equivalent."
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    value:
+                                      description: Value is the value of HTTP Header
+                                        to be matched.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              remove:
+                                description: "Remove the given header(s) from the
+                                  HTTP request before the action. The value of Remove
+                                  is a list of HTTP header names. Note that the header
+                                  names are case-insensitive (see https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
+                                  \n Input:   GET /foo HTTP/1.1   my-header1: foo
+                                  \  my-header2: bar   my-header3: baz \n Config:
+                                  \  remove: [\"my-header1\", \"my-header3\"] \n Output:
+                                  \  GET /foo HTTP/1.1   my-header2: bar"
+                                items:
+                                  type: string
+                                maxItems: 16
+                                type: array
+                              set:
+                                description: "Set overwrites the request with the
+                                  given header (name, value) before the action. \n
+                                  Input:   GET /foo HTTP/1.1   my-header: foo \n Config:
+                                  \  set:   - name: \"my-header\"     value: \"bar\"
+                                  \n Output:   GET /foo HTTP/1.1   my-header: bar"
+                                items:
+                                  description: HTTPHeader represents an HTTP Header
+                                    name and value as defined by RFC 7230.
+                                  properties:
+                                    name:
+                                      description: "Name is the name of the HTTP Header
+                                        to be matched. Name matching MUST be case
+                                        insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                        \n If multiple entries specify equivalent
+                                        header names, the first entry with an equivalent
+                                        name MUST be considered for a match. Subsequent
+                                        entries with an equivalent header name MUST
+                                        be ignored. Due to the case-insensitivity
+                                        of header names, \"foo\" and \"Foo\" are considered
+                                        equivalent."
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    value:
+                                      description: Value is the value of HTTP Header
+                                        to be matched.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                            type: object
                           type:
                             description: "Type identifies the type of filter to apply.
                               As with other API fields, types are classified into
@@ -5832,6 +6275,7 @@ spec:
                               False`, with a Reason of `UnsupportedValue`. \n "
                             enum:
                             - RequestHeaderModifier
+                            - ResponseHeaderModifier
                             - RequestMirror
                             - RequestRedirect
                             - URLRewrite
@@ -5918,22 +6362,21 @@ spec:
                         together. \n If no matches are specified, the default is a
                         prefix path match on \"/\", which has the effect of matching
                         every HTTP request. \n Proxy or Load Balancer routing configuration
-                        generated from HTTPRoutes MUST prioritize rules based on the
-                        following criteria, continuing on ties. Precedence must be
-                        given to the Rule with the largest number of: \n * Characters
-                        in a matching non-wildcard hostname. * Characters in a matching
-                        hostname. * Characters in a matching path. * Header matches.
-                        * Query param matches. \n If ties still exist across multiple
-                        Routes, matching precedence MUST be determined in order of
-                        the following criteria, continuing on ties: \n * The oldest
-                        Route based on creation timestamp. * The Route appearing first
-                        in alphabetical order by   \"{namespace}/{name}\". \n If ties
-                        still exist within the Route that has been given precedence,
-                        matching precedence MUST be granted to the FIRST matching
-                        rule (in list order) meeting the above criteria. \n When no
-                        rules matching a request have been successfully attached to
-                        the parent a request is coming from, a HTTP 404 status code
-                        MUST be returned."
+                        generated from HTTPRoutes MUST prioritize matches based on
+                        the following criteria, continuing on ties. Across all rules
+                        specified on applicable Routes, precedence must be given to
+                        the match with the largest number of: \n * Characters in a
+                        matching path. * Header matches. * Query param matches. \n
+                        If ties still exist across multiple Routes, matching precedence
+                        MUST be determined in order of the following criteria, continuing
+                        on ties: \n * The oldest Route based on creation timestamp.
+                        * The Route appearing first in alphabetical order by   \"{namespace}/{name}\".
+                        \n If ties still exist within an HTTPRoute, matching precedence
+                        MUST be granted to the FIRST matching rule (in list order)
+                        with a match meeting the above criteria. \n When no rules
+                        matching a request have been successfully attached to the
+                        parent a request is coming from, a HTTP 404 status code MUST
+                        be returned."
                       items:
                         description: "HTTPRouteMatch defines the predicate used to
                           match requests to a given action. Multiple match types are


### PR DESCRIPTION
The upstream API is dropping support for the v1alpha2 types for HTTPRoute, Gateway, and GatewayClass in the next release. So, unlike Istio where we always read the alpha versions in Istiod, we must switch to reading the beta types or users on v0.6.0 (next release of API) will be broken.

See https://github.com/istio/istio/issues/41146; without this, any users that are installing new gateway-api CRDs (which is caused by cloud providers, other software, etc - not an Istio thing) will have an Istio outage.

(cherry picked from commit fc33f94ecd1367de8e060aa78d615e106c77b952)

**Please provide a description of this PR:**