### PR TITLE
istioctl analyze revision

### DIFF
--- a/istioctl/cmd/analyze.go
+++ b/istioctl/cmd/analyze.go
@@ -87,6 +87,9 @@ func Analyze() *cobra.Command {
 		Example: `  # Analyze the current live cluster
   istioctl analyze
 
+  # Analyze the current live cluster for a specific revision
+  istioctl analyze --revision 1-16
+
   # Analyze the current live cluster, simulating the effect of applying additional yaml files
   istioctl analyze a.yaml b.yaml my-app-config/
 
@@ -189,7 +192,7 @@ func Analyze() *cobra.Command {
 				if err != nil {
 					return err
 				}
-				sa.AddRunningKubeSource(k)
+				sa.AddRunningKubeSourceWithRevision(k, revision)
 			}
 
 			// If we explicitly specify mesh config, use it.
@@ -317,6 +320,8 @@ func Analyze() *cobra.Command {
 		"Process directory arguments recursively. Useful when you want to analyze related manifests organized within the same directory.")
 	analysisCmd.PersistentFlags().BoolVar(&ignoreUnknown, "ignore-unknown", false,
 		"Don't complain about un-parseable input documents, for cases where analyze should run only on k8s compliant inputs.")
+	analysisCmd.PersistentFlags().StringVarP(&revision, "revision", "", "default",
+		"analyze a specific revision deployed.")
 	return analysisCmd
 }
 

--- a/releasenotes/notes/istioctl-analyze-revision.yaml
+++ b/releasenotes/notes/istioctl-analyze-revision.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: feature
+area: istioctl
+
+releaseNotes:
+- |
+  **Added** revision to istioctl analyze.

--- a/releasenotes/notes/istioctl-analyze-revision.yaml
+++ b/releasenotes/notes/istioctl-analyze-revision.yaml
@@ -1,6 +1,8 @@
 apiVersion: release-notes/v2
 kind: feature
 area: istioctl
+issue:
+  - 38148
 
 releaseNotes:
 - |

--- a/releasenotes/notes/istioctl-analyze-revision.yaml
+++ b/releasenotes/notes/istioctl-analyze-revision.yaml
@@ -6,4 +6,4 @@ issue:
 
 releaseNotes:
 - |
-  **Added** revision to istioctl analyze.
+  **Added** `--revision` to `istioctl analyze` to specify a specific revision.


### PR DESCRIPTION
**Please provide a description of this PR:**
add revision flag to istioctl analyze to allow it to analyze deployments that use revisions. today this is not supported

Issue: https://github.com/istio/istio/issues/38148
PR1: https://github.com/istio/istio/pull/38659
PR2: https://github.com/istio/istio/pull/38826

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [x] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
