### PR TITLE
add DisableSdsServer flag

### DIFF
--- a/pilot/cmd/pilot-agent/options/agent.go
+++ b/pilot/cmd/pilot-agent/options/agent.go
@@ -64,6 +64,7 @@ func NewAgentOptions(proxy *model.Proxy, cfg *meshconfig.ProxyConfig) *istioagen
 		ProxyNamespace:              PodNamespaceVar.Get(),
 		ProxyDomain:                 proxy.DNSDomain,
 		IstiodSAN:                   istiodSAN.Get(),
+		DisableSdsServer:            disableSdsServerEnv,
 	}
 	extractXDSHeadersFromEnv(o)
 	return o

--- a/pilot/cmd/pilot-agent/options/agent.go
+++ b/pilot/cmd/pilot-agent/options/agent.go
@@ -64,7 +64,7 @@ func NewAgentOptions(proxy *model.Proxy, cfg *meshconfig.ProxyConfig) *istioagen
 		ProxyNamespace:              PodNamespaceVar.Get(),
 		ProxyDomain:                 proxy.DNSDomain,
 		IstiodSAN:                   istiodSAN.Get(),
-		DisableSdsServer:            disableSdsServerEnv,
+		DisableAgentSds:             disableAgentSdsEnv,
 	}
 	extractXDSHeadersFromEnv(o)
 	return o

--- a/pilot/cmd/pilot-agent/options/options.go
+++ b/pilot/cmd/pilot-agent/options/options.go
@@ -152,4 +152,7 @@ var (
 	exitOnZeroActiveConnectionsEnv = env.Register("EXIT_ON_ZERO_ACTIVE_CONNECTIONS",
 		false,
 		"When set to true, terminates proxy when number of active connections become zero during draining").Get()
+
+	disableSdsServerEnv = env.Register("DISABLE_SDS_SERVER", false,
+		"Disables the creation of the SDS server.").Get()
 )

--- a/pilot/cmd/pilot-agent/options/options.go
+++ b/pilot/cmd/pilot-agent/options/options.go
@@ -154,5 +154,5 @@ var (
 		"When set to true, terminates proxy when number of active connections become zero during draining").Get()
 
 	disableSdsServerEnv = env.Register("DISABLE_SDS_SERVER", false,
-		"Disables the creation of the SDS server.").Get()
+		"Disables the creation of the SDS server when another application (SPIRE) will satisfy the spiffe requests on the socket.").Get()
 )

--- a/pilot/cmd/pilot-agent/options/options.go
+++ b/pilot/cmd/pilot-agent/options/options.go
@@ -153,6 +153,6 @@ var (
 		false,
 		"When set to true, terminates proxy when number of active connections become zero during draining").Get()
 
-	disableSdsServerEnv = env.Register("DISABLE_SDS_SERVER", false,
-		"Disables the creation of the SDS server when another application (SPIRE) will satisfy the spiffe requests on the socket.").Get()
+	disableAgentSdsEnv = env.Register("DISABLE_AGENT_SDS", false,
+		"Disables the creation of the SDS server in agent when another application (SPIRE) will satisfy the spiffe requests on the socket.").Get()
 )

--- a/pkg/istio-agent/agent.go
+++ b/pkg/istio-agent/agent.go
@@ -186,8 +186,8 @@ type AgentOptions struct {
 
 	WASMOptions wasm.Options
 
-	// Prevents the SDS Server socket from being created by Istio
-	DisableSdsServer bool
+	// Prevents the SDS Server socket from being created by the agent
+	DisableAgentSds bool
 }
 
 // NewAgent hosts the functionality for local SDS and XDS. This consists of the local SDS server and
@@ -333,7 +333,7 @@ func (a *Agent) Run(ctx context.Context) (func(), error) {
 		return nil, fmt.Errorf("failed to start local DNS server: %v", err)
 	}
 
-	if a.cfg.DisableSdsServer {
+	if a.cfg.DisableAgentSds {
 		log.Info("SDS Server disabled. Not starting Istio SDS Server.")
 	} else {
 		socketExists, err := checkSocket(ctx, security.WorkloadIdentitySocketPath)

--- a/releasenotes/notes/41440.yaml
+++ b/releasenotes/notes/41440.yaml
@@ -1,0 +1,12 @@
+apiVersion: release-notes/v2
+kind: enhancement
+area: security
+
+issue:
+- 41308
+
+releaseNotes:
+- |
+  **Added** An optional environment variable DISABLE_AGENT_SDS that inhibits the startup of the SDS server inside the agent
+  even when the well-known /var/run/secrets/workload-spiffe-uds/socket does not exist. This is useful when the SPIRE agent
+  will be used to implement SDS on that socket instead but might not have started yet.


### PR DESCRIPTION
**Please provide a description of this PR:**

The istio-agent/agent.go code checks whether the security.WorkloadIdentitySocketPath exists before starting the Istio SDS server to create that socket.

When using helm to install Istio and SPIRE, the order in which SPIRE and Istio are started is non-deterministic, so this may cause the Istio agent to incorrectly create the socket if SPIRE is started after Istio. It is a kubernetes anti-pattern to force a specific start order during deployment. 

This adds an optional environment variable (like the other boolean agent options) that inhibits the startup of the SDS server by agent.go even when that socket doesn’t yet exist because SPIRE hasn't gotten around to it.