### PR TITLE
No need to cache when the token is equal to the cached one

### DIFF
--- a/pilot/pkg/model/xds_cache.go
+++ b/pilot/pkg/model/xds_cache.go
@@ -276,7 +276,7 @@ func (l *lruCache) Add(entry XdsCacheEntry, pushReq *PushRequest, value *discove
 	cur, f := l.store.Get(k)
 	if f {
 		// This is the stale resource
-		if token < cur.(cacheValue).token || token < l.token {
+		if token <= cur.(cacheValue).token || token < l.token {
 			// entry may be stale, we need to drop it. This can happen when the cache is invalidated
 			// after we call Get.
 			return

--- a/pilot/pkg/model/xds_cache_test.go
+++ b/pilot/pkg/model/xds_cache_test.go
@@ -114,7 +114,6 @@ func TestAddTwoEntries(t *testing.T) {
 }
 
 func TestCleanIndexesOnAddExistant(t *testing.T) {
-	test.SetForTest(t, &features.XDSCacheMaxSize, 1)
 	zeroTime := time.Time{}
 	res := &discovery.Resource{Name: "test"}
 	req := &PushRequest{Start: zeroTime.Add(time.Duration(1))}
@@ -148,7 +147,7 @@ func TestCleanIndexesOnAddExistant(t *testing.T) {
 		dependentTypes:   []kind.Kind{kind.DestinationRule},
 		dependentConfigs: []ConfigHash{ConfigKey{Kind: kind.DestinationRule, Name: "name", Namespace: "namespace"}.HashCode()},
 	}
-
+	req = &PushRequest{Start: zeroTime.Add(time.Duration(2))}
 	// after adding an entry with the same key, previous indexes are correctly cleaned
 	c.Add(&secondEntry, req, res)
 


### PR DESCRIPTION
**Please provide a description of this PR:**



This may occur when multi goroutines building same xds (like clusterXXX) for different proxy.

1. all go routines get() returns nil
2. one goroutine build its own and add().
3. another goroutinebuild its own and add()

the above two tokens are the same, so we can break fast instead of updating indexes