### PR TITLE
telemetry: use native stats by default

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -2745,23 +2745,9 @@ spec:
           name: istio.stats
           typed_config:
             "@type": type.googleapis.com/udpa.type.v1.TypedStruct
-            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+            type_url: type.googleapis.com/stats.PluginConfig
             value:
-              config:
-                root_id: stats_outbound
-                configuration:
-                  "@type": "type.googleapis.com/google.protobuf.StringValue"
-                  value: |
-                    {
-                      "debug": "false",
-                      "stat_prefix": "istio"
-                    }
-                vm_config:
-                  vm_id: stats_outbound
-                  runtime: envoy.wasm.runtime.null
-                  code:
-                    local:
-                      inline_string: envoy.wasm.stats
+              {}
     - applyTo: HTTP_FILTER
       match:
         context: SIDECAR_INBOUND
@@ -2779,24 +2765,11 @@ spec:
           name: istio.stats
           typed_config:
             "@type": type.googleapis.com/udpa.type.v1.TypedStruct
-            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+            type_url: type.googleapis.com/stats.PluginConfig
             value:
-              config:
-                root_id: stats_inbound
-                configuration:
-                  "@type": "type.googleapis.com/google.protobuf.StringValue"
-                  value: |
-                    {
-                      "debug": "false",
-                      "stat_prefix": "istio",
-                      "disable_host_header_fallback": true
-                    }
-                vm_config:
-                  vm_id: stats_inbound
-                  runtime: envoy.wasm.runtime.null
-                  code:
-                    local:
-                      inline_string: envoy.wasm.stats
+              {
+                "disable_host_header_fallback": true
+              }
     - applyTo: HTTP_FILTER
       match:
         context: GATEWAY
@@ -2814,24 +2787,11 @@ spec:
           name: istio.stats
           typed_config:
             "@type": type.googleapis.com/udpa.type.v1.TypedStruct
-            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+            type_url: type.googleapis.com/stats.PluginConfig
             value:
-              config:
-                root_id: stats_outbound
-                configuration:
-                  "@type": "type.googleapis.com/google.protobuf.StringValue"
-                  value: |
-                    {
-                      "debug": "false",
-                      "stat_prefix": "istio",
-                      "disable_host_header_fallback": true
-                    }
-                vm_config:
-                  vm_id: stats_outbound
-                  runtime: envoy.wasm.runtime.null
-                  code:
-                    local:
-                      inline_string: envoy.wasm.stats
+              {
+                "disable_host_header_fallback": true
+              }
 ---
 # Source: istiod/templates/telemetryv2_1.17.yaml
 # Note: tcp stats filter is wasm enabled only in sidecars.
@@ -2860,23 +2820,9 @@ spec:
           name: istio.stats
           typed_config:
             "@type": type.googleapis.com/udpa.type.v1.TypedStruct
-            type_url: type.googleapis.com/envoy.extensions.filters.network.wasm.v3.Wasm
+            type_url: type.googleapis.com/stats.PluginConfig
             value:
-              config:
-                root_id: stats_inbound
-                configuration:
-                  "@type": "type.googleapis.com/google.protobuf.StringValue"
-                  value: |
-                    {
-                      "debug": "false",
-                      "stat_prefix": "istio"
-                    }
-                vm_config:
-                  vm_id: tcp_stats_inbound
-                  runtime: envoy.wasm.runtime.null
-                  code:
-                    local:
-                      inline_string: "envoy.wasm.stats"
+              {}
     - applyTo: NETWORK_FILTER
       match:
         context: SIDECAR_OUTBOUND
@@ -2892,23 +2838,9 @@ spec:
           name: istio.stats
           typed_config:
             "@type": type.googleapis.com/udpa.type.v1.TypedStruct
-            type_url: type.googleapis.com/envoy.extensions.filters.network.wasm.v3.Wasm
+            type_url: type.googleapis.com/stats.PluginConfig
             value:
-              config:
-                root_id: stats_outbound
-                configuration:
-                  "@type": "type.googleapis.com/google.protobuf.StringValue"
-                  value: |
-                    {
-                      "debug": "false",
-                      "stat_prefix": "istio"
-                    }
-                vm_config:
-                  vm_id: tcp_stats_outbound
-                  runtime: envoy.wasm.runtime.null
-                  code:
-                    local:
-                      inline_string: "envoy.wasm.stats"
+              {}
     - applyTo: NETWORK_FILTER
       match:
         context: GATEWAY
@@ -2924,23 +2856,9 @@ spec:
           name: istio.stats
           typed_config:
             "@type": type.googleapis.com/udpa.type.v1.TypedStruct
-            type_url: type.googleapis.com/envoy.extensions.filters.network.wasm.v3.Wasm
+            type_url: type.googleapis.com/stats.PluginConfig
             value:
-              config:
-                root_id: stats_outbound
-                configuration:
-                  "@type": "type.googleapis.com/google.protobuf.StringValue"
-                  value: |
-                    {
-                      "debug": "false",
-                      "stat_prefix": "istio"
-                    }
-                vm_config:
-                  vm_id: tcp_stats_outbound
-                  runtime: envoy.wasm.runtime.null
-                  code:
-                    local:
-                      inline_string: "envoy.wasm.stats"
+              {}
 ---
 # Source: istiod/templates/mutatingwebhook.yaml
 apiVersion: admissionregistration.k8s.io/v1

--- a/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.17.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.17.yaml
@@ -33,35 +33,13 @@ spec:
           name: istio.stats
           typed_config:
             "@type": type.googleapis.com/udpa.type.v1.TypedStruct
-            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+            type_url: type.googleapis.com/stats.PluginConfig
             value:
-              config:
-                root_id: stats_outbound
-                configuration:
-                  "@type": "type.googleapis.com/google.protobuf.StringValue"
-                  value: |
-                    {{- if not .Values.telemetry.v2.prometheus.configOverride.outboundSidecar }}
-                    {
-                      "debug": "false",
-                      "stat_prefix": "istio"
-                    }
-                    {{- else }}
-                    {{ toJson .Values.telemetry.v2.prometheus.configOverride.outboundSidecar | indent 18 }}
-                    {{- end }}
-                vm_config:
-                  vm_id: stats_outbound
-                  {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
-                  runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
-                  code:
-                    local:
-                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
-                  {{- else }}
-                  runtime: envoy.wasm.runtime.null
-                  code:
-                    local:
-                      inline_string: envoy.wasm.stats
-                  {{- end }}
+              {{- if not .Values.telemetry.v2.prometheus.configOverride.outboundSidecar }}
+              {}
+              {{- else }}
+              {{ toJson .Values.telemetry.v2.prometheus.configOverride.outboundSidecar | indent 18 }}
+              {{- end }}
     - applyTo: HTTP_FILTER
       match:
         context: SIDECAR_INBOUND
@@ -79,36 +57,15 @@ spec:
           name: istio.stats
           typed_config:
             "@type": type.googleapis.com/udpa.type.v1.TypedStruct
-            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+            type_url: type.googleapis.com/stats.PluginConfig
             value:
-              config:
-                root_id: stats_inbound
-                configuration:
-                  "@type": "type.googleapis.com/google.protobuf.StringValue"
-                  value: |
-                    {{- if not .Values.telemetry.v2.prometheus.configOverride.inboundSidecar }}
-                    {
-                      "debug": "false",
-                      "stat_prefix": "istio",
-                      "disable_host_header_fallback": true
-                    }
-                    {{- else }}
-                    {{ toJson .Values.telemetry.v2.prometheus.configOverride.inboundSidecar | indent 18 }}
-                    {{- end }}
-                vm_config:
-                  vm_id: stats_inbound
-                  {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
-                  runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
-                  code:
-                    local:
-                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
-                  {{- else }}
-                  runtime: envoy.wasm.runtime.null
-                  code:
-                    local:
-                      inline_string: envoy.wasm.stats
-                  {{- end }}
+              {{- if not .Values.telemetry.v2.prometheus.configOverride.inboundSidecar }}
+              {
+                "disable_host_header_fallback": true
+              }
+              {{- else }}
+              {{ toJson .Values.telemetry.v2.prometheus.configOverride.inboundSidecar | indent 18 }}
+              {{- end }}
     - applyTo: HTTP_FILTER
       match:
         context: GATEWAY
@@ -126,36 +83,15 @@ spec:
           name: istio.stats
           typed_config:
             "@type": type.googleapis.com/udpa.type.v1.TypedStruct
-            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+            type_url: type.googleapis.com/stats.PluginConfig
             value:
-              config:
-                root_id: stats_outbound
-                configuration:
-                  "@type": "type.googleapis.com/google.protobuf.StringValue"
-                  value: |
-                    {{- if not .Values.telemetry.v2.prometheus.configOverride.gateway }}
-                    {
-                      "debug": "false",
-                      "stat_prefix": "istio",
-                      "disable_host_header_fallback": true
-                    }
-                    {{- else }}
-                    {{ toJson .Values.telemetry.v2.prometheus.configOverride.gateway | indent 18 }}
-                    {{- end }}
-                vm_config:
-                  vm_id: stats_outbound
-                  {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
-                  runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
-                  code:
-                    local:
-                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
-                  {{- else }}
-                  runtime: envoy.wasm.runtime.null
-                  code:
-                    local:
-                      inline_string: envoy.wasm.stats
-                  {{- end }}
+              {{- if not .Values.telemetry.v2.prometheus.configOverride.gateway }}
+              {
+                "disable_host_header_fallback": true
+              }
+              {{- else }}
+              {{ toJson .Values.telemetry.v2.prometheus.configOverride.gateway | indent 18 }}
+              {{- end }}
 ---
 # Note: tcp stats filter is wasm enabled only in sidecars.
 apiVersion: networking.istio.io/v1alpha3
@@ -187,35 +123,13 @@ spec:
           name: istio.stats
           typed_config:
             "@type": type.googleapis.com/udpa.type.v1.TypedStruct
-            type_url: type.googleapis.com/envoy.extensions.filters.network.wasm.v3.Wasm
+            type_url: type.googleapis.com/stats.PluginConfig
             value:
-              config:
-                root_id: stats_inbound
-                configuration:
-                  "@type": "type.googleapis.com/google.protobuf.StringValue"
-                  value: |
-                    {{- if not .Values.telemetry.v2.prometheus.configOverride.inboundSidecar }}
-                    {
-                      "debug": "false",
-                      "stat_prefix": "istio"
-                    }
-                    {{- else }}
-                    {{ toJson .Values.telemetry.v2.prometheus.configOverride.inboundSidecar | indent 18 }}
-                    {{- end }}
-                vm_config:
-                  vm_id: tcp_stats_inbound
-                  {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
-                  runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
-                  code:
-                    local:
-                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
-                  {{- else }}
-                  runtime: envoy.wasm.runtime.null
-                  code:
-                    local:
-                      inline_string: "envoy.wasm.stats"
-                  {{- end }}
+              {{- if not .Values.telemetry.v2.prometheus.configOverride.inboundSidecar }}
+              {}
+              {{- else }}
+              {{ toJson .Values.telemetry.v2.prometheus.configOverride.inboundSidecar | indent 18 }}
+              {{- end }}
     - applyTo: NETWORK_FILTER
       match:
         context: SIDECAR_OUTBOUND
@@ -231,35 +145,13 @@ spec:
           name: istio.stats
           typed_config:
             "@type": type.googleapis.com/udpa.type.v1.TypedStruct
-            type_url: type.googleapis.com/envoy.extensions.filters.network.wasm.v3.Wasm
+            type_url: type.googleapis.com/stats.PluginConfig
             value:
-              config:
-                root_id: stats_outbound
-                configuration:
-                  "@type": "type.googleapis.com/google.protobuf.StringValue"
-                  value: |
-                    {{- if not .Values.telemetry.v2.prometheus.configOverride.outboundSidecar }}
-                    {
-                      "debug": "false",
-                      "stat_prefix": "istio"
-                    }
-                    {{- else }}
-                    {{ toJson .Values.telemetry.v2.prometheus.configOverride.outboundSidecar | indent 18 }}
-                    {{- end }}
-                vm_config:
-                  vm_id: tcp_stats_outbound
-                  {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
-                  runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
-                  code:
-                    local:
-                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
-                  {{- else }}
-                  runtime: envoy.wasm.runtime.null
-                  code:
-                    local:
-                      inline_string: "envoy.wasm.stats"
-                  {{- end }}
+              {{- if not .Values.telemetry.v2.prometheus.configOverride.outboundSidecar }}
+              {}
+              {{- else }}
+              {{ toJson .Values.telemetry.v2.prometheus.configOverride.outboundSidecar | indent 18 }}
+              {{- end }}
     - applyTo: NETWORK_FILTER
       match:
         context: GATEWAY
@@ -275,35 +167,13 @@ spec:
           name: istio.stats
           typed_config:
             "@type": type.googleapis.com/udpa.type.v1.TypedStruct
-            type_url: type.googleapis.com/envoy.extensions.filters.network.wasm.v3.Wasm
+            type_url: type.googleapis.com/stats.PluginConfig
             value:
-              config:
-                root_id: stats_outbound
-                configuration:
-                  "@type": "type.googleapis.com/google.protobuf.StringValue"
-                  value: |
-                    {{- if not .Values.telemetry.v2.prometheus.configOverride.gateway }}
-                    {
-                      "debug": "false",
-                      "stat_prefix": "istio"
-                    }
-                    {{- else }}
-                    {{ toJson .Values.telemetry.v2.prometheus.configOverride.gateway | indent 18 }}
-                    {{- end }}
-                vm_config:
-                  vm_id: tcp_stats_outbound
-                  {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
-                  runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
-                  code:
-                    local:
-                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
-                  {{- else }}
-                  runtime: envoy.wasm.runtime.null
-                  code:
-                    local:
-                      inline_string: "envoy.wasm.stats"
-                  {{- end }}
+              {{- if not .Values.telemetry.v2.prometheus.configOverride.gateway }}
+              {}
+              {{- else }}
+              {{ toJson .Values.telemetry.v2.prometheus.configOverride.gateway | indent 18 }}
+              {{- end }}
 ---
 {{- end }}
 {{- if .Values.telemetry.v2.stackdriver.enabled }}

--- a/manifests/charts/istiod-remote/templates/telemetryv2_1.17.yaml
+++ b/manifests/charts/istiod-remote/templates/telemetryv2_1.17.yaml
@@ -33,35 +33,13 @@ spec:
           name: istio.stats
           typed_config:
             "@type": type.googleapis.com/udpa.type.v1.TypedStruct
-            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+            type_url: type.googleapis.com/stats.PluginConfig
             value:
-              config:
-                root_id: stats_outbound
-                configuration:
-                  "@type": "type.googleapis.com/google.protobuf.StringValue"
-                  value: |
-                    {{- if not .Values.telemetry.v2.prometheus.configOverride.outboundSidecar }}
-                    {
-                      "debug": "false",
-                      "stat_prefix": "istio"
-                    }
-                    {{- else }}
-                    {{ toJson .Values.telemetry.v2.prometheus.configOverride.outboundSidecar | indent 18 }}
-                    {{- end }}
-                vm_config:
-                  vm_id: stats_outbound
-                  {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
-                  runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
-                  code:
-                    local:
-                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
-                  {{- else }}
-                  runtime: envoy.wasm.runtime.null
-                  code:
-                    local:
-                      inline_string: envoy.wasm.stats
-                  {{- end }}
+              {{- if not .Values.telemetry.v2.prometheus.configOverride.outboundSidecar }}
+              {}
+              {{- else }}
+              {{ toJson .Values.telemetry.v2.prometheus.configOverride.outboundSidecar | indent 18 }}
+              {{- end }}
     - applyTo: HTTP_FILTER
       match:
         context: SIDECAR_INBOUND
@@ -79,36 +57,15 @@ spec:
           name: istio.stats
           typed_config:
             "@type": type.googleapis.com/udpa.type.v1.TypedStruct
-            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+            type_url: type.googleapis.com/stats.PluginConfig
             value:
-              config:
-                root_id: stats_inbound
-                configuration:
-                  "@type": "type.googleapis.com/google.protobuf.StringValue"
-                  value: |
-                    {{- if not .Values.telemetry.v2.prometheus.configOverride.inboundSidecar }}
-                    {
-                      "debug": "false",
-                      "stat_prefix": "istio",
-                      "disable_host_header_fallback": true
-                    }
-                    {{- else }}
-                    {{ toJson .Values.telemetry.v2.prometheus.configOverride.inboundSidecar | indent 18 }}
-                    {{- end }}
-                vm_config:
-                  vm_id: stats_inbound
-                  {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
-                  runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
-                  code:
-                    local:
-                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
-                  {{- else }}
-                  runtime: envoy.wasm.runtime.null
-                  code:
-                    local:
-                      inline_string: envoy.wasm.stats
-                  {{- end }}
+              {{- if not .Values.telemetry.v2.prometheus.configOverride.inboundSidecar }}
+              {
+                "disable_host_header_fallback": true
+              }
+              {{- else }}
+              {{ toJson .Values.telemetry.v2.prometheus.configOverride.inboundSidecar | indent 18 }}
+              {{- end }}
     - applyTo: HTTP_FILTER
       match:
         context: GATEWAY
@@ -126,36 +83,15 @@ spec:
           name: istio.stats
           typed_config:
             "@type": type.googleapis.com/udpa.type.v1.TypedStruct
-            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+            type_url: type.googleapis.com/stats.PluginConfig
             value:
-              config:
-                root_id: stats_outbound
-                configuration:
-                  "@type": "type.googleapis.com/google.protobuf.StringValue"
-                  value: |
-                    {{- if not .Values.telemetry.v2.prometheus.configOverride.gateway }}
-                    {
-                      "debug": "false",
-                      "stat_prefix": "istio",
-                      "disable_host_header_fallback": true
-                    }
-                    {{- else }}
-                    {{ toJson .Values.telemetry.v2.prometheus.configOverride.gateway | indent 18 }}
-                    {{- end }}
-                vm_config:
-                  vm_id: stats_outbound
-                  {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
-                  runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
-                  code:
-                    local:
-                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
-                  {{- else }}
-                  runtime: envoy.wasm.runtime.null
-                  code:
-                    local:
-                      inline_string: envoy.wasm.stats
-                  {{- end }}
+              {{- if not .Values.telemetry.v2.prometheus.configOverride.gateway }}
+              {
+                "disable_host_header_fallback": true
+              }
+              {{- else }}
+              {{ toJson .Values.telemetry.v2.prometheus.configOverride.gateway | indent 18 }}
+              {{- end }}
 ---
 # Note: tcp stats filter is wasm enabled only in sidecars.
 apiVersion: networking.istio.io/v1alpha3
@@ -187,35 +123,13 @@ spec:
           name: istio.stats
           typed_config:
             "@type": type.googleapis.com/udpa.type.v1.TypedStruct
-            type_url: type.googleapis.com/envoy.extensions.filters.network.wasm.v3.Wasm
+            type_url: type.googleapis.com/stats.PluginConfig
             value:
-              config:
-                root_id: stats_inbound
-                configuration:
-                  "@type": "type.googleapis.com/google.protobuf.StringValue"
-                  value: |
-                    {{- if not .Values.telemetry.v2.prometheus.configOverride.inboundSidecar }}
-                    {
-                      "debug": "false",
-                      "stat_prefix": "istio"
-                    }
-                    {{- else }}
-                    {{ toJson .Values.telemetry.v2.prometheus.configOverride.inboundSidecar | indent 18 }}
-                    {{- end }}
-                vm_config:
-                  vm_id: tcp_stats_inbound
-                  {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
-                  runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
-                  code:
-                    local:
-                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
-                  {{- else }}
-                  runtime: envoy.wasm.runtime.null
-                  code:
-                    local:
-                      inline_string: "envoy.wasm.stats"
-                  {{- end }}
+              {{- if not .Values.telemetry.v2.prometheus.configOverride.inboundSidecar }}
+              {}
+              {{- else }}
+              {{ toJson .Values.telemetry.v2.prometheus.configOverride.inboundSidecar | indent 18 }}
+              {{- end }}
     - applyTo: NETWORK_FILTER
       match:
         context: SIDECAR_OUTBOUND
@@ -231,35 +145,13 @@ spec:
           name: istio.stats
           typed_config:
             "@type": type.googleapis.com/udpa.type.v1.TypedStruct
-            type_url: type.googleapis.com/envoy.extensions.filters.network.wasm.v3.Wasm
+            type_url: type.googleapis.com/stats.PluginConfig
             value:
-              config:
-                root_id: stats_outbound
-                configuration:
-                  "@type": "type.googleapis.com/google.protobuf.StringValue"
-                  value: |
-                    {{- if not .Values.telemetry.v2.prometheus.configOverride.outboundSidecar }}
-                    {
-                      "debug": "false",
-                      "stat_prefix": "istio"
-                    }
-                    {{- else }}
-                    {{ toJson .Values.telemetry.v2.prometheus.configOverride.outboundSidecar | indent 18 }}
-                    {{- end }}
-                vm_config:
-                  vm_id: tcp_stats_outbound
-                  {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
-                  runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
-                  code:
-                    local:
-                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
-                  {{- else }}
-                  runtime: envoy.wasm.runtime.null
-                  code:
-                    local:
-                      inline_string: "envoy.wasm.stats"
-                  {{- end }}
+              {{- if not .Values.telemetry.v2.prometheus.configOverride.outboundSidecar }}
+              {}
+              {{- else }}
+              {{ toJson .Values.telemetry.v2.prometheus.configOverride.outboundSidecar | indent 18 }}
+              {{- end }}
     - applyTo: NETWORK_FILTER
       match:
         context: GATEWAY
@@ -275,35 +167,13 @@ spec:
           name: istio.stats
           typed_config:
             "@type": type.googleapis.com/udpa.type.v1.TypedStruct
-            type_url: type.googleapis.com/envoy.extensions.filters.network.wasm.v3.Wasm
+            type_url: type.googleapis.com/stats.PluginConfig
             value:
-              config:
-                root_id: stats_outbound
-                configuration:
-                  "@type": "type.googleapis.com/google.protobuf.StringValue"
-                  value: |
-                    {{- if not .Values.telemetry.v2.prometheus.configOverride.gateway }}
-                    {
-                      "debug": "false",
-                      "stat_prefix": "istio"
-                    }
-                    {{- else }}
-                    {{ toJson .Values.telemetry.v2.prometheus.configOverride.gateway | indent 18 }}
-                    {{- end }}
-                vm_config:
-                  vm_id: tcp_stats_outbound
-                  {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
-                  runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
-                  code:
-                    local:
-                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
-                  {{- else }}
-                  runtime: envoy.wasm.runtime.null
-                  code:
-                    local:
-                      inline_string: "envoy.wasm.stats"
-                  {{- end }}
+              {{- if not .Values.telemetry.v2.prometheus.configOverride.gateway }}
+              {}
+              {{- else }}
+              {{ toJson .Values.telemetry.v2.prometheus.configOverride.gateway | indent 18 }}
+              {{- end }}
 ---
 {{- end }}
 {{- if .Values.telemetry.v2.stackdriver.enabled }}

--- a/pkg/envoy/proxy.go
+++ b/pkg/envoy/proxy.go
@@ -130,6 +130,7 @@ func (e *envoy) args(fname string, bootstrapConfig string) []string {
 		// than the flush interval.
 		"--file-flush-interval-msec", "1000",
 		"--disable-hot-restart", // We don't use it, so disable it to simplify Envoy's logic
+		"--allow-unknown-static-fields",
 	}
 	if e.ProxyConfig.LogAsJSON {
 		startupArgs = append(startupArgs,

--- a/pkg/envoy/proxy_test.go
+++ b/pkg/envoy/proxy_test.go
@@ -62,6 +62,7 @@ func TestEnvoyArgs(t *testing.T) {
 		"--local-address-ip-version", "v4",
 		"--file-flush-interval-msec", "1000",
 		"--disable-hot-restart",
+		"--allow-unknown-static-fields",
 		"--log-format", "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %g:%#\t%v\tthread=%t",
 		"-l", "trace",
 		"--component-log-level", "misc:error",


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

Follow up to https://github.com/istio/istio/pull/41441 but for non-telemetry API installation (default), until a plan to default to telemetry API emerges. This should give sufficient burn time in CI, and avoid support for rarely used Wasm version.