### PR TITLE
Place `istio.metadata_exchange` before RBAC filters for network and HTTP filters

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/listener_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_builder.go
@@ -363,7 +363,7 @@ func (lb *ListenerBuilder) buildHTTPConnectionManager(httpOpts *httpListenerOpts
 	})
 
 	// Metadata exchange filter needs to be added before any other HTTP filters are added. This is done to
-	// ensure that mx filter comes before HTTP RBAC filter. This is related to https://github.com/tetrateio/tetrate/issues/13093
+	// ensure that mx filter comes before HTTP RBAC filter. This is related to https://github.com/istio/istio/issues/41066
 	if features.MetadataExchange {
 		filters = append(filters, xdsfilters.HTTPMx)
 	}

--- a/releasenotes/notes/41066.yaml
+++ b/releasenotes/notes/41066.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 41066
+
+releaseNotes:
+  - |
+    **Fixed** the ordering of RBAC and metadata exchange filters while generating HTTP/network filters


### PR DESCRIPTION
**Please provide a description of this PR:**
Fixes https://github.com/istio/istio/issues/41066
RBAC filter shows up before metadata exchange filter for both network and HTTP (subfilters of http_connection_manager) filters. This was preventing the metadata to be populated for requests that were denied (403 in case of HTTP or dial failed for TCP) in OAP access logs. 
This PR fixes the order by putting `istio.metadata_exchange` filter before RBAC filter for HTTP filters. For TCP however, the ordering was correct (after changes introduced by https://github.com/istio/istio/pull/38652), so this PR just adds a unit test for the TCP case.

This exists in istio 1.13, 1.14 and 1.15 as well. Will raise backports once this is merged.