### PR TITLE
istioctl example: Modify the example display format of 'istioctl x version -h' and 'istioctl profile -h'

### DIFF
--- a/istioctl/cmd/version.go
+++ b/istioctl/cmd/version.go
@@ -112,21 +112,21 @@ func xdsVersionCommand() *cobra.Command {
 		}
 		return nil
 	}
-	versionCmd.Example = `# Retrieve version information directly from the control plane, using token security
-# (This is the usual way to get the control plane version with an out-of-cluster control plane.)
-istioctl x version --xds-address istio.cloudprovider.example.com:15012
+	versionCmd.Example = `  # Retrieve version information directly from the control plane, using token security
+  # (This is the usual way to get the control plane version with an out-of-cluster control plane.)
+  istioctl x version --xds-address istio.cloudprovider.example.com:15012
 
-# Retrieve version information via Kubernetes config, using token security
-# (This is the usual way to get the control plane version with an in-cluster control plane.)
-istioctl x version
+  # Retrieve version information via Kubernetes config, using token security
+  # (This is the usual way to get the control plane version with an in-cluster control plane.)
+  istioctl x version
 
-# Retrieve version information directly from the control plane, using RSA certificate security
-# (Certificates must be obtained before this step.  The --cert-dir flag lets istioctl bypass the Kubernetes API server.)
-istioctl x version --xds-address istio.example.com:15012 --cert-dir ~/.istio-certs
+  # Retrieve version information directly from the control plane, using RSA certificate security
+  # (Certificates must be obtained before this step.  The --cert-dir flag lets istioctl bypass the Kubernetes API server.)
+  istioctl x version --xds-address istio.example.com:15012 --cert-dir ~/.istio-certs
 
-# Retrieve version information via XDS from specific control plane in multi-control plane in-cluster configuration
-# (Select a specific control plane in an in-cluster canary Istio configuration.)
-istioctl x version --xds-label istio.io/rev=default
+  # Retrieve version information via XDS from specific control plane in multi-control plane in-cluster configuration
+  # (Select a specific control plane in an in-cluster canary Istio configuration.)
+  istioctl x version --xds-label istio.io/rev=default
 `
 
 	versionCmd.Flags().VisitAll(func(flag *pflag.Flag) {

--- a/operator/cmd/mesh/profile.go
+++ b/operator/cmd/mesh/profile.go
@@ -26,8 +26,10 @@ func ProfileCmd(logOpts *log.Options) *cobra.Command {
 		Use:   "profile",
 		Short: "Commands related to Istio configuration profiles",
 		Long:  "The profile command lists, dumps or diffs Istio configuration profiles.",
-		Example: "istioctl profile list\n" +
-			"istioctl install --set profile=demo  # Use a profile from the list",
+		Example: `  # Use a profile from the list
+  istioctl profile list
+  istioctl install --set profile=demo
+`,
 	}
 
 	pdArgs := &profileDumpArgs{}


### PR DESCRIPTION
**Please provide a description of this PR:**

After executing `istioctl x version -h` and `istioctl profile-h`, the following information is displayed. You can see that the example printed in example has a problem with indentation. This pr modifiers it
```shell
➜  istio git:(master) ✗ istioctl x version -h
···
Examples:
# Retrieve version information directly from the control plane, using token security
# (This is the usual way to get the control plane version with an out-of-cluster control plane.)
istioctl x version --xds-address istio.cloudprovider.example.com:15012

# Retrieve version information via Kubernetes config, using token security
# (This is the usual way to get the control plane version with an in-cluster control plane.)
istioctl x version

# Retrieve version information directly from the control plane, using RSA certificate security
# (Certificates must be obtained before this step.  The --cert-dir flag lets istioctl bypass the Kubernetes API server.)
istioctl x version --xds-address istio.example.com:15012 --cert-dir ~/.istio-certs

# Retrieve version information via XDS from specific control plane in multi-control plane in-cluster configuration
# (Select a specific control plane in an in-cluster canary Istio configuration.)
istioctl x version --xds-label istio.io/rev=default
···

➜  istio git:(master) ✗ istioctl profile -h  
···
Examples:
istioctl profile list
istioctl install --set profile=demo  # Use a profile from the list
···

```