### PR TITLE
Introduce warning if the current istioctl version near or after EOL date

### DIFF
--- a/operator/cmd/mesh/install.go
+++ b/operator/cmd/mesh/install.go
@@ -159,6 +159,16 @@ func Install(rootArgs *RootArgs, iArgs *InstallArgs, logOpts *log.Options, stdOu
 	if err != nil {
 		return fmt.Errorf("fetch Istio version: %v", err)
 	}
+
+	// return warning if current date is near the EOL date
+	t := time.Now()
+	warnMarker := color.New(color.FgYellow).Add(color.Italic).Sprint("WARNING:")
+	if t.Year() > operatorVer.OperatorEOLYear {
+		fmt.Printf("%s You are installing a EOL version, see https://istio.io/latest/docs/releases/supported-releases/ for supported release\n", warnMarker)
+	} else if t.Year() == operatorVer.OperatorEOLYear && t.Month() >= operatorVer.OperatorEOLMonth {
+		fmt.Printf("%s may be installing an EOL version: see https://istio.io/latest/docs/releases/supported-releases/ for supported releases\n", warnMarker)
+	}
+
 	setFlags := applyFlagAliases(iArgs.Set, iArgs.ManifestsPath, iArgs.Revision)
 
 	_, iop, err := manifest.GenerateConfig(iArgs.InFilenames, setFlags, iArgs.Force, kubeClient, l)

--- a/operator/cmd/mesh/install.go
+++ b/operator/cmd/mesh/install.go
@@ -163,9 +163,7 @@ func Install(rootArgs *RootArgs, iArgs *InstallArgs, logOpts *log.Options, stdOu
 	// return warning if current date is near the EOL date
 	t := time.Now()
 	warnMarker := color.New(color.FgYellow).Add(color.Italic).Sprint("WARNING:")
-	if t.Year() > operatorVer.OperatorEOLYear {
-		fmt.Printf("%s You are installing a EOL version, see https://istio.io/latest/docs/releases/supported-releases/ for supported release\n", warnMarker)
-	} else if t.Year() == operatorVer.OperatorEOLYear && t.Month() >= operatorVer.OperatorEOLMonth {
+	if t.Year() > operatorVer.OperatorEOLYear || (t.Year() == operatorVer.OperatorEOLYear && t.Month() >= operatorVer.OperatorEOLMonth) {
 		fmt.Printf("%s may be installing an EOL version: see https://istio.io/latest/docs/releases/supported-releases/ for supported releases\n", warnMarker)
 	}
 

--- a/operator/cmd/mesh/install.go
+++ b/operator/cmd/mesh/install.go
@@ -161,10 +161,10 @@ func Install(rootArgs *RootArgs, iArgs *InstallArgs, logOpts *log.Options, stdOu
 	}
 
 	// return warning if current date is near the EOL date
-	t := time.Now()
-	warnMarker := color.New(color.FgYellow).Add(color.Italic).Sprint("WARNING:")
-	if t.Year() > operatorVer.OperatorEOLYear || (t.Year() == operatorVer.OperatorEOLYear && t.Month() >= operatorVer.OperatorEOLMonth) {
-		fmt.Printf("%s may be installing an EOL version: see https://istio.io/latest/docs/releases/supported-releases/ for supported releases\n", warnMarker)
+	if operatorVer.IsEOL() {
+		warnMarker := color.New(color.FgYellow).Add(color.Italic).Sprint("WARNING:")
+		fmt.Printf("%s Istio %v may be out of support (EOL) already: see https://istio.io/latest/docs/releases/supported-releases/ for supported releases\n",
+			warnMarker, operatorVer.OperatorCodeBaseVersion)
 	}
 
 	setFlags := applyFlagAliases(iArgs.Set, iArgs.ManifestsPath, iArgs.Revision)

--- a/operator/version/version.go
+++ b/operator/version/version.go
@@ -24,8 +24,8 @@ import (
 const (
 	// OperatorCodeBaseVersion is the version string from the code base.
 	OperatorCodeBaseVersion = "1.19.0"
-	OperatorEOLYear         = 2023
-	OperatorEOLMonth        = time.January
+	OperatorEOLYear         = 2024
+	OperatorEOLMonth        = time.April
 )
 
 var (
@@ -48,4 +48,9 @@ func init() {
 		panic(err)
 	}
 	OperatorBinaryVersion = *v
+}
+
+func IsEOL() bool {
+	t := time.Now()
+	return t.Year() > OperatorEOLYear || (t.Year() == OperatorEOLYear && t.Month() >= OperatorEOLMonth)
 }

--- a/operator/version/version.go
+++ b/operator/version/version.go
@@ -15,6 +15,8 @@
 package version
 
 import (
+	"time"
+
 	pkgversion "istio.io/istio/operator/pkg/version"
 	buildversion "istio.io/pkg/version"
 )
@@ -22,6 +24,8 @@ import (
 const (
 	// OperatorCodeBaseVersion is the version string from the code base.
 	OperatorCodeBaseVersion = "1.19.0"
+	OperatorEOLYear         = 2023
+	OperatorEOLMonth        = time.January
 )
 
 var (


### PR DESCRIPTION
Signed-off-by: zufardhiyaulhaq <zufardhiyaulhaq@gmail.com>

**Please provide a description of this PR:**
fix https://github.com/istio/istio/issues/41747, introduce a warning if the current date is near or after EOL of the date defined 
in istioctl.

![telegram-cloud-photo-size-5-6077778448312546357-y](https://user-images.githubusercontent.com/11990726/205432291-250d4910-6017-4661-83a3-864a347f8cca.jpg)
![telegram-cloud-photo-size-5-6077778448312546359-y](https://user-images.githubusercontent.com/11990726/205432293-c19dd297-6f94-4cd6-9ad1-e1ec430dd9b5.jpg)