### PR TITLE
Make sure identity is in CSR for istiod CA

### DIFF
--- a/security/pkg/pki/ca/ca.go
+++ b/security/pkg/pki/ca/ca.go
@@ -344,6 +344,10 @@ func (ca *IstioCA) GenKeyCert(hostnames []string, certTTL time.Duration, checkLi
 		RSAKeySize: rsaKeySize,
 	}
 
+	if len(hostnames) > 0 {
+		opts.Host = hostnames[0]
+	}
+
 	// use the type of private key the CA uses to generate an intermediate CA of that type (e.g. CA cert using RSA will
 	// cause intermediate CAs using RSA to be generated)
 	_, signingKey, _, _ := ca.keyCertBundle.GetAll()

--- a/security/pkg/pki/ca/ca_test.go
+++ b/security/pkg/pki/ca/ca_test.go
@@ -400,11 +400,27 @@ func TestSignCSR(t *testing.T) {
 		verifyFields  util.VerifyFields
 		expectedError string
 	}{
+		"Workload identity not in CSR": {
+			forCA: false,
+			certOpts: util.CertOptions{
+				Host:       "spiffe://different.com/test",
+				RSAKeySize: 2048,
+				IsCA:       false,
+			},
+			maxTTL:       time.Hour,
+			requestedTTL: 30 * time.Minute,
+			verifyFields: util.VerifyFields{
+				ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+				KeyUsage:    x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+				IsCA:        false,
+				Host:        subjectID,
+			},
+			expectedError: "CSR does not contain identity: [spiffe://example.com/ns/foo/sa/bar]",
+		},
 		"Workload uses RSA": {
 			forCA: false,
 			certOpts: util.CertOptions{
-				// This value is not used, instead, subjectID should be used in certificate.
-				Host:       "spiffe://different.com/test",
+				Host:       subjectID,
 				RSAKeySize: 2048,
 				IsCA:       false,
 			},
@@ -421,8 +437,7 @@ func TestSignCSR(t *testing.T) {
 		"Workload uses EC": {
 			forCA: false,
 			certOpts: util.CertOptions{
-				// This value is not used, instead, subjectID should be used in certificate.
-				Host:     "spiffe://different.com/test",
+				Host:     subjectID,
 				ECSigAlg: util.EcdsaSigAlg,
 				IsCA:     false,
 			},
@@ -439,6 +454,7 @@ func TestSignCSR(t *testing.T) {
 		"CA uses RSA": {
 			forCA: true,
 			certOpts: util.CertOptions{
+				Host:       subjectID,
 				RSAKeySize: 2048,
 				IsCA:       true,
 			},
@@ -454,6 +470,7 @@ func TestSignCSR(t *testing.T) {
 		"CA uses EC": {
 			forCA: true,
 			certOpts: util.CertOptions{
+				Host:     subjectID,
 				ECSigAlg: util.EcdsaSigAlg,
 				IsCA:     true,
 			},
@@ -469,6 +486,7 @@ func TestSignCSR(t *testing.T) {
 		"CSR uses RSA TTL error": {
 			forCA: false,
 			certOpts: util.CertOptions{
+				Host:       subjectID,
 				Org:        "istio.io",
 				RSAKeySize: 2048,
 			},
@@ -479,6 +497,7 @@ func TestSignCSR(t *testing.T) {
 		"CSR uses EC TTL error": {
 			forCA: false,
 			certOpts: util.CertOptions{
+				Host:     subjectID,
 				Org:      "istio.io",
 				ECSigAlg: util.EcdsaSigAlg,
 			},
@@ -600,7 +619,7 @@ func TestSignWithCertChain(t *testing.T) {
 
 	opts := util.CertOptions{
 		// This value is not used, instead, subjectID should be used in certificate.
-		Host:       "spiffe://different.com/test",
+		//Host:       "spiffe://different.com/test",
 		RSAKeySize: 2048,
 		IsCA:       false,
 	}

--- a/security/pkg/pki/ca/ca_test.go
+++ b/security/pkg/pki/ca/ca_test.go
@@ -618,8 +618,7 @@ func TestSignWithCertChain(t *testing.T) {
 	}
 
 	opts := util.CertOptions{
-		// This value is not used, instead, subjectID should be used in certificate.
-		//Host:       "spiffe://different.com/test",
+		Host:       "spiffe://different.com/test",
 		RSAKeySize: 2048,
 		IsCA:       false,
 	}
@@ -629,7 +628,7 @@ func TestSignWithCertChain(t *testing.T) {
 	}
 
 	caCertOpts := CertOpts{
-		SubjectIDs: []string{"localhost"},
+		SubjectIDs: []string{"spiffe://different.com/test"},
 		TTL:        time.Hour,
 		ForCA:      false,
 	}
@@ -715,7 +714,7 @@ func TestGenKeyCert(t *testing.T) {
 			t.Fatalf("failed to create a plugged-cert CA.")
 		}
 
-		certPEM, privPEM, err := ca.GenKeyCert([]string{"host1", "host2"}, tc.certLifetime, tc.checkCertLifetime)
+		certPEM, privPEM, err := ca.GenKeyCert([]string{"spiffe://different.com/test"}, tc.certLifetime, tc.checkCertLifetime)
 		if err != nil {
 			if tc.expectedError == "" {
 				t.Fatalf("[%s] Unexpected error: %v", id, err)


### PR DESCRIPTION
**Please provide a description of this PR:**

While browsing the [istio-csr](https://github.com/cert-manager/istio-csr/blob/c2e12cd702cca8272366ebccce36aedfd53af2ac/pkg/server/auth.go#L82) repository I see that they check to make sure that they extract from the `metadata.Pair` the `Authorization: Bearer <jwt>` token to create the SPIFFE identity. This identity is then used to checked against the incoming CSR's SAN URI, expecting a match. If a match is found, a certificate can be created. If not, a certificate is not.

I think this would help create a more robust 0-trust environment.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [X] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
