### PR TITLE
push headless endpoint change when headless enabled or dns is enabled

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -383,6 +383,8 @@ type TriggerReason string
 const (
 	// EndpointUpdate describes a push triggered by an Endpoint change
 	EndpointUpdate TriggerReason = "endpoint"
+	// HeadlessEndpointUpdate describes a push triggered by an Endpoint change for headless service
+	HeadlessEndpointUpdate TriggerReason = "headlessendpoint"
 	// ConfigUpdate describes a push triggered by a config (generally and Istio CRD) change.
 	ConfigUpdate TriggerReason = "config"
 	// ServiceUpdate describes a push triggered by a Service change

--- a/pilot/pkg/serviceregistry/kube/controller/endpointcontroller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpointcontroller.go
@@ -65,20 +65,18 @@ func processEndpointEvent(c *Controller, epc kubeEndpointsController, name strin
 	// Update internal endpoint cache no matter what kind of service, even headless service.
 	// As for gateways, the cluster discovery type is `EDS` for headless service.
 	updateEDS(c, epc, ep, event)
-	if features.EnableHeadlessService {
-		if svc, _ := c.serviceLister.Services(namespace).Get(name); svc != nil {
-			// if the service is headless service, trigger a full push.
-			if svc.Spec.ClusterIP == v1.ClusterIPNone {
-				for _, modelSvc := range c.servicesForNamespacedName(kube.NamespacedNameForK8sObject(svc)) {
-					c.opts.XDSUpdater.ConfigUpdate(&model.PushRequest{
-						Full: true,
-						// TODO: extend and set service instance type, so no need to re-init push context
-						ConfigsUpdated: sets.New(model.ConfigKey{Kind: kind.ServiceEntry, Name: modelSvc.Hostname.String(), Namespace: svc.Namespace}),
+	if svc, _ := c.serviceLister.Services(namespace).Get(name); svc != nil {
+		// if the service is headless service, trigger a full push.
+		if svc.Spec.ClusterIP == v1.ClusterIPNone {
+			for _, modelSvc := range c.servicesForNamespacedName(kube.NamespacedNameForK8sObject(svc)) {
+				c.opts.XDSUpdater.ConfigUpdate(&model.PushRequest{
+					Full: true,
+					// TODO: extend and set service instance type, so no need to re-init push context
+					ConfigsUpdated: sets.New(model.ConfigKey{Kind: kind.ServiceEntry, Name: modelSvc.Hostname.String(), Namespace: svc.Namespace}),
 
-						Reason: []model.TriggerReason{model.EndpointUpdate},
-					})
-					return nil
-				}
+					Reason: []model.TriggerReason{model.HeadlessEndpointUpdate},
+				})
+				return nil
 			}
 		}
 	}

--- a/pilot/pkg/serviceregistry/kube/controller/endpointcontroller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpointcontroller.go
@@ -66,11 +66,12 @@ func processEndpointEvent(c *Controller, epc kubeEndpointsController, name strin
 	// As for gateways, the cluster discovery type is `EDS` for headless service.
 	updateEDS(c, epc, ep, event)
 	if svc, _ := c.serviceLister.Services(namespace).Get(name); svc != nil {
-		// if the service is headless service, trigger a full push.
+		// if the service is headless service, trigger a full push if EnableHeadlessService is true,
+		// otherwise push endpoint updates - needed for NDS output.
 		if svc.Spec.ClusterIP == v1.ClusterIPNone {
 			for _, modelSvc := range c.servicesForNamespacedName(kube.NamespacedNameForK8sObject(svc)) {
 				c.opts.XDSUpdater.ConfigUpdate(&model.PushRequest{
-					Full: true,
+					Full: features.EnableHeadlessService,
 					// TODO: extend and set service instance type, so no need to re-init push context
 					ConfigsUpdated: sets.New(model.ConfigKey{Kind: kind.ServiceEntry, Name: modelSvc.Hostname.String(), Namespace: svc.Namespace}),
 

--- a/pilot/pkg/xds/nds.go
+++ b/pilot/pkg/xds/nds.go
@@ -57,9 +57,8 @@ func ndsNeedsPush(req *model.PushRequest) bool {
 		return true
 	}
 	if !req.Full {
-		// NDS only handles full push. For headless services, we trigger a full push
-		// when endpoint changes. So pushing NDS on full pushes is sufficient.
-		return false
+		// NDS generally handles full push. We only allow partial pushes, when headless endpoints change.
+		return headlessEndpointsUpdated(req)
 	}
 	// If none set, we will always push
 	if len(req.ConfigsUpdated) == 0 {
@@ -67,6 +66,15 @@ func ndsNeedsPush(req *model.PushRequest) bool {
 	}
 	for config := range req.ConfigsUpdated {
 		if _, f := skippedNdsConfigs[config.Kind]; !f {
+			return true
+		}
+	}
+	return false
+}
+
+func headlessEndpointsUpdated(req *model.PushRequest) bool {
+	for _, reason := range req.Reason {
+		if reason == model.HeadlessEndpointUpdate {
 			return true
 		}
 	}

--- a/pilot/pkg/xds/proxy_dependencies.go
+++ b/pilot/pkg/xds/proxy_dependencies.go
@@ -35,6 +35,14 @@ func ConfigAffectsProxy(req *model.PushRequest, proxy *model.Proxy) bool {
 		return true
 	}
 
+	// When endpoints for headless service change, we should push if EnableHeadlessService is true
+	// so that we create updated listeners or when DNSCapture is enabled for proxy so that the NDS
+	// table is updated.
+	if req.Full && len(req.Reason) == 1 && req.Reason[0] == model.HeadlessEndpointUpdate &&
+		(features.EnableHeadlessService || bool(proxy.Metadata.DNSCapture)) {
+		return true
+	}
+
 	for config := range req.ConfigsUpdated {
 		affected := true
 

--- a/pilot/pkg/xds/proxy_dependencies.go
+++ b/pilot/pkg/xds/proxy_dependencies.go
@@ -35,13 +35,6 @@ func ConfigAffectsProxy(req *model.PushRequest, proxy *model.Proxy) bool {
 		return true
 	}
 
-	// When endpoints for headless service change, we should push if EnableHeadlessService is true
-	// so that we create updated listeners or when DNSCapture is enabled for proxy so that the NDS
-	// table is updated.
-	if req.Full && headlessEndpointsUpdated(req) && (features.EnableHeadlessService || bool(proxy.Metadata.DNSCapture)) {
-		return true
-	}
-
 	for config := range req.ConfigsUpdated {
 		affected := true
 
@@ -61,15 +54,6 @@ func ConfigAffectsProxy(req *model.PushRequest, proxy *model.Proxy) bool {
 		}
 	}
 
-	return false
-}
-
-func headlessEndpointsUpdated(req *model.PushRequest) bool {
-	for _, reason := range req.Reason {
-		if reason == model.HeadlessEndpointUpdate {
-			return true
-		}
-	}
 	return false
 }
 

--- a/pilot/pkg/xds/proxy_dependencies.go
+++ b/pilot/pkg/xds/proxy_dependencies.go
@@ -38,8 +38,7 @@ func ConfigAffectsProxy(req *model.PushRequest, proxy *model.Proxy) bool {
 	// When endpoints for headless service change, we should push if EnableHeadlessService is true
 	// so that we create updated listeners or when DNSCapture is enabled for proxy so that the NDS
 	// table is updated.
-	if req.Full && len(req.Reason) == 1 && req.Reason[0] == model.HeadlessEndpointUpdate &&
-		(features.EnableHeadlessService || bool(proxy.Metadata.DNSCapture)) {
+	if req.Full && headlessEndpointsUpdated(req) && (features.EnableHeadlessService || bool(proxy.Metadata.DNSCapture)) {
 		return true
 	}
 
@@ -62,6 +61,15 @@ func ConfigAffectsProxy(req *model.PushRequest, proxy *model.Proxy) bool {
 		}
 	}
 
+	return false
+}
+
+func headlessEndpointsUpdated(req *model.PushRequest) bool {
+	for _, reason := range req.Reason {
+		if reason == model.HeadlessEndpointUpdate {
+			return true
+		}
+	}
 	return false
 }
 


### PR DESCRIPTION
Continuing on https://github.com/istio/istio/pull/42089, when headless service endpoints change, but features. EnableHeadlessService is off, DNS is enabled, NDS will have stale endpoints.

This PR fixes it.

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
