### PR TITLE
fix not splitting mutatingwebhook when setting multi revisiontags

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/revision-tags.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/revision-tags.yaml
@@ -136,4 +136,5 @@ webhooks:
 {{- end }}
 
 {{- end }}
+---
 {{- end }}

--- a/releasenotes/notes/42235.yaml
+++ b/releasenotes/notes/42235.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+issue:
+  - https://github.com/istio/istio/issues/42234
+releaseNotes:
+  - |
+    **Fixed** mutatingwebhook not being split when setting multiple revision tags.


### PR DESCRIPTION
**Please provide a description of this PR:**

fix #42234

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [x] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
