### PR TITLE
operator: move metric port to 15014

### DIFF
--- a/manifests/charts/istio-operator/files/gen-operator.yaml
+++ b/manifests/charts/istio-operator/files/gen-operator.yaml
@@ -170,6 +170,9 @@ spec:
     metadata:
       labels:
         name: istio-operator
+      annotations:
+        prometheus.io/port: "15014"
+        prometheus.io/scrape: "true"
     spec:
       serviceAccountName: istio-operator
       containers:
@@ -178,6 +181,8 @@ spec:
           command:
           - operator
           - server
+          - --monitoring-host=127.0.0.1
+          - --monitoring-port=15014
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/manifests/charts/istio-operator/templates/deployment.yaml
+++ b/manifests/charts/istio-operator/templates/deployment.yaml
@@ -16,8 +16,10 @@ spec:
         {{- range $key, $val := .Values.podLabels }}
         {{ $key }}: "{{ $val }}"
         {{- end }}
-    {{- if .Values.podAnnotations }}
       annotations:
+        prometheus.io/port: "{{ .Values.operator.monitoring.port }}"
+        prometheus.io/scrape: "true"
+    {{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
     {{- end }}
     spec:
@@ -28,6 +30,8 @@ spec:
           command:
           - operator
           - server
+          - --monitoring-host={{ .Values.operator.monitoring.host }}
+          - --monitoring-port={{ .Values.operator.monitoring.port }}
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/manifests/charts/istio-operator/values.yaml
+++ b/manifests/charts/istio-operator/values.yaml
@@ -20,6 +20,9 @@ deploymentHistory: 10
 
 # Operator resource defaults
 operator:
+  monitoring:
+    host: 127.0.0.1
+    port: 15014
   resources:
     limits:
       cpu: 200m


### PR DESCRIPTION
**Please provide a description of this PR:**

- allow custom metric address on operator pod
- change default port 15014(same as pilot and pilot-agent)