### PR TITLE
istioctl experimental: change the short of the precheck subcommand to start with uppercase

### DIFF
--- a/istioctl/cmd/precheck.go
+++ b/istioctl/cmd/precheck.go
@@ -58,7 +58,7 @@ func preCheck() *cobra.Command {
 	// cmd represents the upgradeCheck command
 	cmd := &cobra.Command{
 		Use:   "precheck",
-		Short: "check whether Istio can safely be installed or upgrade",
+		Short: "Check whether Istio can safely be installed or upgrade",
 		Long:  `precheck inspects a Kubernetes cluster for Istio install and upgrade requirements.`,
 		Example: `  # Verify that Istio can be installed or upgraded
   istioctl x precheck


### PR DESCRIPTION
**Please provide a description of this PR:**

When we execute `istioctl experimental -h`, the help short is shown as follows. Except for the short of precheck, all the other subcommands start with uppercase letters. This pr modifiers it
```shell
Experimental commands that may be modified or deprecated

Usage:
  istioctl experimental [command]

Aliases:
  experimental, x, exp

Available Commands:
  add-to-mesh          Add workloads into Istio service mesh
  authz                Inspect Istio AuthorizationPolicy
  config               Configure istioctl defaults
  create-remote-secret Create a secret with credentials to allow Istio to access remote Kubernetes apiservers
  describe             Describe resource and related Istio configuration
  envoy-stats          Retrieves Envoy metrics in the specified pod
  injector             List sidecar injector and sidecar versions
  internal-debug       Retrieves the debug information of istio
  kube-uninject        Uninject Envoy sidecar from Kubernetes pod resources
  metrics              Prints the metrics for the specified workload(s) when running in Kubernetes.
  precheck             check whether Istio can safely be installed or upgrade
  proxy-status         Retrieves the synchronization status of each Envoy in the mesh
  remote-clusters      Lists the remote clusters each istiod instance is connected to.
  remove-from-mesh     Remove workloads from Istio service mesh
  revision             Provide insight into various revisions (istiod, gateways) installed in the cluster
  uninstall            Uninstall Istio from a cluster (uninstall has graduated. Use `istioctl uninstall`)
  version              Prints out build version information
  wait                 Wait for an Istio resource
  workload             Commands to assist in configuring and deploying workloads running on VMs and other non-Kubernetes environments
```