### PR TITLE
Fix fsnotify event bit condition

### DIFF
--- a/cni/pkg/util/util.go
+++ b/cni/pkg/util/util.go
@@ -57,7 +57,7 @@ func watchFiles(watcher *fsnotify.Watcher, fileModified chan bool, errChan chan 
 			if !ok {
 				return
 			}
-			if event.Op&(fsnotify.Create|fsnotify.Write|fsnotify.Remove) != 0 {
+			if event.Has(fsnotify.Create) || event.Has(fsnotify.Write) || event.Has(fsnotify.Remove) {
 				fileModified <- true
 			}
 		case err, ok := <-watcher.Errors:


### PR DESCRIPTION
Signed-off-by: yanggang <gang.yang@daocloud.io>

/kind bug

Actually , i test '& and | ' go code in my local env.
The result is 
<img width="618" alt="image" src="https://user-images.githubusercontent.com/12080746/203200678-aaac6a8c-cc8f-436a-a874-70b3accc2981.png">

Can use the logic to improve it.. Like code below
 ```
event.Has(..
``` 

