### PR TITLE
Add missing unit test for #40165

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/serviceentry_simulation_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/serviceentry_simulation_test.go
@@ -126,3 +126,87 @@ func TestServiceEntry(t *testing.T) {
 		})
 	}
 }
+
+const serviceEntriesWithDuplicatedHosts = `
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: istio-http
+spec:
+  hosts:
+  - istio.io
+  location: MESH_EXTERNAL
+  ports:
+  - number: 80
+    name: http
+    protocol: HTTP
+  resolution: DNS
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: istio-https
+spec:
+  hosts:
+  - istio.io
+  location: MESH_EXTERNAL
+  ports:
+  - number: 443
+    name: https
+    protocol: HTTPS
+  resolution: DNS
+`
+
+func TestServiceEntryDuplicatedHostname(t *testing.T) {
+	cases := []simulationTest{
+		{
+			name:   "service entries with reused hosts should have auto allocated the same IP address",
+			config: serviceEntriesWithDuplicatedHosts,
+			calls: []simulation.Expect{
+				{
+					Name: "HTTP call",
+					Call: simulation.Call{
+						Address:    "240.240.0.1",
+						Port:       80,
+						HostHeader: "istio.io",
+						Protocol:   simulation.HTTP,
+					},
+					Result: simulation.Result{
+						ListenerMatched: "0.0.0.0_80",
+						ClusterMatched:  "outbound|80||istio.io",
+					},
+				},
+				{
+					Name: "HTTPS call",
+					Call: simulation.Call{
+						Address:    "240.240.0.1",
+						Port:       443,
+						HostHeader: "istio.io",
+						Protocol:   simulation.HTTP,
+						TLS:        simulation.TLS,
+					},
+					Result: simulation.Result{
+						ListenerMatched: "240.240.0.1_443",
+						ClusterMatched:  "outbound|443||istio.io",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			proxy := &model.Proxy{
+				Metadata: &model.NodeMetadata{
+					DNSCapture:      true,
+					DNSAutoAllocate: true,
+				},
+			}
+			runSimulationTest(t, proxy, xds.FakeOptions{}, simulationTest{
+				name:   tt.name,
+				config: tt.config,
+				calls:  tt.calls,
+			})
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Jacek Ewertowski <jewertow@redhat.com>

**Please provide a description of this PR:**

This is a follow-up to the PR #40165 and a [comment](https://github.com/istio/istio/pull/40165#discussion_r933345677) about tests.

To make sure that this test verifies implementation from #40165, I reverted that commit and then got the error below.
```
traffic.go:261: Full Diff:   simulation.Result{
          	Error:              nil,
        - 	ListenerMatched:    "240.240.0.1_443",
        + 	ListenerMatched:    "virtualOutbound",
          	FilterChainMatched: "virtualOutbound-catchall-tcp",
          	RouteMatched:       "",
          	RouteConfigMatched: "",
          	VirtualHostMatched: "",
        - 	ClusterMatched:     "outbound|443||istio.io",
        + 	ClusterMatched:     "PassthroughCluster",
          	StrictMatch:        false,
          	Skip:               "",
          	... // 1 ignored field
          }
```