### PR TITLE
gateway-api: cacert resource in same ns is valid

### DIFF
--- a/pilot/pkg/model/credentials/resource.go
+++ b/pilot/pkg/model/credentials/resource.go
@@ -33,6 +33,8 @@ const (
 	// BuiltinGatewaySecretType is the name of a SDS secret that uses the workloads own mTLS certificate
 	BuiltinGatewaySecretType    = "builtin"
 	BuiltinGatewaySecretTypeURI = BuiltinGatewaySecretType + "://"
+	// SdsCaSuffix is the suffix of the sds resource name for root CA.
+	SdsCaSuffix = "-cacert"
 )
 
 // SecretResource defines a reference to a secret

--- a/pilot/pkg/model/gateway.go
+++ b/pilot/pkg/model/gateway.go
@@ -175,6 +175,9 @@ func MergeGateways(gateways []gatewayWithInstances, proxy *Proxy, ps *PushContex
 				if gatewayConfig.Namespace == proxy.VerifiedIdentity.Namespace && parse.Namespace == proxy.VerifiedIdentity.Namespace {
 					// Same namespace is always allowed
 					verifiedCertificateReferences.Insert(rn)
+					if s.GetTls().GetMode() == networking.ServerTLSSettings_MUTUAL {
+						verifiedCertificateReferences.Insert(rn + credentials.SdsCaSuffix)
+					}
 				} else if ps.ReferenceAllowed(gvk.Secret, rn, proxy.VerifiedIdentity.Namespace) {
 					// Explicitly allowed by some policy
 					verifiedCertificateReferences.Insert(rn)

--- a/pilot/pkg/security/model/authentication.go
+++ b/pilot/pkg/security/model/authentication.go
@@ -51,7 +51,7 @@ const (
 	K8sSAJwtTokenHeaderKey = "istio_sds_credentials_header-bin"
 
 	// SdsCaSuffix is the suffix of the sds resource name for root CA.
-	SdsCaSuffix = "-cacert"
+	SdsCaSuffix = credentials.SdsCaSuffix
 
 	// EnvoyJwtFilterName is the name of the Envoy JWT filter. This should be the same as the name defined
 	// in https://github.com/envoyproxy/envoy/blob/v1.9.1/source/extensions/filters/http/well_known_names.h#L48


### PR DESCRIPTION
**Please provide a description of this PR:**

Fix bug where `mode: MUTUAL` rejects `-cacert` resource when using Gateway API syntax `kubernetes-gateway://namespace/name` for credentialName/Refs.