### PR TITLE
Correct usage of Istio Revision

### DIFF
--- a/manifests/charts/gateway/templates/deployment.yaml
+++ b/manifests/charts/gateway/templates/deployment.yaml
@@ -21,9 +21,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
+        {{- if .Values.revision }}
+        istio.io/rev: {{ .Values.revision }}
+        {{- else }}
         sidecar.istio.io/inject: "true"
-        {{- with .Values.revision }}
-        istio.io/rev: {{ . }}
         {{- end }}
         {{- include "gateway.selectorLabels" . | nindent 8 }}
     spec:

--- a/manifests/charts/gateway/values.yaml
+++ b/manifests/charts/gateway/values.yaml
@@ -26,7 +26,6 @@ podAnnotations:
   prometheus.io/scrape: "true"
   prometheus.io/path: "/stats/prometheus"
   inject.istio.io/templates: "gateway"
-  sidecar.istio.io/inject: "true"
 
 # Define the security context for the pod.
 # If unset, this will be automatically set to the minimum privileges required to bind to port 80 and 443.


### PR DESCRIPTION


**Please provide a description of this PR:**

This patch removes the `sidecar.istio.io/inject: "true"`, if a specific revision is set, because the it takes precedence over the istio.io/rev label.

Also removing the deprecated annotation in the process.

See your own documentation https://istio.io/latest/docs/setup/upgrade/canary/#data-plane

> To upgrade the namespace test-ns, remove the istio-injection label, and add the istio.io/rev label to point to the canary revision. The istio-injection label must be removed because it takes precedence over the istio.io/rev label for backward compatibility.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [x] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
