### PR TITLE
Fix pod Index

### DIFF
--- a/pkg/kube/controllers/index.go
+++ b/pkg/kube/controllers/index.go
@@ -1,0 +1,100 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"sync"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/cache"
+
+	"istio.io/istio/pilot/pkg/serviceregistry/kube"
+	"istio.io/istio/pkg/util/sets"
+)
+
+// Index maintains a simple index over an informer
+type Index[O runtime.Object, K comparable] struct {
+	mu       sync.RWMutex
+	objects  map[K]sets.Set
+	informer cache.SharedIndexInformer
+}
+
+// Lookup finds all objects matching a given key
+func (i *Index[O, K]) Lookup(k K) []O {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	res := make([]O, 0)
+	for obj := range i.objects[k] {
+		item, f, err := i.informer.GetStore().GetByKey(obj)
+		if !f || err != nil {
+			// This should be extremely rare, maybe impossible due to the mutex.
+			continue
+		}
+		res = append(res, item.(O))
+	}
+	return res
+}
+
+// CreateIndex creates a simple index, keyed by key K, over an informer for O. This is similar to
+// Informer.AddIndex, but is easier to use and can be added after an informer has already started.
+func CreateIndex[O runtime.Object, K comparable](
+	informer cache.SharedIndexInformer,
+	extract func(o O) []K,
+) *Index[O, K] {
+	idx := Index[O, K]{
+		objects:  make(map[K]sets.Set),
+		informer: informer,
+		mu:       sync.RWMutex{},
+	}
+	addObj := func(obj any) {
+		ro := extractObject(obj)
+		o := ro.(O)
+		objectKey := kube.KeyFunc(ro.GetName(), ro.GetNamespace())
+		for _, indexKey := range extract(o) {
+			if _, f := idx.objects[indexKey]; !f {
+				idx.objects[indexKey] = sets.New()
+			}
+			idx.objects[indexKey].Insert(objectKey)
+		}
+	}
+	deleteObj := func(obj any) {
+		ro := extractObject(obj)
+		o := ro.(O)
+		objectKey := kube.KeyFunc(ro.GetName(), ro.GetNamespace())
+		for _, indexKey := range extract(o) {
+			idx.objects[indexKey].Delete(objectKey)
+		}
+	}
+	handler := cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj any) {
+			idx.mu.Lock()
+			defer idx.mu.Unlock()
+			addObj(obj)
+		},
+		UpdateFunc: func(oldObj, newObj any) {
+			idx.mu.Lock()
+			defer idx.mu.Unlock()
+			deleteObj(oldObj)
+			addObj(newObj)
+		},
+		DeleteFunc: func(obj any) {
+			idx.mu.Lock()
+			defer idx.mu.Unlock()
+			deleteObj(obj)
+		},
+	}
+	informer.AddEventHandler(handler)
+	return &idx
+}

--- a/pkg/kube/controllers/index_test.go
+++ b/pkg/kube/controllers/index_test.go
@@ -124,7 +124,7 @@ func TestIndex(t *testing.T) {
 	// This can't happen in practice with Pod, but Index supports arbitrary types
 	pod1Alt.Spec.ServiceAccountName = "new-sa"
 
-	kNew := SaNode{
+	keyNew := SaNode{
 		ServiceAccount: types.NamespacedName{
 			Namespace: "ns",
 			Name:      "new-sa",
@@ -132,10 +132,10 @@ func TestIndex(t *testing.T) {
 		Node: "node",
 	}
 	c.Kube().CoreV1().Pods("ns").Update(context.Background(), pod1Alt, metav1.UpdateOptions{})
-	assertIndex(k1, pod3)      // Pod should be dropped from the index
-	assertIndex(kNew, pod1Alt) // And added under the new key
+	assertIndex(k1, pod3)        // Pod should be dropped from the index
+	assertIndex(keyNew, pod1Alt) // And added under the new key
 
 	c.Kube().CoreV1().Pods("ns").Delete(context.Background(), pod1Alt.Name, metav1.DeleteOptions{})
 	assertIndex(k1, pod3) // Shouldn't impact others
-	assertIndex(kNew)     // but should be removed
+	assertIndex(keyNew)   // but should be removed
 }

--- a/pkg/kube/controllers/index_test.go
+++ b/pkg/kube/controllers/index_test.go
@@ -1,0 +1,141 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/test"
+	"istio.io/istio/pkg/test/util/assert"
+	"istio.io/istio/pkg/test/util/retry"
+)
+
+type SaNode struct {
+	ServiceAccount types.NamespacedName
+	Node           string
+}
+
+func TestIndex(t *testing.T) {
+	c := kube.NewFakeClient()
+	informer := c.KubeInformer().Core().V1().Pods().Informer()
+	c.RunAndWait(test.NewStop(t))
+	index := CreateIndex[*corev1.Pod, SaNode](informer, func(pod *corev1.Pod) []SaNode {
+		if len(pod.Spec.NodeName) == 0 {
+			return nil
+		}
+		if len(pod.Spec.ServiceAccountName) == 0 {
+			return nil
+		}
+		return []SaNode{{
+			ServiceAccount: types.NamespacedName{
+				Namespace: pod.Namespace,
+				Name:      pod.Spec.ServiceAccountName,
+			},
+			Node: pod.Spec.NodeName,
+		}}
+	})
+	k1 := SaNode{
+		ServiceAccount: types.NamespacedName{
+			Namespace: "ns",
+			Name:      "sa",
+		},
+		Node: "node",
+	}
+	k2 := SaNode{
+		ServiceAccount: types.NamespacedName{
+			Namespace: "ns",
+			Name:      "sa2",
+		},
+		Node: "node",
+	}
+	assert.Equal(t, index.Lookup(k1), nil)
+	assert.Equal(t, index.Lookup(k2), nil)
+	pod1 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod",
+			Namespace: "ns",
+		},
+		Spec: corev1.PodSpec{
+			ServiceAccountName: "sa",
+			NodeName:           "node",
+		},
+	}
+	pod2 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod2",
+			Namespace: "ns",
+		},
+		Spec: corev1.PodSpec{
+			ServiceAccountName: "sa2",
+			NodeName:           "node",
+		},
+	}
+	pod3 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod3",
+			Namespace: "ns",
+		},
+		Spec: corev1.PodSpec{
+			ServiceAccountName: "sa",
+			NodeName:           "node",
+		},
+	}
+
+	assertIndex := func(k SaNode, pods ...*corev1.Pod) {
+		t.Helper()
+		assert.EventuallyEqual(t, func() []*corev1.Pod { return index.Lookup(k) }, pods, retry.Timeout(time.Second*5))
+	}
+
+	// When we create a pod, we should (eventually) see it in the index
+	c.Kube().CoreV1().Pods("ns").Create(context.Background(), pod1, metav1.CreateOptions{})
+	assertIndex(k1, pod1)
+	assertIndex(k2)
+
+	// Create another pod; we ought to find it as well now.
+	c.Kube().CoreV1().Pods("ns").Create(context.Background(), pod2, metav1.CreateOptions{})
+	assertIndex(k1, pod1) // Original one must still persist
+	assertIndex(k2, pod2) // New one should be there, eventually
+
+	// Create another pod with the same SA; we ought to find multiple now.
+	c.Kube().CoreV1().Pods("ns").Create(context.Background(), pod3, metav1.CreateOptions{})
+	assertIndex(k1, pod1, pod3) // Original one must still persist
+	assertIndex(k2, pod2)       // New one should be there, eventually
+
+	pod1Alt := pod1.DeepCopy()
+	// This can't happen in practice with Pod, but Index supports arbitrary types
+	pod1Alt.Spec.ServiceAccountName = "new-sa"
+
+	kNew := SaNode{
+		ServiceAccount: types.NamespacedName{
+			Namespace: "ns",
+			Name:      "new-sa",
+		},
+		Node: "node",
+	}
+	c.Kube().CoreV1().Pods("ns").Update(context.Background(), pod1Alt, metav1.UpdateOptions{})
+	assertIndex(k1, pod3)      // Pod should be dropped from the index
+	assertIndex(kNew, pod1Alt) // And added under the new key
+
+	c.Kube().CoreV1().Pods("ns").Delete(context.Background(), pod1Alt.Name, metav1.DeleteOptions{})
+	assertIndex(k1, pod3) // Shouldn't impact others
+	assertIndex(kNew)     // but should be removed
+}


### PR DESCRIPTION
The Index we previously used MUST be added before the informer starts. This is challenging when we use a shared index informer, especially if we consider this is not always used, multicluster, possible future usage of indexes, etc.

Previously, there were race conditions where sometimes the indexer was added after the informer started.

Instead, we re-implement the Index concept on *top* of informers, to work around this issue. This also allows us to expose a much easier to use API.

**Please provide a description of this PR:**