### PR TITLE
wasm test: do not rely on dns resolution

### DIFF
--- a/pkg/wasm/cache_test.go
+++ b/pkg/wasm/cache_test.go
@@ -166,11 +166,11 @@ func TestWasmCache(t *testing.T) {
 			name:                   "download failure",
 			initialCachedModules:   map[moduleKey]cacheEntry{},
 			initialCachedChecksums: map[string]*checksumEntry{},
-			fetchURL:               "https://dummyurl",
+			fetchURL:               "https://-invalid-url",
 			requestTimeout:         time.Second * 10,
 			wantCachedModules:      map[moduleKey]*cacheEntry{},
 			wantCachedChecksums:    map[string]*checksumEntry{},
-			wantErrorMsgPrefix:     "wasm module download failed after 5 attempts, last error: Get \"https://dummyurl\"",
+			wantErrorMsgPrefix:     "wasm module download failed after 5 attempts, last error: Get \"https://-invalid-url\"",
 			wantVisitServer:        false,
 		},
 		{


### PR DESCRIPTION
Slightly change a test case to not rely on dns resolution.

My system has a slow dns and this test fails because every attempt to reach `https://dummyurl` takes between 3 and 5 seconds. The test case timeout is 10s, which gives room to approximately 2 attempts, not 5 as the test expects.

We could also increase the timeout, but I don't think it's the correct approach.

Changing the test case URL to an invalid one gives us the same result (i.e., testing a download failure) whithout relying on DNS resolution.
