### PR TITLE
Fix config key hashcode collision issue.

### DIFF
--- a/pilot/pkg/model/config.go
+++ b/pilot/pkg/model/config.go
@@ -60,8 +60,11 @@ func (key ConfigKey) HashCode() ConfigHash {
 	hash := xxhashv2.New()
 	// the error will always return nil
 	_, _ = hash.Write([]byte{byte(key.Kind)})
-	_, _ = hash.Write([]byte(key.Name))
+	// Add separator / to avoid collision.
+	_, _ = hash.Write([]byte("/"))
 	_, _ = hash.Write([]byte(key.Namespace))
+	_, _ = hash.Write([]byte("/"))
+	_, _ = hash.Write([]byte(key.Name))
 	return ConfigHash(hash.Sum64())
 }
 

--- a/pilot/pkg/model/config_test.go
+++ b/pilot/pkg/model/config_test.go
@@ -581,3 +581,21 @@ func BenchmarkHashCode(b *testing.B) {
 		})
 	}
 }
+
+func TestHashCodeCollision(t *testing.T) {
+	config1 := model.ConfigKey{
+		Kind:      kind.VirtualService,
+		Name:      "abc",
+		Namespace: "ns-foo",
+	}
+
+	config2 := model.ConfigKey{
+		Kind:      kind.VirtualService,
+		Name:      "ab",
+		Namespace: "cns-foo",
+	}
+
+	if config1.HashCode() == config2.HashCode() {
+		t.Fatalf("Hash code of config1 %s should not be equal to config2 %s", config1.String(), config2.String())
+	}
+}


### PR DESCRIPTION
Now, the hashcode of config whose namespace is ns-foo and name is abc is equal to the config  whose namespace is cns-foo and name is ab. The reason is that we can't distinguish the boundary between namespace and name.

This pr add separator / to avoid collision. For better readable, I move namespace in the front of name.
