### PR TITLE
Scope envoy filters for CDS/RDS

### DIFF
--- a/pilot/pkg/model/envoyfilter.go
+++ b/pilot/pkg/model/envoyfilter.go
@@ -185,6 +185,20 @@ func (efw *EnvoyFilterWrapper) Keys() []string {
 	return sets.SortedList(keys)
 }
 
+// Returns the keys of all the wrapped envoyfilters.
+func (efw *EnvoyFilterWrapper) KeysApplyingTo(applyTo ...networking.EnvoyFilter_ApplyTo) []string {
+	if efw == nil {
+		return nil
+	}
+	keys := sets.String{}
+	for _, a := range applyTo {
+		for _, patch := range efw.Patches[a] {
+			keys.Insert(patch.Key())
+		}
+	}
+	return keys.SortedList()
+}
+
 func (cpw *EnvoyFilterConfigPatchWrapper) Key() string {
 	if cpw == nil {
 		return ""

--- a/pilot/pkg/model/envoyfilter.go
+++ b/pilot/pkg/model/envoyfilter.go
@@ -196,7 +196,7 @@ func (efw *EnvoyFilterWrapper) KeysApplyingTo(applyTo ...networking.EnvoyFilter_
 			keys.Insert(patch.Key())
 		}
 	}
-	return keys.SortedList()
+	return sets.SortedList(keys)
 }
 
 func (cpw *EnvoyFilterConfigPatchWrapper) Key() string {

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -216,7 +216,7 @@ func (configgen *ConfigGeneratorImpl) buildOutboundClusters(cb *ClusterBuilder, 
 	services []*model.Service,
 ) ([]*discovery.Resource, cacheStats) {
 	resources := make([]*discovery.Resource, 0)
-	efKeys := cp.efw.Keys()
+	efKeys := cp.efw.KeysApplyingTo(networking.EnvoyFilter_CLUSTER)
 	hit, miss := 0, 0
 	for _, service := range services {
 		for _, port := range service.Ports {

--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -61,7 +61,11 @@ func (configgen *ConfigGeneratorImpl) BuildHTTPRoutes(
 	case model.SidecarProxy:
 		vHostCache := make(map[int][]*route.VirtualHost)
 		// dependent envoyfilters' key, calculate in front once to prevent calc for each route.
-		envoyfilterKeys := efw.Keys()
+		envoyfilterKeys := efw.KeysApplyingTo(
+			networking.EnvoyFilter_ROUTE_CONFIGURATION,
+			networking.EnvoyFilter_VIRTUAL_HOST,
+			networking.EnvoyFilter_HTTP_ROUTE,
+		)
 		for _, routeName := range routeNames {
 			rc, cached := configgen.buildSidecarOutboundHTTPRouteConfig(node, req, routeName, vHostCache, efw, envoyfilterKeys)
 			if cached && !features.EnableUnsafeAssertions {


### PR DESCRIPTION
**Please provide a description of this PR:**
In our environment we are using several envoy filters applying to `NETWORK_FILTER/HTTP_FILTER`. Each time these filters get updated, they invalidate the CDS/RDS cache even though they are not patching clusters/routes

This pr scopes the envoy filters used for CDS/RDS cache, so the cache won't be invalidated ineffectively


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [x] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
