### PR TITLE
only print warning if istio-cni is not default cni plugin when cni is used as a standalone plugin

### DIFF
--- a/cni/pkg/install/install.go
+++ b/cni/pkg/install/install.go
@@ -233,7 +233,7 @@ func checkInstall(cfg *config.InstallConfig, cniConfigFilepath string) error {
 	}
 	defaultCNIConfigFilepath := filepath.Join(cfg.MountedCNINetDir, defaultCNIConfigFilename)
 	if defaultCNIConfigFilepath != cniConfigFilepath {
-		if len(cfg.CNIConfName) > 0 {
+		if len(cfg.CNIConfName) > 0 || !cfg.ChainedCNIPlugin {
 			// Install was run with overridden CNI config file so don't error out on preempt check
 			// Likely the only use for this is testing the script
 			installLog.Warnf("CNI config file %s preempted by %s", cniConfigFilepath, defaultCNIConfigFilepath)

--- a/releasenotes/notes/41858.yaml
+++ b/releasenotes/notes/41858.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+releaseNotes:
+  - |
+    **Removed** warning if istio-cni is not the default CNI plugin when CNI is used as a standalone plugin.


### PR DESCRIPTION
```release-note
only print warning if istio-cni is not default cni plugin when cni is used as a standalone plugin
```
Signed-off-by: Fei Su <sofat1989@126.com>

**Please provide a description of this PR:**
When we use istio-cni as a standalone plugin, we must have another one cni plugin to set up the network (create eth0 and set the ip address) for the containers before calling the istio-cni.
```
00-tnet.conf YYY-istio-cni.conf
```
So the first file `00-tnet.conf` will be treated as the defaultCNIConfigFilename here. But it is expected. 
https://github.com/istio/istio/blob/master/cni/pkg/install/install.go#L230
```
defaultCNIConfigFilename, err := getDefaultCNINetwork(cfg.MountedCNINetDir)
```
It should not return error in the func `func checkInstall(cfg *config.InstallConfig, cniConfigFilepath string) error`. 
We can specify the flag `--cni-conf-name` to make the program only print the warning log because len(cfg.CNIConfName) > 0. But I thinks it is tricky. 
```
if len(cfg.CNIConfName) > 0 {
			// Install was run with overridden CNI config file so don't error out on preempt check
			// Likely the only use for this is testing the script
			installLog.Warnf("CNI config file %s preempted by %s", cniConfigFilepath, defaultCNIConfigFilepath)
		}
```
If we use the plugin as a standalone plugin, it is better that it only print the warning logs here.