### PR TITLE
Use contants string instead of string literals as cacerts secrect name

### DIFF
--- a/pilot/pkg/bootstrap/istio_ca.go
+++ b/pilot/pkg/bootstrap/istio_ca.go
@@ -270,7 +270,7 @@ func (s *Server) loadCACerts(caOpts *caOptions, dir string) error {
 	}
 
 	secret, err := s.kubeClient.Kube().CoreV1().Secrets(caOpts.Namespace).Get(
-		context.TODO(), "cacerts", metav1.GetOptions{})
+		context.TODO(), ca.ExternalCASecret, metav1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return nil

--- a/security/pkg/pki/ca/ca.go
+++ b/security/pkg/pki/ca/ca.go
@@ -57,6 +57,8 @@ const (
 	TLSSecretRootCertFile = "ca.crt"
 	// The standard key size to use when generating an RSA private key
 	rsaKeySize = 2048
+	//ExternalCASecret stores the key/cert of self-signed CA from external Istiod.
+	ExternalCASecret = "cacerts"
 )
 
 // SigningCAFileBundle locations of the files used for the signing CA

--- a/security/pkg/pki/ca/ca.go
+++ b/security/pkg/pki/ca/ca.go
@@ -57,7 +57,7 @@ const (
 	TLSSecretRootCertFile = "ca.crt"
 	// The standard key size to use when generating an RSA private key
 	rsaKeySize = 2048
-	//ExternalCASecret stores the key/cert of self-signed CA from external Istiod.
+	// ExternalCASecret stores the key/cert of self-signed CA from external Istiod.
 	ExternalCASecret = "cacerts"
 )
 


### PR DESCRIPTION
**Please provide a description of this PR:**
When with external Istiod, we want to beable to load cacerts from a remote cluster, the secrest name is a string literals, we'd better use a constants instread.