### PR TITLE
Set seccompProfile on Envoy sidecar

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
@@ -132,6 +132,8 @@ spec:
     securityContext:
       allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
       privileged: {{ .Values.global.proxy.privileged }}
+      seccompProfile:
+        {{ toYaml .Values.global.proxy.seccompProfile | trim | indent 2 }}
       capabilities:
     {{- if not .Values.istio_cni.enabled }}
         add:
@@ -365,6 +367,8 @@ spec:
       runAsNonRoot: true
       runAsUser: 1337
       {{- end }}
+      seccompProfile:
+        {{ toYaml .Values.global.proxy.seccompProfile | trim | indent 2 }}
       {{- end }}
     resources:
   {{ template "resources" . }}

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -338,7 +338,7 @@ global:
     # Expected values are: trace|debug|info|warning|error|critical|off
     logLevel: warning
 
-    #If set to true, istio-proxy container will have privileged securityContext
+    # If set to true, istio-proxy container will have privileged securityContext
     privileged: false
 
     # The number of successive failed probes before indicating readiness failure.
@@ -358,6 +358,9 @@ global:
       limits:
         cpu: 2000m
         memory: 1024Mi
+
+    # Set to `type: RuntimeDefault` to use the default profile if available.
+    seccompProfile: {}
 
     # Default port for Pilot agent health checks. A value of 0 will disable health checking.
     statusPort: 15020


### PR DESCRIPTION
(This is used to request new product features, please visit https://discuss.istio.io/ for questions on using Istio)

Describe the feature request

Set seccompProfile in the security context for the containers in the Envoy sidecar istio-validation and istio-proxy so that when istiod is installed with istio cni enabled, the sidecar containers obey the restricted pod security standards https://kubernetes.io/docs/concepts/security/pod-security-standards/

Describe alternatives you've considered

I don't know of any way to do this without setting this

Affected product area (please put an X in all that apply)

[ ] Ambient
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Extensions and Telemetry
[x] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure

Affected features (please put an X in all that apply)

[ ] Multi Cluster
[ ] Virtual Machine
[ ] Multi Control Plane

Additional context