### PR TITLE
Replace the deprecated match_subject_alt_names

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -1009,7 +1009,9 @@ func (cb *ClusterBuilder) buildUpstreamClusterTLSContext(opts *buildClusterOpts,
 
 		tlsContext.CommonTlsContext.ValidationContextType = &auth.CommonTlsContext_CombinedValidationContext{
 			CombinedValidationContext: &auth.CommonTlsContext_CombinedCertificateValidationContext{
-				DefaultValidationContext:         &auth.CertificateValidationContext{MatchSubjectAltNames: util.StringToExactMatch(tls.SubjectAltNames)},
+				DefaultValidationContext: &auth.CertificateValidationContext{
+					MatchTypedSubjectAltNames: util.StringsToSanExactMatchers(tls.SubjectAltNames),
+				},
 				ValidationContextSdsSecretConfig: authn_model.ConstructSdsSecretConfig(authn_model.SDSRootResourceName),
 			},
 		}
@@ -1063,7 +1065,9 @@ func (cb *ClusterBuilder) buildUpstreamClusterTLSContext(opts *buildClusterOpts,
 			} else {
 				tlsContext.CommonTlsContext.ValidationContextType = &auth.CommonTlsContext_CombinedValidationContext{
 					CombinedValidationContext: &auth.CommonTlsContext_CombinedCertificateValidationContext{
-						DefaultValidationContext:         &auth.CertificateValidationContext{MatchSubjectAltNames: util.StringToExactMatch(tls.SubjectAltNames)},
+						DefaultValidationContext: &auth.CertificateValidationContext{
+							MatchTypedSubjectAltNames: util.StringsToSanExactMatchers(tls.SubjectAltNames),
+						},
 						ValidationContextSdsSecretConfig: authn_model.ConstructSdsSecretConfig(res.GetRootResourceName()),
 					},
 				}
@@ -1116,7 +1120,9 @@ func (cb *ClusterBuilder) buildUpstreamClusterTLSContext(opts *buildClusterOpts,
 			} else {
 				tlsContext.CommonTlsContext.ValidationContextType = &auth.CommonTlsContext_CombinedValidationContext{
 					CombinedValidationContext: &auth.CommonTlsContext_CombinedCertificateValidationContext{
-						DefaultValidationContext:         &auth.CertificateValidationContext{MatchSubjectAltNames: util.StringToExactMatch(tls.SubjectAltNames)},
+						DefaultValidationContext: &auth.CertificateValidationContext{
+							MatchTypedSubjectAltNames: util.StringsToSanExactMatchers(tls.SubjectAltNames),
+						},
 						ValidationContextSdsSecretConfig: authn_model.ConstructSdsSecretConfig(res.GetRootResourceName()),
 					},
 				}

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
@@ -1870,7 +1870,9 @@ func TestBuildUpstreamClusterTLSContext(t *testing.T) {
 						},
 						ValidationContextType: &tls.CommonTlsContext_CombinedValidationContext{
 							CombinedValidationContext: &tls.CommonTlsContext_CombinedCertificateValidationContext{
-								DefaultValidationContext: &tls.CertificateValidationContext{MatchSubjectAltNames: util.StringToExactMatch([]string{"SAN"})},
+								DefaultValidationContext: &tls.CertificateValidationContext{
+									MatchTypedSubjectAltNames: util.StringsToSanExactMatchers([]string{"SAN"}),
+								},
 								ValidationContextSdsSecretConfig: &tls.SdsSecretConfig{
 									Name: "ROOTCA",
 									SdsConfig: &core.ConfigSource{
@@ -1945,7 +1947,9 @@ func TestBuildUpstreamClusterTLSContext(t *testing.T) {
 						},
 						ValidationContextType: &tls.CommonTlsContext_CombinedValidationContext{
 							CombinedValidationContext: &tls.CommonTlsContext_CombinedCertificateValidationContext{
-								DefaultValidationContext: &tls.CertificateValidationContext{MatchSubjectAltNames: util.StringToExactMatch([]string{"SAN"})},
+								DefaultValidationContext: &tls.CertificateValidationContext{
+									MatchTypedSubjectAltNames: util.StringsToSanExactMatchers([]string{"SAN"}),
+								},
 								ValidationContextSdsSecretConfig: &tls.SdsSecretConfig{
 									Name: "ROOTCA",
 									SdsConfig: &core.ConfigSource{
@@ -2125,7 +2129,9 @@ func TestBuildUpstreamClusterTLSContext(t *testing.T) {
 						},
 						ValidationContextType: &tls.CommonTlsContext_CombinedValidationContext{
 							CombinedValidationContext: &tls.CommonTlsContext_CombinedCertificateValidationContext{
-								DefaultValidationContext: &tls.CertificateValidationContext{MatchSubjectAltNames: util.StringToExactMatch([]string{"SAN"})},
+								DefaultValidationContext: &tls.CertificateValidationContext{
+									MatchTypedSubjectAltNames: util.StringsToSanExactMatchers([]string{"SAN"}),
+								},
 								ValidationContextSdsSecretConfig: &tls.SdsSecretConfig{
 									Name: fmt.Sprintf("file-root:%s", rootCert),
 									SdsConfig: &core.ConfigSource{
@@ -2176,7 +2182,9 @@ func TestBuildUpstreamClusterTLSContext(t *testing.T) {
 						},
 						ValidationContextType: &tls.CommonTlsContext_CombinedValidationContext{
 							CombinedValidationContext: &tls.CommonTlsContext_CombinedCertificateValidationContext{
-								DefaultValidationContext: &tls.CertificateValidationContext{MatchSubjectAltNames: util.StringToExactMatch([]string{"SAN"})},
+								DefaultValidationContext: &tls.CertificateValidationContext{
+									MatchTypedSubjectAltNames: util.StringsToSanExactMatchers([]string{"SAN"}),
+								},
 								ValidationContextSdsSecretConfig: &tls.SdsSecretConfig{
 									Name: fmt.Sprintf("file-root:%s", rootCert),
 									SdsConfig: &core.ConfigSource{
@@ -2227,7 +2235,9 @@ func TestBuildUpstreamClusterTLSContext(t *testing.T) {
 						},
 						ValidationContextType: &tls.CommonTlsContext_CombinedValidationContext{
 							CombinedValidationContext: &tls.CommonTlsContext_CombinedCertificateValidationContext{
-								DefaultValidationContext: &tls.CertificateValidationContext{MatchSubjectAltNames: util.StringToExactMatch([]string{"SAN"})},
+								DefaultValidationContext: &tls.CertificateValidationContext{
+									MatchTypedSubjectAltNames: util.StringsToSanExactMatchers([]string{"SAN"}),
+								},
 								ValidationContextSdsSecretConfig: &tls.SdsSecretConfig{
 									Name: fmt.Sprintf("file-root:%s", rootCert),
 									SdsConfig: &core.ConfigSource{
@@ -2278,7 +2288,9 @@ func TestBuildUpstreamClusterTLSContext(t *testing.T) {
 						},
 						ValidationContextType: &tls.CommonTlsContext_CombinedValidationContext{
 							CombinedValidationContext: &tls.CommonTlsContext_CombinedCertificateValidationContext{
-								DefaultValidationContext: &tls.CertificateValidationContext{MatchSubjectAltNames: util.StringToExactMatch([]string{"se-san.com"})},
+								DefaultValidationContext: &tls.CertificateValidationContext{
+									MatchTypedSubjectAltNames: util.StringsToSanExactMatchers([]string{"se-san.com"}),
+								},
 								ValidationContextSdsSecretConfig: &tls.SdsSecretConfig{
 									Name: fmt.Sprintf("file-root:%s", rootCert),
 									SdsConfig: &core.ConfigSource{
@@ -2431,7 +2443,9 @@ func TestBuildUpstreamClusterTLSContext(t *testing.T) {
 						},
 						ValidationContextType: &tls.CommonTlsContext_CombinedValidationContext{
 							CombinedValidationContext: &tls.CommonTlsContext_CombinedCertificateValidationContext{
-								DefaultValidationContext: &tls.CertificateValidationContext{MatchSubjectAltNames: util.StringToExactMatch([]string{"SAN"})},
+								DefaultValidationContext: &tls.CertificateValidationContext{
+									MatchTypedSubjectAltNames: util.StringsToSanExactMatchers([]string{"SAN"}),
+								},
 								ValidationContextSdsSecretConfig: &tls.SdsSecretConfig{
 									Name: fmt.Sprintf("file-root:%s", rootCert),
 									SdsConfig: &core.ConfigSource{
@@ -2483,7 +2497,7 @@ func TestBuildUpstreamClusterTLSContext(t *testing.T) {
 						ValidationContextType: &tls.CommonTlsContext_CombinedValidationContext{
 							CombinedValidationContext: &tls.CommonTlsContext_CombinedCertificateValidationContext{
 								DefaultValidationContext: &tls.CertificateValidationContext{
-									MatchSubjectAltNames: util.StringToExactMatch([]string{"SAN"}),
+									MatchTypedSubjectAltNames: util.StringsToSanExactMatchers([]string{"SAN"}),
 								},
 								ValidationContextSdsSecretConfig: &tls.SdsSecretConfig{
 									Name:      "kubernetes://" + credentialName + authn_model.SdsCaSuffix,
@@ -2562,7 +2576,7 @@ func TestBuildUpstreamClusterTLSContext(t *testing.T) {
 						ValidationContextType: &tls.CommonTlsContext_CombinedValidationContext{
 							CombinedValidationContext: &tls.CommonTlsContext_CombinedCertificateValidationContext{
 								DefaultValidationContext: &tls.CertificateValidationContext{
-									MatchSubjectAltNames: util.StringToExactMatch([]string{"SAN"}),
+									MatchTypedSubjectAltNames: util.StringsToSanExactMatchers([]string{"SAN"}),
 								},
 								ValidationContextSdsSecretConfig: &tls.SdsSecretConfig{
 									Name:      "kubernetes://" + credentialName + authn_model.SdsCaSuffix,
@@ -2669,7 +2683,7 @@ func TestBuildUpstreamClusterTLSContext(t *testing.T) {
 						ValidationContextType: &tls.CommonTlsContext_CombinedValidationContext{
 							CombinedValidationContext: &tls.CommonTlsContext_CombinedCertificateValidationContext{
 								DefaultValidationContext: &tls.CertificateValidationContext{
-									MatchSubjectAltNames: util.StringToExactMatch([]string{"SAN"}),
+									MatchTypedSubjectAltNames: util.StringsToSanExactMatchers([]string{"SAN"}),
 								},
 								ValidationContextSdsSecretConfig: &tls.SdsSecretConfig{
 									Name:      "kubernetes://" + credentialName + authn_model.SdsCaSuffix,
@@ -2712,7 +2726,7 @@ func TestBuildUpstreamClusterTLSContext(t *testing.T) {
 						ValidationContextType: &tls.CommonTlsContext_CombinedValidationContext{
 							CombinedValidationContext: &tls.CommonTlsContext_CombinedCertificateValidationContext{
 								DefaultValidationContext: &tls.CertificateValidationContext{
-									MatchSubjectAltNames: util.StringToExactMatch([]string{"SAN"}),
+									MatchTypedSubjectAltNames: util.StringsToSanExactMatchers([]string{"SAN"}),
 								},
 								ValidationContextSdsSecretConfig: &tls.SdsSecretConfig{
 									Name:      "kubernetes://" + credentialName + authn_model.SdsCaSuffix,

--- a/pilot/pkg/networking/core/v1alpha3/gateway_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway_test.go
@@ -284,7 +284,7 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 					},
 					ValidationContextType: &auth.CommonTlsContext_ValidationContext{
 						ValidationContext: &auth.CertificateValidationContext{
-							MatchSubjectAltNames: util.StringToExactMatch([]string{"subject.name.a.com", "subject.name.b.com"}),
+							MatchTypedSubjectAltNames: util.StringsToSanExactMatchers([]string{"subject.name.a.com", "subject.name.b.com"}),
 						},
 					},
 				},
@@ -444,7 +444,7 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 					ValidationContextType: &auth.CommonTlsContext_CombinedValidationContext{
 						CombinedValidationContext: &auth.CommonTlsContext_CombinedCertificateValidationContext{
 							DefaultValidationContext: &auth.CertificateValidationContext{
-								MatchSubjectAltNames: util.StringToExactMatch([]string{"subject.name.a.com", "subject.name.b.com"}),
+								MatchTypedSubjectAltNames: util.StringsToSanExactMatchers([]string{"subject.name.a.com", "subject.name.b.com"}),
 							},
 							ValidationContextSdsSecretConfig: &auth.SdsSecretConfig{
 								Name: "file-root:ca-cert.crt",
@@ -501,7 +501,7 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 					ValidationContextType: &auth.CommonTlsContext_CombinedValidationContext{
 						CombinedValidationContext: &auth.CommonTlsContext_CombinedCertificateValidationContext{
 							DefaultValidationContext: &auth.CertificateValidationContext{
-								MatchSubjectAltNames: util.StringToExactMatch([]string{"subject.name.a.com", "subject.name.b.com"}),
+								MatchTypedSubjectAltNames: util.StringsToSanExactMatchers([]string{"subject.name.a.com", "subject.name.b.com"}),
 							},
 							ValidationContextSdsSecretConfig: &auth.SdsSecretConfig{
 								Name:      "kubernetes://ingress-sds-resource-name-cacert",
@@ -722,7 +722,7 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 					ValidationContextType: &auth.CommonTlsContext_CombinedValidationContext{
 						CombinedValidationContext: &auth.CommonTlsContext_CombinedCertificateValidationContext{
 							DefaultValidationContext: &auth.CertificateValidationContext{
-								MatchSubjectAltNames: util.StringToExactMatch([]string{"subject.name.a.com", "subject.name.b.com"}),
+								MatchTypedSubjectAltNames: util.StringsToSanExactMatchers([]string{"subject.name.a.com", "subject.name.b.com"}),
 							},
 							ValidationContextSdsSecretConfig: &auth.SdsSecretConfig{
 								Name: "file-root:ca-cert.crt",

--- a/pilot/pkg/networking/grpcgen/grpcgen.go
+++ b/pilot/pkg/networking/grpcgen/grpcgen.go
@@ -16,7 +16,6 @@ package grpcgen
 
 import (
 	tls "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
-	matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/util"
@@ -69,10 +68,6 @@ func (g *GrpcConfigGenerator) Generate(proxy *model.Proxy, w *model.WatchedResou
 // buildCommonTLSContext creates a TLS context that assumes 'default' name, and credentials/tls/certprovider/pemfile
 // (see grpc/xds/internal/client/xds.go securityConfigFromCluster).
 func buildCommonTLSContext(sans []string) *tls.CommonTlsContext {
-	var sanMatch []*matcher.StringMatcher
-	if len(sans) > 0 {
-		sanMatch = util.StringToExactMatch(sans)
-	}
 	return &tls.CommonTlsContext{
 		TlsCertificateCertificateProviderInstance: &tls.CommonTlsContext_CertificateProviderInstance{
 			InstanceName:    "default",
@@ -85,7 +80,7 @@ func buildCommonTLSContext(sans []string) *tls.CommonTlsContext {
 					CertificateName: "ROOTCA",
 				},
 				DefaultValidationContext: &tls.CertificateValidationContext{
-					MatchSubjectAltNames: sanMatch,
+					MatchTypedSubjectAltNames: util.StringsToSanExactMatchers(sans),
 				},
 			},
 		},

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -28,6 +28,7 @@ import (
 	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	auth "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"google.golang.org/protobuf/proto"
@@ -771,4 +772,21 @@ func BuildTunnelMetadataStruct(tunnelAddress, address string, port, tunnelPort i
 		"destination": net.JoinHostPort(address, strconv.Itoa(port)),
 	})
 	return st
+}
+
+// Create a URI typed SubjectAltNameMatcher per each one of the provided StringMatcher
+func StringMatchersToSanMatchers(stringMatchers []*matcher.StringMatcher) []*auth.SubjectAltNameMatcher {
+	sanMatchers := []*auth.SubjectAltNameMatcher{}
+	for _, matcher := range stringMatchers {
+		sanMatchers = append(sanMatchers, &auth.SubjectAltNameMatcher{
+			SanType: auth.SubjectAltNameMatcher_URI,
+			Matcher: matcher,
+		})
+	}
+	return sanMatchers
+}
+
+// Create a URI typed SubjectAltNameMatcher with an exact string matcher per each one of the provided strings
+func StringsToSanExactMatchers(sans []string) []*auth.SubjectAltNameMatcher {
+	return StringMatchersToSanMatchers(StringToExactMatch(sans))
 }

--- a/pilot/pkg/security/model/authentication.go
+++ b/pilot/pkg/security/model/authentication.go
@@ -239,7 +239,9 @@ func ApplyToCommonTLSContext(tlsContext *tls.CommonTlsContext, proxy *model.Prox
 	if validateClient {
 		tlsContext.ValidationContextType = &tls.CommonTlsContext_CombinedValidationContext{
 			CombinedValidationContext: &tls.CommonTlsContext_CombinedCertificateValidationContext{
-				DefaultValidationContext:         &tls.CertificateValidationContext{MatchSubjectAltNames: matchSAN},
+				DefaultValidationContext: &tls.CertificateValidationContext{
+					MatchTypedSubjectAltNames: util.StringMatchersToSanMatchers(matchSAN),
+				},
 				ValidationContextSdsSecretConfig: ConstructSdsSecretConfig(model.GetOrDefault(res.GetRootResourceName(), SDSRootResourceName)),
 			},
 		}
@@ -263,7 +265,7 @@ func ApplyCustomSDSToClientCommonTLSContext(tlsContext *tls.CommonTlsContext,
 	// create SDS config for gateway to fetch certificate validation context
 	// at gateway agent.
 	defaultValidationContext := &tls.CertificateValidationContext{
-		MatchSubjectAltNames: util.StringToExactMatch(tlsOpts.SubjectAltNames),
+		MatchTypedSubjectAltNames: util.StringsToSanExactMatchers(tlsOpts.SubjectAltNames),
 	}
 	tlsContext.ValidationContextType = &tls.CommonTlsContext_CombinedValidationContext{
 		CombinedValidationContext: &tls.CommonTlsContext_CombinedCertificateValidationContext{
@@ -287,9 +289,9 @@ func ApplyCredentialSDSToServerCommonTLSContext(tlsContext *tls.CommonTlsContext
 	// at gateway agent. Otherwise, use the static certificate validation context config.
 	if tlsOpts.Mode == networking.ServerTLSSettings_MUTUAL {
 		defaultValidationContext := &tls.CertificateValidationContext{
-			MatchSubjectAltNames:  util.StringToExactMatch(tlsOpts.SubjectAltNames),
-			VerifyCertificateSpki: tlsOpts.VerifyCertificateSpki,
-			VerifyCertificateHash: tlsOpts.VerifyCertificateHash,
+			MatchTypedSubjectAltNames: util.StringsToSanExactMatchers(tlsOpts.SubjectAltNames),
+			VerifyCertificateSpki:     tlsOpts.VerifyCertificateSpki,
+			VerifyCertificateHash:     tlsOpts.VerifyCertificateHash,
 		}
 		tlsContext.ValidationContextType = &tls.CommonTlsContext_CombinedValidationContext{
 			CombinedValidationContext: &tls.CommonTlsContext_CombinedCertificateValidationContext{
@@ -301,7 +303,7 @@ func ApplyCredentialSDSToServerCommonTLSContext(tlsContext *tls.CommonTlsContext
 	} else if len(tlsOpts.SubjectAltNames) > 0 {
 		tlsContext.ValidationContextType = &tls.CommonTlsContext_ValidationContext{
 			ValidationContext: &tls.CertificateValidationContext{
-				MatchSubjectAltNames: util.StringToExactMatch(tlsOpts.SubjectAltNames),
+				MatchTypedSubjectAltNames: util.StringsToSanExactMatchers(tlsOpts.SubjectAltNames),
 			},
 		}
 	}

--- a/pilot/pkg/security/model/authentication_test.go
+++ b/pilot/pkg/security/model/authentication_test.go
@@ -177,10 +177,16 @@ func TestApplyToCommonTLSContext(t *testing.T) {
 				},
 				ValidationContextType: &auth.CommonTlsContext_CombinedValidationContext{
 					CombinedValidationContext: &auth.CommonTlsContext_CombinedCertificateValidationContext{
-						DefaultValidationContext: &auth.CertificateValidationContext{MatchSubjectAltNames: []*matcher.StringMatcher{
-							{MatchPattern: &matcher.StringMatcher_Prefix{Prefix: spiffe.URIPrefix + "alias-1.domain" + "/"}},
-							{MatchPattern: &matcher.StringMatcher_Prefix{Prefix: spiffe.URIPrefix + "some-other-alias-1.domain" + "/"}},
-							{MatchPattern: &matcher.StringMatcher_Prefix{Prefix: spiffe.URIPrefix + "alias-2.domain" + "/"}},
+						DefaultValidationContext: &auth.CertificateValidationContext{MatchTypedSubjectAltNames: []*auth.SubjectAltNameMatcher{
+							{SanType: auth.SubjectAltNameMatcher_URI, Matcher: &matcher.StringMatcher{
+								MatchPattern: &matcher.StringMatcher_Prefix{Prefix: spiffe.URIPrefix + "alias-1.domain" + "/"},
+							}},
+							{SanType: auth.SubjectAltNameMatcher_URI, Matcher: &matcher.StringMatcher{
+								MatchPattern: &matcher.StringMatcher_Prefix{Prefix: spiffe.URIPrefix + "some-other-alias-1.domain" + "/"},
+							}},
+							{SanType: auth.SubjectAltNameMatcher_URI, Matcher: &matcher.StringMatcher{
+								MatchPattern: &matcher.StringMatcher_Prefix{Prefix: spiffe.URIPrefix + "alias-2.domain" + "/"},
+							}},
 						}},
 						ValidationContextSdsSecretConfig: &auth.SdsSecretConfig{
 							Name: "ROOTCA",

--- a/pilot/pkg/xds/cds_test.go
+++ b/pilot/pkg/xds/cds_test.go
@@ -215,8 +215,8 @@ func TestSAN(t *testing.T) {
 				tl := xdstest.UnmarshalAny[tls.UpstreamTlsContext](t, cluster.GetTransportSocket().GetTypedConfig())
 				names := sets.New[string]()
 				// nolint: staticcheck
-				for _, n := range tl.GetCommonTlsContext().GetCombinedValidationContext().GetDefaultValidationContext().GetMatchSubjectAltNames() {
-					names.Insert(n.GetExact())
+				for _, n := range tl.GetCommonTlsContext().GetCombinedValidationContext().GetDefaultValidationContext().GetMatchTypedSubjectAltNames() {
+					names.Insert(n.Matcher.GetExact())
 				}
 				assert.Equal(t, sets.SortedList(names), sets.SortedList(sets.New(sans...)))
 			}

--- a/pilot/pkg/xds/eds_test.go
+++ b/pilot/pkg/xds/eds_test.go
@@ -163,7 +163,7 @@ func TestSAUpdate(t *testing.T) {
 	}
 	transport := &tls.UpstreamTlsContext{}
 	ads.GetEdsClusters()["outbound|80||test1"].GetTransportSocketMatches()[0].GetTransportSocket().GetTypedConfig().UnmarshalTo(transport)
-	sans := transport.GetCommonTlsContext().GetCombinedValidationContext().GetDefaultValidationContext().GetMatchSubjectAltNames() //nolint: staticcheck
+	sans := transport.GetCommonTlsContext().GetCombinedValidationContext().GetDefaultValidationContext().GetMatchTypedSubjectAltNames() //nolint: staticcheck
 	if len(sans) != 1 {
 		t.Fatalf("expected 1 san, got %v", sans)
 	}

--- a/pkg/bootstrap/option/convert.go
+++ b/pkg/bootstrap/option/convert.go
@@ -102,7 +102,9 @@ func tlsContextConvert(tls *networkingAPI.ClientTLSSettings, sniName string, met
 
 		tlsContext.CommonTlsContext.ValidationContextType = &auth.CommonTlsContext_CombinedValidationContext{
 			CombinedValidationContext: &auth.CommonTlsContext_CombinedCertificateValidationContext{
-				DefaultValidationContext:         &auth.CertificateValidationContext{MatchSubjectAltNames: util.StringToExactMatch(tls.SubjectAltNames)},
+				DefaultValidationContext: &auth.CertificateValidationContext{
+					MatchTypedSubjectAltNames: util.StringsToSanExactMatchers(tls.SubjectAltNames),
+				},
 				ValidationContextSdsSecretConfig: authn_model.ConstructSdsSecretConfig(res.GetRootResourceName()),
 			},
 		}
@@ -121,7 +123,9 @@ func tlsContextConvert(tls *networkingAPI.ClientTLSSettings, sniName string, met
 
 		tlsContext.CommonTlsContext.ValidationContextType = &auth.CommonTlsContext_CombinedValidationContext{
 			CombinedValidationContext: &auth.CommonTlsContext_CombinedCertificateValidationContext{
-				DefaultValidationContext:         &auth.CertificateValidationContext{MatchSubjectAltNames: util.StringToExactMatch(tls.SubjectAltNames)},
+				DefaultValidationContext: &auth.CertificateValidationContext{
+					MatchTypedSubjectAltNames: util.StringsToSanExactMatchers(tls.SubjectAltNames),
+				},
 				ValidationContextSdsSecretConfig: authn_model.ConstructSdsSecretConfig(res.GetRootResourceName()),
 			},
 		}
@@ -133,7 +137,9 @@ func tlsContextConvert(tls *networkingAPI.ClientTLSSettings, sniName string, met
 
 		tlsContext.CommonTlsContext.ValidationContextType = &auth.CommonTlsContext_CombinedValidationContext{
 			CombinedValidationContext: &auth.CommonTlsContext_CombinedCertificateValidationContext{
-				DefaultValidationContext:         &auth.CertificateValidationContext{MatchSubjectAltNames: util.StringToExactMatch(tls.SubjectAltNames)},
+				DefaultValidationContext: &auth.CertificateValidationContext{
+					MatchTypedSubjectAltNames: util.StringsToSanExactMatchers(tls.SubjectAltNames),
+				},
 				ValidationContextSdsSecretConfig: authn_model.ConstructSdsSecretConfig(authn_model.SDSRootResourceName),
 			},
 		}


### PR DESCRIPTION
**Please provide a description of this PR:**

Replacing [the deprecated  match_subject_alt_names](https://github.com/envoyproxy/envoy/blob/main/api/envoy/extensions/transport_sockets/tls/v3/common.proto#L444) with the equivalent _match_typed_subject_alt_names_.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [X] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
