### PR TITLE
Add pod lifecycle and terminationGracePeriodSeconds

### DIFF
--- a/manifests/charts/gateway/templates/deployment.yaml
+++ b/manifests/charts/gateway/templates/deployment.yaml
@@ -84,8 +84,13 @@ spec:
           - containerPort: 15090
             protocol: TCP
             name: http-envoy-prom
+          {{- if .Values.lifecycle }}
+          lifecycle:
+            {{- toYaml .Values.lifecycle | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/manifests/charts/gateway/values.schema.json
+++ b/manifests/charts/gateway/values.schema.json
@@ -104,6 +104,12 @@
         }
       }
     },
+    "lifecycle": {
+      "type": "object"
+    },
+    "terminationGracePeriodSeconds": {
+      "type": "integer"
+    },
     "revision": {
       "type": "string"
     },

--- a/manifests/charts/gateway/values.yaml
+++ b/manifests/charts/gateway/values.yaml
@@ -64,6 +64,10 @@ resources:
     cpu: 2000m
     memory: 1024Mi
 
+lifecycle: {}
+
+terminationGracePeriodSeconds: 30
+
 autoscaling:
   enabled: true
   minReplicas: 1

--- a/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
@@ -125,6 +125,10 @@ spec:
         {{- if .Values.global.sts.servicePort }}
           - --stsPort={{ .Values.global.sts.servicePort }}
         {{- end }}
+{{- if $gateway.lifecycle }}
+          lifecycle: 
+{{ toYaml $gateway.lifecycle | indent 12 }}
+{{- end }}
         {{- if not $gateway.runAsRoot }}
           securityContext:
             allowPrivilegeEscalation: false
@@ -269,6 +273,7 @@ spec:
 {{- if $gateway.additionalContainers }}
 {{ toYaml $gateway.additionalContainers | indent 8 }}
 {{- end }}
+      terminationGracePeriodSeconds: {{ $gateway.terminationGracePeriodSeconds }}
       volumes:
       - emptyDir: {}
         name: workload-socket

--- a/manifests/charts/gateways/istio-ingress/values.yaml
+++ b/manifests/charts/gateways/istio-ingress/values.yaml
@@ -70,6 +70,8 @@ gateways:
 
     ingressPorts: []
     additionalContainers: []
+    terminationGracePeriodSeconds: 30
+    lifecycle: {}
     configVolumes: []
 
     serviceAccount:


### PR DESCRIPTION
**Please provide a description of this PR:**
According to the zero download for pod rollout by using of aws lb, there needs some additional settings for pod lifecycle and terminationGracePeriodSeconds.
Ref: [https://aws.github.io/aws-eks-best-practices/networking/loadbalancing/loadbalancing/#gracefully-handle-termination-signals](https://aws.github.io/aws-eks-best-practices/networking/loadbalancing/loadbalancing/#gracefully-handle-termination-signals)


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [X] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
