### PR TITLE
Add logging in operator controller

### DIFF
--- a/operator/pkg/controller/istiocontrolplane/istiocontrolplane_controller.go
+++ b/operator/pkg/controller/istiocontrolplane/istiocontrolplane_controller.go
@@ -365,9 +365,11 @@ func (r *ReconcileIstioOperator) Reconcile(_ context.Context, request reconcile.
 	}
 	reconciler, err := helmreconciler.NewHelmReconciler(r.client, r.kubeClient, iopMerged, helmReconcilerOptions)
 	if err != nil {
+		scope.Errorf("Error during reconcile. Error: %s", err)
 		return reconcile.Result{}, err
 	}
 	if err := reconciler.SetStatusBegin(); err != nil {
+		scope.Errorf("Error during reconcile, failed to update status to Begin. Error: %s", err)
 		return reconcile.Result{}, err
 	}
 	status, err := reconciler.Reconcile()
@@ -375,6 +377,7 @@ func (r *ReconcileIstioOperator) Reconcile(_ context.Context, request reconcile.
 		scope.Errorf("Error during reconcile: %s", err)
 	}
 	if err := reconciler.SetStatusComplete(status); err != nil {
+		scope.Errorf("Error during reconcile, failed to update status to Complete. Error: %s", err)
 		return reconcile.Result{}, err
 	}
 


### PR DESCRIPTION
**Please provide a description of this PR:**
Adding additional log statements to troubleshoot unexpected issues during operator reconciliation.

In my case, authz errors were not printed when the ClusterRole was misconfigured and resulted in below error:

`istiooperators.install.istio.io "istiod" is forbidden: User "system:serviceaccount:mesh-control-plane:istio-operator-rvfzv5kdwqktwvc" cannot update resource "istiooperators/status" in API group "install.istio.io" in the namespace "mesh-control-plane"`