### PR TITLE
adds support for setting healthCheckNodePort

### DIFF
--- a/manifests/charts/gateway/templates/service.yaml
+++ b/manifests/charts/gateway/templates/service.yaml
@@ -22,6 +22,11 @@ spec:
 {{- with .Values.service.externalTrafficPolicy }}
   externalTrafficPolicy: "{{ . }}"
 {{- end }}
+{{- if and (eq .Values.service.externalTrafficPolicy "Local") (eq .Values.service.Type "LoadBalancer") }}
+{{- with .Values.service.healthCheckNodePort }}
+  healthCheckNodePort: {{.}}
+{{- end }}
+{{- end }}
   type: {{ .Values.service.type }}
   ports:
 {{- if .Values.networkGateway }}

--- a/manifests/charts/gateway/values.yaml
+++ b/manifests/charts/gateway/values.yaml
@@ -54,6 +54,7 @@ service:
   loadBalancerIP: ""
   loadBalancerSourceRanges: []
   externalTrafficPolicy: ""
+  healthCheckNodePort: 0
   externalIPs: []
 
 resources:

--- a/manifests/charts/gateways/istio-ingress/templates/service.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/service.yaml
@@ -26,6 +26,9 @@ spec:
 {{- if $gateway.externalTrafficPolicy }}
   externalTrafficPolicy: {{$gateway.externalTrafficPolicy }}
 {{- end }}
+{{- if and (eq $gateway.externalTrafficPolicy "Local") (eq $gateway.type "LoadBalancer") ($gateway.healthCheckNodePort)}}
+  healthCheckNodePort: {{ $gateway.healthCheckNodePort }}
+{{- end }}
   type: {{ $gateway.type }}
   selector:
 {{ $gateway.labels | toYaml | indent 4 }}

--- a/manifests/charts/gateways/istio-ingress/values.yaml
+++ b/manifests/charts/gateways/istio-ingress/values.yaml
@@ -67,6 +67,7 @@ gateways:
 
     customService: false
     externalTrafficPolicy: ""
+    healthCheckNodePort: 0
 
     ingressPorts: []
     additionalContainers: []


### PR DESCRIPTION
Proposed fix for https://github.com/istio/istio/issues/42227.

When using source IP preservation via the `externalTrafficPolicy: Local` setting for a Service of type `LoadBalancer`, the service controller will allocate a port from the cluster's configured NodePort range.

In restricted environments, it's useful and often necessary to define the health check node port so that network policies can be composed to only allow specific ports rather than broad ranges.

The current Helm charts in `manifests/charts/gateway` and `manifests/charts/gateways/istio-ingress`  currently lack the ability to explicitly set the health check node port.