### PR TITLE
operator: optimizate predicate

### DIFF
--- a/operator/pkg/controller/istiocontrolplane/istiocontrolplane_controller.go
+++ b/operator/pkg/controller/istiocontrolplane/istiocontrolplane_controller.go
@@ -15,11 +15,9 @@
 package istiocontrolplane
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"os"
-	"reflect"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/api/errors"

--- a/operator/pkg/controller/istiocontrolplane/istiocontrolplane_controller.go
+++ b/operator/pkg/controller/istiocontrolplane/istiocontrolplane_controller.go
@@ -190,41 +190,13 @@ var (
 				metrics.IncrementReconcileRequest("update_deletion_timestamp")
 				return true
 			}
+
 			if oldIOP.GetGeneration() != newIOP.GetGeneration() {
 				metrics.IncrementReconcileRequest("update_generation")
 				return true
 			}
-			if !reflect.DeepEqual(oldIOP.Spec, newIOP.Spec) {
-				// hach for configuration like following:
-				//   apiVersion: install.istio.io/v1alpha1
-				//   kind: IstioOperator
-				//   metadata:
-				//     name: istio
-				//     namespace: istio-system
-				//   spec:
-				//     meshConfig:
-				//       defaultConfig:
-				//         proxyMetadata: {}
-				// reflect.DeepEqual always return false even there's no changes in spec
-				oldSpecJSON, err := oldIOP.Spec.MarshalJSON()
-				if err != nil {
-					scope.Error("failed to marshal IstioOperator")
-					return false
-				}
-				newSpecJSON, err := newIOP.Spec.MarshalJSON()
-				if err != nil {
-					scope.Error("failed to marshal IstioOperator")
-					return false
-				}
 
-				if bytes.Equal(oldSpecJSON, newSpecJSON) {
-					return false
-				}
-
-				metrics.IncrementReconcileRequest("update_spec")
-				return true
-			}
-
+			// if generation unchanged, spec also unchanged
 			return false
 		},
 	}

--- a/operator/pkg/metrics/monitoring.go
+++ b/operator/pkg/metrics/monitoring.go
@@ -41,6 +41,9 @@ var (
 	// ResourceKindLabel indicates the kind of resource owned
 	// or created or updated or deleted or pruned by operator.
 	ResourceKindLabel = monitoring.MustCreateLabel("kind")
+
+	// ReconcileRequestReasonLabel describes reason of reconcile request.
+	ReconcileRequestReasonLabel = monitoring.MustCreateLabel("reason")
 )
 
 // MergeErrorType describes the class of errors that could
@@ -99,6 +102,12 @@ var (
 		"version",
 		"Version of operator binary",
 		monitoring.WithLabels(OperatorVersionLabel),
+	)
+
+	ReconcileRequestTotal = monitoring.NewSum(
+		"reconcile_request_total",
+		"Number of times requesting Reconcile",
+		monitoring.WithLabels(ReconcileRequestReasonLabel),
 	)
 
 	// GetCRErrorTotal counts the number of times fetching
@@ -225,7 +234,13 @@ func init() {
 		ManifestRenderErrorTotal,
 		LegacyPathTranslationTotal,
 		CacheFlushTotal,
+
+		ReconcileRequestTotal,
 	)
 
 	initOperatorCrdResourceMetrics()
+}
+
+func IncrementReconcileRequest(reason string) {
+	ReconcileRequestTotal.With(ReconcileRequestReasonLabel.Value(reason)).Increment()
 }


### PR DESCRIPTION
**Please provide a description of this PR:**

during debug https://github.com/istio/istio/issues/41417, I found that `reflect.DeepEqual(oldIOP.Spec, newIOP.Spec)` always return false with following yaml:

```yaml
apiVersion: install.istio.io/v1alpha1
kind: IstioOperator
metadata:
  name: istio
  namespace: istio-system
spec:
  meshConfig:
    defaultConfig:
      proxyMetadata: {}
```

this PR will add new count metric for `Reconcile` and optimizate predicate 