### PR TITLE
Add RequireDualStackCluster option to testing framework

### DIFF
--- a/pkg/test/framework/analyzer.go
+++ b/pkg/test/framework/analyzer.go
@@ -102,6 +102,10 @@ func (s *suiteAnalyzer) RequireMaxClusters(maxClusters int) Suite {
 	return s
 }
 
+func (s *suiteAnalyzer) RequireDualStack() Suite {
+	return s
+}
+
 func (s *suiteAnalyzer) RequireSingleCluster() Suite {
 	// nolint: staticcheck
 	return s.RequireMinClusters(1).RequireMaxClusters(1)


### PR DESCRIPTION
As part of the dual-stack effort we will be bringing in an integration test that is only intended to be run on clusters running in dual stack mode.

Currently setting `IP_FAMILY=dual` will create a dual stack cluster so some support for it is already present.