### PR TITLE
ambient: fix CI

### DIFF
--- a/pilot/pkg/ambient/controller/workloadcache.go
+++ b/pilot/pkg/ambient/controller/workloadcache.go
@@ -64,9 +64,10 @@ func initWorkloadCache(opts Options) *workloadCache {
 func (wc *workloadCache) Reconcile(key types.NamespacedName) error {
 	pod, err := wc.pods(key.Namespace).Get(key.Name)
 	if kubeErrors.IsNotFound(err) {
+		log.Debugf("trigger full push on delete pod %s", key)
 		wc.removeFromAll(key)
 		wc.xds.ConfigUpdate(&model.PushRequest{
-			Full: false,
+			Full: true, // TODO: find a better way?
 			ConfigsUpdated: map[model.ConfigKey]struct{}{{
 				Kind:      kind.Pod,
 				Name:      key.Name,
@@ -94,8 +95,9 @@ func (wc *workloadCache) Reconcile(key types.NamespacedName) error {
 		wc.removeFromAll(key)
 	}
 	if update {
+		log.Debugf("trigger full push on delete pod %s", key)
 		wc.xds.ConfigUpdate(&model.PushRequest{
-			Full: false,
+			Full: true, // TODO: find a better way?
 			ConfigsUpdated: map[model.ConfigKey]struct{}{{
 				Kind:      kind.Pod,
 				Name:      key.Name,


### PR DESCRIPTION
**Please provide a description of this PR:**

gateway API CR create after VS, ztunnel will not be updated, request will not send to waypoint.


```console
[2022-10-29T06:51:33.462Z] "- - -" 0 - - - "-" 249 199 10012 - "-" "-" "-" "-" "envoy://outbound_tunnel_lis_spiffe://cluster.local/ns/default/sa/bookinfo-reviews/10.244.1.32:9080" spiffe://cluster.local/ns/default/sa/bookinfo-reviews_to_http_ratings.default.svc.cluster.local_outbound_internal envoy://internal_client_address/ 10.96.254.139:9080 10.244.1.37:57826 - - capture outbound (no waypoint proxy)
```