### PR TITLE
[1.14] Fix PushContext.sidecarIndex.rootConfig flipping issue (#40575)

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -1321,7 +1321,10 @@ func (ps *PushContext) updateContext(
 			return err
 		}
 	} else {
-		ps.sidecarIndex.sidecarsByNamespace = oldPushContext.sidecarIndex.sidecarsByNamespace
+		// new ADS connection may insert new entry to computedSidecarsByNamespace/gatewayDefaultSidecarsByNamespace
+		oldPushContext.sidecarIndex.defaultSidecarMu.Lock()
+		ps.sidecarIndex = oldPushContext.sidecarIndex
+		oldPushContext.sidecarIndex.defaultSidecarMu.Unlock()
 	}
 
 	return nil

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -889,6 +889,19 @@ func TestInitPushContext(t *testing.T) {
 			ExportTo: []string{".", "ns1"},
 		},
 	})
+	_, _ = configStore.Create(config.Config{
+		Meta: config.Meta{
+			Name:             "default",
+			Namespace:        "istio-system",
+			GroupVersionKind: gvk.Sidecar,
+		},
+		Spec: &networking.Sidecar{
+			Egress: []*networking.IstioEgressListener{
+				{Hosts: []string{"test1/*"}},
+			},
+		},
+	})
+
 	store := istioConfigStore{ConfigStore: configStore}
 
 	env.ConfigStore = &store

--- a/releasenotes/notes/sidecar-flipflop.yaml
+++ b/releasenotes/notes/sidecar-flipflop.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+releaseNotes:
+- |
+  **Fixed** an issue where a root namespace `Sidecar` config would be ignored.


### PR DESCRIPTION
When a PushRequest doesn't have Service/VirtualService/DestinationRule/Sidecar change, in PushContext.updateContext(), initSidecarScopes() will not be invoked, new PushContext only copies sidecarIndex.sidecarsByNamespace from old one, sidecarIndex.rootConfig becomes nil.

When workload namespace doesn't have Sidecar resource, this causes new ADS connection's SidecarScope being created by DefaultSidecarScopeForNamespace(), the global default sidecar in istio root namespace is not respected.

(cherry picked from commit 5da33de3c7ff42e2993f7a91b1af2586fe7de48c) (cherry picked from commit 348b5e9a442f580361e319265e012729807809f7)

**Please provide a description of this PR:**