### PR TITLE
Fixed kind issue

### DIFF
--- a/samples/kind-lb/setupkind.sh
+++ b/samples/kind-lb/setupkind.sh
@@ -67,7 +67,6 @@ done
 FEATURES=$(cat << EOF
 featureGates:
   MixedProtocolLBService: true
-  EndpointSlice: true
   GRPCContainerProbe: true
 kubeadmConfigPatches:
   - |


### PR DESCRIPTION
kind latest version v0.17.0 will fail to create cluster when EndpointSlice presents in the configuration.

Please see this issue
https://github.com/kubernetes-sigs/kind/issues/2997

Signed-off-by: Tong Li <litong01@us.ibm.com>

**Please provide a description of this PR:**