### PR TITLE
Support configuring TLS min/max version and ECDH curves

### DIFF
--- a/pilot/cmd/pilot-discovery/app/cmd.go
+++ b/pilot/cmd/pilot-discovery/app/cmd.go
@@ -178,6 +178,9 @@ func addFlags(c *cobra.Command) {
 	c.PersistentFlags().StringVar(&serverArgs.ServerOptions.TLSOptions.TLSMinVersion, "tlsMinVersion", "TLSv1_2",
 		"Minimum TLS version used in exposed SDS and webhook severs. "+
 			"Allowed values are: TLSv1_0, TLSv1_1, TLSv1_2, TLSv1_3. TLSv1_2 is used by default.")
+	c.PersistentFlags().StringVar(&serverArgs.ServerOptions.TLSOptions.TLSMaxVersion, "tlsMaxVersion", "TLSv1_3",
+		"Maximum TLS version used in exposed SDS and webhook severs. "+
+			"Allowed values are: TLSv1_0, TLSv1_1, TLSv1_2, TLSv1_3. TLSv1_3 is used by default.")
 	c.PersistentFlags().StringSliceVar(&serverArgs.ServerOptions.TLSOptions.TLSCipherSuites, "tls-cipher-suites", nil,
 		"Comma-separated list of cipher suites for istiod TLS server. "+
 			"If omitted, the default Go cipher suites will be used. \n"+

--- a/pilot/cmd/pilot-discovery/app/cmd.go
+++ b/pilot/cmd/pilot-discovery/app/cmd.go
@@ -175,6 +175,9 @@ func addFlags(c *cobra.Command) {
 		"File containing the x509 Server Certificate")
 	c.PersistentFlags().StringVar(&serverArgs.ServerOptions.TLSOptions.KeyFile, "tlsKeyFile", "",
 		"File containing the x509 private key matching --tlsCertFile")
+	c.PersistentFlags().StringVar(&serverArgs.ServerOptions.TLSOptions.TLSMinVersion, "tlsMinVersion", "TLSv1_2",
+		"Minimum TLS version used in exposed SDS and webhook severs. "+
+			"Allowed values are: TLSv1_0, TLSv1_1, TLSv1_2, TLSv1_3. TLSv1_2 is used by default.")
 	c.PersistentFlags().StringSliceVar(&serverArgs.ServerOptions.TLSOptions.TLSCipherSuites, "tls-cipher-suites", nil,
 		"Comma-separated list of cipher suites for istiod TLS server. "+
 			"If omitted, the default Go cipher suites will be used. \n"+

--- a/pilot/cmd/pilot-discovery/app/cmd.go
+++ b/pilot/cmd/pilot-discovery/app/cmd.go
@@ -181,6 +181,10 @@ func addFlags(c *cobra.Command) {
 	c.PersistentFlags().StringVar(&serverArgs.ServerOptions.TLSOptions.TLSMaxVersion, "tlsMaxVersion", "TLSv1_3",
 		"Maximum TLS version used in exposed SDS and webhook severs. "+
 			"Allowed values are: TLSv1_0, TLSv1_1, TLSv1_2, TLSv1_3. TLSv1_3 is used by default.")
+	c.PersistentFlags().StringSliceVar(&serverArgs.ServerOptions.TLSOptions.TLSECDHCurves, "tlsEcdhCurves", nil,
+		"Comma-separated list of cipher suites for SDS and webhook servers. "+
+			"If omitted, the default Go ECDH curves will be used. \n"+
+			"Allowed values are: P-256, P-384, P-521, X25519")
 	c.PersistentFlags().StringSliceVar(&serverArgs.ServerOptions.TLSOptions.TLSCipherSuites, "tls-cipher-suites", nil,
 		"Comma-separated list of cipher suites for istiod TLS server. "+
 			"If omitted, the default Go cipher suites will be used. \n"+

--- a/pilot/cmd/pilot-discovery/app/options.go
+++ b/pilot/cmd/pilot-discovery/app/options.go
@@ -57,6 +57,9 @@ func validateFlags(serverArgs *bootstrap.PilotArgs) error {
 	if _, err := bootstrap.TLSVersion(serverArgs.ServerOptions.TLSOptions.TLSMinVersion); err != nil {
 		return err
 	}
+	if _, err := bootstrap.TLSVersion(serverArgs.ServerOptions.TLSOptions.TLSMaxVersion); err != nil {
+		return err
+	}
 
 	// TODO: add validation for other flags
 	return nil

--- a/pilot/cmd/pilot-discovery/app/options.go
+++ b/pilot/cmd/pilot-discovery/app/options.go
@@ -51,9 +51,13 @@ func validateFlags(serverArgs *bootstrap.PilotArgs) error {
 	if err := validation.ValidateMaxServerConnectionAge(serverArgs.KeepaliveOptions.MaxServerConnectionAge); err != nil {
 		return err
 	}
-
-	_, err := bootstrap.TLSCipherSuites(serverArgs.ServerOptions.TLSOptions.TLSCipherSuites)
+	if _, err := bootstrap.TLSCipherSuites(serverArgs.ServerOptions.TLSOptions.TLSCipherSuites); err != nil {
+		return err
+	}
+	if _, err := bootstrap.TLSVersion(serverArgs.ServerOptions.TLSOptions.TLSMinVersion); err != nil {
+		return err
+	}
 
 	// TODO: add validation for other flags
-	return err
+	return nil
 }

--- a/pilot/cmd/pilot-discovery/app/options.go
+++ b/pilot/cmd/pilot-discovery/app/options.go
@@ -51,13 +51,16 @@ func validateFlags(serverArgs *bootstrap.PilotArgs) error {
 	if err := validation.ValidateMaxServerConnectionAge(serverArgs.KeepaliveOptions.MaxServerConnectionAge); err != nil {
 		return err
 	}
-	if _, err := bootstrap.TLSCipherSuites(serverArgs.ServerOptions.TLSOptions.TLSCipherSuites); err != nil {
-		return err
-	}
 	if _, err := bootstrap.TLSVersion(serverArgs.ServerOptions.TLSOptions.TLSMinVersion); err != nil {
 		return err
 	}
 	if _, err := bootstrap.TLSVersion(serverArgs.ServerOptions.TLSOptions.TLSMaxVersion); err != nil {
+		return err
+	}
+	if _, err := bootstrap.TLSCipherSuites(serverArgs.ServerOptions.TLSOptions.TLSCipherSuites); err != nil {
+		return err
+	}
+	if _, err := bootstrap.TLSECDHCurves(serverArgs.ServerOptions.TLSOptions.TLSECDHCurves); err != nil {
 		return err
 	}
 

--- a/pilot/pkg/bootstrap/options.go
+++ b/pilot/pkg/bootstrap/options.go
@@ -107,9 +107,12 @@ type TLSOptions struct {
 	CertFile        string
 	KeyFile         string
 	TLSMinVersion   string
-	MinVersion      uint16
+	TLSMaxVersion   string
 	TLSCipherSuites []string
-	CipherSuites    []uint16 // This is the parsed cipher suites
+	// Parsed settings
+	MinVersion   uint16
+	MaxVersion   uint16
+	CipherSuites []uint16
 }
 
 var (
@@ -162,6 +165,12 @@ func (p *PilotArgs) Complete() error {
 		return err
 	}
 	p.ServerOptions.TLSOptions.MinVersion = minVersion
+
+	maxVersion, err := TLSVersion(p.ServerOptions.TLSOptions.TLSMaxVersion)
+	if err != nil {
+		return err
+	}
+	p.ServerOptions.TLSOptions.MaxVersion = maxVersion
 
 	return nil
 }

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -748,6 +748,7 @@ func (s *Server) initSecureDiscoveryService(args *PilotArgs) error {
 			return err
 		},
 		MinVersion:   args.ServerOptions.TLSOptions.MinVersion,
+		MaxVersion:   args.ServerOptions.TLSOptions.MaxVersion,
 		CipherSuites: args.ServerOptions.TLSOptions.CipherSuites,
 	}
 

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -747,9 +747,10 @@ func (s *Server) initSecureDiscoveryService(args *PilotArgs) error {
 			}
 			return err
 		},
-		MinVersion:   args.ServerOptions.TLSOptions.MinVersion,
-		MaxVersion:   args.ServerOptions.TLSOptions.MaxVersion,
-		CipherSuites: args.ServerOptions.TLSOptions.CipherSuites,
+		MinVersion:       args.ServerOptions.TLSOptions.MinVersion,
+		MaxVersion:       args.ServerOptions.TLSOptions.MaxVersion,
+		CipherSuites:     args.ServerOptions.TLSOptions.CipherSuites,
+		CurvePreferences: args.ServerOptions.TLSOptions.ECDHCurves,
 	}
 
 	tlsCreds := credentials.NewTLS(cfg)

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -736,6 +736,7 @@ func (s *Server) initSecureDiscoveryService(args *PilotArgs) error {
 		return nil
 	}
 	log.Info("initializing secure discovery service")
+	// #nosec G402 - to disable warning "TLS MinVersion too low"
 	cfg := &tls.Config{
 		GetCertificate: s.getIstiodCertificate,
 		ClientAuth:     tls.VerifyClientCertIfGiven,

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -747,8 +747,8 @@ func (s *Server) initSecureDiscoveryService(args *PilotArgs) error {
 			}
 			return err
 		},
-		MinVersion:   tls.VersionTLS12,
-		CipherSuites: args.ServerOptions.TLSOptions.CipherSuits,
+		MinVersion:   args.ServerOptions.TLSOptions.MinVersion,
+		CipherSuites: args.ServerOptions.TLSOptions.CipherSuites,
 	}
 
 	tlsCreds := credentials.NewTLS(cfg)

--- a/pilot/pkg/bootstrap/server_test.go
+++ b/pilot/pkg/bootstrap/server_test.go
@@ -527,7 +527,7 @@ func TestIstiodCipherSuites(t *testing.T) {
 					GRPCAddr:       ":0",
 					HTTPSAddr:      fmt.Sprintf(":%d", port),
 					TLSOptions: TLSOptions{
-						CipherSuits: c.serverCipherSuites,
+						CipherSuites: c.serverCipherSuites,
 					},
 				}
 				p.RegistryOptions = RegistryOptions{

--- a/pilot/pkg/bootstrap/webhook.go
+++ b/pilot/pkg/bootstrap/webhook.go
@@ -63,6 +63,7 @@ func (s *Server) initSecureWebhookServer(args *PilotArgs) {
 		Addr:     args.ServerOptions.HTTPSAddr,
 		ErrorLog: log.New(&httpServerErrorLogWriter{}, "", 0),
 		Handler:  s.httpsMux,
+		// #nosec G402 - to disable warning "TLS MinVersion too low"
 		TLSConfig: &tls.Config{
 			GetCertificate:   s.getIstiodCertificate,
 			MinVersion:       args.ServerOptions.TLSOptions.MinVersion,

--- a/pilot/pkg/bootstrap/webhook.go
+++ b/pilot/pkg/bootstrap/webhook.go
@@ -65,8 +65,8 @@ func (s *Server) initSecureWebhookServer(args *PilotArgs) {
 		Handler:  s.httpsMux,
 		TLSConfig: &tls.Config{
 			GetCertificate: s.getIstiodCertificate,
-			MinVersion:     tls.VersionTLS12,
-			CipherSuites:   args.ServerOptions.TLSOptions.CipherSuits,
+			MinVersion:     args.ServerOptions.TLSOptions.MinVersion,
+			CipherSuites:   args.ServerOptions.TLSOptions.CipherSuites,
 		},
 	}
 

--- a/pilot/pkg/bootstrap/webhook.go
+++ b/pilot/pkg/bootstrap/webhook.go
@@ -66,6 +66,7 @@ func (s *Server) initSecureWebhookServer(args *PilotArgs) {
 		TLSConfig: &tls.Config{
 			GetCertificate: s.getIstiodCertificate,
 			MinVersion:     args.ServerOptions.TLSOptions.MinVersion,
+			MaxVersion:     args.ServerOptions.TLSOptions.MaxVersion,
 			CipherSuites:   args.ServerOptions.TLSOptions.CipherSuites,
 		},
 	}

--- a/pilot/pkg/bootstrap/webhook.go
+++ b/pilot/pkg/bootstrap/webhook.go
@@ -64,10 +64,11 @@ func (s *Server) initSecureWebhookServer(args *PilotArgs) {
 		ErrorLog: log.New(&httpServerErrorLogWriter{}, "", 0),
 		Handler:  s.httpsMux,
 		TLSConfig: &tls.Config{
-			GetCertificate: s.getIstiodCertificate,
-			MinVersion:     args.ServerOptions.TLSOptions.MinVersion,
-			MaxVersion:     args.ServerOptions.TLSOptions.MaxVersion,
-			CipherSuites:   args.ServerOptions.TLSOptions.CipherSuites,
+			GetCertificate:   s.getIstiodCertificate,
+			MinVersion:       args.ServerOptions.TLSOptions.MinVersion,
+			MaxVersion:       args.ServerOptions.TLSOptions.MaxVersion,
+			CipherSuites:     args.ServerOptions.TLSOptions.CipherSuites,
+			CurvePreferences: args.ServerOptions.TLSOptions.ECDHCurves,
 		},
 	}
 

--- a/releasenotes/notes/configure-tls-min-max-version-and-ecdh-curves.yaml
+++ b/releasenotes/notes/configure-tls-min-max-version-and-ecdh-curves.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+issue:
+  - 41772
+releaseNotes:
+  - |
+    **Added** arguments `--tlsMinVersion`, `--tlsMaxVersion` and `--tlsEcdhCurves` for istiod
+    to configure TLS min/max version and ECDH curves in SDS and webhook servers.


### PR DESCRIPTION
**Please provide a description of this PR:**

This change adds the ability to configure TLS min/max version and ECDH curves in SDS and webhook servers by passing the following arguments to istiod: `--tlsMinVersion=TLSv1_2 --tlsMaxVersion=TLSv1_3 --tlsEcdhCurves=P-256,P-384`.
Issue: #41772

I verified that these options work and are respected in TLS handshakes. For example when I added `--tlsEcdhCurves=P-256` to istiod arguments, the TLS handshake was as follows:
1. `istio-ingressgateway` -> `istiod`: Client Hello (Key Share: Group: x25519)
2. `istiod` -> `istio-ingressgateway`: Hello Retry Request (Key Share: Selected Group: secp256r1)
3. `istio-ingressgateway` -> `istiod`: Client Hello (Key Share: Group: secp256r1)
4. `istiod` -> `istio-ingressgateway`: Server Hello (Key Share: Group: secp256r1)