### PR TITLE
Refactor ambient CNI informer

### DIFF
--- a/cni/pkg/ambient/net.go
+++ b/cni/pkg/ambient/net.go
@@ -73,6 +73,10 @@ func AddPodToMesh(pod *corev1.Pod, ip string) {
 	if ip == "" {
 		ip = pod.Status.PodIP
 	}
+	if ip == "" {
+		log.Debugf("skip adding pod %s/%s, IP not yet allocated", pod.Name, pod.Namespace)
+		return
+	}
 
 	if !IsPodInIpset(pod) {
 		log.Infof("Adding pod '%s/%s' (%s) to ipset", pod.Name, pod.Namespace, string(pod.UID))

--- a/cni/pkg/ambient/options.go
+++ b/cni/pkg/ambient/options.go
@@ -15,7 +15,7 @@
 package ambient
 
 import (
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	klabels "k8s.io/apimachinery/pkg/labels"
 
 	"istio.io/api/label"
 	"istio.io/api/mesh/v1alpha1"
@@ -50,11 +50,9 @@ var Ipset = &ipsetlib.IPSet{
 	Name: "ztunnel-pods-ips",
 }
 
-var ambientSelectors metav1.LabelSelector = metav1.LabelSelector{
-	MatchLabels: map[string]string{
-		label.IoIstioDataplaneMode.Name: dataplaneLabelAmbientValue,
-	},
-}
+var ambientSelectors = klabels.SelectorFromValidatedSet(map[string]string{
+	label.IoIstioDataplaneMode.Name: dataplaneLabelAmbientValue,
+})
 
 type AmbientArgs struct {
 	SystemNamespace string

--- a/cni/pkg/ambient/server.go
+++ b/cni/pkg/ambient/server.go
@@ -21,7 +21,10 @@ import (
 	"os"
 	"sync"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	listerv1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/rest"
 
@@ -39,18 +42,19 @@ type Server struct {
 	ctx         context.Context
 	queue       controllers.Queue
 
-	nsLister listerv1.NamespaceLister
+	nsLister  listerv1.NamespaceLister
+	podLister listerv1.PodLister
 
 	meshMode          v1alpha1.MeshConfig_AmbientMeshConfig_AmbientMeshMode
-	disabledSelectors []*metav1.LabelSelector
+	disabledSelectors []labels.Selector
 	mu                sync.Mutex
-	ztunnelRunning    bool
+	ztunnelPod        *corev1.Pod
 }
 
 type AmbientConfigFile struct {
-	Mode              string                  `json:"mode"`
-	DisabledSelectors []*metav1.LabelSelector `json:"disabledSelectors"`
-	ZTunnelReady      bool                    `json:"ztunnelReady"`
+	Mode              string            `json:"mode"`
+	DisabledSelectors []labels.Selector `json:"disabledSelectors"`
+	ZTunnelReady      bool              `json:"ztunnelReady"`
 }
 
 func NewServer(ctx context.Context, args AmbientArgs) (*Server, error) {
@@ -67,7 +71,6 @@ func NewServer(ctx context.Context, args AmbientArgs) (*Server, error) {
 		ctx:               ctx,
 		meshMode:          v1alpha1.MeshConfig_AmbientMeshConfig_DEFAULT,
 		disabledSelectors: ambientpod.LegacySelectors,
-		ztunnelRunning:    false,
 		kubeClient:        client,
 	}
 
@@ -86,7 +89,7 @@ func NewServer(ctx context.Context, args AmbientArgs) (*Server, error) {
 	if s.environment.Mesh().AmbientMesh != nil {
 		s.mu.Lock()
 		s.meshMode = s.environment.Mesh().AmbientMesh.Mode
-		s.disabledSelectors = s.environment.Mesh().AmbientMesh.DisabledSelectors
+		s.disabledSelectors = convertDisabledSelectors(s.environment.Mesh().AmbientMesh.DisabledSelectors)
 		s.mu.Unlock()
 	}
 
@@ -95,17 +98,23 @@ func NewServer(ctx context.Context, args AmbientArgs) (*Server, error) {
 	return s, nil
 }
 
-func (s *Server) setZTunnelRunning(running bool) {
-	s.mu.Lock()
-	s.ztunnelRunning = running
-	s.mu.Unlock()
-	s.UpdateConfig()
+func convertDisabledSelectors(selectors []*metav1.LabelSelector) []labels.Selector {
+	res := make([]labels.Selector, 0, len(selectors))
+	for _, k := range selectors {
+		s, err := metav1.LabelSelectorAsSelector(k)
+		if err != nil {
+			log.Errorf("failed to convert label selector: %v", err)
+			continue
+		}
+		res = append(res, s)
+	}
+	return res
 }
 
 func (s *Server) isZTunnelRunning() bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return s.ztunnelRunning
+	return s.ztunnelPod != nil
 }
 
 // buildKubeClient creates the kube client
@@ -148,6 +157,76 @@ func (s *Server) UpdateConfig() {
 		log.Errorf("Failed to write config file: %v", err)
 	}
 	log.Debug("Done")
+}
+
+var ztunnelLabels = labels.SelectorFromValidatedSet(labels.Set{"app": "ztunnel"})
+
+func (s *Server) ReconcileZtunnel() error {
+	pods, err := s.podLister.Pods(metav1.NamespaceAll).List(ztunnelLabels)
+	if err != nil {
+		return err
+	}
+	var activePod *corev1.Pod
+	for _, p := range pods {
+		ready := kube.CheckPodReady(p) == nil
+		if !ready {
+			continue
+		}
+		if activePod == nil {
+			// Only pod ready, mark this as active
+			activePod = p
+		} else if p.CreationTimestamp.After(activePod.CreationTimestamp.Time) {
+			// If we have multiple pods that are ready, use the newest one.
+			// This ensures on a rolling update we start sending traffic to the new pod and drain the old one.
+			activePod = p
+		}
+	}
+
+	needsUpdate := false
+	s.mu.Lock()
+	if getUID(s.ztunnelPod) != getUID(activePod) {
+		// Active pod change
+		s.ztunnelPod = activePod
+		needsUpdate = true
+	}
+	s.mu.Unlock()
+
+	if !needsUpdate {
+		log.Debugf("active ztunnel unchanged")
+		return nil
+	}
+	s.UpdateConfig()
+	if activePod == nil {
+		log.Infof("active ztunnel updated, no ztunnel running on the node")
+		s.cleanup()
+		return nil
+	}
+	log.Infof("active ztunnel updated to %v", activePod.Name)
+	// TODO: we should not cleanup and recreate; this has downtime. We should mutate the existing rules in place
+	s.cleanup()
+	veth, err := getDeviceWithDestinationOf(activePod.Status.PodIP)
+	if err != nil {
+		return fmt.Errorf("failed to get device: %v", err)
+	}
+
+	captureDNS := getEnvFromPod(activePod, "ISTIO_META_DNS_CAPTURE") == "true"
+	err = s.CreateRulesOnNode(veth, activePod.Status.PodIP, captureDNS)
+	if err != nil {
+		return fmt.Errorf("failed to configure node for ztunnel: %v", err)
+	}
+	// Reconcile namespaces, as it is possible for the original reconciliation to have failed, and a
+	// small pod to have started up before ztunnel is running... so we need to go back and make sure we
+	// catch the existing pods
+	s.ReconcileNamespaces()
+	return nil
+}
+
+// getUID is a nil safe UID accessor
+func getUID(o *corev1.Pod) types.UID {
+	if o == nil {
+		return ""
+	}
+	return o.GetUID()
 }
 
 func (c *AmbientConfigFile) write() error {

--- a/pkg/kube/controllers/common.go
+++ b/pkg/kube/controllers/common.go
@@ -107,6 +107,88 @@ func EnqueueForParentHandler(q Queue, kind config.GroupVersionKind) func(obj Obj
 	return handler
 }
 
+// EventType represents a registry update event
+type EventType int
+
+const (
+	// EventAdd is sent when an object is added
+	EventAdd EventType = iota
+
+	// EventUpdate is sent when an object is modified
+	// Captures the modified object
+	EventUpdate
+
+	// EventDelete is sent when an object is deleted
+	// Captures the object at the last known state
+	EventDelete
+)
+
+func (event EventType) String() string {
+	out := "unknown"
+	switch event {
+	case EventAdd:
+		out = "add"
+	case EventUpdate:
+		out = "update"
+	case EventDelete:
+		out = "delete"
+	}
+	return out
+}
+
+type Event struct {
+	Old   Object
+	New   Object
+	Event EventType
+}
+
+func (e Event) Latest() Object {
+	if e.New != nil {
+		return e.New
+	}
+	return e.Old
+}
+
+func EventHandler(handler func(o Event)) cache.ResourceEventHandler {
+	return cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj any) {
+			o := ExtractObject(obj)
+			if o == nil {
+				return
+			}
+			handler(Event{
+				New:   o,
+				Event: EventAdd,
+			})
+		},
+		UpdateFunc: func(oldInterface, newInterface any) {
+			oldObj := ExtractObject(oldInterface)
+			if oldObj == nil {
+				return
+			}
+			newObj := ExtractObject(newInterface)
+			if newObj == nil {
+				return
+			}
+			handler(Event{
+				Old:   oldObj,
+				New:   newObj,
+				Event: EventUpdate,
+			})
+		},
+		DeleteFunc: func(obj any) {
+			o := ExtractObject(obj)
+			if o == nil {
+				return
+			}
+			handler(Event{
+				Old:   o,
+				Event: EventDelete,
+			})
+		},
+	}
+}
+
 // ObjectHandler returns a handler that will act on the latest version of an object
 // This means Add/Update/Delete are all handled the same and are just used to trigger reconciling.
 func ObjectHandler(handler func(o Object)) cache.ResourceEventHandler {


### PR DESCRIPTION
This improves a few things:

* Bug: when a new ztunnel spins up, we mark it as active. Then the old one spins down, and we mark ztunnelReady=false, ignoring the new one. Now, we reconcile the state to get the "active" ztunnel reliably
* Performance: tune informers to only watch things on our node, rather than everything
* Style: use a single Reconcile() function instead of 1 queue and 1 pod handler

Unfortunately, there are no unit tests for this; the code here to configuer ipset, etc is not abstracted in a testable way currently. I did manually test and the e2e tests pass, however. Long term we should improve this, but this code may be going away soon anyways

**Please provide a description of this PR:**



**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
