### PR TITLE
Change the log level for the case of no lds for gateways.

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -57,7 +57,7 @@ type mutableListenerOpts struct {
 
 func (configgen *ConfigGeneratorImpl) buildGatewayListeners(builder *ListenerBuilder) *ListenerBuilder {
 	if builder.node.MergedGateway == nil {
-		log.Debugf("buildGatewayListeners: no gateways for router %v", builder.node.ID)
+		log.Warnf("buildGatewayListeners: no gateways for router %v", builder.node.ID)
 		return builder
 	}
 


### PR DESCRIPTION
Add warning log for the case of no lds for gateways to quickly figure out what happened.

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure