### PR TITLE
Revert "wasm: improve wasm cache"

### DIFF
--- a/pkg/istio-agent/xds_proxy.go
+++ b/pkg/istio-agent/xds_proxy.go
@@ -567,7 +567,6 @@ func (p *XdsProxy) handleUpstreamResponse(con *ProxyConnection) {
 }
 
 func (p *XdsProxy) rewriteAndForward(con *ProxyConnection, resp *discovery.DiscoveryResponse, forward func(resp *discovery.DiscoveryResponse)) {
-	p.wasmCache.Reset()
 	sendNack := wasm.MaybeConvertWasmExtensionConfig(resp.Resources, p.wasmCache)
 	if sendNack {
 		proxyLog.Debugf("sending NACK for ECDS resources %+v", resp.Resources)

--- a/pkg/istio-agent/xds_proxy_delta.go
+++ b/pkg/istio-agent/xds_proxy_delta.go
@@ -284,8 +284,6 @@ func (p *XdsProxy) deltaRewriteAndForward(con *ProxyConnection, resp *discovery.
 	for i := range resp.Resources {
 		resources = append(resources, resp.Resources[i].Resource)
 	}
-
-	p.wasmCache.Reset()
 	sendNack := wasm.MaybeConvertWasmExtensionConfig(resources, p.wasmCache)
 	if sendNack {
 		proxyLog.Debugf("sending NACK for ECDS resources %+v", resp.Resources)

--- a/pkg/istio-agent/xds_proxy_test.go
+++ b/pkg/istio-agent/xds_proxy_test.go
@@ -447,7 +447,6 @@ type fakeAckCache struct{}
 func (f *fakeAckCache) Get(string, string, string, string, time.Duration, []byte, extensions.PullPolicy) (string, error) {
 	return "test", nil
 }
-func (f *fakeAckCache) Reset()   {}
 func (f *fakeAckCache) Cleanup() {}
 
 type fakeNackCache struct{}
@@ -455,7 +454,6 @@ type fakeNackCache struct{}
 func (f *fakeNackCache) Get(string, string, string, string, time.Duration, []byte, extensions.PullPolicy) (string, error) {
 	return "", errors.New("errror")
 }
-func (f *fakeNackCache) Reset()   {}
 func (f *fakeNackCache) Cleanup() {}
 
 func TestECDSWasmConversion(t *testing.T) {

--- a/pkg/wasm/cache.go
+++ b/pkg/wasm/cache.go
@@ -49,15 +49,13 @@ const (
 // Cache models a Wasm module cache.
 type Cache interface {
 	Get(url, checksum, resourceName, resourceVersion string, timeout time.Duration, pullSecret []byte, pullPolicy extensions.PullPolicy) (string, error)
-	Reset()
 	Cleanup()
 }
 
 // LocalFileCache for downloaded Wasm modules. Currently it stores the Wasm module as local file.
 type LocalFileCache struct {
 	// Map from Wasm module checksum to cache entry.
-	modules      map[moduleKey]*cacheEntry
-	usingModules sets.Set[moduleKey]
+	modules map[moduleKey]*cacheEntry
 	// Map from tagged URL to checksum
 	checksums map[string]*checksumEntry
 
@@ -158,7 +156,6 @@ func NewLocalFileCache(dir string, options Options) *LocalFileCache {
 		dir:          dir,
 		cacheOptions: cacheOptions.sanitize(),
 		stopChan:     make(chan struct{}),
-		usingModules: sets.New[moduleKey](),
 	}
 
 	go func() {
@@ -307,20 +304,7 @@ func (c *LocalFileCache) Get(
 	if err := c.addEntry(key, b, modulePath); err != nil {
 		return "", err
 	}
-	c.updateUsing(key.moduleKey)
 	return modulePath, nil
-}
-
-func (c *LocalFileCache) updateUsing(key moduleKey) {
-	c.mux.Lock()
-	defer c.mux.Unlock()
-	c.usingModules.Insert(key)
-}
-
-func (c *LocalFileCache) Reset() {
-	c.mux.Lock()
-	defer c.mux.Unlock()
-	c.usingModules = sets.New[moduleKey]()
 }
 
 // Cleanup closes background Wasm module purge routine.

--- a/pkg/wasm/cache_test.go
+++ b/pkg/wasm/cache_test.go
@@ -40,8 +40,6 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/types"
 
 	extensions "istio.io/api/extensions/v1alpha1"
-	"istio.io/istio/pkg/test/util/assert"
-	"istio.io/istio/pkg/test/util/retry"
 	"istio.io/istio/pkg/util/sets"
 )
 
@@ -733,52 +731,6 @@ func TestWasmCache(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestWasmCachePrune(t *testing.T) {
-	tmpDir := t.TempDir()
-	options := defaultOptions()
-	options.ModuleExpiry = time.Second
-	options.PurgeInterval = 500 * time.Millisecond
-	c := NewLocalFileCache(tmpDir, options)
-	c.httpFetcher.initialBackoff = time.Microsecond
-	defer c.Cleanup()
-
-	gotNumRequest := 0
-	binary1 := append(wasmHeader, 1)
-	binary2 := append(wasmHeader, 2)
-
-	// Create a test server which returns 0 for the first two calls, and returns 1 for the following calls.
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if gotNumRequest <= 1 {
-			w.Write(binary1)
-		} else {
-			w.Write(binary2)
-		}
-		gotNumRequest++
-	}))
-	defer ts.Close()
-
-	_, err := c.Get(ts.URL, "", "namespace.resource", "1", time.Second*10, []byte{}, 1)
-	assert.NoError(t, err)
-
-	retry.UntilOrFail(t, func() bool {
-		if len(c.usingModules) == 1 && len(c.modules) == 1 {
-			return true
-		}
-		return false
-	}, retry.BackoffDelay(options.ModuleExpiry))
-
-	c.Reset()
-
-	retry.UntilOrFail(t, func() bool {
-		c.mux.Lock()
-		if len(c.usingModules) == 0 && len(c.modules) == 0 {
-			return true
-		}
-		c.mux.Unlock()
-		return false
-	}, retry.BackoffDelay(options.ModuleExpiry))
 }
 
 func setupOCIRegistry(t *testing.T, host string) (dockerImageDigest, invalidOCIImageDigest string) {

--- a/pkg/wasm/convert_test.go
+++ b/pkg/wasm/convert_test.go
@@ -66,7 +66,6 @@ func (c *mockCache) Get(
 
 	return module, err
 }
-func (c *mockCache) Reset()   {}
 func (c *mockCache) Cleanup() {}
 
 func TestWasmConvert(t *testing.T) {

--- a/releasenotes/notes/42167.yaml
+++ b/releasenotes/notes/42167.yaml
@@ -1,9 +1,0 @@
-apiVersion: release-notes/v2
-kind: bug-fix
-area: extensibility
-
-issue:
-- 42154
-releaseNotes:
-- |
-  **Fixed** the wasm cache file will be marked as stale and deleted, even if it is still in use.


### PR DESCRIPTION
#42167 won't fix the issue, unlike LDS, ECDS do not contains all modules every time.