### PR TITLE
Add mesh id cluster scoped webhookconfig

### DIFF
--- a/manifests/charts/base/templates/default.yaml
+++ b/manifests/charts/base/templates/default.yaml
@@ -8,6 +8,9 @@ metadata:
     release: {{ .Release.Name }}
     istio: istiod
     istio.io/rev: {{ .Values.defaultRevision }}
+    {{- if .Values.global.meshID }}
+    istio.io/mesh-id: "{{ .Values.global.meshID }}"
+    {{- end }}
 webhooks:
   - name: validation.istio.io
     clientConfig:

--- a/manifests/charts/default/templates/mutatingwebhook.yaml
+++ b/manifests/charts/default/templates/mutatingwebhook.yaml
@@ -34,6 +34,9 @@ metadata:
   labels:
     istio.io/tag: "default"
     istio.io/rev: {{ .Values.revision | default "default" }}
+    {{- if .Values.global.meshID }}
+    istio.io/mesh-id: "{{ .Values.global.meshID }}"
+    {{- end }}
     install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: sidecar-injector

--- a/manifests/charts/default/templates/validatingwebhook.yaml
+++ b/manifests/charts/default/templates/validatingwebhook.yaml
@@ -7,6 +7,9 @@ metadata:
     istio: istiod
     istio.io/rev: {{ .Values.revision | default "default" }}
     istio.io/tag: "default"
+    {{ - if .Values.global.meshID }}
+    istio.io/mesh-id: "{{ .Values.global.meshID }}"
+    {{ - end }}
     # Required to make sure this resource is removed
     # when purging Istio resources
     operator.istio.io/component: Pilot

--- a/manifests/charts/default/templates/validatingwebhook.yaml
+++ b/manifests/charts/default/templates/validatingwebhook.yaml
@@ -7,9 +7,9 @@ metadata:
     istio: istiod
     istio.io/rev: {{ .Values.revision | default "default" }}
     istio.io/tag: "default"
-    {{ - if .Values.global.meshID }}
+    {{- if .Values.global.meshID }}
     istio.io/mesh-id: "{{ .Values.global.meshID }}"
-    {{ - end }}
+    {{- end }}
     # Required to make sure this resource is removed
     # when purging Istio resources
     operator.istio.io/component: Pilot

--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -1678,6 +1678,8 @@ spec:
           env:
           - name: REVISION
             value: "default"
+          - name: MESH_ID
+            value: ""
           - name: JWT_POLICY
             value: third-party-jwt
           - name: PILOT_CERT_PROVIDER

--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -122,6 +122,8 @@ spec:
           env:
           - name: REVISION
             value: "{{ .Values.revision | default `default` }}"
+          - name: MESH_ID
+            value: "{{ .Values.global.meshID }}"
           - name: JWT_POLICY
             value: {{ .Values.global.jwtPolicy }}
           - name: PILOT_CERT_PROVIDER

--- a/manifests/charts/istio-control/istio-discovery/templates/mutatingwebhook.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/mutatingwebhook.yaml
@@ -40,6 +40,9 @@ metadata:
 {{- end }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
+    {{- if .Values.global.meshID }}
+    istio.io/mesh-id: "{{ .Values.global.meshID }}"
+    {{- end }}
     install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: sidecar-injector

--- a/manifests/charts/istio-control/istio-discovery/templates/revision-tags.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/revision-tags.yaml
@@ -41,6 +41,9 @@ metadata:
   labels:
     istio.io/tag: {{ $tagName }}
     istio.io/rev: {{ $.Values.revision | default "default" }}
+    {{- if .Values.global.meshID }}
+    istio.io/mesh-id: "{{ .Values.global.meshID }}"
+    {{- end }}
     install.operator.istio.io/owning-resource: {{ $.Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: sidecar-injector

--- a/manifests/charts/istio-control/istio-discovery/templates/validatingwebhookconfiguration.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/validatingwebhookconfiguration.yaml
@@ -8,6 +8,9 @@ metadata:
     release: {{ .Release.Name }}
     istio: istiod
     istio.io/rev: {{ .Values.revision | default "default" }}
+    {{- if .Values.global.meshID }}
+    istio.io/mesh-id: "{{ .Values.global.meshID }}"
+    {{- end }}
 webhooks:
   # Webhook handling per-revision validation. Mostly here so we can determine whether webhooks
   # are rejecting invalid configs on a per-revision basis.

--- a/manifests/charts/istiod-remote/templates/default.yaml
+++ b/manifests/charts/istiod-remote/templates/default.yaml
@@ -9,6 +9,9 @@ metadata:
     release: {{ .Release.Name }}
     istio: istiod
     istio.io/rev: {{ .Values.defaultRevision }}
+    {{- if .Values.global.meshID }}
+    istio.io/mesh-id: "{{ .Values.global.meshID }}"
+    {{- end }}
 webhooks:
   - name: validation.istio.io
     clientConfig:

--- a/manifests/charts/istiod-remote/templates/mutatingwebhook.yaml
+++ b/manifests/charts/istiod-remote/templates/mutatingwebhook.yaml
@@ -40,6 +40,9 @@ metadata:
 {{- end }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
+    {{- if .Values.global.meshID }}
+    istio.io/mesh-id: "{{ .Values.global.meshID }}"
+    {{- end }}
     install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: sidecar-injector

--- a/manifests/charts/istiod-remote/templates/validatingwebhookconfiguration.yaml
+++ b/manifests/charts/istiod-remote/templates/validatingwebhookconfiguration.yaml
@@ -9,6 +9,9 @@ metadata:
     release: {{ .Release.Name }}
     istio: istiod
     istio.io/rev: {{ .Values.revision | default "default" }}
+    {{- if .Values.global.meshID }}
+    istio.io/mesh-id: "{{ .Values.global.meshID }}"
+    {{- end }}
 webhooks:
   # Webhook handling per-revision validation. Mostly here so we can determine whether webhooks
   # are rejecting invalid configs on a per-revision basis.

--- a/pilot/pkg/bootstrap/options.go
+++ b/pilot/pkg/bootstrap/options.go
@@ -51,6 +51,7 @@ type RegistryOptions struct {
 
 // PilotArgs provides all of the configuration parameters for the Pilot discovery service.
 type PilotArgs struct {
+	MeshID             string
 	ServerOptions      DiscoveryServerOptions
 	InjectionOptions   InjectionOptions
 	PodName            string
@@ -117,9 +118,13 @@ var (
 		"The JWT rule used by istiod authentication").Get()
 )
 
-// Revision is the value of the Istio control plane revision, e.g. "canary",
-// and is the value used by the "istio.io/rev" label.
-var Revision = env.Register("REVISION", "", "").Get()
+var (
+	// Revision is the value of the Istio control plane revision, e.g. "canary",
+	// and is the value used by the "istio.io/rev" label.
+	Revision = env.Register("REVISION", "", "").Get()
+	// MeshID is the id of the mesh.
+	MeshID = env.Register("MESH_ID", "", "").Get()
+)
 
 // NewPilotArgs constructs pilotArgs with default values.
 func NewPilotArgs(initFuncs ...func(*PilotArgs)) *PilotArgs {
@@ -138,6 +143,7 @@ func NewPilotArgs(initFuncs ...func(*PilotArgs)) *PilotArgs {
 
 // Apply default value to PilotArgs
 func (p *PilotArgs) applyDefaults() {
+	p.MeshID = MeshID
 	p.Namespace = PodNamespace
 	p.PodName = PodName
 	p.Revision = Revision

--- a/pilot/pkg/bootstrap/servicecontroller.go
+++ b/pilot/pkg/bootstrap/servicecontroller.go
@@ -84,6 +84,7 @@ func (s *Server) initKubeRegistry(args *PilotArgs) (err error) {
 		s.serviceEntryController,
 		s.configController,
 		s.istiodCertBundleWatcher,
+		args.MeshID,
 		args.Revision,
 		s.shouldStartNsController(),
 		s.environment.ClusterLocal(),

--- a/pilot/pkg/bootstrap/sidecarinjector.go
+++ b/pilot/pkg/bootstrap/sidecarinjector.go
@@ -93,7 +93,7 @@ func (s *Server) initSidecarInjector(args *PilotArgs) (*inject.Webhook, error) {
 		s.addStartFunc(func(stop <-chan struct{}) error {
 			// No leader election - different istiod revisions will patch their own cert.
 			// update webhook configuration by watching the cabundle
-			patcher, err := webhooks.NewWebhookCertPatcher(s.kubeClient, args.Revision, webhookName, s.istiodCertBundleWatcher)
+			patcher, err := webhooks.NewWebhookCertPatcher(s.kubeClient, args.MeshID, args.Revision, webhookName, s.istiodCertBundleWatcher)
 			if err != nil {
 				log.Errorf("failed to create webhook cert patcher: %v", err)
 				return nil

--- a/pilot/pkg/bootstrap/validation.go
+++ b/pilot/pkg/bootstrap/validation.go
@@ -43,7 +43,7 @@ func (s *Server) initConfigValidation(args *PilotArgs) error {
 		s.addStartFunc(func(stop <-chan struct{}) error {
 			log.Infof("Starting validation controller")
 			go controller.NewValidatingWebhookController(
-				s.kubeClient, args.Revision, args.Namespace, s.istiodCertBundleWatcher).Run(stop)
+				s.kubeClient, args.MeshID, args.Revision, args.Namespace, s.istiodCertBundleWatcher).Run(stop)
 			return nil
 		})
 	}

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -78,6 +78,7 @@ type Multicluster struct {
 
 	startNsController bool
 	caBundleWatcher   *keycertbundle.Watcher
+	meshID            string
 	revision          string
 
 	// secretNamespace where we get cluster-access secrets
@@ -93,6 +94,7 @@ func NewMulticluster(
 	serviceEntryController *serviceentry.Controller,
 	configController model.ConfigStoreController,
 	caBundleWatcher *keycertbundle.Watcher,
+	meshID string,
 	revision string,
 	startNsController bool,
 	clusterLocal model.ClusterLocalProvider,
@@ -106,6 +108,7 @@ func NewMulticluster(
 		configController:       configController,
 		startNsController:      startNsController,
 		caBundleWatcher:        caBundleWatcher,
+		meshID:                 meshID,
 		revision:               revision,
 		XDSUpdater:             opts.XDSUpdater,
 		remoteKubeControllers:  remoteKubeController,
@@ -301,7 +304,7 @@ func (m *Multicluster) initializeCluster(cluster *multicluster.Cluster, kubeCont
 		// operator or CI/CD
 		if features.InjectionWebhookConfigName != "" {
 			log.Infof("initializing injection webhook cert patcher for cluster %s", cluster.ID)
-			patcher, err := webhooks.NewWebhookCertPatcher(client, m.revision, webhookName, m.caBundleWatcher)
+			patcher, err := webhooks.NewWebhookCertPatcher(client, m.meshID, m.revision, webhookName, m.caBundleWatcher)
 			if err != nil {
 				log.Errorf("could not initialize webhook cert patcher: %v", err)
 			} else {

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster_test.go
@@ -100,7 +100,7 @@ func Test_KubeSecretController(t *testing.T) {
 			DomainSuffix:          DomainSuffix,
 			MeshWatcher:           mesh.NewFixedWatcher(&meshconfig.MeshConfig{}),
 			MeshServiceController: mockserviceController,
-		}, nil, nil, nil, "default", false, nil, s)
+		}, nil, nil, nil, "", "default", false, nil, s)
 	initController(clientset, testSecretNameSpace, stop, mc)
 	clientset.RunAndWait(stop)
 	_ = s.Start(stop)
@@ -150,7 +150,7 @@ func Test_KubeSecretController_ExternalIstiod_MultipleClusters(t *testing.T) {
 			DomainSuffix:          DomainSuffix,
 			MeshWatcher:           mesh.NewFixedWatcher(&meshconfig.MeshConfig{}),
 			MeshServiceController: mockserviceController,
-		}, nil, nil, certWatcher, "default", false, nil, s)
+		}, nil, nil, certWatcher, "", "default", false, nil, s)
 	initController(clientset, testSecretNameSpace, stop, mc)
 	clientset.RunAndWait(stop)
 	_ = s.Start(stop)

--- a/pkg/webhooks/webhookpatch_test.go
+++ b/pkg/webhooks/webhookpatch_test.go
@@ -228,7 +228,7 @@ func TestMutatingWebhookPatch(t *testing.T) {
 
 			watcher := keycertbundle.NewWatcher()
 			watcher.SetAndNotify(nil, nil, tc.pemData)
-			whPatcher, err := NewWebhookCertPatcher(client, tc.revision, tc.webhookName, watcher)
+			whPatcher, err := NewWebhookCertPatcher(client, "", tc.revision, tc.webhookName, watcher)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
**Please provide a description of this PR:**

This is to support multi control plane deployments. RFC is [here](https://docs.google.com/document/d/1y4liRJbQW0NCMeQtqMma46flVqs-izV1/edit) 

We need to distinguish cluster scoped resources `mutatingWebhookConfiguration` and `validatingWebhookConfiguration`

This patch added mesh ID label to the configs, so istiod can only handle configs which belong to it.

TODO: apply discoverySelector to the configs.