### PR TITLE
[1.13] gateway-api: fix an issue causing Informers to fail

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ replace github.com/docker/docker => github.com/moby/moby v17.12.0-ce-rc1.0.20200
 // Client-go does not handle different versions of mergo due to some breaking changes - use the matching version
 replace github.com/imdario/mergo => github.com/imdario/mergo v0.3.5
 
-replace sigs.k8s.io/gateway-api => github.com/howardjohn/gateway-api v0.0.0-20221005154653-a3f8431575ae
+replace sigs.k8s.io/gateway-api => github.com/istio/gateway-api v0.0.0-20221006194514-510afb48c902
 
 require (
 	cloud.google.com/go/compute v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -818,8 +818,6 @@ github.com/hashicorp/memberlist v0.3.0/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOn
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/hashicorp/serf v0.9.5/go.mod h1:UWDWwZeL5cuWDJdl0C6wrvrUwEqtQ4ZKBKKENpqIUyk=
 github.com/hashicorp/serf v0.9.6/go.mod h1:TXZNMjZQijwlDvp+r0b63xZ45H7JmCmgg4gpTwn9UV4=
-github.com/howardjohn/gateway-api v0.0.0-20221005154653-a3f8431575ae h1:QfFTsW5IeWsr4EDqEOPJDMCgeRWuqzQKitMVEoJxH2Y=
-github.com/howardjohn/gateway-api v0.0.0-20221005154653-a3f8431575ae/go.mod h1:W3V6rE55Qx6C+llroEEzsRkmDcmoPxgm+uwMCR2MUrs=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huandu/xstrings v1.3.2 h1:L18LIDzqlW6xN2rEkpdV8+oL/IXWJ1APd+vsdYy4Wdw=
@@ -831,6 +829,8 @@ github.com/imdario/mergo v0.3.5 h1:JboBksRwiiAJWvIYJVo46AfV+IAIKZpfrSzVKj42R4Q=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/istio/gateway-api v0.0.0-20221006194514-510afb48c902 h1:HO3PWUQcKjEV7P8I9qufLXw0m8BvIcbOXAfJIRLba2Q=
+github.com/istio/gateway-api v0.0.0-20221006194514-510afb48c902/go.mod h1:W3V6rE55Qx6C+llroEEzsRkmDcmoPxgm+uwMCR2MUrs=
 github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56/go.mod h1:ymszkNOg6tORTn+6F6j+Jc8TOr5osrynvN6ivFWZ2GA=
 github.com/j-keck/arping v1.0.2/go.mod h1:aJbELhR92bSk7tp79AWM/ftfc90EfEi2bQJrbBFOsPw=
 github.com/jellevandenhooff/dkim v0.0.0-20150330215556-f50fe3d243e1/go.mod h1:E0B/fFc00Y+Rasa88328GlI/XbtyysCtTHZS8h7IrBU=

--- a/pilot/pkg/config/kube/gateway/deploymentcontroller_v1alpha2.go
+++ b/pilot/pkg/config/kube/gateway/deploymentcontroller_v1alpha2.go
@@ -38,7 +38,6 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"istio.io/istio/pkg/config"
-	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/controllers"
 	istiolog "istio.io/pkg/log"
@@ -103,7 +102,7 @@ func NewDeploymentControllerV1Alpha2(client kube.Client) *DeploymentControllerV1
 	// Set up a handler that will add the parent Gateway object onto the queue.
 	// The queue will only handle Gateway objects; if child resources (Service, etc) are updated we re-add
 	// the Gateway to the queue and reconcile the state of the world.
-	handler := controllers.ObjectHandler(controllers.EnqueueForParentHandler(dc.queue, gvk.KubernetesGateway))
+	handler := controllers.ObjectHandler(controllers.EnqueueForParentHandler(dc.queue, KubernetesGateway))
 
 	// Use the full informer, since we are already fetching all Services for other purposes
 	// If we somehow stop watching Services in the future we can add a label selector like below.
@@ -195,8 +194,8 @@ func (d *DeploymentControllerV1Alpha2) configureIstioGateway(log *istiolog.Scope
 
 	gws := &gateway.Gateway{
 		TypeMeta: metav1.TypeMeta{
-			Kind:       gvk.KubernetesGateway.Kind,
-			APIVersion: gvk.KubernetesGateway.Group + "/" + gvk.KubernetesGateway.Version,
+			Kind:       KubernetesGateway.Kind,
+			APIVersion: KubernetesGateway.Group + "/" + KubernetesGateway.Version,
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      gw.Name,
@@ -268,3 +267,5 @@ type deploymentInputV1Alpha2 struct {
 	*gateway.Gateway
 	KubeVersion122 bool
 }
+
+var KubernetesGateway = config.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Kind: "Gateway"}

--- a/pilot/pkg/config/kube/gateway/deploymentcontroller_v1alpha2_test.go
+++ b/pilot/pkg/config/kube/gateway/deploymentcontroller_v1alpha2_test.go
@@ -115,7 +115,7 @@ func TestConfigureIstioGatewayV1Alpha2(t *testing.T) {
 			}
 
 			resp := timestampRegex.ReplaceAll(buf.Bytes(), []byte("lastTransitionTime: fake"))
-			util.CompareContent(t, resp, filepath.Join("testdata", "deployment", tt.name+".yaml"))
+			util.CompareContent(t, resp, filepath.Join("testdata", "deployment", "alpha-"+tt.name+".yaml"))
 		})
 	}
 }

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/alpha-cluster-ip.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/alpha-cluster-ip.yaml
@@ -1,0 +1,101 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    networking.istio.io/service-type: ClusterIP
+  labels:
+    gateway.istio.io/managed: istio.io-gateway-controller
+  name: default
+  namespace: default
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1alpha2
+    kind: Gateway
+    name: default
+    uid: null
+spec:
+  ports:
+  - name: status-port
+    port: 15021
+    protocol: TCP
+  - name: http
+    port: 80
+    protocol: TCP
+  selector:
+    istio.io/gateway-name: default
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    networking.istio.io/service-type: ClusterIP
+  labels:
+    gateway.istio.io/managed: istio.io-gateway-controller
+  name: default
+  namespace: default
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1alpha2
+    kind: Gateway
+    name: default
+    uid: null
+spec:
+  selector:
+    matchLabels:
+      istio.io/gateway-name: default
+  template:
+    metadata:
+      annotations:
+        inject.istio.io/templates: gateway
+        networking.istio.io/service-type: ClusterIP
+      labels:
+        istio.io/gateway-name: default
+        sidecar.istio.io/inject: "true"
+    spec:
+      containers:
+      - image: auto
+        name: istio-proxy
+        ports:
+        - containerPort: 15021
+          name: status-port
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 10
+          httpGet:
+            path: /healthz/ready
+            port: 15021
+            scheme: HTTP
+          periodSeconds: 2
+          successThreshold: 1
+          timeoutSeconds: 2
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
+      securityContext:
+        sysctls:
+        - name: net.ipv4.ip_unprivileged_port_start
+          value: "0"
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: Gateway
+metadata:
+  creationTimestamp: null
+  name: default
+  namespace: default
+spec:
+  gatewayClassName: ""
+  listeners: null
+status:
+  conditions:
+  - lastTransitionTime: fake
+    message: Deployed gateway to the cluster
+    reason: ResourcesAvailable
+    status: "True"
+    type: Scheduled
+---

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/alpha-manual-ip.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/alpha-manual-ip.yaml
@@ -1,0 +1,96 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    gateway.istio.io/managed: istio.io-gateway-controller
+  name: default
+  namespace: default
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1alpha2
+    kind: Gateway
+    name: default
+    uid: null
+spec:
+  loadBalancerIP: 1.2.3.4
+  ports:
+  - name: status-port
+    port: 15021
+    protocol: TCP
+  selector:
+    istio.io/gateway-name: default
+  type: LoadBalancer
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations: {}
+  labels:
+    gateway.istio.io/managed: istio.io-gateway-controller
+  name: default
+  namespace: default
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1alpha2
+    kind: Gateway
+    name: default
+    uid: null
+spec:
+  selector:
+    matchLabels:
+      istio.io/gateway-name: default
+  template:
+    metadata:
+      annotations:
+        inject.istio.io/templates: gateway
+      labels:
+        istio.io/gateway-name: default
+        sidecar.istio.io/inject: "true"
+    spec:
+      containers:
+      - image: auto
+        name: istio-proxy
+        ports:
+        - containerPort: 15021
+          name: status-port
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 10
+          httpGet:
+            path: /healthz/ready
+            port: 15021
+            scheme: HTTP
+          periodSeconds: 2
+          successThreshold: 1
+          timeoutSeconds: 2
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
+      securityContext:
+        sysctls:
+        - name: net.ipv4.ip_unprivileged_port_start
+          value: "0"
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: Gateway
+metadata:
+  creationTimestamp: null
+  name: default
+  namespace: default
+spec:
+  gatewayClassName: ""
+  listeners: null
+status:
+  conditions:
+  - lastTransitionTime: fake
+    message: Deployed gateway to the cluster
+    reason: ResourcesAvailable
+    status: "True"
+    type: Scheduled
+---

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/alpha-multinetwork.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/alpha-multinetwork.yaml
@@ -1,0 +1,104 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    gateway.istio.io/managed: istio.io-gateway-controller
+    topology.istio.io/network: network-1
+  name: default
+  namespace: default
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1alpha2
+    kind: Gateway
+    name: default
+    uid: null
+spec:
+  ports:
+  - name: status-port
+    port: 15021
+    protocol: TCP
+  - name: http
+    port: 80
+    protocol: TCP
+  selector:
+    istio.io/gateway-name: default
+  type: LoadBalancer
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations: {}
+  labels:
+    gateway.istio.io/managed: istio.io-gateway-controller
+    topology.istio.io/network: network-1
+  name: default
+  namespace: default
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1alpha2
+    kind: Gateway
+    name: default
+    uid: null
+spec:
+  selector:
+    matchLabels:
+      istio.io/gateway-name: default
+  template:
+    metadata:
+      annotations:
+        inject.istio.io/templates: gateway
+      labels:
+        istio.io/gateway-name: default
+        sidecar.istio.io/inject: "true"
+        topology.istio.io/network: network-1
+    spec:
+      containers:
+      - env:
+        - name: ISTIO_META_REQUESTED_NETWORK_VIEW
+          value: network-1
+        image: auto
+        name: istio-proxy
+        ports:
+        - containerPort: 15021
+          name: status-port
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 10
+          httpGet:
+            path: /healthz/ready
+            port: 15021
+            scheme: HTTP
+          periodSeconds: 2
+          successThreshold: 1
+          timeoutSeconds: 2
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
+      securityContext:
+        sysctls:
+        - name: net.ipv4.ip_unprivileged_port_start
+          value: "0"
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: Gateway
+metadata:
+  creationTimestamp: null
+  name: default
+  namespace: default
+spec:
+  gatewayClassName: ""
+  listeners: null
+status:
+  conditions:
+  - lastTransitionTime: fake
+    message: Deployed gateway to the cluster
+    reason: ResourcesAvailable
+    status: "True"
+    type: Scheduled
+---

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/alpha-simple.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/alpha-simple.yaml
@@ -1,0 +1,95 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    gateway.istio.io/managed: istio.io-gateway-controller
+  name: default
+  namespace: default
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1alpha2
+    kind: Gateway
+    name: default
+    uid: null
+spec:
+  ports:
+  - name: status-port
+    port: 15021
+    protocol: TCP
+  selector:
+    istio.io/gateway-name: default
+  type: LoadBalancer
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations: {}
+  labels:
+    gateway.istio.io/managed: istio.io-gateway-controller
+  name: default
+  namespace: default
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1alpha2
+    kind: Gateway
+    name: default
+    uid: null
+spec:
+  selector:
+    matchLabels:
+      istio.io/gateway-name: default
+  template:
+    metadata:
+      annotations:
+        inject.istio.io/templates: gateway
+      labels:
+        istio.io/gateway-name: default
+        sidecar.istio.io/inject: "true"
+    spec:
+      containers:
+      - image: auto
+        name: istio-proxy
+        ports:
+        - containerPort: 15021
+          name: status-port
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 10
+          httpGet:
+            path: /healthz/ready
+            port: 15021
+            scheme: HTTP
+          periodSeconds: 2
+          successThreshold: 1
+          timeoutSeconds: 2
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
+      securityContext:
+        sysctls:
+        - name: net.ipv4.ip_unprivileged_port_start
+          value: "0"
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: Gateway
+metadata:
+  creationTimestamp: null
+  name: default
+  namespace: default
+spec:
+  gatewayClassName: ""
+  listeners: null
+status:
+  conditions:
+  - lastTransitionTime: fake
+    message: Deployed gateway to the cluster
+    reason: ResourcesAvailable
+    status: "True"
+    type: Scheduled
+---

--- a/pkg/kube/controllers/common.go
+++ b/pkg/kube/controllers/common.go
@@ -53,7 +53,7 @@ func UnstructuredToGVR(u unstructured.Unstructured) (schema.GroupVersionResource
 		Version: gv.Version,
 		Kind:    u.GetKind(),
 	}
-	found, ok := collections.All.FindByGroupVersionKind(gk)
+	found, ok := collections.All.FindByGroupVersionAliasesKind(gk)
 	if !ok {
 		return res, fmt.Errorf("unknown gvk: %v", gk)
 	}
@@ -74,7 +74,7 @@ func ObjectToGVR(u Object) (schema.GroupVersionResource, error) {
 		Version: kGvk.Version,
 		Kind:    kGvk.Kind,
 	}
-	found, ok := collections.All.FindByGroupVersionKind(gk)
+	found, ok := collections.All.FindByGroupVersionAliasesKind(gk)
 	if !ok {
 		return schema.GroupVersionResource{}, fmt.Errorf("unknown gvk: %v", gk)
 	}

--- a/releasenotes/notes/gateway-v1beta1.yaml
+++ b/releasenotes/notes/gateway-v1beta1.yaml
@@ -1,6 +1,8 @@
 apiVersion: release-notes/v2
 kind: feature
 area: traffic-management
+issues:
+- 41146
 releaseNotes:
 - |
-  **Upgraded** the gateway-api integration to read `v1beta1` resources for `HTTPRoute`, `Gateway`, and `GatewayClass`. Users of the gateway-api must be on v0.5.0+ before upgrading Istio.
+  **Fixed** the gateway-api integration to not fail when `v1alpha2` version is removed


### PR DESCRIPTION
This picks up https://github.com/kubernetes-sigs/gateway-api/pull/1439. Unfortunately we need to fork since the main branch in gateway-api has diverged too much.

(cherry picked from commit https://github.com/istio/istio/commit/7d37334ba2c95a96d2a3ae4c47ecd10f02510428)
Also fixes release note which was from master