### PR TITLE
[release-1.14] Add min version required to 20 for tests using k8sca

### DIFF
--- a/releasenotes/notes/deprecate-k8sca-upto-v1.20.yaml
+++ b/releasenotes/notes/deprecate-k8sca-upto-v1.20.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: security
+issue:
+- https://github.com/GoogleCloudPlatform/anthos-service-mesh-packages/issues/1210
+releaseNotes:
+- |
+  **Fixed** an issue preventing istio-proxy to access root ca when automountServiceAccountToken is false and PILOT_CERT_PROVIDER is kubernetes.
+  **Deprecated** using PILOT_CERT_PROVIDER kubernetes for kubernetes versions less than 1.20.

--- a/tests/integration/security/mtlsk8sca/main_test.go
+++ b/tests/integration/security/mtlsk8sca/main_test.go
@@ -39,6 +39,7 @@ func TestMain(m *testing.M) {
 		RequireSingleCluster().
 		RequireMultiPrimary().
 		Label(label.CustomSetup).
+		RequireMinVersion(20). // versions less than 1.20 doesn't have kube-root-ca.crt configmap. https://github.com/istio/istio/pull/42111
 		// https://github.com/istio/istio/issues/22161. 1.22 drops support for legacy-unknown signer
 		RequireMaxVersion(21).
 		Setup(istio.Setup(&inst, setupConfig)).

--- a/tests/integration/security/sds_ingress_k8sca/main_test.go
+++ b/tests/integration/security/sds_ingress_k8sca/main_test.go
@@ -40,6 +40,7 @@ func TestMain(m *testing.M) {
 		NewSuite(m).
 		RequireSingleCluster().
 		RequireMultiPrimary().
+		RequireMinVersion(20). // versions less than 1.20 doesn't have kube-root-ca.crt configmap. https://github.com/istio/istio/pull/42111
 		// https://github.com/istio/istio/issues/22161. 1.22 drops support for legacy-unknown signer
 		RequireMaxVersion(21).
 		Setup(istio.Setup(&inst, setupConfig)).


### PR DESCRIPTION
PR #42111 adds support for mounting k8s root cert when cert provider is kubernetes. This fixes issues caused when automountServiceAccountToken is false. This uses a configmap kube-root-ca.crt. This configmap is supported from k8s version 1.20 onwards. This means we cannot run the new version of istio with pilot cert provider as kubernetes for k8s version < 1.20

(cherry picked from commit 3c01931113897fffc067bc873ae655d2f20aa866)

**Please provide a description of this PR:**



**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [x] Security
- [x] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
