### PR TITLE
ambient: no checkAmbient if pod is in excluded namespaces

### DIFF
--- a/cni/pkg/plugin/plugin.go
+++ b/cni/pkg/plugin/plugin.go
@@ -227,7 +227,7 @@ func CmdAdd(args *skel.CmdArgs) (err error) {
 		log.Infof("ambientConf.Mode: %s", ambientConf.Mode)
 		log.Infof("ambientConf.ZTunnelReady: %v", ambientConf.ZTunnelReady)
 		added := false
-		if ambientConf.Mode != ambient.AmbientMeshOff.String() && ambientConf.ZTunnelReady {
+		if !excludePod && ambientConf.Mode != ambient.AmbientMeshOff.String() && ambientConf.ZTunnelReady {
 			podIPs, err := getPodIPs(args.IfName, conf.PrevResult)
 			if err != nil {
 				log.Errorf("istio-cni cmdAdd failed to get pod IPs: %s", err)


### PR DESCRIPTION
**Please provide a description of this PR:**

No need to checkAmbient when pod's namespace is in the excluded namespaces(istio-system, kube-system)