### PR TITLE
Add Sidecar validation for duplicate hosts on port

### DIFF
--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -1209,7 +1209,7 @@ var ValidateSidecar = registerValidateFunc("ValidateSidecar",
 					}
 					udsMap[bind] = struct{}{}
 				} else {
-					if _, found := portMap[egress.Port.Number]; found {
+					if _, found := portMap[egress.Port.Number]; found || len(egress.Hosts) > 1 {
 						errs = appendValidation(errs, fmt.Errorf("sidecar: ports on IP bound listeners must be unique"))
 					}
 					portMap[egress.Port.Number] = struct{}{}

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -6052,6 +6052,18 @@ func TestValidateSidecar(t *testing.T) {
 				},
 			},
 		}, false, false},
+		{"egress multiple hosts for single port", &networking.Sidecar{
+			Egress: []*networking.IstioEgressListener{
+				{
+					Hosts: []string{"ns1/foo.com", "ns1/bar.com"},
+					Port: &networking.Port{
+						Protocol: "tcp",
+						Number:   90,
+						Name:     "tcp",
+					},
+				},
+			},
+		}, false, false},
 		{"ingress without port", &networking.Sidecar{
 			Ingress: []*networking.IstioIngressListener{
 				{


### PR DESCRIPTION
When creating EgressListeners on a Sidecar resource, the validation webhook will prevent multiple listeners with the same port. If a single EgressListener is specified with multiple hosts against one port then this is not flagged even though the listener is IP bound and the proxy configuration pushed will only contain one listener.

This PR brings the single EgressListener, multiple hosts and one port case in line with the multiple EgressListeners, each with one host and one port and returns the same validation error to the client.