### PR TITLE
[1.15] gateway-api: fix an issue causing Informers to fail

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -103,6 +103,8 @@ require (
 	sigs.k8s.io/yaml v1.3.0
 )
 
+replace sigs.k8s.io/gateway-api => github.com/istio/gateway-api v0.0.0-20221006194514-510afb48c902
+
 require github.com/emicklei/go-restful/v3 v3.8.0 // indirect
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -906,6 +906,8 @@ github.com/imdario/mergo v0.3.5 h1:JboBksRwiiAJWvIYJVo46AfV+IAIKZpfrSzVKj42R4Q=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/istio/gateway-api v0.0.0-20221006194514-510afb48c902 h1:HO3PWUQcKjEV7P8I9qufLXw0m8BvIcbOXAfJIRLba2Q=
+github.com/istio/gateway-api v0.0.0-20221006194514-510afb48c902/go.mod h1:W3V6rE55Qx6C+llroEEzsRkmDcmoPxgm+uwMCR2MUrs=
 github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56/go.mod h1:ymszkNOg6tORTn+6F6j+Jc8TOr5osrynvN6ivFWZ2GA=
 github.com/jellevandenhooff/dkim v0.0.0-20150330215556-f50fe3d243e1/go.mod h1:E0B/fFc00Y+Rasa88328GlI/XbtyysCtTHZS8h7IrBU=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
@@ -2539,8 +2541,6 @@ sigs.k8s.io/controller-runtime v0.6.1/go.mod h1:XRYBPdbf5XJu9kpS84VJiZ7h/u1hF3gE
 sigs.k8s.io/controller-runtime v0.12.2 h1:nqV02cvhbAj7tbt21bpPpTByrXGn2INHRsi39lXy9sE=
 sigs.k8s.io/controller-runtime v0.12.2/go.mod h1:qKsk4WE6zW2Hfj0G4v10EnNB2jMG1C+NTb8h+DwCoU0=
 sigs.k8s.io/controller-tools v0.3.0/go.mod h1:enhtKGfxZD1GFEoMgP8Fdbu+uKQ/cq1/WGJhdVChfvI=
-sigs.k8s.io/gateway-api v0.5.1-0.20220921185115-ee7a83814203 h1:t53lCjyZa7bsj1vZbAboYAH0p0OpqdGpGeM30IZIew8=
-sigs.k8s.io/gateway-api v0.5.1-0.20220921185115-ee7a83814203/go.mod h1:x0AP6gugkFV8fC/oTlnOMU0pnmuzIR8LfIPRVUjxSqA=
 sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 h1:kDi4JBNAsJWfz1aEXhO8Jg87JJaPNLh5tIzYHgStQ9Y=
 sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2/go.mod h1:B+TnT182UBxE84DiCz4CVE26eOSDAeYCpfDnC2kdKMY=
 sigs.k8s.io/kind v0.8.1/go.mod h1:oNKTxUVPYkV9lWzY6CVMNluVq8cBsyq+UgPJdvA3uu4=

--- a/pilot/pkg/config/kube/gateway/deploymentcontroller_v1alpha2.go
+++ b/pilot/pkg/config/kube/gateway/deploymentcontroller_v1alpha2.go
@@ -38,7 +38,6 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"istio.io/istio/pkg/config"
-	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/controllers"
 	istiolog "istio.io/pkg/log"
@@ -103,7 +102,7 @@ func NewDeploymentControllerV1Alpha2(client kube.Client) *DeploymentControllerV1
 	// Set up a handler that will add the parent Gateway object onto the queue.
 	// The queue will only handle Gateway objects; if child resources (Service, etc) are updated we re-add
 	// the Gateway to the queue and reconcile the state of the world.
-	handler := controllers.ObjectHandler(controllers.EnqueueForParentHandler(dc.queue, gvk.KubernetesGateway))
+	handler := controllers.ObjectHandler(controllers.EnqueueForParentHandler(dc.queue, KubernetesGateway))
 
 	// Use the full informer, since we are already fetching all Services for other purposes
 	// If we somehow stop watching Services in the future we can add a label selector like below.
@@ -197,8 +196,8 @@ func (d *DeploymentControllerV1Alpha2) configureIstioGateway(log *istiolog.Scope
 
 	gws := &gateway.Gateway{
 		TypeMeta: metav1.TypeMeta{
-			Kind:       gvk.KubernetesGateway.Kind,
-			APIVersion: gvk.KubernetesGateway.Group + "/" + gvk.KubernetesGateway.Version,
+			Kind:       KubernetesGateway.Kind,
+			APIVersion: KubernetesGateway.Group + "/" + KubernetesGateway.Version,
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      gw.Name,
@@ -270,3 +269,5 @@ type deploymentInputV1Alpha2 struct {
 	*gateway.Gateway
 	KubeVersion122 bool
 }
+
+var KubernetesGateway = config.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Kind: "Gateway"}

--- a/pilot/pkg/config/kube/gateway/deploymentcontroller_v1alpha2_test.go
+++ b/pilot/pkg/config/kube/gateway/deploymentcontroller_v1alpha2_test.go
@@ -115,7 +115,7 @@ func TestConfigureIstioGatewayV1Alpha2(t *testing.T) {
 			}
 
 			resp := timestampRegex.ReplaceAll(buf.Bytes(), []byte("lastTransitionTime: fake"))
-			util.CompareContent(t, resp, filepath.Join("testdata", "deployment", tt.name+".yaml"))
+			util.CompareContent(t, resp, filepath.Join("testdata", "deployment", "alpha-"+tt.name+".yaml"))
 		})
 	}
 }

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/alpha-cluster-ip.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/alpha-cluster-ip.yaml
@@ -1,0 +1,101 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    networking.istio.io/service-type: ClusterIP
+  labels:
+    gateway.istio.io/managed: istio.io-gateway-controller
+  name: default
+  namespace: default
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1alpha2
+    kind: Gateway
+    name: default
+    uid: null
+spec:
+  ports:
+  - name: status-port
+    port: 15021
+    protocol: TCP
+  - name: http
+    port: 80
+    protocol: TCP
+  selector:
+    istio.io/gateway-name: default
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    networking.istio.io/service-type: ClusterIP
+  labels:
+    gateway.istio.io/managed: istio.io-gateway-controller
+  name: default
+  namespace: default
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1alpha2
+    kind: Gateway
+    name: default
+    uid: null
+spec:
+  selector:
+    matchLabels:
+      istio.io/gateway-name: default
+  template:
+    metadata:
+      annotations:
+        inject.istio.io/templates: gateway
+        networking.istio.io/service-type: ClusterIP
+      labels:
+        istio.io/gateway-name: default
+        sidecar.istio.io/inject: "true"
+    spec:
+      containers:
+      - image: auto
+        name: istio-proxy
+        ports:
+        - containerPort: 15021
+          name: status-port
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 10
+          httpGet:
+            path: /healthz/ready
+            port: 15021
+            scheme: HTTP
+          periodSeconds: 2
+          successThreshold: 1
+          timeoutSeconds: 2
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
+      securityContext:
+        sysctls:
+        - name: net.ipv4.ip_unprivileged_port_start
+          value: "0"
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: Gateway
+metadata:
+  creationTimestamp: null
+  name: default
+  namespace: default
+spec:
+  gatewayClassName: ""
+  listeners: null
+status:
+  conditions:
+  - lastTransitionTime: fake
+    message: Deployed gateway to the cluster
+    reason: ResourcesAvailable
+    status: "True"
+    type: Scheduled
+---

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/alpha-manual-ip.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/alpha-manual-ip.yaml
@@ -1,0 +1,96 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    gateway.istio.io/managed: istio.io-gateway-controller
+  name: default
+  namespace: default
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1alpha2
+    kind: Gateway
+    name: default
+    uid: null
+spec:
+  loadBalancerIP: 1.2.3.4
+  ports:
+  - name: status-port
+    port: 15021
+    protocol: TCP
+  selector:
+    istio.io/gateway-name: default
+  type: LoadBalancer
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations: {}
+  labels:
+    gateway.istio.io/managed: istio.io-gateway-controller
+  name: default
+  namespace: default
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1alpha2
+    kind: Gateway
+    name: default
+    uid: null
+spec:
+  selector:
+    matchLabels:
+      istio.io/gateway-name: default
+  template:
+    metadata:
+      annotations:
+        inject.istio.io/templates: gateway
+      labels:
+        istio.io/gateway-name: default
+        sidecar.istio.io/inject: "true"
+    spec:
+      containers:
+      - image: auto
+        name: istio-proxy
+        ports:
+        - containerPort: 15021
+          name: status-port
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 10
+          httpGet:
+            path: /healthz/ready
+            port: 15021
+            scheme: HTTP
+          periodSeconds: 2
+          successThreshold: 1
+          timeoutSeconds: 2
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
+      securityContext:
+        sysctls:
+        - name: net.ipv4.ip_unprivileged_port_start
+          value: "0"
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: Gateway
+metadata:
+  creationTimestamp: null
+  name: default
+  namespace: default
+spec:
+  gatewayClassName: ""
+  listeners: null
+status:
+  conditions:
+  - lastTransitionTime: fake
+    message: Deployed gateway to the cluster
+    reason: ResourcesAvailable
+    status: "True"
+    type: Scheduled
+---

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/alpha-multinetwork.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/alpha-multinetwork.yaml
@@ -1,0 +1,104 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    gateway.istio.io/managed: istio.io-gateway-controller
+    topology.istio.io/network: network-1
+  name: default
+  namespace: default
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1alpha2
+    kind: Gateway
+    name: default
+    uid: null
+spec:
+  ports:
+  - name: status-port
+    port: 15021
+    protocol: TCP
+  - name: http
+    port: 80
+    protocol: TCP
+  selector:
+    istio.io/gateway-name: default
+  type: LoadBalancer
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations: {}
+  labels:
+    gateway.istio.io/managed: istio.io-gateway-controller
+    topology.istio.io/network: network-1
+  name: default
+  namespace: default
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1alpha2
+    kind: Gateway
+    name: default
+    uid: null
+spec:
+  selector:
+    matchLabels:
+      istio.io/gateway-name: default
+  template:
+    metadata:
+      annotations:
+        inject.istio.io/templates: gateway
+      labels:
+        istio.io/gateway-name: default
+        sidecar.istio.io/inject: "true"
+        topology.istio.io/network: network-1
+    spec:
+      containers:
+      - env:
+        - name: ISTIO_META_REQUESTED_NETWORK_VIEW
+          value: network-1
+        image: auto
+        name: istio-proxy
+        ports:
+        - containerPort: 15021
+          name: status-port
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 10
+          httpGet:
+            path: /healthz/ready
+            port: 15021
+            scheme: HTTP
+          periodSeconds: 2
+          successThreshold: 1
+          timeoutSeconds: 2
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
+      securityContext:
+        sysctls:
+        - name: net.ipv4.ip_unprivileged_port_start
+          value: "0"
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: Gateway
+metadata:
+  creationTimestamp: null
+  name: default
+  namespace: default
+spec:
+  gatewayClassName: ""
+  listeners: null
+status:
+  conditions:
+  - lastTransitionTime: fake
+    message: Deployed gateway to the cluster
+    reason: ResourcesAvailable
+    status: "True"
+    type: Scheduled
+---

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/alpha-simple.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/alpha-simple.yaml
@@ -1,0 +1,95 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    gateway.istio.io/managed: istio.io-gateway-controller
+  name: default
+  namespace: default
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1alpha2
+    kind: Gateway
+    name: default
+    uid: null
+spec:
+  ports:
+  - name: status-port
+    port: 15021
+    protocol: TCP
+  selector:
+    istio.io/gateway-name: default
+  type: LoadBalancer
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations: {}
+  labels:
+    gateway.istio.io/managed: istio.io-gateway-controller
+  name: default
+  namespace: default
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1alpha2
+    kind: Gateway
+    name: default
+    uid: null
+spec:
+  selector:
+    matchLabels:
+      istio.io/gateway-name: default
+  template:
+    metadata:
+      annotations:
+        inject.istio.io/templates: gateway
+      labels:
+        istio.io/gateway-name: default
+        sidecar.istio.io/inject: "true"
+    spec:
+      containers:
+      - image: auto
+        name: istio-proxy
+        ports:
+        - containerPort: 15021
+          name: status-port
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 10
+          httpGet:
+            path: /healthz/ready
+            port: 15021
+            scheme: HTTP
+          periodSeconds: 2
+          successThreshold: 1
+          timeoutSeconds: 2
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
+      securityContext:
+        sysctls:
+        - name: net.ipv4.ip_unprivileged_port_start
+          value: "0"
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: Gateway
+metadata:
+  creationTimestamp: null
+  name: default
+  namespace: default
+spec:
+  gatewayClassName: ""
+  listeners: null
+status:
+  conditions:
+  - lastTransitionTime: fake
+    message: Deployed gateway to the cluster
+    reason: ResourcesAvailable
+    status: "True"
+    type: Scheduled
+---

--- a/pkg/kube/controllers/common.go
+++ b/pkg/kube/controllers/common.go
@@ -53,7 +53,7 @@ func UnstructuredToGVR(u unstructured.Unstructured) (schema.GroupVersionResource
 		Version: gv.Version,
 		Kind:    u.GetKind(),
 	}
-	found, ok := collections.All.FindByGroupVersionKind(gk)
+	found, ok := collections.All.FindByGroupVersionAliasesKind(gk)
 	if !ok {
 		return res, fmt.Errorf("unknown gvk: %v", gk)
 	}
@@ -74,7 +74,7 @@ func ObjectToGVR(u Object) (schema.GroupVersionResource, error) {
 		Version: gvk.Version,
 		Kind:    gvk.Kind,
 	}
-	found, ok := collections.All.FindByGroupVersionKind(gk)
+	found, ok := collections.All.FindByGroupVersionAliasesKind(gk)
 	if !ok {
 		return schema.GroupVersionResource{}, fmt.Errorf("unknown gvk: %v", gk)
 	}

--- a/releasenotes/notes/gateway-v1beta1.yaml
+++ b/releasenotes/notes/gateway-v1beta1.yaml
@@ -1,6 +1,8 @@
 apiVersion: release-notes/v2
 kind: feature
 area: traffic-management
+issues:
+- 41146
 releaseNotes:
 - |
-  **Upgraded** the gateway-api integration to read `v1beta1` resources for `HTTPRoute`, `Gateway`, and `GatewayClass`. Users of the gateway-api must be on v0.5.0+ before upgrading Istio.
+  **Fixed** the gateway-api integration to not fail when `v1alpha2` version is removed


### PR DESCRIPTION
This picks up https://github.com/kubernetes-sigs/gateway-api/pull/1439. Unfortunately we need to fork since the main branch in gateway-api has diverged too much.

Also fixes release note which was from master