### PR TITLE
gateway-api: fix sorting of merged httproutes

### DIFF
--- a/pilot/pkg/config/kube/gateway/conversion.go
+++ b/pilot/pkg/config/kube/gateway/conversion.go
@@ -458,12 +458,10 @@ func routeMeta(obj config.Config) map[string]string {
 // see https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io/v1alpha2.HTTPRouteRule
 func sortHTTPRoutes(routes []*istio.HTTPRoute) {
 	sort.SliceStable(routes, func(i, j int) bool {
-		if len(routes[i].Match) != 0 {
-			if len(routes[j].Match) == 0 {
-				return true
-			}
-		} else if len(routes[j].Match) == 0 {
+		if len(routes[i].Match) == 0 {
 			return false
+		} else if len(routes[j].Match) == 0 {
+			return true
 		}
 		m1, m2 := routes[i].Match[0], routes[j].Match[0]
 		len1, len2 := getURILength(m1), getURILength(m2)


### PR DESCRIPTION
**Please provide a description of this PR:**

This is a followup to #41742 which fixed the `less` function used by `sortHTTPRoutes`, but not quite right. The current and corrected behavior is as follows:

```
i.len   j.len   current      corrected
-----   -----   -------      ---------
!0      !0      cmp match    cmp match
!0      0       true         true
0       !0      cmp match    false
0       0       false        false
```