### PR TITLE
pilot: avoid spam from unset CIDR

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/tls.go
+++ b/pilot/pkg/networking/core/v1alpha3/tls.go
@@ -202,9 +202,13 @@ func buildSidecarOutboundTLSFilterChainOpts(node *model.Proxy, push *model.PushC
 		}
 		destinationRule := CastDestinationRule(node.SidecarScope.DestinationRule(
 			model.TrafficDirectionOutbound, node, service.Hostname).GetRule())
+		var destinationCIDRs []string
+		if destinationCIDR != "" {
+			destinationCIDRs = []string{destinationCIDR}
+		}
 		out = append(out, &filterChainOpts{
 			sniHosts:         sniHosts,
-			destinationCIDRs: []string{destinationCIDR},
+			destinationCIDRs: destinationCIDRs,
 			networkFilters: buildOutboundNetworkFiltersWithSingleDestination(push, node, statPrefix, clusterName, "",
 				listenPort, destinationRule, tunnelingconfig.Apply),
 		})
@@ -311,8 +315,12 @@ TcpLoop:
 		if len(push.Mesh.OutboundClusterStatName) != 0 {
 			statPrefix = telemetry.BuildStatPrefix(push.Mesh.OutboundClusterStatName, string(service.Hostname), "", &model.Port{Port: port}, &service.Attributes)
 		}
+		var destinationCIDRs []string
+		if destinationCIDR != "" {
+			destinationCIDRs = []string{destinationCIDR}
+		}
 		out = append(out, &filterChainOpts{
-			destinationCIDRs: []string{destinationCIDR},
+			destinationCIDRs: destinationCIDRs,
 			networkFilters: buildOutboundNetworkFiltersWithSingleDestination(push, node, statPrefix, clusterName, "",
 				listenPort, destinationRule, tunnelingconfig.Apply),
 		})

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -131,6 +131,7 @@ func ConvertAddressToCidr(addr string) *core.CidrRange {
 	cidr, err := AddrStrToCidrRange(addr)
 	if err != nil {
 		log.Errorf("failed to convert address %s to CidrRange: %v", addr, err)
+		return nil
 	}
 
 	return cidr


### PR DESCRIPTION
Since
https://github.com/istio/istio/commit/d8ca966bdb326f77d901ad02b1f542ec3d082804, we start logging if CIDR fails to convert. Originally, I thought we should just drop the log, but upon further inspection we are actually passing `[]string{""}` as the cidr which is a bit confusing. This changes it to pass empty list if we have no CIDR (we already do this in some callsites, just not all).

The end result here should be the same as all older releases, and the same as master but without spammy logs.

**Please provide a description of this PR:**