### PR TITLE
gateway-api: make default class name and controller name configurable

### DIFF
--- a/pilot/pkg/config/kube/gateway/conversion.go
+++ b/pilot/pkg/config/kube/gateway/conversion.go
@@ -38,9 +38,12 @@ import (
 	"istio.io/istio/pkg/util/sets"
 )
 
+var (
+	DefaultClassName = features.GatewayAPIDefaultGatewayClass
+	ControllerName   = k8sbeta.GatewayController(features.GatewayAPIControllerName)
+)
+
 const (
-	DefaultClassName             = "istio"
-	ControllerName               = "istio.io/gateway-controller"
 	gatewayAliasForAnnotationKey = "gateway.istio.io/alias-for"
 	gatewayTLSTerminateModeKey   = "gateway.istio.io/tls-terminate-mode"
 )

--- a/pilot/pkg/config/kube/gateway/deploymentcontroller.go
+++ b/pilot/pkg/config/kube/gateway/deploymentcontroller.go
@@ -93,7 +93,7 @@ func NewDeploymentController(client kube.Client) *DeploymentController {
 			t := true
 			_, err := c.Patch(context.Background(), name, types.ApplyPatchType, data, metav1.PatchOptions{
 				Force:        &t,
-				FieldManager: ControllerName,
+				FieldManager: string(ControllerName),
 			}, subresources...)
 			return err
 		},
@@ -169,7 +169,7 @@ func (d *DeploymentController) Reconcile(req types.NamespacedName) error {
 		}
 	} else {
 		// Didn't find gateway class... it must use implicit Istio one.
-		if gw.Spec.GatewayClassName != DefaultClassName {
+		if string(gw.Spec.GatewayClassName) != DefaultClassName {
 			return nil
 		}
 	}

--- a/pilot/pkg/config/kube/gateway/gatewayclass_test.go
+++ b/pilot/pkg/config/kube/gateway/gatewayclass_test.go
@@ -77,11 +77,11 @@ func TestClassController(t *testing.T) {
 	}
 
 	// Class should be created initially
-	expectClass(DefaultClassName, ControllerName)
+	expectClass(DefaultClassName, string(ControllerName))
 
 	// Once we delete it, it should be added back
 	deleteClass(DefaultClassName)
-	expectClass(DefaultClassName, ControllerName)
+	expectClass(DefaultClassName, string(ControllerName))
 
 	// Overwrite the class, controller should not reconcile it back
 	createClass(DefaultClassName, "different-controller")
@@ -89,7 +89,7 @@ func TestClassController(t *testing.T) {
 
 	// Once we delete it, it should be added back
 	deleteClass(DefaultClassName)
-	expectClass(DefaultClassName, ControllerName)
+	expectClass(DefaultClassName, string(ControllerName))
 
 	// Create an unrelated GatewayClass, we should not do anything to it
 	createClass("something-else", "different-controller")

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -394,6 +394,12 @@ var (
 	EnableGatewayAPIDeploymentController = env.Register("PILOT_ENABLE_GATEWAY_API_DEPLOYMENT_CONTROLLER", true,
 		"If this is set to true, gateway-api resources will automatically provision in cluster deployment, services, etc").Get()
 
+	GatewayAPIDefaultGatewayClass = env.Register("PILOT_GATEWAY_API_DEFAULT_GATEWAYCLASS", "istio",
+		"Name of the default GatewayClass").Get()
+
+	GatewayAPIControllerName = env.Register("PILOT_GATEWAY_API_CONTROLLER_NAME", "istio.io/gateway-controller",
+		"Gateway API controller name. istiod will only reconcile Gateway API resources referencing a GatewayClass with this controller name").Get()
+
 	ClusterName = env.Register("CLUSTER_ID", "Kubernetes",
 		"Defines the cluster and service registry that this Istiod instance is belongs to").Get()
 


### PR DESCRIPTION
**Please provide a description of this PR:**

This is really useful in multi-tenant/multi-revision scenarios. I'm only adding this as ENV vars for now as I don't know if we really want to expose this in e.g. MeshConfig. That could be done later, though.