### PR TITLE
Fix TOCTOU race conditions

### DIFF
--- a/pkg/file/file.go
+++ b/pkg/file/file.go
@@ -22,11 +22,6 @@ import (
 
 // Copies file by reading the file then writing atomically into the target directory
 func AtomicCopy(srcFilepath, targetDir, targetFilename string) error {
-	info, err := os.Stat(srcFilepath)
-	if err != nil {
-		return err
-	}
-
 	input, err := os.ReadFile(srcFilepath)
 	if err != nil {
 		return err
@@ -36,11 +31,6 @@ func AtomicCopy(srcFilepath, targetDir, targetFilename string) error {
 }
 
 func Copy(srcFilepath, targetDir, targetFilename string) error {
-	info, err := os.Stat(srcFilepath)
-	if err != nil {
-		return err
-	}
-
 	input, err := os.ReadFile(srcFilepath)
 	if err != nil {
 		return err


### PR DESCRIPTION
**Please provide a description of this PR:**
Checking file status before reading it may cause TOCTOU race conditions.
Should try to read the file directly and return error if file does not exist or cannot open file.