### PR TITLE
fix deprecate apiversion for ingress in testdata

### DIFF
--- a/pkg/config/analysis/analyzers/testdata/misannotated.yaml
+++ b/pkg/config/analysis/analyzers/testdata/misannotated.yaml
@@ -50,7 +50,7 @@ spec:
   selector:
     app: details
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: gateway


### PR DESCRIPTION
**Please provide a description of this PR:**
The apiversion `extensions/v1beta1` has been deprecated for k8s ingress for a long time.
Although it does not affect the test results, I think it is better to replace them from the test cases.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [x] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
