### PR TITLE
use service port if virtual service destination does not have port for consistent hash

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -394,7 +394,7 @@ func (configgen *ConfigGeneratorImpl) buildGatewayHTTPRouteConfig(node *model.Pr
 			vskey := virtualService.Name + "/" + virtualService.Namespace
 
 			if routes, exists = gatewayRoutes[gatewayName][vskey]; !exists {
-				hashByDestination := istio_route.GetConsistentHashForVirtualService(push, node, virtualService)
+				hashByDestination := istio_route.GetConsistentHashForVirtualService(push, node, virtualService, nameToServiceMap)
 				routes, err = istio_route.BuildHTTPRoutesForVirtualService(node, virtualService, nameToServiceMap,
 					hashByDestination, port, map[string]bool{gatewayName: true}, isH3DiscoveryNeeded, push.Mesh)
 				if err != nil {

--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -1280,7 +1280,11 @@ func hashForVirtualService(push *model.PushContext,
 	for _, httpRoute := range virtualService.Spec.(*networking.VirtualService).Http {
 		for _, destination := range httpRoute.Route {
 			hostname := host.Name(destination.GetDestination().GetHost())
-			hash, dr := hashForHTTPDestination(push, node, destination, serviceRegistry[hostname])
+			var svc *model.Service
+			if serviceRegistry != nil {
+				svc = serviceRegistry[hostname]
+			}
+			hash, dr := hashForHTTPDestination(push, node, destination, svc)
 			if hash != nil {
 				hashByDestination[destination] = hash
 				destinationRules = append(destinationRules, dr)

--- a/pilot/pkg/networking/core/v1alpha3/route/route_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route_test.go
@@ -489,7 +489,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		})
 
 		proxy := node(cg)
-		hashByDestination := route.GetConsistentHashForVirtualService(cg.PushContext(), proxy, virtualServicePlain)
+		hashByDestination := route.GetConsistentHashForVirtualService(cg.PushContext(), proxy, virtualServicePlain, map[host.Name]*model.Service{})
 		routes, err := route.BuildHTTPRoutesForVirtualService(proxy, virtualServicePlain, serviceRegistry,
 			hashByDestination, 8080, gatewayNames, false, nil)
 		xdstest.ValidateRoutes(t, routes)
@@ -537,7 +537,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		})
 
 		proxy := node(cg)
-		hashByDestination := route.GetConsistentHashForVirtualService(cg.PushContext(), proxy, virtualServicePlain)
+		hashByDestination := route.GetConsistentHashForVirtualService(cg.PushContext(), proxy, virtualServicePlain, map[host.Name]*model.Service{})
 		routes, err := route.BuildHTTPRoutesForVirtualService(proxy, virtualServicePlain, serviceRegistry,
 			hashByDestination, 8080, gatewayNames, false, nil)
 		xdstest.ValidateRoutes(t, routes)
@@ -582,7 +582,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		})
 
 		proxy := node(cg)
-		hashByDestination := route.GetConsistentHashForVirtualService(cg.PushContext(), proxy, virtualService)
+		hashByDestination := route.GetConsistentHashForVirtualService(cg.PushContext(), proxy, virtualService, map[host.Name]*model.Service{})
 		routes, err := route.BuildHTTPRoutesForVirtualService(proxy, virtualService, serviceRegistry,
 			hashByDestination, 8080, gatewayNames, false, nil)
 		xdstest.ValidateRoutes(t, routes)
@@ -625,7 +625,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		})
 
 		proxy := node(cg)
-		hashByDestination := route.GetConsistentHashForVirtualService(cg.PushContext(), proxy, virtualService)
+		hashByDestination := route.GetConsistentHashForVirtualService(cg.PushContext(), proxy, virtualService, map[host.Name]*model.Service{})
 		routes, err := route.BuildHTTPRoutesForVirtualService(proxy, virtualService, serviceRegistry,
 			hashByDestination, 8080, gatewayNames, false, nil)
 		xdstest.ValidateRoutes(t, routes)
@@ -671,7 +671,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		})
 
 		proxy := node(cg)
-		hashByDestination := route.GetConsistentHashForVirtualService(cg.PushContext(), proxy, virtualService)
+		hashByDestination := route.GetConsistentHashForVirtualService(cg.PushContext(), proxy, virtualService, map[host.Name]*model.Service{})
 		routes, err := route.BuildHTTPRoutesForVirtualService(proxy, virtualService, serviceRegistry,
 			hashByDestination, 8080, gatewayNames, false, nil)
 		xdstest.ValidateRoutes(t, routes)
@@ -706,7 +706,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 
 		proxy := node(cg)
 		gatewayNames := map[string]bool{"some-gateway": true}
-		hashByDestination := route.GetConsistentHashForVirtualService(cg.PushContext(), proxy, virtualServicePlain)
+		hashByDestination := route.GetConsistentHashForVirtualService(cg.PushContext(), proxy, virtualServicePlain, map[host.Name]*model.Service{})
 		routes, err := route.BuildHTTPRoutesForVirtualService(proxy, virtualServicePlain, serviceRegistry,
 			hashByDestination, 8080, gatewayNames, false, nil)
 		xdstest.ValidateRoutes(t, routes)

--- a/pilot/pkg/networking/core/v1alpha3/route/route_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route_test.go
@@ -489,7 +489,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		})
 
 		proxy := node(cg)
-		hashByDestination := route.GetConsistentHashForVirtualService(cg.PushContext(), proxy, virtualServicePlain, map[host.Name]*model.Service{})
+		hashByDestination := route.GetConsistentHashForVirtualService(cg.PushContext(), proxy, virtualServicePlain, nil)
 		routes, err := route.BuildHTTPRoutesForVirtualService(proxy, virtualServicePlain, serviceRegistry,
 			hashByDestination, 8080, gatewayNames, false, nil)
 		xdstest.ValidateRoutes(t, routes)
@@ -537,7 +537,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		})
 
 		proxy := node(cg)
-		hashByDestination := route.GetConsistentHashForVirtualService(cg.PushContext(), proxy, virtualServicePlain, map[host.Name]*model.Service{})
+		hashByDestination := route.GetConsistentHashForVirtualService(cg.PushContext(), proxy, virtualServicePlain, nil)
 		routes, err := route.BuildHTTPRoutesForVirtualService(proxy, virtualServicePlain, serviceRegistry,
 			hashByDestination, 8080, gatewayNames, false, nil)
 		xdstest.ValidateRoutes(t, routes)
@@ -582,7 +582,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		})
 
 		proxy := node(cg)
-		hashByDestination := route.GetConsistentHashForVirtualService(cg.PushContext(), proxy, virtualService, map[host.Name]*model.Service{})
+		hashByDestination := route.GetConsistentHashForVirtualService(cg.PushContext(), proxy, virtualService, nil)
 		routes, err := route.BuildHTTPRoutesForVirtualService(proxy, virtualService, serviceRegistry,
 			hashByDestination, 8080, gatewayNames, false, nil)
 		xdstest.ValidateRoutes(t, routes)
@@ -625,7 +625,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		})
 
 		proxy := node(cg)
-		hashByDestination := route.GetConsistentHashForVirtualService(cg.PushContext(), proxy, virtualService, map[host.Name]*model.Service{})
+		hashByDestination := route.GetConsistentHashForVirtualService(cg.PushContext(), proxy, virtualService, nil)
 		routes, err := route.BuildHTTPRoutesForVirtualService(proxy, virtualService, serviceRegistry,
 			hashByDestination, 8080, gatewayNames, false, nil)
 		xdstest.ValidateRoutes(t, routes)
@@ -671,7 +671,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		})
 
 		proxy := node(cg)
-		hashByDestination := route.GetConsistentHashForVirtualService(cg.PushContext(), proxy, virtualService, map[host.Name]*model.Service{})
+		hashByDestination := route.GetConsistentHashForVirtualService(cg.PushContext(), proxy, virtualService, nil)
 		routes, err := route.BuildHTTPRoutesForVirtualService(proxy, virtualService, serviceRegistry,
 			hashByDestination, 8080, gatewayNames, false, nil)
 		xdstest.ValidateRoutes(t, routes)
@@ -706,7 +706,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 
 		proxy := node(cg)
 		gatewayNames := map[string]bool{"some-gateway": true}
-		hashByDestination := route.GetConsistentHashForVirtualService(cg.PushContext(), proxy, virtualServicePlain, map[host.Name]*model.Service{})
+		hashByDestination := route.GetConsistentHashForVirtualService(cg.PushContext(), proxy, virtualServicePlain, nil)
 		routes, err := route.BuildHTTPRoutesForVirtualService(proxy, virtualServicePlain, serviceRegistry,
 			hashByDestination, 8080, gatewayNames, false, nil)
 		xdstest.ValidateRoutes(t, routes)

--- a/releasenotes/notes/41257.yaml
+++ b/releasenotes/notes/41257.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 41257
+releaseNotes:
+  - |
+    **Fixed** an issue where port level consistent hash setting not working when virtual destination does not have port.


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/41257

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure