### PR TITLE
Fixed `istioctl x revision list` the output the data is not accurate of enabled components

### DIFF
--- a/istioctl/cmd/revision.go
+++ b/istioctl/cmd/revision.go
@@ -207,7 +207,7 @@ func revisionList(writer io.Writer, args *revisionArgs, logger clog.Logger) erro
 		}
 		cs, err := getEnabledComponents(iop)
 		if err != nil {
-			return fmt.Errorf("error while get IstioOperator Components: %v", err)
+			return fmt.Errorf("error while getting IstioOperator Components: %v", err)
 		}
 		iopInfo := &tag.IstioOperatorCRInfo{
 			IOP:            iop,
@@ -483,12 +483,12 @@ func getAllMergedIstioOperatorCRs(client kube.CLIClient, logger clog.Logger) ([]
 		}
 		by, err := yaml.Marshal(iop)
 		if err != nil {
-			return nil, fmt.Errorf("error while marshal IstioOperator CR - %s/%s to yaml: %v", u.GetNamespace(), u.GetName(), err)
+			return nil, fmt.Errorf("error while marshaling IstioOperator CR - %s/%s to yaml: %v", u.GetNamespace(), u.GetName(), err)
 		}
 		profile := manifest.GetProfile(iop)
 		mergedIOP, err := manifest.GetMergedIOP(string(by), profile, "", "", client, logger)
 		if err != nil {
-			return nil, fmt.Errorf("error while merge IstioOperator CR - %s/%s with profile %s: %v", u.GetNamespace(), u.GetName(), profile, err)
+			return nil, fmt.Errorf("error while merging IstioOperator CR - %s/%s with profile %s: %v", u.GetNamespace(), u.GetName(), profile, err)
 		}
 		iopCRs = append(iopCRs, mergedIOP)
 	}
@@ -633,7 +633,7 @@ func getBasicRevisionDescription(iopCRs []*iopv1alpha1.IstioOperator,
 	for _, iop := range iopCRs {
 		cs, err := getEnabledComponents(iop)
 		if err != nil {
-			logger.LogAndErrorf("error while get IstioOperator %s/%s Components: %v", iop.Namespace, iop.Name, err)
+			logger.LogAndErrorf("error while getting IstioOperator %s/%s Components: %v", iop.Namespace, iop.Name, err)
 		}
 		revDescription.IstioOperatorCRs = append(revDescription.IstioOperatorCRs, &tag.IstioOperatorCRInfo{
 			IOP:            iop,
@@ -901,7 +901,7 @@ func getEnabledComponents(iop *iopv1alpha1.IstioOperator) ([]string, error) {
 		for _, c := range name2.AllCoreComponentNames {
 			enabled, err := translate.IsComponentEnabledInSpec(c, iop.Spec)
 			if err != nil {
-				return nil, fmt.Errorf("failed to check if component: %s is enabled or not: %v", string(c), err)
+				return nil, fmt.Errorf("error while resolving whether the component is enabled: %v", err)
 			}
 			if enabled {
 				enabledComponents = append(enabledComponents, name2.UserFacingComponentName(c))

--- a/istioctl/cmd/revision.go
+++ b/istioctl/cmd/revision.go
@@ -31,14 +31,16 @@ import (
 	apimachinery_schema "k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/duration"
 	"k8s.io/apimachinery/pkg/util/validation"
+	"sigs.k8s.io/yaml"
 
 	"istio.io/api/label"
-	"istio.io/api/operator/v1alpha1"
 	"istio.io/istio/istioctl/pkg/tag"
 	"istio.io/istio/operator/cmd/mesh"
 	operator_istio "istio.io/istio/operator/pkg/apis/istio"
 	iopv1alpha1 "istio.io/istio/operator/pkg/apis/istio/v1alpha1"
 	"istio.io/istio/operator/pkg/manifest"
+	name2 "istio.io/istio/operator/pkg/name"
+	"istio.io/istio/operator/pkg/translate"
 	"istio.io/istio/operator/pkg/util"
 	"istio.io/istio/operator/pkg/util/clog"
 	"istio.io/istio/pkg/config"
@@ -194,7 +196,7 @@ func revisionList(writer io.Writer, args *revisionArgs, logger clog.Logger) erro
 	}
 
 	// Get a list of all CRs which are installed in this cluster
-	iopcrs, err := getAllIstioOperatorCRs(client)
+	iopcrs, err := getAllMergedIstioOperatorCRs(client, logger)
 	if err != nil {
 		return fmt.Errorf("error while listing IstioOperator CRs: %v", err)
 	}
@@ -203,12 +205,16 @@ func revisionList(writer io.Writer, args *revisionArgs, logger clog.Logger) erro
 		if ri := revisions[rev]; ri == nil {
 			revisions[rev] = &tag.RevisionDescription{}
 		}
+		cs, err := getEnabledComponents(iop)
+		if err != nil {
+			return fmt.Errorf("error while get IstioOperator Components: %v", err)
+		}
 		iopInfo := &tag.IstioOperatorCRInfo{
 			IOP:            iop,
 			Namespace:      iop.GetNamespace(),
 			Name:           iop.GetName(),
-			Profile:        iop.Spec.GetProfile(),
-			Components:     getEnabledComponents(iop.Spec),
+			Profile:        manifest.GetProfile(iop),
+			Components:     cs,
 			Customizations: nil,
 		}
 		if args.verbose {
@@ -275,7 +281,7 @@ func printControlPlaneSummaryTable(w io.Writer, revisions map[string]*tag.Revisi
 	outer:
 		for _, iop := range rd.IstioOperatorCRs {
 			for _, c := range iop.Components {
-				if c == "istiod" {
+				if c == name2.UserFacingComponentName(name2.PilotComponentName) {
 					isIstiodEnabled = true
 					break outer
 				}
@@ -305,84 +311,74 @@ func printControlPlaneSummaryTable(w io.Writer, revisions map[string]*tag.Revisi
 }
 
 func printGatewaySummaryTable(w io.Writer, revisions map[string]*tag.RevisionDescription) error {
-	if err := printIngressGatewaySummaryTable(w, revisions); err != nil {
+	if err := printGatewaySummaryTableWithType(ingressGWTyp, w, revisions); err != nil {
 		return fmt.Errorf("error while printing ingress gateway summary: %v", err)
 	}
-	if err := printEgressGatewaySummaryTable(w, revisions); err != nil {
+	if err := printGatewaySummaryTableWithType(egressGWTyp, w, revisions); err != nil {
 		return fmt.Errorf("error while printing egress gateway summary: %v", err)
 	}
 	return nil
 }
 
-func printIngressGatewaySummaryTable(w io.Writer, revisions map[string]*tag.RevisionDescription) error {
-	fmt.Fprintf(w, "\nINGRESS GATEWAYS:\n")
-	tw := new(tabwriter.Writer).Init(w, 0, 8, 1, ' ', 0)
-	fmt.Fprintf(tw, "REVISION\tDECLARED-GATEWAYS\tGATEWAY-POD\n")
-	for rev, rd := range revisions {
-		enabledIngressGateways := []string{}
-		for _, iop := range rd.IstioOperatorCRs {
-			for _, c := range iop.Components {
-				if strings.HasPrefix(c, "ingress") {
-					enabledIngressGateways = append(enabledIngressGateways, c)
-				}
-			}
-		}
-		maxRows := max(max(1, len(enabledIngressGateways)), len(rd.IngressGatewayPods))
-		for i := 0; i < maxRows; i++ {
-			var rowRev, rowEnabled, rowPod string
-			if i == 0 {
-				rowRev = rev
-			}
-			if i == 0 && len(enabledIngressGateways) == 0 {
-				rowEnabled = "<no-ingress-enabled>"
-			} else if i < len(enabledIngressGateways) {
-				rowEnabled = enabledIngressGateways[i]
-			}
-			if i == 0 && len(rd.IngressGatewayPods) == 0 {
-				rowPod = "<no-ingress-pod>"
-			} else if i < len(rd.IngressGatewayPods) {
-				rowPod = fmt.Sprintf("%s/%s",
-					rd.IngressGatewayPods[i].Namespace,
-					rd.IngressGatewayPods[i].Name)
-			}
-			fmt.Fprintf(tw, "%s\t%s\t%s\n", rowRev, rowEnabled, rowPod)
-		}
-	}
-	return tw.Flush()
-}
+type gwType int
 
-// TODO(su225): This is a copy paste of corresponding function of ingress. Refactor these parts!
-func printEgressGatewaySummaryTable(w io.Writer, revisions map[string]*tag.RevisionDescription) error {
-	fmt.Fprintf(w, "\nEGRESS GATEWAYS:\n")
+const (
+	ingressGWTyp gwType = 0
+	egressGWTyp  gwType = 1
+)
+
+func printGatewaySummaryTableWithType(gT gwType, w io.Writer, revisions map[string]*tag.RevisionDescription) error {
+	gTypeName := name2.IngressComponentName
+	noEnabled := "<no-ingress-enabled>"
+	noPod := "<no-ingress-pod>"
+	if gT == ingressGWTyp {
+		fmt.Fprintf(w, "\nINGRESS GATEWAYS:\n")
+	} else {
+		gTypeName = name2.EgressComponentName
+		fmt.Fprintf(w, "\nEGRESS GATEWAYS:\n")
+		noEnabled = "<no-egress-enabled>"
+		noPod = "<no-egress-pod>"
+	}
+
+	getRowPodAndEnabled := func(index int, enableGws []string, gwPods []*tag.PodFilteredInfo) (rEnabled string, rPod string) {
+		if index == 0 && len(enableGws) == 0 {
+			rEnabled = noEnabled
+		} else if index < len(enableGws) {
+			rEnabled = enableGws[index]
+		}
+		if index == 0 && len(gwPods) == 0 {
+			rPod = noPod
+		} else if index < len(gwPods) {
+			rPod = fmt.Sprintf("%s/%s",
+				gwPods[index].Namespace,
+				gwPods[index].Name)
+		}
+		return
+	}
+
+	prefix := name2.UserFacingComponentName(gTypeName) + ":"
 	tw := new(tabwriter.Writer).Init(w, 0, 8, 1, ' ', 0)
 	fmt.Fprintf(tw, "REVISION\tDECLARED-GATEWAYS\tGATEWAY-POD\n")
 	for rev, rd := range revisions {
-		enabledEgressGateways := []string{}
+		enabledGateways := []string{}
 		for _, iop := range rd.IstioOperatorCRs {
 			for _, c := range iop.Components {
-				if strings.HasPrefix(c, "egress") {
-					enabledEgressGateways = append(enabledEgressGateways, c)
+				if strings.HasPrefix(c, prefix) {
+					enabledGateways = append(enabledGateways, strings.TrimPrefix(c, prefix))
 				}
 			}
 		}
-		maxRows := max(max(1, len(enabledEgressGateways)), len(rd.EgressGatewayPods))
+		gwPods := rd.IngressGatewayPods
+		if gT == egressGWTyp {
+			gwPods = rd.EgressGatewayPods
+		}
+		maxRows := max(max(1, len(enabledGateways)), len(gwPods))
 		for i := 0; i < maxRows; i++ {
 			var rowRev, rowEnabled, rowPod string
 			if i == 0 {
 				rowRev = rev
 			}
-			if i == 0 && len(enabledEgressGateways) == 0 {
-				rowEnabled = "<no-egress-enabled>"
-			} else if i < len(enabledEgressGateways) {
-				rowEnabled = enabledEgressGateways[i]
-			}
-			if i == 0 && len(rd.EgressGatewayPods) == 0 {
-				rowPod = "<no-egress-pod>"
-			} else if i < len(rd.EgressGatewayPods) {
-				rowPod = fmt.Sprintf("%s/%s",
-					rd.EgressGatewayPods[i].Namespace,
-					rd.EgressGatewayPods[i].Name)
-			}
+			rowEnabled, rowPod = getRowPodAndEnabled(i, enabledGateways, gwPods)
 			fmt.Fprintf(tw, "%s\t%s\t%s\n", rowRev, rowEnabled, rowPod)
 		}
 	}
@@ -469,7 +465,7 @@ func printSummaryTable(writer io.Writer, verbose bool, revisions map[string]*tag
 	return tw.Flush()
 }
 
-func getAllIstioOperatorCRs(client kube.CLIClient) ([]*iopv1alpha1.IstioOperator, error) {
+func getAllMergedIstioOperatorCRs(client kube.CLIClient, logger clog.Logger) ([]*iopv1alpha1.IstioOperator, error) {
 	ucrs, err := client.Dynamic().Resource(istioOperatorGVR).
 		List(context.Background(), metav1.ListOptions{})
 	if err != nil {
@@ -485,7 +481,16 @@ func getAllIstioOperatorCRs(client kube.CLIClient) ([]*iopv1alpha1.IstioOperator
 				fmt.Errorf("error while converting to IstioOperator CR - %s/%s: %v",
 					u.GetNamespace(), u.GetName(), err)
 		}
-		iopCRs = append(iopCRs, iop)
+		by, err := yaml.Marshal(iop)
+		if err != nil {
+			return nil, fmt.Errorf("error while marshal IstioOperator CR - %s/%s to yaml: %v", u.GetNamespace(), u.GetName(), err)
+		}
+		profile := manifest.GetProfile(iop)
+		mergedIOP, err := manifest.GetMergedIOP(string(by), profile, "", "", client, logger)
+		if err != nil {
+			return nil, fmt.Errorf("error while merge IstioOperator CR - %s/%s with profile %s: %v", u.GetNamespace(), u.GetName(), profile, err)
+		}
+		iopCRs = append(iopCRs, mergedIOP)
 	}
 	return iopCRs, nil
 }
@@ -497,7 +502,7 @@ func printRevisionDescription(w io.Writer, args *revisionArgs, logger clog.Logge
 		return fmt.Errorf("cannot create kubeclient for kubeconfig=%s, context=%s: %v",
 			kubeconfig, configContext, err)
 	}
-	allIops, err := getAllIstioOperatorCRs(client)
+	allIops, err := getAllMergedIstioOperatorCRs(client, logger)
 	if err != nil {
 		return fmt.Errorf("error while fetching IstioOperator CR: %v", err)
 	}
@@ -507,7 +512,7 @@ func printRevisionDescription(w io.Writer, args *revisionArgs, logger clog.Logge
 		return fmt.Errorf("error while fetching mutating webhook configurations: %v", err)
 	}
 	webhooks := filterWebhooksWithRevision(allWebhooks, revision)
-	revDescription := getBasicRevisionDescription(iopsInCluster, webhooks)
+	revDescription := getBasicRevisionDescription(iopsInCluster, webhooks, logger)
 	if err = annotateWithIOPCustomization(revDescription, args.manifestsPath, logger); err != nil {
 		return err
 	}
@@ -619,19 +624,23 @@ func annotateWithIOPCustomization(revDesc *tag.RevisionDescription, manifestsPat
 }
 
 func getBasicRevisionDescription(iopCRs []*iopv1alpha1.IstioOperator,
-	mutatingWebhooks []admitv1.MutatingWebhookConfiguration,
+	mutatingWebhooks []admitv1.MutatingWebhookConfiguration, logger clog.Logger,
 ) *tag.RevisionDescription {
 	revDescription := &tag.RevisionDescription{
 		IstioOperatorCRs: []*tag.IstioOperatorCRInfo{},
 		Webhooks:         []*tag.MutatingWebhookConfigInfo{},
 	}
 	for _, iop := range iopCRs {
+		cs, err := getEnabledComponents(iop)
+		if err != nil {
+			logger.LogAndErrorf("error while get IstioOperator %s/%s Components: %v", iop.Namespace, iop.Name, err)
+		}
 		revDescription.IstioOperatorCRs = append(revDescription.IstioOperatorCRs, &tag.IstioOperatorCRInfo{
 			IOP:            iop,
 			Namespace:      iop.Namespace,
 			Name:           iop.Name,
-			Profile:        renderWithDefault(iop.Spec.Profile, "default"),
-			Components:     getEnabledComponents(iop.Spec),
+			Profile:        manifest.GetProfile(iop),
+			Components:     cs,
 			Customizations: nil,
 		})
 	}
@@ -882,31 +891,35 @@ func printPodTable(w io.Writer, pods []*tag.PodFilteredInfo) error {
 	return podTableW.Flush()
 }
 
-func getEnabledComponents(iops *v1alpha1.IstioOperatorSpec) []string {
-	if iops == nil || iops.Components == nil {
-		return []string{}
+func getEnabledComponents(iop *iopv1alpha1.IstioOperator) ([]string, error) {
+	if iop == nil {
+		return nil, nil
 	}
-	enabledComponents := []string{}
-	if iops.Components.Base != nil && iops.Components.Base.Enabled.GetValue() {
-		enabledComponents = append(enabledComponents, "base")
-	}
-	if iops.Components.Cni != nil && iops.Components.Cni.Enabled.GetValue() {
-		enabledComponents = append(enabledComponents, "cni")
-	}
-	if iops.Components.Pilot != nil && iops.Components.Pilot.Enabled.GetValue() {
-		enabledComponents = append(enabledComponents, "istiod")
-	}
-	for _, gw := range iops.Components.IngressGateways {
-		if gw.Enabled.GetValue() {
-			enabledComponents = append(enabledComponents, fmt.Sprintf("ingress:%s", gw.GetName()))
+
+	var enabledComponents []string
+	if iop.Spec.Components != nil {
+		for _, c := range name2.AllCoreComponentNames {
+			enabled, err := translate.IsComponentEnabledInSpec(c, iop.Spec)
+			if err != nil {
+				return nil, fmt.Errorf("failed to check if component: %s is enabled or not: %v", string(c), err)
+			}
+			if enabled {
+				enabledComponents = append(enabledComponents, name2.UserFacingComponentName(c))
+			}
+		}
+		for _, c := range iop.Spec.Components.IngressGateways {
+			if c.Enabled.GetValue() {
+				enabledComponents = append(enabledComponents, fmt.Sprintf("%s:%s", name2.UserFacingComponentName(name2.IngressComponentName), c.Name))
+			}
+		}
+		for _, c := range iop.Spec.Components.EgressGateways {
+			if c.Enabled.GetValue() {
+				enabledComponents = append(enabledComponents, fmt.Sprintf("%s:%s", name2.UserFacingComponentName(name2.EgressComponentName), c.Name))
+			}
 		}
 	}
-	for _, gw := range iops.Components.EgressGateways {
-		if gw.Enabled.GetValue() {
-			enabledComponents = append(enabledComponents, fmt.Sprintf("egress:%s", gw.GetName()))
-		}
-	}
-	return enabledComponents
+
+	return enabledComponents, nil
 }
 
 func getPodsForComponent(client kube.CLIClient, component string) ([]v1.Pod, error) {

--- a/istioctl/cmd/revision_test.go
+++ b/istioctl/cmd/revision_test.go
@@ -21,73 +21,82 @@ import (
 	wrappers "google.golang.org/protobuf/types/known/wrapperspb"
 
 	"istio.io/api/operator/v1alpha1"
+	v1alpha12 "istio.io/istio/operator/pkg/apis/istio/v1alpha1"
+	"istio.io/istio/pkg/test/util/assert"
 )
 
-func TestGetEnabledComponentsFromIOPSpec(t *testing.T) {
+func TestGetEnabledComponentsFromIOP(t *testing.T) {
 	enabledPbVal := &wrappers.BoolValue{Value: true}
 	disabledPbVal := &wrappers.BoolValue{Value: false}
 
 	for _, test := range []struct {
 		name     string
-		iops     *v1alpha1.IstioOperatorSpec
+		iops     *v1alpha12.IstioOperator
 		expected []string
 	}{
 		{
 			name:     "iop spec is nil",
 			iops:     nil,
-			expected: []string{},
+			expected: nil,
 		},
 		{
 			name: "all components enabled",
-			iops: &v1alpha1.IstioOperatorSpec{
-				Components: &v1alpha1.IstioComponentSetSpec{
-					Base:  &v1alpha1.BaseComponentSpec{Enabled: enabledPbVal},
-					Pilot: &v1alpha1.ComponentSpec{Enabled: enabledPbVal},
-					Cni:   &v1alpha1.ComponentSpec{Enabled: enabledPbVal},
-					IngressGateways: []*v1alpha1.GatewaySpec{
-						{Name: "ingressgateway", Enabled: enabledPbVal},
-						{Name: "eastwestgateway", Enabled: enabledPbVal},
-					},
-					EgressGateways: []*v1alpha1.GatewaySpec{
-						{Name: "egressgateway", Enabled: enabledPbVal},
+			iops: &v1alpha12.IstioOperator{
+				Spec: &v1alpha1.IstioOperatorSpec{
+					Components: &v1alpha1.IstioComponentSetSpec{
+						Base:  &v1alpha1.BaseComponentSpec{Enabled: enabledPbVal},
+						Pilot: &v1alpha1.ComponentSpec{Enabled: enabledPbVal},
+						Cni:   &v1alpha1.ComponentSpec{Enabled: enabledPbVal},
+						IngressGateways: []*v1alpha1.GatewaySpec{
+							{Name: "ingressgateway", Enabled: enabledPbVal},
+							{Name: "eastwestgateway", Enabled: enabledPbVal},
+						},
+						EgressGateways: []*v1alpha1.GatewaySpec{
+							{Name: "egressgateway", Enabled: enabledPbVal},
+						},
 					},
 				},
 			},
+
 			expected: []string{
-				"base", "istiod", "cni",
-				"ingress:ingressgateway", "ingress:eastwestgateway",
-				"egress:egressgateway",
+				"Istio core", "Istiod", "CNI",
+				"Ingress gateways:ingressgateway", "Ingress gateways:eastwestgateway",
+				"Egress gateways:egressgateway",
 			},
 		},
 		{
 			name: "cni and gateways are disabled",
-			iops: &v1alpha1.IstioOperatorSpec{
-				Components: &v1alpha1.IstioComponentSetSpec{
-					Base:  &v1alpha1.BaseComponentSpec{Enabled: enabledPbVal},
-					Pilot: &v1alpha1.ComponentSpec{Enabled: enabledPbVal},
-					Cni:   &v1alpha1.ComponentSpec{Enabled: disabledPbVal},
-					IngressGateways: []*v1alpha1.GatewaySpec{
-						{Name: "ingressgateway", Enabled: disabledPbVal},
-					},
-					EgressGateways: []*v1alpha1.GatewaySpec{
-						{Name: "egressgateway", Enabled: disabledPbVal},
+			iops: &v1alpha12.IstioOperator{
+				Spec: &v1alpha1.IstioOperatorSpec{
+					Components: &v1alpha1.IstioComponentSetSpec{
+						Base:  &v1alpha1.BaseComponentSpec{Enabled: enabledPbVal},
+						Pilot: &v1alpha1.ComponentSpec{Enabled: enabledPbVal},
+						Cni:   &v1alpha1.ComponentSpec{Enabled: disabledPbVal},
+						IngressGateways: []*v1alpha1.GatewaySpec{
+							{Name: "ingressgateway", Enabled: disabledPbVal},
+						},
+						EgressGateways: []*v1alpha1.GatewaySpec{
+							{Name: "egressgateway", Enabled: disabledPbVal},
+						},
 					},
 				},
 			},
-			expected: []string{"base", "istiod"},
+			expected: []string{"Istio core", "Istiod"},
 		},
 		{
 			name: "all components are disabled",
-			iops: &v1alpha1.IstioOperatorSpec{
-				Components: &v1alpha1.IstioComponentSetSpec{
-					Base:  &v1alpha1.BaseComponentSpec{Enabled: disabledPbVal},
-					Pilot: &v1alpha1.ComponentSpec{Enabled: disabledPbVal},
-					Cni:   &v1alpha1.ComponentSpec{Enabled: disabledPbVal},
-					IngressGateways: []*v1alpha1.GatewaySpec{
-						{Name: "ingressgateway", Enabled: disabledPbVal},
-					},
-					EgressGateways: []*v1alpha1.GatewaySpec{
-						{Name: "egressgateway", Enabled: disabledPbVal},
+			iops: &v1alpha12.IstioOperator{
+				Spec: &v1alpha1.IstioOperatorSpec{
+					Components: &v1alpha1.IstioComponentSetSpec{
+						Base:  &v1alpha1.BaseComponentSpec{Enabled: disabledPbVal},
+						Pilot: &v1alpha1.ComponentSpec{Enabled: disabledPbVal},
+						Cni:   &v1alpha1.ComponentSpec{Enabled: disabledPbVal},
+						IngressGateways: []*v1alpha1.GatewaySpec{
+							{Name: "ingressgateway", Enabled: disabledPbVal},
+						},
+						EgressGateways: []*v1alpha1.GatewaySpec{
+							{Name: "egressgateway", Enabled: disabledPbVal},
+						},
 					},
 				},
 			},
@@ -95,17 +104,20 @@ func TestGetEnabledComponentsFromIOPSpec(t *testing.T) {
 		},
 		{
 			name: "component-spec has nil",
-			iops: &v1alpha1.IstioOperatorSpec{
-				Components: &v1alpha1.IstioComponentSetSpec{
-					Base:  &v1alpha1.BaseComponentSpec{Enabled: enabledPbVal},
-					Pilot: &v1alpha1.ComponentSpec{Enabled: enabledPbVal},
+			iops: &v1alpha12.IstioOperator{
+				Spec: &v1alpha1.IstioOperatorSpec{
+					Components: &v1alpha1.IstioComponentSetSpec{
+						Base:  &v1alpha1.BaseComponentSpec{Enabled: enabledPbVal},
+						Pilot: &v1alpha1.ComponentSpec{Enabled: enabledPbVal},
+					},
 				},
 			},
-			expected: []string{"base", "istiod"},
+			expected: []string{"Istio core", "Istiod"},
 		},
 	} {
 		t.Run(test.name, func(st *testing.T) {
-			actual := getEnabledComponents(test.iops)
+			actual, err := getEnabledComponents(test.iops)
+			assert.NoError(t, err)
 			sort.Strings(actual)
 			sort.Strings(test.expected)
 			if len(actual) != len(test.expected) {

--- a/releasenotes/notes/fix-istioctl-revision.yaml
+++ b/releasenotes/notes/fix-istioctl-revision.yaml
@@ -3,4 +3,4 @@ kind: bug-fix
 area: istioctl
 releaseNotes:
   - |
-    **Fixed** `istioctl x revision list` the data is not accurate  of column with `REQD-COMPONENTS`
+    **Fixed** the `istioctl experimental revision list` `REQD-COMPONENTS` column data being incomplete and general output format.

--- a/releasenotes/notes/fix-istioctl-revision.yaml
+++ b/releasenotes/notes/fix-istioctl-revision.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: istioctl
+releaseNotes:
+  - |
+    **Fixed** `istioctl x revision list` the data is not accurate  of column with `REQD-COMPONENTS`

--- a/tests/integration/pilot/revisioncmd/revision_view_test.go
+++ b/tests/integration/pilot/revisioncmd/revision_view_test.go
@@ -49,17 +49,17 @@ var (
 
 	expectedComponentsPerRevision = map[string]map[string]bool{
 		"stable": {
-			"base":                          true,
-			"istiod":                        true,
-			"ingress:istio-ingressgateway":  true,
-			"ingress:istio-eastwestgateway": true,
-			"egress:istio-egressgateway":    true,
+			"Istio core":                             true,
+			"Istiod":                                 true,
+			"Ingress gateways:istio-ingressgateway":  true,
+			"Ingress gateways:istio-eastwestgateway": true,
+			"Egress gateways:istio-egressgateway":    true,
 		},
 		"canary": {
-			"istiod":                        true,
-			"ingress:istio-ingressgateway":  true,
-			"ingress:istio-eastwestgateway": true,
-			"egress:istio-egressgateway":    true,
+			"Istiod":                                 true,
+			"Ingress gateways:istio-ingressgateway":  true,
+			"Ingress gateways:istio-eastwestgateway": true,
+			"Egress gateways:istio-egressgateway":    true,
 		},
 	}
 )
@@ -266,7 +266,7 @@ func verifyRevisionOutput(t framework.TestContext, descr *tag.RevisionDescriptio
 	actualComponents := map[string]bool{}
 	for _, iop := range descr.IstioOperatorCRs {
 		for _, comp := range iop.Components {
-			if comp == "cni" {
+			if comp == "CNI" {
 				continue
 			}
 			actualComponents[comp] = true


### PR DESCRIPTION
**Please provide a description of this PR:**
```bash
[root@controller-node-1 ~]# kubectl  get iop -n istio-system nicole-mesh -oyaml
apiVersion: install.istio.io/v1alpha1
kind: IstioOperator
metadata:
  labels:
    app.kubernetes.io/managed-by: Helm
  name: nicole-mesh
  namespace: istio-system
spec:
  #   ....
status:
  componentStatus:
    Base:
      status: HEALTHY
    IngressGateways:
      status: HEALTHY
    Pilot:
      status: HEALTHY
  status: HEALTHY

[root@controller-node-1 ~]# istioctl  x  revision list
REVISION TAG      ISTIO-OPERATOR-CR                     PROFILE REQD-COMPONENTS
default  <no-tag> istio-system/nicole-mesh default
# the data is not accurate of cloume `REQD-COMPONENTS`, need echo `base,ingressgateway,pilot`
```
DO:
- fix  the data is not accurate of cloume `REQD-COMPONENTS`
- optimize output format  of `-o table` code
- uniform output style with pkg `operator/pkg/name/name.go fuc: UserFacingComponentName()`,
  https://github.com/istio/istio/blob/e53f236e51a38ae06d64006ce66ae760ca794313/operator/pkg/name/name.go#L139-L148

Example:
```bash
[root@controller-node-1 ~]# istioctl  x  revision list
REVISION TAG      ISTIO-OPERATOR-CR                     PROFILE REQD-COMPONENTS
default  <no-tag> istio-system/nicole-mesh               default   Istio core
                                                                   Istiod
                                                                   Ingress gateways:istio-ingressgateway
```