### PR TITLE
Add release note for jwt parsing update

### DIFF
--- a/releasenotes/notes/jwt-parsing.yaml
+++ b/releasenotes/notes/jwt-parsing.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: security
+
+releaseNotes:
+- |
+  **Updated** dependency in Envoy to properly parse JWTs with negative values for exp, nbf or iat fields.
+


### PR DESCRIPTION
**Please provide a description of this PR:**

Recently Envoy updated a library (jwt_verify_lib, see https://github.com/google/jwt_verify_lib/pull/69) that properly parses negative values for exp, nbf or iat fields.

The PSWG does not consider this a security issue as the JWKS that issued the JWT should not be creating JWTs with invalid JWTs anyway.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [X] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
