### PR TITLE
improve retry backoff for web hook patching during conflict

### DIFF
--- a/pkg/webhooks/monitoring.go
+++ b/pkg/webhooks/monitoring.go
@@ -53,7 +53,6 @@ const (
 	reasonWebhookConfigNotFound = "webhook_config_not_found"
 	reasonWebhookEntryNotFound  = "webhook_entry_not_found"
 	reasonWebhookUpdateFailure  = "webhook_update_failure"
-	reasonWebhookUpdateConflict = "webhook_update_conflict"
 )
 
 func init() {

--- a/pkg/webhooks/monitoring.go
+++ b/pkg/webhooks/monitoring.go
@@ -53,6 +53,7 @@ const (
 	reasonWebhookConfigNotFound = "webhook_config_not_found"
 	reasonWebhookEntryNotFound  = "webhook_entry_not_found"
 	reasonWebhookUpdateFailure  = "webhook_update_failure"
+	reasonWebhookUpdateConflict = "webhook_update_conflict"
 )
 
 func init() {

--- a/pkg/webhooks/webhookpatch.go
+++ b/pkg/webhooks/webhookpatch.go
@@ -186,8 +186,7 @@ func (w *WebhookCertPatcher) startCaBundleWatcher(stop <-chan struct{}) {
 					continue
 				}
 				log.Debugf("updating caBundle for webhook %q", mutatingWebhookConfig.Name)
-				w.queue.
-					w.queue.Add(types.NamespacedName{Name: mutatingWebhookConfig.Name})
+				w.queue.Add(types.NamespacedName{Name: mutatingWebhookConfig.Name})
 			}
 		case <-stop:
 			return

--- a/pkg/webhooks/webhookpatch.go
+++ b/pkg/webhooks/webhookpatch.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"strings"
 	"time"
 
@@ -92,7 +93,7 @@ func newWebhookPatcherQueue(reconciler controllers.ReconcilerFn) controllers.Que
 		// state for longer duration. Slowdown the retries, so that we do not overload kube api server and etcd.
 		controllers.WithRateLimiter(workqueue.NewItemFastSlowRateLimiter(100*time.Millisecond, 1*time.Minute, 5)),
 		// Webhook patching has to be retried forever. But the retries would be rate limited.
-		controllers.RetryForever())
+		controllers.WithMaxAttempts(math.MaxInt))
 }
 
 // Run runs the WebhookCertPatcher

--- a/pkg/webhooks/webhookpatch_test.go
+++ b/pkg/webhooks/webhookpatch_test.go
@@ -299,6 +299,6 @@ func TestWebhookPatchingQueue(t *testing.T) {
 	queue.Add(types.NamespacedName{Name: "conflict-success"})
 	retry.UntilOrFail(t, func() bool { return success.Load() == 2 && retries.Load() == 5 })
 	queue.Add(types.NamespacedName{Name: "conflict-for-ever"})
-	retries = atomic.NewInt32(1)
+	retries.Store(1)
 	retry.UntilOrFail(t, func() bool { return retries.Load() > 5 })
 }

--- a/pkg/webhooks/webhookpatch_test.go
+++ b/pkg/webhooks/webhookpatch_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
-	v1 "k8s.io/api/admissionregistration/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -62,7 +61,9 @@ func TestMutatingWebhookPatch(t *testing.T) {
 	watcher.SetAndNotify(nil, nil, caBundle0)
 	conflictErr := errors.NewConflict(schema.GroupResource{Resource: "webhookconfig"}, "other", nil)
 	retryCount := 0
-	updateFn = func(client admissionregistrationv1client.MutatingWebhookConfigurationInterface, config *v1.MutatingWebhookConfiguration) error {
+	updateFn = func(client admissionregistrationv1client.MutatingWebhookConfigurationInterface,
+		config *admissionregistrationv1.MutatingWebhookConfiguration,
+	) error {
 		retryCount++
 		if config.Name == "conflict-config" {
 			return conflictErr


### PR DESCRIPTION
When we moved from Istio Queue to k8s Queue in https://github.com/istio/istio/pull/35392, we lost the ability to retry with exponential backoff on conflicts added in https://github.com/istio/istio/pull/35243. So when the problem described there comes, we still end up bringing down etcd.

This PR adds in-place retry with backoff on conflict.

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
