### PR TITLE
samples: Add custom-bootstrap with envoy filter sample

### DIFF
--- a/samples/custom-bootstrap/README.md
+++ b/samples/custom-bootstrap/README.md
@@ -1,6 +1,8 @@
 # Custom Envoy Bootstrap Configuration
 
-This sample creates a simple helloworld service that bootstraps the Envoy proxy with a custom configuration file.
+This sample creates a simple helloworld service that bootstraps the Envoy proxy. There are 2 ways to implement this:
+1. With a custom configuration file. 
+2. With envoy filter
 
 ## Starting the service
 
@@ -8,11 +10,13 @@ First, we need to create a `ConfigMap` resource with our bootstrap configuration
 
 ```bash
 kubectl apply -f custom-bootstrap.yaml
+kubectl apply -f custom-bootstrap-envoy-filter.yaml
 ```
 
 Next, we can create a service that uses this bootstrap configuration.
 
-To do this, we need to add an annotation, `sidecar.istio.io/bootstrapOverride`, with the name of our ConfigMap as the value.
+- For using `custom-bootstrap.yaml` we need to add an annotation, `sidecar.istio.io/bootstrapOverride` to pod spec with the name of our ConfigMap as the value.
+- For using `custom-bootstrap-envoy-filter.yaml`, we need to enable `BOOTSTRAP_XDS_AGENT` [environment variable](https://istio.io/latest/docs/reference/commands/pilot-agent/#envvars).
 
 We can create our helloworld app, using the custom config, with:
 
@@ -48,5 +52,6 @@ For reference, [the default bootstrap configuration](../../tools/packaging/commo
 
 ```bash
 kubectl delete -f custom-bootstrap.yaml
+kubectl delete -f custom-bootstrap-envoy-filter.yaml
 kubectl delete -f example-app.yaml
 ```

--- a/samples/custom-bootstrap/custom-bootstrap-envoy-filter.yaml
+++ b/samples/custom-bootstrap/custom-bootstrap-envoy-filter.yaml
@@ -1,0 +1,20 @@
+# This example envoy filter enables hystrix sink based on https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/metrics/v3/stats.proto#extension-envoy-stat-sinks-hystrix
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: hystrix-sink-bootstrap-filter
+spec:
+  workloadSelector:
+    labels:
+      app: helloworld
+      version: v1
+  configPatches:
+  - applyTo: BOOTSTRAP
+    patch:
+      operation: MERGE
+      value:
+        stats_sinks:
+        - name: envoy.stat_sinks.hystrix
+          typed_config:
+            "@type": "type.googleapis.com/envoy.config.metrics.v3.HystrixSink"
+            num_buckets: 10


### PR DESCRIPTION
**Please provide a description of this PR:**
This commit adds a sample envoy filter which enables hystrix sink to showcase custom bootstrap addition.