### PR TITLE
default vwh config differs - helm vs istioctl

### DIFF
--- a/manifests/charts/base/files/gen-istio-cluster.yaml
+++ b/manifests/charts/base/files/gen-istio-cluster.yaml
@@ -7550,6 +7550,8 @@ webhooks:
         apiGroups:
           - security.istio.io
           - networking.istio.io
+          - telemetry.istio.io
+          - extensions.istio.io
         apiVersions:
           - "*"
         resources:

--- a/manifests/charts/base/templates/default.yaml
+++ b/manifests/charts/base/templates/default.yaml
@@ -30,6 +30,11 @@ webhooks:
         apiGroups:
           - security.istio.io
           - networking.istio.io
+          - telemetry.istio.io
+          - extensions.istio.io
+          {{- if .Values.base.validateGateway }}
+          - gateway.networking.k8s.io
+          {{- end }}
         apiVersions:
           - "*"
         resources:

--- a/manifests/charts/istiod-remote/templates/default.yaml
+++ b/manifests/charts/istiod-remote/templates/default.yaml
@@ -31,6 +31,11 @@ webhooks:
         apiGroups:
           - security.istio.io
           - networking.istio.io
+          - telemetry.istio.io
+          - extensions.istio.io
+          {{- if .Values.base.validateGateway }}
+          - gateway.networking.k8s.io
+          {{- end }}
         apiVersions:
           - "*"
         resources:


### PR DESCRIPTION
Signed-off-by: Faseela K <faseela.k@est.tech>

istio when installed with helm has a different validatingwebhookconfig compared to when installed with istioctl.
There are two places in the Istio charts, where istiod-default-validator is defined. In the base chart (https://github.com/istio/istio/blob/master/manifests/charts/base/templates/default.yaml) and in the 'default' chart (https://github.com/istio/istio/blob/master/manifests/charts/default/templates/validatingwebhook.yaml). I think the base chart is used by helm and the default chart by istioctl. These two templates are different. 'default' chart is updated, but 'base' chart is not. 