### PR TITLE
Add delete configmap privilege to fix distribution report cleanup

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -1559,6 +1559,11 @@ rules:
   resources: ["secrets"]
   # TODO lock this down to istio-ca-cert if not using the DNS cert mesh config
   verbs: ["create", "get", "watch", "list", "update", "delete"]
+
+# For status controller, so it can delete the distribution report configmap
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["delete"]
 ---
 # Source: istiod/templates/rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/charts/istio-control/istio-discovery/templates/role.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/role.yaml
@@ -18,3 +18,9 @@ rules:
   resources: ["secrets"]
   # TODO lock this down to istio-ca-cert if not using the DNS cert mesh config
   verbs: ["create", "get", "watch", "list", "update", "delete"]
+
+# For status controller, so it can delete the distribution report configmap
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["delete"]
+

--- a/manifests/charts/istiod-remote/templates/role.yaml
+++ b/manifests/charts/istiod-remote/templates/role.yaml
@@ -19,4 +19,10 @@ rules:
   resources: ["secrets"]
   # TODO lock this down to istio-ca-cert if not using the DNS cert mesh config
   verbs: ["create", "get", "watch", "list", "update", "delete"]
+
+# For status controller, so it can delete the distribution report configmap
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["delete"]
+
 {{- end }}

--- a/releasenotes/notes/41621.yaml
+++ b/releasenotes/notes/41621.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+releaseNotes:
+  - |
+    **Fixed** an issue where istiod, when started with PILOT_ENABLE_STATUS=true, 
+    reported the following error on shutdown: failed to properly clean up distribution report: configmaps 
+    "istiod-xxx-yyy-distribution" is forbidden: User "system:serviceaccount:istio-system:istiod" cannot 
+    delete resource "configmaps" in API group "" in the namespace "istio-system"


### PR DESCRIPTION
This fixes the following error during istiod shutdown when PILOT_ENABLE_STATUS=true:

error   status  failed to properly clean up distribution report: configmaps "istiod-649887579d-rck66-distribution" is forbidden: User "system:serviceaccount:istio-system:istiod" cannot delete resource "configmaps" in API group "" in the namespace "istio-system"