### PR TITLE
Reduce unnecessary workload handler calls on pod updates

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/pod.go
+++ b/pilot/pkg/serviceregistry/kube/controller/pod.go
@@ -174,7 +174,9 @@ func (pc *PodCache) onEvent(curr any, ev model.Event) error {
 	case model.EventUpdate:
 		if !shouldPodBeInEndpoints(pod) || !IsPodReady(pod) {
 			// delete only if this pod was in the cache
-			pc.deleteIP(ip, key)
+			if !pc.deleteIP(ip, key) {
+				return nil
+			}
 			ev = model.EventDelete
 		} else if shouldPodBeInEndpoints(pod) && IsPodReady(pod) {
 			pc.update(ip, key)

--- a/pilot/pkg/serviceregistry/kube/controller/pod_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/pod_test.go
@@ -253,6 +253,11 @@ func TestPodCacheEvents(t *testing.T) {
 	ns := "default"
 	podCache := c.pods
 
+	handled := 0
+	podCache.c.handlers.AppendWorkloadHandler(func(*model.WorkloadInstance, model.Event) {
+		handled++
+	})
+
 	f := podCache.onEvent
 
 	ip := "172.0.3.35"
@@ -261,25 +266,52 @@ func TestPodCacheEvents(t *testing.T) {
 		t.Error(err)
 	}
 
-	podCondition := []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionTrue}}
+	notReadyCondition := []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionFalse}}
+	readyCondition := []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionTrue}}
 
-	if err := f(&v1.Pod{ObjectMeta: pod1, Status: v1.PodStatus{Conditions: podCondition, PodIP: ip, Phase: v1.PodPending}}, model.EventUpdate); err != nil {
+	if err := f(&v1.Pod{ObjectMeta: pod1, Status: v1.PodStatus{Conditions: notReadyCondition, PodIP: ip, Phase: v1.PodPending}}, model.EventUpdate); err != nil {
 		t.Error(err)
 	}
+	if handled != 0 {
+		t.Errorf("notified workload handler %d times, want %d", handled, 0)
+	}
 
+	if err := f(&v1.Pod{ObjectMeta: pod1, Status: v1.PodStatus{Conditions: readyCondition, PodIP: ip, Phase: v1.PodPending}}, model.EventUpdate); err != nil {
+		t.Error(err)
+	}
+	if handled != 1 {
+		t.Errorf("notified workload handler %d times, want %d", handled, 1)
+	}
 	if pod, exists := podCache.getPodKey(ip); !exists || pod != "default/pod1" {
 		t.Errorf("getPodKey => got %s, pod1 not found or incorrect", pod)
 	}
 
-	pod2 := metav1.ObjectMeta{Name: "pod2", Namespace: ns}
 	if err := f(
-		&v1.Pod{ObjectMeta: pod1, Status: v1.PodStatus{Conditions: podCondition, PodIP: ip, Phase: v1.PodFailed}}, model.EventUpdate); err != nil {
+		&v1.Pod{ObjectMeta: pod1, Status: v1.PodStatus{Conditions: readyCondition, PodIP: ip, Phase: v1.PodFailed}}, model.EventUpdate); err != nil {
 		t.Error(err)
 	}
-	if err := f(&v1.Pod{ObjectMeta: pod2, Status: v1.PodStatus{Conditions: podCondition, PodIP: ip, Phase: v1.PodRunning}}, model.EventAdd); err != nil {
-		t.Error(err)
+	if handled != 2 {
+		t.Errorf("notified workload handler %d times, want %d", handled, 2)
+	}
+	if pod, exists := podCache.getPodKey(ip); exists {
+		t.Errorf("getPodKey => got %s, want none", pod)
 	}
 
+	pod1.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+	if err := f(&v1.Pod{ObjectMeta: pod1, Status: v1.PodStatus{PodIP: ip, Phase: v1.PodFailed}}, model.EventUpdate); err != nil {
+		t.Error(err)
+	}
+	if handled != 2 {
+		t.Errorf("notified workload handler %d times, want %d", handled, 2)
+	}
+
+	pod2 := metav1.ObjectMeta{Name: "pod2", Namespace: ns}
+	if err := f(&v1.Pod{ObjectMeta: pod2, Status: v1.PodStatus{Conditions: readyCondition, PodIP: ip, Phase: v1.PodRunning}}, model.EventAdd); err != nil {
+		t.Error(err)
+	}
+	if handled != 3 {
+		t.Errorf("notified workload handler %d times, want %d", handled, 3)
+	}
 	if pod, exists := podCache.getPodKey(ip); !exists || pod != "default/pod2" {
 		t.Errorf("getPodKey => got %s, pod2 not found or incorrect", pod)
 	}
@@ -287,22 +319,29 @@ func TestPodCacheEvents(t *testing.T) {
 	if err := f(&v1.Pod{ObjectMeta: pod1, Status: v1.PodStatus{PodIP: ip, Phase: v1.PodFailed}}, model.EventDelete); err != nil {
 		t.Error(err)
 	}
-
+	if handled != 3 {
+		t.Errorf("notified workload handler %d times, want %d", handled, 3)
+	}
 	if pod, exists := podCache.getPodKey(ip); !exists || pod != "default/pod2" {
 		t.Errorf("getPodKey => got %s, pod2 not found or incorrect", pod)
 	}
 
 	if err := f(&v1.Pod{ObjectMeta: pod2, Spec: v1.PodSpec{
 		RestartPolicy: v1.RestartPolicyOnFailure,
-	}, Status: v1.PodStatus{Conditions: podCondition, PodIP: ip, Phase: v1.PodFailed}}, model.EventUpdate); err != nil {
+	}, Status: v1.PodStatus{Conditions: readyCondition, PodIP: ip, Phase: v1.PodFailed}}, model.EventUpdate); err != nil {
 		t.Error(err)
 	}
-
+	if handled != 4 {
+		t.Errorf("notified workload handler %d times, want %d", handled, 4)
+	}
 	if pod, exists := podCache.getPodKey(ip); exists {
 		t.Errorf("getPodKey => got %s, want none", pod)
 	}
 
-	if err := f(&v1.Pod{ObjectMeta: pod2, Status: v1.PodStatus{Conditions: podCondition, PodIP: ip, Phase: v1.PodFailed}}, model.EventDelete); err != nil {
+	if err := f(&v1.Pod{ObjectMeta: pod2, Status: v1.PodStatus{Conditions: readyCondition, PodIP: ip, Phase: v1.PodFailed}}, model.EventDelete); err != nil {
 		t.Error(err)
+	}
+	if handled != 4 {
+		t.Errorf("notified workload handler %d times, want %d", handled, 5)
 	}
 }


### PR DESCRIPTION
**Please provide a description of this PR:**
When a pod is created/deleted, it gets updated several times before it's ready/removed. We can skip those unnecessary events that build endpoints and notify workload handlers