### PR TITLE
Update to make prow/release-commit.sh executable after sed

### DIFF
--- a/bin/update_deps.sh
+++ b/bin/update_deps.sh
@@ -44,6 +44,7 @@ go get -u "istio.io/pkg@${UPDATE_BRANCH}"
 go mod tidy
 
 sed -i "s/^BUILDER_SHA=.*\$/BUILDER_SHA=$(getSha release-builder)/" prow/release-commit.sh
+chmod +x prow/release-commit.sh
 sed -i '/PROXY_REPO_SHA/,/lastStableSHA/ { s/"lastStableSHA":.*/"lastStableSHA": "'"$(getSha proxy)"'"/  }' istio.deps
 
 # shellcheck disable=SC1001


### PR DESCRIPTION
**Please provide a description of this PR:**

Update to make prow/release-commit.sh executable after sed in update_deps.sh

Running updates_deps.sh yields a prow/release-commit.sh that isn't executable as the sed -i creates a tmp file and copies it over the original replacing the attributes. This makes the script executable again.