### PR TITLE
Failover validation

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/loadbalancer/loadbalancer.go
+++ b/pilot/pkg/networking/core/v1alpha3/loadbalancer/loadbalancer.go
@@ -26,7 +26,6 @@ import (
 	"istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/util"
-	"istio.io/pkg/log"
 )
 
 func GetLocalityLbSetting(
@@ -81,9 +80,6 @@ func ApplyLocalityLBSetting(
 			return
 		}
 		applyLocalityFailover(locality, loadAssignment, localityLB.Failover)
-	} else if !enableFailover && (len(localityLB.FailoverPriority) > 0 || len(localityLB.Failover) > 0) {
-		// Warning for DestinationRule occurs during validation, but meshConfig.localityLbSettings could still be missed here 
-		log.Warnf("failover configuration not applied due to missing outlier detection")
 	}
 }
 

--- a/pilot/pkg/networking/core/v1alpha3/loadbalancer/loadbalancer.go
+++ b/pilot/pkg/networking/core/v1alpha3/loadbalancer/loadbalancer.go
@@ -26,6 +26,7 @@ import (
 	"istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/util"
+	"istio.io/pkg/log"
 )
 
 func GetLocalityLbSetting(
@@ -80,6 +81,9 @@ func ApplyLocalityLBSetting(
 			return
 		}
 		applyLocalityFailover(locality, loadAssignment, localityLB.Failover)
+	} else if !enableFailover && (len(localityLB.FailoverPriority) > 0 || len(localityLB.Failover) > 0) {
+		// Warning for DestinationRule occurs during validation, but meshConfig.localityLbSettings could still be missed here 
+		log.Warnf("failover configuration not applied due to missing outlier detection")
 	}
 }
 

--- a/pkg/config/mesh/mesh.go
+++ b/pkg/config/mesh/mesh.go
@@ -250,7 +250,7 @@ func ApplyMeshConfig(yaml string, defaultConfig *meshconfig.MeshConfig) (*meshco
 		return nil, err
 	}
 	if warn != nil {
-		log.Warnf("warnings ocurred during mesh validation: %v", warn)
+		log.Warnf("warnings occurred during mesh validation: %v", warn)
 	}
 
 	return defaultConfig, nil

--- a/pkg/config/mesh/mesh.go
+++ b/pkg/config/mesh/mesh.go
@@ -31,6 +31,7 @@ import (
 	"istio.io/istio/pkg/config/validation"
 	"istio.io/istio/pkg/util/protomarshal"
 	"istio.io/istio/pkg/util/sets"
+	"istio.io/pkg/log"
 )
 
 // DefaultProxyConfig for individual proxies
@@ -244,8 +245,12 @@ func ApplyMeshConfig(yaml string, defaultConfig *meshconfig.MeshConfig) (*meshco
 
 	defaultConfig.TrustDomainAliases = sets.New(append(defaultConfig.TrustDomainAliases, prevTrustDomainAliases...)...).SortedList()
 
-	if err := validation.ValidateMeshConfig(defaultConfig); err != nil {
+	warn, err := validation.ValidateMeshConfig(defaultConfig)
+	if err != nil {
 		return nil, err
+	}
+	if warn != nil {
+		log.Warnf("warnings ocurred during mesh validation: %v", warn)
 	}
 
 	return defaultConfig, nil

--- a/pkg/config/mesh/mesh_test.go
+++ b/pkg/config/mesh/mesh_test.go
@@ -120,8 +120,12 @@ func TestDefaultProxyConfig(t *testing.T) {
 }
 
 func TestDefaultMeshConfig(t *testing.T) {
-	if err := validation.ValidateMeshConfig(mesh.DefaultMeshConfig()); err != nil {
+	warn, err := validation.ValidateMeshConfig(mesh.DefaultMeshConfig())
+	if err != nil {
 		t.Errorf("validation of default mesh config failed with %v", err)
+	}
+	if warn != nil {
+		t.Errorf("validation of default mesh config produced warnings: %v", warn)
 	}
 }
 

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -1470,9 +1470,8 @@ func validateLoadBalancer(settings *networking.LoadBalancerSettings, outlier *ne
 			errs = appendValidation(errs, fmt.Errorf("only one of MinimumRingSize or Maglev/Ringhash can be specified"))
 		}
 	}
-	if err := validateLocalityLbSetting(settings.LocalityLbSetting, outlier); err != nil {
-		errs = appendValidation(errs, err)
-	}
+
+	errs = appendValidation(errs, validateLocalityLbSetting(settings.LocalityLbSetting, outlier))
 	return
 }
 
@@ -1697,42 +1696,35 @@ func IsNegativeDuration(in time.Duration) error {
 }
 
 // ValidateMeshConfig checks that the mesh config is well-formed
-func ValidateMeshConfig(mesh *meshconfig.MeshConfig) (errs error) {
+func ValidateMeshConfig(mesh *meshconfig.MeshConfig) (Warning, error) {
+	v := Validation{}
 	if err := ValidatePort(int(mesh.ProxyListenPort)); err != nil {
-		errs = multierror.Append(errs, multierror.Prefix(err, "invalid proxy listen port:"))
+		v = appendValidation(v, multierror.Prefix(err, "invalid proxy listen port:"))
 	}
 
 	if err := ValidateConnectTimeout(mesh.ConnectTimeout); err != nil {
-		errs = multierror.Append(errs, multierror.Prefix(err, "invalid connect timeout:"))
+		v = appendValidation(v, multierror.Prefix(err, "invalid connect timeout:"))
 	}
 
 	if err := ValidateProtocolDetectionTimeout(mesh.ProtocolDetectionTimeout); err != nil {
-		errs = multierror.Append(errs, multierror.Prefix(err, "invalid protocol detection timeout:"))
+		v = appendValidation(v, multierror.Prefix(err, "invalid protocol detection timeout:"))
 	}
 
 	if mesh.DefaultConfig == nil {
-		errs = multierror.Append(errs, errors.New("missing default config"))
-	} else if err := ValidateMeshConfigProxyConfig(mesh.DefaultConfig); err != nil {
-		errs = multierror.Append(errs, err)
+		v = appendValidation(v, errors.New("missing default config"))
+	} else {
+		v = appendValidation(v, ValidateMeshConfigProxyConfig(mesh.DefaultConfig))
 	}
 
-	if err := validateLocalityLbSetting(mesh.LocalityLbSetting, &networking.OutlierDetection{}); err != nil {
-		errs = multierror.Append(errs, err)
-	}
-
-	if err := validateServiceSettings(mesh); err != nil {
-		errs = multierror.Append(errs, err)
-	}
-
-	if err := validateTrustDomainConfig(mesh); err != nil {
-		errs = multierror.Append(errs, err)
-	}
+	v = appendValidation(v, validateLocalityLbSetting(mesh.LocalityLbSetting, &networking.OutlierDetection{}))
+	v = appendValidation(v, validateServiceSettings(mesh))
+	v = appendValidation(v, validateTrustDomainConfig(mesh))
 
 	if err := validateExtensionProvider(mesh); err != nil {
 		scope.Warnf("found invalid extension provider (can be ignored if the given extension provider is not used): %v", err)
 	}
 
-	return
+	return v.Unwrap()
 }
 
 func validateTrustDomainConfig(config *meshconfig.MeshConfig) (errs error) {
@@ -3472,13 +3464,14 @@ func appendErrors(err error, errs ...error) error {
 }
 
 // validateLocalityLbSetting checks the LocalityLbSetting of MeshConfig
-func validateLocalityLbSetting(lb *networking.LocalityLoadBalancerSetting, outlier *networking.OutlierDetection) error {
+func validateLocalityLbSetting(lb *networking.LocalityLoadBalancerSetting, outlier *networking.OutlierDetection) (errs Validation) {
 	if lb == nil {
-		return nil
+		return
 	}
 
 	if len(lb.GetDistribute()) > 0 && len(lb.GetFailover()) > 0 {
-		return fmt.Errorf("can not simultaneously specify 'distribute' and 'failover'")
+		errs = appendValidation(errs, fmt.Errorf("can not simultaneously specify 'distribute' and 'failover'"))
+		return
 	}
 
 	srcLocalities := make([]string, 0, len(lb.GetDistribute()))
@@ -3489,39 +3482,37 @@ func validateLocalityLbSetting(lb *networking.LocalityLoadBalancerSetting, outli
 		for loc, weight := range locality.To {
 			destLocalities = append(destLocalities, loc)
 			if weight <= 0 || weight > 100 {
-				return fmt.Errorf("locality weight must be in range [1, 100]")
+				errs = appendValidation(errs, fmt.Errorf("locality weight must be in range [1, 100]"))
+				return
 			}
 			totalWeight += weight
 		}
 		if totalWeight != 100 {
-			return fmt.Errorf("total locality weight %v != 100", totalWeight)
+			errs = appendValidation(errs, fmt.Errorf("total locality weight %v != 100", totalWeight))
+			return
 		}
-		if err := validateLocalities(destLocalities); err != nil {
-			return err
-		}
+		errs = appendValidation(errs, validateLocalities(destLocalities))
 	}
 
-	if err := validateLocalities(srcLocalities); err != nil {
-		return err
-	}
+	errs = appendValidation(errs, validateLocalities(srcLocalities))
 
 	if (len(lb.GetFailover()) != 0 || len(lb.GetFailoverPriority()) != 0) && outlier == nil {
-		return fmt.Errorf("outlier detection poicy must be provided for failover")
+		errs = appendValidation(errs, WrapWarning(fmt.Errorf("outlier detection poicy must be provided for failover")))
 	}
 
 	for _, failover := range lb.GetFailover() {
 		if failover.From == failover.To {
-			return fmt.Errorf("locality lb failover settings must specify different regions")
+			errs = appendValidation(errs, fmt.Errorf("locality lb failover settings must specify different regions"))
 		}
 		if strings.Contains(failover.From, "/") || strings.Contains(failover.To, "/") {
-			return fmt.Errorf("locality lb failover only specify region")
+			errs = appendValidation(errs, fmt.Errorf("locality lb failover only specify region"))
 		}
 		if strings.Contains(failover.To, "*") || strings.Contains(failover.From, "*") {
-			return fmt.Errorf("locality lb failover region should not contain '*' wildcard")
+			errs = appendValidation(errs, fmt.Errorf("locality lb failover region should not contain '*' wildcard"))
 		}
 	}
 
-	return nil
+	return
 }
 
 func validateLocalities(localities []string) error {

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -3909,7 +3909,7 @@ func TestValidateLoadBalancer(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		if got := validateLoadBalancer(c.in); (got.Err == nil) != c.valid {
+		if got := validateLoadBalancer(c.in, nil); (got.Err == nil) != c.valid {
 			t.Errorf("validateLoadBalancer failed on %v: got valid=%v but wanted valid=%v: %v",
 				c.name, got.Err == nil, c.valid, got)
 		}
@@ -6629,147 +6629,188 @@ func TestValidateSidecar(t *testing.T) {
 
 func TestValidateLocalityLbSetting(t *testing.T) {
 	cases := []struct {
-		name  string
-		in    *networking.LocalityLoadBalancerSetting
-		valid bool
+		name    string
+		in      *networking.LocalityLoadBalancerSetting
+		outlier *networking.OutlierDetection
+		valid   bool
 	}{
-		{
-			name:  "valid mesh config without LocalityLoadBalancerSetting",
-			in:    nil,
-			valid: true,
-		},
+		// {
+		// 	name:    "valid mesh config without LocalityLoadBalancerSetting",
+		// 	in:      nil,
+		// 	outlier: nil,
+		// 	valid:   true,
+		// },
 
-		{
-			name: "invalid LocalityLoadBalancerSetting_Distribute total weight > 100",
-			in: &networking.LocalityLoadBalancerSetting{
-				Distribute: []*networking.LocalityLoadBalancerSetting_Distribute{
-					{
-						From: "a/b/c",
-						To: map[string]uint32{
-							"a/b/c": 80,
-							"a/b1":  25,
-						},
-					},
-				},
-			},
-			valid: false,
-		},
-		{
-			name: "invalid LocalityLoadBalancerSetting_Distribute total weight < 100",
-			in: &networking.LocalityLoadBalancerSetting{
-				Distribute: []*networking.LocalityLoadBalancerSetting_Distribute{
-					{
-						From: "a/b/c",
-						To: map[string]uint32{
-							"a/b/c": 80,
-							"a/b1":  15,
-						},
-					},
-				},
-			},
-			valid: false,
-		},
-		{
-			name: "invalid LocalityLoadBalancerSetting_Distribute weight = 0",
-			in: &networking.LocalityLoadBalancerSetting{
-				Distribute: []*networking.LocalityLoadBalancerSetting_Distribute{
-					{
-						From: "a/b/c",
-						To: map[string]uint32{
-							"a/b/c": 0,
-							"a/b1":  100,
-						},
-					},
-				},
-			},
-			valid: false,
-		},
-		{
-			name: "invalid LocalityLoadBalancerSetting specify both distribute and failover",
-			in: &networking.LocalityLoadBalancerSetting{
-				Distribute: []*networking.LocalityLoadBalancerSetting_Distribute{
-					{
-						From: "a/b/c",
-						To: map[string]uint32{
-							"a/b/c": 80,
-							"a/b1":  20,
-						},
-					},
-				},
-				Failover: []*networking.LocalityLoadBalancerSetting_Failover{
-					{
-						From: "region1",
-						To:   "region2",
-					},
-				},
-			},
-			valid: false,
-		},
+		// {
+		// 	name: "invalid LocalityLoadBalancerSetting_Distribute total weight > 100",
+		// 	in: &networking.LocalityLoadBalancerSetting{
+		// 		Distribute: []*networking.LocalityLoadBalancerSetting_Distribute{
+		// 			{
+		// 				From: "a/b/c",
+		// 				To: map[string]uint32{
+		// 					"a/b/c": 80,
+		// 					"a/b1":  25,
+		// 				},
+		// 			},
+		// 		},
+		// 	},
+		// 	outlier: &networking.OutlierDetection{},
+		// 	valid:   false,
+		// },
+		// {
+		// 	name: "invalid LocalityLoadBalancerSetting_Distribute total weight < 100",
+		// 	in: &networking.LocalityLoadBalancerSetting{
+		// 		Distribute: []*networking.LocalityLoadBalancerSetting_Distribute{
+		// 			{
+		// 				From: "a/b/c",
+		// 				To: map[string]uint32{
+		// 					"a/b/c": 80,
+		// 					"a/b1":  15,
+		// 				},
+		// 			},
+		// 		},
+		// 	},
+		// 	outlier: &networking.OutlierDetection{},
+		// 	valid:   false,
+		// },
+		// {
+		// 	name: "invalid LocalityLoadBalancerSetting_Distribute weight = 0",
+		// 	in: &networking.LocalityLoadBalancerSetting{
+		// 		Distribute: []*networking.LocalityLoadBalancerSetting_Distribute{
+		// 			{
+		// 				From: "a/b/c",
+		// 				To: map[string]uint32{
+		// 					"a/b/c": 0,
+		// 					"a/b1":  100,
+		// 				},
+		// 			},
+		// 		},
+		// 	},
+		// 	outlier: &networking.OutlierDetection{},
+		// 	valid:   false,
+		// },
+		// {
+		// 	name: "invalid LocalityLoadBalancerSetting specify both distribute and failover",
+		// 	in: &networking.LocalityLoadBalancerSetting{
+		// 		Distribute: []*networking.LocalityLoadBalancerSetting_Distribute{
+		// 			{
+		// 				From: "a/b/c",
+		// 				To: map[string]uint32{
+		// 					"a/b/c": 80,
+		// 					"a/b1":  20,
+		// 				},
+		// 			},
+		// 		},
+		// 		Failover: []*networking.LocalityLoadBalancerSetting_Failover{
+		// 			{
+		// 				From: "region1",
+		// 				To:   "region2",
+		// 			},
+		// 		},
+		// 	},
+		// 	outlier: &networking.OutlierDetection{},
+		// 	valid:   false,
+		// },
 
+		// {
+		// 	name: "invalid failover src and dst have same region",
+		// 	in: &networking.LocalityLoadBalancerSetting{
+		// 		Failover: []*networking.LocalityLoadBalancerSetting_Failover{
+		// 			{
+		// 				From: "region1",
+		// 				To:   "region1",
+		// 			},
+		// 		},
+		// 	},
+		// 	outlier: &networking.OutlierDetection{},
+		// 	valid:   false,
+		// },
+		// {
+		// 	name: "invalid failover src contain '*' wildcard",
+		// 	in: &networking.LocalityLoadBalancerSetting{
+		// 		Failover: []*networking.LocalityLoadBalancerSetting_Failover{
+		// 			{
+		// 				From: "*",
+		// 				To:   "region2",
+		// 			},
+		// 		},
+		// 	},
+		// 	outlier: &networking.OutlierDetection{},
+		// 	valid:   false,
+		// },
+		// {
+		// 	name: "invalid failover dst contain '*' wildcard",
+		// 	in: &networking.LocalityLoadBalancerSetting{
+		// 		Failover: []*networking.LocalityLoadBalancerSetting_Failover{
+		// 			{
+		// 				From: "region1",
+		// 				To:   "*",
+		// 			},
+		// 		},
+		// 	},
+		// 	outlier: &networking.OutlierDetection{},
+		// 	valid:   false,
+		// },
+		// {
+		// 	name: "invalid failover src contain '/' separator",
+		// 	in: &networking.LocalityLoadBalancerSetting{
+		// 		Failover: []*networking.LocalityLoadBalancerSetting_Failover{
+		// 			{
+		// 				From: "region1/zone1",
+		// 				To:   "region2",
+		// 			},
+		// 		},
+		// 	},
+		// 	outlier: &networking.OutlierDetection{},
+		// 	valid:   false,
+		// },
+		// {
+		// 	name: "invalid failover dst contain '/' separator",
+		// 	in: &networking.LocalityLoadBalancerSetting{
+		// 		Failover: []*networking.LocalityLoadBalancerSetting_Failover{
+		// 			{
+		// 				From: "region1",
+		// 				To:   "region2/zone1",
+		// 			},
+		// 		},
+		// 	},
+		// 	outlier: &networking.OutlierDetection{},
+		// 	valid:   false,
+		// },
 		{
-			name: "invalid failover src and dst have same region",
+			name: "failover priority provided without outlier detection policy",
 			in: &networking.LocalityLoadBalancerSetting{
-				Failover: []*networking.LocalityLoadBalancerSetting_Failover{
-					{
-						From: "region1",
-						To:   "region1",
-					},
+				FailoverPriority: []string{
+					"topology.istio.io/network",
+					"topology.kubernetes.io/region",
+					"topology.kubernetes.io/zone",
+					"topology.istio.io/subzone",
 				},
 			},
-			valid: false,
+			outlier: nil,
+			valid:   false,
 		},
 		{
-			name: "invalid failover src contain '*' wildcard",
+			name: "failover provided without outlier detection policy",
 			in: &networking.LocalityLoadBalancerSetting{
 				Failover: []*networking.LocalityLoadBalancerSetting_Failover{
 					{
-						From: "*",
-						To:   "region2",
+						From: "us-east",
+						To:   "eu-west",
 					},
-				},
-			},
-			valid: false,
-		},
-		{
-			name: "invalid failover dst contain '*' wildcard",
-			in: &networking.LocalityLoadBalancerSetting{
-				Failover: []*networking.LocalityLoadBalancerSetting_Failover{
 					{
-						From: "region1",
-						To:   "*",
+						From: "us-west",
+						To:   "eu-east",
 					},
 				},
 			},
-			valid: false,
-		},
-		{
-			name: "invalid failover src contain '/' separator",
-			in: &networking.LocalityLoadBalancerSetting{
-				Failover: []*networking.LocalityLoadBalancerSetting_Failover{
-					{
-						From: "region1/zone1",
-						To:   "region2",
-					},
-				},
-			},
-			valid: false,
-		},
-		{
-			name: "invalid failover dst contain '/' separator",
-			in: &networking.LocalityLoadBalancerSetting{
-				Failover: []*networking.LocalityLoadBalancerSetting_Failover{
-					{
-						From: "region1",
-						To:   "region2/zone1",
-					},
-				},
-			},
-			valid: false,
+			outlier: nil,
+			valid:   false,
 		},
 	}
 
 	for _, c := range cases {
-		if got := validateLocalityLbSetting(c.in); (got == nil) != c.valid {
+		if got := validateLocalityLbSetting(c.in, nil); (got == nil) != c.valid {
 			t.Errorf("ValidateLocalityLbSetting failed on %v: got valid=%v but wanted valid=%v: %v",
 				c.name, got == nil, c.valid, got)
 		}

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -6634,149 +6634,149 @@ func TestValidateLocalityLbSetting(t *testing.T) {
 		outlier *networking.OutlierDetection
 		valid   bool
 	}{
-		// {
-		// 	name:    "valid mesh config without LocalityLoadBalancerSetting",
-		// 	in:      nil,
-		// 	outlier: nil,
-		// 	valid:   true,
-		// },
+		{
+			name:    "valid mesh config without LocalityLoadBalancerSetting",
+			in:      nil,
+			outlier: nil,
+			valid:   true,
+		},
 
-		// {
-		// 	name: "invalid LocalityLoadBalancerSetting_Distribute total weight > 100",
-		// 	in: &networking.LocalityLoadBalancerSetting{
-		// 		Distribute: []*networking.LocalityLoadBalancerSetting_Distribute{
-		// 			{
-		// 				From: "a/b/c",
-		// 				To: map[string]uint32{
-		// 					"a/b/c": 80,
-		// 					"a/b1":  25,
-		// 				},
-		// 			},
-		// 		},
-		// 	},
-		// 	outlier: &networking.OutlierDetection{},
-		// 	valid:   false,
-		// },
-		// {
-		// 	name: "invalid LocalityLoadBalancerSetting_Distribute total weight < 100",
-		// 	in: &networking.LocalityLoadBalancerSetting{
-		// 		Distribute: []*networking.LocalityLoadBalancerSetting_Distribute{
-		// 			{
-		// 				From: "a/b/c",
-		// 				To: map[string]uint32{
-		// 					"a/b/c": 80,
-		// 					"a/b1":  15,
-		// 				},
-		// 			},
-		// 		},
-		// 	},
-		// 	outlier: &networking.OutlierDetection{},
-		// 	valid:   false,
-		// },
-		// {
-		// 	name: "invalid LocalityLoadBalancerSetting_Distribute weight = 0",
-		// 	in: &networking.LocalityLoadBalancerSetting{
-		// 		Distribute: []*networking.LocalityLoadBalancerSetting_Distribute{
-		// 			{
-		// 				From: "a/b/c",
-		// 				To: map[string]uint32{
-		// 					"a/b/c": 0,
-		// 					"a/b1":  100,
-		// 				},
-		// 			},
-		// 		},
-		// 	},
-		// 	outlier: &networking.OutlierDetection{},
-		// 	valid:   false,
-		// },
-		// {
-		// 	name: "invalid LocalityLoadBalancerSetting specify both distribute and failover",
-		// 	in: &networking.LocalityLoadBalancerSetting{
-		// 		Distribute: []*networking.LocalityLoadBalancerSetting_Distribute{
-		// 			{
-		// 				From: "a/b/c",
-		// 				To: map[string]uint32{
-		// 					"a/b/c": 80,
-		// 					"a/b1":  20,
-		// 				},
-		// 			},
-		// 		},
-		// 		Failover: []*networking.LocalityLoadBalancerSetting_Failover{
-		// 			{
-		// 				From: "region1",
-		// 				To:   "region2",
-		// 			},
-		// 		},
-		// 	},
-		// 	outlier: &networking.OutlierDetection{},
-		// 	valid:   false,
-		// },
+		{
+			name: "invalid LocalityLoadBalancerSetting_Distribute total weight > 100",
+			in: &networking.LocalityLoadBalancerSetting{
+				Distribute: []*networking.LocalityLoadBalancerSetting_Distribute{
+					{
+						From: "a/b/c",
+						To: map[string]uint32{
+							"a/b/c": 80,
+							"a/b1":  25,
+						},
+					},
+				},
+			},
+			outlier: &networking.OutlierDetection{},
+			valid:   false,
+		},
+		{
+			name: "invalid LocalityLoadBalancerSetting_Distribute total weight < 100",
+			in: &networking.LocalityLoadBalancerSetting{
+				Distribute: []*networking.LocalityLoadBalancerSetting_Distribute{
+					{
+						From: "a/b/c",
+						To: map[string]uint32{
+							"a/b/c": 80,
+							"a/b1":  15,
+						},
+					},
+				},
+			},
+			outlier: &networking.OutlierDetection{},
+			valid:   false,
+		},
+		{
+			name: "invalid LocalityLoadBalancerSetting_Distribute weight = 0",
+			in: &networking.LocalityLoadBalancerSetting{
+				Distribute: []*networking.LocalityLoadBalancerSetting_Distribute{
+					{
+						From: "a/b/c",
+						To: map[string]uint32{
+							"a/b/c": 0,
+							"a/b1":  100,
+						},
+					},
+				},
+			},
+			outlier: &networking.OutlierDetection{},
+			valid:   false,
+		},
+		{
+			name: "invalid LocalityLoadBalancerSetting specify both distribute and failover",
+			in: &networking.LocalityLoadBalancerSetting{
+				Distribute: []*networking.LocalityLoadBalancerSetting_Distribute{
+					{
+						From: "a/b/c",
+						To: map[string]uint32{
+							"a/b/c": 80,
+							"a/b1":  20,
+						},
+					},
+				},
+				Failover: []*networking.LocalityLoadBalancerSetting_Failover{
+					{
+						From: "region1",
+						To:   "region2",
+					},
+				},
+			},
+			outlier: &networking.OutlierDetection{},
+			valid:   false,
+		},
 
-		// {
-		// 	name: "invalid failover src and dst have same region",
-		// 	in: &networking.LocalityLoadBalancerSetting{
-		// 		Failover: []*networking.LocalityLoadBalancerSetting_Failover{
-		// 			{
-		// 				From: "region1",
-		// 				To:   "region1",
-		// 			},
-		// 		},
-		// 	},
-		// 	outlier: &networking.OutlierDetection{},
-		// 	valid:   false,
-		// },
-		// {
-		// 	name: "invalid failover src contain '*' wildcard",
-		// 	in: &networking.LocalityLoadBalancerSetting{
-		// 		Failover: []*networking.LocalityLoadBalancerSetting_Failover{
-		// 			{
-		// 				From: "*",
-		// 				To:   "region2",
-		// 			},
-		// 		},
-		// 	},
-		// 	outlier: &networking.OutlierDetection{},
-		// 	valid:   false,
-		// },
-		// {
-		// 	name: "invalid failover dst contain '*' wildcard",
-		// 	in: &networking.LocalityLoadBalancerSetting{
-		// 		Failover: []*networking.LocalityLoadBalancerSetting_Failover{
-		// 			{
-		// 				From: "region1",
-		// 				To:   "*",
-		// 			},
-		// 		},
-		// 	},
-		// 	outlier: &networking.OutlierDetection{},
-		// 	valid:   false,
-		// },
-		// {
-		// 	name: "invalid failover src contain '/' separator",
-		// 	in: &networking.LocalityLoadBalancerSetting{
-		// 		Failover: []*networking.LocalityLoadBalancerSetting_Failover{
-		// 			{
-		// 				From: "region1/zone1",
-		// 				To:   "region2",
-		// 			},
-		// 		},
-		// 	},
-		// 	outlier: &networking.OutlierDetection{},
-		// 	valid:   false,
-		// },
-		// {
-		// 	name: "invalid failover dst contain '/' separator",
-		// 	in: &networking.LocalityLoadBalancerSetting{
-		// 		Failover: []*networking.LocalityLoadBalancerSetting_Failover{
-		// 			{
-		// 				From: "region1",
-		// 				To:   "region2/zone1",
-		// 			},
-		// 		},
-		// 	},
-		// 	outlier: &networking.OutlierDetection{},
-		// 	valid:   false,
-		// },
+		{
+			name: "invalid failover src and dst have same region",
+			in: &networking.LocalityLoadBalancerSetting{
+				Failover: []*networking.LocalityLoadBalancerSetting_Failover{
+					{
+						From: "region1",
+						To:   "region1",
+					},
+				},
+			},
+			outlier: &networking.OutlierDetection{},
+			valid:   false,
+		},
+		{
+			name: "invalid failover src contain '*' wildcard",
+			in: &networking.LocalityLoadBalancerSetting{
+				Failover: []*networking.LocalityLoadBalancerSetting_Failover{
+					{
+						From: "*",
+						To:   "region2",
+					},
+				},
+			},
+			outlier: &networking.OutlierDetection{},
+			valid:   false,
+		},
+		{
+			name: "invalid failover dst contain '*' wildcard",
+			in: &networking.LocalityLoadBalancerSetting{
+				Failover: []*networking.LocalityLoadBalancerSetting_Failover{
+					{
+						From: "region1",
+						To:   "*",
+					},
+				},
+			},
+			outlier: &networking.OutlierDetection{},
+			valid:   false,
+		},
+		{
+			name: "invalid failover src contain '/' separator",
+			in: &networking.LocalityLoadBalancerSetting{
+				Failover: []*networking.LocalityLoadBalancerSetting_Failover{
+					{
+						From: "region1/zone1",
+						To:   "region2",
+					},
+				},
+			},
+			outlier: &networking.OutlierDetection{},
+			valid:   false,
+		},
+		{
+			name: "invalid failover dst contain '/' separator",
+			in: &networking.LocalityLoadBalancerSetting{
+				Failover: []*networking.LocalityLoadBalancerSetting_Failover{
+					{
+						From: "region1",
+						To:   "region2/zone1",
+					},
+				},
+			},
+			outlier: &networking.OutlierDetection{},
+			valid:   false,
+		},
 		{
 			name: "failover priority provided without outlier detection policy",
 			in: &networking.LocalityLoadBalancerSetting{

--- a/releasenotes/notes/failover-validation.yaml
+++ b/releasenotes/notes/failover-validation.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+
+releaseNotes:
+- |
+  **Added** warning validation messages when a DestinationRule specifies failover policies but does not provide an OutlierDetection policy.
+  Previously, istiod was silently ignoring the failover settings 


### PR DESCRIPTION
**Please provide a description of this PR:**

Adds validation and logging in the event Failover is specified in a DestinationRule without configuring OutlierDetection.  Istiod is currently silently not applying any failover settings if outlier detection settings are not provided:

[link](https://github.com/istio/istio/blob/master/pilot/pkg/networking/core/v1alpha3/cluster.go#L854)
```
	// Failover should only be applied with outlier detection, or traffic will never failover.
	enabledFailover := cluster.OutlierDetection != nil
	if cluster.LoadAssignment != nil {
		// TODO: enable failoverPriority for `STRICT_DNS` cluster type
		loadbalancer.ApplyLocalityLBSetting(cluster.LoadAssignment, nil, locality, proxyLabels, localityLB, enabledFailover)
	}
```

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ X ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure