### PR TITLE
Fix verify-install inconsistent behavior

### DIFF
--- a/istioctl/pkg/verifier/verifier.go
+++ b/istioctl/pkg/verifier/verifier.go
@@ -132,6 +132,8 @@ func (v *StatusVerifier) verifyInstallIOPRevision() error {
 		if err != nil {
 			return err
 		}
+	} else if v.controlPlaneOpts.Revision == "default" {
+		v.controlPlaneOpts.Revision = ""
 	}
 	iop, err := v.operatorFromCluster(v.controlPlaneOpts.Revision)
 	if err != nil {

--- a/operator/cmd/mesh/shared.go
+++ b/operator/cmd/mesh/shared.go
@@ -170,7 +170,7 @@ func applyFlagAliases(flags []string, manifestsPath, revision string) []string {
 	if manifestsPath != "" {
 		flags = append(flags, fmt.Sprintf("installPackagePath=%s", manifestsPath))
 	}
-	if revision != "" {
+	if revision != "" && revision != "default" {
 		flags = append(flags, fmt.Sprintf("revision=%s", revision))
 	}
 	return flags

--- a/releasenotes/notes/41912.yaml
+++ b/releasenotes/notes/41912.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+releaseNotes:
+  - |
+    **Fixed** `istioctl install` failed when specifying `--revision default`.
+  - |
+    **Fixed** `istioctl verify-install` inconsistent behavior between `--revision` is not specified and specified with `default`.


### PR DESCRIPTION
**Please provide a description of this PR:**
When using the command and set `--revision=default`, several errors are generated because of the incorrent resource names, which is inconsistent with unspecifying the revision flag(has no error, and should be the correct one). 

Examples:
```
✘ Role: istiod-default.istio-system: roles.rbac.authorization.k8s.io "istiod-default" not found
✘ RoleBinding: istiod-default.istio-system: rolebindings.rbac.authorization.k8s.io "istiod-default" not found
✘ Service: istiod-default.istio-system: services "istiod-default" not found
```

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [x] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [x] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
