### PR TITLE
Fix kube-inject with no webhook having errors

### DIFF
--- a/istioctl/cmd/add-to-mesh.go
+++ b/istioctl/cmd/add-to-mesh.go
@@ -322,7 +322,7 @@ func setupParameters(sidecarTemplate *inject.RawTemplates, valuesConfig *string,
 			return nil, multierror.Append(err, fmt.Errorf("loading --injectConfigFile"))
 		}
 		*sidecarTemplate = injectConfig
-	} else if *sidecarTemplate, err = getInjectConfigFromConfigMap(kubeconfig, revision); err != nil {
+	} else if *sidecarTemplate, err = getInjectConfigFromConfigMap(kubeconfig, revision, valuesConfig); err != nil {
 		return nil, err
 	}
 	if valuesFile != "" {

--- a/istioctl/cmd/kubeinject_test.go
+++ b/istioctl/cmd/kubeinject_test.go
@@ -14,10 +14,18 @@
 package cmd
 
 import (
+	"bytes"
 	"fmt"
 	"regexp"
 	"strings"
 	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"istio.io/istio/pilot/test/util"
 )
 
 func TestKubeInject(t *testing.T) {
@@ -86,4 +94,60 @@ func TestKubeInject(t *testing.T) {
 			verifyOutput(t, c)
 		})
 	}
+}
+
+func TestKubeInjectWithoutWebhook(t *testing.T) {
+	t.Helper()
+
+	args := strings.Split("kube-inject -f testdata/deployment/hello.yaml", " ")
+
+	interfaceFactory = func(kubeconfig string) (kubernetes.Interface, error) {
+		cli := fake.NewSimpleClientset(&v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      defaultInjectWebhookConfigName,
+				Namespace: istioNamespace,
+				Labels: map[string]string{
+					"app":   "sidecar-injector",
+					"istio": "sidecar-injector",
+				},
+			},
+			Data: map[string]string{
+				"values": `global:
+  suffix: test
+`,
+				"config": `templates:
+  sidecar: |-
+    spec:
+      initContainers:
+      - name: istio-init
+        image: docker.io/istio/proxy_init:unittest-{{.Values.global.suffix}}
+      containers:
+      - name: istio-proxy
+        image: docker.io/istio/proxy_debug:unittest
+`,
+			},
+		}, &v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "istio",
+				Namespace: istioNamespace,
+			},
+			Data: map[string]string{
+				"mesh": "",
+			},
+		})
+		return cli, nil
+	}
+
+	var out bytes.Buffer
+	rootCmd := GetRootCmd(args)
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+
+	// shouldn't have errors
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	output := out.String()
+
+	util.CompareContent(t, []byte(output), "testdata/deployment/hello.yaml.injected")
 }

--- a/releasenotes/notes/41326.yaml
+++ b/releasenotes/notes/41326.yaml
@@ -3,4 +3,4 @@ kind: bug-fix
 area: istioctl
 releaseNotes:
   - |
-    **Fixed** an issue that makes `kube-inject` not working as expected when there is no webhook exists.
+    **Fixed** an issue where `kube-inject` does not work as expected when no webhook exists.

--- a/releasenotes/notes/41326.yaml
+++ b/releasenotes/notes/41326.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: istioctl
+releaseNotes:
+  - |
+    **Fixed** an issue that makes `kube-inject` not working as expected when there is no webhook exists.


### PR DESCRIPTION
**Please provide a description of this PR:**
When there is no webhook exists, kube-inject will fall back to use injector config maps. However the values parameter is not set ahead, which leads to the error `Error: failed to run injection template: failed parsing generated injected YAML (check Istio sidecar injector configuration): unmarshal patched pod: json: cannot unmarshal string into Go struct field Probe.spec.containers.readinessProbe.failureThreshold of type int32`.


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [x] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
