### PR TITLE
envoy: use standard logging format

### DIFF
--- a/pkg/envoy/proxy.go
+++ b/pkg/envoy/proxy.go
@@ -139,7 +139,7 @@ func (e *envoy) args(fname string, bootstrapConfig string) []string {
 	} else {
 		// format is like `2020-04-07T16:52:30.471425Z     info    envoy config   ...message..
 		// this matches Istio log format
-		startupArgs = append(startupArgs, "--log-format", "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %g:%# %v thread=%t")
+		startupArgs = append(startupArgs, "--log-format", "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %g:%#\t%v thread=%t")
 	}
 
 	startupArgs = append(startupArgs, e.extraArgs...)

--- a/pkg/envoy/proxy.go
+++ b/pkg/envoy/proxy.go
@@ -134,12 +134,12 @@ func (e *envoy) args(fname string, bootstrapConfig string) []string {
 	if e.ProxyConfig.LogAsJSON {
 		startupArgs = append(startupArgs,
 			"--log-format",
-			`{"level":"%l","time":"%Y-%m-%dT%T.%fZ","scope":"envoy %n","msg":"%j","loc":"%g:%#","tid":"%t"}`,
+			`{"level":"%l","time":"%Y-%m-%dT%T.%fZ","scope":"envoy %n","msg":"%j","caller":"%g:%#","thread":%t}`,
 		)
 	} else {
 		// format is like `2020-04-07T16:52:30.471425Z     info    envoy config   ...message..
 		// this matches Istio log format
-		startupArgs = append(startupArgs, "--log-format", "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n:%t\t[%g:%#] %v")
+		startupArgs = append(startupArgs, "--log-format", "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %g:%# %v thread=%t")
 	}
 
 	startupArgs = append(startupArgs, e.extraArgs...)

--- a/pkg/envoy/proxy.go
+++ b/pkg/envoy/proxy.go
@@ -136,10 +136,6 @@ func (e *envoy) args(fname string, bootstrapConfig string) []string {
 			"--log-format",
 			`{"level":"%l","time":"%Y-%m-%dT%T.%fZ","scope":"envoy %n","msg":"%j"}`,
 		)
-	} else {
-		// format is like `2020-04-07T16:52:30.471425Z     info    envoy config   ...message..
-		// this matches Istio log format
-		startupArgs = append(startupArgs, "--log-format", "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n\t%v")
 	}
 
 	startupArgs = append(startupArgs, e.extraArgs...)

--- a/pkg/envoy/proxy.go
+++ b/pkg/envoy/proxy.go
@@ -134,8 +134,12 @@ func (e *envoy) args(fname string, bootstrapConfig string) []string {
 	if e.ProxyConfig.LogAsJSON {
 		startupArgs = append(startupArgs,
 			"--log-format",
-			`{"level":"%l","time":"%Y-%m-%dT%T.%fZ","scope":"envoy %n","msg":"%j"}`,
+			`{"level":"%l","time":"%Y-%m-%dT%T.%fZ","scope":"envoy %n","msg":"%j","loc":"%g:%#","tid":"%t"}`,
 		)
+	} else {
+		// format is like `2020-04-07T16:52:30.471425Z     info    envoy config   ...message..
+		// this matches Istio log format
+		startupArgs = append(startupArgs, "--log-format", "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n:%t\t[%g:%#] %v")
 	}
 
 	startupArgs = append(startupArgs, e.extraArgs...)

--- a/pkg/envoy/proxy.go
+++ b/pkg/envoy/proxy.go
@@ -139,7 +139,7 @@ func (e *envoy) args(fname string, bootstrapConfig string) []string {
 	} else {
 		// format is like `2020-04-07T16:52:30.471425Z     info    envoy config   ...message..
 		// this matches Istio log format
-		startupArgs = append(startupArgs, "--log-format", "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %g:%#\t%v thread=%t")
+		startupArgs = append(startupArgs, "--log-format", "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %g:%#\t%v\tthread=%t")
 	}
 
 	startupArgs = append(startupArgs, e.extraArgs...)

--- a/pkg/envoy/proxy_test.go
+++ b/pkg/envoy/proxy_test.go
@@ -62,6 +62,7 @@ func TestEnvoyArgs(t *testing.T) {
 		"--local-address-ip-version", "v4",
 		"--file-flush-interval-msec", "1000",
 		"--disable-hot-restart",
+		"--log-format", "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n:%t\t[%g:%#] %v",
 		"-l", "trace",
 		"--component-log-level", "misc:error",
 		"--config-yaml", `{"key": "value"}`,

--- a/pkg/envoy/proxy_test.go
+++ b/pkg/envoy/proxy_test.go
@@ -62,7 +62,7 @@ func TestEnvoyArgs(t *testing.T) {
 		"--local-address-ip-version", "v4",
 		"--file-flush-interval-msec", "1000",
 		"--disable-hot-restart",
-		"--log-format", "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %g:%#\t%v thread=%t",
+		"--log-format", "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %g:%#\t%v\tthread=%t",
 		"-l", "trace",
 		"--component-log-level", "misc:error",
 		"--config-yaml", `{"key": "value"}`,

--- a/pkg/envoy/proxy_test.go
+++ b/pkg/envoy/proxy_test.go
@@ -62,7 +62,7 @@ func TestEnvoyArgs(t *testing.T) {
 		"--local-address-ip-version", "v4",
 		"--file-flush-interval-msec", "1000",
 		"--disable-hot-restart",
-		"--log-format", "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n:%t\t[%g:%#] %v",
+		"--log-format", "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %g:%#\t%v thread=%t",
 		"-l", "trace",
 		"--component-log-level", "misc:error",
 		"--config-yaml", `{"key": "value"}`,

--- a/pkg/envoy/proxy_test.go
+++ b/pkg/envoy/proxy_test.go
@@ -62,7 +62,6 @@ func TestEnvoyArgs(t *testing.T) {
 		"--local-address-ip-version", "v4",
 		"--file-flush-interval-msec", "1000",
 		"--disable-hot-restart",
-		"--log-format", "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n\t%v",
 		"-l", "trace",
 		"--component-log-level", "misc:error",
 		"--config-yaml", `{"key": "value"}`,


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

Revert logging format to standard Envoy format. There's no good reason to drop important debugging information (worker thread, source location, etc).