### PR TITLE
Add labels to gateway pods

### DIFF
--- a/manifests/charts/gateway/templates/deployment.yaml
+++ b/manifests/charts/gateway/templates/deployment.yaml
@@ -26,6 +26,9 @@ spec:
         istio.io/rev: {{ . }}
         {{- end }}
         {{- include "gateway.selectorLabels" . | nindent 8 }}
+        {{- range $key, $val := .Values.labels }}
+        {{ $key }}: {{ $val | quote }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:


### PR DESCRIPTION
**Please provide a description of this PR:**
https://github.com/istio/istio/blob/master/manifests/charts/gateway/values.yaml#L76 says labels to be applied to _all_ resources, but pods template labels are missing, so pods are being created without these labels.