### PR TITLE
Add revision validation to operator dump

### DIFF
--- a/operator/cmd/mesh/operator-dump.go
+++ b/operator/cmd/mesh/operator-dump.go
@@ -21,6 +21,7 @@ import (
 
 	"istio.io/istio/operator/pkg/util/clog"
 	"istio.io/istio/pkg/config/constants"
+	"istio.io/istio/pkg/config/labels"
 	buildversion "istio.io/pkg/version"
 )
 
@@ -51,6 +52,12 @@ func operatorDumpCmd(rootArgs *RootArgs, odArgs *operatorDumpArgs) *cobra.Comman
 		Short: "Dumps the Istio operator controller manifest.",
 		Long:  "The dump subcommand dumps the Istio operator controller manifest.",
 		Args:  cobra.ExactArgs(0),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if !labels.IsDNS1123Label(odArgs.common.revision) && cmd.PersistentFlags().Changed("revision") {
+				return fmt.Errorf("invalid revision specified: %v", odArgs.common.revision)
+			}
+			return nil
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			l := clog.NewConsoleLogger(cmd.OutOrStdout(), cmd.ErrOrStderr(), installerScope)
 			operatorDump(rootArgs, odArgs, l)


### PR DESCRIPTION
**Please provide a description of this PR:**
Revision should be validated, otherwise the generated configs have bad names which cannot be applied.