### PR TITLE
[UT] improve test for operator/pkg/istio/v1alpha1

### DIFF
--- a/operator/pkg/apis/istio/v1alpha1/deepcopy_test.go
+++ b/operator/pkg/apis/istio/v1alpha1/deepcopy_test.go
@@ -66,7 +66,7 @@ spec:
       k8s:
         hpaSpec:
           scaleTargetRef:
-            apiVersion: extensions/v1beta1
+            apiVersion: apps/v1
             kind: Deployment
             name: istiod
           minReplicas: 1
@@ -94,7 +94,7 @@ spec:
       k8s:
         hpaSpec:
           scaleTargetRef:
-            apiVersion: extensions/v1beta1
+            apiVersion: apps/v1
             kind: Deployment
             name: istiod
           minReplicas: 1

--- a/operator/pkg/apis/istio/v1alpha1/testdata/quantity.yaml
+++ b/operator/pkg/apis/istio/v1alpha1/testdata/quantity.yaml
@@ -10,7 +10,7 @@ spec:
       k8s:
         hpaSpec:
           scaleTargetRef:
-            apiVersion: extensions/v1beta1
+            apiVersion: apps/v1
             kind: Deployment
             name: istiod
           minReplicas: 1


### PR DESCRIPTION
**Please provide a description of this PR:**
Please provide a description of this PR:
The apiversion `extensions/v1beta1` has been deprecated from k8s for a long time.
Although it does not affect the test results, I think it is better to replace them from the test cases.


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [x] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
