### PR TITLE
Add proxyAdminPort option to istioctl proxy-config

### DIFF
--- a/istioctl/cmd/proxyconfig.go
+++ b/istioctl/cmd/proxyconfig.go
@@ -500,7 +500,6 @@ func allConfigCmd() *cobra.Command {
 	allConfigCmd.PersistentFlags().StringVarP(&configDumpFile, "file", "f", "",
 		"Envoy config dump file")
 	allConfigCmd.PersistentFlags().BoolVar(&verboseProxyConfig, "verbose", true, "Output more information")
-	allConfigCmd.PersistentFlags().IntVar(&proxyAdminPort, "proxyAdminPort", 15000, "Port on which Envoy listen for administrative commands")
 
 	// cluster
 	allConfigCmd.PersistentFlags().StringVar(&fqdn, "fqdn", "", "Filter clusters by substring of Service FQDN field")
@@ -1229,6 +1228,7 @@ func proxyConfig() *cobra.Command {
 	}
 
 	configCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", summaryOutput, "Output format: one of json|yaml|short")
+	configCmd.PersistentFlags().IntVar(&proxyAdminPort, "proxyAdminPort", 15000, "Port on which Envoy listen for administrative commands")
 
 	configCmd.AddCommand(clusterConfigCmd())
 	configCmd.AddCommand(allConfigCmd())

--- a/istioctl/cmd/proxyconfig.go
+++ b/istioctl/cmd/proxyconfig.go
@@ -44,7 +44,7 @@ const (
 
 var (
 	fqdn, direction, subset string
-	port                    int
+	port, proxyAdminPort    int
 	verboseProxyConfig      bool
 
 	address, listenerType, statsType string
@@ -233,7 +233,7 @@ func setupEnvoyServerStatsConfig(podName, podNamespace string, outputFormat stri
 		return "", fmt.Errorf("failed to create Kubernetes client: %v", err)
 	}
 	path := "stats"
-	port := 15000
+	port := proxyAdminPort
 	if outputFormat == jsonOutput || outputFormat == yamlOutput {
 		// for yaml output we will convert the json to yaml when printed
 		path += "?format=json"
@@ -500,6 +500,7 @@ func allConfigCmd() *cobra.Command {
 	allConfigCmd.PersistentFlags().StringVarP(&configDumpFile, "file", "f", "",
 		"Envoy config dump file")
 	allConfigCmd.PersistentFlags().BoolVar(&verboseProxyConfig, "verbose", true, "Output more information")
+	allConfigCmd.PersistentFlags().IntVar(&proxyAdminPort, "proxyAdminPort", 15000, "Port on which Envoy listen for administrative commands")
 
 	// cluster
 	allConfigCmd.PersistentFlags().StringVar(&fqdn, "fqdn", "", "Filter clusters by substring of Service FQDN field")


### PR DESCRIPTION
Envoy admin port can be overwrite via [meshconfig.defaultConfig.proxyAdminPort](https://istio.io/latest/docs/reference/config/istio.mesh.v1alpha1/#ProxyConfig:~:text=No-,proxyAdminPort,-int32), this pr adds `--proxyAdminPort` to accomodate that 

- [X] istioctl

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
