### PR TITLE
Allow skipping tests not yet working on Rust ztunnel

### DIFF
--- a/pkg/test/framework/resource/flags.go
+++ b/pkg/test/framework/resource/flags.go
@@ -177,6 +177,9 @@ func init() {
 	flag.BoolVar(&settingsFromCommandLine.Ambient, "istio.test.ambient", settingsFromCommandLine.Ambient,
 		"Indicate the use of ambient mesh.")
 
+	flag.BoolVar(&settingsFromCommandLine.AmbientNativeZtunnel, "istio.test.ambientNativeZtunnel", settingsFromCommandLine.AmbientNativeZtunnel,
+		"Indicate the use of ambient mesh with the native ztunnel implementation.")
+
 	flag.BoolVar(&settingsFromCommandLine.Compatibility, "istio.test.compatibility", settingsFromCommandLine.Compatibility,
 		"Transparently deploy echo instances pointing to each revision set in `Revisions`")
 

--- a/pkg/test/framework/resource/settings.go
+++ b/pkg/test/framework/resource/settings.go
@@ -140,6 +140,8 @@ type Settings struct {
 
 	// Ambient mesh is being used
 	Ambient bool
+	// AmbientNativeZtunnel means ambient is used with https://github.com/istio/ztunnel
+	AmbientNativeZtunnel bool
 
 	// Compatibility determines whether we should transparently deploy echo workloads attached to each revision
 	// specified in `Revisions` when creating echo instances. Used primarily for compatibility testing between revisions

--- a/tests/integration/ambient/baseline_test.go
+++ b/tests/integration/ambient/baseline_test.go
@@ -414,6 +414,7 @@ spec:
 
 func TestAuthorizationL4(t *testing.T) {
 	framework.NewTest(t).Features("traffic.ambient").Run(func(t framework.TestContext) {
+		skipOnNativeZtunnel(t, "RBAC not implemented yet")
 		// Workaround https://github.com/solo-io/istio-sidecarless/issues/287
 		t.ConfigIstio().YAML(apps.Namespace.Name(), `apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
@@ -518,6 +519,7 @@ func TestAuthorizationGateway(t *testing.T) {
 		}
 	}
 	framework.NewTest(t).Features("traffic.ambient").Run(func(t framework.TestContext) {
+		skipOnNativeZtunnel(t, "RBAC not implemented yet")
 		// Workaround https://github.com/solo-io/istio-sidecarless/issues/287
 		t.ConfigIstio().YAML(apps.Namespace.Name(), `apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
@@ -641,6 +643,7 @@ spec:
 
 func TestAuthorizationL7(t *testing.T) {
 	framework.NewTest(t).Features("traffic.ambient").Run(func(t framework.TestContext) {
+		skipOnNativeZtunnel(t, "RBAC not implemented yet")
 		// Workaround https://github.com/solo-io/istio-sidecarless/issues/287
 		t.ConfigIstio().YAML(apps.Namespace.Name(), `apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
@@ -747,6 +750,7 @@ func TestMTLS(t *testing.T) {
 	framework.NewTest(t).
 		Features("security.reachability").
 		Run(func(t framework.TestContext) {
+			skipOnNativeZtunnel(t, "RBAC not implemented yet")
 			systemNM := istio.ClaimSystemNamespaceOrFail(t, t)
 			// mtlsOnExpect defines our expectations for when mTLS is expected when its enabled
 			mtlsOnExpect := func(from echo.Instance, opts echo.CallOptions) bool {
@@ -923,6 +927,7 @@ func TestOutboundPolicyAllowAny(t *testing.T) {
 	framework.NewTest(t).
 		Features("traffic.ambient").
 		Run(func(t framework.TestContext) {
+			skipOnNativeZtunnel(t, "TODO? not sure why this is broken")
 			svcs := apps.All
 			for _, svc := range svcs {
 				if svc.Config().IsUncaptured() || svc.Config().HasSidecar() {
@@ -948,6 +953,7 @@ func TestServiceEntryDNS(t *testing.T) {
 	framework.NewTest(t).
 		Features("traffic.ambient").
 		Run(func(t framework.TestContext) {
+			skipOnNativeZtunnel(t, "ServiceEntry not supported")
 			svcs := apps.All
 			for _, svc := range svcs {
 				if svc.Config().IsUncaptured() || svc.Config().HasSidecar() {
@@ -989,6 +995,7 @@ func TestServiceEntry(t *testing.T) {
 	framework.NewTest(t).
 		Features("traffic.ambient").
 		Run(func(t framework.TestContext) {
+			skipOnNativeZtunnel(t, "ServiceEntry not supported")
 			testCases := []struct {
 				location   v1alpha3.ServiceEntry_Location
 				resolution v1alpha3.ServiceEntry_Resolution
@@ -1221,6 +1228,12 @@ func runIngressTest(t *testing.T, f func(t framework.TestContext, src ingress.In
 			})
 		}
 	})
+}
+
+func skipOnNativeZtunnel(tc framework.TestContext, reason string) {
+	if tc.Settings().AmbientNativeZtunnel {
+		tc.Skipf("Not currently supported: %v", reason)
+	}
 }
 
 func TestL7Telemetry(t *testing.T) {


### PR DESCRIPTION
The rest pass, allowing us to run the subset of currently working tests locally and/or in CI

The tests pass only with a couple local PRs I have, but those should be merged soonish