### PR TITLE
add `--purge`  flags to operator remove

### DIFF
--- a/operator/cmd/mesh/root.go
+++ b/operator/cmd/mesh/root.go
@@ -54,10 +54,11 @@ This flag can be specified multiple times to overlay multiple files. Multiple fi
 	TagFlagHelpStr                     = `The tag for the operator controller image.`
 	ImagePullSecretsHelpStr            = `The imagePullSecrets are used to pull the operator image from the private registry,
 could be secret list separated by comma, eg. '--imagePullSecrets imagePullSecret1,imagePullSecret2'`
-	OperatorNamespaceHelpstr = `The namespace the operator controller is installed into.`
-	OperatorRevFlagHelpStr   = `Target revision for the operator.`
-	ComponentFlagHelpStr     = "Specify which component to generate manifests for."
-	VerifyCRInstallHelpStr   = "Verify the Istio control plane after installation/in-place upgrade"
+	OperatorNamespaceHelpstr  = `The namespace the operator controller is installed into.`
+	OperatorRevFlagHelpStr    = `Target revision for the operator.`
+	AllOperatorRevFlagHelpStr = `Remove all versions of Istio operator.`
+	ComponentFlagHelpStr      = "Specify which component to generate manifests for."
+	VerifyCRInstallHelpStr    = "Verify the Istio control plane after installation/in-place upgrade"
 )
 
 type RootArgs struct {

--- a/releasenotes/notes/41548.yaml
+++ b/releasenotes/notes/41548.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: istioctl
+issue:
+  - 41547
+releaseNotes:
+  - |
+    **Added** `--purge` flag to `istioctl operator remove` which will remove all revisions of Istio operator.

--- a/tests/integration/operator/switch_cr_test.go
+++ b/tests/integration/operator/switch_cr_test.go
@@ -127,6 +127,7 @@ func TestController(t *testing.T) {
 			removeCmd := []string{
 				"operator", "remove",
 				"--skip-confirmation",
+				"--purge",
 			}
 			istioCtl.InvokeOrFail(t, removeCmd)
 


### PR DESCRIPTION
**Please provide a description of this PR:**

Add `--purge` flags to `istioctl operator remove` which will remove all revisions of  Istio operator.

Fix https://github.com/istio/istio/issues/41547