### PR TITLE
Make TestResolveAddr err check less strict

### DIFF
--- a/pilot/pkg/util/network/ip_test.go
+++ b/pilot/pkg/util/network/ip_test.go
@@ -145,7 +145,7 @@ func TestResolveAddr(t *testing.T) {
 			name:     "Missing host",
 			input:    ":9080",
 			expected: "",
-			errStr:   "lookup failed for IP address: %!w(<nil>)",
+			errStr:   "lookup failed for IP address",
 			lookup:   nil,
 		},
 		{
@@ -169,11 +169,7 @@ func TestResolveAddr(t *testing.T) {
 		if err != nil {
 			if tc.errStr == "" {
 				t.Errorf("[%s] expected success, but saw error: %v", tc.name, err)
-			} else if err.Error() != tc.errStr {
-				if strings.Contains(err.Error(), "Temporary failure in name resolution") {
-					t.Logf("[%s] expected error %q, got %q", tc.name, tc.errStr, err.Error())
-					continue
-				}
+			} else if !strings.Contains(err.Error(), tc.errStr) {
 				t.Errorf("[%s] expected error %q, got %q", tc.name, tc.errStr, err.Error())
 			}
 		} else {


### PR DESCRIPTION
This fails between go1.19 and go1.20 and is not needed to be this strict

**Please provide a description of this PR:**



**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
