### PR TITLE
Option for Pod Labels in Gateway Chart

### DIFF
--- a/manifests/charts/gateway/templates/deployment.yaml
+++ b/manifests/charts/gateway/templates/deployment.yaml
@@ -26,6 +26,9 @@ spec:
         istio.io/rev: {{ . }}
         {{- end }}
         {{- include "gateway.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/manifests/charts/gateway/values.schema.json
+++ b/manifests/charts/gateway/values.schema.json
@@ -74,6 +74,9 @@
         }
       }
     },
+    "podLabels": {
+      "type": "object"
+    },
     "replicaCount": {
       "type": "integer"
     },

--- a/manifests/charts/gateway/values.yaml
+++ b/manifests/charts/gateway/values.yaml
@@ -28,6 +28,9 @@ podAnnotations:
   inject.istio.io/templates: "gateway"
   sidecar.istio.io/inject: "true"
 
+# Labels to apply to pods
+podLabels: {}
+
 # Define the security context for the pod.
 # If unset, this will be automatically set to the minimum privileges required to bind to port 80 and 443.
 # On Kubernetes 1.22+, this only requires the `net.ipv4.ip_unprivileged_port_start` sysctl.


### PR DESCRIPTION
This patch adds a new option to the gateway chart making it possible to configure additional labels for pods.

Some tools are using Labels on pods for configuration (istio also does this). So it is nice to have the option to set those labels.

Signed-off-by: Sven Haardiek <sven.haardiek@uni-muenster.de>

**Please provide a description of this PR:**