### PR TITLE
Fix Sidecar egress TCP listener doesn't use auto allocated address

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -354,8 +354,7 @@ func (lb *ListenerBuilder) buildSidecarOutboundListeners(node *model.Proxy,
 		var bind string
 		if egressListener.IstioListener != nil && egressListener.IstioListener.Bind != "" {
 			bind = egressListener.IstioListener.Bind
-		}
-		if bindToPort && bind == "" {
+		} else if bindToPort {
 			bind = actualLocalHosts[0]
 		}
 

--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -3001,13 +3001,12 @@ func TestFilterChainMatchEqual(t *testing.T) {
 }
 
 func TestOutboundListenerConfig_WithAutoAllocatedAddress(t *testing.T) {
-
 	const tcpPort = 79
 	services := []*model.Service{
 		{
-			CreationTime:         tnow.Add(1 * time.Second),
-			Hostname:             host.Name("test1.com"),
-			DefaultAddress:       wildcardIPv4,
+			CreationTime:             tnow.Add(1 * time.Second),
+			Hostname:                 host.Name("test1.com"),
+			DefaultAddress:           wildcardIPv4,
 			AutoAllocatedIPv4Address: "240.240.0.100",
 			Ports: model.PortList{
 				&model.Port{
@@ -3087,9 +3086,7 @@ func TestOutboundListenerConfig_WithAutoAllocatedAddress(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-
 			listeners := buildOutboundListeners(t, proxy, tt.sidecar, nil, services...)
-			t.Log(xdstest.DumpList(t, listeners))
 
 			listenersToCheck := make([]string, 0)
 			for _, l := range listeners {
@@ -3108,9 +3105,7 @@ func TestOutboundListenerConfig_WithAutoAllocatedAddress(t *testing.T) {
 						t.Errorf("Expected %d listeners on service port 79, got %d (%v)", tt.numListenersOnServicePort, len(listenersToCheck), listenersToCheck)
 					}
 				}
-
 			}
 		})
 	}
 }
-

--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -2999,3 +2999,118 @@ func TestFilterChainMatchEqual(t *testing.T) {
 		})
 	}
 }
+
+func TestOutboundListenerConfig_WithAutoAllocatedAddress(t *testing.T) {
+
+	const tcpPort = 79
+	services := []*model.Service{
+		{
+			CreationTime:         tnow.Add(1 * time.Second),
+			Hostname:             host.Name("test1.com"),
+			DefaultAddress:       wildcardIPv4,
+			AutoAllocatedIPv4Address: "240.240.0.100",
+			Ports: model.PortList{
+				&model.Port{
+					Name:     "tcp",
+					Port:     tcpPort,
+					Protocol: protocol.TCP,
+				},
+			},
+			Resolution: model.DNSLB,
+			Attributes: model.ServiceAttributes{
+				Namespace: "default",
+			},
+		},
+	}
+
+	sidecarConfig := &config.Config{
+		Meta: config.Meta{
+			Name:             "sidecar-with-tcp",
+			Namespace:        "not-default",
+			GroupVersionKind: gvk.Sidecar,
+		},
+		Spec: &networking.Sidecar{
+			Egress: []*networking.IstioEgressListener{
+				{
+					Hosts: []string{"default/*"},
+				},
+			},
+		},
+	}
+
+	sidecarConfigWithPort := &config.Config{
+		Meta: config.Meta{
+			Name:             "sidecar-with-tcp-port",
+			Namespace:        "not-default",
+			GroupVersionKind: gvk.Sidecar,
+		},
+		Spec: &networking.Sidecar{
+			Egress: []*networking.IstioEgressListener{
+				{
+					Hosts: []string{"default/*"},
+					Port: &networking.Port{
+						Number:   tcpPort,
+						Protocol: "TCP",
+						Name:     "tcp",
+					},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name                      string
+		services                  []*model.Service
+		sidecar                   *config.Config
+		numListenersOnServicePort int
+		useAutoAllocatedAddress   bool
+	}{
+		{
+			name:                      "egress tcp with auto allocated address",
+			services:                  services,
+			sidecar:                   sidecarConfig,
+			numListenersOnServicePort: 1,
+			useAutoAllocatedAddress:   true,
+		},
+		{
+			name:                      "egress tcp and port with auto allocated address",
+			services:                  services,
+			sidecar:                   sidecarConfigWithPort,
+			numListenersOnServicePort: 1,
+			useAutoAllocatedAddress:   true,
+		},
+	}
+
+	proxy := getProxy()
+	proxy.Metadata.DNSCapture = true
+	proxy.Metadata.DNSAutoAllocate = true
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			listeners := buildOutboundListeners(t, proxy, tt.sidecar, nil, services...)
+			t.Log(xdstest.DumpList(t, listeners))
+
+			listenersToCheck := make([]string, 0)
+			for _, l := range listeners {
+				if l.Address.GetSocketAddress().GetPortValue() == tcpPort {
+					listenersToCheck = append(listenersToCheck, l.Address.GetSocketAddress().GetAddress())
+				}
+			}
+
+			if len(listenersToCheck) != tt.numListenersOnServicePort {
+				t.Errorf("Expected %d listeners, got %d (%v)", tt.numListenersOnServicePort, len(listenersToCheck), listenersToCheck)
+			}
+
+			if tt.useAutoAllocatedAddress {
+				for _, addr := range listenersToCheck {
+					if !strings.HasPrefix(addr, "240.240") {
+						t.Errorf("Expected %d listeners on service port 79, got %d (%v)", tt.numListenersOnServicePort, len(listenersToCheck), listenersToCheck)
+					}
+				}
+
+			}
+		})
+	}
+}
+


### PR DESCRIPTION
When proxy metadata DNSCapture and DNSAutoAllocate are enabled, if Sidecar egress listener for TCP service is defined with port number, the generated sidecar outbound listener doesn't bind to auto allocated address(240.240.x.x).

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
