### PR TITLE
[Backport] install: add `--cluster-specific` flag to generate (#40548)

### DIFF
--- a/releasenotes/notes/cluster-specific-generate.yaml
+++ b/releasenotes/notes/cluster-specific-generate.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+releaseNotes:
+- |
+  **Added** a `--cluster-specific` flag to `istioctl manifest generate`. When this is set, the current cluster context will be used to determine dynamic default settings, mirroring `istioctl install`.
+


### PR DESCRIPTION
Hi all,

This is probably a terrible PR, sorry I don't know how the branching strategy for Istio works, or the policy on cherry-picks.

However the folowing change was merged to master before the 1.15 release, but hasn't made it into any 1.15 release yet. I'm trying to install 1.15 into a k8s 1.25 cluster and hitting this issue, so it'd be super useful to have it availble now. Original commit message below.

---

This allows `manifest generate` to use cluster specific settings as well.

The only install method left is `helm template`; I have a bug filed in https://github.com/helm/helm/issues/11240.