### PR TITLE
Default value for validationwebhookconfig seems incorrect

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -448,7 +448,7 @@ var (
 	InjectionWebhookConfigName = env.Register("INJECTION_WEBHOOK_CONFIG_NAME", "istio-sidecar-injector",
 		"Name of the mutatingwebhookconfiguration to patch, if istioctl is not used.").Get()
 
-	ValidationWebhookConfigName = env.Register("VALIDATION_WEBHOOK_CONFIG_NAME", "istio-istio-system",
+	ValidationWebhookConfigName = env.Register("VALIDATION_WEBHOOK_CONFIG_NAME", "istio-validator-istio-system",
 		"Name of the validatingwebhookconfiguration to patch. Empty will skip using cluster admin to patch.").Get()
 
 	SpiffeBundleEndpoints = env.Register("SPIFFE_BUNDLE_ENDPOINTS", "",

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -448,7 +448,7 @@ var (
 	InjectionWebhookConfigName = env.Register("INJECTION_WEBHOOK_CONFIG_NAME", "istio-sidecar-injector",
 		"Name of the mutatingwebhookconfiguration to patch, if istioctl is not used.").Get()
 
-	ValidationWebhookConfigName = env.Register("VALIDATION_WEBHOOK_CONFIG_NAME", "istio-validator-istio-system",
+	ValidationWebhookConfigName = env.Register("VALIDATION_WEBHOOK_CONFIG_NAME", "istio-validator",
 		"Name of the validatingwebhookconfiguration to patch. Empty will skip using cluster admin to patch.").Get()
 
 	SpiffeBundleEndpoints = env.Register("SPIFFE_BUNDLE_ENDPOINTS", "",

--- a/pkg/webhooks/util/util.go
+++ b/pkg/webhooks/util/util.go
@@ -59,7 +59,7 @@ func VerifyCABundle(caBundle []byte) error {
 	return nil
 }
 
-func GetWebhookConfigName(webhookPrefix string, revision string, namespace string) string {
+func GetInjectionWebhookConfigName(webhookPrefix string, revision string, namespace string) string {
 	name := webhookPrefix
 	if revision != "default" {
 		name += "-" + revision
@@ -67,5 +67,14 @@ func GetWebhookConfigName(webhookPrefix string, revision string, namespace strin
 	if namespace != "istio-system" {
 		name += "-" + namespace
 	}
+	return name
+}
+
+func GetValidationWebhookConfigName(webhookPrefix string, revision string, namespace string) string {
+	name := webhookPrefix
+	if revision != "default" {
+		name += "-" + revision
+	}
+	name += "-" + namespace
 	return name
 }

--- a/pkg/webhooks/util/util.go
+++ b/pkg/webhooks/util/util.go
@@ -70,7 +70,7 @@ func GetInjectionWebhookConfigName(webhookPrefix string, revision string, namesp
 	return name
 }
 
-func GetValidationWebhookConfigName(webhookPrefix string, revision string, namespace string) string {
+func GetValidatingWebhookConfigName(webhookPrefix string, revision string, namespace string) string {
 	name := webhookPrefix
 	if revision != "default" {
 		name += "-" + revision

--- a/pkg/webhooks/validation/controller/controller.go
+++ b/pkg/webhooks/validation/controller/controller.go
@@ -197,7 +197,7 @@ func newController(
 		client: client,
 		queue:  workqueue.NewRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(1*time.Second, 5*time.Minute)),
 	}
-	webhookConfigName := util.GetValidationWebhookConfigName(features.ValidationWebhookConfigName, o.Revision, o.WatchedNamespace)
+	webhookConfigName := util.GetValidatingWebhookConfigName(features.ValidationWebhookConfigName, o.Revision, o.WatchedNamespace)
 	webhookInformer := cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {

--- a/pkg/webhooks/validation/controller/controller.go
+++ b/pkg/webhooks/validation/controller/controller.go
@@ -197,7 +197,7 @@ func newController(
 		client: client,
 		queue:  workqueue.NewRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(1*time.Second, 5*time.Minute)),
 	}
-	webhookConfigName := util.GetWebhookConfigName(features.ValidationWebhookConfigName, o.Revision, o.WatchedNamespace)
+	webhookConfigName := util.GetValidationWebhookConfigName(features.ValidationWebhookConfigName, o.Revision, o.WatchedNamespace)
 	webhookInformer := cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {

--- a/pkg/webhooks/webhookpatch.go
+++ b/pkg/webhooks/webhookpatch.go
@@ -80,7 +80,7 @@ func NewWebhookCertPatcher(
 		options.LabelSelector = fmt.Sprintf("%s=%s", label.IoIstioRev.Name, revision)
 		if features.EnableEnhancedResourceScoping {
 			options.FieldSelector = fmt.Sprintf("metadata.name=%s",
-				util.GetWebhookConfigName(features.InjectionWebhookConfigName, revision, systemNameSpace))
+				util.GetInjectionWebhookConfigName(features.InjectionWebhookConfigName, revision, systemNameSpace))
 		}
 	})
 	p.informer = informer

--- a/tests/integration/iop-externalistiod-primary-integration-test-defaults.yaml
+++ b/tests/integration/iop-externalistiod-primary-integration-test-defaults.yaml
@@ -42,7 +42,7 @@ spec:
         - name: INJECTION_WEBHOOK_CONFIG_NAME
           value: "istio-sidecar-injector-istio-system"
         - name: VALIDATION_WEBHOOK_CONFIG_NAME
-          value: "istio-istio-system"
+          value: "istio-validator-istio-system"
         - name: EXTERNAL_ISTIOD
           value: "true"
         - name: SHARED_MESH_CONFIG


### PR DESCRIPTION
Signed-off-by: Faseela K <faseela.k@est.tech>

The features.ValidationWebhookConfigName default value seems to be incorrect (https://github.com/istio/istio/blob/master/pilot/pkg/features/pilot.go#L451)
Should the default value not be "istio-validator" based on the default vwhc name?
https://github.com/istio/istio/blob/master/manifests/charts/istio-control/istio-discovery/templates/validatingwebhookconfiguration.yaml#L5