### PR TITLE
Fix setting route timeout through envoyfilter

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -91,6 +91,11 @@ func (configgen *ConfigGeneratorImpl) BuildHTTPRoutes(
 			rc := configgen.buildGatewayHTTPRouteConfig(node, req.Push, routeName)
 			if rc != nil {
 				rc = envoyfilter.ApplyRouteConfigurationPatches(networking.EnvoyFilter_GATEWAY, node, efw, rc)
+				for _, vs := range rc.VirtualHosts {
+					for _, r := range vs.Routes {
+						istio_route.SetTimeout(r.GetRoute(), node)
+					}
+				}
 				resource := &discovery.Resource{
 					Name:     routeName,
 					Resource: protoconv.MessageToAny(rc),

--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -91,11 +91,6 @@ func (configgen *ConfigGeneratorImpl) BuildHTTPRoutes(
 			rc := configgen.buildGatewayHTTPRouteConfig(node, req.Push, routeName)
 			if rc != nil {
 				rc = envoyfilter.ApplyRouteConfigurationPatches(networking.EnvoyFilter_GATEWAY, node, efw, rc)
-				for _, vs := range rc.VirtualHosts {
-					for _, r := range vs.Routes {
-						istio_route.SetTimeout(r.GetRoute(), node)
-					}
-				}
 				resource := &discovery.Resource{
 					Name:     routeName,
 					Resource: protoconv.MessageToAny(rc),
@@ -217,7 +212,6 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundHTTPRouteConfig(
 
 	// apply envoy filter patches
 	out = envoyfilter.ApplyRouteConfigurationPatches(networking.EnvoyFilter_SIDECAR_OUTBOUND, node, efw, out)
-
 	resource = &discovery.Resource{
 		Name:     out.Name,
 		Resource: protoconv.MessageToAny(out),


### PR DESCRIPTION
**Please provide a description of this PR:**
This PR is fixing a regression introduced in https://github.com/istio/istio/pull/40320

After #40320, if http route timeout is configured through envoyfilter and not through virtual service, timeout is ignored by envoy. 
Example envoyfilter:
```
spec:
  configPatches:
  - applyTo: HTTP_ROUTE
    match:
      context: GATEWAY
      proxy:
        proxyVersion: ^1\.(9|12|15)(\.\d+)?(-.*)?$
      routeConfiguration:
        vhost:
          route:
            action: ROUTE
    patch:
      operation: MERGE
      value:
        '@type': type.googleapis.com/envoy.config.route.v3.Route
        route:
          retry_policy:
            host_selection_retry_max_attempts: "5"
            num_retries: 2
            retriable_status_codes:
            - 503
            retry_host_predicate:
            - name: envoy.retry_host_predicates.previous_hosts
              typed_config:
                '@type': type.googleapis.com/envoy.extensions.retry.host.previous_hosts.v3.PreviousHostsPredicate
            retry_on: reset,connect-failure,refused-stream,unavailable,cancelled,retriable-status-codes
          timeout: 3s
```
#40320 is configuring `action.MaxStreamDuration` only on the basis on virtual service. Configuring `action.MaxStreamDuration` means that any timeouts will be ignored. Therefore when any envoyfilter router config patch(with timeout) is merged with such an action which has action.MaxStreamDuration already configured, timeout gets ignored.

This PR is fixing it by moving the logic, which decides whether to default initialize `action.MaxStreamDuration` or not, ~after the processing of envoyfilter patches.~ just before merging the patches and skip if patch is setting the timeout



