### PR TITLE
Decode payload with URLEncoding per the JWT spec

### DIFF
--- a/pilot/pkg/bootstrap/istio_ca.go
+++ b/pilot/pkg/bootstrap/istio_ca.go
@@ -17,7 +17,6 @@ package bootstrap
 import (
 	"bytes"
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -41,6 +40,7 @@ import (
 	"istio.io/istio/security/pkg/pki/ra"
 	caserver "istio.io/istio/security/pkg/server/ca"
 	"istio.io/istio/security/pkg/server/ca/authenticate"
+	"istio.io/istio/security/pkg/util"	
 	"istio.io/pkg/env"
 	"istio.io/pkg/log"
 )
@@ -206,7 +206,7 @@ func detectAuthEnv(jwt string) (*authenticate.JwtPayload, error) {
 	}
 	payload := jwtSplit[1]
 
-	payloadBytes, err := base64.RawStdEncoding.DecodeString(payload)
+	payloadBytes, err := util.DecodeJwtPart(payload)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode jwt: %v", err.Error())
 	}

--- a/pilot/pkg/bootstrap/istio_ca.go
+++ b/pilot/pkg/bootstrap/istio_ca.go
@@ -40,7 +40,7 @@ import (
 	"istio.io/istio/security/pkg/pki/ra"
 	caserver "istio.io/istio/security/pkg/server/ca"
 	"istio.io/istio/security/pkg/server/ca/authenticate"
-	"istio.io/istio/security/pkg/util"	
+	"istio.io/istio/security/pkg/util"
 	"istio.io/pkg/env"
 	"istio.io/pkg/log"
 )

--- a/security/pkg/util/jwtutil.go
+++ b/security/pkg/util/jwtutil.go
@@ -107,7 +107,7 @@ func ExtractJwtAud(jwt string) ([]string, bool) {
 	}
 	payload := jwtSplit[1]
 
-	payloadBytes, err := base64.RawStdEncoding.DecodeString(payload)
+	payloadBytes, err := base64.URLEncoding.DecodeString(payload)
 	if err != nil {
 		return nil, false
 	}

--- a/security/pkg/util/jwtutil.go
+++ b/security/pkg/util/jwtutil.go
@@ -107,7 +107,7 @@ func ExtractJwtAud(jwt string) ([]string, bool) {
 	}
 	payload := jwtSplit[1]
 
-	payloadBytes, err := base64.URLEncoding.DecodeString(payload)
+	payloadBytes, err := DecodeJwtPart(payload)
 	if err != nil {
 		return nil, false
 	}
@@ -128,7 +128,7 @@ func parseJwtClaims(token string) (map[string]any, error) {
 	}
 
 	// Decode the second part.
-	claimBytes, err := decodeSegment(parts[1])
+	claimBytes, err := DecodeJwtPart(parts[1])
 	if err != nil {
 		return nil, err
 	}
@@ -141,7 +141,7 @@ func parseJwtClaims(token string) (map[string]any, error) {
 	return claims, nil
 }
 
-func decodeSegment(seg string) ([]byte, error) {
+func DecodeJwtPart(seg string) ([]byte, error) {
 	if l := len(seg) % 4; l > 0 {
 		seg += strings.Repeat("=", 4-l)
 	}

--- a/security/pkg/util/jwtutil_test.go
+++ b/security/pkg/util/jwtutil_test.go
@@ -56,6 +56,9 @@ var (
 
 	// twoAudList includes two `aud` claims ["abc", "xyz"] of type []string.
 	twoAudList = "header.eyJhdWQiOlsiYWJjIiwieHl6Il0sImV4cCI6NDczMjk5NDgwMSwiaWF0IjoxNTc5Mzk0ODAxLCJpc3MiOiJ0ZXN0LWlzc3Vlci0xQGlzdGlvLmlvIiwic3ViIjoic3ViLTEifQ.signature" // nolint: lll
+
+	// A JWT encoded payload that has the padding stripped and contains an underscore character from the base64url alphabet
+	base64UrlEncodedPaddingStrippedPart = "eyJpc3MiOiJodHRwczovL2V4YW1wbGUuY29tIiwiYXVkIjoiSm9lIEFyZG_DsWV6In0"
 )
 
 func TestGetExp(t *testing.T) {
@@ -139,3 +142,19 @@ func Test3p(t *testing.T) {
 		}
 	}
 }
+
+func TestBase64UrlPartDecoding(t *testing.T) {
+	payloadBytes, err := DecodeJwtPart(base64UrlEncodedPaddingStrippedPart)
+	if err != nil {
+		t.Error("Expected DecodeJwtPart success, got failure", err)
+	}
+	if (payloadBytes == nil) {
+		t.Error("Expected DecodeJwtPart to return non-nil, got nil")
+	}
+
+	expectedAud := "Joe Ardoñez"
+	if got, _ := GetAud("header." + base64UrlEncodedPaddingStrippedPart + ".signature"); len(got) != 1 || expectedAud != got[0] {
+		t.Errorf("want audience %v but got %v", expectedAud, got)
+	}
+}
+

--- a/security/pkg/util/jwtutil_test.go
+++ b/security/pkg/util/jwtutil_test.go
@@ -148,7 +148,7 @@ func TestBase64UrlPartDecoding(t *testing.T) {
 	if err != nil {
 		t.Error("Expected DecodeJwtPart success, got failure", err)
 	}
-	if (payloadBytes == nil) {
+	if payloadBytes == nil {
 		t.Error("Expected DecodeJwtPart to return non-nil, got nil")
 	}
 
@@ -157,4 +157,3 @@ func TestBase64UrlPartDecoding(t *testing.T) {
 		t.Errorf("want audience %v but got %v", expectedAud, got)
 	}
 }
-


### PR DESCRIPTION
**Please provide a description of this PR:**

Per the JWT spec, all three parts of the token are to be base64url encoded.  The JWT spec (RFC7519) defers to the JWS spec (RFC7515) on the implementation of base64url encoding. The JWS spec calls for `=` padding characters to be removed during encoding.  The current istio implementation for JWT payload decoding uses the raw base64 decoder which causes an error if the encoded payload contains underscore or dash characters from the base64url alphabet.  This PR changes the payload decoding to expect URLEncoding without padding.


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [X] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
