### PR TITLE
Add InvalidateDiscovery() to the Client interface

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -219,6 +219,9 @@ type CLIClient interface {
 
 	// SetPortManager overrides the default port manager to provision local ports
 	SetPortManager(PortManager)
+
+	// InvalidateDiscovery() invalidates the discovery client, useful after manually changing CRD's
+	InvalidateDiscovery()
 }
 
 type PortManager func() (uint16, error)
@@ -1105,11 +1108,15 @@ func (c *client) applyYAMLFile(namespace string, dryRun bool, file string) error
 			log.Warnf("Failed to read %s: %v", file, err)
 		}
 		if len(yml.SplitYamlByKind(string(f))[gvk.CustomResourceDefinition.Kind]) > 0 {
-			c.discoveryClient.Invalidate()
-			c.mapper.Reset()
+			c.InvalidateDiscovery()
 		}
 	}
 	return nil
+}
+
+func (c *client) InvalidateDiscovery() {
+	c.discoveryClient.Invalidate()
+	c.mapper.Reset()
 }
 
 func (c *client) DeleteYAMLFiles(namespace string, yamlFiles ...string) (err error) {

--- a/pkg/kube/mock_client.go
+++ b/pkg/kube/mock_client.go
@@ -237,6 +237,10 @@ func (c MockClient) DeleteYAMLFilesDryRun(string, ...string) error {
 	panic("not implemented by mock")
 }
 
+func (c MockClient) InvalidateDiscovery() {
+	panic("not implemented by mock")
+}
+
 func (c MockClient) Ext() clientset.Interface {
 	panic("not implemented by mock")
 }


### PR DESCRIPTION
This is going to be useful when we need to change CRD's but cannot call `ApplyYAMLFiles()` because our CRD is too big and k8s apply complains about it. So, after changing the CRD through other means, we can call this new `InvalidateDiscovery()` just like `ApplyYAMLFile()` does.
