### PR TITLE
Clarify documentation for Ambient on macOs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ var/
 ._*
 # MacOS Desktop Services Store
 .DS_Store
+local-test-utils

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Retrieve the local-test-utils directory with the following command:
 git checkout b03aa0 -- local-test-utils
 ```
 
-The file is gitignored, so feel free to keep it around in your local copy
+The file is gitignored, so feel free to keep it around in your local copy of the repo.
 
 ## Build
 
@@ -31,6 +31,14 @@ export BUILD_ZTUNNEL=1
 
 # Build Istiod and proxy
 tools/docker --targets=pilot,proxyv2,app,install-cni,ztunnel --hub=$HUB --tag=$TAG --push # consider --builder=crane
+```
+
+### Notes when using Docker for Mac
+
+Docker Desktop on macOS is ~special~, so if you're using it to build Rust ztunnel, you'll have to override some settings. The following one-liner should generally work (assuming the Rust ztunnel directory is siblings with this direectory) on recent versions of Docker Desktop on macOS:
+
+```shell
+DOCKER_SOCKET_MOUNT="-v /var/run/docker.sock.raw:/var/run/docker.sock" CONDITIONAL_HOST_MOUNTS="--mount type=bind,source=${PWD}/../ztunnel,destination=/ztunnel " BUILD_ZTUNNEL=1 BUILD_ZTUNNEL_REPO="/ztunnel" ./common/scripts/run.sh tools/docker --targets=pilot,proxyv2,app,install-cni,ztunnel --hub=$HUB --tag=$TAG --push
 ```
 
 ## Cluster Setup and Install

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,18 @@ to find out how you can help.
 
 The contents below is copied from the old readme for building/running/testing ambient from source:
 
+## NOTE: local-test-utils
+
+Many of the following commands reference a `local-test-utils` directory that was removed to lessen the diff from the master branch. To retrieve the directory, run the following command:
+
+Retrieve the local-test-utils directory with the following command:
+
+```shell
+git checkout b03aa0 -- local-test-utils
+```
+
+The file is gitignored, so feel free to keep it around in your local copy
+
 ## Build
 
 ```shell


### PR DESCRIPTION
**Please provide a description of this PR:**
 
Add instructions for how to retrieve the `local-test-utils` directory, and document some of the overrides necessary to build Rust ztunnel using Docker Desktop for macOS.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [X] Ambient
- [ ] Configuration Infrastructure
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
