### PR TITLE
improve TestBadRemoteSecret portability

### DIFF
--- a/tests/integration/pilot/multicluster_test.go
+++ b/tests/integration/pilot/multicluster_test.go
@@ -254,6 +254,16 @@ stringData:
 			pods := primary.Kube().CoreV1().Pods(ns)
 			podMeta := deps.Items[0].Spec.Template.ObjectMeta
 			podMeta.Name = pod
+			template := deps.Items[0].Spec.Template.Spec
+			for _, container := range template.Containers {
+				if container.Name != "discovery" {
+					continue
+				}
+				container.Env = append(container.Env, corev1.EnvVar{
+					Name:  "PILOT_REMOTE_CLUSTER_TIMEOUT",
+					Value: "15s",
+				})
+			}
 			_, err = pods.Create(context.TODO(), &corev1.Pod{
 				ObjectMeta: podMeta,
 				Spec:       deps.Items[0].Spec.Template.Spec,


### PR DESCRIPTION
Slight improvement that decouples this test from our integration test IstioOperator that sets the env. The env really only needs to be set for this test. 

The test should work better in environments that don't set this. 