### PR TITLE
Fix remote cluster sync timeout issue

### DIFF
--- a/releasenotes/notes/42252.yaml
+++ b/releasenotes/notes/42252.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+
+releaseNotes:
+  - |
+    **Fixed** an issue where the sync timeout setting doesn't work on the remote clusters.


### PR DESCRIPTION
Currently, the informerInit marker doesn't work for remote cluster sync timeout case. Remove it and use the initialSync marker.

CC @hzxuzhonghu