### PR TITLE
Limit webhook patcher to patch owned webhooks

### DIFF
--- a/pilot/pkg/bootstrap/sidecarinjector.go
+++ b/pilot/pkg/bootstrap/sidecarinjector.go
@@ -31,6 +31,8 @@ import (
 )
 
 const (
+	// Name of the webhook config in the config - no need to change it.
+	webhookName = "sidecar-injector.istio.io"
 	// defaultInjectorConfigMapName is the default name of the ConfigMap with the injection config
 	// The actual name can be different - use getInjectorConfigMapName
 	defaultInjectorConfigMapName = "istio-sidecar-injector"
@@ -91,7 +93,7 @@ func (s *Server) initSidecarInjector(args *PilotArgs) (*inject.Webhook, error) {
 		s.addStartFunc(func(stop <-chan struct{}) error {
 			// No leader election - different istiod revisions will patch their own cert.
 			// update webhook configuration by watching the cabundle
-			patcher, err := webhooks.NewWebhookCertPatcher(s.kubeClient, args.Revision, args.Namespace, s.istiodCertBundleWatcher)
+			patcher, err := webhooks.NewWebhookCertPatcher(s.kubeClient, args.Revision, args.Namespace, webhookName, s.istiodCertBundleWatcher)
 			if err != nil {
 				log.Errorf("failed to create webhook cert patcher: %v", err)
 				return nil

--- a/pilot/pkg/bootstrap/sidecarinjector.go
+++ b/pilot/pkg/bootstrap/sidecarinjector.go
@@ -91,8 +91,7 @@ func (s *Server) initSidecarInjector(args *PilotArgs) (*inject.Webhook, error) {
 		s.addStartFunc(func(stop <-chan struct{}) error {
 			// No leader election - different istiod revisions will patch their own cert.
 			// update webhook configuration by watching the cabundle
-			patcher, err := webhooks.NewWebhookCertPatcher(s.kubeClient, args.Revision,
-				getInjectionWebhookName(args.Revision, args.Namespace), s.istiodCertBundleWatcher)
+			patcher, err := webhooks.NewWebhookCertPatcher(s.kubeClient, args.Revision, args.Namespace, s.istiodCertBundleWatcher)
 			if err != nil {
 				log.Errorf("failed to create webhook cert patcher: %v", err)
 				return nil
@@ -107,17 +106,6 @@ func (s *Server) initSidecarInjector(args *PilotArgs) (*inject.Webhook, error) {
 		return nil
 	})
 	return wh, nil
-}
-
-func getInjectionWebhookName(revision string, namespace string) string {
-	name := features.InjectionWebhookConfigName
-	if revision != "default" {
-		name += "-" + revision
-	}
-	if namespace != "istio-system" {
-		name += "-" + namespace
-	}
-	return name
 }
 
 func getInjectorConfigMapName(revision string) string {

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -298,7 +298,8 @@ func (m *Multicluster) initializeCluster(cluster *multicluster.Cluster, kubeCont
 		// operator or CI/CD
 		if features.InjectionWebhookConfigName != "" {
 			log.Infof("initializing injection webhook cert patcher for cluster %s", cluster.ID)
-			patcher, err := webhooks.NewWebhookCertPatcher(client, m.revision, webhookName, m.caBundleWatcher)
+			patcher, err := webhooks.NewWebhookCertPatcher(client, m.revision,
+				getInjectionWebhookName(m.revision, options.SystemNamespace), m.caBundleWatcher)
 			if err != nil {
 				log.Errorf("could not initialize webhook cert patcher: %v", err)
 			} else {
@@ -389,4 +390,15 @@ func createWleConfigStore(client kubelib.Client, revision string, opts Options) 
 		Build()
 	crdOpts := crdclient.Option{Revision: revision, DomainSuffix: opts.DomainSuffix, Identifier: "mc-workload-entry-controller"}
 	return crdclient.NewForSchemas(client, crdOpts, workloadEntriesSchemas)
+}
+
+func getInjectionWebhookName(revision string, namespace string) string {
+	name := features.InjectionWebhookConfigName
+	if revision != "default" {
+		name += "-" + revision
+	}
+	if namespace != "istio-system" {
+		name += "-" + namespace
+	}
+	return name
 }

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -43,11 +43,6 @@ import (
 	"istio.io/istio/pkg/webhooks"
 )
 
-const (
-	// Name of the webhook config in the config - no need to change it.
-	webhookName = "sidecar-injector.istio.io"
-)
-
 var _ multicluster.ClusterHandler = &Multicluster{}
 
 type kubeController struct {
@@ -298,8 +293,7 @@ func (m *Multicluster) initializeCluster(cluster *multicluster.Cluster, kubeCont
 		// operator or CI/CD
 		if features.InjectionWebhookConfigName != "" {
 			log.Infof("initializing injection webhook cert patcher for cluster %s", cluster.ID)
-			patcher, err := webhooks.NewWebhookCertPatcher(client, m.revision,
-				getInjectionWebhookName(m.revision, options.SystemNamespace), m.caBundleWatcher)
+			patcher, err := webhooks.NewWebhookCertPatcher(client, m.revision, m.opts.SystemNamespace, m.caBundleWatcher)
 			if err != nil {
 				log.Errorf("could not initialize webhook cert patcher: %v", err)
 			} else {
@@ -390,15 +384,4 @@ func createWleConfigStore(client kubelib.Client, revision string, opts Options) 
 		Build()
 	crdOpts := crdclient.Option{Revision: revision, DomainSuffix: opts.DomainSuffix, Identifier: "mc-workload-entry-controller"}
 	return crdclient.NewForSchemas(client, crdOpts, workloadEntriesSchemas)
-}
-
-func getInjectionWebhookName(revision string, namespace string) string {
-	name := features.InjectionWebhookConfigName
-	if revision != "default" {
-		name += "-" + revision
-	}
-	if namespace != "istio-system" {
-		name += "-" + namespace
-	}
-	return name
 }

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -43,6 +43,11 @@ import (
 	"istio.io/istio/pkg/webhooks"
 )
 
+const (
+	// Name of the webhook config in the config - no need to change it.
+	webhookName = "sidecar-injector.istio.io"
+)
+
 var _ multicluster.ClusterHandler = &Multicluster{}
 
 type kubeController struct {
@@ -293,7 +298,7 @@ func (m *Multicluster) initializeCluster(cluster *multicluster.Cluster, kubeCont
 		// operator or CI/CD
 		if features.InjectionWebhookConfigName != "" {
 			log.Infof("initializing injection webhook cert patcher for cluster %s", cluster.ID)
-			patcher, err := webhooks.NewWebhookCertPatcher(client, m.revision, m.opts.SystemNamespace, m.caBundleWatcher)
+			patcher, err := webhooks.NewWebhookCertPatcher(client, m.revision, m.opts.SystemNamespace, webhookName, m.caBundleWatcher)
 			if err != nil {
 				log.Errorf("could not initialize webhook cert patcher: %v", err)
 			} else {

--- a/pkg/webhooks/util/util.go
+++ b/pkg/webhooks/util/util.go
@@ -58,3 +58,14 @@ func VerifyCABundle(caBundle []byte) error {
 	}
 	return nil
 }
+
+func GetWebhookConfigName(webhookPrefix string, revision string, namespace string) string {
+	name := webhookPrefix
+	if revision != "default" {
+		name += "-" + revision
+	}
+	if namespace != "istio-system" {
+		name += "-" + namespace
+	}
+	return name
+}

--- a/pkg/webhooks/validation/controller/controller.go
+++ b/pkg/webhooks/validation/controller/controller.go
@@ -197,7 +197,7 @@ func newController(
 		client: client,
 		queue:  workqueue.NewRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(1*time.Second, 5*time.Minute)),
 	}
-	webhookConfigName := getValidationWebhookConfigName(o.Revision, o.WatchedNamespace)
+	webhookConfigName := util.GetWebhookConfigName(features.ValidationWebhookConfigName, o.Revision, o.WatchedNamespace)
 	webhookInformer := cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
@@ -221,17 +221,6 @@ func newController(
 	c.webhookInformer = webhookInformer
 
 	return c
-}
-
-func getValidationWebhookConfigName(revision string, namespace string) string {
-	name := features.ValidationWebhookConfigName
-	if revision != "default" {
-		name += "-" + revision
-	}
-	if namespace != "istio-system" {
-		name += "-" + namespace
-	}
-	return name
 }
 
 func (c *Controller) Run(stop <-chan struct{}) {

--- a/pkg/webhooks/validation/controller/controller.go
+++ b/pkg/webhooks/validation/controller/controller.go
@@ -41,6 +41,7 @@ import (
 	"istio.io/api/label"
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/client-go/pkg/apis/networking/v1alpha3"
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/keycertbundle"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/kube"
@@ -196,15 +197,21 @@ func newController(
 		client: client,
 		queue:  workqueue.NewRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(1*time.Second, 5*time.Minute)),
 	}
-
+	webhookName := getValidationWebhookName(o.Revision, o.WatchedNamespace)
 	webhookInformer := cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				opts.LabelSelector = fmt.Sprintf("%s=%s", label.IoIstioRev.Name, o.Revision)
+				if features.EnableEnhancedResourceScoping {
+					opts.FieldSelector = fmt.Sprintf("metadata.name=%s", webhookName)
+				}
 				return client.Kube().AdmissionregistrationV1().ValidatingWebhookConfigurations().List(context.TODO(), opts)
 			},
 			WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
 				opts.LabelSelector = fmt.Sprintf("%s=%s", label.IoIstioRev.Name, o.Revision)
+				if features.EnableEnhancedResourceScoping {
+					opts.FieldSelector = fmt.Sprintf("metadata.name=%s", webhookName)
+				}
 				return client.Kube().AdmissionregistrationV1().ValidatingWebhookConfigurations().Watch(context.TODO(), opts)
 			},
 		},
@@ -214,6 +221,17 @@ func newController(
 	c.webhookInformer = webhookInformer
 
 	return c
+}
+
+func getValidationWebhookName(revision string, namespace string) string {
+	name := features.ValidationWebhookConfigName
+	if revision != "default" {
+		name += "-" + revision
+	}
+	if namespace != "istio-system" {
+		name += "-" + namespace
+	}
+	return name
 }
 
 func (c *Controller) Run(stop <-chan struct{}) {

--- a/pkg/webhooks/validation/controller/controller.go
+++ b/pkg/webhooks/validation/controller/controller.go
@@ -197,20 +197,20 @@ func newController(
 		client: client,
 		queue:  workqueue.NewRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(1*time.Second, 5*time.Minute)),
 	}
-	webhookName := getValidationWebhookName(o.Revision, o.WatchedNamespace)
+	webhookConfigName := getValidationWebhookConfigName(o.Revision, o.WatchedNamespace)
 	webhookInformer := cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				opts.LabelSelector = fmt.Sprintf("%s=%s", label.IoIstioRev.Name, o.Revision)
 				if features.EnableEnhancedResourceScoping {
-					opts.FieldSelector = fmt.Sprintf("metadata.name=%s", webhookName)
+					opts.FieldSelector = fmt.Sprintf("metadata.name=%s", webhookConfigName)
 				}
 				return client.Kube().AdmissionregistrationV1().ValidatingWebhookConfigurations().List(context.TODO(), opts)
 			},
 			WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
 				opts.LabelSelector = fmt.Sprintf("%s=%s", label.IoIstioRev.Name, o.Revision)
 				if features.EnableEnhancedResourceScoping {
-					opts.FieldSelector = fmt.Sprintf("metadata.name=%s", webhookName)
+					opts.FieldSelector = fmt.Sprintf("metadata.name=%s", webhookConfigName)
 				}
 				return client.Kube().AdmissionregistrationV1().ValidatingWebhookConfigurations().Watch(context.TODO(), opts)
 			},
@@ -223,7 +223,7 @@ func newController(
 	return c
 }
 
-func getValidationWebhookName(revision string, namespace string) string {
+func getValidationWebhookConfigName(revision string, namespace string) string {
 	name := features.ValidationWebhookConfigName
 	if revision != "default" {
 		name += "-" + revision

--- a/pkg/webhooks/webhookpatch.go
+++ b/pkg/webhooks/webhookpatch.go
@@ -79,7 +79,7 @@ func NewWebhookCertPatcher(
 	informer := admissioninformer.NewFilteredMutatingWebhookConfigurationInformer(client.Kube(), 0, cache.Indexers{}, func(options *metav1.ListOptions) {
 		options.LabelSelector = fmt.Sprintf("%s=%s", label.IoIstioRev.Name, revision)
 		if features.EnableEnhancedResourceScoping {
-			options.FieldSelector = fmt.Sprintf("metadata.name=%s", getInjectionWebhookName(revision, systemNameSpace))
+			options.FieldSelector = fmt.Sprintf("metadata.name=%s", getInjectionWebhookConfigName(revision, systemNameSpace))
 		}
 	})
 	p.informer = informer
@@ -192,7 +192,7 @@ func (w *WebhookCertPatcher) startCaBundleWatcher(stop <-chan struct{}) {
 	}
 }
 
-func getInjectionWebhookName(revision string, namespace string) string {
+func getInjectionWebhookConfigName(revision string, namespace string) string {
 	name := features.InjectionWebhookConfigName
 	if revision != "default" {
 		name += "-" + revision

--- a/pkg/webhooks/webhookpatch.go
+++ b/pkg/webhooks/webhookpatch.go
@@ -65,9 +65,8 @@ type WebhookCertPatcher struct {
 // NewWebhookCertPatcher creates a WebhookCertPatcher
 func NewWebhookCertPatcher(
 	client kubelib.Client,
-	revision, systemNameSpace string, caBundleWatcher *keycertbundle.Watcher,
+	revision, systemNameSpace string, webhookName string, caBundleWatcher *keycertbundle.Watcher,
 ) (*WebhookCertPatcher, error) {
-	webhookName := getInjectionWebhookName(revision, systemNameSpace)
 	p := &WebhookCertPatcher{
 		client:          client.Kube(),
 		revision:        revision,
@@ -80,7 +79,7 @@ func NewWebhookCertPatcher(
 	informer := admissioninformer.NewFilteredMutatingWebhookConfigurationInformer(client.Kube(), 0, cache.Indexers{}, func(options *metav1.ListOptions) {
 		options.LabelSelector = fmt.Sprintf("%s=%s", label.IoIstioRev.Name, revision)
 		if features.EnableEnhancedResourceScoping {
-			options.FieldSelector = fmt.Sprintf("metadata.name=%s", webhookName)
+			options.FieldSelector = fmt.Sprintf("metadata.name=%s", getInjectionWebhookName(revision, systemNameSpace))
 		}
 	})
 	p.informer = informer

--- a/pkg/webhooks/webhookpatch.go
+++ b/pkg/webhooks/webhookpatch.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"istio.io/api/label"
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/keycertbundle"
 	kubelib "istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/controllers"
@@ -77,6 +78,9 @@ func NewWebhookCertPatcher(
 		controllers.WithMaxAttempts(5))
 	informer := admissioninformer.NewFilteredMutatingWebhookConfigurationInformer(client.Kube(), 0, cache.Indexers{}, func(options *metav1.ListOptions) {
 		options.LabelSelector = fmt.Sprintf("%s=%s", label.IoIstioRev.Name, revision)
+		if features.EnableEnhancedResourceScoping {
+			options.FieldSelector = fmt.Sprintf("metadata.name=%s", webhookName)
+		}
 	})
 	p.informer = informer
 	informer.AddEventHandler(controllers.ObjectHandler(p.queue.AddObject))

--- a/pkg/webhooks/webhookpatch.go
+++ b/pkg/webhooks/webhookpatch.go
@@ -79,7 +79,8 @@ func NewWebhookCertPatcher(
 	informer := admissioninformer.NewFilteredMutatingWebhookConfigurationInformer(client.Kube(), 0, cache.Indexers{}, func(options *metav1.ListOptions) {
 		options.LabelSelector = fmt.Sprintf("%s=%s", label.IoIstioRev.Name, revision)
 		if features.EnableEnhancedResourceScoping {
-			options.FieldSelector = fmt.Sprintf("metadata.name=%s", getInjectionWebhookConfigName(revision, systemNameSpace))
+			options.FieldSelector = fmt.Sprintf("metadata.name=%s",
+				util.GetWebhookConfigName(features.InjectionWebhookConfigName, revision, systemNameSpace))
 		}
 	})
 	p.informer = informer
@@ -190,15 +191,4 @@ func (w *WebhookCertPatcher) startCaBundleWatcher(stop <-chan struct{}) {
 			return
 		}
 	}
-}
-
-func getInjectionWebhookConfigName(revision string, namespace string) string {
-	name := features.InjectionWebhookConfigName
-	if revision != "default" {
-		name += "-" + revision
-	}
-	if namespace != "istio-system" {
-		name += "-" + namespace
-	}
-	return name
 }

--- a/pkg/webhooks/webhookpatch.go
+++ b/pkg/webhooks/webhookpatch.go
@@ -65,8 +65,9 @@ type WebhookCertPatcher struct {
 // NewWebhookCertPatcher creates a WebhookCertPatcher
 func NewWebhookCertPatcher(
 	client kubelib.Client,
-	revision, webhookName string, caBundleWatcher *keycertbundle.Watcher,
+	revision, systemNameSpace string, caBundleWatcher *keycertbundle.Watcher,
 ) (*WebhookCertPatcher, error) {
+	webhookName := getInjectionWebhookName(revision, systemNameSpace)
 	p := &WebhookCertPatcher{
 		client:          client.Kube(),
 		revision:        revision,
@@ -190,4 +191,15 @@ func (w *WebhookCertPatcher) startCaBundleWatcher(stop <-chan struct{}) {
 			return
 		}
 	}
+}
+
+func getInjectionWebhookName(revision string, namespace string) string {
+	name := features.InjectionWebhookConfigName
+	if revision != "default" {
+		name += "-" + revision
+	}
+	if namespace != "istio-system" {
+		name += "-" + namespace
+	}
+	return name
 }

--- a/pkg/webhooks/webhookpatch_test.go
+++ b/pkg/webhooks/webhookpatch_test.go
@@ -228,7 +228,7 @@ func TestMutatingWebhookPatch(t *testing.T) {
 
 			watcher := keycertbundle.NewWatcher()
 			watcher.SetAndNotify(nil, nil, tc.pemData)
-			whPatcher, err := NewWebhookCertPatcher(client, tc.revision, tc.webhookName, watcher)
+			whPatcher, err := NewWebhookCertPatcher(client, tc.revision, "istio-system", tc.webhookName, watcher)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/releasenotes/notes/scope-webhook-cert-patching.yaml
+++ b/releasenotes/notes/scope-webhook-cert-patching.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+releaseNotes:
+   - |
+     **Added** support for restricting istiod webhook cert patcher to only patch the webhooks it owns
+     if `ENABLE_ENHANCED_RESOURCE_SCOPING` feature flag is enabled.
+docs:
+   - https://docs.google.com/document/d/1y4liRJbQW0NCMeQtqMma46flVqs-izV1/


### PR DESCRIPTION
Signed-off-by: Faseela K <faseela.k@est.tech>

This is to support multi control plane deployments. RFC is [here](https://docs.google.com/document/d/1y4liRJbQW0NCMeQtqMma46flVqs-izV1/edit)

As per comments from @irisdingbj on a [previous attempt PR](https://github.com/istio/istio/pull/41515), this new PR has been raised