### PR TITLE
[release-1.14] Mount K8s CA root when service account automount is disabled

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -589,6 +589,10 @@ data:
             - mountPath: /var/run/secrets/istio
               name: istiod-ca-cert
             {{- end }}
+            {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
+            - mountPath: /var/run/secrets/istio/kubernetes
+              name: kube-ca-cert
+            {{- end }}
             - mountPath: /var/lib/istio/data
               name: istio-data
             {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
@@ -665,6 +669,11 @@ data:
           - name: istiod-ca-cert
             configMap:
               name: istio-ca-root-cert
+          {{- end }}
+          {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
+          - name: kube-ca-cert
+            configMap:
+              name: kube-root-ca.crt
           {{- end }}
           {{- if .Values.global.mountMtlsCerts }}
           # Use the key and cert mounted to /etc/certs/ for the in-cluster mTLS communications.

--- a/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
@@ -374,6 +374,10 @@ spec:
     - mountPath: /var/run/secrets/istio
       name: istiod-ca-cert
     {{- end }}
+    {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
+    - mountPath: /var/run/secrets/istio/kubernetes
+      name: kube-ca-cert
+    {{- end }}
     - mountPath: /var/lib/istio/data
       name: istio-data
     {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
@@ -450,6 +454,11 @@ spec:
   - name: istiod-ca-cert
     configMap:
       name: istio-ca-root-cert
+  {{- end }}
+  {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
+  - name: kube-ca-cert
+    configMap:
+      name: kube-root-ca.crt
   {{- end }}
   {{- if .Values.global.mountMtlsCerts }}
   # Use the key and cert mounted to /etc/certs/ for the in-cluster mTLS communications.

--- a/manifests/charts/istiod-remote/files/injection-template.yaml
+++ b/manifests/charts/istiod-remote/files/injection-template.yaml
@@ -374,6 +374,10 @@ spec:
     - mountPath: /var/run/secrets/istio
       name: istiod-ca-cert
     {{- end }}
+    {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
+    - mountPath: /var/run/secrets/istio/kubernetes
+      name: kube-ca-cert
+    {{- end }}
     - mountPath: /var/lib/istio/data
       name: istio-data
     {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
@@ -450,6 +454,11 @@ spec:
   - name: istiod-ca-cert
     configMap:
       name: istio-ca-root-cert
+  {{- end }}
+  {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
+  - name: kube-ca-cert
+    configMap:
+      name: kube-root-ca.crt
   {{- end }}
   {{- if .Values.global.mountMtlsCerts }}
   # Use the key and cert mounted to /etc/certs/ for the in-cluster mTLS communications.

--- a/pkg/istio-agent/agent.go
+++ b/pkg/istio-agent/agent.go
@@ -80,6 +80,8 @@ import (
 const (
 	// Location of K8S CA root.
 	k8sCAPath = "./var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+	// Location of K8s CA root mounted by istio. This is to avoid issues when service account automount is disabled.
+	k8sCAIstioMountedPath = "./var/run/secrets/istio/kubernetes/ca.crt"
 
 	// CitadelCACertPath is the directory for Citadel CA certificate.
 	// This is mounted from config map 'istio-ca-root-cert'. Part of startup,
@@ -688,7 +690,11 @@ func (a *Agent) FindRootCAForXDS() (string, error) {
 		return security.DefaultRootCertFilePath, nil
 	} else if a.secOpts.PilotCertProvider == constants.CertProviderKubernetes {
 		// Using K8S - this is likely incorrect, may work by accident (https://github.com/istio/istio/issues/22161)
-		rootCAPath = k8sCAPath
+		if fileExists(k8sCAIstioMountedPath) {
+			rootCAPath = k8sCAIstioMountedPath
+		} else {
+			rootCAPath = k8sCAPath
+		}
 	} else if a.secOpts.ProvCert != "" {
 		// This was never completely correct - PROV_CERT are only intended for auth with CA_ADDR,
 		// and should not be involved in determining the root CA.
@@ -794,7 +800,11 @@ func (a *Agent) FindRootCAForCA() (string, error) {
 	} else if a.secOpts.PilotCertProvider == constants.CertProviderKubernetes {
 		// Using K8S - this is likely incorrect, may work by accident.
 		// API is GA.
-		rootCAPath = k8sCAPath // ./var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+		if fileExists(k8sCAIstioMountedPath) {
+			rootCAPath = k8sCAIstioMountedPath
+		} else {
+			rootCAPath = k8sCAPath
+		}
 	} else if a.secOpts.PilotCertProvider == constants.CertProviderCustom {
 		rootCAPath = security.DefaultRootCertFilePath // ./etc/certs/root-cert.pem
 	} else if a.secOpts.ProvCert != "" {

--- a/pkg/kube/inject/testdata/inputs/custom-template.yaml.34.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/custom-template.yaml.34.template.gen.yaml
@@ -385,6 +385,10 @@ templates:
         - mountPath: /var/run/secrets/istio
           name: istiod-ca-cert
         {{- end }}
+        {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
+        - mountPath: /var/run/secrets/istio/kubernetes
+          name: kube-ca-cert
+        {{- end }}
         - mountPath: /var/lib/istio/data
           name: istio-data
         {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
@@ -461,6 +465,11 @@ templates:
       - name: istiod-ca-cert
         configMap:
           name: istio-ca-root-cert
+      {{- end }}
+      {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
+      - name: kube-ca-cert
+        configMap:
+          name: kube-root-ca.crt
       {{- end }}
       {{- if .Values.global.mountMtlsCerts }}
       # Use the key and cert mounted to /etc/certs/ for the in-cluster mTLS communications.

--- a/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
@@ -385,6 +385,10 @@ templates:
         - mountPath: /var/run/secrets/istio
           name: istiod-ca-cert
         {{- end }}
+        {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
+        - mountPath: /var/run/secrets/istio/kubernetes
+          name: kube-ca-cert
+        {{- end }}
         - mountPath: /var/lib/istio/data
           name: istio-data
         {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
@@ -461,6 +465,11 @@ templates:
       - name: istiod-ca-cert
         configMap:
           name: istio-ca-root-cert
+      {{- end }}
+      {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
+      - name: kube-ca-cert
+        configMap:
+          name: kube-root-ca.crt
       {{- end }}
       {{- if .Values.global.mountMtlsCerts }}
       # Use the key and cert mounted to /etc/certs/ for the in-cluster mTLS communications.

--- a/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
@@ -385,6 +385,10 @@ templates:
         - mountPath: /var/run/secrets/istio
           name: istiod-ca-cert
         {{- end }}
+        {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
+        - mountPath: /var/run/secrets/istio/kubernetes
+          name: kube-ca-cert
+        {{- end }}
         - mountPath: /var/lib/istio/data
           name: istio-data
         {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
@@ -461,6 +465,11 @@ templates:
       - name: istiod-ca-cert
         configMap:
           name: istio-ca-root-cert
+      {{- end }}
+      {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
+      - name: kube-ca-cert
+        configMap:
+          name: kube-root-ca.crt
       {{- end }}
       {{- if .Values.global.mountMtlsCerts }}
       # Use the key and cert mounted to /etc/certs/ for the in-cluster mTLS communications.

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
@@ -385,6 +385,10 @@ templates:
         - mountPath: /var/run/secrets/istio
           name: istiod-ca-cert
         {{- end }}
+        {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
+        - mountPath: /var/run/secrets/istio/kubernetes
+          name: kube-ca-cert
+        {{- end }}
         - mountPath: /var/lib/istio/data
           name: istio-data
         {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
@@ -461,6 +465,11 @@ templates:
       - name: istiod-ca-cert
         configMap:
           name: istio-ca-root-cert
+      {{- end }}
+      {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
+      - name: kube-ca-cert
+        configMap:
+          name: kube-root-ca.crt
       {{- end }}
       {{- if .Values.global.mountMtlsCerts }}
       # Use the key and cert mounted to /etc/certs/ for the in-cluster mTLS communications.

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
@@ -385,6 +385,10 @@ templates:
         - mountPath: /var/run/secrets/istio
           name: istiod-ca-cert
         {{- end }}
+        {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
+        - mountPath: /var/run/secrets/istio/kubernetes
+          name: kube-ca-cert
+        {{- end }}
         - mountPath: /var/lib/istio/data
           name: istio-data
         {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
@@ -461,6 +465,11 @@ templates:
       - name: istiod-ca-cert
         configMap:
           name: istio-ca-root-cert
+      {{- end }}
+      {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
+      - name: kube-ca-cert
+        configMap:
+          name: kube-root-ca.crt
       {{- end }}
       {{- if .Values.global.mountMtlsCerts }}
       # Use the key and cert mounted to /etc/certs/ for the in-cluster mTLS communications.

--- a/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
@@ -385,6 +385,10 @@ templates:
         - mountPath: /var/run/secrets/istio
           name: istiod-ca-cert
         {{- end }}
+        {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
+        - mountPath: /var/run/secrets/istio/kubernetes
+          name: kube-ca-cert
+        {{- end }}
         - mountPath: /var/lib/istio/data
           name: istio-data
         {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
@@ -461,6 +465,11 @@ templates:
       - name: istiod-ca-cert
         configMap:
           name: istio-ca-root-cert
+      {{- end }}
+      {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
+      - name: kube-ca-cert
+        configMap:
+          name: kube-root-ca.crt
       {{- end }}
       {{- if .Values.global.mountMtlsCerts }}
       # Use the key and cert mounted to /etc/certs/ for the in-cluster mTLS communications.

--- a/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
@@ -385,6 +385,10 @@ templates:
         - mountPath: /var/run/secrets/istio
           name: istiod-ca-cert
         {{- end }}
+        {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
+        - mountPath: /var/run/secrets/istio/kubernetes
+          name: kube-ca-cert
+        {{- end }}
         - mountPath: /var/lib/istio/data
           name: istio-data
         {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
@@ -461,6 +465,11 @@ templates:
       - name: istiod-ca-cert
         configMap:
           name: istio-ca-root-cert
+      {{- end }}
+      {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
+      - name: kube-ca-cert
+        configMap:
+          name: kube-root-ca.crt
       {{- end }}
       {{- if .Values.global.mountMtlsCerts }}
       # Use the key and cert mounted to /etc/certs/ for the in-cluster mTLS communications.

--- a/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
@@ -385,6 +385,10 @@ templates:
         - mountPath: /var/run/secrets/istio
           name: istiod-ca-cert
         {{- end }}
+        {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
+        - mountPath: /var/run/secrets/istio/kubernetes
+          name: kube-ca-cert
+        {{- end }}
         - mountPath: /var/lib/istio/data
           name: istio-data
         {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
@@ -461,6 +465,11 @@ templates:
       - name: istiod-ca-cert
         configMap:
           name: istio-ca-root-cert
+      {{- end }}
+      {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
+      - name: kube-ca-cert
+        configMap:
+          name: kube-root-ca.crt
       {{- end }}
       {{- if .Values.global.mountMtlsCerts }}
       # Use the key and cert mounted to /etc/certs/ for the in-cluster mTLS communications.

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
@@ -385,6 +385,10 @@ templates:
         - mountPath: /var/run/secrets/istio
           name: istiod-ca-cert
         {{- end }}
+        {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
+        - mountPath: /var/run/secrets/istio/kubernetes
+          name: kube-ca-cert
+        {{- end }}
         - mountPath: /var/lib/istio/data
           name: istio-data
         {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
@@ -461,6 +465,11 @@ templates:
       - name: istiod-ca-cert
         configMap:
           name: istio-ca-root-cert
+      {{- end }}
+      {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
+      - name: kube-ca-cert
+        configMap:
+          name: kube-root-ca.crt
       {{- end }}
       {{- if .Values.global.mountMtlsCerts }}
       # Use the key and cert mounted to /etc/certs/ for the in-cluster mTLS communications.

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
@@ -385,6 +385,10 @@ templates:
         - mountPath: /var/run/secrets/istio
           name: istiod-ca-cert
         {{- end }}
+        {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
+        - mountPath: /var/run/secrets/istio/kubernetes
+          name: kube-ca-cert
+        {{- end }}
         - mountPath: /var/lib/istio/data
           name: istio-data
         {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
@@ -461,6 +465,11 @@ templates:
       - name: istiod-ca-cert
         configMap:
           name: istio-ca-root-cert
+      {{- end }}
+      {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
+      - name: kube-ca-cert
+        configMap:
+          name: kube-root-ca.crt
       {{- end }}
       {{- if .Values.global.mountMtlsCerts }}
       # Use the key and cert mounted to /etc/certs/ for the in-cluster mTLS communications.

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
@@ -385,6 +385,10 @@ templates:
         - mountPath: /var/run/secrets/istio
           name: istiod-ca-cert
         {{- end }}
+        {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
+        - mountPath: /var/run/secrets/istio/kubernetes
+          name: kube-ca-cert
+        {{- end }}
         - mountPath: /var/lib/istio/data
           name: istio-data
         {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
@@ -461,6 +465,11 @@ templates:
       - name: istiod-ca-cert
         configMap:
           name: istio-ca-root-cert
+      {{- end }}
+      {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
+      - name: kube-ca-cert
+        configMap:
+          name: kube-root-ca.crt
       {{- end }}
       {{- if .Values.global.mountMtlsCerts }}
       # Use the key and cert mounted to /etc/certs/ for the in-cluster mTLS communications.

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
@@ -385,6 +385,10 @@ templates:
         - mountPath: /var/run/secrets/istio
           name: istiod-ca-cert
         {{- end }}
+        {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
+        - mountPath: /var/run/secrets/istio/kubernetes
+          name: kube-ca-cert
+        {{- end }}
         - mountPath: /var/lib/istio/data
           name: istio-data
         {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
@@ -461,6 +465,11 @@ templates:
       - name: istiod-ca-cert
         configMap:
           name: istio-ca-root-cert
+      {{- end }}
+      {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
+      - name: kube-ca-cert
+        configMap:
+          name: kube-root-ca.crt
       {{- end }}
       {{- if .Values.global.mountMtlsCerts }}
       # Use the key and cert mounted to /etc/certs/ for the in-cluster mTLS communications.

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
@@ -385,6 +385,10 @@ templates:
         - mountPath: /var/run/secrets/istio
           name: istiod-ca-cert
         {{- end }}
+        {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
+        - mountPath: /var/run/secrets/istio/kubernetes
+          name: kube-ca-cert
+        {{- end }}
         - mountPath: /var/lib/istio/data
           name: istio-data
         {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
@@ -461,6 +465,11 @@ templates:
       - name: istiod-ca-cert
         configMap:
           name: istio-ca-root-cert
+      {{- end }}
+      {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
+      - name: kube-ca-cert
+        configMap:
+          name: kube-root-ca.crt
       {{- end }}
       {{- if .Values.global.mountMtlsCerts }}
       # Use the key and cert mounted to /etc/certs/ for the in-cluster mTLS communications.

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
@@ -385,6 +385,10 @@ templates:
         - mountPath: /var/run/secrets/istio
           name: istiod-ca-cert
         {{- end }}
+        {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
+        - mountPath: /var/run/secrets/istio/kubernetes
+          name: kube-ca-cert
+        {{- end }}
         - mountPath: /var/lib/istio/data
           name: istio-data
         {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
@@ -461,6 +465,11 @@ templates:
       - name: istiod-ca-cert
         configMap:
           name: istio-ca-root-cert
+      {{- end }}
+      {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
+      - name: kube-ca-cert
+        configMap:
+          name: kube-root-ca.crt
       {{- end }}
       {{- if .Values.global.mountMtlsCerts }}
       # Use the key and cert mounted to /etc/certs/ for the in-cluster mTLS communications.

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
@@ -385,6 +385,10 @@ templates:
         - mountPath: /var/run/secrets/istio
           name: istiod-ca-cert
         {{- end }}
+        {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
+        - mountPath: /var/run/secrets/istio/kubernetes
+          name: kube-ca-cert
+        {{- end }}
         - mountPath: /var/lib/istio/data
           name: istio-data
         {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
@@ -461,6 +465,11 @@ templates:
       - name: istiod-ca-cert
         configMap:
           name: istio-ca-root-cert
+      {{- end }}
+      {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
+      - name: kube-ca-cert
+        configMap:
+          name: kube-root-ca.crt
       {{- end }}
       {{- if .Values.global.mountMtlsCerts }}
       # Use the key and cert mounted to /etc/certs/ for the in-cluster mTLS communications.

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
@@ -385,6 +385,10 @@ templates:
         - mountPath: /var/run/secrets/istio
           name: istiod-ca-cert
         {{- end }}
+        {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
+        - mountPath: /var/run/secrets/istio/kubernetes
+          name: kube-ca-cert
+        {{- end }}
         - mountPath: /var/lib/istio/data
           name: istio-data
         {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
@@ -461,6 +465,11 @@ templates:
       - name: istiod-ca-cert
         configMap:
           name: istio-ca-root-cert
+      {{- end }}
+      {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
+      - name: kube-ca-cert
+        configMap:
+          name: kube-root-ca.crt
       {{- end }}
       {{- if .Values.global.mountMtlsCerts }}
       # Use the key and cert mounted to /etc/certs/ for the in-cluster mTLS communications.

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
@@ -385,6 +385,10 @@ templates:
         - mountPath: /var/run/secrets/istio
           name: istiod-ca-cert
         {{- end }}
+        {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
+        - mountPath: /var/run/secrets/istio/kubernetes
+          name: kube-ca-cert
+        {{- end }}
         - mountPath: /var/lib/istio/data
           name: istio-data
         {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
@@ -461,6 +465,11 @@ templates:
       - name: istiod-ca-cert
         configMap:
           name: istio-ca-root-cert
+      {{- end }}
+      {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
+      - name: kube-ca-cert
+        configMap:
+          name: kube-root-ca.crt
       {{- end }}
       {{- if .Values.global.mountMtlsCerts }}
       # Use the key and cert mounted to /etc/certs/ for the in-cluster mTLS communications.

--- a/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
@@ -385,6 +385,10 @@ templates:
         - mountPath: /var/run/secrets/istio
           name: istiod-ca-cert
         {{- end }}
+        {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
+        - mountPath: /var/run/secrets/istio/kubernetes
+          name: kube-ca-cert
+        {{- end }}
         - mountPath: /var/lib/istio/data
           name: istio-data
         {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
@@ -461,6 +465,11 @@ templates:
       - name: istiod-ca-cert
         configMap:
           name: istio-ca-root-cert
+      {{- end }}
+      {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
+      - name: kube-ca-cert
+        configMap:
+          name: kube-root-ca.crt
       {{- end }}
       {{- if .Values.global.mountMtlsCerts }}
       # Use the key and cert mounted to /etc/certs/ for the in-cluster mTLS communications.

--- a/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
@@ -385,6 +385,10 @@ templates:
         - mountPath: /var/run/secrets/istio
           name: istiod-ca-cert
         {{- end }}
+        {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
+        - mountPath: /var/run/secrets/istio/kubernetes
+          name: kube-ca-cert
+        {{- end }}
         - mountPath: /var/lib/istio/data
           name: istio-data
         {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
@@ -461,6 +465,11 @@ templates:
       - name: istiod-ca-cert
         configMap:
           name: istio-ca-root-cert
+      {{- end }}
+      {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
+      - name: kube-ca-cert
+        configMap:
+          name: kube-root-ca.crt
       {{- end }}
       {{- if .Values.global.mountMtlsCerts }}
       # Use the key and cert mounted to /etc/certs/ for the in-cluster mTLS communications.

--- a/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
@@ -385,6 +385,10 @@ templates:
         - mountPath: /var/run/secrets/istio
           name: istiod-ca-cert
         {{- end }}
+        {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
+        - mountPath: /var/run/secrets/istio/kubernetes
+          name: kube-ca-cert
+        {{- end }}
         - mountPath: /var/lib/istio/data
           name: istio-data
         {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
@@ -461,6 +465,11 @@ templates:
       - name: istiod-ca-cert
         configMap:
           name: istio-ca-root-cert
+      {{- end }}
+      {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
+      - name: kube-ca-cert
+        configMap:
+          name: kube-root-ca.crt
       {{- end }}
       {{- if .Values.global.mountMtlsCerts }}
       # Use the key and cert mounted to /etc/certs/ for the in-cluster mTLS communications.

--- a/pkg/test/framework/components/echo/config.go
+++ b/pkg/test/framework/components/echo/config.go
@@ -98,6 +98,9 @@ type Config struct {
 	// for the deployment.
 	ServiceAccount bool
 
+	// DisableAutomountSAToken indicates to opt out of auto mounting ServiceAccount's API credentials
+	DisableAutomountSAToken bool
+
 	// Ports for this application. Port numbers may or may not be used, depending
 	// on the implementation.
 	Ports Ports

--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -147,6 +147,9 @@ spec:
 {{- if $.ServiceAccount }}
       serviceAccountName: {{ $.Service }}
 {{- end }}
+{{- if $.DisableAutomountSAToken }}
+      automountServiceAccountToken: false
+{{- end }}
 {{- if ne $.ImagePullSecretName "" }}
       imagePullSecrets:
       - name: {{ $.ImagePullSecretName }}
@@ -700,27 +703,28 @@ func templateParams(cfg echo.Config, settings *resource.Settings) (map[string]in
 		return nil, err
 	}
 	params := map[string]interface{}{
-		"ImageHub":            settings.Image.Hub,
-		"ImageTag":            strings.TrimSuffix(settings.Image.Tag, "-distroless"),
-		"ImagePullPolicy":     settings.Image.PullPolicy,
-		"ImagePullSecretName": imagePullSecretName,
-		"Service":             cfg.Service,
-		"Version":             cfg.Version,
-		"Headless":            cfg.Headless,
-		"StatefulSet":         cfg.StatefulSet,
-		"ProxylessGRPC":       cfg.IsProxylessGRPC(),
-		"GRPCMagicPort":       grpcMagicPort,
-		"Locality":            cfg.Locality,
-		"ServiceAccount":      cfg.ServiceAccount,
-		"ServicePorts":        cfg.Ports.GetServicePorts(),
-		"ContainerPorts":      getContainerPorts(cfg),
-		"ServiceAnnotations":  cfg.ServiceAnnotations,
-		"Subsets":             cfg.Subsets,
-		"TLSSettings":         cfg.TLSSettings,
-		"Cluster":             cfg.Cluster.Name(),
-		"Namespace":           namespace,
-		"ReadinessTCPPort":    cfg.ReadinessTCPPort,
-		"ReadinessGRPCPort":   cfg.ReadinessGRPCPort,
+		"ImageHub":                settings.Image.Hub,
+		"ImageTag":                strings.TrimSuffix(settings.Image.Tag, "-distroless"),
+		"ImagePullPolicy":         settings.Image.PullPolicy,
+		"ImagePullSecretName":     imagePullSecretName,
+		"Service":                 cfg.Service,
+		"Version":                 cfg.Version,
+		"Headless":                cfg.Headless,
+		"StatefulSet":             cfg.StatefulSet,
+		"ProxylessGRPC":           cfg.IsProxylessGRPC(),
+		"GRPCMagicPort":           grpcMagicPort,
+		"Locality":                cfg.Locality,
+		"ServiceAccount":          cfg.ServiceAccount,
+		"DisableAutomountSAToken": cfg.DisableAutomountSAToken,
+		"ServicePorts":            cfg.Ports.GetServicePorts(),
+		"ContainerPorts":          getContainerPorts(cfg),
+		"ServiceAnnotations":      cfg.ServiceAnnotations,
+		"Subsets":                 cfg.Subsets,
+		"TLSSettings":             cfg.TLSSettings,
+		"Cluster":                 cfg.Cluster.Name(),
+		"Namespace":               namespace,
+		"ReadinessTCPPort":        cfg.ReadinessTCPPort,
+		"ReadinessGRPCPort":       cfg.ReadinessGRPCPort,
 		"VM": map[string]interface{}{
 			"Image": vmImage,
 		},

--- a/pkg/test/framework/components/echo/kube/deployment_test.go
+++ b/pkg/test/framework/components/echo/kube/deployment_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -168,6 +168,24 @@ func TestDeploymentYAML(t *testing.T) {
 				"rev-b": resource.IstioVersion("1.9.0"),
 			},
 			compatibility: true,
+		},
+		{
+			name:         "disable-automount-sa",
+			wantFilePath: "testdata/disable-automount-sa.yaml",
+			config: echo.Config{
+				Service: "foo",
+				Version: "bar",
+				Ports: []echo.Port{
+					{
+						Name:         "http",
+						Protocol:     protocol.HTTP,
+						WorkloadPort: 8090,
+						ServicePort:  8090,
+					},
+				},
+				ServiceAccount:          true,
+				DisableAutomountSAToken: true,
+			},
 		},
 	}
 	for _, tc := range testCase {

--- a/pkg/test/framework/components/echo/kube/testdata/disable-automount-sa.yaml
+++ b/pkg/test/framework/components/echo/kube/testdata/disable-automount-sa.yaml
@@ -1,0 +1,106 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: foo
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: foo
+  labels:
+    app: foo
+spec:
+  ports:
+  - name: grpc
+    port: 7070
+    targetPort: 7070
+  - name: http
+    port: 8090
+    targetPort: 8090
+  selector:
+    app: foo
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: foo-bar
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: foo
+      version: bar
+  template:
+    metadata:
+      labels:
+        app: foo
+        version: bar
+        test.istio.io/class: standard
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "15014"
+    spec:
+      serviceAccountName: foo
+      automountServiceAccountToken: false
+      imagePullSecrets:
+      - name: myregistrykey
+      containers:
+      - name: istio-proxy
+        image: auto
+        imagePullPolicy: Always
+        securityContext: # to allow core dumps
+          readOnlyRootFilesystem: false
+      - name: app
+        image: testing.hub/app:latest
+        imagePullPolicy: Always
+        securityContext:
+          runAsUser: 1338
+          runAsGroup: 1338
+        args:
+          - --metrics=15014
+          - --cluster
+          - "cluster-0"
+          - --grpc
+          - "7070"
+          - --port
+          - "8090"
+          - --port
+          - "8080"
+          - --port
+          - "3333"
+          - --version
+          - "bar"
+          - --istio-version
+          - ""
+          - --crt=/cert.crt
+          - --key=/cert.key
+        ports:
+        - containerPort: 7070
+        - containerPort: 8090
+        - containerPort: 8080
+        - containerPort: 3333
+          name: tcp-health-port
+        env:
+        - name: INSTANCE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 1
+          periodSeconds: 2
+          failureThreshold: 10
+        livenessProbe:
+          tcpSocket:
+            port: tcp-health-port
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          failureThreshold: 10
+        startupProbe:
+          tcpSocket:
+            port: tcp-health-port
+          periodSeconds: 1
+          failureThreshold: 10
+---

--- a/tests/integration/security/util/framework.go
+++ b/tests/integration/security/util/framework.go
@@ -70,10 +70,11 @@ type EchoDeployments struct {
 
 func EchoConfig(name string, ns namespace.Instance, headless bool, annos echo.Annotations) echo.Config {
 	out := echo.Config{
-		Service:        name,
-		Namespace:      ns,
-		ServiceAccount: true,
-		Headless:       headless,
+		Service:                 name,
+		Namespace:               ns,
+		ServiceAccount:          true,
+		Headless:                headless,
+		DisableAutomountSAToken: name == ASvc,
 		Subsets: []echo.SubsetConfig{
 			{
 				Version:     "v1",


### PR DESCRIPTION
When pilotCertProvider is kubernetes and automountServiceAccountToken is false, istio proxy is unable to find the kube-apiserver ca root. These changes will mount the ca root under the istio path and use this path by default.

(cherry picked from commit b6ecae50fa1948b5e2b678ffd6c2cf1a7dd1c186)

**Please provide a description of this PR:**



**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [x] Security
- [x] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
