### PR TITLE
Failover validation (#41272)

### DIFF
--- a/pkg/config/mesh/mesh.go
+++ b/pkg/config/mesh/mesh.go
@@ -31,6 +31,7 @@ import (
 	"istio.io/istio/pkg/config/validation"
 	"istio.io/istio/pkg/util/protomarshal"
 	"istio.io/istio/pkg/util/sets"
+	"istio.io/pkg/log"
 )
 
 // DefaultProxyConfig for individual proxies
@@ -244,8 +245,12 @@ func ApplyMeshConfig(yaml string, defaultConfig *meshconfig.MeshConfig) (*meshco
 
 	defaultConfig.TrustDomainAliases = sets.New(append(defaultConfig.TrustDomainAliases, prevTrustDomainAliases...)...).SortedList()
 
-	if err := validation.ValidateMeshConfig(defaultConfig); err != nil {
+	warn, err := validation.ValidateMeshConfig(defaultConfig)
+	if err != nil {
 		return nil, err
+	}
+	if warn != nil {
+		log.Warnf("warnings occurred during mesh validation: %v", warn)
 	}
 
 	return defaultConfig, nil

--- a/pkg/config/mesh/mesh_test.go
+++ b/pkg/config/mesh/mesh_test.go
@@ -120,8 +120,12 @@ func TestDefaultProxyConfig(t *testing.T) {
 }
 
 func TestDefaultMeshConfig(t *testing.T) {
-	if err := validation.ValidateMeshConfig(mesh.DefaultMeshConfig()); err != nil {
+	warn, err := validation.ValidateMeshConfig(mesh.DefaultMeshConfig())
+	if err != nil {
 		t.Errorf("validation of default mesh config failed with %v", err)
+	}
+	if warn != nil {
+		t.Errorf("validation of default mesh config produced warnings: %v", warn)
 	}
 }
 

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -422,7 +422,7 @@ func TestValidateProtocolDetectionTimeout(t *testing.T) {
 }
 
 func TestValidateMeshConfig(t *testing.T) {
-	if ValidateMeshConfig(&meshconfig.MeshConfig{}) == nil {
+	if _, err := ValidateMeshConfig(&meshconfig.MeshConfig{}); err == nil {
 		t.Error("expected an error on an empty mesh config")
 	}
 
@@ -445,7 +445,7 @@ func TestValidateMeshConfig(t *testing.T) {
 		},
 	}
 
-	err := ValidateMeshConfig(invalid)
+	_, err := ValidateMeshConfig(invalid)
 	if err == nil {
 		t.Errorf("expected an error on invalid proxy mesh config: %v", invalid)
 	} else {
@@ -3590,9 +3590,9 @@ func TestValidateLoadBalancer(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		if got := validateLoadBalancer(c.in); (got == nil) != c.valid {
+		if got := validateLoadBalancer(c.in, nil); (got.Err == nil) != c.valid {
 			t.Errorf("validateLoadBalancer failed on %v: got valid=%v but wanted valid=%v: %v",
-				c.name, got == nil, c.valid, got)
+				c.name, got.Err == nil, c.valid, got)
 		}
 	}
 }
@@ -6262,14 +6262,18 @@ func TestValidateSidecar(t *testing.T) {
 
 func TestValidateLocalityLbSetting(t *testing.T) {
 	cases := []struct {
-		name  string
-		in    *networking.LocalityLoadBalancerSetting
-		valid bool
+		name    string
+		in      *networking.LocalityLoadBalancerSetting
+		outlier *networking.OutlierDetection
+		err     bool
+		warn    bool
 	}{
 		{
-			name:  "valid mesh config without LocalityLoadBalancerSetting",
-			in:    nil,
-			valid: true,
+			name:    "valid mesh config without LocalityLoadBalancerSetting",
+			in:      nil,
+			outlier: nil,
+			err:     false,
+			warn:    false,
 		},
 
 		{
@@ -6285,7 +6289,9 @@ func TestValidateLocalityLbSetting(t *testing.T) {
 					},
 				},
 			},
-			valid: false,
+			outlier: &networking.OutlierDetection{},
+			err:     true,
+			warn:    false,
 		},
 		{
 			name: "invalid LocalityLoadBalancerSetting_Distribute total weight < 100",
@@ -6300,7 +6306,9 @@ func TestValidateLocalityLbSetting(t *testing.T) {
 					},
 				},
 			},
-			valid: false,
+			outlier: &networking.OutlierDetection{},
+			err:     true,
+			warn:    false,
 		},
 		{
 			name: "invalid LocalityLoadBalancerSetting_Distribute weight = 0",
@@ -6315,7 +6323,9 @@ func TestValidateLocalityLbSetting(t *testing.T) {
 					},
 				},
 			},
-			valid: false,
+			outlier: &networking.OutlierDetection{},
+			err:     true,
+			warn:    false,
 		},
 		{
 			name: "invalid LocalityLoadBalancerSetting specify both distribute and failover",
@@ -6336,7 +6346,9 @@ func TestValidateLocalityLbSetting(t *testing.T) {
 					},
 				},
 			},
-			valid: false,
+			outlier: &networking.OutlierDetection{},
+			err:     true,
+			warn:    false,
 		},
 
 		{
@@ -6349,7 +6361,9 @@ func TestValidateLocalityLbSetting(t *testing.T) {
 					},
 				},
 			},
-			valid: false,
+			outlier: &networking.OutlierDetection{},
+			err:     true,
+			warn:    false,
 		},
 		{
 			name: "invalid failover src contain '*' wildcard",
@@ -6361,7 +6375,9 @@ func TestValidateLocalityLbSetting(t *testing.T) {
 					},
 				},
 			},
-			valid: false,
+			outlier: &networking.OutlierDetection{},
+			err:     true,
+			warn:    false,
 		},
 		{
 			name: "invalid failover dst contain '*' wildcard",
@@ -6373,7 +6389,9 @@ func TestValidateLocalityLbSetting(t *testing.T) {
 					},
 				},
 			},
-			valid: false,
+			outlier: &networking.OutlierDetection{},
+			err:     true,
+			warn:    false,
 		},
 		{
 			name: "invalid failover src contain '/' separator",
@@ -6385,7 +6403,9 @@ func TestValidateLocalityLbSetting(t *testing.T) {
 					},
 				},
 			},
-			valid: false,
+			outlier: &networking.OutlierDetection{},
+			err:     true,
+			warn:    false,
 		},
 		{
 			name: "invalid failover dst contain '/' separator",
@@ -6397,14 +6417,54 @@ func TestValidateLocalityLbSetting(t *testing.T) {
 					},
 				},
 			},
-			valid: false,
+			outlier: &networking.OutlierDetection{},
+			err:     true,
+			warn:    false,
+		},
+		{
+			name: "failover priority provided without outlier detection policy",
+			in: &networking.LocalityLoadBalancerSetting{
+				FailoverPriority: []string{
+					"topology.istio.io/network",
+					"topology.kubernetes.io/region",
+					"topology.kubernetes.io/zone",
+					"topology.istio.io/subzone",
+				},
+			},
+			outlier: nil,
+			err:     false,
+			warn:    true,
+		},
+		{
+			name: "failover provided without outlier detection policy",
+			in: &networking.LocalityLoadBalancerSetting{
+				Failover: []*networking.LocalityLoadBalancerSetting_Failover{
+					{
+						From: "us-east",
+						To:   "eu-west",
+					},
+					{
+						From: "us-west",
+						To:   "eu-east",
+					},
+				},
+			},
+			outlier: nil,
+			err:     false,
+			warn:    true,
 		},
 	}
 
 	for _, c := range cases {
-		if got := validateLocalityLbSetting(c.in); (got == nil) != c.valid {
-			t.Errorf("ValidateLocalityLbSetting failed on %v: got valid=%v but wanted valid=%v: %v",
-				c.name, got == nil, c.valid, got)
+		v := validateLocalityLbSetting(c.in, c.outlier)
+		warn, err := v.Unwrap()
+		if (err != nil) != c.err {
+			t.Errorf("ValidateLocalityLbSetting failed on %v: got err=%v but wanted err=%v: %v",
+				c.name, err != nil, c.err, err)
+		}
+		if (warn != nil) != c.warn {
+			t.Errorf("ValidateLocalityLbSetting failed on %v: got warn=%v but wanted warn=%v: %v",
+				c.name, warn != nil, c.warn, warn)
 		}
 	}
 }

--- a/releasenotes/notes/failover-validation.yaml
+++ b/releasenotes/notes/failover-validation.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+
+releaseNotes:
+- |
+  **Added** warning validation messages when a DestinationRule specifies failover policies but does not provide an OutlierDetection policy.
+  Previously, istiod was silently ignoring the failover settings 


### PR DESCRIPTION
* log warning if failover is not configured due to missing outlier detection policy

* add validation logic for failover policy without outlier detection

* uncomment out test scenarios

* switch to warning message instead of error

* remove log message

* fix missing validation references

* add releasenote for new warning validation message

* lint fix

**Please provide a description of this PR:**

manual cherrypick of PR #41272

fixes https://github.com/istio/istio/issues/41407