### PR TITLE
Failover validation (#41272)

### DIFF
--- a/pkg/config/mesh/mesh.go
+++ b/pkg/config/mesh/mesh.go
@@ -31,6 +31,7 @@ import (
 	"istio.io/istio/pkg/config/validation"
 	"istio.io/istio/pkg/util/protomarshal"
 	"istio.io/istio/pkg/util/sets"
+	"istio.io/pkg/log"
 )
 
 // DefaultProxyConfig for individual proxies
@@ -244,8 +245,12 @@ func ApplyMeshConfig(yaml string, defaultConfig *meshconfig.MeshConfig) (*meshco
 
 	defaultConfig.TrustDomainAliases = sets.New(append(defaultConfig.TrustDomainAliases, prevTrustDomainAliases...)...).SortedList()
 
-	if err := validation.ValidateMeshConfig(defaultConfig); err != nil {
+	warn, err := validation.ValidateMeshConfig(defaultConfig)
+	if err != nil {
 		return nil, err
+	}
+	if warn != nil {
+		log.Warnf("warnings occurred during mesh validation: %v", warn)
 	}
 
 	return defaultConfig, nil

--- a/pkg/config/mesh/mesh_test.go
+++ b/pkg/config/mesh/mesh_test.go
@@ -120,8 +120,12 @@ func TestDefaultProxyConfig(t *testing.T) {
 }
 
 func TestDefaultMeshConfig(t *testing.T) {
-	if err := validation.ValidateMeshConfig(mesh.DefaultMeshConfig()); err != nil {
+	warn, err := validation.ValidateMeshConfig(mesh.DefaultMeshConfig())
+	if err != nil {
 		t.Errorf("validation of default mesh config failed with %v", err)
+	}
+	if warn != nil {
+		t.Errorf("validation of default mesh config produced warnings: %v", warn)
 	}
 }
 

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -1353,7 +1353,7 @@ func validateTrafficPolicy(policy *networking.TrafficPolicy) Validation {
 
 	return appendValidation(validateOutlierDetection(policy.OutlierDetection),
 		validateConnectionPool(policy.ConnectionPool),
-		validateLoadBalancer(policy.LoadBalancer),
+		validateLoadBalancer(policy.LoadBalancer, policy.OutlierDetection),
 		validateTLS(policy.Tls),
 		validatePortTrafficPolicies(policy.PortLevelSettings),
 		validateTunnelSettings(policy.Tunnel))
@@ -1447,7 +1447,7 @@ func validateConnectionPool(settings *networking.ConnectionPoolSettings) (errs e
 	return
 }
 
-func validateLoadBalancer(settings *networking.LoadBalancerSettings) (errs error) {
+func validateLoadBalancer(settings *networking.LoadBalancerSettings, outlier *networking.OutlierDetection) (errs Validation) {
 	if settings == nil {
 		return
 	}
@@ -1459,16 +1459,15 @@ func validateLoadBalancer(settings *networking.LoadBalancerSettings) (errs error
 		httpCookie := consistentHash.GetHttpCookie()
 		if httpCookie != nil {
 			if httpCookie.Name == "" {
-				errs = appendErrors(errs, fmt.Errorf("name required for HttpCookie"))
+				errs = appendValidation(errs, fmt.Errorf("name required for HttpCookie"))
 			}
 			if httpCookie.Ttl == nil {
-				errs = appendErrors(errs, fmt.Errorf("ttl required for HttpCookie"))
+				errs = appendValidation(errs, fmt.Errorf("ttl required for HttpCookie"))
 			}
 		}
 	}
-	if err := validateLocalityLbSetting(settings.LocalityLbSetting); err != nil {
-		errs = multierror.Append(errs, err)
-	}
+
+	errs = appendValidation(errs, validateLocalityLbSetting(settings.LocalityLbSetting, outlier))
 	return
 }
 
@@ -1522,7 +1521,7 @@ func validatePortTrafficPolicies(pls []*networking.TrafficPolicy_PortTrafficPoli
 		} else {
 			errs = appendErrors(errs, validateOutlierDetection(t.OutlierDetection),
 				validateConnectionPool(t.ConnectionPool),
-				validateLoadBalancer(t.LoadBalancer),
+				validateLoadBalancer(t.LoadBalancer, t.OutlierDetection),
 				validateTLS(t.Tls))
 		}
 	}
@@ -1693,42 +1692,35 @@ func IsNegativeDuration(in time.Duration) error {
 }
 
 // ValidateMeshConfig checks that the mesh config is well-formed
-func ValidateMeshConfig(mesh *meshconfig.MeshConfig) (errs error) {
+func ValidateMeshConfig(mesh *meshconfig.MeshConfig) (Warning, error) {
+	v := Validation{}
 	if err := ValidatePort(int(mesh.ProxyListenPort)); err != nil {
-		errs = multierror.Append(errs, multierror.Prefix(err, "invalid proxy listen port:"))
+		v = appendValidation(v, multierror.Prefix(err, "invalid proxy listen port:"))
 	}
 
 	if err := ValidateConnectTimeout(mesh.ConnectTimeout); err != nil {
-		errs = multierror.Append(errs, multierror.Prefix(err, "invalid connect timeout:"))
+		v = appendValidation(v, multierror.Prefix(err, "invalid connect timeout:"))
 	}
 
 	if err := ValidateProtocolDetectionTimeout(mesh.ProtocolDetectionTimeout); err != nil {
-		errs = multierror.Append(errs, multierror.Prefix(err, "invalid protocol detection timeout:"))
+		v = appendValidation(v, multierror.Prefix(err, "invalid protocol detection timeout:"))
 	}
 
 	if mesh.DefaultConfig == nil {
-		errs = multierror.Append(errs, errors.New("missing default config"))
-	} else if err := ValidateMeshConfigProxyConfig(mesh.DefaultConfig); err != nil {
-		errs = multierror.Append(errs, err)
+		v = appendValidation(v, errors.New("missing default config"))
+	} else {
+		v = appendValidation(v, ValidateMeshConfigProxyConfig(mesh.DefaultConfig))
 	}
 
-	if err := validateLocalityLbSetting(mesh.LocalityLbSetting); err != nil {
-		errs = multierror.Append(errs, err)
-	}
-
-	if err := validateServiceSettings(mesh); err != nil {
-		errs = multierror.Append(errs, err)
-	}
-
-	if err := validateTrustDomainConfig(mesh); err != nil {
-		errs = multierror.Append(errs, err)
-	}
+	v = appendValidation(v, validateLocalityLbSetting(mesh.LocalityLbSetting, &networking.OutlierDetection{}))
+	v = appendValidation(v, validateServiceSettings(mesh))
+	v = appendValidation(v, validateTrustDomainConfig(mesh))
 
 	if err := validateExtensionProvider(mesh); err != nil {
 		scope.Warnf("found invalid extension provider (can be ignored if the given extension provider is not used): %v", err)
 	}
 
-	return
+	return v.Unwrap()
 }
 
 func validateTrustDomainConfig(config *meshconfig.MeshConfig) (errs error) {
@@ -3468,13 +3460,14 @@ func appendErrors(err error, errs ...error) error {
 }
 
 // validateLocalityLbSetting checks the LocalityLbSetting of MeshConfig
-func validateLocalityLbSetting(lb *networking.LocalityLoadBalancerSetting) error {
+func validateLocalityLbSetting(lb *networking.LocalityLoadBalancerSetting, outlier *networking.OutlierDetection) (errs Validation) {
 	if lb == nil {
-		return nil
+		return
 	}
 
 	if len(lb.GetDistribute()) > 0 && len(lb.GetFailover()) > 0 {
-		return fmt.Errorf("can not simultaneously specify 'distribute' and 'failover'")
+		errs = appendValidation(errs, fmt.Errorf("can not simultaneously specify 'distribute' and 'failover'"))
+		return
 	}
 
 	srcLocalities := make([]string, 0, len(lb.GetDistribute()))
@@ -3485,35 +3478,37 @@ func validateLocalityLbSetting(lb *networking.LocalityLoadBalancerSetting) error
 		for loc, weight := range locality.To {
 			destLocalities = append(destLocalities, loc)
 			if weight <= 0 || weight > 100 {
-				return fmt.Errorf("locality weight must be in range [1, 100]")
+				errs = appendValidation(errs, fmt.Errorf("locality weight must be in range [1, 100]"))
+				return
 			}
 			totalWeight += weight
 		}
 		if totalWeight != 100 {
-			return fmt.Errorf("total locality weight %v != 100", totalWeight)
+			errs = appendValidation(errs, fmt.Errorf("total locality weight %v != 100", totalWeight))
+			return
 		}
-		if err := validateLocalities(destLocalities); err != nil {
-			return err
-		}
+		errs = appendValidation(errs, validateLocalities(destLocalities))
 	}
 
-	if err := validateLocalities(srcLocalities); err != nil {
-		return err
+	errs = appendValidation(errs, validateLocalities(srcLocalities))
+
+	if (len(lb.GetFailover()) != 0 || len(lb.GetFailoverPriority()) != 0) && outlier == nil {
+		errs = appendValidation(errs, WrapWarning(fmt.Errorf("outlier detection poicy must be provided for failover")))
 	}
 
 	for _, failover := range lb.GetFailover() {
 		if failover.From == failover.To {
-			return fmt.Errorf("locality lb failover settings must specify different regions")
+			errs = appendValidation(errs, fmt.Errorf("locality lb failover settings must specify different regions"))
 		}
 		if strings.Contains(failover.From, "/") || strings.Contains(failover.To, "/") {
-			return fmt.Errorf("locality lb failover only specify region")
+			errs = appendValidation(errs, fmt.Errorf("locality lb failover only specify region"))
 		}
 		if strings.Contains(failover.To, "*") || strings.Contains(failover.From, "*") {
-			return fmt.Errorf("locality lb failover region should not contain '*' wildcard")
+			errs = appendValidation(errs, fmt.Errorf("locality lb failover region should not contain '*' wildcard"))
 		}
 	}
 
-	return nil
+	return
 }
 
 func validateLocalities(localities []string) error {

--- a/releasenotes/notes/failover-validation.yaml
+++ b/releasenotes/notes/failover-validation.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+
+releaseNotes:
+- |
+  **Added** warning validation messages when a DestinationRule specifies failover policies but does not provide an OutlierDetection policy.
+  Previously, istiod was silently ignoring the failover settings 


### PR DESCRIPTION
* log warning if failover is not configured due to missing outlier detection policy

* add validation logic for failover policy without outlier detection

* uncomment out test scenarios

* switch to warning message instead of error

* remove log message

* fix missing validation references

* add releasenote for new warning validation message

* lint fix

**Please provide a description of this PR:**

manual cherrypick of PR #41272

fixes https://github.com/istio/istio/issues/41406