### PR TITLE
pilot: ensure initialization of secure grpc server also when serving …

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -1000,7 +1000,8 @@ func getDNSNames(args *PilotArgs, host string) []string {
 
 // createPeerCertVerifier creates a SPIFFE certificate verifier with the current istiod configuration.
 func (s *Server) createPeerCertVerifier(tlsOptions TLSOptions) (*spiffe.PeerCertVerifier, error) {
-	if tlsOptions.CaCertFile == "" && s.CA == nil && features.SpiffeBundleEndpoints == "" && !s.isCADisabled() {
+	customTLSCertsExists, _, _, _ := hasCustomTLSCerts(tlsOptions)
+	if !customTLSCertsExists && s.CA == nil && features.SpiffeBundleEndpoints == "" && !s.isCADisabled() {
 		// Running locally without configured certs - no TLS mode
 		return nil, nil
 	}

--- a/releasenotes/notes/42248.yaml
+++ b/releasenotes/notes/42248.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+issue:
+  - 42249
+releaseNotes:
+  - |
+    **Fixed** initialization of secure gRPC server of Pilot, when serving certificates are provided in default location.


### PR DESCRIPTION
…certificates are loaded from non-custom locations

**Please provide a description of this PR:**
The bootstrap of Pilot should consider certificates at non-custom locations when considering whether to initialise the secure gRPC server.

Closes: https://github.com/istio/istio/issues/42249