### PR TITLE
Revert "[release-1.16] Limit webhook patcher to patch owned webhooks"

### DIFF
--- a/pilot/pkg/bootstrap/sidecarinjector.go
+++ b/pilot/pkg/bootstrap/sidecarinjector.go
@@ -93,7 +93,7 @@ func (s *Server) initSidecarInjector(args *PilotArgs) (*inject.Webhook, error) {
 		s.addStartFunc(func(stop <-chan struct{}) error {
 			// No leader election - different istiod revisions will patch their own cert.
 			// update webhook configuration by watching the cabundle
-			patcher, err := webhooks.NewWebhookCertPatcher(s.kubeClient, args.Revision, args.Namespace, webhookName, s.istiodCertBundleWatcher)
+			patcher, err := webhooks.NewWebhookCertPatcher(s.kubeClient, args.Revision, webhookName, s.istiodCertBundleWatcher)
 			if err != nil {
 				log.Errorf("failed to create webhook cert patcher: %v", err)
 				return nil

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -301,7 +301,7 @@ func (m *Multicluster) initializeCluster(cluster *multicluster.Cluster, kubeCont
 		// operator or CI/CD
 		if features.InjectionWebhookConfigName != "" {
 			log.Infof("initializing injection webhook cert patcher for cluster %s", cluster.ID)
-			patcher, err := webhooks.NewWebhookCertPatcher(client, m.revision, m.opts.SystemNamespace, webhookName, m.caBundleWatcher)
+			patcher, err := webhooks.NewWebhookCertPatcher(client, m.revision, webhookName, m.caBundleWatcher)
 			if err != nil {
 				log.Errorf("could not initialize webhook cert patcher: %v", err)
 			} else {

--- a/pkg/webhooks/util/util.go
+++ b/pkg/webhooks/util/util.go
@@ -58,14 +58,3 @@ func VerifyCABundle(caBundle []byte) error {
 	}
 	return nil
 }
-
-func GetWebhookConfigName(webhookPrefix string, revision string, namespace string) string {
-	name := webhookPrefix
-	if revision != "default" {
-		name += "-" + revision
-	}
-	if namespace != "istio-system" {
-		name += "-" + namespace
-	}
-	return name
-}

--- a/pkg/webhooks/webhookpatch.go
+++ b/pkg/webhooks/webhookpatch.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"istio.io/api/label"
-	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/keycertbundle"
 	kubelib "istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/controllers"
@@ -65,7 +64,7 @@ type WebhookCertPatcher struct {
 // NewWebhookCertPatcher creates a WebhookCertPatcher
 func NewWebhookCertPatcher(
 	client kubelib.Client,
-	revision, systemNameSpace string, webhookName string, caBundleWatcher *keycertbundle.Watcher,
+	revision, webhookName string, caBundleWatcher *keycertbundle.Watcher,
 ) (*WebhookCertPatcher, error) {
 	p := &WebhookCertPatcher{
 		client:          client.Kube(),
@@ -78,10 +77,6 @@ func NewWebhookCertPatcher(
 		controllers.WithMaxAttempts(5))
 	informer := admissioninformer.NewFilteredMutatingWebhookConfigurationInformer(client.Kube(), 0, cache.Indexers{}, func(options *metav1.ListOptions) {
 		options.LabelSelector = fmt.Sprintf("%s=%s", label.IoIstioRev.Name, revision)
-		if features.EnableEnhancedResourceScoping {
-			options.FieldSelector = fmt.Sprintf("metadata.name=%s",
-				util.GetWebhookConfigName(features.InjectionWebhookConfigName, revision, systemNameSpace))
-		}
 	})
 	p.informer = informer
 	informer.AddEventHandler(controllers.ObjectHandler(p.queue.AddObject))

--- a/pkg/webhooks/webhookpatch_test.go
+++ b/pkg/webhooks/webhookpatch_test.go
@@ -228,7 +228,7 @@ func TestMutatingWebhookPatch(t *testing.T) {
 
 			watcher := keycertbundle.NewWatcher()
 			watcher.SetAndNotify(nil, nil, tc.pemData)
-			whPatcher, err := NewWebhookCertPatcher(client, tc.revision, "istio-system", tc.webhookName, watcher)
+			whPatcher, err := NewWebhookCertPatcher(client, tc.revision, tc.webhookName, watcher)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/releasenotes/notes/scope-webhook-cert-patching.yaml
+++ b/releasenotes/notes/scope-webhook-cert-patching.yaml
@@ -1,9 +1,0 @@
-apiVersion: release-notes/v2
-kind: feature
-area: traffic-management
-releaseNotes:
-   - |
-     **Added** support for restricting istiod webhook cert patcher to only patch the webhooks it owns
-     if `ENABLE_ENHANCED_RESOURCE_SCOPING` feature flag is enabled.
-docs:
-   - https://docs.google.com/document/d/1y4liRJbQW0NCMeQtqMma46flVqs-izV1/


### PR DESCRIPTION
This has some open converations still around https://github.com/istio/istio/pull/41789/files . Hence thinking it would be better to revert on 1.16
Reverts istio/istio#41781