### PR TITLE
Make WaitForCRD scoped to struct, not global

### DIFF
--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -160,7 +160,7 @@ func (s *Server) initK8SConfigStore(args *PilotArgs) error {
 		if s.statusManager == nil && features.EnableGatewayAPIStatus {
 			s.initStatusManager(args)
 		}
-		gwc := gateway.NewController(s.kubeClient, configController, args.RegistryOptions.KubeOptions)
+		gwc := gateway.NewController(s.kubeClient, configController, configController.WaitForCRD, args.RegistryOptions.KubeOptions)
 		s.environment.GatewayAPIController = gwc
 		s.ConfigStores = append(s.ConfigStores, s.environment.GatewayAPIController)
 		s.addTerminatingStartFunc(func(stop <-chan struct{}) error {
@@ -188,7 +188,7 @@ func (s *Server) initK8SConfigStore(args *PilotArgs) error {
 					NewLeaderElection(args.Namespace, args.PodName, leaderelection.GatewayDeploymentController, args.Revision, s.kubeClient).
 					AddRunFunction(func(leaderStop <-chan struct{}) {
 						// We can only run this if the Gateway CRD is created
-						if crdclient.WaitForCRD(gvk.KubernetesGateway, leaderStop) {
+						if configController.WaitForCRD(gvk.KubernetesGateway, leaderStop) {
 							controller := gateway.NewDeploymentController(s.kubeClient)
 							// Start informers again. This fixes the case where informers for namespace do not start,
 							// as we create them only after acquiring the leader lock
@@ -343,7 +343,7 @@ func (s *Server) initStatusController(args *PilotArgs, writeStatus bool) {
 	}
 }
 
-func (s *Server) makeKubeConfigController(args *PilotArgs) (model.ConfigStoreController, error) {
+func (s *Server) makeKubeConfigController(args *PilotArgs) (*crdclient.Client, error) {
 	opts := crdclient.Option{
 		Revision:     args.Revision,
 		DomainSuffix: args.RegistryOptions.KubeOptions.DomainSuffix,

--- a/pilot/pkg/config/kube/gateway/controller_test.go
+++ b/pilot/pkg/config/kube/gateway/controller_test.go
@@ -77,11 +77,15 @@ var (
 	}
 )
 
+var AlwaysReady = func(class config.GroupVersionKind, stop <-chan struct{}) bool {
+	return true
+}
+
 func TestListInvalidGroupVersionKind(t *testing.T) {
 	g := NewWithT(t)
 	clientSet := kube.NewFakeClient()
 	store := memory.NewController(memory.Make(collections.All))
-	controller := NewController(clientSet, store, controller.Options{})
+	controller := NewController(clientSet, store, AlwaysReady, controller.Options{})
 
 	typ := config.GroupVersionKind{Kind: "wrong-kind"}
 	c, err := controller.List(typ, "ns1")
@@ -94,7 +98,7 @@ func TestListGatewayResourceType(t *testing.T) {
 
 	clientSet := kube.NewFakeClient()
 	store := memory.NewController(memory.Make(collections.All))
-	controller := NewController(clientSet, store, controller.Options{})
+	controller := NewController(clientSet, store, AlwaysReady, controller.Options{})
 
 	store.Create(config.Config{
 		Meta: config.Meta{
@@ -141,7 +145,7 @@ func TestListVirtualServiceResourceType(t *testing.T) {
 
 	clientSet := kube.NewFakeClient()
 	store := memory.NewController(memory.Make(collections.All))
-	controller := NewController(clientSet, store, controller.Options{})
+	controller := NewController(clientSet, store, AlwaysReady, controller.Options{})
 
 	store.Create(config.Config{
 		Meta: config.Meta{

--- a/pilot/pkg/xds/fake.go
+++ b/pilot/pkg/xds/fake.go
@@ -219,7 +219,9 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 		PushContextLock:     &s.updateMutex,
 		ConfigStoreCaches:   []model.ConfigStoreController{ingr},
 		CreateConfigStore: func(c model.ConfigStoreController) model.ConfigStoreController {
-			g := gateway.NewController(defaultKubeClient, c, kube.Options{
+			g := gateway.NewController(defaultKubeClient, c, func(class config.GroupVersionKind, stop <-chan struct{}) bool {
+				return true
+			}, kube.Options{
 				DomainSuffix: "cluster.local",
 			})
 			gwc = g


### PR DESCRIPTION
Not fixing any known bugs, but I think this could possible have issues in real world with multicluster (read CRD in one cluster, try to watch it in all clusters). But in general this is a code hygene improvement to not use globals

**Please provide a description of this PR:**