### PR TITLE
Add endpoint check for ServiceEntry.

### DIFF
--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -3308,6 +3308,9 @@ var ValidateServiceEntry = registerValidateFunc("ValidateServiceEntry",
 						if !servicePorts[name] {
 							errs = appendValidation(errs, fmt.Errorf("endpoint port %v is not defined by the service entry", port))
 						}
+						errs = appendValidation(errs,
+							ValidatePortName(name),
+							ValidatePort(int(port)))
 					}
 				}
 				errs = appendValidation(errs, labels.Instance(endpoint.Labels).Validate())

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -4923,6 +4923,42 @@ func TestValidateServiceEntries(t *testing.T) {
 			valid: false,
 		},
 		{
+			name: "valid endpoint port", in: &networking.ServiceEntry{
+				Hosts: []string{"google.com"},
+				Ports: []*networking.Port{
+					{Number: 80, Protocol: "http", Name: "http-valid1", TargetPort: 81},
+				},
+				Resolution: networking.ServiceEntry_STATIC,
+				Endpoints: []*networking.WorkloadEntry{
+					{
+						Address: "1.1.1.1",
+						Ports: map[string]uint32{
+							"http-valid1": 8081,
+						},
+					},
+				},
+			},
+			valid: true,
+		},
+		{
+			name: "invalid endpoint port", in: &networking.ServiceEntry{
+				Hosts: []string{"google.com"},
+				Ports: []*networking.Port{
+					{Number: 80, Protocol: "http", Name: "http-valid1", TargetPort: 81},
+				},
+				Resolution: networking.ServiceEntry_STATIC,
+				Endpoints: []*networking.WorkloadEntry{
+					{
+						Address: "1.1.1.1",
+						Ports: map[string]uint32{
+							"http-valid1": 65536,
+						},
+					},
+				},
+			},
+			valid: false,
+		},
+		{
 			name: "protocol unset for addresses empty", in: &networking.ServiceEntry{
 				Hosts:     []string{"google.com"},
 				Addresses: []string{},


### PR DESCRIPTION
Fix the nack of eds as following:
```
embedded message failed validation | caused by LbEndpointValidationError.Endpoint: embedded message failed validation | caused by EndpointValidationError.Address: embedded message failed validation | caused by AddressValidationError.SocketAddress: embedded message failed validation | caused by SocketAddressValidationError.PortValue: value must be less than or equal to 65535)
```