### PR TITLE
ambient: ca: Implement node authorization

### DIFF
--- a/pilot/pkg/bootstrap/istio_ca.go
+++ b/pilot/pkg/bootstrap/istio_ca.go
@@ -165,7 +165,7 @@ func (s *Server) RunCA(grpc *grpc.Server, ca caserver.CertificateAuthority, opts
 	// The CA API uses cert with the max workload cert TTL.
 	// 'hostlist' must be non-empty - but is not used since a grpc server is passed.
 	// Adds client cert auth and kube (sds enabled)
-	caServer, startErr := caserver.New(ca, maxWorkloadCertTTL.Get(), opts.Authenticators)
+	caServer, startErr := caserver.New(ca, maxWorkloadCertTTL.Get(), opts.Authenticators, s.kubeClient)
 	if startErr != nil {
 		log.Fatalf("failed to create istio ca server: %v", startErr)
 	}

--- a/pkg/security/security.go
+++ b/pkg/security/security.go
@@ -377,6 +377,8 @@ type Caller struct {
 	KubernetesInfo KubernetesInfo
 }
 
+// KubernetesInfo defines Kubernetes specific information extracted from the caller.
+// This involves additional metadata about the caller beyond just its SPIFFE identity.
 type KubernetesInfo struct {
 	PodName           string
 	PodNamespace      string

--- a/pkg/security/security.go
+++ b/pkg/security/security.go
@@ -140,7 +140,8 @@ const (
 	K8sTokenPrefix = "Istio "
 
 	// CertSigner info
-	CertSigner = "CertSigner"
+	CertSigner           = "CertSigner"
+	ImpersonatedIdentity = "ImpersonatedIdentity"
 )
 
 // Options provides all of the configuration parameters for secret discovery service
@@ -372,6 +373,19 @@ type AuthContext struct {
 type Caller struct {
 	AuthSource AuthSource
 	Identities []string
+
+	KubernetesInfo KubernetesInfo
+}
+
+type KubernetesInfo struct {
+	PodName           string
+	PodNamespace      string
+	PodUID            string
+	PodServiceAccount string
+}
+
+func (k KubernetesInfo) String() string {
+	return fmt.Sprintf("Pod{Name: %s, Namespace: %s, UID: %s, ServiceAccount: %s}", k.PodName, k.PodNamespace, k.PodUID, k.PodServiceAccount)
 }
 
 // Authenticator determines the caller identity based on request context.

--- a/security/pkg/k8s/tokenreview/k8sauthn.go
+++ b/security/pkg/k8s/tokenreview/k8sauthn.go
@@ -26,6 +26,16 @@ import (
 	"istio.io/istio/pkg/security"
 )
 
+// From https://github.com/kubernetes/kubernetes/blob/4f2faa2f1ce8f49983173ef29214156afdf405f9/staging/src/k8s.io/apiserver/pkg/authentication/serviceaccount/util.go#L41
+const (
+	// PodNameKey is the key used in a user's "extra" to specify the pod name of
+	// the authenticating request.
+	PodNameKey = "authentication.kubernetes.io/pod-name"
+	// PodUIDKey is the key used in a user's "extra" to specify the pod UID of
+	// the authenticating request.
+	PodUIDKey = "authentication.kubernetes.io/pod-uid"
+)
+
 // ValidateK8sJwt validates a k8s JWT at API server.
 // Return {<namespace>, <serviceaccountname>} in the targetToken when the validation passes.
 // Otherwise, return the error.
@@ -94,9 +104,9 @@ func getTokenReviewResult(tokenReview *k8sauth.TokenReview) (security.Kubernetes
 	}
 
 	return security.KubernetesInfo{
-		PodName:           extractExtra(tokenReview, "authentication.kubernetes.io/pod-name"),
+		PodName:           extractExtra(tokenReview, PodNameKey),
 		PodNamespace:      subStrings[2],
-		PodUID:            extractExtra(tokenReview, "authentication.kubernetes.io/pod-uid"),
+		PodUID:            extractExtra(tokenReview, PodUIDKey),
 		PodServiceAccount: subStrings[3],
 	}, nil
 }

--- a/security/pkg/k8s/tokenreview/k8sauthn.go
+++ b/security/pkg/k8s/tokenreview/k8sauthn.go
@@ -26,6 +26,7 @@ import (
 	"istio.io/istio/pkg/security"
 )
 
+// nolint: lll
 // From https://github.com/kubernetes/kubernetes/blob/4f2faa2f1ce8f49983173ef29214156afdf405f9/staging/src/k8s.io/apiserver/pkg/authentication/serviceaccount/util.go#L41
 const (
 	// PodNameKey is the key used in a user's "extra" to specify the pod name of

--- a/security/pkg/k8s/tokenreview/k8sauthn.go
+++ b/security/pkg/k8s/tokenreview/k8sauthn.go
@@ -22,6 +22,8 @@ import (
 	k8sauth "k8s.io/api/authentication/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+
+	"istio.io/istio/pkg/security"
 )
 
 // ValidateK8sJwt validates a k8s JWT at API server.
@@ -29,7 +31,7 @@ import (
 // Otherwise, return the error.
 // targetToken: the JWT of the K8s service account to be reviewed
 // aud: list of audiences to check. If empty 1st party tokens will be checked.
-func ValidateK8sJwt(kubeClient kubernetes.Interface, targetToken string, aud []string) ([]string, error) {
+func ValidateK8sJwt(kubeClient kubernetes.Interface, targetToken string, aud []string) (security.KubernetesInfo, error) {
 	tokenReview := &k8sauth.TokenReview{
 		Spec: k8sauth.TokenReviewSpec{
 			Token: targetToken,
@@ -40,15 +42,15 @@ func ValidateK8sJwt(kubeClient kubernetes.Interface, targetToken string, aud []s
 	}
 	reviewRes, err := kubeClient.AuthenticationV1().TokenReviews().Create(context.TODO(), tokenReview, metav1.CreateOptions{})
 	if err != nil {
-		return nil, err
+		return security.KubernetesInfo{}, err
 	}
 
 	return getTokenReviewResult(reviewRes)
 }
 
-func getTokenReviewResult(tokenReview *k8sauth.TokenReview) ([]string, error) {
+func getTokenReviewResult(tokenReview *k8sauth.TokenReview) (security.KubernetesInfo, error) {
 	if tokenReview.Status.Error != "" {
-		return nil, fmt.Errorf("the service account authentication returns an error: %v",
+		return security.KubernetesInfo{}, fmt.Errorf("the service account authentication returns an error: %v",
 			tokenReview.Status.Error)
 	}
 	// An example SA token:
@@ -72,7 +74,7 @@ func getTokenReviewResult(tokenReview *k8sauth.TokenReview) ([]string, error) {
 	// }
 
 	if !tokenReview.Status.Authenticated {
-		return nil, fmt.Errorf("the token is not authenticated")
+		return security.KubernetesInfo{}, fmt.Errorf("the token is not authenticated")
 	}
 	inServiceAccountGroup := false
 	for _, group := range tokenReview.Status.User.Groups {
@@ -82,15 +84,27 @@ func getTokenReviewResult(tokenReview *k8sauth.TokenReview) ([]string, error) {
 		}
 	}
 	if !inServiceAccountGroup {
-		return nil, fmt.Errorf("the token is not a service account")
+		return security.KubernetesInfo{}, fmt.Errorf("the token is not a service account")
 	}
 	// "username" is in the form of system:serviceaccount:{namespace}:{service account name}",
 	// e.g., "username":"system:serviceaccount:default:example-pod-sa"
 	subStrings := strings.Split(tokenReview.Status.User.Username, ":")
 	if len(subStrings) != 4 {
-		return nil, fmt.Errorf("invalid username field in the token review result")
+		return security.KubernetesInfo{}, fmt.Errorf("invalid username field in the token review result")
 	}
-	namespace := subStrings[2]
-	saName := subStrings[3]
-	return []string{namespace, saName}, nil
+
+	return security.KubernetesInfo{
+		PodName:           extractExtra(tokenReview, "authentication.kubernetes.io/pod-name"),
+		PodNamespace:      subStrings[2],
+		PodUID:            extractExtra(tokenReview, "authentication.kubernetes.io/pod-uid"),
+		PodServiceAccount: subStrings[3],
+	}, nil
+}
+
+func extractExtra(review *k8sauth.TokenReview, s string) string {
+	values, ok := review.Status.User.Extra[s]
+	if !ok || len(values) == 0 {
+		return ""
+	}
+	return values[0]
 }

--- a/security/pkg/server/ca/authenticate/kubeauth/kube_jwt_test.go
+++ b/security/pkg/server/ca/authenticate/kubeauth/kube_jwt_test.go
@@ -31,6 +31,7 @@ import (
 	"istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/jwt"
 	"istio.io/istio/pkg/security"
+	"istio.io/istio/pkg/test/util/assert"
 	"istio.io/istio/security/pkg/server/ca/authenticate"
 )
 
@@ -186,11 +187,13 @@ func TestAuthenticate(t *testing.T) {
 			expectedCaller := &security.Caller{
 				AuthSource: security.AuthSourceIDToken,
 				Identities: []string{tc.expectedID},
+				KubernetesInfo: security.KubernetesInfo{
+					PodNamespace:      "default",
+					PodServiceAccount: "example-pod-sa",
+				},
 			}
 
-			if !reflect.DeepEqual(actualCaller, expectedCaller) {
-				t.Errorf("Case %q: Unexpected token: want %v but got %v", id, expectedCaller, actualCaller)
-			}
+			assert.Equal(t, actualCaller, expectedCaller)
 		})
 	}
 }

--- a/security/pkg/server/ca/node_auth.go
+++ b/security/pkg/server/ca/node_auth.go
@@ -1,3 +1,17 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package ca
 
 import (

--- a/security/pkg/server/ca/node_auth.go
+++ b/security/pkg/server/ca/node_auth.go
@@ -111,6 +111,6 @@ func (na *NodeAuthorizer) authenticateImpersonation(caller security.KubernetesIn
 	if len(res) == 0 {
 		return fmt.Errorf("no instances of %q found on node %q", k.ServiceAccount, k.Node)
 	}
-	serverCaLog.Debugf("Node caller ")
+	serverCaLog.Debugf("Node caller %v impersonated %v", caller, requestedIdentityString)
 	return nil
 }

--- a/security/pkg/server/ca/node_auth.go
+++ b/security/pkg/server/ca/node_auth.go
@@ -1,0 +1,116 @@
+package ca
+
+import (
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	listerv1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+
+	"istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/security"
+	"istio.io/istio/pkg/spiffe"
+)
+
+// NodeAuthorizer is a component that implements a subset of Kubernetes Node Authorization
+// (https://kubernetes.io/docs/reference/access-authn-authz/node/) for Istio CA. Specifically, it
+// validates that a node proxy which requests certificates for workloads on its own node is request
+// valid identities which run on that node (rather than arbitrary ones).
+type NodeAuthorizer struct {
+	podLister           listerv1.PodLister
+	podIndexer          cache.Indexer
+	trustedNodeAccounts map[types.NamespacedName]struct{}
+}
+
+const NodeSaIndex = "node+sa"
+
+func NewNodeAuthorizer(client kube.Client, trustedNodeAccounts map[types.NamespacedName]struct{}) (*NodeAuthorizer, error) {
+	pods := client.KubeInformer().Core().V1().Pods()
+
+	// Add an Index on the pods, storing the service account and node. This allows us to later efficiently query.
+	if err := pods.Informer().AddIndexers(map[string]cache.IndexFunc{
+		NodeSaIndex: func(obj interface{}) ([]string, error) {
+			pod, ok := obj.(*v1.Pod)
+			if !ok {
+				return nil, nil
+			}
+			if len(pod.Spec.NodeName) == 0 {
+				return nil, nil
+			}
+			if len(pod.Spec.ServiceAccountName) == 0 {
+				return nil, nil
+			}
+			return []string{SaNode{
+				ServiceAccount: types.NamespacedName{
+					Namespace: pod.Namespace,
+					Name:      pod.Spec.ServiceAccountName,
+				},
+				Node: pod.Spec.NodeName,
+			}.String()}, nil
+		},
+	}); err != nil {
+		// This should only happen if the informer has already started.
+		// This can only happen if a component started before the CA already registers the informer *and* starts it.
+		// This should not happen; if it does, the CA will not function properly, and its likely a programming error, so returning
+		// an error here (which will ultimately exit the process) is appropriate.
+		return nil, fmt.Errorf("failed to add indexer: %v", err)
+	}
+	return &NodeAuthorizer{
+		podLister:           pods.Lister(),
+		podIndexer:          pods.Informer().GetIndexer(),
+		trustedNodeAccounts: trustedNodeAccounts,
+	}, nil
+}
+
+func (na *NodeAuthorizer) authenticateImpersonation(caller security.KubernetesInfo, requestedIdentityString string) error {
+	callerSa := types.NamespacedName{
+		Namespace: caller.PodNamespace,
+		Name:      caller.PodServiceAccount,
+	}
+	// First, make sure the caller is allowed to impersonate, in general
+	if _, f := na.trustedNodeAccounts[callerSa]; !f {
+		return fmt.Errorf("caller (%v) is not allowed to impersonate", caller)
+	}
+	// Next, make sure the identity they want to impersonate is valid, in general
+	requestedIdentity, err := spiffe.ParseIdentity(requestedIdentityString)
+	if err != nil {
+		return fmt.Errorf("failed to validate impersonated identity %v", requestedIdentityString)
+	}
+
+	// Finally, we validate the requested identity is running on the same node the caller is on
+	callerPod, err := na.podLister.Pods(caller.PodNamespace).Get(caller.PodName)
+	if err != nil {
+		return fmt.Errorf("failed to lookup pod: %v", err)
+	}
+	// Make sure UID is still valid for our current state
+	if callerPod.UID != types.UID(caller.PodUID) {
+		// This would only happen if a pod is re-created with the same name, and the CSR client is not in sync on which is current;
+		// this is fine and should be eventually consistent. Client is expected to retry in this case.
+		return fmt.Errorf("pod found, but UID does not match: %v vs %v", callerPod.UID, caller.PodUID)
+	}
+	if callerPod.Spec.ServiceAccountName != caller.PodServiceAccount {
+		// This should never happen, but just in case add an additional check
+		return fmt.Errorf("pod found, but ServiceAccount does not match: %v vs %v", callerPod.Spec.ServiceAccountName, caller.PodServiceAccount)
+	}
+	// We want to find out if there is any pod running with the requested identity on the callers node.
+	// The indexer (previously setup) creates a lookup table for a {Node, SA} pair, which we can lookup
+	k := SaNode{
+		ServiceAccount: types.NamespacedName{Name: requestedIdentity.ServiceAccount, Namespace: requestedIdentity.Namespace},
+		Node:           callerPod.Spec.NodeName,
+	}
+	// TODO: this is currently single cluster; we will need to take the cluster of the proxy into account
+	// to support multi-cluster properly.
+	res, err := na.podIndexer.ByIndex(NodeSaIndex, k.String())
+	if err != nil {
+		// This should never happen (only possible if the index doesn't exist)
+		return fmt.Errorf("failed to find node local service accounts: %v", err)
+	}
+	// We don't care what pods are part of the index, only that there is at least one. If there is one,
+	// it is appropriate for the caller to request this identity.
+	if len(res) == 0 {
+		return fmt.Errorf("no instances of %q found on node %q", k.ServiceAccount, k.Node)
+	}
+	serverCaLog.Debugf("Node caller ")
+	return nil
+}

--- a/security/pkg/server/ca/node_auth_test.go
+++ b/security/pkg/server/ca/node_auth_test.go
@@ -1,3 +1,17 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package ca
 
 import (

--- a/security/pkg/server/ca/node_auth_test.go
+++ b/security/pkg/server/ca/node_auth_test.go
@@ -1,0 +1,176 @@
+package ca
+
+import (
+	"strings"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+
+	"istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/security"
+	"istio.io/istio/pkg/spiffe"
+	"istio.io/istio/pkg/test"
+)
+
+type pod struct {
+	name, namespace, account, node, uid string
+}
+
+func (p pod) Identity() string {
+	return spiffe.Identity{
+		TrustDomain:    "cluster.local",
+		Namespace:      p.namespace,
+		ServiceAccount: p.account,
+	}.String()
+}
+
+func TestNodeAuthorizer(t *testing.T) {
+	allowZtunnel := map[types.NamespacedName]struct{}{
+		{Name: "ztunnel", Namespace: "istio-system"}: {},
+	}
+	ztunnelCaller := security.KubernetesInfo{
+		PodName:           "ztunnel-a",
+		PodNamespace:      "istio-system",
+		PodUID:            "12345",
+		PodServiceAccount: "ztunnel",
+	}
+	ztunnelPod := pod{
+		name:      ztunnelCaller.PodName,
+		namespace: ztunnelCaller.PodNamespace,
+		account:   ztunnelCaller.PodServiceAccount,
+		uid:       ztunnelCaller.PodUID,
+		node:      "zt-node",
+	}
+	podSameNode := pod{
+		name:      "pod-a",
+		namespace: "ns-a",
+		account:   "sa-a",
+		uid:       "1",
+		node:      "zt-node",
+	}
+	podOtherNode := pod{
+		name:      "pod-b",
+		namespace: podSameNode.namespace,
+		account:   podSameNode.account,
+		uid:       "2",
+		node:      "other-node",
+	}
+	cases := []struct {
+		name                    string
+		pods                    []pod
+		caller                  security.KubernetesInfo
+		requestedIdentityString string
+		trustedAccounts         map[types.NamespacedName]struct{}
+		wantErr                 string
+	}{
+		{
+			name:    "empty allowed identities",
+			wantErr: "not allowed to impersonate",
+		},
+		{
+			name:                    "allowed identities, but not on node",
+			caller:                  ztunnelCaller,
+			trustedAccounts:         allowZtunnel,
+			requestedIdentityString: podSameNode.Identity(),
+			pods:                    []pod{ztunnelPod},
+			wantErr:                 "no instances",
+		},
+		{
+			name:                    "allowed identities, on node",
+			caller:                  ztunnelCaller,
+			trustedAccounts:         allowZtunnel,
+			requestedIdentityString: podSameNode.Identity(),
+			pods:                    []pod{ztunnelPod, podSameNode},
+			wantErr:                 "",
+		},
+		{
+			name:                    "allowed identities, off node",
+			caller:                  ztunnelCaller,
+			trustedAccounts:         allowZtunnel,
+			requestedIdentityString: podSameNode.Identity(),
+			pods:                    []pod{ztunnelPod, podOtherNode},
+			wantErr:                 "no instances",
+		},
+		{
+			name:                    "allowed identities, on and off node",
+			caller:                  ztunnelCaller,
+			trustedAccounts:         allowZtunnel,
+			requestedIdentityString: podSameNode.Identity(),
+			pods:                    []pod{ztunnelPod, podSameNode, podOtherNode},
+			wantErr:                 "",
+		},
+		{
+			name:                    "invalid requested",
+			caller:                  ztunnelCaller,
+			trustedAccounts:         allowZtunnel,
+			requestedIdentityString: "not-spiffe-idenditity",
+			pods:                    []pod{ztunnelPod},
+			wantErr:                 "failed to validate impersonated identity",
+		},
+		{
+			name:                    "unknown caller",
+			caller:                  ztunnelCaller,
+			trustedAccounts:         allowZtunnel,
+			requestedIdentityString: podSameNode.Identity(),
+			pods:                    []pod{podSameNode},
+			wantErr:                 "failed to lookup pod",
+		},
+		{
+			name: "bad UID",
+			caller: func(k security.KubernetesInfo) security.KubernetesInfo {
+				k.PodUID = "bogus"
+				return k
+			}(ztunnelCaller),
+			trustedAccounts:         allowZtunnel,
+			requestedIdentityString: podSameNode.Identity(),
+			pods:                    []pod{ztunnelPod},
+			wantErr:                 "pod found, but UID does not match",
+		},
+		{
+			name:                    "bad account",
+			caller:                  ztunnelCaller,
+			trustedAccounts:         allowZtunnel,
+			requestedIdentityString: podSameNode.Identity(),
+			pods: []pod{func(p pod) pod {
+				p.account = "bogus"
+				return p
+			}(ztunnelPod)},
+			wantErr: "pod found, but ServiceAccount does not match",
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			var pods []runtime.Object
+			for _, p := range tt.pods {
+				pods = append(pods, &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      p.name,
+						Namespace: p.namespace,
+						UID:       types.UID(p.uid),
+					},
+					Spec: v1.PodSpec{
+						ServiceAccountName: p.account,
+						NodeName:           p.node,
+					},
+				})
+			}
+			c := kube.NewFakeClient(pods...)
+			na, err := NewNodeAuthorizer(c, tt.trustedAccounts)
+			if err != nil {
+				t.Fatal(err)
+			}
+			c.RunAndWait(test.NewStop(t))
+
+			err = na.authenticateImpersonation(tt.caller, tt.requestedIdentityString)
+			if tt.wantErr == "" && err != nil {
+				t.Fatalf("wanted no error, got %v", err)
+			}
+			if tt.wantErr != "" && (err == nil || !strings.Contains(err.Error(), tt.wantErr)) {
+				t.Fatalf("expected error %q, got %q", tt.wantErr, err)
+			}
+		})
+	}
+}

--- a/tests/fuzz/security_fuzzer.go
+++ b/tests/fuzz/security_fuzzer.go
@@ -103,7 +103,7 @@ func FuzzCreateCertE2EUsingClientCertAuthenticator(data []byte) int {
 		SignedCert:    signedCert,
 		KeyCertBundle: kcb,
 	}
-	server, err := ca.New(mockCa, 1, []security.Authenticator{auth})
+	server, err := ca.New(mockCa, 1, []security.Authenticator{auth}, nil)
 	if err != nil {
 		return 0
 	}


### PR DESCRIPTION
This implements the node authorization described in https://github.com/istio/istio/issues/41281

Note: this only implements the CA part. The ztunnel and XDS will be updated in a later PR. Because this is extremely security sensitive code, I wanted to keep the PR as small as possible.

**Please provide a description of this PR:**