### PR TITLE
[bug fix] Skip the pod inaccessible for `istioctl ps --xds-via-agent`

### DIFF
--- a/istioctl/pkg/multixds/gather.go
+++ b/istioctl/pkg/multixds/gather.go
@@ -205,16 +205,18 @@ func queryDebugSynczViaAgents(all bool, dr *xdsapi.DiscoveryRequest, istioNamesp
 				if options.XdsViaAgentsLimit != 0 && touchedPods > options.XdsViaAgentsLimit {
 					fmt.Fprintf(options.MessageWriter, "Some proxies may be missing from the list"+
 						" because the number of visited pod hits the limit %d,"+
-						" which can be set by `--xds-via-agents-limit` flag.", options.XdsViaAgentsLimit)
+						" which can be set by `--xds-via-agents-limit` flag.\n", options.XdsViaAgentsLimit)
 					break GetProxyLoop
 				}
-				if visited[pod.Name+"."+pod.Namespace] {
+				namespacedName := pod.Name + "." + pod.Namespace
+				if visited[namespacedName] {
 					// If we alredy have information about the pod, skip it.
 					continue
 				}
 				resp, err := queryToOnePod(&pod)
 				if err != nil {
-					return nil, err
+					fmt.Fprintf(options.MessageWriter, "Skip the agent in Pod %s due to the error: %s\n", namespacedName, err.Error())
+					continue
 				}
 				responses = append(responses, resp)
 			}

--- a/istioctl/pkg/multixds/gather.go
+++ b/istioctl/pkg/multixds/gather.go
@@ -215,7 +215,7 @@ func queryDebugSynczViaAgents(all bool, dr *xdsapi.DiscoveryRequest, istioNamesp
 				}
 				resp, err := queryToOnePod(&pod)
 				if err != nil {
-					fmt.Fprintf(options.MessageWriter, "Skip the agent in Pod %s due to the error: %s\n", namespacedName, err.Error())
+					fmt.Fprintf(os.Stderr, "Skip the agent in Pod %s due to the error: %s\n", namespacedName, err.Error())
 					continue
 				}
 				responses = append(responses, resp)


### PR DESCRIPTION
This PR proposes to skip the pod inaccessible for the command `istioctl ps --xds-via-agent`.

When there is a pod which is terminating or not running yet, such pod can cause an error when creating a port-forward.
During traversing pods for `istioctl ps --xds-via-agent`, it blocks to go with the other healthy pods.

So, this PR skips such inaccessible pods in the traversing loop.