### PR TITLE
Remove my 15 minutes of fame in gcp_bootstrap

### DIFF
--- a/tools/packaging/common/gcp_envoy_bootstrap.json
+++ b/tools/packaging/common/gcp_envoy_bootstrap.json
@@ -93,7 +93,7 @@
             "target_uri": "{{ .discovery_address }}",
             "stat_prefix": "googlegrpcxds",
             "channel_credentials": {
-              "ssl_credentials": {"root_certs": {"filename": "/usr/local/google/home/howardjohn/go/src/istio.io/istio/tests/testdata/certs/pilot/root-cert.pem"}}
+              "ssl_credentials": {}
             },
             "call_credentials": [{
             {{ if .sts }}


### PR DESCRIPTION
I am following up on if this file is still needed, since clearly it had a major bug for a while undetected.

**Please provide a description of this PR:**