### PR TITLE
validate opentelemetry tracing extension provider

### DIFF
--- a/pkg/config/validation/extensionprovider.go
+++ b/pkg/config/validation/extensionprovider.go
@@ -192,6 +192,19 @@ func ValidateExtensionProviderEnvoyOtelAls(provider *meshconfig.MeshConfig_Exten
 	return
 }
 
+func ValidateExtensionProviderTracingOpentelemetry(provider *meshconfig.MeshConfig_ExtensionProvider_OpenTelemetryTracingProvider) (errs error) {
+	if provider == nil {
+		return fmt.Errorf("nil OpenTelemetryTracingProvider")
+	}
+	if err := ValidatePort(int(provider.Port)); err != nil {
+		errs = appendErrors(errs, err)
+	}
+	if err := validateExtensionProviderService(provider.Service); err != nil {
+		errs = appendErrors(errs, err)
+	}
+	return
+}
+
 func ValidateExtensionProviderEnvoyHTTPAls(provider *meshconfig.MeshConfig_ExtensionProvider_EnvoyHttpGrpcV3LogProvider) (errs error) {
 	if provider == nil {
 		return fmt.Errorf("nil EnvoyHttpGrpcV3LogProvider")
@@ -255,6 +268,8 @@ func validateExtensionProvider(config *meshconfig.MeshConfig) (errs error) {
 			currentErrs = appendErrors(currentErrs, validateExtensionProviderEnvoyFileAccessLog(provider.EnvoyFileAccessLog))
 		case *meshconfig.MeshConfig_ExtensionProvider_EnvoyOtelAls:
 			currentErrs = appendErrors(currentErrs, ValidateExtensionProviderEnvoyOtelAls(provider.EnvoyOtelAls))
+		case *meshconfig.MeshConfig_ExtensionProvider_Opentelemetry:
+			currentErrs = appendErrors(currentErrs, ValidateExtensionProviderTracingOpentelemetry(provider.Opentelemetry))
 		case *meshconfig.MeshConfig_ExtensionProvider_EnvoyHttpAls:
 			currentErrs = appendErrors(currentErrs, ValidateExtensionProviderEnvoyHTTPAls(provider.EnvoyHttpAls))
 		case *meshconfig.MeshConfig_ExtensionProvider_EnvoyTcpAls:

--- a/pkg/config/validation/extensionprovider_test.go
+++ b/pkg/config/validation/extensionprovider_test.go
@@ -460,3 +460,60 @@ func TestValidateExtensionProviderEnvoyTCPAls(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateExtensionProviderTracingOpentelemetry(t *testing.T) {
+	cases := []struct {
+		name     string
+		provider *meshconfig.MeshConfig_ExtensionProvider_OpenTelemetryTracingProvider
+		valid    bool
+	}{
+		{
+			name: "normal",
+			provider: &meshconfig.MeshConfig_ExtensionProvider_OpenTelemetryTracingProvider{
+				Service: "collector.namespace.svc",
+				Port:    4317,
+			},
+			valid: true,
+		},
+		{
+			name: "service with namespace",
+			provider: &meshconfig.MeshConfig_ExtensionProvider_OpenTelemetryTracingProvider{
+				Service: "namespace/collector.namespace.svc",
+				Port:    4317,
+			},
+			valid: true,
+		},
+		{
+			name: "service with invalid namespace",
+			provider: &meshconfig.MeshConfig_ExtensionProvider_OpenTelemetryTracingProvider{
+				Service: "name/space/collector.namespace.svc",
+				Port:    4317,
+			},
+			valid: false,
+		},
+		{
+			name: "service with port",
+			provider: &meshconfig.MeshConfig_ExtensionProvider_OpenTelemetryTracingProvider{
+				Service: "collector.namespace.svc:4000",
+				Port:    4317,
+			},
+			valid: false,
+		},
+		{
+			name: "missing port",
+			provider: &meshconfig.MeshConfig_ExtensionProvider_OpenTelemetryTracingProvider{
+				Service: "collector.namespace.svc",
+			},
+			valid: false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := ValidateExtensionProviderTracingOpentelemetry(c.provider)
+			valid := err == nil
+			if valid != c.valid {
+				t.Errorf("Expected valid=%v, got valid=%v for %v", c.valid, valid, c.provider)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Opentelemetry tracing provider in istio `1.16.0` is not working as the validation is missing.

>2022-11-18T11:36:58.850898Z	warn	validation	found invalid extension provider (can be ignored if the given extension provider is not used): invalid extension provider otel: unsupported provider: &{service:"collector.otel.svc.cluster.local"  port:4317} of type *v1alpha1.MeshConfig_ExtensionProvider_Opentelemetry

used config:
```yaml
  meshConfig:
    enableTracing: true
    extensionProviders:
    - name: otel
      opentelemetry:
        service: collector.otel.svc.cluster.local
        port: 4317
    defaultProviders:
      tracing:
      - otel
    defaultConfig:
      tracing:
        sampling: 100
```

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [x] Installation
- [x] Networking
- [ ] Performance and Scalability
- [x] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

Please check any characteristics that apply to this pull request.

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.