### PR TITLE
Fix exportTo field validation

### DIFF
--- a/pkg/config/visibility/visibility.go
+++ b/pkg/config/visibility/visibility.go
@@ -42,7 +42,7 @@ func (v Instance) Validate() (errs error) {
 		return fmt.Errorf("exportTo ~ (none) is not allowed for Istio configuration objects")
 	default:
 		if !labels.IsDNS1123Label(string(v)) {
-			return fmt.Errorf("only .,*,~, or a valid DNS 1123 label is allowed as exportTo entry")
+			return fmt.Errorf("only .,*, or a valid DNS 1123 label is allowed as exportTo entry")
 		}
 	}
 	return nil


### PR DESCRIPTION
**Please provide a description of this PR:**
`~` is not allowed. However if the input is not valid it shows:
```
error: destinationrules.networking.istio.io "reviews" could not be patched: admission webhook "validation.istio.io" denied the request: configuration is invalid: only .,*,~, or a valid DNS 1123 label is allowed as exportTo entry
```