### PR TITLE
Ensure analysis client is configured with actual revision

### DIFF
--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -297,7 +297,7 @@ func (s *Server) initInprocessAnalysisController(args *PilotArgs) error {
 			NewLeaderElection(args.Namespace, args.PodName, leaderelection.AnalyzeController, args.Revision, s.kubeClient).
 			AddRunFunction(func(stop <-chan struct{}) {
 				cont, err := incluster.NewController(stop, s.RWConfigStore,
-					s.kubeClient, args.Namespace, s.statusManager, args.RegistryOptions.KubeOptions.DomainSuffix)
+					s.kubeClient, args.Revision, args.Namespace, s.statusManager, args.RegistryOptions.KubeOptions.DomainSuffix)
 				if err != nil {
 					return
 				}

--- a/pkg/config/analysis/incluster/controller.go
+++ b/pkg/config/analysis/incluster/controller.go
@@ -45,14 +45,14 @@ type Controller struct {
 }
 
 func NewController(stop <-chan struct{}, rwConfigStore model.ConfigStoreController,
-	kubeClient kube.Client, namespace string, statusManager *status.Manager, domainSuffix string,
+	kubeClient kube.Client, revision, namespace string, statusManager *status.Manager, domainSuffix string,
 ) (*Controller, error) {
 	ia := local.NewIstiodAnalyzer(analyzers.AllCombined(),
 		"", resource.Namespace(namespace), func(name collection.Name) {}, true)
 	ia.AddSource(rwConfigStore)
 	// Filter out configs watched by rwConfigStore so we don't watch multiple times
 	store, err := crdclient.NewForSchemas(kubeClient,
-		crdclient.Option{Revision: "default", DomainSuffix: domainSuffix, Identifier: "analysis-controller"},
+		crdclient.Option{Revision: revision, DomainSuffix: domainSuffix, Identifier: "analysis-controller"},
 		collections.All.Remove(rwConfigStore.Schemas().All()...))
 	if err != nil {
 		return nil, fmt.Errorf("unable to load common types for analysis, releasing lease: %v", err)

--- a/pkg/config/analysis/local/istiod_analyze.go
+++ b/pkg/config/analysis/local/istiod_analyze.go
@@ -274,7 +274,7 @@ func (sa *IstiodAnalyzer) AddRunningKubeSourceWithRevision(c kubelib.Client, rev
 	// TODO: are either of these string constants intended to vary?
 	// This gets us only istio/ ones
 	store, err := crdclient.NewForSchemas(c, crdclient.Option{
-		Revision:     "default",
+		Revision:     revision,
 		DomainSuffix: "cluster.local",
 		Identifier:   "analysis-controller",
 	}, sa.kubeResources)


### PR DESCRIPTION
This fix ensures that the client in the analysis controller is initialized with the revision istiod is running with.

Without this fix, the analysis controller would erroneously report the following error if Istio is installed with any revision other than `default`:

```
Error [IST0101] (Gateway default/bookinfo-gateway) Referenced selector not found: "istio=ingressgateway"
```

A pod with the label `istio=ingressgateway` exists, but the analysis controller ignores it because its revision isn't `default`.