### PR TITLE
Handle QAT PrivateKeyProvider configuration

### DIFF
--- a/pilot/pkg/xds/sds.go
+++ b/pilot/pkg/xds/sds.go
@@ -24,6 +24,7 @@ import (
 
 	xxhashv2 "github.com/cespare/xxhash/v2"
 	cryptomb "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/private_key_providers/cryptomb/v3alpha"
+	qat "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/private_key_providers/qat/v3alpha"
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoytls "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
@@ -350,6 +351,34 @@ func toEnvoyKeyCertSecret(name string, key, cert []byte, proxy *model.Proxy, mes
 					},
 					PrivateKeyProvider: &envoytls.PrivateKeyProvider{
 						ProviderName: "cryptomb",
+						ConfigType: &envoytls.PrivateKeyProvider_TypedConfig{
+							TypedConfig: msg,
+						},
+					},
+				},
+			},
+		})
+	case *mesh.PrivateKeyProvider_Qat:
+		qatConf := pkpConf.GetQat()
+		msg := protoconv.MessageToAny(&qat.QatPrivateKeyMethodConfig{
+			PollDelay: durationpb.New(time.Duration(qatConf.GetPollDelay().Nanos)),
+			PrivateKey: &core.DataSource{
+				Specifier: &core.DataSource_InlineBytes{
+					InlineBytes: key,
+				},
+			},
+		})
+		res = protoconv.MessageToAny(&envoytls.Secret{
+			Name: name,
+			Type: &envoytls.Secret_TlsCertificate{
+				TlsCertificate: &envoytls.TlsCertificate{
+					CertificateChain: &core.DataSource{
+						Specifier: &core.DataSource_InlineBytes{
+							InlineBytes: cert,
+						},
+					},
+					PrivateKeyProvider: &envoytls.PrivateKeyProvider{
+						ProviderName: "qat",
 						ConfigType: &envoytls.PrivateKeyProvider_TypedConfig{
 							TypedConfig: msg,
 						},

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -1770,6 +1770,18 @@ func validatePrivateKeyProvider(pkpConf *meshconfig.PrivateKeyProvider) error {
 				errs = multierror.Append(errs, errors.New("pollDelay must be non zero"))
 			}
 		}
+	case *meshconfig.PrivateKeyProvider_Qat:
+		qatConf := pkpConf.GetQat()
+		if qatConf == nil {
+			errs = multierror.Append(errs, errors.New("qat confguration is required"))
+		} else {
+			pollDelay := qatConf.GetPollDelay()
+			if pollDelay == nil {
+				errs = multierror.Append(errs, errors.New("pollDelay is required"))
+			} else if pollDelay.GetSeconds() == 0 && pollDelay.GetNanos() == 0 {
+				errs = multierror.Append(errs, errors.New("pollDelay must be non zero"))
+			}
+		}
 	default:
 		errs = multierror.Append(errs, errors.New("unknown private key provider"))
 	}

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -873,6 +873,55 @@ func TestValidateMeshConfigProxyConfig(t *testing.T) {
 			),
 			isValid: true,
 		},
+		{
+			name: "private key provider with qat without poll_delay",
+			in: modify(valid,
+				func(c *meshconfig.ProxyConfig) {
+					c.PrivateKeyProvider = &meshconfig.PrivateKeyProvider{
+						Provider: &meshconfig.PrivateKeyProvider_Qat{
+							Qat: &meshconfig.PrivateKeyProvider_QAT{},
+						},
+					}
+				},
+			),
+			isValid: false,
+		},
+		{
+			name: "private key provider with qat zero poll_delay",
+			in: modify(valid,
+				func(c *meshconfig.ProxyConfig) {
+					c.PrivateKeyProvider = &meshconfig.PrivateKeyProvider{
+						Provider: &meshconfig.PrivateKeyProvider_Qat{
+							Qat: &meshconfig.PrivateKeyProvider_QAT{
+								PollDelay: &durationpb.Duration{
+									Seconds: 0,
+									Nanos:   0,
+								},
+							},
+						},
+					}
+				},
+			),
+			isValid: false,
+		},
+		{
+			name: "private key provider with qat",
+			in: modify(valid,
+				func(c *meshconfig.ProxyConfig) {
+					c.PrivateKeyProvider = &meshconfig.PrivateKeyProvider{
+						Provider: &meshconfig.PrivateKeyProvider_Qat{
+							Qat: &meshconfig.PrivateKeyProvider_QAT{
+								PollDelay: &durationpb.Duration{
+									Seconds: 0,
+									Nanos:   1000,
+								},
+							},
+						},
+					}
+				},
+			),
+			isValid: true,
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/releasenotes/notes/42203.yaml
+++ b/releasenotes/notes/42203.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: feature
+area: security
+
+releaseNotes:
+- |
+  **Added** support for using QAT (QuickAssist Technology) PrivateKeyProvider in SDS.


### PR DESCRIPTION
**Please provide a description of this PR:**
When the PrivateKeyProvider configuration information is provided through Istio operator yaml file, parse and pass it to gateway or sidecars. Envoy will act based on the information provided by the configuration.

To set the mesh wide defaults, configure the `defaultConfig` section of `meshConfig`. For example:
```
meshConfig:
  defaultConfig:
    privateKeyProvider:
      qat:
        pollDelay: 0.01s
```
This can also be configured on a per-workload basis by configuring the `proxy.istio.io/config` annotation on the pod.
For example:
```
annotations:
  proxy.istio.io/config: |
    privateKeyProvider:
      qat:
        pollDelay: 0.01s
```
API addition PR https://github.com/istio/api/pull/2565
Note: Users should request QAT resources through k8s:resources.