### PR TITLE
Option for Pod Labels in CNI Chart

### DIFF
--- a/manifests/charts/istio-cni/templates/daemonset.yaml
+++ b/manifests/charts/istio-cni/templates/daemonset.yaml
@@ -30,6 +30,10 @@ spec:
       labels:
         k8s-app: istio-cni-node
         sidecar.istio.io/inject: "false"
+        # Custom labels
+        {{- if .Values.cni.podLabels }}
+          {{-  toYaml .Values.cni.podLabels | nindent 8 }}
+        {{- end }}
       annotations:
         sidecar.istio.io/inject: "false"
         # Add Prometheus Scrape annotations

--- a/manifests/charts/istio-cni/values.yaml
+++ b/manifests/charts/istio-cni/values.yaml
@@ -28,6 +28,9 @@ cni:
   # Custom annotations on pod level, if you need them
   podAnnotations: {}
 
+  # Custom Labels on pod level, if you need them
+  podLabels: {}
+
   # If this value is set a RoleBinding will be created
   # in the same namespace as the istio-cni DaemonSet is created.
   # This can be used to bind a preexisting ClusterRole to the istio/cni ServiceAccount


### PR DESCRIPTION
This patch adds a new option to the cni chart making it possible to configure additional labels for pods.

Signed-off-by: Sven Haardiek <sven.haardiek@uni-muenster.de>

**Please provide a description of this PR:**

This patch adds a new option to the cni chart making it possible to configure additional labels for pods.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [x] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
