### PR TITLE
[fix] Increase the timeout for restarting to 60s

### DIFF
--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -177,7 +177,7 @@ func (d *deployment) Restart() error {
 				}
 			}
 			return nil
-		}, retry.Timeout(20*time.Second), retry.Delay(2*time.Second)); err != nil {
+		}, retry.Timeout(60*time.Second), retry.Delay(2*time.Second)); err != nil {
 			errs = multierror.Append(errs, fmt.Errorf("failed to wait rollout status for %v/%v: %v",
 				d.cfg.Namespace.Name(), deploymentName, err))
 		}


### PR DESCRIPTION
Increasing the restart timeout to 60s.

When all workloads are restarted in the integration test, it takes more than 20s . (in local, it took around 25~30s)