### PR TITLE
Fix pure client locality label retrieval

### DIFF
--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -613,7 +613,7 @@ func setTopologyLabels(proxy *model.Proxy) {
 		localityStr = proxy.ServiceInstances[0].Endpoint.Locality.Label
 	} else {
 		// If no service instances(this maybe common for a pure client), respect LocalityLabel
-		localityStr = proxy.Metadata.Labels[model.LocalityLabel]
+		localityStr = model.GetLocalityLabelOrDefault(proxy.Metadata.Labels[model.LocalityLabel], "")
 	}
 	if localityStr != "" {
 		proxy.Locality = util.ConvertLocality(localityStr)


### PR DESCRIPTION
**Please provide a description of this PR:**
I realised that a _'pure client'_ sleep pod was not balancing traffic as expected.
Non-pure clients were doing it fine, though.
Turns out the locality labels where not propagated from `.spec.template.metadata.labels.istio-locality`.
This patch fixes the label retrieval.

On the other hand, my initial expectation was that pure-clients where able to discover `region/zone/subzone` from the underlying node without having to set an explicit `istio-locality` label. I might be missing something, if anyone can throw some light it would be great.