### PR TITLE
Replace `sync.Map` in memory store

### DIFF
--- a/pilot/pkg/config/memory/store.go
+++ b/pilot/pkg/config/memory/store.go
@@ -50,18 +50,18 @@ func MakeSkipValidation(schemas collection.Schemas) model.ConfigStore {
 func newStore(schemas collection.Schemas, skipValidation bool) model.ConfigStore {
 	out := store{
 		schemas:        schemas,
-		data:           make(map[config.GroupVersionKind]map[string]*sync.Map),
+		data:           make(map[config.GroupVersionKind]map[string]map[string]any),
 		skipValidation: skipValidation,
 	}
 	for _, s := range schemas.All() {
-		out.data[s.Resource().GroupVersionKind()] = make(map[string]*sync.Map)
+		out.data[s.Resource().GroupVersionKind()] = make(map[string]map[string]any)
 	}
 	return &out
 }
 
 type store struct {
 	schemas        collection.Schemas
-	data           map[config.GroupVersionKind]map[string]*sync.Map
+	data           map[config.GroupVersionKind]map[string]map[string]any
 	skipValidation bool
 	mutex          sync.RWMutex
 }
@@ -83,7 +83,7 @@ func (cr *store) Get(kind config.GroupVersionKind, name, namespace string) *conf
 		return nil
 	}
 
-	out, exists := ns.Load(name)
+	out, exists := ns[name]
 	if !exists {
 		return nil
 	}
@@ -102,20 +102,18 @@ func (cr *store) List(kind config.GroupVersionKind, namespace string) ([]config.
 	out := make([]config.Config, 0, len(cr.data[kind]))
 	if namespace == "" {
 		for _, ns := range data {
-			ns.Range(func(key, value any) bool {
+			for _, value := range ns {
 				out = append(out, value.(config.Config))
-				return true
-			})
+			}
 		}
 	} else {
 		ns, exists := data[namespace]
 		if !exists {
 			return nil, nil
 		}
-		ns.Range(func(key, value any) bool {
+		for _, value := range ns {
 			out = append(out, value.(config.Config))
-			return true
-		})
+		}
 	}
 	return out, nil
 }
@@ -132,12 +130,12 @@ func (cr *store) Delete(kind config.GroupVersionKind, name, namespace string, re
 		return errNotFound
 	}
 
-	_, exists = ns.Load(name)
+	_, exists = ns[name]
 	if !exists {
 		return errNotFound
 	}
 
-	ns.Delete(name)
+	delete(ns, name)
 	return nil
 }
 
@@ -156,11 +154,11 @@ func (cr *store) Create(cfg config.Config) (string, error) {
 	}
 	ns, exists := cr.data[kind][cfg.Namespace]
 	if !exists {
-		ns = new(sync.Map)
+		ns = map[string]any{}
 		cr.data[kind][cfg.Namespace] = ns
 	}
 
-	_, exists = ns.Load(cfg.Name)
+	_, exists = ns[cfg.Name]
 
 	if !exists {
 		tnow := time.Now()
@@ -172,7 +170,7 @@ func (cr *store) Create(cfg config.Config) (string, error) {
 			cfg.CreationTimestamp = tnow
 		}
 
-		ns.Store(cfg.Name, cfg)
+		ns[cfg.Name] = cfg
 		return cfg.ResourceVersion, nil
 	}
 	return "", errAlreadyExists
@@ -197,7 +195,7 @@ func (cr *store) Update(cfg config.Config) (string, error) {
 		return "", errNotFound
 	}
 
-	existing, exists := ns.Load(cfg.Name)
+	existing, exists := ns[cfg.Name]
 	if !exists {
 		return "", errNotFound
 	}
@@ -211,7 +209,7 @@ func (cr *store) Update(cfg config.Config) (string, error) {
 		cfg.ResourceVersion = time.Now().String()
 	}
 
-	ns.Store(cfg.Name, cfg)
+	ns[cfg.Name] = cfg
 	return cfg.ResourceVersion, nil
 }
 
@@ -247,7 +245,7 @@ func (cr *store) Patch(orig config.Config, patchFn config.PatchFunc) (string, er
 
 	rev := time.Now().String()
 	cfg.ResourceVersion = rev
-	ns.Store(cfg.Name, cfg)
+	ns[cfg.Name] = cfg
 
 	return rev, nil
 }

--- a/pilot/pkg/config/memory/store_test.go
+++ b/pilot/pkg/config/memory/store_test.go
@@ -12,22 +12,122 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package memory_test
+package memory
 
 import (
+	"strconv"
 	"testing"
 
-	"istio.io/istio/pilot/pkg/config/memory"
+	"istio.io/api/networking/v1alpha3"
+	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/test/mock"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/collections"
 )
 
 func TestStoreInvariant(t *testing.T) {
-	store := memory.Make(collections.Mocks)
+	store := Make(collections.Mocks)
 	mock.CheckMapInvariant(store, t, "some-namespace", 10)
 }
 
 func TestIstioConfig(t *testing.T) {
-	store := memory.Make(collections.Pilot)
+	store := Make(collections.Pilot)
 	mock.CheckIstioConfigTypes(store, "some-namespace", t)
+}
+
+func BenchmarkStoreGet(b *testing.B) {
+	s := initStore(b)
+	gvk := config.GroupVersionKind{
+		Group:   "networking.istio.io",
+		Version: "v1alpha3",
+		Kind:    "ServiceEntry",
+	}
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		// get one thousand times
+		for i := 0; i < 1000; i++ {
+			if s.Get(gvk, strconv.Itoa(i), "ns") == nil {
+				b.Fatal("get failed")
+			}
+		}
+	}
+}
+
+func BenchmarkStoreCreate(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		initStore(b)
+	}
+}
+
+func BenchmarkStoreUpdate(b *testing.B) {
+	cfg := config.Config{
+		Meta: config.Meta{
+			GroupVersionKind: config.GroupVersionKind{
+				Group:   "networking.istio.io",
+				Version: "v1alpha3",
+				Kind:    "ServiceEntry",
+			},
+			Namespace: "ns",
+		},
+		Spec: &v1alpha3.ServiceEntry{
+			Hosts: []string{"www.foo.com"},
+		},
+	}
+	for n := 0; n < b.N; n++ {
+		b.StopTimer()
+		s := initStore(b)
+		b.StartTimer()
+		// update one thousand times
+		for i := 0; i < 1000; i++ {
+			cfg.Name = strconv.Itoa(i)
+			cfg.Spec.(*v1alpha3.ServiceEntry).Hosts[0] = cfg.Name
+			if _, err := s.Update(cfg); err != nil {
+				b.Fatalf("update failed: %v", err)
+			}
+		}
+	}
+}
+
+func BenchmarkStoreDelete(b *testing.B) {
+	gvk := config.GroupVersionKind{
+		Group:   "networking.istio.io",
+		Version: "v1alpha3",
+		Kind:    "ServiceEntry",
+	}
+	for n := 0; n < b.N; n++ {
+		b.StopTimer()
+		s := initStore(b)
+		b.StartTimer()
+		// delete one thousand times
+		for i := 0; i < 1000; i++ {
+			if err := s.Delete(gvk, strconv.Itoa(i), "ns", nil); err != nil {
+				b.Fatalf("delete failed: %v", err)
+			}
+		}
+	}
+}
+
+// make a new store and add 1000 configs to it
+func initStore(b *testing.B) model.ConfigStore {
+	s := MakeSkipValidation(collections.Pilot)
+	cfg := config.Config{
+		Meta: config.Meta{
+			GroupVersionKind: config.GroupVersionKind{
+				Group:   "networking.istio.io",
+				Version: "v1alpha3",
+				Kind:    "ServiceEntry",
+			},
+			Namespace: "ns",
+		},
+		Spec: &v1alpha3.ServiceEntry{
+			Hosts: []string{"www.foo.com"},
+		},
+	}
+	for i := 0; i < 1000; i++ {
+		cfg.Name = strconv.Itoa(i)
+		if _, err := s.Create(cfg); err != nil {
+			b.Fatalf("create failed: %v", err)
+		}
+	}
+	return s
 }


### PR DESCRIPTION
**Please provide a description of this PR:**
We are using MCP-over-XDS to include external resources, where istiod uses memory store. Given the store operations are locked by the global mutex, we don't need to use `sync.Map`, which does not scale well under frequent updates