### PR TITLE
refactor and move hbone cluster code

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -184,7 +184,6 @@ func (configgen *ConfigGeneratorImpl) buildClusters(proxy *model.Proxy, req *mod
 		clusters = inboundPatcher.conditionallyAppend(clusters, nil, cb.buildInboundPassthroughClusters()...)
 		clusters = append(clusters, inboundPatcher.insertedClusters()...)
 		if proxy.EnableHBONE() {
-			clusters = append(clusters, outboundTunnelCluster(proxy, req.Push))
 			clusters = append(clusters, configgen.buildInboundHBONEClusters(cb, instances)...)
 		}
 	default: // Gateways
@@ -198,6 +197,11 @@ func (configgen *ConfigGeneratorImpl) buildClusters(proxy *model.Proxy, req *mod
 			clusters = append(clusters, configgen.buildOutboundSniDnatClusters(proxy, req, patcher)...)
 		}
 		clusters = append(clusters, patcher.insertedClusters()...)
+	}
+
+	// OutboundTunnel cluster is needed for sidecar and gateway.
+	if proxy.EnableHBONE() {
+		clusters = append(clusters, outboundTunnelCluster(proxy, req.Push))
 	}
 
 	// if credential socket exists, create a cluster for it

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -924,7 +924,8 @@ func (cb *ClusterBuilder) applyUpstreamTLSSettings(opts *buildClusterOpts, tls *
 			ConfigType: &core.TransportSocket_TypedConfig{TypedConfig: protoconv.MessageToAny(tlsContext)},
 		}
 	}
-	istioAutodetectedMtls := tls.Mode == networking.ClientTLSSettings_ISTIO_MUTUAL && mtlsCtxType == autoDetected
+	istioAutodetectedMtls := tls != nil && tls.Mode == networking.ClientTLSSettings_ISTIO_MUTUAL &&
+		mtlsCtxType == autoDetected
 	if cb.hbone {
 		cb.applyHBONETransportSocketMatches(c.cluster, tls, istioAutodetectedMtls)
 	} else if c.cluster.GetType() != cluster.Cluster_ORIGINAL_DST {

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -910,13 +910,6 @@ func (cb *ClusterBuilder) applyConnectionPool(mesh *meshconfig.MeshConfig, mc *M
 }
 
 func (cb *ClusterBuilder) applyUpstreamTLSSettings(opts *buildClusterOpts, tls *networking.ClientTLSSettings, mtlsCtxType mtlsContextType) {
-	if tls == nil {
-		if cb.hbone {
-			opts.mutable.cluster.TransportSocketMatches = HboneOrPlaintextSocket
-		}
-		return
-	}
-
 	c := opts.mutable
 
 	tlsContext, err := cb.buildUpstreamClusterTLSContext(opts, tls)
@@ -931,45 +924,65 @@ func (cb *ClusterBuilder) applyUpstreamTLSSettings(opts *buildClusterOpts, tls *
 			ConfigType: &core.TransportSocket_TypedConfig{TypedConfig: protoconv.MessageToAny(tlsContext)},
 		}
 	}
-
-	// For headless service, discover type will be `Cluster_ORIGINAL_DST`
-	// Apply auto mtls to clusters excluding these kind of headless service
-	if c.cluster.GetType() != cluster.Cluster_ORIGINAL_DST {
-		// convert to transport socket matcher if the mode was auto detected
-		if tls.Mode == networking.ClientTLSSettings_ISTIO_MUTUAL && mtlsCtxType == autoDetected {
+	istioAutodetectedMtls := tls.Mode == networking.ClientTLSSettings_ISTIO_MUTUAL && mtlsCtxType == autoDetected
+	if cb.hbone {
+		cb.applyHBONETransportSocketMatches(c.cluster, tls, istioAutodetectedMtls)
+	} else if c.cluster.GetType() != cluster.Cluster_ORIGINAL_DST {
+		// For headless service, discovery type will be `Cluster_ORIGINAL_DST`
+		// Apply auto mtls to clusters excluding these kind of headless services.
+		if istioAutodetectedMtls {
+			// convert to transport socket matcher if the mode was auto detected
 			transportSocket := c.cluster.TransportSocket
 			c.cluster.TransportSocket = nil
-			if cb.hbone {
-				c.cluster.TransportSocketMatches = []*cluster.Cluster_TransportSocketMatch{
-					{
-						Name:            "hbone",
-						Match:           hboneTransportSocketMatch,
-						TransportSocket: InternalUpstreamSocket,
-					},
-					{
-						Name:            "tlsMode-" + model.IstioMutualTLSModeLabel,
-						Match:           istioMtlsTransportSocketMatch,
-						TransportSocket: transportSocket,
-					},
-					defaultTransportSocketMatch(),
-				}
-			} else {
-				c.cluster.TransportSocketMatches = []*cluster.Cluster_TransportSocketMatch{
-					{
-						Name:            "tlsMode-" + model.IstioMutualTLSModeLabel,
-						Match:           istioMtlsTransportSocketMatch,
-						TransportSocket: transportSocket,
-					},
-					defaultTransportSocketMatch(),
-				}
+			c.cluster.TransportSocketMatches = []*cluster.Cluster_TransportSocketMatch{
+				{
+					Name:            "tlsMode-" + model.IstioMutualTLSModeLabel,
+					Match:           istioMtlsTransportSocketMatch,
+					TransportSocket: transportSocket,
+				},
+				defaultTransportSocketMatch(),
 			}
-		} else if cb.hbone {
-			opts.mutable.cluster.TransportSocketMatches = HboneOrPlaintextSocket
+		}
+	}
+}
+
+func (cb *ClusterBuilder) applyHBONETransportSocketMatches(c *cluster.Cluster, tls *networking.ClientTLSSettings,
+	istioAutoDetectedMtls bool,
+) {
+	if tls == nil {
+		c.TransportSocketMatches = HboneOrPlaintextSocket
+		return
+	}
+	// For headless service, discovery type will be `Cluster_ORIGINAL_DST`
+	// Apply auto mtls to clusters excluding these kind of headless services.
+	if c.GetType() != cluster.Cluster_ORIGINAL_DST {
+		// convert to transport socket matcher if the mode was auto detected
+		if istioAutoDetectedMtls {
+			transportSocket := c.TransportSocket
+			c.TransportSocket = nil
+			c.TransportSocketMatches = []*cluster.Cluster_TransportSocketMatch{
+				{
+					Name:            "hbone",
+					Match:           hboneTransportSocketMatch,
+					TransportSocket: InternalUpstreamSocket,
+				},
+				{
+					Name:            "tlsMode-" + model.IstioMutualTLSModeLabel,
+					Match:           istioMtlsTransportSocketMatch,
+					TransportSocket: transportSocket,
+				},
+				defaultTransportSocketMatch(),
+			}
+		} else {
+			c.TransportSocketMatches = HboneOrPlaintextSocket
 		}
 	}
 }
 
 func (cb *ClusterBuilder) buildUpstreamClusterTLSContext(opts *buildClusterOpts, tls *networking.ClientTLSSettings) (*auth.UpstreamTlsContext, error) {
+	if tls == nil {
+		return nil, nil
+	}
 	// Hack to avoid egress sds cluster config generation for sidecar when
 	// CredentialName is set in DestinationRule without a workloadSelector.
 	// We do not want to support CredentialName setting in non workloadSelector based DestinationRules, because

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -61,6 +61,9 @@ const (
 	// Passthrough is the name of the virtual host used to forward traffic to the
 	// PassthroughCluster
 	Passthrough = "allow_any"
+	// OutboundTunnel is HBONE's outbound cluster.
+	OutboundTunnel = "outbound-tunnel"
+
 	// PassthroughFilterChain to catch traffic that doesn't match other filter chains.
 	PassthroughFilterChain = "PassthroughFilterChain"
 


### PR DESCRIPTION
Refactor HBone cluster code. Main goal was to move it to single place 

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure