### PR TITLE
original_dst: set idle timeout to 5min

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"math"
 	"sort"
+	"time"
 
 	cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -67,6 +68,9 @@ var hboneTransportSocketMatch = &structpb.Struct{
 // nolint
 // revive:disable-next-line
 var passthroughHttpProtocolOptions = protoconv.MessageToAny(&http.HttpProtocolOptions{
+	CommonHttpProtocolOptions: &core.HttpProtocolOptions{
+		IdleTimeout: durationpb.New(5 * time.Second),
+	},
 	UpstreamProtocolOptions: &http.HttpProtocolOptions_UseDownstreamProtocolConfig{
 		UseDownstreamProtocolConfig: &http.HttpProtocolOptions_UseDownstreamHttpConfig{
 			HttpProtocolOptions:  &core.Http1ProtocolOptions{},
@@ -384,10 +388,7 @@ func (cb *ClusterBuilder) buildDefaultCluster(name string, discoveryType cluster
 	}
 
 	if discoveryType == cluster.Cluster_ORIGINAL_DST {
-		// Extend cleanupInterval beyond 5s default. This ensures that upstream connections will stay
-		// open for up to 60s. With the default of 5s, we may tear things down too quickly for
-		// infrequently accessed services.
-		c.CleanupInterval = &durationpb.Duration{Seconds: 60}
+
 	}
 
 	// For inbound clusters, the default traffic policy is used. For outbound clusters, the default traffic policy

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -69,7 +69,7 @@ var hboneTransportSocketMatch = &structpb.Struct{
 // revive:disable-next-line
 var passthroughHttpProtocolOptions = protoconv.MessageToAny(&http.HttpProtocolOptions{
 	CommonHttpProtocolOptions: &core.HttpProtocolOptions{
-		IdleTimeout: durationpb.New(5 * time.Second),
+		IdleTimeout: durationpb.New(5 * time.Minute),
 	},
 	UpstreamProtocolOptions: &http.HttpProtocolOptions_UseDownstreamProtocolConfig{
 		UseDownstreamProtocolConfig: &http.HttpProtocolOptions_UseDownstreamHttpConfig{
@@ -385,10 +385,6 @@ func (cb *ClusterBuilder) buildDefaultCluster(name string, discoveryType cluster
 			ClusterName: name,
 			Endpoints:   localityLbEndpoints,
 		}
-	}
-
-	if discoveryType == cluster.Cluster_ORIGINAL_DST {
-
 	}
 
 	// For inbound clusters, the default traffic policy is used. For outbound clusters, the default traffic policy


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

Reduce the amount of time an idle HTTP connection to ORIGINAL_DST host stays resident in memory.

Context: https://github.com/envoyproxy/envoy/issues/22218.
