### PR TITLE
Update istio-cni to use logAsJson Flag

### DIFF
--- a/manifests/charts/UPDATING-CHARTS.md
+++ b/manifests/charts/UPDATING-CHARTS.md
@@ -9,8 +9,7 @@ Whenever making changes in the charts, it's important to follow the below steps.
 
 Is this a new parameter being added? If not, go to the next step.
 Dynamic, runtime config that is used to configure Istio components should go into the
-[MeshConfig API](https://github.com/istio/api/blob/master/mesh/v1alpha1/config.proto). Values.yaml is being deprecated and adding
-to it is discouraged. MeshConfig is the official API which follows API management practices and is dynamic
+[MeshConfig API](https://github.com/istio/api/blob/master/mesh/v1alpha1/config.proto). MeshConfig is the official API which follows API management practices and is dynamic
 (does not require component restarts).
 Exceptions to this rule are configuration items that affect K8s level settings (resources, mounts etc.)
 

--- a/manifests/charts/istio-cni/templates/daemonset.yaml
+++ b/manifests/charts/istio-cni/templates/daemonset.yaml
@@ -87,6 +87,9 @@ spec:
             {{- if .Values.global.logging.level }}
             - --log_output_level={{ .Values.global.logging.level }}
             {{- end}}
+            {{- if .Values.global.logAsJson }}
+            - --log_as_json
+            {{- end}}
           env:
 {{- if .Values.cni.cniConfFileName }}
             # Name of the CNI config file to create.

--- a/manifests/charts/istio-cni/values.yaml
+++ b/manifests/charts/istio-cni/values.yaml
@@ -97,6 +97,8 @@ global:
   logging:
     level: default:info,cni:info
 
+  logAsJson: false
+
   # ImagePullSecrets for all ServiceAccount, list of secrets in the same namespace
   # to use for pulling any images in pods that reference this ServiceAccount.
   # For components that don't use ServiceAccounts (i.e. grafana, servicegraph, tracing)


### PR DESCRIPTION
The istio-cni chart was missing the logAsJson flag/bool in the chart template. This PR adds that flag, similar to other charts such as istiod.

Signed-off-by: Derrik Campau <dcampau@vmware.com>

**Please provide a description of this PR:**
The helm chart template for istio-cni was not allowing for users to customize if istio-cni should log as JSON output. This PR fixes that :) 