### PR TITLE
chiron: amend cert watch timeout for DNS certificates

### DIFF
--- a/security/pkg/k8s/chiron/controller.go
+++ b/security/pkg/k8s/chiron/controller.go
@@ -60,7 +60,7 @@ const (
 	certReadInterval = 500 * time.Millisecond
 )
 
-var certWatchTimeout = 5 * time.Second
+var certWatchTimeout = 60 * time.Second
 
 // WebhookController manages the service accounts' secrets that contains Istio keys and certificates.
 type WebhookController struct {


### PR DESCRIPTION
Increase watch timeout only for Istiod DNS certs generated by K8s CA