### PR TITLE
add the default revision for operator chart

### DIFF
--- a/manifests/charts/istio-operator/files/gen-operator.yaml
+++ b/manifests/charts/istio-operator/files/gen-operator.yaml
@@ -210,4 +210,4 @@ spec:
             - name: WAIT_FOR_RESOURCES_TIMEOUT
               value: "300s"
             - name: REVISION
-              value: ""
+              value: "default"

--- a/manifests/charts/istio-operator/templates/deployment.yaml
+++ b/manifests/charts/istio-operator/templates/deployment.yaml
@@ -59,7 +59,7 @@ spec:
             - name: WAIT_FOR_RESOURCES_TIMEOUT
               value: {{.Values.waitForResourcesTimeout | quote}}
             - name: REVISION
-              value: {{.Values.revision | quote}}
+              value: {{.Values.revision | default "default"}}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/operator/cmd/mesh/testdata/operator/output/operator-dump.yaml
+++ b/operator/cmd/mesh/testdata/operator/output/operator-dump.yaml
@@ -185,7 +185,7 @@ spec:
             - name: WAIT_FOR_RESOURCES_TIMEOUT
               value: "300s"
             - name: REVISION
-              value: ""
+              value: "default"
 ---
 apiVersion: v1
 kind: Service

--- a/operator/cmd/mesh/testdata/operator/output/operator-init.yaml
+++ b/operator/cmd/mesh/testdata/operator/output/operator-init.yaml
@@ -185,7 +185,7 @@ spec:
             - name: WAIT_FOR_RESOURCES_TIMEOUT
               value: "300s"
             - name: REVISION
-              value: ""
+              value: "default"
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
**Please provide a description of this PR:**
The `REVISION` env of operator deployment may should have a default value of `default` as elsewhere, like: https://github.com/istio/istio/blob/master/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml#L124