### PR TITLE
xds: fix reconnect on-demand XDS in ambient and Service subscriptions

### DIFF
--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -2699,8 +2699,12 @@ type localServiceDiscovery struct {
 	NetworkGatewaysHandler
 }
 
-func (l *localServiceDiscovery) PodInformation(addresses map[types.NamespacedName]struct{}) ([]*WorkloadInfo, []string) {
+func (l *localServiceDiscovery) PodInformation(addresses sets.Set[types.NamespacedName]) ([]*WorkloadInfo, []string) {
 	return nil, nil
+}
+
+func (l *localServiceDiscovery) AdditionalPodSubscriptions(_, _ sets.Set[types.NamespacedName]) sets.Set[types.NamespacedName] {
+	return nil
 }
 
 var _ ServiceDiscovery = &localServiceDiscovery{}

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -2703,7 +2703,7 @@ func (l *localServiceDiscovery) PodInformation(addresses sets.Set[types.Namespac
 	return nil, nil
 }
 
-func (l *localServiceDiscovery) AdditionalPodSubscriptions(_, _ sets.Set[types.NamespacedName]) sets.Set[types.NamespacedName] {
+func (l *localServiceDiscovery) AdditionalPodSubscriptions(_ *Proxy, _, _ sets.Set[types.NamespacedName]) sets.Set[types.NamespacedName] {
 	return nil
 }
 

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -712,7 +712,8 @@ type ServiceDiscovery interface {
 	// Kubernetes Multi-Cluster Services (MCS) ServiceExport API. Only applies to services in
 	// Kubernetes clusters.
 	MCSServices() []MCSServiceInfo
-	PodInformation(addresses map[types.NamespacedName]struct{}) ([]*WorkloadInfo, []string)
+	PodInformation(addresses sets.Set[types.NamespacedName]) ([]*WorkloadInfo, []string)
+	AdditionalPodSubscriptions(allAddresses sets.Set[types.NamespacedName], currentSubs sets.Set[types.NamespacedName]) sets.Set[types.NamespacedName]
 }
 
 type WorkloadInfo struct {

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -713,7 +713,7 @@ type ServiceDiscovery interface {
 	// Kubernetes clusters.
 	MCSServices() []MCSServiceInfo
 	PodInformation(addresses sets.Set[types.NamespacedName]) ([]*WorkloadInfo, []string)
-	AdditionalPodSubscriptions(allAddresses sets.Set[types.NamespacedName], currentSubs sets.Set[types.NamespacedName]) sets.Set[types.NamespacedName]
+	AdditionalPodSubscriptions(proxy *Proxy, allAddresses sets.Set[types.NamespacedName], currentSubs sets.Set[types.NamespacedName]) sets.Set[types.NamespacedName]
 }
 
 type WorkloadInfo struct {

--- a/pilot/pkg/serviceregistry/aggregate/controller.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller.go
@@ -53,7 +53,15 @@ type Controller struct {
 	model.NetworkGatewaysHandler
 }
 
-func (c *Controller) PodInformation(addresses map[types.NamespacedName]struct{}) ([]*model.WorkloadInfo, []string) {
+func (c *Controller) AdditionalPodSubscriptions(addr, cur sets.Set[types.NamespacedName]) sets.Set[types.NamespacedName] {
+	res := sets.New[types.NamespacedName]()
+	for _, p := range c.registries {
+		res = res.Merge(p.AdditionalPodSubscriptions(addr, cur))
+	}
+	return res
+}
+
+func (c *Controller) PodInformation(addresses sets.Set[types.NamespacedName]) ([]*model.WorkloadInfo, []string) {
 	i := []*model.WorkloadInfo{}
 	removed := sets.New[string]()
 	for _, p := range c.registries {

--- a/pilot/pkg/serviceregistry/aggregate/controller.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller.go
@@ -53,10 +53,10 @@ type Controller struct {
 	model.NetworkGatewaysHandler
 }
 
-func (c *Controller) AdditionalPodSubscriptions(addr, cur sets.Set[types.NamespacedName]) sets.Set[types.NamespacedName] {
+func (c *Controller) AdditionalPodSubscriptions(proxy *model.Proxy, addr, cur sets.Set[types.NamespacedName]) sets.Set[types.NamespacedName] {
 	res := sets.New[types.NamespacedName]()
 	for _, p := range c.registries {
-		res = res.Merge(p.AdditionalPodSubscriptions(addr, cur))
+		res = res.Merge(p.AdditionalPodSubscriptions(proxy, addr, cur))
 	}
 	return res
 }

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -640,8 +640,17 @@ func (c *Controller) setupIndex() *AmbientIndex {
 	return &idx
 }
 
-func (c *Controller) AdditionalPodSubscriptions(allAddresses sets.Set[types.NamespacedName], currentSubs sets.Set[types.NamespacedName]) sets.Set[types.NamespacedName] {
+func (c *Controller) AdditionalPodSubscriptions(
+	proxy *model.Proxy,
+	allAddresses sets.Set[types.NamespacedName],
+	currentSubs sets.Set[types.NamespacedName],
+) sets.Set[types.NamespacedName] {
 	shouldSubscribe := sets.New[types.NamespacedName]()
+
+	// First, we want to handle VIP subscriptions. Example:
+	// Client subscribes to VIP1. Pod1, part of VIP1, is sent.
+	// The client wouldn't be explicitly subscribed to Pod1, so it would normally ignore it.
+	// Since it is a part of VIP1 which we are subscribe to, add it to the subscriptions
 	for s := range allAddresses {
 		for _, wl := range c.ambientIndex.Lookup(s.Name) {
 			// We may have gotten an update for Pod, but are subscribe to a Service.
@@ -655,6 +664,16 @@ func (c *Controller) AdditionalPodSubscriptions(allAddresses sets.Set[types.Name
 			}
 		}
 	}
+
+	// Next, as an optimization, we will send all node-local endpoints
+	if nodeName := proxy.Metadata.NodeName; nodeName != "" {
+		for _, wl := range c.ambientIndex.All() {
+			if wl.Node == nodeName {
+				shouldSubscribe.Insert(types.NamespacedName{Name: wl.ResourceName()})
+			}
+		}
+	}
+
 	return shouldSubscribe
 }
 

--- a/pilot/pkg/serviceregistry/kube/controller/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller_test.go
@@ -2772,7 +2772,6 @@ func TestAmbientIndex(t *testing.T) {
 		controller.ambientIndex.Lookup("127.0.0.3")[0].WaypointAddresses,
 		[][]byte{netip.MustParseAddr("127.0.0.200").AsSlice(), netip.MustParseAddr("127.0.0.201").AsSlice()})
 
-	t.Log("create svc")
 	createService(controller, "svc1", "ns1",
 		map[string]string{},
 		[]int32{80}, map[string]string{"app": "a"}, t)
@@ -2780,7 +2779,6 @@ func TestAmbientIndex(t *testing.T) {
 	// Send update for the workloads as well...
 	assertEvent("127.0.0.1", "127.0.0.2", "127.0.0.3")
 	// Make sure Service sees waypoints as well
-	log.Errorf("howardjohn: %v", controller.ambientIndex.Lookup("10.0.0.1")[0].Name)
 	assert.Equal(t,
 		controller.ambientIndex.Lookup("10.0.0.1")[0].WaypointAddresses,
 		[][]byte{netip.MustParseAddr("127.0.0.200").AsSlice(), netip.MustParseAddr("127.0.0.201").AsSlice()})

--- a/pilot/pkg/serviceregistry/memory/discovery.go
+++ b/pilot/pkg/serviceregistry/memory/discovery.go
@@ -27,6 +27,7 @@ import (
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/config/schema/kind"
+	"istio.io/istio/pkg/util/sets"
 )
 
 // ServiceController is a mock service controller
@@ -83,8 +84,12 @@ type ServiceDiscovery struct {
 	mutex sync.Mutex
 }
 
-func (sd *ServiceDiscovery) PodInformation(addresses map[types.NamespacedName]struct{}) ([]*model.WorkloadInfo, []string) {
+func (sd *ServiceDiscovery) PodInformation(addresses sets.Set[types.NamespacedName]) ([]*model.WorkloadInfo, []string) {
 	return nil, nil
+}
+
+func (sd *ServiceDiscovery) AdditionalPodSubscriptions(_, _ sets.Set[types.NamespacedName]) sets.Set[types.NamespacedName] {
+	return nil
 }
 
 var _ model.ServiceDiscovery = &ServiceDiscovery{}

--- a/pilot/pkg/serviceregistry/memory/discovery.go
+++ b/pilot/pkg/serviceregistry/memory/discovery.go
@@ -88,7 +88,7 @@ func (sd *ServiceDiscovery) PodInformation(addresses sets.Set[types.NamespacedNa
 	return nil, nil
 }
 
-func (sd *ServiceDiscovery) AdditionalPodSubscriptions(_, _ sets.Set[types.NamespacedName]) sets.Set[types.NamespacedName] {
+func (sd *ServiceDiscovery) AdditionalPodSubscriptions(_ *model.Proxy, _, _ sets.Set[types.NamespacedName]) sets.Set[types.NamespacedName] {
 	return nil
 }
 

--- a/pilot/pkg/serviceregistry/serviceentry/controller.go
+++ b/pilot/pkg/serviceregistry/serviceentry/controller.go
@@ -118,7 +118,7 @@ func (s *Controller) PodInformation(addresses sets.Set[types.NamespacedName]) ([
 	return nil, nil
 }
 
-func (s *Controller) AdditionalPodSubscriptions(_, _ sets.Set[types.NamespacedName]) sets.Set[types.NamespacedName] {
+func (s *Controller) AdditionalPodSubscriptions(_ *model.Proxy, _, _ sets.Set[types.NamespacedName]) sets.Set[types.NamespacedName] {
 	return nil
 }
 

--- a/pilot/pkg/serviceregistry/serviceentry/controller.go
+++ b/pilot/pkg/serviceregistry/serviceentry/controller.go
@@ -41,6 +41,7 @@ import (
 	"istio.io/istio/pkg/network"
 	"istio.io/istio/pkg/queue"
 	"istio.io/istio/pkg/util/protomarshal"
+	"istio.io/istio/pkg/util/sets"
 	istiolog "istio.io/pkg/log"
 )
 
@@ -113,8 +114,12 @@ type Controller struct {
 	model.NetworkGatewaysHandler
 }
 
-func (s *Controller) PodInformation(addresses map[types.NamespacedName]struct{}) ([]*model.WorkloadInfo, []string) {
+func (s *Controller) PodInformation(addresses sets.Set[types.NamespacedName]) ([]*model.WorkloadInfo, []string) {
 	return nil, nil
+}
+
+func (s *Controller) AdditionalPodSubscriptions(_, _ sets.Set[types.NamespacedName]) sets.Set[types.NamespacedName] {
+	return nil
 }
 
 type Option func(*Controller)

--- a/pilot/pkg/xds/workload.go
+++ b/pilot/pkg/xds/workload.go
@@ -66,7 +66,7 @@ func (e WorkloadGenerator) GenerateDeltas(
 	for ip := range req.Delta.Subscribed {
 		addresses.Insert(types.NamespacedName{Name: ip})
 	}
-	additional := e.s.Env.ServiceDiscovery.AdditionalPodSubscriptions(updatedAddresses, typedSubs)
+	additional := e.s.Env.ServiceDiscovery.AdditionalPodSubscriptions(proxy, updatedAddresses, typedSubs)
 	addresses.Merge(additional)
 
 	// TODO: it is needlessly wasteful to do a full sync just because the rest of Istio thought it was "full"


### PR DESCRIPTION
2 bugs:
* On reconnect we ignored the initial resource
* On a subscription to a Service, we missed new pods in the service

For https://github.com/istio/istio/issues/42314